### PR TITLE
Fix CCE and Init set to false in can fd peripheral.rs

### DIFF
--- a/embassy-stm32/src/can/fd/peripheral.rs
+++ b/embassy-stm32/src/can/fd/peripheral.rs
@@ -475,9 +475,9 @@ impl Registers {
     #[inline]
     fn leave_init_mode(&mut self, config: FdCanConfig) {
         self.apply_config(config);
-
-        self.regs.cccr().modify(|w| w.set_cce(false));
+        
         self.regs.cccr().modify(|w| w.set_init(false));
+        self.regs.cccr().modify(|w| w.set_cce(false));
         while self.regs.cccr().read().init() == true {}
     }
 


### PR DESCRIPTION
Configuration Change Enable set to false before Init set to false, fixed.
Previously when trying to configure CAN, process would get stuck in leaving init mode (I imagine) because 
``self.regs.cccr().modify(|w| w.set_init(false));`` didn't work after ``self.regs.cccr().modify(|w| w.set_cce(false));`` was run.