### PR TITLE
Re-instate direction discriminant values

### DIFF
--- a/embassy-usb-driver/src/lib.rs
+++ b/embassy-usb-driver/src/lib.rs
@@ -17,6 +17,16 @@ pub enum Direction {
     In = 0x80,
 }
 
+impl From<u8> for Direction {
+    fn from(v: u8) -> Self {
+        if v & (Direction::In as u8) == 0 {
+            Direction::Out
+        } else {
+            Direction::In
+        }
+    }
+}
+
 /// USB endpoint transfer type. The values of this enum can be directly cast into `u8` to get the
 /// transfer bmAttributes transfer type bits.
 #[repr(u8)]

--- a/embassy-usb-driver/src/lib.rs
+++ b/embassy-usb-driver/src/lib.rs
@@ -12,9 +12,9 @@ use core::future::Future;
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub enum Direction {
     /// Host to device (OUT)
-    Out,
+    Out = 0x00,
     /// Device to host (IN)
-    In,
+    In = 0x80,
 }
 
 /// USB endpoint transfer type. The values of this enum can be directly cast into `u8` to get the

--- a/embassy-usb/src/control.rs
+++ b/embassy-usb/src/control.rs
@@ -106,7 +106,7 @@ impl Request {
         let recipient = rt & 0b11111;
 
         Request {
-            direction: if rt & 0x80 == 0 { Direction::Out } else { Direction::In },
+            direction: rt.into(),
             request_type: unsafe { mem::transmute((rt >> 5) & 0b11) },
             recipient: if recipient <= 3 {
                 unsafe { mem::transmute(recipient) }


### PR DESCRIPTION
The previous commit of f4f58249722bc656a13865e06535d208440c3e4a had removed explicit discriminant values from the direction enums, causing USB serial to fail as `0x80` is expected for the inbound direction. A number of places cast a variant into a u8 via "as u8". To my knowledge, there's no way of preventing these numeric casts to occur, so we need to reinstate the explicit discriminant values.

Tested on the nRF USB examples.