### PR TITLE
stm32: add `time-driver-any` cargo feature that automatically picks one.

### DIFF
--- a/ci.sh
+++ b/ci.sh
@@ -42,18 +42,19 @@ cargo batch  \
     --- build --release --manifest-path embassy-nrf/Cargo.toml --target thumbv7em-none-eabi --features nrf52840,gpiote,time-driver-rtc1 \
     --- build --release --manifest-path embassy-nrf/Cargo.toml --target thumbv7em-none-eabi --features nrf52840,log,gpiote,time-driver-rtc1 \
     --- build --release --manifest-path embassy-nrf/Cargo.toml --target thumbv7em-none-eabi --features nrf52840,defmt,gpiote,time-driver-rtc1,unstable-traits \
-    --- build --release --manifest-path embassy-stm32/Cargo.toml --target thumbv7em-none-eabi --features stm32f411ce,defmt \
-    --- build --release --manifest-path embassy-stm32/Cargo.toml --target thumbv7em-none-eabi --features stm32f429zi,log \
-    --- build --release --manifest-path embassy-stm32/Cargo.toml --target thumbv7em-none-eabi --features stm32h755zi-cm7,defmt \
-    --- build --release --manifest-path embassy-stm32/Cargo.toml --target thumbv7em-none-eabi --features stm32l476vg,defmt \
-    --- build --release --manifest-path embassy-stm32/Cargo.toml --target thumbv6m-none-eabi --features stm32l072cz,defmt \
-    --- build --release --manifest-path embassy-stm32/Cargo.toml --target thumbv7m-none-eabi --features stm32l151cb-a,defmt \
-    --- build --release --manifest-path embassy-stm32/Cargo.toml --target thumbv7em-none-eabi --features stm32f411ce,defmt,exti \
-    --- build --release --manifest-path embassy-stm32/Cargo.toml --target thumbv7em-none-eabi --features stm32f429zi,log,exti \
-    --- build --release --manifest-path embassy-stm32/Cargo.toml --target thumbv7em-none-eabi --features stm32h755zi-cm7,defmt,exti \
-    --- build --release --manifest-path embassy-stm32/Cargo.toml --target thumbv7em-none-eabi --features stm32l476vg,defmt,exti \
-    --- build --release --manifest-path embassy-stm32/Cargo.toml --target thumbv6m-none-eabi --features stm32l072cz,defmt,exti \
-    --- build --release --manifest-path embassy-stm32/Cargo.toml --target thumbv7m-none-eabi --features stm32l151cb-a,defmt,exti \
+    --- build --release --manifest-path embassy-stm32/Cargo.toml --target thumbv7em-none-eabi --features stm32f411ce,defmt,time-driver-any \
+    --- build --release --manifest-path embassy-stm32/Cargo.toml --target thumbv7em-none-eabi --features stm32f429zi,log,time-driver-any \
+    --- build --release --manifest-path embassy-stm32/Cargo.toml --target thumbv7em-none-eabi --features stm32h755zi-cm7,defmt,time-driver-any \
+    --- build --release --manifest-path embassy-stm32/Cargo.toml --target thumbv7em-none-eabi --features stm32l476vg,defmt,time-driver-any \
+    --- build --release --manifest-path embassy-stm32/Cargo.toml --target thumbv6m-none-eabi --features stm32l072cz,defmt,time-driver-any \
+    --- build --release --manifest-path embassy-stm32/Cargo.toml --target thumbv7m-none-eabi --features stm32l151cb-a,defmt,time-driver-any \
+    --- build --release --manifest-path embassy-stm32/Cargo.toml --target thumbv7em-none-eabi --features stm32f410tb,defmt,exti,time-driver-any \
+    --- build --release --manifest-path embassy-stm32/Cargo.toml --target thumbv7em-none-eabi --features stm32f411ce,defmt,exti,time-driver-any \
+    --- build --release --manifest-path embassy-stm32/Cargo.toml --target thumbv7em-none-eabi --features stm32f429zi,log,exti,time-driver-any \
+    --- build --release --manifest-path embassy-stm32/Cargo.toml --target thumbv7em-none-eabi --features stm32h755zi-cm7,defmt,exti,time-driver-any \
+    --- build --release --manifest-path embassy-stm32/Cargo.toml --target thumbv7em-none-eabi --features stm32l476vg,defmt,exti,time-driver-any \
+    --- build --release --manifest-path embassy-stm32/Cargo.toml --target thumbv6m-none-eabi --features stm32l072cz,defmt,exti,time-driver-any \
+    --- build --release --manifest-path embassy-stm32/Cargo.toml --target thumbv7m-none-eabi --features stm32l151cb-a,defmt,exti,time-driver-any \
     --- build --release --manifest-path docs/modules/ROOT/examples/basic/Cargo.toml --target thumbv7em-none-eabi \
     --- build --release --manifest-path examples/std/Cargo.toml --target x86_64-unknown-linux-gnu --out-dir out/examples/std \
     --- build --release --manifest-path examples/nrf/Cargo.toml --target thumbv7em-none-eabi --out-dir out/examples/nrf \

--- a/embassy-stm32/Cargo.toml
+++ b/embassy-stm32/Cargo.toml
@@ -28,9 +28,7 @@ stm32-metapac = { version = "0.1.0", path = "../stm32-metapac", features = ["rt"
 vcell = { version = "0.1.3", optional = true }
 bxcan = "0.6.2"
 nb = "1.0.0"
-
 seq-macro = "0.2.2"
-
 cfg-if = "1.0.0"
 
 [build-dependencies]
@@ -46,6 +44,7 @@ exti = []
 # Features starting with `_` are for internal use only. They're not intended
 # to be enabled by other crates, and are not covered by semver guarantees.
 _time-driver = ["embassy/time-tick-32768hz"]
+time-driver-any = ["_time-driver"]
 time-driver-tim2 = ["_time-driver"]
 time-driver-tim3 = ["_time-driver"]
 

--- a/embassy-stm32/Cargo.toml
+++ b/embassy-stm32/Cargo.toml
@@ -47,6 +47,8 @@ _time-driver = ["embassy/time-tick-32768hz"]
 time-driver-any = ["_time-driver"]
 time-driver-tim2 = ["_time-driver"]
 time-driver-tim3 = ["_time-driver"]
+time-driver-tim4 = ["_time-driver"]
+time-driver-tim5 = ["_time-driver"]
 
 # Reexport stm32-metapac at `embassy_stm32::pac`.
 # This is unstable because semver-minor (non-breaking) releases of embassy-stm32 may major-bump (breaking) the stm32-metapac version.

--- a/embassy-stm32/build.rs
+++ b/embassy-stm32/build.rs
@@ -146,13 +146,19 @@ fn main() {
         None => {}
         Some("tim2") => println!("cargo:rustc-cfg=time_driver_tim2"),
         Some("tim3") => println!("cargo:rustc-cfg=time_driver_tim3"),
+        Some("tim4") => println!("cargo:rustc-cfg=time_driver_tim4"),
+        Some("tim5") => println!("cargo:rustc-cfg=time_driver_tim5"),
         Some("any") => {
             if singletons.contains(&"TIM2".to_string()) {
                 println!("cargo:rustc-cfg=time_driver_tim2");
             } else if singletons.contains(&"TIM3".to_string()) {
                 println!("cargo:rustc-cfg=time_driver_tim3");
+            } else if singletons.contains(&"TIM4".to_string()) {
+                println!("cargo:rustc-cfg=time_driver_tim4");
+            } else if singletons.contains(&"TIM5".to_string()) {
+                println!("cargo:rustc-cfg=time_driver_tim5");
             } else {
-                panic!("time-driver-any requested, but the chip doesn't have TIM2 or TIM3.")
+                panic!("time-driver-any requested, but the chip doesn't have TIM2, TIM3, TIM4 or TIM5.")
             }
         }
         _ => panic!("unknown time_driver {:?}", time_driver),

--- a/embassy-stm32/build.rs
+++ b/embassy-stm32/build.rs
@@ -4,13 +4,18 @@ use std::fs;
 use std::path::PathBuf;
 
 fn main() {
-    let chip_name = env::vars_os()
-        .map(|(a, _)| a.to_string_lossy().to_string())
-        .find(|x| x.starts_with("CARGO_FEATURE_STM32"))
-        .expect("No stm32xx Cargo feature enabled")
-        .strip_prefix("CARGO_FEATURE_")
-        .unwrap()
-        .to_ascii_lowercase();
+    let chip_name = match env::vars()
+        .map(|(a, _)| a)
+        .filter(|x| x.starts_with("CARGO_FEATURE_STM32"))
+        .get_one()
+    {
+        Ok(x) => x,
+        Err(GetOneError::None) => panic!("No stm32xx Cargo feature enabled"),
+        Err(GetOneError::Multiple) => panic!("Multiple stm32xx Cargo features enabled"),
+    }
+    .strip_prefix("CARGO_FEATURE_")
+    .unwrap()
+    .to_ascii_lowercase();
 
     struct Peripheral {
         kind: String,
@@ -120,5 +125,63 @@ fn main() {
         println!("cargo:rustc-cfg={}", &chip_name[..chip_name.len() - 2]);
     }
 
+    // ========
+    // Handle time-driver-XXXX features.
+
+    let time_driver = match env::vars()
+        .map(|(a, _)| a)
+        .filter(|x| x.starts_with("CARGO_FEATURE_TIME_DRIVER_"))
+        .get_one()
+    {
+        Ok(x) => Some(
+            x.strip_prefix("CARGO_FEATURE_TIME_DRIVER_")
+                .unwrap()
+                .to_ascii_lowercase(),
+        ),
+        Err(GetOneError::None) => None,
+        Err(GetOneError::Multiple) => panic!("Multiple stm32xx Cargo features enabled"),
+    };
+
+    match time_driver.as_ref().map(|x| x.as_ref()) {
+        None => {}
+        Some("tim2") => println!("cargo:rustc-cfg=time_driver_tim2"),
+        Some("tim3") => println!("cargo:rustc-cfg=time_driver_tim3"),
+        Some("any") => {
+            if singletons.contains(&"TIM2".to_string()) {
+                println!("cargo:rustc-cfg=time_driver_tim2");
+            } else if singletons.contains(&"TIM3".to_string()) {
+                println!("cargo:rustc-cfg=time_driver_tim3");
+            } else {
+                panic!("time-driver-any requested, but the chip doesn't have TIM2 or TIM3.")
+            }
+        }
+        _ => panic!("unknown time_driver {:?}", time_driver),
+    }
+
+    // Handle time-driver-XXXX features.
+    if env::var("CARGO_FEATURE_TIME_DRIVER_ANY").is_ok() {}
+    println!("cargo:rustc-cfg={}", &chip_name[..chip_name.len() - 2]);
+
     println!("cargo:rerun-if-changed=build.rs");
+}
+
+enum GetOneError {
+    None,
+    Multiple,
+}
+
+trait IteratorExt: Iterator {
+    fn get_one(self) -> Result<Self::Item, GetOneError>;
+}
+
+impl<T: Iterator> IteratorExt for T {
+    fn get_one(mut self) -> Result<Self::Item, GetOneError> {
+        match self.next() {
+            None => Err(GetOneError::None),
+            Some(res) => match self.next() {
+                Some(_) => Err(GetOneError::Multiple),
+                None => Ok(res),
+            },
+        }
+    }
 }

--- a/embassy-stm32/src/rcc/mod.rs
+++ b/embassy-stm32/src/rcc/mod.rs
@@ -46,13 +46,17 @@ pub struct Clocks {
     #[cfg(any(rcc_l0, rcc_l1, rcc_f0, rcc_f1, rcc_f3, rcc_f0x0, rcc_g0))]
     pub ahb: Hertz,
 
-    #[cfg(any(rcc_l4, rcc_f4, rcc_f7, rcc_h7, rcc_g4, rcc_u5, rcc_wb, rcc_wl5))]
+    #[cfg(any(
+        rcc_l4, rcc_f4, rcc_f410, rcc_f7, rcc_h7, rcc_g4, rcc_u5, rcc_wb, rcc_wl5
+    ))]
     pub ahb1: Hertz,
 
-    #[cfg(any(rcc_l4, rcc_f4, rcc_f7, rcc_h7, rcc_g4, rcc_u5, rcc_wb, rcc_wl5))]
+    #[cfg(any(
+        rcc_l4, rcc_f4, rcc_f410, rcc_f7, rcc_h7, rcc_g4, rcc_u5, rcc_wb, rcc_wl5
+    ))]
     pub ahb2: Hertz,
 
-    #[cfg(any(rcc_l4, rcc_f4, rcc_f7, rcc_h7, rcc_u5, rcc_wb, rcc_wl5))]
+    #[cfg(any(rcc_l4, rcc_f4, rcc_f410, rcc_f7, rcc_h7, rcc_u5, rcc_wb, rcc_wl5))]
     pub ahb3: Hertz,
 
     #[cfg(any(rcc_h7))]
@@ -61,7 +65,7 @@ pub struct Clocks {
     #[cfg(any(rcc_h7))]
     pub apb4: Hertz,
 
-    #[cfg(any(rcc_f4, rcc_f7))]
+    #[cfg(any(rcc_f4, rcc_f410, rcc_f7))]
     pub pll48: Option<Hertz>,
 
     #[cfg(rcc_f1)]

--- a/embassy-stm32/src/time_driver.rs
+++ b/embassy-stm32/src/time_driver.rs
@@ -18,17 +18,17 @@ use self::sealed::Instance as _;
 
 const ALARM_COUNT: usize = 3;
 
-#[cfg(feature = "time-driver-tim2")]
+#[cfg(time_driver_tim2)]
 type T = peripherals::TIM2;
-#[cfg(feature = "time-driver-tim3")]
+#[cfg(time_driver_tim3)]
 type T = peripherals::TIM3;
 
-#[cfg(feature = "time-driver-tim2")]
+#[cfg(time_driver_tim2)]
 #[interrupt]
 fn TIM2() {
     DRIVER.on_interrupt()
 }
-#[cfg(feature = "time-driver-tim3")]
+#[cfg(time_driver_tim3)]
 #[interrupt]
 fn TIM3() {
     DRIVER.on_interrupt()

--- a/embassy-stm32/src/time_driver.rs
+++ b/embassy-stm32/src/time_driver.rs
@@ -22,6 +22,10 @@ const ALARM_COUNT: usize = 3;
 type T = peripherals::TIM2;
 #[cfg(time_driver_tim3)]
 type T = peripherals::TIM3;
+#[cfg(time_driver_tim4)]
+type T = peripherals::TIM4;
+#[cfg(time_driver_tim5)]
+type T = peripherals::TIM5;
 
 #[cfg(time_driver_tim2)]
 #[interrupt]
@@ -31,6 +35,16 @@ fn TIM2() {
 #[cfg(time_driver_tim3)]
 #[interrupt]
 fn TIM3() {
+    DRIVER.on_interrupt()
+}
+#[cfg(time_driver_tim4)]
+#[interrupt]
+fn TIM4() {
+    DRIVER.on_interrupt()
+}
+#[cfg(time_driver_tim5)]
+#[interrupt]
+fn TIM5() {
     DRIVER.on_interrupt()
 }
 

--- a/examples/stm32f0/Cargo.toml
+++ b/examples/stm32f0/Cargo.toml
@@ -14,5 +14,5 @@ defmt = "0.3"
 defmt-rtt = "0.3"
 panic-probe = "0.3"
 embassy = { path = "../../embassy", features = ["defmt"] }
-embassy-stm32 = { path = "../../embassy-stm32", features = ["defmt", "memory-x", "stm32f030f4", "time-driver-tim3"] }
+embassy-stm32 = { path = "../../embassy-stm32", features = ["defmt", "memory-x", "stm32f030f4", "time-driver-any"] }
 

--- a/examples/stm32f1/Cargo.toml
+++ b/examples/stm32f1/Cargo.toml
@@ -8,7 +8,7 @@ resolver = "2"
 [dependencies]
 embassy = { version = "0.1.0", path = "../../embassy", features = ["defmt"] }
 embassy-traits = { version = "0.1.0", path = "../../embassy-traits", features = ["defmt"] }
-embassy-stm32 = { version = "0.1.0", path = "../../embassy-stm32", features = ["defmt", "stm32f103c8", "unstable-pac", "memory-x", "time-driver-tim2"]  }
+embassy-stm32 = { version = "0.1.0", path = "../../embassy-stm32", features = ["defmt", "stm32f103c8", "unstable-pac", "memory-x", "time-driver-any"]  }
 
 defmt = "0.3"
 defmt-rtt = "0.3"

--- a/examples/stm32f3/Cargo.toml
+++ b/examples/stm32f3/Cargo.toml
@@ -8,7 +8,7 @@ resolver = "2"
 [dependencies]
 embassy = { version = "0.1.0", path = "../../embassy", features = ["defmt"] }
 embassy-traits = { version = "0.1.0", path = "../../embassy-traits", features = ["defmt"] }
-embassy-stm32 = { version = "0.1.0", path = "../../embassy-stm32", features = ["defmt", "stm32f303vc", "unstable-pac", "memory-x", "time-driver-tim2", "exti"]  }
+embassy-stm32 = { version = "0.1.0", path = "../../embassy-stm32", features = ["defmt", "stm32f303vc", "unstable-pac", "memory-x", "time-driver-any", "exti"]  }
 
 defmt = "0.3"
 defmt-rtt = "0.3"

--- a/examples/stm32f4/Cargo.toml
+++ b/examples/stm32f4/Cargo.toml
@@ -9,7 +9,7 @@ resolver = "2"
 [dependencies]
 embassy = { version = "0.1.0", path = "../../embassy", features = ["defmt"] }
 embassy-traits = { version = "0.1.0", path = "../../embassy-traits", features = ["defmt"] }
-embassy-stm32 = { version = "0.1.0", path = "../../embassy-stm32", features = ["defmt", "stm32f429zi", "unstable-pac", "memory-x", "time-driver-tim2", "exti"]  }
+embassy-stm32 = { version = "0.1.0", path = "../../embassy-stm32", features = ["defmt", "stm32f429zi", "unstable-pac", "memory-x", "time-driver-any", "exti"]  }
 
 defmt = "0.3"
 defmt-rtt = "0.3"

--- a/examples/stm32f7/Cargo.toml
+++ b/examples/stm32f7/Cargo.toml
@@ -8,7 +8,7 @@ resolver = "2"
 [dependencies]
 embassy = { version = "0.1.0", path = "../../embassy", features = ["defmt"] }
 embassy-traits = { version = "0.1.0", path = "../../embassy-traits", features = ["defmt"] }
-embassy-stm32 = { version = "0.1.0", path = "../../embassy-stm32", features = ["defmt", "net", "stm32f767zi", "unstable-pac", "time-driver-tim2", "exti"]  }
+embassy-stm32 = { version = "0.1.0", path = "../../embassy-stm32", features = ["defmt", "net", "stm32f767zi", "unstable-pac", "time-driver-any", "exti"]  }
 embassy-net = { path = "../../embassy-net", default-features = false, features = ["defmt", "tcp", "medium-ethernet", "pool-16"] }
 
 defmt = "0.3"

--- a/examples/stm32g0/Cargo.toml
+++ b/examples/stm32g0/Cargo.toml
@@ -8,7 +8,7 @@ resolver = "2"
 [dependencies]
 embassy = { version = "0.1.0", path = "../../embassy", features = ["defmt"] }
 embassy-traits = { version = "0.1.0", path = "../../embassy-traits", features = ["defmt"] }
-embassy-stm32 = { version = "0.1.0", path = "../../embassy-stm32", features = ["defmt", "time-driver-tim2", "stm32g071rb", "memory-x", "unstable-pac", "exti"]  }
+embassy-stm32 = { version = "0.1.0", path = "../../embassy-stm32", features = ["defmt", "time-driver-any", "stm32g071rb", "memory-x", "unstable-pac", "exti"]  }
 
 defmt = "0.3"
 defmt-rtt = "0.3"

--- a/examples/stm32g4/Cargo.toml
+++ b/examples/stm32g4/Cargo.toml
@@ -8,7 +8,7 @@ resolver = "2"
 [dependencies]
 embassy = { version = "0.1.0", path = "../../embassy", features = ["defmt"] }
 embassy-traits = { version = "0.1.0", path = "../../embassy-traits", features = ["defmt"] }
-embassy-stm32 = { version = "0.1.0", path = "../../embassy-stm32", features = ["defmt", "time-driver-tim3", "stm32g491re", "memory-x", "unstable-pac", "exti"]  }
+embassy-stm32 = { version = "0.1.0", path = "../../embassy-stm32", features = ["defmt", "time-driver-any", "stm32g491re", "memory-x", "unstable-pac", "exti"]  }
 embassy-hal-common = {version = "0.1.0", path = "../../embassy-hal-common" }
 
 defmt = "0.3"

--- a/examples/stm32h7/Cargo.toml
+++ b/examples/stm32h7/Cargo.toml
@@ -10,7 +10,7 @@ resolver = "2"
 [dependencies]
 embassy = { version = "0.1.0", path = "../../embassy", features = ["defmt"] }
 embassy-traits = { version = "0.1.0", path = "../../embassy-traits", features = ["defmt"] }
-embassy-stm32 = { version = "0.1.0", path = "../../embassy-stm32", features = ["defmt", "stm32h743zi", "net", "time-driver-tim2", "exti", "unstable-pac"] }
+embassy-stm32 = { version = "0.1.0", path = "../../embassy-stm32", features = ["defmt", "stm32h743zi", "net", "time-driver-any", "exti", "unstable-pac"] }
 embassy-net = { path = "../../embassy-net", default-features = false, features = ["defmt", "tcp", "medium-ethernet", "pool-16"] }
 embassy-hal-common = { path = "../../embassy-hal-common", default-features = false, features = ["defmt"] }
 

--- a/examples/stm32l0/Cargo.toml
+++ b/examples/stm32l0/Cargo.toml
@@ -8,7 +8,7 @@ resolver = "2"
 [dependencies]
 embassy = { version = "0.1.0", path = "../../embassy", features = ["defmt"] }
 embassy-traits = { version = "0.1.0", path = "../../embassy-traits", features = ["defmt"] }
-embassy-stm32 = { version = "0.1.0", path = "../../embassy-stm32", features = ["defmt", "stm32l072cz", "time-driver-tim3", "exti", "memory-x"]  }
+embassy-stm32 = { version = "0.1.0", path = "../../embassy-stm32", features = ["defmt", "stm32l072cz", "time-driver-any", "exti", "memory-x"]  }
 
 embassy-lora = { version = "0.1.0", path = "../../embassy-lora", features = ["sx127x", "time", "defmt"] }
 

--- a/examples/stm32l1/Cargo.toml
+++ b/examples/stm32l1/Cargo.toml
@@ -8,7 +8,7 @@ resolver = "2"
 [dependencies]
 embassy = { version = "0.1.0", path = "../../embassy", features = ["defmt"] }
 embassy-traits = { version = "0.1.0", path = "../../embassy-traits", features = ["defmt"] }
-embassy-stm32 = { version = "0.1.0", path = "../../embassy-stm32", features = ["defmt", "stm32l151cb-a", "time-driver-tim2", "memory-x"]  }
+embassy-stm32 = { version = "0.1.0", path = "../../embassy-stm32", features = ["defmt", "stm32l151cb-a", "time-driver-any", "memory-x"]  }
 
 defmt = "0.3"
 defmt-rtt = "0.3"

--- a/examples/stm32l4/Cargo.toml
+++ b/examples/stm32l4/Cargo.toml
@@ -10,7 +10,7 @@ resolver = "2"
 [dependencies]
 embassy = { version = "0.1.0", path = "../../embassy", features = ["defmt" ] }
 embassy-traits = { version = "0.1.0", path = "../../embassy-traits", features = ["defmt"] }
-embassy-stm32 = { version = "0.1.0", path = "../../embassy-stm32", features = ["defmt", "unstable-pac", "stm32l4s5vi", "time-driver-tim2", "exti"]  }
+embassy-stm32 = { version = "0.1.0", path = "../../embassy-stm32", features = ["defmt", "unstable-pac", "stm32l4s5vi", "time-driver-any", "exti"]  }
 
 defmt = "0.3"
 defmt-rtt = "0.3"

--- a/examples/stm32wb55/Cargo.toml
+++ b/examples/stm32wb55/Cargo.toml
@@ -8,7 +8,7 @@ resolver = "2"
 [dependencies]
 embassy = { version = "0.1.0", path = "../../embassy", features = ["defmt"] }
 embassy-traits = { version = "0.1.0", path = "../../embassy-traits", features = ["defmt"] }
-embassy-stm32 = { version = "0.1.0", path = "../../embassy-stm32", features = ["defmt", "stm32wb55cc", "time-driver-tim2", "exti"]  }
+embassy-stm32 = { version = "0.1.0", path = "../../embassy-stm32", features = ["defmt", "stm32wb55cc", "time-driver-any", "exti"]  }
 
 defmt = "0.3"
 defmt-rtt = "0.3"

--- a/examples/stm32wl55/Cargo.toml
+++ b/examples/stm32wl55/Cargo.toml
@@ -8,7 +8,7 @@ resolver = "2"
 [dependencies]
 embassy = { version = "0.1.0", path = "../../embassy", features = ["defmt"] }
 embassy-traits = { version = "0.1.0", path = "../../embassy-traits", features = ["defmt"] }
-embassy-stm32 = { version = "0.1.0", path = "../../embassy-stm32", features = ["defmt", "stm32wl55jc-cm4", "time-driver-tim2", "memory-x", "subghz", "unstable-pac", "exti"]  }
+embassy-stm32 = { version = "0.1.0", path = "../../embassy-stm32", features = ["defmt", "stm32wl55jc-cm4", "time-driver-any", "memory-x", "subghz", "unstable-pac", "exti"]  }
 embassy-lora = { version = "0.1.0", path = "../../embassy-lora", features = ["stm32wl", "time"] }
 
 lorawan-device = { git = "https://github.com/ivajloip/rust-lorawan.git", rev = "0de1a2a31933f7c97887b5718c1755fa5ab93a42", default-features = false, features = ["async"] }


### PR DESCRIPTION
Most of the time you don't care which one gets used, so this is easier! :) 

It also helps for building docs for all chips, it reduces the feature changes needed.