### PR TITLE
stm32: Fix DAC examples

### DIFF
--- a/embassy-stm32/src/dac/mod.rs
+++ b/embassy-stm32/src/dac/mod.rs
@@ -213,8 +213,9 @@ impl<'d, T: Instance, Tx> DacCh1<'d, T, Tx> {
     pub fn new(
         peri: impl Peripheral<P = T> + 'd,
         dma: impl Peripheral<P = Tx> + 'd,
-        _pin: impl Peripheral<P = impl DacPin<T, 1>> + 'd,
+        pin: impl Peripheral<P = impl DacPin<T, 1>> + crate::gpio::sealed::Pin + 'd,
     ) -> Self {
+        pin.set_as_analog();
         into_ref!(peri, dma);
         T::enable();
         T::reset();
@@ -324,8 +325,9 @@ impl<'d, T: Instance, Tx> DacCh2<'d, T, Tx> {
     pub fn new(
         _peri: impl Peripheral<P = T> + 'd,
         dma: impl Peripheral<P = Tx> + 'd,
-        _pin: impl Peripheral<P = impl DacPin<T, 2>> + 'd,
+        pin: impl Peripheral<P = impl DacPin<T, 2>> + crate::gpio::sealed::Pin + 'd,
     ) -> Self {
+        pin.set_as_analog();
         into_ref!(_peri, dma);
         T::enable();
         T::reset();
@@ -439,9 +441,11 @@ impl<'d, T: Instance, TxCh1, TxCh2> Dac<'d, T, TxCh1, TxCh2> {
         peri: impl Peripheral<P = T> + 'd,
         dma_ch1: impl Peripheral<P = TxCh1> + 'd,
         dma_ch2: impl Peripheral<P = TxCh2> + 'd,
-        _pin_ch1: impl Peripheral<P = impl DacPin<T, 1>> + 'd,
-        _pin_ch2: impl Peripheral<P = impl DacPin<T, 2>> + 'd,
+        pin_ch1: impl Peripheral<P = impl DacPin<T, 1>> + crate::gpio::sealed::Pin + 'd,
+        pin_ch2: impl Peripheral<P = impl DacPin<T, 2>> + crate::gpio::sealed::Pin + 'd,
     ) -> Self {
+        pin_ch1.set_as_analog();
+        pin_ch2.set_as_analog();
         into_ref!(peri, dma_ch1, dma_ch2);
         T::enable();
         T::reset();

--- a/examples/stm32f4/Cargo.toml
+++ b/examples/stm32f4/Cargo.toml
@@ -6,7 +6,7 @@ license = "MIT OR Apache-2.0"
 
 [dependencies]
 embassy-sync = { version = "0.2.0", path = "../../embassy-sync", features = ["defmt"] }
-embassy-executor = { version = "0.2.0", path = "../../embassy-executor", features = ["nightly", "arch-cortex-m", "executor-thread", "executor-interrupt", "defmt", "integrated-timers", "arch-cortex-m", "executor-thread", "executor-interrupt"] }
+embassy-executor = { version = "0.2.0", path = "../../embassy-executor", features = ["nightly", "arch-cortex-m", "executor-thread", "executor-interrupt", "defmt", "integrated-timers"] }
 embassy-time = { version = "0.1.2", path = "../../embassy-time", features = ["defmt", "defmt-timestamp-uptime", "unstable-traits", "tick-hz-32_768"] }
 embassy-stm32 = { version = "0.1.0", path = "../../embassy-stm32", features = ["nightly", "unstable-traits", "defmt", "stm32f429zi", "unstable-pac", "memory-x", "time-driver-any", "exti", "embedded-sdmmc", "chrono"]  }
 embassy-usb = { version = "0.1.0", path = "../../embassy-usb", features = ["defmt"] }

--- a/examples/stm32f4/src/bin/dac.rs
+++ b/examples/stm32f4/src/bin/dac.rs
@@ -14,11 +14,11 @@ async fn main(_spawner: Spawner) -> ! {
     info!("Hello World, dude!");
 
     let mut dac = DacCh1::new(p.DAC, NoDma, p.PA4);
+    unwrap!(dac.set_trigger_enable(false));
 
     loop {
         for v in 0..=255 {
             unwrap!(dac.set(Value::Bit8(to_sine_wave(v))));
-            dac.trigger();
         }
     }
 }

--- a/examples/stm32h7/src/bin/dac.rs
+++ b/examples/stm32h7/src/bin/dac.rs
@@ -21,11 +21,11 @@ fn main() -> ! {
     let p = embassy_stm32::init(config);
 
     let mut dac = DacCh1::new(p.DAC1, NoDma, p.PA4);
+    unwrap!(dac.set_trigger_enable(false));
 
     loop {
         for v in 0..=255 {
             unwrap!(dac.set(Value::Bit8(to_sine_wave(v))));
-            dac.trigger();
         }
     }
 }

--- a/examples/stm32l4/src/bin/dac.rs
+++ b/examples/stm32l4/src/bin/dac.rs
@@ -13,11 +13,11 @@ fn main() -> ! {
     info!("Hello World!");
 
     let mut dac = DacCh1::new(p.DAC1, NoDma, p.PA4);
+    unwrap!(dac.set_trigger_enable(false));
 
     loop {
         for v in 0..=255 {
             unwrap!(dac.set(Value::Bit8(to_sine_wave(v))));
-            dac.trigger();
         }
     }
 }


### PR DESCRIPTION
Currently the DAC examples don't work on F4 or L4, because the DAC driver defaults to enabling the trigger (useful for DMA) but doesn't set the trigger selection, so it's left at the reset value of 0 for `TIM6`. The examples then try to software trigger each new value, but as the DAC isn't configured for software trigger, nothing happens.

One option is to change the trigger selection from `TIM6` to `SOFTWARE`, but as this disables the channel you then have to re-enable it, and since we just trigger immediately after writing each word, it's more sensible to just disable the trigger.

On the H7, in _theory_ the example would work as-is, because the default value for the trigger selection is `SOFTWARE`. However, the PAC is wrong for the H7 and puts the trigger enable bit TEN into the trigger select field instead, so the HAL ends up configuring a different trigger (`TIM1`) instead of enabling trigger mode (which is left disabled), so the software writes go through immediately anyway. Which is good, because the PAC also has the wrong enum for the triggers, so trying to set it to `SOFTWARE` would actually set it to `TIM8`. I think it's best to update the example to match the F4/L4, but at least it still works, and then fix the PAC/HAL separately.

I also updated the DAC driver to set the pin to analogue mode as recommended in the reference manual. The DAC _works_ without this, but would contend with the digital driver if the pin was in output mode, or needlessly trigger the input Schmitt trigger in default input mode, so it's better to set it to analog. I'm not sure if the added constraint on the pin type is the best way to do this though. This issue is covered in #334, but this PR doesn't change the ADC behaviour (maybe it's already fixed, though?).