### PR TITLE
Remove ability to, during runtime, set alt layout - it does not work.

### DIFF
--- a/embassy-stm32/src/flash/asynch.rs
+++ b/embassy-stm32/src/flash/asynch.rs
@@ -34,7 +34,7 @@ impl<'d> Flash<'d, Async> {
     }
 
     pub fn into_regions(self) -> FlashLayout<'d, Async> {
-        family::set_default_layout();
+        assert!(family::is_default_layout());
         FlashLayout::new(self.inner)
     }
 

--- a/embassy-stm32/src/flash/common.rs
+++ b/embassy-stm32/src/flash/common.rs
@@ -30,7 +30,7 @@ impl<'d> Flash<'d, Blocking> {
 
 impl<'d, MODE> Flash<'d, MODE> {
     pub fn into_blocking_regions(self) -> FlashLayout<'d, Blocking> {
-        family::set_default_layout();
+        assert!(family::is_default_layout());
         FlashLayout::new(self.inner)
     }
 

--- a/embassy-stm32/src/flash/f0.rs
+++ b/embassy-stm32/src/flash/f0.rs
@@ -7,7 +7,9 @@ use super::{FlashRegion, FlashSector, FLASH_REGIONS, WRITE_SIZE};
 use crate::flash::Error;
 use crate::pac;
 
-pub const fn set_default_layout() {}
+pub const fn is_default_layout() -> bool {
+    true
+}
 
 pub const fn get_flash_regions() -> &'static [&'static FlashRegion] {
     &FLASH_REGIONS

--- a/embassy-stm32/src/flash/f3.rs
+++ b/embassy-stm32/src/flash/f3.rs
@@ -7,7 +7,9 @@ use super::{FlashRegion, FlashSector, FLASH_REGIONS, WRITE_SIZE};
 use crate::flash::Error;
 use crate::pac;
 
-pub const fn set_default_layout() {}
+pub const fn is_default_layout() -> bool {
+    true
+}
 
 pub const fn get_flash_regions() -> &'static [&'static FlashRegion] {
     &FLASH_REGIONS

--- a/embassy-stm32/src/flash/f7.rs
+++ b/embassy-stm32/src/flash/f7.rs
@@ -6,7 +6,9 @@ use super::{FlashRegion, FlashSector, FLASH_REGIONS, WRITE_SIZE};
 use crate::flash::Error;
 use crate::pac;
 
-pub const fn set_default_layout() {}
+pub const fn is_default_layout() -> bool {
+    true
+}
 
 pub const fn get_flash_regions() -> &'static [&'static FlashRegion] {
     &FLASH_REGIONS

--- a/embassy-stm32/src/flash/h7.rs
+++ b/embassy-stm32/src/flash/h7.rs
@@ -7,7 +7,9 @@ use super::{FlashRegion, FlashSector, BANK1_REGION, FLASH_REGIONS, WRITE_SIZE};
 use crate::flash::Error;
 use crate::pac;
 
-pub const fn set_default_layout() {}
+pub const fn is_default_layout() -> bool {
+    true
+}
 
 const fn is_dual_bank() -> bool {
     FLASH_REGIONS.len() == 2

--- a/embassy-stm32/src/flash/l.rs
+++ b/embassy-stm32/src/flash/l.rs
@@ -6,7 +6,9 @@ use super::{FlashRegion, FlashSector, FLASH_REGIONS, WRITE_SIZE};
 use crate::flash::Error;
 use crate::pac;
 
-pub const fn set_default_layout() {}
+pub const fn is_default_layout() -> bool {
+    true
+}
 
 pub const fn get_flash_regions() -> &'static [&'static FlashRegion] {
     &FLASH_REGIONS

--- a/embassy-stm32/src/flash/other.rs
+++ b/embassy-stm32/src/flash/other.rs
@@ -2,7 +2,9 @@
 
 use super::{Error, FlashRegion, FlashSector, FLASH_REGIONS, WRITE_SIZE};
 
-pub const fn set_default_layout() {}
+pub const fn is_default_layout() -> bool {
+    true
+}
 
 pub const fn get_flash_regions() -> &'static [&'static FlashRegion] {
     &FLASH_REGIONS


### PR DESCRIPTION
I wasted yesterday trying to get this to work. It seems that erase operations does not work when in db1m mode. The erase operations, both bank and sector, runs and completes without any error flags being set. It also takes expected amount of time, but the flash is not actually erased.
I found [this](https://community.st.com/s/question/0D50X00009XkWrASAV/is-it-possilbe-to-checkand-may-be-writethe-db1m-option-byte-from-the-firmware-i-am-using-an-stmf4427ig-1mb-with-double-bank-via-db1m-option-byte) on the topic, at it seems that one have to reset the mcu for the change to take effect, so it does not make any sense to have it as runtime configurable.