### PR TITLE
net: Reset DHCP socket when the link up is detected

### DIFF
--- a/embassy-net/src/lib.rs
+++ b/embassy-net/src/lib.rs
@@ -860,6 +860,9 @@ impl<D: Driver> Inner<D> {
             let socket = s.sockets.get_mut::<dhcpv4::Socket>(dhcp_handle);
 
             if self.link_up {
+                if old_link_up != self.link_up {
+                    socket.reset();
+                }
                 match socket.poll() {
                     None => {}
                     Some(dhcpv4::Event::Deconfigured) => {


### PR DESCRIPTION
Previously, because DHCP DISCOVER is sent before the link is established, socket has to timeout first. Which takes extra 10 s.

Now if the state of the link changed to up, socket is explicitly reset so the DISCOVER is repeated much earlier and DHCP configuration is acquired much faster.