### PR TITLE
stm32 i2c: allow EHA traits without time feature

### DIFF
--- a/embassy-stm32/src/i2c/v2.rs
+++ b/embassy-stm32/src/i2c/v2.rs
@@ -1187,7 +1187,7 @@ mod eh1 {
     }
 }
 
-#[cfg(all(feature = "unstable-traits", feature = "nightly", feature = "time"))]
+#[cfg(all(feature = "unstable-traits", feature = "nightly"))]
 mod eha {
     use super::super::{RxDma, TxDma};
     use super::*;


### PR DESCRIPTION
`embedded-hal-async` works without needing `time`.