### PR TITLE
Feature/stm32g4 pll enhancements - Add PLL support for the P and Q outputs for G4 series chips

### DIFF
--- a/examples/stm32g4/Cargo.toml
+++ b/examples/stm32g4/Cargo.toml
@@ -10,6 +10,7 @@ embassy-executor = { version = "0.2.0", path = "../../embassy-executor", feature
 embassy-time = { version = "0.1.0", path = "../../embassy-time", features = ["defmt", "defmt-timestamp-uptime", "tick-hz-32_768"] }
 embassy-stm32 = { version = "0.1.0", path = "../../embassy-stm32", features = ["nightly", "defmt", "time-driver-any", "stm32g491re", "memory-x", "unstable-pac", "exti"]  }
 embassy-hal-common = {version = "0.1.0", path = "../../embassy-hal-common" }
+embassy-usb = { version = "0.1.0", path = "../../embassy-usb", features = ["defmt"] }
 
 defmt = "0.3"
 defmt-rtt = "0.4"

--- a/examples/stm32g4/src/bin/pll.rs
+++ b/examples/stm32g4/src/bin/pll.rs
@@ -4,7 +4,7 @@
 
 use defmt::*;
 use embassy_executor::Spawner;
-use embassy_stm32::rcc::{ClockSrc, PllM, PllN, PllR, PllSrc};
+use embassy_stm32::rcc::{ClockSrc, Pll, PllM, PllN, PllR, PllSrc};
 use embassy_stm32::Config;
 use embassy_time::{Duration, Timer};
 use {defmt_rtt as _, panic_probe as _};
@@ -13,8 +13,17 @@ use {defmt_rtt as _, panic_probe as _};
 async fn main(_spawner: Spawner) {
     let mut config = Config::default();
 
-    // Configure PLL to max frequency of 170 MHz
-    config.rcc.mux = ClockSrc::PLLCLK(PllSrc::HSI16, PllM::Div4, PllN::Mul85, PllR::Div2);
+    config.rcc.pll = Some(Pll {
+        source: PllSrc::HSI16,
+        prediv_m: PllM::Div4,
+        mul_n: PllN::Mul85,
+        div_p: None,
+        div_q: None,
+        // Main system clock at 170 MHz
+        div_r: Some(PllR::Div2),
+    });
+
+    config.rcc.mux = ClockSrc::PLL;
 
     let _p = embassy_stm32::init(config);
     info!("Hello World!");

--- a/examples/stm32g4/src/bin/usb_serial.rs
+++ b/examples/stm32g4/src/bin/usb_serial.rs
@@ -1,0 +1,110 @@
+#![no_std]
+#![no_main]
+#![feature(type_alias_impl_trait)]
+
+use defmt::{panic, *};
+use embassy_executor::Spawner;
+use embassy_stm32::rcc::{ClockSrc, Pll, PllM, PllN, PllQ, PllR, PllSrc};
+use embassy_stm32::time::Hertz;
+use embassy_stm32::usb::{self, Driver, Instance};
+use embassy_stm32::{bind_interrupts, pac, peripherals, Config};
+use embassy_usb::class::cdc_acm::{CdcAcmClass, State};
+use embassy_usb::driver::EndpointError;
+use embassy_usb::Builder;
+use futures::future::join;
+use {defmt_rtt as _, panic_probe as _};
+
+bind_interrupts!(struct Irqs {
+    USB_LP => usb::InterruptHandler<peripherals::USB>;
+});
+
+#[embassy_executor::main]
+async fn main(_spawner: Spawner) {
+    let mut config = Config::default();
+
+    config.rcc.pll = Some(Pll {
+        source: PllSrc::HSE(Hertz(8000000)),
+        prediv_m: PllM::Div2,
+        mul_n: PllN::Mul72,
+        div_p: None,
+        // USB and CAN at 48 MHz
+        div_q: Some(PllQ::Div6),
+        // Main system clock at 144 MHz
+        div_r: Some(PllR::Div2),
+    });
+
+    config.rcc.mux = ClockSrc::PLL;
+
+    let p = embassy_stm32::init(config);
+    info!("Hello World!");
+
+    unsafe {
+        pac::RCC.ccipr().write(|w| w.set_clk48sel(0b10));
+    }
+
+    let driver = Driver::new(p.USB, Irqs, p.PA12, p.PA11);
+
+    let mut config = embassy_usb::Config::new(0xc0de, 0xcafe);
+    config.manufacturer = Some("Embassy");
+    config.product = Some("USB-Serial Example");
+    config.serial_number = Some("123456");
+
+    config.device_class = 0xEF;
+    config.device_sub_class = 0x02;
+    config.device_protocol = 0x01;
+    config.composite_with_iads = true;
+
+    let mut device_descriptor = [0; 256];
+    let mut config_descriptor = [0; 256];
+    let mut bos_descriptor = [0; 256];
+    let mut control_buf = [0; 64];
+
+    let mut state = State::new();
+
+    let mut builder = Builder::new(
+        driver,
+        config,
+        &mut device_descriptor,
+        &mut config_descriptor,
+        &mut bos_descriptor,
+        &mut control_buf,
+    );
+
+    let mut class = CdcAcmClass::new(&mut builder, &mut state, 64);
+
+    let mut usb = builder.build();
+
+    let usb_fut = usb.run();
+
+    let echo_fut = async {
+        loop {
+            class.wait_connection().await;
+            info!("Connected");
+            let _ = echo(&mut class).await;
+            info!("Disconnected");
+        }
+    };
+
+    join(usb_fut, echo_fut).await;
+}
+
+struct Disconnected {}
+
+impl From<EndpointError> for Disconnected {
+    fn from(val: EndpointError) -> Self {
+        match val {
+            EndpointError::BufferOverflow => panic!("Buffer overflow"),
+            EndpointError::Disabled => Disconnected {},
+        }
+    }
+}
+
+async fn echo<'d, T: Instance + 'd>(class: &mut CdcAcmClass<'d, Driver<'d, T>>) -> Result<(), Disconnected> {
+    let mut buf = [0; 64];
+    loop {
+        let n = class.read_packet(&mut buf).await?;
+        let data = &buf[..n];
+        info!("data: {:x}", data);
+        class.write_packet(data).await?;
+    }
+}


### PR DESCRIPTION
This PR adds onto https://github.com/embassy-rs/embassy/pull/1532 and I believe it completes https://github.com/embassy-rs/embassy/issues/1198 by supporting the rest of the PLL functionality. 

This also adds a USB Serial example for the G4 that uses the other PLL output to ensure it is working correctly. 

This has been tested on a custom STM32G473 board that I have.

@cstlaurent I made a few tweaks to the API you had created to add the other output configurations here. These changes align much closer with the API used for the H5 PLL config.