### PR TITLE
stm32: Add support for read_until_idle on UART - rebase

### DIFF
--- a/examples/stm32f3/src/bin/usart_dma.rs
+++ b/examples/stm32f3/src/bin/usart_dma.rs
@@ -7,6 +7,7 @@ use core::fmt::Write;
 use defmt::*;
 use embassy_executor::Spawner;
 use embassy_stm32::dma::NoDma;
+use embassy_stm32::interrupt;
 use embassy_stm32::usart::{Config, Uart};
 use heapless::String;
 use {defmt_rtt as _, panic_probe as _};
@@ -17,7 +18,8 @@ async fn main(_spawner: Spawner) {
     info!("Hello World!");
 
     let config = Config::default();
-    let mut usart = Uart::new(p.USART1, p.PE1, p.PE0, p.DMA1_CH4, NoDma, config);
+    let irq = interrupt::take!(USART1);
+    let mut usart = Uart::new(p.USART1, p.PE1, p.PE0, irq, p.DMA1_CH4, NoDma, config);
 
     for n in 0u32.. {
         let mut s: String<128> = String::new();

--- a/examples/stm32f4/src/bin/usart.rs
+++ b/examples/stm32f4/src/bin/usart.rs
@@ -5,6 +5,7 @@
 use cortex_m_rt::entry;
 use defmt::*;
 use embassy_stm32::dma::NoDma;
+use embassy_stm32::interrupt;
 use embassy_stm32::usart::{Config, Uart};
 use {defmt_rtt as _, panic_probe as _};
 
@@ -15,7 +16,8 @@ fn main() -> ! {
     let p = embassy_stm32::init(Default::default());
 
     let config = Config::default();
-    let mut usart = Uart::new(p.USART3, p.PD9, p.PD8, NoDma, NoDma, config);
+    let irq = interrupt::take!(USART3);
+    let mut usart = Uart::new(p.USART3, p.PD9, p.PD8, irq, NoDma, NoDma, config);
 
     unwrap!(usart.blocking_write(b"Hello Embassy World!\r\n"));
     info!("wrote Hello, starting echo");

--- a/examples/stm32f4/src/bin/usart_buffered.rs
+++ b/examples/stm32f4/src/bin/usart_buffered.rs
@@ -4,9 +4,8 @@
 
 use defmt::*;
 use embassy_executor::Spawner;
-use embassy_stm32::dma::NoDma;
 use embassy_stm32::interrupt;
-use embassy_stm32::usart::{BufferedUart, Config, State, Uart};
+use embassy_stm32::usart::{BufferedUart, Config, State};
 use embedded_io::asynch::BufRead;
 use {defmt_rtt as _, panic_probe as _};
 
@@ -16,13 +15,21 @@ async fn main(_spawner: Spawner) {
     info!("Hello World!");
 
     let config = Config::default();
-    let usart = Uart::new(p.USART3, p.PD9, p.PD8, NoDma, NoDma, config);
 
     let mut state = State::new();
     let irq = interrupt::take!(USART3);
     let mut tx_buf = [0u8; 32];
     let mut rx_buf = [0u8; 32];
-    let mut buf_usart = BufferedUart::new(&mut state, usart, irq, &mut tx_buf, &mut rx_buf);
+    let mut buf_usart = BufferedUart::new(
+        &mut state,
+        p.USART3,
+        p.PD9,
+        p.PD8,
+        irq,
+        &mut tx_buf,
+        &mut rx_buf,
+        config,
+    );
 
     loop {
         let buf = buf_usart.fill_buf().await.unwrap();

--- a/examples/stm32f4/src/bin/usart_dma.rs
+++ b/examples/stm32f4/src/bin/usart_dma.rs
@@ -7,6 +7,7 @@ use core::fmt::Write;
 use defmt::*;
 use embassy_executor::Spawner;
 use embassy_stm32::dma::NoDma;
+use embassy_stm32::interrupt;
 use embassy_stm32::usart::{Config, Uart};
 use heapless::String;
 use {defmt_rtt as _, panic_probe as _};
@@ -17,7 +18,8 @@ async fn main(_spawner: Spawner) {
     info!("Hello World!");
 
     let config = Config::default();
-    let mut usart = Uart::new(p.USART3, p.PD9, p.PD8, p.DMA1_CH3, NoDma, config);
+    let irq = interrupt::take!(USART3);
+    let mut usart = Uart::new(p.USART3, p.PD9, p.PD8, irq, p.DMA1_CH3, NoDma, config);
 
     for n in 0u32.. {
         let mut s: String<128> = String::new();

--- a/examples/stm32f7/src/bin/usart_dma.rs
+++ b/examples/stm32f7/src/bin/usart_dma.rs
@@ -7,6 +7,7 @@ use core::fmt::Write;
 use defmt::*;
 use embassy_executor::Spawner;
 use embassy_stm32::dma::NoDma;
+use embassy_stm32::interrupt;
 use embassy_stm32::usart::{Config, Uart};
 use heapless::String;
 use {defmt_rtt as _, panic_probe as _};
@@ -15,7 +16,8 @@ use {defmt_rtt as _, panic_probe as _};
 async fn main(_spawner: Spawner) {
     let p = embassy_stm32::init(Default::default());
     let config = Config::default();
-    let mut usart = Uart::new(p.UART7, p.PA8, p.PA15, p.DMA1_CH1, NoDma, config);
+    let irq = interrupt::take!(UART7);
+    let mut usart = Uart::new(p.UART7, p.PA8, p.PA15, irq, p.DMA1_CH1, NoDma, config);
 
     for n in 0u32.. {
         let mut s: String<128> = String::new();

--- a/examples/stm32h7/src/bin/usart.rs
+++ b/examples/stm32h7/src/bin/usart.rs
@@ -6,6 +6,7 @@ use cortex_m_rt::entry;
 use defmt::*;
 use embassy_executor::Executor;
 use embassy_stm32::dma::NoDma;
+use embassy_stm32::interrupt;
 use embassy_stm32::usart::{Config, Uart};
 use static_cell::StaticCell;
 use {defmt_rtt as _, panic_probe as _};
@@ -15,7 +16,8 @@ async fn main_task() {
     let p = embassy_stm32::init(Default::default());
 
     let config = Config::default();
-    let mut usart = Uart::new(p.UART7, p.PF6, p.PF7, NoDma, NoDma, config);
+    let irq = interrupt::take!(UART7);
+    let mut usart = Uart::new(p.UART7, p.PF6, p.PF7, irq, NoDma, NoDma, config);
 
     unwrap!(usart.blocking_write(b"Hello Embassy World!\r\n"));
     info!("wrote Hello, starting echo");

--- a/examples/stm32h7/src/bin/usart_dma.rs
+++ b/examples/stm32h7/src/bin/usart_dma.rs
@@ -8,6 +8,7 @@ use cortex_m_rt::entry;
 use defmt::*;
 use embassy_executor::Executor;
 use embassy_stm32::dma::NoDma;
+use embassy_stm32::interrupt;
 use embassy_stm32::usart::{Config, Uart};
 use heapless::String;
 use static_cell::StaticCell;
@@ -18,7 +19,8 @@ async fn main_task() {
     let p = embassy_stm32::init(Default::default());
 
     let config = Config::default();
-    let mut usart = Uart::new(p.UART7, p.PF6, p.PF7, p.DMA1_CH0, NoDma, config);
+    let irq = interrupt::take!(UART7);
+    let mut usart = Uart::new(p.UART7, p.PF6, p.PF7, irq, p.DMA1_CH0, NoDma, config);
 
     for n in 0u32.. {
         let mut s: String<128> = String::new();

--- a/examples/stm32h7/src/bin/usart_split.rs
+++ b/examples/stm32h7/src/bin/usart_split.rs
@@ -5,6 +5,7 @@
 use defmt::*;
 use embassy_executor::Spawner;
 use embassy_stm32::dma::NoDma;
+use embassy_stm32::interrupt;
 use embassy_stm32::peripherals::{DMA1_CH1, UART7};
 use embassy_stm32::usart::{Config, Uart, UartRx};
 use embassy_sync::blocking_mutex::raw::ThreadModeRawMutex;
@@ -31,7 +32,8 @@ async fn main(spawner: Spawner) -> ! {
     info!("Hello World!");
 
     let config = Config::default();
-    let mut usart = Uart::new(p.UART7, p.PF6, p.PF7, p.DMA1_CH0, p.DMA1_CH1, config);
+    let irq = interrupt::take!(UART7);
+    let mut usart = Uart::new(p.UART7, p.PF6, p.PF7, irq, p.DMA1_CH0, p.DMA1_CH1, config);
     unwrap!(usart.blocking_write(b"Type 8 chars to echo!\r\n"));
 
     let (mut tx, rx) = usart.split();

--- a/examples/stm32l0/src/bin/usart_dma.rs
+++ b/examples/stm32l0/src/bin/usart_dma.rs
@@ -4,13 +4,15 @@
 
 use defmt::*;
 use embassy_executor::Spawner;
+use embassy_stm32::interrupt;
 use embassy_stm32::usart::{Config, Uart};
 use {defmt_rtt as _, panic_probe as _};
 
 #[embassy_executor::main]
 async fn main(_spawner: Spawner) {
     let p = embassy_stm32::init(Default::default());
-    let mut usart = Uart::new(p.USART1, p.PB7, p.PB6, p.DMA1_CH2, p.DMA1_CH3, Config::default());
+    let irq = interrupt::take!(USART1);
+    let mut usart = Uart::new(p.USART1, p.PB7, p.PB6, irq, p.DMA1_CH2, p.DMA1_CH3, Config::default());
 
     usart.write(b"Hello Embassy World!\r\n").await.unwrap();
     info!("wrote Hello, starting echo");

--- a/examples/stm32l0/src/bin/usart_irq.rs
+++ b/examples/stm32l0/src/bin/usart_irq.rs
@@ -4,9 +4,8 @@
 
 use defmt::*;
 use embassy_executor::Spawner;
-use embassy_stm32::dma::NoDma;
 use embassy_stm32::interrupt;
-use embassy_stm32::usart::{BufferedUart, Config, State, Uart};
+use embassy_stm32::usart::{BufferedUart, Config, State};
 use embedded_io::asynch::{Read, Write};
 use {defmt_rtt as _, panic_probe as _};
 
@@ -21,15 +20,18 @@ async fn main(_spawner: Spawner) {
     let mut config = Config::default();
     config.baudrate = 9600;
 
-    let usart = Uart::new(p.USART2, p.PA3, p.PA2, NoDma, NoDma, config);
     let mut state = State::new();
+    let irq = interrupt::take!(USART2);
     let mut usart = unsafe {
         BufferedUart::new(
             &mut state,
-            usart,
-            interrupt::take!(USART2),
+            p.USART2,
+            p.PA3,
+            p.PA2,
+            irq,
             &mut TX_BUFFER,
             &mut RX_BUFFER,
+            config,
         )
     };
 

--- a/examples/stm32l4/src/bin/usart.rs
+++ b/examples/stm32l4/src/bin/usart.rs
@@ -4,6 +4,7 @@
 
 use defmt::*;
 use embassy_stm32::dma::NoDma;
+use embassy_stm32::interrupt;
 use embassy_stm32::usart::{Config, Uart};
 use {defmt_rtt as _, panic_probe as _};
 
@@ -14,7 +15,8 @@ fn main() -> ! {
     let p = embassy_stm32::init(Default::default());
 
     let config = Config::default();
-    let mut usart = Uart::new(p.UART4, p.PA1, p.PA0, NoDma, NoDma, config);
+    let irq = interrupt::take!(UART4);
+    let mut usart = Uart::new(p.UART4, p.PA1, p.PA0, irq, NoDma, NoDma, config);
 
     unwrap!(usart.blocking_write(b"Hello Embassy World!\r\n"));
     info!("wrote Hello, starting echo");

--- a/examples/stm32l4/src/bin/usart_dma.rs
+++ b/examples/stm32l4/src/bin/usart_dma.rs
@@ -7,6 +7,7 @@ use core::fmt::Write;
 use defmt::*;
 use embassy_executor::Spawner;
 use embassy_stm32::dma::NoDma;
+use embassy_stm32::interrupt;
 use embassy_stm32::usart::{Config, Uart};
 use heapless::String;
 use {defmt_rtt as _, panic_probe as _};
@@ -17,7 +18,8 @@ async fn main(_spawner: Spawner) {
     info!("Hello World!");
 
     let config = Config::default();
-    let mut usart = Uart::new(p.UART4, p.PA1, p.PA0, p.DMA1_CH3, NoDma, config);
+    let irq = interrupt::take!(UART4);
+    let mut usart = Uart::new(p.UART4, p.PA1, p.PA0, irq, p.DMA1_CH3, NoDma, config);
 
     for n in 0u32.. {
         let mut s: String<128> = String::new();

--- a/tests/stm32/src/bin/usart.rs
+++ b/tests/stm32/src/bin/usart.rs
@@ -7,6 +7,7 @@ mod example_common;
 use defmt::assert_eq;
 use embassy_executor::Spawner;
 use embassy_stm32::dma::NoDma;
+use embassy_stm32::interrupt;
 use embassy_stm32::usart::{Config, Uart};
 use example_common::*;
 
@@ -18,22 +19,22 @@ async fn main(_spawner: Spawner) {
     // Arduino pins D0 and D1
     // They're connected together with a 1K resistor.
     #[cfg(feature = "stm32f103c8")]
-    let (tx, rx, usart) = (p.PA9, p.PA10, p.USART1);
+    let (tx, rx, usart, irq) = (p.PA9, p.PA10, p.USART1, interrupt::take!(USART1));
     #[cfg(feature = "stm32g491re")]
-    let (tx, rx, usart) = (p.PC4, p.PC5, p.USART1);
+    let (tx, rx, usart, irq) = (p.PC4, p.PC5, p.USART1, interrupt::take!(USART1));
     #[cfg(feature = "stm32g071rb")]
-    let (tx, rx, usart) = (p.PC4, p.PC5, p.USART1);
+    let (tx, rx, usart, irq) = (p.PC4, p.PC5, p.USART1, interrupt::take!(USART1));
     #[cfg(feature = "stm32f429zi")]
-    let (tx, rx, usart) = (p.PG14, p.PG9, p.USART6);
+    let (tx, rx, usart, irq) = (p.PG14, p.PG9, p.USART6, interrupt::take!(USART6));
     #[cfg(feature = "stm32wb55rg")]
-    let (tx, rx, usart) = (p.PA2, p.PA3, p.LPUART1);
+    let (tx, rx, usart, irq) = (p.PA2, p.PA3, p.LPUART1, interrupt::take!(LPUART1));
     #[cfg(feature = "stm32h755zi")]
-    let (tx, rx, usart) = (p.PB6, p.PB7, p.USART1);
+    let (tx, rx, usart, irq) = (p.PB6, p.PB7, p.USART1, interrupt::take!(USART1));
     #[cfg(feature = "stm32u585ai")]
-    let (tx, rx, usart) = (p.PD8, p.PD9, p.USART3);
+    let (tx, rx, usart, irq) = (p.PD8, p.PD9, p.USART3, interrupt::take!(USART3));
 
     let config = Config::default();
-    let mut usart = Uart::new(usart, rx, tx, NoDma, NoDma, config);
+    let mut usart = Uart::new(usart, rx, tx, irq, NoDma, NoDma, config);
 
     // We can't send too many bytes, they have to fit in the FIFO.
     // This is because we aren't sending+receiving at the same time.

--- a/tests/stm32/src/bin/usart_dma.rs
+++ b/tests/stm32/src/bin/usart_dma.rs
@@ -6,6 +6,7 @@
 mod example_common;
 use defmt::assert_eq;
 use embassy_executor::Spawner;
+use embassy_stm32::interrupt;
 use embassy_stm32::usart::{Config, Uart};
 use example_common::*;
 
@@ -17,22 +18,53 @@ async fn main(_spawner: Spawner) {
     // Arduino pins D0 and D1
     // They're connected together with a 1K resistor.
     #[cfg(feature = "stm32f103c8")]
-    let (tx, rx, usart, tx_dma, rx_dma) = (p.PA9, p.PA10, p.USART1, p.DMA1_CH4, p.DMA1_CH5);
+    let (tx, rx, usart, irq, tx_dma, rx_dma) = (
+        p.PA9,
+        p.PA10,
+        p.USART1,
+        interrupt::take!(USART1),
+        p.DMA1_CH4,
+        p.DMA1_CH5,
+    );
     #[cfg(feature = "stm32g491re")]
-    let (tx, rx, usart, tx_dma, rx_dma) = (p.PC4, p.PC5, p.USART1, p.DMA1_CH1, p.DMA1_CH2);
+    let (tx, rx, usart, irq, tx_dma, rx_dma) =
+        (p.PC4, p.PC5, p.USART1, interrupt::take!(USART1), p.DMA1_CH1, p.DMA1_CH2);
     #[cfg(feature = "stm32g071rb")]
-    let (tx, rx, usart, tx_dma, rx_dma) = (p.PC4, p.PC5, p.USART1, p.DMA1_CH1, p.DMA1_CH2);
+    let (tx, rx, usart, irq, tx_dma, rx_dma) =
+        (p.PC4, p.PC5, p.USART1, interrupt::take!(USART1), p.DMA1_CH1, p.DMA1_CH2);
     #[cfg(feature = "stm32f429zi")]
-    let (tx, rx, usart, tx_dma, rx_dma) = (p.PG14, p.PG9, p.USART6, p.DMA2_CH6, p.DMA2_CH1);
+    let (tx, rx, usart, irq, tx_dma, rx_dma) = (
+        p.PG14,
+        p.PG9,
+        p.USART6,
+        interrupt::take!(USART6),
+        p.DMA2_CH6,
+        p.DMA2_CH1,
+    );
     #[cfg(feature = "stm32wb55rg")]
-    let (tx, rx, usart, tx_dma, rx_dma) = (p.PA2, p.PA3, p.LPUART1, p.DMA1_CH1, p.DMA1_CH2);
+    let (tx, rx, usart, irq, tx_dma, rx_dma) = (
+        p.PA2,
+        p.PA3,
+        p.LPUART1,
+        interrupt::take!(LPUART1),
+        p.DMA1_CH1,
+        p.DMA1_CH2,
+    );
     #[cfg(feature = "stm32h755zi")]
-    let (tx, rx, usart, tx_dma, rx_dma) = (p.PB6, p.PB7, p.USART1, p.DMA1_CH0, p.DMA1_CH1);
+    let (tx, rx, usart, irq, tx_dma, rx_dma) =
+        (p.PB6, p.PB7, p.USART1, interrupt::take!(USART1), p.DMA1_CH0, p.DMA1_CH1);
     #[cfg(feature = "stm32u585ai")]
-    let (tx, rx, usart, tx_dma, rx_dma) = (p.PD8, p.PD9, p.USART3, p.GPDMA1_CH0, p.GPDMA1_CH1);
+    let (tx, rx, usart, irq, tx_dma, rx_dma) = (
+        p.PD8,
+        p.PD9,
+        p.USART3,
+        interrupt::take!(USART3),
+        p.GPDMA1_CH0,
+        p.GPDMA1_CH1,
+    );
 
     let config = Config::default();
-    let mut usart = Uart::new(usart, rx, tx, tx_dma, rx_dma, config);
+    let mut usart = Uart::new(usart, rx, tx, irq, tx_dma, rx_dma, config);
 
     // We can't send too many bytes, they have to fit in the FIFO.
     // This is because we aren't sending+receiving at the same time.


### PR DESCRIPTION
@guillaume-michel I rebased #1011 for you and then noticed you don't have the "allowed maintainers to push" option so I had to open a new PR. 

bors r+