### PR TITLE
fix net README.md

### DIFF
--- a/embassy-net/README.md
+++ b/embassy-net/README.md
@@ -17,11 +17,13 @@ sudo ip -6 route add fe80::/64 dev tap0
 sudo ip -6 route add fdaa::/64 dev tap0
 ```
 
+Second, have something listening there. For example `nc -l 8000`
+
 Then run the example located in the `examples` folder:
 
 ```sh
 cd $EMBASSY_ROOT/examples/std/
-cargo run --bin net
+cargo run --bin net -- --static-ip
 ```
 
 ## License


### PR DESCRIPTION
examples/std/src/bin/net.rs connects to TCP port 8000, you need to have something listening there. For example nc -l 8000

Besides, need to add `-- --static-ip` becuase `nc` not support DHCP.


