### PR TITLE
Reverse test for already freed.

### DIFF
--- a/embassy-extras/src/peripheral.rs
+++ b/embassy-extras/src/peripheral.rs
@@ -89,7 +89,7 @@ impl<S: PeripheralState> PeripheralMutex<S> {
     pub fn try_free(self: Pin<&mut Self>) -> Option<(S, S::Interrupt)> {
         let this = unsafe { self.get_unchecked_mut() };
 
-        if this.life != Life::Freed {
+        if this.life == Life::Freed {
             return None;
         }
 


### PR DESCRIPTION
I'm pretty sure this check should check if the peripheral has already been freed. Is this correct?