### PR TITLE
Makes the uarte endtx event available

### DIFF
--- a/embassy-nrf/src/uarte.rs
+++ b/embassy-nrf/src/uarte.rs
@@ -151,6 +151,12 @@ impl<'d, T: Instance> Uarte<'d, T> {
         (self.tx, self.rx)
     }
 
+    /// Return the endtx event for use with PPI
+    pub fn event_endtx(&self) -> Event {
+        let r = T::regs();
+        Event::from_reg(&r.events_endtx)
+    }
+
     fn on_interrupt(_: *mut ()) {
         let r = T::regs();
         let s = T::state();


### PR DESCRIPTION
This PR allows `event_endtx` to be used outside of the `Uarte` itself. As a consequence, PPI can be used to drive tasks given the end of transmission on the Uarte. This is particularly useful for situations like RS485 where a GPIO may be required to be set to high when transmitting, then cleared when done. A non-PPI approach can cause a delay in the clearing of this GPIO as other Embassy tasks might become scheduled. Not clearing the GPIO in a timely manner can be problematic.

Here's an example of our usage with this change:

```rust
    let uarte_tx_enable = OutputChannel::new(
        p.gpiote_ch,
        Output::new(p.uarte_tx_enable_pin, Level::Low, OutputDrive::Standard),
        OutputChannelPolarity::Set,
    );

    let mut ppi = Ppi::new_one_to_one(p.ppi_ch, uarte.event_endtx(), uarte_tx_enable.task_clr());
    ppi.enable();
```

...and then later when writing:

```rust
    uarte_tx_enable.set();
    let _ = uarte_tx.write(&datagram_buf).await;
```