### PR TITLE
boot: release flash after prepare and refactor api

### DIFF
--- a/embassy-boot/nrf/src/lib.rs
+++ b/embassy-boot/nrf/src/lib.rs
@@ -14,28 +14,17 @@ use embassy_nrf::wdt;
 use embedded_storage::nor_flash::{ErrorType, NorFlash, ReadNorFlash};
 
 /// A bootloader for nRF devices.
-pub struct BootLoader<ACTIVE: NorFlash, DFU: NorFlash, STATE: NorFlash, const BUFFER_SIZE: usize = PAGE_SIZE> {
-    boot: embassy_boot::BootLoader<ACTIVE, DFU, STATE>,
-    aligned_buf: AlignedBuffer<BUFFER_SIZE>,
-}
+pub struct BootLoader<const BUFFER_SIZE: usize = PAGE_SIZE>;
 
-impl<ACTIVE: NorFlash, DFU: NorFlash, STATE: NorFlash, const BUFFER_SIZE: usize>
-    BootLoader<ACTIVE, DFU, STATE, BUFFER_SIZE>
-{
-    /// Create a new bootloader instance using the supplied partitions for active, dfu and state.
-    pub fn new(config: BootLoaderConfig<ACTIVE, DFU, STATE>) -> Self {
-        Self {
-            boot: embassy_boot::BootLoader::new(config),
-            aligned_buf: AlignedBuffer([0; BUFFER_SIZE]),
-        }
-    }
-
-    /// Inspect the bootloader state and perform actions required before booting, such as swapping
-    /// firmware.
-    pub fn prepare(&mut self) {
-        self.boot
-            .prepare_boot(&mut self.aligned_buf.0)
-            .expect("Boot prepare error");
+impl<const BUFFER_SIZE: usize> BootLoader<BUFFER_SIZE> {
+    /// Inspect the bootloader state and perform actions required before booting, such as swapping firmware.
+    pub fn prepare<ACTIVE: NorFlash, DFU: NorFlash, STATE: NorFlash>(
+        config: BootLoaderConfig<ACTIVE, DFU, STATE>,
+    ) -> Self {
+        let mut aligned_buf = AlignedBuffer([0; BUFFER_SIZE]);
+        let mut boot = embassy_boot::BootLoader::new(config);
+        boot.prepare_boot(&mut aligned_buf.0).expect("Boot prepare error");
+        Self
     }
 
     /// Boots the application without softdevice mechanisms.
@@ -45,8 +34,6 @@ impl<ACTIVE: NorFlash, DFU: NorFlash, STATE: NorFlash, const BUFFER_SIZE: usize>
     /// This modifies the stack pointer and reset vector and will run code placed in the active partition.
     #[cfg(not(feature = "softdevice"))]
     pub unsafe fn load(self, start: u32) -> ! {
-        core::mem::drop(self.boot);
-
         let mut p = cortex_m::Peripherals::steal();
         p.SCB.invalidate_icache();
         p.SCB.vtor.write(start);
@@ -59,7 +46,7 @@ impl<ACTIVE: NorFlash, DFU: NorFlash, STATE: NorFlash, const BUFFER_SIZE: usize>
     ///
     /// This modifies the stack pointer and reset vector and will run code placed in the active partition.
     #[cfg(feature = "softdevice")]
-    pub unsafe fn load(&mut self, _app: u32) -> ! {
+    pub unsafe fn load(self, _app: u32) -> ! {
         use nrf_softdevice_mbr as mbr;
         const NRF_SUCCESS: u32 = 0;
 

--- a/embassy-boot/rp/src/lib.rs
+++ b/embassy-boot/rp/src/lib.rs
@@ -15,28 +15,17 @@ use embassy_time::Duration;
 use embedded_storage::nor_flash::{ErrorType, NorFlash, ReadNorFlash};
 
 /// A bootloader for RP2040 devices.
-pub struct BootLoader<ACTIVE: NorFlash, DFU: NorFlash, STATE: NorFlash, const BUFFER_SIZE: usize = ERASE_SIZE> {
-    boot: embassy_boot::BootLoader<ACTIVE, DFU, STATE>,
-    aligned_buf: AlignedBuffer<BUFFER_SIZE>,
-}
+pub struct BootLoader<const BUFFER_SIZE: usize = ERASE_SIZE>;
 
-impl<ACTIVE: NorFlash, DFU: NorFlash, STATE: NorFlash, const BUFFER_SIZE: usize>
-    BootLoader<ACTIVE, DFU, STATE, BUFFER_SIZE>
-{
-    /// Create a new bootloader instance using the supplied partitions for active, dfu and state.
-    pub fn new(config: BootLoaderConfig<ACTIVE, DFU, STATE>) -> Self {
-        Self {
-            boot: embassy_boot::BootLoader::new(config),
-            aligned_buf: AlignedBuffer([0; BUFFER_SIZE]),
-        }
-    }
-
-    /// Inspect the bootloader state and perform actions required before booting, such as swapping
-    /// firmware.
-    pub fn prepare(&mut self) {
-        self.boot
-            .prepare_boot(self.aligned_buf.as_mut())
-            .expect("Boot prepare error");
+impl<const BUFFER_SIZE: usize> BootLoader<BUFFER_SIZE> {
+    /// Inspect the bootloader state and perform actions required before booting, such as swapping firmware
+    pub fn prepare<ACTIVE: NorFlash, DFU: NorFlash, STATE: NorFlash>(
+        config: BootLoaderConfig<ACTIVE, DFU, STATE>,
+    ) -> Self {
+        let mut aligned_buf = AlignedBuffer([0; BUFFER_SIZE]);
+        let mut boot = embassy_boot::BootLoader::new(config);
+        boot.prepare_boot(aligned_buf.as_mut()).expect("Boot prepare error");
+        Self
     }
 
     /// Boots the application.
@@ -45,8 +34,6 @@ impl<ACTIVE: NorFlash, DFU: NorFlash, STATE: NorFlash, const BUFFER_SIZE: usize>
     ///
     /// This modifies the stack pointer and reset vector and will run code placed in the active partition.
     pub unsafe fn load(self, start: u32) -> ! {
-        core::mem::drop(self.boot);
-
         trace!("Loading app at 0x{:x}", start);
         #[allow(unused_mut)]
         let mut p = cortex_m::Peripherals::steal();

--- a/embassy-boot/stm32/src/lib.rs
+++ b/embassy-boot/stm32/src/lib.rs
@@ -11,28 +11,17 @@ pub use embassy_boot::{FirmwareState, FirmwareUpdater};
 use embedded_storage::nor_flash::NorFlash;
 
 /// A bootloader for STM32 devices.
-pub struct BootLoader<ACTIVE: NorFlash, DFU: NorFlash, STATE: NorFlash, const BUFFER_SIZE: usize> {
-    boot: embassy_boot::BootLoader<ACTIVE, DFU, STATE>,
-    aligned_buf: AlignedBuffer<BUFFER_SIZE>,
-}
+pub struct BootLoader;
 
-impl<ACTIVE: NorFlash, DFU: NorFlash, STATE: NorFlash, const BUFFER_SIZE: usize>
-    BootLoader<ACTIVE, DFU, STATE, BUFFER_SIZE>
-{
-    /// Create a new bootloader instance using the supplied partitions for active, dfu and state.
-    pub fn new(config: BootLoaderConfig<ACTIVE, DFU, STATE>) -> Self {
-        Self {
-            boot: embassy_boot::BootLoader::new(config),
-            aligned_buf: AlignedBuffer([0; BUFFER_SIZE]),
-        }
-    }
-
-    /// Inspect the bootloader state and perform actions required before booting, such as swapping
-    /// firmware.
-    pub fn prepare(&mut self) {
-        self.boot
-            .prepare_boot(self.aligned_buf.as_mut())
-            .expect("Boot prepare error");
+impl BootLoader {
+    /// Inspect the bootloader state and perform actions required before booting, such as swapping firmware
+    pub fn prepare<ACTIVE: NorFlash, DFU: NorFlash, STATE: NorFlash, const BUFFER_SIZE: usize>(
+        config: BootLoaderConfig<ACTIVE, DFU, STATE>,
+    ) -> Self {
+        let mut aligned_buf = AlignedBuffer([0; BUFFER_SIZE]);
+        let mut boot = embassy_boot::BootLoader::new(config);
+        boot.prepare_boot(aligned_buf.as_mut()).expect("Boot prepare error");
+        Self
     }
 
     /// Boots the application.
@@ -41,8 +30,6 @@ impl<ACTIVE: NorFlash, DFU: NorFlash, STATE: NorFlash, const BUFFER_SIZE: usize>
     ///
     /// This modifies the stack pointer and reset vector and will run code placed in the active partition.
     pub unsafe fn load(self, start: u32) -> ! {
-        core::mem::drop(self.boot);
-
         trace!("Loading app at 0x{:x}", start);
         #[allow(unused_mut)]
         let mut p = cortex_m::Peripherals::steal();

--- a/examples/boot/bootloader/nrf/src/main.rs
+++ b/examples/boot/bootloader/nrf/src/main.rs
@@ -33,9 +33,7 @@ fn main() -> ! {
 
     let config = BootLoaderConfig::from_linkerfile_blocking(&flash);
     let active_offset = config.active.offset();
-    let mut bl: BootLoader<_, _, _> = BootLoader::new(config);
-
-    bl.prepare();
+    let bl: BootLoader = BootLoader::prepare(config);
 
     unsafe { bl.load(active_offset) }
 }

--- a/examples/boot/bootloader/rp/src/main.rs
+++ b/examples/boot/bootloader/rp/src/main.rs
@@ -29,9 +29,7 @@ fn main() -> ! {
 
     let config = BootLoaderConfig::from_linkerfile_blocking(&flash);
     let active_offset = config.active.offset();
-    let mut bl: BootLoader<_, _, _> = BootLoader::new(config);
-
-    bl.prepare();
+    let bl: BootLoader = BootLoader::prepare(config);
 
     unsafe { bl.load(embassy_rp::flash::FLASH_BASE as u32 + active_offset) }
 }

--- a/examples/boot/bootloader/stm32/src/main.rs
+++ b/examples/boot/bootloader/stm32/src/main.rs
@@ -27,9 +27,7 @@ fn main() -> ! {
 
     let config = BootLoaderConfig::from_linkerfile_blocking(&flash);
     let active_offset = config.active.offset();
-    let mut bl: BootLoader<_, _, _, 2048> = BootLoader::new(config);
-
-    bl.prepare();
+    let bl = BootLoader::prepare::<_, _, _, 2048>(config);
 
     unsafe { bl.load(BANK1_REGION.base + active_offset) }
 }


### PR DESCRIPTION
This refactoring of the chip specific bootloader creates the internal boot instance and aligned buffer in the prepare stage, so that they are automatically dropped after. This unlocks a use case where peripherals owning the flash need to be Drop'ed before load() happens.