### PR TITLE
stm32: refcount peripheral enable/disable

### DIFF
--- a/ci.sh
+++ b/ci.sh
@@ -180,9 +180,4 @@ if [[ -z "${TELEPROBE_TOKEN-}" ]]; then
     exit
 fi
 
-rm out/tests/rpi-pico/ethernet_w5100s_perf
-rm out/tests/nrf52840-dk/ethernet_enc28j60_perf
-rm out/tests/nrf52840-dk/wifi_esp_hosted_perf
-rm out/tests/rpi-pico/cyw43-perf
-
 teleprobe client run -r out/tests

--- a/embassy-stm32/build.rs
+++ b/embassy-stm32/build.rs
@@ -308,7 +308,8 @@ fn main() {
     // ========
     // Generate RccPeripheral impls
 
-    let refcounted_peripherals = HashSet::from(["USART", "SPI", "I2C"]);
+    // TODO: maybe get this from peripheral kind? Not sure
+    let refcounted_peripherals = HashSet::from(["UART", "USART", "SPI", "I2C"]);
     let mut refcount_statics = HashSet::new();
 
     for p in METADATA.peripherals {

--- a/embassy-stm32/build.rs
+++ b/embassy-stm32/build.rs
@@ -309,7 +309,7 @@ fn main() {
     // Generate RccPeripheral impls
 
     // TODO: maybe get this from peripheral kind? Not sure
-    let refcounted_peripherals = HashSet::from(["UART", "USART", "SPI", "I2C"]);
+    let refcounted_peripherals = HashSet::from(["USART"]);
     let mut refcount_statics = HashSet::new();
 
     for p in METADATA.peripherals {
@@ -348,13 +348,13 @@ fn main() {
                 TokenStream::new()
             };
 
-            let ptype = p.name.replace(|c| char::is_numeric(c), "");
+            let ptype = (if let Some(reg) = &p.registers { reg.kind } else { "" }).to_ascii_uppercase();
             let pname = format_ident!("{}", p.name);
             let clk = format_ident!("{}", rcc.clock.to_ascii_lowercase());
             let en_reg = format_ident!("{}", en.register.to_ascii_lowercase());
             let set_en_field = format_ident!("set_{}", en.field.to_ascii_lowercase());
 
-            let (before_enable, before_disable) = if refcounted_peripherals.contains(ptype.trim_start_matches("LP")) {
+            let (before_enable, before_disable) = if refcounted_peripherals.contains(ptype.as_str()) {
                 let refcount_static =
                     format_ident!("{}_{}", en.register.to_ascii_uppercase(), en.field.to_ascii_uppercase());
 

--- a/embassy-stm32/build.rs
+++ b/embassy-stm32/build.rs
@@ -308,7 +308,7 @@ fn main() {
     // ========
     // Generate RccPeripheral impls
 
-    let refcounted_peripherals = HashSet::from(["ADC", "USART", "SPI", "I2C"]);
+    let refcounted_peripherals = HashSet::from(["USART", "SPI", "I2C"]);
     let mut refcount_statics = HashSet::new();
 
     for p in METADATA.peripherals {

--- a/embassy-stm32/src/i2c/v1.rs
+++ b/embassy-stm32/src/i2c/v1.rs
@@ -339,6 +339,12 @@ impl<'d, T: Instance, TXDMA, RXDMA> I2c<'d, T, TXDMA, RXDMA> {
     }
 }
 
+impl<'d, T: Instance, TXDMA, RXDMA> Drop for I2c<'d, T, TXDMA, RXDMA> {
+    fn drop(&mut self) {
+        T::disable();
+    }
+}
+
 impl<'d, T: Instance> embedded_hal_02::blocking::i2c::Read for I2c<'d, T> {
     type Error = Error;
 

--- a/embassy-stm32/src/i2c/v2.rs
+++ b/embassy-stm32/src/i2c/v2.rs
@@ -838,6 +838,12 @@ impl<'d, T: Instance, TXDMA, RXDMA> I2c<'d, T, TXDMA, RXDMA> {
     }
 }
 
+impl<'d, T: Instance, TXDMA, RXDMA> Drop for I2c<'d, T, TXDMA, RXDMA> {
+    fn drop(&mut self) {
+        T::disable();
+    }
+}
+
 mod eh02 {
     use super::*;
 

--- a/embassy-stm32/src/spi/mod.rs
+++ b/embassy-stm32/src/spi/mod.rs
@@ -646,6 +646,8 @@ impl<'d, T: Instance, Tx, Rx> Drop for Spi<'d, T, Tx, Rx> {
         self.sck.as_ref().map(|x| x.set_as_disconnected());
         self.mosi.as_ref().map(|x| x.set_as_disconnected());
         self.miso.as_ref().map(|x| x.set_as_disconnected());
+
+        T::disable();
     }
 }
 

--- a/embassy-stm32/src/usart/buffered.rs
+++ b/embassy-stm32/src/usart/buffered.rs
@@ -124,6 +124,8 @@ impl<'d, T: BasicInstance> BufferedUart<'d, T> {
         rx_buffer: &'d mut [u8],
         config: Config,
     ) -> BufferedUart<'d, T> {
+        // UartRx and UartTx have one refcount ea.
+        T::enable();
         T::enable();
         T::reset();
 
@@ -143,6 +145,8 @@ impl<'d, T: BasicInstance> BufferedUart<'d, T> {
     ) -> BufferedUart<'d, T> {
         into_ref!(cts, rts);
 
+        // UartRx and UartTx have one refcount ea.
+        T::enable();
         T::enable();
         T::reset();
 
@@ -169,6 +173,8 @@ impl<'d, T: BasicInstance> BufferedUart<'d, T> {
     ) -> BufferedUart<'d, T> {
         into_ref!(de);
 
+        // UartRx and UartTx have one refcount ea.
+        T::enable();
         T::enable();
         T::reset();
 
@@ -382,6 +388,8 @@ impl<'d, T: BasicInstance> Drop for BufferedUartRx<'d, T> {
                 T::Interrupt::disable();
             }
         }
+
+        T::disable();
     }
 }
 
@@ -397,6 +405,8 @@ impl<'d, T: BasicInstance> Drop for BufferedUartTx<'d, T> {
                 T::Interrupt::disable();
             }
         }
+
+        T::disable();
     }
 }
 

--- a/embassy-stm32/src/usart/mod.rs
+++ b/embassy-stm32/src/usart/mod.rs
@@ -618,6 +618,18 @@ impl<'d, T: BasicInstance, RxDma> UartRx<'d, T, RxDma> {
     }
 }
 
+impl<'d, T: BasicInstance, TxDma> Drop for UartTx<'d, T, TxDma> {
+    fn drop(&mut self) {
+        T::disable();
+    }
+}
+
+impl<'d, T: BasicInstance, TxDma> Drop for UartRx<'d, T, TxDma> {
+    fn drop(&mut self) {
+        T::disable();
+    }
+}
+
 impl<'d, T: BasicInstance, TxDma, RxDma> Uart<'d, T, TxDma, RxDma> {
     pub fn new(
         peri: impl Peripheral<P = T> + 'd,
@@ -628,6 +640,8 @@ impl<'d, T: BasicInstance, TxDma, RxDma> Uart<'d, T, TxDma, RxDma> {
         rx_dma: impl Peripheral<P = RxDma> + 'd,
         config: Config,
     ) -> Self {
+        // UartRx and UartTx have one refcount ea.
+        T::enable();
         T::enable();
         T::reset();
 
@@ -647,6 +661,8 @@ impl<'d, T: BasicInstance, TxDma, RxDma> Uart<'d, T, TxDma, RxDma> {
     ) -> Self {
         into_ref!(cts, rts);
 
+        // UartRx and UartTx have one refcount ea.
+        T::enable();
         T::enable();
         T::reset();
 
@@ -672,6 +688,8 @@ impl<'d, T: BasicInstance, TxDma, RxDma> Uart<'d, T, TxDma, RxDma> {
     ) -> Self {
         into_ref!(de);
 
+        // UartRx and UartTx have one refcount ea.
+        T::enable();
         T::enable();
         T::reset();
 


### PR DESCRIPTION
This appears to work as designed, but the peripherals may currently leak refcounts. That will need to be examined before this can  be merged.