### PR TITLE
stm32: more adc cleanup

### DIFF
--- a/examples/stm32f0/src/bin/adc.rs
+++ b/examples/stm32f0/src/bin/adc.rs
@@ -24,7 +24,7 @@ async fn main(_spawner: Spawner) {
     let mut pin = p.PA1;
 
     let mut vrefint = adc.enable_vref(&mut Delay);
-    let vrefint_sample = adc.read_internal(&mut vrefint).await;
+    let vrefint_sample = adc.read(&mut vrefint).await;
     let convert_to_millivolts = |sample| {
         // From https://www.st.com/resource/en/datasheet/stm32f031c6.pdf
         // 6.3.4 Embedded reference voltage

--- a/examples/stm32f4/src/bin/adc.rs
+++ b/examples/stm32f4/src/bin/adc.rs
@@ -24,7 +24,7 @@ async fn main(_spawner: Spawner) {
     // Startup delay can be combined to the maximum of either
     delay.delay_us(Temperature::start_time_us().max(VrefInt::start_time_us()));
 
-    let vrefint_sample = adc.read_internal(&mut vrefint);
+    let vrefint_sample = adc.read(&mut vrefint);
 
     let convert_to_millivolts = |sample| {
         // From http://www.st.com/resource/en/datasheet/DM00071990.pdf
@@ -55,12 +55,12 @@ async fn main(_spawner: Spawner) {
         info!("PC1: {} ({} mV)", v, convert_to_millivolts(v));
 
         // Read internal temperature
-        let v = adc.read_internal(&mut temp);
+        let v = adc.read(&mut temp);
         let celcius = convert_to_celcius(v);
         info!("Internal temp: {} ({} C)", v, celcius);
 
         // Read internal voltage reference
-        let v = adc.read_internal(&mut vrefint);
+        let v = adc.read(&mut vrefint);
         info!("VrefInt: {}", v);
 
         Timer::after(Duration::from_millis(100)).await;

--- a/examples/stm32f7/src/bin/adc.rs
+++ b/examples/stm32f7/src/bin/adc.rs
@@ -17,7 +17,7 @@ async fn main(_spawner: Spawner) {
     let mut pin = p.PA3;
 
     let mut vrefint = adc.enable_vrefint();
-    let vrefint_sample = adc.read_internal(&mut vrefint);
+    let vrefint_sample = adc.read(&mut vrefint);
     let convert_to_millivolts = |sample| {
         // From http://www.st.com/resource/en/datasheet/DM00273119.pdf
         // 6.3.27 Reference voltage


### PR DESCRIPTION
- [ ] implement drop for all adcs
- [ ] fix adc v3 to leave adc enabled until drop
- [ ] move conversion to async for all adcs
- [ ] move to read method and remove `InternalChannel`