### PR TITLE
fix stm32 warnings

### DIFF
--- a/embassy-stm32/src/adc/mod.rs
+++ b/embassy-stm32/src/adc/mod.rs
@@ -6,12 +6,9 @@ mod _version;
 #[allow(unused)]
 pub use _version::*;
 
-use crate::gpio::NoPin;
 use crate::peripherals;
 
 pub(crate) mod sealed {
-    use crate::gpio::Pin;
-
     pub trait Instance {
         fn regs() -> &'static crate::pac::adc::Adc;
         fn common_regs() -> &'static crate::pac::adccommon::AdcCommon;

--- a/examples/stm32h7/src/bin/blinky.rs
+++ b/examples/stm32h7/src/bin/blinky.rs
@@ -28,7 +28,7 @@ fn main() -> ! {
 
     let rcc = pp.RCC.constrain();
 
-    let ccdr = rcc
+    rcc
         .sys_ck(96.mhz())
         .pclk1(48.mhz())
         .pclk2(48.mhz())

--- a/examples/stm32h7/src/bin/dac.rs
+++ b/examples/stm32h7/src/bin/dac.rs
@@ -1,5 +1,6 @@
 #![no_std]
 #![no_main]
+#![allow(incomplete_features)]
 #![feature(trait_alias)]
 #![feature(min_type_alias_impl_trait)]
 #![feature(impl_trait_in_bindings)]
@@ -8,16 +9,12 @@
 #[path = "../example_common.rs"]
 mod example_common;
 
-use embassy_stm32::gpio::{Level, Output, Input, Pull, NoPin};
-use embedded_hal::digital::v2::{OutputPin, InputPin};
+use embassy_stm32::gpio::NoPin;
 use example_common::*;
 
 use cortex_m_rt::entry;
 use stm32h7::stm32h743 as pac;
-use embassy_stm32::spi::{Spi, MODE_0, ByteOrder, Config};
-use embassy_stm32::time::Hertz;
-use embedded_hal::blocking::spi::Transfer;
-use stm32h7xx_hal::{rcc, prelude::*};
+use stm32h7xx_hal::prelude::*;
 use embassy_stm32::dac::{Dac, Value, Channel};
 
 #[entry]
@@ -31,7 +28,7 @@ fn main() -> ! {
 
     let rcc = pp.RCC.constrain();
 
-    let ccdr = rcc
+    rcc
         .sys_ck(96.mhz())
         .pclk1(48.mhz())
         .pclk2(48.mhz())
@@ -71,8 +68,8 @@ fn main() -> ! {
 
     loop {
         for v in 0..=255 {
-            dac.set(Channel::Ch1, Value::Bit8(to_sine_wave(v)));
-            dac.trigger( Channel::Ch1 );
+            unwrap!(dac.set(Channel::Ch1, Value::Bit8(to_sine_wave(v))));
+            unwrap!(dac.trigger(Channel::Ch1));
         }
     }
 }

--- a/examples/stm32h7/src/bin/eth.rs
+++ b/examples/stm32h7/src/bin/eth.rs
@@ -1,5 +1,6 @@
 #![no_std]
 #![no_main]
+#![allow(incomplete_features)]
 #![feature(trait_alias)]
 #![feature(min_type_alias_impl_trait)]
 #![feature(impl_trait_in_bindings)]

--- a/examples/stm32h7/src/bin/usart.rs
+++ b/examples/stm32h7/src/bin/usart.rs
@@ -59,7 +59,7 @@ fn main() -> ! {
 
     let rcc = pp.RCC.constrain();
 
-    let ccdr = rcc
+    rcc
         .sys_ck(96.mhz())
         .pclk1(48.mhz())
         .pclk2(48.mhz())

--- a/examples/stm32l4/src/bin/adc.rs
+++ b/examples/stm32l4/src/bin/adc.rs
@@ -1,5 +1,6 @@
 #![no_std]
 #![no_main]
+#![allow(incomplete_features)]
 #![feature(trait_alias)]
 #![feature(min_type_alias_impl_trait)]
 #![feature(impl_trait_in_bindings)]
@@ -8,23 +9,15 @@
 #[path = "../example_common.rs"]
 mod example_common;
 
-use embassy_stm32::gpio::{Input, Level, NoPin, Output, Pull};
-use embedded_hal::digital::v2::{InputPin, OutputPin};
 use example_common::*;
 
 use cortex_m_rt::entry;
 //use stm32f4::stm32f429 as pac;
 use cortex_m::delay::Delay;
 use embassy_stm32::adc::{Adc, Resolution};
-use embassy_stm32::dac::{Channel, Dac, Value};
-use embassy_stm32::spi::{ByteOrder, Config, Spi, MODE_0};
-use embassy_stm32::time::Hertz;
-use embedded_hal::blocking::spi::Transfer;
-use micromath::F32Ext;
 use stm32l4::stm32l4x5 as pac;
-use stm32l4xx_hal::gpio::PA4;
 use stm32l4xx_hal::rcc::PllSource;
-use stm32l4xx_hal::{prelude::*, rcc};
+use stm32l4xx_hal::prelude::*;
 
 #[entry]
 fn main() -> ! {
@@ -36,11 +29,11 @@ fn main() -> ! {
     let mut rcc = pp.RCC.constrain();
     let mut pwr = pp.PWR.constrain(&mut rcc.apb1r1);
 
-    let mut delay = Delay::new(cp.SYST, 80_000_000);
+    let delay = Delay::new(cp.SYST, 80_000_000);
 
     // TRY the other clock configuration
     // let clocks = rcc.cfgr.freeze(&mut flash.acr);
-    let clocks = rcc
+    rcc
         .cfgr
         .sysclk(80.mhz())
         .pclk1(80.mhz())
@@ -76,7 +69,7 @@ fn main() -> ! {
 
     let p = embassy_stm32::init(Default::default());
 
-    let (mut adc, mut delay) = Adc::new(p.ADC1, delay);
+    let (mut adc, _) = Adc::new(p.ADC1, delay);
     //adc.enable_vref();
     adc.set_resolution(Resolution::EightBit);
     let mut channel = p.PC0;
@@ -84,17 +77,5 @@ fn main() -> ! {
     loop {
         let v = adc.read(&mut channel);
         info!("--> {}", v);
-    }
-}
-
-fn to_sine_wave(v: u8) -> u8 {
-    if v >= 128 {
-        // top half
-        let r = 3.14 * ((v - 128) as f32 / 128.0);
-        (r.sin() * 128.0 + 127.0) as u8
-    } else {
-        // bottom half
-        let r = 3.14 + 3.14 * (v as f32 / 128.0);
-        (r.sin() * 128.0 + 127.0) as u8
     }
 }

--- a/examples/stm32l4/src/bin/dac.rs
+++ b/examples/stm32l4/src/bin/dac.rs
@@ -1,5 +1,6 @@
 #![no_std]
 #![no_main]
+#![allow(incomplete_features)]
 #![feature(trait_alias)]
 #![feature(min_type_alias_impl_trait)]
 #![feature(impl_trait_in_bindings)]
@@ -8,20 +9,15 @@
 #[path = "../example_common.rs"]
 mod example_common;
 
-use embassy_stm32::gpio::{Input, Level, NoPin, Output, Pull};
-use embedded_hal::digital::v2::{InputPin, OutputPin};
+use embassy_stm32::gpio::NoPin;
 use example_common::*;
 
 use cortex_m_rt::entry;
 //use stm32f4::stm32f429 as pac;
 use embassy_stm32::dac::{Channel, Dac, Value};
-use embassy_stm32::spi::{ByteOrder, Config, Spi, MODE_0};
-use embassy_stm32::time::Hertz;
-use embedded_hal::blocking::spi::Transfer;
 use stm32l4::stm32l4x5 as pac;
-use stm32l4xx_hal::gpio::PA4;
 use stm32l4xx_hal::rcc::PllSource;
-use stm32l4xx_hal::{prelude::*, rcc};
+use stm32l4xx_hal::{prelude::*};
 
 #[entry]
 fn main() -> ! {
@@ -34,7 +30,7 @@ fn main() -> ! {
 
     // TRY the other clock configuration
     // let clocks = rcc.cfgr.freeze(&mut flash.acr);
-    let clocks = rcc
+    rcc
         .cfgr
         .sysclk(80.mhz())
         .pclk1(80.mhz())
@@ -71,8 +67,8 @@ fn main() -> ! {
 
     loop {
         for v in 0..=255 {
-            dac.set(Channel::Ch1, Value::Bit8(to_sine_wave(v)));
-            dac.trigger(Channel::Ch1);
+            unwrap!(dac.set(Channel::Ch1, Value::Bit8(to_sine_wave(v))));
+            unwrap!(dac.trigger(Channel::Ch1));
         }
     }
 }


### PR DESCRIPTION
I suspect deleting `fn calibrate` isn't the right option, did we maybe forget to call it somewhere? or maybe this code is just super WIP?