### PR TITLE
Add PLL config support for F2

### DIFF
--- a/embassy-stm32/src/rcc/f2.rs
+++ b/embassy-stm32/src/rcc/f2.rs
@@ -424,10 +424,10 @@ pub(crate) unsafe fn init(config: Config) {
 
     let pll_src_freq = match config.pll_mux {
         PLLSrc::HSE => {
-            config
+            let hse_config = config
                 .hse
-                .expect("HSE must be configured to be used as PLL input")
-                .frequency
+                .unwrap_or_else(|| panic!("HSE must be configured to be used as PLL input"));
+            hse_config.frequency
         }
         PLLSrc::HSI => HSI,
     };
@@ -458,7 +458,7 @@ pub(crate) unsafe fn init(config: Config) {
         ClockSrc::HSE => {
             let hse_config = config
                 .hse
-                .expect("HSE must be configured to be used as system clock");
+                .unwrap_or_else(|| panic!("HSE must be configured to be used as PLL input"));
             (hse_config.frequency, Sw::HSE)
         }
         ClockSrc::PLL => {
@@ -475,7 +475,7 @@ pub(crate) unsafe fn init(config: Config) {
     // Reference: STM32F215xx/217xx datasheet Table 13. General operating conditions
     assert!(ahb_freq <= Hertz(120_000_000));
 
-    let flash_ws = config.voltage.wait_states(ahb_freq).expect("Invalid HCLK");
+    let flash_ws = unwrap!(config.voltage.wait_states(ahb_freq));
     FLASH.acr().modify(|w| w.set_latency(flash_ws));
 
     RCC.cfgr().modify(|w| {

--- a/embassy-stm32/src/rcc/mod.rs
+++ b/embassy-stm32/src/rcc/mod.rs
@@ -53,7 +53,7 @@ pub struct Clocks {
     #[cfg(any(rcc_h7, rcc_h7ab))]
     pub ahb4: Hertz,
 
-    #[cfg(any(rcc_f4, rcc_f410, rcc_f7))]
+    #[cfg(any(rcc_f2, rcc_f4, rcc_f410, rcc_f7))]
     pub pll48: Option<Hertz>,
 
     #[cfg(rcc_f1)]

--- a/examples/stm32f2/src/bin/pll.rs
+++ b/examples/stm32f2/src/bin/pll.rs
@@ -1,0 +1,56 @@
+#![no_std]
+#![no_main]
+#![feature(type_alias_impl_trait)]
+
+use core::convert::TryFrom;
+use defmt::*;
+use embassy::executor::Spawner;
+use embassy::time::{Duration, Timer};
+use embassy_stm32::{
+    rcc::{
+        APBPrescaler, ClockSrc, HSEConfig, HSESrc, PLL48Div, PLLConfig, PLLMainDiv, PLLMul,
+        PLLPreDiv, PLLSrc,
+    },
+    time::Hertz,
+    Config, Peripherals,
+};
+
+use defmt_rtt as _; // global logger
+use panic_probe as _;
+
+// Example config for maximum performance on a NUCLEO-F207ZG board
+fn config() -> Config {
+    let mut config = Config::default();
+    // By default, HSE on the board comes from a 8 MHz clock signal (not a crystal)
+    config.rcc.hse = Some(HSEConfig {
+        frequency: Hertz(8_000_000),
+        source: HSESrc::Bypass,
+    });
+    // PLL uses HSE as the clock source
+    config.rcc.pll_mux = PLLSrc::HSE;
+    config.rcc.pll = PLLConfig {
+        // 8 MHz clock source / 8 = 1 MHz PLL input
+        pre_div: PLLPreDiv::try_from(8).unwrap(),
+        // 1 MHz PLL input * 240 = 240 MHz PLL VCO
+        mul: PLLMul::try_from(240).unwrap(),
+        // 240 MHz PLL VCO / 2 = 120 MHz main PLL output
+        main_div: PLLMainDiv::Div2,
+        // 240 MHz PLL VCO / 5 = 48 MHz PLL48 output
+        pll48_div: PLL48Div::try_from(5).unwrap(),
+    };
+    // System clock comes from PLL (= the 120 MHz main PLL output)
+    config.rcc.mux = ClockSrc::PLL;
+    // 120 MHz / 4 = 30 MHz APB1 frequency
+    config.rcc.apb1_pre = APBPrescaler::Div4;
+    // 120 MHz / 2 = 60 MHz APB2 frequency
+    config.rcc.apb2_pre = APBPrescaler::Div2;
+    config
+}
+
+#[embassy::main(config = "config()")]
+async fn main(_spawner: Spawner, _p: Peripherals) {
+    loop {
+        Timer::after(Duration::from_millis(1000)).await;
+        info!("1s elapsed");
+    }
+}

--- a/examples/stm32f2/src/bin/pll.rs
+++ b/examples/stm32f2/src/bin/pll.rs
@@ -30,13 +30,13 @@ fn config() -> Config {
     config.rcc.pll_mux = PLLSrc::HSE;
     config.rcc.pll = PLLConfig {
         // 8 MHz clock source / 8 = 1 MHz PLL input
-        pre_div: PLLPreDiv::try_from(8).unwrap(),
+        pre_div: unwrap!(PLLPreDiv::try_from(8)),
         // 1 MHz PLL input * 240 = 240 MHz PLL VCO
-        mul: PLLMul::try_from(240).unwrap(),
+        mul: unwrap!(PLLMul::try_from(240)),
         // 240 MHz PLL VCO / 2 = 120 MHz main PLL output
         main_div: PLLMainDiv::Div2,
         // 240 MHz PLL VCO / 5 = 48 MHz PLL48 output
-        pll48_div: PLL48Div::try_from(5).unwrap(),
+        pll48_div: unwrap!(PLL48Div::try_from(5)),
     };
     // System clock comes from PLL (= the 120 MHz main PLL output)
     config.rcc.mux = ClockSrc::PLL;


### PR DESCRIPTION
- minor changes to make the F2 RCC API a bit more flexible
- low-level PLL config with assertions based on datasheet specs. It shouldn't be very difficult to later add a "reverse API" where you pass the clocks you want to a function and it generates a `PLLConfig` struct for you
- PLL API tested on my custom board with 12 MHz HSE as source for PLL to generate max clocks for SYSCLK/AHB/APB/APB1/PLL48
- the example *should* work but is untested since I don't have the Nucleo board :disappointed: 