### PR TITLE
STM32H7: Ethernet: Disable RA in MAC filtering, fix order of MACA0 register writes

### DIFF
--- a/embassy-stm32/src/eth/v2/mod.rs
+++ b/embassy-stm32/src/eth/v2/mod.rs
@@ -98,6 +98,10 @@ impl<'d, P: PHY, const TX: usize, const RX: usize> Ethernet<'d, P, TX, RX> {
             // TODO: Carrier sense ? ECRSFD
         });
 
+        // Note: Writing to LR triggers synchronisation of both LR and HR into the MAC core,
+        // so the LR write must happen after the HR write.
+        mac.maca0hr()
+            .modify(|w| w.set_addrhi(u16::from(mac_addr[4]) | (u16::from(mac_addr[5]) << 8)));
         mac.maca0lr().write(|w| {
             w.set_addrlo(
                 u32::from(mac_addr[0])
@@ -106,10 +110,7 @@ impl<'d, P: PHY, const TX: usize, const RX: usize> Ethernet<'d, P, TX, RX> {
                     | (u32::from(mac_addr[3]) << 24),
             )
         });
-        mac.maca0hr()
-            .modify(|w| w.set_addrhi(u16::from(mac_addr[4]) | (u16::from(mac_addr[5]) << 8)));
 
-        mac.macpfr().modify(|w| w.set_ra(true));
         mac.macqtx_fcr().modify(|w| w.set_pt(0x100));
 
         mtl.mtlrx_qomr().modify(|w| w.set_rsf(true));


### PR DESCRIPTION
Previously the MACA0 register was written LR and then HR, but the value across both registers only updates when LR is written, so only a partial MAC address was being configured in the core. Presumably this is why destination filtering was failing and the RA (receive all) bit needed to be set.

With this reordering of the writes, the correct MAC address is loaded into the MAC core, and so the RA bit is no longer required.

Tested on an H745ZI nucleo board.