### PR TITLE
Stop sampling when exiting the Saadc methods

### DIFF
--- a/embassy-stm32/src/i2c/v2.rs
+++ b/embassy-stm32/src/i2c/v2.rs
@@ -483,7 +483,7 @@ impl<'d, T: Instance, TXDMA, RXDMA> I2c<'d, T, TXDMA, RXDMA> {
         state.chunks_transferred.store(0, Ordering::Relaxed);
         let mut remaining_len = total_len;
 
-        let _on_drop = OnDrop::new(|| {
+        let on_drop = OnDrop::new(|| {
             let regs = T::regs();
             unsafe {
                 regs.cr1().modify(|w| {
@@ -542,6 +542,9 @@ impl<'d, T: Instance, TXDMA, RXDMA> I2c<'d, T, TXDMA, RXDMA> {
             self.wait_tc(&check_timeout)?;
             self.master_stop();
         }
+
+        drop(on_drop);
+
         Ok(())
     }
 
@@ -580,7 +583,7 @@ impl<'d, T: Instance, TXDMA, RXDMA> I2c<'d, T, TXDMA, RXDMA> {
         state.chunks_transferred.store(0, Ordering::Relaxed);
         let mut remaining_len = total_len;
 
-        let _on_drop = OnDrop::new(|| {
+        let on_drop = OnDrop::new(|| {
             let regs = T::regs();
             unsafe {
                 regs.cr1().modify(|w| {
@@ -629,6 +632,9 @@ impl<'d, T: Instance, TXDMA, RXDMA> I2c<'d, T, TXDMA, RXDMA> {
         // This should be done already
         self.wait_tc(&check_timeout)?;
         self.master_stop();
+
+        drop(on_drop);
+
         Ok(())
     }
 

--- a/embassy-stm32/src/usart/mod.rs
+++ b/embassy-stm32/src/usart/mod.rs
@@ -405,7 +405,7 @@ impl<'d, T: BasicInstance, RxDma> UartRx<'d, T, RxDma> {
         let r = T::regs();
 
         // make sure USART state is restored to neutral state when this future is dropped
-        let _drop = OnDrop::new(move || {
+        let on_drop = OnDrop::new(move || {
             // defmt::trace!("Clear all USART interrupts and DMA Read Request");
             // clear all interrupts and DMA Rx Request
             // SAFETY: only clears Rx related flags
@@ -563,7 +563,7 @@ impl<'d, T: BasicInstance, RxDma> UartRx<'d, T, RxDma> {
         // wait for the first of DMA request or idle line detected to completes
         // select consumes its arguments
         // when transfer is dropped, it will stop the DMA request
-        match select(transfer, idle).await {
+        let r = match select(transfer, idle).await {
             // DMA transfer completed first
             Either::First(()) => Ok(ReadCompletionEvent::DmaCompleted),
 
@@ -572,7 +572,11 @@ impl<'d, T: BasicInstance, RxDma> UartRx<'d, T, RxDma> {
 
             // error occurred
             Either::Second(Err(e)) => Err(e),
-        }
+        };
+
+        drop(on_drop);
+
+        r
     }
 
     async fn inner_read(&mut self, buffer: &mut [u8], enable_idle_line_detection: bool) -> Result<usize, Error>


### PR DESCRIPTION
Prior to this commit, the onDrop function was being dropped immediately and not on exiting the Saadc sampling methods.

A few other places have been corrected also.

Thanks to Peter Hansen for pointing out this issue.