### PR TITLE
FAQ: Remove Xtensa specifier

### DIFF
--- a/docs/modules/ROOT/pages/faq.adoc
+++ b/docs/modules/ROOT/pages/faq.adoc
@@ -35,7 +35,7 @@ For Cortex-M targets, consider making sure that ALL of the following features ar
 * `executor-thread`
 * `nightly`
 
-For Xtensa ESP32, consider using the executors and `#[main]` macro provided by your appropriate link:https://crates.io/crates/esp-hal-common[HAL crate].
+For ESP32, consider using the executors and `#[main]` macro provided by your appropriate link:https://crates.io/crates/esp-hal-common[HAL crate].
 
 == Why is my binary so big?
 


### PR DESCRIPTION
Since the last release, esp-hal provides executors for both Xtensa and RISC-V SoCs. This means the FAQ should recommend esp-hal for all ESP32 users.