### PR TITLE
IPv6 has no checksum

### DIFF
--- a/embassy-net/src/device.rs
+++ b/embassy-net/src/device.rs
@@ -57,10 +57,6 @@ where
             ),
         };
         smolcaps.checksum.ipv4 = convert(caps.checksum.ipv4);
-        #[cfg(feature = "proto-ipv6")]
-        {
-            smolcaps.checksum.ipv6 = convert(caps.checksum.ipv6);
-        }
         smolcaps.checksum.tcp = convert(caps.checksum.tcp);
         smolcaps.checksum.udp = convert(caps.checksum.udp);
         smolcaps.checksum.icmpv4 = convert(caps.checksum.icmpv4);


### PR DESCRIPTION
As title says. Fixes `embassy-net` not compiling when feature `proto-ipv6` is enabled.