### PR TITLE
stm32: Add the ability to center-align timers

### DIFF
--- a/embassy-stm32/src/timer/complementary_pwm.rs
+++ b/embassy-stm32/src/timer/complementary_pwm.rs
@@ -57,11 +57,12 @@ impl<'d, T: ComplementaryCaptureCompare16bitInstance> ComplementaryPwm<'d, T> {
         _ch4: Option<PwmPin<'d, T, Ch4>>,
         _ch4n: Option<ComplementaryPwmPin<'d, T, Ch4>>,
         freq: Hertz,
+        counting_mode: CountingMode,
     ) -> Self {
-        Self::new_inner(tim, freq)
+        Self::new_inner(tim, freq, counting_mode)
     }
 
-    fn new_inner(tim: impl Peripheral<P = T> + 'd, freq: Hertz) -> Self {
+    fn new_inner(tim: impl Peripheral<P = T> + 'd, freq: Hertz, counting_mode: CountingMode) -> Self {
         into_ref!(tim);
 
         T::enable();
@@ -70,6 +71,7 @@ impl<'d, T: ComplementaryCaptureCompare16bitInstance> ComplementaryPwm<'d, T> {
         let mut this = Self { inner: tim };
 
         this.inner.set_frequency(freq);
+        this.inner.set_counting_mode(counting_mode);
         this.inner.start();
 
         this.inner.enable_outputs(true);

--- a/embassy-stm32/src/timer/simple_pwm.rs
+++ b/embassy-stm32/src/timer/simple_pwm.rs
@@ -56,11 +56,12 @@ impl<'d, T: CaptureCompare16bitInstance> SimplePwm<'d, T> {
         _ch3: Option<PwmPin<'d, T, Ch3>>,
         _ch4: Option<PwmPin<'d, T, Ch4>>,
         freq: Hertz,
+        counting_mode: CountingMode,
     ) -> Self {
-        Self::new_inner(tim, freq)
+        Self::new_inner(tim, freq, counting_mode)
     }
 
-    fn new_inner(tim: impl Peripheral<P = T> + 'd, freq: Hertz) -> Self {
+    fn new_inner(tim: impl Peripheral<P = T> + 'd, freq: Hertz, counting_mode: CountingMode) -> Self {
         into_ref!(tim);
 
         T::enable();
@@ -69,6 +70,7 @@ impl<'d, T: CaptureCompare16bitInstance> SimplePwm<'d, T> {
         let mut this = Self { inner: tim };
 
         this.inner.set_frequency(freq);
+        this.inner.set_counting_mode(counting_mode);
         this.inner.start();
 
         this.inner.enable_outputs(true);


### PR DESCRIPTION
Draft because I still need to test it on hardware.

Added it as a nice enum type in place of just the direction.
This is the most straightforward implementation I think.

The reason for adding this is because it enables more fancy PWM usages using the existing simple and complementary pwm implementations.

I've made a variant for each of the interrupt settings for the center-aligned mode. Should that be separated? Or is this combination fine?