### PR TITLE
don't generate adc peripheral for f3 series

### DIFF
--- a/embassy-stm32/build.rs
+++ b/embassy-stm32/build.rs
@@ -310,7 +310,10 @@ fn main() {
 
     for p in METADATA.peripherals {
         // generating RccPeripheral impl for H7 ADC3 would result in bad frequency
-        if !singletons.contains(&p.name.to_string()) || (p.name == "ADC3" && METADATA.line.starts_with("STM32H7")) {
+        if !singletons.contains(&p.name.to_string())
+            || (p.name == "ADC3" && METADATA.line.starts_with("STM32H7"))
+            || (p.name.starts_with("ADC") && p.registers.as_ref().map_or(false, |r| r.version == "f3"))
+        {
             continue;
         }
 


### PR DESCRIPTION
Exclude adc_f3 from generating peripherals in build.rs