### PR TITLE
stm32: avoid useless endian conversion in rng

### DIFF
--- a/embassy-stm32/src/rng.rs
+++ b/embassy-stm32/src/rng.rs
@@ -164,7 +164,7 @@ impl<'d, T: Instance> Rng<'d, T> {
                     return Err(Error::SeedError);
                 }
                 // write bytes to chunk
-                for (dest, src) in chunk.iter_mut().zip(random_word.to_be_bytes().iter()) {
+                for (dest, src) in chunk.iter_mut().zip(random_word.to_ne_bytes().iter()) {
                     *dest = *src
                 }
             }
@@ -195,7 +195,7 @@ impl<'d, T: Instance> RngCore for Rng<'d, T> {
     fn fill_bytes(&mut self, dest: &mut [u8]) {
         for chunk in dest.chunks_mut(4) {
             let rand = self.next_u32();
-            for (slot, num) in chunk.iter_mut().zip(rand.to_be_bytes().iter()) {
+            for (slot, num) in chunk.iter_mut().zip(rand.to_ne_bytes().iter()) {
                 *slot = *num
             }
         }


### PR DESCRIPTION
Most stm32 are little endian. The code in `rng.rs` was converting the generated `u32`s to big_endian before using their bytes. This is not needed.

I did some ad hoc measurement of the speed of `async_fill_bytes`and saw a small but measurable improvement.