### PR TITLE
Add some uncontroversial derives to Error types

### DIFF
--- a/embassy-embedded-hal/src/flash/partition/mod.rs
+++ b/embassy-embedded-hal/src/flash/partition/mod.rs
@@ -11,7 +11,7 @@ pub use asynch::Partition;
 pub use blocking::BlockingPartition;
 
 /// Partition error
-#[derive(Debug)]
+#[derive(Debug, PartialEq, Eq)]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub enum Error<T> {
     /// The requested flash area is outside the partition

--- a/embassy-rp/src/i2c.rs
+++ b/embassy-rp/src/i2c.rs
@@ -12,7 +12,7 @@ use crate::interrupt::typelevel::{Binding, Interrupt};
 use crate::{interrupt, pac, peripherals, Peripheral};
 
 /// I2C error abort reason
-#[derive(Debug)]
+#[derive(Debug, PartialEq, Eq)]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub enum AbortReason {
     /// A bus operation was not acknowledged, e.g. due to the addressed device

--- a/embassy-rp/src/i2c.rs
+++ b/embassy-rp/src/i2c.rs
@@ -27,7 +27,7 @@ pub enum AbortReason {
 }
 
 /// I2C error
-#[derive(Debug)]
+#[derive(Debug, PartialEq, Eq)]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub enum Error {
     /// I2C abort with error

--- a/embassy-rp/src/i2c_slave.rs
+++ b/embassy-rp/src/i2c_slave.rs
@@ -10,7 +10,7 @@ use crate::interrupt::typelevel::{Binding, Interrupt};
 use crate::{pac, Peripheral};
 
 /// I2C error
-#[derive(Debug)]
+#[derive(Debug, PartialEq, Eq)]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
 #[non_exhaustive]
 pub enum Error {

--- a/embassy-stm32/src/dac/mod.rs
+++ b/embassy-stm32/src/dac/mod.rs
@@ -11,7 +11,7 @@ use crate::{peripherals, Peripheral};
 
 #[derive(Debug, Copy, Clone, Eq, PartialEq)]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
-/// Curstom Errors
+/// Custom Errors
 pub enum Error {
     UnconfiguredChannel,
     InvalidValue,

--- a/embassy-stm32/src/i2c/mod.rs
+++ b/embassy-stm32/src/i2c/mod.rs
@@ -14,7 +14,7 @@ pub use timeout::*;
 
 use crate::peripherals;
 
-#[derive(Debug)]
+#[derive(Debug, PartialEq, Eq)]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub enum Error {
     Bus,

--- a/embassy-stm32/src/rng.rs
+++ b/embassy-stm32/src/rng.rs
@@ -13,6 +13,7 @@ use crate::{interrupt, pac, peripherals, Peripheral};
 
 static RNG_WAKER: AtomicWaker = AtomicWaker::new();
 
+#[derive(Debug, PartialEq, Eq)]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub enum Error {
     SeedError,

--- a/embassy-stm32/src/sai/mod.rs
+++ b/embassy-stm32/src/sai/mod.rs
@@ -11,7 +11,7 @@ use crate::pac::sai::{vals, Sai as Regs};
 use crate::rcc::RccPeripheral;
 use crate::{peripherals, Peripheral};
 
-#[derive(Debug)]
+#[derive(Debug, PartialEq, Eq)]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub enum Error {
     NotATransmitter,

--- a/embassy-stm32/src/spi/mod.rs
+++ b/embassy-stm32/src/spi/mod.rs
@@ -15,7 +15,7 @@ use crate::rcc::RccPeripheral;
 use crate::time::Hertz;
 use crate::{peripherals, Peripheral};
 
-#[derive(Debug)]
+#[derive(Debug, PartialEq, Eq)]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub enum Error {
     Framing,

--- a/examples/stm32h7/src/bin/camera.rs
+++ b/examples/stm32h7/src/bin/camera.rs
@@ -184,7 +184,7 @@ mod ov7725 {
 
     const CAM_ADDR: u8 = 0x21;
 
-    #[derive(Format)]
+    #[derive(Format, PartialEq, Eq)]
     pub enum Error<I2cError: Format> {
         I2c(I2cError),
     }

--- a/examples/stm32l4/src/bin/spe_adin1110_http_server.rs
+++ b/examples/stm32l4/src/bin/spe_adin1110_http_server.rs
@@ -366,7 +366,7 @@ pub struct ADT7422<'d, BUS: I2cBus> {
     bus: BUS,
 }
 
-#[derive(Debug, Format)]
+#[derive(Debug, Format, PartialEq, Eq)]
 pub enum Error<I2cError: Format> {
     I2c(I2cError),
     Address,


### PR DESCRIPTION
I did a search for `enum Error`, and added `PartialEq, Eq` where it was missing. You could maybe also make an argument for adding `Clone`, open to thoughts!