### PR TITLE
embassy-nrf: Fix PDM gain register value derivation

### DIFF
--- a/embassy-nrf/src/pdm.rs
+++ b/embassy-nrf/src/pdm.rs
@@ -4,7 +4,6 @@
 
 use core::future::poll_fn;
 use core::marker::PhantomData;
-use core::mem;
 use core::sync::atomic::{compiler_fence, Ordering};
 use core::task::Poll;
 
@@ -150,7 +149,7 @@ impl<'d, T: Instance> Pdm<'d, T> {
             let gain = gain.saturating_add(I7F1::from_bits(0x28))
                 .to_bits()
                 .clamp(0, 0x50);
-            unsafe { mem::transmute(gain) }
+            unsafe { core::mem::transmute(gain) }
         };
         let gain_left = gain_to_bits(gain_left);
         let gain_right = gain_to_bits(gain_right);

--- a/embassy-nrf/src/pdm.rs
+++ b/embassy-nrf/src/pdm.rs
@@ -4,6 +4,7 @@
 
 use core::future::poll_fn;
 use core::marker::PhantomData;
+use core::mem;
 use core::sync::atomic::{compiler_fence, Ordering};
 use core::task::Poll;
 
@@ -145,15 +146,14 @@ impl<'d, T: Instance> Pdm<'d, T> {
     }
 
     fn _set_gain(r: &crate::pac::pdm::RegisterBlock, gain_left: I7F1, gain_right: I7F1) {
-        let gain_left = gain_left
-            .saturating_add(I7F1::from_bits(40))
-            .saturating_to_num::<u8>()
-            .clamp(0, 0x50);
-        let gain_right = gain_right
-            .saturating_add(I7F1::from_bits(40))
-            .saturating_to_num::<u8>()
-            .clamp(0, 0x50);
-
+        let gain_to_bits = |gain: I7F1| -> u8 {
+            let gain = gain.saturating_add(I7F1::from_bits(0x28))
+                .to_bits()
+                .clamp(0, 0x50);
+            unsafe { mem::transmute(gain) }
+        };
+        let gain_left = gain_to_bits(gain_left);
+        let gain_right = gain_to_bits(gain_right);
         r.gainl.write(|w| unsafe { w.gainl().bits(gain_left) });
         r.gainr.write(|w| unsafe { w.gainr().bits(gain_right) });
     }

--- a/embassy-nrf/src/pdm.rs
+++ b/embassy-nrf/src/pdm.rs
@@ -146,9 +146,7 @@ impl<'d, T: Instance> Pdm<'d, T> {
 
     fn _set_gain(r: &crate::pac::pdm::RegisterBlock, gain_left: I7F1, gain_right: I7F1) {
         let gain_to_bits = |gain: I7F1| -> u8 {
-            let gain = gain.saturating_add(I7F1::from_bits(0x28))
-                .to_bits()
-                .clamp(0, 0x50);
+            let gain = gain.saturating_add(I7F1::from_bits(0x28)).to_bits().clamp(0, 0x50);
             unsafe { core::mem::transmute(gain) }
         };
         let gain_left = gain_to_bits(gain_left);


### PR DESCRIPTION
The PDM peripheral gain was not being correctly converted from a fixed-point type to the bits type.  The table below shows the behaviour before and after the patch, and [here](https://infocenter.nordicsemi.com/topic/com.nordic.infocenter.nrf52832.ps.v1.1/pdm.html?cp=5_2_0_42_6_6#register.GAINL) is the register documentation from the microcontroller's manual.

 Gain | Before | After
------|--------|------
-20dB |   0x00 |  0x00
-19dB |   0x01 |  0x02
-18dB |   0x02 |  0x04
-17dB |   0x03 |  0x06
-16dB |   0x04 |  0x08
-15dB |   0x05 |  0x0a
-14dB |   0x06 |  0x0c
-13dB |   0x07 |  0x0e
-12dB |   0x08 |  0x10
-11dB |   0x09 |  0x12
-10dB |   0x0a |  0x14
 -9dB |   0x0b |  0x16
 -8dB |   0x0c |  0x18
 -7dB |   0x0d |  0x1a
 -6dB |   0x0e |  0x1c
 -5dB |   0x0f |  0x1e
 -4dB |   0x10 |  0x20
 -3dB |   0x11 |  0x22
 -2dB |   0x12 |  0x24
 -1dB |   0x13 |  0x26
  0dB |   0x14 |  0x28
  1dB |   0x15 |  0x2a
  2dB |   0x16 |  0x2c
  3dB |   0x17 |  0x2e
  4dB |   0x18 |  0x30
  5dB |   0x19 |  0x32
  6dB |   0x1a |  0x34
  7dB |   0x1b |  0x36
  8dB |   0x1c |  0x38
  9dB |   0x1d |  0x3a
 10dB |   0x1e |  0x3c
 11dB |   0x1f |  0x3e
 12dB |   0x20 |  0x40
 13dB |   0x21 |  0x42
 14dB |   0x22 |  0x44
 15dB |   0x23 |  0x46
 16dB |   0x24 |  0x48
 17dB |   0x25 |  0x4a
 18dB |   0x26 |  0x4c
 19dB |   0x27 |  0x4e
 20dB |   0x28 |  0x50