### PR TITLE
Introduces split on the nRF Uarte

### DIFF
--- a/embassy-nrf/src/uarte.rs
+++ b/embassy-nrf/src/uarte.rs
@@ -133,6 +133,10 @@ impl<'d, T: Instance> Uarte<'d, T> {
         apply_workaround_for_enable_anomaly(&r);
         r.enable.write(|w| w.enable().enabled());
 
+        let s = T::state();
+
+        s.tx_rx_refcount.store(2, Ordering::Relaxed);
+
         Self {
             phantom: PhantomData,
             tx: UarteTx::new(),
@@ -584,7 +588,7 @@ pub(crate) mod sealed {
             Self {
                 endrx_waker: AtomicWaker::new(),
                 endtx_waker: AtomicWaker::new(),
-                tx_rx_refcount: AtomicU8::new(2),
+                tx_rx_refcount: AtomicU8::new(0),
             }
         }
     }

--- a/examples/nrf/src/bin/uart_split.rs
+++ b/examples/nrf/src/bin/uart_split.rs
@@ -1,0 +1,68 @@
+#![no_std]
+#![no_main]
+#![feature(type_alias_impl_trait)]
+
+#[path = "../example_common.rs"]
+mod example_common;
+use embassy::blocking_mutex::kind::Noop;
+use embassy::channel::mpsc::{self, Channel, Sender};
+use embassy::util::Forever;
+use embassy_nrf::peripherals::UARTE0;
+use embassy_nrf::uarte::UarteRx;
+use example_common::*;
+
+use embassy::executor::Spawner;
+use embassy::traits::uart::{Read, Write};
+use embassy_nrf::gpio::NoPin;
+use embassy_nrf::{interrupt, uarte, Peripherals};
+
+static CHANNEL: Forever<Channel<Noop, [u8; 8], 1>> = Forever::new();
+
+#[embassy::main]
+async fn main(spawner: Spawner, p: Peripherals) {
+    let mut config = uarte::Config::default();
+    config.parity = uarte::Parity::EXCLUDED;
+    config.baudrate = uarte::Baudrate::BAUD115200;
+
+    let irq = interrupt::take!(UARTE0_UART0);
+    let uart = uarte::Uarte::new(p.UARTE0, irq, p.P0_08, p.P0_06, NoPin, NoPin, config);
+    let (mut tx, rx) = uart.split();
+
+    let c = CHANNEL.put(Channel::new());
+    let (s, mut r) = mpsc::split(c);
+
+    info!("uarte initialized!");
+
+    // Spawn a task responsible purely for reading
+
+    unwrap!(spawner.spawn(reader(rx, s)));
+
+    // Message must be in SRAM
+    {
+        let mut buf = [0; 23];
+        buf.copy_from_slice(b"Type 8 chars to echo!\r\n");
+
+        unwrap!(tx.write(&buf).await);
+        info!("wrote hello in uart!");
+    }
+
+    // Continue reading in this main task and write
+    // back out the buffer we receive from the read
+    // task.
+    loop {
+        if let Some(buf) = r.recv().await {
+            info!("writing...");
+            unwrap!(tx.write(&buf).await);
+        }
+    }
+}
+
+#[embassy::task]
+async fn reader(mut rx: UarteRx<'static, UARTE0>, s: Sender<'static, Noop, [u8; 8], 1>) {
+    let mut buf = [0; 8];
+    loop {
+        info!("reading...");
+        unwrap!(rx.read(&mut buf).await);
+        unwrap!(s.send(buf).await);
+    }
+}


### PR DESCRIPTION
A new `split` method is introduced such that the Uarte tx and rx can be used from separate tasks. An MPSC is used in an example to illustrate how data may be passed between these tasks.

The approach taken within the `Uarte` struct is to split into tx and rx fields on calling `Uarte::new`. These fields are returned given a call to `Uarte::split`, but otherwise, if that call isn't made, then the API remains as it was before.

Here's a snippet from a new example introduced:

```rust
#[embassy::main]
async fn main(spawner: Spawner, p: Peripherals) {
    // ...

    let uart = uarte::Uarte::new(p.UARTE0, irq, p.P0_08, p.P0_06, NoPin, NoPin, config);
    let (mut tx, rx) = uart.split();

    // ...

    // Spawn a task responsible purely for reading

    unwrap!(spawner.spawn(reader(rx, s)));

    // ...

    // Continue reading in this main task and write
    // back out the buffer we receive from the read
    // task.
    loop {
        if let Some(buf) = r.recv().await {
            info!("writing...");
            unwrap!(tx.write(&buf).await);
        }
    }
}

#[embassy::task]
async fn reader(mut rx: UarteRx<'static, UARTE0>, s: Sender<'static, Noop, [u8; 8], 1>) {
    let mut buf = [0; 8];
    loop {
        info!("reading...");
        unwrap!(rx.read(&mut buf).await);
        unwrap!(s.send(buf).await);
    }
}
```
