### PR TITLE
ADC support for STM32WLx

### DIFF
--- a/embassy-stm32/Cargo.toml
+++ b/embassy-stm32/Cargo.toml
@@ -58,7 +58,7 @@ sdio-host = "0.5.0"
 embedded-sdmmc = { git = "https://github.com/embassy-rs/embedded-sdmmc-rs", rev = "a4f293d3a6f72158385f79c98634cb8a14d0d2fc", optional = true }
 critical-section = "1.1"
 atomic-polyfill = "1.0.1"
-stm32-metapac = { git = "https://github.com/embassy-rs/stm32-data-generated", tag = "stm32-data-7e2310f49fa123fbc3225b91be73522b212703f0" }
+stm32-metapac = { git = "https://github.com/embassy-rs/stm32-data-generated", tag = "stm32-data-eaa4987e523408dfb31c1b76765dd345d2761373" }
 vcell = "0.1.3"
 bxcan = "0.7.0"
 nb = "1.0.0"
@@ -77,7 +77,7 @@ critical-section = { version = "1.1", features = ["std"] }
 [build-dependencies]
 proc-macro2 = "1.0.36"
 quote = "1.0.15"
-stm32-metapac = { git = "https://github.com/embassy-rs/stm32-data-generated", tag = "stm32-data-7e2310f49fa123fbc3225b91be73522b212703f0", default-features = false, features = ["metadata"]}
+stm32-metapac = { git = "https://github.com/embassy-rs/stm32-data-generated", tag = "stm32-data-eaa4987e523408dfb31c1b76765dd345d2761373", default-features = false, features = ["metadata"]}
 
 [features]
 default = ["rt"]

--- a/embassy-stm32/src/adc/mod.rs
+++ b/embassy-stm32/src/adc/mod.rs
@@ -33,7 +33,7 @@ pub struct Adc<'d, T: Instance> {
 pub(crate) mod sealed {
     pub trait Instance {
         fn regs() -> crate::pac::adc::Adc;
-        #[cfg(not(any(adc_f1, adc_v1, adc_f3_v2)))]
+        #[cfg(not(any(adc_f1, adc_v1, adc_f3_v2, adc_g0)))]
         fn common_regs() -> crate::pac::adccommon::AdcCommon;
         #[cfg(adc_f3)]
         fn frequency() -> crate::time::Hertz;
@@ -63,7 +63,7 @@ foreach_peripheral!(
             fn regs() -> crate::pac::adc::Adc {
                 crate::pac::$inst
             }
-            #[cfg(not(any(adc_f1, adc_v1, adc_f3_v2)))]
+            #[cfg(not(any(adc_f1, adc_v1, adc_f3_v2, adc_g0)))]
             fn common_regs() -> crate::pac::adccommon::AdcCommon {
                 foreach_peripheral!{
                     (adccommon, $common_inst:ident) => {

--- a/embassy-stm32/src/adc/v3.rs
+++ b/embassy-stm32/src/adc/v3.rs
@@ -26,9 +26,9 @@ pub struct VrefInt;
 impl<T: Instance> AdcPin<T> for VrefInt {}
 impl<T: Instance> super::sealed::AdcPin<T> for VrefInt {
     fn channel(&self) -> u8 {
-        #[cfg(not(stm32g0))]
+        #[cfg(not(adc_g0))]
         let val = 0;
-        #[cfg(stm32g0)]
+        #[cfg(adc_g0)]
         let val = 13;
         val
     }
@@ -38,9 +38,9 @@ pub struct Temperature;
 impl<T: Instance> AdcPin<T> for Temperature {}
 impl<T: Instance> super::sealed::AdcPin<T> for Temperature {
     fn channel(&self) -> u8 {
-        #[cfg(not(stm32g0))]
+        #[cfg(not(adc_g0))]
         let val = 17;
-        #[cfg(stm32g0)]
+        #[cfg(adc_g0)]
         let val = 12;
         val
     }
@@ -50,9 +50,9 @@ pub struct Vbat;
 impl<T: Instance> AdcPin<T> for Vbat {}
 impl<T: Instance> super::sealed::AdcPin<T> for Vbat {
     fn channel(&self) -> u8 {
-        #[cfg(not(stm32g0))]
+        #[cfg(not(adc_g0))]
         let val = 18;
-        #[cfg(stm32g0)]
+        #[cfg(adc_g0)]
         let val = 14;
         val
     }
@@ -92,7 +92,12 @@ impl<'d, T: Instance> Adc<'d, T> {
     }
 
     pub fn enable_vrefint(&self, delay: &mut impl DelayUs<u32>) -> VrefInt {
+        #[cfg(not(adc_g0))]
         T::common_regs().ccr().modify(|reg| {
+            reg.set_vrefen(true);
+        });
+        #[cfg(adc_g0)]
+        T::regs().ccr().modify(|reg| {
             reg.set_vrefen(true);
         });
 
@@ -106,16 +111,26 @@ impl<'d, T: Instance> Adc<'d, T> {
     }
 
     pub fn enable_temperature(&self) -> Temperature {
+        #[cfg(not(adc_g0))]
         T::common_regs().ccr().modify(|reg| {
             reg.set_ch17sel(true);
+        });
+        #[cfg(adc_g0)]
+        T::regs().ccr().modify(|reg| {
+            reg.set_tsen(true);
         });
 
         Temperature {}
     }
 
     pub fn enable_vbat(&self) -> Vbat {
+        #[cfg(not(adc_g0))]
         T::common_regs().ccr().modify(|reg| {
             reg.set_ch18sel(true);
+        });
+        #[cfg(adc_g0)]
+        T::regs().ccr().modify(|reg| {
+            reg.set_vbaten(true);
         });
 
         Vbat {}
@@ -126,9 +141,9 @@ impl<'d, T: Instance> Adc<'d, T> {
     }
 
     pub fn set_resolution(&mut self, resolution: Resolution) {
-        #[cfg(not(stm32g0))]
+        #[cfg(not(adc_g0))]
         T::regs().cfgr().modify(|reg| reg.set_res(resolution.into()));
-        #[cfg(stm32g0)]
+        #[cfg(adc_g0)]
         T::regs().cfgr1().modify(|reg| reg.set_res(resolution.into()));
     }
 
@@ -182,9 +197,9 @@ impl<'d, T: Instance> Adc<'d, T> {
         Self::set_channel_sample_time(pin.channel(), self.sample_time);
 
         // Select channel
-        #[cfg(not(stm32g0))]
+        #[cfg(not(adc_g0))]
         T::regs().sqr1().write(|reg| reg.set_sq(0, pin.channel()));
-        #[cfg(stm32g0)]
+        #[cfg(adc_g0)]
         T::regs().chselr().write(|reg| reg.set_chsel(1 << pin.channel()));
 
         // Some models are affected by an erratum:
@@ -203,12 +218,12 @@ impl<'d, T: Instance> Adc<'d, T> {
         val
     }
 
-    #[cfg(stm32g0)]
+    #[cfg(adc_g0)]
     fn set_channel_sample_time(_ch: u8, sample_time: SampleTime) {
         T::regs().smpr().modify(|reg| reg.set_smp1(sample_time.into()));
     }
 
-    #[cfg(not(stm32g0))]
+    #[cfg(not(adc_g0))]
     fn set_channel_sample_time(ch: u8, sample_time: SampleTime) {
         let sample_time = sample_time.into();
         T::regs()

--- a/embassy-stm32/src/adc/v3.rs
+++ b/embassy-stm32/src/adc/v3.rs
@@ -13,7 +13,7 @@ pub const VREF_CALIB_MV: u32 = 3000;
 /// configuration.
 fn enable() {
     critical_section::with(|_| {
-        #[cfg(stm32h7)]
+        #[cfg(any(stm32h7, stm32wl))]
         crate::pac::RCC.apb2enr().modify(|w| w.set_adcen(true));
         #[cfg(stm32g0)]
         crate::pac::RCC.apbenr2().modify(|w| w.set_adcen(true));


### PR DESCRIPTION
Waiting for https://github.com/embassy-rs/stm32-data/pull/246.

Will also remove the use of adccommon_v3 CCR register for STM32G0x. Since the CCR register definition for this device seems to have some bits/names swapped (VBATEN/TSEN) compared to the common one.