### PR TITLE
Add example for using CAN with STM32F103 (BluePill) with a real CAN

### DIFF
--- a/examples/stm32f1/src/bin/can.rs
+++ b/examples/stm32f1/src/bin/can.rs
@@ -7,7 +7,6 @@ use embassy_executor::Spawner;
 use embassy_stm32::can::bxcan::filter::Mask32;
 use embassy_stm32::can::bxcan::{Fifo, Frame, Id, StandardId};
 use embassy_stm32::can::{Can, Rx0InterruptHandler, Rx1InterruptHandler, SceInterruptHandler, TxInterruptHandler};
-
 use embassy_stm32::peripherals::CAN;
 use embassy_stm32::{bind_interrupts, Config};
 use {defmt_rtt as _, panic_probe as _};
@@ -54,7 +53,7 @@ async fn main(_spawner: Spawner) {
             Ok(env) => match env.frame.id() {
                 Id::Extended(id) => {
                     defmt::println!("Extended Frame id={:x}", id.as_raw());
-                 }
+                }
                 Id::Standard(id) => {
                     defmt::println!("Standard Frame id={:x}", id.as_raw());
                 }


### PR DESCRIPTION
Add example for using CAN with STM32F103 (BluePill) with a real CAN. None of the existing examples focus on using a real transceiver. Also none of them map to alternate pins so this is easy to miss. In addition F1 STM's have slightly different IRQ names.