### PR TITLE
stm32/examples: cleanup L4

### DIFF
--- a/examples/stm32l4/Cargo.toml
+++ b/examples/stm32l4/Cargo.toml
@@ -21,7 +21,6 @@ embassy = { version = "0.1.0", path = "../../embassy", features = ["defmt", "def
 embassy-traits = { version = "0.1.0", path = "../../embassy-traits", features = ["defmt"] }
 embassy-stm32 = { version = "0.1.0", path = "../../embassy-stm32", features = ["defmt", "defmt-trace", "unstable-pac", "stm32l4s5vi"]  }
 embassy-extras = {version = "0.1.0", path = "../../embassy-extras" }
-stm32l4xx-hal = { version = "0.6.0", features = ["stm32l4x5"] }
 
 defmt = "0.2.0"
 defmt-rtt = "0.2.0"

--- a/examples/stm32l4/src/bin/blinky.rs
+++ b/examples/stm32l4/src/bin/blinky.rs
@@ -8,14 +8,16 @@
 
 #[path = "../example_common.rs"]
 mod example_common;
-use cortex_m_rt::entry;
+use defmt::panic;
+use embassy::executor::Spawner;
+use embassy::time::{Duration, Timer};
 use embassy_stm32::gpio::{Level, Output, Speed};
-use embassy_stm32::pac;
+use embassy_stm32::{pac, Peripherals};
 use embedded_hal::digital::v2::OutputPin;
 use example_common::*;
 
-#[entry]
-fn main() -> ! {
+#[embassy::main]
+async fn main(_spawner: Spawner, p: Peripherals) {
     info!("Hello World!");
 
     unsafe {
@@ -26,17 +28,12 @@ fn main() -> ! {
         });
     }
 
-    let p = embassy_stm32::init(Default::default());
-
     let mut led = Output::new(p.PB14, Level::High, Speed::Low);
 
     loop {
-        info!("high");
         led.set_high().unwrap();
-        cortex_m::asm::delay(10_000_000);
-
-        info!("low");
+        Timer::after(Duration::from_millis(300)).await;
         led.set_low().unwrap();
-        cortex_m::asm::delay(10_000_000);
+        Timer::after(Duration::from_millis(300)).await;
     }
 }

--- a/examples/stm32l4/src/bin/button.rs
+++ b/examples/stm32l4/src/bin/button.rs
@@ -8,14 +8,15 @@
 
 #[path = "../example_common.rs"]
 mod example_common;
-use cortex_m_rt::entry;
-use embassy_stm32::gpio::{Input, Level, Output, Pull, Speed};
-use embassy_stm32::pac;
-use embedded_hal::digital::v2::{InputPin, OutputPin};
+use defmt::panic;
+use embassy::executor::Spawner;
+use embassy_stm32::gpio::{Input, Pull};
+use embassy_stm32::{pac, Peripherals};
+use embedded_hal::digital::v2::InputPin;
 use example_common::*;
 
-#[entry]
-fn main() -> ! {
+#[embassy::main]
+async fn main(_spawner: Spawner, p: Peripherals) {
     info!("Hello World!");
 
     unsafe {
@@ -26,21 +27,13 @@ fn main() -> ! {
         });
     }
 
-    let p = embassy_stm32::init(Default::default());
-
     let button = Input::new(p.PC13, Pull::Up);
-    let mut led1 = Output::new(p.PA5, Level::High, Speed::Low);
-    let mut led2 = Output::new(p.PB14, Level::High, Speed::Low);
 
     loop {
         if button.is_high().unwrap() {
             info!("high");
-            led1.set_high().unwrap();
-            led2.set_low().unwrap();
         } else {
             info!("low");
-            led1.set_low().unwrap();
-            led2.set_high().unwrap();
         }
     }
 }

--- a/examples/stm32l4/src/bin/button_exti.rs
+++ b/examples/stm32l4/src/bin/button_exti.rs
@@ -8,19 +8,25 @@
 
 #[path = "../example_common.rs"]
 mod example_common;
-use cortex_m_rt::entry;
-use embassy::executor::Executor;
-use embassy::time::Clock;
-use embassy::util::Forever;
+use defmt::panic;
+use embassy::executor::Spawner;
 use embassy_stm32::exti::ExtiInput;
 use embassy_stm32::gpio::{Input, Pull};
-use embassy_stm32::pac;
+use embassy_stm32::{pac, Peripherals};
 use embassy_traits::gpio::{WaitForFallingEdge, WaitForRisingEdge};
 use example_common::*;
 
-#[embassy::task]
-async fn main_task() {
-    let p = embassy_stm32::init(Default::default());
+#[embassy::main]
+async fn main(_spawner: Spawner, p: Peripherals) {
+    info!("Hello World!");
+
+    unsafe {
+        pac::DBGMCU.cr().modify(|w| {
+            w.set_dbg_sleep(true);
+            w.set_dbg_standby(true);
+            w.set_dbg_stop(true);
+        });
+    }
 
     let button = Input::new(p.PC13, Pull::Up);
     let mut button = ExtiInput::new(button, p.EXTI13);
@@ -33,35 +39,4 @@ async fn main_task() {
         button.wait_for_rising_edge().await;
         info!("Released!");
     }
-}
-
-struct ZeroClock;
-
-impl Clock for ZeroClock {
-    fn now(&self) -> u64 {
-        0
-    }
-}
-
-static EXECUTOR: Forever<Executor> = Forever::new();
-
-#[entry]
-fn main() -> ! {
-    info!("Hello World!");
-
-    unsafe {
-        pac::DBGMCU.cr().modify(|w| {
-            w.set_dbg_sleep(true);
-            w.set_dbg_standby(true);
-            w.set_dbg_stop(true);
-        });
-    }
-
-    unsafe { embassy::time::set_clock(&ZeroClock) };
-
-    let executor = EXECUTOR.put(Executor::new());
-
-    executor.run(|spawner| {
-        unwrap!(spawner.spawn(main_task()));
-    })
 }

--- a/examples/stm32l4/src/bin/dac.rs
+++ b/examples/stm32l4/src/bin/dac.rs
@@ -9,32 +9,16 @@
 #[path = "../example_common.rs"]
 mod example_common;
 
+use defmt::panic;
+use embassy::executor::Spawner;
+use embassy_stm32::dac::{Channel, Dac, Value};
 use embassy_stm32::gpio::NoPin;
+use embassy_stm32::{pac, Peripherals};
 use example_common::*;
 
-use cortex_m_rt::entry;
-use embassy_stm32::dac::{Channel, Dac, Value};
-use embassy_stm32::pac;
-use stm32l4xx_hal::prelude::*;
-use stm32l4xx_hal::rcc::PllSource;
-
-#[entry]
-fn main() -> ! {
-    info!("Hello World, dude!");
-    //let pp = pac::Peripherals::take().unwrap();
-    let pp = stm32l4xx_hal::stm32::Peripherals::take().unwrap();
-    let mut flash = pp.FLASH.constrain();
-    let mut rcc = pp.RCC.constrain();
-    let mut pwr = pp.PWR.constrain(&mut rcc.apb1r1);
-
-    // TRY the other clock configuration
-    // let clocks = rcc.cfgr.freeze(&mut flash.acr);
-    rcc.cfgr
-        .sysclk(80.mhz())
-        .pclk1(80.mhz())
-        .pclk2(80.mhz())
-        .pll_source(PllSource::HSI16)
-        .freeze(&mut flash.acr, &mut pwr);
+#[embassy::main]
+async fn main(_spawner: Spawner, p: Peripherals) {
+    info!("Hello World!");
 
     unsafe {
         pac::DBGMCU.cr().modify(|w| {
@@ -46,8 +30,6 @@ fn main() -> ! {
             w.set_dac1en(true);
         });
     }
-
-    let p = embassy_stm32::init(Default::default());
 
     let mut dac = Dac::new(p.DAC1, p.PA4, NoPin);
 

--- a/examples/stm32l4/src/bin/spi.rs
+++ b/examples/stm32l4/src/bin/spi.rs
@@ -9,19 +9,20 @@
 #[path = "../example_common.rs"]
 mod example_common;
 
-use cortex_m_rt::entry;
+use defmt::panic;
+use embassy::executor::Spawner;
 use embassy_stm32::dma::NoDma;
 use embassy_stm32::gpio::{Level, Output, Speed};
-use embassy_stm32::pac;
 use embassy_stm32::spi::{Config, Spi};
 use embassy_stm32::time::Hertz;
+use embassy_stm32::{pac, Peripherals};
 use embedded_hal::blocking::spi::Transfer;
 use embedded_hal::digital::v2::OutputPin;
 use example_common::*;
 
-#[entry]
-fn main() -> ! {
-    info!("Hello World, dude!");
+#[embassy::main]
+async fn main(_spawner: Spawner, p: Peripherals) {
+    info!("Hello World!");
 
     unsafe {
         pac::DBGMCU.cr().modify(|w| {
@@ -30,8 +31,6 @@ fn main() -> ! {
             w.set_dbg_stop(true);
         });
     }
-
-    let p = embassy_stm32::init(Default::default());
 
     let mut spi = Spi::new(
         p.SPI3,

--- a/examples/stm32l4/src/bin/usart_dma.rs
+++ b/examples/stm32l4/src/bin/usart_dma.rs
@@ -9,46 +9,17 @@
 #[path = "../example_common.rs"]
 mod example_common;
 use core::fmt::Write;
-use cortex_m_rt::entry;
-use embassy::executor::Executor;
-use embassy::time::Clock;
-use embassy::util::Forever;
+use defmt::panic;
+use embassy::executor::Spawner;
 use embassy_stm32::dma::NoDma;
-use embassy_stm32::pac;
 use embassy_stm32::usart::{Config, Uart};
+use embassy_stm32::{pac, Peripherals};
 use embassy_traits::uart::Write as _;
 use example_common::*;
 use heapless::String;
 
-#[embassy::task]
-async fn main_task() {
-    let p = embassy_stm32::init(Default::default());
-
-    let config = Config::default();
-    let mut usart = Uart::new(p.UART4, p.PA1, p.PA0, p.DMA1_CH3, NoDma, config);
-
-    for n in 0u32.. {
-        let mut s: String<128> = String::new();
-        core::write!(&mut s, "Hello DMA World {}!\r\n", n).unwrap();
-
-        usart.write(s.as_bytes()).await.ok();
-
-        info!("wrote DMA");
-    }
-}
-
-struct ZeroClock;
-
-impl Clock for ZeroClock {
-    fn now(&self) -> u64 {
-        0
-    }
-}
-
-static EXECUTOR: Forever<Executor> = Forever::new();
-
-#[entry]
-fn main() -> ! {
+#[embassy::main]
+async fn main(_spawner: Spawner, p: Peripherals) {
     info!("Hello World!");
 
     unsafe {
@@ -57,19 +28,18 @@ fn main() -> ! {
             w.set_dbg_standby(true);
             w.set_dbg_stop(true);
         });
-        
-        pac::RCC.ahb1enr().modify(|w| {
-            w.set_dmamux1en(true);
-            w.set_dma1en(true);
-            w.set_dma2en(true);
-        });
     }
 
-    unsafe { embassy::time::set_clock(&ZeroClock) };
+    let config = Config::default();
+    let mut usart = Uart::new(p.UART4, p.PA1, p.PA0, p.DMA1_CH3, NoDma, config);
 
-    let executor = EXECUTOR.put(Executor::new());
+    for n in 0u32.. {
+        let mut s: String<128> = String::new();
+        core::write!(&mut s, "Hello DMA World {}!\r\n", n).unwrap();
 
-    executor.run(|spawner| {
-        unwrap!(spawner.spawn(main_task()));
-    })
+        info!("Writing...");
+        usart.write(s.as_bytes()).await.ok();
+
+        info!("wrote DMA");
+    }
 }


### PR DESCRIPTION
- Use only embassy, no legacy pac/hal.
- use embassy::main macro