### PR TITLE
USB: allow setting the interface string for interface alt settings

### DIFF
--- a/embassy-usb/src/builder.rs
+++ b/embassy-usb/src/builder.rs
@@ -306,14 +306,25 @@ impl<'a, 'd, D: Driver<'d>> InterfaceBuilder<'a, 'd, D> {
     /// Alternate setting numbers are guaranteed to be allocated consecutively, starting from 0.
     ///
     /// The first alternate setting, with number 0, is the default one.
-    pub fn alt_setting(&mut self, class: u8, subclass: u8, protocol: u8) -> InterfaceAltBuilder<'_, 'd, D> {
+    pub fn alt_setting(
+        &mut self,
+        class: u8,
+        subclass: u8,
+        protocol: u8,
+        interface_string: Option<StringIndex>,
+    ) -> InterfaceAltBuilder<'_, 'd, D> {
         let number = self.next_alt_setting_number;
         self.next_alt_setting_number += 1;
         self.builder.interfaces[self.interface_number.0 as usize].num_alt_settings += 1;
 
-        self.builder
-            .config_descriptor
-            .interface_alt(self.interface_number, number, class, subclass, protocol, None);
+        self.builder.config_descriptor.interface_alt(
+            self.interface_number,
+            number,
+            class,
+            subclass,
+            protocol,
+            interface_string,
+        );
 
         InterfaceAltBuilder {
             builder: self.builder,

--- a/embassy-usb/src/class/cdc_acm.rs
+++ b/embassy-usb/src/class/cdc_acm.rs
@@ -171,7 +171,7 @@ impl<'d, D: Driver<'d>> CdcAcmClass<'d, D> {
         iface.handler(control);
         let comm_if = iface.interface_number();
         let data_if = u8::from(comm_if) + 1;
-        let mut alt = iface.alt_setting(USB_CLASS_CDC, CDC_SUBCLASS_ACM, CDC_PROTOCOL_NONE);
+        let mut alt = iface.alt_setting(USB_CLASS_CDC, CDC_SUBCLASS_ACM, CDC_PROTOCOL_NONE, None);
 
         alt.descriptor(
             CS_INTERFACE,
@@ -205,7 +205,7 @@ impl<'d, D: Driver<'d>> CdcAcmClass<'d, D> {
         // Data interface
         let mut iface = func.interface();
         let data_if = iface.interface_number();
-        let mut alt = iface.alt_setting(USB_CLASS_CDC_DATA, 0x00, CDC_PROTOCOL_NONE);
+        let mut alt = iface.alt_setting(USB_CLASS_CDC_DATA, 0x00, CDC_PROTOCOL_NONE, None);
         let read_ep = alt.endpoint_bulk_out(max_packet_size);
         let write_ep = alt.endpoint_bulk_in(max_packet_size);
 

--- a/embassy-usb/src/class/cdc_ncm/mod.rs
+++ b/embassy-usb/src/class/cdc_ncm/mod.rs
@@ -254,7 +254,7 @@ impl<'d, D: Driver<'d>> CdcNcmClass<'d, D> {
             mac_addr_str: [0; 12],
         }));
         let comm_if = iface.interface_number();
-        let mut alt = iface.alt_setting(USB_CLASS_CDC, CDC_SUBCLASS_NCM, CDC_PROTOCOL_NONE);
+        let mut alt = iface.alt_setting(USB_CLASS_CDC, CDC_SUBCLASS_NCM, CDC_PROTOCOL_NONE, None);
 
         alt.descriptor(
             CS_INTERFACE,
@@ -304,8 +304,8 @@ impl<'d, D: Driver<'d>> CdcNcmClass<'d, D> {
         let mut iface = func.interface();
         iface.handler(state.data_control.write(DataControl {}));
         let data_if = iface.interface_number();
-        let _alt = iface.alt_setting(USB_CLASS_CDC_DATA, 0x00, CDC_PROTOCOL_NTB);
-        let mut alt = iface.alt_setting(USB_CLASS_CDC_DATA, 0x00, CDC_PROTOCOL_NTB);
+        let _alt = iface.alt_setting(USB_CLASS_CDC_DATA, 0x00, CDC_PROTOCOL_NTB, None);
+        let mut alt = iface.alt_setting(USB_CLASS_CDC_DATA, 0x00, CDC_PROTOCOL_NTB, None);
         let read_ep = alt.endpoint_bulk_out(max_packet_size);
         let write_ep = alt.endpoint_bulk_in(max_packet_size);
 

--- a/embassy-usb/src/class/hid.rs
+++ b/embassy-usb/src/class/hid.rs
@@ -101,7 +101,7 @@ fn build<'d, D: Driver<'d>>(
     let mut func = builder.function(USB_CLASS_HID, USB_SUBCLASS_NONE, USB_PROTOCOL_NONE);
     let mut iface = func.interface();
     iface.handler(control);
-    let mut alt = iface.alt_setting(USB_CLASS_HID, USB_SUBCLASS_NONE, USB_PROTOCOL_NONE);
+    let mut alt = iface.alt_setting(USB_CLASS_HID, USB_SUBCLASS_NONE, USB_PROTOCOL_NONE, None);
 
     // HID descriptor
     alt.descriptor(


### PR DESCRIPTION
This is a breaking change to embassy-usb's API.