### PR TITLE
cyw43: Add Control method to add multicast HW address

### DIFF
--- a/cyw43/src/lib.rs
+++ b/cyw43/src/lib.rs
@@ -27,7 +27,7 @@ use ioctl::IoctlState;
 
 use crate::bus::Bus;
 pub use crate::bus::SpiBusCyw43;
-pub use crate::control::{Control, Error as ControlError, Scanner};
+pub use crate::control::{AddMulticastAddressError, Control, Error as ControlError, Scanner};
 pub use crate::runner::Runner;
 pub use crate::structs::BssInfo;
 


### PR DESCRIPTION
Notably, a method to remove addresses is missing. I can add this if wanted but I ran out of time for now.

In reference to #2176.