### PR TITLE
rp gpio: make pin_bank() inline

### DIFF
--- a/embassy-rp/src/gpio.rs
+++ b/embassy-rp/src/gpio.rs
@@ -743,6 +743,7 @@ macro_rules! impl_pin {
     ($name:ident, $bank:expr, $pin_num:expr) => {
         impl Pin for peripherals::$name {}
         impl sealed::Pin for peripherals::$name {
+            #[inline]
             fn pin_bank(&self) -> u8 {
                 ($bank as u8) * 32 + $pin_num
             }


### PR DESCRIPTION
This allows set_high() etc to be inlined, toggling pins should be much faster.