### PR TITLE
stm32/rcc: allow const-propagation

### DIFF
--- a/embassy-stm32/build.rs
+++ b/embassy-stm32/build.rs
@@ -348,9 +348,7 @@ fn main() {
             g.extend(quote! {
                 impl crate::rcc::sealed::RccPeripheral for peripherals::#pname {
                     fn frequency() -> crate::time::Hertz {
-                        critical_section::with(|_| unsafe {
-                            crate::rcc::get_freqs().#clk
-                        })
+                        unsafe { crate::rcc::get_freqs().#clk }
                     }
                     fn enable() {
                         critical_section::with(|_| {

--- a/embassy-stm32/src/rcc/mod.rs
+++ b/embassy-stm32/src/rcc/mod.rs
@@ -83,12 +83,12 @@ static mut CLOCK_FREQS: MaybeUninit<Clocks> = MaybeUninit::uninit();
 /// Safety: Sets a mutable global.
 pub(crate) unsafe fn set_freqs(freqs: Clocks) {
     debug!("rcc: {:?}", freqs);
-    CLOCK_FREQS.as_mut_ptr().write(freqs);
+    CLOCK_FREQS = MaybeUninit::new(freqs);
 }
 
 /// Safety: Reads a mutable global.
 pub(crate) unsafe fn get_freqs() -> &'static Clocks {
-    &*CLOCK_FREQS.as_ptr()
+    CLOCK_FREQS.assume_init_ref()
 }
 
 #[cfg(feature = "unstable-pac")]


### PR DESCRIPTION
This allows the UB time-travel optimization to propagate clock frequencies.