### PR TITLE
Fix for embassy net dns entries not being extensible

### DIFF
--- a/embassy-net/CHANGELOG.md
+++ b/embassy-net/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## Unreleased
 
 - Avoid never resolving `TcpIo::read` when the output buffer is empty.
+- Update to `smoltcp` git.
+- Forward constants from `smoltcp` in DNS query results so changing DNS result size in `smoltcp` properly propagates.
 
 ## 0.2.1 - 2023-10-31
 

--- a/embassy-net/Cargo.toml
+++ b/embassy-net/Cargo.toml
@@ -25,7 +25,7 @@ features = ["nightly", "defmt", "tcp", "udp", "dns", "dhcpv4", "proto-ipv6", "me
 default = []
 std = []
 
-defmt = ["dep:defmt", "smoltcp/defmt", "embassy-net-driver/defmt"]
+defmt = ["dep:defmt", "smoltcp/defmt", "embassy-net-driver/defmt", "heapless/defmt-03"]
 
 nightly = ["dep:embedded-io-async", "dep:embedded-nal-async"]
 
@@ -46,7 +46,7 @@ igmp = ["smoltcp/proto-igmp"]
 defmt = { version = "0.3", optional = true }
 log = { version = "0.4.14", optional = true }
 
-smoltcp = { git = "https://github.com/smoltcp-rs/smoltcp", rev = "9b791ae3057e10f7afcb70c67deb5daf714293a9", default-features = false, features = [
+smoltcp = { git = "https://github.com/smoltcp-rs/smoltcp.git", rev = "b57e2f9e70e82a13f31d5ea17e55232c11cc2b2d", default-features = false, features = [
   "socket",
   "async",
 ] }

--- a/embassy-net/src/dns.rs
+++ b/embassy-net/src/dns.rs
@@ -63,7 +63,11 @@ where
     }
 
     /// Make a query for a given name and return the corresponding IP addresses.
-    pub async fn query(&self, name: &str, qtype: DnsQueryType) -> Result<Vec<IpAddress, 1>, Error> {
+    pub async fn query(
+        &self,
+        name: &str,
+        qtype: DnsQueryType,
+    ) -> Result<Vec<IpAddress, { smoltcp::config::DNS_MAX_RESULT_COUNT }>, Error> {
         self.stack.dns_query(name, qtype).await
     }
 }

--- a/embassy-net/src/lib.rs
+++ b/embassy-net/src/lib.rs
@@ -494,7 +494,11 @@ impl<D: Driver> Stack<D> {
 
     /// Make a query for a given name and return the corresponding IP addresses.
     #[cfg(feature = "dns")]
-    pub async fn dns_query(&self, name: &str, qtype: dns::DnsQueryType) -> Result<Vec<IpAddress, 1>, dns::Error> {
+    pub async fn dns_query(
+        &self,
+        name: &str,
+        qtype: dns::DnsQueryType,
+    ) -> Result<Vec<IpAddress, { smoltcp::config::DNS_MAX_RESULT_COUNT }>, dns::Error> {
         // For A and AAAA queries we try detect whether `name` is just an IP address
         match qtype {
             #[cfg(feature = "proto-ipv4")]


### PR DESCRIPTION
Not sure if this is a good fix perse, but it allows for extending DNS setting in `smoltcp` up to 8 entries. 
If this is not done these interfaces are hard linked to whatever the return of `smoltcp` is.

Other ways to achieve this is welcome. :)