### PR TITLE
Add YieldingAsync adapter

### DIFF
--- a/embassy-embedded-hal/Cargo.toml
+++ b/embassy-embedded-hal/Cargo.toml
@@ -14,10 +14,10 @@ target = "x86_64-unknown-linux-gnu"
 [features]
 std = []
 # Enable nightly-only features
-nightly = ["embedded-hal-async", "embedded-storage-async"]
+nightly = ["embassy-futures", "embedded-hal-async", "embedded-storage-async"]
 
 [dependencies]
-embassy-futures = { version = "0.1.0", path = "../embassy-futures" }
+embassy-futures = { version = "0.1.0", path = "../embassy-futures", optional = true }
 embassy-sync = { version = "0.2.0", path = "../embassy-sync" }
 embedded-hal-02 = { package = "embedded-hal", version = "0.2.6", features = [
     "unproven",

--- a/embassy-embedded-hal/Cargo.toml
+++ b/embassy-embedded-hal/Cargo.toml
@@ -17,8 +17,11 @@ std = []
 nightly = ["embedded-hal-async", "embedded-storage-async"]
 
 [dependencies]
+embassy-futures = { version = "0.1.0", path = "../embassy-futures" }
 embassy-sync = { version = "0.2.0", path = "../embassy-sync" }
-embedded-hal-02 = { package = "embedded-hal", version = "0.2.6", features = ["unproven"] }
+embedded-hal-02 = { package = "embedded-hal", version = "0.2.6", features = [
+    "unproven",
+] }
 embedded-hal-1 = { package = "embedded-hal", version = "=1.0.0-alpha.10" }
 embedded-hal-async = { version = "=0.2.0-alpha.1", optional = true }
 embedded-storage = "0.3.0"
@@ -26,3 +29,6 @@ embedded-storage-async = { version = "0.4.0", optional = true }
 nb = "1.0.0"
 
 defmt = { version = "0.3", optional = true }
+
+[dev-dependencies]
+futures-test = "0.3.17"

--- a/embassy-embedded-hal/src/adapter.rs
+++ b/embassy-embedded-hal/src/adapter.rs
@@ -1,5 +1,6 @@
 //! Adapters between embedded-hal traits.
 
+use embassy_futures::yield_now;
 use embedded_hal_02::{blocking, serial};
 
 /// Wrapper that implements async traits using blocking implementations.
@@ -150,11 +151,18 @@ where
     const ERASE_SIZE: usize = <T as NorFlash>::ERASE_SIZE;
 
     async fn write(&mut self, offset: u32, data: &[u8]) -> Result<(), Self::Error> {
-        self.wrapped.write(offset, data)
+        self.wrapped.write(offset, data)?;
+        yield_now().await;
+        Ok(())
     }
 
     async fn erase(&mut self, from: u32, to: u32) -> Result<(), Self::Error> {
-        self.wrapped.erase(from, to)
+        for from in (from..to).step_by(T::ERASE_SIZE) {
+            let to = core::cmp::min(from + T::ERASE_SIZE as u32, to);
+            self.wrapped.erase(from, to)?;
+            yield_now().await;
+        }
+        Ok(())
     }
 }
 
@@ -169,5 +177,72 @@ where
 
     fn capacity(&self) -> usize {
         self.wrapped.capacity()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    extern crate std;
+
+    #[derive(Default)]
+    struct FakeFlash(Vec<(u32, u32)>);
+
+    impl embedded_storage::nor_flash::ErrorType for FakeFlash {
+        type Error = std::convert::Infallible;
+    }
+
+    impl embedded_storage::nor_flash::ReadNorFlash for FakeFlash {
+        const READ_SIZE: usize = 1;
+
+        fn read(&mut self, _offset: u32, _bytes: &mut [u8]) -> Result<(), Self::Error> {
+            unimplemented!()
+        }
+
+        fn capacity(&self) -> usize {
+            unimplemented!()
+        }
+    }
+
+    impl embedded_storage::nor_flash::NorFlash for FakeFlash {
+        const WRITE_SIZE: usize = 4;
+        const ERASE_SIZE: usize = 128;
+
+        fn write(&mut self, _offset: u32, _bytes: &[u8]) -> Result<(), Self::Error> {
+            unimplemented!()
+        }
+
+        fn erase(&mut self, from: u32, to: u32) -> Result<(), Self::Error> {
+            self.0.push((from, to));
+            Ok(())
+        }
+    }
+
+    #[futures_test::test]
+    async fn can_erase() {
+        let fake = FakeFlash::default();
+        let mut yielding = BlockingAsync::new(fake);
+
+        yielding.erase(0, 256).await.unwrap();
+
+        let fake = yielding.wrapped;
+        assert_eq!(2, fake.0.len());
+        assert_eq!((0, 128), fake.0[0]);
+        assert_eq!((128, 256), fake.0[1]);
+    }
+
+    #[futures_test::test]
+    async fn can_erase_wrong_erase_size() {
+        let fake = FakeFlash::default();
+        let mut yielding = BlockingAsync::new(fake);
+
+        yielding.erase(0, 257).await.unwrap();
+
+        let fake = yielding.wrapped;
+        assert_eq!(3, fake.0.len());
+        assert_eq!((0, 128), fake.0[0]);
+        assert_eq!((128, 256), fake.0[1]);
+        assert_eq!((256, 257), fake.0[2]);
     }
 }

--- a/embassy-embedded-hal/src/adapter/blocking_async.rs
+++ b/embassy-embedded-hal/src/adapter/blocking_async.rs
@@ -1,5 +1,3 @@
-//! Adapters between embedded-hal traits.
-
 use embedded_hal_02::{blocking, serial};
 
 /// Wrapper that implements async traits using blocking implementations.

--- a/embassy-embedded-hal/src/adapter/mod.rs
+++ b/embassy-embedded-hal/src/adapter/mod.rs
@@ -1,0 +1,5 @@
+mod blocking_async;
+mod yielding_async;
+
+pub use blocking_async::BlockingAsync;
+pub use yielding_async::YieldingAsync;

--- a/embassy-embedded-hal/src/adapter/mod.rs
+++ b/embassy-embedded-hal/src/adapter/mod.rs
@@ -1,3 +1,5 @@
+//! Adapters between embedded-hal traits.
+
 mod blocking_async;
 mod yielding_async;
 

--- a/embassy-embedded-hal/src/adapter/yielding_async.rs
+++ b/embassy-embedded-hal/src/adapter/yielding_async.rs
@@ -1,0 +1,232 @@
+use embassy_futures::yield_now;
+
+/// Wrapper that yields for each operation to the wrapped instance
+///
+/// This can be used in combination with BlockingAsync<T> to enforce yields
+/// between long running blocking operations.
+pub struct YieldingAsync<T> {
+    wrapped: T,
+}
+
+impl<T> YieldingAsync<T> {
+    /// Create a new instance of a wrapper that yields after each operation.
+    pub fn new(wrapped: T) -> Self {
+        Self { wrapped }
+    }
+}
+
+//
+// I2C implementations
+//
+impl<T> embedded_hal_1::i2c::ErrorType for YieldingAsync<T>
+where
+    T: embedded_hal_1::i2c::ErrorType,
+{
+    type Error = T::Error;
+}
+
+impl<T> embedded_hal_async::i2c::I2c for YieldingAsync<T>
+where
+    T: embedded_hal_async::i2c::I2c,
+{
+    async fn read(&mut self, address: u8, read: &mut [u8]) -> Result<(), Self::Error> {
+        self.wrapped.read(address, read).await?;
+        yield_now().await;
+        Ok(())
+    }
+
+    async fn write(&mut self, address: u8, write: &[u8]) -> Result<(), Self::Error> {
+        self.wrapped.write(address, write).await?;
+        yield_now().await;
+        Ok(())
+    }
+
+    async fn write_read(&mut self, address: u8, write: &[u8], read: &mut [u8]) -> Result<(), Self::Error> {
+        self.wrapped.write_read(address, write, read).await?;
+        yield_now().await;
+        Ok(())
+    }
+
+    async fn transaction(
+        &mut self,
+        address: u8,
+        operations: &mut [embedded_hal_1::i2c::Operation<'_>],
+    ) -> Result<(), Self::Error> {
+        self.wrapped.transaction(address, operations).await?;
+        yield_now().await;
+        Ok(())
+    }
+}
+
+//
+// SPI implementations
+//
+
+impl<T> embedded_hal_async::spi::ErrorType for YieldingAsync<T>
+where
+    T: embedded_hal_async::spi::ErrorType,
+{
+    type Error = T::Error;
+}
+
+impl<T> embedded_hal_async::spi::SpiBus<u8> for YieldingAsync<T>
+where
+    T: embedded_hal_async::spi::SpiBus,
+{
+    async fn transfer<'a>(&'a mut self, read: &'a mut [u8], write: &'a [u8]) -> Result<(), Self::Error> {
+        self.wrapped.transfer(read, write).await?;
+        yield_now().await;
+        Ok(())
+    }
+
+    async fn transfer_in_place<'a>(&'a mut self, words: &'a mut [u8]) -> Result<(), Self::Error> {
+        self.wrapped.transfer_in_place(words).await?;
+        yield_now().await;
+        Ok(())
+    }
+}
+
+impl<T> embedded_hal_async::spi::SpiBusFlush for YieldingAsync<T>
+where
+    T: embedded_hal_async::spi::SpiBusFlush,
+{
+    async fn flush(&mut self) -> Result<(), Self::Error> {
+        self.wrapped.flush().await?;
+        yield_now().await;
+        Ok(())
+    }
+}
+
+impl<T> embedded_hal_async::spi::SpiBusWrite<u8> for YieldingAsync<T>
+where
+    T: embedded_hal_async::spi::SpiBusWrite<u8>,
+{
+    async fn write(&mut self, data: &[u8]) -> Result<(), Self::Error> {
+        self.wrapped.write(data).await?;
+        yield_now().await;
+        Ok(())
+    }
+}
+
+impl<T> embedded_hal_async::spi::SpiBusRead<u8> for YieldingAsync<T>
+where
+    T: embedded_hal_async::spi::SpiBusRead<u8>,
+{
+    async fn read(&mut self, data: &mut [u8]) -> Result<(), Self::Error> {
+        self.wrapped.read(data).await?;
+        yield_now().await;
+        Ok(())
+    }
+}
+
+///
+/// NOR flash implementations
+///
+impl<T: embedded_storage::nor_flash::ErrorType> embedded_storage::nor_flash::ErrorType for YieldingAsync<T> {
+    type Error = T::Error;
+}
+
+impl<T: embedded_storage_async::nor_flash::ReadNorFlash> embedded_storage_async::nor_flash::ReadNorFlash
+    for YieldingAsync<T>
+{
+    const READ_SIZE: usize = T::READ_SIZE;
+
+    async fn read(&mut self, offset: u32, bytes: &mut [u8]) -> Result<(), Self::Error> {
+        self.wrapped.read(offset, bytes).await?;
+        Ok(())
+    }
+
+    fn capacity(&self) -> usize {
+        self.wrapped.capacity()
+    }
+}
+
+impl<T: embedded_storage_async::nor_flash::NorFlash> embedded_storage_async::nor_flash::NorFlash for YieldingAsync<T> {
+    const WRITE_SIZE: usize = T::WRITE_SIZE;
+    const ERASE_SIZE: usize = T::ERASE_SIZE;
+
+    async fn write(&mut self, offset: u32, bytes: &[u8]) -> Result<(), Self::Error> {
+        self.wrapped.write(offset, bytes).await?;
+        yield_now().await;
+        Ok(())
+    }
+
+    async fn erase(&mut self, from: u32, to: u32) -> Result<(), Self::Error> {
+        // Yield between each actual erase
+        for from in (from..to).step_by(T::ERASE_SIZE) {
+            let to = core::cmp::min(from + T::ERASE_SIZE as u32, to);
+            self.wrapped.erase(from, to).await?;
+            yield_now().await;
+        }
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use embedded_storage_async::nor_flash::NorFlash;
+
+    use super::*;
+
+    extern crate std;
+
+    #[derive(Default)]
+    struct FakeFlash(Vec<(u32, u32)>);
+
+    impl embedded_storage::nor_flash::ErrorType for FakeFlash {
+        type Error = std::convert::Infallible;
+    }
+
+    impl embedded_storage_async::nor_flash::ReadNorFlash for FakeFlash {
+        const READ_SIZE: usize = 1;
+
+        async fn read(&mut self, _offset: u32, _bytes: &mut [u8]) -> Result<(), Self::Error> {
+            unimplemented!()
+        }
+
+        fn capacity(&self) -> usize {
+            unimplemented!()
+        }
+    }
+
+    impl embedded_storage_async::nor_flash::NorFlash for FakeFlash {
+        const WRITE_SIZE: usize = 4;
+        const ERASE_SIZE: usize = 128;
+
+        async fn write(&mut self, _offset: u32, _bytes: &[u8]) -> Result<(), Self::Error> {
+            unimplemented!()
+        }
+
+        async fn erase(&mut self, from: u32, to: u32) -> Result<(), Self::Error> {
+            self.0.push((from, to));
+            Ok(())
+        }
+    }
+
+    #[futures_test::test]
+    async fn can_erase() {
+        let fake = FakeFlash::default();
+        let mut yielding = YieldingAsync::new(fake);
+
+        yielding.erase(0, 256).await.unwrap();
+
+        let fake = yielding.wrapped;
+        assert_eq!(2, fake.0.len());
+        assert_eq!((0, 128), fake.0[0]);
+        assert_eq!((128, 256), fake.0[1]);
+    }
+
+    #[futures_test::test]
+    async fn can_erase_wrong_erase_size() {
+        let fake = FakeFlash::default();
+        let mut yielding = YieldingAsync::new(fake);
+
+        yielding.erase(0, 257).await.unwrap();
+
+        let fake = yielding.wrapped;
+        assert_eq!(3, fake.0.len());
+        assert_eq!((0, 128), fake.0[0]);
+        assert_eq!((128, 256), fake.0[1]);
+        assert_eq!((256, 257), fake.0[2]);
+    }
+}


### PR DESCRIPTION
This PR calls `yield_now()` for long blocking `NorFlash` read and erase operations.
The motivation for this change is to allow for other tasks on the same executor to get something done between these long running operations, for example a task that feeds a watchdog. This will allow the watchdog to have a timer relative to e.g. one sector erase, instead of all sector erase.