### PR TITLE
Allow arbitrary expressions as `task(pool_size)`

### DIFF
--- a/embassy-macros/Cargo.toml
+++ b/embassy-macros/Cargo.toml
@@ -12,9 +12,9 @@ categories = [
 ]
 
 [dependencies]
-syn = { version = "1.0.76", features = ["full", "extra-traits"] }
+syn = { version = "2.0.15", features = ["full", "extra-traits"] }
 quote = "1.0.9"
-darling = "0.13.0"
+darling = "0.20.1"
 proc-macro2 = "1.0.29"
 
 [lib]

--- a/embassy-macros/src/macros/main.rs
+++ b/embassy-macros/src/macros/main.rs
@@ -1,3 +1,4 @@
+use darling::export::NestedMeta;
 use darling::FromMeta;
 use proc_macro2::TokenStream;
 use quote::quote;
@@ -11,8 +12,8 @@ struct Args {
     entry: Option<String>,
 }
 
-pub fn riscv(args: syn::AttributeArgs) -> TokenStream {
-    let maybe_entry = match Args::from_list(&args) {
+pub fn riscv(args: &[NestedMeta]) -> TokenStream {
+    let maybe_entry = match Args::from_list(args) {
         Ok(args) => args.entry,
         Err(e) => return e.write_errors(),
     };
@@ -77,9 +78,9 @@ pub fn std() -> TokenStream {
     }
 }
 
-pub fn run(args: syn::AttributeArgs, f: syn::ItemFn, main: TokenStream) -> Result<TokenStream, TokenStream> {
+pub fn run(args: &[NestedMeta], f: syn::ItemFn, main: TokenStream) -> Result<TokenStream, TokenStream> {
     #[allow(unused_variables)]
-    let args = Args::from_list(&args).map_err(|e| e.write_errors())?;
+    let args = Args::from_list(args).map_err(|e| e.write_errors())?;
 
     let fargs = f.sig.inputs.clone();
 

--- a/embassy-macros/src/macros/task.rs
+++ b/embassy-macros/src/macros/task.rs
@@ -1,3 +1,4 @@
+use darling::export::NestedMeta;
 use darling::FromMeta;
 use proc_macro2::TokenStream;
 use quote::{format_ident, quote};
@@ -11,8 +12,8 @@ struct Args {
     pool_size: Option<usize>,
 }
 
-pub fn run(args: syn::AttributeArgs, f: syn::ItemFn) -> Result<TokenStream, TokenStream> {
-    let args = Args::from_list(&args).map_err(|e| e.write_errors())?;
+pub fn run(args: &[NestedMeta], f: syn::ItemFn) -> Result<TokenStream, TokenStream> {
+    let args = Args::from_list(args).map_err(|e| e.write_errors())?;
 
     let pool_size: usize = args.pool_size.unwrap_or(1);
 

--- a/embassy-macros/src/macros/task.rs
+++ b/embassy-macros/src/macros/task.rs
@@ -1,21 +1,24 @@
 use darling::export::NestedMeta;
 use darling::FromMeta;
-use proc_macro2::TokenStream;
+use proc_macro2::{Span, TokenStream};
 use quote::{format_ident, quote};
-use syn::{parse_quote, ItemFn, ReturnType, Type};
+use syn::{parse_quote, Expr, ExprLit, ItemFn, Lit, LitInt, ReturnType, Type};
 
 use crate::util::ctxt::Ctxt;
 
 #[derive(Debug, FromMeta)]
 struct Args {
     #[darling(default)]
-    pool_size: Option<usize>,
+    pool_size: Option<syn::Expr>,
 }
 
 pub fn run(args: &[NestedMeta], f: syn::ItemFn) -> Result<TokenStream, TokenStream> {
     let args = Args::from_list(args).map_err(|e| e.write_errors())?;
 
-    let pool_size: usize = args.pool_size.unwrap_or(1);
+    let pool_size = args.pool_size.unwrap_or(Expr::Lit(ExprLit {
+        attrs: vec![],
+        lit: Lit::Int(LitInt::new("1", Span::call_site())),
+    }));
 
     let ctxt = Ctxt::new();
 
@@ -44,10 +47,6 @@ pub fn run(args: &[NestedMeta], f: syn::ItemFn) -> Result<TokenStream, TokenStre
                 "task functions must either not return a value, return `()` or return `!`",
             ),
         },
-    }
-
-    if pool_size < 1 {
-        ctxt.error_spanned_by(&f.sig, "pool_size must be 1 or greater");
     }
 
     let mut arg_names = Vec::new();
@@ -83,7 +82,8 @@ pub fn run(args: &[NestedMeta], f: syn::ItemFn) -> Result<TokenStream, TokenStre
     let mut task_outer: ItemFn = parse_quote! {
         #visibility fn #task_ident(#fargs) -> ::embassy_executor::SpawnToken<impl Sized> {
             type Fut = impl ::core::future::Future + 'static;
-            static POOL: ::embassy_executor::raw::TaskPool<Fut, #pool_size> = ::embassy_executor::raw::TaskPool::new();
+            const POOL_SIZE: usize = #pool_size;
+            static POOL: ::embassy_executor::raw::TaskPool<Fut, POOL_SIZE> = ::embassy_executor::raw::TaskPool::new();
             unsafe { POOL._spawn_async_fn(move || #task_inner_ident(#(#arg_names,)*)) }
         }
     };

--- a/examples/nrf52840/src/bin/self_spawn.rs
+++ b/examples/nrf52840/src/bin/self_spawn.rs
@@ -7,7 +7,11 @@ use embassy_executor::Spawner;
 use embassy_time::{Duration, Timer};
 use {defmt_rtt as _, panic_probe as _};
 
-#[embassy_executor::task(pool_size = 2)]
+mod config {
+    pub const MY_TASK_POOL_SIZE: usize = 2;
+}
+
+#[embassy_executor::task(pool_size = config::MY_TASK_POOL_SIZE)]
 async fn my_task(spawner: Spawner, n: u32) {
     Timer::after(Duration::from_secs(1)).await;
     info!("Spawning self! {}", n);


### PR DESCRIPTION
This PR relaxes `pool_size` to allow arbitrary expressions. Unfortunately, this also means that the attribute now accepts arbitrary paths, meaning the attribute may cause compile errors not constructed by syn/darling/embassy (e.g. use of undeclared module, etc.).

The intent of this PR is to allow controlling both the pool size, and the length of some global resource array with the same constant.