### PR TITLE
stm32/rcc: LSE xtal is 32768hz, not 32000hz.

### DIFF
--- a/embassy-stm32/src/rcc/bd.rs
+++ b/embassy-stm32/src/rcc/bd.rs
@@ -89,7 +89,7 @@ impl LsConfig {
         Self {
             rtc: RtcClockSource::LSE,
             lse: Some(LseConfig {
-                frequency: Hertz(32_000),
+                frequency: Hertz(32_768),
                 mode: LseMode::Oscillator(LseDrive::MediumHigh),
             }),
             lsi: false,


### PR DESCRIPTION
Fixes #2043