### PR TITLE
Add support for USB classes handling control requests.

### DIFF
--- a/embassy-usb/src/builder.rs
+++ b/embassy-usb/src/builder.rs
@@ -175,10 +175,7 @@ impl<'d, D: Driver<'d>> UsbDeviceBuilder<'d, D> {
     }
 
     /// Creates the [`UsbDevice`] instance with the configuration in this builder.
-    ///
-    /// If a device has mutliple [`UsbClass`]es, they can be provided as a tuple list:
-    /// `(class1, (class2, (class3, ()))`.
-    pub fn build<C: UsbClass<'d, D>>(mut self, classes: C) -> UsbDevice<'d, D, C> {
+    pub fn build(mut self, classes: &'d mut [&'d mut dyn UsbClass]) -> UsbDevice<'d, D> {
         self.config_descriptor.end_configuration();
         self.bos_descriptor.end_bos();
 

--- a/embassy-usb/src/class.rs
+++ b/embassy-usb/src/class.rs
@@ -1,0 +1,190 @@
+use core::future::Future;
+
+use crate::control::Request;
+use crate::driver::{ControlPipe, Driver};
+
+#[derive(Copy, Clone, Eq, PartialEq, Debug)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+pub enum RequestStatus {
+    Unhandled,
+    Accepted,
+    Rejected,
+}
+
+impl Default for RequestStatus {
+    fn default() -> Self {
+        RequestStatus::Unhandled
+    }
+}
+
+/// A trait for implementing USB classes.
+///
+/// All methods are optional callbacks that will be called by
+/// [`UsbDevice::run()`](crate::UsbDevice::run)
+pub trait UsbClass<'d, D: Driver<'d>> {
+    type ControlOutFuture<'a>: Future<Output = RequestStatus> + 'a
+    where
+        Self: 'a,
+        'd: 'a,
+        D: 'a;
+
+    type ControlInFuture<'a>: Future<Output = ControlInRequestStatus> + 'a
+    where
+        Self: 'a,
+        'd: 'a,
+        D: 'a;
+
+    /// Called after a USB reset after the bus reset sequence is complete.
+    fn reset(&mut self) {}
+
+    /// Called when a control request is received with direction HostToDevice.
+    ///
+    /// All requests are passed to classes in turn, which can choose to accept, ignore or report an
+    /// error. Classes can even choose to override standard requests, but doing that is rarely
+    /// necessary.
+    ///
+    /// When implementing your own class, you should ignore any requests that are not meant for your
+    /// class so that any other classes in the composite device can process them.
+    ///
+    /// # Arguments
+    ///
+    /// * `req` - The request from the SETUP packet.
+    /// * `data` - The data from the request.
+    fn control_out<'a>(&'a mut self, req: Request, data: &'a [u8]) -> Self::ControlOutFuture<'a>
+    where
+        'd: 'a,
+        D: 'a;
+
+    /// Called when a control request is received with direction DeviceToHost.
+    ///
+    /// All requests are passed to classes in turn, which can choose to accept, ignore or report an
+    /// error. Classes can even choose to override standard requests, but doing that is rarely
+    /// necessary.
+    ///
+    /// See [`ControlIn`] for how to respond to the transfer.
+    ///
+    /// When implementing your own class, you should ignore any requests that are not meant for your
+    /// class so that any other classes in the composite device can process them.
+    ///
+    /// # Arguments
+    ///
+    /// * `req` - The request from the SETUP packet.
+    /// * `control` - The control pipe.
+    fn control_in<'a>(
+        &'a mut self,
+        req: Request,
+        control: ControlIn<'a, 'd, D>,
+    ) -> Self::ControlInFuture<'a>
+    where
+        'd: 'a;
+}
+
+impl<'d, D: Driver<'d>> UsbClass<'d, D> for () {
+    type ControlOutFuture<'a> = impl Future<Output = RequestStatus> + 'a where Self: 'a, 'd: 'a, D: 'a;
+    type ControlInFuture<'a> = impl Future<Output = ControlInRequestStatus> + 'a where Self: 'a, 'd: 'a, D: 'a;
+
+    fn control_out<'a>(&'a mut self, _req: Request, _data: &'a [u8]) -> Self::ControlOutFuture<'a>
+    where
+        'd: 'a,
+        D: 'a,
+    {
+        async move { RequestStatus::default() }
+    }
+
+    fn control_in<'a>(
+        &'a mut self,
+        _req: Request,
+        control: ControlIn<'a, 'd, D>,
+    ) -> Self::ControlInFuture<'a>
+    where
+        'd: 'a,
+        D: 'a,
+    {
+        async move { control.ignore() }
+    }
+}
+
+impl<'d, D: Driver<'d>, Head, Tail> UsbClass<'d, D> for (Head, Tail)
+where
+    Head: UsbClass<'d, D>,
+    Tail: UsbClass<'d, D>,
+{
+    type ControlOutFuture<'a> = impl Future<Output = RequestStatus> + 'a where Self: 'a, 'd: 'a, D: 'a;
+    type ControlInFuture<'a> = impl Future<Output = ControlInRequestStatus> + 'a where Self: 'a, 'd: 'a, D: 'a;
+
+    fn control_out<'a>(&'a mut self, req: Request, data: &'a [u8]) -> Self::ControlOutFuture<'a>
+    where
+        'd: 'a,
+        D: 'a,
+    {
+        async move {
+            match self.0.control_out(req, data).await {
+                RequestStatus::Unhandled => self.1.control_out(req, data).await,
+                status => status,
+            }
+        }
+    }
+
+    fn control_in<'a>(
+        &'a mut self,
+        req: Request,
+        control: ControlIn<'a, 'd, D>,
+    ) -> Self::ControlInFuture<'a>
+    where
+        'd: 'a,
+    {
+        async move {
+            match self
+                .0
+                .control_in(req, ControlIn::new(control.control))
+                .await
+            {
+                ControlInRequestStatus(RequestStatus::Unhandled) => {
+                    self.1.control_in(req, control).await
+                }
+                status => status,
+            }
+        }
+    }
+}
+
+/// Handle for a control IN transfer. When implementing a class, use the methods of this object to
+/// response to the transfer with either data or an error (STALL condition). To ignore the request
+/// and pass it on to the next class, call [`Self::ignore()`].
+pub struct ControlIn<'a, 'd: 'a, D: Driver<'d>> {
+    control: &'a mut D::ControlPipe,
+}
+
+#[derive(Eq, PartialEq, Debug)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+pub struct ControlInRequestStatus(pub(crate) RequestStatus);
+
+impl ControlInRequestStatus {
+    pub fn status(self) -> RequestStatus {
+        self.0
+    }
+}
+
+impl<'a, 'd: 'a, D: Driver<'d>> ControlIn<'a, 'd, D> {
+    pub(crate) fn new(control: &'a mut D::ControlPipe) -> Self {
+        ControlIn { control }
+    }
+
+    /// Ignores the request and leaves it unhandled.
+    pub fn ignore(self) -> ControlInRequestStatus {
+        ControlInRequestStatus(RequestStatus::Unhandled)
+    }
+
+    /// Accepts the transfer with the supplied buffer.
+    pub async fn accept(self, data: &[u8]) -> ControlInRequestStatus {
+        self.control.accept_in(data).await;
+
+        ControlInRequestStatus(RequestStatus::Accepted)
+    }
+
+    /// Rejects the transfer by stalling the pipe.
+    pub fn reject(self) -> ControlInRequestStatus {
+        self.control.reject();
+        ControlInRequestStatus(RequestStatus::Rejected)
+    }
+}

--- a/embassy-usb/src/control.rs
+++ b/embassy-usb/src/control.rs
@@ -2,12 +2,6 @@ use core::mem;
 
 use super::types::*;
 
-#[derive(Debug, PartialEq, Eq, Clone, Copy)]
-#[cfg_attr(feature = "defmt", derive(defmt::Format))]
-pub enum ParseError {
-    InvalidLength,
-}
-
 /// Control request type.
 #[repr(u8)]
 #[derive(Copy, Clone, Eq, PartialEq, Debug)]
@@ -104,15 +98,12 @@ impl Request {
     /// Standard USB feature Device Remote Wakeup for Set/Clear Feature
     pub const FEATURE_DEVICE_REMOTE_WAKEUP: u16 = 1;
 
-    pub(crate) fn parse(buf: &[u8]) -> Result<Request, ParseError> {
-        if buf.len() != 8 {
-            return Err(ParseError::InvalidLength);
-        }
-
+    /// Parses a USB control request from a byte array.
+    pub fn parse(buf: &[u8; 8]) -> Request {
         let rt = buf[0];
         let recipient = rt & 0b11111;
 
-        Ok(Request {
+        Request {
             direction: rt.into(),
             request_type: unsafe { mem::transmute((rt >> 5) & 0b11) },
             recipient: if recipient <= 3 {
@@ -124,7 +115,7 @@ impl Request {
             value: (buf[2] as u16) | ((buf[3] as u16) << 8),
             index: (buf[4] as u16) | ((buf[5] as u16) << 8),
             length: (buf[6] as u16) | ((buf[7] as u16) << 8),
-        })
+        }
     }
 
     /// Gets the descriptor type and index from the value field of a GET_DESCRIPTOR request.

--- a/examples/nrf/src/bin/usb/main.rs
+++ b/examples/nrf/src/bin/usb/main.rs
@@ -16,6 +16,7 @@ use embassy_nrf::interrupt;
 use embassy_nrf::pac;
 use embassy_nrf::usb::Driver;
 use embassy_nrf::Peripherals;
+use embassy_usb::class::UsbClass;
 use embassy_usb::driver::{EndpointIn, EndpointOut};
 use embassy_usb::{Config, UsbDeviceBuilder};
 use futures::future::join3;
@@ -59,7 +60,8 @@ async fn main(_spawner: Spawner, p: Peripherals) {
     let mut class = CdcAcmClass::new(&mut builder, 64);
 
     // Build the builder.
-    let mut usb = builder.build(class.control);
+    let mut classes: [&mut dyn UsbClass; 1] = [&mut class.control];
+    let mut usb = builder.build(&mut classes);
 
     // Run the USB device.
     let fut1 = usb.run();

--- a/examples/nrf/src/bin/usb/main.rs
+++ b/examples/nrf/src/bin/usb/main.rs
@@ -1,5 +1,6 @@
 #![no_std]
 #![no_main]
+#![feature(generic_associated_types)]
 #![feature(type_alias_impl_trait)]
 
 #[path = "../../example_common.rs"]
@@ -58,7 +59,7 @@ async fn main(_spawner: Spawner, p: Peripherals) {
     let mut class = CdcAcmClass::new(&mut builder, 64);
 
     // Build the builder.
-    let mut usb = builder.build();
+    let mut usb = builder.build(class.control);
 
     // Run the USB device.
     let fut1 = usb.run();


### PR DESCRIPTION
Added functionality to #657 to allow classes to handle their own EP0 control requests. This was needed for an HID class implementation I'm working on. It a fairly substantial change so review would be much appreciated.