### PR TITLE
Adds function and macro to create usb logger without device (also fixes a logger issue)

### DIFF
--- a/embassy-usb-logger/src/lib.rs
+++ b/embassy-usb-logger/src/lib.rs
@@ -93,6 +93,9 @@ impl<const N: usize> UsbLogger<N> {
                 loop {
                     let len = self.buffer.read(&mut rx[..]).await;
                     let _ = sender.write_packet(&rx[..len]).await;
+                    if len as u8 == MAX_PACKET_SIZE {
+                        let _ = sender.write_packet(&[]).await;
+                    }
                 }
             };
             let discard_fut = async {
@@ -121,6 +124,9 @@ impl<const N: usize> UsbLogger<N> {
                 loop {
                     let len = self.buffer.read(&mut rx[..]).await;
                     let _ = sender.write_packet(&rx[..len]).await;
+                    if len as u8 == MAX_PACKET_SIZE {
+                        let _ = sender.write_packet(&[]).await;
+                    }
                 }
             };
             let discard_fut = async {

--- a/embassy-usb-logger/src/lib.rs
+++ b/embassy-usb-logger/src/lib.rs
@@ -111,7 +111,7 @@ impl<const N: usize> UsbLogger<N> {
 
     /// Creates the futures needed for the logger from a given class
     /// This can be used in cases where the usb device is already in use for another connection
-    pub async fn create_future_from_class<'d, D>(&'d self, class: CdcAcmClass<'d, D> )
+    pub async fn create_future_from_class<'d, D>(&'d self, class: CdcAcmClass<'d, D>)
     where
         D: Driver<'d>,
     {
@@ -121,7 +121,7 @@ impl<const N: usize> UsbLogger<N> {
         loop {
             let log_fut = async {
                 let mut rx: [u8; MAX_PACKET_SIZE as usize] = [0; MAX_PACKET_SIZE as usize];
-                sender.wait_connection().await; 
+                sender.wait_connection().await;
                 loop {
                     let len = self.buffer.read(&mut rx[..]).await;
                     let _ = sender.write_packet(&rx[..len]).await;
@@ -204,13 +204,11 @@ macro_rules! run {
 /// This macro should only be invoked only once since it is setting the global logging state of the application.
 #[macro_export]
 macro_rules! with_class {
-    ( $x:expr, $l:expr, $p:ident ) => {
-        {
-            static LOGGER: ::embassy_usb_logger::UsbLogger<$x> = ::embassy_usb_logger::UsbLogger::new();
-            unsafe {
-                let _ = ::log::set_logger_racy(&LOGGER).map(|()| log::set_max_level_racy($l));
-            }
-            LOGGER.create_future_from_class($p)
+    ( $x:expr, $l:expr, $p:ident ) => {{
+        static LOGGER: ::embassy_usb_logger::UsbLogger<$x> = ::embassy_usb_logger::UsbLogger::new();
+        unsafe {
+            let _ = ::log::set_logger_racy(&LOGGER).map(|()| log::set_max_level_racy($l));
         }
-    };
+        LOGGER.create_future_from_class($p)
+    }};
 }

--- a/embassy-usb-logger/src/lib.rs
+++ b/embassy-usb-logger/src/lib.rs
@@ -109,7 +109,8 @@ impl<const N: usize> UsbLogger<N> {
         }
     }
 
-    // Creates the futures needed for the logger from a given class
+    /// Creates the futures needed for the logger from a given class
+    /// This can be used in cases where the usb device is already in use for another connection
     pub async fn create_future_from_class<'d, D>(&'d self, class: CdcAcmClass<'d, D> )
     where
         D: Driver<'d>,

--- a/examples/rp/src/bin/usb_serial_with_logger.rs
+++ b/examples/rp/src/bin/usb_serial_with_logger.rs
@@ -1,0 +1,117 @@
+//! This example shows how to use USB (Universal Serial Bus) in the RP2040 chip as well as how to create multiple usb classes for one device
+//!
+//! This creates a USB serial port that echos. It will also print out logging information on a separate serial device
+
+#![no_std]
+#![no_main]
+
+use defmt::{info, panic};
+use embassy_executor::Spawner;
+use embassy_futures::join::join;
+use embassy_rp::bind_interrupts;
+use embassy_rp::peripherals::USB;
+use embassy_rp::usb::{Driver, Instance, InterruptHandler};
+use embassy_usb::class::cdc_acm::{CdcAcmClass, State};
+use embassy_usb::driver::EndpointError;
+use embassy_usb::{Builder, Config};
+use {defmt_rtt as _, panic_probe as _};
+
+bind_interrupts!(struct Irqs {
+    USBCTRL_IRQ => InterruptHandler<USB>;
+});
+
+#[embassy_executor::main]
+async fn main(_spawner: Spawner) {
+    info!("Hello there!");
+
+    let p = embassy_rp::init(Default::default());
+
+    // Create the driver, from the HAL.
+    let driver = Driver::new(p.USB, Irqs);
+
+    // Create embassy-usb Config
+    let mut config = Config::new(0xc0de, 0xcafe);
+    config.manufacturer = Some("Embassy");
+    config.product = Some("USB-serial example");
+    config.serial_number = Some("12345678");
+    config.max_power = 100;
+    config.max_packet_size_0 = 64;
+
+    // Required for windows compatibility.
+    // https://developer.nordicsemi.com/nRF_Connect_SDK/doc/1.9.1/kconfig/CONFIG_CDC_ACM_IAD.html#help
+    config.device_class = 0xEF;
+    config.device_sub_class = 0x02;
+    config.device_protocol = 0x01;
+    config.composite_with_iads = true;
+
+    // Create embassy-usb DeviceBuilder using the driver and config.
+    // It needs some buffers for building the descriptors.
+    let mut device_descriptor = [0; 256];
+    let mut config_descriptor = [0; 256];
+    let mut bos_descriptor = [0; 256];
+    let mut control_buf = [0; 64];
+
+    let mut state = State::new();
+    let mut logger_state = State::new();
+
+    let mut builder = Builder::new(
+        driver,
+        config,
+        &mut device_descriptor,
+        &mut config_descriptor,
+        &mut bos_descriptor,
+        &mut [], // no msos descriptors
+        &mut control_buf,
+    );
+
+    // Create classes on the builder.
+    let mut class = CdcAcmClass::new(&mut builder, &mut state, 64);
+
+    // Create a class for the logger
+    let logger_class = CdcAcmClass::new(&mut builder, &mut logger_state, 64);
+
+    // Creates the logger and returns the logger future
+    // Note: You'll need to use log::info! afterwards instead of info! for this to work (this also applies to all the other log::* macros)
+    let log_fut = embassy_usb_logger::with_class!(1024, log::LevelFilter::Info, logger_class);
+
+    // Build the builder.
+    let mut usb = builder.build();
+
+    // Run the USB device.
+    let usb_fut = usb.run();
+
+    // Do stuff with the class!
+    let echo_fut = async {
+        loop {
+            class.wait_connection().await;
+            log::info!("Connected");
+            let _ = echo(&mut class).await;
+            log::info!("Disconnected");
+        }
+    };
+
+    // Run everything concurrently.
+    // If we had made everything `'static` above instead, we could do this using separate tasks instead.
+    join(usb_fut, join(echo_fut, log_fut)).await;
+}
+
+struct Disconnected {}
+
+impl From<EndpointError> for Disconnected {
+    fn from(val: EndpointError) -> Self {
+        match val {
+            EndpointError::BufferOverflow => panic!("Buffer overflow"),
+            EndpointError::Disabled => Disconnected {},
+        }
+    }
+}
+
+async fn echo<'d, T: Instance + 'd>(class: &mut CdcAcmClass<'d, Driver<'d, T>>) -> Result<(), Disconnected> {
+    let mut buf = [0; 64];
+    loop {
+        let n = class.read_packet(&mut buf).await?;
+        let data = &buf[..n];
+        info!("data: {:x}", data);
+        class.write_packet(data).await?;
+    }
+}


### PR DESCRIPTION
This can be used in cases where the user wants to log something via usb but the usb connection is already in use.
It also serves as an example on how to create multiple usb classes with one device.

Finally this fixes an issue in the usb logger where messages that were exactly MAX_PACKET_SIZE (in this case 64) bytes long wouldn't show up in the log straight away, as explained in the [CdcAcmClass](https://docs.embassy.dev/embassy-usb/git/default/class/cdc_acm/struct.CdcAcmClass.html) (see the third point about messages with exactly the length of MAX_PACKET_SIZE)