### PR TITLE
fix stm32f7 example runner command for probe-rs-cli

### DIFF
--- a/examples/boot/application/stm32f7/.cargo/config.toml
+++ b/examples/boot/application/stm32f7/.cargo/config.toml
@@ -1,6 +1,6 @@
 [target.'cfg(all(target_arch = "arm", target_os = "none"))']
 # replace STM32F429ZITx with your chip as listed in `probe-rs-cli chip list`
-runner = "probe-rs-cli run --chip STM32F767ZITx -v"
+runner = "probe-rs-cli run --chip STM32F767ZITx"
 
 [build]
 target = "thumbv7em-none-eabihf"


### PR DESCRIPTION
Just a minor thing: `-v` option does not work with probe-rs-cli