### PR TITLE
Reinstate rcc::Config adc_clock_source field

### DIFF
--- a/embassy-stm32/Cargo.toml
+++ b/embassy-stm32/Cargo.toml
@@ -58,7 +58,7 @@ rand_core = "0.6.3"
 sdio-host = "0.5.0"
 embedded-sdmmc = { git = "https://github.com/embassy-rs/embedded-sdmmc-rs", rev = "a4f293d3a6f72158385f79c98634cb8a14d0d2fc", optional = true }
 critical-section = "1.1"
-stm32-metapac = { git = "https://github.com/embassy-rs/stm32-data-generated", tag = "stm32-data-bcc9b6bf9fa195e91625849efc4ba473d9ace4e9" }
+stm32-metapac = { git = "https://github.com/embassy-rs/stm32-data-generated", tag = "stm32-data-73b8c37ae74fc28b247188c989fd99400611bd6b" }
 vcell = "0.1.3"
 bxcan = "0.7.0"
 nb = "1.0.0"
@@ -76,7 +76,7 @@ critical-section = { version = "1.1", features = ["std"] }
 [build-dependencies]
 proc-macro2 = "1.0.36"
 quote = "1.0.15"
-stm32-metapac = { git = "https://github.com/embassy-rs/stm32-data-generated", tag = "stm32-data-bcc9b6bf9fa195e91625849efc4ba473d9ace4e9", default-features = false, features = ["metadata"]}
+stm32-metapac = { git = "https://github.com/embassy-rs/stm32-data-generated", tag = "stm32-data-73b8c37ae74fc28b247188c989fd99400611bd6b", default-features = false, features = ["metadata"]}
 
 
 [features]

--- a/embassy-stm32/src/rcc/l4l5.rs
+++ b/embassy-stm32/src/rcc/l4l5.rs
@@ -148,6 +148,7 @@ pub const WPAN_DEFAULT: Config = Config {
     shared_ahb_pre: AHBPrescaler::DIV1,
     apb1_pre: APBPrescaler::DIV1,
     apb2_pre: APBPrescaler::DIV1,
+    adc_clock_source: AdcClockSource::SYS,
 };
 
 pub(crate) unsafe fn init(config: Config) {

--- a/embassy-stm32/src/rcc/l4l5.rs
+++ b/embassy-stm32/src/rcc/l4l5.rs
@@ -113,7 +113,7 @@ impl Default for Config {
             #[cfg(any(stm32l4, stm32l5, stm32wb))]
             clk48_src: Clk48Src::HSI48,
             ls: Default::default(),
-            adc_clock_source: AdcClockSource::HSI,
+            adc_clock_source: AdcClockSource::SYS,
         }
     }
 }
@@ -347,6 +347,9 @@ pub(crate) unsafe fn init(config: Config) {
     });
     while RCC.cfgr().read().sws() != config.mux {}
 
+    #[cfg(stm32l5)]
+    RCC.ccipr1().modify(|w| w.set_adcsel(config.adc_clock_source));
+    #[cfg(not(stm32l5))]
     RCC.ccipr().modify(|w| w.set_adcsel(config.adc_clock_source));
 
     #[cfg(any(stm32wl, stm32wb))]


### PR DESCRIPTION
The rcc::Config adc_clock_source was removed from the STM32WL when the rcc/wl.rs was consolidated into rcc/l4l5.rs. This field was omitted from the rcc::Config on the other family members covered in rcc/l4l5.rs. This brings the field and supporting enums back into rcc::Config.
Changes per discussion with dirbiao in matrix channel.