### PR TITLE
Add std version of embassy::main

### DIFF
--- a/embassy-macros/Cargo.toml
+++ b/embassy-macros/Cargo.toml
@@ -17,3 +17,4 @@ proc-macro = true
 stm32 = []
 nrf = []
 rp = []
+std = []

--- a/embassy-macros/src/lib.rs
+++ b/embassy-macros/src/lib.rs
@@ -280,3 +280,69 @@ pub fn main(args: TokenStream, item: TokenStream) -> TokenStream {
     };
     result.into()
 }
+
+#[cfg(feature = "std")]
+#[proc_macro_attribute]
+pub fn main(_: TokenStream, item: TokenStream) -> TokenStream {
+    let task_fn = syn::parse_macro_input!(item as syn::ItemFn);
+
+    let mut fail = false;
+    if task_fn.sig.asyncness.is_none() {
+        task_fn
+            .sig
+            .span()
+            .unwrap()
+            .error("task functions must be async")
+            .emit();
+        fail = true;
+    }
+    if !task_fn.sig.generics.params.is_empty() {
+        task_fn
+            .sig
+            .span()
+            .unwrap()
+            .error("main function must not be generic")
+            .emit();
+        fail = true;
+    }
+
+    let args = task_fn.sig.inputs.clone();
+
+    if args.len() != 1 {
+        task_fn
+            .sig
+            .span()
+            .unwrap()
+            .error("main function must have one argument")
+            .emit();
+        fail = true;
+    }
+
+    if fail {
+        return TokenStream::new();
+    }
+
+    let task_fn_body = task_fn.block.clone();
+
+    let result = quote! {
+        #[embassy::task]
+        async fn __embassy_main(#args) {
+            #task_fn_body
+        }
+
+        fn main() -> ! {
+            unsafe fn make_static<T>(t: &mut T) -> &'static mut T {
+                ::core::mem::transmute(t)
+            }
+
+            let mut executor = ::embassy_std::Executor::new();
+            let executor = unsafe { make_static(&mut executor) };
+
+            executor.run(|spawner| {
+                spawner.spawn(__embassy_main(spawner)).unwrap();
+            })
+
+        }
+    };
+    result.into()
+}

--- a/embassy-std/Cargo.toml
+++ b/embassy-std/Cargo.toml
@@ -6,4 +6,5 @@ edition = "2018"
 
 [dependencies]
 embassy     = { version = "0.1.0", path = "../embassy", features = ["std"] }
+embassy-macros = { version = "0.1.0", path = "../embassy-macros", features = ["std"]}
 lazy_static = "1.4.0"


### PR DESCRIPTION
When building a generic macro that should work on both cortex-m and std alike, having a main macro that works on std is kind of useful.