### PR TITLE
Switch from probe-run to probe-rs-cli.

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,10 +106,10 @@ git submodule init
 git submodule update
 ```
 
-- Install `probe-run` with defmt support.
+- Install `probe-rs-cli` with defmt support.
 
 ```bash
-cargo install probe-run
+cargo install probe-rs-cli
 ```
 
 - Change directory to the sample's base directory. For example:

--- a/examples/boot/application/nrf/.cargo/config.toml
+++ b/examples/boot/application/nrf/.cargo/config.toml
@@ -1,6 +1,6 @@
 [target.'cfg(all(target_arch = "arm", target_os = "none"))']
-# replace nRF82840_xxAA with your chip as listed in `probe-run --list-chips`
-runner = "probe-run --chip nRF52840_xxAA"
+# replace nRF82840_xxAA with your chip as listed in `probe-rs-cli chip list`
+runner = "probe-rs-cli run --chip nRF52840_xxAA"
 
 [build]
 target = "thumbv7em-none-eabi"

--- a/examples/boot/application/rp/.cargo/config.toml
+++ b/examples/boot/application/rp/.cargo/config.toml
@@ -3,7 +3,7 @@ build-std = ["core"]
 build-std-features = ["panic_immediate_abort"]
 
 [target.'cfg(all(target_arch = "arm", target_os = "none"))']
-runner = "probe-run --chip RP2040"
+runner = "probe-rs-cli run --chip RP2040"
 
 [build]
 target = "thumbv6m-none-eabi"

--- a/examples/boot/application/stm32f3/.cargo/config.toml
+++ b/examples/boot/application/stm32f3/.cargo/config.toml
@@ -1,6 +1,6 @@
 [target.'cfg(all(target_arch = "arm", target_os = "none"))']
-# replace STM32F429ZITx with your chip as listed in `probe-run --list-chips`
-runner = "probe-run --chip STM32F303VCTx"
+# replace STM32F429ZITx with your chip as listed in `probe-rs-cli chip list`
+runner = "probe-rs-cli run --chip STM32F303VCTx"
 
 [build]
 target = "thumbv7em-none-eabihf"

--- a/examples/boot/application/stm32f7/.cargo/config.toml
+++ b/examples/boot/application/stm32f7/.cargo/config.toml
@@ -1,6 +1,6 @@
 [target.'cfg(all(target_arch = "arm", target_os = "none"))']
-# replace STM32F429ZITx with your chip as listed in `probe-run --list-chips`
-runner = "probe-run --chip STM32F767ZITx -v"
+# replace STM32F429ZITx with your chip as listed in `probe-rs-cli chip list`
+runner = "probe-rs-cli run --chip STM32F767ZITx -v"
 
 [build]
 target = "thumbv7em-none-eabihf"

--- a/examples/boot/application/stm32h7/.cargo/config.toml
+++ b/examples/boot/application/stm32h7/.cargo/config.toml
@@ -1,6 +1,6 @@
 [target.'cfg(all(target_arch = "arm", target_os = "none"))']
-# replace STM32F429ZITx with your chip as listed in `probe-run --list-chips`
-runner = "probe-run --chip STM32H743ZITx"
+# replace STM32F429ZITx with your chip as listed in `probe-rs-cli chip list`
+runner = "probe-rs-cli run --chip STM32H743ZITx"
 
 [build]
 target = "thumbv7em-none-eabihf"

--- a/examples/boot/application/stm32l0/.cargo/config.toml
+++ b/examples/boot/application/stm32l0/.cargo/config.toml
@@ -1,6 +1,6 @@
 [target.'cfg(all(target_arch = "arm", target_os = "none"))']
-# replace your chip as listed in `probe-run --list-chips`
-runner = "probe-run --chip STM32L072CZTx"
+# replace your chip as listed in `probe-rs-cli chip list`
+runner = "probe-rs-cli run --chip STM32L072CZTx"
 
 [build]
 target = "thumbv6m-none-eabi"

--- a/examples/boot/application/stm32l1/.cargo/config.toml
+++ b/examples/boot/application/stm32l1/.cargo/config.toml
@@ -1,6 +1,6 @@
 [target.'cfg(all(target_arch = "arm", target_os = "none"))']
-# replace your chip as listed in `probe-run --list-chips`
-runner = "probe-run --chip STM32L151CBxxA"
+# replace your chip as listed in `probe-rs-cli chip list`
+runner = "probe-rs-cli run --chip STM32L151CBxxA"
 
 [build]
 target = "thumbv7m-none-eabi"

--- a/examples/boot/application/stm32l4/.cargo/config.toml
+++ b/examples/boot/application/stm32l4/.cargo/config.toml
@@ -1,6 +1,6 @@
 [target.'cfg(all(target_arch = "arm", target_os = "none"))']
-# replace your chip as listed in `probe-run --list-chips`
-runner = "probe-run --chip STM32L475VG"
+# replace your chip as listed in `probe-rs-cli chip list`
+runner = "probe-rs-cli run --chip STM32L475VG"
 
 [build]
 target = "thumbv7em-none-eabihf"

--- a/examples/boot/application/stm32wl/.cargo/config.toml
+++ b/examples/boot/application/stm32wl/.cargo/config.toml
@@ -1,6 +1,6 @@
 [target.'cfg(all(target_arch = "arm", target_os = "none"))']
-# replace your chip as listed in `probe-run --list-chips`
-runner = "probe-run --chip STM32WLE5JCIx"
+# replace your chip as listed in `probe-rs-cli chip list`
+runner = "probe-rs-cli run --chip STM32WLE5JCIx"
 
 [build]
 target = "thumbv7em-none-eabihf"

--- a/examples/boot/bootloader/nrf/.cargo/config.toml
+++ b/examples/boot/bootloader/nrf/.cargo/config.toml
@@ -4,7 +4,7 @@ build-std-features = ["panic_immediate_abort"]
 
 [target.'cfg(all(target_arch = "arm", target_os = "none"))']
 #runner = "./fruitrunner"
-runner = "probe-run --chip nrf52840_xxAA"
+runner = "probe-rs-cli run --chip nrf52840_xxAA"
 
 rustflags = [
   # Code-size optimizations.

--- a/examples/boot/bootloader/rp/.cargo/config.toml
+++ b/examples/boot/bootloader/rp/.cargo/config.toml
@@ -1,5 +1,5 @@
 [target.'cfg(all(target_arch = "arm", target_os = "none"))']
-runner = "probe-run --chip RP2040"
+runner = "probe-rs-cli run --chip RP2040"
 
 [build]
 target = "thumbv6m-none-eabi"

--- a/examples/nrf-rtos-trace/.cargo/config.toml
+++ b/examples/nrf-rtos-trace/.cargo/config.toml
@@ -1,6 +1,6 @@
 [target.'cfg(all(target_arch = "arm", target_os = "none"))']
-# replace nRF82840_xxAA with your chip as listed in `probe-run --list-chips`
-runner = "probe-run --chip nRF52840_xxAA"
+# replace nRF82840_xxAA with your chip as listed in `probe-rs-cli chip list`
+runner = "probe-rs-cli run --chip nRF52840_xxAA"
 
 [build]
 target = "thumbv7em-none-eabi"

--- a/examples/nrf52840/.cargo/config.toml
+++ b/examples/nrf52840/.cargo/config.toml
@@ -1,6 +1,6 @@
 [target.'cfg(all(target_arch = "arm", target_os = "none"))']
-# replace nRF82840_xxAA with your chip as listed in `probe-run --list-chips`
-runner = "probe-run --chip nRF52840_xxAA"
+# replace nRF82840_xxAA with your chip as listed in `probe-rs-cli chip list`
+runner = "probe-rs-cli run --chip nRF52840_xxAA"
 
 [build]
 target = "thumbv7em-none-eabi"

--- a/examples/nrf52840/src/bin/nvmc.rs
+++ b/examples/nrf52840/src/bin/nvmc.rs
@@ -14,7 +14,7 @@ async fn main(_spawner: Spawner) {
     let p = embassy_nrf::init(Default::default());
     info!("Hello NVMC!");
 
-    // probe-run breaks without this, I'm not sure why.
+    // probe-rs-cli run breaks without this, I'm not sure why.
     Timer::after(Duration::from_secs(1)).await;
 
     let mut f = Nvmc::new(p.NVMC);

--- a/examples/nrf52840/src/bin/wdt.rs
+++ b/examples/nrf52840/src/bin/wdt.rs
@@ -16,7 +16,7 @@ async fn main(_spawner: Spawner) {
     let mut config = Config::default();
     config.timeout_ticks = 32768 * 3; // 3 seconds
 
-    // This is needed for `probe-run` to be able to catch the panic message
+    // This is needed for `probe-rs-cli run` to be able to catch the panic message
     // in the WDT interrupt. The core resets 2 ticks after firing the interrupt.
     config.run_during_debug_halt = false;
 

--- a/examples/nrf5340/.cargo/config.toml
+++ b/examples/nrf5340/.cargo/config.toml
@@ -1,6 +1,6 @@
 [target.'cfg(all(target_arch = "arm", target_os = "none"))']
-# replace nRF5340_xxAA with your chip as listed in `probe-run --list-chips`
-runner = "probe-run --chip nRF5340_xxAA"
+# replace nRF5340_xxAA with your chip as listed in `probe-rs-cli chip list`
+runner = "probe-rs-cli run --chip nRF5340_xxAA"
 
 [build]
 target = "thumbv8m.main-none-eabihf"

--- a/examples/stm32c0/.cargo/config.toml
+++ b/examples/stm32c0/.cargo/config.toml
@@ -1,5 +1,5 @@
 [target.'cfg(all(target_arch = "arm", target_os = "none"))']
-# replace STM32G071C8Rx with your chip as listed in `probe-run --list-chips`
+# replace STM32G071C8Rx with your chip as listed in `probe-rs-cli chip list`
 runner = "probe-rs-cli run --speed 100 --chip STM32c031c6tx"
 
 [build]

--- a/examples/stm32f0/.cargo/config.toml
+++ b/examples/stm32f0/.cargo/config.toml
@@ -1,5 +1,5 @@
 [target.thumbv6m-none-eabi]
-runner = 'probe-run --chip STM32F091RCTX'
+runner = 'probe-rs-cli run --chip STM32F091RCTX'
 
 [build]
 target = "thumbv6m-none-eabi"

--- a/examples/stm32f1/.cargo/config.toml
+++ b/examples/stm32f1/.cargo/config.toml
@@ -1,6 +1,6 @@
 [target.'cfg(all(target_arch = "arm", target_os = "none"))']
-# replace STM32F103C8 with your chip as listed in `probe-run --list-chips`
-runner = "probe-run --chip STM32F103C8"
+# replace STM32F103C8 with your chip as listed in `probe-rs-cli chip list`
+runner = "probe-rs-cli run --chip STM32F103C8"
 
 [build]
 target = "thumbv7m-none-eabi"

--- a/examples/stm32f2/.cargo/config.toml
+++ b/examples/stm32f2/.cargo/config.toml
@@ -1,6 +1,6 @@
 [target.'cfg(all(target_arch = "arm", target_os = "none"))']
-# replace STM32F207ZGTx with your chip as listed in `probe-run --list-chips`
-runner = "probe-run --chip STM32F207ZGTx"
+# replace STM32F207ZGTx with your chip as listed in `probe-rs-cli chip list`
+runner = "probe-rs-cli run --chip STM32F207ZGTx"
 
 [build]
 target = "thumbv7m-none-eabi"

--- a/examples/stm32f3/.cargo/config.toml
+++ b/examples/stm32f3/.cargo/config.toml
@@ -1,6 +1,6 @@
 [target.'cfg(all(target_arch = "arm", target_os = "none"))']
-# replace STM32F429ZITx with your chip as listed in `probe-run --list-chips`
-runner = "probe-run --chip STM32F303ZETx"
+# replace STM32F429ZITx with your chip as listed in `probe-rs-cli chip list`
+runner = "probe-rs-cli run --chip STM32F303ZETx"
 
 [build]
 target = "thumbv7em-none-eabihf"

--- a/examples/stm32f4/.cargo/config.toml
+++ b/examples/stm32f4/.cargo/config.toml
@@ -1,6 +1,6 @@
 [target.'cfg(all(target_arch = "arm", target_os = "none"))']
-# replace STM32F429ZITx with your chip as listed in `probe-run --list-chips`
-runner = "probe-run --chip STM32F429ZITx"
+# replace STM32F429ZITx with your chip as listed in `probe-rs-cli chip list`
+runner = "probe-rs-cli run --chip STM32F429ZITx"
 
 [build]
 target = "thumbv7em-none-eabi"

--- a/examples/stm32f7/.cargo/config.toml
+++ b/examples/stm32f7/.cargo/config.toml
@@ -1,6 +1,6 @@
 [target.'cfg(all(target_arch = "arm", target_os = "none"))']
-# replace STM32F429ZITx with your chip as listed in `probe-run --list-chips`
-runner = "probe-run --chip STM32F767ZITx"
+# replace STM32F429ZITx with your chip as listed in `probe-rs-cli chip list`
+runner = "probe-rs-cli run --chip STM32F767ZITx"
 
 [build]
 target = "thumbv7em-none-eabihf"

--- a/examples/stm32g0/.cargo/config.toml
+++ b/examples/stm32g0/.cargo/config.toml
@@ -1,6 +1,6 @@
 [target.'cfg(all(target_arch = "arm", target_os = "none"))']
-# replace STM32G071C8Rx with your chip as listed in `probe-run --list-chips`
-runner = "probe-run --chip STM32G071RBTx"
+# replace STM32G071C8Rx with your chip as listed in `probe-rs-cli chip list`
+runner = "probe-rs-cli run --chip STM32G071RBTx"
 
 [build]
 target = "thumbv6m-none-eabi"

--- a/examples/stm32g4/.cargo/config.toml
+++ b/examples/stm32g4/.cargo/config.toml
@@ -1,6 +1,6 @@
 [target.'cfg(all(target_arch = "arm", target_os = "none"))']
-# replace STM32G071C8Rx with your chip as listed in `probe-run --list-chips`
-runner = "probe-run --chip STM32G484VETx"
+# replace STM32G071C8Rx with your chip as listed in `probe-rs-cli chip list`
+runner = "probe-rs-cli run --chip STM32G484VETx"
 
 [build]
 target = "thumbv7em-none-eabi"

--- a/examples/stm32h7/.cargo/config.toml
+++ b/examples/stm32h7/.cargo/config.toml
@@ -1,5 +1,5 @@
 [target.thumbv7em-none-eabihf]
-runner = 'probe-run --chip STM32H743ZITx'
+runner = 'probe-rs-cli run --chip STM32H743ZITx'
 
 [build]
 target = "thumbv7em-none-eabihf" # Cortex-M4F and Cortex-M7F (with FPU)

--- a/examples/stm32l0/.cargo/config.toml
+++ b/examples/stm32l0/.cargo/config.toml
@@ -1,6 +1,6 @@
 [target.'cfg(all(target_arch = "arm", target_os = "none"))']
-# replace your chip as listed in `probe-run --list-chips`
-runner = "probe-run --chip STM32L053R8Tx"
+# replace your chip as listed in `probe-rs-cli chip list`
+runner = "probe-rs-cli run --chip STM32L053R8Tx"
 
 [build]
 target = "thumbv6m-none-eabi"

--- a/examples/stm32l1/.cargo/config.toml
+++ b/examples/stm32l1/.cargo/config.toml
@@ -1,6 +1,6 @@
 [target.'cfg(all(target_arch = "arm", target_os = "none"))']
-# replace your chip as listed in `probe-run --list-chips`
-runner = "probe-run --chip STM32L151CBxxA"
+# replace your chip as listed in `probe-rs-cli chip list`
+runner = "probe-rs-cli run --chip STM32L151CBxxA"
 
 [build]
 target = "thumbv7m-none-eabi"

--- a/examples/stm32l4/.cargo/config.toml
+++ b/examples/stm32l4/.cargo/config.toml
@@ -1,8 +1,8 @@
 [target.'cfg(all(target_arch = "arm", target_os = "none"))']
-# replace STM32F429ZITx with your chip as listed in `probe-run --list-chips`
-#runner = "probe-run --chip STM32L475VGT6"
-#runner = "probe-run --chip STM32L475VG"
-runner = "probe-run --chip STM32L4S5VI"
+# replace STM32F429ZITx with your chip as listed in `probe-rs-cli chip list`
+#runner = "probe-rs-cli run --chip STM32L475VGT6"
+#runner = "probe-rs-cli run --chip STM32L475VG"
+runner = "probe-rs-cli run --chip STM32L4S5VI"
 
 [build]
 target = "thumbv7em-none-eabi"

--- a/examples/stm32l5/.cargo/config.toml
+++ b/examples/stm32l5/.cargo/config.toml
@@ -1,6 +1,6 @@
 [target.'cfg(all(target_arch = "arm", target_os = "none"))']
-# replace STM32L552ZETxQ with your chip as listed in `probe-run --list-chips`
-runner = "probe-run --chip STM32L552ZETxQ"
+# replace STM32L552ZETxQ with your chip as listed in `probe-rs-cli chip list`
+runner = "probe-rs-cli run --chip STM32L552ZETxQ"
 
 [build]
 target = "thumbv8m.main-none-eabihf"

--- a/examples/stm32u5/.cargo/config.toml
+++ b/examples/stm32u5/.cargo/config.toml
@@ -1,6 +1,6 @@
 [target.'cfg(all(target_arch = "arm", target_os = "none"))']
-# replace STM32U585AIIx with your chip as listed in `probe-run --list-chips`
-runner = "probe-run --chip STM32U585AIIx"
+# replace STM32U585AIIx with your chip as listed in `probe-rs-cli chip list`
+runner = "probe-rs-cli run --chip STM32U585AIIx"
 
 [build]
 target = "thumbv8m.main-none-eabihf"

--- a/examples/stm32wb/.cargo/config.toml
+++ b/examples/stm32wb/.cargo/config.toml
@@ -1,6 +1,6 @@
 [target.'cfg(all(target_arch = "arm", target_os = "none"))']
-# replace STM32WB55CCUx with your chip as listed in `probe-run --list-chips`
-runner = "probe-run --chip STM32WB55CCUx --speed 1000 --connect-under-reset"
+# replace STM32WB55CCUx with your chip as listed in `probe-rs-cli chip list`
+runner = "probe-rs-cli run --chip STM32WB55CCUx --speed 1000 --connect-under-reset"
 
 [build]
 target = "thumbv7em-none-eabihf"

--- a/examples/stm32wl/.cargo/config.toml
+++ b/examples/stm32wl/.cargo/config.toml
@@ -1,6 +1,6 @@
 [target.'cfg(all(target_arch = "arm", target_os = "none"))']
-# replace your chip as listed in `probe-run --list-chips`
-runner = "probe-run --chip STM32WLE5JCIx"
+# replace your chip as listed in `probe-rs-cli chip list`
+runner = "probe-rs-cli run --chip STM32WLE5JCIx"
 
 [build]
 target = "thumbv7em-none-eabihf"


### PR DESCRIPTION
- probe-run screwed up the last release 2 weeks ago and it's still not fixed (issue 391). Doesn't look well maintained.
- Even when it's not broken, it lags behind probe-rs-cli in new chips support because it's slow in updating probe-rs.


bors r+