### PR TITLE
fix I2C controller problems after NACK

### DIFF
--- a/embassy-stm32/src/i2c/v2.rs
+++ b/embassy-stm32/src/i2c/v2.rs
@@ -262,7 +262,7 @@ impl<'d, T: Instance, TXDMA, RXDMA> I2c<'d, T, TXDMA, RXDMA> {
             if T::regs().isr().read().txis() {
                 T::regs().txdr().write(|w| w.set_txdata(0));
             }
-            if T::regs().isr().read().txe() {
+            if !T::regs().isr().read().txe() {
                 T::regs().isr().modify(|w| w.set_txe(true))
             }
         }


### PR DESCRIPTION
While tinkering with I2C on a NUCLEO-H723ZG, I noticed that when trying to communicate with a non-existent device you do receive a proper NACK error, but afterwards any future communications with any device no longer works as expected.

The use case is auto-detection of devices, in this case a series of Adafruit 24LC32 I2C EEPROM boards.

On closer inspection with a logic analyzer, I observed that after the NACK, any data bytes sent out by the board to the devices are just zeros. Even though the embassy code specifies the correct data in `set_txdata` in `write_internal`. Something seems to be going wrong with the controller or buffers on the board itself.

Then I noticed what seems to be a logic error in `flush_txdr`, which is called when issuing a NACK.

After flipping the if statement, I2C communications keep working as expected after issuing a NACK.