### PR TITLE
Integrate stm32-usbd

### DIFF
--- a/embassy-stm32/Cargo.toml
+++ b/embassy-stm32/Cargo.toml
@@ -23,6 +23,8 @@ futures = { version = "0.3.17", default-features = false, features = ["async-awa
 rand_core = "0.6.3"
 sdio-host = "0.5.0"
 embedded-sdmmc = { git = "https://github.com/thalesfragoso/embedded-sdmmc-rs", branch = "async", optional = true }
+stm32-usbd = { version = "0.6.0", optional = true }
+usb-device = { version = "0.2.8", optional = true }
 critical-section = "0.2.5"
 bare-metal = "1.0.0"
 atomic-polyfill = "0.1.5"
@@ -39,6 +41,7 @@ stm32-metapac = { version = "0.1.0", path = "../stm32-metapac", default-features
 [features]
 sdmmc-rs = ["embedded-sdmmc"]
 net = ["embassy-net", "vcell"]
+usb = ["stm32-usbd", "usb-device"]
 memory-x = ["stm32-metapac/memory-x"]
 subghz = []
 exti = []

--- a/embassy-stm32/build.rs
+++ b/embassy-stm32/build.rs
@@ -125,6 +125,10 @@ fn main() {
         println!("cargo:rustc-cfg={}", &chip_name[..chip_name.len() - 2]);
     }
 
+    if chip_name.starts_with("stm32f3") {
+        println!("cargo:rustc-cfg={}x{}", &chip_name[..9], &chip_name[10..11]);
+    }
+
     // ========
     // Handle time-driver-XXXX features.
 

--- a/embassy-stm32/build.rs
+++ b/embassy-stm32/build.rs
@@ -6,7 +6,7 @@ use std::path::PathBuf;
 fn main() {
     let chip_name = match env::vars()
         .map(|(a, _)| a)
-        .filter(|x| x.starts_with("CARGO_FEATURE_STM32"))
+        .filter(|x| x.starts_with("CARGO_FEATURE_STM32") && x != "CARGO_FEATURE_STM32_USBD")
         .get_one()
     {
         Ok(x) => x,
@@ -128,6 +128,8 @@ fn main() {
     if chip_name.starts_with("stm32f3") {
         println!("cargo:rustc-cfg={}x{}", &chip_name[..9], &chip_name[10..11]);
     }
+
+    println!("cargo:rustc-cfg={}", &chip_name[..7]);
 
     // ========
     // Handle time-driver-XXXX features.

--- a/embassy-stm32/src/lib.rs
+++ b/embassy-stm32/src/lib.rs
@@ -50,6 +50,8 @@ pub mod sdmmc;
 pub mod spi;
 #[cfg(usart)]
 pub mod usart;
+#[cfg(feature = "usb")]
+pub mod usb;
 
 #[cfg(feature = "subghz")]
 pub mod subghz;

--- a/embassy-stm32/src/rcc/f3.rs
+++ b/embassy-stm32/src/rcc/f3.rs
@@ -217,8 +217,8 @@ fn calc_pll(config: &Config, Hertz(sysclk): Hertz) -> (Hertz, PllConfig) {
             cfg_if::cfg_if! {
                 // For some chips PREDIV is always two, and cannot be changed
                 if #[cfg(any(
-                        feature="stm32f302xd", feature="stm32f302xe", feature="stm32f303xd",
-                        feature="stm32f303xe", feature="stm32f398xe"
+                        stm32f302xd, stm32f302xe, stm32f303xd,
+                        stm32f303xe, stm32f398xe
                     ))] {
                     let (multiplier, divisor) = get_mul_div(sysclk, HSI);
                     (

--- a/embassy-stm32/src/usb.rs
+++ b/embassy-stm32/src/usb.rs
@@ -1,0 +1,52 @@
+use crate::pac::{RCC, USB};
+
+pub use embassy_hal_common::usb::*;
+
+unsafe impl embassy_hal_common::usb::USBInterrupt for crate::interrupt::USB_LP {}
+
+pub struct Peripheral {}
+
+unsafe impl Sync for Peripheral {}
+
+unsafe impl stm32_usbd::UsbPeripheral for Peripheral {
+    const REGISTERS: *const () = USB as *const ();
+
+    #[cfg(any(stm32l0, stm32l1))]
+    const DP_PULL_UP_FEATURE: bool = true;
+    #[cfg(any(stm32f1, stm32f3))]
+    const DP_PULL_UP_FEATURE: bool = false;
+
+    const EP_MEMORY: *const () = 0x4000_6000 as _;
+
+    #[cfg(any(stm32f1, stm32l1, stm32f303xb, stm32f303xc))]
+    const EP_MEMORY_SIZE: usize = 512;
+    #[cfg(any(stm32l0, stm32f303xd, stm32f303xe))]
+    const EP_MEMORY_SIZE: usize = 1024;
+
+    #[cfg(any(stm32f1, stm32l1, stm32f303xb, stm32f303xc))]
+    const EP_MEMORY_ACCESS_2X16: bool = false;
+    #[cfg(any(stm32l0, stm32f303xd, stm32f303xe))]
+    const EP_MEMORY_ACCESS_2X16: bool = true;
+
+    fn enable() {
+        unsafe {
+            cortex_m::interrupt::free(|_| {
+                // Enable USB peripheral
+                RCC.apb1enr().modify(|w| w.set_usben(true));
+
+                // Reset USB peripheral
+                RCC.apb1rstr().modify(|w| w.set_usbrst(true));
+                RCC.apb1rstr().modify(|w| w.set_usbrst(false));
+            });
+        }
+    }
+
+    fn startup_delay() {
+        // There is a chip specific startup delay.
+        // 72 MHz is the highest frequency across all chips with this peripheral,
+        // so this should ensure a minimum 1µs wait time.
+        cortex_m::asm::delay(72);
+    }
+}
+
+pub type UsbBus = stm32_usbd::UsbBus<Peripheral>;

--- a/examples/stm32l1/Cargo.toml
+++ b/examples/stm32l1/Cargo.toml
@@ -5,6 +5,9 @@ name = "embassy-stm32l1-examples"
 version = "0.1.0"
 resolver = "2"
 
+[profile.release]
+debug = true
+
 [dependencies]
 embassy = { version = "0.1.0", path = "../../embassy", features = ["defmt"] }
 embassy-traits = { version = "0.1.0", path = "../../embassy-traits", features = ["defmt"] }
@@ -19,3 +22,9 @@ embedded-hal = "0.2.6"
 panic-probe = { version = "0.3", features = ["print-defmt"] }
 futures = { version = "0.3.17", default-features = false, features = ["async-await"] }
 heapless = { version = "0.7.5", default-features = false }
+stm32-usbd = "0.6.0"
+usb-device = "0.2.8"
+
+[[bin]]
+name = "usb_uart"
+required-features = ["embassy-stm32/usb"]

--- a/examples/stm32l1/src/bin/usb_uart.rs
+++ b/examples/stm32l1/src/bin/usb_uart.rs
@@ -1,0 +1,97 @@
+#![no_std]
+#![no_main]
+#![feature(type_alias_impl_trait)]
+
+#[path = "../example_common.rs"]
+mod example_common;
+
+use defmt::{info, unwrap};
+use embassy::interrupt::InterruptExt;
+use futures::pin_mut;
+
+use embassy::executor::Spawner;
+use embassy::io::{AsyncBufReadExt, AsyncWriteExt};
+use embassy_stm32::usb::{Peripheral, State, Usb, UsbBus, UsbSerial};
+use embassy_stm32::{interrupt, rcc, time::U32Ext, Peripherals};
+use usb_device::device::{UsbDeviceBuilder, UsbVidPid};
+
+fn config() -> embassy_stm32::Config {
+    let mut config = embassy_stm32::Config::default();
+    config.rcc.mux = rcc::ClockSrc::PLL(
+        rcc::PLLSource::HSE(16.mhz().into()),
+        rcc::PLLMul::Mul6,
+        rcc::PLLDiv::Div4,
+    );
+    config
+}
+
+#[embassy::main(config = "config()")]
+async fn main(_spawner: Spawner, _p: Peripherals) {
+    let mut rx_buffer = [0u8; 64];
+    // we send back input + cr + lf
+    let mut tx_buffer = [0u8; 66];
+
+    let usb_bus = UsbBus::new(Peripheral {});
+
+    let serial = UsbSerial::new(&usb_bus, &mut rx_buffer, &mut tx_buffer);
+
+    let device = UsbDeviceBuilder::new(&usb_bus, UsbVidPid(0x16c0, 0x27dd))
+        .manufacturer("Fake company")
+        .product("Serial port")
+        .serial_number("TEST")
+        .device_class(0x02)
+        .build();
+
+    let irq = interrupt::take!(USB_LP);
+    irq.set_priority(interrupt::Priority::P3);
+
+    let mut state = State::new();
+    let usb = unsafe { Usb::new(&mut state, device, serial, irq) };
+    pin_mut!(usb);
+
+    let (mut reader, mut writer) = usb.as_ref().take_serial_0();
+
+    info!("usb initialized!");
+
+    unwrap!(
+        writer
+            .write_all(b"\r\nInput returned upper cased on CR or LF\r\n")
+            .await
+    );
+
+    let mut buf = [0u8; 64];
+    loop {
+        let mut n = 0;
+
+        async {
+            loop {
+                let char = unwrap!(reader.read_byte().await);
+
+                if char == b'\r' || char == b'\n' {
+                    break;
+                }
+
+                buf[n] = char;
+                n += 1;
+
+                // stop if we're out of room
+                if n == buf.len() {
+                    break;
+                }
+            }
+        }
+        .await;
+
+        if n > 0 {
+            for char in buf[..n].iter_mut() {
+                // upper case
+                if 0x61 <= *char && *char <= 0x7a {
+                    *char &= !0x20;
+                }
+            }
+            unwrap!(writer.write_all(&buf[..n]).await);
+            unwrap!(writer.write_all(b"\r\n").await);
+            unwrap!(writer.flush().await);
+        }
+    }
+}


### PR DESCRIPTION
Not exactly #557 because other hardware, but kinda related.

Big open question: the EP memory size / 2x16 access flag / onboard pull-up flag… is there a way to get them into stm32-data? Or can it only be a `cfg()` mess? :/ (they only differ by top-level family and I've only found the info in reference manuals)