### PR TITLE
Add .into_inner() and .get_mut() to Mutex

### DIFF
--- a/embassy-sync/src/mutex.rs
+++ b/embassy-sync/src/mutex.rs
@@ -114,7 +114,9 @@ where
 
     /// Consumes this mutex, returning the underlying data.
     pub fn into_inner(self) -> T
-    where T: Sized {
+    where
+        T: Sized,
+    {
         self.inner.into_inner()
     }
 

--- a/embassy-sync/src/mutex.rs
+++ b/embassy-sync/src/mutex.rs
@@ -111,6 +111,20 @@ where
 
         Ok(MutexGuard { mutex: self })
     }
+
+    /// Consumes this mutex, returning the underlying data.
+    pub fn into_inner(self) -> T
+    where T: Sized {
+        self.inner.into_inner()
+    }
+
+    /// Returns a mutable reference to the underlying data.
+    ///
+    /// Since this call borrows the Mutex mutably, no actual locking needs to
+    /// take place -- the mutable borrow statically guarantees no locks exist.
+    pub fn get_mut(&mut self) -> &mut T {
+        self.inner.get_mut()
+    }
 }
 
 /// Async mutex guard.


### PR DESCRIPTION
Similar to the methods on std Mutex, these methods allow accessing the underlying data without locking the mutex when you have exclusive access to it.