### PR TITLE
Update signal.rs

### DIFF
--- a/embassy-util/src/channel/signal.rs
+++ b/embassy-util/src/channel/signal.rs
@@ -69,6 +69,7 @@ impl<T: Send> Signal<T> {
         })
     }
 
+    /// Manually poll the Signal future.
     pub fn poll_wait(&self, cx: &mut Context<'_>) -> Poll<T> {
         critical_section::with(|_| unsafe {
             let state = &mut *self.state.get();

--- a/embassy-util/src/channel/signal.rs
+++ b/embassy-util/src/channel/signal.rs
@@ -69,7 +69,7 @@ impl<T: Send> Signal<T> {
         })
     }
 
-    fn poll_wait(&self, cx: &mut Context<'_>) -> Poll<T> {
+    pub fn poll_wait(&self, cx: &mut Context<'_>) -> Poll<T> {
         critical_section::with(|_| unsafe {
             let state = &mut *self.state.get();
             match state {


### PR DESCRIPTION
Allow `poll_wait` to be public so higher-order futures around Signal can be built.