### PR TITLE
Implement scoped spawn

### DIFF
--- a/embassy/src/executor/raw/mod.rs
+++ b/embassy/src/executor/raw/mod.rs
@@ -239,7 +239,7 @@ impl<T> ScopedTaskStorage<T> {
     #[cfg(not(feature = "nightly"))]
     pub fn new() -> Self {
         Self {
-            raw: TaskHeader::new(),
+            header: TaskHeader::new(),
             future: UninitCell::uninit(),
             result: UnsafeCell::new(MaybeUninit::uninit()),
             waker: AtomicWaker::new(),

--- a/examples/stm32f4/Cargo.toml
+++ b/examples/stm32f4/Cargo.toml
@@ -5,8 +5,22 @@ version = "0.1.0"
 
 
 [dependencies]
-embassy = { version = "0.1.0", path = "../../embassy", features = ["defmt", "defmt-timestamp-uptime", "unstable-traits", "time-tick-32768hz"] }
-embassy-stm32 = { version = "0.1.0", path = "../../embassy-stm32", features = ["nightly", "unstable-traits", "defmt", "stm32f429zi", "unstable-pac", "memory-x", "time-driver-any", "exti"]  }
+embassy = { version = "0.1.0", path = "../../embassy", features = [
+    "defmt",
+    "defmt-timestamp-uptime",
+    "unstable-traits",
+    "time-tick-32768hz",
+] }
+embassy-stm32 = { version = "0.1.0", path = "../../embassy-stm32", features = [
+    "nightly",
+    "unstable-traits",
+    "defmt",
+    "stm32f429zi",
+    "unstable-pac",
+    "memory-x",
+    "time-driver-any",
+    "exti",
+] }
 
 defmt = "0.3"
 defmt-rtt = "0.3"
@@ -16,9 +30,14 @@ cortex-m-rt = "0.7.0"
 embedded-hal = "0.2.6"
 embedded-io = "0.3.0"
 panic-probe = { version = "0.3", features = ["print-defmt"] }
-futures = { version = "0.3.17", default-features = false, features = ["async-await"] }
+futures = { version = "0.3.17", default-features = false, features = [
+    "async-await",
+] }
 heapless = { version = "0.7.5", default-features = false }
 nb = "1.0.0"
 
 usb-device = "0.2"
 usbd-serial = "0.1.1"
+
+[profile.release]
+debug = 1

--- a/examples/stm32f4/Cargo.toml
+++ b/examples/stm32f4/Cargo.toml
@@ -5,22 +5,8 @@ version = "0.1.0"
 
 
 [dependencies]
-embassy = { version = "0.1.0", path = "../../embassy", features = [
-    "defmt",
-    "defmt-timestamp-uptime",
-    "unstable-traits",
-    "time-tick-32768hz",
-] }
-embassy-stm32 = { version = "0.1.0", path = "../../embassy-stm32", features = [
-    "nightly",
-    "unstable-traits",
-    "defmt",
-    "stm32f429zi",
-    "unstable-pac",
-    "memory-x",
-    "time-driver-any",
-    "exti",
-] }
+embassy = { version = "0.1.0", path = "../../embassy", features = ["defmt", "defmt-timestamp-uptime", "unstable-traits", "time-tick-32768hz"] }
+embassy-stm32 = { version = "0.1.0", path = "../../embassy-stm32", features = ["nightly", "unstable-traits", "defmt", "stm32f429zi", "unstable-pac", "memory-x", "time-driver-any", "exti"]  }
 
 defmt = "0.3"
 defmt-rtt = "0.3"
@@ -30,14 +16,9 @@ cortex-m-rt = "0.7.0"
 embedded-hal = "0.2.6"
 embedded-io = "0.3.0"
 panic-probe = { version = "0.3", features = ["print-defmt"] }
-futures = { version = "0.3.17", default-features = false, features = [
-    "async-await",
-] }
+futures = { version = "0.3.17", default-features = false, features = ["async-await"] }
 heapless = { version = "0.7.5", default-features = false }
 nb = "1.0.0"
 
 usb-device = "0.2"
 usbd-serial = "0.1.1"
-
-[profile.release]
-debug = 1

--- a/examples/stm32f4/src/bin/scoped_spawn.rs
+++ b/examples/stm32f4/src/bin/scoped_spawn.rs
@@ -1,0 +1,65 @@
+#![no_std]
+#![no_main]
+#![feature(type_alias_impl_trait)]
+
+use core::mem;
+
+use defmt::{info, unwrap};
+use embassy::executor::raw::{ScopedTaskStorage, TaskHeader};
+use embassy::executor::{Executor, Spawner};
+use embassy::time::{Duration, Timer};
+use embassy_stm32::Peripherals;
+use {defmt_rtt as _, panic_probe as _};
+
+async fn run1() {
+    Timer::after(Duration::from_secs(1)).await;
+    info!("run1(): done!");
+}
+
+async fn run2(a: &mut u8) {
+    Timer::after(Duration::from_secs(2)).await;
+    *a += 1;
+    info!("run2(): done!");
+}
+
+// static RUN1_HEAD: TaskHeader = TaskHeader::new();
+// static RUN2_HEAD: TaskHeader = TaskHeader::new();
+
+#[embassy::main]
+async fn main(spawner: Spawner, _p: Peripherals) -> ! {
+    let run1_head = TaskHeader::new();
+    let run2_head = TaskHeader::new();
+
+    let run1_head = unsafe { make_static(&run1_head) };
+    let run2_head = unsafe { make_static(&run2_head) };
+
+    let run1_task = ScopedTaskStorage::new(run1_head);
+    let run2_task = ScopedTaskStorage::new(run2_head);
+
+    let mut x = 0;
+    let x_ref = &mut x;
+
+    // Safety: these variables do live forever if main never returns.
+    // let run1_task = unsafe { make_static(&run1_task) };
+    // let run2_task = unsafe { make_static(&run2_task) };
+
+    let (run1_guard, run1_token) = unwrap!(run1_task.spawn_scoped(|| run1()));
+    let (run2_guard, run2_token) = unwrap!(run2_task.spawn_scoped(|| run2(x_ref)));
+
+    unwrap!(spawner.spawn(run1_token));
+    unwrap!(spawner.spawn(run2_token));
+
+    run1_guard.await;
+    run2_guard.await;
+
+    info!("x: {}", x);
+
+    loop {
+        info!("Hello World!");
+        Timer::after(Duration::from_secs(1)).await;
+    }
+}
+
+unsafe fn make_static<T>(t: &T) -> &'static T {
+    mem::transmute(t)
+}

--- a/examples/stm32f4/src/bin/scoped_spawn.rs
+++ b/examples/stm32f4/src/bin/scoped_spawn.rs
@@ -14,13 +14,13 @@ use {defmt_rtt as _, panic_probe as _};
 
 async fn add_ref(a: &mut u8, b: u8) {
     Timer::after(Duration::from_secs(2)).await;
+    info!("add_ref(): done!");
     *a += b;
-    info!("run1(): done!");
 }
 
 async fn add_rtn(a: u8, b: u8) -> u8 {
     Timer::after(Duration::from_secs(1)).await;
-    info!("run2(): done!");
+    info!("add_rtn(): done!");
     a + b
 }
 


### PR DESCRIPTION
An attempt on implementing scoped spawn.

Using regular tasks is inconvenient because they require all references to be static and this is difficult when you construct a lot of stuff in the main function. So far I've been using a huge `select_biased!` block to poll all of the anonymous futures, but this is very inefficient, because all of them share the same waker, which means that on wake up each of the futures has to be polled. This PR makes it possible to spawn anonymous futures that use references to the stack and schedules each independently.

I wasn't sure if it's possible to cancel a spawned task, so dropping an unfinished guard results in a panic.

Getting this to work was kind of tricky and I'm not sure if it is the best approach, so I'm open for suggestions.