### PR TITLE
nRF examples crates names

### DIFF
--- a/examples/nrf52840/Cargo.toml
+++ b/examples/nrf52840/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 edition = "2021"
-name = "embassy-nrf-examples"
+name = "embassy-nrf52840-examples"
 version = "0.1.0"
 license = "MIT OR Apache-2.0"
 

--- a/examples/nrf5340/Cargo.toml
+++ b/examples/nrf5340/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 edition = "2021"
-name = "embassy-nrf-examples"
+name = "embassy-nrf5340-examples"
 version = "0.1.0"
 license = "MIT OR Apache-2.0"
 


### PR DESCRIPTION
Fixed nRF examples crates' names: they had the same names and they were conflicting during compilation (Cargo warning).