### PR TITLE
Add critical-section/std to std feature

### DIFF
--- a/embassy-executor/Cargo.toml
+++ b/embassy-executor/Cargo.toml
@@ -22,7 +22,7 @@ flavors = [
 
 [features]
 default = []
-std = ["embassy-macros/std"]
+std = ["embassy-macros/std", "critical-section/std"]
 wasm = ["dep:wasm-bindgen", "dep:js-sys", "embassy-macros/wasm"]
 
 # Enable nightly-only features


### PR DESCRIPTION
This commit suggests adding `critical-section/std` to the std feature as
without this a link time error is generated:
```console
 cargo r --bin main
    Updating git repository `https://github.com/embassy-rs/embassy`
    Updating crates.io index
   Compiling embassy-executor v0.1.0 (https://github.com/embassy-rs/embassy?branch=master#50af13d4)
   Compiling embassy-macros v0.1.0 (https://github.com/embassy-rs/embassy?branch=master#50af13d4)
   Compiling embassy-time v0.1.0 (https://github.com/embassy-rs/embassy?branch=master#50af13d4)
   Compiling embassy-exploration v0.1.0 (/home/danielbevenius/work/rust/learning-rust/embassy)
error: linking with `cc` failed: exit status: 1
  |
  = note: "cc" "-m64" "/tmp/rustcSRodQD/symbols.o" "/home/danielbevenius/work/rust/learning-rust/embassy/target/debug/deps/main-1832a615156f75e5.14ikas4ibqicm80d.rcgu.o" "/home/danielbevenius/work/rust/learning-rust/embassy/target/debug/deps/main-1832a615156f75e5.18i7scdiuioyv581.rcgu.o" "/home/danielbevenius/work/rust/learning-rust/embassy/target/debug/deps/main-1832a615156f75e5.1ok8uqc3ldhimh25.rcgu.o" "/home/danielbevenius/work/rust/learning-rust/embassy/target/debug/deps/main-1832a615156f75e5.1xqethf2arni74gv.rcgu.o" "/home/danielbevenius/work/rust/learning-rust/embassy/target/debug/deps/main-1832a615156f75e5.21vi9l5ujpxyqdul.rcgu.o" "/home/danielbevenius/work/rust/learning-rust/embassy/target/debug/deps/main-1832a615156f75e5.2ddnd7hcxhe0zt3p.rcgu.o" "/home/danielbevenius/work/rust/learning-rust/embassy/target/debug/deps/main-1832a615156f75e5.2sfet6lnlsxolfnj.rcgu.o" "/home/danielbevenius/work/rust/learning-rust/embassy/target/debug/deps/main-1832a615156f75e5.2woh8eris2teqn61.rcgu.o" "/home/danielbevenius/work/rust/learning-rust/embassy/target/debug/deps/main-1832a615156f75e5.3ed4nji3ub904efe.rcgu.o" "/home/danielbevenius/work/rust/learning-rust/embassy/target/debug/deps/main-1832a615156f75e5.3j1qr10cbnc5hdky.rcgu.o" "/home/danielbevenius/work/rust/learning-rust/embassy/target/debug/deps/main-1832a615156f75e5.3kcxk9i0yzeygir7.rcgu.o" "/home/danielbevenius/work/rust/learning-rust/embassy/target/debug/deps/main-1832a615156f75e5.3ztlzj8m8r2zg8uw.rcgu.o" "/home/danielbevenius/work/rust/learning-rust/embassy/target/debug/deps/main-1832a615156f75e5.4121l5kfb4jvrdx7.rcgu.o" "/home/danielbevenius/work/rust/learning-rust/embassy/target/debug/deps/main-1832a615156f75e5.4edu5yotynsqm8za.rcgu.o" "/home/danielbevenius/work/rust/learning-rust/embassy/target/debug/deps/main-1832a615156f75e5.4v8bu7v01yjurri4.rcgu.o" "/home/danielbevenius/work/rust/learning-rust/embassy/target/debug/deps/main-1832a615156f75e5.4vcoqtkqdc34e9mz.rcgu.o" "/home/danielbevenius/work/rust/learning-rust/embassy/target/debug/deps/main-1832a615156f75e5.56mjzsmaddhhm01o.rcgu.o" "/home/danielbevenius/work/rust/learning-rust/embassy/target/debug/deps/main-1832a615156f75e5.5a0f5kqacoiz75iw.rcgu.o" "/home/danielbevenius/work/rust/learning-rust/embassy/target/debug/deps/main-1832a615156f75e5.5cdnitb2zabtf8r6.rcgu.o" "/home/danielbevenius/work/rust/learning-rust/embassy/target/debug/deps/main-1832a615156f75e5.857b2iuurxhsdws.rcgu.o" "/home/danielbevenius/work/rust/learning-rust/embassy/target/debug/deps/main-1832a615156f75e5.vdaib0obomov020.rcgu.o" "/home/danielbevenius/work/rust/learning-rust/embassy/target/debug/deps/main-1832a615156f75e5.wuy7mahwirenj6w.rcgu.o" "/home/danielbevenius/work/rust/learning-rust/embassy/target/debug/deps/main-1832a615156f75e5.2vd161v9s1cmfe2q.rcgu.o" "-Wl,--as-needed" "-L" "/home/danielbevenius/work/rust/learning-rust/embassy/target/debug/deps" "-L" "/home/danielbevenius/work/rust/learning-rust/embassy/target/debug/build/defmt-585554c438e0da4a/out" "-L" "/home/danielbevenius/.rustup/toolchains/nightly-x86_64-unknown-linux-gnu/lib/rustlib/x86_64-unknown-linux-gnu/lib" "-Wl,-Bstatic" "/home/danielbevenius/work/rust/learning-rust/embassy/target/debug/deps/libenv_logger-13edb7439f725ac4.rlib" "/home/danielbevenius/work/rust/learning-rust/embassy/target/debug/deps/libatty-12c8601fe43875b5.rlib" "/home/danielbevenius/work/rust/learning-rust/embassy/target/debug/deps/liblibc-9edce8612524dfa4.rlib" "/home/danielbevenius/work/rust/learning-rust/embassy/target/debug/deps/libtermcolor-6a61078d9610ba74.rlib" "/home/danielbevenius/work/rust/learning-rust/embassy/target/debug/deps/libhumantime-69fede984985242f.rlib" "/home/danielbevenius/work/rust/learning-rust/embassy/target/debug/deps/libregex-626fa72ec79b7aa5.rlib" "/home/danielbevenius/work/rust/learning-rust/embassy/target/debug/deps/libaho_corasick-056f10d3df8fc98c.rlib" "/home/danielbevenius/work/rust/learning-rust/embassy/target/debug/deps/libmemchr-e6bbee201eb478c9.rlib" "/home/danielbevenius/work/rust/learning-rust/embassy/target/debug/deps/libregex_syntax-5e1cc215759dcea0.rlib" "/home/danielbevenius/work/rust/learning-rust/embassy/target/debug/deps/liblog-41607b4997ff699e.rlib" "/home/danielbevenius/work/rust/learning-rust/embassy/target/debug/deps/libembassy_executor-3e221766d4969e83.rlib" "/home/danielbevenius/work/rust/learning-rust/embassy/target/debug/deps/libcfg_if-90e3626e3c41eec3.rlib" "/home/danielbevenius/work/rust/learning-rust/embassy/target/debug/deps/libstatic_cell-999da4360e12ca6a.rlib" "/home/danielbevenius/work/rust/learning-rust/embassy/target/debug/deps/libembassy_time-b2d6b6cd79ad554e.rlib" "/home/danielbevenius/work/rust/learning-rust/embassy/target/debug/deps/libdefmt-dd2e870ef9533c1d.rlib" "/home/danielbevenius/work/rust/learning-rust/embassy/target/debug/deps/libbitflags-05dfd5b5d1225bed.rlib" "/home/danielbevenius/work/rust/learning-rust/embassy/target/debug/deps/libfutures_util-5618995ea68d96a0.rlib" "/home/danielbevenius/work/rust/learning-rust/embassy/target/debug/deps/libpin_project_lite-d4223cfaa04037d7.rlib" "/home/danielbevenius/work/rust/learning-rust/embassy/target/debug/deps/libfutures_task-a4bc7de7fd258585.rlib" "/home/danielbevenius/work/rust/learning-rust/embassy/target/debug/deps/libpin_utils-b7ff504f33cec58a.rlib" "/home/danielbevenius/work/rust/learning-rust/embassy/target/debug/deps/libfutures_core-27e4b4b8992e0256.rlib" "/home/danielbevenius/work/rust/learning-rust/embassy/target/debug/deps/libembedded_hal-5a6482b51eb4cf4d.rlib" "/home/danielbevenius/work/rust/learning-rust/embassy/target/debug/deps/libvoid-7b6fd157ed8721ab.rlib" "/home/danielbevenius/work/rust/learning-rust/embassy/target/debug/deps/libnb-36022c86298e770b.rlib" "/home/danielbevenius/work/rust/learning-rust/embassy/target/debug/deps/libnb-80571a5b05fafda2.rlib" "/home/danielbevenius/work/rust/learning-rust/embassy/target/debug/deps/libcritical_section-b3e8f14a54b3edad.rlib" "/home/danielbevenius/work/rust/learning-rust/embassy/target/debug/deps/libatomic_polyfill-51ffda39a8157221.rlib" "-Wl,--start-group" "/home/danielbevenius/.rustup/toolchains/nightly-x86_64-unknown-linux-gnu/lib/rustlib/x86_64-unknown-linux-gnu/lib/libstd-4393e7d07259b8a4.rlib" "/home/danielbevenius/.rustup/toolchains/nightly-x86_64-unknown-linux-gnu/lib/rustlib/x86_64-unknown-linux-gnu/lib/libpanic_unwind-e13cbb326bcd01a4.rlib" "/home/danielbevenius/.rustup/toolchains/nightly-x86_64-unknown-linux-gnu/lib/rustlib/x86_64-unknown-linux-gnu/lib/libobject-13ac6af5403a52c8.rlib" "/home/danielbevenius/.rustup/toolchains/nightly-x86_64-unknown-linux-gnu/lib/rustlib/x86_64-unknown-linux-gnu/lib/libmemchr-a7b8febdd2acb289.rlib" "/home/danielbevenius/.rustup/toolchains/nightly-x86_64-unknown-linux-gnu/lib/rustlib/x86_64-unknown-linux-gnu/lib/libaddr2line-343513f0726f71ed.rlib" "/home/danielbevenius/.rustup/toolchains/nightly-x86_64-unknown-linux-gnu/lib/rustlib/x86_64-unknown-linux-gnu/lib/libgimli-8f833d900bfb98aa.rlib" "/home/danielbevenius/.rustup/toolchains/nightly-x86_64-unknown-linux-gnu/lib/rustlib/x86_64-unknown-linux-gnu/lib/librustc_demangle-e97a7960ca6216c8.rlib" "/home/danielbevenius/.rustup/toolchains/nightly-x86_64-unknown-linux-gnu/lib/rustlib/x86_64-unknown-linux-gnu/lib/libstd_detect-683fb35093a61fcc.rlib" "/home/danielbevenius/.rustup/toolchains/nightly-x86_64-unknown-linux-gnu/lib/rustlib/x86_64-unknown-linux-gnu/lib/libhashbrown-f943c2d34bd4b56d.rlib" "/home/danielbevenius/.rustup/toolchains/nightly-x86_64-unknown-linux-gnu/lib/rustlib/x86_64-unknown-linux-gnu/lib/libminiz_oxide-72ce2aaa649404e0.rlib" "/home/danielbevenius/.rustup/toolchains/nightly-x86_64-unknown-linux-gnu/lib/rustlib/x86_64-unknown-linux-gnu/lib/libadler-ac5d08ad5339e92e.rlib" "/home/danielbevenius/.rustup/toolchains/nightly-x86_64-unknown-linux-gnu/lib/rustlib/x86_64-unknown-linux-gnu/lib/librustc_std_workspace_alloc-dacfda262d5656fb.rlib" "/home/danielbevenius/.rustup/toolchains/nightly-x86_64-unknown-linux-gnu/lib/rustlib/x86_64-unknown-linux-gnu/lib/libunwind-e2056a834ba0712c.rlib" "/home/danielbevenius/.rustup/toolchains/nightly-x86_64-unknown-linux-gnu/lib/rustlib/x86_64-unknown-linux-gnu/lib/libcfg_if-a60649c148c6e2db.rlib" "/home/danielbevenius/.rustup/toolchains/nightly-x86_64-unknown-linux-gnu/lib/rustlib/x86_64-unknown-linux-gnu/lib/liblibc-3e961d059b9bcde7.rlib" "/home/danielbevenius/.rustup/toolchains/nightly-x86_64-unknown-linux-gnu/lib/rustlib/x86_64-unknown-linux-gnu/lib/liballoc-20f26f875d0170e2.rlib" "/home/danielbevenius/.rustup/toolchains/nightly-x86_64-unknown-linux-gnu/lib/rustlib/x86_64-unknown-linux-gnu/lib/librustc_std_workspace_core-522518611024dce5.rlib" "/home/danielbevenius/.rustup/toolchains/nightly-x86_64-unknown-linux-gnu/lib/rustlib/x86_64-unknown-linux-gnu/lib/libcore-05898138a596088a.rlib" "-Wl,--end-group" "/home/danielbevenius/.rustup/toolchains/nightly-x86_64-unknown-linux-gnu/lib/rustlib/x86_64-unknown-linux-gnu/lib/libcompiler_builtins-5b83a1df856cf582.rlib" "-Wl,-Bdynamic" "-lc" "-lm" "-lrt" "-lpthread" "-lgcc_s" "-lutil" "-lrt" "-lpthread" "-lm" "-ldl" "-lc" "-Wl,--eh-frame-hdr" "-Wl,-znoexecstack" "-L" "/home/danielbevenius/.rustup/toolchains/nightly-x86_64-unknown-linux-gnu/lib/rustlib/x86_64-unknown-linux-gnu/lib" "-o" "/home/danielbevenius/work/rust/learning-rust/embassy/target/debug/deps/main-1832a615156f75e5" "-Wl,--gc-sections" "-pie" "-Wl,-zrelro,-znow" "-nodefaultlibs"
  = note: /usr/bin/ld: /home/danielbevenius/work/rust/learning-rust/embassy/target/debug/deps/libembassy_executor-3e221766d4969e83.rlib(embassy_executor-3e221766d4969e83.embassy_executor.0b7ca5ea-cgu.11.rcgu.o): in function `critical_section::acquire':
          /home/danielbevenius/.cargo/registry/src/github.com-1ecc6299db9ec823/critical-section-1.1.0/src/lib.rs:180: undefined reference to `_critical_section_1_0_acquire'
          /usr/bin/ld: /home/danielbevenius/work/rust/learning-rust/embassy/target/debug/deps/libembassy_executor-3e221766d4969e83.rlib(embassy_executor-3e221766d4969e83.embassy_executor.0b7ca5ea-cgu.11.rcgu.o): in function `critical_section::release':
          /home/danielbevenius/.cargo/registry/src/github.com-1ecc6299db9ec823/critical-section-1.1.0/src/lib.rs:197: undefined reference to `_critical_section_1_0_release'
          /usr/bin/ld: /home/danielbevenius/work/rust/learning-rust/embassy/target/debug/deps/libembassy_executor-3e221766d4969e83.rlib(embassy_executor-3e221766d4969e83.embassy_executor.0b7ca5ea-cgu.11.rcgu.o): in function `critical_section::acquire':
          /home/danielbevenius/.cargo/registry/src/github.com-1ecc6299db9ec823/critical-section-1.1.0/src/lib.rs:180: undefined reference to `_critical_section_1_0_acquire'
          /usr/bin/ld: /home/danielbevenius/work/rust/learning-rust/embassy/target/debug/deps/libembassy_executor-3e221766d4969e83.rlib(embassy_executor-3e221766d4969e83.embassy_executor.0b7ca5ea-cgu.11.rcgu.o): in function `critical_section::release':
          /home/danielbevenius/.cargo/registry/src/github.com-1ecc6299db9ec823/critical-section-1.1.0/src/lib.rs:197: undefined reference to `_critical_section_1_0_release'
          collect2: error: ld returned 1 exit status
          
  = help: some `extern` functions couldn't be found; some native libraries may need to be installed or have their path specified
  = note: use the `-l` flag to specify native libraries to link
  = note: use the `cargo:rustc-link-lib` directive to specify the native libraries to link with Cargo (see https://doc.rust-lang.org/cargo/reference/build-scripts.html#cargorustc-link-libkindname)

error: could not compile `embassy-exploration` due to previous error

```
I ran into this when updating an [example project](https://github.com/danbev/learning-rust/tree/master/embassy) I have to use `embassy-executor`. 

----
### Reproduce
Create a new project:
```console
$ cargo new --bin embassy-standalone
$ cd embassy-standalone
```
Update `Cargo.toml`:
```toml
[package]                                                                       
name = "embassy-standalone"                                                        
version = "0.1.0"                                                                  
edition = "2021"                                                                
                                                                                
# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
                                                                                
[dependencies]                                                                  
embassy-executor = { version = "0.1.0", features = ["std", "integrated-timers", "nightly"] }
embassy-time = { version = "0.1.0", features = ["defmt", "defmt-timestamp-uptime", "std", "nightly"] }
log = "0.4.14"                                                                  
env_logger = "0.9.0"                                                            
#critical-section = { version = "1.1", features = [ "std" ] }                    
                                                                                
[patch.crates-io]                                                               
embassy-executor = { git = "https://github.com/embassy-rs/embassy", branch = "master" }
embassy-time = { git = "https://github.com/embassy-rs/embassy", branch = "master" }
```
Notice the commented out `critical-section` dependency which will produces the link error. 

Update `src/main.rs` with the code from [embassy.dev/dev/examples.html](https://embassy.dev/dev/examples.html):
```rust
#![feature(type_alias_impl_trait)]

use embassy_executor::Spawner;
use embassy_time::{Duration, Timer};
use log::*;

#[embassy_executor::task]
async fn run() {
    loop {
        info!("tick");
        Timer::after(Duration::from_secs(1)).await;
    }
}

#[embassy_executor::main]
async fn main(spawner: Spawner) {
    env_logger::builder()
        .filter_level(log::LevelFilter::Debug)
        .format_timestamp_nanos()
        .init();

    spawner.spawn(run()).unwrap();
}
```
Running the example:
```console
$ cargo r
```