### PR TITLE
Remove the authors field from Cargo.tomls

### DIFF
--- a/embassy-boot/boot/Cargo.toml
+++ b/embassy-boot/boot/Cargo.toml
@@ -1,7 +1,4 @@
 [package]
-authors = [
-    "Ulf Lilleengen <lulf@redhat.com>",
-]
 edition = "2021"
 name = "embassy-boot"
 version = "0.1.0"

--- a/embassy-boot/nrf/Cargo.toml
+++ b/embassy-boot/nrf/Cargo.toml
@@ -1,7 +1,4 @@
 [package]
-authors = [
-    "Ulf Lilleengen <lulf@redhat.com>",
-]
 edition = "2021"
 name = "embassy-boot-nrf"
 version = "0.1.0"

--- a/embassy-boot/stm32/Cargo.toml
+++ b/embassy-boot/stm32/Cargo.toml
@@ -1,7 +1,4 @@
 [package]
-authors = [
-    "Ulf Lilleengen <lulf@redhat.com>",
-]
 edition = "2021"
 name = "embassy-boot-stm32"
 version = "0.1.0"

--- a/embassy-cortex-m/Cargo.toml
+++ b/embassy-cortex-m/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "embassy-cortex-m"
 version = "0.1.0"
-authors = ["Dario Nieuwenhuis <dirbaio@dirbaio.net>"]
 edition = "2021"
 
 [package.metadata.embassy_docs]

--- a/embassy-embedded-hal/Cargo.toml
+++ b/embassy-embedded-hal/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "embassy-embedded-hal"
 version = "0.1.0"
-authors = ["Dario Nieuwenhuis <dirbaio@dirbaio.net>"]
 edition = "2021"
 
 [features]

--- a/embassy-hal-common/Cargo.toml
+++ b/embassy-hal-common/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "embassy-hal-common"
 version = "0.1.0"
-authors = ["Dario Nieuwenhuis <dirbaio@dirbaio.net>"]
 edition = "2021"
 
 [features]

--- a/embassy-lora/Cargo.toml
+++ b/embassy-lora/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "embassy-lora"
 version = "0.1.0"
-authors = ["Ulf Lilleengen <lulf@redhat.com>"]
 edition = "2021"
 
 [package.metadata.embassy_docs]

--- a/embassy-macros/Cargo.toml
+++ b/embassy-macros/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "embassy-macros"
 version = "0.1.0"
-authors = ["Dario Nieuwenhuis <dirbaio@dirbaio.net>"]
 edition = "2021"
 
 [dependencies]

--- a/embassy-net/Cargo.toml
+++ b/embassy-net/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "embassy-net"
 version = "0.1.0"
-authors = ["Dario Nieuwenhuis <dirbaio@dirbaio.net>"]
 edition = "2021"
 
 

--- a/embassy-nrf/Cargo.toml
+++ b/embassy-nrf/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "embassy-nrf"
 version = "0.1.0"
-authors = ["Dario Nieuwenhuis <dirbaio@dirbaio.net>"]
 edition = "2021"
 
 [package.metadata.embassy_docs]

--- a/embassy-rp/Cargo.toml
+++ b/embassy-rp/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "embassy-rp"
 version = "0.1.0"
-authors = ["Dario Nieuwenhuis <dirbaio@dirbaio.net>"]
 edition = "2021"
 
 [package.metadata.embassy_docs]

--- a/embassy-stm32/Cargo.toml
+++ b/embassy-stm32/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "embassy-stm32"
 version = "0.1.0"
-authors = ["Dario Nieuwenhuis <dirbaio@dirbaio.net>"]
 edition = "2021"
 
 [package.metadata.embassy_docs]

--- a/embassy/Cargo.toml
+++ b/embassy/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "embassy"
 version = "0.1.0"
-authors = ["Dario Nieuwenhuis <dirbaio@dirbaio.net>"]
 edition = "2021"
 
 [package.metadata.embassy_docs]

--- a/examples/boot/nrf/Cargo.toml
+++ b/examples/boot/nrf/Cargo.toml
@@ -1,5 +1,4 @@
 [package]
-authors = ["Ulf Lilleengen <lulf@redhat.com>"]
 edition = "2021"
 name = "embassy-boot-nrf-examples"
 version = "0.1.0"

--- a/examples/boot/stm32f3/Cargo.toml
+++ b/examples/boot/stm32f3/Cargo.toml
@@ -1,5 +1,4 @@
 [package]
-authors = ["Ulf Lilleengen <lulf@redhat.com>"]
 edition = "2021"
 name = "embassy-boot-stm32f3-examples"
 version = "0.1.0"

--- a/examples/boot/stm32f7/Cargo.toml
+++ b/examples/boot/stm32f7/Cargo.toml
@@ -1,5 +1,4 @@
 [package]
-authors = ["Ulf Lilleengen <lulf@redhat.com>"]
 edition = "2021"
 name = "embassy-boot-stm32f7-examples"
 version = "0.1.0"

--- a/examples/boot/stm32h7/Cargo.toml
+++ b/examples/boot/stm32h7/Cargo.toml
@@ -1,5 +1,4 @@
 [package]
-authors = ["Ulf Lilleengen <lulf@redhat.com>"]
 edition = "2021"
 name = "embassy-boot-stm32f7-examples"
 version = "0.1.0"

--- a/examples/boot/stm32l0/Cargo.toml
+++ b/examples/boot/stm32l0/Cargo.toml
@@ -1,5 +1,4 @@
 [package]
-authors = ["Ulf Lilleengen <lulf@redhat.com>"]
 edition = "2021"
 name = "embassy-boot-stm32l0-examples"
 version = "0.1.0"

--- a/examples/boot/stm32l1/Cargo.toml
+++ b/examples/boot/stm32l1/Cargo.toml
@@ -1,5 +1,4 @@
 [package]
-authors = ["Ulf Lilleengen <lulf@redhat.com>"]
 edition = "2021"
 name = "embassy-boot-stm32l1-examples"
 version = "0.1.0"

--- a/examples/boot/stm32l4/Cargo.toml
+++ b/examples/boot/stm32l4/Cargo.toml
@@ -1,5 +1,4 @@
 [package]
-authors = ["Ulf Lilleengen <lulf@redhat.com>"]
 edition = "2021"
 name = "embassy-boot-stm32l4-examples"
 version = "0.1.0"

--- a/examples/boot/stm32wl/Cargo.toml
+++ b/examples/boot/stm32wl/Cargo.toml
@@ -1,5 +1,4 @@
 [package]
-authors = ["Ulf Lilleengen <lulf@redhat.com>"]
 edition = "2021"
 name = "embassy-boot-stm32wl-examples"
 version = "0.1.0"

--- a/examples/nrf/Cargo.toml
+++ b/examples/nrf/Cargo.toml
@@ -1,5 +1,4 @@
 [package]
-authors = ["Dario Nieuwenhuis <dirbaio@dirbaio.net>"]
 edition = "2021"
 name = "embassy-nrf-examples"
 version = "0.1.0"

--- a/examples/rp/Cargo.toml
+++ b/examples/rp/Cargo.toml
@@ -1,5 +1,4 @@
 [package]
-authors = ["Dario Nieuwenhuis <dirbaio@dirbaio.net>"]
 edition = "2021"
 name = "embassy-rp-examples"
 version = "0.1.0"

--- a/examples/std/Cargo.toml
+++ b/examples/std/Cargo.toml
@@ -1,5 +1,4 @@
 [package]
-authors = ["Dario Nieuwenhuis <dirbaio@dirbaio.net>"]
 edition = "2021"
 name = "embassy-std-examples"
 version = "0.1.0"

--- a/examples/stm32f0/Cargo.toml
+++ b/examples/stm32f0/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "embassy-stm32f0-examples"
 version = "0.1.0"
-authors = ["Thales Fragoso <thales.fragosoz@gmail.com>"]
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/examples/stm32f1/Cargo.toml
+++ b/examples/stm32f1/Cargo.toml
@@ -1,5 +1,4 @@
 [package]
-authors = ["Dario Nieuwenhuis <dirbaio@dirbaio.net>"]
 edition = "2021"
 name = "embassy-stm32f1-examples"
 version = "0.1.0"

--- a/examples/stm32f2/Cargo.toml
+++ b/examples/stm32f2/Cargo.toml
@@ -1,5 +1,4 @@
 [package]
-authors = ["Dario Nieuwenhuis <dirbaio@dirbaio.net>"]
 edition = "2021"
 name = "embassy-stm32f2-examples"
 version = "0.1.0"

--- a/examples/stm32f3/Cargo.toml
+++ b/examples/stm32f3/Cargo.toml
@@ -1,5 +1,4 @@
 [package]
-authors = ["Dario Nieuwenhuis <dirbaio@dirbaio.net>"]
 edition = "2021"
 name = "embassy-stm32f3-examples"
 version = "0.1.0"

--- a/examples/stm32f4/Cargo.toml
+++ b/examples/stm32f4/Cargo.toml
@@ -1,5 +1,4 @@
 [package]
-authors = ["Dario Nieuwenhuis <dirbaio@dirbaio.net>"]
 edition = "2021"
 name = "embassy-stm32f4-examples"
 version = "0.1.0"

--- a/examples/stm32f7/Cargo.toml
+++ b/examples/stm32f7/Cargo.toml
@@ -1,5 +1,4 @@
 [package]
-authors = ["Dario Nieuwenhuis <dirbaio@dirbaio.net>"]
 edition = "2021"
 name = "embassy-stm32f7-examples"
 version = "0.1.0"

--- a/examples/stm32g0/Cargo.toml
+++ b/examples/stm32g0/Cargo.toml
@@ -1,5 +1,4 @@
 [package]
-authors = ["Dario Nieuwenhuis <dirbaio@dirbaio.net>", "Ben Gamari <ben@smart-cactus.org>"]
 edition = "2021"
 name = "embassy-stm32g0-examples"
 version = "0.1.0"

--- a/examples/stm32g4/Cargo.toml
+++ b/examples/stm32g4/Cargo.toml
@@ -1,5 +1,4 @@
 [package]
-authors = ["Dario Nieuwenhuis <dirbaio@dirbaio.net>", "Ben Gamari <ben@smart-cactus.org>"]
 edition = "2021"
 name = "embassy-stm32g4-examples"
 version = "0.1.0"

--- a/examples/stm32h7/Cargo.toml
+++ b/examples/stm32h7/Cargo.toml
@@ -1,5 +1,4 @@
 [package]
-authors = ["Dario Nieuwenhuis <dirbaio@dirbaio.net>"]
 edition = "2021"
 name = "embassy-stm32h7-examples"
 version = "0.1.0"

--- a/examples/stm32l0/Cargo.toml
+++ b/examples/stm32l0/Cargo.toml
@@ -1,5 +1,4 @@
 [package]
-authors = ["Dario Nieuwenhuis <dirbaio@dirbaio.net>", "Ulf Lilleengen <ulf.lilleengen@gmail.com>"]
 edition = "2021"
 name = "embassy-stm32l0-examples"
 version = "0.1.0"

--- a/examples/stm32l1/Cargo.toml
+++ b/examples/stm32l1/Cargo.toml
@@ -1,5 +1,4 @@
 [package]
-authors = ["Dario Nieuwenhuis <dirbaio@dirbaio.net>", "Ulf Lilleengen <ulf.lilleengen@gmail.com>"]
 edition = "2021"
 name = "embassy-stm32l1-examples"
 version = "0.1.0"

--- a/examples/stm32l4/Cargo.toml
+++ b/examples/stm32l4/Cargo.toml
@@ -1,5 +1,4 @@
 [package]
-authors = ["Dario Nieuwenhuis <dirbaio@dirbaio.net>"]
 edition = "2021"
 name = "embassy-stm32l4-examples"
 version = "0.1.0"

--- a/examples/stm32l5/Cargo.toml
+++ b/examples/stm32l5/Cargo.toml
@@ -1,5 +1,4 @@
 [package]
-authors = ["Dario Nieuwenhuis <dirbaio@dirbaio.net>"]
 edition = "2021"
 name = "embassy-stm32l5-examples"
 version = "0.1.0"

--- a/examples/stm32u5/Cargo.toml
+++ b/examples/stm32u5/Cargo.toml
@@ -1,5 +1,4 @@
 [package]
-authors = ["Dario Nieuwenhuis <dirbaio@dirbaio.net>"]
 edition = "2021"
 name = "embassy-stm32u5-examples"
 version = "0.1.0"

--- a/examples/stm32wb/Cargo.toml
+++ b/examples/stm32wb/Cargo.toml
@@ -1,5 +1,4 @@
 [package]
-authors = ["Dario Nieuwenhuis <dirbaio@dirbaio.net>"]
 edition = "2021"
 name = "embassy-stm32wb-examples"
 version = "0.1.0"

--- a/examples/stm32wl/Cargo.toml
+++ b/examples/stm32wl/Cargo.toml
@@ -1,5 +1,4 @@
 [package]
-authors = ["Dario Nieuwenhuis <dirbaio@dirbaio.net>", "Ulf Lilleengen <ulf.lilleengen@gmail.com>"]
 edition = "2021"
 name = "embassy-stm32wl-examples"
 version = "0.1.0"

--- a/examples/wasm/Cargo.toml
+++ b/examples/wasm/Cargo.toml
@@ -1,5 +1,4 @@
 [package]
-authors = ["Ulf Lilleengen <lulf@redhat.com>"]
 edition = "2021"
 name = "embassy-wasm-example"
 version = "0.1.0"

--- a/stm32-gen-features/Cargo.toml
+++ b/stm32-gen-features/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "gen_features"
 version = "0.1.0"
-authors = ["Côme ALLART <come.allart@netc.fr>"]
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/tests/stm32/Cargo.toml
+++ b/tests/stm32/Cargo.toml
@@ -1,5 +1,4 @@
 [package]
-authors = ["Dario Nieuwenhuis <dirbaio@dirbaio.net>"]
 edition = "2021"
 name = "embassy-stm32-tests"
 version = "0.1.0"

--- a/xtask/Cargo.toml
+++ b/xtask/Cargo.toml
@@ -1,8 +1,4 @@
 [package]
-authors = [
-    "Ulf Lilleengen <lulf@redhat.com>",
-    "Bob McWhirter <bmcwhirt@redhat.com>"
-]
 edition = "2021"
 name = "xtask"
 version = "0.1.0"


### PR DESCRIPTION
It currently contains whoever was first to write some code for the crate,
even if many more people have contributed to it later.

The field is "sort of" deprecated, it was made optional recently:
https://rust-lang.github.io/rfcs/3052-optional-authors-field.html

Due the the reasons listed there I believe removing it is better than
setting it to generic fluff like "The Embassy contributors".