### PR TITLE
dbgmcu: set bits to false when disabled

### DIFF
--- a/embassy-stm32/src/lib.rs
+++ b/embassy-stm32/src/lib.rs
@@ -208,32 +208,30 @@ pub fn init(config: Config) -> Peripherals {
         let p = Peripherals::take_with_cs(cs);
 
         #[cfg(dbgmcu)]
-        if config.enable_debug_during_sleep {
-            crate::pac::DBGMCU.cr().modify(|cr| {
-                #[cfg(any(dbgmcu_f0, dbgmcu_c0, dbgmcu_g0, dbgmcu_u5, dbgmcu_wba))]
-                {
-                    cr.set_dbg_stop(true);
-                    cr.set_dbg_standby(true);
-                }
-                #[cfg(any(
-                    dbgmcu_f1, dbgmcu_f2, dbgmcu_f3, dbgmcu_f4, dbgmcu_f7, dbgmcu_g4, dbgmcu_f7, dbgmcu_l0, dbgmcu_l1,
-                    dbgmcu_l4, dbgmcu_wb, dbgmcu_wl
-                ))]
-                {
-                    cr.set_dbg_sleep(true);
-                    cr.set_dbg_stop(true);
-                    cr.set_dbg_standby(true);
-                }
-                #[cfg(dbgmcu_h7)]
-                {
-                    cr.set_d1dbgcken(true);
-                    cr.set_d3dbgcken(true);
-                    cr.set_dbgsleep_d1(true);
-                    cr.set_dbgstby_d1(true);
-                    cr.set_dbgstop_d1(true);
-                }
-            });
-        }
+        crate::pac::DBGMCU.cr().modify(|cr| {
+            #[cfg(any(dbgmcu_f0, dbgmcu_c0, dbgmcu_g0, dbgmcu_u5, dbgmcu_wba))]
+            {
+                cr.set_dbg_stop(config.enable_debug_during_sleep);
+                cr.set_dbg_standby(config.enable_debug_during_sleep);
+            }
+            #[cfg(any(
+                dbgmcu_f1, dbgmcu_f2, dbgmcu_f3, dbgmcu_f4, dbgmcu_f7, dbgmcu_g4, dbgmcu_f7, dbgmcu_l0, dbgmcu_l1,
+                dbgmcu_l4, dbgmcu_wb, dbgmcu_wl
+            ))]
+            {
+                cr.set_dbg_sleep(config.enable_debug_during_sleep);
+                cr.set_dbg_stop(config.enable_debug_during_sleep);
+                cr.set_dbg_standby(config.enable_debug_during_sleep);
+            }
+            #[cfg(dbgmcu_h7)]
+            {
+                cr.set_d1dbgcken(config.enable_debug_during_sleep);
+                cr.set_d3dbgcken(config.enable_debug_during_sleep);
+                cr.set_dbgsleep_d1(config.enable_debug_during_sleep);
+                cr.set_dbgstby_d1(config.enable_debug_during_sleep);
+                cr.set_dbgstop_d1(config.enable_debug_during_sleep);
+            }
+        });
 
         #[cfg(not(any(stm32f1, stm32wb, stm32wl)))]
         peripherals::SYSCFG::enable_and_reset_with_cs(cs);


### PR DESCRIPTION
Apparently the dbg_stop bits etc keep the value true over a reset. This means when it is set to true once you have to power off the mcu to reset it to false. I was able to reproduce this on my NUCLEO-L552ZE-Q.

With this PR when setting config.enable_debug_during_sleep to false it sets the dbg_stop bits etc. to false.

