### PR TITLE
stm32/rtc: autocompute prescalers

### DIFF
--- a/embassy-stm32/src/rcc/f4.rs
+++ b/embassy-stm32/src/rcc/f4.rs
@@ -499,6 +499,7 @@ pub(crate) unsafe fn init(config: Config) {
         pllsai: None,
 
         rtc: rtc,
+        rtc_hse: None,
     });
 }
 

--- a/embassy-stm32/src/rcc/mod.rs
+++ b/embassy-stm32/src/rcc/mod.rs
@@ -78,8 +78,12 @@ pub struct Clocks {
     pub adc: Option<Hertz>,
 
     #[cfg(any(rcc_wb, rcc_f4, rcc_f410))]
-    /// Set only if the lsi or lse is configured
+    /// Set only if the lsi or lse is configured, indicates stop is supported
     pub rtc: Option<Hertz>,
+
+    #[cfg(any(rcc_f4, rcc_f410))]
+    /// Set if the hse is configured, indicates stop is not supported
+    pub rtc_hse: Option<Hertz>,
 }
 
 #[cfg(feature = "low-power")]

--- a/embassy-stm32/src/rcc/mod.rs
+++ b/embassy-stm32/src/rcc/mod.rs
@@ -81,7 +81,7 @@ pub struct Clocks {
     /// Set only if the lsi or lse is configured, indicates stop is supported
     pub rtc: Option<Hertz>,
 
-    #[cfg(any(rcc_f4, rcc_f410))]
+    #[cfg(any(rcc_wb, rcc_f4, rcc_f410))]
     /// Set if the hse is configured, indicates stop is not supported
     pub rtc_hse: Option<Hertz>,
 }

--- a/embassy-stm32/src/rcc/wb.rs
+++ b/embassy-stm32/src/rcc/wb.rs
@@ -271,6 +271,7 @@ pub(crate) fn compute_clocks(config: &Config) -> Clocks {
         apb1_tim: apb1_tim_clk,
         apb2_tim: apb2_tim_clk,
         rtc: rtc_clk,
+        rtc_hse: None,
     }
 }
 

--- a/embassy-stm32/src/rtc/mod.rs
+++ b/embassy-stm32/src/rtc/mod.rs
@@ -124,6 +124,7 @@ impl Default for RtcCalibrationCyclePeriod {
 
 impl Rtc {
     pub fn new(_rtc: impl Peripheral<P = RTC>, rtc_config: RtcConfig) -> Self {
+        #[cfg(any(rcc_wb, rcc_f4, rcc_f410))]
         use crate::rcc::get_freqs;
 
         RTC::enable_peripheral_clk();

--- a/embassy-stm32/src/rtc/v2.rs
+++ b/embassy-stm32/src/rtc/v2.rs
@@ -1,6 +1,6 @@
 use stm32_metapac::rtc::vals::{Init, Osel, Pol};
 
-use super::{sealed, RtcConfig};
+use super::sealed;
 use crate::pac::rtc::Rtc;
 use crate::peripherals::RTC;
 use crate::rtc::sealed::Instance;

--- a/embassy-stm32/src/rtc/v2.rs
+++ b/embassy-stm32/src/rtc/v2.rs
@@ -154,7 +154,7 @@ impl super::Rtc {
 
     /// Applies the RTC config
     /// It this changes the RTC clock source the time will be reset
-    pub(super) fn configure(&mut self, rtc_config: RtcConfig) {
+    pub(super) fn configure(&mut self, async_psc: u8, sync_psc: u16) {
         self.write(true, |rtc| {
             rtc.cr().modify(|w| {
                 #[cfg(rtc_v2f2)]
@@ -166,8 +166,8 @@ impl super::Rtc {
             });
 
             rtc.prer().modify(|w| {
-                w.set_prediv_s(rtc_config.sync_prescaler);
-                w.set_prediv_a(rtc_config.async_prescaler);
+                w.set_prediv_s(sync_psc);
+                w.set_prediv_a(async_psc);
             });
         });
     }

--- a/embassy-stm32/src/rtc/v3.rs
+++ b/embassy-stm32/src/rtc/v3.rs
@@ -1,6 +1,6 @@
 use stm32_metapac::rtc::vals::{Calp, Calw16, Calw8, Fmt, Init, Key, Osel, Pol, TampalrmPu, TampalrmType};
 
-use super::{sealed, RtcCalibrationCyclePeriod, RtcConfig};
+use super::{sealed, RtcCalibrationCyclePeriod};
 use crate::pac::rtc::Rtc;
 use crate::peripherals::RTC;
 use crate::rtc::sealed::Instance;

--- a/embassy-stm32/src/rtc/v3.rs
+++ b/embassy-stm32/src/rtc/v3.rs
@@ -8,7 +8,7 @@ use crate::rtc::sealed::Instance;
 impl super::Rtc {
     /// Applies the RTC config
     /// It this changes the RTC clock source the time will be reset
-    pub(super) fn configure(&mut self, rtc_config: RtcConfig) {
+    pub(super) fn configure(&mut self, async_psc: u8, sync_psc: u16) {
         self.write(true, |rtc| {
             rtc.cr().modify(|w| {
                 w.set_fmt(Fmt::TWENTYFOURHOUR);
@@ -17,8 +17,8 @@ impl super::Rtc {
             });
 
             rtc.prer().modify(|w| {
-                w.set_prediv_s(rtc_config.sync_prescaler);
-                w.set_prediv_a(rtc_config.async_prescaler);
+                w.set_prediv_s(sync_psc);
+                w.set_prediv_a(async_psc);
             });
 
             // TODO: configuration for output pins


### PR DESCRIPTION
this adjusts the prescalers appropriately if the lsi or hse is used.