### PR TITLE
stm32: add note about Output/OutputOpenDrain drop behavior

### DIFF
--- a/embassy-stm32/src/gpio.rs
+++ b/embassy-stm32/src/gpio.rs
@@ -351,6 +351,10 @@ impl From<Level> for bool {
 }
 
 /// GPIO output driver.
+///
+/// Note that pins will **return to their floating state** when `Output` is dropped.
+/// If pins should retain their state indefinitely, either keep ownership of the
+/// `Output`, or pass it to [`core::mem::forget`].
 pub struct Output<'d, T: Pin> {
     pub(crate) pin: Flex<'d, T>,
 }
@@ -418,6 +422,10 @@ impl<'d, T: Pin> Output<'d, T> {
 }
 
 /// GPIO output open-drain driver.
+///
+/// Note that pins will **return to their floating state** when `OutputOpenDrain` is dropped.
+/// If pins should retain their state indefinitely, either keep ownership of the
+/// `OutputOpenDrain`, or pass it to [`core::mem::forget`].
 pub struct OutputOpenDrain<'d, T: Pin> {
     pub(crate) pin: Flex<'d, T>,
 }


### PR DESCRIPTION
Following some discussion in Matrix after a very long debugging session today, I figured these notes might help others who are coming from firmware environments other than Embassy that treat pins as persistent across the lifetime of the firmware's execution (e.g. ST's own HAL layer in C/C++).