### PR TITLE
Add `Unborrow` trait bound for `Interrupt`

### DIFF
--- a/embassy/src/interrupt.rs
+++ b/embassy/src/interrupt.rs
@@ -30,7 +30,7 @@ unsafe impl cortex_m::interrupt::InterruptNumber for NrWrap {
     }
 }
 
-pub unsafe trait Interrupt {
+pub unsafe trait Interrupt: crate::util::Unborrow<Target = Self> {
     type Priority: From<u8> + Into<u8> + Copy;
     fn number(&self) -> u16;
     unsafe fn steal() -> Self;


### PR DESCRIPTION
Allows the compiler to figure out bounds for wrapper code of owned
peripherals and interrupts.
Example: https://gist.github.com/timokroeger/f025ef590557f1cd6c2e9c7ab30442d2