### PR TITLE
Fix stm32 uart set_config

### DIFF
--- a/embassy-stm32/src/usart/buffered.rs
+++ b/embassy-stm32/src/usart/buffered.rs
@@ -116,28 +116,28 @@ pub struct BufferedUartRx<'d, T: BasicInstance> {
 
 impl<'d, T: BasicInstance> SetConfig for BufferedUart<'d, T> {
     type Config = Config;
-    type ConfigError = ();
+    type ConfigError = ConfigError;
 
-    fn set_config(&mut self, config: &Self::Config) -> Result<(), ()> {
-        self.set_config(config).map_err(|_| ())
+    fn set_config(&mut self, config: &Self::Config) -> Result<(), Self::ConfigError> {
+        self.set_config(config)
     }
 }
 
 impl<'d, T: BasicInstance> SetConfig for BufferedUartRx<'d, T> {
     type Config = Config;
-    type ConfigError = ();
+    type ConfigError = ConfigError;
 
-    fn set_config(&mut self, config: &Self::Config) -> Result<(), ()> {
-        self.set_config(config).map_err(|_| ())
+    fn set_config(&mut self, config: &Self::Config) -> Result<(), Self::ConfigError> {
+        self.set_config(config)
     }
 }
 
 impl<'d, T: BasicInstance> SetConfig for BufferedUartTx<'d, T> {
     type Config = Config;
-    type ConfigError = ();
+    type ConfigError = ConfigError;
 
-    fn set_config(&mut self, config: &Self::Config) -> Result<(), ()> {
-        self.set_config(config).map_err(|_| ())
+    fn set_config(&mut self, config: &Self::Config) -> Result<(), Self::ConfigError> {
+        self.set_config(config)
     }
 }
 

--- a/embassy-stm32/src/usart/buffered.rs
+++ b/embassy-stm32/src/usart/buffered.rs
@@ -233,7 +233,7 @@ impl<'d, T: BasicInstance> BufferedUart<'d, T> {
         configure(r, &config, T::frequency(), T::KIND, true, true)?;
 
         r.cr1().modify(|w| {
-            #[cfg(lpuart_v2)]
+            #[cfg(usart_v4)]
             w.set_fifoen(true);
 
             w.set_rxneie(true);
@@ -254,7 +254,17 @@ impl<'d, T: BasicInstance> BufferedUart<'d, T> {
     }
 
     pub fn set_config(&mut self, config: &Config) -> Result<(), ConfigError> {
-        reconfigure::<T>(config)
+        reconfigure::<T>(config)?;
+
+        T::regs().cr1().modify(|w| {
+            #[cfg(usart_v4)]
+            w.set_fifoen(true);
+
+            w.set_rxneie(true);
+            w.set_idleie(true);
+        });
+
+        Ok(())
     }
 }
 
@@ -334,7 +344,17 @@ impl<'d, T: BasicInstance> BufferedUartRx<'d, T> {
     }
 
     pub fn set_config(&mut self, config: &Config) -> Result<(), ConfigError> {
-        reconfigure::<T>(config)
+        reconfigure::<T>(config)?;
+
+        T::regs().cr1().modify(|w| {
+            #[cfg(usart_v4)]
+            w.set_fifoen(true);
+
+            w.set_rxneie(true);
+            w.set_idleie(true);
+        });
+
+        Ok(())
     }
 }
 
@@ -408,7 +428,17 @@ impl<'d, T: BasicInstance> BufferedUartTx<'d, T> {
     }
 
     pub fn set_config(&mut self, config: &Config) -> Result<(), ConfigError> {
-        reconfigure::<T>(config)
+        reconfigure::<T>(config)?;
+
+        T::regs().cr1().modify(|w| {
+            #[cfg(usart_v4)]
+            w.set_fifoen(true);
+
+            w.set_rxneie(true);
+            w.set_idleie(true);
+        });
+
+        Ok(())
     }
 }
 

--- a/embassy-stm32/src/usart/buffered.rs
+++ b/embassy-stm32/src/usart/buffered.rs
@@ -233,9 +233,6 @@ impl<'d, T: BasicInstance> BufferedUart<'d, T> {
         configure(r, &config, T::frequency(), T::KIND, true, true)?;
 
         r.cr1().modify(|w| {
-            #[cfg(usart_v4)]
-            w.set_fifoen(true);
-
             w.set_rxneie(true);
             w.set_idleie(true);
         });
@@ -257,9 +254,6 @@ impl<'d, T: BasicInstance> BufferedUart<'d, T> {
         reconfigure::<T>(config)?;
 
         T::regs().cr1().modify(|w| {
-            #[cfg(usart_v4)]
-            w.set_fifoen(true);
-
             w.set_rxneie(true);
             w.set_idleie(true);
         });
@@ -347,9 +341,6 @@ impl<'d, T: BasicInstance> BufferedUartRx<'d, T> {
         reconfigure::<T>(config)?;
 
         T::regs().cr1().modify(|w| {
-            #[cfg(usart_v4)]
-            w.set_fifoen(true);
-
             w.set_rxneie(true);
             w.set_idleie(true);
         });
@@ -431,9 +422,6 @@ impl<'d, T: BasicInstance> BufferedUartTx<'d, T> {
         reconfigure::<T>(config)?;
 
         T::regs().cr1().modify(|w| {
-            #[cfg(usart_v4)]
-            w.set_fifoen(true);
-
             w.set_rxneie(true);
             w.set_idleie(true);
         });

--- a/embassy-stm32/src/usart/mod.rs
+++ b/embassy-stm32/src/usart/mod.rs
@@ -910,6 +910,11 @@ fn configure(
         brr + rounding
     }
 
+    // UART must be disabled during configuration.
+    r.cr1().modify(|w| {
+        w.set_ue(false);
+    });
+
     #[cfg(not(usart_v1))]
     let mut over8 = false;
     let mut found_brr = None;
@@ -977,10 +982,9 @@ fn configure(
         // enable receiver
         w.set_re(enable_rx);
         // configure word size
-        w.set_m0(if config.parity != Parity::ParityNone {
-            vals::M0::BIT9
-        } else {
-            vals::M0::BIT8
+        w.set_m0(match config.data_bits {
+            DataBits::DataBits8 => vals::M0::BIT8,
+            DataBits::DataBits9 => vals::M0::BIT9,
         });
         // configure parity
         w.set_pce(config.parity != Parity::ParityNone);

--- a/embassy-stm32/src/usart/mod.rs
+++ b/embassy-stm32/src/usart/mod.rs
@@ -108,6 +108,7 @@ pub enum StopBits {
 pub enum ConfigError {
     BaudrateTooLow,
     BaudrateTooHigh,
+    RxOrTxNotEnabled,
 }
 
 #[non_exhaustive]
@@ -866,7 +867,7 @@ fn configure(
     enable_tx: bool,
 ) -> Result<(), ConfigError> {
     if !enable_rx && !enable_tx {
-        panic!("USART: At least one of RX or TX should be enabled");
+        return Err(ConfigError::RxOrTxNotEnabled);
     }
 
     #[cfg(not(usart_v4))]

--- a/embassy-stm32/src/usart/mod.rs
+++ b/embassy-stm32/src/usart/mod.rs
@@ -182,11 +182,11 @@ pub struct Uart<'d, T: BasicInstance, TxDma = NoDma, RxDma = NoDma> {
 
 impl<'d, T: BasicInstance, TxDma, RxDma> SetConfig for Uart<'d, T, TxDma, RxDma> {
     type Config = Config;
-    type ConfigError = ();
+    type ConfigError = ConfigError;
 
-    fn set_config(&mut self, config: &Self::Config) -> Result<(), ()> {
-        self.tx.set_config(config).map_err(|_| ())?;
-        self.rx.set_config(config).map_err(|_| ())
+    fn set_config(&mut self, config: &Self::Config) -> Result<(), Self::ConfigError> {
+        self.tx.set_config(config)?;
+        self.rx.set_config(config)
     }
 }
 
@@ -197,10 +197,10 @@ pub struct UartTx<'d, T: BasicInstance, TxDma = NoDma> {
 
 impl<'d, T: BasicInstance, TxDma> SetConfig for UartTx<'d, T, TxDma> {
     type Config = Config;
-    type ConfigError = ();
+    type ConfigError = ConfigError;
 
-    fn set_config(&mut self, config: &Self::Config) -> Result<(), ()> {
-        self.set_config(config).map_err(|_| ())
+    fn set_config(&mut self, config: &Self::Config) -> Result<(), Self::ConfigError> {
+        self.set_config(config)
     }
 }
 
@@ -214,10 +214,10 @@ pub struct UartRx<'d, T: BasicInstance, RxDma = NoDma> {
 
 impl<'d, T: BasicInstance, RxDma> SetConfig for UartRx<'d, T, RxDma> {
     type Config = Config;
-    type ConfigError = ();
+    type ConfigError = ConfigError;
 
-    fn set_config(&mut self, config: &Self::Config) -> Result<(), ()> {
-        self.set_config(config).map_err(|_| ())
+    fn set_config(&mut self, config: &Self::Config) -> Result<(), Self::ConfigError> {
+        self.set_config(config)
     }
 }
 

--- a/embassy-stm32/src/usart/ringbuffered.rs
+++ b/embassy-stm32/src/usart/ringbuffered.rs
@@ -18,10 +18,10 @@ pub struct RingBufferedUartRx<'d, T: BasicInstance, RxDma: super::RxDma<T>> {
 
 impl<'d, T: BasicInstance, RxDma: super::RxDma<T>> SetConfig for RingBufferedUartRx<'d, T, RxDma> {
     type Config = Config;
-    type ConfigError = ();
+    type ConfigError = ConfigError;
 
-    fn set_config(&mut self, config: &Self::Config) -> Result<(), ()> {
-        self.set_config(config).map_err(|_| ())
+    fn set_config(&mut self, config: &Self::Config) -> Result<(), Self::ConfigError> {
+        self.set_config(config)
     }
 }
 


### PR DESCRIPTION
* `CR1` `UE` must be false when setting word length and parity bits.
* use `type ConfigError = ConfigError` instead of `type ConfigError = ()`
* In mod.rs there is `fn configure()` which uses write to set `CR1`. This disables `RXNEIE` and `IDLEIE` in `CR1` and those must be re-enabled again. Otherwise receive does not work anymore.

# TODO (done)

- [x]  What to do with `fifoen`, which one is correct?

https://github.com/embassy-rs/embassy/blob/ca27590afac33019dbc81489117b33fd7e3063a5/embassy-stm32/src/usart/mod.rs#L998-L999
vs
https://github.com/embassy-rs/embassy/blob/ca27590afac33019dbc81489117b33fd7e3063a5/embassy-stm32/src/usart/buffered.rs#L236-L237

Edit: `usart_v4` is correct.

# TEST
Tested with stm32g081 by reconfiguring baudrate, parity and stop bits.
