### PR TITLE
Fix gpiote when waking up from systemoff

### DIFF
--- a/embassy-nrf/src/gpiote.rs
+++ b/embassy-nrf/src/gpiote.rs
@@ -86,7 +86,6 @@ pub(crate) fn init(irq_prio: crate::interrupt::Priority) {
     unsafe { irq.enable() };
 
     let g = regs();
-    g.events_port.write(|w| w);
     g.intenset.write(|w| w.port().set());
 }
 


### PR DESCRIPTION
So when the nRF chip wakes up from systemoff sleep from a port event, it the `events_port` will be set. However, embassy currently resets this register on init before any interrupt.

This is a problem because the latch bits will be set and embassy puts the gpio in LDETECT mode. This means that  `events_port` is cleared while DETECT is high. If a new pin gets its DETECT signal, it won't trigger the  `events_port` because it seems that only happens on the overall DETECT signal. This means no new GPIOTE interrupt is triggered and input will not be captured.

TLDR: If we don't clear  `events_port`, then it will be picked up by the GPIOTE interrupt handler and be cleared there.