### PR TITLE
Add clone to embassy_rp::gpio::Level

### DIFF
--- a/embassy-rp/src/gpio.rs
+++ b/embassy-rp/src/gpio.rs
@@ -16,7 +16,7 @@ const NEW_AW: AtomicWaker = AtomicWaker::new();
 static INTERRUPT_WAKERS: [AtomicWaker; PIN_COUNT] = [NEW_AW; PIN_COUNT];
 
 /// Represents a digital input or output level.
-#[derive(Debug, Eq, PartialEq)]
+#[derive(Debug, Eq, PartialEq, Clone)]
 pub enum Level {
     Low,
     High,

--- a/embassy-rp/src/gpio.rs
+++ b/embassy-rp/src/gpio.rs
@@ -16,7 +16,7 @@ const NEW_AW: AtomicWaker = AtomicWaker::new();
 static INTERRUPT_WAKERS: [AtomicWaker; PIN_COUNT] = [NEW_AW; PIN_COUNT];
 
 /// Represents a digital input or output level.
-#[derive(Debug, Eq, PartialEq, Clone)]
+#[derive(Debug, Eq, PartialEq, Clone, Copy)]
 pub enum Level {
     Low,
     High,


### PR DESCRIPTION
Allows you to wite a cleaner state change detector. Example:
```rs
let mut button_state: Level = Level::Low;
let mut prev_button_state: Level = button_state;

loop {
    button_state = button.get_level();

    if prev_button_state != button_state {
        led.set_level(button_state);  // Takes ownership of button_state. 
    }

    prev_button_state = button_state; // Can't be done since the ownership has been moved.
                                      // Adding Clone makes this code possible
}
```