### PR TITLE
stm32f3: fix nonexistent cfg tests

### DIFF
--- a/embassy-stm32/build.rs
+++ b/embassy-stm32/build.rs
@@ -125,6 +125,10 @@ fn main() {
         println!("cargo:rustc-cfg={}", &chip_name[..chip_name.len() - 2]);
     }
 
+    if chip_name.starts_with("stm32f3") {
+        println!("cargo:rustc-cfg={}x{}", &chip_name[..9], &chip_name[10..11]);
+    }
+
     // ========
     // Handle time-driver-XXXX features.
 

--- a/embassy-stm32/src/rcc/f3.rs
+++ b/embassy-stm32/src/rcc/f3.rs
@@ -217,8 +217,8 @@ fn calc_pll(config: &Config, Hertz(sysclk): Hertz) -> (Hertz, PllConfig) {
             cfg_if::cfg_if! {
                 // For some chips PREDIV is always two, and cannot be changed
                 if #[cfg(any(
-                        feature="stm32f302xd", feature="stm32f302xe", feature="stm32f303xd",
-                        feature="stm32f303xe", feature="stm32f398xe"
+                        stm32f302xd, stm32f302xe, stm32f303xd,
+                        stm32f303xe, stm32f398xe
                     ))] {
                     let (multiplier, divisor) = get_mul_div(sysclk, HSI);
                     (


### PR DESCRIPTION
The rcc code was taken from stm32-rs which uses 'x' features, but embassy uses features with full chip names.

Add these 'x' wildcards as cfgs and use them in rcc. They will be useful for USB #580 too.

---

I don't have any F3 boards, so this is not tested. But the original cfg clearly doesn't look right…