### PR TITLE
USART DMA example for the STM32F7

### DIFF
--- a/examples/stm32f7/src/bin/usart_dma.rs
+++ b/examples/stm32f7/src/bin/usart_dma.rs
@@ -1,0 +1,46 @@
+#![no_std]
+#![no_main]
+#![feature(type_alias_impl_trait)]
+
+#[path = "../example_common.rs"]
+mod example_common;
+use core::fmt::Write;
+use embassy::executor::Executor;
+use embassy::util::Forever;
+use embassy_stm32::dma::NoDma;
+use embassy_stm32::usart::{Config, Uart};
+use embassy_traits::uart::Write as _Write;
+use example_common::*;
+
+use cortex_m_rt::entry;
+use heapless::String;
+
+#[embassy::task]
+async fn main_task() {
+    let p = embassy_stm32::init(Default::default());
+
+    let config = Config::default();
+    let mut usart = Uart::new(p.UART7, p.PA8, p.PA15, p.DMA1_CH1, NoDma, config);
+
+    for n in 0u32.. {
+        let mut s: String<128> = String::new();
+        core::write!(&mut s, "Hello DMA World {}!\r\n", n).unwrap();
+
+        usart.write(s.as_bytes()).await.ok();
+
+        info!("wrote DMA");
+    }
+}
+
+static EXECUTOR: Forever<Executor> = Forever::new();
+
+#[entry]
+fn main() -> ! {
+    info!("Hello World!");
+
+    let executor = EXECUTOR.put(Executor::new());
+
+    executor.run(|spawner| {
+        unwrap!(spawner.spawn(main_task()));
+    })
+}


### PR DESCRIPTION
This small PR adds the USART DMA write an example for the STM32F7. The example has been tested on a Nucleo-f767zi board.

Output from `DEFMT_LOG=info cargo run --bin usart_dma`
```
Running `probe-run --chip STM32F767ZITx target/thumbv7em-none-eabihf/debug/usart_dma`
(HOST) INFO  flashing program (108 pages / 108.00 KiB)
(HOST) INFO  success!
────────────────────────────────────────────────────────────────────────────────
0 INFO  Hello World!
└─ usart_dma::__cortex_m_rt_main @ src/bin/usart_dma.rs:39
1 INFO  wrote DMA
└─ usart_dma::main_task::task::{generator#0} @ src/bin/usart_dma.rs:31
```