### PR TITLE
stm32/otg: implement VBUS detection, misc fixes so plug/unplug works.

### DIFF
--- a/embassy-rp/src/usb.rs
+++ b/embassy-rp/src/usb.rs
@@ -353,6 +353,7 @@ impl<'d, T: Instance> driver::Bus for Bus<'d, T> {
         poll_fn(move |cx| {
             BUS_WAKER.register(cx.waker());
 
+            // TODO: implement VBUS detection.
             if !self.inited {
                 self.inited = true;
                 return Poll::Ready(Event::PowerDetected);

--- a/embassy-stm32/Cargo.toml
+++ b/embassy-stm32/Cargo.toml
@@ -57,7 +57,7 @@ sdio-host = "0.5.0"
 embedded-sdmmc = { git = "https://github.com/embassy-rs/embedded-sdmmc-rs", rev = "a4f293d3a6f72158385f79c98634cb8a14d0d2fc", optional = true }
 critical-section = "1.1"
 atomic-polyfill = "1.0.1"
-stm32-metapac = "10"
+stm32-metapac = "11"
 vcell = "0.1.3"
 bxcan = "0.7.0"
 nb = "1.0.0"
@@ -74,7 +74,7 @@ critical-section = { version = "1.1", features = ["std"] }
 [build-dependencies]
 proc-macro2 = "1.0.36"
 quote = "1.0.15"
-stm32-metapac = { version = "10", default-features = false, features = ["metadata"]}
+stm32-metapac = { version = "11", default-features = false, features = ["metadata"]}
 
 [features]
 default = ["rt"]

--- a/embassy-stm32/src/rcc/l0.rs
+++ b/embassy-stm32/src/rcc/l0.rs
@@ -1,7 +1,7 @@
 use crate::pac::rcc::vals::{Hpre, Msirange, Plldiv, Pllmul, Pllsrc, Ppre, Sw};
 use crate::pac::RCC;
 #[cfg(crs)]
-use crate::pac::{CRS, SYSCFG};
+use crate::pac::{crs, CRS, SYSCFG};
 use crate::rcc::{set_freqs, Clocks};
 use crate::time::Hertz;
 
@@ -338,7 +338,7 @@ pub(crate) unsafe fn init(config: Config) {
         CRS.cfgr().write(|w|
 
         // Select LSE as synchronization source
-        w.set_syncsrc(0b01));
+        w.set_syncsrc(crs::vals::Syncsrc::LSE));
         CRS.cr().modify(|w| {
             w.set_autotrimen(true);
             w.set_cen(true);

--- a/embassy-stm32/src/usb_otg/usb.rs
+++ b/embassy-stm32/src/usb_otg/usb.rs
@@ -124,7 +124,7 @@ impl<T: Instance> interrupt::typelevel::Handler<T::Interrupt> for InterruptHandl
                     }
 
                     state.ep_in_wakers[ep_num].wake();
-                    trace!("in ep={} irq val={:b}", ep_num, ep_ints.0);
+                    trace!("in ep={} irq val={:08x}", ep_num, ep_ints.0);
                 }
 
                 ep_mask >>= 1;
@@ -144,7 +144,7 @@ impl<T: Instance> interrupt::typelevel::Handler<T::Interrupt> for InterruptHandl
         //             // clear all
         //             r.doepint(ep_num).write_value(ep_ints);
         //             state.ep_out_wakers[ep_num].wake();
-        //             trace!("out ep={} irq val={=u32:b}", ep_num, ep_ints.0);
+        //             trace!("out ep={} irq val={:08x}", ep_num, ep_ints.0);
         //         }
 
         //         ep_mask >>= 1;
@@ -571,6 +571,8 @@ impl<'d, T: Instance> Bus<'d, T> {
                             w.set_mpsiz(ep.max_packet_size);
                             w.set_eptyp(to_eptyp(ep.ep_type));
                             w.set_sd0pid_sevnfrm(true);
+                            w.set_txfnum(index as _);
+                            w.set_snak(true);
                         }
                     });
                 });

--- a/embassy-stm32/src/usb_otg/usb.rs
+++ b/embassy-stm32/src/usb_otg/usb.rs
@@ -780,13 +780,14 @@ impl<'d, T: Instance> embassy_usb_driver::Bus for Bus<'d, T> {
                     // cancel transfer if active
                     if !enabled && r.diepctl(ep_addr.index()).read().epena() {
                         r.diepctl(ep_addr.index()).modify(|w| {
-                            w.set_snak(true);
+                            w.set_snak(true); // set NAK
                             w.set_epdis(true);
                         })
                     }
 
                     r.diepctl(ep_addr.index()).modify(|w| {
                         w.set_usbaep(enabled);
+                        w.set_cnak(enabled); // clear NAK that might've been set by SNAK above.
                     })
                 });
 

--- a/embassy-sync/src/pipe.rs
+++ b/embassy-sync/src/pipe.rs
@@ -282,7 +282,7 @@ where
     /// returns the amount of bytes written.
     ///
     /// If it is not possible to write a nonzero amount of bytes because the pipe's buffer is full,
-    /// this method will wait until it is. See [`try_write`](Self::try_write) for a variant that
+    /// this method will wait until it isn't. See [`try_write`](Self::try_write) for a variant that
     /// returns an error instead of waiting.
     ///
     /// It is not guaranteed that all bytes in the buffer are written, even if there's enough
@@ -319,7 +319,7 @@ where
     /// returns the amount of bytes read.
     ///
     /// If it is not possible to read a nonzero amount of bytes because the pipe's buffer is empty,
-    /// this method will wait until it is. See [`try_read`](Self::try_read) for a variant that
+    /// this method will wait until it isn't. See [`try_read`](Self::try_read) for a variant that
     /// returns an error instead of waiting.
     ///
     /// It is not guaranteed that all bytes in the buffer are read, even if there's enough

--- a/examples/stm32f4/src/bin/usb_ethernet.rs
+++ b/examples/stm32f4/src/bin/usb_ethernet.rs
@@ -52,7 +52,9 @@ async fn main(spawner: Spawner) {
 
     // Create the driver, from the HAL.
     let ep_out_buffer = &mut make_static!([0; 256])[..];
-    let driver = Driver::new_fs(p.USB_OTG_FS, Irqs, p.PA12, p.PA11, ep_out_buffer);
+    let mut config = embassy_stm32::usb_otg::Config::default();
+    config.vbus_detection = true;
+    let driver = Driver::new_fs(p.USB_OTG_FS, Irqs, p.PA12, p.PA11, ep_out_buffer, config);
 
     // Create embassy-usb Config
     let mut config = embassy_usb::Config::new(0xc0de, 0xcafe);

--- a/examples/stm32f4/src/bin/usb_serial.rs
+++ b/examples/stm32f4/src/bin/usb_serial.rs
@@ -29,7 +29,9 @@ async fn main(_spawner: Spawner) {
 
     // Create the driver, from the HAL.
     let mut ep_out_buffer = [0u8; 256];
-    let driver = Driver::new_fs(p.USB_OTG_FS, Irqs, p.PA12, p.PA11, &mut ep_out_buffer);
+    let mut config = embassy_stm32::usb_otg::Config::default();
+    config.vbus_detection = true;
+    let driver = Driver::new_fs(p.USB_OTG_FS, Irqs, p.PA12, p.PA11, &mut ep_out_buffer, config);
 
     // Create embassy-usb Config
     let mut config = embassy_usb::Config::new(0xc0de, 0xcafe);

--- a/examples/stm32f7/src/bin/usb_serial.rs
+++ b/examples/stm32f7/src/bin/usb_serial.rs
@@ -30,7 +30,9 @@ async fn main(_spawner: Spawner) {
 
     // Create the driver, from the HAL.
     let mut ep_out_buffer = [0u8; 256];
-    let driver = Driver::new_fs(p.USB_OTG_FS, Irqs, p.PA12, p.PA11, &mut ep_out_buffer);
+    let mut config = embassy_stm32::usb_otg::Config::default();
+    config.vbus_detection = true;
+    let driver = Driver::new_fs(p.USB_OTG_FS, Irqs, p.PA12, p.PA11, &mut ep_out_buffer, config);
 
     // Create embassy-usb Config
     let mut config = embassy_usb::Config::new(0xc0de, 0xcafe);

--- a/examples/stm32g4/src/bin/usb_serial.rs
+++ b/examples/stm32g4/src/bin/usb_serial.rs
@@ -38,7 +38,9 @@ async fn main(_spawner: Spawner) {
     let p = embassy_stm32::init(config);
     info!("Hello World!");
 
-    pac::RCC.ccipr().write(|w| w.set_clk48sel(0b10));
+    pac::RCC.ccipr().write(|w| {
+        w.set_clk48sel(pac::rcc::vals::Clk48sel::PLLQCLK);
+    });
 
     let driver = Driver::new(p.USB, Irqs, p.PA12, p.PA11);
 

--- a/examples/stm32h7/src/bin/usb_serial.rs
+++ b/examples/stm32h7/src/bin/usb_serial.rs
@@ -29,7 +29,9 @@ async fn main(_spawner: Spawner) {
 
     // Create the driver, from the HAL.
     let mut ep_out_buffer = [0u8; 256];
-    let driver = Driver::new_fs(p.USB_OTG_FS, Irqs, p.PA12, p.PA11, &mut ep_out_buffer);
+    let mut config = embassy_stm32::usb_otg::Config::default();
+    config.vbus_detection = true;
+    let driver = Driver::new_fs(p.USB_OTG_FS, Irqs, p.PA12, p.PA11, &mut ep_out_buffer, config);
 
     // Create embassy-usb Config
     let mut config = embassy_usb::Config::new(0xc0de, 0xcafe);

--- a/examples/stm32l4/src/bin/usb_serial.rs
+++ b/examples/stm32l4/src/bin/usb_serial.rs
@@ -30,7 +30,9 @@ async fn main(_spawner: Spawner) {
 
     // Create the driver, from the HAL.
     let mut ep_out_buffer = [0u8; 256];
-    let driver = Driver::new_fs(p.USB_OTG_FS, Irqs, p.PA12, p.PA11, &mut ep_out_buffer);
+    let mut config = embassy_stm32::usb_otg::Config::default();
+    config.vbus_detection = true;
+    let driver = Driver::new_fs(p.USB_OTG_FS, Irqs, p.PA12, p.PA11, &mut ep_out_buffer, config);
 
     // Create embassy-usb Config
     let mut config = embassy_usb::Config::new(0xc0de, 0xcafe);

--- a/examples/stm32u5/src/bin/usb_serial.rs
+++ b/examples/stm32u5/src/bin/usb_serial.rs
@@ -31,7 +31,9 @@ async fn main(_spawner: Spawner) {
 
     // Create the driver, from the HAL.
     let mut ep_out_buffer = [0u8; 256];
-    let driver = Driver::new_fs(p.USB_OTG_FS, Irqs, p.PA12, p.PA11, &mut ep_out_buffer);
+    let mut config = embassy_stm32::usb_otg::Config::default();
+    config.vbus_detection = true;
+    let driver = Driver::new_fs(p.USB_OTG_FS, Irqs, p.PA12, p.PA11, &mut ep_out_buffer, config);
 
     // Create embassy-usb Config
     let mut config = embassy_usb::Config::new(0xc0de, 0xcafe);


### PR DESCRIPTION
fixes #1365 
fixes #1442 

TODO: 
- [x] `disable_all_endpoints` crashes on H7 because it has 9 endpoints but the PAC has only 8. PAC fix incoming.