### PR TITLE
impl ReadReady and WriteReady for tcp

### DIFF
--- a/embassy-net/src/tcp.rs
+++ b/embassy-net/src/tcp.rs
@@ -547,6 +547,12 @@ mod embedded_io_impls {
         }
     }
 
+    impl<'d> embedded_io_async::ReadReady for TcpSocket<'d> {
+        fn read_ready(&mut self) -> Result<bool, Self::Error> {
+            Ok(self.io.with(|s, _| s.may_recv()))
+        }
+    }
+
     impl<'d> embedded_io_async::Write for TcpSocket<'d> {
         async fn write(&mut self, buf: &[u8]) -> Result<usize, Self::Error> {
             self.io.write(buf).await
@@ -557,6 +563,12 @@ mod embedded_io_impls {
         }
     }
 
+    impl<'d> embedded_io_async::WriteReady for TcpSocket<'d> {
+        fn write_ready(&mut self) -> Result<bool, Self::Error> {
+            Ok(self.io.with(|s, _| s.may_send()))
+        }
+    }
+
     impl<'d> embedded_io_async::ErrorType for TcpReader<'d> {
         type Error = Error;
     }
@@ -564,6 +576,12 @@ mod embedded_io_impls {
     impl<'d> embedded_io_async::Read for TcpReader<'d> {
         async fn read(&mut self, buf: &mut [u8]) -> Result<usize, Self::Error> {
             self.io.read(buf).await
+        }
+    }
+
+    impl<'d> embedded_io_async::ReadReady for TcpReader<'d> {
+        fn read_ready(&mut self) -> Result<bool, Self::Error> {
+            Ok(self.io.with(|s, _| s.may_recv()))
         }
     }
 
@@ -578,6 +596,12 @@ mod embedded_io_impls {
 
         async fn flush(&mut self) -> Result<(), Self::Error> {
             self.io.flush().await
+        }
+    }
+
+    impl<'d> embedded_io_async::WriteReady for TcpWriter<'d> {
+        fn write_ready(&mut self) -> Result<bool, Self::Error> {
+            Ok(self.io.with(|s, _| s.may_send()))
         }
     }
 }


### PR DESCRIPTION
ref: #1890 

This PR aims to implement `embedded_io_async::ReadReady` and `embedded_io_async::WriteReady` traits for `TcpSocket` as well as `TcpReader`/`TcpWriter`

I saw there are already existing fns ( `may_recv()` and `may_send()` ) which are basically the same, so I just wrapped them in trait impl ( like it is done for other traits )

Though, traits expects to return an `Error` ( whenever there is io error ), but implementation of `may_recv()` or `may_send()` return a `bool` instead of `Result<>`! please let me know if something else was expected here!

Thank you :smile: 