### PR TITLE
Add `SpawnToken::is_success`

### DIFF
--- a/embassy-executor/CHANGELOG.md
+++ b/embassy-executor/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## Unreleased
 
 - Replaced Pender. Implementations now must define an extern function called `__pender`.
+- Added `SpawnToken::is_success()`
 
 ## 0.2.1 - 2023-08-10
 

--- a/embassy-executor/src/spawner.rs
+++ b/embassy-executor/src/spawner.rs
@@ -39,6 +39,11 @@ impl<S> SpawnToken<S> {
             phantom: PhantomData,
         }
     }
+
+    /// Returns whether the task was successfully spawned.
+    pub fn is_success(&self) -> bool {
+        self.raw_task.is_some()
+    }
 }
 
 impl<S> Drop for SpawnToken<S> {


### PR DESCRIPTION
I would like to be able to build a custom TaskPool that allocates TaskStorage objects on-demand. To do this, I would maintain a collection of TaskStorage objects. When I want to spawn a task, I would iterate over these storages, call `TaskStorage::spawn()` (or... well... `_spawn_async_fn`), and decide if the returned SpawnToken is valid or failed.

This PR adds the method to check if a SpawnToken contains a success or a failure. This isn't useful for users directly, as they need to pass the token to a Spawner, but this seems to be the absolute minimum change necessary to support some sort of custom TaskPool implementation.

An alternative idea would be to publish `AvailableTask` and the `SpawnToken` constructors instead, but that is a bigger change and `SpawnToken::new()` would be a loaded gun probably.