### PR TITLE
Use atomics using atomic-polyfill

### DIFF
--- a/embassy-executor/src/arch/riscv32.rs
+++ b/embassy-executor/src/arch/riscv32.rs
@@ -1,6 +1,7 @@
 use core::marker::PhantomData;
 use core::ptr;
-use core::sync::atomic::{AtomicBool, Ordering};
+
+use atomic_polyfill::{AtomicBool, Ordering};
 
 use super::{raw, Spawner};
 

--- a/embassy-hal-common/Cargo.toml
+++ b/embassy-hal-common/Cargo.toml
@@ -7,6 +7,7 @@ license = "MIT OR Apache-2.0"
 [features]
 
 [dependencies]
+atomic-polyfill = { version = "1.0" }
 defmt = { version = "0.3", optional = true }
 log = { version = "0.4.14", optional = true }
 

--- a/embassy-hal-common/src/atomic_ring_buffer.rs
+++ b/embassy-hal-common/src/atomic_ring_buffer.rs
@@ -1,5 +1,6 @@
 use core::slice;
-use core::sync::atomic::{AtomicPtr, AtomicUsize, Ordering};
+
+use atomic_polyfill::{AtomicPtr, AtomicUsize, Ordering};
 
 /// Atomic reusable ringbuffer
 ///


### PR DESCRIPTION
Replace use of `core::sync::atomic` by `atomic_polyfill`

Motivation: When playing with rust and `esp-rs/esp-wifi`, I noticed that the examples does not compile with the embassy master. 
This is quick fix for the problem. I noticed that the polyfill is used as drop-in replacement on other places

- Target: riscv32imc-unknown-none-elf
- Device: esp32c3