### PR TITLE
Fix DateTime Conversion and RTC Example

### DIFF
--- a/embassy-stm32/src/rtc/datetime.rs
+++ b/embassy-stm32/src/rtc/datetime.rs
@@ -89,7 +89,7 @@ pub enum DayOfWeek {
 #[cfg(feature = "chrono")]
 impl From<chrono::Weekday> for DayOfWeek {
     fn from(weekday: Weekday) -> Self {
-        day_of_week_from_u8(weekday.number_from_monday() as u8).unwrap()
+        day_of_week_from_u8(weekday.num_days_from_monday() as u8).unwrap()
     }
 }
 

--- a/examples/stm32f4/src/bin/rtc.rs
+++ b/examples/stm32f4/src/bin/rtc.rs
@@ -5,13 +5,19 @@
 use chrono::{NaiveDate, NaiveDateTime};
 use defmt::*;
 use embassy_executor::Spawner;
-use embassy_stm32::rtc::{Rtc, RtcConfig};
+use embassy_stm32::{
+    rtc::{Rtc, RtcClockSource, RtcConfig},
+    Config,
+};
 use embassy_time::{Duration, Timer};
 use {defmt_rtt as _, panic_probe as _};
 
 #[embassy_executor::main]
 async fn main(_spawner: Spawner) {
-    let p = embassy_stm32::init(Default::default());
+    let mut config = Config::default();
+    config.rcc.rtc = Option::Some(RtcClockSource::LSI);
+    let p = embassy_stm32::init(config);
+
     info!("Hello World!");
 
     let now = NaiveDate::from_ymd_opt(2020, 5, 15)
@@ -23,8 +29,11 @@ async fn main(_spawner: Spawner) {
 
     rtc.set_datetime(now.into()).expect("datetime not set");
 
-    // In reality the delay would be much longer
-    Timer::after(Duration::from_millis(20000)).await;
+    loop {
+        let now: NaiveDateTime = rtc.now().unwrap().into();
 
-    let _then: NaiveDateTime = rtc.now().unwrap().into();
+        info!("{}", now.timestamp());
+
+        Timer::after(Duration::from_millis(1000)).await;
+    }
 }


### PR DESCRIPTION
## Incorrect Weekday Conversion

### Problem 

The `day_of_week_from_u8` implementation for `stm32` expects a number 0-6 which represents Mon-Sun, the current implementation for converting `chrono::Weekday` to `DayOfWeek` uses the `chrono` function `number_from_monday` which returns 1-7 representing Mon-Sun. This causes the following error to be thrown on Sundays and every other day the weekday to be off-by-one.

```
called `Result::unwrap()` on an `Err` value: InvalidDayOfWeek(7)
```

### Solution

Replace the `number_from_monday` function call with `num_days_from_monday` which returns the expected 0-6 representing Mon-Sun.


## RTC Example for `stm32f4` Hangs

### Problem 

The example RTC code hangs on the line `let mut rtc = Rtc::new(p.RTC, RtcConfig::default());`.

### Solution

Configure the RTC clock source to use `LSI`.