### PR TITLE
embassy-stm32: Simplify time

### DIFF
--- a/embassy-stm32/src/adc/v4.rs
+++ b/embassy-stm32/src/adc/v4.rs
@@ -6,7 +6,7 @@ use pac::adc::vals::{Adcaldif, Boost, Difsel, Exten, Pcsel};
 use pac::adccommon::vals::Presc;
 
 use super::{AdcPin, Instance};
-use crate::time::{Hertz, U32Ext};
+use crate::time::Hertz;
 use crate::{pac, Unborrow};
 
 pub enum Resolution {
@@ -336,14 +336,14 @@ impl<'d, T: Instance + crate::rcc::RccPeripheral> Adc<'d, T> {
         let frequency = Hertz(T::frequency().0 / prescaler.divisor());
         info!("ADC frequency set to {} Hz", frequency.0);
 
-        if frequency > 50.mhz().into() {
+        if frequency > Hertz::mhz(50) {
             panic!("Maximal allowed frequency for the ADC is 50 MHz and it varies with different packages, refer to ST docs for more information.");
         }
-        let boost = if frequency < 6_250.khz().into() {
+        let boost = if frequency < Hertz::khz(6_250) {
             Boost::LT6_25
-        } else if frequency < 12_500.khz().into() {
+        } else if frequency < Hertz::khz(12_500) {
             Boost::LT12_5
-        } else if frequency < 25.mhz().into() {
+        } else if frequency < Hertz::mhz(25) {
             Boost::LT25
         } else {
             Boost::LT50

--- a/embassy-stm32/src/i2c/v1.rs
+++ b/embassy-stm32/src/i2c/v1.rs
@@ -22,15 +22,12 @@ pub struct I2c<'d, T: Instance> {
 }
 
 impl<'d, T: Instance> I2c<'d, T> {
-    pub fn new<F>(
+    pub fn new(
         _peri: impl Unborrow<Target = T> + 'd,
         scl: impl Unborrow<Target = impl SclPin<T>> + 'd,
         sda: impl Unborrow<Target = impl SdaPin<T>> + 'd,
-        freq: F,
-    ) -> Self
-    where
-        F: Into<Hertz>,
-    {
+        freq: Hertz,
+    ) -> Self {
         unborrow!(scl, sda);
 
         T::enable();

--- a/embassy-stm32/src/i2c/v2.rs
+++ b/embassy-stm32/src/i2c/v2.rs
@@ -39,18 +39,15 @@ pub struct I2c<'d, T: Instance, TXDMA = NoDma, RXDMA = NoDma> {
 }
 
 impl<'d, T: Instance, TXDMA, RXDMA> I2c<'d, T, TXDMA, RXDMA> {
-    pub fn new<F>(
+    pub fn new(
         _peri: impl Unborrow<Target = T> + 'd,
         scl: impl Unborrow<Target = impl SclPin<T>> + 'd,
         sda: impl Unborrow<Target = impl SdaPin<T>> + 'd,
         irq: impl Unborrow<Target = T::Interrupt> + 'd,
         tx_dma: impl Unborrow<Target = TXDMA> + 'd,
         rx_dma: impl Unborrow<Target = RXDMA> + 'd,
-        freq: F,
-    ) -> Self
-    where
-        F: Into<Hertz>,
-    {
+        freq: Hertz,
+    ) -> Self {
         unborrow!(irq, scl, sda, tx_dma, rx_dma);
 
         T::enable();

--- a/embassy-stm32/src/pwm/simple_pwm.rs
+++ b/embassy-stm32/src/pwm/simple_pwm.rs
@@ -29,53 +29,53 @@ macro_rules! config_pins {
 }
 
 impl<'d, T: CaptureCompare16bitInstance> SimplePwm<'d, T> {
-    pub fn new_1ch<F: Into<Hertz>>(
+    pub fn new_1ch(
         tim: impl Unborrow<Target = T> + 'd,
         ch1: impl Unborrow<Target = impl Channel1Pin<T>> + 'd,
-        freq: F,
+        freq: Hertz,
     ) -> Self {
         Self::new_inner(tim, freq, move || {
             config_pins!(ch1);
         })
     }
 
-    pub fn new_2ch<F: Into<Hertz>>(
+    pub fn new_2ch(
         tim: impl Unborrow<Target = T> + 'd,
         ch1: impl Unborrow<Target = impl Channel1Pin<T>> + 'd,
         ch2: impl Unborrow<Target = impl Channel2Pin<T>> + 'd,
-        freq: F,
+        freq: Hertz,
     ) -> Self {
         Self::new_inner(tim, freq, move || {
             config_pins!(ch1, ch2);
         })
     }
 
-    pub fn new_3ch<F: Into<Hertz>>(
+    pub fn new_3ch(
         tim: impl Unborrow<Target = T> + 'd,
         ch1: impl Unborrow<Target = impl Channel1Pin<T>> + 'd,
         ch2: impl Unborrow<Target = impl Channel2Pin<T>> + 'd,
         ch3: impl Unborrow<Target = impl Channel3Pin<T>> + 'd,
-        freq: F,
+        freq: Hertz,
     ) -> Self {
         Self::new_inner(tim, freq, move || {
             config_pins!(ch1, ch2, ch3);
         })
     }
 
-    pub fn new_4ch<F: Into<Hertz>>(
+    pub fn new_4ch(
         tim: impl Unborrow<Target = T> + 'd,
         ch1: impl Unborrow<Target = impl Channel1Pin<T>> + 'd,
         ch2: impl Unborrow<Target = impl Channel2Pin<T>> + 'd,
         ch3: impl Unborrow<Target = impl Channel3Pin<T>> + 'd,
         ch4: impl Unborrow<Target = impl Channel4Pin<T>> + 'd,
-        freq: F,
+        freq: Hertz,
     ) -> Self {
         Self::new_inner(tim, freq, move || {
             config_pins!(ch1, ch2, ch3, ch4);
         })
     }
 
-    fn new_inner<F: Into<Hertz>>(tim: impl Unborrow<Target = T> + 'd, freq: F, configure_pins: impl FnOnce()) -> Self {
+    fn new_inner(tim: impl Unborrow<Target = T> + 'd, freq: Hertz, configure_pins: impl FnOnce()) -> Self {
         unborrow!(tim);
 
         T::enable();
@@ -118,7 +118,7 @@ impl<'d, T: CaptureCompare16bitInstance> SimplePwm<'d, T> {
         }
     }
 
-    pub fn set_freq<F: Into<Hertz>>(&mut self, freq: F) {
+    pub fn set_freq(&mut self, freq: Hertz) {
         self.inner.set_frequency(freq);
     }
 

--- a/embassy-stm32/src/rcc/g0.rs
+++ b/embassy-stm32/src/rcc/g0.rs
@@ -2,7 +2,7 @@ use crate::pac::flash::vals::Latency;
 use crate::pac::rcc::vals::{self, Hpre, Hsidiv, Ppre, Sw};
 use crate::pac::{FLASH, PWR, RCC};
 use crate::rcc::{set_freqs, Clocks};
-use crate::time::{Hertz, U32Ext};
+use crate::time::Hertz;
 
 /// HSI speed
 pub const HSI_FREQ: Hertz = Hertz(16_000_000);
@@ -449,14 +449,14 @@ pub(crate) unsafe fn init(config: Config) {
     };
 
     if config.low_power_run {
-        assert!(sys_clk.hz() <= 2_000_000.hz());
+        assert!(sys_clk <= 2_000_000);
         PWR.cr1().modify(|w| w.set_lpr(true));
     }
 
     set_freqs(Clocks {
-        sys: sys_clk.hz(),
-        ahb1: ahb_freq.hz(),
-        apb1: apb_freq.hz(),
-        apb1_tim: apb_tim_freq.hz(),
+        sys: Hertz(sys_clk),
+        ahb1: Hertz(ahb_freq),
+        apb1: Hertz(apb_freq),
+        apb1_tim: Hertz(apb_tim_freq),
     });
 }

--- a/embassy-stm32/src/rcc/g4.rs
+++ b/embassy-stm32/src/rcc/g4.rs
@@ -1,6 +1,6 @@
 use crate::pac::{PWR, RCC};
 use crate::rcc::{set_freqs, Clocks};
-use crate::time::{Hertz, U32Ext};
+use crate::time::Hertz;
 
 /// HSI speed
 pub const HSI_FREQ: Hertz = Hertz(16_000_000);
@@ -144,17 +144,17 @@ pub(crate) unsafe fn init(config: Config) {
     };
 
     if config.low_power_run {
-        assert!(sys_clk.hz() <= 2_000_000.hz());
+        assert!(sys_clk <= 2_000_000);
         PWR.cr1().modify(|w| w.set_lpr(true));
     }
 
     set_freqs(Clocks {
-        sys: sys_clk.hz(),
-        ahb1: ahb_freq.hz(),
-        ahb2: ahb_freq.hz(),
-        apb1: apb1_freq.hz(),
-        apb1_tim: apb1_tim_freq.hz(),
-        apb2: apb2_freq.hz(),
-        apb2_tim: apb2_tim_freq.hz(),
+        sys: Hertz(sys_clk),
+        ahb1: Hertz(ahb_freq),
+        ahb2: Hertz(ahb_freq),
+        apb1: Hertz(apb1_freq),
+        apb1_tim: Hertz(apb1_tim_freq),
+        apb2: Hertz(apb2_freq),
+        apb2_tim: Hertz(apb2_tim_freq),
     });
 }

--- a/embassy-stm32/src/rcc/l0.rs
+++ b/embassy-stm32/src/rcc/l0.rs
@@ -3,7 +3,7 @@ use crate::pac::RCC;
 #[cfg(crs)]
 use crate::pac::{CRS, SYSCFG};
 use crate::rcc::{set_freqs, Clocks};
-use crate::time::{Hertz, U32Ext};
+use crate::time::Hertz;
 
 /// HSI speed
 pub const HSI_FREQ: Hertz = Hertz(16_000_000);
@@ -266,7 +266,7 @@ pub(crate) unsafe fn init(config: Config) {
                 PLLDiv::Div3 => freq / 3,
                 PLLDiv::Div4 => freq / 4,
             };
-            assert!(freq <= 32_u32.mhz().0);
+            assert!(freq <= 32_000_000);
 
             RCC.cfgr().write(move |w| {
                 w.set_pllmul(mul.into());
@@ -359,11 +359,11 @@ pub(crate) unsafe fn init(config: Config) {
     }
 
     set_freqs(Clocks {
-        sys: sys_clk.hz(),
-        ahb1: ahb_freq.hz(),
-        apb1: apb1_freq.hz(),
-        apb2: apb2_freq.hz(),
-        apb1_tim: apb1_tim_freq.hz(),
-        apb2_tim: apb2_tim_freq.hz(),
+        sys: Hertz(sys_clk),
+        ahb1: Hertz(ahb_freq),
+        apb1: Hertz(apb1_freq),
+        apb2: Hertz(apb2_freq),
+        apb1_tim: Hertz(apb1_tim_freq),
+        apb2_tim: Hertz(apb2_tim_freq),
     });
 }

--- a/embassy-stm32/src/rcc/l1.rs
+++ b/embassy-stm32/src/rcc/l1.rs
@@ -1,7 +1,7 @@
 use crate::pac::rcc::vals::{Hpre, Msirange, Plldiv, Pllmul, Pllsrc, Ppre, Sw};
 use crate::pac::{FLASH, RCC};
 use crate::rcc::{set_freqs, Clocks};
-use crate::time::{Hertz, U32Ext};
+use crate::time::Hertz;
 
 /// HSI speed
 pub const HSI_FREQ: Hertz = Hertz(16_000_000);
@@ -320,11 +320,11 @@ pub(crate) unsafe fn init(config: Config) {
     };
 
     set_freqs(Clocks {
-        sys: sys_clk.hz(),
-        ahb1: ahb_freq.hz(),
-        apb1: apb1_freq.hz(),
-        apb2: apb2_freq.hz(),
-        apb1_tim: apb1_tim_freq.hz(),
-        apb2_tim: apb2_tim_freq.hz(),
+        sys: Hertz(sys_clk),
+        ahb1: Hertz(ahb_freq),
+        apb1: Hertz(apb1_freq),
+        apb2: Hertz(apb2_freq),
+        apb1_tim: Hertz(apb1_tim_freq),
+        apb2_tim: Hertz(apb2_tim_freq),
     });
 }

--- a/embassy-stm32/src/rcc/l4.rs
+++ b/embassy-stm32/src/rcc/l4.rs
@@ -1,7 +1,7 @@
 use crate::pac::rcc::vals::{Hpre, Msirange, Pllsrc, Ppre, Sw};
 use crate::pac::{FLASH, RCC};
 use crate::rcc::{set_freqs, Clocks};
-use crate::time::{Hertz, U32Ext};
+use crate::time::Hertz;
 
 /// HSI speed
 pub const HSI_FREQ: Hertz = Hertz(16_000_000);
@@ -489,13 +489,13 @@ pub(crate) unsafe fn init(config: Config) {
     };
 
     set_freqs(Clocks {
-        sys: sys_clk.hz(),
-        ahb1: ahb_freq.hz(),
-        ahb2: ahb_freq.hz(),
-        ahb3: ahb_freq.hz(),
-        apb1: apb1_freq.hz(),
-        apb2: apb2_freq.hz(),
-        apb1_tim: apb1_tim_freq.hz(),
-        apb2_tim: apb2_tim_freq.hz(),
+        sys: Hertz(sys_clk),
+        ahb1: Hertz(ahb_freq),
+        ahb2: Hertz(ahb_freq),
+        ahb3: Hertz(ahb_freq),
+        apb1: Hertz(apb1_freq),
+        apb2: Hertz(apb2_freq),
+        apb1_tim: Hertz(apb1_tim_freq),
+        apb2_tim: Hertz(apb2_tim_freq),
     });
 }

--- a/embassy-stm32/src/rcc/l5.rs
+++ b/embassy-stm32/src/rcc/l5.rs
@@ -3,7 +3,7 @@ use stm32_metapac::PWR;
 use crate::pac::rcc::vals::{Hpre, Msirange, Pllsrc, Ppre, Sw};
 use crate::pac::{FLASH, RCC};
 use crate::rcc::{set_freqs, Clocks};
-use crate::time::{Hertz, U32Ext};
+use crate::time::Hertz;
 
 /// HSI speed
 pub const HSI_FREQ: Hertz = Hertz(16_000_000);
@@ -487,13 +487,13 @@ pub(crate) unsafe fn init(config: Config) {
     };
 
     set_freqs(Clocks {
-        sys: sys_clk.hz(),
-        ahb1: ahb_freq.hz(),
-        ahb2: ahb_freq.hz(),
-        ahb3: ahb_freq.hz(),
-        apb1: apb1_freq.hz(),
-        apb2: apb2_freq.hz(),
-        apb1_tim: apb1_tim_freq.hz(),
-        apb2_tim: apb2_tim_freq.hz(),
+        sys: Hertz(sys_clk),
+        ahb1: Hertz(ahb_freq),
+        ahb2: Hertz(ahb_freq),
+        ahb3: Hertz(ahb_freq),
+        apb1: Hertz(apb1_freq),
+        apb2: Hertz(apb2_freq),
+        apb1_tim: Hertz(apb1_tim_freq),
+        apb2_tim: Hertz(apb2_tim_freq),
     });
 }

--- a/embassy-stm32/src/rcc/u5.rs
+++ b/embassy-stm32/src/rcc/u5.rs
@@ -2,7 +2,7 @@ use stm32_metapac::rcc::vals::{Hpre, Msirange, Msirgsel, Pllm, Pllsrc, Ppre, Sw}
 
 use crate::pac::{FLASH, RCC};
 use crate::rcc::{set_freqs, Clocks};
-use crate::time::{Hertz, U32Ext};
+use crate::time::Hertz;
 
 /// HSI speed
 pub const HSI_FREQ: Hertz = Hertz(16_000_000);
@@ -483,14 +483,14 @@ pub(crate) unsafe fn init(config: Config) {
     };
 
     set_freqs(Clocks {
-        sys: sys_clk.hz(),
-        ahb1: ahb_freq.hz(),
-        ahb2: ahb_freq.hz(),
-        ahb3: ahb_freq.hz(),
-        apb1: apb1_freq.hz(),
-        apb2: apb2_freq.hz(),
-        apb3: apb3_freq.hz(),
-        apb1_tim: apb1_tim_freq.hz(),
-        apb2_tim: apb2_tim_freq.hz(),
+        sys: Hertz(sys_clk),
+        ahb1: Hertz(ahb_freq),
+        ahb2: Hertz(ahb_freq),
+        ahb3: Hertz(ahb_freq),
+        apb1: Hertz(apb1_freq),
+        apb2: Hertz(apb2_freq),
+        apb3: Hertz(apb3_freq),
+        apb1_tim: Hertz(apb1_tim_freq),
+        apb2_tim: Hertz(apb2_tim_freq),
     });
 }

--- a/embassy-stm32/src/rcc/wb.rs
+++ b/embassy-stm32/src/rcc/wb.rs
@@ -1,6 +1,6 @@
 use crate::pac::RCC;
 use crate::rcc::{set_freqs, Clocks};
-use crate::time::{Hertz, U32Ext};
+use crate::time::Hertz;
 
 /// Most of clock setup is copied from stm32l0xx-hal, and adopted to the generated PAC,
 /// and with the addition of the init function to configure a system clock.
@@ -157,13 +157,13 @@ pub(crate) unsafe fn init(config: Config) {
     };
 
     set_freqs(Clocks {
-        sys: sys_clk.hz(),
-        ahb1: ahb_freq.hz(),
-        ahb2: ahb_freq.hz(),
-        ahb3: ahb_freq.hz(),
-        apb1: apb1_freq.hz(),
-        apb2: apb2_freq.hz(),
-        apb1_tim: apb1_tim_freq.hz(),
-        apb2_tim: apb2_tim_freq.hz(),
+        sys: Hertz(sys_clk),
+        ahb1: Hertz(ahb_freq),
+        ahb2: Hertz(ahb_freq),
+        ahb3: Hertz(ahb_freq),
+        apb1: Hertz(apb1_freq),
+        apb2: Hertz(apb2_freq),
+        apb1_tim: Hertz(apb1_tim_freq),
+        apb2_tim: Hertz(apb2_tim_freq),
     });
 }

--- a/embassy-stm32/src/rcc/wl.rs
+++ b/embassy-stm32/src/rcc/wl.rs
@@ -1,6 +1,6 @@
 use crate::pac::{FLASH, RCC};
 use crate::rcc::{set_freqs, Clocks};
-use crate::time::{Hertz, U32Ext};
+use crate::time::Hertz;
 
 /// Most of clock setup is copied from stm32l0xx-hal, and adopted to the generated PAC,
 /// and with the addition of the init function to configure a system clock.
@@ -320,14 +320,14 @@ pub(crate) unsafe fn init(config: Config) {
     while FLASH.acr().read().latency() != ws {}
 
     set_freqs(Clocks {
-        sys: sys_clk.hz(),
-        ahb1: ahb_freq.hz(),
-        ahb2: ahb_freq.hz(),
-        ahb3: shd_ahb_freq.hz(),
-        apb1: apb1_freq.hz(),
-        apb2: apb2_freq.hz(),
-        apb3: apb3_freq.hz(),
-        apb1_tim: apb1_tim_freq.hz(),
-        apb2_tim: apb2_tim_freq.hz(),
+        sys: Hertz(sys_clk),
+        ahb1: Hertz(ahb_freq),
+        ahb2: Hertz(ahb_freq),
+        ahb3: Hertz(shd_ahb_freq),
+        apb1: Hertz(apb1_freq),
+        apb2: Hertz(apb2_freq),
+        apb3: Hertz(apb3_freq),
+        apb1_tim: Hertz(apb1_tim_freq),
+        apb2_tim: Hertz(apb2_tim_freq),
     });
 }

--- a/embassy-stm32/src/sdmmc/mod.rs
+++ b/embassy-stm32/src/sdmmc/mod.rs
@@ -261,7 +261,7 @@ impl<'d, T: Instance, P: Pins<T>> Sdmmc<'d, T, P, NoDma> {
 
 impl<'d, T: Instance, P: Pins<T>, Dma: SdmmcDma<T>> Sdmmc<'d, T, P, Dma> {
     #[inline(always)]
-    pub async fn init_card(&mut self, freq: impl Into<Hertz>) -> Result<(), Error> {
+    pub async fn init_card(&mut self, freq: Hertz) -> Result<(), Error> {
         let inner = T::inner();
         let freq = freq.into();
 

--- a/embassy-stm32/src/spi/mod.rs
+++ b/embassy-stm32/src/spi/mod.rs
@@ -83,19 +83,16 @@ pub struct Spi<'d, T: Instance, Tx, Rx> {
 }
 
 impl<'d, T: Instance, Tx, Rx> Spi<'d, T, Tx, Rx> {
-    pub fn new<F>(
+    pub fn new(
         peri: impl Unborrow<Target = T> + 'd,
         sck: impl Unborrow<Target = impl SckPin<T>> + 'd,
         mosi: impl Unborrow<Target = impl MosiPin<T>> + 'd,
         miso: impl Unborrow<Target = impl MisoPin<T>> + 'd,
         txdma: impl Unborrow<Target = Tx> + 'd,
         rxdma: impl Unborrow<Target = Rx> + 'd,
-        freq: F,
+        freq: Hertz,
         config: Config,
-    ) -> Self
-    where
-        F: Into<Hertz>,
-    {
+    ) -> Self {
         unborrow!(sck, mosi, miso);
         unsafe {
             sck.set_as_af(sck.af_num(), AFType::OutputPushPull);
@@ -121,18 +118,15 @@ impl<'d, T: Instance, Tx, Rx> Spi<'d, T, Tx, Rx> {
         )
     }
 
-    pub fn new_rxonly<F>(
+    pub fn new_rxonly(
         peri: impl Unborrow<Target = T> + 'd,
         sck: impl Unborrow<Target = impl SckPin<T>> + 'd,
         miso: impl Unborrow<Target = impl MisoPin<T>> + 'd,
         txdma: impl Unborrow<Target = Tx> + 'd, // TODO remove
         rxdma: impl Unborrow<Target = Rx> + 'd,
-        freq: F,
+        freq: Hertz,
         config: Config,
-    ) -> Self
-    where
-        F: Into<Hertz>,
-    {
+    ) -> Self {
         unborrow!(sck, miso);
         unsafe {
             sck.set_as_af(sck.af_num(), AFType::OutputPushPull);
@@ -155,18 +149,15 @@ impl<'d, T: Instance, Tx, Rx> Spi<'d, T, Tx, Rx> {
         )
     }
 
-    pub fn new_txonly<F>(
+    pub fn new_txonly(
         peri: impl Unborrow<Target = T> + 'd,
         sck: impl Unborrow<Target = impl SckPin<T>> + 'd,
         mosi: impl Unborrow<Target = impl MosiPin<T>> + 'd,
         txdma: impl Unborrow<Target = Tx> + 'd,
         rxdma: impl Unborrow<Target = Rx> + 'd, // TODO remove
-        freq: F,
+        freq: Hertz,
         config: Config,
-    ) -> Self
-    where
-        F: Into<Hertz>,
-    {
+    ) -> Self {
         unborrow!(sck, mosi);
         unsafe {
             sck.set_as_af(sck.af_num(), AFType::OutputPushPull);
@@ -189,19 +180,16 @@ impl<'d, T: Instance, Tx, Rx> Spi<'d, T, Tx, Rx> {
         )
     }
 
-    fn new_inner<F>(
+    fn new_inner(
         _peri: impl Unborrow<Target = T> + 'd,
         sck: Option<AnyPin>,
         mosi: Option<AnyPin>,
         miso: Option<AnyPin>,
         txdma: impl Unborrow<Target = Tx> + 'd,
         rxdma: impl Unborrow<Target = Rx> + 'd,
-        freq: F,
+        freq: Hertz,
         config: Config,
-    ) -> Self
-    where
-        F: Into<Hertz>,
-    {
+    ) -> Self {
         unborrow!(txdma, rxdma);
 
         let pclk = T::frequency();

--- a/embassy-stm32/src/time.rs
+++ b/embassy-stm32/src/time.rs
@@ -1,126 +1,34 @@
 //! Time units
 
-/// Bits per second
-#[derive(PartialEq, PartialOrd, Clone, Copy, Debug)]
-pub struct Bps(pub u32);
-
 /// Hertz
 #[derive(PartialEq, PartialOrd, Clone, Copy, Debug, Eq)]
 pub struct Hertz(pub u32);
 
-/// KiloHertz
-#[derive(PartialEq, PartialOrd, Clone, Copy, Debug)]
-pub struct KiloHertz(pub u32);
-
-/// MegaHertz
-#[derive(PartialEq, PartialOrd, Clone, Copy, Debug)]
-pub struct MegaHertz(pub u32);
-
-/// MilliSeconds
-#[derive(PartialEq, PartialOrd, Clone, Copy, Debug)]
-pub struct MilliSeconds(pub u32);
-
-/// MicroSeconds
-#[derive(PartialEq, PartialOrd, Clone, Copy, Debug)]
-pub struct MicroSeconds(pub u32);
-
-/// NanoSeconds
-#[derive(PartialEq, PartialOrd, Clone, Copy, Debug)]
-pub struct NanoSeconds(pub u32);
-
-/// Extension trait that adds convenience methods to the `u32` type
-pub trait U32Ext {
-    /// Wrap in `Bps`
-    fn bps(self) -> Bps;
-
-    /// Wrap in `Hertz`
-    fn hz(self) -> Hertz;
-
-    /// Wrap in `KiloHertz`
-    fn khz(self) -> KiloHertz;
-
-    /// Wrap in `MegaHertz`
-    fn mhz(self) -> MegaHertz;
-
-    /// Wrap in "MilliSeconds"
-    fn ms(self) -> MilliSeconds;
-
-    /// Wrap in "MicroSeconds"
-    fn us(self) -> MicroSeconds;
-
-    /// Wrap in "NanoSeconds"
-    fn ns(self) -> NanoSeconds;
-}
-
-impl U32Ext for u32 {
-    fn bps(self) -> Bps {
-        Bps(self)
+impl Hertz {
+    pub fn hz(hertz: u32) -> Self {
+        Self(hertz)
     }
 
-    fn hz(self) -> Hertz {
-        Hertz(self)
+    pub fn khz(kilohertz: u32) -> Self {
+        Self(kilohertz * 1_000)
     }
 
-    fn khz(self) -> KiloHertz {
-        KiloHertz(self)
-    }
-
-    fn mhz(self) -> MegaHertz {
-        MegaHertz(self)
-    }
-
-    fn ms(self) -> MilliSeconds {
-        MilliSeconds(self)
-    }
-
-    fn us(self) -> MicroSeconds {
-        MicroSeconds(self)
-    }
-
-    fn ns(self) -> NanoSeconds {
-        NanoSeconds(self)
+    pub fn mhz(megahertz: u32) -> Self {
+        Self(megahertz * 1_000_000)
     }
 }
 
-// Unit conversions
-impl Into<Hertz> for Bps {
-    fn into(self) -> Hertz {
-        Hertz(self.0)
-    }
+/// This is a convenience shortcut for [`Hertz::hz`]
+pub fn hz(hertz: u32) -> Hertz {
+    Hertz::hz(hertz)
 }
 
-impl Into<Hertz> for KiloHertz {
-    fn into(self) -> Hertz {
-        Hertz(self.0 * 1_000)
-    }
+/// This is a convenience shortcut for [`Hertz::khz`]
+pub fn khz(kilohertz: u32) -> Hertz {
+    Hertz::khz(kilohertz)
 }
 
-impl Into<Hertz> for MegaHertz {
-    fn into(self) -> Hertz {
-        Hertz(self.0 * 1_000_000)
-    }
-}
-
-impl Into<KiloHertz> for MegaHertz {
-    fn into(self) -> KiloHertz {
-        KiloHertz(self.0 * 1_000)
-    }
-}
-
-impl Into<NanoSeconds> for MicroSeconds {
-    fn into(self) -> NanoSeconds {
-        NanoSeconds(self.0 * 1_000)
-    }
-}
-
-impl Into<NanoSeconds> for MilliSeconds {
-    fn into(self) -> NanoSeconds {
-        NanoSeconds(self.0 * 1_000_000)
-    }
-}
-
-impl Into<MicroSeconds> for MilliSeconds {
-    fn into(self) -> MicroSeconds {
-        MicroSeconds(self.0 * 1_000)
-    }
+/// This is a convenience shortcut for [`Hertz::mhz`]
+pub fn mhz(megahertz: u32) -> Hertz {
+    Hertz::mhz(megahertz)
 }

--- a/embassy-stm32/src/timer/mod.rs
+++ b/embassy-stm32/src/timer/mod.rs
@@ -23,7 +23,7 @@ pub(crate) mod sealed {
 
         fn reset(&mut self);
 
-        fn set_frequency<F: Into<Hertz>>(&mut self, frequency: F);
+        fn set_frequency(&mut self, frequency: Hertz);
 
         fn clear_update_interrupt(&mut self) -> bool;
 
@@ -37,7 +37,7 @@ pub(crate) mod sealed {
     pub trait GeneralPurpose32bitInstance: GeneralPurpose16bitInstance {
         fn regs_gp32() -> crate::pac::timer::TimGp32;
 
-        fn set_frequency<F: Into<Hertz>>(&mut self, frequency: F);
+        fn set_frequency(&mut self, frequency: Hertz);
     }
 
     pub trait AdvancedControlInstance: Basic16bitInstance {
@@ -81,9 +81,9 @@ macro_rules! impl_basic_16bit_timer {
                 }
             }
 
-            fn set_frequency<F: Into<Hertz>>(&mut self, frequency: F) {
+            fn set_frequency(&mut self, frequency: Hertz) {
                 use core::convert::TryInto;
-                let f = frequency.into().0;
+                let f = frequency.0;
                 let timer_f = Self::frequency().0;
                 let pclk_ticks_per_timer_period = timer_f / f;
                 let psc: u16 = unwrap!(((pclk_ticks_per_timer_period - 1) / (1 << 16)).try_into());
@@ -132,9 +132,9 @@ macro_rules! impl_32bit_timer {
                 crate::pac::$inst
             }
 
-            fn set_frequency<F: Into<Hertz>>(&mut self, frequency: F) {
+            fn set_frequency(&mut self, frequency: Hertz) {
                 use core::convert::TryInto;
-                let f = frequency.into().0;
+                let f = frequency.0;
                 let timer_f = Self::frequency().0;
                 let pclk_ticks_per_timer_period = (timer_f / f) as u64;
                 let psc: u16 = unwrap!(((pclk_ticks_per_timer_period - 1) / (1 << 32)).try_into());

--- a/examples/stm32f3/src/bin/usb_serial.rs
+++ b/examples/stm32f3/src/bin/usb_serial.rs
@@ -6,7 +6,7 @@ use defmt::{panic, *};
 use embassy::executor::Spawner;
 use embassy::time::{Duration, Timer};
 use embassy_stm32::gpio::{Level, Output, Speed};
-use embassy_stm32::time::U32Ext;
+use embassy_stm32::time::mhz;
 use embassy_stm32::usb::{Driver, Instance};
 use embassy_stm32::{interrupt, Config, Peripherals};
 use embassy_usb::driver::EndpointError;
@@ -18,10 +18,10 @@ use {defmt_rtt as _, panic_probe as _};
 fn config() -> Config {
     let mut config = Config::default();
 
-    config.rcc.hse = Some(8.mhz().into());
-    config.rcc.sysclk = Some(48.mhz().into());
-    config.rcc.pclk1 = Some(24.mhz().into());
-    config.rcc.pclk2 = Some(24.mhz().into());
+    config.rcc.hse = Some(mhz(8));
+    config.rcc.sysclk = Some(mhz(48));
+    config.rcc.pclk1 = Some(mhz(24));
+    config.rcc.pclk2 = Some(mhz(24));
     config.rcc.pll48 = true;
 
     config

--- a/examples/stm32f4/src/bin/pwm.rs
+++ b/examples/stm32f4/src/bin/pwm.rs
@@ -7,7 +7,7 @@ use embassy::executor::Spawner;
 use embassy::time::{Duration, Timer};
 use embassy_stm32::pwm::simple_pwm::SimplePwm;
 use embassy_stm32::pwm::Channel;
-use embassy_stm32::time::U32Ext;
+use embassy_stm32::time::khz;
 use embassy_stm32::Peripherals;
 use {defmt_rtt as _, panic_probe as _};
 
@@ -15,7 +15,7 @@ use {defmt_rtt as _, panic_probe as _};
 async fn main(_spawner: Spawner, p: Peripherals) {
     info!("Hello World!");
 
-    let mut pwm = SimplePwm::new_1ch(p.TIM1, p.PE9, 10000.hz());
+    let mut pwm = SimplePwm::new_1ch(p.TIM1, p.PE9, khz(10));
     let max = pwm.get_max_duty();
     pwm.enable(Channel::Ch1);
 

--- a/examples/stm32f4/src/bin/sdmmc.rs
+++ b/examples/stm32f4/src/bin/sdmmc.rs
@@ -5,13 +5,13 @@
 use defmt::*;
 use embassy::executor::Spawner;
 use embassy_stm32::sdmmc::Sdmmc;
-use embassy_stm32::time::U32Ext;
+use embassy_stm32::time::mhz;
 use embassy_stm32::{interrupt, Config, Peripherals};
 use {defmt_rtt as _, panic_probe as _};
 
 fn config() -> Config {
     let mut config = Config::default();
-    config.rcc.sys_ck = Some(48.mhz().into());
+    config.rcc.sys_ck = Some(mhz(48));
     config
 }
 
@@ -32,7 +32,7 @@ async fn main(_spawner: Spawner, p: Peripherals) -> ! {
     // Should print 400kHz for initialization
     info!("Configured clock: {}", sdmmc.clock().0);
 
-    unwrap!(sdmmc.init_card(25.mhz()).await);
+    unwrap!(sdmmc.init_card(mhz(25)).await);
 
     let card = unwrap!(sdmmc.card());
 

--- a/examples/stm32f7/src/bin/eth.rs
+++ b/examples/stm32f7/src/bin/eth.rs
@@ -12,7 +12,7 @@ use embassy_stm32::eth::generic_smi::GenericSMI;
 use embassy_stm32::eth::{Ethernet, State};
 use embassy_stm32::peripherals::ETH;
 use embassy_stm32::rng::Rng;
-use embassy_stm32::time::U32Ext;
+use embassy_stm32::time::mhz;
 use embassy_stm32::{interrupt, Config, Peripherals};
 use embedded_io::asynch::Write;
 use rand_core::RngCore;
@@ -35,7 +35,7 @@ async fn net_task(stack: &'static Stack<Device>) -> ! {
 
 fn config() -> Config {
     let mut config = Config::default();
-    config.rcc.sys_ck = Some(200.mhz().into());
+    config.rcc.sys_ck = Some(mhz(200));
     config
 }
 

--- a/examples/stm32f7/src/bin/sdmmc.rs
+++ b/examples/stm32f7/src/bin/sdmmc.rs
@@ -5,13 +5,13 @@
 use defmt::*;
 use embassy::executor::Spawner;
 use embassy_stm32::sdmmc::Sdmmc;
-use embassy_stm32::time::U32Ext;
+use embassy_stm32::time::mhz;
 use embassy_stm32::{interrupt, Config, Peripherals};
 use {defmt_rtt as _, panic_probe as _};
 
 fn config() -> Config {
     let mut config = Config::default();
-    config.rcc.sys_ck = Some(200.mhz().into());
+    config.rcc.sys_ck = Some(mhz(200));
     config
 }
 
@@ -32,7 +32,7 @@ async fn main(_spawner: Spawner, p: Peripherals) -> ! {
     // Should print 400kHz for initialization
     info!("Configured clock: {}", sdmmc.clock().0);
 
-    unwrap!(sdmmc.init_card(25.mhz()).await);
+    unwrap!(sdmmc.init_card(mhz(25)).await);
 
     let card = unwrap!(sdmmc.card());
 

--- a/examples/stm32g4/src/bin/pwm.rs
+++ b/examples/stm32g4/src/bin/pwm.rs
@@ -7,7 +7,7 @@ use embassy::executor::Spawner;
 use embassy::time::{Duration, Timer};
 use embassy_stm32::pwm::simple_pwm::SimplePwm;
 use embassy_stm32::pwm::Channel;
-use embassy_stm32::time::U32Ext;
+use embassy_stm32::time::khz;
 use embassy_stm32::Peripherals;
 use {defmt_rtt as _, panic_probe as _};
 
@@ -15,7 +15,7 @@ use {defmt_rtt as _, panic_probe as _};
 async fn main(_spawner: Spawner, p: Peripherals) {
     info!("Hello World!");
 
-    let mut pwm = SimplePwm::new_1ch(p.TIM2, p.PA5, 10000.hz());
+    let mut pwm = SimplePwm::new_1ch(p.TIM2, p.PA5, khz(10));
     let max = pwm.get_max_duty();
     pwm.enable(Channel::Ch1);
 

--- a/examples/stm32h7/src/bin/adc.rs
+++ b/examples/stm32h7/src/bin/adc.rs
@@ -7,15 +7,15 @@ use embassy::executor::Spawner;
 use embassy::time::{Delay, Duration, Timer};
 use embassy_stm32::adc::{Adc, SampleTime};
 use embassy_stm32::rcc::AdcClockSource;
-use embassy_stm32::time::U32Ext;
+use embassy_stm32::time::mhz;
 use embassy_stm32::{Config, Peripherals};
 use {defmt_rtt as _, panic_probe as _};
 
 pub fn config() -> Config {
     let mut config = Config::default();
-    config.rcc.sys_ck = Some(400.mhz().into());
-    config.rcc.hclk = Some(200.mhz().into());
-    config.rcc.per_ck = Some(64.mhz().into());
+    config.rcc.sys_ck = Some(mhz(400));
+    config.rcc.hclk = Some(mhz(200));
+    config.rcc.per_ck = Some(mhz(64));
     config.rcc.adc_clock_source = AdcClockSource::PerCk;
     config
 }

--- a/examples/stm32h7/src/bin/camera.rs
+++ b/examples/stm32h7/src/bin/camera.rs
@@ -8,20 +8,20 @@ use embassy_stm32::dcmi::{self, *};
 use embassy_stm32::gpio::{Level, Output, Speed};
 use embassy_stm32::i2c::I2c;
 use embassy_stm32::rcc::{Mco, Mco1Source, McoClock};
-use embassy_stm32::time::U32Ext;
+use embassy_stm32::time::{khz, mhz};
 use embassy_stm32::{interrupt, Config, Peripherals};
 use {defmt_rtt as _, panic_probe as _};
 
 #[allow(unused)]
 pub fn config() -> Config {
     let mut config = Config::default();
-    config.rcc.sys_ck = Some(400.mhz().into());
-    config.rcc.hclk = Some(400.mhz().into());
-    config.rcc.pll1.q_ck = Some(100.mhz().into());
-    config.rcc.pclk1 = Some(100.mhz().into());
-    config.rcc.pclk2 = Some(100.mhz().into());
-    config.rcc.pclk3 = Some(100.mhz().into());
-    config.rcc.pclk4 = Some(100.mhz().into());
+    config.rcc.sys_ck = Some(mhz(400));
+    config.rcc.hclk = Some(mhz(400));
+    config.rcc.pll1.q_ck = Some(mhz(100));
+    config.rcc.pclk1 = Some(mhz(100));
+    config.rcc.pclk2 = Some(mhz(100));
+    config.rcc.pclk3 = Some(mhz(100));
+    config.rcc.pclk4 = Some(mhz(100));
     config
 }
 
@@ -39,7 +39,7 @@ async fn main(_spawner: Spawner, p: Peripherals) {
 
     let mut led = Output::new(p.PE3, Level::High, Speed::Low);
     let i2c_irq = interrupt::take!(I2C1_EV);
-    let cam_i2c = I2c::new(p.I2C1, p.PB8, p.PB9, i2c_irq, p.DMA1_CH1, p.DMA1_CH2, 100u32.khz());
+    let cam_i2c = I2c::new(p.I2C1, p.PB8, p.PB9, i2c_irq, p.DMA1_CH1, p.DMA1_CH2, khz(100));
 
     let mut camera = Ov7725::new(cam_i2c, mco);
 

--- a/examples/stm32h7/src/bin/dac.rs
+++ b/examples/stm32h7/src/bin/dac.rs
@@ -5,15 +5,15 @@
 use cortex_m_rt::entry;
 use defmt::*;
 use embassy_stm32::dac::{Channel, Dac, Value};
-use embassy_stm32::time::U32Ext;
+use embassy_stm32::time::mhz;
 use embassy_stm32::Config;
 use {defmt_rtt as _, panic_probe as _};
 
 pub fn config() -> Config {
     let mut config = Config::default();
-    config.rcc.sys_ck = Some(400.mhz().into());
-    config.rcc.hclk = Some(200.mhz().into());
-    config.rcc.pll1.q_ck = Some(100.mhz().into());
+    config.rcc.sys_ck = Some(mhz(400));
+    config.rcc.hclk = Some(mhz(200));
+    config.rcc.pll1.q_ck = Some(mhz(100));
     config
 }
 

--- a/examples/stm32h7/src/bin/eth.rs
+++ b/examples/stm32h7/src/bin/eth.rs
@@ -12,7 +12,7 @@ use embassy_stm32::eth::generic_smi::GenericSMI;
 use embassy_stm32::eth::{Ethernet, State};
 use embassy_stm32::peripherals::ETH;
 use embassy_stm32::rng::Rng;
-use embassy_stm32::time::U32Ext;
+use embassy_stm32::time::mhz;
 use embassy_stm32::{interrupt, Config, Peripherals};
 use embedded_io::asynch::Write;
 use rand_core::RngCore;
@@ -35,9 +35,9 @@ async fn net_task(stack: &'static Stack<Device>) -> ! {
 
 pub fn config() -> Config {
     let mut config = Config::default();
-    config.rcc.sys_ck = Some(400.mhz().into());
-    config.rcc.hclk = Some(200.mhz().into());
-    config.rcc.pll1.q_ck = Some(100.mhz().into());
+    config.rcc.sys_ck = Some(mhz(400));
+    config.rcc.hclk = Some(mhz(200));
+    config.rcc.pll1.q_ck = Some(mhz(100));
     config
 }
 

--- a/examples/stm32h7/src/bin/fmc.rs
+++ b/examples/stm32h7/src/bin/fmc.rs
@@ -6,15 +6,15 @@ use defmt::*;
 use embassy::executor::Spawner;
 use embassy::time::{Delay, Duration, Timer};
 use embassy_stm32::fmc::Fmc;
-use embassy_stm32::time::U32Ext;
+use embassy_stm32::time::mhz;
 use embassy_stm32::{Config, Peripherals};
 use {defmt_rtt as _, panic_probe as _};
 
 pub fn config() -> Config {
     let mut config = Config::default();
-    config.rcc.sys_ck = Some(400.mhz().into());
-    config.rcc.hclk = Some(200.mhz().into());
-    config.rcc.pll1.q_ck = Some(100.mhz().into());
+    config.rcc.sys_ck = Some(mhz(400));
+    config.rcc.hclk = Some(mhz(200));
+    config.rcc.pll1.q_ck = Some(mhz(100));
     config
 }
 

--- a/examples/stm32h7/src/bin/low_level_timer_api.rs
+++ b/examples/stm32h7/src/bin/low_level_timer_api.rs
@@ -10,19 +10,19 @@ use embassy::time::{Duration, Timer};
 use embassy_stm32::gpio::low_level::AFType;
 use embassy_stm32::gpio::Speed;
 use embassy_stm32::pwm::*;
-use embassy_stm32::time::{Hertz, U32Ext};
+use embassy_stm32::time::{khz, mhz, Hertz};
 use embassy_stm32::{unborrow, Config, Peripherals, Unborrow};
 use {defmt_rtt as _, panic_probe as _};
 
 pub fn config() -> Config {
     let mut config = Config::default();
-    config.rcc.sys_ck = Some(400.mhz().into());
-    config.rcc.hclk = Some(400.mhz().into());
-    config.rcc.pll1.q_ck = Some(100.mhz().into());
-    config.rcc.pclk1 = Some(100.mhz().into());
-    config.rcc.pclk2 = Some(100.mhz().into());
-    config.rcc.pclk3 = Some(100.mhz().into());
-    config.rcc.pclk4 = Some(100.mhz().into());
+    config.rcc.sys_ck = Some(mhz(400));
+    config.rcc.hclk = Some(mhz(400));
+    config.rcc.pll1.q_ck = Some(mhz(100));
+    config.rcc.pclk1 = Some(mhz(100));
+    config.rcc.pclk2 = Some(mhz(100));
+    config.rcc.pclk3 = Some(mhz(100));
+    config.rcc.pclk4 = Some(mhz(100));
     config
 }
 
@@ -30,7 +30,7 @@ pub fn config() -> Config {
 async fn main(_spawner: Spawner, p: Peripherals) {
     info!("Hello World!");
 
-    let mut pwm = SimplePwm32::new(p.TIM5, p.PA0, p.PA1, p.PA2, p.PA3, 10000.hz());
+    let mut pwm = SimplePwm32::new(p.TIM5, p.PA0, p.PA1, p.PA2, p.PA3, khz(10));
     let max = pwm.get_max_duty();
     pwm.enable(Channel::Ch1);
 
@@ -54,13 +54,13 @@ pub struct SimplePwm32<'d, T: CaptureCompare32bitInstance> {
 }
 
 impl<'d, T: CaptureCompare32bitInstance> SimplePwm32<'d, T> {
-    pub fn new<F: Into<Hertz>>(
+    pub fn new(
         tim: impl Unborrow<Target = T> + 'd,
         ch1: impl Unborrow<Target = impl Channel1Pin<T>> + 'd,
         ch2: impl Unborrow<Target = impl Channel2Pin<T>> + 'd,
         ch3: impl Unborrow<Target = impl Channel3Pin<T>> + 'd,
         ch4: impl Unborrow<Target = impl Channel4Pin<T>> + 'd,
-        freq: F,
+        freq: Hertz,
     ) -> Self {
         unborrow!(tim, ch1, ch2, ch3, ch4);
 
@@ -115,7 +115,7 @@ impl<'d, T: CaptureCompare32bitInstance> SimplePwm32<'d, T> {
         }
     }
 
-    pub fn set_freq<F: Into<Hertz>>(&mut self, freq: F) {
+    pub fn set_freq(&mut self, freq: Hertz) {
         <T as embassy_stm32::timer::low_level::GeneralPurpose32bitInstance>::set_frequency(&mut self.inner, freq);
     }
 

--- a/examples/stm32h7/src/bin/pwm.rs
+++ b/examples/stm32h7/src/bin/pwm.rs
@@ -7,19 +7,19 @@ use embassy::executor::Spawner;
 use embassy::time::{Duration, Timer};
 use embassy_stm32::pwm::simple_pwm::SimplePwm;
 use embassy_stm32::pwm::Channel;
-use embassy_stm32::time::U32Ext;
+use embassy_stm32::time::{khz, mhz};
 use embassy_stm32::{Config, Peripherals};
 use {defmt_rtt as _, panic_probe as _};
 
 pub fn config() -> Config {
     let mut config = Config::default();
-    config.rcc.sys_ck = Some(400.mhz().into());
-    config.rcc.hclk = Some(400.mhz().into());
-    config.rcc.pll1.q_ck = Some(100.mhz().into());
-    config.rcc.pclk1 = Some(100.mhz().into());
-    config.rcc.pclk2 = Some(100.mhz().into());
-    config.rcc.pclk3 = Some(100.mhz().into());
-    config.rcc.pclk4 = Some(100.mhz().into());
+    config.rcc.sys_ck = Some(mhz(400));
+    config.rcc.hclk = Some(mhz(400));
+    config.rcc.pll1.q_ck = Some(mhz(100));
+    config.rcc.pclk1 = Some(mhz(100));
+    config.rcc.pclk2 = Some(mhz(100));
+    config.rcc.pclk3 = Some(mhz(100));
+    config.rcc.pclk4 = Some(mhz(100));
     config
 }
 
@@ -27,7 +27,7 @@ pub fn config() -> Config {
 async fn main(_spawner: Spawner, p: Peripherals) {
     info!("Hello World!");
 
-    let mut pwm = SimplePwm::new_1ch(p.TIM3, p.PA6, 10000.hz());
+    let mut pwm = SimplePwm::new_1ch(p.TIM3, p.PA6, khz(10));
     let max = pwm.get_max_duty();
     pwm.enable(Channel::Ch1);
 

--- a/examples/stm32h7/src/bin/sdmmc.rs
+++ b/examples/stm32h7/src/bin/sdmmc.rs
@@ -5,13 +5,13 @@
 use defmt::*;
 use embassy::executor::Spawner;
 use embassy_stm32::sdmmc::Sdmmc;
-use embassy_stm32::time::U32Ext;
+use embassy_stm32::time::mhz;
 use embassy_stm32::{interrupt, Config, Peripherals};
 use {defmt_rtt as _, panic_probe as _};
 
 fn config() -> Config {
     let mut config = Config::default();
-    config.rcc.sys_ck = Some(200.mhz().into());
+    config.rcc.sys_ck = Some(mhz(200));
     config
 }
 
@@ -31,7 +31,7 @@ async fn main(_spawner: Spawner, p: Peripherals) -> ! {
     // Should print 400kHz for initialization
     info!("Configured clock: {}", sdmmc.clock().0);
 
-    unwrap!(sdmmc.init_card(25.mhz()).await);
+    unwrap!(sdmmc.init_card(mhz(25)).await);
 
     let card = unwrap!(sdmmc.card());
 

--- a/examples/stm32h7/src/bin/spi.rs
+++ b/examples/stm32h7/src/bin/spi.rs
@@ -11,16 +11,16 @@ use embassy::executor::Executor;
 use embassy::util::Forever;
 use embassy_stm32::dma::NoDma;
 use embassy_stm32::peripherals::SPI3;
-use embassy_stm32::time::U32Ext;
+use embassy_stm32::time::mhz;
 use embassy_stm32::{spi, Config};
 use heapless::String;
 use {defmt_rtt as _, panic_probe as _};
 
 pub fn config() -> Config {
     let mut config = Config::default();
-    config.rcc.sys_ck = Some(400.mhz().into());
-    config.rcc.hclk = Some(200.mhz().into());
-    config.rcc.pll1.q_ck = Some(100.mhz().into());
+    config.rcc.sys_ck = Some(mhz(400));
+    config.rcc.hclk = Some(mhz(200));
+    config.rcc.pll1.q_ck = Some(mhz(100));
     config
 }
 
@@ -54,7 +54,7 @@ fn main() -> ! {
         p.PB4,
         NoDma,
         NoDma,
-        1.mhz(),
+        mhz(1),
         spi::Config::default(),
     );
 

--- a/examples/stm32h7/src/bin/spi_dma.rs
+++ b/examples/stm32h7/src/bin/spi_dma.rs
@@ -10,16 +10,16 @@ use defmt::*;
 use embassy::executor::Executor;
 use embassy::util::Forever;
 use embassy_stm32::peripherals::{DMA1_CH3, DMA1_CH4, SPI3};
-use embassy_stm32::time::U32Ext;
+use embassy_stm32::time::mhz;
 use embassy_stm32::{spi, Config};
 use heapless::String;
 use {defmt_rtt as _, panic_probe as _};
 
 pub fn config() -> Config {
     let mut config = Config::default();
-    config.rcc.sys_ck = Some(400.mhz().into());
-    config.rcc.hclk = Some(200.mhz().into());
-    config.rcc.pll1.q_ck = Some(100.mhz().into());
+    config.rcc.sys_ck = Some(mhz(400));
+    config.rcc.hclk = Some(mhz(200));
+    config.rcc.pll1.q_ck = Some(mhz(100));
     config
 }
 
@@ -50,7 +50,7 @@ fn main() -> ! {
         p.PB4,
         p.DMA1_CH3,
         p.DMA1_CH4,
-        1.mhz(),
+        mhz(1),
         spi::Config::default(),
     );
 

--- a/examples/stm32l0/src/bin/lorawan.rs
+++ b/examples/stm32l0/src/bin/lorawan.rs
@@ -11,7 +11,7 @@ use embassy_lora::LoraTimer;
 use embassy_stm32::exti::ExtiInput;
 use embassy_stm32::gpio::{Input, Level, Output, Pull, Speed};
 use embassy_stm32::rng::Rng;
-use embassy_stm32::time::U32Ext;
+use embassy_stm32::time::khz;
 use embassy_stm32::{spi, Peripherals};
 use lorawan::default_crypto::DefaultFactory as Crypto;
 use lorawan_device::async_device::{region, Device, JoinMode};
@@ -34,7 +34,7 @@ async fn main(_spawner: embassy::executor::Spawner, p: Peripherals) {
         p.PA6,
         p.DMA1_CH3,
         p.DMA1_CH2,
-        200_000.hz(),
+        khz(200),
         spi::Config::default(),
     );
 


### PR DESCRIPTION
- Remove unused `MilliSeconds`, `MicroSeconds`, and `NanoSeconds` types
- Remove `Bps`, `KiloHertz`, and `MegaHertz` types that were only used
for converting to `Hertz`
- Replace all instances of `impl Into<Hertz>` with `Hertz`
- Add `hz`, `khz`, and `mhz` methods to `Hertz`, as well as
free function shortcuts
- Remove `U32Ext` extension trait