### PR TITLE
Wake Stack's polling task after queueing a DNS query

### DIFF
--- a/embassy-net/src/lib.rs
+++ b/embassy-net/src/lib.rs
@@ -509,7 +509,10 @@ impl<D: Driver> Stack<D> {
             self.with_mut(|s, i| {
                 let socket = s.sockets.get_mut::<dns::Socket>(i.dns_socket);
                 match socket.start_query(s.iface.context(), name, qtype) {
-                    Ok(handle) => Poll::Ready(Ok(handle)),
+                    Ok(handle) => {
+                        s.waker.wake();
+                        Poll::Ready(Ok(handle))
+                    }
                     Err(dns::StartQueryError::NoFreeSlot) => {
                         i.dns_waker.register(cx.waker());
                         Poll::Pending


### PR DESCRIPTION
The query is transmitted on the next `Stack::poll` which may or may not be happening in a timely manner. This PR is an attempt to fix this delay.