### PR TITLE
embassy-nrf: Default disable UARTE (nrf9160)

### DIFF
--- a/embassy-nrf/src/lib.rs
+++ b/embassy-nrf/src/lib.rs
@@ -267,5 +267,12 @@ pub fn init(config: config::Config) -> Peripherals {
     #[cfg(feature = "_time-driver")]
     time_driver::init(config.time_interrupt_priority);
 
+    // Disable UARTE (enabled by default for some reason)
+    #[cfg(feature = "_nrf9160")]
+    unsafe {
+        (*pac::UARTE0::ptr()).enable.write(|w| w.enable().disabled());
+        (*pac::UARTE1::ptr()).enable.write(|w| w.enable().disabled());
+    }
+
     peripherals
 }


### PR DESCRIPTION
Uarte is enabled by default on the nrf9160, which is both bad for power consumption and renders the other "shared" peripherals unusable. This might be an SPM bug, but had the same issue with all pre-compiled SPM:s available out there, so adding this fix until we figure out.