### PR TITLE
Improve ADC configuration options

### DIFF
--- a/embassy-stm32/src/adc/v2.rs
+++ b/embassy-stm32/src/adc/v2.rs
@@ -153,7 +153,7 @@ impl Prescaler {
 
 pub struct Adc<'d, T: Instance> {
     sample_time: SampleTime,
-    vref: u32,
+    vref_mv: u32,
     resolution: Resolution,
     phantom: PhantomData<&'d mut T>,
 }
@@ -183,7 +183,7 @@ where
         Self {
             sample_time: Default::default(),
             resolution: Resolution::default(),
-            vref: VREF_DEFAULT_MV,
+            vref_mv: VREF_DEFAULT_MV,
             phantom: PhantomData,
         }
     }
@@ -199,13 +199,13 @@ where
     /// Set VREF value in millivolts. This value is used for [to_millivolts()] sample conversion.
     ///
     /// Use this if you have a known precise VREF (VDDA) pin reference voltage.
-    pub fn set_vref(&mut self, vref: u32) {
-        self.vref = vref;
+    pub fn set_vref_mv(&mut self, vref_mv: u32) {
+        self.vref_mv = vref_mv;
     }
 
     /// Convert a measurement to millivolts
     pub fn to_millivolts(&self, sample: u16) -> u16 {
-        ((u32::from(sample) * self.vref) / self.resolution.to_max_count()) as u16
+        ((u32::from(sample) * self.vref_mv) / self.resolution.to_max_count()) as u16
     }
 
     /// Perform a single conversion.

--- a/embassy-stm32/src/adc/v2.rs
+++ b/embassy-stm32/src/adc/v2.rs
@@ -7,7 +7,10 @@ use crate::adc::{AdcPin, Instance};
 use crate::time::Hertz;
 use crate::Peripheral;
 
-pub const VDDA_CALIB_MV: u32 = 3000;
+/// Default VREF voltage used for sample conversion to millivolts.
+pub const VREF_DEFAULT_MV: u32 = 3300;
+/// VREF voltage used for factory calibration of VREFINTCAL register.
+pub const VREF_CALIB_MV: u32 = 3300;
 
 #[cfg(not(any(rcc_f4, rcc_f7)))]
 fn enable() {
@@ -47,7 +50,7 @@ impl Resolution {
         }
     }
 
-    fn to_max_count(&self) -> u32 {
+    pub fn to_max_count(&self) -> u32 {
         match self {
             Resolution::TwelveBit => (1 << 12) - 1,
             Resolution::TenBit => (1 << 10) - 1,
@@ -57,9 +60,9 @@ impl Resolution {
     }
 }
 
-pub struct Vref;
-impl<T: Instance> AdcPin<T> for Vref {}
-impl<T: Instance> super::sealed::AdcPin<T> for Vref {
+pub struct VrefInt;
+impl<T: Instance> AdcPin<T> for VrefInt {}
+impl<T: Instance> super::sealed::AdcPin<T> for VrefInt {
     fn channel(&self) -> u8 {
         17
     }
@@ -150,7 +153,7 @@ impl Prescaler {
 
 pub struct Adc<'d, T: Instance> {
     sample_time: SampleTime,
-    calibrated_vdda: u32,
+    vref: u32,
     resolution: Resolution,
     phantom: PhantomData<&'d mut T>,
 }
@@ -180,7 +183,7 @@ where
         Self {
             sample_time: Default::default(),
             resolution: Resolution::default(),
-            calibrated_vdda: VDDA_CALIB_MV,
+            vref: VREF_DEFAULT_MV,
             phantom: PhantomData,
         }
     }
@@ -193,9 +196,16 @@ where
         self.resolution = resolution;
     }
 
+    /// Set VREF, which is used for [to_millivolts()] conversion.
+    ///
+    /// Use this if you have a known precise VREF (VDDA) pin reference voltage.
+    pub fn set_vref(&mut self, vref: u32) {
+        self.vref = vref;
+    }
+
     /// Convert a measurement to millivolts
     pub fn to_millivolts(&self, sample: u16) -> u16 {
-        ((u32::from(sample) * self.calibrated_vdda) / self.resolution.to_max_count()) as u16
+        ((u32::from(sample) * self.vref) / self.resolution.to_max_count()) as u16
     }
 
     /// Perform a single conversion.

--- a/embassy-stm32/src/adc/v2.rs
+++ b/embassy-stm32/src/adc/v2.rs
@@ -196,7 +196,7 @@ where
         self.resolution = resolution;
     }
 
-    /// Set VREF, which is used for [to_millivolts()] conversion.
+    /// Set VREF value in millivolts. This value is used for [to_millivolts()] sample conversion.
     ///
     /// Use this if you have a known precise VREF (VDDA) pin reference voltage.
     pub fn set_vref(&mut self, vref: u32) {

--- a/embassy-stm32/src/adc/v3.rs
+++ b/embassy-stm32/src/adc/v3.rs
@@ -205,7 +205,7 @@ pub use sample_time::SampleTime;
 
 pub struct Adc<'d, T: Instance> {
     sample_time: SampleTime,
-    vref: u32,
+    vref_mv: u32,
     resolution: Resolution,
     phantom: PhantomData<&'d mut T>,
 }
@@ -244,7 +244,7 @@ impl<'d, T: Instance> Adc<'d, T> {
         Self {
             sample_time: Default::default(),
             resolution: Resolution::default(),
-            vref: VREF_DEFAULT_MV,
+            vref_mv: VREF_DEFAULT_MV,
             phantom: PhantomData,
         }
     }
@@ -307,7 +307,7 @@ impl<'d, T: Instance> Adc<'d, T> {
 
         self.sample_time = old_sample_time;
 
-        self.vref = (VREF_CALIB_MV * u32::from(vrefint_cal)) / u32::from(vrefint_samp);
+        self.vref_mv = (VREF_CALIB_MV * u32::from(vrefint_cal)) / u32::from(vrefint_samp);
     }
 
     pub fn set_sample_time(&mut self, sample_time: SampleTime) {
@@ -321,13 +321,13 @@ impl<'d, T: Instance> Adc<'d, T> {
     /// Set VREF value in millivolts. This value is used for [to_millivolts()] sample conversion.
     ///
     /// Use this if you have a known precise VREF (VDDA) pin reference voltage.
-    pub fn set_vref(&mut self, vref: u32) {
-        self.vref = vref;
+    pub fn set_vref_mv(&mut self, vref_mv: u32) {
+        self.vref_mv = vref_mv;
     }
 
     /// Convert a measurement to millivolts
     pub fn to_millivolts(&self, sample: u16) -> u16 {
-        ((u32::from(sample) * self.vref) / self.resolution.to_max_count()) as u16
+        ((u32::from(sample) * self.vref_mv) / self.resolution.to_max_count()) as u16
     }
 
     /*

--- a/embassy-stm32/src/adc/v3.rs
+++ b/embassy-stm32/src/adc/v3.rs
@@ -318,7 +318,7 @@ impl<'d, T: Instance> Adc<'d, T> {
         self.resolution = resolution;
     }
 
-    /// Set VREF used for [to_millivolts()] conversion.
+    /// Set VREF value in millivolts. This value is used for [to_millivolts()] sample conversion.
     ///
     /// Use this if you have a known precise VREF (VDDA) pin reference voltage.
     pub fn set_vref(&mut self, vref: u32) {

--- a/embassy-stm32/src/adc/v4.rs
+++ b/embassy-stm32/src/adc/v4.rs
@@ -322,7 +322,7 @@ impl Prescaler {
 
 pub struct Adc<'d, T: Instance> {
     sample_time: SampleTime,
-    vref: u32,
+    vref_mv: u32,
     resolution: Resolution,
     phantom: PhantomData<&'d mut T>,
 }
@@ -360,7 +360,7 @@ impl<'d, T: Instance + crate::rcc::RccPeripheral> Adc<'d, T> {
 
         let mut s = Self {
             sample_time: Default::default(),
-            vref: VREF_DEFAULT_MV,
+            vref_mv: VREF_DEFAULT_MV,
             resolution: Resolution::default(),
             phantom: PhantomData,
         };
@@ -470,13 +470,13 @@ impl<'d, T: Instance + crate::rcc::RccPeripheral> Adc<'d, T> {
     /// Set VREF value in millivolts. This value is used for [to_millivolts()] sample conversion.
     ///
     /// Use this if you have a known precise VREF (VDDA) pin reference voltage.
-    pub fn set_vref(&mut self, vref: u32) {
-        self.vref = vref;
+    pub fn set_vref_mv(&mut self, vref_mv: u32) {
+        self.vref_mv = vref_mv;
     }
 
     /// Convert a measurement to millivolts
     pub fn to_millivolts(&self, sample: u16) -> u16 {
-        ((u32::from(sample) * self.vref) / self.resolution.to_max_count()) as u16
+        ((u32::from(sample) * self.vref_mv) / self.resolution.to_max_count()) as u16
     }
 
     /// Perform a single conversion.

--- a/embassy-stm32/src/adc/v4.rs
+++ b/embassy-stm32/src/adc/v4.rs
@@ -467,7 +467,7 @@ impl<'d, T: Instance + crate::rcc::RccPeripheral> Adc<'d, T> {
         self.resolution = resolution;
     }
 
-    /// Set VREF used for [to_millivolts()] conversion.
+    /// Set VREF value in millivolts. This value is used for [to_millivolts()] sample conversion.
     ///
     /// Use this if you have a known precise VREF (VDDA) pin reference voltage.
     pub fn set_vref(&mut self, vref: u32) {

--- a/examples/stm32h7/src/bin/adc.rs
+++ b/examples/stm32h7/src/bin/adc.rs
@@ -28,11 +28,11 @@ async fn main(_spawner: Spawner, mut p: Peripherals) {
 
     adc.set_sample_time(SampleTime::Cycles32_5);
 
-    let mut vref_channel = adc.enable_vref();
+    let mut vrefint_channel = adc.enable_vrefint();
 
     loop {
-        let vref = adc.read_internal(&mut vref_channel);
-        info!("vref: {}", vref);
+        let vrefint = adc.read_internal(&mut vrefint_channel);
+        info!("vrefint: {}", vrefint);
         let measured = adc.read(&mut p.PC0);
         info!("measured: {}", measured);
         Timer::after(Duration::from_millis(500)).await;


### PR DESCRIPTION
This smooths out a few rough edges with ADC:
- Make `Resolution::to_max_count()` pub for all ADC versions. Useful if performing conversion manually.
- `VREF` and `VREFINT` were convoluted. `VREF` is an external voltage reference used for all ADC conversions and it is exposed as a separate pin on large chips, while on smaller ones it is connected to `VDDA` internally. `VREFINT` is an internal voltage reference connected to one of the ADC channels and can be used to calculate unknown `VREF` voltage.
- Add a separate `VREF_DEFAULT_MV`, equal to 3.3V, which is the usual supply voltage and should work for most simple cases.
  - For an external voltage reference `set_vref()` can be used to set a known precise voltage.
  - If no voltage reference is present, `VREFINT` calibration can be used to calculate unknown `VREF` voltage. If I understand correctly, this is only implemented for `adc_v3` (L4?), but is not currently exposed (private). If someone is interested, this can be fixed in separate PR.