### PR TITLE
stm32/rcc: convert bus prescalers to pac enums

### DIFF
--- a/embassy-stm32/Cargo.toml
+++ b/embassy-stm32/Cargo.toml
@@ -59,7 +59,7 @@ sdio-host = "0.5.0"
 embedded-sdmmc = { git = "https://github.com/embassy-rs/embedded-sdmmc-rs", rev = "a4f293d3a6f72158385f79c98634cb8a14d0d2fc", optional = true }
 critical-section = "1.1"
 atomic-polyfill = "1.0.1"
-stm32-metapac = { git = "https://github.com/embassy-rs/stm32-data-generated", tag = "stm32-data-546aead07086342605102d66dec49c5e2d459a0c" }
+stm32-metapac = { git = "https://github.com/embassy-rs/stm32-data-generated", tag = "stm32-data-907dd82c848bc912252c61509944e85c2a48c919" }
 vcell = "0.1.3"
 bxcan = "0.7.0"
 nb = "1.0.0"
@@ -78,7 +78,7 @@ critical-section = { version = "1.1", features = ["std"] }
 [build-dependencies]
 proc-macro2 = "1.0.36"
 quote = "1.0.15"
-stm32-metapac = { git = "https://github.com/embassy-rs/stm32-data-generated", tag = "stm32-data-546aead07086342605102d66dec49c5e2d459a0c", default-features = false, features = ["metadata"]}
+stm32-metapac = { git = "https://github.com/embassy-rs/stm32-data-generated", tag = "stm32-data-907dd82c848bc912252c61509944e85c2a48c919", default-features = false, features = ["metadata"]}
 
 [features]
 default = ["rt"]

--- a/embassy-stm32/src/rcc/bus.rs
+++ b/embassy-stm32/src/rcc/bus.rs
@@ -2,6 +2,7 @@ use core::ops::Div;
 
 #[allow(unused_imports)]
 use crate::pac::rcc;
+pub use crate::pac::rcc::vals::{Hpre as AHBPrescaler, Ppre as APBPrescaler};
 use crate::time::Hertz;
 
 /// Voltage Scale
@@ -20,108 +21,34 @@ pub enum VoltageScale {
     Scale3,
 }
 
-/// AHB prescaler
-#[derive(Clone, Copy, PartialEq)]
-pub enum AHBPrescaler {
-    NotDivided,
-    Div2,
-    #[cfg(any(rcc_wb, rcc_wl5, rcc_wle))]
-    Div3,
-    Div4,
-    #[cfg(any(rcc_wb, rcc_wl5, rcc_wle))]
-    Div5,
-    #[cfg(any(rcc_wb, rcc_wl5, rcc_wle))]
-    Div6,
-    Div8,
-    #[cfg(any(rcc_wb, rcc_wl5, rcc_wle))]
-    Div10,
-    Div16,
-    #[cfg(any(rcc_wb, rcc_wl5, rcc_wle))]
-    Div32,
-    Div64,
-    Div128,
-    Div256,
-    Div512,
-}
-
 impl Div<AHBPrescaler> for Hertz {
     type Output = Hertz;
 
     fn div(self, rhs: AHBPrescaler) -> Self::Output {
         let divisor = match rhs {
-            AHBPrescaler::NotDivided => 1,
-            AHBPrescaler::Div2 => 2,
+            AHBPrescaler::DIV1 => 1,
+            AHBPrescaler::DIV2 => 2,
             #[cfg(any(rcc_wb, rcc_wl5, rcc_wle))]
-            AHBPrescaler::Div3 => 3,
-            AHBPrescaler::Div4 => 4,
+            AHBPrescaler::DIV3 => 3,
+            AHBPrescaler::DIV4 => 4,
             #[cfg(any(rcc_wb, rcc_wl5, rcc_wle))]
-            AHBPrescaler::Div5 => 5,
+            AHBPrescaler::DIV5 => 5,
             #[cfg(any(rcc_wb, rcc_wl5, rcc_wle))]
-            AHBPrescaler::Div6 => 6,
-            AHBPrescaler::Div8 => 8,
+            AHBPrescaler::DIV6 => 6,
+            AHBPrescaler::DIV8 => 8,
             #[cfg(any(rcc_wb, rcc_wl5, rcc_wle))]
-            AHBPrescaler::Div10 => 10,
-            AHBPrescaler::Div16 => 16,
+            AHBPrescaler::DIV10 => 10,
+            AHBPrescaler::DIV16 => 16,
             #[cfg(any(rcc_wb, rcc_wl5, rcc_wle))]
-            AHBPrescaler::Div32 => 32,
-            AHBPrescaler::Div64 => 64,
-            AHBPrescaler::Div128 => 128,
-            AHBPrescaler::Div256 => 256,
-            AHBPrescaler::Div512 => 512,
+            AHBPrescaler::DIV32 => 32,
+            AHBPrescaler::DIV64 => 64,
+            AHBPrescaler::DIV128 => 128,
+            AHBPrescaler::DIV256 => 256,
+            AHBPrescaler::DIV512 => 512,
+            _ => unreachable!(),
         };
         Hertz(self.0 / divisor)
     }
-}
-
-#[cfg(not(any(rcc_g4, rcc_wb, rcc_wl5, rcc_wle)))]
-impl From<AHBPrescaler> for rcc::vals::Hpre {
-    fn from(val: AHBPrescaler) -> rcc::vals::Hpre {
-        use rcc::vals::Hpre;
-
-        match val {
-            AHBPrescaler::NotDivided => Hpre::DIV1,
-            AHBPrescaler::Div2 => Hpre::DIV2,
-            AHBPrescaler::Div4 => Hpre::DIV4,
-            AHBPrescaler::Div8 => Hpre::DIV8,
-            AHBPrescaler::Div16 => Hpre::DIV16,
-            AHBPrescaler::Div64 => Hpre::DIV64,
-            AHBPrescaler::Div128 => Hpre::DIV128,
-            AHBPrescaler::Div256 => Hpre::DIV256,
-            AHBPrescaler::Div512 => Hpre::DIV512,
-        }
-    }
-}
-
-#[cfg(any(rcc_wb, rcc_wl5, rcc_wle))]
-impl From<AHBPrescaler> for u8 {
-    fn from(val: AHBPrescaler) -> u8 {
-        match val {
-            AHBPrescaler::NotDivided => 0x0,
-            AHBPrescaler::Div2 => 0x08,
-            AHBPrescaler::Div3 => 0x01,
-            AHBPrescaler::Div4 => 0x09,
-            AHBPrescaler::Div5 => 0x02,
-            AHBPrescaler::Div6 => 0x05,
-            AHBPrescaler::Div8 => 0x0a,
-            AHBPrescaler::Div10 => 0x06,
-            AHBPrescaler::Div16 => 0x0b,
-            AHBPrescaler::Div32 => 0x07,
-            AHBPrescaler::Div64 => 0x0c,
-            AHBPrescaler::Div128 => 0x0d,
-            AHBPrescaler::Div256 => 0x0e,
-            AHBPrescaler::Div512 => 0x0f,
-        }
-    }
-}
-
-/// APB prescaler
-#[derive(Clone, Copy)]
-pub enum APBPrescaler {
-    NotDivided,
-    Div2,
-    Div4,
-    Div8,
-    Div16,
 }
 
 impl Div<APBPrescaler> for Hertz {
@@ -129,40 +56,13 @@ impl Div<APBPrescaler> for Hertz {
 
     fn div(self, rhs: APBPrescaler) -> Self::Output {
         let divisor = match rhs {
-            APBPrescaler::NotDivided => 1,
-            APBPrescaler::Div2 => 2,
-            APBPrescaler::Div4 => 4,
-            APBPrescaler::Div8 => 8,
-            APBPrescaler::Div16 => 16,
+            APBPrescaler::DIV1 => 1,
+            APBPrescaler::DIV2 => 2,
+            APBPrescaler::DIV4 => 4,
+            APBPrescaler::DIV8 => 8,
+            APBPrescaler::DIV16 => 16,
+            _ => unreachable!(),
         };
         Hertz(self.0 / divisor)
-    }
-}
-
-#[cfg(not(any(rcc_f1, rcc_f100, rcc_f1cl, rcc_g4, rcc_h7, rcc_h7ab, rcc_wb, rcc_wl5, rcc_wle)))]
-impl From<APBPrescaler> for rcc::vals::Ppre {
-    fn from(val: APBPrescaler) -> rcc::vals::Ppre {
-        use rcc::vals::Ppre;
-
-        match val {
-            APBPrescaler::NotDivided => Ppre::DIV1,
-            APBPrescaler::Div2 => Ppre::DIV2,
-            APBPrescaler::Div4 => Ppre::DIV4,
-            APBPrescaler::Div8 => Ppre::DIV8,
-            APBPrescaler::Div16 => Ppre::DIV16,
-        }
-    }
-}
-
-#[cfg(any(rcc_wb, rcc_wl5, rcc_wle))]
-impl From<APBPrescaler> for u8 {
-    fn from(val: APBPrescaler) -> u8 {
-        match val {
-            APBPrescaler::NotDivided => 1,
-            APBPrescaler::Div2 => 0x04,
-            APBPrescaler::Div4 => 0x05,
-            APBPrescaler::Div8 => 0x06,
-            APBPrescaler::Div16 => 0x07,
-        }
     }
 }

--- a/embassy-stm32/src/rcc/c0.rs
+++ b/embassy-stm32/src/rcc/c0.rs
@@ -58,8 +58,8 @@ impl Default for Config {
     fn default() -> Config {
         Config {
             mux: ClockSrc::HSI(HSIPrescaler::NotDivided),
-            ahb_pre: AHBPrescaler::NotDivided,
-            apb_pre: APBPrescaler::NotDivided,
+            ahb_pre: AHBPrescaler::DIV1,
+            apb_pre: APBPrescaler::DIV1,
         }
     }
 }
@@ -151,20 +151,21 @@ pub(crate) unsafe fn init(config: Config) {
     }
 
     let ahb_div = match config.ahb_pre {
-        AHBPrescaler::NotDivided => 1,
-        AHBPrescaler::Div2 => 2,
-        AHBPrescaler::Div4 => 4,
-        AHBPrescaler::Div8 => 8,
-        AHBPrescaler::Div16 => 16,
-        AHBPrescaler::Div64 => 64,
-        AHBPrescaler::Div128 => 128,
-        AHBPrescaler::Div256 => 256,
-        AHBPrescaler::Div512 => 512,
+        AHBPrescaler::DIV1 => 1,
+        AHBPrescaler::DIV2 => 2,
+        AHBPrescaler::DIV4 => 4,
+        AHBPrescaler::DIV8 => 8,
+        AHBPrescaler::DIV16 => 16,
+        AHBPrescaler::DIV64 => 64,
+        AHBPrescaler::DIV128 => 128,
+        AHBPrescaler::DIV256 => 256,
+        AHBPrescaler::DIV512 => 512,
+        _ => unreachable!(),
     };
     let ahb_freq = sys_clk / ahb_div;
 
     let (apb_freq, apb_tim_freq) = match config.apb_pre {
-        APBPrescaler::NotDivided => (ahb_freq, ahb_freq),
+        APBPrescaler::DIV1 => (ahb_freq, ahb_freq),
         pre => {
             let pre: Ppre = pre.into();
             let pre: u8 = 1 << (pre.to_bits() - 3);

--- a/embassy-stm32/src/rcc/f1.rs
+++ b/embassy-stm32/src/rcc/f1.rs
@@ -163,8 +163,8 @@ pub(crate) unsafe fn init(config: Config) {
     // Only needed for stm32f103?
     RCC.cfgr().modify(|w| {
         w.set_adcpre(Adcpre::from_bits(apre_bits));
-        w.set_ppre2(Ppre1::from_bits(ppre2_bits));
-        w.set_ppre1(Ppre1::from_bits(ppre1_bits));
+        w.set_ppre2(Ppre::from_bits(ppre2_bits));
+        w.set_ppre1(Ppre::from_bits(ppre1_bits));
         w.set_hpre(Hpre::from_bits(hpre_bits));
         #[cfg(not(rcc_f100))]
         w.set_usbpre(Usbpre::from_bits(usbpre as u8));

--- a/embassy-stm32/src/rcc/f2.rs
+++ b/embassy-stm32/src/rcc/f2.rs
@@ -308,9 +308,9 @@ impl Default for Config {
             voltage: VoltageScale::Scale3,
             mux: ClockSrc::HSI,
             rtc: None,
-            ahb_pre: AHBPrescaler::NotDivided,
-            apb1_pre: APBPrescaler::NotDivided,
-            apb2_pre: APBPrescaler::NotDivided,
+            ahb_pre: AHBPrescaler::DIV1,
+            apb1_pre: APBPrescaler::DIV1,
+            apb2_pre: APBPrescaler::DIV1,
         }
     }
 }
@@ -383,7 +383,7 @@ pub(crate) unsafe fn init(config: Config) {
     assert!(ahb_freq <= Hertz(120_000_000));
 
     let (apb1_freq, apb1_tim_freq) = match config.apb1_pre {
-        APBPrescaler::NotDivided => (ahb_freq, ahb_freq),
+        APBPrescaler::DIV1 => (ahb_freq, ahb_freq),
         pre => {
             let freq = ahb_freq / pre;
             (freq, Hertz(freq.0 * 2))
@@ -393,7 +393,7 @@ pub(crate) unsafe fn init(config: Config) {
     assert!(apb1_freq <= Hertz(30_000_000));
 
     let (apb2_freq, apb2_tim_freq) = match config.apb2_pre {
-        APBPrescaler::NotDivided => (ahb_freq, ahb_freq),
+        APBPrescaler::DIV1 => (ahb_freq, ahb_freq),
         pre => {
             let freq = ahb_freq / pre;
             (freq, Hertz(freq.0 * 2))

--- a/embassy-stm32/src/rcc/g0.rs
+++ b/embassy-stm32/src/rcc/g0.rs
@@ -186,8 +186,8 @@ impl Default for Config {
     fn default() -> Config {
         Config {
             mux: ClockSrc::HSI16(HSI16Prescaler::NotDivided),
-            ahb_pre: AHBPrescaler::NotDivided,
-            apb_pre: APBPrescaler::NotDivided,
+            ahb_pre: AHBPrescaler::DIV1,
+            apb_pre: APBPrescaler::DIV1,
             low_power_run: false,
         }
     }
@@ -377,7 +377,7 @@ pub(crate) unsafe fn init(config: Config) {
     let ahb_freq = Hertz(sys_clk) / config.ahb_pre;
 
     let (apb_freq, apb_tim_freq) = match config.apb_pre {
-        APBPrescaler::NotDivided => (ahb_freq.0, ahb_freq.0),
+        APBPrescaler::DIV1 => (ahb_freq.0, ahb_freq.0),
         pre => {
             let pre: Ppre = pre.into();
             let pre: u8 = 1 << (pre.to_bits() - 3);

--- a/embassy-stm32/src/rcc/h7.rs
+++ b/embassy-stm32/src/rcc/h7.rs
@@ -6,7 +6,7 @@ use stm32_metapac::rcc::vals::{Mco1, Mco2};
 
 use crate::gpio::sealed::AFType;
 use crate::gpio::Speed;
-use crate::pac::rcc::vals::{Adcsel, Ckpersel, Dppre, Hpre, Hsidiv, Pllsrc, Sw, Timpre};
+use crate::pac::rcc::vals::{Adcsel, Ckpersel, Hpre, Hsidiv, Pllsrc, Ppre, Sw, Timpre};
 use crate::pac::{PWR, RCC, SYSCFG};
 use crate::rcc::{set_freqs, Clocks};
 use crate::time::Hertz;
@@ -631,7 +631,7 @@ pub(crate) unsafe fn init(mut config: Config) {
     // Core Prescaler / AHB Prescaler / APB3 Prescaler
     RCC.d1cfgr().modify(|w| {
         w.set_d1cpre(Hpre::from_bits(d1cpre_bits));
-        w.set_d1ppre(Dppre::from_bits(ppre3_bits));
+        w.set_d1ppre(Ppre::from_bits(ppre3_bits));
         w.set_hpre(hpre_bits)
     });
     // Ensure core prescaler value is valid before future lower
@@ -642,12 +642,12 @@ pub(crate) unsafe fn init(mut config: Config) {
 
     // APB1 / APB2 Prescaler
     RCC.d2cfgr().modify(|w| {
-        w.set_d2ppre1(Dppre::from_bits(ppre1_bits));
-        w.set_d2ppre2(Dppre::from_bits(ppre2_bits));
+        w.set_d2ppre1(Ppre::from_bits(ppre1_bits));
+        w.set_d2ppre2(Ppre::from_bits(ppre2_bits));
     });
 
     // APB4 Prescaler
-    RCC.d3cfgr().modify(|w| w.set_d3ppre(Dppre::from_bits(ppre4_bits)));
+    RCC.d3cfgr().modify(|w| w.set_d3ppre(Ppre::from_bits(ppre4_bits)));
 
     // Peripheral Clock (per_ck)
     RCC.d1ccipr().modify(|w| w.set_ckpersel(ckpersel));

--- a/embassy-stm32/src/rcc/l0.rs
+++ b/embassy-stm32/src/rcc/l0.rs
@@ -145,9 +145,9 @@ impl Default for Config {
     fn default() -> Config {
         Config {
             mux: ClockSrc::MSI(MSIRange::default()),
-            ahb_pre: AHBPrescaler::NotDivided,
-            apb1_pre: APBPrescaler::NotDivided,
-            apb2_pre: APBPrescaler::NotDivided,
+            ahb_pre: AHBPrescaler::DIV1,
+            apb1_pre: APBPrescaler::DIV1,
+            apb2_pre: APBPrescaler::DIV1,
             #[cfg(crs)]
             enable_hsi48: false,
             rtc: None,
@@ -247,7 +247,7 @@ pub(crate) unsafe fn init(config: Config) {
     });
 
     let ahb_freq: u32 = match config.ahb_pre {
-        AHBPrescaler::NotDivided => sys_clk,
+        AHBPrescaler::DIV1 => sys_clk,
         pre => {
             let pre: Hpre = pre.into();
             let pre = 1 << (pre.to_bits() as u32 - 7);
@@ -256,7 +256,7 @@ pub(crate) unsafe fn init(config: Config) {
     };
 
     let (apb1_freq, apb1_tim_freq) = match config.apb1_pre {
-        APBPrescaler::NotDivided => (ahb_freq, ahb_freq),
+        APBPrescaler::DIV1 => (ahb_freq, ahb_freq),
         pre => {
             let pre: Ppre = pre.into();
             let pre: u8 = 1 << (pre.to_bits() - 3);
@@ -266,7 +266,7 @@ pub(crate) unsafe fn init(config: Config) {
     };
 
     let (apb2_freq, apb2_tim_freq) = match config.apb2_pre {
-        APBPrescaler::NotDivided => (ahb_freq, ahb_freq),
+        APBPrescaler::DIV1 => (ahb_freq, ahb_freq),
         pre => {
             let pre: Ppre = pre.into();
             let pre: u8 = 1 << (pre.to_bits() - 3);

--- a/embassy-stm32/src/rcc/l1.rs
+++ b/embassy-stm32/src/rcc/l1.rs
@@ -138,9 +138,9 @@ impl Default for Config {
     fn default() -> Config {
         Config {
             mux: ClockSrc::MSI(MSIRange::default()),
-            ahb_pre: AHBPrescaler::NotDivided,
-            apb1_pre: APBPrescaler::NotDivided,
-            apb2_pre: APBPrescaler::NotDivided,
+            ahb_pre: AHBPrescaler::DIV1,
+            apb1_pre: APBPrescaler::DIV1,
+            apb2_pre: APBPrescaler::DIV1,
         }
     }
 }
@@ -240,7 +240,7 @@ pub(crate) unsafe fn init(config: Config) {
     });
 
     let ahb_freq: u32 = match config.ahb_pre {
-        AHBPrescaler::NotDivided => sys_clk,
+        AHBPrescaler::DIV1 => sys_clk,
         pre => {
             let pre: Hpre = pre.into();
             let pre = 1 << (pre.to_bits() as u32 - 7);
@@ -249,7 +249,7 @@ pub(crate) unsafe fn init(config: Config) {
     };
 
     let (apb1_freq, apb1_tim_freq) = match config.apb1_pre {
-        APBPrescaler::NotDivided => (ahb_freq, ahb_freq),
+        APBPrescaler::DIV1 => (ahb_freq, ahb_freq),
         pre => {
             let pre: Ppre = pre.into();
             let pre: u8 = 1 << (pre.to_bits() - 3);
@@ -259,7 +259,7 @@ pub(crate) unsafe fn init(config: Config) {
     };
 
     let (apb2_freq, apb2_tim_freq) = match config.apb2_pre {
-        APBPrescaler::NotDivided => (ahb_freq, ahb_freq),
+        APBPrescaler::DIV1 => (ahb_freq, ahb_freq),
         pre => {
             let pre: Ppre = pre.into();
             let pre: u8 = 1 << (pre.to_bits() - 3);

--- a/embassy-stm32/src/rcc/l4.rs
+++ b/embassy-stm32/src/rcc/l4.rs
@@ -248,9 +248,9 @@ impl Default for Config {
     fn default() -> Config {
         Config {
             mux: ClockSrc::MSI(MSIRange::Range6),
-            ahb_pre: AHBPrescaler::NotDivided,
-            apb1_pre: APBPrescaler::NotDivided,
-            apb2_pre: APBPrescaler::NotDivided,
+            ahb_pre: AHBPrescaler::DIV1,
+            apb1_pre: APBPrescaler::DIV1,
+            apb2_pre: APBPrescaler::DIV1,
             pllsai1: None,
             #[cfg(not(any(stm32l471, stm32l475, stm32l476, stm32l486)))]
             hsi48: false,
@@ -576,7 +576,7 @@ pub(crate) unsafe fn init(config: Config) {
     });
 
     let ahb_freq: u32 = match config.ahb_pre {
-        AHBPrescaler::NotDivided => sys_clk,
+        AHBPrescaler::DIV1 => sys_clk,
         pre => {
             let pre: Hpre = pre.into();
             let pre = 1 << (pre.to_bits() as u32 - 7);
@@ -585,7 +585,7 @@ pub(crate) unsafe fn init(config: Config) {
     };
 
     let (apb1_freq, apb1_tim_freq) = match config.apb1_pre {
-        APBPrescaler::NotDivided => (ahb_freq, ahb_freq),
+        APBPrescaler::DIV1 => (ahb_freq, ahb_freq),
         pre => {
             let pre: Ppre = pre.into();
             let pre: u8 = 1 << (pre.to_bits() - 3);
@@ -595,7 +595,7 @@ pub(crate) unsafe fn init(config: Config) {
     };
 
     let (apb2_freq, apb2_tim_freq) = match config.apb2_pre {
-        APBPrescaler::NotDivided => (ahb_freq, ahb_freq),
+        APBPrescaler::DIV1 => (ahb_freq, ahb_freq),
         pre => {
             let pre: Ppre = pre.into();
             let pre: u8 = 1 << (pre.to_bits() - 3);

--- a/embassy-stm32/src/rcc/l5.rs
+++ b/embassy-stm32/src/rcc/l5.rs
@@ -238,9 +238,9 @@ impl Default for Config {
     fn default() -> Config {
         Config {
             mux: ClockSrc::MSI(MSIRange::Range6),
-            ahb_pre: AHBPrescaler::NotDivided,
-            apb1_pre: APBPrescaler::NotDivided,
-            apb2_pre: APBPrescaler::NotDivided,
+            ahb_pre: AHBPrescaler::DIV1,
+            apb1_pre: APBPrescaler::DIV1,
+            apb2_pre: APBPrescaler::DIV1,
             pllsai1: None,
             hsi48: false,
         }
@@ -407,7 +407,7 @@ pub(crate) unsafe fn init(config: Config) {
     });
 
     let ahb_freq: u32 = match config.ahb_pre {
-        AHBPrescaler::NotDivided => sys_clk,
+        AHBPrescaler::DIV1 => sys_clk,
         pre => {
             let pre: Hpre = pre.into();
             let pre = 1 << (pre.to_bits() as u32 - 7);
@@ -416,7 +416,7 @@ pub(crate) unsafe fn init(config: Config) {
     };
 
     let (apb1_freq, apb1_tim_freq) = match config.apb1_pre {
-        APBPrescaler::NotDivided => (ahb_freq, ahb_freq),
+        APBPrescaler::DIV1 => (ahb_freq, ahb_freq),
         pre => {
             let pre: Ppre = pre.into();
             let pre: u8 = 1 << (pre.to_bits() - 3);
@@ -426,7 +426,7 @@ pub(crate) unsafe fn init(config: Config) {
     };
 
     let (apb2_freq, apb2_tim_freq) = match config.apb2_pre {
-        APBPrescaler::NotDivided => (ahb_freq, ahb_freq),
+        APBPrescaler::DIV1 => (ahb_freq, ahb_freq),
         pre => {
             let pre: Ppre = pre.into();
             let pre: u8 = 1 << (pre.to_bits() - 3);

--- a/embassy-stm32/src/rcc/u5.rs
+++ b/embassy-stm32/src/rcc/u5.rs
@@ -119,46 +119,6 @@ impl Into<Pllm> for PllM {
     }
 }
 
-impl Into<u8> for AHBPrescaler {
-    fn into(self) -> u8 {
-        match self {
-            AHBPrescaler::NotDivided => 1,
-            AHBPrescaler::Div2 => 0x08,
-            AHBPrescaler::Div4 => 0x09,
-            AHBPrescaler::Div8 => 0x0a,
-            AHBPrescaler::Div16 => 0x0b,
-            AHBPrescaler::Div64 => 0x0c,
-            AHBPrescaler::Div128 => 0x0d,
-            AHBPrescaler::Div256 => 0x0e,
-            AHBPrescaler::Div512 => 0x0f,
-        }
-    }
-}
-
-impl Default for AHBPrescaler {
-    fn default() -> Self {
-        AHBPrescaler::NotDivided
-    }
-}
-
-impl Default for APBPrescaler {
-    fn default() -> Self {
-        APBPrescaler::NotDivided
-    }
-}
-
-impl Into<u8> for APBPrescaler {
-    fn into(self) -> u8 {
-        match self {
-            APBPrescaler::NotDivided => 1,
-            APBPrescaler::Div2 => 0x04,
-            APBPrescaler::Div4 => 0x05,
-            APBPrescaler::Div8 => 0x06,
-            APBPrescaler::Div16 => 0x07,
-        }
-    }
-}
-
 impl Into<Sw> for ClockSrc {
     fn into(self) -> Sw {
         match self {
@@ -239,10 +199,10 @@ impl Default for Config {
     fn default() -> Self {
         Self {
             mux: ClockSrc::MSI(MSIRange::default()),
-            ahb_pre: Default::default(),
-            apb1_pre: Default::default(),
-            apb2_pre: Default::default(),
-            apb3_pre: Default::default(),
+            ahb_pre: AHBPrescaler::DIV1,
+            apb1_pre: APBPrescaler::DIV1,
+            apb2_pre: APBPrescaler::DIV1,
+            apb3_pre: APBPrescaler::DIV1,
             hsi48: false,
         }
     }
@@ -395,7 +355,7 @@ pub(crate) unsafe fn init(config: Config) {
     });
 
     let ahb_freq: u32 = match config.ahb_pre {
-        AHBPrescaler::NotDivided => sys_clk,
+        AHBPrescaler::DIV1 => sys_clk,
         pre => {
             let pre: u8 = pre.into();
             let pre = 1 << (pre as u32 - 7);
@@ -404,7 +364,7 @@ pub(crate) unsafe fn init(config: Config) {
     };
 
     let (apb1_freq, apb1_tim_freq) = match config.apb1_pre {
-        APBPrescaler::NotDivided => (ahb_freq, ahb_freq),
+        APBPrescaler::DIV1 => (ahb_freq, ahb_freq),
         pre => {
             let pre: u8 = pre.into();
             let pre: u8 = 1 << (pre - 3);
@@ -414,7 +374,7 @@ pub(crate) unsafe fn init(config: Config) {
     };
 
     let (apb2_freq, apb2_tim_freq) = match config.apb2_pre {
-        APBPrescaler::NotDivided => (ahb_freq, ahb_freq),
+        APBPrescaler::DIV1 => (ahb_freq, ahb_freq),
         pre => {
             let pre: u8 = pre.into();
             let pre: u8 = 1 << (pre - 3);
@@ -424,7 +384,7 @@ pub(crate) unsafe fn init(config: Config) {
     };
 
     let (apb3_freq, _apb3_tim_freq) = match config.apb3_pre {
-        APBPrescaler::NotDivided => (ahb_freq, ahb_freq),
+        APBPrescaler::DIV1 => (ahb_freq, ahb_freq),
         pre => {
             let pre: u8 = pre.into();
             let pre: u8 = 1 << (pre - 3);

--- a/embassy-stm32/src/rcc/wb.rs
+++ b/embassy-stm32/src/rcc/wb.rs
@@ -145,11 +145,11 @@ pub const WPAN_DEFAULT: Config = Config {
     }),
     pllsai: None,
 
-    ahb1_pre: AHBPrescaler::NotDivided,
-    ahb2_pre: AHBPrescaler::Div2,
-    ahb3_pre: AHBPrescaler::NotDivided,
-    apb1_pre: APBPrescaler::NotDivided,
-    apb2_pre: APBPrescaler::NotDivided,
+    ahb1_pre: AHBPrescaler::DIV1,
+    ahb2_pre: AHBPrescaler::DIV2,
+    ahb3_pre: AHBPrescaler::DIV1,
+    apb1_pre: APBPrescaler::DIV1,
+    apb2_pre: APBPrescaler::DIV1,
 };
 
 impl Default for Config {
@@ -165,11 +165,11 @@ impl Default for Config {
             pllsai: None,
             rtc: None,
 
-            ahb1_pre: AHBPrescaler::NotDivided,
-            ahb2_pre: AHBPrescaler::NotDivided,
-            ahb3_pre: AHBPrescaler::NotDivided,
-            apb1_pre: APBPrescaler::NotDivided,
-            apb2_pre: APBPrescaler::NotDivided,
+            ahb1_pre: AHBPrescaler::DIV1,
+            ahb2_pre: AHBPrescaler::DIV1,
+            ahb3_pre: AHBPrescaler::DIV1,
+            apb1_pre: APBPrescaler::DIV1,
+            apb2_pre: APBPrescaler::DIV1,
         }
     }
 }
@@ -209,7 +209,7 @@ pub(crate) fn compute_clocks(config: &Config) -> Clocks {
     };
 
     let ahb1_clk = match config.ahb1_pre {
-        AHBPrescaler::NotDivided => sys_clk,
+        AHBPrescaler::DIV1 => sys_clk,
         pre => {
             let pre: u8 = pre.into();
             let pre = 1u32 << (pre as u32 - 7);
@@ -218,7 +218,7 @@ pub(crate) fn compute_clocks(config: &Config) -> Clocks {
     };
 
     let ahb2_clk = match config.ahb2_pre {
-        AHBPrescaler::NotDivided => sys_clk,
+        AHBPrescaler::DIV1 => sys_clk,
         pre => {
             let pre: u8 = pre.into();
             let pre = 1u32 << (pre as u32 - 7);
@@ -227,7 +227,7 @@ pub(crate) fn compute_clocks(config: &Config) -> Clocks {
     };
 
     let ahb3_clk = match config.ahb3_pre {
-        AHBPrescaler::NotDivided => sys_clk,
+        AHBPrescaler::DIV1 => sys_clk,
         pre => {
             let pre: u8 = pre.into();
             let pre = 1u32 << (pre as u32 - 7);
@@ -236,7 +236,7 @@ pub(crate) fn compute_clocks(config: &Config) -> Clocks {
     };
 
     let (apb1_clk, apb1_tim_clk) = match config.apb1_pre {
-        APBPrescaler::NotDivided => (ahb1_clk, ahb1_clk),
+        APBPrescaler::DIV1 => (ahb1_clk, ahb1_clk),
         pre => {
             let pre: u8 = pre.into();
             let pre: u8 = 1 << (pre - 3);
@@ -246,7 +246,7 @@ pub(crate) fn compute_clocks(config: &Config) -> Clocks {
     };
 
     let (apb2_clk, apb2_tim_clk) = match config.apb2_pre {
-        APBPrescaler::NotDivided => (ahb1_clk, ahb1_clk),
+        APBPrescaler::DIV1 => (ahb1_clk, ahb1_clk),
         pre => {
             let pre: u8 = pre.into();
             let pre: u8 = 1 << (pre - 3);

--- a/examples/stm32f2/src/bin/pll.rs
+++ b/examples/stm32f2/src/bin/pll.rs
@@ -39,9 +39,9 @@ async fn main(_spawner: Spawner) {
     // System clock comes from PLL (= the 120 MHz main PLL output)
     config.rcc.mux = ClockSrc::PLL;
     // 120 MHz / 4 = 30 MHz APB1 frequency
-    config.rcc.apb1_pre = APBPrescaler::Div4;
+    config.rcc.apb1_pre = APBPrescaler::DIV4;
     // 120 MHz / 2 = 60 MHz APB2 frequency
-    config.rcc.apb2_pre = APBPrescaler::Div2;
+    config.rcc.apb2_pre = APBPrescaler::DIV2;
 
     let _p = embassy_stm32::init(config);
 

--- a/examples/stm32h5/src/bin/eth.rs
+++ b/examples/stm32h5/src/bin/eth.rs
@@ -48,10 +48,10 @@ async fn main(spawner: Spawner) -> ! {
         divq: Some(2),
         divr: None,
     });
-    config.rcc.ahb_pre = AHBPrescaler::NotDivided;
-    config.rcc.apb1_pre = APBPrescaler::NotDivided;
-    config.rcc.apb2_pre = APBPrescaler::NotDivided;
-    config.rcc.apb3_pre = APBPrescaler::NotDivided;
+    config.rcc.ahb_pre = AHBPrescaler::DIV1;
+    config.rcc.apb1_pre = APBPrescaler::DIV1;
+    config.rcc.apb2_pre = APBPrescaler::DIV1;
+    config.rcc.apb3_pre = APBPrescaler::DIV1;
     config.rcc.sys = Sysclk::Pll1P;
     config.rcc.voltage_scale = VoltageScale::Scale0;
     let p = embassy_stm32::init(config);

--- a/examples/stm32h5/src/bin/usb_serial.rs
+++ b/examples/stm32h5/src/bin/usb_serial.rs
@@ -35,10 +35,10 @@ async fn main(_spawner: Spawner) {
         divq: None,
         divr: None,
     });
-    config.rcc.ahb_pre = AHBPrescaler::Div2;
-    config.rcc.apb1_pre = APBPrescaler::Div4;
-    config.rcc.apb2_pre = APBPrescaler::Div2;
-    config.rcc.apb3_pre = APBPrescaler::Div4;
+    config.rcc.ahb_pre = AHBPrescaler::DIV2;
+    config.rcc.apb1_pre = APBPrescaler::DIV4;
+    config.rcc.apb2_pre = APBPrescaler::DIV2;
+    config.rcc.apb3_pre = APBPrescaler::DIV4;
     config.rcc.sys = Sysclk::Pll1P;
     config.rcc.voltage_scale = VoltageScale::Scale0;
     let p = embassy_stm32::init(config);


### PR DESCRIPTION
this may require the addition of enums in metapac.

- [x] rcc_c0
- [x] rcc_f0
- [ ] rcc_f1 - ppre1
- [ ] rcc_f1cl - ppre1
- [x] rcc_f2
- [x] rcc_f3_v2
- [x] rcc_f4
- [x] rcc_f7
- [ ] rcc_f100 - ppre1
- [x] rcc_f410
- [x] rcc_g0
- [x] rcc_g4
- [x] rcc_h5
- [ ] rcc_h7 - dppre
- [ ] rcc_h7ab - dppre
- [x] rcc_h50
- [x] rcc_l0
- [x] rcc_l1
- [x] rcc_l4
- [x] rcc_l5
- [x] rcc_u5
- [ ] rcc_wb - ppre and  hpre does not exist
- [ ] rcc_wl5 - ppre and  hpre does not exist
- [ ] rcc_wle - ppre and  hpre does not exist