### PR TITLE
Update `Handler` and `RequestHandler` traits to enable cross-core usb

### DIFF
--- a/embassy-usb/src/class/hid.rs
+++ b/embassy-usb/src/class/hid.rs
@@ -370,7 +370,7 @@ impl<'d, D: Driver<'d>, const N: usize> HidReader<'d, D, N> {
 }
 
 /// Handler for HID-related control requests.
-pub trait RequestHandler {
+pub trait RequestHandler: Sync + Send {
     /// Reads the value of report `id` into `buf` returning the size.
     ///
     /// Returns `None` if `id` is invalid or no data is available.

--- a/embassy-usb/src/lib.rs
+++ b/embassy-usb/src/lib.rs
@@ -85,7 +85,7 @@ const STRING_INDEX_CUSTOM_START: u8 = 4;
 ///
 /// All methods are optional callbacks that will be called by
 /// [`UsbDevice::run()`](crate::UsbDevice::run)
-pub trait Handler {
+pub trait Handler: Sync + Send {
     /// Called when the USB device has been enabled or disabled.
     fn enabled(&mut self, _enabled: bool) {}
 

--- a/tests/rp/Cargo.toml
+++ b/tests/rp/Cargo.toml
@@ -13,6 +13,7 @@ embassy-time = { version = "0.1.2", path = "../../embassy-time", features = ["de
 embassy-rp = { version = "0.1.0", path = "../../embassy-rp", features = ["nightly", "defmt", "unstable-pac", "unstable-traits", "time-driver", "critical-section-impl", "intrinsics", "rom-v2-intrinsics", "run-from-ram"]  }
 embassy-futures = { version = "0.1.0", path = "../../embassy-futures" }
 embassy-net = { version = "0.1.0", path = "../../embassy-net", features = ["defmt", "nightly", "tcp", "udp", "dhcpv4", "medium-ethernet"] }
+embassy-usb = { version = "0.1.0", path = "../../embassy-usb", features = ["defmt"] }
 cyw43 = { path = "../../cyw43", features = ["defmt", "firmware-logs"] }
 cyw43-pio = { path = "../../cyw43-pio", features = ["defmt", "overclock"] }
 

--- a/tests/rp/src/bin/usb_multicore.rs
+++ b/tests/rp/src/bin/usb_multicore.rs
@@ -1,0 +1,102 @@
+#![no_std]
+#![no_main]
+#![feature(type_alias_impl_trait)]
+#[path = "../common.rs"]
+mod common;
+
+use defmt::{info, unwrap};
+use embassy_executor::Executor;
+use embassy_executor::_export::StaticCell;
+use embassy_rp::multicore::{spawn_core1, Stack};
+use embassy_sync::blocking_mutex::raw::CriticalSectionRawMutex;
+use embassy_sync::channel::Channel;
+use embassy_rp::bind_interrupts;
+use embassy_rp::pac::usb::Usb;
+use embassy_rp::peripherals::USB;
+use embassy_rp::usb::{Driver, InterruptHandler};
+use embassy_time::{Duration, Timer};
+use embassy_usb::Builder;
+use embassy_usb::class::cdc_acm::{CdcAcmClass, State};
+use static_cell::make_static;
+use {defmt_rtt as _, panic_probe as _};
+
+static mut CORE1_STACK: Stack<4096> = Stack::new();
+static EXECUTOR0: StaticCell<Executor> = StaticCell::new();
+static EXECUTOR1: StaticCell<Executor> = StaticCell::new();
+static CHANNEL0: Channel<CriticalSectionRawMutex, bool, 1> = Channel::new();
+static CHANNEL1: Channel<CriticalSectionRawMutex, bool, 1> = Channel::new();
+
+bind_interrupts!(struct Irqs {
+    USBCTRL_IRQ => InterruptHandler<USB>;
+});
+
+#[cortex_m_rt::entry]
+fn main() -> ! {
+    let p = embassy_rp::init(Default::default());
+
+    // Create the driver, from the HAL.
+    let driver = Driver::new(p.USB, Irqs);
+
+    let mut config = embassy_usb::Config::new(0xc0de, 0xcafe);
+    config.manufacturer = Some("Embassy");
+    config.product = Some("USB-serial logger");
+    config.serial_number = Some("12345678");
+    config.max_power = 100;
+    config.max_packet_size_0 = 8;
+
+    // Required for windows compatiblity.
+    // https://developer.nordicsemi.com/nRF_Connect_SDK/doc/1.9.1/kconfig/CONFIG_CDC_ACM_IAD.html#help
+    config.device_class = 0xEF;
+    config.device_sub_class = 0x02;
+    config.device_protocol = 0x01;
+    config.composite_with_iads = true;
+
+    let device_descriptor = make_static!([0; 256]);
+    let config_descriptor = make_static!([0; 256]);
+    let bos_descriptor = make_static!([0; 256]);
+    let control_buf = make_static!([0; 64]);
+    let state = make_static!(State::new());
+
+    let mut builder = Builder::new(
+        driver,
+        config,
+        device_descriptor,
+        config_descriptor,
+        bos_descriptor,
+        control_buf,
+    );
+
+    // Create classes on the builder.
+    let class = make_static!(CdcAcmClass::new(&mut builder, state, 8));
+    let usb = make_static!(builder.build());
+
+    spawn_core1(p.CORE1, unsafe { &mut CORE1_STACK }, move || {
+        let executor1 = EXECUTOR1.init(Executor::new());
+        executor1.run(|spawner| {
+            unwrap!(spawner.spawn(run_usb(usb)));
+        });
+    });
+    let executor0 = EXECUTOR0.init(Executor::new());
+    executor0.run(|spawner| unwrap!(spawner.spawn(core0_task())));
+}
+
+#[embassy_executor::task]
+async fn core0_task() {
+    info!("CORE0 is running");
+    let ping = true;
+    CHANNEL0.send(ping).await;
+    let pong = CHANNEL1.recv().await;
+    assert_eq!(ping, pong);
+
+    info!("Test OK");
+    cortex_m::asm::bkpt();
+}
+
+#[embassy_executor::task]
+pub async fn run_usb(usb: &'static mut embassy_usb::UsbDevice<'static, Driver<'static, USB>>
+) {
+    info!("CORE1 is running");
+    let ping = CHANNEL0.recv().await;
+    CHANNEL1.send(ping).await;
+    usb.run().await;
+}


### PR DESCRIPTION
I was working on my project and while I was trying to get Core1 of my RP2040 to handle dealing with usb packets and message serialization/deserialization, I could not get the classes across to the other core.

I ended up having to add the `Sync` and `Send` traits to the `Handler` and `RequestHandler` traits in `embassy_usb`. After these modifications, I am able to build and use the `CdcAcmClass` successfully on Core1 of my RS2040.

I'm not fully aware of the ramifications of adding these traits bounds to the traits, but it appears to enable the functionality I need.

I also added a test, however I'm not sure if that is needed or wanted. If the fixes are not added, then the test should not compile.

It should also be noted that I could not get the test to run locally for some reason. I'm probably missing a tool. However, copying the files to the embassy-rp examples folder and removing lines 4-5 did effectively the same thing as running the test.