### PR TITLE
rp: add async flash

### DIFF
--- a/embassy-rp/Cargo.toml
+++ b/embassy-rp/Cargo.toml
@@ -48,7 +48,7 @@ boot2-w25x10cl = []
 run-from-ram = []
 
 # Enable nightly-only features
-nightly = ["embedded-hal-1", "embedded-hal-async", "embassy-embedded-hal/nightly", "dep:embassy-usb-driver", "dep:embedded-io"]
+nightly = ["embedded-hal-1", "embedded-hal-async", "embedded-storage-async", "embassy-embedded-hal/nightly", "dep:embassy-usb-driver", "dep:embedded-io"]
 
 # Implement embedded-hal 1.0 alpha traits.
 # Implement embedded-hal-async traits if `nightly` is set as well.
@@ -73,6 +73,7 @@ futures = { version = "0.3.17", default-features = false, features = ["async-awa
 chrono = { version = "0.4", default-features = false, optional = true }
 embedded-io = { version = "0.4.0", features = ["async"], optional = true }
 embedded-storage = { version = "0.3" }
+embedded-storage-async = { version = "0.4.0", optional = true }
 rand_core = "0.6.4"
 fixed = "1.23.1"
 

--- a/examples/boot/application/rp/src/bin/a.rs
+++ b/examples/boot/application/rp/src/bin/a.rs
@@ -7,7 +7,7 @@ use core::cell::RefCell;
 use defmt_rtt as _;
 use embassy_boot_rp::*;
 use embassy_executor::Spawner;
-use embassy_rp::flash::Flash;
+use embassy_rp::flash::{self, Flash};
 use embassy_rp::gpio::{Level, Output};
 use embassy_rp::watchdog::Watchdog;
 use embassy_sync::blocking_mutex::Mutex;
@@ -34,7 +34,7 @@ async fn main(_s: Spawner) {
     let mut watchdog = Watchdog::new(p.WATCHDOG);
     watchdog.start(Duration::from_secs(8));
 
-    let flash: Flash<_, FLASH_SIZE> = Flash::new(p.FLASH);
+    let flash = Flash::<_, flash::Blocking, FLASH_SIZE>::new(p.FLASH);
     let flash = Mutex::new(RefCell::new(flash));
 
     let config = FirmwareUpdaterConfig::from_linkerfile_blocking(&flash);

--- a/examples/rp/src/bin/flash.rs
+++ b/examples/rp/src/bin/flash.rs
@@ -6,7 +6,7 @@
 
 use defmt::*;
 use embassy_executor::Spawner;
-use embassy_rp::flash::{ERASE_SIZE, FLASH_BASE};
+use embassy_rp::flash::{Async, ERASE_SIZE, FLASH_BASE};
 use embassy_rp::peripherals::FLASH;
 use embassy_time::{Duration, Timer};
 use {defmt_rtt as _, panic_probe as _};
@@ -25,7 +25,7 @@ async fn main(_spawner: Spawner) {
     // https://github.com/knurling-rs/defmt/pull/683
     Timer::after(Duration::from_millis(10)).await;
 
-    let mut flash = embassy_rp::flash::Flash::<_, FLASH_SIZE>::new(p.FLASH);
+    let mut flash = embassy_rp::flash::Flash::<_, Async, FLASH_SIZE>::new(p.FLASH, p.DMA_CH0);
 
     // Get JEDEC id
     let jedec = flash.jedec_id().unwrap();
@@ -40,10 +40,12 @@ async fn main(_spawner: Spawner) {
 
     multiwrite_bytes(&mut flash, ERASE_SIZE as u32);
 
+    background_read(&mut flash, (ERASE_SIZE * 2) as u32).await;
+
     loop {}
 }
 
-fn multiwrite_bytes(flash: &mut embassy_rp::flash::Flash<'_, FLASH, FLASH_SIZE>, offset: u32) {
+fn multiwrite_bytes(flash: &mut embassy_rp::flash::Flash<'_, FLASH, Async, FLASH_SIZE>, offset: u32) {
     info!(">>>> [multiwrite_bytes]");
     let mut read_buf = [0u8; ERASE_SIZE];
     defmt::unwrap!(flash.read(ADDR_OFFSET + offset, &mut read_buf));
@@ -71,7 +73,7 @@ fn multiwrite_bytes(flash: &mut embassy_rp::flash::Flash<'_, FLASH, FLASH_SIZE>,
     }
 }
 
-fn erase_write_sector(flash: &mut embassy_rp::flash::Flash<'_, FLASH, FLASH_SIZE>, offset: u32) {
+fn erase_write_sector(flash: &mut embassy_rp::flash::Flash<'_, FLASH, Async, FLASH_SIZE>, offset: u32) {
     info!(">>>> [erase_write_sector]");
     let mut buf = [0u8; ERASE_SIZE];
     defmt::unwrap!(flash.read(ADDR_OFFSET + offset, &mut buf));
@@ -96,6 +98,38 @@ fn erase_write_sector(flash: &mut embassy_rp::flash::Flash<'_, FLASH, FLASH_SIZE
     defmt::unwrap!(flash.read(ADDR_OFFSET + offset, &mut buf));
     info!("Contents after write starts with {=[u8]}", buf[0..4]);
     if buf.iter().any(|x| *x != 0xDA) {
+        defmt::panic!("unexpected");
+    }
+}
+
+async fn background_read(flash: &mut embassy_rp::flash::Flash<'_, FLASH, Async, FLASH_SIZE>, offset: u32) {
+    info!(">>>> [background_read]");
+
+    let mut buf = [0u32; 8];
+    defmt::unwrap!(flash.background_read(ADDR_OFFSET + offset, &mut buf)).await;
+
+    info!("Addr of flash block is {:x}", ADDR_OFFSET + offset + FLASH_BASE as u32);
+    info!("Contents start with {=u32:x}", buf[0]);
+
+    defmt::unwrap!(flash.erase(ADDR_OFFSET + offset, ADDR_OFFSET + offset + ERASE_SIZE as u32));
+
+    defmt::unwrap!(flash.background_read(ADDR_OFFSET + offset, &mut buf)).await;
+    info!("Contents after erase starts with {=u32:x}", buf[0]);
+    if buf.iter().any(|x| *x != 0xFFFFFFFF) {
+        defmt::panic!("unexpected");
+    }
+
+    for b in buf.iter_mut() {
+        *b = 0xDABA1234;
+    }
+
+    defmt::unwrap!(flash.write(ADDR_OFFSET + offset, unsafe {
+        core::slice::from_raw_parts(buf.as_ptr() as *const u8, buf.len() * 4)
+    }));
+
+    defmt::unwrap!(flash.background_read(ADDR_OFFSET + offset, &mut buf)).await;
+    info!("Contents after write starts with {=u32:x}", buf[0]);
+    if buf.iter().any(|x| *x != 0xDABA1234) {
         defmt::panic!("unexpected");
     }
 }


### PR DESCRIPTION
This adds an async mode to RP flash operations.  This mode requires a DMA channel but can utilize the background best effort read mechanism.  This mechanism avoids stalling actual code execution from XIP as well as avoiding filling the cache with flash data (that's going to RAM anyway).  Write and erase remain blocking, however.

See the [Pico SDK Example](https://github.com/raspberrypi/pico-examples/blob/master/flash/xip_stream/flash_xip_stream.c) and  section (2.6.3.4) of the manual. 