### PR TITLE
embassy-net: Implement flush for TcpSocket

### DIFF
--- a/embassy-net/src/tcp.rs
+++ b/embassy-net/src/tcp.rs
@@ -63,6 +63,10 @@ impl<'a> TcpWriter<'a> {
     pub async fn write(&mut self, buf: &[u8]) -> Result<usize, Error> {
         self.io.write(buf).await
     }
+
+    pub async fn flush(&mut self) -> Result<(), Error> {
+        self.io.flush().await
+    }
 }
 
 impl<'a> TcpSocket<'a> {
@@ -144,6 +148,10 @@ impl<'a> TcpSocket<'a> {
 
     pub async fn write(&mut self, buf: &[u8]) -> Result<usize, Error> {
         self.io.write(buf).await
+    }
+
+    pub async fn flush(&mut self) -> Result<(), Error> {
+        self.io.flush().await
     }
 
     pub fn set_timeout(&mut self, duration: Option<Duration>) {


### PR DESCRIPTION
Implements flush for TcpSocket by checking the send queue. 

Flushing is implemented by checking if smoltcp's send_queue/tx_buffer is empty. The flush is completed when all outstanding octets are acknowledged. Smoltcp wakes the send waker [here](https://docs.rs/smoltcp/latest/src/smoltcp/socket/tcp.rs.html#1712) when ACKs are processed and data is removed from the send buffer. So we can re-check in our flush implementation, if the buffer is now empty.

fixes #1223

