### PR TITLE
stm32: u5: implement >55 MHz clock speeds

### DIFF
--- a/examples/stm32u5/src/bin/usb_serial.rs
+++ b/examples/stm32u5/src/bin/usb_serial.rs
@@ -23,7 +23,12 @@ async fn main(_spawner: Spawner) {
     info!("Hello World!");
 
     let mut config = Config::default();
-    config.rcc.mux = ClockSrc::PLL1R(PllSrc::HSI16, PllM::Div2, PllN::Mul10, PllClkDiv::NotDivided);
+    config.rcc.mux = ClockSrc::PLL1R(PllConfig {
+        source: PllSrc::HSI16,
+        m: PllM::Div2,
+        n: PllN::Mul10,
+        r: PllClkDiv::NotDivided,
+    });
     //config.rcc.mux = ClockSrc::MSI(MSIRange::Range48mhz);
     config.rcc.hsi48 = true;
 


### PR DESCRIPTION
This commit allows STM32U5 devices to operate at 160 MHz.

On STM32U5, MSIS can run at 48 MHz and HSE can reach 50 MHz. Faster clocks require using PLL1's R output, though PLL1 can serve other functions besides using the R output for the system clock. This commit extracts a public `PllConfig` struct, primarily to place associated constructors on that type, but also with an eye towards enabling the P and Q outputs in a later commit.

STM32U5 PLLs have various frequency requirements on each stage: after the `m` prescaler, after the `n` multiplier, and after the `r` divider. This commit implements the associated checks as assertions.

This commit fixes clock calculation and PLL register configuration errors in PLL initialization.

STM32U5 has a PWR peripheral which can be configured to push Vcore into different voltage ranges. System clocks exceeding 55 MHz require range 2, and system clocks exceeding 110 MHz require range 1. This commit adds `voltage_range` to `Config` and configures PWR as directed.

The voltage range implies different performance limits on various clock signals, including inside a PLL. This commit implements voltage range <-> frequency range checks as assertions, and extracts the otherwise-repeated MSIS, HSI16, and HSE initialization into private methods on `Config`.

STM32U5 frequencies above 55 MHz require using the PWR EPOD booster. The EPOD booster requires configuring a second `m` term for PLL1, `mboost`, such that it falls in a particular range. (Recall that >50 MHz cannot be reached without PLL1, so there is no scenario where EPOD is needed but PLL1 is not.) This commit configures and enables the EPOD booster automatically as required.