### PR TITLE
Fix nrf spim nightly error

### DIFF
--- a/embassy-nrf/src/spim.rs
+++ b/embassy-nrf/src/spim.rs
@@ -521,11 +521,11 @@ mod eha {
     }
 
     impl<'d, T: Instance> embedded_hal_async::spi::SpiBus<u8> for Spim<'d, T> {
-        async fn transfer(&mut self, rx: &mut [u8], tx: &[u8]) -> Result<(), Error> {
+        async fn transfer<'a>(&'a mut self, rx: &'a mut [u8], tx: &'a [u8]) -> Result<(), Error> {
             self.transfer(rx, tx).await
         }
 
-        async fn transfer_in_place(&mut self, words: &mut [u8]) -> Result<(), Error> {
+        async fn transfer_in_place<'a>(&'a mut self, words: &'a mut [u8]) -> Result<(), Error> {
             self.transfer_in_place(words).await
         }
     }


### PR DESCRIPTION
I updated to the newest nightly today (yay, let else formatting!), but embassy-nrf stopped compiling. Apparently the compiler now cares about lifetime annotation in the SPIM embedded-hal-async trait implementations.

<details>
  <summary>Error</summary>

```txt
error: `impl` item signature doesn't match `trait` item signature
   --> /home/dion/.cargo/git/checkouts/embassy-9312dcb0ed774b29/99b4ea7/embassy-nrf/src/spim.rs:524:67
    |
524 |           async fn transfer(&mut self, rx: &mut [u8], tx: &[u8]) -> Result<(), Error> {
    |                                                                     ^^^^^^^^^^^^^^^^^ found `fn(&'1 mut spim::Spim<'d, T>, &'2 mut [u8], &'3 [u8]) -> impl futures::Future<Output = Result<(), spim::Error>>`
    |
   ::: /home/dion/.cargo/registry/src/index.crates.io-6f17d22bba15001f/embedded-hal-async-0.2.0-alpha.1/src/spi.rs:240:5
    |
240 | /     async fn transfer<'a>(
241 | |         &'a mut self,
242 | |         read: &'a mut [Word],
243 | |         write: &'a [Word],
244 | |     ) -> Result<(), Self::Error>;
    | |_________________________________- expected `fn(&'1 mut spim::Spim<'d, T>, &'1 mut [u8], &'1 [u8]) -> _`
    |
    = note: expected signature `fn(&'1 mut spim::Spim<'d, T>, &'1 mut [u8], &'1 [u8]) -> _`
               found signature `fn(&'1 mut spim::Spim<'d, T>, &'2 mut [u8], &'3 [u8]) -> impl futures::Future<Output = Result<(), spim::Error>>`
    = help: the lifetime requirements from the `impl` do not correspond to the requirements in the `trait`
    = help: verify the lifetime relationships in the `trait` and `impl` between the `self` argument, the other inputs and its output

error: `impl` item signature doesn't match `trait` item signature
   --> /home/dion/.cargo/git/checkouts/embassy-9312dcb0ed774b29/99b4ea7/embassy-nrf/src/spim.rs:528:68
    |
528 |         async fn transfer_in_place(&mut self, words: &mut [u8]) -> Result<(), Error> {
    |                                                                    ^^^^^^^^^^^^^^^^^ found `fn(&'1 mut spim::Spim<'d, T>, &'2 mut [u8]) -> impl futures::Future<Output = Result<(), spim::Error>>`
    |
   ::: /home/dion/.cargo/registry/src/index.crates.io-6f17d22bba15001f/embedded-hal-async-0.2.0-alpha.1/src/spi.rs:252:5
    |
252 |     async fn transfer_in_place<'a>(&'a mut self, words: &'a mut [Word]) -> Result<(), Self::Error>;
    |     ----------------------------------------------------------------------------------------------- expected `fn(&'1 mut spim::Spim<'d, T>, &'1 mut [u8]) -> _`
    |
    = note: expected signature `fn(&'1 mut spim::Spim<'d, T>, &'1 mut [u8]) -> _`
               found signature `fn(&'1 mut spim::Spim<'d, T>, &'2 mut [u8]) -> impl futures::Future<Output = Result<(), spim::Error>>`
    = help: the lifetime requirements from the `impl` do not correspond to the requirements in the `trait`
    = help: verify the lifetime relationships in the `trait` and `impl` between the `self` argument, the other inputs and its output

error: could not compile `embassy-nrf` (lib) due to 2 previous errors
```
</details>

By writing the same lifetimes as the trait, it works again. It's also accepted in the nightly version that is pinned by embassy, so this change should be pretty harmless. (Unless we think the pre-pr version of the code should be correct and that this nightly compiler is wrong)