### PR TITLE
Make StackResources::new() const

### DIFF
--- a/embassy-net/src/lib.rs
+++ b/embassy-net/src/lib.rs
@@ -57,7 +57,7 @@ pub struct StackResources<const SOCK: usize> {
 
 impl<const SOCK: usize> StackResources<SOCK> {
     /// Create a new set of stack resources.
-    pub fn new() -> Self {
+    pub const fn new() -> Self {
         #[cfg(feature = "dns")]
         const INIT: Option<dns::DnsQuery> = None;
         Self {


### PR DESCRIPTION
So, I don't actually know for a fact if this works, but since the constructor seems to only initialize arrays, I don't see a reason why not. CI shall tell us :)