### PR TITLE
Skip EasyDMA slice location check for empty slices and copy data if necessary

### DIFF
--- a/embassy-nrf/src/lib.rs
+++ b/embassy-nrf/src/lib.rs
@@ -1,7 +1,7 @@
 #![no_std]
 #![cfg_attr(
     feature = "nightly",
-    feature(generic_associated_types, type_alias_impl_trait)
+    feature(generic_associated_types, type_alias_impl_trait, slice_ptr_len)
 )]
 
 #[cfg(not(any(

--- a/embassy-nrf/src/lib.rs
+++ b/embassy-nrf/src/lib.rs
@@ -1,7 +1,7 @@
 #![no_std]
 #![cfg_attr(
     feature = "nightly",
-    feature(generic_associated_types, type_alias_impl_trait, slice_ptr_len)
+    feature(generic_associated_types, type_alias_impl_trait)
 )]
 
 #[cfg(not(any(

--- a/embassy-nrf/src/spim.rs
+++ b/embassy-nrf/src/spim.rs
@@ -31,38 +31,7 @@ pub enum Error {
 
 /// Interface for the SPIM peripheral using EasyDMA to offload the transmission and reception workload.
 ///
-/// ## Data locality requirements
-///
-/// On nRF chips, EasyDMA requires the buffers to reside in RAM. However, Rust
-/// slices will not always do so. Take the following example:
-///
-/// ```no_run
-/// // As we pass a slice to the function whose contents will not ever change,
-/// // the compiler writes it into the flash and thus the pointer to it will
-/// // reference static memory. Since EasyDMA requires slices to reside in RAM,
-/// // this function call will fail.
-/// let result = spim.write_from_ram(&[1, 2, 3]);
-/// assert_eq!(result, Error::DMABufferNotInDataMemory);
-///
-/// // The data is still static and located in flash. However, since we are assigning
-/// // it to a variable, the compiler will load it into memory. Passing a reference to the
-/// // variable will yield a pointer that references dynamic memory, thus making EasyDMA happy.
-/// // This function call succeeds.
-/// let data = [1, 2, 3];
-/// let result = spim.write_from_ram(&data);
-/// assert!(result.is_ok());
-/// ```
-///
-/// Each function in this struct has a `_from_ram` variant and one without this suffix.
-/// - Functions with the suffix (e.g. [`write_from_ram`](Spim::write_from_ram), [`transfer_from_ram`](Spim::transfer_from_ram)) will return an error if the passed slice does not reside in RAM.
-/// - Functions without the suffix (e.g. [`write`](Spim::write), [`transfer`](Spim::transfer)) will check whether the data is in RAM and copy it into memory prior to transmission.
-///
-/// Since copying incurs a overhead, you are given the option to choose from `_from_ram` variants which will
-/// fail and notify you, or the more convenient versions without the suffix which are potentially a little bit
-/// more inefficient.
-///
-/// Note that the [`read`](Spim::read) and [`transfer_in_place`](Spim::transfer_in_place) methods do not have the corresponding `_from_ram` variants as
-/// mutable slices always reside in RAM.
+/// For more details about EasyDMA, consult the module documentation.
 pub struct Spim<'d, T: Instance> {
     phantom: PhantomData<&'d mut T>,
 }
@@ -325,7 +294,7 @@ impl<'d, T: Instance> Spim<'d, T> {
         self.blocking_inner(read, write)
     }
 
-    /// Same as [`blocking_transfer`](Spim::blocking_transfer) but will fail instead of copying data into RAM.
+    /// Same as [`blocking_transfer`](Spim::blocking_transfer) but will fail instead of copying data into RAM. Consult the module level documentation to learn more.
     pub fn blocking_transfer_from_ram(
         &mut self,
         read: &mut [u8],
@@ -346,7 +315,7 @@ impl<'d, T: Instance> Spim<'d, T> {
         self.blocking_inner(&mut [], data)
     }
 
-    /// Same as [`blocking_write`](Spim::blocking_write) but will fail instead of copying data into RAM.
+    /// Same as [`blocking_write`](Spim::blocking_write) but will fail instead of copying data into RAM. Consult the module level documentation to learn more.
     pub fn blocking_write_from_ram(&mut self, data: &[u8]) -> Result<(), Error> {
         self.blocking_inner(&mut [], data)
     }
@@ -362,7 +331,7 @@ impl<'d, T: Instance> Spim<'d, T> {
         self.async_inner(read, write).await
     }
 
-    /// Same as [`transfer`](Spim::transfer) but will fail instead of copying data into RAM.
+    /// Same as [`transfer`](Spim::transfer) but will fail instead of copying data into RAM. Consult the module level documentation to learn more.
     pub async fn transfer_from_ram(&mut self, read: &mut [u8], write: &[u8]) -> Result<(), Error> {
         self.async_inner_from_ram(read, write).await
     }
@@ -378,7 +347,7 @@ impl<'d, T: Instance> Spim<'d, T> {
         self.async_inner(&mut [], data).await
     }
 
-    /// Same as [`write`](Spim::write) but will fail instead of copying data into RAM.
+    /// Same as [`write`](Spim::write) but will fail instead of copying data into RAM. Consult the module level documentation to learn more.
     pub async fn write_from_ram(&mut self, data: &[u8]) -> Result<(), Error> {
         self.async_inner_from_ram(&mut [], data).await
     }

--- a/embassy-nrf/src/spim.rs
+++ b/embassy-nrf/src/spim.rs
@@ -272,6 +272,7 @@ impl<'d, T: Instance> Spim<'d, T> {
         match self.blocking_inner_from_ram(rx, tx) {
             Ok(_) => Ok(()),
             Err(Error::DMABufferNotInDataMemory) => {
+                trace!("Copying SPIM tx buffer into RAM for DMA");
                 let tx_copied = tx.clone();
                 self.blocking_inner_from_ram(rx, tx_copied)
             }
@@ -302,6 +303,7 @@ impl<'d, T: Instance> Spim<'d, T> {
         match self.async_inner_from_ram(rx, tx).await {
             Ok(_) => Ok(()),
             Err(Error::DMABufferNotInDataMemory) => {
+                trace!("Copying SPIM tx buffer into RAM for DMA");
                 let tx_copied = tx.clone();
                 self.async_inner_from_ram(rx, tx_copied).await
             }

--- a/embassy-nrf/src/spim.rs
+++ b/embassy-nrf/src/spim.rs
@@ -274,9 +274,9 @@ impl<'d, T: Instance> Spim<'d, T> {
             Ok(_) => Ok(()),
             Err(Error::DMABufferNotInDataMemory) => {
                 trace!("Copying SPIM tx buffer into RAM for DMA");
-                let mut tx_buf = [0u8; FORCE_COPY_BUFFER_SIZE];
-                tx_buf[..tx.len()].copy_from_slice(tx);
-                self.blocking_inner_from_ram(rx, &tx_buf[..tx.len()])
+                let tx_ram_buf = &mut [0; FORCE_COPY_BUFFER_SIZE][..tx.len()];
+                tx_ram_buf.copy_from_slice(tx);
+                self.blocking_inner_from_ram(rx, tx_ram_buf)
             }
             Err(error) => Err(error),
         }
@@ -306,9 +306,9 @@ impl<'d, T: Instance> Spim<'d, T> {
             Ok(_) => Ok(()),
             Err(Error::DMABufferNotInDataMemory) => {
                 trace!("Copying SPIM tx buffer into RAM for DMA");
-                let mut tx_buf = [0u8; FORCE_COPY_BUFFER_SIZE];
-                tx_buf[..tx.len()].copy_from_slice(tx);
-                self.async_inner_from_ram(rx, &tx_buf[..tx.len()]).await
+                let tx_ram_buf = &mut [0; FORCE_COPY_BUFFER_SIZE][..tx.len()];
+                tx_ram_buf.copy_from_slice(tx);
+                self.async_inner_from_ram(rx, tx_ram_buf).await
             }
             Err(error) => Err(error),
         }

--- a/embassy-nrf/src/twim.rs
+++ b/embassy-nrf/src/twim.rs
@@ -64,7 +64,9 @@ pub enum Error {
     Overrun,
 }
 
-/// Interface to a TWIM instance.
+/// Interface to a TWIM instance using EasyDMA to offload the transmission and reception workload.
+///
+/// For more details about EasyDMA, consult the module documentation.
 pub struct Twim<'d, T: Instance> {
     phantom: PhantomData<&'d mut T>,
 }
@@ -432,6 +434,7 @@ impl<'d, T: Instance> Twim<'d, T> {
         Ok(())
     }
 
+    /// Same as [`blocking_write`](Twim::blocking_write) but will fail instead of copying data into RAM. Consult the module level documentation to learn more.
     pub fn blocking_write_from_ram(&mut self, address: u8, buffer: &[u8]) -> Result<(), Error> {
         self.setup_write_from_ram(address, buffer, false)?;
         self.blocking_wait();
@@ -474,6 +477,7 @@ impl<'d, T: Instance> Twim<'d, T> {
         Ok(())
     }
 
+    /// Same as [`blocking_write_read`](Twim::blocking_write_read) but will fail instead of copying data into RAM. Consult the module level documentation to learn more.
     pub fn blocking_write_read_from_ram(
         &mut self,
         address: u8,
@@ -507,6 +511,7 @@ impl<'d, T: Instance> Twim<'d, T> {
         Ok(())
     }
 
+    /// Same as [`write`](Twim::write) but will fail instead of copying data into RAM. Consult the module level documentation to learn more.
     pub async fn write_from_ram(&mut self, address: u8, buffer: &[u8]) -> Result<(), Error> {
         self.setup_write_from_ram(address, buffer, true)?;
         self.async_wait().await;
@@ -531,6 +536,7 @@ impl<'d, T: Instance> Twim<'d, T> {
         Ok(())
     }
 
+    /// Same as [`write_read`](Twim::write_read) but will fail instead of copying data into RAM. Consult the module level documentation to learn more.
     pub async fn write_read_from_ram(
         &mut self,
         address: u8,

--- a/embassy-nrf/src/twim.rs
+++ b/embassy-nrf/src/twim.rs
@@ -398,14 +398,9 @@ impl<'d, T: Instance> Twim<'d, T> {
             Ok(_) => Ok(()),
             Err(Error::DMABufferNotInDataMemory) => {
                 trace!("Copying TWIM tx buffer into RAM for DMA");
-                let mut tx_buf = [0u8; FORCE_COPY_BUFFER_SIZE];
-                tx_buf[..wr_buffer.len()].copy_from_slice(wr_buffer);
-                self.setup_write_read_from_ram(
-                    address,
-                    &tx_buf[..wr_buffer.len()],
-                    rd_buffer,
-                    inten,
-                )
+                let tx_ram_buf = &mut [0; FORCE_COPY_BUFFER_SIZE][..wr_buffer.len()];
+                tx_ram_buf.copy_from_slice(wr_buffer);
+                self.setup_write_read_from_ram(address, &tx_ram_buf, rd_buffer, inten)
             }
             Err(error) => Err(error),
         }
@@ -416,9 +411,9 @@ impl<'d, T: Instance> Twim<'d, T> {
             Ok(_) => Ok(()),
             Err(Error::DMABufferNotInDataMemory) => {
                 trace!("Copying TWIM tx buffer into RAM for DMA");
-                let mut tx_buf = [0u8; FORCE_COPY_BUFFER_SIZE];
-                tx_buf[..wr_buffer.len()].copy_from_slice(wr_buffer);
-                self.setup_write_from_ram(address, &tx_buf[..wr_buffer.len()], inten)
+                let tx_ram_buf = &mut [0; FORCE_COPY_BUFFER_SIZE][..wr_buffer.len()];
+                tx_ram_buf.copy_from_slice(wr_buffer);
+                self.setup_write_from_ram(address, &tx_ram_buf, inten)
             }
             Err(error) => Err(error),
         }

--- a/embassy-nrf/src/uarte.rs
+++ b/embassy-nrf/src/uarte.rs
@@ -60,7 +60,9 @@ pub enum Error {
     // TODO: add other error variants.
 }
 
-/// Interface to the UARTE peripheral
+/// Interface to the UARTE peripheral using EasyDMA to offload the transmission and reception workload.
+///
+/// For more details about EasyDMA, consult the module documentation.
 pub struct Uarte<'d, T: Instance> {
     phantom: PhantomData<&'d mut T>,
     tx: UarteTx<'d, T>,
@@ -224,6 +226,7 @@ impl<'d, T: Instance> Uarte<'d, T> {
         self.tx.write(buffer).await
     }
 
+    /// Same as [`write`](Uarte::write) but will fail instead of copying data into RAM. Consult the module level documentation to learn more.
     pub async fn write_from_ram(&mut self, buffer: &[u8]) -> Result<(), Error> {
         self.tx.write_from_ram(buffer).await
     }
@@ -236,6 +239,7 @@ impl<'d, T: Instance> Uarte<'d, T> {
         self.tx.blocking_write(buffer)
     }
 
+    /// Same as [`blocking_write`](Uarte::blocking_write) but will fail instead of copying data into RAM. Consult the module level documentation to learn more.
     pub fn blocking_write_from_ram(&mut self, buffer: &[u8]) -> Result<(), Error> {
         self.tx.blocking_write_from_ram(buffer)
     }

--- a/embassy-nrf/src/uarte.rs
+++ b/embassy-nrf/src/uarte.rs
@@ -247,9 +247,9 @@ impl<'d, T: Instance> UarteTx<'d, T> {
             Ok(_) => Ok(()),
             Err(Error::DMABufferNotInDataMemory) => {
                 trace!("Copying UARTE tx buffer into RAM for DMA");
-                let mut tx_buf = [0u8; FORCE_COPY_BUFFER_SIZE];
-                tx_buf[..buffer.len()].copy_from_slice(buffer);
-                self.write_from_ram(&tx_buf[..buffer.len()]).await
+                let ram_buf = &mut [0; FORCE_COPY_BUFFER_SIZE][..buffer.len()];
+                ram_buf.copy_from_slice(buffer);
+                self.write_from_ram(&ram_buf).await
             }
             Err(error) => Err(error),
         }
@@ -314,9 +314,9 @@ impl<'d, T: Instance> UarteTx<'d, T> {
             Ok(_) => Ok(()),
             Err(Error::DMABufferNotInDataMemory) => {
                 trace!("Copying UARTE tx buffer into RAM for DMA");
-                let mut tx_buf = [0u8; FORCE_COPY_BUFFER_SIZE];
-                tx_buf[..buffer.len()].copy_from_slice(buffer);
-                self.blocking_write_from_ram(&tx_buf[..buffer.len()])
+                let ram_buf = &mut [0; FORCE_COPY_BUFFER_SIZE][..buffer.len()];
+                ram_buf.copy_from_slice(buffer);
+                self.blocking_write_from_ram(&ram_buf)
             }
             Err(error) => Err(error),
         }

--- a/embassy-nrf/src/util.rs
+++ b/embassy-nrf/src/util.rs
@@ -22,7 +22,8 @@ pub(crate) fn slice_in_ram<T>(slice: *const [T]) -> bool {
 /// Return an error if slice is not in RAM. Skips check if slice is zero-length.
 #[cfg(not(feature = "nrf51"))]
 pub(crate) fn slice_in_ram_or<T, E>(slice: *const [T], err: E) -> Result<(), E> {
-    if slice.len() > 0 && slice_in_ram(slice) {
+    let (_, len) = slice_ptr_parts(slice);
+    if len > 0 && slice_in_ram(slice) {
         Ok(())
     } else {
         Err(err)

--- a/embassy-nrf/src/util.rs
+++ b/embassy-nrf/src/util.rs
@@ -23,7 +23,7 @@ pub(crate) fn slice_in_ram<T>(slice: *const [T]) -> bool {
 #[cfg(not(feature = "nrf51"))]
 pub(crate) fn slice_in_ram_or<T, E>(slice: *const [T], err: E) -> Result<(), E> {
     let (_, len) = slice_ptr_parts(slice);
-    if len > 0 && slice_in_ram(slice) {
+    if len == 0 || slice_in_ram(slice) {
         Ok(())
     } else {
         Err(err)

--- a/embassy-nrf/src/util.rs
+++ b/embassy-nrf/src/util.rs
@@ -19,10 +19,10 @@ pub(crate) fn slice_in_ram<T>(slice: *const [T]) -> bool {
     ptr >= SRAM_LOWER && (ptr + len * core::mem::size_of::<T>()) < SRAM_UPPER
 }
 
-/// Return an error if slice is not in RAM.
+/// Return an error if slice is not in RAM. Skips check if slice is zero-length.
 #[cfg(not(feature = "nrf51"))]
 pub(crate) fn slice_in_ram_or<T, E>(slice: *const [T], err: E) -> Result<(), E> {
-    if slice_in_ram(slice) {
+    if slice.len() > 0 && slice_in_ram(slice) {
         Ok(())
     } else {
         Err(err)


### PR DESCRIPTION
As discussed, this PR makes the following changes:
- Ignore pointer location of zero-length slices (fixes #631)
- Change default functions so they copy the tx buffer if it does not reside in RAM
- Introduce new variants for `write`, `transfer`, and their blocking versions which fails instead of copying
- Add documentation about the motivation behind all these variants
<img width="984" alt="image" src="https://user-images.githubusercontent.com/5037967/155415788-c2cd1055-9289-4004-959d-be3b1934a439.png">


Remaining TODOs:

- [x] Change copying behaviour for other peripherals
    - [x] TWI
    - [x] UART
- [x] Add module-level documentation regarding EasyDMA and `_from_ram` method variants

@Dirbaio it probably makes sense for you to review it now before I "copy" over the changes to the other two peripherals.