### PR TITLE
F2 ADC fixes

### DIFF
--- a/embassy-stm32/src/adc/v2.rs
+++ b/embassy-stm32/src/adc/v2.rs
@@ -34,7 +34,7 @@ impl AdcPin<ADC1> for Temperature {}
 impl super::sealed::AdcPin<ADC1> for Temperature {
     fn channel(&self) -> u8 {
         cfg_if::cfg_if! {
-            if #[cfg(any(stm32f40, stm32f41))] {
+            if #[cfg(any(stm32f2, stm32f40, stm32f41))] {
                 16
             } else {
                 18

--- a/embassy-stm32/src/adc/v2.rs
+++ b/embassy-stm32/src/adc/v2.rs
@@ -67,7 +67,11 @@ enum Prescaler {
 
 impl Prescaler {
     fn from_pclk2(freq: Hertz) -> Self {
+        // Datasheet for F2 specifies min frequency 0.6 MHz, and max 30 MHz (with VDDA 2.4-3.6V).
+        #[cfg(stm32f2)]
+        const MAX_FREQUENCY: Hertz = Hertz(30_000_000);
         // Datasheet for both F4 and F7 specifies min frequency 0.6 MHz, typ freq. 30 MHz and max 36 MHz.
+        #[cfg(not(stm32f2))]
         const MAX_FREQUENCY: Hertz = Hertz(36_000_000);
         let raw_div = freq.0 / MAX_FREQUENCY.0;
         match raw_div {


### PR DESCRIPTION
I recently tested the ADC on STM32F215, and it seems to work great with the exception of these two small differences compared to F4/F7.

PS. F2 ADC is listed as "?" in the stm32 register versions Google sheet. I quickly compared the F2 reference manual with ADC v2 register definitions in stm32-data and couldn't find differences, so at least to me it looks like a match and the current v2 assumption seems correct.