### PR TITLE
Add a STM32/DMARingBuffer::read_exact helper

### DIFF
--- a/embassy-stm32/src/dma/bdma.rs
+++ b/embassy-stm32/src/dma/bdma.rs
@@ -466,13 +466,51 @@ impl<'a, C: Channel, W: Word> RingBuffer<'a, C, W> {
         self.ringbuf.clear(DmaCtrlImpl(self.channel.reborrow()));
     }
 
-    /// Read bytes from the ring buffer
+    /// Read elements from the ring buffer
     /// Return a tuple of the length read and the length remaining in the buffer
-    /// If not all of the bytes were read, then there will be some bytes in the buffer remaining
-    /// The length remaining is the capacity, ring_buf.len(), less the bytes remaining after the read
+    /// If not all of the elements were read, then there will be some elements in the buffer remaining
+    /// The length remaining is the capacity, ring_buf.len(), less the elements remaining after the read
     /// OverrunError is returned if the portion to be read was overwritten by the DMA controller.
     pub fn read(&mut self, buf: &mut [W]) -> Result<(usize, usize), OverrunError> {
         self.ringbuf.read(DmaCtrlImpl(self.channel.reborrow()), buf)
+    }
+
+    /// Read an exact number of elements from the ringbuffer.
+    ///
+    /// Returns the remaining number of elements available for immediate reading.
+    /// OverrunError is returned if the portion to be read was overwritten by the DMA controller.
+    ///
+    /// Async/Wake Behavior:
+    /// The underlying DMA peripheral only can wake us when its buffer pointer has reached the halfway point,
+    /// and when it wraps around. This means that when called with a buffer of length 'M', when this
+    /// ring buffer was created with a buffer of size 'N':
+    /// - If M equals N/2 or N/2 divides evenly into M, this function will return every N/2 elements read on the DMA source.
+    /// - Otherwise, this function may need up to N/2 extra elements to arrive before returning.
+    pub async fn read_exact(&mut self, buffer: &mut [W]) -> Result<usize, OverrunError> {
+        use core::future::poll_fn;
+        use core::sync::atomic::compiler_fence;
+
+        let mut read_data = 0;
+        let buffer_len = buffer.len();
+
+        poll_fn(|cx| {
+            self.set_waker(cx.waker());
+
+            compiler_fence(Ordering::SeqCst);
+
+            match self.read(&mut buffer[read_data..buffer_len]) {
+                Ok((len, remaining)) => {
+                    read_data += len;
+                    if read_data == buffer_len {
+                        Poll::Ready(Ok(remaining))
+                    } else {
+                        Poll::Pending
+                    }
+                }
+                Err(e) => Poll::Ready(Err(e)),
+            }
+        })
+        .await
     }
 
     /// The capacity of the ringbuffer

--- a/embassy-stm32/src/dma/dma.rs
+++ b/embassy-stm32/src/dma/dma.rs
@@ -696,13 +696,51 @@ impl<'a, C: Channel, W: Word> RingBuffer<'a, C, W> {
         self.ringbuf.clear(DmaCtrlImpl(self.channel.reborrow()));
     }
 
-    /// Read bytes from the ring buffer
+    /// Read elements from the ring buffer
     /// Return a tuple of the length read and the length remaining in the buffer
-    /// If not all of the bytes were read, then there will be some bytes in the buffer remaining
-    /// The length remaining is the capacity, ring_buf.len(), less the bytes remaining after the read
+    /// If not all of the elements were read, then there will be some elements in the buffer remaining
+    /// The length remaining is the capacity, ring_buf.len(), less the elements remaining after the read
     /// OverrunError is returned if the portion to be read was overwritten by the DMA controller.
     pub fn read(&mut self, buf: &mut [W]) -> Result<(usize, usize), OverrunError> {
         self.ringbuf.read(DmaCtrlImpl(self.channel.reborrow()), buf)
+    }
+
+    /// Read an exact number of elements from the ringbuffer.
+    ///
+    /// Returns the remaining number of elements available for immediate reading.
+    /// OverrunError is returned if the portion to be read was overwritten by the DMA controller.
+    ///
+    /// Async/Wake Behavior:
+    /// The underlying DMA peripheral only can wake us when its buffer pointer has reached the halfway point,
+    /// and when it wraps around. This means that when called with a buffer of length 'M', when this
+    /// ring buffer was created with a buffer of size 'N':
+    /// - If M equals N/2 or N/2 divides evenly into M, this function will return every N/2 elements read on the DMA source.
+    /// - Otherwise, this function may need up to N/2 extra elements to arrive before returning.
+    pub async fn read_exact(&mut self, buffer: &mut [W]) -> Result<usize, OverrunError> {
+        use core::future::poll_fn;
+        use core::sync::atomic::compiler_fence;
+
+        let mut read_data = 0;
+        let buffer_len = buffer.len();
+
+        poll_fn(|cx| {
+            self.set_waker(cx.waker());
+
+            compiler_fence(Ordering::SeqCst);
+
+            match self.read(&mut buffer[read_data..buffer_len]) {
+                Ok((len, remaining)) => {
+                    read_data += len;
+                    if read_data == buffer_len {
+                        Poll::Ready(Ok(remaining))
+                    } else {
+                        Poll::Pending
+                    }
+                }
+                Err(e) => Poll::Ready(Err(e)),
+            }
+        })
+        .await
     }
 
     // The capacity of the ringbuffer

--- a/embassy-stm32/src/dma/ringbuffer.rs
+++ b/embassy-stm32/src/dma/ringbuffer.rs
@@ -72,10 +72,10 @@ impl<'a, W: Word> DmaRingBuffer<'a, W> {
         self.cap() - remaining_transfers
     }
 
-    /// Read bytes from the ring buffer
+    /// Read elements from the ring buffer
     /// Return a tuple of the length read and the length remaining in the buffer
-    /// If not all of the bytes were read, then there will be some bytes in the buffer remaining
-    /// The length remaining is the capacity, ring_buf.len(), less the bytes remaining after the read
+    /// If not all of the elements were read, then there will be some elements in the buffer remaining
+    /// The length remaining is the capacity, ring_buf.len(), less the elements remaining after the read
     /// OverrunError is returned if the portion to be read was overwritten by the DMA controller.
     pub fn read(&mut self, mut dma: impl DmaCtrl, buf: &mut [W]) -> Result<(usize, usize), OverrunError> {
         /*
@@ -95,11 +95,11 @@ impl<'a, W: Word> DmaRingBuffer<'a, W> {
         */
         let end = self.pos(dma.get_remaining_transfers());
         if self.start == end && dma.get_complete_count() == 0 {
-            // No bytes are available in the buffer
+            // No elements are available in the buffer
             Ok((0, self.cap()))
         } else if self.start < end {
             // The available, unread portion in the ring buffer DOES NOT wrap
-            // Copy out the bytes from the dma buffer
+            // Copy out the elements from the dma buffer
             let len = self.copy_to(buf, self.start..end);
 
             compiler_fence(Ordering::SeqCst);
@@ -128,7 +128,7 @@ impl<'a, W: Word> DmaRingBuffer<'a, W> {
             // The DMA writer has wrapped since we last read and is currently
             // writing (or the next byte added will be) in the beginning of the ring buffer.
 
-            // The provided read buffer is not large enough to include all bytes from the tail of the dma buffer.
+            // The provided read buffer is not large enough to include all elements from the tail of the dma buffer.
 
             // Copy out from the dma buffer
             let len = self.copy_to(buf, self.start..self.cap());
@@ -154,8 +154,8 @@ impl<'a, W: Word> DmaRingBuffer<'a, W> {
             // The DMA writer has wrapped since we last read and is currently
             // writing (or the next byte added will be) in the beginning of the ring buffer.
 
-            // The provided read buffer is large enough to include all bytes from the tail of the dma buffer,
-            // so the next read will not have any unread tail bytes in the ring buffer.
+            // The provided read buffer is large enough to include all elements from the tail of the dma buffer,
+            // so the next read will not have any unread tail elements in the ring buffer.
 
             // Copy out from the dma buffer
             let tail = self.copy_to(buf, self.start..self.cap());
@@ -180,7 +180,7 @@ impl<'a, W: Word> DmaRingBuffer<'a, W> {
     }
     /// Copy from the dma buffer at `data_range` into `buf`
     fn copy_to(&mut self, buf: &mut [W], data_range: Range<usize>) -> usize {
-        // Limit the number of bytes that can be copied
+        // Limit the number of elements that can be copied
         let length = usize::min(data_range.len(), buf.len());
 
         // Copy from dma buffer into read buffer


### PR DESCRIPTION
 Add a STM32/DMARingBuffer::read_exact helper

This provides a helper function with an async implementation, that
will only return (or error) when it was able to read that many bytes,
sleeping until ready.

Additionally, corrected the documentation for Ringbuffer functions to use
"elements" instead of "bytes" as the types were already generic over the
word/element size.

This is in reference to #1604.

Adding this helper function is right on the edge of what felt acceptable to me to duplicate, rather than refactor. I'm fine with this being merged as is, but it feels like there's a better way and I'm just not experienced enough to know what is best, especially in a project other people develop and use.
<details>
<summary>Implementation Choices</summary>

I started down the path of refactoring DMA to unify the code, but ran into a number of paths.
Implementation options I can see:
- Duplicate code: Simple to understand and reason about. Bad for maintenance. (Chose this, to open a discussion)
- Add a public DmaRingBuf Trait providing the public API of DmaRingBuf, and implement it by both DMA and BDMA. Additionally have read_exact an async function that is defaulted by the trait: No code duplication. All existing users, both in and out of tree, must bring the trait into scope, which feels odd when most chips only have one available anyway. Required nightly and async_trait.
- DmaRingBuf Trait and DmaRingBufEx with the nightly cfg flag enabled: See above, but this avoids the nightly issue, just even more traits needed.
- Add an Adapter that turns a DmaRingBuf into an DmaRingBufExact (via a method `into_read_exact(self)` or similar). Requires a trait still to use in the bounds of the generic for the helper object: This one feels the most discoverable, and does not require nightly for async_trait, but still has the downsides of turning the API of DmaRingBuffer into a trait.
- Macros?: I know there's macros used for some of this code duplication elsewhere in embassy, but this feels like a bit of a hack, and I'm not sue I know enough to get this right.

I suppose it could also be just the bare minimum of `set_waker` and `read` needed by the trait, and those could be duplicated inside the trait impl, but that seems ugly and confusing ("why do these functions exist twice, which one should I use?")

</details>

I also changed the word choice (after I noticed I was subconsciously doing it too) in the comments for the ringbuffer to substitute 'elements' for 'bytes' as the DMA types are generic over byte/half/word. While the trait bound used for the buffer element is 'Word' I chose to avoid it due to the overloaded meaning of 'word' outside of the context of the DMA peripheral/driver.


<details>
<summary>Why read_exact is a "async fn" not a regular function returning impl Future</summary>
I had originally written this PR in such a way that it was not using an async function, just returning a Future. See this code block:

```rust
pub fn read_exact<'a>(
    &'a mut self,
    buffer: &'a mut [W],
) -> impl core::future::Future<Output = Result<(), OverrunError>> + 'a {
    use core::future::poll_fn;
    use core::sync::atomic::{compiler_fence, Ordering};
    use core::task::Poll;

    let mut read_data = 0;
    let buffer_len = buffer.len();

    poll_fn(move |cx| {
        self.set_waker(cx.waker());

        compiler_fence(Ordering::SeqCst);

        match self.read(&mut buffer[read_data..buffer_len]) {
            Ok((len, _remaining)) => {
                read_data += len;
                if read_data == buffer_len {
                    Poll::Ready(Ok(()))
                } else {
                    Poll::Pending
                }
            }
            Err(e) => Poll::Ready(Err(e)),
        }
    })
}
```
However, while that had worked in my original prototyped testing (in my project I had a wrapper type), when I added it directly to RingBuffer, I ran into several lifetime issues that did not make sense to me, and even as I fixed them locally, then they just extended into the point of use. At least at my current understanding of them, this was a non-starter. I think I was ending up with telling the compiler that the buffer had to outlive the DMA or something.
However, as I went back to my original async fn I had written for my project, I found it worked properly, without any lifetime issues, probably as the created future is definitely consumed internally.

</details>

