### PR TITLE
Add more convenience GPIO functions

### DIFF
--- a/embassy-nrf/src/gpio.rs
+++ b/embassy-nrf/src/gpio.rs
@@ -165,7 +165,7 @@ impl<'d, T: Pin> Output<'d, T> {
 
     /// What level output is set to
     #[inline]
-    pub fn get_set_level(&self) -> Level {
+    pub fn get_output_level(&self) -> Level {
         self.pin.is_set_high().into()
     }
 }
@@ -323,7 +323,7 @@ impl<'d, T: Pin> Flex<'d, T> {
 
     /// What level output is set to
     #[inline]
-    pub fn get_set_level(&self) -> Level {
+    pub fn get_output_level(&self) -> Level {
         self.is_set_high().into()
     }
 }

--- a/embassy-nrf/src/gpio.rs
+++ b/embassy-nrf/src/gpio.rs
@@ -59,7 +59,7 @@ impl<'d, T: Pin> Input<'d, T> {
     /// Returns current pin level
     #[inline]
     pub fn get_level(&self) -> Level {
-        self.pin.is_high().into()
+        self.pin.get_level()
     }
 }
 
@@ -145,10 +145,7 @@ impl<'d, T: Pin> Output<'d, T> {
     /// Set the output level.
     #[inline]
     pub fn set_level(&mut self, level: Level) {
-        match level {
-            Level::Low => self.pin.set_low(),
-            Level::High => self.pin.set_high(),
-        }
+        self.pin.set_level(level)
     }
 
     /// Is the output pin set as high?
@@ -166,7 +163,7 @@ impl<'d, T: Pin> Output<'d, T> {
     /// What level output is set to
     #[inline]
     pub fn get_output_level(&self) -> Level {
-        self.pin.is_set_high().into()
+        self.pin.get_output_level()
     }
 }
 

--- a/embassy-rp/src/gpio.rs
+++ b/embassy-rp/src/gpio.rs
@@ -129,7 +129,7 @@ impl<'d, T: Pin> Output<'d, T> {
 
     /// What level output is set to
     #[inline]
-    pub fn get_set_level(&self) -> Level {
+    pub fn get_output_level(&self) -> Level {
         self.pin.is_set_high().into()
     }
 
@@ -194,7 +194,7 @@ impl<'d, T: Pin> OutputOpenDrain<'d, T> {
 
     /// What level output is set to
     #[inline]
-    pub fn get_set_level(&self) -> Level {
+    pub fn get_output_level(&self) -> Level {
         self.is_set_high().into()
     }
 
@@ -334,7 +334,7 @@ impl<'d, T: Pin> Flex<'d, T> {
 
     /// What level output is set to
     #[inline]
-    pub fn get_set_level(&self) -> Level {
+    pub fn get_output_level(&self) -> Level {
         self.is_set_high().into()
     }
 

--- a/embassy-rp/src/gpio.rs
+++ b/embassy-rp/src/gpio.rs
@@ -14,6 +14,24 @@ pub enum Level {
     High,
 }
 
+impl From<bool> for Level {
+    fn from(val: bool) -> Self {
+        match val {
+            true => Self::High,
+            false => Self::Low,
+        }
+    }
+}
+
+impl Into<bool> for Level {
+    fn into(self) -> bool {
+        match self {
+            Level::Low => false,
+            Level::High => true,
+        }
+    }
+}
+
 /// Represents a pull setting for an input.
 #[derive(Debug, Eq, PartialEq)]
 pub enum Pull {
@@ -34,6 +52,7 @@ pub struct Input<'d, T: Pin> {
 }
 
 impl<'d, T: Pin> Input<'d, T> {
+    #[inline]
     pub fn new(pin: impl Unborrow<Target = T> + 'd, pull: Pull) -> Self {
         let mut pin = Flex::new(pin);
         pin.set_as_input();
@@ -41,12 +60,20 @@ impl<'d, T: Pin> Input<'d, T> {
         Self { pin }
     }
 
+    #[inline]
     pub fn is_high(&self) -> bool {
         self.pin.is_high()
     }
 
+    #[inline]
     pub fn is_low(&self) -> bool {
         self.pin.is_low()
+    }
+
+    /// Returns current pin level
+    #[inline]
+    pub fn get_level(&self) -> Level {
+        self.pin.is_high().into()
     }
 }
 
@@ -79,6 +106,15 @@ impl<'d, T: Pin> Output<'d, T> {
         self.pin.set_low()
     }
 
+    /// Set the output level.
+    #[inline]
+    pub fn set_level(&mut self, level: Level) {
+        match level {
+            Level::Low => self.pin.set_low(),
+            Level::High => self.pin.set_high(),
+        }
+    }
+
     /// Is the output pin set as high?
     #[inline]
     pub fn is_set_high(&self) -> bool {
@@ -89,6 +125,12 @@ impl<'d, T: Pin> Output<'d, T> {
     #[inline]
     pub fn is_set_low(&self) -> bool {
         self.pin.is_set_low()
+    }
+
+    /// What level output is set to
+    #[inline]
+    pub fn get_set_level(&self) -> Level {
+        self.pin.is_set_high().into()
     }
 
     /// Toggle pin output
@@ -129,6 +171,15 @@ impl<'d, T: Pin> OutputOpenDrain<'d, T> {
         self.pin.set_as_output()
     }
 
+    /// Set the output level.
+    #[inline]
+    pub fn set_level(&mut self, level: Level) {
+        match level {
+            Level::Low => self.set_low(),
+            Level::High => self.set_high(),
+        }
+    }
+
     /// Is the output level high?
     #[inline]
     pub fn is_set_high(&self) -> bool {
@@ -139,6 +190,12 @@ impl<'d, T: Pin> OutputOpenDrain<'d, T> {
     #[inline]
     pub fn is_set_low(&self) -> bool {
         self.pin.is_set_as_output()
+    }
+
+    /// What level output is set to
+    #[inline]
+    pub fn get_set_level(&self) -> Level {
+        self.is_set_high().into()
     }
 
     /// Toggle pin output
@@ -236,6 +293,12 @@ impl<'d, T: Pin> Flex<'d, T> {
         unsafe { self.pin.sio_in().read() & self.bit() == 0 }
     }
 
+    /// Returns current pin level
+    #[inline]
+    pub fn get_level(&self) -> Level {
+        self.is_high().into()
+    }
+
     /// Set the output as high.
     #[inline]
     pub fn set_high(&mut self) {
@@ -248,6 +311,15 @@ impl<'d, T: Pin> Flex<'d, T> {
         unsafe { self.pin.sio_out().value_clr().write_value(self.bit()) }
     }
 
+    /// Set the output level.
+    #[inline]
+    pub fn set_level(&mut self, level: Level) {
+        match level {
+            Level::Low => self.set_low(),
+            Level::High => self.set_high(),
+        }
+    }
+
     /// Is the output level high?
     #[inline]
     pub fn is_set_high(&self) -> bool {
@@ -258,6 +330,12 @@ impl<'d, T: Pin> Flex<'d, T> {
     #[inline]
     pub fn is_set_low(&self) -> bool {
         !self.is_set_high()
+    }
+
+    /// What level output is set to
+    #[inline]
+    pub fn get_set_level(&self) -> Level {
+        self.is_set_high().into()
     }
 
     /// Toggle pin output

--- a/embassy-rp/src/gpio.rs
+++ b/embassy-rp/src/gpio.rs
@@ -73,7 +73,7 @@ impl<'d, T: Pin> Input<'d, T> {
     /// Returns current pin level
     #[inline]
     pub fn get_level(&self) -> Level {
-        self.pin.is_high().into()
+        self.pin.get_level()
     }
 }
 
@@ -109,10 +109,7 @@ impl<'d, T: Pin> Output<'d, T> {
     /// Set the output level.
     #[inline]
     pub fn set_level(&mut self, level: Level) {
-        match level {
-            Level::Low => self.pin.set_low(),
-            Level::High => self.pin.set_high(),
-        }
+        self.pin.set_level(level)
     }
 
     /// Is the output pin set as high?
@@ -130,7 +127,7 @@ impl<'d, T: Pin> Output<'d, T> {
     /// What level output is set to
     #[inline]
     pub fn get_output_level(&self) -> Level {
-        self.pin.is_set_high().into()
+        self.pin.get_output_level()
     }
 
     /// Toggle pin output

--- a/embassy-stm32/src/gpio.rs
+++ b/embassy-stm32/src/gpio.rs
@@ -143,10 +143,7 @@ impl<'d, T: Pin> Flex<'d, T> {
 
     #[inline]
     pub fn get_level(&self) -> Level {
-        match self.is_high() {
-            true => Level::High,
-            false => Level::Low,
-        }
+        self.is_high().into()
     }
 
     #[inline]
@@ -164,10 +161,7 @@ impl<'d, T: Pin> Flex<'d, T> {
     /// What level output is set to
     #[inline]
     pub fn get_set_level(&self) -> Level {
-        match self.is_set_high() {
-            true => Level::High,
-            false => Level::Low,
-        }
+        self.is_set_high().into()
     }
 
     #[inline]
@@ -309,10 +303,7 @@ impl<'d, T: Pin> Input<'d, T> {
 
     #[inline]
     pub fn get_level(&self) -> Level {
-        match self.pin.is_high() {
-            true => Level::High,
-            false => Level::Low,
-        }
+        self.pin.is_high().into()
     }
 }
 
@@ -395,10 +386,7 @@ impl<'d, T: Pin> Output<'d, T> {
     /// What level output is set to
     #[inline]
     pub fn get_set_level(&self) -> Level {
-        match self.pin.is_set_high() {
-            true => Level::High,
-            false => Level::Low,
-        }
+        self.pin.is_set_high().into()
     }
 
     /// Toggle pin output
@@ -440,10 +428,7 @@ impl<'d, T: Pin> OutputOpenDrain<'d, T> {
     /// Returns current pin level
     #[inline]
     pub fn get_level(&self) -> Level {
-        match self.pin.is_high() {
-            true => Level::High,
-            false => Level::Low,
-        }
+        self.pin.is_high().into()
     }
 
     /// Set the output as high.
@@ -482,10 +467,7 @@ impl<'d, T: Pin> OutputOpenDrain<'d, T> {
     /// What level output is set to
     #[inline]
     pub fn get_set_level(&self) -> Level {
-        match self.pin.is_set_high() {
-            true => Level::High,
-            false => Level::Low,
-        }
+        self.pin.is_set_high().into()
     }
 
     /// Toggle pin output

--- a/embassy-stm32/src/gpio.rs
+++ b/embassy-stm32/src/gpio.rs
@@ -303,7 +303,7 @@ impl<'d, T: Pin> Input<'d, T> {
 
     #[inline]
     pub fn get_level(&self) -> Level {
-        self.pin.is_high().into()
+        self.pin.get_level()
     }
 }
 
@@ -365,10 +365,7 @@ impl<'d, T: Pin> Output<'d, T> {
     /// Set the output level.
     #[inline]
     pub fn set_level(&mut self, level: Level) {
-        match level {
-            Level::Low => self.pin.set_low(),
-            Level::High => self.pin.set_high(),
-        }
+        self.pin.set_level(level)
     }
 
     /// Is the output pin set as high?
@@ -386,7 +383,7 @@ impl<'d, T: Pin> Output<'d, T> {
     /// What level output is set to
     #[inline]
     pub fn get_output_level(&self) -> Level {
-        self.pin.is_set_high().into()
+        self.pin.get_output_level()
     }
 
     /// Toggle pin output
@@ -428,7 +425,7 @@ impl<'d, T: Pin> OutputOpenDrain<'d, T> {
     /// Returns current pin level
     #[inline]
     pub fn get_level(&self) -> Level {
-        self.pin.is_high().into()
+        self.pin.get_level()
     }
 
     /// Set the output as high.
@@ -446,16 +443,13 @@ impl<'d, T: Pin> OutputOpenDrain<'d, T> {
     /// Set the output level.
     #[inline]
     pub fn set_level(&mut self, level: Level) {
-        match level {
-            Level::Low => self.pin.set_low(),
-            Level::High => self.pin.set_high(),
-        }
+        self.pin.set_level(level);
     }
 
     /// Is the output pin set as high?
     #[inline]
     pub fn is_set_high(&self) -> bool {
-        !self.is_set_low()
+        self.pin.is_set_high()
     }
 
     /// Is the output pin set as low?
@@ -467,7 +461,7 @@ impl<'d, T: Pin> OutputOpenDrain<'d, T> {
     /// What level output is set to
     #[inline]
     pub fn get_output_level(&self) -> Level {
-        self.pin.is_set_high().into()
+        self.pin.get_output_level()
     }
 
     /// Toggle pin output

--- a/embassy-stm32/src/gpio.rs
+++ b/embassy-stm32/src/gpio.rs
@@ -142,6 +142,14 @@ impl<'d, T: Pin> Flex<'d, T> {
     }
 
     #[inline]
+    pub fn get_level(&self) -> Level {
+        match self.is_high() {
+            true => Level::High,
+            false => Level::Low,
+        }
+    }
+
+    #[inline]
     pub fn is_set_high(&self) -> bool {
         !self.is_set_low()
     }
@@ -153,6 +161,15 @@ impl<'d, T: Pin> Flex<'d, T> {
         state == vals::Odr::LOW
     }
 
+    /// What level output is set to
+    #[inline]
+    pub fn get_set_level(&self) -> Level {
+        match self.is_set_high() {
+            true => Level::High,
+            false => Level::Low,
+        }
+    }
+
     #[inline]
     pub fn set_high(&mut self) {
         self.pin.set_high();
@@ -162,6 +179,14 @@ impl<'d, T: Pin> Flex<'d, T> {
     #[inline]
     pub fn set_low(&mut self) {
         self.pin.set_low();
+    }
+
+    #[inline]
+    pub fn set_level(&mut self, level: Level) {
+        match level {
+            Level::Low => self.pin.set_low(),
+            Level::High => self.pin.set_high(),
+        }
     }
 
     /// Toggle pin output
@@ -281,6 +306,14 @@ impl<'d, T: Pin> Input<'d, T> {
     pub fn is_low(&self) -> bool {
         self.pin.is_low()
     }
+
+    #[inline]
+    pub fn get_level(&self) -> Level {
+        match self.pin.is_high() {
+            true => Level::High,
+            false => Level::Low,
+        }
+    }
 }
 
 /// Digital input or output level.
@@ -289,6 +322,24 @@ impl<'d, T: Pin> Input<'d, T> {
 pub enum Level {
     Low,
     High,
+}
+
+impl From<bool> for Level {
+    fn from(val: bool) -> Self {
+        match val {
+            true => Self::High,
+            false => Self::Low,
+        }
+    }
+}
+
+impl Into<bool> for Level {
+    fn into(self) -> bool {
+        match self {
+            Level::Low => false,
+            Level::High => true,
+        }
+    }
 }
 
 /// GPIO output driver.
@@ -320,6 +371,15 @@ impl<'d, T: Pin> Output<'d, T> {
         self.pin.set_low();
     }
 
+    /// Set the output level.
+    #[inline]
+    pub fn set_level(&mut self, level: Level) {
+        match level {
+            Level::Low => self.pin.set_low(),
+            Level::High => self.pin.set_high(),
+        }
+    }
+
     /// Is the output pin set as high?
     #[inline]
     pub fn is_set_high(&self) -> bool {
@@ -330,6 +390,15 @@ impl<'d, T: Pin> Output<'d, T> {
     #[inline]
     pub fn is_set_low(&self) -> bool {
         self.pin.is_set_low()
+    }
+
+    /// What level output is set to
+    #[inline]
+    pub fn get_set_level(&self) -> Level {
+        match self.pin.is_set_high() {
+            true => Level::High,
+            false => Level::Low,
+        }
     }
 
     /// Toggle pin output
@@ -368,6 +437,15 @@ impl<'d, T: Pin> OutputOpenDrain<'d, T> {
         self.pin.is_low()
     }
 
+    /// Returns current pin level
+    #[inline]
+    pub fn get_level(&self) -> Level {
+        match self.pin.is_high() {
+            true => Level::High,
+            false => Level::Low,
+        }
+    }
+
     /// Set the output as high.
     #[inline]
     pub fn set_high(&mut self) {
@@ -380,6 +458,15 @@ impl<'d, T: Pin> OutputOpenDrain<'d, T> {
         self.pin.set_low();
     }
 
+    /// Set the output level.
+    #[inline]
+    pub fn set_level(&mut self, level: Level) {
+        match level {
+            Level::Low => self.pin.set_low(),
+            Level::High => self.pin.set_high(),
+        }
+    }
+
     /// Is the output pin set as high?
     #[inline]
     pub fn is_set_high(&self) -> bool {
@@ -390,6 +477,15 @@ impl<'d, T: Pin> OutputOpenDrain<'d, T> {
     #[inline]
     pub fn is_set_low(&self) -> bool {
         self.pin.is_set_low()
+    }
+
+    /// What level output is set to
+    #[inline]
+    pub fn get_set_level(&self) -> Level {
+        match self.pin.is_set_high() {
+            true => Level::High,
+            false => Level::Low,
+        }
     }
 
     /// Toggle pin output

--- a/embassy-stm32/src/gpio.rs
+++ b/embassy-stm32/src/gpio.rs
@@ -160,7 +160,7 @@ impl<'d, T: Pin> Flex<'d, T> {
 
     /// What level output is set to
     #[inline]
-    pub fn get_set_level(&self) -> Level {
+    pub fn get_output_level(&self) -> Level {
         self.is_set_high().into()
     }
 
@@ -385,7 +385,7 @@ impl<'d, T: Pin> Output<'d, T> {
 
     /// What level output is set to
     #[inline]
-    pub fn get_set_level(&self) -> Level {
+    pub fn get_output_level(&self) -> Level {
         self.pin.is_set_high().into()
     }
 
@@ -466,7 +466,7 @@ impl<'d, T: Pin> OutputOpenDrain<'d, T> {
 
     /// What level output is set to
     #[inline]
-    pub fn get_set_level(&self) -> Level {
+    pub fn get_output_level(&self) -> Level {
         self.pin.is_set_high().into()
     }
 


### PR DESCRIPTION
This reduces boilerplate code from:
```rs
if config.pin_high {
    pin.set_high()
} else {
    pin.set_low()
}
```
to
```rs
pin.set_level(config.pin_high.into());
```