### PR TITLE
stm32/sdmmc: Implement proper clock configuration

### DIFF
--- a/embassy-stm32/src/sdmmc/mod.rs
+++ b/embassy-stm32/src/sdmmc/mod.rs
@@ -1580,7 +1580,7 @@ cfg_if::cfg_if! {
         // F1 uses AHB1(HCLK), which is correct in PAC
         macro_rules! kernel_clk {
             ($inst:ident) => {
-                peripherals::$inst::frequency()
+                <peripherals::$inst as crate::rcc::sealed::RccPeripheral>::frequency()
             }
         }
     } else if #[cfg(any(stm32f2, stm32f4))] {
@@ -1619,7 +1619,7 @@ cfg_if::cfg_if! {
         // Use default peripheral clock and hope it works
         macro_rules! kernel_clk {
             ($inst:ident) => {
-                peripherals::$inst::frequency()
+                <peripherals::$inst as crate::rcc::sealed::RccPeripheral>::frequency()
             }
         }
     }

--- a/examples/stm32f4/src/bin/sdmmc.rs
+++ b/examples/stm32f4/src/bin/sdmmc.rs
@@ -17,6 +17,7 @@ const ALLOW_WRITES: bool = false;
 async fn main(_spawner: Spawner) -> ! {
     let mut config = Config::default();
     config.rcc.sys_ck = Some(mhz(48));
+    config.rcc.pll48 = true;
     let p = embassy_stm32::init(config);
     info!("Hello World!");
 
@@ -38,7 +39,7 @@ async fn main(_spawner: Spawner) -> ! {
     // Should print 400kHz for initialization
     info!("Configured clock: {}", sdmmc.clock().0);
 
-    unwrap!(sdmmc.init_card(mhz(24)).await);
+    unwrap!(sdmmc.init_card(mhz(48)).await);
 
     let card = unwrap!(sdmmc.card());
 

--- a/examples/stm32f7/src/bin/sdmmc.rs
+++ b/examples/stm32f7/src/bin/sdmmc.rs
@@ -13,6 +13,7 @@ use {defmt_rtt as _, panic_probe as _};
 async fn main(_spawner: Spawner) -> ! {
     let mut config = Config::default();
     config.rcc.sys_ck = Some(mhz(200));
+    config.rcc.pll48 = true;
     let p = embassy_stm32::init(config);
 
     info!("Hello World!");


### PR DESCRIPTION
This implements proper clock configuration for sdmmc based on chip family, because `RccPeripheral::frequency()` is almost always incorrect. This can't be fixed in PAC, because sdmmc uses two clock domains, one for memory bus and one for sd card. `RccPeripheral::frequency()` usually returns the memory bus clock, but SDIO clock calculations need sd card domain clock. Moreover, chips have multiple clock source selection bits, which makes this even more complicated. I'm not sure if it's worth implementing all this logic in `RccPeripheral::frequency()` instead of cfg's in sdmmc.

Some chips (Lx, U5, H7) require RCC updates to expose required clocks. I didn't want to mash everything in a single PR so left a TODO comment. I also left a `T::frequency()` fallback, which seemed to work in H7 case even though the clock is most certainly incorrect.

In addition, added support for clock divider bypass for sdmmc_v1, which allows reaching a maximum clock of 48 MHz. The peripheral theoretically supports up to 50 MHz, but for that ST recommends setting pll48 frequency to 50 MHz 🤔