### PR TITLE
Fix all warnings on embassy-nrf + embassy-nrf-examples + embassy_extras

### DIFF
--- a/embassy-extras/src/ring_buffer.rs
+++ b/embassy-extras/src/ring_buffer.rs
@@ -1,4 +1,4 @@
-use crate::fmt::{assert, *};
+use crate::fmt::assert;
 
 pub struct RingBuffer<'a> {
     buf: &'a mut [u8],

--- a/embassy-nrf-examples/src/bin/blinky.rs
+++ b/embassy-nrf-examples/src/bin/blinky.rs
@@ -7,7 +7,6 @@
 
 #[path = "../example_common.rs"]
 mod example_common;
-use example_common::*;
 
 use defmt::panic;
 use embassy::executor::Spawner;
@@ -17,7 +16,7 @@ use embassy_nrf::Peripherals;
 use embedded_hal::digital::v2::OutputPin;
 
 #[embassy::main]
-async fn main(spawner: Spawner, p: Peripherals) {
+async fn main(_spawner: Spawner, p: Peripherals) {
     let mut led = Output::new(p.P0_13, Level::Low, OutputDrive::Standard);
 
     loop {

--- a/embassy-nrf-examples/src/bin/buffered_uart.rs
+++ b/embassy-nrf-examples/src/bin/buffered_uart.rs
@@ -17,7 +17,7 @@ use example_common::*;
 use futures::pin_mut;
 
 #[embassy::main]
-async fn main(spawner: Spawner, p: Peripherals) {
+async fn main(_spawner: Spawner, p: Peripherals) {
     let mut config = uarte::Config::default();
     config.parity = uarte::Parity::EXCLUDED;
     config.baudrate = uarte::Baudrate::BAUD115200;

--- a/embassy-nrf-examples/src/bin/executor_fairness_test.rs
+++ b/embassy-nrf-examples/src/bin/executor_fairness_test.rs
@@ -40,7 +40,7 @@ async fn run3() {
 }
 
 #[embassy::main]
-async fn main(spawner: Spawner, p: Peripherals) {
+async fn main(spawner: Spawner, _p: Peripherals) {
     unwrap!(spawner.spawn(run1()));
     unwrap!(spawner.spawn(run2()));
     unwrap!(spawner.spawn(run3()));

--- a/embassy-nrf-examples/src/bin/gpiote_channel.rs
+++ b/embassy-nrf-examples/src/bin/gpiote_channel.rs
@@ -16,7 +16,7 @@ use embassy_nrf::gpiote::{InputChannel, InputChannelPolarity};
 use embassy_nrf::{interrupt, Peripherals};
 
 #[embassy::main]
-async fn main(spawner: Spawner, p: Peripherals) {
+async fn main(_spawner: Spawner, p: Peripherals) {
     info!("Starting!");
 
     let ch1 = InputChannel::new(

--- a/embassy-nrf-examples/src/bin/ppi.rs
+++ b/embassy-nrf-examples/src/bin/ppi.rs
@@ -19,7 +19,7 @@ use embassy_nrf::{interrupt, Peripherals};
 use gpiote::{OutputChannel, OutputChannelPolarity};
 
 #[embassy::main]
-async fn main(spawner: Spawner, p: Peripherals) {
+async fn main(_spawner: Spawner, p: Peripherals) {
     info!("Starting!");
 
     let button1 = InputChannel::new(

--- a/embassy-nrf-examples/src/bin/pwm.rs
+++ b/embassy-nrf-examples/src/bin/pwm.rs
@@ -87,7 +87,7 @@ static DUTY: [u16; 1024] = [
 ];
 
 #[embassy::main]
-async fn main(spawner: Spawner, p: Peripherals) {
+async fn main(_spawner: Spawner, p: Peripherals) {
     let pwm = Pwm::new(p.PWM0, p.P0_13, p.P0_14, p.P0_16, p.P0_15);
     pwm.set_prescaler(Prescaler::Div1);
     info!("pwm initialized!");

--- a/embassy-nrf-examples/src/bin/qspi.rs
+++ b/embassy-nrf-examples/src/bin/qspi.rs
@@ -23,7 +23,7 @@ const PAGE_SIZE: usize = 4096;
 struct AlignedBuf([u8; 4096]);
 
 #[embassy::main]
-async fn main(spawner: Spawner, p: Peripherals) {
+async fn main(_spawner: Spawner, p: Peripherals) {
     let csn = p.P0_17;
     let sck = p.P0_19;
     let io0 = p.P0_20;

--- a/embassy-nrf-examples/src/bin/spim.rs
+++ b/embassy-nrf-examples/src/bin/spim.rs
@@ -10,7 +10,6 @@ mod example_common;
 
 use defmt::panic;
 use embassy::executor::Spawner;
-use embassy::util::Steal;
 use embassy_nrf::gpio::{Level, Output, OutputDrive};
 use embassy_nrf::Peripherals;
 use embassy_nrf::{interrupt, spim};
@@ -19,7 +18,7 @@ use embedded_hal::digital::v2::*;
 use example_common::*;
 
 #[embassy::main]
-async fn main(spawner: Spawner, p: Peripherals) {
+async fn main(_spawner: Spawner, p: Peripherals) {
     info!("running!");
 
     let mut config = spim::Config::default();

--- a/embassy-nrf-examples/src/bin/timer.rs
+++ b/embassy-nrf-examples/src/bin/timer.rs
@@ -31,7 +31,7 @@ async fn run2() {
 }
 
 #[embassy::main]
-async fn main(spawner: Spawner, p: Peripherals) {
+async fn main(spawner: Spawner, _p: Peripherals) {
     unwrap!(spawner.spawn(run1()));
     unwrap!(spawner.spawn(run2()));
 }

--- a/embassy-nrf-examples/src/bin/uart.rs
+++ b/embassy-nrf-examples/src/bin/uart.rs
@@ -12,12 +12,11 @@ use example_common::*;
 use defmt::panic;
 use embassy::executor::Spawner;
 use embassy::traits::uart::{Read, Write};
-use embassy::util::Steal;
 use embassy_nrf::gpio::NoPin;
 use embassy_nrf::{interrupt, uarte, Peripherals};
 
 #[embassy::main]
-async fn main(spawner: Spawner, p: Peripherals) {
+async fn main(_spawner: Spawner, p: Peripherals) {
     let mut config = uarte::Config::default();
     config.parity = uarte::Parity::EXCLUDED;
     config.baudrate = uarte::Baudrate::BAUD115200;

--- a/embassy-nrf-examples/src/bin/uart_idle.rs
+++ b/embassy-nrf-examples/src/bin/uart_idle.rs
@@ -12,13 +12,12 @@ use example_common::*;
 
 use defmt::panic;
 use embassy::executor::Spawner;
-use embassy::traits::uart::{Read, Write};
-use embassy::util::Steal;
+use embassy::traits::uart::Write;
 use embassy_nrf::gpio::NoPin;
 use embassy_nrf::{interrupt, uarte, Peripherals};
 
 #[embassy::main]
-async fn main(spawner: Spawner, p: Peripherals) {
+async fn main(_spawner: Spawner, p: Peripherals) {
     let mut config = uarte::Config::default();
     config.parity = uarte::Parity::EXCLUDED;
     config.baudrate = uarte::Baudrate::BAUD115200;

--- a/embassy-nrf/src/gpio.rs
+++ b/embassy-nrf/src/gpio.rs
@@ -11,7 +11,6 @@ use gpio::pin_cnf::DRIVE_A;
 
 use crate::pac;
 use crate::pac::p0 as gpio;
-use crate::peripherals;
 
 /// A GPIO port with up to 32 pins.
 #[derive(Debug, Eq, PartialEq)]

--- a/embassy-nrf/src/pwm.rs
+++ b/embassy-nrf/src/pwm.rs
@@ -6,7 +6,7 @@ use core::sync::atomic::{compiler_fence, Ordering};
 use embassy::util::Unborrow;
 use embassy_extras::unborrow;
 
-use crate::fmt::{assert, panic, unreachable, *};
+use crate::fmt::{unreachable, *};
 use crate::gpio::sealed::Pin as _;
 use crate::gpio::OptionalPin as GpioOptionalPin;
 use crate::interrupt::Interrupt;

--- a/embassy-nrf/src/pwm.rs
+++ b/embassy-nrf/src/pwm.rs
@@ -26,7 +26,6 @@ pub enum Prescaler {
 
 /// Interface to the UARTE peripheral
 pub struct Pwm<'d, T: Instance> {
-    peri: T,
     phantom: PhantomData<&'d mut T>,
 }
 
@@ -41,13 +40,13 @@ impl<'d, T: Instance> Pwm<'d, T> {
     /// or [`receive`](Pwm::receive).
     #[allow(unused_unsafe)]
     pub fn new(
-        pwm: impl Unborrow<Target = T> + 'd,
+        _pwm: impl Unborrow<Target = T> + 'd,
         ch0: impl Unborrow<Target = impl GpioOptionalPin> + 'd,
         ch1: impl Unborrow<Target = impl GpioOptionalPin> + 'd,
         ch2: impl Unborrow<Target = impl GpioOptionalPin> + 'd,
         ch3: impl Unborrow<Target = impl GpioOptionalPin> + 'd,
     ) -> Self {
-        unborrow!(pwm, ch0, ch1, ch2, ch3);
+        unborrow!(ch0, ch1, ch2, ch3);
 
         let r = T::regs();
         let s = T::state();
@@ -97,7 +96,6 @@ impl<'d, T: Instance> Pwm<'d, T> {
         r.loop_.write(|w| w.cnt().disabled());
 
         Self {
-            peri: pwm,
             phantom: PhantomData,
         }
     }

--- a/embassy-nrf/src/qspi.rs
+++ b/embassy-nrf/src/qspi.rs
@@ -11,8 +11,7 @@ use futures::future::poll_fn;
 
 use crate::fmt::{assert, assert_eq, *};
 use crate::gpio::Pin as GpioPin;
-use crate::interrupt::{self};
-use crate::{pac, peripherals};
+use crate::pac;
 
 pub use crate::pac::qspi::ifconfig0::ADDRMODE_A as AddressMode;
 pub use crate::pac::qspi::ifconfig0::PPSIZE_A as WritePageSize;

--- a/embassy-nrf/src/qspi.rs
+++ b/embassy-nrf/src/qspi.rs
@@ -55,14 +55,12 @@ impl Default for Config {
 }
 
 pub struct Qspi<'d, T: Instance> {
-    peri: T,
-    irq: T::Interrupt,
     phantom: PhantomData<&'d mut T>,
 }
 
 impl<'d, T: Instance> Qspi<'d, T> {
     pub fn new(
-        qspi: impl Unborrow<Target = T> + 'd,
+        _qspi: impl Unborrow<Target = T> + 'd,
         irq: impl Unborrow<Target = T::Interrupt> + 'd,
         sck: impl Unborrow<Target = impl GpioPin> + 'd,
         csn: impl Unborrow<Target = impl GpioPin> + 'd,
@@ -72,7 +70,7 @@ impl<'d, T: Instance> Qspi<'d, T> {
         io3: impl Unborrow<Target = impl GpioPin> + 'd,
         config: Config,
     ) -> Self {
-        unborrow!(qspi, irq, sck, csn, io0, io1, io2, io3);
+        unborrow!(irq, sck, csn, io0, io1, io2, io3);
 
         let r = T::regs();
 
@@ -139,8 +137,6 @@ impl<'d, T: Instance> Qspi<'d, T> {
         irq.enable();
 
         Self {
-            peri: qspi,
-            irq,
             phantom: PhantomData,
         }
     }

--- a/embassy-nrf/src/saadc.rs
+++ b/embassy-nrf/src/saadc.rs
@@ -32,8 +32,6 @@ pub enum Error {}
 
 /// One-shot saadc. Continuous sample mode TODO.
 pub struct OneShot<'d, T: PositivePin> {
-    peri: peripherals::SAADC,
-    positive_pin: T,
     irq: interrupt::SAADC,
     phantom: PhantomData<(&'d mut peripherals::SAADC, &'d mut T)>,
 }
@@ -71,12 +69,12 @@ impl Default for Config {
 
 impl<'d, T: PositivePin> OneShot<'d, T> {
     pub fn new(
-        saadc: impl Unborrow<Target = peripherals::SAADC> + 'd,
+        _saadc: impl Unborrow<Target = peripherals::SAADC> + 'd,
         irq: impl Unborrow<Target = interrupt::SAADC> + 'd,
         positive_pin: impl Unborrow<Target = T> + 'd,
         config: Config,
     ) -> Self {
-        unborrow!(saadc, irq, positive_pin);
+        unborrow!(irq, positive_pin);
 
         let r = unsafe { &*SAADC::ptr() };
 
@@ -118,8 +116,6 @@ impl<'d, T: PositivePin> OneShot<'d, T> {
         r.intenclr.write(|w| unsafe { w.bits(0x003F_FFFF) });
 
         Self {
-            peri: saadc,
-            positive_pin,
             irq,
             phantom: PhantomData,
         }

--- a/embassy-nrf/src/spim.rs
+++ b/embassy-nrf/src/spim.rs
@@ -13,8 +13,8 @@ use traits::spi::FullDuplex;
 
 use crate::gpio::sealed::Pin as _;
 use crate::gpio::{OptionalPin, Pin as GpioPin};
-use crate::interrupt::{self, Interrupt};
-use crate::{pac, peripherals, util::slice_in_ram_or};
+use crate::interrupt::Interrupt;
+use crate::{pac, util::slice_in_ram_or};
 
 pub use embedded_hal::spi::{Mode, Phase, Polarity, MODE_0, MODE_1, MODE_2, MODE_3};
 pub use pac::spim0::frequency::FREQUENCY_A as Frequency;
@@ -285,7 +285,7 @@ impl<'d, T: Instance> embedded_hal::blocking::spi::Write<u8> for Spim<'d, T> {
 
     fn write(&mut self, words: &[u8]) -> Result<(), Self::Error> {
         slice_in_ram_or(words, Error::DMABufferNotInDataMemory)?;
-        let mut recv: &mut [u8] = &mut [];
+        let recv: &mut [u8] = &mut [];
 
         // Conservative compiler fence to prevent optimizations that do not
         // take in to account actions by DMA. The fence has been placed here,

--- a/embassy-nrf/src/spim.rs
+++ b/embassy-nrf/src/spim.rs
@@ -30,8 +30,6 @@ pub enum Error {
 }
 
 pub struct Spim<'d, T: Instance> {
-    peri: T,
-    irq: T::Interrupt,
     phantom: PhantomData<&'d mut T>,
 }
 
@@ -54,14 +52,14 @@ impl Default for Config {
 
 impl<'d, T: Instance> Spim<'d, T> {
     pub fn new(
-        spim: impl Unborrow<Target = T> + 'd,
+        _spim: impl Unborrow<Target = T> + 'd,
         irq: impl Unborrow<Target = T::Interrupt> + 'd,
         sck: impl Unborrow<Target = impl GpioPin> + 'd,
         miso: impl Unborrow<Target = impl OptionalPin> + 'd,
         mosi: impl Unborrow<Target = impl OptionalPin> + 'd,
         config: Config,
     ) -> Self {
-        unborrow!(spim, irq, sck, miso, mosi);
+        unborrow!(irq, sck, miso, mosi);
 
         let r = T::regs();
 
@@ -140,8 +138,6 @@ impl<'d, T: Instance> Spim<'d, T> {
         irq.enable();
 
         Self {
-            peri: spim,
-            irq,
             phantom: PhantomData,
         }
     }

--- a/embassy-nrf/src/twim.rs
+++ b/embassy-nrf/src/twim.rs
@@ -42,20 +42,18 @@ impl Default for Config {
 
 /// Interface to a TWIM instance.
 pub struct Twim<'d, T: Instance> {
-    peri: T,
-    irq: T::Interrupt,
     phantom: PhantomData<&'d mut T>,
 }
 
 impl<'d, T: Instance> Twim<'d, T> {
     pub fn new(
-        twim: impl Unborrow<Target = T> + 'd,
+        _twim: impl Unborrow<Target = T> + 'd,
         irq: impl Unborrow<Target = T::Interrupt> + 'd,
         sda: impl Unborrow<Target = impl GpioPin> + 'd,
         scl: impl Unborrow<Target = impl GpioPin> + 'd,
         config: Config,
     ) -> Self {
-        unborrow!(twim, irq, sda, scl);
+        unborrow!(irq, sda, scl);
 
         let r = T::regs();
 
@@ -94,8 +92,6 @@ impl<'d, T: Instance> Twim<'d, T> {
         irq.enable();
 
         Self {
-            peri: twim,
-            irq,
             phantom: PhantomData,
         }
     }

--- a/embassy-nrf/src/uarte.rs
+++ b/embassy-nrf/src/uarte.rs
@@ -16,10 +16,8 @@ use crate::chip::EASY_DMA_SIZE;
 use crate::fmt::{assert, panic, *};
 use crate::gpio::sealed::Pin as _;
 use crate::gpio::{OptionalPin as GpioOptionalPin, Pin as GpioPin};
-use crate::interrupt;
 use crate::interrupt::Interrupt;
 use crate::pac;
-use crate::peripherals;
 use crate::ppi::{AnyConfigurableChannel, ConfigurableChannel, Event, Ppi, Task};
 use crate::timer::Instance as TimerInstance;
 
@@ -43,7 +41,6 @@ impl Default for Config {
 
 /// Interface to the UARTE peripheral
 pub struct Uarte<'d, T: Instance> {
-    peri: T,
     phantom: PhantomData<&'d mut T>,
 }
 
@@ -58,7 +55,7 @@ impl<'d, T: Instance> Uarte<'d, T> {
     /// or [`receive`](Uarte::receive).
     #[allow(unused_unsafe)]
     pub unsafe fn new(
-        uarte: impl Unborrow<Target = T> + 'd,
+        _uarte: impl Unborrow<Target = T> + 'd,
         irq: impl Unborrow<Target = T::Interrupt> + 'd,
         rxd: impl Unborrow<Target = impl GpioPin> + 'd,
         txd: impl Unborrow<Target = impl GpioPin> + 'd,
@@ -66,7 +63,7 @@ impl<'d, T: Instance> Uarte<'d, T> {
         rts: impl Unborrow<Target = impl GpioOptionalPin> + 'd,
         config: Config,
     ) -> Self {
-        unborrow!(uarte, irq, rxd, txd, cts, rts);
+        unborrow!(irq, rxd, txd, cts, rts);
 
         let r = T::regs();
 
@@ -119,7 +116,6 @@ impl<'d, T: Instance> Uarte<'d, T> {
         r.enable.write(|w| w.enable().enabled());
 
         Self {
-            peri: uarte,
             phantom: PhantomData,
         }
     }


### PR DESCRIPTION
I was wary of removing the unused fields, but I couldnt see any problem with doing so as the `embassy_nrf::peripherals::*` dont have drop impls.