### PR TITLE
stm32/uart: clear idle flag on interrupt

### DIFF
--- a/embassy-stm32/src/usart/buffered.rs
+++ b/embassy-stm32/src/usart/buffered.rs
@@ -53,6 +53,8 @@ impl<T: BasicInstance> interrupt::typelevel::Handler<T::Interrupt> for Interrupt
             }
 
             if sr.idle() {
+                // This read also clears the error and idle interrupt flags on v1.
+                rdr(r).read_volatile();
                 state.rx_waker.wake();
             };
         }


### PR DESCRIPTION
Idle interrupt flag in `usart::buffered` need clear.