### PR TITLE
Forward attributes to generated task function

### DIFF
--- a/embassy-macros/src/lib.rs
+++ b/embassy-macros/src/lib.rs
@@ -110,7 +110,10 @@ pub fn task(args: TokenStream, item: TokenStream) -> TokenStream {
         quote!(impl ::core::future::Future + 'static)
     };
 
+    let attrs = &task_fn.attrs;
+
     let result = quote! {
+        #(#attrs)*
         #visibility fn #name(#args) -> #embassy_path::executor::SpawnToken<#impl_ty> {
             use #embassy_path::executor::raw::Task;
             #task_fn


### PR DESCRIPTION
Fixes #18

Syn considers doc comments to be attributes, so forwarding those fixes the issue.
It's probably a good idea to forward most attributes anyway.