### PR TITLE
rp: fix qspi gpio interrupts, make qspi gpio optional

### DIFF
--- a/ci.sh
+++ b/ci.sh
@@ -58,6 +58,7 @@ cargo batch  \
     --- build --release --manifest-path embassy-rp/Cargo.toml --target thumbv6m-none-eabi --features nightly,unstable-traits \
     --- build --release --manifest-path embassy-rp/Cargo.toml --target thumbv6m-none-eabi --features nightly \
     --- build --release --manifest-path embassy-rp/Cargo.toml --target thumbv6m-none-eabi --features nightly,intrinsics \
+    --- build --release --manifest-path embassy-rp/Cargo.toml --target thumbv6m-none-eabi --features nightly,qspi-as-gpio \
     --- build --release --manifest-path embassy-stm32/Cargo.toml --target thumbv8m.main-none-eabihf --features stm32l552ze,defmt,exti,time-driver-any,unstable-traits \
     --- build --release --manifest-path embassy-stm32/Cargo.toml --target thumbv8m.main-none-eabihf --features stm32l552ze,defmt,exti,time-driver-any \
     --- build --release --manifest-path embassy-stm32/Cargo.toml --target thumbv8m.main-none-eabihf --features stm32l552ze,defmt,time-driver-any \

--- a/ci_stable.sh
+++ b/ci_stable.sh
@@ -36,6 +36,7 @@ cargo batch  \
     --- build --release --manifest-path embassy-rp/Cargo.toml --target thumbv6m-none-eabi --features unstable-traits,defmt \
     --- build --release --manifest-path embassy-rp/Cargo.toml --target thumbv6m-none-eabi --features unstable-traits,log \
     --- build --release --manifest-path embassy-rp/Cargo.toml --target thumbv6m-none-eabi \
+    --- build --release --manifest-path embassy-rp/Cargo.toml --target thumbv6m-none-eabi --features qspi-as-gpio \
     --- build --release --manifest-path embassy-stm32/Cargo.toml --target thumbv7em-none-eabi --features stm32g473cc,defmt,exti,time-driver-any,unstable-traits \
     --- build --release --manifest-path embassy-stm32/Cargo.toml --target thumbv7em-none-eabi --features stm32g491re,defmt,exti,time-driver-any,unstable-traits \
     --- build --release --manifest-path embassy-stm32/Cargo.toml --target thumbv7em-none-eabi --features stm32u585zi,defmt,exti,time-driver-any,unstable-traits \

--- a/embassy-rp/Cargo.toml
+++ b/embassy-rp/Cargo.toml
@@ -42,6 +42,10 @@ boot2-ram-memcpy = []
 boot2-w25q080 = []
 boot2-w25x10cl = []
 
+# Allow using QSPI pins as GPIO pins. This is mostly not what you want (because your flash lives there)
+# and would add both code and memory overhead when enabled needlessly.
+qspi-as-gpio = []
+
 # Indicate code is running from RAM.
 # Set this if all code is in RAM, and the cores never access memory-mapped flash memory through XIP.
 # This allows the flash driver to not force pausing execution on both cores when doing flash operations.

--- a/embassy-rp/src/clocks.rs
+++ b/embassy-rp/src/clocks.rs
@@ -702,7 +702,7 @@ impl<'d, T: Pin> Gpin<'d, T> {
     pub fn new<P: GpinPin>(gpin: impl Peripheral<P = P> + 'd) -> Gpin<'d, P> {
         into_ref!(gpin);
 
-        gpin.io().ctrl().write(|w| w.set_funcsel(0x08));
+        gpin.gpio().ctrl().write(|w| w.set_funcsel(0x08));
 
         Gpin {
             gpin: gpin.map_into(),
@@ -718,7 +718,7 @@ impl<'d, T: Pin> Gpin<'d, T> {
 impl<'d, T: Pin> Drop for Gpin<'d, T> {
     fn drop(&mut self) {
         self.gpin
-            .io()
+            .gpio()
             .ctrl()
             .write(|w| w.set_funcsel(pac::io::vals::Gpio0ctrlFuncsel::NULL as _));
     }
@@ -766,7 +766,7 @@ impl<'d, T: GpoutPin> Gpout<'d, T> {
     pub fn new(gpout: impl Peripheral<P = T> + 'd) -> Self {
         into_ref!(gpout);
 
-        gpout.io().ctrl().write(|w| w.set_funcsel(0x08));
+        gpout.gpio().ctrl().write(|w| w.set_funcsel(0x08));
 
         Self { gpout }
     }
@@ -831,7 +831,7 @@ impl<'d, T: GpoutPin> Drop for Gpout<'d, T> {
     fn drop(&mut self) {
         self.disable();
         self.gpout
-            .io()
+            .gpio()
             .ctrl()
             .write(|w| w.set_funcsel(pac::io::vals::Gpio0ctrlFuncsel::NULL as _));
     }

--- a/embassy-rp/src/gpio.rs
+++ b/embassy-rp/src/gpio.rs
@@ -643,12 +643,15 @@ pub(crate) mod sealed {
             }
         }
 
-        fn gpio(&self) -> pac::io::Gpio {
-            let block = match self._bank() {
+        fn io(&self) -> pac::io::Io {
+            match self._bank() {
                 Bank::Bank0 => crate::pac::IO_BANK0,
                 Bank::Qspi => crate::pac::IO_QSPI,
-            };
-            block.gpio(self._pin() as _)
+            }
+        }
+
+        fn gpio(&self) -> pac::io::Gpio {
+            self.io().gpio(self._pin() as _)
         }
 
         fn pad_ctrl(&self) -> Reg<pac::pads::regs::GpioCtrl, RW> {
@@ -672,12 +675,8 @@ pub(crate) mod sealed {
         }
 
         fn int_proc(&self) -> pac::io::Int {
-            let io_block = match self._bank() {
-                Bank::Bank0 => crate::pac::IO_BANK0,
-                Bank::Qspi => crate::pac::IO_QSPI,
-            };
             let proc = SIO.cpuid().read();
-            io_block.int_proc(proc as _)
+            self.io().int_proc(proc as _)
         }
     }
 }

--- a/embassy-rp/src/gpio.rs
+++ b/embassy-rp/src/gpio.rs
@@ -451,7 +451,7 @@ impl<'d, T: Pin> Flex<'d, T> {
             w.set_ie(true);
         });
 
-        pin.io().ctrl().write(|w| {
+        pin.gpio().ctrl().write(|w| {
             w.set_funcsel(pac::io::vals::Gpio0ctrlFuncsel::SIO_0 as _);
         });
 
@@ -617,7 +617,7 @@ impl<'d, T: Pin> Drop for Flex<'d, T> {
     #[inline]
     fn drop(&mut self) {
         self.pin.pad_ctrl().write(|_| {});
-        self.pin.io().ctrl().write(|w| {
+        self.pin.gpio().ctrl().write(|w| {
             w.set_funcsel(pac::io::vals::Gpio0ctrlFuncsel::NULL as _);
         });
     }
@@ -643,7 +643,7 @@ pub(crate) mod sealed {
             }
         }
 
-        fn io(&self) -> pac::io::Gpio {
+        fn gpio(&self) -> pac::io::Gpio {
             let block = match self._bank() {
                 Bank::Bank0 => crate::pac::IO_BANK0,
                 Bank::Qspi => crate::pac::IO_QSPI,

--- a/embassy-rp/src/gpio.rs
+++ b/embassy-rp/src/gpio.rs
@@ -67,6 +67,7 @@ pub enum SlewRate {
 #[derive(Debug, Eq, PartialEq)]
 pub enum Bank {
     Bank0 = 0,
+    #[cfg(feature = "qspi-as-gpio")]
     Qspi = 1,
 }
 
@@ -636,16 +637,17 @@ pub(crate) mod sealed {
 
         #[inline]
         fn _bank(&self) -> Bank {
-            if self.pin_bank() & 0x20 == 0 {
-                Bank::Bank0
-            } else {
-                Bank::Qspi
+            match self.pin_bank() & 0x20 {
+                #[cfg(feature = "qspi-as-gpio")]
+                1 => Bank::Qspi,
+                _ => Bank::Bank0,
             }
         }
 
         fn io(&self) -> pac::io::Io {
             match self._bank() {
                 Bank::Bank0 => crate::pac::IO_BANK0,
+                #[cfg(feature = "qspi-as-gpio")]
                 Bank::Qspi => crate::pac::IO_QSPI,
             }
         }
@@ -657,6 +659,7 @@ pub(crate) mod sealed {
         fn pad_ctrl(&self) -> Reg<pac::pads::regs::GpioCtrl, RW> {
             let block = match self._bank() {
                 Bank::Bank0 => crate::pac::PADS_BANK0,
+                #[cfg(feature = "qspi-as-gpio")]
                 Bank::Qspi => crate::pac::PADS_QSPI,
             };
             block.gpio(self._pin() as _)
@@ -766,11 +769,17 @@ impl_pin!(PIN_27, Bank::Bank0, 27);
 impl_pin!(PIN_28, Bank::Bank0, 28);
 impl_pin!(PIN_29, Bank::Bank0, 29);
 
+#[cfg(feature = "qspi-as-gpio")]
 impl_pin!(PIN_QSPI_SCLK, Bank::Qspi, 0);
+#[cfg(feature = "qspi-as-gpio")]
 impl_pin!(PIN_QSPI_SS, Bank::Qspi, 1);
+#[cfg(feature = "qspi-as-gpio")]
 impl_pin!(PIN_QSPI_SD0, Bank::Qspi, 2);
+#[cfg(feature = "qspi-as-gpio")]
 impl_pin!(PIN_QSPI_SD1, Bank::Qspi, 3);
+#[cfg(feature = "qspi-as-gpio")]
 impl_pin!(PIN_QSPI_SD2, Bank::Qspi, 4);
+#[cfg(feature = "qspi-as-gpio")]
 impl_pin!(PIN_QSPI_SD3, Bank::Qspi, 5);
 
 // ====================

--- a/embassy-rp/src/i2c.rs
+++ b/embassy-rp/src/i2c.rs
@@ -353,8 +353,8 @@ impl<'d, T: Instance + 'd, M: Mode> I2c<'d, T, M> {
         p.ic_rx_tl().write(|w| w.set_rx_tl(0));
 
         // Configure SCL & SDA pins
-        scl.io().ctrl().write(|w| w.set_funcsel(3));
-        sda.io().ctrl().write(|w| w.set_funcsel(3));
+        scl.gpio().ctrl().write(|w| w.set_funcsel(3));
+        sda.gpio().ctrl().write(|w| w.set_funcsel(3));
 
         scl.pad_ctrl().write(|w| {
             w.set_schmitt(true);

--- a/embassy-rp/src/pio.rs
+++ b/embassy-rp/src/pio.rs
@@ -852,7 +852,7 @@ impl<'d, PIO: Instance> Common<'d, PIO> {
     /// of [`Pio`] do not keep pin registrations alive.**
     pub fn make_pio_pin(&mut self, pin: impl Peripheral<P = impl PioPin + 'd> + 'd) -> Pin<'d, PIO> {
         into_ref!(pin);
-        pin.io().ctrl().write(|w| w.set_funcsel(PIO::FUNCSEL as _));
+        pin.gpio().ctrl().write(|w| w.set_funcsel(PIO::FUNCSEL as _));
         // we can be relaxed about this because we're &mut here and nothing is cached
         PIO::state().used_pins.fetch_or(1 << pin.pin_bank(), Ordering::Relaxed);
         Pin {

--- a/embassy-rp/src/pwm.rs
+++ b/embassy-rp/src/pwm.rs
@@ -79,10 +79,10 @@ impl<'d, T: Channel> Pwm<'d, T> {
         Self::configure(p, &config);
 
         if let Some(pin) = &a {
-            pin.io().ctrl().write(|w| w.set_funcsel(4));
+            pin.gpio().ctrl().write(|w| w.set_funcsel(4));
         }
         if let Some(pin) = &b {
-            pin.io().ctrl().write(|w| w.set_funcsel(4));
+            pin.gpio().ctrl().write(|w| w.set_funcsel(4));
         }
         Self {
             inner,
@@ -243,10 +243,10 @@ impl<'d, T: Channel> Drop for Pwm<'d, T> {
     fn drop(&mut self) {
         self.inner.regs().csr().write_clear(|w| w.set_en(false));
         if let Some(pin) = &self.pin_a {
-            pin.io().ctrl().write(|w| w.set_funcsel(31));
+            pin.gpio().ctrl().write(|w| w.set_funcsel(31));
         }
         if let Some(pin) = &self.pin_b {
-            pin.io().ctrl().write(|w| w.set_funcsel(31));
+            pin.gpio().ctrl().write(|w| w.set_funcsel(31));
         }
     }
 }

--- a/embassy-rp/src/spi.rs
+++ b/embassy-rp/src/spi.rs
@@ -100,16 +100,16 @@ impl<'d, T: Instance, M: Mode> Spi<'d, T, M> {
         p.cr1().write(|w| w.set_sse(true));
 
         if let Some(pin) = &clk {
-            pin.io().ctrl().write(|w| w.set_funcsel(1));
+            pin.gpio().ctrl().write(|w| w.set_funcsel(1));
         }
         if let Some(pin) = &mosi {
-            pin.io().ctrl().write(|w| w.set_funcsel(1));
+            pin.gpio().ctrl().write(|w| w.set_funcsel(1));
         }
         if let Some(pin) = &miso {
-            pin.io().ctrl().write(|w| w.set_funcsel(1));
+            pin.gpio().ctrl().write(|w| w.set_funcsel(1));
         }
         if let Some(pin) = &cs {
-            pin.io().ctrl().write(|w| w.set_funcsel(1));
+            pin.gpio().ctrl().write(|w| w.set_funcsel(1));
         }
         Self {
             inner,

--- a/embassy-rp/src/uart/mod.rs
+++ b/embassy-rp/src/uart/mod.rs
@@ -565,7 +565,7 @@ impl<'d, T: Instance + 'd, M: Mode> Uart<'d, T, M> {
     ) {
         let r = T::regs();
         if let Some(pin) = &tx {
-            pin.io().ctrl().write(|w| {
+            pin.gpio().ctrl().write(|w| {
                 w.set_funcsel(2);
                 w.set_outover(if config.invert_tx {
                     Outover::INVERT
@@ -576,7 +576,7 @@ impl<'d, T: Instance + 'd, M: Mode> Uart<'d, T, M> {
             pin.pad_ctrl().write(|w| w.set_ie(true));
         }
         if let Some(pin) = &rx {
-            pin.io().ctrl().write(|w| {
+            pin.gpio().ctrl().write(|w| {
                 w.set_funcsel(2);
                 w.set_inover(if config.invert_rx {
                     Inover::INVERT
@@ -587,7 +587,7 @@ impl<'d, T: Instance + 'd, M: Mode> Uart<'d, T, M> {
             pin.pad_ctrl().write(|w| w.set_ie(true));
         }
         if let Some(pin) = &cts {
-            pin.io().ctrl().write(|w| {
+            pin.gpio().ctrl().write(|w| {
                 w.set_funcsel(2);
                 w.set_inover(if config.invert_cts {
                     Inover::INVERT
@@ -598,7 +598,7 @@ impl<'d, T: Instance + 'd, M: Mode> Uart<'d, T, M> {
             pin.pad_ctrl().write(|w| w.set_ie(true));
         }
         if let Some(pin) = &rts {
-            pin.io().ctrl().write(|w| {
+            pin.gpio().ctrl().write(|w| {
                 w.set_funcsel(2);
                 w.set_outover(if config.invert_rts {
                     Outover::INVERT


### PR DESCRIPTION
qspi gpio interrupts simply would not have worked, at all. this alone has us suspect that nobody uses qspi pins for anything other than qspi, so we'll make the qspi gpio implementations optional as well to avoid the mostly-unnecessary overhead they come with. this does seem like much of a downside, anyone using qspi pins for gpio must already acknowledge this by using a different boot2 config.