### PR TITLE
Add uart async task example

### DIFF
--- a/examples/stm32wl/src/bin/uart_async.rs
+++ b/examples/stm32wl/src/bin/uart_async.rs
@@ -1,0 +1,60 @@
+#![no_std]
+#![no_main]
+#![feature(type_alias_impl_trait)]
+
+use defmt::*;
+use embassy_executor::Spawner;
+use embassy_stm32::interrupt;
+use embassy_stm32::usart::{Config, Uart};
+use {defmt_rtt as _, panic_probe as _};
+
+/*
+Pass Incoming data from LPUART1 to USART1
+Example is written for the LoRa-E5 mini v1.0,
+but can be surely changed for your needs.
+*/
+#[embassy_executor::main]
+async fn main(_spawner: Spawner) {
+    let mut config = embassy_stm32::Config::default();
+    config.rcc.mux = embassy_stm32::rcc::ClockSrc::HSE32;
+    let p = embassy_stm32::init(config);
+
+    defmt::info!("Starting system");
+
+    let mut config1 = Config::default();
+    config1.baudrate = 9600;
+
+    let mut config2 = Config::default();
+    config2.baudrate = 9600;
+
+    //RX/TX connected to USB/UART Bridge on LoRa-E5 mini v1.0
+    let irq = interrupt::take!(USART1);
+    let mut usart1 = Uart::new(p.USART1, p.PB7, p.PB6, irq, p.DMA1_CH3, p.DMA1_CH4, config1);
+
+    //RX1/TX1 (LPUART) on LoRa-E5 mini v1.0
+    let irq = interrupt::take!(LPUART1);
+    let mut usart2 = Uart::new(p.LPUART1, p.PC0, p.PC1, irq, p.DMA1_CH5, p.DMA1_CH6, config2);
+
+    unwrap!(usart1.write(b"Hello Embassy World!\r\n").await);
+    unwrap!(usart2.write(b"Hello Embassy World!\r\n").await);
+
+    let mut buf = [0u8; 300];
+    loop {
+        let result = usart2.read_until_idle(&mut buf).await;
+        match result {
+            Ok(size) => {
+                match usart1.write(&buf[0..size]).await {
+                    Ok(()) => {
+                        //Write suc.
+                    }
+                    Err(..) => {
+                        //Wasnt able to write
+                    }
+                }
+            }
+            Err(_err) => {
+                //Ignore eg. framing errors
+            }
+        }
+    }
+}


### PR DESCRIPTION
Dear Embassy Team,

here i propose an additional async uart pass-through example for the STM32WL.


Because im quite new to Rust, is there something like **interfaces**?

The code: 
```
mut usart1: Uart<
    'static,
    embassy_stm32::peripherals::USART1,
    embassy_stm32::peripherals::DMA1_CH3,
    embassy_stm32::peripherals::DMA1_CH4,
>,
mut usart2: Uart<
    'static,
    embassy_stm32::peripherals::LPUART1,
    embassy_stm32::peripherals::DMA1_CH5,
    embassy_stm32::peripherals::DMA1_CH6,
>,
```
is quite ugly in my opinion. I would like to allow any Type of DMA and USART/UART as argument. Is this possible somehow?
Im open to any feedback.

With love,
Mia