### PR TITLE
usb: builtin handling of interface alternate settings

### DIFF
--- a/embassy-nrf/Cargo.toml
+++ b/embassy-nrf/Cargo.toml
@@ -17,6 +17,8 @@ flavors = [
 
 [features]
 
+defmt = ["dep:defmt", "embassy/defmt", "embassy-usb?/defmt"]
+
 # Enable nightly-only features
 nightly = ["embassy/nightly", "embedded-hal-1", "embedded-hal-async", "embassy-usb", "embedded-storage-async"]
 

--- a/embassy-usb-hid/src/lib.rs
+++ b/embassy-usb-hid/src/lib.rs
@@ -112,7 +112,8 @@ fn build<'d, D: Driver<'d>>(
     let len = config.report_descriptor.len();
 
     let mut func = builder.function(USB_CLASS_HID, USB_SUBCLASS_NONE, USB_PROTOCOL_NONE);
-    let mut iface = func.interface(Some(control));
+    let mut iface = func.interface();
+    iface.handler(control);
     let mut alt = iface.alt_setting(USB_CLASS_HID, USB_SUBCLASS_NONE, USB_PROTOCOL_NONE);
 
     // HID descriptor
@@ -438,7 +439,7 @@ impl<'d> ControlHandler for Control<'d> {
         self.out_report_offset.store(0, Ordering::Release);
     }
 
-    fn get_descriptor<'a>(&'a mut self, req: Request, buf: &'a mut [u8]) -> InResponse<'a> {
+    fn get_descriptor<'a>(&'a mut self, req: Request, _buf: &'a mut [u8]) -> InResponse<'a> {
         match (req.value >> 8) as u8 {
             HID_DESC_DESCTYPE_HID_REPORT => InResponse::Accepted(self.report_descriptor),
             HID_DESC_DESCTYPE_HID => InResponse::Accepted(&self.hid_descriptor),

--- a/embassy-usb-hid/src/lib.rs
+++ b/embassy-usb-hid/src/lib.rs
@@ -438,6 +438,14 @@ impl<'d> ControlHandler for Control<'d> {
         self.out_report_offset.store(0, Ordering::Release);
     }
 
+    fn get_descriptor<'a>(&'a mut self, req: Request, buf: &'a mut [u8]) -> InResponse<'a> {
+        match (req.value >> 8) as u8 {
+            HID_DESC_DESCTYPE_HID_REPORT => InResponse::Accepted(self.report_descriptor),
+            HID_DESC_DESCTYPE_HID => InResponse::Accepted(&self.hid_descriptor),
+            _ => InResponse::Rejected,
+        }
+    }
+
     fn control_out(&mut self, req: embassy_usb::control::Request, data: &[u8]) -> OutResponse {
         trace!("HID control_out {:?} {=[u8]:x}", req, data);
         if let RequestType::Class = req.request_type {
@@ -477,13 +485,8 @@ impl<'d> ControlHandler for Control<'d> {
 
     fn control_in<'a>(&'a mut self, req: Request, buf: &'a mut [u8]) -> InResponse<'a> {
         trace!("HID control_in {:?}", req);
-        match (req.request_type, req.request) {
-            (RequestType::Standard, Request::GET_DESCRIPTOR) => match (req.value >> 8) as u8 {
-                HID_DESC_DESCTYPE_HID_REPORT => InResponse::Accepted(self.report_descriptor),
-                HID_DESC_DESCTYPE_HID => InResponse::Accepted(&self.hid_descriptor),
-                _ => InResponse::Rejected,
-            },
-            (RequestType::Class, HID_REQ_GET_REPORT) => {
+        match req.request {
+            HID_REQ_GET_REPORT => {
                 let size = match ReportId::try_from(req.value) {
                     Ok(id) => self.request_handler.and_then(|x| x.get_report(id, buf)),
                     Err(_) => None,
@@ -495,7 +498,7 @@ impl<'d> ControlHandler for Control<'d> {
                     InResponse::Rejected
                 }
             }
-            (RequestType::Class, HID_REQ_GET_IDLE) => {
+            HID_REQ_GET_IDLE => {
                 if let Some(handler) = self.request_handler {
                     let id = req.value as u8;
                     let id = (id != 0).then(|| ReportId::In(id));
@@ -510,7 +513,7 @@ impl<'d> ControlHandler for Control<'d> {
                     InResponse::Rejected
                 }
             }
-            (RequestType::Class, HID_REQ_GET_PROTOCOL) => {
+            HID_REQ_GET_PROTOCOL => {
                 // UNSUPPORTED: Boot Protocol
                 buf[0] = 1;
                 InResponse::Accepted(&buf[0..1])

--- a/embassy-usb-serial/src/lib.rs
+++ b/embassy-usb-serial/src/lib.rs
@@ -178,7 +178,8 @@ impl<'d, D: Driver<'d>> CdcAcmClass<'d, D> {
         let mut func = builder.function(USB_CLASS_CDC, CDC_SUBCLASS_ACM, CDC_PROTOCOL_NONE);
 
         // Control interface
-        let mut iface = func.interface(Some(control));
+        let mut iface = func.interface();
+        iface.handler(control);
         let comm_if = iface.interface_number();
         let data_if = u8::from(comm_if) + 1;
         let mut alt = iface.alt_setting(USB_CLASS_CDC, CDC_SUBCLASS_ACM, CDC_PROTOCOL_NONE);
@@ -218,7 +219,7 @@ impl<'d, D: Driver<'d>> CdcAcmClass<'d, D> {
         let comm_ep = alt.endpoint_interrupt_in(8, 255);
 
         // Data interface
-        let mut iface = func.interface(None);
+        let mut iface = func.interface();
         let data_if = iface.interface_number();
         let mut alt = iface.alt_setting(USB_CLASS_CDC_DATA, 0x00, CDC_PROTOCOL_NONE);
         let read_ep = alt.endpoint_bulk_out(max_packet_size);

--- a/embassy-usb/src/builder.rs
+++ b/embassy-usb/src/builder.rs
@@ -267,17 +267,14 @@ impl<'a, 'd, D: Driver<'d>> FunctionBuilder<'a, 'd, D> {
     /// Add an interface to the function.
     ///
     /// Interface numbers are guaranteed to be allocated consecutively, starting from 0.
-    pub fn interface(
-        &mut self,
-        handler: Option<&'d mut dyn ControlHandler>,
-    ) -> InterfaceBuilder<'_, 'd, D> {
+    pub fn interface(&mut self) -> InterfaceBuilder<'_, 'd, D> {
         if let Some(i) = self.iface_count_index {
             self.builder.config_descriptor.buf[i] += 1;
         }
 
         let number = self.builder.interfaces.len() as _;
         let iface = Interface {
-            handler,
+            handler: None,
             current_alt_setting: 0,
             num_alt_settings: 0,
         };
@@ -305,6 +302,10 @@ impl<'a, 'd, D: Driver<'d>> InterfaceBuilder<'a, 'd, D> {
     /// Get the interface number.
     pub fn interface_number(&self) -> InterfaceNumber {
         self.interface_number
+    }
+
+    pub fn handler(&mut self, handler: &'d mut dyn ControlHandler) {
+        self.builder.interfaces[self.interface_number.0 as usize].handler = Some(handler);
     }
 
     /// Add an alternate setting to the interface and write its descriptor.

--- a/embassy-usb/src/control.rs
+++ b/embassy-usb/src/control.rs
@@ -189,6 +189,20 @@ pub trait ControlHandler {
         let _ = (req, buf);
         InResponse::Rejected
     }
+
+    /// Called when a GET_DESCRIPTOR STRING control request is received.
+    ///
+    /// Write the response string somewhere (usually to `buf`, but you may use another buffer
+    /// owned by yourself, or a static buffer), then return it.
+    fn get_string<'a>(
+        &'a mut self,
+        index: StringIndex,
+        lang_id: u16,
+        buf: &'a mut [u8],
+    ) -> Option<&'a str> {
+        let _ = (index, lang_id, buf);
+        None
+    }
 }
 
 /// Typestate representing a ControlPipe in the DATA IN stage

--- a/embassy-usb/src/descriptor.rs
+++ b/embassy-usb/src/descriptor.rs
@@ -1,5 +1,5 @@
 use super::builder::Config;
-use super::{types::*, CONFIGURATION_VALUE, DEFAULT_ALTERNATE_SETTING};
+use super::{types::*, CONFIGURATION_VALUE};
 
 /// Standard descriptor types
 #[allow(missing_docs)]
@@ -192,7 +192,7 @@ impl<'a> DescriptorWriter<'a> {
         interface_protocol: u8,
         interface_string: Option<StringIndex>,
     ) {
-        if alternate_setting == DEFAULT_ALTERNATE_SETTING {
+        if alternate_setting == 0 {
             match self.num_interfaces_mark {
                 Some(mark) => self.buf[mark] += 1,
                 None => {

--- a/embassy-usb/src/descriptor_reader.rs
+++ b/embassy-usb/src/descriptor_reader.rs
@@ -1,0 +1,110 @@
+use crate::descriptor::descriptor_type;
+use crate::types::EndpointAddress;
+
+#[derive(Copy, Clone, PartialEq, Eq, Debug)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+pub struct ReadError;
+
+pub struct Reader<'a> {
+    data: &'a [u8],
+}
+
+impl<'a> Reader<'a> {
+    pub fn new(data: &'a [u8]) -> Self {
+        Self { data }
+    }
+
+    pub fn eof(&self) -> bool {
+        self.data.is_empty()
+    }
+
+    pub fn read<const N: usize>(&mut self) -> Result<[u8; N], ReadError> {
+        let n = self.data.get(0..N).ok_or(ReadError)?;
+        self.data = &self.data[N..];
+        Ok(n.try_into().unwrap())
+    }
+
+    pub fn read_u8(&mut self) -> Result<u8, ReadError> {
+        Ok(u8::from_le_bytes(self.read()?))
+    }
+    pub fn read_u16(&mut self) -> Result<u16, ReadError> {
+        Ok(u16::from_le_bytes(self.read()?))
+    }
+
+    pub fn read_slice(&mut self, len: usize) -> Result<&'a [u8], ReadError> {
+        let res = self.data.get(0..len).ok_or(ReadError)?;
+        self.data = &self.data[len..];
+        Ok(res)
+    }
+
+    pub fn read_descriptors(&mut self) -> DescriptorIter<'_, 'a> {
+        DescriptorIter { r: self }
+    }
+}
+
+pub struct DescriptorIter<'a, 'b> {
+    r: &'a mut Reader<'b>,
+}
+
+impl<'a, 'b> Iterator for DescriptorIter<'a, 'b> {
+    type Item = Result<(u8, Reader<'a>), ReadError>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        if self.r.eof() {
+            return None;
+        }
+
+        let len = match self.r.read_u8() {
+            Ok(x) => x,
+            Err(e) => return Some(Err(e)),
+        };
+        let type_ = match self.r.read_u8() {
+            Ok(x) => x,
+            Err(e) => return Some(Err(e)),
+        };
+        let data = match self.r.read_slice(len as usize - 2) {
+            Ok(x) => x,
+            Err(e) => return Some(Err(e)),
+        };
+
+        Some(Ok((type_, Reader::new(data))))
+    }
+}
+
+#[derive(Copy, Clone, PartialEq, Eq, Debug)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+pub struct EndpointInfo {
+    pub configuration: u8,
+    pub interface: u8,
+    pub interface_alt: u8,
+    pub ep_address: EndpointAddress,
+}
+
+pub fn foreach_endpoint(data: &[u8], mut f: impl FnMut(EndpointInfo)) -> Result<(), ReadError> {
+    let mut ep = EndpointInfo {
+        configuration: 0,
+        interface: 0,
+        interface_alt: 0,
+        ep_address: EndpointAddress::from(0),
+    };
+    for res in Reader::new(data).read_descriptors() {
+        let (kind, mut r) = res?;
+        match kind {
+            descriptor_type::CONFIGURATION => {
+                let _total_length = r.read_u16()?;
+                let _total_length = r.read_u8()?;
+                ep.configuration = r.read_u8()?;
+            }
+            descriptor_type::INTERFACE => {
+                ep.interface = r.read_u8()?;
+                ep.interface_alt = r.read_u8()?;
+            }
+            descriptor_type::ENDPOINT => {
+                ep.ep_address = EndpointAddress::from(r.read_u8()?);
+                f(ep)
+            }
+            _ => {}
+        }
+    }
+    Ok(())
+}

--- a/embassy-usb/src/driver.rs
+++ b/embassy-usb/src/driver.rs
@@ -79,17 +79,17 @@ pub trait Bus {
     fn poll<'a>(&'a mut self) -> Self::PollFuture<'a>;
 
     /// Sets the device USB address to `addr`.
-    fn set_device_address(&mut self, addr: u8);
+    fn set_address(&mut self, addr: u8);
 
-    /// Sets the device configured state.
-    fn set_configured(&mut self, configured: bool);
+    /// Enables or disables an endpoint.
+    fn endpoint_set_enabled(&mut self, ep_addr: EndpointAddress, enabled: bool);
 
     /// Sets or clears the STALL condition for an endpoint. If the endpoint is an OUT endpoint, it
     /// should be prepared to receive data again. Only used during control transfers.
-    fn set_stalled(&mut self, ep_addr: EndpointAddress, stalled: bool);
+    fn endpoint_set_stalled(&mut self, ep_addr: EndpointAddress, stalled: bool);
 
     /// Gets whether the STALL condition is set for an endpoint. Only used during control transfers.
-    fn is_stalled(&mut self, ep_addr: EndpointAddress) -> bool;
+    fn endpoint_is_stalled(&mut self, ep_addr: EndpointAddress) -> bool;
 
     /// Simulates a disconnect from the USB bus, causing the host to reset and re-enumerate the
     /// device.

--- a/embassy-usb/src/types.rs
+++ b/embassy-usb/src/types.rs
@@ -106,7 +106,7 @@ pub struct EndpointInfo {
 /// A handle for a USB interface that contains its number.
 #[derive(Copy, Clone, Eq, PartialEq)]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
-pub struct InterfaceNumber(u8);
+pub struct InterfaceNumber(pub(crate) u8);
 
 impl InterfaceNumber {
     pub(crate) fn new(index: u8) -> InterfaceNumber {


### PR DESCRIPTION
Currently altsetting handling is left to classes, which is annoying because they have to enable/disable the EPs themselves from the ControlHandler. This PR builds the handling into embassy-usb core.

TODO: actually enable/disable the endpoints on SET_INTERFACE.