### PR TITLE
Don't require Embassy users to depend on `cortex-m-rt` directly

### DIFF
--- a/embassy-executor/Cargo.toml
+++ b/embassy-executor/Cargo.toml
@@ -32,7 +32,7 @@ features = ["nightly", "defmt", "pender-callback", "arch-cortex-m", "executor-th
 # Architecture
 _arch = [] # some arch was picked
 arch-std = ["_arch", "critical-section/std"]
-arch-cortex-m = ["_arch", "dep:cortex-m"]
+arch-cortex-m = ["_arch", "dep:cortex-m", "dep:cortex-m-rt"]
 arch-xtensa = ["_arch"]
 arch-riscv32 = ["_arch"]
 arch-wasm = ["_arch", "dep:wasm-bindgen", "dep:js-sys"]
@@ -69,6 +69,7 @@ static_cell = "1.1"
 
 # arch-cortex-m dependencies
 cortex-m = { version = "0.7.6", optional = true }
+cortex-m-rt = { version = "0.7.3", optional = true }
 
 # arch-wasm dependencies
 wasm-bindgen = { version = "0.2.82", optional = true }

--- a/embassy-executor/src/arch/cortex_m.rs
+++ b/embassy-executor/src/arch/cortex_m.rs
@@ -5,6 +5,8 @@ mod thread {
     use core::arch::asm;
     use core::marker::PhantomData;
 
+    // Used from the `main` macro.
+    pub use cortex_m_rt;
     #[cfg(feature = "nightly")]
     pub use embassy_macros::main_cortex_m as main;
 

--- a/embassy-macros/src/macros/main.rs
+++ b/embassy-macros/src/macros/main.rs
@@ -38,7 +38,7 @@ pub fn riscv(args: &[NestedMeta]) -> TokenStream {
 
 pub fn cortex_m() -> TokenStream {
     quote! {
-        #[cortex_m_rt::entry]
+        #[embassy_executor::cortex_m_rt::entry]
         fn main() -> ! {
             let mut executor = ::embassy_executor::Executor::new();
             let executor = unsafe { __make_static(&mut executor) };


### PR DESCRIPTION
When setting up my first Embassy app, I got an error about `cortex-m-rt` from the `main` macro. I figured out quickly what was wrong, but still, requiring users to depend on a library they might otherwise not be using directly seemed unintuitive and unnecessary. So I fixed it :smile: 

Please let me know, if I'm missing something! I'm just getting started with Embassy, so I might be totally on the wrong track here.