### PR TITLE
Rename SimplePwm to SimplifiedPwm

### DIFF
--- a/embassy-nrf/src/saadc.rs
+++ b/embassy-nrf/src/saadc.rs
@@ -29,7 +29,7 @@ pub use saadc::{
 #[non_exhaustive]
 pub enum Error {}
 
-/// One-shot saadc. Continuous sample mode TODO.
+/// One-shot and continuous SAADC.
 pub struct Saadc<'d, const N: usize> {
     phantom: PhantomData<&'d mut peripherals::SAADC>,
 }

--- a/examples/nrf/src/bin/pwm.rs
+++ b/examples/nrf/src/bin/pwm.rs
@@ -7,7 +7,7 @@ mod example_common;
 use defmt::*;
 use embassy::executor::Spawner;
 use embassy::time::{Duration, Timer};
-use embassy_nrf::pwm::{Prescaler, SimplePwm};
+use embassy_nrf::pwm::{Prescaler, SimplifiedPwm};
 use embassy_nrf::Peripherals;
 
 // for i in range(1024): print(int((math.sin(i/512*math.pi)*0.4+0.5)**2*32767), ', ', end='')
@@ -85,7 +85,7 @@ static DUTY: [u16; 1024] = [
 
 #[embassy::main]
 async fn main(_spawner: Spawner, p: Peripherals) {
-    let mut pwm = SimplePwm::new(p.PWM0, p.P0_13, p.P0_14, p.P0_16, p.P0_15);
+    let mut pwm = SimplifiedPwm::new(p.PWM0, p.P0_13, p.P0_14, p.P0_16, p.P0_15);
     pwm.set_prescaler(Prescaler::Div1);
     pwm.set_max_duty(32767);
     info!("pwm initialized!");

--- a/examples/nrf/src/bin/pwm_led.rs
+++ b/examples/nrf/src/bin/pwm_led.rs
@@ -8,40 +8,33 @@ use defmt::*;
 use embassy::executor::Spawner;
 use embassy::time::{Duration, Timer};
 use embassy_nrf::gpio::NoPin;
-use embassy_nrf::pwm::{Prescaler, SimplePwm};
+use embassy_nrf::pwm::{Prescaler, SequenceConfig, SequenceMode, SequencePwm};
 use embassy_nrf::Peripherals;
 
 #[embassy::main]
 async fn main(_spawner: Spawner, p: Peripherals) {
-    let mut pwm = SimplePwm::new(p.PWM0, p.P0_13, NoPin, NoPin, NoPin);
-    // set_period doesnt actually set what you give it, because it only has a
-    // few options from the hardhware so be explicit instead
-    // Div128 is slowest, 125khz still crazy fast for our eyes
-    pwm.set_prescaler(Prescaler::Div128);
+    let seq_values: [u16; 5] = [1000, 250, 100, 50, 0];
 
-    info!("pwm initialized!");
+    let mut config = SequenceConfig::default();
+    config.prescaler = Prescaler::Div128;
+    // 1 period is 1000 * (128/16mhz =0.000008s = 0.008ms) = 8ms
+    // 5000ms wait = 5000/8 = 625
+    config.refresh = 625;
 
-    // default max_duty if not specified is 1000
-    // so 0 would be fully off and 1000 or above would be fully on
+    let pwm = unwrap!(SequencePwm::new(
+        p.PWM0,
+        p.P0_13,
+        NoPin,
+        NoPin,
+        NoPin,
+        config,
+        &seq_values
+    ));
+    let _ = pwm.start(SequenceMode::Infinite);
+
+    info!("pwm started!");
+
     loop {
-        info!("100%");
-        pwm.set_duty(0, 1000);
-        Timer::after(Duration::from_millis(5000)).await;
-
-        info!("25%");
-        pwm.set_duty(0, 250);
-        Timer::after(Duration::from_millis(5000)).await;
-
-        info!("10%");
-        pwm.set_duty(0, 100);
-        Timer::after(Duration::from_millis(5000)).await;
-
-        info!("5%");
-        pwm.set_duty(0, 50);
-        Timer::after(Duration::from_millis(5000)).await;
-
-        info!("0%");
-        pwm.set_duty(0, 0);
         Timer::after(Duration::from_millis(5000)).await;
     }
 }

--- a/examples/nrf/src/bin/pwm_servo.rs
+++ b/examples/nrf/src/bin/pwm_servo.rs
@@ -8,12 +8,12 @@ use defmt::*;
 use embassy::executor::Spawner;
 use embassy::time::{Duration, Timer};
 use embassy_nrf::gpio::NoPin;
-use embassy_nrf::pwm::{Prescaler, SimplePwm};
+use embassy_nrf::pwm::{Prescaler, SimplifiedPwm};
 use embassy_nrf::Peripherals;
 
 #[embassy::main]
 async fn main(_spawner: Spawner, p: Peripherals) {
-    let mut pwm = SimplePwm::new(p.PWM0, p.P0_05, NoPin, NoPin, NoPin);
+    let mut pwm = SimplifiedPwm::new(p.PWM0, p.P0_05, NoPin, NoPin, NoPin);
     // sg90 microervo requires 50hz or 20ms period
     // set_period can only set down to 125khz so we cant use it directly
     // Div128 is 125khz or 0.000008s or 0.008ms, 20/0.008 is 2500 is top


### PR DESCRIPTION
I feel that renaming to `SimplifiedPwm` is more accurate - PWM isn't necessarily simple.

Also, provided an improved pwm_led example from Jacob Rosenthal leveraging sequences.

Lastly, an `enabled` method was missing and a buffer was incorrectly written to a register.