### PR TITLE
rp pio IV (the voyage home)

### DIFF
--- a/embassy-rp/src/pio.rs
+++ b/embassy-rp/src/pio.rs
@@ -1070,7 +1070,8 @@ fn on_pio_drop<PIO: Instance>() {
     if state.users.fetch_sub(1, Ordering::AcqRel) == 1 {
         let used_pins = state.used_pins.load(Ordering::Relaxed);
         let null = Gpio0ctrlFuncsel::NULL.0;
-        for i in 0..32 {
+        // we only have 30 pins. don't test the other two since gpio() asserts.
+        for i in 0..30 {
             if used_pins & (1 << i) != 0 {
                 unsafe {
                     pac::IO_BANK0.gpio(i).ctrl().write(|w| w.set_funcsel(null));

--- a/embassy-rp/src/pio.rs
+++ b/embassy-rp/src/pio.rs
@@ -307,7 +307,9 @@ impl<'d, PIO: Instance, const SM: usize> StateMachineRx<'d, PIO, SM> {
         unsafe {
             let fdebug = PIO::PIO.fdebug();
             let ret = fdebug.read().rxstall() & (1 << SM) != 0;
-            fdebug.write(|w| w.set_rxstall(1 << SM));
+            if ret {
+                fdebug.write(|w| w.set_rxstall(1 << SM));
+            }
             ret
         }
     }
@@ -316,7 +318,9 @@ impl<'d, PIO: Instance, const SM: usize> StateMachineRx<'d, PIO, SM> {
         unsafe {
             let fdebug = PIO::PIO.fdebug();
             let ret = fdebug.read().rxunder() & (1 << SM) != 0;
-            fdebug.write(|w| w.set_rxunder(1 << SM));
+            if ret {
+                fdebug.write(|w| w.set_rxunder(1 << SM));
+            }
             ret
         }
     }
@@ -383,7 +387,9 @@ impl<'d, PIO: Instance, const SM: usize> StateMachineTx<'d, PIO, SM> {
         unsafe {
             let fdebug = PIO::PIO.fdebug();
             let ret = fdebug.read().txstall() & (1 << SM) != 0;
-            fdebug.write(|w| w.set_txstall(1 << SM));
+            if ret {
+                fdebug.write(|w| w.set_txstall(1 << SM));
+            }
             ret
         }
     }
@@ -392,7 +398,9 @@ impl<'d, PIO: Instance, const SM: usize> StateMachineTx<'d, PIO, SM> {
         unsafe {
             let fdebug = PIO::PIO.fdebug();
             let ret = fdebug.read().txover() & (1 << SM) != 0;
-            fdebug.write(|w| w.set_txover(1 << SM));
+            if ret {
+                fdebug.write(|w| w.set_txover(1 << SM));
+            }
             ret
         }
     }

--- a/embassy-rp/src/pio.rs
+++ b/embassy-rp/src/pio.rs
@@ -191,17 +191,10 @@ impl<'a, 'd, PIO: Instance> Future for IrqFuture<'a, 'd, PIO> {
         //debug!("Poll {},{}", PIO::PIO_NO, SM);
 
         // Check if IRQ flag is already set
-        if critical_section::with(|_| unsafe {
-            let irq_flags = PIO::PIO.irq();
-            if irq_flags.read().0 & (1 << self.irq_no) != 0 {
-                irq_flags.write(|m| {
-                    m.0 = 1 << self.irq_no;
-                });
-                true
-            } else {
-                false
+        if unsafe { PIO::PIO.irq().read().0 & (1 << self.irq_no) != 0 } {
+            unsafe {
+                PIO::PIO.irq().write(|m| m.0 = 1 << self.irq_no);
             }
-        }) {
             return Poll::Ready(());
         }
 

--- a/embassy-rp/src/pio.rs
+++ b/embassy-rp/src/pio.rs
@@ -181,7 +181,7 @@ impl<'a, 'd, PIO: Instance, const SM: usize> Drop for FifoInFuture<'a, 'd, PIO, 
 /// Future that waits for IRQ
 #[must_use = "futures do nothing unless you `.await` or poll them"]
 pub struct IrqFuture<'a, 'd, PIO: Instance> {
-    pio: PhantomData<&'a Irq<'d, PIO, 0>>,
+    pio: PhantomData<&'a mut Irq<'d, PIO, 0>>,
     irq_no: u8,
 }
 
@@ -287,7 +287,7 @@ impl<'l, PIO: Instance> Pin<'l, PIO> {
 }
 
 pub struct StateMachineRx<'d, PIO: Instance, const SM: usize> {
-    pio: PhantomData<&'d PIO>,
+    pio: PhantomData<&'d mut PIO>,
 }
 
 impl<'d, PIO: Instance, const SM: usize> StateMachineRx<'d, PIO, SM> {
@@ -364,7 +364,7 @@ impl<'d, PIO: Instance, const SM: usize> StateMachineRx<'d, PIO, SM> {
 }
 
 pub struct StateMachineTx<'d, PIO: Instance, const SM: usize> {
-    pio: PhantomData<&'d PIO>,
+    pio: PhantomData<&'d mut PIO>,
 }
 
 impl<'d, PIO: Instance, const SM: usize> StateMachineTx<'d, PIO, SM> {
@@ -777,7 +777,7 @@ impl<'d, PIO: Instance + 'd, const SM: usize> StateMachine<'d, PIO, SM> {
 
 pub struct Common<'d, PIO: Instance> {
     instructions_used: u32,
-    pio: PhantomData<&'d PIO>,
+    pio: PhantomData<&'d mut PIO>,
 }
 
 impl<'d, PIO: Instance> Drop for Common<'d, PIO> {
@@ -788,7 +788,7 @@ impl<'d, PIO: Instance> Drop for Common<'d, PIO> {
 
 pub struct InstanceMemory<'d, PIO: Instance> {
     used_mask: u32,
-    pio: PhantomData<&'d PIO>,
+    pio: PhantomData<&'d mut PIO>,
 }
 
 impl<'d, PIO: Instance> Common<'d, PIO> {
@@ -859,7 +859,7 @@ impl<'d, PIO: Instance> Common<'d, PIO> {
 }
 
 pub struct Irq<'d, PIO: Instance, const N: usize> {
-    pio: PhantomData<&'d PIO>,
+    pio: PhantomData<&'d mut PIO>,
 }
 
 impl<'d, PIO: Instance, const N: usize> Irq<'d, PIO, N> {
@@ -873,7 +873,7 @@ impl<'d, PIO: Instance, const N: usize> Irq<'d, PIO, N> {
 
 #[derive(Clone)]
 pub struct IrqFlags<'d, PIO: Instance> {
-    pio: PhantomData<&'d PIO>,
+    pio: PhantomData<&'d mut PIO>,
 }
 
 impl<'d, PIO: Instance> IrqFlags<'d, PIO> {
@@ -920,6 +920,7 @@ pub struct Pio<'d, PIO: Instance> {
     pub sm1: StateMachine<'d, PIO, 1>,
     pub sm2: StateMachine<'d, PIO, 2>,
     pub sm3: StateMachine<'d, PIO, 3>,
+    _pio: PhantomData<&'d mut PIO>,
 }
 
 impl<'d, PIO: Instance> Pio<'d, PIO> {
@@ -952,6 +953,7 @@ impl<'d, PIO: Instance> Pio<'d, PIO> {
                 rx: StateMachineRx { pio: PhantomData },
                 tx: StateMachineTx { pio: PhantomData },
             },
+            _pio: PhantomData,
         }
     }
 }

--- a/embassy-rp/src/pio.rs
+++ b/embassy-rp/src/pio.rs
@@ -790,10 +790,8 @@ impl<'d, PIO: Instance + 'd, const SM: usize> StateMachine<'d, PIO, SM> {
         }
     }
 
-    pub fn exec_instr(&mut self, instr: u16) {
-        unsafe {
-            Self::this_sm().instr().write(|w| w.set_instr(instr));
-        }
+    pub unsafe fn exec_instr(&mut self, instr: u16) {
+        Self::this_sm().instr().write(|w| w.set_instr(instr));
     }
 
     pub fn rx(&mut self) -> &mut StateMachineRx<'d, PIO, SM> {

--- a/embassy-rp/src/pio_instr_util.rs
+++ b/embassy-rp/src/pio_instr_util.rs
@@ -1,8 +1,8 @@
 use pio::{InSource, InstructionOperands, JmpCondition, OutDestination, SetDestination};
 
-use crate::pio::{PioInstance, PioStateMachine};
+use crate::pio::{Instance, StateMachine};
 
-pub fn set_x<PIO: PioInstance, const SM: usize>(sm: &mut PioStateMachine<PIO, SM>, value: u32) {
+pub fn set_x<PIO: Instance, const SM: usize>(sm: &mut StateMachine<PIO, SM>, value: u32) {
     const OUT: u16 = InstructionOperands::OUT {
         destination: OutDestination::X,
         bit_count: 32,
@@ -12,7 +12,7 @@ pub fn set_x<PIO: PioInstance, const SM: usize>(sm: &mut PioStateMachine<PIO, SM
     sm.exec_instr(OUT);
 }
 
-pub fn get_x<PIO: PioInstance, const SM: usize>(sm: &mut PioStateMachine<PIO, SM>) -> u32 {
+pub fn get_x<PIO: Instance, const SM: usize>(sm: &mut StateMachine<PIO, SM>) -> u32 {
     const IN: u16 = InstructionOperands::IN {
         source: InSource::X,
         bit_count: 32,
@@ -22,7 +22,7 @@ pub fn get_x<PIO: PioInstance, const SM: usize>(sm: &mut PioStateMachine<PIO, SM
     sm.rx().pull()
 }
 
-pub fn set_y<PIO: PioInstance, const SM: usize>(sm: &mut PioStateMachine<PIO, SM>, value: u32) {
+pub fn set_y<PIO: Instance, const SM: usize>(sm: &mut StateMachine<PIO, SM>, value: u32) {
     const OUT: u16 = InstructionOperands::OUT {
         destination: OutDestination::Y,
         bit_count: 32,
@@ -32,7 +32,7 @@ pub fn set_y<PIO: PioInstance, const SM: usize>(sm: &mut PioStateMachine<PIO, SM
     sm.exec_instr(OUT);
 }
 
-pub fn get_y<PIO: PioInstance, const SM: usize>(sm: &mut PioStateMachine<PIO, SM>) -> u32 {
+pub fn get_y<PIO: Instance, const SM: usize>(sm: &mut StateMachine<PIO, SM>) -> u32 {
     const IN: u16 = InstructionOperands::IN {
         source: InSource::Y,
         bit_count: 32,
@@ -43,7 +43,7 @@ pub fn get_y<PIO: PioInstance, const SM: usize>(sm: &mut PioStateMachine<PIO, SM
     sm.rx().pull()
 }
 
-pub fn set_pindir<PIO: PioInstance, const SM: usize>(sm: &mut PioStateMachine<PIO, SM>, data: u8) {
+pub fn set_pindir<PIO: Instance, const SM: usize>(sm: &mut StateMachine<PIO, SM>, data: u8) {
     let set: u16 = InstructionOperands::SET {
         destination: SetDestination::PINDIRS,
         data,
@@ -52,7 +52,7 @@ pub fn set_pindir<PIO: PioInstance, const SM: usize>(sm: &mut PioStateMachine<PI
     sm.exec_instr(set);
 }
 
-pub fn set_pin<PIO: PioInstance, const SM: usize>(sm: &mut PioStateMachine<PIO, SM>, data: u8) {
+pub fn set_pin<PIO: Instance, const SM: usize>(sm: &mut StateMachine<PIO, SM>, data: u8) {
     let set: u16 = InstructionOperands::SET {
         destination: SetDestination::PINS,
         data,
@@ -61,7 +61,7 @@ pub fn set_pin<PIO: PioInstance, const SM: usize>(sm: &mut PioStateMachine<PIO, 
     sm.exec_instr(set);
 }
 
-pub fn set_out_pin<PIO: PioInstance, const SM: usize>(sm: &mut PioStateMachine<PIO, SM>, data: u32) {
+pub fn set_out_pin<PIO: Instance, const SM: usize>(sm: &mut StateMachine<PIO, SM>, data: u32) {
     const OUT: u16 = InstructionOperands::OUT {
         destination: OutDestination::PINS,
         bit_count: 32,
@@ -70,7 +70,7 @@ pub fn set_out_pin<PIO: PioInstance, const SM: usize>(sm: &mut PioStateMachine<P
     sm.tx().push(data);
     sm.exec_instr(OUT);
 }
-pub fn set_out_pindir<PIO: PioInstance, const SM: usize>(sm: &mut PioStateMachine<PIO, SM>, data: u32) {
+pub fn set_out_pindir<PIO: Instance, const SM: usize>(sm: &mut StateMachine<PIO, SM>, data: u32) {
     const OUT: u16 = InstructionOperands::OUT {
         destination: OutDestination::PINDIRS,
         bit_count: 32,
@@ -80,7 +80,7 @@ pub fn set_out_pindir<PIO: PioInstance, const SM: usize>(sm: &mut PioStateMachin
     sm.exec_instr(OUT);
 }
 
-pub fn exec_jmp<PIO: PioInstance, const SM: usize>(sm: &mut PioStateMachine<PIO, SM>, to_addr: u8) {
+pub fn exec_jmp<PIO: Instance, const SM: usize>(sm: &mut StateMachine<PIO, SM>, to_addr: u8) {
     let jmp: u16 = InstructionOperands::JMP {
         address: to_addr,
         condition: JmpCondition::Always,

--- a/embassy-rp/src/pio_instr_util.rs
+++ b/embassy-rp/src/pio_instr_util.rs
@@ -2,7 +2,7 @@ use pio::{InSource, InstructionOperands, JmpCondition, OutDestination, SetDestin
 
 use crate::pio::{Instance, StateMachine};
 
-pub fn set_x<PIO: Instance, const SM: usize>(sm: &mut StateMachine<PIO, SM>, value: u32) {
+pub unsafe fn set_x<PIO: Instance, const SM: usize>(sm: &mut StateMachine<PIO, SM>, value: u32) {
     const OUT: u16 = InstructionOperands::OUT {
         destination: OutDestination::X,
         bit_count: 32,
@@ -12,7 +12,7 @@ pub fn set_x<PIO: Instance, const SM: usize>(sm: &mut StateMachine<PIO, SM>, val
     sm.exec_instr(OUT);
 }
 
-pub fn get_x<PIO: Instance, const SM: usize>(sm: &mut StateMachine<PIO, SM>) -> u32 {
+pub unsafe fn get_x<PIO: Instance, const SM: usize>(sm: &mut StateMachine<PIO, SM>) -> u32 {
     const IN: u16 = InstructionOperands::IN {
         source: InSource::X,
         bit_count: 32,
@@ -22,7 +22,7 @@ pub fn get_x<PIO: Instance, const SM: usize>(sm: &mut StateMachine<PIO, SM>) -> 
     sm.rx().pull()
 }
 
-pub fn set_y<PIO: Instance, const SM: usize>(sm: &mut StateMachine<PIO, SM>, value: u32) {
+pub unsafe fn set_y<PIO: Instance, const SM: usize>(sm: &mut StateMachine<PIO, SM>, value: u32) {
     const OUT: u16 = InstructionOperands::OUT {
         destination: OutDestination::Y,
         bit_count: 32,
@@ -32,7 +32,7 @@ pub fn set_y<PIO: Instance, const SM: usize>(sm: &mut StateMachine<PIO, SM>, val
     sm.exec_instr(OUT);
 }
 
-pub fn get_y<PIO: Instance, const SM: usize>(sm: &mut StateMachine<PIO, SM>) -> u32 {
+pub unsafe fn get_y<PIO: Instance, const SM: usize>(sm: &mut StateMachine<PIO, SM>) -> u32 {
     const IN: u16 = InstructionOperands::IN {
         source: InSource::Y,
         bit_count: 32,
@@ -43,7 +43,7 @@ pub fn get_y<PIO: Instance, const SM: usize>(sm: &mut StateMachine<PIO, SM>) -> 
     sm.rx().pull()
 }
 
-pub fn set_pindir<PIO: Instance, const SM: usize>(sm: &mut StateMachine<PIO, SM>, data: u8) {
+pub unsafe fn set_pindir<PIO: Instance, const SM: usize>(sm: &mut StateMachine<PIO, SM>, data: u8) {
     let set: u16 = InstructionOperands::SET {
         destination: SetDestination::PINDIRS,
         data,
@@ -52,7 +52,7 @@ pub fn set_pindir<PIO: Instance, const SM: usize>(sm: &mut StateMachine<PIO, SM>
     sm.exec_instr(set);
 }
 
-pub fn set_pin<PIO: Instance, const SM: usize>(sm: &mut StateMachine<PIO, SM>, data: u8) {
+pub unsafe fn set_pin<PIO: Instance, const SM: usize>(sm: &mut StateMachine<PIO, SM>, data: u8) {
     let set: u16 = InstructionOperands::SET {
         destination: SetDestination::PINS,
         data,
@@ -61,7 +61,7 @@ pub fn set_pin<PIO: Instance, const SM: usize>(sm: &mut StateMachine<PIO, SM>, d
     sm.exec_instr(set);
 }
 
-pub fn set_out_pin<PIO: Instance, const SM: usize>(sm: &mut StateMachine<PIO, SM>, data: u32) {
+pub unsafe fn set_out_pin<PIO: Instance, const SM: usize>(sm: &mut StateMachine<PIO, SM>, data: u32) {
     const OUT: u16 = InstructionOperands::OUT {
         destination: OutDestination::PINS,
         bit_count: 32,
@@ -70,7 +70,7 @@ pub fn set_out_pin<PIO: Instance, const SM: usize>(sm: &mut StateMachine<PIO, SM
     sm.tx().push(data);
     sm.exec_instr(OUT);
 }
-pub fn set_out_pindir<PIO: Instance, const SM: usize>(sm: &mut StateMachine<PIO, SM>, data: u32) {
+pub unsafe fn set_out_pindir<PIO: Instance, const SM: usize>(sm: &mut StateMachine<PIO, SM>, data: u32) {
     const OUT: u16 = InstructionOperands::OUT {
         destination: OutDestination::PINDIRS,
         bit_count: 32,
@@ -80,7 +80,7 @@ pub fn set_out_pindir<PIO: Instance, const SM: usize>(sm: &mut StateMachine<PIO,
     sm.exec_instr(OUT);
 }
 
-pub fn exec_jmp<PIO: Instance, const SM: usize>(sm: &mut StateMachine<PIO, SM>, to_addr: u8) {
+pub unsafe fn exec_jmp<PIO: Instance, const SM: usize>(sm: &mut StateMachine<PIO, SM>, to_addr: u8) {
     let jmp: u16 = InstructionOperands::JMP {
         address: to_addr,
         condition: JmpCondition::Always,

--- a/embassy-rp/src/relocate.rs
+++ b/embassy-rp/src/relocate.rs
@@ -26,11 +26,7 @@ where
             Some(if instr & 0b1110_0000_0000_0000 == 0 {
                 // this is a JMP instruction -> add offset to address
                 let address = (instr & 0b1_1111) as u8;
-                let address = address + self.offset;
-                assert!(
-                    address < pio::RP2040_MAX_PROGRAM_SIZE as u8,
-                    "Invalid JMP out of the program after offset addition"
-                );
+                let address = address.wrapping_add(self.offset) % 32;
                 instr & (!0b11111) | address as u16
             } else {
                 instr
@@ -62,8 +58,8 @@ impl<'a, const PROGRAM_SIZE: usize> RelocatedProgram<'a, PROGRAM_SIZE> {
         let wrap = self.program.wrap;
         let origin = self.origin;
         Wrap {
-            source: wrap.source + origin,
-            target: wrap.target + origin,
+            source: wrap.source.wrapping_add(origin) % 32,
+            target: wrap.target.wrapping_add(origin) % 32,
         }
     }
 

--- a/examples/rp/Cargo.toml
+++ b/examples/rp/Cargo.toml
@@ -22,6 +22,8 @@ lorawan = { version = "0.7.3", default-features = false, features = ["default-cr
 
 defmt = "0.3"
 defmt-rtt = "0.4"
+fixed = "1.23.1"
+fixed-macro = "1.2"
 
 #cortex-m = { version = "0.7.6", features = ["critical-section-single-core"] }
 cortex-m = { version = "0.7.6", features = ["inline-asm"] }

--- a/examples/rp/src/bin/pio_async.rs
+++ b/examples/rp/src/bin/pio_async.rs
@@ -4,12 +4,12 @@
 use defmt::info;
 use embassy_executor::Spawner;
 use embassy_rp::peripherals::PIO0;
-use embassy_rp::pio::{Pio, PioCommon, PioIrq, PioPin, PioStateMachine, ShiftDirection};
+use embassy_rp::pio::{Common, Irq, Pio, PioPin, ShiftDirection, StateMachine};
 use embassy_rp::pio_instr_util;
 use embassy_rp::relocate::RelocatedProgram;
 use {defmt_rtt as _, panic_probe as _};
 
-fn setup_pio_task_sm0(pio: &mut PioCommon<PIO0>, sm: &mut PioStateMachine<PIO0, 0>, pin: impl PioPin) {
+fn setup_pio_task_sm0(pio: &mut Common<PIO0>, sm: &mut StateMachine<PIO0, 0>, pin: impl PioPin) {
     // Setup sm0
 
     // Send data serially to pin
@@ -37,7 +37,7 @@ fn setup_pio_task_sm0(pio: &mut PioCommon<PIO0>, sm: &mut PioStateMachine<PIO0, 
 }
 
 #[embassy_executor::task]
-async fn pio_task_sm0(mut sm: PioStateMachine<'static, PIO0, 0>) {
+async fn pio_task_sm0(mut sm: StateMachine<'static, PIO0, 0>) {
     sm.set_enable(true);
 
     let mut v = 0x0f0caffa;
@@ -48,7 +48,7 @@ async fn pio_task_sm0(mut sm: PioStateMachine<'static, PIO0, 0>) {
     }
 }
 
-fn setup_pio_task_sm1(pio: &mut PioCommon<PIO0>, sm: &mut PioStateMachine<PIO0, 1>) {
+fn setup_pio_task_sm1(pio: &mut Common<PIO0>, sm: &mut StateMachine<PIO0, 1>) {
     // Setupm sm1
 
     // Read 0b10101 repeatedly until ISR is full
@@ -67,7 +67,7 @@ fn setup_pio_task_sm1(pio: &mut PioCommon<PIO0>, sm: &mut PioStateMachine<PIO0, 
 }
 
 #[embassy_executor::task]
-async fn pio_task_sm1(mut sm: PioStateMachine<'static, PIO0, 1>) {
+async fn pio_task_sm1(mut sm: StateMachine<'static, PIO0, 1>) {
     sm.set_enable(true);
     loop {
         let rx = sm.rx().wait_pull().await;
@@ -75,7 +75,7 @@ async fn pio_task_sm1(mut sm: PioStateMachine<'static, PIO0, 1>) {
     }
 }
 
-fn setup_pio_task_sm2(pio: &mut PioCommon<PIO0>, sm: &mut PioStateMachine<PIO0, 2>) {
+fn setup_pio_task_sm2(pio: &mut Common<PIO0>, sm: &mut StateMachine<PIO0, 2>) {
     // Setup sm2
 
     // Repeatedly trigger IRQ 3
@@ -99,7 +99,7 @@ fn setup_pio_task_sm2(pio: &mut PioCommon<PIO0>, sm: &mut PioStateMachine<PIO0, 
 }
 
 #[embassy_executor::task]
-async fn pio_task_sm2(mut irq: PioIrq<'static, PIO0, 3>, mut sm: PioStateMachine<'static, PIO0, 2>) {
+async fn pio_task_sm2(mut irq: Irq<'static, PIO0, 3>, mut sm: StateMachine<'static, PIO0, 2>) {
     sm.set_enable(true);
     loop {
         irq.wait().await;

--- a/examples/rp/src/bin/pio_dma.rs
+++ b/examples/rp/src/bin/pio_dma.rs
@@ -6,7 +6,7 @@ use embassy_executor::Spawner;
 use embassy_futures::join::join;
 use embassy_rp::pio::{Pio, ShiftDirection};
 use embassy_rp::relocate::RelocatedProgram;
-use embassy_rp::{pio_instr_util, Peripheral};
+use embassy_rp::Peripheral;
 use {defmt_rtt as _, panic_probe as _};
 
 fn swap_nibbles(v: u32) -> u32 {
@@ -38,11 +38,8 @@ async fn main(_spawner: Spawner) {
     );
 
     let relocated = RelocatedProgram::new(&prg.program);
-    common.write_instr(relocated.origin() as usize, relocated.code());
-    pio_instr_util::exec_jmp(&mut sm, relocated.origin());
+    sm.use_program(&common.load_program(&relocated), &[]);
     sm.set_clkdiv((125e6 / 10e3 * 256.0) as u32);
-    let pio::Wrap { source, target } = relocated.wrap();
-    sm.set_wrap(source, target);
     sm.set_autopull(true);
     sm.set_autopush(true);
     sm.set_pull_threshold(32);

--- a/examples/rp/src/bin/pio_hd44780.rs
+++ b/examples/rp/src/bin/pio_hd44780.rs
@@ -7,7 +7,7 @@ use core::fmt::Write;
 use embassy_executor::Spawner;
 use embassy_rp::dma::{AnyChannel, Channel};
 use embassy_rp::peripherals::PIO0;
-use embassy_rp::pio::{FifoJoin, Pio, PioPin, ShiftDirection, StateMachine};
+use embassy_rp::pio::{Direction, FifoJoin, Pio, PioPin, ShiftDirection, StateMachine};
 use embassy_rp::pwm::{Config, Pwm};
 use embassy_rp::relocate::RelocatedProgram;
 use embassy_rp::{into_ref, Peripheral, PeripheralRef};
@@ -115,12 +115,7 @@ impl<'l> HD44780<'l> {
         let db6 = common.make_pio_pin(db6);
         let db7 = common.make_pio_pin(db7);
 
-        sm0.set_set_pins(&[&rs, &rw]);
-        embassy_rp::pio_instr_util::set_pindir(&mut sm0, 0b11);
-        sm0.set_set_pins(&[&e]);
-        embassy_rp::pio_instr_util::set_pindir(&mut sm0, 0b1);
-        sm0.set_set_pins(&[&db4, &db5, &db6, &db7]);
-        embassy_rp::pio_instr_util::set_pindir(&mut sm0, 0b11111);
+        sm0.set_pin_dirs(Direction::Out, &[&rs, &rw, &e, &db4, &db5, &db6, &db7]);
 
         let relocated = RelocatedProgram::new(&prg.program);
         sm0.use_program(&common.load_program(&relocated), &[&e]);

--- a/examples/rp/src/bin/pio_hd44780.rs
+++ b/examples/rp/src/bin/pio_hd44780.rs
@@ -95,6 +95,7 @@ impl<'l> HD44780<'l> {
         let prg = pio_proc::pio_asm!(
             r#"
                 .side_set 1 opt
+                .origin 20
 
                 loop:
                     out x,     24
@@ -148,7 +149,7 @@ impl<'l> HD44780<'l> {
         // many side sets are only there to free up a delay bit!
         let prg = pio_proc::pio_asm!(
             r#"
-                .origin 7
+                .origin 27
                 .side_set 1
 
                 .wrap_target

--- a/examples/rp/src/bin/pio_hd44780.rs
+++ b/examples/rp/src/bin/pio_hd44780.rs
@@ -7,7 +7,7 @@ use core::fmt::Write;
 use embassy_executor::Spawner;
 use embassy_rp::dma::{AnyChannel, Channel};
 use embassy_rp::peripherals::PIO0;
-use embassy_rp::pio::{FifoJoin, Pio, PioPin, PioStateMachine, ShiftDirection};
+use embassy_rp::pio::{FifoJoin, Pio, PioPin, ShiftDirection, StateMachine};
 use embassy_rp::pwm::{Config, Pwm};
 use embassy_rp::relocate::RelocatedProgram;
 use embassy_rp::{into_ref, Peripheral, PeripheralRef};
@@ -64,7 +64,7 @@ async fn main(_spawner: Spawner) {
 
 pub struct HD44780<'l> {
     dma: PeripheralRef<'l, AnyChannel>,
-    sm: PioStateMachine<'l, PIO0, 0>,
+    sm: StateMachine<'l, PIO0, 0>,
 
     buf: [u8; 40],
 }

--- a/examples/rp/src/bin/pio_hd44780.rs
+++ b/examples/rp/src/bin/pio_hd44780.rs
@@ -123,15 +123,9 @@ impl<'l> HD44780<'l> {
         embassy_rp::pio_instr_util::set_pindir(&mut sm0, 0b11111);
 
         let relocated = RelocatedProgram::new(&prg.program);
-        common.write_instr(relocated.origin() as usize, relocated.code());
-        embassy_rp::pio_instr_util::exec_jmp(&mut sm0, relocated.origin());
+        sm0.use_program(&common.load_program(&relocated), &[&e]);
         sm0.set_clkdiv(125 * 256);
-        let pio::Wrap { source, target } = relocated.wrap();
-        sm0.set_wrap(source, target);
-        sm0.set_side_enable(true);
         sm0.set_out_pins(&[&db4, &db5, &db6, &db7]);
-        sm0.set_sideset_base_pin(&e);
-        sm0.set_sideset_count(2);
         sm0.set_out_shift_dir(ShiftDirection::Left);
         sm0.set_fifo_join(FifoJoin::TxOnly);
         sm0.set_autopull(true);
@@ -199,17 +193,11 @@ impl<'l> HD44780<'l> {
         );
 
         let relocated = RelocatedProgram::new(&prg.program);
-        common.write_instr(relocated.origin() as usize, relocated.code());
-        embassy_rp::pio_instr_util::exec_jmp(&mut sm0, relocated.origin());
-        let pio::Wrap { source, target } = relocated.wrap();
+        sm0.use_program(&common.load_program(&relocated), &[&e]);
         sm0.set_clkdiv(8 * 256); // ~64ns/insn
-        sm0.set_side_enable(false);
         sm0.set_jmp_pin(db7pin);
-        sm0.set_wrap(source, target);
         sm0.set_set_pins(&[&rs, &rw]);
         sm0.set_out_pins(&[&db4, &db5, &db6, &db7]);
-        sm0.set_sideset_base_pin(&e);
-        sm0.set_sideset_count(1);
         sm0.set_out_shift_dir(ShiftDirection::Left);
         sm0.set_fifo_join(FifoJoin::TxOnly);
 

--- a/examples/rp/src/bin/ws2812-pio.rs
+++ b/examples/rp/src/bin/ws2812-pio.rs
@@ -3,10 +3,12 @@
 #![feature(type_alias_impl_trait)]
 
 use defmt::*;
+use embassy_embedded_hal::SetConfig;
 use embassy_executor::Spawner;
-use embassy_rp::pio::{Common, FifoJoin, Instance, Pio, PioPin, ShiftDirection, StateMachine};
+use embassy_rp::pio::{Common, Config, FifoJoin, Instance, Pio, PioPin, ShiftConfig, ShiftDirection, StateMachine};
 use embassy_rp::relocate::RelocatedProgram;
 use embassy_time::{Duration, Timer};
+use fixed_macro::fixed;
 use smart_leds::RGB8;
 use {defmt_rtt as _, panic_probe as _};
 pub struct Ws2812<'d, P: Instance, const S: usize> {
@@ -43,35 +45,30 @@ impl<'d, P: Instance, const S: usize> Ws2812<'d, P, S> {
         a.bind(&mut wrap_source);
 
         let prg = a.assemble_with_wrap(wrap_source, wrap_target);
+        let mut cfg = Config::default();
 
         // Pin config
         let out_pin = pio.make_pio_pin(pin);
 
         let relocated = RelocatedProgram::new(&prg);
-        sm.use_program(&pio.load_program(&relocated), &[&out_pin]);
+        cfg.use_program(&pio.load_program(&relocated), &[&out_pin]);
 
-        // Clock config
+        // Clock config, measured in kHz to avoid overflows
         // TODO CLOCK_FREQ should come from embassy_rp
-        const CLOCK_FREQ: u32 = 125_000_000;
-        const WS2812_FREQ: u32 = 800_000;
-
-        let bit_freq = WS2812_FREQ * CYCLES_PER_BIT;
-        let mut int = CLOCK_FREQ / bit_freq;
-        let rem = CLOCK_FREQ - (int * bit_freq);
-        let frac = (rem * 256) / bit_freq;
-        // 65536.0 is represented as 0 in the pio's clock divider
-        if int == 65536 {
-            int = 0;
-        }
-
-        sm.set_clkdiv((int << 8) | frac);
+        let clock_freq = fixed!(125_000: U24F8);
+        let ws2812_freq = fixed!(800: U24F8);
+        let bit_freq = ws2812_freq * CYCLES_PER_BIT;
+        cfg.clock_divider = clock_freq / bit_freq;
 
         // FIFO config
-        sm.set_autopull(true);
-        sm.set_fifo_join(FifoJoin::TxOnly);
-        sm.set_pull_threshold(24);
-        sm.set_out_shift_dir(ShiftDirection::Left);
+        cfg.fifo_join = FifoJoin::TxOnly;
+        cfg.shift_out = ShiftConfig {
+            auto_fill: true,
+            threshold: 24,
+            direction: ShiftDirection::Left,
+        };
 
+        sm.set_config(&cfg);
         sm.set_enable(true);
 
         Self { sm }

--- a/examples/rp/src/bin/ws2812-pio.rs
+++ b/examples/rp/src/bin/ws2812-pio.rs
@@ -4,18 +4,18 @@
 
 use defmt::*;
 use embassy_executor::Spawner;
-use embassy_rp::pio::{FifoJoin, Pio, PioCommon, PioInstance, PioPin, PioStateMachine, ShiftDirection};
+use embassy_rp::pio::{Common, FifoJoin, Instance, Pio, PioPin, ShiftDirection, StateMachine};
 use embassy_rp::pio_instr_util;
 use embassy_rp::relocate::RelocatedProgram;
 use embassy_time::{Duration, Timer};
 use smart_leds::RGB8;
 use {defmt_rtt as _, panic_probe as _};
-pub struct Ws2812<'d, P: PioInstance, const S: usize> {
-    sm: PioStateMachine<'d, P, S>,
+pub struct Ws2812<'d, P: Instance, const S: usize> {
+    sm: StateMachine<'d, P, S>,
 }
 
-impl<'d, P: PioInstance, const S: usize> Ws2812<'d, P, S> {
-    pub fn new(mut pio: PioCommon<'d, P>, mut sm: PioStateMachine<'d, P, S>, pin: impl PioPin) -> Self {
+impl<'d, P: Instance, const S: usize> Ws2812<'d, P, S> {
+    pub fn new(mut pio: Common<'d, P>, mut sm: StateMachine<'d, P, S>, pin: impl PioPin) -> Self {
         // Setup sm0
 
         // prepare the PIO program


### PR DESCRIPTION
this should hopefully be the last entry in this series. after this we'll have a reasonably safe interface to pio, both for configuration and at runtime. pio now looks very much like the other peripherals (though not exactly, seeing how state machines can't be constructed from a config but only have it applied to them later). the generated code for `StateMachine::set_config` is still larger than we'd like (almost 300 bytes at Oz), but it's a great step up in safety from the previous interface at approximately the same code space cost.