### PR TITLE
cortex-m/executor: don't use the owned interrupts system.

### DIFF
--- a/examples/stm32f0/Cargo.toml
+++ b/examples/stm32f0/Cargo.toml
@@ -15,5 +15,5 @@ panic-probe = "0.3"
 embassy-sync = { version = "0.1.0", path = "../../embassy-sync", features = ["defmt"] }
 embassy-executor = { version = "0.1.0", path = "../../embassy-executor", features = ["defmt", "integrated-timers"] }
 embassy-time = { version = "0.1.0", path = "../../embassy-time", features = ["defmt", "defmt-timestamp-uptime", "tick-hz-32_768"] }
-embassy-stm32 = { version = "0.1.0", path = "../../embassy-stm32", features = ["nightly", "defmt", "memory-x", "stm32f091rc", "time-driver-any", "exti"] }
+embassy-stm32 = { version = "0.1.0", path = "../../embassy-stm32", features = ["nightly", "defmt", "memory-x", "stm32f091rc", "time-driver-any", "exti", "unstable-pac"] }
 static_cell = "1.0"

--- a/examples/stm32f3/src/bin/multiprio.rs
+++ b/examples/stm32f3/src/bin/multiprio.rs
@@ -57,11 +57,14 @@
 #![no_main]
 #![feature(type_alias_impl_trait)]
 
+use core::mem;
+
+use cortex_m::peripheral::NVIC;
 use cortex_m_rt::entry;
 use defmt::*;
 use embassy_stm32::executor::{Executor, InterruptExecutor};
 use embassy_stm32::interrupt;
-use embassy_stm32::interrupt::InterruptExt;
+use embassy_stm32::pac::Interrupt;
 use embassy_time::{Duration, Instant, Timer};
 use static_cell::StaticCell;
 use {defmt_rtt as _, panic_probe as _};
@@ -108,28 +111,35 @@ async fn run_low() {
     }
 }
 
-static EXECUTOR_HIGH: StaticCell<InterruptExecutor<interrupt::UART4>> = StaticCell::new();
-static EXECUTOR_MED: StaticCell<InterruptExecutor<interrupt::UART5>> = StaticCell::new();
+static EXECUTOR_HIGH: InterruptExecutor = InterruptExecutor::new();
+static EXECUTOR_MED: InterruptExecutor = InterruptExecutor::new();
 static EXECUTOR_LOW: StaticCell<Executor> = StaticCell::new();
+
+#[interrupt]
+unsafe fn UART4() {
+    EXECUTOR_HIGH.on_interrupt()
+}
+
+#[interrupt]
+unsafe fn UART5() {
+    EXECUTOR_MED.on_interrupt()
+}
 
 #[entry]
 fn main() -> ! {
     info!("Hello World!");
 
     let _p = embassy_stm32::init(Default::default());
+    let mut nvic: NVIC = unsafe { mem::transmute(()) };
 
-    // High-priority executor: SWI1_EGU1, priority level 6
-    let irq = interrupt::take!(UART4);
-    irq.set_priority(interrupt::Priority::P6);
-    let executor = EXECUTOR_HIGH.init(InterruptExecutor::new(irq));
-    let spawner = executor.start();
+    // High-priority executor: UART4, priority level 6
+    unsafe { nvic.set_priority(Interrupt::UART4, 6 << 4) };
+    let spawner = EXECUTOR_HIGH.start(Interrupt::UART4);
     unwrap!(spawner.spawn(run_high()));
 
-    // Medium-priority executor: SWI0_EGU0, priority level 7
-    let irq = interrupt::take!(UART5);
-    irq.set_priority(interrupt::Priority::P7);
-    let executor = EXECUTOR_MED.init(InterruptExecutor::new(irq));
-    let spawner = executor.start();
+    // Medium-priority executor: UART5, priority level 7
+    unsafe { nvic.set_priority(Interrupt::UART5, 7 << 4) };
+    let spawner = EXECUTOR_MED.start(Interrupt::UART5);
     unwrap!(spawner.spawn(run_med()));
 
     // Low priority executor: runs in thread mode, using WFE/SEV

--- a/examples/stm32f4/src/bin/multiprio.rs
+++ b/examples/stm32f4/src/bin/multiprio.rs
@@ -57,11 +57,14 @@
 #![no_main]
 #![feature(type_alias_impl_trait)]
 
+use core::mem;
+
+use cortex_m::peripheral::NVIC;
 use cortex_m_rt::entry;
 use defmt::*;
 use embassy_stm32::executor::{Executor, InterruptExecutor};
 use embassy_stm32::interrupt;
-use embassy_stm32::interrupt::InterruptExt;
+use embassy_stm32::pac::Interrupt;
 use embassy_time::{Duration, Instant, Timer};
 use static_cell::StaticCell;
 use {defmt_rtt as _, panic_probe as _};
@@ -108,28 +111,35 @@ async fn run_low() {
     }
 }
 
-static EXECUTOR_HIGH: StaticCell<InterruptExecutor<interrupt::UART4>> = StaticCell::new();
-static EXECUTOR_MED: StaticCell<InterruptExecutor<interrupt::UART5>> = StaticCell::new();
+static EXECUTOR_HIGH: InterruptExecutor = InterruptExecutor::new();
+static EXECUTOR_MED: InterruptExecutor = InterruptExecutor::new();
 static EXECUTOR_LOW: StaticCell<Executor> = StaticCell::new();
+
+#[interrupt]
+unsafe fn UART4() {
+    EXECUTOR_HIGH.on_interrupt()
+}
+
+#[interrupt]
+unsafe fn UART5() {
+    EXECUTOR_MED.on_interrupt()
+}
 
 #[entry]
 fn main() -> ! {
     info!("Hello World!");
 
     let _p = embassy_stm32::init(Default::default());
+    let mut nvic: NVIC = unsafe { mem::transmute(()) };
 
-    // High-priority executor: SWI1_EGU1, priority level 6
-    let irq = interrupt::take!(UART4);
-    irq.set_priority(interrupt::Priority::P6);
-    let executor = EXECUTOR_HIGH.init(InterruptExecutor::new(irq));
-    let spawner = executor.start();
+    // High-priority executor: UART4, priority level 6
+    unsafe { nvic.set_priority(Interrupt::UART4, 6 << 4) };
+    let spawner = EXECUTOR_HIGH.start(Interrupt::UART4);
     unwrap!(spawner.spawn(run_high()));
 
-    // Medium-priority executor: SWI0_EGU0, priority level 7
-    let irq = interrupt::take!(UART5);
-    irq.set_priority(interrupt::Priority::P7);
-    let executor = EXECUTOR_MED.init(InterruptExecutor::new(irq));
-    let spawner = executor.start();
+    // Medium-priority executor: UART5, priority level 7
+    unsafe { nvic.set_priority(Interrupt::UART5, 7 << 4) };
+    let spawner = EXECUTOR_MED.start(Interrupt::UART5);
     unwrap!(spawner.spawn(run_med()));
 
     // Low priority executor: runs in thread mode, using WFE/SEV


### PR DESCRIPTION
Preparation for #1224.

InterruptExecutor can't easily use the new interrupt binding system. The problem is the context pointer, I don't see an easy way to get it to the interrupt handler. I don't want to add a `context` pointer to all interrupts in the new system.

Use manual interrupt handlers for now. We can add a nicer macro on top of the current API later.

(Interestingly, the reason this is not an issue in HALs is  because the impls are made by macros, so each irq handler can be gen'd with its own static state, because the HAL knows all the interrupts that exist. Not the case in embassy-cortex-m though...)