### PR TITLE
fix: typo in netcat command for std example

### DIFF
--- a/examples/std/README.md
+++ b/examples/std/README.md
@@ -13,7 +13,7 @@ sudo ip -6 route add fe80::/64 dev tap0
 sudo ip -6 route add fdaa::/64 dev tap0
 ```
 
-Second, have something listening there. For example `nc -l 8000`
+Second, have something listening there. For example `nc -lp 8000`
 
 Then run the example located in the `examples` folder:
 


### PR DESCRIPTION
The previous given command `nc -l 8000` doesn't let me see anything and lead to a "WARN connect error: ConnectionReset". By explicitly changing the `local-port` of `nc` with the `-p` I can now see the `Hello` message printed, and the warning log disappeared.