### PR TITLE
stm32h7 ADC: Fix stalled clock in default h7 config

### DIFF
--- a/embassy-stm32/src/rcc/h.rs
+++ b/embassy-stm32/src/rcc/h.rs
@@ -170,9 +170,9 @@ impl Default for Config {
             per_clock_source: PerClockSource::HSI,
 
             #[cfg(stm32h5)]
-            adc_clock_source: AdcClockSource::from_bits(0), // HCLK on H5
+            adc_clock_source: AdcClockSource::HCLK1,
             #[cfg(stm32h7)]
-            adc_clock_source: AdcClockSource::from_bits(2), // PCLK on H7
+            adc_clock_source: AdcClockSource::PER,
 
             timer_prescaler: TimerPrescaler::DefaultX2,
             voltage_scale: VoltageScale::Scale0,

--- a/embassy-stm32/src/rcc/h.rs
+++ b/embassy-stm32/src/rcc/h.rs
@@ -168,7 +168,12 @@ impl Default for Config {
             apb4_pre: APBPrescaler::DIV1,
 
             per_clock_source: PerClockSource::HSI,
-            adc_clock_source: AdcClockSource::from_bits(0), // PLL2_P on H7, HCLK on H5
+
+            #[cfg(stm32h5)]
+            adc_clock_source: AdcClockSource::from_bits(0), // HCLK on H5
+            #[cfg(stm32h7)]
+            adc_clock_source: AdcClockSource::from_bits(2), // PCLK on H7
+
             timer_prescaler: TimerPrescaler::DefaultX2,
             voltage_scale: VoltageScale::Scale0,
             ls: Default::default(),


### PR DESCRIPTION
Naive fix to clock source of ADC on STM32H7 (issue #2167)

In a nutshell, the default configuration for the v4 ADC selects clock source `ADCSEL[1:0]=0`. For the H5, that might be fine, but for the H7, that selects `PLL2_P` which is not configured. Using `ADCSEL[1:0]=2` selects the peripheral clock, which happens to be acceptable.

I hope to get advice on rust side of how to do this better.
- I just hard coded the value `2`. Note, the original hard coded `0` so I don't feel that bad.
- The mechanism to vary H7 from H5 (conditional compilation) is probably not done the way it should be
- I'm not sure the H7 and H5 are the only micros that use the v4 ADC.  If not, I've certainly done this wrong and should use something like `#[cfg(!stm32h7)]` if there is such a syntax
- I don't even know if ADCSEL[1:0]=0 works for the H5... it might need a similar fix.

I have tested on the H7, but I don't have an H5 yet so that part is untested. I can pick up an H5 before this is all over