### PR TITLE
Fix typo in derivation of PLLP divisor for STM32F2 family

### DIFF
--- a/embassy-stm32/src/rcc/f2.rs
+++ b/embassy-stm32/src/rcc/f2.rs
@@ -148,7 +148,7 @@ impl Into<Pllp> for PLLMainDiv {
         match self {
             PLLMainDiv::Div2 => Pllp::DIV2,
             PLLMainDiv::Div4 => Pllp::DIV4,
-            PLLMainDiv::Div6 => Pllp::DIV8,
+            PLLMainDiv::Div6 => Pllp::DIV6,
             PLLMainDiv::Div8 => Pllp::DIV8,
         }
     }


### PR DESCRIPTION
This PR fixes a typo in the derivation of the PLLP divisor for the STM32F2 family.

Fixes #1357 