### PR TITLE
fiix stm32wl rng example to use MSI instead of LSI

### DIFF
--- a/examples/stm32wl/src/bin/random.rs
+++ b/examples/stm32wl/src/bin/random.rs
@@ -18,8 +18,11 @@ async fn main(_spawner: Spawner) {
     config.rcc.mux = embassy_stm32::rcc::ClockSrc::HSE;
 
     let p = embassy_stm32::init(config);
+
+    // Use MSI as rng clock source.
+    // Slower clocks such as LSI and LSE will fail with clock error
     pac::RCC.ccipr().modify(|w| {
-        w.set_rngsel(0b01);
+        w.set_rngsel(0b11);
     });
 
     info!("Hello World!");


### PR DESCRIPTION
Small change to avoid confusion for people trying the random example for stm32wl.