### PR TITLE
stm32/adc: New single channel API

### DIFF
--- a/embassy-stm32/src/adc/f1.rs
+++ b/embassy-stm32/src/adc/f1.rs
@@ -85,7 +85,6 @@ mod sample_time {
 pub use sample_time::SampleTime;
 
 pub struct Adc<'d, T: Instance> {
-    sample_time: SampleTime,
     phantom: PhantomData<&'d mut T>,
 }
 
@@ -119,10 +118,7 @@ impl<'d, T: Instance> Adc<'d, T> {
         // One cycle after calibration
         delay.delay_us((1_000_000) / Self::freq().0 + 1);
 
-        Self {
-            sample_time: Default::default(),
-            phantom: PhantomData,
-        }
+        Self { phantom: PhantomData }
     }
 
     fn freq() -> Hertz {
@@ -160,10 +156,6 @@ impl<'d, T: Instance> Adc<'d, T> {
         Temperature {}
     }
 
-    pub fn set_sample_time(&mut self, sample_time: SampleTime) {
-        self.sample_time = sample_time;
-    }
-
     /// Perform a single conversion.
     fn convert(&mut self) -> u16 {
         unsafe {
@@ -178,9 +170,9 @@ impl<'d, T: Instance> Adc<'d, T> {
         }
     }
 
-    pub fn read(&mut self, pin: &mut impl AdcPin<T>) -> u16 {
+    pub fn read(&mut self, pin: &mut impl AdcPin<T>, sample_time: SampleTime) -> u16 {
         unsafe {
-            Self::set_channel_sample_time(pin.channel(), self.sample_time);
+            Self::set_channel_sample_time(pin.channel(), sample_time);
             T::regs().cr1().modify(|reg| {
                 reg.set_scan(false);
                 reg.set_discen(false);

--- a/embassy-stm32/src/adc/mod.rs
+++ b/embassy-stm32/src/adc/mod.rs
@@ -12,6 +12,14 @@ mod _version;
 pub use _version::*;
 
 use crate::peripherals;
+#[cfg(not(adc_v1))]
+use crate::PeripheralRef;
+
+#[cfg(not(adc_v1))]
+pub struct Adc<'d, T: Instance> {
+    #[allow(unused)] // TODO: this will be used eventually
+    adc: PeripheralRef<'d, T>,
+}
 
 pub(crate) mod sealed {
     pub trait Instance {

--- a/embassy-stm32/src/adc/v2.rs
+++ b/embassy-stm32/src/adc/v2.rs
@@ -80,15 +80,6 @@ impl super::sealed::InternalChannel<ADC1> for Temperature {
 }
 
 impl Temperature {
-    /// Converts temperature sensor reading in millivolts to degrees celcius
-    pub fn to_celcius(sample_mv: u16) -> f32 {
-        // From 6.3.22 Temperature sensor characteristics
-        const V25: i32 = 760; // mV
-        const AVG_SLOPE: f32 = 2.5; // mV/C
-
-        (sample_mv as i32 - V25) as f32 / AVG_SLOPE + 25.0
-    }
-
     /// Time needed for temperature sensor readings to stabilize
     pub fn start_time_us() -> u32 {
         10
@@ -172,7 +163,6 @@ impl Prescaler {
 
 pub struct Adc<'d, T: Instance> {
     sample_time: SampleTime,
-    vref_mv: u32,
     resolution: Resolution,
     phantom: PhantomData<&'d mut T>,
 }
@@ -200,7 +190,6 @@ where
         Self {
             sample_time: Default::default(),
             resolution: Resolution::default(),
-            vref_mv: VREF_DEFAULT_MV,
             phantom: PhantomData,
         }
     }
@@ -211,18 +200,6 @@ where
 
     pub fn set_resolution(&mut self, resolution: Resolution) {
         self.resolution = resolution;
-    }
-
-    /// Set VREF value in millivolts. This value is used for [to_millivolts()] sample conversion.
-    ///
-    /// Use this if you have a known precise VREF (VDDA) pin reference voltage.
-    pub fn set_vref_mv(&mut self, vref_mv: u32) {
-        self.vref_mv = vref_mv;
-    }
-
-    /// Convert a measurement to millivolts
-    pub fn to_millivolts(&self, sample: u16) -> u16 {
-        ((u32::from(sample) * self.vref_mv) / self.resolution.to_max_count()) as u16
     }
 
     /// Enables internal voltage reference and returns [VrefInt], which can be used in

--- a/embassy-stm32/src/adc/v2.rs
+++ b/embassy-stm32/src/adc/v2.rs
@@ -2,7 +2,7 @@ use embassy_hal_common::into_ref;
 use embedded_hal_02::blocking::delay::DelayUs;
 
 use super::InternalChannel;
-use crate::adc::{Adc, AdcPin, Instance};
+use crate::adc::{Adc, AdcPin, Instance, SingleChannel};
 use crate::peripherals::ADC1;
 use crate::time::Hertz;
 use crate::Peripheral;
@@ -221,7 +221,12 @@ where
         Vbat {}
     }
 
-    pub fn read<P>(&mut self, pin: &mut P, sample_time: SampleTime, resolution: Resolution) -> u16
+    pub fn single_channel<'a, P>(
+        &'a mut self,
+        pin: &'a mut P,
+        sample_time: SampleTime,
+        resolution: Resolution,
+    ) -> SingleChannel<'a, T>
     where
         P: AdcPin<T>,
         P: crate::gpio::sealed::Pin,
@@ -229,8 +234,25 @@ where
         unsafe {
             pin.set_as_analog();
 
-            self.read_channel(pin.channel(), sample_time, resolution)
+            self._single_channel(pin.channel(), sample_time, resolution)
         }
+    }
+
+    pub fn read<P>(&mut self, pin: &mut P, sample_time: SampleTime, resolution: Resolution) -> u16
+    where
+        P: AdcPin<T>,
+        P: crate::gpio::sealed::Pin,
+    {
+        self.single_channel(pin, sample_time, resolution).read()
+    }
+
+    pub fn single_channel_internal<'a>(
+        &'a mut self,
+        channel: &'a mut impl InternalChannel<T>,
+        sample_time: SampleTime,
+        resolution: Resolution,
+    ) -> SingleChannel<'a, T> {
+        unsafe { self._single_channel(channel.channel(), sample_time, resolution) }
     }
 
     pub fn read_internal(
@@ -239,10 +261,15 @@ where
         sample_time: SampleTime,
         resolution: Resolution,
     ) -> u16 {
-        unsafe { self.read_channel(channel.channel(), sample_time, resolution) }
+        self.single_channel_internal(channel, sample_time, resolution).read()
     }
 
-    unsafe fn read_channel(&mut self, channel: u8, sample_time: SampleTime, resolution: Resolution) -> u16 {
+    unsafe fn _single_channel(
+        &mut self,
+        channel: u8,
+        sample_time: SampleTime,
+        resolution: Resolution,
+    ) -> SingleChannel<'_, T> {
         // Configure ADC
         T::regs().cr1().modify(|reg| reg.set_res(resolution.res()));
 
@@ -252,7 +279,9 @@ where
         // Configure channel
         Self::set_channel_sample_time(channel, sample_time);
 
-        convert(*T::regs())
+        SingleChannel {
+            adc: self.adc.reborrow(),
+        }
     }
 
     unsafe fn set_channel_sample_time(ch: u8, sample_time: SampleTime) {

--- a/embassy-stm32/src/adc/v4.rs
+++ b/embassy-stm32/src/adc/v4.rs
@@ -314,7 +314,6 @@ impl Prescaler {
 
 pub struct Adc<'d, T: Instance> {
     sample_time: SampleTime,
-    vref_mv: u32,
     resolution: Resolution,
     phantom: PhantomData<&'d mut T>,
 }
@@ -352,7 +351,6 @@ impl<'d, T: Instance + crate::rcc::RccPeripheral> Adc<'d, T> {
 
         let mut s = Self {
             sample_time: Default::default(),
-            vref_mv: VREF_DEFAULT_MV,
             resolution: Resolution::default(),
             phantom: PhantomData,
         };
@@ -457,18 +455,6 @@ impl<'d, T: Instance + crate::rcc::RccPeripheral> Adc<'d, T> {
 
     pub fn set_resolution(&mut self, resolution: Resolution) {
         self.resolution = resolution;
-    }
-
-    /// Set VREF value in millivolts. This value is used for [to_millivolts()] sample conversion.
-    ///
-    /// Use this if you have a known precise VREF (VDDA) pin reference voltage.
-    pub fn set_vref_mv(&mut self, vref_mv: u32) {
-        self.vref_mv = vref_mv;
-    }
-
-    /// Convert a measurement to millivolts
-    pub fn to_millivolts(&self, sample: u16) -> u16 {
-        ((u32::from(sample) * self.vref_mv) / self.resolution.to_max_count()) as u16
     }
 
     /// Perform a single conversion.

--- a/examples/stm32f1/src/bin/adc.rs
+++ b/examples/stm32f1/src/bin/adc.rs
@@ -16,14 +16,14 @@ async fn main(_spawner: Spawner) {
     let mut adc = Adc::new(p.ADC1, &mut Delay);
     let mut pin = p.PB1;
 
-    let mut vref = adc.enable_vref(&mut Delay);
-    let vref_sample = adc.read(&mut vref);
+    let mut vrefint = adc.enable_vref(&mut Delay);
+    let vrefint_sample = adc.read(&mut vrefint);
     let convert_to_millivolts = |sample| {
         // From http://www.st.com/resource/en/datasheet/CD00161566.pdf
         // 5.3.4 Embedded reference voltage
-        const VREF_MV: u32 = 1200;
+        const VREFINT_MV: u32 = 1200; // mV
 
-        (u32::from(sample) * VREF_MV / u32::from(vref_sample)) as u16
+        (u32::from(sample) * VREFINT_MV / u32::from(vrefint_sample)) as u16
     };
 
     loop {

--- a/examples/stm32f1/src/bin/adc.rs
+++ b/examples/stm32f1/src/bin/adc.rs
@@ -17,10 +17,18 @@ async fn main(_spawner: Spawner) {
     let mut pin = p.PB1;
 
     let mut vref = adc.enable_vref(&mut Delay);
-    adc.calibrate(&mut vref);
+    let vref_sample = adc.read(&mut vref);
+    let convert_to_millivolts = |sample| {
+        // From http://www.st.com/resource/en/datasheet/CD00161566.pdf
+        // 5.3.4 Embedded reference voltage
+        const VREF_MV: u32 = 1200;
+
+        (u32::from(sample) * VREF_MV / u32::from(vref_sample)) as u16
+    };
+
     loop {
         let v = adc.read(&mut pin);
-        info!("--> {} - {} mV", v, adc.to_millivolts(v));
+        info!("--> {} - {} mV", v, convert_to_millivolts(v));
         Timer::after(Duration::from_millis(100)).await;
     }
 }

--- a/examples/stm32f1/src/bin/adc.rs
+++ b/examples/stm32f1/src/bin/adc.rs
@@ -4,7 +4,7 @@
 
 use defmt::*;
 use embassy_executor::Spawner;
-use embassy_stm32::adc::Adc;
+use embassy_stm32::adc::{Adc, SampleTime};
 use embassy_time::{Delay, Duration, Timer};
 use {defmt_rtt as _, panic_probe as _};
 
@@ -17,7 +17,7 @@ async fn main(_spawner: Spawner) {
     let mut pin = p.PB1;
 
     let mut vrefint = adc.enable_vref(&mut Delay);
-    let vrefint_sample = adc.read(&mut vrefint);
+    let vrefint_sample = adc.read(&mut vrefint, SampleTime::Cycles239_5);
     let convert_to_millivolts = |sample| {
         // From http://www.st.com/resource/en/datasheet/CD00161566.pdf
         // 5.3.4 Embedded reference voltage
@@ -27,7 +27,7 @@ async fn main(_spawner: Spawner) {
     };
 
     loop {
-        let v = adc.read(&mut pin);
+        let v = adc.read(&mut pin, SampleTime::default());
         info!("--> {} - {} mV", v, convert_to_millivolts(v));
         Timer::after(Duration::from_millis(100)).await;
     }

--- a/examples/stm32f1/src/bin/adc.rs
+++ b/examples/stm32f1/src/bin/adc.rs
@@ -26,8 +26,10 @@ async fn main(_spawner: Spawner) {
         (u32::from(sample) * VREFINT_MV / u32::from(vrefint_sample)) as u16
     };
 
+    let mut input = adc.single_channel(&mut pin, SampleTime::default());
+
     loop {
-        let v = adc.read(&mut pin, SampleTime::default());
+        let v = input.read();
         info!("--> {} - {} mV", v, convert_to_millivolts(v));
         Timer::after(Duration::from_millis(100)).await;
     }

--- a/examples/stm32f4/src/bin/adc.rs
+++ b/examples/stm32f4/src/bin/adc.rs
@@ -5,7 +5,7 @@
 use cortex_m::prelude::_embedded_hal_blocking_delay_DelayUs;
 use defmt::*;
 use embassy_executor::Spawner;
-use embassy_stm32::adc::{Adc, Temperature, VrefInt};
+use embassy_stm32::adc::{Adc, Resolution, SampleTime, Temperature, VrefInt};
 use embassy_time::{Delay, Duration, Timer};
 use {defmt_rtt as _, panic_probe as _};
 
@@ -24,7 +24,7 @@ async fn main(_spawner: Spawner) {
     // Startup delay can be combined to the maximum of either
     delay.delay_us(Temperature::start_time_us().max(VrefInt::start_time_us()));
 
-    let vrefint_sample = adc.read_internal(&mut vrefint);
+    let vrefint_sample = adc.read_internal(&mut vrefint, SampleTime::Cycles480, Resolution::TwelveBit);
 
     let convert_to_millivolts = |sample| {
         // From http://www.st.com/resource/en/datasheet/DM00071990.pdf
@@ -51,16 +51,16 @@ async fn main(_spawner: Spawner) {
 
     loop {
         // Read pin
-        let v = adc.read(&mut pin);
+        let v = adc.read(&mut pin, SampleTime::default(), Resolution::TwelveBit);
         info!("PC1: {} ({} mV)", v, convert_to_millivolts(v));
 
         // Read internal temperature
-        let v = adc.read_internal(&mut temp);
+        let v = adc.read_internal(&mut temp, SampleTime::default(), Resolution::TwelveBit);
         let celcius = convert_to_celcius(v);
         info!("Internal temp: {} ({} C)", v, celcius);
 
         // Read internal voltage reference
-        let v = adc.read_internal(&mut vrefint);
+        let v = adc.read_internal(&mut vrefint, SampleTime::default(), Resolution::TwelveBit);
         info!("VrefInt: {}", v);
 
         Timer::after(Duration::from_millis(100)).await;

--- a/examples/stm32f7/src/bin/adc.rs
+++ b/examples/stm32f7/src/bin/adc.rs
@@ -16,9 +16,19 @@ async fn main(_spawner: Spawner) {
     let mut adc = Adc::new(p.ADC1, &mut Delay);
     let mut pin = p.PA3;
 
+    let mut vref = adc.enable_vrefint();
+    let vref_sample = adc.read_internal(&mut vref);
+    let convert_to_millivolts = |sample| {
+        // From http://www.st.com/resource/en/datasheet/DM00273119.pdf
+        // 6.3.27 Reference voltage
+        const VREF_MV: u32 = 1210;
+
+        (u32::from(sample) * VREF_MV / u32::from(vref_sample)) as u16
+    };
+
     loop {
         let v = adc.read(&mut pin);
-        info!("--> {} - {} mV", v, adc.to_millivolts(v));
+        info!("--> {} - {} mV", v, convert_to_millivolts(v));
         Timer::after(Duration::from_millis(100)).await;
     }
 }

--- a/examples/stm32f7/src/bin/adc.rs
+++ b/examples/stm32f7/src/bin/adc.rs
@@ -16,14 +16,14 @@ async fn main(_spawner: Spawner) {
     let mut adc = Adc::new(p.ADC1, &mut Delay);
     let mut pin = p.PA3;
 
-    let mut vref = adc.enable_vrefint();
-    let vref_sample = adc.read_internal(&mut vref);
+    let mut vrefint = adc.enable_vrefint();
+    let vrefint_sample = adc.read_internal(&mut vrefint);
     let convert_to_millivolts = |sample| {
         // From http://www.st.com/resource/en/datasheet/DM00273119.pdf
         // 6.3.27 Reference voltage
-        const VREF_MV: u32 = 1210;
+        const VREFINT_MV: u32 = 1210; // mV
 
-        (u32::from(sample) * VREF_MV / u32::from(vref_sample)) as u16
+        (u32::from(sample) * VREFINT_MV / u32::from(vrefint_sample)) as u16
     };
 
     loop {

--- a/examples/stm32f7/src/bin/adc.rs
+++ b/examples/stm32f7/src/bin/adc.rs
@@ -4,7 +4,7 @@
 
 use defmt::*;
 use embassy_executor::Spawner;
-use embassy_stm32::adc::Adc;
+use embassy_stm32::adc::{Adc, Resolution, SampleTime};
 use embassy_time::{Delay, Duration, Timer};
 use {defmt_rtt as _, panic_probe as _};
 
@@ -17,7 +17,7 @@ async fn main(_spawner: Spawner) {
     let mut pin = p.PA3;
 
     let mut vrefint = adc.enable_vrefint();
-    let vrefint_sample = adc.read_internal(&mut vrefint);
+    let vrefint_sample = adc.read_internal(&mut vrefint, SampleTime::Cycles480, Resolution::TwelveBit);
     let convert_to_millivolts = |sample| {
         // From http://www.st.com/resource/en/datasheet/DM00273119.pdf
         // 6.3.27 Reference voltage
@@ -27,7 +27,7 @@ async fn main(_spawner: Spawner) {
     };
 
     loop {
-        let v = adc.read(&mut pin);
+        let v = adc.read(&mut pin, SampleTime::default(), Resolution::TwelveBit);
         info!("--> {} - {} mV", v, convert_to_millivolts(v));
         Timer::after(Duration::from_millis(100)).await;
     }

--- a/examples/stm32f7/src/bin/adc.rs
+++ b/examples/stm32f7/src/bin/adc.rs
@@ -26,8 +26,10 @@ async fn main(_spawner: Spawner) {
         (u32::from(sample) * VREFINT_MV / u32::from(vrefint_sample)) as u16
     };
 
+    let mut input = adc.single_channel(&mut pin, SampleTime::default(), Resolution::TwelveBit);
+
     loop {
-        let v = adc.read(&mut pin, SampleTime::default(), Resolution::TwelveBit);
+        let v = input.read();
         info!("--> {} - {} mV", v, convert_to_millivolts(v));
         Timer::after(Duration::from_millis(100)).await;
     }

--- a/examples/stm32h7/src/bin/adc.rs
+++ b/examples/stm32h7/src/bin/adc.rs
@@ -4,7 +4,7 @@
 
 use defmt::*;
 use embassy_executor::Spawner;
-use embassy_stm32::adc::{Adc, SampleTime};
+use embassy_stm32::adc::{Adc, Resolution, SampleTime};
 use embassy_stm32::rcc::AdcClockSource;
 use embassy_stm32::time::mhz;
 use embassy_stm32::Config;
@@ -24,14 +24,12 @@ async fn main(_spawner: Spawner) {
 
     let mut adc = Adc::new(p.ADC3, &mut Delay);
 
-    adc.set_sample_time(SampleTime::Cycles32_5);
-
     let mut vrefint_channel = adc.enable_vrefint();
 
     loop {
-        let vrefint = adc.read_internal(&mut vrefint_channel);
+        let vrefint = adc.read_internal(&mut vrefint_channel, SampleTime::Cycles32_5, Resolution::TwelveBit);
         info!("vrefint: {}", vrefint);
-        let measured = adc.read(&mut p.PC0);
+        let measured = adc.read(&mut p.PC0, SampleTime::Cycles32_5, Resolution::TwelveBit);
         info!("measured: {}", measured);
         Timer::after(Duration::from_millis(500)).await;
     }

--- a/examples/stm32l4/src/bin/adc.rs
+++ b/examples/stm32l4/src/bin/adc.rs
@@ -3,7 +3,7 @@
 #![feature(type_alias_impl_trait)]
 
 use defmt::*;
-use embassy_stm32::adc::{Adc, Resolution};
+use embassy_stm32::adc::{Adc, Resolution, SampleTime};
 use embassy_stm32::pac;
 use embassy_time::Delay;
 use {defmt_rtt as _, panic_probe as _};
@@ -22,12 +22,11 @@ fn main() -> ! {
     let p = embassy_stm32::init(Default::default());
 
     let mut adc = Adc::new(p.ADC1, &mut Delay);
-    //adc.enable_vref();
-    adc.set_resolution(Resolution::EightBit);
+
     let mut channel = p.PC0;
 
     loop {
-        let v = adc.read(&mut channel);
+        let v = adc.read(&mut channel, SampleTime::default(), Resolution::EightBit);
         info!("--> {}", v);
     }
 }

--- a/examples/stm32l4/src/bin/adc.rs
+++ b/examples/stm32l4/src/bin/adc.rs
@@ -22,11 +22,12 @@ fn main() -> ! {
     let p = embassy_stm32::init(Default::default());
 
     let mut adc = Adc::new(p.ADC1, &mut Delay);
+    let mut pin = p.PC0;
 
-    let mut channel = p.PC0;
+    let mut input = adc.single_channel(&mut pin, SampleTime::default(), Resolution::EightBit);
 
     loop {
-        let v = adc.read(&mut channel, SampleTime::default(), Resolution::EightBit);
+        let v = input.read();
         info!("--> {}", v);
     }
 }


### PR DESCRIPTION
Based on #1024, cc @chemicstry 

```rust
let mut input = adc.single_channel(&mut pin, SampleTime::default(), Resolution::TwelveBit);
loop {
        let v = input.read();
        info!("Adc value: {}", v);
}
```

The preferred sample time and resolution are no longer stored inside the `Adc` struct with setter methods, those parameters are now supplied by the user directly whenever the driver needs to configure them.

The `Adc::single_channel` method configures the adc for the specified pin, sample time, and resolution, and returns a `SingleChannel` struct. This struct can be used to quickly and efficiently read from the adc multiple times without re-configuring each time.

I kept the `Adc::read` method because it is slightly more ergonomic in some cases:
```rust
adc.read(pin, sample_time, resolution);
// is a slightly shorter way to write this:
adc.single_channel(pin, sample_time, resolution).read();
```

### Future possibilities

```rust
let mut input = adc.single_channel(&mut pin, SampleTime::default(), Resolution::TwelveBit);

input.dma_read(dma_channel, &mut buffer).await;
```