### PR TITLE
examples: Consistently use unwrap! in favor of .unwrap()

### DIFF
--- a/embassy-macros/src/lib.rs
+++ b/embassy-macros/src/lib.rs
@@ -364,7 +364,7 @@ pub fn main(args: TokenStream, item: TokenStream) -> TokenStream {
             #chip_setup
 
             executor.run(|spawner| {
-                spawner.spawn(__embassy_main(spawner, p)).unwrap();
+                spawner.must_spawn(__embassy_main(spawner, p));
             })
 
         }

--- a/embassy-stm32/src/rcc/h7/mod.rs
+++ b/embassy-stm32/src/rcc/h7/mod.rs
@@ -120,7 +120,7 @@ impl<'d> Rcc<'d> {
             unsafe { pll_setup(srcclk.0, &self.config.pll3, 2) };
 
         let sys_ck = if sys_use_pll1_p {
-            Hertz(pll1_p_ck.unwrap()) // Must have been set by sys_ck_setup
+            Hertz(unwrap!(pll1_p_ck)) // Must have been set by sys_ck_setup
         } else {
             sys_ck
         };
@@ -390,7 +390,7 @@ impl<'d> Rcc<'d> {
             // set. The traceclk mux is synchronous with the system
             // clock mux, but has pll1_r_ck as an input. In order to
             // keep traceclk running, we force a pll1_r_ck.
-            (true, None) => Some(Hertz(self.config.pll1.p_ck.unwrap().0 / 2)),
+            (true, None) => Some(Hertz(unwrap!(self.config.pll1.p_ck).0 / 2)),
 
             // Either pll1 not selected as system clock, free choice
             // of pll1_r_ck. Or pll1 is selected, assume user has set

--- a/embassy-stm32/src/time_driver.rs
+++ b/embassy-stm32/src/time_driver.rs
@@ -106,7 +106,10 @@ impl State {
             r.cnt().write(|w| w.set_cnt(0));
 
             let psc = timer_freq.0 / TICKS_PER_SECOND as u32 - 1;
-            let psc: u16 = psc.try_into().unwrap();
+            let psc: u16 = match psc.try_into() {
+                Err(_) => panic!("psc division overflow: {}", psc),
+                Ok(n) => n,
+            };
 
             r.psc().write(|w| w.set_psc(psc));
             r.arr().write(|w| w.set_arr(u16::MAX));

--- a/embassy/src/executor/mod.rs
+++ b/embassy/src/executor/mod.rs
@@ -56,6 +56,14 @@ impl Spawner {
         }
     }
 
+    /// Used by the `embassy_macros::main!` macro to throw an error when spawn
+    /// fails. This is here to allow conditional use of `defmt::unwrap!`
+    /// without introducing a `defmt` feature in the `embassy_macros` package,
+    /// which would require use of `-Z namespaced-features`.
+    pub fn must_spawn<F>(&self, token: SpawnToken<F>) -> () {
+        unwrap!(self.spawn(token));
+    }
+
     /// Convert this Spawner to a SendSpawner. This allows you to send the
     /// spawner to other threads, but the spawner loses the ability to spawn
     /// non-Send tasks.

--- a/examples/nrf/src/bin/blinky.rs
+++ b/examples/nrf/src/bin/blinky.rs
@@ -6,6 +6,7 @@
 #[path = "../example_common.rs"]
 mod example_common;
 
+use defmt::unwrap;
 use embassy::executor::Spawner;
 use embassy::time::{Duration, Timer};
 use embassy_nrf::gpio::{Level, Output, OutputDrive};
@@ -17,9 +18,9 @@ async fn main(_spawner: Spawner, p: Peripherals) {
     let mut led = Output::new(p.P0_13, Level::Low, OutputDrive::Standard);
 
     loop {
-        led.set_high().unwrap();
+        unwrap!(led.set_high());
         Timer::after(Duration::from_millis(300)).await;
-        led.set_low().unwrap();
+        unwrap!(led.set_low());
         Timer::after(Duration::from_millis(300)).await;
     }
 }

--- a/examples/nrf/src/bin/gpiote_port.rs
+++ b/examples/nrf/src/bin/gpiote_port.rs
@@ -32,8 +32,8 @@ async fn main(spawner: Spawner, p: Peripherals) {
     let btn3 = PortInput::new(Input::new(p.P0_24.degrade(), Pull::Up));
     let btn4 = PortInput::new(Input::new(p.P0_25.degrade(), Pull::Up));
 
-    spawner.spawn(button_task(1, btn1)).unwrap();
-    spawner.spawn(button_task(2, btn2)).unwrap();
-    spawner.spawn(button_task(3, btn3)).unwrap();
-    spawner.spawn(button_task(4, btn4)).unwrap();
+    unwrap!(spawner.spawn(button_task(1, btn1)));
+    unwrap!(spawner.spawn(button_task(2, btn2)));
+    unwrap!(spawner.spawn(button_task(3, btn3)));
+    unwrap!(spawner.spawn(button_task(4, btn4)));
 }

--- a/examples/nrf/src/bin/mpsc.rs
+++ b/examples/nrf/src/bin/mpsc.rs
@@ -6,6 +6,7 @@
 #[path = "../example_common.rs"]
 mod example_common;
 
+use defmt::unwrap;
 use embassy::executor::Spawner;
 use embassy::time::{Duration, Timer};
 use embassy::util::mpsc::TryRecvError;
@@ -39,7 +40,7 @@ async fn main(spawner: Spawner, p: Peripherals) {
     let channel = CHANNEL.put(Channel::new());
     let (sender, mut receiver) = mpsc::split(channel);
 
-    spawner.spawn(my_task(sender)).unwrap();
+    unwrap!(spawner.spawn(my_task(sender)));
 
     // We could just loop on `receiver.recv()` for simplicity. The code below
     // is optimized to drain the queue as fast as possible in the spirit of
@@ -53,8 +54,8 @@ async fn main(spawner: Spawner, p: Peripherals) {
             Err(TryRecvError::Closed) => break,
         };
         match maybe_message {
-            Some(LedState::On) => led.set_high().unwrap(),
-            Some(LedState::Off) => led.set_low().unwrap(),
+            Some(LedState::On) => unwrap!(led.set_high()),
+            Some(LedState::Off) => unwrap!(led.set_low()),
             _ => (),
         }
     }

--- a/examples/nrf/src/bin/qspi.rs
+++ b/examples/nrf/src/bin/qspi.rs
@@ -35,19 +35,19 @@ async fn main(_spawner: Spawner, p: Peripherals) {
     .await;
 
     let mut id = [1; 3];
-    q.custom_instruction(0x9F, &[], &mut id).await.unwrap();
+    unwrap!(q.custom_instruction(0x9F, &[], &mut id).await);
     info!("id: {}", id);
 
     // Read status register
     let mut status = [4; 1];
-    q.custom_instruction(0x05, &[], &mut status).await.unwrap();
+    unwrap!(q.custom_instruction(0x05, &[], &mut status).await);
 
     info!("status: {:?}", status[0]);
 
     if status[0] & 0x40 == 0 {
         status[0] |= 0x40;
 
-        q.custom_instruction(0x01, &status, &mut []).await.unwrap();
+        unwrap!(q.custom_instruction(0x01, &status, &mut []).await);
 
         info!("enabled quad in status");
     }
@@ -58,19 +58,19 @@ async fn main(_spawner: Spawner, p: Peripherals) {
 
     for i in 0..8 {
         info!("page {:?}: erasing... ", i);
-        q.erase(i * PAGE_SIZE).await.unwrap();
+        unwrap!(q.erase(i * PAGE_SIZE).await);
 
         for j in 0..PAGE_SIZE {
             buf.0[j] = pattern((j + i * PAGE_SIZE) as u32);
         }
 
         info!("programming...");
-        q.write(i * PAGE_SIZE, &buf.0).await.unwrap();
+        unwrap!(q.write(i * PAGE_SIZE, &buf.0).await);
     }
 
     for i in 0..8 {
         info!("page {:?}: reading... ", i);
-        q.read(i * PAGE_SIZE, &mut buf.0).await.unwrap();
+        unwrap!(q.read(i * PAGE_SIZE, &mut buf.0).await);
 
         info!("verifying...");
         for j in 0..PAGE_SIZE {

--- a/examples/nrf/src/bin/qspi_lowpower.rs
+++ b/examples/nrf/src/bin/qspi_lowpower.rs
@@ -49,19 +49,19 @@ async fn main(_spawner: Spawner, mut p: Peripherals) {
         .await;
 
         let mut id = [1; 3];
-        q.custom_instruction(0x9F, &[], &mut id).await.unwrap();
+        unwrap!(q.custom_instruction(0x9F, &[], &mut id).await);
         info!("id: {}", id);
 
         // Read status register
         let mut status = [4; 1];
-        q.custom_instruction(0x05, &[], &mut status).await.unwrap();
+        unwrap!(q.custom_instruction(0x05, &[], &mut status).await);
 
         info!("status: {:?}", status[0]);
 
         if status[0] & 0x40 == 0 {
             status[0] |= 0x40;
 
-            q.custom_instruction(0x01, &status, &mut []).await.unwrap();
+            unwrap!(q.custom_instruction(0x01, &status, &mut []).await);
 
             info!("enabled quad in status");
         }
@@ -69,7 +69,7 @@ async fn main(_spawner: Spawner, mut p: Peripherals) {
         let mut buf = AlignedBuf([0u8; 64]);
 
         info!("reading...");
-        q.read(0, &mut buf.0).await.unwrap();
+        unwrap!(q.read(0, &mut buf.0).await);
         info!("read: {=[u8]:x}", buf.0);
 
         // Drop the QSPI instance. This disables the peripehral and deconfigures the pins.

--- a/examples/nrf/src/bin/rng.rs
+++ b/examples/nrf/src/bin/rng.rs
@@ -6,7 +6,7 @@
 #[path = "../example_common.rs"]
 mod example_common;
 
-use defmt::panic;
+use defmt::{panic, unwrap};
 use embassy::executor::Spawner;
 use embassy::traits::rng::Rng as _;
 use embassy_nrf::interrupt;
@@ -20,14 +20,14 @@ async fn main(_spawner: Spawner, p: Peripherals) {
 
     // Async API
     let mut bytes = [0; 4];
-    rng.fill_bytes(&mut bytes).await.unwrap(); // nRF RNG is infallible
+    unwrap!(rng.fill_bytes(&mut bytes).await); // nRF RNG is infallible
     defmt::info!("Some random bytes: {:?}", bytes);
 
     // Sync API with `rand`
     defmt::info!("A random number from 1 to 10: {:?}", rng.gen_range(1..=10));
 
     let mut bytes = [0; 1024];
-    rng.fill_bytes(&mut bytes).await.unwrap();
+    unwrap!(rng.fill_bytes(&mut bytes).await);
     let zero_count: u32 = bytes.iter().fold(0, |acc, val| acc + val.count_zeros());
     let one_count: u32 = bytes.iter().fold(0, |acc, val| acc + val.count_ones());
     defmt::info!(

--- a/examples/nrf/src/bin/spim.rs
+++ b/examples/nrf/src/bin/spim.rs
@@ -31,12 +31,12 @@ async fn main(_spawner: Spawner, p: Peripherals) {
 
     // softreset
     cortex_m::asm::delay(10);
-    ncs.set_low().unwrap();
+    unwrap!(ncs.set_low());
     cortex_m::asm::delay(5);
     let tx = [0xFF];
     unwrap!(spim.read_write(&mut [], &tx).await);
     cortex_m::asm::delay(10);
-    ncs.set_high().unwrap();
+    unwrap!(ncs.set_high());
 
     cortex_m::asm::delay(100000);
 
@@ -44,31 +44,31 @@ async fn main(_spawner: Spawner, p: Peripherals) {
 
     // read ESTAT
     cortex_m::asm::delay(5000);
-    ncs.set_low().unwrap();
+    unwrap!(ncs.set_low());
     cortex_m::asm::delay(5000);
     let tx = [0b000_11101, 0];
     unwrap!(spim.read_write(&mut rx, &tx).await);
     cortex_m::asm::delay(5000);
-    ncs.set_high().unwrap();
+    unwrap!(ncs.set_high());
     info!("estat: {=[?]}", rx);
 
     // Switch to bank 3
     cortex_m::asm::delay(10);
-    ncs.set_low().unwrap();
+    unwrap!(ncs.set_low());
     cortex_m::asm::delay(5);
     let tx = [0b100_11111, 0b11];
     unwrap!(spim.read_write(&mut rx, &tx).await);
     cortex_m::asm::delay(10);
-    ncs.set_high().unwrap();
+    unwrap!(ncs.set_high());
 
     // read EREVID
     cortex_m::asm::delay(10);
-    ncs.set_low().unwrap();
+    unwrap!(ncs.set_low());
     cortex_m::asm::delay(5);
     let tx = [0b000_10010, 0];
     unwrap!(spim.read_write(&mut rx, &tx).await);
     cortex_m::asm::delay(10);
-    ncs.set_high().unwrap();
+    unwrap!(ncs.set_high());
 
     info!("erevid: {=[?]}", rx);
 }

--- a/examples/nrf/src/bin/twim.rs
+++ b/examples/nrf/src/bin/twim.rs
@@ -27,7 +27,7 @@ async fn main(_spawner: Spawner, p: Peripherals) {
     info!("Reading...");
 
     let mut buf = [0u8; 16];
-    twi.write_then_read(ADDRESS, &mut [0x00], &mut buf).unwrap();
+    unwrap!(twi.write_then_read(ADDRESS, &mut [0x00], &mut buf));
 
     info!("Read: {=[u8]:x}", buf);
 }

--- a/examples/nrf/src/bin/twim_lowpower.rs
+++ b/examples/nrf/src/bin/twim_lowpower.rs
@@ -37,7 +37,7 @@ async fn main(_spawner: Spawner, mut p: Peripherals) {
         info!("Reading...");
 
         let mut buf = [0u8; 16];
-        twi.write_then_read(ADDRESS, &mut [0x00], &mut buf).unwrap();
+        unwrap!(twi.write_then_read(ADDRESS, &mut [0x00], &mut buf));
 
         info!("Read: {=[u8]:x}", buf);
 

--- a/examples/stm32f4/src/bin/blinky.rs
+++ b/examples/stm32f4/src/bin/blinky.rs
@@ -26,11 +26,11 @@ async fn main(_spawner: Spawner, p: Peripherals) {
 
     loop {
         info!("high");
-        led.set_high().unwrap();
+        unwrap!(led.set_high());
         Timer::after(Duration::from_millis(300)).await;
 
         info!("low");
-        led.set_low().unwrap();
+        unwrap!(led.set_low());
         Timer::after(Duration::from_millis(300)).await;
     }
 }

--- a/examples/stm32f4/src/bin/button.rs
+++ b/examples/stm32f4/src/bin/button.rs
@@ -28,14 +28,14 @@ fn main() -> ! {
     let mut led3 = Output::new(p.PB14, Level::High, Speed::Low);
 
     loop {
-        if button.is_high().unwrap() {
+        if unwrap!(button.is_high()) {
             info!("high");
-            led1.set_high().unwrap();
-            led3.set_low().unwrap();
+            unwrap!(led1.set_high());
+            unwrap!(led3.set_low());
         } else {
             info!("low");
-            led1.set_low().unwrap();
-            led3.set_high().unwrap();
+            unwrap!(led1.set_low());
+            unwrap!(led3.set_high());
         }
     }
 }

--- a/examples/stm32f4/src/bin/usart.rs
+++ b/examples/stm32f4/src/bin/usart.rs
@@ -31,7 +31,7 @@ fn main() -> ! {
 
     let mut buf = [0u8; 1];
     loop {
-        unwrap!(usart.read_blocking(&mut buf).unwbrap());
-        unwrap!(usart.bwrite_all(&buf).unwrap());
+        unwrap!(usart.read_blocking(&mut buf));
+        unwrap!(usart.bwrite_all(&buf));
     }
 }

--- a/examples/stm32f4/src/bin/usart.rs
+++ b/examples/stm32f4/src/bin/usart.rs
@@ -26,12 +26,12 @@ fn main() -> ! {
     let config = Config::default();
     let mut usart = Uart::new(p.USART3, p.PD9, p.PD8, NoDma, NoDma, config);
 
-    usart.bwrite_all(b"Hello Embassy World!\r\n").unwrap();
+    unwrap!(usart.bwrite_all(b"Hello Embassy World!\r\n"));
     info!("wrote Hello, starting echo");
 
     let mut buf = [0u8; 1];
     loop {
-        usart.read_blocking(&mut buf).unwrap();
-        usart.bwrite_all(&buf).unwrap();
+        unwrap!(usart.read_blocking(&mut buf).unwbrap());
+        unwrap!(usart.bwrite_all(&buf).unwrap());
     }
 }

--- a/examples/stm32f4/src/bin/usart_dma.rs
+++ b/examples/stm32f4/src/bin/usart_dma.rs
@@ -31,7 +31,7 @@ async fn main(_spawner: Spawner, p: Peripherals) {
         let mut s: String<128> = String::new();
         core::write!(&mut s, "Hello DMA World {}!\r\n", n).unwrap();
 
-        usart.write(s.as_bytes()).await.unwrap();
+        unwrap!(usart.write(s.as_bytes()).await);
         info!("wrote DMA");
     }
 }

--- a/examples/stm32h7/src/bin/blinky.rs
+++ b/examples/stm32h7/src/bin/blinky.rs
@@ -24,11 +24,11 @@ async fn main(_spawner: Spawner, p: Peripherals) {
 
     loop {
         info!("high");
-        led.set_high().unwrap();
+        unwrap!(led.set_high());
         Timer::after(Duration::from_millis(500)).await;
 
         info!("low");
-        led.set_low().unwrap();
+        unwrap!(led.set_low());
         Timer::after(Duration::from_millis(500)).await;
     }
 }

--- a/examples/stm32h7/src/bin/usart.rs
+++ b/examples/stm32h7/src/bin/usart.rs
@@ -23,13 +23,13 @@ async fn main_task() {
     let config = Config::default();
     let mut usart = Uart::new(p.UART7, p.PF6, p.PF7, NoDma, NoDma, config);
 
-    usart.bwrite_all(b"Hello Embassy World!\r\n").unwrap();
+    unwrap!(usart.bwrite_all(b"Hello Embassy World!\r\n"));
     info!("wrote Hello, starting echo");
 
     let mut buf = [0u8; 1];
     loop {
-        usart.read_blocking(&mut buf).unwrap();
-        usart.bwrite_all(&buf).unwrap();
+        unwrap!(usart.read_blocking(&mut buf));
+        unwrap!(usart.bwrite_all(&buf));
     }
 }
 

--- a/examples/stm32l0/src/bin/blinky.rs
+++ b/examples/stm32l0/src/bin/blinky.rs
@@ -25,11 +25,11 @@ async fn main(_spawner: Spawner, mut p: Peripherals) {
 
     loop {
         info!("high");
-        led.set_high().unwrap();
+        unwrap!(led.set_high());
         Timer::after(Duration::from_millis(300)).await;
 
         info!("low");
-        led.set_low().unwrap();
+        unwrap!(led.set_low());
         Timer::after(Duration::from_millis(300)).await;
     }
 }

--- a/examples/stm32l0/src/bin/button.rs
+++ b/examples/stm32l0/src/bin/button.rs
@@ -27,14 +27,14 @@ fn main() -> ! {
     let mut led2 = Output::new(p.PB5, Level::High, Speed::Low);
 
     loop {
-        if button.is_high().unwrap() {
+        if unwrap!(button.is_high()) {
             info!("high");
-            led1.set_high().unwrap();
-            led2.set_low().unwrap();
+            unwrap!(led1.set_high());
+            unwrap!(led2.set_low());
         } else {
             info!("low");
-            led1.set_low().unwrap();
-            led2.set_high().unwrap();
+            unwrap!(led1.set_low());
+            unwrap!(led2.set_high());
         }
     }
 }

--- a/examples/stm32l4/src/bin/blinky.rs
+++ b/examples/stm32l4/src/bin/blinky.rs
@@ -25,9 +25,9 @@ async fn main(_spawner: Spawner, p: Peripherals) {
     let mut led = Output::new(p.PB14, Level::High, Speed::Low);
 
     loop {
-        led.set_high().unwrap();
+        unwrap!(led.set_high());
         Timer::after(Duration::from_millis(300)).await;
-        led.set_low().unwrap();
+        unwrap!(led.set_low());
         Timer::after(Duration::from_millis(300)).await;
     }
 }

--- a/examples/stm32l4/src/bin/button.rs
+++ b/examples/stm32l4/src/bin/button.rs
@@ -24,7 +24,7 @@ fn main() -> ! {
     let button = Input::new(p.PC13, Pull::Up);
 
     loop {
-        if button.is_high().unwrap() {
+        if unwrap!(button.is_high()) {
             info!("high");
         } else {
             info!("low");

--- a/examples/stm32l4/src/bin/spi_dma.rs
+++ b/examples/stm32l4/src/bin/spi_dma.rs
@@ -45,10 +45,10 @@ async fn main(_spawner: Spawner, p: Peripherals) {
     let ready = Input::new(p.PE1, Pull::Up);
 
     cortex_m::asm::delay(100_000);
-    reset.set_high().unwrap();
+    unwrap!(reset.set_high());
     cortex_m::asm::delay(100_000);
 
-    while ready.is_low().unwrap() {
+    while unwrap!(ready.is_low()) {
         info!("waiting for ready");
     }
 

--- a/examples/stm32l4/src/bin/usart.rs
+++ b/examples/stm32l4/src/bin/usart.rs
@@ -26,12 +26,12 @@ fn main() -> ! {
     let config = Config::default();
     let mut usart = Uart::new(p.UART4, p.PA1, p.PA0, NoDma, NoDma, config);
 
-    usart.bwrite_all(b"Hello Embassy World!\r\n").unwrap();
+    unwrap!(usart.bwrite_all(b"Hello Embassy World!\r\n"));
     info!("wrote Hello, starting echo");
 
     let mut buf = [0u8; 1];
     loop {
-        usart.read_blocking(&mut buf).unwrap();
-        usart.bwrite_all(&buf).unwrap();
+        unwrap!(usart.read_blocking(&mut buf));
+        unwrap!(usart.bwrite_all(&buf));
     }
 }

--- a/examples/stm32wb55/src/bin/blinky.rs
+++ b/examples/stm32wb55/src/bin/blinky.rs
@@ -24,11 +24,11 @@ async fn main(_spawner: Spawner, p: Peripherals) {
 
     loop {
         info!("high");
-        led.set_high().unwrap();
+        unwrap!(led.set_high());
         Timer::after(Duration::from_millis(500)).await;
 
         info!("low");
-        led.set_low().unwrap();
+        unwrap!(led.set_low());
         Timer::after(Duration::from_millis(500)).await;
     }
 }


### PR DESCRIPTION
Unfortunately errors from `embedded_graphics` and `core` doesn't provide
the necessary instances currently.