### PR TITLE
embassy-stm32: Add support for read_until_idle on UART

### DIFF
--- a/embassy-stm32/src/usart/buffered.rs
+++ b/embassy-stm32/src/usart/buffered.rs
@@ -46,16 +46,47 @@ impl<'d, T: BasicInstance> Unpin for BufferedUart<'d, T> {}
 impl<'d, T: BasicInstance> BufferedUart<'d, T> {
     pub fn new(
         state: &'d mut State<'d, T>,
-        _uart: Uart<'d, T, NoDma, NoDma>,
+        _peri: impl Peripheral<P = T> + 'd,
+        rx: impl Peripheral<P = impl RxPin<T>> + 'd,
+        tx: impl Peripheral<P = impl TxPin<T>> + 'd,
         irq: impl Peripheral<P = T::Interrupt> + 'd,
         tx_buffer: &'d mut [u8],
         rx_buffer: &'d mut [u8],
+        config: Config,
     ) -> BufferedUart<'d, T> {
-        into_ref!(irq);
+        into_ref!(_peri, rx, tx, irq);
+
+        T::enable();
+        T::reset();
+        let pclk_freq = T::frequency();
+
+        // TODO: better calculation, including error checking and OVER8 if possible.
+        let div = (pclk_freq.0 + (config.baudrate / 2)) / config.baudrate * T::MULTIPLIER;
 
         let r = T::regs();
+
         unsafe {
-            r.cr1().modify(|w| {
+            rx.set_as_af(rx.af_num(), AFType::Input);
+            tx.set_as_af(tx.af_num(), AFType::OutputPushPull);
+
+            r.cr2().write(|_w| {});
+            r.cr3().write(|_w| {});
+            r.brr().write_value(regs::Brr(div));
+            r.cr1().write(|w| {
+                w.set_ue(true);
+                w.set_te(true);
+                w.set_re(true);
+                w.set_m0(if config.parity != Parity::ParityNone {
+                    vals::M0::BIT9
+                } else {
+                    vals::M0::BIT8
+                });
+                w.set_pce(config.parity != Parity::ParityNone);
+                w.set_ps(match config.parity {
+                    Parity::ParityOdd => vals::Ps::ODD,
+                    Parity::ParityEven => vals::Ps::EVEN,
+                    _ => vals::Ps::EVEN,
+                });
                 w.set_rxneie(true);
                 w.set_idleie(true);
             });

--- a/embassy-stm32/src/usart/buffered.rs
+++ b/embassy-stm32/src/usart/buffered.rs
@@ -58,12 +58,10 @@ impl<'d, T: BasicInstance> BufferedUart<'d, T> {
 
         T::enable();
         T::reset();
-        let pclk_freq = T::frequency();
-
-        // TODO: better calculation, including error checking and OVER8 if possible.
-        let div = (pclk_freq.0 + (config.baudrate / 2)) / config.baudrate * T::MULTIPLIER;
 
         let r = T::regs();
+
+        configure(r, &config, T::frequency(), T::MULTIPLIER);
 
         unsafe {
             rx.set_as_af(rx.af_num(), AFType::Input);
@@ -71,7 +69,6 @@ impl<'d, T: BasicInstance> BufferedUart<'d, T> {
 
             r.cr2().write(|_w| {});
             r.cr3().write(|_w| {});
-            r.brr().write_value(regs::Brr(div));
             r.cr1().write(|w| {
                 w.set_ue(true);
                 w.set_te(true);

--- a/embassy-stm32/src/usart/mod.rs
+++ b/embassy-stm32/src/usart/mod.rs
@@ -76,8 +76,6 @@ pub enum Error {
     Parity,
     /// Buffer too large for DMA
     BufferTooLong,
-    /// Buffer of length zero was given
-    BufferZeroLength,
 }
 
 pub struct Uart<'d, T: BasicInstance, TxDma = NoDma, RxDma = NoDma> {
@@ -506,7 +504,7 @@ impl<'d, T: BasicInstance, RxDma> UartRxWithIdle<'d, T, RxDma> {
         RxDma: crate::usart::RxDma<T>,
     {
         if buffer.is_empty() {
-            return Err(Error::BufferZeroLength);
+            return Ok(0);
         } else if buffer.len() > 0xFFFF {
             return Err(Error::BufferTooLong);
         }
@@ -778,7 +776,6 @@ mod eh1 {
                 Self::Overrun => embedded_hal_1::serial::ErrorKind::Overrun,
                 Self::Parity => embedded_hal_1::serial::ErrorKind::Parity,
                 Self::BufferTooLong => embedded_hal_1::serial::ErrorKind::Other,
-                Self::BufferZeroLength => embedded_hal_1::serial::ErrorKind::Other,
             }
         }
     }

--- a/embassy-stm32/src/usart/mod.rs
+++ b/embassy-stm32/src/usart/mod.rs
@@ -600,6 +600,9 @@ impl<'d, T: BasicInstance, RxDma> UartRxWithIdle<'d, T, RxDma> {
         let res = poll_fn(move |cx| {
             let s = T::state();
 
+            ch.set_waker(cx.waker());
+            s.rx_waker.register(cx.waker());
+
             // SAFETY: read only and we only use Rx related flags
             let usart_sr = unsafe { sr(r).read() };
 
@@ -669,9 +672,6 @@ impl<'d, T: BasicInstance, RxDma> UartRxWithIdle<'d, T, RxDma> {
                 // DMA complete
                 return Poll::Ready(Ok(buffer_len));
             }
-
-            ch.set_waker(cx.waker());
-            s.rx_waker.register(cx.waker());
 
             Poll::Pending
         })

--- a/embassy-stm32/src/usart/mod.rs
+++ b/embassy-stm32/src/usart/mod.rs
@@ -1,7 +1,11 @@
 #![macro_use]
 
+use core::future::poll_fn;
 use core::marker::PhantomData;
+use core::task::Poll;
 
+use atomic_polyfill::{compiler_fence, Ordering};
+use embassy_cortex_m::interrupt::InterruptExt;
 use embassy_hal_common::{into_ref, PeripheralRef};
 
 use crate::dma::NoDma;
@@ -70,6 +74,10 @@ pub enum Error {
     Overrun,
     /// Parity check error
     Parity,
+    /// Buffer too large for DMA
+    BufferTooLong,
+    /// Buffer of length zero was given
+    BufferZeroLength,
 }
 
 pub struct Uart<'d, T: BasicInstance, TxDma = NoDma, RxDma = NoDma> {
@@ -303,10 +311,408 @@ impl<'d, T: BasicInstance, TxDma, RxDma> Uart<'d, T, TxDma, RxDma> {
     }
 }
 
+pub struct UartWithIdle<'d, T: BasicInstance, TxDma = NoDma, RxDma = NoDma> {
+    tx: UartTx<'d, T, TxDma>,
+    rx: UartRxWithIdle<'d, T, RxDma>,
+}
+
+pub struct UartRxWithIdle<'d, T: BasicInstance, RxDma = NoDma> {
+    _peri: PeripheralRef<'d, T>,
+    rx: UartRx<'d, T, RxDma>,
+    detect_previous_overrun: bool,
+}
+
+impl<'d, T: BasicInstance, TxDma, RxDma> UartWithIdle<'d, T, TxDma, RxDma> {
+    pub fn new(
+        peri: impl Peripheral<P = T> + 'd,
+        irq: impl Peripheral<P = T::Interrupt> + 'd,
+        rx: impl Peripheral<P = impl RxPin<T>> + 'd,
+        tx: impl Peripheral<P = impl TxPin<T>> + 'd,
+        tx_dma: impl Peripheral<P = TxDma> + 'd,
+        rx_dma: impl Peripheral<P = RxDma> + 'd,
+        config: Config,
+        detect_previous_overrun: bool,
+    ) -> Self {
+        into_ref!(peri, irq, rx, tx, tx_dma, rx_dma);
+
+        T::enable();
+        T::reset();
+        let pclk_freq = T::frequency();
+
+        // TODO: better calculation, including error checking and OVER8 if possible.
+        let div = (pclk_freq.0 + (config.baudrate / 2)) / config.baudrate * T::MULTIPLIER;
+
+        let r = T::regs();
+
+        unsafe {
+            rx.set_as_af(rx.af_num(), AFType::Input);
+            tx.set_as_af(tx.af_num(), AFType::OutputPushPull);
+
+            r.cr2().write(|_w| {});
+            r.cr3().write(|w| {
+                // enable Error Interrupt: (Frame error, Noise error, Overrun error)
+                w.set_eie(true);
+            });
+            r.brr().write_value(regs::Brr(div));
+            r.cr1().write(|w| {
+                // enable uart
+                w.set_ue(true);
+                // enable transmitter
+                w.set_te(true);
+                // enable receiver
+                w.set_re(true);
+                // configure word size
+                w.set_m0(if config.parity != Parity::ParityNone {
+                    vals::M0::BIT9
+                } else {
+                    vals::M0::BIT8
+                });
+                // configure parity
+                w.set_pce(config.parity != Parity::ParityNone);
+                w.set_ps(match config.parity {
+                    Parity::ParityOdd => vals::Ps::ODD,
+                    Parity::ParityEven => vals::Ps::EVEN,
+                    _ => vals::Ps::EVEN,
+                });
+            });
+        }
+
+        irq.set_handler(Self::on_interrupt);
+        irq.unpend();
+        irq.enable();
+
+        // create state once!
+        let _s = T::state();
+
+        Self {
+            tx: UartTx::new(tx_dma),
+            rx: UartRxWithIdle {
+                _peri: peri,
+                rx: UartRx::new(rx_dma),
+                detect_previous_overrun,
+            },
+        }
+    }
+
+    fn on_interrupt(_: *mut ()) {
+        let r = T::regs();
+        let s = T::state();
+
+        let (sr, cr1, cr3) = unsafe { (sr(r).read(), r.cr1().read(), r.cr3().read()) };
+
+        let has_errors = (sr.pe() && cr1.peie()) || ((sr.fe() || sr.ne() || sr.ore()) && cr3.eie());
+
+        if has_errors {
+            // clear all interrupts and DMA Rx Request
+            unsafe {
+                r.cr1().modify(|w| {
+                    // disable RXNE interrupt
+                    w.set_rxneie(false);
+                    // disable parity interrupt
+                    w.set_peie(false);
+                    // disable idle line interrupt
+                    w.set_idleie(false);
+                });
+                r.cr3().modify(|w| {
+                    // disable Error Interrupt: (Frame error, Noise error, Overrun error)
+                    w.set_eie(false);
+                    // disable DMA Rx Request
+                    w.set_dmar(false);
+                });
+            }
+
+            compiler_fence(Ordering::SeqCst);
+
+            s.rx_waker.wake();
+        } else if cr1.idleie() && sr.idle() {
+            // IDLE detected: no more data will come
+            unsafe {
+                r.cr1().modify(|w| {
+                    // disable idle line detection
+                    w.set_idleie(false);
+                });
+
+                r.cr3().modify(|w| {
+                    // disable DMA Rx Request
+                    w.set_dmar(false);
+                });
+            }
+            compiler_fence(Ordering::SeqCst);
+
+            s.rx_waker.wake();
+        }
+    }
+
+    pub async fn write(&mut self, buffer: &[u8]) -> Result<(), Error>
+    where
+        TxDma: crate::usart::TxDma<T>,
+    {
+        self.tx.write(buffer).await
+    }
+
+    pub fn blocking_write(&mut self, buffer: &[u8]) -> Result<(), Error> {
+        self.tx.blocking_write(buffer)
+    }
+
+    pub fn blocking_flush(&mut self) -> Result<(), Error> {
+        self.tx.blocking_flush()
+    }
+
+    pub async fn read(&mut self, buffer: &mut [u8]) -> Result<(), Error>
+    where
+        RxDma: crate::usart::RxDma<T>,
+    {
+        self.rx.read(buffer).await
+    }
+
+    pub fn nb_read(&mut self) -> Result<u8, nb::Error<Error>> {
+        self.rx.nb_read()
+    }
+
+    pub fn blocking_read(&mut self, buffer: &mut [u8]) -> Result<(), Error> {
+        self.rx.blocking_read(buffer)
+    }
+
+    pub async fn read_until_idle(&mut self, buffer: &mut [u8]) -> Result<usize, Error>
+    where
+        RxDma: crate::usart::RxDma<T>,
+    {
+        self.rx.read_until_idle(buffer).await
+    }
+
+    pub fn split(self) -> (UartRxWithIdle<'d, T, RxDma>, UartTx<'d, T, TxDma>) {
+        (self.rx, self.tx)
+    }
+}
+
+impl<'d, T: BasicInstance, RxDma> UartRxWithIdle<'d, T, RxDma> {
+    pub async fn read(&mut self, buffer: &mut [u8]) -> Result<(), Error>
+    where
+        RxDma: crate::usart::RxDma<T>,
+    {
+        self.rx.read(buffer).await
+    }
+
+    pub fn nb_read(&mut self) -> Result<u8, nb::Error<Error>> {
+        self.rx.nb_read()
+    }
+
+    pub fn blocking_read(&mut self, buffer: &mut [u8]) -> Result<(), Error> {
+        self.rx.blocking_read(buffer)
+    }
+
+    pub async fn read_until_idle(&mut self, buffer: &mut [u8]) -> Result<usize, Error>
+    where
+        RxDma: crate::usart::RxDma<T>,
+    {
+        if buffer.is_empty() {
+            return Err(Error::BufferZeroLength);
+        } else if buffer.len() > 0xFFFF {
+            return Err(Error::BufferTooLong);
+        }
+
+        let r = T::regs();
+
+        let buffer_len = buffer.len();
+
+        let ch = &mut self.rx.rx_dma;
+        let request = ch.request();
+
+        // SAFETY: The only way we might have a problem is using split rx and tx
+        // here we only modify or read Rx related flags, interrupts and DMA channel
+        unsafe {
+            // Start USART DMA
+            // will not do anything yet because DMAR is not yet set
+            ch.start_read(request, rdr(r), buffer, Default::default());
+
+            // clear ORE flag just before enabling DMA Rx Request: can be mandatory for the second transfer
+            if !self.detect_previous_overrun {
+                let sr = sr(r).read();
+                // This read also clears the error and idle interrupt flags on v1.
+                let _ = rdr(r).read_volatile();
+                clear_interrupt_flags(r, sr);
+            }
+
+            r.cr1().modify(|w| {
+                // disable RXNE interrupt
+                w.set_rxneie(false);
+                // enable parity interrupt if not ParityNone
+                w.set_peie(w.pce());
+            });
+
+            r.cr3().modify(|w| {
+                // enable Error Interrupt: (Frame error, Noise error, Overrun error)
+                w.set_eie(true);
+                // enable DMA Rx Request
+                w.set_dmar(true);
+            });
+
+            compiler_fence(Ordering::SeqCst);
+
+            // In case of errors already pending when reception started, interrupts may have already been raised
+            // and lead to reception abortion (Overrun error for instance). In such a case, all interrupts
+            // have been disabled in interrupt handler and DMA Rx Request has been disabled.
+
+            let cr3 = r.cr3().read();
+
+            if !cr3.dmar() {
+                // something went wrong
+                // because the only way to get this flag cleared is to have an interrupt
+
+                // abort DMA transfer
+                ch.request_stop();
+                while ch.is_running() {}
+
+                let sr = sr(r).read();
+                // This read also clears the error and idle interrupt flags on v1.
+                let _ = rdr(r).read_volatile();
+                clear_interrupt_flags(r, sr);
+
+                if sr.pe() {
+                    return Err(Error::Parity);
+                }
+                if sr.fe() {
+                    return Err(Error::Framing);
+                }
+                if sr.ne() {
+                    return Err(Error::Noise);
+                }
+                if sr.ore() {
+                    return Err(Error::Overrun);
+                }
+
+                unreachable!();
+            }
+
+            // clear idle flag
+            {
+                let sr = sr(r).read();
+                // This read also clears the error and idle interrupt flags on v1.
+                let _ = rdr(r).read_volatile();
+                clear_interrupt_flags(r, sr);
+            }
+            // enable idle interrupt
+            r.cr1().modify(|w| {
+                w.set_idleie(true);
+            });
+        }
+
+        compiler_fence(Ordering::SeqCst);
+
+        let res = poll_fn(move |cx| {
+            let s = T::state();
+
+            // SAFETY: read only and we only use Rx related flags
+            let usart_sr = unsafe { sr(r).read() };
+
+            // SAFETY: only clears Rx related flags
+            unsafe {
+                // This read also clears the error and idle interrupt flags on v1.
+                let _ = rdr(r).read_volatile();
+
+                clear_interrupt_flags(r, usart_sr);
+            }
+
+            compiler_fence(Ordering::SeqCst);
+
+            let has_errors = usart_sr.pe() || usart_sr.fe() || usart_sr.ne() || usart_sr.ore();
+
+            if has_errors {
+                // clear all interrupts and DMA Rx Request
+                // SAFETY: only clears Rx related flags
+                unsafe {
+                    r.cr1().modify(|w| {
+                        // disable RXNE interrupt
+                        w.set_rxneie(false);
+                        // disable parity interrupt
+                        w.set_peie(false);
+                        // disable idle line interrupt
+                        w.set_idleie(false);
+                    });
+                    r.cr3().modify(|w| {
+                        // disable Error Interrupt: (Frame error, Noise error, Overrun error)
+                        w.set_eie(false);
+                        // disable DMA Rx Request
+                        w.set_dmar(false);
+                    });
+                }
+
+                compiler_fence(Ordering::SeqCst);
+
+                // stop dma transfer
+                ch.request_stop();
+                while ch.is_running() {}
+
+                if usart_sr.pe() {
+                    return Poll::Ready(Err(Error::Parity));
+                }
+                if usart_sr.fe() {
+                    return Poll::Ready(Err(Error::Framing));
+                }
+                if usart_sr.ne() {
+                    return Poll::Ready(Err(Error::Noise));
+                }
+                if usart_sr.ore() {
+                    return Poll::Ready(Err(Error::Overrun));
+                }
+            }
+
+            if usart_sr.idle() {
+                // Idle line
+
+                // stop dma transfer
+                ch.request_stop();
+                while ch.is_running() {}
+
+                let n = buffer_len - (ch.remaining_transfers() as usize);
+
+                return Poll::Ready(Ok(n));
+            } else if !ch.is_running() {
+                // DMA complete
+                return Poll::Ready(Ok(buffer_len));
+            }
+
+            ch.set_waker(cx.waker());
+            s.rx_waker.register(cx.waker());
+
+            Poll::Pending
+        })
+        .await;
+
+        // clear all interrupts and DMA Rx Request
+        // SAFETY: only clears Rx related flags
+        unsafe {
+            r.cr1().modify(|w| {
+                // disable RXNE interrupt
+                w.set_rxneie(false);
+                // disable parity interrupt
+                w.set_peie(false);
+                // disable idle line interrupt
+                w.set_idleie(false);
+            });
+            r.cr3().modify(|w| {
+                // disable Error Interrupt: (Frame error, Noise error, Overrun error)
+                w.set_eie(false);
+                // disable DMA Rx Request
+                w.set_dmar(false);
+            });
+        }
+
+        res
+    }
+}
+
 mod eh02 {
     use super::*;
 
     impl<'d, T: BasicInstance, RxDma> embedded_hal_02::serial::Read<u8> for UartRx<'d, T, RxDma> {
+        type Error = Error;
+        fn read(&mut self) -> Result<u8, nb::Error<Self::Error>> {
+            self.nb_read()
+        }
+    }
+
+    impl<'d, T: BasicInstance, RxDma> embedded_hal_02::serial::Read<u8> for UartRxWithIdle<'d, T, RxDma> {
         type Error = Error;
         fn read(&mut self) -> Result<u8, nb::Error<Self::Error>> {
             self.nb_read()
@@ -330,7 +736,26 @@ mod eh02 {
         }
     }
 
+    impl<'d, T: BasicInstance, TxDma, RxDma> embedded_hal_02::serial::Read<u8> for UartWithIdle<'d, T, TxDma, RxDma> {
+        type Error = Error;
+        fn read(&mut self) -> Result<u8, nb::Error<Self::Error>> {
+            self.nb_read()
+        }
+    }
+
     impl<'d, T: BasicInstance, TxDma, RxDma> embedded_hal_02::blocking::serial::Write<u8> for Uart<'d, T, TxDma, RxDma> {
+        type Error = Error;
+        fn bwrite_all(&mut self, buffer: &[u8]) -> Result<(), Self::Error> {
+            self.blocking_write(buffer)
+        }
+        fn bflush(&mut self) -> Result<(), Self::Error> {
+            self.blocking_flush()
+        }
+    }
+
+    impl<'d, T: BasicInstance, TxDma, RxDma> embedded_hal_02::blocking::serial::Write<u8>
+        for UartWithIdle<'d, T, TxDma, RxDma>
+    {
         type Error = Error;
         fn bwrite_all(&mut self, buffer: &[u8]) -> Result<(), Self::Error> {
             self.blocking_write(buffer)
@@ -352,11 +777,17 @@ mod eh1 {
                 Self::Noise => embedded_hal_1::serial::ErrorKind::Noise,
                 Self::Overrun => embedded_hal_1::serial::ErrorKind::Overrun,
                 Self::Parity => embedded_hal_1::serial::ErrorKind::Parity,
+                Self::BufferTooLong => embedded_hal_1::serial::ErrorKind::Other,
+                Self::BufferZeroLength => embedded_hal_1::serial::ErrorKind::Other,
             }
         }
     }
 
     impl<'d, T: BasicInstance, TxDma, RxDma> embedded_hal_1::serial::ErrorType for Uart<'d, T, TxDma, RxDma> {
+        type Error = Error;
+    }
+
+    impl<'d, T: BasicInstance, TxDma, RxDma> embedded_hal_1::serial::ErrorType for UartWithIdle<'d, T, TxDma, RxDma> {
         type Error = Error;
     }
 
@@ -368,7 +799,17 @@ mod eh1 {
         type Error = Error;
     }
 
+    impl<'d, T: BasicInstance, RxDma> embedded_hal_1::serial::ErrorType for UartRxWithIdle<'d, T, RxDma> {
+        type Error = Error;
+    }
+
     impl<'d, T: BasicInstance, RxDma> embedded_hal_nb::serial::Read for UartRx<'d, T, RxDma> {
+        fn read(&mut self) -> nb::Result<u8, Self::Error> {
+            self.nb_read()
+        }
+    }
+
+    impl<'d, T: BasicInstance, RxDma> embedded_hal_nb::serial::Read for UartRxWithIdle<'d, T, RxDma> {
         fn read(&mut self) -> nb::Result<u8, Self::Error> {
             self.nb_read()
         }
@@ -400,6 +841,12 @@ mod eh1 {
         }
     }
 
+    impl<'d, T: BasicInstance, TxDma, RxDma> embedded_hal_nb::serial::Read for UartWithIdle<'d, T, TxDma, RxDma> {
+        fn read(&mut self) -> Result<u8, nb::Error<Self::Error>> {
+            self.nb_read()
+        }
+    }
+
     impl<'d, T: BasicInstance, TxDma, RxDma> embedded_hal_1::serial::Write for Uart<'d, T, TxDma, RxDma> {
         fn write(&mut self, buffer: &[u8]) -> Result<(), Self::Error> {
             self.blocking_write(buffer)
@@ -410,7 +857,27 @@ mod eh1 {
         }
     }
 
+    impl<'d, T: BasicInstance, TxDma, RxDma> embedded_hal_1::serial::Write for UartWithIdle<'d, T, TxDma, RxDma> {
+        fn write(&mut self, buffer: &[u8]) -> Result<(), Self::Error> {
+            self.blocking_write(buffer)
+        }
+
+        fn flush(&mut self) -> Result<(), Self::Error> {
+            self.blocking_flush()
+        }
+    }
+
     impl<'d, T: BasicInstance, TxDma, RxDma> embedded_hal_nb::serial::Write for Uart<'d, T, TxDma, RxDma> {
+        fn write(&mut self, char: u8) -> nb::Result<(), Self::Error> {
+            self.blocking_write(&[char]).map_err(nb::Error::Other)
+        }
+
+        fn flush(&mut self) -> nb::Result<(), Self::Error> {
+            self.blocking_flush().map_err(nb::Error::Other)
+        }
+    }
+
+    impl<'d, T: BasicInstance, TxDma, RxDma> embedded_hal_nb::serial::Write for UartWithIdle<'d, T, TxDma, RxDma> {
         fn write(&mut self, char: u8) -> nb::Result<(), Self::Error> {
             self.blocking_write(&[char]).map_err(nb::Error::Other)
         }
@@ -459,6 +926,17 @@ mod eha {
         }
     }
 
+    impl<'d, T: BasicInstance, RxDma> embedded_hal_async::serial::Read for UartRxWithIdle<'d, T, RxDma>
+    where
+        RxDma: crate::usart::RxDma<T>,
+    {
+        type ReadFuture<'a> = impl Future<Output = Result<(), Self::Error>> + 'a where Self: 'a;
+
+        fn read<'a>(&'a mut self, buf: &'a mut [u8]) -> Self::ReadFuture<'a> {
+            self.read(buf)
+        }
+    }
+
     impl<'d, T: BasicInstance, TxDma, RxDma> embedded_hal_async::serial::Write for Uart<'d, T, TxDma, RxDma>
     where
         TxDma: crate::usart::TxDma<T>,
@@ -476,7 +954,35 @@ mod eha {
         }
     }
 
+    impl<'d, T: BasicInstance, TxDma, RxDma> embedded_hal_async::serial::Write for UartWithIdle<'d, T, TxDma, RxDma>
+    where
+        TxDma: crate::usart::TxDma<T>,
+    {
+        type WriteFuture<'a> = impl Future<Output = Result<(), Self::Error>> + 'a where Self: 'a;
+
+        fn write<'a>(&'a mut self, buf: &'a [u8]) -> Self::WriteFuture<'a> {
+            self.write(buf)
+        }
+
+        type FlushFuture<'a> = impl Future<Output = Result<(), Self::Error>> + 'a where Self: 'a;
+
+        fn flush<'a>(&'a mut self) -> Self::FlushFuture<'a> {
+            async move { Ok(()) }
+        }
+    }
+
     impl<'d, T: BasicInstance, TxDma, RxDma> embedded_hal_async::serial::Read for Uart<'d, T, TxDma, RxDma>
+    where
+        RxDma: crate::usart::RxDma<T>,
+    {
+        type ReadFuture<'a> = impl Future<Output = Result<(), Self::Error>> + 'a where Self: 'a;
+
+        fn read<'a>(&'a mut self, buf: &'a mut [u8]) -> Self::ReadFuture<'a> {
+            self.read(buf)
+        }
+    }
+
+    impl<'d, T: BasicInstance, TxDma, RxDma> embedded_hal_async::serial::Read for UartWithIdle<'d, T, TxDma, RxDma>
     where
         RxDma: crate::usart::RxDma<T>,
     {
@@ -536,13 +1042,28 @@ unsafe fn clear_interrupt_flags(r: Regs, sr: regs::Isr) {
 }
 
 pub(crate) mod sealed {
+    use embassy_sync::waitqueue::AtomicWaker;
+
     use super::*;
+
+    pub struct State {
+        pub rx_waker: AtomicWaker,
+    }
+
+    impl State {
+        pub const fn new() -> Self {
+            Self {
+                rx_waker: AtomicWaker::new(),
+            }
+        }
+    }
 
     pub trait BasicInstance: crate::rcc::RccPeripheral {
         const MULTIPLIER: u32;
         type Interrupt: crate::interrupt::Interrupt;
 
         fn regs() -> Regs;
+        fn state() -> &'static State;
     }
 
     pub trait FullInstance: BasicInstance {
@@ -550,7 +1071,7 @@ pub(crate) mod sealed {
     }
 }
 
-pub trait BasicInstance: sealed::BasicInstance {}
+pub trait BasicInstance: Peripheral<P = Self> + sealed::BasicInstance + 'static + Send {}
 
 pub trait FullInstance: sealed::FullInstance {}
 
@@ -571,6 +1092,11 @@ macro_rules! impl_lpuart {
 
             fn regs() -> Regs {
                 Regs(crate::pac::$inst.0)
+            }
+
+            fn state() -> &'static crate::usart::sealed::State {
+                static STATE: crate::usart::sealed::State = crate::usart::sealed::State::new();
+                &STATE
             }
         }
 

--- a/examples/stm32f3/src/bin/usart_dma.rs
+++ b/examples/stm32f3/src/bin/usart_dma.rs
@@ -7,6 +7,7 @@ use core::fmt::Write;
 use defmt::*;
 use embassy_executor::Spawner;
 use embassy_stm32::dma::NoDma;
+use embassy_stm32::interrupt;
 use embassy_stm32::usart::{Config, Uart};
 use heapless::String;
 use {defmt_rtt as _, panic_probe as _};
@@ -17,7 +18,8 @@ async fn main(_spawner: Spawner) {
     info!("Hello World!");
 
     let config = Config::default();
-    let mut usart = Uart::new(p.USART1, p.PE1, p.PE0, p.DMA1_CH4, NoDma, config);
+    let irq = interrupt::take!(USART1);
+    let mut usart = Uart::new(p.USART1, p.PE1, p.PE0, irq, p.DMA1_CH4, NoDma, config);
 
     for n in 0u32.. {
         let mut s: String<128> = String::new();

--- a/examples/stm32f4/src/bin/usart.rs
+++ b/examples/stm32f4/src/bin/usart.rs
@@ -5,6 +5,7 @@
 use cortex_m_rt::entry;
 use defmt::*;
 use embassy_stm32::dma::NoDma;
+use embassy_stm32::interrupt;
 use embassy_stm32::usart::{Config, Uart};
 use {defmt_rtt as _, panic_probe as _};
 
@@ -15,7 +16,8 @@ fn main() -> ! {
     let p = embassy_stm32::init(Default::default());
 
     let config = Config::default();
-    let mut usart = Uart::new(p.USART3, p.PD9, p.PD8, NoDma, NoDma, config);
+    let irq = interrupt::take!(USART3);
+    let mut usart = Uart::new(p.USART3, p.PD9, p.PD8, irq, NoDma, NoDma, config);
 
     unwrap!(usart.blocking_write(b"Hello Embassy World!\r\n"));
     info!("wrote Hello, starting echo");

--- a/examples/stm32f4/src/bin/usart_buffered.rs
+++ b/examples/stm32f4/src/bin/usart_buffered.rs
@@ -4,9 +4,8 @@
 
 use defmt::*;
 use embassy_executor::Spawner;
-use embassy_stm32::dma::NoDma;
 use embassy_stm32::interrupt;
-use embassy_stm32::usart::{BufferedUart, Config, State, Uart};
+use embassy_stm32::usart::{BufferedUart, Config, State};
 use embedded_io::asynch::BufRead;
 use {defmt_rtt as _, panic_probe as _};
 
@@ -16,13 +15,21 @@ async fn main(_spawner: Spawner) {
     info!("Hello World!");
 
     let config = Config::default();
-    let usart = Uart::new(p.USART3, p.PD9, p.PD8, NoDma, NoDma, config);
 
     let mut state = State::new();
     let irq = interrupt::take!(USART3);
     let mut tx_buf = [0u8; 32];
     let mut rx_buf = [0u8; 32];
-    let mut buf_usart = BufferedUart::new(&mut state, usart, irq, &mut tx_buf, &mut rx_buf);
+    let mut buf_usart = BufferedUart::new(
+        &mut state,
+        p.USART3,
+        p.PD9,
+        p.PD8,
+        irq,
+        &mut tx_buf,
+        &mut rx_buf,
+        config,
+    );
 
     loop {
         let buf = buf_usart.fill_buf().await.unwrap();

--- a/examples/stm32f4/src/bin/usart_dma.rs
+++ b/examples/stm32f4/src/bin/usart_dma.rs
@@ -7,6 +7,7 @@ use core::fmt::Write;
 use defmt::*;
 use embassy_executor::Spawner;
 use embassy_stm32::dma::NoDma;
+use embassy_stm32::interrupt;
 use embassy_stm32::usart::{Config, Uart};
 use heapless::String;
 use {defmt_rtt as _, panic_probe as _};
@@ -17,7 +18,8 @@ async fn main(_spawner: Spawner) {
     info!("Hello World!");
 
     let config = Config::default();
-    let mut usart = Uart::new(p.USART3, p.PD9, p.PD8, p.DMA1_CH3, NoDma, config);
+    let irq = interrupt::take!(USART3);
+    let mut usart = Uart::new(p.USART3, p.PD9, p.PD8, irq, p.DMA1_CH3, NoDma, config);
 
     for n in 0u32.. {
         let mut s: String<128> = String::new();

--- a/examples/stm32f4/src/bin/usart_idle.rs
+++ b/examples/stm32f4/src/bin/usart_idle.rs
@@ -1,0 +1,112 @@
+#![no_std]
+#![no_main]
+#![feature(type_alias_impl_trait)]
+
+// For this app to work, you should connect PB11 and PA9 pins
+
+use defmt::*;
+use embassy_executor::Spawner;
+use embassy_stm32::dma::NoDma;
+use embassy_stm32::interrupt;
+use embassy_stm32::peripherals::{DMA2_CH7, USART1};
+use embassy_stm32::time::Hertz;
+use embassy_stm32::usart::{Config, Uart, UartWithIdle};
+use embassy_time::{Duration, Timer};
+use {defmt_rtt as _, panic_probe as _};
+
+const INCOMMING_DATA_SIZE: usize = 17;
+const BUFFER_SIZE: usize = 16;
+const MAIN_BUFFER_SIZE: usize = 32;
+
+pub fn config() -> embassy_stm32::Config {
+    let mut config = embassy_stm32::Config::default();
+
+    config.rcc.hse = Some(Hertz(8_000_000));
+    config.rcc.bypass_hse = false;
+    config.rcc.pll48 = false;
+    config.rcc.sys_ck = Some(Hertz(180_000_000));
+    config.rcc.hclk = Some(Hertz(180_000_000));
+    config.rcc.pclk1 = Some(Hertz(45_000_000));
+    config.rcc.pclk2 = Some(Hertz(90_000_000));
+
+    config
+}
+
+fn fill_ref_buffer(buffer: &mut [u8]) {
+    let mut ch = 0;
+
+    for i in 0..buffer.len() {
+        buffer[i] = ch;
+        ch += 1;
+    }
+}
+
+#[embassy_executor::task]
+async fn emitter_task(mut uart: Uart<'static, USART1, DMA2_CH7, NoDma>) {
+    let mut buffer = [0; INCOMMING_DATA_SIZE];
+
+    fill_ref_buffer(&mut buffer);
+
+    loop {
+        Timer::after(Duration::from_millis(500)).await;
+
+        uart.write(&buffer).await.unwrap();
+    }
+}
+
+#[embassy_executor::main]
+async fn main(spawner: Spawner) -> ! {
+    let p = embassy_stm32::init(config());
+    info!("Hello World!");
+
+    let config = Config::default();
+
+    // set to false if you don't want to detect previous overrun errors
+    let detect_previous_overrun = true;
+
+    let irq = interrupt::take!(USART3);
+    let mut usart = UartWithIdle::new(
+        p.USART3,
+        irq,
+        p.PB11,
+        p.PB10,
+        NoDma,
+        p.DMA1_CH1,
+        config,
+        detect_previous_overrun,
+    );
+
+    let emitter = Uart::new(p.USART1, p.PA10, p.PA9, p.DMA2_CH7, NoDma, config);
+
+    // buffer of chunks of data
+    let mut buffer: [u8; BUFFER_SIZE] = [0; BUFFER_SIZE];
+
+    // circular buffer for incomming data
+    let mut main_buffer: [u8; MAIN_BUFFER_SIZE] = [0; MAIN_BUFFER_SIZE];
+
+    defmt::assert!(BUFFER_SIZE <= MAIN_BUFFER_SIZE);
+
+    spawner.spawn(emitter_task(emitter)).unwrap();
+
+    let mut new_pos = 0;
+
+    loop {
+        let received_bytes = usart.read_until_idle(&mut buffer).await.unwrap();
+
+        info!("Received {} bytes: {}", received_bytes, buffer[..received_bytes]);
+
+        // copy data to larger main ring buffer
+        let old_pos = new_pos;
+        if old_pos + received_bytes > MAIN_BUFFER_SIZE {
+            let data_to_copy = MAIN_BUFFER_SIZE - old_pos;
+            main_buffer[old_pos..].copy_from_slice(&buffer[..data_to_copy]);
+            new_pos = received_bytes - data_to_copy;
+            main_buffer[..new_pos].copy_from_slice(&buffer[data_to_copy..received_bytes]);
+        } else {
+            new_pos = old_pos + received_bytes;
+            main_buffer[old_pos..new_pos].copy_from_slice(&buffer[..received_bytes]);
+        }
+
+        info!("Main buffer: {}", main_buffer);
+    }
+}

--- a/examples/stm32f7/src/bin/usart_dma.rs
+++ b/examples/stm32f7/src/bin/usart_dma.rs
@@ -7,6 +7,7 @@ use core::fmt::Write;
 use defmt::*;
 use embassy_executor::Spawner;
 use embassy_stm32::dma::NoDma;
+use embassy_stm32::interrupt;
 use embassy_stm32::usart::{Config, Uart};
 use heapless::String;
 use {defmt_rtt as _, panic_probe as _};
@@ -15,7 +16,8 @@ use {defmt_rtt as _, panic_probe as _};
 async fn main(_spawner: Spawner) {
     let p = embassy_stm32::init(Default::default());
     let config = Config::default();
-    let mut usart = Uart::new(p.UART7, p.PA8, p.PA15, p.DMA1_CH1, NoDma, config);
+    let irq = interrupt::take!(UART7);
+    let mut usart = Uart::new(p.UART7, p.PA8, p.PA15, irq, p.DMA1_CH1, NoDma, config);
 
     for n in 0u32.. {
         let mut s: String<128> = String::new();

--- a/examples/stm32h7/src/bin/usart.rs
+++ b/examples/stm32h7/src/bin/usart.rs
@@ -6,6 +6,7 @@ use cortex_m_rt::entry;
 use defmt::*;
 use embassy_executor::Executor;
 use embassy_stm32::dma::NoDma;
+use embassy_stm32::interrupt;
 use embassy_stm32::usart::{Config, Uart};
 use static_cell::StaticCell;
 use {defmt_rtt as _, panic_probe as _};
@@ -15,7 +16,8 @@ async fn main_task() {
     let p = embassy_stm32::init(Default::default());
 
     let config = Config::default();
-    let mut usart = Uart::new(p.UART7, p.PF6, p.PF7, NoDma, NoDma, config);
+    let irq = interrupt::take!(UART7);
+    let mut usart = Uart::new(p.UART7, p.PF6, p.PF7, irq, NoDma, NoDma, config);
 
     unwrap!(usart.blocking_write(b"Hello Embassy World!\r\n"));
     info!("wrote Hello, starting echo");

--- a/examples/stm32h7/src/bin/usart_dma.rs
+++ b/examples/stm32h7/src/bin/usart_dma.rs
@@ -8,6 +8,7 @@ use cortex_m_rt::entry;
 use defmt::*;
 use embassy_executor::Executor;
 use embassy_stm32::dma::NoDma;
+use embassy_stm32::interrupt;
 use embassy_stm32::usart::{Config, Uart};
 use heapless::String;
 use static_cell::StaticCell;
@@ -18,7 +19,8 @@ async fn main_task() {
     let p = embassy_stm32::init(Default::default());
 
     let config = Config::default();
-    let mut usart = Uart::new(p.UART7, p.PF6, p.PF7, p.DMA1_CH0, NoDma, config);
+    let irq = interrupt::take!(UART7);
+    let mut usart = Uart::new(p.UART7, p.PF6, p.PF7, irq, p.DMA1_CH0, NoDma, config);
 
     for n in 0u32.. {
         let mut s: String<128> = String::new();

--- a/examples/stm32h7/src/bin/usart_split.rs
+++ b/examples/stm32h7/src/bin/usart_split.rs
@@ -5,6 +5,7 @@
 use defmt::*;
 use embassy_executor::Spawner;
 use embassy_stm32::dma::NoDma;
+use embassy_stm32::interrupt;
 use embassy_stm32::peripherals::{DMA1_CH1, UART7};
 use embassy_stm32::usart::{Config, Uart, UartRx};
 use embassy_sync::blocking_mutex::raw::ThreadModeRawMutex;
@@ -31,7 +32,8 @@ async fn main(spawner: Spawner) -> ! {
     info!("Hello World!");
 
     let config = Config::default();
-    let mut usart = Uart::new(p.UART7, p.PF6, p.PF7, p.DMA1_CH0, p.DMA1_CH1, config);
+    let irq = interrupt::take!(UART7);
+    let mut usart = Uart::new(p.UART7, p.PF6, p.PF7, irq, p.DMA1_CH0, p.DMA1_CH1, config);
     unwrap!(usart.blocking_write(b"Type 8 chars to echo!\r\n"));
 
     let (mut tx, rx) = usart.split();

--- a/examples/stm32l0/src/bin/usart_dma.rs
+++ b/examples/stm32l0/src/bin/usart_dma.rs
@@ -4,13 +4,15 @@
 
 use defmt::*;
 use embassy_executor::Spawner;
+use embassy_stm32::interrupt;
 use embassy_stm32::usart::{Config, Uart};
 use {defmt_rtt as _, panic_probe as _};
 
 #[embassy_executor::main]
 async fn main(_spawner: Spawner) {
     let p = embassy_stm32::init(Default::default());
-    let mut usart = Uart::new(p.USART1, p.PB7, p.PB6, p.DMA1_CH2, p.DMA1_CH3, Config::default());
+    let irq = interrupt::take!(USART1);
+    let mut usart = Uart::new(p.USART1, p.PB7, p.PB6, irq, p.DMA1_CH2, p.DMA1_CH3, Config::default());
 
     usart.write(b"Hello Embassy World!\r\n").await.unwrap();
     info!("wrote Hello, starting echo");

--- a/examples/stm32l0/src/bin/usart_irq.rs
+++ b/examples/stm32l0/src/bin/usart_irq.rs
@@ -22,16 +22,18 @@ async fn main(_spawner: Spawner) {
 
     let mut state = State::new();
     let irq = interrupt::take!(USART2);
-    let mut usart = BufferedUart::new(
-        &mut state,
-        p.USART2,
-        p.PA3,
-        p.PA2,
-        irq,
-        &mut TX_BUFFER,
-        &mut RX_BUFFER,
-        config,
-    );
+    let mut usart = unsafe {
+        BufferedUart::new(
+            &mut state,
+            p.USART2,
+            p.PA3,
+            p.PA2,
+            irq,
+            &mut TX_BUFFER,
+            &mut RX_BUFFER,
+            config,
+        )
+    };
 
     usart.write_all(b"Hello Embassy World!\r\n").await.unwrap();
     info!("wrote Hello, starting echo");

--- a/examples/stm32l4/src/bin/usart.rs
+++ b/examples/stm32l4/src/bin/usart.rs
@@ -4,6 +4,7 @@
 
 use defmt::*;
 use embassy_stm32::dma::NoDma;
+use embassy_stm32::interrupt;
 use embassy_stm32::usart::{Config, Uart};
 use {defmt_rtt as _, panic_probe as _};
 
@@ -14,7 +15,8 @@ fn main() -> ! {
     let p = embassy_stm32::init(Default::default());
 
     let config = Config::default();
-    let mut usart = Uart::new(p.UART4, p.PA1, p.PA0, NoDma, NoDma, config);
+    let irq = interrupt::take!(UART4);
+    let mut usart = Uart::new(p.UART4, p.PA1, p.PA0, irq, NoDma, NoDma, config);
 
     unwrap!(usart.blocking_write(b"Hello Embassy World!\r\n"));
     info!("wrote Hello, starting echo");

--- a/examples/stm32l4/src/bin/usart_dma.rs
+++ b/examples/stm32l4/src/bin/usart_dma.rs
@@ -7,6 +7,7 @@ use core::fmt::Write;
 use defmt::*;
 use embassy_executor::Spawner;
 use embassy_stm32::dma::NoDma;
+use embassy_stm32::interrupt;
 use embassy_stm32::usart::{Config, Uart};
 use heapless::String;
 use {defmt_rtt as _, panic_probe as _};
@@ -17,7 +18,8 @@ async fn main(_spawner: Spawner) {
     info!("Hello World!");
 
     let config = Config::default();
-    let mut usart = Uart::new(p.UART4, p.PA1, p.PA0, p.DMA1_CH3, NoDma, config);
+    let irq = interrupt::take!(UART4);
+    let mut usart = Uart::new(p.UART4, p.PA1, p.PA0, irq, p.DMA1_CH3, NoDma, config);
 
     for n in 0u32.. {
         let mut s: String<128> = String::new();

--- a/tests/stm32/src/bin/usart.rs
+++ b/tests/stm32/src/bin/usart.rs
@@ -7,6 +7,7 @@ mod example_common;
 use defmt::assert_eq;
 use embassy_executor::Spawner;
 use embassy_stm32::dma::NoDma;
+use embassy_stm32::interrupt;
 use embassy_stm32::usart::{Config, Uart};
 use example_common::*;
 
@@ -18,22 +19,22 @@ async fn main(_spawner: Spawner) {
     // Arduino pins D0 and D1
     // They're connected together with a 1K resistor.
     #[cfg(feature = "stm32f103c8")]
-    let (tx, rx, usart) = (p.PA9, p.PA10, p.USART1);
+    let (tx, rx, usart, irq) = (p.PA9, p.PA10, p.USART1, interrupt::take!(USART1));
     #[cfg(feature = "stm32g491re")]
-    let (tx, rx, usart) = (p.PC4, p.PC5, p.USART1);
+    let (tx, rx, usart, irq) = (p.PC4, p.PC5, p.USART1, interrupt::take!(USART1));
     #[cfg(feature = "stm32g071rb")]
-    let (tx, rx, usart) = (p.PC4, p.PC5, p.USART1);
+    let (tx, rx, usart, irq) = (p.PC4, p.PC5, p.USART1, interrupt::take!(USART1));
     #[cfg(feature = "stm32f429zi")]
-    let (tx, rx, usart) = (p.PG14, p.PG9, p.USART6);
+    let (tx, rx, usart, irq) = (p.PG14, p.PG9, p.USART6, interrupt::take!(USART6));
     #[cfg(feature = "stm32wb55rg")]
-    let (tx, rx, usart) = (p.PA2, p.PA3, p.LPUART1);
+    let (tx, rx, usart, irq) = (p.PA2, p.PA3, p.LPUART1, interrupt::take!(LPUART1));
     #[cfg(feature = "stm32h755zi")]
-    let (tx, rx, usart) = (p.PB6, p.PB7, p.USART1);
+    let (tx, rx, usart, irq) = (p.PB6, p.PB7, p.USART1, interrupt::take!(USART1));
     #[cfg(feature = "stm32u585ai")]
-    let (tx, rx, usart) = (p.PD8, p.PD9, p.USART3);
+    let (tx, rx, usart, irq) = (p.PD8, p.PD9, p.USART3, interrupt::take!(USART3));
 
     let config = Config::default();
-    let mut usart = Uart::new(usart, rx, tx, NoDma, NoDma, config);
+    let mut usart = Uart::new(usart, rx, tx, irq, NoDma, NoDma, config);
 
     // We can't send too many bytes, they have to fit in the FIFO.
     // This is because we aren't sending+receiving at the same time.

--- a/tests/stm32/src/bin/usart_dma.rs
+++ b/tests/stm32/src/bin/usart_dma.rs
@@ -6,6 +6,7 @@
 mod example_common;
 use defmt::assert_eq;
 use embassy_executor::Spawner;
+use embassy_stm32::interrupt;
 use embassy_stm32::usart::{Config, Uart};
 use example_common::*;
 
@@ -17,22 +18,53 @@ async fn main(_spawner: Spawner) {
     // Arduino pins D0 and D1
     // They're connected together with a 1K resistor.
     #[cfg(feature = "stm32f103c8")]
-    let (tx, rx, usart, tx_dma, rx_dma) = (p.PA9, p.PA10, p.USART1, p.DMA1_CH4, p.DMA1_CH5);
+    let (tx, rx, usart, irq, tx_dma, rx_dma) = (
+        p.PA9,
+        p.PA10,
+        p.USART1,
+        interrupt::take!(USART1),
+        p.DMA1_CH4,
+        p.DMA1_CH5,
+    );
     #[cfg(feature = "stm32g491re")]
-    let (tx, rx, usart, tx_dma, rx_dma) = (p.PC4, p.PC5, p.USART1, p.DMA1_CH1, p.DMA1_CH2);
+    let (tx, rx, usart, irq, tx_dma, rx_dma) =
+        (p.PC4, p.PC5, p.USART1, interrupt::take!(USART1), p.DMA1_CH1, p.DMA1_CH2);
     #[cfg(feature = "stm32g071rb")]
-    let (tx, rx, usart, tx_dma, rx_dma) = (p.PC4, p.PC5, p.USART1, p.DMA1_CH1, p.DMA1_CH2);
+    let (tx, rx, usart, irq, tx_dma, rx_dma) =
+        (p.PC4, p.PC5, p.USART1, interrupt::take!(USART1), p.DMA1_CH1, p.DMA1_CH2);
     #[cfg(feature = "stm32f429zi")]
-    let (tx, rx, usart, tx_dma, rx_dma) = (p.PG14, p.PG9, p.USART6, p.DMA2_CH6, p.DMA2_CH1);
+    let (tx, rx, usart, irq, tx_dma, rx_dma) = (
+        p.PG14,
+        p.PG9,
+        p.USART6,
+        interrupt::take!(USART6),
+        p.DMA2_CH6,
+        p.DMA2_CH1,
+    );
     #[cfg(feature = "stm32wb55rg")]
-    let (tx, rx, usart, tx_dma, rx_dma) = (p.PA2, p.PA3, p.LPUART1, p.DMA1_CH1, p.DMA1_CH2);
+    let (tx, rx, usart, irq, tx_dma, rx_dma) = (
+        p.PA2,
+        p.PA3,
+        p.LPUART1,
+        interrupt::take!(LPUART1),
+        p.DMA1_CH1,
+        p.DMA1_CH2,
+    );
     #[cfg(feature = "stm32h755zi")]
-    let (tx, rx, usart, tx_dma, rx_dma) = (p.PB6, p.PB7, p.USART1, p.DMA1_CH0, p.DMA1_CH1);
+    let (tx, rx, usart, irq, tx_dma, rx_dma) =
+        (p.PB6, p.PB7, p.USART1, interrupt::take!(USART1), p.DMA1_CH0, p.DMA1_CH1);
     #[cfg(feature = "stm32u585ai")]
-    let (tx, rx, usart, tx_dma, rx_dma) = (p.PD8, p.PD9, p.USART3, p.GPDMA1_CH0, p.GPDMA1_CH1);
+    let (tx, rx, usart, irq, tx_dma, rx_dma) = (
+        p.PD8,
+        p.PD9,
+        p.USART3,
+        interrupt::take!(USART3),
+        p.GPDMA1_CH0,
+        p.GPDMA1_CH1,
+    );
 
     let config = Config::default();
-    let mut usart = Uart::new(usart, rx, tx, tx_dma, rx_dma, config);
+    let mut usart = Uart::new(usart, rx, tx, irq, tx_dma, rx_dma, config);
 
     // We can't send too many bytes, they have to fit in the FIFO.
     // This is because we aren't sending+receiving at the same time.


### PR DESCRIPTION
Hi,
On #967, we identified that we need a `read_until_idle` for `Uart` on STM32. 
It also add support for detecting UART errors (like framing, parity, etc...) to `read`.
For this to work, Uart now take the uart interrupt and `BufferedUart` is created completely independant from `Uart` because they both need uart interrupt.

You can create an `Uart` instance like this:
```rust
let mut config = Config::default();
// set to true if you want to detect previous overrun errors
config.detect_previous_overrun = true;

let irq = interrupt::take!(USART3);
let usart = Uart::new(p.USART3, p.PB11, p.PB10, irq, NoDma, p.DMA1_CH1, config);
```

For `BufferedUart`, you can create it like this:
```rust
    let config = Config::default();

    let mut state = State::new();
    let irq = interrupt::take!(USART3);
    let mut tx_buf = [0u8; 32];
    let mut rx_buf = [0u8; 32];
    let mut buf_usart = BufferedUart::new(
        &mut state,
        p.USART3,
        p.PB11,
        p.PB10,
        irq,
        &mut tx_buf,
        &mut rx_buf,
        config,
    );
```

`read_until_idle` is only available when DMA is enabled on Rx for now.