### PR TITLE
rp: remove take!, add bind_interrupts!

### DIFF
--- a/examples/rp/src/bin/adc.rs
+++ b/examples/rp/src/bin/adc.rs
@@ -4,16 +4,19 @@
 
 use defmt::*;
 use embassy_executor::Spawner;
-use embassy_rp::adc::{Adc, Config};
-use embassy_rp::interrupt;
+use embassy_rp::adc::{Adc, Config, InterruptHandler};
+use embassy_rp::bind_interrupts;
 use embassy_time::{Duration, Timer};
 use {defmt_rtt as _, panic_probe as _};
+
+bind_interrupts!(struct Irqs {
+    ADC_IRQ_FIFO => InterruptHandler;
+});
 
 #[embassy_executor::main]
 async fn main(_spawner: Spawner) {
     let p = embassy_rp::init(Default::default());
-    let irq = interrupt::take!(ADC_IRQ_FIFO);
-    let mut adc = Adc::new(p.ADC, irq, Config::default());
+    let mut adc = Adc::new(p.ADC, Irqs, Config::default());
 
     let mut p26 = p.PIN_26;
     let mut p27 = p.PIN_27;

--- a/examples/rp/src/bin/i2c_async.rs
+++ b/examples/rp/src/bin/i2c_async.rs
@@ -4,11 +4,16 @@
 
 use defmt::*;
 use embassy_executor::Spawner;
-use embassy_rp::i2c::{self, Config};
-use embassy_rp::interrupt;
+use embassy_rp::bind_interrupts;
+use embassy_rp::i2c::{self, Config, InterruptHandler};
+use embassy_rp::peripherals::I2C1;
 use embassy_time::{Duration, Timer};
 use embedded_hal_async::i2c::I2c;
 use {defmt_rtt as _, panic_probe as _};
+
+bind_interrupts!(struct Irqs {
+    I2C1_IRQ => InterruptHandler<I2C1>;
+});
 
 #[allow(dead_code)]
 mod mcp23017 {
@@ -64,10 +69,9 @@ async fn main(_spawner: Spawner) {
 
     let sda = p.PIN_14;
     let scl = p.PIN_15;
-    let irq = interrupt::take!(I2C1_IRQ);
 
     info!("set up i2c ");
-    let mut i2c = i2c::I2c::new_async(p.I2C1, scl, sda, irq, Config::default());
+    let mut i2c = i2c::I2c::new_async(p.I2C1, scl, sda, Irqs, Config::default());
 
     use mcp23017::*;
 

--- a/examples/rp/src/bin/uart_buffered_split.rs
+++ b/examples/rp/src/bin/uart_buffered_split.rs
@@ -5,12 +5,16 @@
 use defmt::*;
 use embassy_executor::Spawner;
 use embassy_executor::_export::StaticCell;
-use embassy_rp::interrupt;
+use embassy_rp::bind_interrupts;
 use embassy_rp::peripherals::UART0;
-use embassy_rp::uart::{BufferedUart, BufferedUartRx, Config};
+use embassy_rp::uart::{BufferedInterruptHandler, BufferedUart, BufferedUartRx, Config};
 use embassy_time::{Duration, Timer};
 use embedded_io::asynch::{Read, Write};
 use {defmt_rtt as _, panic_probe as _};
+
+bind_interrupts!(struct Irqs {
+    UART0_IRQ => BufferedInterruptHandler<UART0>;
+});
 
 macro_rules! singleton {
     ($val:expr) => {{
@@ -26,10 +30,9 @@ async fn main(spawner: Spawner) {
     let p = embassy_rp::init(Default::default());
     let (tx_pin, rx_pin, uart) = (p.PIN_0, p.PIN_1, p.UART0);
 
-    let irq = interrupt::take!(UART0_IRQ);
     let tx_buf = &mut singleton!([0u8; 16])[..];
     let rx_buf = &mut singleton!([0u8; 16])[..];
-    let uart = BufferedUart::new(uart, irq, tx_pin, rx_pin, tx_buf, rx_buf, Config::default());
+    let uart = BufferedUart::new(uart, Irqs, tx_pin, rx_pin, tx_buf, rx_buf, Config::default());
     let (rx, mut tx) = uart.split();
 
     unwrap!(spawner.spawn(reader(rx)));

--- a/examples/rp/src/bin/uart_unidir.rs
+++ b/examples/rp/src/bin/uart_unidir.rs
@@ -7,24 +7,22 @@
 
 use defmt::*;
 use embassy_executor::Spawner;
-use embassy_rp::interrupt;
+use embassy_rp::bind_interrupts;
 use embassy_rp::peripherals::UART1;
-use embassy_rp::uart::{Async, Config, UartRx, UartTx};
+use embassy_rp::uart::{Async, Config, InterruptHandler, UartRx, UartTx};
 use embassy_time::{Duration, Timer};
 use {defmt_rtt as _, panic_probe as _};
+
+bind_interrupts!(struct Irqs {
+    UART1_IRQ => InterruptHandler<UART1>;
+});
 
 #[embassy_executor::main]
 async fn main(spawner: Spawner) {
     let p = embassy_rp::init(Default::default());
 
     let mut uart_tx = UartTx::new(p.UART0, p.PIN_0, p.DMA_CH0, Config::default());
-    let uart_rx = UartRx::new(
-        p.UART1,
-        p.PIN_5,
-        interrupt::take!(UART1_IRQ),
-        p.DMA_CH1,
-        Config::default(),
-    );
+    let uart_rx = UartRx::new(p.UART1, p.PIN_5, Irqs, p.DMA_CH1, Config::default());
 
     unwrap!(spawner.spawn(reader(uart_rx)));
 

--- a/examples/rp/src/bin/usb_logger.rs
+++ b/examples/rp/src/bin/usb_logger.rs
@@ -3,11 +3,15 @@
 #![feature(type_alias_impl_trait)]
 
 use embassy_executor::Spawner;
-use embassy_rp::interrupt;
+use embassy_rp::bind_interrupts;
 use embassy_rp::peripherals::USB;
-use embassy_rp::usb::Driver;
+use embassy_rp::usb::{Driver, InterruptHandler};
 use embassy_time::{Duration, Timer};
 use {defmt_rtt as _, panic_probe as _};
+
+bind_interrupts!(struct Irqs {
+    USBCTRL_IRQ => InterruptHandler<USB>;
+});
 
 #[embassy_executor::task]
 async fn logger_task(driver: Driver<'static, USB>) {
@@ -17,8 +21,7 @@ async fn logger_task(driver: Driver<'static, USB>) {
 #[embassy_executor::main]
 async fn main(spawner: Spawner) {
     let p = embassy_rp::init(Default::default());
-    let irq = interrupt::take!(USBCTRL_IRQ);
-    let driver = Driver::new(p.USB, irq);
+    let driver = Driver::new(p.USB, Irqs);
     spawner.spawn(logger_task(driver)).unwrap();
 
     let mut counter = 0;


### PR DESCRIPTION
both of the uart interrupts now check a flag that only the dma rx path ever sets (and now unsets again on drop) to return early if it's not as they expect. this is ... not our preferred solution, but if bind_interrupts *must* allow mutiple handlers to be specified then this is the only way we can think of that doesn't break uarts.