### PR TITLE
Embassy nrf docs and nrf91 example

### DIFF
--- a/ci.sh
+++ b/ci.sh
@@ -147,6 +147,7 @@ cargo batch  \
     --- build --release --manifest-path docs/modules/ROOT/examples/layer-by-layer/blinky-async/Cargo.toml --target thumbv7em-none-eabi \
     --- build --release --manifest-path examples/nrf52840/Cargo.toml --target thumbv7em-none-eabi --out-dir out/examples/nrf52840 \
     --- build --release --manifest-path examples/nrf5340/Cargo.toml --target thumbv8m.main-none-eabihf --out-dir out/examples/nrf5340 \
+    --- build --release --manifest-path examples/nrf9160/Cargo.toml --target thumbv8m.main-none-eabihf --out-dir out/examples/nrf9160 \
     --- build --release --manifest-path examples/rp/Cargo.toml --target thumbv6m-none-eabi --out-dir out/examples/rp \
     --- build --release --manifest-path examples/stm32f0/Cargo.toml --target thumbv6m-none-eabi --out-dir out/examples/stm32f0 \
     --- build --release --manifest-path examples/stm32f1/Cargo.toml --target thumbv7m-none-eabi --out-dir out/examples/stm32f1 \

--- a/embassy-nrf/README.md
+++ b/embassy-nrf/README.md
@@ -24,7 +24,7 @@ Most peripherals are supported.
 
 If the `time` feature is enabled, the HAL uses the RTC peripheral as a global time driver for [embassy-time](https://crates.io/crates/embassy-time), with a tick rate of 32768 Hz.
 
-## API
+## Embedded-hal
 
 The `embassy-nrf` HAL implements the traits from [embedded-hal](https://crates.io/crates/embedded-hal) (v0.2 and 1.0) and [embedded-hal-async](https://crates.io/crates/embedded-hal-async), as well as [embedded-io](https://crates.io/crates/embedded-io) and [embedded-io-async](https://crates.io/crates/embedded-io-async).
 

--- a/embassy-nrf/README.md
+++ b/embassy-nrf/README.md
@@ -8,6 +8,20 @@ complete operations in low power mod and handling interrupts, so that applicatio
 
 NOTE: The Embassy HALs can be used both for non-async and async operations. For async, you can choose which runtime you want to use.
 
+## Hardware support
+
+The `embassy-nrf` HAL supports most variants of the nRF family:
+
+* nRF52 ([examples](https://github.com/embassy-rs/embassy/tree/main/examples/nrf52840))
+* nRF53 ([examples](https://github.com/embassy-rs/embassy/tree/main/examples/nrf5340))
+* nRF91 ([examples](https://github.com/embassy-rs/embassy/tree/main/examples/nrf9160))
+
+Most peripherals are supported. For a complete list of available peripherals and features, see the [documentation](https://docs.embassy.dev/embassy-nrf/git/nrf52805/index.html).
+
+## API
+
+The `embassy-nrf` HAL implements the traits from [embedded-hal](https://crates.io/crates/embedded-hal) (v0.2 and 1.0) and [embedded-hal-async](https://crates.io/crates/embedded-hal-async), as well as [embedded-io](https://crates.io/crates/embedded-io) and [embedded-io-async](https://crates.io/crates/embedded-io-async).
+
 ## EasyDMA considerations
 
 On nRF chips, peripherals can use the so called EasyDMA feature to offload the task of interacting

--- a/embassy-nrf/README.md
+++ b/embassy-nrf/README.md
@@ -8,6 +8,8 @@ complete operations in low power mod and handling interrupts, so that applicatio
 
 NOTE: The Embassy HALs can be used both for non-async and async operations. For async, you can choose which runtime you want to use.
 
+For a complete list of available peripherals and features, see the [embassy-nrf documentation](https://docs.embassy.dev/embassy-nrf).
+
 ## Hardware support
 
 The `embassy-nrf` HAL supports most variants of the nRF family:
@@ -16,9 +18,11 @@ The `embassy-nrf` HAL supports most variants of the nRF family:
 * nRF53 ([examples](https://github.com/embassy-rs/embassy/tree/main/examples/nrf5340))
 * nRF91 ([examples](https://github.com/embassy-rs/embassy/tree/main/examples/nrf9160))
 
-Most peripherals are supported. If the `time` feature is enabled, the HAL uses the RTC peripheral as a global time driver for [embassy-time](https://crates.io/crates/embassy-time), with a tick rate of 32768 Hz.
+Most peripherals are supported. 
 
-For a complete list of available peripherals and features, see the [documentation](https://docs.embassy.dev/embassy-nrf/git/nrf52805/index.html).
+## Time driver
+
+If the `time` feature is enabled, the HAL uses the RTC peripheral as a global time driver for [embassy-time](https://crates.io/crates/embassy-time), with a tick rate of 32768 Hz.
 
 ## API
 

--- a/embassy-nrf/README.md
+++ b/embassy-nrf/README.md
@@ -16,7 +16,9 @@ The `embassy-nrf` HAL supports most variants of the nRF family:
 * nRF53 ([examples](https://github.com/embassy-rs/embassy/tree/main/examples/nrf5340))
 * nRF91 ([examples](https://github.com/embassy-rs/embassy/tree/main/examples/nrf9160))
 
-Most peripherals are supported. For a complete list of available peripherals and features, see the [documentation](https://docs.embassy.dev/embassy-nrf/git/nrf52805/index.html).
+Most peripherals are supported. If the `time` feature is enabled, the HAL uses the RTC peripheral as a global time driver for [embassy-time](https://crates.io/crates/embassy-time), with a tick rate of 32768 Hz.
+
+For a complete list of available peripherals and features, see the [documentation](https://docs.embassy.dev/embassy-nrf/git/nrf52805/index.html).
 
 ## API
 

--- a/examples/nrf9160/.cargo/config.toml
+++ b/examples/nrf9160/.cargo/config.toml
@@ -1,0 +1,9 @@
+[target.'cfg(all(target_arch = "arm", target_os = "none"))']
+# replace nRF82840_xxAA with your chip as listed in `probe-rs chip list`
+runner = "probe-rs run --chip nRF9160_xxAA"
+
+[build]
+target = "thumbv8m.main-none-eabihf"
+
+[env]
+DEFMT_LOG = "trace"

--- a/examples/nrf9160/Cargo.toml
+++ b/examples/nrf9160/Cargo.toml
@@ -5,36 +5,16 @@ version = "0.1.0"
 license = "MIT OR Apache-2.0"
 
 [dependencies]
-embassy-futures = { version = "0.1.0", path = "../../embassy-futures" }
-embassy-sync = { version = "0.5.0", path = "../../embassy-sync", features = ["defmt"] }
 embassy-executor = { version = "0.4.0", path = "../../embassy-executor", features = ["task-arena-size-32768", "arch-cortex-m", "executor-thread", "executor-interrupt", "defmt", "integrated-timers"] }
 embassy-time = { version = "0.2", path = "../../embassy-time", features = ["defmt", "defmt-timestamp-uptime"] }
 embassy-nrf = { version = "0.1.0", path = "../../embassy-nrf", features = ["defmt", "nrf9160-s", "time-driver-rtc1", "gpiote", "unstable-pac", "time"] }
-embassy-net = { version = "0.3", path = "../../embassy-net", features = ["defmt", "tcp", "dhcpv4", "medium-ethernet"] }
-embassy-usb = { version = "0.1.0", path = "../../embassy-usb", features = ["defmt"] }
-embedded-io = { version = "0.6.0", features = ["defmt-03"]  }
-embedded-io-async = { version = "0.6.1", features = ["defmt-03"] }
-embassy-net-esp-hosted = { version = "0.1.0", path = "../../embassy-net-esp-hosted", features = ["defmt"] }
-embassy-net-enc28j60 = { version = "0.1.0", path = "../../embassy-net-enc28j60", features = ["defmt"] }
 
 defmt = "0.3"
 defmt-rtt = "0.4"
 
-fixed = "1.10.0"
-static_cell = { version = "2" }
 cortex-m = { version = "0.7.6", features = ["inline-asm", "critical-section-single-core"] }
 cortex-m-rt = "0.7.0"
 panic-probe = { version = "0.3", features = ["print-defmt"] }
-futures = { version = "0.3.17", default-features = false, features = ["async-await"] }
-rand = { version = "0.8.4", default-features = false }
-embedded-storage = "0.3.1"
-usbd-hid = "0.6.0"
-serde = { version = "1.0.136", default-features = false }
-embedded-hal = { version = "1.0" }
-embedded-hal-async = { version = "1.0" }
-embedded-hal-bus = { version = "0.1", features = ["async"] }
-num-integer = { version = "0.1.45", default-features = false }
-microfft = "0.5.0"
 
 [profile.release]
 debug = 2

--- a/examples/nrf9160/Cargo.toml
+++ b/examples/nrf9160/Cargo.toml
@@ -9,7 +9,7 @@ embassy-futures = { version = "0.1.0", path = "../../embassy-futures" }
 embassy-sync = { version = "0.5.0", path = "../../embassy-sync", features = ["defmt"] }
 embassy-executor = { version = "0.4.0", path = "../../embassy-executor", features = ["task-arena-size-32768", "arch-cortex-m", "executor-thread", "executor-interrupt", "defmt", "integrated-timers"] }
 embassy-time = { version = "0.2", path = "../../embassy-time", features = ["defmt", "defmt-timestamp-uptime"] }
-embassy-nrf = { version = "0.1.0", path = "../../embassy-nrf", features = ["defmt", "nrf9160-ns", "time-driver-rtc1", "gpiote", "unstable-pac", "time"] }
+embassy-nrf = { version = "0.1.0", path = "../../embassy-nrf", features = ["defmt", "nrf9160-s", "time-driver-rtc1", "gpiote", "unstable-pac", "time"] }
 embassy-net = { version = "0.3", path = "../../embassy-net", features = ["defmt", "tcp", "dhcpv4", "medium-ethernet"] }
 embassy-usb = { version = "0.1.0", path = "../../embassy-usb", features = ["defmt"] }
 embedded-io = { version = "0.6.0", features = ["defmt-03"]  }

--- a/examples/nrf9160/Cargo.toml
+++ b/examples/nrf9160/Cargo.toml
@@ -1,0 +1,40 @@
+[package]
+edition = "2021"
+name = "embassy-nrf9160-examples"
+version = "0.1.0"
+license = "MIT OR Apache-2.0"
+
+[dependencies]
+embassy-futures = { version = "0.1.0", path = "../../embassy-futures" }
+embassy-sync = { version = "0.5.0", path = "../../embassy-sync", features = ["defmt"] }
+embassy-executor = { version = "0.4.0", path = "../../embassy-executor", features = ["task-arena-size-32768", "arch-cortex-m", "executor-thread", "executor-interrupt", "defmt", "integrated-timers"] }
+embassy-time = { version = "0.2", path = "../../embassy-time", features = ["defmt", "defmt-timestamp-uptime"] }
+embassy-nrf = { version = "0.1.0", path = "../../embassy-nrf", features = ["defmt", "nrf9160-ns", "time-driver-rtc1", "gpiote", "unstable-pac", "time"] }
+embassy-net = { version = "0.3", path = "../../embassy-net", features = ["defmt", "tcp", "dhcpv4", "medium-ethernet"] }
+embassy-usb = { version = "0.1.0", path = "../../embassy-usb", features = ["defmt"] }
+embedded-io = { version = "0.6.0", features = ["defmt-03"]  }
+embedded-io-async = { version = "0.6.1", features = ["defmt-03"] }
+embassy-net-esp-hosted = { version = "0.1.0", path = "../../embassy-net-esp-hosted", features = ["defmt"] }
+embassy-net-enc28j60 = { version = "0.1.0", path = "../../embassy-net-enc28j60", features = ["defmt"] }
+
+defmt = "0.3"
+defmt-rtt = "0.4"
+
+fixed = "1.10.0"
+static_cell = { version = "2" }
+cortex-m = { version = "0.7.6", features = ["inline-asm", "critical-section-single-core"] }
+cortex-m-rt = "0.7.0"
+panic-probe = { version = "0.3", features = ["print-defmt"] }
+futures = { version = "0.3.17", default-features = false, features = ["async-await"] }
+rand = { version = "0.8.4", default-features = false }
+embedded-storage = "0.3.1"
+usbd-hid = "0.6.0"
+serde = { version = "1.0.136", default-features = false }
+embedded-hal = { version = "1.0" }
+embedded-hal-async = { version = "1.0" }
+embedded-hal-bus = { version = "0.1", features = ["async"] }
+num-integer = { version = "0.1.45", default-features = false }
+microfft = "0.5.0"
+
+[profile.release]
+debug = 2

--- a/examples/nrf9160/build.rs
+++ b/examples/nrf9160/build.rs
@@ -1,0 +1,35 @@
+//! This build script copies the `memory.x` file from the crate root into
+//! a directory where the linker can always find it at build time.
+//! For many projects this is optional, as the linker always searches the
+//! project root directory -- wherever `Cargo.toml` is. However, if you
+//! are using a workspace or have a more complicated build setup, this
+//! build script becomes required. Additionally, by requesting that
+//! Cargo re-run the build script whenever `memory.x` is changed,
+//! updating `memory.x` ensures a rebuild of the application with the
+//! new memory settings.
+
+use std::env;
+use std::fs::File;
+use std::io::Write;
+use std::path::PathBuf;
+
+fn main() {
+    // Put `memory.x` in our output directory and ensure it's
+    // on the linker search path.
+    let out = &PathBuf::from(env::var_os("OUT_DIR").unwrap());
+    File::create(out.join("memory.x"))
+        .unwrap()
+        .write_all(include_bytes!("memory.x"))
+        .unwrap();
+    println!("cargo:rustc-link-search={}", out.display());
+
+    // By default, Cargo will re-run a build script whenever
+    // any file in the project changes. By specifying `memory.x`
+    // here, we ensure the build script is only re-run when
+    // `memory.x` is changed.
+    println!("cargo:rerun-if-changed=memory.x");
+
+    println!("cargo:rustc-link-arg-bins=--nmagic");
+    println!("cargo:rustc-link-arg-bins=-Tlink.x");
+    println!("cargo:rustc-link-arg-bins=-Tdefmt.x");
+}

--- a/examples/nrf9160/memory.x
+++ b/examples/nrf9160/memory.x
@@ -1,7 +1,5 @@
 MEMORY
 {
-  /* Assumes Secure Partition Manager (SPM) flashed at the start */
-  SPM                      : ORIGIN = 0x00000000, LENGTH = 320K
-  FLASH                    : ORIGIN = 0x00050000, LENGTH = 704K
+  FLASH                    : ORIGIN = 0x00000000, LENGTH = 1024K
   RAM                      : ORIGIN = 0x20018000, LENGTH = 160K
 }

--- a/examples/nrf9160/memory.x
+++ b/examples/nrf9160/memory.x
@@ -1,0 +1,7 @@
+MEMORY
+{
+  /* Assumes Secure Partition Manager (SPM) flashed at the start */
+  SPM                      : ORIGIN = 0x00000000, LENGTH = 320K
+  FLASH                    : ORIGIN = 0x00050000, LENGTH = 704K
+  RAM                      : ORIGIN = 0x20018000, LENGTH = 160K
+}

--- a/examples/nrf9160/src/bin/blinky.rs
+++ b/examples/nrf9160/src/bin/blinky.rs
@@ -1,0 +1,20 @@
+#![no_std]
+#![no_main]
+
+use embassy_executor::Spawner;
+use embassy_nrf::gpio::{Level, Output, OutputDrive};
+use embassy_time::Timer;
+use {defmt_rtt as _, panic_probe as _};
+
+#[embassy_executor::main]
+async fn main(_spawner: Spawner) {
+    let p = embassy_nrf::init(Default::default());
+    let mut led = Output::new(p.P0_02, Level::Low, OutputDrive::Standard);
+
+    loop {
+        led.set_high();
+        Timer::after_millis(300).await;
+        led.set_low();
+        Timer::after_millis(300).await;
+    }
+}


### PR DESCRIPTION
It occurred to me we don't have nrf91 example. The nrf91 example assumes the SPM module (for instance installed using https://github.com/tweedegolf/nrf9160-rust-starter/). Not sure where to best explain that?