### PR TITLE
Change GPIO inherent methods back to `&self`.

### DIFF
--- a/docs/modules/ROOT/examples/layer-by-layer/blinky-hal/src/main.rs
+++ b/docs/modules/ROOT/examples/layer-by-layer/blinky-hal/src/main.rs
@@ -9,7 +9,7 @@ use {defmt_rtt as _, panic_probe as _};
 fn main() -> ! {
     let p = embassy_stm32::init(Default::default());
     let mut led = Output::new(p.PB14, Level::High, Speed::VeryHigh);
-    let mut button = Input::new(p.PC13, Pull::Up);
+    let button = Input::new(p.PC13, Pull::Up);
 
     loop {
         if button.is_low() {

--- a/embassy-nrf/src/gpio.rs
+++ b/embassy-nrf/src/gpio.rs
@@ -52,19 +52,19 @@ impl<'d, T: Pin> Input<'d, T> {
 
     /// Get whether the pin input level is high.
     #[inline]
-    pub fn is_high(&mut self) -> bool {
+    pub fn is_high(&self) -> bool {
         self.pin.is_high()
     }
 
     /// Get whether the pin input level is low.
     #[inline]
-    pub fn is_low(&mut self) -> bool {
+    pub fn is_low(&self) -> bool {
         self.pin.is_low()
     }
 
     /// Get the pin input level.
     #[inline]
-    pub fn get_level(&mut self) -> Level {
+    pub fn get_level(&self) -> Level {
         self.pin.get_level()
     }
 }
@@ -166,19 +166,19 @@ impl<'d, T: Pin> Output<'d, T> {
 
     /// Get whether the output level is set to high.
     #[inline]
-    pub fn is_set_high(&mut self) -> bool {
+    pub fn is_set_high(&self) -> bool {
         self.pin.is_set_high()
     }
 
     /// Get whether the output level is set to low.
     #[inline]
-    pub fn is_set_low(&mut self) -> bool {
+    pub fn is_set_low(&self) -> bool {
         self.pin.is_set_low()
     }
 
     /// Get the current output level.
     #[inline]
-    pub fn get_output_level(&mut self) -> Level {
+    pub fn get_output_level(&self) -> Level {
         self.pin.get_output_level()
     }
 }
@@ -283,24 +283,19 @@ impl<'d, T: Pin> Flex<'d, T> {
 
     /// Get whether the pin input level is high.
     #[inline]
-    pub fn is_high(&mut self) -> bool {
+    pub fn is_high(&self) -> bool {
         !self.is_low()
     }
 
     /// Get whether the pin input level is low.
     #[inline]
-    pub fn is_low(&mut self) -> bool {
-        self.ref_is_low()
-    }
-
-    #[inline]
-    pub(crate) fn ref_is_low(&self) -> bool {
+    pub fn is_low(&self) -> bool {
         self.pin.block().in_.read().bits() & (1 << self.pin.pin()) == 0
     }
 
     /// Get the pin input level.
     #[inline]
-    pub fn get_level(&mut self) -> Level {
+    pub fn get_level(&self) -> Level {
         self.is_high().into()
     }
 
@@ -337,24 +332,19 @@ impl<'d, T: Pin> Flex<'d, T> {
 
     /// Get whether the output level is set to high.
     #[inline]
-    pub fn is_set_high(&mut self) -> bool {
+    pub fn is_set_high(&self) -> bool {
         !self.is_set_low()
     }
 
     /// Get whether the output level is set to low.
     #[inline]
-    pub fn is_set_low(&mut self) -> bool {
-        self.ref_is_set_low()
-    }
-
-    #[inline]
-    pub(crate) fn ref_is_set_low(&self) -> bool {
+    pub fn is_set_low(&self) -> bool {
         self.pin.block().out.read().bits() & (1 << self.pin.pin()) == 0
     }
 
     /// Get the current output level.
     #[inline]
-    pub fn get_output_level(&mut self) -> Level {
+    pub fn get_output_level(&self) -> Level {
         self.is_set_high().into()
     }
 }
@@ -524,11 +514,11 @@ mod eh02 {
         type Error = Infallible;
 
         fn is_high(&self) -> Result<bool, Self::Error> {
-            Ok(!self.pin.ref_is_low())
+            Ok(self.is_high())
         }
 
         fn is_low(&self) -> Result<bool, Self::Error> {
-            Ok(self.pin.ref_is_low())
+            Ok(self.is_low())
         }
     }
 
@@ -546,11 +536,11 @@ mod eh02 {
 
     impl<'d, T: Pin> embedded_hal_02::digital::v2::StatefulOutputPin for Output<'d, T> {
         fn is_set_high(&self) -> Result<bool, Self::Error> {
-            Ok(!self.pin.ref_is_set_low())
+            Ok(self.is_set_high())
         }
 
         fn is_set_low(&self) -> Result<bool, Self::Error> {
-            Ok(self.pin.ref_is_set_low())
+            Ok(self.is_set_low())
         }
     }
 
@@ -570,11 +560,11 @@ mod eh02 {
         type Error = Infallible;
 
         fn is_high(&self) -> Result<bool, Self::Error> {
-            Ok(!self.ref_is_low())
+            Ok(self.is_high())
         }
 
         fn is_low(&self) -> Result<bool, Self::Error> {
-            Ok(self.ref_is_low())
+            Ok(self.is_low())
         }
     }
 
@@ -592,11 +582,11 @@ mod eh02 {
 
     impl<'d, T: Pin> embedded_hal_02::digital::v2::StatefulOutputPin for Flex<'d, T> {
         fn is_set_high(&self) -> Result<bool, Self::Error> {
-            Ok(!self.ref_is_set_low())
+            Ok(self.is_set_high())
         }
 
         fn is_set_low(&self) -> Result<bool, Self::Error> {
-            Ok(self.ref_is_set_low())
+            Ok(self.is_set_low())
         }
     }
 
@@ -616,11 +606,11 @@ impl<'d, T: Pin> embedded_hal_1::digital::ErrorType for Input<'d, T> {
 
 impl<'d, T: Pin> embedded_hal_1::digital::InputPin for Input<'d, T> {
     fn is_high(&mut self) -> Result<bool, Self::Error> {
-        Ok(self.is_high())
+        Ok((*self).is_high())
     }
 
     fn is_low(&mut self) -> Result<bool, Self::Error> {
-        Ok(self.is_low())
+        Ok((*self).is_low())
     }
 }
 
@@ -640,11 +630,11 @@ impl<'d, T: Pin> embedded_hal_1::digital::OutputPin for Output<'d, T> {
 
 impl<'d, T: Pin> embedded_hal_1::digital::StatefulOutputPin for Output<'d, T> {
     fn is_set_high(&mut self) -> Result<bool, Self::Error> {
-        Ok(self.is_set_high())
+        Ok((*self).is_set_high())
     }
 
     fn is_set_low(&mut self) -> Result<bool, Self::Error> {
-        Ok(self.is_set_low())
+        Ok((*self).is_set_low())
     }
 }
 
@@ -657,11 +647,11 @@ impl<'d, T: Pin> embedded_hal_1::digital::ErrorType for Flex<'d, T> {
 /// If the pin is not in input mode the result is unspecified.
 impl<'d, T: Pin> embedded_hal_1::digital::InputPin for Flex<'d, T> {
     fn is_high(&mut self) -> Result<bool, Self::Error> {
-        Ok(self.is_high())
+        Ok((*self).is_high())
     }
 
     fn is_low(&mut self) -> Result<bool, Self::Error> {
-        Ok(self.is_low())
+        Ok((*self).is_low())
     }
 }
 
@@ -677,10 +667,10 @@ impl<'d, T: Pin> embedded_hal_1::digital::OutputPin for Flex<'d, T> {
 
 impl<'d, T: Pin> embedded_hal_1::digital::StatefulOutputPin for Flex<'d, T> {
     fn is_set_high(&mut self) -> Result<bool, Self::Error> {
-        Ok(self.is_set_high())
+        Ok((*self).is_set_high())
     }
 
     fn is_set_low(&mut self) -> Result<bool, Self::Error> {
-        Ok(self.is_set_low())
+        Ok((*self).is_set_low())
     }
 }

--- a/embassy-nrf/src/gpiote.rs
+++ b/embassy-nrf/src/gpiote.rs
@@ -243,7 +243,7 @@ impl<'d, C: Channel, T: GpioPin> Drop for OutputChannel<'d, C, T> {
 
 impl<'d, C: Channel, T: GpioPin> OutputChannel<'d, C, T> {
     /// Create a new GPIOTE output channel driver.
-    pub fn new(ch: impl Peripheral<P = C> + 'd, mut pin: Output<'d, T>, polarity: OutputChannelPolarity) -> Self {
+    pub fn new(ch: impl Peripheral<P = C> + 'd, pin: Output<'d, T>, polarity: OutputChannelPolarity) -> Self {
         into_ref!(ch);
         let g = regs();
         let num = ch.number();
@@ -481,11 +481,11 @@ mod eh02 {
         type Error = Infallible;
 
         fn is_high(&self) -> Result<bool, Self::Error> {
-            Ok(!self.pin.pin.ref_is_low())
+            Ok(self.pin.is_high())
         }
 
         fn is_low(&self) -> Result<bool, Self::Error> {
-            Ok(self.pin.pin.ref_is_low())
+            Ok(self.pin.is_low())
         }
     }
 }

--- a/embassy-rp/src/gpio.rs
+++ b/embassy-rp/src/gpio.rs
@@ -127,19 +127,19 @@ impl<'d, T: Pin> Input<'d, T> {
 
     /// Get whether the pin input level is high.
     #[inline]
-    pub fn is_high(&mut self) -> bool {
+    pub fn is_high(&self) -> bool {
         self.pin.is_high()
     }
 
     /// Get whether the pin input level is low.
     #[inline]
-    pub fn is_low(&mut self) -> bool {
+    pub fn is_low(&self) -> bool {
         self.pin.is_low()
     }
 
     /// Returns current pin level
     #[inline]
-    pub fn get_level(&mut self) -> Level {
+    pub fn get_level(&self) -> Level {
         self.pin.get_level()
     }
 
@@ -394,19 +394,19 @@ impl<'d, T: Pin> Output<'d, T> {
 
     /// Is the output pin set as high?
     #[inline]
-    pub fn is_set_high(&mut self) -> bool {
+    pub fn is_set_high(&self) -> bool {
         self.pin.is_set_high()
     }
 
     /// Is the output pin set as low?
     #[inline]
-    pub fn is_set_low(&mut self) -> bool {
+    pub fn is_set_low(&self) -> bool {
         self.pin.is_set_low()
     }
 
     /// What level output is set to
     #[inline]
-    pub fn get_output_level(&mut self) -> Level {
+    pub fn get_output_level(&self) -> Level {
         self.pin.get_output_level()
     }
 
@@ -472,19 +472,19 @@ impl<'d, T: Pin> OutputOpenDrain<'d, T> {
 
     /// Is the output level high?
     #[inline]
-    pub fn is_set_high(&mut self) -> bool {
+    pub fn is_set_high(&self) -> bool {
         !self.is_set_low()
     }
 
     /// Is the output level low?
     #[inline]
-    pub fn is_set_low(&mut self) -> bool {
+    pub fn is_set_low(&self) -> bool {
         self.pin.is_set_as_output()
     }
 
     /// What level output is set to
     #[inline]
-    pub fn get_output_level(&mut self) -> Level {
+    pub fn get_output_level(&self) -> Level {
         self.is_set_high().into()
     }
 
@@ -496,19 +496,19 @@ impl<'d, T: Pin> OutputOpenDrain<'d, T> {
 
     /// Get whether the pin input level is high.
     #[inline]
-    pub fn is_high(&mut self) -> bool {
+    pub fn is_high(&self) -> bool {
         self.pin.is_high()
     }
 
     /// Get whether the pin input level is low.
     #[inline]
-    pub fn is_low(&mut self) -> bool {
+    pub fn is_low(&self) -> bool {
         self.pin.is_low()
     }
 
     /// Returns current pin level
     #[inline]
-    pub fn get_level(&mut self) -> Level {
+    pub fn get_level(&self) -> Level {
         self.is_high().into()
     }
 
@@ -640,12 +640,7 @@ impl<'d, T: Pin> Flex<'d, T> {
 
     /// Set as output pin.
     #[inline]
-    pub fn is_set_as_output(&mut self) -> bool {
-        self.ref_is_set_as_output()
-    }
-
-    #[inline]
-    pub(crate) fn ref_is_set_as_output(&self) -> bool {
+    fn is_set_as_output(&self) -> bool {
         (self.pin.sio_oe().value().read() & self.bit()) != 0
     }
 
@@ -657,24 +652,19 @@ impl<'d, T: Pin> Flex<'d, T> {
 
     /// Get whether the pin input level is high.
     #[inline]
-    pub fn is_high(&mut self) -> bool {
+    pub fn is_high(&self) -> bool {
         !self.is_low()
     }
     /// Get whether the pin input level is low.
 
     #[inline]
-    pub fn is_low(&mut self) -> bool {
-        self.ref_is_low()
-    }
-
-    #[inline]
-    pub(crate) fn ref_is_low(&self) -> bool {
+    pub fn is_low(&self) -> bool {
         self.pin.sio_in().read() & self.bit() == 0
     }
 
     /// Returns current pin level
     #[inline]
-    pub fn get_level(&mut self) -> Level {
+    pub fn get_level(&self) -> Level {
         self.is_high().into()
     }
 
@@ -701,24 +691,19 @@ impl<'d, T: Pin> Flex<'d, T> {
 
     /// Is the output level high?
     #[inline]
-    pub fn is_set_high(&mut self) -> bool {
+    pub fn is_set_high(&self) -> bool {
         !self.is_set_low()
     }
 
     /// Is the output level low?
     #[inline]
-    pub fn is_set_low(&mut self) -> bool {
-        self.ref_is_set_low()
-    }
-
-    #[inline]
-    pub(crate) fn ref_is_set_low(&self) -> bool {
+    pub fn is_set_low(&self) -> bool {
         (self.pin.sio_out().value().read() & self.bit()) == 0
     }
 
     /// What level output is set to
     #[inline]
-    pub fn get_output_level(&mut self) -> Level {
+    pub fn get_output_level(&self) -> Level {
         self.is_set_high().into()
     }
 
@@ -989,11 +974,11 @@ mod eh02 {
         type Error = Infallible;
 
         fn is_high(&self) -> Result<bool, Self::Error> {
-            Ok(!self.pin.ref_is_low())
+            Ok(self.is_high())
         }
 
         fn is_low(&self) -> Result<bool, Self::Error> {
-            Ok(self.pin.ref_is_low())
+            Ok(self.is_low())
         }
     }
 
@@ -1011,11 +996,11 @@ mod eh02 {
 
     impl<'d, T: Pin> embedded_hal_02::digital::v2::StatefulOutputPin for Output<'d, T> {
         fn is_set_high(&self) -> Result<bool, Self::Error> {
-            Ok(!self.pin.ref_is_set_low())
+            Ok(self.is_set_high())
         }
 
         fn is_set_low(&self) -> Result<bool, Self::Error> {
-            Ok(self.pin.ref_is_set_low())
+            Ok(self.is_set_low())
         }
     }
 
@@ -1031,11 +1016,11 @@ mod eh02 {
         type Error = Infallible;
 
         fn is_high(&self) -> Result<bool, Self::Error> {
-            Ok(!self.pin.ref_is_low())
+            Ok(self.is_high())
         }
 
         fn is_low(&self) -> Result<bool, Self::Error> {
-            Ok(self.pin.ref_is_low())
+            Ok(self.is_low())
         }
     }
 
@@ -1055,11 +1040,11 @@ mod eh02 {
 
     impl<'d, T: Pin> embedded_hal_02::digital::v2::StatefulOutputPin for OutputOpenDrain<'d, T> {
         fn is_set_high(&self) -> Result<bool, Self::Error> {
-            Ok(!self.pin.ref_is_set_as_output())
+            Ok(self.is_set_high())
         }
 
         fn is_set_low(&self) -> Result<bool, Self::Error> {
-            Ok(self.pin.ref_is_set_as_output())
+            Ok(self.is_set_low())
         }
     }
 
@@ -1075,11 +1060,11 @@ mod eh02 {
         type Error = Infallible;
 
         fn is_high(&self) -> Result<bool, Self::Error> {
-            Ok(!self.ref_is_low())
+            Ok(self.is_high())
         }
 
         fn is_low(&self) -> Result<bool, Self::Error> {
-            Ok(self.ref_is_low())
+            Ok(self.is_low())
         }
     }
 
@@ -1097,11 +1082,11 @@ mod eh02 {
 
     impl<'d, T: Pin> embedded_hal_02::digital::v2::StatefulOutputPin for Flex<'d, T> {
         fn is_set_high(&self) -> Result<bool, Self::Error> {
-            Ok(!self.ref_is_set_low())
+            Ok(self.is_set_high())
         }
 
         fn is_set_low(&self) -> Result<bool, Self::Error> {
-            Ok(self.ref_is_set_low())
+            Ok(self.is_set_low())
         }
     }
 
@@ -1120,11 +1105,11 @@ impl<'d, T: Pin> embedded_hal_1::digital::ErrorType for Input<'d, T> {
 
 impl<'d, T: Pin> embedded_hal_1::digital::InputPin for Input<'d, T> {
     fn is_high(&mut self) -> Result<bool, Self::Error> {
-        Ok(self.is_high())
+        Ok((*self).is_high())
     }
 
     fn is_low(&mut self) -> Result<bool, Self::Error> {
-        Ok(self.is_low())
+        Ok((*self).is_low())
     }
 }
 
@@ -1144,11 +1129,11 @@ impl<'d, T: Pin> embedded_hal_1::digital::OutputPin for Output<'d, T> {
 
 impl<'d, T: Pin> embedded_hal_1::digital::StatefulOutputPin for Output<'d, T> {
     fn is_set_high(&mut self) -> Result<bool, Self::Error> {
-        Ok(self.is_set_high())
+        Ok((*self).is_set_high())
     }
 
     fn is_set_low(&mut self) -> Result<bool, Self::Error> {
-        Ok(self.is_set_low())
+        Ok((*self).is_set_low())
     }
 }
 
@@ -1168,21 +1153,21 @@ impl<'d, T: Pin> embedded_hal_1::digital::OutputPin for OutputOpenDrain<'d, T> {
 
 impl<'d, T: Pin> embedded_hal_1::digital::StatefulOutputPin for OutputOpenDrain<'d, T> {
     fn is_set_high(&mut self) -> Result<bool, Self::Error> {
-        Ok(self.is_set_high())
+        Ok((*self).is_set_high())
     }
 
     fn is_set_low(&mut self) -> Result<bool, Self::Error> {
-        Ok(self.is_set_low())
+        Ok((*self).is_set_low())
     }
 }
 
 impl<'d, T: Pin> embedded_hal_1::digital::InputPin for OutputOpenDrain<'d, T> {
     fn is_high(&mut self) -> Result<bool, Self::Error> {
-        Ok(self.is_high())
+        Ok((*self).is_high())
     }
 
     fn is_low(&mut self) -> Result<bool, Self::Error> {
-        Ok(self.is_low())
+        Ok((*self).is_low())
     }
 }
 
@@ -1192,11 +1177,11 @@ impl<'d, T: Pin> embedded_hal_1::digital::ErrorType for Flex<'d, T> {
 
 impl<'d, T: Pin> embedded_hal_1::digital::InputPin for Flex<'d, T> {
     fn is_high(&mut self) -> Result<bool, Self::Error> {
-        Ok(self.is_high())
+        Ok((*self).is_high())
     }
 
     fn is_low(&mut self) -> Result<bool, Self::Error> {
-        Ok(self.is_low())
+        Ok((*self).is_low())
     }
 }
 
@@ -1212,11 +1197,11 @@ impl<'d, T: Pin> embedded_hal_1::digital::OutputPin for Flex<'d, T> {
 
 impl<'d, T: Pin> embedded_hal_1::digital::StatefulOutputPin for Flex<'d, T> {
     fn is_set_high(&mut self) -> Result<bool, Self::Error> {
-        Ok(self.is_set_high())
+        Ok((*self).is_set_high())
     }
 
     fn is_set_low(&mut self) -> Result<bool, Self::Error> {
-        Ok(self.is_set_low())
+        Ok((*self).is_set_low())
     }
 }
 

--- a/embassy-stm32/src/exti.rs
+++ b/embassy-stm32/src/exti.rs
@@ -106,17 +106,17 @@ impl<'d, T: GpioPin> ExtiInput<'d, T> {
     }
 
     /// Get whether the pin is high.
-    pub fn is_high(&mut self) -> bool {
+    pub fn is_high(&self) -> bool {
         self.pin.is_high()
     }
 
     /// Get whether the pin is low.
-    pub fn is_low(&mut self) -> bool {
+    pub fn is_low(&self) -> bool {
         self.pin.is_low()
     }
 
     /// Get the pin level.
-    pub fn get_level(&mut self) -> Level {
+    pub fn get_level(&self) -> Level {
         self.pin.get_level()
     }
 
@@ -166,11 +166,11 @@ impl<'d, T: GpioPin> embedded_hal_02::digital::v2::InputPin for ExtiInput<'d, T>
     type Error = Infallible;
 
     fn is_high(&self) -> Result<bool, Self::Error> {
-        Ok(!self.pin.pin.ref_is_low())
+        Ok(self.is_high())
     }
 
     fn is_low(&self) -> Result<bool, Self::Error> {
-        Ok(self.pin.pin.ref_is_low())
+        Ok(self.is_low())
     }
 }
 
@@ -180,11 +180,11 @@ impl<'d, T: GpioPin> embedded_hal_1::digital::ErrorType for ExtiInput<'d, T> {
 
 impl<'d, T: GpioPin> embedded_hal_1::digital::InputPin for ExtiInput<'d, T> {
     fn is_high(&mut self) -> Result<bool, Self::Error> {
-        Ok(self.is_high())
+        Ok((*self).is_high())
     }
 
     fn is_low(&mut self) -> Result<bool, Self::Error> {
-        Ok(self.is_low())
+        Ok((*self).is_low())
     }
 }
 

--- a/embassy-stm32/src/gpio.rs
+++ b/embassy-stm32/src/gpio.rs
@@ -150,49 +150,39 @@ impl<'d, T: Pin> Flex<'d, T> {
 
     /// Get whether the pin input level is high.
     #[inline]
-    pub fn is_high(&mut self) -> bool {
-        !self.ref_is_low()
+    pub fn is_high(&self) -> bool {
+        !self.is_low()
     }
 
     /// Get whether the pin input level is low.
     #[inline]
-    pub fn is_low(&mut self) -> bool {
-        self.ref_is_low()
-    }
-
-    #[inline]
-    pub(crate) fn ref_is_low(&self) -> bool {
+    pub fn is_low(&self) -> bool {
         let state = self.pin.block().idr().read().idr(self.pin.pin() as _);
         state == vals::Idr::LOW
     }
 
     /// Get the current pin input level.
     #[inline]
-    pub fn get_level(&mut self) -> Level {
+    pub fn get_level(&self) -> Level {
         self.is_high().into()
     }
 
     /// Get whether the output level is set to high.
     #[inline]
-    pub fn is_set_high(&mut self) -> bool {
-        !self.ref_is_set_low()
+    pub fn is_set_high(&self) -> bool {
+        !self.is_set_low()
     }
 
     /// Get whether the output level is set to low.
     #[inline]
-    pub fn is_set_low(&mut self) -> bool {
-        self.ref_is_set_low()
-    }
-
-    #[inline]
-    pub(crate) fn ref_is_set_low(&self) -> bool {
+    pub fn is_set_low(&self) -> bool {
         let state = self.pin.block().odr().read().odr(self.pin.pin() as _);
         state == vals::Odr::LOW
     }
 
     /// Get the current output level.
     #[inline]
-    pub fn get_output_level(&mut self) -> Level {
+    pub fn get_output_level(&self) -> Level {
         self.is_set_high().into()
     }
 
@@ -346,19 +336,19 @@ impl<'d, T: Pin> Input<'d, T> {
 
     /// Get whether the pin input level is high.
     #[inline]
-    pub fn is_high(&mut self) -> bool {
+    pub fn is_high(&self) -> bool {
         self.pin.is_high()
     }
 
     /// Get whether the pin input level is low.
     #[inline]
-    pub fn is_low(&mut self) -> bool {
+    pub fn is_low(&self) -> bool {
         self.pin.is_low()
     }
 
     /// Get the current pin input level.
     #[inline]
-    pub fn get_level(&mut self) -> Level {
+    pub fn get_level(&self) -> Level {
         self.pin.get_level()
     }
 }
@@ -445,19 +435,19 @@ impl<'d, T: Pin> Output<'d, T> {
 
     /// Is the output pin set as high?
     #[inline]
-    pub fn is_set_high(&mut self) -> bool {
+    pub fn is_set_high(&self) -> bool {
         self.pin.is_set_high()
     }
 
     /// Is the output pin set as low?
     #[inline]
-    pub fn is_set_low(&mut self) -> bool {
+    pub fn is_set_low(&self) -> bool {
         self.pin.is_set_low()
     }
 
     /// What level output is set to
     #[inline]
-    pub fn get_output_level(&mut self) -> Level {
+    pub fn get_output_level(&self) -> Level {
         self.pin.get_output_level()
     }
 
@@ -506,19 +496,19 @@ impl<'d, T: Pin> OutputOpenDrain<'d, T> {
 
     /// Get whether the pin input level is high.
     #[inline]
-    pub fn is_high(&mut self) -> bool {
+    pub fn is_high(&self) -> bool {
         !self.pin.is_low()
     }
 
     /// Get whether the pin input level is low.
     #[inline]
-    pub fn is_low(&mut self) -> bool {
+    pub fn is_low(&self) -> bool {
         self.pin.is_low()
     }
 
     /// Get the current pin input level.
     #[inline]
-    pub fn get_level(&mut self) -> Level {
+    pub fn get_level(&self) -> Level {
         self.pin.get_level()
     }
 
@@ -542,19 +532,19 @@ impl<'d, T: Pin> OutputOpenDrain<'d, T> {
 
     /// Get whether the output level is set to high.
     #[inline]
-    pub fn is_set_high(&mut self) -> bool {
+    pub fn is_set_high(&self) -> bool {
         self.pin.is_set_high()
     }
 
     /// Get whether the output level is set to low.
     #[inline]
-    pub fn is_set_low(&mut self) -> bool {
+    pub fn is_set_low(&self) -> bool {
         self.pin.is_set_low()
     }
 
     /// Get the current output level.
     #[inline]
-    pub fn get_output_level(&mut self) -> Level {
+    pub fn get_output_level(&self) -> Level {
         self.pin.get_output_level()
     }
 
@@ -851,12 +841,12 @@ impl<'d, T: Pin> embedded_hal_02::digital::v2::InputPin for Input<'d, T> {
 
     #[inline]
     fn is_high(&self) -> Result<bool, Self::Error> {
-        Ok(!self.pin.ref_is_low())
+        Ok(self.is_high())
     }
 
     #[inline]
     fn is_low(&self) -> Result<bool, Self::Error> {
-        Ok(self.pin.ref_is_low())
+        Ok(self.is_low())
     }
 }
 
@@ -879,13 +869,13 @@ impl<'d, T: Pin> embedded_hal_02::digital::v2::OutputPin for Output<'d, T> {
 impl<'d, T: Pin> embedded_hal_02::digital::v2::StatefulOutputPin for Output<'d, T> {
     #[inline]
     fn is_set_high(&self) -> Result<bool, Self::Error> {
-        Ok(!self.pin.ref_is_set_low())
+        Ok(self.is_set_high())
     }
 
     /// Is the output pin set as low?
     #[inline]
     fn is_set_low(&self) -> Result<bool, Self::Error> {
-        Ok(self.pin.ref_is_set_low())
+        Ok(self.is_set_low())
     }
 }
 
@@ -917,13 +907,13 @@ impl<'d, T: Pin> embedded_hal_02::digital::v2::OutputPin for OutputOpenDrain<'d,
 impl<'d, T: Pin> embedded_hal_02::digital::v2::StatefulOutputPin for OutputOpenDrain<'d, T> {
     #[inline]
     fn is_set_high(&self) -> Result<bool, Self::Error> {
-        Ok(!self.pin.ref_is_set_low())
+        Ok(self.is_set_high())
     }
 
     /// Is the output pin set as low?
     #[inline]
     fn is_set_low(&self) -> Result<bool, Self::Error> {
-        Ok(self.pin.ref_is_set_low())
+        Ok(self.is_set_low())
     }
 }
 
@@ -941,12 +931,12 @@ impl<'d, T: Pin> embedded_hal_02::digital::v2::InputPin for Flex<'d, T> {
 
     #[inline]
     fn is_high(&self) -> Result<bool, Self::Error> {
-        Ok(!self.ref_is_low())
+        Ok(self.is_high())
     }
 
     #[inline]
     fn is_low(&self) -> Result<bool, Self::Error> {
-        Ok(self.ref_is_low())
+        Ok(self.is_low())
     }
 }
 
@@ -969,13 +959,13 @@ impl<'d, T: Pin> embedded_hal_02::digital::v2::OutputPin for Flex<'d, T> {
 impl<'d, T: Pin> embedded_hal_02::digital::v2::StatefulOutputPin for Flex<'d, T> {
     #[inline]
     fn is_set_high(&self) -> Result<bool, Self::Error> {
-        Ok(!self.ref_is_set_low())
+        Ok(self.is_set_high())
     }
 
     /// Is the output pin set as low?
     #[inline]
     fn is_set_low(&self) -> Result<bool, Self::Error> {
-        Ok(self.ref_is_set_low())
+        Ok(self.is_set_low())
     }
 }
 
@@ -995,12 +985,12 @@ impl<'d, T: Pin> embedded_hal_1::digital::ErrorType for Input<'d, T> {
 impl<'d, T: Pin> embedded_hal_1::digital::InputPin for Input<'d, T> {
     #[inline]
     fn is_high(&mut self) -> Result<bool, Self::Error> {
-        Ok(self.is_high())
+        Ok((*self).is_high())
     }
 
     #[inline]
     fn is_low(&mut self) -> Result<bool, Self::Error> {
-        Ok(self.is_low())
+        Ok((*self).is_low())
     }
 }
 
@@ -1023,13 +1013,13 @@ impl<'d, T: Pin> embedded_hal_1::digital::OutputPin for Output<'d, T> {
 impl<'d, T: Pin> embedded_hal_1::digital::StatefulOutputPin for Output<'d, T> {
     #[inline]
     fn is_set_high(&mut self) -> Result<bool, Self::Error> {
-        Ok(self.is_set_high())
+        Ok((*self).is_set_high())
     }
 
     /// Is the output pin set as low?
     #[inline]
     fn is_set_low(&mut self) -> Result<bool, Self::Error> {
-        Ok(self.is_set_low())
+        Ok((*self).is_set_low())
     }
 }
 
@@ -1040,12 +1030,12 @@ impl<'d, T: Pin> embedded_hal_1::digital::ErrorType for OutputOpenDrain<'d, T> {
 impl<'d, T: Pin> embedded_hal_1::digital::InputPin for OutputOpenDrain<'d, T> {
     #[inline]
     fn is_high(&mut self) -> Result<bool, Self::Error> {
-        Ok(self.is_high())
+        Ok((*self).is_high())
     }
 
     #[inline]
     fn is_low(&mut self) -> Result<bool, Self::Error> {
-        Ok(self.is_low())
+        Ok((*self).is_low())
     }
 }
 
@@ -1064,25 +1054,25 @@ impl<'d, T: Pin> embedded_hal_1::digital::OutputPin for OutputOpenDrain<'d, T> {
 impl<'d, T: Pin> embedded_hal_1::digital::StatefulOutputPin for OutputOpenDrain<'d, T> {
     #[inline]
     fn is_set_high(&mut self) -> Result<bool, Self::Error> {
-        Ok(self.is_set_high())
+        Ok((*self).is_set_high())
     }
 
     /// Is the output pin set as low?
     #[inline]
     fn is_set_low(&mut self) -> Result<bool, Self::Error> {
-        Ok(self.is_set_low())
+        Ok((*self).is_set_low())
     }
 }
 
 impl<'d, T: Pin> embedded_hal_1::digital::InputPin for Flex<'d, T> {
     #[inline]
     fn is_high(&mut self) -> Result<bool, Self::Error> {
-        Ok(self.is_high())
+        Ok((*self).is_high())
     }
 
     #[inline]
     fn is_low(&mut self) -> Result<bool, Self::Error> {
-        Ok(self.is_low())
+        Ok((*self).is_low())
     }
 }
 
@@ -1105,13 +1095,13 @@ impl<'d, T: Pin> embedded_hal_1::digital::ErrorType for Flex<'d, T> {
 impl<'d, T: Pin> embedded_hal_1::digital::StatefulOutputPin for Flex<'d, T> {
     #[inline]
     fn is_set_high(&mut self) -> Result<bool, Self::Error> {
-        Ok(self.is_set_high())
+        Ok((*self).is_set_high())
     }
 
     /// Is the output pin set as low?
     #[inline]
     fn is_set_low(&mut self) -> Result<bool, Self::Error> {
-        Ok(self.is_set_low())
+        Ok((*self).is_set_low())
     }
 }
 

--- a/embassy-time/CHANGELOG.md
+++ b/embassy-time/CHANGELOG.md
@@ -24,8 +24,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## 0.1.3 - 2023-08-28
 
-- Update `embedded-hal-async` to `1.0.0-rc.3`
-- Update `embedded-hal v1` to `1.0.0-rc.3`
+- Update `embedded-hal-async` to `1.0.0-rc.2`
+- Update `embedded-hal v1` to `1.0.0-rc.2`
 
 ## 0.1.2 - 2023-07-05
 

--- a/examples/rp/src/bin/button.rs
+++ b/examples/rp/src/bin/button.rs
@@ -16,7 +16,7 @@ async fn main(_spawner: Spawner) {
 
     // Use PIN_28, Pin34 on J0 for RP Pico, as a input.
     // You need to add your own button.
-    let mut button = Input::new(p.PIN_28, Pull::Up);
+    let button = Input::new(p.PIN_28, Pull::Up);
 
     loop {
         if button.is_high() {

--- a/examples/stm32c0/src/bin/button.rs
+++ b/examples/stm32c0/src/bin/button.rs
@@ -12,7 +12,7 @@ fn main() -> ! {
 
     let p = embassy_stm32::init(Default::default());
 
-    let mut button = Input::new(p.PC13, Pull::Up);
+    let button = Input::new(p.PC13, Pull::Up);
 
     loop {
         if button.is_high() {

--- a/examples/stm32f3/src/bin/button.rs
+++ b/examples/stm32f3/src/bin/button.rs
@@ -12,7 +12,7 @@ fn main() -> ! {
 
     let p = embassy_stm32::init(Default::default());
 
-    let mut button = Input::new(p.PA0, Pull::Down);
+    let button = Input::new(p.PA0, Pull::Down);
     let mut led1 = Output::new(p.PE9, Level::High, Speed::Low);
     let mut led2 = Output::new(p.PE15, Level::High, Speed::Low);
 

--- a/examples/stm32f4/src/bin/button.rs
+++ b/examples/stm32f4/src/bin/button.rs
@@ -12,7 +12,7 @@ fn main() -> ! {
 
     let p = embassy_stm32::init(Default::default());
 
-    let mut button = Input::new(p.PC13, Pull::Down);
+    let button = Input::new(p.PC13, Pull::Down);
     let mut led1 = Output::new(p.PB0, Level::High, Speed::Low);
     let _led2 = Output::new(p.PB7, Level::High, Speed::Low);
     let mut led3 = Output::new(p.PB14, Level::High, Speed::Low);

--- a/examples/stm32f7/src/bin/button.rs
+++ b/examples/stm32f7/src/bin/button.rs
@@ -12,7 +12,7 @@ fn main() -> ! {
 
     let p = embassy_stm32::init(Default::default());
 
-    let mut button = Input::new(p.PC13, Pull::Down);
+    let button = Input::new(p.PC13, Pull::Down);
     let mut led1 = Output::new(p.PB0, Level::High, Speed::Low);
     let _led2 = Output::new(p.PB7, Level::High, Speed::Low);
     let mut led3 = Output::new(p.PB14, Level::High, Speed::Low);

--- a/examples/stm32g0/src/bin/button.rs
+++ b/examples/stm32g0/src/bin/button.rs
@@ -12,7 +12,7 @@ fn main() -> ! {
 
     let p = embassy_stm32::init(Default::default());
 
-    let mut button = Input::new(p.PC13, Pull::Up);
+    let button = Input::new(p.PC13, Pull::Up);
 
     loop {
         if button.is_high() {

--- a/examples/stm32g4/src/bin/button.rs
+++ b/examples/stm32g4/src/bin/button.rs
@@ -12,7 +12,7 @@ fn main() -> ! {
 
     let p = embassy_stm32::init(Default::default());
 
-    let mut button = Input::new(p.PC13, Pull::Down);
+    let button = Input::new(p.PC13, Pull::Down);
 
     loop {
         if button.is_high() {

--- a/examples/stm32l0/src/bin/button.rs
+++ b/examples/stm32l0/src/bin/button.rs
@@ -11,7 +11,7 @@ async fn main(_spawner: Spawner) {
     let p = embassy_stm32::init(Default::default());
     info!("Hello World!");
 
-    let mut button = Input::new(p.PB2, Pull::Up);
+    let button = Input::new(p.PB2, Pull::Up);
     let mut led1 = Output::new(p.PA5, Level::High, Speed::Low);
     let mut led2 = Output::new(p.PB5, Level::High, Speed::Low);
 

--- a/examples/stm32l4/src/bin/button.rs
+++ b/examples/stm32l4/src/bin/button.rs
@@ -11,7 +11,7 @@ fn main() -> ! {
 
     let p = embassy_stm32::init(Default::default());
 
-    let mut button = Input::new(p.PC13, Pull::Up);
+    let button = Input::new(p.PC13, Pull::Up);
 
     loop {
         if button.is_high() {

--- a/examples/stm32l4/src/bin/spe_adin1110_http_server.rs
+++ b/examples/stm32l4/src/bin/spe_adin1110_http_server.rs
@@ -111,8 +111,8 @@ async fn main(spawner: Spawner) {
     let led_uc4_blue = Output::new(dp.PG15, Level::High, Speed::Low);
 
     // Read the uc_cfg switches
-    let mut uc_cfg0 = Input::new(dp.PB2, Pull::None);
-    let mut uc_cfg1 = Input::new(dp.PF11, Pull::None);
+    let uc_cfg0 = Input::new(dp.PB2, Pull::None);
+    let uc_cfg1 = Input::new(dp.PF11, Pull::None);
     let _uc_cfg2 = Input::new(dp.PG6, Pull::None);
     let _uc_cfg3 = Input::new(dp.PG11, Pull::None);
 
@@ -130,8 +130,8 @@ async fn main(spawner: Spawner) {
 
     // Setup IO and SPI for the SPE chip
     let spe_reset_n = Output::new(dp.PC7, Level::Low, Speed::Low);
-    let mut spe_cfg0 = Input::new(dp.PC8, Pull::None);
-    let mut spe_cfg1 = Input::new(dp.PC9, Pull::None);
+    let spe_cfg0 = Input::new(dp.PC8, Pull::None);
+    let spe_cfg1 = Input::new(dp.PC9, Pull::None);
     let _spe_ts_capt = Output::new(dp.PC6, Level::Low, Speed::Low);
 
     let spe_int = Input::new(dp.PB11, Pull::None);

--- a/examples/stm32l4/src/bin/spi_blocking_async.rs
+++ b/examples/stm32l4/src/bin/spi_blocking_async.rs
@@ -29,7 +29,7 @@ async fn main(_spawner: Spawner) {
     let _wake = Output::new(p.PB13, Level::Low, Speed::VeryHigh);
     let mut reset = Output::new(p.PE8, Level::Low, Speed::VeryHigh);
     let mut cs = Output::new(p.PE0, Level::High, Speed::VeryHigh);
-    let mut ready = Input::new(p.PE1, Pull::Up);
+    let ready = Input::new(p.PE1, Pull::Up);
 
     cortex_m::asm::delay(100_000);
     reset.set_high();

--- a/examples/stm32l4/src/bin/spi_dma.rs
+++ b/examples/stm32l4/src/bin/spi_dma.rs
@@ -24,7 +24,7 @@ async fn main(_spawner: Spawner) {
     let _wake = Output::new(p.PB13, Level::Low, Speed::VeryHigh);
     let mut reset = Output::new(p.PE8, Level::Low, Speed::VeryHigh);
     let mut cs = Output::new(p.PE0, Level::High, Speed::VeryHigh);
-    let mut ready = Input::new(p.PE1, Pull::Up);
+    let ready = Input::new(p.PE1, Pull::Up);
 
     cortex_m::asm::delay(100_000);
     reset.set_high();

--- a/examples/stm32wl/src/bin/button.rs
+++ b/examples/stm32wl/src/bin/button.rs
@@ -12,7 +12,7 @@ fn main() -> ! {
 
     let p = embassy_stm32::init(Default::default());
 
-    let mut button = Input::new(p.PA0, Pull::Up);
+    let button = Input::new(p.PA0, Pull::Up);
     let mut led1 = Output::new(p.PB15, Level::High, Speed::Low);
     let mut led2 = Output::new(p.PB9, Level::High, Speed::Low);
 

--- a/tests/rp/src/bin/gpio.rs
+++ b/tests/rp/src/bin/gpio.rs
@@ -16,10 +16,10 @@ async fn main(_spawner: Spawner) {
 
     // Test initial output
     {
-        let mut b = Input::new(&mut b, Pull::None);
+        let b = Input::new(&mut b, Pull::None);
 
         {
-            let mut a = Output::new(&mut a, Level::Low);
+            let a = Output::new(&mut a, Level::Low);
             delay();
             assert!(b.is_low());
             assert!(!b.is_high());
@@ -64,7 +64,7 @@ async fn main(_spawner: Spawner) {
 
     // Test input no pull
     {
-        let mut b = Input::new(&mut b, Pull::None);
+        let b = Input::new(&mut b, Pull::None);
         // no pull, the status is undefined
 
         let mut a = Output::new(&mut a, Level::Low);
@@ -77,7 +77,7 @@ async fn main(_spawner: Spawner) {
 
     // Test input pulldown
     {
-        let mut b = Input::new(&mut b, Pull::Down);
+        let b = Input::new(&mut b, Pull::Down);
         delay();
         assert!(b.is_low());
 
@@ -91,7 +91,7 @@ async fn main(_spawner: Spawner) {
 
     // Test input pullup
     {
-        let mut b = Input::new(&mut b, Pull::Up);
+        let b = Input::new(&mut b, Pull::Up);
         delay();
         assert!(b.is_high());
 

--- a/tests/rp/src/bin/pwm.rs
+++ b/tests/rp/src/bin/pwm.rs
@@ -45,7 +45,7 @@ async fn main(_spawner: Spawner) {
 
         // Test output from A
         {
-            let mut pin1 = Input::new(&mut p9, Pull::None);
+            let pin1 = Input::new(&mut p9, Pull::None);
             let _pwm = Pwm::new_output_a(&mut p.PWM_CH3, &mut p6, cfg.clone());
             Timer::after_millis(1).await;
             assert_eq!(pin1.is_low(), invert_a);
@@ -59,7 +59,7 @@ async fn main(_spawner: Spawner) {
 
         // Test output from B
         {
-            let mut pin2 = Input::new(&mut p11, Pull::None);
+            let pin2 = Input::new(&mut p11, Pull::None);
             let _pwm = Pwm::new_output_b(&mut p.PWM_CH3, &mut p7, cfg.clone());
             Timer::after_millis(1).await;
             assert_ne!(pin2.is_low(), invert_a);
@@ -73,8 +73,8 @@ async fn main(_spawner: Spawner) {
 
         // Test output from A+B
         {
-            let mut pin1 = Input::new(&mut p9, Pull::None);
-            let mut pin2 = Input::new(&mut p11, Pull::None);
+            let pin1 = Input::new(&mut p9, Pull::None);
+            let pin2 = Input::new(&mut p11, Pull::None);
             let _pwm = Pwm::new_output_ab(&mut p.PWM_CH3, &mut p6, &mut p7, cfg.clone());
             Timer::after_millis(1).await;
             assert_eq!(pin1.is_low(), invert_a);

--- a/tests/stm32/src/bin/gpio.rs
+++ b/tests/stm32/src/bin/gpio.rs
@@ -20,10 +20,10 @@ async fn main(_spawner: Spawner) {
 
     // Test initial output
     {
-        let mut b = Input::new(&mut b, Pull::None);
+        let b = Input::new(&mut b, Pull::None);
 
         {
-            let mut a = Output::new(&mut a, Level::Low, Speed::Low);
+            let a = Output::new(&mut a, Level::Low, Speed::Low);
             delay();
             assert!(b.is_low());
             assert!(!b.is_high());
@@ -68,7 +68,7 @@ async fn main(_spawner: Spawner) {
 
     // Test input no pull
     {
-        let mut b = Input::new(&mut b, Pull::None);
+        let b = Input::new(&mut b, Pull::None);
         // no pull, the status is undefined
 
         let mut a = Output::new(&mut a, Level::Low, Speed::Low);
@@ -81,7 +81,7 @@ async fn main(_spawner: Spawner) {
 
     // Test input pulldown
     {
-        let mut b = Input::new(&mut b, Pull::Down);
+        let b = Input::new(&mut b, Pull::Down);
         delay();
         assert!(b.is_low());
 
@@ -95,7 +95,7 @@ async fn main(_spawner: Spawner) {
 
     // Test input pullup
     {
-        let mut b = Input::new(&mut b, Pull::Up);
+        let b = Input::new(&mut b, Pull::Up);
         delay();
         assert!(b.is_high());
 
@@ -109,7 +109,7 @@ async fn main(_spawner: Spawner) {
 
     // Test output open drain
     {
-        let mut b = Input::new(&mut b, Pull::Down);
+        let b = Input::new(&mut b, Pull::Down);
         // no pull, the status is undefined
 
         let mut a = OutputOpenDrain::new(&mut a, Level::Low, Speed::Low, Pull::None);


### PR DESCRIPTION
With the embedded-hal rc3 update I changed them to require `&mut self`, but
in retrospect I think `&self` is better, for extra flexibility.

This PR reverts the changes from the rc3 update to inherent methods.
