### PR TITLE
Enable PLL Clocks for TIMx peripherals on STM32F3xx Chips

### DIFF
--- a/embassy-stm32/build.rs
+++ b/embassy-stm32/build.rs
@@ -510,11 +510,7 @@ fn main() {
                     let field_name = format_ident!("{}", field_name);
                     let enum_name = format_ident!("{}", enum_name);
 
-                    rcc_cfgr_regs.insert((
-                        fieldset_name.clone(),
-                        field_name.clone(),
-                        enum_name.clone(),
-                    ));
+                    rcc_cfgr_regs.insert((fieldset_name.clone(), field_name.clone(), enum_name.clone()));
 
                     let match_arms: TokenStream = enumm
                         .variants

--- a/embassy-stm32/build.rs
+++ b/embassy-stm32/build.rs
@@ -601,7 +601,7 @@ fn main() {
             .iter()
             .map(|(_fieldset, fieldname, enum_name)| {
                 quote! {
-                    pub #fieldname: Option<crate::pac::rcc::vals::#enum_name>
+                    pub #fieldname: Option<#enum_name>
                 }
             })
             .collect();
@@ -627,23 +627,32 @@ fn main() {
             })
             .collect();
 
-        g.extend(quote! {
-            #[derive(Clone, Copy)]
-            pub struct ClockMux {
-                #( #struct_fields, )*
-            }
+        let enum_names: BTreeSet<_> = rcc_cfgr_regs
+            .iter()
+            .map(|(_fieldset, _fieldname, enum_name)| enum_name)
+            .collect();
 
-            impl Default for ClockMux {
-                fn default() -> Self {
-                    Self {
-                        #( #field_names: None, )*
+        g.extend(quote! {
+            pub mod mux {
+                #(pub use crate::pac::rcc::vals::#enum_names as #enum_names; )*
+
+                #[derive(Clone, Copy)]
+                pub struct ClockMux {
+                    #( #struct_fields, )*
+                }
+
+                impl Default for ClockMux {
+                    fn default() -> Self {
+                        Self {
+                            #( #field_names: None, )*
+                        }
                     }
                 }
-            }
 
-            impl ClockMux {
-                pub fn init(self) {
-                    #( #inits )*
+                impl ClockMux {
+                    pub fn init(self) {
+                        #( #inits )*
+                    }
                 }
             }
         });

--- a/embassy-stm32/src/rcc/f013.rs
+++ b/embassy-stm32/src/rcc/f013.rs
@@ -97,10 +97,9 @@ pub struct Config {
     pub adc: AdcClockSource,
     #[cfg(all(stm32f3, not(rcc_f37), adc3_common))]
     pub adc34: AdcClockSource,
-    #[cfg(stm32f334)]
-    pub hrtim: HrtimClockSource,
+
     #[cfg(clock_mux)]
-    pub mux: crate::rcc::ClockMux,
+    pub mux: crate::rcc::mux::ClockMux,
 
     pub ls: super::LsConfig,
 }
@@ -128,8 +127,7 @@ impl Default for Config {
             adc: AdcClockSource::Hclk(AdcHclkPrescaler::Div1),
             #[cfg(all(stm32f3, not(rcc_f37), adc3_common))]
             adc34: AdcClockSource::Hclk(AdcHclkPrescaler::Div1),
-            #[cfg(stm32f334)]
-            hrtim: HrtimClockSource::BusClk,
+
             #[cfg(clock_mux)]
             mux: Default::default(),
         }
@@ -350,7 +348,8 @@ pub(crate) unsafe fn init(config: Config) {
         }
     };
 
-    #[cfg(stm32f334)]
+    /*
+    TODO: Maybe add something like this to clock_mux? How can we autogenerate the data for this?
     let hrtim = match config.hrtim {
         // Must be configured after the bus is ready, otherwise it won't work
         HrtimClockSource::BusClk => None,
@@ -366,6 +365,7 @@ pub(crate) unsafe fn init(config: Config) {
             Some(pll * 2u32)
         }
     };
+     */
 
     #[cfg(clock_mux)]
     config.mux.init();
@@ -384,8 +384,6 @@ pub(crate) unsafe fn init(config: Config) {
         adc: Some(adc),
         #[cfg(all(stm32f3, not(rcc_f37), adc3_common))]
         adc34: Some(adc34),
-        #[cfg(stm32f334)]
-        hrtim: hrtim,
         rtc: rtc,
         hsi48: hsi48,
         #[cfg(any(rcc_f1, rcc_f1cl, stm32f3))]

--- a/embassy-stm32/src/rcc/f013.rs
+++ b/embassy-stm32/src/rcc/f013.rs
@@ -179,7 +179,7 @@ pub struct Config {
     pub adc34: AdcClockSource,
     #[cfg(stm32f334)]
     pub hrtim: HrtimClockSource,
-    #[cfg(all(stm32f3, not(stm32f37)))]
+    #[cfg(all(stm32f3, not(rcc_f37)))]
     pub tim: TimClockSources,
 
     pub ls: super::LsConfig,
@@ -449,62 +449,34 @@ pub(crate) unsafe fn init(config: Config) {
     };
 
     #[cfg(all(stm32f3, not(rcc_f37)))]
-    let tim1 = match config.tim.tim1 {
-        TimClockSource::PClk2 => None,
+    match config.tim.tim1 {
+        TimClockSource::PClk2 => {},
         TimClockSource::PllClk => {
-            use crate::pac::rcc::vals::Timsw;
-
-            let pll = unwrap!(pll);
-            assert!((pclk2 == pll) || (pclk2 * 2u32 == pll));
-
-            RCC.cfgr3().modify(|w| w.set_tim1sw(Timsw::PLL1_P));
-
-            Some(pll * 2u32)
+            RCC.cfgr3().modify(|w| w.set_tim1sw(crate::pac::rcc::vals::Timsw::PLL1_P));
         }
     };
 
     #[cfg(any(all(stm32f303, any(package_D, package_E)), all(stm32f302, any(package_D, package_E))))]
-    let tim2 = match config.tim.tim2 {
-        TimClockSource::PClk2 => None,
+    match config.tim.tim2 {
+        TimClockSource::PClk2 => {},
         TimClockSource::PllClk => {
-            use crate::pac::rcc::vals::Timsw;
-
-            let pll = unwrap!(pll);
-            assert!((pclk2 == pll) || (pclk2 * 2u32 == pll));
-
-            RCC.cfgr3().modify(|w| w.set_tim2sw(Timsw::PLL1_P));
-
-            Some(pll * 2u32)
+            RCC.cfgr3().modify(|w| w.set_tim2sw(crate::pac::rcc::vals::Timsw::PLL1_P));
         }
     };
 
     #[cfg(any(all(stm32f303, any(package_D, package_E)), all(stm32f302, any(package_D, package_E))))]
-    let tim34 = match config.tim.tim34 {
-        TimClockSource::PClk2 => None,
+    match config.tim.tim34 {
+        TimClockSource::PClk2 => {},
         TimClockSource::PllClk => {
-            use crate::pac::rcc::vals::Timsw;
-
-            let pll = unwrap!(pll);
-            assert!((pclk2 == pll) || (pclk2 * 2u32 == pll));
-
-            RCC.cfgr3().modify(|w| w.set_tim34sw(Timsw::PLL1_P));
-
-            Some(pll * 2u32)
+            RCC.cfgr3().modify(|w| w.set_tim34sw(crate::pac::rcc::vals::Timsw::PLL1_P));
         }
     };
 
     #[cfg(any(all(stm32f303, any(package_B, package_C, package_D, package_E)), stm32f358))]
-    let tim8 = match config.tim.tim8 {
-        TimClockSource::PClk2 => None,
+    match config.tim.tim8 {
+        TimClockSource::PClk2 => {},
         TimClockSource::PllClk => {
-            use crate::pac::rcc::vals::Timsw;
-
-            let pll = unwrap!(pll);
-            assert!((pclk2 == pll) || (pclk2 * 2u32 == pll));
-
-            RCC.cfgr3().modify(|w| w.set_tim8sw(Timsw::PLL1_P));
-
-            Some(pll * 2u32)
+            RCC.cfgr3().modify(|w| w.set_tim8sw(crate::pac::rcc::vals::Timsw::PLL1_P));
         }
     };
 
@@ -514,17 +486,10 @@ pub(crate) unsafe fn init(config: Config) {
         stm32f318,
         all(stm32f302, any(package_6, package_8))
     ))]
-    let tim15 = match config.tim.tim15 {
+    match config.tim.tim15 {
         TimClockSource::PClk2 => None,
         TimClockSource::PllClk => {
-            use crate::pac::rcc::vals::Timsw;
-
-            let pll = unwrap!(pll);
-            assert!((pclk2 == pll) || (pclk2 * 2u32 == pll));
-
-            RCC.cfgr3().modify(|w| w.set_tim15sw(Timsw::PLL1_P));
-
-            Some(pll * 2u32)
+            RCC.cfgr3().modify(|w| w.set_tim15sw(crate::pac::rcc::vals::Timsw::PLL1_P));
         }
     };
 
@@ -534,17 +499,10 @@ pub(crate) unsafe fn init(config: Config) {
         stm32f318,
         all(stm32f302, any(package_6, package_8))
     ))]
-    let tim16 = match config.tim.tim16 {
+    match config.tim.tim16 {
         TimClockSource::PClk2 => None,
         TimClockSource::PllClk => {
-            use crate::pac::rcc::vals::Timsw;
-
-            let pll = unwrap!(pll);
-            assert!((pclk2 == pll) || (pclk2 * 2u32 == pll));
-
-            RCC.cfgr3().modify(|w| w.set_tim16sw(Timsw::PLL1_P));
-
-            Some(pll * 2u32)
+            RCC.cfgr3().modify(|w| w.set_tim16sw(crate::pac::rcc::vals::Timsw::PLL1_P));
         }
     };
 
@@ -554,34 +512,20 @@ pub(crate) unsafe fn init(config: Config) {
         stm32f318,
         all(stm32f302, any(package_6, package_8))
     ))]
-    let tim17 = match config.tim.tim17 {
+    match config.tim.tim17 {
         TimClockSource::PClk2 => None,
         TimClockSource::PllClk => {
-            use crate::pac::rcc::vals::Timsw;
-
-            let pll = unwrap!(pll);
-            assert!((pclk2 == pll) || (pclk2 * 2u32 == pll));
-
-            RCC.cfgr3().modify(|w| w.set_tim17sw(Timsw::PLL1_P));
-
-            Some(pll * 2u32)
+            RCC.cfgr3().modify(|w| w.set_tim17sw(crate::pac::rcc::vals::Timsw::PLL1_P));
         }
-    };
+    }
 
     #[cfg(any(all(stm32f303, any(package_D, package_E))))]
-    let tim20 = match config.tim.tim20 {
+    match config.tim.tim20 {
         TimClockSource::PClk2 => None,
         TimClockSource::PllClk => {
-            use crate::pac::rcc::vals::Timsw;
-
-            let pll = unwrap!(pll);
-            assert!((pclk2 == pll) || (pclk2 * 2u32 == pll));
-
-            RCC.cfgr3().modify(|w| w.set_tim20sw(Timsw::PLL1_P));
-
-            Some(pll * 2u32)
+            RCC.cfgr3().modify(|w| w.set_tim20sw(crate::pac::rcc::vals::Timsw::PLL1_P));
         }
-    };
+    }
 
     set_clocks!(
         hsi: hsi,
@@ -599,22 +543,6 @@ pub(crate) unsafe fn init(config: Config) {
         adc34: Some(adc34),
         #[cfg(stm32f334)]
         hrtim: hrtim,
-        #[cfg(all(stm32f3, not(rcc_f37)))]
-        tim1: tim1,
-        #[cfg(any(all(stm32f303, any(package_D, package_E)), all(stm32f302, any(package_D, package_E))))]
-        tim2: tim2,
-        #[cfg(any(all(stm32f303, any(package_D, package_E)), all(stm32f302, any(package_D, package_E))))]
-        tim34: tim34,
-        #[cfg(any(all(stm32f303, any(package_B, package_C, package_D, package_E)), stm32f358))]
-        tim8: tim8,
-        #[cfg(any(all(stm32f303, any(package_D, package_E)), stm32f301, stm32f318, all(stm32f302, any(package_6, package_8))))]
-        tim15: tim15,
-        #[cfg(any(all(stm32f303, any(package_D, package_E)), stm32f301, stm32f318, all(stm32f302, any(package_6, package_8))))]
-        tim16: tim16,
-        #[cfg(any(all(stm32f303, any(package_D, package_E)), stm32f301, stm32f318, all(stm32f302, any(package_6, package_8))))]
-        tim17: tim17,
-        #[cfg(any(all(stm32f303, any(package_D, package_E))))]
-        tim20: tim20,
         rtc: rtc,
         hsi48: hsi48,
         #[cfg(any(rcc_f1, rcc_f1cl, stm32f3))]

--- a/embassy-stm32/src/rcc/f013.rs
+++ b/embassy-stm32/src/rcc/f013.rs
@@ -87,7 +87,7 @@ pub struct TimClockSources {
     pub tim1: TimClockSource,
     #[cfg(any(
         all(stm32f303, any(package_D, package_E)),
-        all(stm32f302, any(package_D, package_E))
+        all(stm32f302, any(package_D, package_E)),
         stm32f398
     ))]
     pub tim2: TimClockSource,
@@ -533,7 +533,7 @@ pub(crate) unsafe fn init(config: Config) {
         stm32f398
     ))]
     match config.tim.tim15 {
-        TimClockSource::PClk2 => {},
+        TimClockSource::PClk2 => {}
         TimClockSource::PllClk => {
             RCC.cfgr3()
                 .modify(|w| w.set_tim15sw(crate::pac::rcc::vals::Timsw::PLL1_P));
@@ -548,7 +548,7 @@ pub(crate) unsafe fn init(config: Config) {
         stm32f398
     ))]
     match config.tim.tim16 {
-        TimClockSource::PClk2 => {},
+        TimClockSource::PClk2 => {}
         TimClockSource::PllClk => {
             RCC.cfgr3()
                 .modify(|w| w.set_tim16sw(crate::pac::rcc::vals::Timsw::PLL1_P));
@@ -563,7 +563,7 @@ pub(crate) unsafe fn init(config: Config) {
         stm32f398
     ))]
     match config.tim.tim17 {
-        TimClockSource::PClk2 => {},
+        TimClockSource::PClk2 => {}
         TimClockSource::PllClk => {
             RCC.cfgr3()
                 .modify(|w| w.set_tim17sw(crate::pac::rcc::vals::Timsw::PLL1_P));
@@ -572,7 +572,7 @@ pub(crate) unsafe fn init(config: Config) {
 
     #[cfg(any(all(stm32f303, any(package_D, package_E))))]
     match config.tim.tim20 {
-        TimClockSource::PClk2 => {},
+        TimClockSource::PClk2 => {}
         TimClockSource::PllClk => {
             RCC.cfgr3()
                 .modify(|w| w.set_tim20sw(crate::pac::rcc::vals::Timsw::PLL1_P));

--- a/embassy-stm32/src/rcc/f013.rs
+++ b/embassy-stm32/src/rcc/f013.rs
@@ -85,31 +85,34 @@ pub enum TimClockSource {
 #[derive(Clone, Copy)]
 pub struct TimClockSources {
     pub tim1: TimClockSource,
-    #[cfg(any(all(stm32f303, any(package_D, package_E)), all(stm32f302, any(package_D, package_E))))]
+    #[cfg(any(all(stm32f303, any(package_D, package_E)), all(stm32f302, any(package_D, package_E)), stm32f398))]
     pub tim2: TimClockSource,
-    #[cfg(any(all(stm32f303, any(package_D, package_E)), all(stm32f302, any(package_D, package_E))))]
+    #[cfg(any(all(stm32f303, any(package_D, package_E)), all(stm32f302, any(package_D, package_E)), stm32f398))]
     pub tim34: TimClockSource,
-    #[cfg(any(all(stm32f303, any(package_B, package_C, package_D, package_E)), stm32f358))]
+    #[cfg(any(all(stm32f303, any(package_B, package_C, package_D, package_E)), stm32f358, stm32f398))]
     pub tim8: TimClockSource,
     #[cfg(any(
         all(stm32f303, any(package_D, package_E)),
         stm32f301,
         stm32f318,
-        all(stm32f302, any(package_6, package_8))
+        all(stm32f302, any(package_6, package_8)),
+        stm32f398
     ))]
     pub tim15: TimClockSource,
     #[cfg(any(
         all(stm32f303, any(package_D, package_E)),
         stm32f301,
         stm32f318,
-        all(stm32f302, any(package_6, package_8))
+        all(stm32f302, any(package_6, package_8)),
+        stm32f398
     ))]
     pub tim16: TimClockSource,
     #[cfg(any(
         all(stm32f303, any(package_D, package_E)),
         stm32f301,
         stm32f318,
-        all(stm32f302, any(package_6, package_8))
+        all(stm32f302, any(package_6, package_8)),
+        stm32f398
     ))]
     pub tim17: TimClockSource,
     #[cfg(any(all(stm32f303, any(package_D, package_E))))]
@@ -121,31 +124,34 @@ impl Default for TimClockSources {
     fn default() -> Self {
         Self {
             tim1: TimClockSource::PClk2,
-            #[cfg(any(all(stm32f303, any(package_D, package_E)), all(stm32f302, any(package_D, package_E))))]
+            #[cfg(any(all(stm32f303, any(package_D, package_E)), all(stm32f302, any(package_D, package_E)), stm32f398))]
             tim2: TimClockSource::PClk2,
-            #[cfg(any(all(stm32f303, any(package_D, package_E)), all(stm32f302, any(package_D, package_E))))]
+            #[cfg(any(all(stm32f303, any(package_D, package_E)), all(stm32f302, any(package_D, package_E)), stm32f398))]
             tim34: TimClockSource::PClk2,
-            #[cfg(any(all(stm32f303, any(package_B, package_C, package_D, package_E)), stm32f358))]
+            #[cfg(any(all(stm32f303, any(package_B, package_C, package_D, package_E)), stm32f358, stm32f398))]
             tim8: TimClockSource::PClk2,
             #[cfg(any(
                 all(stm32f303, any(package_D, package_E)),
                 stm32f301,
                 stm32f318,
-                all(stm32f302, any(package_6, package_8))
+                all(stm32f302, any(package_6, package_8)),
+                stm32f398
             ))]
             tim15: TimClockSource::PClk2,
             #[cfg(any(
                 all(stm32f303, any(package_D, package_E)),
                 stm32f301,
                 stm32f318,
-                all(stm32f302, any(package_6, package_8))
+                all(stm32f302, any(package_6, package_8)),
+                stm32f398
             ))]
             tim16: TimClockSource::PClk2,
             #[cfg(any(
                 all(stm32f303, any(package_D, package_E)),
                 stm32f301,
                 stm32f318,
-                all(stm32f302, any(package_6, package_8))
+                all(stm32f302, any(package_6, package_8)),
+                stm32f398
             ))]
             tim17: TimClockSource::PClk2,
             #[cfg(any(all(stm32f303, any(package_D, package_E))))]
@@ -456,7 +462,7 @@ pub(crate) unsafe fn init(config: Config) {
         }
     };
 
-    #[cfg(any(all(stm32f303, any(package_D, package_E)), all(stm32f302, any(package_D, package_E))))]
+    #[cfg(any(all(stm32f303, any(package_D, package_E)), all(stm32f302, any(package_D, package_E)), stm32f398))]
     match config.tim.tim2 {
         TimClockSource::PClk2 => {}
         TimClockSource::PllClk => {
@@ -465,7 +471,7 @@ pub(crate) unsafe fn init(config: Config) {
         }
     };
 
-    #[cfg(any(all(stm32f303, any(package_D, package_E)), all(stm32f302, any(package_D, package_E))))]
+    #[cfg(any(all(stm32f303, any(package_D, package_E)), all(stm32f302, any(package_D, package_E)), stm32f398))]
     match config.tim.tim34 {
         TimClockSource::PClk2 => {}
         TimClockSource::PllClk => {
@@ -474,7 +480,7 @@ pub(crate) unsafe fn init(config: Config) {
         }
     };
 
-    #[cfg(any(all(stm32f303, any(package_B, package_C, package_D, package_E)), stm32f358))]
+    #[cfg(any(all(stm32f303, any(package_B, package_C, package_D, package_E)), stm32f358, stm32f398))]
     match config.tim.tim8 {
         TimClockSource::PClk2 => {}
         TimClockSource::PllClk => {
@@ -487,7 +493,8 @@ pub(crate) unsafe fn init(config: Config) {
         all(stm32f303, any(package_D, package_E)),
         stm32f301,
         stm32f318,
-        all(stm32f302, any(package_6, package_8))
+        all(stm32f302, any(package_6, package_8)),
+        stm32f398
     ))]
     match config.tim.tim15 {
         TimClockSource::PClk2 => None,
@@ -501,7 +508,8 @@ pub(crate) unsafe fn init(config: Config) {
         all(stm32f303, any(package_D, package_E)),
         stm32f301,
         stm32f318,
-        all(stm32f302, any(package_6, package_8))
+        all(stm32f302, any(package_6, package_8)),
+        stm32f398
     ))]
     match config.tim.tim16 {
         TimClockSource::PClk2 => None,
@@ -515,7 +523,8 @@ pub(crate) unsafe fn init(config: Config) {
         all(stm32f303, any(package_D, package_E)),
         stm32f301,
         stm32f318,
-        all(stm32f302, any(package_6, package_8))
+        all(stm32f302, any(package_6, package_8)),
+        stm32f398
     ))]
     match config.tim.tim17 {
         TimClockSource::PClk2 => None,

--- a/embassy-stm32/src/rcc/f013.rs
+++ b/embassy-stm32/src/rcc/f013.rs
@@ -85,11 +85,23 @@ pub enum TimClockSource {
 #[derive(Clone, Copy)]
 pub struct TimClockSources {
     pub tim1: TimClockSource,
-    #[cfg(any(all(stm32f303, any(package_D, package_E)), all(stm32f302, any(package_D, package_E)), stm32f398))]
+    #[cfg(any(
+        all(stm32f303, any(package_D, package_E)),
+        all(stm32f302, any(package_D, package_E))
+        stm32f398
+    ))]
     pub tim2: TimClockSource,
-    #[cfg(any(all(stm32f303, any(package_D, package_E)), all(stm32f302, any(package_D, package_E)), stm32f398))]
+    #[cfg(any(
+        all(stm32f303, any(package_D, package_E)),
+        all(stm32f302, any(package_D, package_E)),
+        stm32f398
+    ))]
     pub tim34: TimClockSource,
-    #[cfg(any(all(stm32f303, any(package_B, package_C, package_D, package_E)), stm32f358, stm32f398))]
+    #[cfg(any(
+        all(stm32f303, any(package_B, package_C, package_D, package_E)),
+        stm32f358,
+        stm32f398
+    ))]
     pub tim8: TimClockSource,
     #[cfg(any(
         all(stm32f303, any(package_D, package_E)),
@@ -124,11 +136,23 @@ impl Default for TimClockSources {
     fn default() -> Self {
         Self {
             tim1: TimClockSource::PClk2,
-            #[cfg(any(all(stm32f303, any(package_D, package_E)), all(stm32f302, any(package_D, package_E)), stm32f398))]
+            #[cfg(any(
+                all(stm32f303, any(package_D, package_E)),
+                all(stm32f302, any(package_D, package_E)),
+                stm32f398
+            ))]
             tim2: TimClockSource::PClk2,
-            #[cfg(any(all(stm32f303, any(package_D, package_E)), all(stm32f302, any(package_D, package_E)), stm32f398))]
+            #[cfg(any(
+                all(stm32f303, any(package_D, package_E)),
+                all(stm32f302, any(package_D, package_E)),
+                stm32f398
+            ))]
             tim34: TimClockSource::PClk2,
-            #[cfg(any(all(stm32f303, any(package_B, package_C, package_D, package_E)), stm32f358, stm32f398))]
+            #[cfg(any(
+                all(stm32f303, any(package_B, package_C, package_D, package_E)),
+                stm32f358,
+                stm32f398
+            ))]
             tim8: TimClockSource::PClk2,
             #[cfg(any(
                 all(stm32f303, any(package_D, package_E)),
@@ -462,7 +486,11 @@ pub(crate) unsafe fn init(config: Config) {
         }
     };
 
-    #[cfg(any(all(stm32f303, any(package_D, package_E)), all(stm32f302, any(package_D, package_E)), stm32f398))]
+    #[cfg(any(
+        all(stm32f303, any(package_D, package_E)),
+        all(stm32f302, any(package_D, package_E)),
+        stm32f398
+    ))]
     match config.tim.tim2 {
         TimClockSource::PClk2 => {}
         TimClockSource::PllClk => {
@@ -471,7 +499,11 @@ pub(crate) unsafe fn init(config: Config) {
         }
     };
 
-    #[cfg(any(all(stm32f303, any(package_D, package_E)), all(stm32f302, any(package_D, package_E)), stm32f398))]
+    #[cfg(any(
+        all(stm32f303, any(package_D, package_E)),
+        all(stm32f302, any(package_D, package_E)),
+        stm32f398
+    ))]
     match config.tim.tim34 {
         TimClockSource::PClk2 => {}
         TimClockSource::PllClk => {
@@ -480,7 +512,11 @@ pub(crate) unsafe fn init(config: Config) {
         }
     };
 
-    #[cfg(any(all(stm32f303, any(package_B, package_C, package_D, package_E)), stm32f358, stm32f398))]
+    #[cfg(any(
+        all(stm32f303, any(package_B, package_C, package_D, package_E)),
+        stm32f358,
+        stm32f398
+    ))]
     match config.tim.tim8 {
         TimClockSource::PClk2 => {}
         TimClockSource::PllClk => {

--- a/embassy-stm32/src/rcc/f013.rs
+++ b/embassy-stm32/src/rcc/f013.rs
@@ -495,7 +495,7 @@ pub(crate) unsafe fn init(config: Config) {
         TimClockSource::PClk2 => {}
         TimClockSource::PllClk => {
             RCC.cfgr3()
-                .modify(|w| w.set_tim2sw(crate::pac::rcc::vals::Timsw::PLL1_P));
+                .modify(|w| w.set_tim2sw(crate::pac::rcc::vals::Tim2sw::PLL1_P));
         }
     };
 
@@ -533,7 +533,7 @@ pub(crate) unsafe fn init(config: Config) {
         stm32f398
     ))]
     match config.tim.tim15 {
-        TimClockSource::PClk2 => None,
+        TimClockSource::PClk2 => {},
         TimClockSource::PllClk => {
             RCC.cfgr3()
                 .modify(|w| w.set_tim15sw(crate::pac::rcc::vals::Timsw::PLL1_P));
@@ -548,7 +548,7 @@ pub(crate) unsafe fn init(config: Config) {
         stm32f398
     ))]
     match config.tim.tim16 {
-        TimClockSource::PClk2 => None,
+        TimClockSource::PClk2 => {},
         TimClockSource::PllClk => {
             RCC.cfgr3()
                 .modify(|w| w.set_tim16sw(crate::pac::rcc::vals::Timsw::PLL1_P));
@@ -563,7 +563,7 @@ pub(crate) unsafe fn init(config: Config) {
         stm32f398
     ))]
     match config.tim.tim17 {
-        TimClockSource::PClk2 => None,
+        TimClockSource::PClk2 => {},
         TimClockSource::PllClk => {
             RCC.cfgr3()
                 .modify(|w| w.set_tim17sw(crate::pac::rcc::vals::Timsw::PLL1_P));
@@ -572,7 +572,7 @@ pub(crate) unsafe fn init(config: Config) {
 
     #[cfg(any(all(stm32f303, any(package_D, package_E))))]
     match config.tim.tim20 {
-        TimClockSource::PClk2 => None,
+        TimClockSource::PClk2 => {},
         TimClockSource::PllClk => {
             RCC.cfgr3()
                 .modify(|w| w.set_tim20sw(crate::pac::rcc::vals::Timsw::PLL1_P));

--- a/embassy-stm32/src/rcc/f013.rs
+++ b/embassy-stm32/src/rcc/f013.rs
@@ -85,11 +85,11 @@ pub enum TimClockSource {
 #[derive(Clone, Copy)]
 pub struct TimClockSources {
     pub tim1: TimClockSource,
-    #[cfg(any(all(stm32f303, any(package_D, package_E)), all(stm32f302, any(package_D, package_E)),))]
+    #[cfg(any(all(stm32f303, any(package_D, package_E)), all(stm32f302, any(package_D, package_E))))]
     pub tim2: TimClockSource,
-    #[cfg(any(all(stm32f303, any(package_D, package_E)), all(stm32f302, any(package_D, package_E)),))]
+    #[cfg(any(all(stm32f303, any(package_D, package_E)), all(stm32f302, any(package_D, package_E))))]
     pub tim34: TimClockSource,
-    #[cfg(any(all(stm32f303, any(package_B, package_C, package_D, package_E)), stm32f358,))]
+    #[cfg(any(all(stm32f303, any(package_B, package_C, package_D, package_E)), stm32f358))]
     pub tim8: TimClockSource,
     #[cfg(any(
         all(stm32f303, any(package_D, package_E)),
@@ -112,7 +112,7 @@ pub struct TimClockSources {
         all(stm32f302, any(package_6, package_8))
     ))]
     pub tim17: TimClockSource,
-    #[cfg(any(all(stm32f303, any(package_D, package_E)),))]
+    #[cfg(any(all(stm32f303, any(package_D, package_E))))]
     pub tim20: TimClockSource,
 }
 
@@ -121,11 +121,11 @@ impl Default for TimClockSources {
     fn default() -> Self {
         Self {
             tim1: TimClockSource::PClk2,
-            #[cfg(any(all(stm32f303, any(package_D, package_E)), all(stm32f302, any(package_D, package_E)),))]
+            #[cfg(any(all(stm32f303, any(package_D, package_E)), all(stm32f302, any(package_D, package_E))))]
             tim2: TimClockSource::PClk2,
-            #[cfg(any(all(stm32f303, any(package_D, package_E)), all(stm32f302, any(package_D, package_E)),))]
+            #[cfg(any(all(stm32f303, any(package_D, package_E)), all(stm32f302, any(package_D, package_E))))]
             tim34: TimClockSource::PClk2,
-            #[cfg(any(all(stm32f303, any(package_B, package_C, package_D, package_E)), stm32f358,))]
+            #[cfg(any(all(stm32f303, any(package_B, package_C, package_D, package_E)), stm32f358))]
             tim8: TimClockSource::PClk2,
             #[cfg(any(
                 all(stm32f303, any(package_D, package_E)),
@@ -148,7 +148,7 @@ impl Default for TimClockSources {
                 all(stm32f302, any(package_6, package_8))
             ))]
             tim17: TimClockSource::PClk2,
-            #[cfg(any(all(stm32f303, any(package_D, package_E)),))]
+            #[cfg(any(all(stm32f303, any(package_D, package_E))))]
             tim20: TimClockSource::PClk2,
         }
     }

--- a/embassy-stm32/src/rcc/f013.rs
+++ b/embassy-stm32/src/rcc/f013.rs
@@ -99,8 +99,8 @@ pub struct Config {
     pub adc34: AdcClockSource,
     #[cfg(stm32f334)]
     pub hrtim: HrtimClockSource,
-    #[cfg(cfgr3)]
-    pub cfgr3: crate::_generated::CFGR3,
+    #[cfg(clock_mux)]
+    pub mux: crate::rcc::ClockMux,
 
     pub ls: super::LsConfig,
 }
@@ -130,8 +130,8 @@ impl Default for Config {
             adc34: AdcClockSource::Hclk(AdcHclkPrescaler::Div1),
             #[cfg(stm32f334)]
             hrtim: HrtimClockSource::BusClk,
-            #[cfg(cfgr3)]
-            cfgr3: Default::default(),
+            #[cfg(clock_mux)]
+            mux: Default::default(),
         }
     }
 }
@@ -367,8 +367,8 @@ pub(crate) unsafe fn init(config: Config) {
         }
     };
 
-    #[cfg(cfgr3)]
-    config.cfgr3.init();
+    #[cfg(clock_mux)]
+    config.mux.init();
 
     set_clocks!(
         hsi: hsi,

--- a/embassy-stm32/src/rcc/f013.rs
+++ b/embassy-stm32/src/rcc/f013.rs
@@ -204,14 +204,13 @@ impl Default for Config {
             // ensure ADC is not out of range by default even if APB2 is maxxed out (36mhz)
             adc_pre: ADCPrescaler::DIV6,
 
-
             #[cfg(all(stm32f3, not(rcc_f37)))]
             adc: AdcClockSource::Hclk(AdcHclkPrescaler::Div1),
             #[cfg(all(stm32f3, not(rcc_f37), adc3_common))]
             adc34: AdcClockSource::Hclk(AdcHclkPrescaler::Div1),
             #[cfg(stm32f334)]
             hrtim: HrtimClockSource::BusClk,
-            #[cfg(all(stm32f3, not(stm32f37)))]
+            #[cfg(all(stm32f3, not(rcc_f37)))]
             tim: Default::default(),
         }
     }
@@ -450,33 +449,37 @@ pub(crate) unsafe fn init(config: Config) {
 
     #[cfg(all(stm32f3, not(rcc_f37)))]
     match config.tim.tim1 {
-        TimClockSource::PClk2 => {},
+        TimClockSource::PClk2 => {}
         TimClockSource::PllClk => {
-            RCC.cfgr3().modify(|w| w.set_tim1sw(crate::pac::rcc::vals::Timsw::PLL1_P));
+            RCC.cfgr3()
+                .modify(|w| w.set_tim1sw(crate::pac::rcc::vals::Timsw::PLL1_P));
         }
     };
 
     #[cfg(any(all(stm32f303, any(package_D, package_E)), all(stm32f302, any(package_D, package_E))))]
     match config.tim.tim2 {
-        TimClockSource::PClk2 => {},
+        TimClockSource::PClk2 => {}
         TimClockSource::PllClk => {
-            RCC.cfgr3().modify(|w| w.set_tim2sw(crate::pac::rcc::vals::Timsw::PLL1_P));
+            RCC.cfgr3()
+                .modify(|w| w.set_tim2sw(crate::pac::rcc::vals::Timsw::PLL1_P));
         }
     };
 
     #[cfg(any(all(stm32f303, any(package_D, package_E)), all(stm32f302, any(package_D, package_E))))]
     match config.tim.tim34 {
-        TimClockSource::PClk2 => {},
+        TimClockSource::PClk2 => {}
         TimClockSource::PllClk => {
-            RCC.cfgr3().modify(|w| w.set_tim34sw(crate::pac::rcc::vals::Timsw::PLL1_P));
+            RCC.cfgr3()
+                .modify(|w| w.set_tim34sw(crate::pac::rcc::vals::Timsw::PLL1_P));
         }
     };
 
     #[cfg(any(all(stm32f303, any(package_B, package_C, package_D, package_E)), stm32f358))]
     match config.tim.tim8 {
-        TimClockSource::PClk2 => {},
+        TimClockSource::PClk2 => {}
         TimClockSource::PllClk => {
-            RCC.cfgr3().modify(|w| w.set_tim8sw(crate::pac::rcc::vals::Timsw::PLL1_P));
+            RCC.cfgr3()
+                .modify(|w| w.set_tim8sw(crate::pac::rcc::vals::Timsw::PLL1_P));
         }
     };
 
@@ -489,7 +492,8 @@ pub(crate) unsafe fn init(config: Config) {
     match config.tim.tim15 {
         TimClockSource::PClk2 => None,
         TimClockSource::PllClk => {
-            RCC.cfgr3().modify(|w| w.set_tim15sw(crate::pac::rcc::vals::Timsw::PLL1_P));
+            RCC.cfgr3()
+                .modify(|w| w.set_tim15sw(crate::pac::rcc::vals::Timsw::PLL1_P));
         }
     };
 
@@ -502,7 +506,8 @@ pub(crate) unsafe fn init(config: Config) {
     match config.tim.tim16 {
         TimClockSource::PClk2 => None,
         TimClockSource::PllClk => {
-            RCC.cfgr3().modify(|w| w.set_tim16sw(crate::pac::rcc::vals::Timsw::PLL1_P));
+            RCC.cfgr3()
+                .modify(|w| w.set_tim16sw(crate::pac::rcc::vals::Timsw::PLL1_P));
         }
     };
 
@@ -515,7 +520,8 @@ pub(crate) unsafe fn init(config: Config) {
     match config.tim.tim17 {
         TimClockSource::PClk2 => None,
         TimClockSource::PllClk => {
-            RCC.cfgr3().modify(|w| w.set_tim17sw(crate::pac::rcc::vals::Timsw::PLL1_P));
+            RCC.cfgr3()
+                .modify(|w| w.set_tim17sw(crate::pac::rcc::vals::Timsw::PLL1_P));
         }
     }
 
@@ -523,7 +529,8 @@ pub(crate) unsafe fn init(config: Config) {
     match config.tim.tim20 {
         TimClockSource::PClk2 => None,
         TimClockSource::PllClk => {
-            RCC.cfgr3().modify(|w| w.set_tim20sw(crate::pac::rcc::vals::Timsw::PLL1_P));
+            RCC.cfgr3()
+                .modify(|w| w.set_tim20sw(crate::pac::rcc::vals::Timsw::PLL1_P));
         }
     }
 

--- a/embassy-stm32/src/rcc/f013.rs
+++ b/embassy-stm32/src/rcc/f013.rs
@@ -85,20 +85,11 @@ pub enum TimClockSource {
 #[derive(Clone, Copy)]
 pub struct TimClockSources {
     pub tim1: TimClockSource,
-    #[cfg(any(
-        all(stm32f303, any(package_D, package_E)),
-        all(stm32f302, any(package_D, package_E)),
-    ))]
+    #[cfg(any(all(stm32f303, any(package_D, package_E)), all(stm32f302, any(package_D, package_E)),))]
     pub tim2: TimClockSource,
-    #[cfg(any(
-        all(stm32f303, any(package_D, package_E)),
-        all(stm32f302, any(package_D, package_E)),
-    ))]
+    #[cfg(any(all(stm32f303, any(package_D, package_E)), all(stm32f302, any(package_D, package_E)),))]
     pub tim34: TimClockSource,
-    #[cfg(any(
-        all(stm32f303, any(package_B, package_C, package_D, package_E)),
-        stm32f358,
-    ))]
+    #[cfg(any(all(stm32f303, any(package_B, package_C, package_D, package_E)), stm32f358,))]
     pub tim8: TimClockSource,
     #[cfg(any(
         all(stm32f303, any(package_D, package_E)),
@@ -121,30 +112,19 @@ pub struct TimClockSources {
         all(stm32f302, any(package_6, package_8))
     ))]
     pub tim17: TimClockSource,
-    #[cfg(any(
-        all(stm32f303, any(package_D, package_E)),
-    ))]
-    pub tim20: TimClockSource
+    #[cfg(any(all(stm32f303, any(package_D, package_E)),))]
+    pub tim20: TimClockSource,
 }
 
 impl Default for TimClockSources {
     fn default() -> Self {
         Self {
             tim1: TimClockSource::PClk2,
-            #[cfg(any(
-                all(stm32f303, any(package_D, package_E)),
-                all(stm32f302, any(package_D, package_E)),
-            ))]
+            #[cfg(any(all(stm32f303, any(package_D, package_E)), all(stm32f302, any(package_D, package_E)),))]
             tim2: TimClockSource::PClk2,
-            #[cfg(any(
-                all(stm32f303, any(package_D, package_E)),
-                all(stm32f302, any(package_D, package_E)),
-            ))]
+            #[cfg(any(all(stm32f303, any(package_D, package_E)), all(stm32f302, any(package_D, package_E)),))]
             tim34: TimClockSource::PClk2,
-            #[cfg(any(
-                all(stm32f303, any(package_B, package_C, package_D, package_E)),
-                stm32f358,
-            ))]
+            #[cfg(any(all(stm32f303, any(package_B, package_C, package_D, package_E)), stm32f358,))]
             tim8: TimClockSource::PClk2,
             #[cfg(any(
                 all(stm32f303, any(package_D, package_E)),
@@ -167,10 +147,8 @@ impl Default for TimClockSources {
                 all(stm32f302, any(package_6, package_8))
             ))]
             tim17: TimClockSource::PClk2,
-            #[cfg(any(
-                all(stm32f303, any(package_D, package_E)),
-            ))]
-            tim20: TimClockSource::PClk2
+            #[cfg(any(all(stm32f303, any(package_D, package_E)),))]
+            tim20: TimClockSource::PClk2,
         }
     }
 }
@@ -233,7 +211,7 @@ impl Default for Config {
             #[cfg(stm32f334)]
             hrtim: HrtimClockSource::BusClk,
             #[cfg(not(stm32f37))]
-            tim: Default::default()
+            tim: Default::default(),
         }
     }
 }
@@ -476,9 +454,9 @@ pub(crate) unsafe fn init(config: Config) {
             use crate::pac::rcc::vals::Timsw;
 
             let pll = unwrap!(pll);
-            assert((pclk2 == pll) || (pclk2 * 2u32 == pll));
+            assert!((pclk2 == pll) || (pclk2 * 2u32 == pll));
 
-            RCC.cfgr3().modify(|w| w.set_tim1(Timsw::PLL1_P));
+            RCC.cfgr3().modify(|w| w.set_tim1sw(Timsw::PLL1_P));
 
             Some(pll * 2u32)
         }
@@ -491,9 +469,9 @@ pub(crate) unsafe fn init(config: Config) {
             use crate::pac::rcc::vals::Timsw;
 
             let pll = unwrap!(pll);
-            assert((pclk2 == pll) || (pclk2 * 2u32 == pll));
+            assert!((pclk2 == pll) || (pclk2 * 2u32 == pll));
 
-            RCC.cfgr3().modify(|w| w.set_tim2(Timsw::PLL1_P));
+            RCC.cfgr3().modify(|w| w.set_tim2sw(Timsw::PLL1_P));
 
             Some(pll * 2u32)
         }
@@ -506,9 +484,9 @@ pub(crate) unsafe fn init(config: Config) {
             use crate::pac::rcc::vals::Timsw;
 
             let pll = unwrap!(pll);
-            assert((pclk2 == pll) || (pclk2 * 2u32 == pll));
+            assert!((pclk2 == pll) || (pclk2 * 2u32 == pll));
 
-            RCC.cfgr3().modify(|w| w.set_tim34(Timsw::PLL1_P));
+            RCC.cfgr3().modify(|w| w.set_tim34sw(Timsw::PLL1_P));
 
             Some(pll * 2u32)
         }
@@ -521,54 +499,69 @@ pub(crate) unsafe fn init(config: Config) {
             use crate::pac::rcc::vals::Timsw;
 
             let pll = unwrap!(pll);
-            assert((pclk2 == pll) || (pclk2 * 2u32 == pll));
+            assert!((pclk2 == pll) || (pclk2 * 2u32 == pll));
 
-            RCC.cfgr3().modify(|w| w.set_tim8(Timsw::PLL1_P));
+            RCC.cfgr3().modify(|w| w.set_tim8sw(Timsw::PLL1_P));
 
             Some(pll * 2u32)
         }
     };
 
-    #[cfg(any(all(stm32f303, any(package_D, package_E)), stm32f301, stm32f318, all(stm32f302, any(package_6, package_8))))]
+    #[cfg(any(
+        all(stm32f303, any(package_D, package_E)),
+        stm32f301,
+        stm32f318,
+        all(stm32f302, any(package_6, package_8))
+    ))]
     let tim15 = match config.tim.tim15 {
         TimClockSource::PClk2 => None,
         TimClockSource::PllClk => {
             use crate::pac::rcc::vals::Timsw;
 
             let pll = unwrap!(pll);
-            assert((pclk2 == pll) || (pclk2 * 2u32 == pll));
+            assert!((pclk2 == pll) || (pclk2 * 2u32 == pll));
 
-            RCC.cfgr3().modify(|w| w.set_tim15(Timsw::PLL1_P));
+            RCC.cfgr3().modify(|w| w.set_tim15sw(Timsw::PLL1_P));
 
             Some(pll * 2u32)
         }
     };
 
-    #[cfg(any(all(stm32f303, any(package_D, package_E)), stm32f301, stm32f318, all(stm32f302, any(package_6, package_8))))]
+    #[cfg(any(
+        all(stm32f303, any(package_D, package_E)),
+        stm32f301,
+        stm32f318,
+        all(stm32f302, any(package_6, package_8))
+    ))]
     let tim16 = match config.tim.tim16 {
         TimClockSource::PClk2 => None,
         TimClockSource::PllClk => {
             use crate::pac::rcc::vals::Timsw;
 
             let pll = unwrap!(pll);
-            assert((pclk2 == pll) || (pclk2 * 2u32 == pll));
+            assert!((pclk2 == pll) || (pclk2 * 2u32 == pll));
 
-            RCC.cfgr3().modify(|w| w.set_tim16(Timsw::PLL1_P));
+            RCC.cfgr3().modify(|w| w.set_tim16sw(Timsw::PLL1_P));
 
             Some(pll * 2u32)
         }
     };
 
-    #[cfg(any(all(stm32f303, any(package_D, package_E)), stm32f301, stm32f318, all(stm32f302, any(package_6, package_8))))]
+    #[cfg(any(
+        all(stm32f303, any(package_D, package_E)),
+        stm32f301,
+        stm32f318,
+        all(stm32f302, any(package_6, package_8))
+    ))]
     let tim17 = match config.tim.tim17 {
         TimClockSource::PClk2 => None,
         TimClockSource::PllClk => {
             use crate::pac::rcc::vals::Timsw;
 
             let pll = unwrap!(pll);
-            assert((pclk2 == pll) || (pclk2 * 2u32 == pll));
+            assert!((pclk2 == pll) || (pclk2 * 2u32 == pll));
 
-            RCC.cfgr3().modify(|w| w.set_tim17(Timsw::PLL1_P));
+            RCC.cfgr3().modify(|w| w.set_tim17sw(Timsw::PLL1_P));
 
             Some(pll * 2u32)
         }
@@ -581,9 +574,9 @@ pub(crate) unsafe fn init(config: Config) {
             use crate::pac::rcc::vals::Timsw;
 
             let pll = unwrap!(pll);
-            assert((pclk2 == pll) || (pclk2 * 2u32 == pll));
+            assert!((pclk2 == pll) || (pclk2 * 2u32 == pll));
 
-            RCC.cfgr3().modify(|w| w.set_tim20(Timsw::PLL1_P));
+            RCC.cfgr3().modify(|w| w.set_tim20sw(Timsw::PLL1_P));
 
             Some(pll * 2u32)
         }

--- a/embassy-stm32/src/rcc/f013.rs
+++ b/embassy-stm32/src/rcc/f013.rs
@@ -74,116 +74,6 @@ pub enum HrtimClockSource {
     PllClk,
 }
 
-#[cfg(all(stm32f3, not(rcc_f37)))]
-#[derive(Clone, Copy, PartialEq, Eq)]
-pub enum TimClockSource {
-    PClk2,
-    PllClk,
-}
-
-#[cfg(all(stm32f3, not(rcc_f37)))]
-#[derive(Clone, Copy)]
-pub struct TimClockSources {
-    pub tim1: TimClockSource,
-    #[cfg(any(
-        all(stm32f303, any(package_D, package_E)),
-        all(stm32f302, any(package_D, package_E)),
-        stm32f398
-    ))]
-    pub tim2: TimClockSource,
-    #[cfg(any(
-        all(stm32f303, any(package_D, package_E)),
-        all(stm32f302, any(package_D, package_E)),
-        stm32f398
-    ))]
-    pub tim34: TimClockSource,
-    #[cfg(any(
-        all(stm32f303, any(package_B, package_C, package_D, package_E)),
-        stm32f358,
-        stm32f398
-    ))]
-    pub tim8: TimClockSource,
-    #[cfg(any(
-        all(stm32f303, any(package_D, package_E)),
-        stm32f301,
-        stm32f318,
-        all(stm32f302, any(package_6, package_8)),
-        stm32f398
-    ))]
-    pub tim15: TimClockSource,
-    #[cfg(any(
-        all(stm32f303, any(package_D, package_E)),
-        stm32f301,
-        stm32f318,
-        all(stm32f302, any(package_6, package_8)),
-        stm32f398
-    ))]
-    pub tim16: TimClockSource,
-    #[cfg(any(
-        all(stm32f303, any(package_D, package_E)),
-        stm32f301,
-        stm32f318,
-        all(stm32f302, any(package_6, package_8)),
-        stm32f398
-    ))]
-    pub tim17: TimClockSource,
-    #[cfg(any(all(stm32f303, any(package_D, package_E))))]
-    pub tim20: TimClockSource,
-}
-
-#[cfg(all(stm32f3, not(rcc_f37)))]
-impl Default for TimClockSources {
-    fn default() -> Self {
-        Self {
-            tim1: TimClockSource::PClk2,
-            #[cfg(any(
-                all(stm32f303, any(package_D, package_E)),
-                all(stm32f302, any(package_D, package_E)),
-                stm32f398
-            ))]
-            tim2: TimClockSource::PClk2,
-            #[cfg(any(
-                all(stm32f303, any(package_D, package_E)),
-                all(stm32f302, any(package_D, package_E)),
-                stm32f398
-            ))]
-            tim34: TimClockSource::PClk2,
-            #[cfg(any(
-                all(stm32f303, any(package_B, package_C, package_D, package_E)),
-                stm32f358,
-                stm32f398
-            ))]
-            tim8: TimClockSource::PClk2,
-            #[cfg(any(
-                all(stm32f303, any(package_D, package_E)),
-                stm32f301,
-                stm32f318,
-                all(stm32f302, any(package_6, package_8)),
-                stm32f398
-            ))]
-            tim15: TimClockSource::PClk2,
-            #[cfg(any(
-                all(stm32f303, any(package_D, package_E)),
-                stm32f301,
-                stm32f318,
-                all(stm32f302, any(package_6, package_8)),
-                stm32f398
-            ))]
-            tim16: TimClockSource::PClk2,
-            #[cfg(any(
-                all(stm32f303, any(package_D, package_E)),
-                stm32f301,
-                stm32f318,
-                all(stm32f302, any(package_6, package_8)),
-                stm32f398
-            ))]
-            tim17: TimClockSource::PClk2,
-            #[cfg(any(all(stm32f303, any(package_D, package_E))))]
-            tim20: TimClockSource::PClk2,
-        }
-    }
-}
-
 /// Clocks configutation
 #[non_exhaustive]
 pub struct Config {
@@ -209,8 +99,8 @@ pub struct Config {
     pub adc34: AdcClockSource,
     #[cfg(stm32f334)]
     pub hrtim: HrtimClockSource,
-    #[cfg(all(stm32f3, not(rcc_f37)))]
-    pub tim: TimClockSources,
+    #[cfg(cfgr3)]
+    pub cfgr3: crate::_generated::CFGR3,
 
     pub ls: super::LsConfig,
 }
@@ -240,8 +130,8 @@ impl Default for Config {
             adc34: AdcClockSource::Hclk(AdcHclkPrescaler::Div1),
             #[cfg(stm32f334)]
             hrtim: HrtimClockSource::BusClk,
-            #[cfg(all(stm32f3, not(rcc_f37)))]
-            tim: Default::default(),
+            #[cfg(cfgr3)]
+            cfgr3: Default::default(),
         }
     }
 }
@@ -477,107 +367,8 @@ pub(crate) unsafe fn init(config: Config) {
         }
     };
 
-    #[cfg(all(stm32f3, not(rcc_f37)))]
-    match config.tim.tim1 {
-        TimClockSource::PClk2 => {}
-        TimClockSource::PllClk => {
-            RCC.cfgr3()
-                .modify(|w| w.set_tim1sw(crate::pac::rcc::vals::Timsw::PLL1_P));
-        }
-    };
-
-    #[cfg(any(
-        all(stm32f303, any(package_D, package_E)),
-        all(stm32f302, any(package_D, package_E)),
-        stm32f398
-    ))]
-    match config.tim.tim2 {
-        TimClockSource::PClk2 => {}
-        TimClockSource::PllClk => {
-            RCC.cfgr3()
-                .modify(|w| w.set_tim2sw(crate::pac::rcc::vals::Tim2sw::PLL1_P));
-        }
-    };
-
-    #[cfg(any(
-        all(stm32f303, any(package_D, package_E)),
-        all(stm32f302, any(package_D, package_E)),
-        stm32f398
-    ))]
-    match config.tim.tim34 {
-        TimClockSource::PClk2 => {}
-        TimClockSource::PllClk => {
-            RCC.cfgr3()
-                .modify(|w| w.set_tim34sw(crate::pac::rcc::vals::Timsw::PLL1_P));
-        }
-    };
-
-    #[cfg(any(
-        all(stm32f303, any(package_B, package_C, package_D, package_E)),
-        stm32f358,
-        stm32f398
-    ))]
-    match config.tim.tim8 {
-        TimClockSource::PClk2 => {}
-        TimClockSource::PllClk => {
-            RCC.cfgr3()
-                .modify(|w| w.set_tim8sw(crate::pac::rcc::vals::Timsw::PLL1_P));
-        }
-    };
-
-    #[cfg(any(
-        all(stm32f303, any(package_D, package_E)),
-        stm32f301,
-        stm32f318,
-        all(stm32f302, any(package_6, package_8)),
-        stm32f398
-    ))]
-    match config.tim.tim15 {
-        TimClockSource::PClk2 => {}
-        TimClockSource::PllClk => {
-            RCC.cfgr3()
-                .modify(|w| w.set_tim15sw(crate::pac::rcc::vals::Timsw::PLL1_P));
-        }
-    };
-
-    #[cfg(any(
-        all(stm32f303, any(package_D, package_E)),
-        stm32f301,
-        stm32f318,
-        all(stm32f302, any(package_6, package_8)),
-        stm32f398
-    ))]
-    match config.tim.tim16 {
-        TimClockSource::PClk2 => {}
-        TimClockSource::PllClk => {
-            RCC.cfgr3()
-                .modify(|w| w.set_tim16sw(crate::pac::rcc::vals::Timsw::PLL1_P));
-        }
-    };
-
-    #[cfg(any(
-        all(stm32f303, any(package_D, package_E)),
-        stm32f301,
-        stm32f318,
-        all(stm32f302, any(package_6, package_8)),
-        stm32f398
-    ))]
-    match config.tim.tim17 {
-        TimClockSource::PClk2 => {}
-        TimClockSource::PllClk => {
-            RCC.cfgr3()
-                .modify(|w| w.set_tim17sw(crate::pac::rcc::vals::Timsw::PLL1_P));
-        }
-    }
-
-    #[cfg(any(all(stm32f303, any(package_D, package_E))))]
-    match config.tim.tim20 {
-        TimClockSource::PClk2 => {}
-        TimClockSource::PllClk => {
-            RCC.cfgr3()
-                .modify(|w| w.set_tim20sw(crate::pac::rcc::vals::Timsw::PLL1_P));
-        }
-    }
+    #[cfg(cfgr3)]
+    config.cfgr3.init();
 
     set_clocks!(
         hsi: hsi,

--- a/embassy-stm32/src/rcc/f013.rs
+++ b/embassy-stm32/src/rcc/f013.rs
@@ -116,6 +116,7 @@ pub struct TimClockSources {
     pub tim20: TimClockSource,
 }
 
+#[cfg(all(stm32f3, not(rcc_f37)))]
 impl Default for TimClockSources {
     fn default() -> Self {
         Self {
@@ -178,7 +179,7 @@ pub struct Config {
     pub adc34: AdcClockSource,
     #[cfg(stm32f334)]
     pub hrtim: HrtimClockSource,
-    #[cfg(not(stm32f37))]
+    #[cfg(all(stm32f3, not(stm32f37)))]
     pub tim: TimClockSources,
 
     pub ls: super::LsConfig,
@@ -210,7 +211,7 @@ impl Default for Config {
             adc34: AdcClockSource::Hclk(AdcHclkPrescaler::Div1),
             #[cfg(stm32f334)]
             hrtim: HrtimClockSource::BusClk,
-            #[cfg(not(stm32f37))]
+            #[cfg(all(stm32f3, not(stm32f37)))]
             tim: Default::default(),
         }
     }

--- a/embassy-stm32/src/rcc/mod.rs
+++ b/embassy-stm32/src/rcc/mod.rs
@@ -32,7 +32,7 @@ mod _version;
 pub use _version::*;
 
 #[cfg(clock_mux)]
-pub use crate::_generated::mux as mux;
+pub use crate::_generated::mux;
 pub use crate::_generated::Clocks;
 
 #[cfg(feature = "low-power")]

--- a/embassy-stm32/src/rcc/mod.rs
+++ b/embassy-stm32/src/rcc/mod.rs
@@ -31,9 +31,9 @@ mod _version;
 
 pub use _version::*;
 
-pub use crate::_generated::Clocks;
 #[cfg(clock_mux)]
 pub use crate::_generated::ClockMux;
+pub use crate::_generated::Clocks;
 
 #[cfg(feature = "low-power")]
 /// Must be written within a critical section

--- a/embassy-stm32/src/rcc/mod.rs
+++ b/embassy-stm32/src/rcc/mod.rs
@@ -32,6 +32,8 @@ mod _version;
 pub use _version::*;
 
 pub use crate::_generated::Clocks;
+#[cfg(clock_mux)]
+pub use crate::_generated::ClockMux;
 
 #[cfg(feature = "low-power")]
 /// Must be written within a critical section

--- a/embassy-stm32/src/rcc/mod.rs
+++ b/embassy-stm32/src/rcc/mod.rs
@@ -32,7 +32,7 @@ mod _version;
 pub use _version::*;
 
 #[cfg(clock_mux)]
-pub use crate::_generated::ClockMux;
+pub use crate::_generated::mux as mux;
 pub use crate::_generated::Clocks;
 
 #[cfg(feature = "low-power")]

--- a/examples/stm32f3/src/bin/usart_dma.rs
+++ b/examples/stm32f3/src/bin/usart_dma.rs
@@ -17,9 +17,7 @@ bind_interrupts!(struct Irqs {
 
 #[embassy_executor::main]
 async fn main(_spawner: Spawner) {
-    let mut init_config = embassy_stm32::Config::default();
-    init_config.rcc.cfgr3.usart1sw = Some(embassy_stm32::pac::rcc::vals::Usart1sw::HSI);
-    let p = embassy_stm32::init(init_config);
+    let p = embassy_stm32::init(Default::default());
     info!("Hello World!");
 
     let config = Config::default();

--- a/examples/stm32f3/src/bin/usart_dma.rs
+++ b/examples/stm32f3/src/bin/usart_dma.rs
@@ -17,7 +17,9 @@ bind_interrupts!(struct Irqs {
 
 #[embassy_executor::main]
 async fn main(_spawner: Spawner) {
-    let p = embassy_stm32::init(Default::default());
+    let mut init_config = embassy_stm32::Config::default();
+    init_config.rcc.cfgr3.usart1sw = Some(embassy_stm32::pac::rcc::vals::Usart1sw::HSI);
+    let p = embassy_stm32::init(init_config);
     info!("Hello World!");
 
     let config = Config::default();

--- a/examples/stm32f334/src/bin/pwm.rs
+++ b/examples/stm32f334/src/bin/pwm.rs
@@ -27,8 +27,10 @@ async fn main(_spawner: Spawner) {
         config.rcc.ahb_pre = AHBPrescaler::DIV1;
         config.rcc.apb1_pre = APBPrescaler::DIV2;
         config.rcc.apb2_pre = APBPrescaler::DIV1;
+
+        // TODO: The two lines here do the same thing
         config.rcc.hrtim = HrtimClockSource::PllClk;
-        config.rcc.mux.hrtim1sw = Some(embassy_stm32::pac::rcc::vals::Timsw::PLL1_P); // TODO: The two lines here do the same thing
+        config.rcc.mux.hrtim1sw = Some(embassy_stm32::pac::rcc::vals::Timsw::PLL1_P);
     }
     let p = embassy_stm32::init(config);
 

--- a/examples/stm32f334/src/bin/pwm.rs
+++ b/examples/stm32f334/src/bin/pwm.rs
@@ -28,6 +28,7 @@ async fn main(_spawner: Spawner) {
         config.rcc.apb1_pre = APBPrescaler::DIV2;
         config.rcc.apb2_pre = APBPrescaler::DIV1;
         config.rcc.hrtim = HrtimClockSource::PllClk;
+        config.rcc.mux.hrtim1sw = Some(embassy_stm32::pac::rcc::vals::Timsw::PLL1_P); // TODO: The two lines here do the same thing
     }
     let p = embassy_stm32::init(config);
 

--- a/examples/stm32f334/src/bin/pwm.rs
+++ b/examples/stm32f334/src/bin/pwm.rs
@@ -28,9 +28,7 @@ async fn main(_spawner: Spawner) {
         config.rcc.apb1_pre = APBPrescaler::DIV2;
         config.rcc.apb2_pre = APBPrescaler::DIV1;
 
-        // TODO: The two lines here do the same thing
-        config.rcc.hrtim = HrtimClockSource::PllClk;
-        config.rcc.mux.hrtim1sw = Some(embassy_stm32::pac::rcc::vals::Timsw::PLL1_P);
+        config.rcc.mux.hrtim1sw = Some(embassy_stm32::rcc::mux::Timsw::PLL1_P);
     }
     let p = embassy_stm32::init(config);
 


### PR DESCRIPTION
Things still to do:
- [x] Make sure that with the new metapac the frequencies are set correctly and also read with this change.
- [ ] Test on an STM32F303RE for real functionality.

Opening the PR now to get basic feedback.

Documents Referenced:
- [RM0313](https://www.st.com/resource/en/reference_manual/rm0313-stm32f37xxx-advanced-armbased-32bit-mcus-stmicroelectronics.pdf) STM32F37xx Chips - No TIMSW available
- [RM0316](https://www.st.com/resource/en/reference_manual/rm0316-stm32f303xbcde-stm32f303x68-stm32f328x8-stm32f358xc-stm32f398xe-advanced-armbased-mcus-stmicroelectronics.pdf) STM32F303xx/STM32F3x8xx Chips - Section 9.2.10
- [RM0364](https://www.st.com/resource/en/reference_manual/rm0364-stm32f334xx-advanced-armbased-32bit-mcus-stmicroelectronics.pdf) STM32F334xx Chips - Section 8.2.10
- [RM0365](https://www.st.com/resource/en/reference_manual/rm0365-stm32f302xbcde-and-stm32f302x68-advanced-armbased-32bit-mcus-stmicroelectronics.pdf) STM32F302xx Chips - Section 9.2.10
- [RM0366](https://www.st.com/resource/en/reference_manual/rm0366-stm32f301x68-and-stm32f318x8-advanced-armbased-32bit-mcus-stmicroelectronics.pdf) STM32F301xx/STM32F318xx Chips - Section 7.2.10