### PR TITLE
all Cargo.toml: Add license to all crate Cargo.toml files

### DIFF
--- a/docs/modules/ROOT/examples/basic/Cargo.toml
+++ b/docs/modules/ROOT/examples/basic/Cargo.toml
@@ -3,6 +3,7 @@ authors = ["Dario Nieuwenhuis <dirbaio@dirbaio.net>"]
 edition = "2018"
 name = "embassy-basic-example"
 version = "0.1.0"
+license = "MIT OR Apache-2.0"
 
 [dependencies]
 embassy-executor = { version = "0.1.0", path = "../../../../../embassy-executor", features = ["defmt", "nightly"] }

--- a/docs/modules/ROOT/examples/layer-by-layer/blinky-async/Cargo.toml
+++ b/docs/modules/ROOT/examples/layer-by-layer/blinky-async/Cargo.toml
@@ -2,6 +2,7 @@
 name = "blinky-async"
 version = "0.1.0"
 edition = "2021"
+license = "MIT OR Apache-2.0"
 
 [dependencies]
 cortex-m = "0.7"

--- a/docs/modules/ROOT/examples/layer-by-layer/blinky-hal/Cargo.toml
+++ b/docs/modules/ROOT/examples/layer-by-layer/blinky-hal/Cargo.toml
@@ -2,6 +2,7 @@
 name = "blinky-hal"
 version = "0.1.0"
 edition = "2021"
+license = "MIT OR Apache-2.0"
 
 [dependencies]
 cortex-m = "0.7"

--- a/docs/modules/ROOT/examples/layer-by-layer/blinky-irq/Cargo.toml
+++ b/docs/modules/ROOT/examples/layer-by-layer/blinky-irq/Cargo.toml
@@ -2,6 +2,7 @@
 name = "blinky-irq"
 version = "0.1.0"
 edition = "2021"
+license = "MIT OR Apache-2.0"
 
 [dependencies]
 cortex-m = "0.7"

--- a/docs/modules/ROOT/examples/layer-by-layer/blinky-pac/Cargo.toml
+++ b/docs/modules/ROOT/examples/layer-by-layer/blinky-pac/Cargo.toml
@@ -2,6 +2,7 @@
 name = "blinky-pac"
 version = "0.1.0"
 edition = "2021"
+license = "MIT OR Apache-2.0"
 
 [dependencies]
 cortex-m = "0.7"

--- a/embassy-boot/boot/Cargo.toml
+++ b/embassy-boot/boot/Cargo.toml
@@ -3,6 +3,7 @@ edition = "2021"
 name = "embassy-boot"
 version = "0.1.0"
 description = "Bootloader using Embassy"
+license = "MIT OR Apache-2.0"
 
 [package.metadata.embassy_docs]
 src_base = "https://github.com/embassy-rs/embassy/blob/embassy-boot-v$VERSION/embassy-boot/boot/src/"

--- a/embassy-boot/nrf/Cargo.toml
+++ b/embassy-boot/nrf/Cargo.toml
@@ -3,6 +3,7 @@ edition = "2021"
 name = "embassy-boot-nrf"
 version = "0.1.0"
 description = "Bootloader lib for nRF chips"
+license = "MIT OR Apache-2.0"
 
 [package.metadata.embassy_docs]
 src_base = "https://github.com/embassy-rs/embassy/blob/embassy-boot-nrf-v$VERSION/embassy-boot/nrf/src/"

--- a/embassy-boot/stm32/Cargo.toml
+++ b/embassy-boot/stm32/Cargo.toml
@@ -3,6 +3,7 @@ edition = "2021"
 name = "embassy-boot-stm32"
 version = "0.1.0"
 description = "Bootloader lib for STM32 chips"
+license = "MIT OR Apache-2.0"
 
 [package.metadata.embassy_docs]
 src_base = "https://github.com/embassy-rs/embassy/blob/embassy-boot-nrf-v$VERSION/embassy-boot/stm32/src/"

--- a/embassy-cortex-m/Cargo.toml
+++ b/embassy-cortex-m/Cargo.toml
@@ -2,6 +2,7 @@
 name = "embassy-cortex-m"
 version = "0.1.0"
 edition = "2021"
+license = "MIT OR Apache-2.0"
 
 [package.metadata.embassy_docs]
 src_base = "https://github.com/embassy-rs/embassy/blob/embassy-cortex-m-v$VERSION/embassy-cortex-m/src/"

--- a/embassy-embedded-hal/Cargo.toml
+++ b/embassy-embedded-hal/Cargo.toml
@@ -2,6 +2,7 @@
 name = "embassy-embedded-hal"
 version = "0.1.0"
 edition = "2021"
+license = "MIT OR Apache-2.0"
 
 
 [package.metadata.embassy_docs]

--- a/embassy-executor/Cargo.toml
+++ b/embassy-executor/Cargo.toml
@@ -2,6 +2,7 @@
 name = "embassy-executor"
 version = "0.1.0"
 edition = "2021"
+license = "MIT OR Apache-2.0"
 
 
 [package.metadata.embassy_docs]

--- a/embassy-hal-common/Cargo.toml
+++ b/embassy-hal-common/Cargo.toml
@@ -2,6 +2,7 @@
 name = "embassy-hal-common"
 version = "0.1.0"
 edition = "2021"
+license = "MIT OR Apache-2.0"
 
 [features]
 

--- a/embassy-lora/Cargo.toml
+++ b/embassy-lora/Cargo.toml
@@ -2,6 +2,7 @@
 name = "embassy-lora"
 version = "0.1.0"
 edition = "2021"
+license = "MIT OR Apache-2.0"
 
 [package.metadata.embassy_docs]
 src_base = "https://github.com/embassy-rs/embassy/blob/embassy-lora-v$VERSION/embassy-lora/src/"

--- a/embassy-macros/Cargo.toml
+++ b/embassy-macros/Cargo.toml
@@ -2,6 +2,7 @@
 name = "embassy-macros"
 version = "0.1.0"
 edition = "2021"
+license = "MIT OR Apache-2.0"
 
 [dependencies]
 syn = { version = "1.0.76", features = ["full", "extra-traits"] }

--- a/embassy-net/Cargo.toml
+++ b/embassy-net/Cargo.toml
@@ -2,6 +2,7 @@
 name = "embassy-net"
 version = "0.1.0"
 edition = "2021"
+license = "MIT OR Apache-2.0"
 
 
 [package.metadata.embassy_docs]

--- a/embassy-nrf/Cargo.toml
+++ b/embassy-nrf/Cargo.toml
@@ -2,6 +2,7 @@
 name = "embassy-nrf"
 version = "0.1.0"
 edition = "2021"
+license = "MIT OR Apache-2.0"
 
 [package.metadata.embassy_docs]
 src_base = "https://github.com/embassy-rs/embassy/blob/embassy-nrf-v$VERSION/embassy-nrf/src/"

--- a/embassy-rp/Cargo.toml
+++ b/embassy-rp/Cargo.toml
@@ -2,6 +2,7 @@
 name = "embassy-rp"
 version = "0.1.0"
 edition = "2021"
+license = "MIT OR Apache-2.0"
 
 [package.metadata.embassy_docs]
 src_base = "https://github.com/embassy-rs/embassy/blob/embassy-rp-v$VERSION/embassy-rp/src/"

--- a/embassy-stm32/Cargo.toml
+++ b/embassy-stm32/Cargo.toml
@@ -2,6 +2,7 @@
 name = "embassy-stm32"
 version = "0.1.0"
 edition = "2021"
+license = "MIT OR Apache-2.0"
 
 [package.metadata.embassy_docs]
 src_base = "https://github.com/embassy-rs/embassy/blob/embassy-stm32-v$VERSION/embassy-stm32/src/"

--- a/embassy-time/Cargo.toml
+++ b/embassy-time/Cargo.toml
@@ -2,6 +2,7 @@
 name = "embassy-time"
 version = "0.1.0"
 edition = "2021"
+license = "MIT OR Apache-2.0"
 
 
 [package.metadata.embassy_docs]

--- a/embassy-usb-driver/Cargo.toml
+++ b/embassy-usb-driver/Cargo.toml
@@ -2,6 +2,7 @@
 name = "embassy-usb-driver"
 version = "0.1.0"
 edition = "2021"
+license = "MIT OR Apache-2.0"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/embassy-usb/Cargo.toml
+++ b/embassy-usb/Cargo.toml
@@ -2,6 +2,7 @@
 name = "embassy-usb"
 version = "0.1.0"
 edition = "2021"
+license = "MIT OR Apache-2.0"
 
 [package.metadata.embassy_docs]
 src_base = "https://github.com/embassy-rs/embassy/blob/embassy-usb-v$VERSION/embassy-usb/src/"

--- a/examples/boot/application/nrf/Cargo.toml
+++ b/examples/boot/application/nrf/Cargo.toml
@@ -2,6 +2,7 @@
 edition = "2021"
 name = "embassy-boot-nrf-examples"
 version = "0.1.0"
+license = "MIT OR Apache-2.0"
 
 [dependencies]
 embassy-sync = { version = "0.1.0", path = "../../../../embassy-sync" }

--- a/examples/boot/application/stm32f3/Cargo.toml
+++ b/examples/boot/application/stm32f3/Cargo.toml
@@ -2,6 +2,7 @@
 edition = "2021"
 name = "embassy-boot-stm32f3-examples"
 version = "0.1.0"
+license = "MIT OR Apache-2.0"
 
 [dependencies]
 embassy-sync = { version = "0.1.0", path = "../../../../embassy-sync", features = ["defmt"] }

--- a/examples/boot/application/stm32f7/Cargo.toml
+++ b/examples/boot/application/stm32f7/Cargo.toml
@@ -2,6 +2,7 @@
 edition = "2021"
 name = "embassy-boot-stm32f7-examples"
 version = "0.1.0"
+license = "MIT OR Apache-2.0"
 
 [dependencies]
 embassy-sync = { version = "0.1.0", path = "../../../../embassy-sync", features = ["defmt"] }

--- a/examples/boot/application/stm32h7/Cargo.toml
+++ b/examples/boot/application/stm32h7/Cargo.toml
@@ -2,6 +2,7 @@
 edition = "2021"
 name = "embassy-boot-stm32h7-examples"
 version = "0.1.0"
+license = "MIT OR Apache-2.0"
 
 [dependencies]
 embassy-sync = { version = "0.1.0", path = "../../../../embassy-sync" }

--- a/examples/boot/application/stm32l0/Cargo.toml
+++ b/examples/boot/application/stm32l0/Cargo.toml
@@ -2,6 +2,7 @@
 edition = "2021"
 name = "embassy-boot-stm32l0-examples"
 version = "0.1.0"
+license = "MIT OR Apache-2.0"
 
 [dependencies]
 embassy-sync = { version = "0.1.0", path = "../../../../embassy-sync", features = ["defmt"] }

--- a/examples/boot/application/stm32l1/Cargo.toml
+++ b/examples/boot/application/stm32l1/Cargo.toml
@@ -2,6 +2,7 @@
 edition = "2021"
 name = "embassy-boot-stm32l1-examples"
 version = "0.1.0"
+license = "MIT OR Apache-2.0"
 
 [dependencies]
 embassy-sync = { version = "0.1.0", path = "../../../../embassy-sync", features = ["defmt"] }

--- a/examples/boot/application/stm32l4/Cargo.toml
+++ b/examples/boot/application/stm32l4/Cargo.toml
@@ -2,6 +2,7 @@
 edition = "2021"
 name = "embassy-boot-stm32l4-examples"
 version = "0.1.0"
+license = "MIT OR Apache-2.0"
 
 [dependencies]
 embassy-sync = { version = "0.1.0", path = "../../../../embassy-sync", features = ["defmt"] }

--- a/examples/boot/application/stm32wl/Cargo.toml
+++ b/examples/boot/application/stm32wl/Cargo.toml
@@ -2,6 +2,7 @@
 edition = "2021"
 name = "embassy-boot-stm32wl-examples"
 version = "0.1.0"
+license = "MIT OR Apache-2.0"
 
 [dependencies]
 embassy-sync = { version = "0.1.0", path = "../../../../embassy-sync", features = ["defmt"] }

--- a/examples/boot/bootloader/nrf/Cargo.toml
+++ b/examples/boot/bootloader/nrf/Cargo.toml
@@ -3,6 +3,7 @@ edition = "2021"
 name = "nrf-bootloader-example"
 version = "0.1.0"
 description = "Bootloader for nRF chips"
+license = "MIT OR Apache-2.0"
 
 [dependencies]
 defmt = { version = "0.3", optional = true }

--- a/examples/boot/bootloader/stm32/Cargo.toml
+++ b/examples/boot/bootloader/stm32/Cargo.toml
@@ -3,6 +3,7 @@ edition = "2021"
 name = "stm32-bootloader-example"
 version = "0.1.0"
 description = "Example bootloader for STM32 chips"
+license = "MIT OR Apache-2.0"
 
 [dependencies]
 defmt = { version = "0.3", optional = true }

--- a/examples/nrf-rtos-trace/Cargo.toml
+++ b/examples/nrf-rtos-trace/Cargo.toml
@@ -2,6 +2,7 @@
 edition = "2021"
 name = "embassy-nrf-rtos-trace-examples"
 version = "0.1.0"
+license = "MIT OR Apache-2.0"
 
 [features]
 default = ["log", "nightly"]

--- a/examples/nrf/Cargo.toml
+++ b/examples/nrf/Cargo.toml
@@ -2,6 +2,7 @@
 edition = "2021"
 name = "embassy-nrf-examples"
 version = "0.1.0"
+license = "MIT OR Apache-2.0"
 
 [features]
 default = ["nightly"]

--- a/examples/rp/Cargo.toml
+++ b/examples/rp/Cargo.toml
@@ -2,6 +2,7 @@
 edition = "2021"
 name = "embassy-rp-examples"
 version = "0.1.0"
+license = "MIT OR Apache-2.0"
 
 
 [dependencies]

--- a/examples/std/Cargo.toml
+++ b/examples/std/Cargo.toml
@@ -2,6 +2,7 @@
 edition = "2021"
 name = "embassy-std-examples"
 version = "0.1.0"
+license = "MIT OR Apache-2.0"
 
 [dependencies]
 embassy-sync = { version = "0.1.0", path = "../../embassy-sync", features = ["log"] }

--- a/examples/stm32f0/Cargo.toml
+++ b/examples/stm32f0/Cargo.toml
@@ -2,6 +2,7 @@
 name = "embassy-stm32f0-examples"
 version = "0.1.0"
 edition = "2021"
+license = "MIT OR Apache-2.0"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/examples/stm32f1/Cargo.toml
+++ b/examples/stm32f1/Cargo.toml
@@ -2,6 +2,7 @@
 edition = "2021"
 name = "embassy-stm32f1-examples"
 version = "0.1.0"
+license = "MIT OR Apache-2.0"
 
 [dependencies]
 embassy-sync = { version = "0.1.0", path = "../../embassy-sync", features = ["defmt"] }

--- a/examples/stm32f2/Cargo.toml
+++ b/examples/stm32f2/Cargo.toml
@@ -2,6 +2,7 @@
 edition = "2021"
 name = "embassy-stm32f2-examples"
 version = "0.1.0"
+license = "MIT OR Apache-2.0"
 
 [dependencies]
 embassy-sync = { version = "0.1.0", path = "../../embassy-sync", features = ["defmt"] }

--- a/examples/stm32f3/Cargo.toml
+++ b/examples/stm32f3/Cargo.toml
@@ -2,6 +2,7 @@
 edition = "2021"
 name = "embassy-stm32f3-examples"
 version = "0.1.0"
+license = "MIT OR Apache-2.0"
 
 [dependencies]
 embassy-sync = { version = "0.1.0", path = "../../embassy-sync", features = ["defmt"] }

--- a/examples/stm32f4/Cargo.toml
+++ b/examples/stm32f4/Cargo.toml
@@ -2,6 +2,7 @@
 edition = "2021"
 name = "embassy-stm32f4-examples"
 version = "0.1.0"
+license = "MIT OR Apache-2.0"
 
 
 [dependencies]

--- a/examples/stm32f7/Cargo.toml
+++ b/examples/stm32f7/Cargo.toml
@@ -2,6 +2,7 @@
 edition = "2021"
 name = "embassy-stm32f7-examples"
 version = "0.1.0"
+license = "MIT OR Apache-2.0"
 
 [dependencies]
 embassy-sync = { version = "0.1.0", path = "../../embassy-sync", features = ["defmt"] }

--- a/examples/stm32g0/Cargo.toml
+++ b/examples/stm32g0/Cargo.toml
@@ -2,6 +2,7 @@
 edition = "2021"
 name = "embassy-stm32g0-examples"
 version = "0.1.0"
+license = "MIT OR Apache-2.0"
 
 [dependencies]
 embassy-sync = { version = "0.1.0", path = "../../embassy-sync", features = ["defmt"] }

--- a/examples/stm32g4/Cargo.toml
+++ b/examples/stm32g4/Cargo.toml
@@ -2,6 +2,7 @@
 edition = "2021"
 name = "embassy-stm32g4-examples"
 version = "0.1.0"
+license = "MIT OR Apache-2.0"
 
 [dependencies]
 embassy-sync = { version = "0.1.0", path = "../../embassy-sync", features = ["defmt"] }

--- a/examples/stm32h7/Cargo.toml
+++ b/examples/stm32h7/Cargo.toml
@@ -2,6 +2,7 @@
 edition = "2021"
 name = "embassy-stm32h7-examples"
 version = "0.1.0"
+license = "MIT OR Apache-2.0"
 
 [dependencies]
 embassy-sync = { version = "0.1.0", path = "../../embassy-sync", features = ["defmt"] }

--- a/examples/stm32l0/Cargo.toml
+++ b/examples/stm32l0/Cargo.toml
@@ -2,6 +2,7 @@
 edition = "2021"
 name = "embassy-stm32l0-examples"
 version = "0.1.0"
+license = "MIT OR Apache-2.0"
 
 [features]
 default = ["nightly"]

--- a/examples/stm32l1/Cargo.toml
+++ b/examples/stm32l1/Cargo.toml
@@ -2,6 +2,7 @@
 edition = "2021"
 name = "embassy-stm32l1-examples"
 version = "0.1.0"
+license = "MIT OR Apache-2.0"
 
 [dependencies]
 embassy-sync = { version = "0.1.0", path = "../../embassy-sync", features = ["defmt"] }

--- a/examples/stm32l4/Cargo.toml
+++ b/examples/stm32l4/Cargo.toml
@@ -2,6 +2,7 @@
 edition = "2021"
 name = "embassy-stm32l4-examples"
 version = "0.1.0"
+license = "MIT OR Apache-2.0"
 
 [features]
 

--- a/examples/stm32l5/Cargo.toml
+++ b/examples/stm32l5/Cargo.toml
@@ -2,6 +2,7 @@
 edition = "2021"
 name = "embassy-stm32l5-examples"
 version = "0.1.0"
+license = "MIT OR Apache-2.0"
 
 [features]
 

--- a/examples/stm32u5/Cargo.toml
+++ b/examples/stm32u5/Cargo.toml
@@ -2,6 +2,7 @@
 edition = "2021"
 name = "embassy-stm32u5-examples"
 version = "0.1.0"
+license = "MIT OR Apache-2.0"
 
 [dependencies]
 embassy-sync = { version = "0.1.0", path = "../../embassy-sync", features = ["defmt"] }

--- a/examples/stm32wb/Cargo.toml
+++ b/examples/stm32wb/Cargo.toml
@@ -2,6 +2,7 @@
 edition = "2021"
 name = "embassy-stm32wb-examples"
 version = "0.1.0"
+license = "MIT OR Apache-2.0"
 
 [dependencies]
 embassy-sync = { version = "0.1.0", path = "../../embassy-sync", features = ["defmt"] }

--- a/examples/stm32wl/Cargo.toml
+++ b/examples/stm32wl/Cargo.toml
@@ -2,6 +2,7 @@
 edition = "2021"
 name = "embassy-stm32wl-examples"
 version = "0.1.0"
+license = "MIT OR Apache-2.0"
 
 [dependencies]
 embassy-sync = { version = "0.1.0", path = "../../embassy-sync", features = ["defmt"] }

--- a/examples/wasm/Cargo.toml
+++ b/examples/wasm/Cargo.toml
@@ -2,6 +2,7 @@
 edition = "2021"
 name = "embassy-wasm-example"
 version = "0.1.0"
+license = "MIT OR Apache-2.0"
 
 [lib]
 crate-type = ["cdylib"]

--- a/stm32-gen-features/Cargo.toml
+++ b/stm32-gen-features/Cargo.toml
@@ -2,6 +2,7 @@
 name = "gen_features"
 version = "0.1.0"
 edition = "2021"
+license = "MIT OR Apache-2.0"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/stm32-metapac-gen/Cargo.toml
+++ b/stm32-metapac-gen/Cargo.toml
@@ -2,6 +2,7 @@
 name = "stm32-metapac-gen"
 version = "0.1.0"
 edition = "2021"
+license = "MIT OR Apache-2.0"
 
 
 [dependencies]

--- a/tests/rp/Cargo.toml
+++ b/tests/rp/Cargo.toml
@@ -2,6 +2,7 @@
 edition = "2021"
 name = "embassy-rp-tests"
 version = "0.1.0"
+license = "MIT OR Apache-2.0"
 
 [dependencies]
 embassy-sync = { version = "0.1.0", path = "../../embassy-sync", features = ["defmt"] }

--- a/tests/stm32/Cargo.toml
+++ b/tests/stm32/Cargo.toml
@@ -2,6 +2,7 @@
 edition = "2021"
 name = "embassy-stm32-tests"
 version = "0.1.0"
+license = "MIT OR Apache-2.0"
 
 [features]
 stm32f103c8 = ["embassy-stm32/stm32f103c8"]     # Blue Pill

--- a/xtask/Cargo.toml
+++ b/xtask/Cargo.toml
@@ -2,6 +2,7 @@
 edition = "2021"
 name = "xtask"
 version = "0.1.0"
+license = "MIT OR Apache-2.0"
 
 [dependencies]
 anyhow = "1.0.43"


### PR DESCRIPTION
This sets the license to "MIT OR Apache-2.0" in a machine readable form on all crates, as it was already in human readable form in the README.md file, and reaffirmed in #1002.

(The statements on all the individual examples might not be strictly essential for the `cargo deny` use case as they are leaf crates, but other tools might use that information).