### PR TITLE
Extend mock time driver to support alarms

### DIFF
--- a/.github/ci/test.sh
+++ b/.github/ci/test.sh
@@ -11,7 +11,7 @@ export CARGO_TARGET_DIR=/ci/cache/target
 cargo test --manifest-path ./embassy-sync/Cargo.toml 
 cargo test --manifest-path ./embassy-embedded-hal/Cargo.toml 
 cargo test --manifest-path ./embassy-hal-internal/Cargo.toml 
-cargo test --manifest-path ./embassy-time/Cargo.toml --features generic-queue
+cargo test --manifest-path ./embassy-time/Cargo.toml --features generic-queue,mock-driver
 
 cargo test --manifest-path ./embassy-boot/boot/Cargo.toml
 cargo test --manifest-path ./embassy-boot/boot/Cargo.toml --features ed25519-dalek

--- a/ci.sh
+++ b/ci.sh
@@ -34,7 +34,7 @@ cargo batch  \
     --- build --release --manifest-path embassy-executor/Cargo.toml --target riscv32imac-unknown-none-elf --features arch-riscv32,executor-thread \
     --- build --release --manifest-path embassy-executor/Cargo.toml --target riscv32imac-unknown-none-elf --features arch-riscv32,executor-thread,integrated-timers \
     --- build --release --manifest-path embassy-sync/Cargo.toml --target thumbv6m-none-eabi --features defmt \
-    --- build --release --manifest-path embassy-time/Cargo.toml --target thumbv6m-none-eabi --features defmt,defmt-timestamp-uptime,tick-hz-32_768,generic-queue-8 \
+    --- build --release --manifest-path embassy-time/Cargo.toml --target thumbv6m-none-eabi --features defmt,defmt-timestamp-uptime,generic-queue-8,mock-driver \
     --- build --release --manifest-path embassy-net/Cargo.toml --target thumbv7em-none-eabi --features defmt,tcp,udp,dns,proto-ipv4,medium-ethernet \
     --- build --release --manifest-path embassy-net/Cargo.toml --target thumbv7em-none-eabi --features defmt,tcp,udp,dns,proto-ipv4,igmp,medium-ethernet \
     --- build --release --manifest-path embassy-net/Cargo.toml --target thumbv7em-none-eabi --features defmt,tcp,udp,dns,dhcpv4,medium-ethernet \

--- a/embassy-time/src/driver.rs
+++ b/embassy-time/src/driver.rs
@@ -42,7 +42,6 @@
 //! use embassy_time::driver::{Driver, AlarmHandle};
 //!
 //! struct MyDriver{} // not public!
-//! embassy_time::time_driver_impl!(static DRIVER: MyDriver = MyDriver{});
 //!
 //! impl Driver for MyDriver {
 //!     fn now(&self) -> u64 {
@@ -58,6 +57,9 @@
 //!         todo!()
 //!     }
 //! }
+//! ```
+//! ```ignore
+//! embassy_time::time_driver_impl!(static DRIVER: MyDriver = MyDriver{});
 //! ```
 
 /// Alarm handle, assigned by the driver.

--- a/embassy-time/src/driver_mock.rs
+++ b/embassy-time/src/driver_mock.rs
@@ -56,7 +56,7 @@ impl MockDriver {
             critical_section::with(|cs| {
                 let mut inner = self.0.borrow_ref_mut(cs);
 
-                inner.now = inner.now + duration;
+                inner.now += duration;
 
                 let now = inner.now.as_ticks();
 

--- a/embassy-time/src/driver_mock.rs
+++ b/embassy-time/src/driver_mock.rs
@@ -164,10 +164,19 @@ unsafe impl Send for AlarmState {}
 
 #[cfg(test)]
 mod tests {
+    use serial_test::serial;
+
     use super::*;
 
+    fn setup() {
+        DRIVER.reset();
+    }
+
     #[test]
+    #[serial]
     fn test_advance() {
+        setup();
+
         let driver = MockDriver::get();
         let reference = driver.now();
         driver.advance(Duration::from_secs(1));
@@ -175,14 +184,20 @@ mod tests {
     }
 
     #[test]
+    #[serial]
     fn test_set_alarm_not_in_future() {
+        setup();
+
         let driver = MockDriver::get();
         let alarm = unsafe { AlarmHandle::new(0) };
         assert_eq!(false, driver.set_alarm(alarm, driver.now()));
     }
 
     #[test]
+    #[serial]
     fn test_alarm() {
+        setup();
+
         let driver = MockDriver::get();
         let alarm = unsafe { driver.allocate_alarm() }.expect("No alarms available");
         static mut CALLBACK_CALLED: bool = false;
@@ -195,7 +210,10 @@ mod tests {
     }
 
     #[test]
+    #[serial]
     fn test_allocate_alarm() {
+        setup();
+
         let driver = MockDriver::get();
         assert!(unsafe { driver.allocate_alarm() }.is_some());
         assert!(unsafe { driver.allocate_alarm() }.is_none());

--- a/embassy-time/src/queue.rs
+++ b/embassy-time/src/queue.rs
@@ -23,13 +23,15 @@
 //! use embassy_time::queue::{TimerQueue};
 //!
 //! struct MyTimerQueue{}; // not public!
-//! embassy_time::timer_queue_impl!(static QUEUE: MyTimerQueue = MyTimerQueue{});
 //!
 //! impl TimerQueue for MyTimerQueue {
 //!     fn schedule_wake(&'static self, at: Instant, waker: &Waker) {
 //!         todo!()
 //!     }
 //! }
+//! ```
+//! ```ignore
+//! embassy_time::timer_queue_impl!(static QUEUE: MyTimerQueue = MyTimerQueue{});
 //! ```
 use core::task::Waker;
 

--- a/embassy-time/src/queue_generic.rs
+++ b/embassy-time/src/queue_generic.rs
@@ -180,14 +180,12 @@ mod tests {
     use core::cell::Cell;
     use core::task::{RawWaker, RawWakerVTable, Waker};
     use std::rc::Rc;
-    use std::sync::Mutex;
 
     use serial_test::serial;
 
-    use crate::driver::{AlarmHandle, Driver};
     use crate::driver_mock::MockDriver;
     use crate::queue_generic::QUEUE;
-    use crate::{Instant, Duration};
+    use crate::{Duration, Instant};
 
     struct TestWaker {
         pub awoken: Rc<Cell<bool>>,


### PR DESCRIPTION
Fixes #2412.

I think the most contentious change is utilising `MockDriver` in the tests inside `queue_generic.rs`, but it seemed a shame not to.