### PR TITLE
executor: enable features for docs.rs

### DIFF
--- a/embassy-executor/Cargo.toml
+++ b/embassy-executor/Cargo.toml
@@ -27,6 +27,9 @@ flavors = [
     { name = "thumbv8m.main-none-eabihf", target = "thumbv8m.main-none-eabihf",  features = [] },
 ]
 
+[package.metadata.docs.rs]
+features = ["std", "nightly", "defmt"]
+
 [features]
 default = []
 std = ["critical-section/std"]


### PR DESCRIPTION
Otherwise the non-raw executor and the macros don't show up.