### PR TITLE
[embassy-stm32]: started stm32g4 RCC refactor

### DIFF
--- a/examples/stm32g4/src/bin/adc.rs
+++ b/examples/stm32g4/src/bin/adc.rs
@@ -4,7 +4,7 @@
 use defmt::*;
 use embassy_executor::Spawner;
 use embassy_stm32::adc::{Adc, SampleTime};
-use embassy_stm32::rcc::{AdcClockSource, ClockSrc, Pll, PllM, PllN, PllR, PllSource};
+use embassy_stm32::rcc::{AdcClockSource, Pll, PllMul, PllPreDiv, PllRDiv, Pllsrc, Sysclk};
 use embassy_stm32::Config;
 use embassy_time::{Delay, Timer};
 use {defmt_rtt as _, panic_probe as _};
@@ -14,17 +14,17 @@ async fn main(_spawner: Spawner) {
     let mut config = Config::default();
 
     config.rcc.pll = Some(Pll {
-        source: PllSource::HSI,
-        prediv_m: PllM::DIV4,
-        mul_n: PllN::MUL85,
-        div_p: None,
-        div_q: None,
+        source: Pllsrc::HSI,
+        prediv: PllPreDiv::DIV4,
+        mul: PllMul::MUL85,
+        divp: None,
+        divq: None,
         // Main system clock at 170 MHz
-        div_r: Some(PllR::DIV2),
+        divr: Some(PllRDiv::DIV2),
     });
 
     config.rcc.adc12_clock_source = AdcClockSource::SYS;
-    config.rcc.mux = ClockSrc::PLL;
+    config.rcc.sys = Sysclk::PLL1_R;
 
     let mut p = embassy_stm32::init(config);
     info!("Hello World!");

--- a/examples/stm32g4/src/bin/pll.rs
+++ b/examples/stm32g4/src/bin/pll.rs
@@ -3,7 +3,7 @@
 
 use defmt::*;
 use embassy_executor::Spawner;
-use embassy_stm32::rcc::{ClockSrc, Pll, PllM, PllN, PllR, PllSource};
+use embassy_stm32::rcc::{Pll, PllMul, PllPreDiv, PllRDiv, Pllsrc, Sysclk};
 use embassy_stm32::Config;
 use embassy_time::Timer;
 use {defmt_rtt as _, panic_probe as _};
@@ -13,16 +13,16 @@ async fn main(_spawner: Spawner) {
     let mut config = Config::default();
 
     config.rcc.pll = Some(Pll {
-        source: PllSource::HSI,
-        prediv_m: PllM::DIV4,
-        mul_n: PllN::MUL85,
-        div_p: None,
-        div_q: None,
+        source: Pllsrc::HSI,
+        prediv: PllPreDiv::DIV4,
+        mul: PllMul::MUL85,
+        divp: None,
+        divq: None,
         // Main system clock at 170 MHz
-        div_r: Some(PllR::DIV2),
+        divr: Some(PllRDiv::DIV2),
     });
 
-    config.rcc.mux = ClockSrc::PLL;
+    config.rcc.sys = Sysclk::PLL1_R;
 
     let _p = embassy_stm32::init(config);
     info!("Hello World!");

--- a/examples/stm32g4/src/bin/usb_serial.rs
+++ b/examples/stm32g4/src/bin/usb_serial.rs
@@ -3,7 +3,9 @@
 
 use defmt::{panic, *};
 use embassy_executor::Spawner;
-use embassy_stm32::rcc::{Clock48MhzSrc, ClockSrc, Hsi48Config, Pll, PllM, PllN, PllQ, PllR, PllSource};
+use embassy_stm32::rcc::{
+    Clock48MhzSrc, Hse, HseMode, Hsi48Config, Pll, PllMul, PllPreDiv, PllQDiv, PllRDiv, Pllsrc, Sysclk,
+};
 use embassy_stm32::time::Hertz;
 use embassy_stm32::usb::{self, Driver, Instance};
 use embassy_stm32::{bind_interrupts, peripherals, Config};
@@ -24,25 +26,30 @@ async fn main(_spawner: Spawner) {
     // Change this to `false` to use the HSE clock source for the USB. This example assumes an 8MHz HSE.
     const USE_HSI48: bool = true;
 
-    let plldivq = if USE_HSI48 { None } else { Some(PllQ::DIV6) };
+    let plldivq = if USE_HSI48 { None } else { Some(PllQDiv::DIV6) };
 
-    config.rcc.pll = Some(Pll {
-        source: PllSource::HSE(Hertz(8_000_000)),
-        prediv_m: PllM::DIV2,
-        mul_n: PllN::MUL72,
-        div_p: None,
-        div_q: plldivq,
-        // Main system clock at 144 MHz
-        div_r: Some(PllR::DIV2),
+    config.rcc.hse = Some(Hse {
+        freq: Hertz(8_000_000),
+        mode: HseMode::Oscillator,
     });
 
-    config.rcc.mux = ClockSrc::PLL;
+    config.rcc.pll = Some(Pll {
+        source: Pllsrc::HSE,
+        prediv: PllPreDiv::DIV2,
+        mul: PllMul::MUL72,
+        divp: None,
+        divq: plldivq,
+        // Main system clock at 144 MHz
+        divr: Some(PllRDiv::DIV2),
+    });
+
+    config.rcc.sys = Sysclk::PLL1_R;
 
     if USE_HSI48 {
         // Sets up the Clock Recovery System (CRS) to use the USB SOF to trim the HSI48 oscillator.
-        config.rcc.clock_48mhz_src = Some(Clock48MhzSrc::Hsi48(Hsi48Config { sync_from_usb: true }));
+        config.rcc.clk48_src = Some(Clock48MhzSrc::Hsi48(Hsi48Config { sync_from_usb: true }));
     } else {
-        config.rcc.clock_48mhz_src = Some(Clock48MhzSrc::PllQ);
+        config.rcc.clk48_src = Some(Clock48MhzSrc::PllQ);
     }
 
     let p = embassy_stm32::init(config);


### PR DESCRIPTION
Part of #2515

* Copied API from f.rs where applicable
* HSE and HSI independantly configurable
* Boost mode set by user rather
* Added HSE, pll1_q and pll1_p frequencies to set_clocks call
* Stubbed max module based on f.rs, needs cleanup

I updated the examples and could successfully run blinky.rs on hardware. usb_serial.rs compiled and flashed successfully, was able to view the serial port using serial-monitor, text appeared to be echoed but I’m unsure exactly what should have happened.

Probably needs some cleanup, but if you’re happy with the API and the overall approach, I might be up for trying to make a g.rs driver generic over G0 and C0 if they are indeed similar in structure. I don’t have hardware to test those on though.