### PR TITLE
Add MCO support for stm32wl family

### DIFF
--- a/embassy-stm32/build.rs
+++ b/embassy-stm32/build.rs
@@ -50,12 +50,10 @@ fn main() {
                 // We *shouldn't* have singletons for these, but the HAL currently requires
                 // singletons, for using with RccPeripheral to enable/disable clocks to them.
                 "rcc" => {
-                    if r.version.starts_with("h5") || r.version.starts_with("h7") || r.version.starts_with("f4") {
-                        singletons.push("MCO1".to_string());
-                        singletons.push("MCO2".to_string());
-                    }
-                    if r.version.starts_with("l4") {
-                        singletons.push("MCO".to_string());
+                    for pin in p.pins {
+                        if pin.signal.starts_with("MCO") {
+                            singletons.push(pin.signal.replace('_', "").to_string());
+                        }
                     }
                     singletons.push(p.name.to_string());
                 }
@@ -751,25 +749,8 @@ fn main() {
                     let af = pin.af.unwrap_or(0);
 
                     // MCO is special
-                    if pin.signal.starts_with("MCO_") {
-                        // Supported in H7 only for now
-                        if regs.version.starts_with("h5")
-                            || regs.version.starts_with("h7")
-                            || regs.version.starts_with("f4")
-                        {
-                            peri = format_ident!("{}", pin.signal.replace('_', ""));
-                        } else {
-                            continue;
-                        }
-                    }
-
-                    if pin.signal == "MCO" {
-                        // Supported in H7 only for now
-                        if regs.version.starts_with("l4") {
-                            peri = format_ident!("MCO");
-                        } else {
-                            continue;
-                        }
+                    if pin.signal.starts_with("MCO") {
+                        peri = format_ident!("{}", pin.signal.replace('_', ""));
                     }
 
                     g.extend(quote! {

--- a/embassy-stm32/src/rcc/mod.rs
+++ b/embassy-stm32/src/rcc/mod.rs
@@ -7,9 +7,9 @@ use crate::time::Hertz;
 
 pub(crate) mod bd;
 mod bus;
-#[cfg(any(stm32h5, stm32h7))]
+#[cfg(any(stm32h5, stm32h7, stm32wl))]
 mod mco;
-#[cfg(any(stm32h5, stm32h7))]
+#[cfg(any(stm32h5, stm32h7, stm32wl))]
 pub use mco::*;
 
 #[cfg_attr(rcc_f0, path = "f0.rs")]


### PR DESCRIPTION
Per discussions in the chat forum, this exposes the MCO feature for the STM32WL. It exposes the McoPin trait on any processor that has an MCO peripheral, by making the selection based on the pin signal starting with MCO.