### PR TITLE
Wait for high for DIO1 for rp2040-based LoRa boards

### DIFF
--- a/embassy-lora/src/iv.rs
+++ b/embassy-lora/src/iv.rs
@@ -284,11 +284,7 @@ where
         self.busy.wait_for_low().await.map_err(|_| Busy)
     }
     async fn await_irq(&mut self) -> Result<(), RadioError> {
-        if self.board_type != BoardType::RpPicoWaveshareSx1262 {
-            self.dio1.wait_for_high().await.map_err(|_| DIO1)?;
-        } else {
-            self.dio1.wait_for_rising_edge().await.map_err(|_| DIO1)?;
-        }
+        self.dio1.wait_for_high().await.map_err(|_| DIO1)?;
         Ok(())
     }
 


### PR DESCRIPTION
Handle rp2040-based LoRa boards in the same manner as LoRa boards for other MCUs with regard to detecting an IRQ on the DIO1 pin - wait for high rather than rising edge.

This is PR is a result of analysis within the following issue:

https://github.com/embassy-rs/lora-phy/issues/27.