### PR TITLE
configure flash latency after axi clock and  handle different flash on STM32H7A/B devices

### DIFF
--- a/embassy-stm32/Cargo.toml
+++ b/embassy-stm32/Cargo.toml
@@ -57,7 +57,7 @@ sdio-host = "0.5.0"
 embedded-sdmmc = { git = "https://github.com/embassy-rs/embedded-sdmmc-rs", rev = "a4f293d3a6f72158385f79c98634cb8a14d0d2fc", optional = true }
 critical-section = "1.1"
 atomic-polyfill = "1.0.1"
-stm32-metapac = { git = "https://github.com/embassy-rs/stm32-data-generated", tag = "stm32-data-7eddb78e705905af4c1dd2359900db3e78a3c500" }
+stm32-metapac = { git = "https://github.com/embassy-rs/stm32-data-generated", tag = "stm32-data-2b87e34c661e19ff6dc603fabfe7fe99ab7261f7" }
 vcell = "0.1.3"
 bxcan = "0.7.0"
 nb = "1.0.0"
@@ -76,7 +76,7 @@ critical-section = { version = "1.1", features = ["std"] }
 [build-dependencies]
 proc-macro2 = "1.0.36"
 quote = "1.0.15"
-stm32-metapac = { git = "https://github.com/embassy-rs/stm32-data-generated", tag = "stm32-data-7eddb78e705905af4c1dd2359900db3e78a3c500", default-features = false, features = ["metadata"]}
+stm32-metapac = { git = "https://github.com/embassy-rs/stm32-data-generated", tag = "stm32-data-2b87e34c661e19ff6dc603fabfe7fe99ab7261f7", default-features = false, features = ["metadata"]}
 
 [features]
 default = ["rt"]

--- a/embassy-stm32/src/flash/mod.rs
+++ b/embassy-stm32/src/flash/mod.rs
@@ -65,9 +65,11 @@ impl FlashRegion {
 #[cfg_attr(flash_f7, path = "f7.rs")]
 #[cfg_attr(flash_g0, path = "g0.rs")]
 #[cfg_attr(flash_h7, path = "h7.rs")]
+#[cfg_attr(flash_h7ab, path = "h7.rs")]
 #[cfg_attr(
     not(any(
-        flash_l0, flash_l1, flash_l4, flash_wl, flash_wb, flash_f0, flash_f3, flash_f4, flash_f7, flash_g0, flash_h7
+        flash_l0, flash_l1, flash_l4, flash_wl, flash_wb, flash_f0, flash_f3, flash_f4, flash_f7, flash_g0, flash_h7,
+        flash_h7ab
     )),
     path = "other.rs"
 )]

--- a/embassy-stm32/src/rcc/h7.rs
+++ b/embassy-stm32/src/rcc/h7.rs
@@ -200,6 +200,7 @@ fn flash_setup(rcc_aclk: u32, vos: VoltageScale) {
 
     // See RM0433 Rev 7 Table 17. FLASH recommended number of wait
     // states and programming delay
+    #[cfg(flash_h7)]
     let (wait_states, progr_delay) = match vos {
         // VOS 0 range VCORE 1.26V - 1.40V
         VoltageScale::Scale0 => match rcc_aclk_mhz {
@@ -235,6 +236,50 @@ fn flash_setup(rcc_aclk: u32, vos: VoltageScale) {
             90..=134 => (2, 1),
             135..=179 => (3, 2),
             180..=224 => (4, 2),
+            _ => (7, 3),
+        },
+    };
+
+    // See RM0455 Rev 10 Table 16. FLASH recommended number of wait
+    // states and programming delay
+    #[cfg(flash_h7ab)]
+    let (wait_states, progr_delay) = match vos {
+        // VOS 0 range VCORE 1.25V - 1.35V
+        VoltageScale::Scale0 => match rcc_aclk_mhz {
+            0..=42 => (0, 0),
+            43..=84 => (1, 0),
+            85..=126 => (2, 1),
+            127..=168 => (3, 1),
+            169..=210 => (4, 2),
+            211..=252 => (5, 2),
+            253..=280 => (6, 3),
+            _ => (7, 3),
+        },
+        // VOS 1 range VCORE 1.15V - 1.25V
+        VoltageScale::Scale1 => match rcc_aclk_mhz {
+            0..=38 => (0, 0),
+            39..=76 => (1, 0),
+            77..=114 => (2, 1),
+            115..=152 => (3, 1),
+            153..=190 => (4, 2),
+            191..=225 => (5, 2),
+            _ => (7, 3),
+        },
+        // VOS 2 range VCORE 1.05V - 1.15V
+        VoltageScale::Scale2 => match rcc_aclk_mhz {
+            0..=34 => (0, 0),
+            35..=68 => (1, 0),
+            69..=102 => (2, 1),
+            103..=136 => (3, 1),
+            137..=160 => (4, 2),
+            _ => (7, 3),
+        },
+        // VOS 3 range VCORE 0.95V - 1.05V
+        VoltageScale::Scale3 => match rcc_aclk_mhz {
+            0..=22 => (0, 0),
+            23..=44 => (1, 0),
+            45..=66 => (2, 1),
+            67..=88 => (3, 1),
             _ => (7, 3),
         },
     };
@@ -538,8 +583,6 @@ pub(crate) unsafe fn init(mut config: Config) {
     let requested_pclk4 = config.pclk4.map(|v| v.0).unwrap_or_else(|| pclk_max.min(rcc_hclk / 2));
     let (rcc_pclk4, ppre4_bits, ppre4, _) = ppre_calculate(requested_pclk4, rcc_hclk, pclk_max, None);
 
-    flash_setup(rcc_aclk, pwr_vos);
-
     // Start switching clocks -------------------
 
     // Ensure CSI is on and stable
@@ -594,6 +637,8 @@ pub(crate) unsafe fn init(mut config: Config) {
     // Ensure core prescaler value is valid before future lower
     // core voltage
     while RCC.d1cfgr().read().d1cpre().to_bits() != d1cpre_bits {}
+
+    flash_setup(rcc_aclk, pwr_vos);
 
     // APB1 / APB2 Prescaler
     RCC.d2cfgr().modify(|w| {


### PR DESCRIPTION
Flash latency was being calculated and set based on requested clock, but before the clock was actually configured.
STM32H7A/B devices has slightly different FLASH peripheral.