### PR TITLE
Work around xtensa deadlock

### DIFF
--- a/embassy-executor/src/arch/xtensa.rs
+++ b/embassy-executor/src/arch/xtensa.rs
@@ -63,26 +63,29 @@ mod thread {
             loop {
                 unsafe {
                     self.inner.poll();
+
+                    // Manual critical section implementation that only masks interrupts handlers.
+                    // We must not acquire the cross-core on dual-core systems because that would
+                    // prevent the other core from doing useful work while this core is sleeping.
+                    let token: critical_section::RawRestoreState;
+                    core::arch::asm!("rsil {0}, 5", out(reg) token);
+
                     // we do not care about race conditions between the load and store operations, interrupts
                     // will only set this value to true.
                     // if there is work to do, loop back to polling
-                    // TODO can we relax this?
-                    critical_section::with(|_| {
-                        if SIGNAL_WORK_THREAD_MODE.load(Ordering::SeqCst) {
-                            SIGNAL_WORK_THREAD_MODE.store(false, Ordering::SeqCst);
-                        } else {
-                            // waiti sets the PS.INTLEVEL when slipping into sleep
-                            // because critical sections in Xtensa are implemented via increasing
-                            // PS.INTLEVEL the critical section ends here
-                            // take care not add code after `waiti` if it needs to be inside the CS
-                            core::arch::asm!("waiti 0"); // critical section ends here
+                    if SIGNAL_WORK_THREAD_MODE.load(Ordering::SeqCst) {
+                        SIGNAL_WORK_THREAD_MODE.store(false, Ordering::SeqCst);
 
-                            // Re-lock the critical section to prevent possible xtensa-specific
-                            // deadlock (see #1449)
-                            let tkn: critical_section::RawRestoreState;
-                            core::arch::asm!("rsil {0}, 5", out(reg) tkn);
-                        }
-                    });
+                        core::arch::asm!(
+                            "wsr.ps {0}",
+                            "rsync", in(reg) token)
+                    } else {
+                        // waiti sets the PS.INTLEVEL when slipping into sleep
+                        // because critical sections in Xtensa are implemented via increasing
+                        // PS.INTLEVEL the critical section ends here
+                        // take care not add code after `waiti` if it needs to be inside the CS
+                        core::arch::asm!("waiti 0"); // critical section ends here
+                    }
                 }
             }
         }

--- a/embassy-executor/src/arch/xtensa.rs
+++ b/embassy-executor/src/arch/xtensa.rs
@@ -63,29 +63,26 @@ mod thread {
             loop {
                 unsafe {
                     self.inner.poll();
-
-                    // Manual critical section implementation that only masks interrupts handlers.
-                    // We must not acquire the cross-core on dual-core systems because that would
-                    // prevent the other core from doing useful work while this core is sleeping.
-                    let token: critical_section::RawRestoreState;
-                    core::arch::asm!("rsil {0}, 5", out(reg) token);
-
                     // we do not care about race conditions between the load and store operations, interrupts
                     // will only set this value to true.
                     // if there is work to do, loop back to polling
-                    if SIGNAL_WORK_THREAD_MODE.load(Ordering::SeqCst) {
-                        SIGNAL_WORK_THREAD_MODE.store(false, Ordering::SeqCst);
+                    // TODO can we relax this?
+                    critical_section::with(|_| {
+                        if SIGNAL_WORK_THREAD_MODE.load(Ordering::SeqCst) {
+                            SIGNAL_WORK_THREAD_MODE.store(false, Ordering::SeqCst);
+                        } else {
+                            // waiti sets the PS.INTLEVEL when slipping into sleep
+                            // because critical sections in Xtensa are implemented via increasing
+                            // PS.INTLEVEL the critical section ends here
+                            // take care not add code after `waiti` if it needs to be inside the CS
+                            core::arch::asm!("waiti 0"); // critical section ends here
 
-                        core::arch::asm!(
-                            "wsr.ps {0}",
-                            "rsync", in(reg) token)
-                    } else {
-                        // waiti sets the PS.INTLEVEL when slipping into sleep
-                        // because critical sections in Xtensa are implemented via increasing
-                        // PS.INTLEVEL the critical section ends here
-                        // take care not add code after `waiti` if it needs to be inside the CS
-                        core::arch::asm!("waiti 0"); // critical section ends here
-                    }
+                            // Re-lock the critical section to prevent possible xtensa-specific
+                            // deadlock (see #1449)
+                            let tkn: critical_section::RawRestoreState;
+                            core::arch::asm!("rsil {0}, 5", out(reg) tkn);
+                        }
+                    });
                 }
             }
         }

--- a/embassy-executor/src/arch/xtensa.rs
+++ b/embassy-executor/src/arch/xtensa.rs
@@ -76,6 +76,11 @@ mod thread {
                             // PS.INTLEVEL the critical section ends here
                             // take care not add code after `waiti` if it needs to be inside the CS
                             core::arch::asm!("waiti 0"); // critical section ends here
+
+                            // Re-lock the critical section to prevent possible xtensa-specific
+                            // deadlock (see #1449)
+                            let tkn: critical_section::RawRestoreState;
+                            core::arch::asm!("rsil {0}, 5", out(reg) tkn);
                         }
                     });
                 }


### PR DESCRIPTION
Fixes (works around) #1449

This PR is intended as a temporary workaround until a proper solution can be found. This is unnecessary and wasteful on single-core MCUs, and also probably wasteful on dual-core ones. As dirbaio explained, `esp-hal` should probably provide a specialized executor implementation for dual-core Xtensa CPUs that maybe only disables interrupts without a complete cross-core lock.

Hacky and probably shouldn't be merged.