### PR TITLE
re-export main_riscv macro as main for riscv arch.

### DIFF
--- a/embassy-executor/src/arch/riscv32.rs
+++ b/embassy-executor/src/arch/riscv32.rs
@@ -8,6 +8,9 @@ mod thread {
     use core::marker::PhantomData;
     use core::sync::atomic::{AtomicBool, Ordering};
 
+    #[cfg(feature = "nightly")]
+    pub use embassy_macros::main_riscv as main;
+
     use crate::raw::{Pender, PenderInner};
     use crate::{raw, Spawner};
 


### PR DESCRIPTION
embassy_executor::main was missing for riscv targets.