### PR TITLE
Update Rust nightly.

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,6 +1,6 @@
 # Before upgrading check that everything is available on all tier1 targets here:
 # https://rust-lang.github.io/rustup-components-history
 [toolchain]
-channel = "nightly-2022-03-10"
+channel = "nightly-2022-04-24"
 components = [ "rust-src", "rustfmt" ]
 targets = [ "thumbv7em-none-eabi", "thumbv7m-none-eabi", "thumbv6m-none-eabi", "thumbv7em-none-eabihf", "thumbv8m.main-none-eabihf", "wasm32-unknown-unknown" ]


### PR DESCRIPTION
Fixes a new opaque type error in the task macro.
Full error is "opaque type's hidden type cannot be another opaque type from the same scope".
This got disallwed by the lazy-TAIT PR: https://github.com/rust-lang/rust/pull/94081

Sadly there's now some weird type inference errors with pre-lazy-TAIT
nightlies, so support for those is dropped.