### PR TITLE
stm32f1: fix input GPIO AFs, add to HIL.

### DIFF
--- a/ci.sh
+++ b/ci.sh
@@ -73,6 +73,7 @@ cargo batch  \
     --- build --release --manifest-path examples/stm32wb55/Cargo.toml --target thumbv7em-none-eabihf --out-dir out/examples/stm32wb55 \
     --- build --release --manifest-path examples/stm32wl55/Cargo.toml --target thumbv7em-none-eabihf --out-dir out/examples/stm32wl55 \
     --- build --release --manifest-path examples/wasm/Cargo.toml --target wasm32-unknown-unknown --out-dir out/examples/wasm \
+    --- build --release --manifest-path tests/stm32/Cargo.toml --target thumbv7m-none-eabi --features stm32f103c8 --out-dir out/tests/bluepill-stm32f103c8 \
     --- build --release --manifest-path tests/stm32/Cargo.toml --target thumbv7em-none-eabi --features stm32f429zi --out-dir out/tests/nucleo-stm32f429zi \
     --- build --release --manifest-path tests/stm32/Cargo.toml --target thumbv7em-none-eabi --features stm32g491re --out-dir out/tests/nucleo-stm32g491re \
     --- build --release --manifest-path tests/stm32/Cargo.toml --target thumbv6m-none-eabi --features stm32g071rb --out-dir out/tests/nucleo-stm32g071rb \

--- a/embassy-stm32/src/can/bxcan.rs
+++ b/embassy-stm32/src/can/bxcan.rs
@@ -23,7 +23,7 @@ impl<'d, T: Instance + bxcan::Instance> Can<'d, T> {
         unborrow!(peri, rx, tx);
 
         unsafe {
-            rx.set_as_af(rx.af_num(), AFType::OutputOpenDrain);
+            rx.set_as_af(rx.af_num(), AFType::Input);
             tx.set_as_af(tx.af_num(), AFType::OutputPushPull);
         }
 

--- a/embassy-stm32/src/gpio.rs
+++ b/embassy-stm32/src/gpio.rs
@@ -410,7 +410,7 @@ pub(crate) mod sealed {
                 AFType::Input => {
                     r.cr(crlh).modify(|w| {
                         w.set_mode(n % 8, vals::Mode::INPUT);
-                        w.set_cnf(n % 8, vals::Cnf::PUSHPULL);
+                        w.set_cnf(n % 8, vals::Cnf::OPENDRAIN);
                     });
                 }
                 AFType::OutputPushPull => {

--- a/embassy-stm32/src/usart/mod.rs
+++ b/embassy-stm32/src/usart/mod.rs
@@ -6,7 +6,7 @@ use embassy::util::Unborrow;
 use embassy_hal_common::unborrow;
 
 use crate::dma::NoDma;
-use crate::gpio::sealed::AFType::{OutputOpenDrain, OutputPushPull};
+use crate::gpio::sealed::AFType;
 use crate::pac::usart::{regs, vals};
 use crate::peripherals;
 use crate::rcc::RccPeripheral;
@@ -98,8 +98,8 @@ impl<'d, T: Instance, TxDma, RxDma> Uart<'d, T, TxDma, RxDma> {
         let r = inner.regs();
 
         unsafe {
-            rx.set_as_af(rx.af_num(), OutputOpenDrain);
-            tx.set_as_af(tx.af_num(), OutputPushPull);
+            rx.set_as_af(rx.af_num(), AFType::Input);
+            tx.set_as_af(tx.af_num(), AFType::OutputPushPull);
 
             r.cr2().write(|_w| {});
             r.cr3().write(|_w| {});

--- a/tests/stm32/.cargo/config.toml
+++ b/tests/stm32/.cargo/config.toml
@@ -3,9 +3,8 @@ build-std = ["core"]
 build-std-features = ["panic_immediate_abort"]
 
 [target.'cfg(all(target_arch = "arm", target_os = "none"))']
-# replace STM32F429ZITx with your chip as listed in `probe-run --list-chips`
-#runner = "teleprobe run --chip STM32G071RBTx --elf"
-runner = "./teleprobe.sh nucleo-stm32f429zi"
+runner = "teleprobe client run --target bluepill-stm32f103c8 --elf"
+#runner = "teleprobe local run --chip STM32F103C8 --elf"
 
 rustflags = [
   # Code-size optimizations.
@@ -15,4 +14,4 @@ rustflags = [
 ]
 
 [build]
-target = "thumbv7em-none-eabi"
+target = "thumbv7m-none-eabi"

--- a/tests/stm32/Cargo.toml
+++ b/tests/stm32/Cargo.toml
@@ -6,6 +6,7 @@ version = "0.1.0"
 resolver = "2"
 
 [features]
+stm32f103c8 = ["embassy-stm32/stm32f103c8"]
 stm32f429zi = ["embassy-stm32/stm32f429zi"]
 stm32g071rb = ["embassy-stm32/stm32g071rb"]
 stm32g491re = ["embassy-stm32/stm32g491re"]

--- a/tests/stm32/src/bin/gpio.rs
+++ b/tests/stm32/src/bin/gpio.rs
@@ -16,6 +16,8 @@ async fn main(_spawner: Spawner, p: Peripherals) {
 
     // Arduino pins D0 and D1
     // They're connected together with a 1K resistor.
+    #[cfg(feature = "stm32f103c8")]
+    let (mut a, mut b) = (p.PA9, p.PA10);
     #[cfg(feature = "stm32g491re")]
     let (mut a, mut b) = (p.PC4, p.PC5);
     #[cfg(feature = "stm32g071rb")]

--- a/tests/stm32/src/bin/spi_dma.rs
+++ b/tests/stm32/src/bin/spi_dma.rs
@@ -15,6 +15,8 @@ use example_common::*;
 async fn main(_spawner: Spawner, p: Peripherals) {
     info!("Hello World!");
 
+    #[cfg(feature = "stm32f103c8")]
+    let (sck, mosi, miso, tx_dma, rx_dma) = (p.PA5, p.PA7, p.PA6, p.DMA1_CH3, p.DMA1_CH2);
     #[cfg(feature = "stm32f429zi")]
     let (sck, mosi, miso, tx_dma, rx_dma) = (p.PA5, p.PA7, p.PA6, p.DMA2_CH3, p.DMA2_CH2);
     #[cfg(feature = "stm32h755zi")]

--- a/tests/stm32/src/bin/usart.rs
+++ b/tests/stm32/src/bin/usart.rs
@@ -23,6 +23,8 @@ async fn main(_spawner: Spawner, p: Peripherals) {
 
     // Arduino pins D0 and D1
     // They're connected together with a 1K resistor.
+    #[cfg(feature = "stm32f103c8")]
+    let (tx, rx, usart) = (p.PA9, p.PA10, p.USART1);
     #[cfg(feature = "stm32g491re")]
     let (tx, rx, usart) = (p.PC4, p.PC5, p.USART1);
     #[cfg(feature = "stm32g071rb")]

--- a/tests/stm32/src/bin/usart_dma.rs
+++ b/tests/stm32/src/bin/usart_dma.rs
@@ -22,6 +22,8 @@ async fn main(_spawner: Spawner, p: Peripherals) {
 
     // Arduino pins D0 and D1
     // They're connected together with a 1K resistor.
+    #[cfg(feature = "stm32f103c8")]
+    let (tx, rx, usart, tx_dma, rx_dma) = (p.PA9, p.PA10, p.USART1, p.DMA1_CH4, p.DMA1_CH5);
     #[cfg(feature = "stm32g491re")]
     let (tx, rx, usart, tx_dma, rx_dma) = (p.PC4, p.PC5, p.USART1, p.DMA1_CH0, p.DMA1_CH1);
     #[cfg(feature = "stm32g071rb")]


### PR DESCRIPTION
- Fix 2 bugs in GPIOv1 configuration
- Add stm32f1 to HIL so that this doesn't regress again.