### PR TITLE
Added blinky example for stm32f0

### DIFF
--- a/examples/stm32f0/.cargo/config.toml
+++ b/examples/stm32f0/.cargo/config.toml
@@ -1,5 +1,5 @@
 [target.thumbv6m-none-eabi]
-runner = 'probe-run --chip STM32F030F4Px'
+runner = 'probe-run --chip STM32F091RCTX'
 
 [build]
 target = "thumbv6m-none-eabi"

--- a/examples/stm32f0/Cargo.toml
+++ b/examples/stm32f0/Cargo.toml
@@ -15,5 +15,5 @@ panic-probe = "0.3"
 embassy-sync = { version = "0.1.0", path = "../../embassy-sync", features = ["defmt"] }
 embassy-executor = { version = "0.1.0", path = "../../embassy-executor", features = ["defmt", "integrated-timers"] }
 embassy-time = { version = "0.1.0", path = "../../embassy-time", features = ["defmt", "defmt-timestamp-uptime", "tick-hz-32_768"] }
-embassy-stm32 = { version = "0.1.0", path = "../../embassy-stm32", features = ["nightly", "defmt", "memory-x", "stm32f030f4", "time-driver-any"] }
+embassy-stm32 = { version = "0.1.0", path = "../../embassy-stm32", features = ["nightly", "defmt", "memory-x", "stm32f091rc", "time-driver-any"] }
 

--- a/examples/stm32f0/src/bin/blinky.rs
+++ b/examples/stm32f0/src/bin/blinky.rs
@@ -1,0 +1,28 @@
+#![no_std]
+#![no_main]
+#![feature(type_alias_impl_trait)]
+
+use defmt::*;
+use embassy_executor::Spawner;
+use embassy_stm32::gpio::{Level, Output, Speed};
+use embassy_time::{Duration, Timer};
+use {defmt_rtt as _, panic_probe as _};
+
+// main is itself an async function.
+#[embassy_executor::main]
+async fn main(_spawner: Spawner) {
+    let p = embassy_stm32::init(Default::default());
+    info!("Hello World!");
+    //PA5 is the onboard LED on the Nucleo F091RC
+    let mut led = Output::new(p.PA5, Level::High, Speed::Low);
+
+    loop {
+        info!("high");
+        led.set_high();
+        Timer::after(Duration::from_millis(300)).await;
+
+        info!("low");
+        led.set_low();
+        Timer::after(Duration::from_millis(300)).await;
+    }
+}


### PR DESCRIPTION
Hi, I have added **blinky** example for `stm32f0` and tested with Nucleo board `STM32F091RC`.

- Can I add more example for stm32f0?