### PR TITLE
STM32WBA's high speed external clock has to run at 32 MHz

### DIFF
--- a/embassy-stm32/src/rcc/wba.rs
+++ b/embassy-stm32/src/rcc/wba.rs
@@ -6,26 +6,28 @@ use crate::time::Hertz;
 
 /// HSI speed
 pub const HSI_FREQ: Hertz = Hertz(16_000_000);
+// HSE speed
+pub const HSE_FREQ: Hertz = Hertz(32_000_000);
 
 pub use crate::pac::pwr::vals::Vos as VoltageScale;
 pub use crate::pac::rcc::vals::{Hpre as AHBPrescaler, Ppre as APBPrescaler};
 
 #[derive(Copy, Clone)]
 pub enum ClockSrc {
-    HSE(Hertz),
+    HSE,
     HSI,
 }
 
 #[derive(Clone, Copy, Debug)]
 pub enum PllSource {
-    HSE(Hertz),
+    HSE,
     HSI,
 }
 
 impl Into<Pllsrc> for PllSource {
     fn into(self) -> Pllsrc {
         match self {
-            PllSource::HSE(..) => Pllsrc::HSE,
+            PllSource::HSE => Pllsrc::HSE,
             PllSource::HSI => Pllsrc::HSI,
         }
     }
@@ -34,7 +36,7 @@ impl Into<Pllsrc> for PllSource {
 impl Into<Sw> for ClockSrc {
     fn into(self) -> Sw {
         match self {
-            ClockSrc::HSE(..) => Sw::HSE,
+            ClockSrc::HSE => Sw::HSE,
             ClockSrc::HSI => Sw::HSI,
         }
     }
@@ -64,11 +66,11 @@ impl Default for Config {
 
 pub(crate) unsafe fn init(config: Config) {
     let sys_clk = match config.mux {
-        ClockSrc::HSE(freq) => {
+        ClockSrc::HSE => {
             RCC.cr().write(|w| w.set_hseon(true));
             while !RCC.cr().read().hserdy() {}
 
-            freq
+            HSE_FREQ
         }
         ClockSrc::HSI => {
             RCC.cr().write(|w| w.set_hsion(true));


### PR DESCRIPTION
STM32WBA's HSE speed cannot be configured: it *has* to run at 32 MHz.

I'm not sure the `PllSource` enum is still needed at this point but since this is my first contribution I went for something minimal. Let me know if `PllSource` should just go.

As a side note, because their frequencies are fixed, the datasheet of that chip refers to the high-speed clocks as HSI16 and HSE32. I'd be willing to contribute a change in that direction if it'd be useful.