### PR TITLE
Add wifi_blinky.rs for easy beginners start.

### DIFF
--- a/examples/rp/src/bin/button.rs
+++ b/examples/rp/src/bin/button.rs
@@ -12,7 +12,7 @@ async fn main(_spawner: Spawner) {
     let mut led = Output::new(p.PIN_25, Level::Low);
 
     // Use PIN_28, Pin34 on J0 for RP Pico, as a input.
-    // You need to ad your own button.
+    // You need to add your own button.
     let button = Input::new(p.PIN_28, Pull::Up);
 
     loop {

--- a/examples/rp/src/bin/button.rs
+++ b/examples/rp/src/bin/button.rs
@@ -9,8 +9,11 @@ use {defmt_rtt as _, panic_probe as _};
 #[embassy_executor::main]
 async fn main(_spawner: Spawner) {
     let p = embassy_rp::init(Default::default());
-    let button = Input::new(p.PIN_28, Pull::Up);
     let mut led = Output::new(p.PIN_25, Level::Low);
+
+    // Use PIN_28, Pin34 on J0 for RP Pico, as a input.
+    // You need to ad your own button.
+    let button = Input::new(p.PIN_28, Pull::Up);
 
     loop {
         if button.is_high() {

--- a/examples/rp/src/bin/wifi_blinky.rs
+++ b/examples/rp/src/bin/wifi_blinky.rs
@@ -1,0 +1,59 @@
+#![no_std]
+#![no_main]
+#![feature(type_alias_impl_trait)]
+
+use cyw43_pio::PioSpi;
+use defmt::*;
+use embassy_executor::Spawner;
+use embassy_rp::gpio::{Level, Output};
+use embassy_rp::peripherals::{DMA_CH0, PIN_23, PIN_25, PIO0};
+use embassy_rp::pio::Pio;
+use embassy_time::{Duration, Timer};
+use static_cell::make_static;
+use {defmt_rtt as _, panic_probe as _};
+
+#[embassy_executor::task]
+async fn wifi_task(
+    runner: cyw43::Runner<'static, Output<'static, PIN_23>, PioSpi<'static, PIN_25, PIO0, 0, DMA_CH0>>,
+) -> ! {
+    runner.run().await
+}
+
+#[embassy_executor::main]
+async fn main(spawner: Spawner) {
+    let p = embassy_rp::init(Default::default());
+    let fw = include_bytes!("../../../../cyw43-firmware/43439A0.bin");
+    let clm = include_bytes!("../../../../cyw43-firmware/43439A0_clm.bin");
+
+    // To make flashing faster for development, you may want to flash the firmwares independently
+    // at hardcoded addresses, instead of baking them into the program with `include_bytes!`:
+    //     probe-rs-cli download 43439A0.bin --format bin --chip RP2040 --base-address 0x10100000
+    //     probe-rs-cli download 43439A0_clm.bin --format bin --chip RP2040 --base-address 0x10140000
+    //let fw = unsafe { core::slice::from_raw_parts(0x10100000 as *const u8, 224190) };
+    //let clm = unsafe { core::slice::from_raw_parts(0x10140000 as *const u8, 4752) };
+
+    let pwr = Output::new(p.PIN_23, Level::Low);
+    let cs = Output::new(p.PIN_25, Level::High);
+    let mut pio = Pio::new(p.PIO0);
+    let spi = PioSpi::new(&mut pio.common, pio.sm0, pio.irq0, cs, p.PIN_24, p.PIN_29, p.DMA_CH0);
+
+    let state = make_static!(cyw43::State::new());
+    let (_net_device, mut control, runner) = cyw43::new(state, pwr, spi, fw).await;
+    unwrap!(spawner.spawn(wifi_task(runner)));
+ 
+    control.init(clm).await;
+    control
+        .set_power_management(cyw43::PowerManagementMode::PowerSave)
+        .await;
+
+    let delay = Duration::from_secs(1);
+    loop {
+        info!("led on!");
+        control.gpio_set(0, true).await;
+        Timer::after(delay).await;
+
+        info!("led off!");
+        control.gpio_set(0, false).await;
+        Timer::after(delay).await;
+    }
+}

--- a/examples/rp/src/bin/wifi_blinky.rs
+++ b/examples/rp/src/bin/wifi_blinky.rs
@@ -40,7 +40,7 @@ async fn main(spawner: Spawner) {
     let state = make_static!(cyw43::State::new());
     let (_net_device, mut control, runner) = cyw43::new(state, pwr, spi, fw).await;
     unwrap!(spawner.spawn(wifi_task(runner)));
- 
+
     control.init(clm).await;
     control
         .set_power_management(cyw43::PowerManagementMode::PowerSave)


### PR DESCRIPTION
I got a RP Pico W and wanted to verify it's function. The only easy output is a LED, but it has moved from the standard PR Pico. I also spent some time to discover how the button was connected, only to find that button.rs use a normal GPIO.

- Add rp/src/bin/wifi_blinky.rs for easy beginners start.
- Document external button.in rp/src/bin/button.rs.

