### PR TITLE
Expose IEEE802.15.4 address in Driver

### DIFF
--- a/ci.sh
+++ b/ci.sh
@@ -36,6 +36,9 @@ cargo batch  \
     --- build --release --manifest-path embassy-net/Cargo.toml --target thumbv7em-none-eabi --features defmt,tcp,udp,dns,proto-ipv4,proto-ipv6,medium-ethernet,unstable-traits \
     --- build --release --manifest-path embassy-net/Cargo.toml --target thumbv7em-none-eabi --features defmt,tcp,udp,dns,proto-ipv4,proto-ipv6,medium-ethernet,nightly \
     --- build --release --manifest-path embassy-net/Cargo.toml --target thumbv7em-none-eabi --features defmt,tcp,udp,dns,proto-ipv4,proto-ipv6,medium-ethernet,unstable-traits,nightly \
+    --- build --release --manifest-path embassy-net/Cargo.toml --target thumbv7em-none-eabi --features defmt,tcp,udp,dns,proto-ipv4,proto-ipv6,medium-ip,unstable-traits,nightly \
+    --- build --release --manifest-path embassy-net/Cargo.toml --target thumbv7em-none-eabi --features defmt,tcp,udp,dns,proto-ipv4,proto-ipv6,medium-ip,medium-ethernet,unstable-traits,nightly \
+    --- build --release --manifest-path embassy-net/Cargo.toml --target thumbv7em-none-eabi --features defmt,tcp,udp,dns,proto-ipv4,proto-ipv6,medium-ip,medium-ethernet,medium-ieee802154,unstable-traits,nightly \
     --- build --release --manifest-path embassy-nrf/Cargo.toml --target thumbv7em-none-eabi --features nightly,nrf52805,gpiote,time-driver-rtc1 \
     --- build --release --manifest-path embassy-nrf/Cargo.toml --target thumbv7em-none-eabi --features nightly,nrf52810,gpiote,time-driver-rtc1 \
     --- build --release --manifest-path embassy-nrf/Cargo.toml --target thumbv7em-none-eabi --features nightly,nrf52811,gpiote,time-driver-rtc1 \

--- a/cyw43/src/lib.rs
+++ b/cyw43/src/lib.rs
@@ -216,7 +216,7 @@ where
     PWR: OutputPin,
     SPI: SpiBusCyw43,
 {
-    let (ch_runner, device) = ch::new(&mut state.ch, [0; 6]);
+    let (ch_runner, device) = ch::new(&mut state.ch, ch::driver::HardwareAddress::Ethernet([0; 6]));
     let state_ch = ch_runner.state_runner();
 
     let mut runner = Runner::new(ch_runner, Bus::new(pwr, spi), &state.ioctl_state, &state.events);

--- a/embassy-net-driver-channel/src/lib.rs
+++ b/embassy-net-driver-channel/src/lib.rs
@@ -42,7 +42,7 @@ struct StateInner<'d, const MTU: usize> {
 struct Shared {
     link_state: LinkState,
     waker: WakerRegistration,
-    hardware_address: HardwareAddress,
+    hardware_address: driver::HardwareAddress,
 }
 
 pub struct Runner<'d, const MTU: usize> {
@@ -85,7 +85,7 @@ impl<'d, const MTU: usize> Runner<'d, MTU> {
         });
     }
 
-    pub fn set_hardware_address(&mut self, address: HardwareAddress) {
+    pub fn set_hardware_address(&mut self, address: driver::HardwareAddress) {
         self.shared.lock(|s| {
             let s = &mut *s.borrow_mut();
             s.hardware_address = address;
@@ -150,7 +150,15 @@ impl<'d> StateRunner<'d> {
     pub fn set_ethernet_address(&self, address: [u8; 6]) {
         self.shared.lock(|s| {
             let s = &mut *s.borrow_mut();
-            s.ethernet_address = address;
+            s.hardware_address = driver::HardwareAddress::Ethernet(address);
+            s.waker.wake();
+        });
+    }
+
+    pub fn set_ieee802154_address(&self, address: [u8; 8]) {
+        self.shared.lock(|s| {
+            let s = &mut *s.borrow_mut();
+            s.hardware_address = driver::HardwareAddress::Ieee802154(address);
             s.waker.wake();
         });
     }
@@ -206,8 +214,7 @@ impl<'d, const MTU: usize> TxRunner<'d, MTU> {
 
 pub fn new<'d, const MTU: usize, const N_RX: usize, const N_TX: usize>(
     state: &'d mut State<MTU, N_RX, N_TX>,
-    ethernet_address: [u8; 6],
-    ieee802154_address: [u8; 8],
+    hardware_address: driver::HardwareAddress,
 ) -> (Runner<'d, MTU>, Device<'d, MTU>) {
     let mut caps = Capabilities::default();
     caps.max_transmission_unit = MTU;
@@ -223,8 +230,7 @@ pub fn new<'d, const MTU: usize, const N_RX: usize, const N_TX: usize>(
         tx: zerocopy_channel::Channel::new(&mut state.tx[..]),
         shared: Mutex::new(RefCell::new(Shared {
             link_state: LinkState::Down,
-            ethernet_address,
-            ieee802154_address,
+            hardware_address,
             waker: WakerRegistration::new(),
         })),
     });
@@ -291,7 +297,7 @@ impl<'d, const MTU: usize> embassy_net_driver::Driver for Device<'d, MTU> {
         self.caps.clone()
     }
 
-    fn hardware_address(&self) -> HardwareAddress {
+    fn hardware_address(&self) -> driver::HardwareAddress {
         self.shared.lock(|s| s.borrow().hardware_address)
     }
 

--- a/embassy-net-driver-channel/src/lib.rs
+++ b/embassy-net-driver-channel/src/lib.rs
@@ -42,8 +42,7 @@ struct StateInner<'d, const MTU: usize> {
 struct Shared {
     link_state: LinkState,
     waker: WakerRegistration,
-    ethernet_address: [u8; 6],
-    ieee802154_address: [u8; 8],
+    hardware_address: HardwareAddress,
 }
 
 pub struct Runner<'d, const MTU: usize> {
@@ -86,18 +85,10 @@ impl<'d, const MTU: usize> Runner<'d, MTU> {
         });
     }
 
-    pub fn set_ethernet_address(&mut self, address: [u8; 6]) {
+    pub fn set_hardware_address(&mut self, address: HardwareAddress) {
         self.shared.lock(|s| {
             let s = &mut *s.borrow_mut();
-            s.ethernet_address = address;
-            s.waker.wake();
-        });
-    }
-
-    pub fn set_ieee802154_address(&mut self, address: [u8; 8]) {
-        self.shared.lock(|s| {
-            let s = &mut *s.borrow_mut();
-            s.ieee802154_address = address;
+            s.hardware_address = address;
             s.waker.wake();
         });
     }
@@ -300,12 +291,8 @@ impl<'d, const MTU: usize> embassy_net_driver::Driver for Device<'d, MTU> {
         self.caps.clone()
     }
 
-    fn ethernet_address(&self) -> [u8; 6] {
-        self.shared.lock(|s| s.borrow().ethernet_address)
-    }
-
-    fn ieee802154_address(&self) -> [u8; 8] {
-        self.shared.lock(|s| s.borrow().ieee802154_address)
+    fn hardware_address(&self) -> HardwareAddress {
+        self.shared.lock(|s| s.borrow().hardware_address)
     }
 
     fn link_state(&mut self, cx: &mut Context) -> LinkState {

--- a/embassy-net-driver/Cargo.toml
+++ b/embassy-net-driver/Cargo.toml
@@ -22,4 +22,3 @@ features = ["defmt"]
 
 [dependencies]
 defmt = { version = "0.3", optional = true }
-smoltcp = { version = "0.10", default-features = false }

--- a/embassy-net-driver/Cargo.toml
+++ b/embassy-net-driver/Cargo.toml
@@ -22,3 +22,4 @@ features = ["defmt"]
 
 [dependencies]
 defmt = { version = "0.3", optional = true }
+smoltcp = { version = "0.10", default-features = false }

--- a/embassy-net-driver/src/lib.rs
+++ b/embassy-net-driver/src/lib.rs
@@ -4,7 +4,15 @@
 
 use core::task::Context;
 
-use smoltcp::wire::HardwareAddress;
+/// Representation of an hardware address, such as an Ethernet address or an IEEE802.15.4 address.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+pub enum HardwareAddress {
+    /// A six-octet Ethernet address
+    Ethernet([u8; 6]),
+    /// An eight-octet IEEE802.15.4 address
+    Ieee802154([u8; 8]),
+}
 
 /// Main `embassy-net` driver API.
 ///

--- a/embassy-net-driver/src/lib.rs
+++ b/embassy-net-driver/src/lib.rs
@@ -53,6 +53,9 @@ pub trait Driver {
 
     /// Get the device's Ethernet address.
     fn ethernet_address(&self) -> [u8; 6];
+
+    /// Get the device's IEEE 802.15.4 address.
+    fn ieee802154_address(&self) -> [u8; 8];
 }
 
 impl<T: ?Sized + Driver> Driver for &mut T {
@@ -77,6 +80,9 @@ impl<T: ?Sized + Driver> Driver for &mut T {
     }
     fn ethernet_address(&self) -> [u8; 6] {
         T::ethernet_address(self)
+    }
+    fn ieee802154_address(&self) -> [u8; 8] {
+        T::ieee802154_address(self)
     }
 }
 

--- a/embassy-net-driver/src/lib.rs
+++ b/embassy-net-driver/src/lib.rs
@@ -12,6 +12,8 @@ pub enum HardwareAddress {
     Ethernet([u8; 6]),
     /// An eight-octet IEEE802.15.4 address
     Ieee802154([u8; 8]),
+    /// Indicates that a Driver is IP-native, and has no hardware address
+    Ip,
 }
 
 /// Main `embassy-net` driver API.

--- a/embassy-net-driver/src/lib.rs
+++ b/embassy-net-driver/src/lib.rs
@@ -4,6 +4,8 @@
 
 use core::task::Context;
 
+use smoltcp::wire::HardwareAddress;
+
 /// Main `embassy-net` driver API.
 ///
 /// This is essentially an interface for sending and receiving raw network frames.
@@ -51,11 +53,8 @@ pub trait Driver {
     /// Get a description of device capabilities.
     fn capabilities(&self) -> Capabilities;
 
-    /// Get the device's Ethernet address.
-    fn ethernet_address(&self) -> [u8; 6];
-
-    /// Get the device's IEEE 802.15.4 address.
-    fn ieee802154_address(&self) -> [u8; 8];
+    /// Get the device's hardware address.
+    fn hardware_address(&self) -> HardwareAddress;
 }
 
 impl<T: ?Sized + Driver> Driver for &mut T {
@@ -78,11 +77,8 @@ impl<T: ?Sized + Driver> Driver for &mut T {
     fn link_state(&mut self, cx: &mut Context) -> LinkState {
         T::link_state(self, cx)
     }
-    fn ethernet_address(&self) -> [u8; 6] {
-        T::ethernet_address(self)
-    }
-    fn ieee802154_address(&self) -> [u8; 8] {
-        T::ieee802154_address(self)
+    fn hardware_address(&self) -> HardwareAddress {
+        T::hardware_address(self)
     }
 }
 

--- a/embassy-net-esp-hosted/src/lib.rs
+++ b/embassy-net-esp-hosted/src/lib.rs
@@ -124,7 +124,7 @@ where
     IN: InputPin + Wait,
     OUT: OutputPin,
 {
-    let (ch_runner, device) = ch::new(&mut state.ch, [0; 6]);
+    let (ch_runner, device) = ch::new(&mut state.ch, ch::driver::HardwareAddress::Ethernet([0; 6]));
     let state_ch = ch_runner.state_runner();
 
     let mut runner = Runner {

--- a/embassy-net-w5500/src/lib.rs
+++ b/embassy-net-w5500/src/lib.rs
@@ -96,7 +96,7 @@ pub async fn new<'a, const N_RX: usize, const N_TX: usize, SPI: SpiDevice, INT: 
 
     let mac = W5500::new(spi_dev, mac_addr).await.unwrap();
 
-    let (runner, device) = ch::new(&mut state.ch_state, mac_addr);
+    let (runner, device) = ch::new(&mut state.ch_state, ch::driver::HardwareAddress::Ethernet(mac_addr));
     (
         device,
         Runner {

--- a/embassy-net/src/lib.rs
+++ b/embassy-net/src/lib.rs
@@ -247,7 +247,7 @@ impl<D: Driver + 'static> Stack<D> {
             #[cfg(feature = "medium-ip")]
             Medium::Ip => HardwareAddress::Ip,
             #[cfg(feature = "medium-ieee802154")]
-            Medium::Ieee802154 => HardwareAddress::Ieee802154(Ieee802154Address::Absent),
+            Medium::Ieee802154 => HardwareAddress::Ieee802154(Ieee802154Address::Extended(device.ieee802154_address())),
             #[allow(unreachable_patterns)]
             _ => panic!(
                 "Unsupported medium {:?}. Make sure to enable it in embassy-net's Cargo features.",
@@ -744,6 +744,13 @@ impl<D: Driver + 'static> Inner<D> {
         if self.device.capabilities().medium == Medium::Ethernet {
             s.iface.set_hardware_addr(HardwareAddress::Ethernet(EthernetAddress(
                 self.device.ethernet_address(),
+            )));
+        }
+
+        #[cfg(feature = "medium-ieee802154")]
+        if self.device.capabilities().medium == Medium::Ieee802154 {
+            s.iface.set_hardware_addr(HardwareAddress::Ieee802154(Ieee802154Address::Extended(
+                self.device.ieee802154_address(),
             )));
         }
 

--- a/embassy-net/src/lib.rs
+++ b/embassy-net/src/lib.rs
@@ -236,6 +236,8 @@ fn to_smoltcp_hardware_address(addr: driver::HardwareAddress) -> HardwareAddress
         driver::HardwareAddress::Ethernet(eth) => HardwareAddress::Ethernet(EthernetAddress(eth)),
         #[cfg(feature = "medium-ieee802154")]
         driver::HardwareAddress::Ieee802154(ieee) => HardwareAddress::Ieee802154(Ieee802154Address::Extended(ieee)),
+        #[cfg(feature = "medium-ip")]
+        driver::HardwareAddress::Ip => HardwareAddress::Ip,
 
         #[allow(unreachable_patterns)]
         _ => panic!("Unsupported address {:?}. Make sure to enable medium-ethernet or medium-ieee802154 in embassy-net's Cargo features.", addr),

--- a/embassy-stm32-wpan/src/mac/driver.rs
+++ b/embassy-stm32-wpan/src/mac/driver.rs
@@ -3,7 +3,7 @@
 
 use core::task::Context;
 
-use embassy_net_driver::{Capabilities, LinkState, Medium};
+use embassy_net_driver::{Capabilities, HardwareAddress, LinkState, Medium};
 use embassy_sync::blocking_mutex::raw::CriticalSectionRawMutex;
 use embassy_sync::channel::Channel;
 
@@ -76,7 +76,7 @@ impl<'d> embassy_net_driver::Driver for Driver<'d> {
     fn hardware_address(&self) -> HardwareAddress {
         // self.mac_addr
 
-        HardwareAddress::Ethernet(EthernetAddress([0; 6]))
+        HardwareAddress::Ieee802154([0; 8])
     }
 }
 

--- a/embassy-stm32-wpan/src/mac/driver.rs
+++ b/embassy-stm32-wpan/src/mac/driver.rs
@@ -73,10 +73,10 @@ impl<'d> embassy_net_driver::Driver for Driver<'d> {
         LinkState::Down
     }
 
-    fn ethernet_address(&self) -> [u8; 6] {
+    fn hardware_address(&self) -> HardwareAddress {
         // self.mac_addr
 
-        [0; 6]
+        HardwareAddress::Ethernet(EthernetAddress([0; 6]))
     }
 }
 

--- a/embassy-stm32/src/eth/mod.rs
+++ b/embassy-stm32/src/eth/mod.rs
@@ -8,7 +8,7 @@ pub mod generic_smi;
 use core::mem::MaybeUninit;
 use core::task::Context;
 
-use embassy_net_driver::{Capabilities, LinkState};
+use embassy_net_driver::{Capabilities, HardwareAddress, LinkState};
 use embassy_sync::waitqueue::AtomicWaker;
 
 pub use self::_version::{InterruptHandler, *};
@@ -88,8 +88,8 @@ impl<'d, T: Instance, P: PHY> embassy_net_driver::Driver for Ethernet<'d, T, P> 
         }
     }
 
-    fn ethernet_address(&self) -> [u8; 6] {
-        self.mac_addr
+    fn hardware_address(&self) -> HardwareAddress {
+        HardwareAddress::Ethernet(self.mac_addr)
     }
 }
 

--- a/embassy-usb/src/class/cdc_ncm/embassy_net.rs
+++ b/embassy-usb/src/class/cdc_ncm/embassy_net.rs
@@ -87,7 +87,10 @@ impl<'d, D: Driver<'d>> CdcNcmClass<'d, D> {
         ethernet_address: [u8; 6],
     ) -> (Runner<'d, D, MTU>, Device<'d, MTU>) {
         let (tx_usb, rx_usb) = self.split();
-        let (runner, device) = ch::new(&mut state.ch_state, ethernet_address);
+        let (runner, device) = ch::new(
+            &mut state.ch_state,
+            ch::driver::HardwareAddress::Ethernet(ethernet_address),
+        );
 
         (
             Runner {

--- a/examples/std/src/tuntap.rs
+++ b/examples/std/src/tuntap.rs
@@ -4,8 +4,7 @@ use std::os::unix::io::{AsRawFd, RawFd};
 use std::task::Context;
 
 use async_io::Async;
-use embassy_net::HardwareAddress;
-use embassy_net_driver::{self, Capabilities, Driver, LinkState};
+use embassy_net_driver::{self, Capabilities, Driver, HardwareAddress, LinkState};
 use log::*;
 
 pub const SIOCGIFMTU: libc::c_ulong = 0x8921;
@@ -182,7 +181,7 @@ impl Driver for TunTapDevice {
     }
 
     fn hardware_address(&self) -> HardwareAddress {
-        HardwareAddress::Ethernet(EthernetAddress([0x02, 0x03, 0x04, 0x05, 0x06, 0x07]))
+        HardwareAddress::Ethernet([0x02, 0x03, 0x04, 0x05, 0x06, 0x07])
     }
 }
 

--- a/examples/std/src/tuntap.rs
+++ b/examples/std/src/tuntap.rs
@@ -4,6 +4,7 @@ use std::os::unix::io::{AsRawFd, RawFd};
 use std::task::Context;
 
 use async_io::Async;
+use embassy_net::HardwareAddress;
 use embassy_net_driver::{self, Capabilities, Driver, LinkState};
 use log::*;
 
@@ -180,8 +181,8 @@ impl Driver for TunTapDevice {
         LinkState::Up
     }
 
-    fn ethernet_address(&self) -> [u8; 6] {
-        [0x02, 0x03, 0x04, 0x05, 0x06, 0x07]
+    fn hardware_address(&self) -> HardwareAddress {
+        HardwareAddress::Ethernet(EthernetAddress([0x02, 0x03, 0x04, 0x05, 0x06, 0x07]))
     }
 }
 


### PR DESCRIPTION
(I'm sorry for the PR-spam. I'm trying to get the "finished" things we have cleaned up, atomic and mergeable.)

This allows a net::Driver to be an IEEE802.15.4 device.

I wrote this in two stages.

1. Added `ieee802154_address()` to the trait
2. Merged `ethernet_address()` and `ieee802154_address` into `hardware_address()`.

This allows the community (mainly @Dirbaio, cc @xoviat) to decide which way is better. HardwareAddress means we have a bunch of match-statements at runtime, for a property that's typically known at compile time (but that's the case anyway with smoltcp, currently), but it's a lot more compact and future proof. It's a (big-ish) breaking change, however.

CI will probably complain, but I'll clean that up after a decision on the above is taken :-)