### PR TITLE
Add Clone & Copy on embassy_nrf::gpio::Level

### DIFF
--- a/embassy-nrf/src/gpio.rs
+++ b/embassy-nrf/src/gpio.rs
@@ -70,7 +70,7 @@ impl<'d, T: Pin> Input<'d, T> {
 }
 
 /// Digital input or output level.
-#[derive(Debug, Eq, PartialEq)]
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub enum Level {
     /// Logical low.


### PR DESCRIPTION
This simply adds the Clone and Copy derive traits on embassy_nrf::gpio::Level.