### PR TITLE
rp: report errors from buffered and dma uart receives

### DIFF
--- a/embassy-rp/src/uart/buffered.rs
+++ b/embassy-rp/src/uart/buffered.rs
@@ -74,7 +74,7 @@ pub(crate) fn init_buffers<'d, T: Instance + 'd>(
     // to pend the ISR when we want data transmission to start.
     let regs = T::regs();
     unsafe {
-        regs.uartimsc().write_set(|w| {
+        regs.uartimsc().write(|w| {
             w.set_rxim(true);
             w.set_rtim(true);
             w.set_txim(true);

--- a/embassy-rp/src/uart/mod.rs
+++ b/embassy-rp/src/uart/mod.rs
@@ -763,7 +763,7 @@ mod sealed {
         fn regs() -> pac::uart::Uart;
 
         #[cfg(feature = "nightly")]
-        fn state() -> &'static buffered::State;
+        fn buffered_state() -> &'static buffered::State;
     }
     pub trait TxPin<T: Instance> {}
     pub trait RxPin<T: Instance> {}
@@ -801,7 +801,7 @@ macro_rules! impl_instance {
             }
 
             #[cfg(feature = "nightly")]
-            fn state() -> &'static buffered::State {
+            fn buffered_state() -> &'static buffered::State {
                 static STATE: buffered::State = buffered::State::new();
                 &STATE
             }

--- a/embassy-rp/src/uart/mod.rs
+++ b/embassy-rp/src/uart/mod.rs
@@ -229,6 +229,16 @@ impl<'d, T: Instance, M: Mode> UartRx<'d, T, M> {
 }
 
 impl<'d, T: Instance> UartRx<'d, T, Blocking> {
+    pub fn new_blocking(
+        _uart: impl Peripheral<P = T> + 'd,
+        rx: impl Peripheral<P = impl RxPin<T>> + 'd,
+        config: Config,
+    ) -> Self {
+        into_ref!(rx);
+        Uart::<T, Blocking>::init(None, Some(rx.map_into()), None, None, config);
+        Self::new_inner(None)
+    }
+
     #[cfg(feature = "nightly")]
     pub fn into_buffered(
         self,

--- a/embassy-rp/src/uart/mod.rs
+++ b/embassy-rp/src/uart/mod.rs
@@ -206,7 +206,7 @@ impl<'d, T: Instance> UartTx<'d, T, Async> {
     pub async fn write(&mut self, buffer: &[u8]) -> Result<(), Error> {
         let ch = self.tx_dma.as_mut().unwrap();
         let transfer = unsafe {
-            T::regs().uartdmacr().modify(|reg| {
+            T::regs().uartdmacr().write_set(|reg| {
                 reg.set_txdmae(true);
             });
             // If we don't assign future to a variable, the data register pointer
@@ -296,7 +296,7 @@ impl<'d, T: Instance> UartRx<'d, T, Async> {
     pub async fn read(&mut self, buffer: &mut [u8]) -> Result<(), Error> {
         let ch = self.rx_dma.as_mut().unwrap();
         let transfer = unsafe {
-            T::regs().uartdmacr().modify(|reg| {
+            T::regs().uartdmacr().write_set(|reg| {
                 reg.set_rxdmae(true);
             });
             // If we don't assign future to a variable, the data register pointer

--- a/examples/rp/src/bin/uart_unidir.rs
+++ b/examples/rp/src/bin/uart_unidir.rs
@@ -7,6 +7,7 @@
 
 use defmt::*;
 use embassy_executor::Spawner;
+use embassy_rp::interrupt;
 use embassy_rp::peripherals::UART1;
 use embassy_rp::uart::{Async, Config, UartRx, UartTx};
 use embassy_time::{Duration, Timer};
@@ -17,7 +18,13 @@ async fn main(spawner: Spawner) {
     let p = embassy_rp::init(Default::default());
 
     let mut uart_tx = UartTx::new(p.UART0, p.PIN_0, p.DMA_CH0, Config::default());
-    let uart_rx = UartRx::new(p.UART1, p.PIN_5, p.DMA_CH1, Config::default());
+    let uart_rx = UartRx::new(
+        p.UART1,
+        p.PIN_5,
+        interrupt::take!(UART1_IRQ),
+        p.DMA_CH1,
+        Config::default(),
+    );
 
     unwrap!(spawner.spawn(reader(uart_rx)));
 

--- a/tests/rp/src/bin/uart.rs
+++ b/tests/rp/src/bin/uart.rs
@@ -4,28 +4,165 @@
 
 use defmt::{assert_eq, *};
 use embassy_executor::Spawner;
-use embassy_rp::uart::{Config, Uart};
+use embassy_rp::gpio::{Level, Output};
+use embassy_rp::uart::{Blocking, Config, Error, Instance, Parity, Uart, UartRx};
+use embassy_time::{Duration, Timer};
 use {defmt_rtt as _, panic_probe as _};
+
+fn read<const N: usize>(uart: &mut Uart<'_, impl Instance, Blocking>) -> Result<[u8; N], Error> {
+    let mut buf = [255; N];
+    uart.blocking_read(&mut buf)?;
+    Ok(buf)
+}
+
+fn read1<const N: usize>(uart: &mut UartRx<'_, impl Instance, Blocking>) -> Result<[u8; N], Error> {
+    let mut buf = [255; N];
+    uart.blocking_read(&mut buf)?;
+    Ok(buf)
+}
+
+async fn send(pin: &mut Output<'_, impl embassy_rp::gpio::Pin>, v: u8, parity: Option<bool>) {
+    pin.set_low();
+    Timer::after(Duration::from_millis(1)).await;
+    for i in 0..8 {
+        if v & (1 << i) == 0 {
+            pin.set_low();
+        } else {
+            pin.set_high();
+        }
+        Timer::after(Duration::from_millis(1)).await;
+    }
+    if let Some(b) = parity {
+        if b {
+            pin.set_high();
+        } else {
+            pin.set_low();
+        }
+        Timer::after(Duration::from_millis(1)).await;
+    }
+    pin.set_high();
+    Timer::after(Duration::from_millis(1)).await;
+}
 
 #[embassy_executor::main]
 async fn main(_spawner: Spawner) {
     let p = embassy_rp::init(Default::default());
     info!("Hello World!");
 
-    let (tx, rx, uart) = (p.PIN_0, p.PIN_1, p.UART0);
+    let (mut tx, mut rx, mut uart) = (p.PIN_0, p.PIN_1, p.UART0);
 
-    let config = Config::default();
-    let mut uart = Uart::new_blocking(uart, tx, rx, config);
+    {
+        let config = Config::default();
+        let mut uart = Uart::new_blocking(&mut uart, &mut tx, &mut rx, config);
 
-    // We can't send too many bytes, they have to fit in the FIFO.
-    // This is because we aren't sending+receiving at the same time.
+        // We can't send too many bytes, they have to fit in the FIFO.
+        // This is because we aren't sending+receiving at the same time.
 
-    let data = [0xC0, 0xDE];
-    uart.blocking_write(&data).unwrap();
+        let data = [0xC0, 0xDE];
+        uart.blocking_write(&data).unwrap();
+        assert_eq!(read(&mut uart).unwrap(), data);
+    }
 
-    let mut buf = [0; 2];
-    uart.blocking_read(&mut buf).unwrap();
-    assert_eq!(buf, data);
+    info!("test overflow detection");
+    {
+        let config = Config::default();
+        let mut uart = Uart::new_blocking(&mut uart, &mut tx, &mut rx, config);
+
+        let data = [
+            1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29,
+            30, 31, 32,
+        ];
+        let overflow = [
+            101, 102, 103, 104, 105, 106, 107, 108, 109, 110, 111, 112, 113, 114, 115, 116,
+        ];
+        uart.blocking_write(&data).unwrap();
+        uart.blocking_write(&overflow).unwrap();
+        while uart.busy() {}
+
+        // prefix in fifo is valid
+        assert_eq!(read(&mut uart).unwrap(), data);
+        // next received character causes overrun error and is discarded
+        uart.blocking_write(&[1, 2, 3]).unwrap();
+        assert_eq!(read::<1>(&mut uart).unwrap_err(), Error::Overrun);
+        assert_eq!(read(&mut uart).unwrap(), [2, 3]);
+    }
+
+    info!("test break detection");
+    {
+        let config = Config::default();
+        let mut uart = Uart::new_blocking(&mut uart, &mut tx, &mut rx, config);
+
+        // break on empty fifo
+        uart.send_break(20).await;
+        uart.blocking_write(&[64]).unwrap();
+        assert_eq!(read::<1>(&mut uart).unwrap_err(), Error::Break);
+        assert_eq!(read(&mut uart).unwrap(), [64]);
+
+        // break on partially filled fifo
+        uart.blocking_write(&[65; 2]).unwrap();
+        uart.send_break(20).await;
+        uart.blocking_write(&[66]).unwrap();
+        assert_eq!(read(&mut uart).unwrap(), [65; 2]);
+        assert_eq!(read::<1>(&mut uart).unwrap_err(), Error::Break);
+        assert_eq!(read(&mut uart).unwrap(), [66]);
+    }
+
+    // parity detection. here we bitbang to not require two uarts.
+    info!("test parity error detection");
+    {
+        let mut pin = Output::new(&mut tx, Level::High);
+        let mut config = Config::default();
+        config.baudrate = 1000;
+        config.parity = Parity::ParityEven;
+        let mut uart = UartRx::new_blocking(&mut uart, &mut rx, config);
+
+        async fn chr(pin: &mut Output<'_, impl embassy_rp::gpio::Pin>, v: u8, parity: u8) {
+            send(pin, v, Some(parity != 0)).await;
+        }
+
+        // first check that we can send correctly
+        chr(&mut pin, 64, 1).await;
+        assert_eq!(read1(&mut uart).unwrap(), [64]);
+
+        // all good, check real errors
+        chr(&mut pin, 2, 1).await;
+        chr(&mut pin, 3, 0).await;
+        chr(&mut pin, 4, 0).await;
+        chr(&mut pin, 5, 0).await;
+        assert_eq!(read1(&mut uart).unwrap(), [2, 3]);
+        assert_eq!(read1::<1>(&mut uart).unwrap_err(), Error::Parity);
+        assert_eq!(read1(&mut uart).unwrap(), [5]);
+    }
+
+    // framing error detection. here we bitbang because there's no other way.
+    info!("test framing error detection");
+    {
+        let mut pin = Output::new(&mut tx, Level::High);
+        let mut config = Config::default();
+        config.baudrate = 1000;
+        let mut uart = UartRx::new_blocking(&mut uart, &mut rx, config);
+
+        async fn chr(pin: &mut Output<'_, impl embassy_rp::gpio::Pin>, v: u8, good: bool) {
+            if good {
+                send(pin, v, None).await;
+            } else {
+                send(pin, v, Some(false)).await;
+            }
+        }
+
+        // first check that we can send correctly
+        chr(&mut pin, 64, true).await;
+        assert_eq!(read1(&mut uart).unwrap(), [64]);
+
+        // all good, check real errors
+        chr(&mut pin, 2, true).await;
+        chr(&mut pin, 3, true).await;
+        chr(&mut pin, 4, false).await;
+        chr(&mut pin, 5, true).await;
+        assert_eq!(read1(&mut uart).unwrap(), [2, 3]);
+        assert_eq!(read1::<1>(&mut uart).unwrap_err(), Error::Framing);
+        assert_eq!(read1(&mut uart).unwrap(), [5]);
+    }
 
     info!("Test OK");
     cortex_m::asm::bkpt();

--- a/tests/rp/src/bin/uart_buffered.rs
+++ b/tests/rp/src/bin/uart_buffered.rs
@@ -2,39 +2,248 @@
 #![no_main]
 #![feature(type_alias_impl_trait)]
 
-use defmt::{assert_eq, *};
+use defmt::{assert_eq, panic, *};
 use embassy_executor::Spawner;
+use embassy_rp::gpio::{Level, Output};
 use embassy_rp::interrupt;
-use embassy_rp::uart::{BufferedUart, Config};
-use embedded_io::asynch::{Read, Write};
+use embassy_rp::uart::{BufferedUart, BufferedUartRx, Config, Error, Instance, Parity};
+use embassy_time::{Duration, Timer};
+use embedded_io::asynch::{Read, ReadExactError, Write};
 use {defmt_rtt as _, panic_probe as _};
+
+async fn read<const N: usize>(uart: &mut BufferedUart<'_, impl Instance>) -> Result<[u8; N], Error> {
+    let mut buf = [255; N];
+    match uart.read_exact(&mut buf).await {
+        Ok(()) => Ok(buf),
+        // we should not ever produce an Eof condition
+        Err(ReadExactError::UnexpectedEof) => panic!(),
+        Err(ReadExactError::Other(e)) => Err(e),
+    }
+}
+
+async fn read1<const N: usize>(uart: &mut BufferedUartRx<'_, impl Instance>) -> Result<[u8; N], Error> {
+    let mut buf = [255; N];
+    match uart.read_exact(&mut buf).await {
+        Ok(()) => Ok(buf),
+        // we should not ever produce an Eof condition
+        Err(ReadExactError::UnexpectedEof) => panic!(),
+        Err(ReadExactError::Other(e)) => Err(e),
+    }
+}
+
+async fn send(pin: &mut Output<'_, impl embassy_rp::gpio::Pin>, v: u8, parity: Option<bool>) {
+    pin.set_low();
+    Timer::after(Duration::from_millis(1)).await;
+    for i in 0..8 {
+        if v & (1 << i) == 0 {
+            pin.set_low();
+        } else {
+            pin.set_high();
+        }
+        Timer::after(Duration::from_millis(1)).await;
+    }
+    if let Some(b) = parity {
+        if b {
+            pin.set_high();
+        } else {
+            pin.set_low();
+        }
+        Timer::after(Duration::from_millis(1)).await;
+    }
+    pin.set_high();
+    Timer::after(Duration::from_millis(1)).await;
+}
 
 #[embassy_executor::main]
 async fn main(_spawner: Spawner) {
     let p = embassy_rp::init(Default::default());
     info!("Hello World!");
 
-    let (tx, rx, uart) = (p.PIN_0, p.PIN_1, p.UART0);
+    let (mut tx, mut rx, mut uart) = (p.PIN_0, p.PIN_1, p.UART0);
+    let mut irq = interrupt::take!(UART0_IRQ);
 
-    let config = Config::default();
-    let irq = interrupt::take!(UART0_IRQ);
-    let tx_buf = &mut [0u8; 16];
-    let rx_buf = &mut [0u8; 16];
-    let mut uart = BufferedUart::new(uart, irq, tx, rx, tx_buf, rx_buf, config);
+    {
+        let config = Config::default();
+        let tx_buf = &mut [0u8; 16];
+        let rx_buf = &mut [0u8; 16];
+        let mut uart = BufferedUart::new(&mut uart, &mut irq, &mut tx, &mut rx, tx_buf, rx_buf, config);
 
-    // Make sure we send more bytes than fits in the FIFO, to test the actual
-    // bufferedUart.
+        // Make sure we send more bytes than fits in the FIFO, to test the actual
+        // bufferedUart.
 
-    let data = [
-        1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30,
-        31, 32, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44, 45, 46, 47, 48,
-    ];
-    uart.write_all(&data).await.unwrap();
-    info!("Done writing");
+        let data = [
+            1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29,
+            30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44, 45, 46, 47, 48,
+        ];
+        uart.write_all(&data).await.unwrap();
+        info!("Done writing");
 
-    let mut buf = [0; 48];
-    uart.read_exact(&mut buf).await.unwrap();
-    assert_eq!(buf, data);
+        assert_eq!(read(&mut uart).await.unwrap(), data);
+    }
+
+    info!("test overflow detection");
+    {
+        let config = Config::default();
+        let tx_buf = &mut [0u8; 16];
+        let rx_buf = &mut [0u8; 16];
+        let mut uart = BufferedUart::new(&mut uart, &mut irq, &mut tx, &mut rx, tx_buf, rx_buf, config);
+
+        // Make sure we send more bytes than fits in the FIFO, to test the actual
+        // bufferedUart.
+
+        let data = [
+            1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29,
+            30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44, 45, 46, 47, 48,
+        ];
+        let overflow = [
+            101, 102, 103, 104, 105, 106, 107, 108, 109, 110, 111, 112, 113, 114, 115, 116,
+        ];
+        // give each block time to settle into the fifo. we want the overrun to occur at a well-defined point.
+        uart.write_all(&data).await.unwrap();
+        uart.blocking_flush().unwrap();
+        while uart.busy() {}
+        uart.write_all(&overflow).await.unwrap();
+        uart.blocking_flush().unwrap();
+        while uart.busy() {}
+
+        // already buffered/fifod prefix is valid
+        assert_eq!(read(&mut uart).await.unwrap(), data);
+        // next received character causes overrun error and is discarded
+        uart.write_all(&[1, 2, 3]).await.unwrap();
+        uart.blocking_flush().unwrap();
+        assert_eq!(read::<1>(&mut uart).await.unwrap_err(), Error::Overrun);
+        assert_eq!(read(&mut uart).await.unwrap(), [2, 3]);
+    }
+
+    info!("test break detection");
+    {
+        let mut config = Config::default();
+        config.baudrate = 1000;
+        let tx_buf = &mut [0u8; 16];
+        let rx_buf = &mut [0u8; 16];
+        let mut uart = BufferedUart::new(&mut uart, &mut irq, &mut tx, &mut rx, tx_buf, rx_buf, config);
+
+        // break on empty buffer
+        uart.send_break(20).await;
+        assert_eq!(read::<1>(&mut uart).await.unwrap_err(), Error::Break);
+        uart.write_all(&[64]).await.unwrap();
+        assert_eq!(read(&mut uart).await.unwrap(), [64]);
+
+        // break on partially filled buffer
+        uart.write_all(&[65; 2]).await.unwrap();
+        uart.send_break(20).await;
+        uart.write_all(&[66]).await.unwrap();
+        assert_eq!(read(&mut uart).await.unwrap(), [65; 2]);
+        assert_eq!(read::<1>(&mut uart).await.unwrap_err(), Error::Break);
+        assert_eq!(read(&mut uart).await.unwrap(), [66]);
+
+        // break on full buffer
+        uart.write_all(&[64; 16]).await.unwrap();
+        uart.send_break(20).await;
+        uart.write_all(&[65]).await.unwrap();
+        assert_eq!(read(&mut uart).await.unwrap(), [64; 16]);
+        assert_eq!(read::<1>(&mut uart).await.unwrap_err(), Error::Break);
+        assert_eq!(read(&mut uart).await.unwrap(), [65]);
+    }
+
+    // parity detection. here we bitbang to not require two uarts.
+    info!("test parity error detection");
+    {
+        let mut pin = Output::new(&mut tx, Level::High);
+        // choose a very slow baud rate to make tests reliable even with O0
+        let mut config = Config::default();
+        config.baudrate = 1000;
+        config.parity = Parity::ParityEven;
+        let rx_buf = &mut [0u8; 16];
+        let mut uart = BufferedUartRx::new(&mut uart, &mut irq, &mut rx, rx_buf, config);
+
+        async fn chr(pin: &mut Output<'_, impl embassy_rp::gpio::Pin>, v: u8, parity: u32) {
+            send(pin, v, Some(parity != 0)).await;
+        }
+
+        // first check that we can send correctly
+        chr(&mut pin, 64, 1).await;
+        assert_eq!(read1(&mut uart).await.unwrap(), [64]);
+
+        // parity on empty buffer
+        chr(&mut pin, 64, 0).await;
+        chr(&mut pin, 4, 1).await;
+        assert_eq!(read1::<1>(&mut uart).await.unwrap_err(), Error::Parity);
+        assert_eq!(read1(&mut uart).await.unwrap(), [4]);
+
+        // parity on partially filled buffer
+        chr(&mut pin, 64, 1).await;
+        chr(&mut pin, 32, 1).await;
+        chr(&mut pin, 64, 0).await;
+        chr(&mut pin, 65, 0).await;
+        assert_eq!(read1(&mut uart).await.unwrap(), [64, 32]);
+        assert_eq!(read1::<1>(&mut uart).await.unwrap_err(), Error::Parity);
+        assert_eq!(read1(&mut uart).await.unwrap(), [65]);
+
+        // parity on full buffer
+        for i in 0..16 {
+            chr(&mut pin, i, i.count_ones() % 2).await;
+        }
+        chr(&mut pin, 64, 0).await;
+        chr(&mut pin, 65, 0).await;
+        assert_eq!(
+            read1(&mut uart).await.unwrap(),
+            [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15]
+        );
+        assert_eq!(read1::<1>(&mut uart).await.unwrap_err(), Error::Parity);
+        assert_eq!(read1(&mut uart).await.unwrap(), [65]);
+    }
+
+    // framing error detection. here we bitbang because there's no other way.
+    info!("test framing error detection");
+    {
+        let mut pin = Output::new(&mut tx, Level::High);
+        // choose a very slow baud rate to make tests reliable even with O0
+        let mut config = Config::default();
+        config.baudrate = 1000;
+        let rx_buf = &mut [0u8; 16];
+        let mut uart = BufferedUartRx::new(&mut uart, &mut irq, &mut rx, rx_buf, config);
+
+        async fn chr(pin: &mut Output<'_, impl embassy_rp::gpio::Pin>, v: u8, good: bool) {
+            if good {
+                send(pin, v, None).await;
+            } else {
+                send(pin, v, Some(false)).await;
+            }
+        }
+
+        // first check that we can send correctly
+        chr(&mut pin, 64, true).await;
+        assert_eq!(read1(&mut uart).await.unwrap(), [64]);
+
+        // framing on empty buffer
+        chr(&mut pin, 64, false).await;
+        assert_eq!(read1::<1>(&mut uart).await.unwrap_err(), Error::Framing);
+        chr(&mut pin, 65, true).await;
+        assert_eq!(read1(&mut uart).await.unwrap(), [65]);
+
+        // framing on partially filled buffer
+        chr(&mut pin, 64, true).await;
+        chr(&mut pin, 32, true).await;
+        chr(&mut pin, 64, false).await;
+        chr(&mut pin, 65, true).await;
+        assert_eq!(read1(&mut uart).await.unwrap(), [64, 32]);
+        assert_eq!(read1::<1>(&mut uart).await.unwrap_err(), Error::Framing);
+        assert_eq!(read1(&mut uart).await.unwrap(), [65]);
+
+        // framing on full buffer
+        for i in 0..16 {
+            chr(&mut pin, i, true).await;
+        }
+        chr(&mut pin, 64, false).await;
+        chr(&mut pin, 65, true).await;
+        assert_eq!(
+            read1(&mut uart).await.unwrap(),
+            [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15]
+        );
+        assert_eq!(read1::<1>(&mut uart).await.unwrap_err(), Error::Framing);
+        assert_eq!(read1(&mut uart).await.unwrap(), [65]);
+    }
 
     info!("Test OK");
     cortex_m::asm::bkpt();

--- a/tests/rp/src/bin/uart_buffered.rs
+++ b/tests/rp/src/bin/uart_buffered.rs
@@ -26,13 +26,13 @@ async fn main(_spawner: Spawner) {
     // bufferedUart.
 
     let data = [
-        1u8, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29,
-        30, 31,
+        1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30,
+        31, 32, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44, 45, 46, 47, 48,
     ];
     uart.write_all(&data).await.unwrap();
     info!("Done writing");
 
-    let mut buf = [0; 31];
+    let mut buf = [0; 48];
     uart.read_exact(&mut buf).await.unwrap();
     assert_eq!(buf, data);
 

--- a/tests/rp/src/bin/uart_dma.rs
+++ b/tests/rp/src/bin/uart_dma.rs
@@ -4,28 +4,246 @@
 
 use defmt::{assert_eq, *};
 use embassy_executor::Spawner;
-use embassy_rp::uart::{Config, Uart};
+use embassy_rp::gpio::{Level, Output};
+use embassy_rp::interrupt;
+use embassy_rp::uart::{Async, Config, Error, Instance, Parity, Uart, UartRx};
+use embassy_time::{Duration, Timer};
 use {defmt_rtt as _, panic_probe as _};
+
+async fn read<const N: usize>(uart: &mut Uart<'_, impl Instance, Async>) -> Result<[u8; N], Error> {
+    let mut buf = [255; N];
+    uart.read(&mut buf).await?;
+    Ok(buf)
+}
+
+async fn read1<const N: usize>(uart: &mut UartRx<'_, impl Instance, Async>) -> Result<[u8; N], Error> {
+    let mut buf = [255; N];
+    uart.read(&mut buf).await?;
+    Ok(buf)
+}
+
+async fn send(pin: &mut Output<'_, impl embassy_rp::gpio::Pin>, v: u8, parity: Option<bool>) {
+    pin.set_low();
+    Timer::after(Duration::from_millis(1)).await;
+    for i in 0..8 {
+        if v & (1 << i) == 0 {
+            pin.set_low();
+        } else {
+            pin.set_high();
+        }
+        Timer::after(Duration::from_millis(1)).await;
+    }
+    if let Some(b) = parity {
+        if b {
+            pin.set_high();
+        } else {
+            pin.set_low();
+        }
+        Timer::after(Duration::from_millis(1)).await;
+    }
+    pin.set_high();
+    Timer::after(Duration::from_millis(1)).await;
+}
 
 #[embassy_executor::main]
 async fn main(_spawner: Spawner) {
-    let p = embassy_rp::init(Default::default());
+    let mut p = embassy_rp::init(Default::default());
     info!("Hello World!");
 
-    let (tx, rx, uart) = (p.PIN_0, p.PIN_1, p.UART0);
+    let (mut tx, mut rx, mut uart) = (p.PIN_0, p.PIN_1, p.UART0);
+    let mut irq = interrupt::take!(UART0_IRQ);
 
-    let config = Config::default();
-    let mut uart = Uart::new(uart, tx, rx, p.DMA_CH0, p.DMA_CH1, config);
+    // TODO
+    // nuclear error reporting. just abort the entire transfer and invalidate the
+    // dma buffer, buffered buffer, fifo etc.
 
     // We can't send too many bytes, they have to fit in the FIFO.
     // This is because we aren't sending+receiving at the same time.
+    {
+        let config = Config::default();
+        let mut uart = Uart::new(
+            &mut uart,
+            &mut tx,
+            &mut rx,
+            &mut irq,
+            &mut p.DMA_CH0,
+            &mut p.DMA_CH1,
+            config,
+        );
 
-    let data = [0xC0, 0xDE];
-    uart.write(&data).await.unwrap();
+        let data = [0xC0, 0xDE];
+        uart.write(&data).await.unwrap();
 
-    let mut buf = [0; 2];
-    uart.read(&mut buf).await.unwrap();
-    assert_eq!(buf, data);
+        let mut buf = [0; 2];
+        uart.read(&mut buf).await.unwrap();
+        assert_eq!(buf, data);
+    }
+
+    info!("test overflow detection");
+    {
+        let config = Config::default();
+        let mut uart = Uart::new(
+            &mut uart,
+            &mut tx,
+            &mut rx,
+            &mut irq,
+            &mut p.DMA_CH0,
+            &mut p.DMA_CH1,
+            config,
+        );
+
+        uart.blocking_write(&[42; 32]).unwrap();
+        uart.blocking_write(&[1, 2, 3]).unwrap();
+        uart.blocking_flush().unwrap();
+
+        // can receive regular fifo contents
+        assert_eq!(read(&mut uart).await, Ok([42; 16]));
+        assert_eq!(read(&mut uart).await, Ok([42; 16]));
+        // receiving the rest fails with overrun
+        assert_eq!(read::<16>(&mut uart).await, Err(Error::Overrun));
+        // new data is accepted, latest overrunning byte first
+        assert_eq!(read(&mut uart).await, Ok([3]));
+        uart.blocking_write(&[8, 9]).unwrap();
+        Timer::after(Duration::from_millis(1)).await;
+        assert_eq!(read(&mut uart).await, Ok([8, 9]));
+    }
+
+    info!("test break detection");
+    {
+        let config = Config::default();
+        let (mut tx, mut rx) = Uart::new(
+            &mut uart,
+            &mut tx,
+            &mut rx,
+            &mut irq,
+            &mut p.DMA_CH0,
+            &mut p.DMA_CH1,
+            config,
+        )
+        .split();
+
+        // break before read
+        tx.send_break(20).await;
+        tx.write(&[64]).await.unwrap();
+        assert_eq!(read1::<1>(&mut rx).await.unwrap_err(), Error::Break);
+        assert_eq!(read1(&mut rx).await.unwrap(), [64]);
+
+        // break during read
+        {
+            let r = read1::<2>(&mut rx);
+            tx.write(&[2]).await.unwrap();
+            tx.send_break(20).await;
+            tx.write(&[3]).await.unwrap();
+            assert_eq!(r.await.unwrap_err(), Error::Break);
+            assert_eq!(read1(&mut rx).await.unwrap(), [3]);
+        }
+
+        // break after read
+        {
+            let r = read1(&mut rx);
+            tx.write(&[2]).await.unwrap();
+            tx.send_break(20).await;
+            tx.write(&[3]).await.unwrap();
+            assert_eq!(r.await.unwrap(), [2]);
+            assert_eq!(read1::<1>(&mut rx).await.unwrap_err(), Error::Break);
+            assert_eq!(read1(&mut rx).await.unwrap(), [3]);
+        }
+    }
+
+    // parity detection. here we bitbang to not require two uarts.
+    info!("test parity error detection");
+    {
+        let mut pin = Output::new(&mut tx, Level::High);
+        // choose a very slow baud rate to make tests reliable even with O0
+        let mut config = Config::default();
+        config.baudrate = 1000;
+        config.parity = Parity::ParityEven;
+        let mut uart = UartRx::new(&mut uart, &mut rx, &mut irq, &mut p.DMA_CH0, config);
+
+        async fn chr(pin: &mut Output<'_, impl embassy_rp::gpio::Pin>, v: u8, parity: u32) {
+            send(pin, v, Some(parity != 0)).await;
+        }
+
+        // first check that we can send correctly
+        chr(&mut pin, 32, 1).await;
+        assert_eq!(read1(&mut uart).await.unwrap(), [32]);
+
+        // parity error before read
+        chr(&mut pin, 32, 0).await;
+        chr(&mut pin, 31, 1).await;
+        assert_eq!(read1::<1>(&mut uart).await.unwrap_err(), Error::Parity);
+        assert_eq!(read1(&mut uart).await.unwrap(), [31]);
+
+        // parity error during read
+        {
+            let r = read1::<2>(&mut uart);
+            chr(&mut pin, 2, 1).await;
+            chr(&mut pin, 32, 0).await;
+            chr(&mut pin, 3, 0).await;
+            assert_eq!(r.await.unwrap_err(), Error::Parity);
+            assert_eq!(read1(&mut uart).await.unwrap(), [3]);
+        }
+
+        // parity error after read
+        {
+            let r = read1(&mut uart);
+            chr(&mut pin, 2, 1).await;
+            chr(&mut pin, 32, 0).await;
+            chr(&mut pin, 3, 0).await;
+            assert_eq!(r.await.unwrap(), [2]);
+            assert_eq!(read1::<1>(&mut uart).await.unwrap_err(), Error::Parity);
+            assert_eq!(read1(&mut uart).await.unwrap(), [3]);
+        }
+    }
+
+    // framing error detection. here we bitbang because there's no other way.
+    info!("test framing error detection");
+    {
+        let mut pin = Output::new(&mut tx, Level::High);
+        // choose a very slow baud rate to make tests reliable even with O0
+        let mut config = Config::default();
+        config.baudrate = 1000;
+        let mut uart = UartRx::new(&mut uart, &mut rx, &mut irq, &mut p.DMA_CH0, config);
+
+        async fn chr(pin: &mut Output<'_, impl embassy_rp::gpio::Pin>, v: u8, good: bool) {
+            if good {
+                send(pin, v, None).await;
+            } else {
+                send(pin, v, Some(false)).await;
+            }
+        }
+
+        // first check that we can send correctly
+        chr(&mut pin, 32, true).await;
+        assert_eq!(read1(&mut uart).await.unwrap(), [32]);
+
+        // parity error before read
+        chr(&mut pin, 32, false).await;
+        chr(&mut pin, 31, true).await;
+        assert_eq!(read1::<1>(&mut uart).await.unwrap_err(), Error::Framing);
+        assert_eq!(read1(&mut uart).await.unwrap(), [31]);
+
+        // parity error during read
+        {
+            let r = read1::<2>(&mut uart);
+            chr(&mut pin, 2, true).await;
+            chr(&mut pin, 32, false).await;
+            chr(&mut pin, 3, true).await;
+            assert_eq!(r.await.unwrap_err(), Error::Framing);
+            assert_eq!(read1(&mut uart).await.unwrap(), [3]);
+        }
+
+        // parity error after read
+        {
+            let r = read1(&mut uart);
+            chr(&mut pin, 2, true).await;
+            chr(&mut pin, 32, false).await;
+            chr(&mut pin, 3, true).await;
+            assert_eq!(r.await.unwrap(), [2]);
+            assert_eq!(read1::<1>(&mut uart).await.unwrap_err(), Error::Framing);
+            assert_eq!(read1(&mut uart).await.unwrap(), [3]);
+        }
+    }
 
     info!("Test OK");
     cortex_m::asm::bkpt();


### PR DESCRIPTION
neither of these reported errors so far, which is not ideal. add error reporting to both of them that matches the blocking error reporting as closely as is feasible, even allowing partial receives from buffered uarts before errors are reported where they would have been by the blocking code. dma transfers don't do this, if an errors applies to any byte in a transfer the entire transfer is nuked (though we probably could report how many bytes have been transferred).