### PR TITLE
nrf/saadc: remove Sample trait.

### DIFF
--- a/examples/nrf/src/bin/saadc.rs
+++ b/examples/nrf/src/bin/saadc.rs
@@ -7,7 +7,7 @@ mod example_common;
 use defmt::panic;
 use embassy::executor::Spawner;
 use embassy::time::{Duration, Timer};
-use embassy_nrf::saadc::{Config, OneShot, Sample};
+use embassy_nrf::saadc::{Config, OneShot};
 use embassy_nrf::{interrupt, Peripherals};
 use example_common::*;
 


### PR DESCRIPTION
It's not useful since it's only used for nrf. Use an inherent method for now.

When embedded-hal adds async ADC traits we can add support for them.