### PR TITLE
Update STM32 RCC U5 to support P and Q dividers

### DIFF
--- a/embassy-stm32/src/rcc/u5.rs
+++ b/embassy-stm32/src/rcc/u5.rs
@@ -45,6 +45,18 @@ pub struct PllConfig {
     /// The multiplied clock – `source` divided by `m` times `n` – must be between 128 and 544
     /// MHz. The upper limit may be lower depending on the `Config { voltage_range }`.
     pub n: Plln,
+    /// The divider for the P output.
+    ///
+    /// When used to drive the system clock, `source` divided by `m` times `n` divided by `r`
+    /// must not exceed 160 MHz. System clocks above 55 MHz require a non-default
+    /// `Config { voltage_range }`.
+    pub p: Plldiv,
+    /// The divider for the Q output.
+    ///
+    /// When used to drive the system clock, `source` divided by `m` times `n` divided by `r`
+    /// must not exceed 160 MHz. System clocks above 55 MHz require a non-default
+    /// `Config { voltage_range }`.
+    pub q: Plldiv,
     /// The divider for the R output.
     ///
     /// When used to drive the system clock, `source` divided by `m` times `n` divided by `r`
@@ -60,6 +72,8 @@ impl PllConfig {
             source: PllSource::HSI,
             m: Pllm::DIV1,
             n: Plln::MUL10,
+            p: Plldiv::DIV3,
+            q: Plldiv::DIV2,
             r: Plldiv::DIV1,
         }
     }
@@ -70,6 +84,8 @@ impl PllConfig {
             source: PllSource::MSIS(Msirange::RANGE_48MHZ),
             m: Pllm::DIV3,
             n: Plln::MUL10,
+            p: Plldiv::DIV3,
+            q: Plldiv::DIV2,
             r: Plldiv::DIV1,
         }
     }
@@ -301,6 +317,8 @@ pub(crate) unsafe fn init(config: Config) {
             RCC.pll1divr().modify(|w| {
                 // Set the VCO multiplier
                 w.set_plln(pll.n);
+                w.set_pllp(pll.p);
+                w.set_pllq(pll.q);
                 // Set the R output divisor
                 w.set_pllr(pll.r);
             });

--- a/embassy-stm32/src/rcc/u5.rs
+++ b/embassy-stm32/src/rcc/u5.rs
@@ -45,13 +45,13 @@ pub struct PllConfig {
     /// The multiplied clock – `source` divided by `m` times `n` – must be between 128 and 544
     /// MHz. The upper limit may be lower depending on the `Config { voltage_range }`.
     pub n: Plln,
-    /// The divider for the P output. 
-    /// 
+    /// The divider for the P output.
+    ///
     /// The P output is one of several options
     /// that can be used to feed the SAI/MDF/ADF Clock mux's.
     pub p: Plldiv,
-    /// The divider for the Q output. 
-    /// 
+    /// The divider for the Q output.
+    ///
     /// The Q ouput is one of severals options that can be used to feed the 48MHz clocks
     /// and the OCTOSPI clock. It may also be used on the MDF/ADF clock mux's.
     pub q: Plldiv,

--- a/embassy-stm32/src/rcc/u5.rs
+++ b/embassy-stm32/src/rcc/u5.rs
@@ -45,17 +45,15 @@ pub struct PllConfig {
     /// The multiplied clock – `source` divided by `m` times `n` – must be between 128 and 544
     /// MHz. The upper limit may be lower depending on the `Config { voltage_range }`.
     pub n: Plln,
-    /// The divider for the P output.
-    ///
-    /// When used to drive the system clock, `source` divided by `m` times `n` divided by `r`
-    /// must not exceed 160 MHz. System clocks above 55 MHz require a non-default
-    /// `Config { voltage_range }`.
+    /// The divider for the P output. 
+    /// 
+    /// The P output is one of several options
+    /// that can be used to feed the SAI/MDF/ADF Clock mux's.
     pub p: Plldiv,
-    /// The divider for the Q output.
-    ///
-    /// When used to drive the system clock, `source` divided by `m` times `n` divided by `r`
-    /// must not exceed 160 MHz. System clocks above 55 MHz require a non-default
-    /// `Config { voltage_range }`.
+    /// The divider for the Q output. 
+    /// 
+    /// The Q ouput is one of severals options that can be used to feed the 48MHz clocks
+    /// and the OCTOSPI clock. It may also be used on the MDF/ADF clock mux's.
     pub q: Plldiv,
     /// The divider for the R output.
     ///

--- a/examples/stm32u5/src/bin/usb_serial.rs
+++ b/examples/stm32u5/src/bin/usb_serial.rs
@@ -26,6 +26,8 @@ async fn main(_spawner: Spawner) {
         source: PllSource::HSI,
         m: Pllm::DIV2,
         n: Plln::MUL10,
+        p: Plldiv::DIV1,
+        q: Plldiv::DIV1,
         r: Plldiv::DIV1,
     });
     config.rcc.hsi48 = Some(Hsi48Config { sync_from_usb: true }); // needed for USB


### PR DESCRIPTION
This MR adds support for setting the P and Q dividers in the STM32 U5 RCC. This is used when setting the SAI clock.