### PR TITLE
(embassy-stm32): remove flash lock/unlock public API from stm32 flash

### DIFF
--- a/examples/boot/application/stm32f3/src/bin/a.rs
+++ b/examples/boot/application/stm32f3/src/bin/a.rs
@@ -17,7 +17,7 @@ static APP_B: &[u8] = include_bytes!("../../b.bin");
 #[embassy_executor::main]
 async fn main(_spawner: Spawner) {
     let p = embassy_stm32::init(Default::default());
-    let flash = Flash::unlock(p.FLASH);
+    let flash = Flash::new(p.FLASH);
     let mut flash = BlockingAsync::new(flash);
 
     let button = Input::new(p.PC13, Pull::Up);

--- a/examples/boot/application/stm32f7/src/bin/a.rs
+++ b/examples/boot/application/stm32f7/src/bin/a.rs
@@ -16,7 +16,7 @@ static APP_B: &[u8] = include_bytes!("../../b.bin");
 #[embassy_executor::main]
 async fn main(_spawner: Spawner) {
     let p = embassy_stm32::init(Default::default());
-    let mut flash = Flash::unlock(p.FLASH);
+    let mut flash = Flash::new(p.FLASH);
 
     let button = Input::new(p.PC13, Pull::Down);
     let mut button = ExtiInput::new(button, p.EXTI13);

--- a/examples/boot/application/stm32h7/src/bin/a.rs
+++ b/examples/boot/application/stm32h7/src/bin/a.rs
@@ -16,7 +16,7 @@ static APP_B: &[u8] = include_bytes!("../../b.bin");
 #[embassy_executor::main]
 async fn main(_spawner: Spawner) {
     let p = embassy_stm32::init(Default::default());
-    let mut flash = Flash::unlock(p.FLASH);
+    let mut flash = Flash::new(p.FLASH);
 
     let button = Input::new(p.PC13, Pull::Down);
     let mut button = ExtiInput::new(button, p.EXTI13);

--- a/examples/boot/application/stm32l0/src/bin/a.rs
+++ b/examples/boot/application/stm32l0/src/bin/a.rs
@@ -18,7 +18,7 @@ static APP_B: &[u8] = include_bytes!("../../b.bin");
 #[embassy_executor::main]
 async fn main(_spawner: Spawner) {
     let p = embassy_stm32::init(Default::default());
-    let flash = Flash::unlock(p.FLASH);
+    let flash = Flash::new(p.FLASH);
     let mut flash = BlockingAsync::new(flash);
 
     let button = Input::new(p.PB2, Pull::Up);

--- a/examples/boot/application/stm32l1/src/bin/a.rs
+++ b/examples/boot/application/stm32l1/src/bin/a.rs
@@ -18,7 +18,7 @@ static APP_B: &[u8] = include_bytes!("../../b.bin");
 #[embassy_executor::main]
 async fn main(_spawner: Spawner) {
     let p = embassy_stm32::init(Default::default());
-    let flash = Flash::unlock(p.FLASH);
+    let flash = Flash::new(p.FLASH);
     let mut flash = BlockingAsync::new(flash);
 
     let button = Input::new(p.PB2, Pull::Up);

--- a/examples/boot/application/stm32l4/src/bin/a.rs
+++ b/examples/boot/application/stm32l4/src/bin/a.rs
@@ -17,7 +17,7 @@ static APP_B: &[u8] = include_bytes!("../../b.bin");
 #[embassy_executor::main]
 async fn main(_spawner: Spawner) {
     let p = embassy_stm32::init(Default::default());
-    let flash = Flash::unlock(p.FLASH);
+    let flash = Flash::new(p.FLASH);
     let mut flash = BlockingAsync::new(flash);
 
     let button = Input::new(p.PC13, Pull::Up);

--- a/examples/boot/application/stm32wl/src/bin/a.rs
+++ b/examples/boot/application/stm32wl/src/bin/a.rs
@@ -17,7 +17,7 @@ static APP_B: &[u8] = include_bytes!("../../b.bin");
 #[embassy_executor::main]
 async fn main(_spawner: Spawner) {
     let p = embassy_stm32::init(Default::default());
-    let flash = Flash::unlock(p.FLASH);
+    let flash = Flash::new(p.FLASH);
     let mut flash = BlockingAsync::new(flash);
 
     let button = Input::new(p.PA0, Pull::Up);

--- a/examples/boot/bootloader/stm32/src/main.rs
+++ b/examples/boot/bootloader/stm32/src/main.rs
@@ -20,7 +20,7 @@ fn main() -> ! {
     */
 
     let mut bl: BootLoader<ERASE_SIZE, WRITE_SIZE> = BootLoader::default();
-    let flash = Flash::unlock(p.FLASH);
+    let flash = Flash::new(p.FLASH);
     let mut flash = BootFlash::<_, ERASE_SIZE, ERASE_VALUE>::new(flash);
     let start = bl.prepare(&mut SingleFlashConfig::new(&mut flash));
     core::mem::drop(flash);

--- a/examples/stm32f3/src/bin/flash.rs
+++ b/examples/stm32f3/src/bin/flash.rs
@@ -15,7 +15,7 @@ async fn main(_spawner: Spawner) {
 
     const ADDR: u32 = 0x26000;
 
-    let mut f = Flash::unlock(p.FLASH);
+    let mut f = Flash::new(p.FLASH);
 
     info!("Reading...");
     let mut buf = [0u8; 8];

--- a/examples/stm32f4/src/bin/flash.rs
+++ b/examples/stm32f4/src/bin/flash.rs
@@ -13,7 +13,7 @@ async fn main(_spawner: Spawner) {
     let p = embassy_stm32::init(Default::default());
     info!("Hello Flash!");
 
-    let mut f = Flash::unlock(p.FLASH);
+    let mut f = Flash::new(p.FLASH);
 
     // Sector 5
     test_flash(&mut f, 128 * 1024, 128 * 1024);

--- a/examples/stm32f7/src/bin/flash.rs
+++ b/examples/stm32f7/src/bin/flash.rs
@@ -19,7 +19,7 @@ async fn main(_spawner: Spawner) {
     // wait a bit before accessing the flash
     Timer::after(Duration::from_millis(300)).await;
 
-    let mut f = Flash::unlock(p.FLASH);
+    let mut f = Flash::new(p.FLASH);
 
     info!("Reading...");
     let mut buf = [0u8; 32];

--- a/examples/stm32h7/src/bin/flash.rs
+++ b/examples/stm32h7/src/bin/flash.rs
@@ -19,7 +19,7 @@ async fn main(_spawner: Spawner) {
     // wait a bit before accessing the flash
     Timer::after(Duration::from_millis(300)).await;
 
-    let mut f = Flash::unlock(p.FLASH);
+    let mut f = Flash::new(p.FLASH);
 
     info!("Reading...");
     let mut buf = [0u8; 32];

--- a/examples/stm32l0/src/bin/flash.rs
+++ b/examples/stm32l0/src/bin/flash.rs
@@ -15,7 +15,7 @@ async fn main(_spawner: Spawner) {
 
     const ADDR: u32 = 0x26000;
 
-    let mut f = Flash::unlock(p.FLASH);
+    let mut f = Flash::new(p.FLASH);
 
     info!("Reading...");
     let mut buf = [0u8; 8];

--- a/examples/stm32l1/src/bin/flash.rs
+++ b/examples/stm32l1/src/bin/flash.rs
@@ -15,7 +15,7 @@ async fn main(_spawner: Spawner) {
 
     const ADDR: u32 = 0x26000;
 
-    let mut f = Flash::unlock(p.FLASH);
+    let mut f = Flash::new(p.FLASH);
 
     info!("Reading...");
     let mut buf = [0u8; 8];

--- a/examples/stm32wl/src/bin/flash.rs
+++ b/examples/stm32wl/src/bin/flash.rs
@@ -15,7 +15,7 @@ async fn main(_spawner: Spawner) {
 
     const ADDR: u32 = 0x36000;
 
-    let mut f = Flash::unlock(p.FLASH);
+    let mut f = Flash::new(p.FLASH);
 
     info!("Reading...");
     let mut buf = [0u8; 8];


### PR DESCRIPTION
Instead, perform the unlocking and locking automatically on erase and write operations.

This makes the `embedded-storage` abstraction actually useable in libraries, while still keeping the flash peripheral locked the majority of the time.