### PR TITLE
stm32/uart: add swap_rx_tx

### DIFF
--- a/embassy-stm32/src/usart/mod.rs
+++ b/embassy-stm32/src/usart/mod.rs
@@ -694,19 +694,21 @@ impl<'d, T: BasicInstance, TxDma, RxDma> Uart<'d, T, TxDma, RxDma> {
 
         let r = T::regs();
 
-        #[allow(unused_variables)]
-        let swap_rx_tx = false;
-
-        #[cfg(any(usart_v3, usart_v4))]
-        let swap_rx_tx = config.swap_rx_tx;
-
-        if swap_rx_tx {
-            let (rx, tx) = (tx, rx);
-            rx.set_as_af(rx.af_num(), AFType::Input);
-            tx.set_as_af(tx.af_num(), AFType::OutputPushPull);
-        } else {
-            rx.set_as_af(rx.af_num(), AFType::Input);
-            tx.set_as_af(tx.af_num(), AFType::OutputPushPull);
+        // Some chips do not have swap_rx_tx bit
+        cfg_if::cfg_if! {
+            if #[cfg(any(usart_v3, usart_v4))] {
+                if config.swap_rx_tx {
+                    let (rx, tx) = (tx, rx);
+                    rx.set_as_af(rx.af_num(), AFType::Input);
+                    tx.set_as_af(tx.af_num(), AFType::OutputPushPull);
+                } else {
+                    rx.set_as_af(rx.af_num(), AFType::Input);
+                    tx.set_as_af(tx.af_num(), AFType::OutputPushPull);
+                }
+            } else {
+                rx.set_as_af(rx.af_num(), AFType::Input);
+                tx.set_as_af(tx.af_num(), AFType::OutputPushPull);
+            }
         }
 
         configure(r, &config, T::frequency(), T::KIND, true, true);

--- a/embassy-stm32/src/usart/mod.rs
+++ b/embassy-stm32/src/usart/mod.rs
@@ -116,6 +116,10 @@ pub struct Config {
     /// but will effectively disable noise detection.
     #[cfg(not(usart_v1))]
     pub assume_noise_free: bool,
+
+    /// Set this to true to swap the RX and TX pins.
+    #[cfg(any(usart_v3, usart_v4))]
+    pub swap_rx_tx: bool,
 }
 
 impl Default for Config {
@@ -129,6 +133,8 @@ impl Default for Config {
             detect_previous_overrun: false,
             #[cfg(not(usart_v1))]
             assume_noise_free: false,
+            #[cfg(any(usart_v3, usart_v4))]
+            swap_rx_tx: false,
         }
     }
 }
@@ -688,8 +694,20 @@ impl<'d, T: BasicInstance, TxDma, RxDma> Uart<'d, T, TxDma, RxDma> {
 
         let r = T::regs();
 
-        rx.set_as_af(rx.af_num(), AFType::Input);
-        tx.set_as_af(tx.af_num(), AFType::OutputPushPull);
+        #[allow(unused_variables)]
+        let swap_rx_tx = false;
+
+        #[cfg(any(usart_v3, usart_v4))]
+        let swap_rx_tx = config.swap_rx_tx;
+
+        if swap_rx_tx {
+            let (rx, tx) = (tx, rx);
+            rx.set_as_af(rx.af_num(), AFType::Input);
+            tx.set_as_af(tx.af_num(), AFType::OutputPushPull);
+        } else {
+            rx.set_as_af(rx.af_num(), AFType::Input);
+            tx.set_as_af(tx.af_num(), AFType::OutputPushPull);
+        }
 
         configure(r, &config, T::frequency(), T::KIND, true, true);
 
@@ -847,6 +865,9 @@ fn configure(r: Regs, config: &Config, pclk_freq: Hertz, kind: Kind, enable_rx: 
             StopBits::STOP1P5 => vals::Stop::STOP1P5,
             StopBits::STOP2 => vals::Stop::STOP2,
         });
+
+        #[cfg(any(usart_v3, usart_v4))]
+        w.set_swap(config.swap_rx_tx);
     });
     r.cr1().write(|w| {
         // enable uart


### PR DESCRIPTION
Add an option to swap RX and TX. Tested on STM32U575ZITx on a board with swapped tx/rx pins.