### PR TITLE
Move frequency to SPI config

### DIFF
--- a/embassy-stm32/src/i2s.rs
+++ b/embassy-stm32/src/i2s.rs
@@ -165,7 +165,9 @@ impl<'d, T: Instance, Tx, Rx> I2S<'d, T, Tx, Rx> {
         mck.set_as_af(mck.af_num(), AFType::OutputPushPull);
         mck.set_speed(crate::gpio::Speed::VeryHigh);
 
-        let spi = Spi::new_internal(peri, txdma, rxdma, freq, SpiConfig::default());
+        let mut spi_cfg = SpiConfig::default();
+        spi_cfg.freq = freq;
+        let spi = Spi::new_internal(peri, txdma, rxdma, spi_cfg);
 
         #[cfg(all(rcc_f4, not(stm32f410)))]
         let pclk = unsafe { get_freqs() }.plli2s.unwrap();

--- a/embassy-stm32/src/i2s.rs
+++ b/embassy-stm32/src/i2s.rs
@@ -166,7 +166,7 @@ impl<'d, T: Instance, Tx, Rx> I2S<'d, T, Tx, Rx> {
         mck.set_speed(crate::gpio::Speed::VeryHigh);
 
         let mut spi_cfg = SpiConfig::default();
-        spi_cfg.freq = freq;
+        spi_cfg.frequency = freq;
         let spi = Spi::new_internal(peri, txdma, rxdma, spi_cfg);
 
         #[cfg(all(rcc_f4, not(stm32f410)))]

--- a/examples/stm32f3/src/bin/spi_dma.rs
+++ b/examples/stm32f3/src/bin/spi_dma.rs
@@ -8,7 +8,6 @@ use core::str::from_utf8;
 use defmt::*;
 use embassy_executor::Spawner;
 use embassy_stm32::spi::{Config, Spi};
-use embassy_stm32::time::Hertz;
 use heapless::String;
 use {defmt_rtt as _, panic_probe as _};
 
@@ -24,7 +23,6 @@ async fn main(_spawner: Spawner) {
         p.PB4,
         p.DMA1_CH3,
         p.DMA1_CH2,
-        Hertz(1_000_000),
         Config::default(),
     );
 

--- a/examples/stm32f3/src/bin/spi_dma.rs
+++ b/examples/stm32f3/src/bin/spi_dma.rs
@@ -16,15 +16,7 @@ async fn main(_spawner: Spawner) {
     let p = embassy_stm32::init(Default::default());
     info!("Hello World!");
 
-    let mut spi = Spi::new(
-        p.SPI1,
-        p.PB3,
-        p.PB5,
-        p.PB4,
-        p.DMA1_CH3,
-        p.DMA1_CH2,
-        Config::default(),
-    );
+    let mut spi = Spi::new(p.SPI1, p.PB3, p.PB5, p.PB4, p.DMA1_CH3, p.DMA1_CH2, Config::default());
 
     for n in 0u32.. {
         let mut write: String<128> = String::new();

--- a/examples/stm32f3/src/bin/spi_dma.rs
+++ b/examples/stm32f3/src/bin/spi_dma.rs
@@ -8,6 +8,7 @@ use core::str::from_utf8;
 use defmt::*;
 use embassy_executor::Spawner;
 use embassy_stm32::spi::{Config, Spi};
+use embassy_stm32::time::Hertz;
 use heapless::String;
 use {defmt_rtt as _, panic_probe as _};
 
@@ -16,7 +17,10 @@ async fn main(_spawner: Spawner) {
     let p = embassy_stm32::init(Default::default());
     info!("Hello World!");
 
-    let mut spi = Spi::new(p.SPI1, p.PB3, p.PB5, p.PB4, p.DMA1_CH3, p.DMA1_CH2, Config::default());
+    let mut spi_config = Config::default();
+    spi_config.frequency = Hertz(1_000_000);
+
+    let mut spi = Spi::new(p.SPI1, p.PB3, p.PB5, p.PB4, p.DMA1_CH3, p.DMA1_CH2, spi_config);
 
     for n in 0u32.. {
         let mut write: String<128> = String::new();

--- a/examples/stm32f4/src/bin/spi.rs
+++ b/examples/stm32f4/src/bin/spi.rs
@@ -7,7 +7,6 @@ use defmt::*;
 use embassy_stm32::dma::NoDma;
 use embassy_stm32::gpio::{Level, Output, Speed};
 use embassy_stm32::spi::{Config, Spi};
-use embassy_stm32::time::Hertz;
 use {defmt_rtt as _, panic_probe as _};
 
 #[entry]
@@ -16,16 +15,7 @@ fn main() -> ! {
 
     let p = embassy_stm32::init(Default::default());
 
-    let mut spi = Spi::new(
-        p.SPI3,
-        p.PC10,
-        p.PC12,
-        p.PC11,
-        NoDma,
-        NoDma,
-        Hertz(1_000_000),
-        Config::default(),
-    );
+    let mut spi = Spi::new(p.SPI3, p.PC10, p.PC12, p.PC11, NoDma, NoDma, Config::default());
 
     let mut cs = Output::new(p.PE0, Level::High, Speed::VeryHigh);
 

--- a/examples/stm32f4/src/bin/spi.rs
+++ b/examples/stm32f4/src/bin/spi.rs
@@ -7,6 +7,7 @@ use defmt::*;
 use embassy_stm32::dma::NoDma;
 use embassy_stm32::gpio::{Level, Output, Speed};
 use embassy_stm32::spi::{Config, Spi};
+use embassy_stm32::time::Hertz;
 use {defmt_rtt as _, panic_probe as _};
 
 #[entry]
@@ -15,7 +16,10 @@ fn main() -> ! {
 
     let p = embassy_stm32::init(Default::default());
 
-    let mut spi = Spi::new(p.SPI3, p.PC10, p.PC12, p.PC11, NoDma, NoDma, Config::default());
+    let mut spi_config = Config::default();
+    spi_config.frequency = Hertz(1_000_000);
+
+    let mut spi = Spi::new(p.SPI3, p.PC10, p.PC12, p.PC11, NoDma, NoDma, spi_config);
 
     let mut cs = Output::new(p.PE0, Level::High, Speed::VeryHigh);
 

--- a/examples/stm32f4/src/bin/spi_dma.rs
+++ b/examples/stm32f4/src/bin/spi_dma.rs
@@ -8,7 +8,6 @@ use core::str::from_utf8;
 use defmt::*;
 use embassy_executor::Spawner;
 use embassy_stm32::spi::{Config, Spi};
-use embassy_stm32::time::Hertz;
 use heapless::String;
 use {defmt_rtt as _, panic_probe as _};
 
@@ -24,7 +23,6 @@ async fn main(_spawner: Spawner) {
         p.PB4,
         p.DMA2_CH3,
         p.DMA2_CH2,
-        Hertz(1_000_000),
         Config::default(),
     );
 

--- a/examples/stm32f4/src/bin/spi_dma.rs
+++ b/examples/stm32f4/src/bin/spi_dma.rs
@@ -8,6 +8,7 @@ use core::str::from_utf8;
 use defmt::*;
 use embassy_executor::Spawner;
 use embassy_stm32::spi::{Config, Spi};
+use embassy_stm32::time::Hertz;
 use heapless::String;
 use {defmt_rtt as _, panic_probe as _};
 
@@ -16,7 +17,10 @@ async fn main(_spawner: Spawner) {
     let p = embassy_stm32::init(Default::default());
     info!("Hello World!");
 
-    let mut spi = Spi::new(p.SPI1, p.PB3, p.PB5, p.PB4, p.DMA2_CH3, p.DMA2_CH2, Config::default());
+    let mut spi_config = Config::default();
+    spi_config.frequency = Hertz(1_000_000);
+
+    let mut spi = Spi::new(p.SPI1, p.PB3, p.PB5, p.PB4, p.DMA2_CH3, p.DMA2_CH2, spi_config);
 
     for n in 0u32.. {
         let mut write: String<128> = String::new();

--- a/examples/stm32f4/src/bin/spi_dma.rs
+++ b/examples/stm32f4/src/bin/spi_dma.rs
@@ -16,15 +16,7 @@ async fn main(_spawner: Spawner) {
     let p = embassy_stm32::init(Default::default());
     info!("Hello World!");
 
-    let mut spi = Spi::new(
-        p.SPI1,
-        p.PB3,
-        p.PB5,
-        p.PB4,
-        p.DMA2_CH3,
-        p.DMA2_CH2,
-        Config::default(),
-    );
+    let mut spi = Spi::new(p.SPI1, p.PB3, p.PB5, p.PB4, p.DMA2_CH3, p.DMA2_CH2, Config::default());
 
     for n in 0u32.. {
         let mut write: String<128> = String::new();

--- a/examples/stm32g0/src/bin/spi_neopixel.rs
+++ b/examples/stm32g0/src/bin/spi_neopixel.rs
@@ -76,7 +76,9 @@ async fn main(_spawner: Spawner) {
     let p = embassy_stm32::init(Default::default());
     info!("Start test using spi as neopixel driver");
 
-    let mut spi = Spi::new_txonly_nosck(p.SPI1, p.PB5, p.DMA1_CH3, NoDma, Hertz(4_000_000), Config::default());
+    let mut config = Config::default();
+    config.frequency = Hertz(4_000_000);
+    let mut spi = Spi::new_txonly_nosck(p.SPI1, p.PB5, p.DMA1_CH3, NoDma, config);
 
     let mut neopixels = Ws2812::new();
 

--- a/examples/stm32h7/src/bin/spi.rs
+++ b/examples/stm32h7/src/bin/spi.rs
@@ -46,15 +46,7 @@ fn main() -> ! {
     let mut spi_config = spi::Config::default();
     spi_config.frequency = mhz(1);
 
-    let spi = spi::Spi::new(
-        p.SPI3,
-        p.PB3,
-        p.PB5,
-        p.PB4,
-        NoDma,
-        NoDma,
-        spi_config,
-    );
+    let spi = spi::Spi::new(p.SPI3, p.PB3, p.PB5, p.PB4, NoDma, NoDma, spi_config);
 
     let executor = EXECUTOR.init(Executor::new());
 

--- a/examples/stm32h7/src/bin/spi.rs
+++ b/examples/stm32h7/src/bin/spi.rs
@@ -43,6 +43,9 @@ fn main() -> ! {
     config.rcc.pll1.q_ck = Some(mhz(100));
     let p = embassy_stm32::init(config);
 
+    let mut spi_config = spi::Config::default();
+    spi_config.frequency = mhz(1);
+
     let spi = spi::Spi::new(
         p.SPI3,
         p.PB3,
@@ -50,8 +53,7 @@ fn main() -> ! {
         p.PB4,
         NoDma,
         NoDma,
-        mhz(1),
-        spi::Config::default(),
+        spi_config,
     );
 
     let executor = EXECUTOR.init(Executor::new());

--- a/examples/stm32h7/src/bin/spi_dma.rs
+++ b/examples/stm32h7/src/bin/spi_dma.rs
@@ -42,15 +42,7 @@ fn main() -> ! {
     let mut spi_config = spi::Config::default();
     spi_config.frequency = mhz(1);
 
-    let spi = spi::Spi::new(
-        p.SPI3,
-        p.PB3,
-        p.PB5,
-        p.PB4,
-        p.DMA1_CH3,
-        p.DMA1_CH4,
-        spi_config,
-    );
+    let spi = spi::Spi::new(p.SPI3, p.PB3, p.PB5, p.PB4, p.DMA1_CH3, p.DMA1_CH4, spi_config);
 
     let executor = EXECUTOR.init(Executor::new());
 

--- a/examples/stm32h7/src/bin/spi_dma.rs
+++ b/examples/stm32h7/src/bin/spi_dma.rs
@@ -39,6 +39,9 @@ fn main() -> ! {
     config.rcc.pll1.q_ck = Some(mhz(100));
     let p = embassy_stm32::init(config);
 
+    let mut spi_config = spi::Config::default();
+    spi_config.frequency = mhz(1);
+
     let spi = spi::Spi::new(
         p.SPI3,
         p.PB3,
@@ -46,8 +49,7 @@ fn main() -> ! {
         p.PB4,
         p.DMA1_CH3,
         p.DMA1_CH4,
-        mhz(1),
-        spi::Config::default(),
+        spi_config,
     );
 
     let executor = EXECUTOR.init(Executor::new());

--- a/examples/stm32l0/src/bin/lora_cad.rs
+++ b/examples/stm32l0/src/bin/lora_cad.rs
@@ -27,6 +27,9 @@ async fn main(_spawner: Spawner) {
     config.rcc.enable_hsi48 = true;
     let p = embassy_stm32::init(config);
 
+    let mut spi_config = spi::Config::default();
+    spi_config.frequency = khz(200);
+
     // SPI for sx1276
     let spi = spi::Spi::new(
         p.SPI1,
@@ -35,8 +38,7 @@ async fn main(_spawner: Spawner) {
         p.PA6,
         p.DMA1_CH3,
         p.DMA1_CH2,
-        khz(200),
-        spi::Config::default(),
+        spi_config,
     );
 
     let nss = Output::new(p.PA15.degrade(), Level::High, Speed::Low);

--- a/examples/stm32l0/src/bin/lora_cad.rs
+++ b/examples/stm32l0/src/bin/lora_cad.rs
@@ -31,15 +31,7 @@ async fn main(_spawner: Spawner) {
     spi_config.frequency = khz(200);
 
     // SPI for sx1276
-    let spi = spi::Spi::new(
-        p.SPI1,
-        p.PB3,
-        p.PA7,
-        p.PA6,
-        p.DMA1_CH3,
-        p.DMA1_CH2,
-        spi_config,
-    );
+    let spi = spi::Spi::new(p.SPI1, p.PB3, p.PA7, p.PA6, p.DMA1_CH3, p.DMA1_CH2, spi_config);
 
     let nss = Output::new(p.PA15.degrade(), Level::High, Speed::Low);
     let reset = Output::new(p.PC0.degrade(), Level::High, Speed::Low);

--- a/examples/stm32l0/src/bin/lora_lorawan.rs
+++ b/examples/stm32l0/src/bin/lora_lorawan.rs
@@ -32,6 +32,9 @@ async fn main(_spawner: Spawner) {
     config.rcc.enable_hsi48 = true;
     let p = embassy_stm32::init(config);
 
+    let mut spi_config = spi::Config::default();
+    spi_config.frequency = khz(200);
+
     // SPI for sx1276
     let spi = spi::Spi::new(
         p.SPI1,
@@ -40,8 +43,7 @@ async fn main(_spawner: Spawner) {
         p.PA6,
         p.DMA1_CH3,
         p.DMA1_CH2,
-        khz(200),
-        spi::Config::default(),
+        spi_config,
     );
 
     let nss = Output::new(p.PA15.degrade(), Level::High, Speed::Low);

--- a/examples/stm32l0/src/bin/lora_lorawan.rs
+++ b/examples/stm32l0/src/bin/lora_lorawan.rs
@@ -36,15 +36,7 @@ async fn main(_spawner: Spawner) {
     spi_config.frequency = khz(200);
 
     // SPI for sx1276
-    let spi = spi::Spi::new(
-        p.SPI1,
-        p.PB3,
-        p.PA7,
-        p.PA6,
-        p.DMA1_CH3,
-        p.DMA1_CH2,
-        spi_config,
-    );
+    let spi = spi::Spi::new(p.SPI1, p.PB3, p.PA7, p.PA6, p.DMA1_CH3, p.DMA1_CH2, spi_config);
 
     let nss = Output::new(p.PA15.degrade(), Level::High, Speed::Low);
     let reset = Output::new(p.PC0.degrade(), Level::High, Speed::Low);

--- a/examples/stm32l0/src/bin/lora_p2p_receive.rs
+++ b/examples/stm32l0/src/bin/lora_p2p_receive.rs
@@ -27,6 +27,9 @@ async fn main(_spawner: Spawner) {
     config.rcc.enable_hsi48 = true;
     let p = embassy_stm32::init(config);
 
+    let mut spi_config = spi::Config::default();
+    spi_config.frequency = khz(200);
+
     // SPI for sx1276
     let spi = spi::Spi::new(
         p.SPI1,
@@ -35,8 +38,7 @@ async fn main(_spawner: Spawner) {
         p.PA6,
         p.DMA1_CH3,
         p.DMA1_CH2,
-        khz(200),
-        spi::Config::default(),
+        spi_config,
     );
 
     let nss = Output::new(p.PA15.degrade(), Level::High, Speed::Low);

--- a/examples/stm32l0/src/bin/lora_p2p_receive.rs
+++ b/examples/stm32l0/src/bin/lora_p2p_receive.rs
@@ -31,15 +31,7 @@ async fn main(_spawner: Spawner) {
     spi_config.frequency = khz(200);
 
     // SPI for sx1276
-    let spi = spi::Spi::new(
-        p.SPI1,
-        p.PB3,
-        p.PA7,
-        p.PA6,
-        p.DMA1_CH3,
-        p.DMA1_CH2,
-        spi_config,
-    );
+    let spi = spi::Spi::new(p.SPI1, p.PB3, p.PA7, p.PA6, p.DMA1_CH3, p.DMA1_CH2, spi_config);
 
     let nss = Output::new(p.PA15.degrade(), Level::High, Speed::Low);
     let reset = Output::new(p.PC0.degrade(), Level::High, Speed::Low);

--- a/examples/stm32l0/src/bin/lora_p2p_send.rs
+++ b/examples/stm32l0/src/bin/lora_p2p_send.rs
@@ -27,6 +27,9 @@ async fn main(_spawner: Spawner) {
     config.rcc.enable_hsi48 = true;
     let p = embassy_stm32::init(config);
 
+    let mut spi_config = spi::Config::default();
+    spi_config.frequency = khz(200);
+
     // SPI for sx1276
     let spi = spi::Spi::new(
         p.SPI1,
@@ -35,8 +38,7 @@ async fn main(_spawner: Spawner) {
         p.PA6,
         p.DMA1_CH3,
         p.DMA1_CH2,
-        khz(200),
-        spi::Config::default(),
+        spi_config,
     );
 
     let nss = Output::new(p.PA15.degrade(), Level::High, Speed::Low);

--- a/examples/stm32l0/src/bin/lora_p2p_send.rs
+++ b/examples/stm32l0/src/bin/lora_p2p_send.rs
@@ -31,15 +31,7 @@ async fn main(_spawner: Spawner) {
     spi_config.frequency = khz(200);
 
     // SPI for sx1276
-    let spi = spi::Spi::new(
-        p.SPI1,
-        p.PB3,
-        p.PA7,
-        p.PA6,
-        p.DMA1_CH3,
-        p.DMA1_CH2,
-        spi_config,
-    );
+    let spi = spi::Spi::new(p.SPI1, p.PB3, p.PA7, p.PA6, p.DMA1_CH3, p.DMA1_CH2, spi_config);
 
     let nss = Output::new(p.PA15.degrade(), Level::High, Speed::Low);
     let reset = Output::new(p.PC0.degrade(), Level::High, Speed::Low);

--- a/examples/stm32l0/src/bin/spi.rs
+++ b/examples/stm32l0/src/bin/spi.rs
@@ -7,7 +7,6 @@ use embassy_executor::Spawner;
 use embassy_stm32::dma::NoDma;
 use embassy_stm32::gpio::{Level, Output, Speed};
 use embassy_stm32::spi::{Config, Spi};
-use embassy_stm32::time::Hertz;
 use {defmt_rtt as _, panic_probe as _};
 
 #[embassy_executor::main]
@@ -22,7 +21,6 @@ async fn main(_spawner: Spawner) {
         p.PA6,
         NoDma,
         NoDma,
-        Hertz(1_000_000),
         Config::default(),
     );
 

--- a/examples/stm32l0/src/bin/spi.rs
+++ b/examples/stm32l0/src/bin/spi.rs
@@ -14,15 +14,7 @@ async fn main(_spawner: Spawner) {
     let p = embassy_stm32::init(Default::default());
     info!("Hello World, folks!");
 
-    let mut spi = Spi::new(
-        p.SPI1,
-        p.PB3,
-        p.PA7,
-        p.PA6,
-        NoDma,
-        NoDma,
-        Config::default(),
-    );
+    let mut spi = Spi::new(p.SPI1, p.PB3, p.PA7, p.PA6, NoDma, NoDma, Config::default());
 
     let mut cs = Output::new(p.PA15, Level::High, Speed::VeryHigh);
 

--- a/examples/stm32l0/src/bin/spi.rs
+++ b/examples/stm32l0/src/bin/spi.rs
@@ -7,6 +7,7 @@ use embassy_executor::Spawner;
 use embassy_stm32::dma::NoDma;
 use embassy_stm32::gpio::{Level, Output, Speed};
 use embassy_stm32::spi::{Config, Spi};
+use embassy_stm32::time::Hertz;
 use {defmt_rtt as _, panic_probe as _};
 
 #[embassy_executor::main]
@@ -14,7 +15,10 @@ async fn main(_spawner: Spawner) {
     let p = embassy_stm32::init(Default::default());
     info!("Hello World, folks!");
 
-    let mut spi = Spi::new(p.SPI1, p.PB3, p.PA7, p.PA6, NoDma, NoDma, Config::default());
+    let mut spi_config = Config::default();
+    spi_config.frequency = Hertz(1_000_000);
+
+    let mut spi = Spi::new(p.SPI1, p.PB3, p.PA7, p.PA6, NoDma, NoDma, spi_config);
 
     let mut cs = Output::new(p.PA15, Level::High, Speed::VeryHigh);
 

--- a/examples/stm32l1/src/bin/spi.rs
+++ b/examples/stm32l1/src/bin/spi.rs
@@ -7,7 +7,6 @@ use embassy_executor::Spawner;
 use embassy_stm32::dma::NoDma;
 use embassy_stm32::gpio::{Level, Output, Speed};
 use embassy_stm32::spi::{Config, Spi};
-use embassy_stm32::time::Hertz;
 use {defmt_rtt as _, panic_probe as _};
 
 #[embassy_executor::main]
@@ -22,7 +21,6 @@ async fn main(_spawner: Spawner) {
         p.PA6,
         NoDma,
         NoDma,
-        Hertz(1_000_000),
         Config::default(),
     );
 

--- a/examples/stm32l1/src/bin/spi.rs
+++ b/examples/stm32l1/src/bin/spi.rs
@@ -7,6 +7,7 @@ use embassy_executor::Spawner;
 use embassy_stm32::dma::NoDma;
 use embassy_stm32::gpio::{Level, Output, Speed};
 use embassy_stm32::spi::{Config, Spi};
+use embassy_stm32::time::Hertz;
 use {defmt_rtt as _, panic_probe as _};
 
 #[embassy_executor::main]
@@ -14,7 +15,10 @@ async fn main(_spawner: Spawner) {
     let p = embassy_stm32::init(Default::default());
     info!("Hello World, folks!");
 
-    let mut spi = Spi::new(p.SPI1, p.PA5, p.PA7, p.PA6, NoDma, NoDma, Config::default());
+    let mut spi_config = Config::default();
+    spi_config.frequency = Hertz(1_000_000);
+
+    let mut spi = Spi::new(p.SPI1, p.PA5, p.PA7, p.PA6, NoDma, NoDma, spi_config);
 
     let mut cs = Output::new(p.PA4, Level::High, Speed::VeryHigh);
 

--- a/examples/stm32l1/src/bin/spi.rs
+++ b/examples/stm32l1/src/bin/spi.rs
@@ -14,15 +14,7 @@ async fn main(_spawner: Spawner) {
     let p = embassy_stm32::init(Default::default());
     info!("Hello World, folks!");
 
-    let mut spi = Spi::new(
-        p.SPI1,
-        p.PA5,
-        p.PA7,
-        p.PA6,
-        NoDma,
-        NoDma,
-        Config::default(),
-    );
+    let mut spi = Spi::new(p.SPI1, p.PA5, p.PA7, p.PA6, NoDma, NoDma, Config::default());
 
     let mut cs = Output::new(p.PA4, Level::High, Speed::VeryHigh);
 

--- a/examples/stm32l4/src/bin/spi.rs
+++ b/examples/stm32l4/src/bin/spi.rs
@@ -6,7 +6,6 @@ use defmt::*;
 use embassy_stm32::dma::NoDma;
 use embassy_stm32::gpio::{Level, Output, Speed};
 use embassy_stm32::spi::{Config, Spi};
-use embassy_stm32::time::Hertz;
 use {defmt_rtt as _, panic_probe as _};
 
 #[cortex_m_rt::entry]
@@ -15,16 +14,7 @@ fn main() -> ! {
 
     let p = embassy_stm32::init(Default::default());
 
-    let mut spi = Spi::new(
-        p.SPI3,
-        p.PC10,
-        p.PC12,
-        p.PC11,
-        NoDma,
-        NoDma,
-        Hertz(1_000_000),
-        Config::default(),
-    );
+    let mut spi = Spi::new(p.SPI3, p.PC10, p.PC12, p.PC11, NoDma, NoDma, Config::default());
 
     let mut cs = Output::new(p.PE0, Level::High, Speed::VeryHigh);
 

--- a/examples/stm32l4/src/bin/spi.rs
+++ b/examples/stm32l4/src/bin/spi.rs
@@ -6,6 +6,7 @@ use defmt::*;
 use embassy_stm32::dma::NoDma;
 use embassy_stm32::gpio::{Level, Output, Speed};
 use embassy_stm32::spi::{Config, Spi};
+use embassy_stm32::time::Hertz;
 use {defmt_rtt as _, panic_probe as _};
 
 #[cortex_m_rt::entry]
@@ -14,7 +15,10 @@ fn main() -> ! {
 
     let p = embassy_stm32::init(Default::default());
 
-    let mut spi = Spi::new(p.SPI3, p.PC10, p.PC12, p.PC11, NoDma, NoDma, Config::default());
+    let mut spi_config = Config::default();
+    spi_config.frequency = Hertz(1_000_000);
+
+    let mut spi = Spi::new(p.SPI3, p.PC10, p.PC12, p.PC11, NoDma, NoDma, spi_config);
 
     let mut cs = Output::new(p.PE0, Level::High, Speed::VeryHigh);
 

--- a/examples/stm32l4/src/bin/spi_blocking_async.rs
+++ b/examples/stm32l4/src/bin/spi_blocking_async.rs
@@ -16,15 +16,7 @@ async fn main(_spawner: Spawner) {
     let p = embassy_stm32::init(Default::default());
     info!("Hello World!");
 
-    let spi = Spi::new(
-        p.SPI3,
-        p.PC10,
-        p.PC12,
-        p.PC11,
-        NoDma,
-        NoDma,
-        Config::default(),
-    );
+    let spi = Spi::new(p.SPI3, p.PC10, p.PC12, p.PC11, NoDma, NoDma, Config::default());
 
     let mut spi = BlockingAsync::new(spi);
 

--- a/examples/stm32l4/src/bin/spi_blocking_async.rs
+++ b/examples/stm32l4/src/bin/spi_blocking_async.rs
@@ -8,6 +8,7 @@ use embassy_executor::Spawner;
 use embassy_stm32::dma::NoDma;
 use embassy_stm32::gpio::{Input, Level, Output, Pull, Speed};
 use embassy_stm32::spi::{Config, Spi};
+use embassy_stm32::time::Hertz;
 use embedded_hal_async::spi::SpiBus;
 use {defmt_rtt as _, panic_probe as _};
 
@@ -16,7 +17,10 @@ async fn main(_spawner: Spawner) {
     let p = embassy_stm32::init(Default::default());
     info!("Hello World!");
 
-    let spi = Spi::new(p.SPI3, p.PC10, p.PC12, p.PC11, NoDma, NoDma, Config::default());
+    let mut spi_config = Config::default();
+    spi_config.frequency = Hertz(1_000_000);
+
+    let spi = Spi::new(p.SPI3, p.PC10, p.PC12, p.PC11, NoDma, NoDma, spi_config);
 
     let mut spi = BlockingAsync::new(spi);
 

--- a/examples/stm32l4/src/bin/spi_blocking_async.rs
+++ b/examples/stm32l4/src/bin/spi_blocking_async.rs
@@ -8,7 +8,6 @@ use embassy_executor::Spawner;
 use embassy_stm32::dma::NoDma;
 use embassy_stm32::gpio::{Input, Level, Output, Pull, Speed};
 use embassy_stm32::spi::{Config, Spi};
-use embassy_stm32::time::Hertz;
 use embedded_hal_async::spi::SpiBus;
 use {defmt_rtt as _, panic_probe as _};
 
@@ -24,7 +23,6 @@ async fn main(_spawner: Spawner) {
         p.PC11,
         NoDma,
         NoDma,
-        Hertz(1_000_000),
         Config::default(),
     );
 

--- a/examples/stm32l4/src/bin/spi_dma.rs
+++ b/examples/stm32l4/src/bin/spi_dma.rs
@@ -6,6 +6,7 @@ use defmt::*;
 use embassy_executor::Spawner;
 use embassy_stm32::gpio::{Input, Level, Output, Pull, Speed};
 use embassy_stm32::spi::{Config, Spi};
+use embassy_stm32::time::Hertz;
 use {defmt_rtt as _, panic_probe as _};
 
 #[embassy_executor::main]
@@ -13,15 +14,10 @@ async fn main(_spawner: Spawner) {
     let p = embassy_stm32::init(Default::default());
     info!("Hello World!");
 
-    let mut spi = Spi::new(
-        p.SPI3,
-        p.PC10,
-        p.PC12,
-        p.PC11,
-        p.DMA1_CH1,
-        p.DMA1_CH2,
-        Config::default(),
-    );
+    let mut spi_config = Config::default();
+    spi_config.frequency = Hertz(1_000_000);
+
+    let mut spi = Spi::new(p.SPI3, p.PC10, p.PC12, p.PC11, p.DMA1_CH1, p.DMA1_CH2, spi_config);
 
     // These are the pins for the Inventek eS-Wifi SPI Wifi Adapter.
 

--- a/examples/stm32l4/src/bin/spi_dma.rs
+++ b/examples/stm32l4/src/bin/spi_dma.rs
@@ -6,7 +6,6 @@ use defmt::*;
 use embassy_executor::Spawner;
 use embassy_stm32::gpio::{Input, Level, Output, Pull, Speed};
 use embassy_stm32::spi::{Config, Spi};
-use embassy_stm32::time::Hertz;
 use {defmt_rtt as _, panic_probe as _};
 
 #[embassy_executor::main]
@@ -21,7 +20,6 @@ async fn main(_spawner: Spawner) {
         p.PC11,
         p.DMA1_CH1,
         p.DMA1_CH2,
-        Hertz(1_000_000),
         Config::default(),
     );
 

--- a/tests/stm32/src/bin/spi.rs
+++ b/tests/stm32/src/bin/spi.rs
@@ -42,7 +42,6 @@ async fn main(_spawner: Spawner) {
         miso, // Arduino D12
         NoDma,
         NoDma,
-        Hertz(1_000_000),
         spi::Config::default(),
     );
 

--- a/tests/stm32/src/bin/spi.rs
+++ b/tests/stm32/src/bin/spi.rs
@@ -9,6 +9,7 @@ use defmt::assert_eq;
 use embassy_executor::Spawner;
 use embassy_stm32::dma::NoDma;
 use embassy_stm32::spi::{self, Spi};
+use embassy_stm32::time::Hertz;
 
 #[embassy_executor::main]
 async fn main(_spawner: Spawner) {
@@ -34,14 +35,14 @@ async fn main(_spawner: Spawner) {
     #[cfg(feature = "stm32c031c6")]
     let (spi, sck, mosi, miso) = (p.SPI1, p.PA5, p.PA7, p.PA6);
 
+    let mut spi_config = spi::Config::default();
+    spi_config.frequency = Hertz(1_000_000);
+
     let mut spi = Spi::new(
-        spi,
-        sck,  // Arduino D13
+        spi, sck,  // Arduino D13
         mosi, // Arduino D11
         miso, // Arduino D12
-        NoDma,
-        NoDma,
-        spi::Config::default(),
+        NoDma, NoDma, spi_config,
     );
 
     let data: [u8; 9] = [0x00, 0xFF, 0xAA, 0x55, 0xC0, 0xFF, 0xEE, 0xC0, 0xDE];

--- a/tests/stm32/src/bin/spi.rs
+++ b/tests/stm32/src/bin/spi.rs
@@ -9,7 +9,6 @@ use defmt::assert_eq;
 use embassy_executor::Spawner;
 use embassy_stm32::dma::NoDma;
 use embassy_stm32::spi::{self, Spi};
-use embassy_stm32::time::Hertz;
 
 #[embassy_executor::main]
 async fn main(_spawner: Spawner) {

--- a/tests/stm32/src/bin/spi_dma.rs
+++ b/tests/stm32/src/bin/spi_dma.rs
@@ -41,7 +41,6 @@ async fn main(_spawner: Spawner) {
         miso, // Arduino D12
         tx_dma,
         rx_dma,
-        Hertz(1_000_000),
         spi::Config::default(),
     );
 

--- a/tests/stm32/src/bin/spi_dma.rs
+++ b/tests/stm32/src/bin/spi_dma.rs
@@ -8,6 +8,7 @@ use common::*;
 use defmt::assert_eq;
 use embassy_executor::Spawner;
 use embassy_stm32::spi::{self, Spi};
+use embassy_stm32::time::Hertz;
 
 #[embassy_executor::main]
 async fn main(_spawner: Spawner) {
@@ -33,14 +34,14 @@ async fn main(_spawner: Spawner) {
     #[cfg(feature = "stm32c031c6")]
     let (spi, sck, mosi, miso, tx_dma, rx_dma) = (p.SPI1, p.PA5, p.PA7, p.PA6, p.DMA1_CH1, p.DMA1_CH2);
 
+    let mut spi_config = spi::Config::default();
+    spi_config.frequency = Hertz(1_000_000);
+
     let mut spi = Spi::new(
-        spi,
-        sck,  // Arduino D13
+        spi, sck,  // Arduino D13
         mosi, // Arduino D11
         miso, // Arduino D12
-        tx_dma,
-        rx_dma,
-        spi::Config::default(),
+        tx_dma, rx_dma, spi_config,
     );
 
     let data: [u8; 9] = [0x00, 0xFF, 0xAA, 0x55, 0xC0, 0xFF, 0xEE, 0xC0, 0xDE];

--- a/tests/stm32/src/bin/spi_dma.rs
+++ b/tests/stm32/src/bin/spi_dma.rs
@@ -8,7 +8,6 @@ use common::*;
 use defmt::assert_eq;
 use embassy_executor::Spawner;
 use embassy_stm32::spi::{self, Spi};
-use embassy_stm32::time::Hertz;
 
 #[embassy_executor::main]
 async fn main(_spawner: Spawner) {


### PR DESCRIPTION
This will move stm32-spi frequency settings from function parameters to config, see #1682.

Tested on NUCLEO-F303K8, not tested for #[cfg(any(spi_v3, spi_v4, spi_v5))] variant.