### PR TITLE
Blocking shared bus EH 0.2 impls + example docs

### DIFF
--- a/embassy-embedded-hal/src/shared_bus/blocking/i2c.rs
+++ b/embassy-embedded-hal/src/shared_bus/blocking/i2c.rs
@@ -1,4 +1,21 @@
 //! Blocking shared I2C bus
+//!
+//! # Example (nrf52)
+//!
+//! ```rust
+//! use embassy_embedded_hal::shared_bus::blocking::i2c::I2cBusDevice;
+//! use embassy::blocking_mutex::{NoopMutex, raw::NoopRawMutex};
+//!
+//! static I2C_BUS: Forever<NoopMutex<RefCell<Twim<TWISPI0>>>> = Forever::new();
+//! let irq = interrupt::take!(SPIM0_SPIS0_TWIM0_TWIS0_SPI0_TWI0);
+//! let i2c = Twim::new(p.TWISPI0, irq, p.P0_03, p.P0_04, Config::default());
+//! let i2c_bus = NoopMutex::new(RefCell::new(i2c));
+//! let i2c_bus = I2C_BUS.put(i2c_bus);
+//!
+//! let i2c_dev1 = I2cBusDevice::new(i2c_bus);
+//! let mpu = Mpu6050::new(i2c_dev1);
+//! ```
+
 use core::cell::RefCell;
 
 use embassy::blocking_mutex::raw::RawMutex;
@@ -80,5 +97,47 @@ where
         let _ = address;
         let _ = operations;
         todo!()
+    }
+}
+
+impl<'a, M, BUS, E> embedded_hal_02::blocking::i2c::Write for I2cBusDevice<'_, M, BUS>
+where
+    M: RawMutex,
+    BUS: embedded_hal_02::blocking::i2c::Write<Error = E>,
+{
+    type Error = I2cBusDeviceError<E>;
+
+    fn write<'w>(&mut self, addr: u8, bytes: &'w [u8]) -> Result<(), Self::Error> {
+        self.bus
+            .lock(|bus| bus.borrow_mut().write(addr, bytes).map_err(I2cBusDeviceError::I2c))
+    }
+}
+
+impl<'a, M, BUS, E> embedded_hal_02::blocking::i2c::Read for I2cBusDevice<'_, M, BUS>
+where
+    M: RawMutex,
+    BUS: embedded_hal_02::blocking::i2c::Read<Error = E>,
+{
+    type Error = I2cBusDeviceError<E>;
+
+    fn read<'w>(&mut self, addr: u8, bytes: &'w mut [u8]) -> Result<(), Self::Error> {
+        self.bus
+            .lock(|bus| bus.borrow_mut().read(addr, bytes).map_err(I2cBusDeviceError::I2c))
+    }
+}
+
+impl<'a, M, BUS, E> embedded_hal_02::blocking::i2c::WriteRead for I2cBusDevice<'_, M, BUS>
+where
+    M: RawMutex,
+    BUS: embedded_hal_02::blocking::i2c::WriteRead<Error = E>,
+{
+    type Error = I2cBusDeviceError<E>;
+
+    fn write_read<'w>(&mut self, addr: u8, bytes: &'w [u8], buffer: &'w mut [u8]) -> Result<(), Self::Error> {
+        self.bus.lock(|bus| {
+            bus.borrow_mut()
+                .write_read(addr, bytes, buffer)
+                .map_err(I2cBusDeviceError::I2c)
+        })
     }
 }

--- a/embassy-embedded-hal/src/shared_bus/blocking/spi.rs
+++ b/embassy-embedded-hal/src/shared_bus/blocking/spi.rs
@@ -1,4 +1,23 @@
 //! Blocking shared SPI bus
+//!
+//! # Example (nrf52)
+//!
+//! ```rust
+//! use embassy_embedded_hal::shared_bus::blocking::spi::SpiBusDevice;
+//! use embassy::blocking_mutex::{NoopMutex, raw::NoopRawMutex};
+//!
+//! static SPI_BUS: Forever<NoopMutex<RefCell<Spim<SPI3>>>> = Forever::new();
+//! let irq = interrupt::take!(SPIM3);
+//! let spi = Spim::new_txonly(p.SPI3, irq, p.P0_15, p.P0_18, Config::default());
+//! let spi_bus = NoopMutex::new(RefCell::new(spi));
+//! let spi_bus = SPI_BUS.put(spi_bus);
+//!
+//! // Device 1, using embedded-hal compatible driver for ST7735 LCD display
+//! let cs_pin1 = Output::new(p.P0_24, Level::Low, OutputDrive::Standard);
+//! let spi_dev1 = SpiBusDevice::new(spi_bus, cs_pin1);
+//! let display1 = ST7735::new(spi_dev1, dc1, rst1, Default::default(), false, 160, 128);
+//! ```
+
 use core::cell::RefCell;
 
 use embassy::blocking_mutex::raw::RawMutex;
@@ -51,6 +70,47 @@ where
             flush_res.map_err(SpiBusDeviceError::Spi)?;
             cs_res.map_err(SpiBusDeviceError::Cs)?;
 
+            Ok(f_res)
+        })
+    }
+}
+
+impl<'d, M, BUS, CS, BusErr, CsErr> embedded_hal_02::blocking::spi::Transfer<u8> for SpiBusDevice<'_, M, BUS, CS>
+where
+    M: RawMutex,
+    BUS: embedded_hal_02::blocking::spi::Transfer<u8, Error = BusErr>,
+    CS: OutputPin<Error = CsErr>,
+{
+    type Error = SpiBusDeviceError<BusErr, CsErr>;
+    fn transfer<'w>(&mut self, words: &'w mut [u8]) -> Result<&'w [u8], Self::Error> {
+        self.bus.lock(|bus| {
+            let mut bus = bus.borrow_mut();
+            self.cs.set_low().map_err(SpiBusDeviceError::Cs)?;
+            let f_res = bus.transfer(words);
+            let cs_res = self.cs.set_high();
+            let f_res = f_res.map_err(SpiBusDeviceError::Spi)?;
+            cs_res.map_err(SpiBusDeviceError::Cs)?;
+            Ok(f_res)
+        })
+    }
+}
+
+impl<'d, M, BUS, CS, BusErr, CsErr> embedded_hal_02::blocking::spi::Write<u8> for SpiBusDevice<'_, M, BUS, CS>
+where
+    M: RawMutex,
+    BUS: embedded_hal_02::blocking::spi::Write<u8, Error = BusErr>,
+    CS: OutputPin<Error = CsErr>,
+{
+    type Error = SpiBusDeviceError<BusErr, CsErr>;
+
+    fn write(&mut self, words: &[u8]) -> Result<(), Self::Error> {
+        self.bus.lock(|bus| {
+            let mut bus = bus.borrow_mut();
+            self.cs.set_low().map_err(SpiBusDeviceError::Cs)?;
+            let f_res = bus.write(words);
+            let cs_res = self.cs.set_high();
+            let f_res = f_res.map_err(SpiBusDeviceError::Spi)?;
+            cs_res.map_err(SpiBusDeviceError::Cs)?;
             Ok(f_res)
         })
     }


### PR DESCRIPTION
Adds impls for the old embedded-hal v0.2 traits for usability until the ecosystem catches up with EH1.
Also added some basic examples in docs of how the shared buses can be set up.