### PR TITLE
Implement I2C timeout

### DIFF
--- a/embassy-stm32/Cargo.toml
+++ b/embassy-stm32/Cargo.toml
@@ -34,7 +34,7 @@ flavors = [
 [dependencies]
 embassy-sync = { version = "0.1.0", path = "../embassy-sync" }
 embassy-executor = { version = "0.1.0", path = "../embassy-executor" }
-embassy-time = { version = "0.1.0", path = "../embassy-time", optional = true }
+embassy-time = { version = "0.1.0", path = "../embassy-time" }
 embassy-futures = { version = "0.1.0", path = "../embassy-futures" }
 embassy-cortex-m = { version = "0.1.0", path = "../embassy-cortex-m", features = ["prio-bits-4"]}
 embassy-hal-common = {version = "0.1.0", path = "../embassy-hal-common" }
@@ -84,7 +84,7 @@ exti = []
 
 # Features starting with `_` are for internal use only. They're not intended
 # to be enabled by other crates, and are not covered by semver guarantees.
-_time-driver = ["dep:embassy-time"]
+_time-driver = []
 time-driver-any = ["_time-driver"]
 time-driver-tim2 = ["_time-driver"]
 time-driver-tim3 = ["_time-driver"]

--- a/embassy-stm32/src/i2c/mod.rs
+++ b/embassy-stm32/src/i2c/mod.rs
@@ -1,5 +1,7 @@
 #![macro_use]
 
+use embassy_time::Duration;
+
 use crate::interrupt::Interrupt;
 
 #[cfg_attr(i2c_v1, path = "v1.rs")]
@@ -19,6 +21,29 @@ pub enum Error {
     Crc,
     Overrun,
     ZeroLengthTransfer,
+}
+
+#[non_exhaustive]
+#[derive(Copy, Clone)]
+pub struct Config {
+    /// Enables SDA pullup, if supported by hardware.
+    pub sda_pullup: bool,
+    /// Enabled SCL pullup, if supported by hardware.
+    pub scl_pullup: bool,
+    /// If provided, I2C methods will fail with [Error::Timeout] after a given amount of time instead of spinning infinitely.
+    ///
+    /// It is possible to provide different timeout for each operation with `xxx_timeout()` methods.
+    pub timeout: Option<Duration>,
+}
+
+impl Default for Config {
+    fn default() -> Self {
+        Self {
+            sda_pullup: false,
+            scl_pullup: false,
+            timeout: None,
+        }
+    }
 }
 
 pub(crate) mod sealed {

--- a/embassy-stm32/src/i2c/v1.rs
+++ b/embassy-stm32/src/i2c/v1.rs
@@ -248,6 +248,8 @@ impl<'d, T: Instance> I2c<'d, T> {
 
             // Also wait until signalled we're master and everything is waiting for us
             while {
+                unsafe { self.check_and_clear_error_flags()? };
+
                 let sr2 = unsafe { T::regs().sr2().read() };
                 !sr2.msl() && !sr2.busy()
             } {

--- a/embassy-stm32/src/i2c/v1.rs
+++ b/embassy-stm32/src/i2c/v1.rs
@@ -136,19 +136,12 @@ impl<'d, T: Instance> I2c<'d, T> {
             reg.set_start(true);
         });
 
-        // Wait until START condition was generated
-        while !self.check_and_clear_error_flags()?.start() {
-            if deadline.map(|d| Instant::now() > d).unwrap_or(false) {
-                return Err(Error::Timeout);
-            }
-        }
-
-        // Also wait until signalled we're master and everything is waiting for us
+        // Wait until START condition is generated and peripheral is ready
         while {
-            self.check_and_clear_error_flags()?;
-
+            let sr1 = self.check_and_clear_error_flags()?;
             let sr2 = T::regs().sr2().read();
-            !sr2.msl() && !sr2.busy()
+
+            sr1.start() && !sr2.msl() && !sr2.busy()
         } {
             if deadline.map(|d| Instant::now() > d).unwrap_or(false) {
                 return Err(Error::Timeout);
@@ -239,17 +232,12 @@ impl<'d, T: Instance> I2c<'d, T> {
                 });
             }
 
-            // Wait until START condition was generated
-            while unsafe { !self.check_and_clear_error_flags()?.start() } {
-                if deadline.map(|d| Instant::now() > d).unwrap_or(false) {
-                    return Err(Error::Timeout);
-                }
-            }
-
-            // Also wait until signalled we're master and everything is waiting for us
+            // Wait until START condition is generated and peripheral is ready
             while {
+                let sr1 = unsafe { self.check_and_clear_error_flags()? };
                 let sr2 = unsafe { T::regs().sr2().read() };
-                !sr2.msl() && !sr2.busy()
+
+                sr1.start() && !sr2.msl() && !sr2.busy()
             } {
                 if deadline.map(|d| Instant::now() > d).unwrap_or(false) {
                     return Err(Error::Timeout);

--- a/examples/stm32f4/src/bin/i2c.rs
+++ b/examples/stm32f4/src/bin/i2c.rs
@@ -1,0 +1,30 @@
+#![no_std]
+#![no_main]
+#![feature(type_alias_impl_trait)]
+
+use defmt::*;
+use embassy_executor::Spawner;
+use embassy_stm32::i2c::{Config, I2c};
+use embassy_stm32::time::Hertz;
+use embassy_time::Duration;
+use {defmt_rtt as _, panic_probe as _};
+
+const ADDRESS: u8 = 0x5F;
+const WHOAMI: u8 = 0x0F;
+
+#[embassy_executor::main]
+async fn main(_spawner: Spawner) -> ! {
+    info!("Hello world!");
+    let p = embassy_stm32::init(Default::default());
+
+    let mut config = Config::default();
+
+    // Setting a timeout prevents i2c methods from spinning infinitely
+    config.timeout = Some(Duration::from_millis(100));
+
+    let mut i2c = I2c::new(p.I2C2, p.PB10, p.PB11, Hertz(100_000), config);
+
+    let mut data = [0u8; 1];
+    unwrap!(i2c.blocking_write_read(ADDRESS, &[WHOAMI], &mut data));
+    info!("Whoami: {}", data[0]);
+}


### PR DESCRIPTION
This PR implements timeouts for all I2C methods.

Without timeouts, there are cases where I2C peripheral can be stuck in an infinite loop (i.e. SCL line is shorted to ground). This allows handling such errors without freezing entire application.

In case anyone is wondering, the `TIMEOUT` flag in `SR1` register is only available in SMBus mode, hence for regular I2C timeouts must be handled in software.

I'm not sure about the required `embassy-time` dependency, though. `embassy-nrf` I2C uses `time` feature gating, but this would cause a lot of code duplication. I believe compiler should be able to optimise out all timeout checks if `Config::timeout` is never set.