### PR TITLE
Fix all warnings on embassy-rp and embassy-rp-examples and embassy-std-examples

### DIFF
--- a/embassy-rp-examples/src/bin/button.rs
+++ b/embassy-rp-examples/src/bin/button.rs
@@ -9,7 +9,6 @@
 #[path = "../example_common.rs"]
 mod example_common;
 
-use defmt::*;
 use embassy::executor::Spawner;
 use embassy_rp::gpio::{Input, Level, Output, Pull};
 use embassy_rp::Peripherals;

--- a/embassy-rp-examples/src/bin/uart.rs
+++ b/embassy-rp-examples/src/bin/uart.rs
@@ -9,7 +9,6 @@
 #[path = "../example_common.rs"]
 mod example_common;
 
-use defmt::*;
 use embassy::executor::Spawner;
 use embassy_rp::{uart, Peripherals};
 

--- a/embassy-rp/build.rs
+++ b/embassy-rp/build.rs
@@ -1,7 +1,7 @@
-use std::fs::{self, File};
+use std::env;
+use std::fs::File;
 use std::io::Write;
-use std::path::{Path, PathBuf};
-use std::{env, ffi::OsStr};
+use std::path::PathBuf;
 
 fn main() {
     // Put the linker script somewhere the linker can find it

--- a/embassy-rp/src/dma.rs
+++ b/embassy-rp/src/dma.rs
@@ -1,11 +1,11 @@
 use core::sync::atomic::{compiler_fence, Ordering};
 
-use crate::fmt::{assert, *};
+use crate::fmt::assert;
 use crate::pac::dma::vals;
 use crate::{pac, peripherals};
 
 pub struct Dma<T: Channel> {
-    inner: T,
+    _inner: T,
 }
 
 impl<T: Channel> Dma<T> {

--- a/embassy-rp/src/lib.rs
+++ b/embassy-rp/src/lib.rs
@@ -3,6 +3,7 @@
 #![feature(asm)]
 #![feature(type_alias_impl_trait)]
 #![feature(never_type)]
+#![allow(incomplete_features)]
 
 pub use rp2040_pac2 as pac;
 
@@ -87,7 +88,7 @@ pub mod config {
     }
 }
 
-pub fn init(config: config::Config) -> Peripherals {
+pub fn init(_config: config::Config) -> Peripherals {
     // Do this first, so that it panics if user is calling `init` a second time
     // before doing anything important.
     let peripherals = Peripherals::take();

--- a/embassy-rp/src/pll.rs
+++ b/embassy-rp/src/pll.rs
@@ -1,6 +1,4 @@
-use core::ops::Deref;
-
-use crate::fmt::{assert, *};
+use crate::fmt::assert;
 use crate::pac;
 
 const XOSC_MHZ: u32 = 12;

--- a/embassy-std-examples/src/bin/serial.rs
+++ b/embassy-std-examples/src/bin/serial.rs
@@ -1,6 +1,7 @@
 #![feature(min_type_alias_impl_trait)]
 #![feature(impl_trait_in_bindings)]
 #![feature(type_alias_impl_trait)]
+#![allow(incomplete_features)]
 
 #[path = "../serial_port.rs"]
 mod serial_port;

--- a/embassy-std-examples/src/bin/tick.rs
+++ b/embassy-std-examples/src/bin/tick.rs
@@ -1,6 +1,7 @@
 #![feature(min_type_alias_impl_trait)]
 #![feature(impl_trait_in_bindings)]
 #![feature(type_alias_impl_trait)]
+#![allow(incomplete_features)]
 
 use embassy::time::{Duration, Timer};
 use embassy::util::Forever;


### PR DESCRIPTION
Pulls the warning fixes out of https://github.com/embassy-rs/embassy/pull/190
I'm landing these separately as the namespaced-features addition is fairly contentious

This still leaves a warning unfixed when compiling embassy without defmt. e.g. when compiling embassy-std-examples.