### PR TITLE
fix(stm32h7/flash): enhance resilience to program sequence errors (pgserr)

### DIFF
--- a/embassy-stm32/src/flash/h7.rs
+++ b/embassy-stm32/src/flash/h7.rs
@@ -77,11 +77,11 @@ pub(crate) unsafe fn blocking_write(start_address: u32, buf: &[u8; WRITE_SIZE]) 
         }
     }
 
-    bank.cr().write(|w| w.set_pg(false));
-
     cortex_m::asm::isb();
     cortex_m::asm::dsb();
     fence(Ordering::SeqCst);
+
+    bank.cr().write(|w| w.set_pg(false));
 
     res.unwrap()
 }
@@ -99,6 +99,10 @@ pub(crate) unsafe fn blocking_erase_sector(sector: &FlashSector) -> Result<(), E
     bank.cr().modify(|w| {
         w.set_start(true);
     });
+
+    cortex_m::asm::isb();
+    cortex_m::asm::dsb();
+    fence(Ordering::SeqCst);
 
     let ret: Result<(), Error> = blocking_wait_ready(bank);
     bank.cr().modify(|w| w.set_ser(false));


### PR DESCRIPTION
PR #1014 introduced memory barriers to H7 flash driver to mitigate PGSERR errors.
Despite initial implementations, there was a noticeable frequency of these errors during write operations.

The changes in this PR results in a significant enhancement to the resilience against Program Sequence Errors (PGSERR) in the H7 flash module in my experience.

I believe this is related to this note from rm0399 §4.3.9:

> Any write access requested while the PG1/2 bit is cleared to 0 is rejected. In this case, no  error is generated on the bus, but the PGSERR1/2 flag is raised.

Although I didn't experience any issues during erase operations, this PR also adds memory barriers during erase operations to be on the safe side.

[Zephyr's STM32H7 flash driver](https://github.com/zephyrproject-rtos/zephyr/blob/main/drivers/flash/flash_stm32h7x.c) has a similar implementation.