### PR TITLE
Purge outdated references

### DIFF
--- a/Cargo.example.toml
+++ b/Cargo.example.toml
@@ -29,9 +29,6 @@ members = [
 
     # stm32
     #"embassy-stm32",
-    #"embassy-stm32f4",
-    #"embassy-stm32l0",
-    #"embassy-stm32f4-examples",
 
     # rp2040
     #"embassy-rp",


### PR DESCRIPTION
The device-specific stm HALs no longer exist as they were merged into `embassy-stm32`.
This PR removes references to them in the example workspace toml