### PR TITLE
STM32WB: Add scatter memory files for extended BLE stack

### DIFF
--- a/embassy-stm32-wpan/Cargo.toml
+++ b/embassy-stm32-wpan/Cargo.toml
@@ -44,6 +44,8 @@ defmt = ["dep:defmt", "embassy-sync/defmt", "embassy-embedded-hal/defmt", "embas
 ble = ["dep:stm32wb-hci"]
 mac = ["dep:bitflags", "dep:embassy-net-driver" ]
 
+extended = []
+
 stm32wb10cc = [ "embassy-stm32/stm32wb10cc" ]
 stm32wb15cc = [ "embassy-stm32/stm32wb15cc" ]
 stm32wb30ce = [ "embassy-stm32/stm32wb30ce" ]

--- a/embassy-stm32-wpan/build.rs
+++ b/embassy-stm32-wpan/build.rs
@@ -18,9 +18,22 @@ fn main() {
     // stm32wb tl_mbox link sections
 
     let out_file = out_dir.join("tl_mbox.x").to_string_lossy().to_string();
-    fs::write(out_file, fs::read_to_string("tl_mbox.x.in").unwrap()).unwrap();
+    let in_file;
+    if env::var_os("CARGO_FEATURE_EXTENDED").is_some() {
+        if env::vars()
+            .map(|(a, _)| a)
+            .any(|x| x.starts_with("CARGO_FEATURE_STM32WB1"))
+        {
+            in_file = "tl_mbox_extended_wb1.x.in";
+        } else {
+            in_file = "tl_mbox_extended_wbx5.x.in";
+        }
+    } else {
+        in_file = "tl_mbox.x.in";
+    }
+    fs::write(out_file, fs::read_to_string(in_file).unwrap()).unwrap();
     println!("cargo:rustc-link-search={}", out_dir.display());
-    println!("cargo:rerun-if-changed=tl_mbox.x.in");
+    println!("cargo:rerun-if-changed={}", in_file);
 }
 
 enum GetOneError {

--- a/embassy-stm32-wpan/tl_mbox_extended_wb1.x.in
+++ b/embassy-stm32-wpan/tl_mbox_extended_wb1.x.in
@@ -1,0 +1,16 @@
+MEMORY 
+{
+    RAM_SHARED (xrw)           : ORIGIN = 0x20030000, LENGTH = 4K
+    RAMB_SHARED (xrw)          : ORIGIN = 0x20030028, LENGTH = 4K
+}
+
+/*
+ * Scatter the mailbox interface memory sections in shared memory
+ */
+SECTIONS
+{
+    TL_REF_TABLE                     (NOLOAD) : { *(TL_REF_TABLE) } >RAM_SHARED
+
+    MB_MEM1 (NOLOAD)                          : { *(MB_MEM1) } >RAMB_SHARED
+    MB_MEM2 (NOLOAD)                          : { _sMB_MEM2 = . ; *(MB_MEM2) ; _eMB_MEM2 = . ; } >RAMB_SHARED
+}

--- a/embassy-stm32-wpan/tl_mbox_extended_wbx5.x.in
+++ b/embassy-stm32-wpan/tl_mbox_extended_wbx5.x.in
@@ -1,0 +1,16 @@
+MEMORY 
+{
+    RAM_SHARED (xrw)           : ORIGIN = 0x20030000, LENGTH = 2K
+    RAMB_SHARED (xrw)          : ORIGIN = 0x20038000, LENGTH = 10K
+}
+
+/*
+ * Scatter the mailbox interface memory sections in shared memory
+ */
+SECTIONS
+{
+    TL_REF_TABLE                     (NOLOAD) : { *(TL_REF_TABLE) } >RAM_SHARED
+
+    MB_MEM1 (NOLOAD)                          : { *(MB_MEM1) } >RAMB_SHARED
+    MB_MEM2 (NOLOAD)                          : { _sMB_MEM2 = . ; *(MB_MEM2) ; _eMB_MEM2 = . ; } >RAMB_SHARED
+}


### PR DESCRIPTION
Build script chooses the 'x.in' to copy over to 'tl_mbox.x' based on features