### PR TITLE
Report ready status of run queue after run_queued have run

### DIFF
--- a/embassy/src/executor/raw.rs
+++ b/embassy/src/executor/raw.rs
@@ -191,7 +191,7 @@ impl Executor {
         self.enqueue(task as *const _ as _);
     }
 
-    pub unsafe fn run_queued(&'static self) {
+    pub unsafe fn run_queued(&'static self) -> bool {
         if self.alarm.is_some() {
             self.timer_queue.dequeue_expired(Instant::now(), |p| {
                 p.as_ref().enqueue();
@@ -226,6 +226,8 @@ impl Executor {
             alarm.set_callback(self.signal_fn, self.signal_ctx);
             alarm.set(next_expiration.as_ticks());
         }
+
+        self.run_queue.is_empty()
     }
 
     pub unsafe fn spawner(&'static self) -> super::Spawner {

--- a/embassy/src/executor/run_queue.rs
+++ b/embassy/src/executor/run_queue.rs
@@ -68,4 +68,8 @@ impl RunQueue {
             task = next
         }
     }
+
+    pub(crate) unsafe fn is_empty(&self) -> bool {
+        self.head.load(Ordering::Acquire).is_null()
+    }
 }


### PR DESCRIPTION
This is useful for the earlier mentioned test executor that needs to know if tasks have not spawned any new tasks that needs to complete.