### PR TITLE
Add new lines between SIO methods

### DIFF
--- a/embassy-rp/src/gpio.rs
+++ b/embassy-rp/src/gpio.rs
@@ -190,12 +190,15 @@ pub(crate) mod sealed {
             };
             block.gpio(self.pin() as _)
         }
+
         fn sio_out(&self) -> pac::sio::Gpio {
             SIO.gpio_out(self.bank() as _)
         }
+
         fn sio_oe(&self) -> pac::sio::Gpio {
             SIO.gpio_oe(self.bank() as _)
         }
+
         fn sio_in(&self) -> Reg<u32, RW> {
             SIO.gpio_in(self.bank() as _)
         }


### PR DESCRIPTION
The commit adds new lines between the SIO functions which at least for
me improves readability and is consistent with the other methods in the
trait.