### PR TITLE
Add a basic RP "read to break" function

### DIFF
--- a/embassy-rp/src/uart/mod.rs
+++ b/embassy-rp/src/uart/mod.rs
@@ -125,6 +125,7 @@ pub enum Error {
 pub enum ReadToBreakError {
     /// Read this many bytes, but never received a line break.
     MissingBreak(usize),
+    /// Other, standard issue with the serial request
     Other(Error),
 }
 
@@ -936,6 +937,9 @@ impl<'d, T: Instance> Uart<'d, T, Async> {
         self.rx.read(buffer).await
     }
 
+    /// Read until the buffer is full or a line break occurs.
+    ///
+    /// See [`UartRx::read_to_break()`] for more details
     pub async fn read_to_break<'a>(&mut self, buf: &'a mut [u8]) -> Result<usize, ReadToBreakError> {
         self.rx.read_to_break(buf).await
     }

--- a/embassy-rp/src/uart/mod.rs
+++ b/embassy-rp/src/uart/mod.rs
@@ -278,13 +278,16 @@ impl<'d, T: Instance, M: Mode> UartRx<'d, T, M> {
 
     /// Read from UART RX blocking execution until done.
     pub fn blocking_read(&mut self, mut buffer: &mut [u8]) -> Result<(), Error> {
-        while buffer.len() > 0 {
+        while !buffer.is_empty() {
             let received = self.drain_fifo(buffer).map_err(|(_i, e)| e)?;
             buffer = &mut buffer[received..];
         }
         Ok(())
     }
 
+    /// Returns Ok(len) if no errors occurred. Returns Err((len, err)) if an error was
+    /// encountered. in both cases, `len` is the number of *good* bytes copied into
+    /// `buffer`.
     fn drain_fifo(&mut self, buffer: &mut [u8]) -> Result<usize, (usize, Error)> {
         let r = T::regs();
         for (i, b) in buffer.iter_mut().enumerate() {


### PR DESCRIPTION
This adds a function called "read_to_break" that receives until one of the following happen:

1. We receive the whole buffer amount
2. We receive a line break interrupt

In the latter case, we figure out how many bytes we DID get, and then return that subslice. In the former case, we return the whole subslice.

All other errors are returned the same.

One note:

This is basically a big copy/paste of `read`. I should probably clean that up, I could do the DMA reg check in a function that basically does:

```rust
pub async fn read_to_break<'a>(&mut self, buf: &'a mut [u8]) -> Result<&'a mut [u8], Error> {
    match self.read(buf) {
        Ok(()) => Ok(buf),
        Err(Break) => {
            // get bytes received...
            Ok(&mut buf[..count])
        }
        Err(e) => Err(e)
    }
}
```

But then we'd have to unwrap `self.rx_dma` again, which is annoying. Open to thoughts.