### PR TITLE
Add basic device state handling for endpoints.

### DIFF
--- a/embassy-usb-serial/src/lib.rs
+++ b/embassy-usb-serial/src/lib.rs
@@ -273,6 +273,11 @@ impl<'d, D: Driver<'d>> CdcAcmClass<'d, D> {
     pub async fn read_packet(&mut self, data: &mut [u8]) -> Result<usize, ReadError> {
         self.read_ep.read(data).await
     }
+
+    /// Waits for the USB host to enable this interface
+    pub async fn wait_connection(&mut self) {
+        self.read_ep.wait_enabled().await
+    }
 }
 
 /// Number of stop bits for LineCoding

--- a/examples/nrf/src/bin/usb_serial.rs
+++ b/examples/nrf/src/bin/usb_serial.rs
@@ -4,12 +4,13 @@
 #![feature(type_alias_impl_trait)]
 
 use core::mem;
-use defmt::*;
+use defmt::{info, panic};
 use embassy::executor::Spawner;
 use embassy_nrf::interrupt;
 use embassy_nrf::pac;
-use embassy_nrf::usb::Driver;
+use embassy_nrf::usb::{Driver, Instance};
 use embassy_nrf::Peripherals;
+use embassy_usb::driver::{ReadError, WriteError};
 use embassy_usb::{Config, UsbDeviceBuilder};
 use embassy_usb_serial::{CdcAcmClass, State};
 use futures::future::join;
@@ -66,16 +67,47 @@ async fn main(_spawner: Spawner, p: Peripherals) {
 
     // Do stuff with the class!
     let echo_fut = async {
-        let mut buf = [0; 64];
         loop {
-            let n = class.read_packet(&mut buf).await.unwrap();
-            let data = &buf[..n];
-            info!("data: {:x}", data);
-            class.write_packet(data).await.unwrap();
+            class.wait_connection().await;
+            info!("Connected");
+            let _ = echo(&mut class).await;
+            info!("Disconnected");
         }
     };
 
     // Run everything concurrently.
     // If we had made everything `'static` above instead, we could do this using separate tasks instead.
     join(usb_fut, echo_fut).await;
+}
+
+struct Disconnected {}
+
+impl From<ReadError> for Disconnected {
+    fn from(val: ReadError) -> Self {
+        match val {
+            ReadError::BufferOverflow => panic!("Buffer overflow"),
+            ReadError::Disabled => Disconnected {},
+        }
+    }
+}
+
+impl From<WriteError> for Disconnected {
+    fn from(val: WriteError) -> Self {
+        match val {
+            WriteError::BufferOverflow => panic!("Buffer overflow"),
+            WriteError::Disabled => Disconnected {},
+        }
+    }
+}
+
+async fn echo<'d, T: Instance + 'd>(
+    class: &mut CdcAcmClass<'d, Driver<'d, T>>,
+) -> Result<(), Disconnected> {
+    let mut buf = [0; 64];
+    loop {
+        let n = class.read_packet(&mut buf).await?;
+        let data = &buf[..n];
+        info!("data: {:x}", data);
+        class.write_packet(data).await?;
+    }
 }


### PR DESCRIPTION
For protocols where the endpoint stream is stateful, it will be necessary for endpoint tasks to handle bus reset events. We should also avoid enabling endpoints until the host has set the device configuration.

This PR adds a `set_configured()` method to the `driver::Bus` trait to allow the driver to enable/disable endpoints in response to SET_CONFIGURATION control requests.

It also adds a `Disabled` error to both `WriteError` and `ReadError` which should be returned from `EndpointIn::write()` or `EndpointOut::read()` if the endpoint is disabled during the call.

Finally, it adds an `Endpoint::wait_enabled()` method to allow clients to wait for the device to be configured and the endpoint(s) enabled.
