### PR TITLE
Remove feature(impl_trait_projections) from async traits.

### DIFF
--- a/embassy-embedded-hal/src/flash/partition/asynch.rs
+++ b/embassy-embedded-hal/src/flash/partition/asynch.rs
@@ -49,7 +49,7 @@ impl<M: RawMutex, T: NorFlash> ErrorType for Partition<'_, M, T> {
 impl<M: RawMutex, T: NorFlash> ReadNorFlash for Partition<'_, M, T> {
     const READ_SIZE: usize = T::READ_SIZE;
 
-    async fn read(&mut self, offset: u32, bytes: &mut [u8]) -> Result<(), Self::Error> {
+    async fn read(&mut self, offset: u32, bytes: &mut [u8]) -> Result<(), Error<T::Error>> {
         if offset + bytes.len() as u32 > self.size {
             return Err(Error::OutOfBounds);
         }
@@ -67,7 +67,7 @@ impl<M: RawMutex, T: NorFlash> NorFlash for Partition<'_, M, T> {
     const WRITE_SIZE: usize = T::WRITE_SIZE;
     const ERASE_SIZE: usize = T::ERASE_SIZE;
 
-    async fn write(&mut self, offset: u32, bytes: &[u8]) -> Result<(), Self::Error> {
+    async fn write(&mut self, offset: u32, bytes: &[u8]) -> Result<(), Error<T::Error>> {
         if offset + bytes.len() as u32 > self.size {
             return Err(Error::OutOfBounds);
         }
@@ -76,7 +76,7 @@ impl<M: RawMutex, T: NorFlash> NorFlash for Partition<'_, M, T> {
         flash.write(self.offset + offset, bytes).await.map_err(Error::Flash)
     }
 
-    async fn erase(&mut self, from: u32, to: u32) -> Result<(), Self::Error> {
+    async fn erase(&mut self, from: u32, to: u32) -> Result<(), Error<T::Error>> {
         if to > self.size {
             return Err(Error::OutOfBounds);
         }

--- a/embassy-embedded-hal/src/lib.rs
+++ b/embassy-embedded-hal/src/lib.rs
@@ -1,5 +1,5 @@
 #![cfg_attr(not(feature = "std"), no_std)]
-#![cfg_attr(feature = "nightly", feature(async_fn_in_trait, impl_trait_projections, try_blocks))]
+#![cfg_attr(feature = "nightly", feature(async_fn_in_trait, try_blocks))]
 #![warn(missing_docs)]
 
 //! Utilities to use `embedded-hal` traits with Embassy.

--- a/embassy-embedded-hal/src/shared_bus/asynch/i2c.rs
+++ b/embassy-embedded-hal/src/shared_bus/asynch/i2c.rs
@@ -151,7 +151,11 @@ where
         Ok(())
     }
 
-    async fn transaction(&mut self, address: u8, operations: &mut [i2c::Operation<'_>]) -> Result<(), Self::Error> {
+    async fn transaction(
+        &mut self,
+        address: u8,
+        operations: &mut [i2c::Operation<'_>],
+    ) -> Result<(), I2cDeviceError<BUS::Error>> {
         let mut bus = self.bus.lock().await;
         bus.set_config(&self.config);
         bus.transaction(address, operations)

--- a/embassy-embedded-hal/src/shared_bus/asynch/spi.rs
+++ b/embassy-embedded-hal/src/shared_bus/asynch/spi.rs
@@ -62,7 +62,10 @@ where
     BUS: spi::SpiBus,
     CS: OutputPin,
 {
-    async fn transaction(&mut self, operations: &mut [spi::Operation<'_, u8>]) -> Result<(), Self::Error> {
+    async fn transaction(
+        &mut self,
+        operations: &mut [spi::Operation<'_, u8>],
+    ) -> Result<(), SpiDeviceError<BUS::Error, CS::Error>> {
         let mut bus = self.bus.lock().await;
         self.cs.set_low().map_err(SpiDeviceError::Cs)?;
 
@@ -128,7 +131,10 @@ where
     BUS: spi::SpiBus + SetConfig,
     CS: OutputPin,
 {
-    async fn transaction(&mut self, operations: &mut [spi::Operation<'_, u8>]) -> Result<(), Self::Error> {
+    async fn transaction(
+        &mut self,
+        operations: &mut [spi::Operation<'_, u8>],
+    ) -> Result<(), SpiDeviceError<BUS::Error, CS::Error>> {
         let mut bus = self.bus.lock().await;
         bus.set_config(&self.config);
         self.cs.set_low().map_err(SpiDeviceError::Cs)?;

--- a/embassy-lora/src/lib.rs
+++ b/embassy-lora/src/lib.rs
@@ -1,5 +1,5 @@
 #![no_std]
-#![feature(async_fn_in_trait, impl_trait_projections)]
+#![feature(async_fn_in_trait)]
 //! embassy-lora holds LoRa-specific functionality.
 
 pub(crate) mod fmt;

--- a/embassy-net/src/dns.rs
+++ b/embassy-net/src/dns.rs
@@ -79,7 +79,7 @@ where
         &self,
         host: &str,
         addr_type: embedded_nal_async::AddrType,
-    ) -> Result<embedded_nal_async::IpAddr, Self::Error> {
+    ) -> Result<embedded_nal_async::IpAddr, Error> {
         use embedded_nal_async::{AddrType, IpAddr};
         let qtype = match addr_type {
             AddrType::IPv6 => DnsQueryType::Aaaa,
@@ -98,10 +98,7 @@ where
         }
     }
 
-    async fn get_host_by_address(
-        &self,
-        _addr: embedded_nal_async::IpAddr,
-    ) -> Result<heapless::String<256>, Self::Error> {
+    async fn get_host_by_address(&self, _addr: embedded_nal_async::IpAddr) -> Result<heapless::String<256>, Error> {
         todo!()
     }
 }

--- a/embassy-net/src/lib.rs
+++ b/embassy-net/src/lib.rs
@@ -1,5 +1,5 @@
 #![cfg_attr(not(feature = "std"), no_std)]
-#![cfg_attr(feature = "nightly", feature(async_fn_in_trait, impl_trait_projections))]
+#![cfg_attr(feature = "nightly", feature(async_fn_in_trait))]
 #![warn(missing_docs)]
 #![doc = include_str!("../README.md")]
 

--- a/embassy-net/src/tcp.rs
+++ b/embassy-net/src/tcp.rs
@@ -536,17 +536,17 @@ mod embedded_io_impls {
     }
 
     impl<'d> embedded_io_async::Read for TcpSocket<'d> {
-        async fn read(&mut self, buf: &mut [u8]) -> Result<usize, Self::Error> {
+        async fn read(&mut self, buf: &mut [u8]) -> Result<usize, Error> {
             self.io.read(buf).await
         }
     }
 
     impl<'d> embedded_io_async::Write for TcpSocket<'d> {
-        async fn write(&mut self, buf: &[u8]) -> Result<usize, Self::Error> {
+        async fn write(&mut self, buf: &[u8]) -> Result<usize, Error> {
             self.io.write(buf).await
         }
 
-        async fn flush(&mut self) -> Result<(), Self::Error> {
+        async fn flush(&mut self) -> Result<(), Error> {
             self.io.flush().await
         }
     }
@@ -556,7 +556,7 @@ mod embedded_io_impls {
     }
 
     impl<'d> embedded_io_async::Read for TcpReader<'d> {
-        async fn read(&mut self, buf: &mut [u8]) -> Result<usize, Self::Error> {
+        async fn read(&mut self, buf: &mut [u8]) -> Result<usize, Error> {
             self.io.read(buf).await
         }
     }
@@ -566,11 +566,11 @@ mod embedded_io_impls {
     }
 
     impl<'d> embedded_io_async::Write for TcpWriter<'d> {
-        async fn write(&mut self, buf: &[u8]) -> Result<usize, Self::Error> {
+        async fn write(&mut self, buf: &[u8]) -> Result<usize, Error> {
             self.io.write(buf).await
         }
 
-        async fn flush(&mut self) -> Result<(), Self::Error> {
+        async fn flush(&mut self) -> Result<(), Error> {
             self.io.flush().await
         }
     }
@@ -612,7 +612,7 @@ pub mod client {
         async fn connect<'a>(
             &'a self,
             remote: embedded_nal_async::SocketAddr,
-        ) -> Result<Self::Connection<'a>, Self::Error>
+        ) -> Result<TcpConnection<'a, N, TX_SZ, RX_SZ>, Error>
         where
             Self: 'a,
         {
@@ -673,7 +673,7 @@ pub mod client {
     impl<'d, const N: usize, const TX_SZ: usize, const RX_SZ: usize> embedded_io_async::Read
         for TcpConnection<'d, N, TX_SZ, RX_SZ>
     {
-        async fn read(&mut self, buf: &mut [u8]) -> Result<usize, Self::Error> {
+        async fn read(&mut self, buf: &mut [u8]) -> Result<usize, Error> {
             self.socket.read(buf).await
         }
     }
@@ -681,11 +681,11 @@ pub mod client {
     impl<'d, const N: usize, const TX_SZ: usize, const RX_SZ: usize> embedded_io_async::Write
         for TcpConnection<'d, N, TX_SZ, RX_SZ>
     {
-        async fn write(&mut self, buf: &[u8]) -> Result<usize, Self::Error> {
+        async fn write(&mut self, buf: &[u8]) -> Result<usize, Error> {
             self.socket.write(buf).await
         }
 
-        async fn flush(&mut self) -> Result<(), Self::Error> {
+        async fn flush(&mut self) -> Result<(), Error> {
             self.socket.flush().await
         }
     }

--- a/embassy-nrf/src/buffered_uarte.rs
+++ b/embassy-nrf/src/buffered_uarte.rs
@@ -591,19 +591,19 @@ mod _embedded_io {
     }
 
     impl<'d, U: UarteInstance, T: TimerInstance> embedded_io_async::Read for BufferedUarte<'d, U, T> {
-        async fn read(&mut self, buf: &mut [u8]) -> Result<usize, Self::Error> {
+        async fn read(&mut self, buf: &mut [u8]) -> Result<usize, Error> {
             self.inner_read(buf).await
         }
     }
 
     impl<'u, 'd: 'u, U: UarteInstance, T: TimerInstance> embedded_io_async::Read for BufferedUarteRx<'u, 'd, U, T> {
-        async fn read(&mut self, buf: &mut [u8]) -> Result<usize, Self::Error> {
+        async fn read(&mut self, buf: &mut [u8]) -> Result<usize, Error> {
             self.inner.inner_read(buf).await
         }
     }
 
     impl<'d, U: UarteInstance, T: TimerInstance> embedded_io_async::BufRead for BufferedUarte<'d, U, T> {
-        async fn fill_buf(&mut self) -> Result<&[u8], Self::Error> {
+        async fn fill_buf(&mut self) -> Result<&[u8], Error> {
             self.inner_fill_buf().await
         }
 
@@ -613,7 +613,7 @@ mod _embedded_io {
     }
 
     impl<'u, 'd: 'u, U: UarteInstance, T: TimerInstance> embedded_io_async::BufRead for BufferedUarteRx<'u, 'd, U, T> {
-        async fn fill_buf(&mut self) -> Result<&[u8], Self::Error> {
+        async fn fill_buf(&mut self) -> Result<&[u8], Error> {
             self.inner.inner_fill_buf().await
         }
 
@@ -623,21 +623,21 @@ mod _embedded_io {
     }
 
     impl<'d, U: UarteInstance, T: TimerInstance> embedded_io_async::Write for BufferedUarte<'d, U, T> {
-        async fn write(&mut self, buf: &[u8]) -> Result<usize, Self::Error> {
+        async fn write(&mut self, buf: &[u8]) -> Result<usize, Error> {
             self.inner_write(buf).await
         }
 
-        async fn flush(&mut self) -> Result<(), Self::Error> {
+        async fn flush(&mut self) -> Result<(), Error> {
             self.inner_flush().await
         }
     }
 
     impl<'u, 'd: 'u, U: UarteInstance, T: TimerInstance> embedded_io_async::Write for BufferedUarteTx<'u, 'd, U, T> {
-        async fn write(&mut self, buf: &[u8]) -> Result<usize, Self::Error> {
+        async fn write(&mut self, buf: &[u8]) -> Result<usize, Error> {
             self.inner.inner_write(buf).await
         }
 
-        async fn flush(&mut self) -> Result<(), Self::Error> {
+        async fn flush(&mut self) -> Result<(), Error> {
             self.inner.inner_flush().await
         }
     }

--- a/embassy-nrf/src/gpiote.rs
+++ b/embassy-nrf/src/gpiote.rs
@@ -515,45 +515,45 @@ mod eha {
     use super::*;
 
     impl<'d, T: GpioPin> embedded_hal_async::digital::Wait for Input<'d, T> {
-        async fn wait_for_high(&mut self) -> Result<(), Self::Error> {
+        async fn wait_for_high(&mut self) -> Result<(), Infallible> {
             Ok(self.wait_for_high().await)
         }
 
-        async fn wait_for_low(&mut self) -> Result<(), Self::Error> {
+        async fn wait_for_low(&mut self) -> Result<(), Infallible> {
             Ok(self.wait_for_low().await)
         }
 
-        async fn wait_for_rising_edge(&mut self) -> Result<(), Self::Error> {
+        async fn wait_for_rising_edge(&mut self) -> Result<(), Infallible> {
             Ok(self.wait_for_rising_edge().await)
         }
 
-        async fn wait_for_falling_edge(&mut self) -> Result<(), Self::Error> {
+        async fn wait_for_falling_edge(&mut self) -> Result<(), Infallible> {
             Ok(self.wait_for_falling_edge().await)
         }
 
-        async fn wait_for_any_edge(&mut self) -> Result<(), Self::Error> {
+        async fn wait_for_any_edge(&mut self) -> Result<(), Infallible> {
             Ok(self.wait_for_any_edge().await)
         }
     }
 
     impl<'d, T: GpioPin> embedded_hal_async::digital::Wait for Flex<'d, T> {
-        async fn wait_for_high(&mut self) -> Result<(), Self::Error> {
+        async fn wait_for_high(&mut self) -> Result<(), Infallible> {
             Ok(self.wait_for_high().await)
         }
 
-        async fn wait_for_low(&mut self) -> Result<(), Self::Error> {
+        async fn wait_for_low(&mut self) -> Result<(), Infallible> {
             Ok(self.wait_for_low().await)
         }
 
-        async fn wait_for_rising_edge(&mut self) -> Result<(), Self::Error> {
+        async fn wait_for_rising_edge(&mut self) -> Result<(), Infallible> {
             Ok(self.wait_for_rising_edge().await)
         }
 
-        async fn wait_for_falling_edge(&mut self) -> Result<(), Self::Error> {
+        async fn wait_for_falling_edge(&mut self) -> Result<(), Infallible> {
             Ok(self.wait_for_falling_edge().await)
         }
 
-        async fn wait_for_any_edge(&mut self) -> Result<(), Self::Error> {
+        async fn wait_for_any_edge(&mut self) -> Result<(), Infallible> {
             Ok(self.wait_for_any_edge().await)
         }
     }

--- a/embassy-nrf/src/lib.rs
+++ b/embassy-nrf/src/lib.rs
@@ -1,5 +1,5 @@
 #![no_std]
-#![cfg_attr(feature = "nightly", feature(async_fn_in_trait, impl_trait_projections))]
+#![cfg_attr(feature = "nightly", feature(async_fn_in_trait))]
 #![doc = include_str!("../README.md")]
 #![warn(missing_docs)]
 

--- a/embassy-nrf/src/qspi.rs
+++ b/embassy-nrf/src/qspi.rs
@@ -595,11 +595,11 @@ mod _eh1 {
         const WRITE_SIZE: usize = <Self as NorFlash>::WRITE_SIZE;
         const ERASE_SIZE: usize = <Self as NorFlash>::ERASE_SIZE;
 
-        async fn write(&mut self, offset: u32, data: &[u8]) -> Result<(), Self::Error> {
+        async fn write(&mut self, offset: u32, data: &[u8]) -> Result<(), Error> {
             self.write(offset, data).await
         }
 
-        async fn erase(&mut self, from: u32, to: u32) -> Result<(), Self::Error> {
+        async fn erase(&mut self, from: u32, to: u32) -> Result<(), Error> {
             for address in (from..to).step_by(<Self as AsyncNorFlash>::ERASE_SIZE) {
                 self.erase(address).await?
             }
@@ -609,7 +609,7 @@ mod _eh1 {
 
     impl<'d, T: Instance> AsyncReadNorFlash for Qspi<'d, T> {
         const READ_SIZE: usize = 4;
-        async fn read(&mut self, address: u32, data: &mut [u8]) -> Result<(), Self::Error> {
+        async fn read(&mut self, address: u32, data: &mut [u8]) -> Result<(), Error> {
             self.read(address, data).await
         }
 

--- a/embassy-nrf/src/twim.rs
+++ b/embassy-nrf/src/twim.rs
@@ -864,14 +864,14 @@ mod eh1 {
 mod eha {
     use super::*;
     impl<'d, T: Instance> embedded_hal_async::i2c::I2c for Twim<'d, T> {
-        async fn read(&mut self, address: u8, read: &mut [u8]) -> Result<(), Self::Error> {
+        async fn read(&mut self, address: u8, read: &mut [u8]) -> Result<(), Error> {
             self.read(address, read).await
         }
 
-        async fn write(&mut self, address: u8, write: &[u8]) -> Result<(), Self::Error> {
+        async fn write(&mut self, address: u8, write: &[u8]) -> Result<(), Error> {
             self.write(address, write).await
         }
-        async fn write_read(&mut self, address: u8, write: &[u8], read: &mut [u8]) -> Result<(), Self::Error> {
+        async fn write_read(&mut self, address: u8, write: &[u8], read: &mut [u8]) -> Result<(), Error> {
             self.write_read(address, write, read).await
         }
 
@@ -879,7 +879,7 @@ mod eha {
             &mut self,
             address: u8,
             operations: &mut [embedded_hal_1::i2c::Operation<'_>],
-        ) -> Result<(), Self::Error> {
+        ) -> Result<(), Error> {
             let _ = address;
             let _ = operations;
             todo!()

--- a/embassy-rp/src/flash.rs
+++ b/embassy-rp/src/flash.rs
@@ -390,7 +390,7 @@ impl<'d, T: Instance, const FLASH_SIZE: usize> embedded_storage_async::nor_flash
 {
     const READ_SIZE: usize = ASYNC_READ_SIZE;
 
-    async fn read(&mut self, offset: u32, bytes: &mut [u8]) -> Result<(), Self::Error> {
+    async fn read(&mut self, offset: u32, bytes: &mut [u8]) -> Result<(), Error> {
         self.read(offset, bytes).await
     }
 
@@ -407,11 +407,11 @@ impl<'d, T: Instance, const FLASH_SIZE: usize> embedded_storage_async::nor_flash
 
     const ERASE_SIZE: usize = ERASE_SIZE;
 
-    async fn erase(&mut self, from: u32, to: u32) -> Result<(), Self::Error> {
+    async fn erase(&mut self, from: u32, to: u32) -> Result<(), Error> {
         self.blocking_erase(from, to)
     }
 
-    async fn write(&mut self, offset: u32, bytes: &[u8]) -> Result<(), Self::Error> {
+    async fn write(&mut self, offset: u32, bytes: &[u8]) -> Result<(), Error> {
         self.blocking_write(offset, bytes)
     }
 }

--- a/embassy-rp/src/gpio.rs
+++ b/embassy-rp/src/gpio.rs
@@ -1138,27 +1138,27 @@ mod eh1 {
 
     #[cfg(feature = "nightly")]
     impl<'d, T: Pin> embedded_hal_async::digital::Wait for Flex<'d, T> {
-        async fn wait_for_high(&mut self) -> Result<(), Self::Error> {
+        async fn wait_for_high(&mut self) -> Result<(), Infallible> {
             self.wait_for_high().await;
             Ok(())
         }
 
-        async fn wait_for_low(&mut self) -> Result<(), Self::Error> {
+        async fn wait_for_low(&mut self) -> Result<(), Infallible> {
             self.wait_for_low().await;
             Ok(())
         }
 
-        async fn wait_for_rising_edge(&mut self) -> Result<(), Self::Error> {
+        async fn wait_for_rising_edge(&mut self) -> Result<(), Infallible> {
             self.wait_for_rising_edge().await;
             Ok(())
         }
 
-        async fn wait_for_falling_edge(&mut self) -> Result<(), Self::Error> {
+        async fn wait_for_falling_edge(&mut self) -> Result<(), Infallible> {
             self.wait_for_falling_edge().await;
             Ok(())
         }
 
-        async fn wait_for_any_edge(&mut self) -> Result<(), Self::Error> {
+        async fn wait_for_any_edge(&mut self) -> Result<(), Infallible> {
             self.wait_for_any_edge().await;
             Ok(())
         }
@@ -1166,27 +1166,27 @@ mod eh1 {
 
     #[cfg(feature = "nightly")]
     impl<'d, T: Pin> embedded_hal_async::digital::Wait for Input<'d, T> {
-        async fn wait_for_high(&mut self) -> Result<(), Self::Error> {
+        async fn wait_for_high(&mut self) -> Result<(), Infallible> {
             self.wait_for_high().await;
             Ok(())
         }
 
-        async fn wait_for_low(&mut self) -> Result<(), Self::Error> {
+        async fn wait_for_low(&mut self) -> Result<(), Infallible> {
             self.wait_for_low().await;
             Ok(())
         }
 
-        async fn wait_for_rising_edge(&mut self) -> Result<(), Self::Error> {
+        async fn wait_for_rising_edge(&mut self) -> Result<(), Infallible> {
             self.wait_for_rising_edge().await;
             Ok(())
         }
 
-        async fn wait_for_falling_edge(&mut self) -> Result<(), Self::Error> {
+        async fn wait_for_falling_edge(&mut self) -> Result<(), Infallible> {
             self.wait_for_falling_edge().await;
             Ok(())
         }
 
-        async fn wait_for_any_edge(&mut self) -> Result<(), Self::Error> {
+        async fn wait_for_any_edge(&mut self) -> Result<(), Infallible> {
             self.wait_for_any_edge().await;
             Ok(())
         }
@@ -1194,27 +1194,27 @@ mod eh1 {
 
     #[cfg(feature = "nightly")]
     impl<'d, T: Pin> embedded_hal_async::digital::Wait for OutputOpenDrain<'d, T> {
-        async fn wait_for_high(&mut self) -> Result<(), Self::Error> {
+        async fn wait_for_high(&mut self) -> Result<(), Infallible> {
             self.wait_for_high().await;
             Ok(())
         }
 
-        async fn wait_for_low(&mut self) -> Result<(), Self::Error> {
+        async fn wait_for_low(&mut self) -> Result<(), Infallible> {
             self.wait_for_low().await;
             Ok(())
         }
 
-        async fn wait_for_rising_edge(&mut self) -> Result<(), Self::Error> {
+        async fn wait_for_rising_edge(&mut self) -> Result<(), Infallible> {
             self.wait_for_rising_edge().await;
             Ok(())
         }
 
-        async fn wait_for_falling_edge(&mut self) -> Result<(), Self::Error> {
+        async fn wait_for_falling_edge(&mut self) -> Result<(), Infallible> {
             self.wait_for_falling_edge().await;
             Ok(())
         }
 
-        async fn wait_for_any_edge(&mut self) -> Result<(), Self::Error> {
+        async fn wait_for_any_edge(&mut self) -> Result<(), Infallible> {
             self.wait_for_any_edge().await;
             Ok(())
         }

--- a/embassy-rp/src/i2c.rs
+++ b/embassy-rp/src/i2c.rs
@@ -691,21 +691,21 @@ mod nightly {
         A: AddressMode + Into<u16> + 'static,
         T: Instance + 'd,
     {
-        async fn read(&mut self, address: A, read: &mut [u8]) -> Result<(), Self::Error> {
+        async fn read(&mut self, address: A, read: &mut [u8]) -> Result<(), Error> {
             let addr: u16 = address.into();
 
             Self::setup(addr)?;
             self.read_async_internal(read, false, true).await
         }
 
-        async fn write(&mut self, address: A, write: &[u8]) -> Result<(), Self::Error> {
+        async fn write(&mut self, address: A, write: &[u8]) -> Result<(), Error> {
             let addr: u16 = address.into();
 
             Self::setup(addr)?;
             self.write_async_internal(write.iter().copied(), true).await
         }
 
-        async fn write_read(&mut self, address: A, write: &[u8], read: &mut [u8]) -> Result<(), Self::Error> {
+        async fn write_read(&mut self, address: A, write: &[u8], read: &mut [u8]) -> Result<(), Error> {
             let addr: u16 = address.into();
 
             Self::setup(addr)?;
@@ -713,7 +713,7 @@ mod nightly {
             self.read_async_internal(read, false, true).await
         }
 
-        async fn transaction(&mut self, address: A, operations: &mut [Operation<'_>]) -> Result<(), Self::Error> {
+        async fn transaction(&mut self, address: A, operations: &mut [Operation<'_>]) -> Result<(), Error> {
             let addr: u16 = address.into();
 
             if operations.len() > 0 {

--- a/embassy-rp/src/lib.rs
+++ b/embassy-rp/src/lib.rs
@@ -1,5 +1,5 @@
 #![no_std]
-#![cfg_attr(feature = "nightly", feature(async_fn_in_trait, impl_trait_projections))]
+#![cfg_attr(feature = "nightly", feature(async_fn_in_trait))]
 
 // This mod MUST go first, so that the others see its macros.
 pub(crate) mod fmt;

--- a/embassy-rp/src/spi.rs
+++ b/embassy-rp/src/spi.rs
@@ -573,23 +573,23 @@ mod eha {
     use super::*;
 
     impl<'d, T: Instance> embedded_hal_async::spi::SpiBus<u8> for Spi<'d, T, Async> {
-        async fn flush(&mut self) -> Result<(), Self::Error> {
+        async fn flush(&mut self) -> Result<(), Error> {
             Ok(())
         }
 
-        async fn write(&mut self, words: &[u8]) -> Result<(), Self::Error> {
+        async fn write(&mut self, words: &[u8]) -> Result<(), Error> {
             self.write(words).await
         }
 
-        async fn read(&mut self, words: &mut [u8]) -> Result<(), Self::Error> {
+        async fn read(&mut self, words: &mut [u8]) -> Result<(), Error> {
             self.read(words).await
         }
 
-        async fn transfer(&mut self, read: &mut [u8], write: &[u8]) -> Result<(), Self::Error> {
+        async fn transfer(&mut self, read: &mut [u8], write: &[u8]) -> Result<(), Error> {
             self.transfer(read, write).await
         }
 
-        async fn transfer_in_place(&mut self, words: &mut [u8]) -> Result<(), Self::Error> {
+        async fn transfer_in_place(&mut self, words: &mut [u8]) -> Result<(), Error> {
             self.transfer_in_place(words).await
         }
     }

--- a/embassy-rp/src/uart/buffered.rs
+++ b/embassy-rp/src/uart/buffered.rs
@@ -587,19 +587,19 @@ impl<'d, T: Instance> embedded_io_async::ErrorType for BufferedUartTx<'d, T> {
 }
 
 impl<'d, T: Instance + 'd> embedded_io_async::Read for BufferedUart<'d, T> {
-    async fn read(&mut self, buf: &mut [u8]) -> Result<usize, Self::Error> {
+    async fn read(&mut self, buf: &mut [u8]) -> Result<usize, Error> {
         BufferedUartRx::<'d, T>::read(buf).await
     }
 }
 
 impl<'d, T: Instance + 'd> embedded_io_async::Read for BufferedUartRx<'d, T> {
-    async fn read(&mut self, buf: &mut [u8]) -> Result<usize, Self::Error> {
+    async fn read(&mut self, buf: &mut [u8]) -> Result<usize, Error> {
         Self::read(buf).await
     }
 }
 
 impl<'d, T: Instance + 'd> embedded_io_async::BufRead for BufferedUart<'d, T> {
-    async fn fill_buf(&mut self) -> Result<&[u8], Self::Error> {
+    async fn fill_buf(&mut self) -> Result<&[u8], Error> {
         BufferedUartRx::<'d, T>::fill_buf().await
     }
 
@@ -609,7 +609,7 @@ impl<'d, T: Instance + 'd> embedded_io_async::BufRead for BufferedUart<'d, T> {
 }
 
 impl<'d, T: Instance + 'd> embedded_io_async::BufRead for BufferedUartRx<'d, T> {
-    async fn fill_buf(&mut self) -> Result<&[u8], Self::Error> {
+    async fn fill_buf(&mut self) -> Result<&[u8], Error> {
         Self::fill_buf().await
     }
 
@@ -619,21 +619,21 @@ impl<'d, T: Instance + 'd> embedded_io_async::BufRead for BufferedUartRx<'d, T> 
 }
 
 impl<'d, T: Instance + 'd> embedded_io_async::Write for BufferedUart<'d, T> {
-    async fn write(&mut self, buf: &[u8]) -> Result<usize, Self::Error> {
+    async fn write(&mut self, buf: &[u8]) -> Result<usize, Error> {
         BufferedUartTx::<'d, T>::write(buf).await
     }
 
-    async fn flush(&mut self) -> Result<(), Self::Error> {
+    async fn flush(&mut self) -> Result<(), Error> {
         BufferedUartTx::<'d, T>::flush().await
     }
 }
 
 impl<'d, T: Instance + 'd> embedded_io_async::Write for BufferedUartTx<'d, T> {
-    async fn write(&mut self, buf: &[u8]) -> Result<usize, Self::Error> {
+    async fn write(&mut self, buf: &[u8]) -> Result<usize, Error> {
         Self::write(buf).await
     }
 
-    async fn flush(&mut self) -> Result<(), Self::Error> {
+    async fn flush(&mut self) -> Result<(), Error> {
         Self::flush().await
     }
 }

--- a/embassy-stm32/src/exti.rs
+++ b/embassy-stm32/src/exti.rs
@@ -167,31 +167,32 @@ mod eh1 {
 }
 #[cfg(all(feature = "unstable-traits", feature = "nightly"))]
 mod eha {
+    use core::convert::Infallible;
 
     use super::*;
 
     impl<'d, T: GpioPin> embedded_hal_async::digital::Wait for ExtiInput<'d, T> {
-        async fn wait_for_high(&mut self) -> Result<(), Self::Error> {
+        async fn wait_for_high(&mut self) -> Result<(), Infallible> {
             self.wait_for_high().await;
             Ok(())
         }
 
-        async fn wait_for_low(&mut self) -> Result<(), Self::Error> {
+        async fn wait_for_low(&mut self) -> Result<(), Infallible> {
             self.wait_for_low().await;
             Ok(())
         }
 
-        async fn wait_for_rising_edge(&mut self) -> Result<(), Self::Error> {
+        async fn wait_for_rising_edge(&mut self) -> Result<(), Infallible> {
             self.wait_for_rising_edge().await;
             Ok(())
         }
 
-        async fn wait_for_falling_edge(&mut self) -> Result<(), Self::Error> {
+        async fn wait_for_falling_edge(&mut self) -> Result<(), Infallible> {
             self.wait_for_falling_edge().await;
             Ok(())
         }
 
-        async fn wait_for_any_edge(&mut self) -> Result<(), Self::Error> {
+        async fn wait_for_any_edge(&mut self) -> Result<(), Infallible> {
             self.wait_for_any_edge().await;
             Ok(())
         }

--- a/embassy-stm32/src/flash/asynch.rs
+++ b/embassy-stm32/src/flash/asynch.rs
@@ -59,7 +59,7 @@ impl interrupt::typelevel::Handler<crate::interrupt::typelevel::FLASH> for Inter
 impl embedded_storage_async::nor_flash::ReadNorFlash for Flash<'_, Async> {
     const READ_SIZE: usize = super::READ_SIZE;
 
-    async fn read(&mut self, offset: u32, bytes: &mut [u8]) -> Result<(), Self::Error> {
+    async fn read(&mut self, offset: u32, bytes: &mut [u8]) -> Result<(), Error> {
         self.read(offset, bytes)
     }
 
@@ -73,11 +73,11 @@ impl embedded_storage_async::nor_flash::NorFlash for Flash<'_, Async> {
     const WRITE_SIZE: usize = WRITE_SIZE;
     const ERASE_SIZE: usize = super::MAX_ERASE_SIZE;
 
-    async fn write(&mut self, offset: u32, bytes: &[u8]) -> Result<(), Self::Error> {
+    async fn write(&mut self, offset: u32, bytes: &[u8]) -> Result<(), Error> {
         self.write(offset, bytes).await
     }
 
-    async fn erase(&mut self, from: u32, to: u32) -> Result<(), Self::Error> {
+    async fn erase(&mut self, from: u32, to: u32) -> Result<(), Error> {
         self.erase(from, to).await
     }
 }
@@ -162,7 +162,7 @@ foreach_flash_region! {
         impl embedded_storage_async::nor_flash::ReadNorFlash for crate::_generated::flash_regions::$type_name<'_, Async> {
             const READ_SIZE: usize = super::READ_SIZE;
 
-            async fn read(&mut self, offset: u32, bytes: &mut [u8]) -> Result<(), Self::Error> {
+            async fn read(&mut self, offset: u32, bytes: &mut [u8]) -> Result<(), Error> {
                 self.read(offset, bytes).await
             }
 
@@ -176,11 +176,11 @@ foreach_flash_region! {
             const WRITE_SIZE: usize = $write_size;
             const ERASE_SIZE: usize = $erase_size;
 
-            async fn write(&mut self, offset: u32, bytes: &[u8]) -> Result<(), Self::Error> {
+            async fn write(&mut self, offset: u32, bytes: &[u8]) -> Result<(), Error> {
                 self.write(offset, bytes).await
             }
 
-            async fn erase(&mut self, from: u32, to: u32) -> Result<(), Self::Error> {
+            async fn erase(&mut self, from: u32, to: u32) -> Result<(), Error> {
                 self.erase(from, to).await
             }
         }

--- a/embassy-stm32/src/flash/f4.rs
+++ b/embassy-stm32/src/flash/f4.rs
@@ -146,7 +146,7 @@ mod alt_regions {
             impl embedded_storage_async::nor_flash::ReadNorFlash for $type_name<'_, Async> {
                 const READ_SIZE: usize = crate::flash::READ_SIZE;
 
-                async fn read(&mut self, offset: u32, bytes: &mut [u8]) -> Result<(), Self::Error> {
+                async fn read(&mut self, offset: u32, bytes: &mut [u8]) -> Result<(), Error> {
                     self.read(offset, bytes).await
                 }
 
@@ -160,11 +160,11 @@ mod alt_regions {
                 const WRITE_SIZE: usize = $region.write_size as usize;
                 const ERASE_SIZE: usize = $region.erase_size as usize;
 
-                async fn write(&mut self, offset: u32, bytes: &[u8]) -> Result<(), Self::Error> {
+                async fn write(&mut self, offset: u32, bytes: &[u8]) -> Result<(), Error> {
                     self.write(offset, bytes).await
                 }
 
-                async fn erase(&mut self, from: u32, to: u32) -> Result<(), Self::Error> {
+                async fn erase(&mut self, from: u32, to: u32) -> Result<(), Error> {
                     self.erase(from, to).await
                 }
             }

--- a/embassy-stm32/src/i2c/v2.rs
+++ b/embassy-stm32/src/i2c/v2.rs
@@ -1049,15 +1049,15 @@ mod eha {
     use super::*;
 
     impl<'d, T: Instance, TXDMA: TxDma<T>, RXDMA: RxDma<T>> embedded_hal_async::i2c::I2c for I2c<'d, T, TXDMA, RXDMA> {
-        async fn read(&mut self, address: u8, read: &mut [u8]) -> Result<(), Self::Error> {
+        async fn read(&mut self, address: u8, read: &mut [u8]) -> Result<(), Error> {
             self.read(address, read).await
         }
 
-        async fn write(&mut self, address: u8, write: &[u8]) -> Result<(), Self::Error> {
+        async fn write(&mut self, address: u8, write: &[u8]) -> Result<(), Error> {
             self.write(address, write).await
         }
 
-        async fn write_read(&mut self, address: u8, write: &[u8], read: &mut [u8]) -> Result<(), Self::Error> {
+        async fn write_read(&mut self, address: u8, write: &[u8], read: &mut [u8]) -> Result<(), Error> {
             self.write_read(address, write, read).await
         }
 
@@ -1065,7 +1065,7 @@ mod eha {
             &mut self,
             address: u8,
             operations: &mut [embedded_hal_1::i2c::Operation<'_>],
-        ) -> Result<(), Self::Error> {
+        ) -> Result<(), Error> {
             let _ = address;
             let _ = operations;
             todo!()

--- a/embassy-stm32/src/sdmmc/mod.rs
+++ b/embassy-stm32/src/sdmmc/mod.rs
@@ -1491,12 +1491,7 @@ mod sdmmc_rs {
     impl<'d, T: Instance, Dma: SdmmcDma<T>> BlockDevice for Sdmmc<'d, T, Dma> {
         type Error = Error;
 
-        async fn read(
-            &mut self,
-            blocks: &mut [Block],
-            start_block_idx: BlockIdx,
-            _reason: &str,
-        ) -> Result<(), Self::Error> {
+        async fn read(&mut self, blocks: &mut [Block], start_block_idx: BlockIdx, _reason: &str) -> Result<(), Error> {
             let mut address = start_block_idx.0;
 
             for block in blocks.iter_mut() {
@@ -1510,7 +1505,7 @@ mod sdmmc_rs {
             Ok(())
         }
 
-        async fn write(&mut self, blocks: &[Block], start_block_idx: BlockIdx) -> Result<(), Self::Error> {
+        async fn write(&mut self, blocks: &[Block], start_block_idx: BlockIdx) -> Result<(), Error> {
             let mut address = start_block_idx.0;
 
             for block in blocks.iter() {

--- a/embassy-stm32/src/spi/mod.rs
+++ b/embassy-stm32/src/spi/mod.rs
@@ -925,23 +925,23 @@ mod eha {
     use super::*;
 
     impl<'d, T: Instance, Tx: TxDma<T>, Rx: RxDma<T>, W: Word> embedded_hal_async::spi::SpiBus<W> for Spi<'d, T, Tx, Rx> {
-        async fn flush(&mut self) -> Result<(), Self::Error> {
+        async fn flush(&mut self) -> Result<(), Error> {
             Ok(())
         }
 
-        async fn write(&mut self, words: &[W]) -> Result<(), Self::Error> {
+        async fn write(&mut self, words: &[W]) -> Result<(), Error> {
             self.write(words).await
         }
 
-        async fn read(&mut self, words: &mut [W]) -> Result<(), Self::Error> {
+        async fn read(&mut self, words: &mut [W]) -> Result<(), Error> {
             self.read(words).await
         }
 
-        async fn transfer(&mut self, read: &mut [W], write: &[W]) -> Result<(), Self::Error> {
+        async fn transfer(&mut self, read: &mut [W], write: &[W]) -> Result<(), Error> {
             self.transfer(read, write).await
         }
 
-        async fn transfer_in_place(&mut self, words: &mut [W]) -> Result<(), Self::Error> {
+        async fn transfer_in_place(&mut self, words: &mut [W]) -> Result<(), Error> {
             self.transfer_in_place(words).await
         }
     }

--- a/embassy-stm32/src/usart/buffered.rs
+++ b/embassy-stm32/src/usart/buffered.rs
@@ -429,19 +429,19 @@ impl<'d, T: BasicInstance> embedded_io_async::ErrorType for BufferedUartTx<'d, T
 }
 
 impl<'d, T: BasicInstance> embedded_io_async::Read for BufferedUart<'d, T> {
-    async fn read(&mut self, buf: &mut [u8]) -> Result<usize, Self::Error> {
+    async fn read(&mut self, buf: &mut [u8]) -> Result<usize, Error> {
         self.rx.read(buf).await
     }
 }
 
 impl<'d, T: BasicInstance> embedded_io_async::Read for BufferedUartRx<'d, T> {
-    async fn read(&mut self, buf: &mut [u8]) -> Result<usize, Self::Error> {
+    async fn read(&mut self, buf: &mut [u8]) -> Result<usize, Error> {
         Self::read(self, buf).await
     }
 }
 
 impl<'d, T: BasicInstance> embedded_io_async::BufRead for BufferedUart<'d, T> {
-    async fn fill_buf(&mut self) -> Result<&[u8], Self::Error> {
+    async fn fill_buf(&mut self) -> Result<&[u8], Error> {
         self.rx.fill_buf().await
     }
 
@@ -451,7 +451,7 @@ impl<'d, T: BasicInstance> embedded_io_async::BufRead for BufferedUart<'d, T> {
 }
 
 impl<'d, T: BasicInstance> embedded_io_async::BufRead for BufferedUartRx<'d, T> {
-    async fn fill_buf(&mut self) -> Result<&[u8], Self::Error> {
+    async fn fill_buf(&mut self) -> Result<&[u8], Error> {
         Self::fill_buf(self).await
     }
 
@@ -461,21 +461,21 @@ impl<'d, T: BasicInstance> embedded_io_async::BufRead for BufferedUartRx<'d, T> 
 }
 
 impl<'d, T: BasicInstance> embedded_io_async::Write for BufferedUart<'d, T> {
-    async fn write(&mut self, buf: &[u8]) -> Result<usize, Self::Error> {
+    async fn write(&mut self, buf: &[u8]) -> Result<usize, Error> {
         self.tx.write(buf).await
     }
 
-    async fn flush(&mut self) -> Result<(), Self::Error> {
+    async fn flush(&mut self) -> Result<(), Error> {
         self.tx.flush().await
     }
 }
 
 impl<'d, T: BasicInstance> embedded_io_async::Write for BufferedUartTx<'d, T> {
-    async fn write(&mut self, buf: &[u8]) -> Result<usize, Self::Error> {
+    async fn write(&mut self, buf: &[u8]) -> Result<usize, Error> {
         Self::write(self, buf).await
     }
 
-    async fn flush(&mut self) -> Result<(), Self::Error> {
+    async fn flush(&mut self) -> Result<(), Error> {
         Self::flush(self).await
     }
 }

--- a/embassy-stm32/src/usart/mod.rs
+++ b/embassy-stm32/src/usart/mod.rs
@@ -1048,12 +1048,12 @@ mod eio {
         T: BasicInstance,
         TxDma: super::TxDma<T>,
     {
-        async fn write(&mut self, buf: &[u8]) -> Result<usize, Self::Error> {
+        async fn write(&mut self, buf: &[u8]) -> Result<usize, Error> {
             self.write(buf).await?;
             Ok(buf.len())
         }
 
-        async fn flush(&mut self) -> Result<(), Self::Error> {
+        async fn flush(&mut self) -> Result<(), Error> {
             self.blocking_flush()
         }
     }
@@ -1070,12 +1070,12 @@ mod eio {
         T: BasicInstance,
         TxDma: super::TxDma<T>,
     {
-        async fn write(&mut self, buf: &[u8]) -> Result<usize, Self::Error> {
+        async fn write(&mut self, buf: &[u8]) -> Result<usize, Error> {
             self.write(buf).await?;
             Ok(buf.len())
         }
 
-        async fn flush(&mut self) -> Result<(), Self::Error> {
+        async fn flush(&mut self) -> Result<(), Error> {
             self.blocking_flush()
         }
     }

--- a/embassy-stm32/src/usart/ringbuffered.rs
+++ b/embassy-stm32/src/usart/ringbuffered.rs
@@ -245,7 +245,7 @@ mod eio {
         T: BasicInstance,
         Rx: RxDma<T>,
     {
-        async fn read(&mut self, buf: &mut [u8]) -> Result<usize, Self::Error> {
+        async fn read(&mut self, buf: &mut [u8]) -> Result<usize, Error> {
             self.read(buf).await
         }
     }

--- a/embassy-sync/src/lib.rs
+++ b/embassy-sync/src/lib.rs
@@ -1,5 +1,5 @@
 #![cfg_attr(not(any(feature = "std", feature = "wasm")), no_std)]
-#![cfg_attr(feature = "nightly", feature(async_fn_in_trait, impl_trait_projections))]
+#![cfg_attr(feature = "nightly", feature(async_fn_in_trait))]
 #![allow(clippy::new_without_default)]
 #![doc = include_str!("../README.md")]
 #![warn(missing_docs)]

--- a/embassy-sync/src/pipe.rs
+++ b/embassy-sync/src/pipe.rs
@@ -488,17 +488,17 @@ mod io_impls {
     }
 
     impl<M: RawMutex, const N: usize> embedded_io_async::Read for &Pipe<M, N> {
-        async fn read(&mut self, buf: &mut [u8]) -> Result<usize, Self::Error> {
+        async fn read(&mut self, buf: &mut [u8]) -> Result<usize, Infallible> {
             Ok(Pipe::read(self, buf).await)
         }
     }
 
     impl<M: RawMutex, const N: usize> embedded_io_async::Write for &Pipe<M, N> {
-        async fn write(&mut self, buf: &[u8]) -> Result<usize, Self::Error> {
+        async fn write(&mut self, buf: &[u8]) -> Result<usize, Infallible> {
             Ok(Pipe::write(self, buf).await)
         }
 
-        async fn flush(&mut self) -> Result<(), Self::Error> {
+        async fn flush(&mut self) -> Result<(), Infallible> {
             Ok(())
         }
     }
@@ -508,13 +508,13 @@ mod io_impls {
     }
 
     impl<M: RawMutex, const N: usize> embedded_io_async::Read for Reader<'_, M, N> {
-        async fn read(&mut self, buf: &mut [u8]) -> Result<usize, Self::Error> {
+        async fn read(&mut self, buf: &mut [u8]) -> Result<usize, Infallible> {
             Ok(Reader::read(self, buf).await)
         }
     }
 
     impl<M: RawMutex, const N: usize> embedded_io_async::BufRead for Reader<'_, M, N> {
-        async fn fill_buf(&mut self) -> Result<&[u8], Self::Error> {
+        async fn fill_buf(&mut self) -> Result<&[u8], Infallible> {
             Ok(Reader::fill_buf(self).await)
         }
 
@@ -528,11 +528,11 @@ mod io_impls {
     }
 
     impl<M: RawMutex, const N: usize> embedded_io_async::Write for Writer<'_, M, N> {
-        async fn write(&mut self, buf: &[u8]) -> Result<usize, Self::Error> {
+        async fn write(&mut self, buf: &[u8]) -> Result<usize, Infallible> {
             Ok(Writer::write(self, buf).await)
         }
 
-        async fn flush(&mut self) -> Result<(), Self::Error> {
+        async fn flush(&mut self) -> Result<(), Infallible> {
             Ok(())
         }
     }

--- a/examples/std/src/bin/net_ppp.rs
+++ b/examples/std/src/bin/net_ppp.rs
@@ -8,7 +8,7 @@
 //!     nc 192.168.7.10 1234
 
 #![feature(type_alias_impl_trait)]
-#![feature(async_fn_in_trait, impl_trait_projections)]
+#![feature(async_fn_in_trait)]
 
 #[path = "../serial_port.rs"]
 mod serial_port;


### PR DESCRIPTION
It's possible `async_fn_in_traits` will get stabilized before `impl_trait_projections` (see [zulip thread](https://rust-lang.zulipchat.com/#narrow/stream/187312-wg-async/topic/sync.20meeting.202023-09-07)). 

Trying out whether it's feasible to use `async_fn_in_traits` only. Do not merge yet. Since it makes the code a bit uglier, we should only merge this if indeed `async_fn_in_traits` gets stabilized before `impl_trait_projections`.

EDIT: maybe `impl_trait_projections` does get stabilized before AFIT: https://github.com/rust-lang/rust/pull/115659