### PR TITLE
stm32/gpio: Implement `eh1::digital::InputPin` for `OutputOpenDrain`

### DIFF
--- a/embassy-stm32/src/gpio.rs
+++ b/embassy-stm32/src/gpio.rs
@@ -974,6 +974,18 @@ mod eh1 {
         type Error = Infallible;
     }
 
+    impl<'d, T: Pin> InputPin for OutputOpenDrain<'d, T> {
+        #[inline]
+        fn is_high(&self) -> Result<bool, Self::Error> {
+            Ok(self.is_high())
+        }
+
+        #[inline]
+        fn is_low(&self) -> Result<bool, Self::Error> {
+            Ok(self.is_low())
+        }
+    }
+
     impl<'d, T: Pin> OutputPin for OutputOpenDrain<'d, T> {
         #[inline]
         fn set_high(&mut self) -> Result<(), Self::Error> {


### PR DESCRIPTION
Pins in open-drain mode are outputs and inputs simultaneously.