### PR TITLE
Add feature defmt-timestamp-uptime

### DIFF
--- a/embassy/Cargo.toml
+++ b/embassy/Cargo.toml
@@ -17,6 +17,10 @@ nightly = ["embedded-hal-async"]
 # Implement embedded-hal-async traits if `nightly` is set as well.
 unstable-traits = ["embedded-hal-1"]
 
+# Display a timestamp of the number of seconds since startup next to defmt log messages
+# To use this you must have a time driver provided.
+defmt-timestamp-uptime = ["defmt"]
+
 # Enable `embassy::time` module. 
 # NOTE: This feature is only intended to be enabled by crates providing the time driver implementation.
 # Enabling it directly without supplying a time driver will fail to link.

--- a/embassy/src/fmt.rs
+++ b/embassy/src/fmt.rs
@@ -195,6 +195,10 @@ macro_rules! unwrap {
     }
 }
 
+#[cfg(feature = "defmt-timestamp-uptime")]
+// defmt offers a disply hint for microseconds so we convert from millis
+defmt::timestamp! {"{=u64:us}", crate::time::Instant::now().as_millis() * 1_000 }
+
 #[derive(Debug, Copy, Clone, Eq, PartialEq)]
 pub struct NoneError;
 

--- a/embassy/src/fmt.rs
+++ b/embassy/src/fmt.rs
@@ -196,8 +196,7 @@ macro_rules! unwrap {
 }
 
 #[cfg(feature = "defmt-timestamp-uptime")]
-// defmt offers a disply hint for microseconds so we convert from millis
-defmt::timestamp! {"{=u64:us}", crate::time::Instant::now().as_millis() * 1_000 }
+defmt::timestamp! {"{=u64:us}", crate::time::Instant::now().as_micros() }
 
 #[derive(Debug, Copy, Clone, Eq, PartialEq)]
 pub struct NoneError;

--- a/embassy/src/time/instant.rs
+++ b/embassy/src/time/instant.rs
@@ -28,6 +28,13 @@ impl Instant {
         Self { ticks }
     }
 
+    /// Create an Instant from a microsecond count since system boot.
+    pub const fn from_micros(micros: u64) -> Self {
+        Self {
+            ticks: micros * TICKS_PER_SECOND / 1_000_000,
+        }
+    }
+
     /// Create an Instant from a millisecond count since system boot.
     pub const fn from_millis(millis: u64) -> Self {
         Self {
@@ -55,6 +62,11 @@ impl Instant {
     /// Milliseconds since system boot.
     pub const fn as_millis(&self) -> u64 {
         self.ticks * 1000 / TICKS_PER_SECOND
+    }
+
+    /// Microseconds since system boot.
+    pub const fn as_micros(&self) -> u64 {
+        self.ticks * 1_000_000 / TICKS_PER_SECOND
     }
 
     /// Duration between this Instant and another Instant


### PR DESCRIPTION
Add the feature defmt-timestamp-uptime. Enabling it adds a timestamp of the number of seconds since startup next to defmt log messages using `Instant::now`.