### PR TITLE
Fix PWM for advanced timers

### DIFF
--- a/embassy-stm32/src/pwm/simple_pwm.rs
+++ b/embassy-stm32/src/pwm/simple_pwm.rs
@@ -92,6 +92,8 @@ impl<'d, T: CaptureCompare16bitInstance> SimplePwm<'d, T> {
         this.inner.start();
 
         unsafe {
+            this.inner.enable_outputs(true);
+
             this.inner
                 .set_output_compare_mode(Channel::Ch1, OutputCompareMode::PwmMode1);
             this.inner

--- a/examples/stm32f4/src/bin/pwm.rs
+++ b/examples/stm32f4/src/bin/pwm.rs
@@ -7,18 +7,11 @@ use embassy::executor::Spawner;
 use embassy::time::{Duration, Timer};
 use embassy_stm32::pwm::simple_pwm::SimplePwm;
 use embassy_stm32::pwm::Channel;
-use embassy_stm32::time::{Hertz, U32Ext};
-use embassy_stm32::{Config, Peripherals};
+use embassy_stm32::time::U32Ext;
+use embassy_stm32::Peripherals;
 use {defmt_rtt as _, panic_probe as _};
 
-fn config() -> Config {
-    let mut config = Config::default();
-    config.rcc.hse = Some(Hertz(8_000_000));
-    config.rcc.sys_ck = Some(Hertz(84_000_000));
-    config
-}
-
-#[embassy::main(config = "config()")]
+#[embassy::main]
 async fn main(_spawner: Spawner, p: Peripherals) {
     info!("Hello World!");
 

--- a/examples/stm32f4/src/bin/pwm.rs
+++ b/examples/stm32f4/src/bin/pwm.rs
@@ -1,0 +1,42 @@
+#![no_std]
+#![no_main]
+#![feature(type_alias_impl_trait)]
+
+use defmt::*;
+use embassy::executor::Spawner;
+use embassy::time::{Duration, Timer};
+use embassy_stm32::pwm::simple_pwm::SimplePwm;
+use embassy_stm32::pwm::Channel;
+use embassy_stm32::time::{Hertz, U32Ext};
+use embassy_stm32::{Config, Peripherals};
+use {defmt_rtt as _, panic_probe as _};
+
+fn config() -> Config {
+    let mut config = Config::default();
+    config.rcc.hse = Some(Hertz(8_000_000));
+    config.rcc.sys_ck = Some(Hertz(84_000_000));
+    config
+}
+
+#[embassy::main(config = "config()")]
+async fn main(_spawner: Spawner, p: Peripherals) {
+    info!("Hello World!");
+
+    let mut pwm = SimplePwm::new_1ch(p.TIM1, p.PE9, 10000.hz());
+    let max = pwm.get_max_duty();
+    pwm.enable(Channel::Ch1);
+
+    info!("PWM initialized");
+    info!("PWM max duty {}", max);
+
+    loop {
+        pwm.set_duty(Channel::Ch1, 0);
+        Timer::after(Duration::from_millis(300)).await;
+        pwm.set_duty(Channel::Ch1, max / 4);
+        Timer::after(Duration::from_millis(300)).await;
+        pwm.set_duty(Channel::Ch1, max / 2);
+        Timer::after(Duration::from_millis(300)).await;
+        pwm.set_duty(Channel::Ch1, max - 1);
+        Timer::after(Duration::from_millis(300)).await;
+    }
+}


### PR DESCRIPTION
Advanced timers have additional BDTR register, which has a global output enable bit and it is disabled by default.

Also added an example for F4, but it will only work once https://github.com/embassy-rs/stm32-data/pull/149 is merged. We can also move it to some other chip, but I don't have anything else to test on atm.