### PR TITLE
rp: Fix wrong io _bank calc

### DIFF
--- a/embassy-rp/src/gpio.rs
+++ b/embassy-rp/src/gpio.rs
@@ -815,7 +815,7 @@ pub(crate) mod sealed {
 
         #[inline]
         fn _bank(&self) -> Bank {
-            match self.pin_bank() & 0x20 {
+            match self.pin_bank() >> 5 {
                 #[cfg(feature = "qspi-as-gpio")]
                 1 => Bank::Qspi,
                 _ => Bank::Bank0,


### PR DESCRIPTION
I just happened to read this.
I think it's a typo in #1728.


Original change:

https://github.com/embassy-rs/embassy/pull/1728/files#diff-f1f6b8e9c6e1d28058169a0a521287b2f9875e96e2cd7a9a5f7216f0139e5534L639-L645