### PR TITLE
Implement proper `Drop` for `BufferedUarte`

### DIFF
--- a/embassy-nrf/src/buffered_uarte.rs
+++ b/embassy-nrf/src/buffered_uarte.rs
@@ -429,14 +429,15 @@ impl<'a, U: UarteInstance, T: TimerInstance> Drop for StateInner<'a, U, T> {
     fn drop(&mut self) {
         let r = U::regs();
 
+        self.timer.stop();
+
         r.inten.reset();
         r.events_rxto.reset();
         r.tasks_stoprx.write(|w| unsafe { w.bits(1) });
-
         r.events_txstopped.reset();
         r.tasks_stoptx.write(|w| unsafe { w.bits(1) });
-        while r.events_txstopped.read().bits() == 0 {}
 
+        while r.events_txstopped.read().bits() == 0 {}
         while r.events_rxto.read().bits() == 0 {}
 
         r.enable.write(|w| w.enable().disabled());

--- a/embassy-nrf/src/buffered_uarte.rs
+++ b/embassy-nrf/src/buffered_uarte.rs
@@ -431,13 +431,13 @@ impl<'a, U: UarteInstance, T: TimerInstance> Drop for StateInner<'a, U, T> {
 
         r.inten.reset();
         r.events_rxto.reset();
-        r.tasks_stoprx.write(|w| w.tasks_stoprx().set_bit());
+        r.tasks_stoprx.write(|w| unsafe { w.bits(1) });
 
         r.events_txstopped.reset();
-        r.tasks_stoptx.write(|w| w.tasks_stoptx().set_bit());
-        while !r.events_txstopped.read().events_txstopped().bit_is_set() {}
+        r.tasks_stoptx.write(|w| unsafe { w.bits(1) });
+        while r.events_txstopped.read().bits() == 0 {}
 
-        while !r.events_rxto.read().events_rxto().bit_is_set() {}
+        while r.events_rxto.read().bits() == 0 {}
 
         r.enable.write(|w| w.enable().disabled());
 

--- a/embassy-nrf/src/buffered_uarte.rs
+++ b/embassy-nrf/src/buffered_uarte.rs
@@ -550,13 +550,3 @@ impl<'a, U: UarteInstance, T: TimerInstance> PeripheralState for StateInner<'a, 
         trace!("irq: end");
     }
 }
-
-/// Low power blocking wait loop using WFE/SEV.
-fn low_power_wait_until(mut condition: impl FnMut() -> bool) {
-    while !condition() {
-        // WFE might "eat" an event that would have otherwise woken the executor.
-        cortex_m::asm::wfe();
-    }
-    // Retrigger an event to be transparent to the executor.
-    cortex_m::asm::sev();
-}

--- a/embassy-nrf/src/buffered_uarte.rs
+++ b/embassy-nrf/src/buffered_uarte.rs
@@ -427,10 +427,8 @@ impl<'u, 'd: 'u, U: UarteInstance, T: TimerInstance> embedded_io::asynch::Write 
 
 impl<'a, U: UarteInstance, T: TimerInstance> Drop for StateInner<'a, U, T> {
     fn drop(&mut self) {
-        debug!("oh no, dropping uarte");
         let r = U::regs();
 
-        // TODO this probably deadlocks. do like Uarte instead.
         r.inten.reset();
         r.events_rxto.reset();
         r.tasks_stoprx.write(|w| w.tasks_stoprx().set_bit());


### PR DESCRIPTION
The drop method in `BufferedUarte` was prone to hanging indefinitely and also didn't actually disable the peripheral. I mostly copied over the drop method from `Uarte` with some modifications since `BufferedUarte` could have a transmit lasting indefinitely.