### PR TITLE
Add parameter for enabling pull-up and pull-down in RP PWM input mode

### DIFF
--- a/examples/rp/src/bin/pwm_input.rs
+++ b/examples/rp/src/bin/pwm_input.rs
@@ -5,6 +5,7 @@
 
 use defmt::*;
 use embassy_executor::Spawner;
+use embassy_rp::gpio::Pull;
 use embassy_rp::pwm::{Config, InputMode, Pwm};
 use embassy_time::{Duration, Ticker};
 use {defmt_rtt as _, panic_probe as _};
@@ -14,7 +15,7 @@ async fn main(_spawner: Spawner) {
     let p = embassy_rp::init(Default::default());
 
     let cfg: Config = Default::default();
-    let pwm = Pwm::new_input(p.PWM_SLICE2, p.PIN_5, InputMode::RisingEdge, cfg);
+    let pwm = Pwm::new_input(p.PWM_SLICE2, p.PIN_5, Pull::None, InputMode::RisingEdge, cfg);
 
     let mut ticker = Ticker::every(Duration::from_secs(1));
     loop {

--- a/tests/rp/src/bin/pwm.rs
+++ b/tests/rp/src/bin/pwm.rs
@@ -94,7 +94,7 @@ async fn main(_spawner: Spawner) {
     // Test level-gated
     {
         let mut pin2 = Output::new(&mut p11, Level::Low);
-        let pwm = Pwm::new_input(&mut p.PWM_SLICE3, &mut p7, InputMode::Level, cfg.clone());
+        let pwm = Pwm::new_input(&mut p.PWM_SLICE3, &mut p7, Pull::None, InputMode::Level, cfg.clone());
         assert_eq!(pwm.counter(), 0);
         Timer::after_millis(5).await;
         assert_eq!(pwm.counter(), 0);
@@ -110,7 +110,13 @@ async fn main(_spawner: Spawner) {
     // Test rising-gated
     {
         let mut pin2 = Output::new(&mut p11, Level::Low);
-        let pwm = Pwm::new_input(&mut p.PWM_SLICE3, &mut p7, InputMode::RisingEdge, cfg.clone());
+        let pwm = Pwm::new_input(
+            &mut p.PWM_SLICE3,
+            &mut p7,
+            Pull::None,
+            InputMode::RisingEdge,
+            cfg.clone(),
+        );
         assert_eq!(pwm.counter(), 0);
         Timer::after_millis(5).await;
         assert_eq!(pwm.counter(), 0);
@@ -125,7 +131,13 @@ async fn main(_spawner: Spawner) {
     // Test falling-gated
     {
         let mut pin2 = Output::new(&mut p11, Level::High);
-        let pwm = Pwm::new_input(&mut p.PWM_SLICE3, &mut p7, InputMode::FallingEdge, cfg.clone());
+        let pwm = Pwm::new_input(
+            &mut p.PWM_SLICE3,
+            &mut p7,
+            Pull::None,
+            InputMode::FallingEdge,
+            cfg.clone(),
+        );
         assert_eq!(pwm.counter(), 0);
         Timer::after_millis(5).await;
         assert_eq!(pwm.counter(), 0);
@@ -135,6 +147,34 @@ async fn main(_spawner: Spawner) {
         assert_eq!(pwm.counter(), 1);
         Timer::after_millis(1).await;
         assert_eq!(pwm.counter(), 1);
+    }
+
+    // pull-down
+    {
+        let pin2 = Input::new(&mut p11, Pull::None);
+        Pwm::new_input(
+            &mut p.PWM_SLICE3,
+            &mut p7,
+            Pull::Down,
+            InputMode::FallingEdge,
+            cfg.clone(),
+        );
+        Timer::after_millis(1).await;
+        assert!(pin2.is_low());
+    }
+
+    // pull-up
+    {
+        let pin2 = Input::new(&mut p11, Pull::None);
+        Pwm::new_input(
+            &mut p.PWM_SLICE3,
+            &mut p7,
+            Pull::Up,
+            InputMode::FallingEdge,
+            cfg.clone(),
+        );
+        Timer::after_millis(1).await;
+        assert!(pin2.is_high());
     }
 
     info!("Test OK");


### PR DESCRIPTION
I created this simple change that allows pin B (the one that can be used as PWM counter input) to be set with pull-up or pull-down internal resistor.

I made tests for two most important cases. I was thinking about adding extra test for checking if the input is floating by default, but it even in case of code being wrong test could on occasion pass so I decided not to add it:
```
    // PWM input is floating by default
    {
        let pin2 = Input::new(&mut p11, Pull::Down);
        let pwm = Pwm::new_input(&mut p.PWM_CH3, &mut p7, Pull::None, InputMode::FallingEdge, cfg.clone());
        Timer::after_millis(1).await;
        assert!(pin2.is_low());
    }
    {
        let pin2 = Input::new(&mut p11, Pull::Up);
        let pwm = Pwm::new_input(&mut p.PWM_CH3, &mut p7, Pull::None, InputMode::FallingEdge, cfg.clone());
        Timer::after_millis(1).await;
        assert!(pin2.is_high());
    }
```
Alternative test for this case could be to use ADC with pullup/down and check voltage levels, in case the voltage was in the middle it would mean that an opposite pullup/down resistor was enabled when it shouldn't, but it would require rewiring test board and would be in my opinion a bit overkill.

Please note that I'm barely experienced in Rust and I'm an amateur in EE/embedded field so I'd advice extra caution reviewing the proposed change. 