### PR TITLE
Bump `usbd-hid` version to 0.7.0

### DIFF
--- a/embassy-usb/Cargo.toml
+++ b/embassy-usb/Cargo.toml
@@ -56,5 +56,5 @@ log = { version = "0.4.14", optional = true }
 heapless = "0.8"
 
 # for HID
-usbd-hid = { version = "0.6.0", optional = true }
+usbd-hid = { version = "0.7.0", optional = true }
 ssmarshal = { version = "1.0", default-features = false, optional = true }

--- a/examples/nrf52840/Cargo.toml
+++ b/examples/nrf52840/Cargo.toml
@@ -28,7 +28,7 @@ panic-probe = { version = "0.3", features = ["print-defmt"] }
 futures = { version = "0.3.17", default-features = false, features = ["async-await"] }
 rand = { version = "0.8.4", default-features = false }
 embedded-storage = "0.3.1"
-usbd-hid = "0.6.0"
+usbd-hid = "0.7.0"
 serde = { version = "1.0.136", default-features = false }
 embedded-hal = { version = "1.0" }
 embedded-hal-async = { version = "1.0" }

--- a/examples/nrf5340/Cargo.toml
+++ b/examples/nrf5340/Cargo.toml
@@ -24,7 +24,7 @@ panic-probe = { version = "0.3", features = ["print-defmt"] }
 futures = { version = "0.3.17", default-features = false, features = ["async-await"] }
 rand = { version = "0.8.4", default-features = false }
 embedded-storage = "0.3.1"
-usbd-hid = "0.6.0"
+usbd-hid = "0.7.0"
 serde = { version = "1.0.136", default-features = false }
 
 [profile.release]

--- a/examples/rp/Cargo.toml
+++ b/examples/rp/Cargo.toml
@@ -36,7 +36,7 @@ display-interface = "0.4.1"
 byte-slice-cast = { version = "1.2.0", default-features = false }
 smart-leds = "0.3.0"
 heapless = "0.8"
-usbd-hid = "0.6.1"
+usbd-hid = "0.7.0"
 
 embedded-hal-1 = { package = "embedded-hal", version = "1.0" }
 embedded-hal-async = "1.0"

--- a/examples/stm32g4/Cargo.toml
+++ b/examples/stm32g4/Cargo.toml
@@ -12,7 +12,7 @@ embassy-executor = { version = "0.5.0", path = "../../embassy-executor", feature
 embassy-time = { version = "0.3.0", path = "../../embassy-time", features = ["defmt", "defmt-timestamp-uptime", "tick-hz-32_768"] }
 embassy-usb = { version = "0.1.0", path = "../../embassy-usb", features = ["defmt"] }
 embassy-futures = { version = "0.1.0", path = "../../embassy-futures" }
-usbd-hid = "0.6.0"
+usbd-hid = "0.7.0"
 
 defmt = "0.3"
 defmt-rtt = "0.4"

--- a/examples/stm32l5/Cargo.toml
+++ b/examples/stm32l5/Cargo.toml
@@ -13,7 +13,7 @@ embassy-time = { version = "0.3.0", path = "../../embassy-time", features = ["de
 embassy-usb = { version = "0.1.0", path = "../../embassy-usb", features = ["defmt"] }
 embassy-net = { version = "0.4.0", path = "../../embassy-net", features = ["defmt",  "tcp", "dhcpv4", "medium-ethernet"] }
 embassy-futures = { version = "0.1.0", path = "../../embassy-futures" }
-usbd-hid = "0.6.0"
+usbd-hid = "0.7.0"
 
 defmt = "0.3"
 defmt-rtt = "0.4"


### PR DESCRIPTION
`usbd-hid` released 0.7.0, this PR updates embassy-usb, using latest `usbd-hid`