### PR TITLE
Assert CR2.USV on stm32wb55, wb35 series chips

### DIFF
--- a/embassy-stm32/src/usb/usb.rs
+++ b/embassy-stm32/src/usb/usb.rs
@@ -263,7 +263,7 @@ impl<'d, T: Instance> Driver<'d, T> {
 
         let regs = T::regs();
 
-        #[cfg(stm32l5)]
+        #[cfg(any(stm32l5, stm32wb55, stm32wb35))]
         crate::pac::PWR.cr2().modify(|w| w.set_usv(true));
 
         #[cfg(pwr_h5)]


### PR DESCRIPTION
As discussed in matrix, value must be asserted for USB to function properly.

https://www.st.com/resource/en/reference_manual/rm0434-multiprotocol-wireless-32bit-mcu-armbased-cortexm4-with-fpu-bluetooth-lowenergy-and-802154-radio-solution-stmicroelectronics.pdf pg. 175 for reference