### PR TITLE
stm32/adc: Misc refactoring

### DIFF
--- a/embassy-stm32/src/adc/f1.rs
+++ b/embassy-stm32/src/adc/f1.rs
@@ -146,14 +146,11 @@ impl<'d, T: Instance> Adc<'d, T> {
     }
 
     unsafe fn set_channel_sample_time(ch: u8, sample_time: SampleTime) {
+        let sample_time = sample_time.into();
         if ch <= 9 {
-            T::regs()
-                .smpr2()
-                .modify(|reg| reg.set_smp(ch as _, sample_time.sample_time()));
+            T::regs().smpr2().modify(|reg| reg.set_smp(ch as _, sample_time));
         } else {
-            T::regs()
-                .smpr1()
-                .modify(|reg| reg.set_smp((ch - 10) as _, sample_time.sample_time()));
+            T::regs().smpr1().modify(|reg| reg.set_smp((ch - 10) as _, sample_time));
         }
     }
 }

--- a/embassy-stm32/src/adc/f1.rs
+++ b/embassy-stm32/src/adc/f1.rs
@@ -1,5 +1,3 @@
-use core::marker::PhantomData;
-
 use embassy_hal_common::into_ref;
 use embedded_hal_02::blocking::delay::DelayUs;
 
@@ -30,8 +28,8 @@ impl<T: Instance> super::sealed::AdcPin<T> for Temperature {
 }
 
 impl<'d, T: Instance> Adc<'d, T> {
-    pub fn new(_peri: impl Peripheral<P = T> + 'd, delay: &mut impl DelayUs<u32>) -> Self {
-        into_ref!(_peri);
+    pub fn new(adc: impl Peripheral<P = T> + 'd, delay: &mut impl DelayUs<u32>) -> Self {
+        into_ref!(adc);
         T::enable();
         T::reset();
         unsafe {
@@ -60,8 +58,8 @@ impl<'d, T: Instance> Adc<'d, T> {
         delay.delay_us((1_000_000) / Self::freq().0 + 1);
 
         Self {
+            adc,
             sample_time: Default::default(),
-            phantom: PhantomData,
         }
     }
 

--- a/embassy-stm32/src/adc/f1.rs
+++ b/embassy-stm32/src/adc/f1.rs
@@ -3,7 +3,7 @@ use core::marker::PhantomData;
 use embassy_hal_common::into_ref;
 use embedded_hal_02::blocking::delay::DelayUs;
 
-use crate::adc::{AdcPin, Instance, SampleTime};
+use crate::adc::{Adc, AdcPin, Instance, SampleTime};
 use crate::rcc::get_freqs;
 use crate::time::Hertz;
 use crate::Peripheral;
@@ -27,11 +27,6 @@ impl<T: Instance> super::sealed::AdcPin<T> for Temperature {
     fn channel(&self) -> u8 {
         16
     }
-}
-
-pub struct Adc<'d, T: Instance> {
-    sample_time: SampleTime,
-    phantom: PhantomData<&'d mut T>,
 }
 
 impl<'d, T: Instance> Adc<'d, T> {

--- a/embassy-stm32/src/adc/f1.rs
+++ b/embassy-stm32/src/adc/f1.rs
@@ -3,7 +3,7 @@ use core::marker::PhantomData;
 use embassy_hal_common::into_ref;
 use embedded_hal_02::blocking::delay::DelayUs;
 
-use crate::adc::{AdcPin, Instance};
+use crate::adc::{AdcPin, Instance, SampleTime};
 use crate::rcc::get_freqs;
 use crate::time::Hertz;
 use crate::Peripheral;
@@ -28,61 +28,6 @@ impl<T: Instance> super::sealed::AdcPin<T> for Temperature {
         16
     }
 }
-
-mod sample_time {
-    /// ADC sample time
-    ///
-    /// The default setting is 1.5 ADC clock cycles.
-    #[derive(Clone, Copy, Debug, Eq, PartialEq, Ord, PartialOrd)]
-    pub enum SampleTime {
-        /// 1.5 ADC clock cycles
-        Cycles1_5 = 0b000,
-
-        /// 7.5 ADC clock cycles
-        Cycles7_5 = 0b001,
-
-        /// 13.5 ADC clock cycles
-        Cycles13_5 = 0b010,
-
-        /// 28.5 ADC clock cycles
-        Cycles28_5 = 0b011,
-
-        /// 41.5 ADC clock cycles
-        Cycles41_5 = 0b100,
-
-        /// 55.5 ADC clock cycles
-        Cycles55_5 = 0b101,
-
-        /// 71.5 ADC clock cycles
-        Cycles71_5 = 0b110,
-
-        /// 239.5 ADC clock cycles
-        Cycles239_5 = 0b111,
-    }
-
-    impl SampleTime {
-        pub(crate) fn sample_time(&self) -> crate::pac::adc::vals::SampleTime {
-            match self {
-                SampleTime::Cycles1_5 => crate::pac::adc::vals::SampleTime::CYCLES1_5,
-                SampleTime::Cycles7_5 => crate::pac::adc::vals::SampleTime::CYCLES7_5,
-                SampleTime::Cycles13_5 => crate::pac::adc::vals::SampleTime::CYCLES13_5,
-                SampleTime::Cycles28_5 => crate::pac::adc::vals::SampleTime::CYCLES28_5,
-                SampleTime::Cycles41_5 => crate::pac::adc::vals::SampleTime::CYCLES41_5,
-                SampleTime::Cycles55_5 => crate::pac::adc::vals::SampleTime::CYCLES55_5,
-                SampleTime::Cycles71_5 => crate::pac::adc::vals::SampleTime::CYCLES71_5,
-                SampleTime::Cycles239_5 => crate::pac::adc::vals::SampleTime::CYCLES239_5,
-            }
-        }
-    }
-
-    impl Default for SampleTime {
-        fn default() -> Self {
-            Self::Cycles28_5
-        }
-    }
-}
-
-pub use sample_time::SampleTime;
 
 pub struct Adc<'d, T: Instance> {
     sample_time: SampleTime,

--- a/embassy-stm32/src/adc/mod.rs
+++ b/embassy-stm32/src/adc/mod.rs
@@ -11,8 +11,13 @@ mod _version;
 #[cfg(not(adc_v1))]
 mod sample_time;
 
+#[cfg(not(any(adc_f1, adc_v1)))]
+mod resolution;
+
 #[allow(unused)]
 pub use _version::*;
+#[cfg(not(any(adc_f1, adc_v1)))]
+pub use resolution::Resolution;
 #[cfg(not(adc_v1))]
 pub use sample_time::SampleTime;
 

--- a/embassy-stm32/src/adc/mod.rs
+++ b/embassy-stm32/src/adc/mod.rs
@@ -8,11 +8,10 @@
 #[cfg_attr(adc_v1, path = "v1.rs")]
 mod _version;
 
-#[cfg(not(adc_v1))]
-mod sample_time;
-
 #[cfg(not(any(adc_f1, adc_v1)))]
 mod resolution;
+#[cfg(not(adc_v1))]
+mod sample_time;
 
 #[allow(unused)]
 pub use _version::*;

--- a/embassy-stm32/src/adc/mod.rs
+++ b/embassy-stm32/src/adc/mod.rs
@@ -1,11 +1,10 @@
 #![macro_use]
 
-#[cfg_attr(adc_v4, path = "v4.rs")]
-#[cfg_attr(adc_v3, path = "v3.rs")]
-#[cfg_attr(adc_v2, path = "v2.rs")]
-#[cfg_attr(adc_g0, path = "v3.rs")]
 #[cfg_attr(adc_f1, path = "f1.rs")]
 #[cfg_attr(adc_v1, path = "v1.rs")]
+#[cfg_attr(adc_v2, path = "v2.rs")]
+#[cfg_attr(any(adc_v3, adc_g0), path = "v3.rs")]
+#[cfg_attr(adc_v4, path = "v4.rs")]
 mod _version;
 
 #[cfg(not(any(adc_f1, adc_v1)))]

--- a/embassy-stm32/src/adc/mod.rs
+++ b/embassy-stm32/src/adc/mod.rs
@@ -8,8 +8,13 @@
 #[cfg_attr(adc_v1, path = "v1.rs")]
 mod _version;
 
+#[cfg(not(adc_v1))]
+mod sample_time;
+
 #[allow(unused)]
 pub use _version::*;
+#[cfg(not(adc_v1))]
+pub use sample_time::SampleTime;
 
 use crate::peripherals;
 

--- a/embassy-stm32/src/adc/mod.rs
+++ b/embassy-stm32/src/adc/mod.rs
@@ -44,9 +44,9 @@ pub(crate) mod sealed {
     }
 }
 
-#[cfg(not(any(adc_f1, adc_v2)))]
+#[cfg(not(any(adc_f1, adc_v2, adc_v4)))]
 pub trait Instance: sealed::Instance + 'static {}
-#[cfg(any(adc_f1, adc_v2))]
+#[cfg(any(adc_f1, adc_v2, adc_v4))]
 pub trait Instance: sealed::Instance + crate::rcc::RccPeripheral + 'static {}
 
 pub trait AdcPin<T: Instance>: sealed::AdcPin<T> {}

--- a/embassy-stm32/src/adc/mod.rs
+++ b/embassy-stm32/src/adc/mod.rs
@@ -22,6 +22,12 @@ pub use sample_time::SampleTime;
 
 use crate::peripherals;
 
+#[cfg(not(adc_v1))]
+pub struct Adc<'d, T: Instance> {
+    sample_time: SampleTime,
+    phantom: core::marker::PhantomData<&'d mut T>,
+}
+
 pub(crate) mod sealed {
     pub trait Instance {
         fn regs() -> crate::pac::adc::Adc;

--- a/embassy-stm32/src/adc/mod.rs
+++ b/embassy-stm32/src/adc/mod.rs
@@ -24,9 +24,9 @@ use crate::peripherals;
 
 pub(crate) mod sealed {
     pub trait Instance {
-        fn regs() -> &'static crate::pac::adc::Adc;
+        fn regs() -> crate::pac::adc::Adc;
         #[cfg(all(not(adc_f1), not(adc_v1)))]
-        fn common_regs() -> &'static crate::pac::adccommon::AdcCommon;
+        fn common_regs() -> crate::pac::adccommon::AdcCommon;
     }
 
     pub trait AdcPin<T: Instance> {
@@ -50,14 +50,14 @@ pub trait InternalChannel<T>: sealed::InternalChannel<T> {}
 foreach_peripheral!(
     (adc, $inst:ident) => {
         impl crate::adc::sealed::Instance for peripherals::$inst {
-            fn regs() -> &'static crate::pac::adc::Adc {
-                &crate::pac::$inst
+            fn regs() -> crate::pac::adc::Adc {
+                crate::pac::$inst
             }
             #[cfg(all(not(adc_f1), not(adc_v1)))]
-            fn common_regs() -> &'static crate::pac::adccommon::AdcCommon {
+            fn common_regs() -> crate::pac::adccommon::AdcCommon {
                 foreach_peripheral!{
                     (adccommon, $common_inst:ident) => {
-                        return &crate::pac::$common_inst
+                        return crate::pac::$common_inst
                     };
                 }
             }
@@ -71,14 +71,14 @@ foreach_peripheral!(
 foreach_peripheral!(
     (adc, ADC3) => {
         impl crate::adc::sealed::Instance for peripherals::ADC3 {
-            fn regs() -> &'static crate::pac::adc::Adc {
-                &crate::pac::ADC3
+            fn regs() -> crate::pac::adc::Adc {
+                crate::pac::ADC3
             }
             #[cfg(all(not(adc_f1), not(adc_v1)))]
-            fn common_regs() -> &'static crate::pac::adccommon::AdcCommon {
+            fn common_regs() -> crate::pac::adccommon::AdcCommon {
                 foreach_peripheral!{
                     (adccommon, ADC3_COMMON) => {
-                        return &crate::pac::ADC3_COMMON
+                        return crate::pac::ADC3_COMMON
                     };
                 }
             }
@@ -88,14 +88,14 @@ foreach_peripheral!(
     };
     (adc, $inst:ident) => {
         impl crate::adc::sealed::Instance for peripherals::$inst {
-            fn regs() -> &'static crate::pac::adc::Adc {
-                &crate::pac::$inst
+            fn regs() -> crate::pac::adc::Adc {
+                crate::pac::$inst
             }
             #[cfg(all(not(adc_f1), not(adc_v1)))]
-            fn common_regs() -> &'static crate::pac::adccommon::AdcCommon {
+            fn common_regs() -> crate::pac::adccommon::AdcCommon {
                 foreach_peripheral!{
                     (adccommon, ADC_COMMON) => {
-                        return &crate::pac::ADC_COMMON
+                        return crate::pac::ADC_COMMON
                     };
                 }
             }

--- a/embassy-stm32/src/adc/mod.rs
+++ b/embassy-stm32/src/adc/mod.rs
@@ -29,11 +29,6 @@ pub(crate) mod sealed {
         fn common_regs() -> &'static crate::pac::adccommon::AdcCommon;
     }
 
-    #[cfg(all(not(adc_f1), not(adc_v1)))]
-    pub trait Common {
-        fn regs() -> &'static crate::pac::adccommon::AdcCommon;
-    }
-
     pub trait AdcPin<T: Instance> {
         fn channel(&self) -> u8;
     }
@@ -47,8 +42,7 @@ pub(crate) mod sealed {
 pub trait Instance: sealed::Instance + 'static {}
 #[cfg(any(adc_f1, adc_v2))]
 pub trait Instance: sealed::Instance + crate::rcc::RccPeripheral + 'static {}
-#[cfg(all(not(adc_f1), not(adc_v1)))]
-pub trait Common: sealed::Common + 'static {}
+
 pub trait AdcPin<T: Instance>: sealed::AdcPin<T> {}
 pub trait InternalChannel<T>: sealed::InternalChannel<T> {}
 
@@ -108,19 +102,6 @@ foreach_peripheral!(
         }
 
         impl crate::adc::Instance for peripherals::$inst {}
-    };
-);
-
-#[cfg(all(not(adc_f1), not(adc_v1)))]
-foreach_peripheral!(
-    (adccommon, $inst:ident) => {
-        impl sealed::Common for peripherals::$inst {
-            fn regs() -> &'static crate::pac::adccommon::AdcCommon {
-                &crate::pac::$inst
-            }
-        }
-
-        impl crate::adc::Common for peripherals::$inst {}
     };
 );
 

--- a/embassy-stm32/src/adc/mod.rs
+++ b/embassy-stm32/src/adc/mod.rs
@@ -23,8 +23,9 @@ use crate::peripherals;
 
 #[cfg(not(adc_v1))]
 pub struct Adc<'d, T: Instance> {
+    #[allow(unused)]
+    adc: crate::PeripheralRef<'d, T>,
     sample_time: SampleTime,
-    phantom: core::marker::PhantomData<&'d mut T>,
 }
 
 pub(crate) mod sealed {
@@ -44,9 +45,9 @@ pub(crate) mod sealed {
 }
 
 #[cfg(not(any(adc_f1, adc_v2, adc_v4)))]
-pub trait Instance: sealed::Instance + 'static {}
+pub trait Instance: sealed::Instance + crate::Peripheral<P = Self> {}
 #[cfg(any(adc_f1, adc_v2, adc_v4))]
-pub trait Instance: sealed::Instance + crate::rcc::RccPeripheral + 'static {}
+pub trait Instance: sealed::Instance + crate::Peripheral<P = Self> + crate::rcc::RccPeripheral {}
 
 pub trait AdcPin<T: Instance>: sealed::AdcPin<T> {}
 pub trait InternalChannel<T>: sealed::InternalChannel<T> {}

--- a/embassy-stm32/src/adc/resolution.rs
+++ b/embassy-stm32/src/adc/resolution.rs
@@ -1,0 +1,59 @@
+#[cfg(any(adc_v2, adc_v3, adc_g0))]
+pub enum Resolution {
+    TwelveBit,
+    TenBit,
+    EightBit,
+    SixBit,
+}
+
+#[cfg(adc_v4)]
+pub enum Resolution {
+    SixteenBit,
+    FourteenBit,
+    TwelveBit,
+    TenBit,
+    EightBit,
+}
+
+impl Default for Resolution {
+    fn default() -> Self {
+        #[cfg(any(adc_v2, adc_v3, adc_g0))]
+        {
+            Self::TwelveBit
+        }
+        #[cfg(adc_v4)]
+        {
+            Self::SixteenBit
+        }
+    }
+}
+
+impl Resolution {
+    pub(super) fn res(&self) -> crate::pac::adc::vals::Res {
+        match self {
+            #[cfg(adc_v4)]
+            Resolution::SixteenBit => crate::pac::adc::vals::Res::SIXTEENBIT,
+            #[cfg(adc_v4)]
+            Resolution::FourteenBit => crate::pac::adc::vals::Res::FOURTEENBITV,
+            Resolution::TwelveBit => crate::pac::adc::vals::Res::TWELVEBIT,
+            Resolution::TenBit => crate::pac::adc::vals::Res::TENBIT,
+            Resolution::EightBit => crate::pac::adc::vals::Res::EIGHTBIT,
+            #[cfg(any(adc_v2, adc_v3, adc_g0))]
+            Resolution::SixBit => crate::pac::adc::vals::Res::SIXBIT,
+        }
+    }
+
+    pub fn to_max_count(&self) -> u32 {
+        match self {
+            #[cfg(adc_v4)]
+            Resolution::SixteenBit => (1 << 16) - 1,
+            #[cfg(adc_v4)]
+            Resolution::FourteenBit => (1 << 14) - 1,
+            Resolution::TwelveBit => (1 << 12) - 1,
+            Resolution::TenBit => (1 << 10) - 1,
+            Resolution::EightBit => (1 << 8) - 1,
+            #[cfg(any(adc_v2, adc_v3, adc_g0))]
+            Resolution::SixBit => (1 << 6) - 1,
+        }
+    }
+}

--- a/embassy-stm32/src/adc/resolution.rs
+++ b/embassy-stm32/src/adc/resolution.rs
@@ -1,4 +1,5 @@
 #[cfg(any(adc_v2, adc_v3, adc_g0))]
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub enum Resolution {
     TwelveBit,
     TenBit,
@@ -7,6 +8,7 @@ pub enum Resolution {
 }
 
 #[cfg(adc_v4)]
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub enum Resolution {
     SixteenBit,
     FourteenBit,
@@ -28,9 +30,9 @@ impl Default for Resolution {
     }
 }
 
-impl Resolution {
-    pub(super) fn res(&self) -> crate::pac::adc::vals::Res {
-        match self {
+impl From<Resolution> for crate::pac::adc::vals::Res {
+    fn from(res: Resolution) -> crate::pac::adc::vals::Res {
+        match res {
             #[cfg(adc_v4)]
             Resolution::SixteenBit => crate::pac::adc::vals::Res::SIXTEENBIT,
             #[cfg(adc_v4)]
@@ -42,7 +44,9 @@ impl Resolution {
             Resolution::SixBit => crate::pac::adc::vals::Res::SIXBIT,
         }
     }
+}
 
+impl Resolution {
     pub fn to_max_count(&self) -> u32 {
         match self {
             #[cfg(adc_v4)]

--- a/embassy-stm32/src/adc/sample_time.rs
+++ b/embassy-stm32/src/adc/sample_time.rs
@@ -25,11 +25,10 @@ macro_rules! impl_sample_time {
     };
 }
 
-// TODO: Fix default
 #[cfg(adc_f1)]
 impl_sample_time!(
     "1.5",
-    Cycles28_5,
+    Cycles1_5,
     crate::pac::adc::vals::SampleTime,
     (
         ("1.5", Cycles1_5, CYCLES1_5),
@@ -43,7 +42,6 @@ impl_sample_time!(
     )
 );
 
-// TODO: Fix 85 vs 84
 #[cfg(adc_v2)]
 impl_sample_time!(
     "3",
@@ -54,7 +52,7 @@ impl_sample_time!(
         ("15", Cycles15, CYCLES15),
         ("28", Cycles28, CYCLES28),
         ("56", Cycles56, CYCLES56),
-        ("85", Cycles85, CYCLES84),
+        ("84", Cycles84, CYCLES84),
         ("112", Cycles112, CYCLES112),
         ("144", Cycles144, CYCLES144),
         ("480", Cycles480, CYCLES480)
@@ -95,10 +93,9 @@ impl_sample_time!(
     )
 );
 
-// TODO: Fix default doc
 #[cfg(adc_v4)]
 impl_sample_time!(
-    "2.5",
+    "1.5",
     Cycles1_5,
     crate::pac::adc::vals::Smp,
     (

--- a/embassy-stm32/src/adc/sample_time.rs
+++ b/embassy-stm32/src/adc/sample_time.rs
@@ -9,10 +9,10 @@ macro_rules! impl_sample_time {
             )*
         }
 
-        impl SampleTime {
-            pub(crate) fn sample_time(&self) -> $pac {
-                match self {
-                    $(Self::$variant => <$pac>::$pac_variant),*
+        impl From<SampleTime> for $pac {
+            fn from(sample_time: SampleTime) -> $pac {
+                match sample_time {
+                    $(SampleTime::$variant => <$pac>::$pac_variant),*
                 }
             }
         }

--- a/embassy-stm32/src/adc/sample_time.rs
+++ b/embassy-stm32/src/adc/sample_time.rs
@@ -1,0 +1,114 @@
+macro_rules! impl_sample_time {
+    ($default_doc:expr, $default:ident, $pac:ty, ($(($doc:expr, $variant:ident, $pac_variant:ident)),*)) => {
+        #[doc = concat!("ADC sample time\n\nThe default setting is ", $default_doc, " ADC clock cycles.")]
+        #[derive(Clone, Copy, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        pub enum SampleTime {
+            $(
+                #[doc = concat!($doc, " ADC clock cycles.")]
+                $variant,
+            )*
+        }
+
+        impl SampleTime {
+            pub(crate) fn sample_time(&self) -> $pac {
+                match self {
+                    $(Self::$variant => <$pac>::$pac_variant),*
+                }
+            }
+        }
+
+        impl Default for SampleTime {
+            fn default() -> Self {
+                Self::$default
+            }
+        }
+    };
+}
+
+// TODO: Fix default
+#[cfg(adc_f1)]
+impl_sample_time!(
+    "1.5",
+    Cycles28_5,
+    crate::pac::adc::vals::SampleTime,
+    (
+        ("1.5", Cycles1_5, CYCLES1_5),
+        ("7.5", Cycles7_5, CYCLES7_5),
+        ("13.5", Cycles13_5, CYCLES13_5),
+        ("28.5", Cycles28_5, CYCLES28_5),
+        ("41.5", Cycles41_5, CYCLES41_5),
+        ("55.5", Cycles55_5, CYCLES55_5),
+        ("71.5", Cycles71_5, CYCLES71_5),
+        ("239.5", Cycles239_5, CYCLES239_5)
+    )
+);
+
+// TODO: Fix 85 vs 84
+#[cfg(adc_v2)]
+impl_sample_time!(
+    "3",
+    Cycles3,
+    crate::pac::adc::vals::Smp,
+    (
+        ("3", Cycles3, CYCLES3),
+        ("15", Cycles15, CYCLES15),
+        ("28", Cycles28, CYCLES28),
+        ("56", Cycles56, CYCLES56),
+        ("85", Cycles85, CYCLES84),
+        ("112", Cycles112, CYCLES112),
+        ("144", Cycles144, CYCLES144),
+        ("480", Cycles480, CYCLES480)
+    )
+);
+
+#[cfg(adc_v3)]
+impl_sample_time!(
+    "2.5",
+    Cycles2_5,
+    crate::pac::adc::vals::SampleTime,
+    (
+        ("2.5", Cycles2_5, CYCLES2_5),
+        ("6.5", Cycles6_5, CYCLES6_5),
+        ("12.5", Cycles12_5, CYCLES12_5),
+        ("24.5", Cycles24_5, CYCLES24_5),
+        ("47.5", Cycles47_5, CYCLES47_5),
+        ("92.5", Cycles92_5, CYCLES92_5),
+        ("247.5", Cycles247_5, CYCLES247_5),
+        ("640.5", Cycles640_5, CYCLES640_5)
+    )
+);
+
+#[cfg(adc_g0)]
+impl_sample_time!(
+    "1.5",
+    Cycles1_5,
+    crate::pac::adc::vals::SampleTime,
+    (
+        ("1.5", Cycles1_5, CYCLES1_5),
+        ("3.5", Cycles3_5, CYCLES3_5),
+        ("7.5", Cycles7_5, CYCLES7_5),
+        ("12.5", Cycles12_5, CYCLES12_5),
+        ("19.5", Cycles19_5, CYCLES19_5),
+        ("39.5", Cycles39_5, CYCLES39_5),
+        ("79.5", Cycles79_5, CYCLES79_5),
+        ("160.5", Cycles160_5, CYCLES160_5)
+    )
+);
+
+// TODO: Fix default doc
+#[cfg(adc_v4)]
+impl_sample_time!(
+    "2.5",
+    Cycles1_5,
+    crate::pac::adc::vals::Smp,
+    (
+        ("1.5", Cycles1_5, CYCLES1_5),
+        ("2.5", Cycles2_5, CYCLES2_5),
+        ("8.5", Cycles8_5, CYCLES8_5),
+        ("16.5", Cycles16_5, CYCLES16_5),
+        ("32.5", Cycles32_5, CYCLES32_5),
+        ("64.5", Cycles64_5, CYCLES64_5),
+        ("387.5", Cycles387_5, CYCLES387_5),
+        ("810.5", Cycles810_5, CYCLES810_5)
+    )
+);

--- a/embassy-stm32/src/adc/v2.rs
+++ b/embassy-stm32/src/adc/v2.rs
@@ -1,5 +1,3 @@
-use core::marker::PhantomData;
-
 use embassy_hal_common::into_ref;
 use embedded_hal_02::blocking::delay::DelayUs;
 
@@ -96,8 +94,8 @@ impl<'d, T> Adc<'d, T>
 where
     T: Instance,
 {
-    pub fn new(_peri: impl Peripheral<P = T> + 'd, delay: &mut impl DelayUs<u32>) -> Self {
-        into_ref!(_peri);
+    pub fn new(adc: impl Peripheral<P = T> + 'd, delay: &mut impl DelayUs<u32>) -> Self {
+        into_ref!(adc);
         T::enable();
         T::reset();
 
@@ -113,8 +111,8 @@ where
         delay.delay_us(ADC_POWERUP_TIME_US);
 
         Self {
+            adc,
             sample_time: Default::default(),
-            phantom: PhantomData,
         }
     }
 

--- a/embassy-stm32/src/adc/v2.rs
+++ b/embassy-stm32/src/adc/v2.rs
@@ -4,7 +4,7 @@ use embassy_hal_common::into_ref;
 use embedded_hal_02::blocking::delay::DelayUs;
 
 use super::InternalChannel;
-use crate::adc::{AdcPin, Instance, Resolution, SampleTime};
+use crate::adc::{Adc, AdcPin, Instance, Resolution, SampleTime};
 use crate::peripherals::ADC1;
 use crate::time::Hertz;
 use crate::Peripheral;
@@ -90,11 +90,6 @@ impl Prescaler {
             Prescaler::Div8 => crate::pac::adccommon::vals::Adcpre::DIV8,
         }
     }
-}
-
-pub struct Adc<'d, T: Instance> {
-    sample_time: SampleTime,
-    phantom: PhantomData<&'d mut T>,
 }
 
 impl<'d, T> Adc<'d, T>

--- a/embassy-stm32/src/adc/v2.rs
+++ b/embassy-stm32/src/adc/v2.rs
@@ -94,7 +94,6 @@ impl Prescaler {
 
 pub struct Adc<'d, T: Instance> {
     sample_time: SampleTime,
-    resolution: Resolution,
     phantom: PhantomData<&'d mut T>,
 }
 
@@ -120,7 +119,6 @@ where
 
         Self {
             sample_time: Default::default(),
-            resolution: Resolution::default(),
             phantom: PhantomData,
         }
     }
@@ -130,7 +128,9 @@ where
     }
 
     pub fn set_resolution(&mut self, resolution: Resolution) {
-        self.resolution = resolution;
+        unsafe {
+            T::regs().cr1().modify(|reg| reg.set_res(resolution.into()));
+        }
     }
 
     /// Enables internal voltage reference and returns [VrefInt], which can be used in
@@ -214,7 +214,6 @@ where
 
     unsafe fn read_channel(&mut self, channel: u8) -> u16 {
         // Configure ADC
-        T::regs().cr1().modify(|reg| reg.set_res(self.resolution.into()));
 
         // Select channel
         T::regs().sqr3().write(|reg| reg.set_sq(0, channel));

--- a/embassy-stm32/src/adc/v2.rs
+++ b/embassy-stm32/src/adc/v2.rs
@@ -4,7 +4,7 @@ use embassy_hal_common::into_ref;
 use embedded_hal_02::blocking::delay::DelayUs;
 
 use super::InternalChannel;
-use crate::adc::{AdcPin, Instance, SampleTime};
+use crate::adc::{AdcPin, Instance, Resolution, SampleTime};
 use crate::peripherals::ADC1;
 use crate::time::Hertz;
 use crate::Peripheral;
@@ -16,39 +16,6 @@ pub const VREF_CALIB_MV: u32 = 3300;
 
 /// ADC turn-on time
 pub const ADC_POWERUP_TIME_US: u32 = 3;
-
-pub enum Resolution {
-    TwelveBit,
-    TenBit,
-    EightBit,
-    SixBit,
-}
-
-impl Default for Resolution {
-    fn default() -> Self {
-        Self::TwelveBit
-    }
-}
-
-impl Resolution {
-    fn res(&self) -> crate::pac::adc::vals::Res {
-        match self {
-            Resolution::TwelveBit => crate::pac::adc::vals::Res::TWELVEBIT,
-            Resolution::TenBit => crate::pac::adc::vals::Res::TENBIT,
-            Resolution::EightBit => crate::pac::adc::vals::Res::EIGHTBIT,
-            Resolution::SixBit => crate::pac::adc::vals::Res::SIXBIT,
-        }
-    }
-
-    pub fn to_max_count(&self) -> u32 {
-        match self {
-            Resolution::TwelveBit => (1 << 12) - 1,
-            Resolution::TenBit => (1 << 10) - 1,
-            Resolution::EightBit => (1 << 8) - 1,
-            Resolution::SixBit => (1 << 6) - 1,
-        }
-    }
-}
 
 pub struct VrefInt;
 impl InternalChannel<ADC1> for VrefInt {}

--- a/embassy-stm32/src/adc/v2.rs
+++ b/embassy-stm32/src/adc/v2.rs
@@ -4,7 +4,7 @@ use embassy_hal_common::into_ref;
 use embedded_hal_02::blocking::delay::DelayUs;
 
 use super::InternalChannel;
-use crate::adc::{AdcPin, Instance};
+use crate::adc::{AdcPin, Instance, SampleTime};
 use crate::peripherals::ADC1;
 use crate::time::Hertz;
 use crate::Peripheral;
@@ -91,42 +91,6 @@ impl InternalChannel<ADC1> for Vbat {}
 impl super::sealed::InternalChannel<ADC1> for Vbat {
     fn channel(&self) -> u8 {
         18
-    }
-}
-
-/// ADC sample time
-///
-/// The default setting is 3 ADC clock cycles.
-#[derive(Clone, Copy, Debug, Eq, PartialEq, Ord, PartialOrd)]
-pub enum SampleTime {
-    Cycles3 = 0b000,
-    Cycles15 = 0b001,
-    Cycles28 = 0b010,
-    Cycles56 = 0b011,
-    Cycles85 = 0b100,
-    Cycles112 = 0b101,
-    Cycles144 = 0b110,
-    Cycles480 = 0b111,
-}
-
-impl SampleTime {
-    pub(crate) fn sample_time(&self) -> crate::pac::adc::vals::Smp {
-        match self {
-            SampleTime::Cycles3 => crate::pac::adc::vals::Smp::CYCLES3,
-            SampleTime::Cycles15 => crate::pac::adc::vals::Smp::CYCLES15,
-            SampleTime::Cycles28 => crate::pac::adc::vals::Smp::CYCLES28,
-            SampleTime::Cycles56 => crate::pac::adc::vals::Smp::CYCLES56,
-            SampleTime::Cycles85 => crate::pac::adc::vals::Smp::CYCLES84,
-            SampleTime::Cycles112 => crate::pac::adc::vals::Smp::CYCLES112,
-            SampleTime::Cycles144 => crate::pac::adc::vals::Smp::CYCLES144,
-            SampleTime::Cycles480 => crate::pac::adc::vals::Smp::CYCLES480,
-        }
-    }
-}
-
-impl Default for SampleTime {
-    fn default() -> Self {
-        Self::Cycles3
     }
 }
 

--- a/embassy-stm32/src/adc/v2.rs
+++ b/embassy-stm32/src/adc/v2.rs
@@ -214,7 +214,7 @@ where
 
     unsafe fn read_channel(&mut self, channel: u8) -> u16 {
         // Configure ADC
-        T::regs().cr1().modify(|reg| reg.set_res(self.resolution.res()));
+        T::regs().cr1().modify(|reg| reg.set_res(self.resolution.into()));
 
         // Select channel
         T::regs().sqr3().write(|reg| reg.set_sq(0, channel));
@@ -228,14 +228,11 @@ where
     }
 
     unsafe fn set_channel_sample_time(ch: u8, sample_time: SampleTime) {
+        let sample_time = sample_time.into();
         if ch <= 9 {
-            T::regs()
-                .smpr2()
-                .modify(|reg| reg.set_smp(ch as _, sample_time.sample_time()));
+            T::regs().smpr2().modify(|reg| reg.set_smp(ch as _, sample_time));
         } else {
-            T::regs()
-                .smpr1()
-                .modify(|reg| reg.set_smp((ch - 10) as _, sample_time.sample_time()));
+            T::regs().smpr1().modify(|reg| reg.set_smp((ch - 10) as _, sample_time));
         }
     }
 }

--- a/embassy-stm32/src/adc/v3.rs
+++ b/embassy-stm32/src/adc/v3.rs
@@ -1,5 +1,3 @@
-use core::marker::PhantomData;
-
 use embassy_hal_common::into_ref;
 use embedded_hal_02::blocking::delay::DelayUs;
 
@@ -61,8 +59,8 @@ impl<T: Instance> super::sealed::AdcPin<T> for Vbat {
 }
 
 impl<'d, T: Instance> Adc<'d, T> {
-    pub fn new(_peri: impl Peripheral<P = T> + 'd, delay: &mut impl DelayUs<u32>) -> Self {
-        into_ref!(_peri);
+    pub fn new(adc: impl Peripheral<P = T> + 'd, delay: &mut impl DelayUs<u32>) -> Self {
+        into_ref!(adc);
         enable();
         unsafe {
             T::regs().cr().modify(|reg| {
@@ -92,8 +90,8 @@ impl<'d, T: Instance> Adc<'d, T> {
         delay.delay_us(1);
 
         Self {
+            adc,
             sample_time: Default::default(),
-            phantom: PhantomData,
         }
     }
 

--- a/embassy-stm32/src/adc/v3.rs
+++ b/embassy-stm32/src/adc/v3.rs
@@ -3,7 +3,7 @@ use core::marker::PhantomData;
 use embassy_hal_common::into_ref;
 use embedded_hal_02::blocking::delay::DelayUs;
 
-use crate::adc::{AdcPin, Instance, SampleTime};
+use crate::adc::{AdcPin, Instance, Resolution, SampleTime};
 use crate::Peripheral;
 
 /// Default VREF voltage used for sample conversion to millivolts.
@@ -22,39 +22,6 @@ fn enable() {
         #[cfg(any(stm32l4, stm32l5, stm32wb))]
         crate::pac::RCC.ahb2enr().modify(|w| w.set_adcen(true));
     });
-}
-
-pub enum Resolution {
-    TwelveBit,
-    TenBit,
-    EightBit,
-    SixBit,
-}
-
-impl Default for Resolution {
-    fn default() -> Self {
-        Self::TwelveBit
-    }
-}
-
-impl Resolution {
-    fn res(&self) -> crate::pac::adc::vals::Res {
-        match self {
-            Resolution::TwelveBit => crate::pac::adc::vals::Res::TWELVEBIT,
-            Resolution::TenBit => crate::pac::adc::vals::Res::TENBIT,
-            Resolution::EightBit => crate::pac::adc::vals::Res::EIGHTBIT,
-            Resolution::SixBit => crate::pac::adc::vals::Res::SIXBIT,
-        }
-    }
-
-    pub fn to_max_count(&self) -> u32 {
-        match self {
-            Resolution::TwelveBit => (1 << 12) - 1,
-            Resolution::TenBit => (1 << 10) - 1,
-            Resolution::EightBit => (1 << 8) - 1,
-            Resolution::SixBit => (1 << 6) - 1,
-        }
-    }
 }
 
 pub struct VrefInt;

--- a/embassy-stm32/src/adc/v3.rs
+++ b/embassy-stm32/src/adc/v3.rs
@@ -199,9 +199,9 @@ impl<'d, T: Instance> Adc<'d, T> {
 
             // Configure ADC
             #[cfg(not(stm32g0))]
-            T::regs().cfgr().modify(|reg| reg.set_res(self.resolution.res()));
+            T::regs().cfgr().modify(|reg| reg.set_res(self.resolution.into()));
             #[cfg(stm32g0)]
-            T::regs().cfgr1().modify(|reg| reg.set_res(self.resolution.res()));
+            T::regs().cfgr1().modify(|reg| reg.set_res(self.resolution.into()));
 
             // Configure channel
             Self::set_channel_sample_time(pin.channel(), self.sample_time);
@@ -231,19 +231,16 @@ impl<'d, T: Instance> Adc<'d, T> {
 
     #[cfg(stm32g0)]
     unsafe fn set_channel_sample_time(_ch: u8, sample_time: SampleTime) {
-        T::regs().smpr().modify(|reg| reg.set_smp1(sample_time.sample_time()));
+        T::regs().smpr().modify(|reg| reg.set_smp1(sample_time.into()));
     }
 
     #[cfg(not(stm32g0))]
     unsafe fn set_channel_sample_time(ch: u8, sample_time: SampleTime) {
+        let sample_time = sample_time.into();
         if ch <= 9 {
-            T::regs()
-                .smpr1()
-                .modify(|reg| reg.set_smp(ch as _, sample_time.sample_time()));
+            T::regs().smpr1().modify(|reg| reg.set_smp(ch as _, sample_time));
         } else {
-            T::regs()
-                .smpr2()
-                .modify(|reg| reg.set_smp((ch - 10) as _, sample_time.sample_time()));
+            T::regs().smpr2().modify(|reg| reg.set_smp((ch - 10) as _, sample_time));
         }
     }
 }

--- a/embassy-stm32/src/adc/v3.rs
+++ b/embassy-stm32/src/adc/v3.rs
@@ -3,7 +3,7 @@ use core::marker::PhantomData;
 use embassy_hal_common::into_ref;
 use embedded_hal_02::blocking::delay::DelayUs;
 
-use crate::adc::{AdcPin, Instance};
+use crate::adc::{AdcPin, Instance, SampleTime};
 use crate::Peripheral;
 
 /// Default VREF voltage used for sample conversion to millivolts.
@@ -92,116 +92,6 @@ impl<T: Instance> super::sealed::AdcPin<T> for Vbat {
         val
     }
 }
-
-#[cfg(not(adc_g0))]
-mod sample_time {
-    /// ADC sample time
-    ///
-    /// The default setting is 2.5 ADC clock cycles.
-    #[derive(Clone, Copy, Debug, Eq, PartialEq, Ord, PartialOrd)]
-    pub enum SampleTime {
-        /// 2.5 ADC clock cycles
-        Cycles2_5 = 0b000,
-
-        /// 6.5 ADC clock cycles
-        Cycles6_5 = 0b001,
-
-        /// 12.5 ADC clock cycles
-        Cycles12_5 = 0b010,
-
-        /// 24.5 ADC clock cycles
-        Cycles24_5 = 0b011,
-
-        /// 47.5 ADC clock cycles
-        Cycles47_5 = 0b100,
-
-        /// 92.5 ADC clock cycles
-        Cycles92_5 = 0b101,
-
-        /// 247.5 ADC clock cycles
-        Cycles247_5 = 0b110,
-
-        /// 640.5 ADC clock cycles
-        Cycles640_5 = 0b111,
-    }
-
-    impl SampleTime {
-        pub(crate) fn sample_time(&self) -> crate::pac::adc::vals::SampleTime {
-            match self {
-                SampleTime::Cycles2_5 => crate::pac::adc::vals::SampleTime::CYCLES2_5,
-                SampleTime::Cycles6_5 => crate::pac::adc::vals::SampleTime::CYCLES6_5,
-                SampleTime::Cycles12_5 => crate::pac::adc::vals::SampleTime::CYCLES12_5,
-                SampleTime::Cycles24_5 => crate::pac::adc::vals::SampleTime::CYCLES24_5,
-                SampleTime::Cycles47_5 => crate::pac::adc::vals::SampleTime::CYCLES47_5,
-                SampleTime::Cycles92_5 => crate::pac::adc::vals::SampleTime::CYCLES92_5,
-                SampleTime::Cycles247_5 => crate::pac::adc::vals::SampleTime::CYCLES247_5,
-                SampleTime::Cycles640_5 => crate::pac::adc::vals::SampleTime::CYCLES640_5,
-            }
-        }
-    }
-
-    impl Default for SampleTime {
-        fn default() -> Self {
-            Self::Cycles2_5
-        }
-    }
-}
-
-#[cfg(adc_g0)]
-mod sample_time {
-    /// ADC sample time
-    ///
-    /// The default setting is 1.5 ADC clock cycles.
-    #[derive(Clone, Copy, Debug, Eq, PartialEq, Ord, PartialOrd)]
-    pub enum SampleTime {
-        /// 1.5 ADC clock cycles
-        Cycles1_5 = 0b000,
-
-        /// 3.5 ADC clock cycles
-        Cycles3_5 = 0b001,
-
-        /// 7.5 ADC clock cycles
-        Cycles7_5 = 0b010,
-
-        /// 12.5 ADC clock cycles
-        Cycles12_5 = 0b011,
-
-        /// 19.5 ADC clock cycles
-        Cycles19_5 = 0b100,
-
-        /// 39.5 ADC clock cycles
-        Cycles39_5 = 0b101,
-
-        /// 79.5 ADC clock cycles
-        Cycles79_5 = 0b110,
-
-        /// 160.5 ADC clock cycles
-        Cycles160_5 = 0b111,
-    }
-
-    impl SampleTime {
-        pub(crate) fn sample_time(&self) -> crate::pac::adc::vals::SampleTime {
-            match self {
-                SampleTime::Cycles1_5 => crate::pac::adc::vals::SampleTime::CYCLES1_5,
-                SampleTime::Cycles3_5 => crate::pac::adc::vals::SampleTime::CYCLES3_5,
-                SampleTime::Cycles7_5 => crate::pac::adc::vals::SampleTime::CYCLES7_5,
-                SampleTime::Cycles12_5 => crate::pac::adc::vals::SampleTime::CYCLES12_5,
-                SampleTime::Cycles19_5 => crate::pac::adc::vals::SampleTime::CYCLES19_5,
-                SampleTime::Cycles39_5 => crate::pac::adc::vals::SampleTime::CYCLES39_5,
-                SampleTime::Cycles79_5 => crate::pac::adc::vals::SampleTime::CYCLES79_5,
-                SampleTime::Cycles160_5 => crate::pac::adc::vals::SampleTime::CYCLES160_5,
-            }
-        }
-    }
-
-    impl Default for SampleTime {
-        fn default() -> Self {
-            Self::Cycles1_5
-        }
-    }
-}
-
-pub use sample_time::SampleTime;
 
 pub struct Adc<'d, T: Instance> {
     sample_time: SampleTime,

--- a/embassy-stm32/src/adc/v3.rs
+++ b/embassy-stm32/src/adc/v3.rs
@@ -3,7 +3,7 @@ use core::marker::PhantomData;
 use embassy_hal_common::into_ref;
 use embedded_hal_02::blocking::delay::DelayUs;
 
-use crate::adc::{AdcPin, Instance, Resolution, SampleTime};
+use crate::adc::{Adc, AdcPin, Instance, Resolution, SampleTime};
 use crate::Peripheral;
 
 /// Default VREF voltage used for sample conversion to millivolts.
@@ -58,11 +58,6 @@ impl<T: Instance> super::sealed::AdcPin<T> for Vbat {
         let val = 14;
         val
     }
-}
-
-pub struct Adc<'d, T: Instance> {
-    sample_time: SampleTime,
-    phantom: PhantomData<&'d mut T>,
 }
 
 impl<'d, T: Instance> Adc<'d, T> {

--- a/embassy-stm32/src/adc/v4.rs
+++ b/embassy-stm32/src/adc/v4.rs
@@ -409,7 +409,7 @@ impl<'d, T: Instance + crate::rcc::RccPeripheral> Adc<'d, T> {
 
     unsafe fn read_channel(&mut self, channel: u8) -> u16 {
         // Configure ADC
-        T::regs().cfgr().modify(|reg| reg.set_res(self.resolution.res()));
+        T::regs().cfgr().modify(|reg| reg.set_res(self.resolution.into()));
 
         // Configure channel
         Self::set_channel_sample_time(channel, self.sample_time);
@@ -427,14 +427,11 @@ impl<'d, T: Instance + crate::rcc::RccPeripheral> Adc<'d, T> {
     }
 
     unsafe fn set_channel_sample_time(ch: u8, sample_time: SampleTime) {
+        let sample_time = sample_time.into();
         if ch <= 9 {
-            T::regs()
-                .smpr(0)
-                .modify(|reg| reg.set_smp(ch as _, sample_time.sample_time()));
+            T::regs().smpr(0).modify(|reg| reg.set_smp(ch as _, sample_time));
         } else {
-            T::regs()
-                .smpr(1)
-                .modify(|reg| reg.set_smp((ch - 10) as _, sample_time.sample_time()));
+            T::regs().smpr(1).modify(|reg| reg.set_smp((ch - 10) as _, sample_time));
         }
     }
 }

--- a/embassy-stm32/src/adc/v4.rs
+++ b/embassy-stm32/src/adc/v4.rs
@@ -225,7 +225,7 @@ impl Prescaler {
     }
 }
 
-impl<'d, T: Instance + crate::rcc::RccPeripheral> Adc<'d, T> {
+impl<'d, T: Instance> Adc<'d, T> {
     pub fn new(_peri: impl Peripheral<P = T> + 'd, delay: &mut impl DelayUs<u16>) -> Self {
         embassy_hal_common::into_ref!(_peri);
         T::enable();

--- a/embassy-stm32/src/adc/v4.rs
+++ b/embassy-stm32/src/adc/v4.rs
@@ -5,7 +5,7 @@ use embedded_hal_02::blocking::delay::DelayUs;
 use pac::adc::vals::{Adcaldif, Boost, Difsel, Exten, Pcsel};
 use pac::adccommon::vals::Presc;
 
-use super::{AdcPin, Instance, InternalChannel, SampleTime};
+use super::{AdcPin, Instance, InternalChannel, Resolution, SampleTime};
 use crate::time::Hertz;
 use crate::{pac, Peripheral};
 
@@ -13,42 +13,6 @@ use crate::{pac, Peripheral};
 pub const VREF_DEFAULT_MV: u32 = 3300;
 /// VREF voltage used for factory calibration of VREFINTCAL register.
 pub const VREF_CALIB_MV: u32 = 3300;
-
-pub enum Resolution {
-    SixteenBit,
-    FourteenBit,
-    TwelveBit,
-    TenBit,
-    EightBit,
-}
-
-impl Default for Resolution {
-    fn default() -> Self {
-        Self::SixteenBit
-    }
-}
-
-impl Resolution {
-    fn res(&self) -> pac::adc::vals::Res {
-        match self {
-            Resolution::SixteenBit => pac::adc::vals::Res::SIXTEENBIT,
-            Resolution::FourteenBit => pac::adc::vals::Res::FOURTEENBITV,
-            Resolution::TwelveBit => pac::adc::vals::Res::TWELVEBITV,
-            Resolution::TenBit => pac::adc::vals::Res::TENBIT,
-            Resolution::EightBit => pac::adc::vals::Res::EIGHTBIT,
-        }
-    }
-
-    pub fn to_max_count(&self) -> u32 {
-        match self {
-            Resolution::SixteenBit => (1 << 16) - 1,
-            Resolution::FourteenBit => (1 << 14) - 1,
-            Resolution::TwelveBit => (1 << 12) - 1,
-            Resolution::TenBit => (1 << 10) - 1,
-            Resolution::EightBit => (1 << 8) - 1,
-        }
-    }
-}
 
 // NOTE: Vrefint/Temperature/Vbat are only available on ADC3 on H7, this currently cannot be modeled with stm32-data, so these are available from the software on all ADCs
 pub struct VrefInt;

--- a/embassy-stm32/src/adc/v4.rs
+++ b/embassy-stm32/src/adc/v4.rs
@@ -5,7 +5,7 @@ use embedded_hal_02::blocking::delay::DelayUs;
 use pac::adc::vals::{Adcaldif, Boost, Difsel, Exten, Pcsel};
 use pac::adccommon::vals::Presc;
 
-use super::{AdcPin, Instance, InternalChannel, Resolution, SampleTime};
+use super::{Adc, AdcPin, Instance, InternalChannel, Resolution, SampleTime};
 use crate::time::Hertz;
 use crate::{pac, Peripheral};
 
@@ -223,11 +223,6 @@ impl Prescaler {
             Prescaler::DividedBy256 => Presc::DIV256,
         }
     }
-}
-
-pub struct Adc<'d, T: Instance> {
-    sample_time: SampleTime,
-    phantom: PhantomData<&'d mut T>,
 }
 
 impl<'d, T: Instance + crate::rcc::RccPeripheral> Adc<'d, T> {

--- a/embassy-stm32/src/adc/v4.rs
+++ b/embassy-stm32/src/adc/v4.rs
@@ -1,5 +1,3 @@
-use core::marker::PhantomData;
-
 use atomic_polyfill::{AtomicU8, Ordering};
 use embedded_hal_02::blocking::delay::DelayUs;
 use pac::adc::vals::{Adcaldif, Boost, Difsel, Exten, Pcsel};
@@ -226,8 +224,8 @@ impl Prescaler {
 }
 
 impl<'d, T: Instance> Adc<'d, T> {
-    pub fn new(_peri: impl Peripheral<P = T> + 'd, delay: &mut impl DelayUs<u16>) -> Self {
-        embassy_hal_common::into_ref!(_peri);
+    pub fn new(adc: impl Peripheral<P = T> + 'd, delay: &mut impl DelayUs<u16>) -> Self {
+        embassy_hal_common::into_ref!(adc);
         T::enable();
         T::reset();
 
@@ -257,8 +255,8 @@ impl<'d, T: Instance> Adc<'d, T> {
         }
 
         let mut s = Self {
+            adc,
             sample_time: Default::default(),
-            phantom: PhantomData,
         };
         s.power_up(delay);
         s.configure_differential_inputs();

--- a/embassy-stm32/src/adc/v4.rs
+++ b/embassy-stm32/src/adc/v4.rs
@@ -5,7 +5,7 @@ use embedded_hal_02::blocking::delay::DelayUs;
 use pac::adc::vals::{Adcaldif, Boost, Difsel, Exten, Pcsel};
 use pac::adccommon::vals::Presc;
 
-use super::{AdcPin, Instance, InternalChannel};
+use super::{AdcPin, Instance, InternalChannel, SampleTime};
 use crate::time::Hertz;
 use crate::{pac, Peripheral};
 
@@ -192,57 +192,6 @@ foreach_peripheral!(
         impl crate::rcc::RccPeripheral for crate::peripherals::ADC3 {}
     };
 );
-
-/// ADC sample time
-///
-/// The default setting is 2.5 ADC clock cycles.
-#[derive(Clone, Copy, Debug, Eq, PartialEq, Ord, PartialOrd)]
-pub enum SampleTime {
-    /// 1.5 ADC clock cycles
-    Cycles1_5,
-
-    /// 2.5 ADC clock cycles
-    Cycles2_5,
-
-    /// 8.5 ADC clock cycles
-    Cycles8_5,
-
-    /// 16.5 ADC clock cycles
-    Cycles16_5,
-
-    /// 32.5 ADC clock cycles
-    Cycles32_5,
-
-    /// 64.5 ADC clock cycles
-    Cycles64_5,
-
-    /// 387.5 ADC clock cycles
-    Cycles387_5,
-
-    /// 810.5 ADC clock cycles
-    Cycles810_5,
-}
-
-impl SampleTime {
-    pub(crate) fn sample_time(&self) -> pac::adc::vals::Smp {
-        match self {
-            SampleTime::Cycles1_5 => pac::adc::vals::Smp::CYCLES1_5,
-            SampleTime::Cycles2_5 => pac::adc::vals::Smp::CYCLES2_5,
-            SampleTime::Cycles8_5 => pac::adc::vals::Smp::CYCLES8_5,
-            SampleTime::Cycles16_5 => pac::adc::vals::Smp::CYCLES16_5,
-            SampleTime::Cycles32_5 => pac::adc::vals::Smp::CYCLES32_5,
-            SampleTime::Cycles64_5 => pac::adc::vals::Smp::CYCLES64_5,
-            SampleTime::Cycles387_5 => pac::adc::vals::Smp::CYCLES387_5,
-            SampleTime::Cycles810_5 => pac::adc::vals::Smp::CYCLES810_5,
-        }
-    }
-}
-
-impl Default for SampleTime {
-    fn default() -> Self {
-        Self::Cycles1_5
-    }
-}
 
 // NOTE (unused): The prescaler enum closely copies the hardware capabilities,
 // but high prescaling doesn't make a lot of sense in the current implementation and is ommited.


### PR DESCRIPTION
Noteworthy changes:

- Fixed a few typos in the `SampleTime`s
- `set_resolution` now writes directly to the configuration register. This also fixed a bug in v3 where the resolution was changed while `ADEN` is enabled, which the datasheet says isn't allowed.