### PR TITLE
stm32: Add support for using TIM12 and TIM15 as time driver

### DIFF
--- a/embassy-stm32/Cargo.toml
+++ b/embassy-stm32/Cargo.toml
@@ -56,6 +56,8 @@ time-driver-tim2 = ["_time-driver"]
 time-driver-tim3 = ["_time-driver"]
 time-driver-tim4 = ["_time-driver"]
 time-driver-tim5 = ["_time-driver"]
+time-driver-tim12 = ["_time-driver"]
+time-driver-tim15 = ["_time-driver"]
 
 # Enable nightly-only features
 nightly = ["embassy/nightly", "embedded-hal-1", "embedded-hal-async"]

--- a/embassy-stm32/build.rs
+++ b/embassy-stm32/build.rs
@@ -720,6 +720,8 @@ fn main() {
         Some("tim3") => println!("cargo:rustc-cfg=time_driver_tim3"),
         Some("tim4") => println!("cargo:rustc-cfg=time_driver_tim4"),
         Some("tim5") => println!("cargo:rustc-cfg=time_driver_tim5"),
+        Some("tim12") => println!("cargo:rustc-cfg=time_driver_tim12"),
+        Some("tim15") => println!("cargo:rustc-cfg=time_driver_tim15"),
         Some("any") => {
             if singletons.contains(&"TIM2".to_string()) {
                 println!("cargo:rustc-cfg=time_driver_tim2");
@@ -729,8 +731,12 @@ fn main() {
                 println!("cargo:rustc-cfg=time_driver_tim4");
             } else if singletons.contains(&"TIM5".to_string()) {
                 println!("cargo:rustc-cfg=time_driver_tim5");
+            } else if singletons.contains(&"TIM12".to_string()) {
+                println!("cargo:rustc-cfg=time_driver_tim12");
+            } else if singletons.contains(&"TIM15".to_string()) {
+                println!("cargo:rustc-cfg=time_driver_tim15");
             } else {
-                panic!("time-driver-any requested, but the chip doesn't have TIM2, TIM3, TIM4 or TIM5.")
+                panic!("time-driver-any requested, but the chip doesn't have TIM2, TIM3, TIM4, TIM5, TIM12 or TIM15.")
             }
         }
         _ => panic!("unknown time_driver {:?}", time_driver),

--- a/embassy-stm32/src/time_driver.rs
+++ b/embassy-stm32/src/time_driver.rs
@@ -18,7 +18,11 @@ use crate::rcc::sealed::RccPeripheral;
 use crate::timer::sealed::Basic16bitInstance as BasicInstance;
 use crate::timer::sealed::GeneralPurpose16bitInstance as Instance;
 
+#[cfg(not(any(time_driver_tim12, time_driver_tim15)))]
 const ALARM_COUNT: usize = 3;
+
+#[cfg(any(time_driver_tim12, time_driver_tim15))]
+const ALARM_COUNT: usize = 1;
 
 #[cfg(time_driver_tim2)]
 type T = peripherals::TIM2;
@@ -28,6 +32,11 @@ type T = peripherals::TIM3;
 type T = peripherals::TIM4;
 #[cfg(time_driver_tim5)]
 type T = peripherals::TIM5;
+
+#[cfg(time_driver_tim12)]
+type T = peripherals::TIM12;
+#[cfg(time_driver_tim15)]
+type T = peripherals::TIM15;
 
 foreach_interrupt! {
     (TIM2, timer, $block:ident, UP, $irq:ident) => {
@@ -53,6 +62,20 @@ foreach_interrupt! {
     };
     (TIM5, timer, $block:ident, UP, $irq:ident) => {
         #[cfg(time_driver_tim5)]
+        #[interrupt]
+        fn $irq() {
+            DRIVER.on_interrupt()
+        }
+    };
+    (TIM12, timer, $block:ident, UP, $irq:ident) => {
+        #[cfg(time_driver_tim12)]
+        #[interrupt]
+        fn $irq() {
+            DRIVER.on_interrupt()
+        }
+    };
+    (TIM15, timer, $block:ident, UP, $irq:ident) => {
+        #[cfg(time_driver_tim15)]
         #[interrupt]
         fn $irq() {
             DRIVER.on_interrupt()


### PR DESCRIPTION
I am not sure what the effect of reducing the number of alarms will be, but these are the only timers I have available on my board.