### PR TITLE
feat(nrf/spim): allow specifying drive of SPI pins

### DIFF
--- a/embassy-nrf/src/gpio.rs
+++ b/embassy-nrf/src/gpio.rs
@@ -189,7 +189,7 @@ impl<'d> Output<'d> {
     }
 }
 
-fn convert_drive(drive: OutputDrive) -> DRIVE_A {
+pub(crate) fn convert_drive(drive: OutputDrive) -> DRIVE_A {
     match drive {
         OutputDrive::Standard => DRIVE_A::S0S1,
         OutputDrive::HighDrive0Standard1 => DRIVE_A::H0S1,

--- a/embassy-nrf/src/spim.rs
+++ b/embassy-nrf/src/spim.rs
@@ -50,6 +50,15 @@ pub struct Config {
     /// When doing bidirectional transfers, if the TX buffer is shorter than the RX buffer,
     /// this byte will be transmitted in the MOSI line for the left-over bytes.
     pub orc: u8,
+
+    /// Enable high drive for the SCK line.
+    pub sck_high_drive: bool,
+
+    /// Enable high drive for the MOSI line.
+    pub mosi_high_drive: bool,
+
+    /// Enable high drive for the MISO line.
+    pub miso_high_drive: bool,
 }
 
 impl Default for Config {
@@ -59,6 +68,9 @@ impl Default for Config {
             mode: MODE_0,
             bit_order: BitOrder::MSB_FIRST,
             orc: 0x00,
+            sck_high_drive: false,
+            mosi_high_drive: false,
+            miso_high_drive: false,
         }
     }
 }
@@ -159,13 +171,37 @@ impl<'d, T: Instance> Spim<'d, T> {
 
         // Configure pins
         if let Some(sck) = &sck {
-            sck.conf().write(|w| w.dir().output().drive().h0h1());
+            sck.conf().write(|w| {
+                w.dir().output();
+                if config.sck_high_drive {
+                    w.drive().h0h1();
+                } else {
+                    w.drive().s0s1();
+                }
+                w
+            });
         }
         if let Some(mosi) = &mosi {
-            mosi.conf().write(|w| w.dir().output().drive().h0h1());
+            mosi.conf().write(|w| {
+                w.dir().output();
+                if config.mosi_high_drive {
+                    w.drive().h0h1();
+                } else {
+                    w.drive().s0s1();
+                }
+                w
+            });
         }
         if let Some(miso) = &miso {
-            miso.conf().write(|w| w.input().connect().drive().h0h1());
+            miso.conf().write(|w| {
+                w.input().connect();
+                if config.miso_high_drive {
+                    w.drive().h0h1();
+                } else {
+                    w.drive().s0s1();
+                }
+                w
+            });
         }
 
         match config.mode.polarity {

--- a/embassy-nrf/src/spim.rs
+++ b/embassy-nrf/src/spim.rs
@@ -15,7 +15,7 @@ pub use pac::spim0::frequency::FREQUENCY_A as Frequency;
 
 use crate::chip::{EASY_DMA_SIZE, FORCE_COPY_BUFFER_SIZE};
 use crate::gpio::sealed::Pin as _;
-use crate::gpio::{self, AnyPin, Pin as GpioPin, PselBits};
+use crate::gpio::{self, convert_drive, AnyPin, OutputDrive, Pin as GpioPin, PselBits};
 use crate::interrupt::typelevel::Interrupt;
 use crate::util::{slice_in_ram_or, slice_ptr_parts, slice_ptr_parts_mut};
 use crate::{interrupt, pac, Peripheral};
@@ -51,14 +51,14 @@ pub struct Config {
     /// this byte will be transmitted in the MOSI line for the left-over bytes.
     pub orc: u8,
 
-    /// Enable high drive for the SCK line.
-    pub sck_high_drive: bool,
+    /// Drive strength for the SCK line.
+    pub sck_drive: OutputDrive,
 
-    /// Enable high drive for the MOSI line.
-    pub mosi_high_drive: bool,
+    /// Drive strength for the MOSI line.
+    pub mosi_drive: OutputDrive,
 
-    /// Enable high drive for the MISO line.
-    pub miso_high_drive: bool,
+    /// Drive strength for the MISO line.
+    pub miso_drive: OutputDrive,
 }
 
 impl Default for Config {
@@ -68,9 +68,9 @@ impl Default for Config {
             mode: MODE_0,
             bit_order: BitOrder::MSB_FIRST,
             orc: 0x00,
-            sck_high_drive: false,
-            mosi_high_drive: false,
-            miso_high_drive: false,
+            sck_drive: OutputDrive::HighDrive,
+            mosi_drive: OutputDrive::HighDrive,
+            miso_drive: OutputDrive::HighDrive,
         }
     }
 }
@@ -171,37 +171,16 @@ impl<'d, T: Instance> Spim<'d, T> {
 
         // Configure pins
         if let Some(sck) = &sck {
-            sck.conf().write(|w| {
-                w.dir().output();
-                if config.sck_high_drive {
-                    w.drive().h0h1();
-                } else {
-                    w.drive().s0s1();
-                }
-                w
-            });
+            sck.conf()
+                .write(|w| w.dir().output().drive().variant(convert_drive(config.sck_drive)));
         }
         if let Some(mosi) = &mosi {
-            mosi.conf().write(|w| {
-                w.dir().output();
-                if config.mosi_high_drive {
-                    w.drive().h0h1();
-                } else {
-                    w.drive().s0s1();
-                }
-                w
-            });
+            mosi.conf()
+                .write(|w| w.dir().output().drive().variant(convert_drive(config.mosi_drive)));
         }
         if let Some(miso) = &miso {
-            miso.conf().write(|w| {
-                w.input().connect();
-                if config.miso_high_drive {
-                    w.drive().h0h1();
-                } else {
-                    w.drive().s0s1();
-                }
-                w
-            });
+            miso.conf()
+                .write(|w| w.input().connect().drive().variant(convert_drive(config.miso_drive)));
         }
 
         match config.mode.polarity {


### PR DESCRIPTION
Makes nrf SPIM pin drives configurable, similar to the TWIM peripheral.
Apparently, high drive messes up interfacing with 3-wire SPI.