### PR TITLE
stm32/usart: enable fifo mode on usartv4.

### DIFF
--- a/embassy-stm32/src/usart/mod.rs
+++ b/embassy-stm32/src/usart/mod.rs
@@ -998,6 +998,8 @@ fn configure(
         });
         #[cfg(not(usart_v1))]
         w.set_over8(vals::Over8::from_bits(over8 as _));
+        #[cfg(usart_v4)]
+        w.set_fifoen(true);
     });
 
     #[cfg(not(usart_v1))]

--- a/tests/stm32/src/bin/usart.rs
+++ b/tests/stm32/src/bin/usart.rs
@@ -5,11 +5,11 @@
 mod common;
 
 use common::*;
-use defmt::assert_eq;
+use defmt::{assert, assert_eq, unreachable};
 use embassy_executor::Spawner;
 use embassy_stm32::dma::NoDma;
-use embassy_stm32::usart::{Config, Error, Uart};
-use embassy_time::{Duration, Instant};
+use embassy_stm32::usart::{Config, ConfigError, Error, Uart};
+use embassy_time::{block_for, Duration, Instant};
 
 #[embassy_executor::main]
 async fn main(_spawner: Spawner) {
@@ -44,9 +44,15 @@ async fn main(_spawner: Spawner) {
         let mut usart = Uart::new(&mut usart, &mut rx, &mut tx, irq, NoDma, NoDma, config).unwrap();
 
         // Send enough bytes to fill the RX FIFOs off all USART versions.
-        let data = [0xC0, 0xDE, 0x12, 0x23, 0x34];
+        let data = [0; 64];
         usart.blocking_write(&data).unwrap();
         usart.blocking_flush().unwrap();
+
+        // USART can still take up to 1 bit time (?) to receive the last byte
+        // that we just flushed, so wait a bit.
+        // otherwise, we might clear the overrun flag from an *earlier* byte and
+        // it gets set again when receiving the last byte is done.
+        block_for(Duration::from_millis(1));
 
         // The error should be reported first.
         let mut buf = [0; 1];
@@ -60,22 +66,25 @@ async fn main(_spawner: Spawner) {
 
     // Test that baudrate divider is calculated correctly.
     // Do it by comparing the time it takes to send a known number of bytes.
-    for baudrate in [
-        300,
-        9600,
-        115200,
-        250_000,
-        337_934,
-        #[cfg(not(feature = "stm32f103c8"))]
-        1_000_000,
-        #[cfg(not(feature = "stm32f103c8"))]
-        2_000_000,
-    ] {
+    for baudrate in [300, 9600, 115200, 250_000, 337_934, 1_000_000, 2_000_000] {
         info!("testing baudrate {}", baudrate);
 
         let mut config = Config::default();
         config.baudrate = baudrate;
-        let mut usart = Uart::new(&mut usart, &mut rx, &mut tx, irq, NoDma, NoDma, config).unwrap();
+        let mut usart = match Uart::new(&mut usart, &mut rx, &mut tx, irq, NoDma, NoDma, config) {
+            Ok(x) => x,
+            Err(ConfigError::BaudrateTooHigh) => {
+                info!("baudrate too high");
+                assert!(baudrate >= 1_000_000);
+                continue;
+            }
+            Err(ConfigError::BaudrateTooLow) => {
+                info!("baudrate too low");
+                assert!(baudrate <= 300);
+                continue;
+            }
+            Err(_) => unreachable!(),
+        };
 
         let n = (baudrate as usize / 100).max(64);
 
@@ -83,6 +92,7 @@ async fn main(_spawner: Spawner) {
         for _ in 0..n {
             usart.blocking_write(&[0x00]).unwrap();
         }
+        usart.blocking_flush().unwrap();
         let dur = Instant::now() - start;
         let want_dur = Duration::from_micros(n as u64 * 10 * 1_000_000 / (baudrate as u64));
         let fuzz = want_dur / 5;


### PR DESCRIPTION
Without this, it seems flushing returns earlier than it should?