### PR TITLE
usb-logger: fix breakage in log 0.4.19

### DIFF
--- a/embassy-usb-logger/src/lib.rs
+++ b/embassy-usb-logger/src/lib.rs
@@ -138,7 +138,7 @@ macro_rules! run {
     ( $x:expr, $l:expr, $p:ident ) => {
         static LOGGER: ::embassy_usb_logger::UsbLogger<$x> = ::embassy_usb_logger::UsbLogger::new();
         unsafe {
-            let _ = ::log::set_logger_racy(&LOGGER).map(|()| log::set_max_level($l));
+            let _ = ::log::set_logger_racy(&LOGGER).map(|()| log::set_max_level_racy($l));
         }
         let _ = LOGGER.run(&mut ::embassy_usb_logger::LoggerState::new(), $p).await;
     };


### PR DESCRIPTION
https://github.com/rust-lang/log/issues/567