### PR TITLE
embassy-stm32/pwm: Generalize channel selection

### DIFF
--- a/embassy-stm32/src/pwm/simple_pwm.rs
+++ b/embassy-stm32/src/pwm/simple_pwm.rs
@@ -20,9 +20,9 @@ pub struct PwmPin<'d, Perip, Channel> {
 }
 
 macro_rules! channel_impl {
-    ($channel:ident, $pin_trait:ident) => {
+    ($new_chx:ident, $channel:ident, $pin_trait:ident) => {
         impl<'d, Perip: CaptureCompare16bitInstance> PwmPin<'d, Perip, $channel> {
-            pub fn new(pin: impl Peripheral<P = impl $pin_trait<Perip>> + 'd) -> Self {
+            pub fn $new_chx(pin: impl Peripheral<P = impl $pin_trait<Perip>> + 'd) -> Self {
                 into_ref!(pin);
                 critical_section::with(|_| unsafe {
                     pin.set_low();
@@ -39,10 +39,10 @@ macro_rules! channel_impl {
     };
 }
 
-channel_impl!(Ch1, Channel1Pin);
-channel_impl!(Ch2, Channel2Pin);
-channel_impl!(Ch3, Channel3Pin);
-channel_impl!(Ch4, Channel4Pin);
+channel_impl!(new_ch1, Ch1, Channel1Pin);
+channel_impl!(new_ch2, Ch2, Channel2Pin);
+channel_impl!(new_ch3, Ch3, Channel3Pin);
+channel_impl!(new_ch4, Ch4, Channel4Pin);
 
 pub struct SimplePwm<'d, T> {
     inner: PeripheralRef<'d, T>,
@@ -51,10 +51,10 @@ pub struct SimplePwm<'d, T> {
 impl<'d, T: CaptureCompare16bitInstance> SimplePwm<'d, T> {
     pub fn new(
         tim: impl Peripheral<P = T> + 'd,
-        _ch1: Option<PwmPin<T, Ch1>>,
-        _ch2: Option<PwmPin<T, Ch2>>,
-        _ch3: Option<PwmPin<T, Ch3>>,
-        _ch4: Option<PwmPin<T, Ch4>>,
+        _ch1: Option<PwmPin<'d, T, Ch1>>,
+        _ch2: Option<PwmPin<'d, T, Ch2>>,
+        _ch3: Option<PwmPin<'d, T, Ch3>>,
+        _ch4: Option<PwmPin<'d, T, Ch4>>,
         freq: Hertz,
     ) -> Self {
         Self::new_inner(tim, freq)

--- a/examples/stm32f4/src/bin/pwm.rs
+++ b/examples/stm32f4/src/bin/pwm.rs
@@ -5,7 +5,7 @@
 use defmt::*;
 use embassy::executor::Spawner;
 use embassy::time::{Duration, Timer};
-use embassy_stm32::pwm::simple_pwm::SimplePwm;
+use embassy_stm32::pwm::simple_pwm::{PwmPin, SimplePwm};
 use embassy_stm32::pwm::Channel;
 use embassy_stm32::time::khz;
 use embassy_stm32::Peripherals;
@@ -15,7 +15,8 @@ use {defmt_rtt as _, panic_probe as _};
 async fn main(_spawner: Spawner, p: Peripherals) {
     info!("Hello World!");
 
-    let mut pwm = SimplePwm::new_1ch(p.TIM1, p.PE9, khz(10));
+    let ch1 = PwmPin::new_ch1(p.PE9);
+    let mut pwm = SimplePwm::new(p.TIM1, Some(ch1), None, None, None, khz(10));
     let max = pwm.get_max_duty();
     pwm.enable(Channel::Ch1);
 

--- a/examples/stm32g4/src/bin/pwm.rs
+++ b/examples/stm32g4/src/bin/pwm.rs
@@ -5,7 +5,7 @@
 use defmt::*;
 use embassy::executor::Spawner;
 use embassy::time::{Duration, Timer};
-use embassy_stm32::pwm::simple_pwm::SimplePwm;
+use embassy_stm32::pwm::simple_pwm::{PwmPin, SimplePwm};
 use embassy_stm32::pwm::Channel;
 use embassy_stm32::time::khz;
 use embassy_stm32::Peripherals;
@@ -15,7 +15,8 @@ use {defmt_rtt as _, panic_probe as _};
 async fn main(_spawner: Spawner, p: Peripherals) {
     info!("Hello World!");
 
-    let mut pwm = SimplePwm::new_1ch(p.TIM2, p.PA5, khz(10));
+    let ch1 = PwmPin::new_ch1(p.PA5);
+    let mut pwm = SimplePwm::new(p.TIM2, Some(ch1), None, None, None, khz(10));
     let max = pwm.get_max_duty();
     pwm.enable(Channel::Ch1);
 

--- a/examples/stm32h7/src/bin/pwm.rs
+++ b/examples/stm32h7/src/bin/pwm.rs
@@ -5,7 +5,7 @@
 use defmt::*;
 use embassy::executor::Spawner;
 use embassy::time::{Duration, Timer};
-use embassy_stm32::pwm::simple_pwm::SimplePwm;
+use embassy_stm32::pwm::simple_pwm::{PwmPin, SimplePwm};
 use embassy_stm32::pwm::Channel;
 use embassy_stm32::time::{khz, mhz};
 use embassy_stm32::{Config, Peripherals};
@@ -27,7 +27,8 @@ pub fn config() -> Config {
 async fn main(_spawner: Spawner, p: Peripherals) {
     info!("Hello World!");
 
-    let mut pwm = SimplePwm::new_1ch(p.TIM3, p.PA6, khz(10));
+    let ch1 = PwmPin::new_ch1(p.PA6);
+    let mut pwm = SimplePwm::new(p.TIM3, Some(ch1), None, None, None, khz(10));
     let max = pwm.get_max_duty();
     pwm.enable(Channel::Ch1);
 


### PR DESCRIPTION
550da471be7b56927b50b5955a6de0916ebe6b1f previously refactored the STM32
PWM logic in such a way to preclude use of non-contiguous channels (e.g.
channel 2 but not channel 1). Refactor it yet again to yet again allow
this sort of usage.