### PR TITLE
Refactor Channel/Sender/Receiver poll methods

### DIFF
--- a/embassy-stm32-wpan/src/mac/driver.rs
+++ b/embassy-stm32-wpan/src/mac/driver.rs
@@ -46,7 +46,7 @@ impl<'d> embassy_net_driver::Driver for Driver<'d> {
     }
 
     fn transmit(&mut self, cx: &mut Context) -> Option<Self::TxToken<'_>> {
-        if self.runner.tx_buf_channel.poll_ready_to_receive(cx) {
+        if self.runner.tx_buf_channel.poll_ready_to_receive(cx).is_ready() {
             Some(TxToken {
                 tx: &self.runner.tx_channel,
                 tx_buf: &self.runner.tx_buf_channel,

--- a/embassy-stm32-wpan/src/mac/driver.rs
+++ b/embassy-stm32-wpan/src/mac/driver.rs
@@ -28,7 +28,9 @@ impl<'d> embassy_net_driver::Driver for Driver<'d> {
     type TxToken<'a> = TxToken<'d> where Self: 'a;
 
     fn receive(&mut self, cx: &mut Context) -> Option<(Self::RxToken<'_>, Self::TxToken<'_>)> {
-        if self.runner.rx_channel.poll_ready_to_receive(cx) && self.runner.tx_buf_channel.poll_ready_to_receive(cx) {
+        if self.runner.rx_channel.poll_ready_to_receive(cx).is_ready()
+            && self.runner.tx_buf_channel.poll_ready_to_receive(cx).is_ready()
+        {
             Some((
                 RxToken {
                     rx: &self.runner.rx_channel,

--- a/embassy-stm32-wpan/src/mac/driver.rs
+++ b/embassy-stm32-wpan/src/mac/driver.rs
@@ -93,7 +93,7 @@ impl<'d> embassy_net_driver::RxToken for RxToken<'d> {
     {
         // Only valid data events should be put into the queue
 
-        let data_event = match self.rx.try_recv().unwrap() {
+        let data_event = match self.rx.try_receive().unwrap() {
             MacEvent::McpsDataInd(data_event) => data_event,
             _ => unreachable!(),
         };
@@ -113,7 +113,7 @@ impl<'d> embassy_net_driver::TxToken for TxToken<'d> {
         F: FnOnce(&mut [u8]) -> R,
     {
         // Only valid tx buffers should be put into the queue
-        let buf = self.tx_buf.try_recv().unwrap();
+        let buf = self.tx_buf.try_receive().unwrap();
         let r = f(&mut buf[..len]);
 
         // The tx channel should always be of equal capacity to the tx_buf channel

--- a/embassy-stm32-wpan/src/mac/runner.rs
+++ b/embassy-stm32-wpan/src/mac/runner.rs
@@ -73,7 +73,7 @@ impl<'a> Runner<'a> {
                 let mut msdu_handle = 0x02;
 
                 loop {
-                    let (buf, len) = self.tx_channel.recv().await;
+                    let (buf, len) = self.tx_channel.receive().await;
                     let _wm = self.write_mutex.lock().await;
 
                     // The mutex should be dropped on the next loop iteration

--- a/embassy-stm32/src/can/bxcan.rs
+++ b/embassy-stm32/src/can/bxcan.rs
@@ -506,14 +506,7 @@ impl<'c, 'd, T: Instance> CanRx<'c, 'd, T> {
 
     /// Waits while receive queue is empty.
     pub async fn wait_not_empty(&mut self) {
-        poll_fn(|cx| {
-            if T::state().rx_queue.poll_ready_to_receive(cx) {
-                Poll::Ready(())
-            } else {
-                Poll::Pending
-            }
-        })
-        .await
+        poll_fn(|cx| T::state().rx_queue.poll_ready_to_receive(cx)).await
     }
 
     fn curr_error(&self) -> Option<BusError> {

--- a/embassy-stm32/src/can/bxcan.rs
+++ b/embassy-stm32/src/can/bxcan.rs
@@ -478,7 +478,7 @@ impl<'c, 'd, T: Instance> CanRx<'c, 'd, T> {
     pub async fn read(&mut self) -> Result<Envelope, BusError> {
         poll_fn(|cx| {
             T::state().err_waker.register(cx.waker());
-            if let Poll::Ready(envelope) = T::state().rx_queue.recv().poll_unpin(cx) {
+            if let Poll::Ready(envelope) = T::state().rx_queue.receive().poll_unpin(cx) {
                 return Poll::Ready(Ok(envelope));
             } else if let Some(err) = self.curr_error() {
                 return Poll::Ready(Err(err));
@@ -493,7 +493,7 @@ impl<'c, 'd, T: Instance> CanRx<'c, 'd, T> {
     ///
     /// Returns [Err(TryReadError::Empty)] if there are no frames in the rx queue.
     pub fn try_read(&mut self) -> Result<Envelope, TryReadError> {
-        if let Ok(envelope) = T::state().rx_queue.try_recv() {
+        if let Ok(envelope) = T::state().rx_queue.try_receive() {
             return Ok(envelope);
         }
 

--- a/embassy-sync/src/channel.rs
+++ b/embassy-sync/src/channel.rs
@@ -65,6 +65,13 @@ where
     pub fn try_send(&self, message: T) -> Result<(), TrySendError<T>> {
         self.channel.try_send(message)
     }
+
+    /// Allows a poll_fn to poll until the channel is ready to send
+    ///
+    /// See [`Channel::poll_ready_to_send()`]
+    pub fn poll_ready_to_send(&self, cx: &mut Context<'_>) -> bool {
+        self.channel.poll_ready_to_send(cx)
+    }
 }
 
 /// Send-only access to a [`Channel`] without knowing channel size.
@@ -106,6 +113,13 @@ impl<'ch, T> DynamicSender<'ch, T> {
     pub fn try_send(&self, message: T) -> Result<(), TrySendError<T>> {
         self.channel.try_send_with_context(message, None)
     }
+
+    /// Allows a poll_fn to poll until the channel is ready to send
+    ///
+    /// See [`Channel::poll_ready_to_send()`]
+    pub fn poll_ready_to_send(&self, cx: &mut Context<'_>) -> bool {
+        self.channel.poll_ready_to_send(cx)
+    }
 }
 
 /// Receive-only access to a [`Channel`].
@@ -144,6 +158,13 @@ where
     pub fn try_recv(&self) -> Result<T, TryRecvError> {
         self.channel.try_recv()
     }
+
+    /// Allows a poll_fn to poll until the channel is ready to receive
+    ///
+    /// See [`Channel::poll_ready_to_receive()`]
+    pub fn poll_ready_to_receive(&self, cx: &mut Context<'_>) -> bool {
+        self.channel.poll_ready_to_receive(cx)
+    }
 }
 
 /// Receive-only access to a [`Channel`] without knowing channel size.
@@ -172,6 +193,13 @@ impl<'ch, T> DynamicReceiver<'ch, T> {
     /// See [`Channel::try_recv()`]
     pub fn try_recv(&self) -> Result<T, TryRecvError> {
         self.channel.try_recv_with_context(None)
+    }
+
+    /// Allows a poll_fn to poll until the channel is ready to receive
+    ///
+    /// See [`Channel::poll_ready_to_receive()`]
+    pub fn poll_ready_to_receive(&self, cx: &mut Context<'_>) -> bool {
+        self.channel.poll_ready_to_receive(cx)
     }
 }
 
@@ -286,6 +314,9 @@ trait DynamicChannel<T> {
     fn try_send_with_context(&self, message: T, cx: Option<&mut Context<'_>>) -> Result<(), TrySendError<T>>;
 
     fn try_recv_with_context(&self, cx: Option<&mut Context<'_>>) -> Result<T, TryRecvError>;
+
+    fn poll_ready_to_send(&self, cx: &mut Context<'_>) -> bool;
+    fn poll_ready_to_receive(&self, cx: &mut Context<'_>) -> bool;
 }
 
 /// Error returned by [`try_recv`](Channel::try_recv).
@@ -491,6 +522,14 @@ where
 
     fn try_recv_with_context(&self, cx: Option<&mut Context<'_>>) -> Result<T, TryRecvError> {
         Channel::try_recv_with_context(self, cx)
+    }
+
+    fn poll_ready_to_send(&self, cx: &mut Context<'_>) -> bool {
+        Channel::poll_ready_to_send(self, cx)
+    }
+
+    fn poll_ready_to_receive(&self, cx: &mut Context<'_>) -> bool {
+        Channel::poll_ready_to_receive(self, cx)
     }
 }
 

--- a/examples/nrf52840/src/bin/channel.rs
+++ b/examples/nrf52840/src/bin/channel.rs
@@ -35,7 +35,7 @@ async fn main(spawner: Spawner) {
     unwrap!(spawner.spawn(my_task()));
 
     loop {
-        match CHANNEL.recv().await {
+        match CHANNEL.receive().await {
             LedState::On => led.set_high(),
             LedState::Off => led.set_low(),
         }

--- a/examples/nrf52840/src/bin/channel_sender_receiver.rs
+++ b/examples/nrf52840/src/bin/channel_sender_receiver.rs
@@ -33,7 +33,7 @@ async fn recv_task(led: AnyPin, receiver: Receiver<'static, NoopRawMutex, LedSta
     let mut led = Output::new(led, Level::Low, OutputDrive::Standard);
 
     loop {
-        match receiver.recv().await {
+        match receiver.receive().await {
             LedState::On => led.set_high(),
             LedState::Off => led.set_low(),
         }

--- a/examples/nrf52840/src/bin/uart_split.rs
+++ b/examples/nrf52840/src/bin/uart_split.rs
@@ -46,7 +46,7 @@ async fn main(spawner: Spawner) {
     // back out the buffer we receive from the read
     // task.
     loop {
-        let buf = CHANNEL.recv().await;
+        let buf = CHANNEL.receive().await;
         info!("writing...");
         unwrap!(tx.write(&buf).await);
     }

--- a/examples/rp/src/bin/lora_p2p_send_multicore.rs
+++ b/examples/rp/src/bin/lora_p2p_send_multicore.rs
@@ -113,7 +113,7 @@ async fn core1_task(
     };
 
     loop {
-        let buffer: [u8; 3] = CHANNEL.recv().await;
+        let buffer: [u8; 3] = CHANNEL.receive().await;
         match lora.prepare_for_tx(&mdltn_params, 20, false).await {
             Ok(()) => {}
             Err(err) => {

--- a/examples/rp/src/bin/multicore.rs
+++ b/examples/rp/src/bin/multicore.rs
@@ -56,7 +56,7 @@ async fn core0_task() {
 async fn core1_task(mut led: Output<'static, PIN_25>) {
     info!("Hello from core 1");
     loop {
-        match CHANNEL.recv().await {
+        match CHANNEL.receive().await {
             LedState::On => led.set_high(),
             LedState::Off => led.set_low(),
         }

--- a/examples/stm32f3/src/bin/button_events.rs
+++ b/examples/stm32f3/src/bin/button_events.rs
@@ -49,12 +49,12 @@ impl<'a> Leds<'a> {
 
     async fn show(&mut self) {
         self.leds[self.current_led].set_high();
-        if let Ok(new_message) = with_timeout(Duration::from_millis(500), CHANNEL.recv()).await {
+        if let Ok(new_message) = with_timeout(Duration::from_millis(500), CHANNEL.receive()).await {
             self.leds[self.current_led].set_low();
             self.process_event(new_message).await;
         } else {
             self.leds[self.current_led].set_low();
-            if let Ok(new_message) = with_timeout(Duration::from_millis(200), CHANNEL.recv()).await {
+            if let Ok(new_message) = with_timeout(Duration::from_millis(200), CHANNEL.receive()).await {
                 self.process_event(new_message).await;
             }
         }

--- a/examples/stm32h5/src/bin/usart_split.rs
+++ b/examples/stm32h5/src/bin/usart_split.rs
@@ -44,7 +44,7 @@ async fn main(spawner: Spawner) -> ! {
     unwrap!(spawner.spawn(reader(rx)));
 
     loop {
-        let buf = CHANNEL.recv().await;
+        let buf = CHANNEL.receive().await;
         info!("writing...");
         unwrap!(tx.write(&buf).await);
     }

--- a/examples/stm32h7/src/bin/usart_split.rs
+++ b/examples/stm32h7/src/bin/usart_split.rs
@@ -44,7 +44,7 @@ async fn main(spawner: Spawner) -> ! {
     unwrap!(spawner.spawn(reader(rx)));
 
     loop {
-        let buf = CHANNEL.recv().await;
+        let buf = CHANNEL.receive().await;
         info!("writing...");
         unwrap!(tx.write(&buf).await);
     }

--- a/tests/rp/src/bin/gpio_multicore.rs
+++ b/tests/rp/src/bin/gpio_multicore.rs
@@ -38,11 +38,11 @@ async fn core0_task(p: PIN_0) {
     let mut pin = Output::new(p, Level::Low);
 
     CHANNEL0.send(()).await;
-    CHANNEL1.recv().await;
+    CHANNEL1.receive().await;
 
     pin.set_high();
 
-    CHANNEL1.recv().await;
+    CHANNEL1.receive().await;
 
     info!("Test OK");
     cortex_m::asm::bkpt();
@@ -52,7 +52,7 @@ async fn core0_task(p: PIN_0) {
 async fn core1_task(p: PIN_1) {
     info!("CORE1 is running");
 
-    CHANNEL0.recv().await;
+    CHANNEL0.receive().await;
 
     let mut pin = Input::new(p, Pull::Down);
     let wait = pin.wait_for_rising_edge();

--- a/tests/rp/src/bin/multicore.rs
+++ b/tests/rp/src/bin/multicore.rs
@@ -34,7 +34,7 @@ async fn core0_task() {
     info!("CORE0 is running");
     let ping = true;
     CHANNEL0.send(ping).await;
-    let pong = CHANNEL1.recv().await;
+    let pong = CHANNEL1.receive().await;
     assert_eq!(ping, pong);
 
     info!("Test OK");
@@ -44,6 +44,6 @@ async fn core0_task() {
 #[embassy_executor::task]
 async fn core1_task() {
     info!("CORE1 is running");
-    let ping = CHANNEL0.recv().await;
+    let ping = CHANNEL0.receive().await;
     CHANNEL1.send(ping).await;
 }


### PR DESCRIPTION
(Was "Expose `poll_ready_to_{send,receive}` in `Sender`/`Receiver`")

These are useful methods when manually writing Futures.

@lulf suggested on Matrix to also expose `try_{recv,send}_with_context` in `Receiver` and `Sender`, but those are private in `Channel`.