### PR TITLE
stm32: can: fd: allow TX buffers in FIFO mode

### DIFF
--- a/embassy-stm32/src/can/fd/config.rs
+++ b/embassy-stm32/src/can/fd/config.rs
@@ -287,6 +287,24 @@ impl Default for GlobalFilter {
     }
 }
 
+/// TX buffer operation mode
+#[derive(Clone, Copy, Debug)]
+pub enum TxBufferMode {
+    /// TX FIFO operation
+    Fifo,
+    /// TX queue operation
+    Queue,
+}
+
+impl From<TxBufferMode> for crate::pac::can::vals::Tfqm {
+    fn from(value: TxBufferMode) -> Self {
+        match value {
+            TxBufferMode::Queue => Self::QUEUE,
+            TxBufferMode::Fifo => Self::FIFO,
+        }
+    }
+}
+
 /// FdCan Config Struct
 #[derive(Clone, Copy, Debug)]
 pub struct FdCanConfig {
@@ -327,6 +345,8 @@ pub struct FdCanConfig {
     pub timestamp_source: TimestampSource,
     /// Configures the Global Filter
     pub global_filter: GlobalFilter,
+    /// TX buffer mode (FIFO or queue)
+    pub tx_buffer_mode: TxBufferMode,
 }
 
 impl FdCanConfig {
@@ -433,6 +453,7 @@ impl Default for FdCanConfig {
             clock_divider: ClockDivider::_1,
             timestamp_source: TimestampSource::None,
             global_filter: GlobalFilter::default(),
+            tx_buffer_mode: TxBufferMode::Queue,
         }
     }
 }

--- a/embassy-stm32/src/can/fd/config.rs
+++ b/embassy-stm32/src/can/fd/config.rs
@@ -288,7 +288,7 @@ impl Default for GlobalFilter {
 }
 
 /// TX buffer operation mode
-#[derive(Clone, Copy, Debug)]
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
 pub enum TxBufferMode {
     /// TX FIFO operation
     Fifo,
@@ -301,6 +301,15 @@ impl From<TxBufferMode> for crate::pac::can::vals::Tfqm {
         match value {
             TxBufferMode::Queue => Self::QUEUE,
             TxBufferMode::Fifo => Self::FIFO,
+        }
+    }
+}
+
+impl From<crate::pac::can::vals::Tfqm> for TxBufferMode {
+    fn from(value: crate::pac::can::vals::Tfqm) -> Self {
+        match value {
+            crate::pac::can::vals::Tfqm::QUEUE => Self::Queue,
+            crate::pac::can::vals::Tfqm::FIFO => Self::Fifo,
         }
     }
 }

--- a/embassy-stm32/src/can/fd/peripheral.rs
+++ b/embassy-stm32/src/can/fd/peripheral.rs
@@ -170,7 +170,7 @@ impl Registers {
     }
 
     #[inline]
-    pub fn abort_pending_mailbox_generic<F: embedded_can::Frame>(&self, bufidx: usize) -> Option<F> {
+    fn abort_pending_mailbox<F: embedded_can::Frame>(&self, bufidx: usize) -> Option<F> {
         if self.abort(bufidx) {
             let mailbox = self.tx_buffer_element(bufidx);
 
@@ -212,11 +212,11 @@ impl Registers {
             // Discard the first slot with a lower priority message
             let id = frame.header().id();
             if self.is_available(0, id) {
-                (0, self.abort_pending_mailbox_generic(0))
+                (0, self.abort_pending_mailbox(0))
             } else if self.is_available(1, id) {
-                (1, self.abort_pending_mailbox_generic(1))
+                (1, self.abort_pending_mailbox(1))
             } else if self.is_available(2, id) {
-                (2, self.abort_pending_mailbox_generic(2))
+                (2, self.abort_pending_mailbox(2))
             } else {
                 // For now we bail when there is no lower priority slot available
                 // Can this lead to priority inversion?

--- a/embassy-stm32/src/can/fd/peripheral.rs
+++ b/embassy-stm32/src/can/fd/peripheral.rs
@@ -302,10 +302,8 @@ impl Registers {
 
         // Framework specific settings are set here
 
-        // set TxBuffer to Queue Mode
-        self.regs
-            .txbc()
-            .write(|w| w.set_tfqm(crate::pac::can::vals::Tfqm::QUEUE));
+        // set TxBuffer Mode
+        self.regs.txbc().write(|w| w.set_tfqm(_config.tx_buffer_mode.into()));
 
         // set standard filters list size to 28
         // set extended filters list size to 8


### PR DESCRIPTION
Uses enum in pac introduced here: https://github.com/embassy-rs/stm32-data/pull/429

Need to figure out what this breaks. First glance suggests `BufferedCan` should work fine with it at least