### PR TITLE
LoRa timings for SX126x/STM32WL

### DIFF
--- a/embassy-lora/src/stm32wl/mod.rs
+++ b/embassy-lora/src/stm32wl/mod.rs
@@ -260,10 +260,10 @@ impl From<embassy_stm32::spi::Error> for RadioError {
 
 impl<'d, RS> Timings for SubGhzRadio<'d, RS> {
     fn get_rx_window_offset_ms(&self) -> i32 {
-        -500
+        -3
     }
     fn get_rx_window_duration_ms(&self) -> u32 {
-        3000
+        1003
     }
 }
 

--- a/embassy-lora/src/sx126x/mod.rs
+++ b/embassy-lora/src/sx126x/mod.rs
@@ -55,10 +55,10 @@ where
     BUS: Error + Format + 'static,
 {
     fn get_rx_window_offset_ms(&self) -> i32 {
-        -500
+        -3
     }
     fn get_rx_window_duration_ms(&self) -> u32 {
-        800
+        1003
     }
 }
 


### PR DESCRIPTION
Those timings open Rx time windows covering 99.7% of the one expected
by the antenna while allowing 3ms for the Rx subsystem to start listening.
