### PR TITLE
Use upstream version of rust-lorawan

### DIFF
--- a/embassy-lora/Cargo.toml
+++ b/embassy-lora/Cargo.toml
@@ -29,5 +29,5 @@ futures = { version = "0.3.17", default-features = false, features = [ "async-aw
 embedded-hal = { version = "0.2", features = ["unproven"] }
 bit_field = { version = "0.10" }
 
-lorawan-device = { git = "https://github.com/lulf/rust-lorawan.git", rev = "e529b74421346cb6537f8872d3c8eddcf14804b4", default-features = false, features = ["async"] }
-lorawan-encoding = { git = "https://github.com/lulf/rust-lorawan.git", rev = "e529b74421346cb6537f8872d3c8eddcf14804b4", default-features = false }
+lorawan-device = { git = "https://github.com/ivajloip/rust-lorawan.git", rev = "4bff2e0021103adfbccedcbf49dbcd0474adc4b2", default-features = false, features = ["async"] }
+lorawan-encoding = { git = "https://github.com/ivajloip/rust-lorawan.git", rev = "4bff2e0021103adfbccedcbf49dbcd0474adc4b2", default-features = false }

--- a/examples/stm32l0/Cargo.toml
+++ b/examples/stm32l0/Cargo.toml
@@ -24,8 +24,8 @@ embassy-hal-common = {version = "0.1.0", path = "../../embassy-hal-common" }
 embassy-macros = { path = "../../embassy-macros" }
 
 embassy-lora = { version = "0.1.0", path = "../../embassy-lora", features = ["sx127x", "time"] }
-lorawan-device = { git = "https://github.com/lulf/rust-lorawan.git", rev = "e529b74421346cb6537f8872d3c8eddcf14804b4", default-features = false, features = ["async"] }
-lorawan-encoding = { git = "https://github.com/lulf/rust-lorawan.git", rev = "e529b74421346cb6537f8872d3c8eddcf14804b4", default-features = false, features = ["default-crypto"] }
+lorawan-device = { git = "https://github.com/ivajloip/rust-lorawan.git", rev = "4bff2e0021103adfbccedcbf49dbcd0474adc4b2", default-features = false, features = ["async"] }
+lorawan-encoding = { git = "https://github.com/ivajloip/rust-lorawan.git", rev = "4bff2e0021103adfbccedcbf49dbcd0474adc4b2", default-features = false, features = ["default-crypto"] }
 
 defmt = "0.2.3"
 defmt-rtt = "0.2.0"

--- a/examples/stm32wl55/Cargo.toml
+++ b/examples/stm32wl55/Cargo.toml
@@ -23,8 +23,8 @@ embassy-stm32 = { version = "0.1.0", path = "../../embassy-stm32", features = ["
 embassy-hal-common = {version = "0.1.0", path = "../../embassy-hal-common" }
 embassy-lora = { version = "0.1.0", path = "../../embassy-lora", features = ["stm32wl", "time"] }
 
-lorawan-device = { git = "https://github.com/lulf/rust-lorawan.git", rev = "e529b74421346cb6537f8872d3c8eddcf14804b4", default-features = false, features = ["async"] }
-lorawan-encoding = { git = "https://github.com/lulf/rust-lorawan.git", rev = "e529b74421346cb6537f8872d3c8eddcf14804b4", default-features = false, features = ["default-crypto"] }
+lorawan-device = { git = "https://github.com/ivajloip/rust-lorawan.git", rev = "4bff2e0021103adfbccedcbf49dbcd0474adc4b2", default-features = false, features = ["async"] }
+lorawan-encoding = { git = "https://github.com/ivajloip/rust-lorawan.git", rev = "4bff2e0021103adfbccedcbf49dbcd0474adc4b2", default-features = false, features = ["default-crypto"] }
 
 defmt = "0.2.3"
 defmt-rtt = "0.2.0"


### PR DESCRIPTION
The async device has been merged, so dependency can be updated to commit on the upstream master branch.