### PR TITLE
stm32: fix buffered uart flush

### DIFF
--- a/embassy-stm32/src/usart/buffered.rs
+++ b/embassy-stm32/src/usart/buffered.rs
@@ -62,8 +62,8 @@ impl<T: BasicInstance> interrupt::typelevel::Handler<T::Interrupt> for Interrupt
             state.rx_waker.wake();
         }
 
-        // With `usart_v4` hardware FIFO is enabled, making `state.tx_buf`
-        // insufficient to determine if all bytes are sent out.
+        // With `usart_v4` hardware FIFO is enabled, making `state.tx_buf` insufficient
+        // to determine if all bytes are sent out.
         // Transmission complete (TC) interrupt here indicates that all bytes are pushed out from the FIFO.
         #[cfg(usart_v4)]
         if sr_val.tc() {
@@ -90,9 +90,12 @@ impl<T: BasicInstance> interrupt::typelevel::Handler<T::Interrupt> for Interrupt
 
                 tdr(r).write_volatile(buf[0].into());
                 tx_reader.pop_done(1);
+
+                // Notice that in case of `usart_v4` waker is called when TC interrupt happens.
+                #[cfg(not(usart_v4))]
                 state.tx_waker.wake();
             } else {
-                // Disable interrupt until we have something to transmit again
+                // Disable interrupt until we have something to transmit again.
                 r.cr1().modify(|w| {
                     w.set_txeie(false);
                 });

--- a/embassy-stm32/src/usart/buffered.rs
+++ b/embassy-stm32/src/usart/buffered.rs
@@ -47,8 +47,10 @@ impl<T: BasicInstance> interrupt::typelevel::Handler<T::Interrupt> for Interrupt
             let mut rx_writer = state.rx_buf.writer();
             let buf = rx_writer.push_slice();
             if !buf.is_empty() {
-                buf[0] = dr.unwrap();
-                rx_writer.push_done(1);
+                if let Some(byte) = dr {
+                    buf[0] = byte;
+                    rx_writer.push_done(1);
+                }
             } else {
                 // FIXME: Should we disable any further RX interrupts when the buffer becomes full.
             }


### PR DESCRIPTION
`usart_v4` uses internal FIFO and therefore actually all bytes are not yet sent out although `state.tx_buf.is_empty()`.

Code to demonstrate the problem:
```rust
let t = Mono::now();

pin.set_high();
rs485_tx.write_all(&tx_data).await.ok();
rs485_tx.flush().await.ok();
pin.set_low();

let diff = (Mono::now() - t).to_micros();
defmt::info!("tx {} us", diff);

```

Here red line shows `pin`. So `flush` finishes although in reality 9 bytes were not yet sent out from the FIFO.
![Screenshot 2024-01-08 at 14 48 33](https://github.com/embassy-rs/embassy/assets/809232/1c318ab2-c82b-470a-8469-83048c8d91c6)

With this patch `flush` finishes right after TX is done.
![Screenshot 2024-01-08 at 17 36 21](https://github.com/embassy-rs/embassy/assets/809232/c53de695-9153-4cd0-ade4-d04d6d1c5139)

# [STM32G0 reference manual](https://www.st.com/resource/en/reference_manual/rm0444-stm32g0x1-advanced-armbased-32bit-mcus-stmicroelectronics.pdf)
Page 1008:

7. Write the data to send in the `USART_TDR` register. Repeat this for each data to be transmitted in case of single buffer.
* When FIFO mode is disabled, writing a data to the `USART_TDR` clears the `TXE` flag.
* When FIFO mode is enabled, writing a data to the `USART_TDR` adds one data to the TXFIFO. Write operations to the `USART_TDR` are performed when `TXFNF` flag is set. This flag remains set until the TXFIFO is full.
8. When the last data is written to the `USART_TDR` register, wait until `TC = 1`.
* When FIFO mode is disabled, this indicates that the transmission of the last frame is complete.
* When FIFO mode is enabled, this indicates that both TXFIFO and shift register are empty.

# TODO

- [x] Currently `flush` would return 1 byte time too early for non `usart_v4` implementation. Final byte is written to register and after that `flush` can see that `tx_buf` is empty and it returns `Ready` although actually final bytes is still being written to the wire.
- [x] Test on a board that uses `usart_v4` (STM32G081).
- [x] Test on a board that uses `usart_v2` (STM32F411).
- [ ] Figure out why on STM32F411 with first transfer TC flag is set right after first byte is written to `DR`. Consecutive transfers works as expected. https://github.com/embassy-rs/embassy/pull/2416/commits/0a6f4c9e05f7326059abd0375d9a392cde798695
