### PR TITLE
Make advanced timer trait not require general purpose timer trait as …

### DIFF
--- a/embassy-stm32/src/timer/mod.rs
+++ b/embassy-stm32/src/timer/mod.rs
@@ -39,7 +39,7 @@ pub(crate) mod sealed {
         fn set_frequency<F: Into<Hertz>>(&mut self, frequency: F);
     }
 
-    pub trait AdvancedControlInstance: GeneralPurpose16bitInstance {
+    pub trait AdvancedControlInstance: Basic16bitInstance {
         fn regs_advanced(&self) -> crate::pac::timer::TimAdv;
     }
 }
@@ -205,14 +205,6 @@ crate::pac::interrupts! {
         impl Basic16bitInstance for crate::peripherals::$inst {
         }
 
-        impl sealed::GeneralPurpose16bitInstance for crate::peripherals::$inst {
-            fn regs_gp16(&self) -> crate::pac::timer::TimGp16 {
-                crate::pac::timer::TimGp16(crate::pac::$inst.0)
-            }
-        }
-
-        impl GeneralPurpose16bitInstance for crate::peripherals::$inst {
-        }
         impl sealed::AdvancedControlInstance for crate::peripherals::$inst {
             fn regs_advanced(&self) -> crate::pac::timer::TimAdv {
                 crate::pac::$inst


### PR DESCRIPTION
…the timers are too different.

When developing pwm driver, I originally used T: GeneralPurpose16bitTimer as it could support both GP timers and advanced timer, but advanced timer requires further modifications in registers accessible only in it (BDTR - bit AOE).

This PR makes advanced timers depend on Basic16bitTimer instead, which should hopefully improve type safety and allow for better timer drivers that can distinguish between advanced timers and general purpose ones.