### PR TITLE
rp: Fix write size in embassy-boot example app

### DIFF
--- a/examples/boot/application/rp/src/bin/a.rs
+++ b/examples/boot/application/rp/src/bin/a.rs
@@ -38,7 +38,7 @@ async fn main(_s: Spawner) {
     let flash = Mutex::new(RefCell::new(flash));
 
     let config = FirmwareUpdaterConfig::from_linkerfile_blocking(&flash);
-    let mut aligned = AlignedBuffer([0; 4]);
+    let mut aligned = AlignedBuffer([0; 1]);
     let mut updater = BlockingFirmwareUpdater::new(config, &mut aligned.0);
 
     Timer::after(Duration::from_secs(5)).await;


### PR DESCRIPTION
Aligned buffer size should be equal to flash write size (1 instead of 4)