### PR TITLE
Example fixes.

### DIFF
--- a/examples/nrf52840/src/bin/usb_ethernet.rs
+++ b/examples/nrf52840/src/bin/usb_ethernet.rs
@@ -46,31 +46,8 @@ async fn net_task(stack: &'static Stack<Device<'static, MTU>>) -> ! {
     stack.run().await
 }
 
-#[inline(never)]
-pub fn test_function() -> (usize, u32, [u32; 2]) {
-    let mut array = [3; 2];
-
-    let mut index = 0;
-    let mut result = 0;
-
-    for x in [1, 2] {
-        if x == 1 {
-            array[1] = 99;
-        } else {
-            index = if x == 2 { 1 } else { 0 };
-
-            // grabs value from array[0], not array[1]
-            result = array[index];
-        }
-    }
-
-    (index, result, array)
-}
-
 #[embassy_executor::main]
 async fn main(spawner: Spawner) {
-    info!("{:?}", test_function());
-
     let p = embassy_nrf::init(Default::default());
     let clock: pac::CLOCK = unsafe { mem::transmute(()) };
 

--- a/examples/nrf5340/Cargo.toml
+++ b/examples/nrf5340/Cargo.toml
@@ -4,24 +4,13 @@ name = "embassy-nrf5340-examples"
 version = "0.1.0"
 license = "MIT OR Apache-2.0"
 
-[features]
-default = ["nightly"]
-nightly = [
-    "embassy-executor/nightly",
-    "embassy-nrf/nightly",
-    "embassy-net/nightly",
-    "embassy-nrf/unstable-traits",
-    "embassy-usb",
-    "embedded-io/async",
-    "embassy-net",
-]
-
 [dependencies]
 embassy-futures = { version = "0.1.0", path = "../../embassy-futures" }
 embassy-sync = { version = "0.1.0", path = "../../embassy-sync", features = [
     "defmt",
 ] }
 embassy-executor = { version = "0.1.0", path = "../../embassy-executor", features = [
+    "nightly",
     "defmt",
     "integrated-timers",
 ] }
@@ -30,6 +19,8 @@ embassy-time = { version = "0.1.0", path = "../../embassy-time", features = [
     "defmt-timestamp-uptime",
 ] }
 embassy-nrf = { version = "0.1.0", path = "../../embassy-nrf", features = [
+    "nightly",
+    "unstable-traits",
     "defmt",
     "nrf5340-app-s",
     "time-driver-rtc1",
@@ -37,16 +28,16 @@ embassy-nrf = { version = "0.1.0", path = "../../embassy-nrf", features = [
     "unstable-pac",
 ] }
 embassy-net = { version = "0.1.0", path = "../../embassy-net", features = [
+    "nightly",
     "defmt",
     "tcp",
     "dhcpv4",
     "medium-ethernet",
-], optional = true }
+] }
 embassy-usb = { version = "0.1.0", path = "../../embassy-usb", features = [
     "defmt",
-], optional = true }
-embedded-io = "0.4.0"
-
+] }
+embedded-io = { version = "0.4.0", features = [ "async" ]}
 
 defmt = "0.3"
 defmt-rtt = "0.4"

--- a/examples/stm32f4/Cargo.toml
+++ b/examples/stm32f4/Cargo.toml
@@ -10,7 +10,7 @@ embassy-executor = { version = "0.1.0", path = "../../embassy-executor", feature
 embassy-time = { version = "0.1.0", path = "../../embassy-time", features = ["defmt", "defmt-timestamp-uptime", "unstable-traits", "tick-hz-32_768"] }
 embassy-stm32 = { version = "0.1.0", path = "../../embassy-stm32", features = ["nightly", "unstable-traits", "defmt", "stm32f429zi", "unstable-pac", "memory-x", "time-driver-any", "exti"]  }
 embassy-usb = { version = "0.1.0", path = "../../embassy-usb", features = ["defmt"] }
-embassy-net = { version = "0.1.0", path = "../../embassy-net", features = ["defmt", "tcp", "dhcpv4", "medium-ethernet", "nightly"], optional = true }
+embassy-net = { version = "0.1.0", path = "../../embassy-net", features = ["defmt", "tcp", "dhcpv4", "medium-ethernet", "nightly"] }
 
 defmt = "0.3"
 defmt-rtt = "0.4"
@@ -26,10 +26,6 @@ nb = "1.0.0"
 embedded-storage = "0.3.0"
 micromath = "2.0.0"
 static_cell = "1.0"
-
-[[bin]]
-name = "usb_ethernet"
-required-features = ["embassy-net"]
 
 [profile.release]
 debug = 2

--- a/examples/stm32f4/src/bin/usb_ethernet.rs
+++ b/examples/stm32f4/src/bin/usb_ethernet.rs
@@ -100,8 +100,8 @@ async fn main(spawner: Spawner) {
     let (runner, device) = class.into_embassy_net_device::<MTU, 4, 4>(singleton!(NetState::new()), our_mac_addr);
     unwrap!(spawner.spawn(usb_ncm_task(runner)));
 
-    let config = embassy_net::ConfigStrategy::Dhcp;
-    //let config = embassy_net::ConfigStrategy::Static(embassy_net::Config {
+    let config = embassy_net::Config::Dhcp(Default::default());
+    //let config = embassy_net::Config::Static(embassy_net::StaticConfig {
     //    address: Ipv4Cidr::new(Ipv4Address::new(10, 42, 0, 61), 24),
     //    dns_servers: Vec::new(),
     //    gateway: Some(Ipv4Address::new(10, 42, 0, 1)),
@@ -114,12 +114,7 @@ async fn main(spawner: Spawner) {
     let seed = u64::from_le_bytes(seed);
 
     // Init network stack
-    let stack = &*singleton!(Stack::new(
-        device,
-        config,
-        singleton!(StackResources::<1, 2, 8>::new()),
-        seed
-    ));
+    let stack = &*singleton!(Stack::new(device, config, singleton!(StackResources::<2>::new()), seed));
 
     unwrap!(spawner.spawn(net_task(stack)));
 

--- a/examples/stm32l4/Cargo.toml
+++ b/examples/stm32l4/Cargo.toml
@@ -4,8 +4,6 @@ name = "embassy-stm32l4-examples"
 version = "0.1.0"
 license = "MIT OR Apache-2.0"
 
-[features]
-
 [dependencies]
 embassy-sync = { version = "0.1.0", path = "../../embassy-sync", features = ["defmt"] }
 embassy-executor = { version = "0.1.0", path = "../../embassy-executor", features = ["defmt", "integrated-timers"] }

--- a/examples/stm32l5/Cargo.toml
+++ b/examples/stm32l5/Cargo.toml
@@ -4,8 +4,6 @@ name = "embassy-stm32l5-examples"
 version = "0.1.0"
 license = "MIT OR Apache-2.0"
 
-[features]
-
 [dependencies]
 embassy-sync = { version = "0.1.0", path = "../../embassy-sync", features = ["defmt"] }
 embassy-executor = { version = "0.1.0", path = "../../embassy-executor", features = ["defmt", "integrated-timers"] }


### PR DESCRIPTION
- Avoid features except in nrf52840, stm32l0 which are the only ones tested in `ci_stable.sh`. It caused stm32f4 usb_ethernet to not get tested in CI and bitrot.
- Remove test code added accidentally :) 

bors r+