### PR TITLE
LSE requires setting PWREN bit on STM32L4

### DIFF
--- a/embassy-stm32/src/rcc/l4.rs
+++ b/embassy-stm32/src/rcc/l4.rs
@@ -412,6 +412,7 @@ pub(crate) unsafe fn init(config: Config) {
     match config.rtc_mux {
         RtcClockSource::LSE32 => {
             // 1. Unlock the backup domain
+            RCC.apb1enr1().modify(|w| w.set_pwren(true));
             PWR.cr1().modify(|w| w.set_dbp(true));
 
             // 2. Setup the LSE


### PR DESCRIPTION
According to the reference manual RM0394, section 5.1.4, Backup domain Access:
To make changes to the RTC registers, you first need to enable the power interface clock by setting the PWREN bits.

This is missing from the current code and the program will hang on while !RCC.csr().read().lsirdy() {} every time on my STM32L431.

Adding the line to set the bit fixes the issue.