### PR TITLE
Executor: prepare 0.2.1 release

### DIFF
--- a/embassy-executor/CHANGELOG.md
+++ b/embassy-executor/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+- Avoid calling `pend()` when waking expired timers
+- Properly reset finished task state with `integrated-timers` enabled
+- Introduce `InterruptExecutor::spawner()`
+- Fix incorrect critical section in Xtensa executor
+
 ## 0.2.0 - 2023-04-27
 
 - Replace unnecessary atomics in runqueue

--- a/embassy-executor/CHANGELOG.md
+++ b/embassy-executor/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## Unreleased
+## 0.2.1 - 2023-08-10
 
 - Avoid calling `pend()` when waking expired timers
 - Properly reset finished task state with `integrated-timers` enabled

--- a/embassy-executor/Cargo.toml
+++ b/embassy-executor/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "embassy-executor"
-version = "0.2.0"
+version = "0.2.1"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 description = "async/await executor designed for embedded usage"


### PR DESCRIPTION
I think it's okay to have this as a point release, as it only seems to contain a bunch of fixes and a new API.