### PR TITLE
GPIOTE InputChannel with mutable reference.

### DIFF
--- a/embassy-nrf/src/gpiote.rs
+++ b/embassy-nrf/src/gpiote.rs
@@ -419,6 +419,12 @@ macro_rules! impl_channel {
                 $number as usize
             }
         }
+        impl sealed::Channel for &mut peripherals::$type {}
+        impl Channel for &mut peripherals::$type {
+            fn number(&self) -> usize {
+                $number as usize
+            }
+        }
     };
 }
 

--- a/embassy-nrf/src/gpiote.rs
+++ b/embassy-nrf/src/gpiote.rs
@@ -149,7 +149,7 @@ impl Iterator for BitIter {
 /// GPIOTE channel driver in input mode
 pub struct InputChannel<'d, C: Channel, T: GpioPin> {
     _ch: PeripheralRef<'d, C>,
-    pin: Input<'d, T>,
+    _pin: Input<'d, T>,
 }
 
 impl<'d, C: Channel, T: GpioPin> Drop for InputChannel<'d, C, T> {
@@ -185,7 +185,7 @@ impl<'d, C: Channel, T: GpioPin> InputChannel<'d, C, T> {
 
         g.events_in[num].reset();
 
-        InputChannel { _ch: ch, pin }
+        InputChannel { _ch: ch, _pin: pin }
     }
 
     pub async fn wait(&self) {
@@ -443,11 +443,11 @@ mod eh02 {
         type Error = Infallible;
 
         fn is_high(&self) -> Result<bool, Self::Error> {
-            Ok(self.pin.is_high())
+            Ok(self._pin.is_high())
         }
 
         fn is_low(&self) -> Result<bool, Self::Error> {
-            Ok(self.pin.is_low())
+            Ok(self._pin.is_low())
         }
     }
 }
@@ -462,11 +462,11 @@ mod eh1 {
 
     impl<'d, C: Channel, T: GpioPin> embedded_hal_1::digital::InputPin for InputChannel<'d, C, T> {
         fn is_high(&self) -> Result<bool, Self::Error> {
-            Ok(self.pin.is_high())
+            Ok(self._pin.is_high())
         }
 
         fn is_low(&self) -> Result<bool, Self::Error> {
-            Ok(self.pin.is_low())
+            Ok(self._pin.is_low())
         }
     }
 }

--- a/embassy-nrf/src/gpiote.rs
+++ b/embassy-nrf/src/gpiote.rs
@@ -2,7 +2,7 @@ use core::convert::Infallible;
 use core::future::{poll_fn, Future};
 use core::task::{Context, Poll};
 
-use embassy_hal_common::{impl_peripheral, Peripheral, PeripheralRef, into_ref};
+use embassy_hal_common::{impl_peripheral, into_ref, Peripheral, PeripheralRef};
 use embassy_sync::waitqueue::AtomicWaker;
 
 use crate::gpio::sealed::Pin as _;


### PR DESCRIPTION
Adding these changes enables us to define a channel using a mutable reference to `GPIOTE_CH(n)`, similar to how we can do with other drivers. So instead of using:
```rust
let p = embassy_nrf::init(config);
let freq_in = InputChannel::new(
    p.GPIOTE_CH0,
    Input::new(&mut p.P0_19, embassy_nrf::gpio::Pull::Up),
    embassy_nrf::gpiote::InputChannelPolarity::HiToLo,
);
```
we can use:
```rust
let p = embassy_nrf::init(config);
let freq_in = InputChannel::new(
    &mut p.GPIOTE_CH0,
    Input::new(&mut p.P0_19, embassy_nrf::gpio::Pull::Up),
    embassy_nrf::gpiote::InputChannelPolarity::HiToLo,
);
```
therefore not giving ownership to GPIOTE_CH0.