### PR TITLE
track DMA circular mode in `Transfer` struct, when `poll`, just return `Ready` without checking `.is_running()`

### DIFF
--- a/embassy-stm32/src/dma/bdma.rs
+++ b/embassy-stm32/src/dma/bdma.rs
@@ -170,6 +170,7 @@ pub(crate) mod sealed {
 #[must_use = "futures do nothing unless you `.await` or poll them"]
 pub struct Transfer<'a, C: Channel> {
     channel: PeripheralRef<'a, C>,
+    circular: bool,
 }
 
 impl<'a, C: Channel> Transfer<'a, C> {
@@ -290,7 +291,10 @@ impl<'a, C: Channel> Transfer<'a, C> {
         #[cfg(bdma_v2)]
         critical_section::with(|_| channel.regs().cselr().modify(|w| w.set_cs(channel.num(), _request)));
 
-        let mut this = Self { channel };
+        let mut this = Self {
+            channel,
+            circular: options.circular,
+        };
         this.clear_irqs();
         STATE.complete_count[this.channel.index()].store(0, Ordering::Release);
 
@@ -387,7 +391,7 @@ impl<'a, C: Channel> Future for Transfer<'a, C> {
     fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
         STATE.ch_wakers[self.channel.index()].register(cx.waker());
 
-        if self.is_running() {
+        if !self.circular && self.is_running() {
             Poll::Pending
         } else {
             Poll::Ready(())


### PR DESCRIPTION
Since in circular mode, DMA will keep running until manually stop. But when user `.await` a circular `Transfer`, they got no chance (in the same thread) to manually stop it.

Unresolved:
* Should we read `Circ` bit from register every time it pulls, or record it in struct?
* Should we reject when user set both `FlowControl::Peripheral` and `circular` mode in one `TransferOptions`?
  * If we do reject setting them at the same time, then we can safely store the `circular` mode in `Transfer` struct, and reduce an AHB access on each poll (also make `Transfer` a little bigger)