### PR TITLE
Reset peripherals on enable

### DIFF
--- a/embassy-stm32/src/adc/v3.rs
+++ b/embassy-stm32/src/adc/v3.rs
@@ -8,13 +8,15 @@ pub const VDDA_CALIB_MV: u32 = 3000;
 
 /// Sadly we cannot use `RccPeripheral::enable` since devices are quite inconsistent ADC clock
 /// configuration.
-unsafe fn enable() {
-    #[cfg(stm32h7)]
-    crate::pac::RCC.apb2enr().modify(|w| w.set_adcen(true));
-    #[cfg(stm32g0)]
-    crate::pac::RCC.apbenr2().modify(|w| w.set_adcen(true));
-    #[cfg(stm32l4)]
-    crate::pac::RCC.ahb2enr().modify(|w| w.set_adcen(true));
+fn enable() {
+    critical_section::with(|_| unsafe {
+        #[cfg(stm32h7)]
+        crate::pac::RCC.apb2enr().modify(|w| w.set_adcen(true));
+        #[cfg(stm32g0)]
+        crate::pac::RCC.apbenr2().modify(|w| w.set_adcen(true));
+        #[cfg(stm32l4)]
+        crate::pac::RCC.ahb2enr().modify(|w| w.set_adcen(true));
+    });
 }
 
 pub enum Resolution {
@@ -206,8 +208,8 @@ pub struct Adc<'d, T: Instance> {
 impl<'d, T: Instance> Adc<'d, T> {
     pub fn new(_peri: impl Unborrow<Target = T> + 'd, delay: &mut impl DelayUs<u32>) -> Self {
         unborrow!(_peri);
+        enable();
         unsafe {
-            enable();
             T::regs().cr().modify(|reg| {
                 #[cfg(not(adc_g0))]
                 reg.set_deeppwd(false);

--- a/embassy-stm32/src/adc/v3.rs
+++ b/embassy-stm32/src/adc/v3.rs
@@ -14,7 +14,7 @@ fn enable() {
         crate::pac::RCC.apb2enr().modify(|w| w.set_adcen(true));
         #[cfg(stm32g0)]
         crate::pac::RCC.apbenr2().modify(|w| w.set_adcen(true));
-        #[cfg(stm32l4)]
+        #[cfg(any(stm32l4, stm32wb))]
         crate::pac::RCC.ahb2enr().modify(|w| w.set_adcen(true));
     });
 }

--- a/embassy-stm32/src/dac/v2.rs
+++ b/embassy-stm32/src/dac/v2.rs
@@ -92,7 +92,7 @@ pub struct Dac<'d, T: Instance> {
 }
 
 macro_rules! enable {
-    ($enable_reg:ident, $enable_field: ident, $reset_reg:ident, $reset_field:ident) => {
+    ($enable_reg:ident, $enable_field:ident, $reset_reg:ident, $reset_field:ident) => {
         crate::pac::RCC
             .$enable_reg()
             .modify(|w| w.$enable_field(true));

--- a/embassy-stm32/src/dac/v2.rs
+++ b/embassy-stm32/src/dac/v2.rs
@@ -91,6 +91,20 @@ pub struct Dac<'d, T: Instance> {
     phantom: PhantomData<&'d mut T>,
 }
 
+macro_rules! enable {
+    ($enable_reg:ident, $enable_field: ident, $reset_reg:ident, $reset_field:ident) => {
+        crate::pac::RCC
+            .$enable_reg()
+            .modify(|w| w.$enable_field(true));
+        crate::pac::RCC
+            .$reset_reg()
+            .modify(|w| w.$reset_field(true));
+        crate::pac::RCC
+            .$reset_reg()
+            .modify(|w| w.$reset_field(false));
+    };
+}
+
 impl<'d, T: Instance> Dac<'d, T> {
     pub fn new_1ch(
         peri: impl Unborrow<Target = T> + 'd,
@@ -113,14 +127,16 @@ impl<'d, T: Instance> Dac<'d, T> {
         unsafe {
             // Sadly we cannot use `RccPeripheral::enable` since devices are quite inconsistent DAC clock
             // configuration.
-            #[cfg(rcc_h7)]
-            crate::pac::RCC.apb1lenr().modify(|w| w.set_dac12en(true));
-            #[cfg(rcc_h7ab)]
-            crate::pac::RCC.apb1lenr().modify(|w| w.set_dac1en(true));
-            #[cfg(stm32g0)]
-            crate::pac::RCC.apbenr1().modify(|w| w.set_dac1en(true));
-            #[cfg(stm32l4)]
-            crate::pac::RCC.apb1enr1().modify(|w| w.set_dac1en(true));
+            critical_section::with(|_| {
+                #[cfg(rcc_h7)]
+                enable!(apb1lenr, set_dac12en, apb1lrstr, set_dac12rst);
+                #[cfg(rcc_h7ab)]
+                enable!(apb1lenr, set_dac1en, apb1lrstr, set_dac1rst);
+                #[cfg(stm32g0)]
+                enable!(apbenr1, set_dac1en, apbrstr1, set_dac1rst);
+                #[cfg(stm32l4)]
+                enable!(apb1enr1, set_dac1en, apb1rstr1, set_dac1rst);
+            });
 
             if channels >= 1 {
                 T::regs().cr().modify(|reg| {

--- a/embassy-stm32/src/i2c/v1.rs
+++ b/embassy-stm32/src/i2c/v1.rs
@@ -32,6 +32,7 @@ impl<'d, T: Instance> I2c<'d, T> {
         unborrow!(scl, sda);
 
         T::enable();
+        T::reset();
 
         unsafe {
             scl.set_as_af(scl.af_num(), AFType::OutputOpenDrain);

--- a/embassy-stm32/src/i2c/v2.rs
+++ b/embassy-stm32/src/i2c/v2.rs
@@ -53,6 +53,7 @@ impl<'d, T: Instance, TXDMA, RXDMA> I2c<'d, T, TXDMA, RXDMA> {
         unborrow!(irq, scl, sda, tx_dma, rx_dma);
 
         T::enable();
+        T::reset();
 
         unsafe {
             scl.set_as_af(scl.af_num(), AFType::OutputOpenDrain);

--- a/embassy-stm32/src/usart/mod.rs
+++ b/embassy-stm32/src/usart/mod.rs
@@ -200,6 +200,7 @@ impl<'d, T: Instance, TxDma, RxDma> Uart<'d, T, TxDma, RxDma> {
         unborrow!(_inner, rx, tx, tx_dma, rx_dma);
 
         T::enable();
+        T::reset();
         let pclk_freq = T::frequency();
 
         // TODO: better calculation, including error checking and OVER8 if possible.


### PR DESCRIPTION
Add reset on initialization to peripherals that did not have it before. This fixes problems when same peripheral is reinitialized at runtime multiple times.

Some exceptions:
- ADC: all ADCs share a single reset
- DCMI: does reset before enable - couldn't find anything about the order in the reference manual. Just keep it if it works?

I also fixed safety issues where global RCC registers where accessed without critical section.