### PR TITLE
rp/adc: rewrite the module

### DIFF
--- a/embassy-rp/src/gpio.rs
+++ b/embassy-rp/src/gpio.rs
@@ -41,7 +41,7 @@ impl From<Level> for bool {
 }
 
 /// Represents a pull setting for an input.
-#[derive(Debug, Eq, PartialEq)]
+#[derive(Debug, Clone, Copy, Eq, PartialEq)]
 pub enum Pull {
     None,
     Up,

--- a/examples/rp/src/bin/adc.rs
+++ b/examples/rp/src/bin/adc.rs
@@ -4,8 +4,9 @@
 
 use defmt::*;
 use embassy_executor::Spawner;
-use embassy_rp::adc::{Adc, Config, InterruptHandler};
+use embassy_rp::adc::{Adc, Config, InterruptHandler, Pin};
 use embassy_rp::bind_interrupts;
+use embassy_rp::gpio::Pull;
 use embassy_time::{Duration, Timer};
 use {defmt_rtt as _, panic_probe as _};
 
@@ -18,18 +19,18 @@ async fn main(_spawner: Spawner) {
     let p = embassy_rp::init(Default::default());
     let mut adc = Adc::new(p.ADC, Irqs, Config::default());
 
-    let mut p26 = p.PIN_26;
-    let mut p27 = p.PIN_27;
-    let mut p28 = p.PIN_28;
+    let mut p26 = Pin::new(p.PIN_26, Pull::None);
+    let mut p27 = Pin::new(p.PIN_27, Pull::None);
+    let mut p28 = Pin::new(p.PIN_28, Pull::None);
 
     loop {
-        let level = adc.read(&mut p26).await;
+        let level = adc.read(&mut p26).await.unwrap();
         info!("Pin 26 ADC: {}", level);
-        let level = adc.read(&mut p27).await;
+        let level = adc.read(&mut p27).await.unwrap();
         info!("Pin 27 ADC: {}", level);
-        let level = adc.read(&mut p28).await;
+        let level = adc.read(&mut p28).await.unwrap();
         info!("Pin 28 ADC: {}", level);
-        let temp = adc.read_temperature().await;
+        let temp = adc.read_temperature().await.unwrap();
         info!("Temp: {} degrees", convert_to_celsius(temp));
         Timer::after(Duration::from_secs(1)).await;
     }

--- a/tests/rp/src/bin/adc.rs
+++ b/tests/rp/src/bin/adc.rs
@@ -1,0 +1,86 @@
+#![no_std]
+#![no_main]
+#![feature(type_alias_impl_trait)]
+#[path = "../common.rs"]
+mod common;
+
+use defmt::*;
+use embassy_executor::Spawner;
+use embassy_rp::adc::{Adc, Config, InterruptHandler, Pin};
+use embassy_rp::bind_interrupts;
+use embassy_rp::gpio::Pull;
+use {defmt_rtt as _, panic_probe as _};
+
+bind_interrupts!(struct Irqs {
+    ADC_IRQ_FIFO => InterruptHandler;
+});
+
+#[embassy_executor::main]
+async fn main(_spawner: Spawner) {
+    let mut p = embassy_rp::init(Default::default());
+    let mut adc = Adc::new(p.ADC, Irqs, Config::default());
+
+    {
+        {
+            let mut p = Pin::new(&mut p.PIN_26, Pull::Down);
+            defmt::assert!(adc.blocking_read(&mut p).unwrap() < 0b01_0000_0000);
+            defmt::assert!(adc.read(&mut p).await.unwrap() < 0b01_0000_0000);
+        }
+        {
+            let mut p = Pin::new(&mut p.PIN_26, Pull::Up);
+            defmt::assert!(adc.blocking_read(&mut p).unwrap() > 0b11_0000_0000);
+            defmt::assert!(adc.read(&mut p).await.unwrap() > 0b11_0000_0000);
+        }
+    }
+    // not bothering with async reads from now on
+    {
+        {
+            let mut p = Pin::new(&mut p.PIN_27, Pull::Down);
+            defmt::assert!(adc.blocking_read(&mut p).unwrap() < 0b01_0000_0000);
+        }
+        {
+            let mut p = Pin::new(&mut p.PIN_27, Pull::Up);
+            defmt::assert!(adc.blocking_read(&mut p).unwrap() > 0b11_0000_0000);
+        }
+    }
+    {
+        {
+            let mut p = Pin::new(&mut p.PIN_28, Pull::Down);
+            defmt::assert!(adc.blocking_read(&mut p).unwrap() < 0b01_0000_0000);
+        }
+        {
+            let mut p = Pin::new(&mut p.PIN_28, Pull::Up);
+            defmt::assert!(adc.blocking_read(&mut p).unwrap() > 0b11_0000_0000);
+        }
+    }
+    {
+        // gp29 is connected to vsys through a 200k/100k divider,
+        // adding pulls should change the value
+        let low = {
+            let mut p = Pin::new(&mut p.PIN_29, Pull::Down);
+            adc.blocking_read(&mut p).unwrap()
+        };
+        let none = {
+            let mut p = Pin::new(&mut p.PIN_29, Pull::None);
+            adc.blocking_read(&mut p).unwrap()
+        };
+        let up = {
+            let mut p = Pin::new(&mut p.PIN_29, Pull::Up);
+            adc.blocking_read(&mut p).unwrap()
+        };
+        defmt::assert!(low < none);
+        defmt::assert!(none < up);
+    }
+
+    let temp = convert_to_celsius(adc.read_temperature().await.unwrap());
+    defmt::assert!(temp > 0.0);
+    defmt::assert!(temp < 60.0);
+
+    info!("Test OK");
+    cortex_m::asm::bkpt();
+}
+
+fn convert_to_celsius(raw_temp: u16) -> f32 {
+    // According to chapter 4.9.5. Temperature Sensor in RP2040 datasheet
+    27.0 - (raw_temp as f32 * 3.3 / 4096.0 - 0.706) / 0.001721 as f32
+}


### PR DESCRIPTION
- don't require an irq binding for blocking-only adc
- abstract adc pins into an AnyPin like interface, erasing the actual peripheral type at runtime.
- add pull-up/pull-down functions for adc pins
- add a test (mostly a copy of the example, to be honest)
- configure adc pads according to datasheet
- drop embedded-hal interfaces. embedded-hal channels can do neither AnyPin nor pullup/pulldown without encoding both into the type

incorporates #1286, which seems to cause no problems. should not interfere with other drivers because during pin drop we reset the IE/OD bits to defaults.