### PR TITLE
stm32/dma: consolidate code for ringbuf

### DIFF
--- a/embassy-stm32/src/dma/bdma.rs
+++ b/embassy-stm32/src/dma/bdma.rs
@@ -17,7 +17,7 @@ use crate::_generated::BDMA_CHANNEL_COUNT;
 use crate::interrupt::typelevel::Interrupt;
 use crate::interrupt::Priority;
 use crate::pac;
-use crate::pac::bdma::{regs, vals};
+use crate::pac::bdma::vals;
 
 #[derive(Debug, Copy, Clone, PartialEq, Eq)]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]

--- a/embassy-stm32/src/dma/bdma.rs
+++ b/embassy-stm32/src/dma/bdma.rs
@@ -406,6 +406,10 @@ impl<'a, C: Channel> DmaCtrl for DmaCtrlImpl<'a, C> {
     fn reset_complete_count(&mut self) -> usize {
         STATE.complete_count[self.0.index()].swap(0, Ordering::AcqRel)
     }
+
+    fn set_waker(&mut self, waker: &Waker) {
+        STATE.ch_wakers[self.0.index()].register(waker);
+    }
 }
 
 pub struct ReadableRingBuffer<'a, C: Channel, W: Word> {
@@ -458,7 +462,7 @@ impl<'a, C: Channel, W: Word> ReadableRingBuffer<'a, C, W> {
     }
 
     pub fn clear(&mut self) {
-        self.ringbuf.clear(DmaCtrlImpl(self.channel.reborrow()));
+        self.ringbuf.clear(&mut DmaCtrlImpl(self.channel.reborrow()));
     }
 
     /// Read elements from the ring buffer
@@ -467,7 +471,7 @@ impl<'a, C: Channel, W: Word> ReadableRingBuffer<'a, C, W> {
     /// The length remaining is the capacity, ring_buf.len(), less the elements remaining after the read
     /// OverrunError is returned if the portion to be read was overwritten by the DMA controller.
     pub fn read(&mut self, buf: &mut [W]) -> Result<(usize, usize), OverrunError> {
-        self.ringbuf.read(DmaCtrlImpl(self.channel.reborrow()), buf)
+        self.ringbuf.read(&mut DmaCtrlImpl(self.channel.reborrow()), buf)
     }
 
     /// Read an exact number of elements from the ringbuffer.
@@ -482,30 +486,9 @@ impl<'a, C: Channel, W: Word> ReadableRingBuffer<'a, C, W> {
     /// - If M equals N/2 or N/2 divides evenly into M, this function will return every N/2 elements read on the DMA source.
     /// - Otherwise, this function may need up to N/2 extra elements to arrive before returning.
     pub async fn read_exact(&mut self, buffer: &mut [W]) -> Result<usize, OverrunError> {
-        use core::future::poll_fn;
-        use core::sync::atomic::compiler_fence;
-
-        let mut read_data = 0;
-        let buffer_len = buffer.len();
-
-        poll_fn(|cx| {
-            self.set_waker(cx.waker());
-
-            compiler_fence(Ordering::SeqCst);
-
-            match self.read(&mut buffer[read_data..buffer_len]) {
-                Ok((len, remaining)) => {
-                    read_data += len;
-                    if read_data == buffer_len {
-                        Poll::Ready(Ok(remaining))
-                    } else {
-                        Poll::Pending
-                    }
-                }
-                Err(e) => Poll::Ready(Err(e)),
-            }
-        })
-        .await
+        self.ringbuf
+            .read_exact(&mut DmaCtrlImpl(self.channel.reborrow()), buffer)
+            .await
     }
 
     /// The capacity of the ringbuffer.
@@ -514,7 +497,7 @@ impl<'a, C: Channel, W: Word> ReadableRingBuffer<'a, C, W> {
     }
 
     pub fn set_waker(&mut self, waker: &Waker) {
-        STATE.ch_wakers[self.channel.index()].register(waker);
+        DmaCtrlImpl(self.channel.reborrow()).set_waker(waker);
     }
 
     fn clear_irqs(&mut self) {
@@ -607,41 +590,20 @@ impl<'a, C: Channel, W: Word> WritableRingBuffer<'a, C, W> {
     }
 
     pub fn clear(&mut self) {
-        self.ringbuf.clear(DmaCtrlImpl(self.channel.reborrow()));
+        self.ringbuf.clear(&mut DmaCtrlImpl(self.channel.reborrow()));
     }
 
     /// Write elements to the ring buffer
     /// Return a tuple of the length written and the length remaining in the buffer
     pub fn write(&mut self, buf: &[W]) -> Result<(usize, usize), OverrunError> {
-        self.ringbuf.write(DmaCtrlImpl(self.channel.reborrow()), buf)
+        self.ringbuf.write(&mut DmaCtrlImpl(self.channel.reborrow()), buf)
     }
 
     /// Write an exact number of elements to the ringbuffer.
     pub async fn write_exact(&mut self, buffer: &[W]) -> Result<usize, OverrunError> {
-        use core::future::poll_fn;
-        use core::sync::atomic::compiler_fence;
-
-        let mut written_data = 0;
-        let buffer_len = buffer.len();
-
-        poll_fn(|cx| {
-            self.set_waker(cx.waker());
-
-            compiler_fence(Ordering::SeqCst);
-
-            match self.write(&buffer[written_data..buffer_len]) {
-                Ok((len, remaining)) => {
-                    written_data += len;
-                    if written_data == buffer_len {
-                        Poll::Ready(Ok(remaining))
-                    } else {
-                        Poll::Pending
-                    }
-                }
-                Err(e) => Poll::Ready(Err(e)),
-            }
-        })
-        .await
+        self.ringbuf
+            .write_exact(&mut DmaCtrlImpl(self.channel.reborrow()), buffer)
+            .await
     }
 
     /// The capacity of the ringbuffer.
@@ -650,7 +612,7 @@ impl<'a, C: Channel, W: Word> WritableRingBuffer<'a, C, W> {
     }
 
     pub fn set_waker(&mut self, waker: &Waker) {
-        STATE.ch_wakers[self.channel.index()].register(waker);
+        DmaCtrlImpl(self.channel.reborrow()).set_waker(waker);
     }
 
     fn clear_irqs(&mut self) {

--- a/embassy-stm32/src/dma/dma.rs
+++ b/embassy-stm32/src/dma/dma.rs
@@ -633,6 +633,10 @@ impl<'a, C: Channel> DmaCtrl for DmaCtrlImpl<'a, C> {
     fn reset_complete_count(&mut self) -> usize {
         STATE.complete_count[self.0.index()].swap(0, Ordering::AcqRel)
     }
+
+    fn set_waker(&mut self, waker: &Waker) {
+        STATE.ch_wakers[self.0.index()].register(waker);
+    }
 }
 
 pub struct ReadableRingBuffer<'a, C: Channel, W: Word> {
@@ -684,7 +688,7 @@ impl<'a, C: Channel, W: Word> ReadableRingBuffer<'a, C, W> {
     }
 
     pub fn clear(&mut self) {
-        self.ringbuf.clear(DmaCtrlImpl(self.channel.reborrow()));
+        self.ringbuf.clear(&mut DmaCtrlImpl(self.channel.reborrow()));
     }
 
     /// Read elements from the ring buffer
@@ -693,7 +697,7 @@ impl<'a, C: Channel, W: Word> ReadableRingBuffer<'a, C, W> {
     /// The length remaining is the capacity, ring_buf.len(), less the elements remaining after the read
     /// OverrunError is returned if the portion to be read was overwritten by the DMA controller.
     pub fn read(&mut self, buf: &mut [W]) -> Result<(usize, usize), OverrunError> {
-        self.ringbuf.read(DmaCtrlImpl(self.channel.reborrow()), buf)
+        self.ringbuf.read(&mut DmaCtrlImpl(self.channel.reborrow()), buf)
     }
 
     /// Read an exact number of elements from the ringbuffer.
@@ -708,30 +712,9 @@ impl<'a, C: Channel, W: Word> ReadableRingBuffer<'a, C, W> {
     /// - If M equals N/2 or N/2 divides evenly into M, this function will return every N/2 elements read on the DMA source.
     /// - Otherwise, this function may need up to N/2 extra elements to arrive before returning.
     pub async fn read_exact(&mut self, buffer: &mut [W]) -> Result<usize, OverrunError> {
-        use core::future::poll_fn;
-        use core::sync::atomic::compiler_fence;
-
-        let mut read_data = 0;
-        let buffer_len = buffer.len();
-
-        poll_fn(|cx| {
-            self.set_waker(cx.waker());
-
-            compiler_fence(Ordering::SeqCst);
-
-            match self.read(&mut buffer[read_data..buffer_len]) {
-                Ok((len, remaining)) => {
-                    read_data += len;
-                    if read_data == buffer_len {
-                        Poll::Ready(Ok(remaining))
-                    } else {
-                        Poll::Pending
-                    }
-                }
-                Err(e) => Poll::Ready(Err(e)),
-            }
-        })
-        .await
+        self.ringbuf
+            .read_exact(&mut DmaCtrlImpl(self.channel.reborrow()), buffer)
+            .await
     }
 
     // The capacity of the ringbuffer
@@ -835,41 +818,20 @@ impl<'a, C: Channel, W: Word> WritableRingBuffer<'a, C, W> {
     }
 
     pub fn clear(&mut self) {
-        self.ringbuf.clear(DmaCtrlImpl(self.channel.reborrow()));
+        self.ringbuf.clear(&mut DmaCtrlImpl(self.channel.reborrow()));
     }
 
     /// Write elements from the ring buffer
     /// Return a tuple of the length written and the length remaining in the buffer
     pub fn write(&mut self, buf: &[W]) -> Result<(usize, usize), OverrunError> {
-        self.ringbuf.write(DmaCtrlImpl(self.channel.reborrow()), buf)
+        self.ringbuf.write(&mut DmaCtrlImpl(self.channel.reborrow()), buf)
     }
 
     /// Write an exact number of elements to the ringbuffer.
     pub async fn write_exact(&mut self, buffer: &[W]) -> Result<usize, OverrunError> {
-        use core::future::poll_fn;
-        use core::sync::atomic::compiler_fence;
-
-        let mut written_data = 0;
-        let buffer_len = buffer.len();
-
-        poll_fn(|cx| {
-            self.set_waker(cx.waker());
-
-            compiler_fence(Ordering::SeqCst);
-
-            match self.write(&buffer[written_data..buffer_len]) {
-                Ok((len, remaining)) => {
-                    written_data += len;
-                    if written_data == buffer_len {
-                        Poll::Ready(Ok(remaining))
-                    } else {
-                        Poll::Pending
-                    }
-                }
-                Err(e) => Poll::Ready(Err(e)),
-            }
-        })
-        .await
+        self.ringbuf
+            .write_exact(&mut DmaCtrlImpl(self.channel.reborrow()), buffer)
+            .await
     }
 
     // The capacity of the ringbuffer

--- a/embassy-stm32/src/dma/mod.rs
+++ b/embassy-stm32/src/dma/mod.rs
@@ -34,7 +34,7 @@ use crate::interrupt::Priority;
 
 #[derive(Debug, Copy, Clone, PartialEq, Eq)]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
-enum Dir {
+pub(crate) enum Dir {
     MemoryToPeripheral,
     PeripheralToMemory,
 }

--- a/embassy-stm32/src/dma/ringbuffer.rs
+++ b/embassy-stm32/src/dma/ringbuffer.rs
@@ -386,7 +386,7 @@ mod tests {
         requests: cell::RefCell<vec::Vec<TestCircularTransferRequest>>,
     }
 
-    impl DmaCtrl for &mut TestCircularTransfer {
+    impl DmaCtrl for TestCircularTransfer {
         fn get_remaining_transfers(&self) -> usize {
             match self.requests.borrow_mut().pop().unwrap() {
                 TestCircularTransferRequest::PositionRequest(pos) => {
@@ -413,6 +413,8 @@ mod tests {
                 _ => unreachable!(),
             }
         }
+
+        fn set_waker(&mut self, waker: &Waker) {}
     }
 
     impl TestCircularTransfer {


### PR DESCRIPTION
It did not save as many lines as I thought it would, but some duplication is reduced.