### PR TITLE
Use explicit return statement TaskStorage::spawn

### DIFF
--- a/embassy/src/executor/raw/mod.rs
+++ b/embassy/src/executor/raw/mod.rs
@@ -165,7 +165,7 @@ impl<F: Future + 'static> TaskStorage<F> {
     /// on a different executor.
     pub fn spawn(&'static self, future: impl FnOnce() -> F) -> SpawnToken<impl Sized> {
         if self.spawn_mark_used() {
-            return unsafe { SpawnToken::<F>::new(self.spawn_initialize(future)) }
+            return unsafe { SpawnToken::<F>::new(self.spawn_initialize(future)) };
         }
 
         SpawnToken::<F>::new_failed()

--- a/embassy/src/executor/raw/mod.rs
+++ b/embassy/src/executor/raw/mod.rs
@@ -165,10 +165,10 @@ impl<F: Future + 'static> TaskStorage<F> {
     /// on a different executor.
     pub fn spawn(&'static self, future: impl FnOnce() -> F) -> SpawnToken<impl Sized> {
         if self.spawn_mark_used() {
-            unsafe { SpawnToken::<F>::new(self.spawn_initialize(future)) }
-        } else {
-            SpawnToken::<F>::new_failed()
+            return unsafe { SpawnToken::<F>::new(self.spawn_initialize(future)) }
         }
+
+        SpawnToken::<F>::new_failed()
     }
 
     fn spawn_mark_used(&'static self) -> bool {


### PR DESCRIPTION
This commit removes the else branch in `TaskStorage::spawn`, and returns
explicitly from the if statement's branch, similar to what
[TaskPool::spawn](https://github.com/embassy-rs/embassy/blob/85c0525e01c52bbb85c7b93600a60837ee7b87dc/embassy/src/executor/raw/mod.rs#L235-L243) does.