### PR TITLE
check PLL settings before set VOS

### DIFF
--- a/embassy-stm32/src/rcc/f4f7.rs
+++ b/embassy-stm32/src/rcc/f4f7.rs
@@ -1,8 +1,9 @@
+use crate::pac::pwr::vals::Vos;
 pub use crate::pac::rcc::vals::{
     Hpre as AHBPrescaler, Pllm as PllPreDiv, Plln as PllMul, Pllp, Pllq, Pllr, Pllsrc as PllSource,
     Ppre as APBPrescaler, Sw as Sysclk,
 };
-use crate::pac::{FLASH, RCC};
+use crate::pac::{FLASH, PWR, RCC};
 use crate::rcc::{set_freqs, Clocks};
 use crate::time::Hertz;
 
@@ -100,25 +101,22 @@ impl Default for Config {
 }
 
 pub(crate) unsafe fn init(config: Config) {
+    // set VOS to SCALE1, if use PLL
+    // TODO: check real clock speed before set VOS
+    if config.pll.is_some() {
+        PWR.cr1().modify(|w| w.set_vos(Vos::SCALE1));
+    }
+
     // always enable overdrive for now. Make it configurable in the future.
     #[cfg(not(any(
         stm32f401, stm32f410, stm32f411, stm32f412, stm32f413, stm32f423, stm32f405, stm32f407, stm32f415, stm32f417
     )))]
     {
-        use crate::pac::PWR;
         PWR.cr1().modify(|w| w.set_oden(true));
         while !PWR.csr1().read().odrdy() {}
 
         PWR.cr1().modify(|w| w.set_odswen(true));
         while !PWR.csr1().read().odswrdy() {}
-    }
-
-    #[cfg(any(stm32f401, stm32f410, stm32f411, stm32f412, stm32f413, stm32f423))]
-    {
-        use crate::pac::pwr::vals::Vos;
-        use crate::pac::PWR;
-
-        PWR.cr1().modify(|w| w.set_vos(Vos::SCALE1));
     }
 
     // Configure HSI


### PR DESCRIPTION
this is a tiny fix after commit [stm32/rcc: set highest VOS on some F4s with no overdrive.](https://github.com/embassy-rs/embassy/commit/b8679c0cc85e5eb65bd996ee18deac4a952b1b10)

VOS can be set when use PLL (depending on target speed) on any chips, not only the chips without over-drive. 