### PR TITLE
feat: enhance bootloader for multiple flash support

### DIFF
--- a/ci.sh
+++ b/ci.sh
@@ -194,7 +194,8 @@ cargo batch  \
     --- build --release --manifest-path examples/boot/bootloader/nrf/Cargo.toml --target thumbv8m.main-none-eabihf --features embassy-nrf/nrf9160-ns \
     --- build --release --manifest-path examples/boot/bootloader/rp/Cargo.toml --target thumbv6m-none-eabi \
     --- build --release --manifest-path examples/boot/bootloader/stm32/Cargo.toml --target thumbv7em-none-eabi --features embassy-stm32/stm32wl55jc-cm4 \
-    --- build --release --manifest-path examples/boot/bootloader/stm32wb-dfu/Cargo.toml --target thumbv7em-none-eabihf \
+    --- build --release --manifest-path examples/boot/bootloader/stm32wb-dfu/Cargo.toml --target thumbv7em-none-eabihf --features embassy-stm32/stm32wb55rg \
+    --- build --release --manifest-path examples/boot/bootloader/stm32-dual-bank/Cargo.toml --target thumbv7em-none-eabihf --features embassy-stm32/stm32h747xi-cm7 \
     --- build --release --manifest-path examples/wasm/Cargo.toml --target wasm32-unknown-unknown --out-dir out/examples/wasm \
     --- build --release --manifest-path tests/stm32/Cargo.toml --target thumbv7m-none-eabi --features stm32f103c8 --out-dir out/tests/stm32f103c8 \
     --- build --release --manifest-path tests/stm32/Cargo.toml --target thumbv7em-none-eabi --features stm32f429zi --out-dir out/tests/stm32f429zi \

--- a/embassy-boot/src/boot_loader.rs
+++ b/embassy-boot/src/boot_loader.rs
@@ -79,7 +79,7 @@ impl<'a, ACTIVE: NorFlash, DFU: NorFlash, STATE: NorFlash>
     /// A `BootLoaderConfig` instance with `BlockingPartition` instances for the active, DFU, and state partitions.
     ///
     /// # Example
-    /// ```no_run
+    /// ```ignore
     /// // Assume `active_flash`, `dfu_flash`, and `state_flash` all share the same flash memory interface.
     /// let layout = Flash::new_blocking(p.FLASH).into_blocking_regions();
     /// let flash = Mutex::new(RefCell::new(layout.bank1_region));

--- a/embassy-boot/src/boot_loader.rs
+++ b/embassy-boot/src/boot_loader.rs
@@ -49,19 +49,19 @@ pub struct BootLoaderConfig<ACTIVE, DFU, STATE> {
     pub state: STATE,
 }
 
-impl<'a, ActiveFlash: NorFlash, DFUFlash: NorFlash, StateFlash: NorFlash>
+impl<'a, ACTIVE: NorFlash, DFU: NorFlash, STATE: NorFlash>
     BootLoaderConfig<
-        BlockingPartition<'a, NoopRawMutex, ActiveFlash>,
-        BlockingPartition<'a, NoopRawMutex, DFUFlash>,
-        BlockingPartition<'a, NoopRawMutex, StateFlash>,
+        BlockingPartition<'a, NoopRawMutex, ACTIVE>,
+        BlockingPartition<'a, NoopRawMutex, DFU>,
+        BlockingPartition<'a, NoopRawMutex, STATE>,
     >
 {
     /// Create a bootloader config from the flash and address symbols defined in the linkerfile
     // #[cfg(target_os = "none")]
     pub fn from_linkerfile_blocking(
-        active_flash: &'a Mutex<NoopRawMutex, RefCell<ActiveFlash>>,
-        dfu_flash: &'a Mutex<NoopRawMutex, RefCell<DFUFlash>>,
-        state_flash: &'a Mutex<NoopRawMutex, RefCell<StateFlash>>,
+        active_flash: &'a Mutex<NoopRawMutex, RefCell<ACTIVE>>,
+        dfu_flash: &'a Mutex<NoopRawMutex, RefCell<DFU>>,
+        state_flash: &'a Mutex<NoopRawMutex, RefCell<STATE>>,
     ) -> Self {
         extern "C" {
             static __bootloader_state_start: u32;

--- a/embassy-boot/src/boot_loader.rs
+++ b/embassy-boot/src/boot_loader.rs
@@ -56,7 +56,38 @@ impl<'a, ACTIVE: NorFlash, DFU: NorFlash, STATE: NorFlash>
         BlockingPartition<'a, NoopRawMutex, STATE>,
     >
 {
-    /// Create a bootloader config from the flash and address symbols defined in the linkerfile
+    /// Constructs a `BootLoaderConfig` instance from flash memory and address symbols defined in the linker file.
+    ///
+    /// This method initializes `BlockingPartition` instances for the active, DFU (Device Firmware Update),
+    /// and state partitions, leveraging start and end addresses specified by the linker. These partitions
+    /// are critical for managing firmware updates, application state, and boot operations within the bootloader.
+    ///
+    /// # Parameters
+    /// - `active_flash`: A reference to a mutex-protected `RefCell` for the active partition's flash interface.
+    /// - `dfu_flash`: A reference to a mutex-protected `RefCell` for the DFU partition's flash interface.
+    /// - `state_flash`: A reference to a mutex-protected `RefCell` for the state partition's flash interface.
+    ///
+    /// # Safety
+    /// The method contains `unsafe` blocks for dereferencing raw pointers that represent the start and end addresses
+    /// of the bootloader's partitions in flash memory. It is crucial that these addresses are accurately defined
+    /// in the memory.x file to prevent undefined behavior.
+    ///
+    /// The caller must ensure that the memory regions defined by these symbols are valid and that the flash memory
+    /// interfaces provided are compatible with these regions.
+    ///
+    /// # Returns
+    /// A `BootLoaderConfig` instance with `BlockingPartition` instances for the active, DFU, and state partitions.
+    ///
+    /// # Example
+    /// ```no_run
+    /// // Assume `active_flash`, `dfu_flash`, and `state_flash` all share the same flash memory interface.
+    /// let layout = Flash::new_blocking(p.FLASH).into_blocking_regions();
+    /// let flash = Mutex::new(RefCell::new(layout.bank1_region));
+    ///
+    /// let config = BootLoaderConfig::from_linkerfile_blocking(&flash, &flash, &flash);
+    /// // `config` can now be used to create a `BootLoader` instance for managing boot operations.
+    /// ```
+    /// Working examples can be found in the bootloader examples folder.
     // #[cfg(target_os = "none")]
     pub fn from_linkerfile_blocking(
         active_flash: &'a Mutex<NoopRawMutex, RefCell<ACTIVE>>,

--- a/embassy-boot/src/firmware_updater/asynch.rs
+++ b/embassy-boot/src/firmware_updater/asynch.rs
@@ -16,11 +16,14 @@ pub struct FirmwareUpdater<'d, DFU: NorFlash, STATE: NorFlash> {
 }
 
 #[cfg(target_os = "none")]
-impl<'a, FLASH: NorFlash>
-    FirmwareUpdaterConfig<Partition<'a, NoopRawMutex, FLASH>, Partition<'a, NoopRawMutex, FLASH>>
+impl<'a, DFUFlash: NorFlash, StateFlash: NorFlash>
+    FirmwareUpdaterConfig<Partition<'a, NoopRawMutex, DFUFlash>, Partition<'a, NoopRawMutex, StateFlash>>
 {
     /// Create a firmware updater config from the flash and address symbols defined in the linkerfile
-    pub fn from_linkerfile(flash: &'a embassy_sync::mutex::Mutex<NoopRawMutex, FLASH>) -> Self {
+    pub fn from_linkerfile(
+        dfu_flash: &'a embassy_sync::mutex::Mutex<NoopRawMutex, DFUFlash>,
+        state_flash: &'a embassy_sync::mutex::Mutex<NoopRawMutex, StateFlash>,
+    ) -> Self {
         extern "C" {
             static __bootloader_state_start: u32;
             static __bootloader_state_end: u32;
@@ -33,14 +36,14 @@ impl<'a, FLASH: NorFlash>
             let end = &__bootloader_dfu_end as *const u32 as u32;
             trace!("DFU: 0x{:x} - 0x{:x}", start, end);
 
-            Partition::new(flash, start, end - start)
+            Partition::new(dfu_flash, start, end - start)
         };
         let state = unsafe {
             let start = &__bootloader_state_start as *const u32 as u32;
             let end = &__bootloader_state_end as *const u32 as u32;
             trace!("STATE: 0x{:x} - 0x{:x}", start, end);
 
-            Partition::new(flash, start, end - start)
+            Partition::new(state_flash, start, end - start)
         };
 
         Self { dfu, state }

--- a/embassy-boot/src/firmware_updater/asynch.rs
+++ b/embassy-boot/src/firmware_updater/asynch.rs
@@ -16,13 +16,13 @@ pub struct FirmwareUpdater<'d, DFU: NorFlash, STATE: NorFlash> {
 }
 
 #[cfg(target_os = "none")]
-impl<'a, DFUFlash: NorFlash, StateFlash: NorFlash>
-    FirmwareUpdaterConfig<Partition<'a, NoopRawMutex, DFUFlash>, Partition<'a, NoopRawMutex, StateFlash>>
+impl<'a, DFU: NorFlash, STATE: NorFlash>
+    FirmwareUpdaterConfig<Partition<'a, NoopRawMutex, DFU>, Partition<'a, NoopRawMutex, STATE>>
 {
     /// Create a firmware updater config from the flash and address symbols defined in the linkerfile
     pub fn from_linkerfile(
-        dfu_flash: &'a embassy_sync::mutex::Mutex<NoopRawMutex, DFUFlash>,
-        state_flash: &'a embassy_sync::mutex::Mutex<NoopRawMutex, StateFlash>,
+        dfu_flash: &'a embassy_sync::mutex::Mutex<NoopRawMutex, DFU>,
+        state_flash: &'a embassy_sync::mutex::Mutex<NoopRawMutex, STATE>,
     ) -> Self {
         extern "C" {
             static __bootloader_state_start: u32;

--- a/embassy-boot/src/firmware_updater/blocking.rs
+++ b/embassy-boot/src/firmware_updater/blocking.rs
@@ -41,7 +41,7 @@ impl<'a, DFU: NorFlash, STATE: NorFlash>
     /// A `FirmwareUpdaterConfig` instance with `BlockingPartition` instances for the DFU, and state partitions.
     ///
     /// # Example
-    /// ```no_run
+    /// ```ignore
     /// // Assume `dfu_flash`, and `state_flash` share the same flash memory interface.
     /// let layout = Flash::new_blocking(p.FLASH).into_blocking_regions();
     /// let flash = Mutex::new(RefCell::new(layout.bank1_region));

--- a/embassy-boot/src/firmware_updater/blocking.rs
+++ b/embassy-boot/src/firmware_updater/blocking.rs
@@ -19,7 +19,37 @@ pub struct BlockingFirmwareUpdater<'d, DFU: NorFlash, STATE: NorFlash> {
 impl<'a, DFU: NorFlash, STATE: NorFlash>
     FirmwareUpdaterConfig<BlockingPartition<'a, NoopRawMutex, DFU>, BlockingPartition<'a, NoopRawMutex, STATE>>
 {
-    /// Create a firmware updater config from the flash and address symbols defined in the linkerfile
+    /// Constructs a `FirmwareUpdaterConfig` instance from flash memory and address symbols defined in the linker file.
+    ///
+    /// This method initializes `BlockingPartition` instances for the DFU (Device Firmware Update), and state
+    /// partitions, leveraging start and end addresses specified by the linker. These partitions are critical
+    /// for managing firmware updates, application state, and boot operations within the bootloader.
+    ///
+    /// # Parameters
+    /// - `dfu_flash`: A reference to a mutex-protected `RefCell` for the DFU partition's flash interface.
+    /// - `state_flash`: A reference to a mutex-protected `RefCell` for the state partition's flash interface.
+    ///
+    /// # Safety
+    /// The method contains `unsafe` blocks for dereferencing raw pointers that represent the start and end addresses
+    /// of the bootloader's partitions in flash memory. It is crucial that these addresses are accurately defined
+    /// in the memory.x file to prevent undefined behavior.
+    ///
+    /// The caller must ensure that the memory regions defined by these symbols are valid and that the flash memory
+    /// interfaces provided are compatible with these regions.
+    ///
+    /// # Returns
+    /// A `FirmwareUpdaterConfig` instance with `BlockingPartition` instances for the DFU, and state partitions.
+    ///
+    /// # Example
+    /// ```no_run
+    /// // Assume `dfu_flash`, and `state_flash` share the same flash memory interface.
+    /// let layout = Flash::new_blocking(p.FLASH).into_blocking_regions();
+    /// let flash = Mutex::new(RefCell::new(layout.bank1_region));
+    ///
+    /// let config = FirmwareUpdaterConfig::from_linkerfile_blocking(&flash, &flash);
+    /// // `config` can now be used to create a `FirmwareUpdater` instance for managing boot operations.
+    /// ```
+    /// Working examples can be found in the bootloader examples folder.
     pub fn from_linkerfile_blocking(
         dfu_flash: &'a embassy_sync::blocking_mutex::Mutex<NoopRawMutex, core::cell::RefCell<DFU>>,
         state_flash: &'a embassy_sync::blocking_mutex::Mutex<NoopRawMutex, core::cell::RefCell<STATE>>,

--- a/embassy-boot/src/firmware_updater/blocking.rs
+++ b/embassy-boot/src/firmware_updater/blocking.rs
@@ -16,16 +16,13 @@ pub struct BlockingFirmwareUpdater<'d, DFU: NorFlash, STATE: NorFlash> {
 }
 
 #[cfg(target_os = "none")]
-impl<'a, DFUFlash: NorFlash, StateFlash: NorFlash>
-    FirmwareUpdaterConfig<
-        BlockingPartition<'a, NoopRawMutex, DFUFlash>,
-        BlockingPartition<'a, NoopRawMutex, StateFlash>,
-    >
+impl<'a, DFU: NorFlash, STATE: NorFlash>
+    FirmwareUpdaterConfig<BlockingPartition<'a, NoopRawMutex, DFU>, BlockingPartition<'a, NoopRawMutex, STATE>>
 {
     /// Create a firmware updater config from the flash and address symbols defined in the linkerfile
     pub fn from_linkerfile_blocking(
-        dfu_flash: &'a embassy_sync::blocking_mutex::Mutex<NoopRawMutex, core::cell::RefCell<DFUFlash>>,
-        state_flash: &'a embassy_sync::blocking_mutex::Mutex<NoopRawMutex, core::cell::RefCell<StateFlash>>,
+        dfu_flash: &'a embassy_sync::blocking_mutex::Mutex<NoopRawMutex, core::cell::RefCell<DFU>>,
+        state_flash: &'a embassy_sync::blocking_mutex::Mutex<NoopRawMutex, core::cell::RefCell<STATE>>,
     ) -> Self {
         extern "C" {
             static __bootloader_state_start: u32;

--- a/embassy-boot/src/firmware_updater/mod.rs
+++ b/embassy-boot/src/firmware_updater/mod.rs
@@ -8,7 +8,7 @@ use embedded_storage::nor_flash::{NorFlashError, NorFlashErrorKind};
 /// Firmware updater flash configuration holding the two flashes used by the updater
 ///
 /// If only a single flash is actually used, then that flash should be partitioned into two partitions before use.
-/// The easiest way to do this is to use [`FirmwareUpdaterConfig::from_linkerfile`] or [`FirmwareUpdaterConfig::from_linkerfile_blocking`] which will partition
+/// The easiest way to do this is to use [`FirmwareUpdaterConfig::from_linkerfile_blocking`] or [`FirmwareUpdaterConfig::from_linkerfile_blocking`] which will partition
 /// the provided flash according to symbols defined in the linkerfile.
 pub struct FirmwareUpdaterConfig<DFU, STATE> {
     /// The dfu flash partition

--- a/examples/boot/application/nrf/src/bin/a.rs
+++ b/examples/boot/application/nrf/src/bin/a.rs
@@ -50,7 +50,7 @@ async fn main(_spawner: Spawner) {
     let nvmc = Nvmc::new(p.NVMC);
     let nvmc = Mutex::new(BlockingAsync::new(nvmc));
 
-    let config = FirmwareUpdaterConfig::from_linkerfile(&nvmc);
+    let config = FirmwareUpdaterConfig::from_linkerfile(&nvmc, &nvmc);
     let mut magic = [0; 4];
     let mut updater = FirmwareUpdater::new(config, &mut magic);
     loop {

--- a/examples/boot/application/rp/src/bin/a.rs
+++ b/examples/boot/application/rp/src/bin/a.rs
@@ -36,7 +36,7 @@ async fn main(_s: Spawner) {
     let flash = Flash::<_, _, FLASH_SIZE>::new_blocking(p.FLASH);
     let flash = Mutex::new(RefCell::new(flash));
 
-    let config = FirmwareUpdaterConfig::from_linkerfile_blocking(&flash);
+    let config = FirmwareUpdaterConfig::from_linkerfile_blocking(&flash, &flash);
     let mut aligned = AlignedBuffer([0; 1]);
     let mut updater = BlockingFirmwareUpdater::new(config, &mut aligned.0);
 

--- a/examples/boot/application/stm32f3/memory.x
+++ b/examples/boot/application/stm32f3/memory.x
@@ -3,8 +3,8 @@ MEMORY
   /* NOTE 1 K = 1 KiBi = 1024 bytes */
   BOOTLOADER                        : ORIGIN = 0x08000000, LENGTH = 24K
   BOOTLOADER_STATE                  : ORIGIN = 0x08006000, LENGTH = 4K
-  FLASH                             : ORIGIN = 0x08008000, LENGTH = 32K
-  DFU                               : ORIGIN = 0x08010000, LENGTH = 36K
+  FLASH                             : ORIGIN = 0x08008000, LENGTH = 64K
+  DFU                               : ORIGIN = 0x08018000, LENGTH = 66K
   RAM                         (rwx) : ORIGIN = 0x20000000, LENGTH = 32K
 }
 

--- a/examples/boot/application/stm32f3/src/bin/a.rs
+++ b/examples/boot/application/stm32f3/src/bin/a.rs
@@ -28,7 +28,7 @@ async fn main(_spawner: Spawner) {
     let mut led = Output::new(p.PA5, Level::Low, Speed::Low);
     led.set_high();
 
-    let config = FirmwareUpdaterConfig::from_linkerfile(&flash);
+    let config = FirmwareUpdaterConfig::from_linkerfile(&flash, &flash);
     let mut magic = AlignedBuffer([0; WRITE_SIZE]);
     let mut updater = FirmwareUpdater::new(config, &mut magic.0);
     button.wait_for_falling_edge().await;

--- a/examples/boot/application/stm32f7/src/bin/a.rs
+++ b/examples/boot/application/stm32f7/src/bin/a.rs
@@ -30,7 +30,7 @@ async fn main(_spawner: Spawner) {
     let mut led = Output::new(p.PB7, Level::Low, Speed::Low);
     led.set_high();
 
-    let config = FirmwareUpdaterConfig::from_linkerfile_blocking(&flash);
+    let config = FirmwareUpdaterConfig::from_linkerfile_blocking(&flash, &flash);
     let mut magic = AlignedBuffer([0; WRITE_SIZE]);
     let mut updater = BlockingFirmwareUpdater::new(config, &mut magic.0);
     let writer = updater.prepare_update().unwrap();

--- a/examples/boot/application/stm32h7/src/bin/a.rs
+++ b/examples/boot/application/stm32h7/src/bin/a.rs
@@ -30,7 +30,7 @@ async fn main(_spawner: Spawner) {
     let mut led = Output::new(p.PB14, Level::Low, Speed::Low);
     led.set_high();
 
-    let config = FirmwareUpdaterConfig::from_linkerfile_blocking(&flash);
+    let config = FirmwareUpdaterConfig::from_linkerfile_blocking(&flash, &flash);
     let mut magic = AlignedBuffer([0; WRITE_SIZE]);
     let mut updater = BlockingFirmwareUpdater::new(config, &mut magic.0);
     let writer = updater.prepare_update().unwrap();

--- a/examples/boot/application/stm32l0/memory.x
+++ b/examples/boot/application/stm32l0/memory.x
@@ -3,8 +3,8 @@ MEMORY
   /* NOTE 1 K = 1 KiBi = 1024 bytes */
   BOOTLOADER                        : ORIGIN = 0x08000000, LENGTH = 24K
   BOOTLOADER_STATE                  : ORIGIN = 0x08006000, LENGTH = 4K
-  FLASH                             : ORIGIN = 0x08008000, LENGTH = 32K
-  DFU                               : ORIGIN = 0x08010000, LENGTH = 36K
+  FLASH                             : ORIGIN = 0x08008000, LENGTH = 64K
+  DFU                               : ORIGIN = 0x08018000, LENGTH = 66K
   RAM                         (rwx) : ORIGIN = 0x20000000, LENGTH = 16K
 }
 

--- a/examples/boot/application/stm32l0/src/bin/a.rs
+++ b/examples/boot/application/stm32l0/src/bin/a.rs
@@ -30,7 +30,7 @@ async fn main(_spawner: Spawner) {
 
     led.set_high();
 
-    let config = FirmwareUpdaterConfig::from_linkerfile(&flash);
+    let config = FirmwareUpdaterConfig::from_linkerfile(&flash, &flash);
     let mut magic = AlignedBuffer([0; WRITE_SIZE]);
     let mut updater = FirmwareUpdater::new(config, &mut magic.0);
     button.wait_for_falling_edge().await;

--- a/examples/boot/application/stm32l1/memory.x
+++ b/examples/boot/application/stm32l1/memory.x
@@ -3,8 +3,8 @@ MEMORY
   /* NOTE 1 K = 1 KiBi = 1024 bytes */
   BOOTLOADER                        : ORIGIN = 0x08000000, LENGTH = 24K
   BOOTLOADER_STATE                  : ORIGIN = 0x08006000, LENGTH = 4K
-  FLASH                             : ORIGIN = 0x08008000, LENGTH = 32K
-  DFU                               : ORIGIN = 0x08010000, LENGTH = 36K
+  FLASH                             : ORIGIN = 0x08008000, LENGTH = 46K
+  DFU                               : ORIGIN = 0x08013800, LENGTH = 54K
   RAM                         (rwx) : ORIGIN = 0x20000000, LENGTH = 16K
 }
 

--- a/examples/boot/application/stm32l1/src/bin/a.rs
+++ b/examples/boot/application/stm32l1/src/bin/a.rs
@@ -30,7 +30,7 @@ async fn main(_spawner: Spawner) {
 
     led.set_high();
 
-    let config = FirmwareUpdaterConfig::from_linkerfile(&flash);
+    let config = FirmwareUpdaterConfig::from_linkerfile(&flash, &flash);
     let mut magic = AlignedBuffer([0; WRITE_SIZE]);
     let mut updater = FirmwareUpdater::new(config, &mut magic.0);
     button.wait_for_falling_edge().await;

--- a/examples/boot/application/stm32l4/memory.x
+++ b/examples/boot/application/stm32l4/memory.x
@@ -3,8 +3,8 @@ MEMORY
   /* NOTE 1 K = 1 KiBi = 1024 bytes */
   BOOTLOADER                        : ORIGIN = 0x08000000, LENGTH = 24K
   BOOTLOADER_STATE                  : ORIGIN = 0x08006000, LENGTH = 4K
-  FLASH                             : ORIGIN = 0x08008000, LENGTH = 32K
-  DFU                               : ORIGIN = 0x08010000, LENGTH = 36K
+  FLASH                             : ORIGIN = 0x08008000, LENGTH = 64K
+  DFU                               : ORIGIN = 0x08018000, LENGTH = 68K
   RAM                         (rwx) : ORIGIN = 0x20000000, LENGTH = 32K
 }
 

--- a/examples/boot/application/stm32l4/src/bin/a.rs
+++ b/examples/boot/application/stm32l4/src/bin/a.rs
@@ -28,7 +28,7 @@ async fn main(_spawner: Spawner) {
     let mut led = Output::new(p.PB14, Level::Low, Speed::Low);
     led.set_high();
 
-    let config = FirmwareUpdaterConfig::from_linkerfile(&flash);
+    let config = FirmwareUpdaterConfig::from_linkerfile(&flash, &flash);
     let mut magic = AlignedBuffer([0; WRITE_SIZE]);
     let mut updater = FirmwareUpdater::new(config, &mut magic.0);
     button.wait_for_falling_edge().await;

--- a/examples/boot/application/stm32wb-dfu/README.md
+++ b/examples/boot/application/stm32wb-dfu/README.md
@@ -1,29 +1,9 @@
 # Examples using bootloader
 
-Example for STM32WL demonstrating the bootloader. The example consists of application binaries, 'a'
-which allows you to press a button to start the DFU process, and 'b' which is the updated
-application.
-
-
-## Prerequisites
-
-* `cargo-binutils`
-* `cargo-flash`
-* `embassy-boot-stm32`
+Example for STM32WB demonstrating the USB DFU application.
 
 ## Usage
 
 ```
-# Flash bootloader
-cargo flash --manifest-path ../../bootloader/stm32/Cargo.toml --release --features embassy-stm32/stm32wl55jc-cm4 --chip STM32WLE5JCIx
-# Build 'b'
-cargo build --release --bin b
-# Generate binary for 'b'
-cargo objcopy --release --bin b -- -O binary b.bin
-```
-
-# Flash `a` (which includes b.bin)
-
-```
-cargo flash --release --bin a --chip STM32WLE5JCIx
+cargo flash --release --chip STM32WB55RGVx
 ```

--- a/examples/boot/application/stm32wb-dfu/src/main.rs
+++ b/examples/boot/application/stm32wb-dfu/src/main.rs
@@ -30,7 +30,7 @@ async fn main(_spawner: Spawner) {
     let flash = Flash::new_blocking(p.FLASH);
     let flash = Mutex::new(RefCell::new(flash));
 
-    let config = FirmwareUpdaterConfig::from_linkerfile_blocking(&flash);
+    let config = FirmwareUpdaterConfig::from_linkerfile_blocking(&flash, &flash);
     let mut magic = AlignedBuffer([0; WRITE_SIZE]);
     let mut firmware_state = BlockingFirmwareState::from_config(config, &mut magic.0);
     firmware_state.mark_booted().expect("Failed to mark booted");

--- a/examples/boot/application/stm32wl/memory.x
+++ b/examples/boot/application/stm32wl/memory.x
@@ -3,8 +3,8 @@ MEMORY
   /* NOTE 1 K = 1 KiBi = 1024 bytes */
   BOOTLOADER                        : ORIGIN = 0x08000000, LENGTH = 24K
   BOOTLOADER_STATE                  : ORIGIN = 0x08006000, LENGTH = 4K
-  FLASH                             : ORIGIN = 0x08008000, LENGTH = 32K
-  DFU                               : ORIGIN = 0x08010000, LENGTH = 36K
+  FLASH                             : ORIGIN = 0x08008000, LENGTH = 64K
+  DFU                               : ORIGIN = 0x08018000, LENGTH = 68K
   RAM                         (rwx) : ORIGIN = 0x20000000, LENGTH = 32K
 }
 

--- a/examples/boot/application/stm32wl/src/bin/a.rs
+++ b/examples/boot/application/stm32wl/src/bin/a.rs
@@ -28,7 +28,7 @@ async fn main(_spawner: Spawner) {
     let mut led = Output::new(p.PB9, Level::Low, Speed::Low);
     led.set_high();
 
-    let config = FirmwareUpdaterConfig::from_linkerfile(&flash);
+    let config = FirmwareUpdaterConfig::from_linkerfile(&flash, &flash);
     let mut magic = AlignedBuffer([0; WRITE_SIZE]);
     let mut updater = FirmwareUpdater::new(config, &mut magic.0);
     button.wait_for_falling_edge().await;

--- a/examples/boot/bootloader/nrf/src/main.rs
+++ b/examples/boot/bootloader/nrf/src/main.rs
@@ -31,7 +31,7 @@ fn main() -> ! {
     let flash = WatchdogFlash::start(Nvmc::new(p.NVMC), p.WDT, wdt_config);
     let flash = Mutex::new(RefCell::new(flash));
 
-    let config = BootLoaderConfig::from_linkerfile_blocking(&flash);
+    let config = BootLoaderConfig::from_linkerfile_blocking(&flash, &flash, &flash);
     let active_offset = config.active.offset();
     let bl: BootLoader = BootLoader::prepare(config);
 

--- a/examples/boot/bootloader/rp/src/main.rs
+++ b/examples/boot/bootloader/rp/src/main.rs
@@ -27,7 +27,7 @@ fn main() -> ! {
     let flash = WatchdogFlash::<FLASH_SIZE>::start(p.FLASH, p.WATCHDOG, Duration::from_secs(8));
     let flash = Mutex::new(RefCell::new(flash));
 
-    let config = BootLoaderConfig::from_linkerfile_blocking(&flash);
+    let config = BootLoaderConfig::from_linkerfile_blocking(&flash, &flash, &flash);
     let active_offset = config.active.offset();
     let bl: BootLoader = BootLoader::prepare(config);
 

--- a/examples/boot/bootloader/stm32-dual-bank/Cargo.toml
+++ b/examples/boot/bootloader/stm32-dual-bank/Cargo.toml
@@ -1,0 +1,57 @@
+[package]
+edition = "2021"
+name = "stm32-bootloader-dual-bank-flash-example"
+version = "0.1.0"
+description = "Example bootloader for dual-bank flash STM32 chips"
+license = "MIT OR Apache-2.0"
+
+[dependencies]
+defmt = { version = "0.3", optional = true }
+defmt-rtt = { version = "0.4", optional = true }
+
+embassy-stm32 = { path = "../../../../embassy-stm32", features = [] }
+embassy-boot-stm32 = { path = "../../../../embassy-boot-stm32" }
+cortex-m = { version = "0.7.6", features = [
+  "inline-asm",
+  "critical-section-single-core",
+] }
+embassy-sync = { version = "0.5.0", path = "../../../../embassy-sync" }
+cortex-m-rt = { version = "0.7" }
+embedded-storage = "0.3.1"
+embedded-storage-async = "0.4.0"
+cfg-if = "1.0.0"
+
+[features]
+defmt = ["dep:defmt", "embassy-boot-stm32/defmt", "embassy-stm32/defmt"]
+debug = ["defmt-rtt", "defmt"]
+
+[profile.dev]
+debug = 2
+debug-assertions = true
+incremental = false
+opt-level = 'z'
+overflow-checks = true
+
+[profile.release]
+codegen-units = 1
+debug = 2
+debug-assertions = false
+incremental = false
+lto = 'fat'
+opt-level = 'z'
+overflow-checks = false
+
+# do not optimize proc-macro crates = faster builds from scratch
+[profile.dev.build-override]
+codegen-units = 8
+debug = false
+debug-assertions = false
+opt-level = 0
+overflow-checks = false
+
+[profile.release.build-override]
+codegen-units = 8
+debug = false
+debug-assertions = false
+opt-level = 0
+overflow-checks = false

--- a/examples/boot/bootloader/stm32-dual-bank/README.md
+++ b/examples/boot/bootloader/stm32-dual-bank/README.md
@@ -1,0 +1,44 @@
+# STM32 dual-bank flash Bootloader
+
+## Overview
+
+This bootloader leverages `embassy-boot` to interact with the flash. 
+This example targets STM32 devices with dual-bank flash memory, with a primary focus on the STM32H747XI series. 
+Users must modify the `memory.x` configuration file to match with the memory layout of their specific STM32 device.
+
+Additionally, this example can be extended to utilize external flash memory, such as QSPI, for storing partitions.
+
+## Memory Configuration
+
+In this example's `memory.x` file, various symbols are defined to assist in effective memory management within the bootloader environment.  
+For dual-bank STM32 devices, it's crucial to assign these symbols correctly to their respective memory banks. 
+
+### Symbol Definitions
+
+The bootloader's state and active symbols are anchored to the flash origin of **bank 1**:
+
+- `__bootloader_state_start` and `__bootloader_state_end`
+- `__bootloader_active_start` and `__bootloader_active_end`
+
+In contrast, the Device Firmware Upgrade (DFU) symbols are aligned with the DFU flash origin in **bank 2**:
+
+- `__bootloader_dfu_start` and `__bootloader_dfu_end`
+
+```rust
+__bootloader_state_start = ORIGIN(BOOTLOADER_STATE) - ORIGIN(**FLASH**);
+__bootloader_state_end = ORIGIN(BOOTLOADER_STATE) + LENGTH(BOOTLOADER_STATE) - ORIGIN(**FLASH**);
+
+__bootloader_active_start = ORIGIN(ACTIVE) - ORIGIN(**FLASH**);
+__bootloader_active_end = ORIGIN(ACTIVE) + LENGTH(ACTIVE) - ORIGIN(**FLASH**);
+
+__bootloader_dfu_start = ORIGIN(DFU) - ORIGIN(**DFU**);
+__bootloader_dfu_end = ORIGIN(DFU) + LENGTH(DFU) - ORIGIN(**DFU**);
+```
+
+## Flashing the Bootloader
+
+To flash the bootloader onto your STM32H747XI device, use the following command:
+
+```bash
+cargo flash --features embassy-stm32/stm32h747xi-cm7 --release --chip STM32H747XIHx
+```

--- a/examples/boot/bootloader/stm32-dual-bank/build.rs
+++ b/examples/boot/bootloader/stm32-dual-bank/build.rs
@@ -1,0 +1,27 @@
+use std::env;
+use std::fs::File;
+use std::io::Write;
+use std::path::PathBuf;
+
+fn main() {
+    // Put `memory.x` in our output directory and ensure it's
+    // on the linker search path.
+    let out = &PathBuf::from(env::var_os("OUT_DIR").unwrap());
+    File::create(out.join("memory.x"))
+        .unwrap()
+        .write_all(include_bytes!("memory.x"))
+        .unwrap();
+    println!("cargo:rustc-link-search={}", out.display());
+
+    // By default, Cargo will re-run a build script whenever
+    // any file in the project changes. By specifying `memory.x`
+    // here, we ensure the build script is only re-run when
+    // `memory.x` is changed.
+    println!("cargo:rerun-if-changed=memory.x");
+
+    println!("cargo:rustc-link-arg-bins=--nmagic");
+    println!("cargo:rustc-link-arg-bins=-Tlink.x");
+    if env::var("CARGO_FEATURE_DEFMT").is_ok() {
+        println!("cargo:rustc-link-arg-bins=-Tdefmt.x");
+    }
+}

--- a/examples/boot/bootloader/stm32-dual-bank/memory.x
+++ b/examples/boot/bootloader/stm32-dual-bank/memory.x
@@ -1,0 +1,18 @@
+MEMORY
+{
+  /* NOTE 1 K = 1 KiBi = 1024 bytes */
+  FLASH                             : ORIGIN = 0x08000000, LENGTH = 128K
+  BOOTLOADER_STATE                  : ORIGIN = 0x08020000, LENGTH = 128K
+  ACTIVE                            : ORIGIN = 0x08040000, LENGTH = 512K
+  DFU                               : ORIGIN = 0x08100000, LENGTH = 640K
+  RAM                         (rwx) : ORIGIN = 0x24000000, LENGTH = 512K
+}
+
+__bootloader_state_start = ORIGIN(BOOTLOADER_STATE) - ORIGIN(FLASH);
+__bootloader_state_end = ORIGIN(BOOTLOADER_STATE) + LENGTH(BOOTLOADER_STATE) - ORIGIN(FLASH);
+
+__bootloader_active_start = ORIGIN(ACTIVE) - ORIGIN(FLASH);
+__bootloader_active_end = ORIGIN(ACTIVE) + LENGTH(ACTIVE) - ORIGIN(FLASH);
+
+__bootloader_dfu_start = ORIGIN(DFU) - ORIGIN(DFU);
+__bootloader_dfu_end = ORIGIN(DFU) + LENGTH(DFU) - ORIGIN(DFU);

--- a/examples/boot/bootloader/stm32-dual-bank/src/main.rs
+++ b/examples/boot/bootloader/stm32-dual-bank/src/main.rs
@@ -23,9 +23,10 @@ fn main() -> ! {
     */
 
     let layout = Flash::new_blocking(p.FLASH).into_blocking_regions();
-    let flash = Mutex::new(RefCell::new(layout.bank1_region));
+    let flash_bank1 = Mutex::new(RefCell::new(layout.bank1_region));
+    let flash_bank2 = Mutex::new(RefCell::new(layout.bank2_region));
 
-    let config = BootLoaderConfig::from_linkerfile_blocking(&flash, &flash, &flash);
+    let config = BootLoaderConfig::from_linkerfile_blocking(&flash_bank1, &flash_bank2, &flash_bank1);
     let active_offset = config.active.offset();
     let bl = BootLoader::prepare::<_, _, _, 2048>(config);
 

--- a/examples/boot/bootloader/stm32wb-dfu/Cargo.toml
+++ b/examples/boot/bootloader/stm32wb-dfu/Cargo.toml
@@ -9,7 +9,7 @@ license = "MIT OR Apache-2.0"
 defmt = { version = "0.3", optional = true }
 defmt-rtt = { version = "0.4", optional = true }
 
-embassy-stm32 = { path = "../../../../embassy-stm32", features = ["stm32wb55rg"] }
+embassy-stm32 = { path = "../../../../embassy-stm32", features = [] }
 embassy-boot-stm32 = { path = "../../../../embassy-boot-stm32" }
 cortex-m = { version = "0.7.6", features = ["inline-asm", "critical-section-single-core"] }
 embassy-sync = { version = "0.5.0", path = "../../../../embassy-sync" }

--- a/examples/boot/bootloader/stm32wb-dfu/README.md
+++ b/examples/boot/bootloader/stm32wb-dfu/README.md
@@ -7,5 +7,5 @@ The bootloader uses `embassy-boot` to interact with the flash.
 Flash the bootloader
 
 ```
-cargo flash --features embassy-stm32/stm32wl55jc-cm4 --release --chip STM32WLE5JCIx
+cargo flash --features embassy-stm32/stm32wb55rg --release --chip STM32WB55RGVx
 ```

--- a/examples/boot/bootloader/stm32wb-dfu/src/main.rs
+++ b/examples/boot/bootloader/stm32wb-dfu/src/main.rs
@@ -35,7 +35,7 @@ fn main() -> ! {
     let layout = Flash::new_blocking(p.FLASH).into_blocking_regions();
     let flash = Mutex::new(RefCell::new(layout.bank1_region));
 
-    let config = BootLoaderConfig::from_linkerfile_blocking(&flash);
+    let config = BootLoaderConfig::from_linkerfile_blocking(&flash, &flash, &flash);
     let active_offset = config.active.offset();
     let bl = BootLoader::prepare::<_, _, _, 2048>(config);
     if bl.state == State::DfuDetach {
@@ -45,7 +45,7 @@ fn main() -> ! {
         config.product = Some("USB-DFU Bootloader example");
         config.serial_number = Some("1235678");
 
-        let fw_config = FirmwareUpdaterConfig::from_linkerfile_blocking(&flash);
+        let fw_config = FirmwareUpdaterConfig::from_linkerfile_blocking(&flash, &flash);
         let mut buffer = AlignedBuffer([0; WRITE_SIZE]);
         let updater = BlockingFirmwareUpdater::new(fw_config, &mut buffer.0[..]);
 


### PR DESCRIPTION
## Summary
This pull request introduces a enhancement to the `BootLoaderConfig` and `FirmwareUpdaterConfig` in the `embassy-boot` crate. The primary goal is to implement support for multiple flash partitions, enabling the bootloader and firmware updater to handle `ActiveFlash`, `DFUFlash`, and `StateFlash` independently. This change is particularly beneficial for systems with dual-bank or external flash setups.

## Key Changes
- **Configurations Refactored**: Both `BootLoaderConfig` and `FirmwareUpdaterConfig` have been updated to support different flash partition types.
- **Partition Handling**: Adjustments made in various modules for alignment with the new multi-flash support, specifically in the instantiation of `BlockingPartition` and `Partition`.
- `bootloader/stm32` and `bootloader/stm32wb-dfu` have been updated and a new example `bootloader/stm32-dual-bank` has been introduced.

## Testing
- The changes have been tested in the blocking flavor on an STM32H747XI.

## TODO

- [x] Update all examples
- [x] Test on other targets (is the CI capable of performing this?)
- [x] Improve `from_linkerfile_blocking` api?

Your review would be greatly appreciated!

Specifically, I am not fully satisfied with the `from_linkerfile_blocking` when the same flash is used:
```rust
let config = BootLoaderConfig::from_linkerfile_blocking(&flash, &flash, &flash);
```
I see two ways to handle this: a builder pattern or wrapping `&flash` with an Option.