### PR TITLE
low-power: add stop support for stm32l5

### DIFF
--- a/embassy-stm32/Cargo.toml
+++ b/embassy-stm32/Cargo.toml
@@ -57,7 +57,7 @@ futures = { version = "0.3.17", default-features = false, features = ["async-awa
 rand_core = "0.6.3"
 sdio-host = "0.5.0"
 critical-section = "1.1"
-stm32-metapac = { git = "https://github.com/embassy-rs/stm32-data-generated", tag = "stm32-data-8caf2f0bda28baf4393899dc67ba57f058087f5a" }
+stm32-metapac = { git = "https://github.com/embassy-rs/stm32-data-generated", tag = "stm32-data-4d06d091219322837b7cef21748a180d09d7a34f" }
 vcell = "0.1.3"
 bxcan = "0.7.0"
 nb = "1.0.0"
@@ -75,7 +75,7 @@ critical-section = { version = "1.1", features = ["std"] }
 [build-dependencies]
 proc-macro2 = "1.0.36"
 quote = "1.0.15"
-stm32-metapac = { git = "https://github.com/embassy-rs/stm32-data-generated", tag = "stm32-data-8caf2f0bda28baf4393899dc67ba57f058087f5a", default-features = false, features = ["metadata"]}
+stm32-metapac = { git = "https://github.com/embassy-rs/stm32-data-generated", tag = "stm32-data-4d06d091219322837b7cef21748a180d09d7a34f", default-features = false, features = ["metadata"]}
 
 
 [features]

--- a/embassy-stm32/Cargo.toml
+++ b/embassy-stm32/Cargo.toml
@@ -24,7 +24,7 @@ flavors = [
     { regex_feature = "stm32l0.*", target = "thumbv6m-none-eabi", features = ["low-power"] },
     { regex_feature = "stm32l1.*", target = "thumbv7m-none-eabi" },
     { regex_feature = "stm32l4.*", target = "thumbv7em-none-eabi" },
-    { regex_feature = "stm32l5.*", target = "thumbv8m.main-none-eabihf" },
+    { regex_feature = "stm32l5.*", target = "thumbv8m.main-none-eabihf", features = ["low-power"] },
     { regex_feature = "stm32u5.*", target = "thumbv8m.main-none-eabihf" },
     { regex_feature = "stm32wb.*", target = "thumbv7em-none-eabi" },
     { regex_feature = "stm32wba.*", target = "thumbv8m.main-none-eabihf" },

--- a/embassy-stm32/src/lib.rs
+++ b/embassy-stm32/src/lib.rs
@@ -209,7 +209,7 @@ pub fn init(config: Config) -> Peripherals {
 
         #[cfg(dbgmcu)]
         crate::pac::DBGMCU.cr().modify(|cr| {
-            #[cfg(any(dbgmcu_f0, dbgmcu_c0, dbgmcu_g0, dbgmcu_u5, dbgmcu_wba))]
+            #[cfg(any(dbgmcu_f0, dbgmcu_c0, dbgmcu_g0, dbgmcu_u5, dbgmcu_wba, dbgmcu_l5))]
             {
                 cr.set_dbg_stop(config.enable_debug_during_sleep);
                 cr.set_dbg_standby(config.enable_debug_during_sleep);

--- a/embassy-stm32/src/lib.rs
+++ b/embassy-stm32/src/lib.rs
@@ -157,7 +157,7 @@ pub struct Config {
     /// RCC config.
     pub rcc: rcc::Config,
 
-    /// Enable debug during sleep.
+    /// Enable debug during sleep and stop.
     ///
     /// May incrase power consumption. Defaults to true.
     #[cfg(dbgmcu)]

--- a/embassy-stm32/src/low_power.rs
+++ b/embassy-stm32/src/low_power.rs
@@ -179,6 +179,7 @@ impl Executor {
         }
     }
 
+    #[allow(unused_variables)]
     fn configure_stop(&mut self, stop_mode: StopMode) {
         #[cfg(stm32l5)]
         crate::pac::PWR.cr1().modify(|m| m.set_lpms(stop_mode.into()));

--- a/embassy-stm32/src/low_power.rs
+++ b/embassy-stm32/src/low_power.rs
@@ -37,6 +37,8 @@
 //! async fn async_main(spawner: Spawner) {
 //!     // initialize the platform...
 //!     let mut config = embassy_stm32::Config::default();
+//!     // when enabled the power-consumption is much higher during stop, but debugging and RTT is working
+//!     config.enable_debug_during_sleep = false;
 //!     let p = embassy_stm32::init(config);
 //!
 //!     // give the RTC to the executor...
@@ -107,6 +109,19 @@ pub enum StopMode {
     Stop2,
 }
 
+#[cfg(stm32l5)]
+use stm32_metapac::pwr::vals::Lpms;
+
+#[cfg(stm32l5)]
+impl Into<Lpms> for StopMode {
+    fn into(self) -> Lpms {
+        match self {
+            StopMode::Stop1 => Lpms::STOP1,
+            StopMode::Stop2 => Lpms::STOP2,
+        }
+    }
+}
+
 /// Thread mode executor, using WFE/SEV.
 ///
 /// This is the simplest and most common kind of executor. It runs on
@@ -164,8 +179,9 @@ impl Executor {
         }
     }
 
-    fn configure_stop(&mut self, _stop_mode: StopMode) {
-        // TODO: configure chip-specific settings for stop
+    fn configure_stop(&mut self, stop_mode: StopMode) {
+        #[cfg(stm32l5)]
+        crate::pac::PWR.cr1().modify(|m| m.set_lpms(stop_mode.into()));
     }
 
     fn configure_pwr(&mut self) {

--- a/examples/stm32l5/Cargo.toml
+++ b/examples/stm32l5/Cargo.toml
@@ -6,7 +6,7 @@ license = "MIT OR Apache-2.0"
 
 [dependencies]
 # Change stm32l552ze to your chip name, if necessary.
-embassy-stm32 = { version = "0.1.0", path = "../../embassy-stm32", features = [ "defmt", "unstable-pac", "stm32l552ze", "time-driver-any", "exti", "memory-x"]  }
+embassy-stm32 = { version = "0.1.0", path = "../../embassy-stm32", features = [ "defmt", "unstable-pac", "stm32l552ze", "time-driver-any", "exti", "memory-x", "low-power"]  }
 embassy-sync = { version = "0.5.0", path = "../../embassy-sync", features = ["defmt"] }
 embassy-executor = { version = "0.4.0", path = "../../embassy-executor", features = ["task-arena-size-32768", "arch-cortex-m", "executor-thread", "defmt", "integrated-timers"] }
 embassy-time = { version = "0.2", path = "../../embassy-time", features = ["defmt", "defmt-timestamp-uptime", "tick-hz-32_768"] }
@@ -30,3 +30,7 @@ static_cell = "2"
 
 [profile.release]
 debug = 2
+
+[[bin]]
+name = "stop"
+default-features = ["embassy-stm32/low-power"]

--- a/examples/stm32l5/src/bin/stop.rs
+++ b/examples/stm32l5/src/bin/stop.rs
@@ -1,0 +1,61 @@
+#![no_std]
+#![no_main]
+
+use defmt::*;
+use embassy_executor::Spawner;
+use embassy_stm32::gpio::{Level, Output, Speed, AnyPin};
+use embassy_stm32::low_power::Executor;
+use embassy_stm32::rtc::{Rtc, RtcConfig};
+use embassy_stm32::Config;
+use embassy_stm32::rcc::LsConfig;
+use embassy_time::Timer;
+use static_cell::StaticCell;
+use {defmt_rtt as _, panic_probe as _};
+
+#[cortex_m_rt::entry]
+fn main() -> ! {
+    Executor::take().run(|spawner| {
+        unwrap!(spawner.spawn(async_main(spawner)));
+    })
+}
+
+#[embassy_executor::task]
+async fn async_main(spawner: Spawner) {
+    let mut config = Config::default();
+    config.rcc.ls = LsConfig::default_lsi();
+    // when enabled the power-consumption is much higher during stop, but debugging and RTT is working
+    // if you wan't to measure the power-consumption, or for production: uncomment this line
+    // config.enable_debug_during_sleep = false;
+    let p = embassy_stm32::init(config);
+
+    // give the RTC to the executor...
+    let rtc = Rtc::new(p.RTC, RtcConfig::default());
+    static RTC: StaticCell<Rtc> = StaticCell::new();
+    let rtc = RTC.init(rtc);
+    embassy_stm32::low_power::stop_with_rtc(rtc);
+
+    unwrap!(spawner.spawn(blinky(p.PC7.into())));
+    unwrap!(spawner.spawn(timeout()));
+}
+
+#[embassy_executor::task]
+async fn blinky(led: AnyPin) -> ! {
+    let mut led = Output::new(led, Level::Low, Speed::Low);
+    loop {
+        info!("high");
+        led.set_high();
+        Timer::after_millis(300).await;
+
+        info!("low");
+        led.set_low();
+        Timer::after_millis(300).await;
+    }
+}
+
+// when enable_debug_during_sleep is false, it is more difficult to reprogram the MCU
+// therefore we block the MCU after 30s to be able to reprogram it easily
+#[embassy_executor::task]
+async fn timeout() -> ! {
+    Timer::after_secs(30).await;
+    loop {}
+}

--- a/examples/stm32l5/src/bin/stop.rs
+++ b/examples/stm32l5/src/bin/stop.rs
@@ -3,11 +3,11 @@
 
 use defmt::*;
 use embassy_executor::Spawner;
-use embassy_stm32::gpio::{Level, Output, Speed, AnyPin};
+use embassy_stm32::gpio::{AnyPin, Level, Output, Speed};
 use embassy_stm32::low_power::Executor;
+use embassy_stm32::rcc::LsConfig;
 use embassy_stm32::rtc::{Rtc, RtcConfig};
 use embassy_stm32::Config;
-use embassy_stm32::rcc::LsConfig;
 use embassy_time::Timer;
 use static_cell::StaticCell;
 use {defmt_rtt as _, panic_probe as _};


### PR DESCRIPTION
This PR adds support for the low-power modes STOP1 and STOP2. 

In this image enable_debug_during_sleep is true (by default) and the power-consumption is around 700uA. This is already better than normal because of the sleep mode.
![l5-debug-true](https://github.com/embassy-rs/embassy/assets/7701334/37c6de1d-eb49-4291-bfe5-e037d5ac47fd)

In this image enable_debug_during_sleep is set to false and the power-consumption is much lower (170uA). The blinky example has a pretty high interval (300ms). With a lower interval I tested a power-consumption of ~12uA (no wakeup in this measurement). With an interval of 1s I measured around 50uA (active led uses 60uA).
![l5-debug-false](https://github.com/embassy-rs/embassy/assets/7701334/05633400-58c9-4dac-a8ab-5bf28b61531e)
