### PR TITLE
Enable timer clock in RCC on timer start

### DIFF
--- a/embassy-macros/src/chip/stm32.rs
+++ b/embassy-macros/src/chip/stm32.rs
@@ -16,7 +16,10 @@ pub fn generate(embassy_prefix: &ModulePrefix, config: syn::Expr) -> TokenStream
             interrupt::take!(TIM2),
         );
         let clock = unsafe { make_static(&mut c) };
-        clock.start_tim2();
+
+        // TODO: Is TIM2 always APB1?
+        let timer_freq = unsafe { #embassy_stm32_path::rcc::get_freqs().apb1_clk };
+        clock.start(timer_freq);
 
         let mut alarm = clock.alarm1();
         unsafe { #embassy_path::time::set_clock(clock) };

--- a/stm32-metapac/gen/src/lib.rs
+++ b/stm32-metapac/gen/src/lib.rs
@@ -268,42 +268,42 @@ pub fn gen(options: Options) {
                 }
 
                 if let Some(rcc) = &rcc {
-                    // Workaround for clock registers being split on some chip families. Assume fields are
-                    // named after peripheral and look for first field matching and use that register.
-                    //
-                    // Not all peripherals have the clock hint due to insufficient information from
-                    // chip definition. If clock is not specified, the first matching register with the
-                    // expected field will be used.
-                    let en = find_reg_for_field(
-                        &rcc,
-                        p.clock.as_ref().unwrap_or(&String::new()),
-                        &format!("{}EN", name),
-                    );
-                    let rst = find_reg_for_field(
-                        &rcc,
-                        p.clock.as_ref().unwrap_or(&String::new()),
-                        &format!("{}RST", name),
-                    );
+                    let mut generate_rcc_peripheral = |clock_prefix| {
+                        // Workaround for clock registers being split on some chip families. Assume fields are
+                        // named after peripheral and look for first field matching and use that register.
 
-                    match (en, rst) {
-                        (Some((enable_reg, enable_field)), Some((reset_reg, reset_field))) => {
-                            peripheral_rcc_table.push(vec![
-                                name.clone(),
-                                enable_reg.to_ascii_lowercase(),
-                                reset_reg.to_ascii_lowercase(),
-                                format!("set_{}", enable_field.to_ascii_lowercase()),
-                                format!("set_{}", reset_field.to_ascii_lowercase()),
-                            ]);
+                        let en = find_reg_for_field(&rcc, clock_prefix, &format!("{}EN", name));
+                        let rst = find_reg_for_field(&rcc, clock_prefix, &format!("{}RST", name));
+
+                        match (en, rst) {
+                            (Some((enable_reg, enable_field)), Some((reset_reg, reset_field))) => {
+                                peripheral_rcc_table.push(vec![
+                                    name.clone(),
+                                    enable_reg.to_ascii_lowercase(),
+                                    reset_reg.to_ascii_lowercase(),
+                                    format!("set_{}", enable_field.to_ascii_lowercase()),
+                                    format!("set_{}", reset_field.to_ascii_lowercase()),
+                                ]);
+                            }
+                            (None, Some(_)) => {
+                                println!("Unable to find enable register for {}", name)
+                            }
+                            (Some(_), None) => {
+                                println!("Unable to find reset register for {}", name)
+                            }
+                            (None, None) => {
+                                println!("Unable to find enable and reset register for {}", name)
+                            }
                         }
-                        (None, Some(_)) => {
-                            println!("Unable to find enable register for {}", name)
-                        }
-                        (Some(_), None) => {
-                            println!("Unable to find reset register for {}", name)
-                        }
-                        (None, None) => {
-                            println!("Unable to find enable and reset register for {}", name)
-                        }
+                    };
+
+                    if let Some(clock) = &p.clock {
+                        generate_rcc_peripheral(clock);
+                    } else if name.starts_with("TIM") {
+                        // Not all peripherals like timers the clock hint due to insufficient information from
+                        // chip definition. If clock is not specified, the first matching register with the
+                        // expected field will be used.
+                        generate_rcc_peripheral("");
                     }
                 }
             }


### PR DESCRIPTION
* Moves the tim2-specific code into macro which always uses TIM2
* For peripherals without clock specified, attempt to locate enable and
  reset registers in the RCC block matching the peripheral name. This
  could be useful for peripherals where deducing the clock name might
  not be feasible, but it remains to be tested with more chip families
  to see if it is sufficiently accurate.