### PR TITLE
Add a `Dbgmcu` struct capable of enabling all relevant DBGMCU.cr fields.

### DIFF
--- a/embassy-stm32/src/dbgmcu/mod.rs
+++ b/embassy-stm32/src/dbgmcu/mod.rs
@@ -1,0 +1,13 @@
+pub struct Dbgmcu {}
+
+impl Dbgmcu {
+    pub unsafe fn enable_all() {
+        crate::pac::DBGMCU.cr().modify(|cr| {
+            crate::pac::dbgmcu! {
+                (cr, $fn_name:ident) => {
+                    cr.$fn_name(true);
+                };
+            }
+        });
+    }
+}

--- a/embassy-stm32/src/lib.rs
+++ b/embassy-stm32/src/lib.rs
@@ -31,6 +31,8 @@ pub mod adc;
 pub mod clock;
 #[cfg(dac)]
 pub mod dac;
+#[cfg(dbgmcu)]
+pub mod dbgmcu;
 #[cfg(all(eth, feature = "net"))]
 pub mod eth;
 #[cfg(exti)]

--- a/examples/stm32f4/src/bin/spi.rs
+++ b/examples/stm32f4/src/bin/spi.rs
@@ -18,17 +18,14 @@ use embassy_stm32::pac;
 use embassy_stm32::spi::{Config, Spi};
 use embassy_stm32::time::Hertz;
 use embedded_hal::blocking::spi::Transfer;
+use embassy_stm32::dbgmcu::Dbgmcu;
 
 #[entry]
 fn main() -> ! {
     info!("Hello World, dude!");
 
     unsafe {
-        pac::DBGMCU.cr().modify(|w| {
-            w.set_dbg_sleep(true);
-            w.set_dbg_standby(true);
-            w.set_dbg_stop(true);
-        });
+        Dbgmcu::enable_all();
 
         pac::RCC.ahb1enr().modify(|w| {
             w.set_gpioaen(true);

--- a/examples/stm32h7/src/bin/usart_dma.rs
+++ b/examples/stm32h7/src/bin/usart_dma.rs
@@ -14,6 +14,7 @@ use embassy::time::Clock;
 use embassy::util::Forever;
 use embassy_stm32::dma::NoDma;
 use embassy_stm32::usart::{Config, Uart};
+use embassy_stm32::dbgmcu::Dbgmcu;
 use example_common::*;
 use embassy_traits::uart::Write as _Write;
 
@@ -72,13 +73,9 @@ fn main() -> ! {
 
     let pp = unsafe { pac::Peripherals::steal() };
 
-    pp.DBGMCU.cr.modify(|_, w| {
-        w.dbgsleep_d1().set_bit();
-        w.dbgstby_d1().set_bit();
-        w.dbgstop_d1().set_bit();
-        w.d1dbgcken().set_bit();
-        w
-    });
+    unsafe {
+        Dbgmcu::enable_all();
+    }
 
     pp.RCC.ahb4enr.modify(|_, w| {
         w.gpioaen().set_bit();


### PR DESCRIPTION
Includes the addition of a `dbgmcu!(...)` macro table which currently takes
the form of

	(cr, $fn_name:ident)

where `$fn_name` is something like `set_dbgsleep_d1` etc.

The method is unsafe, since it's performing unsafe PAC operations.

Two examples modified to demonstrate its usage.