### PR TITLE
adding FDCANSEL logic for STM32H7x

### DIFF
--- a/embassy-stm32/src/rcc/h.rs
+++ b/embassy-stm32/src/rcc/h.rs
@@ -557,6 +557,9 @@ pub(crate) unsafe fn init(config: Config) {
         RCC.d3ccipr().modify(|w| {
             w.set_adcsel(config.adc_clock_source);
         });
+        RCC.d2ccip1r().modify(|w| {
+            w.set_fdcansel(config.fdcan_clock_source);
+        });
     }
     #[cfg(stm32h5)]
     {


### PR DESCRIPTION
Currently, using any clock other than the HSE with FDCAN causes hardfaults due to the FDCANSEL register not being set correctly.
See [Issue 2620](https://github.com/embassy-rs/embassy/issues/2620). 

This PR is not complete, as logic may still be needed to set the frequency correctly.