### PR TITLE
allow higher psc value for iwdg_v3 ...

### DIFF
--- a/embassy-stm32/src/wdg/mod.rs
+++ b/embassy-stm32/src/wdg/mod.rs
@@ -42,9 +42,13 @@ impl<'d, T: Instance> IndependentWatchdog<'d, T> {
         // Prescaler value
         let psc = 2u16.pow(psc_power);
 
+        #[cfg(not(iwdg_v3))]
+        assert!(psc <= 256, "IWDG prescaler should be no more than 256");
+        #[cfg(iwdg_v3)] // H5, U5, WBA
+        assert!(psc <= 1024, "IWDG prescaler should be no more than 1024");
+
         // Convert prescaler power to PR register value
         let pr = psc_power as u8 - 2;
-        assert!(pr <= 0b110);
 
         // Reload value
         let rl = reload_value(psc, timeout_us);


### PR DESCRIPTION
... and refactor a little bit, since H5 RM says:

```
PR[3:0]: Prescaler divider

0000: divider / 4
0001: divider / 8
0010: divider / 16
0011: divider / 32
0100: divider / 64
0101: divider / 128
0110: divider / 256
0111: divider / 512
Others: divider / 1024
```

thus we wouldn't need to limit bit value, but to make sure achievable prescale value.