### PR TITLE
executor: Add `Spawner::for_current_executor`.

### DIFF
--- a/embassy/src/executor/arch/cortex_m.rs
+++ b/embassy/src/executor/arch/cortex_m.rs
@@ -115,6 +115,9 @@ impl<I: Interrupt> InterruptExecutor<I> {
     /// different "thread" (the interrupt), so spawning tasks on it is effectively
     /// sending them.
     ///
+    /// To obtain a [`Spawner`] for this executor, use [`Spawner::for_current_executor`] from
+    /// a task running in it.
+    ///
     /// This function requires `&'static mut self`. This means you have to store the
     /// Executor instance in a place where it'll live forever and grants you mutable
     /// access. There's a few ways to do this:

--- a/examples/nrf/src/bin/self_spawn_current_executor.rs
+++ b/examples/nrf/src/bin/self_spawn_current_executor.rs
@@ -1,0 +1,24 @@
+#![no_std]
+#![no_main]
+#![feature(type_alias_impl_trait)]
+
+use defmt::{info, unwrap};
+use embassy::executor::Spawner;
+use embassy::time::{Duration, Timer};
+use embassy_nrf::Peripherals;
+
+use defmt_rtt as _; // global logger
+use panic_probe as _;
+
+#[embassy::task(pool_size = 2)]
+async fn my_task(n: u32) {
+    Timer::after(Duration::from_secs(1)).await;
+    info!("Spawning self! {}", n);
+    unwrap!(Spawner::for_current_executor().await.spawn(my_task(n + 1)));
+}
+
+#[embassy::main]
+async fn main(spawner: Spawner, _p: Peripherals) {
+    info!("Hello World!");
+    unwrap!(spawner.spawn(my_task(0)));
+}


### PR DESCRIPTION
This is needed to spawn non-Send tasks in an InterruptExecutor, after the fixes in #730 .

@matoushybl could you check if this works for your use case?