### PR TITLE
Combine into one Pwm type

### DIFF
--- a/embassy-nrf/src/pwm.rs
+++ b/embassy-nrf/src/pwm.rs
@@ -44,14 +44,14 @@ impl<'d, T: Instance> Pwm<'d, T> {
     /// mechanisms) on stack allocated buffers which which have been passed to
     /// [`new()`](Pwm::new).
     #[allow(unused_unsafe)]
-    pub fn new<'a>(
+    pub fn new(
         _pwm: impl Unborrow<Target = T> + 'd,
         ch0: impl Unborrow<Target = impl GpioOptionalPin> + 'd,
         ch1: impl Unborrow<Target = impl GpioOptionalPin> + 'd,
         ch2: impl Unborrow<Target = impl GpioOptionalPin> + 'd,
         ch3: impl Unborrow<Target = impl GpioOptionalPin> + 'd,
         config: Config,
-        sequence: &'a [u16],
+        sequence: &'d [u16],
     ) -> Result<Self, Error> {
         slice_in_ram_or(sequence, Error::DMABufferNotInDataMemory)?;
 

--- a/examples/nrf/src/bin/pwm.rs
+++ b/examples/nrf/src/bin/pwm.rs
@@ -87,28 +87,22 @@ static DUTY: [u16; 1024] = [
 async fn main(_spawner: Spawner, p: Peripherals) {
     let mut config = Config::default();
     config.prescaler = Prescaler::Div1;
-    // 1 period is 32767 * 1/16mhz = 0.002047938 = 2.047938ms
     config.top = 32767;
     config.sequence_load = SequenceLoad::Individual;
-    // pwm example is delaying >~3ms before updating duty cycle, our refreshes
-    // happen exactly at 2.047938ms so we need a delay after each value of >~1ms
-    // which for us is ~1-2 periods
-    config.refresh = 3;
 
     let mut duty = [0; 4];
-    let pwm = unwrap!(Pwm::new(
-        p.PWM0, p.P0_13, p.P0_14, p.P0_16, p.P0_15, config, &duty
+    let mut pwm = unwrap!(Pwm::new(
+        p.PWM0, p.P0_13, p.P0_14, p.P0_16, p.P0_15, config, &mut duty
     ));
-    let _ = pwm.start(SequenceMode::Infinite);
     info!("pwm initialized!");
 
     let mut i = 0;
     loop {
         i += 1;
-        duty[0] = DUTY[i % 1024];
-        duty[1] = DUTY[(i + 256) % 1024];
-        duty[2] = DUTY[(i + 512) % 1024];
-        duty[3] = DUTY[(i + 768) % 1024];
+        pwm.set_duty(0, DUTY[i % 1024]);
+        pwm.set_duty(1, DUTY[(i + 256) % 1024]);
+        pwm.set_duty(2, DUTY[(i + 512) % 1024]);
+        pwm.set_duty(3, DUTY[(i + 768) % 1024]);
         Timer::after(Duration::from_millis(3)).await;
     }
 }

--- a/examples/nrf/src/bin/pwm.rs
+++ b/examples/nrf/src/bin/pwm.rs
@@ -7,7 +7,7 @@ mod example_common;
 use defmt::*;
 use embassy::executor::Spawner;
 use embassy::time::{Duration, Timer};
-use embassy_nrf::pwm::{Prescaler, SimplePwm};
+use embassy_nrf::pwm::{Config, Prescaler, Pwm, SequenceLoad, SequenceMode};
 use embassy_nrf::Peripherals;
 
 // for i in range(1024): print(int((math.sin(i/512*math.pi)*0.4+0.5)**2*32767), ', ', end='')
@@ -85,18 +85,30 @@ static DUTY: [u16; 1024] = [
 
 #[embassy::main]
 async fn main(_spawner: Spawner, p: Peripherals) {
-    let mut pwm = SimplePwm::new(p.PWM0, p.P0_13, p.P0_14, p.P0_16, p.P0_15);
-    pwm.set_prescaler(Prescaler::Div1);
-    pwm.set_max_duty(32767);
+    let mut config = Config::default();
+    config.prescaler = Prescaler::Div1;
+    // 1 period is 32767 * 1/16mhz = 0.002047938 = 2.047938ms
+    config.top = 32767;
+    config.sequence_load = SequenceLoad::Individual;
+    // pwm example is delaying >~3ms before updating duty cycle, our refreshes
+    // happen exactly at 2.047938ms so we need a delay after each value of >~1ms
+    // which for us is ~1-2 periods
+    config.refresh = 3;
+
+    let mut duty = [0; 4];
+    let pwm = unwrap!(Pwm::new(
+        p.PWM0, p.P0_13, p.P0_14, p.P0_16, p.P0_15, config, &duty
+    ));
+    let _ = pwm.start(SequenceMode::Infinite);
     info!("pwm initialized!");
 
     let mut i = 0;
     loop {
         i += 1;
-        pwm.set_duty(0, DUTY[i % 1024]);
-        pwm.set_duty(1, DUTY[(i + 256) % 1024]);
-        pwm.set_duty(2, DUTY[(i + 512) % 1024]);
-        pwm.set_duty(3, DUTY[(i + 768) % 1024]);
+        duty[0] = DUTY[i % 1024];
+        duty[1] = DUTY[(i + 256) % 1024];
+        duty[2] = DUTY[(i + 512) % 1024];
+        duty[3] = DUTY[(i + 768) % 1024];
         Timer::after(Duration::from_millis(3)).await;
     }
 }

--- a/examples/nrf/src/bin/pwm.rs
+++ b/examples/nrf/src/bin/pwm.rs
@@ -7,7 +7,7 @@ mod example_common;
 use defmt::*;
 use embassy::executor::Spawner;
 use embassy::time::{Duration, Timer};
-use embassy_nrf::pwm::{Config, Prescaler, Pwm, SequenceLoad, SequenceMode};
+use embassy_nrf::pwm::{Config, Prescaler, Pwm, SequenceLoad};
 use embassy_nrf::Peripherals;
 
 // for i in range(1024): print(int((math.sin(i/512*math.pi)*0.4+0.5)**2*32767), ', ', end='')

--- a/examples/nrf/src/bin/pwm_led.rs
+++ b/examples/nrf/src/bin/pwm_led.rs
@@ -13,7 +13,7 @@ use embassy_nrf::Peripherals;
 
 #[embassy::main]
 async fn main(_spawner: Spawner, p: Peripherals) {
-    let seq_values: [u16; 5] = [1000, 250, 100, 50, 0];
+    let mut seq_values: [u16; 5] = [1000, 250, 100, 50, 0];
 
     let mut config = Config::default();
     config.prescaler = Prescaler::Div128;
@@ -28,7 +28,7 @@ async fn main(_spawner: Spawner, p: Peripherals) {
         NoPin,
         NoPin,
         config,
-        &seq_values
+        &mut seq_values
     ));
     let _ = pwm.start(SequenceMode::Infinite);
 

--- a/examples/nrf/src/bin/pwm_led.rs
+++ b/examples/nrf/src/bin/pwm_led.rs
@@ -13,40 +13,27 @@ use embassy_nrf::Peripherals;
 
 #[embassy::main]
 async fn main(_spawner: Spawner, p: Peripherals) {
-    let mut config = Config::default();
-    // set_period doesnt actually set what you give it, because it only has a
-    // few options from the hardhware so be explicit instead
-    // Div128 is slowest, 125khz still crazy fast for our eyes
-    config.prescaler = Prescaler::Div128;
+    let seq_values: [u16; 5] = [1000, 250, 100, 50, 0];
 
-    let mut duty = [0; 1];
+    let mut config = Config::default();
+    config.prescaler = Prescaler::Div128;
+    // 1 period is 1000 * 1/16mhz/128 =0.000008= 0.008ms
+    config.refresh = 625; // Why am I off by like a factor of 1000?
+
     let pwm = unwrap!(Pwm::new(
-        p.PWM0, p.P0_13, NoPin, NoPin, NoPin, config, &duty
+        p.PWM0,
+        p.P0_13,
+        NoPin,
+        NoPin,
+        NoPin,
+        config,
+        &seq_values
     ));
     let _ = pwm.start(SequenceMode::Infinite);
-    info!("pwm initialized!");
 
-    // default max_duty if not specified is 1000
-    // so 0 would be fully off and 1000 or above would be fully on
+    info!("pwm started!");
+
     loop {
-        info!("100%");
-        duty[0] = 1000;
-        Timer::after(Duration::from_millis(5000)).await;
-
-        info!("25%");
-        duty[0] = 250;
-        Timer::after(Duration::from_millis(5000)).await;
-
-        info!("10%");
-        duty[0] = 100;
-        Timer::after(Duration::from_millis(5000)).await;
-
-        info!("5%");
-        duty[0] = 50;
-        Timer::after(Duration::from_millis(5000)).await;
-
-        info!("0%");
-        duty[0] = 0;
         Timer::after(Duration::from_millis(5000)).await;
     }
 }

--- a/examples/nrf/src/bin/pwm_led.rs
+++ b/examples/nrf/src/bin/pwm_led.rs
@@ -8,40 +8,45 @@ use defmt::*;
 use embassy::executor::Spawner;
 use embassy::time::{Duration, Timer};
 use embassy_nrf::gpio::NoPin;
-use embassy_nrf::pwm::{Prescaler, SimplePwm};
+use embassy_nrf::pwm::{Config, Prescaler, Pwm, SequenceMode};
 use embassy_nrf::Peripherals;
 
 #[embassy::main]
 async fn main(_spawner: Spawner, p: Peripherals) {
-    let mut pwm = SimplePwm::new(p.PWM0, p.P0_13, NoPin, NoPin, NoPin);
+    let mut config = Config::default();
     // set_period doesnt actually set what you give it, because it only has a
     // few options from the hardhware so be explicit instead
     // Div128 is slowest, 125khz still crazy fast for our eyes
-    pwm.set_prescaler(Prescaler::Div128);
+    config.prescaler = Prescaler::Div128;
 
+    let mut duty = [0; 1];
+    let pwm = unwrap!(Pwm::new(
+        p.PWM0, p.P0_13, NoPin, NoPin, NoPin, config, &duty
+    ));
+    let _ = pwm.start(SequenceMode::Infinite);
     info!("pwm initialized!");
 
     // default max_duty if not specified is 1000
     // so 0 would be fully off and 1000 or above would be fully on
     loop {
         info!("100%");
-        pwm.set_duty(0, 1000);
+        duty[0] = 1000;
         Timer::after(Duration::from_millis(5000)).await;
 
         info!("25%");
-        pwm.set_duty(0, 250);
+        duty[0] = 250;
         Timer::after(Duration::from_millis(5000)).await;
 
         info!("10%");
-        pwm.set_duty(0, 100);
+        duty[0] = 100;
         Timer::after(Duration::from_millis(5000)).await;
 
         info!("5%");
-        pwm.set_duty(0, 50);
+        duty[0] = 50;
         Timer::after(Duration::from_millis(5000)).await;
 
         info!("0%");
-        pwm.set_duty(0, 0);
+        duty[0] = 0;
         Timer::after(Duration::from_millis(5000)).await;
     }
 }

--- a/examples/nrf/src/bin/pwm_led.rs
+++ b/examples/nrf/src/bin/pwm_led.rs
@@ -17,8 +17,9 @@ async fn main(_spawner: Spawner, p: Peripherals) {
 
     let mut config = Config::default();
     config.prescaler = Prescaler::Div128;
-    // 1 period is 1000 * 1/16mhz/128 =0.000008= 0.008ms
-    config.refresh = 625; // Why am I off by like a factor of 1000?
+    // 1 period is 1000 * (128/16mhz =0.000008 = 0.008ms) = 8ms
+    // 5000ms wait = 5000/8 = 625
+    config.refresh = 625;
 
     let pwm = unwrap!(Pwm::new(
         p.PWM0,

--- a/examples/nrf/src/bin/pwm_sequence.rs
+++ b/examples/nrf/src/bin/pwm_sequence.rs
@@ -14,7 +14,7 @@ use embassy_nrf::Peripherals;
 #[embassy::main]
 async fn main(_spawner: Spawner, p: Peripherals) {
     // for i in range(1024): print(int((math.sin(i/512*math.pi)*0.4+0.5)**2*32767), ', ', end='')
-    let seq_values: [u16; 1024] = [
+    let mut seq_values: [u16; 1024] = [
         8191, 8272, 8353, 8434, 8516, 8598, 8681, 8764, 8847, 8931, 9015, 9099, 9184, 9269, 9354,
         9440, 9526, 9613, 9700, 9787, 9874, 9962, 10050, 10139, 10227, 10316, 10406, 10495, 10585,
         10675, 10766, 10857, 10948, 11039, 11131, 11223, 11315, 11407, 11500, 11592, 11685, 11779,
@@ -104,7 +104,7 @@ async fn main(_spawner: Spawner, p: Peripherals) {
         NoPin,
         NoPin,
         config,
-        &seq_values
+        &mut seq_values
     ));
     let _ = pwm.start(SequenceMode::Infinite);
     info!("pwm started!");

--- a/examples/nrf/src/bin/pwm_sequence.rs
+++ b/examples/nrf/src/bin/pwm_sequence.rs
@@ -8,7 +8,7 @@ use defmt::*;
 use embassy::executor::Spawner;
 use embassy::time::{Duration, Timer};
 use embassy_nrf::gpio::NoPin;
-use embassy_nrf::pwm::{Prescaler, SequenceConfig, SequenceMode, SequencePwm};
+use embassy_nrf::pwm::{Config, Prescaler, Pwm, SequenceMode};
 use embassy_nrf::Peripherals;
 
 #[embassy::main]
@@ -88,7 +88,7 @@ async fn main(_spawner: Spawner, p: Peripherals) {
         7255, 7331, 7407, 7484, 7561, 7638, 7716, 7794, 7873, 7952, 8031, 8111,
     ];
 
-    let mut config = SequenceConfig::default();
+    let mut config = Config::default();
     config.prescaler = Prescaler::Div1;
     // 1 period is 32767 * 1/16mhz = 0.002047938 = 2.047938ms
     config.top = 32767;
@@ -97,7 +97,7 @@ async fn main(_spawner: Spawner, p: Peripherals) {
     // which for us is ~1-2 periods
     config.refresh = 3;
 
-    let pwm = unwrap!(SequencePwm::new(
+    let pwm = unwrap!(Pwm::new(
         p.PWM0,
         p.P0_13,
         NoPin,

--- a/examples/nrf/src/bin/pwm_servo.rs
+++ b/examples/nrf/src/bin/pwm_servo.rs
@@ -8,7 +8,7 @@ use defmt::*;
 use embassy::executor::Spawner;
 use embassy::time::{Duration, Timer};
 use embassy_nrf::gpio::NoPin;
-use embassy_nrf::pwm::{Config, Prescaler, Pwm, SequenceMode};
+use embassy_nrf::pwm::{Config, Prescaler, Pwm};
 use embassy_nrf::Peripherals;
 
 #[embassy::main]

--- a/examples/nrf/src/bin/pwm_servo.rs
+++ b/examples/nrf/src/bin/pwm_servo.rs
@@ -18,13 +18,12 @@ async fn main(_spawner: Spawner, p: Peripherals) {
     // set_period can only set down to 125khz so we cant use it directly
     // Div128 is 125khz or 0.000008s or 0.008ms, 20/0.008 is 2500 is top
     config.prescaler = Prescaler::Div128;
-    config.top = 25000;
+    config.top = 2500;
 
     let mut duty = [0];
     let mut pwm = unwrap!(Pwm::new(
         p.PWM0, p.P0_05, NoPin, NoPin, NoPin, config, &mut duty
     ));
-    let _ = pwm.start(SequenceMode::Infinite);
     info!("pwm initialized!");
 
     Timer::after(Duration::from_millis(5000)).await;

--- a/examples/nrf/src/bin/pwm_servo.rs
+++ b/examples/nrf/src/bin/pwm_servo.rs
@@ -21,8 +21,8 @@ async fn main(_spawner: Spawner, p: Peripherals) {
     config.top = 25000;
 
     let mut duty = [0];
-    let pwm = unwrap!(Pwm::new(
-        p.PWM0, p.P0_05, NoPin, NoPin, NoPin, config, &duty
+    let mut pwm = unwrap!(Pwm::new(
+        p.PWM0, p.P0_05, NoPin, NoPin, NoPin, config, &mut duty
     ));
     let _ = pwm.start(SequenceMode::Infinite);
     info!("pwm initialized!");
@@ -32,23 +32,23 @@ async fn main(_spawner: Spawner, p: Peripherals) {
     // 1ms 0deg (1/.008=125), 1.5ms 90deg (1.5/.008=187.5), 2ms 180deg (2/.008=250),
     loop {
         info!("45 deg");
-        duty[0] = 2500 - 156;
+        pwm.set_duty(0, 2500 - 156);
         Timer::after(Duration::from_millis(5000)).await;
 
         info!("90 deg");
-        duty[0] = 2500 - 187;
+        pwm.set_duty(0, 2500 - 187);
         Timer::after(Duration::from_millis(5000)).await;
 
         info!("135 deg");
-        duty[0] = 2500 - 218;
+        pwm.set_duty(0, 2500 - 218);
         Timer::after(Duration::from_millis(5000)).await;
 
         info!("180 deg");
-        duty[0] = 2500 - 250;
+        pwm.set_duty(0, 2500 - 250);
         Timer::after(Duration::from_millis(5000)).await;
 
         info!("0 deg");
-        duty[0] = 2500 - 125;
+        pwm.set_duty(0, 2500 - 125);
         Timer::after(Duration::from_millis(5000)).await;
     }
 }

--- a/examples/nrf/src/bin/pwm_servo.rs
+++ b/examples/nrf/src/bin/pwm_servo.rs
@@ -8,17 +8,23 @@ use defmt::*;
 use embassy::executor::Spawner;
 use embassy::time::{Duration, Timer};
 use embassy_nrf::gpio::NoPin;
-use embassy_nrf::pwm::{Prescaler, SimplePwm};
+use embassy_nrf::pwm::{Config, Prescaler, Pwm, SequenceMode};
 use embassy_nrf::Peripherals;
 
 #[embassy::main]
 async fn main(_spawner: Spawner, p: Peripherals) {
-    let mut pwm = SimplePwm::new(p.PWM0, p.P0_05, NoPin, NoPin, NoPin);
+    let mut config = Config::default();
     // sg90 microervo requires 50hz or 20ms period
     // set_period can only set down to 125khz so we cant use it directly
     // Div128 is 125khz or 0.000008s or 0.008ms, 20/0.008 is 2500 is top
-    pwm.set_prescaler(Prescaler::Div128);
-    pwm.set_max_duty(2500);
+    config.prescaler = Prescaler::Div128;
+    config.top = 25000;
+
+    let mut duty = [0];
+    let pwm = unwrap!(Pwm::new(
+        p.PWM0, p.P0_05, NoPin, NoPin, NoPin, config, &duty
+    ));
+    let _ = pwm.start(SequenceMode::Infinite);
     info!("pwm initialized!");
 
     Timer::after(Duration::from_millis(5000)).await;
@@ -26,23 +32,23 @@ async fn main(_spawner: Spawner, p: Peripherals) {
     // 1ms 0deg (1/.008=125), 1.5ms 90deg (1.5/.008=187.5), 2ms 180deg (2/.008=250),
     loop {
         info!("45 deg");
-        pwm.set_duty(0, 2500 - 156);
+        duty[0] = 2500 - 156;
         Timer::after(Duration::from_millis(5000)).await;
 
         info!("90 deg");
-        pwm.set_duty(0, 2500 - 187);
+        duty[0] = 2500 - 187;
         Timer::after(Duration::from_millis(5000)).await;
 
         info!("135 deg");
-        pwm.set_duty(0, 2500 - 218);
+        duty[0] = 2500 - 218;
         Timer::after(Duration::from_millis(5000)).await;
 
         info!("180 deg");
-        pwm.set_duty(0, 2500 - 250);
+        duty[0] = 2500 - 250;
         Timer::after(Duration::from_millis(5000)).await;
 
         info!("0 deg");
-        pwm.set_duty(0, 2500 - 125);
+        duty[0] = 2500 - 125;
         Timer::after(Duration::from_millis(5000)).await;
     }
 }


### PR DESCRIPTION
The existing nRF HAL name of `SimplePwm` does not appear to correlate with existing nRF terminology. This PR converts all examples to the `SequencePwm` struct, renames it to `Pwm` and then removes `SimplePwm`.

The changes to the examples to support "simple PWM" are minimal. One example:

```rust
    let mut config = Config::default();
    config.prescaler = Prescaler::Div1;
    config.top = 32767;
    config.sequence_load = SequenceLoad::Individual;

    let mut duty = [0; 4];
    let mut pwm = unwrap!(Pwm::new(
        p.PWM0, p.P0_13, p.P0_14, p.P0_16, p.P0_15, config, &mut duty
    ));
    info!("pwm initialized!");

    let mut i = 0;
    loop {
        i += 1;
        pwm.set_duty(0, DUTY[i % 1024]);
        pwm.set_duty(1, DUTY[(i + 256) % 1024]);
        pwm.set_duty(2, DUTY[(i + 512) % 1024]);
        pwm.set_duty(3, DUTY[(i + 768) % 1024]);
        Timer::after(Duration::from_millis(3)).await;
    }
```
