### PR TITLE
USB HID: simplify API

### DIFF
--- a/embassy-usb/src/control.rs
+++ b/embassy-usb/src/control.rs
@@ -271,9 +271,9 @@ impl<C: driver::ControlPipe> ControlPipe<C> {
 
             let res = &buf[0..total];
             #[cfg(feature = "defmt")]
-            trace!("  control out data: {:02x}", buf);
+            trace!("  control out data: {:02x}", res);
             #[cfg(not(feature = "defmt"))]
-            trace!("  control out data: {:02x?}", buf);
+            trace!("  control out data: {:02x?}", res);
 
             Ok((res, StatusStage {}))
         }

--- a/examples/nrf/src/bin/usb_hid_keyboard.rs
+++ b/examples/nrf/src/bin/usb_hid_keyboard.rs
@@ -18,7 +18,7 @@ use embassy_nrf::usb::Driver;
 use embassy_nrf::Peripherals;
 use embassy_usb::control::OutResponse;
 use embassy_usb::{Config, DeviceStateHandler, UsbDeviceBuilder};
-use embassy_usb_hid::{HidClass, ReportId, RequestHandler, State};
+use embassy_usb_hid::{HidReaderWriter, ReportId, RequestHandler, State};
 use futures::future::join;
 use usbd_hid::descriptor::{KeyboardReport, SerializedDescriptor};
 
@@ -75,7 +75,7 @@ async fn main(_spawner: Spawner, p: Peripherals) {
     let request_handler = MyRequestHandler {};
     let device_state_handler = MyDeviceStateHandler::new();
 
-    let mut state = State::<8, 1>::new();
+    let mut state = State::new();
 
     let mut builder = UsbDeviceBuilder::new(
         driver,
@@ -88,7 +88,7 @@ async fn main(_spawner: Spawner, p: Peripherals) {
     );
 
     // Create classes on the builder.
-    let hid = HidClass::with_output_ep(
+    let hid = HidReaderWriter::<_, 1, 8>::new(
         &mut builder,
         &mut state,
         KeyboardReport::desc(),
@@ -135,7 +135,7 @@ async fn main(_spawner: Spawner, p: Peripherals) {
 
     let mut button = Input::new(p.P0_11.degrade(), Pull::Up);
 
-    let (mut hid_in, hid_out) = hid.split();
+    let (reader, mut writer) = hid.split();
 
     // Do stuff with the class!
     let in_fut = async {
@@ -153,7 +153,7 @@ async fn main(_spawner: Spawner, p: Peripherals) {
                     modifier: 0,
                     reserved: 0,
                 };
-                match hid_in.serialize(&report).await {
+                match writer.write_serialize(&report).await {
                     Ok(()) => {}
                     Err(e) => warn!("Failed to send report: {:?}", e),
                 };
@@ -167,7 +167,7 @@ async fn main(_spawner: Spawner, p: Peripherals) {
                 modifier: 0,
                 reserved: 0,
             };
-            match hid_in.serialize(&report).await {
+            match writer.write_serialize(&report).await {
                 Ok(()) => {}
                 Err(e) => warn!("Failed to send report: {:?}", e),
             };
@@ -175,7 +175,7 @@ async fn main(_spawner: Spawner, p: Peripherals) {
     };
 
     let out_fut = async {
-        hid_out.run(false, &request_handler).await;
+        reader.run(false, &request_handler).await;
     };
 
     let power_irq = interrupt::take!(POWER_CLOCK);

--- a/examples/nrf/src/bin/usb_hid_keyboard.rs
+++ b/examples/nrf/src/bin/usb_hid_keyboard.rs
@@ -88,14 +88,13 @@ async fn main(_spawner: Spawner, p: Peripherals) {
     );
 
     // Create classes on the builder.
-    let hid = HidReaderWriter::<_, 1, 8>::new(
-        &mut builder,
-        &mut state,
-        KeyboardReport::desc(),
-        Some(&request_handler),
-        60,
-        64,
-    );
+    let config = embassy_usb_hid::Config {
+        report_descriptor: KeyboardReport::desc(),
+        request_handler: Some(&request_handler),
+        poll_ms: 60,
+        max_packet_size: 64,
+    };
+    let hid = HidReaderWriter::<_, 1, 8>::new(&mut builder, &mut state, config);
 
     // Build the builder.
     let mut usb = builder.build();

--- a/examples/nrf/src/bin/usb_hid_mouse.rs
+++ b/examples/nrf/src/bin/usb_hid_mouse.rs
@@ -13,7 +13,7 @@ use embassy_nrf::usb::Driver;
 use embassy_nrf::Peripherals;
 use embassy_usb::control::OutResponse;
 use embassy_usb::{Config, UsbDeviceBuilder};
-use embassy_usb_hid::{HidClass, ReportId, RequestHandler, State};
+use embassy_usb_hid::{HidWriter, ReportId, RequestHandler, State};
 use futures::future::join;
 use usbd_hid::descriptor::{MouseReport, SerializedDescriptor};
 
@@ -52,7 +52,7 @@ async fn main(_spawner: Spawner, p: Peripherals) {
     let mut control_buf = [0; 16];
     let request_handler = MyRequestHandler {};
 
-    let mut control = State::<5, 0>::new();
+    let mut control = State::new();
 
     let mut builder = UsbDeviceBuilder::new(
         driver,
@@ -65,7 +65,7 @@ async fn main(_spawner: Spawner, p: Peripherals) {
     );
 
     // Create classes on the builder.
-    let mut hid = HidClass::new(
+    let mut writer = HidWriter::<_, 5>::new(
         &mut builder,
         &mut control,
         MouseReport::desc(),
@@ -94,7 +94,7 @@ async fn main(_spawner: Spawner, p: Peripherals) {
                 wheel: 0,
                 pan: 0,
             };
-            match hid.input().serialize(&report).await {
+            match writer.write_serialize(&report).await {
                 Ok(()) => {}
                 Err(e) => warn!("Failed to send report: {:?}", e),
             }

--- a/examples/nrf/src/bin/usb_hid_mouse.rs
+++ b/examples/nrf/src/bin/usb_hid_mouse.rs
@@ -52,7 +52,7 @@ async fn main(_spawner: Spawner, p: Peripherals) {
     let mut control_buf = [0; 16];
     let request_handler = MyRequestHandler {};
 
-    let mut control = State::new();
+    let mut state = State::new();
 
     let mut builder = UsbDeviceBuilder::new(
         driver,
@@ -65,14 +65,14 @@ async fn main(_spawner: Spawner, p: Peripherals) {
     );
 
     // Create classes on the builder.
-    let mut writer = HidWriter::<_, 5>::new(
-        &mut builder,
-        &mut control,
-        MouseReport::desc(),
-        Some(&request_handler),
-        60,
-        8,
-    );
+    let config = embassy_usb_hid::Config {
+        report_descriptor: MouseReport::desc(),
+        request_handler: Some(&request_handler),
+        poll_ms: 60,
+        max_packet_size: 8,
+    };
+
+    let mut writer = HidWriter::<_, 5>::new(&mut builder, &mut state, config);
 
     // Build the builder.
     let mut usb = builder.build();


### PR DESCRIPTION
Following the discussion from #720  and [matrix](https://matrix.to/#/!YoLPkieCYHGzdjUhOK:matrix.org/$PcPr8E_JbodEPuUUKI2PzIC9sx7nF3y0kV2T5O4UWj8?via=matrix.org&via=converser.eu&via=braun-odw.eu), this is a second take on simplifying the HID API.

Split into a separate PR so it can be reviewed separately.

See individual commit messages for details.

cc @alexmoon 