### PR TITLE
Remove initialiser generic from saadc

### DIFF
--- a/embassy-nrf/src/saadc.rs
+++ b/embassy-nrf/src/saadc.rs
@@ -466,7 +466,7 @@ impl<'d> Saadc<'d, 1> {
     /// that the size of this buffer can be less than the original buffer's size.
     /// A command is return from the closure that indicates whether the sampling
     /// should continue or stop.
-    pub async fn run_timer_sampler<I, S, const N0: usize>(
+    pub async fn run_timer_sampler<S, const N0: usize>(
         &mut self,
         bufs: &mut [[[i16; 1]; N0]; 2],
         sample_rate_divisor: u16,

--- a/examples/nrf52840/src/bin/saadc_continuous_one_ch.rs
+++ b/examples/nrf52840/src/bin/saadc_continuous_one_ch.rs
@@ -1,0 +1,52 @@
+#![no_std]
+#![no_main]
+#![feature(type_alias_impl_trait)]
+
+use defmt::info;
+use embassy_executor::Spawner;
+use embassy_nrf::saadc::{CallbackResult, ChannelConfig, Config, Saadc};
+use embassy_nrf::{bind_interrupts, saadc};
+use {defmt_rtt as _, panic_probe as _};
+
+// Demonstrates continuous sampling with one channel and the internal timer
+
+bind_interrupts!(struct Irqs {
+    SAADC => saadc::InterruptHandler;
+});
+
+#[embassy_executor::main]
+async fn main(_p: Spawner) {
+    let mut p = embassy_nrf::init(Default::default());
+    let config = Config::default();
+    let channel_1_config = ChannelConfig::single_ended(&mut p.P0_02);
+    let mut saadc = Saadc::new(p.SAADC, Irqs, config, [channel_1_config]);
+
+    saadc.calibrate().await;
+
+    let mut bufs = [[[0; 1]; 10]; 2];
+
+    let mut c = 0;
+    let mut a: i32 = 0;
+
+    saadc
+        .run_timer_sampler(&mut bufs, 2000, move |buf| {
+            // NOTE: It is important that the time spent within this callback
+            // does not exceed the time taken to acquire the 500 samples we
+            // have in this example, which would be 10us + 2us per
+            // sample * 500 = 6ms. You need to measure the time taken here
+            // and set the sample buffer size accordingly. Exceeding this
+            // time can lead to the peripheral re-writing the other buffer.
+            for b in buf {
+                a += b[0] as i32;
+            }
+            c += buf.len();
+            if c > 1000 {
+                a = a / c as i32;
+                info!("channel 1: {=i32}", a);
+                c = 0;
+                a = 0;
+            }
+            CallbackResult::Continue
+        })
+        .await;
+}


### PR DESCRIPTION
The initialiser generic is not required when using the `run_timer_sampler` method, and there is no example. This commit solves both.