### PR TITLE
Align with updated stm32 metapac

### DIFF
--- a/embassy-stm32/Cargo.toml
+++ b/embassy-stm32/Cargo.toml
@@ -58,7 +58,7 @@ sdio-host = "0.5.0"
 embedded-sdmmc = { git = "https://github.com/embassy-rs/embedded-sdmmc-rs", rev = "a4f293d3a6f72158385f79c98634cb8a14d0d2fc", optional = true }
 critical-section = "1.1"
 atomic-polyfill = "1.0.1"
-stm32-metapac = "7"
+stm32-metapac = "8"
 vcell = "0.1.3"
 bxcan = "0.7.0"
 nb = "1.0.0"
@@ -75,7 +75,7 @@ critical-section = { version = "1.1", features = ["std"] }
 [build-dependencies]
 proc-macro2 = "1.0.36"
 quote = "1.0.15"
-stm32-metapac = { version = "7", default-features = false, features = ["metadata"]}
+stm32-metapac = { version = "8", default-features = false, features = ["metadata"]}
 
 [features]
 default = ["stm32-metapac/rt"]

--- a/embassy-stm32/src/rcc/g4.rs
+++ b/embassy-stm32/src/rcc/g4.rs
@@ -1,3 +1,5 @@
+use stm32_metapac::rcc::vals::{Hpre, Ppre, Sw};
+
 use crate::pac::{PWR, RCC};
 use crate::rcc::{set_freqs, Clocks};
 use crate::time::Hertz;
@@ -39,30 +41,58 @@ pub enum APBPrescaler {
     Div16,
 }
 
-impl Into<u8> for APBPrescaler {
-    fn into(self) -> u8 {
+impl AHBPrescaler {
+    const fn div(self) -> u32 {
         match self {
-            APBPrescaler::NotDivided => 1,
-            APBPrescaler::Div2 => 0x04,
-            APBPrescaler::Div4 => 0x05,
-            APBPrescaler::Div8 => 0x06,
-            APBPrescaler::Div16 => 0x07,
+            AHBPrescaler::NotDivided => 1,
+            AHBPrescaler::Div2 => 2,
+            AHBPrescaler::Div4 => 4,
+            AHBPrescaler::Div8 => 8,
+            AHBPrescaler::Div16 => 16,
+            AHBPrescaler::Div64 => 64,
+            AHBPrescaler::Div128 => 128,
+            AHBPrescaler::Div256 => 256,
+            AHBPrescaler::Div512 => 512,
         }
     }
 }
 
-impl Into<u8> for AHBPrescaler {
-    fn into(self) -> u8 {
+impl APBPrescaler {
+    const fn div(self) -> u32 {
         match self {
-            AHBPrescaler::NotDivided => 1,
-            AHBPrescaler::Div2 => 0x08,
-            AHBPrescaler::Div4 => 0x09,
-            AHBPrescaler::Div8 => 0x0a,
-            AHBPrescaler::Div16 => 0x0b,
-            AHBPrescaler::Div64 => 0x0c,
-            AHBPrescaler::Div128 => 0x0d,
-            AHBPrescaler::Div256 => 0x0e,
-            AHBPrescaler::Div512 => 0x0f,
+            APBPrescaler::NotDivided => 1,
+            APBPrescaler::Div2 => 2,
+            APBPrescaler::Div4 => 4,
+            APBPrescaler::Div8 => 8,
+            APBPrescaler::Div16 => 16,
+        }
+    }
+}
+
+impl Into<Ppre> for APBPrescaler {
+    fn into(self) -> Ppre {
+        match self {
+            APBPrescaler::NotDivided => Ppre::DIV1,
+            APBPrescaler::Div2 => Ppre::DIV2,
+            APBPrescaler::Div4 => Ppre::DIV4,
+            APBPrescaler::Div8 => Ppre::DIV8,
+            APBPrescaler::Div16 => Ppre::DIV16,
+        }
+    }
+}
+
+impl Into<Hpre> for AHBPrescaler {
+    fn into(self) -> Hpre {
+        match self {
+            AHBPrescaler::NotDivided => Hpre::DIV1,
+            AHBPrescaler::Div2 => Hpre::DIV2,
+            AHBPrescaler::Div4 => Hpre::DIV4,
+            AHBPrescaler::Div8 => Hpre::DIV8,
+            AHBPrescaler::Div16 => Hpre::DIV16,
+            AHBPrescaler::Div64 => Hpre::DIV64,
+            AHBPrescaler::Div128 => Hpre::DIV128,
+            AHBPrescaler::Div256 => Hpre::DIV256,
+            AHBPrescaler::Div512 => Hpre::DIV512,
         }
     }
 }
@@ -96,19 +126,19 @@ pub(crate) unsafe fn init(config: Config) {
             RCC.cr().write(|w| w.set_hsion(true));
             while !RCC.cr().read().hsirdy() {}
 
-            (HSI_FREQ.0, 0x01)
+            (HSI_FREQ.0, Sw::HSI16)
         }
         ClockSrc::HSE(freq) => {
             // Enable HSE
             RCC.cr().write(|w| w.set_hseon(true));
             while !RCC.cr().read().hserdy() {}
 
-            (freq.0, 0x02)
+            (freq.0, Sw::HSE)
         }
     };
 
     RCC.cfgr().modify(|w| {
-        w.set_sw(sw.into());
+        w.set_sw(sw);
         w.set_hpre(config.ahb_pre.into());
         w.set_ppre1(config.apb1_pre.into());
         w.set_ppre2(config.apb2_pre.into());
@@ -116,19 +146,13 @@ pub(crate) unsafe fn init(config: Config) {
 
     let ahb_freq: u32 = match config.ahb_pre {
         AHBPrescaler::NotDivided => sys_clk,
-        pre => {
-            let pre: u8 = pre.into();
-            let pre = 1 << (pre as u32 - 7);
-            sys_clk / pre
-        }
+        pre => sys_clk / pre.div(),
     };
 
     let (apb1_freq, apb1_tim_freq) = match config.apb1_pre {
         APBPrescaler::NotDivided => (ahb_freq, ahb_freq),
         pre => {
-            let pre: u8 = pre.into();
-            let pre: u8 = 1 << (pre - 3);
-            let freq = ahb_freq / pre as u32;
+            let freq = ahb_freq / pre.div();
             (freq, freq * 2)
         }
     };
@@ -136,9 +160,7 @@ pub(crate) unsafe fn init(config: Config) {
     let (apb2_freq, apb2_tim_freq) = match config.apb2_pre {
         APBPrescaler::NotDivided => (ahb_freq, ahb_freq),
         pre => {
-            let pre: u8 = pre.into();
-            let pre: u8 = 1 << (pre - 3);
-            let freq = ahb_freq / pre as u32;
+            let freq = ahb_freq / pre.div();
             (freq, freq * 2)
         }
     };

--- a/embassy-stm32/src/rtc/v3.rs
+++ b/embassy-stm32/src/rtc/v3.rs
@@ -9,7 +9,7 @@ impl<'d, T: Instance> super::Rtc<'d, T> {
     pub(super) fn apply_config(&mut self, rtc_config: RtcConfig) {
         // Unlock the backup domain
         unsafe {
-            #[cfg(any(rtc_v3u5, rcc_g0))]
+            #[cfg(any(rtc_v3u5, rcc_g0, rcc_g4))]
             use crate::pac::rcc::vals::Rtcsel;
             #[cfg(not(any(rtc_v3u5, rcc_g0, rcc_g4, rcc_wl5, rcc_wle)))]
             use crate::pac::rtc::vals::Rtcsel;
@@ -31,7 +31,7 @@ impl<'d, T: Instance> super::Rtc<'d, T> {
             assert!(!reg.lsecsson(), "RTC is not compatible with LSE CSS, yet.");
 
             let config_rtcsel = rtc_config.clock_config as u8;
-            #[cfg(not(any(rcc_wl5, rcc_wle, rcc_g4)))]
+            #[cfg(not(any(rcc_wl5, rcc_wle)))]
             let config_rtcsel = Rtcsel(config_rtcsel);
 
             if !reg.rtcen() || reg.rtcsel() != config_rtcsel {


### PR DESCRIPTION
This now depends on https://github.com/embassy-rs/stm32-data/pull/192 as it seems that ppre1 is using the enum, but ppre2 does not.

Please have a good look at this. I do not have a G4 chip so I cannot verify this change.