### PR TITLE
Make Hertz constructors `const`

### DIFF
--- a/embassy-stm32/src/time.rs
+++ b/embassy-stm32/src/time.rs
@@ -8,31 +8,31 @@ use core::ops::{Div, Mul};
 pub struct Hertz(pub u32);
 
 impl Hertz {
-    pub fn hz(hertz: u32) -> Self {
+    pub const fn hz(hertz: u32) -> Self {
         Self(hertz)
     }
 
-    pub fn khz(kilohertz: u32) -> Self {
+    pub const fn khz(kilohertz: u32) -> Self {
         Self(kilohertz * 1_000)
     }
 
-    pub fn mhz(megahertz: u32) -> Self {
+    pub const fn mhz(megahertz: u32) -> Self {
         Self(megahertz * 1_000_000)
     }
 }
 
 /// This is a convenience shortcut for [`Hertz::hz`]
-pub fn hz(hertz: u32) -> Hertz {
+pub const fn hz(hertz: u32) -> Hertz {
     Hertz::hz(hertz)
 }
 
 /// This is a convenience shortcut for [`Hertz::khz`]
-pub fn khz(kilohertz: u32) -> Hertz {
+pub const fn khz(kilohertz: u32) -> Hertz {
     Hertz::khz(kilohertz)
 }
 
 /// This is a convenience shortcut for [`Hertz::mhz`]
-pub fn mhz(megahertz: u32) -> Hertz {
+pub const fn mhz(megahertz: u32) -> Hertz {
     Hertz::mhz(megahertz)
 }
 


### PR DESCRIPTION
This PR makes `Hertz` associated functions `hz()`, `khz()`, `mhz()` and their unassociated variants `const`, allowing `Hertz` to be used more easily in constant values:

```rust
const FREQ1: Hertz = Hertz::khz(120);
const FREQ2: Hertz = mhz(1);
```

This follows the pattern used for similar types such as `Duration` and `Instant`, from `embassy-time/src/duration.rs` and `embassy-time/src/instant.rs`, respectively.

https://github.com/embassy-rs/embassy/blob/ba8cafb20c2458a2016c7db3efd91d718f1a91b6/embassy-time/src/duration.rs#L44-L47

https://github.com/embassy-rs/embassy/blob/ba8cafb20c2458a2016c7db3efd91d718f1a91b6/embassy-time/src/instant.rs#L29-L34