### PR TITLE
Lora: sx126x: Change timing window to match values found experimentally.

### DIFF
--- a/embassy-lora/src/sx126x/mod.rs
+++ b/embassy-lora/src/sx126x/mod.rs
@@ -55,10 +55,10 @@ where
     BUS: Error + Format + 'static,
 {
     fn get_rx_window_offset_ms(&self) -> i32 {
-        -3
+        -50
     }
     fn get_rx_window_duration_ms(&self) -> u32 {
-        1003
+        1050
     }
 }
 


### PR DESCRIPTION
As mentioned in #1188.