### PR TITLE
Use atomic polyfill for core::sync::atomic.

### DIFF
--- a/embassy-executor/src/arch/riscv32.rs
+++ b/embassy-executor/src/arch/riscv32.rs
@@ -1,6 +1,7 @@
 use core::marker::PhantomData;
 use core::ptr;
-use core::sync::atomic::{AtomicBool, Ordering};
+
+use atomic_polyfill::{AtomicBool, Ordering};
 
 use super::{raw, Spawner};
 

--- a/embassy-hal-common/Cargo.toml
+++ b/embassy-hal-common/Cargo.toml
@@ -9,5 +9,6 @@ license = "MIT OR Apache-2.0"
 [dependencies]
 defmt = { version = "0.3", optional = true }
 log = { version = "0.4.14", optional = true }
+atomic-polyfill = "1.0.2"
 
 num-traits = { version = "0.2.14", default-features = false }

--- a/embassy-hal-common/src/atomic_ring_buffer.rs
+++ b/embassy-hal-common/src/atomic_ring_buffer.rs
@@ -1,5 +1,6 @@
 use core::slice;
-use core::sync::atomic::{AtomicPtr, AtomicUsize, Ordering};
+
+use atomic_polyfill::{AtomicPtr, AtomicUsize, Ordering};
 
 /// Atomic reusable ringbuffer
 ///


### PR DESCRIPTION
Hi, I ran into an issue with building embassy for the riscv32i-unknown-none-elf target.

This target's core lib does not contain sync::atomic, or it's empty. The imports to atomic-polyfill fixes the issue, and has been done for other parts of Embassy too.