### PR TITLE
use constant for the pwm clock

### DIFF
--- a/embassy-nrf/src/pwm.rs
+++ b/embassy-nrf/src/pwm.rs
@@ -47,6 +47,7 @@ pub enum Error {
 }
 
 const MAX_SEQUENCE_LEN: usize = 32767;
+/// The used pwm clock frequency
 pub const PWM_CLK_HZ: u32 = 16_000_000;
 
 impl<'d, T: Instance> SequencePwm<'d, T> {

--- a/embassy-nrf/src/pwm.rs
+++ b/embassy-nrf/src/pwm.rs
@@ -715,6 +715,13 @@ impl<'d, T: Instance> SimplePwm<'d, T> {
         pwm
     }
 
+    /// Returns the enable state of the pwm counter
+    #[inline(always)]
+    pub fn is_enabled(&self) -> bool {
+        let r = T::regs();
+        r.enable.read().enable().bit_is_set()
+    }
+
     /// Enables the PWM generator.
     #[inline(always)]
     pub fn enable(&self) {

--- a/embassy-nrf/src/pwm.rs
+++ b/embassy-nrf/src/pwm.rs
@@ -47,6 +47,7 @@ pub enum Error {
 }
 
 const MAX_SEQUENCE_LEN: usize = 32767;
+pub const PWM_CLK_HZ: u32 = 16_000_000;
 
 impl<'d, T: Instance> SequencePwm<'d, T> {
     /// Create a new 1-channel PWM
@@ -788,7 +789,7 @@ impl<'d, T: Instance> SimplePwm<'d, T> {
     /// Sets the PWM output frequency.
     #[inline(always)]
     pub fn set_period(&self, freq: u32) {
-        let clk = 16_000_000u32 >> (self.prescaler() as u8);
+        let clk = PWM_CLK_HZ >> (self.prescaler() as u8);
         let duty = clk / freq;
         self.set_max_duty(duty.min(32767) as u16);
     }
@@ -796,7 +797,7 @@ impl<'d, T: Instance> SimplePwm<'d, T> {
     /// Returns the PWM output frequency.
     #[inline(always)]
     pub fn period(&self) -> u32 {
-        let clk = 16_000_000u32 >> (self.prescaler() as u8);
+        let clk = PWM_CLK_HZ >> (self.prescaler() as u8);
         let max_duty = self.max_duty() as u32;
         clk / max_duty
     }


### PR DESCRIPTION
So it can be used outside of the crate to calculate max duty