### PR TITLE
Added a neopixel constructor to spi, with an example in the stm32g0 d…

### DIFF
--- a/embassy-stm32/src/dma/bdma.rs
+++ b/embassy-stm32/src/dma/bdma.rs
@@ -9,7 +9,8 @@ use embassy_cortex_m::interrupt::Priority;
 use embassy_hal_common::{into_ref, Peripheral, PeripheralRef};
 use embassy_sync::waitqueue::AtomicWaker;
 
-use super::{Dir, Word, WordSize};
+use super::word::{Word, WordSize};
+use super::Dir;
 use crate::_generated::BDMA_CHANNEL_COUNT;
 use crate::interrupt::{Interrupt, InterruptExt};
 use crate::pac;
@@ -167,7 +168,7 @@ impl<'a, C: Channel> Transfer<'a, C> {
             ptr as *mut u32,
             len,
             true,
-            W::bits(),
+            W::size(),
             options,
         )
     }
@@ -202,7 +203,7 @@ impl<'a, C: Channel> Transfer<'a, C> {
             ptr as *mut u32,
             len,
             true,
-            W::bits(),
+            W::size(),
             options,
         )
     }
@@ -225,7 +226,7 @@ impl<'a, C: Channel> Transfer<'a, C> {
             repeated as *const W as *mut u32,
             count,
             false,
-            W::bits(),
+            W::size(),
             options,
         )
     }

--- a/embassy-stm32/src/dma/dma.rs
+++ b/embassy-stm32/src/dma/dma.rs
@@ -9,7 +9,8 @@ use embassy_hal_common::{into_ref, Peripheral, PeripheralRef};
 use embassy_sync::waitqueue::AtomicWaker;
 use pac::dma::regs;
 
-use super::{Dir, Word, WordSize};
+use super::word::{Word, WordSize};
+use super::Dir;
 use crate::_generated::DMA_CHANNEL_COUNT;
 use crate::interrupt::{Interrupt, InterruptExt};
 use crate::pac::dma::vals;
@@ -246,7 +247,7 @@ impl<'a, C: Channel> Transfer<'a, C> {
             ptr as *mut u32,
             len,
             true,
-            W::bits(),
+            W::size(),
             options,
         )
     }
@@ -281,7 +282,7 @@ impl<'a, C: Channel> Transfer<'a, C> {
             ptr as *mut u32,
             len,
             true,
-            W::bits(),
+            W::size(),
             options,
         )
     }
@@ -304,7 +305,7 @@ impl<'a, C: Channel> Transfer<'a, C> {
             repeated as *const W as *mut u32,
             count,
             false,
-            W::bits(),
+            W::size(),
             options,
         )
     }
@@ -464,7 +465,7 @@ impl<'a, C: Channel, W: Word> DoubleBuffered<'a, C, W> {
         assert!(len > 0 && len <= 0xFFFF);
 
         let dir = Dir::PeripheralToMemory;
-        let data_size = W::bits();
+        let data_size = W::size();
 
         let channel_number = channel.num();
         let dma = channel.regs();

--- a/embassy-stm32/src/dma/gpdma.rs
+++ b/embassy-stm32/src/dma/gpdma.rs
@@ -9,7 +9,8 @@ use embassy_cortex_m::interrupt::Priority;
 use embassy_hal_common::{into_ref, Peripheral, PeripheralRef};
 use embassy_sync::waitqueue::AtomicWaker;
 
-use super::{Dir, Word, WordSize};
+use super::word::{Word, WordSize};
+use super::Dir;
 use crate::_generated::GPDMA_CHANNEL_COUNT;
 use crate::interrupt::{Interrupt, InterruptExt};
 use crate::pac;
@@ -165,7 +166,7 @@ impl<'a, C: Channel> Transfer<'a, C> {
             ptr as *mut u32,
             len,
             true,
-            W::bits(),
+            W::size(),
             options,
         )
     }
@@ -200,7 +201,7 @@ impl<'a, C: Channel> Transfer<'a, C> {
             ptr as *mut u32,
             len,
             true,
-            W::bits(),
+            W::size(),
             options,
         )
     }
@@ -223,7 +224,7 @@ impl<'a, C: Channel> Transfer<'a, C> {
             repeated as *const W as *mut u32,
             count,
             false,
-            W::bits(),
+            W::size(),
             options,
         )
     }

--- a/embassy-stm32/src/dma/mod.rs
+++ b/embassy-stm32/src/dma/mod.rs
@@ -21,6 +21,8 @@ pub use gpdma::*;
 #[cfg(dmamux)]
 mod dmamux;
 
+pub mod word;
+
 use core::mem;
 
 use embassy_cortex_m::interrupt::Priority;
@@ -34,53 +36,6 @@ pub use self::dmamux::*;
 enum Dir {
     MemoryToPeripheral,
     PeripheralToMemory,
-}
-
-#[derive(Debug, Copy, Clone, PartialEq, Eq)]
-#[cfg_attr(feature = "defmt", derive(defmt::Format))]
-pub enum WordSize {
-    OneByte,
-    TwoBytes,
-    FourBytes,
-}
-
-impl WordSize {
-    pub fn bytes(&self) -> usize {
-        match self {
-            Self::OneByte => 1,
-            Self::TwoBytes => 2,
-            Self::FourBytes => 4,
-        }
-    }
-}
-
-mod word_sealed {
-    pub trait Word {}
-}
-
-pub trait Word: word_sealed::Word {
-    fn bits() -> WordSize;
-}
-
-impl word_sealed::Word for u8 {}
-impl Word for u8 {
-    fn bits() -> WordSize {
-        WordSize::OneByte
-    }
-}
-
-impl word_sealed::Word for u16 {}
-impl Word for u16 {
-    fn bits() -> WordSize {
-        WordSize::TwoBytes
-    }
-}
-
-impl word_sealed::Word for u32 {}
-impl Word for u32 {
-    fn bits() -> WordSize {
-        WordSize::FourBytes
-    }
 }
 
 pub struct NoDma;

--- a/embassy-stm32/src/dma/word.rs
+++ b/embassy-stm32/src/dma/word.rs
@@ -1,0 +1,79 @@
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+pub enum WordSize {
+    OneByte,
+    TwoBytes,
+    FourBytes,
+}
+
+impl WordSize {
+    pub fn bytes(&self) -> usize {
+        match self {
+            Self::OneByte => 1,
+            Self::TwoBytes => 2,
+            Self::FourBytes => 4,
+        }
+    }
+}
+
+mod sealed {
+    pub trait Word {}
+}
+
+pub trait Word: sealed::Word + Default + Copy + 'static {
+    fn size() -> WordSize;
+    fn bits() -> usize;
+}
+
+macro_rules! impl_word {
+    (_, $T:ident, $bits:literal, $size:ident) => {
+        impl sealed::Word for $T {}
+        impl Word for $T {
+            fn bits() -> usize {
+                $bits
+            }
+            fn size() -> WordSize {
+                WordSize::$size
+            }
+        }
+    };
+    ($T:ident, $uX:ident, $bits:literal, $size:ident) => {
+        #[repr(transparent)]
+        #[derive(Copy, Clone, Default)]
+        pub struct $T(pub $uX);
+        impl_word!(_, $T, $bits, $size);
+    };
+}
+
+impl_word!(U1, u8, 1, OneByte);
+impl_word!(U2, u8, 2, OneByte);
+impl_word!(U3, u8, 3, OneByte);
+impl_word!(U4, u8, 4, OneByte);
+impl_word!(U5, u8, 5, OneByte);
+impl_word!(U6, u8, 6, OneByte);
+impl_word!(U7, u8, 7, OneByte);
+impl_word!(_, u8, 8, OneByte);
+impl_word!(U9, u16, 9, TwoBytes);
+impl_word!(U10, u16, 10, TwoBytes);
+impl_word!(U11, u16, 11, TwoBytes);
+impl_word!(U12, u16, 12, TwoBytes);
+impl_word!(U13, u16, 13, TwoBytes);
+impl_word!(U14, u16, 14, TwoBytes);
+impl_word!(U15, u16, 15, TwoBytes);
+impl_word!(_, u16, 16, TwoBytes);
+impl_word!(U17, u32, 17, FourBytes);
+impl_word!(U18, u32, 18, FourBytes);
+impl_word!(U19, u32, 19, FourBytes);
+impl_word!(U20, u32, 20, FourBytes);
+impl_word!(U21, u32, 21, FourBytes);
+impl_word!(U22, u32, 22, FourBytes);
+impl_word!(U23, u32, 23, FourBytes);
+impl_word!(U24, u32, 24, FourBytes);
+impl_word!(U25, u32, 25, FourBytes);
+impl_word!(U26, u32, 26, FourBytes);
+impl_word!(U27, u32, 27, FourBytes);
+impl_word!(U28, u32, 28, FourBytes);
+impl_word!(U29, u32, 29, FourBytes);
+impl_word!(U30, u32, 30, FourBytes);
+impl_word!(U31, u32, 31, FourBytes);
+impl_word!(_, u32, 32, FourBytes);

--- a/embassy-stm32/src/spi/mod.rs
+++ b/embassy-stm32/src/spi/mod.rs
@@ -177,6 +177,23 @@ impl<'d, T: Instance, Tx, Rx> Spi<'d, T, Tx, Rx> {
         )
     }
 
+    pub fn new_txonly_nosck(
+        peri: impl Peripheral<P = T> + 'd,
+        mosi: impl Peripheral<P = impl MosiPin<T>> + 'd,
+        txdma: impl Peripheral<P = Tx> + 'd,
+        rxdma: impl Peripheral<P = Rx> + 'd, // TODO: remove
+        freq: Hertz,
+        config: Config,
+    ) -> Self {
+        into_ref!(mosi);
+        unsafe {
+            mosi.set_as_af_pull(mosi.af_num(), AFType::OutputPushPull, Pull::Down);
+            mosi.set_speed(crate::gpio::Speed::Medium);
+        }
+
+        Self::new_inner(peri, None, Some(mosi.map_into()), None, txdma, rxdma, freq, config)
+    }
+
     /// Useful for on chip peripherals like SUBGHZ which are hardwired.
     /// The bus can optionally be exposed externally with `Spi::new()` still.
     #[allow(dead_code)]

--- a/examples/stm32g0/src/bin/spi_neopixel.rs
+++ b/examples/stm32g0/src/bin/spi_neopixel.rs
@@ -1,0 +1,101 @@
+#![no_std]
+#![no_main]
+#![feature(type_alias_impl_trait)]
+
+use defmt::*;
+use embassy_executor::Spawner;
+use embassy_stm32::dma::word::U5;
+use embassy_stm32::dma::NoDma;
+use embassy_stm32::spi::{Config, Spi};
+use embassy_stm32::time::Hertz;
+use embassy_time::{Duration, Timer};
+use {defmt_rtt as _, panic_probe as _};
+
+const NR_PIXELS: usize = 15;
+const BITS_PER_PIXEL: usize = 24; // 24 for rgb, 32 for rgbw
+const TOTAL_BITS: usize = NR_PIXELS * BITS_PER_PIXEL;
+
+struct RGB {
+    r: u8,
+    g: u8,
+    b: u8,
+}
+impl Default for RGB {
+    fn default() -> RGB {
+        RGB { r: 0, g: 0, b: 0 }
+    }
+}
+pub struct Ws2812 {
+    // Note that the U5 type controls the selection of 5 bits to output
+    bitbuffer: [U5; TOTAL_BITS],
+}
+
+impl Ws2812 {
+    pub fn new() -> Ws2812 {
+        Ws2812 {
+            bitbuffer: [U5(0); TOTAL_BITS],
+        }
+    }
+    fn len(&self) -> usize {
+        return NR_PIXELS;
+    }
+    fn set(&mut self, idx: usize, rgb: RGB) {
+        self.render_color(idx, 0, rgb.g);
+        self.render_color(idx, 8, rgb.r);
+        self.render_color(idx, 16, rgb.b);
+    }
+    // transform one color byte into an array of 8 byte. Each byte in the array does represent 1 neopixel bit pattern
+    fn render_color(&mut self, pixel_idx: usize, offset: usize, color: u8) {
+        let mut bits = color as usize;
+        let mut idx = pixel_idx * BITS_PER_PIXEL + offset;
+
+        // render one bit in one spi byte. High time first, then the low time
+        // clock should be 4 Mhz, 5 bits, each bit is 0.25 us.
+        // a one bit is send as a pulse of 0.75 high -- 0.50 low
+        // a zero bit is send as a pulse of 0.50 high -- 0.75 low
+        // clock frequency for the neopixel is exact 800 khz
+        // note that the mosi output should have a resistor to ground of 10k,
+        // to assure that between the bursts the line is low
+        for _i in 0..8 {
+            if idx >= TOTAL_BITS {
+                return;
+            }
+            let pattern = match bits & 0x80 {
+                0x80 => 0b0000_1110,
+                _ => 0b000_1100,
+            };
+            bits = bits << 1;
+            self.bitbuffer[idx] = U5(pattern);
+            idx += 1;
+        }
+    }
+}
+
+#[embassy_executor::main]
+async fn main(_spawner: Spawner) {
+    let p = embassy_stm32::init(Default::default());
+    info!("Start test using spi as neopixel driver");
+
+    let mut spi = Spi::new_txonly_nosck(p.SPI1, p.PB5, p.DMA1_CH3, NoDma, Hertz(4_000_000), Config::default());
+
+    let mut neopixels = Ws2812::new();
+
+    loop {
+        let mut cnt: usize = 0;
+        for _i in 0..10 {
+            for idx in 0..neopixels.len() {
+                let color = match (cnt + idx) % 3 {
+                    0 => RGB { r: 0x21, g: 0, b: 0 },
+                    1 => RGB { r: 0, g: 0x31, b: 0 },
+                    _ => RGB { r: 0, g: 0, b: 0x41 },
+                };
+                neopixels.set(idx, color);
+            }
+            cnt += 1;
+            // start sending the neopixel bit patters over spi to the neopixel string
+            spi.write(&neopixels.bitbuffer).await.ok();
+            Timer::after(Duration::from_millis(500)).await;
+        }
+        Timer::after(Duration::from_millis(1000)).await;
+    }
+}


### PR DESCRIPTION
For Spi I added the possibility to use the Spi device as a Neopixel driver, with very precise timing, and not dependent on software during the transfer. Even without the --release flag, the timing is perfect.
Note that between the bursts of data the Mosi line should stay on low level. A resistor of 10k can guarantee that, as it seems the the pin is floating between the bursts (on the nucleo-G070RB platform I use).
I created an example for the STM32G0 family.
This example  does contain a very simple Neopixel driver, only for one type. But this Neopixel driver can easy be adapted to different types (for example RGBW types).
