### PR TITLE
Remove a few ultra-verbose logs.

### DIFF
--- a/embassy-rp/src/uart/buffered.rs
+++ b/embassy-rp/src/uart/buffered.rs
@@ -490,8 +490,6 @@ impl<T: Instance> interrupt::typelevel::Handler<T::Interrupt> for BufferedInterr
             w.set_oeic(ris.oeris());
         });
 
-        trace!("on_interrupt ris={:#X}", ris.0);
-
         // Errors
         if ris.feris() {
             warn!("Framing error");

--- a/tests/stm32/src/bin/dac.rs
+++ b/tests/stm32/src/bin/dac.rs
@@ -54,7 +54,7 @@ async fn main(_spawner: Spawner) {
         // Calibrate and normalize the measurement to get close to the dac_output_val
         let measured_normalized = ((measured as i32 - offset as i32) / normalization_factor) as i16;
 
-        info!("value / measured: {} / {}", dac_output_val, measured_normalized);
+        //info!("value / measured: {} / {}", dac_output_val, measured_normalized);
 
         // The deviations are quite enormous but that does not matter since this is only a quick test
         assert!((dac_output_val as i16 - measured_normalized).abs() < 15);


### PR DESCRIPTION
They're heavily spamming logs for HIL tests, and I don't believe they're valuable now that the thing they helped debug in their young age is now solid and mature.