### PR TITLE
Handle SUBGHZSPI as async

### DIFF
--- a/examples/stm32wl/src/bin/lora_p2p_receive.rs
+++ b/examples/stm32wl/src/bin/lora_p2p_receive.rs
@@ -7,15 +7,12 @@
 #![allow(incomplete_features)]
 
 use defmt::info;
-use embassy_embedded_hal::adapter::BlockingAsync;
 use embassy_executor::Spawner;
 use embassy_lora::iv::Stm32wlInterfaceVariant;
-use embassy_stm32::dma::NoDma;
 use embassy_stm32::gpio::{Level, Output, Pin, Speed};
 use embassy_stm32::peripherals::SUBGHZSPI;
 use embassy_stm32::rcc::low_level::RccPeripheral;
-use embassy_stm32::spi::{BitOrder, Config as SpiConfig, Spi, MODE_0};
-use embassy_stm32::time::Hertz;
+use embassy_stm32::spi::Spi;
 use embassy_stm32::{interrupt, into_ref, Peripheral};
 use embassy_time::{Delay, Duration, Timer};
 use lora_phy::mod_params::*;
@@ -31,13 +28,8 @@ async fn main(_spawner: Spawner) {
     config.rcc.mux = embassy_stm32::rcc::ClockSrc::HSE32;
     let p = embassy_stm32::init(config);
 
-    let clk = Hertz(core::cmp::min(SUBGHZSPI::frequency().0 / 2, 16_000_000));
-    let mut spi_config = SpiConfig::default();
-    spi_config.mode = MODE_0;
-    spi_config.bit_order = BitOrder::MsbFirst;
-    let spi = Spi::new_subghz(p.SUBGHZSPI, NoDma, NoDma, clk, spi_config);
-
-    let spi = BlockingAsync::new(spi);
+    let pclk3_freq = SUBGHZSPI::frequency().0;
+    let spi = Spi::new_subghz(p.SUBGHZSPI, p.DMA1_CH1, p.DMA1_CH2, pclk3_freq);
 
     let irq = interrupt::take!(SUBGHZ_RADIO);
     into_ref!(irq);

--- a/examples/stm32wl/src/bin/lora_p2p_send.rs
+++ b/examples/stm32wl/src/bin/lora_p2p_send.rs
@@ -7,15 +7,12 @@
 #![allow(incomplete_features)]
 
 use defmt::info;
-use embassy_embedded_hal::adapter::BlockingAsync;
 use embassy_executor::Spawner;
 use embassy_lora::iv::Stm32wlInterfaceVariant;
-use embassy_stm32::dma::NoDma;
 use embassy_stm32::gpio::{Level, Output, Pin, Speed};
 use embassy_stm32::peripherals::SUBGHZSPI;
 use embassy_stm32::rcc::low_level::RccPeripheral;
-use embassy_stm32::spi::{BitOrder, Config as SpiConfig, Spi, MODE_0};
-use embassy_stm32::time::Hertz;
+use embassy_stm32::spi::Spi;
 use embassy_stm32::{interrupt, into_ref, Peripheral};
 use embassy_time::Delay;
 use lora_phy::mod_params::*;
@@ -31,13 +28,8 @@ async fn main(_spawner: Spawner) {
     config.rcc.mux = embassy_stm32::rcc::ClockSrc::HSE32;
     let p = embassy_stm32::init(config);
 
-    let clk = Hertz(core::cmp::min(SUBGHZSPI::frequency().0 / 2, 16_000_000));
-    let mut spi_config = SpiConfig::default();
-    spi_config.mode = MODE_0;
-    spi_config.bit_order = BitOrder::MsbFirst;
-    let spi = Spi::new_subghz(p.SUBGHZSPI, NoDma, NoDma, clk, spi_config);
-
-    let spi = BlockingAsync::new(spi);
+    let pclk3_freq = SUBGHZSPI::frequency().0;
+    let spi = Spi::new_subghz(p.SUBGHZSPI, p.DMA1_CH1, p.DMA1_CH2, pclk3_freq);
 
     let irq = interrupt::take!(SUBGHZ_RADIO);
     into_ref!(irq);


### PR DESCRIPTION
For STM32WL, simplify configuration for the use of SUBGHZSPI to perform LoRa operations.  Use Rx/Tx DMA on SPI to enable async functionality.