### PR TITLE
Add the `embassy_traits::i2c::WriteIter` trait

### DIFF
--- a/embassy-traits/src/i2c.rs
+++ b/embassy-traits/src/i2c.rs
@@ -176,9 +176,9 @@ pub trait WriteIter<A: AddressMode = SevenBitAddress> {
     /// Error type
     type Error;
 
-    type WriteIterFuture<'a, U>: Future<Output = Result<(), Self::Error>> + 'a
+    type WriteIterFuture<'a, V>: Future<Output = Result<(), Self::Error>> + 'a
     where
-        U: 'a,
+        V: 'a + IntoIterator<Item = u8>,
         Self: 'a;
 
     /// Sends bytes to slave with address `address`

--- a/embassy-traits/src/i2c.rs
+++ b/embassy-traits/src/i2c.rs
@@ -171,3 +171,22 @@ pub trait I2c<A: AddressMode = SevenBitAddress> {
         buffer: &'a mut [u8],
     ) -> Self::WriteReadFuture<'a>;
 }
+
+pub trait WriteIter<A: AddressMode = SevenBitAddress> {
+    /// Error type
+    type Error;
+
+    type WriteIterFuture<'a, U>: Future<Output = Result<(), Self::Error>> + 'a
+    where
+        U: 'a,
+        Self: 'a;
+
+    /// Sends bytes to slave with address `address`
+    ///
+    /// # I2C Events (contract)
+    ///
+    /// Same as `I2c::write`
+    fn write_iter<'a, U>(&'a mut self, address: A, bytes: U) -> Self::WriteIterFuture<'a, U>
+    where
+        U: IntoIterator<Item = u8> + 'a;
+}


### PR DESCRIPTION
This trait makes the parallel with `embedded_hal::i2c::WriteIter`.

It allows to fetch bytes to write from an Iterator rather than requiring an allocation for an array.

It is provided as an extra Trait to avoid breaking existing implementations of `embassy_traits::i2c::I2c`.