### PR TITLE
stm32/usart: fix unstable traits

### DIFF
--- a/embassy-stm32/src/usart/buffered.rs
+++ b/embassy-stm32/src/usart/buffered.rs
@@ -589,11 +589,23 @@ mod eh1 {
         type Error = Error;
     }
 
+    impl<'d, T: BasicInstance> embedded_hal_nb::serial::ErrorType for BufferedUart<'d, T> {
+        type Error = Error;
+    }
+
     impl<'d, T: BasicInstance> embedded_hal_1::serial::ErrorType for BufferedUartTx<'d, T> {
         type Error = Error;
     }
 
+    impl<'d, T: BasicInstance> embedded_hal_nb::serial::ErrorType for BufferedUartTx<'d, T> {
+        type Error = Error;
+    }
+
     impl<'d, T: BasicInstance> embedded_hal_1::serial::ErrorType for BufferedUartRx<'d, T> {
+        type Error = Error;
+    }
+
+    impl<'d, T: BasicInstance> embedded_hal_nb::serial::ErrorType for BufferedUartRx<'d, T> {
         type Error = Error;
     }
 

--- a/embassy-stm32/src/usart/mod.rs
+++ b/embassy-stm32/src/usart/mod.rs
@@ -856,7 +856,23 @@ mod eh1 {
         }
     }
 
+    impl embedded_hal_nb::serial::Error for Error {
+        fn kind(&self) -> embedded_hal_nb::serial::ErrorKind {
+            match *self {
+                Self::Framing => embedded_hal_nb::serial::ErrorKind::FrameFormat,
+                Self::Noise => embedded_hal_nb::serial::ErrorKind::Noise,
+                Self::Overrun => embedded_hal_nb::serial::ErrorKind::Overrun,
+                Self::Parity => embedded_hal_nb::serial::ErrorKind::Parity,
+                Self::BufferTooLong => embedded_hal_nb::serial::ErrorKind::Other,
+            }
+        }
+    }
+
     impl<'d, T: BasicInstance, TxDma, RxDma> embedded_hal_1::serial::ErrorType for Uart<'d, T, TxDma, RxDma> {
+        type Error = Error;
+    }
+
+    impl<'d, T: BasicInstance, TxDma, RxDma> embedded_hal_nb::serial::ErrorType for Uart<'d, T, TxDma, RxDma> {
         type Error = Error;
     }
 
@@ -864,7 +880,15 @@ mod eh1 {
         type Error = Error;
     }
 
+    impl<'d, T: BasicInstance, TxDma> embedded_hal_nb::serial::ErrorType for UartTx<'d, T, TxDma> {
+        type Error = Error;
+    }
+
     impl<'d, T: BasicInstance, RxDma> embedded_hal_1::serial::ErrorType for UartRx<'d, T, RxDma> {
+        type Error = Error;
+    }
+
+    impl<'d, T: BasicInstance, RxDma> embedded_hal_nb::serial::ErrorType for UartRx<'d, T, RxDma> {
         type Error = Error;
     }
 


### PR DESCRIPTION
The update to embedded-hal-nb led to warnings as discussed in chat. These changes appear to fix the problem.