### PR TITLE
embassy-net: add async wait_config_up

### DIFF
--- a/embassy-net/src/lib.rs
+++ b/embassy-net/src/lib.rs
@@ -365,7 +365,7 @@ impl<D: Driver + 'static> Stack<D> {
         v4_up || v6_up
     }
 
-    /// Get for the network stack to obtainer a valid IP configuration.
+    /// Wait for the network stack to obtaine a valid IP configuration.
     pub async fn wait_config_up(&self) {
         if self.is_config_up() {
             return;

--- a/embassy-net/src/lib.rs
+++ b/embassy-net/src/lib.rs
@@ -371,7 +371,7 @@ impl<D: Driver + 'static> Stack<D> {
     /// ## Notes:
     /// - Ensure [`Stack::run`] has been called before using this function.
     ///
-    /// - This function may never yield (e.g. if no configuration is obtained through DHCP).
+    /// - This function may never return (e.g. if no configuration is obtained through DHCP).
     /// The caller is supposed to handle a timeout for this case.
     ///
     /// ## Example

--- a/embassy-net/src/lib.rs
+++ b/embassy-net/src/lib.rs
@@ -367,13 +367,12 @@ impl<D: Driver + 'static> Stack<D> {
     }
 
     /// Wait for the network stack to obtain a valid IP configuration.
-    /// Returns instantly if [`Stack::is_config_up`] returns `true`.
     ///
-    /// ## Watch out:
-    /// The Future is polled only when the [`Stack`] is running,
-    /// e.g. call `spawner.spawn(net_task(stack))`.
+    /// ## Notes:
+    /// - Ensure [`Stack::run`] has been called before using this function.
     ///
-    /// `await`ing before will never yield!
+    /// - This function may never yield (e.g. if no configuration is obtained through DHCP).
+    /// The caller is supposed to handle a timeout for this case.
     ///
     /// ## Example
     /// ```ignore
@@ -385,7 +384,7 @@ impl<D: Driver + 'static> Stack<D> {
     ///    make_static!(embassy_net::StackResources::<2>::new()),
     ///    seed
     /// ));
-    /// // Launch network task
+    /// // Launch network task that runs `stack.run().await`
     /// spawner.spawn(net_task(stack)).unwrap();
     /// // Wait for DHCP config
     /// stack.wait_config_up().await;

--- a/examples/stm32f4/src/bin/eth.rs
+++ b/examples/stm32f4/src/bin/eth.rs
@@ -79,7 +79,10 @@ async fn main(spawner: Spawner) -> ! {
     ));
 
     // Launch network task
-    unwrap!(spawner.spawn(net_task(&stack)));
+    unwrap!(spawner.spawn(net_task(stack)));
+
+    // Ensure DHCP configuration is up before trying connect
+    stack.wait_config_up().await;
 
     info!("Network task initialized");
 

--- a/examples/stm32f7/src/bin/eth.rs
+++ b/examples/stm32f7/src/bin/eth.rs
@@ -80,7 +80,10 @@ async fn main(spawner: Spawner) -> ! {
     ));
 
     // Launch network task
-    unwrap!(spawner.spawn(net_task(&stack)));
+    unwrap!(spawner.spawn(net_task(stack)));
+
+    // Ensure DHCP configuration is up before trying connect
+    stack.wait_config_up().await;
 
     info!("Network task initialized");
 

--- a/examples/stm32h5/src/bin/eth.rs
+++ b/examples/stm32h5/src/bin/eth.rs
@@ -101,6 +101,9 @@ async fn main(spawner: Spawner) -> ! {
     // Launch network task
     unwrap!(spawner.spawn(net_task(&stack)));
 
+    // Ensure DHCP configuration is up before trying connect
+    stack.wait_config_up().await;
+
     info!("Network task initialized");
 
     // Then we can use it!

--- a/examples/stm32h7/src/bin/eth.rs
+++ b/examples/stm32h7/src/bin/eth.rs
@@ -83,6 +83,9 @@ async fn main(spawner: Spawner) -> ! {
     // Launch network task
     unwrap!(spawner.spawn(net_task(&stack)));
 
+    // Ensure DHCP configuration is up before trying connect
+    stack.wait_config_up().await;
+
     info!("Network task initialized");
 
     // Then we can use it!

--- a/examples/stm32h7/src/bin/eth_client.rs
+++ b/examples/stm32h7/src/bin/eth_client.rs
@@ -82,12 +82,12 @@ async fn main(spawner: Spawner) -> ! {
     ));
 
     // Launch network task
-    unwrap!(spawner.spawn(net_task(&stack)));
+    unwrap!(spawner.spawn(net_task(stack)));
+
+    // Ensure DHCP configuration is up before trying connect
+    stack.wait_config_up().await;
 
     info!("Network task initialized");
-
-    // To ensure DHCP configuration before trying connect
-    Timer::after(Duration::from_secs(20)).await;
 
     static STATE: TcpClientState<1, 1024, 1024> = TcpClientState::new();
     let client = TcpClient::new(&stack, &STATE);


### PR DESCRIPTION
This PR adds a function `wait_config_up` to the embassy_net `Stack`.
It will check whether `is_config_up` is true and if not register a waker that is woken in `apply_static_config` (e.g. by DHCP).

I added a not-working example to the docstring. Not sure whether we can make this run somehow.