### PR TITLE
Remove Pin

### DIFF
--- a/embassy-nrf-examples/src/bin/gpiote_port.rs
+++ b/embassy-nrf-examples/src/bin/gpiote_port.rs
@@ -21,9 +21,9 @@ use example_common::*;
 #[embassy::task(pool_size = 4)]
 async fn button_task(n: usize, mut pin: PortInput<'static, AnyPin>) {
     loop {
-        Pin::new(&mut pin).wait_for_low().await;
+        pin.wait_for_low().await;
         info!("Button {:?} pressed!", n);
-        Pin::new(&mut pin).wait_for_high().await;
+        pin.wait_for_high().await;
         info!("Button {:?} released!", n);
     }
 }

--- a/embassy-nrf-examples/src/bin/spim.rs
+++ b/embassy-nrf-examples/src/bin/spim.rs
@@ -17,7 +17,6 @@ use embassy_nrf::{interrupt, spim};
 use embassy_traits::spi::FullDuplex;
 use embedded_hal::digital::v2::*;
 use example_common::*;
-use futures::pin_mut;
 
 #[embassy::main]
 async fn main(spawner: Spawner) {
@@ -32,8 +31,7 @@ async fn main(spawner: Spawner) {
     };
 
     let irq = interrupt::take!(SPIM3);
-    let spim = spim::Spim::new(p.SPIM3, irq, p.P0_29, p.P0_28, p.P0_30, config);
-    pin_mut!(spim);
+    let mut spim = spim::Spim::new(p.SPIM3, irq, p.P0_29, p.P0_28, p.P0_30, config);
 
     let mut ncs = Output::new(p.P0_31, Level::High, OutputDrive::Standard);
 
@@ -44,7 +42,7 @@ async fn main(spawner: Spawner) {
     ncs.set_low().unwrap();
     cortex_m::asm::delay(5);
     let tx = [0xFF];
-    unwrap!(spim.as_mut().read_write(&mut [], &tx).await);
+    unwrap!(spim.read_write(&mut [], &tx).await);
     cortex_m::asm::delay(10);
     ncs.set_high().unwrap();
 
@@ -57,7 +55,7 @@ async fn main(spawner: Spawner) {
     ncs.set_low().unwrap();
     cortex_m::asm::delay(5000);
     let tx = [0b000_11101, 0];
-    unwrap!(spim.as_mut().read_write(&mut rx, &tx).await);
+    unwrap!(spim.read_write(&mut rx, &tx).await);
     cortex_m::asm::delay(5000);
     ncs.set_high().unwrap();
     info!("estat: {=[?]}", rx);
@@ -67,7 +65,7 @@ async fn main(spawner: Spawner) {
     ncs.set_low().unwrap();
     cortex_m::asm::delay(5);
     let tx = [0b100_11111, 0b11];
-    unwrap!(spim.as_mut().read_write(&mut rx, &tx).await);
+    unwrap!(spim.read_write(&mut rx, &tx).await);
     cortex_m::asm::delay(10);
     ncs.set_high().unwrap();
 
@@ -76,7 +74,7 @@ async fn main(spawner: Spawner) {
     ncs.set_low().unwrap();
     cortex_m::asm::delay(5);
     let tx = [0b000_10010, 0];
-    unwrap!(spim.as_mut().read_write(&mut rx, &tx).await);
+    unwrap!(spim.read_write(&mut rx, &tx).await);
     cortex_m::asm::delay(10);
     ncs.set_high().unwrap();
 

--- a/embassy-nrf-examples/src/bin/uart.rs
+++ b/embassy-nrf-examples/src/bin/uart.rs
@@ -15,7 +15,6 @@ use embassy::traits::uart::{Read, Write};
 use embassy::util::Steal;
 use embassy_nrf::gpio::NoPin;
 use embassy_nrf::{interrupt, uarte, Peripherals};
-use futures::pin_mut;
 
 #[embassy::main]
 async fn main(spawner: Spawner) {
@@ -26,8 +25,8 @@ async fn main(spawner: Spawner) {
     config.baudrate = uarte::Baudrate::BAUD115200;
 
     let irq = interrupt::take!(UARTE0_UART0);
-    let uart = unsafe { uarte::Uarte::new(p.UARTE0, irq, p.P0_08, p.P0_06, NoPin, NoPin, config) };
-    pin_mut!(uart);
+    let mut uart =
+        unsafe { uarte::Uarte::new(p.UARTE0, irq, p.P0_08, p.P0_06, NoPin, NoPin, config) };
 
     info!("uarte initialized!");
 
@@ -35,14 +34,14 @@ async fn main(spawner: Spawner) {
     let mut buf = [0; 8];
     buf.copy_from_slice(b"Hello!\r\n");
 
-    unwrap!(uart.as_mut().write(&buf).await);
+    unwrap!(uart.write(&buf).await);
     info!("wrote hello in uart!");
 
     loop {
         info!("reading...");
-        unwrap!(uart.as_mut().read(&mut buf).await);
+        unwrap!(uart.read(&mut buf).await);
         info!("writing...");
-        unwrap!(uart.as_mut().write(&buf).await);
+        unwrap!(uart.write(&buf).await);
 
         /*
         // `receive()` doesn't return until the buffer has been completely filled with

--- a/embassy-nrf/src/buffered_uarte.rs
+++ b/embassy-nrf/src/buffered_uarte.rs
@@ -78,7 +78,7 @@ impl<'d, U: UarteInstance, T: TimerInstance> BufferedUarte<'d, U, T> {
     ) -> Self {
         unborrow!(uarte, timer, ppi_ch1, ppi_ch2, irq, rxd, txd, cts, rts);
 
-        let r = uarte.regs();
+        let r = U::regs();
         let rt = timer.regs();
 
         rxd.conf().write(|w| w.input().connect().drive().h0h1());
@@ -178,7 +178,7 @@ impl<'d, U: UarteInstance, T: TimerInstance> BufferedUarte<'d, U, T> {
 
     pub fn set_baudrate(self: Pin<&mut Self>, baudrate: Baudrate) {
         self.inner().with(|state, _irq| {
-            let r = state.uarte.regs();
+            let r = U::regs();
             let rt = state.timer.regs();
 
             let timeout = 0x8000_0000 / (baudrate as u32 / 40);
@@ -265,7 +265,7 @@ impl<'d, U: UarteInstance, T: TimerInstance> AsyncWrite for BufferedUarte<'d, U,
 
 impl<'a, U: UarteInstance, T: TimerInstance> Drop for State<'a, U, T> {
     fn drop(&mut self) {
-        let r = self.uarte.regs();
+        let r = U::regs();
         let rt = self.timer.regs();
 
         // TODO this probably deadlocks. do like Uarte instead.
@@ -290,7 +290,7 @@ impl<'a, U: UarteInstance, T: TimerInstance> PeripheralState for State<'a, U, T>
     type Interrupt = U::Interrupt;
     fn on_interrupt(&mut self) {
         trace!("irq: start");
-        let r = self.uarte.regs();
+        let r = U::regs();
         let rt = self.timer.regs();
 
         loop {

--- a/embassy-nrf/src/gpiote.rs
+++ b/embassy-nrf/src/gpiote.rs
@@ -1,7 +1,6 @@
 use core::convert::Infallible;
 use core::future::Future;
 use core::marker::PhantomData;
-use core::pin::Pin;
 use core::task::{Context, Poll};
 use embassy::interrupt::InterruptExt;
 use embassy::traits::gpio::{WaitForHigh, WaitForLow};
@@ -318,7 +317,7 @@ impl<'d, T: GpioPin> InputPin for PortInput<'d, T> {
 impl<'d, T: GpioPin> WaitForHigh for PortInput<'d, T> {
     type Future<'a> = PortInputFuture<'a>;
 
-    fn wait_for_high<'a>(self: Pin<&'a mut Self>) -> Self::Future<'a> {
+    fn wait_for_high<'a>(&'a mut self) -> Self::Future<'a> {
         self.pin.pin.conf().modify(|_, w| w.sense().high());
 
         PortInputFuture {
@@ -331,7 +330,7 @@ impl<'d, T: GpioPin> WaitForHigh for PortInput<'d, T> {
 impl<'d, T: GpioPin> WaitForLow for PortInput<'d, T> {
     type Future<'a> = PortInputFuture<'a>;
 
-    fn wait_for_low<'a>(self: Pin<&'a mut Self>) -> Self::Future<'a> {
+    fn wait_for_low<'a>(&'a mut self) -> Self::Future<'a> {
         self.pin.pin.conf().modify(|_, w| w.sense().low());
 
         PortInputFuture {

--- a/embassy-stm32-examples/src/bin/exti.rs
+++ b/embassy-stm32-examples/src/bin/exti.rs
@@ -26,13 +26,12 @@ async fn run(dp: stm32::Peripherals, _cp: cortex_m::Peripherals) {
     let button = gpioa.pa0.into_pull_up_input();
     let mut syscfg = dp.SYSCFG.constrain();
 
-    let pin = ExtiPin::new(button, interrupt::take!(EXTI0), &mut syscfg);
-    pin_mut!(pin);
+    let mut pin = ExtiPin::new(button, interrupt::take!(EXTI0), &mut syscfg);
 
     info!("Starting loop");
 
     loop {
-        pin.as_mut().wait_for_rising_edge().await;
+        pin.wait_for_rising_edge().await;
         info!("edge detected!");
     }
 }

--- a/embassy-traits/src/delay.rs
+++ b/embassy-traits/src/delay.rs
@@ -1,12 +1,11 @@
 use core::future::Future;
-use core::pin::Pin;
 
 pub trait Delay {
     type DelayFuture<'a>: Future<Output = ()> + 'a;
 
     /// Future that completes after now + millis
-    fn delay_ms<'a>(self: Pin<&'a mut Self>, millis: u64) -> Self::DelayFuture<'a>;
+    fn delay_ms<'a>(&'a mut self, millis: u64) -> Self::DelayFuture<'a>;
 
     /// Future that completes after now + micros
-    fn delay_us<'a>(self: Pin<&'a mut Self>, micros: u64) -> Self::DelayFuture<'a>;
+    fn delay_us<'a>(&'a mut self, micros: u64) -> Self::DelayFuture<'a>;
 }

--- a/embassy-traits/src/flash.rs
+++ b/embassy-traits/src/flash.rs
@@ -27,19 +27,18 @@ pub trait Flash {
     ///
     /// address must be a multiple of self.read_size().
     /// buf.len() must be a multiple of self.read_size().
-    fn read<'a>(self: Pin<&'a mut Self>, address: usize, buf: &'a mut [u8])
-        -> Self::ReadFuture<'a>;
+    fn read<'a>(&'a mut self, address: usize, buf: &'a mut [u8]) -> Self::ReadFuture<'a>;
 
     /// Writes data to the flash device.
     ///
     /// address must be a multiple of self.write_size().
     /// buf.len() must be a multiple of self.write_size().
-    fn write<'a>(self: Pin<&'a mut Self>, address: usize, buf: &'a [u8]) -> Self::WriteFuture<'a>;
+    fn write<'a>(&'a mut self, address: usize, buf: &'a [u8]) -> Self::WriteFuture<'a>;
 
     /// Erases a single page from the flash device.
     ///
     /// address must be a multiple of self.erase_size().
-    fn erase<'a>(self: Pin<&'a mut Self>, address: usize) -> Self::ErasePageFuture<'a>;
+    fn erase<'a>(&'a mut self, address: usize) -> Self::ErasePageFuture<'a>;
 
     /// Returns the total size, in bytes.
     /// This is not guaranteed to be a power of 2.

--- a/embassy-traits/src/gpio.rs
+++ b/embassy-traits/src/gpio.rs
@@ -9,7 +9,7 @@ pub trait WaitForHigh {
     ///
     /// If the pin is already high, the future completes immediately.
     /// Otherwise, it completes when it becomes high.
-    fn wait_for_high<'a>(self: Pin<&'a mut Self>) -> Self::Future<'a>;
+    fn wait_for_high<'a>(&'a mut self) -> Self::Future<'a>;
 }
 
 /// Wait for a pin to become low.
@@ -20,7 +20,7 @@ pub trait WaitForLow {
     ///
     /// If the pin is already low, the future completes immediately.
     /// Otherwise, it completes when it becomes low.
-    fn wait_for_low<'a>(self: Pin<&'a mut Self>) -> Self::Future<'a>;
+    fn wait_for_low<'a>(&'a mut self) -> Self::Future<'a>;
 }
 
 /// Wait for a rising edge (transition from low to high)
@@ -28,7 +28,7 @@ pub trait WaitForRisingEdge {
     type Future<'a>: Future<Output = ()> + 'a;
 
     /// Wait for a rising edge (transition from low to high)
-    fn wait_for_rising_edge<'a>(self: Pin<&'a mut Self>) -> Self::Future<'a>;
+    fn wait_for_rising_edge<'a>(&'a mut self) -> Self::Future<'a>;
 }
 
 /// Wait for a falling edge (transition from high to low)
@@ -36,7 +36,7 @@ pub trait WaitForFallingEdge {
     type Future<'a>: Future<Output = ()> + 'a;
 
     /// Wait for a falling edge (transition from high to low)
-    fn wait_for_falling_edge<'a>(self: Pin<&'a mut Self>) -> Self::Future<'a>;
+    fn wait_for_falling_edge<'a>(&'a mut self) -> Self::Future<'a>;
 }
 
 /// Wait for any edge (any transition, high to low or low to high)
@@ -44,5 +44,5 @@ pub trait WaitForAnyEdge {
     type Future<'a>: Future<Output = ()> + 'a;
 
     /// Wait for any edge (any transition, high to low or low to high)
-    fn wait_for_any_edge<'a>(self: Pin<&'a mut Self>) -> Self::Future<'a>;
+    fn wait_for_any_edge<'a>(&'a mut self) -> Self::Future<'a>;
 }

--- a/embassy-traits/src/i2c.rs
+++ b/embassy-traits/src/i2c.rs
@@ -67,7 +67,6 @@
 //! ```
 
 use core::future::Future;
-use core::pin::Pin;
 
 mod private {
     pub trait Sealed {}
@@ -117,7 +116,7 @@ pub trait I2c<A: AddressMode = SevenBitAddress> {
     /// - `MAK` = master acknowledge
     /// - `NMAK` = master no acknowledge
     /// - `SP` = stop condition
-    fn read<'a>(self: Pin<&'a mut Self>, address: A, buffer: &mut [u8]) -> Self::ReadFuture<'a>;
+    fn read<'a>(&'a mut self, address: A, buffer: &mut [u8]) -> Self::ReadFuture<'a>;
 
     /// Sends bytes to slave with address `address`
     ///
@@ -135,7 +134,7 @@ pub trait I2c<A: AddressMode = SevenBitAddress> {
     /// - `SAK` = slave acknowledge
     /// - `Bi` = ith byte of data
     /// - `SP` = stop condition
-    fn write<'a>(self: Pin<&'a mut Self>, address: A, bytes: &[u8]) -> Self::WriteFuture<'a>;
+    fn write<'a>(&'a mut self, address: A, bytes: &[u8]) -> Self::WriteFuture<'a>;
 
     /// Sends bytes to slave with address `address` and then reads enough bytes to fill `buffer` *in a
     /// single transaction*
@@ -160,7 +159,7 @@ pub trait I2c<A: AddressMode = SevenBitAddress> {
     /// - `NMAK` = master no acknowledge
     /// - `SP` = stop condition
     fn write_read<'a>(
-        self: Pin<&'a mut Self>,
+        &'a mut self,
         address: A,
         bytes: &[u8],
         buffer: &mut [u8],

--- a/embassy-traits/src/spi.rs
+++ b/embassy-traits/src/spi.rs
@@ -33,10 +33,10 @@ pub trait FullDuplex<Word> {
     where
         Self: 'a;
 
-    fn read<'a>(self: Pin<&'a mut Self>, data: &'a mut [Word]) -> Self::ReadFuture<'a>;
-    fn write<'a>(self: Pin<&'a mut Self>, data: &'a [Word]) -> Self::WriteFuture<'a>;
+    fn read<'a>(&'a mut self, data: &'a mut [Word]) -> Self::ReadFuture<'a>;
+    fn write<'a>(&'a mut self, data: &'a [Word]) -> Self::WriteFuture<'a>;
     fn read_write<'a>(
-        self: Pin<&'a mut Self>,
+        &'a mut self,
         read: &'a mut [Word],
         write: &'a [Word],
     ) -> Self::WriteReadFuture<'a>;

--- a/embassy-traits/src/uart.rs
+++ b/embassy-traits/src/uart.rs
@@ -13,7 +13,7 @@ pub trait Read {
     where
         Self: 'a;
 
-    fn read<'a>(self: Pin<&'a mut Self>, buf: &'a mut [u8]) -> Self::ReadFuture<'a>;
+    fn read<'a>(&'a mut self, buf: &'a mut [u8]) -> Self::ReadFuture<'a>;
 }
 
 pub trait ReadUntilIdle {
@@ -23,10 +23,7 @@ pub trait ReadUntilIdle {
 
     /// Receive into the buffer until the buffer is full or the line is idle after some bytes are received
     /// Return the number of bytes received
-    fn read_until_idle<'a>(
-        self: Pin<&'a mut Self>,
-        buf: &'a mut [u8],
-    ) -> Self::ReadUntilIdleFuture<'a>;
+    fn read_until_idle<'a>(&'a mut self, buf: &'a mut [u8]) -> Self::ReadUntilIdleFuture<'a>;
 }
 
 pub trait Write {
@@ -34,5 +31,5 @@ pub trait Write {
     where
         Self: 'a;
 
-    fn write<'a>(self: Pin<&'a mut Self>, buf: &'a [u8]) -> Self::WriteFuture<'a>;
+    fn write<'a>(&'a mut self, buf: &'a [u8]) -> Self::WriteFuture<'a>;
 }

--- a/embassy/src/executor/timer.rs
+++ b/embassy/src/executor/timer.rs
@@ -23,10 +23,10 @@ impl Delay {
 impl crate::traits::delay::Delay for Delay {
     type DelayFuture<'a> = impl Future<Output = ()> + 'a;
 
-    fn delay_ms<'a>(self: Pin<&'a mut Self>, millis: u64) -> Self::DelayFuture<'a> {
+    fn delay_ms<'a>(&'a mut self, millis: u64) -> Self::DelayFuture<'a> {
         Timer::after(Duration::from_millis(millis))
     }
-    fn delay_us<'a>(self: Pin<&'a mut Self>, micros: u64) -> Self::DelayFuture<'a> {
+    fn delay_us<'a>(&'a mut self, micros: u64) -> Self::DelayFuture<'a> {
         Timer::after(Duration::from_micros(micros))
     }
 }


### PR DESCRIPTION
Many people have reported struggling with putting pinned drivers in their structs. Pin has lots of usability issues:

- It doesn't integrate well with the borrow checker. For example it doesn't automatically reborrow, so you have to use `.as_mut()`.
- It's "infectious": if a struct contains something pinned, you have to make it pinned too, all the way to the topmost allocation.
- There's no good story on how to do pin projections: you either have to use unsafe, or use the bloated `pin-project`, or the incomplete `pin-project-lite`.

This PR attempts to remove Pin by moving the irq-accessible state from the driver structs to `static`s, so driver struct instances can be moved around freely.

- [x] Uart
- [x] Spi
- [x] I2c
- [x] GPIO WaitForX
- [x] Delay
- [x] Flash

