### PR TITLE
features/esp32 c3

### DIFF
--- a/examples/wasm/README.md
+++ b/examples/wasm/README.md
@@ -3,7 +3,7 @@
 Examples use a CLI tool named `wasm-pack` to build this example:
 
 ```
-cargo install wasm-pack --version 0.9.1
+cargo install wasm-pack --version 0.12.1
 ```
 
 ## Building

--- a/examples/wasm/README.md
+++ b/examples/wasm/README.md
@@ -23,4 +23,4 @@ To run the example, start a webserver server the local folder:
 python -m http.server
 ```
 
-Then, open a browser at https://127.0.0.1:8000 and watch the ticker print entries to the window.
+Then, open a browser at http://127.0.0.1:8000 and watch the ticker print entries to the window.


### PR DESCRIPTION
- Revert "Forgot set_count_direction and set_clock_division in 32 bit instance"
- enc28j60: expose a the MAC address via `address()` getter
- stm32/rtc: enable lse in examples.
- typo
- bump wasm-pack version
