### PR TITLE
Introduce reset_{at|after} functions for Ticker.

### DIFF
--- a/embassy-time/src/timer.rs
+++ b/embassy-time/src/timer.rs
@@ -184,6 +184,16 @@ impl Ticker {
         self.expires_at = Instant::now() + self.duration;
     }
 
+    /// Reset the ticker to fire for the next time on the deadline.
+    pub fn reset_at(&mut self, deadline: Instant) {
+        self.expires_at = deadline;
+    }
+
+    /// Resets the ticker, after the specified duration has passed.
+    pub fn reset_after(&mut self, after: Duration) {
+        self.expires_at = Instant::now() + after;
+    }
+
     /// Waits for the next tick.
     pub fn next(&mut self) -> impl Future<Output = ()> + '_ {
         poll_fn(|cx| {

--- a/embassy-time/src/timer.rs
+++ b/embassy-time/src/timer.rs
@@ -185,13 +185,15 @@ impl Ticker {
     }
 
     /// Reset the ticker to fire for the next time on the deadline.
+    /// If the deadline is in the past, the ticker will fire instantly.
     pub fn reset_at(&mut self, deadline: Instant) {
         self.expires_at = deadline;
     }
 
     /// Resets the ticker, after the specified duration has passed.
+    /// If the specified duration is zero, the next tick will be after the duration of the ticker.
     pub fn reset_after(&mut self, after: Duration) {
-        self.expires_at = Instant::now() + after;
+        self.expires_at = Instant::now() + after + self.duration;
     }
 
     /// Waits for the next tick.


### PR DESCRIPTION
These functions perform a similar job to reset, by reseting the timer either after a specified duration or at an instant.