### PR TITLE
boot: Take maximum of READ_SIZE and WRITE_SIZE when checking sizes, fixes #2382

### DIFF
--- a/embassy-boot/boot/src/firmware_updater/asynch.rs
+++ b/embassy-boot/boot/src/firmware_updater/asynch.rs
@@ -224,10 +224,10 @@ impl<'d, STATE: NorFlash> FirmwareState<'d, STATE> {
     ///
     /// # Safety
     ///
-    /// The `aligned` buffer must have a size of STATE::WRITE_SIZE, and follow the alignment rules for the flash being read from
-    /// and written to.
+    /// The `aligned` buffer must have a size of maximum of STATE::WRITE_SIZE and STATE::READ_SIZE,
+    /// and follow the alignment rules for the flash being read from and written to.
     pub fn new(state: STATE, aligned: &'d mut [u8]) -> Self {
-        assert_eq!(aligned.len(), STATE::WRITE_SIZE);
+        assert_eq!(aligned.len(), STATE::WRITE_SIZE.max(STATE::READ_SIZE));
         Self { state, aligned }
     }
 


### PR DESCRIPTION
I run into this issue when using async firmware updater on rp2040. Because READ_SIZE is 4 and WRITE_SIZE is 1 the aligned buffer of 1 is insufficient causing the flash subsystem to return an error.