### PR TITLE
Simplify SUBGHZSPI configuration

### DIFF
--- a/embassy-stm32/src/spi/mod.rs
+++ b/embassy-stm32/src/spi/mod.rs
@@ -194,17 +194,17 @@ impl<'d, T: Instance, Tx, Rx> Spi<'d, T, Tx, Rx> {
         Self::new_inner(peri, None, Some(mosi.map_into()), None, txdma, rxdma, freq, config)
     }
 
+    #[cfg(stm32wl)]
     /// Useful for on chip peripherals like SUBGHZ which are hardwired.
-    #[allow(dead_code)]
     pub fn new_subghz(
         peri: impl Peripheral<P = T> + 'd,
         txdma: impl Peripheral<P = Tx> + 'd,
         rxdma: impl Peripheral<P = Rx> + 'd,
-        pclk3_freq: u32,
     ) -> Self {
         // see RM0453 rev 1 section 7.2.13 page 291
         // The SUBGHZSPI_SCK frequency is obtained by PCLK3 divided by two.
         // The SUBGHZSPI_SCK clock maximum speed must not exceed 16 MHz.
+        let pclk3_freq = <peripherals::SUBGHZSPI as crate::rcc::sealed::RccPeripheral>::frequency().0;
         let freq = Hertz(core::cmp::min(pclk3_freq / 2, 16_000_000));
         let mut config = Config::default();
         config.mode = MODE_0;

--- a/examples/stm32wl/src/bin/lora_lorawan.rs
+++ b/examples/stm32wl/src/bin/lora_lorawan.rs
@@ -11,8 +11,6 @@ use embassy_executor::Spawner;
 use embassy_lora::iv::Stm32wlInterfaceVariant;
 use embassy_lora::LoraTimer;
 use embassy_stm32::gpio::{Level, Output, Pin, Speed};
-use embassy_stm32::peripherals::SUBGHZSPI;
-use embassy_stm32::rcc::low_level::RccPeripheral;
 use embassy_stm32::rng::Rng;
 use embassy_stm32::spi::Spi;
 use embassy_stm32::{interrupt, into_ref, pac, Peripheral};
@@ -36,8 +34,7 @@ async fn main(_spawner: Spawner) {
 
     unsafe { pac::RCC.ccipr().modify(|w| w.set_rngsel(0b01)) }
 
-    let pclk3_freq = SUBGHZSPI::frequency().0;
-    let spi = Spi::new_subghz(p.SUBGHZSPI, p.DMA1_CH1, p.DMA1_CH2, pclk3_freq);
+    let spi = Spi::new_subghz(p.SUBGHZSPI, p.DMA1_CH1, p.DMA1_CH2);
 
     let irq = interrupt::take!(SUBGHZ_RADIO);
     into_ref!(irq);

--- a/examples/stm32wl/src/bin/lora_p2p_receive.rs
+++ b/examples/stm32wl/src/bin/lora_p2p_receive.rs
@@ -10,8 +10,6 @@ use defmt::info;
 use embassy_executor::Spawner;
 use embassy_lora::iv::Stm32wlInterfaceVariant;
 use embassy_stm32::gpio::{Level, Output, Pin, Speed};
-use embassy_stm32::peripherals::SUBGHZSPI;
-use embassy_stm32::rcc::low_level::RccPeripheral;
 use embassy_stm32::spi::Spi;
 use embassy_stm32::{interrupt, into_ref, Peripheral};
 use embassy_time::{Delay, Duration, Timer};
@@ -28,8 +26,7 @@ async fn main(_spawner: Spawner) {
     config.rcc.mux = embassy_stm32::rcc::ClockSrc::HSE32;
     let p = embassy_stm32::init(config);
 
-    let pclk3_freq = SUBGHZSPI::frequency().0;
-    let spi = Spi::new_subghz(p.SUBGHZSPI, p.DMA1_CH1, p.DMA1_CH2, pclk3_freq);
+    let spi = Spi::new_subghz(p.SUBGHZSPI, p.DMA1_CH1, p.DMA1_CH2);
 
     let irq = interrupt::take!(SUBGHZ_RADIO);
     into_ref!(irq);

--- a/examples/stm32wl/src/bin/lora_p2p_send.rs
+++ b/examples/stm32wl/src/bin/lora_p2p_send.rs
@@ -10,8 +10,6 @@ use defmt::info;
 use embassy_executor::Spawner;
 use embassy_lora::iv::Stm32wlInterfaceVariant;
 use embassy_stm32::gpio::{Level, Output, Pin, Speed};
-use embassy_stm32::peripherals::SUBGHZSPI;
-use embassy_stm32::rcc::low_level::RccPeripheral;
 use embassy_stm32::spi::Spi;
 use embassy_stm32::{interrupt, into_ref, Peripheral};
 use embassy_time::Delay;
@@ -28,8 +26,7 @@ async fn main(_spawner: Spawner) {
     config.rcc.mux = embassy_stm32::rcc::ClockSrc::HSE32;
     let p = embassy_stm32::init(config);
 
-    let pclk3_freq = SUBGHZSPI::frequency().0;
-    let spi = Spi::new_subghz(p.SUBGHZSPI, p.DMA1_CH1, p.DMA1_CH2, pclk3_freq);
+    let spi = Spi::new_subghz(p.SUBGHZSPI, p.DMA1_CH1, p.DMA1_CH2);
 
     let irq = interrupt::take!(SUBGHZ_RADIO);
     into_ref!(irq);


### PR DESCRIPTION
Determine SUBGHZSPI PCLK3 within new_subghz(), controlled by the stm32wl feature.