### PR TITLE
STM32: RNG update

### DIFF
--- a/embassy-stm32/Cargo.toml
+++ b/embassy-stm32/Cargo.toml
@@ -57,7 +57,7 @@ sdio-host = "0.5.0"
 embedded-sdmmc = { git = "https://github.com/embassy-rs/embedded-sdmmc-rs", rev = "a4f293d3a6f72158385f79c98634cb8a14d0d2fc", optional = true }
 critical-section = "1.1"
 atomic-polyfill = "1.0.1"
-stm32-metapac = "13"
+stm32-metapac = { git = "https://github.com/embassy-rs/stm32-data-generated", tag = "stm32-data-1f8ab493e029fc601edebc6bac105a63cc9858fe" }
 vcell = "0.1.3"
 bxcan = "0.7.0"
 nb = "1.0.0"
@@ -75,7 +75,7 @@ critical-section = { version = "1.1", features = ["std"] }
 [build-dependencies]
 proc-macro2 = "1.0.36"
 quote = "1.0.15"
-stm32-metapac = { version = "13", default-features = false, features = ["metadata"]}
+stm32-metapac = { git = "https://github.com/embassy-rs/stm32-data-generated", tag = "stm32-data-1f8ab493e029fc601edebc6bac105a63cc9858fe", default-features = false, features = ["metadata"]}
 
 [features]
 default = ["rt"]

--- a/examples/stm32f4/src/bin/usb_ethernet.rs
+++ b/examples/stm32f4/src/bin/usb_ethernet.rs
@@ -6,7 +6,7 @@ use defmt::*;
 use embassy_executor::Spawner;
 use embassy_net::tcp::TcpSocket;
 use embassy_net::{Stack, StackResources};
-use embassy_stm32::rng::Rng;
+use embassy_stm32::rng::{self, Rng};
 use embassy_stm32::time::mhz;
 use embassy_stm32::usb_otg::Driver;
 use embassy_stm32::{bind_interrupts, peripherals, usb_otg, Config};
@@ -38,6 +38,7 @@ async fn net_task(stack: &'static Stack<Device<'static, MTU>>) -> ! {
 
 bind_interrupts!(struct Irqs {
     OTG_FS => usb_otg::InterruptHandler<peripherals::USB_OTG_FS>;
+    HASH_RNG => rng::InterruptHandler<peripherals::RNG>;
 });
 
 #[embassy_executor::main]
@@ -104,7 +105,7 @@ async fn main(spawner: Spawner) {
     //});
 
     // Generate random seed
-    let mut rng = Rng::new(p.RNG);
+    let mut rng = Rng::new(p.RNG, Irqs);
     let mut seed = [0; 8];
     unwrap!(rng.async_fill_bytes(&mut seed).await);
     let seed = u64::from_le_bytes(seed);

--- a/examples/stm32f7/src/bin/eth.rs
+++ b/examples/stm32f7/src/bin/eth.rs
@@ -11,14 +11,16 @@ use embassy_stm32::eth::{Ethernet, PacketQueue};
 use embassy_stm32::peripherals::ETH;
 use embassy_stm32::rng::Rng;
 use embassy_stm32::time::mhz;
-use embassy_stm32::{bind_interrupts, eth, Config};
+use embassy_stm32::{bind_interrupts, eth, peripherals, rng, Config};
 use embassy_time::{Duration, Timer};
 use embedded_io::asynch::Write;
 use rand_core::RngCore;
 use static_cell::make_static;
 use {defmt_rtt as _, panic_probe as _};
+
 bind_interrupts!(struct Irqs {
     ETH => eth::InterruptHandler;
+    RNG => rng::InterruptHandler<peripherals::RNG>;
 });
 
 type Device = Ethernet<'static, ETH, GenericSMI>;
@@ -37,7 +39,7 @@ async fn main(spawner: Spawner) -> ! {
     info!("Hello World!");
 
     // Generate random seed.
-    let mut rng = Rng::new(p.RNG);
+    let mut rng = Rng::new(p.RNG, Irqs);
     let mut seed = [0; 8];
     rng.fill_bytes(&mut seed);
     let seed = u64::from_le_bytes(seed);

--- a/examples/stm32h5/src/bin/eth.rs
+++ b/examples/stm32h5/src/bin/eth.rs
@@ -12,14 +12,16 @@ use embassy_stm32::peripherals::ETH;
 use embassy_stm32::rcc::{AHBPrescaler, APBPrescaler, Hse, HseMode, Pll, PllSource, Sysclk, VoltageScale};
 use embassy_stm32::rng::Rng;
 use embassy_stm32::time::Hertz;
-use embassy_stm32::{bind_interrupts, eth, Config};
+use embassy_stm32::{bind_interrupts, eth, peripherals, rng, Config};
 use embassy_time::{Duration, Timer};
 use embedded_io::asynch::Write;
 use rand_core::RngCore;
 use static_cell::make_static;
 use {defmt_rtt as _, panic_probe as _};
+
 bind_interrupts!(struct Irqs {
     ETH => eth::InterruptHandler;
+    RNG => rng::InterruptHandler<peripherals::RNG>;
 });
 
 type Device = Ethernet<'static, ETH, GenericSMI>;
@@ -56,7 +58,7 @@ async fn main(spawner: Spawner) -> ! {
     info!("Hello World!");
 
     // Generate random seed.
-    let mut rng = Rng::new(p.RNG);
+    let mut rng = Rng::new(p.RNG, Irqs);
     let mut seed = [0; 8];
     rng.fill_bytes(&mut seed);
     let seed = u64::from_le_bytes(seed);

--- a/examples/stm32h5/src/bin/rng.rs
+++ b/examples/stm32h5/src/bin/rng.rs
@@ -5,14 +5,19 @@
 use defmt::*;
 use embassy_executor::Spawner;
 use embassy_stm32::rng::Rng;
+use embassy_stm32::{bind_interrupts, peripherals, rng};
 use {defmt_rtt as _, panic_probe as _};
+
+bind_interrupts!(struct Irqs {
+    RNG => rng::InterruptHandler<peripherals::RNG>;
+});
 
 #[embassy_executor::main]
 async fn main(_spawner: Spawner) {
     let p = embassy_stm32::init(Default::default());
     info!("Hello World!");
 
-    let mut rng = Rng::new(p.RNG);
+    let mut rng = Rng::new(p.RNG, Irqs);
 
     let mut buf = [0u8; 16];
     unwrap!(rng.async_fill_bytes(&mut buf).await);

--- a/examples/stm32h7/src/bin/eth_client.rs
+++ b/examples/stm32h7/src/bin/eth_client.rs
@@ -11,15 +11,17 @@ use embassy_stm32::eth::{Ethernet, PacketQueue};
 use embassy_stm32::peripherals::ETH;
 use embassy_stm32::rng::Rng;
 use embassy_stm32::time::mhz;
-use embassy_stm32::{bind_interrupts, eth, Config};
+use embassy_stm32::{bind_interrupts, eth, peripherals, rng, Config};
 use embassy_time::{Duration, Timer};
 use embedded_io::asynch::Write;
 use embedded_nal_async::{Ipv4Addr, SocketAddr, SocketAddrV4, TcpConnect};
 use rand_core::RngCore;
 use static_cell::make_static;
 use {defmt_rtt as _, panic_probe as _};
+
 bind_interrupts!(struct Irqs {
     ETH => eth::InterruptHandler;
+    RNG => rng::InterruptHandler<peripherals::RNG>;
 });
 
 type Device = Ethernet<'static, ETH, GenericSMI>;
@@ -39,7 +41,7 @@ async fn main(spawner: Spawner) -> ! {
     info!("Hello World!");
 
     // Generate random seed.
-    let mut rng = Rng::new(p.RNG);
+    let mut rng = Rng::new(p.RNG, Irqs);
     let mut seed = [0; 8];
     rng.fill_bytes(&mut seed);
     let seed = u64::from_le_bytes(seed);

--- a/examples/stm32h7/src/bin/rng.rs
+++ b/examples/stm32h7/src/bin/rng.rs
@@ -5,14 +5,19 @@
 use defmt::*;
 use embassy_executor::Spawner;
 use embassy_stm32::rng::Rng;
+use embassy_stm32::{bind_interrupts, peripherals, rng};
 use {defmt_rtt as _, panic_probe as _};
+
+bind_interrupts!(struct Irqs {
+    RNG => rng::InterruptHandler<peripherals::RNG>;
+});
 
 #[embassy_executor::main]
 async fn main(_spawner: Spawner) {
     let p = embassy_stm32::init(Default::default());
     info!("Hello World!");
 
-    let mut rng = Rng::new(p.RNG);
+    let mut rng = Rng::new(p.RNG, Irqs);
 
     let mut buf = [0u8; 16];
     unwrap!(rng.async_fill_bytes(&mut buf).await);

--- a/examples/stm32l0/src/bin/lora_lorawan.rs
+++ b/examples/stm32l0/src/bin/lora_lorawan.rs
@@ -12,8 +12,8 @@ use embassy_lora::LoraTimer;
 use embassy_stm32::exti::{Channel, ExtiInput};
 use embassy_stm32::gpio::{Input, Level, Output, Pin, Pull, Speed};
 use embassy_stm32::rng::Rng;
-use embassy_stm32::spi;
 use embassy_stm32::time::khz;
+use embassy_stm32::{bind_interrupts, peripherals, rng, spi};
 use embassy_time::Delay;
 use lora_phy::mod_params::*;
 use lora_phy::sx1276_7_8_9::SX1276_7_8_9;
@@ -22,6 +22,10 @@ use lorawan::default_crypto::DefaultFactory as Crypto;
 use lorawan_device::async_device::lora_radio::LoRaRadio;
 use lorawan_device::async_device::{region, Device, JoinMode};
 use {defmt_rtt as _, panic_probe as _};
+
+bind_interrupts!(struct Irqs {
+    RNG_LPUART1 => rng::InterruptHandler<peripherals::RNG>;
+});
 
 const LORAWAN_REGION: region::Region = region::Region::EU868; // warning: set this appropriately for the region
 
@@ -66,7 +70,7 @@ async fn main(_spawner: Spawner) {
 
     let radio = LoRaRadio::new(lora);
     let region: region::Configuration = region::Configuration::new(LORAWAN_REGION);
-    let mut device: Device<_, Crypto, _, _> = Device::new(region, radio, LoraTimer::new(), Rng::new(p.RNG));
+    let mut device: Device<_, Crypto, _, _> = Device::new(region, radio, LoraTimer::new(), Rng::new(p.RNG, Irqs));
 
     defmt::info!("Joining LoRaWAN network");
 

--- a/examples/stm32l4/src/bin/rng.rs
+++ b/examples/stm32l4/src/bin/rng.rs
@@ -6,8 +6,12 @@ use defmt::*;
 use embassy_executor::Spawner;
 use embassy_stm32::rcc::{ClockSrc, PLLClkDiv, PLLMul, PLLSource, PLLSrcDiv};
 use embassy_stm32::rng::Rng;
-use embassy_stm32::Config;
+use embassy_stm32::{bind_interrupts, peripherals, rng, Config};
 use {defmt_rtt as _, panic_probe as _};
+
+bind_interrupts!(struct Irqs {
+    RNG => rng::InterruptHandler<peripherals::RNG>;
+});
 
 #[embassy_executor::main]
 async fn main(_spawner: Spawner) {
@@ -24,7 +28,7 @@ async fn main(_spawner: Spawner) {
 
     info!("Hello World!");
 
-    let mut rng = Rng::new(p.RNG);
+    let mut rng = Rng::new(p.RNG, Irqs);
 
     let mut buf = [0u8; 16];
     unwrap!(rng.async_fill_bytes(&mut buf).await);

--- a/examples/stm32l5/src/bin/rng.rs
+++ b/examples/stm32l5/src/bin/rng.rs
@@ -6,8 +6,12 @@ use defmt::*;
 use embassy_executor::Spawner;
 use embassy_stm32::rcc::{ClockSrc, PLLClkDiv, PLLMul, PLLSource, PLLSrcDiv};
 use embassy_stm32::rng::Rng;
-use embassy_stm32::Config;
+use embassy_stm32::{bind_interrupts, peripherals, rng, Config};
 use {defmt_rtt as _, panic_probe as _};
+
+bind_interrupts!(struct Irqs {
+    RNG => rng::InterruptHandler<peripherals::RNG>;
+});
 
 #[embassy_executor::main]
 async fn main(_spawner: Spawner) {
@@ -23,7 +27,7 @@ async fn main(_spawner: Spawner) {
 
     info!("Hello World!");
 
-    let mut rng = Rng::new(p.RNG);
+    let mut rng = Rng::new(p.RNG, Irqs);
 
     let mut buf = [0u8; 16];
     unwrap!(rng.async_fill_bytes(&mut buf).await);

--- a/examples/stm32l5/src/bin/usb_ethernet.rs
+++ b/examples/stm32l5/src/bin/usb_ethernet.rs
@@ -9,7 +9,7 @@ use embassy_net::{Stack, StackResources};
 use embassy_stm32::rcc::*;
 use embassy_stm32::rng::Rng;
 use embassy_stm32::usb::Driver;
-use embassy_stm32::{bind_interrupts, peripherals, usb, Config};
+use embassy_stm32::{bind_interrupts, peripherals, rng, usb, Config};
 use embassy_usb::class::cdc_ncm::embassy_net::{Device, Runner, State as NetState};
 use embassy_usb::class::cdc_ncm::{CdcNcmClass, State};
 use embassy_usb::{Builder, UsbDevice};
@@ -24,6 +24,7 @@ const MTU: usize = 1514;
 
 bind_interrupts!(struct Irqs {
     USB_FS => usb::InterruptHandler<peripherals::USB>;
+    RNG => rng::InterruptHandler<peripherals::RNG>;
 });
 
 #[embassy_executor::task]
@@ -99,7 +100,7 @@ async fn main(spawner: Spawner) {
     //});
 
     // Generate random seed
-    let mut rng = Rng::new(p.RNG);
+    let mut rng = Rng::new(p.RNG, Irqs);
     let seed = rng.next_u64();
 
     // Init network stack

--- a/examples/stm32wl/src/bin/random.rs
+++ b/examples/stm32wl/src/bin/random.rs
@@ -4,9 +4,13 @@
 
 use defmt::*;
 use embassy_executor::Spawner;
-use embassy_stm32::pac;
-use embassy_stm32::rng::Rng;
+use embassy_stm32::rng::{self, Rng};
+use embassy_stm32::{bind_interrupts, pac, peripherals};
 use {defmt_rtt as _, panic_probe as _};
+
+bind_interrupts!(struct Irqs{
+    RNG => rng::InterruptHandler<peripherals::RNG>;
+});
 
 #[embassy_executor::main]
 async fn main(_spawner: Spawner) {
@@ -21,7 +25,7 @@ async fn main(_spawner: Spawner) {
 
     info!("Hello World!");
 
-    let mut rng = Rng::new(p.RNG);
+    let mut rng = Rng::new(p.RNG, Irqs);
 
     let mut buf = [0u8; 16];
     unwrap!(rng.async_fill_bytes(&mut buf).await);


### PR DESCRIPTION
- fix missing NVIC RNG interrupt enable
- add conditioning sequence for RNGs that support it
- add recovery from noise-source/seed error according to reference manual
- speed up polling of data by `await`ing only if there is no more data available

note: requires https://github.com/embassy-rs/stm32-data/pull/209