### PR TITLE
Reset rx_started state of nrf buffered_uarte on init

### DIFF
--- a/embassy-nrf/src/buffered_uarte.rs
+++ b/embassy-nrf/src/buffered_uarte.rs
@@ -342,6 +342,7 @@ impl<'d, U: UarteInstance, T: TimerInstance> BufferedUarte<'d, U, T> {
         s.tx_count.store(0, Ordering::Relaxed);
         s.rx_started_count.store(0, Ordering::Relaxed);
         s.rx_ended_count.store(0, Ordering::Relaxed);
+        s.rx_started.store(false, Ordering::Relaxed);
         let len = tx_buffer.len();
         unsafe { s.tx_buf.init(tx_buffer.as_mut_ptr(), len) };
         let len = rx_buffer.len();


### PR DESCRIPTION
This was likely forgotten as part of c46418f12. Without this, when creating a uarte instance, dropping it and then creating another instance, this instance would never receive any bytes.

Please note that I've not yet understood the whole uarte interrupt machinery in it's entirety, but only made this change based on "pattern matching" and the observation that `rx_started` is not reset otherwise. I have observed tested that this change makes the "enable -> disable -> enable" use case work again after c46418f12 in my project, though. Maybe @Dirbaio as the author of c46418f12 can review this?