### PR TITLE
Disable MMC interrupts

### DIFF
--- a/embassy-stm32/src/eth/v2/mod.rs
+++ b/embassy-stm32/src/eth/v2/mod.rs
@@ -116,6 +116,24 @@ impl<'d, T: Instance, P: PHY, const TX: usize, const RX: usize> Ethernet<'d, T, 
 
         mac.macqtx_fcr().modify(|w| w.set_pt(0x100));
 
+        // disable all MMC RX interrupts
+        mac.mmc_rx_interrupt_mask().write(|w| {
+            w.set_rxcrcerpim(true);
+            w.set_rxalgnerpim(true);
+            w.set_rxucgpim(true);
+            w.set_rxlpiuscim(true);
+            w.set_rxlpitrcim(true)
+        });
+
+        // disable all MMC TX interrupts
+        mac.mmc_tx_interrupt_mask().write(|w| {
+            w.set_txscolgpim(true);
+            w.set_txmcolgpim(true);
+            w.set_txgpktim(true);
+            w.set_txlpiuscim(true);
+            w.set_txlpitrcim(true);
+        });
+
         mtl.mtlrx_qomr().modify(|w| w.set_rsf(true));
         mtl.mtltx_qomr().modify(|w| w.set_tsf(true));
 


### PR DESCRIPTION
MMC interrupts can cause firmware hangup - refer to: https://github.com/stm32-rs/stm32h7xx-hal/issues/275 for more information

Fixes #594 