### PR TITLE
stm32: fix rtc example

### DIFF
--- a/examples/stm32f4/src/bin/rtc.rs
+++ b/examples/stm32f4/src/bin/rtc.rs
@@ -13,6 +13,7 @@ use {defmt_rtt as _, panic_probe as _};
 #[embassy_executor::main]
 async fn main(_spawner: Spawner) {
     let mut config = Config::default();
+    config.rcc.lsi = true;
     config.rcc.rtc = Option::Some(RtcClockSource::LSI);
     let p = embassy_stm32::init(config);
 


### PR DESCRIPTION
lsi must be enabled otherwise a assertion fails