### PR TITLE
nrf/gpio: add infallible inherent methods, remove some duplication.

### DIFF
--- a/docs/modules/ROOT/examples/basic/src/main.rs
+++ b/docs/modules/ROOT/examples/basic/src/main.rs
@@ -14,14 +14,13 @@ use embassy_nrf::{
     peripherals::P0_13,
     Peripherals,
 };
-use embedded_hal::digital::v2::OutputPin;
 
 #[embassy::task]
 async fn blinker(mut led: Output<'static, P0_13>, interval: Duration) {
     loop {
-        unwrap!(led.set_high());
+        led.set_high();
         Timer::after(interval).await;
-        unwrap!(led.set_low());
+        led.set_low();
         Timer::after(interval).await;
     }
 }

--- a/examples/nrf/src/bin/blinky.rs
+++ b/examples/nrf/src/bin/blinky.rs
@@ -5,21 +5,19 @@
 #[path = "../example_common.rs"]
 mod example_common;
 
-use defmt::unwrap;
 use embassy::executor::Spawner;
 use embassy::time::{Duration, Timer};
 use embassy_nrf::gpio::{Level, Output, OutputDrive};
 use embassy_nrf::Peripherals;
-use embedded_hal::digital::v2::OutputPin;
 
 #[embassy::main]
 async fn main(_spawner: Spawner, p: Peripherals) {
     let mut led = Output::new(p.P0_13, Level::Low, OutputDrive::Standard);
 
     loop {
-        unwrap!(led.set_high());
+        led.set_high();
         Timer::after(Duration::from_millis(300)).await;
-        unwrap!(led.set_low());
+        led.set_low();
         Timer::after(Duration::from_millis(300)).await;
     }
 }

--- a/examples/nrf/src/bin/mpsc.rs
+++ b/examples/nrf/src/bin/mpsc.rs
@@ -13,7 +13,6 @@ use embassy::time::{Duration, Timer};
 use embassy::util::Forever;
 use embassy_nrf::gpio::{Level, Output, OutputDrive};
 use embassy_nrf::Peripherals;
-use embedded_hal::digital::v2::OutputPin;
 
 enum LedState {
     On,
@@ -53,8 +52,8 @@ async fn main(spawner: Spawner, p: Peripherals) {
             Err(TryRecvError::Closed) => break,
         };
         match maybe_message {
-            Some(LedState::On) => unwrap!(led.set_high()),
-            Some(LedState::Off) => unwrap!(led.set_low()),
+            Some(LedState::On) => led.set_high(),
+            Some(LedState::Off) => led.set_low(),
             _ => (),
         }
     }

--- a/examples/nrf/src/bin/spim.rs
+++ b/examples/nrf/src/bin/spim.rs
@@ -10,7 +10,6 @@ use embassy_nrf::gpio::{Level, Output, OutputDrive};
 use embassy_nrf::Peripherals;
 use embassy_nrf::{interrupt, spim};
 use embassy_traits::spi::FullDuplex;
-use embedded_hal::digital::v2::*;
 use example_common::*;
 
 #[embassy::main]
@@ -29,12 +28,12 @@ async fn main(_spawner: Spawner, p: Peripherals) {
 
     // softreset
     cortex_m::asm::delay(10);
-    unwrap!(ncs.set_low());
+    ncs.set_low();
     cortex_m::asm::delay(5);
     let tx = [0xFF];
     unwrap!(spim.read_write(&mut [], &tx).await);
     cortex_m::asm::delay(10);
-    unwrap!(ncs.set_high());
+    ncs.set_high();
 
     cortex_m::asm::delay(100000);
 
@@ -42,31 +41,31 @@ async fn main(_spawner: Spawner, p: Peripherals) {
 
     // read ESTAT
     cortex_m::asm::delay(5000);
-    unwrap!(ncs.set_low());
+    ncs.set_low();
     cortex_m::asm::delay(5000);
     let tx = [0b000_11101, 0];
     unwrap!(spim.read_write(&mut rx, &tx).await);
     cortex_m::asm::delay(5000);
-    unwrap!(ncs.set_high());
+    ncs.set_high();
     info!("estat: {=[?]}", rx);
 
     // Switch to bank 3
     cortex_m::asm::delay(10);
-    unwrap!(ncs.set_low());
+    ncs.set_low();
     cortex_m::asm::delay(5);
     let tx = [0b100_11111, 0b11];
     unwrap!(spim.read_write(&mut rx, &tx).await);
     cortex_m::asm::delay(10);
-    unwrap!(ncs.set_high());
+    ncs.set_high();
 
     // read EREVID
     cortex_m::asm::delay(10);
-    unwrap!(ncs.set_low());
+    ncs.set_low();
     cortex_m::asm::delay(5);
     let tx = [0b000_10010, 0];
     unwrap!(spim.read_write(&mut rx, &tx).await);
     cortex_m::asm::delay(10);
-    unwrap!(ncs.set_high());
+    ncs.set_high();
 
     info!("erevid: {=[?]}", rx);
 }


### PR DESCRIPTION
Add infallible inherent methods, so that users don't have to import a trait, or `.unwrap()`.

This implements Input and Output using FlexPin, to avoid some code duplication.