### PR TITLE
STM32: Add UID driver

### DIFF
--- a/embassy-stm32/src/lib.rs
+++ b/embassy-stm32/src/lib.rs
@@ -63,6 +63,8 @@ pub mod sai;
 pub mod sdmmc;
 #[cfg(spi)]
 pub mod spi;
+#[cfg(uid)]
+pub mod uid;
 #[cfg(usart)]
 pub mod usart;
 #[cfg(usb)]

--- a/embassy-stm32/src/uid.rs
+++ b/embassy-stm32/src/uid.rs
@@ -1,0 +1,29 @@
+/// Get this device's unique 96-bit ID.
+pub fn uid() -> &'static [u8; 12] {
+    unsafe { &*crate::pac::UID.uid(0).as_ptr().cast::<[u8; 12]>() }
+}
+
+/// Get this device's unique 96-bit ID, encoded into a string of 24 hexadecimal ASCII digits.
+pub fn uid_hex() -> &'static str {
+    unsafe { core::str::from_utf8_unchecked(uid_hex_bytes()) }
+}
+
+/// Get this device's unique 96-bit ID, encoded into 24 hexadecimal ASCII bytes.
+pub fn uid_hex_bytes() -> &'static [u8; 24] {
+    const HEX: &[u8; 16] = b"0123456789ABCDEF";
+    static mut UID_HEX: [u8; 24] = [0; 24];
+    static mut LOADED: bool = false;
+    critical_section::with(|_| unsafe {
+        if !LOADED {
+            let uid = uid();
+            for (idx, v) in uid.iter().enumerate() {
+                let lo = v & 0x0f;
+                let hi = (v & 0xf0) >> 4;
+                UID_HEX[idx * 2] = HEX[hi as usize];
+                UID_HEX[idx * 2 + 1] = HEX[lo as usize];
+            }
+            LOADED = true;
+        }
+    });
+    unsafe { &UID_HEX }
+}


### PR DESCRIPTION
Based on #1253 but updated to use the now-available UID peripheral from stm32-metapac.

I'm not 100% sure if it's nicer to return the `&'static` references or just return directly a `[u8; 12]` and `[u8; 24]`; we can avoid the critical section and all the unsafe code if we just return arrays, but it wastes a bit of stack. For the `&str`, I don't see any other way, and I guess a major use case will be passing this to the USB serial number, so perhaps it's worth keeping as-is.

I added the `LOADED` check to prevent needing a critical section and computation loop on every call of `uid_hex()`/`uid_hex_bytes()`, but probably the most common case is to only call it once, in which case the memory and load/store is wasted, so I could remove it.

Tested only on stm32g4 hardware.