### PR TITLE
stm32/usart: Fix bug where USART idle flag could end a `read` prematuraly

### DIFF
--- a/embassy-stm32/src/usart/mod.rs
+++ b/embassy-stm32/src/usart/mod.rs
@@ -465,7 +465,7 @@ impl<'d, T: BasicInstance, RxDma> UartRx<'d, T, RxDma> {
                 }
             }
 
-            if sr.idle() {
+            if enable_idle_line_detection && sr.idle() {
                 // Idle line
 
                 // stop dma transfer


### PR DESCRIPTION
on STM32, when setting USART `detect_previous_overrun = true`, the idle flag is not cleared and could result in premature end of the `read` method.

This PR fixes that.