### PR TITLE
fix (rp i2c): stretch the clock during read transfers

### DIFF
--- a/embassy-rp/src/i2c_slave.rs
+++ b/embassy-rp/src/i2c_slave.rs
@@ -139,7 +139,7 @@ impl<'d, T: Instance> I2cSlave<'d, T> {
 
         // mask everything initially
         T::Interrupt::unpend();
-        p.ic_intr_mask().write(|w| {});
+        p.ic_intr_mask().write(|_| {});
         unsafe { T::Interrupt::enable() };
 
         Self {

--- a/examples/rp/.cargo/config.toml
+++ b/examples/rp/.cargo/config.toml
@@ -5,4 +5,4 @@ runner = "probe-rs run --chip RP2040"
 target = "thumbv6m-none-eabi"        # Cortex-M0 and Cortex-M0+
 
 [env]
-DEFMT_LOG = "debug"
+DEFMT_LOG = "trace"

--- a/examples/rp/.cargo/config.toml
+++ b/examples/rp/.cargo/config.toml
@@ -1,8 +1,13 @@
 [target.'cfg(all(target_arch = "arm", target_os = "none"))']
-runner = "probe-rs run --chip RP2040"
+runner = "probe-rs run --chip RP2040 --speed 5000"
+rustflags = [
+    "-C", "inline-threshold=5",
+    "-C", "no-vectorize-loops",
+]
 
 [build]
 target = "thumbv6m-none-eabi"        # Cortex-M0 and Cortex-M0+
 
 [env]
 DEFMT_LOG = "trace"
+DEFMT_RTT_BUFFER_SIZE = "8192"

--- a/examples/rp/Cargo.toml
+++ b/examples/rp/Cargo.toml
@@ -55,3 +55,8 @@ rand = { version = "0.8.5", default-features = false }
 
 [profile.release]
 debug = 2
+
+[features]
+default = ["i2c_slave", "i2c_master"]
+i2c_slave = []
+i2c_master = []

--- a/examples/rp/src/bin/i2c_slave.rs
+++ b/examples/rp/src/bin/i2c_slave.rs
@@ -111,7 +111,7 @@ async fn main(spawner: Spawner) {
     let c_sda = p.PIN_1;
     let c_scl = p.PIN_0;
     let mut config = i2c::Config::default();
-    config.frequency = 5_000;
+    config.frequency = 100_000;
     let controller = i2c::I2c::new_async(p.I2C0, c_sda, c_scl, Irqs, config);
 
     unwrap!(spawner.spawn(controller_task(controller)));

--- a/examples/rp/src/bin/i2c_slave.rs
+++ b/examples/rp/src/bin/i2c_slave.rs
@@ -5,7 +5,8 @@
 
 use defmt::*;
 use embassy_executor::Spawner;
-use embassy_rp::peripherals::{I2C0, I2C1};
+use embassy_rp::gpio::{Level, Output};
+use embassy_rp::peripherals::{I2C0, I2C1, PIN_25};
 use embassy_rp::{bind_interrupts, i2c, i2c_slave};
 use embassy_time::{Duration, Timer};
 use embedded_hal_async::i2c::I2c;
@@ -27,38 +28,52 @@ async fn device_task(mut dev: i2c_slave::I2cSlave<'static, I2C1>) -> ! {
     loop {
         let mut buf = [0u8; 128];
         match dev.listen(&mut buf).await {
-            Ok(i2c_slave::Command::GeneralCall(len)) => info!("Device recieved general call write: {}", buf[..len]),
+            Ok(i2c_slave::Command::GeneralCall(len)) => info!("Device recieved general call write: {:x}", buf[..len]),
             Ok(i2c_slave::Command::Read) => loop {
-                match dev.respond_to_read(&[state]).await {
+                info!("Device received read");
+                match dev.respond_to_read(&[state, state]).await {
                     Ok(x) => match x {
                         i2c_slave::ReadStatus::Done => break,
-                        i2c_slave::ReadStatus::NeedMoreBytes => (),
+                        i2c_slave::ReadStatus::NeedMoreBytes => error!("need more bytes?"),
                         i2c_slave::ReadStatus::LeftoverBytes(x) => {
                             info!("tried to write {} extra bytes", x);
                             break;
                         }
                     },
-                    Err(e) => error!("error while responding {}", e),
+                    Err(e) => {
+                        error!("error while responding {}", e);
+                        break;
+                    }
                 }
             },
-            Ok(i2c_slave::Command::Write(len)) => info!("Device recieved write: {}", buf[..len]),
+            Ok(i2c_slave::Command::Write(len)) => info!("Device recieved write: {:x}", buf[..len]),
             Ok(i2c_slave::Command::WriteRead(len)) => {
                 info!("device recieved write read: {:x}", buf[..len]);
                 match buf[0] {
                     // Set the state
                     0xC2 => {
+                        defmt::assert_eq!(len, 2);
                         state = buf[1];
                         match dev.respond_and_fill(&[state], 0x00).await {
-                            Ok(read_status) => info!("response read status {}", read_status),
-                            Err(e) => error!("error while responding {}", e),
+                            Ok(read_status) => info!("set state status {}", read_status),
+                            Err(e) => error!("error while responding to set state{}", e),
                         }
                     }
                     // Reset State
                     0xC8 => {
+                        defmt::assert_eq!(len, 1);
                         state = 0;
                         match dev.respond_and_fill(&[state], 0x00).await {
-                            Ok(read_status) => info!("response read status {}", read_status),
-                            Err(e) => error!("error while responding {}", e),
+                            Ok(read_status) => info!("reset state status {}", read_status),
+                            Err(e) => error!("error while responding reset state {}", e),
+                        }
+                    }
+                    // Read States
+                    0xC9 => {
+                        defmt::assert_eq!(len, 1);
+                        match dev.respond_and_fill(&[state], 0x00).await {
+                            Ok(read_status) => info!("read state status {}", read_status),
+                            Err(e) => error!("error while responding to read state {}", e),
                         }
                     }
                     x => error!("Invalid Write Read {:x}", x),
@@ -75,7 +90,7 @@ async fn controller_task(mut con: i2c::I2c<'static, I2C0, i2c::Async>) {
 
     loop {
         let mut resp_buff = [0u8; 2];
-        for i in 0..10 {
+        for i in 0..1 {
             match con.write_read(DEV_ADDR, &[0xC2, i], &mut resp_buff).await {
                 Ok(_) => info!("write_read response: {}", resp_buff),
                 Err(e) => error!("Error writing {}", e),
@@ -83,15 +98,41 @@ async fn controller_task(mut con: i2c::I2c<'static, I2C0, i2c::Async>) {
 
             Timer::after(Duration::from_millis(100)).await;
         }
+        match con.write(DEV_ADDR, &[0xDE, 0xAD, 0xBE, 0xEF]).await {
+            Ok(_) => info!("(1) wrote bytes"),
+            Err(e) => error!("(1) Error writing {}", e),
+        }
         match con.read(DEV_ADDR, &mut resp_buff).await {
-            Ok(_) => info!("read response: {}", resp_buff),
-            Err(e) => error!("Error writing {}", e),
+            Ok(_) => info!("(2) read response: {:x}", resp_buff),
+            Err(e) => error!("(2) Error writing {}", e),
+        }
+        match con.write_read(DEV_ADDR, &[0xC9], &mut resp_buff).await {
+            Ok(_) => info!("(3) write_read response: {}", resp_buff),
+            Err(e) => error!("(3) Error writing {}", e),
+        }
+        match con.read(DEV_ADDR, &mut resp_buff).await {
+            Ok(_) => info!("(4) read response: {:x}", resp_buff),
+            Err(e) => error!("(4) Error writing {}", e),
+        }
+        match con.write(DEV_ADDR, &[0xDA, 0xBB, 0xAD, 0x00]).await {
+            Ok(_) => info!("(5) wrote bytes"),
+            Err(e) => error!("(5) Error writing {}", e),
         }
         match con.write_read(DEV_ADDR, &[0xC8], &mut resp_buff).await {
-            Ok(_) => info!("write_read response: {}", resp_buff),
-            Err(e) => error!("Error writing {}", e),
+            Ok(_) => info!("(6) write_read response: {}", resp_buff),
+            Err(e) => error!("(6) Error writing {}", e),
         }
-        Timer::after(Duration::from_millis(100)).await;
+        Timer::after(Duration::from_micros(100)).await;
+    }
+}
+
+#[embassy_executor::task]
+async fn toggle_led(mut o: Output<'static, PIN_25>) {
+    info!("Blinky start");
+
+    loop {
+        o.toggle();
+        Timer::after(Duration::from_millis(500)).await;
     }
 }
 
@@ -100,19 +141,29 @@ async fn main(spawner: Spawner) {
     let p = embassy_rp::init(Default::default());
     info!("Hello World!");
 
-    let d_sda = p.PIN_3;
-    let d_scl = p.PIN_2;
-    let mut config = i2c_slave::Config::default();
-    config.addr = DEV_ADDR as u16;
-    let device = i2c_slave::I2cSlave::new(p.I2C1, d_sda, d_scl, Irqs, config);
+    #[cfg(feature = "i2c_slave")]
+    {
+        let d_scl = p.PIN_11;
+        let d_sda = p.PIN_10;
+        let mut config = i2c_slave::Config::default();
+        config.addr = DEV_ADDR as u16;
+        let device = i2c_slave::I2cSlave::new(p.I2C1, d_scl, d_sda, Irqs, config);
 
-    unwrap!(spawner.spawn(device_task(device)));
+        unwrap!(spawner.spawn(device_task(device)));
+    }
 
-    let c_sda = p.PIN_1;
-    let c_scl = p.PIN_0;
-    let mut config = i2c::Config::default();
-    config.frequency = 100_000;
-    let controller = i2c::I2c::new_async(p.I2C0, c_sda, c_scl, Irqs, config);
+    #[cfg(feature = "i2c_master")]
+    {
+        let c_scl = p.PIN_17;
+        let c_sda = p.PIN_16;
+        let mut config = i2c::Config::default();
+        config.frequency = 400_000;
+        let controller = i2c::I2c::new_async(p.I2C0, c_scl, c_sda, Irqs, config);
 
-    unwrap!(spawner.spawn(controller_task(controller)));
+        unwrap!(spawner.spawn(controller_task(controller)));
+    }
+
+    let c_led = p.PIN_25;
+    let output = Output::new(c_led, Level::Low);
+    unwrap!(spawner.spawn(toggle_led(output)));
 }


### PR DESCRIPTION
Stretches the clock during read transfers.

I tested this against the in-repo I2c slave example, as well as my prototype.

Please allow @CBJamo to weigh in, possibly test, before merging. I'm pretty green at embedded, so may interrupt/register juggling might be off.