### PR TITLE
BDMA: request stop after busy loop in blocking_wait()

### DIFF
--- a/embassy-stm32/src/dma/bdma.rs
+++ b/embassy-stm32/src/dma/bdma.rs
@@ -327,6 +327,7 @@ impl<'a, C: Channel> Transfer<'a, C> {
 
     pub fn blocking_wait(mut self) {
         while self.is_running() {}
+        self.request_stop();
 
         // "Subsequent reads and writes cannot be moved ahead of preceding reads."
         fence(Ordering::SeqCst);


### PR DESCRIPTION
Otherwise the channel cannot be used again, since CR.EN remains set and the DMA channel registers are read-only while it is set.