### PR TITLE
Update rust-lorawan and embassy to use lora-phy version 2

### DIFF
--- a/embassy-lora/Cargo.toml
+++ b/embassy-lora/Cargo.toml
@@ -28,7 +28,4 @@ embedded-hal = { version = "0.2", features = ["unproven"] }
 
 futures = { version = "0.3.17", default-features = false, features = [ "async-await" ] }
 lora-phy = { version = "2" }
-lorawan-device = { version = "0.10.0", default-features = false, features = ["async"], optional = true }
-
-[patch.crates-io]
-lorawan-device = { git = "https://github.com/ivajloip/rust-lorawan", rev = "b0502c1a802427638cc8bcd928fc632d13b778b6"}
+lorawan-device = { version = "0.11.0", default-features = false, features = ["async"], optional = true }

--- a/embassy-lora/Cargo.toml
+++ b/embassy-lora/Cargo.toml
@@ -27,8 +27,8 @@ embedded-hal-async = { version = "=1.0.0-rc.1" }
 embedded-hal = { version = "0.2", features = ["unproven"] }
 
 futures = { version = "0.3.17", default-features = false, features = [ "async-await" ] }
-lora-phy = { version = "1" }
+lora-phy = { version = "2" }
 lorawan-device = { version = "0.10.0", default-features = false, features = ["async"], optional = true }
 
 [patch.crates-io]
-lora-phy = { git = "https://github.com/embassy-rs/lora-phy", rev = "1323eccc1c470d4259f95f4f315d1be830d572a3"}
+lorawan-device = { git = "https://github.com/ivajloip/rust-lorawan", rev = "b0502c1a802427638cc8bcd928fc632d13b778b6"}

--- a/examples/nrf52840/Cargo.toml
+++ b/examples/nrf52840/Cargo.toml
@@ -39,8 +39,8 @@ embedded-io = { version = "0.5.0", features = ["defmt-03"]  }
 embedded-io-async = { version = "0.5.0", optional = true, features = ["defmt-03"] }
 embassy-lora = { version = "0.1.0", path = "../../embassy-lora", features = ["time", "defmt"], optional = true }
 lora-phy = { version = "2", optional = true }
-lorawan-device = { version = "0.10.0", default-features = false, features = ["async", "external-lora-phy"], optional = true }
-lorawan = { version = "0.7.3", default-features = false, features = ["default-crypto"], optional = true }
+lorawan-device = { version = "0.11.0", default-features = false, features = ["async", "external-lora-phy"], optional = true }
+lorawan = { version = "0.7.4", default-features = false, features = ["default-crypto"], optional = true }
 embassy-net-esp-hosted = { version = "0.1.0", path = "../../embassy-net-esp-hosted", features = ["defmt"], optional = true }
 embassy-net-enc28j60 = { version = "0.1.0", path = "../../embassy-net-enc28j60", features = ["defmt"], optional = true }
 
@@ -65,7 +65,3 @@ microfft = "0.5.0"
 
 [profile.release]
 debug = 2
-
-[patch.crates-io]
-lorawan-device = { git = "https://github.com/ivajloip/rust-lorawan", rev = "b0502c1a802427638cc8bcd928fc632d13b778b6"}
-lorawan = { git = "https://github.com/ivajloip/rust-lorawan", rev = "b0502c1a802427638cc8bcd928fc632d13b778b6"}

--- a/examples/nrf52840/Cargo.toml
+++ b/examples/nrf52840/Cargo.toml
@@ -38,7 +38,7 @@ embassy-usb = { version = "0.1.0", path = "../../embassy-usb", features = ["defm
 embedded-io = { version = "0.5.0", features = ["defmt-03"]  }
 embedded-io-async = { version = "0.5.0", optional = true, features = ["defmt-03"] }
 embassy-lora = { version = "0.1.0", path = "../../embassy-lora", features = ["time", "defmt"], optional = true }
-lora-phy = { version = "1", optional = true }
+lora-phy = { version = "2", optional = true }
 lorawan-device = { version = "0.10.0", default-features = false, features = ["async", "external-lora-phy"], optional = true }
 lorawan = { version = "0.7.3", default-features = false, features = ["default-crypto"], optional = true }
 embassy-net-esp-hosted = { version = "0.1.0", path = "../../embassy-net-esp-hosted", features = ["defmt"], optional = true }
@@ -67,4 +67,5 @@ microfft = "0.5.0"
 debug = 2
 
 [patch.crates-io]
-lora-phy = { git = "https://github.com/embassy-rs/lora-phy", rev = "1323eccc1c470d4259f95f4f315d1be830d572a3"}
+lorawan-device = { git = "https://github.com/ivajloip/rust-lorawan", rev = "b0502c1a802427638cc8bcd928fc632d13b778b6"}
+lorawan = { git = "https://github.com/ivajloip/rust-lorawan", rev = "b0502c1a802427638cc8bcd928fc632d13b778b6"}

--- a/examples/nrf52840/src/bin/lora_cad.rs
+++ b/examples/nrf52840/src/bin/lora_cad.rs
@@ -41,10 +41,8 @@ async fn main(_spawner: Spawner) {
     let iv =
         GenericSx126xInterfaceVariant::new(nss, reset, dio1, busy, Some(rf_switch_rx), Some(rf_switch_tx)).unwrap();
 
-    let mut delay = Delay;
-
     let mut lora = {
-        match LoRa::new(SX1261_2::new(BoardType::Rak4631Sx1262, spim, iv), false, &mut delay).await {
+        match LoRa::new(SX1261_2::new(BoardType::Rak4631Sx1262, spim, iv), false, Delay).await {
             Ok(l) => l,
             Err(err) => {
                 info!("Radio error = {}", err);

--- a/examples/nrf52840/src/bin/lora_lorawan.rs
+++ b/examples/nrf52840/src/bin/lora_lorawan.rs
@@ -20,6 +20,7 @@ use lora_phy::LoRa;
 use lorawan::default_crypto::DefaultFactory as Crypto;
 use lorawan_device::async_device::lora_radio::LoRaRadio;
 use lorawan_device::async_device::{region, Device, JoinMode};
+use lorawan_device::{AppEui, AppKey, DevEui};
 use {defmt_rtt as _, panic_probe as _};
 
 const LORAWAN_REGION: region::Region = region::Region::EU868; // warning: set this appropriately for the region
@@ -47,10 +48,8 @@ async fn main(_spawner: Spawner) {
     let iv =
         GenericSx126xInterfaceVariant::new(nss, reset, dio1, busy, Some(rf_switch_rx), Some(rf_switch_tx)).unwrap();
 
-    let mut delay = Delay;
-
     let lora = {
-        match LoRa::new(SX1261_2::new(BoardType::Rak4631Sx1262, spim, iv), true, &mut delay).await {
+        match LoRa::new(SX1261_2::new(BoardType::Rak4631Sx1262, spim, iv), true, Delay).await {
             Ok(l) => l,
             Err(err) => {
                 info!("Radio error = {}", err);
@@ -68,9 +67,9 @@ async fn main(_spawner: Spawner) {
     // TODO: Adjust the EUI and Keys according to your network credentials
     match device
         .join(&JoinMode::OTAA {
-            deveui: [0, 0, 0, 0, 0, 0, 0, 0],
-            appeui: [0, 0, 0, 0, 0, 0, 0, 0],
-            appkey: [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+            deveui: DevEui::from([0, 0, 0, 0, 0, 0, 0, 0]),
+            appeui: AppEui::from([0, 0, 0, 0, 0, 0, 0, 0]),
+            appkey: AppKey::from([0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]),
         })
         .await
     {

--- a/examples/nrf52840/src/bin/lora_p2p_receive.rs
+++ b/examples/nrf52840/src/bin/lora_p2p_receive.rs
@@ -41,10 +41,8 @@ async fn main(_spawner: Spawner) {
     let iv =
         GenericSx126xInterfaceVariant::new(nss, reset, dio1, busy, Some(rf_switch_rx), Some(rf_switch_tx)).unwrap();
 
-    let mut delay = Delay;
-
     let mut lora = {
-        match LoRa::new(SX1261_2::new(BoardType::Rak4631Sx1262, spim, iv), false, &mut delay).await {
+        match LoRa::new(SX1261_2::new(BoardType::Rak4631Sx1262, spim, iv), false, Delay).await {
             Ok(l) => l,
             Err(err) => {
                 info!("Radio error = {}", err);
@@ -88,7 +86,7 @@ async fn main(_spawner: Spawner) {
     };
 
     match lora
-        .prepare_for_rx(&mdltn_params, &rx_pkt_params, None, true, false, 0, 0x00ffffffu32)
+        .prepare_for_rx(&mdltn_params, &rx_pkt_params, None, None, false)
         .await
     {
         Ok(()) => {}

--- a/examples/nrf52840/src/bin/lora_p2p_receive_duty_cycle.rs
+++ b/examples/nrf52840/src/bin/lora_p2p_receive_duty_cycle.rs
@@ -41,10 +41,8 @@ async fn main(_spawner: Spawner) {
     let iv =
         GenericSx126xInterfaceVariant::new(nss, reset, dio1, busy, Some(rf_switch_rx), Some(rf_switch_tx)).unwrap();
 
-    let mut delay = Delay;
-
     let mut lora = {
-        match LoRa::new(SX1261_2::new(BoardType::Rak4631Sx1262, spim, iv), false, &mut delay).await {
+        match LoRa::new(SX1261_2::new(BoardType::Rak4631Sx1262, spim, iv), false, Delay).await {
             Ok(l) => l,
             Err(err) => {
                 info!("Radio error = {}", err);
@@ -92,14 +90,12 @@ async fn main(_spawner: Spawner) {
         .prepare_for_rx(
             &mdltn_params,
             &rx_pkt_params,
+            None,
             Some(&DutyCycleParams {
                 rx_time: 300_000,    // 300_000 units * 15.625 us/unit = 4.69 s
                 sleep_time: 200_000, // 200_000 units * 15.625 us/unit = 3.13 s
             }),
             false,
-            false,
-            0,
-            0,
         )
         .await
     {

--- a/examples/nrf52840/src/bin/lora_p2p_send.rs
+++ b/examples/nrf52840/src/bin/lora_p2p_send.rs
@@ -41,10 +41,8 @@ async fn main(_spawner: Spawner) {
     let iv =
         GenericSx126xInterfaceVariant::new(nss, reset, dio1, busy, Some(rf_switch_rx), Some(rf_switch_tx)).unwrap();
 
-    let mut delay = Delay;
-
     let mut lora = {
-        match LoRa::new(SX1261_2::new(BoardType::Rak4631Sx1262, spim, iv), false, &mut delay).await {
+        match LoRa::new(SX1261_2::new(BoardType::Rak4631Sx1262, spim, iv), false, Delay).await {
             Ok(l) => l,
             Err(err) => {
                 info!("Radio error = {}", err);
@@ -97,7 +95,7 @@ async fn main(_spawner: Spawner) {
         }
     };
 
-    match lora.sleep(&mut delay).await {
+    match lora.sleep(false).await {
         Ok(()) => info!("Sleep successful"),
         Err(err) => info!("Sleep unsuccessful = {}", err),
     }

--- a/examples/rp/Cargo.toml
+++ b/examples/rp/Cargo.toml
@@ -18,8 +18,8 @@ embassy-futures = { version = "0.1.0", path = "../../embassy-futures" }
 embassy-usb-logger = { version = "0.1.0", path = "../../embassy-usb-logger" }
 embassy-lora = { version = "0.1.0", path = "../../embassy-lora", features = ["time", "defmt"] }
 lora-phy = { version = "2" }
-lorawan-device = { version = "0.10.0", default-features = false, features = ["async", "external-lora-phy"] }
-lorawan = { version = "0.7.3", default-features = false, features = ["default-crypto"] }
+lorawan-device = { version = "0.11.0", default-features = false, features = ["async", "external-lora-phy"] }
+lorawan = { version = "0.7.4", default-features = false, features = ["default-crypto"] }
 cyw43 = { path = "../../cyw43", features = ["defmt", "firmware-logs"] }
 cyw43-pio = { path = "../../cyw43-pio", features = ["defmt", "overclock"] }
 
@@ -55,7 +55,3 @@ rand = { version = "0.8.5", default-features = false }
 
 [profile.release]
 debug = 2
-
-[patch.crates-io]
-lorawan-device = { git = "https://github.com/ivajloip/rust-lorawan", rev = "b0502c1a802427638cc8bcd928fc632d13b778b6"}
-lorawan = { git = "https://github.com/ivajloip/rust-lorawan", rev = "b0502c1a802427638cc8bcd928fc632d13b778b6"}

--- a/examples/rp/Cargo.toml
+++ b/examples/rp/Cargo.toml
@@ -17,7 +17,7 @@ embassy-net-wiznet = { version = "0.1.0", path = "../../embassy-net-wiznet", fea
 embassy-futures = { version = "0.1.0", path = "../../embassy-futures" }
 embassy-usb-logger = { version = "0.1.0", path = "../../embassy-usb-logger" }
 embassy-lora = { version = "0.1.0", path = "../../embassy-lora", features = ["time", "defmt"] }
-lora-phy = { version = "1" }
+lora-phy = { version = "2" }
 lorawan-device = { version = "0.10.0", default-features = false, features = ["async", "external-lora-phy"] }
 lorawan = { version = "0.7.3", default-features = false, features = ["default-crypto"] }
 cyw43 = { path = "../../cyw43", features = ["defmt", "firmware-logs"] }
@@ -57,4 +57,5 @@ rand = { version = "0.8.5", default-features = false }
 debug = 2
 
 [patch.crates-io]
-lora-phy = { git = "https://github.com/embassy-rs/lora-phy", rev = "1323eccc1c470d4259f95f4f315d1be830d572a3"}
+lorawan-device = { git = "https://github.com/ivajloip/rust-lorawan", rev = "b0502c1a802427638cc8bcd928fc632d13b778b6"}
+lorawan = { git = "https://github.com/ivajloip/rust-lorawan", rev = "b0502c1a802427638cc8bcd928fc632d13b778b6"}

--- a/examples/rp/src/bin/lora_lorawan.rs
+++ b/examples/rp/src/bin/lora_lorawan.rs
@@ -19,6 +19,7 @@ use lora_phy::LoRa;
 use lorawan::default_crypto::DefaultFactory as Crypto;
 use lorawan_device::async_device::lora_radio::LoRaRadio;
 use lorawan_device::async_device::{region, Device, JoinMode};
+use lorawan_device::{AppEui, AppKey, DevEui};
 use {defmt_rtt as _, panic_probe as _};
 
 const LORAWAN_REGION: region::Region = region::Region::EU868; // warning: set this appropriately for the region
@@ -39,16 +40,8 @@ async fn main(_spawner: Spawner) {
 
     let iv = GenericSx126xInterfaceVariant::new(nss, reset, dio1, busy, None, None).unwrap();
 
-    let mut delay = Delay;
-
     let lora = {
-        match LoRa::new(
-            SX1261_2::new(BoardType::RpPicoWaveshareSx1262, spi, iv),
-            true,
-            &mut delay,
-        )
-        .await
-        {
+        match LoRa::new(SX1261_2::new(BoardType::RpPicoWaveshareSx1262, spi, iv), true, Delay).await {
             Ok(l) => l,
             Err(err) => {
                 info!("Radio error = {}", err);
@@ -66,9 +59,9 @@ async fn main(_spawner: Spawner) {
     // TODO: Adjust the EUI and Keys according to your network credentials
     match device
         .join(&JoinMode::OTAA {
-            deveui: [0, 0, 0, 0, 0, 0, 0, 0],
-            appeui: [0, 0, 0, 0, 0, 0, 0, 0],
-            appkey: [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+            deveui: DevEui::from([0, 0, 0, 0, 0, 0, 0, 0]),
+            appeui: AppEui::from([0, 0, 0, 0, 0, 0, 0, 0]),
+            appkey: AppKey::from([0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]),
         })
         .await
     {

--- a/examples/rp/src/bin/lora_p2p_receive.rs
+++ b/examples/rp/src/bin/lora_p2p_receive.rs
@@ -35,16 +35,8 @@ async fn main(_spawner: Spawner) {
 
     let iv = GenericSx126xInterfaceVariant::new(nss, reset, dio1, busy, None, None).unwrap();
 
-    let mut delay = Delay;
-
     let mut lora = {
-        match LoRa::new(
-            SX1261_2::new(BoardType::RpPicoWaveshareSx1262, spi, iv),
-            false,
-            &mut delay,
-        )
-        .await
-        {
+        match LoRa::new(SX1261_2::new(BoardType::RpPicoWaveshareSx1262, spi, iv), false, Delay).await {
             Ok(l) => l,
             Err(err) => {
                 info!("Radio error = {}", err);
@@ -83,7 +75,7 @@ async fn main(_spawner: Spawner) {
     };
 
     match lora
-        .prepare_for_rx(&mdltn_params, &rx_pkt_params, None, true, false, 0, 0x00ffffffu32)
+        .prepare_for_rx(&mdltn_params, &rx_pkt_params, None, None, false)
         .await
     {
         Ok(()) => {}

--- a/examples/rp/src/bin/lora_p2p_send.rs
+++ b/examples/rp/src/bin/lora_p2p_send.rs
@@ -35,16 +35,8 @@ async fn main(_spawner: Spawner) {
 
     let iv = GenericSx126xInterfaceVariant::new(nss, reset, dio1, busy, None, None).unwrap();
 
-    let mut delay = Delay;
-
     let mut lora = {
-        match LoRa::new(
-            SX1261_2::new(BoardType::RpPicoWaveshareSx1262, spi, iv),
-            false,
-            &mut delay,
-        )
-        .await
-        {
+        match LoRa::new(SX1261_2::new(BoardType::RpPicoWaveshareSx1262, spi, iv), false, Delay).await {
             Ok(l) => l,
             Err(err) => {
                 info!("Radio error = {}", err);
@@ -97,7 +89,7 @@ async fn main(_spawner: Spawner) {
         }
     };
 
-    match lora.sleep(&mut delay).await {
+    match lora.sleep(false).await {
         Ok(()) => info!("Sleep successful"),
         Err(err) => info!("Sleep unsuccessful = {}", err),
     }

--- a/examples/rp/src/bin/lora_p2p_send_multicore.rs
+++ b/examples/rp/src/bin/lora_p2p_send_multicore.rs
@@ -69,16 +69,9 @@ async fn core1_task(
     iv: GenericSx126xInterfaceVariant<Output<'static, AnyPin>, Input<'static, AnyPin>>,
 ) {
     info!("Hello from core 1");
-    let mut delay = Delay;
 
     let mut lora = {
-        match LoRa::new(
-            SX1261_2::new(BoardType::RpPicoWaveshareSx1262, spi, iv),
-            false,
-            &mut delay,
-        )
-        .await
-        {
+        match LoRa::new(SX1261_2::new(BoardType::RpPicoWaveshareSx1262, spi, iv), false, Delay).await {
             Ok(l) => l,
             Err(err) => {
                 info!("Radio error = {}", err);
@@ -132,7 +125,7 @@ async fn core1_task(
             }
         };
 
-        match lora.sleep(&mut delay).await {
+        match lora.sleep(false).await {
             Ok(()) => info!("Sleep successful"),
             Err(err) => info!("Sleep unsuccessful = {}", err),
         }

--- a/examples/stm32l0/Cargo.toml
+++ b/examples/stm32l0/Cargo.toml
@@ -16,7 +16,7 @@ embassy-sync = { version = "0.3.0", path = "../../embassy-sync", features = ["de
 embassy-executor = { version = "0.3.0", path = "../../embassy-executor", features = ["arch-cortex-m", "executor-thread", "defmt", "integrated-timers"] }
 embassy-time = { version = "0.1.3", path = "../../embassy-time", features = ["defmt", "defmt-timestamp-uptime", "tick-hz-32_768"] }
 embassy-lora = { version = "0.1.0", path = "../../embassy-lora", features = ["time", "defmt"], optional = true }
-lora-phy = { version = "1", optional = true }
+lora-phy = { version = "2", optional = true }
 lorawan-device = { version = "0.10.0", default-features = false, features = ["async", "external-lora-phy"], optional = true }
 lorawan = { version = "0.7.3", default-features = false, features = ["default-crypto"], optional = true }
 
@@ -39,4 +39,5 @@ static_cell = "1.1"
 debug = 2
 
 [patch.crates-io]
-lora-phy = { git = "https://github.com/embassy-rs/lora-phy", rev = "1323eccc1c470d4259f95f4f315d1be830d572a3"}
+lorawan-device = { git = "https://github.com/ivajloip/rust-lorawan", rev = "b0502c1a802427638cc8bcd928fc632d13b778b6"}
+lorawan = { git = "https://github.com/ivajloip/rust-lorawan", rev = "b0502c1a802427638cc8bcd928fc632d13b778b6"}

--- a/examples/stm32l0/Cargo.toml
+++ b/examples/stm32l0/Cargo.toml
@@ -17,8 +17,8 @@ embassy-executor = { version = "0.3.0", path = "../../embassy-executor", feature
 embassy-time = { version = "0.1.3", path = "../../embassy-time", features = ["defmt", "defmt-timestamp-uptime", "tick-hz-32_768"] }
 embassy-lora = { version = "0.1.0", path = "../../embassy-lora", features = ["time", "defmt"], optional = true }
 lora-phy = { version = "2", optional = true }
-lorawan-device = { version = "0.10.0", default-features = false, features = ["async", "external-lora-phy"], optional = true }
-lorawan = { version = "0.7.3", default-features = false, features = ["default-crypto"], optional = true }
+lorawan-device = { version = "0.11.0", default-features = false, features = ["async", "external-lora-phy"], optional = true }
+lorawan = { version = "0.7.4", default-features = false, features = ["default-crypto"], optional = true }
 
 defmt = "0.3"
 defmt-rtt = "0.4"
@@ -37,7 +37,3 @@ static_cell = "1.1"
 
 [profile.release]
 debug = 2
-
-[patch.crates-io]
-lorawan-device = { git = "https://github.com/ivajloip/rust-lorawan", rev = "b0502c1a802427638cc8bcd928fc632d13b778b6"}
-lorawan = { git = "https://github.com/ivajloip/rust-lorawan", rev = "b0502c1a802427638cc8bcd928fc632d13b778b6"}

--- a/examples/stm32l0/src/bin/lora_cad.rs
+++ b/examples/stm32l0/src/bin/lora_cad.rs
@@ -41,10 +41,8 @@ async fn main(_spawner: Spawner) {
 
     let iv = Stm32l0InterfaceVariant::new(nss, reset, irq, None, None).unwrap();
 
-    let mut delay = Delay;
-
     let mut lora = {
-        match LoRa::new(SX1276_7_8_9::new(BoardType::Stm32l0Sx1276, spi, iv), false, &mut delay).await {
+        match LoRa::new(SX1276_7_8_9::new(BoardType::Stm32l0Sx1276, spi, iv), false, Delay).await {
             Ok(l) => l,
             Err(err) => {
                 info!("Radio error = {}", err);

--- a/examples/stm32l0/src/bin/lora_lorawan.rs
+++ b/examples/stm32l0/src/bin/lora_lorawan.rs
@@ -21,6 +21,7 @@ use lora_phy::LoRa;
 use lorawan::default_crypto::DefaultFactory as Crypto;
 use lorawan_device::async_device::lora_radio::LoRaRadio;
 use lorawan_device::async_device::{region, Device, JoinMode};
+use lorawan_device::{AppEui, AppKey, DevEui};
 use {defmt_rtt as _, panic_probe as _};
 
 bind_interrupts!(struct Irqs {
@@ -50,10 +51,8 @@ async fn main(_spawner: Spawner) {
 
     let iv = Stm32l0InterfaceVariant::new(nss, reset, irq, None, None).unwrap();
 
-    let mut delay = Delay;
-
     let lora = {
-        match LoRa::new(SX1276_7_8_9::new(BoardType::Stm32l0Sx1276, spi, iv), true, &mut delay).await {
+        match LoRa::new(SX1276_7_8_9::new(BoardType::Stm32l0Sx1276, spi, iv), true, Delay).await {
             Ok(l) => l,
             Err(err) => {
                 info!("Radio error = {}", err);
@@ -71,9 +70,9 @@ async fn main(_spawner: Spawner) {
     // TODO: Adjust the EUI and Keys according to your network credentials
     match device
         .join(&JoinMode::OTAA {
-            deveui: [0, 0, 0, 0, 0, 0, 0, 0],
-            appeui: [0, 0, 0, 0, 0, 0, 0, 0],
-            appkey: [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+            deveui: DevEui::from([0, 0, 0, 0, 0, 0, 0, 0]),
+            appeui: AppEui::from([0, 0, 0, 0, 0, 0, 0, 0]),
+            appkey: AppKey::from([0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]),
         })
         .await
     {

--- a/examples/stm32l0/src/bin/lora_p2p_receive.rs
+++ b/examples/stm32l0/src/bin/lora_p2p_receive.rs
@@ -41,10 +41,8 @@ async fn main(_spawner: Spawner) {
 
     let iv = Stm32l0InterfaceVariant::new(nss, reset, irq, None, None).unwrap();
 
-    let mut delay = Delay;
-
     let mut lora = {
-        match LoRa::new(SX1276_7_8_9::new(BoardType::Stm32l0Sx1276, spi, iv), false, &mut delay).await {
+        match LoRa::new(SX1276_7_8_9::new(BoardType::Stm32l0Sx1276, spi, iv), false, Delay).await {
             Ok(l) => l,
             Err(err) => {
                 info!("Radio error = {}", err);
@@ -88,7 +86,7 @@ async fn main(_spawner: Spawner) {
     };
 
     match lora
-        .prepare_for_rx(&mdltn_params, &rx_pkt_params, None, true, false, 0, 0x00ffffffu32)
+        .prepare_for_rx(&mdltn_params, &rx_pkt_params, None, None, false)
         .await
     {
         Ok(()) => {}

--- a/examples/stm32l0/src/bin/lora_p2p_send.rs
+++ b/examples/stm32l0/src/bin/lora_p2p_send.rs
@@ -41,10 +41,8 @@ async fn main(_spawner: Spawner) {
 
     let iv = Stm32l0InterfaceVariant::new(nss, reset, irq, None, None).unwrap();
 
-    let mut delay = Delay;
-
     let mut lora = {
-        match LoRa::new(SX1276_7_8_9::new(BoardType::Stm32l0Sx1276, spi, iv), false, &mut delay).await {
+        match LoRa::new(SX1276_7_8_9::new(BoardType::Stm32l0Sx1276, spi, iv), false, Delay).await {
             Ok(l) => l,
             Err(err) => {
                 info!("Radio error = {}", err);
@@ -97,7 +95,7 @@ async fn main(_spawner: Spawner) {
         }
     };
 
-    match lora.sleep(&mut delay).await {
+    match lora.sleep(false).await {
         Ok(()) => info!("Sleep successful"),
         Err(err) => info!("Sleep unsuccessful = {}", err),
     }

--- a/examples/stm32wl/Cargo.toml
+++ b/examples/stm32wl/Cargo.toml
@@ -12,7 +12,7 @@ embassy-executor = { version = "0.3.0", path = "../../embassy-executor", feature
 embassy-time = { version = "0.1.3", path = "../../embassy-time", features = ["nightly", "unstable-traits", "defmt", "defmt-timestamp-uptime", "tick-hz-32_768"] }
 embassy-embedded-hal = { version = "0.1.0", path = "../../embassy-embedded-hal" }
 embassy-lora = { version = "0.1.0", path = "../../embassy-lora", features = ["stm32wl", "time", "defmt"] }
-lora-phy = { version = "1" }
+lora-phy = { version = "2" }
 lorawan-device = { version = "0.10.0", default-features = false, features = ["async", "external-lora-phy"] }
 lorawan = { version = "0.7.3", default-features = false, features = ["default-crypto"] }
 
@@ -32,4 +32,5 @@ chrono = { version = "^0.4", default-features = false }
 debug = 2
 
 [patch.crates-io]
-lora-phy = { git = "https://github.com/embassy-rs/lora-phy", rev = "1323eccc1c470d4259f95f4f315d1be830d572a3"}
+lorawan-device = { git = "https://github.com/ivajloip/rust-lorawan", rev = "b0502c1a802427638cc8bcd928fc632d13b778b6"}
+lorawan = { git = "https://github.com/ivajloip/rust-lorawan", rev = "b0502c1a802427638cc8bcd928fc632d13b778b6"}

--- a/examples/stm32wl/Cargo.toml
+++ b/examples/stm32wl/Cargo.toml
@@ -13,8 +13,8 @@ embassy-time = { version = "0.1.3", path = "../../embassy-time", features = ["ni
 embassy-embedded-hal = { version = "0.1.0", path = "../../embassy-embedded-hal" }
 embassy-lora = { version = "0.1.0", path = "../../embassy-lora", features = ["stm32wl", "time", "defmt"] }
 lora-phy = { version = "2" }
-lorawan-device = { version = "0.10.0", default-features = false, features = ["async", "external-lora-phy"] }
-lorawan = { version = "0.7.3", default-features = false, features = ["default-crypto"] }
+lorawan-device = { version = "0.11.0", default-features = false, features = ["async", "external-lora-phy"] }
+lorawan = { version = "0.7.4", default-features = false, features = ["default-crypto"] }
 
 defmt = "0.3"
 defmt-rtt = "0.4"
@@ -30,7 +30,3 @@ chrono = { version = "^0.4", default-features = false }
 
 [profile.release]
 debug = 2
-
-[patch.crates-io]
-lorawan-device = { git = "https://github.com/ivajloip/rust-lorawan", rev = "b0502c1a802427638cc8bcd928fc632d13b778b6"}
-lorawan = { git = "https://github.com/ivajloip/rust-lorawan", rev = "b0502c1a802427638cc8bcd928fc632d13b778b6"}

--- a/examples/stm32wl/src/bin/lora_lorawan.rs
+++ b/examples/stm32wl/src/bin/lora_lorawan.rs
@@ -20,6 +20,7 @@ use lora_phy::LoRa;
 use lorawan::default_crypto::DefaultFactory as Crypto;
 use lorawan_device::async_device::lora_radio::LoRaRadio;
 use lorawan_device::async_device::{region, Device, JoinMode};
+use lorawan_device::{AppEui, AppKey, DevEui};
 use {defmt_rtt as _, panic_probe as _};
 
 const LORAWAN_REGION: region::Region = region::Region::EU868; // warning: set this appropriately for the region
@@ -46,10 +47,8 @@ async fn main(_spawner: Spawner) {
     let _ctrl3 = Output::new(p.PC3.degrade(), Level::High, Speed::High);
     let iv = Stm32wlInterfaceVariant::new(Irqs, None, Some(ctrl2)).unwrap();
 
-    let mut delay = Delay;
-
     let lora = {
-        match LoRa::new(SX1261_2::new(BoardType::Stm32wlSx1262, spi, iv), true, &mut delay).await {
+        match LoRa::new(SX1261_2::new(BoardType::Stm32wlSx1262, spi, iv), true, Delay).await {
             Ok(l) => l,
             Err(err) => {
                 info!("Radio error = {}", err);
@@ -66,9 +65,9 @@ async fn main(_spawner: Spawner) {
     // TODO: Adjust the EUI and Keys according to your network credentials
     match device
         .join(&JoinMode::OTAA {
-            deveui: [0, 0, 0, 0, 0, 0, 0, 0],
-            appeui: [0, 0, 0, 0, 0, 0, 0, 0],
-            appkey: [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+            deveui: DevEui::from([0, 0, 0, 0, 0, 0, 0, 0]),
+            appeui: AppEui::from([0, 0, 0, 0, 0, 0, 0, 0]),
+            appkey: AppKey::from([0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]),
         })
         .await
     {

--- a/examples/stm32wl/src/bin/lora_p2p_receive.rs
+++ b/examples/stm32wl/src/bin/lora_p2p_receive.rs
@@ -37,10 +37,8 @@ async fn main(_spawner: Spawner) {
     let _ctrl3 = Output::new(p.PC3.degrade(), Level::High, Speed::High);
     let iv = Stm32wlInterfaceVariant::new(Irqs, None, Some(ctrl2)).unwrap();
 
-    let mut delay = Delay;
-
     let mut lora = {
-        match LoRa::new(SX1261_2::new(BoardType::Stm32wlSx1262, spi, iv), false, &mut delay).await {
+        match LoRa::new(SX1261_2::new(BoardType::Stm32wlSx1262, spi, iv), false, Delay).await {
             Ok(l) => l,
             Err(err) => {
                 info!("Radio error = {}", err);
@@ -84,7 +82,7 @@ async fn main(_spawner: Spawner) {
     };
 
     match lora
-        .prepare_for_rx(&mdltn_params, &rx_pkt_params, None, true, false, 0, 0x00ffffffu32)
+        .prepare_for_rx(&mdltn_params, &rx_pkt_params, None, None, false)
         .await
     {
         Ok(()) => {}

--- a/examples/stm32wl/src/bin/lora_p2p_send.rs
+++ b/examples/stm32wl/src/bin/lora_p2p_send.rs
@@ -37,10 +37,8 @@ async fn main(_spawner: Spawner) {
     let _ctrl3 = Output::new(p.PC3.degrade(), Level::High, Speed::High);
     let iv = Stm32wlInterfaceVariant::new(Irqs, None, Some(ctrl2)).unwrap();
 
-    let mut delay = Delay;
-
     let mut lora = {
-        match LoRa::new(SX1261_2::new(BoardType::Stm32wlSx1262, spi, iv), false, &mut delay).await {
+        match LoRa::new(SX1261_2::new(BoardType::Stm32wlSx1262, spi, iv), false, Delay).await {
             Ok(l) => l,
             Err(err) => {
                 info!("Radio error = {}", err);
@@ -93,7 +91,7 @@ async fn main(_spawner: Spawner) {
         }
     };
 
-    match lora.sleep(&mut delay).await {
+    match lora.sleep(false).await {
         Ok(()) => info!("Sleep successful"),
         Err(err) => info!("Sleep unsuccessful = {}", err),
     }


### PR DESCRIPTION
Update rust-lorawan and embassy to use lora-phy version 2.  This includes the latest released version of embedded-hal-async.