### PR TITLE
Remove bad semicolon in time driver example struct declaration

### DIFF
--- a/embassy-time/src/driver.rs
+++ b/embassy-time/src/driver.rs
@@ -36,7 +36,7 @@
 //! ```
 //! use embassy_time::driver::{Driver, AlarmHandle};
 //!
-//! struct MyDriver{}; // not public!
+//! struct MyDriver{} // not public!
 //! embassy_time::time_driver_impl!(static DRIVER: MyDriver = MyDriver{});
 //!
 //! impl Driver for MyDriver {


### PR DESCRIPTION
Discovered this when I simply copy pasted the example from the time driver example.
The semicolon is not allowed with struct declarations with braces.

The doc test compiles fine for some reason!? (am I misunderstanding something here?)

Thought this might help others copy pasting the example in the future.