### PR TITLE
Add Missing Clocks on G0 to `Clocks`

### DIFF
--- a/embassy-stm32/build.rs
+++ b/embassy-stm32/build.rs
@@ -505,7 +505,7 @@ fn main() {
                 (TokenStream::new(), TokenStream::new())
             };
 
-            let mux_supported = HashSet::from(["c0", "h5", "h50", "h7", "h7ab", "h7rm0433", "g4", "l4"])
+            let mux_supported = HashSet::from(["c0", "h5", "h50", "h7", "h7ab", "h7rm0433", "g0", "g4", "l4"])
                 .contains(rcc_registers.version);
             let mux_for = |mux: Option<&'static PeripheralRccRegister>| {
                 // restrict mux implementation to supported versions
@@ -534,7 +534,7 @@ fn main() {
                             let variant_name = format_ident!("{}", v.name);
                             let clock_name = format_ident!("{}", v.name.to_ascii_lowercase());
 
-                            if v.name.starts_with("HCLK") || v.name.starts_with("PCLK") || v.name == "SYS" { 
+                            if v.name.starts_with("HCLK") || v.name.starts_with("PCLK") || v.name == "SYS" {
                                 quote! {
                                     #enum_name::#variant_name => unsafe { crate::rcc::get_freqs().#clock_name },
                                 }

--- a/embassy-stm32/src/rcc/g0.rs
+++ b/embassy-stm32/src/rcc/g0.rs
@@ -299,7 +299,9 @@ pub(crate) unsafe fn init(config: Config) {
     let lse_freq = config.ls.lse.map(|lse| lse.frequency);
 
     let hsi_freq = (sw == Sw::HSI).then_some(HSI_FREQ);
+    let hsi_div_8_freq = hsi_freq.map(|f| f / 8u32);
     let lsi_freq = (sw == Sw::LSI).then_some(super::LSI_FREQ);
+    let hse_freq = (sw == Sw::HSE).then_some(sys_clk);
 
     set_freqs(Clocks {
         sys: sys_clk,
@@ -307,6 +309,9 @@ pub(crate) unsafe fn init(config: Config) {
         pclk1: apb_freq,
         pclk1_tim: apb_tim_freq,
         hsi: hsi_freq,
+        hsi48: None,
+        hsi_div_8: hsi_div_8_freq,
+        hse: hse_freq,
         lse: lse_freq,
         lsi: lsi_freq,
         pll1_q: pll1_q_freq,

--- a/embassy-stm32/src/rcc/mod.rs
+++ b/embassy-stm32/src/rcc/mod.rs
@@ -162,8 +162,10 @@ pub struct Clocks {
 
     #[cfg(any(stm32h5, stm32h7, rcc_l4, rcc_c0, stm32g0))]
     pub hsi: Option<Hertz>,
-    #[cfg(stm32h5)]
+    #[cfg(any(stm32h5, stm32g0))]
     pub hsi48: Option<Hertz>,
+    #[cfg(stm32g0)]
+    pub hsi_div_8: Option<Hertz>,
     #[cfg(any(stm32g0, stm32h5))]
     pub lsi: Option<Hertz>,
     #[cfg(any(stm32h5, stm32h7))]
@@ -171,7 +173,7 @@ pub struct Clocks {
 
     #[cfg(any(stm32h5, stm32h7, rcc_l4, rcc_c0, stm32g0))]
     pub lse: Option<Hertz>,
-    #[cfg(any(stm32h5, stm32h7, stm32g4))]
+    #[cfg(any(stm32h5, stm32h7, stm32g0, stm32g4))]
     pub hse: Option<Hertz>,
 
     #[cfg(stm32h5)]

--- a/embassy-stm32/src/rcc/mod.rs
+++ b/embassy-stm32/src/rcc/mod.rs
@@ -121,9 +121,9 @@ pub struct Clocks {
     #[cfg(rcc_l4)]
     pub pllsai2_p: Option<Hertz>,
 
-    #[cfg(any(stm32g4, rcc_l4))]
+    #[cfg(any(stm32g0, stm32g4, rcc_l4))]
     pub pll1_p: Option<Hertz>,
-    #[cfg(any(stm32h5, stm32h7, stm32f2, stm32f4, stm32f7, rcc_l4, stm32g4))]
+    #[cfg(any(stm32h5, stm32h7, stm32f2, stm32f4, stm32f7, rcc_l4, stm32g0, stm32g4))]
     pub pll1_q: Option<Hertz>,
     #[cfg(any(stm32h5, stm32h7))]
     pub pll2_p: Option<Hertz>,
@@ -160,16 +160,16 @@ pub struct Clocks {
 
     pub rtc: Option<Hertz>,
 
-    #[cfg(any(stm32h5, stm32h7, rcc_l4, rcc_c0))]
+    #[cfg(any(stm32h5, stm32h7, rcc_l4, rcc_c0, stm32g0))]
     pub hsi: Option<Hertz>,
     #[cfg(stm32h5)]
     pub hsi48: Option<Hertz>,
-    #[cfg(stm32h5)]
+    #[cfg(any(stm32g0, stm32h5))]
     pub lsi: Option<Hertz>,
     #[cfg(any(stm32h5, stm32h7))]
     pub csi: Option<Hertz>,
 
-    #[cfg(any(stm32h5, stm32h7, rcc_l4, rcc_c0))]
+    #[cfg(any(stm32h5, stm32h7, rcc_l4, rcc_c0, stm32g0))]
     pub lse: Option<Hertz>,
     #[cfg(any(stm32h5, stm32h7, stm32g4))]
     pub hse: Option<Hertz>,


### PR DESCRIPTION
Many clocks in the G0 were not listed nor configurable, this resulted in the PWM frequency calculation being wrong, amongst other things.