### PR TITLE
fix: rtos-trace time missing

### DIFF
--- a/ci.sh
+++ b/ci.sh
@@ -23,6 +23,8 @@ cargo batch  \
     --- build --release --manifest-path embassy-executor/Cargo.toml --target thumbv6m-none-eabi --features defmt,arch-cortex-m,executor-thread,executor-interrupt,integrated-timers \
     --- build --release --manifest-path embassy-executor/Cargo.toml --target thumbv7em-none-eabi --features arch-cortex-m \
     --- build --release --manifest-path embassy-executor/Cargo.toml --target thumbv7em-none-eabi --features arch-cortex-m,integrated-timers \
+    --- build --release --manifest-path embassy-executor/Cargo.toml --target thumbv7em-none-eabi --features arch-cortex-m,rtos-trace \
+    --- build --release --manifest-path embassy-executor/Cargo.toml --target thumbv7em-none-eabi --features arch-cortex-m,integrated-timers,rtos-trace \
     --- build --release --manifest-path embassy-executor/Cargo.toml --target thumbv7em-none-eabi --features arch-cortex-m,executor-thread \
     --- build --release --manifest-path embassy-executor/Cargo.toml --target thumbv7em-none-eabi --features arch-cortex-m,executor-thread,integrated-timers \
     --- build --release --manifest-path embassy-executor/Cargo.toml --target thumbv7em-none-eabi --features arch-cortex-m,executor-interrupt \

--- a/embassy-executor/Cargo.toml
+++ b/embassy-executor/Cargo.toml
@@ -34,6 +34,7 @@ log = { version = "0.4.14", optional = true }
 rtos-trace = { version = "0.1.2", optional = true }
 
 embassy-executor-macros = { version = "0.4.0", path = "../embassy-executor-macros" }
+embassy-time = { version = "0.3.0", path = "../embassy-time", optional = true }
 embassy-time-driver = { version = "0.1.0", path = "../embassy-time-driver", optional = true }
 embassy-time-queue-driver = { version = "0.1.0", path = "../embassy-time-queue-driver", optional = true }
 critical-section = "1.1"
@@ -70,6 +71,9 @@ turbowakers = []
 
 ## Use the executor-integrated `embassy-time` timer queue.
 integrated-timers = ["dep:embassy-time-driver", "dep:embassy-time-queue-driver"]
+
+# Support for rtos trace require time
+rtos-trace = ["dep:rtos-trace", "dep:embassy-time"]
 
 #! ### Architecture
 _arch = [] # some arch was picked

--- a/embassy-executor/Cargo.toml
+++ b/embassy-executor/Cargo.toml
@@ -34,7 +34,6 @@ log = { version = "0.4.14", optional = true }
 rtos-trace = { version = "0.1.2", optional = true }
 
 embassy-executor-macros = { version = "0.4.0", path = "../embassy-executor-macros" }
-embassy-time = { version = "0.3.0", path = "../embassy-time", optional = true }
 embassy-time-driver = { version = "0.1.0", path = "../embassy-time-driver", optional = true }
 embassy-time-queue-driver = { version = "0.1.0", path = "../embassy-time-queue-driver", optional = true }
 critical-section = "1.1"
@@ -71,9 +70,6 @@ turbowakers = []
 
 ## Use the executor-integrated `embassy-time` timer queue.
 integrated-timers = ["dep:embassy-time-driver", "dep:embassy-time-queue-driver"]
-
-# Support for rtos trace require time
-rtos-trace = ["dep:rtos-trace", "dep:embassy-time"]
 
 #! ### Architecture
 _arch = [] # some arch was picked

--- a/embassy-executor/src/raw/mod.rs
+++ b/embassy-executor/src/raw/mod.rs
@@ -598,7 +598,7 @@ impl rtos_trace::RtosTraceOSCallbacks for Executor {
     #[cfg(feature = "integrated-timers")]
     fn time() -> u64 {
         const GCD_1M: u64 = gcd(embassy_time_driver::TICK_HZ, 1_000_000);
-        embassy_time_driver::now() * (1_000_00 / GCD_1M) / (embassy_time_driver::TICK_HZ / GCD_1M);
+        embassy_time_driver::now() * (1_000_000 / GCD_1M) / (embassy_time_driver::TICK_HZ / GCD_1M);
     }
     #[cfg(not(feature = "integrated-timers"))]
     fn time() -> u64 {

--- a/embassy-executor/src/raw/mod.rs
+++ b/embassy-executor/src/raw/mod.rs
@@ -581,6 +581,15 @@ impl embassy_time_queue_driver::TimerQueue for TimerQueue {
 #[cfg(feature = "integrated-timers")]
 embassy_time_queue_driver::timer_queue_impl!(static TIMER_QUEUE: TimerQueue = TimerQueue);
 
+#[cfg(all(feature = "rtos-trace", feature = "integrated-timers"))]
+const fn gcd(a: u64, b: u64) -> u64 {
+    if b == 0 {
+        a
+    } else {
+        gcd(b, a % b)
+    }
+}
+
 #[cfg(feature = "rtos-trace")]
 impl rtos_trace::RtosTraceOSCallbacks for Executor {
     fn task_list() {
@@ -588,7 +597,8 @@ impl rtos_trace::RtosTraceOSCallbacks for Executor {
     }
     #[cfg(feature = "integrated-timers")]
     fn time() -> u64 {
-        embassy_time::Instant::now().as_millis()
+        const GCD_1M: u64 = gcd(embassy_time_driver::TICK_HZ, 1_000_000);
+        embassy_time_driver::now() * (1_000_00 / GCD_1M) / (embassy_time_driver::TICK_HZ / GCD_1M);
     }
     #[cfg(not(feature = "integrated-timers"))]
     fn time() -> u64 {

--- a/embassy-executor/src/raw/mod.rs
+++ b/embassy-executor/src/raw/mod.rs
@@ -588,7 +588,7 @@ impl rtos_trace::RtosTraceOSCallbacks for Executor {
     }
     #[cfg(feature = "integrated-timers")]
     fn time() -> u64 {
-        Instant::now().as_micros()
+        embassy_time::Instant::now().as_millis()
     }
     #[cfg(not(feature = "integrated-timers"))]
     fn time() -> u64 {

--- a/embassy-executor/src/raw/mod.rs
+++ b/embassy-executor/src/raw/mod.rs
@@ -598,7 +598,7 @@ impl rtos_trace::RtosTraceOSCallbacks for Executor {
     #[cfg(feature = "integrated-timers")]
     fn time() -> u64 {
         const GCD_1M: u64 = gcd(embassy_time_driver::TICK_HZ, 1_000_000);
-        embassy_time_driver::now() * (1_000_000 / GCD_1M) / (embassy_time_driver::TICK_HZ / GCD_1M);
+        embassy_time_driver::now() * (1_000_000 / GCD_1M) / (embassy_time_driver::TICK_HZ / GCD_1M)
     }
     #[cfg(not(feature = "integrated-timers"))]
     fn time() -> u64 {


### PR DESCRIPTION
Could not compile when `rtos-trace` was enabled due to missing embassy_time feature. Note that I added `embassy-time` for the `rtos-trace` feature

We could probably derive from `embassy-time-driver::now()` if it's preferred and don't want to depend on `embassy-time`