### PR TITLE
Correctly calculate target VCO frequency from multipliers

### DIFF
--- a/embassy-stm32/src/rcc/h7.rs
+++ b/embassy-stm32/src/rcc/h7.rs
@@ -740,7 +740,7 @@ mod pll {
             }
         };
 
-        let vco_ck = output + pll_x_p;
+        let vco_ck = output * pll_x_p;
 
         assert!(pll_x_p < 128);
         assert!(vco_ck >= VCO_MIN);


### PR DESCRIPTION
The STM32H7 reference manual (RM0433) specifies PLL output frequency with these formulas:

`F_ref_ck = F_pll_src / DIVM`
`F_vco = F_ref_ck * DIVN`
`F_pll_p_ck = F_vco / (DIVP+1)`

... where `F_pll_p_ck` is the output of the PLL postdivider P.

Expanding this and solving for `F_vco`, we get:

`F_vco = F_pll_p_ck * (DIVP+1)`

i.e. `vco_ck = output * pll_x_p`

But the formula in the H7 RCC is incorrectly specified as `vco_ck = output + pll_x_p`.  Therefore asking for a PLL output frequency of 80 MHz causes `vco_ck` to be calculated as `80000005`, which is nonsense (you cannot actually realize a VCO frequency of 80000005 with only integer multipliers), and leads to a panic as `vco_ck` is out of range.

With this fix, asking for a PLL output frequency of 80 MHz with a PLL source clock of 16 MHz results in the correct set of parameters:

```
pll_src = 16 MHz
pll_x_m = 8
pll_x_n = 200
pll_x_p = 5
output = 16 MHz / 8 * 200 / 5 = 80000000
```

Similarly, asking for 400 MHz output also gives correct parameters:

```
pll_src = 16 MHz
pll_x_m = 8
pll_x_n = 200
pll_x_p = 1
output = 16 MHz / 8 * 200 / 1 = 400000000
```

I believe `*` was the intended operation here, and it seems to be working properly for me with the change.  Hoping someone else can confirm my logic.
