### PR TITLE
stm32: Enable fifo for buffered uart

### DIFF
--- a/embassy-stm32/src/usart/buffered.rs
+++ b/embassy-stm32/src/usart/buffered.rs
@@ -112,6 +112,9 @@ impl<'d, T: BasicInstance> BufferedUart<'d, T> {
 
         unsafe {
             r.cr1().modify(|w| {
+                #[cfg(lpuart_v2)]
+                w.set_fifoen(true);
+
                 w.set_rxneie(true);
                 w.set_idleie(true);
             });


### PR DESCRIPTION
This PR enables fifo for buffered uart where it is available. This should hopfully get rid of some overrun errors. I tried it in my application where it worked, but more intensive testing is probably required.