### PR TITLE
Ensure interrupt::take works without embassy-executor

### DIFF
--- a/embassy-executor/Cargo.toml
+++ b/embassy-executor/Cargo.toml
@@ -31,7 +31,7 @@ nightly = []
 integrated-timers = ["dep:embassy-time"]
 
 # Trace interrupt invocations with rtos-trace.
-rtos-trace-interrupt = ["rtos-trace"]
+rtos-trace-interrupt = ["rtos-trace", "embassy-macros/rtos-trace-interrupt"]
 
 [dependencies]
 defmt = { version = "0.3", optional = true }
@@ -39,7 +39,7 @@ log = { version = "0.4.14", optional = true }
 rtos-trace = { version = "0.1.2", optional = true }
 
 futures-util = { version = "0.3.17", default-features = false }
-embassy-macros  = { version = "0.1.0", path = "../embassy-macros"}
+embassy-macros  = { version = "0.1.0", path = "../embassy-macros" }
 embassy-time  = { version = "0.1.0", path = "../embassy-time", optional = true}
 atomic-polyfill = "1.0.1"
 critical-section = "1.1"

--- a/embassy-macros/Cargo.toml
+++ b/embassy-macros/Cargo.toml
@@ -15,3 +15,6 @@ proc-macro = true
 [features]
 std = []
 wasm = []
+
+# Enabling this cause interrupt::take! to require embassy-executor
+rtos-trace-interrupt = []

--- a/embassy-macros/src/macros/cortex_m_interrupt_take.rs
+++ b/embassy-macros/src/macros/cortex_m_interrupt_take.rs
@@ -6,6 +6,23 @@ pub fn run(name: syn::Ident) -> Result<TokenStream, TokenStream> {
     let name_interrupt = format_ident!("{}", name);
     let name_handler = format!("__EMBASSY_{}_HANDLER", name);
 
+    #[cfg(feature = "rtos-trace-interrupt")]
+    let (isr_enter, isr_exit) = (
+        quote! {
+            ::embassy_executor::rtos_trace_interrupt! {
+                ::embassy_executor::export::trace::isr_enter();
+            }
+        },
+        quote! {
+            ::embassy_executor::rtos_trace_interrupt! {
+                ::embassy_executor::export::trace::isr_exit();
+            }
+        },
+    );
+
+    #[cfg(not(feature = "rtos-trace-interrupt"))]
+    let (isr_enter, isr_exit) = (quote! {}, quote! {});
+
     let result = quote! {
         {
             #[allow(non_snake_case)]
@@ -19,13 +36,11 @@ pub fn run(name: syn::Ident) -> Result<TokenStream, TokenStream> {
                 let func = HANDLER.func.load(interrupt::_export::atomic::Ordering::Relaxed);
                 let ctx = HANDLER.ctx.load(interrupt::_export::atomic::Ordering::Relaxed);
                 let func: fn(*mut ()) = ::core::mem::transmute(func);
-                ::embassy_executor::rtos_trace_interrupt! {
-                    ::embassy_executor::export::trace::isr_enter();
-                }
+                #isr_enter
+
                 func(ctx);
-                ::embassy_executor::rtos_trace_interrupt! {
-                    ::embassy_executor::export::trace::isr_exit();
-                }
+                #isr_exit
+
             }
 
             static TAKEN: interrupt::_export::atomic::AtomicBool = interrupt::_export::atomic::AtomicBool::new(false);


### PR DESCRIPTION
Add "rtos-trace-interrupt" feature flag on embassy-macros and enable it
for embassy-executor, to ensure that the interrupt::take! macro can be
used without depending on embassy-executor.