### PR TITLE
Simplify PeripheralMutex

### DIFF
--- a/embassy-extras/src/peripheral.rs
+++ b/embassy-extras/src/peripheral.rs
@@ -1,30 +1,20 @@
 use core::cell::UnsafeCell;
 use core::marker::{PhantomData, PhantomPinned};
-use core::mem::MaybeUninit;
 use core::pin::Pin;
 use core::sync::atomic::{compiler_fence, Ordering};
 
 use embassy::interrupt::{Interrupt, InterruptExt};
-
-use crate::fmt::assert;
 
 pub trait PeripheralState {
     type Interrupt: Interrupt;
     fn on_interrupt(&mut self);
 }
 
-#[derive(Clone, Copy, PartialEq, Eq, Debug)]
-enum Life {
-    Ready,
-    Created,
-    Freed,
-}
-
 pub struct PeripheralMutex<S: PeripheralState> {
-    life: Life,
+    state: UnsafeCell<S>,
 
-    state: MaybeUninit<UnsafeCell<S>>, // Init if life != Freed
-    irq: MaybeUninit<S::Interrupt>,    // Init if life != Freed
+    irq_setup_done: bool,
+    irq: S::Interrupt,
 
     _not_send: PhantomData<*mut ()>,
     _pinned: PhantomPinned,
@@ -33,9 +23,10 @@ pub struct PeripheralMutex<S: PeripheralState> {
 impl<S: PeripheralState> PeripheralMutex<S> {
     pub fn new(state: S, irq: S::Interrupt) -> Self {
         Self {
-            life: Life::Created,
-            state: MaybeUninit::new(UnsafeCell::new(state)),
-            irq: MaybeUninit::new(irq),
+            irq,
+            irq_setup_done: false,
+
+            state: UnsafeCell::new(state),
             _not_send: PhantomData,
             _pinned: PhantomPinned,
         }
@@ -43,77 +34,49 @@ impl<S: PeripheralState> PeripheralMutex<S> {
 
     /// safety: self must be pinned.
     unsafe fn setup(&mut self) {
-        assert!(self.life == Life::Created);
-
-        let irq = &mut *self.irq.as_mut_ptr();
-        irq.disable();
+        self.irq.disable();
         compiler_fence(Ordering::SeqCst);
 
-        irq.set_handler(|p| {
+        self.irq.set_handler(|p| {
             // Safety: it's OK to get a &mut to the state, since
             // - We're in the IRQ, no one else can't preempt us
             // - We can't have preempted a with() call because the irq is disabled during it.
             let state = &mut *(p as *mut S);
             state.on_interrupt();
         });
-        irq.set_handler_context(self.state.as_mut_ptr() as *mut ());
+        self.irq
+            .set_handler_context((&mut self.state) as *mut _ as *mut ());
 
         compiler_fence(Ordering::SeqCst);
-        irq.enable();
+        self.irq.enable();
 
-        self.life = Life::Ready;
+        self.irq_setup_done = true;
     }
 
     pub fn with<R>(self: Pin<&mut Self>, f: impl FnOnce(&mut S, &mut S::Interrupt) -> R) -> R {
         let this = unsafe { self.get_unchecked_mut() };
-        if this.life != Life::Ready {
+        if !this.irq_setup_done {
             unsafe { this.setup() }
         }
 
-        let irq = unsafe { &mut *this.irq.as_mut_ptr() };
-
-        irq.disable();
+        this.irq.disable();
         compiler_fence(Ordering::SeqCst);
 
         // Safety: it's OK to get a &mut to the state, since the irq is disabled.
-        let state = unsafe { &mut *(*this.state.as_ptr()).get() };
+        let state = unsafe { &mut *this.state.get() };
 
-        let r = f(state, irq);
+        let r = f(state, &mut this.irq);
 
         compiler_fence(Ordering::SeqCst);
-        irq.enable();
+        this.irq.enable();
 
         r
-    }
-
-    pub fn try_free(self: Pin<&mut Self>) -> Option<(S, S::Interrupt)> {
-        let this = unsafe { self.get_unchecked_mut() };
-
-        if this.life != Life::Freed {
-            return None;
-        }
-
-        unsafe { &mut *this.irq.as_mut_ptr() }.disable();
-        compiler_fence(Ordering::SeqCst);
-
-        this.life = Life::Freed;
-
-        let state = unsafe { this.state.as_ptr().read().into_inner() };
-        let irq = unsafe { this.irq.as_ptr().read() };
-        Some((state, irq))
-    }
-
-    pub fn free(self: Pin<&mut Self>) -> (S, S::Interrupt) {
-        unwrap!(self.try_free())
     }
 }
 
 impl<S: PeripheralState> Drop for PeripheralMutex<S> {
     fn drop(&mut self) {
-        if self.life != Life::Freed {
-            let irq = unsafe { &mut *self.irq.as_mut_ptr() };
-            irq.disable();
-            irq.remove_handler();
-        }
+        self.irq.disable();
+        self.irq.remove_handler();
     }
 }

--- a/embassy-nrf/src/qspi.rs
+++ b/embassy-nrf/src/qspi.rs
@@ -238,11 +238,6 @@ impl Qspi {
         unsafe { Pin::new_unchecked(&mut self.get_unchecked_mut().inner) }
     }
 
-    pub fn free(self: Pin<&mut Self>) -> (QSPI, interrupt::QSPI) {
-        let (state, irq) = self.inner().free();
-        (state.inner, irq)
-    }
-
     fn wait_ready<'a>(mut self: Pin<&'a mut Self>) -> impl Future<Output = ()> + 'a {
         poll_fn(move |cx| {
             self.as_mut().inner().with(|s, _irq| {

--- a/embassy-nrf/src/spim.rs
+++ b/embassy-nrf/src/spim.rs
@@ -120,11 +120,6 @@ impl<T: Instance> Spim<T> {
     fn inner(self: Pin<&mut Self>) -> Pin<&mut PeripheralMutex<State<T>>> {
         unsafe { Pin::new_unchecked(&mut self.get_unchecked_mut().inner) }
     }
-
-    pub fn free(self: Pin<&mut Self>) -> (T, T::Interrupt) {
-        let (state, irq) = self.inner().free();
-        (state.spim, irq)
-    }
 }
 
 impl<T: Instance> FullDuplex<u8> for Spim<T> {

--- a/embassy-nrf/src/spim.rs
+++ b/embassy-nrf/src/spim.rs
@@ -148,6 +148,7 @@ impl<T: Instance> FullDuplex<u8> for Spim<T> {
             slice_in_ram_or(rx, Error::DMABufferNotInDataMemory)?;
             slice_in_ram_or(tx, Error::DMABufferNotInDataMemory)?;
 
+            self.as_mut().inner().register_interrupt();
             self.as_mut().inner().with(|s, _irq| {
                 // Conservative compiler fence to prevent optimizations that do not
                 // take in to account actions by DMA. The fence has been placed here,


### PR DESCRIPTION
Change 1: Remove `free()`. Simplifies code significantly, since now it's no longer possible for it to be in "freed" state. 

The free() pattern works really badly with pinned data anyway: you can't take owned Self because that would mean moving self.

The need for free() should go away once we figure out how to create drivers that borrow the peripherals, so you'll be able to simply drop the driver to recover access to the owned peripherals.

Change 2: separate `register_interrupt()` method. It's the driver's responsibility to call it. This allows more code size, because drivers may call `with` in codepaths where they know the interrupt is already registered, which saves the check.