### PR TITLE
stm32-metapac-gen: Use `serde_json` to parse json files

### DIFF
--- a/stm32-metapac-gen/Cargo.toml
+++ b/stm32-metapac-gen/Cargo.toml
@@ -9,5 +9,7 @@ license = "MIT OR Apache-2.0"
 regex = "1.5.4"
 chiptool = { git = "https://github.com/embassy-rs/chiptool", rev = "28ffa8a19d84914089547f52900ffb5877a5dc23" }
 serde = { version = "1.0.130", features = [ "derive" ] }
+serde_json = "1.0.87"
 serde_yaml = "0.8.21"
 proc-macro2 = "1.0.29"
+

--- a/stm32-metapac-gen/src/lib.rs
+++ b/stm32-metapac-gen/src/lib.rs
@@ -223,7 +223,7 @@ impl Gen {
     fn load_chip(&mut self, name: &str) -> Chip {
         let chip_path = self.opts.data_dir.join("chips").join(&format!("{}.json", name));
         let chip = fs::read(chip_path).expect(&format!("Could not load chip {}", name));
-        serde_yaml::from_slice(&chip).unwrap()
+        serde_json::from_slice(&chip).unwrap()
     }
 
     pub fn gen(&mut self) {


### PR DESCRIPTION
This makes stm32-metapac-gen over twice as fast. A full run on my desktop goes from about six and a half seconds to about three seconds. Suprisingly, it also reduces the fresh compile time by almost a second.