### PR TITLE
fix (rp i2c): set i2c slew rate to spec value

### DIFF
--- a/embassy-rp/src/i2c_slave.rs
+++ b/embassy-rp/src/i2c_slave.rs
@@ -5,7 +5,9 @@ use core::task::Poll;
 use embassy_hal_internal::into_ref;
 use pac::i2c;
 
-use crate::i2c::{i2c_reserved_addr, AbortReason, Instance, InterruptHandler, SclPin, SdaPin, FIFO_SIZE};
+use crate::i2c::{
+    i2c_reserved_addr, set_up_i2c_pin, AbortReason, Instance, InterruptHandler, SclPin, SdaPin, FIFO_SIZE,
+};
 use crate::interrupt::typelevel::{Binding, Interrupt};
 use crate::{pac, Peripheral};
 
@@ -100,23 +102,8 @@ impl<'d, T: Instance> I2cSlave<'d, T> {
         p.ic_rx_tl().write(|w| w.set_rx_tl(0));
 
         // Configure SCL & SDA pins
-        scl.gpio().ctrl().write(|w| w.set_funcsel(3));
-        sda.gpio().ctrl().write(|w| w.set_funcsel(3));
-
-        scl.pad_ctrl().write(|w| {
-            w.set_schmitt(true);
-            w.set_ie(true);
-            w.set_od(false);
-            w.set_pue(true);
-            w.set_pde(false);
-        });
-        sda.pad_ctrl().write(|w| {
-            w.set_schmitt(true);
-            w.set_ie(true);
-            w.set_od(false);
-            w.set_pue(true);
-            w.set_pde(false);
-        });
+        set_up_i2c_pin(&scl);
+        set_up_i2c_pin(&sda);
 
         // Clear interrupts
         p.ic_clr_intr().read();


### PR DESCRIPTION
The RP2040 datasheet indicates that I2C pins should have a limited slew rate (Page 440 - 4.3.1.3.). This configures that for both `I2c` and `I2cSlave`.

In addition, the pin configuration has been centralized to a single fn.