### PR TITLE
NRF: handle `uarte` RX errors

### DIFF
--- a/embassy-nrf/Cargo.toml
+++ b/embassy-nrf/Cargo.toml
@@ -133,6 +133,7 @@ embedded-io = { version = "0.6.0" }
 embedded-io-async = { version = "0.6.1" }
 
 defmt = { version = "0.3", optional = true }
+bitflags = "2.4.2"
 log = { version = "0.4.14", optional = true }
 cortex-m-rt = ">=0.6.15,<0.8"
 cortex-m = "0.7.6"

--- a/embassy-nrf/src/uarte.rs
+++ b/embassy-nrf/src/uarte.rs
@@ -676,7 +676,7 @@ impl<'d, T: Instance> UarteRx<'d, T> {
         let result = poll_fn(|cx| {
             s.endrx_waker.register(cx.waker());
 
-            if let Err(e) =  self.check_and_clear_errors() {
+            if let Err(e) = self.check_and_clear_errors() {
                 return Poll::Ready(Err(e));
             }
             if r.events_endrx.read().bits() != 0 {
@@ -810,7 +810,10 @@ impl<'d, T: Instance, U: TimerInstance> UarteRxWithIdle<'d, T, U> {
 
         r.events_endrx.reset();
         r.events_error.reset();
-        r.intenset.write(|w| {w.endrx().set(); w.error().set()});
+        r.intenset.write(|w| {
+            w.endrx().set();
+            w.error().set()
+        });
 
         compiler_fence(Ordering::SeqCst);
 
@@ -864,7 +867,10 @@ impl<'d, T: Instance, U: TimerInstance> UarteRxWithIdle<'d, T, U> {
 
         r.events_endrx.reset();
         r.events_error.reset();
-        r.intenclr.write(|w| {w.endrx().clear(); w.error().clear()});
+        r.intenclr.write(|w| {
+            w.endrx().clear();
+            w.error().clear()
+        });
 
         compiler_fence(Ordering::SeqCst);
 


### PR DESCRIPTION
This PR adds a mechanism to handle RX errors for UART RX transactions.

Closes #2500.