### PR TITLE
stm32/usart: fix read_until_idle not wake up issue

### DIFF
--- a/embassy-stm32/src/usart/mod.rs
+++ b/embassy-stm32/src/usart/mod.rs
@@ -545,6 +545,13 @@ impl<'d, T: BasicInstance, RxDma> UartRx<'d, T, RxDma> {
             unsafe { rdr(r).read_volatile() };
             clear_interrupt_flags(r, sr);
 
+            if enable_idle_line_detection {
+                // enable idle interrupt
+                r.cr1().modify(|w| {
+                    w.set_idleie(true);
+                });
+            }
+
             compiler_fence(Ordering::SeqCst);
 
             let has_errors = sr.pe() || sr.fe() || sr.ne() || sr.ore();


### PR DESCRIPTION
When use `RartRx::read_until_idle` to read from uart, sometime it can't wake up. 

**Reason**:  while `abort` future is polling which is triggered by idle interrupt , at the same time the next data is start transferring, the `sr.idle()` return false, and the `abort` future still return `Poll::Pending` state, so it can't be wake up anymore.

**Solution**: Always enable idle interrupt when poll `abort` future