### PR TITLE
Fix probe-rs chip type in stm32h7 example

### DIFF
--- a/examples/stm32h7/.cargo/config.toml
+++ b/examples/stm32h7/.cargo/config.toml
@@ -1,5 +1,5 @@
 [target.thumbv7em-none-eabihf]
-runner = 'probe-rs run --chip STM32H7A3ZITxQ'
+runner = 'probe-rs run --chip STM32H743ZITx'
 
 [build]
 target = "thumbv7em-none-eabihf" # Cortex-M4F and Cortex-M7F (with FPU)


### PR DESCRIPTION
Accidently commited one file too many in  #1705 :/ Sorry.
This reverts part of commit 937a63ce28beee87ae78756ecf8377f465b8cf9d
