### PR TITLE
stm32f2 PLL overflow with crystal

### DIFF
--- a/embassy-stm32/src/rcc/f2.rs
+++ b/embassy-stm32/src/rcc/f2.rs
@@ -58,7 +58,7 @@ impl Default for PLLConfig {
 impl PLLConfig {
     pub fn clocks(&self, src_freq: Hertz) -> PLLClocks {
         let in_freq = src_freq / self.pre_div;
-        let vco_freq = src_freq * self.mul / self.pre_div;
+        let vco_freq = Hertz((src_freq.0 as u64 * self.mul.0 as u64 / self.pre_div.0 as u64) as u32);
         let main_freq = vco_freq / self.main_div;
         let pll48_freq = vco_freq / self.pll48_div;
         PLLClocks {


### PR DESCRIPTION
With a significant enough HSE input frequency, the VCO clock calculation will overflow a u32. Therefore, we must use the inner value and cast to u64 in this specific case to ensure the mul isn't clipped before applying the divider.

FYI the input source on my board is a 25mhz external crystal.

