### PR TITLE
Write to TaskStorage::future via never-inlined fn to encourage RVO

### DIFF
--- a/embassy-executor/src/arch/wasm.rs
+++ b/embassy-executor/src/arch/wasm.rs
@@ -73,9 +73,10 @@ mod thread {
         pub fn start(&'static mut self, init: impl FnOnce(Spawner)) {
             unsafe {
                 let executor = &self.inner;
-                self.ctx.closure.write(Closure::new(move |_| {
+                let future = Closure::new(move |_| {
                     executor.poll();
-                }));
+                });
+                self.ctx.closure.write_in_place(|| future);
                 init(self.inner.spawner());
             }
         }

--- a/embassy-executor/src/raw/mod.rs
+++ b/embassy-executor/src/raw/mod.rs
@@ -203,7 +203,7 @@ impl<F: Future + 'static> AvailableTask<F> {
     fn initialize_impl<S>(self, future: impl FnOnce() -> F) -> SpawnToken<S> {
         unsafe {
             self.task.raw.poll_fn.set(Some(TaskStorage::<F>::poll));
-            self.task.future.write(future());
+            self.task.future.write_in_place(future);
 
             let task = TaskRef::new(self.task);
 

--- a/embassy-executor/src/raw/util.rs
+++ b/embassy-executor/src/raw/util.rs
@@ -17,8 +17,9 @@ impl<T> UninitCell<T> {
         &mut *self.as_mut_ptr()
     }
 
-    pub unsafe fn write(&self, val: T) {
-        ptr::write(self.as_mut_ptr(), val)
+    #[inline(never)]
+    pub unsafe fn write_in_place(&self, func: impl FnOnce() -> T) {
+        ptr::write(self.as_mut_ptr(), func())
     }
 
     pub unsafe fn drop_in_place(&self) {


### PR DESCRIPTION
In programs that contain large future objects, for example those which declare large buffers as locals in async functions:

```rust
async fn run() -> Result<(), RunError> {
    let mut rx_meta = [PacketMetadata::EMPTY; 16];
    let mut rx_buffer = [0; 4096];

    let mut tx_meta = [PacketMetadata::EMPTY; 16];
    let mut tx_buffer = [0; 4096];

    // ...
```

`TaskPool::spawn_impl` can in some cases use an enormous amount of stack to instantiate the future into a `TaskStorage`:

```sh-session
$ cargo build --release
   Compiling embassy-executor v0.3.0 (/home/hailey/code/embassy/embassy-executor)
   Compiling bark-esp v0.1.0 (/home/hailey/code/bark-esp)
    Finished release [optimized + debuginfo] target(s) in 1.36s
$ stack-usage target/xtensa-esp32-none-elf/release/bark-esp
FUNCTION                                                                               STACK SIZE
embassy_executor::raw::TaskPool<F,_>::spawn_impl::h3954ad8fc673878e                         20304
```

Rust _does_ support [return value optimisation](https://en.wikipedia.org/wiki/Copy_elision#Return_value_optimization), and it's unclear to me why it is not applying this optimisation in this case. Sure enough though, the disassembly for this instantiation of `TaskPool::spawn_impl` shows that the future object is returned by the future constructor to the stack before being separately memcpy'd into the `TaskStorage` struct:

![image](https://github.com/embassy-rs/embassy/assets/179065/20451bdb-56a4-481b-95f3-7d761bfaea33)

I found that writing to `TaskStorage::future` via a `#[inline(never)]` function successfully coaxes the compiler into doing RVO here. Perhaps it's because a smaller, simpler function makes it more obvious to the optimizer that RVO is a valid optimization here.

The disassembly for `TaskPool::spawn_impl` _after_ applying this change:

![image](https://github.com/embassy-rs/embassy/assets/179065/0a6f4432-638e-4e85-b3f1-561ed56a795b)

And the disassembly for this particular `UninitCell::write_in_place` instantiation:

![image](https://github.com/embassy-rs/embassy/assets/179065/0bd35e33-9af6-4726-8d23-6aab451e7647)

Interestingly, as well as performing RVO, the compiler is now able to see that it can validly only partially initialize the future object, by only setting what I assume is the discriminant field, even though the future object is still just as large.