### PR TITLE
Update nightly

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,6 +1,6 @@
 # Before upgrading check that everything is available on all tier1 targets here:
 # https://rust-lang.github.io/rustup-components-history
 [toolchain]
-channel = "nightly-2021-05-07"
+channel = "nightly-2021-07-13"
 components = [ "rust-src", "rustfmt" ]
 targets = [ "thumbv7em-none-eabi", "thumbv6m-none-eabi", "thumbv7em-none-eabihf" ]


### PR DESCRIPTION
The currently pinned nightly is broken with last rust-analyzer (due proc-macro ABI shenanigans, causes "proc macro server crashed" errors). Latest nightly works fine.