### PR TITLE
stm32/dma: Store wakers in "associated statics"

### DIFF
--- a/embassy-stm32/build.rs
+++ b/embassy-stm32/build.rs
@@ -602,29 +602,15 @@ fn main() {
         }
     }
 
-    let mut dma_channel_count: usize = 0;
-    let mut bdma_channel_count: usize = 0;
-    let mut gpdma_channel_count: usize = 0;
-
     for ch in METADATA.dma_channels {
         let mut row = Vec::new();
         let dma_peri = METADATA.peripherals.iter().find(|p| p.name == ch.dma).unwrap();
         let bi = dma_peri.registers.as_ref().unwrap();
 
-        let num;
         match bi.kind {
-            "dma" => {
-                num = dma_channel_count;
-                dma_channel_count += 1;
-            }
-            "bdma" => {
-                num = bdma_channel_count;
-                bdma_channel_count += 1;
-            }
-            "gpdma" => {
-                num = gpdma_channel_count;
-                gpdma_channel_count += 1;
-            }
+            "dma" => {}
+            "bdma" => {}
+            "gpdma" => {}
             _ => panic!("bad dma channel kind {}", bi.kind),
         }
 
@@ -632,7 +618,6 @@ fn main() {
         row.push(ch.dma.to_string());
         row.push(bi.kind.to_string());
         row.push(ch.channel.to_string());
-        row.push(num.to_string());
         if let Some(dmamux) = &ch.dmamux {
             let dmamux_channel = ch.dmamux_channel.unwrap();
             row.push(format!("{{dmamux: {}, dmamux_channel: {}}}", dmamux, dmamux_channel));
@@ -642,12 +627,6 @@ fn main() {
 
         dma_channels_table.push(row);
     }
-
-    g.extend(quote! {
-        pub(crate) const DMA_CHANNEL_COUNT: usize = #dma_channel_count;
-        pub(crate) const BDMA_CHANNEL_COUNT: usize = #bdma_channel_count;
-        pub(crate) const GPDMA_CHANNEL_COUNT: usize = #gpdma_channel_count;
-    });
 
     for irq in METADATA.interrupts {
         let name = irq.name.to_ascii_uppercase();

--- a/embassy-stm32/src/dma/bdma.rs
+++ b/embassy-stm32/src/dma/bdma.rs
@@ -32,10 +32,10 @@ pub(crate) unsafe fn init() {
 }
 
 foreach_dma_channel! {
-    ($channel_peri:ident, BDMA1, bdma, $channel_num:expr, $index:expr, $dmamux:tt) => {
+    ($channel_peri:ident, BDMA1, bdma, $channel_num:expr, $dmamux:tt) => {
         // BDMA1 in H7 doesn't use DMAMUX, which breaks
     };
-    ($channel_peri:ident, $dma_peri:ident, bdma, $channel_num:expr, $index:expr, $dmamux:tt) => {
+    ($channel_peri:ident, $dma_peri:ident, bdma, $channel_num:expr, $dmamux:tt) => {
         impl crate::peripherals::$channel_peri {
             fn waker() -> &'static AtomicWaker {
                 static WAKER: AtomicWaker = AtomicWaker::new();

--- a/embassy-stm32/src/dma/dma.rs
+++ b/embassy-stm32/src/dma/dma.rs
@@ -49,7 +49,7 @@ pub(crate) unsafe fn init() {
 }
 
 foreach_dma_channel! {
-    ($channel_peri:ident, $dma_peri:ident, dma, $channel_num:expr, $index:expr, $dmamux:tt) => {
+    ($channel_peri:ident, $dma_peri:ident, dma, $channel_num:expr, $dmamux:tt) => {
         impl crate::peripherals::$channel_peri {
             fn waker() -> &'static AtomicWaker {
                 static WAKER: AtomicWaker = AtomicWaker::new();

--- a/embassy-stm32/src/dma/dmamux.rs
+++ b/embassy-stm32/src/dma/dmamux.rs
@@ -31,7 +31,7 @@ pub trait MuxChannel: sealed::MuxChannel + super::Channel {
 }
 
 foreach_dma_channel! {
-    ($channel_peri:ident, $dma_peri:ident, $version:ident, $channel_num:expr, $index:expr, {dmamux: $dmamux:ident, dmamux_channel: $dmamux_channel:expr}) => {
+    ($channel_peri:ident, $dma_peri:ident, $version:ident, $channel_num:expr, {dmamux: $dmamux:ident, dmamux_channel: $dmamux_channel:expr}) => {
         impl sealed::MuxChannel for peripherals::$channel_peri {
             const DMAMUX_CH_NUM: u8 = $dmamux_channel;
             const DMAMUX_REGS: pac::dmamux::Dmamux = pac::$dmamux;

--- a/embassy-stm32/src/dma/gpdma.rs
+++ b/embassy-stm32/src/dma/gpdma.rs
@@ -29,7 +29,7 @@ pub(crate) unsafe fn init() {
 }
 
 foreach_dma_channel! {
-    ($channel_peri:ident, $dma_peri:ident, gpdma, $channel_num:expr, $index:expr, $dmamux:tt) => {
+    ($channel_peri:ident, $dma_peri:ident, gpdma, $channel_num:expr, $dmamux:tt) => {
         impl crate::peripherals::$channel_peri {
             fn waker() -> &'static AtomicWaker {
                 static WAKER: AtomicWaker = AtomicWaker::new();


### PR DESCRIPTION
I'm sure that I'm not the first person to use this technique, but I don't think I have seen it anywhere else.

Instead of storing all the wakers in a single static array, each channel singleton gets an associated function that returns a static reference to its waker
```rust
fn waker() -> &'static AtomicWaker {
    static WAKER: AtomicWaker = AtomicWaker::new();
    &WAKER
}
```

Another alternative would be to use the `foreach_dma_channel!` macro to generate normal statics like this:
```rust
static CH1_WAKER: AtomicWaker = AtomicWaker::new();
static CH2_WAKER: AtomicWaker = AtomicWaker::new();
// etc...
```
But I think that it is cleaner to tie the statics directly to the channel singletons.

Based on my very limited testing, this is also a small code-size win. I checked the stm32f1 adc example in debug (with `opt-level = "s"`) and release. `text` is 86 bytes smaller in debug and 64 bytes smaller in release, `data` and `bss` were unchanged.

### Future possibilities
If unused interrupt handlers could be optimized away, the unused statics should be optimized away too. I have an idea for this, it involves dynamically assigning interrupt handlers at runtime.