### PR TITLE
stm32: Implement embedded-hal-async I2C trait for TimeoutI2c

### DIFF
--- a/embassy-stm32/src/i2c/timeout.rs
+++ b/embassy-stm32/src/i2c/timeout.rs
@@ -211,15 +211,15 @@ mod eha {
         for TimeoutI2c<'a, T, TXDMA, RXDMA>
     {
         async fn read(&mut self, address: u8, read: &mut [u8]) -> Result<(), Self::Error> {
-            self.read(address, read).await
+            self.i2c.read_timeout(address, read, timeout_fn(timeout)).await
         }
 
         async fn write(&mut self, address: u8, write: &[u8]) -> Result<(), Self::Error> {
-            self.write(address, write).await
+            self.i2c.write_timeout(address, write, timeout_fn(timeout)).await
         }
 
         async fn write_read(&mut self, address: u8, write: &[u8], read: &mut [u8]) -> Result<(), Self::Error> {
-            self.write_read(address, write, read).await
+            self.i2c.write_read_timeout(address, write, read, timeout_fn(timeout)).await
         }
 
         async fn transaction(

--- a/embassy-stm32/src/i2c/timeout.rs
+++ b/embassy-stm32/src/i2c/timeout.rs
@@ -147,9 +147,7 @@ impl<'a, T: Instance, TXDMA, RXDMA> TimeoutI2c<'a, T, TXDMA, RXDMA> {
     }
 }
 
-impl<'a, T: Instance, TXDMA, RXDMA> embedded_hal_02::blocking::i2c::Read
-    for TimeoutI2c<'a, T, TXDMA, RXDMA>
-{
+impl<'a, T: Instance, TXDMA, RXDMA> embedded_hal_02::blocking::i2c::Read for TimeoutI2c<'a, T, TXDMA, RXDMA> {
     type Error = Error;
 
     fn read(&mut self, addr: u8, read: &mut [u8]) -> Result<(), Self::Error> {
@@ -157,9 +155,7 @@ impl<'a, T: Instance, TXDMA, RXDMA> embedded_hal_02::blocking::i2c::Read
     }
 }
 
-impl<'a, T: Instance, TXDMA, RXDMA> embedded_hal_02::blocking::i2c::Write
-    for TimeoutI2c<'a, T, TXDMA, RXDMA>
-{
+impl<'a, T: Instance, TXDMA, RXDMA> embedded_hal_02::blocking::i2c::Write for TimeoutI2c<'a, T, TXDMA, RXDMA> {
     type Error = Error;
 
     fn write(&mut self, addr: u8, write: &[u8]) -> Result<(), Self::Error> {
@@ -167,9 +163,7 @@ impl<'a, T: Instance, TXDMA, RXDMA> embedded_hal_02::blocking::i2c::Write
     }
 }
 
-impl<'a, T: Instance, TXDMA, RXDMA> embedded_hal_02::blocking::i2c::WriteRead
-    for TimeoutI2c<'a, T, TXDMA, RXDMA>
-{
+impl<'a, T: Instance, TXDMA, RXDMA> embedded_hal_02::blocking::i2c::WriteRead for TimeoutI2c<'a, T, TXDMA, RXDMA> {
     type Error = Error;
 
     fn write_read(&mut self, addr: u8, write: &[u8], read: &mut [u8]) -> Result<(), Self::Error> {
@@ -213,7 +207,9 @@ mod eha {
     use super::super::{RxDma, TxDma};
     use super::*;
 
-    impl<'a, T: Instance, TXDMA: TxDma<T>, RXDMA: RxDma<T>> embedded_hal_async::i2c::I2c for TimeoutI2c<'a, T, TXDMA, RXDMA> {
+    impl<'a, T: Instance, TXDMA: TxDma<T>, RXDMA: RxDma<T>> embedded_hal_async::i2c::I2c
+        for TimeoutI2c<'a, T, TXDMA, RXDMA>
+    {
         async fn read(&mut self, address: u8, read: &mut [u8]) -> Result<(), Self::Error> {
             self.read(address, read).await
         }

--- a/embassy-stm32/src/i2c/timeout.rs
+++ b/embassy-stm32/src/i2c/timeout.rs
@@ -219,7 +219,9 @@ mod eha {
         }
 
         async fn write_read(&mut self, address: u8, write: &[u8], read: &mut [u8]) -> Result<(), Self::Error> {
-            self.i2c.write_read_timeout(address, write, read, timeout_fn(timeout)).await
+            self.i2c
+                .write_read_timeout(address, write, read, timeout_fn(timeout))
+                .await
         }
 
         async fn transaction(

--- a/embassy-stm32/src/i2c/timeout.rs
+++ b/embassy-stm32/src/i2c/timeout.rs
@@ -207,3 +207,33 @@ mod eh1 {
         }
     }
 }
+
+#[cfg(all(feature = "unstable-traits", feature = "nightly"))]
+mod eha {
+    use super::super::{RxDma, TxDma};
+    use super::*;
+
+    impl<'a, T: Instance, TXDMA: TxDma<T>, RXDMA: RxDma<T>> embedded_hal_async::i2c::I2c for I2c<'a, T, TXDMA, RXDMA> {
+        async fn read(&mut self, address: u8, read: &mut [u8]) -> Result<(), Self::Error> {
+            self.read(address, read).await
+        }
+
+        async fn write(&mut self, address: u8, write: &[u8]) -> Result<(), Self::Error> {
+            self.write(address, write).await
+        }
+
+        async fn write_read(&mut self, address: u8, write: &[u8], read: &mut [u8]) -> Result<(), Self::Error> {
+            self.write_read(address, write, read).await
+        }
+
+        async fn transaction(
+            &mut self,
+            address: u8,
+            operations: &mut [embedded_hal_1::i2c::Operation<'_>],
+        ) -> Result<(), Self::Error> {
+            let _ = address;
+            let _ = operations;
+            todo!()
+        }
+    }
+}

--- a/embassy-stm32/src/i2c/timeout.rs
+++ b/embassy-stm32/src/i2c/timeout.rs
@@ -213,7 +213,7 @@ mod eha {
     use super::super::{RxDma, TxDma};
     use super::*;
 
-    impl<'a, T: Instance, TXDMA: TxDma<T>, RXDMA: RxDma<T>> embedded_hal_async::i2c::I2c for I2c<'a, T, TXDMA, RXDMA> {
+    impl<'a, T: Instance, TXDMA: TxDma<T>, RXDMA: RxDma<T>> embedded_hal_async::i2c::I2c for TimeoutI2c<'a, T, TXDMA, RXDMA> {
         async fn read(&mut self, address: u8, read: &mut [u8]) -> Result<(), Self::Error> {
             self.read(address, read).await
         }

--- a/embassy-stm32/src/i2c/timeout.rs
+++ b/embassy-stm32/src/i2c/timeout.rs
@@ -6,8 +6,8 @@ use super::{Error, I2c, Instance};
 ///
 /// This is useful for recovering from a shorted bus or a device stuck in a clock stretching state.
 /// A regular [I2c] would freeze until condition is removed.
-pub struct TimeoutI2c<'a, 'd: 'a, T: Instance, TXDMA, RXDMA> {
-    i2c: &'a mut I2c<'d, T, TXDMA, RXDMA>,
+pub struct TimeoutI2c<'a, T: Instance, TXDMA, RXDMA> {
+    i2c: I2c<'a, T, TXDMA, RXDMA>,
     timeout: Duration,
 }
 
@@ -22,8 +22,8 @@ fn timeout_fn(timeout: Duration) -> impl Fn() -> Result<(), Error> {
     }
 }
 
-impl<'a, 'd: 'a, T: Instance, TXDMA, RXDMA> TimeoutI2c<'a, 'd, T, TXDMA, RXDMA> {
-    pub fn new(i2c: &'a mut I2c<'d, T, TXDMA, RXDMA>, timeout: Duration) -> Self {
+impl<'a, T: Instance, TXDMA, RXDMA> TimeoutI2c<'a, T, TXDMA, RXDMA> {
+    pub fn new(i2c: I2c<'d, T, TXDMA, RXDMA>, timeout: Duration) -> Self {
         Self { i2c, timeout }
     }
 
@@ -157,8 +157,8 @@ impl<'a, 'd: 'a, T: Instance, TXDMA, RXDMA> embedded_hal_02::blocking::i2c::Read
     }
 }
 
-impl<'a, 'd: 'a, T: Instance, TXDMA, RXDMA> embedded_hal_02::blocking::i2c::Write
-    for TimeoutI2c<'a, 'd, T, TXDMA, RXDMA>
+impl<'a, T: Instance, TXDMA, RXDMA> embedded_hal_02::blocking::i2c::Write
+    for TimeoutI2c<'a, T, TXDMA, RXDMA>
 {
     type Error = Error;
 
@@ -181,11 +181,11 @@ impl<'a, 'd: 'a, T: Instance, TXDMA, RXDMA> embedded_hal_02::blocking::i2c::Writ
 mod eh1 {
     use super::*;
 
-    impl<'a, 'd: 'a, T: Instance, TXDMA, RXDMA> embedded_hal_1::i2c::ErrorType for TimeoutI2c<'a, 'd, T, TXDMA, RXDMA> {
+    impl<'a, T: Instance, TXDMA, RXDMA> embedded_hal_1::i2c::ErrorType for TimeoutI2c<'a, T, TXDMA, RXDMA> {
         type Error = Error;
     }
 
-    impl<'a, 'd: 'a, T: Instance, TXDMA, RXDMA> embedded_hal_1::i2c::I2c for TimeoutI2c<'a, 'd, T, TXDMA, RXDMA> {
+    impl<'a, T: Instance, TXDMA, RXDMA> embedded_hal_1::i2c::I2c for TimeoutI2c<'a, T, TXDMA, RXDMA> {
         fn read(&mut self, address: u8, read: &mut [u8]) -> Result<(), Self::Error> {
             self.blocking_read(address, read)
         }

--- a/embassy-stm32/src/i2c/timeout.rs
+++ b/embassy-stm32/src/i2c/timeout.rs
@@ -207,7 +207,9 @@ mod eha {
     use super::super::{RxDma, TxDma};
     use super::*;
 
-    impl<'a, T: Instance, TXDMA, RXDMA> embedded_hal_async::i2c::I2c for TimeoutI2c<'a, T, TXDMA, RXDMA> {
+    impl<'a, T: Instance, TXDMA: TxDma<T>, RXDMA: RxDma<T>> embedded_hal_async::i2c::I2c
+        for TimeoutI2c<'a, T, TXDMA, RXDMA>
+    {
         async fn read(&mut self, address: u8, read: &mut [u8]) -> Result<(), Self::Error> {
             self.i2c.read_timeout(address, read, timeout_fn(self.timeout)).await
         }

--- a/embassy-stm32/src/i2c/timeout.rs
+++ b/embassy-stm32/src/i2c/timeout.rs
@@ -23,7 +23,7 @@ fn timeout_fn(timeout: Duration) -> impl Fn() -> Result<(), Error> {
 }
 
 impl<'a, T: Instance, TXDMA, RXDMA> TimeoutI2c<'a, T, TXDMA, RXDMA> {
-    pub fn new(i2c: I2c<'d, T, TXDMA, RXDMA>, timeout: Duration) -> Self {
+    pub fn new(i2c: I2c<'a, T, TXDMA, RXDMA>, timeout: Duration) -> Self {
         Self { i2c, timeout }
     }
 
@@ -147,8 +147,8 @@ impl<'a, T: Instance, TXDMA, RXDMA> TimeoutI2c<'a, T, TXDMA, RXDMA> {
     }
 }
 
-impl<'a, 'd: 'a, T: Instance, TXDMA, RXDMA> embedded_hal_02::blocking::i2c::Read
-    for TimeoutI2c<'a, 'd, T, TXDMA, RXDMA>
+impl<'a, T: Instance, TXDMA, RXDMA> embedded_hal_02::blocking::i2c::Read
+    for TimeoutI2c<'a, T, TXDMA, RXDMA>
 {
     type Error = Error;
 
@@ -167,8 +167,8 @@ impl<'a, T: Instance, TXDMA, RXDMA> embedded_hal_02::blocking::i2c::Write
     }
 }
 
-impl<'a, 'd: 'a, T: Instance, TXDMA, RXDMA> embedded_hal_02::blocking::i2c::WriteRead
-    for TimeoutI2c<'a, 'd, T, TXDMA, RXDMA>
+impl<'a, T: Instance, TXDMA, RXDMA> embedded_hal_02::blocking::i2c::WriteRead
+    for TimeoutI2c<'a, T, TXDMA, RXDMA>
 {
     type Error = Error;
 

--- a/embassy-stm32/src/i2c/timeout.rs
+++ b/embassy-stm32/src/i2c/timeout.rs
@@ -207,20 +207,18 @@ mod eha {
     use super::super::{RxDma, TxDma};
     use super::*;
 
-    impl<'a, T: Instance, TXDMA: TxDma<T>, RXDMA: RxDma<T>> embedded_hal_async::i2c::I2c
-        for TimeoutI2c<'a, T, TXDMA, RXDMA>
-    {
+    impl<'a, T: Instance, TXDMA, RXDMA> embedded_hal_async::i2c::I2c for TimeoutI2c<'a, T, TXDMA, RXDMA> {
         async fn read(&mut self, address: u8, read: &mut [u8]) -> Result<(), Self::Error> {
-            self.i2c.read_timeout(address, read, timeout_fn(timeout)).await
+            self.i2c.read_timeout(address, read, timeout_fn(self.timeout)).await
         }
 
         async fn write(&mut self, address: u8, write: &[u8]) -> Result<(), Self::Error> {
-            self.i2c.write_timeout(address, write, timeout_fn(timeout)).await
+            self.i2c.write_timeout(address, write, timeout_fn(self.timeout)).await
         }
 
         async fn write_read(&mut self, address: u8, write: &[u8], read: &mut [u8]) -> Result<(), Self::Error> {
             self.i2c
-                .write_read_timeout(address, write, read, timeout_fn(timeout))
+                .write_read_timeout(address, write, read, timeout_fn(self.timeout))
                 .await
         }
 

--- a/embassy-stm32/src/i2c/timeout.rs
+++ b/embassy-stm32/src/i2c/timeout.rs
@@ -202,7 +202,7 @@ mod eh1 {
     }
 }
 
-#[cfg(all(feature = "unstable-traits", feature = "nightly"))]
+#[cfg(all(feature = "unstable-traits", feature = "nightly", i2c_v2))]
 mod eha {
     use super::super::{RxDma, TxDma};
     use super::*;

--- a/examples/stm32f4/src/bin/i2c.rs
+++ b/examples/stm32f4/src/bin/i2c.rs
@@ -23,7 +23,7 @@ async fn main(_spawner: Spawner) {
     info!("Hello world!");
     let p = embassy_stm32::init(Default::default());
 
-    let mut i2c = I2c::new(
+    let i2c = I2c::new(
         p.I2C2,
         p.PB10,
         p.PB11,

--- a/examples/stm32f4/src/bin/i2c.rs
+++ b/examples/stm32f4/src/bin/i2c.rs
@@ -36,7 +36,7 @@ async fn main(_spawner: Spawner) {
 
     // I2C bus can freeze if SCL line is shorted or due to a broken device that clock stretches for too long.
     // TimeoutI2c allows recovering from such errors by throwing `Error::Timeout` after a given delay.
-    let mut timeout_i2c = TimeoutI2c::new(&mut i2c, Duration::from_millis(1000));
+    let mut timeout_i2c = TimeoutI2c::new(i2c, Duration::from_millis(1000));
 
     let mut data = [0u8; 1];
 

--- a/examples/stm32h5/src/bin/i2c.rs
+++ b/examples/stm32h5/src/bin/i2c.rs
@@ -35,7 +35,7 @@ async fn main(_spawner: Spawner) {
 
     // I2C bus can freeze if SCL line is shorted or due to a broken device that clock stretches for too long.
     // TimeoutI2c allows recovering from such errors by throwing `Error::Timeout` after a given delay.
-    let mut timeout_i2c = TimeoutI2c::new(&mut i2c, Duration::from_millis(1000));
+    let mut timeout_i2c = TimeoutI2c::new(i2c, Duration::from_millis(1000));
 
     let mut data = [0u8; 1];
 

--- a/examples/stm32h5/src/bin/i2c.rs
+++ b/examples/stm32h5/src/bin/i2c.rs
@@ -22,7 +22,7 @@ async fn main(_spawner: Spawner) {
     info!("Hello world!");
     let p = embassy_stm32::init(Default::default());
 
-    let mut i2c = I2c::new(
+    let i2c = I2c::new(
         p.I2C2,
         p.PB10,
         p.PB11,

--- a/examples/stm32h7/src/bin/i2c.rs
+++ b/examples/stm32h7/src/bin/i2c.rs
@@ -35,7 +35,7 @@ async fn main(_spawner: Spawner) {
 
     // I2C bus can freeze if SCL line is shorted or due to a broken device that clock stretches for too long.
     // TimeoutI2c allows recovering from such errors by throwing `Error::Timeout` after a given delay.
-    let mut timeout_i2c = TimeoutI2c::new(&mut i2c, Duration::from_millis(1000));
+    let mut timeout_i2c = TimeoutI2c::new(i2c, Duration::from_millis(1000));
 
     let mut data = [0u8; 1];
 

--- a/examples/stm32h7/src/bin/i2c.rs
+++ b/examples/stm32h7/src/bin/i2c.rs
@@ -22,7 +22,7 @@ async fn main(_spawner: Spawner) {
     info!("Hello world!");
     let p = embassy_stm32::init(Default::default());
 
-    let mut i2c = I2c::new(
+    let i2c = I2c::new(
         p.I2C2,
         p.PB10,
         p.PB11,


### PR DESCRIPTION
I also made `TimeoutI2c` take ownership of the I2C peripheral. I didn't see the point in taking a mutable reference, it made it unnecessarily harder to use IMO.