### PR TITLE
Use lora-phy v1.2.1; modify embassy-lora dependencies

### DIFF
--- a/embassy-lora/Cargo.toml
+++ b/embassy-lora/Cargo.toml
@@ -12,7 +12,7 @@ target = "thumbv7em-none-eabi"
 
 [features]
 stm32wl = ["dep:embassy-stm32"]
-time = []
+time = ["dep:embassy-time", "dep:lorawan-device"]
 defmt = ["dep:defmt", "lorawan-device/defmt"]
 
 [dependencies]
@@ -20,18 +20,11 @@ defmt = ["dep:defmt", "lorawan-device/defmt"]
 defmt = { version = "0.3", optional = true }
 log = { version = "0.4.14", optional = true }
 
-embassy-time = { version = "0.1.2", path = "../embassy-time" }
+embassy-time = { version = "0.1.2", path = "../embassy-time", optional = true }
 embassy-sync = { version = "0.2.0", path = "../embassy-sync" }
 embassy-stm32 = { version = "0.1.0", path = "../embassy-stm32", default-features = false, optional = true }
-embedded-hal-1 = { package = "embedded-hal", version = "=1.0.0-alpha.11" }
 embedded-hal-async = { version = "=0.2.0-alpha.2" }
-embassy-hal-common = { version = "0.1.0", path = "../embassy-hal-common", default-features = false }
-futures = { version = "0.3.17", default-features = false, features = [ "async-await" ] }
 embedded-hal = { version = "0.2", features = ["unproven"] }
-bit_field = { version = "0.10" }
 
 lora-phy = { version = "1" }
-lorawan-device = { version = "0.10.0", default-features = false, features = ["async"] }
-
-[patch.crates-io]
-lora-phy = { git = "https://github.com/embassy-rs/lora-phy", rev = "ad289428fd44b02788e2fa2116445cc8f640a265" }
+lorawan-device = { version = "0.10.0", default-features = false, features = ["async"], optional = true }

--- a/embassy-lora/Cargo.toml
+++ b/embassy-lora/Cargo.toml
@@ -12,7 +12,7 @@ target = "thumbv7em-none-eabi"
 
 [features]
 stm32wl = ["dep:embassy-stm32"]
-time = ["dep:embassy-time", "dep:lorawan-device"]
+time = ["embassy-time", "lorawan-device"]
 defmt = ["dep:defmt", "lorawan-device/defmt"]
 
 [dependencies]

--- a/examples/nrf52840/Cargo.toml
+++ b/examples/nrf52840/Cargo.toml
@@ -56,6 +56,3 @@ serde = { version = "1.0.136", default-features = false }
 embedded-hal-async = { version = "0.2.0-alpha.2", optional = true }
 num-integer = { version = "0.1.45", default-features = false }
 microfft = "0.5.0"
-
-[patch.crates-io]
-lora-phy = { git = "https://github.com/embassy-rs/lora-phy", rev = "ad289428fd44b02788e2fa2116445cc8f640a265" }

--- a/examples/rp/Cargo.toml
+++ b/examples/rp/Cargo.toml
@@ -54,6 +54,3 @@ rand = { version = "0.8.5", default-features = false }
 
 [profile.release]
 debug = true
-
-[patch.crates-io]
-lora-phy = { git = "https://github.com/embassy-rs/lora-phy", rev = "ad289428fd44b02788e2fa2116445cc8f640a265" }

--- a/examples/stm32l0/Cargo.toml
+++ b/examples/stm32l0/Cargo.toml
@@ -33,6 +33,3 @@ futures = { version = "0.3.17", default-features = false, features = ["async-awa
 heapless = { version = "0.7.5", default-features = false }
 embedded-hal = "0.2.6"
 static_cell = "1.1"
-
-[patch.crates-io]
-lora-phy = { git = "https://github.com/embassy-rs/lora-phy", rev = "ad289428fd44b02788e2fa2116445cc8f640a265" }

--- a/examples/stm32wl/Cargo.toml
+++ b/examples/stm32wl/Cargo.toml
@@ -27,6 +27,3 @@ panic-probe = { version = "0.3", features = ["print-defmt"] }
 futures = { version = "0.3.17", default-features = false, features = ["async-await"] }
 heapless = { version = "0.7.5", default-features = false }
 chrono = { version = "^0.4", default-features = false }
-
-[patch.crates-io]
-lora-phy = { git = "https://github.com/embassy-rs/lora-phy", rev = "ad289428fd44b02788e2fa2116445cc8f640a265" }


### PR DESCRIPTION
Use lora-phy v1.2.1 rather than a patch.

Remove unnecessary dependencies for embassy-lora.

Place the embassy-lora dependency on rust-lorawan behind the time feature so that users of embassy-lora have the option to not pull in rust-lorawan.