### PR TITLE
stm32/usart: fix error msg for lptim

### DIFF
--- a/embassy-stm32/src/usart/mod.rs
+++ b/embassy-stm32/src/usart/mod.rs
@@ -857,7 +857,7 @@ fn configure(r: Regs, config: &Config, pclk_freq: Hertz, kind: Kind, enable_rx: 
         "Using {} oversampling, desired baudrate: {}, actual baudrate: {}",
         oversampling,
         config.baudrate,
-        pclk_freq.0 / div
+        (pclk_freq.0 * mul as u32) / div
     );
 
     r.cr2().write(|w| {


### PR DESCRIPTION
I am 80% sure this is the right fix because it correctly outputs the frequency in most cases. However, I don't really understand this code completely at this point, so I may have go this wrong.