### PR TITLE
Fix underflow in embassy-rp uartrx.read_to_break

### DIFF
--- a/embassy-rp/src/uart/mod.rs
+++ b/embassy-rp/src/uart/mod.rs
@@ -604,8 +604,8 @@ impl<'d, T: Instance> UartRx<'d, T, Async> {
             return match (all_full, last_was_break) {
                 (true, true) | (false, _) => {
                     // We got less than the full amount + a break, or the full amount
-                    // and the last byte was a break. Subtract the break off.
-                    Ok((next_addr - 1) - sval)
+                    // and the last byte was a break. Subtract the break off by adding one to sval.
+                    Ok(next_addr.saturating_sub(1 + sval))
                 }
                 (true, false) => {
                     // We finished the whole DMA, and the last DMA'd byte was NOT a break


### PR DESCRIPTION
This fixes #2490.

In rare cases the line break can be triggered without any data having been read which causes both `next_addr` and `sval` to be the same value. Subtracting 1 and `sval` from `next_addr` causes an underflow panic in debug mode and  a high chance of panic in release mode when the user uses the returned `usize::Max` value to try and index their data 