### PR TITLE
Peripehral Borrow v1

### DIFF
--- a/embassy-macros/src/lib.rs
+++ b/embassy-macros/src/lib.rs
@@ -128,9 +128,6 @@ pub fn interrupt_declare(item: TokenStream) -> TokenStream {
                 let irq = crate::pac::interrupt::#name;
                 irq.number() as u16
             }
-            unsafe fn steal() -> Self {
-                Self(())
-            }
             unsafe fn __handler(&self) -> &'static ::embassy::interrupt::Handler {
                 #[export_name = #name_handler]
                 static HANDLER: ::embassy::interrupt::Handler = ::embassy::interrupt::Handler::new();

--- a/embassy-nrf/src/spim.rs
+++ b/embassy-nrf/src/spim.rs
@@ -252,3 +252,12 @@ make_impl!(SPIM2, SPIM2_SPIS2_SPI2);
 
 #[cfg(any(feature = "52833", feature = "52840"))]
 make_impl!(SPIM3, SPIM3);
+
+impl<T: sealed::Instance> sealed::Instance for &mut T {
+    fn regs(&mut self) -> &pac::spim0::RegisterBlock {
+        T::regs(*self)
+    }
+}
+impl<'a, T: Instance> Instance for &'a mut T {
+    type Interrupt = &'a mut T::Interrupt;
+}

--- a/embassy/src/interrupt.rs
+++ b/embassy/src/interrupt.rs
@@ -33,11 +33,24 @@ unsafe impl cortex_m::interrupt::InterruptNumber for NrWrap {
 pub unsafe trait Interrupt {
     type Priority: From<u8> + Into<u8> + Copy;
     fn number(&self) -> u16;
-    unsafe fn steal() -> Self;
 
     /// Implementation detail, do not use outside embassy crates.
     #[doc(hidden)]
     unsafe fn __handler(&self) -> &'static Handler;
+}
+
+unsafe impl<'a, T: Interrupt> Interrupt for &'a mut T {
+    type Priority = T::Priority;
+
+    fn number(&self) -> u16 {
+        T::number(self)
+    }
+
+    /// Implementation detail, do not use outside embassy crates.
+    #[doc(hidden)]
+    unsafe fn __handler(&self) -> &'static Handler {
+        T::__handler(self)
+    }
 }
 
 pub trait InterruptExt: Interrupt {

--- a/embassy/src/util/borrow.rs
+++ b/embassy/src/util/borrow.rs
@@ -1,0 +1,30 @@
+use core::marker::PhantomData;
+use core::ops::Deref;
+
+/// Borrow of a peripheral instance.
+///
+/// This is equivalent to `&mut T`, except smaller. For example, if
+/// T is zero-sized, Borrowed<T> is too, while `&mut T` would be 32 bits.
+pub struct Borrow<'a, T> {
+    inner: T,
+    phantom: PhantomData<&'a mut T>,
+}
+
+impl<'a, T> Borrow<'a, T> {
+    pub fn from_owned(inner: T) -> Self {
+        Borrow {
+            inner,
+            phantom: PhantomData,
+        }
+    }
+}
+impl<'a, T> Deref for Borrow<'a, T> {
+    type Target = T;
+    fn deref(&self) -> &Self::Target {
+        &self.inner
+    }
+}
+
+pub trait Borrowable: Sized {
+    fn borrow(&mut self) -> Borrow<'_, Self>;
+}

--- a/embassy/src/util/mod.rs
+++ b/embassy/src/util/mod.rs
@@ -1,3 +1,4 @@
+mod borrow;
 mod drop_bomb;
 mod forever;
 mod mutex;
@@ -7,6 +8,7 @@ mod signal;
 #[cfg_attr(feature = "executor-agnostic", path = "waker_agnostic.rs")]
 mod waker;
 
+pub use borrow::*;
 pub use drop_bomb::*;
 pub use forever::*;
 pub use mutex::*;


### PR DESCRIPTION
This adds the possibility of creating drivers with borrowed peripheral instances.

```rust
let p = pac::Peripherals::take().unwrap();
let mut irq = interrupt::take!(SPIM3);

let spim = spim::Spim::new(&mut p.SPIM3, &mut irq, config);
// use spim...
mem::drop(spim);

// Here we have access to p.SPIM3 and irq again!
```

The way this works is implementing Instance for `&mut T`:

```rust
impl<'a, T: Instance> Instance for &'a mut T {
    type Interrupt = &'a mut T::Interrupt;
}
```

Problems: 
- This is useless if borrowing pins is not possible. I plan to work on this next.
- The type for Spim changes: `Spim<SPIM3>` vs `Spim<&'a mut SPIM3>`. This means code bloat if both are used.
- `&'a mut SPIM3` is 32bits even though `SPIM3` is zero-sized.

There's also a `Borrow<'a, T>` that acts like a `&'a mut T` but zero-sized if T is zero-sized. It has problems too:
- Not idiomatic, very ugly and hard to discover for users.
- embassy-nrf can't impl embassy::util::Borrowable for pac::SPIM3 because both are foreign.


I plan on trying out an alternative v2 approach where the *drivers* are generic over owned/borrowed structs. The types would be `Spim<'static, SPIM3>` for owned or `Spim<'a, SPIM3>` for borrowed. No code bloat, more idiomatic, although the `'static` might be annoying