### PR TITLE
Prepare embassy-net 0.2.0

### DIFF
--- a/cyw43/Cargo.toml
+++ b/cyw43/Cargo.toml
@@ -14,7 +14,7 @@ firmware-logs = []
 embassy-time = { version = "0.1.5", path = "../embassy-time"}
 embassy-sync = { version = "0.3.0", path = "../embassy-sync"}
 embassy-futures = { version = "0.1.0", path = "../embassy-futures"}
-embassy-net-driver-channel = { version = "0.1.0", path = "../embassy-net-driver-channel"}
+embassy-net-driver-channel = { version = "0.2.0", path = "../embassy-net-driver-channel"}
 
 defmt = { version = "0.3", optional = true }
 log = { version = "0.4.17", optional = true }

--- a/embassy-net-adin1110/Cargo.toml
+++ b/embassy-net-adin1110/Cargo.toml
@@ -16,7 +16,7 @@ log = { version = "0.4", default-features = false, optional = true }
 embedded-hal-1 = { package = "embedded-hal", version = "=1.0.0-rc.1" }
 embedded-hal-async = { version = "=1.0.0-rc.1" }
 embedded-hal-bus = { version = "=0.1.0-rc.1", features = ["async"] }
-embassy-net-driver-channel = { version = "0.1.0", path = "../embassy-net-driver-channel" }
+embassy-net-driver-channel = { version = "0.2.0", path = "../embassy-net-driver-channel" }
 embassy-time = { version = "0.1.5", path = "../embassy-time" }
 embassy-futures = { version = "0.1.0", path = "../embassy-futures" }
 bitfield = "0.14.0"

--- a/embassy-net-driver-channel/CHANGELOG.md
+++ b/embassy-net-driver-channel/CHANGELOG.md
@@ -1,0 +1,18 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## 0.2.0 - 2023-10-15
+
+- Update embassy-net-driver
+- `Runner::new` now takes an `embassy_net_driver::HardwareAddress` parameter
+- Added `Runner::set_ieee802154_address`, `Runner::ieee802154_address`
+
+## 0.1.0 - 2023-06-29
+
+- First release
+
+

--- a/embassy-net-driver-channel/Cargo.toml
+++ b/embassy-net-driver-channel/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "embassy-net-driver-channel"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 description = "High-level channel-based driver for the `embassy-net` async TCP/IP network stack."
@@ -26,4 +26,4 @@ log = { version = "0.4.14", optional = true }
 
 embassy-sync = { version = "0.3.0", path = "../embassy-sync" }
 embassy-futures = { version = "0.1.0", path = "../embassy-futures" }
-embassy-net-driver = { version = "0.1.0", path = "../embassy-net-driver" }
+embassy-net-driver = { version = "0.2.0", path = "../embassy-net-driver" }

--- a/embassy-net-driver/CHANGELOG.md
+++ b/embassy-net-driver/CHANGELOG.md
@@ -1,0 +1,17 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## 0.2.0 - 2023-10-15
+
+- Added `Driver::ieee802154_address`
+- Added `Medium::Ieee802154`
+
+## 0.1.0 - 2023-06-29
+
+- First release
+
+

--- a/embassy-net-driver/Cargo.toml
+++ b/embassy-net-driver/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "embassy-net-driver"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 description = "Driver trait for the `embassy-net` async TCP/IP network stack."

--- a/embassy-net-enc28j60/Cargo.toml
+++ b/embassy-net-enc28j60/Cargo.toml
@@ -10,7 +10,7 @@ edition = "2021"
 [dependencies]
 embedded-hal = { version = "1.0.0-rc.1" }
 embedded-hal-async = { version = "=1.0.0-rc.1" }
-embassy-net-driver = { version = "0.1.0", path = "../embassy-net-driver" }
+embassy-net-driver = { version = "0.2.0", path = "../embassy-net-driver" }
 embassy-time = { version = "0.1.5", path = "../embassy-time" }
 embassy-futures = { version = "0.1.0", path = "../embassy-futures" }
 

--- a/embassy-net-esp-hosted/Cargo.toml
+++ b/embassy-net-esp-hosted/Cargo.toml
@@ -10,7 +10,7 @@ log = { version = "0.4.14", optional = true }
 embassy-time = { version = "0.1.5", path = "../embassy-time" }
 embassy-sync = { version = "0.3.0", path = "../embassy-sync"}
 embassy-futures = { version = "0.1.0", path = "../embassy-futures"}
-embassy-net-driver-channel = { version = "0.1.0", path = "../embassy-net-driver-channel"}
+embassy-net-driver-channel = { version = "0.2.0", path = "../embassy-net-driver-channel"}
 
 embedded-hal = { version = "1.0.0-rc.1" }
 embedded-hal-async = { version = "=1.0.0-rc.1" }

--- a/embassy-net-ppp/Cargo.toml
+++ b/embassy-net-ppp/Cargo.toml
@@ -16,7 +16,7 @@ defmt = { version = "0.3", optional = true }
 log = { version = "0.4.14", optional = true }
 
 embedded-io-async = { version = "0.6.0" }
-embassy-net-driver-channel = { version = "0.1.0", path = "../embassy-net-driver-channel" }
+embassy-net-driver-channel = { version = "0.2.0", path = "../embassy-net-driver-channel" }
 embassy-futures = { version = "0.1.0", path = "../embassy-futures" }
 ppproto = { version = "0.1.2"}
 embassy-sync = { version = "0.3.0", path = "../embassy-sync" }

--- a/embassy-net-tuntap/Cargo.toml
+++ b/embassy-net-tuntap/Cargo.toml
@@ -8,7 +8,7 @@ license = "MIT OR Apache-2.0"
 edition = "2021"
 
 [dependencies]
-embassy-net-driver = { version = "0.1.0", path = "../embassy-net-driver" }
+embassy-net-driver = { version = "0.2.0", path = "../embassy-net-driver" }
 async-io = "1.6.0"
 log = "0.4.14"
 libc = "0.2.101"

--- a/embassy-net-wiznet/Cargo.toml
+++ b/embassy-net-wiznet/Cargo.toml
@@ -10,7 +10,7 @@ edition = "2021"
 [dependencies]
 embedded-hal = { version = "1.0.0-rc.1" }
 embedded-hal-async = { version = "=1.0.0-rc.1" }
-embassy-net-driver-channel = { version = "0.1.0", path = "../embassy-net-driver-channel" }
+embassy-net-driver-channel = { version = "0.2.0", path = "../embassy-net-driver-channel" }
 embassy-time = { version = "0.1.5", path = "../embassy-time" }
 embassy-futures = { version = "0.1.0", path = "../embassy-futures" }
 defmt = { version = "0.3", optional = true }

--- a/embassy-net/CHANGELOG.md
+++ b/embassy-net/CHANGELOG.md
@@ -1,0 +1,31 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## 0.2.0 - 2023-10-15
+
+- Re-export `smoltcp::wire::IpEndpoint`
+- Add poll functions on UdpSocket
+- Make dual-stack work in embassy-net
+- Fix multicast support
+- Allow ethernet and 802.15.4 to coexist
+- Add IEEE802.15.4 address to embassy net Stack
+- Use HardwareAddress in Driver
+- Add async versions of smoltcp's `send` and `recv` closure based API
+- add error translation to tcp errors
+- Forward TCP/UDP socket capacity impls
+- allow changing IP config at runtime
+- allow non-'static drivers
+- Remove impl_trait_projections
+- update embedded-io, embedded-nal-async
+- add support for dhcp hostname option
+- Wake stack's task after queueing a DNS query
+
+## 0.1.0 - 2023-06-29
+
+- First release
+
+

--- a/embassy-net/Cargo.toml
+++ b/embassy-net/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "embassy-net"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 description = "Async TCP/IP network stack for embedded systems"
@@ -51,7 +51,7 @@ smoltcp = { version = "0.10.0", default-features = false, features = [
   "async",
 ] }
 
-embassy-net-driver = { version = "0.1.0", path = "../embassy-net-driver" }
+embassy-net-driver = { version = "0.2.0", path = "../embassy-net-driver" }
 embassy-time = { version = "0.1.5", path = "../embassy-time" }
 embassy-sync = { version = "0.3.0", path = "../embassy-sync" }
 embedded-io-async = { version = "0.6.0", optional = true }

--- a/embassy-stm32-wpan/Cargo.toml
+++ b/embassy-stm32-wpan/Cargo.toml
@@ -17,7 +17,7 @@ embassy-time = { version = "0.1.5", path = "../embassy-time", optional = true }
 embassy-futures = { version = "0.1.0", path = "../embassy-futures" }
 embassy-hal-internal = { version = "0.1.0", path = "../embassy-hal-internal" }
 embassy-embedded-hal = { version = "0.1.0", path = "../embassy-embedded-hal" }
-embassy-net-driver = { version = "0.1.0", path = "../embassy-net-driver", optional=true }
+embassy-net-driver = { version = "0.2.0", path = "../embassy-net-driver", optional=true }
 
 defmt = { version = "0.3", optional = true }
 cortex-m = "0.7.6"

--- a/embassy-stm32/Cargo.toml
+++ b/embassy-stm32/Cargo.toml
@@ -37,7 +37,7 @@ embassy-time = { version = "0.1.5", path = "../embassy-time", optional = true }
 embassy-futures = { version = "0.1.0", path = "../embassy-futures" }
 embassy-hal-internal = {version = "0.1.0", path = "../embassy-hal-internal", features = ["cortex-m", "prio-bits-4"] }
 embassy-embedded-hal = {version = "0.1.0", path = "../embassy-embedded-hal" }
-embassy-net-driver = { version = "0.1.0", path = "../embassy-net-driver" }
+embassy-net-driver = { version = "0.2.0", path = "../embassy-net-driver" }
 embassy-usb-driver = {version = "0.1.0", path = "../embassy-usb-driver", optional = true }
 embassy-executor = { version = "0.3.0", path = "../embassy-executor", optional = true }
 

--- a/embassy-usb/Cargo.toml
+++ b/embassy-usb/Cargo.toml
@@ -42,7 +42,7 @@ max-handler-count-8 = []
 embassy-futures = { version = "0.1.0", path = "../embassy-futures" }
 embassy-usb-driver = { version = "0.1.0", path = "../embassy-usb-driver" }
 embassy-sync = { version = "0.3.0", path = "../embassy-sync" }
-embassy-net-driver-channel = { version = "0.1.0", path = "../embassy-net-driver-channel" }
+embassy-net-driver-channel = { version = "0.2.0", path = "../embassy-net-driver-channel" }
 
 defmt = { version = "0.3", optional = true }
 log = { version = "0.4.14", optional = true }

--- a/examples/nrf52840/Cargo.toml
+++ b/examples/nrf52840/Cargo.toml
@@ -33,7 +33,7 @@ embassy-sync = { version = "0.3.0", path = "../../embassy-sync", features = ["de
 embassy-executor = { version = "0.3.0", path = "../../embassy-executor", features = ["arch-cortex-m", "executor-thread", "executor-interrupt", "defmt", "integrated-timers"] }
 embassy-time = { version = "0.1.5", path = "../../embassy-time", features = ["defmt", "defmt-timestamp-uptime"] }
 embassy-nrf = { version = "0.1.0", path = "../../embassy-nrf", features = ["defmt", "nrf52840", "time-driver-rtc1", "gpiote", "unstable-pac", "time"] }
-embassy-net = { version = "0.1.0", path = "../../embassy-net", features = ["defmt", "tcp", "dhcpv4", "medium-ethernet"], optional = true }
+embassy-net = { version = "0.2.0", path = "../../embassy-net", features = ["defmt", "tcp", "dhcpv4", "medium-ethernet"], optional = true }
 embassy-usb = { version = "0.1.0", path = "../../embassy-usb", features = ["defmt", "msos-descriptor",], optional = true }
 embedded-io = { version = "0.6.0", features = ["defmt-03"]  }
 embedded-io-async = { version = "0.6.0", optional = true, features = ["defmt-03"] }

--- a/examples/nrf5340/Cargo.toml
+++ b/examples/nrf5340/Cargo.toml
@@ -27,7 +27,7 @@ embassy-nrf = { version = "0.1.0", path = "../../embassy-nrf", features = [
     "gpiote",
     "unstable-pac",
 ] }
-embassy-net = { version = "0.1.0", path = "../../embassy-net", features = [
+embassy-net = { version = "0.2.0", path = "../../embassy-net", features = [
     "nightly",
     "defmt",
     "tcp",

--- a/examples/rp/Cargo.toml
+++ b/examples/rp/Cargo.toml
@@ -12,7 +12,7 @@ embassy-executor = { version = "0.3.0", path = "../../embassy-executor", feature
 embassy-time = { version = "0.1.5", path = "../../embassy-time", features = ["nightly", "unstable-traits", "defmt", "defmt-timestamp-uptime"] }
 embassy-rp = { version = "0.1.0", path = "../../embassy-rp", features = ["defmt", "unstable-traits", "nightly", "unstable-pac", "time-driver", "critical-section-impl"] }
 embassy-usb = { version = "0.1.0", path = "../../embassy-usb", features = ["defmt"] }
-embassy-net = { version = "0.1.0", path = "../../embassy-net", features = ["defmt", "nightly", "tcp", "udp", "dhcpv4", "medium-ethernet"] }
+embassy-net = { version = "0.2.0", path = "../../embassy-net", features = ["defmt", "nightly", "tcp", "udp", "dhcpv4", "medium-ethernet"] }
 embassy-net-wiznet = { version = "0.1.0", path = "../../embassy-net-wiznet", features = ["defmt"] }
 embassy-futures = { version = "0.1.0", path = "../../embassy-futures" }
 embassy-usb-logger = { version = "0.1.0", path = "../../embassy-usb-logger" }

--- a/examples/std/Cargo.toml
+++ b/examples/std/Cargo.toml
@@ -8,7 +8,7 @@ license = "MIT OR Apache-2.0"
 embassy-sync = { version = "0.3.0", path = "../../embassy-sync", features = ["log"] }
 embassy-executor = { version = "0.3.0", path = "../../embassy-executor", features = ["arch-std", "executor-thread", "log", "nightly", "integrated-timers"] }
 embassy-time = { version = "0.1.5", path = "../../embassy-time", features = ["log", "std", "nightly"] }
-embassy-net = { version = "0.1.0", path = "../../embassy-net", features=[ "std", "nightly", "log", "medium-ethernet", "medium-ip", "tcp", "udp", "dns", "dhcpv4", "proto-ipv6"] }
+embassy-net = { version = "0.2.0", path = "../../embassy-net", features=[ "std", "nightly", "log", "medium-ethernet", "medium-ip", "tcp", "udp", "dns", "dhcpv4", "proto-ipv6"] }
 embassy-net-tuntap = { version = "0.1.0", path = "../../embassy-net-tuntap" }
 embassy-net-ppp = { version = "0.1.0", path = "../../embassy-net-ppp", features = ["log"]}
 embedded-io-async = { version = "0.6.0" }

--- a/examples/stm32f4/Cargo.toml
+++ b/examples/stm32f4/Cargo.toml
@@ -11,7 +11,7 @@ embassy-sync = { version = "0.3.0", path = "../../embassy-sync", features = ["de
 embassy-executor = { version = "0.3.0", path = "../../embassy-executor", features = ["nightly", "arch-cortex-m", "executor-thread", "executor-interrupt", "defmt", "integrated-timers"] }
 embassy-time = { version = "0.1.5", path = "../../embassy-time", features = ["defmt", "defmt-timestamp-uptime", "unstable-traits", "tick-hz-32_768"] }
 embassy-usb = { version = "0.1.0", path = "../../embassy-usb", features = ["defmt"] }
-embassy-net = { version = "0.1.0", path = "../../embassy-net", features = ["defmt", "tcp", "dhcpv4", "medium-ethernet", "nightly"] }
+embassy-net = { version = "0.2.0", path = "../../embassy-net", features = ["defmt", "tcp", "dhcpv4", "medium-ethernet", "nightly"] }
 
 defmt = "0.3"
 defmt-rtt = "0.4"

--- a/examples/stm32f7/Cargo.toml
+++ b/examples/stm32f7/Cargo.toml
@@ -10,7 +10,7 @@ embassy-stm32 = { version = "0.1.0", path = "../../embassy-stm32", features = ["
 embassy-sync = { version = "0.3.0", path = "../../embassy-sync", features = ["defmt"] }
 embassy-executor = { version = "0.3.0", path = "../../embassy-executor", features = ["nightly", "arch-cortex-m", "executor-thread", "defmt", "integrated-timers"] }
 embassy-time = { version = "0.1.5", path = "../../embassy-time", features = ["defmt", "defmt-timestamp-uptime", "tick-hz-32_768"] }
-embassy-net = { path = "../../embassy-net", features = ["defmt", "nightly", "tcp", "dhcpv4", "medium-ethernet"] }
+embassy-net = { version = "0.2.0", path = "../../embassy-net", features = ["defmt", "nightly", "tcp", "dhcpv4", "medium-ethernet"] }
 embedded-io-async = { version = "0.6.0" }
 embassy-usb = { version = "0.1.0", path = "../../embassy-usb", features = ["defmt"] }
 

--- a/examples/stm32h5/Cargo.toml
+++ b/examples/stm32h5/Cargo.toml
@@ -10,7 +10,7 @@ embassy-stm32 = { version = "0.1.0", path = "../../embassy-stm32", features = ["
 embassy-sync = { version = "0.3.0", path = "../../embassy-sync", features = ["defmt"] }
 embassy-executor = { version = "0.3.0", path = "../../embassy-executor", features = ["nightly", "arch-cortex-m", "executor-thread", "defmt", "integrated-timers"] }
 embassy-time = { version = "0.1.5", path = "../../embassy-time", features = ["defmt", "defmt-timestamp-uptime", "unstable-traits", "tick-hz-32_768"] }
-embassy-net = { path = "../../embassy-net", features = ["defmt", "nightly", "tcp", "dhcpv4", "medium-ethernet", "proto-ipv6"] }
+embassy-net = { version = "0.2.0", path = "../../embassy-net", features = ["defmt", "nightly", "tcp", "dhcpv4", "medium-ethernet", "proto-ipv6"] }
 embedded-io-async = { version = "0.6.0" }
 embassy-usb = { version = "0.1.0", path = "../../embassy-usb", features = ["defmt"] }
 

--- a/examples/stm32h7/Cargo.toml
+++ b/examples/stm32h7/Cargo.toml
@@ -10,7 +10,7 @@ embassy-stm32 = { version = "0.1.0", path = "../../embassy-stm32", features = ["
 embassy-sync = { version = "0.3.0", path = "../../embassy-sync", features = ["defmt"] }
 embassy-executor = { version = "0.3.0", path = "../../embassy-executor", features = ["nightly", "arch-cortex-m", "executor-thread", "defmt", "integrated-timers"] }
 embassy-time = { version = "0.1.5", path = "../../embassy-time", features = ["defmt", "defmt-timestamp-uptime", "unstable-traits", "tick-hz-32_768"] }
-embassy-net = { path = "../../embassy-net", features = ["defmt", "nightly", "tcp", "dhcpv4", "medium-ethernet", "proto-ipv6"] }
+embassy-net = { version = "0.2.0", path = "../../embassy-net", features = ["defmt", "nightly", "tcp", "dhcpv4", "medium-ethernet", "proto-ipv6"] }
 embedded-io-async = { version = "0.6.0" }
 embassy-usb = { version = "0.1.0", path = "../../embassy-usb", features = ["defmt"] }
 

--- a/examples/stm32l4/Cargo.toml
+++ b/examples/stm32l4/Cargo.toml
@@ -13,7 +13,7 @@ embassy-time = { version = "0.1.5", path = "../../embassy-time", features = ["de
 embassy-embedded-hal = { version = "0.1.0", path = "../../embassy-embedded-hal" }
 embassy-usb = { version = "0.1.0", path = "../../embassy-usb", features = ["defmt"] }
 embassy-net-adin1110 = { version = "0.2.0", path = "../../embassy-net-adin1110" }
-embassy-net = { version = "0.1.0", path = "../../embassy-net", features = ["defmt", "nightly", "udp", "tcp", "dhcpv4", "medium-ethernet"] }
+embassy-net = { version = "0.2.0", path = "../../embassy-net", features = ["defmt", "nightly", "udp", "tcp", "dhcpv4", "medium-ethernet"] }
 embassy-futures = { version = "0.1.0", path = "../../embassy-futures" }
 embedded-io-async = { version = "0.6.0", features = ["defmt-03"] }
 embedded-io = { version = "0.6.0", features = ["defmt-03"] }

--- a/examples/stm32l5/Cargo.toml
+++ b/examples/stm32l5/Cargo.toml
@@ -11,7 +11,7 @@ embassy-sync = { version = "0.3.0", path = "../../embassy-sync", features = ["de
 embassy-executor = { version = "0.3.0", path = "../../embassy-executor", features = ["nightly", "arch-cortex-m", "executor-thread", "defmt", "integrated-timers"] }
 embassy-time = { version = "0.1.5", path = "../../embassy-time", features = ["defmt", "defmt-timestamp-uptime", "tick-hz-32_768"] }
 embassy-usb = { version = "0.1.0", path = "../../embassy-usb", features = ["defmt"] }
-embassy-net = { version = "0.1.0", path = "../../embassy-net", features = ["defmt", "nightly", "tcp", "dhcpv4", "medium-ethernet"] }
+embassy-net = { version = "0.2.0", path = "../../embassy-net", features = ["defmt", "nightly", "tcp", "dhcpv4", "medium-ethernet"] }
 embassy-futures = { version = "0.1.0", path = "../../embassy-futures" }
 usbd-hid = "0.6.0"
 

--- a/examples/stm32wb/Cargo.toml
+++ b/examples/stm32wb/Cargo.toml
@@ -11,7 +11,7 @@ embassy-stm32-wpan = { version = "0.1.0", path = "../../embassy-stm32-wpan", fea
 embassy-sync = { version = "0.3.0", path = "../../embassy-sync", features = ["defmt"] }
 embassy-executor = { version = "0.3.0", path = "../../embassy-executor", features = ["nightly", "arch-cortex-m", "executor-thread", "defmt", "integrated-timers"] }
 embassy-time = { version = "0.1.5", path = "../../embassy-time", features = ["defmt", "defmt-timestamp-uptime", "tick-hz-32_768"] }
-embassy-net = { version = "0.1.0", path = "../../embassy-net", features = ["defmt", "udp", "proto-ipv6", "medium-ieee802154", "nightly"], optional=true }
+embassy-net = { version = "0.2.0", path = "../../embassy-net", features = ["defmt", "udp", "proto-ipv6", "medium-ieee802154", "nightly"], optional=true }
 
 defmt = "0.3"
 defmt-rtt = "0.4"

--- a/examples/stm32wba/Cargo.toml
+++ b/examples/stm32wba/Cargo.toml
@@ -9,7 +9,7 @@ embassy-stm32 = { version = "0.1.0", path = "../../embassy-stm32", features = ["
 embassy-sync = { version = "0.3.0", path = "../../embassy-sync", features = ["defmt"] }
 embassy-executor = { version = "0.3.0", path = "../../embassy-executor", features = ["nightly", "arch-cortex-m", "executor-thread", "defmt", "integrated-timers"] }
 embassy-time = { version = "0.1.5", path = "../../embassy-time", features = ["defmt", "defmt-timestamp-uptime", "tick-hz-32_768"] }
-embassy-net = { version = "0.1.0", path = "../../embassy-net", features = ["defmt", "udp", "proto-ipv6", "medium-ieee802154", "nightly"], optional=true }
+embassy-net = { version = "0.2.0", path = "../../embassy-net", features = ["defmt", "udp", "proto-ipv6", "medium-ieee802154", "nightly"], optional=true }
 
 defmt = "0.3"
 defmt-rtt = "0.4"

--- a/tests/nrf/Cargo.toml
+++ b/tests/nrf/Cargo.toml
@@ -13,7 +13,7 @@ embassy-executor = { version = "0.3.0", path = "../../embassy-executor", feature
 embassy-time = { version = "0.1.5", path = "../../embassy-time", features = ["defmt", "nightly", "unstable-traits", "defmt-timestamp-uptime"] }
 embassy-nrf = { version = "0.1.0", path = "../../embassy-nrf", features = ["defmt", "nightly", "unstable-traits", "nrf52840", "time-driver-rtc1", "gpiote", "unstable-pac"] }
 embedded-io-async = { version = "0.6.0" }
-embassy-net = { version = "0.1.0", path = "../../embassy-net", features = ["defmt", "tcp", "dhcpv4", "medium-ethernet", "nightly"] }
+embassy-net = { version = "0.2.0", path = "../../embassy-net", features = ["defmt", "tcp", "dhcpv4", "medium-ethernet", "nightly"] }
 embassy-net-esp-hosted = { version = "0.1.0", path = "../../embassy-net-esp-hosted", features = ["defmt"] }
 embassy-net-enc28j60 = { version = "0.1.0", path = "../../embassy-net-enc28j60", features = ["defmt"] }
 embedded-hal-async = { version = "1.0.0-rc.1" }

--- a/tests/perf-client/Cargo.toml
+++ b/tests/perf-client/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-embassy-net = { version = "0.1.0", path = "../../embassy-net", features = ["defmt", "tcp", "dhcpv4"] }
+embassy-net = { version = "0.2.0", path = "../../embassy-net", features = ["defmt", "tcp", "dhcpv4"] }
 embassy-time = { version = "0.1.5", path = "../../embassy-time", features = ["defmt", "nightly", "unstable-traits"] }
 embassy-futures = { version = "0.1.0", path = "../../embassy-futures" }
 defmt = "0.3.0"

--- a/tests/rp/Cargo.toml
+++ b/tests/rp/Cargo.toml
@@ -12,7 +12,7 @@ embassy-executor = { version = "0.3.0", path = "../../embassy-executor", feature
 embassy-time = { version = "0.1.5", path = "../../embassy-time", features = ["defmt", "nightly", "unstable-traits"] }
 embassy-rp = { version = "0.1.0", path = "../../embassy-rp", features = ["nightly", "defmt", "unstable-pac", "unstable-traits", "time-driver", "critical-section-impl", "intrinsics", "rom-v2-intrinsics", "run-from-ram"]  }
 embassy-futures = { version = "0.1.0", path = "../../embassy-futures" }
-embassy-net = { version = "0.1.0", path = "../../embassy-net", features = ["defmt", "nightly", "tcp", "udp", "dhcpv4", "medium-ethernet"] }
+embassy-net = { version = "0.2.0", path = "../../embassy-net", features = ["defmt", "nightly", "tcp", "udp", "dhcpv4", "medium-ethernet"] }
 embassy-net-wiznet = { version = "0.1.0", path = "../../embassy-net-wiznet", features = ["defmt"] }
 cyw43 = { path = "../../cyw43", features = ["defmt", "firmware-logs"] }
 cyw43-pio = { path = "../../cyw43-pio", features = ["defmt", "overclock"] }

--- a/tests/stm32/Cargo.toml
+++ b/tests/stm32/Cargo.toml
@@ -46,7 +46,7 @@ embassy-time = { version = "0.1.5", path = "../../embassy-time", features = ["de
 embassy-stm32 = { version = "0.1.0", path = "../../embassy-stm32", features = ["nightly", "defmt", "unstable-pac", "memory-x", "time-driver-any"]  }
 embassy-futures = { version = "0.1.0", path = "../../embassy-futures" }
 embassy-stm32-wpan = { version = "0.1.0", path = "../../embassy-stm32-wpan", optional = true, features = ["defmt", "stm32wb55rg", "ble"] }
-embassy-net = { version = "0.1.0", path = "../../embassy-net", features = ["defmt", "nightly", "tcp", "udp", "dhcpv4", "medium-ethernet"] }
+embassy-net = { version = "0.2.0", path = "../../embassy-net", features = ["defmt", "nightly", "tcp", "udp", "dhcpv4", "medium-ethernet"] }
 perf-client = { path = "../perf-client" }
 
 defmt = "0.3.0"


### PR DESCRIPTION
Not sure what else is planned but maybe it's not a bad idea to do a pre-AFIT, pre-embedded-hal-1.0 release so other crates may pull in fixes and try to catch up.