### PR TITLE
Protect default implementations for FirmwareUpdater and BootLoader

### DIFF
--- a/embassy-boot/boot/src/firmware_updater.rs
+++ b/embassy-boot/boot/src/firmware_updater.rs
@@ -40,6 +40,7 @@ pub struct FirmwareUpdater {
     dfu: Partition,
 }
 
+#[cfg(target_os = "none")]
 impl Default for FirmwareUpdater {
     fn default() -> Self {
         extern "C" {

--- a/embassy-boot/nrf/src/lib.rs
+++ b/embassy-boot/nrf/src/lib.rs
@@ -15,6 +15,7 @@ pub struct BootLoader<const BUFFER_SIZE: usize = PAGE_SIZE> {
     aligned_buf: AlignedBuffer<BUFFER_SIZE>,
 }
 
+#[cfg(target_os = "none")]
 impl Default for BootLoader<PAGE_SIZE> {
     /// Create a new bootloader instance using parameters from linker script
     fn default() -> Self {

--- a/embassy-boot/rp/src/lib.rs
+++ b/embassy-boot/rp/src/lib.rs
@@ -51,6 +51,7 @@ impl<const BUFFER_SIZE: usize> BootLoader<BUFFER_SIZE> {
     }
 }
 
+#[cfg(target_os = "none")]
 impl Default for BootLoader<ERASE_SIZE> {
     /// Create a new bootloader instance using parameters from linker script
     fn default() -> Self {

--- a/embassy-boot/stm32/src/lib.rs
+++ b/embassy-boot/stm32/src/lib.rs
@@ -46,6 +46,7 @@ impl<const BUFFER_SIZE: usize> BootLoader<BUFFER_SIZE> {
     }
 }
 
+#[cfg(target_os = "none")]
 impl<const BUFFER_SIZE: usize> Default for BootLoader<BUFFER_SIZE> {
     /// Create a new bootloader instance using parameters from linker script
     fn default() -> Self {


### PR DESCRIPTION
It seems as if the arm compiler can does not care about whether the bootloader symbols are undefined if the default() function is never used. The x64 compiler does care however, so this change ensures that we can instantiate the types from tests.