### PR TITLE
Fix trait inconsistency between sealed traits and implementations

### DIFF
--- a/embassy-stm32/src/timer/mod.rs
+++ b/embassy-stm32/src/timer/mod.rs
@@ -5,7 +5,6 @@ pub mod simple_pwm;
 use stm32_metapac::timer::vals;
 
 use crate::interrupt;
-use crate::rcc::sealed::RccPeripheral as __RccPeri;
 use crate::rcc::RccPeripheral;
 use crate::time::Hertz;
 
@@ -89,7 +88,6 @@ pub(crate) mod sealed {
         fn regs_gp32() -> crate::pac::timer::TimGp32;
 
         fn set_frequency(&mut self, frequency: Hertz) {
-            use core::convert::TryInto;
             let f = frequency.0;
             assert!(f > 0);
             let timer_f = Self::frequency().0;

--- a/embassy-stm32/src/timer/mod.rs
+++ b/embassy-stm32/src/timer/mod.rs
@@ -210,6 +210,7 @@ pub trait CaptureCompare32bitInstance:
     sealed::CaptureCompare32bitInstance + CaptureCompare16bitInstance + GeneralPurpose32bitInstance + 'static
 {
 }
+
 pin_trait!(Channel1Pin, CaptureCompare16bitInstance);
 pin_trait!(Channel1ComplementaryPin, CaptureCompare16bitInstance);
 pin_trait!(Channel2Pin, CaptureCompare16bitInstance);

--- a/embassy-stm32/src/timer/mod.rs
+++ b/embassy-stm32/src/timer/mod.rs
@@ -217,7 +217,7 @@ pub(crate) mod sealed {
         }
 
         fn get_max_compare_value(&self) -> u32 {
-            Self::regs_gp32().arr().read().arr() as u32
+            Self::regs_gp32().arr().read().arr()
         }
     }
 }


### PR DESCRIPTION
There are currently inconsistencies between the trait inheritance of the sealed traits
and what they implement.

In particular, the CaptureCompare32BitInstance trait does not require the CaptureCompare16BitInstance trait,
however, all 32 bit counts implement both traits. As they have overlapping functions, this causes
disambiguation issues when you try to use any 32 bit timers.

This is exacerbated by the fact that all channel pins implement CaptureCompare16BitInstance, whether the pins
belong to a 32 bit timer or not.

There are two ways to fix this:

1. Cleanly separate the traits, remove the 16 bit capture traits from 32bit capture timers,
   create a set of traits for 32 bit capture pins, and modify the build script to generate 32 bit pin
   traits for 32 bit pins.
  This requires duplicating every set of pin traits to be either for a 16 bit timer or a 32 bit timer 
(IE you need Channel132bitPin), and then the build script has to special case timers depending on their reg block

2.  Fix 90% of it by describing what the inheritance structure is right now - 32 bit timers inherit 16 bit traits
    Remove all duplicate methods, only keep the 32 bit specific methods in the 32bit specific trait
This PR takes approach #2 - we mark the 32 bit trait to require the 16 bit trait, and remove duplicate mehtods between them.
The downside of this is: All channel pins remain implementing 16 bit traits only regardless of whether they belong to 32 bit timers,
and there are 4 methods that still require disambiguated use (vs many more before) - set_frequency, set_compare_value, get_capture_value, get_max_compare_value
Prior to this patch, you have to disambiguate between 13 methods :)


I am happy to take approach 1 if we want it, it's just more involved.

It would result in not having to disambiguate any methods for 32 vs 16 bit timers.
However, it would also result in having to have 16 and 32 bit channel pins, and them not being compatible with each other by default, because you can't do union traits in rust right now.  
