### PR TITLE
Add [profile.release] debug = true to all examples

### DIFF
--- a/examples/.cargo/config.toml
+++ b/examples/.cargo/config.toml
@@ -1,0 +1,3 @@
+[profile.release]
+# Allows defmt to display log locations even in release
+debug = true


### PR DESCRIPTION
Currently release builds of the examples don't report the location of defmt log lines:

```
0.000000 DEBUG rcc: Clocks { sys: Hertz(8000000), apb1: Hertz(8000000), apb1_tim: Hertz(8000000), apb2: Hertz(8000000), apb2_tim: Hertz(8000000), ahb1: Hertz(8000000) }
└─ <invalid location: defmt frame-index: 13>
0.000030 INFO Hello World!
└─ <invalid location: defmt frame-index: 5>
```


With this change, they log their location just like in debug:

```
0.000000 DEBUG rcc: Clocks { sys: Hertz(8000000), apb1: Hertz(8000000), apb1_tim: Hertz(8000000), apb2: Hertz(8000000), apb2_tim: Hertz(8000000), ahb1: Hertz(8000000) }
└─ [snipped]\...\embassy-clone\embassy\embassy-stm32\src\fmt.rs:125
0.000030 INFO Hello World!
└─ src\bin\blinky.rs:14
```