### PR TITLE
Fix a typo in "PioPeripheral"

### DIFF
--- a/embassy-rp/src/pio.rs
+++ b/embassy-rp/src/pio.rs
@@ -1174,7 +1174,7 @@ impl<const SM_NO: u8> SmInstance for SmInstanceBase<SM_NO> {
     const SM_NO: u8 = SM_NO;
 }
 
-pub trait PioPeripherial: Sized {
+pub trait PioPeripheral: Sized {
     type Pio: PioInstance;
     fn pio(&self) -> u8 {
         let _ = self;
@@ -1249,7 +1249,7 @@ pub type Sm3 = SmInstanceBase<3>;
 
 macro_rules! impl_pio_sm {
     ($name:ident, $pio:expr) => {
-        impl PioPeripherial for peripherals::$name {
+        impl PioPeripheral for peripherals::$name {
             type Pio = PioInstanceBase<$pio>;
         }
     };

--- a/examples/rp/src/bin/pio_async.rs
+++ b/examples/rp/src/bin/pio_async.rs
@@ -4,7 +4,7 @@
 use defmt::info;
 use embassy_executor::Spawner;
 use embassy_rp::gpio::{AnyPin, Pin};
-use embassy_rp::pio::{Pio0, PioPeripherial, PioStateMachine, PioStateMachineInstance, ShiftDirection, Sm0, Sm1, Sm2};
+use embassy_rp::pio::{Pio0, PioPeripheral, PioStateMachine, PioStateMachineInstance, ShiftDirection, Sm0, Sm1, Sm2};
 use embassy_rp::pio_instr_util;
 use embassy_rp::relocate::RelocatedProgram;
 use {defmt_rtt as _, panic_probe as _};

--- a/examples/rp/src/bin/pio_dma.rs
+++ b/examples/rp/src/bin/pio_dma.rs
@@ -4,7 +4,7 @@
 use defmt::info;
 use embassy_executor::Spawner;
 use embassy_futures::join::join;
-use embassy_rp::pio::{PioPeripherial, PioStateMachine, ShiftDirection};
+use embassy_rp::pio::{PioPeripheral, PioStateMachine, ShiftDirection};
 use embassy_rp::relocate::RelocatedProgram;
 use embassy_rp::{pio_instr_util, Peripheral};
 use {defmt_rtt as _, panic_probe as _};


### PR DESCRIPTION
Renames "PioPeripherial" to "PioPeripheral" (without the second i).