### PR TITLE
Add memory barriers to H7 flash driver to mitigate PGSERR errors

### DIFF
--- a/embassy-stm32/src/flash/h7.rs
+++ b/embassy-stm32/src/flash/h7.rs
@@ -39,6 +39,10 @@ pub(crate) unsafe fn blocking_write(offset: u32, buf: &[u8]) -> Result<(), Error
         w.set_psize(2); // 32 bits at once
     });
 
+    cortex_m::asm::isb();
+    cortex_m::asm::dsb();
+    atomic_polyfill::fence(atomic_polyfill::Ordering::SeqCst);
+
     let ret = {
         let mut ret: Result<(), Error> = Ok(());
         let mut offset = offset;
@@ -63,6 +67,10 @@ pub(crate) unsafe fn blocking_write(offset: u32, buf: &[u8]) -> Result<(), Error
     };
 
     bank.cr().write(|w| w.set_pg(false));
+
+    cortex_m::asm::isb();
+    cortex_m::asm::dsb();
+    atomic_polyfill::fence(atomic_polyfill::Ordering::SeqCst);
 
     ret
 }


### PR DESCRIPTION
The stm32h7xx-hal uses only the ordering barrier, while the CubeMX uses the DSB and ISB instructions, to be on the safe side, both are used here.

Without the barrier, the PG bit is not set, when the writes are being done, resulting in an error.