### PR TITLE
stm32: Implement `set_config` for Uart structs

### DIFF
--- a/embassy-stm32/src/spi/mod.rs
+++ b/embassy-stm32/src/spi/mod.rs
@@ -323,7 +323,7 @@ impl<'d, T: Instance, Tx, Rx> Spi<'d, T, Tx, Rx> {
     }
 
     /// Reconfigures it with the supplied config.
-    pub fn reconfigure(&mut self, config: Config) {
+    pub fn set_config(&mut self, config: Config) {
         let cpha = config.raw_phase();
         let cpol = config.raw_polarity();
 
@@ -1062,6 +1062,6 @@ foreach_peripheral!(
 impl<'d, T: Instance, Tx, Rx> SetConfig for Spi<'d, T, Tx, Rx> {
     type Config = Config;
     fn set_config(&mut self, config: &Self::Config) {
-        self.reconfigure(*config);
+        self.set_config(*config);
     }
 }

--- a/embassy-stm32/src/usart/buffered.rs
+++ b/embassy-stm32/src/usart/buffered.rs
@@ -114,6 +114,30 @@ pub struct BufferedUartRx<'d, T: BasicInstance> {
     phantom: PhantomData<&'d mut T>,
 }
 
+impl<'d, T: BasicInstance> SetConfig for BufferedUart<'d, T> {
+    type Config = Config;
+
+    fn set_config(&mut self, config: &Self::Config) {
+        self.set_config(config)
+    }
+}
+
+impl<'d, T: BasicInstance> SetConfig for BufferedUartRx<'d, T> {
+    type Config = Config;
+
+    fn set_config(&mut self, config: &Self::Config) {
+        self.set_config(config)
+    }
+}
+
+impl<'d, T: BasicInstance> SetConfig for BufferedUartTx<'d, T> {
+    type Config = Config;
+
+    fn set_config(&mut self, config: &Self::Config) {
+        self.set_config(config)
+    }
+}
+
 impl<'d, T: BasicInstance> BufferedUart<'d, T> {
     pub fn new(
         peri: impl Peripheral<P = T> + 'd,
@@ -228,6 +252,10 @@ impl<'d, T: BasicInstance> BufferedUart<'d, T> {
     pub fn split(self) -> (BufferedUartTx<'d, T>, BufferedUartRx<'d, T>) {
         (self.tx, self.rx)
     }
+
+    pub fn set_config(&mut self, config: &Config) {
+        reconfigure::<T>(config)
+    }
 }
 
 impl<'d, T: BasicInstance> BufferedUartRx<'d, T> {
@@ -304,6 +332,10 @@ impl<'d, T: BasicInstance> BufferedUartRx<'d, T> {
             T::Interrupt::pend();
         }
     }
+
+    pub fn set_config(&mut self, config: &Config) {
+        reconfigure::<T>(config)
+    }
 }
 
 impl<'d, T: BasicInstance> BufferedUartTx<'d, T> {
@@ -373,6 +405,10 @@ impl<'d, T: BasicInstance> BufferedUartTx<'d, T> {
                 return Ok(());
             }
         }
+    }
+
+    pub fn set_config(&mut self, config: &Config) {
+        reconfigure::<T>(config)
     }
 }
 


### PR DESCRIPTION
Allows the uart to be reconfigured after initialization. 