### PR TITLE
stm32: time_driver: allow use of TIM1 for driver

### DIFF
--- a/embassy-stm32/Cargo.toml
+++ b/embassy-stm32/Cargo.toml
@@ -144,8 +144,6 @@ time-driver-tim5 = ["_time-driver"]
 time-driver-tim8 = ["_time-driver"]
 ## Use TIM9 as time driver
 time-driver-tim9 = ["_time-driver"]
-## Use TIM11 as time driver
-time-driver-tim11 = ["_time-driver"]
 ## Use TIM12 as time driver
 time-driver-tim12 = ["_time-driver"]
 ## Use TIM15 as time driver

--- a/embassy-stm32/Cargo.toml
+++ b/embassy-stm32/Cargo.toml
@@ -130,6 +130,8 @@ _time-driver = ["dep:embassy-time-driver", "time"]
 
 ## Use any time driver
 time-driver-any = ["_time-driver"]
+## Use TIM1 as time driver
+time-driver-tim1 = ["_time-driver"]
 ## Use TIM2 as time driver
 time-driver-tim2 = ["_time-driver"]
 ## Use TIM3 as time driver

--- a/embassy-stm32/Cargo.toml
+++ b/embassy-stm32/Cargo.toml
@@ -140,6 +140,8 @@ time-driver-tim3 = ["_time-driver"]
 time-driver-tim4 = ["_time-driver"]
 ## Use TIM5 as time driver
 time-driver-tim5 = ["_time-driver"]
+## Use TIM8 as time driver
+time-driver-tim8 = ["_time-driver"]
 ## Use TIM9 as time driver
 time-driver-tim9 = ["_time-driver"]
 ## Use TIM11 as time driver
@@ -148,10 +150,16 @@ time-driver-tim11 = ["_time-driver"]
 time-driver-tim12 = ["_time-driver"]
 ## Use TIM15 as time driver
 time-driver-tim15 = ["_time-driver"]
+## Use TIM20 as time driver
+time-driver-tim20 = ["_time-driver"]
 ## Use TIM21 as time driver
 time-driver-tim21 = ["_time-driver"]
 ## Use TIM22 as time driver
 time-driver-tim22 = ["_time-driver"]
+## Use TIM23 as time driver
+time-driver-tim23 = ["_time-driver"]
+## Use TIM24 as time driver
+time-driver-tim24 = ["_time-driver"]
 
 
 #! ## Analog Switch Pins (Pxy_C) on STM32H7 series

--- a/embassy-stm32/build.rs
+++ b/embassy-stm32/build.rs
@@ -189,7 +189,6 @@ fn main() {
         Some("tim5") => "TIM5",
         Some("tim8") => "TIM8",
         Some("tim9") => "TIM9",
-        Some("tim11") => "TIM11",
         Some("tim12") => "TIM12",
         Some("tim15") => "TIM15",
         Some("tim20") => "TIM20",

--- a/embassy-stm32/build.rs
+++ b/embassy-stm32/build.rs
@@ -189,6 +189,7 @@ fn main() {
         Some("tim5") => "TIM5",
         Some("tim8") => "TIM8",
         Some("tim9") => "TIM9",
+        Some("tim11") => "TIM11",
         Some("tim12") => "TIM12",
         Some("tim15") => "TIM15",
         Some("tim20") => "TIM20",

--- a/embassy-stm32/src/time_driver.rs
+++ b/embassy-stm32/src/time_driver.rs
@@ -16,6 +16,8 @@ use crate::pac::timer::vals;
 use crate::rcc::sealed::RccPeripheral;
 #[cfg(feature = "low-power")]
 use crate::rtc::Rtc;
+#[cfg(any(time_driver_tim1, time_driver_tim8, time_driver_tim20))]
+use crate::timer::sealed::AdvancedControlInstance;
 use crate::timer::sealed::{CoreInstance, GeneralPurpose16bitInstance as Instance};
 use crate::{interrupt, peripherals};
 
@@ -76,6 +78,14 @@ foreach_interrupt! {
             DRIVER.on_interrupt()
         }
     };
+    (TIM1, timer, $block:ident, CC, $irq:ident) => {
+        #[cfg(time_driver_tim1)]
+        #[cfg(feature = "rt")]
+        #[interrupt]
+        fn $irq() {
+            DRIVER.on_interrupt()
+        }
+    };
     (TIM2, timer, $block:ident, UP, $irq:ident) => {
         #[cfg(time_driver_tim2)]
         #[cfg(feature = "rt")]
@@ -116,6 +126,14 @@ foreach_interrupt! {
             DRIVER.on_interrupt()
         }
     };
+    (TIM8, timer, $block:ident, CC, $irq:ident) => {
+        #[cfg(time_driver_tim8)]
+        #[cfg(feature = "rt")]
+        #[interrupt]
+        fn $irq() {
+            DRIVER.on_interrupt()
+        }
+    };
     (TIM9, timer, $block:ident, UP, $irq:ident) => {
         #[cfg(time_driver_tim9)]
         #[cfg(feature = "rt")]
@@ -141,6 +159,14 @@ foreach_interrupt! {
         }
     };
     (TIM20, timer, $block:ident, UP, $irq:ident) => {
+        #[cfg(time_driver_tim20)]
+        #[cfg(feature = "rt")]
+        #[interrupt]
+        fn $irq() {
+            DRIVER.on_interrupt()
+        }
+    };
+    (TIM20, timer, $block:ident, CC, $irq:ident) => {
         #[cfg(time_driver_tim20)]
         #[cfg(feature = "rt")]
         #[interrupt]
@@ -280,6 +306,14 @@ impl RtcDriver {
 
         <T as CoreInstance>::Interrupt::unpend();
         unsafe { <T as CoreInstance>::Interrupt::enable() };
+
+        #[cfg(any(time_driver_tim1, time_driver_tim8, time_driver_tim20))]
+        {
+            <T as AdvancedControlInstance>::CaptureCompareInterrupt::unpend();
+            unsafe {
+                <T as AdvancedControlInstance>::CaptureCompareInterrupt::enable();
+            }
+        }
 
         r.cr1().modify(|w| w.set_cen(true));
     }

--- a/embassy-stm32/src/time_driver.rs
+++ b/embassy-stm32/src/time_driver.rs
@@ -38,7 +38,7 @@ cfg_if::cfg_if! {
     }
 }
 
-#[cfg(time_drvier_tim1)]
+#[cfg(time_driver_tim1)]
 type T = peripherals::TIM1;
 #[cfg(time_driver_tim2)]
 type T = peripherals::TIM2;

--- a/embassy-stm32/src/time_driver.rs
+++ b/embassy-stm32/src/time_driver.rs
@@ -52,8 +52,6 @@ type T = peripherals::TIM5;
 type T = peripherals::TIM8;
 #[cfg(time_driver_tim9)]
 type T = peripherals::TIM9;
-#[cfg(time_driver_tim11)]
-type T = peripherals::TIM11;
 #[cfg(time_driver_tim12)]
 type T = peripherals::TIM12;
 #[cfg(time_driver_tim15)]

--- a/embassy-stm32/src/timer/mod.rs
+++ b/embassy-stm32/src/timer/mod.rs
@@ -464,6 +464,9 @@ pub(crate) mod sealed {
     pub trait AdvancedControlInstance:
         GeneralPurpose2ChannelComplementaryInstance + GeneralPurpose16bitInstance
     {
+        /// Capture compare interrupt for this timer.
+        type CaptureCompareInterrupt: interrupt::typelevel::Interrupt;
+
         /// Get access to the advanced timer registers.
         fn regs_advanced() -> crate::pac::timer::TimAdv;
 
@@ -831,8 +834,10 @@ macro_rules! impl_2ch_cmp_timer {
 
 #[allow(unused)]
 macro_rules! impl_adv_timer {
-    ($inst:ident) => {
+    ($inst:ident, $irq:ident) => {
         impl sealed::AdvancedControlInstance for crate::peripherals::$inst {
+            type CaptureCompareInterrupt = crate::interrupt::typelevel::$irq;
+
             fn regs_advanced() -> crate::pac::timer::TimAdv {
                 unsafe { crate::pac::timer::TimAdv::from_ptr(crate::pac::$inst.as_ptr()) }
             }
@@ -905,10 +910,12 @@ foreach_interrupt! {
         impl_gp16_timer!($inst);
         impl_1ch_cmp_timer!($inst);
         impl_2ch_cmp_timer!($inst);
-        impl_adv_timer!($inst);
         impl BasicInstance for crate::peripherals::$inst {}
         impl CaptureCompare16bitInstance for crate::peripherals::$inst {}
         impl ComplementaryCaptureCompare16bitInstance for crate::peripherals::$inst {}
+    };
+    ($inst:ident, timer, TIM_1CH_CMP, CC, $irq:ident) => {
+        impl_adv_timer!($inst, $irq);
     };
 
 
@@ -921,10 +928,12 @@ foreach_interrupt! {
         impl_gp16_timer!($inst);
         impl_1ch_cmp_timer!($inst);
         impl_2ch_cmp_timer!($inst);
-        impl_adv_timer!($inst);
         impl BasicInstance for crate::peripherals::$inst {}
         impl CaptureCompare16bitInstance for crate::peripherals::$inst {}
         impl ComplementaryCaptureCompare16bitInstance for crate::peripherals::$inst {}
+    };
+    ($inst:ident, timer, TIM_2CH_CMP, CC, $irq:ident) => {
+        impl_adv_timer!($inst, $irq);
     };
 
 
@@ -937,10 +946,12 @@ foreach_interrupt! {
         impl_gp16_timer!($inst);
         impl_1ch_cmp_timer!($inst);
         impl_2ch_cmp_timer!($inst);
-        impl_adv_timer!($inst);
         impl BasicInstance for crate::peripherals::$inst {}
         impl CaptureCompare16bitInstance for crate::peripherals::$inst {}
         impl ComplementaryCaptureCompare16bitInstance for crate::peripherals::$inst {}
+    };
+    ($inst:ident, timer, TIM_ADV, CC, $irq:ident) => {
+        impl_adv_timer!($inst, $irq);
     };
 }
 


### PR DESCRIPTION
I'm sure there's a great reason for this being omitted, typo included, <s>but the thing seems to work</s> [bit eager there] and I really need TIM2 & 3 free, sooooo

edit: PR's scope now includes correctly using the TIMx_CC interrupt source for advanced timers (TIM1/8/20)