### PR TITLE
stm32/gpdma: fix drop() to use documented method for aborting transfer

### DIFF
--- a/embassy-stm32/src/dma/gpdma.rs
+++ b/embassy-stm32/src/dma/gpdma.rs
@@ -299,19 +299,15 @@ impl<'a, C: Channel> Transfer<'a, C> {
 
     pub fn request_stop(&mut self) {
         let ch = self.channel.regs().ch(self.channel.num());
-
-        // Disable the channel. Keep the IEs enabled so the irqs still fire.
-        ch.cr().write(|w| {
-            w.set_tcie(true);
-            w.set_useie(true);
-            w.set_dteie(true);
-            w.set_suspie(true);
+        ch.cr().modify(|w| {
+            w.set_susp(true);
         })
     }
 
     pub fn is_running(&mut self) -> bool {
         let ch = self.channel.regs().ch(self.channel.num());
-        !ch.sr().read().tcf()
+        let sr = ch.sr().read();
+        !sr.tcf() && !sr.suspf()
     }
 
     /// Gets the total remaining transfers for the channel


### PR DESCRIPTION
See e.g. STM32H503 RM section 15.4.4.

1. Write 1 into GPDMA_CxCR.SUSP
2. Poll GPDMA_CxSR.SUSPF until it is 1
3. Write 1 into GPDMA_CxCR.RESET

This fixes #2171 for me - instead of hanging forever, my UART read fails with a framing error (as it should!)

This *should* be the correct behaviour in any instance where a GPDMA transfer needs to be aborted.

## Why it was broken

Old behaviour step by step:

1. Reset all bits on CxCR except relevant interrupt enables.

This has the effect of writing 0 to EN, RESET and SUSP. Writing 0 to EN and RESET has no effect, per RM. Writing 0 to SUSP resumes the channel if it was already suspended (irrelevant in this case).

2. Poll TCF, waiting for it to be set

This is fine if one expects the transfer to proceed, but that may not be the case, and if Transfer is being dropped, the application will never see the data anyway.

In my case - #2171 - the transfer is being dropped due to an error in the source peripheral, so I would never expect TCF to be set! Hence, the hang on this tight polling loop.