### PR TITLE
Dummy pin implementation for Saadc internal vdd sampling

### DIFF
--- a/embassy-nrf/src/saadc.rs
+++ b/embassy-nrf/src/saadc.rs
@@ -78,6 +78,29 @@ pub struct ChannelConfig<'d> {
     phantom: PhantomData<&'d ()>,
 }
 
+/// A dummy `Input` pin implementation for SAADC peripheral sampling from the
+/// internal voltage.
+pub struct VddInput;
+
+unsafe impl Unborrow for VddInput {
+    type Target = VddInput;
+    unsafe fn unborrow(self) -> Self::Target {
+        self
+    }
+}
+
+impl sealed::Input for VddInput {
+    #[cfg(not(feature = "nrf9160"))]
+    fn channel(&self) -> InputChannel {
+        InputChannel::VDD
+    }
+    #[cfg(feature = "nrf9160")]
+    fn channel(&self) -> InputChannel {
+        InputChannel::VDDGPIO
+    }
+}
+impl Input for VddInput {}
+
 impl<'d> ChannelConfig<'d> {
     /// Default configuration for single ended channel sampling.
     pub fn single_ended(input: impl Unborrow<Target = impl Input> + 'd) -> Self {


### PR DESCRIPTION
For instance, for reading the battery input voltage on the nrf
Api ends up looking like
`let channel_config = saadc::ChannelConfig::single_ended(saadc::VddInput::default());`

I ~haven't confirmed a sane reading yet~, but this compiles so is ready for bikeshedding
Update: It looks like Ive got sane readings