### PR TITLE
Expose methods for doing stepwise execution of the std executor

### DIFF
--- a/embassy/src/executor/raw.rs
+++ b/embassy/src/executor/raw.rs
@@ -191,7 +191,7 @@ impl Executor {
         self.enqueue(task as *const _ as _);
     }
 
-    pub unsafe fn run_queued(&'static self) {
+    pub unsafe fn run_queued(&'static self) -> bool {
         if self.alarm.is_some() {
             self.timer_queue.dequeue_expired(Instant::now(), |p| {
                 p.as_ref().enqueue();
@@ -226,6 +226,8 @@ impl Executor {
             alarm.set_callback(self.signal_fn, self.signal_ctx);
             alarm.set(next_expiration.as_ticks());
         }
+
+        self.run_queue.is_empty()
     }
 
     pub unsafe fn spawner(&'static self) -> super::Spawner {

--- a/embassy/src/executor/run_queue.rs
+++ b/embassy/src/executor/run_queue.rs
@@ -68,4 +68,9 @@ impl RunQueue {
             task = next
         }
     }
+
+    pub(crate) unsafe fn is_empty(&self) -> bool {
+        let mut prev = self.head.load(Ordering::Acquire);
+        prev.is_null()
+    }
 }


### PR DESCRIPTION
Doing stepswise execution is useful in unit tests of
platform-independent code, as one can follow this process in testing:

* Set some state in test
* Run executor until no tasks are queued
* Assert new state in test


NOTE: I attempted to use a RefCell instead of UnsafeCell, but the raw::Executor::spawner() requires static borrow.