### PR TITLE
rp/multicore: explicitly copy the entry function from core0's stack

### DIFF
--- a/embassy-rp/src/multicore.rs
+++ b/embassy-rp/src/multicore.rs
@@ -127,7 +127,7 @@ where
     ) -> ! {
         core1_setup(stack_bottom);
 
-        let entry = unsafe { ManuallyDrop::take(&mut *entry) };
+        let entry = unsafe { ManuallyDrop::take(&mut core::ptr::read(entry)) };
 
         // make sure the preceding read doesn't get reordered past the following fifo write
         compiler_fence(Ordering::SeqCst);


### PR DESCRIPTION
I'd prefer to explicitly read the pointer value, instead of just dereferencing it.
`&mut *entry` still points to memory on the core0 stack, and `ManuallyDrop::take` is not guaranteed to copy the contents somewhere else.