### PR TITLE
examples/stm32wb: do not reserve words at start of RAM.

### DIFF
--- a/examples/stm32wb/memory.x
+++ b/examples/stm32wb/memory.x
@@ -6,7 +6,7 @@
 MEMORY
 {
     FLASH (rx)                 : ORIGIN = 0x08000000, LENGTH = 256K
-    RAM (xrw)                  : ORIGIN = 0x20000008, LENGTH = 0x2FFF8
+    RAM (xrw)                  : ORIGIN = 0x20000000, LENGTH = 192K
     RAM_SHARED (xrw)           : ORIGIN = 0x20030000, LENGTH = 10K
 }
 


### PR DESCRIPTION
They're used to communicate from the app to ST's OTA bootloader. See AN5247. 

This bootloader is optional, must be flashed by the user, and requires changing the FLASH start address as well, so the current memory regions still require modifications to use it. Therefore there's no point in reserving these words.

Thanks @adamgreig for investigating the purpose.

bors r+