### PR TITLE
add initial interrupt table

### DIFF
--- a/embassy/src/interrupt.rs
+++ b/embassy/src/interrupt.rs
@@ -124,3 +124,29 @@ impl<T: Interrupt + ?Sized> InterruptExt for T {
         }
     }
 }
+
+pub struct InterruptTable {}
+
+impl InterruptTable {
+    /*
+        Register the interrupt table with the NVIC
+    */
+    pub fn register_table() {
+        // unsafe { p.core.SCB.vtor.write(0x4000) }
+    }
+
+    /*
+        JIT a trampoline function, given a fn and ctx
+    */
+    pub fn generate_fn(func: unsafe fn(*mut ()), ctx: *mut ()) -> [u8] {}
+
+    /*
+        Set the handler in the interrupt table
+    */
+    pub fn set_handler(irq: u8, func: unsafe fn(*mut ())) {}
+
+    /*
+        Remove the handler in the interrupt table
+    */
+    pub fn remove_handler(irq: u8) {}
+}

--- a/embassy/src/interrupt.rs
+++ b/embassy/src/interrupt.rs
@@ -125,6 +125,16 @@ impl<T: Interrupt + ?Sized> InterruptExt for T {
     }
 }
 
+#[repr(C, align(VECTORTABLE_ALIGNMENT))]
+#[no_mangle]
+static mut INTERRUPT_TABLE: [unsafe extern "C" fn(); 240] = [{
+    extern "C" {
+        fn DefaultHandler();
+    }
+
+    DefaultHandler
+}; 240];
+
 pub struct InterruptTable {}
 
 impl InterruptTable {
@@ -132,7 +142,7 @@ impl InterruptTable {
         Register the interrupt table with the NVIC
     */
     pub fn register_table() {
-        // unsafe { p.core.SCB.vtor.write(0x4000) }
+        unsafe { p.core.SCB.vtor.write(*INTERRUPT_TABLE) }
     }
 
     /*


### PR DESCRIPTION
Steps:

- [ ] Generate correct trampoline JIT function, given ctx and function ptr.
- [ ]  Set table correctly
- [ ] Set handler to trampoline function direct function, depending on ctx

Not: eventual API will be `InterruptTable::take()` sets function pointer.