### PR TITLE
embassy-{net, sync, time}: Use fmt::unwrap

### DIFF
--- a/embassy-net/src/device.rs
+++ b/embassy-net/src/device.rs
@@ -22,13 +22,13 @@ where
 
     fn receive(&mut self, _timestamp: Instant) -> Option<(Self::RxToken<'_>, Self::TxToken<'_>)> {
         self.inner
-            .receive(self.cx.as_deref_mut().unwrap())
+            .receive(unwrap!(self.cx.as_deref_mut()))
             .map(|(rx, tx)| (RxTokenAdapter(rx), TxTokenAdapter(tx)))
     }
 
     /// Construct a transmit token.
     fn transmit(&mut self, _timestamp: Instant) -> Option<Self::TxToken<'_>> {
-        self.inner.transmit(self.cx.as_deref_mut().unwrap()).map(TxTokenAdapter)
+        self.inner.transmit(unwrap!(self.cx.as_deref_mut())).map(TxTokenAdapter)
     }
 
     /// Get a description of device capabilities.

--- a/embassy-net/src/lib.rs
+++ b/embassy-net/src/lib.rs
@@ -616,7 +616,7 @@ impl<D: Driver + 'static> Inner<D> {
                 }
 
                 // Configure it
-                let socket = _s.sockets.get_mut::<dhcpv4::Socket>(self.dhcp_socket.unwrap());
+                let socket = _s.sockets.get_mut::<dhcpv4::Socket>(unwrap!(self.dhcp_socket));
                 socket.set_ignore_naks(c.ignore_naks);
                 socket.set_max_lease_duration(c.max_lease_duration.map(crate::time::duration_to_smoltcp));
                 socket.set_ports(c.server_port, c.client_port);
@@ -656,12 +656,12 @@ impl<D: Driver + 'static> Inner<D> {
             debug!("   IP address:      {:?}", config.address);
             debug!("   Default gateway: {:?}", config.gateway);
 
-            addrs.push(IpCidr::Ipv4(config.address)).unwrap();
+            unwrap!(addrs.push(IpCidr::Ipv4(config.address)).ok());
             gateway_v4 = config.gateway.into();
             #[cfg(feature = "dns")]
             for s in &config.dns_servers {
                 debug!("   DNS server:      {:?}", s);
-                dns_servers.push(s.clone().into()).unwrap();
+                unwrap!(dns_servers.push(s.clone().into()).ok());
             }
         } else {
             info!("IPv4: DOWN");
@@ -673,12 +673,12 @@ impl<D: Driver + 'static> Inner<D> {
             debug!("   IP address:      {:?}", config.address);
             debug!("   Default gateway: {:?}", config.gateway);
 
-            addrs.push(IpCidr::Ipv6(config.address)).unwrap();
+            unwrap!(addrs.push(IpCidr::Ipv6(config.address)).ok());
             gateway_v6 = config.gateway.into();
             #[cfg(feature = "dns")]
             for s in &config.dns_servers {
                 debug!("   DNS server:      {:?}", s);
-                dns_servers.push(s.clone().into()).unwrap();
+                unwrap!(dns_servers.push(s.clone().into()).ok());
             }
         } else {
             info!("IPv6: DOWN");
@@ -690,13 +690,13 @@ impl<D: Driver + 'static> Inner<D> {
         // Apply gateways
         #[cfg(feature = "proto-ipv4")]
         if let Some(gateway) = gateway_v4 {
-            s.iface.routes_mut().add_default_ipv4_route(gateway).unwrap();
+            unwrap!(s.iface.routes_mut().add_default_ipv4_route(gateway));
         } else {
             s.iface.routes_mut().remove_default_ipv4_route();
         }
         #[cfg(feature = "proto-ipv6")]
         if let Some(gateway) = gateway_v6 {
-            s.iface.routes_mut().add_default_ipv6_route(gateway).unwrap();
+            unwrap!(s.iface.routes_mut().add_default_ipv6_route(gateway));
         } else {
             s.iface.routes_mut().remove_default_ipv6_route();
         }

--- a/embassy-net/src/tcp.rs
+++ b/embassy-net/src/tcp.rs
@@ -440,7 +440,7 @@ impl<'d> TcpIo<'d> {
                         Poll::Ready(Err(Error::ConnectionReset))
                     }
                 } else {
-                    Poll::Ready(match s.send(f.take().unwrap()) {
+                    Poll::Ready(match s.send(unwrap!(f.take())) {
                         // Connection reset. TODO: this can also be timeouts etc, investigate.
                         Err(tcp::SendError::InvalidState) => Err(Error::ConnectionReset),
                         Ok(r) => Ok(r),
@@ -468,7 +468,7 @@ impl<'d> TcpIo<'d> {
                         Poll::Ready(Err(Error::ConnectionReset))
                     }
                 } else {
-                    Poll::Ready(match s.recv(f.take().unwrap()) {
+                    Poll::Ready(match s.recv(unwrap!(f.take())) {
                         // Connection reset. TODO: this can also be timeouts etc, investigate.
                         Err(tcp::RecvError::Finished) | Err(tcp::RecvError::InvalidState) => {
                             Err(Error::ConnectionReset)

--- a/embassy-sync/src/channel.rs
+++ b/embassy-sync/src/channel.rs
@@ -471,7 +471,7 @@ where
     }
 
     fn lock<R>(&self, f: impl FnOnce(&mut ChannelState<T, N>) -> R) -> R {
-        self.inner.lock(|rc| f(&mut *rc.borrow_mut()))
+        self.inner.lock(|rc| f(&mut *unwrap!(rc.try_borrow_mut())))
     }
 
     fn try_receive_with_context(&self, cx: Option<&mut Context<'_>>) -> Result<T, TryReceiveError> {

--- a/embassy-sync/src/mutex.rs
+++ b/embassy-sync/src/mutex.rs
@@ -149,7 +149,7 @@ where
 {
     fn drop(&mut self) {
         self.mutex.state.lock(|s| {
-            let mut s = s.borrow_mut();
+            let mut s = unwrap!(s.try_borrow_mut());
             s.locked = false;
             s.waker.wake();
         })

--- a/embassy-time/src/instant.rs
+++ b/embassy-time/src/instant.rs
@@ -71,7 +71,7 @@ impl Instant {
     /// Panics on over/underflow.
     pub fn duration_since(&self, earlier: Instant) -> Duration {
         Duration {
-            ticks: self.ticks.checked_sub(earlier.ticks).unwrap(),
+            ticks: unwrap!(self.ticks.checked_sub(earlier.ticks)),
         }
     }
 

--- a/examples/boot/application/rp/Cargo.toml
+++ b/examples/boot/application/rp/Cargo.toml
@@ -27,6 +27,7 @@ default = ["panic-reset"]
 debug = [
     "embassy-rp/defmt",
     "embassy-boot-rp/defmt",
+    "embassy-sync/defmt",
     "panic-probe"
 ]
 skip-include = []

--- a/examples/boot/application/stm32f3/Cargo.toml
+++ b/examples/boot/application/stm32f3/Cargo.toml
@@ -5,7 +5,7 @@ version = "0.1.0"
 license = "MIT OR Apache-2.0"
 
 [dependencies]
-embassy-sync = { version = "0.2.0", path = "../../../../embassy-sync", features = ["defmt"] }
+embassy-sync = { version = "0.2.0", path = "../../../../embassy-sync" }
 embassy-executor = { version = "0.3.0", path = "../../../../embassy-executor", features = ["arch-cortex-m", "executor-thread", "nightly", "integrated-timers"] }
 embassy-time = { version = "0.1.2", path = "../../../../embassy-time", features = ["nightly", "tick-hz-32_768"] }
 embassy-stm32 = { version = "0.1.0", path = "../../../../embassy-stm32", features = ["unstable-traits", "nightly", "stm32f303re", "time-driver-any", "exti"]  }
@@ -25,5 +25,6 @@ defmt = [
       "dep:defmt",
       "embassy-stm32/defmt",
       "embassy-boot-stm32/defmt",
+      "embassy-sync/defmt",
 ]
 skip-include = []

--- a/examples/boot/application/stm32f7/Cargo.toml
+++ b/examples/boot/application/stm32f7/Cargo.toml
@@ -5,7 +5,7 @@ version = "0.1.0"
 license = "MIT OR Apache-2.0"
 
 [dependencies]
-embassy-sync = { version = "0.2.0", path = "../../../../embassy-sync", features = ["defmt"] }
+embassy-sync = { version = "0.2.0", path = "../../../../embassy-sync" }
 embassy-executor = { version = "0.3.0", path = "../../../../embassy-executor", features = ["arch-cortex-m", "executor-thread", "nightly", "integrated-timers"] }
 embassy-time = { version = "0.1.2", path = "../../../../embassy-time", features = ["nightly", "tick-hz-32_768"] }
 embassy-stm32 = { version = "0.1.0", path = "../../../../embassy-stm32", features = ["unstable-traits", "nightly", "stm32f767zi", "time-driver-any", "exti"]  }
@@ -26,5 +26,6 @@ defmt = [
       "dep:defmt",
       "embassy-stm32/defmt",
       "embassy-boot-stm32/defmt",
+      "embassy-sync/defmt",
 ]
 skip-include = []

--- a/examples/boot/application/stm32h7/Cargo.toml
+++ b/examples/boot/application/stm32h7/Cargo.toml
@@ -26,5 +26,6 @@ defmt = [
       "dep:defmt",
       "embassy-stm32/defmt",
       "embassy-boot-stm32/defmt",
+      "embassy-sync/defmt",
 ]
 skip-include = []

--- a/examples/boot/application/stm32l0/Cargo.toml
+++ b/examples/boot/application/stm32l0/Cargo.toml
@@ -5,7 +5,7 @@ version = "0.1.0"
 license = "MIT OR Apache-2.0"
 
 [dependencies]
-embassy-sync = { version = "0.2.0", path = "../../../../embassy-sync", features = ["defmt"] }
+embassy-sync = { version = "0.2.0", path = "../../../../embassy-sync" }
 embassy-executor = { version = "0.3.0", path = "../../../../embassy-executor", features = ["arch-cortex-m", "executor-thread", "nightly", "integrated-timers"] }
 embassy-time = { version = "0.1.2", path = "../../../../embassy-time", features = ["nightly", "tick-hz-32_768"] }
 embassy-stm32 = { version = "0.1.0", path = "../../../../embassy-stm32", features = ["unstable-traits", "nightly", "stm32l072cz", "time-driver-any", "exti", "memory-x"]  }
@@ -25,5 +25,6 @@ defmt = [
       "dep:defmt",
       "embassy-stm32/defmt",
       "embassy-boot-stm32/defmt",
+      "embassy-sync/defmt",
 ]
 skip-include = []

--- a/examples/boot/application/stm32l1/Cargo.toml
+++ b/examples/boot/application/stm32l1/Cargo.toml
@@ -5,7 +5,7 @@ version = "0.1.0"
 license = "MIT OR Apache-2.0"
 
 [dependencies]
-embassy-sync = { version = "0.2.0", path = "../../../../embassy-sync", features = ["defmt"] }
+embassy-sync = { version = "0.2.0", path = "../../../../embassy-sync" }
 embassy-executor = { version = "0.3.0", path = "../../../../embassy-executor", features = ["arch-cortex-m", "executor-thread", "nightly", "integrated-timers"] }
 embassy-time = { version = "0.1.2", path = "../../../../embassy-time", features = ["nightly", "tick-hz-32_768"] }
 embassy-stm32 = { version = "0.1.0", path = "../../../../embassy-stm32", features = ["unstable-traits", "nightly", "stm32l151cb-a", "time-driver-any", "exti"]  }
@@ -25,5 +25,6 @@ defmt = [
       "dep:defmt",
       "embassy-stm32/defmt",
       "embassy-boot-stm32/defmt",
+      "embassy-sync/defmt",
 ]
 skip-include = []

--- a/examples/boot/application/stm32l4/Cargo.toml
+++ b/examples/boot/application/stm32l4/Cargo.toml
@@ -5,7 +5,7 @@ version = "0.1.0"
 license = "MIT OR Apache-2.0"
 
 [dependencies]
-embassy-sync = { version = "0.2.0", path = "../../../../embassy-sync", features = ["defmt"] }
+embassy-sync = { version = "0.2.0", path = "../../../../embassy-sync" }
 embassy-executor = { version = "0.3.0", path = "../../../../embassy-executor", features = ["arch-cortex-m", "executor-thread", "nightly", "integrated-timers"] }
 embassy-time = { version = "0.1.2", path = "../../../../embassy-time", features = ["nightly", "tick-hz-32_768"] }
 embassy-stm32 = { version = "0.1.0", path = "../../../../embassy-stm32", features = ["unstable-traits", "nightly", "stm32l475vg", "time-driver-any", "exti"]  }
@@ -25,5 +25,6 @@ defmt = [
       "dep:defmt",
       "embassy-stm32/defmt",
       "embassy-boot-stm32/defmt",
+      "embassy-sync/defmt",
 ]
 skip-include = []

--- a/examples/boot/application/stm32wl/Cargo.toml
+++ b/examples/boot/application/stm32wl/Cargo.toml
@@ -5,7 +5,7 @@ version = "0.1.0"
 license = "MIT OR Apache-2.0"
 
 [dependencies]
-embassy-sync = { version = "0.2.0", path = "../../../../embassy-sync", features = ["defmt"] }
+embassy-sync = { version = "0.2.0", path = "../../../../embassy-sync" }
 embassy-executor = { version = "0.3.0", path = "../../../../embassy-executor", features = ["arch-cortex-m", "executor-thread", "nightly", "integrated-timers"] }
 embassy-time = { version = "0.1.2", path = "../../../../embassy-time", features = ["nightly", "tick-hz-32_768"] }
 embassy-stm32 = { version = "0.1.0", path = "../../../../embassy-stm32", features = ["unstable-traits", "nightly", "stm32wl55jc-cm4", "time-driver-any", "exti"]  }
@@ -25,5 +25,6 @@ defmt = [
       "dep:defmt",
       "embassy-stm32/defmt",
       "embassy-boot-stm32/defmt",
+      "embassy-sync/defmt",
 ]
 skip-include = []

--- a/examples/boot/bootloader/nrf/Cargo.toml
+++ b/examples/boot/bootloader/nrf/Cargo.toml
@@ -25,7 +25,7 @@ defmt = [
 softdevice = [
     "embassy-boot-nrf/softdevice",
 ]
-debug = ["defmt-rtt"]
+debug = ["defmt-rtt", "defmt"]
 
 [profile.dev]
 debug = 2

--- a/examples/boot/bootloader/stm32/Cargo.toml
+++ b/examples/boot/bootloader/stm32/Cargo.toml
@@ -24,7 +24,7 @@ defmt = [
     "embassy-boot-stm32/defmt",
     "embassy-stm32/defmt",
 ]
-debug = ["defmt-rtt"]
+debug = ["defmt-rtt", "defmt"]
 
 [profile.dev]
 debug = 2


### PR DESCRIPTION
This PR tries to avoid including panic strings in the binary by preferring defmt::unwrap if available.