### PR TITLE
Decouple embassy-hal-common InterruptExt from cortex-m

### DIFF
--- a/.github/ci/test.sh
+++ b/.github/ci/test.sh
@@ -11,9 +11,9 @@ export CARGO_TARGET_DIR=/ci/cache/target
 hashtime restore /ci/cache/filetime.json || true
 hashtime save /ci/cache/filetime.json
 
-cargo test --manifest-path ./embassy-sync/Cargo.toml 
-cargo test --manifest-path ./embassy-embedded-hal/Cargo.toml 
-cargo test --manifest-path ./embassy-hal-common/Cargo.toml 
+cargo test --manifest-path ./embassy-sync/Cargo.toml
+cargo test --manifest-path ./embassy-embedded-hal/Cargo.toml
+cargo test --manifest-path ./embassy-hal-common/Cargo.toml --features riscv-plic
 cargo test --manifest-path ./embassy-time/Cargo.toml --features generic-queue
 
 cargo test --manifest-path ./embassy-boot/boot/Cargo.toml

--- a/embassy-hal-common/Cargo.toml
+++ b/embassy-hal-common/Cargo.toml
@@ -18,6 +18,7 @@ prio-bits-7 = []
 prio-bits-8 = []
 
 cortex-m = ["dep:cortex-m", "dep:critical-section"]
+riscv-plic = ["riscv/plic", "prio-bits-2"]
 
 [dependencies]
 defmt = { version = "0.3", optional = true }
@@ -27,3 +28,7 @@ num-traits = { version = "0.2.14", default-features = false }
 
 cortex-m = { version = "0.7.6", optional = true }
 critical-section = { version = "1", optional = true }
+riscv = { git = "https://github.com/rust-embedded/riscv.git", optional = true }
+
+[dev-dependencies]
+rstest = "0.18.1"

--- a/embassy-hal-common/src/interrupt.rs
+++ b/embassy-hal-common/src/interrupt.rs
@@ -926,6 +926,7 @@ mod riscv_plic {
     mod tests {
         use riscv::peripheral::plic::PriorityNumber;
         use rstest::rstest;
+        
         use crate::interrupt::Priority;
 
         #[rstest]

--- a/embassy-hal-common/src/interrupt.rs
+++ b/embassy-hal-common/src/interrupt.rs
@@ -926,7 +926,7 @@ mod riscv_plic {
     mod tests {
         use riscv::peripheral::plic::PriorityNumber;
         use rstest::rstest;
-        
+
         use crate::interrupt::Priority;
 
         #[rstest]

--- a/embassy-hal-common/src/lib.rs
+++ b/embassy-hal-common/src/lib.rs
@@ -1,4 +1,4 @@
-#![no_std]
+#![cfg_attr(not(test), no_std)]
 #![allow(clippy::new_without_default)]
 
 // This mod MUST go first, so that the others see its macros.
@@ -11,6 +11,4 @@ mod peripheral;
 pub mod ratio;
 pub mod ring_buffer;
 pub use peripheral::{Peripheral, PeripheralRef};
-
-#[cfg(feature = "cortex-m")]
 pub mod interrupt;

--- a/tests/riscv32/Cargo.toml
+++ b/tests/riscv32/Cargo.toml
@@ -5,15 +5,14 @@ version = "0.1.0"
 license = "MIT OR Apache-2.0"
 
 [dependencies]
-critical-section = { version = "1.1.1", features = ["restore-state-bool"] }
 embassy-sync = { version = "0.2.0", path = "../../embassy-sync" }
 embassy-executor = { version = "0.2.0", path = "../../embassy-executor", features = ["arch-riscv32", "nightly", "executor-thread"] }
 embassy-time = { version = "0.1.2", path = "../../embassy-time" }
 embassy-futures = { version = "0.1.0", path = "../../embassy-futures" }
+embassy-hal-common = { path = "../../embassy-hal-common", features = ["riscv-plic", "prio-bits-2"] }
 
-riscv-rt = "0.11"
-riscv = { version = "0.10", features = ["critical-section-single-hart"] }
-
+riscv-rt = "0.11.0"
+riscv = { git = "https://github.com/rust-embedded/riscv.git", features = ["critical-section-single-hart", "plic"] }
 
 [profile.dev]
 debug = 2

--- a/tests/riscv32/src/bin/empty.rs
+++ b/tests/riscv32/src/bin/empty.rs
@@ -4,6 +4,78 @@
 
 use embassy_executor::Spawner;
 
+use crate::pac::PLIC;
+
+mod pac {
+    use embassy_hal_common::interrupt::Priority;
+
+    // PLIC context at 0xc00_0000.
+    riscv::plic_context!(PLIC, 0xc00_0000, 0, Interrupt, Priority);
+
+    unsafe impl embassy_hal_common::interrupt::InterruptExt for Interrupt {
+        unsafe fn enable(self) {
+            let mut plic: PLIC = core::mem::transmute(());
+            plic.enable_interrupt(self)
+        }
+
+        fn disable(self) {
+            unsafe {
+                let mut plic: PLIC = core::mem::transmute(());
+                plic.disable_interrupt(self)
+            }
+        }
+
+        fn is_enabled(self) -> bool {
+            PLIC::is_interrupt_enabled(self)
+        }
+
+        fn is_pending(self) -> bool {
+            PLIC::is_interrupt_pending(self)
+        }
+
+        fn pend(self) {
+            todo!()
+        }
+
+        fn unpend(self) {
+            todo!()
+        }
+
+        fn get_priority(self) -> Priority {
+            PLIC::priority(self)
+        }
+
+        fn set_priority(self, prio: Priority) {
+            unsafe {
+                let mut plic: PLIC = core::mem::transmute(());
+                plic.set_priority(self, prio);
+            }
+        }
+    }
+
+    #[derive(Copy, Clone)]
+    pub enum Interrupt {
+        INT0,
+    }
+
+    unsafe impl riscv::peripheral::plic::InterruptNumber for Interrupt {
+        const MAX_INTERRUPT_NUMBER: u16 = 1;
+
+        fn number(self) -> u16 {
+            1
+        }
+
+        fn try_from(value: u16) -> Result<Self, u16> {
+            match value {
+                1 => Ok(Interrupt::INT0),
+                v => Err(v),
+            }
+        }
+    }
+}
+
+embassy_hal_common::interrupt_mod_core!(INT0);
+
 #[panic_handler]
 fn panic(_info: &core::panic::PanicInfo) -> ! {
     loop {}
@@ -11,6 +83,29 @@ fn panic(_info: &core::panic::PanicInfo) -> ! {
 
 #[embassy_executor::main]
 async fn main(_spawner: Spawner) {
+    use embassy_hal_common::interrupt::{InterruptExt, Priority};
+
+    use crate::interrupt::INT0;
+
+    // Example, running not recommended.
+    unsafe { INT0.enable() };
+    INT0.disable();
+    let _ = INT0.get_priority();
+    // `P0` is the highest priority.
+    INT0.set_priority(Priority::P0);
+
+    unsafe {
+        let mut plic: PLIC = core::mem::transmute(());
+        plic.set_threshold(Priority::P3);
+    };
+
+    unsafe {
+        // Enable all interrupts in the current Hart.
+        riscv::interrupt::enable();
+        // Enable all interrupts in the PLIC.
+        PLIC::enable();
+    };
+
     // Don't do anything, just make sure it compiles.
     loop {}
 }


### PR DESCRIPTION
Decouples `embassy_hal_common::interrupt` from Cortex-M and Cortex-M dependencies, allowing implementations of `embassy_hal_common::interrupt::InterruptExt` for non-NVIC interrupt controllers (PLIC, CLIC, GIC, ...). Adds a sample implementation for the RISC-V PLIC from the [riscv crate](https://github.com/rust-embedded/riscv).

There are a couple of things to highlight:

- The example depends unreleased features in the [riscv crate](https://github.com/rust-embedded/riscv), and it looks like the PLIC implementation is in flux.
- Not all interrupt controllers have feature parity.  For example, a PLIC cannot pend/unpend interrupts.  `InterruptExt` is unopinionated about how to handle such feature gaps in interrupt controller implementations.  The RISC-V PLIC also supports a priority threshold.
- Interrupt priorities are inverted from the NVIC as noted in the implementation.
- Implementation currently only supports `embassy-hal-common/prio-bits-2`.

Nonetheless this begins to decouple the `InterruptExt` abstraction from the NVIC, allow of non-NVIC implementations, and maintains backwards compatibility.