### PR TITLE
introduce `OptionalPeripherals`

### DIFF
--- a/embassy-hal-internal/src/macros.rs
+++ b/embassy-hal-internal/src/macros.rs
@@ -46,6 +46,16 @@ macro_rules! peripherals_struct {
             )*
         }
 
+        /// Struct containing all the peripheral singletons wrapped in `Option`.
+        #[allow(non_snake_case)]
+        pub struct OptionalPeripherals {
+            $(
+                #[doc = concat!(stringify!($name), " peripheral")]
+                $(#[$cfg])?
+                pub $name: Option<peripherals::$name>,
+            )*
+        }
+
         impl Peripherals {
             ///Returns all the peripherals *once*
             #[inline]
@@ -82,6 +92,19 @@ macro_rules! peripherals_struct {
                     $(
                         $(#[$cfg])?
                         $name: peripherals::$name::steal(),
+                    )*
+                }
+            }
+        }
+
+        impl OptionalPeripherals {
+            /// Create an `OptionalPeripherals`, consuming a `Peripherals`
+            #[inline]
+            pub fn from(p: Peripherals) -> Self {
+                Self {
+                    $(
+                        $(#[$cfg])?
+                        $name: Some(p.$name),
                     )*
                 }
             }

--- a/embassy-nrf/src/lib.rs
+++ b/embassy-nrf/src/lib.rs
@@ -172,7 +172,7 @@ macro_rules! bind_interrupts {
 pub use chip::pac;
 #[cfg(not(feature = "unstable-pac"))]
 pub(crate) use chip::pac;
-pub use chip::{peripherals, Peripherals, EASY_DMA_SIZE};
+pub use chip::{peripherals, OptionalPeripherals, Peripherals, EASY_DMA_SIZE};
 pub use embassy_hal_internal::{into_ref, Peripheral, PeripheralRef};
 
 pub use crate::chip::interrupt;

--- a/embassy-stm32/src/lib.rs
+++ b/embassy-stm32/src/lib.rs
@@ -153,7 +153,7 @@ macro_rules! bind_interrupts {
 }
 
 // Reexports
-pub use _generated::{peripherals, Peripherals};
+pub use _generated::{peripherals, OptionalPeripherals, Peripherals};
 pub use embassy_hal_internal::{into_ref, Peripheral, PeripheralRef};
 #[cfg(feature = "unstable-pac")]
 pub use stm32_metapac as pac;


### PR DESCRIPTION
I needed a way to spread peripheral initialization over multiple `init()` functions.
Passing `&mut Peripherals` around won't work as it's field cannot be moved out.
But `steal()`ing `Peripherals` in multiple places doesn't seem right.

So this PR augments `peripherals_struct!()` to also create a `struct OptionalPeripherals {}` that contains all fields of `Peripherals`, but wrapped in `Option`.

This is quite wasteful (1b per Peripheral, e.g., ~119b on nrf52840). I hope that this will be on stack only, or *edit* we'll optimize this into some kind of bit-field but with a similar interface, or even just compile it out.

*edit* ~~this only exposes `OptionalPeripherals` for nrf52840 now. If I get positive feedback on the idea, I'll add re-exporting for the other crates. Marking as draft for now.~~ now supports nrf, stm32 and rp. We have a similar PR to esp-rs.