### PR TITLE
nrf/uart: add support for tx-only and rx-only buffered uart.

### DIFF
--- a/embassy-hal-internal/src/atomic_ring_buffer.rs
+++ b/embassy-hal-internal/src/atomic_ring_buffer.rs
@@ -1,6 +1,6 @@
 //! Atomic reusable ringbuffer.
-use core::slice;
 use core::sync::atomic::{AtomicPtr, AtomicUsize, Ordering};
+use core::{ptr, slice};
 
 /// Atomic reusable ringbuffer
 ///
@@ -73,6 +73,7 @@ impl RingBuffer {
     pub unsafe fn deinit(&self) {
         // Ordering: it's OK to use `Relaxed` because this is not called
         // concurrently with other methods.
+        self.buf.store(ptr::null_mut(), Ordering::Relaxed);
         self.len.store(0, Ordering::Relaxed);
         self.start.store(0, Ordering::Relaxed);
         self.end.store(0, Ordering::Relaxed);
@@ -82,18 +83,44 @@ impl RingBuffer {
     ///
     /// # Safety
     ///
-    /// Only one reader can exist at a time.
+    /// - Only one reader can exist at a time.
+    /// - Ringbuffer must be initialized.
     pub unsafe fn reader(&self) -> Reader<'_> {
         Reader(self)
+    }
+
+    /// Try creating a reader, fails if not initialized.
+    ///
+    /// # Safety
+    ///
+    /// Only one reader can exist at a time.
+    pub unsafe fn try_reader(&self) -> Option<Reader<'_>> {
+        if self.buf.load(Ordering::Relaxed).is_null() {
+            return None;
+        }
+        Some(Reader(self))
     }
 
     /// Create a writer.
     ///
     /// # Safety
     ///
-    /// Only one writer can exist at a time.
+    /// - Only one writer can exist at a time.
+    /// - Ringbuffer must be initialized.
     pub unsafe fn writer(&self) -> Writer<'_> {
         Writer(self)
+    }
+
+    /// Try creating a writer, fails if not initialized.
+    ///
+    /// # Safety
+    ///
+    /// Only one writer can exist at a time.
+    pub unsafe fn try_writer(&self) -> Option<Writer<'_>> {
+        if self.buf.load(Ordering::Relaxed).is_null() {
+            return None;
+        }
+        Some(Writer(self))
     }
 
     /// Return length of buffer.

--- a/embassy-nrf/src/buffered_uarte.rs
+++ b/embassy-nrf/src/buffered_uarte.rs
@@ -426,7 +426,7 @@ impl<'d, U: UarteInstance, T: TimerInstance> BufferedUarte<'d, U, T> {
     /// Split the UART in reader and writer parts.
     ///
     /// This allows reading and writing concurrently from independent tasks.
-    pub fn split<'u>(&'u mut self) -> (BufferedUarteRx<'u, 'd, U, T>, BufferedUarteTx<'u, 'd, U, T>) {
+    pub fn split(&mut self) -> (BufferedUarteRx<'_, U, T>, BufferedUarteTx<'_, U, T>) {
         (BufferedUarteRx { inner: self }, BufferedUarteTx { inner: self })
     }
 
@@ -570,11 +570,11 @@ impl<'d, U: UarteInstance, T: TimerInstance> BufferedUarte<'d, U, T> {
 }
 
 /// Reader part of the buffered UARTE driver.
-pub struct BufferedUarteTx<'u, 'd, U: UarteInstance, T: TimerInstance> {
-    inner: &'u BufferedUarte<'d, U, T>,
+pub struct BufferedUarteTx<'d, U: UarteInstance, T: TimerInstance> {
+    inner: &'d BufferedUarte<'d, U, T>,
 }
 
-impl<'u, 'd, U: UarteInstance, T: TimerInstance> BufferedUarteTx<'u, 'd, U, T> {
+impl<'d, U: UarteInstance, T: TimerInstance> BufferedUarteTx<'d, U, T> {
     /// Write a buffer into this writer, returning how many bytes were written.
     pub async fn write(&mut self, buf: &[u8]) -> Result<usize, Error> {
         self.inner.inner_write(buf).await
@@ -587,11 +587,11 @@ impl<'u, 'd, U: UarteInstance, T: TimerInstance> BufferedUarteTx<'u, 'd, U, T> {
 }
 
 /// Writer part of the buffered UARTE driver.
-pub struct BufferedUarteRx<'u, 'd, U: UarteInstance, T: TimerInstance> {
-    inner: &'u BufferedUarte<'d, U, T>,
+pub struct BufferedUarteRx<'d, U: UarteInstance, T: TimerInstance> {
+    inner: &'d BufferedUarte<'d, U, T>,
 }
 
-impl<'u, 'd, U: UarteInstance, T: TimerInstance> BufferedUarteRx<'u, 'd, U, T> {
+impl<'d, U: UarteInstance, T: TimerInstance> BufferedUarteRx<'d, U, T> {
     /// Pull some bytes from this source into the specified buffer, returning how many bytes were read.
     pub async fn read(&mut self, buf: &mut [u8]) -> Result<usize, Error> {
         self.inner.inner_read(buf).await
@@ -621,11 +621,11 @@ mod _embedded_io {
         type Error = Error;
     }
 
-    impl<'u, 'd, U: UarteInstance, T: TimerInstance> embedded_io_async::ErrorType for BufferedUarteRx<'u, 'd, U, T> {
+    impl<'d, U: UarteInstance, T: TimerInstance> embedded_io_async::ErrorType for BufferedUarteRx<'d, U, T> {
         type Error = Error;
     }
 
-    impl<'u, 'd, U: UarteInstance, T: TimerInstance> embedded_io_async::ErrorType for BufferedUarteTx<'u, 'd, U, T> {
+    impl<'d, U: UarteInstance, T: TimerInstance> embedded_io_async::ErrorType for BufferedUarteTx<'d, U, T> {
         type Error = Error;
     }
 
@@ -635,7 +635,7 @@ mod _embedded_io {
         }
     }
 
-    impl<'u, 'd: 'u, U: UarteInstance, T: TimerInstance> embedded_io_async::Read for BufferedUarteRx<'u, 'd, U, T> {
+    impl<'d: 'd, U: UarteInstance, T: TimerInstance> embedded_io_async::Read for BufferedUarteRx<'d, U, T> {
         async fn read(&mut self, buf: &mut [u8]) -> Result<usize, Self::Error> {
             self.inner.inner_read(buf).await
         }
@@ -651,7 +651,7 @@ mod _embedded_io {
         }
     }
 
-    impl<'u, 'd: 'u, U: UarteInstance, T: TimerInstance> embedded_io_async::BufRead for BufferedUarteRx<'u, 'd, U, T> {
+    impl<'d: 'd, U: UarteInstance, T: TimerInstance> embedded_io_async::BufRead for BufferedUarteRx<'d, U, T> {
         async fn fill_buf(&mut self) -> Result<&[u8], Self::Error> {
             self.inner.inner_fill_buf().await
         }
@@ -671,7 +671,7 @@ mod _embedded_io {
         }
     }
 
-    impl<'u, 'd: 'u, U: UarteInstance, T: TimerInstance> embedded_io_async::Write for BufferedUarteTx<'u, 'd, U, T> {
+    impl<'d: 'd, U: UarteInstance, T: TimerInstance> embedded_io_async::Write for BufferedUarteTx<'d, U, T> {
         async fn write(&mut self, buf: &[u8]) -> Result<usize, Self::Error> {
             self.inner.inner_write(buf).await
         }

--- a/embassy-nrf/src/uarte.rs
+++ b/embassy-nrf/src/uarte.rs
@@ -242,6 +242,14 @@ impl<'d, T: Instance> Uarte<'d, T> {
         (self.tx, self.rx)
     }
 
+    /// Split the UART in reader and writer parts, by reference.
+    ///
+    /// The returned halves borrow from `self`, so you can drop them and go back to using
+    /// the "un-split" `self`. This allows temporarily splitting the UART.
+    pub fn split_by_ref(&mut self) -> (&mut UarteTx<'d, T>, &mut UarteRx<'d, T>) {
+        (&mut self.tx, &mut self.rx)
+    }
+
     /// Split the Uarte into the transmitter and receiver with idle support parts.
     ///
     /// This is useful to concurrently transmit and receive from independent tasks.

--- a/embassy-nrf/src/uarte.rs
+++ b/embassy-nrf/src/uarte.rs
@@ -299,7 +299,7 @@ impl<'d, T: Instance> Uarte<'d, T> {
     }
 }
 
-fn configure(r: &RegisterBlock, config: Config, hardware_flow_control: bool) {
+pub(crate) fn configure(r: &RegisterBlock, config: Config, hardware_flow_control: bool) {
     r.config.write(|w| {
         w.hwfc().bit(hardware_flow_control);
         w.parity().variant(config.parity);

--- a/embassy-nrf/src/uarte.rs
+++ b/embassy-nrf/src/uarte.rs
@@ -159,7 +159,7 @@ impl<'d, T: Instance> Uarte<'d, T> {
         txd: impl Peripheral<P = impl GpioPin> + 'd,
         config: Config,
     ) -> Self {
-        into_ref!(rxd, txd);
+        into_ref!(uarte, rxd, txd);
         Self::new_inner(uarte, rxd.map_into(), txd.map_into(), None, None, config)
     }
 
@@ -173,7 +173,7 @@ impl<'d, T: Instance> Uarte<'d, T> {
         rts: impl Peripheral<P = impl GpioPin> + 'd,
         config: Config,
     ) -> Self {
-        into_ref!(rxd, txd, cts, rts);
+        into_ref!(uarte, rxd, txd, cts, rts);
         Self::new_inner(
             uarte,
             rxd.map_into(),
@@ -185,16 +185,21 @@ impl<'d, T: Instance> Uarte<'d, T> {
     }
 
     fn new_inner(
-        uarte: impl Peripheral<P = T> + 'd,
+        uarte: PeripheralRef<'d, T>,
         rxd: PeripheralRef<'d, AnyPin>,
         txd: PeripheralRef<'d, AnyPin>,
         cts: Option<PeripheralRef<'d, AnyPin>>,
         rts: Option<PeripheralRef<'d, AnyPin>>,
         config: Config,
     ) -> Self {
-        into_ref!(uarte);
-
         let r = T::regs();
+
+        let hardware_flow_control = match (rts.is_some(), cts.is_some()) {
+            (false, false) => false,
+            (true, true) => true,
+            _ => panic!("RTS and CTS pins must be either both set or none set."),
+        };
+        configure(r, config, hardware_flow_control);
 
         rxd.conf().write(|w| w.input().connect().drive().h0h1());
         r.psel.rxd.write(|w| unsafe { w.bits(rxd.psel_bits()) });
@@ -216,13 +221,6 @@ impl<'d, T: Instance> Uarte<'d, T> {
 
         T::Interrupt::unpend();
         unsafe { T::Interrupt::enable() };
-
-        let hardware_flow_control = match (rts.is_some(), cts.is_some()) {
-            (false, false) => false,
-            (true, true) => true,
-            _ => panic!("RTS and CTS pins must be either both set or none set."),
-        };
-        configure(r, config, hardware_flow_control);
 
         let s = T::state();
         s.tx_rx_refcount.store(2, Ordering::Relaxed);
@@ -315,6 +313,12 @@ pub(crate) fn configure(r: &RegisterBlock, config: Config, hardware_flow_control
     r.events_rxstarted.reset();
     r.events_txstarted.reset();
 
+    // reset all pins
+    r.psel.txd.write(|w| w.connect().disconnected());
+    r.psel.rxd.write(|w| w.connect().disconnected());
+    r.psel.cts.write(|w| w.connect().disconnected());
+    r.psel.rts.write(|w| w.connect().disconnected());
+
     // Enable
     apply_workaround_for_enable_anomaly(r);
     r.enable.write(|w| w.enable().enabled());
@@ -328,7 +332,7 @@ impl<'d, T: Instance> UarteTx<'d, T> {
         txd: impl Peripheral<P = impl GpioPin> + 'd,
         config: Config,
     ) -> Self {
-        into_ref!(txd);
+        into_ref!(uarte, txd);
         Self::new_inner(uarte, txd.map_into(), None, config)
     }
 
@@ -340,19 +344,19 @@ impl<'d, T: Instance> UarteTx<'d, T> {
         cts: impl Peripheral<P = impl GpioPin> + 'd,
         config: Config,
     ) -> Self {
-        into_ref!(txd, cts);
+        into_ref!(uarte, txd, cts);
         Self::new_inner(uarte, txd.map_into(), Some(cts.map_into()), config)
     }
 
     fn new_inner(
-        uarte: impl Peripheral<P = T> + 'd,
+        uarte: PeripheralRef<'d, T>,
         txd: PeripheralRef<'d, AnyPin>,
         cts: Option<PeripheralRef<'d, AnyPin>>,
         config: Config,
     ) -> Self {
-        into_ref!(uarte);
-
         let r = T::regs();
+
+        configure(r, config, cts.is_some());
 
         txd.set_high();
         txd.conf().write(|w| w.dir().output().drive().s0s1());
@@ -362,12 +366,6 @@ impl<'d, T: Instance> UarteTx<'d, T> {
             pin.conf().write(|w| w.input().connect().drive().h0h1());
         }
         r.psel.cts.write(|w| unsafe { w.bits(cts.psel_bits()) });
-
-        r.psel.rxd.write(|w| w.connect().disconnected());
-        r.psel.rts.write(|w| w.connect().disconnected());
-
-        let hardware_flow_control = cts.is_some();
-        configure(r, config, hardware_flow_control);
 
         T::Interrupt::unpend();
         unsafe { T::Interrupt::enable() };
@@ -524,7 +522,7 @@ impl<'d, T: Instance> UarteRx<'d, T> {
         rxd: impl Peripheral<P = impl GpioPin> + 'd,
         config: Config,
     ) -> Self {
-        into_ref!(rxd);
+        into_ref!(uarte, rxd);
         Self::new_inner(uarte, rxd.map_into(), None, config)
     }
 
@@ -536,7 +534,7 @@ impl<'d, T: Instance> UarteRx<'d, T> {
         rts: impl Peripheral<P = impl GpioPin> + 'd,
         config: Config,
     ) -> Self {
-        into_ref!(rxd, rts);
+        into_ref!(uarte, rxd, rts);
         Self::new_inner(uarte, rxd.map_into(), Some(rts.map_into()), config)
     }
 
@@ -549,14 +547,14 @@ impl<'d, T: Instance> UarteRx<'d, T> {
     }
 
     fn new_inner(
-        uarte: impl Peripheral<P = T> + 'd,
+        uarte: PeripheralRef<'d, T>,
         rxd: PeripheralRef<'d, AnyPin>,
         rts: Option<PeripheralRef<'d, AnyPin>>,
         config: Config,
     ) -> Self {
-        into_ref!(uarte);
-
         let r = T::regs();
+
+        configure(r, config, rts.is_some());
 
         rxd.conf().write(|w| w.input().connect().drive().h0h1());
         r.psel.rxd.write(|w| unsafe { w.bits(rxd.psel_bits()) });
@@ -567,14 +565,8 @@ impl<'d, T: Instance> UarteRx<'d, T> {
         }
         r.psel.rts.write(|w| unsafe { w.bits(rts.psel_bits()) });
 
-        r.psel.txd.write(|w| w.connect().disconnected());
-        r.psel.cts.write(|w| w.connect().disconnected());
-
         T::Interrupt::unpend();
         unsafe { T::Interrupt::enable() };
-
-        let hardware_flow_control = rts.is_some();
-        configure(r, config, hardware_flow_control);
 
         let s = T::state();
         s.tx_rx_refcount.store(1, Ordering::Relaxed);

--- a/tests/nrf52840/src/bin/buffered_uart.rs
+++ b/tests/nrf52840/src/bin/buffered_uart.rs
@@ -23,7 +23,7 @@ async fn main(_spawner: Spawner) {
     let mut tx_buffer = [0u8; 1024];
     let mut rx_buffer = [0u8; 1024];
 
-    let mut u = BufferedUarte::new(
+    let u = BufferedUarte::new(
         p.UARTE0,
         p.TIMER0,
         p.PPI_CH0,

--- a/tests/nrf52840/src/bin/buffered_uart_full.rs
+++ b/tests/nrf52840/src/bin/buffered_uart_full.rs
@@ -23,7 +23,7 @@ async fn main(_spawner: Spawner) {
     let mut tx_buffer = [0u8; 1024];
     let mut rx_buffer = [0u8; 1024];
 
-    let mut u = BufferedUarte::new(
+    let u = BufferedUarte::new(
         p.UARTE0,
         p.TIMER0,
         p.PPI_CH0,

--- a/tests/nrf52840/src/bin/buffered_uart_halves.rs
+++ b/tests/nrf52840/src/bin/buffered_uart_halves.rs
@@ -5,12 +5,13 @@ teleprobe_meta::target!(b"nrf52840-dk");
 use defmt::{assert_eq, *};
 use embassy_executor::Spawner;
 use embassy_futures::join::join;
-use embassy_nrf::buffered_uarte::{self, BufferedUarte};
+use embassy_nrf::buffered_uarte::{self, BufferedUarteRx, BufferedUarteTx};
 use embassy_nrf::{bind_interrupts, peripherals, uarte};
 use {defmt_rtt as _, panic_probe as _};
 
 bind_interrupts!(struct Irqs {
     UARTE0_UART0 => buffered_uarte::InterruptHandler<peripherals::UARTE0>;
+    UARTE1 => buffered_uarte::InterruptHandler<peripherals::UARTE1>;
 });
 
 #[embassy_executor::main]
@@ -25,7 +26,11 @@ async fn main(_spawner: Spawner) {
 
     // test teardown + recreate of the buffereduarte works fine.
     for _ in 0..2 {
-        let u = BufferedUarte::new(
+        const COUNT: usize = 40_000;
+
+        let mut tx = BufferedUarteTx::new(&mut p.UARTE1, Irqs, &mut p.P1_02, config.clone(), &mut tx_buffer);
+
+        let mut rx = BufferedUarteRx::new(
             &mut p.UARTE0,
             &mut p.TIMER0,
             &mut p.PPI_CH0,
@@ -33,19 +38,13 @@ async fn main(_spawner: Spawner) {
             &mut p.PPI_GROUP0,
             Irqs,
             &mut p.P1_03,
-            &mut p.P1_02,
             config.clone(),
             &mut rx_buffer,
-            &mut tx_buffer,
         );
 
-        info!("uarte initialized!");
-
-        let (mut rx, mut tx) = u.split();
-
-        const COUNT: usize = 40_000;
-
         let tx_fut = async {
+            info!("tx initialized!");
+
             let mut tx_buf = [0; 215];
             let mut i = 0;
             while i < COUNT {
@@ -59,6 +58,8 @@ async fn main(_spawner: Spawner) {
             }
         };
         let rx_fut = async {
+            info!("rx initialized!");
+
             let mut i = 0;
             while i < COUNT {
                 let buf = unwrap!(rx.fill_buf().await);


### PR DESCRIPTION
- nrf/buffered_uart: simplify split lifetimes.
- nrf/uart: add split_by_ref.
- nrf/buffered_uart: refactor so rx/tx halves are independent.
