### PR TITLE
Allow maximal clock for F7 HCLK

### DIFF
--- a/embassy-stm32/src/rcc/f7.rs
+++ b/embassy-stm32/src/rcc/f7.rs
@@ -170,7 +170,7 @@ pub(crate) unsafe fn init(config: Config) {
     // Calculate real AHB clock
     let hclk = sysclk / hpre_div;
 
-    assert!(hclk < max::HCLK_MAX);
+    assert!(hclk <= max::HCLK_MAX);
 
     let pclk1 = config
         .pclk1


### PR DESCRIPTION
Fixes a typo in clock calculations, see: https://github.com/stm32-rs/stm32f7xx-hal/blob/aaf2034cab697577e6f4fc6079fc7e4691d7ad9d/src/rcc.rs#L347