### PR TITLE
Reexport unborrow macro in HALs

### DIFF
--- a/embassy-nrf/src/lib.rs
+++ b/embassy-nrf/src/lib.rs
@@ -115,6 +115,9 @@ pub use chip::pac;
 #[cfg(not(feature = "unstable-pac"))]
 pub(crate) use chip::pac;
 
+pub use embassy::util::Unborrow;
+pub use embassy_hal_common::unborrow;
+
 pub use chip::{peripherals, Peripherals};
 
 pub mod interrupt {

--- a/embassy-rp/src/lib.rs
+++ b/embassy-rp/src/lib.rs
@@ -7,6 +7,9 @@ pub use rp2040_pac2 as pac;
 #[cfg(not(feature = "unstable-pac"))]
 pub(crate) use rp2040_pac2 as pac;
 
+pub use embassy::util::Unborrow;
+pub use embassy_hal_common::unborrow;
+
 // This mod MUST go first, so that the others see its macros.
 pub(crate) mod fmt;
 

--- a/embassy-stm32/src/lib.rs
+++ b/embassy-stm32/src/lib.rs
@@ -9,6 +9,9 @@ pub use stm32_metapac as pac;
 #[cfg(not(feature = "unstable-pac"))]
 pub(crate) use stm32_metapac as pac;
 
+pub use embassy::util::Unborrow;
+pub use embassy_hal_common::unborrow;
+
 // This must go FIRST so that all the other modules see its macros.
 pub mod fmt;
 include!(concat!(env!("OUT_DIR"), "/_macros.rs"));

--- a/examples/stm32h7/Cargo.toml
+++ b/examples/stm32h7/Cargo.toml
@@ -11,7 +11,6 @@ resolver = "2"
 embassy = { version = "0.1.0", path = "../../embassy", features = ["defmt", "defmt-timestamp-uptime"] }
 embassy-stm32 = { version = "0.1.0", path = "../../embassy-stm32", features = ["nightly", "defmt", "stm32h743bi", "net", "time-driver-any", "exti", "unstable-pac", "unstable-traits"] }
 embassy-net = { path = "../../embassy-net", default-features = false, features = ["defmt", "tcp", "medium-ethernet", "pool-16"] }
-embassy-hal-common = { path = "../../embassy-hal-common", default-features = false, features = ["defmt"] }
 
 defmt = "0.3"
 defmt-rtt = "0.3"

--- a/examples/stm32h7/src/bin/low_level_timer_api.rs
+++ b/examples/stm32h7/src/bin/low_level_timer_api.rs
@@ -10,11 +10,11 @@ use defmt::*;
 use embassy::executor::Spawner;
 use embassy::time::{Duration, Timer};
 use embassy::util::Unborrow;
-use embassy_hal_common::unborrow;
 use embassy_stm32::gpio::low_level::AFType;
 use embassy_stm32::gpio::Speed;
 use embassy_stm32::pwm::*;
 use embassy_stm32::time::{Hertz, U32Ext};
+use embassy_stm32::unborrow;
 use embassy_stm32::{Config, Peripherals};
 
 pub fn config() -> Config {


### PR DESCRIPTION
Removes the need to depend on embassy-hal-common in the case of developing custom peripheral drivers.