### PR TITLE
Fix build on the latest nightly

### DIFF
--- a/embassy-traits/src/lib.rs
+++ b/embassy-traits/src/lib.rs
@@ -1,6 +1,5 @@
 #![cfg_attr(not(feature = "std"), no_std)]
 #![feature(generic_associated_types)]
-#![feature(const_fn)]
 #![feature(const_fn_fn_ptr_basics)]
 #![feature(const_option)]
 #![allow(incomplete_features)]

--- a/embassy/src/lib.rs
+++ b/embassy/src/lib.rs
@@ -1,6 +1,6 @@
 #![cfg_attr(not(feature = "std"), no_std)]
 #![feature(generic_associated_types)]
-#![feature(const_fn)]
+#![feature(const_fn_trait_bound)]
 #![feature(const_fn_fn_ptr_basics)]
 #![feature(const_option)]
 #![allow(incomplete_features)]


### PR DESCRIPTION
the const_fn feature was split into const_fn_trait_bound and const_fn_unsize: https://github.com/rust-lang/rust/pull/84310

I'm not sure why the CI wasnt failing as the rust change was merged a few weeks ago.