### PR TITLE
Enable RTC on STM32WL chips

### DIFF
--- a/embassy-stm32/src/rcc/wl.rs
+++ b/embassy-stm32/src/rcc/wl.rs
@@ -1,5 +1,4 @@
-use stm32_metapac::pwr::vals::Dbp;
-
+use crate::pac::pwr::vals::Dbp;
 use crate::pac::{FLASH, PWR, RCC};
 use crate::rcc::{set_freqs, Clocks};
 use crate::time::Hertz;

--- a/embassy-stm32/src/rtc/v3.rs
+++ b/embassy-stm32/src/rtc/v3.rs
@@ -172,6 +172,7 @@ impl sealed::Instance for crate::peripherals::RTC {
     const BACKUP_REGISTER_COUNT: usize = 32;
 
     fn read_backup_register(_rtc: &Rtc, register: usize) -> Option<u32> {
+        #[allow(clippy::if_same_then_else)]
         if register < Self::BACKUP_REGISTER_COUNT {
             //Some(rtc.bkpr()[register].read().bits())
             None // RTC3 backup registers come from the TAMP peripe=heral, not RTC. Not() even in the L412 PAC

--- a/examples/stm32wl/.cargo/config.toml
+++ b/examples/stm32wl/.cargo/config.toml
@@ -3,7 +3,7 @@
 runner = "probe-rs run --chip STM32WLE5JCIx"
 
 [build]
-target = "thumbv7em-none-eabihf"
+target = "thumbv7em-none-eabi"
 
 [env]
 DEFMT_LOG = "trace"

--- a/examples/stm32wl/Cargo.toml
+++ b/examples/stm32wl/Cargo.toml
@@ -5,26 +5,65 @@ version = "0.1.0"
 license = "MIT OR Apache-2.0"
 
 [dependencies]
-embassy-sync = { version = "0.2.0", path = "../../embassy-sync", features = ["defmt"] }
-embassy-executor = { version = "0.2.0", path = "../../embassy-executor", features = ["nightly", "arch-cortex-m", "executor-thread", "defmt", "integrated-timers"] }
-embassy-time = { version = "0.1.2", path = "../../embassy-time", features = ["nightly", "unstable-traits", "defmt", "defmt-timestamp-uptime", "tick-hz-32_768"] }
-embassy-stm32 = { version = "0.1.0", path = "../../embassy-stm32", features = ["nightly", "unstable-traits", "defmt", "stm32wl55jc-cm4", "time-driver-any", "memory-x", "unstable-pac", "exti"]  }
-embassy-embedded-hal = {version = "0.1.0", path = "../../embassy-embedded-hal" }
-embassy-lora = { version = "0.1.0", path = "../../embassy-lora", features = ["stm32wl", "time", "defmt"] }
+embassy-sync = { version = "0.2.0", path = "../../embassy-sync", features = [
+    "defmt",
+] }
+embassy-executor = { version = "0.2.0", path = "../../embassy-executor", features = [
+    "nightly",
+    "arch-cortex-m",
+    "executor-thread",
+    "defmt",
+    "integrated-timers",
+] }
+embassy-time = { version = "0.1.2", path = "../../embassy-time", features = [
+    "nightly",
+    "unstable-traits",
+    "defmt",
+    "defmt-timestamp-uptime",
+    "tick-hz-32_768",
+] }
+embassy-stm32 = { version = "0.1.0", path = "../../embassy-stm32", features = [
+    "nightly",
+    "unstable-traits",
+    "defmt",
+    "stm32wl55jc-cm4",
+    "time-driver-any",
+    "memory-x",
+    "unstable-pac",
+    "exti",
+    "chrono",
+] }
+embassy-embedded-hal = { version = "0.1.0", path = "../../embassy-embedded-hal" }
+embassy-lora = { version = "0.1.0", path = "../../embassy-lora", features = [
+    "stm32wl",
+    "time",
+    "defmt",
+] }
 lora-phy = { version = "1" }
-lorawan-device = { version = "0.10.0", default-features = false, features = ["async", "external-lora-phy"] }
-lorawan = { version = "0.7.3", default-features = false, features = ["default-crypto"] }
+lorawan-device = { version = "0.10.0", default-features = false, features = [
+    "async",
+    "external-lora-phy",
+] }
+lorawan = { version = "0.7.3", default-features = false, features = [
+    "default-crypto",
+] }
 
 defmt = "0.3"
 defmt-rtt = "0.4"
 
-cortex-m = { version = "0.7.6", features = ["inline-asm", "critical-section-single-core"] }
+cortex-m = { version = "0.7.6", features = [
+    "inline-asm",
+    "critical-section-single-core",
+] }
 cortex-m-rt = "0.7.0"
 embedded-hal = "0.2.6"
 embedded-storage = "0.3.0"
 panic-probe = { version = "0.3", features = ["print-defmt"] }
-futures = { version = "0.3.17", default-features = false, features = ["async-await"] }
+futures = { version = "0.3.17", default-features = false, features = [
+    "async-await",
+] }
 heapless = { version = "0.7.5", default-features = false }
+chrono = { version = "^0.4", default-features = false }
 
 [patch.crates-io]
 lora-phy = { git = "https://github.com/embassy-rs/lora-phy", rev = "ad289428fd44b02788e2fa2116445cc8f640a265" }

--- a/examples/stm32wl/Cargo.toml
+++ b/examples/stm32wl/Cargo.toml
@@ -5,63 +5,25 @@ version = "0.1.0"
 license = "MIT OR Apache-2.0"
 
 [dependencies]
-embassy-sync = { version = "0.2.0", path = "../../embassy-sync", features = [
-    "defmt",
-] }
-embassy-executor = { version = "0.2.0", path = "../../embassy-executor", features = [
-    "nightly",
-    "arch-cortex-m",
-    "executor-thread",
-    "defmt",
-    "integrated-timers",
-] }
-embassy-time = { version = "0.1.2", path = "../../embassy-time", features = [
-    "nightly",
-    "unstable-traits",
-    "defmt",
-    "defmt-timestamp-uptime",
-    "tick-hz-32_768",
-] }
-embassy-stm32 = { version = "0.1.0", path = "../../embassy-stm32", features = [
-    "nightly",
-    "unstable-traits",
-    "defmt",
-    "stm32wl55jc-cm4",
-    "time-driver-any",
-    "memory-x",
-    "unstable-pac",
-    "exti",
-    "chrono",
-] }
+embassy-sync = { version = "0.2.0", path = "../../embassy-sync", features = ["defmt"] }
+embassy-executor = { version = "0.2.0", path = "../../embassy-executor", features = ["nightly", "arch-cortex-m", "executor-thread", "defmt", "integrated-timers"] }
+embassy-time = { version = "0.1.2", path = "../../embassy-time", features = ["nightly", "unstable-traits", "defmt", "defmt-timestamp-uptime", "tick-hz-32_768"] }
+embassy-stm32 = { version = "0.1.0", path = "../../embassy-stm32", features = ["nightly", "unstable-traits", "defmt", "stm32wl55jc-cm4", "time-driver-any", "memory-x", "unstable-pac", "exti", "chrono"] }
 embassy-embedded-hal = { version = "0.1.0", path = "../../embassy-embedded-hal" }
-embassy-lora = { version = "0.1.0", path = "../../embassy-lora", features = [
-    "stm32wl",
-    "time",
-    "defmt",
-] }
+embassy-lora = { version = "0.1.0", path = "../../embassy-lora", features = ["stm32wl", "time", "defmt"] }
 lora-phy = { version = "1" }
-lorawan-device = { version = "0.10.0", default-features = false, features = [
-    "async",
-    "external-lora-phy",
-] }
-lorawan = { version = "0.7.3", default-features = false, features = [
-    "default-crypto",
-] }
+lorawan-device = { version = "0.10.0", default-features = false, features = ["async", "external-lora-phy"] }
+lorawan = { version = "0.7.3", default-features = false, features = ["default-crypto"] }
 
 defmt = "0.3"
 defmt-rtt = "0.4"
 
-cortex-m = { version = "0.7.6", features = [
-    "inline-asm",
-    "critical-section-single-core",
-] }
+cortex-m = { version = "0.7.6", features = ["inline-asm", "critical-section-single-core"] }
 cortex-m-rt = "0.7.0"
 embedded-hal = "0.2.6"
 embedded-storage = "0.3.0"
 panic-probe = { version = "0.3", features = ["print-defmt"] }
-futures = { version = "0.3.17", default-features = false, features = [
-    "async-await",
-] }
+futures = { version = "0.3.17", default-features = false, features = ["async-await"] }
 heapless = { version = "0.7.5", default-features = false }
 chrono = { version = "^0.4", default-features = false }
 

--- a/examples/stm32wl/src/bin/rtc.rs
+++ b/examples/stm32wl/src/bin/rtc.rs
@@ -1,0 +1,43 @@
+#![no_std]
+#![no_main]
+#![feature(type_alias_impl_trait)]
+
+use chrono::{NaiveDate, NaiveDateTime};
+use defmt::*;
+use embassy_executor::Spawner;
+use embassy_stm32::rcc::{self, ClockSrc};
+use embassy_stm32::rtc::{Rtc, RtcConfig};
+use embassy_stm32::Config;
+use embassy_time::{Duration, Timer};
+use {defmt_rtt as _, panic_probe as _};
+
+#[embassy_executor::main]
+async fn main(_spawner: Spawner) {
+    let p = {
+        let mut config = Config::default();
+        config.rcc.mux = ClockSrc::HSE32;
+        config.rcc.rtc_mux = rcc::RtcClockSource::LSE32;
+        config.rcc.enable_rtc_apb = true;
+        embassy_stm32::init(config)
+    };
+    info!("Hello World!");
+
+    let now = NaiveDate::from_ymd_opt(2020, 5, 15)
+        .unwrap()
+        .and_hms_opt(10, 30, 15)
+        .unwrap();
+
+    let mut rtc = Rtc::new(
+        p.RTC,
+        RtcConfig::default().clock_config(embassy_stm32::rtc::RtcClockSource::LSE),
+    );
+    info!("Got RTC! {:?}", now.timestamp());
+
+    rtc.set_datetime(now.into()).expect("datetime not set");
+
+    // In reality the delay would be much longer
+    Timer::after(Duration::from_millis(20000)).await;
+
+    let then: NaiveDateTime = rtc.now().unwrap().into();
+    info!("Got RTC! {:?}", then.timestamp());
+}


### PR DESCRIPTION
Sets up options and RCC clocks for STM32WL RTC module.
Adds rcc configuration option to enable the APB RTC enable.
Add rtc example for STM32WL
Corrects compiler in examples/stm32wl... this processor does not support hardware floating point.