### PR TITLE
F4 flash fixes

### DIFF
--- a/embassy-stm32/src/flash/f4.rs
+++ b/embassy-stm32/src/flash/f4.rs
@@ -99,9 +99,9 @@ unsafe fn get_sector(addr: u32) -> u8 {
 
 pub(crate) unsafe fn blocking_erase(from: u32, to: u32) -> Result<(), Error> {
     let start_sector = get_sector(from);
-    let end_sector = get_sector(to);
+    let end_sector = get_sector(to - 1); // end range is exclusive
 
-    for sector in start_sector..end_sector {
+    for sector in start_sector..=end_sector {
         let ret = erase_sector(sector as u8);
         if ret.is_err() {
             return ret;
@@ -114,6 +114,8 @@ pub(crate) unsafe fn blocking_erase(from: u32, to: u32) -> Result<(), Error> {
 unsafe fn erase_sector(sector: u8) -> Result<(), Error> {
     let bank = sector / SECOND_BANK_SECTOR_START as u8;
     let snb = (bank << 4) + (sector % SECOND_BANK_SECTOR_START as u8);
+
+    trace!("Erasing sector: {}", sector);
 
     pac::FLASH.cr().modify(|w| {
         w.set_ser(true);

--- a/embassy-stm32/src/flash/mod.rs
+++ b/embassy-stm32/src/flash/mod.rs
@@ -72,7 +72,7 @@ impl<'d> Flash<'d> {
         if to < from || to as usize > FLASH_END {
             return Err(Error::Size);
         }
-        if ((to - from) as usize % ERASE_SIZE) != 0 {
+        if (from as usize % ERASE_SIZE) != 0 || (to as usize % ERASE_SIZE) != 0 {
             return Err(Error::Unaligned);
         }
 

--- a/examples/stm32f4/src/bin/flash.rs
+++ b/examples/stm32f4/src/bin/flash.rs
@@ -7,36 +7,46 @@ use embassy::executor::Spawner;
 use embassy::time::{Duration, Timer};
 use embassy_stm32::flash::Flash;
 use embassy_stm32::Peripherals;
-use embedded_storage::nor_flash::{NorFlash, ReadNorFlash};
 use {defmt_rtt as _, panic_probe as _};
 
 #[embassy::main]
 async fn main(_spawner: Spawner, p: Peripherals) {
     info!("Hello Flash!");
 
-    const ADDR: u32 = 0x10_0000;
-
-    // wait a bit before accessing the flash
-    Timer::after(Duration::from_millis(300)).await;
-
     let mut f = Flash::unlock(p.FLASH);
+
+    // Sector 5
+    test_flash(&mut f, 128 * 1024, 128 * 1024);
+
+    // Sector 11, last in bank 1
+    test_flash(&mut f, (1024 - 128) * 1024, 128 * 1024);
+
+    // Sectors 12..=16, start of bank 2 (16K, 16K, 16K, 16K, 64K)
+    test_flash(&mut f, 1024 * 1024, 128 * 1024);
+
+    // Sectors 23, last in bank 2
+    test_flash(&mut f, (2048 - 128) * 1024, 128 * 1024);
+}
+
+fn test_flash(f: &mut Flash, offset: u32, size: u32) {
+    info!("Testing offset: {=u32:#X}, size: {=u32:#X}", offset, size);
 
     info!("Reading...");
     let mut buf = [0u8; 32];
-    unwrap!(f.read(ADDR, &mut buf));
+    unwrap!(f.read(offset, &mut buf));
     info!("Read: {=[u8]:x}", buf);
 
     info!("Erasing...");
-    unwrap!(f.erase(ADDR, ADDR + 128 * 1024));
+    unwrap!(f.erase(offset, offset + size));
 
     info!("Reading...");
     let mut buf = [0u8; 32];
-    unwrap!(f.read(ADDR, &mut buf));
+    unwrap!(f.read(offset, &mut buf));
     info!("Read after erase: {=[u8]:x}", buf);
 
     info!("Writing...");
     unwrap!(f.write(
-        ADDR,
+        offset,
         &[
             1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29,
             30, 31, 32
@@ -45,7 +55,7 @@ async fn main(_spawner: Spawner, p: Peripherals) {
 
     info!("Reading...");
     let mut buf = [0u8; 32];
-    unwrap!(f.read(ADDR, &mut buf));
+    unwrap!(f.read(offset, &mut buf));
     info!("Read: {=[u8]:x}", buf);
     assert_eq!(
         &buf[..],

--- a/examples/stm32f4/src/bin/flash.rs
+++ b/examples/stm32f4/src/bin/flash.rs
@@ -7,6 +7,7 @@ use embassy::executor::Spawner;
 use embassy::time::{Duration, Timer};
 use embassy_stm32::flash::Flash;
 use embassy_stm32::Peripherals;
+use embedded_storage::nor_flash::{NorFlash, ReadNorFlash};
 use {defmt_rtt as _, panic_probe as _};
 
 #[embassy::main]
@@ -18,11 +19,8 @@ async fn main(_spawner: Spawner, p: Peripherals) {
     // Sector 5
     test_flash(&mut f, 128 * 1024, 128 * 1024);
 
-    // Sector 11, last in bank 1
-    test_flash(&mut f, (1024 - 128) * 1024, 128 * 1024);
-
-    // Sectors 12..=16, start of bank 2 (16K, 16K, 16K, 16K, 64K)
-    test_flash(&mut f, 1024 * 1024, 128 * 1024);
+    // Sectors 11..=16, across banks (128K, 16K, 16K, 16K, 16K, 64K)
+    test_flash(&mut f, (1024 - 128) * 1024, 256 * 1024);
 
     // Sectors 23, last in bank 2
     test_flash(&mut f, (2048 - 128) * 1024, 128 * 1024);

--- a/examples/stm32f4/src/bin/flash.rs
+++ b/examples/stm32f4/src/bin/flash.rs
@@ -4,7 +4,6 @@
 
 use defmt::{info, unwrap};
 use embassy::executor::Spawner;
-use embassy::time::{Duration, Timer};
 use embassy_stm32::flash::Flash;
 use embassy_stm32::Peripherals;
 use embedded_storage::nor_flash::{NorFlash, ReadNorFlash};


### PR DESCRIPTION
This discontinuous flash sector layout is too cursed and I left some mistakes in last PR. Erasing last sector did not work and it wasn't possible to erase between memory banks for 1MB dual-bank devices. So I changed the erase function to iterate over memory addresses (which is continuous) instead of sector numbers.

It should also be possible to implement erase across memory banks for H7, but it requires special handling for write too. I don't have an H7 to test now so left it as is.

I wasn't sure how to add tests to `embassy-stm32` and it seems that there are none, except for `subghz`, but no test runner? Anyway, I tested the `get_sector` on playground: https://play.rust-lang.org/?version=stable&mode=debug&edition=2021&gist=13b59339fe6c70a3249e6183e81f869e

Also fixed erase alignment requirements on `Flash::blocking_erase()`, as it previously only checked alignment on size, but not on offsets.

P.S. the diff is a bit messed up, I recommend looking at files directly