### PR TITLE
Wdt config changes

### DIFF
--- a/embassy-boot/nrf/src/lib.rs
+++ b/embassy-boot/nrf/src/lib.rs
@@ -149,11 +149,7 @@ pub struct WatchdogFlash<'d> {
 
 impl<'d> WatchdogFlash<'d> {
     /// Start a new watchdog with a given flash and WDT peripheral and a timeout
-    pub fn start(flash: Nvmc<'d>, wdt: WDT, timeout: u32) -> Self {
-        let mut config = wdt::Config::default();
-        config.timeout_ticks = 32768 * timeout; // timeout seconds
-        config.run_during_sleep = true;
-        config.run_during_debug_halt = false;
+    pub fn start(flash: Nvmc<'d>, wdt: WDT, config: wdt::Config) -> Self {
         let (_wdt, [wdt]) = match wdt::Watchdog::try_new(wdt, config) {
             Ok(x) => x,
             Err(_) => {

--- a/examples/boot/application/nrf/README.md
+++ b/examples/boot/application/nrf/README.md
@@ -32,3 +32,7 @@ cargo objcopy --release --bin b -- -O binary b.bin
 ```
 cargo flash --release --bin a --chip nRF52840_xxAA
 ```
+
+You should then see a solid LED. Pressing button 1 will cause the DFU to be loaded by the bootloader. Upon
+successfully loading, you'll see the LED flash. After 5 seconds, because there is no petting of the watchdog,
+you'll see the LED go solid again. This indicates that the bootloader has reverted the update.

--- a/examples/boot/application/nrf/memory-bl.x
+++ b/examples/boot/application/nrf/memory-bl.x
@@ -5,7 +5,7 @@ MEMORY
   BOOTLOADER_STATE                  : ORIGIN = 0x00006000, LENGTH = 4K
   ACTIVE                            : ORIGIN = 0x00007000, LENGTH = 64K
   DFU                               : ORIGIN = 0x00017000, LENGTH = 68K
-  RAM                         (rwx) : ORIGIN = 0x20000008, LENGTH = 32K
+  RAM                         (rwx) : ORIGIN = 0x20000000, LENGTH = 32K
 }
 
 __bootloader_state_start = ORIGIN(BOOTLOADER_STATE);

--- a/examples/boot/application/nrf/memory.x
+++ b/examples/boot/application/nrf/memory.x
@@ -5,7 +5,7 @@ MEMORY
   BOOTLOADER_STATE                  : ORIGIN = 0x00006000, LENGTH = 4K
   FLASH                             : ORIGIN = 0x00007000, LENGTH = 64K
   DFU                               : ORIGIN = 0x00017000, LENGTH = 68K
-  RAM                         (rwx) : ORIGIN = 0x20000008, LENGTH = 32K
+  RAM                         (rwx) : ORIGIN = 0x20000000, LENGTH = 32K
 }
 
 __bootloader_state_start = ORIGIN(BOOTLOADER_STATE);

--- a/examples/boot/bootloader/nrf/memory-bm.x
+++ b/examples/boot/bootloader/nrf/memory-bm.x
@@ -5,7 +5,7 @@ MEMORY
   BOOTLOADER_STATE                  : ORIGIN = 0x00006000, LENGTH = 4K
   ACTIVE                            : ORIGIN = 0x00007000, LENGTH = 64K
   DFU                               : ORIGIN = 0x00017000, LENGTH = 68K
-  RAM                         (rwx) : ORIGIN = 0x20000008, LENGTH = 32K
+  RAM                         (rwx) : ORIGIN = 0x20000000, LENGTH = 32K
 }
 
 __bootloader_state_start = ORIGIN(BOOTLOADER_STATE);

--- a/examples/boot/bootloader/nrf/memory.x
+++ b/examples/boot/bootloader/nrf/memory.x
@@ -5,7 +5,7 @@ MEMORY
   BOOTLOADER_STATE                  : ORIGIN = 0x00006000, LENGTH = 4K
   ACTIVE                            : ORIGIN = 0x00007000, LENGTH = 64K
   DFU                               : ORIGIN = 0x00017000, LENGTH = 68K
-  RAM                         (rwx) : ORIGIN = 0x20000008, LENGTH = 32K
+  RAM                         (rwx) : ORIGIN = 0x20000000, LENGTH = 32K
 }
 
 __bootloader_state_start = ORIGIN(BOOTLOADER_STATE);

--- a/examples/boot/bootloader/nrf/src/main.rs
+++ b/examples/boot/bootloader/nrf/src/main.rs
@@ -6,6 +6,7 @@ use cortex_m_rt::{entry, exception};
 use defmt_rtt as _;
 use embassy_boot_nrf::*;
 use embassy_nrf::nvmc::Nvmc;
+use embassy_nrf::wdt;
 
 #[entry]
 fn main() -> ! {
@@ -20,8 +21,14 @@ fn main() -> ! {
     */
 
     let mut bl = BootLoader::default();
+
+    let mut wdt_config = wdt::Config::default();
+    wdt_config.timeout_ticks = 32768 * 5; // timeout seconds
+    wdt_config.run_during_sleep = true;
+    wdt_config.run_during_debug_halt = false;
+
     let start = bl.prepare(&mut SingleFlashConfig::new(&mut BootFlash::<_, 4096>::new(
-        WatchdogFlash::start(Nvmc::new(p.NVMC), p.WDT, 5),
+        WatchdogFlash::start(Nvmc::new(p.NVMC), p.WDT, wdt_config),
     )));
     unsafe { bl.load(start) }
 }


### PR DESCRIPTION
Per commits:

* By passing WDT config around we can control it more easily and promote sharing it between files.

* The memory layout of the s140 crept into a number of memory files, which can cause confusion (well, it did for me!).

* Obtaining the current WDT config is useful so that we do not have to duplicate configurations around the place. A constructor method has been introduced that attempts to return the current running WDT config from the WDT peripheral. The bootloader example has also been updated to show how the watchdog can be obtained and used.