### PR TITLE
sync/pipe: write all user data to pipe

### DIFF
--- a/embassy-sync/src/pipe.rs
+++ b/embassy-sync/src/pipe.rs
@@ -294,6 +294,16 @@ where
         WriteFuture { pipe: self, buf }
     }
 
+    /// Write all bytes to the pipe.
+    ///
+    /// This method writes all bytes from `buf` into the pipe
+    pub async fn write_all(&self, mut buf: &[u8]) {
+        while !buf.is_empty() {
+            let n = self.write(buf).await;
+            buf = &buf[n..];
+        }
+    }
+
     /// Attempt to immediately write some bytes to the pipe.
     ///
     /// This method will either write a nonzero amount of bytes to the pipe immediately,


### PR DESCRIPTION
Hello, old _try_write_with_context_ function only write minimum available size to pipe, some data will be lost from user.

It can workaround by user side base on return bytes from write(buf).await, but it's complex.

This patch will wait until all bytes are written to pipe.
