### PR TITLE
Async-ify Driver::enable and UsbDeviceBuilder::build

### DIFF
--- a/embassy-nrf/src/usb.rs
+++ b/embassy-nrf/src/usb.rs
@@ -662,14 +662,14 @@ impl<'d, T: Instance> driver::ControlPipe for ControlPipe<'d, T> {
             poll_fn(|cx| {
                 EP0_WAKER.register(cx.waker());
                 let regs = T::regs();
-                if regs.events_usbreset.read().bits() != 0 {
+                if regs.events_ep0datadone.read().bits() != 0 {
+                    Poll::Ready(Ok(()))
+                } else if regs.events_usbreset.read().bits() != 0 {
                     trace!("aborted control data_out: usb reset");
                     Poll::Ready(Err(ReadError::Disabled))
                 } else if regs.events_ep0setup.read().bits() != 0 {
                     trace!("aborted control data_out: received another SETUP");
                     Poll::Ready(Err(ReadError::Disabled))
-                } else if regs.events_ep0datadone.read().bits() != 0 {
-                    Poll::Ready(Ok(()))
                 } else {
                     Poll::Pending
                 }
@@ -701,14 +701,14 @@ impl<'d, T: Instance> driver::ControlPipe for ControlPipe<'d, T> {
                 cx.waker().wake_by_ref();
                 EP0_WAKER.register(cx.waker());
                 let regs = T::regs();
-                if regs.events_usbreset.read().bits() != 0 {
+                if regs.events_ep0datadone.read().bits() != 0 {
+                    Poll::Ready(Ok(()))
+                } else if regs.events_usbreset.read().bits() != 0 {
                     trace!("aborted control data_in: usb reset");
                     Poll::Ready(Err(WriteError::Disabled))
                 } else if regs.events_ep0setup.read().bits() != 0 {
                     trace!("aborted control data_in: received another SETUP");
                     Poll::Ready(Err(WriteError::Disabled))
-                } else if regs.events_ep0datadone.read().bits() != 0 {
-                    Poll::Ready(Ok(()))
                 } else {
                     Poll::Pending
                 }

--- a/embassy-usb/src/driver.rs
+++ b/embassy-usb/src/driver.rs
@@ -11,6 +11,7 @@ pub trait Driver<'a> {
     type EndpointIn: EndpointIn + 'a;
     type ControlPipe: ControlPipe + 'a;
     type Bus: Bus + 'a;
+    type EnableFuture: Future<Output = Self::Bus> + 'a;
 
     /// Allocates an endpoint and specified endpoint parameters. This method is called by the device
     /// and class implementations to allocate endpoints, and can only be called before
@@ -46,7 +47,7 @@ pub trait Driver<'a> {
 
     /// Enables and initializes the USB peripheral. Soon after enabling the device will be reset, so
     /// there is no need to perform a USB reset in this method.
-    fn enable(self) -> Self::Bus;
+    fn enable(self) -> Self::EnableFuture;
 
     /// Indicates that `set_device_address` must be called before accepting the corresponding
     /// control transfer, not after.

--- a/examples/nrf/src/bin/usb_hid_keyboard.rs
+++ b/examples/nrf/src/bin/usb_hid_keyboard.rs
@@ -76,7 +76,7 @@ async fn main(_spawner: Spawner, p: Peripherals) {
     );
 
     // Build the builder.
-    let mut usb = builder.build();
+    let mut usb = builder.build().await;
 
     // Run the USB device.
     let usb_fut = usb.run();

--- a/examples/nrf/src/bin/usb_hid_mouse.rs
+++ b/examples/nrf/src/bin/usb_hid_mouse.rs
@@ -74,7 +74,7 @@ async fn main(_spawner: Spawner, p: Peripherals) {
     );
 
     // Build the builder.
-    let mut usb = builder.build();
+    let mut usb = builder.build().await;
 
     // Run the USB device.
     let usb_fut = usb.run();

--- a/examples/nrf/src/bin/usb_serial.rs
+++ b/examples/nrf/src/bin/usb_serial.rs
@@ -60,7 +60,7 @@ async fn main(_spawner: Spawner, p: Peripherals) {
     let mut class = CdcAcmClass::new(&mut builder, &mut state, 64);
 
     // Build the builder.
-    let mut usb = builder.build();
+    let mut usb = builder.build().await;
 
     // Run the USB device.
     let usb_fut = usb.run();

--- a/examples/nrf/src/bin/usb_serial_multitask.rs
+++ b/examples/nrf/src/bin/usb_serial_multitask.rs
@@ -85,7 +85,7 @@ async fn main(spawner: Spawner, p: Peripherals) {
     let class = CdcAcmClass::new(&mut builder, &mut res.serial_state, 64);
 
     // Build the builder.
-    let usb = builder.build();
+    let usb = builder.build().await;
 
     unwrap!(spawner.spawn(usb_task(usb)));
     unwrap!(spawner.spawn(echo_task(class)));


### PR DESCRIPTION
As discussed, this prevents the 1ms blocking wait in the nrf USB driver.

I also found an issue with `ControlPipe::accept_in` returning an error when a setup packet is received immediately after `data_in` completes (before the future is polled). That's now fixed.