### PR TITLE
stm32 flash: check lock bit before unlocking

### DIFF
--- a/embassy-stm32/src/flash/f0.rs
+++ b/embassy-stm32/src/flash/f0.rs
@@ -19,8 +19,10 @@ pub(crate) unsafe fn lock() {
 }
 
 pub(crate) unsafe fn unlock() {
-    pac::FLASH.keyr().write(|w| w.set_fkeyr(0x4567_0123));
-    pac::FLASH.keyr().write(|w| w.set_fkeyr(0xCDEF_89AB));
+    if pac::FLASH.cr().read().lock() {
+        pac::FLASH.keyr().write(|w| w.set_fkeyr(0x4567_0123));
+        pac::FLASH.keyr().write(|w| w.set_fkeyr(0xCDEF_89AB));
+    }
 }
 
 pub(crate) unsafe fn enable_blocking_write() {

--- a/embassy-stm32/src/flash/f3.rs
+++ b/embassy-stm32/src/flash/f3.rs
@@ -19,8 +19,10 @@ pub(crate) unsafe fn lock() {
 }
 
 pub(crate) unsafe fn unlock() {
-    pac::FLASH.keyr().write(|w| w.set_fkeyr(0x4567_0123));
-    pac::FLASH.keyr().write(|w| w.set_fkeyr(0xCDEF_89AB));
+    if pac::FLASH.cr().read().lock() {
+        pac::FLASH.keyr().write(|w| w.set_fkeyr(0x4567_0123));
+        pac::FLASH.keyr().write(|w| w.set_fkeyr(0xCDEF_89AB));
+    }
 }
 
 pub(crate) unsafe fn enable_blocking_write() {

--- a/embassy-stm32/src/flash/f4.rs
+++ b/embassy-stm32/src/flash/f4.rs
@@ -228,8 +228,10 @@ pub(crate) unsafe fn lock() {
 }
 
 pub(crate) unsafe fn unlock() {
-    pac::FLASH.keyr().write(|w| w.set_key(0x45670123));
-    pac::FLASH.keyr().write(|w| w.set_key(0xCDEF89AB));
+    if pac::FLASH.cr().read().lock() {
+        pac::FLASH.keyr().write(|w| w.set_key(0x45670123));
+        pac::FLASH.keyr().write(|w| w.set_key(0xCDEF89AB));
+    }
 }
 
 pub(crate) unsafe fn enable_write() {

--- a/embassy-stm32/src/flash/f7.rs
+++ b/embassy-stm32/src/flash/f7.rs
@@ -19,8 +19,10 @@ pub(crate) unsafe fn lock() {
 }
 
 pub(crate) unsafe fn unlock() {
-    pac::FLASH.keyr().write(|w| w.set_key(0x4567_0123));
-    pac::FLASH.keyr().write(|w| w.set_key(0xCDEF_89AB));
+    if pac::FLASH.cr().read().lock() {
+        pac::FLASH.keyr().write(|w| w.set_key(0x4567_0123));
+        pac::FLASH.keyr().write(|w| w.set_key(0xCDEF_89AB));
+    }
 }
 
 pub(crate) unsafe fn enable_blocking_write() {

--- a/embassy-stm32/src/flash/g0.rs
+++ b/embassy-stm32/src/flash/g0.rs
@@ -24,8 +24,10 @@ pub(crate) unsafe fn unlock() {
     while pac::FLASH.sr().read().bsy() {}
 
     // Unlock flash
-    pac::FLASH.keyr().write(|w| w.set_keyr(0x4567_0123));
-    pac::FLASH.keyr().write(|w| w.set_keyr(0xCDEF_89AB));
+    if pac::FLASH.cr().read().lock() {
+        pac::FLASH.keyr().write(|w| w.set_keyr(0x4567_0123));
+        pac::FLASH.keyr().write(|w| w.set_keyr(0xCDEF_89AB));
+    }
 }
 
 pub(crate) unsafe fn enable_blocking_write() {

--- a/embassy-stm32/src/flash/h7.rs
+++ b/embassy-stm32/src/flash/h7.rs
@@ -26,11 +26,15 @@ pub(crate) unsafe fn lock() {
 }
 
 pub(crate) unsafe fn unlock() {
-    pac::FLASH.bank(0).keyr().write(|w| w.set_keyr(0x4567_0123));
-    pac::FLASH.bank(0).keyr().write(|w| w.set_keyr(0xCDEF_89AB));
+    if pac::FLASH.bank(0).cr().read().lock() {
+        pac::FLASH.bank(0).keyr().write(|w| w.set_keyr(0x4567_0123));
+        pac::FLASH.bank(0).keyr().write(|w| w.set_keyr(0xCDEF_89AB));
+    }
     if is_dual_bank() {
-        pac::FLASH.bank(1).keyr().write(|w| w.set_keyr(0x4567_0123));
-        pac::FLASH.bank(1).keyr().write(|w| w.set_keyr(0xCDEF_89AB));
+        if pac::FLASH.bank(1).cr().read().lock() {
+            pac::FLASH.bank(1).keyr().write(|w| w.set_keyr(0x4567_0123));
+            pac::FLASH.bank(1).keyr().write(|w| w.set_keyr(0xCDEF_89AB));
+        }
     }
 }
 

--- a/embassy-stm32/src/flash/l.rs
+++ b/embassy-stm32/src/flash/l.rs
@@ -28,17 +28,23 @@ pub(crate) unsafe fn lock() {
 pub(crate) unsafe fn unlock() {
     #[cfg(any(flash_wl, flash_wb, flash_l4))]
     {
-        pac::FLASH.keyr().write(|w| w.set_keyr(0x4567_0123));
-        pac::FLASH.keyr().write(|w| w.set_keyr(0xCDEF_89AB));
+        if pac::FLASH.cr().read().lock() {
+            pac::FLASH.keyr().write(|w| w.set_keyr(0x4567_0123));
+            pac::FLASH.keyr().write(|w| w.set_keyr(0xCDEF_89AB));
+        }
     }
 
     #[cfg(any(flash_l0, flash_l1))]
     {
-        pac::FLASH.pekeyr().write(|w| w.set_pekeyr(0x89ABCDEF));
-        pac::FLASH.pekeyr().write(|w| w.set_pekeyr(0x02030405));
+        if pac::FLASH.pecr().read().pelock() {
+            pac::FLASH.pekeyr().write(|w| w.set_pekeyr(0x89ABCDEF));
+            pac::FLASH.pekeyr().write(|w| w.set_pekeyr(0x02030405));
+        }
 
-        pac::FLASH.prgkeyr().write(|w| w.set_prgkeyr(0x8C9DAEBF));
-        pac::FLASH.prgkeyr().write(|w| w.set_prgkeyr(0x13141516));
+        if pac::FLASH.pecr().read().prglock() {
+            pac::FLASH.prgkeyr().write(|w| w.set_prgkeyr(0x8C9DAEBF));
+            pac::FLASH.prgkeyr().write(|w| w.set_prgkeyr(0x13141516));
+        }
     }
 }
 


### PR DESCRIPTION
It hardfaults if already unlocked flash is unlocked again.

Tested on stm32g081 where I always got hardfault when unlocking and then realised that flash was actually already unlocked. Not sure why it is unlocked after flashing on my case, but those changes prevent hardfault if this is the case.

At least on stm32g081 erase read write are still working after those changes.