### PR TITLE
Introduce future types

### DIFF
--- a/embassy/src/util/mpsc.rs
+++ b/embassy/src/util/mpsc.rs
@@ -156,7 +156,7 @@ where
     /// closed by `recv` until they are all consumed.
     ///
     /// [`close`]: Self::close
-    pub fn recv(&mut self) -> RecvFuture<'ch, M, T, N> {
+    pub fn recv<'m>(&'m mut self) -> RecvFuture<'m, M, T, N> {
         RecvFuture {
             channel_cell: self.channel_cell,
         }

--- a/embassy/src/util/mpsc.rs
+++ b/embassy/src/util/mpsc.rs
@@ -218,6 +218,16 @@ where
     }
 }
 
+// Safe to pass the receive future around since it locks channel whenever polled
+unsafe impl<'ch, M, T, const N: usize> Send for RecvFuture<'ch, M, T, N> where
+    M: Mutex<Data = ()> + Sync
+{
+}
+unsafe impl<'ch, M, T, const N: usize> Sync for RecvFuture<'ch, M, T, N> where
+    M: Mutex<Data = ()> + Sync
+{
+}
+
 impl<'ch, M, T, const N: usize> Sender<'ch, M, T, N>
 where
     M: Mutex<Data = ()>,


### PR DESCRIPTION
Instead of using inferred types for send() and recv(), introduce future types allowing them to be more easily wrapped in other types without `Box` or other unstable features.

I think this change should be sound:

* For send(), sender is already Sync + Send, and there is only a syntactic change.
* For recv(), the added lifetime argument should ensure that only 1 RecvFuture can be created at a time or else the borrow checker will complain. Moreover, making RecvFuture Send + Sync should be safe because there can exist only 1, and it also locks the underlying channel_cell.

@huntc ^^