### PR TITLE
STM32: Add raw access to FMC peripheral and fix typo in build.rs

### DIFF
--- a/embassy-stm32/build.rs
+++ b/embassy-stm32/build.rs
@@ -797,7 +797,7 @@ fn main() {
         (("fmc", "NCE"), quote!(crate::fmc::NCEPin)),
         (("fmc", "NOE"), quote!(crate::fmc::NOEPin)),
         (("fmc", "NWE"), quote!(crate::fmc::NWEPin)),
-        (("fmc", "Clk"), quote!(crate::fmc::ClkPin)),
+        (("fmc", "CLK"), quote!(crate::fmc::ClkPin)),
         (("fmc", "BA0"), quote!(crate::fmc::BA0Pin)),
         (("fmc", "BA1"), quote!(crate::fmc::BA1Pin)),
         (("timer", "CH1"), quote!(crate::timer::Channel1Pin)),

--- a/embassy-stm32/src/fmc.rs
+++ b/embassy-stm32/src/fmc.rs
@@ -12,6 +12,37 @@ pub struct Fmc<'d, T: Instance> {
 
 unsafe impl<'d, T> Send for Fmc<'d, T> where T: Instance {}
 
+impl<'d, T> Fmc<'d, T>
+where
+    T: Instance,
+{
+    /// Create a raw FMC instance.
+    ///
+    /// **Note:** This is currently used to provide access to some basic FMC functions
+    /// for manual configuration for memory types that stm32-fmc does not support.
+    pub fn new_raw(_instance: impl Peripheral<P = T> + 'd) -> Self {
+        Self { peri: PhantomData }
+    }
+
+    /// Enable the FMC peripheral and reset it.
+    pub fn enable(&mut self) {
+        T::enable_and_reset();
+    }
+
+    /// Enable the memory controller on applicable chips.
+    pub fn memory_controller_enable(&mut self) {
+        // fmc v1 and v2 does not have the fmcen bit
+        // fsmc v1, v2 and v3 does not have the fmcen bit
+        // This is a "not" because it is expected that all future versions have this bit
+        #[cfg(not(any(fmc_v1x3, fmc_v2x1, fsmc_v1x0, fsmc_v1x3, fsmc_v2x3, fsmc_v3x1)))]
+        T::REGS.bcr1().modify(|r| r.set_fmcen(true));
+    }
+
+    pub fn source_clock_hz(&self) -> u32 {
+        <T as crate::rcc::sealed::RccPeripheral>::frequency().0
+    }
+}
+
 unsafe impl<'d, T> stm32_fmc::FmcPeripheral for Fmc<'d, T>
 where
     T: Instance,


### PR DESCRIPTION
This PR fixes a typo in the build.rs file that caused the FMC ClkPin to not be implemented (was `Clk`, changed to `CLK`) and adds a basic "raw" implementation for the `Fmc` struct so one gets access to the Rcc `enable_and_reset()` function.

Essentially it makes it a little more convenient to manually configure FMC for purposes that are either not implemented by stm32-fmc or where the FMC peripheral is used for other things like reading an ADC by exposing the `enable()` function.