### PR TITLE
enc28j60: expose a the MAC address via `address()` getter

### DIFF
--- a/embassy-net-enc28j60/src/lib.rs
+++ b/embassy-net-enc28j60/src/lib.rs
@@ -194,6 +194,11 @@ where
         self.bit_field_set(common::Register::ECON1, common::ECON1::mask().rxen());
     }
 
+    /// Returns the device's MAC address
+    pub fn address(&self) -> [u8; 6] {
+        self.mac_addr
+    }
+
     /// Flushes the transmit buffer, ensuring all pending transmissions have completed
     /// NOTE: The returned packet *must* be `read` or `ignore`-d, otherwise this method will always
     /// return `None` on subsequent invocations


### PR DESCRIPTION
Title. Just a little getter to avoid having to wrap the struct in a tuple or something when implementing application-specific traits.