### PR TITLE
Add embedded-storage trait impls for QSPI

### DIFF
--- a/embassy-nrf/Cargo.toml
+++ b/embassy-nrf/Cargo.toml
@@ -18,7 +18,7 @@ flavors = [
 [features]
 
 # Enable nightly-only features
-nightly = ["embassy/nightly", "embedded-hal-1", "embedded-hal-async", "embassy-usb"]
+nightly = ["embassy/nightly", "embedded-hal-1", "embedded-hal-async", "embassy-usb", "embedded-storage-async"]
 
 # Reexport the PAC for the currently enabled chip at `embassy_nrf::pac`.
 # This is unstable because semver-minor (non-breaking) releases of embassy-nrf may major-bump (breaking) the PAC version.
@@ -80,6 +80,7 @@ critical-section = "0.2.5"
 rand_core = "0.6.3"
 fixed = "1.10.0"
 embedded-storage = "0.3.0"
+embedded-storage-async = { version = "0.3.0", optional = true }
 cfg-if = "1.0.0"
 
 nrf52805-pac  = { version = "0.11.0", optional = true, features = [ "rt" ] }

--- a/examples/nrf/src/bin/qspi.rs
+++ b/examples/nrf/src/bin/qspi.rs
@@ -26,10 +26,9 @@ async fn main(_spawner: Spawner, p: Peripherals) {
     config.write_page_size = qspi::WritePageSize::_256BYTES;
 
     let irq = interrupt::take!(QSPI);
-    let mut q = qspi::Qspi::new(
+    let mut q: qspi::Qspi<_, 67108864> = qspi::Qspi::new(
         p.QSPI, irq, p.P0_19, p.P0_17, p.P0_20, p.P0_21, p.P0_22, p.P0_23, config,
-    )
-    .await;
+    );
 
     let mut id = [1; 3];
     unwrap!(q.custom_instruction(0x9F, &[], &mut id).await);

--- a/examples/nrf/src/bin/qspi_lowpower.rs
+++ b/examples/nrf/src/bin/qspi_lowpower.rs
@@ -32,7 +32,7 @@ async fn main(_spawner: Spawner, mut p: Peripherals) {
             exit_time: 3,  // tRDP = 35uS
         });
 
-        let mut q = qspi::Qspi::new(
+        let mut q: qspi::Qspi<_, 67108864> = qspi::Qspi::new(
             &mut p.QSPI,
             &mut irq,
             &mut p.P0_19,
@@ -42,8 +42,7 @@ async fn main(_spawner: Spawner, mut p: Peripherals) {
             &mut p.P0_22,
             &mut p.P0_23,
             config,
-        )
-        .await;
+        );
 
         let mut id = [1; 3];
         unwrap!(q.custom_instruction(0x9F, &[], &mut id).await);


### PR DESCRIPTION
* Adds implementations of embedded-storage and embedded-storage-async
for QSPI
* Add blocking implementations of QSPI
* Use blocking implementation in new() and embedded-storage impls
* Use async implementation in embedded-storage-async impls
* Add FLASH_SIZE const generic parameter
* Own IRQ in Qspi instance to disable it on drop.