### PR TITLE
Prevent bootloader revert and add missing examples to CI

### DIFF
--- a/ci.sh
+++ b/ci.sh
@@ -133,16 +133,16 @@ cargo batch  \
     --- build --release --manifest-path examples/stm32u5/Cargo.toml --target thumbv8m.main-none-eabihf --out-dir out/examples/stm32u5 \
     --- build --release --manifest-path examples/stm32wb/Cargo.toml --target thumbv7em-none-eabihf --out-dir out/examples/stm32wb \
     --- build --release --manifest-path examples/stm32wl/Cargo.toml --target thumbv7em-none-eabihf --out-dir out/examples/stm32wl \
-    --- build --release --manifest-path examples/boot/application/nrf/Cargo.toml --target thumbv7em-none-eabi --features embassy-nrf/nrf52840 --out-dir out/examples/boot/nrf --bin b \
-    --- build --release --manifest-path examples/boot/application/nrf/Cargo.toml --target thumbv8m.main-none-eabihf --features embassy-nrf/nrf9160-ns --out-dir out/examples/boot/nrf --bin b \
-    --- build --release --manifest-path examples/boot/application/rp/Cargo.toml --target thumbv6m-none-eabi --out-dir out/examples/boot/rp --bin b \
-    --- build --release --manifest-path examples/boot/application/stm32f3/Cargo.toml --target thumbv7em-none-eabi --out-dir out/examples/boot/stm32f3 --bin b \
-    --- build --release --manifest-path examples/boot/application/stm32f7/Cargo.toml --target thumbv7em-none-eabi --out-dir out/examples/boot/stm32f7 --bin b \
-    --- build --release --manifest-path examples/boot/application/stm32h7/Cargo.toml --target thumbv7em-none-eabi --out-dir out/examples/boot/stm32h7 --bin b \
-    --- build --release --manifest-path examples/boot/application/stm32l0/Cargo.toml --target thumbv6m-none-eabi --out-dir out/examples/boot/stm32l0 --bin b \
-    --- build --release --manifest-path examples/boot/application/stm32l1/Cargo.toml --target thumbv7m-none-eabi --out-dir out/examples/boot/stm32l1 --bin b \
-    --- build --release --manifest-path examples/boot/application/stm32l4/Cargo.toml --target thumbv7em-none-eabi --out-dir out/examples/boot/stm32l4 --bin b \
-    --- build --release --manifest-path examples/boot/application/stm32wl/Cargo.toml --target thumbv7em-none-eabihf --out-dir out/examples/boot/stm32wl --bin b \
+    --- build --release --manifest-path examples/boot/application/nrf/Cargo.toml --target thumbv7em-none-eabi --features embassy-nrf/nrf52840,skip-include --out-dir out/examples/boot/nrf  \
+    --- build --release --manifest-path examples/boot/application/nrf/Cargo.toml --target thumbv8m.main-none-eabihf --features embassy-nrf/nrf9160-ns,skip-include --out-dir out/examples/boot/nrf \
+    --- build --release --manifest-path examples/boot/application/rp/Cargo.toml --target thumbv6m-none-eabi --features skip-include --out-dir out/examples/boot/rp \
+    --- build --release --manifest-path examples/boot/application/stm32f3/Cargo.toml --target thumbv7em-none-eabi --features skip-include --out-dir out/examples/boot/stm32f3 \
+    --- build --release --manifest-path examples/boot/application/stm32f7/Cargo.toml --target thumbv7em-none-eabi --features skip-include --out-dir out/examples/boot/stm32f7 \
+    --- build --release --manifest-path examples/boot/application/stm32h7/Cargo.toml --target thumbv7em-none-eabi --features skip-include --out-dir out/examples/boot/stm32h7 \
+    --- build --release --manifest-path examples/boot/application/stm32l0/Cargo.toml --target thumbv6m-none-eabi --features skip-include --out-dir out/examples/boot/stm32l0 \
+    --- build --release --manifest-path examples/boot/application/stm32l1/Cargo.toml --target thumbv7m-none-eabi --features skip-include --out-dir out/examples/boot/stm32l1 \
+    --- build --release --manifest-path examples/boot/application/stm32l4/Cargo.toml --target thumbv7em-none-eabi --features skip-include --out-dir out/examples/boot/stm32l4 \
+    --- build --release --manifest-path examples/boot/application/stm32wl/Cargo.toml --target thumbv7em-none-eabihf --features skip-include --out-dir out/examples/boot/stm32wl \
     --- build --release --manifest-path examples/boot/bootloader/nrf/Cargo.toml --target thumbv7em-none-eabi --features embassy-nrf/nrf52840 \
     --- build --release --manifest-path examples/boot/bootloader/nrf/Cargo.toml --target thumbv8m.main-none-eabihf --features embassy-nrf/nrf9160-ns \
     --- build --release --manifest-path examples/boot/bootloader/rp/Cargo.toml --target thumbv6m-none-eabi \

--- a/embassy-boot/boot/src/firmware_updater/mod.rs
+++ b/embassy-boot/boot/src/firmware_updater/mod.rs
@@ -26,6 +26,8 @@ pub enum FirmwareUpdaterError {
     Flash(NorFlashErrorKind),
     /// Signature errors.
     Signature(signature::Error),
+    /// Bad state.
+    BadState,
 }
 
 #[cfg(feature = "defmt")]
@@ -34,6 +36,7 @@ impl defmt::Format for FirmwareUpdaterError {
         match self {
             FirmwareUpdaterError::Flash(_) => defmt::write!(fmt, "FirmwareUpdaterError::Flash(_)"),
             FirmwareUpdaterError::Signature(_) => defmt::write!(fmt, "FirmwareUpdaterError::Signature(_)"),
+            FirmwareUpdaterError::BadState => defmt::write!(fmt, "FirmwareUpdaterError::BadState"),
         }
     }
 }

--- a/examples/boot/application/nrf/Cargo.toml
+++ b/examples/boot/application/nrf/Cargo.toml
@@ -24,3 +24,4 @@ cortex-m-rt = "0.7.0"
 [features]
 ed25519-dalek = ["embassy-boot/ed25519-dalek"]
 ed25519-salty = ["embassy-boot/ed25519-salty"]
+skip-include = []

--- a/examples/boot/application/rp/Cargo.toml
+++ b/examples/boot/application/rp/Cargo.toml
@@ -29,6 +29,7 @@ debug = [
     "embassy-boot-rp/defmt",
     "panic-probe"
 ]
+skip-include = []
 
 [profile.release]
 debug = true

--- a/examples/boot/application/rp/src/bin/a.rs
+++ b/examples/boot/application/rp/src/bin/a.rs
@@ -18,7 +18,11 @@ use panic_probe as _;
 #[cfg(feature = "panic-reset")]
 use panic_reset as _;
 
+#[cfg(feature = "skip-include")]
+static APP_B: &[u8] = &[0, 1, 2, 3];
+#[cfg(not(feature = "skip-include"))]
 static APP_B: &[u8] = include_bytes!("../../b.bin");
+
 const FLASH_SIZE: usize = 2 * 1024 * 1024;
 
 #[embassy_executor::main]
@@ -43,7 +47,7 @@ async fn main(_s: Spawner) {
     let mut buf: AlignedBuffer<4096> = AlignedBuffer([0; 4096]);
     defmt::info!("preparing update");
     let writer = updater
-        .prepare_update()
+        .prepare_update(&mut buf.0[..1])
         .map_err(|e| defmt::warn!("E: {:?}", defmt::Debug2Format(&e)))
         .unwrap();
     defmt::info!("writer created, starting write");

--- a/examples/boot/application/stm32f3/Cargo.toml
+++ b/examples/boot/application/stm32f3/Cargo.toml
@@ -26,3 +26,4 @@ defmt = [
       "embassy-stm32/defmt",
       "embassy-boot-stm32/defmt",
 ]
+skip-include = []

--- a/examples/boot/application/stm32f7/Cargo.toml
+++ b/examples/boot/application/stm32f7/Cargo.toml
@@ -16,6 +16,7 @@ defmt = { version = "0.3", optional = true }
 defmt-rtt = { version = "0.4", optional = true }
 panic-reset = { version = "0.1.1" }
 embedded-hal = { version = "0.2.6" }
+embedded-storage = "0.3.0"
 
 cortex-m = { version = "0.7.6", features = ["inline-asm", "critical-section-single-core"] }
 cortex-m-rt = "0.7.0"
@@ -26,3 +27,4 @@ defmt = [
       "embassy-stm32/defmt",
       "embassy-boot-stm32/defmt",
 ]
+skip-include = []

--- a/examples/boot/application/stm32f7/src/bin/a.rs
+++ b/examples/boot/application/stm32f7/src/bin/a.rs
@@ -2,6 +2,8 @@
 #![no_main]
 #![feature(type_alias_impl_trait)]
 
+use core::cell::RefCell;
+
 #[cfg(feature = "defmt-rtt")]
 use defmt_rtt::*;
 use embassy_boot_stm32::{AlignedBuffer, BlockingFirmwareUpdater, FirmwareUpdaterConfig};
@@ -9,8 +11,13 @@ use embassy_executor::Spawner;
 use embassy_stm32::exti::ExtiInput;
 use embassy_stm32::flash::{Flash, WRITE_SIZE};
 use embassy_stm32::gpio::{Input, Level, Output, Pull, Speed};
+use embassy_sync::blocking_mutex::Mutex;
+use embedded_storage::nor_flash::NorFlash;
 use panic_reset as _;
 
+#[cfg(feature = "skip-include")]
+static APP_B: &[u8] = &[0, 1, 2, 3];
+#[cfg(not(feature = "skip-include"))]
 static APP_B: &[u8] = include_bytes!("../../b.bin");
 
 #[embassy_executor::main]
@@ -27,16 +34,16 @@ async fn main(_spawner: Spawner) {
 
     let config = FirmwareUpdaterConfig::from_linkerfile_blocking(&flash);
     let mut updater = BlockingFirmwareUpdater::new(config);
-    let mut writer = updater.prepare_update().unwrap();
+    let mut magic = AlignedBuffer([0; WRITE_SIZE]);
+    let writer = updater.prepare_update(magic.as_mut()).unwrap();
     button.wait_for_rising_edge().await;
     let mut offset = 0;
     let mut buf = AlignedBuffer([0; 4096]);
     for chunk in APP_B.chunks(4096) {
         buf.as_mut()[..chunk.len()].copy_from_slice(chunk);
         writer.write(offset, buf.as_ref()).unwrap();
-        offset += chunk.len();
+        offset += chunk.len() as u32;
     }
-    let mut magic = AlignedBuffer([0; WRITE_SIZE]);
     updater.mark_updated(magic.as_mut()).unwrap();
     led.set_low();
     cortex_m::peripheral::SCB::sys_reset();

--- a/examples/boot/application/stm32h7/Cargo.toml
+++ b/examples/boot/application/stm32h7/Cargo.toml
@@ -16,6 +16,7 @@ defmt = { version = "0.3", optional = true }
 defmt-rtt = { version = "0.4", optional = true }
 panic-reset = { version = "0.1.1" }
 embedded-hal = { version = "0.2.6" }
+embedded-storage = "0.3.0"
 
 cortex-m = { version = "0.7.6", features = ["inline-asm", "critical-section-single-core"] }
 cortex-m-rt = "0.7.0"
@@ -26,3 +27,4 @@ defmt = [
       "embassy-stm32/defmt",
       "embassy-boot-stm32/defmt",
 ]
+skip-include = []

--- a/examples/boot/application/stm32h7/src/bin/a.rs
+++ b/examples/boot/application/stm32h7/src/bin/a.rs
@@ -2,6 +2,8 @@
 #![no_main]
 #![feature(type_alias_impl_trait)]
 
+use core::cell::RefCell;
+
 #[cfg(feature = "defmt-rtt")]
 use defmt_rtt::*;
 use embassy_boot_stm32::{AlignedBuffer, BlockingFirmwareUpdater, FirmwareUpdaterConfig};
@@ -9,8 +11,13 @@ use embassy_executor::Spawner;
 use embassy_stm32::exti::ExtiInput;
 use embassy_stm32::flash::{Flash, WRITE_SIZE};
 use embassy_stm32::gpio::{Input, Level, Output, Pull, Speed};
+use embassy_sync::blocking_mutex::Mutex;
+use embedded_storage::nor_flash::NorFlash;
 use panic_reset as _;
 
+#[cfg(feature = "skip-include")]
+static APP_B: &[u8] = &[0, 1, 2, 3];
+#[cfg(not(feature = "skip-include"))]
 static APP_B: &[u8] = include_bytes!("../../b.bin");
 
 #[embassy_executor::main]
@@ -26,17 +33,17 @@ async fn main(_spawner: Spawner) {
     led.set_high();
 
     let config = FirmwareUpdaterConfig::from_linkerfile_blocking(&flash);
+    let mut magic = AlignedBuffer([0; WRITE_SIZE]);
     let mut updater = BlockingFirmwareUpdater::new(config);
-    let mut writer = updater.prepare_update().unwrap();
+    let writer = updater.prepare_update(magic.as_mut()).unwrap();
     button.wait_for_rising_edge().await;
     let mut offset = 0;
     let mut buf = AlignedBuffer([0; 4096]);
     for chunk in APP_B.chunks(4096) {
         buf.as_mut()[..chunk.len()].copy_from_slice(chunk);
         writer.write(offset, buf.as_ref()).unwrap();
-        offset += chunk.len();
+        offset += chunk.len() as u32;
     }
-    let mut magic = AlignedBuffer([0; WRITE_SIZE]);
     updater.mark_updated(magic.as_mut()).unwrap();
     led.set_low();
     cortex_m::peripheral::SCB::sys_reset();

--- a/examples/boot/application/stm32l0/Cargo.toml
+++ b/examples/boot/application/stm32l0/Cargo.toml
@@ -26,3 +26,4 @@ defmt = [
       "embassy-stm32/defmt",
       "embassy-boot-stm32/defmt",
 ]
+skip-include = []

--- a/examples/boot/application/stm32l0/src/bin/a.rs
+++ b/examples/boot/application/stm32l0/src/bin/a.rs
@@ -4,22 +4,26 @@
 
 #[cfg(feature = "defmt-rtt")]
 use defmt_rtt::*;
-use embassy_boot_stm32::{AlignedBuffer, FirmwareUpdater};
+use embassy_boot_stm32::{AlignedBuffer, FirmwareUpdater, FirmwareUpdaterConfig};
 use embassy_embedded_hal::adapter::BlockingAsync;
 use embassy_executor::Spawner;
 use embassy_stm32::exti::ExtiInput;
 use embassy_stm32::flash::{Flash, WRITE_SIZE};
 use embassy_stm32::gpio::{Input, Level, Output, Pull, Speed};
+use embassy_sync::mutex::Mutex;
 use embassy_time::{Duration, Timer};
 use panic_reset as _;
 
+#[cfg(feature = "skip-include")]
+static APP_B: &[u8] = &[0, 1, 2, 3];
+#[cfg(not(feature = "skip-include"))]
 static APP_B: &[u8] = include_bytes!("../../b.bin");
 
 #[embassy_executor::main]
 async fn main(_spawner: Spawner) {
     let p = embassy_stm32::init(Default::default());
     let flash = Flash::new_blocking(p.FLASH);
-    let mut flash = BlockingAsync::new(flash);
+    let flash = Mutex::new(BlockingAsync::new(flash));
 
     let button = Input::new(p.PB2, Pull::Up);
     let mut button = ExtiInput::new(button, p.EXTI2);
@@ -28,18 +32,19 @@ async fn main(_spawner: Spawner) {
 
     led.set_high();
 
-    let mut updater = FirmwareUpdater::default();
+    let config = FirmwareUpdaterConfig::from_linkerfile(&flash);
+    let mut updater = FirmwareUpdater::new(config);
     button.wait_for_falling_edge().await;
     let mut offset = 0;
+    let mut magic = AlignedBuffer([0; WRITE_SIZE]);
     for chunk in APP_B.chunks(128) {
         let mut buf: [u8; 128] = [0; 128];
         buf[..chunk.len()].copy_from_slice(chunk);
-        updater.write_firmware(offset, &buf, &mut flash, 128).await.unwrap();
+        updater.write_firmware(magic.as_mut(), offset, &buf).await.unwrap();
         offset += chunk.len();
     }
 
-    let mut magic = AlignedBuffer([0; WRITE_SIZE]);
-    updater.mark_updated(&mut flash, magic.as_mut()).await.unwrap();
+    updater.mark_updated(magic.as_mut()).await.unwrap();
     led.set_low();
     Timer::after(Duration::from_secs(1)).await;
     cortex_m::peripheral::SCB::sys_reset();

--- a/examples/boot/application/stm32l1/Cargo.toml
+++ b/examples/boot/application/stm32l1/Cargo.toml
@@ -26,3 +26,4 @@ defmt = [
       "embassy-stm32/defmt",
       "embassy-boot-stm32/defmt",
 ]
+skip-include = []

--- a/examples/boot/application/stm32l4/Cargo.toml
+++ b/examples/boot/application/stm32l4/Cargo.toml
@@ -26,3 +26,4 @@ defmt = [
       "embassy-stm32/defmt",
       "embassy-boot-stm32/defmt",
 ]
+skip-include = []

--- a/examples/boot/application/stm32l4/src/bin/a.rs
+++ b/examples/boot/application/stm32l4/src/bin/a.rs
@@ -10,8 +10,12 @@ use embassy_executor::Spawner;
 use embassy_stm32::exti::ExtiInput;
 use embassy_stm32::flash::{Flash, WRITE_SIZE};
 use embassy_stm32::gpio::{Input, Level, Output, Pull, Speed};
+use embassy_sync::mutex::Mutex;
 use panic_reset as _;
 
+#[cfg(feature = "skip-include")]
+static APP_B: &[u8] = &[0, 1, 2, 3];
+#[cfg(not(feature = "skip-include"))]
 static APP_B: &[u8] = include_bytes!("../../b.bin");
 
 #[embassy_executor::main]
@@ -29,15 +33,15 @@ async fn main(_spawner: Spawner) {
     let config = FirmwareUpdaterConfig::from_linkerfile(&flash);
     let mut updater = FirmwareUpdater::new(config);
     button.wait_for_falling_edge().await;
+    let mut magic = AlignedBuffer([0; WRITE_SIZE]);
     let mut offset = 0;
     for chunk in APP_B.chunks(2048) {
         let mut buf: [u8; 2048] = [0; 2048];
         buf[..chunk.len()].copy_from_slice(chunk);
-        updater.write_firmware(offset, &buf).await.unwrap();
+        updater.write_firmware(magic.as_mut(), offset, &buf).await.unwrap();
         offset += chunk.len();
     }
-    let mut magic = AlignedBuffer([0; WRITE_SIZE]);
-    updater.mark_updated(&mut flash, magic.as_mut()).await.unwrap();
+    updater.mark_updated(magic.as_mut()).await.unwrap();
     led.set_low();
     cortex_m::peripheral::SCB::sys_reset();
 }

--- a/examples/boot/application/stm32wl/Cargo.toml
+++ b/examples/boot/application/stm32wl/Cargo.toml
@@ -26,3 +26,4 @@ defmt = [
       "embassy-stm32/defmt",
       "embassy-boot-stm32/defmt",
 ]
+skip-include = []


### PR DESCRIPTION
Prevent accidental revert when using firmware updater
    
    This change prevents accidentally overwriting the previous firmware before
    the new one has been marked as booted.

Add firmware updater examples to CI
    
    CI was not building the a.rs application due to the requirement of b.bin
    having been built first. Add a feature flag to examples so that CI can
    build them including a dummy application.
    
    Update a.rs application examples so that they compile again.


I was tempted to give a go at adding the magic buffer to FirmwareUpdater type but decided against it for now and will probably raise a separate PR for that.
