### PR TITLE
Add block-device-driver impl for use with embedded-fatfs

### DIFF
--- a/embassy-stm32/Cargo.toml
+++ b/embassy-stm32/Cargo.toml
@@ -88,6 +88,8 @@ static_assertions = { version = "1.1" }
 volatile-register = { version = "0.2.1" }
 bitflags = "2.4.2"
 
+block-device-driver = { version = "0.2" }
+aligned = "0.4.1"
 
 [dev-dependencies]
 critical-section = { version = "1.1", features = ["std"] }


### PR DESCRIPTION
I'm slowly working towards the first embedded-fatfs release! The biggest changes have been that the device trait and helpers are now outside of embedded-fatfs itself. This means I can 

* PR impls before releasing embedded-fatfs
* make breaking changes in embedded-fatfs _without_ making HAL implementors update
* the block device is now more useful outside of embedded-fatfs, for instance someone could use these building blocks to implement another filesystem, or even there own.

This PR is mostly inert, but if you'd like to try it out you can use [the esp32c6 example I have](https://github.com/MabezDev/embedded-fatfs/tree/master/examples/esp32c6) in embedded-fatfs proper, which you can use a reference to craft an stm example. I have tested with my project and once embedded-fatfs has a release I plan on adding a stm32f2 example either here or in embedded-fatfs.