### PR TITLE
Implements nRF SAADC continuous mode

### DIFF
--- a/embassy-nrf/src/saadc.rs
+++ b/embassy-nrf/src/saadc.rs
@@ -1,6 +1,7 @@
 #![macro_use]
 
 use core::marker::PhantomData;
+use core::slice;
 use core::sync::atomic::{compiler_fence, Ordering};
 use core::task::Poll;
 use embassy::interrupt::InterruptExt;
@@ -8,6 +9,7 @@ use embassy::util::Unborrow;
 use embassy::waitqueue::AtomicWaker;
 use embassy_hal_common::unborrow;
 use futures::future::poll_fn;
+use futures::Stream;
 
 use crate::interrupt;
 use crate::{pac, peripherals};
@@ -27,11 +29,6 @@ pub use saadc::{
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
 #[non_exhaustive]
 pub enum Error {}
-
-/// One-shot saadc. Continuous sample mode TODO.
-pub struct OneShot<'d, const N: usize> {
-    phantom: PhantomData<&'d mut peripherals::SAADC>,
-}
 
 static WAKER: AtomicWaker = AtomicWaker::new();
 
@@ -107,6 +104,11 @@ impl<'d> ChannelConfig<'d> {
             phantom: PhantomData,
         }
     }
+}
+
+/// One-shot SAADC.
+pub struct OneShot<'d, const N: usize> {
+    phantom: PhantomData<&'d mut peripherals::SAADC>,
 }
 
 impl<'d, const N: usize> OneShot<'d, N> {
@@ -222,6 +224,176 @@ impl<'d, const N: usize> OneShot<'d, N> {
 }
 
 impl<'d, const N: usize> Drop for OneShot<'d, N> {
+    fn drop(&mut self) {
+        let r = Self::regs();
+        r.enable.write(|w| w.enable().disabled());
+    }
+}
+
+/// Continuous SAADC.
+pub struct Continuous<'d, const N: usize> {
+    phantom: PhantomData<&'d mut peripherals::SAADC>,
+}
+
+impl<'d, const N: usize> Continuous<'d, N> {
+    pub fn new(
+        _saadc: impl Unborrow<Target = peripherals::SAADC> + 'd,
+        irq: impl Unborrow<Target = interrupt::SAADC> + 'd,
+        config: Config,
+        channel_configs: [ChannelConfig; N],
+    ) -> Self {
+        unborrow!(irq);
+
+        let r = unsafe { &*SAADC::ptr() };
+
+        let Config {
+            resolution,
+            oversample,
+        } = config;
+
+        // Configure channels
+        r.enable.write(|w| w.enable().enabled());
+        r.resolution.write(|w| w.val().variant(resolution));
+        r.oversample.write(|w| w.oversample().variant(oversample));
+
+        for (i, cc) in channel_configs.iter().enumerate() {
+            r.ch[i].pselp.write(|w| w.pselp().variant(cc.p_channel));
+            if let Some(n_channel) = cc.n_channel {
+                r.ch[i]
+                    .pseln
+                    .write(|w| unsafe { w.pseln().bits(n_channel as u8) });
+            }
+            r.ch[i].config.write(|w| {
+                w.refsel().variant(cc.reference);
+                w.gain().variant(cc.gain);
+                w.tacq().variant(cc.time);
+                if cc.n_channel.is_none() {
+                    w.mode().se();
+                } else {
+                    w.mode().diff();
+                }
+                w.resp().variant(cc.resistor);
+                w.resn().bypass();
+                if !matches!(oversample, Oversample::BYPASS) {
+                    w.burst().enabled();
+                } else {
+                    w.burst().disabled();
+                }
+                w
+            });
+        }
+
+        // Disable all events interrupts
+        r.intenclr.write(|w| unsafe { w.bits(0x003F_FFFF) });
+
+        irq.set_handler(Self::on_interrupt);
+        irq.unpend();
+        irq.enable();
+
+        Self {
+            phantom: PhantomData,
+        }
+    }
+
+    fn on_interrupt(_ctx: *mut ()) {
+        let r = Self::regs();
+
+        if r.events_end.read().bits() != 0 {
+            r.intenclr.write(|w| w.end().clear());
+            WAKER.wake();
+
+            // FIXME I think we need to move the IRQ setup into the sample method so that
+            // we can provide it with the raw double buffers and fire off the next sample
+            // request.
+        }
+    }
+
+    fn regs() -> &'static saadc::RegisterBlock {
+        unsafe { &*SAADC::ptr() }
+    }
+
+    /// Start sampling by providing a double buffer and a sample rate expressed in
+    /// terms of 16MHz divided by it e.g. 16_000_000 / 80 = 200_000 samples per second.
+    /// The sample rate ranges from 80..2047.
+    pub fn sample<'b, const N0: usize>(
+        &mut self,
+        buf: &'b mut [[i16; N0]; 2],
+        sample_rate: u16,
+    ) -> ContinuousStream {
+        let r = Self::regs();
+
+        // Set up the DMA
+        r.result
+            .ptr
+            .write(|w| unsafe { w.ptr().bits(buf[0].as_mut_ptr() as u32) });
+        r.result
+            .maxcnt
+            .write(|w| unsafe { w.maxcnt().bits(N0 as _) });
+
+        // Set up the sample rate
+        r.samplerate.write(|w| {
+            unsafe {
+                w.cc().bits(sample_rate);
+                w.mode().bit(true); // FIXME: only set this and the above sample rate when N == 1. If N != 1, we'll need to setup the timer and PPI.
+            }
+            w
+        });
+
+        // Reset and enable the end event
+        r.events_end.reset();
+        r.intenset.write(|w| w.end().set());
+
+        // Don't reorder the ADC start event before the previous writes. Hopefully self
+        // wouldn't happen anyway.
+        compiler_fence(Ordering::SeqCst);
+
+        r.tasks_start.write(|w| unsafe { w.bits(1) });
+        r.tasks_sample.write(|w| unsafe { w.bits(1) });
+
+        ContinuousStream {
+            regs: Self::regs(),
+            phantom: PhantomData,
+        }
+    }
+
+    // FIXME: Provide an explicit stop method?
+}
+
+pub struct ContinuousStream<'b> {
+    regs: &'static saadc::RegisterBlock,
+    phantom: PhantomData<&'b ()>,
+}
+
+impl<'b> Stream for ContinuousStream<'b> {
+    type Item = &'b [i16];
+
+    fn poll_next(
+        self: core::pin::Pin<&mut Self>,
+        cx: &mut core::task::Context<'_>,
+    ) -> Poll<Option<Self::Item>> {
+        let r = self.regs;
+
+        WAKER.register(cx.waker());
+
+        if r.events_end.read().bits() != 0 {
+            r.events_end.reset();
+            return Poll::Ready(Some(unsafe {
+                slice::from_raw_parts(
+                    self.regs.result.ptr.read().bits() as *const i16,
+                    self.regs.result.amount.read().bits() as usize,
+                )
+            }));
+        }
+
+        if r.events_stopped.read().bits() != 0 {
+            return Poll::Ready(None);
+        }
+
+        Poll::Pending
+    }
+}
+
+impl<'d, const N: usize> Drop for Continuous<'d, N> {
     fn drop(&mut self) {
         let r = Self::regs();
         r.enable.write(|w| w.enable().disabled());

--- a/examples/nrf/src/bin/saadc_continuous.rs
+++ b/examples/nrf/src/bin/saadc_continuous.rs
@@ -1,0 +1,28 @@
+#![no_std]
+#![no_main]
+#![feature(type_alias_impl_trait)]
+
+#[path = "../example_common.rs"]
+mod example_common;
+use defmt::panic;
+use embassy::executor::Spawner;
+use embassy_nrf::saadc::{ChannelConfig, Config, Continuous};
+use embassy_nrf::{interrupt, Peripherals};
+use example_common::*;
+use futures::StreamExt;
+
+#[embassy::main]
+async fn main(_spawner: Spawner, mut p: Peripherals) {
+    let config = Config::default();
+    let channel_config = ChannelConfig::single_ended(&mut p.P0_02);
+    let mut saadc = Continuous::new(p.SAADC, interrupt::take!(SAADC), config, [channel_config]);
+
+    let mut double_buf = [[0; 500]; 2]; // A double buffer for 10_000 samples / 1/20th second
+    let mut samples = saadc.sample(&mut double_buf, 1600); // 10_000 samples per second
+    while let Some(buf) = samples.next().await {
+        info!(
+            "samples: {=i16}, {=i16}, {=i16}...",
+            &buf[0], &buf[1], &buf[2]
+        );
+    }
+}


### PR DESCRIPTION
SAADC continuous mode is now supported by offering a new `Continuous` struct alongside the existing `OneShot` one. Its `sample` method returns a `ContinuousStream` (a `futures::Stream`) of buffer samples.

When a single channel is sampled, the internal SAADC timer will be used. For multiple channels, PPI will be configured to wire up the TIMER with SAADC.

A new example is provided to illustrate continuous mode. In summary:

```rust
#[embassy::main]
async fn main(_spawner: Spawner, mut p: Peripherals) {
    let config = Config::default();
    let channel_config = ChannelConfig::single_ended(&mut p.P0_02);
    let mut saadc = Continuous::new(p.SAADC, interrupt::take!(SAADC), config, [channel_config]);

    let mut double_buf = [[0; 500]; 2]; // A double buffer for 10_000 samples / 1/20th second
    let mut samples = saadc.sample(&mut double_buf, 1600); // 10_000 samples per second
    while let Some(buf) = samples.next().await {
        info!(
            "samples: {=i16}, {=i16}, {=i16}...",
            &buf[0], &buf[1], &buf[2]
        );
    }
}
```

TODO:

* [ ] Fire the sample task from the interrupt handler and switch buffers there having filled one buffer
* [ ] Provide a stop method
* [ ] Wire up PPI with the timer where more than one channel is to be sampled