### PR TITLE
Updates to WL5x

### DIFF
--- a/embassy-stm32/src/rcc/wl5x/mod.rs
+++ b/embassy-stm32/src/rcc/wl5x/mod.rs
@@ -113,6 +113,17 @@ impl<'d> Rcc<'d> {
         }
     }
 
+    pub fn enable_lsi(&mut self) {
+        let rcc = pac::RCC;
+        unsafe {
+            let csr = rcc.csr().read();
+            if !csr.lsion() {
+                rcc.csr().modify(|w| w.set_lsion(true));
+                while !rcc.csr().read().lsirdy() {}
+            }
+        }
+    }
+
     // Safety: RCC init must have been called
     pub fn clocks(&self) -> &'static Clocks {
         unsafe { get_freqs() }

--- a/embassy-stm32/src/subghz/cad_params.rs
+++ b/embassy-stm32/src/subghz/cad_params.rs
@@ -1,4 +1,4 @@
-use crate::subghz::timeout::Timeout;
+use super::Timeout;
 
 /// Number of symbols used for channel activity detection scans.
 ///

--- a/embassy-stm32/src/subghz/hse_trim.rs
+++ b/embassy-stm32/src/subghz/hse_trim.rs
@@ -1,4 +1,4 @@
-use crate::subghz::value_error::ValueError;
+use super::ValueError;
 
 /// HSE32 load capacitor trimming.
 ///

--- a/embassy-stm32/src/subghz/mod.rs
+++ b/embassy-stm32/src/subghz/mod.rs
@@ -240,6 +240,14 @@ impl<'d, Tx, Rx> SubGhz<'d, Tx, Rx> {
 
         SubGhz { spi }
     }
+
+    pub fn is_busy(&mut self) -> bool {
+        rfbusys()
+    }
+
+    pub fn reset(&mut self) {
+        Self::pulse_radio_reset();
+    }
 }
 
 impl<'d> SubGhz<'d, NoDma, NoDma> {

--- a/embassy-stm32/src/subghz/mod_params.rs
+++ b/embassy-stm32/src/subghz/mod_params.rs
@@ -561,6 +561,16 @@ impl FskModParams {
         bw > br + 2 * fdev + freq_err
     }
 
+    /// Returns `true` if the modulation parameters are valid for a worst-case
+    /// crystal tolerance.
+    ///
+    /// This is equivalent to [`is_valid`](Self::is_valid) with a `ppm` argument
+    /// of 30.
+    #[must_use = "the return value indicates if the modulation parameters are valid"]
+    pub const fn is_valid_worst_case(&self) -> bool {
+        self.is_valid(30)
+    }
+
     /// Extracts a slice containing the packet.
     ///
     /// # Example
@@ -613,11 +623,11 @@ pub enum SpreadingFactor {
     /// Spreading factor 9.
     Sf9 = 0x09,
     /// Spreading factor 10.
-    Sf10 = 0xA0,
+    Sf10 = 0x0A,
     /// Spreading factor 11.
-    Sf11 = 0xB0,
+    Sf11 = 0x0B,
     /// Spreading factor 12.
-    Sf12 = 0xC0,
+    Sf12 = 0x0C,
 }
 
 impl From<SpreadingFactor> for u8 {

--- a/embassy-stm32/src/subghz/ocp.rs
+++ b/embassy-stm32/src/subghz/ocp.rs
@@ -2,7 +2,7 @@
 ///
 /// Used by [`set_pa_ocp`].
 ///
-/// [`set_pa_ocp`]: crate::subghz::SubGhz::set_pa_ocp
+/// [`set_pa_ocp`]: super::SubGhz::set_pa_ocp
 #[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Clone, Copy)]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
 #[repr(u8)]

--- a/embassy-stm32/src/subghz/op_error.rs
+++ b/embassy-stm32/src/subghz/op_error.rs
@@ -2,7 +2,7 @@
 ///
 /// Returned by [`op_error`].
 ///
-/// [`op_error`]: crate::subghz::SubGhz::op_error
+/// [`op_error`]: super::SubGhz::op_error
 #[derive(Debug, PartialEq, Eq, Clone, Copy)]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
 #[repr(u8)]

--- a/embassy-stm32/src/subghz/pa_config.rs
+++ b/embassy-stm32/src/subghz/pa_config.rs
@@ -2,7 +2,7 @@
 ///
 /// Argument of [`set_pa_config`].
 ///
-/// [`set_pa_config`]: crate::subghz::SubGhz::set_pa_config
+/// [`set_pa_config`]: super::SubGhz::set_pa_config
 #[derive(Debug, PartialEq, Eq, Clone, Copy)]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub struct PaConfig {
@@ -10,6 +10,62 @@ pub struct PaConfig {
 }
 
 impl PaConfig {
+    /// Optimal settings for +15dBm output power with the low-power PA.
+    ///
+    /// This must be used with [`TxParams::LP_15`](super::TxParams::LP_15).
+    pub const LP_15: PaConfig = PaConfig::new()
+        .set_pa_duty_cycle(0x6)
+        .set_hp_max(0x0)
+        .set_pa(PaSel::Lp);
+
+    /// Optimal settings for +14dBm output power with the low-power PA.
+    ///
+    /// This must be used with [`TxParams::LP_14`](super::TxParams::LP_14).
+    pub const LP_14: PaConfig = PaConfig::new()
+        .set_pa_duty_cycle(0x4)
+        .set_hp_max(0x0)
+        .set_pa(PaSel::Lp);
+
+    /// Optimal settings for +10dBm output power with the low-power PA.
+    ///
+    /// This must be used with [`TxParams::LP_10`](super::TxParams::LP_10).
+    pub const LP_10: PaConfig = PaConfig::new()
+        .set_pa_duty_cycle(0x1)
+        .set_hp_max(0x0)
+        .set_pa(PaSel::Lp);
+
+    /// Optimal settings for +22dBm output power with the high-power PA.
+    ///
+    /// This must be used with [`TxParams::HP`](super::TxParams::HP).
+    pub const HP_22: PaConfig = PaConfig::new()
+        .set_pa_duty_cycle(0x4)
+        .set_hp_max(0x7)
+        .set_pa(PaSel::Hp);
+
+    /// Optimal settings for +20dBm output power with the high-power PA.
+    ///
+    /// This must be used with [`TxParams::HP`](super::TxParams::HP).
+    pub const HP_20: PaConfig = PaConfig::new()
+        .set_pa_duty_cycle(0x3)
+        .set_hp_max(0x5)
+        .set_pa(PaSel::Hp);
+
+    /// Optimal settings for +17dBm output power with the high-power PA.
+    ///
+    /// This must be used with [`TxParams::HP`](super::TxParams::HP).
+    pub const HP_17: PaConfig = PaConfig::new()
+        .set_pa_duty_cycle(0x2)
+        .set_hp_max(0x3)
+        .set_pa(PaSel::Hp);
+
+    /// Optimal settings for +14dBm output power with the high-power PA.
+    ///
+    /// This must be used with [`TxParams::HP`](super::TxParams::HP).
+    pub const HP_14: PaConfig = PaConfig::new()
+        .set_pa_duty_cycle(0x2)
+        .set_hp_max(0x2)
+        .set_pa(PaSel::Hp);
+
     /// Create a new `PaConfig` struct.
     ///
     /// This is the same as `default`, but in a `const` function.

--- a/embassy-stm32/src/subghz/packet_params.rs
+++ b/embassy-stm32/src/subghz/packet_params.rs
@@ -76,7 +76,7 @@ pub enum CrcType {
 
 /// Packet parameters for [`set_packet_params`].
 ///
-/// [`set_packet_params`]: crate::subghz::SubGhz::set_packet_params
+/// [`set_packet_params`]: super::SubGhz::set_packet_params
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub struct GenericPacketParams {
@@ -311,7 +311,7 @@ impl Default for GenericPacketParams {
 
 /// Packet parameters for [`set_lora_packet_params`].
 ///
-/// [`set_lora_packet_params`]: crate::subghz::SubGhz::set_lora_packet_params
+/// [`set_lora_packet_params`]: super::SubGhz::set_lora_packet_params
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct LoRaPacketParams {
     buf: [u8; 7],
@@ -470,7 +470,7 @@ impl Default for LoRaPacketParams {
 
 /// Packet parameters for [`set_lora_packet_params`].
 ///
-/// [`set_lora_packet_params`]: crate::subghz::SubGhz::set_lora_packet_params
+/// [`set_lora_packet_params`]: super::SubGhz::set_lora_packet_params
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub struct BpskPacketParams {

--- a/embassy-stm32/src/subghz/packet_status.rs
+++ b/embassy-stm32/src/subghz/packet_status.rs
@@ -1,12 +1,12 @@
-use embassy_hal_common::ratio::Ratio;
+use super::Ratio;
 
-use crate::subghz::status::Status;
+use super::Status;
 
 /// (G)FSK packet status.
 ///
 /// Returned by [`fsk_packet_status`].
 ///
-/// [`fsk_packet_status`]: crate::subghz::SubGhz::fsk_packet_status
+/// [`fsk_packet_status`]: super::SubGhz::fsk_packet_status
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct FskPacketStatus {
     buf: [u8; 4],
@@ -37,7 +37,7 @@ impl FskPacketStatus {
     }
 
     /// Returns `true` if a preabmle error occured.
-    pub const fn preamble_error(&self) -> bool {
+    pub const fn preamble_err(&self) -> bool {
         (self.buf[1] & (1 << 7)) != 0
     }
 
@@ -47,7 +47,7 @@ impl FskPacketStatus {
     }
 
     /// Returns `true` if an address error occured.
-    pub const fn adrs_err(&self) -> bool {
+    pub const fn addr_err(&self) -> bool {
         (self.buf[1] & (1 << 5)) != 0
     }
 
@@ -74,6 +74,11 @@ impl FskPacketStatus {
     /// Returns `true` when a packet has been sent.
     pub const fn pkt_sent(&self) -> bool {
         (self.buf[1] & 1) != 0
+    }
+
+    /// Returns `true` if any error occured.
+    pub const fn any_err(&self) -> bool {
+        (self.buf[1] & 0xFC) != 0
     }
 
     /// RSSI level when the synchronization address is detected.
@@ -118,9 +123,9 @@ impl defmt::Format for FskPacketStatus {
             fmt,
             r#"FskPacketStatus {{
     status: {},
-    preamble_error: {},
+    preamble_err: {},
     sync_err: {},
-    adrs_err: {},
+    addr_err: {},
     crc_err: {},
     length_err: {},
     abort_err: {},
@@ -130,9 +135,9 @@ impl defmt::Format for FskPacketStatus {
     rssi_avg: {},
 }}"#,
             self.status(),
-            self.preamble_error(),
+            self.preamble_err(),
             self.sync_err(),
-            self.adrs_err(),
+            self.addr_err(),
             self.crc_err(),
             self.length_err(),
             self.abort_err(),
@@ -148,9 +153,9 @@ impl core::fmt::Display for FskPacketStatus {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         f.debug_struct("FskPacketStatus")
             .field("status", &self.status())
-            .field("preamble_error", &self.preamble_error())
+            .field("preamble_err", &self.preamble_err())
             .field("sync_err", &self.sync_err())
-            .field("adrs_err", &self.adrs_err())
+            .field("addr_err", &self.addr_err())
             .field("crc_err", &self.crc_err())
             .field("length_err", &self.length_err())
             .field("abort_err", &self.abort_err())
@@ -166,7 +171,7 @@ impl core::fmt::Display for FskPacketStatus {
 ///
 /// Returned by [`lora_packet_status`].
 ///
-/// [`lora_packet_status`]: crate::subghz::SubGhz::lora_packet_status
+/// [`lora_packet_status`]: super::SubGhz::lora_packet_status
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct LoRaPacketStatus {
     buf: [u8; 4],

--- a/embassy-stm32/src/subghz/packet_type.rs
+++ b/embassy-stm32/src/subghz/packet_type.rs
@@ -2,7 +2,7 @@
 ///
 /// Argument of [`set_packet_type`]
 ///
-/// [`set_packet_type`]: crate::subghz::SubGhz::set_packet_type
+/// [`set_packet_type`]: super::SubGhz::set_packet_type
 #[repr(u8)]
 #[derive(Debug, PartialEq, Eq, Clone, Copy)]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]

--- a/embassy-stm32/src/subghz/pkt_ctrl.rs
+++ b/embassy-stm32/src/subghz/pkt_ctrl.rs
@@ -22,7 +22,7 @@ impl Default for InfSeqSel {
 
 /// Generic packet control.
 ///
-/// Argument of [`set_pkt_ctrl`](crate::subghz::SubGhz::set_pkt_ctrl).
+/// Argument of [`set_pkt_ctrl`](super::SubGhz::set_pkt_ctrl).
 #[derive(Debug, PartialEq, Eq, Clone, Copy)]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub struct PktCtrl {

--- a/embassy-stm32/src/subghz/pmode.rs
+++ b/embassy-stm32/src/subghz/pmode.rs
@@ -2,7 +2,7 @@
 ///
 /// Argument of [`set_rx_gain`].
 ///
-/// [`set_rx_gain`]: crate::subghz::SubGhz::set_rx_gain
+/// [`set_rx_gain`]: super::SubGhz::set_rx_gain
 #[repr(u8)]
 #[derive(Debug, PartialEq, Eq, Clone, Copy)]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]

--- a/embassy-stm32/src/subghz/pwr_ctrl.rs
+++ b/embassy-stm32/src/subghz/pwr_ctrl.rs
@@ -46,7 +46,7 @@ impl Default for CurrentLim {
 
 /// Power control.
 ///
-/// Argument of [`set_bit_sync`](crate::subghz::SubGhz::set_bit_sync).
+/// Argument of [`set_bit_sync`](super::SubGhz::set_bit_sync).
 #[derive(Debug, PartialEq, Eq, Clone, Copy)]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub struct PwrCtrl {

--- a/embassy-stm32/src/subghz/rf_frequency.rs
+++ b/embassy-stm32/src/subghz/rf_frequency.rs
@@ -2,7 +2,7 @@
 ///
 /// Argument of [`set_rf_frequency`].
 ///
-/// [`set_rf_frequency`]: crate::subghz::SubGhz::set_rf_frequency
+/// [`set_rf_frequency`]: super::SubGhz::set_rf_frequency
 #[derive(Debug, PartialEq, Eq, Clone, Copy, PartialOrd, Ord)]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub struct RfFreq {

--- a/embassy-stm32/src/subghz/rx_timeout_stop.rs
+++ b/embassy-stm32/src/subghz/rx_timeout_stop.rs
@@ -2,7 +2,7 @@
 ///
 /// Used by [`set_rx_timeout_stop`].
 ///
-/// [`set_rx_timeout_stop`]: crate::subghz::SubGhz::set_rx_timeout_stop
+/// [`set_rx_timeout_stop`]: super::SubGhz::set_rx_timeout_stop
 #[derive(Debug, PartialEq, Eq, Clone, Copy)]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
 #[repr(u8)]

--- a/embassy-stm32/src/subghz/sleep_cfg.rs
+++ b/embassy-stm32/src/subghz/sleep_cfg.rs
@@ -27,7 +27,7 @@ impl Default for Startup {
 ///
 /// Argument of [`set_sleep`].
 ///
-/// [`set_sleep`]: crate::subghz::SubGhz::set_sleep
+/// [`set_sleep`]: super::SubGhz::set_sleep
 #[derive(Debug, PartialEq, Eq, Clone, Copy)]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub struct SleepCfg(u8);

--- a/embassy-stm32/src/subghz/smps.rs
+++ b/embassy-stm32/src/subghz/smps.rs
@@ -1,6 +1,6 @@
 /// SMPS maximum drive capability.
 ///
-/// Argument of [`set_smps_drv`](crate::subghz::SubGhz::set_smps_drv).
+/// Argument of [`set_smps_drv`](super::SubGhz::set_smps_drv).
 #[derive(Debug, PartialEq, Eq, Ord, PartialOrd, Clone, Copy)]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
 #[repr(u8)]

--- a/embassy-stm32/src/subghz/standby_clk.rs
+++ b/embassy-stm32/src/subghz/standby_clk.rs
@@ -2,7 +2,7 @@
 ///
 /// Used by [`set_standby`].
 ///
-/// [`set_standby`]: crate::subghz::SubGhz::set_standby
+/// [`set_standby`]: super::SubGhz::set_standby
 #[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Clone, Copy)]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
 #[repr(u8)]

--- a/embassy-stm32/src/subghz/stats.rs
+++ b/embassy-stm32/src/subghz/stats.rs
@@ -1,4 +1,4 @@
-use crate::subghz::status::Status;
+use super::Status;
 
 #[derive(Debug, PartialEq, Eq, Clone, Copy)]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
@@ -24,8 +24,8 @@ impl FskStats {
 ///
 /// Returned by [`fsk_stats`] and [`lora_stats`].
 ///
-/// [`fsk_stats`]: crate::subghz::SubGhz::fsk_stats
-/// [`lora_stats`]: crate::subghz::SubGhz::lora_stats
+/// [`fsk_stats`]: super::SubGhz::fsk_stats
+/// [`lora_stats`]: super::SubGhz::lora_stats
 #[derive(Debug, Eq, PartialEq, Clone, Copy)]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub struct Stats<ModType> {
@@ -169,7 +169,7 @@ impl core::fmt::Display for Stats<FskStats> {
 
 #[cfg(test)]
 mod test {
-    use crate::subghz::{CmdStatus, LoRaStats, Stats, StatusMode};
+    use super::super::{CmdStatus, LoRaStats, Stats, StatusMode};
 
     #[test]
     fn mixed() {

--- a/embassy-stm32/src/subghz/status.rs
+++ b/embassy-stm32/src/subghz/status.rs
@@ -115,7 +115,7 @@ impl CmdStatus {
 ///
 /// This is returned by [`status`].
 ///
-/// [`status`]: crate::subghz::SubGhz::status
+/// [`status`]: super::SubGhz::status
 #[derive(Debug, PartialEq, Eq, Clone, Copy)]
 pub struct Status(u8);
 

--- a/embassy-stm32/src/subghz/tcxo_mode.rs
+++ b/embassy-stm32/src/subghz/tcxo_mode.rs
@@ -1,4 +1,4 @@
-use crate::subghz::timeout::Timeout;
+use super::Timeout;
 
 /// TCXO trim.
 ///
@@ -78,7 +78,7 @@ impl TcxoTrim {
 ///
 /// Argument of [`set_tcxo_mode`].
 ///
-/// [`set_tcxo_mode`]: crate::subghz::SubGhz::set_tcxo_mode
+/// [`set_tcxo_mode`]: super::SubGhz::set_tcxo_mode
 #[derive(Debug, PartialEq, Eq, Clone, Copy)]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub struct TcxoMode {

--- a/embassy-stm32/src/subghz/tx_params.rs
+++ b/embassy-stm32/src/subghz/tx_params.rs
@@ -1,6 +1,6 @@
 /// Power amplifier ramp time for FSK, MSK, and LoRa modulation.
 ///
-/// Argument of [`set_ramp_time`][`crate::subghz::TxParams::set_ramp_time`].
+/// Argument of [`set_ramp_time`][`super::TxParams::set_ramp_time`].
 #[derive(Debug, PartialEq, Eq, PartialOrd, Ord)]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
 #[repr(u8)]
@@ -60,7 +60,7 @@ impl From<RampTime> for embassy::time::Duration {
 }
 /// Transmit parameters, output power and power amplifier ramp up time.
 ///
-/// Argument of [`set_tx_params`][`crate::subghz::SubGhz::set_tx_params`].
+/// Argument of [`set_tx_params`][`super::SubGhz::set_tx_params`].
 #[derive(Debug, PartialEq, Eq, Clone, Copy)]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub struct TxParams {
@@ -68,6 +68,31 @@ pub struct TxParams {
 }
 
 impl TxParams {
+    /// Optimal power setting for +15dBm output power with the low-power PA.
+    ///
+    /// This must be used with [`PaConfig::LP_15`](super::PaConfig::LP_15).
+    pub const LP_15: TxParams = TxParams::new().set_power(0x0E);
+
+    /// Optimal power setting for +14dBm output power with the low-power PA.
+    ///
+    /// This must be used with [`PaConfig::LP_14`](super::PaConfig::LP_14).
+    pub const LP_14: TxParams = TxParams::new().set_power(0x0E);
+
+    /// Optimal power setting for +10dBm output power with the low-power PA.
+    ///
+    /// This must be used with [`PaConfig::LP_10`](super::PaConfig::LP_10).
+    pub const LP_10: TxParams = TxParams::new().set_power(0x0D);
+
+    /// Optimal power setting for the high-power PA.
+    ///
+    /// This must be used with one of:
+    ///
+    /// * [`PaConfig::HP_22`](super::PaConfig::HP_22)
+    /// * [`PaConfig::HP_20`](super::PaConfig::HP_20)
+    /// * [`PaConfig::HP_17`](super::PaConfig::HP_17)
+    /// * [`PaConfig::HP_14`](super::PaConfig::HP_14)
+    pub const HP: TxParams = TxParams::new().set_power(0x16);
+
     /// Create a new `TxParams` struct.
     ///
     /// This is the same as `default`, but in a `const` function.
@@ -117,7 +142,7 @@ impl TxParams {
     /// # assert_eq!(TX_PARAMS.as_slice()[1], 0x00);
     /// ```
     ///
-    /// [`set_pa_config`]: crate::subghz::SubGhz::set_pa_config
+    /// [`set_pa_config`]: super::SubGhz::set_pa_config
     #[must_use = "set_power returns a modified TxParams"]
     pub const fn set_power(mut self, power: u8) -> TxParams {
         self.buf[1] = power;

--- a/embassy-stm32/src/subghz/value_error.rs
+++ b/embassy-stm32/src/subghz/value_error.rs
@@ -2,7 +2,7 @@
 ///
 /// Used by [`Timeout::from_duration`].
 ///
-/// [`Timeout::from_duration`]: crate::subghz::Timeout::from_duration
+/// [`Timeout::from_duration`]: super::Timeout::from_duration
 #[derive(Debug, PartialEq, Eq, Clone, Copy)]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub struct ValueError<T> {


### PR DESCRIPTION
* Import changes in stm32wl-hal for the subghz peripheral
* Add method for enabling LSI clock (required for RNG)