### PR TITLE
stm32: fix  wpan_ble test

### DIFF
--- a/ci.sh
+++ b/ci.sh
@@ -182,6 +182,4 @@ if [[ -z "${TELEPROBE_TOKEN-}" ]]; then
     exit
 fi
 
-rm out/tests/stm32wb55rg/wpan_ble
-
 teleprobe client run -r out/tests

--- a/embassy-stm32/src/rcc/wb.rs
+++ b/embassy-stm32/src/rcc/wb.rs
@@ -135,7 +135,7 @@ pub const WPAN_DEFAULT: Config = Config {
         prediv: 2,
     }),
     pll48: None,
-    rtc: None,
+    rtc: Some(RtcClockSource::LSE),
 
     pll: Some(Pll {
         mul: 12,


### PR DESCRIPTION
because the rtc code was not run in this case, the backup domain was not reset, which contaminated the HIL test.