### PR TITLE
Fix panic safety issue in TaskStorage

### DIFF
--- a/embassy-executor/src/raw/mod.rs
+++ b/embassy-executor/src/raw/mod.rs
@@ -36,13 +36,15 @@ use super::SpawnToken;
 
 /// Task is eligible for allocation
 pub(crate) const STATE_ELIGIBLE: u32 = 0;
+/// Task is claimed (ineligible for allocation, but does not have a valid future)
+pub(crate) const STATE_CLAIMED: u32 = 1 << 0;
 /// Task is spawned (has a future)
-pub(crate) const STATE_SPAWNED: u32 = 1 << 0;
+pub(crate) const STATE_SPAWNED: u32 = 1 << 1;
 /// Task is in the executor run queue
-pub(crate) const STATE_RUN_QUEUED: u32 = 1 << 1;
+pub(crate) const STATE_RUN_QUEUED: u32 = 1 << 2;
 /// Task is in the executor timer queue
 #[cfg(feature = "integrated-timers")]
-pub(crate) const STATE_TIMER_QUEUED: u32 = 1 << 2;
+pub(crate) const STATE_TIMER_QUEUED: u32 = 1 << 3;
 
 /// Raw task header for use in task pointers.
 pub(crate) struct TaskHeader {


### PR DESCRIPTION
Eyeballed this bug while working on #1896.

If the future constructor function passed to `AvailableTask::initialize` panics, `TaskStorage` is left invalid, where its state is `STATE_SPAWNED` but the future cell remains uninitialized.

This pull request adds a new state, `STATE_CLAIMED`, which is used to reserve an `AvailableTask` in `claim` before being initialized properly in `initialize_impl`. Once the future slot is initialized, state is set to `STATE_SPAWNED | STATE_RUN_QUEUED` with release ordering. I'm not 100% confident about memory ordering stuff, but I _think_ release is the correct barrier to use here, since we need to prevent any writes from being reordered after this point.