### PR TITLE
STM32 SPI: Set clk-pin pull-up/-down to match spi clock polarity

### DIFF
--- a/embassy-stm32/src/spi/mod.rs
+++ b/embassy-stm32/src/spi/mod.rs
@@ -10,7 +10,7 @@ pub use embedded_hal_02::spi::{Mode, Phase, Polarity, MODE_0, MODE_1, MODE_2, MO
 use self::sealed::WordSize;
 use crate::dma::{slice_ptr_parts, Transfer};
 use crate::gpio::sealed::{AFType, Pin as _};
-use crate::gpio::AnyPin;
+use crate::gpio::{AnyPin, Pull};
 use crate::pac::spi::{regs, vals, Spi as Regs};
 use crate::rcc::RccPeripheral;
 use crate::time::Hertz;
@@ -93,8 +93,14 @@ impl<'d, T: Instance, Tx, Rx> Spi<'d, T, Tx, Rx> {
         config: Config,
     ) -> Self {
         into_ref!(peri, sck, mosi, miso);
+
+        let sck_pull_mode = match config.mode.polarity {
+            Polarity::IdleLow => Pull::Down,
+            Polarity::IdleHigh => Pull::Up,
+        };
+
         unsafe {
-            sck.set_as_af(sck.af_num(), AFType::OutputPushPull);
+            sck.set_as_af_pull(sck.af_num(), AFType::OutputPushPull, sck_pull_mode);
             sck.set_speed(crate::gpio::Speed::VeryHigh);
             mosi.set_as_af(mosi.af_num(), AFType::OutputPushPull);
             mosi.set_speed(crate::gpio::Speed::VeryHigh);


### PR DESCRIPTION
Fixes #1094 

There are some proposed solutions in #1094 

> Keep the DMA transaction open across calls to read/write
        This may be problematic if the user changes bus settings between calls, and also the reference manual says the chip should not be placed into low power mode while SPI is enabled

As already described, this is problematic and against reference manual recommendation

>    Set the CLK (and maybe MOSI) pins as pull-down on setup (or pull-up, depending on config - and this would need to be updated if the user modified the config)
        This is less good than driving the pin to the correct value, but may be better than nothing

That is also my preferred solution. See below citation from reference manual.

>    Document this and require users fix it themselves (add a pull-up/down resistor - or configure the pins as pull-up/pull-down before passing them into SPI setup)

Setting internal pull-up/-down won't work, because `sck.set_as_af()` will change the gpio pull mode to none: https://github.com/embassy-rs/embassy/blob/master/embassy-stm32/src/gpio.rs#L552-L555

>    Dig around in the reference manual and determine if there is a better way to start/stop a DMA transaction while keeping active control of the clock the whole time

I haven't found a better way

------
From ST reference manual RM0394 (L4) 
(Same note in RM0399 (H7) / RM0038 (L1) / RM0316 /F3)):

    40.4.6
    Communication formats
    ...
    The idle state of SCK must correspond to the polarity selected in the SPIx_CR1 register (by
    pulling up SCK if CPOL=1 or pulling down SCK if CPOL=0).
