### PR TITLE
Add inline attribute to embassy-rp async functions

### DIFF
--- a/embassy-rp/src/gpio.rs
+++ b/embassy-rp/src/gpio.rs
@@ -84,22 +84,27 @@ impl<'d, T: Pin> Input<'d, T> {
         self.pin.get_level()
     }
 
+    #[inline]
     pub async fn wait_for_high<'a>(&mut self) {
         self.pin.wait_for_high().await;
     }
 
+    #[inline]
     pub async fn wait_for_low<'a>(&mut self) {
         self.pin.wait_for_low().await;
     }
 
+    #[inline]
     pub async fn wait_for_rising_edge<'a>(&mut self) {
         self.pin.wait_for_rising_edge().await;
     }
 
+    #[inline]
     pub async fn wait_for_falling_edge<'a>(&mut self) {
         self.pin.wait_for_falling_edge().await;
     }
 
+    #[inline]
     pub async fn wait_for_any_edge<'a>(&mut self) {
         self.pin.wait_for_any_edge().await;
     }
@@ -547,24 +552,29 @@ impl<'d, T: Pin> Flex<'d, T> {
         unsafe { self.pin.sio_out().value_xor().write_value(self.bit()) }
     }
 
+    #[inline]
     pub async fn wait_for_high<'a>(&mut self) {
         InputFuture::new(&mut self.pin, InterruptTrigger::LevelHigh).await;
     }
 
+    #[inline]
     pub async fn wait_for_low<'a>(&mut self) {
         InputFuture::new(&mut self.pin, InterruptTrigger::LevelLow).await;
     }
 
+    #[inline]
     pub async fn wait_for_rising_edge<'a>(&mut self) {
         self.wait_for_low().await;
         self.wait_for_high().await;
     }
 
+    #[inline]
     pub async fn wait_for_falling_edge<'a>(&mut self) {
         self.wait_for_high().await;
         self.wait_for_low().await;
     }
 
+    #[inline]
     pub async fn wait_for_any_edge<'a>(&mut self) {
         if self.is_high() {
             self.wait_for_low().await;


### PR DESCRIPTION
This commit adds the inline attribute to the recently added async gpio
functions. This is to enable cross-crate inlining and to be consistent
with the other functions implemented for Input and Flex.