### PR TITLE
fix (rp i2c): fix restart/stop flags for i2c master methods

### DIFF
--- a/embassy-rp/src/i2c.rs
+++ b/embassy-rp/src/i2c.rs
@@ -295,12 +295,23 @@ impl<'d, T: Instance> I2c<'d, T, Async> {
 
     pub async fn read_async(&mut self, addr: u16, buffer: &mut [u8]) -> Result<(), Error> {
         Self::setup(addr)?;
-        self.read_async_internal(buffer, false, true).await
+        self.read_async_internal(buffer, true, true).await
     }
 
     pub async fn write_async(&mut self, addr: u16, bytes: impl IntoIterator<Item = u8>) -> Result<(), Error> {
         Self::setup(addr)?;
         self.write_async_internal(bytes, true).await
+    }
+
+    pub async fn write_read_async(
+        &mut self,
+        addr: u16,
+        bytes: impl IntoIterator<Item = u8>,
+        buffer: &mut [u8],
+    ) -> Result<(), Error> {
+        Self::setup(addr)?;
+        self.write_async_internal(bytes, false).await?;
+        self.read_async_internal(buffer, true, true).await
     }
 }
 
@@ -713,7 +724,7 @@ mod nightly {
 
             Self::setup(addr)?;
             self.write_async_internal(write.iter().cloned(), false).await?;
-            self.read_async_internal(read, false, true).await
+            self.read_async_internal(read, true, true).await
         }
 
         async fn transaction(&mut self, address: A, operations: &mut [Operation<'_>]) -> Result<(), Self::Error> {


### PR DESCRIPTION
Update the start and stop flags for all read/write/read_write methods to match those in the default blocking implementation of these methods (as well as other RP2040 I2C implementations, and expected I2C behavior).

Flags used correctly elsewhere: https://github.com/embassy-rs/embassy/blob/022d870d616575805ace9b37ea87bae1fd90cb84/embassy-rp/src/i2c.rs#L561

rp-rs implementation: https://github.com/rp-rs/rp-hal/blob/c4d3fa882acc5b19269d20ff74f65f1e53e81ee9/rp2040-hal/src/i2c/controller.rs#L313

Also adds a write_read_async method that doesn't require using embedded-hal, as this is required to use I2C in an idiomatic fashion (see TI Application Report [SLVA704](https://www.ti.com/lit/an/slva704/slva704.pdf)).