### PR TITLE
stm32: make time provider public again

### DIFF
--- a/embassy-stm32/src/rtc/mod.rs
+++ b/embassy-stm32/src/rtc/mod.rs
@@ -102,7 +102,8 @@ pub enum RtcError {
     NotRunning,
 }
 
-pub(crate) struct RtcTimeProvider {
+/// Provides immutable access to the current time of the RTC.
+pub struct RtcTimeProvider {
     _private: (),
 }
 
@@ -243,7 +244,7 @@ impl Rtc {
     }
 
     /// Acquire a [`RtcTimeProvider`] instance.
-    pub(crate) const fn time_provider(&self) -> RtcTimeProvider {
+    pub const fn time_provider(&self) -> RtcTimeProvider {
         RtcTimeProvider { _private: () }
     }
 


### PR DESCRIPTION
This was accidentally made private during the doc updates.