### PR TITLE
stm32/rng Fix rng generation lock-up

### DIFF
--- a/embassy-stm32/src/rng.rs
+++ b/embassy-stm32/src/rng.rs
@@ -32,8 +32,9 @@ impl<'d, T: Instance> Rng<'d, T> {
     }
 
     pub fn reset(&mut self) {
+        // rng_v2 locks up on seed error, needs reset
         #[cfg(rng_v2)]
-        if unsafe { T::regs().sr().read().seis()} {
+        if unsafe { T::regs().sr().read().seis() } {
             T::reset();
         }
         unsafe {

--- a/embassy-stm32/src/rng.rs
+++ b/embassy-stm32/src/rng.rs
@@ -90,8 +90,10 @@ impl<'d, T: Instance> Rng<'d, T> {
 impl<'d, T: Instance> RngCore for Rng<'d, T> {
     fn next_u32(&mut self) -> u32 {
         loop {
-            let bits = unsafe { T::regs().sr().read() };
-            if bits.drdy() {
+            let sr = unsafe { T::regs().sr().read() };
+            if sr.seis() | sr.ceis() {
+                self.reset();
+            } else if sr.drdy() {
                 return unsafe { T::regs().dr().read() };
             }
         }

--- a/embassy-stm32/src/rng.rs
+++ b/embassy-stm32/src/rng.rs
@@ -32,8 +32,7 @@ impl<'d, T: Instance> Rng<'d, T> {
     }
 
     pub fn reset(&mut self) {
-        //stm32wl gets stuck if there is a seed error
-        #[cfg(stm32wl)]
+        #[cfg(rng_v2)]
         if unsafe { T::regs().sr().read().seis()} {
             T::reset();
         }

--- a/embassy-stm32/src/rng.rs
+++ b/embassy-stm32/src/rng.rs
@@ -32,6 +32,11 @@ impl<'d, T: Instance> Rng<'d, T> {
     }
 
     pub fn reset(&mut self) {
+        //stm32wl gets stuck if there is a seed error
+        #[cfg(stm32wl)]
+        if unsafe { T::regs().sr().read().seis()} {
+            T::reset();
+        }
         unsafe {
             T::regs().cr().modify(|reg| {
                 reg.set_rngen(true);


### PR DESCRIPTION
This PR fixes a problem where the device gets locked in case of rng errors.

The PR also includes a hack for stm32wl based devices where the more complicated RNG peripheral can get stuck on seed errors.