### PR TITLE
Convert chip name to upper case to fix rebuilds

### DIFF
--- a/stm32-metapac/build.rs
+++ b/stm32-metapac/build.rs
@@ -69,7 +69,7 @@ fn main() {
     println!(
         "cargo:rerun-if-changed={}/chips/{}.json",
         data_dir.display(),
-        chip_name
+        chip_name.to_uppercase()
     );
 
     println!("cargo:rerun-if-changed={}/registers", data_dir.display());


### PR DESCRIPTION
PR #665 made stm32-metapac rebuild when the chip definition was changed.
Though it used the lowercase version of the chip name as a filename which probably worked fine on windows with its case-independent filesystem, but was causing constant rebuilds on linux