### PR TITLE
fix typo / update wasm example

### DIFF
--- a/examples/wasm/README.md
+++ b/examples/wasm/README.md
@@ -3,7 +3,7 @@
 Examples use a CLI tool named `wasm-pack` to build this example:
 
 ```
-cargo install wasm-pack --version 0.9.1
+cargo install wasm-pack --version 0.12.1
 ```
 
 ## Building

--- a/examples/wasm/README.md
+++ b/examples/wasm/README.md
@@ -23,4 +23,4 @@ To run the example, start a webserver server the local folder:
 python -m http.server
 ```
 
-Then, open a browser at https://127.0.0.1:8000 and watch the ticker print entries to the window.
+Then, open a browser at http://127.0.0.1:8000 and watch the ticker print entries to the window.


### PR DESCRIPTION
noticed an errant "s" in the wasm/http example