### PR TITLE
Implement Output::is_set_low for embassy-rp

### DIFF
--- a/embassy-rp/src/gpio.rs
+++ b/embassy-rp/src/gpio.rs
@@ -127,8 +127,8 @@ impl<'d, T: Pin> Output<'d, T> {
 
     /// Is the output pin set as low?
     pub fn is_set_low(&self) -> bool {
-        // todo
-        true
+        // Reading from SIO: GPIO_OUT gives the last value written.
+        unsafe { self.pin.sio_out().value().read() == 0 }
     }
 }
 

--- a/embassy-rp/src/gpio.rs
+++ b/embassy-rp/src/gpio.rs
@@ -128,7 +128,8 @@ impl<'d, T: Pin> Output<'d, T> {
     /// Is the output pin set as low?
     pub fn is_set_low(&self) -> bool {
         // Reading from SIO: GPIO_OUT gives the last value written.
-        unsafe { self.pin.sio_out().value().read() == 0 }
+        let val = 1 << self.pin.pin();
+        unsafe { (self.pin.sio_out().value().read() & val) == 0 }
     }
 }
 


### PR DESCRIPTION
This commit implements a suggestion for the method `is_set_low` which is
currently a `todo`, by reading last value written to `GPIO_OUT`.