### PR TITLE
rp: don't use SetConfig trait in PWM and PIO.

### DIFF
--- a/embassy-rp/src/pio.rs
+++ b/embassy-rp/src/pio.rs
@@ -6,7 +6,6 @@ use core::task::{Context, Poll};
 
 use atomic_polyfill::{AtomicU32, AtomicU8};
 use embassy_cortex_m::interrupt::{Interrupt, InterruptExt};
-use embassy_embedded_hal::SetConfig;
 use embassy_hal_common::{into_ref, Peripheral, PeripheralRef};
 use embassy_sync::waitqueue::AtomicWaker;
 use fixed::types::extra::U8;
@@ -637,10 +636,8 @@ impl<'d, PIO: Instance> Config<'d, PIO> {
     }
 }
 
-impl<'d, PIO: Instance, const SM: usize> SetConfig for StateMachine<'d, PIO, SM> {
-    type Config = Config<'d, PIO>;
-
-    fn set_config(&mut self, config: &Self::Config) {
+impl<'d, PIO: Instance + 'd, const SM: usize> StateMachine<'d, PIO, SM> {
+    pub fn set_config(&mut self, config: &Config<'d, PIO>) {
         // sm expects 0 for 65536, truncation makes that happen
         assert!(config.clock_divider <= 65536, "clkdiv must be <= 65536");
         assert!(config.clock_divider >= 1, "clkdiv must be >= 1");
@@ -691,9 +688,7 @@ impl<'d, PIO: Instance, const SM: usize> SetConfig for StateMachine<'d, PIO, SM>
             }
         }
     }
-}
 
-impl<'d, PIO: Instance + 'd, const SM: usize> StateMachine<'d, PIO, SM> {
     #[inline(always)]
     fn this_sm() -> crate::pac::pio::StateMachine {
         PIO::PIO.sm(SM)

--- a/embassy-rp/src/pwm.rs
+++ b/embassy-rp/src/pwm.rs
@@ -1,6 +1,5 @@
 //! Pulse Width Modulation (PWM)
 
-use embassy_embedded_hal::SetConfig;
 use embassy_hal_common::{into_ref, Peripheral, PeripheralRef};
 use fixed::traits::ToFixed;
 use fixed::FixedU16;
@@ -151,6 +150,10 @@ impl<'d, T: Channel> Pwm<'d, T> {
     ) -> Self {
         into_ref!(a, b);
         Self::new_inner(inner, Some(a.map_into()), Some(b.map_into()), config, mode.into())
+    }
+
+    pub fn set_config(&mut self, config: &Config) {
+        Self::configure(self.inner.regs(), config);
     }
 
     fn configure(p: pac::pwm::Channel, config: &Config) {
@@ -329,10 +332,3 @@ impl_pin!(PIN_26, PWM_CH5, PwmPinA);
 impl_pin!(PIN_27, PWM_CH5, PwmPinB);
 impl_pin!(PIN_28, PWM_CH6, PwmPinA);
 impl_pin!(PIN_29, PWM_CH6, PwmPinB);
-
-impl<'d, T: Channel> SetConfig for Pwm<'d, T> {
-    type Config = Config;
-    fn set_config(&mut self, config: &Self::Config) {
-        Self::configure(self.inner.regs(), config);
-    }
-}

--- a/examples/rp/src/bin/pio_async.rs
+++ b/examples/rp/src/bin/pio_async.rs
@@ -2,7 +2,6 @@
 #![no_main]
 #![feature(type_alias_impl_trait)]
 use defmt::info;
-use embassy_embedded_hal::SetConfig;
 use embassy_executor::Spawner;
 use embassy_rp::peripherals::PIO0;
 use embassy_rp::pio::{Common, Config, Irq, Pio, PioPin, ShiftDirection, StateMachine};

--- a/examples/rp/src/bin/pio_dma.rs
+++ b/examples/rp/src/bin/pio_dma.rs
@@ -2,7 +2,6 @@
 #![no_main]
 #![feature(type_alias_impl_trait)]
 use defmt::info;
-use embassy_embedded_hal::SetConfig;
 use embassy_executor::Spawner;
 use embassy_futures::join::join;
 use embassy_rp::pio::{Config, Pio, ShiftConfig, ShiftDirection};

--- a/examples/rp/src/bin/pio_hd44780.rs
+++ b/examples/rp/src/bin/pio_hd44780.rs
@@ -4,7 +4,6 @@
 
 use core::fmt::Write;
 
-use embassy_embedded_hal::SetConfig;
 use embassy_executor::Spawner;
 use embassy_rp::dma::{AnyChannel, Channel};
 use embassy_rp::peripherals::PIO0;

--- a/examples/rp/src/bin/pwm.rs
+++ b/examples/rp/src/bin/pwm.rs
@@ -3,7 +3,6 @@
 #![feature(type_alias_impl_trait)]
 
 use defmt::*;
-use embassy_embedded_hal::SetConfig;
 use embassy_executor::Spawner;
 use embassy_rp::pwm::{Config, Pwm};
 use embassy_time::{Duration, Timer};

--- a/examples/rp/src/bin/ws2812-pio.rs
+++ b/examples/rp/src/bin/ws2812-pio.rs
@@ -3,7 +3,6 @@
 #![feature(type_alias_impl_trait)]
 
 use defmt::*;
-use embassy_embedded_hal::SetConfig;
 use embassy_executor::Spawner;
 use embassy_rp::pio::{Common, Config, FifoJoin, Instance, Pio, PioPin, ShiftConfig, ShiftDirection, StateMachine};
 use embassy_rp::relocate::RelocatedProgram;


### PR DESCRIPTION
It was intended to allow changing baudrate on shared spi/i2c. There's no advantage in using it for PWM or PIO, and makes it less usable because you have to have `embassy-embedded-hal` as a dep to use it.

bors r+