### PR TITLE
[STM32] QUADSPI support bank 2

### DIFF
--- a/embassy-stm32/build.rs
+++ b/embassy-stm32/build.rs
@@ -736,7 +736,6 @@ fn main() {
         if let Some(regs) = &p.registers {
             for pin in p.pins {
                 let key = (regs.kind, pin.signal);
-                eprintln!("key: {:#?}", &key);
                 if let Some(tr) = signals.get(&key) {
                     let mut peri = format_ident!("{}", p.name);
 

--- a/embassy-stm32/build.rs
+++ b/embassy-stm32/build.rs
@@ -719,18 +719,24 @@ fn main() {
         (("sdmmc", "D6"), quote!(crate::sdmmc::D6Pin)),
         (("sdmmc", "D6"), quote!(crate::sdmmc::D7Pin)),
         (("sdmmc", "D8"), quote!(crate::sdmmc::D8Pin)),
-        (("quadspi", "BK1_IO0"), quote!(crate::qspi::D0Pin)),
-        (("quadspi", "BK1_IO1"), quote!(crate::qspi::D1Pin)),
-        (("quadspi", "BK1_IO2"), quote!(crate::qspi::D2Pin)),
-        (("quadspi", "BK1_IO3"), quote!(crate::qspi::D3Pin)),
+        (("quadspi", "BK1_IO0"), quote!(crate::qspi::BK1D0Pin)),
+        (("quadspi", "BK1_IO1"), quote!(crate::qspi::BK1D1Pin)),
+        (("quadspi", "BK1_IO2"), quote!(crate::qspi::BK1D2Pin)),
+        (("quadspi", "BK1_IO3"), quote!(crate::qspi::BK1D3Pin)),
+        (("quadspi", "BK1_NCS"), quote!(crate::qspi::BK1NSSPin)),
+        (("quadspi", "BK2_IO0"), quote!(crate::qspi::BK2D0Pin)),
+        (("quadspi", "BK2_IO1"), quote!(crate::qspi::BK2D1Pin)),
+        (("quadspi", "BK2_IO2"), quote!(crate::qspi::BK2D2Pin)),
+        (("quadspi", "BK2_IO3"), quote!(crate::qspi::BK2D3Pin)),
+        (("quadspi", "BK2_NCS"), quote!(crate::qspi::BK2NSSPin)),
         (("quadspi", "CLK"), quote!(crate::qspi::SckPin)),
-        (("quadspi", "BK1_NCS"), quote!(crate::qspi::NSSPin)),
     ].into();
 
     for p in METADATA.peripherals {
         if let Some(regs) = &p.registers {
             for pin in p.pins {
                 let key = (regs.kind, pin.signal);
+                eprintln!("key: {:#?}", &key);
                 if let Some(tr) = signals.get(&key) {
                     let mut peri = format_ident!("{}", p.name);
 

--- a/embassy-stm32/src/qspi/enums.rs
+++ b/embassy-stm32/src/qspi/enums.rs
@@ -38,6 +38,22 @@ impl Into<u8> for QspiWidth {
     }
 }
 
+#[allow(dead_code)]
+#[derive(Copy, Clone)]
+pub enum FlashSelection {
+    Flash1,
+    Flash2,
+}
+
+impl Into<bool> for FlashSelection {
+    fn into(self) -> bool {
+        match self {
+            FlashSelection::Flash1 => false,
+            FlashSelection::Flash2 => true,
+        }
+    }
+}
+
 #[derive(Copy, Clone)]
 pub enum MemorySize {
     _1KiB,

--- a/embassy-stm32/src/qspi/mod.rs
+++ b/embassy-stm32/src/qspi/mod.rs
@@ -83,14 +83,53 @@ pub struct Qspi<'d, T: Instance, Dma> {
 }
 
 impl<'d, T: Instance, Dma> Qspi<'d, T, Dma> {
-    pub fn new(
+    pub fn new_bk1(
         peri: impl Peripheral<P = T> + 'd,
-        d0: impl Peripheral<P = impl D0Pin<T>> + 'd,
-        d1: impl Peripheral<P = impl D1Pin<T>> + 'd,
-        d2: impl Peripheral<P = impl D2Pin<T>> + 'd,
-        d3: impl Peripheral<P = impl D3Pin<T>> + 'd,
+        d0: impl Peripheral<P = impl BK1D0Pin<T>> + 'd,
+        d1: impl Peripheral<P = impl BK1D1Pin<T>> + 'd,
+        d2: impl Peripheral<P = impl BK1D2Pin<T>> + 'd,
+        d3: impl Peripheral<P = impl BK1D3Pin<T>> + 'd,
         sck: impl Peripheral<P = impl SckPin<T>> + 'd,
-        nss: impl Peripheral<P = impl NSSPin<T>> + 'd,
+        nss: impl Peripheral<P = impl BK1NSSPin<T>> + 'd,
+        dma: impl Peripheral<P = Dma> + 'd,
+        config: Config,
+    ) -> Self {
+        into_ref!(peri, d0, d1, d2, d3, sck, nss);
+
+        sck.set_as_af(sck.af_num(), AFType::OutputPushPull);
+        sck.set_speed(crate::gpio::Speed::VeryHigh);
+        nss.set_as_af(nss.af_num(), AFType::OutputPushPull);
+        nss.set_speed(crate::gpio::Speed::VeryHigh);
+        d0.set_as_af(d0.af_num(), AFType::OutputPushPull);
+        d0.set_speed(crate::gpio::Speed::VeryHigh);
+        d1.set_as_af(d1.af_num(), AFType::OutputPushPull);
+        d1.set_speed(crate::gpio::Speed::VeryHigh);
+        d2.set_as_af(d2.af_num(), AFType::OutputPushPull);
+        d2.set_speed(crate::gpio::Speed::VeryHigh);
+        d3.set_as_af(d3.af_num(), AFType::OutputPushPull);
+        d3.set_speed(crate::gpio::Speed::VeryHigh);
+
+        Self::new_inner(
+            peri,
+            Some(d0.map_into()),
+            Some(d1.map_into()),
+            Some(d2.map_into()),
+            Some(d3.map_into()),
+            Some(sck.map_into()),
+            Some(nss.map_into()),
+            dma,
+            config,
+        )
+    }
+
+    pub fn new_bk2(
+        peri: impl Peripheral<P = T> + 'd,
+        d0: impl Peripheral<P = impl BK2D0Pin<T>> + 'd,
+        d1: impl Peripheral<P = impl BK2D1Pin<T>> + 'd,
+        d2: impl Peripheral<P = impl BK2D2Pin<T>> + 'd,
+        d3: impl Peripheral<P = impl BK2D3Pin<T>> + 'd,
+        sck: impl Peripheral<P = impl SckPin<T>> + 'd,
+        nss: impl Peripheral<P = impl BK2NSSPin<T>> + 'd,
         dma: impl Peripheral<P = Dma> + 'd,
         config: Config,
     ) -> Self {
@@ -313,11 +352,17 @@ pub(crate) mod sealed {
 pub trait Instance: Peripheral<P = Self> + sealed::Instance + RccPeripheral {}
 
 pin_trait!(SckPin, Instance);
-pin_trait!(D0Pin, Instance);
-pin_trait!(D1Pin, Instance);
-pin_trait!(D2Pin, Instance);
-pin_trait!(D3Pin, Instance);
-pin_trait!(NSSPin, Instance);
+pin_trait!(BK1D0Pin, Instance);
+pin_trait!(BK1D1Pin, Instance);
+pin_trait!(BK1D2Pin, Instance);
+pin_trait!(BK1D3Pin, Instance);
+pin_trait!(BK1NSSPin, Instance);
+
+pin_trait!(BK2D0Pin, Instance);
+pin_trait!(BK2D1Pin, Instance);
+pin_trait!(BK2D2Pin, Instance);
+pin_trait!(BK2D3Pin, Instance);
+pin_trait!(BK2NSSPin, Instance);
 
 dma_trait!(QuadDma, Instance);
 

--- a/embassy-stm32/src/qspi/mod.rs
+++ b/embassy-stm32/src/qspi/mod.rs
@@ -183,14 +183,17 @@ impl<'d, T: Instance, Dma> Qspi<'d, T, Dma> {
 
         while T::REGS.sr().read().busy() {}
 
-        // Apply precautionary steps according to the errata...
-        T::REGS.cr().write_value(Cr(0));
-        while T::REGS.sr().read().busy() {}
-        T::REGS.cr().write_value(Cr(0xFF000001));
-        T::REGS.ccr().write(|w| w.set_frcm(true));
-        T::REGS.ccr().write(|w| w.set_frcm(true));
-        T::REGS.cr().write_value(Cr(0));
-        while T::REGS.sr().read().busy() {}
+        #[cfg(stm32h7)]
+        {
+            // Apply precautionary steps according to the errata...
+            T::REGS.cr().write_value(Cr(0));
+            while T::REGS.sr().read().busy() {}
+            T::REGS.cr().write_value(Cr(0xFF000001));
+            T::REGS.ccr().write(|w| w.set_frcm(true));
+            T::REGS.ccr().write(|w| w.set_frcm(true));
+            T::REGS.cr().write_value(Cr(0));
+            while T::REGS.sr().read().busy() {}
+        }
 
         T::REGS.cr().modify(|w| {
             w.set_en(true);

--- a/embassy-stm32/src/qspi/mod.rs
+++ b/embassy-stm32/src/qspi/mod.rs
@@ -8,7 +8,7 @@ use stm32_metapac::quadspi::regs::Cr;
 
 use crate::dma::Transfer;
 use crate::gpio::sealed::AFType;
-use crate::gpio::AnyPin;
+use crate::gpio::{AnyPin, Pull};
 use crate::pac::quadspi::Quadspi as Regs;
 use crate::rcc::RccPeripheral;
 use crate::{peripherals, Peripheral};
@@ -97,17 +97,17 @@ impl<'d, T: Instance, Dma> Qspi<'d, T, Dma> {
     ) -> Self {
         into_ref!(peri, d0, d1, d2, d3, sck, nss);
 
-        sck.set_as_af(sck.af_num(), AFType::OutputPushPull);
+        sck.set_as_af_pull(sck.af_num(), AFType::OutputPushPull, Pull::None);
         sck.set_speed(crate::gpio::Speed::VeryHigh);
-        nss.set_as_af(nss.af_num(), AFType::OutputPushPull);
+        nss.set_as_af_pull(nss.af_num(), AFType::OutputPushPull, Pull::Up);
         nss.set_speed(crate::gpio::Speed::VeryHigh);
-        d0.set_as_af(d0.af_num(), AFType::OutputPushPull);
+        d0.set_as_af_pull(d0.af_num(), AFType::OutputPushPull, Pull::None);
         d0.set_speed(crate::gpio::Speed::VeryHigh);
-        d1.set_as_af(d1.af_num(), AFType::OutputPushPull);
+        d1.set_as_af_pull(d1.af_num(), AFType::OutputPushPull, Pull::None);
         d1.set_speed(crate::gpio::Speed::VeryHigh);
-        d2.set_as_af(d2.af_num(), AFType::OutputPushPull);
+        d2.set_as_af_pull(d2.af_num(), AFType::OutputPushPull, Pull::None);
         d2.set_speed(crate::gpio::Speed::VeryHigh);
-        d3.set_as_af(d3.af_num(), AFType::OutputPushPull);
+        d3.set_as_af_pull(d3.af_num(), AFType::OutputPushPull, Pull::None);
         d3.set_speed(crate::gpio::Speed::VeryHigh);
 
         Self::new_inner(
@@ -137,17 +137,17 @@ impl<'d, T: Instance, Dma> Qspi<'d, T, Dma> {
     ) -> Self {
         into_ref!(peri, d0, d1, d2, d3, sck, nss);
 
-        sck.set_as_af(sck.af_num(), AFType::OutputPushPull);
+        sck.set_as_af_pull(sck.af_num(), AFType::OutputPushPull, Pull::None);
         sck.set_speed(crate::gpio::Speed::VeryHigh);
-        nss.set_as_af(nss.af_num(), AFType::OutputPushPull);
+        nss.set_as_af_pull(nss.af_num(), AFType::OutputPushPull, Pull::Up);
         nss.set_speed(crate::gpio::Speed::VeryHigh);
-        d0.set_as_af(d0.af_num(), AFType::OutputOpenDrain);
+        d0.set_as_af_pull(d0.af_num(), AFType::OutputPushPull, Pull::None);
         d0.set_speed(crate::gpio::Speed::VeryHigh);
-        d1.set_as_af(d1.af_num(), AFType::OutputOpenDrain);
+        d1.set_as_af_pull(d1.af_num(), AFType::OutputPushPull, Pull::None);
         d1.set_speed(crate::gpio::Speed::VeryHigh);
-        d2.set_as_af(d2.af_num(), AFType::OutputOpenDrain);
+        d2.set_as_af_pull(d2.af_num(), AFType::OutputPushPull, Pull::None);
         d2.set_speed(crate::gpio::Speed::VeryHigh);
-        d3.set_as_af(d3.af_num(), AFType::OutputOpenDrain);
+        d3.set_as_af_pull(d3.af_num(), AFType::OutputPushPull, Pull::None);
         d3.set_speed(crate::gpio::Speed::VeryHigh);
 
         Self::new_inner(

--- a/embassy-stm32/src/qspi/mod.rs
+++ b/embassy-stm32/src/qspi/mod.rs
@@ -4,7 +4,6 @@ pub mod enums;
 
 use embassy_hal_internal::{into_ref, PeripheralRef};
 use enums::*;
-use stm32_metapac::quadspi::regs::Cr;
 
 use crate::dma::Transfer;
 use crate::gpio::sealed::AFType;
@@ -185,6 +184,7 @@ impl<'d, T: Instance, Dma> Qspi<'d, T, Dma> {
 
         #[cfg(stm32h7)]
         {
+            use stm32_metapac::quadspi::regs::Cr;
             // Apply precautionary steps according to the errata...
             T::REGS.cr().write_value(Cr(0));
             while T::REGS.sr().read().busy() {}

--- a/embassy-stm32/src/qspi/mod.rs
+++ b/embassy-stm32/src/qspi/mod.rs
@@ -209,10 +209,6 @@ impl<'d, T: Instance, Dma> Qspi<'d, T, Dma> {
             w.set_ckmode(true);
         });
 
-        // FOR TESTING ONLY
-        //T::REGS.ccr().write(|w| w.set_frcm(true));
-        // END FOR TESTING ONLY
-
         Self {
             _peri: peri,
             sck,
@@ -260,8 +256,10 @@ impl<'d, T: Instance, Dma> Qspi<'d, T, Dma> {
     }
 
     pub fn blocking_write(&mut self, buf: &[u8], transaction: TransferConfig) {
+        // STM32H7 does not have dmaen
         #[cfg(not(stm32h7))]
         T::REGS.cr().modify(|v| v.set_dmaen(false));
+
         self.setup_transaction(QspiMode::IndirectWrite, &transaction);
 
         if let Some(len) = transaction.data_len {
@@ -304,6 +302,7 @@ impl<'d, T: Instance, Dma> Qspi<'d, T, Dma> {
             )
         };
 
+        // STM32H7 does not have dmaen
         #[cfg(not(stm32h7))]
         T::REGS.cr().modify(|v| v.set_dmaen(true));
 
@@ -331,6 +330,7 @@ impl<'d, T: Instance, Dma> Qspi<'d, T, Dma> {
             )
         };
 
+        // STM32H7 does not have dmaen
         #[cfg(not(stm32h7))]
         T::REGS.cr().modify(|v| v.set_dmaen(true));
 


### PR DESCRIPTION
This PR supports using QSPI bank 2 on stm32 by introducing a second constructor that accepts the pins implementing the BK2 traits.
It does not yet allow for using both banks, but at least you can use bank 2 for now, e.g., if BK1 pins are used by another peripheral or so.

Further, a "precautionary step" according to the STM32H7 errata sheet is added. It looks very odd, but it is what the recommended "workaround" looks like. Hope it avoids some unwanted surprises in the future.