### PR TITLE
stm32-wl: set RTC clock source on RCC init

### DIFF
--- a/embassy-stm32/src/rcc/wl.rs
+++ b/embassy-stm32/src/rcc/wl.rs
@@ -2,6 +2,7 @@ pub use super::common::{AHBPrescaler, APBPrescaler, VoltageScale};
 use crate::pac::pwr::vals::Dbp;
 use crate::pac::{FLASH, PWR, RCC};
 use crate::rcc::{set_freqs, Clocks};
+use crate::rtc::{Rtc, RtcClockSource as RCS};
 use crate::time::Hertz;
 
 /// Most of clock setup is copied from stm32l0xx-hal, and adopted to the generated PAC,
@@ -229,6 +230,8 @@ pub(crate) unsafe fn init(config: Config) {
 
             // Wait until LSE is running
             while !RCC.bdcr().read().lserdy() {}
+
+            Rtc::set_clock_source(RCS::LSE);
         }
         RtcClockSource::LSI32 => {
             // Turn on the internal 32 kHz LSI oscillator
@@ -236,6 +239,8 @@ pub(crate) unsafe fn init(config: Config) {
 
             // Wait until LSI is running
             while !RCC.csr().read().lsirdy() {}
+
+            Rtc::set_clock_source(RCS::LSI);
         }
     }
 


### PR DESCRIPTION
Seems the RTC clock source is never set for stm32-wl, and creating a new `Rtc` instance will hang (at least using LSI). This PR sets the RTC clock source similar as for stm32-wb.