### PR TITLE
minimum build code for new APPROTECT is chip type-specific

### DIFF
--- a/embassy-nrf/src/chips/nrf52805.rs
+++ b/embassy-nrf/src/chips/nrf52805.rs
@@ -7,6 +7,7 @@ pub const FORCE_COPY_BUFFER_SIZE: usize = 256;
 pub const FLASH_SIZE: usize = 192 * 1024;
 
 pub const RESET_PIN: u32 = 21;
+pub const APPROTECT_MIN_BUILD_CODE: u8 = b'B';
 
 embassy_hal_internal::peripherals! {
     // RTC

--- a/embassy-nrf/src/chips/nrf52810.rs
+++ b/embassy-nrf/src/chips/nrf52810.rs
@@ -7,6 +7,7 @@ pub const FORCE_COPY_BUFFER_SIZE: usize = 256;
 pub const FLASH_SIZE: usize = 192 * 1024;
 
 pub const RESET_PIN: u32 = 21;
+pub const APPROTECT_MIN_BUILD_CODE: u8 = b'E';
 
 embassy_hal_internal::peripherals! {
     // RTC

--- a/embassy-nrf/src/chips/nrf52811.rs
+++ b/embassy-nrf/src/chips/nrf52811.rs
@@ -7,6 +7,7 @@ pub const FORCE_COPY_BUFFER_SIZE: usize = 256;
 pub const FLASH_SIZE: usize = 192 * 1024;
 
 pub const RESET_PIN: u32 = 21;
+pub const APPROTECT_MIN_BUILD_CODE: u8 = b'B';
 
 embassy_hal_internal::peripherals! {
     // RTC

--- a/embassy-nrf/src/chips/nrf52820.rs
+++ b/embassy-nrf/src/chips/nrf52820.rs
@@ -7,6 +7,7 @@ pub const FORCE_COPY_BUFFER_SIZE: usize = 512;
 pub const FLASH_SIZE: usize = 256 * 1024;
 
 pub const RESET_PIN: u32 = 18;
+pub const APPROTECT_MIN_BUILD_CODE: u8 = b'D';
 
 embassy_hal_internal::peripherals! {
     // USB

--- a/embassy-nrf/src/chips/nrf52832.rs
+++ b/embassy-nrf/src/chips/nrf52832.rs
@@ -11,6 +11,7 @@ pub const FORCE_COPY_BUFFER_SIZE: usize = 255;
 pub const FLASH_SIZE: usize = 512 * 1024;
 
 pub const RESET_PIN: u32 = 21;
+pub const APPROTECT_MIN_BUILD_CODE: u8 = b'G';
 
 embassy_hal_internal::peripherals! {
     // RTC

--- a/embassy-nrf/src/chips/nrf52833.rs
+++ b/embassy-nrf/src/chips/nrf52833.rs
@@ -7,6 +7,7 @@ pub const FORCE_COPY_BUFFER_SIZE: usize = 512;
 pub const FLASH_SIZE: usize = 512 * 1024;
 
 pub const RESET_PIN: u32 = 18;
+pub const APPROTECT_MIN_BUILD_CODE: u8 = b'B';
 
 embassy_hal_internal::peripherals! {
     // USB

--- a/embassy-nrf/src/chips/nrf52840.rs
+++ b/embassy-nrf/src/chips/nrf52840.rs
@@ -7,6 +7,7 @@ pub const FORCE_COPY_BUFFER_SIZE: usize = 512;
 pub const FLASH_SIZE: usize = 1024 * 1024;
 
 pub const RESET_PIN: u32 = 18;
+pub const APPROTECT_MIN_BUILD_CODE: u8 = b'F';
 
 embassy_hal_internal::peripherals! {
     // USB

--- a/embassy-nrf/src/lib.rs
+++ b/embassy-nrf/src/lib.rs
@@ -349,10 +349,11 @@ pub fn init(config: config::Config) -> Peripherals {
                 // Get the letter for the build code (b'A' .. b'F')
                 let build_code = (variant >> 8) as u8;
 
-                if build_code >= b'F' {
-                    // Chips with build code F and higher (revision 3 and higher) have an
+                if build_code >= chip::APPROTECT_MIN_BUILD_CODE {
+                    // Chips with a certain chip type-specific build code or higher have an
                     // improved APPROTECT ("hardware and software controlled access port protection")
                     // which needs explicit action by the firmware to keep it unlocked
+                    // See https://devzone.nordicsemi.com/nordic/nordic-blog/b/blog/posts/working-with-the-nrf52-series-improved-approtect
 
                     // UICR.APPROTECT = SwDisabled
                     let res = uicr_write(consts::UICR_APPROTECT, consts::APPROTECT_DISABLED);


### PR DESCRIPTION
The APPROTECT stuff involving the Config debug field was not working correctly for chips other than nRF52840.  As noted in the page linked in the comment in lib.rs, different chip types have different minimum build codes when the APPROTECT improvements were made.  The old code used 'F' for everything, but that's valid only for 52840.