### PR TITLE
populate `medium` in DriverAdapter struct in IGMP code

### DIFF
--- a/ci.sh
+++ b/ci.sh
@@ -38,6 +38,7 @@ cargo batch  \
     --- build --release --manifest-path embassy-sync/Cargo.toml --target thumbv6m-none-eabi --features nightly,defmt \
     --- build --release --manifest-path embassy-time/Cargo.toml --target thumbv6m-none-eabi --features nightly,defmt,defmt-timestamp-uptime,tick-hz-32_768,generic-queue-8 \
     --- build --release --manifest-path embassy-net/Cargo.toml --target thumbv7em-none-eabi --features defmt,tcp,udp,dns,proto-ipv4,medium-ethernet \
+    --- build --release --manifest-path embassy-net/Cargo.toml --target thumbv7em-none-eabi --features defmt,tcp,udp,dns,proto-ipv4,igmp,medium-ethernet \
     --- build --release --manifest-path embassy-net/Cargo.toml --target thumbv7em-none-eabi --features defmt,tcp,udp,dns,dhcpv4,medium-ethernet \
     --- build --release --manifest-path embassy-net/Cargo.toml --target thumbv7em-none-eabi --features defmt,tcp,udp,dns,dhcpv4,medium-ethernet,nightly,dhcpv4-hostname \
     --- build --release --manifest-path embassy-net/Cargo.toml --target thumbv7em-none-eabi --features defmt,tcp,udp,dns,proto-ipv6,medium-ethernet \

--- a/embassy-net/src/lib.rs
+++ b/embassy-net/src/lib.rs
@@ -616,9 +616,11 @@ impl<D: Driver> Stack<D> {
         let addr = addr.into();
 
         self.with_mut(|s, i| {
+            let (_hardware_addr, medium) = to_smoltcp_hardware_address(i.device.hardware_address());
             let mut smoldev = DriverAdapter {
                 cx: Some(cx),
                 inner: &mut i.device,
+                medium,
             };
 
             match s
@@ -653,9 +655,11 @@ impl<D: Driver> Stack<D> {
         let addr = addr.into();
 
         self.with_mut(|s, i| {
+            let (_hardware_addr, medium) = to_smoltcp_hardware_address(i.device.hardware_address());
             let mut smoldev = DriverAdapter {
                 cx: Some(cx),
                 inner: &mut i.device,
+                medium,
             };
 
             match s


### PR DESCRIPTION
I think the code hidden behind the `igmp` feature got left behind in #2076 where `medium` was added to `DriverAdapter`.

This PR fixes errors like:
```
error[E0063]: missing field `medium` in initializer of `DriverAdapter<'_, '_, _>`
   --> src/lib.rs:619:31
    |
619 |             let mut smoldev = DriverAdapter {
    |                               ^^^^^^^^^^^^^ missing `medium`

error[E0063]: missing field `medium` in initializer of `DriverAdapter<'_, '_, _>`
   --> src/lib.rs:656:31
    |
656 |             let mut smoldev = DriverAdapter {
    |                               ^^^^^^^^^^^^^ missing `medium`

For more information about this error, try `rustc --explain E0063`.
error: could not compile `embassy-net` (lib) due to 2 previous errors
```