### PR TITLE
stm32/simple_pwm: add set_output_compare_mode

### DIFF
--- a/embassy-stm32/src/timer/simple_pwm.rs
+++ b/embassy-stm32/src/timer/simple_pwm.rs
@@ -151,6 +151,11 @@ impl<'d, T: CaptureCompare16bitInstance> SimplePwm<'d, T> {
         self.inner.set_output_polarity(channel, polarity);
     }
 
+    /// Set the output compare mode for a given channel.
+    pub fn set_output_compare_mode(&mut self, channel: Channel, mode: OutputCompareMode) {
+        self.inner.set_output_compare_mode(channel, mode);
+    }
+
     /// Generate a sequence of PWM waveform
     ///
     /// Note:  


### PR DESCRIPTION
To use two channels in complementary mode, e.g. to drive a buzzer, a combination of mode PWM1 and PWM2 is necessary.
