### PR TITLE
stm32: Add basic support for DMA priority settings

### DIFF
--- a/embassy-stm32/src/dma/dma.rs
+++ b/embassy-stm32/src/dma/dma.rs
@@ -1,6 +1,7 @@
 use core::sync::atomic::{fence, Ordering};
 use core::task::Waker;
 
+use embassy_cortex_m::interrupt::Priority;
 use embassy_sync::waitqueue::AtomicWaker;
 
 use super::{Burst, FlowControl, Request, TransferOptions, Word, WordSize};
@@ -67,10 +68,12 @@ impl State {
 static STATE: State = State::new();
 
 /// safety: must be called only once
-pub(crate) unsafe fn init() {
+pub(crate) unsafe fn init(irq_priority: Priority) {
     foreach_interrupt! {
         ($peri:ident, dma, $block:ident, $signal_name:ident, $irq:ident) => {
-            interrupt::$irq::steal().enable();
+            let irq = interrupt::$irq::steal();
+            irq.set_priority(irq_priority);
+            irq.enable();
         };
     }
     crate::_generated::init_dma();

--- a/embassy-stm32/src/dma/mod.rs
+++ b/embassy-stm32/src/dma/mod.rs
@@ -12,6 +12,8 @@ use core::mem;
 use core::pin::Pin;
 use core::task::{Context, Poll, Waker};
 
+#[cfg(any(dma, bdma))]
+use embassy_cortex_m::interrupt::Priority;
 use embassy_hal_common::{impl_peripheral, into_ref};
 
 #[cfg(dmamux)]
@@ -294,11 +296,11 @@ pub struct NoDma;
 impl_peripheral!(NoDma);
 
 // safety: must be called only once at startup
-pub(crate) unsafe fn init() {
+pub(crate) unsafe fn init(#[cfg(bdma)] bdma_priority: Priority, #[cfg(dma)] dma_priority: Priority) {
     #[cfg(bdma)]
-    bdma::init();
+    bdma::init(bdma_priority);
     #[cfg(dma)]
-    dma::init();
+    dma::init(dma_priority);
     #[cfg(dmamux)]
     dmamux::init();
     #[cfg(gpdma)]

--- a/embassy-stm32/src/lib.rs
+++ b/embassy-stm32/src/lib.rs
@@ -79,6 +79,8 @@ pub(crate) mod _generated {
 // Reexports
 pub use _generated::{peripherals, Peripherals};
 pub use embassy_cortex_m::executor;
+#[cfg(any(dma, bdma))]
+use embassy_cortex_m::interrupt::Priority;
 pub use embassy_cortex_m::interrupt::_export::interrupt;
 pub use embassy_hal_common::{into_ref, Peripheral, PeripheralRef};
 #[cfg(feature = "unstable-pac")]
@@ -91,6 +93,10 @@ pub struct Config {
     pub rcc: rcc::Config,
     #[cfg(dbgmcu)]
     pub enable_debug_during_sleep: bool,
+    #[cfg(bdma)]
+    pub bdma_interrupt_priority: Priority,
+    #[cfg(dma)]
+    pub dma_interrupt_priority: Priority,
 }
 
 impl Default for Config {
@@ -99,6 +105,10 @@ impl Default for Config {
             rcc: Default::default(),
             #[cfg(dbgmcu)]
             enable_debug_during_sleep: true,
+            #[cfg(bdma)]
+            bdma_interrupt_priority: Priority::P0,
+            #[cfg(dma)]
+            dma_interrupt_priority: Priority::P0,
         }
     }
 }
@@ -137,7 +147,12 @@ pub fn init(config: Config) -> Peripherals {
         }
 
         gpio::init();
-        dma::init();
+        dma::init(
+            #[cfg(bdma)]
+            config.bdma_interrupt_priority,
+            #[cfg(dma)]
+            config.dma_interrupt_priority,
+        );
         #[cfg(feature = "exti")]
         exti::init();
 


### PR DESCRIPTION
This adds very basic support for specifying priority for DMA interrupts. Unfortunately, the patch now doesn't allow for specifying different priorities for DMA1/DMA2, or BDMA1/BDMA2, which I didn't know how to support.