### PR TITLE
stm32: Flash refactor

### DIFF
--- a/embassy-stm32/src/flash/asynch.rs
+++ b/embassy-stm32/src/flash/asynch.rs
@@ -6,7 +6,7 @@ use embassy_hal_common::into_ref;
 use embassy_sync::blocking_mutex::raw::CriticalSectionRawMutex;
 use embassy_sync::mutex::Mutex;
 use embassy_sync::waitqueue::AtomicWaker;
-use family::get_flash;
+use family::FAMILY;
 use futures::future::poll_fn;
 
 use super::{
@@ -41,7 +41,7 @@ impl<'d> Flash<'d, Async> {
     /// Split the flash into its the distinct regions
     /// When the flash is split, then it is no longer possible to do blocking operations
     pub fn into_regions(self) -> FlashLayout<'d, Async> {
-        assert!(get_flash().default_layout_configured());
+        assert!(FAMILY.default_layout_configured());
         FlashLayout::new(self.inner)
     }
 
@@ -92,16 +92,15 @@ pub(super) async unsafe fn write(base: u32, size: u32, offset: u32, bytes: &[u8]
     let start_address = base + offset;
     trace!("Writing {} bytes at 0x{:x}", bytes.len(), start_address);
 
-    let flash = get_flash();
-    let regions = flash.get_flash_regions();
+    let regions = FAMILY.get_flash_regions();
     let mut sector = get_sector(base, regions);
     let mut offset = start_address - sector.start;
-    let mut writer = flash.unlocked_writer(&sector);
+    let mut writer = FAMILY.unlocked_writer(&sector);
 
     for chunk in bytes.chunks(WRITE_SIZE) {
         if offset == sector.size {
             sector = get_sector(sector.start + sector.size, regions);
-            writer = flash.unlocked_writer(&sector);
+            writer = FAMILY.unlocked_writer(&sector);
             offset = 0;
         }
 
@@ -109,8 +108,8 @@ pub(super) async unsafe fn write(base: u32, size: u32, offset: u32, bytes: &[u8]
         poll_fn(|cx| {
             WAKER.register(cx.waker());
 
-            if !flash.is_busy() {
-                Poll::Ready(flash.read_result())
+            if !FAMILY.is_busy() {
+                Poll::Ready(FAMILY.read_result())
             } else {
                 return Poll::Pending;
             }
@@ -132,8 +131,7 @@ pub(super) async unsafe fn erase(base: u32, from: u32, to: u32) -> Result<(), Er
 
     trace!("Erasing from 0x{:x} to 0x{:x}", start_address, end_address);
 
-    let flash = get_flash();
-    let mut eraser = flash.unlocked_eraser();
+    let mut eraser = FAMILY.unlocked_eraser();
     let mut address = start_address;
     while address < end_address {
         let sector = get_sector(address, regions);
@@ -143,8 +141,8 @@ pub(super) async unsafe fn erase(base: u32, from: u32, to: u32) -> Result<(), Er
         poll_fn(|cx| {
             WAKER.register(cx.waker());
 
-            if !flash.is_busy() {
-                Poll::Ready(flash.read_result())
+            if !FAMILY.is_busy() {
+                Poll::Ready(FAMILY.read_result())
             } else {
                 return Poll::Pending;
             }

--- a/embassy-stm32/src/flash/asynch.rs
+++ b/embassy-stm32/src/flash/asynch.rs
@@ -13,7 +13,7 @@ use super::{
     blocking_read, ensure_sector_aligned, family, get_sector, Async, Error, Flash, FlashLayout, FLASH_BASE, FLASH_SIZE,
     WRITE_SIZE,
 };
-use crate::flash::{FlashFamily, UnlockedErase, UnlockedWrite};
+use crate::flash::{FlashCtrl, UnlockedErase, UnlockedWrite};
 use crate::peripherals::FLASH;
 use crate::{interrupt, Peripheral};
 

--- a/embassy-stm32/src/flash/asynch.rs
+++ b/embassy-stm32/src/flash/asynch.rs
@@ -1,25 +1,30 @@
 use core::marker::PhantomData;
+use core::task::Poll;
 
-use atomic_polyfill::{fence, Ordering};
 use embassy_cortex_m::interrupt::{Interrupt, InterruptExt};
-use embassy_hal_common::drop::OnDrop;
 use embassy_hal_common::into_ref;
 use embassy_sync::blocking_mutex::raw::CriticalSectionRawMutex;
 use embassy_sync::mutex::Mutex;
+use embassy_sync::waitqueue::AtomicWaker;
+use family::get_flash;
+use futures::future::poll_fn;
 
 use super::{
     blocking_read, ensure_sector_aligned, family, get_sector, Async, Error, Flash, FlashLayout, FLASH_BASE, FLASH_SIZE,
     WRITE_SIZE,
 };
+use crate::flash::{FlashFamily, UnlockedErase, UnlockedWrite};
 use crate::peripherals::FLASH;
 use crate::{interrupt, Peripheral};
 
 pub(super) static REGION_ACCESS: Mutex<CriticalSectionRawMutex, ()> = Mutex::new(());
+pub(crate) static WAKER: AtomicWaker = AtomicWaker::new();
 
 impl<'d> Flash<'d, Async> {
+    /// Create a new flash driver that supports blocking and async operations
     pub fn new(
         p: impl Peripheral<P = FLASH> + 'd,
-        _irq: impl interrupt::Binding<crate::interrupt::FLASH, InterruptHandler> + 'd,
+        _irq: impl interrupt::Binding<crate::interrupt::FLASH, crate::flash::InterruptHandler> + 'd,
     ) -> Self {
         into_ref!(p);
 
@@ -33,26 +38,19 @@ impl<'d> Flash<'d, Async> {
         }
     }
 
+    /// Split the flash into its the distinct regions
+    /// When the flash is split, then it is no longer possible to do blocking operations
     pub fn into_regions(self) -> FlashLayout<'d, Async> {
-        family::set_default_layout();
+        assert!(get_flash().default_layout_configured());
         FlashLayout::new(self.inner)
     }
 
     pub async fn write(&mut self, offset: u32, bytes: &[u8]) -> Result<(), Error> {
-        unsafe { write_chunked(FLASH_BASE as u32, FLASH_SIZE as u32, offset, bytes).await }
+        unsafe { write(FLASH_BASE as u32, FLASH_SIZE as u32, offset, bytes).await }
     }
 
     pub async fn erase(&mut self, from: u32, to: u32) -> Result<(), Error> {
-        unsafe { erase_sectored(FLASH_BASE as u32, from, to).await }
-    }
-}
-
-/// Interrupt handler
-pub struct InterruptHandler;
-
-impl interrupt::Handler<crate::interrupt::FLASH> for InterruptHandler {
-    unsafe fn on_interrupt() {
-        family::on_interrupt();
+        unsafe { erase(FLASH_BASE as u32, from, to).await }
     }
 }
 
@@ -83,7 +81,7 @@ impl embedded_storage_async::nor_flash::NorFlash for Flash<'_, Async> {
     }
 }
 
-pub(super) async unsafe fn write_chunked(base: u32, size: u32, offset: u32, bytes: &[u8]) -> Result<(), Error> {
+pub(super) async unsafe fn write(base: u32, size: u32, offset: u32, bytes: &[u8]) -> Result<(), Error> {
     if offset + bytes.len() as u32 > size {
         return Err(Error::Size);
     }
@@ -91,30 +89,41 @@ pub(super) async unsafe fn write_chunked(base: u32, size: u32, offset: u32, byte
         return Err(Error::Unaligned);
     }
 
-    let mut address = base + offset;
-    trace!("Writing {} bytes at 0x{:x}", bytes.len(), address);
+    let start_address = base + offset;
+    trace!("Writing {} bytes at 0x{:x}", bytes.len(), start_address);
+
+    let flash = get_flash();
+    let regions = flash.get_flash_regions();
+    let mut sector = get_sector(base, regions);
+    let mut offset = start_address - sector.start;
+    let mut writer = flash.unlocked_writer(&sector);
 
     for chunk in bytes.chunks(WRITE_SIZE) {
-        family::clear_all_err();
-        fence(Ordering::SeqCst);
-        family::unlock();
-        fence(Ordering::SeqCst);
-        family::enable_write();
-        fence(Ordering::SeqCst);
+        if offset == sector.size {
+            sector = get_sector(sector.start + sector.size, regions);
+            writer = flash.unlocked_writer(&sector);
+            offset = 0;
+        }
 
-        let _on_drop = OnDrop::new(|| {
-            family::disable_write();
-            fence(Ordering::SeqCst);
-            family::lock();
-        });
+        writer.initiate_word_write(&sector, offset, chunk.try_into().unwrap());
+        poll_fn(|cx| {
+            WAKER.register(cx.waker());
 
-        family::write(address, chunk.try_into().unwrap()).await?;
-        address += WRITE_SIZE as u32;
+            if !flash.is_busy() {
+                Poll::Ready(flash.read_result())
+            } else {
+                return Poll::Pending;
+            }
+        })
+        .await?;
+
+        offset += WRITE_SIZE as u32;
     }
+
     Ok(())
 }
 
-pub(super) async unsafe fn erase_sectored(base: u32, from: u32, to: u32) -> Result<(), Error> {
+pub(super) async unsafe fn erase(base: u32, from: u32, to: u32) -> Result<(), Error> {
     let start_address = base + from;
     let end_address = base + to;
     let regions = family::get_flash_regions();
@@ -123,19 +132,25 @@ pub(super) async unsafe fn erase_sectored(base: u32, from: u32, to: u32) -> Resu
 
     trace!("Erasing from 0x{:x} to 0x{:x}", start_address, end_address);
 
+    let flash = get_flash();
+    let mut eraser = flash.unlocked_eraser();
     let mut address = start_address;
     while address < end_address {
         let sector = get_sector(address, regions);
         trace!("Erasing sector: {:?}", sector);
 
-        family::clear_all_err();
-        fence(Ordering::SeqCst);
-        family::unlock();
-        fence(Ordering::SeqCst);
+        eraser.initiate_sector_erase(&sector);
+        poll_fn(|cx| {
+            WAKER.register(cx.waker());
 
-        let _on_drop = OnDrop::new(|| family::lock());
+            if !flash.is_busy() {
+                Poll::Ready(flash.read_result())
+            } else {
+                return Poll::Pending;
+            }
+        })
+        .await?;
 
-        family::erase_sector(&sector).await?;
         address += sector.size;
     }
     Ok(())
@@ -150,12 +165,12 @@ foreach_flash_region! {
 
             pub async fn write(&mut self, offset: u32, bytes: &[u8]) -> Result<(), Error> {
                 let _guard = REGION_ACCESS.lock().await;
-                unsafe { write_chunked(self.0.base, self.0.size, offset, bytes).await }
+                unsafe { write(self.0.base, self.0.size, offset, bytes).await }
             }
 
             pub async fn erase(&mut self, from: u32, to: u32) -> Result<(), Error> {
                 let _guard = REGION_ACCESS.lock().await;
-                unsafe { erase_sectored(self.0.base, from, to).await }
+                unsafe { erase(self.0.base, from, to).await }
             }
         }
 

--- a/embassy-stm32/src/flash/common.rs
+++ b/embassy-stm32/src/flash/common.rs
@@ -8,7 +8,7 @@ use super::{
     family, Async, Blocking, Error, FlashBank, FlashLayout, FlashRegion, FlashSector, FLASH_SIZE, MAX_ERASE_SIZE,
     READ_SIZE, WRITE_SIZE,
 };
-use crate::flash::{FlashFamily, UnlockedErase, UnlockedWrite};
+use crate::flash::{FlashCtrl, UnlockedErase, UnlockedWrite};
 use crate::peripherals::FLASH;
 use crate::Peripheral;
 

--- a/embassy-stm32/src/flash/common.rs
+++ b/embassy-stm32/src/flash/common.rs
@@ -1,14 +1,14 @@
 use core::marker::PhantomData;
 
 use embassy_hal_common::{into_ref, PeripheralRef};
-use family::get_blocking_flash;
+use family::FAMILY;
 use stm32_metapac::FLASH_BASE;
 
 use super::{
-    family, Async, Blocking, Error, FlashBank, FlashFamily, FlashLayout, FlashRegion, FlashSector, FLASH_SIZE,
-    MAX_ERASE_SIZE, READ_SIZE, WRITE_SIZE,
+    family, Async, Blocking, Error, FlashBank, FlashLayout, FlashRegion, FlashSector, FLASH_SIZE, MAX_ERASE_SIZE,
+    READ_SIZE, WRITE_SIZE,
 };
-use crate::flash::{UnlockedErase, UnlockedWrite};
+use crate::flash::{FlashFamily, UnlockedErase, UnlockedWrite};
 use crate::peripherals::FLASH;
 use crate::Peripheral;
 
@@ -32,7 +32,7 @@ impl<'d> Flash<'d, Blocking> {
 impl<'d, MODE> Flash<'d, MODE> {
     /// Split the flash into its the distinct regions
     pub fn into_blocking_regions(self) -> FlashLayout<'d, Blocking> {
-        assert!(get_blocking_flash().default_layout_configured());
+        assert!(FAMILY.default_layout_configured());
         FlashLayout::new(self.inner)
     }
 
@@ -77,22 +77,21 @@ unsafe fn blocking_write(base: u32, size: u32, offset: u32, bytes: &[u8]) -> Res
 
     // Write within a cs to ensure that no-one else takes an unlocked_writer or unlocked_eraser
     critical_section::with(|_| {
-        let flash = get_blocking_flash();
-        let regions = flash.get_flash_regions();
+        let regions = FAMILY.get_flash_regions();
         let mut sector = get_sector(start_address, regions);
         let mut offset = start_address - sector.start;
-        let mut writer = flash.unlocked_writer(&sector);
+        let mut writer = FAMILY.unlocked_writer(&sector);
 
         for chunk in bytes.chunks(WRITE_SIZE) {
             if offset == sector.size {
                 sector = get_sector(sector.start + sector.size, regions);
-                writer = flash.unlocked_writer(&sector);
+                writer = FAMILY.unlocked_writer(&sector);
                 offset = 0;
             }
 
             writer.initiate_word_write(&sector, offset, chunk.try_into().unwrap());
-            while flash.is_busy() {}
-            flash.read_result()?;
+            while FAMILY.is_busy() {}
+            FAMILY.read_result()?;
 
             offset += WRITE_SIZE as u32;
         }
@@ -117,12 +116,11 @@ pub(super) unsafe fn blocking_erase(base: u32, from: u32, to: u32) -> Result<(),
 
         // Erase within a cs to ensure that no-one else takes an unlocked_writer or unlocked_eraser
         critical_section::with(|_| {
-            let flash = get_blocking_flash();
-            let mut eraser = flash.unlocked_eraser();
+            let mut eraser = FAMILY.unlocked_eraser();
 
             eraser.initiate_sector_erase(&sector);
-            while flash.is_busy() {}
-            flash.read_result()
+            while FAMILY.is_busy() {}
+            FAMILY.read_result()
         })?;
 
         address += sector.size;

--- a/embassy-stm32/src/flash/f4.rs
+++ b/embassy-stm32/src/flash/f4.rs
@@ -6,9 +6,7 @@ use pac::flash::vals;
 use pac::FLASH_SIZE;
 
 use super::asynch::WAKER;
-use super::{
-    FlashBank, FlashFamily, FlashRegion, FlashSector, UnlockedErase, UnlockedWrite, FLASH_REGIONS, WRITE_SIZE,
-};
+use super::{FlashBank, FlashCtrl, FlashRegion, FlashSector, UnlockedErase, UnlockedWrite, FLASH_REGIONS, WRITE_SIZE};
 use crate::flash::Error;
 use crate::{interrupt, pac};
 
@@ -22,7 +20,7 @@ mod alt_regions {
     use super::FAMILY;
     use crate::_generated::flash_regions::{OTPRegion, BANK1_REGION1, BANK1_REGION2, BANK1_REGION3, OTP_REGION};
     use crate::flash::{
-        asynch, Async, Bank1Region1, Bank1Region2, Blocking, Error, Flash, FlashBank, FlashFamily, FlashRegion,
+        asynch, Async, Bank1Region1, Bank1Region2, Blocking, Error, Flash, FlashBank, FlashCtrl, FlashRegion,
     };
     use crate::peripherals::FLASH;
 
@@ -212,7 +210,7 @@ impl interrupt::Handler<crate::interrupt::FLASH> for InterruptHandler {
     }
 }
 
-impl FlashFamily for F4 {
+impl FlashCtrl for F4 {
     type WRITE = UnlockedF4;
     type ERASE = UnlockedF4;
 

--- a/embassy-stm32/src/flash/mod.rs
+++ b/embassy-stm32/src/flash/mod.rs
@@ -100,34 +100,34 @@ pub(crate) trait FlashCtrl {
     type ERASE: UnlockedErase;
 
     /// Get whether the default layout is configured for the flash
-    fn default_layout_configured(&self) -> bool {
+    fn default_layout_configured() -> bool {
         true
     }
 
     /// Get the flash regions
-    fn get_flash_regions(&self) -> &'static [&'static FlashRegion];
+    fn get_flash_regions() -> &'static [&'static FlashRegion];
 
     /// Create a new unlocked async flash writer
     /// When the writer is dropped it is expected that the flash locks
-    unsafe fn unlocked_writer(&self, sector: &FlashSector) -> Self::WRITE;
+    unsafe fn unlocked_writer(sector: &FlashSector) -> Self::WRITE;
 
     /// Create a new unlocked blocking flash writer
     /// When the writer is dropped it is expected that the flash locks
-    unsafe fn unlocked_blocking_writer(&self, sector: &FlashSector) -> Self::WRITE;
+    unsafe fn unlocked_blocking_writer(sector: &FlashSector) -> Self::WRITE;
 
     /// Create a new unlocked async flash eraser
     /// When the eraser is dropped it is expected that the flash locks
-    unsafe fn unlocked_eraser(&self) -> Self::ERASE;
+    unsafe fn unlocked_eraser() -> Self::ERASE;
 
     /// Create a new unlocked blocking flash eraser
     /// When the eraser is dropped it is expected that the flash locks
-    unsafe fn unlocked_blocking_eraser(&self) -> Self::ERASE;
+    unsafe fn unlocked_blocking_eraser() -> Self::ERASE;
 
-    /// Determine if a flash operation si ongoing
-    fn is_busy(&self) -> bool;
+    /// Determine if a flash operation is ongoing
+    fn is_busy() -> bool;
 
     /// Read flash operation completetion status
-    unsafe fn read_result(&self) -> Result<(), Error>;
+    unsafe fn read_result() -> Result<(), Error>;
 }
 
 pub(crate) trait UnlockedWrite {

--- a/embassy-stm32/src/flash/mod.rs
+++ b/embassy-stm32/src/flash/mod.rs
@@ -125,17 +125,19 @@ pub(crate) trait FlashCtrl {
 
     /// Determine if a flash operation is ongoing
     fn is_busy() -> bool;
-
-    /// Read flash operation completetion status
-    unsafe fn read_result() -> Result<(), Error>;
 }
 
 pub(crate) trait UnlockedWrite {
     /// Start writing of a flash word
     fn initiate_word_write(&mut self, sector: &FlashSector, offset: u32, word: &[u8; WRITE_SIZE]);
+
+    /// Read flash write operation completetion status
+    fn read_result(&mut self) -> Result<(), Error>;
 }
 
 pub(crate) trait UnlockedErase {
     /// Start erasing a sector
     fn initiate_sector_erase(&mut self, sector: &FlashSector);
+    /// Read flash erase operation completetion status
+    fn read_result(&mut self) -> Result<(), Error>;
 }

--- a/embassy-stm32/src/flash/mod.rs
+++ b/embassy-stm32/src/flash/mod.rs
@@ -95,7 +95,7 @@ impl NorFlashError for Error {
     }
 }
 
-pub(crate) trait FlashFamily {
+pub(crate) trait FlashCtrl {
     type WRITE: UnlockedWrite;
     type ERASE: UnlockedErase;
 

--- a/embassy-stm32/src/flash/mod.rs
+++ b/embassy-stm32/src/flash/mod.rs
@@ -95,9 +95,9 @@ impl NorFlashError for Error {
     }
 }
 
-pub(crate) trait FlashFamily<MODE> {
-    type WRITE: UnlockedWrite<MODE>;
-    type ERASE: UnlockedErase<MODE>;
+pub(crate) trait FlashFamily {
+    type WRITE: UnlockedWrite;
+    type ERASE: UnlockedErase;
 
     /// Get whether the default layout is configured for the flash
     fn default_layout_configured(&self) -> bool {
@@ -107,13 +107,21 @@ pub(crate) trait FlashFamily<MODE> {
     /// Get the flash regions
     fn get_flash_regions(&self) -> &'static [&'static FlashRegion];
 
-    /// Create a new unlocked flash writer
+    /// Create a new unlocked async flash writer
     /// When the writer is dropped it is expected that the flash locks
     unsafe fn unlocked_writer(&self, sector: &FlashSector) -> Self::WRITE;
 
-    /// Create a new unlocked flash eraser
+    /// Create a new unlocked blocking flash writer
+    /// When the writer is dropped it is expected that the flash locks
+    unsafe fn unlocked_blocking_writer(&self, sector: &FlashSector) -> Self::WRITE;
+
+    /// Create a new unlocked async flash eraser
     /// When the eraser is dropped it is expected that the flash locks
     unsafe fn unlocked_eraser(&self) -> Self::ERASE;
+
+    /// Create a new unlocked blocking flash eraser
+    /// When the eraser is dropped it is expected that the flash locks
+    unsafe fn unlocked_blocking_eraser(&self) -> Self::ERASE;
 
     /// Determine if a flash operation si ongoing
     fn is_busy(&self) -> bool;
@@ -122,12 +130,12 @@ pub(crate) trait FlashFamily<MODE> {
     unsafe fn read_result(&self) -> Result<(), Error>;
 }
 
-pub(crate) trait UnlockedWrite<MODE> {
+pub(crate) trait UnlockedWrite {
     /// Start writing of a flash word
     fn initiate_word_write(&mut self, sector: &FlashSector, offset: u32, word: &[u8; WRITE_SIZE]);
 }
 
-pub(crate) trait UnlockedErase<MODE> {
+pub(crate) trait UnlockedErase {
     /// Start erasing a sector
     fn initiate_sector_erase(&mut self, sector: &FlashSector);
 }


### PR DESCRIPTION
This is a proposal for a refactor of the stm32 flash driver. It is currently has a lot of duplicating code which this refactor tries to greatly reduce.

It does this by introducing a `FlashCtrl` trait that all families are supposed to implement. Let me know your thoughts whether this is something I should continue on, or?