### PR TITLE
embassy-sync: manual Copy impls for channel and pipe

### DIFF
--- a/embassy-sync/src/channel.rs
+++ b/embassy-sync/src/channel.rs
@@ -30,7 +30,6 @@ use crate::blocking_mutex::Mutex;
 use crate::waitqueue::WakerRegistration;
 
 /// Send-only access to a [`Channel`].
-#[derive(Copy)]
 pub struct Sender<'ch, M, T, const N: usize>
 where
     M: RawMutex,
@@ -46,6 +45,8 @@ where
         Sender { channel: self.channel }
     }
 }
+
+impl<'ch, M, T, const N: usize> Copy for Sender<'ch, M, T, N> where M: RawMutex {}
 
 impl<'ch, M, T, const N: usize> Sender<'ch, M, T, N>
 where
@@ -67,7 +68,6 @@ where
 }
 
 /// Send-only access to a [`Channel`] without knowing channel size.
-#[derive(Copy)]
 pub struct DynamicSender<'ch, T> {
     channel: &'ch dyn DynamicChannel<T>,
 }
@@ -77,6 +77,8 @@ impl<'ch, T> Clone for DynamicSender<'ch, T> {
         DynamicSender { channel: self.channel }
     }
 }
+
+impl<'ch, T> Copy for DynamicSender<'ch, T> {}
 
 impl<'ch, M, T, const N: usize> From<Sender<'ch, M, T, N>> for DynamicSender<'ch, T>
 where
@@ -107,7 +109,6 @@ impl<'ch, T> DynamicSender<'ch, T> {
 }
 
 /// Receive-only access to a [`Channel`].
-#[derive(Copy)]
 pub struct Receiver<'ch, M, T, const N: usize>
 where
     M: RawMutex,
@@ -123,6 +124,8 @@ where
         Receiver { channel: self.channel }
     }
 }
+
+impl<'ch, M, T, const N: usize> Copy for Receiver<'ch, M, T, N> where M: RawMutex {}
 
 impl<'ch, M, T, const N: usize> Receiver<'ch, M, T, N>
 where
@@ -144,7 +147,6 @@ where
 }
 
 /// Receive-only access to a [`Channel`] without knowing channel size.
-#[derive(Copy)]
 pub struct DynamicReceiver<'ch, T> {
     channel: &'ch dyn DynamicChannel<T>,
 }
@@ -154,6 +156,8 @@ impl<'ch, T> Clone for DynamicReceiver<'ch, T> {
         DynamicReceiver { channel: self.channel }
     }
 }
+
+impl<'ch, T> Copy for DynamicReceiver<'ch, T> {}
 
 impl<'ch, T> DynamicReceiver<'ch, T> {
     /// Receive the next value.

--- a/embassy-sync/src/pipe.rs
+++ b/embassy-sync/src/pipe.rs
@@ -11,7 +11,6 @@ use crate::ring_buffer::RingBuffer;
 use crate::waitqueue::WakerRegistration;
 
 /// Write-only access to a [`Pipe`].
-#[derive(Copy)]
 pub struct Writer<'p, M, const N: usize>
 where
     M: RawMutex,
@@ -27,6 +26,8 @@ where
         Writer { pipe: self.pipe }
     }
 }
+
+impl<'p, M, const N: usize> Copy for Writer<'p, M, N> where M: RawMutex {}
 
 impl<'p, M, const N: usize> Writer<'p, M, N>
 where
@@ -74,7 +75,6 @@ where
 impl<'p, M, const N: usize> Unpin for WriteFuture<'p, M, N> where M: RawMutex {}
 
 /// Read-only access to a [`Pipe`].
-#[derive(Copy)]
 pub struct Reader<'p, M, const N: usize>
 where
     M: RawMutex,
@@ -90,6 +90,8 @@ where
         Reader { pipe: self.pipe }
     }
 }
+
+impl<'p, M, const N: usize> Copy for Reader<'p, M, N> where M: RawMutex {}
 
 impl<'p, M, const N: usize> Reader<'p, M, N>
 where


### PR DESCRIPTION
See #1759 

This removes an implicit T: Copy bound on these types