### PR TITLE
embassy-time: Introduce reset function for Ticker.

### DIFF
--- a/embassy-time/src/timer.rs
+++ b/embassy-time/src/timer.rs
@@ -133,7 +133,7 @@ impl Ticker {
         Self { expires_at, duration }
     }
 
-    /// Resets the ticker back to its original state. 
+    /// Resets the ticker back to its original state.
     /// This causes the ticker to go back to zero, even if the current tick isn't over yet.
     pub fn reset(&mut self) {
         self.expires_at = Instant::now() + self.duration;

--- a/embassy-time/src/timer.rs
+++ b/embassy-time/src/timer.rs
@@ -133,8 +133,7 @@ impl Ticker {
         Self { expires_at, duration }
     }
 
-    /// Resets the ticker back to its original state.
-    /// 
+    /// Resets the ticker back to its original state. 
     /// This causes the ticker to go back to zero, even if the current tick isn't over yet.
     pub fn reset(&mut self) {
         self.expires_at = Instant::now() + self.duration;

--- a/embassy-time/src/timer.rs
+++ b/embassy-time/src/timer.rs
@@ -133,7 +133,14 @@ impl Ticker {
         Self { expires_at, duration }
     }
 
-    /// Waits for the next tick
+    /// Resets the ticker back to its original state.
+    /// 
+    /// This causes the ticker to go back to zero, even if the current tick isn't over yet.
+    pub fn reset(&mut self) {
+        self.expires_at = Instant::now() + self.duration;
+    }
+
+    /// Waits for the next tick.
     pub fn next(&mut self) -> impl Future<Output = ()> + '_ {
         poll_fn(|cx| {
             if self.expires_at <= Instant::now() {


### PR DESCRIPTION
This PR attempts to allow resetting the Ticker in embassy-time. This could prove useful for the implementation of some network protocols, which require precise timing alignments.