### PR TITLE
Added debug=2 in release profile to all examples.

### DIFF
--- a/examples/nrf-rtos-trace/Cargo.toml
+++ b/examples/nrf-rtos-trace/Cargo.toml
@@ -34,3 +34,6 @@ log = { version = "0.4.17", optional = true }
 [[bin]]
 name = "rtos_trace"
 required-features = ["nightly"]
+
+[profile.release]
+debug = 2

--- a/examples/nrf52840-rtic/Cargo.toml
+++ b/examples/nrf52840-rtic/Cargo.toml
@@ -19,3 +19,6 @@ cortex-m = { version = "0.7.6", features = ["inline-asm", "critical-section-sing
 cortex-m-rt = "0.7.0"
 panic-probe = { version = "0.3", features = ["print-defmt"] }
 futures = { version = "0.3.17", default-features = false, features = ["async-await"] }
+
+[profile.release]
+debug = 2

--- a/examples/nrf52840/Cargo.toml
+++ b/examples/nrf52840/Cargo.toml
@@ -59,3 +59,6 @@ microfft = "0.5.0"
 
 [patch.crates-io]
 lora-phy = { git = "https://github.com/embassy-rs/lora-phy", rev = "ad289428fd44b02788e2fa2116445cc8f640a265" }
+
+[profile.release]
+debug = 2

--- a/examples/nrf5340/Cargo.toml
+++ b/examples/nrf5340/Cargo.toml
@@ -53,3 +53,6 @@ rand = { version = "0.8.4", default-features = false }
 embedded-storage = "0.3.0"
 usbd-hid = "0.6.0"
 serde = { version = "1.0.136", default-features = false }
+
+[profile.release]
+debug = 2

--- a/examples/rp/Cargo.toml
+++ b/examples/rp/Cargo.toml
@@ -53,7 +53,8 @@ pio = "0.2.1"
 rand = { version = "0.8.5", default-features = false }
 
 [profile.release]
-debug = true
+debug = 2
 
 [patch.crates-io]
 lora-phy = { git = "https://github.com/embassy-rs/lora-phy", rev = "ad289428fd44b02788e2fa2116445cc8f640a265" }
+

--- a/examples/std/Cargo.toml
+++ b/examples/std/Cargo.toml
@@ -23,3 +23,6 @@ clap = { version = "3.0.0-beta.5", features = ["derive"] }
 rand_core = { version = "0.6.3", features = ["std"] }
 heapless = { version = "0.7.5", default-features = false }
 static_cell = { version = "1.1", features = ["nightly"]}
+
+[profile.release]
+debug = 2

--- a/examples/stm32c0/Cargo.toml
+++ b/examples/stm32c0/Cargo.toml
@@ -20,3 +20,6 @@ embedded-hal = "0.2.6"
 panic-probe = { version = "0.3", features = ["print-defmt"] }
 futures = { version = "0.3.17", default-features = false, features = ["async-await"] }
 heapless = { version = "0.7.5", default-features = false }
+
+[profile.release]
+debug = 2

--- a/examples/stm32f0/Cargo.toml
+++ b/examples/stm32f0/Cargo.toml
@@ -18,3 +18,6 @@ embassy-sync = { version = "0.2.0", path = "../../embassy-sync", features = ["de
 embassy-executor = { version = "0.2.0", path = "../../embassy-executor", features = ["nightly", "arch-cortex-m", "executor-thread", "executor-interrupt", "defmt", "integrated-timers"] }
 embassy-time = { version = "0.1.2", path = "../../embassy-time", features = ["defmt", "defmt-timestamp-uptime", "tick-hz-32_768"] }
 static_cell = { version = "1.1", features = ["nightly"]}
+
+[profile.release]
+debug = 2

--- a/examples/stm32f1/Cargo.toml
+++ b/examples/stm32f1/Cargo.toml
@@ -26,3 +26,6 @@ nb = "1.0.0"
 
 [profile.dev]
 opt-level = "s"
+
+[profile.release]
+debug = 2

--- a/examples/stm32f2/Cargo.toml
+++ b/examples/stm32f2/Cargo.toml
@@ -21,3 +21,6 @@ panic-probe = { version = "0.3", features = ["print-defmt"] }
 futures = { version = "0.3.17", default-features = false, features = ["async-await"] }
 heapless = { version = "0.7.5", default-features = false }
 nb = "1.0.0"
+
+[profile.release]
+debug = 2

--- a/examples/stm32f3/Cargo.toml
+++ b/examples/stm32f3/Cargo.toml
@@ -25,3 +25,6 @@ heapless = { version = "0.7.5", default-features = false }
 nb = "1.0.0"
 embedded-storage = "0.3.0"
 static_cell = { version = "1.1", features = ["nightly"]}
+
+[profile.release]
+debug = 2

--- a/examples/stm32f7/Cargo.toml
+++ b/examples/stm32f7/Cargo.toml
@@ -28,3 +28,6 @@ rand_core = "0.6.3"
 critical-section = "1.1"
 embedded-storage = "0.3.0"
 static_cell = { version = "1.1", features = ["nightly"]}
+
+[profile.release]
+debug = 2

--- a/examples/stm32g0/Cargo.toml
+++ b/examples/stm32g0/Cargo.toml
@@ -20,3 +20,6 @@ embedded-hal = "0.2.6"
 panic-probe = { version = "0.3", features = ["print-defmt"] }
 futures = { version = "0.3.17", default-features = false, features = ["async-await"] }
 heapless = { version = "0.7.5", default-features = false }
+
+[profile.release]
+debug = 2

--- a/examples/stm32g4/Cargo.toml
+++ b/examples/stm32g4/Cargo.toml
@@ -22,3 +22,6 @@ embedded-hal = "0.2.6"
 panic-probe = { version = "0.3", features = ["print-defmt"] }
 futures = { version = "0.3.17", default-features = false, features = ["async-await"] }
 heapless = { version = "0.7.5", default-features = false }
+
+[profile.release]
+debug = 2

--- a/examples/stm32l0/Cargo.toml
+++ b/examples/stm32l0/Cargo.toml
@@ -36,3 +36,6 @@ static_cell = "1.1"
 
 [patch.crates-io]
 lora-phy = { git = "https://github.com/embassy-rs/lora-phy", rev = "ad289428fd44b02788e2fa2116445cc8f640a265" }
+
+[profile.release]
+debug = 2

--- a/examples/stm32l1/Cargo.toml
+++ b/examples/stm32l1/Cargo.toml
@@ -20,3 +20,6 @@ panic-probe = { version = "0.3", features = ["print-defmt"] }
 futures = { version = "0.3.17", default-features = false, features = ["async-await"] }
 heapless = { version = "0.7.5", default-features = false }
 embedded-storage = "0.3.0"
+
+[profile.release]
+debug = 2

--- a/examples/stm32l4/Cargo.toml
+++ b/examples/stm32l4/Cargo.toml
@@ -27,3 +27,6 @@ heapless = { version = "0.7.5", default-features = false }
 chrono = { version = "^0.4", default-features = false }
 
 micromath = "2.0.0"
+
+[profile.release]
+debug = 2

--- a/examples/stm32l5/Cargo.toml
+++ b/examples/stm32l5/Cargo.toml
@@ -27,3 +27,6 @@ heapless = { version = "0.7.5", default-features = false }
 rand_core = { version = "0.6.3", default-features = false }
 embedded-io = { version = "0.4.0", features = ["async"] }
 static_cell = { version = "1.1", features = ["nightly"]}
+
+[profile.release]
+debug = 2

--- a/examples/stm32u5/Cargo.toml
+++ b/examples/stm32u5/Cargo.toml
@@ -23,3 +23,6 @@ futures = { version = "0.3.17", default-features = false, features = ["async-awa
 heapless = { version = "0.7.5", default-features = false }
 
 micromath = "2.0.0"
+
+[profile.release]
+debug = 2

--- a/examples/stm32wb/Cargo.toml
+++ b/examples/stm32wb/Cargo.toml
@@ -52,3 +52,6 @@ required-features = ["ble"]
 [[bin]] 
 name = "gatt_server"
 required-features = ["ble"]
+
+[profile.release]
+debug = 2

--- a/examples/stm32wl/Cargo.toml
+++ b/examples/stm32wl/Cargo.toml
@@ -30,3 +30,6 @@ chrono = { version = "^0.4", default-features = false }
 
 [patch.crates-io]
 lora-phy = { git = "https://github.com/embassy-rs/lora-phy", rev = "ad289428fd44b02788e2fa2116445cc8f640a265" }
+
+[profile.release]
+debug = 2

--- a/examples/wasm/Cargo.toml
+++ b/examples/wasm/Cargo.toml
@@ -17,3 +17,6 @@ wasm-bindgen = "0.2"
 web-sys = { version = "0.3", features = ["Document", "Element", "HtmlElement", "Node", "Window" ] }
 log = "0.4.11"
 critical-section = { version = "1.1", features = ["std"] }
+
+[profile.release]
+debug = 2


### PR DESCRIPTION
This makes rtt output work right when using `cargo run` in release mode.

Debug was already enabled for release builds in some of the examples but not all.