### PR TITLE
Fix duplicate package name `embassy-stm32h7-examples`

### DIFF
--- a/examples/stm32h5/Cargo.toml
+++ b/examples/stm32h5/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 edition = "2021"
-name = "embassy-stm32h7-examples"
+name = "embassy-stm32h5-examples"
 version = "0.1.0"
 license = "MIT OR Apache-2.0"
 


### PR DESCRIPTION
This uses the correct package name for the `stm32h5` example.

Fixes #1349 