### PR TITLE
Enable 'std' feature on critical-section for WASM

### DIFF
--- a/embassy-executor/Cargo.toml
+++ b/embassy-executor/Cargo.toml
@@ -47,5 +47,5 @@ cfg-if = "1.0.0"
 static_cell = "1.0"
 
 # WASM dependencies
-wasm-bindgen = { version = "0.2.76", features = ["nightly"], optional = true }
+wasm-bindgen = { version = "0.2.82", optional = true }
 js-sys = { version = "0.3", optional = true }

--- a/embassy-time/Cargo.toml
+++ b/embassy-time/Cargo.toml
@@ -49,6 +49,6 @@ critical-section = "1.1"
 cfg-if = "1.0.0"
 
 # WASM dependencies
-wasm-bindgen = { version = "0.2.76", features = ["nightly"], optional = true }
+wasm-bindgen = { version = "0.2.81", optional = true }
 js-sys = { version = "0.3", optional = true }
 wasm-timer = { version = "0.2.5", optional = true }

--- a/examples/wasm/Cargo.toml
+++ b/examples/wasm/Cargo.toml
@@ -15,4 +15,4 @@ wasm-logger = "0.2.0"
 wasm-bindgen = "0.2"
 web-sys = { version = "0.3", features = ["Document", "Element", "HtmlElement", "Node", "Window" ] }
 log = "0.4.11"
-critical-section = "1.1"
+critical-section = { version = "1.1", features = ["std"] }

--- a/examples/wasm/README.md
+++ b/examples/wasm/README.md
@@ -3,7 +3,7 @@
 Examples use a CLI tool named `wasm-pack` to build this example:
 
 ```
-cargo install wasm-pack
+cargo install wasm-pack --version 0.9.1
 ```
 
 ## Building


### PR DESCRIPTION
This fixes the WASM support which was failing due to missing
critical-section implementation. This also upgrades the bindgen
dependency and ensures that tooling works.