### PR TITLE
Add buffer size info to read_packet docs

### DIFF
--- a/embassy-usb/src/class/cdc_acm.rs
+++ b/embassy-usb/src/class/cdc_acm.rs
@@ -439,6 +439,7 @@ impl<'d, D: Driver<'d>> Receiver<'d, D> {
     }
 
     /// Reads a single packet from the OUT endpoint.
+    /// Must be called with a buffer large enough to hold max_packet_size bytes.
     pub async fn read_packet(&mut self, data: &mut [u8]) -> Result<usize, EndpointError> {
         self.read_ep.read(data).await
     }


### PR DESCRIPTION
Just a tiny addition to the docs after I spent way too long to get `read_packet` to work with a too small buffer