### PR TITLE
Peripheral borrow v2

### DIFF
--- a/embassy-nrf-examples/src/bin/spim.rs
+++ b/embassy-nrf-examples/src/bin/spim.rs
@@ -24,7 +24,7 @@ use embassy_nrf::{interrupt, pac, rtc, spim};
 async fn run() {
     info!("running!");
 
-    let p = unsafe { embassy_nrf::pac::Peripherals::steal() };
+    let mut p = unsafe { embassy_nrf::pac::Peripherals::steal() };
     let p0 = gpio::p0::Parts::new(p.P0);
 
     let pins = spim::Pins {
@@ -40,7 +40,10 @@ async fn run() {
     };
 
     let mut ncs = p0.p0_31.into_push_pull_output(gpio::Level::High);
-    let spim = spim::Spim::new(p.SPIM3, interrupt::take!(SPIM3), config);
+
+    let mut irq = interrupt::take!(SPIM3);
+
+    let spim: spim::Spim<'_, pac::SPIM3> = spim::Spim::new(&mut p.SPIM3, &mut irq, config);
     pin_mut!(spim);
 
     // Example on how to talk to an ENC28J60 chip


### PR DESCRIPTION
Alternate solution to #86: Drivers take `impl BorrowMut<T>` and then unsafely copy the value.

I like this much more:

- Type signature is `Spim<'_, SPIM3>` regardless whether it's owned or borrowed
- Spim always holds the zero-sized struct
- No weird unergonomic `Borrow<'a, T>` struct.

The *only* problem is type inference doesn't seem to work when borrowing...

```rust
// this is rejected: cannot infer type for type parameter `T`
let spim = spim::Spim::new(&mut p.SPIM3, &mut irq, config);
// You have to write this instead
let spim: spim::Spim<'_, pac::SPIM3> = spim::Spim::new(&mut p.SPIM3, &mut irq, config);
```

Thoughts? Any trait magic we can do so type is always inferred?