### PR TITLE
NRF: Implement chunked DMA transfers for SPIM

### DIFF
--- a/embassy-nrf/src/util.rs
+++ b/embassy-nrf/src/util.rs
@@ -4,6 +4,19 @@ use core::mem;
 const SRAM_LOWER: usize = 0x2000_0000;
 const SRAM_UPPER: usize = 0x3000_0000;
 
+// #![feature(const_slice_ptr_len)]
+// https://github.com/rust-lang/rust/issues/71146
+pub(crate) fn slice_ptr_len<T>(ptr: *const [T]) -> usize {
+    use core::ptr::NonNull;
+    let ptr = ptr.cast_mut();
+    if let Some(ptr) = NonNull::new(ptr) {
+        ptr.len()
+    } else {
+        // We know ptr is null, so we know ptr.wrapping_byte_add(1) is not null.
+        NonNull::new(ptr.wrapping_byte_add(1)).unwrap().len()
+    }
+}
+
 // TODO: replace transmutes with core::ptr::metadata once it's stable
 pub(crate) fn slice_ptr_parts<T>(slice: *const [T]) -> (*const T, usize) {
     unsafe { mem::transmute(slice) }


### PR DESCRIPTION
On some chips (notably nrf52832), the maximum DMA transfer length was 255 which caused some hard to understand issues when interfacing with various devices over SPI bus.

Tested with nrf52832 + SPI flash (+ DFU flashing over BLE with SPI-NOR page size of 256 bytes).