### PR TITLE
Fix warnings for embassy-stm32 and embassy-stm32-examples and add .cargo/config.toml + memory.x

### DIFF
--- a/embassy-stm32-examples/.cargo/config.toml
+++ b/embassy-stm32-examples/.cargo/config.toml
@@ -2,8 +2,8 @@
 build-std = ["core"]
 
 [target.'cfg(all(target_arch = "arm", target_os = "none"))']
-# replace nRF82840_xxAA with your chip as listed in `probe-run --list-chips`
-runner = "probe-run --chip nRF52840_xxAA"
+# replace STM32F429ZITx with your chip as listed in `probe-run --list-chips`
+runner = "probe-run --chip STM32F429ZITx"
 
 rustflags = [
   # LLD (shipped with the Rust toolchain) is used as the default linker

--- a/embassy-stm32-examples/memory.x
+++ b/embassy-stm32-examples/memory.x
@@ -1,0 +1,7 @@
+MEMORY
+{
+  /* NOTE 1 K = 1 KiBi = 1024 bytes */
+  /* These values correspond to the STM32F429ZI */
+  FLASH : ORIGIN = 0x08000000, LENGTH = 1024K
+  RAM : ORIGIN = 0x20000000, LENGTH = 256K
+}

--- a/embassy-stm32-examples/src/bin/blinky.rs
+++ b/embassy-stm32-examples/src/bin/blinky.rs
@@ -4,6 +4,7 @@
 #![feature(min_type_alias_impl_trait)]
 #![feature(impl_trait_in_bindings)]
 #![feature(type_alias_impl_trait)]
+#![allow(incomplete_features)]
 
 #[path = "../example_common.rs"]
 mod example_common;

--- a/embassy-stm32-examples/src/bin/button.rs
+++ b/embassy-stm32-examples/src/bin/button.rs
@@ -4,6 +4,7 @@
 #![feature(min_type_alias_impl_trait)]
 #![feature(impl_trait_in_bindings)]
 #![feature(type_alias_impl_trait)]
+#![allow(incomplete_features)]
 
 #[path = "../example_common.rs"]
 mod example_common;

--- a/embassy-stm32-examples/src/bin/button_exti.rs
+++ b/embassy-stm32-examples/src/bin/button_exti.rs
@@ -4,13 +4,14 @@
 #![feature(min_type_alias_impl_trait)]
 #![feature(impl_trait_in_bindings)]
 #![feature(type_alias_impl_trait)]
+#![allow(incomplete_features)]
 
 #[path = "../example_common.rs"]
 mod example_common;
 use embassy::executor::Executor;
 use embassy::time::Clock;
 use embassy::util::Forever;
-use embassy_stm32::exti::{self, ExtiInput};
+use embassy_stm32::exti::ExtiInput;
 use embassy_stm32::gpio::{Input, Pull};
 use embassy_traits::gpio::{WaitForFallingEdge, WaitForRisingEdge};
 use example_common::*;

--- a/embassy-stm32-examples/src/bin/spi.rs
+++ b/embassy-stm32-examples/src/bin/spi.rs
@@ -4,20 +4,20 @@
 #![feature(min_type_alias_impl_trait)]
 #![feature(impl_trait_in_bindings)]
 #![feature(type_alias_impl_trait)]
+#![allow(incomplete_features)]
 
 #[path = "../example_common.rs"]
 mod example_common;
 
-use embassy_stm32::gpio::{Input, Level, Output, Pull};
-use embedded_hal::digital::v2::{InputPin, OutputPin};
+use embassy_stm32::gpio::{Level, Output};
+use embedded_hal::digital::v2::OutputPin;
 use example_common::*;
 
 use cortex_m_rt::entry;
-use stm32f4::stm32f429 as pac;
-//use stm32l4::stm32l4x5 as pac;
-use embassy_stm32::spi::{ByteOrder, Config, Spi, MODE_0};
+use embassy_stm32::spi::{Config, Spi};
 use embassy_stm32::time::Hertz;
 use embedded_hal::blocking::spi::Transfer;
+use stm32f4::stm32f429 as pac;
 
 #[entry]
 fn main() -> ! {
@@ -47,7 +47,6 @@ fn main() -> ! {
         w
     });
 
-    let rc = pp.RCC.cfgr.read().sws().bits();
     let p = embassy_stm32::init(Default::default());
 
     let mut spi = Spi::new(
@@ -64,9 +63,9 @@ fn main() -> ! {
 
     loop {
         let mut buf = [0x0A; 4];
-        cs.set_low();
-        spi.transfer(&mut buf);
-        cs.set_high();
+        unwrap!(cs.set_low());
+        unwrap!(spi.transfer(&mut buf));
+        unwrap!(cs.set_high());
         info!("xfer {=[u8]:x}", buf);
     }
 }

--- a/embassy-stm32-examples/src/bin/usart.rs
+++ b/embassy-stm32-examples/src/bin/usart.rs
@@ -4,6 +4,7 @@
 #![feature(min_type_alias_impl_trait)]
 #![feature(impl_trait_in_bindings)]
 #![feature(type_alias_impl_trait)]
+#![allow(incomplete_features)]
 
 #[path = "../example_common.rs"]
 mod example_common;
@@ -11,7 +12,6 @@ use cortex_m::prelude::_embedded_hal_blocking_serial_Write;
 use embassy::executor::Executor;
 use embassy::time::Clock;
 use embassy::util::Forever;
-use embassy_stm32::gpio::NoPin;
 use embassy_stm32::usart::{Config, Uart};
 use example_common::*;
 

--- a/embassy-stm32-examples/src/bin/usart_dma.rs
+++ b/embassy-stm32-examples/src/bin/usart_dma.rs
@@ -4,6 +4,7 @@
 #![feature(min_type_alias_impl_trait)]
 #![feature(impl_trait_in_bindings)]
 #![feature(type_alias_impl_trait)]
+#![allow(incomplete_features)]
 
 #[path = "../example_common.rs"]
 mod example_common;

--- a/embassy-stm32/src/dma/mod.rs
+++ b/embassy-stm32/src/dma/mod.rs
@@ -3,6 +3,7 @@
 #[cfg_attr(feature = "_dma_v1", path = "v1.rs")]
 #[cfg_attr(feature = "_dma_v2", path = "v2.rs")]
 mod _version;
+#[allow(unused)]
 pub use _version::*;
 
 use crate::pac;

--- a/embassy-stm32/src/dma/v2.rs
+++ b/embassy-stm32/src/dma/v2.rs
@@ -5,7 +5,7 @@ use embassy::util::AtomicWaker;
 use futures::future::poll_fn;
 
 use super::*;
-use crate::fmt::{assert, *};
+use crate::fmt::assert;
 use crate::interrupt;
 use crate::pac;
 use crate::pac::dma::{regs, vals};

--- a/embassy-stm32/src/exti.rs
+++ b/embassy-stm32/src/exti.rs
@@ -11,7 +11,6 @@ use embassy_extras::unsafe_impl_unborrow;
 use embedded_hal::digital::v2::InputPin;
 use pac::exti::{regs, vals};
 
-use crate::fmt::*;
 use crate::gpio::{AnyPin, Input, Pin as GpioPin};
 use crate::interrupt;
 use crate::pac;

--- a/embassy-stm32/src/lib.rs
+++ b/embassy-stm32/src/lib.rs
@@ -9,8 +9,6 @@
 // This must go FIRST so that all the other modules see its macros.
 pub mod fmt;
 
-use embassy::interrupt::{Interrupt, InterruptExt};
-
 #[cfg(feature = "_dma")]
 pub mod dma;
 pub mod exti;

--- a/embassy-stm32/src/pac/regs.rs
+++ b/embassy-stm32/src/pac/regs.rs
@@ -1,4 +1,3 @@
-#![no_std]
 #![doc = "Peripheral access API (generated using svd2rust v0.17.0 (22741fa 2021-04-20))"]
 pub mod syscfg_h7 {
     use crate::generic::*;

--- a/embassy-stm32/src/rng.rs
+++ b/embassy-stm32/src/rng.rs
@@ -8,7 +8,6 @@ use embassy_extras::unborrow;
 use futures::future::poll_fn;
 use rand_core::{CryptoRng, RngCore};
 
-use crate::fmt::*;
 use crate::pac;
 
 pub(crate) static RNG_WAKER: AtomicWaker = AtomicWaker::new();

--- a/embassy-stm32/src/spi/mod.rs
+++ b/embassy-stm32/src/spi/mod.rs
@@ -7,6 +7,7 @@ pub use _version::*;
 
 use crate::gpio::Pin;
 
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub enum Error {
     Framing,
     Crc,

--- a/embassy-stm32/src/spi/v1.rs
+++ b/embassy-stm32/src/spi/v1.rs
@@ -19,7 +19,6 @@ impl WordSize {
 }
 
 pub struct Spi<'d, T: Instance> {
-    //peri: T,
     sck: AnyPin,
     mosi: AnyPin,
     miso: AnyPin,
@@ -30,7 +29,7 @@ pub struct Spi<'d, T: Instance> {
 impl<'d, T: Instance> Spi<'d, T> {
     pub fn new<F>(
         pclk: Hertz,
-        peri: impl Unborrow<Target = T> + 'd,
+        _peri: impl Unborrow<Target = T> + 'd,
         sck: impl Unborrow<Target = impl SckPin<T>>,
         mosi: impl Unborrow<Target = impl MosiPin<T>>,
         miso: impl Unborrow<Target = impl MisoPin<T>>,
@@ -40,7 +39,7 @@ impl<'d, T: Instance> Spi<'d, T> {
     where
         F: Into<Hertz>,
     {
-        unborrow!(peri, sck, mosi, miso);
+        unborrow!(sck, mosi, miso);
 
         unsafe {
             sck.set_as_af(sck.af_num());
@@ -89,7 +88,6 @@ impl<'d, T: Instance> Spi<'d, T> {
         }
 
         Self {
-            //peri,
             sck,
             mosi,
             miso,

--- a/embassy-stm32/src/usart/v1.rs
+++ b/embassy-stm32/src/usart/v1.rs
@@ -3,8 +3,7 @@ use core::marker::PhantomData;
 use embassy::util::Unborrow;
 use embassy_extras::unborrow;
 
-use crate::gpio::{NoPin, Pin};
-use crate::pac::usart::{regs, vals, Usart};
+use crate::pac::usart::{regs, vals};
 
 use super::*;
 


### PR DESCRIPTION
I used the STM32F429ZITx chip as the cargo.toml uses stm32f429zi but there also seems to be a STM32F429ZIYx not sure what the difference would be..