### PR TITLE
RFC: Introduce type state based control for cyw43.

### DIFF
--- a/cyw43/src/events.rs
+++ b/cyw43/src/events.rs
@@ -1,5 +1,5 @@
 #![allow(dead_code)]
-#![allow(non_camel_case_types)]
+#![allow(non_upper_case_globals, non_camel_case_types)]
 
 use core::cell::RefCell;
 

--- a/cyw43/src/lib.rs
+++ b/cyw43/src/lib.rs
@@ -20,6 +20,7 @@ mod runner;
 
 use core::slice;
 
+use control::control_states::Uninit;
 use embassy_net_driver_channel as ch;
 use embedded_hal_1::digital::OutputPin;
 use events::Events;
@@ -27,7 +28,7 @@ use ioctl::IoctlState;
 
 use crate::bus::Bus;
 pub use crate::bus::SpiBusCyw43;
-pub use crate::control::{Control, Error as ControlError};
+pub use crate::control::{control_states, Control, Error as ControlError};
 pub use crate::runner::Runner;
 pub use crate::structs::BssInfo;
 
@@ -211,7 +212,7 @@ pub async fn new<'a, PWR, SPI>(
     pwr: PWR,
     spi: SPI,
     firmware: &[u8],
-) -> (NetDriver<'a>, Control<'a>, Runner<'a, PWR, SPI>)
+) -> (NetDriver<'a>, Control<'a, Uninit>, Runner<'a, PWR, SPI>)
 where
     PWR: OutputPin,
     SPI: SpiBusCyw43,

--- a/examples/rp/src/bin/wifi_ap_tcp_server.rs
+++ b/examples/rp/src/bin/wifi_ap_tcp_server.rs
@@ -61,10 +61,10 @@ async fn main(spawner: Spawner) {
     let spi = PioSpi::new(&mut pio.common, pio.sm0, pio.irq0, cs, p.PIN_24, p.PIN_29, p.DMA_CH0);
 
     let state = make_static!(cyw43::State::new());
-    let (net_device, mut control, runner) = cyw43::new(state, pwr, spi, fw).await;
+    let (net_device, control, runner) = cyw43::new(state, pwr, spi, fw).await;
     unwrap!(spawner.spawn(wifi_task(runner)));
 
-    control.init(clm).await;
+    let mut control = control.init(clm).await.up().await;
     control
         .set_power_management(cyw43::PowerManagementMode::PowerSave)
         .await;
@@ -90,7 +90,7 @@ async fn main(spawner: Spawner) {
     unwrap!(spawner.spawn(net_task(stack)));
 
     //control.start_ap_open("cyw43", 5).await;
-    control.start_ap_wpa2("cyw43", "password", 5).await;
+    let mut control = control.start_ap_wpa2("cyw43", "password", 5).await;
 
     // And now we can use it!
 

--- a/examples/rp/src/bin/wifi_blinky.rs
+++ b/examples/rp/src/bin/wifi_blinky.rs
@@ -47,10 +47,10 @@ async fn main(spawner: Spawner) {
     let spi = PioSpi::new(&mut pio.common, pio.sm0, pio.irq0, cs, p.PIN_24, p.PIN_29, p.DMA_CH0);
 
     let state = make_static!(cyw43::State::new());
-    let (_net_device, mut control, runner) = cyw43::new(state, pwr, spi, fw).await;
+    let (_net_device, control, runner) = cyw43::new(state, pwr, spi, fw).await;
     unwrap!(spawner.spawn(wifi_task(runner)));
 
-    control.init(clm).await;
+    let mut control = control.init(clm).await;
     control
         .set_power_management(cyw43::PowerManagementMode::PowerSave)
         .await;

--- a/examples/rp/src/bin/wifi_scan.rs
+++ b/examples/rp/src/bin/wifi_scan.rs
@@ -58,13 +58,14 @@ async fn main(spawner: Spawner) {
     let spi = PioSpi::new(&mut pio.common, pio.sm0, pio.irq0, cs, p.PIN_24, p.PIN_29, p.DMA_CH0);
 
     let state = make_static!(cyw43::State::new());
-    let (_net_device, mut control, runner) = cyw43::new(state, pwr, spi, fw).await;
+    let (_net_device, control, runner) = cyw43::new(state, pwr, spi, fw).await;
     unwrap!(spawner.spawn(wifi_task(runner)));
 
-    control.init(clm).await;
+    let mut control = control.init(clm).await;
     control
         .set_power_management(cyw43::PowerManagementMode::PowerSave)
         .await;
+    let mut control = control.up().await;
 
     let mut scanner = control.scan().await;
     while let Some(bss) = scanner.next().await {

--- a/tests/rp/src/bin/cyw43-perf.rs
+++ b/tests/rp/src/bin/cyw43-perf.rs
@@ -58,10 +58,10 @@ async fn main(spawner: Spawner) {
     let spi = PioSpi::new(&mut pio.common, pio.sm0, pio.irq0, cs, p.PIN_24, p.PIN_29, p.DMA_CH0);
 
     let state = make_static!(cyw43::State::new());
-    let (net_device, mut control, runner) = cyw43::new(state, pwr, spi, fw).await;
+    let (net_device, control, runner) = cyw43::new(state, pwr, spi, fw).await;
     unwrap!(spawner.spawn(wifi_task(runner)));
 
-    control.init(clm).await;
+    let mut control = control.init(clm).await.up().await;
     control
         .set_power_management(cyw43::PowerManagementMode::PowerSave)
         .await;
@@ -79,14 +79,14 @@ async fn main(spawner: Spawner) {
 
     unwrap!(spawner.spawn(net_task(stack)));
 
-    loop {
+    let _control = loop {
         match control.join_wpa2(WIFI_NETWORK, WIFI_PASSWORD).await {
-            Ok(_) => break,
-            Err(err) => {
+            Ok(control) => break control,
+            Err((err, _)) => {
                 panic!("join failed with status={}", err.status);
             }
         }
-    }
+    };
 
     info!("Waiting for DHCP up...");
     while stack.config_v4().is_none() {


### PR DESCRIPTION
This PR primarily aims at preventing users from calling functions on the `Control` struct, which would be invalid at that point in time. As a second goal, we could introduce functions to leave a WiFi network and stop hosting an AP. All the changes currently made should have zero impact on performance and could in certain cases even improve it, by moving checks which were previously executed at run-time, back to compile-time.