### PR TITLE
Enable critical-section/restore-state-u32 feature on xtensa

### DIFF
--- a/embassy-executor/Cargo.toml
+++ b/embassy-executor/Cargo.toml
@@ -33,7 +33,7 @@ features = ["nightly", "defmt", "arch-cortex-m", "executor-thread", "executor-in
 _arch = [] # some arch was picked
 arch-std = ["_arch", "critical-section/std"]
 arch-cortex-m = ["_arch", "dep:cortex-m"]
-arch-xtensa = ["_arch"]
+arch-xtensa = ["_arch", "critical-section/restore-state-u32"]
 arch-riscv32 = ["_arch"]
 arch-wasm = ["_arch", "dep:wasm-bindgen", "dep:js-sys"]
 


### PR DESCRIPTION
embassy-executor fails to compile without this feature:

```
λ cargo build
    Updating crates.io index
   Compiling bark-esp v0.0.0 (/home/hailey/code/bark-esp)
   Compiling embassy-executor v0.3.0
error: cannot use value of type `()` for inline assembly
  --> /home/hailey/.cargo/registry/src/index.crates.io-6f17d22bba15001f/embassy-executor-0.3.0/src/arch/xtensa.rs:65:62
   |
65 |                     core::arch::asm!("rsil {0}, 5", out(reg) token);
   |                                                              ^^^^^
   |
   = note: only integers, floats, SIMD vectors, pointers and function pointers can be used as arguments for inline assembly

error: cannot use value of type `()` for inline assembly
  --> /home/hailey/.cargo/registry/src/index.crates.io-6f17d22bba15001f/embassy-executor-0.3.0/src/arch/xtensa.rs:75:42
   |
75 |                         "rsync", in(reg) token)
   |                                          ^^^^^
   |
   = note: only integers, floats, SIMD vectors, pointers and function pointers can be used as arguments for inline assembly

error: could not compile `embassy-executor` (lib) due to 2 previous errors
```

This feature can be enabled by other crates, which means this error is usually masked.