### PR TITLE
Use rust-toolchain.toml for developers and CI

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -71,10 +71,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions-rs/toolchain@v1
         with:
-          toolchain: nightly
-          target: ${{ matrix.target }}
-          components: rust-src, rustfmt
-          override: true
+          toolchain: stable
       - name: cache
         id: cache-target
         uses: actions/cache@v2
@@ -90,8 +87,6 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions-rs/toolchain@v1
         with:
-          toolchain: nightly
-          components: rustfmt
-          override: true
+          toolchain: stable
       - name: Check fmt
         run: for i in embassy-*; do (cd $i; cargo fmt -- --check); done

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,6 @@
+# Before upgrading check that everything is available on all tier1 targets here:
+# https://rust-lang.github.io/rustup-components-history
+[toolchain]
+channel = "nightly-2021-05-07"
+components = [ "rust-src", "rustfmt" ]
+targets = [ "thumbv7em-none-eabi", "thumbv6m-none-eabi" ]


### PR DESCRIPTION
The changes are:
*   setup a rust-toolchain file using the modern format: https://rust-lang.github.io/rustup/overrides.html#the-toolchain-file
*   removed toolchain specification from github actions config so that it will fall back to the toolchain file: https://github.com/actions-rs/toolchain

I hope my CI changes do what I think they should... I cant really test them locally.

Dependent on: https://github.com/embassy-rs/embassy/pull/166

This change could be controversial so I'm happy to discuss it.
The advantages I see here are:
*   CI doesnt break due to nightly regressions or breaking changes.
*   Developers work on a common nightly, preventing differences between nightlies from causing hard to track down issues.
*   Users have a documented nightly version that embassy supports, and they can also copy in the embassy rust-toolchain file without having to setup their own.

A disadvantage is:
*   If a user wants to try building one of the examples it will pull in rustfmt and a target they dont need.

However I dont think that is a big problem because if they are bothered by that they can just move the example into its own crate. Which they will probably want to do eventually anyway if they have interest in using embassy.