### PR TITLE
Remove unsafe from new on RND

### DIFF
--- a/embassy-nrf/src/rng.rs
+++ b/embassy-nrf/src/rng.rs
@@ -52,7 +52,7 @@ impl<'d> Rng<'d> {
     /// e.g. using `mem::forget`.
     ///
     /// The synchronous API is safe.
-    pub unsafe fn new(
+    pub fn new(
         _rng: impl Unborrow<Target = RNG> + 'd,
         irq: impl Unborrow<Target = interrupt::RNG> + 'd,
     ) -> Self {

--- a/examples/nrf/src/bin/rng.rs
+++ b/examples/nrf/src/bin/rng.rs
@@ -15,7 +15,7 @@ use rand::Rng as _;
 
 #[embassy::main]
 async fn main(_spawner: Spawner, p: Peripherals) {
-    let mut rng = unsafe { Rng::new(p.RNG, interrupt::take!(RNG)) };
+    let mut rng = Rng::new(p.RNG, interrupt::take!(RNG));
 
     // Async API
     let mut bytes = [0; 4];


### PR DESCRIPTION
Unsafe is not required here given that all futures are required to live longer than their global peripheral instances. There are other occurrences of unsafe being used on new that should be removed. I started to do that but then went down a bit of a rabbit hole. Therefore, just confining this PR to what I'm currently exposed to.