### PR TITLE
net: make TcpIo private.

### DIFF
--- a/embassy-net/src/tcp.rs
+++ b/embassy-net/src/tcp.rs
@@ -181,7 +181,7 @@ impl<'a> Drop for TcpSocket<'a> {
 // =======================
 
 #[derive(Copy, Clone)]
-pub struct TcpIo<'a> {
+struct TcpIo<'a> {
     stack: &'a UnsafeCell<SocketStack>,
     handle: SocketHandle,
 }


### PR DESCRIPTION
It's just an implementation detail to share code between Socket, Reader, Writer. It wasn't supposed to be public.