### PR TITLE
STM32: combine RccPeripherals reset() and enable() to enable_and_reset()

### DIFF
--- a/embassy-stm32/build.rs
+++ b/embassy-stm32/build.rs
@@ -452,10 +452,8 @@ fn main() {
                     let rst_reg = format_ident!("{}", rst.register.to_ascii_lowercase());
                     let set_rst_field = format_ident!("set_{}", rst.field.to_ascii_lowercase());
                     quote! {
-                        critical_section::with(|_| {
-                            crate::pac::RCC.#rst_reg().modify(|w| w.#set_rst_field(true));
-                            crate::pac::RCC.#rst_reg().modify(|w| w.#set_rst_field(false));
-                        });
+                        crate::pac::RCC.#rst_reg().modify(|w| w.#set_rst_field(true));
+                        crate::pac::RCC.#rst_reg().modify(|w| w.#set_rst_field(false));
                     }
                 }
                 None => TokenStream::new(),

--- a/embassy-stm32/build.rs
+++ b/embassy-stm32/build.rs
@@ -556,14 +556,14 @@ fn main() {
                     fn frequency() -> crate::time::Hertz {
                         #clock_frequency
                     }
-                    fn enable() {
+                    fn enable_and_reset() {
                         critical_section::with(|_cs| {
                             #before_enable
-                            #rst
                             #[cfg(feature = "low-power")]
                             crate::rcc::clock_refcount_add(_cs);
                             crate::pac::RCC.#en_reg().modify(|w| w.#set_en_field(true));
                             #after_enable
+                            #rst
                         })
                     }
                     fn disable() {

--- a/embassy-stm32/build.rs
+++ b/embassy-stm32/build.rs
@@ -559,6 +559,7 @@ fn main() {
                     fn enable() {
                         critical_section::with(|_cs| {
                             #before_enable
+                            #rst
                             #[cfg(feature = "low-power")]
                             crate::rcc::clock_refcount_add(_cs);
                             crate::pac::RCC.#en_reg().modify(|w| w.#set_en_field(true));
@@ -572,9 +573,6 @@ fn main() {
                             #[cfg(feature = "low-power")]
                             crate::rcc::clock_refcount_sub(_cs);
                         })
-                    }
-                    fn reset() {
-                        #rst
                     }
                 }
 

--- a/embassy-stm32/src/adc/f1.rs
+++ b/embassy-stm32/src/adc/f1.rs
@@ -51,8 +51,7 @@ impl<T: Instance> super::sealed::AdcPin<T> for Temperature {
 impl<'d, T: Instance> Adc<'d, T> {
     pub fn new(adc: impl Peripheral<P = T> + 'd, delay: &mut impl DelayUs<u32>) -> Self {
         into_ref!(adc);
-        T::enable();
-        T::reset();
+        T::reset_and_enable();
         T::regs().cr2().modify(|reg| reg.set_adon(true));
 
         // 11.4: Before starting a calibration, the ADC must have been in power-on state (ADON bit = ‘1’)

--- a/embassy-stm32/src/adc/f1.rs
+++ b/embassy-stm32/src/adc/f1.rs
@@ -51,7 +51,7 @@ impl<T: Instance> super::sealed::AdcPin<T> for Temperature {
 impl<'d, T: Instance> Adc<'d, T> {
     pub fn new(adc: impl Peripheral<P = T> + 'd, delay: &mut impl DelayUs<u32>) -> Self {
         into_ref!(adc);
-        T::reset_and_enable();
+        T::enable_and_reset();
         T::regs().cr2().modify(|reg| reg.set_adon(true));
 
         // 11.4: Before starting a calibration, the ADC must have been in power-on state (ADON bit = ‘1’)

--- a/embassy-stm32/src/adc/f3.rs
+++ b/embassy-stm32/src/adc/f3.rs
@@ -64,7 +64,7 @@ impl<'d, T: Instance> Adc<'d, T> {
 
         into_ref!(adc);
 
-        T::reset_and_enable();
+        T::enable_and_reset();
 
         // Enable the adc regulator
         T::regs().cr().modify(|w| w.set_advregen(vals::Advregen::INTERMEDIATE));

--- a/embassy-stm32/src/adc/f3.rs
+++ b/embassy-stm32/src/adc/f3.rs
@@ -64,8 +64,7 @@ impl<'d, T: Instance> Adc<'d, T> {
 
         into_ref!(adc);
 
-        T::enable();
-        T::reset();
+        T::reset_and_enable();
 
         // Enable the adc regulator
         T::regs().cr().modify(|w| w.set_advregen(vals::Advregen::INTERMEDIATE));

--- a/embassy-stm32/src/adc/mod.rs
+++ b/embassy-stm32/src/adc/mod.rs
@@ -74,9 +74,9 @@ pub(crate) mod sealed {
     }
 }
 
-#[cfg(not(any(adc_f1, adc_v1, adc_v2, adc_v4, adc_f3)))]
+#[cfg(not(any(adc_f1, adc_v1, adc_v2, adc_v3, adc_v4, adc_f3, adc_g0)))]
 pub trait Instance: sealed::Instance + crate::Peripheral<P = Self> {}
-#[cfg(any(adc_f1, adc_v1, adc_v2, adc_v4, adc_f3))]
+#[cfg(any(adc_f1, adc_v1, adc_v2, adc_v3, adc_v4, adc_f3, adc_g0))]
 pub trait Instance: sealed::Instance + crate::Peripheral<P = Self> + crate::rcc::RccPeripheral {}
 
 pub trait AdcPin<T: Instance>: sealed::AdcPin<T> {}

--- a/embassy-stm32/src/adc/v1.rs
+++ b/embassy-stm32/src/adc/v1.rs
@@ -61,7 +61,7 @@ impl<'d, T: Instance> Adc<'d, T> {
         delay: &mut impl DelayUs<u32>,
     ) -> Self {
         into_ref!(adc);
-        T::reset_and_enable();
+        T::enable_and_reset();
 
         // Delay 1μs when using HSI14 as the ADC clock.
         //

--- a/embassy-stm32/src/adc/v1.rs
+++ b/embassy-stm32/src/adc/v1.rs
@@ -61,8 +61,7 @@ impl<'d, T: Instance> Adc<'d, T> {
         delay: &mut impl DelayUs<u32>,
     ) -> Self {
         into_ref!(adc);
-        T::enable();
-        T::reset();
+        T::reset_and_enable();
 
         // Delay 1μs when using HSI14 as the ADC clock.
         //

--- a/embassy-stm32/src/adc/v2.rs
+++ b/embassy-stm32/src/adc/v2.rs
@@ -95,7 +95,7 @@ where
 {
     pub fn new(adc: impl Peripheral<P = T> + 'd, delay: &mut impl DelayUs<u32>) -> Self {
         into_ref!(adc);
-        T::reset_and_enable();
+        T::enable_and_reset();
 
         let presc = Prescaler::from_pclk2(T::frequency());
         T::common_regs().ccr().modify(|w| w.set_adcpre(presc.adcpre()));

--- a/embassy-stm32/src/adc/v2.rs
+++ b/embassy-stm32/src/adc/v2.rs
@@ -95,8 +95,7 @@ where
 {
     pub fn new(adc: impl Peripheral<P = T> + 'd, delay: &mut impl DelayUs<u32>) -> Self {
         into_ref!(adc);
-        T::enable();
-        T::reset();
+        T::reset_and_enable();
 
         let presc = Prescaler::from_pclk2(T::frequency());
         T::common_regs().ccr().modify(|w| w.set_adcpre(presc.adcpre()));

--- a/embassy-stm32/src/adc/v3.rs
+++ b/embassy-stm32/src/adc/v3.rs
@@ -48,7 +48,7 @@ impl<T: Instance> super::sealed::AdcPin<T> for Vbat {
 impl<'d, T: Instance> Adc<'d, T> {
     pub fn new(adc: impl Peripheral<P = T> + 'd, delay: &mut impl DelayUs<u32>) -> Self {
         into_ref!(adc);
-        T::reset_and_enable();
+        T::enable_and_reset();
         T::regs().cr().modify(|reg| {
             #[cfg(not(adc_g0))]
             reg.set_deeppwd(false);

--- a/embassy-stm32/src/adc/v3.rs
+++ b/embassy-stm32/src/adc/v3.rs
@@ -9,19 +9,6 @@ pub const VREF_DEFAULT_MV: u32 = 3300;
 /// VREF voltage used for factory calibration of VREFINTCAL register.
 pub const VREF_CALIB_MV: u32 = 3000;
 
-/// Sadly we cannot use `RccPeripheral::enable` since devices are quite inconsistent ADC clock
-/// configuration.
-fn enable() {
-    critical_section::with(|_| {
-        #[cfg(any(stm32h7, stm32wl))]
-        crate::pac::RCC.apb2enr().modify(|w| w.set_adcen(true));
-        #[cfg(stm32g0)]
-        crate::pac::RCC.apbenr2().modify(|w| w.set_adcen(true));
-        #[cfg(any(stm32l4, stm32l5, stm32wb))]
-        crate::pac::RCC.ahb2enr().modify(|w| w.set_adcen(true));
-    });
-}
-
 pub struct VrefInt;
 impl<T: Instance> AdcPin<T> for VrefInt {}
 impl<T: Instance> super::sealed::AdcPin<T> for VrefInt {
@@ -61,7 +48,7 @@ impl<T: Instance> super::sealed::AdcPin<T> for Vbat {
 impl<'d, T: Instance> Adc<'d, T> {
     pub fn new(adc: impl Peripheral<P = T> + 'd, delay: &mut impl DelayUs<u32>) -> Self {
         into_ref!(adc);
-        enable();
+        T::reset_and_enable();
         T::regs().cr().modify(|reg| {
             #[cfg(not(adc_g0))]
             reg.set_deeppwd(false);

--- a/embassy-stm32/src/adc/v4.rs
+++ b/embassy-stm32/src/adc/v4.rs
@@ -127,7 +127,7 @@ impl Prescaler {
 impl<'d, T: Instance> Adc<'d, T> {
     pub fn new(adc: impl Peripheral<P = T> + 'd, delay: &mut impl DelayUs<u16>) -> Self {
         embassy_hal_internal::into_ref!(adc);
-        T::reset_and_enable();
+        T::enable_and_reset();
 
         let prescaler = Prescaler::from_ker_ck(T::frequency());
 

--- a/embassy-stm32/src/adc/v4.rs
+++ b/embassy-stm32/src/adc/v4.rs
@@ -127,8 +127,7 @@ impl Prescaler {
 impl<'d, T: Instance> Adc<'d, T> {
     pub fn new(adc: impl Peripheral<P = T> + 'd, delay: &mut impl DelayUs<u16>) -> Self {
         embassy_hal_internal::into_ref!(adc);
-        T::enable();
-        T::reset();
+        T::reset_and_enable();
 
         let prescaler = Prescaler::from_ker_ck(T::frequency());
 

--- a/embassy-stm32/src/can/bxcan.rs
+++ b/embassy-stm32/src/can/bxcan.rs
@@ -136,7 +136,7 @@ impl<'d, T: Instance> Can<'d, T> {
         rx.set_as_af(rx.af_num(), AFType::Input);
         tx.set_as_af(tx.af_num(), AFType::OutputPushPull);
 
-        T::reset_and_enable();
+        T::enable_and_reset();
 
         {
             use crate::pac::can::vals::{Errie, Fmpie, Tmeie};

--- a/embassy-stm32/src/can/bxcan.rs
+++ b/embassy-stm32/src/can/bxcan.rs
@@ -136,8 +136,7 @@ impl<'d, T: Instance> Can<'d, T> {
         rx.set_as_af(rx.af_num(), AFType::Input);
         tx.set_as_af(tx.af_num(), AFType::OutputPushPull);
 
-        T::enable();
-        T::reset();
+        T::reset_and_enable();
 
         {
             use crate::pac::can::vals::{Errie, Fmpie, Tmeie};

--- a/embassy-stm32/src/crc/v1.rs
+++ b/embassy-stm32/src/crc/v1.rs
@@ -16,9 +16,7 @@ impl<'d> Crc<'d> {
 
         // Note: enable and reset come from RccPeripheral.
         // enable CRC clock in RCC.
-        CRC::enable();
-        // Reset CRC to default values.
-        CRC::reset();
+        CRC::reset_and_enable();
         // Peripheral the peripheral
         let mut instance = Self { _peri: peripheral };
         instance.reset();

--- a/embassy-stm32/src/crc/v1.rs
+++ b/embassy-stm32/src/crc/v1.rs
@@ -16,7 +16,7 @@ impl<'d> Crc<'d> {
 
         // Note: enable and reset come from RccPeripheral.
         // enable CRC clock in RCC.
-        CRC::reset_and_enable();
+        CRC::enable_and_reset();
         // Peripheral the peripheral
         let mut instance = Self { _peri: peripheral };
         instance.reset();

--- a/embassy-stm32/src/crc/v2v3.rs
+++ b/embassy-stm32/src/crc/v2v3.rs
@@ -69,16 +69,13 @@ impl<'d> Crc<'d> {
     /// Instantiates the CRC32 peripheral and initializes it to default values.
     pub fn new(peripheral: impl Peripheral<P = CRC> + 'd, config: Config) -> Self {
         // Note: enable and reset come from RccPeripheral.
-        // enable CRC clock in RCC.
-        CRC::enable();
-        // Reset CRC to default values.
-        CRC::reset();
+        // reset to default values and enable CRC clock in RCC.
+        CRC::reset_and_enable();
         into_ref!(peripheral);
         let mut instance = Self {
             _peripheral: peripheral,
             _config: config,
         };
-        CRC::reset();
         instance.reconfigure();
         instance.reset();
         instance

--- a/embassy-stm32/src/crc/v2v3.rs
+++ b/embassy-stm32/src/crc/v2v3.rs
@@ -70,7 +70,7 @@ impl<'d> Crc<'d> {
     pub fn new(peripheral: impl Peripheral<P = CRC> + 'd, config: Config) -> Self {
         // Note: enable and reset come from RccPeripheral.
         // reset to default values and enable CRC clock in RCC.
-        CRC::reset_and_enable();
+        CRC::enable_and_reset();
         into_ref!(peripheral);
         let mut instance = Self {
             _peripheral: peripheral,

--- a/embassy-stm32/src/dac/mod.rs
+++ b/embassy-stm32/src/dac/mod.rs
@@ -255,7 +255,7 @@ impl<'d, T: Instance, Tx> DacCh1<'d, T, Tx> {
     ) -> Self {
         pin.set_as_analog();
         into_ref!(peri, dma);
-        T::reset_and_enable();
+        T::enable_and_reset();
 
         let mut dac = Self { _peri: peri, dma };
 
@@ -365,7 +365,7 @@ impl<'d, T: Instance, Tx> DacCh2<'d, T, Tx> {
     ) -> Self {
         pin.set_as_analog();
         into_ref!(_peri, dma);
-        T::reset_and_enable();
+        T::enable_and_reset();
 
         let mut dac = Self {
             phantom: PhantomData,
@@ -481,7 +481,7 @@ impl<'d, T: Instance, TxCh1, TxCh2> Dac<'d, T, TxCh1, TxCh2> {
         pin_ch1.set_as_analog();
         pin_ch2.set_as_analog();
         into_ref!(peri, dma_ch1, dma_ch2);
-        T::reset_and_enable();
+        T::enable_and_reset();
 
         let mut dac_ch1 = DacCh1 {
             _peri: peri,
@@ -567,7 +567,7 @@ foreach_peripheral!(
                         critical_section::with(|_| unsafe { crate::rcc::get_freqs().apb1 })
                     }
 
-                    fn reset_and_enable() {
+                    fn enable_and_reset() {
                         critical_section::with(|_| {
                             crate::pac::RCC.apb1lrstr().modify(|w| w.set_dac12rst(true));
                             crate::pac::RCC.apb1lrstr().modify(|w| w.set_dac12rst(false));

--- a/embassy-stm32/src/dac/mod.rs
+++ b/embassy-stm32/src/dac/mod.rs
@@ -255,8 +255,7 @@ impl<'d, T: Instance, Tx> DacCh1<'d, T, Tx> {
     ) -> Self {
         pin.set_as_analog();
         into_ref!(peri, dma);
-        T::enable();
-        T::reset();
+        T::reset_and_enable();
 
         let mut dac = Self { _peri: peri, dma };
 
@@ -366,8 +365,7 @@ impl<'d, T: Instance, Tx> DacCh2<'d, T, Tx> {
     ) -> Self {
         pin.set_as_analog();
         into_ref!(_peri, dma);
-        T::enable();
-        T::reset();
+        T::reset_and_enable();
 
         let mut dac = Self {
             phantom: PhantomData,
@@ -483,8 +481,7 @@ impl<'d, T: Instance, TxCh1, TxCh2> Dac<'d, T, TxCh1, TxCh2> {
         pin_ch1.set_as_analog();
         pin_ch2.set_as_analog();
         into_ref!(peri, dma_ch1, dma_ch2);
-        T::enable();
-        T::reset();
+        T::reset_and_enable();
 
         let mut dac_ch1 = DacCh1 {
             _peri: peri,
@@ -563,35 +560,30 @@ pub trait DacPin<T: Instance, const C: u8>: crate::gpio::Pin + 'static {}
 
 foreach_peripheral!(
     (dac, $inst:ident) => {
-        // H7 uses single bit for both DAC1 and DAC2, this is a hack until a proper fix is implemented
-        #[cfg(any(rcc_h7, rcc_h7rm0433))]
-        impl crate::rcc::sealed::RccPeripheral for peripherals::$inst {
-            fn frequency() -> crate::time::Hertz {
-                critical_section::with(|_| unsafe { crate::rcc::get_freqs().apb1 })
-            }
+                // H7 uses single bit for both DAC1 and DAC2, this is a hack until a proper fix is implemented
+                #[cfg(any(rcc_h7, rcc_h7rm0433))]
+                impl crate::rcc::sealed::RccPeripheral for peripherals::$inst {
+                    fn frequency() -> crate::time::Hertz {
+                        critical_section::with(|_| unsafe { crate::rcc::get_freqs().apb1 })
+                    }
 
-            fn reset() {
-                critical_section::with(|_| {
-                    crate::pac::RCC.apb1lrstr().modify(|w| w.set_dac12rst(true));
-                    crate::pac::RCC.apb1lrstr().modify(|w| w.set_dac12rst(false));
-                })
-            }
+                    fn reset_and_enable() {
+                        critical_section::with(|_| {
+                            crate::pac::RCC.apb1lrstr().modify(|w| w.set_dac12rst(true));
+                            crate::pac::RCC.apb1lrstr().modify(|w| w.set_dac12rst(false));
+                            crate::pac::RCC.apb1lenr().modify(|w| w.set_dac12en(true));
+                        })
+                    }
 
-            fn enable() {
-                critical_section::with(|_| {
-                    crate::pac::RCC.apb1lenr().modify(|w| w.set_dac12en(true));
-                })
-            }
+                    fn disable() {
+                        critical_section::with(|_| {
+                            crate::pac::RCC.apb1lenr().modify(|w| w.set_dac12en(false))
+                        })
+                    }
+                }
 
-            fn disable() {
-                critical_section::with(|_| {
-                    crate::pac::RCC.apb1lenr().modify(|w| w.set_dac12en(false))
-                })
-            }
-        }
-
-        #[cfg(any(rcc_h7, rcc_h7rm0433))]
-        impl crate::rcc::RccPeripheral for peripherals::$inst {}
+                #[cfg(any(rcc_h7, rcc_h7rm0433))]
+                impl crate::rcc::RccPeripheral for peripherals::$inst {}
 
         impl crate::dac::sealed::Instance for peripherals::$inst {
             fn regs() -> &'static crate::pac::dac::Dac {

--- a/embassy-stm32/src/dcmi.rs
+++ b/embassy-stm32/src/dcmi.rs
@@ -330,7 +330,7 @@ where
         use_embedded_synchronization: bool,
         edm: u8,
     ) -> Self {
-        T::reset_and_enable();
+        T::enable_and_reset();
 
         peri.regs().cr().modify(|r| {
             r.set_cm(true); // disable continuous mode (snapshot mode)

--- a/embassy-stm32/src/dcmi.rs
+++ b/embassy-stm32/src/dcmi.rs
@@ -330,8 +330,7 @@ where
         use_embedded_synchronization: bool,
         edm: u8,
     ) -> Self {
-        T::reset();
-        T::enable();
+        T::reset_and_enable();
 
         peri.regs().cr().modify(|r| {
             r.set_cm(true); // disable continuous mode (snapshot mode)

--- a/embassy-stm32/src/fmc.rs
+++ b/embassy-stm32/src/fmc.rs
@@ -19,7 +19,7 @@ where
     const REGISTERS: *const () = T::REGS.as_ptr() as *const _;
 
     fn enable(&mut self) {
-        T::reset_and_enable();
+        T::enable_and_reset();
     }
 
     fn memory_controller_enable(&mut self) {

--- a/embassy-stm32/src/fmc.rs
+++ b/embassy-stm32/src/fmc.rs
@@ -19,8 +19,7 @@ where
     const REGISTERS: *const () = T::REGS.as_ptr() as *const _;
 
     fn enable(&mut self) {
-        <T as crate::rcc::sealed::RccPeripheral>::enable();
-        <T as crate::rcc::sealed::RccPeripheral>::reset();
+        T::reset_and_enable();
     }
 
     fn memory_controller_enable(&mut self) {

--- a/embassy-stm32/src/gpio.rs
+++ b/embassy-stm32/src/gpio.rs
@@ -759,7 +759,7 @@ foreach_pin!(
 
 pub(crate) unsafe fn init() {
     #[cfg(afio)]
-    <crate::peripherals::AFIO as crate::rcc::sealed::RccPeripheral>::reset_and_enable();
+    <crate::peripherals::AFIO as crate::rcc::sealed::RccPeripheral>::enable_and_reset();
 
     crate::_generated::init_gpio();
 }

--- a/embassy-stm32/src/gpio.rs
+++ b/embassy-stm32/src/gpio.rs
@@ -759,7 +759,7 @@ foreach_pin!(
 
 pub(crate) unsafe fn init() {
     #[cfg(afio)]
-    <crate::peripherals::AFIO as crate::rcc::sealed::RccPeripheral>::enable();
+    <crate::peripherals::AFIO as crate::rcc::sealed::RccPeripheral>::reset_and_enable();
 
     crate::_generated::init_gpio();
 }

--- a/embassy-stm32/src/hrtim/mod.rs
+++ b/embassy-stm32/src/hrtim/mod.rs
@@ -157,8 +157,7 @@ impl<'d, T: Instance> AdvancedPwm<'d, T> {
     fn new_inner(tim: impl Peripheral<P = T> + 'd) -> Self {
         into_ref!(tim);
 
-        T::enable();
-        <T as crate::rcc::sealed::RccPeripheral>::reset();
+        T::reset_and_enable();
 
         #[cfg(stm32f334)]
         if unsafe { get_freqs() }.hrtim.is_some() {

--- a/embassy-stm32/src/hrtim/mod.rs
+++ b/embassy-stm32/src/hrtim/mod.rs
@@ -157,7 +157,7 @@ impl<'d, T: Instance> AdvancedPwm<'d, T> {
     fn new_inner(tim: impl Peripheral<P = T> + 'd) -> Self {
         into_ref!(tim);
 
-        T::reset_and_enable();
+        T::enable_and_reset();
 
         #[cfg(stm32f334)]
         if unsafe { get_freqs() }.hrtim.is_some() {

--- a/embassy-stm32/src/i2c/v1.rs
+++ b/embassy-stm32/src/i2c/v1.rs
@@ -56,8 +56,7 @@ impl<'d, T: Instance, TXDMA, RXDMA> I2c<'d, T, TXDMA, RXDMA> {
     ) -> Self {
         into_ref!(scl, sda, tx_dma, rx_dma);
 
-        T::enable();
-        T::reset();
+        T::reset_and_enable();
 
         scl.set_as_af_pull(
             scl.af_num(),

--- a/embassy-stm32/src/i2c/v1.rs
+++ b/embassy-stm32/src/i2c/v1.rs
@@ -56,7 +56,7 @@ impl<'d, T: Instance, TXDMA, RXDMA> I2c<'d, T, TXDMA, RXDMA> {
     ) -> Self {
         into_ref!(scl, sda, tx_dma, rx_dma);
 
-        T::reset_and_enable();
+        T::enable_and_reset();
 
         scl.set_as_af_pull(
             scl.af_num(),

--- a/embassy-stm32/src/i2c/v2.rs
+++ b/embassy-stm32/src/i2c/v2.rs
@@ -86,7 +86,7 @@ impl<'d, T: Instance, TXDMA, RXDMA> I2c<'d, T, TXDMA, RXDMA> {
     ) -> Self {
         into_ref!(peri, scl, sda, tx_dma, rx_dma);
 
-        T::reset_and_enable();
+        T::enable_and_reset();
 
         scl.set_as_af_pull(
             scl.af_num(),

--- a/embassy-stm32/src/i2c/v2.rs
+++ b/embassy-stm32/src/i2c/v2.rs
@@ -86,8 +86,7 @@ impl<'d, T: Instance, TXDMA, RXDMA> I2c<'d, T, TXDMA, RXDMA> {
     ) -> Self {
         into_ref!(peri, scl, sda, tx_dma, rx_dma);
 
-        T::enable();
-        T::reset();
+        T::reset_and_enable();
 
         scl.set_as_af_pull(
             scl.af_num(),

--- a/embassy-stm32/src/ipcc.rs
+++ b/embassy-stm32/src/ipcc.rs
@@ -93,8 +93,7 @@ pub struct Ipcc;
 
 impl Ipcc {
     pub fn enable(_config: Config) {
-        IPCC::enable();
-        IPCC::reset();
+        IPCC::reset_and_enable();
         IPCC::set_cpu2(true);
 
         _configure_pwr();

--- a/embassy-stm32/src/ipcc.rs
+++ b/embassy-stm32/src/ipcc.rs
@@ -93,7 +93,7 @@ pub struct Ipcc;
 
 impl Ipcc {
     pub fn enable(_config: Config) {
-        IPCC::reset_and_enable();
+        IPCC::enable_and_reset();
         IPCC::set_cpu2(true);
 
         _configure_pwr();

--- a/embassy-stm32/src/lib.rs
+++ b/embassy-stm32/src/lib.rs
@@ -186,11 +186,11 @@ pub fn init(config: Config) -> Peripherals {
     }
 
     #[cfg(not(any(stm32f1, stm32wb, stm32wl)))]
-    peripherals::SYSCFG::enable();
+    peripherals::SYSCFG::reset_and_enable();
     #[cfg(not(any(stm32h5, stm32h7, stm32wb, stm32wl)))]
-    peripherals::PWR::enable();
+    peripherals::PWR::reset_and_enable();
     #[cfg(not(any(stm32f2, stm32f4, stm32f7, stm32l0, stm32h5, stm32h7)))]
-    peripherals::FLASH::enable();
+    peripherals::FLASH::reset_and_enable();
 
     unsafe {
         #[cfg(feature = "_split-pins-enabled")]

--- a/embassy-stm32/src/lib.rs
+++ b/embassy-stm32/src/lib.rs
@@ -186,11 +186,11 @@ pub fn init(config: Config) -> Peripherals {
     }
 
     #[cfg(not(any(stm32f1, stm32wb, stm32wl)))]
-    peripherals::SYSCFG::reset_and_enable();
+    peripherals::SYSCFG::enable_and_reset();
     #[cfg(not(any(stm32h5, stm32h7, stm32wb, stm32wl)))]
-    peripherals::PWR::reset_and_enable();
+    peripherals::PWR::enable_and_reset();
     #[cfg(not(any(stm32f2, stm32f4, stm32f7, stm32l0, stm32h5, stm32h7)))]
-    peripherals::FLASH::reset_and_enable();
+    peripherals::FLASH::enable_and_reset();
 
     unsafe {
         #[cfg(feature = "_split-pins-enabled")]

--- a/embassy-stm32/src/qspi/mod.rs
+++ b/embassy-stm32/src/qspi/mod.rs
@@ -177,8 +177,7 @@ impl<'d, T: Instance, Dma> Qspi<'d, T, Dma> {
     ) -> Self {
         into_ref!(peri, dma);
 
-        T::enable();
-        T::reset();
+        T::reset_and_enable();
 
         while T::REGS.sr().read().busy() {}
 

--- a/embassy-stm32/src/qspi/mod.rs
+++ b/embassy-stm32/src/qspi/mod.rs
@@ -177,7 +177,7 @@ impl<'d, T: Instance, Dma> Qspi<'d, T, Dma> {
     ) -> Self {
         into_ref!(peri, dma);
 
-        T::reset_and_enable();
+        T::enable_and_reset();
 
         while T::REGS.sr().read().busy() {}
 

--- a/embassy-stm32/src/rcc/g4.rs
+++ b/embassy-stm32/src/rcc/g4.rs
@@ -296,7 +296,7 @@ pub(crate) unsafe fn init(config: Config) {
 
                 // Enable and setup CRS if needed
                 if let Some(crs_config) = crs_config {
-                    crate::peripherals::CRS::reset_and_enable();
+                    crate::peripherals::CRS::enable_and_reset();
 
                     let sync_src = match crs_config.sync_src {
                         CrsSyncSource::Gpio => crate::pac::crs::vals::Syncsrc::GPIO,

--- a/embassy-stm32/src/rcc/g4.rs
+++ b/embassy-stm32/src/rcc/g4.rs
@@ -296,7 +296,7 @@ pub(crate) unsafe fn init(config: Config) {
 
                 // Enable and setup CRS if needed
                 if let Some(crs_config) = crs_config {
-                    crate::peripherals::CRS::enable();
+                    crate::peripherals::CRS::reset_and_enable();
 
                     let sync_src = match crs_config.sync_src {
                         CrsSyncSource::Gpio => crate::pac::crs::vals::Syncsrc::GPIO,

--- a/embassy-stm32/src/rcc/mod.rs
+++ b/embassy-stm32/src/rcc/mod.rs
@@ -231,8 +231,7 @@ pub mod low_level {
 pub(crate) mod sealed {
     pub trait RccPeripheral {
         fn frequency() -> crate::time::Hertz;
-        fn reset();
-        fn enable();
+        fn reset_and_enable();
         fn disable();
     }
 }

--- a/embassy-stm32/src/rcc/mod.rs
+++ b/embassy-stm32/src/rcc/mod.rs
@@ -231,7 +231,7 @@ pub mod low_level {
 pub(crate) mod sealed {
     pub trait RccPeripheral {
         fn frequency() -> crate::time::Hertz;
-        fn reset_and_enable();
+        fn enable_and_reset();
         fn disable();
     }
 }

--- a/embassy-stm32/src/rng.rs
+++ b/embassy-stm32/src/rng.rs
@@ -43,8 +43,7 @@ impl<'d, T: Instance> Rng<'d, T> {
         inner: impl Peripheral<P = T> + 'd,
         _irq: impl interrupt::typelevel::Binding<T::Interrupt, InterruptHandler<T>> + 'd,
     ) -> Self {
-        T::enable();
-        T::reset();
+        T::reset_and_enable();
         into_ref!(inner);
         let mut random = Self { _inner: inner };
         random.reset();

--- a/embassy-stm32/src/rng.rs
+++ b/embassy-stm32/src/rng.rs
@@ -43,7 +43,7 @@ impl<'d, T: Instance> Rng<'d, T> {
         inner: impl Peripheral<P = T> + 'd,
         _irq: impl interrupt::typelevel::Binding<T::Interrupt, InterruptHandler<T>> + 'd,
     ) -> Self {
-        T::reset_and_enable();
+        T::enable_and_reset();
         into_ref!(inner);
         let mut random = Self { _inner: inner };
         random.reset();

--- a/embassy-stm32/src/rtc/mod.rs
+++ b/embassy-stm32/src/rtc/mod.rs
@@ -184,7 +184,7 @@ impl Default for RtcCalibrationCyclePeriod {
 impl Rtc {
     pub fn new(_rtc: impl Peripheral<P = RTC>, rtc_config: RtcConfig) -> Self {
         #[cfg(not(any(stm32l0, stm32f3, stm32l1, stm32f0, stm32f2)))]
-        <RTC as crate::rcc::sealed::RccPeripheral>::enable();
+        <RTC as crate::rcc::sealed::RccPeripheral>::reset_and_enable();
 
         let mut this = Self {
             #[cfg(feature = "low-power")]

--- a/embassy-stm32/src/rtc/mod.rs
+++ b/embassy-stm32/src/rtc/mod.rs
@@ -184,7 +184,7 @@ impl Default for RtcCalibrationCyclePeriod {
 impl Rtc {
     pub fn new(_rtc: impl Peripheral<P = RTC>, rtc_config: RtcConfig) -> Self {
         #[cfg(not(any(stm32l0, stm32f3, stm32l1, stm32f0, stm32f2)))]
-        <RTC as crate::rcc::sealed::RccPeripheral>::reset_and_enable();
+        <RTC as crate::rcc::sealed::RccPeripheral>::enable_and_reset();
 
         let mut this = Self {
             #[cfg(feature = "low-power")]

--- a/embassy-stm32/src/sai/mod.rs
+++ b/embassy-stm32/src/sai/mod.rs
@@ -580,7 +580,7 @@ fn get_ring_buffer<'d, T: Instance, C: Channel, W: word::Word>(
 
 impl<'d, T: Instance> Sai<'d, T> {
     pub fn new(peri: impl Peripheral<P = T> + 'd) -> Self {
-        T::reset_and_enable();
+        T::enable_and_reset();
 
         Self {
             _peri: unsafe { peri.clone_unchecked().into_ref() },
@@ -960,7 +960,7 @@ impl<'d, T: Instance, C: Channel, W: word::Word> SubBlock<'d, T, C, W> {
     }
 
     pub fn reset() {
-        T::reset_and_enable();
+        T::enable_and_reset();
     }
 
     pub fn flush(&mut self) {

--- a/embassy-stm32/src/sai/mod.rs
+++ b/embassy-stm32/src/sai/mod.rs
@@ -531,10 +531,13 @@ pub struct SubBlock<'d, T: Instance, C: Channel, W: word::Word> {
 pub struct SubBlockA {}
 pub struct SubBlockB {}
 
+pub struct SubBlockAPeripheral<'d, T>(PeripheralRef<'d, T>);
+pub struct SubBlockBPeripheral<'d, T>(PeripheralRef<'d, T>);
+
 pub struct Sai<'d, T: Instance> {
     _peri: PeripheralRef<'d, T>,
-    sub_block_a_peri: Option<PeripheralRef<'d, T>>,
-    sub_block_b_peri: Option<PeripheralRef<'d, T>>,
+    sub_block_a_peri: Option<SubBlockAPeripheral<'d, T>>,
+    sub_block_b_peri: Option<SubBlockBPeripheral<'d, T>>,
 }
 
 // return the type for (sd, sck)
@@ -577,17 +580,16 @@ fn get_ring_buffer<'d, T: Instance, C: Channel, W: word::Word>(
 
 impl<'d, T: Instance> Sai<'d, T> {
     pub fn new(peri: impl Peripheral<P = T> + 'd) -> Self {
-        T::enable();
-        T::reset();
+        T::reset_and_enable();
 
         Self {
             _peri: unsafe { peri.clone_unchecked().into_ref() },
-            sub_block_a_peri: Some(unsafe { peri.clone_unchecked().into_ref() }),
-            sub_block_b_peri: Some(peri.into_ref()),
+            sub_block_a_peri: Some(SubBlockAPeripheral(unsafe { peri.clone_unchecked().into_ref() })),
+            sub_block_b_peri: Some(SubBlockBPeripheral(peri.into_ref())),
         }
     }
 
-    pub fn take_sub_block_a(self: &mut Self) -> Option<PeripheralRef<'d, T>> {
+    pub fn take_sub_block_a(self: &mut Self) -> Option<SubBlockAPeripheral<'d, T>> {
         if self.sub_block_a_peri.is_some() {
             self.sub_block_a_peri.take()
         } else {
@@ -595,7 +597,7 @@ impl<'d, T: Instance> Sai<'d, T> {
         }
     }
 
-    pub fn take_sub_block_b(self: &mut Self) -> Option<PeripheralRef<'d, T>> {
+    pub fn take_sub_block_b(self: &mut Self) -> Option<SubBlockBPeripheral<'d, T>> {
         if self.sub_block_b_peri.is_some() {
             self.sub_block_b_peri.take()
         } else {
@@ -623,7 +625,7 @@ fn update_synchronous_config(config: &mut Config) {
 
 impl SubBlockA {
     pub fn new_asynchronous_with_mclk<'d, T: Instance, C: Channel, W: word::Word>(
-        peri: impl Peripheral<P = T> + 'd,
+        peri: SubBlockAPeripheral<'d, T>,
         sck: impl Peripheral<P = impl SckAPin<T>> + 'd,
         sd: impl Peripheral<P = impl SdAPin<T>> + 'd,
         fs: impl Peripheral<P = impl FsAPin<T>> + 'd,
@@ -631,7 +633,7 @@ impl SubBlockA {
         dma: impl Peripheral<P = C> + 'd,
         dma_buf: &'d mut [W],
         mut config: Config,
-    ) -> SubBlock<T, C, W>
+    ) -> SubBlock<'d, T, C, W>
     where
         C: Channel + DmaA<T>,
     {
@@ -650,17 +652,18 @@ impl SubBlockA {
     }
 
     pub fn new_asynchronous<'d, T: Instance, C: Channel, W: word::Word>(
-        peri: impl Peripheral<P = T> + 'd,
+        peri: SubBlockAPeripheral<'d, T>,
         sck: impl Peripheral<P = impl SckAPin<T>> + 'd,
         sd: impl Peripheral<P = impl SdAPin<T>> + 'd,
         fs: impl Peripheral<P = impl FsAPin<T>> + 'd,
         dma: impl Peripheral<P = C> + 'd,
         dma_buf: &'d mut [W],
         config: Config,
-    ) -> SubBlock<T, C, W>
+    ) -> SubBlock<'d, T, C, W>
     where
         C: Channel + DmaA<T>,
     {
+        let peri = peri.0;
         into_ref!(peri, dma, sck, sd, fs);
 
         let (sd_af_type, ck_af_type) = get_af_types(config.mode, config.tx_rx);
@@ -688,17 +691,18 @@ impl SubBlockA {
     }
 
     pub fn new_synchronous<'d, T: Instance, C: Channel, W: word::Word>(
-        peri: impl Peripheral<P = T> + 'd,
+        peri: SubBlockAPeripheral<'d, T>,
         sd: impl Peripheral<P = impl SdAPin<T>> + 'd,
         dma: impl Peripheral<P = C> + 'd,
         dma_buf: &'d mut [W],
         mut config: Config,
-    ) -> SubBlock<T, C, W>
+    ) -> SubBlock<'d, T, C, W>
     where
         C: Channel + DmaA<T>,
     {
         update_synchronous_config(&mut config);
 
+        let peri = peri.0;
         into_ref!(dma, peri, sd);
 
         let (sd_af_type, _ck_af_type) = get_af_types(config.mode, config.tx_rx);
@@ -724,7 +728,7 @@ impl SubBlockA {
 
 impl SubBlockB {
     pub fn new_asynchronous_with_mclk<'d, T: Instance, C: Channel, W: word::Word>(
-        peri: impl Peripheral<P = T> + 'd,
+        peri: SubBlockBPeripheral<'d, T>,
         sck: impl Peripheral<P = impl SckBPin<T>> + 'd,
         sd: impl Peripheral<P = impl SdBPin<T>> + 'd,
         fs: impl Peripheral<P = impl FsBPin<T>> + 'd,
@@ -732,7 +736,7 @@ impl SubBlockB {
         dma: impl Peripheral<P = C> + 'd,
         dma_buf: &'d mut [W],
         mut config: Config,
-    ) -> SubBlock<T, C, W>
+    ) -> SubBlock<'d, T, C, W>
     where
         C: Channel + DmaB<T>,
     {
@@ -751,17 +755,18 @@ impl SubBlockB {
     }
 
     pub fn new_asynchronous<'d, T: Instance, C: Channel, W: word::Word>(
-        peri: impl Peripheral<P = T> + 'd,
+        peri: SubBlockBPeripheral<'d, T>,
         sck: impl Peripheral<P = impl SckBPin<T>> + 'd,
         sd: impl Peripheral<P = impl SdBPin<T>> + 'd,
         fs: impl Peripheral<P = impl FsBPin<T>> + 'd,
         dma: impl Peripheral<P = C> + 'd,
         dma_buf: &'d mut [W],
         config: Config,
-    ) -> SubBlock<T, C, W>
+    ) -> SubBlock<'d, T, C, W>
     where
         C: Channel + DmaB<T>,
     {
+        let peri = peri.0;
         into_ref!(dma, peri, sck, sd, fs);
 
         let (sd_af_type, ck_af_type) = get_af_types(config.mode, config.tx_rx);
@@ -790,17 +795,17 @@ impl SubBlockB {
     }
 
     pub fn new_synchronous<'d, T: Instance, C: Channel, W: word::Word>(
-        peri: impl Peripheral<P = T> + 'd,
+        peri: SubBlockBPeripheral<'d, T>,
         sd: impl Peripheral<P = impl SdBPin<T>> + 'd,
         dma: impl Peripheral<P = C> + 'd,
         dma_buf: &'d mut [W],
         mut config: Config,
-    ) -> SubBlock<T, C, W>
+    ) -> SubBlock<'d, T, C, W>
     where
         C: Channel + DmaB<T>,
     {
         update_synchronous_config(&mut config);
-
+        let peri = peri.0;
         into_ref!(dma, peri, sd);
 
         let (sd_af_type, _ck_af_type) = get_af_types(config.mode, config.tx_rx);
@@ -853,10 +858,6 @@ impl<'d, T: Instance, C: Channel, W: word::Word> SubBlock<'d, T, C, W> {
         ring_buffer: RingBuffer<'d, C, W>,
         config: Config,
     ) -> Self {
-        T::enable();
-
-        // can't reset here because the other sub-block might be in use
-
         #[cfg(any(sai_v1, sai_v2, sai_v3, sai_v4))]
         {
             let ch = T::REGS.ch(sub_block as usize);
@@ -959,8 +960,7 @@ impl<'d, T: Instance, C: Channel, W: word::Word> SubBlock<'d, T, C, W> {
     }
 
     pub fn reset() {
-        T::enable();
-        T::reset();
+        T::reset_and_enable();
     }
 
     pub fn flush(&mut self) {

--- a/embassy-stm32/src/sdmmc/mod.rs
+++ b/embassy-stm32/src/sdmmc/mod.rs
@@ -452,8 +452,7 @@ impl<'d, T: Instance, Dma: SdmmcDma<T> + 'd> Sdmmc<'d, T, Dma> {
     ) -> Self {
         into_ref!(sdmmc, dma);
 
-        T::enable();
-        T::reset();
+        T::reset_and_enable();
 
         T::Interrupt::unpend();
         unsafe { T::Interrupt::enable() };

--- a/embassy-stm32/src/sdmmc/mod.rs
+++ b/embassy-stm32/src/sdmmc/mod.rs
@@ -452,7 +452,7 @@ impl<'d, T: Instance, Dma: SdmmcDma<T> + 'd> Sdmmc<'d, T, Dma> {
     ) -> Self {
         into_ref!(sdmmc, dma);
 
-        T::reset_and_enable();
+        T::enable_and_reset();
 
         T::Interrupt::unpend();
         unsafe { T::Interrupt::enable() };

--- a/embassy-stm32/src/spi/mod.rs
+++ b/embassy-stm32/src/spi/mod.rs
@@ -230,7 +230,7 @@ impl<'d, T: Instance, Tx, Rx> Spi<'d, T, Tx, Rx> {
 
         let lsbfirst = config.raw_byte_order();
 
-        T::reset_and_enable();
+        T::enable_and_reset();
 
         #[cfg(any(spi_v1, spi_f1))]
         {

--- a/embassy-stm32/src/spi/mod.rs
+++ b/embassy-stm32/src/spi/mod.rs
@@ -230,8 +230,7 @@ impl<'d, T: Instance, Tx, Rx> Spi<'d, T, Tx, Rx> {
 
         let lsbfirst = config.raw_byte_order();
 
-        T::enable();
-        T::reset();
+        T::reset_and_enable();
 
         #[cfg(any(spi_v1, spi_f1))]
         {

--- a/embassy-stm32/src/time_driver.rs
+++ b/embassy-stm32/src/time_driver.rs
@@ -155,8 +155,7 @@ impl RtcDriver {
     fn init(&'static self) {
         let r = T::regs_gp16();
 
-        <T as RccPeripheral>::enable();
-        <T as RccPeripheral>::reset();
+        <T as RccPeripheral>::reset_and_enable();
 
         let timer_freq = T::frequency();
 

--- a/embassy-stm32/src/time_driver.rs
+++ b/embassy-stm32/src/time_driver.rs
@@ -155,7 +155,7 @@ impl RtcDriver {
     fn init(&'static self) {
         let r = T::regs_gp16();
 
-        <T as RccPeripheral>::reset_and_enable();
+        <T as RccPeripheral>::enable_and_reset();
 
         let timer_freq = T::frequency();
 

--- a/embassy-stm32/src/timer/complementary_pwm.rs
+++ b/embassy-stm32/src/timer/complementary_pwm.rs
@@ -64,7 +64,7 @@ impl<'d, T: ComplementaryCaptureCompare16bitInstance> ComplementaryPwm<'d, T> {
     fn new_inner(tim: impl Peripheral<P = T> + 'd, freq: Hertz) -> Self {
         into_ref!(tim);
 
-        T::reset_and_enable();
+        T::enable_and_reset();
 
         let mut this = Self { inner: tim };
 

--- a/embassy-stm32/src/timer/complementary_pwm.rs
+++ b/embassy-stm32/src/timer/complementary_pwm.rs
@@ -64,8 +64,7 @@ impl<'d, T: ComplementaryCaptureCompare16bitInstance> ComplementaryPwm<'d, T> {
     fn new_inner(tim: impl Peripheral<P = T> + 'd, freq: Hertz) -> Self {
         into_ref!(tim);
 
-        T::enable();
-        <T as crate::rcc::sealed::RccPeripheral>::reset();
+        T::reset_and_enable();
 
         let mut this = Self { inner: tim };
 

--- a/embassy-stm32/src/timer/qei.rs
+++ b/embassy-stm32/src/timer/qei.rs
@@ -55,8 +55,7 @@ impl<'d, T: CaptureCompare16bitInstance> Qei<'d, T> {
     fn new_inner(tim: impl Peripheral<P = T> + 'd) -> Self {
         into_ref!(tim);
 
-        T::enable();
-        <T as crate::rcc::sealed::RccPeripheral>::reset();
+        T::reset_and_enable();
 
         // Configure TxC1 and TxC2 as captures
         T::regs_gp16().ccmr_input(0).modify(|w| {

--- a/embassy-stm32/src/timer/qei.rs
+++ b/embassy-stm32/src/timer/qei.rs
@@ -55,7 +55,7 @@ impl<'d, T: CaptureCompare16bitInstance> Qei<'d, T> {
     fn new_inner(tim: impl Peripheral<P = T> + 'd) -> Self {
         into_ref!(tim);
 
-        T::reset_and_enable();
+        T::enable_and_reset();
 
         // Configure TxC1 and TxC2 as captures
         T::regs_gp16().ccmr_input(0).modify(|w| {

--- a/embassy-stm32/src/timer/simple_pwm.rs
+++ b/embassy-stm32/src/timer/simple_pwm.rs
@@ -63,7 +63,7 @@ impl<'d, T: CaptureCompare16bitInstance> SimplePwm<'d, T> {
     fn new_inner(tim: impl Peripheral<P = T> + 'd, freq: Hertz) -> Self {
         into_ref!(tim);
 
-        T::reset_and_enable();
+        T::enable_and_reset();
 
         let mut this = Self { inner: tim };
 

--- a/embassy-stm32/src/timer/simple_pwm.rs
+++ b/embassy-stm32/src/timer/simple_pwm.rs
@@ -63,8 +63,7 @@ impl<'d, T: CaptureCompare16bitInstance> SimplePwm<'d, T> {
     fn new_inner(tim: impl Peripheral<P = T> + 'd, freq: Hertz) -> Self {
         into_ref!(tim);
 
-        T::enable();
-        <T as crate::rcc::sealed::RccPeripheral>::reset();
+        T::reset_and_enable();
 
         let mut this = Self { inner: tim };
 

--- a/embassy-stm32/src/usart/buffered.rs
+++ b/embassy-stm32/src/usart/buffered.rs
@@ -152,9 +152,8 @@ impl<'d, T: BasicInstance> BufferedUart<'d, T> {
         config: Config,
     ) -> Result<Self, ConfigError> {
         // UartRx and UartTx have one refcount ea.
-        T::enable();
-        T::enable();
-        T::reset();
+        T::reset_and_enable();
+        T::reset_and_enable();
 
         Self::new_inner(peri, rx, tx, tx_buffer, rx_buffer, config)
     }
@@ -173,9 +172,8 @@ impl<'d, T: BasicInstance> BufferedUart<'d, T> {
         into_ref!(cts, rts);
 
         // UartRx and UartTx have one refcount ea.
-        T::enable();
-        T::enable();
-        T::reset();
+        T::reset_and_enable();
+        T::reset_and_enable();
 
         rts.set_as_af(rts.af_num(), AFType::OutputPushPull);
         cts.set_as_af(cts.af_num(), AFType::Input);
@@ -201,9 +199,8 @@ impl<'d, T: BasicInstance> BufferedUart<'d, T> {
         into_ref!(de);
 
         // UartRx and UartTx have one refcount ea.
-        T::enable();
-        T::enable();
-        T::reset();
+        T::reset_and_enable();
+        T::reset_and_enable();
 
         de.set_as_af(de.af_num(), AFType::OutputPushPull);
         T::regs().cr3().write(|w| {

--- a/embassy-stm32/src/usart/buffered.rs
+++ b/embassy-stm32/src/usart/buffered.rs
@@ -152,8 +152,8 @@ impl<'d, T: BasicInstance> BufferedUart<'d, T> {
         config: Config,
     ) -> Result<Self, ConfigError> {
         // UartRx and UartTx have one refcount ea.
-        T::reset_and_enable();
-        T::reset_and_enable();
+        T::enable_and_reset();
+        T::enable_and_reset();
 
         Self::new_inner(peri, rx, tx, tx_buffer, rx_buffer, config)
     }
@@ -172,8 +172,8 @@ impl<'d, T: BasicInstance> BufferedUart<'d, T> {
         into_ref!(cts, rts);
 
         // UartRx and UartTx have one refcount ea.
-        T::reset_and_enable();
-        T::reset_and_enable();
+        T::enable_and_reset();
+        T::enable_and_reset();
 
         rts.set_as_af(rts.af_num(), AFType::OutputPushPull);
         cts.set_as_af(cts.af_num(), AFType::Input);
@@ -199,8 +199,8 @@ impl<'d, T: BasicInstance> BufferedUart<'d, T> {
         into_ref!(de);
 
         // UartRx and UartTx have one refcount ea.
-        T::reset_and_enable();
-        T::reset_and_enable();
+        T::enable_and_reset();
+        T::enable_and_reset();
 
         de.set_as_af(de.af_num(), AFType::OutputPushPull);
         T::regs().cr3().write(|w| {

--- a/embassy-stm32/src/usart/mod.rs
+++ b/embassy-stm32/src/usart/mod.rs
@@ -228,8 +228,7 @@ impl<'d, T: BasicInstance, TxDma> UartTx<'d, T, TxDma> {
         tx_dma: impl Peripheral<P = TxDma> + 'd,
         config: Config,
     ) -> Result<Self, ConfigError> {
-        T::enable();
-        T::reset();
+        T::reset_and_enable();
 
         Self::new_inner(peri, tx, tx_dma, config)
     }
@@ -243,8 +242,7 @@ impl<'d, T: BasicInstance, TxDma> UartTx<'d, T, TxDma> {
     ) -> Result<Self, ConfigError> {
         into_ref!(cts);
 
-        T::enable();
-        T::reset();
+        T::reset_and_enable();
 
         cts.set_as_af(cts.af_num(), AFType::Input);
         T::regs().cr3().write(|w| {
@@ -321,8 +319,7 @@ impl<'d, T: BasicInstance, RxDma> UartRx<'d, T, RxDma> {
         rx_dma: impl Peripheral<P = RxDma> + 'd,
         config: Config,
     ) -> Result<Self, ConfigError> {
-        T::enable();
-        T::reset();
+        T::reset_and_enable();
 
         Self::new_inner(peri, rx, rx_dma, config)
     }
@@ -337,8 +334,7 @@ impl<'d, T: BasicInstance, RxDma> UartRx<'d, T, RxDma> {
     ) -> Result<Self, ConfigError> {
         into_ref!(rts);
 
-        T::enable();
-        T::reset();
+        T::reset_and_enable();
 
         rts.set_as_af(rts.af_num(), AFType::OutputPushPull);
         T::regs().cr3().write(|w| {
@@ -695,9 +691,8 @@ impl<'d, T: BasicInstance, TxDma, RxDma> Uart<'d, T, TxDma, RxDma> {
         config: Config,
     ) -> Result<Self, ConfigError> {
         // UartRx and UartTx have one refcount ea.
-        T::enable();
-        T::enable();
-        T::reset();
+        T::reset_and_enable();
+        T::reset_and_enable();
 
         Self::new_inner(peri, rx, tx, tx_dma, rx_dma, config)
     }
@@ -716,9 +711,8 @@ impl<'d, T: BasicInstance, TxDma, RxDma> Uart<'d, T, TxDma, RxDma> {
         into_ref!(cts, rts);
 
         // UartRx and UartTx have one refcount ea.
-        T::enable();
-        T::enable();
-        T::reset();
+        T::reset_and_enable();
+        T::reset_and_enable();
 
         rts.set_as_af(rts.af_num(), AFType::OutputPushPull);
         cts.set_as_af(cts.af_num(), AFType::Input);
@@ -743,9 +737,8 @@ impl<'d, T: BasicInstance, TxDma, RxDma> Uart<'d, T, TxDma, RxDma> {
         into_ref!(de);
 
         // UartRx and UartTx have one refcount ea.
-        T::enable();
-        T::enable();
-        T::reset();
+        T::reset_and_enable();
+        T::reset_and_enable();
 
         de.set_as_af(de.af_num(), AFType::OutputPushPull);
         T::regs().cr3().write(|w| {

--- a/embassy-stm32/src/usart/mod.rs
+++ b/embassy-stm32/src/usart/mod.rs
@@ -228,7 +228,7 @@ impl<'d, T: BasicInstance, TxDma> UartTx<'d, T, TxDma> {
         tx_dma: impl Peripheral<P = TxDma> + 'd,
         config: Config,
     ) -> Result<Self, ConfigError> {
-        T::reset_and_enable();
+        T::enable_and_reset();
 
         Self::new_inner(peri, tx, tx_dma, config)
     }
@@ -242,7 +242,7 @@ impl<'d, T: BasicInstance, TxDma> UartTx<'d, T, TxDma> {
     ) -> Result<Self, ConfigError> {
         into_ref!(cts);
 
-        T::reset_and_enable();
+        T::enable_and_reset();
 
         cts.set_as_af(cts.af_num(), AFType::Input);
         T::regs().cr3().write(|w| {
@@ -319,7 +319,7 @@ impl<'d, T: BasicInstance, RxDma> UartRx<'d, T, RxDma> {
         rx_dma: impl Peripheral<P = RxDma> + 'd,
         config: Config,
     ) -> Result<Self, ConfigError> {
-        T::reset_and_enable();
+        T::enable_and_reset();
 
         Self::new_inner(peri, rx, rx_dma, config)
     }
@@ -334,7 +334,7 @@ impl<'d, T: BasicInstance, RxDma> UartRx<'d, T, RxDma> {
     ) -> Result<Self, ConfigError> {
         into_ref!(rts);
 
-        T::reset_and_enable();
+        T::enable_and_reset();
 
         rts.set_as_af(rts.af_num(), AFType::OutputPushPull);
         T::regs().cr3().write(|w| {
@@ -691,8 +691,8 @@ impl<'d, T: BasicInstance, TxDma, RxDma> Uart<'d, T, TxDma, RxDma> {
         config: Config,
     ) -> Result<Self, ConfigError> {
         // UartRx and UartTx have one refcount ea.
-        T::reset_and_enable();
-        T::reset_and_enable();
+        T::enable_and_reset();
+        T::enable_and_reset();
 
         Self::new_inner(peri, rx, tx, tx_dma, rx_dma, config)
     }
@@ -711,8 +711,8 @@ impl<'d, T: BasicInstance, TxDma, RxDma> Uart<'d, T, TxDma, RxDma> {
         into_ref!(cts, rts);
 
         // UartRx and UartTx have one refcount ea.
-        T::reset_and_enable();
-        T::reset_and_enable();
+        T::enable_and_reset();
+        T::enable_and_reset();
 
         rts.set_as_af(rts.af_num(), AFType::OutputPushPull);
         cts.set_as_af(cts.af_num(), AFType::Input);
@@ -737,8 +737,8 @@ impl<'d, T: BasicInstance, TxDma, RxDma> Uart<'d, T, TxDma, RxDma> {
         into_ref!(de);
 
         // UartRx and UartTx have one refcount ea.
-        T::reset_and_enable();
-        T::reset_and_enable();
+        T::enable_and_reset();
+        T::enable_and_reset();
 
         de.set_as_af(de.af_num(), AFType::OutputPushPull);
         T::regs().cr3().write(|w| {

--- a/embassy-stm32/src/usb/usb.rs
+++ b/embassy-stm32/src/usb/usb.rs
@@ -269,8 +269,7 @@ impl<'d, T: Instance> Driver<'d, T> {
         #[cfg(pwr_h5)]
         crate::pac::PWR.usbscr().modify(|w| w.set_usb33sv(true));
 
-        <T as RccPeripheral>::enable();
-        <T as RccPeripheral>::reset();
+        <T as RccPeripheral>::reset_and_enable();
 
         regs.cntr().write(|w| {
             w.set_pdwn(false);

--- a/embassy-stm32/src/usb/usb.rs
+++ b/embassy-stm32/src/usb/usb.rs
@@ -269,7 +269,7 @@ impl<'d, T: Instance> Driver<'d, T> {
         #[cfg(pwr_h5)]
         crate::pac::PWR.usbscr().modify(|w| w.set_usb33sv(true));
 
-        <T as RccPeripheral>::reset_and_enable();
+        <T as RccPeripheral>::enable_and_reset();
 
         regs.cntr().write(|w| {
             w.set_pdwn(false);

--- a/embassy-stm32/src/usb_otg/usb.rs
+++ b/embassy-stm32/src/usb_otg/usb.rs
@@ -632,7 +632,7 @@ impl<'d, T: Instance> Bus<'d, T> {
             });
         }
 
-        <T as RccPeripheral>::reset_and_enable();
+        <T as RccPeripheral>::enable_and_reset();
 
         T::Interrupt::unpend();
         unsafe { T::Interrupt::enable() };

--- a/embassy-stm32/src/usb_otg/usb.rs
+++ b/embassy-stm32/src/usb_otg/usb.rs
@@ -632,8 +632,7 @@ impl<'d, T: Instance> Bus<'d, T> {
             });
         }
 
-        <T as RccPeripheral>::enable();
-        <T as RccPeripheral>::reset();
+        <T as RccPeripheral>::reset_and_enable();
 
         T::Interrupt::unpend();
         unsafe { T::Interrupt::enable() };

--- a/examples/stm32h7/src/bin/dac_dma.rs
+++ b/examples/stm32h7/src/bin/dac_dma.rs
@@ -79,7 +79,7 @@ async fn dac_task1(mut dac: Dac1Type) {
     dac.select_trigger(embassy_stm32::dac::Ch1Trigger::Tim6).unwrap();
     dac.enable_channel().unwrap();
 
-    TIM6::reset_and_enable();
+    TIM6::enable_and_reset();
     TIM6::regs().arr().modify(|w| w.set_arr(reload as u16 - 1));
     TIM6::regs().cr2().modify(|w| w.set_mms(Mms::UPDATE));
     TIM6::regs().cr1().modify(|w| {
@@ -118,7 +118,7 @@ async fn dac_task2(mut dac: Dac2Type) {
         error!("Reload value {} below threshold!", reload);
     }
 
-    TIM7::reset_and_enable();
+    TIM7::enable_and_reset();
     TIM7::regs().arr().modify(|w| w.set_arr(reload as u16 - 1));
     TIM7::regs().cr2().modify(|w| w.set_mms(Mms::UPDATE));
     TIM7::regs().cr1().modify(|w| {

--- a/examples/stm32h7/src/bin/dac_dma.rs
+++ b/examples/stm32h7/src/bin/dac_dma.rs
@@ -79,7 +79,7 @@ async fn dac_task1(mut dac: Dac1Type) {
     dac.select_trigger(embassy_stm32::dac::Ch1Trigger::Tim6).unwrap();
     dac.enable_channel().unwrap();
 
-    TIM6::enable();
+    TIM6::reset_and_enable();
     TIM6::regs().arr().modify(|w| w.set_arr(reload as u16 - 1));
     TIM6::regs().cr2().modify(|w| w.set_mms(Mms::UPDATE));
     TIM6::regs().cr1().modify(|w| {
@@ -118,7 +118,7 @@ async fn dac_task2(mut dac: Dac2Type) {
         error!("Reload value {} below threshold!", reload);
     }
 
-    TIM7::enable();
+    TIM7::reset_and_enable();
     TIM7::regs().arr().modify(|w| w.set_arr(reload as u16 - 1));
     TIM7::regs().cr2().modify(|w| w.set_mms(Mms::UPDATE));
     TIM7::regs().cr1().modify(|w| {

--- a/examples/stm32h7/src/bin/low_level_timer_api.rs
+++ b/examples/stm32h7/src/bin/low_level_timer_api.rs
@@ -73,8 +73,7 @@ impl<'d, T: CaptureCompare32bitInstance> SimplePwm32<'d, T> {
     ) -> Self {
         into_ref!(tim, ch1, ch2, ch3, ch4);
 
-        T::enable();
-        <T as embassy_stm32::rcc::low_level::RccPeripheral>::reset();
+        T::reset_and_enable();
 
         ch1.set_speed(Speed::VeryHigh);
         ch1.set_as_af(ch1.af_num(), AFType::OutputPushPull);

--- a/examples/stm32h7/src/bin/low_level_timer_api.rs
+++ b/examples/stm32h7/src/bin/low_level_timer_api.rs
@@ -73,7 +73,7 @@ impl<'d, T: CaptureCompare32bitInstance> SimplePwm32<'d, T> {
     ) -> Self {
         into_ref!(tim, ch1, ch2, ch3, ch4);
 
-        T::reset_and_enable();
+        T::enable_and_reset();
 
         ch1.set_speed(Speed::VeryHigh);
         ch1.set_as_af(ch1.af_num(), AFType::OutputPushPull);

--- a/examples/stm32l4/src/bin/dac_dma.rs
+++ b/examples/stm32l4/src/bin/dac_dma.rs
@@ -51,7 +51,7 @@ async fn dac_task1(mut dac: Dac1Type) {
     dac.select_trigger(embassy_stm32::dac::Ch1Trigger::Tim6).unwrap();
     dac.enable_channel().unwrap();
 
-    TIM6::enable();
+    TIM6::reset_and_enable();
     TIM6::regs().arr().modify(|w| w.set_arr(reload as u16 - 1));
     TIM6::regs().cr2().modify(|w| w.set_mms(Mms::UPDATE));
     TIM6::regs().cr1().modify(|w| {
@@ -90,7 +90,7 @@ async fn dac_task2(mut dac: Dac2Type) {
         error!("Reload value {} below threshold!", reload);
     }
 
-    TIM7::enable();
+    TIM7::reset_and_enable();
     TIM7::regs().arr().modify(|w| w.set_arr(reload as u16 - 1));
     TIM7::regs().cr2().modify(|w| w.set_mms(Mms::UPDATE));
     TIM7::regs().cr1().modify(|w| {

--- a/examples/stm32l4/src/bin/dac_dma.rs
+++ b/examples/stm32l4/src/bin/dac_dma.rs
@@ -51,7 +51,7 @@ async fn dac_task1(mut dac: Dac1Type) {
     dac.select_trigger(embassy_stm32::dac::Ch1Trigger::Tim6).unwrap();
     dac.enable_channel().unwrap();
 
-    TIM6::reset_and_enable();
+    TIM6::enable_and_reset();
     TIM6::regs().arr().modify(|w| w.set_arr(reload as u16 - 1));
     TIM6::regs().cr2().modify(|w| w.set_mms(Mms::UPDATE));
     TIM6::regs().cr1().modify(|w| {
@@ -90,7 +90,7 @@ async fn dac_task2(mut dac: Dac2Type) {
         error!("Reload value {} below threshold!", reload);
     }
 
-    TIM7::reset_and_enable();
+    TIM7::enable_and_reset();
     TIM7::regs().arr().modify(|w| w.set_arr(reload as u16 - 1));
     TIM7::regs().cr2().modify(|w| w.set_mms(Mms::UPDATE));
     TIM7::regs().cr1().modify(|w| {


### PR DESCRIPTION
Close  #2034

Combining the standalone functions `reset()` and `enable()` into `enable_and_reset()`.
 
 This are a lot of breaking changes, maybe we should add `reset_and_enable()`, but keep `enable()` and `reset()`. 
 And port only the obvious usages.
 I'm not able to test everything on real hardware.