### PR TITLE
stm32/adc: Allow Adc::read to take !Sized arg

### DIFF
--- a/embassy-stm32/src/adc/f1.rs
+++ b/embassy-stm32/src/adc/f1.rs
@@ -136,7 +136,7 @@ impl<'d, T: Instance> Adc<'d, T> {
         T::regs().dr().read().0 as u16
     }
 
-    pub async fn read(&mut self, pin: &mut impl AdcPin<T>) -> u16 {
+    pub async fn read(&mut self, pin: &mut (impl AdcPin<T> + ?Sized)) -> u16 {
         Self::set_channel_sample_time(pin.channel(), self.sample_time);
         T::regs().cr1().modify(|reg| {
             reg.set_scan(false);

--- a/embassy-stm32/src/adc/f3.rs
+++ b/embassy-stm32/src/adc/f3.rs
@@ -155,7 +155,7 @@ impl<'d, T: Instance> Adc<'d, T> {
         T::regs().dr().read().rdata()
     }
 
-    pub async fn read(&mut self, pin: &mut impl AdcPin<T>) -> u16 {
+    pub async fn read(&mut self, pin: &mut (impl AdcPin<T> + ?Sized)) -> u16 {
         Self::set_channel_sample_time(pin.channel(), self.sample_time);
 
         // Configure the channel to sample

--- a/embassy-stm32/src/adc/f3_v1_1.rs
+++ b/embassy-stm32/src/adc/f3_v1_1.rs
@@ -276,7 +276,7 @@ impl<'d, T: Instance> Adc<'d, T> {
         }
     }
 
-    pub async fn read(&mut self, pin: &mut impl AdcPin<T>) -> u16 {
+    pub async fn read(&mut self, pin: &mut (impl AdcPin<T> + ?Sized)) -> u16 {
         self.set_sample_sequence(&[pin.channel()]).await;
         self.convert().await
     }

--- a/embassy-stm32/src/adc/v1.rs
+++ b/embassy-stm32/src/adc/v1.rs
@@ -133,7 +133,7 @@ impl<'d, T: Instance> Adc<'d, T> {
         T::regs().cfgr1().modify(|reg| reg.set_res(resolution.into()));
     }
 
-    pub async fn read(&mut self, pin: &mut impl AdcPin<T>) -> u16 {
+    pub async fn read(&mut self, pin: &mut (impl AdcPin<T> + ?Sized)) -> u16 {
         let channel = pin.channel();
         pin.set_as_analog();
 

--- a/embassy-stm32/src/adc/v2.rs
+++ b/embassy-stm32/src/adc/v2.rs
@@ -174,7 +174,7 @@ where
         T::regs().dr().read().0 as u16
     }
 
-    pub fn read(&mut self, pin: &mut impl AdcPin<T>) -> u16 {
+    pub fn read(&mut self, pin: &mut (impl AdcPin<T> + ?Sized)) -> u16 {
         pin.set_as_analog();
 
         // Configure ADC

--- a/embassy-stm32/src/adc/v3.rs
+++ b/embassy-stm32/src/adc/v3.rs
@@ -162,7 +162,7 @@ impl<'d, T: Instance> Adc<'d, T> {
         T::regs().dr().read().0 as u16
     }
 
-    pub fn read(&mut self, pin: &mut impl AdcPin<T>) -> u16 {
+    pub fn read(&mut self, pin: &mut (impl AdcPin<T> + ?Sized)) -> u16 {
         // Make sure bits are off
         while T::regs().cr().read().addis() {
             // spin

--- a/embassy-stm32/src/adc/v4.rs
+++ b/embassy-stm32/src/adc/v4.rs
@@ -276,6 +276,7 @@ impl<'d, T: Instance> Adc<'d, T> {
     pub fn read<P>(&mut self, pin: &mut P) -> u16
     where
         P: AdcPin<T>,
+        P: ?Sized,
         P: crate::gpio::sealed::Pin,
     {
         pin.set_as_analog();


### PR DESCRIPTION
tl;dr: The default bound of `Sized` is unnecessarily strict, and creates an obstacle for me.

My use case is that I want to loop over many ADC pins and read them, so I want to put all my pins in an array:
```rs
let mut pins : [?; 2] = [
    &mut p.PC0,
    &mut p.PC1,
];
```
and here I want some type which I can "upcast" all my pins to (`?` in the snippet above). In certain other interfaces in Embassy you can just use `AnyPin` if you want a "type erased" pin, but in the case of `Adc::read` we need to pass a parameter which implements `AdcPin<T>`, so I ended up with this approach (simplified somewhat from my real code):
```rs
#[embassy_executor::main]
async fn main(_spawner: Spawner) {
    let mut p = embassy_stm32::init(Default::default());

    let mut detectors : [&mut dyn AdcPin<ADC2>; 2] = [
       &mut p.PC0,
       &mut p.PC1,
    ];

    let mut adc = Adc::new(p.ADC2, &mut Delay);

    loop {
        for d in &mut detectors {
            let value = adc.read(*d);
            dbg!(value);
        }
    }
}
```
But this also does not compile, because `Adc::read` expects the pin parameter to be a sized type, but my trait objects are of course not sized. Hence I'd like to relax this bound to make this compile.

There might be more elegant solutions to this problem; any suggestions are welcome.