### PR TITLE
nrf/gpiote: remove PortInput, move impls to Input/FlexPin.

### DIFF
--- a/examples/nrf/src/bin/gpiote_port.rs
+++ b/examples/nrf/src/bin/gpiote_port.rs
@@ -8,12 +8,11 @@ mod example_common;
 use embassy::executor::Spawner;
 use embassy::traits::gpio::{WaitForHigh, WaitForLow};
 use embassy_nrf::gpio::{AnyPin, Input, Pin as _, Pull};
-use embassy_nrf::gpiote::PortInput;
 use embassy_nrf::Peripherals;
 use example_common::*;
 
 #[embassy::task(pool_size = 4)]
-async fn button_task(n: usize, mut pin: PortInput<'static, AnyPin>) {
+async fn button_task(n: usize, mut pin: Input<'static, AnyPin>) {
     loop {
         pin.wait_for_low().await;
         info!("Button {:?} pressed!", n);
@@ -26,10 +25,10 @@ async fn button_task(n: usize, mut pin: PortInput<'static, AnyPin>) {
 async fn main(spawner: Spawner, p: Peripherals) {
     info!("Starting!");
 
-    let btn1 = PortInput::new(Input::new(p.P0_11.degrade(), Pull::Up));
-    let btn2 = PortInput::new(Input::new(p.P0_12.degrade(), Pull::Up));
-    let btn3 = PortInput::new(Input::new(p.P0_24.degrade(), Pull::Up));
-    let btn4 = PortInput::new(Input::new(p.P0_25.degrade(), Pull::Up));
+    let btn1 = Input::new(p.P0_11.degrade(), Pull::Up);
+    let btn2 = Input::new(p.P0_12.degrade(), Pull::Up);
+    let btn3 = Input::new(p.P0_24.degrade(), Pull::Up);
+    let btn4 = Input::new(p.P0_25.degrade(), Pull::Up);
 
     unwrap!(spawner.spawn(button_task(1, btn1)));
     unwrap!(spawner.spawn(button_task(2, btn2)));

--- a/examples/nrf/src/bin/wdt.rs
+++ b/examples/nrf/src/bin/wdt.rs
@@ -8,7 +8,6 @@ mod example_common;
 use defmt::*;
 use embassy::executor::Spawner;
 use embassy_nrf::gpio::{Input, Pull};
-use embassy_nrf::gpiote::PortInput;
 use embassy_nrf::wdt::{Config, Watchdog};
 use embassy_nrf::Peripherals;
 use embassy_traits::gpio::{WaitForHigh, WaitForLow};
@@ -32,7 +31,7 @@ async fn main(_spawner: Spawner, p: Peripherals) {
         }
     };
 
-    let mut button = PortInput::new(Input::new(p.P0_11, Pull::Up));
+    let mut button = Input::new(p.P0_11, Pull::Up);
 
     info!("Watchdog started, press button 1 to pet it or I'll reset in 3 seconds!");
 


### PR DESCRIPTION
`PortInput` is just a dumb wrapper around `Input`, it has no reason whatsoever to exist. This PR moves the `wait_for_x` functionality to `Input` directly.

It also adds it to `FlexPin` for completeness and consistency with `Input`.

(The reason `PortInput` exists is a while ago `GPIOTE` was an owned singleton that you had to initialize, so `PortInput::new()` would require it to enforce it's been initialized. This doesn't apply anymore now that GPIOTE is "global")