### PR TITLE
time: cloneable delay

### DIFF
--- a/embassy-time/src/delay.rs
+++ b/embassy-time/src/delay.rs
@@ -13,6 +13,7 @@ pub fn block_for(duration: Duration) {
 /// the amount provided, but accuracy can be affected by many factors, including interrupt usage.
 /// Make sure to use a suitable tick rate for your use case. The tick rate is defined by the currently
 /// active driver.
+#[derive(Clone)]
 pub struct Delay;
 
 impl embedded_hal_1::delay::DelayNs for Delay {


### PR DESCRIPTION
Seems like there isn't a reason not to do this :). It's already possible with a new type, see [this](https://github.com/MabezDev/embedded-fatfs/pull/20/files#diff-7213147062427ea584e8ccf1d7774b5567474d65bc02a9547fb4f444b6503014R99-R120).