### PR TITLE
A possibly ill-thought-out BSP multi-board support.

### DIFF
--- a/examples/stm32f4/.cargo/config.toml
+++ b/examples/stm32f4/.cargo/config.toml
@@ -1,7 +1,5 @@
 [target.'cfg(all(target_arch = "arm", target_os = "none"))']
-# replace STM32F429ZITx with your chip as listed in `probe-run --list-chips`
-runner = "probe-run --chip STM32F429ZITx"
-
+runner = "./runner"
 rustflags = [
   # LLD (shipped with the Rust toolchain) is used as the default linker
   "-C", "link-arg=--nmagic",

--- a/examples/stm32f4/Cargo.toml
+++ b/examples/stm32f4/Cargo.toml
@@ -16,10 +16,14 @@ defmt-info = []
 defmt-warn = []
 defmt-error = []
 
+stm32f401 = [ "embassy-stm32/stm32f401re"]
+stm32f429 = [ "embassy-stm32/stm32f429zi"]
+
 [dependencies]
 embassy = { version = "0.1.0", path = "../../embassy", features = ["defmt", "defmt-trace"] }
 embassy-traits = { version = "0.1.0", path = "../../embassy-traits", features = ["defmt"] }
-embassy-stm32 = { version = "0.1.0", path = "../../embassy-stm32", features = ["defmt", "defmt-trace", "stm32f429zi", "unstable-pac", "memory-x"]  }
+#embassy-stm32 = { version = "0.1.0", path = "../../embassy-stm32", features = ["defmt", "defmt-trace", "stm32f429zi", "unstable-pac", "memory-x"]  }
+embassy-stm32 = { version = "0.1.0", path = "../../embassy-stm32", features = ["defmt", "defmt-trace", "unstable-pac", "memory-x"]  }
 embassy-hal-common = {version = "0.1.0", path = "../../embassy-hal-common" }
 
 defmt = "0.2.0"

--- a/examples/stm32f4/build.rs
+++ b/examples/stm32f4/build.rs
@@ -1,0 +1,23 @@
+
+use std::env;
+use std::fs::File;
+use std::io::Write;
+use std::path::Path;
+use std::path::PathBuf;
+
+fn main() {
+    let out_dir = PathBuf::from(env::var_os("OUT_DIR").unwrap());
+
+    let chip_name = env::vars_os()
+        .map(|(a, _)| a.to_string_lossy().to_string())
+        .find(|x| x.starts_with("CARGO_FEATURE_STM32"))
+        .expect("No stm32xx Cargo feature enabled")
+        .strip_prefix("CARGO_FEATURE_")
+        .unwrap()
+        .to_ascii_uppercase();
+
+    let mut file = File::create(out_dir.join("..").join("..").join("..").join("chip")).unwrap();
+    file.write_all( chip_name.as_bytes() ).unwrap();
+
+
+}

--- a/examples/stm32f4/src/bin/spi_dma.rs
+++ b/examples/stm32f4/src/bin/spi_dma.rs
@@ -20,6 +20,9 @@ use embassy_traits::spi::FullDuplex;
 use example_common::*;
 use heapless::String;
 
+extern crate embassy_stm32f4_examples;
+use embassy_stm32f4_examples::bsp;
+
 #[embassy::main]
 async fn main(_spawner: Spawner, p: Peripherals) {
     info!("Hello World!");
@@ -28,6 +31,7 @@ async fn main(_spawner: Spawner, p: Peripherals) {
         Dbgmcu::enable_all();
     }
 
+    /*
     let mut spi = Spi::new(
         p.SPI1,
         p.PB3,
@@ -38,6 +42,9 @@ async fn main(_spawner: Spawner, p: Peripherals) {
         Hertz(1_000_000),
         Config::default(),
     );
+     */
+
+    let mut spi = bsp::spi::new_spi(p);
 
     for n in 0u32.. {
         let mut write: String<128> = String::new();

--- a/examples/stm32f4/src/bsp/mod.rs
+++ b/examples/stm32f4/src/bsp/mod.rs
@@ -1,0 +1,10 @@
+
+#[cfg(feature="stm32f401")]
+mod stm32f401;
+#[cfg(feature="stm32f401")]
+pub use stm32f401::*;
+
+#[cfg(feature="stm32f429")]
+mod stm32f429;
+#[cfg(feature="stm32f429")]
+pub use stm32f429::*;

--- a/examples/stm32f4/src/bsp/stm32f401.rs
+++ b/examples/stm32f4/src/bsp/stm32f401.rs
@@ -1,0 +1,21 @@
+
+pub mod spi {
+    use embassy_stm32::Peripherals;
+    use embassy_stm32::spi::{Spi, Config};
+    use embassy_stm32::time::Hertz;
+    use embassy_stm32::peripherals::{SPI1, DMA2_CH2, DMA2_CH3};
+
+    pub fn new_spi<'a>(p: Peripherals) -> Spi<'a, SPI1, DMA2_CH3, DMA2_CH2>{
+        Spi::new(
+            p.SPI1,
+            p.PB3,
+            p.PA7,
+            p.PA6,
+            p.DMA2_CH3,
+            p.DMA2_CH2,
+            Hertz(1_000_000),
+            Config::default(),
+        )
+    }
+
+}

--- a/examples/stm32f4/src/bsp/stm32f429.rs
+++ b/examples/stm32f4/src/bsp/stm32f429.rs
@@ -1,0 +1,21 @@
+
+pub mod spi {
+    use embassy_stm32::Peripherals;
+    use embassy_stm32::spi::{Spi, Config};
+    use embassy_stm32::time::Hertz;
+    use embassy_stm32::peripherals::{SPI1, DMA2_CH2, DMA2_CH3};
+
+    pub fn new_spi<'a>(p: Peripherals) -> Spi<'a, SPI1, DMA2_CH3, DMA2_CH2>{
+        Spi::new(
+            p.SPI1,
+            p.PB3,
+            p.PB5,
+            p.PB4,
+            p.DMA2_CH3,
+            p.DMA2_CH2,
+            Hertz(1_000_000),
+            Config::default(),
+        )
+    }
+
+}

--- a/examples/stm32f4/src/lib.rs
+++ b/examples/stm32f4/src/lib.rs
@@ -1,0 +1,3 @@
+#![no_std]
+
+pub mod bsp;


### PR DESCRIPTION
Run an example (in this case only spi_dma is set up) with a --features

    cargo run --bin spi_dma --features=stm32f401

Does involve an outboard runner.sh which of course won't work on Windows.