### PR TITLE
(embassy-stm32): rework bufferedUart to get rid of PeripheralMutex

### DIFF
--- a/embassy-stm32/src/usart/mod.rs
+++ b/embassy-stm32/src/usart/mod.rs
@@ -1112,6 +1112,9 @@ pub(crate) mod sealed {
 
         fn regs() -> Regs;
         fn state() -> &'static State;
+
+        #[cfg(feature = "nightly")]
+        fn buffered_state() -> &'static buffered::State;
     }
 
     pub trait FullInstance: BasicInstance {
@@ -1145,6 +1148,12 @@ macro_rules! impl_lpuart {
 
             fn state() -> &'static crate::usart::sealed::State {
                 static STATE: crate::usart::sealed::State = crate::usart::sealed::State::new();
+                &STATE
+            }
+
+            #[cfg(feature = "nightly")]
+            fn buffered_state() -> &'static buffered::State {
+                static STATE: buffered::State = buffered::State::new();
                 &STATE
             }
         }

--- a/examples/stm32f4/src/bin/usart_buffered.rs
+++ b/examples/stm32f4/src/bin/usart_buffered.rs
@@ -5,7 +5,7 @@
 use defmt::*;
 use embassy_executor::Spawner;
 use embassy_stm32::interrupt;
-use embassy_stm32::usart::{BufferedUart, Config, State};
+use embassy_stm32::usart::{BufferedUart, Config};
 use embedded_io::asynch::BufRead;
 use {defmt_rtt as _, panic_probe as _};
 
@@ -16,20 +16,10 @@ async fn main(_spawner: Spawner) {
 
     let config = Config::default();
 
-    let mut state = State::new();
     let irq = interrupt::take!(USART3);
     let mut tx_buf = [0u8; 32];
     let mut rx_buf = [0u8; 32];
-    let mut buf_usart = BufferedUart::new(
-        &mut state,
-        p.USART3,
-        p.PD9,
-        p.PD8,
-        irq,
-        &mut tx_buf,
-        &mut rx_buf,
-        config,
-    );
+    let mut buf_usart = BufferedUart::new(p.USART3, irq, p.PD9, p.PD8, &mut tx_buf, &mut rx_buf, config);
 
     loop {
         let buf = buf_usart.fill_buf().await.unwrap();

--- a/examples/stm32l0/src/bin/usart_irq.rs
+++ b/examples/stm32l0/src/bin/usart_irq.rs
@@ -5,7 +5,7 @@
 use defmt::*;
 use embassy_executor::Spawner;
 use embassy_stm32::interrupt;
-use embassy_stm32::usart::{BufferedUart, Config, State};
+use embassy_stm32::usart::{BufferedUart, Config};
 use embedded_io::asynch::{Read, Write};
 use {defmt_rtt as _, panic_probe as _};
 
@@ -20,20 +20,8 @@ async fn main(_spawner: Spawner) {
     let mut config = Config::default();
     config.baudrate = 9600;
 
-    let mut state = State::new();
     let irq = interrupt::take!(USART2);
-    let mut usart = unsafe {
-        BufferedUart::new(
-            &mut state,
-            p.USART2,
-            p.PA3,
-            p.PA2,
-            irq,
-            &mut TX_BUFFER,
-            &mut RX_BUFFER,
-            config,
-        )
-    };
+    let mut usart = unsafe { BufferedUart::new(p.USART2, irq, p.PA3, p.PA2, &mut TX_BUFFER, &mut RX_BUFFER, config) };
 
     usart.write_all(b"Hello Embassy World!\r\n").await.unwrap();
     info!("wrote Hello, starting echo");


### PR DESCRIPTION
New implementation is very similar to the implementation of embassy-nrf & embassy-rp. 

Also adds embedded-hal traits to bufferedUart.

**NB**: Still needs testing on actual hardware