### PR TITLE
metapac: Improve enable bit search

### DIFF
--- a/stm32-metapac-gen/src/lib.rs
+++ b/stm32-metapac-gen/src/lib.rs
@@ -447,11 +447,13 @@ pub fn gen(options: Options) {
                                 Some(clock) => clock.as_str(),
                                 None => {
                                     // No clock was specified, derive the clock name from the enable register name.
-                                    let re = Regex::new("([A-Z]+\\d*).*").unwrap();
-                                    let caps = re.captures(enable_reg).expect(
-                                        "unable to derive clock name from register name {}",
-                                    );
-                                    caps.get(1).unwrap().as_str()
+                                    Regex::new("([A-Z]+\\d*).*")
+                                        .unwrap()
+                                        .captures(enable_reg)
+                                        .unwrap()
+                                        .get(1)
+                                        .unwrap()
+                                        .as_str()
                                 }
                             };
 

--- a/stm32-metapac-gen/src/lib.rs
+++ b/stm32-metapac-gen/src/lib.rs
@@ -1,7 +1,7 @@
 use chiptool::generate::CommonModule;
 use regex::Regex;
 use serde::Deserialize;
-use std::collections::{HashMap, HashSet};
+use std::collections::{BTreeMap, HashMap, HashSet};
 use std::env;
 use std::fmt::Write as _;
 use std::fs;
@@ -39,9 +39,9 @@ pub struct MemoryRegion {
 #[derive(Debug, Eq, PartialEq, Clone, Deserialize)]
 pub struct Core {
     pub name: String,
-    pub peripherals: HashMap<String, Peripheral>,
-    pub interrupts: HashMap<String, u32>,
-    pub dma_channels: HashMap<String, DmaChannel>,
+    pub peripherals: BTreeMap<String, Peripheral>,
+    pub interrupts: BTreeMap<String, u32>,
+    pub dma_channels: BTreeMap<String, DmaChannel>,
 }
 
 #[derive(Debug, Eq, PartialEq, Clone, Deserialize)]
@@ -62,9 +62,9 @@ pub struct Peripheral {
     #[serde(default)]
     pub pins: Vec<Pin>,
     #[serde(default)]
-    pub dma_channels: HashMap<String, Vec<PeripheralDmaChannel>>,
+    pub dma_channels: BTreeMap<String, Vec<PeripheralDmaChannel>>,
     #[serde(default)]
-    pub interrupts: HashMap<String, String>,
+    pub interrupts: BTreeMap<String, String>,
 }
 
 #[derive(Debug, Eq, PartialEq, Clone, Deserialize)]
@@ -144,7 +144,7 @@ fn find_reg_for_field<'c>(
     })
 }
 
-fn make_peripheral_counts(out: &mut String, data: &HashMap<String, u8>) {
+fn make_peripheral_counts(out: &mut String, data: &BTreeMap<String, u8>) {
     write!(
         out,
         "#[macro_export]
@@ -158,7 +158,7 @@ macro_rules! peripheral_count {{
     write!(out, " }}\n").unwrap();
 }
 
-fn make_dma_channel_counts(out: &mut String, data: &HashMap<String, u8>) {
+fn make_dma_channel_counts(out: &mut String, data: &BTreeMap<String, u8>) {
     write!(
         out,
         "#[macro_export]
@@ -219,7 +219,7 @@ pub fn gen(options: Options) {
     println!("cwd: {:?}", env::current_dir());
 
     let mut all_peripheral_versions: HashSet<(String, String)> = HashSet::new();
-    let mut chip_cores: HashMap<String, Option<String>> = HashMap::new();
+    let mut chip_cores: BTreeMap<String, Option<String>> = BTreeMap::new();
 
     for chip_name in &options.chips {
         let mut s = chip_name.split('_');
@@ -291,7 +291,7 @@ pub fn gen(options: Options) {
             }
         });
 
-        let mut peripheral_versions: HashMap<String, String> = HashMap::new();
+        let mut peripheral_versions: BTreeMap<String, String> = BTreeMap::new();
         let mut pin_table: Vec<Vec<String>> = Vec::new();
         let mut interrupt_table: Vec<Vec<String>> = Vec::new();
         let mut peripherals_table: Vec<Vec<String>> = Vec::new();
@@ -299,8 +299,8 @@ pub fn gen(options: Options) {
         let mut peripheral_rcc_table: Vec<Vec<String>> = Vec::new();
         let mut dma_channels_table: Vec<Vec<String>> = Vec::new();
         let mut peripheral_dma_channels_table: Vec<Vec<String>> = Vec::new();
-        let mut peripheral_counts: HashMap<String, u8> = HashMap::new();
-        let mut dma_channel_counts: HashMap<String, u8> = HashMap::new();
+        let mut peripheral_counts: BTreeMap<String, u8> = BTreeMap::new();
+        let mut dma_channel_counts: BTreeMap<String, u8> = BTreeMap::new();
         let mut dbgmcu_table: Vec<Vec<String>> = Vec::new();
         let mut gpio_rcc_table: Vec<Vec<String>> = Vec::new();
         let mut gpio_regs: HashSet<String> = HashSet::new();
@@ -504,10 +504,10 @@ pub fn gen(options: Options) {
                                 }
                             }
                             (None, Some(_)) => {
-                                print!("Unable to find enable register for {}", name)
+                                println!("Unable to find enable register for {}", name)
                             }
                             (None, None) => {
-                                print!("Unable to find enable and reset register for {}", name)
+                                println!("Unable to find enable and reset register for {}", name)
                             }
                         }
                     }

--- a/stm32-metapac-gen/src/lib.rs
+++ b/stm32-metapac-gen/src/lib.rs
@@ -446,8 +446,8 @@ pub fn gen(options: Options) {
                             let clock = match &p.clock {
                                 Some(clock) => clock.as_str(),
                                 None => {
-                                // No clock was specified, derive the clock name from the enable register name.
-                                let re = Regex::new("([A-Z]+\\d*).*").unwrap();
+                                    // No clock was specified, derive the clock name from the enable register name.
+                                    let re = Regex::new("([A-Z]+\\d*).*").unwrap();
                                     let caps = re.captures(enable_reg).expect(
                                         "unable to derive clock name from register name {}",
                                     );
@@ -666,7 +666,6 @@ pub fn gen(options: Options) {
         let re = Regex::new("# *! *\\[.*\\]").unwrap();
         let data = re.replace_all(&data, "");
         file.write_all(data.as_bytes()).unwrap();
-
     }
 
     // Generate src/lib_inner.rs
@@ -727,7 +726,6 @@ pub fn gen(options: Options) {
 
     // Generate build.rs
     fs::write(out_dir.join("build.rs"), include_bytes!("assets/build.rs")).unwrap();
-
 }
 
 fn bytes_find(haystack: &[u8], needle: &[u8]) -> Option<usize> {
@@ -739,19 +737,40 @@ fn bytes_find(haystack: &[u8], needle: &[u8]) -> Option<usize> {
 fn gen_memory_x(out_dir: &PathBuf, chip: &Chip) {
     let mut memory_x = String::new();
 
-    let flash_bytes = chip.flash.regions.get("BANK_1").unwrap().bytes.unwrap_or(chip.flash.bytes);
+    let flash_bytes = chip
+        .flash
+        .regions
+        .get("BANK_1")
+        .unwrap()
+        .bytes
+        .unwrap_or(chip.flash.bytes);
     let flash_origin = chip.flash.regions.get("BANK_1").unwrap().base;
 
-    let ram_bytes = chip.ram.regions.get("SRAM").unwrap().bytes.unwrap_or(chip.ram.bytes);
+    let ram_bytes = chip
+        .ram
+        .regions
+        .get("SRAM")
+        .unwrap()
+        .bytes
+        .unwrap_or(chip.ram.bytes);
     let ram_origin = chip.ram.regions.get("SRAM").unwrap().base;
 
     write!(memory_x, "MEMORY\n{{\n").unwrap();
-    write!(memory_x, "    FLASH : ORIGIN = 0x{:x}, LENGTH = {}\n", flash_origin, flash_bytes).unwrap();
-    write!(memory_x, "    RAM : ORIGIN = 0x{:x}, LENGTH = {}\n", ram_origin, ram_bytes).unwrap();
+    write!(
+        memory_x,
+        "    FLASH : ORIGIN = 0x{:x}, LENGTH = {}\n",
+        flash_origin, flash_bytes
+    )
+    .unwrap();
+    write!(
+        memory_x,
+        "    RAM : ORIGIN = 0x{:x}, LENGTH = {}\n",
+        ram_origin, ram_bytes
+    )
+    .unwrap();
     write!(memory_x, "}}").unwrap();
 
     fs::create_dir_all(out_dir.join("memory_x")).unwrap();
     let mut file = File::create(out_dir.join("memory_x").join("memory.x")).unwrap();
     file.write_all(memory_x.as_bytes()).unwrap();
-
 }


### PR DESCRIPTION
The number has different meanings depending on family:
stm32f0: RCC_APB2ENR - APB peripheral clock enable register 2    CLOCK: APB1
stm32f4: RCC_APB2ENR - RCC APB2 peripheral clock enable register CLOCK: APB2

Ignore the clock number and search all registers for a matching enable bit.