### PR TITLE
ci: replace openid connect with static secret.

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -36,6 +36,8 @@ jobs:
             target_ci
           key: rust3-${{ runner.os }}-${{ hashFiles('rust-toolchain.toml') }}
       - name: build
+        env:
+          TELEPROBE_TOKEN: ${{ secrets.TELEPROBE_TOKEN }}
         run: |
           curl -L -o /usr/local/bin/cargo-batch https://github.com/embassy-rs/cargo-batch/releases/download/batch-0.3.0/cargo-batch
           chmod +x /usr/local/bin/cargo-batch

--- a/ci.sh
+++ b/ci.sh
@@ -160,12 +160,8 @@ function run_elf {
 }
 
 if [[ -z "${TELEPROBE_TOKEN-}" ]]; then
-    if [[ -z "${ACTIONS_ID_TOKEN_REQUEST_TOKEN-}" ]]; then
-        echo No teleprobe token found, skipping running HIL tests
-        exit
-    fi
-
-    export TELEPROBE_TOKEN=$(curl -sS -H "Authorization: Bearer $ACTIONS_ID_TOKEN_REQUEST_TOKEN" "$ACTIONS_ID_TOKEN_REQUEST_URL" | jq -r '.value')
+    echo No teleprobe token found, skipping running HIL tests
+    exit
 fi
 
 for board in $(ls out/tests); do 


### PR DESCRIPTION
The oidc token is only valid for 5min, builds are starting to fail because HIL tests take more than 5 min and we only obtain it once at start.

Instead of fixing it, let's remove it. My hope for OIDC was to allow running HIL tests on PRs from forks if the author is in a list of trusted users. However GHA simply doesn't give the ID token to PRs from forks. :shrug: Same limitation as with static tokens. So it's useless complexity, let's kill it.