### PR TITLE
Add size of bytes received as return param for uart reads

### DIFF
--- a/embassy-stm32/src/usart/mod.rs
+++ b/embassy-stm32/src/usart/mod.rs
@@ -331,7 +331,6 @@ impl<'d, T: BasicInstance, RxDma> UartRx<'d, T, RxDma> {
         RxDma: crate::usart::RxDma<T>,
     {
         self.inner_read(buffer, false).await?;
-
         Ok(())
     }
 


### PR DESCRIPTION
Hi fellow ambassador Rustoceans :crab:!

Just a minor change,

for being able to implement a tty cli using embassy, the information how many bytes have been received is important.
The information is actually available, but not forwarded to the user. Now it is.

With kind regards,
Mia
