### PR TITLE
Update cargo-batch.

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -37,7 +37,7 @@ jobs:
           key: rust3-${{ runner.os }}-${{ hashFiles('rust-toolchain.toml') }}
       - name: build
         run: |
-          curl -L -o /usr/local/bin/cargo-batch https://github.com/embassy-rs/cargo-batch/releases/download/batch-0.1.0/cargo-batch
+          curl -L -o /usr/local/bin/cargo-batch https://github.com/embassy-rs/cargo-batch/releases/download/batch-0.2.0/cargo-batch
           chmod +x /usr/local/bin/cargo-batch
           ./ci.sh
           rm -rf target_ci/*{,/release}/{build,deps,.fingerprint}/{lib,}{embassy,stm32}*


### PR DESCRIPTION
Cargo-batch now prints target+features when buildng a crate fails, which is very handy when one of the 30 `embassy-stm32`s fails in CI.


Before: 
```
error: could not compile embassy-stm32 due to 2 previous errors
```

After:
```
error: could not compile `embassy-stm32` due to 2 previous errors
     target: Target(CompileTarget { name: "thumbv7em-none-eabi" })
     features: ["_time-driver", "defmt", "exti", "stm32f410tb", "time-driver-any"]
```