### PR TITLE
Document remainder of embassy::time

### DIFF
--- a/embassy-traits/src/delay.rs
+++ b/embassy-traits/src/delay.rs
@@ -4,6 +4,9 @@ use core::pin::Pin;
 pub trait Delay {
     type DelayFuture<'a>: Future<Output = ()> + 'a;
 
+    /// Future that completes after now + millis
     fn delay_ms<'a>(self: Pin<&'a mut Self>, millis: u64) -> Self::DelayFuture<'a>;
+
+    /// Future that completes after now + micros
     fn delay_us<'a>(self: Pin<&'a mut Self>, micros: u64) -> Self::DelayFuture<'a>;
 }


### PR DESCRIPTION
Adds documentation and a couple inline examples for the remainder of `embassy::time`

Relates to #60 
