### PR TITLE
usb: Make driver generic over max interfaces

### DIFF
--- a/embassy-usb-logger/src/lib.rs
+++ b/embassy-usb-logger/src/lib.rs
@@ -67,7 +67,7 @@ impl<const N: usize> UsbLogger<N> {
         config.device_protocol = 0x01;
         config.composite_with_iads = true;
 
-        let mut builder = Builder::new(
+        let mut builder = Builder::<'d, D, 4>::new(
             driver,
             config,
             &mut state.device_descriptor,

--- a/embassy-usb/src/class/cdc_acm.rs
+++ b/embassy-usb/src/class/cdc_acm.rs
@@ -158,7 +158,11 @@ impl<'d> ControlHandler for Control<'d> {
 impl<'d, D: Driver<'d>> CdcAcmClass<'d, D> {
     /// Creates a new CdcAcmClass with the provided UsbBus and max_packet_size in bytes. For
     /// full-speed devices, max_packet_size has to be one of 8, 16, 32 or 64.
-    pub fn new(builder: &mut Builder<'d, D>, state: &'d mut State<'d>, max_packet_size: u16) -> Self {
+    pub fn new<const I: usize>(
+        builder: &mut Builder<'d, D, I>,
+        state: &'d mut State<'d>,
+        max_packet_size: u16,
+    ) -> Self {
         let control = state.control.write(Control { shared: &state.shared });
 
         let control_shared = &state.shared;

--- a/embassy-usb/src/class/cdc_ncm/mod.rs
+++ b/embassy-usb/src/class/cdc_ncm/mod.rs
@@ -236,8 +236,8 @@ pub struct CdcNcmClass<'d, D: Driver<'d>> {
 }
 
 impl<'d, D: Driver<'d>> CdcNcmClass<'d, D> {
-    pub fn new(
-        builder: &mut Builder<'d, D>,
+    pub fn new<const I: usize>(
+        builder: &mut Builder<'d, D, I>,
         state: &'d mut State<'d>,
         mac_address: [u8; 6],
         max_packet_size: u16,

--- a/embassy-usb/src/class/hid.rs
+++ b/embassy-usb/src/class/hid.rs
@@ -84,8 +84,8 @@ pub struct HidReaderWriter<'d, D: Driver<'d>, const READ_N: usize, const WRITE_N
     writer: HidWriter<'d, D, WRITE_N>,
 }
 
-fn build<'d, D: Driver<'d>>(
-    builder: &mut Builder<'d, D>,
+fn build<'d, D: Driver<'d>, const I: usize>(
+    builder: &mut Builder<'d, D, I>,
     state: &'d mut State<'d>,
     config: Config<'d>,
     with_out_endpoint: bool,
@@ -138,7 +138,7 @@ impl<'d, D: Driver<'d>, const READ_N: usize, const WRITE_N: usize> HidReaderWrit
     /// This will allocate one IN and one OUT endpoints. If you only need writing (sending)
     /// HID reports, consider using [`HidWriter::new`] instead, which allocates an IN endpoint only.
     ///
-    pub fn new(builder: &mut Builder<'d, D>, state: &'d mut State<'d>, config: Config<'d>) -> Self {
+    pub fn new<const I: usize>(builder: &mut Builder<'d, D, I>, state: &'d mut State<'d>, config: Config<'d>) -> Self {
         let (ep_out, ep_in, offset) = build(builder, state, config, true);
 
         Self {
@@ -217,7 +217,7 @@ impl<'d, D: Driver<'d>, const N: usize> HidWriter<'d, D, N> {
     /// HID reports. A lower value means better throughput & latency, at the expense
     /// of CPU on the device & bandwidth on the bus. A value of 10 is reasonable for
     /// high performance uses, and a value of 255 is good for best-effort usecases.
-    pub fn new(builder: &mut Builder<'d, D>, state: &'d mut State<'d>, config: Config<'d>) -> Self {
+    pub fn new<const I: usize>(builder: &mut Builder<'d, D, I>, state: &'d mut State<'d>, config: Config<'d>) -> Self {
         let (ep_out, ep_in, _offset) = build(builder, state, config, false);
 
         assert!(ep_out.is_none());

--- a/embassy-usb/src/descriptor.rs
+++ b/embassy-usb/src/descriptor.rs
@@ -313,7 +313,7 @@ impl<'a> BosWriter<'a> {
         let blen = data.len();
 
         if (start + blen + 3) > self.writer.buf.len() || (blen + 3) > 255 {
-            panic!("Descriptor buffer full");
+            panic!("BOS descriptor buffer full");
         }
 
         self.writer.buf[start] = (blen + 3) as u8;

--- a/examples/nrf/src/bin/usb_ethernet.rs
+++ b/examples/nrf/src/bin/usb_ethernet.rs
@@ -32,7 +32,7 @@ macro_rules! singleton {
 const MTU: usize = 1514;
 
 #[embassy_executor::task]
-async fn usb_task(mut device: UsbDevice<'static, MyDriver>) -> ! {
+async fn usb_task(mut device: UsbDevice<'static, MyDriver, 4>) -> ! {
     device.run().await
 }
 

--- a/examples/nrf/src/bin/usb_hid_keyboard.rs
+++ b/examples/nrf/src/bin/usb_hid_keyboard.rs
@@ -56,7 +56,7 @@ async fn main(_spawner: Spawner) {
 
     let mut state = State::new();
 
-    let mut builder = Builder::new(
+    let mut builder = Builder::<'_, _, 4>::new(
         driver,
         config,
         &mut device_descriptor,

--- a/examples/nrf/src/bin/usb_hid_mouse.rs
+++ b/examples/nrf/src/bin/usb_hid_mouse.rs
@@ -48,7 +48,7 @@ async fn main(_spawner: Spawner) {
 
     let mut state = State::new();
 
-    let mut builder = Builder::new(
+    let mut builder = Builder::<'_, _, 4>::new(
         driver,
         config,
         &mut device_descriptor,

--- a/examples/nrf/src/bin/usb_serial.rs
+++ b/examples/nrf/src/bin/usb_serial.rs
@@ -52,7 +52,7 @@ async fn main(_spawner: Spawner) {
 
     let mut state = State::new();
 
-    let mut builder = Builder::new(
+    let mut builder = Builder::<'_, _, 4>::new(
         driver,
         config,
         &mut device_descriptor,

--- a/examples/nrf/src/bin/usb_serial_multitask.rs
+++ b/examples/nrf/src/bin/usb_serial_multitask.rs
@@ -17,7 +17,7 @@ use {defmt_rtt as _, panic_probe as _};
 type MyDriver = Driver<'static, peripherals::USBD, PowerUsb>;
 
 #[embassy_executor::task]
-async fn usb_task(mut device: UsbDevice<'static, MyDriver>) {
+async fn usb_task(mut device: UsbDevice<'static, MyDriver, 4>) {
     device.run().await;
 }
 

--- a/examples/rp/src/bin/usb_ethernet.rs
+++ b/examples/rp/src/bin/usb_ethernet.rs
@@ -29,7 +29,7 @@ macro_rules! singleton {
 const MTU: usize = 1514;
 
 #[embassy_executor::task]
-async fn usb_task(mut device: UsbDevice<'static, MyDriver>) -> ! {
+async fn usb_task(mut device: UsbDevice<'static, MyDriver, 4>) -> ! {
     device.run().await
 }
 

--- a/examples/rp/src/bin/usb_serial.rs
+++ b/examples/rp/src/bin/usb_serial.rs
@@ -46,7 +46,7 @@ async fn main(_spawner: Spawner) {
 
     let mut state = State::new();
 
-    let mut builder = Builder::new(
+    let mut builder = Builder::<'_, _, 4>::new(
         driver,
         config,
         &mut device_descriptor,

--- a/examples/stm32f1/src/bin/usb_serial.rs
+++ b/examples/stm32f1/src/bin/usb_serial.rs
@@ -51,7 +51,7 @@ async fn main(_spawner: Spawner) {
 
     let mut state = State::new();
 
-    let mut builder = Builder::new(
+    let mut builder = Builder::<'_, _, 4>::new(
         driver,
         config,
         &mut device_descriptor,

--- a/examples/stm32f3/src/bin/usb_serial.rs
+++ b/examples/stm32f3/src/bin/usb_serial.rs
@@ -48,7 +48,7 @@ async fn main(_spawner: Spawner) {
 
     let mut state = State::new();
 
-    let mut builder = Builder::new(
+    let mut builder = Builder::<'_, _, 4>::new(
         driver,
         config,
         &mut device_descriptor,

--- a/examples/stm32l5/src/bin/usb_ethernet.rs
+++ b/examples/stm32l5/src/bin/usb_ethernet.rs
@@ -32,7 +32,7 @@ macro_rules! singleton {
 const MTU: usize = 1514;
 
 #[embassy_executor::task]
-async fn usb_task(mut device: UsbDevice<'static, MyDriver>) -> ! {
+async fn usb_task(mut device: UsbDevice<'static, MyDriver, 4>) -> ! {
     device.run().await
 }
 

--- a/examples/stm32l5/src/bin/usb_hid_mouse.rs
+++ b/examples/stm32l5/src/bin/usb_hid_mouse.rs
@@ -44,7 +44,7 @@ async fn main(_spawner: Spawner) {
 
     let mut state = State::new();
 
-    let mut builder = Builder::new(
+    let mut builder = Builder::<'_, _, 4>::new(
         driver,
         config,
         &mut device_descriptor,

--- a/examples/stm32l5/src/bin/usb_serial.rs
+++ b/examples/stm32l5/src/bin/usb_serial.rs
@@ -39,7 +39,7 @@ async fn main(_spawner: Spawner) {
 
     let mut state = State::new();
 
-    let mut builder = Builder::new(
+    let mut builder = Builder::<'_, _, 4>::new(
         driver,
         config,
         &mut device_descriptor,


### PR DESCRIPTION
It would be nice if a default value could be used so old code would mostly just work, but defaults are not used while determining types so adding a default does nothing here.

It would also be nice if we could calculate the number of interfaces needed at compile time, but I'll leave that as an exercise for later.

https://github.com/rust-lang/rust/issues/95486
https://github.com/rust-lang/rust/issues/99727
https://github.com/rust-lang/rust/issues/27336