### PR TITLE
stm32: move dma trait impls from macrotables to build.rs

### DIFF
--- a/embassy-stm32/src/dcmi.rs
+++ b/embassy-stm32/src/dcmi.rs
@@ -482,15 +482,6 @@ crate::pac::interrupts! {
 
 dma_trait!(FrameDma, Instance);
 
-crate::pac::peripheral_dma_channels! {
-    ($peri:ident, dcmi, $kind:ident, PSSI, $channel:tt, $request:expr) => {
-        dma_trait_impl!(FrameDma, $peri, $channel, $request);
-    };
-    ($peri:ident, dcmi, $kind:ident, DCMI, $channel:tt, $request:expr) => {
-        dma_trait_impl!(FrameDma, $peri, $channel, $request);
-    };
-}
-
 crate::pac::peripheral_pins!(
     ($inst:ident, dcmi, DCMI, $pin:ident, D0, $af:expr) => {
         pin_trait_impl!(D0Pin, $inst, $pin, $af);

--- a/embassy-stm32/src/i2c/mod.rs
+++ b/embassy-stm32/src/i2c/mod.rs
@@ -91,12 +91,3 @@ crate::pac::peripheral_pins!(
         pin_trait_impl!(SdaPin, $inst, $pin, 0);
     };
 );
-
-crate::pac::peripheral_dma_channels! {
-    ($peri:ident, i2c, $kind:ident, RX, $channel:tt, $request:expr) => {
-        dma_trait_impl!(RxDma, $peri, $channel, $request);
-    };
-    ($peri:ident, i2c, $kind:ident, TX, $channel:tt, $request:expr) => {
-        dma_trait_impl!(TxDma, $peri, $channel, $request);
-    };
-}

--- a/embassy-stm32/src/spi/mod.rs
+++ b/embassy-stm32/src/spi/mod.rs
@@ -911,12 +911,3 @@ crate::pac::peripheral_pins!(
         pin_trait_impl!(MisoPin, $inst, $pin, 0);
     };
 );
-
-crate::pac::peripheral_dma_channels! {
-    ($peri:ident, spi, $kind:ident, RX, $channel:tt, $request:expr) => {
-        dma_trait_impl!(RxDma, $peri, $channel, $request);
-    };
-    ($peri:ident, spi, $kind:ident, TX, $channel:tt, $request:expr) => {
-        dma_trait_impl!(TxDma, $peri, $channel, $request);
-    };
-}

--- a/embassy-stm32/src/traits.rs
+++ b/embassy-stm32/src/traits.rs
@@ -31,8 +31,8 @@ macro_rules! dma_trait {
 #[allow(unused)]
 macro_rules! dma_trait_impl {
     // DMAMUX
-    ($signal:ident, $instance:ident, {dmamux: $dmamux:ident}, $request:expr) => {
-        impl<T> $signal<crate::peripherals::$instance> for T
+    (crate::$mod:ident::$trait:ident, $instance:ident, {dmamux: $dmamux:ident}, $request:expr) => {
+        impl<T> crate::$mod::$trait<crate::peripherals::$instance> for T
         where
             T: crate::dma::MuxChannel<Mux = crate::dma::$dmamux>,
         {
@@ -43,8 +43,8 @@ macro_rules! dma_trait_impl {
     };
 
     // No DMAMUX
-    ($signal:ident, $instance:ident, {channel: $channel:ident}, $request:expr) => {
-        impl $signal<crate::peripherals::$instance> for crate::peripherals::$channel {
+    (crate::$mod:ident::$trait:ident, $instance:ident, {channel: $channel:ident}, $request:expr) => {
+        impl crate::$mod::$trait<crate::peripherals::$instance> for crate::peripherals::$channel {
             fn request(&self) -> crate::dma::Request {
                 $request
             }

--- a/embassy-stm32/src/usart/mod.rs
+++ b/embassy-stm32/src/usart/mod.rs
@@ -712,18 +712,3 @@ crate::pac::peripheral_pins!(
         pin_trait_impl!(CkPin, $inst, $pin, 0);
     };
 );
-
-crate::pac::peripheral_dma_channels! {
-    ($peri:ident, usart, $kind:ident, RX, $channel:tt, $request:expr) => {
-        dma_trait_impl!(RxDma, $peri, $channel, $request);
-    };
-    ($peri:ident, usart, $kind:ident, TX, $channel:tt, $request:expr) => {
-        dma_trait_impl!(TxDma, $peri, $channel, $request);
-    };
-    ($peri:ident, uart, $kind:ident, RX, $channel:tt, $request:expr) => {
-        dma_trait_impl!(RxDma, $peri, $channel, $request);
-    };
-    ($peri:ident, uart, $kind:ident, TX, $channel:tt, $request:expr) => {
-        dma_trait_impl!(TxDma, $peri, $channel, $request);
-    };
-}

--- a/stm32-metapac-gen/src/lib.rs
+++ b/stm32-metapac-gen/src/lib.rs
@@ -127,7 +127,6 @@ pub fn gen_chip(
     let mut peripherals_table: Vec<Vec<String>> = Vec::new();
     let mut peripheral_pins_table: Vec<Vec<String>> = Vec::new();
     let mut dma_channels_table: Vec<Vec<String>> = Vec::new();
-    let mut peripheral_dma_channels_table: Vec<Vec<String>> = Vec::new();
     let mut peripheral_counts: BTreeMap<String, u8> = BTreeMap::new();
     let mut dma_channel_counts: BTreeMap<String, u8> = BTreeMap::new();
     let mut dbgmcu_table: Vec<Vec<String>> = Vec::new();
@@ -196,35 +195,6 @@ pub fn gen_chip(
                 row.push(irq.signal.clone());
                 row.push(irq.interrupt.to_ascii_uppercase());
                 interrupt_table.push(row)
-            }
-
-            for ch in &p.dma_channels {
-                let mut row = Vec::new();
-                row.push(p.name.clone());
-                row.push(bi.kind.clone());
-                row.push(bi.block.clone());
-                row.push(ch.signal.clone());
-                row.push(if let Some(channel) = &ch.channel {
-                    format!("{{channel: {}}}", channel)
-                } else if let Some(dmamux) = &ch.dmamux {
-                    format!("{{dmamux: {}}}", dmamux)
-                } else {
-                    unreachable!();
-                });
-
-                row.push(if let Some(request) = ch.request {
-                    request.to_string()
-                } else {
-                    "()".to_string()
-                });
-
-                if peripheral_dma_channels_table
-                    .iter()
-                    .find(|a| a[..a.len() - 1] == row[..row.len() - 1])
-                    .is_none()
-                {
-                    peripheral_dma_channels_table.push(row);
-                }
             }
 
             let mut peripheral_row = Vec::new();
@@ -388,11 +358,6 @@ pub fn gen_chip(
     make_table(&mut data, "peripherals", &peripherals_table);
     make_table(&mut data, "peripheral_versions", &peripheral_version_table);
     make_table(&mut data, "peripheral_pins", &peripheral_pins_table);
-    make_table(
-        &mut data,
-        "peripheral_dma_channels",
-        &peripheral_dma_channels_table,
-    );
     make_table(&mut data, "dma_channels", &dma_channels_table);
     make_table(&mut data, "dbgmcu", &dbgmcu_table);
     make_peripheral_counts(&mut data, &peripheral_counts);


### PR DESCRIPTION
Continuation of work from #601