### PR TITLE
Revert "stm32-wpan: Pin dep to work around regression"

### DIFF
--- a/embassy-stm32-wpan/Cargo.toml
+++ b/embassy-stm32-wpan/Cargo.toml
@@ -34,9 +34,7 @@ aligned = "0.4.1"
 
 bit_field = "0.10.2"
 stm32-device-signature = { version = "0.3.3", features = ["stm32wb5x"] }
-# NOTE: pinned to avoid regression:
-# https://github.com/OueslatiGhaith/stm32wb-hci/issues/8
-stm32wb-hci = { version = "=0.17.0", optional = true }
+stm32wb-hci = { version = "0.17.0", optional = true }
 futures = { version = "0.3.17", default-features = false, features = ["async-await"] }
 bitflags = { version = "2.3.3", optional = true }
 


### PR DESCRIPTION
Reverts embassy-rs/embassy#2457

https://github.com/OueslatiGhaith/stm32wb-hci/issues/8 got fixed and the regression yanked, worth seeing if CI is still green.