### PR TITLE
Fix the backticks on the getting started page

### DIFF
--- a/docs/modules/ROOT/pages/getting_started.adoc
+++ b/docs/modules/ROOT/pages/getting_started.adoc
@@ -88,7 +88,7 @@ NOTE: How does the `cargo run` command know how to connect to our board and prog
 
 If you hare having issues when running `cargo run --release`, please check the following:
 
-* You are specifying the correct `--chip on the command line``, OR
+* You are specifying the correct `--chip` on the command line, OR
 * You have set `.cargo/config.toml`'s run line to the correct chip, AND
 * You have changed `examples/Cargo.toml`'s HAL (e.g. embassy-stm32) dependency's feature to use the correct chip (replace the existing stm32xxxx feature)
 


### PR DESCRIPTION
![image](https://github.com/embassy-rs/embassy/assets/10117564/d9c7b4a9-980e-4a52-9cc2-c32093e0227e)

There was a little mistake in the formatting on the Getting Started page of the docs. This is just a quick fix to what I think the intended markup was.