### PR TITLE
PWM WS2812B example and flexible sequence config

### DIFF
--- a/embassy-nrf/src/pwm.rs
+++ b/embassy-nrf/src/pwm.rs
@@ -342,6 +342,14 @@ impl<'d, 's, T: Instance> SingleSequencer<'d, 's, T> {
         };
         self.sequencer.start(start_seq, times)
     }
+
+    /// Stop playback. Disables the peripheral. Does NOT clear the last duty
+    /// cycle from the pin. Returns any sequences previously provided to
+    /// `start` so that they may be further mutated.
+    #[inline(always)]
+    pub fn stop(&self) {
+        self.sequencer.stop();
+    }
 }
 
 /// A composition of sequences that can be started and stopped.

--- a/embassy-nrf/src/pwm.rs
+++ b/embassy-nrf/src/pwm.rs
@@ -321,7 +321,7 @@ impl<'s> Sequence<'s> {
 /// is used.
 #[non_exhaustive]
 pub struct Sequences<'d, 's, T: Instance> {
-    _pwm: &'s mut SequencePwm<'d, T>,
+    pub pwm: &'s mut SequencePwm<'d, T>,
     sequence0: Sequence<'s>,
     sequence1: Option<Sequence<'s>>,
 }
@@ -333,7 +333,7 @@ impl<'d, 's, T: Instance> Sequences<'d, 's, T> {
         sequence1: Option<Sequence<'s>>,
     ) -> Self {
         Sequences {
-            _pwm: pwm,
+            pwm,
             sequence0,
             sequence1,
         }

--- a/embassy-nrf/src/pwm.rs
+++ b/embassy-nrf/src/pwm.rs
@@ -131,9 +131,7 @@ impl<'d, T: Instance> SequencePwm<'d, T> {
     /// Start or restart playback. Takes at least one sequence along with its
     /// configuration. Optionally takes a second sequence and/or its configuration.
     /// In the case where no second sequence is provided then the first sequence
-    /// is used. In the case where no second sequence configuration is supplied,
-    /// the first sequence configuration is used. The sequence mode applies to both
-    /// sequences combined as one.
+    /// is used. The sequence mode applies to both sequences combined as one.
     #[inline(always)]
     pub fn start(
         &mut self,

--- a/embassy-nrf/src/pwm.rs
+++ b/embassy-nrf/src/pwm.rs
@@ -323,9 +323,9 @@ pub struct SingleSequencer<'d, 's, T: Instance> {
 
 impl<'d, 's, T: Instance> SingleSequencer<'d, 's, T> {
     /// Create a new sequencer
-    pub fn new(pwm: &'s mut SequencePwm<'d, T>, sequence: Sequence<'s>) -> Self {
+    pub fn new(pwm: &'s mut SequencePwm<'d, T>, words: &'s [u16], config: SequenceConfig) -> Self {
         Self {
-            sequencer: Sequencer::new(pwm, sequence, None),
+            sequencer: Sequencer::new(pwm, Sequence::new(words, config), None),
         }
     }
 

--- a/embassy-nrf/src/pwm.rs
+++ b/embassy-nrf/src/pwm.rs
@@ -428,6 +428,8 @@ impl Default for SequenceConfig {
 #[non_exhaustive]
 pub struct Sequence<'d> {
     /// The words comprising the sequence. Must not exceed 32767 words.
+    /// The reason for this buffer to be mutable is so that stopping
+    /// the PWM can relinquish the sequence for subsequent modification.
     pub words: &'d mut [u16],
     /// Configuration associated with the sequence.
     pub config: SequenceConfig,

--- a/embassy-nrf/src/pwm.rs
+++ b/embassy-nrf/src/pwm.rs
@@ -459,9 +459,9 @@ pub enum SequenceMode {
     /// Run sequence n Times total.
     /// 1 = Run sequence 0 once
     /// 2 = Run sequence 0 and then sequence 1
-    /// 3 to 4 = Run sequence 0, sequence 1, sequence 0 and then sequence 1
-    /// 5 to 6 = Run sequence 0, sequence 1, sequence 0, sequence 1, sequence 0 and then sequence 1
-    /// i.e the when >= 2 the loop count is determined by dividing by 2 and rounding up
+    /// 3 = Run sequence 1, sequence 0, sequence 1 and then sequence 0
+    /// 4 = Run sequence 0, sequence 1, sequence 0 and then sequence 1
+    /// ...and so on.
     Times(u16),
     /// Repeat until `stop` is called.
     Infinite,

--- a/embassy-nrf/src/pwm.rs
+++ b/embassy-nrf/src/pwm.rs
@@ -314,26 +314,58 @@ impl<'s> Sequence<'s> {
     }
 }
 
+/// A single sequence that can be started and stopped.
+/// Takes at one sequence along with its configuration.
+#[non_exhaustive]
+pub struct SingleSequencer<'d, 's, T: Instance> {
+    pub sequencer: Sequencer<'d, 's, T>,
+}
+
+impl<'d, 's, T: Instance> SingleSequencer<'d, 's, T> {
+    /// Create a new sequencer
+    pub fn new(pwm: &'s mut SequencePwm<'d, T>, sequence: Sequence<'s>) -> Self {
+        Self {
+            sequencer: Sequencer::new(pwm, sequence, None),
+        }
+    }
+
+    /// Start or restart playback.
+    #[inline(always)]
+    pub fn start(&self, times: SingleSequenceMode) -> Result<(), Error> {
+        let (start_seq, times) = match times {
+            SingleSequenceMode::Times(n) if n == 1 => (StartSequence::One, SequenceMode::Loop(1)),
+            SingleSequenceMode::Times(n) if n & 1 == 1 => {
+                (StartSequence::One, SequenceMode::Loop((n / 2) + 1))
+            }
+            SingleSequenceMode::Times(n) => (StartSequence::Zero, SequenceMode::Loop(n / 2)),
+            SingleSequenceMode::Infinite => (StartSequence::Zero, SequenceMode::Infinite),
+        };
+        self.sequencer.start(start_seq, times)
+    }
+}
+
 /// A composition of sequences that can be started and stopped.
 /// Takes at least one sequence along with its configuration.
 /// Optionally takes a second sequence and its configuration.
 /// In the case where no second sequence is provided then the first sequence
 /// is used.
 #[non_exhaustive]
-pub struct Sequences<'d, 's, T: Instance> {
-    pub pwm: &'s mut SequencePwm<'d, T>,
+pub struct Sequencer<'d, 's, T: Instance> {
+    _pwm: &'s mut SequencePwm<'d, T>,
     sequence0: Sequence<'s>,
     sequence1: Option<Sequence<'s>>,
 }
 
-impl<'d, 's, T: Instance> Sequences<'d, 's, T> {
+impl<'d, 's, T: Instance> Sequencer<'d, 's, T> {
+    /// Create a new double sequence. In the absence of sequence 1, sequence 0
+    /// will be used twice in the one loop.
     pub fn new(
         pwm: &'s mut SequencePwm<'d, T>,
         sequence0: Sequence<'s>,
         sequence1: Option<Sequence<'s>>,
     ) -> Self {
-        Sequences {
-            pwm,
+        Sequencer {
+            _pwm: pwm,
             sequence0,
             sequence1,
         }
@@ -341,7 +373,7 @@ impl<'d, 's, T: Instance> Sequences<'d, 's, T> {
 
     /// Start or restart playback. The sequence mode applies to both sequences combined as one.
     #[inline(always)]
-    pub fn start(&self, times: SequenceMode) -> Result<(), Error> {
+    pub fn start(&self, start_seq: StartSequence, times: SequenceMode) -> Result<(), Error> {
         let sequence0 = &self.sequence0;
         let alt_sequence = self.sequence1.as_ref().unwrap_or(&self.sequence0);
 
@@ -352,7 +384,7 @@ impl<'d, 's, T: Instance> Sequences<'d, 's, T> {
             return Err(Error::SequenceTooLong);
         }
 
-        if let SequenceMode::Times(0) = times {
+        if let SequenceMode::Loop(0) = times {
             return Err(Error::SequenceTimesAtLeastOne);
         }
 
@@ -391,40 +423,26 @@ impl<'d, 's, T: Instance> Sequences<'d, 's, T> {
         // defensive before seqstart
         compiler_fence(Ordering::SeqCst);
 
+        let seqstart_index = if start_seq == StartSequence::One {
+            1
+        } else {
+            0
+        };
+
         match times {
             // just the one time, no loop count
-            SequenceMode::Times(1) => {
-                r.loop_.write(|w| w.cnt().disabled());
-                // tasks_seqstart() doesn't exist in all svds so write its bit instead
-                r.tasks_seqstart[0].write(|w| unsafe { w.bits(0x01) });
-            }
-            // loop count is how many times to play BOTH sequences
-            // 2 total  (1 x 2)
-            // 3 total, (2 x 2) - 1
-            SequenceMode::Times(n) => {
-                let odd = n & 1 == 1;
-                let times = if odd { (n / 2) + 1 } else { n / 2 };
-
-                r.loop_.write(|w| unsafe { w.cnt().bits(times) });
-
-                // we can subtract 1 by starting at seq1 instead of seq0
-                if odd {
-                    // tasks_seqstart() doesn't exist in all svds so write its bit instead
-                    r.tasks_seqstart[1].write(|w| unsafe { w.bits(0x01) });
-                } else {
-                    // tasks_seqstart() doesn't exist in all svds so write its bit instead
-                    r.tasks_seqstart[0].write(|w| unsafe { w.bits(0x01) });
-                }
+            SequenceMode::Loop(n) => {
+                r.loop_.write(|w| unsafe { w.cnt().bits(n) });
             }
             // to play infinitely, repeat the sequence one time, then have loops done self trigger seq0 again
             SequenceMode::Infinite => {
                 r.loop_.write(|w| unsafe { w.cnt().bits(0x1) });
                 r.shorts.write(|w| w.loopsdone_seqstart0().enabled());
-
-                // tasks_seqstart() doesn't exist in all svds so write its bit instead
-                r.tasks_seqstart[0].write(|w| unsafe { w.bits(0x01) });
             }
         }
+
+        // tasks_seqstart() doesn't exist in all svds so write its bit instead
+        r.tasks_seqstart[seqstart_index].write(|w| unsafe { w.bits(0x01) });
 
         Ok(())
     }
@@ -447,22 +465,35 @@ impl<'d, 's, T: Instance> Sequences<'d, 's, T> {
     }
 }
 
-impl<'d, 's, T: Instance> Drop for Sequences<'d, 's, T> {
+impl<'d, 's, T: Instance> Drop for Sequencer<'d, 's, T> {
     fn drop(&mut self) {
         let _ = self.stop();
     }
 }
 
-/// How many times to run the sequence
+/// How many times to run a single sequence
+#[derive(Debug, Eq, PartialEq, Clone, Copy)]
+pub enum SingleSequenceMode {
+    /// Run a single sequence n Times total.
+    Times(u16),
+    /// Repeat until `stop` is called.
+    Infinite,
+}
+
+/// Which sequence to start a loop with
+#[derive(Debug, Eq, PartialEq, Clone, Copy)]
+pub enum StartSequence {
+    /// Start with Sequence 0
+    Zero,
+    /// Start with Sequence 1
+    One,
+}
+
+/// How many loops to run two sequences
 #[derive(Debug, Eq, PartialEq, Clone, Copy)]
 pub enum SequenceMode {
-    /// Run sequence n Times total.
-    /// 1 = Run sequence 0 once
-    /// 2 = Run sequence 0 and then sequence 1
-    /// 3 = Run sequence 1, sequence 0, sequence 1 and then sequence 0
-    /// 4 = Run sequence 0, sequence 1, sequence 0 and then sequence 1
-    /// ...and so on.
-    Times(u16),
+    /// Run two sequences n loops i.e. (n * (seq0 + seq1.unwrap_or(seq0)))
+    Loop(u16),
     /// Repeat until `stop` is called.
     Infinite,
 }

--- a/embassy-nrf/src/pwm.rs
+++ b/embassy-nrf/src/pwm.rs
@@ -25,14 +25,14 @@ pub struct SimplePwm<'d, T: Instance> {
 
 /// SequencePwm allows you to offload the updating of a sequence of duty cycles
 /// to up to four channels, as well as repeat that sequence n times.
-pub struct SequencePwm<'d, T: Instance, const S0: usize, const S1: usize> {
+pub struct SequencePwm<'d, T: Instance> {
     phantom: PhantomData<&'d mut T>,
     ch0: Option<AnyPin>,
     ch1: Option<AnyPin>,
     ch2: Option<AnyPin>,
     ch3: Option<AnyPin>,
-    sequence0: Option<Sequence<S0>>,
-    sequence1: Option<Sequence<S1>>,
+    sequence0: Option<Sequence<'d>>,
+    sequence1: Option<Sequence<'d>>,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -43,17 +43,13 @@ pub enum Error {
     SequenceTooLong,
     /// Min Sequence count is 1
     SequenceTimesAtLeastOne,
-    /// Sequence 0 is required, Sequence 1 is NOT required
-    SequenceTimesRequireSeq0Only,
-    /// Sequence 0 is required, Sequence 1 is required
-    SequenceTimesRequireBothSeq0AndSeq1,
     /// EasyDMA can only read from data memory, read only buffers in flash will fail.
     DMABufferNotInDataMemory,
 }
 
 const MAX_SEQUENCE_LEN: usize = 32767;
 
-impl<'d, T: Instance, const S0: usize, const S1: usize> SequencePwm<'d, T, S0, S1> {
+impl<'d, T: Instance> SequencePwm<'d, T> {
     /// Creates the interface to a `SequencePwm`.
     ///
     /// Must be started by calling `start`
@@ -72,10 +68,6 @@ impl<'d, T: Instance, const S0: usize, const S1: usize> SequencePwm<'d, T, S0, S
         ch3: impl Unborrow<Target = impl GpioOptionalPin> + 'd,
         config: Config,
     ) -> Result<Self, Error> {
-        if S0 > MAX_SEQUENCE_LEN || S1 > MAX_SEQUENCE_LEN {
-            return Err(Error::SequenceTooLong);
-        }
-
         unborrow!(ch0, ch1, ch2, ch3);
 
         let r = T::regs();
@@ -141,48 +133,30 @@ impl<'d, T: Instance, const S0: usize, const S1: usize> SequencePwm<'d, T, S0, S
     }
 
     /// Start or restart playback. Takes at least one sequence along with its
-    /// configuration. A second sequence must be provided when looping i.e.
-    /// when the sequence mode is anything other than Times(1).
+    /// configuration. Optionally takes a second sequence and its configuration.
+    /// In the case where no second sequence is provided then the first sequence
+    /// is used. The sequence mode applies to both sequences combined as one.
     #[inline(always)]
     pub fn start(
         &mut self,
-        sequence0: Sequence<S0>,
-        sequence1: Sequence<S1>,
+        sequence0: Sequence<'d>,
+        sequence1: Option<Sequence<'d>>,
         times: SequenceMode,
     ) -> Result<(), Error> {
-        slice_in_ram_or(&sequence0.words, Error::DMABufferNotInDataMemory)?;
-        slice_in_ram_or(&sequence1.words, Error::DMABufferNotInDataMemory)?;
+        let alt_sequence = sequence1.as_ref().unwrap_or(&sequence0);
 
-        let seq_0_word_count = sequence0.word_count.unwrap_or(S0);
-        let seq_1_word_count = sequence0.word_count.unwrap_or(S1);
-        if seq_0_word_count > S0 || seq_1_word_count > S1 {
+        slice_in_ram_or(sequence0.words, Error::DMABufferNotInDataMemory)?;
+        slice_in_ram_or(alt_sequence.words, Error::DMABufferNotInDataMemory)?;
+
+        if sequence0.words.len() > MAX_SEQUENCE_LEN || alt_sequence.words.len() > MAX_SEQUENCE_LEN {
             return Err(Error::SequenceTooLong);
         }
 
-        match times {
-            SequenceMode::Times(0) => return Err(Error::SequenceTimesAtLeastOne),
-            SequenceMode::Times(1) if seq_0_word_count == 0 || seq_1_word_count != 0 => {
-                return Err(Error::SequenceTimesRequireSeq0Only)
-            }
-            SequenceMode::Times(1) => (),
-            SequenceMode::Times(_) | SequenceMode::Infinite
-                if seq_0_word_count == 0 || seq_1_word_count == 0 =>
-            {
-                return Err(Error::SequenceTimesRequireBothSeq0AndSeq1)
-            }
-            SequenceMode::Times(_) | SequenceMode::Infinite => (),
+        if let SequenceMode::Times(0) = times {
+            return Err(Error::SequenceTimesAtLeastOne);
         }
 
         let _ = self.stop();
-
-        // We now own these sequences and they will be moved. We want
-        // the peripheral to point at the right bits of memory hence
-        // moving the sequences early.
-        self.sequence0 = Some(sequence0);
-        self.sequence1 = Some(sequence1);
-
-        let sequence0 = self.sequence0.as_ref().unwrap();
-        let sequence1 = self.sequence1.as_ref().unwrap();
 
         let r = T::regs();
 
@@ -197,20 +171,20 @@ impl<'d, T: Instance, const S0: usize, const S1: usize> SequencePwm<'d, T, S0, S
             .write(|w| unsafe { w.bits(sequence0.words.as_ptr() as u32) });
         r.seq0
             .cnt
-            .write(|w| unsafe { w.bits(seq_0_word_count as u32) });
+            .write(|w| unsafe { w.bits(sequence0.words.len() as u32) });
 
         r.seq1
             .refresh
-            .write(|w| unsafe { w.bits(sequence1.config.refresh) });
+            .write(|w| unsafe { w.bits(alt_sequence.config.refresh) });
         r.seq1
             .enddelay
-            .write(|w| unsafe { w.bits(sequence1.config.end_delay) });
+            .write(|w| unsafe { w.bits(alt_sequence.config.end_delay) });
         r.seq1
             .ptr
-            .write(|w| unsafe { w.bits(sequence1.words.as_ptr() as u32) });
+            .write(|w| unsafe { w.bits(alt_sequence.words.as_ptr() as u32) });
         r.seq1
             .cnt
-            .write(|w| unsafe { w.bits(seq_1_word_count as u32) });
+            .write(|w| unsafe { w.bits(alt_sequence.words.len() as u32) });
 
         r.enable.write(|w| w.enable().enabled());
 
@@ -251,6 +225,9 @@ impl<'d, T: Instance, const S0: usize, const S1: usize> SequencePwm<'d, T, S0, S
                 r.tasks_seqstart[0].write(|w| unsafe { w.bits(0x01) });
             }
         }
+
+        self.sequence0 = Some(sequence0);
+        self.sequence1 = sequence1;
 
         Ok(())
     }
@@ -359,7 +336,7 @@ impl<'d, T: Instance, const S0: usize, const S1: usize> SequencePwm<'d, T, S0, S
     /// cycle from the pin. Returns any sequences previously provided to
     /// `start` so that they may be further mutated.
     #[inline(always)]
-    pub fn stop(&mut self) -> (Option<Sequence<S0>>, Option<Sequence<S1>>) {
+    pub fn stop(&mut self) -> (Option<Sequence<'d>>, Option<Sequence<'d>>) {
         let r = T::regs();
 
         r.shorts.reset();
@@ -375,7 +352,7 @@ impl<'d, T: Instance, const S0: usize, const S1: usize> SequencePwm<'d, T, S0, S
     }
 }
 
-impl<'a, T: Instance, const S0: usize, const S1: usize> Drop for SequencePwm<'a, T, S0, S1> {
+impl<'a, T: Instance> Drop for SequencePwm<'a, T> {
     fn drop(&mut self) {
         let r = T::regs();
 
@@ -404,7 +381,6 @@ impl<'a, T: Instance, const S0: usize, const S1: usize> Drop for SequencePwm<'a,
     }
 }
 
-/// Configuration for the PWM as a whole.
 #[non_exhaustive]
 pub struct Config {
     /// Selects up mode or up-and-down mode for the counter
@@ -428,7 +404,6 @@ impl Default for Config {
     }
 }
 
-/// Configuration per sequence
 #[non_exhaustive]
 #[derive(Clone)]
 pub struct SequenceConfig {
@@ -447,38 +422,19 @@ impl Default for SequenceConfig {
     }
 }
 
-/// A composition of a sequence buffer and its configuration.
 #[non_exhaustive]
-#[derive(Clone)]
-pub struct Sequence<const S: usize> {
+pub struct Sequence<'d> {
     /// The words comprising the sequence. Must not exceed 32767 words.
-    pub words: [u16; S],
-    /// The count of words to use. If None the S will be used.
-    pub word_count: Option<usize>,
+    pub words: &'d mut [u16],
     /// Configuration associated with the sequence.
     pub config: SequenceConfig,
 }
 
-impl<const S: usize> Sequence<S> {
-    pub const fn new(words: [u16; S], config: SequenceConfig) -> Self {
-        Self {
-            words,
-            word_count: None,
-            config,
-        }
+impl<'d> Sequence<'d> {
+    pub fn new(words: &'d mut [u16], config: SequenceConfig) -> Self {
+        Self { words, config }
     }
 }
-
-/// Declares an empty sequence which will cause it to be disabled.
-/// Note that any looping i.e. !Times(1), will require a second
-/// sequence given the way the PWM peripheral works.
-pub const EMPTY_SEQ: Sequence<0> = Sequence::new(
-    [],
-    SequenceConfig {
-        refresh: 0,
-        end_delay: 0,
-    },
-);
 
 /// How many times to run the sequence
 #[derive(Debug, Eq, PartialEq, Clone, Copy)]
@@ -490,7 +446,7 @@ pub enum SequenceMode {
     /// 5 to 6 = Run sequence 0, sequence 1, sequence 0, sequence 1, sequence 0 and then sequence 1
     /// i.e the when >= 2 the loop count is determined by dividing by 2 and rounding up
     Times(u16),
-    /// Repeat until `stop` is called. Both sequences must be provided.
+    /// Repeat until `stop` is called.
     Infinite,
 }
 

--- a/embassy-nrf/src/pwm.rs
+++ b/embassy-nrf/src/pwm.rs
@@ -381,6 +381,7 @@ impl<'a, T: Instance> Drop for SequencePwm<'a, T> {
     }
 }
 
+/// Configuration for the PWM as a whole.
 #[non_exhaustive]
 pub struct Config {
     /// Selects up mode or up-and-down mode for the counter
@@ -404,6 +405,7 @@ impl Default for Config {
     }
 }
 
+/// Configuration per sequence
 #[non_exhaustive]
 #[derive(Clone)]
 pub struct SequenceConfig {
@@ -422,6 +424,7 @@ impl Default for SequenceConfig {
     }
 }
 
+/// A composition of a sequence buffer and its configuration.
 #[non_exhaustive]
 pub struct Sequence<'d> {
     /// The words comprising the sequence. Must not exceed 32767 words.

--- a/examples/nrf/src/bin/pwm_double_sequence.rs
+++ b/examples/nrf/src/bin/pwm_double_sequence.rs
@@ -9,13 +9,15 @@ use embassy::executor::Spawner;
 use embassy::time::{Duration, Timer};
 use embassy_nrf::gpio::NoPin;
 use embassy_nrf::pwm::{
-    Config, Prescaler, Sequence, SequenceConfig, SequencePwm, SingleSequenceMode, SingleSequencer,
+    Config, Prescaler, Sequence, SequenceConfig, SequenceMode, SequencePwm, Sequencer,
+    StartSequence,
 };
 use embassy_nrf::Peripherals;
 
 #[embassy::main]
 async fn main(_spawner: Spawner, p: Peripherals) {
-    let seq_words: [u16; 5] = [1000, 250, 100, 50, 0];
+    let seq_words_0: [u16; 5] = [1000, 250, 100, 50, 0];
+    let seq_words_1: [u16; 4] = [50, 100, 250, 1000];
 
     let mut config = Config::default();
     config.prescaler = Prescaler::Div128;
@@ -31,13 +33,14 @@ async fn main(_spawner: Spawner, p: Peripherals) {
         p.PWM0, p.P0_13, NoPin, NoPin, NoPin, config,
     ));
 
-    let sequence = Sequence::new(&seq_words, seq_config.clone());
-    let sequencer = SingleSequencer::new(&mut pwm, sequence);
-    unwrap!(sequencer.start(SingleSequenceMode::Times(1)));
+    let sequence_0 = Sequence::new(&seq_words_0, seq_config.clone());
+    let sequence_1 = Sequence::new(&seq_words_1, seq_config);
+    let sequencer = Sequencer::new(&mut pwm, sequence_0, Some(sequence_1));
+    unwrap!(sequencer.start(StartSequence::Zero, SequenceMode::Loop(1)));
 
     // we can abort a sequence if we need to before its complete with pwm.stop()
     // or stop is also implicitly called when the pwm peripheral is dropped
     // when it goes out of scope
-    Timer::after(Duration::from_millis(20000)).await;
+    Timer::after(Duration::from_millis(40000)).await;
     info!("pwm stopped early!");
 }

--- a/examples/nrf/src/bin/pwm_sequence.rs
+++ b/examples/nrf/src/bin/pwm_sequence.rs
@@ -8,13 +8,13 @@ use defmt::*;
 use embassy::executor::Spawner;
 use embassy::time::{Duration, Timer};
 use embassy_nrf::gpio::NoPin;
-use embassy_nrf::pwm::{Config, Prescaler, SequenceMode, SequencePwm};
+use embassy_nrf::pwm::{Config, Prescaler, Sequence, SequenceConfig, SequenceMode, SequencePwm};
 use embassy_nrf::Peripherals;
 
 #[embassy::main]
 async fn main(_spawner: Spawner, p: Peripherals) {
-    let seq_values_1: [u16; 5] = [1000, 250, 100, 50, 0];
-    let seq_values_2: [u16; 5] = [0, 50, 100, 250, 1000];
+    let seq_words_1: [u16; 5] = [1000, 250, 100, 50, 0];
+    let seq_words_2: [u16; 5] = [0, 50, 100, 250, 1000];
 
     let mut config = Config::default();
     config.prescaler = Prescaler::Div128;
@@ -22,7 +22,7 @@ async fn main(_spawner: Spawner, p: Peripherals) {
     // but say we want to hold the value for 5000ms
     // so we want to repeat our value as many times as necessary until 5000ms passes
     // want 5000/8 = 625 periods total to occur, so 624 (we get the one period for free remember)
-    let mut seq_config = Config::default();
+    let mut seq_config = SequenceConfig::default();
     seq_config.refresh = 624;
     // thus our sequence takes 5 * 5000ms or 25 seconds
 
@@ -30,11 +30,9 @@ async fn main(_spawner: Spawner, p: Peripherals) {
         p.PWM0, p.P0_13, NoPin, NoPin, NoPin, config,
     ));
     let _ = pwm.start(
-        &seq_values_1,
-        seq_config,
+        Sequence::new(&seq_words_1, seq_config.clone()),
         None,
-        None,
-        SeqSequenceMode::Infinite,
+        SequenceMode::Infinite,
     );
 
     info!("pwm started!");
@@ -43,9 +41,7 @@ async fn main(_spawner: Spawner, p: Peripherals) {
     info!("pwm starting with another sequence!");
 
     let _ = pwm.start(
-        &seq_values_2,
-        seq_config,
-        None,
+        Sequence::new(&seq_words_2, seq_config),
         None,
         SequenceMode::Infinite,
     );

--- a/examples/nrf/src/bin/pwm_sequence.rs
+++ b/examples/nrf/src/bin/pwm_sequence.rs
@@ -9,7 +9,7 @@ use embassy::executor::Spawner;
 use embassy::time::{Duration, Timer};
 use embassy_nrf::gpio::NoPin;
 use embassy_nrf::pwm::{
-    Config, Prescaler, Sequence, SequenceConfig, SequencePwm, SingleSequenceMode, SingleSequencer,
+    Config, Prescaler, SequenceConfig, SequencePwm, SingleSequenceMode, SingleSequencer,
 };
 use embassy_nrf::Peripherals;
 
@@ -31,8 +31,7 @@ async fn main(_spawner: Spawner, p: Peripherals) {
         p.PWM0, p.P0_13, NoPin, NoPin, NoPin, config,
     ));
 
-    let sequence = Sequence::new(&seq_words, seq_config);
-    let sequencer = SingleSequencer::new(&mut pwm, sequence);
+    let sequencer = SingleSequencer::new(&mut pwm, &seq_words, seq_config);
     unwrap!(sequencer.start(SingleSequenceMode::Times(1)));
 
     // we can abort a sequence if we need to before its complete with pwm.stop()

--- a/examples/nrf/src/bin/pwm_sequence.rs
+++ b/examples/nrf/src/bin/pwm_sequence.rs
@@ -8,7 +8,7 @@ use defmt::*;
 use embassy::executor::Spawner;
 use embassy::time::{Duration, Timer};
 use embassy_nrf::gpio::NoPin;
-use embassy_nrf::pwm::{Prescaler, SequenceConfig, SequenceMode, SequencePwm};
+use embassy_nrf::pwm::{Config, Prescaler, SequenceMode, SequencePwm};
 use embassy_nrf::Peripherals;
 
 #[embassy::main]
@@ -16,26 +16,39 @@ async fn main(_spawner: Spawner, p: Peripherals) {
     let seq_values_1: [u16; 5] = [1000, 250, 100, 50, 0];
     let seq_values_2: [u16; 5] = [0, 50, 100, 250, 1000];
 
-    let mut config = SequenceConfig::default();
+    let mut config = Config::default();
     config.prescaler = Prescaler::Div128;
     // 1 period is 1000 * (128/16mhz = 0.000008s = 0.008ms) = 8us
     // but say we want to hold the value for 5000ms
     // so we want to repeat our value as many times as necessary until 5000ms passes
     // want 5000/8 = 625 periods total to occur, so 624 (we get the one period for free remember)
-    config.refresh = 624;
+    let mut seq_config = Config::default();
+    seq_config.refresh = 624;
     // thus our sequence takes 5 * 5000ms or 25 seconds
 
     let mut pwm = unwrap!(SequencePwm::new(
         p.PWM0, p.P0_13, NoPin, NoPin, NoPin, config,
     ));
-    let _ = pwm.start(&seq_values_1, SequenceMode::Infinite);
+    let _ = pwm.start(
+        &seq_values_1,
+        seq_config,
+        None,
+        None,
+        SeqSequenceMode::Infinite,
+    );
 
     info!("pwm started!");
 
     Timer::after(Duration::from_millis(20000)).await;
     info!("pwm starting with another sequence!");
 
-    let _ = pwm.start(&seq_values_2, SequenceMode::Infinite);
+    let _ = pwm.start(
+        &seq_values_2,
+        seq_config,
+        None,
+        None,
+        SequenceMode::Infinite,
+    );
 
     // we can abort a sequence if we need to before its complete with pwm.stop()
     // or stop is also implicitly called when the pwm peripheral is dropped

--- a/examples/nrf/src/bin/pwm_sequence.rs
+++ b/examples/nrf/src/bin/pwm_sequence.rs
@@ -32,7 +32,7 @@ async fn main(_spawner: Spawner, p: Peripherals) {
     let _ = pwm.start(
         Sequence::new(&mut seq_words_1, seq_config.clone()),
         None,
-        SequenceMode::Infinite,
+        SequenceMode::Times(1),
     );
 
     info!("pwm started!");
@@ -43,7 +43,7 @@ async fn main(_spawner: Spawner, p: Peripherals) {
     let _ = pwm.start(
         Sequence::new(&mut seq_words_2, seq_config),
         None,
-        SequenceMode::Infinite,
+        SequenceMode::Times(1),
     );
 
     // we can abort a sequence if we need to before its complete with pwm.stop()

--- a/examples/nrf/src/bin/pwm_sequence.rs
+++ b/examples/nrf/src/bin/pwm_sequence.rs
@@ -13,8 +13,8 @@ use embassy_nrf::Peripherals;
 
 #[embassy::main]
 async fn main(_spawner: Spawner, p: Peripherals) {
-    let seq_words_1: [u16; 5] = [1000, 250, 100, 50, 0];
-    let seq_words_2: [u16; 5] = [0, 50, 100, 250, 1000];
+    let mut seq_words_1: [u16; 5] = [1000, 250, 100, 50, 0];
+    let mut seq_words_2: [u16; 5] = [0, 50, 100, 250, 1000];
 
     let mut config = Config::default();
     config.prescaler = Prescaler::Div128;
@@ -30,7 +30,7 @@ async fn main(_spawner: Spawner, p: Peripherals) {
         p.PWM0, p.P0_13, NoPin, NoPin, NoPin, config,
     ));
     let _ = pwm.start(
-        Sequence::new(&seq_words_1, seq_config.clone()),
+        Sequence::new(&mut seq_words_1, seq_config.clone()),
         None,
         SequenceMode::Infinite,
     );
@@ -41,7 +41,7 @@ async fn main(_spawner: Spawner, p: Peripherals) {
     info!("pwm starting with another sequence!");
 
     let _ = pwm.start(
-        Sequence::new(&seq_words_2, seq_config),
+        Sequence::new(&mut seq_words_2, seq_config),
         None,
         SequenceMode::Infinite,
     );

--- a/examples/nrf/src/bin/pwm_sequence.rs
+++ b/examples/nrf/src/bin/pwm_sequence.rs
@@ -31,7 +31,7 @@ async fn main(_spawner: Spawner, p: Peripherals) {
         p.PWM0, p.P0_13, NoPin, NoPin, NoPin, config,
     ));
 
-    let sequence = Sequence::new(&seq_words, seq_config.clone());
+    let sequence = Sequence::new(&seq_words, seq_config);
     let sequencer = SingleSequencer::new(&mut pwm, sequence);
     unwrap!(sequencer.start(SingleSequenceMode::Times(1)));
 

--- a/examples/nrf/src/bin/pwm_sequence.rs
+++ b/examples/nrf/src/bin/pwm_sequence.rs
@@ -8,13 +8,14 @@ use defmt::*;
 use embassy::executor::Spawner;
 use embassy::time::{Duration, Timer};
 use embassy_nrf::gpio::NoPin;
-use embassy_nrf::pwm::{
-    Config, Prescaler, Sequence, SequenceConfig, SequenceMode, SequencePwm, EMPTY_SEQ,
-};
+use embassy_nrf::pwm::{Config, Prescaler, Sequence, SequenceConfig, SequenceMode, SequencePwm};
 use embassy_nrf::Peripherals;
 
 #[embassy::main]
 async fn main(_spawner: Spawner, p: Peripherals) {
+    let mut seq_words_1: [u16; 5] = [1000, 250, 100, 50, 0];
+    let mut seq_words_2: [u16; 5] = [0, 50, 100, 250, 1000];
+
     let mut config = Config::default();
     config.prescaler = Prescaler::Div128;
     // 1 period is 1000 * (128/16mhz = 0.000008s = 0.008ms) = 8us
@@ -25,20 +26,25 @@ async fn main(_spawner: Spawner, p: Peripherals) {
     seq_config.refresh = 624;
     // thus our sequence takes 5 * 5000ms or 25 seconds
 
-    let seq_1 = Sequence::new([1000, 250, 100, 50, 0], seq_config.clone());
-    let seq_2 = Sequence::new([0, 50, 100, 250, 1000], seq_config);
-
     let mut pwm = unwrap!(SequencePwm::new(
         p.PWM0, p.P0_13, NoPin, NoPin, NoPin, config,
     ));
-    unwrap!(pwm.start(seq_1, EMPTY_SEQ, SequenceMode::Times(1)));
+    let _ = pwm.start(
+        Sequence::new(&mut seq_words_1, seq_config.clone()),
+        None,
+        SequenceMode::Infinite,
+    );
 
     info!("pwm started!");
 
     Timer::after(Duration::from_millis(20000)).await;
     info!("pwm starting with another sequence!");
 
-    unwrap!(pwm.start(seq_2, EMPTY_SEQ, SequenceMode::Times(1)));
+    let _ = pwm.start(
+        Sequence::new(&mut seq_words_2, seq_config),
+        None,
+        SequenceMode::Infinite,
+    );
 
     // we can abort a sequence if we need to before its complete with pwm.stop()
     // or stop is also implicitly called when the pwm peripheral is dropped

--- a/examples/nrf/src/bin/pwm_sequence_ppi.rs
+++ b/examples/nrf/src/bin/pwm_sequence_ppi.rs
@@ -16,7 +16,7 @@ use embassy_nrf::Peripherals;
 
 #[embassy::main]
 async fn main(_spawner: Spawner, p: Peripherals) {
-    let seq_words: [u16; 5] = [1000, 250, 100, 50, 0];
+    let mut seq_words: [u16; 5] = [1000, 250, 100, 50, 0];
 
     let mut config = Config::default();
     config.prescaler = Prescaler::Div128;
@@ -31,12 +31,11 @@ async fn main(_spawner: Spawner, p: Peripherals) {
         p.PWM0, p.P0_13, NoPin, NoPin, NoPin, config,
     ));
 
-    // If we loop in any way i.e. not Times(1), then we must provide
-    // the PWM peripheral with two sequences.
-    let seq_0 = Sequence::new(seq_words, seq_config);
-    let seq_1 = seq_0.clone();
-
-    unwrap!(pwm.start(seq_0, seq_1, SequenceMode::Infinite));
+    let _ = pwm.start(
+        Sequence::new(&mut seq_words, seq_config),
+        None,
+        SequenceMode::Infinite,
+    );
     // pwm.stop() deconfigures pins, and then the task_start_seq0 task cant work
     // so its going to have to start running in order load the configuration
 

--- a/examples/nrf/src/bin/pwm_sequence_ppi.rs
+++ b/examples/nrf/src/bin/pwm_sequence_ppi.rs
@@ -11,12 +11,12 @@ use embassy::executor::Spawner;
 use embassy_nrf::gpio::{Input, NoPin, Pull};
 use embassy_nrf::gpiote::{InputChannel, InputChannelPolarity};
 use embassy_nrf::ppi::Ppi;
-use embassy_nrf::pwm::{Config, Prescaler, SequenceConfig, SequenceMode, SequencePwm};
+use embassy_nrf::pwm::{Config, Prescaler, Sequence, SequenceConfig, SequenceMode, SequencePwm};
 use embassy_nrf::Peripherals;
 
 #[embassy::main]
 async fn main(_spawner: Spawner, p: Peripherals) {
-    let seq_values: [u16; 5] = [1000, 250, 100, 50, 0];
+    let seq_words: [u16; 5] = [1000, 250, 100, 50, 0];
 
     let mut config = Config::default();
     config.prescaler = Prescaler::Div128;
@@ -31,7 +31,11 @@ async fn main(_spawner: Spawner, p: Peripherals) {
         p.PWM0, p.P0_13, NoPin, NoPin, NoPin, config,
     ));
 
-    let _ = pwm.start(&seq_values, seq_config, None, None, SequenceMode::Infinite);
+    let _ = pwm.start(
+        Sequence::new(&seq_words, seq_config),
+        None,
+        SequenceMode::Infinite,
+    );
     // pwm.stop() deconfigures pins, and then the task_start_seq0 task cant work
     // so its going to have to start running in order load the configuration
 

--- a/examples/nrf/src/bin/pwm_sequence_ppi.rs
+++ b/examples/nrf/src/bin/pwm_sequence_ppi.rs
@@ -12,7 +12,7 @@ use embassy_nrf::gpio::{Input, NoPin, Pull};
 use embassy_nrf::gpiote::{InputChannel, InputChannelPolarity};
 use embassy_nrf::ppi::Ppi;
 use embassy_nrf::pwm::{
-    Config, Prescaler, Sequence, SequenceConfig, SequencePwm, SingleSequenceMode, SingleSequencer,
+    Config, Prescaler, SequenceConfig, SequencePwm, SingleSequenceMode, SingleSequencer,
 };
 use embassy_nrf::Peripherals;
 
@@ -53,8 +53,7 @@ async fn main(_spawner: Spawner, p: Peripherals) {
     let start = unsafe { pwm.task_start_seq0() };
     let stop = unsafe { pwm.task_stop() };
 
-    let sequence = Sequence::new(&seq_words, seq_config);
-    let sequencer = SingleSequencer::new(&mut pwm, sequence);
+    let sequencer = SingleSequencer::new(&mut pwm, &seq_words, seq_config);
     unwrap!(sequencer.start(SingleSequenceMode::Infinite));
 
     let mut ppi = Ppi::new_one_to_one(p.PPI_CH1, button1.event_in(), start);

--- a/examples/nrf/src/bin/pwm_sequence_ppi.rs
+++ b/examples/nrf/src/bin/pwm_sequence_ppi.rs
@@ -16,7 +16,7 @@ use embassy_nrf::Peripherals;
 
 #[embassy::main]
 async fn main(_spawner: Spawner, p: Peripherals) {
-    let mut seq_words: [u16; 5] = [1000, 250, 100, 50, 0];
+    let seq_words: [u16; 5] = [1000, 250, 100, 50, 0];
 
     let mut config = Config::default();
     config.prescaler = Prescaler::Div128;
@@ -31,11 +31,12 @@ async fn main(_spawner: Spawner, p: Peripherals) {
         p.PWM0, p.P0_13, NoPin, NoPin, NoPin, config,
     ));
 
-    let _ = pwm.start(
-        Sequence::new(&mut seq_words, seq_config),
-        None,
-        SequenceMode::Infinite,
-    );
+    // If we loop in any way i.e. not Times(1), then we must provide
+    // the PWM peripheral with two sequences.
+    let seq_0 = Sequence::new(seq_words, seq_config);
+    let seq_1 = seq_0.clone();
+
+    unwrap!(pwm.start(seq_0, seq_1, SequenceMode::Infinite));
     // pwm.stop() deconfigures pins, and then the task_start_seq0 task cant work
     // so its going to have to start running in order load the configuration
 

--- a/examples/nrf/src/bin/pwm_sequence_ppi.rs
+++ b/examples/nrf/src/bin/pwm_sequence_ppi.rs
@@ -11,12 +11,14 @@ use embassy::executor::Spawner;
 use embassy_nrf::gpio::{Input, NoPin, Pull};
 use embassy_nrf::gpiote::{InputChannel, InputChannelPolarity};
 use embassy_nrf::ppi::Ppi;
-use embassy_nrf::pwm::{Config, Prescaler, Sequence, SequenceConfig, SequenceMode, SequencePwm};
+use embassy_nrf::pwm::{
+    Config, Prescaler, Sequence, SequenceConfig, SequenceMode, SequencePwm, Sequences,
+};
 use embassy_nrf::Peripherals;
 
 #[embassy::main]
 async fn main(_spawner: Spawner, p: Peripherals) {
-    let mut seq_words: [u16; 5] = [1000, 250, 100, 50, 0];
+    let seq_words: [u16; 5] = [1000, 250, 100, 50, 0];
 
     let mut config = Config::default();
     config.prescaler = Prescaler::Div128;
@@ -31,11 +33,10 @@ async fn main(_spawner: Spawner, p: Peripherals) {
         p.PWM0, p.P0_13, NoPin, NoPin, NoPin, config,
     ));
 
-    let _ = pwm.start(
-        Sequence::new(&mut seq_words, seq_config),
-        None,
-        SequenceMode::Infinite,
-    );
+    let sequence0 = Sequence::new(&seq_words, seq_config);
+    let sequences = Sequences::new(&mut pwm, sequence0, None);
+    unwrap!(sequences.start(SequenceMode::Infinite));
+
     // pwm.stop() deconfigures pins, and then the task_start_seq0 task cant work
     // so its going to have to start running in order load the configuration
 
@@ -53,8 +54,8 @@ async fn main(_spawner: Spawner, p: Peripherals) {
 
     // messing with the pwm tasks is ill advised
     // Times::Ininite and Times even are seq0, Times odd is seq1
-    let start = unsafe { pwm.task_start_seq0() };
-    let stop = unsafe { pwm.task_stop() };
+    let start = unsafe { sequences.pwm.task_start_seq0() };
+    let stop = unsafe { sequences.pwm.task_stop() };
 
     let mut ppi = Ppi::new_one_to_one(p.PPI_CH1, button1.event_in(), start);
     ppi.enable();

--- a/examples/nrf/src/bin/pwm_sequence_ppi.rs
+++ b/examples/nrf/src/bin/pwm_sequence_ppi.rs
@@ -16,7 +16,7 @@ use embassy_nrf::Peripherals;
 
 #[embassy::main]
 async fn main(_spawner: Spawner, p: Peripherals) {
-    let seq_words: [u16; 5] = [1000, 250, 100, 50, 0];
+    let mut seq_words: [u16; 5] = [1000, 250, 100, 50, 0];
 
     let mut config = Config::default();
     config.prescaler = Prescaler::Div128;
@@ -32,7 +32,7 @@ async fn main(_spawner: Spawner, p: Peripherals) {
     ));
 
     let _ = pwm.start(
-        Sequence::new(&seq_words, seq_config),
+        Sequence::new(&mut seq_words, seq_config),
         None,
         SequenceMode::Infinite,
     );

--- a/examples/nrf/src/bin/pwm_sequence_ws2812b.rs
+++ b/examples/nrf/src/bin/pwm_sequence_ws2812b.rs
@@ -55,7 +55,7 @@ async fn main(_spawner: Spawner, p: Peripherals) {
     loop {
         let sequence0 = Sequence::new(&seq_words, seq_config.clone());
         let sequences = Sequences::new(&mut pwm, sequence0, None);
-        unwrap!(sequences.start(SequenceMode::Times(2)));
+        unwrap!(sequences.start(SequenceMode::Times(1)));
 
         Timer::after(Duration::from_millis(50)).await;
 

--- a/examples/nrf/src/bin/pwm_sequence_ws2812b.rs
+++ b/examples/nrf/src/bin/pwm_sequence_ws2812b.rs
@@ -1,0 +1,60 @@
+#![no_std]
+#![no_main]
+#![feature(type_alias_impl_trait)]
+
+#[path = "../example_common.rs"]
+mod example_common;
+use defmt::*;
+use embassy::executor::Spawner;
+use embassy::time::{Duration, Timer};
+use embassy_nrf::gpio::NoPin;
+use embassy_nrf::pwm::{
+    Config, Prescaler, SequenceConfig, SequenceLoad, SequenceMode, SequencePwm,
+};
+use embassy_nrf::Peripherals;
+
+// WS2812B LED light demonstration. Drives just one light.
+// The following reference on WS2812B may be of use:
+// https://cdn-shop.adafruit.com/datasheets/WS2812B.pdf
+
+// In the following declarations, setting the high bit tells the PWM
+// to reverse polarity, which is what the WS2812B expects.
+
+const T1H: u16 = 0x8000 | 13; // Duty = 13/20 ticks (0.8us/1.25us) for a 1
+const T0H: u16 = 0x8000 | 7; // Duty 7/20 ticks (0.4us/1.25us) for a 0
+const RES: u16 = 0x8000;
+
+// Provides data to a WS2812b (Neopixel) LED and makes it go blue. The data
+// line is assumed to be P1_05.
+#[embassy::main]
+async fn main(_spawner: Spawner, p: Peripherals) {
+    // Declare the bits of 24 bits
+    let mut blue_seq: [u16; 8 * 3] = [
+        T0H, T0H, T0H, T0H, T0H, T0H, T0H, T0H, // G
+        T0H, T0H, T0H, T0H, T0H, T0H, T0H, T0H, // R
+        T1H, T1H, T1H, T1H, T1H, T1H, T1H, T1H, // B
+    ];
+    let reset_seq = [RES; 1];
+
+    let mut config = Config::default();
+    config.sequence_load = SequenceLoad::Common;
+    config.prescaler = Prescaler::Div1;
+    config.max_duty = 20; // 1.25us (1s / 16Mhz * 20)
+    let mut pwm = unwrap!(SequencePwm::new(
+        p.PWM0, p.P1_05, NoPin, NoPin, NoPin, config,
+    ));
+
+    let blue_seq_config = SequenceConfig::default();
+    let mut reset_seq_config = SequenceConfig::default();
+    reset_seq_config.end_delay = 799; // 50us (20 ticks * 40) - 1 tick because we've already got one RES
+    unwrap!(pwm.start(
+        &blue_seq,
+        blue_seq_config,
+        Some(&reset_seq),
+        Some(reset_seq_config),
+        SequenceMode::Times(2)
+    ));
+
+    Timer::after(Duration::from_millis(20000)).await;
+    info!("Program stopped");
+}

--- a/examples/nrf/src/bin/pwm_sequence_ws2812b.rs
+++ b/examples/nrf/src/bin/pwm_sequence_ws2812b.rs
@@ -9,7 +9,8 @@ use embassy::executor::Spawner;
 use embassy::time::{Duration, Timer};
 use embassy_nrf::gpio::NoPin;
 use embassy_nrf::pwm::{
-    Config, Prescaler, Sequence, SequenceConfig, SequenceLoad, SequenceMode, SequencePwm, Sequences,
+    Config, Prescaler, Sequence, SequenceConfig, SequenceLoad, SequencePwm, SingleSequenceMode,
+    SingleSequencer,
 };
 use embassy_nrf::Peripherals;
 
@@ -54,8 +55,8 @@ async fn main(_spawner: Spawner, p: Peripherals) {
 
     loop {
         let sequence0 = Sequence::new(&seq_words, seq_config.clone());
-        let sequences = Sequences::new(&mut pwm, sequence0, None);
-        unwrap!(sequences.start(SequenceMode::Times(1)));
+        let sequences = SingleSequencer::new(&mut pwm, sequence0);
+        unwrap!(sequences.start(SingleSequenceMode::Times(1)));
 
         Timer::after(Duration::from_millis(50)).await;
 

--- a/examples/nrf/src/bin/pwm_sequence_ws2812b.rs
+++ b/examples/nrf/src/bin/pwm_sequence_ws2812b.rs
@@ -7,11 +7,12 @@ mod example_common;
 use defmt::*;
 use embassy::executor::Spawner;
 use embassy::time::{Duration, Timer};
+use embassy::util::Forever;
 use embassy_nrf::gpio::NoPin;
 use embassy_nrf::pwm::{
     Config, Prescaler, Sequence, SequenceConfig, SequenceLoad, SequenceMode, SequencePwm, Sequences,
 };
-use embassy_nrf::Peripherals;
+use embassy_nrf::{peripherals, Peripherals};
 
 // WS2812B LED light demonstration. Drives just one light.
 // The following reference on WS2812B may be of use:
@@ -26,6 +27,8 @@ const T1H: u16 = 0x8000 | 13; // Duty = 13/20 ticks (0.8us/1.25us) for a 1
 const T0H: u16 = 0x8000 | 7; // Duty 7/20 ticks (0.4us/1.25us) for a 0
 const RES: u16 = 0x8000;
 
+static PWM: Forever<SequencePwm<peripherals::PWM0>> = Forever::new();
+
 // Provides data to a WS2812b (Neopixel) LED and makes it go blue. The data
 // line is assumed to be P1_05.
 #[embassy::main]
@@ -34,9 +37,11 @@ async fn main(_spawner: Spawner, p: Peripherals) {
     config.sequence_load = SequenceLoad::Common;
     config.prescaler = Prescaler::Div1;
     config.max_duty = 20; // 1.25us (1s / 16Mhz * 20)
-    let mut pwm = unwrap!(SequencePwm::new(
+    let pwm = unwrap!(SequencePwm::new(
         p.PWM0, p.P1_05, NoPin, NoPin, NoPin, config,
     ));
+
+    let mut pwm = PWM.put(pwm);
 
     // Declare the bits of 24 bits in a buffer we'll be
     // mutating later.

--- a/examples/nrf/src/bin/pwm_sequence_ws2812b.rs
+++ b/examples/nrf/src/bin/pwm_sequence_ws2812b.rs
@@ -9,7 +9,7 @@ use embassy::executor::Spawner;
 use embassy::time::{Duration, Timer};
 use embassy_nrf::gpio::NoPin;
 use embassy_nrf::pwm::{
-    Config, Prescaler, Sequence, SequenceConfig, SequenceLoad, SequencePwm, SingleSequenceMode,
+    Config, Prescaler, SequenceConfig, SequenceLoad, SequencePwm, SingleSequenceMode,
     SingleSequencer,
 };
 use embassy_nrf::Peripherals;
@@ -54,8 +54,7 @@ async fn main(_spawner: Spawner, p: Peripherals) {
     let mut bit_value = T0H;
 
     loop {
-        let sequence0 = Sequence::new(&seq_words, seq_config.clone());
-        let sequences = SingleSequencer::new(&mut pwm, sequence0);
+        let sequences = SingleSequencer::new(&mut pwm, &seq_words, seq_config.clone());
         unwrap!(sequences.start(SingleSequenceMode::Times(1)));
 
         Timer::after(Duration::from_millis(50)).await;

--- a/examples/nrf/src/bin/pwm_sequence_ws2812b.rs
+++ b/examples/nrf/src/bin/pwm_sequence_ws2812b.rs
@@ -30,19 +30,6 @@ const RES: u16 = 0x8000;
 // line is assumed to be P1_05.
 #[embassy::main]
 async fn main(_spawner: Spawner, p: Peripherals) {
-    // Declare the bits of 24 bits
-    let mut color_seq_words = [
-        T0H, T0H, T0H, T0H, T0H, T0H, T0H, T0H, // G
-        T0H, T0H, T0H, T0H, T0H, T0H, T0H, T0H, // R
-        T1H, T1H, T1H, T1H, T1H, T1H, T1H, T1H, // B
-    ];
-    let color_seq = Sequence::new(&mut color_seq_words, SequenceConfig::default());
-
-    let mut reset_seq_words = [RES; 1];
-    let mut reset_seq_config = SequenceConfig::default();
-    reset_seq_config.end_delay = 799; // 50us (20 ticks * 40) - 1 tick because we've already got one RES;
-    let reset_seq = Sequence::new(&mut reset_seq_words, reset_seq_config);
-
     let mut config = Config::default();
     config.sequence_load = SequenceLoad::Common;
     config.prescaler = Prescaler::Div1;
@@ -51,7 +38,21 @@ async fn main(_spawner: Spawner, p: Peripherals) {
         p.PWM0, p.P1_05, NoPin, NoPin, NoPin, config,
     ));
 
-    unwrap!(pwm.start(color_seq, Some(reset_seq), SequenceMode::Times(2)));
+    // Declare the bits of 24 bits
+    let color_seq = Sequence::new(
+        [
+            T0H, T0H, T0H, T0H, T0H, T0H, T0H, T0H, // G
+            T0H, T0H, T0H, T0H, T0H, T0H, T0H, T0H, // R
+            T1H, T1H, T1H, T1H, T1H, T1H, T1H, T1H, // B
+        ],
+        SequenceConfig::default(),
+    );
+
+    let mut reset_seq_config = SequenceConfig::default();
+    reset_seq_config.end_delay = 799; // 50us (20 ticks * 40) - 1 tick because we've already got one RES;
+    let reset_seq = Sequence::new([RES], reset_seq_config);
+
+    unwrap!(pwm.start(color_seq, reset_seq, SequenceMode::Times(2)));
 
     Timer::after(Duration::from_millis(1000)).await;
 
@@ -59,9 +60,9 @@ async fn main(_spawner: Spawner, p: Peripherals) {
     let mut bit_value = T0H;
 
     loop {
-        if let (Some(color_seq), Some(reset_seq)) = pwm.stop() {
+        if let (Some(mut color_seq), Some(reset_seq)) = pwm.stop() {
             color_seq.words[color_bit] = bit_value;
-            unwrap!(pwm.start(color_seq, Some(reset_seq), SequenceMode::Times(2)));
+            unwrap!(pwm.start(color_seq, reset_seq, SequenceMode::Times(2)));
         }
 
         Timer::after(Duration::from_millis(50)).await;

--- a/examples/nrf/src/bin/pwm_sequence_ws2812b.rs
+++ b/examples/nrf/src/bin/pwm_sequence_ws2812b.rs
@@ -9,7 +9,7 @@ use embassy::executor::Spawner;
 use embassy::time::{Duration, Timer};
 use embassy_nrf::gpio::NoPin;
 use embassy_nrf::pwm::{
-    Config, Prescaler, Sequence, SequenceConfig, SequenceLoad, SequenceMode, SequencePwm,
+    Config, Prescaler, Sequence, SequenceConfig, SequenceLoad, SequenceMode, SequencePwm, Sequences,
 };
 use embassy_nrf::Peripherals;
 
@@ -30,19 +30,6 @@ const RES: u16 = 0x8000;
 // line is assumed to be P1_05.
 #[embassy::main]
 async fn main(_spawner: Spawner, p: Peripherals) {
-    // Declare the bits of 24 bits
-    let mut color_seq_words = [
-        T0H, T0H, T0H, T0H, T0H, T0H, T0H, T0H, // G
-        T0H, T0H, T0H, T0H, T0H, T0H, T0H, T0H, // R
-        T1H, T1H, T1H, T1H, T1H, T1H, T1H, T1H, // B
-    ];
-    let color_seq = Sequence::new(&mut color_seq_words, SequenceConfig::default());
-
-    let mut reset_seq_words = [RES; 1];
-    let mut reset_seq_config = SequenceConfig::default();
-    reset_seq_config.end_delay = 799; // 50us (20 ticks * 40) - 1 tick because we've already got one RES;
-    let reset_seq = Sequence::new(&mut reset_seq_words, reset_seq_config);
-
     let mut config = Config::default();
     config.sequence_load = SequenceLoad::Common;
     config.prescaler = Prescaler::Div1;
@@ -51,18 +38,24 @@ async fn main(_spawner: Spawner, p: Peripherals) {
         p.PWM0, p.P1_05, NoPin, NoPin, NoPin, config,
     ));
 
-    unwrap!(pwm.start(color_seq, Some(reset_seq), SequenceMode::Times(2)));
-
-    Timer::after(Duration::from_millis(1000)).await;
+    // Declare the bits of 24 bits in a buffer we'll be
+    // mutating later.
+    let mut seq_words = [
+        T0H, T0H, T0H, T0H, T0H, T0H, T0H, T0H, // G
+        T0H, T0H, T0H, T0H, T0H, T0H, T0H, T0H, // R
+        T1H, T1H, T1H, T1H, T1H, T1H, T1H, T1H, // B
+        RES,
+    ];
+    let mut seq_config = SequenceConfig::default();
+    seq_config.end_delay = 799; // 50us (20 ticks * 40) - 1 tick because we've already got one RES;
 
     let mut color_bit = 16;
     let mut bit_value = T0H;
 
     loop {
-        if let (Some(color_seq), Some(reset_seq)) = pwm.stop() {
-            color_seq.words[color_bit] = bit_value;
-            unwrap!(pwm.start(color_seq, Some(reset_seq), SequenceMode::Times(2)));
-        }
+        let sequence0 = Sequence::new(&seq_words, seq_config.clone());
+        let sequences = Sequences::new(&mut pwm, sequence0, None);
+        unwrap!(sequences.start(SequenceMode::Times(2)));
 
         Timer::after(Duration::from_millis(50)).await;
 
@@ -79,5 +72,9 @@ async fn main(_spawner: Spawner, p: Peripherals) {
                 color_bit -= 1;
             }
         }
+
+        drop(sequences);
+
+        seq_words[color_bit] = bit_value;
     }
 }

--- a/examples/nrf/src/bin/pwm_sequence_ws2812b.rs
+++ b/examples/nrf/src/bin/pwm_sequence_ws2812b.rs
@@ -7,12 +7,11 @@ mod example_common;
 use defmt::*;
 use embassy::executor::Spawner;
 use embassy::time::{Duration, Timer};
-use embassy::util::Forever;
 use embassy_nrf::gpio::NoPin;
 use embassy_nrf::pwm::{
     Config, Prescaler, Sequence, SequenceConfig, SequenceLoad, SequenceMode, SequencePwm, Sequences,
 };
-use embassy_nrf::{peripherals, Peripherals};
+use embassy_nrf::Peripherals;
 
 // WS2812B LED light demonstration. Drives just one light.
 // The following reference on WS2812B may be of use:
@@ -27,8 +26,6 @@ const T1H: u16 = 0x8000 | 13; // Duty = 13/20 ticks (0.8us/1.25us) for a 1
 const T0H: u16 = 0x8000 | 7; // Duty 7/20 ticks (0.4us/1.25us) for a 0
 const RES: u16 = 0x8000;
 
-static PWM: Forever<SequencePwm<peripherals::PWM0>> = Forever::new();
-
 // Provides data to a WS2812b (Neopixel) LED and makes it go blue. The data
 // line is assumed to be P1_05.
 #[embassy::main]
@@ -37,11 +34,9 @@ async fn main(_spawner: Spawner, p: Peripherals) {
     config.sequence_load = SequenceLoad::Common;
     config.prescaler = Prescaler::Div1;
     config.max_duty = 20; // 1.25us (1s / 16Mhz * 20)
-    let pwm = unwrap!(SequencePwm::new(
+    let mut pwm = unwrap!(SequencePwm::new(
         p.PWM0, p.P1_05, NoPin, NoPin, NoPin, config,
     ));
-
-    let mut pwm = PWM.put(pwm);
 
     // Declare the bits of 24 bits in a buffer we'll be
     // mutating later.


### PR DESCRIPTION
I've permitted the PWM sequences to be mutated on stopping the PWM by associating them with a new  `SingleSequencer` structure. This is so that we can perform effects on the LEDs (and other use-cases, I'm sure!). The example has been updated to illustrate the use of this by flashing a WS2812B LED.

There's also a `Sequencer` structure for more sophisticated PWM interactions, along with a `pwm_double_sequence`  example to illustrate.

These changes should make it possible to attain all of the nRF PWM functionality available.