### PR TITLE
stm32/can: bxcan async enable

### DIFF
--- a/examples/stm32f4/src/bin/can.rs
+++ b/examples/stm32f4/src/bin/can.rs
@@ -40,10 +40,13 @@ async fn main(_spawner: Spawner) {
 
     can.as_mut()
         .modify_config()
-        .set_bit_timing(0x001c0003) // http://www.bittiming.can-wiki.info/
         .set_loopback(true) // Receive own frames
         .set_silent(true)
-        .enable();
+        .leave_disabled();
+
+    can.set_bitrate(1_000_000);
+
+    can.enable().await;
 
     let mut i: u8 = 0;
     loop {


### PR DESCRIPTION
This PR implements async enable for bxcan.

Using the default enable from bxcan library can lead to infinite loops if there is a hardware problem (i.e. canbus shorted to VCC, or faulty transceiver).

Unfortunatelly, bxcan seems to only have interrupt for entering sleep mode, but not for leaving (SLAK = 0) so I used `yield_now()`.