### PR TITLE
nrf: spim: Expose buffer length limits

### DIFF
--- a/embassy-nrf/src/spim.rs
+++ b/embassy-nrf/src/spim.rs
@@ -20,6 +20,11 @@ use crate::interrupt::typelevel::Interrupt;
 use crate::util::{slice_in_ram_or, slice_ptr_parts, slice_ptr_parts_mut};
 use crate::{interrupt, pac, Peripheral};
 
+/// Maximum receive buffer size for single transfer
+pub const MAX_RX_LEN: usize = EASY_DMA_SIZE;
+/// Maximum transfer buffer size for single transfer
+pub const MAX_TX_LEN: usize = EASY_DMA_SIZE;
+
 /// SPIM error
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]


### PR DESCRIPTION
Exposing this feels a bit awkward, but still better than nothing.

One use-case for this would be pushing data to SPI-NOR flash at maximum bandwidth supported by either bus/device. For example in case of nRF52832 and Renesas SPI-NOR flash(AT25FF081A):
* nRF52832 supports transfers up to 255 bytes
* Flash can be programmed either in Byte/Page mode (1..256 bytes), but we cannot cross the 256-byte boundaries.

Therefore the most sensible way to operate in this case would be to push out data as two 128 byte chunks to program a single page.