### PR TITLE
docs: add linker script comments

### DIFF
--- a/examples/nrf52840-rtic/memory.x
+++ b/examples/nrf52840-rtic/memory.x
@@ -1,7 +1,12 @@
 MEMORY
 {
   /* NOTE 1 K = 1 KiBi = 1024 bytes */
-  /* These values correspond to the NRF52840 with Softdevices S140 7.0.1 */
   FLASH : ORIGIN = 0x00000000, LENGTH = 1024K
   RAM : ORIGIN = 0x20000000, LENGTH = 256K
+
+  /* These values correspond to the NRF52840 with Softdevices S140 7.3.0 */
+  /*
+     FLASH : ORIGIN = 0x00027000, LENGTH = 868K
+     RAM : ORIGIN = 0x20020000, LENGTH = 128K
+  */
 }

--- a/examples/nrf52840/memory.x
+++ b/examples/nrf52840/memory.x
@@ -1,7 +1,12 @@
 MEMORY
 {
   /* NOTE 1 K = 1 KiBi = 1024 bytes */
-  /* These values correspond to the NRF52840 with Softdevices S140 7.0.1 */
   FLASH : ORIGIN = 0x00000000, LENGTH = 1024K
   RAM : ORIGIN = 0x20000000, LENGTH = 256K
+
+  /* These values correspond to the NRF52840 with Softdevices S140 7.3.0 */
+  /*
+     FLASH : ORIGIN = 0x00027000, LENGTH = 868K
+     RAM : ORIGIN = 0x20020000, LENGTH = 128K
+  */
 }


### PR DESCRIPTION
Existing comment were outdated. Provide an example configuration for using the softdevice with the nRF52 examples.

Fixes #2079