### PR TITLE
stm32/adc: Remove voltage and temperature conversions

### DIFF
--- a/embassy-stm32/src/adc/v2.rs
+++ b/embassy-stm32/src/adc/v2.rs
@@ -80,15 +80,6 @@ impl super::sealed::InternalChannel<ADC1> for Temperature {
 }
 
 impl Temperature {
-    /// Converts temperature sensor reading in millivolts to degrees celcius
-    pub fn to_celcius(sample_mv: u16) -> f32 {
-        // From 6.3.22 Temperature sensor characteristics
-        const V25: i32 = 760; // mV
-        const AVG_SLOPE: f32 = 2.5; // mV/C
-
-        (sample_mv as i32 - V25) as f32 / AVG_SLOPE + 25.0
-    }
-
     /// Time needed for temperature sensor readings to stabilize
     pub fn start_time_us() -> u32 {
         10
@@ -172,7 +163,6 @@ impl Prescaler {
 
 pub struct Adc<'d, T: Instance> {
     sample_time: SampleTime,
-    vref_mv: u32,
     resolution: Resolution,
     phantom: PhantomData<&'d mut T>,
 }
@@ -200,7 +190,6 @@ where
         Self {
             sample_time: Default::default(),
             resolution: Resolution::default(),
-            vref_mv: VREF_DEFAULT_MV,
             phantom: PhantomData,
         }
     }
@@ -211,18 +200,6 @@ where
 
     pub fn set_resolution(&mut self, resolution: Resolution) {
         self.resolution = resolution;
-    }
-
-    /// Set VREF value in millivolts. This value is used for [to_millivolts()] sample conversion.
-    ///
-    /// Use this if you have a known precise VREF (VDDA) pin reference voltage.
-    pub fn set_vref_mv(&mut self, vref_mv: u32) {
-        self.vref_mv = vref_mv;
-    }
-
-    /// Convert a measurement to millivolts
-    pub fn to_millivolts(&self, sample: u16) -> u16 {
-        ((u32::from(sample) * self.vref_mv) / self.resolution.to_max_count()) as u16
     }
 
     /// Enables internal voltage reference and returns [VrefInt], which can be used in

--- a/embassy-stm32/src/adc/v4.rs
+++ b/embassy-stm32/src/adc/v4.rs
@@ -314,7 +314,6 @@ impl Prescaler {
 
 pub struct Adc<'d, T: Instance> {
     sample_time: SampleTime,
-    vref_mv: u32,
     resolution: Resolution,
     phantom: PhantomData<&'d mut T>,
 }
@@ -352,7 +351,6 @@ impl<'d, T: Instance + crate::rcc::RccPeripheral> Adc<'d, T> {
 
         let mut s = Self {
             sample_time: Default::default(),
-            vref_mv: VREF_DEFAULT_MV,
             resolution: Resolution::default(),
             phantom: PhantomData,
         };
@@ -457,18 +455,6 @@ impl<'d, T: Instance + crate::rcc::RccPeripheral> Adc<'d, T> {
 
     pub fn set_resolution(&mut self, resolution: Resolution) {
         self.resolution = resolution;
-    }
-
-    /// Set VREF value in millivolts. This value is used for [to_millivolts()] sample conversion.
-    ///
-    /// Use this if you have a known precise VREF (VDDA) pin reference voltage.
-    pub fn set_vref_mv(&mut self, vref_mv: u32) {
-        self.vref_mv = vref_mv;
-    }
-
-    /// Convert a measurement to millivolts
-    pub fn to_millivolts(&self, sample: u16) -> u16 {
-        ((u32::from(sample) * self.vref_mv) / self.resolution.to_max_count()) as u16
     }
 
     /// Perform a single conversion.

--- a/examples/stm32f1/src/bin/adc.rs
+++ b/examples/stm32f1/src/bin/adc.rs
@@ -16,14 +16,14 @@ async fn main(_spawner: Spawner) {
     let mut adc = Adc::new(p.ADC1, &mut Delay);
     let mut pin = p.PB1;
 
-    let mut vref = adc.enable_vref(&mut Delay);
-    let vref_sample = adc.read(&mut vref);
+    let mut vrefint = adc.enable_vref(&mut Delay);
+    let vrefint_sample = adc.read(&mut vrefint);
     let convert_to_millivolts = |sample| {
         // From http://www.st.com/resource/en/datasheet/CD00161566.pdf
         // 5.3.4 Embedded reference voltage
-        const VREF_MV: u32 = 1200;
+        const VREFINT_MV: u32 = 1200; // mV
 
-        (u32::from(sample) * VREF_MV / u32::from(vref_sample)) as u16
+        (u32::from(sample) * VREFINT_MV / u32::from(vrefint_sample)) as u16
     };
 
     loop {

--- a/examples/stm32f1/src/bin/adc.rs
+++ b/examples/stm32f1/src/bin/adc.rs
@@ -17,10 +17,18 @@ async fn main(_spawner: Spawner) {
     let mut pin = p.PB1;
 
     let mut vref = adc.enable_vref(&mut Delay);
-    adc.calibrate(&mut vref);
+    let vref_sample = adc.read(&mut vref);
+    let convert_to_millivolts = |sample| {
+        // From http://www.st.com/resource/en/datasheet/CD00161566.pdf
+        // 5.3.4 Embedded reference voltage
+        const VREF_MV: u32 = 1200;
+
+        (u32::from(sample) * VREF_MV / u32::from(vref_sample)) as u16
+    };
+
     loop {
         let v = adc.read(&mut pin);
-        info!("--> {} - {} mV", v, adc.to_millivolts(v));
+        info!("--> {} - {} mV", v, convert_to_millivolts(v));
         Timer::after(Duration::from_millis(100)).await;
     }
 }

--- a/examples/stm32f7/src/bin/adc.rs
+++ b/examples/stm32f7/src/bin/adc.rs
@@ -16,9 +16,19 @@ async fn main(_spawner: Spawner) {
     let mut adc = Adc::new(p.ADC1, &mut Delay);
     let mut pin = p.PA3;
 
+    let mut vref = adc.enable_vrefint();
+    let vref_sample = adc.read_internal(&mut vref);
+    let convert_to_millivolts = |sample| {
+        // From http://www.st.com/resource/en/datasheet/DM00273119.pdf
+        // 6.3.27 Reference voltage
+        const VREF_MV: u32 = 1210;
+
+        (u32::from(sample) * VREF_MV / u32::from(vref_sample)) as u16
+    };
+
     loop {
         let v = adc.read(&mut pin);
-        info!("--> {} - {} mV", v, adc.to_millivolts(v));
+        info!("--> {} - {} mV", v, convert_to_millivolts(v));
         Timer::after(Duration::from_millis(100)).await;
     }
 }

--- a/examples/stm32f7/src/bin/adc.rs
+++ b/examples/stm32f7/src/bin/adc.rs
@@ -16,14 +16,14 @@ async fn main(_spawner: Spawner) {
     let mut adc = Adc::new(p.ADC1, &mut Delay);
     let mut pin = p.PA3;
 
-    let mut vref = adc.enable_vrefint();
-    let vref_sample = adc.read_internal(&mut vref);
+    let mut vrefint = adc.enable_vrefint();
+    let vrefint_sample = adc.read_internal(&mut vrefint);
     let convert_to_millivolts = |sample| {
         // From http://www.st.com/resource/en/datasheet/DM00273119.pdf
         // 6.3.27 Reference voltage
-        const VREF_MV: u32 = 1210;
+        const VREFINT_MV: u32 = 1210; // mV
 
-        (u32::from(sample) * VREF_MV / u32::from(vref_sample)) as u16
+        (u32::from(sample) * VREFINT_MV / u32::from(vrefint_sample)) as u16
     };
 
     loop {


### PR DESCRIPTION
The current conversion utilities are confusing and a bit of a footgun. (Two out of the three examples got it wrong! They didn't measure vref at all, so all the conversions are completely wrong if vcca isn't 3.3v)

I think we should eventually have some sort of conversion utilities in the HAL, but for now I think it is best to just remove it and let the users do their own math.

cc @chemicstry 