### PR TITLE
cyw43: Add utility functions.

### DIFF
--- a/cyw43/src/consts.rs
+++ b/cyw43/src/consts.rs
@@ -96,6 +96,7 @@ pub(crate) const IOCTL_CMD_UP: u32 = 2;
 pub(crate) const IOCTL_CMD_DOWN: u32 = 3;
 pub(crate) const IOCTL_CMD_SET_SSID: u32 = 26;
 pub(crate) const IOCTL_CMD_SET_CHANNEL: u32 = 30;
+pub(crate) const IOCTL_CMD_DISASSOC: u32 = 52;
 pub(crate) const IOCTL_CMD_ANTDIV: u32 = 64;
 pub(crate) const IOCTL_CMD_SET_AP: u32 = 118;
 pub(crate) const IOCTL_CMD_SET_VAR: u32 = 263;

--- a/cyw43/src/control.rs
+++ b/cyw43/src/control.rs
@@ -124,7 +124,7 @@ impl<'a> Control<'a> {
         Timer::after(Duration::from_millis(100)).await;
 
         // set wifi up
-        self.ioctl(IoctlType::Set, IOCTL_CMD_UP, 0, &mut []).await;
+        self.up().await;
 
         Timer::after(Duration::from_millis(100)).await;
 
@@ -136,6 +136,16 @@ impl<'a> Control<'a> {
         self.state_ch.set_ethernet_address(mac_addr);
 
         debug!("INIT DONE");
+    }
+
+    /// Set the WiFi interface up.
+    async fn up(&mut self) {
+        self.ioctl(IoctlType::Set, IOCTL_CMD_UP, 0, &mut []).await;
+    }
+
+    /// Set the interface down.
+    async fn down(&mut self) {
+        self.ioctl(IoctlType::Set, IOCTL_CMD_DOWN, 0, &mut []).await;
     }
 
     pub async fn set_power_management(&mut self, mode: PowerManagementMode) {
@@ -256,13 +266,13 @@ impl<'a> Control<'a> {
         }
 
         // Temporarily set wifi down
-        self.ioctl(IoctlType::Set, IOCTL_CMD_DOWN, 0, &mut []).await;
+        self.down().await;
 
         // Turn off APSTA mode
         self.set_iovar_u32("apsta", 0).await;
 
         // Set wifi up again
-        self.ioctl(IoctlType::Set, IOCTL_CMD_UP, 0, &mut []).await;
+        self.up().await;
 
         // Turn on AP mode
         self.ioctl_set_u32(IOCTL_CMD_SET_AP, 0, 1).await;

--- a/cyw43/src/control.rs
+++ b/cyw43/src/control.rs
@@ -433,6 +433,11 @@ impl<'a> Control<'a> {
             events: &self.events,
         }
     }
+    /// Leave the wifi, with which we are currently associated.
+    pub async fn leave(&mut self) {
+        self.ioctl(IoctlType::Set, IOCTL_CMD_DISASSOC, 0, &mut []).await;
+        info!("Disassociated")
+    }
 }
 
 pub struct Scanner<'a> {

--- a/cyw43/src/events.rs
+++ b/cyw43/src/events.rs
@@ -1,5 +1,5 @@
 #![allow(dead_code)]
-#![allow(non_camel_case_types)]
+#![allow(non_camel_case_types, non_upper_case_globals)]
 
 use core::cell::RefCell;
 

--- a/cyw43/src/events.rs
+++ b/cyw43/src/events.rs
@@ -1,5 +1,5 @@
 #![allow(dead_code)]
-#![allow(non_camel_case_types, non_upper_case_globals)]
+#![allow(non_camel_case_types)]
 
 use core::cell::RefCell;
 

--- a/cyw43/src/lib.rs
+++ b/cyw43/src/lib.rs
@@ -27,7 +27,7 @@ use ioctl::IoctlState;
 
 use crate::bus::Bus;
 pub use crate::bus::SpiBusCyw43;
-pub use crate::control::{Control, Error as ControlError};
+pub use crate::control::{Control, Error as ControlError, Scanner};
 pub use crate::runner::Runner;
 pub use crate::structs::BssInfo;
 


### PR DESCRIPTION
In its current state, this PR introduces separate up/down functions, which are just used internally for now. As well as introducing a function for leaving an infra.