### PR TITLE
Ensure idle & ove flags are cleared in BufferedUart ISR on STM32

### DIFF
--- a/embassy-stm32/src/usart/buffered.rs
+++ b/embassy-stm32/src/usart/buffered.rs
@@ -48,7 +48,8 @@ impl<T: BasicInstance> interrupt::typelevel::Handler<T::Interrupt> for Interrupt
                 if !buf.is_empty() {
                     buf[0] = dr.unwrap();
                     rx_writer.push_done(1);
-                } else {
+                }
+                else {
                     // FIXME: Should we disable any further RX interrupts when the buffer becomes full.
                 }
 

--- a/embassy-stm32/src/usart/buffered.rs
+++ b/embassy-stm32/src/usart/buffered.rs
@@ -21,8 +21,10 @@ impl<T: BasicInstance> interrupt::typelevel::Handler<T::Interrupt> for Interrupt
         // RX
         unsafe {
             let sr = sr(r).read();
-            // Reading DR clears the rxne, error and idle interrupt flags on v1.
-            let dr = if sr.ore() || sr.idle() || sr.rxne() {
+            // On v1 & v2, reading DR clears the rxne, error and idle interrupt
+            // flags. Keep this close to the SR read to reduce the chance of a
+            // flag being set in-between.
+            let dr = if sr.rxne() || cfg!(any(usart_v1, usart_v2)) && (sr.ore() || sr.idle()) {
                 Some(rdr(r).read_volatile())
             } else {
                 None

--- a/embassy-stm32/src/usart/buffered.rs
+++ b/embassy-stm32/src/usart/buffered.rs
@@ -24,8 +24,7 @@ impl<T: BasicInstance> interrupt::typelevel::Handler<T::Interrupt> for Interrupt
             // Reading DR clears the rxne, error and idle interrupt flags on v1.
             let dr = if sr.ore() || sr.idle() || sr.rxne() {
                 Some(rdr(r).read_volatile())
-            }
-            else {
+            } else {
                 None
             };
             clear_interrupt_flags(r, sr);
@@ -48,8 +47,7 @@ impl<T: BasicInstance> interrupt::typelevel::Handler<T::Interrupt> for Interrupt
                 if !buf.is_empty() {
                     buf[0] = dr.unwrap();
                     rx_writer.push_done(1);
-                }
-                else {
+                } else {
                     // FIXME: Should we disable any further RX interrupts when the buffer becomes full.
                 }
 


### PR DESCRIPTION
This fixes the main issue in #1556 on STM32F4 where the interrupt flags are not always cleared, leading to a continuous ISR loop. It does not address the potential race conditions:

1. The overflow interrupt can occur independently of RXNE, however on v1 we need to read DR to clear the OVE flag. A character could arrive after checking SR, but before reading DR to clear OVE. There is no way of disabling OVE without also disabling RXNE as they are both controlled by RXNEIE. 
2. The idle interrupt has a similar issue, although it can be disabled independently by IDLEIE. This allows us to disable the interrupt until the next character is received, which gets around the race condition, however in my testing this lead to worse performance in the typical use case (more overflows when receiving data) possibly due to the longer ISR

These race conditions only happen when you're already servicing the interrupt too slowly. I think by placing the SR & DR reads as close together as possible, we're mitigating the issue as much as possible on the F4.

I'm happy to keep working on this though if you disagree, or if there are other ideas.

I've also only tested this on the F4. Does this introduce race conditions on other STM32 chips?