### PR TITLE
Make dual-stack work in embassy-net

### DIFF
--- a/embassy-net/src/lib.rs
+++ b/embassy-net/src/lib.rs
@@ -648,16 +648,17 @@ impl<D: Driver + 'static> Inner<D> {
         socket.set_retry_config(config.retry_config);
     }
 
-    #[allow(unused)] // used only with dhcp
+    #[cfg(feature = "dhcpv4")]
     fn unapply_config_v4(&mut self, s: &mut SocketStack) {
         #[cfg(feature = "medium-ethernet")]
         let medium = self.device.capabilities().medium;
         debug!("Lost IP configuration");
         s.iface.update_ip_addrs(|ip_addrs| {
+            #[cfg(feature = "proto-ipv4")]
             if let Some((index, _)) = ip_addrs
                 .iter()
                 .enumerate()
-                .find(|(index, &addr)| matches!(addr, IpCidr::Ipv4(_)))
+                .find(|(_, &addr)| matches!(addr, IpCidr::Ipv4(_)))
             {
                 ip_addrs.remove(index);
             }

--- a/embassy-net/src/lib.rs
+++ b/embassy-net/src/lib.rs
@@ -531,11 +531,14 @@ impl<D: Driver + 'static> Inner<D> {
 
         debug!("   IP address:      {}", config.address);
         s.iface.update_ip_addrs(|addrs| {
-            if addrs.is_empty() {
-                addrs.push(IpCidr::Ipv4(config.address)).unwrap();
-            } else {
-                addrs[0] = IpCidr::Ipv4(config.address);
+            if let Some((index, _)) = addrs
+                .iter()
+                .enumerate()
+                .find(|(_, &addr)| matches!(addr, IpCidr::Ipv4(_)))
+            {
+                addrs.remove(index);
             }
+            addrs.push(IpCidr::Ipv4(config.address)).unwrap();
         });
 
         #[cfg(feature = "medium-ethernet")]
@@ -570,11 +573,14 @@ impl<D: Driver + 'static> Inner<D> {
 
         debug!("   IP address:      {}", config.address);
         s.iface.update_ip_addrs(|addrs| {
-            if addrs.is_empty() {
-                addrs.push(IpCidr::Ipv6(config.address)).unwrap();
-            } else {
-                addrs[0] = IpCidr::Ipv6(config.address);
+            if let Some((index, _)) = addrs
+                .iter()
+                .enumerate()
+                .find(|(_, &addr)| matches!(addr, IpCidr::Ipv6(_)))
+            {
+                addrs.remove(index);
             }
+            addrs.push(IpCidr::Ipv6(config.address)).unwrap();
         });
 
         #[cfg(feature = "medium-ethernet")]
@@ -643,12 +649,19 @@ impl<D: Driver + 'static> Inner<D> {
     }
 
     #[allow(unused)] // used only with dhcp
-    fn unapply_config(&mut self, s: &mut SocketStack) {
+    fn unapply_config_v4(&mut self, s: &mut SocketStack) {
         #[cfg(feature = "medium-ethernet")]
         let medium = self.device.capabilities().medium;
-
         debug!("Lost IP configuration");
-        s.iface.update_ip_addrs(|ip_addrs| ip_addrs.clear());
+        s.iface.update_ip_addrs(|ip_addrs| {
+            if let Some((index, _)) = ip_addrs
+                .iter()
+                .enumerate()
+                .find(|(index, &addr)| matches!(addr, IpCidr::Ipv4(_)))
+            {
+                ip_addrs.remove(index);
+            }
+        });
         #[cfg(feature = "medium-ethernet")]
         if medium == Medium::Ethernet {
             #[cfg(feature = "proto-ipv4")]
@@ -695,7 +708,7 @@ impl<D: Driver + 'static> Inner<D> {
             if self.link_up {
                 match socket.poll() {
                     None => {}
-                    Some(dhcpv4::Event::Deconfigured) => self.unapply_config(s),
+                    Some(dhcpv4::Event::Deconfigured) => self.unapply_config_v4(s),
                     Some(dhcpv4::Event::Configured(config)) => {
                         let config = StaticConfigV4 {
                             address: config.address,
@@ -707,7 +720,7 @@ impl<D: Driver + 'static> Inner<D> {
                 }
             } else if old_link_up {
                 socket.reset();
-                self.unapply_config(s);
+                self.unapply_config_v4(s);
             }
         }
         //if old_link_up || self.link_up {


### PR DESCRIPTION
While it is possible to configure both, IPv4 and IPv6, it isn't possible to use both at the same time because the IP address was always set as the first element
