### PR TITLE
hal-common: require DerefMut for peripherals, not just Deref.

### DIFF
--- a/embassy-hal-common/src/peripheral.rs
+++ b/embassy-hal-common/src/peripheral.rs
@@ -161,7 +161,7 @@ pub trait Peripheral: Sized {
     }
 }
 
-impl<'b, T: Deref> Peripheral for T
+impl<'b, T: DerefMut> Peripheral for T
 where
     T::Target: Peripheral,
 {

--- a/embassy-stm32/src/dac/mod.rs
+++ b/embassy-stm32/src/dac/mod.rs
@@ -264,7 +264,7 @@ impl<'d, T: Instance, Tx> DacCh1<'d, T, Tx> {
         });
 
         let tx_request = self.dma.request();
-        let dma_channel = &self.dma;
+        let dma_channel = &mut self.dma;
 
         let tx_options = crate::dma::TransferOptions {
             circular,
@@ -376,7 +376,7 @@ impl<'d, T: Instance, Tx> DacCh2<'d, T, Tx> {
         });
 
         let tx_request = self.dma.request();
-        let dma_channel = &self.dma;
+        let dma_channel = &mut self.dma;
 
         let tx_options = crate::dma::TransferOptions {
             circular,


### PR DESCRIPTION
Otherwise you can create multiple drivers on the same singleton like this:

```rust
let mut input = Input::new(&pin, Pull::None);
let mut output = Output::new(&pin, Level::Low, Speed::Low);
input.is_high();
output.set_high();
input.is_high();
output.set_high();
```

Thanks @pennae for reporting.