### PR TITLE
Make usb_serial examples work on windows

### DIFF
--- a/examples/nrf/src/bin/usb_serial.rs
+++ b/examples/nrf/src/bin/usb_serial.rs
@@ -43,6 +43,13 @@ async fn main(_spawner: Spawner, p: Peripherals) {
     config.max_power = 100;
     config.max_packet_size_0 = 64;
 
+    // Required for windows compatiblity.
+    // https://developer.nordicsemi.com/nRF_Connect_SDK/doc/1.9.1/kconfig/CONFIG_CDC_ACM_IAD.html#help
+    config.device_class = 0xEF;
+    config.device_sub_class = 0x02;
+    config.device_protocol = 0x01;
+    config.composite_with_iads = true;
+
     // Create embassy-usb DeviceBuilder using the driver and config.
     // It needs some buffers for building the descriptors.
     let mut device_descriptor = [0; 256];

--- a/examples/nrf/src/bin/usb_serial_multitask.rs
+++ b/examples/nrf/src/bin/usb_serial_multitask.rs
@@ -60,6 +60,13 @@ async fn main(spawner: Spawner, p: Peripherals) {
     config.max_power = 100;
     config.max_packet_size_0 = 64;
 
+    // Required for windows compatiblity.
+    // https://developer.nordicsemi.com/nRF_Connect_SDK/doc/1.9.1/kconfig/CONFIG_CDC_ACM_IAD.html#help
+    config.device_class = 0xEF;
+    config.device_sub_class = 0x02;
+    config.device_protocol = 0x01;
+    config.composite_with_iads = true;
+
     struct Resources {
         device_descriptor: [u8; 256],
         config_descriptor: [u8; 256],


### PR DESCRIPTION
Windows shows `error 10` when using CDC ACM on non composite devices.
Workaround is to use IADS:
https://developer.nordicsemi.com/nRF_Connect_SDK/doc/1.9.1/kconfig/CONFIG_CDC_ACM_IAD.html#help