### PR TITLE
[STM32] Handle STM32H7 "_C" pins

### DIFF
--- a/.github/ci/build-stable.sh
+++ b/.github/ci/build-stable.sh
@@ -8,6 +8,10 @@ export RUSTUP_HOME=/ci/cache/rustup
 export CARGO_HOME=/ci/cache/cargo
 export CARGO_TARGET_DIR=/ci/cache/target
 
+# needed for "dumb HTTP" transport support
+# used when pointing stm32-metapac to a CI-built one.
+export CARGO_NET_GIT_FETCH_WITH_CLI=true
+
 hashtime restore /ci/cache/filetime.json || true
 hashtime save /ci/cache/filetime.json
 

--- a/.github/ci/build.sh
+++ b/.github/ci/build.sh
@@ -14,6 +14,10 @@ if [ -f /ci/secrets/teleprobe-token.txt ]; then
     export TELEPROBE_CACHE=/ci/cache/teleprobe_cache.json
 fi
 
+# needed for "dumb HTTP" transport support
+# used when pointing stm32-metapac to a CI-built one.
+export CARGO_NET_GIT_FETCH_WITH_CLI=true
+
 hashtime restore /ci/cache/filetime.json || true
 hashtime save /ci/cache/filetime.json
 

--- a/.github/ci/test.sh
+++ b/.github/ci/test.sh
@@ -8,6 +8,10 @@ export RUSTUP_HOME=/ci/cache/rustup
 export CARGO_HOME=/ci/cache/cargo
 export CARGO_TARGET_DIR=/ci/cache/target
 
+# needed for "dumb HTTP" transport support
+# used when pointing stm32-metapac to a CI-built one.
+export CARGO_NET_GIT_FETCH_WITH_CLI=true
+
 hashtime restore /ci/cache/filetime.json || true
 hashtime save /ci/cache/filetime.json
 

--- a/embassy-stm32/Cargo.toml
+++ b/embassy-stm32/Cargo.toml
@@ -133,6 +133,22 @@ time-driver-tim12 = ["_time-driver"]
 time-driver-tim15 = ["_time-driver"]
 
 
+#! ## Analog Switch Pins (Pxy_C) on STM32H7 series
+#! Get `PXY` and `PXY_C` singletons. Digital impls are on `PXY`, Analog impls are on `PXY_C`
+#! If disabled, you get only the `PXY` singleton. It has both digital and analog impls.
+
+## Split PA0
+split-pa0 = ["_split-pins-enabled"]
+## Split PA1
+split-pa1 = ["_split-pins-enabled"]
+## Split PC2
+split-pc2 = ["_split-pins-enabled"]
+## Split PC3
+split-pc3 = ["_split-pins-enabled"]
+
+## internal use only
+_split-pins-enabled = []
+
 #! ## Chip-selection features
 #! Select your chip by specifying the model as a feature, e.g. `stm32c011d6`.
 #! Check the `Cargo.toml` for the latest list of supported chips.

--- a/embassy-stm32/Cargo.toml
+++ b/embassy-stm32/Cargo.toml
@@ -58,7 +58,7 @@ sdio-host = "0.5.0"
 embedded-sdmmc = { git = "https://github.com/embassy-rs/embedded-sdmmc-rs", rev = "a4f293d3a6f72158385f79c98634cb8a14d0d2fc", optional = true }
 critical-section = "1.1"
 atomic-polyfill = "1.0.1"
-stm32-metapac = { git = "https://github.com/embassy-rs/stm32-data-generated", tag = "stm32-data-4e6a74f69c4bc5d2d4872ba50d805e75bfe55cad" }
+stm32-metapac = { git = "https://ci.embassy.dev/jobs/fc52d4c63842/artifacts/generated.git" }
 vcell = "0.1.3"
 bxcan = "0.7.0"
 nb = "1.0.0"
@@ -77,7 +77,7 @@ critical-section = { version = "1.1", features = ["std"] }
 [build-dependencies]
 proc-macro2 = "1.0.36"
 quote = "1.0.15"
-stm32-metapac = { git = "https://github.com/embassy-rs/stm32-data-generated", tag = "stm32-data-4e6a74f69c4bc5d2d4872ba50d805e75bfe55cad", default-features = false, features = ["metadata"]}
+stm32-metapac = { git = "https://ci.embassy.dev/jobs/fc52d4c63842/artifacts/generated.git", default-features = false, features = ["metadata"]}
 
 [features]
 default = ["rt"]

--- a/embassy-stm32/build.rs
+++ b/embassy-stm32/build.rs
@@ -81,6 +81,16 @@ fn main() {
         singletons.push(c.name.to_string());
     }
 
+    // Extra analog switch pins available on most H7 chips
+    #[cfg(feature = "split-pa0")]
+    singletons.push("PA0_C".into());
+    #[cfg(feature = "split-pa1")]
+    singletons.push("PA1_C".into());
+    #[cfg(feature = "split-pc2")]
+    singletons.push("PC2_C".into());
+    #[cfg(feature = "split-pc3")]
+    singletons.push("PC3_C".into());
+
     // ========
     // Handle time-driver-XXXX features.
 
@@ -670,7 +680,31 @@ fn main() {
                 let key = (regs.kind, pin.signal);
                 if let Some(tr) = signals.get(&key) {
                     let mut peri = format_ident!("{}", p.name);
-                    let pin_name = format_ident!("{}", pin.pin);
+                    let pin_name = {
+                        #[allow(unused_mut)]
+                        let mut pin_name = pin.pin;
+
+                        #[cfg(not(feature = "split-pa0"))]
+                        if pin.pin == "PA0_C" {
+                            pin_name = "PA0";
+                        }
+                        #[cfg(not(feature = "split-pa1"))]
+                        if pin.pin == "PA1_C" {
+                            pin_name = "PA1";
+                        }
+
+                        #[cfg(not(feature = "split-pc2"))]
+                        if pin.pin == "PC2_C" {
+                            pin_name = "PC2";
+                        }
+                        #[cfg(not(feature = "split-pc3"))]
+                        if pin.pin == "PC3_C" {
+                            pin_name = "PC3";
+                        }
+
+                        format_ident!("{}", pin_name)
+                    };
+
                     let af = pin.af.unwrap_or(0);
 
                     // MCO is special
@@ -707,7 +741,30 @@ fn main() {
                     }
 
                     let peri = format_ident!("{}", p.name);
-                    let pin_name = format_ident!("{}", pin.pin);
+                    let pin_name = {
+                        #[allow(unused_mut)]
+                        let mut pin_name = pin.pin;
+
+                        #[cfg(not(feature = "split-pa0"))]
+                        if pin.pin == "PA0_C" {
+                            pin_name = "PA0";
+                        }
+                        #[cfg(not(feature = "split-pa1"))]
+                        if pin.pin == "PA1_C" {
+                            pin_name = "PA1";
+                        }
+
+                        #[cfg(not(feature = "split-pc2"))]
+                        if pin.pin == "PC2_C" {
+                            pin_name = "PC2";
+                        }
+                        #[cfg(not(feature = "split-pc3"))]
+                        if pin.pin == "PC3_C" {
+                            pin_name = "PC3";
+                        }
+
+                        format_ident!("{}", pin_name)
+                    };
 
                     // H7 has differential voltage measurements
                     let ch: Option<u8> = if pin.signal.starts_with("INP") {

--- a/embassy-stm32/build.rs
+++ b/embassy-stm32/build.rs
@@ -95,7 +95,7 @@ fn main() {
     }
 
     // Extra analog switch pins available on most H7 chips
-    let split_features = [
+    let split_features: Vec<SplitFeature> = vec![
         #[cfg(feature = "split-pa0")]
         SplitFeature {
             feature_name: "split-pa0".to_string(),

--- a/embassy-stm32/build.rs
+++ b/embassy-stm32/build.rs
@@ -723,17 +723,14 @@ fn main() {
                 let key = (regs.kind, pin.signal);
                 if let Some(tr) = signals.get(&key) {
                     let mut peri = format_ident!("{}", p.name);
+
                     let pin_name = {
-                        // If we encounter a "_C" pin, we remove the suffix
-                        let mut pin_name = pin.pin.strip_suffix("_C").unwrap_or(pin.pin).to_string();
-                        // However, if the corresponding split_feature is enabled, we actually do want the pin name including "_C"
-                        for split_feature in &split_features {
-                            if pin.pin == split_feature.pin_name_with_c {
-                                pin_name = split_feature.pin_name_with_c.clone();
-                            }
+                        // If we encounter a _C pin but the split_feature for this pin is not enabled, skip it
+                        if pin.pin.ends_with("_C") && !split_features.iter().any(|x| x.pin_name_with_c == pin.pin) {
+                            continue;
                         }
 
-                        format_ident!("{}", pin_name)
+                        format_ident!("{}", pin.pin)
                     };
 
                     let af = pin.af.unwrap_or(0);
@@ -773,16 +770,11 @@ fn main() {
 
                     let peri = format_ident!("{}", p.name);
                     let pin_name = {
-                        // If we encounter a "_C" pin, we remove the suffix
-                        let mut pin_name = pin.pin.strip_suffix("_C").unwrap_or(pin.pin).to_string();
-                        // However, if the corresponding split_feature is enabled, we actually do want the pin name including "_C"
-                        for split_feature in &split_features {
-                            if pin.pin == split_feature.pin_name_with_c {
-                                pin_name = split_feature.pin_name_with_c.clone();
-                            }
+                        // If we encounter a _C pin but the split_feature for this pin is not enabled, skip it
+                        if pin.pin.ends_with("_C") && !split_features.iter().any(|x| x.pin_name_with_c == pin.pin) {
+                            continue;
                         }
-
-                        format_ident!("{}", pin_name)
+                        format_ident!("{}", pin.pin)
                     };
 
                     // H7 has differential voltage measurements

--- a/embassy-stm32/build.rs
+++ b/embassy-stm32/build.rs
@@ -81,15 +81,36 @@ fn main() {
         singletons.push(c.name.to_string());
     }
 
+    let mut pin_set = std::collections::HashSet::new();
+    for p in METADATA.peripherals {
+        for pin in p.pins {
+            pin_set.insert(pin.pin);
+        }
+    }
+
     // Extra analog switch pins available on most H7 chips
-    #[cfg(feature = "split-pa0")]
-    singletons.push("PA0_C".into());
-    #[cfg(feature = "split-pa1")]
-    singletons.push("PA1_C".into());
-    #[cfg(feature = "split-pc2")]
-    singletons.push("PC2_C".into());
-    #[cfg(feature = "split-pc3")]
-    singletons.push("PC3_C".into());
+    let split_features = [
+        #[cfg(feature = "split-pa0")]
+        ("split-pa0", "PA0_C"),
+        #[cfg(feature = "split-pa1")]
+        ("split-pa1", "PA1_C"),
+        #[cfg(feature = "split-pc2")]
+        ("split-pc2", "PC2_C"),
+        #[cfg(feature = "split-pc3")]
+        ("split-pc3", "PC3_C"),
+    ];
+
+    for (feature_name, pin_name) in split_features {
+        if pin_set.contains(pin_name) {
+            singletons.push(pin_name.into());
+        } else {
+            panic!(
+                "'{}' feature invalid for this chip! No pin '{}' found.\n
+                Found pins: {:#?}",
+                feature_name, pin_name, pin_set
+            )
+        }
+    }
 
     // ========
     // Handle time-driver-XXXX features.
@@ -901,6 +922,20 @@ fn main() {
 
                 for pin_num in 0u32..16 {
                     let pin_name = format!("P{}{}", port_letter, pin_num);
+
+                    // TODO: Here we need to take care of the _C pins properly.
+                    // Maybe it would be better to not iterate over 0..16 but the
+                    // Pin names directly. However, this might have side-effects... :(
+                    if pin_name == "PC2" {
+                        pins_table.push(vec![
+                            "PC2_C".to_string(),
+                            p.name.to_string(),
+                            port_num.to_string(),
+                            "2".to_string(),
+                            format!("EXTI{}", 2),
+                        ]);
+                    }
+
                     pins_table.push(vec![
                         pin_name,
                         p.name.to_string(),

--- a/embassy-stm32/src/lib.rs
+++ b/embassy-stm32/src/lib.rs
@@ -180,6 +180,18 @@ pub fn init(config: Config) -> Peripherals {
     }
 
     unsafe {
+        #[cfg(feature = "_split-pins-enabled")]
+        crate::pac::SYSCFG.pmcr().modify(|pmcr| {
+            #[cfg(feature = "split-pa0")]
+            pmcr.set_pa0so(true);
+            #[cfg(feature = "split-pa1")]
+            pmcr.set_pa1so(true);
+            #[cfg(feature = "split-pc2")]
+            pmcr.set_pc2so(true);
+            #[cfg(feature = "split-pc3")]
+            pmcr.set_pc3so(true);
+        });
+
         gpio::init();
         dma::init(
             #[cfg(bdma)]


### PR DESCRIPTION
As discussed in the chat, the `split-pxy` features are introduced for use with https://github.com/embassy-rs/stm32-data/pull/254

Ideas for improvement:
- Verify this actually works with the split functions enabled (the traits are there, but I have no device that actually exposes the PC2/3 pins)
-  Add a testcase / CI step for compilation with these flags. Any suggestions where that should go? Or maybe a HIL test on an H7 board?