### PR TITLE
Reimplement BufRead for BufferedUart

### DIFF
--- a/embassy-nrf/src/buffered_uarte.rs
+++ b/embassy-nrf/src/buffered_uarte.rs
@@ -268,9 +268,9 @@ impl<'d, U: UarteInstance, T: TimerInstance> embedded_io::asynch::BufRead
 
     fn consume(&mut self, amt: usize) {
         let signal = self.inner.with(|state| {
-            let full = state.rx.is_full();
+            let empty = state.rx.is_empty();
             state.rx.pop(amt);
-            full
+            !empty
         });
         if signal {
             self.inner.pend();

--- a/embassy-nrf/src/buffered_uarte.rs
+++ b/embassy-nrf/src/buffered_uarte.rs
@@ -268,9 +268,9 @@ impl<'d, U: UarteInstance, T: TimerInstance> embedded_io::asynch::BufRead
 
     fn consume(&mut self, amt: usize) {
         let signal = self.inner.with(|state| {
-            let empty = state.rx.is_empty();
+            let full = state.rx.is_full();
             state.rx.pop(amt);
-            !empty
+            full
         });
         if signal {
             self.inner.pend();

--- a/examples/stm32f4/Cargo.toml
+++ b/examples/stm32f4/Cargo.toml
@@ -9,6 +9,7 @@ resolver = "2"
 [dependencies]
 embassy = { version = "0.1.0", path = "../../embassy", features = ["defmt", "defmt-timestamp-uptime", "unstable-traits"] }
 embassy-stm32 = { version = "0.1.0", path = "../../embassy-stm32", features = ["nightly", "unstable-traits", "defmt", "stm32f429zi", "unstable-pac", "memory-x", "time-driver-any", "exti"]  }
+
 defmt = "0.3"
 defmt-rtt = "0.3"
 

--- a/examples/stm32f4/Cargo.toml
+++ b/examples/stm32f4/Cargo.toml
@@ -9,13 +9,13 @@ resolver = "2"
 [dependencies]
 embassy = { version = "0.1.0", path = "../../embassy", features = ["defmt", "defmt-timestamp-uptime", "unstable-traits"] }
 embassy-stm32 = { version = "0.1.0", path = "../../embassy-stm32", features = ["nightly", "unstable-traits", "defmt", "stm32f429zi", "unstable-pac", "memory-x", "time-driver-any", "exti"]  }
-
 defmt = "0.3"
 defmt-rtt = "0.3"
 
 cortex-m = "0.7.3"
 cortex-m-rt = "0.7.0"
 embedded-hal = "0.2.6"
+embedded-io = "0.3.0"
 panic-probe = { version = "0.3", features = ["print-defmt"] }
 futures = { version = "0.3.17", default-features = false, features = ["async-await"] }
 heapless = { version = "0.7.5", default-features = false }

--- a/examples/stm32f4/src/bin/usart_buffered.rs
+++ b/examples/stm32f4/src/bin/usart_buffered.rs
@@ -26,13 +26,11 @@ async fn main(_spawner: Spawner, p: Peripherals) {
         unsafe { BufferedUart::new(&mut state, usart, irq, &mut tx_buf, &mut rx_buf) };
 
     loop {
-        let n = {
-            let buf = buf_usart.fill_buf().await.unwrap();
-            info!("Received: {}", buf);
-            buf.len()
-        };
+        let buf = buf_usart.fill_buf().await.unwrap();
+        info!("Received: {}", buf);
 
         // Read bytes have to be explicitly consumed, otherwise fill_buf() will return them again
+        let n = buf.len();
         buf_usart.consume(n);
     }
 }

--- a/examples/stm32f4/src/bin/usart_buffered.rs
+++ b/examples/stm32f4/src/bin/usart_buffered.rs
@@ -1,0 +1,38 @@
+#![no_std]
+#![no_main]
+#![feature(type_alias_impl_trait)]
+
+use defmt::*;
+use defmt_rtt as _; // global logger
+use embassy::executor::Spawner;
+use embassy_stm32::dma::NoDma;
+use embassy_stm32::usart::{BufferedUart, Config, State, Uart};
+use embassy_stm32::{interrupt, Peripherals};
+use embedded_io::asynch::BufRead;
+use panic_probe as _;
+
+#[embassy::main]
+async fn main(_spawner: Spawner, p: Peripherals) {
+    info!("Hello World!");
+
+    let config = Config::default();
+    let usart = Uart::new(p.USART3, p.PD9, p.PD8, NoDma, NoDma, config);
+
+    let mut state = State::new();
+    let irq = interrupt::take!(USART3);
+    let mut tx_buf = [0u8; 32];
+    let mut rx_buf = [0u8; 32];
+    let mut buf_usart =
+        unsafe { BufferedUart::new(&mut state, usart, irq, &mut tx_buf, &mut rx_buf) };
+
+    loop {
+        let n = {
+            let buf = buf_usart.fill_buf().await.unwrap();
+            info!("Received: {}", buf);
+            buf.len()
+        };
+
+        // Read bytes have to be explicitly consumed, otherwise fill_buf() will return them again
+        buf_usart.consume(n);
+    }
+}


### PR DESCRIPTION
The `AsyncBufRead` implementation for `BufferedUart` was removed in https://github.com/embassy-rs/embassy/pull/752, this PR reimplements it from `embedded-io`. This allows reading `BufferedUart` without copying slices.