### PR TITLE
stm32/sdmmc: Fix SDIOv1 writes

### DIFF
--- a/embassy-stm32/src/dma/bdma.rs
+++ b/embassy-stm32/src/dma/bdma.rs
@@ -192,6 +192,7 @@ mod low_level_api {
             options.flow_ctrl == crate::dma::FlowControl::Dma,
             "Peripheral flow control not supported"
         );
+        assert!(options.fifo_threshold.is_none(), "FIFO mode not supported");
 
         let ch = dma.ch(channel_number as _);
 

--- a/embassy-stm32/src/dma/gpdma.rs
+++ b/embassy-stm32/src/dma/gpdma.rs
@@ -176,8 +176,16 @@ mod low_level_api {
         mem_len: usize,
         incr_mem: bool,
         data_size: WordSize,
-        _options: TransferOptions,
+        options: TransferOptions,
     ) {
+        assert!(options.mburst == crate::dma::Burst::Single, "Burst mode not supported");
+        assert!(options.pburst == crate::dma::Burst::Single, "Burst mode not supported");
+        assert!(
+            options.flow_ctrl == crate::dma::FlowControl::Dma,
+            "Peripheral flow control not supported"
+        );
+        assert!(options.fifo_threshold.is_none(), "FIFO mode not supported");
+
         // "Preceding reads and writes cannot be moved past subsequent writes."
         fence(Ordering::SeqCst);
 

--- a/embassy-stm32/src/dma/mod.rs
+++ b/embassy-stm32/src/dma/mod.rs
@@ -188,6 +188,19 @@ pub enum FlowControl {
 
 #[derive(Debug, Copy, Clone, PartialEq, Eq)]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
+pub enum FifoThreshold {
+    /// 1/4 full FIFO
+    Quarter,
+    /// 1/2 full FIFO
+    Half,
+    /// 3/4 full FIFO
+    ThreeQuarters,
+    /// Full FIFO
+    Full,
+}
+
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub struct TransferOptions {
     /// Peripheral burst transfer configuration
     pub pburst: Burst,
@@ -195,6 +208,8 @@ pub struct TransferOptions {
     pub mburst: Burst,
     /// Flow control configuration
     pub flow_ctrl: FlowControl,
+    /// FIFO threshold for DMA FIFO mode. If none, direct mode is used.
+    pub fifo_threshold: Option<FifoThreshold>,
 }
 
 impl Default for TransferOptions {
@@ -203,6 +218,7 @@ impl Default for TransferOptions {
             pburst: Burst::Single,
             mburst: Burst::Single,
             flow_ctrl: FlowControl::Dma,
+            fifo_threshold: None,
         }
     }
 }

--- a/examples/stm32f4/src/bin/sdmmc.rs
+++ b/examples/stm32f4/src/bin/sdmmc.rs
@@ -4,10 +4,14 @@
 
 use defmt::*;
 use embassy_executor::Spawner;
-use embassy_stm32::sdmmc::Sdmmc;
+use embassy_stm32::sdmmc::{DataBlock, Sdmmc};
 use embassy_stm32::time::mhz;
 use embassy_stm32::{interrupt, Config};
 use {defmt_rtt as _, panic_probe as _};
+
+/// This is a safeguard to not overwrite any data on the SD card.
+/// If you don't care about SD card contents, set this to `true` to test writes.
+const ALLOW_WRITES: bool = false;
 
 #[embassy_executor::main]
 async fn main(_spawner: Spawner) -> ! {
@@ -34,11 +38,42 @@ async fn main(_spawner: Spawner) -> ! {
     // Should print 400kHz for initialization
     info!("Configured clock: {}", sdmmc.clock().0);
 
-    unwrap!(sdmmc.init_card(mhz(25)).await);
+    unwrap!(sdmmc.init_card(mhz(24)).await);
 
     let card = unwrap!(sdmmc.card());
 
     info!("Card: {:#?}", Debug2Format(card));
+    info!("Clock: {}", sdmmc.clock());
+
+    // Arbitrary block index
+    let block_idx = 16;
+
+    // SDMMC uses `DataBlock` instead of `&[u8]` to ensure 4 byte alignment required by the hardware.
+    let mut block = DataBlock([0u8; 512]);
+
+    sdmmc.read_block(block_idx, &mut block).await.unwrap();
+    info!("Read: {=[u8]:X}...{=[u8]:X}", block[..8], block[512 - 8..]);
+
+    if !ALLOW_WRITES {
+        info!("Writing is disabled.");
+        loop {}
+    }
+
+    info!("Filling block with 0x55");
+    block.fill(0x55);
+    sdmmc.write_block(block_idx, &block).await.unwrap();
+    info!("Write done");
+
+    sdmmc.read_block(block_idx, &mut block).await.unwrap();
+    info!("Read: {=[u8]:X}...{=[u8]:X}", block[..8], block[512 - 8..]);
+
+    info!("Filling block with 0xAA");
+    block.fill(0xAA);
+    sdmmc.write_block(block_idx, &block).await.unwrap();
+    info!("Write done");
+
+    sdmmc.read_block(block_idx, &mut block).await.unwrap();
+    info!("Read: {=[u8]:X}...{=[u8]:X}", block[..8], block[512 - 8..]);
 
     loop {}
 }


### PR DESCRIPTION
This fixes writes on sdmmc v1 (SDIO). I'm pretty sure I tested writes in #669, but maybe I was just lucky or I just forgot.

There were two problems:
- Writes require DMA FIFO mode, otherwise SDIO FIFO is under/overrun depending on sdio/pclk2 clock ratio.
- Hardware flow control is broken for sdmmc v1 (I checked F1 and F4 erratas). This causes clock glitches above 12 MHz and results in write CRC errors.