### PR TITLE
Make UART futures Send

### DIFF
--- a/embassy-stm32/src/usart/mod.rs
+++ b/embassy-stm32/src/usart/mod.rs
@@ -106,8 +106,8 @@ impl<'d, T: Instance, TxDma> UartTx<'d, T, TxDma> {
                 reg.set_dmat(true);
             });
         }
-        let dst = tdr(T::regs());
-        crate::dma::write(ch, request, buffer, dst).await;
+        let transfer = crate::dma::write(ch, request, buffer, tdr(T::regs()));
+        transfer.await;
         Ok(())
     }
 
@@ -150,9 +150,8 @@ impl<'d, T: Instance, RxDma> UartRx<'d, T, RxDma> {
                 reg.set_dmar(true);
             });
         }
-        let r = T::regs();
-        let src = rdr(r);
-        crate::dma::read(ch, request, src, buffer).await;
+        let transfer = crate::dma::read(ch, request, rdr(T::regs()), buffer);
+        transfer.await;
         Ok(())
     }
 

--- a/embassy-stm32/src/usart/mod.rs
+++ b/embassy-stm32/src/usart/mod.rs
@@ -106,6 +106,8 @@ impl<'d, T: Instance, TxDma> UartTx<'d, T, TxDma> {
                 reg.set_dmat(true);
             });
         }
+        // If we don't assign future to a variable, the data register pointer
+        // is held across an await and makes the future non-Send.
         let transfer = crate::dma::write(ch, request, buffer, tdr(T::regs()));
         transfer.await;
         Ok(())
@@ -150,6 +152,8 @@ impl<'d, T: Instance, RxDma> UartRx<'d, T, RxDma> {
                 reg.set_dmar(true);
             });
         }
+        // If we don't assign future to a variable, the data register pointer
+        // is held across an await and makes the future non-Send.
         let transfer = crate::dma::read(ch, request, rdr(T::regs()), buffer);
         transfer.await;
         Ok(())


### PR DESCRIPTION
This is a quick fix to make `Uart` futures implement `Send`.

Previously they were `!Send`, because pointer to the data register was held across an await point. Simple rearrange fixes the issue.