### PR TITLE
Interface for programming Option Bytes on stm32g family.

### DIFF
--- a/embassy-stm32/src/flash/g.rs
+++ b/embassy-stm32/src/flash/g.rs
@@ -30,6 +30,51 @@ pub(crate) unsafe fn unlock() {
     }
 }
 
+/// This locks the option bytes, but doesn't "enable" or flash them.
+pub(crate) unsafe fn opt_lock() {
+    pac::FLASH.cr().modify(|w| w.set_optlock(true));
+}
+
+/// Unlock option bytes registers according to RM0440 page 206.
+/// Flash needs to be unlocked first to use this.
+pub(crate) unsafe fn opt_unlock() {
+    // Unlock option bytes
+    if pac::FLASH.cr().read().optlock() {
+        pac::FLASH.optkeyr().write_value(0x0819_2A3B);
+        pac::FLASH.optkeyr().write_value(0x4C5D_6E7F);
+    }
+}
+
+/// This should flash the option bytes and restart the device.
+/// If it returns - something went wrong (eg. option bytes are locked).
+pub(crate) unsafe fn opt_reload() {
+    pac::FLASH.cr().modify(|w| w.set_optstrt(true));
+    while pac::FLASH.sr().read().bsy() {}
+}
+
+/// Program the option bytes according to procedure from RM0440. Pass a function
+/// that changes required bits within the option bytes. On success, this
+/// function doesn't return - it resets the device. Before calling it, check if
+/// the option bytes were already programmed.
+pub unsafe fn program_option_bytes(setter: impl FnOnce() -> ()) {
+    // Unlocking flash also waits for all flash operations to cease.
+    unlock();
+    opt_unlock();
+    assert_eq!(pac::FLASH.cr().read().optlock(), false);
+
+    // Call user setter and modify the bits.
+    setter();
+
+    // This should reset and configured the bits and not return.
+    opt_reload();
+
+    // But if we failed: cleanup.
+    pac::FLASH.cr().modify(|w| w.set_obl_launch(true));
+    opt_lock();
+    lock();
+}
+
+
 pub(crate) unsafe fn enable_blocking_write() {
     assert_eq!(0, WRITE_SIZE % 4);
     pac::FLASH.cr().write(|w| w.set_pg(true));


### PR DESCRIPTION
Seems to work for me like this:
```rust
unsafe {                                      
    flash::program_option_bytes(|| {          
        pac::FLASH.optr().modify(|r| {        
            r.set_n_boot0(true);              
            r.set_n_swboot0(false);           
        });                                   
        let data = pac::FLASH.optr().read();  
        assert_eq!(data.n_boot0(), true);     
        assert_eq!(data.n_swboot0(), false);  
    });                                       
}                                             
```

Instead of doing the whole process (as unlock/lock is pub(crate) only):

```rust
// Wait, while the memory interface is busy.                
while pac::FLASH.sr().read().bsy() {}                       
                                                            
// Unlock flash                                             
if pac::FLASH.cr().read().lock() {                          
    defmt::info!("Flash is locked, unlocking");             
    /* Magic bytes from embassy-stm32/src/flash/g.rs / RM */
    pac::FLASH.keyr().write_value(0x4567_0123);             
    pac::FLASH.keyr().write_value(0xCDEF_89AB);             
}                                                           
// Check: Should be unlocked.                               
assert_eq!(pac::FLASH.cr().read().lock(), false);           
                                                            
// Unlock Option bytes                                      
if pac::FLASH.cr().read().optlock() {                       
    defmt::info!("Option bytes locked, unlocking");         
                                                            
    /* Source: RM / original HAL */                         
    pac::FLASH.optkeyr().write_value(0x0819_2A3B);          
    pac::FLASH.optkeyr().write_value(0x4C5D_6E7F);          
}                                                           
// Check: Should be unlocked                                
assert_eq!(pac::FLASH.cr().read().optlock(), false);        
                                                            
/* Program boot0 */                                         
pac::FLASH.optr().modify(|r| {                              
    r.set_n_boot0(true);                                    
    r.set_n_swboot0(false);                                 
});                                                         
                                                            
// Check: Should have changed                               
assert_eq!(pac::FLASH.optr().read().n_boot0(), true);       
assert_eq!(pac::FLASH.optr().read().n_swboot0(), false);    
                                                            
// Reload option bytes. This should in general cause RESET. 
pac::FLASH.cr().modify(|w| w.set_optstrt(true));            
while pac::FLASH.sr().read().bsy() {}                       
                                                            
pac::FLASH.cr().modify(|w| w.set_obl_launch(true));         
                                                            
defmt::info!("Relocking");  
// Lock option bytes and flash                              
pac::FLASH.cr().modify(|w| w.set_optlock(true));            
pac::FLASH.cr().modify(|w| w.set_lock(true));               

```