### PR TITLE
docs: fix some `cargo doc` warnings

### DIFF
--- a/embassy/src/blocking_mutex/mod.rs
+++ b/embassy/src/blocking_mutex/mod.rs
@@ -7,7 +7,7 @@ use critical_section::CriticalSection;
 
 /// Any object implementing this trait guarantees exclusive access to the data contained
 /// within the mutex for the duration of the lock.
-/// Adapted from https://github.com/rust-embedded/mutex-trait.
+/// Adapted from <https://github.com/rust-embedded/mutex-trait>.
 pub trait Mutex {
     /// Data protected by the mutex.
     type Data;

--- a/embassy/src/channel/mpsc.rs
+++ b/embassy/src/channel/mpsc.rs
@@ -35,7 +35,7 @@
 //! consumes the channel to completion, at which point the receiver can be
 //! dropped.
 //!
-//! This channel and its associated types were derived from https://docs.rs/tokio/0.1.22/tokio/sync/mpsc/fn.channel.html
+//! This channel and its associated types were derived from <https://docs.rs/tokio/0.1.22/tokio/sync/mpsc/fn.channel.html>
 
 use core::cell::RefCell;
 use core::fmt;
@@ -259,8 +259,8 @@ where
     /// [`Receiver`] is dropped, or when the [`Receiver::close`] method is
     /// called.
     ///
-    /// [`Receiver`]: crate::sync::mpsc::Receiver
-    /// [`Receiver::close`]: crate::sync::mpsc::Receiver::close
+    /// [`Receiver`]: Receiver
+    /// [`Receiver::close`]: Receiver::close
     pub fn is_closed(&self) -> bool {
         self.channel.lock(|c| c.is_closed())
     }
@@ -342,7 +342,7 @@ where
 
 /// An error returned from the [`try_recv`] method.
 ///
-/// [`try_recv`]: super::Receiver::try_recv
+/// [`try_recv`]: Receiver::try_recv
 #[derive(PartialEq, Eq, Clone, Copy, Debug)]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub enum TryRecvError {
@@ -371,7 +371,7 @@ impl<T> defmt::Format for SendError<T> {
 }
 
 /// This enumeration is the list of the possible error outcomes for the
-/// [try_send](super::Sender::try_send) method.
+/// [try_send](Sender::try_send) method.
 #[derive(Debug)]
 pub enum TrySendError<T> {
     /// The data could not be sent on the channel because the channel is

--- a/embassy/src/executor/spawner.rs
+++ b/embassy/src/executor/spawner.rs
@@ -77,7 +77,7 @@ impl Spawner {
 
     /// Spawn a task into an executor.
     ///
-    /// You obtain the `token` by calling a task function (i.e. one marked with `#[embassy::task]).
+    /// You obtain the `token` by calling a task function (i.e. one marked with `#[embassy::task]`).
     pub fn spawn<F>(&self, token: SpawnToken<F>) -> Result<(), SpawnError> {
         let task = token.raw_task;
         mem::forget(token);
@@ -129,7 +129,7 @@ unsafe impl Sync for SendSpawner {}
 impl SendSpawner {
     /// Spawn a task into an executor.
     ///
-    /// You obtain the `token` by calling a task function (i.e. one marked with `#[embassy::task]).
+    /// You obtain the `token` by calling a task function (i.e. one marked with `#[embassy::task]`).
     pub fn spawn<F: Send>(&self, token: SpawnToken<F>) -> Result<(), SpawnError> {
         let header = token.raw_task;
         mem::forget(token);


### PR DESCRIPTION
There are still 3 warnings (below)

```
 Documenting embassy v0.1.0 (embassy)
warning: unresolved link to `channel`
   --> src/channel/mpsc.rs:241:22
    |
241 |     /// [`channel`]: channel
    |                      ^^^^^^^ no item named `channel` in scope
    |
    = note: `#[warn(rustdoc::broken_intra_doc_links)]` on by default
    = help: to escape `[` and `]` characters, add '\' before them like `\[` or `\]`

warning: unresolved link to `Task::spawn`
   --> src/executor/raw/mod.rs:105:12
    |
105 | /// with [`Task::spawn()`], which will fail if it is already spawned.
    |            ^^^^^^^^^^^^^ no item named `Task` in scope

warning: public documentation for `spawn` links to private item `Executor::spawn`
   --> src/executor/raw/mod.rs:156:17
    |
156 |     /// cause [`Executor::spawn()`] to return the error.
    |                 ^^^^^^^^^^^^^^^^^ this item is private
    |
    = note: `#[warn(rustdoc::private_intra_doc_links)]` on by default
    = note: this link will resolve properly if you pass `--document-private-items`

warning: `embassy` (lib doc) generated 3 warnings
```