### PR TITLE
fix: `embassy-executor` - use `atomic_polyfill` for `riscv` & `xtensa`

### DIFF
--- a/embassy-executor/src/arch/riscv32.rs
+++ b/embassy-executor/src/arch/riscv32.rs
@@ -6,8 +6,8 @@ pub use thread::*;
 #[cfg(feature = "executor-thread")]
 mod thread {
     use core::marker::PhantomData;
-    use core::sync::atomic::{AtomicBool, Ordering};
 
+    use atomic_polyfill::{AtomicBool, Ordering};
     #[cfg(feature = "nightly")]
     pub use embassy_macros::main_riscv as main;
 

--- a/embassy-executor/src/arch/xtensa.rs
+++ b/embassy-executor/src/arch/xtensa.rs
@@ -6,7 +6,8 @@ pub use thread::*;
 #[cfg(feature = "executor-thread")]
 mod thread {
     use core::marker::PhantomData;
-    use core::sync::atomic::{AtomicBool, Ordering};
+
+    use atomic_polyfill::{AtomicBool, Ordering};
 
     use crate::raw::{Pender, PenderInner};
     use crate::{raw, Spawner};


### PR DESCRIPTION
Updating to latest executor in `esp-wifi` (see https://github.com/esp-rs/esp-wifi/pull/163#issuecomment-1513792161) it ended up failing builds for examples since riscv apparently does not support `AtomicBool` from core