### PR TITLE
examples: Drop build-std = ["core"]

### DIFF
--- a/examples/nrf/.cargo/config.toml
+++ b/examples/nrf/.cargo/config.toml
@@ -1,6 +1,3 @@
-[unstable]
-build-std = ["core"]
-
 [target.'cfg(all(target_arch = "arm", target_os = "none"))']
 # replace nRF82840_xxAA with your chip as listed in `probe-run --list-chips`
 runner = "probe-run --chip nRF52840_xxAA"

--- a/examples/rp/.cargo/config.toml
+++ b/examples/rp/.cargo/config.toml
@@ -1,6 +1,3 @@
-[unstable]
-build-std = ["core"]
-
 [target.'cfg(all(target_arch = "arm", target_os = "none"))']
 runner = "probe-run-rp --chip RP2040"
 

--- a/examples/stm32f4/.cargo/config.toml
+++ b/examples/stm32f4/.cargo/config.toml
@@ -1,6 +1,3 @@
-[unstable]
-build-std = ["core"]
-
 [target.'cfg(all(target_arch = "arm", target_os = "none"))']
 # replace STM32F429ZITx with your chip as listed in `probe-run --list-chips`
 runner = "probe-run --chip STM32F429ZITx"

--- a/examples/stm32l0/.cargo/config.toml
+++ b/examples/stm32l0/.cargo/config.toml
@@ -1,6 +1,3 @@
-[unstable]
-build-std = ["core"]
-
 [target.'cfg(all(target_arch = "arm", target_os = "none"))']
 # replace your chip as listed in `probe-run --list-chips`
 runner = "probe-run --chip STM32L072CZ"

--- a/examples/stm32l4/.cargo/config.toml
+++ b/examples/stm32l4/.cargo/config.toml
@@ -1,6 +1,3 @@
-[unstable]
-build-std = ["core"]
-
 [target.'cfg(all(target_arch = "arm", target_os = "none"))']
 # replace STM32F429ZITx with your chip as listed in `probe-run --list-chips`
 runner = "probe-run --chip STM32L4S5VI"

--- a/examples/stm32wb55/.cargo/config.toml
+++ b/examples/stm32wb55/.cargo/config.toml
@@ -1,6 +1,3 @@
-[unstable]
-build-std = ["core"]
-
 [target.'cfg(all(target_arch = "arm", target_os = "none"))']
 # replace STM32WB55CCUx with your chip as listed in `probe-run --list-chips`
 runner = "probe-run --chip STM32WB55CCUx --speed 1000 --connect-under-reset"


### PR DESCRIPTION
Previously the cargo configurations of all of the example projects had
`build-std = ["core"]`, which forces compilation of `core` as a
code-size optimisation. However, this is strictly unnecessary and will
currently break for users who do not use `rustup` directly (e.g. nix
users).