### PR TITLE
Add low-power support for stm32l5

### DIFF
--- a/embassy-stm32/src/rtc/v3.rs
+++ b/embassy-stm32/src/rtc/v3.rs
@@ -135,6 +135,12 @@ impl sealed::Instance for crate::peripherals::RTC {
     #[cfg(all(feature = "low-power", stm32g4))]
     type WakeupInterrupt = crate::interrupt::typelevel::RTC_WKUP;
 
+    #[cfg(all(feature = "low-power", stm32l5))]
+    const EXTI_WAKEUP_LINE: usize = 17;
+
+    #[cfg(all(feature = "low-power", stm32l5))]
+    type WakeupInterrupt = crate::interrupt::typelevel::RTC;
+
     fn read_backup_register(_rtc: &Rtc, register: usize) -> Option<u32> {
         #[allow(clippy::if_same_then_else)]
         if register < Self::BACKUP_REGISTER_COUNT {


### PR DESCRIPTION
This PR adds support for the low-power executor for the STM32L5 series. I tested this with a NUCLEO-L552ZE-Q board.

This PR depends on this PR in stm32-data: embassy-rs/stm32-data#325