### PR TITLE
Fix package name for stm32f334-examples

### DIFF
--- a/examples/stm32f334/Cargo.toml
+++ b/examples/stm32f334/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 edition = "2021"
-name = "embassy-stm32f3-examples"
+name = "embassy-stm32f334-examples"
 version = "0.1.0"
 license = "MIT OR Apache-2.0"
 


### PR DESCRIPTION
Fixes this warning on `cargo update` etc:

    warning: skipping duplicate package `embassy-stm32f3-examples` found at `/home/adam/.cargo/git/checkouts/embassy-9312dcb0ed774b29/a40daa9/examples/stm32f3`