### PR TITLE
stm32/usart: fix LPUART clock multiplier

### DIFF
--- a/embassy-stm32/src/usart/mod.rs
+++ b/embassy-stm32/src/usart/mod.rs
@@ -1148,7 +1148,7 @@ macro_rules! impl_lpuart {
 
 foreach_interrupt!(
     ($inst:ident, lpuart, $block:ident, $signal_name:ident, $irq:ident) => {
-        impl_lpuart!($inst, $irq, 255);
+        impl_lpuart!($inst, $irq, 256);
     };
 
     ($inst:ident, usart, $block:ident, $signal_name:ident, $irq:ident) => {


### PR DESCRIPTION
According to RM0351 Rev 9 (L4) and RM0399 Rev 3 (H7):

baud = (256 * clock) / LPUARTDIV
