### PR TITLE
Embassy-rp I2C: Fix 1664 (async transaction failure)

### DIFF
--- a/embassy-rp/src/i2c.rs
+++ b/embassy-rp/src/i2c.rs
@@ -716,6 +716,9 @@ mod nightly {
         async fn transaction(&mut self, address: A, operations: &mut [Operation<'_>]) -> Result<(), Self::Error> {
             let addr: u16 = address.into();
 
+            if operations.len() > 0 {
+                Self::setup(addr)?;
+            }
             let mut iterator = operations.iter_mut();
 
             while let Some(op) = iterator.next() {
@@ -723,11 +726,9 @@ mod nightly {
 
                 match op {
                     Operation::Read(buffer) => {
-                        Self::setup(addr)?;
                         self.read_async_internal(buffer, false, last).await?;
                     }
                     Operation::Write(buffer) => {
-                        Self::setup(addr)?;
                         self.write_async_internal(buffer.into_iter().cloned(), last).await?;
                     }
                 }


### PR DESCRIPTION
Change embassy-rp i2c.rs impl of embedded_hal_async::i2c::I2c::transaction to only do the call to setup() for address once per call to transactions. Calling setup multiple times results in I2C transactions being skipped on the bus, even across calls to transaction() or devices.

This fixes the issue I opened, but I do not know if there is an underlying issue in the driver that causes this. 