### PR TITLE
Stop PWM before assigning the new sequence

### DIFF
--- a/embassy-nrf/src/pwm.rs
+++ b/embassy-nrf/src/pwm.rs
@@ -149,6 +149,8 @@ impl<'d, T: Instance> SequencePwm<'d, T> {
             return Err(Error::SequenceTimesAtLeastOne);
         }
 
+        self.stop();
+
         let r = T::regs();
 
         r.seq0
@@ -164,8 +166,6 @@ impl<'d, T: Instance> SequencePwm<'d, T> {
         r.seq1
             .cnt
             .write(|w| unsafe { w.bits(sequence.len() as u32) });
-
-        self.stop();
 
         r.enable.write(|w| w.enable().enabled());
 

--- a/examples/nrf/src/bin/pwm_sequence.rs
+++ b/examples/nrf/src/bin/pwm_sequence.rs
@@ -18,7 +18,7 @@ async fn main(_spawner: Spawner, p: Peripherals) {
 
     let mut config = SequenceConfig::default();
     config.prescaler = Prescaler::Div128;
-    // 1 period is 1000 * (128/16mhz = 0.000008s = 0.008ms) = 8ms
+    // 1 period is 1000 * (128/16mhz = 0.000008s = 0.008ms) = 8us
     // but say we want to hold the value for 5000ms
     // so we want to repeat our value as many times as necessary until 5000ms passes
     // want 5000/8 = 625 periods total to occur, so 624 (we get the one period for free remember)

--- a/examples/nrf/src/bin/pwm_sequence_ppi.rs
+++ b/examples/nrf/src/bin/pwm_sequence_ppi.rs
@@ -20,7 +20,7 @@ async fn main(_spawner: Spawner, p: Peripherals) {
 
     let mut config = SequenceConfig::default();
     config.prescaler = Prescaler::Div128;
-    // 1 period is 1000 * (128/16mhz = 0.000008s = 0.008ms) = 8ms
+    // 1 period is 1000 * (128/16mhz = 0.000008s = 0.008ms) = 8us
     // but say we want to hold the value for 250ms 250ms/8 = 31.25 periods
     // so round to 31 - 1 (we get the one period for free remember)
     // thus our sequence takes 5 * 250ms or 1.25 seconds


### PR DESCRIPTION
I had introduced a small bug in my last PR where I assigned the sequence before stopping the PWM. I now stop the PWM before doing that now.

Also, corrected a math comment.