### PR TITLE
interrupt: transmute instead of steal.

### DIFF
--- a/embassy/src/interrupt.rs
+++ b/embassy/src/interrupt.rs
@@ -1,7 +1,7 @@
+use atomic_polyfill::{compiler_fence, AtomicPtr, Ordering};
+use core::mem;
 use core::ptr;
 use cortex_m::peripheral::NVIC;
-
-use atomic_polyfill::{compiler_fence, AtomicPtr, Ordering};
 
 pub use embassy_macros::interrupt_declare as declare;
 pub use embassy_macros::interrupt_take as take;
@@ -124,9 +124,8 @@ impl<T: Interrupt + ?Sized> InterruptExt for T {
     #[inline]
     fn set_priority(&self, prio: Self::Priority) {
         unsafe {
-            cortex_m::peripheral::Peripherals::steal()
-                .NVIC
-                .set_priority(NrWrap(self.number()), prio.into())
+            let mut nvic: cortex_m::peripheral::NVIC = mem::transmute(());
+            nvic.set_priority(NrWrap(self.number()), prio.into())
         }
     }
 }


### PR DESCRIPTION
That steal method has a TAKEN=true write [here](https://github.com/rust-embedded/cortex-m/blob/6b013138b734b9bbeb24a345f75d2bcc1c69fa8d/src/peripheral/mod.rs#L180).
This is not zero cost, we don't want it. Transmute instead, which is zero cost.