### PR TITLE
Add DAC v3

### DIFF
--- a/embassy-stm32/Cargo.toml
+++ b/embassy-stm32/Cargo.toml
@@ -57,7 +57,7 @@ sdio-host = "0.5.0"
 embedded-sdmmc = { git = "https://github.com/embassy-rs/embedded-sdmmc-rs", rev = "a4f293d3a6f72158385f79c98634cb8a14d0d2fc", optional = true }
 critical-section = "1.1"
 atomic-polyfill = "1.0.1"
-stm32-metapac = "12"
+stm32-metapac = "13"
 vcell = "0.1.3"
 bxcan = "0.7.0"
 nb = "1.0.0"
@@ -74,7 +74,7 @@ critical-section = { version = "1.1", features = ["std"] }
 [build-dependencies]
 proc-macro2 = "1.0.36"
 quote = "1.0.15"
-stm32-metapac = { version = "12", default-features = false, features = ["metadata"]}
+stm32-metapac = { version = "13", default-features = false, features = ["metadata"]}
 
 [features]
 default = ["rt"]

--- a/embassy-stm32/src/dac/mod.rs
+++ b/embassy-stm32/src/dac/mod.rs
@@ -164,7 +164,7 @@ pub trait DacChannel<T: Instance, Tx> {
     }
 
     /// Set mode register of the given channel
-    #[cfg(dac_v2)]
+    #[cfg(any(dac_v2, dac_v3))]
     fn set_channel_mode(&mut self, val: u8) -> Result<(), Error> {
         T::regs().mcr().modify(|reg| {
             reg.set_mode(Self::CHANNEL.index(), val);
@@ -262,7 +262,7 @@ impl<'d, T: Instance, Tx> DacCh1<'d, T, Tx> {
 
         // Configure each activated channel. All results can be `unwrap`ed since they
         // will only error if the channel is not configured (i.e. ch1, ch2 are false)
-        #[cfg(dac_v2)]
+        #[cfg(any(dac_v2, dac_v3))]
         dac.set_channel_mode(0).unwrap();
         dac.enable_channel().unwrap();
         dac.set_trigger_enable(true).unwrap();
@@ -288,7 +288,6 @@ impl<'d, T: Instance, Tx> DacCh1<'d, T, Tx> {
     /// Note that for performance reasons in circular mode the transfer complete interrupt is disabled.
     ///
     /// **Important:** Channel 1 has to be configured for the DAC instance!
-    #[cfg(all(bdma, not(dma)))] // It currently only works with BDMA-only chips (DMA should theoretically work though)
     pub async fn write(&mut self, data: ValueArray<'_>, circular: bool) -> Result<(), Error>
     where
         Tx: DmaCh1<T>,
@@ -377,7 +376,7 @@ impl<'d, T: Instance, Tx> DacCh2<'d, T, Tx> {
 
         // Configure each activated channel. All results can be `unwrap`ed since they
         // will only error if the channel is not configured (i.e. ch1, ch2 are false)
-        #[cfg(dac_v2)]
+        #[cfg(any(dac_v2, dac_v3))]
         dac.set_channel_mode(0).unwrap();
         dac.enable_channel().unwrap();
         dac.set_trigger_enable(true).unwrap();
@@ -499,7 +498,7 @@ impl<'d, T: Instance, TxCh1, TxCh2> Dac<'d, T, TxCh1, TxCh2> {
 
         // Configure each activated channel. All results can be `unwrap`ed since they
         // will only error if the channel is not configured (i.e. ch1, ch2 are false)
-        #[cfg(dac_v2)]
+        #[cfg(any(dac_v2, dac_v3))]
         dac_ch1.set_channel_mode(0).unwrap();
         dac_ch1.enable_channel().unwrap();
         dac_ch1.set_trigger_enable(true).unwrap();

--- a/embassy-stm32/src/dac/mod.rs
+++ b/embassy-stm32/src/dac/mod.rs
@@ -38,11 +38,30 @@ impl Channel {
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
 /// Trigger sources for CH1
 pub enum Ch1Trigger {
-    Tim6,
-    Tim3,
-    Tim7,
-    Tim15,
+    #[cfg(dac_v3)]
+    Tim1,
     Tim2,
+    #[cfg(not(dac_v2))]
+    Tim3,
+    #[cfg(dac_v3)]
+    Tim4,
+    #[cfg(dac_v3)]
+    Tim5,
+    Tim6,
+    Tim7,
+    #[cfg(dac_v3)]
+    Tim8,
+    Tim15,
+    #[cfg(dac_v3)]
+    Hrtim1Dactrg1,
+    #[cfg(dac_v3)]
+    Hrtim1Dactrg2,
+    #[cfg(dac_v3)]
+    Lptim1,
+    #[cfg(dac_v3)]
+    Lptim2,
+    #[cfg(dac_v3)]
+    Lptim3,
     Exti9,
     Software,
 }
@@ -50,11 +69,30 @@ pub enum Ch1Trigger {
 impl Ch1Trigger {
     fn tsel(&self) -> dac::vals::Tsel1 {
         match self {
-            Ch1Trigger::Tim6 => dac::vals::Tsel1::TIM6_TRGO,
-            Ch1Trigger::Tim3 => dac::vals::Tsel1::TIM3_TRGO,
-            Ch1Trigger::Tim7 => dac::vals::Tsel1::TIM7_TRGO,
-            Ch1Trigger::Tim15 => dac::vals::Tsel1::TIM15_TRGO,
+            #[cfg(dac_v3)]
+            Ch1Trigger::Tim1 => dac::vals::Tsel1::TIM1_TRGO,
             Ch1Trigger::Tim2 => dac::vals::Tsel1::TIM2_TRGO,
+            #[cfg(dac_v2)]
+            Ch1Trigger::Tim3 => dac::vals::Tsel1::TIM3_TRGO,
+            #[cfg(dac_v3)]
+            Ch1Trigger::Tim4 => dac::vals::Tsel1::TIM4_TRGO,
+            #[cfg(dac_v3)]
+            Ch1Trigger::Tim5 => dac::vals::Tsel1::TIM5_TRGO,
+            Ch1Trigger::Tim6 => dac::vals::Tsel1::TIM6_TRGO,
+            Ch1Trigger::Tim7 => dac::vals::Tsel1::TIM7_TRGO,
+            #[cfg(dac_v3)]
+            Ch1Trigger::Tim8 => dac::vals::Tsel1::TIM8_TRGO,
+            Ch1Trigger::Tim15 => dac::vals::Tsel1::TIM15_TRGO,
+            #[cfg(dac_v3)]
+            Ch1Trigger::Hrtim1Dactrg1 => dac::vals::Tsel1::HRTIM1_DACTRG1,
+            #[cfg(dac_v3)]
+            Ch1Trigger::Hrtim1Dactrg2 => dac::vals::Tsel1::HRTIM1_DACTRG2,
+            #[cfg(dac_v3)]
+            Ch1Trigger::Lptim1 => dac::vals::Tsel1::LPTIM1_OUT,
+            #[cfg(dac_v3)]
+            Ch1Trigger::Lptim2 => dac::vals::Tsel1::LPTIM2_OUT,
+            #[cfg(dac_v3)]
+            Ch1Trigger::Lptim3 => dac::vals::Tsel1::LPTIM3_OUT,
             Ch1Trigger::Exti9 => dac::vals::Tsel1::EXTI9,
             Ch1Trigger::Software => dac::vals::Tsel1::SOFTWARE,
         }
@@ -363,7 +401,6 @@ impl<'d, T: Instance, Tx> DacCh2<'d, T, Tx> {
     /// Note that for performance reasons in circular mode the transfer complete interrupt is disabled.
     ///
     /// **Important:** Channel 2 has to be configured for the DAC instance!
-    #[cfg(all(bdma, not(dma)))] // It currently only works with BDMA-only chips (DMA should theoretically work though)
     pub async fn write(&mut self, data: ValueArray<'_>, circular: bool) -> Result<(), Error>
     where
         Tx: DmaCh2<T>,
@@ -467,7 +504,7 @@ impl<'d, T: Instance, TxCh1, TxCh2> Dac<'d, T, TxCh1, TxCh2> {
         dac_ch1.enable_channel().unwrap();
         dac_ch1.set_trigger_enable(true).unwrap();
 
-        #[cfg(dac_v2)]
+        #[cfg(any(dac_v2, dac_v3))]
         dac_ch2.set_channel_mode(0).unwrap();
         dac_ch2.enable_channel().unwrap();
         dac_ch2.set_trigger_enable(true).unwrap();

--- a/embassy-stm32/src/sdmmc/mod.rs
+++ b/embassy-stm32/src/sdmmc/mod.rs
@@ -225,6 +225,9 @@ const DMA_TRANSFER_OPTIONS: crate::dma::TransferOptions = crate::dma::TransferOp
     mburst: crate::dma::Burst::Incr4,
     flow_ctrl: crate::dma::FlowControl::Peripheral,
     fifo_threshold: Some(crate::dma::FifoThreshold::Full),
+    circular: false,
+    half_transfer_ir: false,
+    complete_transfer_ir: true,
 };
 #[cfg(all(sdmmc_v1, not(dma)))]
 const DMA_TRANSFER_OPTIONS: crate::dma::TransferOptions = crate::dma::TransferOptions {


### PR DESCRIPTION
Based on the PRs https://github.com/embassy-rs/embassy/pull/1676 and https://github.com/embassy-rs/embassy/pull/1677, this adds DAC v3 (available in stm32-metapac v13, https://github.com/embassy-rs/stm32-data/pull/223) for the STM32H7 and some others that previously had no support for DMA in the DAC implementation.