### PR TITLE
nrf/usb: fix control out transfers getting corrupted due to ep0rcvout sticking from earlier.

### DIFF
--- a/embassy-usb/src/driver.rs
+++ b/embassy-usb/src/driver.rs
@@ -1,7 +1,5 @@
 use core::future::Future;
 
-use crate::control::Request;
-
 use super::types::*;
 
 /// Driver for a specific USB peripheral. Implement this to add support for a new hardware
@@ -146,7 +144,7 @@ pub trait EndpointOut: Endpoint {
 }
 
 pub trait ControlPipe {
-    type SetupFuture<'a>: Future<Output = Request> + 'a
+    type SetupFuture<'a>: Future<Output = [u8; 8]> + 'a
     where
         Self: 'a;
     type DataOutFuture<'a>: Future<Output = Result<usize, EndpointError>> + 'a

--- a/embassy-usb/src/lib.rs
+++ b/embassy-usb/src/lib.rs
@@ -246,7 +246,9 @@ impl<'d, D: Driver<'d>> UsbDevice<'d, D> {
         }
     }
 
-    async fn handle_control(&mut self, req: Request) {
+    async fn handle_control(&mut self, req: [u8; 8]) {
+        let req = Request::parse(&req);
+
         trace!("control request: {:02x}", req);
 
         match req.direction {


### PR DESCRIPTION
bors r+