### PR TITLE
Add MCO peripheral.

### DIFF
--- a/examples/stm32h7/src/bin/mco.rs
+++ b/examples/stm32h7/src/bin/mco.rs
@@ -1,0 +1,32 @@
+#![no_std]
+#![no_main]
+#![feature(type_alias_impl_trait)]
+
+#[path = "../example_common.rs"]
+mod example_common;
+use embassy::executor::Spawner;
+use embassy::time::{Duration, Timer};
+use embassy_stm32::gpio::{Level, Output, Speed};
+use embassy_stm32::rcc::{Mco, Mco1Source, McoClock};
+use embassy_stm32::Peripherals;
+use embedded_hal::digital::v2::OutputPin;
+use example_common::*;
+
+#[embassy::main]
+async fn main(_spawner: Spawner, p: Peripherals) {
+    info!("Hello World!");
+
+    let mut led = Output::new(p.PB14, Level::High, Speed::Low);
+
+    let _mco = Mco::new(p.MCO1, p.PA8, Mco1Source::Hsi, McoClock::Divided(8));
+
+    loop {
+        info!("high");
+        unwrap!(led.set_high());
+        Timer::after(Duration::from_millis(500)).await;
+
+        info!("low");
+        unwrap!(led.set_low());
+        Timer::after(Duration::from_millis(500)).await;
+    }
+}


### PR DESCRIPTION
This PR adds an abstraction over STM32 RCC feature called MCO (Microcontroller Clock Output). The clock output can bind to several clock sources and then can be scaled using a prescaler.

Given that from the embassy ecosystem the RCC is generaly invisible to the user, the MCO was implemented as a separate peripheral bound to the pin where the clock should appear.