### PR TITLE
common/PeripheralMutex: remove unsafe API.

### DIFF
--- a/embassy-nrf/src/buffered_uarte.rs
+++ b/embassy-nrf/src/buffered_uarte.rs
@@ -164,22 +164,20 @@ impl<'d, U: UarteInstance, T: TimerInstance> BufferedUarte<'d, U, T> {
         ppi_ch2.enable();
 
         Self {
-            inner: unsafe {
-                PeripheralMutex::new_unchecked(irq, &mut state.0, move || StateInner {
-                    phantom: PhantomData,
-                    timer,
-                    _ppi_ch1: ppi_ch1,
-                    _ppi_ch2: ppi_ch2,
+            inner: PeripheralMutex::new(irq, &mut state.0, move || StateInner {
+                phantom: PhantomData,
+                timer,
+                _ppi_ch1: ppi_ch1,
+                _ppi_ch2: ppi_ch2,
 
-                    rx: RingBuffer::new(rx_buffer),
-                    rx_state: RxState::Idle,
-                    rx_waker: WakerRegistration::new(),
+                rx: RingBuffer::new(rx_buffer),
+                rx_state: RxState::Idle,
+                rx_waker: WakerRegistration::new(),
 
-                    tx: RingBuffer::new(tx_buffer),
-                    tx_state: TxState::Idle,
-                    tx_waker: WakerRegistration::new(),
-                })
-            },
+                tx: RingBuffer::new(tx_buffer),
+                tx_state: TxState::Idle,
+                tx_waker: WakerRegistration::new(),
+            }),
         }
     }
 

--- a/embassy-stm32/src/eth/v1/mod.rs
+++ b/embassy-stm32/src/eth/v1/mod.rs
@@ -146,7 +146,7 @@ impl<'d, T: Instance, P: PHY, const TX: usize, const RX: usize> Ethernet<'d, T, 
         config_pins!(ref_clk, mdio, mdc, crs, rx_d0, rx_d1, tx_d0, tx_d1, tx_en);
 
         // NOTE(unsafe) We are ourselves not leak-safe.
-        let state = PeripheralMutex::new_unchecked(interrupt, &mut state.0, || Inner::new(peri));
+        let state = PeripheralMutex::new(interrupt, &mut state.0, || Inner::new(peri));
 
         // NOTE(unsafe) We have exclusive access to the registers
         let dma = ETH.ethernet_dma();

--- a/embassy-stm32/src/eth/v2/mod.rs
+++ b/embassy-stm32/src/eth/v2/mod.rs
@@ -83,7 +83,7 @@ impl<'d, T: Instance, P: PHY, const TX: usize, const RX: usize> Ethernet<'d, T, 
         config_pins!(ref_clk, mdio, mdc, crs, rx_d0, rx_d1, tx_d0, tx_d1, tx_en);
 
         // NOTE(unsafe) We are ourselves not leak-safe.
-        let state = PeripheralMutex::new_unchecked(interrupt, &mut state.0, || Inner::new(peri));
+        let state = PeripheralMutex::new(interrupt, &mut state.0, || Inner::new(peri));
 
         // NOTE(unsafe) We have exclusive access to the registers
         let dma = ETH.ethernet_dma();

--- a/examples/stm32f4/src/bin/usart_buffered.rs
+++ b/examples/stm32f4/src/bin/usart_buffered.rs
@@ -22,8 +22,7 @@ async fn main(_spawner: Spawner, p: Peripherals) {
     let irq = interrupt::take!(USART3);
     let mut tx_buf = [0u8; 32];
     let mut rx_buf = [0u8; 32];
-    let mut buf_usart =
-        unsafe { BufferedUart::new(&mut state, usart, irq, &mut tx_buf, &mut rx_buf) };
+    let mut buf_usart = BufferedUart::new(&mut state, usart, irq, &mut tx_buf, &mut rx_buf);
 
     loop {
         let buf = buf_usart.fill_buf().await.unwrap();


### PR DESCRIPTION
Following the project's decision that  "leak unsafe" APIs are not marked as "unsafe",
update PeripheralMutex to accept non-'static state without unsafe.

Fixes #801 

bors r+