### PR TITLE
Print panics via defmt per default for the stm32f0 example

### DIFF
--- a/examples/stm32f0/Cargo.toml
+++ b/examples/stm32f0/Cargo.toml
@@ -13,7 +13,7 @@ cortex-m = { version = "0.7.6", features = ["inline-asm", "critical-section-sing
 cortex-m-rt = "0.7.0"
 defmt = "0.3"
 defmt-rtt = "0.4"
-panic-probe = "0.3"
+panic-probe = { version = "0.3", features = ["print-defmt"] }
 embassy-sync = { version = "0.5.0", path = "../../embassy-sync", features = ["defmt"] }
 embassy-executor = { version = "0.5.0", path = "../../embassy-executor", features = ["arch-cortex-m", "executor-thread", "executor-interrupt", "defmt", "integrated-timers"] }
 embassy-time = { version = "0.3.0", path = "../../embassy-time", features = ["defmt", "defmt-timestamp-uptime", "tick-hz-32_768"] }


### PR DESCRIPTION
Hey,

This is the default for nearly all examples and helps locate bugs.
