### PR TITLE
stm32/dma: fix spurious transfer complete interrupts

### DIFF
--- a/embassy-stm32/src/dma/dma.rs
+++ b/embassy-stm32/src/dma/dma.rs
@@ -411,12 +411,8 @@ mod low_level_api {
         }
 
         if isr.tcif(channel_num % 4) && cr.read().tcie() {
-            if cr.read().dbm() == vals::Dbm::DISABLED {
-                cr.write(|_| ()); // Disable channel with the default value.
-            } else {
-                // for double buffered mode, clear TCIF flag but do not stop the transfer
-                dma.ifcr(channel_num / 4).write(|w| w.set_tcif(channel_num % 4, true));
-            }
+            /* acknowledge transfer complete interrupt */
+            dma.ifcr(channel_num / 4).write(|w| w.set_tcif(channel_num % 4, true));
             STATE.channels[state_index].waker.wake();
         }
     }


### PR DESCRIPTION
DMA interrupts must be acknowledged by writing to the DMA_{L,H}IFCR
register.

Writing to the CR register is unnecessary as the channel (EN bit) is
disabled by hardware on completion of the transfer.
