### PR TITLE
Buffer is not big enough for FD frames.

### DIFF
--- a/embassy-stm32/src/can/fd/peripheral.rs
+++ b/embassy-stm32/src/can/fd/peripheral.rs
@@ -46,7 +46,7 @@ impl Registers {
         let read_idx = self.regs.rxfs(fifonr).read().fgi();
         let mailbox = self.rx_fifo_element(fifonr, read_idx as usize);
 
-        let mut buffer: [u8; 8] = [0; 8];
+        let mut buffer = [0u8; 64];
         let maybe_header = extract_frame(mailbox, &mut buffer);
 
         // Clear FIFO, reduces count and increments read buf


### PR DESCRIPTION
https://github.com/embassy-rs/embassy/pull/2635 Did some nice refactoring however the combined reader function only declared an 8 byte data buffer as per ClassicCan instead of the larger 64 byte that is needed in order to receive full-sized CAN FD frames.