### PR TITLE
Update to critical-section 1.0, atomic-polyfill 1.0

### DIFF
--- a/embassy-boot/nrf/Cargo.toml
+++ b/embassy-boot/nrf/Cargo.toml
@@ -18,7 +18,7 @@ defmt = { version = "0.3", optional = true }
 embassy-util = { path = "../../embassy-util" }
 embassy-nrf = { path = "../../embassy-nrf", default-features = false, features = ["nightly"] }
 embassy-boot = { path = "../boot", default-features = false }
-cortex-m = { version = "0.7" }
+cortex-m = { version = "0.7.6" }
 cortex-m-rt = { version = "0.7" }
 embedded-storage = "0.3.0"
 embedded-storage-async = "0.3.0"

--- a/embassy-boot/stm32/Cargo.toml
+++ b/embassy-boot/stm32/Cargo.toml
@@ -20,7 +20,7 @@ log = { version = "0.4", optional = true }
 embassy-util = { path = "../../embassy-util" }
 embassy-stm32 = { path = "../../embassy-stm32", default-features = false, features = ["nightly"] }
 embassy-boot = { path = "../boot", default-features = false }
-cortex-m = { version = "0.7" }
+cortex-m = { version = "0.7.6" }
 cortex-m-rt = { version = "0.7" }
 embedded-storage = "0.3.0"
 embedded-storage-async = "0.3.0"

--- a/embassy-cortex-m/Cargo.toml
+++ b/embassy-cortex-m/Cargo.toml
@@ -39,8 +39,8 @@ embassy-util = { version = "0.1.0", path = "../embassy-util" }
 embassy-executor = { version = "0.1.0", path = "../embassy-executor"}
 embassy-macros = { version = "0.1.0", path = "../embassy-macros"}
 embassy-hal-common = { version = "0.1.0", path = "../embassy-hal-common"}
-atomic-polyfill = "0.1.5"
-critical-section = "0.2.5"
+atomic-polyfill = "1.0.1"
+critical-section = "1.1"
 cfg-if = "1.0.0"
-cortex-m = "0.7.3"
+cortex-m = "0.7.6"
 

--- a/embassy-executor/Cargo.toml
+++ b/embassy-executor/Cargo.toml
@@ -60,8 +60,8 @@ embedded-hal-async = { version = "0.1.0-alpha.1", optional = true}
 
 futures-util = { version = "0.3.17", default-features = false }
 embassy-macros  = { version = "0.1.0", path = "../embassy-macros"}
-atomic-polyfill = "0.1.5"
-critical-section = "0.2.5"
+atomic-polyfill = "1.0.1"
+critical-section = "1.1"
 cfg-if = "1.0.0"
 
 # WASM dependencies

--- a/embassy-nrf/Cargo.toml
+++ b/embassy-nrf/Cargo.toml
@@ -80,9 +80,9 @@ embedded-io = { version = "0.3.0", features = ["async"], optional = true }
 defmt = { version = "0.3", optional = true }
 log = { version = "0.4.14", optional = true }
 cortex-m-rt = ">=0.6.15,<0.8"
-cortex-m = "0.7.3"
+cortex-m = "0.7.6"
 futures     = { version = "0.3.17", default-features = false }
-critical-section = "0.2.5"
+critical-section = "1.1"
 rand_core = "0.6.3"
 fixed = "1.10.0"
 embedded-storage = "0.3.0"

--- a/embassy-rp/Cargo.toml
+++ b/embassy-rp/Cargo.toml
@@ -33,12 +33,12 @@ embassy-cortex-m = { version = "0.1.0", path = "../embassy-cortex-m", features =
 embassy-hal-common = {version = "0.1.0", path = "../embassy-hal-common" }
 embassy-embedded-hal = {version = "0.1.0", path = "../embassy-embedded-hal" }
 embassy-macros = { version = "0.1.0", path = "../embassy-macros", features = ["rp"]}
-atomic-polyfill = "0.1.5"
+atomic-polyfill = "1.0.1"
 defmt = { version = "0.3", optional = true }
 log = { version = "0.4.14", optional = true }
 cortex-m-rt = ">=0.6.15,<0.8"
-cortex-m = "0.7.3"
-critical-section = "0.2.5"
+cortex-m = "0.7.6"
+critical-section = "1.1"
 futures = { version = "0.3.17", default-features = false, features = ["async-await"] }
 
 rp2040-pac2 = { git = "https://github.com/embassy-rs/rp2040-pac2", rev="9ad7223a48a065e612bc7dc7be5bf5bd0b41cfc4", features = ["rt"] }

--- a/embassy-stm32/Cargo.toml
+++ b/embassy-stm32/Cargo.toml
@@ -50,14 +50,13 @@ embedded-storage-async = { version = "0.3.0", optional = true }
 defmt = { version = "0.3", optional = true }
 log = { version = "0.4.14", optional = true }
 cortex-m-rt = ">=0.6.15,<0.8"
-cortex-m = "0.7.3"
+cortex-m = "0.7.6"
 futures = { version = "0.3.17", default-features = false, features = ["async-await"] }
 rand_core = "0.6.3"
 sdio-host = "0.5.0"
 embedded-sdmmc = { git = "https://github.com/thalesfragoso/embedded-sdmmc-rs", branch = "async", optional = true }
-critical-section = "0.2.5"
-bare-metal = "1.0.0"
-atomic-polyfill = "0.1.5"
+critical-section = "1.1"
+atomic-polyfill = "1.0.1"
 stm32-metapac = { version = "0.1.0", path = "../stm32-metapac", features = ["rt"] }
 vcell = "0.1.3"
 bxcan = "0.7.0"

--- a/embassy-stm32/src/interrupt.rs
+++ b/embassy-stm32/src/interrupt.rs
@@ -1,5 +1,4 @@
-pub use bare_metal::Mutex;
-pub use critical_section::CriticalSection;
+pub use critical_section::{CriticalSection, Mutex};
 pub use embassy_cortex_m::interrupt::*;
 
 pub use crate::_generated::interrupt::*;

--- a/embassy-util/Cargo.toml
+++ b/embassy-util/Cargo.toml
@@ -17,8 +17,8 @@ defmt = { version = "0.3", optional = true }
 log = { version = "0.4.14", optional = true }
 
 futures-util = { version = "0.3.17", default-features = false }
-atomic-polyfill = "0.1.5"
-critical-section = "0.2.5"
+atomic-polyfill = "1.0.1"
+critical-section = "1.1"
 heapless = "0.7.5"
 cfg-if = "1.0.0"
 embedded-io = "0.3.0"
@@ -28,3 +28,6 @@ futures-executor = { version = "0.3.17", features = [ "thread-pool" ] }
 futures-test = "0.3.17"
 futures-timer = "3.0.2"
 futures-util = { version = "0.3.17", features = [ "channel" ] }
+
+# Enable critical-section implementation for std, for tests
+critical-section = { version = "1.1", features = ["std"] }

--- a/examples/boot/application/nrf/Cargo.toml
+++ b/examples/boot/application/nrf/Cargo.toml
@@ -15,5 +15,5 @@ defmt-rtt = { version = "0.3", optional = true }
 panic-reset = { version = "0.1.1" }
 embedded-hal = { version = "0.2.6" }
 
-cortex-m = "0.7.3"
+cortex-m = { version = "0.7.6", features = ["critical-section-single-core"] }
 cortex-m-rt = "0.7.0"

--- a/examples/boot/application/stm32f3/Cargo.toml
+++ b/examples/boot/application/stm32f3/Cargo.toml
@@ -15,7 +15,7 @@ defmt-rtt = { version = "0.3", optional = true }
 panic-reset = { version = "0.1.1" }
 embedded-hal = { version = "0.2.6" }
 
-cortex-m = "0.7.3"
+cortex-m = { version = "0.7.6", features = ["critical-section-single-core"] }
 cortex-m-rt = "0.7.0"
 
 [features]

--- a/examples/boot/application/stm32f7/Cargo.toml
+++ b/examples/boot/application/stm32f7/Cargo.toml
@@ -15,7 +15,7 @@ defmt-rtt = { version = "0.3", optional = true }
 panic-reset = { version = "0.1.1" }
 embedded-hal = { version = "0.2.6" }
 
-cortex-m = "0.7.3"
+cortex-m = { version = "0.7.6", features = ["critical-section-single-core"] }
 cortex-m-rt = "0.7.0"
 
 [features]

--- a/examples/boot/application/stm32h7/Cargo.toml
+++ b/examples/boot/application/stm32h7/Cargo.toml
@@ -15,7 +15,7 @@ defmt-rtt = { version = "0.3", optional = true }
 panic-reset = { version = "0.1.1" }
 embedded-hal = { version = "0.2.6" }
 
-cortex-m = "0.7.3"
+cortex-m = { version = "0.7.6", features = ["critical-section-single-core"] }
 cortex-m-rt = "0.7.0"
 
 [features]

--- a/examples/boot/application/stm32l0/Cargo.toml
+++ b/examples/boot/application/stm32l0/Cargo.toml
@@ -15,7 +15,7 @@ defmt-rtt = { version = "0.3", optional = true }
 panic-reset = { version = "0.1.1" }
 embedded-hal = { version = "0.2.6" }
 
-cortex-m = "0.7.3"
+cortex-m = { version = "0.7.6", features = ["critical-section-single-core"] }
 cortex-m-rt = "0.7.0"
 
 [features]

--- a/examples/boot/application/stm32l1/Cargo.toml
+++ b/examples/boot/application/stm32l1/Cargo.toml
@@ -15,7 +15,7 @@ defmt-rtt = { version = "0.3", optional = true }
 panic-reset = { version = "0.1.1" }
 embedded-hal = { version = "0.2.6" }
 
-cortex-m = "0.7.3"
+cortex-m = { version = "0.7.6", features = ["critical-section-single-core"] }
 cortex-m-rt = "0.7.0"
 
 [features]

--- a/examples/boot/application/stm32l4/Cargo.toml
+++ b/examples/boot/application/stm32l4/Cargo.toml
@@ -15,7 +15,7 @@ defmt-rtt = { version = "0.3", optional = true }
 panic-reset = { version = "0.1.1" }
 embedded-hal = { version = "0.2.6" }
 
-cortex-m = "0.7.3"
+cortex-m = { version = "0.7.6", features = ["critical-section-single-core"] }
 cortex-m-rt = "0.7.0"
 
 [features]

--- a/examples/boot/application/stm32wl/Cargo.toml
+++ b/examples/boot/application/stm32wl/Cargo.toml
@@ -15,7 +15,7 @@ defmt-rtt = { version = "0.3", optional = true }
 panic-reset = { version = "0.1.1" }
 embedded-hal = { version = "0.2.6" }
 
-cortex-m = "0.7.3"
+cortex-m = { version = "0.7.6", features = ["critical-section-single-core"] }
 cortex-m-rt = "0.7.0"
 
 [features]

--- a/examples/boot/bootloader/nrf/Cargo.toml
+++ b/examples/boot/bootloader/nrf/Cargo.toml
@@ -10,7 +10,7 @@ defmt-rtt = { version = "0.3", optional = true }
 
 embassy-nrf = { path = "../../../../embassy-nrf", default-features = false, features = ["nightly"] }
 embassy-boot-nrf = { path = "../../../../embassy-boot/nrf", default-features = false }
-cortex-m = { version = "0.7" }
+cortex-m = { version = "0.7.6", features = ["critical-section-single-core"] }
 cortex-m-rt = { version = "0.7" }
 cfg-if = "1.0.0"
 

--- a/examples/boot/bootloader/stm32/Cargo.toml
+++ b/examples/boot/bootloader/stm32/Cargo.toml
@@ -10,7 +10,7 @@ defmt-rtt = { version = "0.3", optional = true }
 
 embassy-stm32 = { path = "../../../../embassy-stm32", default-features = false, features = ["nightly"] }
 embassy-boot-stm32 = { path = "../../../../embassy-boot/stm32", default-features = false }
-cortex-m = { version = "0.7" }
+cortex-m = { version = "0.7.6", features = ["critical-section-single-core"] }
 cortex-m-rt = { version = "0.7" }
 embedded-storage = "0.3.0"
 embedded-storage-async = "0.3.0"

--- a/examples/nrf/Cargo.toml
+++ b/examples/nrf/Cargo.toml
@@ -21,7 +21,7 @@ embedded-io = "0.3.0"
 defmt = "0.3"
 defmt-rtt = "0.3"
 
-cortex-m = "0.7.3"
+cortex-m = { version = "0.7.6", features = ["critical-section-single-core"] }
 cortex-m-rt = "0.7.0"
 panic-probe = { version = "0.3", features = ["print-defmt"] }
 futures = { version = "0.3.17", default-features = false, features = ["async-await"] }

--- a/examples/rp/Cargo.toml
+++ b/examples/rp/Cargo.toml
@@ -8,12 +8,11 @@ version = "0.1.0"
 embassy-util = { version = "0.1.0", path = "../../embassy-util", features = ["defmt"] }
 embassy-executor = { version = "0.1.0", path = "../../embassy-executor", features = ["defmt", "defmt-timestamp-uptime"] }
 embassy-rp = { version = "0.1.0", path = "../../embassy-rp", features = ["defmt", "unstable-traits", "nightly", "unstable-pac"] }
-atomic-polyfill = "0.1.5"
 
 defmt = "0.3"
 defmt-rtt = "0.3"
 
-cortex-m = "0.7.3"
+cortex-m = { version = "0.7.6", features = ["critical-section-single-core"] }
 cortex-m-rt = "0.7.0"
 panic-probe = { version = "0.3", features = ["print-defmt"] }
 futures = { version = "0.3.17", default-features = false, features = ["async-await", "cfg-target-has-atomic", "unstable"] }

--- a/examples/std/Cargo.toml
+++ b/examples/std/Cargo.toml
@@ -8,6 +8,7 @@ embassy-util = { version = "0.1.0", path = "../../embassy-util", features = ["lo
 embassy-executor = { version = "0.1.0", path = "../../embassy-executor", features = ["log", "std", "time", "nightly"] }
 embassy-net = { version = "0.1.0", path = "../../embassy-net", features=[ "std", "log", "medium-ethernet", "tcp", "udp", "dhcpv4", "pool-16"] }
 embedded-io = { version = "0.3.0", features = ["async", "std", "futures"] }
+critical-section = { version = "1.1", features = ["std"] }
 
 async-io = "1.6.0"
 env_logger = "0.9.0"

--- a/examples/stm32f0/Cargo.toml
+++ b/examples/stm32f0/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-cortex-m = "0.7.3"
+cortex-m = { version = "0.7.6", features = ["critical-section-single-core"] }
 cortex-m-rt = "0.7.0"
 defmt = "0.3"
 defmt-rtt = "0.3"

--- a/examples/stm32f1/Cargo.toml
+++ b/examples/stm32f1/Cargo.toml
@@ -13,7 +13,7 @@ embassy-usb-serial = { version = "0.1.0", path = "../../embassy-usb-serial", fea
 defmt = "0.3"
 defmt-rtt = "0.3"
 
-cortex-m = "0.7.3"
+cortex-m = { version = "0.7.6", features = ["critical-section-single-core"] }
 cortex-m-rt = "0.7.0"
 embedded-hal = "0.2.6"
 panic-probe = { version = "0.3", features = ["print-defmt"] }

--- a/examples/stm32f2/Cargo.toml
+++ b/examples/stm32f2/Cargo.toml
@@ -11,7 +11,7 @@ embassy-stm32 = { version = "0.1.0", path = "../../embassy-stm32", features = ["
 defmt = "0.3"
 defmt-rtt = "0.3"
 
-cortex-m = "0.7.3"
+cortex-m = { version = "0.7.6", features = ["critical-section-single-core"] }
 cortex-m-rt = "0.7.0"
 embedded-hal = "0.2.6"
 panic-probe = { version = "0.3", features = ["print-defmt"] }

--- a/examples/stm32f3/Cargo.toml
+++ b/examples/stm32f3/Cargo.toml
@@ -14,7 +14,7 @@ embassy-usb-hid = { version = "0.1.0", path = "../../embassy-usb-hid", features 
 defmt = "0.3"
 defmt-rtt = "0.3"
 
-cortex-m = "0.7.3"
+cortex-m = { version = "0.7.6", features = ["critical-section-single-core"] }
 cortex-m-rt = "0.7.0"
 embedded-hal = "0.2.6"
 panic-probe = { version = "0.3", features = ["print-defmt"] }

--- a/examples/stm32f4/Cargo.toml
+++ b/examples/stm32f4/Cargo.toml
@@ -12,7 +12,7 @@ embassy-stm32 = { version = "0.1.0", path = "../../embassy-stm32", features = ["
 defmt = "0.3"
 defmt-rtt = "0.3"
 
-cortex-m = "0.7.3"
+cortex-m = { version = "0.7.6", features = ["critical-section-single-core"] }
 cortex-m-rt = "0.7.0"
 embedded-hal = "0.2.6"
 embedded-io = "0.3.0"

--- a/examples/stm32f7/Cargo.toml
+++ b/examples/stm32f7/Cargo.toml
@@ -13,7 +13,7 @@ embedded-io = { version = "0.3.0", features = ["async"] }
 defmt = "0.3"
 defmt-rtt = "0.3"
 
-cortex-m = "0.7.3"
+cortex-m = { version = "0.7.6", features = ["critical-section-single-core"] }
 cortex-m-rt = "0.7.0"
 embedded-hal = "0.2.6"
 panic-probe = { version = "0.3", features = ["print-defmt"] }
@@ -21,5 +21,5 @@ futures = { version = "0.3.17", default-features = false, features = ["async-awa
 heapless = { version = "0.7.5", default-features = false }
 nb = "1.0.0"
 rand_core = "0.6.3"
-critical-section = "0.2.3"
+critical-section = "1.1"
 embedded-storage = "0.3.0"

--- a/examples/stm32g0/Cargo.toml
+++ b/examples/stm32g0/Cargo.toml
@@ -11,7 +11,7 @@ embassy-stm32 = { version = "0.1.0", path = "../../embassy-stm32", features = ["
 defmt = "0.3"
 defmt-rtt = "0.3"
 
-cortex-m = "0.7.3"
+cortex-m = { version = "0.7.6", features = ["critical-section-single-core"] }
 cortex-m-rt = "0.7.0"
 embedded-hal = "0.2.6"
 panic-probe = { version = "0.3", features = ["print-defmt"] }

--- a/examples/stm32g4/Cargo.toml
+++ b/examples/stm32g4/Cargo.toml
@@ -12,7 +12,7 @@ embassy-hal-common = {version = "0.1.0", path = "../../embassy-hal-common" }
 defmt = "0.3"
 defmt-rtt = "0.3"
 
-cortex-m = "0.7.3"
+cortex-m = { version = "0.7.6", features = ["critical-section-single-core"] }
 cortex-m-rt = "0.7.0"
 embedded-hal = "0.2.6"
 panic-probe = { version = "0.3", features = ["print-defmt"] }

--- a/examples/stm32h7/Cargo.toml
+++ b/examples/stm32h7/Cargo.toml
@@ -13,7 +13,7 @@ embedded-io = { version = "0.3.0", features = ["async"] }
 defmt = "0.3"
 defmt-rtt = "0.3"
 
-cortex-m = "0.7.3"
+cortex-m = { version = "0.7.6", features = ["critical-section-single-core"] }
 cortex-m-rt = "0.7.0"
 embedded-hal = "0.2.6"
 embedded-hal-1 = { package = "embedded-hal", version = "1.0.0-alpha.8" }
@@ -23,7 +23,7 @@ panic-probe = { version = "0.3", features = ["print-defmt"] }
 futures = { version = "0.3.17", default-features = false, features = ["async-await"] }
 heapless = { version = "0.7.5", default-features = false }
 rand_core = "0.6.3"
-critical-section = "0.2.5"
+critical-section = "1.1"
 micromath = "2.0.0"
 stm32-fmc = "0.2.4"
 embedded-storage = "0.3.0"

--- a/examples/stm32l0/Cargo.toml
+++ b/examples/stm32l0/Cargo.toml
@@ -22,7 +22,7 @@ defmt-rtt = "0.3"
 embedded-storage = "0.3.0"
 embedded-io = "0.3.0"
 
-cortex-m = "0.7.3"
+cortex-m = { version = "0.7.6", features = ["critical-section-single-core"] }
 cortex-m-rt = "0.7.0"
 panic-probe = { version = "0.3", features = ["print-defmt"] }
 futures = { version = "0.3.17", default-features = false, features = ["async-await"] }

--- a/examples/stm32l1/Cargo.toml
+++ b/examples/stm32l1/Cargo.toml
@@ -11,7 +11,7 @@ embassy-stm32 = { version = "0.1.0", path = "../../embassy-stm32", features = ["
 defmt = "0.3"
 defmt-rtt = "0.3"
 
-cortex-m = "0.7.3"
+cortex-m = { version = "0.7.6", features = ["critical-section-single-core"] }
 cortex-m-rt = "0.7.0"
 embedded-hal = "0.2.6"
 panic-probe = { version = "0.3", features = ["print-defmt"] }

--- a/examples/stm32l4/Cargo.toml
+++ b/examples/stm32l4/Cargo.toml
@@ -14,7 +14,7 @@ embassy-stm32 = { version = "0.1.0", path = "../../embassy-stm32", features = ["
 defmt = "0.3"
 defmt-rtt = "0.3"
 
-cortex-m = "0.7.3"
+cortex-m = { version = "0.7.6", features = ["critical-section-single-core"] }
 cortex-m-rt = "0.7.0"
 embedded-hal = "0.2.6"
 embedded-hal-1 = { package = "embedded-hal", version = "1.0.0-alpha.8" }

--- a/examples/stm32l5/Cargo.toml
+++ b/examples/stm32l5/Cargo.toml
@@ -20,7 +20,7 @@ defmt = "0.3"
 defmt-rtt = "0.3"
 panic-probe = { version = "0.3", features = ["print-defmt"] }
 
-cortex-m = "0.7.3"
+cortex-m = { version = "0.7.6", features = ["critical-section-single-core"] }
 cortex-m-rt = "0.7.0"
 embedded-hal = "0.2.6"
 futures = { version = "0.3.17", default-features = false, features = ["async-await"] }

--- a/examples/stm32u5/Cargo.toml
+++ b/examples/stm32u5/Cargo.toml
@@ -11,7 +11,7 @@ embassy-stm32 = { version = "0.1.0", path = "../../embassy-stm32", features = ["
 defmt = "0.3"
 defmt-rtt = "0.3"
 
-cortex-m = "0.7.3"
+cortex-m = { version = "0.7.6", features = ["critical-section-single-core"] }
 cortex-m-rt = "0.7.0"
 embedded-hal = "0.2.6"
 panic-probe = { version = "0.3", features = ["print-defmt"] }

--- a/examples/stm32wb/Cargo.toml
+++ b/examples/stm32wb/Cargo.toml
@@ -11,7 +11,7 @@ embassy-stm32 = { version = "0.1.0", path = "../../embassy-stm32", features = ["
 defmt = "0.3"
 defmt-rtt = "0.3"
 
-cortex-m = "0.7.3"
+cortex-m = { version = "0.7.6", features = ["critical-section-single-core"] }
 cortex-m-rt = "0.7.0"
 embedded-hal = "0.2.6"
 panic-probe = { version = "0.3", features = ["print-defmt"] }

--- a/examples/stm32wl/Cargo.toml
+++ b/examples/stm32wl/Cargo.toml
@@ -15,7 +15,7 @@ lorawan = { version = "0.7.1", default-features = false, features = ["default-cr
 defmt = "0.3"
 defmt-rtt = "0.3"
 
-cortex-m = "0.7.3"
+cortex-m = { version = "0.7.6", features = ["critical-section-single-core"] }
 cortex-m-rt = "0.7.0"
 embedded-hal = "0.2.6"
 embedded-storage = "0.3.0"

--- a/examples/wasm/Cargo.toml
+++ b/examples/wasm/Cargo.toml
@@ -14,4 +14,4 @@ wasm-logger = "0.2.0"
 wasm-bindgen = "0.2"
 web-sys = { version = "0.3", features = ["Document", "Element", "HtmlElement", "Node", "Window" ] }
 log = "0.4.11"
-critical-section = "0.2.5"
+critical-section = "1.1"

--- a/stm32-metapac/Cargo.toml
+++ b/stm32-metapac/Cargo.toml
@@ -40,7 +40,7 @@ flavors = [
 ]
 
 [dependencies]
-cortex-m = "0.7.3"
+cortex-m = "0.7.6"
 cortex-m-rt = { version = ">=0.6.15,<0.8", optional = true }
 
 # BEGIN BUILD DEPENDENCIES

--- a/tests/rp/Cargo.toml
+++ b/tests/rp/Cargo.toml
@@ -11,7 +11,7 @@ embassy-rp = { version = "0.1.0", path = "../../embassy-rp", features = ["nightl
 defmt = "0.3.0"
 defmt-rtt = "0.3.0"
 
-cortex-m = "0.7.3"
+cortex-m = { version = "0.7.6", features = ["critical-section-single-core"] }
 cortex-m-rt = "0.7.0"
 embedded-hal = "0.2.6"
 embedded-hal-1 = { package = "embedded-hal", version = "1.0.0-alpha.8" }

--- a/tests/stm32/Cargo.toml
+++ b/tests/stm32/Cargo.toml
@@ -20,7 +20,7 @@ embassy-stm32 = { version = "0.1.0", path = "../../embassy-stm32", features = ["
 defmt = "0.3.0"
 defmt-rtt = "0.3.0"
 
-cortex-m = "0.7.3"
+cortex-m = { version = "0.7.6", features = ["critical-section-single-core"] }
 cortex-m-rt = "0.7.0"
 embedded-hal = "0.2.6"
 embedded-hal-1 = { package = "embedded-hal", version = "1.0.0-alpha.8" }


### PR DESCRIPTION
TODO
- [x] Wait for cortex-m 0.7.6 release https://github.com/rust-embedded/cortex-m/pull/449
- [x] ~~Wait for defmt-rtt 0.4 release https://github.com/knurling-rs/defmt/pull/689~~ we're still going to use defmt 0.3 for now, which will use the `critical-section` 0.2 default impl, which works.
- [x] Wait for critical-secton `std` impl https://github.com/rust-embedded/critical-section/pull/22