### PR TITLE
Let the bootloader block-size be decoupled from the flash

### DIFF
--- a/embassy-boot/boot/src/boot_loader.rs
+++ b/embassy-boot/boot/src/boot_loader.rs
@@ -48,11 +48,11 @@ pub trait FlashConfig {
     const BLOCK_SIZE: usize;
 
     /// Flash type used for the state partition.
-    type STATE: NorFlash + ReadNorFlash;
+    type STATE: NorFlash;
     /// Flash type used for the active partition.
-    type ACTIVE: NorFlash + ReadNorFlash;
+    type ACTIVE: NorFlash;
     /// Flash type used for the dfu partition.
-    type DFU: NorFlash + ReadNorFlash;
+    type DFU: NorFlash;
 
     /// Return flash instance used to write/read to/from active partition.
     fn active(&mut self) -> &mut Self::ACTIVE;

--- a/embassy-boot/boot/src/lib.rs
+++ b/embassy-boot/boot/src/lib.rs
@@ -10,7 +10,7 @@ mod firmware_updater;
 mod firmware_writer;
 mod partition;
 
-pub use boot_loader::{BootError, BootFlash, BootLoader, Flash, FlashConfig, MultiFlashConfig, SingleFlashConfig};
+pub use boot_loader::{BootError, BootFlash, BootLoader, FlashConfig, MultiFlashConfig, SingleFlashConfig};
 pub use firmware_updater::{FirmwareUpdater, FirmwareUpdaterError};
 pub use firmware_writer::FirmwareWriter;
 pub use partition::Partition;
@@ -357,12 +357,6 @@ mod tests {
         fn capacity(&self) -> usize {
             SIZE
         }
-    }
-
-    impl<const SIZE: usize, const ERASE_SIZE: usize, const WRITE_SIZE: usize> super::Flash
-        for MemFlash<SIZE, ERASE_SIZE, WRITE_SIZE>
-    {
-        const ERASE_VALUE: u8 = 0xFF;
     }
 
     impl<const SIZE: usize, const ERASE_SIZE: usize, const WRITE_SIZE: usize> AsyncReadNorFlash

--- a/embassy-boot/boot/src/mem_flash.rs
+++ b/embassy-boot/boot/src/mem_flash.rs
@@ -1,0 +1,170 @@
+#![allow(unused)]
+
+use core::convert::Infallible;
+use core::ops::{Bound, Range, RangeBounds};
+
+use embedded_storage::nor_flash::{ErrorType, NorFlash, ReadNorFlash};
+use embedded_storage_async::nor_flash::{NorFlash as AsyncNorFlash, ReadNorFlash as AsyncReadNorFlash};
+
+pub struct MemFlash<const SIZE: usize, const ERASE_SIZE: usize, const WRITE_SIZE: usize> {
+    pub mem: [u8; SIZE],
+    pub verify_erased_before_write: Range<usize>,
+}
+
+impl<const SIZE: usize, const ERASE_SIZE: usize, const WRITE_SIZE: usize> MemFlash<SIZE, ERASE_SIZE, WRITE_SIZE> {
+    pub const fn new(fill: u8) -> Self {
+        Self {
+            mem: [fill; SIZE],
+            verify_erased_before_write: 0..SIZE,
+        }
+    }
+
+    #[cfg(test)]
+    pub fn random() -> Self {
+        let mut mem = [0; SIZE];
+        for byte in mem.iter_mut() {
+            *byte = rand::random::<u8>();
+        }
+        Self {
+            mem,
+            verify_erased_before_write: 0..SIZE,
+        }
+    }
+
+    #[must_use]
+    pub fn with_limited_erase_before_write_verification<R: RangeBounds<usize>>(self, verified_range: R) -> Self {
+        let start = match verified_range.start_bound() {
+            Bound::Included(start) => *start,
+            Bound::Excluded(start) => *start + 1,
+            Bound::Unbounded => 0,
+        };
+        let end = match verified_range.end_bound() {
+            Bound::Included(end) => *end - 1,
+            Bound::Excluded(end) => *end,
+            Bound::Unbounded => self.mem.len(),
+        };
+        Self {
+            mem: self.mem,
+            verify_erased_before_write: start..end,
+        }
+    }
+}
+
+impl<const SIZE: usize, const ERASE_SIZE: usize, const WRITE_SIZE: usize> Default
+    for MemFlash<SIZE, ERASE_SIZE, WRITE_SIZE>
+{
+    fn default() -> Self {
+        Self::new(0xFF)
+    }
+}
+
+impl<const SIZE: usize, const ERASE_SIZE: usize, const WRITE_SIZE: usize> ErrorType
+    for MemFlash<SIZE, ERASE_SIZE, WRITE_SIZE>
+{
+    type Error = Infallible;
+}
+
+impl<const SIZE: usize, const ERASE_SIZE: usize, const WRITE_SIZE: usize> ReadNorFlash
+    for MemFlash<SIZE, ERASE_SIZE, WRITE_SIZE>
+{
+    const READ_SIZE: usize = 1;
+
+    fn read(&mut self, offset: u32, bytes: &mut [u8]) -> Result<(), Self::Error> {
+        let len = bytes.len();
+        bytes.copy_from_slice(&self.mem[offset as usize..offset as usize + len]);
+        Ok(())
+    }
+
+    fn capacity(&self) -> usize {
+        SIZE
+    }
+}
+
+impl<const SIZE: usize, const ERASE_SIZE: usize, const WRITE_SIZE: usize> NorFlash
+    for MemFlash<SIZE, ERASE_SIZE, WRITE_SIZE>
+{
+    const WRITE_SIZE: usize = WRITE_SIZE;
+    const ERASE_SIZE: usize = ERASE_SIZE;
+
+    fn erase(&mut self, from: u32, to: u32) -> Result<(), Self::Error> {
+        let from = from as usize;
+        let to = to as usize;
+        assert!(from % ERASE_SIZE == 0);
+        assert!(to % ERASE_SIZE == 0, "To: {}, erase size: {}", to, ERASE_SIZE);
+        for i in from..to {
+            self.mem[i] = 0xFF;
+        }
+        Ok(())
+    }
+
+    fn write(&mut self, offset: u32, bytes: &[u8]) -> Result<(), Self::Error> {
+        let offset = offset as usize;
+        assert!(bytes.len() % WRITE_SIZE == 0);
+        assert!(offset % WRITE_SIZE == 0);
+        assert!(offset + bytes.len() <= SIZE);
+
+        for ((offset, mem_byte), new_byte) in self
+            .mem
+            .iter_mut()
+            .enumerate()
+            .skip(offset)
+            .take(bytes.len())
+            .zip(bytes)
+        {
+            if self.verify_erased_before_write.contains(&offset) {
+                assert_eq!(0xFF, *mem_byte, "Offset {} is not erased", offset);
+            }
+            *mem_byte &= *new_byte;
+        }
+
+        Ok(())
+    }
+}
+
+impl<const SIZE: usize, const ERASE_SIZE: usize, const WRITE_SIZE: usize> AsyncReadNorFlash
+    for MemFlash<SIZE, ERASE_SIZE, WRITE_SIZE>
+{
+    const READ_SIZE: usize = 1;
+
+    async fn read(&mut self, offset: u32, bytes: &mut [u8]) -> Result<(), Self::Error> {
+        <Self as ReadNorFlash>::read(self, offset, bytes)
+    }
+
+    fn capacity(&self) -> usize {
+        <Self as ReadNorFlash>::capacity(self)
+    }
+}
+
+impl<const SIZE: usize, const ERASE_SIZE: usize, const WRITE_SIZE: usize> AsyncNorFlash
+    for MemFlash<SIZE, ERASE_SIZE, WRITE_SIZE>
+{
+    const WRITE_SIZE: usize = WRITE_SIZE;
+    const ERASE_SIZE: usize = ERASE_SIZE;
+
+    async fn erase(&mut self, from: u32, to: u32) -> Result<(), Self::Error> {
+        <Self as NorFlash>::erase(self, from, to)
+    }
+
+    async fn write(&mut self, offset: u32, bytes: &[u8]) -> Result<(), Self::Error> {
+        <Self as NorFlash>::write(self, offset, bytes)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use core::ops::Range;
+
+    use embedded_storage::nor_flash::NorFlash;
+
+    use super::MemFlash;
+
+    #[test]
+    fn writes_only_flip_bits_from_1_to_0() {
+        let mut flash = MemFlash::<16, 16, 1>::default().with_limited_erase_before_write_verification(0..0);
+
+        flash.write(0, &[0x55]).unwrap();
+        flash.write(0, &[0xAA]).unwrap();
+
+        assert_eq!(0x00, flash.mem[0]);
+    }
+}

--- a/embassy-boot/boot/src/partition.rs
+++ b/embassy-boot/boot/src/partition.rs
@@ -105,45 +105,45 @@ impl Partition {
 
 #[cfg(test)]
 mod tests {
-    use crate::tests::MemFlash;
+    use crate::mem_flash::MemFlash;
     use crate::Partition;
 
     #[test]
     fn can_erase() {
-        let mut flash = MemFlash::<1024, 64, 4>([0x00; 1024]);
+        let mut flash = MemFlash::<1024, 64, 4>::new(0x00);
         let partition = Partition::new(256, 512);
 
         partition.erase_blocking(&mut flash, 64, 192).unwrap();
 
-        for (index, byte) in flash.0.iter().copied().enumerate().take(256 + 64) {
+        for (index, byte) in flash.mem.iter().copied().enumerate().take(256 + 64) {
             assert_eq!(0x00, byte, "Index {}", index);
         }
 
-        for (index, byte) in flash.0.iter().copied().enumerate().skip(256 + 64).take(128) {
+        for (index, byte) in flash.mem.iter().copied().enumerate().skip(256 + 64).take(128) {
             assert_eq!(0xFF, byte, "Index {}", index);
         }
 
-        for (index, byte) in flash.0.iter().copied().enumerate().skip(256 + 64 + 128) {
+        for (index, byte) in flash.mem.iter().copied().enumerate().skip(256 + 64 + 128) {
             assert_eq!(0x00, byte, "Index {}", index);
         }
     }
 
     #[test]
     fn can_wipe() {
-        let mut flash = MemFlash::<1024, 64, 4>([0x00; 1024]);
+        let mut flash = MemFlash::<1024, 64, 4>::new(0x00);
         let partition = Partition::new(256, 512);
 
         partition.wipe_blocking(&mut flash).unwrap();
 
-        for (index, byte) in flash.0.iter().copied().enumerate().take(256) {
+        for (index, byte) in flash.mem.iter().copied().enumerate().take(256) {
             assert_eq!(0x00, byte, "Index {}", index);
         }
 
-        for (index, byte) in flash.0.iter().copied().enumerate().skip(256).take(256) {
+        for (index, byte) in flash.mem.iter().copied().enumerate().skip(256).take(256) {
             assert_eq!(0xFF, byte, "Index {}", index);
         }
 
-        for (index, byte) in flash.0.iter().copied().enumerate().skip(512) {
+        for (index, byte) in flash.mem.iter().copied().enumerate().skip(512) {
             assert_eq!(0x00, byte, "Index {}", index);
         }
     }

--- a/embassy-boot/stm32/src/lib.rs
+++ b/embassy-boot/stm32/src/lib.rs
@@ -7,26 +7,24 @@ mod fmt;
 pub use embassy_boot::{AlignedBuffer, BootFlash, FirmwareUpdater, FlashConfig, Partition, SingleFlashConfig, State};
 
 /// A bootloader for STM32 devices.
-pub struct BootLoader<const PAGE_SIZE: usize, const WRITE_SIZE: usize> {
+pub struct BootLoader<const BLOCK_SIZE: usize> {
     boot: embassy_boot::BootLoader,
-    magic: AlignedBuffer<WRITE_SIZE>,
-    page: AlignedBuffer<PAGE_SIZE>,
+    block_buffer: AlignedBuffer<BLOCK_SIZE>,
 }
 
-impl<const PAGE_SIZE: usize, const WRITE_SIZE: usize> BootLoader<PAGE_SIZE, WRITE_SIZE> {
+impl<const BLOCK_SIZE: usize> BootLoader<BLOCK_SIZE> {
     /// Create a new bootloader instance using the supplied partitions for active, dfu and state.
     pub fn new(active: Partition, dfu: Partition, state: Partition) -> Self {
         Self {
             boot: embassy_boot::BootLoader::new(active, dfu, state),
-            magic: AlignedBuffer([0; WRITE_SIZE]),
-            page: AlignedBuffer([0; PAGE_SIZE]),
+            block_buffer: AlignedBuffer([0; BLOCK_SIZE]),
         }
     }
 
     /// Inspect the bootloader state and perform actions required before booting, such as swapping
     /// firmware.
     pub fn prepare<F: FlashConfig>(&mut self, flash: &mut F) -> usize {
-        match self.boot.prepare_boot(flash, self.magic.as_mut(), self.page.as_mut()) {
+        match self.boot.prepare_boot(flash, self.block_buffer.as_mut()) {
             Ok(_) => embassy_stm32::flash::FLASH_BASE + self.boot.boot_address(),
             Err(_) => panic!("boot prepare error!"),
         }
@@ -49,7 +47,7 @@ impl<const PAGE_SIZE: usize, const WRITE_SIZE: usize> BootLoader<PAGE_SIZE, WRIT
     }
 }
 
-impl<const PAGE_SIZE: usize, const WRITE_SIZE: usize> Default for BootLoader<PAGE_SIZE, WRITE_SIZE> {
+impl<const BLOCK_SIZE: usize> Default for BootLoader<BLOCK_SIZE> {
     /// Create a new bootloader instance using parameters from linker script
     fn default() -> Self {
         extern "C" {


### PR DESCRIPTION
This changes the block copy operation sequence.
Previously the assumption was that we could have an entire flash-erase-size in memory. Now, erases are done on a per-need basis, and writes are always tracked on a well-defined block size.

This allows the block-size tracked by the bootloader to be much smaller than the flash-erase-size.

The work is based on https://github.com/embassy-rs/embassy/pull/1312
cc @lulf 