### PR TITLE
rp pio, √9

### DIFF
--- a/embassy-rp/src/pio_instr_util.rs
+++ b/embassy-rp/src/pio_instr_util.rs
@@ -8,7 +8,7 @@ pub fn set_x<PIO: PioInstance, const SM: usize>(sm: &mut PioStateMachine<PIO, SM
         bit_count: 32,
     }
     .encode();
-    sm.push_tx(value);
+    sm.tx().push(value);
     sm.exec_instr(OUT);
 }
 
@@ -19,7 +19,7 @@ pub fn get_x<PIO: PioInstance, const SM: usize>(sm: &mut PioStateMachine<PIO, SM
     }
     .encode();
     sm.exec_instr(IN);
-    sm.pull_rx()
+    sm.rx().pull()
 }
 
 pub fn set_y<PIO: PioInstance, const SM: usize>(sm: &mut PioStateMachine<PIO, SM>, value: u32) {
@@ -28,7 +28,7 @@ pub fn set_y<PIO: PioInstance, const SM: usize>(sm: &mut PioStateMachine<PIO, SM
         bit_count: 32,
     }
     .encode();
-    sm.push_tx(value);
+    sm.tx().push(value);
     sm.exec_instr(OUT);
 }
 
@@ -40,7 +40,7 @@ pub fn get_y<PIO: PioInstance, const SM: usize>(sm: &mut PioStateMachine<PIO, SM
     .encode();
     sm.exec_instr(IN);
 
-    sm.pull_rx()
+    sm.rx().pull()
 }
 
 pub fn set_pindir<PIO: PioInstance, const SM: usize>(sm: &mut PioStateMachine<PIO, SM>, data: u8) {
@@ -67,7 +67,7 @@ pub fn set_out_pin<PIO: PioInstance, const SM: usize>(sm: &mut PioStateMachine<P
         bit_count: 32,
     }
     .encode();
-    sm.push_tx(data);
+    sm.tx().push(data);
     sm.exec_instr(OUT);
 }
 pub fn set_out_pindir<PIO: PioInstance, const SM: usize>(sm: &mut PioStateMachine<PIO, SM>, data: u32) {
@@ -76,7 +76,7 @@ pub fn set_out_pindir<PIO: PioInstance, const SM: usize>(sm: &mut PioStateMachin
         bit_count: 32,
     }
     .encode();
-    sm.push_tx(data);
+    sm.tx().push(data);
     sm.exec_instr(OUT);
 }
 

--- a/examples/rp/src/bin/pio_async.rs
+++ b/examples/rp/src/bin/pio_async.rs
@@ -42,7 +42,7 @@ async fn pio_task_sm0(mut sm: PioStateMachine<'static, PIO0, 0>) {
 
     let mut v = 0x0f0caffa;
     loop {
-        sm.wait_push(v).await;
+        sm.tx().wait_push(v).await;
         v ^= 0xffff;
         info!("Pushed {:032b} to FIFO", v);
     }
@@ -70,7 +70,7 @@ fn setup_pio_task_sm1(pio: &mut PioCommon<PIO0>, sm: &mut PioStateMachine<PIO0, 
 async fn pio_task_sm1(mut sm: PioStateMachine<'static, PIO0, 1>) {
     sm.set_enable(true);
     loop {
-        let rx = sm.wait_pull().await;
+        let rx = sm.rx().wait_pull().await;
         info!("Pulled {:032b} from FIFO", rx);
     }
 }

--- a/examples/rp/src/bin/pio_dma.rs
+++ b/examples/rp/src/bin/pio_dma.rs
@@ -60,9 +60,10 @@ async fn main(_spawner: Spawner) {
     }
     let mut din = [0u32; 29];
     loop {
+        let (rx, tx) = sm.rx_tx();
         join(
-            sm.dma_push(dma_out_ref.reborrow(), &dout),
-            sm.dma_pull(dma_in_ref.reborrow(), &mut din),
+            tx.dma_push(dma_out_ref.reborrow(), &dout),
+            rx.dma_pull(dma_in_ref.reborrow(), &mut din),
         )
         .await;
         for i in 0..din.len() {

--- a/examples/rp/src/bin/pio_hd44780.rs
+++ b/examples/rp/src/bin/pio_hd44780.rs
@@ -139,14 +139,14 @@ impl<'l> HD44780<'l> {
 
         sm0.set_enable(true);
         // init to 8 bit thrice
-        sm0.push_tx((50000 << 8) | 0x30);
-        sm0.push_tx((5000 << 8) | 0x30);
-        sm0.push_tx((200 << 8) | 0x30);
+        sm0.tx().push((50000 << 8) | 0x30);
+        sm0.tx().push((5000 << 8) | 0x30);
+        sm0.tx().push((200 << 8) | 0x30);
         // init 4 bit
-        sm0.push_tx((200 << 8) | 0x20);
+        sm0.tx().push((200 << 8) | 0x20);
         // set font and lines
-        sm0.push_tx((50 << 8) | 0x20);
-        sm0.push_tx(0b1100_0000);
+        sm0.tx().push((50 << 8) | 0x20);
+        sm0.tx().push(0b1100_0000);
 
         irq0.wait().await;
         sm0.set_enable(false);
@@ -216,7 +216,7 @@ impl<'l> HD44780<'l> {
         sm0.set_enable(true);
 
         // display on and cursor on and blinking, reset display
-        sm0.dma_push(dma.reborrow(), &[0x81u8, 0x0f, 1]).await;
+        sm0.tx().dma_push(dma.reborrow(), &[0x81u8, 0x0f, 1]).await;
 
         Self {
             dma: dma.map_into(),
@@ -240,6 +240,6 @@ impl<'l> HD44780<'l> {
         // set cursor to 1:15
         self.buf[38..].copy_from_slice(&[0x80, 0xcf]);
 
-        self.sm.dma_push(self.dma.reborrow(), &self.buf).await;
+        self.sm.tx().dma_push(self.dma.reborrow(), &self.buf).await;
     }
 }

--- a/examples/rp/src/bin/ws2812-pio.rs
+++ b/examples/rp/src/bin/ws2812-pio.rs
@@ -87,7 +87,7 @@ impl<'d, P: PioInstance, const S: usize> Ws2812<'d, P, S> {
     pub async fn write(&mut self, colors: &[RGB8]) {
         for color in colors {
             let word = (u32::from(color.g) << 24) | (u32::from(color.r) << 16) | (u32::from(color.b) << 8);
-            self.sm.wait_push(word).await;
+            self.sm.tx().wait_push(word).await;
         }
     }
 }


### PR DESCRIPTION
another mix of refactoring and soundness issues. most notably pio pins are now checked for being actually accessible to the pio blocks, are constructible from not just the owned peripherals but refs as well, and have their registrations to the pio block reverted once all state machines and the common block has been dropped.

state machines are now also stopped when dropped, and concurrent rx+tx using dma can finally be done in a sound manner. previously it was possible to do, but allowed users to start two concurrent transfers to the same fifo using different dma channels, which obviously would not have the expected results on average.