### PR TITLE
Remove generic const expressions from embassy-boot

### DIFF
--- a/embassy-boot/README.md
+++ b/embassy-boot/README.md
@@ -1,0 +1,30 @@
+# embassy-boot
+
+An [Embassy](https://embassy.dev) project.
+
+A lightweight bootloader supporting firmware updates in a power-fail-safe way, with trial boots and rollbacks.
+
+The bootloader can be used either as a library or be flashed directly with the default configuration derived from linker scripts.
+
+By design, the bootloader does not provide any network capabilities. Networking capabilities for fetching new firmware can be provided by the user application, using the bootloader as a library for updating the firmware, or by using the bootloader as a library and adding this capability yourself.
+
+## Hardware support
+
+The bootloader supports different hardware in separate crates:
+
+* `embassy-boot-nrf` - for the nRF microcontrollers.
+* `embassy-boot-stm32` - for the STM32 microcontrollers.
+
+## Minimum supported Rust version (MSRV)
+
+`embassy-boot` requires Rust nightly to compile as it relies on async traits for interacting with the flash peripherals.
+
+## License
+
+This work is licensed under either of
+
+- Apache License, Version 2.0 ([LICENSE-APACHE](LICENSE-APACHE) or
+  <http://www.apache.org/licenses/LICENSE-2.0>)
+- MIT license ([LICENSE-MIT](LICENSE-MIT) or <http://opensource.org/licenses/MIT>)
+
+at your option.

--- a/embassy-boot/nrf/src/lib.rs
+++ b/embassy-boot/nrf/src/lib.rs
@@ -1,19 +1,21 @@
 #![no_std]
 #![feature(generic_associated_types)]
 #![feature(type_alias_impl_trait)]
-#![allow(incomplete_features)]
-#![feature(generic_const_exprs)]
-
+#![warn(missing_docs)]
+#![doc = include_str!("../../README.md")]
 mod fmt;
 
-pub use embassy_boot::{FirmwareUpdater, FlashConfig, FlashProvider, Partition, SingleFlashProvider};
+pub use embassy_boot::{AlignedBuffer, BootFlash, FirmwareUpdater, FlashConfig, Partition, SingleFlashConfig};
 use embassy_nrf::nvmc::{Nvmc, PAGE_SIZE};
 use embassy_nrf::peripherals::WDT;
 use embassy_nrf::wdt;
 use embedded_storage::nor_flash::{ErrorType, NorFlash, ReadNorFlash};
 
+/// A bootloader for nRF devices.
 pub struct BootLoader {
-    boot: embassy_boot::BootLoader<PAGE_SIZE>,
+    boot: embassy_boot::BootLoader,
+    magic: AlignedBuffer<4>,
+    page: AlignedBuffer<PAGE_SIZE>,
 }
 
 impl BootLoader {
@@ -58,21 +60,25 @@ impl BootLoader {
     pub fn new(active: Partition, dfu: Partition, state: Partition) -> Self {
         Self {
             boot: embassy_boot::BootLoader::new(active, dfu, state),
+            magic: AlignedBuffer([0; 4]),
+            page: AlignedBuffer([0; PAGE_SIZE]),
         }
     }
 
-    /// Boots the application without softdevice mechanisms
-    pub fn prepare<F: FlashProvider>(&mut self, flash: &mut F) -> usize
-    where
-        [(); <<F as FlashProvider>::STATE as FlashConfig>::FLASH::WRITE_SIZE]:,
-        [(); <<F as FlashProvider>::ACTIVE as FlashConfig>::FLASH::ERASE_SIZE]:,
-    {
-        match self.boot.prepare_boot(flash) {
+    /// Inspect the bootloader state and perform actions required before booting, such as swapping
+    /// firmware.
+    pub fn prepare<F: FlashConfig>(&mut self, flash: &mut F) -> usize {
+        match self.boot.prepare_boot(flash, &mut self.magic.0, &mut self.page.0) {
             Ok(_) => self.boot.boot_address(),
             Err(_) => panic!("boot prepare error!"),
         }
     }
 
+    /// Boots the application without softdevice mechanisms.
+    ///
+    /// # Safety
+    ///
+    /// This modifies the stack pointer and reset vector and will run code placed in the active partition.
     #[cfg(not(feature = "softdevice"))]
     pub unsafe fn load(&mut self, start: usize) -> ! {
         let mut p = cortex_m::Peripherals::steal();
@@ -81,6 +87,11 @@ impl BootLoader {
         cortex_m::asm::bootload(start as *const u32)
     }
 
+    /// Boots the application assuming softdevice is present.
+    ///
+    /// # Safety
+    ///
+    /// This modifies the stack pointer and reset vector and will run code placed in the active partition.
     #[cfg(feature = "softdevice")]
     pub unsafe fn load(&mut self, _app: usize) -> ! {
         use nrf_softdevice_mbr as mbr;

--- a/examples/boot/application/nrf/src/bin/a.rs
+++ b/examples/boot/application/nrf/src/bin/a.rs
@@ -36,7 +36,8 @@ async fn main(_spawner: Spawner) {
                 updater.write_firmware(offset, &buf, &mut nvmc, 4096).await.unwrap();
                 offset += chunk.len();
             }
-            updater.update(&mut nvmc).await.unwrap();
+            let mut magic = [0; 4];
+            updater.mark_updated(&mut nvmc, &mut magic).await.unwrap();
             led.set_high();
             cortex_m::peripheral::SCB::sys_reset();
         }

--- a/examples/boot/application/stm32f3/src/bin/a.rs
+++ b/examples/boot/application/stm32f3/src/bin/a.rs
@@ -4,11 +4,11 @@
 
 #[cfg(feature = "defmt-rtt")]
 use defmt_rtt::*;
-use embassy_boot_stm32::FirmwareUpdater;
+use embassy_boot_stm32::{AlignedBuffer, FirmwareUpdater};
 use embassy_embedded_hal::adapter::BlockingAsync;
 use embassy_executor::Spawner;
 use embassy_stm32::exti::ExtiInput;
-use embassy_stm32::flash::Flash;
+use embassy_stm32::flash::{Flash, WRITE_SIZE};
 use embassy_stm32::gpio::{Input, Level, Output, Pull, Speed};
 use panic_reset as _;
 
@@ -35,7 +35,8 @@ async fn main(_spawner: Spawner) {
         updater.write_firmware(offset, &buf, &mut flash, 2048).await.unwrap();
         offset += chunk.len();
     }
-    updater.update(&mut flash).await.unwrap();
+    let mut magic = AlignedBuffer([0; WRITE_SIZE]);
+    updater.mark_updated(&mut flash, magic.as_mut()).await.unwrap();
     led.set_low();
     cortex_m::peripheral::SCB::sys_reset();
 }

--- a/examples/boot/application/stm32f7/src/bin/a.rs
+++ b/examples/boot/application/stm32f7/src/bin/a.rs
@@ -4,11 +4,11 @@
 
 #[cfg(feature = "defmt-rtt")]
 use defmt_rtt::*;
-use embassy_boot_stm32::FirmwareUpdater;
+use embassy_boot_stm32::{AlignedBuffer, FirmwareUpdater};
 use embassy_embedded_hal::adapter::BlockingAsync;
 use embassy_executor::Spawner;
 use embassy_stm32::exti::ExtiInput;
-use embassy_stm32::flash::Flash;
+use embassy_stm32::flash::{Flash, WRITE_SIZE};
 use embassy_stm32::gpio::{Input, Level, Output, Pull, Speed};
 use panic_reset as _;
 
@@ -35,7 +35,8 @@ async fn main(_spawner: Spawner) {
         updater.write_firmware(offset, &buf, &mut flash, 2048).await.unwrap();
         offset += chunk.len();
     }
-    updater.update(&mut flash).await.unwrap();
+    let mut magic = AlignedBuffer([0; WRITE_SIZE]);
+    updater.mark_updated(&mut flash, magic.as_mut()).await.unwrap();
     led.set_low();
     cortex_m::peripheral::SCB::sys_reset();
 }

--- a/examples/boot/application/stm32h7/Cargo.toml
+++ b/examples/boot/application/stm32h7/Cargo.toml
@@ -4,7 +4,7 @@ name = "embassy-boot-stm32h7-examples"
 version = "0.1.0"
 
 [dependencies]
-embassy-sync = { version = "0.1.0", path = "../../../../embassy-sync", features = ["defmt"] }
+embassy-sync = { version = "0.1.0", path = "../../../../embassy-sync" }
 embassy-executor = { version = "0.1.0", path = "../../../../embassy-executor", features = ["nightly", "integrated-timers"] }
 embassy-time = { version = "0.1.0", path = "../../../../embassy-time", features = ["nightly", "tick-32768hz"] }
 embassy-stm32 = { version = "0.1.0", path = "../../../../embassy-stm32", features = ["unstable-traits", "nightly", "stm32h743zi", "time-driver-any", "exti"]  }

--- a/examples/boot/application/stm32h7/flash-boot.sh
+++ b/examples/boot/application/stm32h7/flash-boot.sh
@@ -1,8 +1,9 @@
 #!/bin/bash
+probe-rs-cli erase --chip STM32H743ZITx
 mv ../../bootloader/stm32/memory.x ../../bootloader/stm32/memory-old.x
 cp memory-bl.x ../../bootloader/stm32/memory.x
 
-cargo flash --manifest-path ../../bootloader/stm32/Cargo.toml --release --features embassy-stm32/stm32f767zi --chip STM32F767ZITx --target thumbv7em-none-eabihf
+cargo flash --manifest-path ../../bootloader/stm32/Cargo.toml --release --features embassy-stm32/stm32h743zi --chip STM32H743ZITx --target thumbv7em-none-eabihf
 
 rm ../../bootloader/stm32/memory.x
 mv ../../bootloader/stm32/memory-old.x ../../bootloader/stm32/memory.x

--- a/examples/boot/application/stm32l0/src/bin/a.rs
+++ b/examples/boot/application/stm32l0/src/bin/a.rs
@@ -4,11 +4,11 @@
 
 #[cfg(feature = "defmt-rtt")]
 use defmt_rtt::*;
-use embassy_boot_stm32::FirmwareUpdater;
+use embassy_boot_stm32::{AlignedBuffer, FirmwareUpdater};
 use embassy_embedded_hal::adapter::BlockingAsync;
 use embassy_executor::Spawner;
 use embassy_stm32::exti::ExtiInput;
-use embassy_stm32::flash::Flash;
+use embassy_stm32::flash::{Flash, WRITE_SIZE};
 use embassy_stm32::gpio::{Input, Level, Output, Pull, Speed};
 use embassy_time::{Duration, Timer};
 use panic_reset as _;
@@ -38,7 +38,8 @@ async fn main(_spawner: Spawner) {
         offset += chunk.len();
     }
 
-    updater.update(&mut flash).await.unwrap();
+    let mut magic = AlignedBuffer([0; WRITE_SIZE]);
+    updater.mark_updated(&mut flash, magic.as_mut()).await.unwrap();
     led.set_low();
     Timer::after(Duration::from_secs(1)).await;
     cortex_m::peripheral::SCB::sys_reset();

--- a/examples/boot/application/stm32l1/src/bin/a.rs
+++ b/examples/boot/application/stm32l1/src/bin/a.rs
@@ -4,11 +4,11 @@
 
 #[cfg(feature = "defmt-rtt")]
 use defmt_rtt::*;
-use embassy_boot_stm32::FirmwareUpdater;
+use embassy_boot_stm32::{AlignedBuffer, FirmwareUpdater};
 use embassy_embedded_hal::adapter::BlockingAsync;
 use embassy_executor::Spawner;
 use embassy_stm32::exti::ExtiInput;
-use embassy_stm32::flash::Flash;
+use embassy_stm32::flash::{Flash, WRITE_SIZE};
 use embassy_stm32::gpio::{Input, Level, Output, Pull, Speed};
 use embassy_time::{Duration, Timer};
 use panic_reset as _;
@@ -38,7 +38,8 @@ async fn main(_spawner: Spawner) {
         offset += chunk.len();
     }
 
-    updater.update(&mut flash).await.unwrap();
+    let mut magic = AlignedBuffer([0; WRITE_SIZE]);
+    updater.mark_updated(&mut flash, magic.as_mut()).await.unwrap();
     led.set_low();
     Timer::after(Duration::from_secs(1)).await;
     cortex_m::peripheral::SCB::sys_reset();

--- a/examples/boot/application/stm32l4/src/bin/a.rs
+++ b/examples/boot/application/stm32l4/src/bin/a.rs
@@ -4,11 +4,11 @@
 
 #[cfg(feature = "defmt-rtt")]
 use defmt_rtt::*;
-use embassy_boot_stm32::FirmwareUpdater;
+use embassy_boot_stm32::{AlignedBuffer, FirmwareUpdater};
 use embassy_embedded_hal::adapter::BlockingAsync;
 use embassy_executor::Spawner;
 use embassy_stm32::exti::ExtiInput;
-use embassy_stm32::flash::Flash;
+use embassy_stm32::flash::{Flash, WRITE_SIZE};
 use embassy_stm32::gpio::{Input, Level, Output, Pull, Speed};
 use panic_reset as _;
 
@@ -35,7 +35,8 @@ async fn main(_spawner: Spawner) {
         updater.write_firmware(offset, &buf, &mut flash, 2048).await.unwrap();
         offset += chunk.len();
     }
-    updater.update(&mut flash).await.unwrap();
+    let mut magic = AlignedBuffer([0; WRITE_SIZE]);
+    updater.mark_updated(&mut flash, magic.as_mut()).await.unwrap();
     led.set_low();
     cortex_m::peripheral::SCB::sys_reset();
 }

--- a/examples/boot/application/stm32wl/src/bin/a.rs
+++ b/examples/boot/application/stm32wl/src/bin/a.rs
@@ -4,11 +4,11 @@
 
 #[cfg(feature = "defmt-rtt")]
 use defmt_rtt::*;
-use embassy_boot_stm32::FirmwareUpdater;
+use embassy_boot_stm32::{AlignedBuffer, FirmwareUpdater};
 use embassy_embedded_hal::adapter::BlockingAsync;
 use embassy_executor::Spawner;
 use embassy_stm32::exti::ExtiInput;
-use embassy_stm32::flash::Flash;
+use embassy_stm32::flash::{Flash, WRITE_SIZE};
 use embassy_stm32::gpio::{Input, Level, Output, Pull, Speed};
 use panic_reset as _;
 
@@ -37,7 +37,8 @@ async fn main(_spawner: Spawner) {
         updater.write_firmware(offset, &buf, &mut flash, 2048).await.unwrap();
         offset += chunk.len();
     }
-    updater.update(&mut flash).await.unwrap();
+    let mut magic = AlignedBuffer([0; WRITE_SIZE]);
+    updater.mark_updated(&mut flash, magic.as_mut()).await.unwrap();
     //defmt::info!("Marked as updated");
     led.set_low();
     cortex_m::peripheral::SCB::sys_reset();

--- a/examples/boot/bootloader/nrf/src/main.rs
+++ b/examples/boot/bootloader/nrf/src/main.rs
@@ -20,10 +20,8 @@ fn main() -> ! {
     */
 
     let mut bl = BootLoader::default();
-    let start = bl.prepare(&mut SingleFlashProvider::new(&mut WatchdogFlash::start(
-        Nvmc::new(p.NVMC),
-        p.WDT,
-        5,
+    let start = bl.prepare(&mut SingleFlashConfig::new(&mut BootFlash::<_, 4096>::new(
+        &mut WatchdogFlash::start(Nvmc::new(p.NVMC), p.WDT, 5),
     )));
     unsafe { bl.load(start) }
 }

--- a/examples/boot/bootloader/stm32/src/main.rs
+++ b/examples/boot/bootloader/stm32/src/main.rs
@@ -5,7 +5,7 @@ use cortex_m_rt::{entry, exception};
 #[cfg(feature = "defmt")]
 use defmt_rtt as _;
 use embassy_boot_stm32::*;
-use embassy_stm32::flash::{Flash, ERASE_SIZE};
+use embassy_stm32::flash::{Flash, ERASE_SIZE, ERASE_VALUE, WRITE_SIZE};
 
 #[entry]
 fn main() -> ! {
@@ -19,9 +19,11 @@ fn main() -> ! {
         }
     */
 
-    let mut bl: BootLoader<ERASE_SIZE> = BootLoader::default();
+    let mut bl: BootLoader<ERASE_SIZE, WRITE_SIZE> = BootLoader::default();
     let mut flash = Flash::unlock(p.FLASH);
-    let start = bl.prepare(&mut SingleFlashProvider::new(&mut flash));
+    let start = bl.prepare(&mut SingleFlashConfig::new(
+        &mut BootFlash::<_, ERASE_SIZE, ERASE_VALUE>::new(&mut flash),
+    ));
     core::mem::drop(flash);
     unsafe { bl.load(start) }
 }


### PR DESCRIPTION
* Remove the need for generic const expressions and use buffers provided in the flash config.
* Extend embedded-storage traits to simplify generics.
* Document all public APIs
* Add toplevel README
* Expose AlignedBuffer type for convenience.
* Update examples