### PR TITLE
Ensure TcpIo not blocking when reading into empty slice

### DIFF
--- a/embassy-net/CHANGELOG.md
+++ b/embassy-net/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+- Avoid never resolving `TcpIo::read` when the output buffer is empty.
+
 ## 0.2.1 - 2023-10-31
 
 - Re-add impl_trait_projections


### PR DESCRIPTION
`embedded_io_async::Read` should return immediately if its output buffer can't hold any data. The easiest way to ensure that is to handle the case at `TcpIo`'s level, changing its semantics a bit, but probably for the better.