### PR TITLE
Mark peripherals as taken

### DIFF
--- a/embassy-extras/src/macros.rs
+++ b/embassy-extras/src/macros.rs
@@ -55,6 +55,7 @@ macro_rules! peripherals {
                     if unsafe { _EMBASSY_DEVICE_PERIPHERALS } {
                         None
                     } else {
+                        unsafe { _EMBASSY_DEVICE_PERIPHERALS = true };
                         Some(unsafe { <Self as embassy::util::Steal>::steal() })
                     }
                 })


### PR DESCRIPTION
Ensures that, after the first call to `take()`, we can't take the peripherals again.