### PR TITLE
add more clock options for l4 and l5

### DIFF
--- a/examples/stm32l4/src/bin/rng.rs
+++ b/examples/stm32l4/src/bin/rng.rs
@@ -12,12 +12,13 @@ use panic_probe as _;
 
 fn config() -> Config {
     let mut config = Config::default();
+    // 72Mhz clock (16 / 1 * 18 / 4)
     config.rcc.mux = ClockSrc::PLL(
         PLLSource::HSI16,
-        PLLClkDiv::Div2,
+        PLLClkDiv::Div4,
         PLLSrcDiv::Div1,
-        PLLMul::Mul8,
-        Some(PLLClkDiv::Div2),
+        PLLMul::Mul18,
+        Some(PLLClkDiv::Div6), // 48Mhz (16 / 1 * 18 / 6)
     );
     config
 }


### PR DESCRIPTION
- added an assert so it panics if pll48div is not 48Mhz
- added MSI as a clock source for PLL
- removed hsi48 option for MCUs mentioned in l4 rcc presentation
- copied some code from l4 to l5, but don't have a way of testing it.