### PR TITLE
async usb stack: Let ControlHandler's provide the control_in buffer

### DIFF
--- a/embassy-usb/src/control.rs
+++ b/embassy-usb/src/control.rs
@@ -133,8 +133,8 @@ pub enum OutResponse {
 
 #[derive(Copy, Clone, Eq, PartialEq, Debug)]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
-pub enum InResponse {
-    Accepted(usize),
+pub enum InResponse<'a> {
+    Accepted(&'a [u8]),
     Rejected,
 }
 
@@ -164,8 +164,7 @@ pub trait ControlHandler {
     /// # Arguments
     ///
     /// * `req` - The request from the SETUP packet.
-    /// * `resp` - The buffer for you to write the response.
-    fn control_in(&mut self, req: Request, resp: &mut [u8]) -> InResponse {
+    fn control_in(&mut self, req: Request) -> InResponse<'_> {
         InResponse::Rejected
     }
 }

--- a/embassy-usb/src/control.rs
+++ b/embassy-usb/src/control.rs
@@ -164,7 +164,7 @@ pub trait ControlHandler {
     /// # Arguments
     ///
     /// * `req` - The request from the SETUP packet.
-    fn control_in(&mut self, req: Request) -> InResponse<'_> {
+    fn control_in<'a>(&'a mut self, req: Request, buf: &'a mut [u8]) -> InResponse<'a> {
         InResponse::Rejected
     }
 }

--- a/embassy-usb/src/lib.rs
+++ b/embassy-usb/src/lib.rs
@@ -284,13 +284,10 @@ impl<'d, D: Driver<'d>> UsbDevice<'d, D> {
                     .find(|(i, _)| req.index == *i as _)
                     .map(|(_, h)| h);
                 match handler {
-                    Some(handler) => {
-                        let mut buf = [0; 128];
-                        match handler.control_in(req, &mut buf) {
-                            InResponse::Accepted(len) => self.control.accept_in(&buf[..len]).await,
-                            InResponse::Rejected => self.control.reject(),
-                        }
-                    }
+                    Some(handler) => match handler.control_in(req) {
+                        InResponse::Accepted(data) => self.control.accept_in(data).await,
+                        InResponse::Rejected => self.control.reject(),
+                    },
                     None => self.control.reject(),
                 }
             }

--- a/examples/nrf/src/bin/usb/main.rs
+++ b/examples/nrf/src/bin/usb/main.rs
@@ -47,6 +47,7 @@ async fn main(_spawner: Spawner, p: Peripherals) {
     let mut device_descriptor = [0; 256];
     let mut config_descriptor = [0; 256];
     let mut bos_descriptor = [0; 256];
+    let mut control_buf = [0; 7];
 
     let mut state = State::new();
 
@@ -56,6 +57,7 @@ async fn main(_spawner: Spawner, p: Peripherals) {
         &mut device_descriptor,
         &mut config_descriptor,
         &mut bos_descriptor,
+        &mut control_buf,
     );
 
     // Create classes on the builder.


### PR DESCRIPTION
This removes the buffer from UsbDevice for control_in requests and lets the ControlHandler provide it's own buffer or a static buffer for the response.