### PR TITLE
rp: Check intrstatus before signalling suspended

### DIFF
--- a/embassy-rp/src/usb.rs
+++ b/embassy-rp/src/usb.rs
@@ -361,6 +361,7 @@ impl<'d, T: Instance> driver::Bus for Bus<'d, T> {
 
             let regs = T::regs();
             let siestatus = regs.sie_status().read();
+            let intrstatus = regs.intr().read();
 
             if siestatus.resume() {
                 regs.sie_status().write(|w| w.set_resume(true));
@@ -389,7 +390,7 @@ impl<'d, T: Instance> driver::Bus for Bus<'d, T> {
                 return Poll::Ready(Event::Reset);
             }
 
-            if siestatus.suspended() {
+            if siestatus.suspended() && intrstatus.dev_suspend() {
                 regs.sie_status().write(|w| w.set_suspended(true));
                 return Poll::Ready(Event::Suspend);
             }


### PR DESCRIPTION
I'm not sure if this is also needed elsewhere, but currently on rp2040 the device gets stuck if the usb suspends because Bus::poll will always yield Ready(Suspended)