### PR TITLE
Add compound descriptor set tracking to the usb descriptor writer

### DIFF
--- a/embassy-usb/src/class/cdc_acm.rs
+++ b/embassy-usb/src/class/cdc_acm.rs
@@ -182,7 +182,6 @@ impl<'d, D: Driver<'d>> CdcAcmClass<'d, D> {
         // Control interface
         let mut iface = func.interface();
         let comm_if = iface.interface_number();
-        let data_if = u8::from(comm_if) + 1;
         let mut alt = iface.alt_setting(USB_CLASS_CDC, CDC_SUBCLASS_ACM, CDC_PROTOCOL_NONE, None);
 
         alt.descriptor(
@@ -208,18 +207,28 @@ impl<'d, D: Driver<'d>> CdcAcmClass<'d, D> {
             &[
                 CDC_TYPE_UNION, // bDescriptorSubtype
                 comm_if.into(), // bControlInterface
-                data_if.into(), // bSubordinateInterface
+                // Padding, bSubordinateInterface byte will be written later.
+                0x0, // bSubordinateInterface
             ],
         );
+
+        // Keep the position of the subordinate interface byte so we can fill it in later
+        let subordinate_interface_position = alt.config_descriptor_writer().position() - 1;
 
         let comm_ep = alt.endpoint_interrupt_in(8, 255);
 
         // Data interface
         let mut iface = func.interface();
         let data_if = iface.interface_number();
+        let data_if_number_byte = data_if.0;
+
         let mut alt = iface.alt_setting(USB_CLASS_CDC_DATA, 0x00, CDC_PROTOCOL_NONE, None);
         let read_ep = alt.endpoint_bulk_out(max_packet_size);
         let write_ep = alt.endpoint_bulk_in(max_packet_size);
+
+        // Fill in the subordinate interface byte with the right interface number.
+        alt.config_descriptor_writer()
+            .overwrite(subordinate_interface_position, &[data_if_number_byte]);
 
         drop(func);
 

--- a/embassy-usb/src/descriptor.rs
+++ b/embassy-usb/src/descriptor.rs
@@ -37,7 +37,8 @@ pub mod capability_type {
 }
 
 /// A writer for USB descriptors.
-pub(crate) struct DescriptorWriter<'a> {
+pub struct DescriptorWriter<'a> {
+    /// The inner buffer of the descriptor writer.
     pub buf: &'a mut [u8],
     position: usize,
     num_interfaces_mark: Option<usize>,


### PR DESCRIPTION
# Content

While writing a USB Audio Class (MIDI) I've realized that the initial class specific descriptor requires the total length of the whole class specific descriptor set. 

Page: `38`, Section `B.3.2`
https://www.usb.org/sites/default/files/USB%20MIDI%20v2_0.pdf

This is also true for class specific descriptors from the Video class.
https://www.xmos.ai/download/AN00127:-USB-Video-Class-Device(2.0.2rc1).pdf#subsubsection.2.7.2

I'd like to add at least the audio class to `embassy-usb` step by step.
This PR aims to provide the underlying machinery to unlock having dynamic length and types of class specific descriptors depending on the user configuration which might come from lets say.. a builder pattern. 

I have chosen to call these kinds of descriptor chains a "compound set" of descriptors where the initial descriptor needs a total length of the following ones and the following ones may vary in length and type.

It is mainly about tracking the total length of the compound set and rewriting it to the initial descriptor. 

# Notes

- This will be my first contribution to this code base so don't hesitate to nitpick. I don't know the style here yet :) 
- I've written long function names, verbose comments and didn't think so much about publicity of the functions. I'd gladly update the code according to your advises.
- If you see a better path of implementing this functionality or a better api to expose to the user. I'd love to hear it 🙏 

Thanks for your review 🙏 

