### PR TITLE
embassy-usb: Fixed the final null terminator for RegMultiSz.

### DIFF
--- a/embassy-usb/src/msos.rs
+++ b/embassy-usb/src/msos.rs
@@ -526,7 +526,7 @@ impl<'a> PropertyData<'a> {
             PropertyData::Binary(val) => val.len(),
             PropertyData::DwordLittleEndian(val) | PropertyData::DwordBigEndian(val) => core::mem::size_of_val(val),
             PropertyData::RegMultiSz(val) => {
-                core::mem::size_of::<u16>() * val.iter().map(|x| x.encode_utf16().count() + 1).sum::<usize>() + 1
+                core::mem::size_of::<u16>() * (val.iter().map(|x| x.encode_utf16().count() + 1).sum::<usize>() + 1)
             }
         }
     }


### PR DESCRIPTION
According to the [Microsoft documentation][1] the `RegMultiSz` value should be terminated by an empty UTF-16 string, i.e. 2 null bytes instead of only one.

This also matches what this [Google article][2] is doing.

It seems to be working regardless, at least for me, but it is probably best to follow the spec.

Beware though that this will make the descriptor one byte larger which can panic the `Builder` when supplied with a buffer that had exactly the required size before.

[1]: https://learn.microsoft.com/en-us/windows/win32/sysinfo/registry-value-types
[2]: https://developer.chrome.com/articles/build-for-webusb/