### PR TITLE
add convert_to_celsius function in the adc module

### DIFF
--- a/examples/rp/src/bin/adc.rs
+++ b/examples/rp/src/bin/adc.rs
@@ -34,5 +34,5 @@ async fn main(_spawner: Spawner) {
 
 fn convert_to_celsius(raw_temp: u16) -> f32 {
     // According to chapter 4.9.5. Temperature Sensor in RP2040 datasheet
-    27.0 - (raw_temp as f32 * 3.3 / 4096.0 -0.706)/0.001721 as f32
+    27.0 - (raw_temp as f32 * 3.3 / 4096.0 - 0.706) / 0.001721 as f32
 }

--- a/examples/rp/src/bin/adc.rs
+++ b/examples/rp/src/bin/adc.rs
@@ -27,7 +27,12 @@ async fn main(_spawner: Spawner) {
         let level = adc.read(&mut p28).await;
         info!("Pin 28 ADC: {}", level);
         let temp = adc.read_temperature().await;
-        info!("Temp: {}", temp);
+        info!("Temp: {} degrees", convert_to_celsius(temp));
         Timer::after(Duration::from_secs(1)).await;
     }
+}
+
+fn convert_to_celsius(raw_temp: u16) -> f32 {
+    // According to chapter 4.9.5. Temperature Sensor in RP2040 datasheet
+    27.0 - (raw_temp as f32 * 3.3 / 4096.0 -0.706)/0.001721 as f32
 }


### PR DESCRIPTION
    modify RP2040 adc example to get inside biased bipolar diode voltage,
    then convert this temperature sensor data into Celsius degree,
    according to chapter 4.9.5. Temperature Sensor in RP2040 datasheet.