### PR TITLE
Embassy net improvements

### DIFF
--- a/embassy-net/Cargo.toml
+++ b/embassy-net/Cargo.toml
@@ -22,6 +22,7 @@ defmt = ["dep:defmt", "smoltcp/defmt"]
 tcp = ["smoltcp/socket-tcp"]
 dns = ["smoltcp/socket-dns"]
 dhcpv4 = ["medium-ethernet", "smoltcp/socket-dhcpv4"]
+proto-ipv6 = ["smoltcp/proto-ipv6"]
 medium-ethernet = ["smoltcp/medium-ethernet"]
 medium-ip = ["smoltcp/medium-ip"]
 

--- a/embassy-net/src/lib.rs
+++ b/embassy-net/src/lib.rs
@@ -23,3 +23,6 @@ pub use smoltcp::time::Instant as SmolInstant;
 #[cfg(feature = "medium-ethernet")]
 pub use smoltcp::wire::{EthernetAddress, HardwareAddress};
 pub use smoltcp::wire::{IpAddress, IpCidr, Ipv4Address, Ipv4Cidr};
+
+#[cfg(feature = "proto-ipv6")]
+pub use smoltcp::wire::{Ipv6Address, Ipv6Cidr};

--- a/embassy-net/src/tcp.rs
+++ b/embassy-net/src/tcp.rs
@@ -259,6 +259,12 @@ impl<'d> TcpIo<'d> {
     }
 }
 
+impl embedded_io::Error for ConnectError {
+    fn kind(&self) -> embedded_io::ErrorKind {
+        embedded_io::ErrorKind::Other
+    }
+}
+
 impl embedded_io::Error for Error {
     fn kind(&self) -> embedded_io::ErrorKind {
         embedded_io::ErrorKind::Other


### PR DESCRIPTION
I found these useful while implementing the TcpClient traits for embedded-nal-async:

https://github.com/drogue-iot/drogue-device/blob/shared-tcp-stack/device/src/drivers/tcp/smoltcp.rs

Once e-n-a PR is merged, I might add the above client to embassy-net if you think it makes sense.