### PR TITLE
USB needs PWR_CR2 USV set on STM32L4

### DIFF
--- a/embassy-stm32/src/usb/usb.rs
+++ b/embassy-stm32/src/usb/usb.rs
@@ -264,7 +264,7 @@ impl<'d, T: Instance> Driver<'d, T> {
 
         let regs = T::regs();
 
-        #[cfg(any(stm32l5, stm32wb))]
+        #[cfg(any(stm32l4, stm32l5, stm32wb))]
         crate::pac::PWR.cr2().modify(|w| w.set_usv(true));
 
         #[cfg(pwr_h5)]


### PR DESCRIPTION
Confirmed to be needed on an STM32L422, and based on a quick look at L4/L4+ reference manuals, this bit is present and required to be set on all L4 chips that have some kind of USB peripheral (USB or OTG_FS). The `usb_otg` driver already sets it for `cfg(stm32l4)` and we should do the same thing here.