### PR TITLE
ci: cache lockfiles

### DIFF
--- a/.github/ci/build-stable.sh
+++ b/.github/ci/build-stable.sh
@@ -12,9 +12,19 @@ export CARGO_TARGET_DIR=/ci/cache/target
 # used when pointing stm32-metapac to a CI-built one.
 export CARGO_NET_GIT_FETCH_WITH_CLI=true
 
+# Restore lockfiles
+if [ -f /ci/cache/lockfiles.tar ]; then
+    echo Restoring lockfiles...
+    tar xf /ci/cache/lockfiles.tar
+fi
+
 hashtime restore /ci/cache/filetime.json || true
 hashtime save /ci/cache/filetime.json
 
 sed -i 's/channel.*/channel = "stable"/g' rust-toolchain.toml
 
 ./ci_stable.sh
+
+# Save lockfiles
+echo Saving lockfiles...
+find . -type f -name Cargo.lock -exec tar -cf /ci/cache/lockfiles.tar '{}' \+

--- a/.github/ci/build.sh
+++ b/.github/ci/build.sh
@@ -18,7 +18,17 @@ fi
 # used when pointing stm32-metapac to a CI-built one.
 export CARGO_NET_GIT_FETCH_WITH_CLI=true
 
+# Restore lockfiles
+if [ -f /ci/cache/lockfiles.tar ]; then
+    echo Restoring lockfiles...
+    tar xf /ci/cache/lockfiles.tar
+fi
+
 hashtime restore /ci/cache/filetime.json || true
 hashtime save /ci/cache/filetime.json
 
 ./ci.sh
+
+# Save lockfiles
+echo Saving lockfiles...
+find . -type f -name Cargo.lock -exec tar -cf /ci/cache/lockfiles.tar '{}' \+


### PR DESCRIPTION
- Removes the slow "updating crates.io index, updating git" at start of the job.
- Avoids CI being randomly slower if a widely-used dep (like serde) gets bumped causing rebuilding everything.
