### PR TITLE
stm32: add async timeout functions to I2c and TimeoutI2c

### DIFF
--- a/embassy-stm32/src/i2c/timeout.rs
+++ b/embassy-stm32/src/i2c/timeout.rs
@@ -27,6 +27,80 @@ impl<'a, 'd: 'a, T: Instance, TXDMA, RXDMA> TimeoutI2c<'a, 'd, T, TXDMA, RXDMA> 
         Self { i2c, timeout }
     }
 
+    // =========================
+    //  Async public API
+
+    pub async fn write(&mut self, address: u8, write: &[u8]) -> Result<(), Error>
+    where
+        TXDMA: crate::i2c::TxDma<T>,
+    {
+        self.write_timeout(address, write, self.timeout).await
+    }
+
+    pub async fn write_timeout(&mut self, address: u8, write: &[u8], timeout: Duration) -> Result<(), Error>
+    where
+        TXDMA: crate::i2c::TxDma<T>,
+    {
+        self.i2c.write_timeout(address, write, timeout_fn(timeout)).await
+    }
+
+    pub async fn write_vectored(&mut self, address: u8, write: &[&[u8]]) -> Result<(), Error>
+    where
+        TXDMA: crate::i2c::TxDma<T>,
+    {
+        self.write_vectored_timeout(address, write, self.timeout).await
+    }
+
+    pub async fn write_vectored_timeout(&mut self, address: u8, write: &[&[u8]], timeout: Duration) -> Result<(), Error>
+    where
+        TXDMA: crate::i2c::TxDma<T>,
+    {
+        self.i2c
+            .write_vectored_timeout(address, write, timeout_fn(timeout))
+            .await
+    }
+
+    pub async fn read(&mut self, address: u8, buffer: &mut [u8]) -> Result<(), Error>
+    where
+        RXDMA: crate::i2c::RxDma<T>,
+    {
+        self.read_timeout(address, buffer, self.timeout).await
+    }
+
+    pub async fn read_timeout(&mut self, address: u8, buffer: &mut [u8], timeout: Duration) -> Result<(), Error>
+    where
+        RXDMA: crate::i2c::RxDma<T>,
+    {
+        self.i2c.read_timeout(address, buffer, timeout_fn(timeout)).await
+    }
+
+    pub async fn write_read(&mut self, address: u8, write: &[u8], read: &mut [u8]) -> Result<(), Error>
+    where
+        TXDMA: super::TxDma<T>,
+        RXDMA: super::RxDma<T>,
+    {
+        self.write_read_timeout(address, write, read, self.timeout).await
+    }
+
+    pub async fn write_read_timeout(
+        &mut self,
+        address: u8,
+        write: &[u8],
+        read: &mut [u8],
+        timeout: Duration,
+    ) -> Result<(), Error>
+    where
+        TXDMA: super::TxDma<T>,
+        RXDMA: super::RxDma<T>,
+    {
+        self.i2c
+            .write_read_timeout(address, write, read, timeout_fn(timeout))
+            .await
+    }
+
+    // =========================
+    //  Blocking public API
+
     /// Blocking read with a custom timeout
     pub fn blocking_read_timeout(&mut self, addr: u8, read: &mut [u8], timeout: Duration) -> Result<(), Error> {
         self.i2c.blocking_read_timeout(addr, read, timeout_fn(timeout))

--- a/embassy-stm32/src/i2c/timeout.rs
+++ b/embassy-stm32/src/i2c/timeout.rs
@@ -30,6 +30,7 @@ impl<'a, 'd: 'a, T: Instance, TXDMA, RXDMA> TimeoutI2c<'a, 'd, T, TXDMA, RXDMA> 
     // =========================
     //  Async public API
 
+    #[cfg(i2c_v2)]
     pub async fn write(&mut self, address: u8, write: &[u8]) -> Result<(), Error>
     where
         TXDMA: crate::i2c::TxDma<T>,
@@ -37,6 +38,7 @@ impl<'a, 'd: 'a, T: Instance, TXDMA, RXDMA> TimeoutI2c<'a, 'd, T, TXDMA, RXDMA> 
         self.write_timeout(address, write, self.timeout).await
     }
 
+    #[cfg(i2c_v2)]
     pub async fn write_timeout(&mut self, address: u8, write: &[u8], timeout: Duration) -> Result<(), Error>
     where
         TXDMA: crate::i2c::TxDma<T>,
@@ -44,6 +46,7 @@ impl<'a, 'd: 'a, T: Instance, TXDMA, RXDMA> TimeoutI2c<'a, 'd, T, TXDMA, RXDMA> 
         self.i2c.write_timeout(address, write, timeout_fn(timeout)).await
     }
 
+    #[cfg(i2c_v2)]
     pub async fn write_vectored(&mut self, address: u8, write: &[&[u8]]) -> Result<(), Error>
     where
         TXDMA: crate::i2c::TxDma<T>,
@@ -51,6 +54,7 @@ impl<'a, 'd: 'a, T: Instance, TXDMA, RXDMA> TimeoutI2c<'a, 'd, T, TXDMA, RXDMA> 
         self.write_vectored_timeout(address, write, self.timeout).await
     }
 
+    #[cfg(i2c_v2)]
     pub async fn write_vectored_timeout(&mut self, address: u8, write: &[&[u8]], timeout: Duration) -> Result<(), Error>
     where
         TXDMA: crate::i2c::TxDma<T>,
@@ -60,6 +64,7 @@ impl<'a, 'd: 'a, T: Instance, TXDMA, RXDMA> TimeoutI2c<'a, 'd, T, TXDMA, RXDMA> 
             .await
     }
 
+    #[cfg(i2c_v2)]
     pub async fn read(&mut self, address: u8, buffer: &mut [u8]) -> Result<(), Error>
     where
         RXDMA: crate::i2c::RxDma<T>,
@@ -67,6 +72,7 @@ impl<'a, 'd: 'a, T: Instance, TXDMA, RXDMA> TimeoutI2c<'a, 'd, T, TXDMA, RXDMA> 
         self.read_timeout(address, buffer, self.timeout).await
     }
 
+    #[cfg(i2c_v2)]
     pub async fn read_timeout(&mut self, address: u8, buffer: &mut [u8], timeout: Duration) -> Result<(), Error>
     where
         RXDMA: crate::i2c::RxDma<T>,
@@ -74,6 +80,7 @@ impl<'a, 'd: 'a, T: Instance, TXDMA, RXDMA> TimeoutI2c<'a, 'd, T, TXDMA, RXDMA> 
         self.i2c.read_timeout(address, buffer, timeout_fn(timeout)).await
     }
 
+    #[cfg(i2c_v2)]
     pub async fn write_read(&mut self, address: u8, write: &[u8], read: &mut [u8]) -> Result<(), Error>
     where
         TXDMA: super::TxDma<T>,
@@ -82,6 +89,7 @@ impl<'a, 'd: 'a, T: Instance, TXDMA, RXDMA> TimeoutI2c<'a, 'd, T, TXDMA, RXDMA> 
         self.write_read_timeout(address, write, read, self.timeout).await
     }
 
+    #[cfg(i2c_v2)]
     pub async fn write_read_timeout(
         &mut self,
         address: u8,

--- a/embassy-stm32/src/i2c/timeout.rs
+++ b/embassy-stm32/src/i2c/timeout.rs
@@ -22,7 +22,7 @@ fn timeout_fn(timeout: Duration) -> impl Fn() -> Result<(), Error> {
     }
 }
 
-impl<'a, 'd, T: Instance, TXDMA, RXDMA> TimeoutI2c<'a, 'd, T, TXDMA, RXDMA> {
+impl<'a, 'd: 'a, T: Instance, TXDMA, RXDMA> TimeoutI2c<'a, 'd, T, TXDMA, RXDMA> {
     pub fn new(i2c: &'a mut I2c<'d, T, TXDMA, RXDMA>, timeout: Duration) -> Self {
         Self { i2c, timeout }
     }
@@ -65,7 +65,9 @@ impl<'a, 'd, T: Instance, TXDMA, RXDMA> TimeoutI2c<'a, 'd, T, TXDMA, RXDMA> {
     }
 }
 
-impl<'a, 'd, T: Instance, TXDMA, RXDMA> embedded_hal_02::blocking::i2c::Read for TimeoutI2c<'a, 'd, T, TXDMA, RXDMA> {
+impl<'a, 'd: 'a, T: Instance, TXDMA, RXDMA> embedded_hal_02::blocking::i2c::Read
+    for TimeoutI2c<'a, 'd, T, TXDMA, RXDMA>
+{
     type Error = Error;
 
     fn read(&mut self, addr: u8, read: &mut [u8]) -> Result<(), Self::Error> {
@@ -73,7 +75,9 @@ impl<'a, 'd, T: Instance, TXDMA, RXDMA> embedded_hal_02::blocking::i2c::Read for
     }
 }
 
-impl<'a, 'd, T: Instance, TXDMA, RXDMA> embedded_hal_02::blocking::i2c::Write for TimeoutI2c<'a, 'd, T, TXDMA, RXDMA> {
+impl<'a, 'd: 'a, T: Instance, TXDMA, RXDMA> embedded_hal_02::blocking::i2c::Write
+    for TimeoutI2c<'a, 'd, T, TXDMA, RXDMA>
+{
     type Error = Error;
 
     fn write(&mut self, addr: u8, write: &[u8]) -> Result<(), Self::Error> {
@@ -81,7 +85,7 @@ impl<'a, 'd, T: Instance, TXDMA, RXDMA> embedded_hal_02::blocking::i2c::Write fo
     }
 }
 
-impl<'a, 'd, T: Instance, TXDMA, RXDMA> embedded_hal_02::blocking::i2c::WriteRead
+impl<'a, 'd: 'a, T: Instance, TXDMA, RXDMA> embedded_hal_02::blocking::i2c::WriteRead
     for TimeoutI2c<'a, 'd, T, TXDMA, RXDMA>
 {
     type Error = Error;
@@ -95,11 +99,11 @@ impl<'a, 'd, T: Instance, TXDMA, RXDMA> embedded_hal_02::blocking::i2c::WriteRea
 mod eh1 {
     use super::*;
 
-    impl<'a, 'd, T: Instance, TXDMA, RXDMA> embedded_hal_1::i2c::ErrorType for TimeoutI2c<'a, 'd, T, TXDMA, RXDMA> {
+    impl<'a, 'd: 'a, T: Instance, TXDMA, RXDMA> embedded_hal_1::i2c::ErrorType for TimeoutI2c<'a, 'd, T, TXDMA, RXDMA> {
         type Error = Error;
     }
 
-    impl<'a, 'd, T: Instance, TXDMA, RXDMA> embedded_hal_1::i2c::I2c for TimeoutI2c<'a, 'd, T, TXDMA, RXDMA> {
+    impl<'a, 'd: 'a, T: Instance, TXDMA, RXDMA> embedded_hal_1::i2c::I2c for TimeoutI2c<'a, 'd, T, TXDMA, RXDMA> {
         fn read(&mut self, address: u8, read: &mut [u8]) -> Result<(), Self::Error> {
             self.blocking_read(address, read)
         }

--- a/embassy-stm32/src/i2c/v2.rs
+++ b/embassy-stm32/src/i2c/v2.rs
@@ -598,14 +598,38 @@ impl<'d, T: Instance, TXDMA, RXDMA> I2c<'d, T, TXDMA, RXDMA> {
     where
         TXDMA: crate::i2c::TxDma<T>,
     {
+        self.write_timeout(address, write, || Ok(())).await
+    }
+
+    pub async fn write_timeout(
+        &mut self,
+        address: u8,
+        write: &[u8],
+        check_timeout: impl Fn() -> Result<(), Error>,
+    ) -> Result<(), Error>
+    where
+        TXDMA: crate::i2c::TxDma<T>,
+    {
         if write.is_empty() {
-            self.write_internal(address, write, true, || Ok(()))
+            self.write_internal(address, write, true, check_timeout)
         } else {
-            self.write_dma_internal(address, write, true, true, || Ok(())).await
+            self.write_dma_internal(address, write, true, true, check_timeout).await
         }
     }
 
     pub async fn write_vectored(&mut self, address: u8, write: &[&[u8]]) -> Result<(), Error>
+    where
+        TXDMA: crate::i2c::TxDma<T>,
+    {
+        self.write_vectored_timeout(address, write, || Ok(())).await
+    }
+
+    pub async fn write_vectored_timeout(
+        &mut self,
+        address: u8,
+        write: &[&[u8]],
+        check_timeout: impl Fn() -> Result<(), Error>,
+    ) -> Result<(), Error>
     where
         TXDMA: crate::i2c::TxDma<T>,
     {
@@ -620,7 +644,8 @@ impl<'d, T: Instance, TXDMA, RXDMA> I2c<'d, T, TXDMA, RXDMA> {
             let next = iter.next();
             let is_last = next.is_none();
 
-            self.write_dma_internal(address, c, first, is_last, || Ok(())).await?;
+            self.write_dma_internal(address, c, first, is_last, || check_timeout())
+                .await?;
             first = false;
             current = next;
         }
@@ -631,10 +656,22 @@ impl<'d, T: Instance, TXDMA, RXDMA> I2c<'d, T, TXDMA, RXDMA> {
     where
         RXDMA: crate::i2c::RxDma<T>,
     {
+        self.read_timeout(address, buffer, || Ok(())).await
+    }
+
+    pub async fn read_timeout(
+        &mut self,
+        address: u8,
+        buffer: &mut [u8],
+        check_timeout: impl Fn() -> Result<(), Error>,
+    ) -> Result<(), Error>
+    where
+        RXDMA: crate::i2c::RxDma<T>,
+    {
         if buffer.is_empty() {
-            self.read_internal(address, buffer, false, || Ok(()))
+            self.read_internal(address, buffer, false, check_timeout)
         } else {
-            self.read_dma_internal(address, buffer, false, || Ok(())).await
+            self.read_dma_internal(address, buffer, false, check_timeout).await
         }
     }
 
@@ -643,16 +680,31 @@ impl<'d, T: Instance, TXDMA, RXDMA> I2c<'d, T, TXDMA, RXDMA> {
         TXDMA: super::TxDma<T>,
         RXDMA: super::RxDma<T>,
     {
+        self.write_read_timeout(address, write, read, || Ok(())).await
+    }
+
+    pub async fn write_read_timeout(
+        &mut self,
+        address: u8,
+        write: &[u8],
+        read: &mut [u8],
+        check_timeout: impl Fn() -> Result<(), Error>,
+    ) -> Result<(), Error>
+    where
+        TXDMA: super::TxDma<T>,
+        RXDMA: super::RxDma<T>,
+    {
         if write.is_empty() {
-            self.write_internal(address, write, false, || Ok(()))?;
+            self.write_internal(address, write, false, || check_timeout())?;
         } else {
-            self.write_dma_internal(address, write, true, true, || Ok(())).await?;
+            self.write_dma_internal(address, write, true, true, || check_timeout())
+                .await?;
         }
 
         if read.is_empty() {
-            self.read_internal(address, read, true, || Ok(()))?;
+            self.read_internal(address, read, true, check_timeout)?;
         } else {
-            self.read_dma_internal(address, read, true, || Ok(())).await?;
+            self.read_dma_internal(address, read, true, check_timeout).await?;
         }
 
         Ok(())


### PR DESCRIPTION
I think it's fine as is but there are two things I thought about:

1. Wrapping `async fn`s like this might create some bloat. I'm not sure what the best practice is, but this is simplest and I expect LTO to handle it.
2. These timeouts are currently only checked inside of busy-wait loops inside the I2C implementation. If it is waiting for a DMA transfer to complete, for example, the timeout expiry won't interrupt that. We could use something like [embassy_time::with_timeout](https://docs.embassy.dev/embassy-time/git/default/fn.with_timeout.html#) to stop polling when the timeout expires but I'm not sure if that would leave the peripheral in an invalid state or something.