### PR TITLE
stm32: Remove OptionalPin

### DIFF
--- a/embassy-rp/src/spi.rs
+++ b/embassy-rp/src/spi.rs
@@ -62,11 +62,11 @@ fn calc_prescs(freq: u32) -> (u8, u8) {
 
 impl<'d, T: Instance> Spi<'d, T> {
     pub fn new(
-        inner: impl Unborrow<Target = T>,
-        clk: impl Unborrow<Target = impl ClkPin<T>>,
-        mosi: impl Unborrow<Target = impl MosiPin<T>>,
-        miso: impl Unborrow<Target = impl MisoPin<T>>,
-        cs: impl Unborrow<Target = impl CsPin<T>>,
+        inner: impl Unborrow<Target = T> + 'd,
+        clk: impl Unborrow<Target = impl ClkPin<T>> + 'd,
+        mosi: impl Unborrow<Target = impl MosiPin<T>> + 'd,
+        miso: impl Unborrow<Target = impl MisoPin<T>> + 'd,
+        cs: impl Unborrow<Target = impl CsPin<T>> + 'd,
         config: Config,
     ) -> Self {
         unborrow!(inner, clk, mosi, miso, cs);

--- a/embassy-rp/src/uart.rs
+++ b/embassy-rp/src/uart.rs
@@ -30,11 +30,11 @@ pub struct Uart<'d, T: Instance> {
 
 impl<'d, T: Instance> Uart<'d, T> {
     pub fn new(
-        inner: impl Unborrow<Target = T>,
-        tx: impl Unborrow<Target = impl TxPin<T>>,
-        rx: impl Unborrow<Target = impl RxPin<T>>,
-        cts: impl Unborrow<Target = impl CtsPin<T>>,
-        rts: impl Unborrow<Target = impl RtsPin<T>>,
+        inner: impl Unborrow<Target = T> + 'd,
+        tx: impl Unborrow<Target = impl TxPin<T>> + 'd,
+        rx: impl Unborrow<Target = impl RxPin<T>> + 'd,
+        cts: impl Unborrow<Target = impl CtsPin<T>> + 'd,
+        rts: impl Unborrow<Target = impl RtsPin<T>> + 'd,
         config: Config,
     ) -> Self {
         unborrow!(inner, tx, rx, cts, rts);

--- a/embassy-stm32/src/crc/v1.rs
+++ b/embassy-stm32/src/crc/v1.rs
@@ -1,16 +1,19 @@
+use core::marker::PhantomData;
+
 use crate::pac::CRC as PAC_CRC;
 use crate::peripherals::CRC;
 use crate::rcc::sealed::RccPeripheral;
 use embassy::util::Unborrow;
 use embassy_hal_common::unborrow;
 
-pub struct Crc {
+pub struct Crc<'d> {
     _peripheral: CRC,
+    _phantom: PhantomData<&'d mut CRC>,
 }
 
-impl Crc {
+impl<'d> Crc<'d> {
     /// Instantiates the CRC32 peripheral and initializes it to default values.
-    pub fn new(peripheral: impl Unborrow<Target = CRC>) -> Self {
+    pub fn new(peripheral: impl Unborrow<Target = CRC> + 'd) -> Self {
         // Note: enable and reset come from RccPeripheral.
         // enable CRC clock in RCC.
         CRC::enable();
@@ -20,6 +23,7 @@ impl Crc {
         unborrow!(peripheral);
         let mut instance = Self {
             _peripheral: peripheral,
+            _phantom: PhantomData,
         };
         instance.reset();
         instance

--- a/embassy-stm32/src/crc/v2v3.rs
+++ b/embassy-stm32/src/crc/v2v3.rs
@@ -1,3 +1,5 @@
+use core::marker::PhantomData;
+
 use crate::pac::crc::vals;
 use crate::pac::CRC as PAC_CRC;
 use crate::peripherals::CRC;
@@ -5,8 +7,9 @@ use crate::rcc::sealed::RccPeripheral;
 use embassy::util::Unborrow;
 use embassy_hal_common::unborrow;
 
-pub struct Crc {
+pub struct Crc<'d> {
     _peripheral: CRC,
+    _phantom: PhantomData<&'d mut CRC>,
     _config: Config,
 }
 
@@ -64,9 +67,9 @@ pub enum PolySize {
     Width32,
 }
 
-impl Crc {
+impl<'d> Crc<'d> {
     /// Instantiates the CRC32 peripheral and initializes it to default values.
-    pub fn new(peripheral: impl Unborrow<Target = CRC>, config: Config) -> Self {
+    pub fn new(peripheral: impl Unborrow<Target = CRC> + 'd, config: Config) -> Self {
         // Note: enable and reset come from RccPeripheral.
         // enable CRC clock in RCC.
         CRC::enable();
@@ -75,6 +78,7 @@ impl Crc {
         unborrow!(peripheral);
         let mut instance = Self {
             _peripheral: peripheral,
+            _phantom: PhantomData,
             _config: config,
         };
         CRC::reset();

--- a/embassy-stm32/src/dac/mod.rs
+++ b/embassy-stm32/src/dac/mod.rs
@@ -3,26 +3,20 @@
 #[cfg_attr(dac_v1, path = "v1.rs")]
 #[cfg_attr(dac_v2, path = "v2.rs")]
 mod _version;
-use crate::gpio::NoPin;
 use crate::peripherals;
 pub use _version::*;
 
 pub(crate) mod sealed {
-    use crate::gpio::OptionalPin;
-
     pub trait Instance {
         fn regs() -> &'static crate::pac::dac::Dac;
     }
 
-    pub trait DacPin<T: Instance, const C: u8>: OptionalPin {}
+    pub trait DacPin<T: Instance, const C: u8>: crate::gpio::Pin {}
 }
 
 pub trait Instance: sealed::Instance + 'static {}
 
 pub trait DacPin<T: Instance, const C: u8>: sealed::DacPin<T, C> + 'static {}
-
-impl<T: Instance, const C: u8> DacPin<T, C> for NoPin {}
-impl<T: Instance, const C: u8> sealed::DacPin<T, C> for NoPin {}
 
 crate::pac::peripherals!(
     (dac, $inst:ident) => {

--- a/embassy-stm32/src/gpio.rs
+++ b/embassy-stm32/src/gpio.rs
@@ -544,54 +544,6 @@ impl sealed::Pin for AnyPin {
 
 // ====================
 
-pub trait OptionalPin: sealed::OptionalPin + Sized {
-    type Pin: Pin;
-    fn pin(&self) -> Option<&Self::Pin>;
-    fn pin_mut(&mut self) -> Option<&mut Self::Pin>;
-
-    /// Convert from concrete pin type PX_XX to type erased `Option<AnyPin>`.
-    #[inline]
-    fn degrade_optional(mut self) -> Option<AnyPin> {
-        self.pin_mut()
-            .map(|pin| unsafe { core::ptr::read(pin) }.degrade())
-    }
-}
-
-impl<T: Pin> sealed::OptionalPin for T {}
-impl<T: Pin> OptionalPin for T {
-    type Pin = T;
-
-    #[inline]
-    fn pin(&self) -> Option<&T> {
-        Some(self)
-    }
-
-    #[inline]
-    fn pin_mut(&mut self) -> Option<&mut T> {
-        Some(self)
-    }
-}
-
-#[derive(Clone, Copy, Debug)]
-pub struct NoPin;
-unsafe_impl_unborrow!(NoPin);
-impl sealed::OptionalPin for NoPin {}
-impl OptionalPin for NoPin {
-    type Pin = AnyPin;
-
-    #[inline]
-    fn pin(&self) -> Option<&AnyPin> {
-        None
-    }
-
-    #[inline]
-    fn pin_mut(&mut self) -> Option<&mut AnyPin> {
-        None
-    }
-}
-
-// ====================
-
 crate::pac::pins!(
     ($pin_name:ident, $port_name:ident, $port_num:expr, $pin_num:expr, $exti_ch:ident) => {
         impl Pin for peripherals::$pin_name {

--- a/embassy-stm32/src/i2c/v1.rs
+++ b/embassy-stm32/src/i2c/v1.rs
@@ -15,8 +15,8 @@ pub struct I2c<'d, T: Instance> {
 impl<'d, T: Instance> I2c<'d, T> {
     pub fn new<F>(
         _peri: impl Unborrow<Target = T> + 'd,
-        scl: impl Unborrow<Target = impl SclPin<T>>,
-        sda: impl Unborrow<Target = impl SdaPin<T>>,
+        scl: impl Unborrow<Target = impl SclPin<T>> + 'd,
+        sda: impl Unborrow<Target = impl SdaPin<T>> + 'd,
         freq: F,
     ) -> Self
     where

--- a/embassy-stm32/src/pwm/mod.rs
+++ b/embassy-stm32/src/pwm/mod.rs
@@ -248,31 +248,6 @@ crate::pac::interrupts! {
     };
 }
 
-#[allow(unused)]
-macro_rules! impl_pwm_nopin {
-    ($inst:ident) => {
-        impl_no_pin!($inst, Channel1Pin);
-        impl_no_pin!($inst, Channel1ComplementaryPin);
-        impl_no_pin!($inst, Channel2Pin);
-        impl_no_pin!($inst, Channel2ComplementaryPin);
-        impl_no_pin!($inst, Channel3Pin);
-        impl_no_pin!($inst, Channel3ComplementaryPin);
-        impl_no_pin!($inst, Channel4Pin);
-        impl_no_pin!($inst, Channel4ComplementaryPin);
-        impl_no_pin!($inst, ExternalTriggerPin);
-        impl_no_pin!($inst, BreakInputPin);
-        impl_no_pin!($inst, BreakInputComparator1Pin);
-        impl_no_pin!($inst, BreakInputComparator2Pin);
-        impl_no_pin!($inst, BreakInput2Pin);
-        impl_no_pin!($inst, BreakInput2Comparator1Pin);
-        impl_no_pin!($inst, BreakInput2Comparator2Pin);
-    };
-}
-
-crate::pac::peripherals!(
-    (timer, $inst:ident) => { impl_pwm_nopin!($inst); };
-);
-
 crate::pac::peripheral_pins!(
     ($inst:ident, timer, $block:ident, $pin:ident, CH1, $af:expr) => {
         impl_pin!($inst, Channel1Pin, $pin, $af);

--- a/embassy-stm32/src/pwm/pins.rs
+++ b/embassy-stm32/src/pwm/pins.rs
@@ -1,4 +1,4 @@
-use crate::gpio::OptionalPin;
+use crate::gpio::Pin;
 
 #[cfg(feature = "unstable-pac")]
 pub mod low_level {
@@ -6,116 +6,104 @@ pub mod low_level {
 }
 
 pub(crate) mod sealed {
-    use crate::gpio::sealed::OptionalPin;
+    use crate::gpio::sealed::Pin;
 
-    pub trait Channel1Pin<Timer>: OptionalPin {
+    pub trait Channel1Pin<Timer>: Pin {
         unsafe fn configure(&mut self);
     }
-    pub trait Channel1ComplementaryPin<Timer>: OptionalPin {
-        unsafe fn configure(&mut self);
-    }
-
-    pub trait Channel2Pin<Timer>: OptionalPin {
-        unsafe fn configure(&mut self);
-    }
-    pub trait Channel2ComplementaryPin<Timer>: OptionalPin {
+    pub trait Channel1ComplementaryPin<Timer>: Pin {
         unsafe fn configure(&mut self);
     }
 
-    pub trait Channel3Pin<Timer>: OptionalPin {
+    pub trait Channel2Pin<Timer>: Pin {
         unsafe fn configure(&mut self);
     }
-    pub trait Channel3ComplementaryPin<Timer>: OptionalPin {
-        unsafe fn configure(&mut self);
-    }
-
-    pub trait Channel4Pin<Timer>: OptionalPin {
-        unsafe fn configure(&mut self);
-    }
-    pub trait Channel4ComplementaryPin<Timer>: OptionalPin {
+    pub trait Channel2ComplementaryPin<Timer>: Pin {
         unsafe fn configure(&mut self);
     }
 
-    pub trait ExternalTriggerPin<Timer>: OptionalPin {
+    pub trait Channel3Pin<Timer>: Pin {
+        unsafe fn configure(&mut self);
+    }
+    pub trait Channel3ComplementaryPin<Timer>: Pin {
         unsafe fn configure(&mut self);
     }
 
-    pub trait BreakInputPin<Timer>: OptionalPin {
+    pub trait Channel4Pin<Timer>: Pin {
         unsafe fn configure(&mut self);
     }
-    pub trait BreakInputComparator1Pin<Timer>: OptionalPin {
-        unsafe fn configure(&mut self);
-    }
-    pub trait BreakInputComparator2Pin<Timer>: OptionalPin {
+    pub trait Channel4ComplementaryPin<Timer>: Pin {
         unsafe fn configure(&mut self);
     }
 
-    pub trait BreakInput2Pin<Timer>: OptionalPin {
+    pub trait ExternalTriggerPin<Timer>: Pin {
         unsafe fn configure(&mut self);
     }
-    pub trait BreakInput2Comparator1Pin<Timer>: OptionalPin {
+
+    pub trait BreakInputPin<Timer>: Pin {
         unsafe fn configure(&mut self);
     }
-    pub trait BreakInput2Comparator2Pin<Timer>: OptionalPin {
+    pub trait BreakInputComparator1Pin<Timer>: Pin {
+        unsafe fn configure(&mut self);
+    }
+    pub trait BreakInputComparator2Pin<Timer>: Pin {
+        unsafe fn configure(&mut self);
+    }
+
+    pub trait BreakInput2Pin<Timer>: Pin {
+        unsafe fn configure(&mut self);
+    }
+    pub trait BreakInput2Comparator1Pin<Timer>: Pin {
+        unsafe fn configure(&mut self);
+    }
+    pub trait BreakInput2Comparator2Pin<Timer>: Pin {
         unsafe fn configure(&mut self);
     }
 }
-pub trait Channel1Pin<Timer>: sealed::Channel1Pin<Timer> + OptionalPin + 'static {}
+pub trait Channel1Pin<Timer>: sealed::Channel1Pin<Timer> + Pin + 'static {}
 pub trait Channel1ComplementaryPin<Timer>:
-    sealed::Channel1ComplementaryPin<Timer> + OptionalPin + 'static
+    sealed::Channel1ComplementaryPin<Timer> + Pin + 'static
 {
 }
 
 pub trait Channel2Pin<Timer>: sealed::Channel2Pin<Timer> + 'static {}
 pub trait Channel2ComplementaryPin<Timer>:
-    sealed::Channel2ComplementaryPin<Timer> + OptionalPin + 'static
+    sealed::Channel2ComplementaryPin<Timer> + Pin + 'static
 {
 }
 
 pub trait Channel3Pin<Timer>: sealed::Channel3Pin<Timer> + 'static {}
 pub trait Channel3ComplementaryPin<Timer>:
-    sealed::Channel3ComplementaryPin<Timer> + OptionalPin + 'static
+    sealed::Channel3ComplementaryPin<Timer> + Pin + 'static
 {
 }
 
 pub trait Channel4Pin<Timer>: sealed::Channel4Pin<Timer> + 'static {}
 pub trait Channel4ComplementaryPin<Timer>:
-    sealed::Channel4ComplementaryPin<Timer> + OptionalPin + 'static
+    sealed::Channel4ComplementaryPin<Timer> + Pin + 'static
 {
 }
 
-pub trait ExternalTriggerPin<Timer>:
-    sealed::ExternalTriggerPin<Timer> + OptionalPin + 'static
-{
-}
+pub trait ExternalTriggerPin<Timer>: sealed::ExternalTriggerPin<Timer> + Pin + 'static {}
 
-pub trait BreakInputPin<Timer>: sealed::BreakInputPin<Timer> + OptionalPin + 'static {}
+pub trait BreakInputPin<Timer>: sealed::BreakInputPin<Timer> + Pin + 'static {}
 pub trait BreakInputComparator1Pin<Timer>:
-    sealed::BreakInputComparator1Pin<Timer> + OptionalPin + 'static
+    sealed::BreakInputComparator1Pin<Timer> + Pin + 'static
 {
 }
 pub trait BreakInputComparator2Pin<Timer>:
-    sealed::BreakInputComparator2Pin<Timer> + OptionalPin + 'static
+    sealed::BreakInputComparator2Pin<Timer> + Pin + 'static
 {
 }
 
-pub trait BreakInput2Pin<Timer>: sealed::BreakInput2Pin<Timer> + OptionalPin + 'static {}
+pub trait BreakInput2Pin<Timer>: sealed::BreakInput2Pin<Timer> + Pin + 'static {}
 pub trait BreakInput2Comparator1Pin<Timer>:
-    sealed::BreakInput2Comparator1Pin<Timer> + OptionalPin + 'static
+    sealed::BreakInput2Comparator1Pin<Timer> + Pin + 'static
 {
 }
 pub trait BreakInput2Comparator2Pin<Timer>:
-    sealed::BreakInput2Comparator2Pin<Timer> + OptionalPin + 'static
+    sealed::BreakInput2Comparator2Pin<Timer> + Pin + 'static
 {
-}
-
-macro_rules! impl_no_pin {
-    ($timer:ident, $signal:ident) => {
-        impl crate::pwm::pins::sealed::$signal<crate::peripherals::$timer> for crate::gpio::NoPin {
-            unsafe fn configure(&mut self) {}
-        }
-        impl crate::pwm::pins::$signal<crate::peripherals::$timer> for crate::gpio::NoPin {}
-    };
 }
 
 #[allow(unused)]

--- a/embassy-stm32/src/sdmmc/v2.rs
+++ b/embassy-stm32/src/sdmmc/v2.rs
@@ -189,7 +189,7 @@ impl<'d, T: Instance, P: Pins<T>> Sdmmc<'d, T, P> {
     pub unsafe fn new(
         _peripheral: impl Unborrow<Target = T> + 'd,
         pins: impl Unborrow<Target = P> + 'd,
-        irq: impl Unborrow<Target = T::Interrupt>,
+        irq: impl Unborrow<Target = T::Interrupt> + 'd,
         config: Config,
     ) -> Self {
         unborrow!(irq, pins);

--- a/embassy-stm32/src/spi/mod.rs
+++ b/embassy-stm32/src/spi/mod.rs
@@ -8,8 +8,8 @@ use embassy_hal_common::unborrow;
 use self::sealed::WordSize;
 use crate::dma;
 use crate::dma::NoDma;
-use crate::gpio::sealed::{AFType, Pin};
-use crate::gpio::{AnyPin, NoPin, OptionalPin};
+use crate::gpio::sealed::{AFType, Pin as _};
+use crate::gpio::{AnyPin, Pin};
 use crate::pac::spi::{regs, vals};
 use crate::peripherals;
 use crate::rcc::RccPeripheral;
@@ -92,10 +92,116 @@ pub struct Spi<'d, T: Instance, Tx, Rx> {
 
 impl<'d, T: Instance, Tx, Rx> Spi<'d, T, Tx, Rx> {
     pub fn new<F>(
+        peri: impl Unborrow<Target = T> + 'd,
+        sck: impl Unborrow<Target = impl SckPin<T>> + 'd,
+        mosi: impl Unborrow<Target = impl MosiPin<T>> + 'd,
+        miso: impl Unborrow<Target = impl MisoPin<T>> + 'd,
+        txdma: impl Unborrow<Target = Tx> + 'd,
+        rxdma: impl Unborrow<Target = Rx> + 'd,
+        freq: F,
+        config: Config,
+    ) -> Self
+    where
+        F: Into<Hertz>,
+    {
+        unborrow!(sck, mosi, miso);
+        unsafe {
+            sck.set_as_af(sck.af_num(), AFType::OutputPushPull);
+            #[cfg(any(spi_v2, spi_v3))]
+            sck.set_speed(crate::gpio::Speed::VeryHigh);
+            mosi.set_as_af(mosi.af_num(), AFType::OutputPushPull);
+            #[cfg(any(spi_v2, spi_v3))]
+            mosi.set_speed(crate::gpio::Speed::VeryHigh);
+            miso.set_as_af(miso.af_num(), AFType::Input);
+            #[cfg(any(spi_v2, spi_v3))]
+            miso.set_speed(crate::gpio::Speed::VeryHigh);
+        }
+
+        Self::new_inner(
+            peri,
+            Some(sck.degrade()),
+            Some(mosi.degrade()),
+            Some(miso.degrade()),
+            txdma,
+            rxdma,
+            freq,
+            config,
+        )
+    }
+
+    pub fn new_rxonly<F>(
+        peri: impl Unborrow<Target = T> + 'd,
+        sck: impl Unborrow<Target = impl SckPin<T>> + 'd,
+        miso: impl Unborrow<Target = impl MisoPin<T>> + 'd,
+        txdma: impl Unborrow<Target = Tx> + 'd, // TODO remove
+        rxdma: impl Unborrow<Target = Rx> + 'd,
+        freq: F,
+        config: Config,
+    ) -> Self
+    where
+        F: Into<Hertz>,
+    {
+        unborrow!(sck, miso);
+        unsafe {
+            sck.set_as_af(sck.af_num(), AFType::OutputPushPull);
+            #[cfg(any(spi_v2, spi_v3))]
+            sck.set_speed(crate::gpio::Speed::VeryHigh);
+            miso.set_as_af(miso.af_num(), AFType::Input);
+            #[cfg(any(spi_v2, spi_v3))]
+            miso.set_speed(crate::gpio::Speed::VeryHigh);
+        }
+
+        Self::new_inner(
+            peri,
+            Some(sck.degrade()),
+            None,
+            Some(miso.degrade()),
+            txdma,
+            rxdma,
+            freq,
+            config,
+        )
+    }
+
+    pub fn new_txonly<F>(
+        peri: impl Unborrow<Target = T> + 'd,
+        sck: impl Unborrow<Target = impl SckPin<T>> + 'd,
+        mosi: impl Unborrow<Target = impl MosiPin<T>> + 'd,
+        txdma: impl Unborrow<Target = Tx> + 'd,
+        rxdma: impl Unborrow<Target = Rx> + 'd, // TODO remove
+        freq: F,
+        config: Config,
+    ) -> Self
+    where
+        F: Into<Hertz>,
+    {
+        unborrow!(sck, mosi);
+        unsafe {
+            sck.set_as_af(sck.af_num(), AFType::OutputPushPull);
+            #[cfg(any(spi_v2, spi_v3))]
+            sck.set_speed(crate::gpio::Speed::VeryHigh);
+            mosi.set_as_af(mosi.af_num(), AFType::OutputPushPull);
+            #[cfg(any(spi_v2, spi_v3))]
+            mosi.set_speed(crate::gpio::Speed::VeryHigh);
+        }
+
+        Self::new_inner(
+            peri,
+            Some(sck.degrade()),
+            Some(mosi.degrade()),
+            None,
+            txdma,
+            rxdma,
+            freq,
+            config,
+        )
+    }
+
+    fn new_inner<F>(
         _peri: impl Unborrow<Target = T> + 'd,
-        sck: impl Unborrow<Target = impl SckPin<T>>,
-        mosi: impl Unborrow<Target = impl MosiPin<T>>,
-        miso: impl Unborrow<Target = impl MisoPin<T>>,
+        sck: Option<AnyPin>,
+        mosi: Option<AnyPin>,
+        miso: Option<AnyPin>,
         txdma: impl Unborrow<Target = Tx>,
         rxdma: impl Unborrow<Target = Rx>,
         freq: F,
@@ -104,32 +210,7 @@ impl<'d, T: Instance, Tx, Rx> Spi<'d, T, Tx, Rx> {
     where
         F: Into<Hertz>,
     {
-        unborrow!(sck, mosi, miso, txdma, rxdma);
-
-        let sck_af = sck.af_num();
-        let mosi_af = mosi.af_num();
-        let miso_af = miso.af_num();
-        let sck = sck.degrade_optional();
-        let mosi = mosi.degrade_optional();
-        let miso = miso.degrade_optional();
-
-        unsafe {
-            sck.as_ref().map(|x| {
-                x.set_as_af(sck_af, AFType::OutputPushPull);
-                #[cfg(any(spi_v2, spi_v3))]
-                x.set_speed(crate::gpio::Speed::VeryHigh);
-            });
-            mosi.as_ref().map(|x| {
-                x.set_as_af(mosi_af, AFType::OutputPushPull);
-                #[cfg(any(spi_v2, spi_v3))]
-                x.set_speed(crate::gpio::Speed::VeryHigh);
-            });
-            miso.as_ref().map(|x| {
-                x.set_as_af(miso_af, AFType::Input);
-                #[cfg(any(spi_v2, spi_v3))]
-                x.set_speed(crate::gpio::Speed::VeryHigh);
-            });
-        }
+        unborrow!(txdma, rxdma);
 
         let pclk = T::frequency();
         let br = compute_baud_rate(pclk, freq.into());
@@ -719,15 +800,15 @@ pub(crate) mod sealed {
         fn regs() -> &'static crate::pac::spi::Spi;
     }
 
-    pub trait SckPin<T: Instance>: OptionalPin {
+    pub trait SckPin<T: Instance>: Pin {
         fn af_num(&self) -> u8;
     }
 
-    pub trait MosiPin<T: Instance>: OptionalPin {
+    pub trait MosiPin<T: Instance>: Pin {
         fn af_num(&self) -> u8;
     }
 
-    pub trait MisoPin<T: Instance>: OptionalPin {
+    pub trait MisoPin<T: Instance>: Pin {
         fn af_num(&self) -> u8;
     }
 
@@ -862,26 +943,6 @@ crate::pac::peripheral_pins!(
 
     ($inst:ident, spi, SPI, $pin:ident, MISO) => {
         impl_pin!($inst, $pin, MisoPin, 0);
-    };
-);
-
-macro_rules! impl_nopin {
-    ($inst:ident, $signal:ident) => {
-        impl $signal<peripherals::$inst> for NoPin {}
-
-        impl sealed::$signal<peripherals::$inst> for NoPin {
-            fn af_num(&self) -> u8 {
-                0
-            }
-        }
-    };
-}
-
-crate::pac::peripherals!(
-    (spi, $inst:ident) => {
-        impl_nopin!($inst, SckPin);
-        impl_nopin!($inst, MosiPin);
-        impl_nopin!($inst, MisoPin);
     };
 );
 

--- a/embassy-stm32/src/spi/mod.rs
+++ b/embassy-stm32/src/spi/mod.rs
@@ -202,8 +202,8 @@ impl<'d, T: Instance, Tx, Rx> Spi<'d, T, Tx, Rx> {
         sck: Option<AnyPin>,
         mosi: Option<AnyPin>,
         miso: Option<AnyPin>,
-        txdma: impl Unborrow<Target = Tx>,
-        rxdma: impl Unborrow<Target = Rx>,
+        txdma: impl Unborrow<Target = Tx> + 'd,
+        rxdma: impl Unborrow<Target = Rx> + 'd,
         freq: F,
         config: Config,
     ) -> Self

--- a/embassy-stm32/src/subghz/mod.rs
+++ b/embassy-stm32/src/subghz/mod.rs
@@ -215,11 +215,11 @@ impl<'d, Tx, Rx> SubGhz<'d, Tx, Rx> {
     /// clock.
     pub fn new(
         peri: impl Unborrow<Target = SUBGHZSPI> + 'd,
-        sck: impl Unborrow<Target = impl SckPin<SUBGHZSPI>>,
-        mosi: impl Unborrow<Target = impl MosiPin<SUBGHZSPI>>,
-        miso: impl Unborrow<Target = impl MisoPin<SUBGHZSPI>>,
-        txdma: impl Unborrow<Target = Tx>,
-        rxdma: impl Unborrow<Target = Rx>,
+        sck: impl Unborrow<Target = impl SckPin<SUBGHZSPI>> + 'd,
+        mosi: impl Unborrow<Target = impl MosiPin<SUBGHZSPI>> + 'd,
+        miso: impl Unborrow<Target = impl MisoPin<SUBGHZSPI>> + 'd,
+        txdma: impl Unborrow<Target = Tx> + 'd,
+        rxdma: impl Unborrow<Target = Rx> + 'd,
     ) -> Self {
         Self::pulse_radio_reset();
 

--- a/embassy-stm32/src/usart/mod.rs
+++ b/embassy-stm32/src/usart/mod.rs
@@ -81,11 +81,11 @@ pub struct Uart<'d, T: Instance, TxDma = NoDma, RxDma = NoDma> {
 
 impl<'d, T: Instance, TxDma, RxDma> Uart<'d, T, TxDma, RxDma> {
     pub fn new(
-        inner: impl Unborrow<Target = T>,
-        rx: impl Unborrow<Target = impl RxPin<T>>,
-        tx: impl Unborrow<Target = impl TxPin<T>>,
-        tx_dma: impl Unborrow<Target = TxDma>,
-        rx_dma: impl Unborrow<Target = RxDma>,
+        inner: impl Unborrow<Target = T> + 'd,
+        rx: impl Unborrow<Target = impl RxPin<T>> + 'd,
+        tx: impl Unborrow<Target = impl TxPin<T>> + 'd,
+        tx_dma: impl Unborrow<Target = TxDma> + 'd,
+        rx_dma: impl Unborrow<Target = RxDma> + 'd,
         config: Config,
     ) -> Self {
         unborrow!(inner, rx, tx, tx_dma, rx_dma);

--- a/examples/stm32g4/src/bin/pwm.rs
+++ b/examples/stm32g4/src/bin/pwm.rs
@@ -6,7 +6,6 @@
 mod example_common;
 use embassy::executor::Spawner;
 use embassy::time::{Duration, Timer};
-use embassy_stm32::gpio::NoPin;
 use embassy_stm32::pwm::{simple_pwm::SimplePwm, Channel};
 use embassy_stm32::time::U32Ext;
 use embassy_stm32::Peripherals;
@@ -16,7 +15,7 @@ use example_common::*;
 async fn main(_spawner: Spawner, p: Peripherals) {
     info!("Hello World!");
 
-    let mut pwm = SimplePwm::new(p.TIM2, p.PA5, NoPin, NoPin, NoPin, 10000.hz());
+    let mut pwm = SimplePwm::new_1ch(p.TIM2, p.PA5, 10000.hz());
     let max = pwm.get_max_duty();
     pwm.enable(Channel::Ch1);
 

--- a/examples/stm32h7/src/bin/camera.rs
+++ b/examples/stm32h7/src/bin/camera.rs
@@ -4,8 +4,8 @@
 
 use embassy::executor::Spawner;
 use embassy::time::{Duration, Timer};
-use embassy_stm32::dcmi::*;
-use embassy_stm32::gpio::{Level, NoPin, Output, Speed};
+use embassy_stm32::dcmi::{self, *};
+use embassy_stm32::gpio::{Level, Output, Speed};
 use embassy_stm32::i2c::I2c;
 use embassy_stm32::interrupt;
 use embassy_stm32::rcc::{Mco, Mco1Source, McoClock};
@@ -78,31 +78,10 @@ async fn main(_spawner: Spawner, p: Peripherals) {
     );
 
     let dcmi_irq = interrupt::take!(DCMI);
-    let mut dcmi = Dcmi::new(
-        p.DCMI,
-        p.DMA1_CH0,
-        VSyncDataInvalidLevel::High,
-        HSyncDataInvalidLevel::Low,
-        PixelClockPolarity::RisingEdge,
-        false,
-        dcmi_irq,
-        p.PC6,
-        p.PC7,
-        p.PE0,
-        p.PE1,
-        p.PE4,
-        p.PD3,
-        p.PE5,
-        p.PE6,
-        NoPin,
-        NoPin,
-        NoPin,
-        NoPin,
-        NoPin,
-        NoPin,
-        p.PB7,
-        p.PA4,
-        p.PA6,
+    let config = dcmi::Config::default();
+    let mut dcmi = Dcmi::new_8bit(
+        p.DCMI, p.DMA1_CH0, dcmi_irq, p.PC6, p.PC7, p.PE0, p.PE1, p.PE4, p.PD3, p.PE5, p.PE6,
+        p.PB7, p.PA4, p.PA6, config,
     );
 
     defmt::info!("attempting capture");

--- a/examples/stm32h7/src/bin/dac.rs
+++ b/examples/stm32h7/src/bin/dac.rs
@@ -5,7 +5,6 @@
 #[path = "../example_common.rs"]
 mod example_common;
 
-use embassy_stm32::gpio::NoPin;
 use example_common::*;
 
 use cortex_m_rt::entry;
@@ -17,7 +16,7 @@ fn main() -> ! {
 
     let p = embassy_stm32::init(config());
 
-    let mut dac = Dac::new(p.DAC1, p.PA4, NoPin);
+    let mut dac = Dac::new_1ch(p.DAC1, p.PA4);
 
     loop {
         for v in 0..=255 {

--- a/examples/stm32h7/src/bin/low_level_timer_api.rs
+++ b/examples/stm32h7/src/bin/low_level_timer_api.rs
@@ -10,7 +10,6 @@ use embassy::executor::Spawner;
 use embassy::time::{Duration, Timer};
 use embassy::util::Unborrow;
 use embassy_hal_common::unborrow;
-use embassy_stm32::gpio::NoPin;
 use embassy_stm32::pwm::{pins::*, Channel, OutputCompareMode};
 use embassy_stm32::time::{Hertz, U32Ext};
 use embassy_stm32::timer::GeneralPurpose32bitInstance;
@@ -33,7 +32,7 @@ pub fn config() -> Config {
 async fn main(_spawner: Spawner, p: Peripherals) {
     info!("Hello World!");
 
-    let mut pwm = SimplePwm32::new(p.TIM5, p.PA0, NoPin, NoPin, NoPin, 10000.hz());
+    let mut pwm = SimplePwm32::new(p.TIM5, p.PA0, p.PA1, p.PA2, p.PA3, 10000.hz());
     let max = pwm.get_max_duty();
     pwm.enable(Channel::Ch1);
 

--- a/examples/stm32h7/src/bin/pwm.rs
+++ b/examples/stm32h7/src/bin/pwm.rs
@@ -6,7 +6,6 @@
 mod example_common;
 use embassy::executor::Spawner;
 use embassy::time::{Duration, Timer};
-use embassy_stm32::gpio::NoPin;
 use embassy_stm32::pwm::{simple_pwm::SimplePwm, Channel};
 use embassy_stm32::time::U32Ext;
 use embassy_stm32::{Config, Peripherals};
@@ -28,7 +27,7 @@ pub fn config() -> Config {
 async fn main(_spawner: Spawner, p: Peripherals) {
     info!("Hello World!");
 
-    let mut pwm = SimplePwm::new(p.TIM3, p.PA6, NoPin, NoPin, NoPin, 10000.hz());
+    let mut pwm = SimplePwm::new_1ch(p.TIM3, p.PA6, 10000.hz());
     let max = pwm.get_max_duty();
     pwm.enable(Channel::Ch1);
 

--- a/examples/stm32l4/src/bin/dac.rs
+++ b/examples/stm32l4/src/bin/dac.rs
@@ -6,7 +6,6 @@
 mod example_common;
 
 use embassy_stm32::dac::{Channel, Dac, Value};
-use embassy_stm32::gpio::NoPin;
 use embassy_stm32::pac;
 use example_common::*;
 
@@ -22,7 +21,7 @@ fn main() -> ! {
 
     let p = embassy_stm32::init(Default::default());
 
-    let mut dac = Dac::new(p.DAC1, p.PA4, NoPin);
+    let mut dac = Dac::new_1ch(p.DAC1, p.PA4);
 
     loop {
         for v in 0..=255 {


### PR DESCRIPTION
The idea behind OptionalPin has a few problems:

- you need to impl the signal traits for NoPin which is a bit weird https://github.com/embassy-rs/embassy/blob/master/embassy-stm32/src/dcmi.rs#L413-L416
- you can pass any combination of set/unset pins, which needs checking at runtime  https://github.com/embassy-rs/embassy/blob/master/embassy-stm32/src/dcmi.rs#L130

The replacement is to do multiple `new` constructors for each combination of pins you want to take.