### PR TITLE
RccPeripharal + generate SPI clock enable

### DIFF
--- a/embassy-stm32/src/dac/mod.rs
+++ b/embassy-stm32/src/dac/mod.rs
@@ -51,5 +51,3 @@ crate::pac::peripheral_pins!(
         }
     };
 );
-
-

--- a/embassy-stm32/src/dac/mod.rs
+++ b/embassy-stm32/src/dac/mod.rs
@@ -51,3 +51,5 @@ crate::pac::peripheral_pins!(
         }
     };
 );
+
+

--- a/embassy-stm32/src/rcc/mod.rs
+++ b/embassy-stm32/src/rcc/mod.rs
@@ -62,20 +62,26 @@ crate::pac::peripheral_rcc!(
     ($inst:ident, $enable:ident, $reset:ident, $perien:ident, $perirst:ident) => {
         impl sealed::RccPeripheral for peripherals::$inst {
             fn enable() {
-                unsafe {
-                    crate::pac::RCC.$enable().modify(|w| w.$perien(true));
-                }
+                critical_section::with(|_| {
+                    unsafe {
+                        crate::pac::RCC.$enable().modify(|w| w.$perien(true));
+                    }
+                })
             }
             fn disable() {
-                unsafe {
-                    crate::pac::RCC.$enable().modify(|w| w.$perien(false));
-                }
+                critical_section::with(|_| {
+                    unsafe {
+                        crate::pac::RCC.$enable().modify(|w| w.$perien(false));
+                    }
+                })
             }
             fn reset() {
-                unsafe {
-                    crate::pac::RCC.$reset().modify(|w| w.$perirst(true));
-                    crate::pac::RCC.$reset().modify(|w| w.$perirst(false));
-                }
+                critical_section::with(|_| {
+                    unsafe {
+                        crate::pac::RCC.$reset().modify(|w| w.$perirst(true));
+                        crate::pac::RCC.$reset().modify(|w| w.$perirst(false));
+                    }
+                })
             }
         }
 

--- a/embassy-stm32/src/rcc/mod.rs
+++ b/embassy-stm32/src/rcc/mod.rs
@@ -1,3 +1,6 @@
+#![macro_use]
+
+use crate::peripherals;
 use crate::time::Hertz;
 use core::mem::MaybeUninit;
 
@@ -44,3 +47,38 @@ cfg_if::cfg_if! {
         }
     }
 }
+
+pub(crate) mod sealed {
+    pub trait RccPeripheral {
+        fn reset();
+        fn enable();
+        fn disable();
+    }
+}
+
+pub trait RccPeripheral: sealed::RccPeripheral + 'static {}
+
+crate::pac::peripheral_rcc!(
+    ($inst:ident, $enable:ident, $reset:ident, $perien:ident, $perirst:ident) => {
+        impl sealed::RccPeripheral for peripherals::$inst {
+            fn enable() {
+                unsafe {
+                    crate::pac::RCC.$enable().modify(|w| w.$perien(true));
+                }
+            }
+            fn disable() {
+                unsafe {
+                    crate::pac::RCC.$enable().modify(|w| w.$perien(false));
+                }
+            }
+            fn reset() {
+                unsafe {
+                    crate::pac::RCC.$reset().modify(|w| w.$perirst(true));
+                    crate::pac::RCC.$reset().modify(|w| w.$perirst(false));
+                }
+            }
+        }
+
+        impl RccPeripheral for peripherals::$inst {}
+    };
+);

--- a/embassy-stm32/src/spi/mod.rs
+++ b/embassy-stm32/src/spi/mod.rs
@@ -4,7 +4,7 @@
 #[cfg_attr(spi_v2, path = "v2.rs")]
 #[cfg_attr(spi_v3, path = "v3.rs")]
 mod _version;
-use crate::peripherals;
+use crate::{peripherals, rcc::RccPeripheral};
 pub use _version::*;
 
 use crate::gpio::Pin;
@@ -64,7 +64,7 @@ pub(crate) mod sealed {
     }
 }
 
-pub trait Instance: sealed::Instance + 'static {}
+pub trait Instance: sealed::Instance + RccPeripheral + 'static {}
 
 pub trait SckPin<T: Instance>: sealed::SckPin<T> + 'static {}
 

--- a/embassy-stm32/src/spi/v1.rs
+++ b/embassy-stm32/src/spi/v1.rs
@@ -2,7 +2,6 @@
 
 use crate::gpio::{sealed::Pin, AnyPin};
 use crate::pac::spi;
-use crate::rcc::RccPeripheral;
 use crate::spi::{ByteOrder, Config, Error, Instance, MisoPin, MosiPin, SckPin, WordSize};
 use crate::time::Hertz;
 use core::marker::PhantomData;
@@ -20,7 +19,7 @@ impl WordSize {
     }
 }
 
-pub struct Spi<'d, T: Instance + RccPeripheral> {
+pub struct Spi<'d, T: Instance> {
     sck: AnyPin,
     mosi: AnyPin,
     miso: AnyPin,
@@ -28,7 +27,7 @@ pub struct Spi<'d, T: Instance + RccPeripheral> {
     phantom: PhantomData<&'d mut T>,
 }
 
-impl<'d, T: Instance + RccPeripheral> Spi<'d, T> {
+impl<'d, T: Instance> Spi<'d, T> {
     pub fn new<F>(
         pclk: Hertz,
         _peri: impl Unborrow<Target = T> + 'd,
@@ -131,7 +130,7 @@ impl<'d, T: Instance + RccPeripheral> Spi<'d, T> {
     }
 }
 
-impl<'d, T: Instance + RccPeripheral> Drop for Spi<'d, T> {
+impl<'d, T: Instance> Drop for Spi<'d, T> {
     fn drop(&mut self) {
         unsafe {
             self.sck.set_as_analog();
@@ -141,7 +140,7 @@ impl<'d, T: Instance + RccPeripheral> Drop for Spi<'d, T> {
     }
 }
 
-impl<'d, T: Instance + RccPeripheral> embedded_hal::blocking::spi::Write<u8> for Spi<'d, T> {
+impl<'d, T: Instance> embedded_hal::blocking::spi::Write<u8> for Spi<'d, T> {
     type Error = Error;
 
     fn write(&mut self, words: &[u8]) -> Result<(), Self::Error> {
@@ -177,7 +176,7 @@ impl<'d, T: Instance + RccPeripheral> embedded_hal::blocking::spi::Write<u8> for
     }
 }
 
-impl<'d, T: Instance + RccPeripheral> embedded_hal::blocking::spi::Transfer<u8> for Spi<'d, T> {
+impl<'d, T: Instance> embedded_hal::blocking::spi::Transfer<u8> for Spi<'d, T> {
     type Error = Error;
 
     fn transfer<'w>(&mut self, words: &'w mut [u8]) -> Result<&'w [u8], Self::Error> {
@@ -218,7 +217,7 @@ impl<'d, T: Instance + RccPeripheral> embedded_hal::blocking::spi::Transfer<u8> 
     }
 }
 
-impl<'d, T: Instance + RccPeripheral> embedded_hal::blocking::spi::Write<u16> for Spi<'d, T> {
+impl<'d, T: Instance> embedded_hal::blocking::spi::Write<u16> for Spi<'d, T> {
     type Error = Error;
 
     fn write(&mut self, words: &[u16]) -> Result<(), Self::Error> {
@@ -254,7 +253,7 @@ impl<'d, T: Instance + RccPeripheral> embedded_hal::blocking::spi::Write<u16> fo
     }
 }
 
-impl<'d, T: Instance + RccPeripheral> embedded_hal::blocking::spi::Transfer<u16> for Spi<'d, T> {
+impl<'d, T: Instance> embedded_hal::blocking::spi::Transfer<u16> for Spi<'d, T> {
     type Error = Error;
 
     fn transfer<'w>(&mut self, words: &'w mut [u16]) -> Result<&'w [u16], Self::Error> {

--- a/embassy-stm32/src/spi/v2.rs
+++ b/embassy-stm32/src/spi/v2.rs
@@ -4,7 +4,6 @@ use crate::gpio::{AnyPin, Pin};
 use crate::pac::gpio::vals::{Afr, Moder};
 use crate::pac::gpio::Gpio;
 use crate::pac::spi;
-use crate::rcc::RccPeripheral;
 use crate::spi::{ByteOrder, Config, Error, Instance, MisoPin, MosiPin, SckPin, WordSize};
 use crate::time::Hertz;
 use core::marker::PhantomData;
@@ -29,14 +28,14 @@ impl WordSize {
     }
 }
 
-pub struct Spi<'d, T: Instance + RccPeripheral> {
+pub struct Spi<'d, T: Instance> {
     sck: AnyPin,
     mosi: AnyPin,
     miso: AnyPin,
     phantom: PhantomData<&'d mut T>,
 }
 
-impl<'d, T: Instance + RccPeripheral> Spi<'d, T> {
+impl<'d, T: Instance> Spi<'d, T> {
     pub fn new<F>(
         pclk: Hertz,
         _peri: impl Unborrow<Target = T> + 'd,
@@ -143,7 +142,7 @@ impl<'d, T: Instance + RccPeripheral> Spi<'d, T> {
     }
 }
 
-impl<'d, T: Instance + RccPeripheral> Drop for Spi<'d, T> {
+impl<'d, T: Instance> Drop for Spi<'d, T> {
     fn drop(&mut self) {
         unsafe {
             Self::unconfigure_pin(self.sck.block(), self.sck.pin() as _);
@@ -201,7 +200,7 @@ fn read_word<W: Word>(regs: &'static crate::pac::spi::Spi) -> Result<W, Error> {
     }
 }
 
-impl<'d, T: Instance + RccPeripheral> embedded_hal::blocking::spi::Write<u8> for Spi<'d, T> {
+impl<'d, T: Instance> embedded_hal::blocking::spi::Write<u8> for Spi<'d, T> {
     type Error = Error;
 
     fn write(&mut self, words: &[u8]) -> Result<(), Self::Error> {
@@ -217,7 +216,7 @@ impl<'d, T: Instance + RccPeripheral> embedded_hal::blocking::spi::Write<u8> for
     }
 }
 
-impl<'d, T: Instance + RccPeripheral> embedded_hal::blocking::spi::Transfer<u8> for Spi<'d, T> {
+impl<'d, T: Instance> embedded_hal::blocking::spi::Transfer<u8> for Spi<'d, T> {
     type Error = Error;
 
     fn transfer<'w>(&mut self, words: &'w mut [u8]) -> Result<&'w [u8], Self::Error> {
@@ -233,7 +232,7 @@ impl<'d, T: Instance + RccPeripheral> embedded_hal::blocking::spi::Transfer<u8> 
     }
 }
 
-impl<'d, T: Instance + RccPeripheral> embedded_hal::blocking::spi::Write<u16> for Spi<'d, T> {
+impl<'d, T: Instance> embedded_hal::blocking::spi::Write<u16> for Spi<'d, T> {
     type Error = Error;
 
     fn write(&mut self, words: &[u16]) -> Result<(), Self::Error> {
@@ -249,7 +248,7 @@ impl<'d, T: Instance + RccPeripheral> embedded_hal::blocking::spi::Write<u16> fo
     }
 }
 
-impl<'d, T: Instance + RccPeripheral> embedded_hal::blocking::spi::Transfer<u16> for Spi<'d, T> {
+impl<'d, T: Instance> embedded_hal::blocking::spi::Transfer<u16> for Spi<'d, T> {
     type Error = Error;
 
     fn transfer<'w>(&mut self, words: &'w mut [u16]) -> Result<&'w [u16], Self::Error> {

--- a/embassy-stm32/src/spi/v3.rs
+++ b/embassy-stm32/src/spi/v3.rs
@@ -4,6 +4,7 @@ use crate::gpio::{AnyPin, Pin};
 use crate::pac::gpio::vals::{Afr, Moder};
 use crate::pac::gpio::Gpio;
 use crate::pac::spi;
+use crate::rcc::RccPeripheral;
 use crate::spi::{ByteOrder, Config, Error, Instance, MisoPin, MosiPin, SckPin, WordSize};
 use crate::time::Hertz;
 use core::marker::PhantomData;
@@ -28,14 +29,14 @@ impl WordSize {
     }
 }
 
-pub struct Spi<'d, T: Instance> {
+pub struct Spi<'d, T: Instance + RccPeripheral> {
     sck: AnyPin,
     mosi: AnyPin,
     miso: AnyPin,
     phantom: PhantomData<&'d mut T>,
 }
 
-impl<'d, T: Instance> Spi<'d, T> {
+impl<'d, T: Instance + RccPeripheral> Spi<'d, T> {
     pub fn new<F>(
         pclk: Hertz,
         _peri: impl Unborrow<Target = T> + 'd,
@@ -64,6 +65,8 @@ impl<'d, T: Instance> Spi<'d, T> {
 
         let br = Self::compute_baud_rate(pclk, freq.into());
         unsafe {
+            T::enable();
+            T::reset();
             T::regs().ifcr().write(|w| w.0 = 0xffff_ffff);
             T::regs().cfg2().modify(|w| {
                 //w.set_ssoe(true);
@@ -161,7 +164,7 @@ impl<'d, T: Instance> Spi<'d, T> {
     }
 }
 
-impl<'d, T: Instance> Drop for Spi<'d, T> {
+impl<'d, T: Instance + RccPeripheral> Drop for Spi<'d, T> {
     fn drop(&mut self) {
         unsafe {
             Self::unconfigure_pin(self.sck.block(), self.sck.pin() as _);
@@ -171,7 +174,7 @@ impl<'d, T: Instance> Drop for Spi<'d, T> {
     }
 }
 
-impl<'d, T: Instance> embedded_hal::blocking::spi::Write<u8> for Spi<'d, T> {
+impl<'d, T: Instance + RccPeripheral> embedded_hal::blocking::spi::Write<u8> for Spi<'d, T> {
     type Error = Error;
 
     fn write(&mut self, words: &[u8]) -> Result<(), Self::Error> {
@@ -208,7 +211,7 @@ impl<'d, T: Instance> embedded_hal::blocking::spi::Write<u8> for Spi<'d, T> {
     }
 }
 
-impl<'d, T: Instance> embedded_hal::blocking::spi::Transfer<u8> for Spi<'d, T> {
+impl<'d, T: Instance + RccPeripheral> embedded_hal::blocking::spi::Transfer<u8> for Spi<'d, T> {
     type Error = Error;
 
     fn transfer<'w>(&mut self, words: &'w mut [u8]) -> Result<&'w [u8], Self::Error> {
@@ -265,7 +268,7 @@ impl<'d, T: Instance> embedded_hal::blocking::spi::Transfer<u8> for Spi<'d, T> {
     }
 }
 
-impl<'d, T: Instance> embedded_hal::blocking::spi::Write<u16> for Spi<'d, T> {
+impl<'d, T: Instance + RccPeripheral> embedded_hal::blocking::spi::Write<u16> for Spi<'d, T> {
     type Error = Error;
 
     fn write(&mut self, words: &[u16]) -> Result<(), Self::Error> {
@@ -302,7 +305,7 @@ impl<'d, T: Instance> embedded_hal::blocking::spi::Write<u16> for Spi<'d, T> {
     }
 }
 
-impl<'d, T: Instance> embedded_hal::blocking::spi::Transfer<u16> for Spi<'d, T> {
+impl<'d, T: Instance + RccPeripheral> embedded_hal::blocking::spi::Transfer<u16> for Spi<'d, T> {
     type Error = Error;
 
     fn transfer<'w>(&mut self, words: &'w mut [u16]) -> Result<&'w [u16], Self::Error> {

--- a/embassy-stm32/src/spi/v3.rs
+++ b/embassy-stm32/src/spi/v3.rs
@@ -4,7 +4,6 @@ use crate::gpio::{AnyPin, Pin};
 use crate::pac::gpio::vals::{Afr, Moder};
 use crate::pac::gpio::Gpio;
 use crate::pac::spi;
-use crate::rcc::RccPeripheral;
 use crate::spi::{ByteOrder, Config, Error, Instance, MisoPin, MosiPin, SckPin, WordSize};
 use crate::time::Hertz;
 use core::marker::PhantomData;
@@ -29,14 +28,14 @@ impl WordSize {
     }
 }
 
-pub struct Spi<'d, T: Instance + RccPeripheral> {
+pub struct Spi<'d, T: Instance> {
     sck: AnyPin,
     mosi: AnyPin,
     miso: AnyPin,
     phantom: PhantomData<&'d mut T>,
 }
 
-impl<'d, T: Instance + RccPeripheral> Spi<'d, T> {
+impl<'d, T: Instance> Spi<'d, T> {
     pub fn new<F>(
         pclk: Hertz,
         _peri: impl Unborrow<Target = T> + 'd,
@@ -164,7 +163,7 @@ impl<'d, T: Instance + RccPeripheral> Spi<'d, T> {
     }
 }
 
-impl<'d, T: Instance + RccPeripheral> Drop for Spi<'d, T> {
+impl<'d, T: Instance> Drop for Spi<'d, T> {
     fn drop(&mut self) {
         unsafe {
             Self::unconfigure_pin(self.sck.block(), self.sck.pin() as _);
@@ -174,7 +173,7 @@ impl<'d, T: Instance + RccPeripheral> Drop for Spi<'d, T> {
     }
 }
 
-impl<'d, T: Instance + RccPeripheral> embedded_hal::blocking::spi::Write<u8> for Spi<'d, T> {
+impl<'d, T: Instance> embedded_hal::blocking::spi::Write<u8> for Spi<'d, T> {
     type Error = Error;
 
     fn write(&mut self, words: &[u8]) -> Result<(), Self::Error> {
@@ -211,7 +210,7 @@ impl<'d, T: Instance + RccPeripheral> embedded_hal::blocking::spi::Write<u8> for
     }
 }
 
-impl<'d, T: Instance + RccPeripheral> embedded_hal::blocking::spi::Transfer<u8> for Spi<'d, T> {
+impl<'d, T: Instance> embedded_hal::blocking::spi::Transfer<u8> for Spi<'d, T> {
     type Error = Error;
 
     fn transfer<'w>(&mut self, words: &'w mut [u8]) -> Result<&'w [u8], Self::Error> {
@@ -268,7 +267,7 @@ impl<'d, T: Instance + RccPeripheral> embedded_hal::blocking::spi::Transfer<u8> 
     }
 }
 
-impl<'d, T: Instance + RccPeripheral> embedded_hal::blocking::spi::Write<u16> for Spi<'d, T> {
+impl<'d, T: Instance> embedded_hal::blocking::spi::Write<u16> for Spi<'d, T> {
     type Error = Error;
 
     fn write(&mut self, words: &[u16]) -> Result<(), Self::Error> {
@@ -305,7 +304,7 @@ impl<'d, T: Instance + RccPeripheral> embedded_hal::blocking::spi::Write<u16> fo
     }
 }
 
-impl<'d, T: Instance + RccPeripheral> embedded_hal::blocking::spi::Transfer<u16> for Spi<'d, T> {
+impl<'d, T: Instance> embedded_hal::blocking::spi::Transfer<u16> for Spi<'d, T> {
     type Error = Error;
 
     fn transfer<'w>(&mut self, words: &'w mut [u16]) -> Result<&'w [u16], Self::Error> {

--- a/stm32-metapac/build.rs
+++ b/stm32-metapac/build.rs
@@ -219,17 +219,22 @@ fn main() {
                 }
                 "spi" => {
                     if let Some(clock) = &p.clock {
-                        // Workaround for APB1 register being split on some chip families
-                        let reg = if chip.family == "STM32H7" && clock == "APB1" {
-                            format!("{}l", clock.to_ascii_lowercase())
+                        // Workaround for APB1 register being split on some chip families. Assume
+                        // first register until we can find a way to hint which register is used
+                        let reg = clock.to_ascii_lowercase();
+                        let (enable_reg, reset_reg) = if chip.family == "STM32H7" && clock == "APB1"
+                        {
+                            (format!("{}lenr", reg), format!("{}lrstr", reg))
+                        } else if chip.family == "STM32L4" && clock == "APB1" {
+                            (format!("{}enr1", reg), format!("{}rstr1", reg))
                         } else {
-                            clock.to_ascii_lowercase()
+                            (format!("{}enr", reg), format!("{}rstr", reg))
                         };
                         let field = name.to_ascii_lowercase();
                         peripheral_rcc_table.push(vec![
                             name.clone(),
-                            format!("{}enr", reg),
-                            format!("{}rstr", reg),
+                            enable_reg,
+                            reset_reg,
                             format!("set_{}en", field),
                             format!("set_{}rst", field),
                         ]);

--- a/stm32-metapac/build.rs
+++ b/stm32-metapac/build.rs
@@ -225,7 +225,7 @@ fn main() {
                         let (enable_reg, reset_reg) = if chip.family == "STM32H7" && clock == "APB1"
                         {
                             (format!("{}lenr", reg), format!("{}lrstr", reg))
-                        } else if chip.family == "STM32L4" && clock == "APB1" {
+                        } else if chip.family.starts_with("STM32L4") && clock == "APB1" {
                             (format!("{}enr1", reg), format!("{}rstr1", reg))
                         } else {
                             (format!("{}enr", reg), format!("{}rstr", reg))

--- a/stm32-metapac/build.rs
+++ b/stm32-metapac/build.rs
@@ -219,7 +219,12 @@ fn main() {
                 }
                 "spi" => {
                     if let Some(clock) = &p.clock {
-                        let reg = clock.to_ascii_lowercase();
+                        // Workaround for APB1 register being split on some chip families
+                        let reg = if chip.family == "STM32H7" && clock == "APB1" {
+                            format!("{}l", clock.to_ascii_lowercase())
+                        } else {
+                            clock.to_ascii_lowercase()
+                        };
                         let field = name.to_ascii_lowercase();
                         peripheral_rcc_table.push(vec![
                             name.clone(),

--- a/stm32-metapac/build.rs
+++ b/stm32-metapac/build.rs
@@ -136,6 +136,7 @@ fn main() {
     let mut interrupt_table: Vec<Vec<String>> = Vec::new();
     let mut peripherals_table: Vec<Vec<String>> = Vec::new();
     let mut peripheral_pins_table: Vec<Vec<String>> = Vec::new();
+    let mut peripheral_rcc_table: Vec<Vec<String>> = Vec::new();
 
     let dma_base = chip
         .peripherals
@@ -216,6 +217,19 @@ fn main() {
                     };
                     assert_eq!(p.address, dma_base + dma_stride * dma_num);
                 }
+                "spi" => {
+                    if let Some(clock) = &p.clock {
+                        let reg = clock.to_ascii_lowercase();
+                        let field = name.to_ascii_lowercase();
+                        peripheral_rcc_table.push(vec![
+                            name.clone(),
+                            format!("{}enr", reg),
+                            format!("{}rstr", reg),
+                            format!("set_{}en", field),
+                            format!("set_{}rst", field),
+                        ]);
+                    }
+                }
                 _ => {}
             }
         }
@@ -255,6 +269,7 @@ fn main() {
     make_table(&mut extra, "peripherals", &peripherals_table);
     make_table(&mut extra, "peripheral_versions", &peripheral_version_table);
     make_table(&mut extra, "peripheral_pins", &peripheral_pins_table);
+    make_table(&mut extra, "peripheral_rcc", &peripheral_rcc_table);
 
     for (module, version) in peripheral_versions {
         println!("loading {} {}", module, version);


### PR DESCRIPTION
Adds RccPeripheral trait and a macro table for peripherals implementing clock enable and reset for a given peripheral