### PR TITLE
docs: Embassy in the wild - add air quality monitoring system

### DIFF
--- a/docs/modules/ROOT/pages/embassy_in_the_wild.adoc
+++ b/docs/modules/ROOT/pages/embassy_in_the_wild.adoc
@@ -7,3 +7,5 @@ Here are known examples of real-world projects which make use of Embassy. Feel f
 * link:https://github.com/card-io-ecg/card-io-fw[Card/IO firmware] - firmware for an open source ECG device
 ** Targets the ESP32-S3 or ESP32-C6 MCU
 * The link:https://github.com/lora-rs/lora-rs[lora-rs] project includes link:https://github.com/lora-rs/lora-rs/tree/main/examples/stm32l0/src/bin[various standalone examples] for NRF52840, RP2040, STM32L0 and STM32WL
+** link:https://github.com/matoushybl/air-force-one[Air force one: A simple air quality monitoring system]
+* Targets nRF52 and uses nrf-softdevice


### PR DESCRIPTION
I developed a simple system for air quality monitoring (CO2, temperature and humidity) based on nRF52 using the nrf-softdevice. It could help as an example for people starting with the softdevice.

OT: Do you want Embassy in the wild section to also have links to commecial/proprietary projects (of course with descriptions to what is embassy used for there), or should it be kept to open-source projects only?