### PR TITLE
time: fix MockDriver::now()

### DIFF
--- a/embassy-time/src/driver_mock.rs
+++ b/embassy-time/src/driver_mock.rs
@@ -51,7 +51,7 @@ impl MockDriver {
 
 impl Driver for MockDriver {
     fn now(&self) -> u64 {
-        critical_section::with(|cs| self.now.borrow(cs).get().as_micros() as u64)
+        critical_section::with(|cs| self.now.borrow(cs).get().as_ticks() as u64)
     }
 
     unsafe fn allocate_alarm(&self) -> Option<AlarmHandle> {


### PR DESCRIPTION
When I implemented this I used the std driver as a reference, but now I realize that the implementation of `now()`should use `as_ticks()` instead of `as_micros()`. 