### PR TITLE
Use firmware writer in stm32{f7, h7} example app

### DIFF
--- a/examples/boot/application/stm32f7/src/bin/a.rs
+++ b/examples/boot/application/stm32f7/src/bin/a.rs
@@ -5,7 +5,6 @@
 #[cfg(feature = "defmt-rtt")]
 use defmt_rtt::*;
 use embassy_boot_stm32::{AlignedBuffer, FirmwareUpdater};
-use embassy_embedded_hal::adapter::BlockingAsync;
 use embassy_executor::Spawner;
 use embassy_stm32::exti::ExtiInput;
 use embassy_stm32::flash::{Flash, WRITE_SIZE};
@@ -17,8 +16,7 @@ static APP_B: &[u8] = include_bytes!("../../b.bin");
 #[embassy_executor::main]
 async fn main(_spawner: Spawner) {
     let p = embassy_stm32::init(Default::default());
-    let flash = Flash::unlock(p.FLASH);
-    let mut flash = BlockingAsync::new(flash);
+    let mut flash = Flash::unlock(p.FLASH);
 
     let button = Input::new(p.PC13, Pull::Down);
     let mut button = ExtiInput::new(button, p.EXTI13);
@@ -27,16 +25,19 @@ async fn main(_spawner: Spawner) {
     led.set_high();
 
     let mut updater = FirmwareUpdater::default();
+    let mut writer = updater.prepare_update_blocking(&mut flash).unwrap();
     button.wait_for_rising_edge().await;
     let mut offset = 0;
-    let mut buf: [u8; 256 * 1024] = [0; 256 * 1024];
-    for chunk in APP_B.chunks(256 * 1024) {
-        buf[..chunk.len()].copy_from_slice(chunk);
-        updater.write_firmware(offset, &buf, &mut flash, 2048).await.unwrap();
+    let mut buf = AlignedBuffer([0; 4096]);
+    for chunk in APP_B.chunks(4096) {
+        buf.as_mut()[..chunk.len()].copy_from_slice(chunk);
+        writer
+            .write_block_blocking(offset, buf.as_ref(), &mut flash, chunk.len())
+            .unwrap();
         offset += chunk.len();
     }
     let mut magic = AlignedBuffer([0; WRITE_SIZE]);
-    updater.mark_updated(&mut flash, magic.as_mut()).await.unwrap();
+    updater.mark_updated_blocking(&mut flash, magic.as_mut()).unwrap();
     led.set_low();
     cortex_m::peripheral::SCB::sys_reset();
 }

--- a/examples/boot/application/stm32h7/src/bin/a.rs
+++ b/examples/boot/application/stm32h7/src/bin/a.rs
@@ -5,7 +5,6 @@
 #[cfg(feature = "defmt-rtt")]
 use defmt_rtt::*;
 use embassy_boot_stm32::{AlignedBuffer, FirmwareUpdater};
-use embassy_embedded_hal::adapter::BlockingAsync;
 use embassy_executor::Spawner;
 use embassy_stm32::exti::ExtiInput;
 use embassy_stm32::flash::{Flash, WRITE_SIZE};
@@ -17,8 +16,7 @@ static APP_B: &[u8] = include_bytes!("../../b.bin");
 #[embassy_executor::main]
 async fn main(_spawner: Spawner) {
     let p = embassy_stm32::init(Default::default());
-    let flash = Flash::unlock(p.FLASH);
-    let mut flash = BlockingAsync::new(flash);
+    let mut flash = Flash::unlock(p.FLASH);
 
     let button = Input::new(p.PC13, Pull::Down);
     let mut button = ExtiInput::new(button, p.EXTI13);
@@ -27,19 +25,20 @@ async fn main(_spawner: Spawner) {
     led.set_high();
 
     let mut updater = FirmwareUpdater::default();
+
+    let mut writer = updater.prepare_update_blocking(&mut flash).unwrap();
     button.wait_for_rising_edge().await;
     let mut offset = 0;
-    let mut buf = AlignedBuffer([0; 128 * 1024]);
-    for chunk in APP_B.chunks(128 * 1024) {
+    let mut buf = AlignedBuffer([0; 4096]);
+    for chunk in APP_B.chunks(4096) {
         buf.as_mut()[..chunk.len()].copy_from_slice(chunk);
-        updater
-            .write_firmware(offset, buf.as_ref(), &mut flash, 2048)
-            .await
+        writer
+            .write_block_blocking(offset, buf.as_ref(), &mut flash, 4096)
             .unwrap();
         offset += chunk.len();
     }
     let mut magic = AlignedBuffer([0; WRITE_SIZE]);
-    updater.mark_updated(&mut flash, magic.as_mut()).await.unwrap();
+    updater.mark_updated_blocking(&mut flash, magic.as_mut()).unwrap();
     led.set_low();
     cortex_m::peripheral::SCB::sys_reset();
 }


### PR DESCRIPTION
The new FirmwareWriter is useful in particular for these architectures due to the large erase sector size.