### PR TITLE
net: Make the user pass in the StackResources in init

### DIFF
--- a/embassy-net/src/lib.rs
+++ b/embassy-net/src/lib.rs
@@ -14,7 +14,7 @@ pub use config::{Config, Configurator, Event as ConfigEvent, StaticConfigurator}
 
 pub use device::{Device, LinkState};
 pub use packet_pool::{Packet, PacketBox, PacketBoxExt, PacketBuf, MTU};
-pub use stack::{init, is_config_up, is_init, is_link_up, run};
+pub use stack::{init, is_config_up, is_init, is_link_up, run, StackResources};
 
 #[cfg(feature = "tcp")]
 mod tcp_socket;

--- a/examples/std/src/bin/net.rs
+++ b/examples/std/src/bin/net.rs
@@ -19,6 +19,7 @@ use crate::tuntap::TunTapDevice;
 
 static DEVICE: Forever<TunTapDevice> = Forever::new();
 static CONFIG: Forever<DhcpConfigurator> = Forever::new();
+static NET_RESOURCES: Forever<StackResources<1, 2, 8>> = Forever::new();
 
 #[derive(Clap)]
 #[clap(version = "1.0")]
@@ -51,8 +52,10 @@ async fn main_task(spawner: Spawner) {
     // DHCP configruation
     let config = DhcpConfigurator::new();
 
+    let net_resources = StackResources::new();
+
     // Init network stack
-    embassy_net::init(DEVICE.put(device), CONFIG.put(config));
+    embassy_net::init(DEVICE.put(device), CONFIG.put(config), NET_RESOURCES.put(net_resources));
 
     // Launch network task
     spawner.spawn(net_task()).unwrap();


### PR DESCRIPTION
By having the user pass in the resources, we can make them generic, this way the user can choose the size of the individual resources.