### PR TITLE
stm32/h7: fix h7 examples

### DIFF
--- a/examples/stm32h7/src/bin/eth.rs
+++ b/examples/stm32h7/src/bin/eth.rs
@@ -92,7 +92,7 @@ async fn main(spawner: Spawner) -> ! {
     let stack = &*make_static!(Stack::new(
         device,
         config,
-        make_static!(StackResources::<2>::new()),
+        make_static!(StackResources::<3>::new()),
         seed
     ));
 

--- a/examples/stm32h7/src/bin/eth.rs
+++ b/examples/stm32h7/src/bin/eth.rs
@@ -113,6 +113,7 @@ async fn main(spawner: Spawner) -> ! {
 
         socket.set_timeout(Some(embassy_time::Duration::from_secs(10)));
 
+        // You need to start a server on the host machine, for example: `nc -l 8000`
         let remote_endpoint = (Ipv4Address::new(10, 42, 0, 1), 8000);
         info!("connecting...");
         let r = socket.connect(remote_endpoint).await;

--- a/examples/stm32h7/src/bin/eth_client.rs
+++ b/examples/stm32h7/src/bin/eth_client.rs
@@ -93,7 +93,7 @@ async fn main(spawner: Spawner) -> ! {
     let stack = &*make_static!(Stack::new(
         device,
         config,
-        make_static!(StackResources::<2>::new()),
+        make_static!(StackResources::<3>::new()),
         seed
     ));
 

--- a/examples/stm32h7/src/bin/eth_client.rs
+++ b/examples/stm32h7/src/bin/eth_client.rs
@@ -109,6 +109,7 @@ async fn main(spawner: Spawner) -> ! {
     let client = TcpClient::new(&stack, &state);
 
     loop {
+        // You need to start a server on the host machine, for example: `nc -l 8000`
         let addr = SocketAddr::V4(SocketAddrV4::new(Ipv4Addr::new(10, 42, 0, 1), 8000));
 
         info!("connecting...");


### PR DESCRIPTION
This PR fixes the STM32H7 Ethernet examples.

The examples enable `dhcpv4` and `dns` features. Both use one socket, meaning that we need one extra socket for our firmware TCP socket.