### PR TITLE
Async API working

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -30,6 +30,7 @@
     // "examples/stm32f2/Cargo.toml",
     // "examples/stm32f3/Cargo.toml",
     // "examples/stm32f334/Cargo.toml",
+    // "embassy-stm32/Cargo.toml",
     "examples/stm32f4/Cargo.toml",
     // "examples/stm32f7/Cargo.toml",
     // "examples/stm32g0/Cargo.toml",

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -18,7 +18,7 @@
   "rust-analyzer.linkedProjects": [
     // Uncomment ONE line for the chip you want to work on.
     // This makes rust-analyzer work on the example crate and all its dependencies.
-    "examples/stm32l4/Cargo.toml",
+    // "examples/stm32l4/Cargo.toml",
     // "examples/nrf52840-rtic/Cargo.toml",
     // "examples/nrf5340/Cargo.toml",
     // "examples/nrf-rtos-trace/Cargo.toml",
@@ -30,7 +30,7 @@
     // "examples/stm32f2/Cargo.toml",
     // "examples/stm32f3/Cargo.toml",
     // "examples/stm32f334/Cargo.toml",
-    // "examples/stm32f4/Cargo.toml",
+    "examples/stm32f4/Cargo.toml",
     // "examples/stm32f7/Cargo.toml",
     // "examples/stm32g0/Cargo.toml",
     // "examples/stm32g4/Cargo.toml",

--- a/embassy-stm32/build.rs
+++ b/embassy-stm32/build.rs
@@ -885,6 +885,10 @@ fn main() {
         (("quadspi", "BK2_IO3"), quote!(crate::qspi::BK2D3Pin)),
         (("quadspi", "BK2_NCS"), quote!(crate::qspi::BK2NSSPin)),
         (("quadspi", "CLK"), quote!(crate::qspi::SckPin)),
+        (("adc", "ADC"), quote!(crate::adc::RxDma)),
+        (("adc", "ADC1"), quote!(crate::adc::RxDma)),
+        (("adc", "ADC2"), quote!(crate::adc::RxDma)),
+        (("adc", "ADC3"), quote!(crate::adc::RxDma)),
     ].into();
 
     for p in METADATA.peripherals {

--- a/embassy-stm32/build.rs
+++ b/embassy-stm32/build.rs
@@ -885,10 +885,6 @@ fn main() {
         (("quadspi", "BK2_IO3"), quote!(crate::qspi::BK2D3Pin)),
         (("quadspi", "BK2_NCS"), quote!(crate::qspi::BK2NSSPin)),
         (("quadspi", "CLK"), quote!(crate::qspi::SckPin)),
-        (("adc", "ADC"), quote!(crate::adc::RxDma)),
-        (("adc", "ADC1"), quote!(crate::adc::RxDma)),
-        (("adc", "ADC2"), quote!(crate::adc::RxDma)),
-        (("adc", "ADC3"), quote!(crate::adc::RxDma)),
     ].into();
 
     for p in METADATA.peripherals {
@@ -1012,6 +1008,10 @@ fn main() {
         (("quadspi", "QUADSPI"), quote!(crate::qspi::QuadDma)),
         (("dac", "CH1"), quote!(crate::dac::DacDma1)),
         (("dac", "CH2"), quote!(crate::dac::DacDma2)),
+        (("adc", "ADC"), quote!(crate::adc::RxDma)),
+        (("adc", "ADC1"), quote!(crate::adc::RxDma)),
+        (("adc", "ADC2"), quote!(crate::adc::RxDma)),
+        (("adc", "ADC3"), quote!(crate::adc::RxDma)),
     ]
     .into();
 

--- a/embassy-stm32/src/adc/mod.rs
+++ b/embassy-stm32/src/adc/mod.rs
@@ -12,6 +12,7 @@
 #[cfg_attr(any(adc_v3, adc_g0), path = "v3.rs")]
 #[cfg_attr(adc_v4, path = "v4.rs")]
 mod _version;
+dma_trait!(RxDma, Instance);
 
 #[cfg(not(any(adc_f1, adc_f3_v2)))]
 mod resolution;
@@ -36,15 +37,15 @@ pub struct Adc<'d, T: Instance> {
 }
 
 pub(crate) mod sealed {
-    #[cfg(any(adc_f1, adc_f3, adc_v1, adc_f3_v1_1))]
+    #[cfg(any(adc_f1, adc_f3, adc_v1, adc_f3_v1_1, adc_v2))]
     use embassy_sync::waitqueue::AtomicWaker;
 
-    #[cfg(any(adc_f1, adc_f3, adc_v1, adc_f3_v1_1))]
+    #[cfg(any(adc_f1, adc_f3, adc_v1, adc_f3_v1_1, adc_v2))]
     pub struct State {
         pub waker: AtomicWaker,
     }
 
-    #[cfg(any(adc_f1, adc_f3, adc_v1, adc_f3_v1_1))]
+    #[cfg(any(adc_f1, adc_f3, adc_v1, adc_f3_v1_1, adc_v2))]
     impl State {
         pub const fn new() -> Self {
             Self {
@@ -63,7 +64,7 @@ pub(crate) mod sealed {
         fn common_regs() -> crate::pac::adccommon::AdcCommon;
         #[cfg(adc_f3)]
         fn frequency() -> crate::time::Hertz;
-        #[cfg(any(adc_f1, adc_f3, adc_v1, adc_f3_v1_1))]
+        #[cfg(any(adc_f1, adc_f3, adc_v1, adc_f3_v1_1, adc_v2))]
         fn state() -> &'static State;
     }
 
@@ -108,7 +109,7 @@ foreach_adc!(
                 unsafe { crate::rcc::get_freqs() }.$clock.unwrap()
             }
 
-            #[cfg(any(adc_f1, adc_f3, adc_v1, adc_f3_v1_1))]
+            #[cfg(any(adc_f1, adc_f3, adc_v1, adc_f3_v1_1, adc_v2))]
             fn state() -> &'static sealed::State {
                 static STATE: sealed::State = sealed::State::new();
                 &STATE

--- a/embassy-stm32/src/adc/mod.rs
+++ b/embassy-stm32/src/adc/mod.rs
@@ -18,9 +18,12 @@ dma_trait!(RxDma, Instance);
 mod resolution;
 mod sample_time;
 
+use core::marker::PhantomData;
+
 #[allow(unused)]
 #[cfg(not(adc_f3_v2))]
 pub use _version::*;
+use embassy_hal_internal::{Peripheral, PeripheralRef};
 #[cfg(not(any(adc_f1, adc_f3, adc_f3_v2)))]
 pub use resolution::Resolution;
 #[cfg(not(adc_f3_v2))]
@@ -29,11 +32,14 @@ pub use sample_time::SampleTime;
 use crate::peripherals;
 
 /// Analog to Digital driver.
-pub struct Adc<'d, T: Instance> {
+pub struct Adc<'d, T: Instance, RXDMA> {
     #[allow(unused)]
-    adc: crate::PeripheralRef<'d, T>,
+    // adc: crate::PeripheralRef<'d, T>,
     #[cfg(not(any(adc_f3_v2, adc_f3_v1_1)))]
     sample_time: SampleTime,
+    calibrated_vdda: u32,
+    rxdma: PeripheralRef<'d, RXDMA>,
+    phantom: PhantomData<&'d mut T>,
 }
 
 pub(crate) mod sealed {

--- a/embassy-stm32/src/adc/v2.rs
+++ b/embassy-stm32/src/adc/v2.rs
@@ -1,10 +1,27 @@
+use core::future::poll_fn;
+use core::marker::PhantomData;
+use core::sync::atomic::AtomicU16;
+use core::task::Poll;
+
+use super::RxDma;
+use embassy_futures::yield_now;
+use embassy_hal_internal::interrupt::{InterruptExt, Priority};
 use embassy_hal_internal::into_ref;
+use embassy_time::Instant;
 use embedded_hal_02::blocking::delay::DelayUs;
+use stm32_metapac::adc::{self, vals};
 
 use crate::adc::{Adc, AdcPin, Instance, Resolution, SampleTime};
+use crate::interrupt::typelevel::Interrupt;
 use crate::peripherals::ADC1;
 use crate::time::Hertz;
-use crate::Peripheral;
+use crate::{interrupt, Peripheral};
+
+const ADC_FREQ: Hertz = crate::rcc::HSI_FREQ;
+
+pub const VDDA_CALIB_MV: u32 = 3300;
+pub const ADC_MAX: u32 = (1 << 12) - 1;
+pub const VREF_INT: u32 = 1230;
 
 /// Default VREF voltage used for sample conversion to millivolts.
 pub const VREF_DEFAULT_MV: u32 = 3300;
@@ -14,24 +31,99 @@ pub const VREF_CALIB_MV: u32 = 3300;
 /// ADC turn-on time
 pub const ADC_POWERUP_TIME_US: u32 = 3;
 
-pub struct VrefInt;
-impl AdcPin<ADC1> for VrefInt {}
-impl super::sealed::AdcPin<ADC1> for VrefInt {
+/// Interrupt handler.
+pub struct InterruptHandler<T: Instance> {
+    _phantom: PhantomData<T>,
+}
+
+impl<T: Instance> interrupt::typelevel::Handler<T::Interrupt> for InterruptHandler<T> {
+    unsafe fn on_interrupt() {
+        if T::regs().sr().read().eoc().to_bits() == 0x01 {
+            T::regs().cr1().modify(|w| w.set_eocie(false));
+            // ADC_DATA[0].store(T::regs().dr().read().data(), core::sync::atomic::Ordering::Relaxed);
+        } else {
+            return;
+        }
+
+        T::state().waker.wake();
+    }
+}
+
+fn update_vref<T: Instance>(op: i8) {
+    static VREF_STATUS: core::sync::atomic::AtomicU8 = core::sync::atomic::AtomicU8::new(0);
+
+    if op > 0 {
+        if VREF_STATUS.fetch_add(1, core::sync::atomic::Ordering::SeqCst) == 0 {
+            T::common_regs().ccr().modify(|w| w.set_tsvrefe(true));
+        }
+    } else {
+        if VREF_STATUS.fetch_sub(1, core::sync::atomic::Ordering::SeqCst) == 1 {
+            T::common_regs().ccr().modify(|w| w.set_tsvrefe(false));
+        }
+    }
+}
+
+pub struct Vref<T: Instance>(core::marker::PhantomData<T>);
+impl<T: Instance> AdcPin<T> for Vref<T> {}
+impl<T: Instance> super::sealed::AdcPin<T> for Vref<T> {
     fn channel(&self) -> u8 {
         17
     }
 }
 
-impl VrefInt {
-    /// Time needed for internal voltage reference to stabilize
-    pub fn start_time_us() -> u32 {
-        10
+impl<T: Instance> Vref<T> {
+    /// The value that vref would be if vdda was at 3000mv
+    pub fn calibrated_value(&self) -> u16 {
+        ADC_MAX as u16
+    }
+
+    pub async fn calibrate(&mut self, adc: &mut Adc<'_, T>) -> Calibration {
+        let vref_val = adc.read(self).await;
+        Calibration {
+            vref_cal: self.calibrated_value(),
+            vref_val,
+        }
     }
 }
 
-pub struct Temperature;
-impl AdcPin<ADC1> for Temperature {}
-impl super::sealed::AdcPin<ADC1> for Temperature {
+pub struct Calibration {
+    vref_cal: u16,
+    vref_val: u16,
+}
+
+impl Calibration {
+    /// The millivolts that the calibration value was measured at
+    pub const CALIBRATION_UV: u32 = 3_000_000;
+
+    /// Returns the measured VddA in microvolts (uV)
+    pub fn vdda_uv(&self) -> u32 {
+        (Self::CALIBRATION_UV * self.vref_cal as u32) / self.vref_val as u32
+    }
+
+    /// Returns the measured VddA as an f32
+    pub fn vdda_f32(&self) -> f32 {
+        (Self::CALIBRATION_UV as f32 / 1_000.0) * (self.vref_cal as f32 / self.vref_val as f32)
+    }
+
+    /// Returns a calibrated voltage value as in microvolts (uV)
+    pub fn cal_uv(&self, raw: u16, resolution: super::Resolution) -> u32 {
+        (self.vdda_uv() / resolution.to_max_count()) * raw as u32
+    }
+
+    /// Returns a calibrated voltage value as an f32
+    pub fn cal_f32(&self, raw: u16, resolution: super::Resolution) -> f32 {
+        raw as f32 * self.vdda_f32() / resolution.to_max_count() as f32
+    }
+}
+
+impl<T: Instance> Drop for Vref<T> {
+    fn drop(&mut self) {
+        update_vref::<T>(-1)
+    }
+}
+pub struct Temperature<T: Instance>(core::marker::PhantomData<T>);
+impl<T: Instance> AdcPin<ADC1> for Temperature<T> {}
+impl<T: Instance> super::sealed::AdcPin<ADC1> for Temperature<T> {
     fn channel(&self) -> u8 {
         cfg_if::cfg_if! {
             if #[cfg(any(stm32f40, stm32f41))] {
@@ -43,7 +135,7 @@ impl super::sealed::AdcPin<ADC1> for Temperature {
     }
 }
 
-impl Temperature {
+impl<T: Instance> Temperature<T> {
     /// Time needed for temperature sensor readings to stabilize
     pub fn start_time_us() -> u32 {
         10
@@ -89,21 +181,25 @@ impl Prescaler {
     }
 }
 
-impl<'d, T> Adc<'d, T>
+impl<'d, T: Instance> Adc<'d, T>
 where
     T: Instance,
 {
-    pub fn new(adc: impl Peripheral<P = T> + 'd, delay: &mut impl DelayUs<u32>) -> Self {
+    pub fn new(
+        adc: impl Peripheral<P = T> + 'd,
+        _irq: impl interrupt::typelevel::Binding<T::Interrupt, InterruptHandler<T>> + 'd,
+        delay: &mut impl DelayUs<u32>,
+    ) -> Self {
         into_ref!(adc);
+
+        T::regs().cr2().modify(|reg| reg.set_adon(true));
+        delay.delay_us((1_000_000 * 2) / Self::freq().0 + 1);
+
         T::enable_and_reset();
-
-        let presc = Prescaler::from_pclk2(T::frequency());
-        T::common_regs().ccr().modify(|w| w.set_adcpre(presc.adcpre()));
-        T::regs().cr2().modify(|reg| {
-            reg.set_adon(true);
-        });
-
-        delay.delay_us(ADC_POWERUP_TIME_US);
+        T::Interrupt::unpend();
+        unsafe {
+            T::Interrupt::enable();
+        }
 
         Self {
             adc,
@@ -111,22 +207,93 @@ where
         }
     }
 
-    pub fn set_sample_time(&mut self, sample_time: SampleTime) {
-        self.sample_time = sample_time;
+    pub async fn set_resolution(&mut self, resolution: Resolution) {
+        let was_on = Self::is_on();
+        if was_on {
+            self.stop_adc().await;
+        }
+
+        T::regs().cr1().modify(|w| w.set_res(resolution.into()));
+
+        if was_on {
+            self.start_adc().await;
+        }
     }
 
-    pub fn set_resolution(&mut self, resolution: Resolution) {
-        T::regs().cr1().modify(|reg| reg.set_res(resolution.into()));
+    pub fn resolution(&self) -> Resolution {
+        match T::regs().cr1().read().res() {
+            crate::pac::adc::vals::Res::TWELVEBIT => Resolution::TwelveBit,
+            crate::pac::adc::vals::Res::TENBIT => Resolution::TenBit,
+            crate::pac::adc::vals::Res::EIGHTBIT => Resolution::EightBit,
+            crate::pac::adc::vals::Res::SIXBIT => Resolution::SixBit,
+        }
+    }
+
+    #[inline(always)]
+    fn is_on() -> bool {
+        T::regs().cr2().read().adon()
+    }
+
+    pub async fn start_adc(&self) {
+        // defmt::trace!("Turn ADC on");
+        T::regs().cr2().modify(|w| w.set_adon(true));
+        //defmt::trace!("Waiting for ADC to turn on");
+
+        let mut t = Instant::now();
+
+        while !T::regs().cr2().read().adon() {
+            yield_now().await;
+            if t.elapsed() > embassy_time::Duration::from_millis(1000) {
+                t = Instant::now();
+                defmt::trace!("ADC still not on");
+            }
+        }
+
+        // defmt::trace!("ADC on");
+    }
+
+    fn freq() -> Hertz {
+        let div: u8 = T::common_regs().ccr().read().adcpre() as u8 + 1;
+        ADC_FREQ / div as u32
+    }
+
+    pub async fn stop_adc(&self) {
+        if T::regs().cr2().read().adon() {
+            //   defmt::trace!("ADC should be on, wait for it to start");
+            while !T::regs().cr2().read().adon() {
+                yield_now().await;
+            }
+        }
+
+        // defmt::trace!("Turn ADC off");
+
+        T::regs().cr2().modify(|w| w.set_adon(false));
+
+        // defmt::trace!("Waiting for ADC to turn off");
+
+        while T::regs().cr2().read().adon() {
+            yield_now().await;
+        }
+    }
+
+    pub async fn read(&mut self, pin: &mut impl AdcPin<T>) -> u16 {
+        self.set_channel_sample_sequence(&[pin.channel()]).await;
+        self.convert().await
+    }
+
+    async fn wait_sample_ready(&self) {
+        // trace!("Waiting for sample channel to be ready");
+        while T::regs().sr().read().strt() == adc::vals::Strt::STARTED {
+            yield_now().await;
+        }
     }
 
     /// Enables internal voltage reference and returns [VrefInt], which can be used in
     /// [Adc::read_internal()] to perform conversion.
-    pub fn enable_vrefint(&self) -> VrefInt {
-        T::common_regs().ccr().modify(|reg| {
-            reg.set_tsvrefe(true);
-        });
+    pub fn enable_vref(&self) -> Vref<T> {
+        update_vref::<T>(1);
 
-        VrefInt {}
+        Vref(core::marker::PhantomData)
     }
 
     /// Enables internal temperature sensor and returns [Temperature], which can be used in
@@ -134,12 +301,10 @@ where
     ///
     /// On STM32F42 and STM32F43 this can not be used together with [Vbat]. If both are enabled,
     /// temperature sensor will return vbat value.
-    pub fn enable_temperature(&self) -> Temperature {
-        T::common_regs().ccr().modify(|reg| {
-            reg.set_tsvrefe(true);
-        });
+    pub fn enable_temperature(&self) -> Temperature<T> {
+        T::common_regs().ccr().modify(|w| w.set_tsvrefe(true));
 
-        Temperature {}
+        Temperature::<T>(core::marker::PhantomData)
     }
 
     /// Enables vbat input and returns [Vbat], which can be used in
@@ -152,50 +317,215 @@ where
         Vbat {}
     }
 
-    /// Perform a single conversion.
-    fn convert(&mut self) -> u16 {
-        // clear end of conversion flag
-        T::regs().sr().modify(|reg| {
-            reg.set_eoc(crate::pac::adc::vals::Eoc::NOTCOMPLETE);
-        });
-
-        // Start conversion
-        T::regs().cr2().modify(|reg| {
-            reg.set_swstart(true);
-        });
-
-        while T::regs().sr().read().strt() == crate::pac::adc::vals::Strt::NOTSTARTED {
-            // spin //wait for actual start
+    pub async fn set_sample_time(&mut self, pin: &mut impl AdcPin<T>, sample_time: SampleTime) {
+        if Self::get_channel_sample_time(pin.channel()) != sample_time {
+            let was_on = Self::is_on();
+            if was_on {
+                self.stop_adc().await;
+            }
+            unsafe {
+                Self::set_channel_sample_time(pin.channel(), sample_time);
+                trace!(
+                    "Set sample time for channel {} to {:?}",
+                    pin.channel(),
+                    Self::get_channel_sample_time(pin.channel())
+                );
+            }
+            if was_on {
+                self.start_adc().await;
+            }
         }
-        while T::regs().sr().read().eoc() == crate::pac::adc::vals::Eoc::NOTCOMPLETE {
-            // spin //wait for finish
-        }
-
-        T::regs().dr().read().0 as u16
     }
-
-    pub fn read(&mut self, pin: &mut impl AdcPin<T>) -> u16 {
-        pin.set_as_analog();
-
-        // Configure ADC
-        let channel = pin.channel();
-
-        // Select channel
-        T::regs().sqr3().write(|reg| reg.set_sq(0, channel));
-
-        // Configure channel
-        Self::set_channel_sample_time(channel, self.sample_time);
-
-        self.convert()
-    }
-
-    fn set_channel_sample_time(ch: u8, sample_time: SampleTime) {
+    /// Sets the channel sample time
+    ///
+    /// ## SAFETY:
+    /// - ADON == 0 i.e ADC must not be enabled when this is called.
+    unsafe fn set_channel_sample_time(ch: u8, sample_time: SampleTime) {
         let sample_time = sample_time.into();
         if ch <= 9 {
             T::regs().smpr2().modify(|reg| reg.set_smp(ch as _, sample_time));
         } else {
             T::regs().smpr1().modify(|reg| reg.set_smp((ch - 10) as _, sample_time));
         }
+    }
+
+    fn set_channels_sample_time(&mut self, ch: &[u8], sample_time: SampleTime) {
+        let ch_iter = ch.iter();
+        for idx in ch_iter {
+            unsafe {
+                Self::set_channel_sample_time(*idx, sample_time);
+            }
+        }
+    }
+
+    fn get_channel_sample_time(ch: u8) -> SampleTime {
+        match ch {
+            0..=9 => T::regs().smpr2().read().smp(ch as _),
+            10..=16 => T::regs().smpr1().read().smp(ch as usize - 10),
+            _ => panic!("Invalid channel to sample"),
+        }
+        .into()
+    }
+    pub async fn read_sample_sequence(&mut self, sequence: &[u8]) -> [u16; 18] {
+        let was_on = Self::is_on();
+        if !was_on {
+            self.start_adc().await;
+        }
+
+        T::regs().cr1().modify(|w| {
+            w.set_eocie(false);
+            w.set_scan(true);
+        });
+        self.sample_time = SampleTime::Cycles144;
+        self.set_channel_sample_sequence(sequence).await;
+        self.set_channels_sample_time(sequence, self.sample_time);
+
+        T::regs().cr2().modify(|w| {
+            w.set_swstart(true);
+            w.set_cont(adc::vals::Cont::CONTINUOUS);
+        }); // swstart cleared by HW
+
+        T::regs().cr1().write(|w| w.set_eocie(true));
+
+        let mut i = 0;
+        let mut buf = [0u16; 18];
+        let res = poll_fn(|cx| {
+            T::state().waker.register(cx.waker());
+            if T::regs().sr().read().eoc() == adc::vals::Eoc::COMPLETE {
+                buf[i] = T::regs().dr().read().data();
+                T::regs().sr().write(|w| w.set_eoc(vals::Eoc::NOTCOMPLETE));
+                i = i + 1;
+                if i == sequence.len() {
+                    Poll::Ready(buf)
+                } else {
+                    //Unmask interrupt after previous trigger & storing data.
+                    T::regs().cr1().write(|w| w.set_eocie(true));
+
+                    Poll::Pending
+                }
+            } else {
+                Poll::Pending
+            }
+        })
+        .await;
+
+        T::regs().cr2().write(|w| {
+            w.set_swstart(false);
+        }); // swstart cleared by HW
+
+        // T::regs().cr1().write(|w| w.set_eocie(true));
+        if !was_on {
+            self.stop_adc().await;
+        }
+
+        res
+    }
+
+    /// Sets the sequence to sample the ADC. Must be less than  elements.
+    pub async fn set_channel_sample_sequence(&self, sequence: &[u8]) {
+        assert!(sequence.len() <= 16);
+        // trace!("Sequence Length: {}", sequence.len());
+        let mut iter = sequence.iter();
+
+        T::regs().sqr1().modify(|w| w.set_l((sequence.len() - 1) as _));
+        for (idx, ch) in iter.by_ref().take(6).enumerate() {
+            T::regs().sqr3().modify(|w| w.set_sq(idx, *ch));
+        }
+        for (idx, ch) in iter.by_ref().take(6).enumerate() {
+            T::regs().sqr2().modify(|w| w.set_sq(idx, *ch));
+        }
+        for (idx, ch) in iter.by_ref().take(4).enumerate() {
+            T::regs().sqr1().modify(|w| w.set_sq(idx, *ch));
+        }
+    }
+
+    fn get_res_clks(res: Resolution) -> u32 {
+        match res {
+            Resolution::TwelveBit => 12,
+            Resolution::TenBit => 11,
+            Resolution::EightBit => 9,
+            Resolution::SixBit => 7,
+        }
+    }
+
+    fn get_sample_time_clks(sample_time: SampleTime) -> u32 {
+        match sample_time {
+            SampleTime::Cycles3 => 3,
+            SampleTime::Cycles15 => 15,
+            SampleTime::Cycles28 => 28,
+            SampleTime::Cycles56 => 56,
+            SampleTime::Cycles84 => 84,
+            SampleTime::Cycles112 => 112,
+            SampleTime::Cycles144 => 144,
+            SampleTime::Cycles480 => 480,
+        }
+    }
+
+    pub fn sample_time_for_us(&self, us: u32) -> SampleTime {
+        let res_clks = Self::get_res_clks(self.resolution());
+        let us_clks = us * Self::freq().0 / 1_000_000;
+        let clks = us_clks.saturating_sub(res_clks);
+        match clks {
+            0..=3 => SampleTime::Cycles3,
+            4..=15 => SampleTime::Cycles15,
+            16..=28 => SampleTime::Cycles28,
+            29..=56 => SampleTime::Cycles56,
+            57..=84 => SampleTime::Cycles84,
+            85..=112 => SampleTime::Cycles112,
+            113..=144 => SampleTime::Cycles144,
+            _ => SampleTime::Cycles480,
+        }
+    }
+
+    pub fn us_for_cfg(&self, res: Resolution, sample_time: SampleTime) -> u32 {
+        let res_clks = Self::get_res_clks(res);
+        let sample_clks = Self::get_sample_time_clks(sample_time);
+        (res_clks + sample_clks) * 1_000_000 / Self::freq().0
+    }
+
+    pub fn ns_for_cfg(&self, res: Resolution, sample_time: SampleTime) -> u64 {
+        let res_clks = Self::get_res_clks(res);
+        let sample_clks = Self::get_sample_time_clks(sample_time);
+        (res_clks + sample_clks) as u64 * 1_000_000_000 / Self::freq().0 as u64
+    }
+
+    /// Perform a single conversion.
+    async fn convert(&mut self) -> u16 {
+        let was_on = Self::is_on();
+
+        if !was_on {
+            self.start_adc().await;
+        }
+
+        self.wait_sample_ready().await;
+
+        T::regs().sr().write(|_| {});
+        T::regs().cr1().modify(|w| {
+            w.set_eocie(true);
+            w.set_scan(false);
+        });
+        T::regs().cr2().modify(|w| {
+            w.set_swstart(true);
+            w.set_cont(adc::vals::Cont::SINGLE);
+        }); // swstart cleared by HW
+
+        let res = poll_fn(|cx| {
+            T::state().waker.register(cx.waker());
+
+            if T::regs().sr().read().eoc() == adc::vals::Eoc::COMPLETE {
+                let res = T::regs().dr().read().data();
+                Poll::Ready(res)
+            } else {
+                Poll::Pending
+            }
+        })
+        .await;
+
+        if !was_on {
+            self.stop_adc().await;
+        }
+
+        res
     }
 }
 
@@ -208,3 +538,72 @@ impl<'d, T: Instance> Drop for Adc<'d, T> {
         T::disable();
     }
 }
+
+// pub async fn read_continuous<S, const N: usize>(
+//     &mut self,
+//     pin: &mut impl AdcPin<T>,
+//     data: &mut [[u16; N]; 2],
+//     sampler: &mut S,
+// ) where
+//     S: FnMut(&[u16; N]) -> SamplerState,
+//     RXDMA: RxDma<T>,
+// {
+//     let rx_request = self.rxdma.request();
+//     let rx_src = T::regs().dr().ptr() as *mut u16;
+
+//     unsafe {
+//         self.rxdma
+//             .start_circular_read(rx_request, rx_src, data.as_mut_ptr(), N * 2, Default::default());
+//     }
+
+//     unsafe {
+//         Self::set_channel_sample_time(pin.channel(), self.sample_time);
+//         T::regs().cr1().modify(|reg| {
+//             reg.set_scan(false);
+//             reg.set_discen(false);
+//         });
+//         T::regs().sqr1().modify(|reg| reg.set_l(0));
+
+//         T::regs().cr2().modify(|reg| {
+//             reg.set_cont(true); //Goes with circular DMA
+//             reg.set_exttrig(true);
+//             reg.set_swstart(false);
+//             reg.set_extsel(crate::pac::adc::vals::Extsel::SWSTART);
+//             reg.set_dma(true);
+//         });
+//     }
+
+//     // Configure the channel to sample
+//     unsafe { T::regs().sqr3().write(|reg| reg.set_sq(0, pin.channel())) }
+
+//     //Enable ADC
+//     unsafe {
+//         T::regs().cr2().modify(|reg| {
+//             reg.set_adon(true);
+//             reg.set_swstart(true);
+//         });
+//     }
+//     let mut buf_index = 0;
+//     //Loop for retrieving data
+//     poll_fn(|cx| {
+//         self.rxdma.set_waker(cx.waker());
+
+//         if self.rxdma.is_data_ready() {
+//             let sampler_state = sampler(&data[buf_index]);
+//             self.rxdma.set_data_processing_done();
+
+//             if sampler_state == SamplerState::Sampled {
+//                 buf_index = !buf_index & 0x01; // switch the buffer index (0/1)
+//                 return Poll::Pending;
+//             } else {
+//                 return Poll::Ready(());
+//             }
+//         } else {
+//             return Poll::Pending;
+//         }
+//     })
+//     .await;
+
+//     self.rxdma.request_stop();
+//     while self.rxdma.is_running() {}
+// }

--- a/examples/stm32f4/.cargo/config.toml
+++ b/examples/stm32f4/.cargo/config.toml
@@ -1,9 +1,9 @@
 [target.'cfg(all(target_arch = "arm", target_os = "none"))']
 # replace STM32F429ZITx with your chip as listed in `probe-rs chip list`
-runner = "probe-rs run --chip STM32F429ZITx"
+runner = "probe-run --chip STM32F405VGTx"
 
 [build]
-target = "thumbv7em-none-eabi"
+target = "thumbv7em-none-eabihf"
 
 [env]
 DEFMT_LOG = "trace"

--- a/examples/stm32f4/.cargo/config.toml
+++ b/examples/stm32f4/.cargo/config.toml
@@ -1,6 +1,10 @@
 [target.'cfg(all(target_arch = "arm", target_os = "none"))']
 # replace STM32F429ZITx with your chip as listed in `probe-rs chip list`
-runner = "probe-run --chip STM32F405VGTx"
+runner = "probe-rs run --chip STM32F405VGTx"
+
+[unstable]
+build-std = ["core"]
+build-std-features = ["panic_immediate_abort"]
 
 [build]
 target = "thumbv7em-none-eabihf"

--- a/examples/stm32f4/Cargo.toml
+++ b/examples/stm32f4/Cargo.toml
@@ -6,10 +6,10 @@ license = "MIT OR Apache-2.0"
 
 [dependencies]
 # Change stm32f429zi to your chip name, if necessary.
-embassy-stm32 = { version = "0.1.0", path = "../../embassy-stm32", features = [ "defmt", "stm32f429zi", "unstable-pac", "memory-x", "time-driver-any", "exti", "chrono"]  }
+embassy-stm32 = { version = "0.1.0", path = "../../embassy-stm32", features = [ "defmt", "stm32f405vg", "unstable-pac", "memory-x", "time-driver-any", "exti", "chrono"]  }
 embassy-sync = { version = "0.5.0", path = "../../embassy-sync", features = ["defmt"] }
 embassy-executor = { version = "0.4.0", path = "../../embassy-executor", features = ["arch-cortex-m", "executor-thread", "executor-interrupt", "defmt", "integrated-timers"] }
-embassy-time = { version = "0.2", path = "../../embassy-time", features = ["defmt", "defmt-timestamp-uptime", "tick-hz-32_768"] }
+embassy-time = { version = "0.2", path = "../../embassy-time", features = ["defmt", "defmt-timestamp-uptime", "tick-hz-1_000_000"] }
 embassy-usb = { version = "0.1.0", path = "../../embassy-usb", features = ["defmt" ] }
 embassy-net = { version = "0.2.0", path = "../../embassy-net", features = ["defmt", "tcp", "dhcpv4", "medium-ethernet", ] }
 

--- a/examples/stm32f4/Cargo.toml
+++ b/examples/stm32f4/Cargo.toml
@@ -8,8 +8,8 @@ license = "MIT OR Apache-2.0"
 # Change stm32f429zi to your chip name, if necessary.
 embassy-stm32 = { version = "0.1.0", path = "../../embassy-stm32", features = [ "defmt", "stm32f405vg", "unstable-pac", "memory-x", "time-driver-any", "exti", "chrono"]  }
 embassy-sync = { version = "0.5.0", path = "../../embassy-sync", features = ["defmt"] }
-embassy-executor = { version = "0.4.0", path = "../../embassy-executor", features = ["arch-cortex-m", "executor-thread", "executor-interrupt", "defmt", "integrated-timers"] }
-embassy-time = { version = "0.2", path = "../../embassy-time", features = ["defmt", "defmt-timestamp-uptime", "tick-hz-1_000_000"] }
+embassy-executor = { version = "0.4.0", path = "../../embassy-executor", features = ["arch-cortex-m", "executor-thread", "executor-interrupt", "defmt", "nightly"] }
+embassy-time = { version = "0.2", path = "../../embassy-time", features = ["defmt", "defmt-timestamp-uptime", "tick-hz-1_000_000", "generic-queue"] }
 embassy-usb = { version = "0.1.0", path = "../../embassy-usb", features = ["defmt" ] }
 embassy-net = { version = "0.2.0", path = "../../embassy-net", features = ["defmt", "tcp", "dhcpv4", "medium-ethernet", ] }
 
@@ -30,5 +30,22 @@ micromath = "2.0.0"
 static_cell = "2"
 chrono = { version = "^0.4", default-features = false}
 
+# cargo build/run --release
+[profile.dev]
+codegen-units = 1
+debug = 1
+debug-assertions = true # <-
+incremental = true
+lto = true
+opt-level = 's' # <-
+overflow-checks = true # <-
+
+# cargo build/run --release
 [profile.release]
-debug = 2
+codegen-units = 1
+debug = 0
+debug-assertions = false # <-
+incremental = false
+lto = true
+opt-level = 's' # <-
+overflow-checks = false # <-

--- a/examples/stm32f4/src/bin/adc.rs
+++ b/examples/stm32f4/src/bin/adc.rs
@@ -4,64 +4,81 @@
 use cortex_m::prelude::_embedded_hal_blocking_delay_DelayUs;
 use defmt::*;
 use embassy_executor::Spawner;
-use embassy_stm32::adc::{Adc, Temperature, VrefInt};
-use embassy_time::{Delay, Timer};
+use embassy_stm32::adc::InterruptHandler;
+use embassy_stm32::adc::{Adc, Resolution, Temperature, Vref};
+use embassy_stm32::interrupt::{InterruptExt, Priority};
+use embassy_stm32::peripherals::{PA0, PC0};
+use embassy_stm32::{bind_interrupts, interrupt};
+use embassy_time::{Delay, Instant, Timer};
+use embedded_hal::adc::Channel;
 use {defmt_rtt as _, panic_probe as _};
+
+bind_interrupts!(struct Irqs {
+    ADC => InterruptHandler<embassy_stm32::peripherals::ADC1>;
+});
 
 #[embassy_executor::main]
 async fn main(_spawner: Spawner) {
-    let p = embassy_stm32::init(Default::default());
     info!("Hello World!");
-
+    let p = embassy_stm32::init(Default::default());
+    interrupt::ADC.set_priority(Priority::P1);
     let mut delay = Delay;
-    let mut adc = Adc::new(p.ADC1, &mut delay);
-    let mut pin = p.PC1;
+    let mut adc = Adc::new(p.ADC1, Irqs, &mut delay);
+    let mut pin2 = p.PC0;
+    let mut vrefint: Vref<embassy_stm32::peripherals::ADC1> = adc.enable_vref();
+    let mut temp: Temperature<embassy_stm32::peripherals::ADC1> = adc.enable_temperature();
+    adc.set_resolution(Resolution::TwelveBit).await;
 
-    let mut vrefint = adc.enable_vrefint();
-    let mut temp = adc.enable_temperature();
+    let samepletime = adc.ns_for_cfg(Resolution::TwelveBit, embassy_stm32::adc::SampleTime::Cycles3);
+    info!("Sample time: {} ns", samepletime);
+    // let vrefint_sample = adc.read(&mut vrefint).await;
 
-    // Startup delay can be combined to the maximum of either
-    delay.delay_us(Temperature::start_time_us().max(VrefInt::start_time_us()));
+    // let convert_to_millivolts = |sample| {
+    //     // From http://www.st.com/resource/en/datasheet/DM00071990.pdf
+    //     // 6.3.24 Reference voltage
+    //     const VREFINT_MV: u32 = 1500; // mV
+    //     (u32::from(sample) * VREFINT_MV / u32::from(vrefint_sample)) as u16
+    // };
 
-    let vrefint_sample = adc.read(&mut vrefint);
+    // let convert_to_celcius = |sample| {
+    //     // From http://www.st.com/resource/en/datasheet/DM00071990.pdf
+    //     // 6.3.22 Temperature sensor characteristics
+    //     const V25: i32 = 760; // mV
+    //     const AVG_SLOPE: f32 = 2.5; // mV/C
 
-    let convert_to_millivolts = |sample| {
-        // From http://www.st.com/resource/en/datasheet/DM00071990.pdf
-        // 6.3.24 Reference voltage
-        const VREFINT_MV: u32 = 1210; // mV
+    //     let sample_mv = convert_to_millivolts(sample) as i32;
 
-        (u32::from(sample) * VREFINT_MV / u32::from(vrefint_sample)) as u16
-    };
-
-    let convert_to_celcius = |sample| {
-        // From http://www.st.com/resource/en/datasheet/DM00071990.pdf
-        // 6.3.22 Temperature sensor characteristics
-        const V25: i32 = 760; // mV
-        const AVG_SLOPE: f32 = 2.5; // mV/C
-
-        let sample_mv = convert_to_millivolts(sample) as i32;
-
-        (sample_mv - V25) as f32 / AVG_SLOPE + 25.0
-    };
-
-    info!("VrefInt: {}", vrefint_sample);
+    //     (sample_mv - V25) as f32 / AVG_SLOPE + 25.0
+    // };
+    // adc.stop_adc().await;
+    // info!("VrefInt: {}", vrefint_sample);
     const MAX_ADC_SAMPLE: u16 = (1 << 12) - 1;
-    info!("VCCA: {} mV", convert_to_millivolts(MAX_ADC_SAMPLE));
+    // info!("VCCA: {} mV", convert_to_millivolts(MAX_ADC_SAMPLE));
+    // adc.start_adc().await;
 
+    // info!("Sample rate: {} Hz", adc.);
+    //adc.set_channel_sample_sequence(&[0, 10]).await;
     loop {
         // Read pin
-        let v = adc.read(&mut pin);
-        info!("PC1: {} ({} mV)", v, convert_to_millivolts(v));
+        let tic = Instant::now();
+        let data = adc.read_sample_sequence(&[0, 1, 2, 3, 4, 5, 6]).await;
 
-        // Read internal temperature
-        let v = adc.read(&mut temp);
-        let celcius = convert_to_celcius(v);
-        info!("Internal temp: {} ({} C)", v, celcius);
+        let toc = Instant::elapsed(&tic);
+        info!("Data: {:?} | {} us", data, toc.as_micros());
+        // info!("Channel 0: {} ({} mV)", data[0], convert_to_millivolts(data[0]));
+        // info!("Channel 10: {} ({} mV)", data[1], convert_to_millivolts(data[1]));
+        // info!("Took {} us", toc.as_micros());
 
-        // Read internal voltage reference
-        let v = adc.read(&mut vrefint);
-        info!("VrefInt: {}", v);
+        // let tic = Instant::now();
+        // let v1 = adc.read(&mut pin2).await;
+        // let toc = Instant::elapsed(&tic);
+        // info!("PC0: {} | {} us", v1, toc.as_micros());
 
-        Timer::after_millis(100).await;
+        // let vref = adc.read(&mut vrefint).await;
+        // info!("VrefInt: {} ({} mV)", vref, convert_to_millivolts(vref));
+        // let t = adc.read(&mut temp).await;
+        // info!("bits: {}, T: {} C", t, convert_to_celcius(t));
+
+        // Timer::after_millis(1).await;
     }
 }

--- a/examples/stm32f4/src/bin/adc.rs
+++ b/examples/stm32f4/src/bin/adc.rs
@@ -1,11 +1,10 @@
 #![no_std]
 #![no_main]
-
+#![feature(type_alias_impl_trait)]
 use cortex_m::prelude::_embedded_hal_blocking_delay_DelayUs;
 use defmt::*;
 use embassy_executor::Spawner;
-use embassy_stm32::adc::InterruptHandler;
-use embassy_stm32::adc::{Adc, Resolution, Temperature, Vref};
+use embassy_stm32::adc::{Adc, InterruptHandler, Resolution, Temperature, Vref};
 use embassy_stm32::interrupt::{InterruptExt, Priority};
 use embassy_stm32::peripherals::{PA0, PC0};
 use embassy_stm32::{bind_interrupts, interrupt};
@@ -61,7 +60,7 @@ async fn main(_spawner: Spawner) {
     loop {
         // Read pin
         let tic = Instant::now();
-        let data = adc.read_sample_sequence(&[0, 1, 2, 3, 4, 5, 6]).await;
+        let data = adc.read_sample_sequence(&[0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10]).await;
 
         let toc = Instant::elapsed(&tic);
         info!("Data: {:?} | {} us", data, toc.as_micros());
@@ -79,6 +78,6 @@ async fn main(_spawner: Spawner) {
         // let t = adc.read(&mut temp).await;
         // info!("bits: {}, T: {} C", t, convert_to_celcius(t));
 
-        // Timer::after_millis(1).await;
+        Timer::after_millis(100).await;
     }
 }

--- a/examples/stm32f4/src/bin/adc_dma.rs
+++ b/examples/stm32f4/src/bin/adc_dma.rs
@@ -1,0 +1,74 @@
+#![no_std]
+#![no_main]
+#![feature(type_alias_impl_trait)]
+
+use defmt::*;
+use embassy_executor::Spawner;
+use embassy_stm32::adc::{Adc, AdcPin, Instance, RxDma, SamplerState};
+use embassy_stm32::Peripheral;
+use embassy_time::{Delay, Duration, Instant, Timer};
+use {defmt_rtt as _, panic_probe as _};
+
+// async fn single_read<T: Instance + Peripheral<P = T>, RXDMA>(adc: &mut Adc<'_, T, RXDMA>, pin: &mut impl AdcPin<T>) {
+//     info!("Single read");
+
+//     for _ in 0..20 {
+//         let v = adc.read(pin);
+//         info!("--> {}", v);
+//         Timer::after(Duration::from_millis(300)).await;
+//     }
+// }
+
+async fn continous_read<T: Instance + Peripheral<P = T>, RXDMA: RxDma<T> + Peripheral<P = RXDMA>>(
+    adc: &mut Adc<'_, T, RXDMA>,
+    pin: &mut impl AdcPin<T>,
+) {
+    // info!("Continuous read");
+    let mut cnt: u8 = 0;
+    let mut data: [u16; 36] = [0u16; 36];
+    adc.read_continuous(pin, &mut data, &mut |buf| {
+        let state;
+        if cnt < 7 as u8 {
+            // info!("sampler: {} ", buf);
+            //     info!("--> 32 {} ", buf[32]);
+            //     info!("--> 64 {} ", buf[64]);
+            //     info!("--> 96 {} ", buf[96]);
+            //     info!("--> 128 {} ", buf[128]);
+            //     info!("--> 255 {} ", buf[255]);
+            state = SamplerState::Sampled
+        } else {
+            // info!("Stopped");
+            state = SamplerState::Stopped
+        }
+        cnt = cnt + 1;
+        // info!("Cnt: {}", cnt);
+        state
+    })
+    .await;
+    // info!("{} ", data);
+}
+
+#[embassy_executor::main]
+async fn main(_spawner: Spawner) {
+    info!("Hello World!");
+    let p = embassy_stm32::init(Default::default());
+    let mut adc = Adc::new(p.ADC1, p.DMA2_CH0, &mut Delay);
+    let mut pin = p.PA0;
+
+    // let mut vref = adc.enable_vref();
+    // adc.read(&mut vref);
+    // adc.set_sample_time(&mut pin, embassy_stm32::adc::SampleTime::Cycles112);
+
+    // Switching alternatively between ADC continuous mode with DMA and ADC single reading
+    loop {
+        let tic = Instant::now();
+        continous_read(&mut adc, &mut pin).await;
+        let toc = Instant::elapsed(&tic);
+        info!("Elapsed: {} ", toc.as_micros());
+        Timer::after_millis(1000).await;
+    }
+
+    // single_read(&mut adc, &mut pin).await;
+
+    // continous_read(&mut adc, &mut pin).await;
+}

--- a/examples/stm32f7/Cargo.toml
+++ b/examples/stm32f7/Cargo.toml
@@ -6,7 +6,7 @@ license = "MIT OR Apache-2.0"
 
 [dependencies]
 # Change stm32f767zi to your chip name, if necessary.
-embassy-stm32 = { version = "0.1.0", path = "../../embassy-stm32", features = ["defmt", "stm32f767zi", "memory-x", "unstable-pac", "time-driver-any", "exti"]  }
+embassy-stm32 = { version = "0.1.0", path = "../../embassy-stm32", features = ["defmt", "stm32f405vg", "memory-x", "unstable-pac", "time-driver-any", "exti"]  }
 embassy-sync = { version = "0.5.0", path = "../../embassy-sync", features = ["defmt"] }
 embassy-executor = { version = "0.4.0", path = "../../embassy-executor", features = ["arch-cortex-m", "executor-thread", "defmt", "integrated-timers"] }
 embassy-time = { version = "0.2", path = "../../embassy-time", features = ["defmt", "defmt-timestamp-uptime", "tick-hz-32_768"] }

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,6 +1,6 @@
 [toolchain]
-channel = "beta-2023-12-17"
-components = [ "rust-src", "rustfmt", "llvm-tools" ]
+channel = "nightly-2023-12-20"
+components = [ "rust-src", "rustfmt", "llvm-tools", "miri" ]
 targets = [
     "thumbv7em-none-eabi",
     "thumbv7m-none-eabi",

--- a/turbo.sh
+++ b/turbo.sh
@@ -1,0 +1,179 @@
+#!/bin/bash
+
+set -e
+
+nightly=nightly-2023-12-20
+rustup install $nightly
+rustup component add rust-src --toolchain $nightly
+core=$HOME/.rustup/toolchains/$nightly-aarch64-apple-darwin/lib/rustlib/src/rust/library/core
+
+test -d $core
+
+if [ -f $core/Cargo.toml.turbo-bak ]; then
+    mv $core/Cargo.toml.turbo-bak $core/Cargo.toml
+fi
+if [ -f $core/src/task/wake.rs.turbo-bak ]; then
+    mv $core/src/task/wake.rs.turbo-bak $core/src/task/wake.rs
+fi
+
+cp $core/Cargo.toml $core/Cargo.toml.turbo-bak
+cp $core/src/task/wake.rs $core/src/task/wake.rs.turbo-bak 
+
+patch $core/Cargo.toml <<"EOF"
+*** Cargo.toml.turbo-bak	2023-03-07 00:26:08.627557642 +0100
+--- Cargo.toml	2023-03-07 00:26:54.764578210 +0100
+***************
+*** 33,35 ****
+--- 33,36 ----
+  # Make `RefCell` store additional debugging information, which is printed out when
+  # a borrow error occurs
+  debug_refcell = []
++ turbowakers = []
+EOF
+
+patch $core/src/task/wake.rs <<"EOF"
+*** src/task/wake.rs.turbo-bak	2023-03-07 00:22:10.825721535 +0100
+--- src/task/wake.rs	2023-03-07 00:22:10.825721535 +0100
+***************
+*** 235,240 ****
+--- 235,243 ----
+  #[repr(transparent)]
+  #[stable(feature = "futures_api", since = "1.36.0")]
+  pub struct Waker {
++     #[cfg(feature = "turbowakers")]
++     ptr: crate::ptr::NonNull<()>,
++     #[cfg(not(feature = "turbowakers"))]
+      waker: RawWaker,
+  }
+  
+***************
+*** 245,250 ****
+--- 248,256 ----
+  #[stable(feature = "futures_api", since = "1.36.0")]
+  unsafe impl Sync for Waker {}
+  
++ #[cfg(not(feature = "turbowakers"))]
++ mod waker {
++ use super::*;
+  impl Waker {
+      /// Wake up the task associated with this `Waker`.
+      ///
+***************
+*** 365,367 ****
+--- 371,485 ----
+              .finish()
+      }
+  }
++ }
++ 
++ #[cfg(feature = "turbowakers")]
++ mod waker {
++     use crate::ptr::NonNull;
++ 
++     use super::*;
++     extern "Rust" {
++         fn _turbo_wake(ptr: NonNull<()>);
++     }
++ 
++     impl Waker {
++         /// Wake up the task associated with this `Waker`.
++         ///
++         /// As long as the executor keeps running and the task is not finished, it is
++         /// guaranteed that each invocation of [`wake()`](Self::wake) (or
++         /// [`wake_by_ref()`](Self::wake_by_ref)) will be followed by at least one
++         /// [`poll()`] of the task to which this `Waker` belongs. This makes
++         /// it possible to temporarily yield to other tasks while running potentially
++         /// unbounded processing loops.
++         ///
++         /// Note that the above implies that multiple wake-ups may be coalesced into a
++         /// single [`poll()`] invocation by the runtime.
++         ///
++         /// Also note that yielding to competing tasks is not guaranteed: it is the
++         /// executor’s choice which task to run and the executor may choose to run the
++         /// current task again.
++         ///
++         /// [`poll()`]: crate::future::Future::poll
++         #[inline]
++         #[stable(feature = "futures_api", since = "1.36.0")]
++         pub fn wake(self) {
++             unsafe { _turbo_wake(self.ptr) }
++         }
++ 
++         /// Wake up the task associated with this `Waker` without consuming the `Waker`.
++         ///
++         /// This is similar to [`wake()`](Self::wake), but may be slightly less efficient in
++         /// the case where an owned `Waker` is available. This method should be preferred to
++         /// calling `waker.clone().wake()`.
++         #[inline]
++         #[stable(feature = "futures_api", since = "1.36.0")]
++         pub fn wake_by_ref(&self) {
++             unsafe { _turbo_wake(self.ptr) }
++         }
++ 
++         /// Returns `true` if this `Waker` and another `Waker` would awake the same task.
++         ///
++         /// This function works on a best-effort basis, and may return false even
++         /// when the `Waker`s would awaken the same task. However, if this function
++         /// returns `true`, it is guaranteed that the `Waker`s will awaken the same task.
++         ///
++         /// This function is primarily used for optimization purposes.
++         #[inline]
++         #[must_use]
++         #[stable(feature = "futures_api", since = "1.36.0")]
++         pub fn will_wake(&self, other: &Waker) -> bool {
++             self.ptr == other.ptr
++         }
++ 
++         /// Creates a new `Waker` from [`RawWaker`].
++         ///
++         /// The behavior of the returned `Waker` is undefined if the contract defined
++         /// in [`RawWaker`]'s and [`RawWakerVTable`]'s documentation is not upheld.
++         /// Therefore this method is unsafe.
++         #[inline]
++         #[must_use]
++         #[stable(feature = "futures_api", since = "1.36.0")]
++         #[rustc_const_unstable(feature = "const_waker", issue = "102012")]
++         pub const unsafe fn from_raw(waker: RawWaker) -> Waker {
++             panic!("Waker::from_raw is unavailable due to enabling turbowakers.");
++         }
++ 
++         /// Get a reference to the underlying [`RawWaker`].
++         #[inline]
++         #[must_use]
++         #[unstable(feature = "waker_getters", issue = "87021")]
++         pub fn as_raw(&self) -> &RawWaker {
++             panic!("Waker::as_raw is unavailable due to enabling turbowakers.");
++         }
++ 
++         #[inline]
++         #[must_use]
++         #[stable(feature = "futures_api", since = "1.36.0")]
++         #[rustc_const_unstable(feature = "const_waker", issue = "102012")]
++         pub const unsafe fn from_turbo_ptr(ptr: NonNull<()>) -> Waker {
++             Self { ptr }
++         }
++ 
++         #[inline]
++         #[must_use]
++         #[stable(feature = "futures_api", since = "1.36.0")]
++         pub fn as_turbo_ptr(&self) -> NonNull<()> {
++             self.ptr
++         }
++     }
++ 
++     #[stable(feature = "futures_api", since = "1.36.0")]
++     impl Clone for Waker {
++         #[inline]
++         fn clone(&self) -> Self {
++             Self { ptr: self.ptr }
++         }
++     }
++ 
++     #[stable(feature = "futures_api", since = "1.36.0")]
++     impl fmt::Debug for Waker {
++         fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
++             f.debug_struct("Waker").field("data", &self.ptr).finish()
++         }
++     }
++ }
+EOF


### PR DESCRIPTION
**Note**: Note even close to merging yet, just opening the PR for some feedback from maintainers.

Done:
- adc_v2 now uses ADC interrupt to trigger wakers for async impls. 
  - adc.read().await; works!
 
WIP:
- Scan-mode single-shot down to about 50uS with WFE & normal wakers.
  - Needs to use AdcPin instead of &[u8] of channels for safe access to peripheral.
  - Each call to .read_sample_sequence().await requires re-configuration of the ADC, should be broken up into a configure step and a run step.
 
Todo:
- Need DMA for continuous mode & general speedup.
- Need to look into adc_v2. calibration methods.
- Reconsider the interrupt mechanism. (masking the entire peripheral interrupt seems inefficient)
- Consider adccommon steps for interleaved sampling
- Look into burst mode for short data capture of high time-resolution data. Might be better to use timers/atomics here instead of DMA?