### PR TITLE
STM32 QSPI: Fix flash selection.

### DIFF
--- a/embassy-stm32/src/qspi/mod.rs
+++ b/embassy-stm32/src/qspi/mod.rs
@@ -119,7 +119,7 @@ impl<'d, T: Instance, Dma> Qspi<'d, T, Dma> {
             Some(nss.map_into()),
             dma,
             config,
-            FlashSelection::Flash2,
+            FlashSelection::Flash1,
         )
     }
 


### PR DESCRIPTION
The `new_bk1` should probably use `Flash1` not `Flash2`.