### PR TITLE
Prevent overflow in std timer driver

### DIFF
--- a/embassy/src/time/driver_std.rs
+++ b/embassy/src/time/driver_std.rs
@@ -90,7 +90,7 @@ impl TimeDriver {
             // Ensure we don't overflow
             let until = zero
                 .checked_add(StdDuration::from_micros(next_alarm))
-                .unwrap_or(zero + StdDuration::from_secs(1));
+                .unwrap_or_else(|| StdInstant::now() + StdDuration::from_secs(1));
 
             unsafe { DRIVER.signaler.as_ref() }.wait_until(until);
         }


### PR DESCRIPTION
This prevents the std time driver from overflowing when setting the next
wakeup time. If an overflow occurs, default to sleeping up to 1 second.

Fixes #438