### PR TITLE
Preliminary support for bootloader regions

### DIFF
--- a/embassy-boot/boot/src/lib.rs
+++ b/embassy-boot/boot/src/lib.rs
@@ -90,9 +90,8 @@ impl<const N: usize> AsMut<[u8]> for AlignedBuffer<N> {
 
 /// Extension of the embedded-storage flash type information with block size and erase value.
 pub trait Flash: NorFlash + ReadNorFlash {
-    /// The block size that should be used when writing to flash. For most builtin flashes, this is the same as the erase
-    /// size of the flash, but for external QSPI flash modules, this can be lower.
-    const BLOCK_SIZE: usize;
+    /// The block size that should be used when writing to flash.
+    const BLOCK_SIZE: usize = Self::WRITE_SIZE;
     /// The erase value of the flash. Typically the default of 0xFF is used, but some flashes use a different value.
     const ERASE_VALUE: u8 = 0xFF;
 }

--- a/embassy-boot/boot/src/lib.rs
+++ b/embassy-boot/boot/src/lib.rs
@@ -115,27 +115,6 @@ pub trait FlashConfig {
     fn state(&mut self) -> &mut Self::STATE;
 }
 
-impl<T> FlashConfig for &mut T
-where
-    T: FlashConfig,
-{
-    type STATE = T::STATE;
-    type ACTIVE = T::ACTIVE;
-    type DFU = T::DFU;
-
-    fn active(&mut self) -> &mut Self::ACTIVE {
-        T::active(self)
-    }
-
-    fn dfu(&mut self) -> &mut Self::DFU {
-        T::dfu(self)
-    }
-
-    fn state(&mut self) -> &mut Self::STATE {
-        T::state(self)
-    }
-}
-
 /// Trait defining the flash handles used for active and DFU partition
 pub trait BlockingFlashConfig {
     /// Flash type used for the state partition.
@@ -153,32 +132,9 @@ pub trait BlockingFlashConfig {
     fn state(&mut self) -> &mut Self::STATE;
 }
 
-impl<T> BlockingFlashConfig for &mut T
-where
-    T: BlockingFlashConfig,
-{
-    type STATE = T::STATE;
-    type ACTIVE = T::ACTIVE;
-    type DFU = T::DFU;
-
-    fn active(&mut self) -> &mut Self::ACTIVE {
-        T::active(self)
-    }
-
-    fn dfu(&mut self) -> &mut Self::DFU {
-        T::dfu(self)
-    }
-
-    fn state(&mut self) -> &mut Self::STATE {
-        T::state(self)
-    }
-}
-
 /// BootLoader works with any flash implementing embedded_storage and can also work with
 /// different page sizes and flash write sizes.
-pub struct BootLoader<F: BlockingFlashConfig> {
-    flash: F,
-
+pub struct BootLoader {
     // Page with current state of bootloader. The state partition has the following format:
     // | Range          | Description                                                                      |
     // | 0 - WRITE_SIZE | Magic indicating bootloader state. BOOT_MAGIC means boot, SWAP_MAGIC means swap. |
@@ -190,18 +146,13 @@ pub struct BootLoader<F: BlockingFlashConfig> {
     dfu: Partition,
 }
 
-impl<F: BlockingFlashConfig> BootLoader<F> {
+impl BootLoader {
     /// Create a new instance of a bootloader with the given partitions.
     ///
     /// - All partitions must be aligned with the PAGE_SIZE const generic parameter.
     /// - The dfu partition must be at least PAGE_SIZE bigger than the active partition.
-    pub fn new(flash: F, active: Partition, dfu: Partition, state: Partition) -> Self {
-        Self {
-            flash,
-            active,
-            dfu,
-            state,
-        }
+    pub fn new(active: Partition, dfu: Partition, state: Partition) -> Self {
+        Self { active, dfu, state }
     }
 
     /// Return the boot address for the active partition.
@@ -292,70 +243,90 @@ impl<F: BlockingFlashConfig> BootLoader<F> {
     /// |       DFU |            3 |      3 |      2 |      1 |      3 |
     /// +-----------+--------------+--------+--------+--------+--------+
     ///
-    pub fn prepare_boot(&mut self, magic: &mut [u8], page: &mut [u8]) -> Result<State, BootError> {
+    pub fn prepare_boot<P: BlockingFlashConfig>(
+        &mut self,
+        p: &mut P,
+        magic: &mut [u8],
+        page: &mut [u8],
+    ) -> Result<State, BootError> {
         // Ensure we have enough progress pages to store copy progress
-        assert_partitions(self.active, self.dfu, self.state, page.len(), F::STATE::WRITE_SIZE);
-        assert_eq!(magic.len(), F::STATE::WRITE_SIZE);
+        assert_partitions(self.active, self.dfu, self.state, page.len(), P::STATE::WRITE_SIZE);
+        assert_eq!(magic.len(), P::STATE::WRITE_SIZE);
 
         // Copy contents from partition N to active
-        let state = self.read_state(magic)?;
+        let state = self.read_state(p, magic)?;
         if state == State::Swap {
             //
             // Check if we already swapped. If we're in the swap state, this means we should revert
             // since the app has failed to mark boot as successful
             //
-            if !self.is_swapped(magic, page)? {
+            if !self.is_swapped(p, magic, page)? {
                 trace!("Swapping");
-                self.swap(magic, page)?;
+                self.swap(p, magic, page)?;
                 trace!("Swapping done");
             } else {
                 trace!("Reverting");
-                self.revert(magic, page)?;
+                self.revert(p, magic, page)?;
 
                 // Overwrite magic and reset progress
-                let state = self.flash.state();
-                magic.fill(!F::STATE::ERASE_VALUE);
-                state.write(self.state.from as u32, magic)?;
-                state.erase(self.state.from as u32, self.state.to as u32)?;
+                let fstate = p.state();
+                magic.fill(!P::STATE::ERASE_VALUE);
+                fstate.write(self.state.from as u32, magic)?;
+                fstate.erase(self.state.from as u32, self.state.to as u32)?;
 
                 magic.fill(BOOT_MAGIC);
-                state.write(self.state.from as u32, magic)?;
+                fstate.write(self.state.from as u32, magic)?;
             }
         }
         Ok(state)
     }
 
-    fn is_swapped(&mut self, magic: &mut [u8], page: &mut [u8]) -> Result<bool, BootError> {
+    fn is_swapped<P: BlockingFlashConfig>(
+        &mut self,
+        p: &mut P,
+        magic: &mut [u8],
+        page: &mut [u8],
+    ) -> Result<bool, BootError> {
         let page_size = page.len();
         let page_count = self.active.len() / page_size;
-        let progress = self.current_progress(magic)?;
+        let progress = self.current_progress(p, magic)?;
 
         Ok(progress >= page_count * 2)
     }
 
-    fn current_progress(&mut self, aligned: &mut [u8]) -> Result<usize, BootError> {
+    fn current_progress<P: BlockingFlashConfig>(
+        &mut self,
+        config: &mut P,
+        aligned: &mut [u8],
+    ) -> Result<usize, BootError> {
         let write_size = aligned.len();
         let max_index = ((self.state.len() - write_size) / write_size) - 1;
-        aligned.fill(!F::STATE::ERASE_VALUE);
+        aligned.fill(!P::STATE::ERASE_VALUE);
 
-        let state = self.flash.state();
+        let flash = config.state();
         for i in 0..max_index {
-            state.read((self.state.from + write_size + i * write_size) as u32, aligned)?;
+            flash.read((self.state.from + write_size + i * write_size) as u32, aligned)?;
 
-            if aligned.iter().any(|&b| b == F::STATE::ERASE_VALUE) {
+            if aligned.iter().any(|&b| b == P::STATE::ERASE_VALUE) {
                 return Ok(i);
             }
         }
         Ok(max_index)
     }
 
-    fn update_progress(&mut self, idx: usize, magic: &mut [u8]) -> Result<(), BootError> {
+    fn update_progress<P: BlockingFlashConfig>(
+        &mut self,
+        idx: usize,
+        p: &mut P,
+        magic: &mut [u8],
+    ) -> Result<(), BootError> {
+        let flash = p.state();
         let write_size = magic.len();
         let w = self.state.from + write_size + idx * write_size;
 
         let aligned = magic;
-        aligned.fill(!F::STATE::ERASE_VALUE);
-        self.flash.state().write(w as u32, aligned)?;
+        aligned.fill(!P::STATE::ERASE_VALUE);
+        flash.write(w as u32, aligned)?;
         Ok(())
     }
 
@@ -367,69 +338,65 @@ impl<F: BlockingFlashConfig> BootLoader<F> {
         self.dfu.from + n * page_size
     }
 
-    fn copy_page_once_to_active(
+    fn copy_page_once_to_active<P: BlockingFlashConfig>(
         &mut self,
         idx: usize,
         from_page: usize,
         to_page: usize,
+        p: &mut P,
         magic: &mut [u8],
         page: &mut [u8],
     ) -> Result<(), BootError> {
         let buf = page;
-        if self.current_progress(magic)? <= idx {
+        if self.current_progress(p, magic)? <= idx {
             let mut offset = from_page;
-            let dfu = self.flash.dfu();
-            for chunk in buf.chunks_mut(F::DFU::BLOCK_SIZE) {
-                dfu.read(offset as u32, chunk)?;
+            for chunk in buf.chunks_mut(P::DFU::BLOCK_SIZE) {
+                p.dfu().read(offset as u32, chunk)?;
                 offset += chunk.len();
             }
 
-            self.flash
-                .active()
-                .erase(to_page as u32, (to_page + buf.len()) as u32)?;
+            p.active().erase(to_page as u32, (to_page + buf.len()) as u32)?;
 
             let mut offset = to_page;
-            let active = self.flash.active();
-            for chunk in buf.chunks(F::ACTIVE::BLOCK_SIZE) {
-                active.write(offset as u32, chunk)?;
+            for chunk in buf.chunks(P::ACTIVE::BLOCK_SIZE) {
+                p.active().write(offset as u32, chunk)?;
                 offset += chunk.len();
             }
-            self.update_progress(idx, magic)?;
+            self.update_progress(idx, p, magic)?;
         }
         Ok(())
     }
 
-    fn copy_page_once_to_dfu(
+    fn copy_page_once_to_dfu<P: BlockingFlashConfig>(
         &mut self,
         idx: usize,
         from_page: usize,
         to_page: usize,
+        p: &mut P,
         magic: &mut [u8],
         page: &mut [u8],
     ) -> Result<(), BootError> {
         let buf = page;
-        if self.current_progress(magic)? <= idx {
+        if self.current_progress(p, magic)? <= idx {
             let mut offset = from_page;
-            let active = self.flash.active();
-            for chunk in buf.chunks_mut(F::ACTIVE::BLOCK_SIZE) {
-                active.read(offset as u32, chunk)?;
+            for chunk in buf.chunks_mut(P::ACTIVE::BLOCK_SIZE) {
+                p.active().read(offset as u32, chunk)?;
                 offset += chunk.len();
             }
 
-            let dfu = self.flash.dfu();
-            dfu.erase(to_page as u32, (to_page + buf.len()) as u32)?;
+            p.dfu().erase(to_page as u32, (to_page + buf.len()) as u32)?;
 
             let mut offset = to_page;
-            for chunk in buf.chunks(F::DFU::BLOCK_SIZE) {
-                dfu.write(offset as u32, chunk)?;
+            for chunk in buf.chunks(P::DFU::BLOCK_SIZE) {
+                p.dfu().write(offset as u32, chunk)?;
                 offset += chunk.len();
             }
-            self.update_progress(idx, magic)?;
+            self.update_progress(idx, p, magic)?;
         }
         Ok(())
     }
 
-    fn swap(&mut self, magic: &mut [u8], page: &mut [u8]) -> Result<(), BootError> {
+    fn swap<P: BlockingFlashConfig>(&mut self, p: &mut P, magic: &mut [u8], page: &mut [u8]) -> Result<(), BootError> {
         let page_size = page.len();
         let page_count = self.active.len() / page_size;
         trace!("Page count: {}", page_count);
@@ -439,38 +406,44 @@ impl<F: BlockingFlashConfig> BootLoader<F> {
             let active_page = self.active_addr(page_count - 1 - page_num, page_size);
             let dfu_page = self.dfu_addr(page_count - page_num, page_size);
             //trace!("Copy active {} to dfu {}", active_page, dfu_page);
-            self.copy_page_once_to_dfu(page_num * 2, active_page, dfu_page, magic, page)?;
+            self.copy_page_once_to_dfu(page_num * 2, active_page, dfu_page, p, magic, page)?;
 
             // Copy DFU page to the active page
             let active_page = self.active_addr(page_count - 1 - page_num, page_size);
             let dfu_page = self.dfu_addr(page_count - 1 - page_num, page_size);
             //trace!("Copy dfy {} to active {}", dfu_page, active_page);
-            self.copy_page_once_to_active(page_num * 2 + 1, dfu_page, active_page, magic, page)?;
+            self.copy_page_once_to_active(page_num * 2 + 1, dfu_page, active_page, p, magic, page)?;
         }
 
         Ok(())
     }
 
-    fn revert(&mut self, magic: &mut [u8], page: &mut [u8]) -> Result<(), BootError> {
+    fn revert<P: BlockingFlashConfig>(
+        &mut self,
+        p: &mut P,
+        magic: &mut [u8],
+        page: &mut [u8],
+    ) -> Result<(), BootError> {
         let page_size = page.len();
         let page_count = self.active.len() / page_size;
         for page_num in 0..page_count {
             // Copy the bad active page to the DFU page
             let active_page = self.active_addr(page_num, page_size);
             let dfu_page = self.dfu_addr(page_num, page_size);
-            self.copy_page_once_to_dfu(page_count * 2 + page_num * 2, active_page, dfu_page, magic, page)?;
+            self.copy_page_once_to_dfu(page_count * 2 + page_num * 2, active_page, dfu_page, p, magic, page)?;
 
             // Copy the DFU page back to the active page
             let active_page = self.active_addr(page_num, page_size);
             let dfu_page = self.dfu_addr(page_num + 1, page_size);
-            self.copy_page_once_to_active(page_count * 2 + page_num * 2 + 1, dfu_page, active_page, magic, page)?;
+            self.copy_page_once_to_active(page_count * 2 + page_num * 2 + 1, dfu_page, active_page, p, magic, page)?;
         }
 
         Ok(())
     }
 
-    fn read_state(&mut self, magic: &mut [u8]) -> Result<State, BootError> {
-        self.flash.state().read(self.state.from as u32, magic)?;
+    fn read_state<P: BlockingFlashConfig>(&mut self, config: &mut P, magic: &mut [u8]) -> Result<State, BootError> {
+        let flash = config.state();
+        flash.read(self.state.from as u32, magic)?;
 
         if !magic.iter().any(|&b| b != SWAP_MAGIC) {
             Ok(State::Swap)
@@ -700,27 +673,13 @@ where
 
 /// FirmwareUpdater is an application API for interacting with the BootLoader without the ability to
 /// 'mess up' the internal bootloader state
-pub struct FirmwareUpdater<F> {
-    flash: F,
+pub struct FirmwareUpdater {
     state: Partition,
     dfu: Partition,
 }
 
-impl<F> FirmwareUpdater<F> {
-    /// Return the length of the DFU area
-    pub fn firmware_len(&self) -> usize {
-        self.dfu.len()
-    }
-}
-
-impl<F: FlashConfig> FirmwareUpdater<F> {
-    /// Create a firmware updater instance with partition ranges for the update and state partitions.
-    pub fn new(flash: F, dfu: Partition, state: Partition) -> Self {
-        Self { flash, dfu, state }
-    }
-
-    /// Create a firmware updater instance with partition ranges for the update and state partitions.
-    pub fn with_defaults(flash: F) -> Self {
+impl Default for FirmwareUpdater {
+    fn default() -> Self {
         extern "C" {
             static __bootloader_state_start: u32;
             static __bootloader_state_end: u32;
@@ -743,8 +702,19 @@ impl<F: FlashConfig> FirmwareUpdater<F> {
 
         trace!("DFU: 0x{:x} - 0x{:x}", dfu.from, dfu.to);
         trace!("STATE: 0x{:x} - 0x{:x}", state.from, state.to);
+        FirmwareUpdater::new(dfu, state)
+    }
+}
 
-        Self::new(flash, dfu, state)
+impl FirmwareUpdater {
+    /// Create a firmware updater instance with partition ranges for the update and state partitions.
+    pub const fn new(dfu: Partition, state: Partition) -> Self {
+        Self { dfu, state }
+    }
+
+    /// Return the length of the DFU area
+    pub fn firmware_len(&self) -> usize {
+        self.dfu.len()
     }
 
     /// Obtain the current state.
@@ -752,8 +722,12 @@ impl<F: FlashConfig> FirmwareUpdater<F> {
     /// This is useful to check if the bootloader has just done a swap, in order
     /// to do verifications and self-tests of the new image before calling
     /// `mark_booted`.
-    pub async fn get_state(&mut self, aligned: &mut [u8]) -> Result<State, FirmwareUpdaterError> {
-        self.flash.state().read(self.state.from as u32, aligned).await?;
+    pub async fn get_state<F: FlashConfig>(
+        &mut self,
+        flash: &mut F,
+        aligned: &mut [u8],
+    ) -> Result<State, FirmwareUpdaterError> {
+        flash.state().read(self.state.from as u32, aligned).await?;
 
         if !aligned.iter().any(|&b| b != SWAP_MAGIC) {
             Ok(State::Swap)
@@ -779,14 +753,15 @@ impl<F: FlashConfig> FirmwareUpdater<F> {
     /// The `_aligned` buffer must have a size of F::WRITE_SIZE, and follow the alignment rules for the flash being read from
     /// and written to.
     #[cfg(feature = "_verify")]
-    pub async fn verify_and_mark_updated(
+    pub async fn verify_and_mark_updated<F: FlashConfig>(
         &mut self,
+        _flash: &mut F,
         _public_key: &[u8],
         _signature: &[u8],
         _update_len: usize,
         _aligned: &mut [u8],
     ) -> Result<(), FirmwareUpdaterError> {
-        let _dfu = self.flash.dfu();
+        let _dfu = _flash.dfu();
         let _end = self.dfu.from + _update_len;
         let _read_size = _aligned.len();
 
@@ -877,9 +852,13 @@ impl<F: FlashConfig> FirmwareUpdater<F> {
     ///
     /// The `aligned` buffer must have a size of F::WRITE_SIZE, and follow the alignment rules for the flash being written to.
     #[cfg(not(feature = "_verify"))]
-    pub async fn mark_updated(&mut self, aligned: &mut [u8]) -> Result<(), FirmwareUpdaterError> {
+    pub async fn mark_updated<F: FlashConfig>(
+        &mut self,
+        flash: &mut F,
+        aligned: &mut [u8],
+    ) -> Result<(), FirmwareUpdaterError> {
         assert_eq!(aligned.len(), F::STATE::WRITE_SIZE);
-        self.set_magic(aligned, SWAP_MAGIC).await
+        self.set_magic(aligned, SWAP_MAGIC, flash).await
     }
 
     /// Mark firmware boot successful and stop rollback on reset.
@@ -887,13 +866,22 @@ impl<F: FlashConfig> FirmwareUpdater<F> {
     /// # Safety
     ///
     /// The `aligned` buffer must have a size of F::WRITE_SIZE, and follow the alignment rules for the flash being written to.
-    pub async fn mark_booted(&mut self, aligned: &mut [u8]) -> Result<(), FirmwareUpdaterError> {
+    pub async fn mark_booted<F: FlashConfig>(
+        &mut self,
+        flash: &mut F,
+        aligned: &mut [u8],
+    ) -> Result<(), FirmwareUpdaterError> {
         assert_eq!(aligned.len(), F::STATE::WRITE_SIZE);
-        self.set_magic(aligned, BOOT_MAGIC).await
+        self.set_magic(aligned, BOOT_MAGIC, flash).await
     }
 
-    async fn set_magic(&mut self, aligned: &mut [u8], magic: u8) -> Result<(), FirmwareUpdaterError> {
-        let state = self.flash.state();
+    async fn set_magic<F: FlashConfig>(
+        &mut self,
+        aligned: &mut [u8],
+        magic: u8,
+        flash: &mut F,
+    ) -> Result<(), FirmwareUpdaterError> {
+        let state = flash.state();
         state.read(self.state.from as u32, aligned).await?;
 
         if aligned.iter().any(|&b| b != magic) {
@@ -915,10 +903,15 @@ impl<F: FlashConfig> FirmwareUpdater<F> {
     /// # Safety
     ///
     /// Failing to meet alignment and size requirements may result in a panic.
-    pub async fn write_firmware(&mut self, offset: usize, data: &[u8]) -> Result<(), FirmwareUpdaterError> {
+    pub async fn write_firmware<F: FlashConfig>(
+        &mut self,
+        flash: &mut F,
+        offset: usize,
+        data: &[u8],
+    ) -> Result<(), FirmwareUpdaterError> {
         assert!(data.len() >= F::DFU::ERASE_SIZE);
 
-        let dfu = self.flash.dfu();
+        let dfu = flash.dfu();
         dfu.erase(
             (self.dfu.from + offset) as u32,
             (self.dfu.from + offset + data.len()) as u32,
@@ -942,31 +935,32 @@ impl<F: FlashConfig> FirmwareUpdater<F> {
     ///
     /// Using this instead of `write_firmware` allows for an optimized API in
     /// exchange for added complexity.
-    pub async fn prepare_update(&mut self) -> Result<FirmwareWriter, FirmwareUpdaterError> {
-        self.flash
-            .dfu()
-            .erase((self.dfu.from) as u32, (self.dfu.to) as u32)
-            .await?;
+    pub async fn prepare_update<F: FlashConfig>(
+        &mut self,
+        flash: &mut F,
+    ) -> Result<FirmwareWriter, FirmwareUpdaterError> {
+        flash.dfu().erase((self.dfu.from) as u32, (self.dfu.to) as u32).await?;
 
         trace!("Erased from {} to {}", self.dfu.from, self.dfu.to);
 
         Ok(FirmwareWriter::new(self.dfu))
     }
-}
 
-impl<F: BlockingFlashConfig> FirmwareUpdater<F> {
-    /// Create a firmware updater instance with partition ranges for the update and state partitions.
-    pub fn new_blocking(flash: F, dfu: Partition, state: Partition) -> Self {
-        Self { flash, dfu, state }
-    }
+    //
+    // Blocking API
+    //
 
     /// Obtain the current state.
     ///
     /// This is useful to check if the bootloader has just done a swap, in order
     /// to do verifications and self-tests of the new image before calling
     /// `mark_booted`.
-    pub fn get_state_blocking(&mut self, aligned: &mut [u8]) -> Result<State, FirmwareUpdaterError> {
-        self.flash.state().read(self.state.from as u32, aligned)?;
+    pub fn get_state_blocking<F: BlockingFlashConfig>(
+        &mut self,
+        flash: &mut F,
+        aligned: &mut [u8],
+    ) -> Result<State, FirmwareUpdaterError> {
+        flash.state().read(self.state.from as u32, aligned)?;
 
         if !aligned.iter().any(|&b| b != SWAP_MAGIC) {
             Ok(State::Swap)
@@ -994,12 +988,13 @@ impl<F: BlockingFlashConfig> FirmwareUpdater<F> {
     #[cfg(feature = "_verify")]
     pub fn verify_and_mark_updated_blocking<F: BlockingFlashConfig>(
         &mut self,
+        _flash: &mut F,
         _public_key: &[u8],
         _signature: &[u8],
         _update_len: usize,
         _aligned: &mut [u8],
     ) -> Result<(), FirmwareUpdaterError> {
-        let _dfu = self.flash.dfu();
+        let _dfu = _flash.dfu();
         let _end = self.dfu.from + _update_len;
         let _read_size = _aligned.len();
 
@@ -1090,9 +1085,13 @@ impl<F: BlockingFlashConfig> FirmwareUpdater<F> {
     ///
     /// The `aligned` buffer must have a size of F::WRITE_SIZE, and follow the alignment rules for the flash being written to.
     #[cfg(not(feature = "_verify"))]
-    pub fn mark_updated_blocking(&mut self, aligned: &mut [u8]) -> Result<(), FirmwareUpdaterError> {
+    pub fn mark_updated_blocking<F: BlockingFlashConfig>(
+        &mut self,
+        flash: &mut F,
+        aligned: &mut [u8],
+    ) -> Result<(), FirmwareUpdaterError> {
         assert_eq!(aligned.len(), F::STATE::WRITE_SIZE);
-        self.set_magic_blocking(aligned, SWAP_MAGIC)
+        self.set_magic_blocking(aligned, SWAP_MAGIC, flash)
     }
 
     /// Mark firmware boot successful and stop rollback on reset.
@@ -1100,13 +1099,22 @@ impl<F: BlockingFlashConfig> FirmwareUpdater<F> {
     /// # Safety
     ///
     /// The `aligned` buffer must have a size of F::WRITE_SIZE, and follow the alignment rules for the flash being written to.
-    pub fn mark_booted_blocking(&mut self, aligned: &mut [u8]) -> Result<(), FirmwareUpdaterError> {
+    pub fn mark_booted_blocking<F: BlockingFlashConfig>(
+        &mut self,
+        flash: &mut F,
+        aligned: &mut [u8],
+    ) -> Result<(), FirmwareUpdaterError> {
         assert_eq!(aligned.len(), F::STATE::WRITE_SIZE);
-        self.set_magic_blocking(aligned, BOOT_MAGIC)
+        self.set_magic_blocking(aligned, BOOT_MAGIC, flash)
     }
 
-    fn set_magic_blocking(&mut self, aligned: &mut [u8], magic: u8) -> Result<(), FirmwareUpdaterError> {
-        let state = self.flash.state();
+    fn set_magic_blocking<F: BlockingFlashConfig>(
+        &mut self,
+        aligned: &mut [u8],
+        magic: u8,
+        flash: &mut F,
+    ) -> Result<(), FirmwareUpdaterError> {
+        let state = flash.state();
         state.read(self.state.from as u32, aligned)?;
 
         if aligned.iter().any(|&b| b != magic) {
@@ -1128,10 +1136,15 @@ impl<F: BlockingFlashConfig> FirmwareUpdater<F> {
     /// # Safety
     ///
     /// Failing to meet alignment and size requirements may result in a panic.
-    pub fn write_firmware_blocking(&mut self, offset: usize, data: &[u8]) -> Result<(), FirmwareUpdaterError> {
+    pub fn write_firmware_blocking<F: BlockingFlashConfig>(
+        &mut self,
+        flash: &mut F,
+        offset: usize,
+        data: &[u8],
+    ) -> Result<(), FirmwareUpdaterError> {
         assert!(data.len() >= F::DFU::ERASE_SIZE);
 
-        let dfu = self.flash.dfu();
+        let dfu = flash.dfu();
         dfu.erase(
             (self.dfu.from + offset) as u32,
             (self.dfu.from + offset + data.len()) as u32,
@@ -1154,8 +1167,11 @@ impl<F: BlockingFlashConfig> FirmwareUpdater<F> {
     ///
     /// Using this instead of `write_firmware_blocking` allows for an optimized
     /// API in exchange for added complexity.
-    pub fn prepare_update_blocking(&mut self) -> Result<FirmwareWriter, FirmwareUpdaterError> {
-        self.flash.dfu().erase((self.dfu.from) as u32, (self.dfu.to) as u32)?;
+    pub fn prepare_update_blocking<F: BlockingFlashConfig>(
+        &mut self,
+        flash: &mut F,
+    ) -> Result<FirmwareWriter, FirmwareUpdaterError> {
+        flash.dfu().erase((self.dfu.from) as u32, (self.dfu.to) as u32)?;
 
         trace!("Erased from {} to {}", self.dfu.from, self.dfu.to);
 
@@ -1239,11 +1255,14 @@ mod tests {
         flash.0[0..4].copy_from_slice(&[BOOT_MAGIC; 4]);
         let mut flash = SingleFlashConfig::new(&mut flash);
 
-        let mut bootloader = BootLoader::new(&mut flash, ACTIVE, DFU, STATE);
+        let mut bootloader: BootLoader = BootLoader::new(ACTIVE, DFU, STATE);
 
         let mut magic = [0; 4];
         let mut page = [0; 4096];
-        assert_eq!(State::Boot, bootloader.prepare_boot(&mut magic, &mut page).unwrap());
+        assert_eq!(
+            State::Boot,
+            bootloader.prepare_boot(&mut flash, &mut magic, &mut page).unwrap()
+        );
     }
 
     #[test]
@@ -1258,6 +1277,8 @@ mod tests {
         let update: [u8; DFU.len()] = [rand::random::<u8>(); DFU.len()];
         let mut aligned = [0; 4];
 
+        let mut bootloader: BootLoader = BootLoader::new(ACTIVE, DFU, STATE);
+        let mut updater = FirmwareUpdater::new(DFU, STATE);
         let mut magic = [0; 4];
         let mut page = [0; 4096];
 
@@ -1267,22 +1288,20 @@ mod tests {
 
         {
             let mut flash_config = SingleFlashConfig::new(&mut flash);
-            let mut updater = FirmwareUpdater::new(&mut flash_config, DFU, STATE);
 
             let mut offset = 0;
             for chunk in update.chunks(4096) {
-                block_on(updater.write_firmware(offset, chunk)).unwrap();
+                block_on(updater.write_firmware(&mut flash_config, offset, chunk)).unwrap();
                 offset += chunk.len();
             }
+            block_on(updater.mark_updated(&mut flash_config, &mut aligned)).unwrap();
 
-            block_on(updater.mark_updated(&mut aligned)).unwrap();
-        }
-
-        {
-            let mut flash_config = SingleFlashConfig::new(&mut flash);
-            let mut bootloader = BootLoader::new(&mut flash_config, ACTIVE, DFU, STATE);
-
-            assert_eq!(State::Swap, bootloader.prepare_boot(&mut magic, &mut page).unwrap());
+            assert_eq!(
+                State::Swap,
+                bootloader
+                    .prepare_boot(&mut flash_config, &mut magic, &mut page)
+                    .unwrap()
+            );
         }
 
         for i in ACTIVE.from..ACTIVE.to {
@@ -1296,10 +1315,14 @@ mod tests {
 
         {
             let mut flash_config = SingleFlashConfig::new(&mut flash);
-            let mut bootloader = BootLoader::new(&mut flash_config, ACTIVE, DFU, STATE);
 
             // Running again should cause a revert
-            assert_eq!(State::Swap, bootloader.prepare_boot(&mut magic, &mut page).unwrap());
+            assert_eq!(
+                State::Swap,
+                bootloader
+                    .prepare_boot(&mut flash_config, &mut magic, &mut page)
+                    .unwrap()
+            );
         }
 
         for i in ACTIVE.from..ACTIVE.to {
@@ -1313,17 +1336,15 @@ mod tests {
 
         {
             let mut flash_config = SingleFlashConfig::new(&mut flash);
-            let mut updater = FirmwareUpdater::new(&mut flash_config, DFU, STATE);
 
             // Mark as booted
-            block_on(updater.mark_booted(&mut aligned)).unwrap();
-        }
-
-        {
-            let mut flash_config = SingleFlashConfig::new(&mut flash);
-            let mut bootloader = BootLoader::new(&mut flash_config, ACTIVE, DFU, STATE);
-
-            assert_eq!(State::Boot, bootloader.prepare_boot(&mut magic, &mut page).unwrap());
+            block_on(updater.mark_booted(&mut flash_config, &mut aligned)).unwrap();
+            assert_eq!(
+                State::Boot,
+                bootloader
+                    .prepare_boot(&mut SingleFlashConfig::new(&mut flash), &mut magic, &mut page)
+                    .unwrap()
+            );
         }
     }
 
@@ -1346,26 +1367,32 @@ mod tests {
             active.0[i] = original[i - ACTIVE.from];
         }
 
+        let mut updater = FirmwareUpdater::new(DFU, STATE);
+
         {
             let mut flash_config = MultiFlashConfig::new(&mut active, &mut state, &mut dfu);
-            let mut updater = FirmwareUpdater::new(&mut flash_config, DFU, STATE);
 
             let mut offset = 0;
             for chunk in update.chunks(2048) {
-                block_on(updater.write_firmware(offset, chunk)).unwrap();
+                block_on(updater.write_firmware(&mut flash_config, offset, chunk)).unwrap();
                 offset += chunk.len();
             }
-            block_on(updater.mark_updated(&mut aligned)).unwrap();
+            block_on(updater.mark_updated(&mut flash_config, &mut aligned)).unwrap();
         }
 
+        let mut bootloader: BootLoader = BootLoader::new(ACTIVE, DFU, STATE);
         let mut magic = [0; 4];
         let mut page = [0; 4096];
 
         {
             let mut flash_config = MultiFlashConfig::new(&mut active, &mut state, &mut dfu);
-            let mut bootloader = BootLoader::new(&mut flash_config, ACTIVE, DFU, STATE);
 
-            assert_eq!(State::Swap, bootloader.prepare_boot(&mut magic, &mut page).unwrap());
+            assert_eq!(
+                State::Swap,
+                bootloader
+                    .prepare_boot(&mut flash_config, &mut magic, &mut page)
+                    .unwrap()
+            );
         }
 
         for i in ACTIVE.from..ACTIVE.to {
@@ -1397,26 +1424,32 @@ mod tests {
             active.0[i] = original[i - ACTIVE.from];
         }
 
+        let mut updater = FirmwareUpdater::new(DFU, STATE);
+
         {
             let mut flash_config = MultiFlashConfig::new(&mut active, &mut state, &mut dfu);
-            let mut updater = FirmwareUpdater::new(&mut flash_config, DFU, STATE);
 
             let mut offset = 0;
             for chunk in update.chunks(4096) {
-                block_on(updater.write_firmware(offset, chunk)).unwrap();
+                block_on(updater.write_firmware(&mut flash_config, offset, chunk)).unwrap();
                 offset += chunk.len();
             }
-            block_on(updater.mark_updated(&mut aligned)).unwrap();
+            block_on(updater.mark_updated(&mut flash_config, &mut aligned)).unwrap();
         }
 
+        let mut bootloader: BootLoader = BootLoader::new(ACTIVE, DFU, STATE);
         let mut magic = [0; 4];
         let mut page = [0; 4096];
 
         {
             let mut flash_config = MultiFlashConfig::new(&mut active, &mut state, &mut dfu);
-            let mut bootloader = BootLoader::new(&mut flash_config, ACTIVE, DFU, STATE);
 
-            assert_eq!(State::Swap, bootloader.prepare_boot(&mut magic, &mut page).unwrap());
+            assert_eq!(
+                State::Swap,
+                bootloader
+                    .prepare_boot(&mut flash_config, &mut magic, &mut page)
+                    .unwrap()
+            );
         }
 
         for i in ACTIVE.from..ACTIVE.to {

--- a/embassy-boot/stm32/src/lib.rs
+++ b/embassy-boot/stm32/src/lib.rs
@@ -4,28 +4,54 @@
 #![doc = include_str!("../README.md")]
 mod fmt;
 
-use embassy_boot::BlockingFlashConfig;
 pub use embassy_boot::{AlignedBuffer, BootFlash, FirmwareUpdater, FlashConfig, Partition, SingleFlashConfig, State};
 
 /// A bootloader for STM32 devices.
-pub struct BootLoader<F: BlockingFlashConfig> {
-    boot: embassy_boot::BootLoader<F>,
-    magic: AlignedBuffer<F::STATE::WRITE_SIZE>,
-    page: AlignedBuffer<F::STATE::WRITE_SIZE>,
+pub struct BootLoader<const PAGE_SIZE: usize, const WRITE_SIZE: usize> {
+    boot: embassy_boot::BootLoader,
+    magic: AlignedBuffer<WRITE_SIZE>,
+    page: AlignedBuffer<PAGE_SIZE>,
 }
 
-impl<F: BlockingFlashConfig> BootLoader<F> {
+impl<const PAGE_SIZE: usize, const WRITE_SIZE: usize> BootLoader<PAGE_SIZE, WRITE_SIZE> {
     /// Create a new bootloader instance using the supplied partitions for active, dfu and state.
-    pub fn new(flash: F, active: Partition, dfu: Partition, state: Partition) -> Self {
+    pub fn new(active: Partition, dfu: Partition, state: Partition) -> Self {
         Self {
-            boot: embassy_boot::BootLoader::new(flash, active, dfu, state),
+            boot: embassy_boot::BootLoader::new(active, dfu, state),
             magic: AlignedBuffer([0; WRITE_SIZE]),
             page: AlignedBuffer([0; PAGE_SIZE]),
         }
     }
 
+    /// Inspect the bootloader state and perform actions required before booting, such as swapping
+    /// firmware.
+    pub fn prepare<F: FlashConfig>(&mut self, flash: &mut F) -> usize {
+        match self.boot.prepare_boot(flash, self.magic.as_mut(), self.page.as_mut()) {
+            Ok(_) => embassy_stm32::flash::FLASH_BASE + self.boot.boot_address(),
+            Err(_) => panic!("boot prepare error!"),
+        }
+    }
+
+    /// Boots the application.
+    ///
+    /// # Safety
+    ///
+    /// This modifies the stack pointer and reset vector and will run code placed in the active partition.
+    pub unsafe fn load(&mut self, start: usize) -> ! {
+        trace!("Loading app at 0x{:x}", start);
+        #[allow(unused_mut)]
+        let mut p = cortex_m::Peripherals::steal();
+        #[cfg(not(armv6m))]
+        p.SCB.invalidate_icache();
+        p.SCB.vtor.write(start as u32);
+
+        cortex_m::asm::bootload(start as *const u32)
+    }
+}
+
+impl<const PAGE_SIZE: usize, const WRITE_SIZE: usize> Default for BootLoader<PAGE_SIZE, WRITE_SIZE> {
     /// Create a new bootloader instance using parameters from linker script
-    pub fn with_defaults(flash: F) -> Self {
+    fn default() -> Self {
         extern "C" {
             static __bootloader_state_start: u32;
             static __bootloader_state_end: u32;
@@ -58,31 +84,6 @@ impl<F: BlockingFlashConfig> BootLoader<F> {
         trace!("DFU: 0x{:x} - 0x{:x}", dfu.from, dfu.to);
         trace!("STATE: 0x{:x} - 0x{:x}", state.from, state.to);
 
-        Self::new(flash, active, dfu, state)
-    }
-
-    /// Inspect the bootloader state and perform actions required before booting, such as swapping
-    /// firmware.
-    pub fn prepare(&mut self) -> usize {
-        match self.boot.prepare_boot(self.magic.as_mut(), self.page.as_mut()) {
-            Ok(_) => embassy_stm32::flash::FLASH_BASE + self.boot.boot_address(),
-            Err(_) => panic!("boot prepare error!"),
-        }
-    }
-
-    /// Boots the application.
-    ///
-    /// # Safety
-    ///
-    /// This modifies the stack pointer and reset vector and will run code placed in the active partition.
-    pub unsafe fn load(&mut self, start: usize) -> ! {
-        trace!("Loading app at 0x{:x}", start);
-        #[allow(unused_mut)]
-        let mut p = cortex_m::Peripherals::steal();
-        #[cfg(not(armv6m))]
-        p.SCB.invalidate_icache();
-        p.SCB.vtor.write(start as u32);
-
-        cortex_m::asm::bootload(start as *const u32)
+        Self::new(active, dfu, state)
     }
 }


### PR DESCRIPTION
This PR makes it easier to add support for multiple flash regions in the bootloader. It contains:
* Redefintion of the `Flash` trait. It now only includes required fields. Any blocking or async storage traits must be added manually.
* Let there be both a `FlashConfig` and a `BlockingFlashConfig`
* Let Bootloader and FirmwareUpdater have the flash config as a member so that they internally can request mut ref's for each of the flash regions depending on their need.
* Remove Bootloader::default() and FirmwareUpdater::default() - they must now be new'ed with their respective config.
* Let firmware writer track the written number of bytes instead of relying on passing the offset

I have only aligned the embassy-boot-stm32 project with the changes. Depending on feedback I can align the others as well.

I am splitting the PR here to avoid too many changes when supporting multiple regions.

cc @lulf 