### PR TITLE
stm32/i2c: allow empty writes

### DIFF
--- a/embassy-stm32/src/dma/mod.rs
+++ b/embassy-stm32/src/dma/mod.rs
@@ -130,7 +130,7 @@ mod transfers {
         reg_addr: *mut W,
         buf: &'a mut [W],
     ) -> impl Future<Output = ()> + 'a {
-        assert!(buf.len() <= 0xFFFF);
+        assert!(buf.len() > 0 && buf.len() <= 0xFFFF);
         unborrow!(channel);
 
         unsafe { channel.start_read::<W>(request, reg_addr, buf) };
@@ -145,7 +145,7 @@ mod transfers {
         buf: &'a [W],
         reg_addr: *mut W,
     ) -> impl Future<Output = ()> + 'a {
-        assert!(buf.len() <= 0xFFFF);
+        assert!(buf.len() > 0 && buf.len() <= 0xFFFF);
         unborrow!(channel);
 
         unsafe { channel.start_write::<W>(request, buf, reg_addr) };


### PR DESCRIPTION
The Senseair Sunrise CO2 sensor expects a wake-up packet in the form of (START, address, STOP), which looks like a `write(addr, &[])`, but this assertion prevents sending that.

I'm not sure why the assertion is there. Sending empty packets works fine in my limited testing, at least.