### PR TITLE
stm32: fix exti impl. to require dp.SYSCFG.constrain()

### DIFF
--- a/embassy-stm32f4-examples/src/bin/exti.rs
+++ b/embassy-stm32f4-examples/src/bin/exti.rs
@@ -24,8 +24,9 @@ async fn run(dp: stm32::Peripherals, _cp: cortex_m::Peripherals) {
     let gpioa = dp.GPIOA.split();
 
     let button = gpioa.pa0.into_pull_up_input();
+    let mut syscfg = dp.SYSCFG.constrain();
 
-    let pin = ExtiPin::new(button, interrupt::take!(EXTI0));
+    let pin = ExtiPin::new(button, interrupt::take!(EXTI0), &mut syscfg);
     pin_mut!(pin);
 
     info!("Starting loop");


### PR DESCRIPTION
fixes #105 