### PR TITLE
stm32: allow setting PWM duty cycle to 100%

### DIFF
--- a/embassy-stm32/src/timer/complementary_pwm.rs
+++ b/embassy-stm32/src/timer/complementary_pwm.rs
@@ -100,11 +100,11 @@ impl<'d, T: ComplementaryCaptureCompare16bitInstance> ComplementaryPwm<'d, T> {
     }
 
     pub fn get_max_duty(&self) -> u16 {
-        self.inner.get_max_compare_value()
+        self.inner.get_max_compare_value() + 1
     }
 
     pub fn set_duty(&mut self, channel: Channel, duty: u16) {
-        assert!(duty < self.get_max_duty());
+        assert!(duty <= self.get_max_duty());
         self.inner.set_compare_value(channel, duty)
     }
 

--- a/embassy-stm32/src/timer/simple_pwm.rs
+++ b/embassy-stm32/src/timer/simple_pwm.rs
@@ -97,11 +97,11 @@ impl<'d, T: CaptureCompare16bitInstance> SimplePwm<'d, T> {
     }
 
     pub fn get_max_duty(&self) -> u16 {
-        self.inner.get_max_compare_value()
+        self.inner.get_max_compare_value() + 1
     }
 
     pub fn set_duty(&mut self, channel: Channel, duty: u16) {
-        assert!(duty < self.get_max_duty());
+        assert!(duty <= self.get_max_duty());
         self.inner.set_compare_value(channel, duty)
     }
 }


### PR DESCRIPTION
Setting the compare_value to max_compare_value make the PWM output go low when the timer reach the max_compare_value and go high again on the next timer clock, when the value roll back to 0.
So to allow a 100% PWM that never goes low, the compare_value must be set to max_compare_value + 1.