### PR TITLE
embassy-rp : Fix for division intrinsics clashing with rp2040-hal

### DIFF
--- a/embassy-rp/src/intrinsics.rs
+++ b/embassy-rp/src/intrinsics.rs
@@ -284,7 +284,7 @@ macro_rules! intrinsics {
 // alias the division operators to these for a similar reason r0 is the
 // result either way and r1 a scratch register, so the caller can't assume it
 // retains the argument value.
-#[cfg(target_arch = "arm")]
+#[cfg(all(target_arch = "arm", feature = "intrinsics"))]
 core::arch::global_asm!(
     ".macro hwdivider_head",
     "ldr    r2, =(0xd0000000)", // SIO_BASE

--- a/embassy-rp/src/intrinsics.rs
+++ b/embassy-rp/src/intrinsics.rs
@@ -284,7 +284,7 @@ macro_rules! intrinsics {
 // alias the division operators to these for a similar reason r0 is the
 // result either way and r1 a scratch register, so the caller can't assume it
 // retains the argument value.
-#[cfg(all(target_arch = "arm", feature = "intrinsics"))]
+#[cfg(target_arch = "arm")]
 core::arch::global_asm!(
     ".macro hwdivider_head",
     "ldr    r2, =(0xd0000000)", // SIO_BASE
@@ -352,6 +352,7 @@ core::arch::global_asm!(
     ".endm",
 );
 
+#[cfg(all(target_arch = "arm", feature = "intrinsics"))]
 macro_rules! division_function {
     (
         $name:ident $($intrinsic:ident)* ( $argty:ty ) {
@@ -438,6 +439,7 @@ fn divider_signed(n: i32, d: i32) -> DivResult<i32> {
 }
 
 /// Result of divide/modulo operation
+#[cfg(all(target_arch = "arm", feature = "intrinsics"))]
 struct DivResult<T> {
     /// The quotient of divide/modulo operation
     pub quotient: T,

--- a/embassy-rp/src/intrinsics.rs
+++ b/embassy-rp/src/intrinsics.rs
@@ -402,6 +402,7 @@ macro_rules! division_function {
     };
 }
 
+#[cfg(all(target_arch = "arm", feature = "intrinsics"))]
 division_function! {
     unsigned_divmod __aeabi_uidivmod __aeabi_uidiv ( u32 ) {
         "str    r0, [r2, #0x060]", // DIV_UDIVIDEND
@@ -409,6 +410,7 @@ division_function! {
     }
 }
 
+#[cfg(all(target_arch = "arm", feature = "intrinsics"))]
 division_function! {
     signed_divmod __aeabi_idivmod __aeabi_idiv ( i32 ) {
         "str    r0, [r2, #0x068]", // DIV_SDIVIDEND
@@ -416,6 +418,7 @@ division_function! {
     }
 }
 
+#[cfg(all(target_arch = "arm", feature = "intrinsics"))]
 fn divider_unsigned(n: u32, d: u32) -> DivResult<u32> {
     let packed = unsafe { unsigned_divmod(n, d) };
     DivResult {
@@ -424,6 +427,7 @@ fn divider_unsigned(n: u32, d: u32) -> DivResult<u32> {
     }
 }
 
+#[cfg(all(target_arch = "arm", feature = "intrinsics"))]
 fn divider_signed(n: i32, d: i32) -> DivResult<i32> {
     let packed = unsafe { signed_divmod(n, d) };
     // Double casts to avoid sign extension
@@ -441,6 +445,7 @@ struct DivResult<T> {
     pub remainder: T,
 }
 
+#[cfg(all(target_arch = "arm", feature = "intrinsics"))]
 intrinsics! {
     extern "C" fn __udivsi3(n: u32, d: u32) -> u32 {
         divider_unsigned(n, d).quotient


### PR DESCRIPTION
Commit [7a682ec](https://github.com/embassy-rs/embassy/commit/7a682ec02af50026d31296ce5cac6383580f5e55#diff-f121955242a67342004444b26214e5d1d591c3182dcd0fedf4329ad472cd1200) may break compilation if also using `rp2040-hal`. It seems that the rp2040-hal does have a feature flag for [disabling intrinsics](https://github.com/rp-rs/rp-hal/blob/2c9921cdc578bfcbd5c6e0eb0085bb91f9a7e229/rp2040-hal/src/sio.rs#L323), but I still cannot seem to compile with that enabled. Adding these flags fixes it for me.