### PR TITLE
stm32/f2: Fix typo in RCC voltage range docs

### DIFF
--- a/embassy-stm32/src/rcc/f2.rs
+++ b/embassy-stm32/src/rcc/f2.rs
@@ -208,13 +208,13 @@ pub struct PLLClocks {
 /// Used to calculate flash waitstates. See
 /// RM0033 - Table 3. Number of wait states according to Cortex®-M3 clock frequency
 pub enum VoltageScale {
-    /// 2.7v to 4.6v
+    /// 2.7 to 3.6 V
     Range0,
-    /// 2.4v to 2.7v
+    /// 2.4 to 2.7 V
     Range1,
-    /// 2.1v to 2.4v
+    /// 2.1 to 2.4 V
     Range2,
-    /// 1.8v to 2.1v
+    /// 1.8 to 2.1 V
     Range3,
 }
 


### PR DESCRIPTION
According to [RM0033](https://www.st.com/resource/en/reference_manual/rm0033-stm32f205xx-stm32f207xx-stm32f215xx-and-stm32f217xx-advanced-armbased-32bit-mcus-stmicroelectronics.pdf), the top voltage range goes to 3.6 V instead of 4.6 V. I also adjusted the wording to match the table headers (with regards to the unit "V"):

<img width="639" alt="Screenshot 2023-09-19 at 10 17 58" src="https://github.com/embassy-rs/embassy/assets/1277035/b2c394f3-63ac-4532-8bc9-d1b6c3a02ce9">