### PR TITLE
Experiment: remove Instance generics.

### DIFF
--- a/embassy-hal-common/src/atomic_ring_buffer.rs
+++ b/embassy-hal-common/src/atomic_ring_buffer.rs
@@ -1,0 +1,154 @@
+use core::slice;
+use core::sync::atomic::{AtomicPtr, AtomicUsize, Ordering};
+
+pub struct RingBuffer {
+    buf: AtomicPtr<u8>,
+    len: AtomicUsize,
+    start: AtomicUsize,
+    end: AtomicUsize,
+}
+
+pub struct Reader<'a>(&'a RingBuffer);
+pub struct Writer<'a>(&'a RingBuffer);
+
+impl RingBuffer {
+    pub const fn new() -> Self {
+        Self {
+            buf: AtomicPtr::new(core::ptr::null_mut()),
+            len: AtomicUsize::new(0),
+            start: AtomicUsize::new(0),
+            end: AtomicUsize::new(0),
+        }
+    }
+
+    /// # Safety
+    /// - The buffer (`buf .. buf+len`) must be valid memory until `deinit` is called.
+    /// - Must not be called concurrently with any other methods.
+    pub unsafe fn init(&self, buf: *mut u8, len: usize) {
+        self.buf.store(buf, Ordering::Relaxed);
+        self.len.store(len, Ordering::Relaxed);
+        self.start.store(0, Ordering::Relaxed);
+        self.end.store(0, Ordering::Relaxed);
+    }
+
+    pub unsafe fn deinit(&self) {
+        self.len.store(0, Ordering::Relaxed);
+    }
+
+    pub unsafe fn reader(&self) -> Reader<'_> {
+        Reader(self)
+    }
+
+    pub unsafe fn writer(&self) -> Writer<'_> {
+        Writer(self)
+    }
+
+    pub fn is_full(&self) -> bool {
+        let start = self.start.load(Ordering::Relaxed);
+        let end = self.end.load(Ordering::Relaxed);
+
+        self.wrap(end + 1) == start
+    }
+
+    pub fn is_empty(&self) -> bool {
+        let start = self.start.load(Ordering::Relaxed);
+        let end = self.end.load(Ordering::Relaxed);
+
+        start == end
+    }
+
+    pub fn wrap(&self, n: usize) -> usize {
+        let len = self.len.load(Ordering::Relaxed);
+
+        assert!(n <= len);
+        if n == len {
+            0
+        } else {
+            n
+        }
+    }
+}
+
+impl<'a> Writer<'a> {
+    pub fn push(&self, f: impl FnOnce(&mut [u8]) -> usize) -> usize {
+        let (p, n) = self.push_buf();
+        let buf = unsafe { slice::from_raw_parts_mut(p, n) };
+        let n = f(buf);
+        self.push_done(n);
+        n
+    }
+
+    pub fn push_one(&self, val: u8) -> bool {
+        let n = self.push(|f| match f {
+            [] => 0,
+            [x, ..] => {
+                *x = val;
+                1
+            }
+        });
+        n != 0
+    }
+
+    pub fn push_buf(&self) -> (*mut u8, usize) {
+        let start = self.0.start.load(Ordering::Acquire);
+        let buf = self.0.buf.load(Ordering::Relaxed);
+        let len = self.0.len.load(Ordering::Relaxed);
+        let end = self.0.end.load(Ordering::Relaxed);
+
+        let n = if start <= end {
+            len - end - (start == 0) as usize
+        } else {
+            start - end - 1
+        };
+
+        trace!("  ringbuf: push_buf {:?}..{:?}", end, end + n);
+        (unsafe { buf.add(end) }, n)
+    }
+
+    pub fn push_done(&self, n: usize) {
+        trace!("  ringbuf: push {:?}", n);
+        let end = self.0.end.load(Ordering::Relaxed);
+        self.0.end.store(self.0.wrap(end + n), Ordering::Release);
+    }
+}
+
+impl<'a> Reader<'a> {
+    pub fn pop(&self, f: impl FnOnce(&[u8]) -> usize) -> usize {
+        let (p, n) = self.pop_buf();
+        let buf = unsafe { slice::from_raw_parts(p, n) };
+        let n = f(buf);
+        self.pop_done(n);
+        n
+    }
+
+    pub fn pop_one(&self) -> Option<u8> {
+        let mut res = None;
+        self.pop(|f| match f {
+            &[] => 0,
+            &[x, ..] => {
+                res = Some(x);
+                1
+            }
+        });
+        res
+    }
+
+    pub fn pop_buf(&self) -> (*mut u8, usize) {
+        let end = self.0.end.load(Ordering::Acquire);
+        let buf = self.0.buf.load(Ordering::Relaxed);
+        let len = self.0.len.load(Ordering::Relaxed);
+        let start = self.0.start.load(Ordering::Relaxed);
+
+        let n = if end < start { len - start } else { end - start };
+
+        trace!("  ringbuf: pop_buf {:?}..{:?}", start, start + n);
+        (unsafe { buf.add(start) }, n)
+    }
+
+    pub fn pop_done(&self, n: usize) {
+        trace!("  ringbuf: pop {:?}", n);
+
+        let start = self.0.start.load(Ordering::Relaxed);
+        self.0.start.store(self.0.wrap(start + n), Ordering::Release);
+    }
+}

--- a/embassy-hal-common/src/lib.rs
+++ b/embassy-hal-common/src/lib.rs
@@ -4,6 +4,7 @@
 // This mod MUST go first, so that the others see its macros.
 pub(crate) mod fmt;
 
+pub mod atomic_ring_buffer;
 pub mod drop;
 mod macros;
 mod peripheral;

--- a/embassy-rp/src/interrupt.rs
+++ b/embassy-rp/src/interrupt.rs
@@ -34,3 +34,27 @@ declare!(ADC_IRQ_FIFO);
 declare!(I2C0_IRQ);
 declare!(I2C1_IRQ);
 declare!(RTC_IRQ);
+
+pub trait InterruptFunction {
+    fn on_interrupt();
+}
+
+// Marker trait
+pub unsafe trait Registration<T: Interrupt> {}
+
+#[macro_export]
+macro_rules! register_interrupts {
+    ($name:ident: $($irq:ident),*) => {
+        struct $name;
+
+        $(
+            #[allow(non_snake_case)]
+            #[no_mangle]
+            extern "C" fn $irq() {
+                <$crate::interrupt::$irq as $crate::interrupt::InterruptFunction>::on_interrupt();
+            }
+
+            unsafe impl $crate::interrupt::Registration<$crate::interrupt::$irq> for $name {}
+        )*
+    };
+}

--- a/examples/rp/src/bin/uart.rs
+++ b/examples/rp/src/bin/uart.rs
@@ -3,8 +3,10 @@
 #![feature(type_alias_impl_trait)]
 
 use embassy_executor::Spawner;
-use embassy_rp::uart;
+use embassy_rp::{register_interrupts, uart};
 use {defmt_rtt as _, panic_probe as _};
+
+register_interrupts!(Reg: UART0_IRQ);
 
 #[embassy_executor::main]
 async fn main(_spawner: Spawner) {

--- a/tests/rp/src/bin/uart_buffered.rs
+++ b/tests/rp/src/bin/uart_buffered.rs
@@ -4,10 +4,12 @@
 
 use defmt::{assert_eq, *};
 use embassy_executor::Spawner;
-use embassy_rp::interrupt;
-use embassy_rp::uart::{BufferedUart, Config, State, Uart};
+use embassy_rp::register_interrupts;
+use embassy_rp::uart::{BufferedUart, Config};
 use embedded_io::asynch::{Read, Write};
 use {defmt_rtt as _, panic_probe as _};
+
+register_interrupts!(Irqs: UART0_IRQ);
 
 #[embassy_executor::main]
 async fn main(_spawner: Spawner) {
@@ -16,26 +18,26 @@ async fn main(_spawner: Spawner) {
 
     let (tx, rx, uart) = (p.PIN_0, p.PIN_1, p.UART0);
 
-    let config = Config::default();
-    let uart = Uart::new_blocking(uart, tx, rx, config);
-
-    let irq = interrupt::take!(UART0_IRQ);
     let tx_buf = &mut [0u8; 16];
     let rx_buf = &mut [0u8; 16];
-    let mut state = State::new();
-    let mut uart = BufferedUart::new(&mut state, uart, irq, tx_buf, rx_buf);
+    let config = Config::default();
+    let mut uart = BufferedUart::new(uart, Irqs, tx, rx, tx_buf, rx_buf, config);
 
     // Make sure we send more bytes than fits in the FIFO, to test the actual
     // bufferedUart.
 
     let data = [
         1_u8, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29,
-        30, 31, 32,
+        30, 31,
+    ];
+    let data = [
+        1u8, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29,
+        30, 31,
     ];
     uart.write_all(&data).await.unwrap();
     info!("Done writing");
 
-    let mut buf = [0; 32];
+    let mut buf = [0; 31];
     uart.read_exact(&mut buf).await.unwrap();
     assert_eq!(buf, data);
 


### PR DESCRIPTION
This is an experiment of removing "peripheral instance" generics on driver structs. For example, uart is now `Uart<'d, Blocking>` instead of `Uart<'d, UART1, Blocking>`.

Everything is still checked at compile time as before (such as pin functions). The `T` generic is moved from the struct to the `new` methods, not removed entirely.

The main advantage is you can now write code that works with, e.g, both UART0 and UART1 without generics or macros.

```rust
#[embassy_executor::main]
async fn main(spawner: Spawner) {
    let p = embassy_rp::init(Default::default());
    let config = uart::Config::default();
    let uart0 = uart::Uart::new_with_rtscts_blocking(p.UART0, p.PIN_0, p.PIN_1, p.PIN_3, p.PIN_2, config);
    let uart1 = uart::Uart::new_with_rtscts_blocking(p.UART1, p.PIN_4, p.PIN_5, p.PIN_7, p.PIN_6, config);
    spawner.spawn(hello_task(uart0)).unwrap();
    spawner.spawn(hello_task(uart1)).unwrap();
}

#[embassy_executor::task(pool_size = 2)]
async fn hello_task(mut uart: Uart<'static, Blocking>) {
    uart.blocking_write("Hello World!\r\n".as_bytes()).unwrap();

    loop {
        uart.blocking_write("hello there!\r\n".as_bytes()).unwrap();
        Timer::after(Duration::from_secs(1)).await;
    }
}
```