### PR TITLE
docs: update basic example references in basic_application.adoc

### DIFF
--- a/docs/modules/ROOT/pages/basic_application.adoc
+++ b/docs/modules/ROOT/pages/basic_application.adoc
@@ -17,15 +17,6 @@ The first thing you’ll notice are two attributes at the top of the file. These
 include::example$basic/src/main.rs[lines="1..2"]
 ----
 
-=== Rust Nightly
-
-The next declaration is a Rust Unstable feature, which means that Embassy requires Rust Nightly:
-
-[source,rust]
-----
-include::example$basic/src/main.rs[lines="3"]
-----
-
 === Dealing with errors
 
 Then, what follows are some declarations on how to deal with panics and faults. During development, a good practice is to rely on `defmt-rtt` and `panic-probe` to print diagnostics to the terminal:
@@ -41,7 +32,7 @@ After a bit of import declaration, the tasks run by the application should be de
 
 [source,rust]
 ----
-include::example$basic/src/main.rs[lines="12..20"]
+include::example$basic/src/main.rs[lines="10..18"]
 ----
 
 An embassy task must be declared `async`, and may NOT take generic arguments. In this case, we are handed the LED that should be blinked and the interval of the blinking.
@@ -56,7 +47,7 @@ We then initialize the HAL with a default config, which gives us a `Peripherals`
 
 [source,rust]
 ----
-include::example$basic/src/main.rs[lines="22..-1"]
+include::example$basic/src/main.rs[lines="20..-1"]
 ----
 
 What happens when the `blinker` task has been spawned and main returns? Well, the main entry point is actually just like any other task, except that you can only have one and it takes some specific type arguments. The magic lies within the `#[embassy_executor::main]` macro. The macro does the following:


### PR DESCRIPTION
The documentation of the basic example contains broken references to the `main.rs` file. This PR edits the referenced lines in order to make documentation clearer.