### PR TITLE
Refactor firmware updater

### DIFF
--- a/embassy-boot/boot/src/firmware_updater/mod.rs
+++ b/embassy-boot/boot/src/firmware_updater/mod.rs
@@ -3,8 +3,8 @@ mod asynch;
 mod blocking;
 
 #[cfg(feature = "nightly")]
-pub use asynch::FirmwareUpdater;
-pub use blocking::BlockingFirmwareUpdater;
+pub use asynch::{FirmwareState, FirmwareUpdater};
+pub use blocking::{BlockingFirmwareState, BlockingFirmwareUpdater};
 use embedded_storage::nor_flash::{NorFlashError, NorFlashErrorKind};
 
 /// Firmware updater flash configuration holding the two flashes used by the updater

--- a/embassy-boot/nrf/src/lib.rs
+++ b/embassy-boot/nrf/src/lib.rs
@@ -3,9 +3,11 @@
 #![doc = include_str!("../README.md")]
 mod fmt;
 
+pub use embassy_boot::{
+    AlignedBuffer, BlockingFirmwareState, BlockingFirmwareUpdater, BootLoaderConfig, FirmwareUpdaterConfig,
+};
 #[cfg(feature = "nightly")]
-pub use embassy_boot::FirmwareUpdater;
-pub use embassy_boot::{AlignedBuffer, BlockingFirmwareUpdater, BootLoaderConfig, FirmwareUpdaterConfig};
+pub use embassy_boot::{FirmwareState, FirmwareUpdater};
 use embassy_nrf::nvmc::PAGE_SIZE;
 use embassy_nrf::peripherals::WDT;
 use embassy_nrf::wdt;

--- a/embassy-boot/rp/src/lib.rs
+++ b/embassy-boot/rp/src/lib.rs
@@ -3,9 +3,11 @@
 #![doc = include_str!("../README.md")]
 mod fmt;
 
+pub use embassy_boot::{
+    AlignedBuffer, BlockingFirmwareState, BlockingFirmwareUpdater, BootLoaderConfig, FirmwareUpdaterConfig, State,
+};
 #[cfg(feature = "nightly")]
-pub use embassy_boot::FirmwareUpdater;
-pub use embassy_boot::{AlignedBuffer, BlockingFirmwareUpdater, BootLoaderConfig, FirmwareUpdaterConfig, State};
+pub use embassy_boot::{FirmwareState, FirmwareUpdater};
 use embassy_rp::flash::{Blocking, Flash, ERASE_SIZE};
 use embassy_rp::peripherals::{FLASH, WATCHDOG};
 use embassy_rp::watchdog::Watchdog;

--- a/embassy-boot/stm32/src/lib.rs
+++ b/embassy-boot/stm32/src/lib.rs
@@ -3,9 +3,11 @@
 #![doc = include_str!("../README.md")]
 mod fmt;
 
+pub use embassy_boot::{
+    AlignedBuffer, BlockingFirmwareState, BlockingFirmwareUpdater, BootLoaderConfig, FirmwareUpdaterConfig, State,
+};
 #[cfg(feature = "nightly")]
-pub use embassy_boot::FirmwareUpdater;
-pub use embassy_boot::{AlignedBuffer, BlockingFirmwareUpdater, BootLoaderConfig, FirmwareUpdaterConfig, State};
+pub use embassy_boot::{FirmwareState, FirmwareUpdater};
 use embedded_storage::nor_flash::NorFlash;
 
 /// A bootloader for STM32 devices.

--- a/examples/boot/application/rp/src/bin/a.rs
+++ b/examples/boot/application/rp/src/bin/a.rs
@@ -38,7 +38,8 @@ async fn main(_s: Spawner) {
     let flash = Mutex::new(RefCell::new(flash));
 
     let config = FirmwareUpdaterConfig::from_linkerfile_blocking(&flash);
-    let mut updater = BlockingFirmwareUpdater::new(config);
+    let mut aligned = AlignedBuffer([0; 4]);
+    let mut updater = BlockingFirmwareUpdater::new(config, &mut aligned.0);
 
     Timer::after(Duration::from_secs(5)).await;
     watchdog.feed();
@@ -47,7 +48,7 @@ async fn main(_s: Spawner) {
     let mut buf: AlignedBuffer<4096> = AlignedBuffer([0; 4096]);
     defmt::info!("preparing update");
     let writer = updater
-        .prepare_update(&mut buf.0[..1])
+        .prepare_update()
         .map_err(|e| defmt::warn!("E: {:?}", defmt::Debug2Format(&e)))
         .unwrap();
     defmt::info!("writer created, starting write");
@@ -59,7 +60,7 @@ async fn main(_s: Spawner) {
     }
     watchdog.feed();
     defmt::info!("firmware written, marking update");
-    updater.mark_updated(&mut buf.0[..1]).unwrap();
+    updater.mark_updated().unwrap();
     Timer::after(Duration::from_secs(2)).await;
     led.set_low();
     defmt::info!("update marked, resetting");

--- a/examples/boot/application/stm32f3/src/bin/a.rs
+++ b/examples/boot/application/stm32f3/src/bin/a.rs
@@ -31,17 +31,17 @@ async fn main(_spawner: Spawner) {
     led.set_high();
 
     let config = FirmwareUpdaterConfig::from_linkerfile(&flash);
-    let mut updater = FirmwareUpdater::new(config);
+    let mut magic = AlignedBuffer([0; WRITE_SIZE]);
+    let mut updater = FirmwareUpdater::new(config, &mut magic.0);
     button.wait_for_falling_edge().await;
     let mut offset = 0;
-    let mut magic = AlignedBuffer([0; WRITE_SIZE]);
     for chunk in APP_B.chunks(2048) {
         let mut buf: [u8; 2048] = [0; 2048];
         buf[..chunk.len()].copy_from_slice(chunk);
-        updater.write_firmware(magic.as_mut(), offset, &buf).await.unwrap();
+        updater.write_firmware(offset, &buf).await.unwrap();
         offset += chunk.len();
     }
-    updater.mark_updated(magic.as_mut()).await.unwrap();
+    updater.mark_updated().await.unwrap();
     led.set_low();
     cortex_m::peripheral::SCB::sys_reset();
 }

--- a/examples/boot/application/stm32f7/src/bin/a.rs
+++ b/examples/boot/application/stm32f7/src/bin/a.rs
@@ -33,9 +33,9 @@ async fn main(_spawner: Spawner) {
     led.set_high();
 
     let config = FirmwareUpdaterConfig::from_linkerfile_blocking(&flash);
-    let mut updater = BlockingFirmwareUpdater::new(config);
     let mut magic = AlignedBuffer([0; WRITE_SIZE]);
-    let writer = updater.prepare_update(magic.as_mut()).unwrap();
+    let mut updater = BlockingFirmwareUpdater::new(config, &mut magic.0);
+    let writer = updater.prepare_update().unwrap();
     button.wait_for_rising_edge().await;
     let mut offset = 0;
     let mut buf = AlignedBuffer([0; 4096]);
@@ -44,7 +44,7 @@ async fn main(_spawner: Spawner) {
         writer.write(offset, buf.as_ref()).unwrap();
         offset += chunk.len() as u32;
     }
-    updater.mark_updated(magic.as_mut()).unwrap();
+    updater.mark_updated().unwrap();
     led.set_low();
     cortex_m::peripheral::SCB::sys_reset();
 }

--- a/examples/boot/application/stm32h7/src/bin/a.rs
+++ b/examples/boot/application/stm32h7/src/bin/a.rs
@@ -34,8 +34,8 @@ async fn main(_spawner: Spawner) {
 
     let config = FirmwareUpdaterConfig::from_linkerfile_blocking(&flash);
     let mut magic = AlignedBuffer([0; WRITE_SIZE]);
-    let mut updater = BlockingFirmwareUpdater::new(config);
-    let writer = updater.prepare_update(magic.as_mut()).unwrap();
+    let mut updater = BlockingFirmwareUpdater::new(config, &mut magic.0);
+    let writer = updater.prepare_update().unwrap();
     button.wait_for_rising_edge().await;
     let mut offset = 0;
     let mut buf = AlignedBuffer([0; 4096]);
@@ -44,7 +44,7 @@ async fn main(_spawner: Spawner) {
         writer.write(offset, buf.as_ref()).unwrap();
         offset += chunk.len() as u32;
     }
-    updater.mark_updated(magic.as_mut()).unwrap();
+    updater.mark_updated().unwrap();
     led.set_low();
     cortex_m::peripheral::SCB::sys_reset();
 }

--- a/examples/boot/application/stm32l1/src/bin/a.rs
+++ b/examples/boot/application/stm32l1/src/bin/a.rs
@@ -33,18 +33,18 @@ async fn main(_spawner: Spawner) {
     led.set_high();
 
     let config = FirmwareUpdaterConfig::from_linkerfile(&flash);
-    let mut updater = FirmwareUpdater::new(config);
-    button.wait_for_falling_edge().await;
     let mut magic = AlignedBuffer([0; WRITE_SIZE]);
+    let mut updater = FirmwareUpdater::new(config, &mut magic.0);
+    button.wait_for_falling_edge().await;
     let mut offset = 0;
     for chunk in APP_B.chunks(128) {
         let mut buf: [u8; 128] = [0; 128];
         buf[..chunk.len()].copy_from_slice(chunk);
-        updater.write_firmware(magic.as_mut(), offset, &buf).await.unwrap();
+        updater.write_firmware(offset, &buf).await.unwrap();
         offset += chunk.len();
     }
 
-    updater.mark_updated(magic.as_mut()).await.unwrap();
+    updater.mark_updated().await.unwrap();
     led.set_low();
     Timer::after(Duration::from_secs(1)).await;
     cortex_m::peripheral::SCB::sys_reset();

--- a/examples/boot/application/stm32l4/src/bin/a.rs
+++ b/examples/boot/application/stm32l4/src/bin/a.rs
@@ -31,17 +31,17 @@ async fn main(_spawner: Spawner) {
     led.set_high();
 
     let config = FirmwareUpdaterConfig::from_linkerfile(&flash);
-    let mut updater = FirmwareUpdater::new(config);
-    button.wait_for_falling_edge().await;
     let mut magic = AlignedBuffer([0; WRITE_SIZE]);
+    let mut updater = FirmwareUpdater::new(config, &mut magic.0);
+    button.wait_for_falling_edge().await;
     let mut offset = 0;
     for chunk in APP_B.chunks(2048) {
         let mut buf: [u8; 2048] = [0; 2048];
         buf[..chunk.len()].copy_from_slice(chunk);
-        updater.write_firmware(magic.as_mut(), offset, &buf).await.unwrap();
+        updater.write_firmware(offset, &buf).await.unwrap();
         offset += chunk.len();
     }
-    updater.mark_updated(magic.as_mut()).await.unwrap();
+    updater.mark_updated().await.unwrap();
     led.set_low();
     cortex_m::peripheral::SCB::sys_reset();
 }


### PR DESCRIPTION
* Allow manipulating state without accessing DFU partition.
* Provide aligned buffer when creating updater to reduce potential wrong parameters passed.
