### PR TITLE
Rename XXBusDevice to XXDevice.

### DIFF
--- a/embassy-embedded-hal/src/shared_bus/asynch/spi.rs
+++ b/embassy-embedded-hal/src/shared_bus/asynch/spi.rs
@@ -3,7 +3,7 @@
 //! # Example (nrf52)
 //!
 //! ```rust
-//! use embassy_embedded_hal::shared_bus::spi::SpiBusDevice;
+//! use embassy_embedded_hal::shared_bus::spi::SpiDevice;
 //! use embassy::mutex::Mutex;
 //! use embassy::blocking_mutex::raw::ThreadModeRawMutex;
 //!
@@ -17,12 +17,12 @@
 //!
 //! // Device 1, using embedded-hal-async compatible driver for ST7735 LCD display
 //! let cs_pin1 = Output::new(p.P0_24, Level::Low, OutputDrive::Standard);
-//! let spi_dev1 = SpiBusDevice::new(spi_bus, cs_pin1);
+//! let spi_dev1 = SpiDevice::new(spi_bus, cs_pin1);
 //! let display1 = ST7735::new(spi_dev1, dc1, rst1, Default::default(), 160, 128);
 //!
 //! // Device 2
 //! let cs_pin2 = Output::new(p.P0_24, Level::Low, OutputDrive::Standard);
-//! let spi_dev2 = SpiBusDevice::new(spi_bus, cs_pin2);
+//! let spi_dev2 = SpiDevice::new(spi_bus, cs_pin2);
 //! let display2 = ST7735::new(spi_dev2, dc2, rst2, Default::default(), 160, 128);
 //! ```
 use core::future::Future;
@@ -33,29 +33,29 @@ use embedded_hal_1::digital::blocking::OutputPin;
 use embedded_hal_1::spi::ErrorType;
 use embedded_hal_async::spi;
 
-use crate::shared_bus::SpiBusDeviceError;
+use crate::shared_bus::SpiDeviceError;
 use crate::SetConfig;
 
-pub struct SpiBusDevice<'a, M: RawMutex, BUS, CS> {
+pub struct SpiDevice<'a, M: RawMutex, BUS, CS> {
     bus: &'a Mutex<M, BUS>,
     cs: CS,
 }
 
-impl<'a, M: RawMutex, BUS, CS> SpiBusDevice<'a, M, BUS, CS> {
+impl<'a, M: RawMutex, BUS, CS> SpiDevice<'a, M, BUS, CS> {
     pub fn new(bus: &'a Mutex<M, BUS>, cs: CS) -> Self {
         Self { bus, cs }
     }
 }
 
-impl<'a, M: RawMutex, BUS, CS> spi::ErrorType for SpiBusDevice<'a, M, BUS, CS>
+impl<'a, M: RawMutex, BUS, CS> spi::ErrorType for SpiDevice<'a, M, BUS, CS>
 where
     BUS: spi::ErrorType,
     CS: OutputPin,
 {
-    type Error = SpiBusDeviceError<BUS::Error, CS::Error>;
+    type Error = SpiDeviceError<BUS::Error, CS::Error>;
 }
 
-impl<M, BUS, CS> spi::SpiDevice for SpiBusDevice<'_, M, BUS, CS>
+impl<M, BUS, CS> spi::SpiDevice for SpiDevice<'_, M, BUS, CS>
 where
     M: RawMutex + 'static,
     BUS: spi::SpiBusFlush + 'static,
@@ -76,7 +76,7 @@ where
     {
         async move {
             let mut bus = self.bus.lock().await;
-            self.cs.set_low().map_err(SpiBusDeviceError::Cs)?;
+            self.cs.set_low().map_err(SpiDeviceError::Cs)?;
 
             let f_res = f(&mut *bus).await;
 
@@ -84,37 +84,37 @@ where
             let flush_res = bus.flush().await;
             let cs_res = self.cs.set_high();
 
-            let f_res = f_res.map_err(SpiBusDeviceError::Spi)?;
-            flush_res.map_err(SpiBusDeviceError::Spi)?;
-            cs_res.map_err(SpiBusDeviceError::Cs)?;
+            let f_res = f_res.map_err(SpiDeviceError::Spi)?;
+            flush_res.map_err(SpiDeviceError::Spi)?;
+            cs_res.map_err(SpiDeviceError::Cs)?;
 
             Ok(f_res)
         }
     }
 }
 
-pub struct SpiBusDeviceWithConfig<'a, M: RawMutex, BUS: SetConfig, CS> {
+pub struct SpiDeviceWithConfig<'a, M: RawMutex, BUS: SetConfig, CS> {
     bus: &'a Mutex<M, BUS>,
     cs: CS,
     config: BUS::Config,
 }
 
-impl<'a, M: RawMutex, BUS: SetConfig, CS> SpiBusDeviceWithConfig<'a, M, BUS, CS> {
+impl<'a, M: RawMutex, BUS: SetConfig, CS> SpiDeviceWithConfig<'a, M, BUS, CS> {
     pub fn new(bus: &'a Mutex<M, BUS>, cs: CS, config: BUS::Config) -> Self {
         Self { bus, cs, config }
     }
 }
 
-impl<'a, M, BUS, CS> spi::ErrorType for SpiBusDeviceWithConfig<'a, M, BUS, CS>
+impl<'a, M, BUS, CS> spi::ErrorType for SpiDeviceWithConfig<'a, M, BUS, CS>
 where
     BUS: spi::ErrorType + SetConfig,
     CS: OutputPin,
     M: RawMutex,
 {
-    type Error = SpiBusDeviceError<BUS::Error, CS::Error>;
+    type Error = SpiDeviceError<BUS::Error, CS::Error>;
 }
 
-impl<M, BUS, CS> spi::SpiDevice for SpiBusDeviceWithConfig<'_, M, BUS, CS>
+impl<M, BUS, CS> spi::SpiDevice for SpiDeviceWithConfig<'_, M, BUS, CS>
 where
     M: RawMutex + 'static,
     BUS: spi::SpiBusFlush + SetConfig + 'static,
@@ -136,7 +136,7 @@ where
         async move {
             let mut bus = self.bus.lock().await;
             bus.set_config(&self.config);
-            self.cs.set_low().map_err(SpiBusDeviceError::Cs)?;
+            self.cs.set_low().map_err(SpiDeviceError::Cs)?;
 
             let f_res = f(&mut *bus).await;
 
@@ -144,9 +144,9 @@ where
             let flush_res = bus.flush().await;
             let cs_res = self.cs.set_high();
 
-            let f_res = f_res.map_err(SpiBusDeviceError::Spi)?;
-            flush_res.map_err(SpiBusDeviceError::Spi)?;
-            cs_res.map_err(SpiBusDeviceError::Cs)?;
+            let f_res = f_res.map_err(SpiDeviceError::Spi)?;
+            flush_res.map_err(SpiDeviceError::Spi)?;
+            cs_res.map_err(SpiDeviceError::Cs)?;
 
             Ok(f_res)
         }

--- a/embassy-embedded-hal/src/shared_bus/blocking/i2c.rs
+++ b/embassy-embedded-hal/src/shared_bus/blocking/i2c.rs
@@ -3,7 +3,7 @@
 //! # Example (nrf52)
 //!
 //! ```rust
-//! use embassy_embedded_hal::shared_bus::blocking::i2c::I2cBusDevice;
+//! use embassy_embedded_hal::shared_bus::blocking::i2c::I2cDevice;
 //! use embassy::blocking_mutex::{NoopMutex, raw::NoopRawMutex};
 //!
 //! static I2C_BUS: Forever<NoopMutex<RefCell<Twim<TWISPI0>>>> = Forever::new();
@@ -12,7 +12,7 @@
 //! let i2c_bus = NoopMutex::new(RefCell::new(i2c));
 //! let i2c_bus = I2C_BUS.put(i2c_bus);
 //!
-//! let i2c_dev1 = I2cBusDevice::new(i2c_bus);
+//! let i2c_dev1 = I2cDevice::new(i2c_bus);
 //! let mpu = Mpu6050::new(i2c_dev1);
 //! ```
 
@@ -23,46 +23,46 @@ use embassy::blocking_mutex::Mutex;
 use embedded_hal_1::i2c::blocking::{I2c, Operation};
 use embedded_hal_1::i2c::ErrorType;
 
-use crate::shared_bus::I2cBusDeviceError;
+use crate::shared_bus::I2cDeviceError;
 use crate::SetConfig;
 
-pub struct I2cBusDevice<'a, M: RawMutex, BUS> {
+pub struct I2cDevice<'a, M: RawMutex, BUS> {
     bus: &'a Mutex<M, RefCell<BUS>>,
 }
 
-impl<'a, M: RawMutex, BUS> I2cBusDevice<'a, M, BUS> {
+impl<'a, M: RawMutex, BUS> I2cDevice<'a, M, BUS> {
     pub fn new(bus: &'a Mutex<M, RefCell<BUS>>) -> Self {
         Self { bus }
     }
 }
 
-impl<'a, M: RawMutex, BUS> ErrorType for I2cBusDevice<'a, M, BUS>
+impl<'a, M: RawMutex, BUS> ErrorType for I2cDevice<'a, M, BUS>
 where
     BUS: ErrorType,
 {
-    type Error = I2cBusDeviceError<BUS::Error>;
+    type Error = I2cDeviceError<BUS::Error>;
 }
 
-impl<M, BUS> I2c for I2cBusDevice<'_, M, BUS>
+impl<M, BUS> I2c for I2cDevice<'_, M, BUS>
 where
     M: RawMutex,
     BUS: I2c,
 {
     fn read(&mut self, address: u8, buffer: &mut [u8]) -> Result<(), Self::Error> {
         self.bus
-            .lock(|bus| bus.borrow_mut().read(address, buffer).map_err(I2cBusDeviceError::I2c))
+            .lock(|bus| bus.borrow_mut().read(address, buffer).map_err(I2cDeviceError::I2c))
     }
 
     fn write(&mut self, address: u8, bytes: &[u8]) -> Result<(), Self::Error> {
         self.bus
-            .lock(|bus| bus.borrow_mut().write(address, bytes).map_err(I2cBusDeviceError::I2c))
+            .lock(|bus| bus.borrow_mut().write(address, bytes).map_err(I2cDeviceError::I2c))
     }
 
     fn write_read(&mut self, address: u8, wr_buffer: &[u8], rd_buffer: &mut [u8]) -> Result<(), Self::Error> {
         self.bus.lock(|bus| {
             bus.borrow_mut()
                 .write_read(address, wr_buffer, rd_buffer)
-                .map_err(I2cBusDeviceError::I2c)
+                .map_err(I2cDeviceError::I2c)
         })
     }
 
@@ -101,68 +101,68 @@ where
     }
 }
 
-impl<'a, M, BUS, E> embedded_hal_02::blocking::i2c::Write for I2cBusDevice<'_, M, BUS>
+impl<'a, M, BUS, E> embedded_hal_02::blocking::i2c::Write for I2cDevice<'_, M, BUS>
 where
     M: RawMutex,
     BUS: embedded_hal_02::blocking::i2c::Write<Error = E>,
 {
-    type Error = I2cBusDeviceError<E>;
+    type Error = I2cDeviceError<E>;
 
     fn write<'w>(&mut self, addr: u8, bytes: &'w [u8]) -> Result<(), Self::Error> {
         self.bus
-            .lock(|bus| bus.borrow_mut().write(addr, bytes).map_err(I2cBusDeviceError::I2c))
+            .lock(|bus| bus.borrow_mut().write(addr, bytes).map_err(I2cDeviceError::I2c))
     }
 }
 
-impl<'a, M, BUS, E> embedded_hal_02::blocking::i2c::Read for I2cBusDevice<'_, M, BUS>
+impl<'a, M, BUS, E> embedded_hal_02::blocking::i2c::Read for I2cDevice<'_, M, BUS>
 where
     M: RawMutex,
     BUS: embedded_hal_02::blocking::i2c::Read<Error = E>,
 {
-    type Error = I2cBusDeviceError<E>;
+    type Error = I2cDeviceError<E>;
 
     fn read<'w>(&mut self, addr: u8, bytes: &'w mut [u8]) -> Result<(), Self::Error> {
         self.bus
-            .lock(|bus| bus.borrow_mut().read(addr, bytes).map_err(I2cBusDeviceError::I2c))
+            .lock(|bus| bus.borrow_mut().read(addr, bytes).map_err(I2cDeviceError::I2c))
     }
 }
 
-impl<'a, M, BUS, E> embedded_hal_02::blocking::i2c::WriteRead for I2cBusDevice<'_, M, BUS>
+impl<'a, M, BUS, E> embedded_hal_02::blocking::i2c::WriteRead for I2cDevice<'_, M, BUS>
 where
     M: RawMutex,
     BUS: embedded_hal_02::blocking::i2c::WriteRead<Error = E>,
 {
-    type Error = I2cBusDeviceError<E>;
+    type Error = I2cDeviceError<E>;
 
     fn write_read<'w>(&mut self, addr: u8, bytes: &'w [u8], buffer: &'w mut [u8]) -> Result<(), Self::Error> {
         self.bus.lock(|bus| {
             bus.borrow_mut()
                 .write_read(addr, bytes, buffer)
-                .map_err(I2cBusDeviceError::I2c)
+                .map_err(I2cDeviceError::I2c)
         })
     }
 }
 
-pub struct I2cBusDeviceWithConfig<'a, M: RawMutex, BUS: SetConfig> {
+pub struct I2cDeviceWithConfig<'a, M: RawMutex, BUS: SetConfig> {
     bus: &'a Mutex<M, RefCell<BUS>>,
     config: BUS::Config,
 }
 
-impl<'a, M: RawMutex, BUS: SetConfig> I2cBusDeviceWithConfig<'a, M, BUS> {
+impl<'a, M: RawMutex, BUS: SetConfig> I2cDeviceWithConfig<'a, M, BUS> {
     pub fn new(bus: &'a Mutex<M, RefCell<BUS>>, config: BUS::Config) -> Self {
         Self { bus, config }
     }
 }
 
-impl<'a, M, BUS> ErrorType for I2cBusDeviceWithConfig<'a, M, BUS>
+impl<'a, M, BUS> ErrorType for I2cDeviceWithConfig<'a, M, BUS>
 where
     M: RawMutex,
     BUS: ErrorType + SetConfig,
 {
-    type Error = I2cBusDeviceError<BUS::Error>;
+    type Error = I2cDeviceError<BUS::Error>;
 }
 
-impl<M, BUS> I2c for I2cBusDeviceWithConfig<'_, M, BUS>
+impl<M, BUS> I2c for I2cDeviceWithConfig<'_, M, BUS>
 where
     M: RawMutex,
     BUS: I2c + SetConfig,
@@ -171,7 +171,7 @@ where
         self.bus.lock(|bus| {
             let mut bus = bus.borrow_mut();
             bus.set_config(&self.config);
-            bus.read(address, buffer).map_err(I2cBusDeviceError::I2c)
+            bus.read(address, buffer).map_err(I2cDeviceError::I2c)
         })
     }
 
@@ -179,7 +179,7 @@ where
         self.bus.lock(|bus| {
             let mut bus = bus.borrow_mut();
             bus.set_config(&self.config);
-            bus.write(address, bytes).map_err(I2cBusDeviceError::I2c)
+            bus.write(address, bytes).map_err(I2cDeviceError::I2c)
         })
     }
 
@@ -188,7 +188,7 @@ where
             let mut bus = bus.borrow_mut();
             bus.set_config(&self.config);
             bus.write_read(address, wr_buffer, rd_buffer)
-                .map_err(I2cBusDeviceError::I2c)
+                .map_err(I2cDeviceError::I2c)
         })
     }
 

--- a/embassy-embedded-hal/src/shared_bus/mod.rs
+++ b/embassy-embedded-hal/src/shared_bus/mod.rs
@@ -9,11 +9,11 @@ pub mod asynch;
 pub mod blocking;
 
 #[derive(Copy, Clone, Eq, PartialEq, Debug)]
-pub enum I2cBusDeviceError<BUS> {
+pub enum I2cDeviceError<BUS> {
     I2c(BUS),
 }
 
-impl<BUS> i2c::Error for I2cBusDeviceError<BUS>
+impl<BUS> i2c::Error for I2cDeviceError<BUS>
 where
     BUS: i2c::Error + Debug,
 {
@@ -25,12 +25,12 @@ where
 }
 
 #[derive(Copy, Clone, Eq, PartialEq, Debug)]
-pub enum SpiBusDeviceError<BUS, CS> {
+pub enum SpiDeviceError<BUS, CS> {
     Spi(BUS),
     Cs(CS),
 }
 
-impl<BUS, CS> spi::Error for SpiBusDeviceError<BUS, CS>
+impl<BUS, CS> spi::Error for SpiDeviceError<BUS, CS>
 where
     BUS: spi::Error + Debug,
     CS: Debug,


### PR DESCRIPTION
I think the current naming is a bit odd, the EH traits are organized as "Bus" vs "Device", and XxxBusDevice is a Device (not a Bus, not both)

@kalkyl 