### PR TITLE
rp/flash: change naming to `blocking_*`, `new_blocking`.

### DIFF
--- a/embassy-boot/rp/src/lib.rs
+++ b/embassy-boot/rp/src/lib.rs
@@ -54,7 +54,7 @@ pub struct WatchdogFlash<'d, const SIZE: usize> {
 impl<'d, const SIZE: usize> WatchdogFlash<'d, SIZE> {
     /// Start a new watchdog with a given flash and watchdog peripheral and a timeout
     pub fn start(flash: FLASH, watchdog: WATCHDOG, timeout: Duration) -> Self {
-        let flash = Flash::<_, Blocking, SIZE>::new(flash);
+        let flash = Flash::<_, Blocking, SIZE>::new_blocking(flash);
         let mut watchdog = Watchdog::new(watchdog);
         watchdog.start(timeout);
         Self { flash, watchdog }
@@ -71,11 +71,11 @@ impl<'d, const SIZE: usize> NorFlash for WatchdogFlash<'d, SIZE> {
 
     fn erase(&mut self, from: u32, to: u32) -> Result<(), Self::Error> {
         self.watchdog.feed();
-        self.flash.erase(from, to)
+        self.flash.blocking_erase(from, to)
     }
     fn write(&mut self, offset: u32, data: &[u8]) -> Result<(), Self::Error> {
         self.watchdog.feed();
-        self.flash.write(offset, data)
+        self.flash.blocking_write(offset, data)
     }
 }
 
@@ -83,7 +83,7 @@ impl<'d, const SIZE: usize> ReadNorFlash for WatchdogFlash<'d, SIZE> {
     const READ_SIZE: usize = <Flash<'d, FLASH, Blocking, SIZE> as ReadNorFlash>::READ_SIZE;
     fn read(&mut self, offset: u32, data: &mut [u8]) -> Result<(), Self::Error> {
         self.watchdog.feed();
-        self.flash.read(offset, data)
+        self.flash.blocking_read(offset, data)
     }
     fn capacity(&self) -> usize {
         self.flash.capacity()

--- a/examples/boot/application/rp/src/bin/a.rs
+++ b/examples/boot/application/rp/src/bin/a.rs
@@ -7,7 +7,7 @@ use core::cell::RefCell;
 use defmt_rtt as _;
 use embassy_boot_rp::*;
 use embassy_executor::Spawner;
-use embassy_rp::flash::{self, Flash};
+use embassy_rp::flash::Flash;
 use embassy_rp::gpio::{Level, Output};
 use embassy_rp::watchdog::Watchdog;
 use embassy_sync::blocking_mutex::Mutex;
@@ -34,7 +34,7 @@ async fn main(_s: Spawner) {
     let mut watchdog = Watchdog::new(p.WATCHDOG);
     watchdog.start(Duration::from_secs(8));
 
-    let flash = Flash::<_, flash::Blocking, FLASH_SIZE>::new(p.FLASH);
+    let flash = Flash::<_, _, FLASH_SIZE>::new_blocking(p.FLASH);
     let flash = Mutex::new(RefCell::new(flash));
 
     let config = FirmwareUpdaterConfig::from_linkerfile_blocking(&flash);

--- a/tests/rp/src/bin/flash.rs
+++ b/tests/rp/src/bin/flash.rs
@@ -25,23 +25,23 @@ async fn main(_spawner: Spawner) {
     let mut flash = embassy_rp::flash::Flash::<_, Async, { 2 * 1024 * 1024 }>::new(p.FLASH, p.DMA_CH0);
 
     // Get JEDEC id
-    let jedec = defmt::unwrap!(flash.jedec_id());
+    let jedec = defmt::unwrap!(flash.blocking_jedec_id());
     info!("jedec id: 0x{:x}", jedec);
 
     // Get unique id
     let mut uid = [0; 8];
-    defmt::unwrap!(flash.unique_id(&mut uid));
+    defmt::unwrap!(flash.blocking_unique_id(&mut uid));
     info!("unique id: {:?}", uid);
 
     let mut buf = [0u8; ERASE_SIZE];
-    defmt::unwrap!(flash.read(ADDR_OFFSET, &mut buf));
+    defmt::unwrap!(flash.blocking_read(ADDR_OFFSET, &mut buf));
 
     info!("Addr of flash block is {:x}", ADDR_OFFSET + FLASH_BASE as u32);
     info!("Contents start with {=[u8]}", buf[0..4]);
 
-    defmt::unwrap!(flash.erase(ADDR_OFFSET, ADDR_OFFSET + ERASE_SIZE as u32));
+    defmt::unwrap!(flash.blocking_erase(ADDR_OFFSET, ADDR_OFFSET + ERASE_SIZE as u32));
 
-    defmt::unwrap!(flash.read(ADDR_OFFSET, &mut buf));
+    defmt::unwrap!(flash.blocking_read(ADDR_OFFSET, &mut buf));
     info!("Contents after erase starts with {=[u8]}", buf[0..4]);
     if buf.iter().any(|x| *x != 0xFF) {
         defmt::panic!("unexpected");
@@ -51,9 +51,9 @@ async fn main(_spawner: Spawner) {
         *b = 0xDA;
     }
 
-    defmt::unwrap!(flash.write(ADDR_OFFSET, &mut buf));
+    defmt::unwrap!(flash.blocking_write(ADDR_OFFSET, &mut buf));
 
-    defmt::unwrap!(flash.read(ADDR_OFFSET, &mut buf));
+    defmt::unwrap!(flash.blocking_read(ADDR_OFFSET, &mut buf));
     info!("Contents after write starts with {=[u8]}", buf[0..4]);
     if buf.iter().any(|x| *x != 0xDA) {
         defmt::panic!("unexpected");


### PR DESCRIPTION
- Needed for consistency with other drivers.
- Having two `new()` functions sometimes resulted in 'multiple applicable methods' errors.