### PR TITLE
Rename channel to mpmc

### DIFF
--- a/embassy/src/channel/mod.rs
+++ b/embassy/src/channel/mod.rs
@@ -1,7 +1,5 @@
 //! Async channels
 
-pub mod channel;
-pub use channel::*;
+pub mod mpmc;
 
 pub mod signal;
-pub use signal::*;

--- a/embassy/src/channel/mpmc.rs
+++ b/embassy/src/channel/mpmc.rs
@@ -388,7 +388,7 @@ where
     /// Establish a new bounded channel. For example, to create one with a NoopMutex:
     ///
     /// ```
-    /// use embassy::channel::channel::Channel;
+    /// use embassy::channel::mpmc::Channel;
     /// use embassy::blocking_mutex::raw::NoopRawMutex;
     ///
     /// // Declare a bounded channel of 3 u32s.
@@ -404,7 +404,7 @@ where
     /// Establish a new bounded channel. For example, to create one with a NoopMutex:
     ///
     /// ```
-    /// use embassy::channel::channel::Channel;
+    /// use embassy::channel::mpmc::Channel;
     /// use embassy::blocking_mutex::raw::NoopRawMutex;
     ///
     /// // Declare a bounded channel of 3 u32s.

--- a/embassy/src/channel/signal.rs
+++ b/embassy/src/channel/signal.rs
@@ -5,7 +5,7 @@ use core::task::{Context, Poll, Waker};
 
 /// Synchronization primitive. Allows creating awaitable signals that may be passed between tasks.
 /// For a simple use-case where the receiver is only ever interested in the latest value of
-/// something, Signals work well. For more advanced use cases, you might want to use [`Channel`](crate::channel::channel::Channel) instead..
+/// something, Signals work well. For more advanced use cases, you might want to use [`Channel`](crate::channel::mpmc::Channel) instead..
 ///
 /// Signals are generally declared as being a static const and then borrowed as required.
 ///

--- a/examples/nrf/src/bin/channel.rs
+++ b/examples/nrf/src/bin/channel.rs
@@ -4,7 +4,7 @@
 
 use defmt::unwrap;
 use embassy::blocking_mutex::raw::ThreadModeRawMutex;
-use embassy::channel::channel::Channel;
+use embassy::channel::mpmc::Channel;
 use embassy::executor::Spawner;
 use embassy::time::{Duration, Timer};
 use embassy_nrf::gpio::{Level, Output, OutputDrive};

--- a/examples/nrf/src/bin/channel_sender_receiver.rs
+++ b/examples/nrf/src/bin/channel_sender_receiver.rs
@@ -4,7 +4,7 @@
 
 use defmt::unwrap;
 use embassy::blocking_mutex::raw::NoopRawMutex;
-use embassy::channel::channel::{Channel, Receiver, Sender};
+use embassy::channel::mpmc::{Channel, Receiver, Sender};
 use embassy::executor::Spawner;
 use embassy::time::{Duration, Timer};
 use embassy::util::Forever;

--- a/examples/nrf/src/bin/uart_split.rs
+++ b/examples/nrf/src/bin/uart_split.rs
@@ -4,7 +4,7 @@
 
 use defmt::*;
 use embassy::blocking_mutex::raw::ThreadModeRawMutex;
-use embassy::channel::channel::Channel;
+use embassy::channel::mpmc::Channel;
 use embassy::executor::Spawner;
 use embassy_nrf::peripherals::UARTE0;
 use embassy_nrf::uarte::UarteRx;

--- a/examples/nrf/src/bin/usb_ethernet.rs
+++ b/examples/nrf/src/bin/usb_ethernet.rs
@@ -8,7 +8,7 @@ use core::sync::atomic::{AtomicBool, Ordering};
 use core::task::Waker;
 use defmt::*;
 use embassy::blocking_mutex::raw::ThreadModeRawMutex;
-use embassy::channel::Channel;
+use embassy::channel::mpmc::Channel;
 use embassy::executor::Spawner;
 use embassy::util::Forever;
 use embassy_net::tcp::TcpSocket;

--- a/examples/nrf/src/bin/usb_hid_keyboard.rs
+++ b/examples/nrf/src/bin/usb_hid_keyboard.rs
@@ -6,7 +6,7 @@
 use core::mem;
 use core::sync::atomic::{AtomicBool, Ordering};
 use defmt::*;
-use embassy::channel::Signal;
+use embassy::channel::signal::Signal;
 use embassy::executor::Spawner;
 use embassy::interrupt::InterruptExt;
 use embassy::time::Duration;

--- a/examples/stm32f3/src/bin/button_events.rs
+++ b/examples/stm32f3/src/bin/button_events.rs
@@ -12,7 +12,7 @@
 
 use defmt::*;
 use embassy::blocking_mutex::raw::ThreadModeRawMutex;
-use embassy::channel::channel::Channel;
+use embassy::channel::mpmc::Channel;
 use embassy::executor::Spawner;
 use embassy::time::{with_timeout, Duration, Timer};
 use embassy_stm32::exti::ExtiInput;

--- a/examples/stm32h7/src/bin/signal.rs
+++ b/examples/stm32h7/src/bin/signal.rs
@@ -8,7 +8,7 @@ use defmt_rtt as _;
 
 use panic_probe as _;
 
-use embassy::channel::Signal;
+use embassy::channel::signal::Signal;
 use embassy::executor::Spawner;
 use embassy::time::{Duration, Timer};
 

--- a/examples/stm32h7/src/bin/usart_split.rs
+++ b/examples/stm32h7/src/bin/usart_split.rs
@@ -5,7 +5,7 @@
 use defmt::*;
 use defmt_rtt as _; // global logger
 use embassy::blocking_mutex::raw::ThreadModeRawMutex;
-use embassy::channel::channel::Channel;
+use embassy::channel::mpmc::Channel;
 use embassy::executor::Spawner;
 use embassy_stm32::dma::NoDma;
 use embassy_stm32::{

--- a/examples/stm32l5/src/bin/usb_ethernet.rs
+++ b/examples/stm32l5/src/bin/usb_ethernet.rs
@@ -8,7 +8,7 @@ use core::task::Waker;
 use defmt::*;
 use defmt_rtt as _; // global logger
 use embassy::blocking_mutex::raw::ThreadModeRawMutex;
-use embassy::channel::Channel;
+use embassy::channel::mpmc::Channel;
 use embassy::executor::Spawner;
 use embassy::util::Forever;
 use embassy_net::tcp::TcpSocket;


### PR DESCRIPTION
I've renamed the channel module for the MPMC as `mpmc`. There was a previous debate about this, but I feel that the strategy here avoids importing `channel::channel`. The change leaves `signal::Signal`, but I think that's ok. It is all a bit subjective of course. The bottom line for me is that I really like the term `mpmc` - it means something to me and aligns with broader naming e.g. in Tokio.