### PR TITLE
Ensure that the sampling is stopped

### DIFF
--- a/embassy-nrf/src/saadc.rs
+++ b/embassy-nrf/src/saadc.rs
@@ -224,6 +224,8 @@ impl<'d, const N: usize> Saadc<'d, N> {
     }
 
     /// One shot sampling. The buffer must be the same size as the number of channels configured.
+    /// The sampling is stopped prior to returning in order to reduce power consumption (power
+    /// consumption remains higher if sampling is not stopped explicitly).
     pub async fn sample(&mut self, buf: &mut [i16; N]) {
         let r = Self::regs();
 

--- a/embassy-nrf/src/saadc.rs
+++ b/embassy-nrf/src/saadc.rs
@@ -184,11 +184,6 @@ impl<'d, const N: usize> Saadc<'d, N> {
             r.intenclr.write(|w| w.started().clear());
             WAKER.wake();
         }
-
-        if r.events_stopped.read().bits() != 0 {
-            r.intenclr.write(|w| w.stopped().clear());
-            WAKER.wake();
-        }
     }
 
     fn regs() -> &'static saadc::RegisterBlock {
@@ -230,7 +225,7 @@ impl<'d, const N: usize> Saadc<'d, N> {
     /// also cause the sampling to be stopped.
     pub async fn sample(&mut self, buf: &mut [i16; N]) {
         // In case the future is dropped, stop the task and wait for it to end.
-        let on_drop = OnDrop::new(Self::stop_sampling_immediately);
+        OnDrop::new(Self::stop_sampling_immediately);
 
         let r = Self::regs();
 
@@ -263,9 +258,6 @@ impl<'d, const N: usize> Saadc<'d, N> {
             Poll::Pending
         })
         .await;
-
-        on_drop.defuse();
-        Self::stop_sampling().await;
     }
 
     /// Continuous sampling with double buffers.
@@ -343,7 +335,7 @@ impl<'d, const N: usize> Saadc<'d, N> {
         S: FnMut(&[[i16; N]]) -> SamplerState,
     {
         // In case the future is dropped, stop the task and wait for it to end.
-        let on_drop = OnDrop::new(Self::stop_sampling_immediately);
+        OnDrop::new(Self::stop_sampling_immediately);
 
         let r = Self::regs();
 
@@ -427,9 +419,6 @@ impl<'d, const N: usize> Saadc<'d, N> {
             Poll::Pending
         })
         .await;
-
-        on_drop.defuse();
-        Self::stop_sampling().await;
     }
 
     // Stop sampling and wait for it to stop in a blocking fashion
@@ -443,40 +432,6 @@ impl<'d, const N: usize> Saadc<'d, N> {
 
         while r.events_stopped.read().bits() == 0 {}
         r.events_stopped.reset();
-    }
-
-    // Stop sampling and wait for it to stop in a non-blocking fashino
-    async fn stop_sampling() {
-        let r = Self::regs();
-
-        // Reset and enable the events
-
-        compiler_fence(Ordering::SeqCst);
-
-        r.events_stopped.reset();
-        r.intenset.write(|w| {
-            w.stopped().set();
-            w
-        });
-
-        // Stop
-
-        r.tasks_stop.write(|w| unsafe { w.bits(1) });
-
-        // Wait for 'stopped' event.
-        poll_fn(|cx| {
-            let r = Self::regs();
-
-            WAKER.register(cx.waker());
-
-            if r.events_stopped.read().bits() != 0 {
-                r.events_stopped.reset();
-                return Poll::Ready(());
-            }
-
-            Poll::Pending
-        })
-        .await;
     }
 }
 


### PR DESCRIPTION
Ensures that nRF saadc sampling is stopped and is awaited prior to exiting the two sampling methods. Not doing so causes a potential power drain and the potential for dropped buffer writes when having finished continuous sampling.