### PR TITLE
`PacketQueue::init()`

### DIFF
--- a/embassy-stm32/src/eth/mod.rs
+++ b/embassy-stm32/src/eth/mod.rs
@@ -30,13 +30,24 @@ pub struct PacketQueue<const TX: usize, const RX: usize> {
 
 impl<const TX: usize, const RX: usize> PacketQueue<TX, RX> {
     pub const fn new() -> Self {
-        const NEW_TDES: TDes = TDes::new();
-        const NEW_RDES: RDes = RDes::new();
-        Self {
-            tx_desc: [NEW_TDES; TX],
-            rx_desc: [NEW_RDES; RX],
-            tx_buf: [Packet([0; TX_BUFFER_SIZE]); TX],
-            rx_buf: [Packet([0; RX_BUFFER_SIZE]); RX],
+        #[cfg(feature = "nightly")]
+        {
+            let mut this = core::mem::MaybeUninit::uninit();
+            unsafe {
+                Self::init(&mut this);
+                this.assume_init()
+            }
+        }
+        #[cfg(not(feature = "nightly"))]
+        {
+            const NEW_TDES: TDes = TDes::new();
+            const NEW_RDES: RDes = RDes::new();
+            Self {
+                tx_desc: [NEW_TDES; TX],
+                rx_desc: [NEW_RDES; RX],
+                tx_buf: [Packet([0; TX_BUFFER_SIZE]); TX],
+                rx_buf: [Packet([0; RX_BUFFER_SIZE]); RX],
+            }
         }
     }
 

--- a/embassy-stm32/src/eth/mod.rs
+++ b/embassy-stm32/src/eth/mod.rs
@@ -39,6 +39,24 @@ impl<const TX: usize, const RX: usize> PacketQueue<TX, RX> {
             rx_buf: [Packet([0; RX_BUFFER_SIZE]); RX],
         }
     }
+
+    // Allow to initialize a Self without requiring it to go on the stack
+    #[cfg(feature = "nightly")]
+    pub const unsafe fn init(this: &mut core::mem::MaybeUninit<Self>) {
+        let this: &mut Self = unsafe { this.assume_init_mut() };
+        let mut i = 0;
+        while i < TX {
+            this.tx_desc[i] = TDes::new();
+            this.tx_buf[i] = Packet([0; TX_BUFFER_SIZE]);
+            i += 1;
+        }
+        i = 0;
+        while i < RX {
+            this.rx_desc[i] = RDes::new();
+            this.rx_buf[i] = Packet([0; RX_BUFFER_SIZE]);
+            i += 1;
+        }
+    }
 }
 
 static WAKER: AtomicWaker = AtomicWaker::new();

--- a/embassy-stm32/src/eth/mod.rs
+++ b/embassy-stm32/src/eth/mod.rs
@@ -42,8 +42,10 @@ impl<const TX: usize, const RX: usize> PacketQueue<TX, RX> {
     }
 
     // Allow to initialize a Self without requiring it to go on the stack
-    pub unsafe fn init(this: &mut MaybeUninit<Self>) {
-        this.as_mut_ptr().write_bytes(0u8, core::mem::size_of::<Self>());
+    pub fn init(this: &mut MaybeUninit<Self>) {
+        unsafe {
+            this.as_mut_ptr().write_bytes(0u8, core::mem::size_of::<Self>());
+        }
     }
 }
 

--- a/embassy-stm32/src/lib.rs
+++ b/embassy-stm32/src/lib.rs
@@ -1,13 +1,7 @@
 #![no_std]
 #![cfg_attr(
     feature = "nightly",
-    feature(
-        type_alias_impl_trait,
-        async_fn_in_trait,
-        impl_trait_projections,
-        const_mut_refs,
-        const_maybe_uninit_assume_init
-    )
+    feature(type_alias_impl_trait, async_fn_in_trait, impl_trait_projections)
 )]
 #![cfg_attr(feature = "nightly", allow(incomplete_features))]
 

--- a/embassy-stm32/src/lib.rs
+++ b/embassy-stm32/src/lib.rs
@@ -1,7 +1,13 @@
 #![no_std]
 #![cfg_attr(
     feature = "nightly",
-    feature(type_alias_impl_trait, async_fn_in_trait, impl_trait_projections)
+    feature(
+        type_alias_impl_trait,
+        async_fn_in_trait,
+        impl_trait_projections,
+        const_mut_refs,
+        const_maybe_uninit_assume_init
+    )
 )]
 #![cfg_attr(feature = "nightly", allow(incomplete_features))]
 


### PR DESCRIPTION
`PacketQueue` is pretty big, so I added a method to initialize it without requiring an allocation on the stack (which could in fact overflow). Before this PR, the only solution would be to declare a `PacketQueue` instance as a `static mut`, while now one could for example have a `Box<MaybeUninit<PacketQueue<...>>>` and then use `init()` on it.

Ideally, the same work would need to be done for all those structures that own big arrays which could overflow the stack.