### PR TITLE
stm32/dac: Check proper channel

### DIFF
--- a/embassy-stm32/src/dac/v2.rs
+++ b/embassy-stm32/src/dac/v2.rs
@@ -240,7 +240,7 @@ impl<'d, T: Instance> Dac<'d, T> {
     }
 
     pub fn set(&mut self, ch: Channel, value: Value) -> Result<(), Error> {
-        self.check_channel_exists(Channel::Ch2)?;
+        self.check_channel_exists(ch)?;
         match ch {
             Channel::Ch1 => match value {
                 Value::Bit8(v) => unsafe {


### PR DESCRIPTION
Small fix. Otherwise it panics when trying to use channel 1 if channel 2 does not exist.