### PR TITLE
Only 1 argument in embassy::main when there is no HAL

### DIFF
--- a/embassy-macros/src/macros/main.rs
+++ b/embassy-macros/src/macros/main.rs
@@ -42,7 +42,7 @@ pub fn run(args: syn::AttributeArgs, f: syn::ItemFn) -> Result<TokenStream, Toke
         ctxt.error_spanned_by(&f.sig, "main function must have 2 arguments");
     }
     if HAL.is_none() && fargs.len() != 1 {
-        ctxt.error_spanned_by(&f.sig, "main function must have 2 arguments");
+        ctxt.error_spanned_by(&f.sig, "main function must have 1 argument");
     }
 
     ctxt.check()?;


### PR DESCRIPTION
There is a slight mistake in an error message from `[embassy::main]` macro. When there is no HAL specified, `main` should take only one argument.