### PR TITLE
rp: Implement embedded_hal::serial::Write for Uart/UartTx

### DIFF
--- a/embassy-rp/src/uart/mod.rs
+++ b/embassy-rp/src/uart/mod.rs
@@ -758,7 +758,7 @@ mod eh02 {
     impl<'d, T: Instance, M: Mode> embedded_hal_02::serial::Write<u8> for UartTx<'d, T, M> {
         type Error = Error;
 
-        fn write(&mut self, word: u8) -> nb::Result<(), Self::Error> {
+        fn write(&mut self, word: u8) -> Result<(), nb::Error<Self::Error>> {
             let r = T::regs();
             unsafe {
                 if r.uartfr().read().txff() {
@@ -770,7 +770,7 @@ mod eh02 {
             Ok(())
         }
 
-        fn flush(&mut self) -> nb::Result<(), Self::Error> {
+        fn flush(&mut self) -> Result<(), nb::Error<Self::Error>> {
             let r = T::regs();
             unsafe {
                 if !r.uartfr().read().txfe() {


### PR DESCRIPTION
Uart/UartTx currently implements `embedded_hal_02::serial::Read<u8>` and `embedded_hal_02::blocking::serial::Write<u8>` but not `embedded_hal_02::serial::Write<u8>`.

This implements the missing `embedded_hal_02::serial::Write<u8>` to allow use of Uart with crates that expect this interface, such as [defmt_serial](https://docs.rs/defmt-serial/latest/defmt_serial/).