### PR TITLE
Small adjustment to 'set_as_af' interface

### DIFF
--- a/embassy-stm32/src/can/bxcan.rs
+++ b/embassy-stm32/src/can/bxcan.rs
@@ -5,7 +5,7 @@ use embassy::util::Unborrow;
 use embassy_hal_common::unborrow;
 
 use crate::gpio::{
-    OutputType::{OpenDrain, PushPull},
+    sealed::OutputType::{OpenDrain, PushPull},
     Pin,
 };
 use crate::{peripherals, rcc::RccPeripheral};

--- a/embassy-stm32/src/can/bxcan.rs
+++ b/embassy-stm32/src/can/bxcan.rs
@@ -4,7 +4,10 @@ use core::ops::{Deref, DerefMut};
 use embassy::util::Unborrow;
 use embassy_hal_common::unborrow;
 
-use crate::gpio::Pin;
+use crate::gpio::{
+    OutputType::{OpenDrain, PushPull},
+    Pin,
+};
 use crate::{peripherals, rcc::RccPeripheral};
 
 pub use bxcan::*;
@@ -23,8 +26,8 @@ impl<'d, T: Instance + bxcan::Instance> Can<'d, T> {
         unborrow!(peri, rx, tx);
 
         unsafe {
-            rx.set_as_af(rx.af_num());
-            tx.set_as_af(tx.af_num());
+            rx.set_as_af(rx.af_num(), OpenDrain);
+            tx.set_as_af(tx.af_num(), PushPull);
         }
 
         T::enable();

--- a/embassy-stm32/src/eth/v2/mod.rs
+++ b/embassy-stm32/src/eth/v2/mod.rs
@@ -9,8 +9,8 @@ use embassy_hal_common::unborrow;
 use embassy_net::{Device, DeviceCapabilities, LinkState, PacketBuf, MTU};
 
 use crate::gpio::sealed::Pin as __GpioPin;
-use crate::gpio::AnyPin;
 use crate::gpio::Pin as GpioPin;
+use crate::gpio::{AnyPin, OutputType::PushPull};
 use crate::pac::gpio::vals::Ospeedr;
 use crate::pac::{ETH, RCC, SYSCFG};
 use crate::peripherals;
@@ -416,7 +416,7 @@ macro_rules! impl_pin {
             fn configure(&mut self) {
                 // NOTE(unsafe) Exclusive access to the registers
                 critical_section::with(|_| unsafe {
-                    self.set_as_af($af);
+                    self.set_as_af($af, PushPull);
                     self.block()
                         .ospeedr()
                         .modify(|w| w.set_ospeedr(self.pin() as usize, Ospeedr::VERYHIGHSPEED));

--- a/embassy-stm32/src/eth/v2/mod.rs
+++ b/embassy-stm32/src/eth/v2/mod.rs
@@ -10,7 +10,7 @@ use embassy_net::{Device, DeviceCapabilities, LinkState, PacketBuf, MTU};
 
 use crate::gpio::sealed::Pin as __GpioPin;
 use crate::gpio::Pin as GpioPin;
-use crate::gpio::{AnyPin, OutputType::PushPull};
+use crate::gpio::{sealed::OutputType::PushPull, AnyPin};
 use crate::pac::gpio::vals::Ospeedr;
 use crate::pac::{ETH, RCC, SYSCFG};
 use crate::peripherals;

--- a/embassy-stm32/src/gpio.rs
+++ b/embassy-stm32/src/gpio.rs
@@ -55,14 +55,6 @@ impl From<Speed> for vals::Ospeedr {
     }
 }
 
-/// Type settings
-#[derive(Debug)]
-#[cfg_attr(feature = "defmt", derive(defmt::Format))]
-pub enum OutputType {
-    PushPull,
-    OpenDrain,
-}
-
 /// GPIO input driver.
 pub struct Input<'d, T: Pin> {
     pub(crate) pin: T,
@@ -271,6 +263,14 @@ impl<'d, T: Pin> InputPin for OutputOpenDrain<'d, T> {
 
 pub(crate) mod sealed {
     use super::*;
+
+    /// Output type settings
+    #[derive(Debug)]
+    #[cfg_attr(feature = "defmt", derive(defmt::Format))]
+    pub enum OutputType {
+        PushPull,
+        OpenDrain,
+    }
 
     pub trait Pin {
         fn pin_port(&self) -> u8;

--- a/embassy-stm32/src/i2c/v1.rs
+++ b/embassy-stm32/src/i2c/v1.rs
@@ -9,7 +9,7 @@ use embedded_hal::blocking::i2c::WriteRead;
 
 use crate::pac::i2c;
 
-use crate::gpio::OutputType::OpenDrain;
+use crate::gpio::sealed::OutputType::OpenDrain;
 
 pub struct I2c<'d, T: Instance> {
     phantom: PhantomData<&'d mut T>,

--- a/embassy-stm32/src/spi/v1.rs
+++ b/embassy-stm32/src/spi/v1.rs
@@ -1,7 +1,11 @@
 #![macro_use]
 
 use crate::dma::NoDma;
-use crate::gpio::{sealed::Pin, AnyPin};
+use crate::gpio::{
+    sealed::Pin,
+    AnyPin,
+    OutputType::{OpenDrain, PushPull},
+};
 use crate::pac::spi;
 use crate::spi::{
     ByteOrder, Config, Error, Instance, MisoPin, MosiPin, RxDmaChannel, SckPin, TxDmaChannel,
@@ -53,9 +57,9 @@ impl<'d, T: Instance, Tx, Rx> Spi<'d, T, Tx, Rx> {
         unborrow!(sck, mosi, miso, txdma, rxdma);
 
         unsafe {
-            sck.set_as_af(sck.af_num());
-            mosi.set_as_af(mosi.af_num());
-            miso.set_as_af(miso.af_num());
+            sck.set_as_af(sck.af_num(), PushPull);
+            mosi.set_as_af(mosi.af_num(), PushPull);
+            miso.set_as_af(miso.af_num(), OpenDrain);
         }
 
         let sck = sck.degrade();

--- a/embassy-stm32/src/spi/v1.rs
+++ b/embassy-stm32/src/spi/v1.rs
@@ -2,9 +2,11 @@
 
 use crate::dma::NoDma;
 use crate::gpio::{
-    sealed::Pin,
+    sealed::{
+        OutputType::{OpenDrain, PushPull},
+        Pin,
+    },
     AnyPin,
-    OutputType::{OpenDrain, PushPull},
 };
 use crate::pac::spi;
 use crate::spi::{

--- a/embassy-stm32/src/usart/v1.rs
+++ b/embassy-stm32/src/usart/v1.rs
@@ -1,3 +1,4 @@
+use crate::gpio::OutputType::{OpenDrain, PushPull};
 use core::future::Future;
 use core::marker::PhantomData;
 use embassy::util::Unborrow;
@@ -36,8 +37,8 @@ impl<'d, T: Instance, TxDma, RxDma> Uart<'d, T, TxDma, RxDma> {
         let r = inner.regs();
 
         unsafe {
-            rx.set_as_af(rx.af_num());
-            tx.set_as_af(tx.af_num());
+            rx.set_as_af(rx.af_num(), OpenDrain);
+            tx.set_as_af(tx.af_num(), PushPull);
 
             r.brr().write_value(regs::Brr(div));
             r.cr1().write(|w| {

--- a/embassy-stm32/src/usart/v1.rs
+++ b/embassy-stm32/src/usart/v1.rs
@@ -1,4 +1,4 @@
-use crate::gpio::OutputType::{OpenDrain, PushPull};
+use crate::gpio::sealed::OutputType::{OpenDrain, PushPull};
 use core::future::Future;
 use core::marker::PhantomData;
 use embassy::util::Unborrow;

--- a/embassy-stm32/src/usart/v2.rs
+++ b/embassy-stm32/src/usart/v2.rs
@@ -13,6 +13,7 @@ use futures::TryFutureExt;
 
 use super::*;
 use crate::dma::NoDma;
+use crate::gpio::OutputType::{OpenDrain, PushPull};
 use crate::pac::usart::{regs, vals};
 
 pub struct Uart<'d, T: Instance, TxDma = NoDma, RxDma = NoDma> {
@@ -42,8 +43,8 @@ impl<'d, T: Instance, TxDma, RxDma> Uart<'d, T, TxDma, RxDma> {
         let r = inner.regs();
 
         unsafe {
-            rx.set_as_af(rx.af_num());
-            tx.set_as_af(tx.af_num());
+            rx.set_as_af(rx.af_num(), OpenDrain);
+            tx.set_as_af(tx.af_num(), PushPull);
 
             r.cr2().write(|_w| {});
             r.cr3().write(|_w| {});

--- a/embassy-stm32/src/usart/v2.rs
+++ b/embassy-stm32/src/usart/v2.rs
@@ -13,7 +13,7 @@ use futures::TryFutureExt;
 
 use super::*;
 use crate::dma::NoDma;
-use crate::gpio::OutputType::{OpenDrain, PushPull};
+use crate::gpio::sealed::OutputType::{OpenDrain, PushPull};
 use crate::pac::usart::{regs, vals};
 
 pub struct Uart<'d, T: Instance, TxDma = NoDma, RxDma = NoDma> {


### PR DESCRIPTION
Small adjustment to 'set_as_af' interface. Mostly just to remove the dependency on the raw GPIO registers in i2c.