### PR TITLE
PeripheralMutex: Remove Pin

### DIFF
--- a/embassy-hal-common/src/peripheral.rs
+++ b/embassy-hal-common/src/peripheral.rs
@@ -17,7 +17,7 @@ pub trait PeripheralState: Send {
 pub struct StateStorage<S>(MaybeUninit<S>);
 
 impl<S> StateStorage<S> {
-    pub fn new() -> Self {
+    pub const fn new() -> Self {
         Self(MaybeUninit::uninit())
     }
 }

--- a/embassy-hal-common/src/usb/mod.rs
+++ b/embassy-hal-common/src/usb/mod.rs
@@ -67,12 +67,11 @@ where
         class_set: S,
         irq: I,
     ) -> Self {
-        let initial_state = StateInner {
+        let mutex = PeripheralMutex::new_unchecked(irq, &mut state.0, || StateInner {
             device,
             classes: class_set.into_class_set(),
             _interrupt: PhantomData,
-        };
-        let mutex = PeripheralMutex::new_unchecked(&mut state.0, initial_state, irq);
+        });
         Self {
             inner: RefCell::new(mutex),
         }

--- a/embassy-hal-common/src/usb/mod.rs
+++ b/embassy-hal-common/src/usb/mod.rs
@@ -9,14 +9,31 @@ use usb_device::device::UsbDevice;
 mod cdc_acm;
 pub mod usb_serial;
 
-use crate::peripheral::{PeripheralMutex, PeripheralState};
+use crate::peripheral::{PeripheralMutex, PeripheralState, StateStorage};
 use embassy::interrupt::Interrupt;
 use usb_serial::{ReadInterface, UsbSerial, WriteInterface};
 
 /// Marker trait to mark an interrupt to be used with the [`Usb`] abstraction.
 pub unsafe trait USBInterrupt: Interrupt + Send {}
 
-pub(crate) struct State<'bus, B, T, I>
+pub struct State<'bus, B, T, I>(StateStorage<StateInner<'bus, B, T, I>>)
+where
+    B: UsbBus,
+    T: ClassSet<B>,
+    I: USBInterrupt;
+
+impl<'bus, B, T, I> State<'bus, B, T, I>
+where
+    B: UsbBus,
+    T: ClassSet<B>,
+    I: USBInterrupt,
+{
+    pub fn new() -> Self {
+        Self(StateStorage::new())
+    }
+}
+
+pub(crate) struct StateInner<'bus, B, T, I>
 where
     B: UsbBus,
     T: ClassSet<B>,
@@ -34,7 +51,7 @@ where
     I: USBInterrupt,
 {
     // Don't you dare moving out `PeripheralMutex`
-    inner: RefCell<PeripheralMutex<State<'bus, B, T, I>>>,
+    inner: RefCell<PeripheralMutex<'bus, StateInner<'bus, B, T, I>>>,
 }
 
 impl<'bus, B, T, I> Usb<'bus, B, T, I>
@@ -43,29 +60,21 @@ where
     T: ClassSet<B>,
     I: USBInterrupt,
 {
-    pub fn new<S: IntoClassSet<B, T>>(device: UsbDevice<'bus, B>, class_set: S, irq: I) -> Self {
-        let state = State {
+    pub fn new<S: IntoClassSet<B, T>>(
+        state: &'bus mut State<'bus, B, T, I>,
+        device: UsbDevice<'bus, B>,
+        class_set: S,
+        irq: I,
+    ) -> Self {
+        let initial_state = StateInner {
             device,
             classes: class_set.into_class_set(),
             _interrupt: PhantomData,
         };
-        let mutex = PeripheralMutex::new(state, irq);
+        let mutex = unsafe { PeripheralMutex::new_unchecked(&mut state.0, initial_state, irq) };
         Self {
             inner: RefCell::new(mutex),
         }
-    }
-
-    /// # Safety
-    /// The `UsbDevice` passed to `Self::new` must not be dropped without calling `Drop` on this `Usb` first.
-    pub unsafe fn start(self: Pin<&mut Self>) {
-        let this = self.get_unchecked_mut();
-        let mut mutex = this.inner.borrow_mut();
-        let mutex = Pin::new_unchecked(&mut *mutex);
-
-        // Use inner to register the irq
-        // SAFETY: the safety contract of this function makes sure the `UsbDevice` won't be invalidated
-        // without the `PeripheralMutex` being dropped.
-        mutex.register_interrupt_unchecked();
     }
 }
 
@@ -129,7 +138,7 @@ where
     }
 }
 
-impl<'bus, B, T, I> PeripheralState for State<'bus, B, T, I>
+impl<'bus, B, T, I> PeripheralState for StateInner<'bus, B, T, I>
 where
     B: UsbBus,
     T: ClassSet<B>,

--- a/embassy-hal-common/src/usb/mod.rs
+++ b/embassy-hal-common/src/usb/mod.rs
@@ -60,7 +60,8 @@ where
     T: ClassSet<B>,
     I: USBInterrupt,
 {
-    pub fn new<S: IntoClassSet<B, T>>(
+    /// safety: the returned instance is not leak-safe
+    pub unsafe fn new<S: IntoClassSet<B, T>>(
         state: &'bus mut State<'bus, B, T, I>,
         device: UsbDevice<'bus, B>,
         class_set: S,
@@ -71,7 +72,7 @@ where
             classes: class_set.into_class_set(),
             _interrupt: PhantomData,
         };
-        let mutex = unsafe { PeripheralMutex::new_unchecked(&mut state.0, initial_state, irq) };
+        let mutex = PeripheralMutex::new_unchecked(&mut state.0, initial_state, irq);
         Self {
             inner: RefCell::new(mutex),
         }

--- a/embassy-nrf/src/buffered_uarte.rs
+++ b/embassy-nrf/src/buffered_uarte.rs
@@ -155,23 +155,21 @@ impl<'d, U: UarteInstance, T: TimerInstance> BufferedUarte<'d, U, T> {
         ppi_ch2.set_task(Task::from_reg(&r.tasks_stoprx));
         ppi_ch2.enable();
 
-        let initial_state = StateInner {
-            phantom: PhantomData,
-            timer,
-            _ppi_ch1: ppi_ch1,
-            _ppi_ch2: ppi_ch2,
-
-            rx: RingBuffer::new(rx_buffer),
-            rx_state: RxState::Idle,
-            rx_waker: WakerRegistration::new(),
-
-            tx: RingBuffer::new(tx_buffer),
-            tx_state: TxState::Idle,
-            tx_waker: WakerRegistration::new(),
-        };
-
         Self {
-            inner: PeripheralMutex::new_unchecked(&mut state.0, initial_state, irq),
+            inner: PeripheralMutex::new_unchecked(irq, &mut state.0, move || StateInner {
+                phantom: PhantomData,
+                timer,
+                _ppi_ch1: ppi_ch1,
+                _ppi_ch2: ppi_ch2,
+
+                rx: RingBuffer::new(rx_buffer),
+                rx_state: RxState::Idle,
+                rx_waker: WakerRegistration::new(),
+
+                tx: RingBuffer::new(tx_buffer),
+                tx_state: TxState::Idle,
+                tx_waker: WakerRegistration::new(),
+            }),
         }
     }
 

--- a/embassy-nrf/src/buffered_uarte.rs
+++ b/embassy-nrf/src/buffered_uarte.rs
@@ -7,7 +7,7 @@ use core::task::{Context, Poll};
 use embassy::interrupt::InterruptExt;
 use embassy::io::{AsyncBufRead, AsyncWrite, Result};
 use embassy::util::{Unborrow, WakerRegistration};
-use embassy_hal_common::peripheral::{PeripheralMutex, PeripheralState};
+use embassy_hal_common::peripheral::{PeripheralMutex, PeripheralState, StateStorage};
 use embassy_hal_common::ring_buffer::RingBuffer;
 use embassy_hal_common::{low_power_wait_until, unborrow};
 
@@ -35,7 +35,14 @@ enum TxState {
     Transmitting(usize),
 }
 
-struct State<'d, U: UarteInstance, T: TimerInstance> {
+pub struct State<'d, U: UarteInstance, T: TimerInstance>(StateStorage<StateInner<'d, U, T>>);
+impl<'d, U: UarteInstance, T: TimerInstance> State<'d, U, T> {
+    pub fn new() -> Self {
+        Self(StateStorage::new())
+    }
+}
+
+struct StateInner<'d, U: UarteInstance, T: TimerInstance> {
     phantom: PhantomData<&'d mut U>,
     timer: Timer<'d, T>,
     _ppi_ch1: Ppi<'d, AnyConfigurableChannel>,
@@ -51,20 +58,16 @@ struct State<'d, U: UarteInstance, T: TimerInstance> {
 }
 
 /// Interface to a UARTE instance
-///
-/// This is a very basic interface that comes with the following limitations:
-/// - The UARTE instances share the same address space with instances of UART.
-///   You need to make sure that conflicting instances
-///   are disabled before using `Uarte`. See product specification:
-///     - nrf52832: Section 15.2
-///     - nrf52840: Section 6.1.2
 pub struct BufferedUarte<'d, U: UarteInstance, T: TimerInstance> {
-    inner: PeripheralMutex<State<'d, U, T>>,
+    inner: PeripheralMutex<'d, StateInner<'d, U, T>>,
 }
+
+impl<'d, U: UarteInstance, T: TimerInstance> Unpin for BufferedUarte<'d, U, T> {}
 
 impl<'d, U: UarteInstance, T: TimerInstance> BufferedUarte<'d, U, T> {
     /// unsafe: may not leak self or futures
     pub unsafe fn new(
+        state: &'d mut State<'d, U, T>,
         _uarte: impl Unborrow<Target = U> + 'd,
         timer: impl Unborrow<Target = T> + 'd,
         ppi_ch1: impl Unborrow<Target = impl ConfigurableChannel> + 'd,
@@ -152,31 +155,28 @@ impl<'d, U: UarteInstance, T: TimerInstance> BufferedUarte<'d, U, T> {
         ppi_ch2.set_task(Task::from_reg(&r.tasks_stoprx));
         ppi_ch2.enable();
 
-        BufferedUarte {
-            inner: PeripheralMutex::new(
-                State {
-                    phantom: PhantomData,
-                    timer,
-                    _ppi_ch1: ppi_ch1,
-                    _ppi_ch2: ppi_ch2,
+        let initial_state = StateInner {
+            phantom: PhantomData,
+            timer,
+            _ppi_ch1: ppi_ch1,
+            _ppi_ch2: ppi_ch2,
 
-                    rx: RingBuffer::new(rx_buffer),
-                    rx_state: RxState::Idle,
-                    rx_waker: WakerRegistration::new(),
+            rx: RingBuffer::new(rx_buffer),
+            rx_state: RxState::Idle,
+            rx_waker: WakerRegistration::new(),
 
-                    tx: RingBuffer::new(tx_buffer),
-                    tx_state: TxState::Idle,
-                    tx_waker: WakerRegistration::new(),
-                },
-                irq,
-            ),
+            tx: RingBuffer::new(tx_buffer),
+            tx_state: TxState::Idle,
+            tx_waker: WakerRegistration::new(),
+        };
+
+        Self {
+            inner: PeripheralMutex::new_unchecked(&mut state.0, initial_state, irq),
         }
     }
 
-    pub fn set_baudrate(self: Pin<&mut Self>, baudrate: Baudrate) {
-        let mut inner = self.inner();
-        unsafe { inner.as_mut().register_interrupt_unchecked() }
-        inner.with(|state| {
+    pub fn set_baudrate(&mut self, baudrate: Baudrate) {
+        self.inner.with(|state| {
             let r = U::regs();
 
             let timeout = 0x8000_0000 / (baudrate as u32 / 40);
@@ -186,17 +186,11 @@ impl<'d, U: UarteInstance, T: TimerInstance> BufferedUarte<'d, U, T> {
             r.baudrate.write(|w| w.baudrate().variant(baudrate));
         });
     }
-
-    fn inner(self: Pin<&mut Self>) -> Pin<&mut PeripheralMutex<State<'d, U, T>>> {
-        unsafe { Pin::new_unchecked(&mut self.get_unchecked_mut().inner) }
-    }
 }
 
 impl<'d, U: UarteInstance, T: TimerInstance> AsyncBufRead for BufferedUarte<'d, U, T> {
-    fn poll_fill_buf(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Result<&[u8]>> {
-        let mut inner = self.inner();
-        unsafe { inner.as_mut().register_interrupt_unchecked() }
-        inner.with(|state| {
+    fn poll_fill_buf(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Result<&[u8]>> {
+        self.inner.with(|state| {
             // Conservative compiler fence to prevent optimizations that do not
             // take in to account actions by DMA. The fence has been placed here,
             // before any DMA action has started
@@ -218,22 +212,22 @@ impl<'d, U: UarteInstance, T: TimerInstance> AsyncBufRead for BufferedUarte<'d, 
         })
     }
 
-    fn consume(self: Pin<&mut Self>, amt: usize) {
-        let mut inner = self.inner();
-        unsafe { inner.as_mut().register_interrupt_unchecked() }
-        inner.as_mut().with(|state| {
+    fn consume(mut self: Pin<&mut Self>, amt: usize) {
+        self.inner.with(|state| {
             trace!("consume {:?}", amt);
             state.rx.pop(amt);
         });
-        inner.pend();
+        self.inner.pend();
     }
 }
 
 impl<'d, U: UarteInstance, T: TimerInstance> AsyncWrite for BufferedUarte<'d, U, T> {
-    fn poll_write(self: Pin<&mut Self>, cx: &mut Context<'_>, buf: &[u8]) -> Poll<Result<usize>> {
-        let mut inner = self.inner();
-        unsafe { inner.as_mut().register_interrupt_unchecked() }
-        let poll = inner.as_mut().with(|state| {
+    fn poll_write(
+        mut self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+        buf: &[u8],
+    ) -> Poll<Result<usize>> {
+        let poll = self.inner.with(|state| {
             trace!("poll_write: {:?}", buf.len());
 
             let tx_buf = state.tx.push_buf();
@@ -257,13 +251,13 @@ impl<'d, U: UarteInstance, T: TimerInstance> AsyncWrite for BufferedUarte<'d, U,
             Poll::Ready(Ok(n))
         });
 
-        inner.pend();
+        self.inner.pend();
 
         poll
     }
 }
 
-impl<'a, U: UarteInstance, T: TimerInstance> Drop for State<'a, U, T> {
+impl<'a, U: UarteInstance, T: TimerInstance> Drop for StateInner<'a, U, T> {
     fn drop(&mut self) {
         let r = U::regs();
 
@@ -285,7 +279,7 @@ impl<'a, U: UarteInstance, T: TimerInstance> Drop for State<'a, U, T> {
     }
 }
 
-impl<'a, U: UarteInstance, T: TimerInstance> PeripheralState for State<'a, U, T> {
+impl<'a, U: UarteInstance, T: TimerInstance> PeripheralState for StateInner<'a, U, T> {
     type Interrupt = U::Interrupt;
     fn on_interrupt(&mut self) {
         trace!("irq: start");

--- a/embassy-stm32/src/eth/v2/mod.rs
+++ b/embassy-stm32/src/eth/v2/mod.rs
@@ -20,7 +20,7 @@ use descriptors::DescriptorRing;
 
 pub struct State<'d, const TX: usize, const RX: usize>(StateStorage<Inner<'d, TX, RX>>);
 impl<'d, const TX: usize, const RX: usize> State<'d, TX, RX> {
-    pub fn new() -> Self {
+    pub const fn new() -> Self {
         Self(StateStorage::new())
     }
 }

--- a/embassy-stm32/src/eth/v2/mod.rs
+++ b/embassy-stm32/src/eth/v2/mod.rs
@@ -78,10 +78,8 @@ impl<'d, P: PHY, const TX: usize, const RX: usize> Ethernet<'d, P, TX, RX> {
         tx_d1.configure();
         tx_en.configure();
 
-        let inner = Inner::new(peri);
-
         // NOTE(unsafe) We are ourselves not leak-safe.
-        let state = PeripheralMutex::new_unchecked(&mut state.0, inner, interrupt);
+        let state = PeripheralMutex::new_unchecked(interrupt, &mut state.0, || Inner::new(peri));
 
         // NOTE(unsafe) We have exclusive access to the registers
         let dma = ETH.ethernet_dma();

--- a/examples/nrf/src/bin/buffered_uart.rs
+++ b/examples/nrf/src/bin/buffered_uart.rs
@@ -11,6 +11,7 @@ mod example_common;
 use defmt::panic;
 use embassy::executor::Spawner;
 use embassy::io::{AsyncBufReadExt, AsyncWriteExt};
+use embassy_nrf::buffered_uarte::State;
 use embassy_nrf::gpio::NoPin;
 use embassy_nrf::{buffered_uarte::BufferedUarte, interrupt, uarte, Peripherals};
 use example_common::*;
@@ -26,8 +27,10 @@ async fn main(_spawner: Spawner, p: Peripherals) {
     let mut rx_buffer = [0u8; 4096];
 
     let irq = interrupt::take!(UARTE0_UART0);
+    let mut state = State::new();
     let u = unsafe {
         BufferedUarte::new(
+            &mut state,
             p.UARTE0,
             p.TIMER0,
             p.PPI_CH0,

--- a/examples/stm32h7/src/bin/eth.rs
+++ b/examples/stm32h7/src/bin/eth.rs
@@ -135,10 +135,12 @@ fn main() -> ! {
     let eth_int = interrupt_take!(ETH);
     let mac_addr = [0x10; 6];
     let state = STATE.put(State::new());
-    let eth = ETH.put(Ethernet::new(
-        state, p.ETH, eth_int, p.PA1, p.PA2, p.PC1, p.PA7, p.PC4, p.PC5, p.PB12, p.PB13, p.PB11,
-        LAN8742A, mac_addr, 1,
-    ));
+    let eth = unsafe {
+        ETH.put(Ethernet::new(
+            state, p.ETH, eth_int, p.PA1, p.PA2, p.PC1, p.PA7, p.PC4, p.PC5, p.PB12, p.PB13,
+            p.PB11, LAN8742A, mac_addr, 1,
+        ))
+    };
 
     let config = StaticConfigurator::new(NetConfig {
         address: Ipv4Cidr::new(Ipv4Address::new(192, 168, 0, 61), 24),


### PR DESCRIPTION
Fixes #323 

- Refactor PeripheralMutex so it borrows a state instead of storing it inside itself. This guarantees the state won't move, so Pin is no longer needed.
- Update all uses
  - nrf BufferedUarte
  - stm32h7 eth
  - hal-common usb