### PR TITLE
Enable `critical-section/std` when using `std` feature of `embassy-time`

### DIFF
--- a/embassy-time/Cargo.toml
+++ b/embassy-time/Cargo.toml
@@ -23,7 +23,7 @@ target = "x86_64-unknown-linux-gnu"
 features = ["nightly", "defmt", "unstable-traits", "std"]
 
 [features]
-std = ["tick-hz-1_000_000"]
+std = ["tick-hz-1_000_000", "critical-section/std"]
 wasm = ["dep:wasm-bindgen", "dep:js-sys", "dep:wasm-timer", "tick-hz-1_000_000"]
 
 # Enable nightly-only features


### PR DESCRIPTION
I'm using only the `embassy-time` crate in a `std` context and I found that it wouldn't link without this change. The link error I got is as such:

```
  = note: /usr/bin/ld: /home/james/Repositories/ethercrab/target/debug/deps/libembassy_time-91c1a3c881edf7b5.rlib(embassy_time-91c1a3c881edf7b5.embassy_time.ac31f442-cgu.7.rcgu.o): in function `embassy_time::timer::schedule_wake':
          /home/james/.cargo/registry/src/index.crates.io-6f17d22bba15001f/embassy-time-0.1.1/src/timer.rs:172: undefined reference to `_embassy_time_schedule_wake'
          /usr/bin/ld: /home/james/Repositories/ethercrab/target/debug/deps/libembassy_time-91c1a3c881edf7b5.rlib(embassy_time-91c1a3c881edf7b5.embassy_time.ac31f442-cgu.11.rcgu.o): in function `critical_section::release':
          /home/james/.cargo/registry/src/index.crates.io-6f17d22bba15001f/critical-section-1.1.1/src/lib.rs:197: undefined reference to `_critical_section_1_0_release'
          /usr/bin/ld: /home/james/Repositories/ethercrab/target/debug/deps/libembassy_time-91c1a3c881edf7b5.rlib(embassy_time-91c1a3c881edf7b5.embassy_time.ac31f442-cgu.14.rcgu.o): in function `critical_section::acquire':
          /home/james/.cargo/registry/src/index.crates.io-6f17d22bba15001f/critical-section-1.1.1/src/lib.rs:180: undefined reference to `_critical_section_1_0_acquire'
          collect2: error: ld returned 1 exit status
          
  = note: some `extern` functions couldn't be found; some native libraries may need to be installed or have their path specified
  = note: use the `-l` flag to specify native libraries to link
  = note: use the `cargo:rustc-link-lib` directive to specify the native libraries to link with Cargo (see https://doc.rust-lang.org/cargo/reference/build-scripts.html#cargorustc-link-libkindname)
```

Please let me know if you'd like me to add a changelog entry or anything else!