### PR TITLE
Disable ppi group in BufferedUarte drop

### DIFF
--- a/embassy-nrf/src/buffered_uarte.rs
+++ b/embassy-nrf/src/buffered_uarte.rs
@@ -646,6 +646,8 @@ mod _embedded_io {
 
 impl<'a, U: UarteInstance, T: TimerInstance> Drop for BufferedUarte<'a, U, T> {
     fn drop(&mut self) {
+        self._ppi_group.disable_all();
+
         let r = U::regs();
 
         self.timer.stop();

--- a/embassy-nrf/src/timer.rs
+++ b/embassy-nrf/src/timer.rs
@@ -124,7 +124,7 @@ impl<'d, T: Instance> Timer<'d, T> {
         this.stop();
 
         if is_counter {
-            regs.mode.write(|w| w.mode().counter());
+            regs.mode.write(|w| w.mode().low_power_counter());
         } else {
             regs.mode.write(|w| w.mode().timer());
         }


### PR DESCRIPTION
Solve the issue where power consumption stays high after dropping BufferedUarte