### PR TITLE
Update GitHub Actions CI

### DIFF
--- a/.github/workflows/doc.yml
+++ b/.github/workflows/doc.yml
@@ -29,7 +29,7 @@ jobs:
     concurrency: doc-${{ matrix.crates }}
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           submodules: true
       - name: Install Rust targets

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -22,11 +22,11 @@ jobs:
       id-token: write
       contents: read
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           submodules: true
       - name: Cache multiple paths
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: |
             ~/.cargo/bin/
@@ -44,11 +44,11 @@ jobs:
   build-stable:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           submodules: true
       - name: Cache multiple paths
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: |
             ~/.cargo/bin/
@@ -67,7 +67,7 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Test boot
         working-directory: ./embassy-boot/boot


### PR DESCRIPTION
The following updates are performed:
* update [`actions/cache`](https://github.com/actions/cache) to v3
* update [`actions/checkout`](https://github.com/actions/checkout) to v3

Still using the outdated actions will generate several warnings in CI runs, for example in https://github.com/embassy-rs/embassy/actions/runs/4917900672:

> Node.js 12 actions are deprecated. Please update the following actions to use Node.js 16: actions/checkout@v2, actions/cache@v2. For more information see: https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/.

The PR will get rid of those warnings.