### PR TITLE
STM32: Re-enable I2Cv1 Interrupts if poll-fn is not ready

### DIFF
--- a/embassy-stm32/src/i2c/v1.rs
+++ b/embassy-stm32/src/i2c/v1.rs
@@ -375,6 +375,9 @@ impl<'d, T: Instance, TXDMA, RXDMA> I2c<'d, T, TXDMA, RXDMA> {
                         T::regs().sr2().read();
                         Poll::Ready(Ok(()))
                     } else {
+                        // If we need to go around, then re-enable the interrupts, otherwise nothing
+                        // can wake us up and we'll hang.
+                        Self::enable_interrupts();
                         Poll::Pending
                     }
                 }


### PR DESCRIPTION
This seems to help with my hanging problem, though I'm unsure if this
is the "right" solution.

If it is, it is possible we should do this in more places, since interrupts seem to usually disable themselves after firing.