### PR TITLE
examples/stm32wb: fix linker script.

### DIFF
--- a/examples/stm32wb/memory.x
+++ b/examples/stm32wb/memory.x
@@ -6,7 +6,7 @@
 MEMORY
 {
     FLASH (rx)                 : ORIGIN = 0x08000000, LENGTH = 256K
-    RAM (xrw)                  : ORIGIN = 0x20000004, LENGTH = 191K
+    RAM (xrw)                  : ORIGIN = 0x20000008, LENGTH = 0x2FFF8
     RAM_SHARED (xrw)           : ORIGIN = 0x20030000, LENGTH = 10K
 }
 


### PR DESCRIPTION
cortex-m-rt 0.7.2 now enforces the stack is 8-byte aligned. Stack is placed at `ORIGIN(RAM) + LENGTH(RAM)` by default, which wasn't 8-byte-aligned. See https://github.com/rust-embedded/cortex-m/discussions/469

ST trims 8 bytes from start of RAM, and uses the whole 192kb, so let's just copy that:

https://github.com/STMicroelectronics/STM32CubeWB/blob/bceb1dae09f912eae47fba059251d499ba32f4ca/Drivers/CMSIS/Device/ST/STM32WBxx/Source/Templates/gcc/linker/stm32wb55xx_flash_cm4.ld#L48

bors r+