### PR TITLE
Fix rcc prescaler for wb55 HCLK1

### DIFF
--- a/embassy-stm32/src/rcc/wb.rs
+++ b/embassy-stm32/src/rcc/wb.rs
@@ -64,7 +64,7 @@ impl Into<u8> for APBPrescaler {
 impl Into<u8> for AHBPrescaler {
     fn into(self) -> u8 {
         match self {
-            AHBPrescaler::NotDivided => 1,
+            AHBPrescaler::NotDivided => 0x0,
             AHBPrescaler::Div2 => 0x08,
             AHBPrescaler::Div3 => 0x01,
             AHBPrescaler::Div4 => 0x09,


### PR DESCRIPTION
- fix prescaler not divided which incorrectly set prescaler divided by 3
Issue: #1137 