### PR TITLE
Refactor bxcan split.

### DIFF
--- a/embassy-stm32/src/can/bxcan.rs
+++ b/embassy-stm32/src/can/bxcan.rs
@@ -1,4 +1,3 @@
-use core::cell::{RefCell, RefMut};
 use core::future::poll_fn;
 use core::marker::PhantomData;
 use core::ops::{Deref, DerefMut};
@@ -84,7 +83,7 @@ impl<T: Instance> interrupt::typelevel::Handler<T::SCEInterrupt> for SceInterrup
 }
 
 pub struct Can<'d, T: Instance> {
-    pub can: RefCell<bxcan::Can<BxcanInstance<'d, T>>>,
+    pub can: bxcan::Can<BxcanInstance<'d, T>>,
 }
 
 #[derive(Debug)]
@@ -175,14 +174,12 @@ impl<'d, T: Instance> Can<'d, T> {
         tx.set_as_af(tx.af_num(), AFType::OutputPushPull);
 
         let can = bxcan::Can::builder(BxcanInstance(peri)).leave_disabled();
-        let can_ref_cell = RefCell::new(can);
-        Self { can: can_ref_cell }
+        Self { can }
     }
 
     pub fn set_bitrate(&mut self, bitrate: u32) {
         let bit_timing = Self::calc_bxcan_timings(T::frequency(), bitrate).unwrap();
         self.can
-            .borrow_mut()
             .modify_config()
             .set_bit_timing(bit_timing)
             .leave_disabled();
@@ -193,55 +190,56 @@ impl<'d, T: Instance> Can<'d, T> {
     /// This will wait for 11 consecutive recessive bits (bus idle state).
     /// Contrary to enable method from bxcan library, this will not freeze the executor while waiting.
     pub async fn enable(&mut self) {
-        while self.borrow_mut().enable_non_blocking().is_err() {
+        while self.enable_non_blocking().is_err() {
             // SCE interrupt is only generated for entering sleep mode, but not leaving.
             // Yield to allow other tasks to execute while can bus is initializing.
             embassy_futures::yield_now().await;
         }
     }
 
+
     /// Queues the message to be sent but exerts backpressure
     pub async fn write(&mut self, frame: &Frame) -> bxcan::TransmitStatus {
-        CanTx { can: &self.can }.write(frame).await
+        self.split().0.write(frame).await
     }
 
     /// Attempts to transmit a frame without blocking.
     ///
     /// Returns [Err(TryWriteError::Full)] if all transmit mailboxes are full.
     pub fn try_write(&mut self, frame: &Frame) -> Result<bxcan::TransmitStatus, TryWriteError> {
-        CanTx { can: &self.can }.try_write(frame)
+        self.split().0.try_write(frame)
     }
 
     /// Waits for a specific transmit mailbox to become empty
     pub async fn flush(&self, mb: bxcan::Mailbox) {
-        CanTx { can: &self.can }.flush(mb).await
+        CanTx::<T>::_flush(mb).await
     }
 
     /// Waits until any of the transmit mailboxes become empty
     pub async fn flush_any(&self) {
-        CanTx { can: &self.can }.flush_any().await
+        CanTx::<T>::_flush_any().await
     }
 
     /// Waits until all of the transmit mailboxes become empty
     pub async fn flush_all(&self) {
-        CanTx { can: &self.can }.flush_all().await
+        CanTx::<T>::_flush_all().await
     }
 
     /// Returns a tuple of the time the message was received and the message frame
     pub async fn read(&mut self) -> Result<Envelope, BusError> {
-        CanRx { can: &self.can }.read().await
+        self.split().1.read().await
     }
 
     /// Attempts to read a can frame without blocking.
     ///
     /// Returns [Err(TryReadError::Empty)] if there are no frames in the rx queue.
     pub fn try_read(&mut self) -> Result<Envelope, TryReadError> {
-        CanRx { can: &self.can }.try_read()
+        self.split().1.try_read()
     }
 
     /// Waits while receive queue is empty.
     pub async fn wait_not_empty(&mut self) {
-        CanRx { can: &self.can }.wait_not_empty().await
+        self.split().1.wait_not_empty().await
     }
 
     unsafe fn receive_fifo(fifo: RxFifo) {
@@ -385,24 +383,25 @@ impl<'d, T: Instance> Can<'d, T> {
         Some((sjw - 1) << 24 | (bs1 as u32 - 1) << 16 | (bs2 as u32 - 1) << 20 | (prescaler - 1))
     }
 
-    pub fn split<'c>(&'c self) -> (CanTx<'c, 'd, T>, CanRx<'c, 'd, T>) {
-        (CanTx { can: &self.can }, CanRx { can: &self.can })
+    pub fn split<'c>(&'c mut self) -> (CanTx<'c, 'd, T>, CanRx<'c, 'd, T>) {
+        let (tx, rx0, rx1) = self.can.split_by_ref();
+        (CanTx { tx }, CanRx { rx0, rx1 })
     }
 
-    pub fn as_mut(&self) -> RefMut<'_, bxcan::Can<BxcanInstance<'d, T>>> {
-        self.can.borrow_mut()
+    pub fn as_mut(&mut self) -> &mut bxcan::Can<BxcanInstance<'d, T>> {
+        &mut self.can
     }
 }
 
 pub struct CanTx<'c, 'd, T: Instance> {
-    can: &'c RefCell<bxcan::Can<BxcanInstance<'d, T>>>,
+    tx: &'c mut bxcan::Tx<BxcanInstance<'d, T>>,
 }
 
 impl<'c, 'd, T: Instance> CanTx<'c, 'd, T> {
     pub async fn write(&mut self, frame: &Frame) -> bxcan::TransmitStatus {
         poll_fn(|cx| {
             T::state().tx_waker.register(cx.waker());
-            if let Ok(status) = self.can.borrow_mut().transmit(frame) {
+            if let Ok(status) = self.tx.transmit(frame) {
                 return Poll::Ready(status);
             }
 
@@ -415,11 +414,10 @@ impl<'c, 'd, T: Instance> CanTx<'c, 'd, T> {
     ///
     /// Returns [Err(TryWriteError::Full)] if all transmit mailboxes are full.
     pub fn try_write(&mut self, frame: &Frame) -> Result<bxcan::TransmitStatus, TryWriteError> {
-        self.can.borrow_mut().transmit(frame).map_err(|_| TryWriteError::Full)
+        self.tx.transmit(frame).map_err(|_| TryWriteError::Full)
     }
 
-    /// Waits for a specific transmit mailbox to become empty
-    pub async fn flush(&self, mb: bxcan::Mailbox) {
+    pub async fn _flush(mb: bxcan::Mailbox) {
         poll_fn(|cx| {
             T::state().tx_waker.register(cx.waker());
             if T::regs().tsr().read().tme(mb.index()) {
@@ -431,8 +429,13 @@ impl<'c, 'd, T: Instance> CanTx<'c, 'd, T> {
         .await;
     }
 
+    /// Waits for a specific transmit mailbox to become empty
+    pub async fn flush(&self, mb: bxcan::Mailbox) {
+        Self::_flush(mb).await
+    }
+
     /// Waits until any of the transmit mailboxes become empty
-    pub async fn flush_any(&self) {
+    pub async fn _flush_any() {
         poll_fn(|cx| {
             T::state().tx_waker.register(cx.waker());
 
@@ -449,8 +452,13 @@ impl<'c, 'd, T: Instance> CanTx<'c, 'd, T> {
         .await;
     }
 
+    /// Waits until any of the transmit mailboxes become empty
+    pub async fn flush_any(&self) {
+        Self::_flush_any().await
+    }
+
     /// Waits until all of the transmit mailboxes become empty
-    pub async fn flush_all(&self) {
+    pub async fn _flush_all() {
         poll_fn(|cx| {
             T::state().tx_waker.register(cx.waker());
 
@@ -466,11 +474,19 @@ impl<'c, 'd, T: Instance> CanTx<'c, 'd, T> {
         })
         .await;
     }
+
+
+
+    /// Waits until all of the transmit mailboxes become empty
+    pub async fn flush_all(&self) {
+        Self::_flush_all().await
+    }
 }
 
 #[allow(dead_code)]
 pub struct CanRx<'c, 'd, T: Instance> {
-    can: &'c RefCell<bxcan::Can<BxcanInstance<'d, T>>>,
+    rx0: &'c mut bxcan::Rx0<BxcanInstance<'d, T>>,
+    rx1: &'c mut bxcan::Rx1<BxcanInstance<'d, T>>,
 }
 
 impl<'c, 'd, T: Instance> CanRx<'c, 'd, T> {
@@ -538,7 +554,7 @@ impl<'d, T: Instance> Drop for Can<'d, T> {
 }
 
 impl<'d, T: Instance> Deref for Can<'d, T> {
-    type Target = RefCell<bxcan::Can<BxcanInstance<'d, T>>>;
+    type Target = bxcan::Can<BxcanInstance<'d, T>>;
 
     fn deref(&self) -> &Self::Target {
         &self.can


### PR DESCRIPTION
In this PR I have changed the way splitting the can bus works. This because I encountered a problem with the fact that the old implementation would result in `Mutex<_, CanTx<_>>` not being `Sync`. This is because:
- `Mutex<_, _>` is `Sync` when its content is `Send` (https://docs.rs/embassy-sync/latest/embassy_sync/mutex/struct.Mutex.html#impl-Sync-for-Mutex%3CM,+T%3E)
- `RefCell<_>` is `Send` but not `Sync` (https://doc.rust-lang.org/std/cell/struct.RefCell.html#impl-Send-for-RefCell%3CT%3E)
- A reference is `Send` when the value it points to is `Sync` (https://doc.rust-lang.org/nomicon/send-and-sync.html)

This means that putting a `CanTx` in a `Mutex` will result in the mutex being not `Sync`, which means that it is impossible to have multiple tasks share the mutex and concurrently access the can bus for Tx operations, which I need.

I have changed the `split(&self)` to `split(&mut self)`, which allows using the `bxcan` `split_by_ref(&mut)` function. This eliminates the need for the `RefCell` as the actual `bxcan` types are split. Once both `CanTx` and `CanRx` are dropped, `Can` becomes available again.

With this change is it no longer possible to share both a `Can` and a `CanTx`/`CanRx`/, nor is it possible to have multiple splits. I would argue that this is desirable:
- As the `CanTx` uses a `RefCell`, it will panic whenever there are concurrent accesses. This means that although the compiler allows multiple splits, the runtime does not and this limitation is also hidden. It is up to the application to guarantee that no concurrent accesses occur. I would argue that it is better to then use either a mutex of a cell to share a single `CanTx` as this makes the limitation clear to the user/application.
- In case of having both a `Can` and a `CanTx`/`CanRx`, I would argue that again this is not desirable as the limitations imposed by the `RefCell` still apply. A concurrent access to both the `Can` and the `CanTx` will result in a panic.

As the `flush_` functions are `&self`, they can no longer use the split as it is now `&mut self`. I have opted to use private static `_flush_` functions that thus can be used in a `&self` context.

I have tested this change and did not encounter problems.