### PR TITLE
Reset `expires_at` of finished task

### DIFF
--- a/embassy-executor/src/raw/mod.rs
+++ b/embassy-executor/src/raw/mod.rs
@@ -165,6 +165,9 @@ impl<F: Future + 'static> TaskStorage<F> {
             Poll::Ready(_) => {
                 this.future.drop_in_place();
                 this.raw.state.fetch_and(!STATE_SPAWNED, Ordering::AcqRel);
+
+                #[cfg(feature = "integrated-timers")]
+                this.raw.expires_at.set(Instant::MAX);
             }
             Poll::Pending => {}
         }


### PR DESCRIPTION
Currently, it is possible for finished tasks to remain in a non-zero state (namely, `STATE_TIMER_QUEUED`). This PR resets the `expires_at` field to allow the timer queue to remove the bit, which will in turn allow the task's pool slot to be reused.