### PR TITLE
feat: compile bootloader examples for nRF91

### DIFF
--- a/ci.sh
+++ b/ci.sh
@@ -81,6 +81,7 @@ cargo batch  \
     --- build --release --manifest-path embassy-stm32/Cargo.toml --target thumbv7m-none-eabi --features nightly,stm32f103re,defmt,exti,time-driver-any,unstable-traits \
     --- build --release --manifest-path embassy-stm32/Cargo.toml --target thumbv7m-none-eabi --features nightly,stm32f100c4,defmt,exti,time-driver-any,unstable-traits \
     --- build --release --manifest-path embassy-boot/nrf/Cargo.toml --target thumbv7em-none-eabi --features embassy-nrf/nrf52840 \
+    --- build --release --manifest-path embassy-boot/nrf/Cargo.toml --target thumbv8m.main-none-eabihf --features embassy-nrf/nrf9160-ns \
     --- build --release --manifest-path embassy-boot/rp/Cargo.toml --target thumbv6m-none-eabi \
     --- build --release --manifest-path embassy-boot/stm32/Cargo.toml --target thumbv7em-none-eabi --features embassy-stm32/stm32wl55jc-cm4 \
     --- build --release --manifest-path docs/modules/ROOT/examples/basic/Cargo.toml --target thumbv7em-none-eabi \
@@ -106,7 +107,8 @@ cargo batch  \
     --- build --release --manifest-path examples/stm32u5/Cargo.toml --target thumbv8m.main-none-eabihf --out-dir out/examples/stm32u5 \
     --- build --release --manifest-path examples/stm32wb/Cargo.toml --target thumbv7em-none-eabihf --out-dir out/examples/stm32wb \
     --- build --release --manifest-path examples/stm32wl/Cargo.toml --target thumbv7em-none-eabihf --out-dir out/examples/stm32wl \
-    --- build --release --manifest-path examples/boot/application/nrf/Cargo.toml --target thumbv7em-none-eabi --out-dir out/examples/boot/nrf --bin b \
+    --- build --release --manifest-path examples/boot/application/nrf/Cargo.toml --target thumbv7em-none-eabi --features embassy-nrf/nrf52840 --out-dir out/examples/boot/nrf --bin b \
+    --- build --release --manifest-path examples/boot/application/nrf/Cargo.toml --target thumbv8m.main-none-eabihf --features embassy-nrf/nrf9160-ns --out-dir out/examples/boot/nrf --bin b \
     --- build --release --manifest-path examples/boot/application/rp/Cargo.toml --target thumbv6m-none-eabi --out-dir out/examples/boot/rp --bin b \
     --- build --release --manifest-path examples/boot/application/stm32f3/Cargo.toml --target thumbv7em-none-eabi --out-dir out/examples/boot/stm32f3 --bin b \
     --- build --release --manifest-path examples/boot/application/stm32f7/Cargo.toml --target thumbv7em-none-eabi --out-dir out/examples/boot/stm32f7 --bin b \
@@ -116,6 +118,7 @@ cargo batch  \
     --- build --release --manifest-path examples/boot/application/stm32l4/Cargo.toml --target thumbv7em-none-eabi --out-dir out/examples/boot/stm32l4 --bin b \
     --- build --release --manifest-path examples/boot/application/stm32wl/Cargo.toml --target thumbv7em-none-eabihf --out-dir out/examples/boot/stm32wl --bin b \
     --- build --release --manifest-path examples/boot/bootloader/nrf/Cargo.toml --target thumbv7em-none-eabi --features embassy-nrf/nrf52840 \
+    --- build --release --manifest-path examples/boot/bootloader/nrf/Cargo.toml --target thumbv8m.main-none-eabihf --features embassy-nrf/nrf9160-ns \
     --- build --release --manifest-path examples/boot/bootloader/rp/Cargo.toml --target thumbv6m-none-eabi \
     --- build --release --manifest-path examples/boot/bootloader/stm32/Cargo.toml --target thumbv7em-none-eabi --features embassy-stm32/stm32wl55jc-cm4 \
     --- build --release --manifest-path examples/wasm/Cargo.toml --target wasm32-unknown-unknown --out-dir out/examples/wasm \

--- a/examples/boot/application/nrf/Cargo.toml
+++ b/examples/boot/application/nrf/Cargo.toml
@@ -8,7 +8,7 @@ license = "MIT OR Apache-2.0"
 embassy-sync = { version = "0.1.0", path = "../../../../embassy-sync" }
 embassy-executor = { version = "0.1.0", path = "../../../../embassy-executor", features = ["nightly", "integrated-timers"] }
 embassy-time = { version = "0.1.0", path = "../../../../embassy-time", features = ["nightly"] }
-embassy-nrf = { version = "0.1.0", path = "../../../../embassy-nrf", features = ["time-driver-rtc1", "gpiote", "nightly", "nrf52840"] }
+embassy-nrf = { version = "0.1.0", path = "../../../../embassy-nrf", features = ["time-driver-rtc1", "gpiote", "nightly"] }
 embassy-boot-nrf = { version = "0.1.0", path = "../../../../embassy-boot/nrf" }
 embassy-embedded-hal = { version = "0.1.0", path = "../../../../embassy-embedded-hal" }
 

--- a/examples/boot/application/nrf/README.md
+++ b/examples/boot/application/nrf/README.md
@@ -1,6 +1,6 @@
 # Examples using bootloader
 
-Example for nRF52 demonstrating the bootloader. The example consists of application binaries, 'a'
+Example for nRF demonstrating the bootloader. The example consists of application binaries, 'a'
 which allows you to press a button to start the DFU process, and 'b' which is the updated
 application.
 
@@ -20,17 +20,17 @@ application.
 cp memory-bl.x ../../bootloader/nrf/memory.x
 
 # Flash bootloader
-cargo flash --manifest-path ../../bootloader/nrf/Cargo.toml --features embassy-nrf/nrf52840 --release --chip nRF52840_xxAA
+cargo flash --manifest-path ../../bootloader/nrf/Cargo.toml --features embassy-nrf/nrf52840 --target thumbv7em-none-eabi --release --chip nRF52840_xxAA
 # Build 'b'
 cargo build --release --bin b
 # Generate binary for 'b'
-cargo objcopy --release --bin b -- -O binary b.bin
+cargo objcopy --release --bin b --features embassy-nrf/nrf52840 --target thumbv7em-none-eabi -- -O binary b.bin
 ```
 
 # Flash `a` (which includes b.bin)
 
 ```
-cargo flash --release --bin a --chip nRF52840_xxAA
+cargo flash --release --bin a --features embassy-nrf/nrf52840 --target thumbv7em-none-eabi --chip nRF52840_xxAA
 ```
 
 You should then see a solid LED. Pressing button 1 will cause the DFU to be loaded by the bootloader. Upon

--- a/examples/boot/application/nrf/memory-bl-nrf91.x
+++ b/examples/boot/application/nrf/memory-bl-nrf91.x
@@ -1,0 +1,19 @@
+MEMORY
+{
+  /* NOTE 1 K = 1 KiBi = 1024 bytes */
+  /* Assumes Secure Partition Manager (SPM) flashed at the start */
+  FLASH                             : ORIGIN = 0x00050000, LENGTH = 24K
+  BOOTLOADER_STATE                  : ORIGIN = 0x00056000, LENGTH = 4K
+  ACTIVE                            : ORIGIN = 0x00057000, LENGTH = 64K
+  DFU                               : ORIGIN = 0x00067000, LENGTH = 68K
+  RAM                         (rwx) : ORIGIN = 0x20018000, LENGTH = 32K
+}
+
+__bootloader_state_start = ORIGIN(BOOTLOADER_STATE);
+__bootloader_state_end = ORIGIN(BOOTLOADER_STATE) + LENGTH(BOOTLOADER_STATE);
+
+__bootloader_active_start = ORIGIN(ACTIVE);
+__bootloader_active_end = ORIGIN(ACTIVE) + LENGTH(ACTIVE);
+
+__bootloader_dfu_start = ORIGIN(DFU);
+__bootloader_dfu_end = ORIGIN(DFU) + LENGTH(DFU);

--- a/examples/boot/application/nrf/memory-nrf91.x
+++ b/examples/boot/application/nrf/memory-nrf91.x
@@ -1,0 +1,16 @@
+MEMORY
+{
+  /* NOTE 1 K = 1 KiBi = 1024 bytes */
+  /* Assumes Secure Partition Manager (SPM) flashed at the start */
+  BOOTLOADER                        : ORIGIN = 0x00050000, LENGTH = 24K
+  BOOTLOADER_STATE                  : ORIGIN = 0x00056000, LENGTH = 4K
+  FLASH                             : ORIGIN = 0x00057000, LENGTH = 64K
+  DFU                               : ORIGIN = 0x00067000, LENGTH = 68K
+  RAM                         (rwx) : ORIGIN = 0x20018000, LENGTH = 32K
+}
+
+__bootloader_state_start = ORIGIN(BOOTLOADER_STATE);
+__bootloader_state_end = ORIGIN(BOOTLOADER_STATE) + LENGTH(BOOTLOADER_STATE);
+
+__bootloader_dfu_start = ORIGIN(DFU);
+__bootloader_dfu_end = ORIGIN(DFU) + LENGTH(DFU);

--- a/examples/boot/application/nrf/src/bin/a.rs
+++ b/examples/boot/application/nrf/src/bin/a.rs
@@ -16,10 +16,16 @@ static APP_B: &[u8] = include_bytes!("../../b.bin");
 #[embassy_executor::main]
 async fn main(_spawner: Spawner) {
     let p = embassy_nrf::init(Default::default());
+
     let mut button = Input::new(p.P0_11, Pull::Up);
     let mut led = Output::new(p.P0_13, Level::Low, OutputDrive::Standard);
+
     //let mut led = Output::new(p.P1_10, Level::Low, OutputDrive::Standard);
     //let mut button = Input::new(p.P1_02, Pull::Up);
+
+    // nRF91 DK
+    // let mut led = Output::new(p.P0_02, Level::Low, OutputDrive::Standard);
+    // let mut button = Input::new(p.P0_06, Pull::Up);
 
     // The following code block illustrates how to obtain a watchdog that is configured
     // as per the existing watchdog. Ordinarily, we'd use the handle returned to "pet" the

--- a/examples/boot/application/nrf/src/bin/b.rs
+++ b/examples/boot/application/nrf/src/bin/b.rs
@@ -12,7 +12,10 @@ use panic_reset as _;
 async fn main(_spawner: Spawner) {
     let p = embassy_nrf::init(Default::default());
     let mut led = Output::new(p.P0_13, Level::Low, OutputDrive::Standard);
-    //let mut led = Output::new(p.P1_10, Level::Low, OutputDrive::Standard);
+    // let mut led = Output::new(p.P1_10, Level::Low, OutputDrive::Standard);
+
+    // nRF91 DK
+    // let mut led = Output::new(p.P0_02, Level::Low, OutputDrive::Standard);
 
     loop {
         led.set_high();

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -2,7 +2,7 @@
 # https://rust-lang.github.io/rustup-components-history
 [toolchain]
 channel = "nightly-2022-11-22"
-components = [ "rust-src", "rustfmt" ]
+components = [ "rust-src", "rustfmt", "llvm-tools-preview" ]
 targets = [
     "thumbv7em-none-eabi",
     "thumbv7m-none-eabi",


### PR DESCRIPTION
* Add nRF91 as target in CI builds
* Add example linker scripts for nrf91
* Make less nRF52 assumptions example config
* Add llvm-tools-preview required for cargo objcopy example