### PR TITLE
Fix: erroneous behavior of pins  being configured into AF

### DIFF
--- a/embassy-stm32/src/gpio.rs
+++ b/embassy-stm32/src/gpio.rs
@@ -311,9 +311,6 @@ pub(crate) mod sealed {
             let pin = self._pin() as usize;
             let block = self.block();
             block
-                .moder()
-                .modify(|w| w.set_moder(pin, vals::Moder::ALTERNATE));
-            block
                 .afr(pin / 8)
                 .modify(|w| w.set_afr(pin % 8, vals::Afr(af_num)));
             match af_type {
@@ -327,6 +324,10 @@ pub(crate) mod sealed {
             block
                 .pupdr()
                 .modify(|w| w.set_pupdr(pin, vals::Pupdr::FLOATING));
+
+            block
+                .moder()
+                .modify(|w| w.set_moder(pin, vals::Moder::ALTERNATE));
         }
 
         unsafe fn set_as_analog(&self) {

--- a/embassy-stm32/src/gpio.rs
+++ b/embassy-stm32/src/gpio.rs
@@ -130,9 +130,9 @@ impl<'d, T: Pin> Output<'d, T> {
             let r = pin.block();
             let n = pin.pin() as usize;
             r.pupdr().modify(|w| w.set_pupdr(n, vals::Pupdr::FLOATING));
-            r.moder().modify(|w| w.set_moder(n, vals::Moder::OUTPUT));
             r.otyper().modify(|w| w.set_ot(n, vals::Ot::PUSHPULL));
             pin.set_speed(speed);
+            r.moder().modify(|w| w.set_moder(n, vals::Moder::OUTPUT));
         });
 
         Self {
@@ -208,9 +208,9 @@ impl<'d, T: Pin> OutputOpenDrain<'d, T> {
             let r = pin.block();
             let n = pin.pin() as usize;
             r.pupdr().modify(|w| w.set_pupdr(n, pull.into()));
-            r.moder().modify(|w| w.set_moder(n, vals::Moder::OUTPUT));
             r.otyper().modify(|w| w.set_ot(n, vals::Ot::OPENDRAIN));
             pin.set_speed(speed);
+            r.moder().modify(|w| w.set_moder(n, vals::Moder::OUTPUT));
         });
 
         Self {


### PR DESCRIPTION
A race condition exists when configuring pins into a peripheral's AF.

In the case of usart_v1 on a stm32f446RE, this causes an erroneous `0xF8` byte to be written to the usart's TX pin during startup.

This PR fixes the race condition by only configuring the pin into AF mode at the end of the configuration.

Minimal falsifying example:
```rs
#![no_std]
#![no_main]
#![feature(type_alias_impl_trait)]

/*
Module declartions
 */
// stuff used across binaries
#[path = "../example_common.rs"]
mod example_common;
use example_common::*;
/*
Includes
 */
use embassy::executor::Spawner;
use embassy::traits::*;
use embassy_stm32::usart::{Config, Uart};
use embassy_stm32::Peripherals;

#[embassy::main]
async fn main(_spawner: Spawner, p: Peripherals) {
    info!("Hello World!");

    let config = Config::default();
    let mut usart = Uart::new(p.USART1, p.PA10, p.PA9, p.DMA2_CH7, p.DMA2_CH5, config); 
}