### PR TITLE
docs: update broken reference in basic_application.adoc

### DIFF
--- a/docs/modules/ROOT/pages/basic_application.adoc
+++ b/docs/modules/ROOT/pages/basic_application.adoc
@@ -23,7 +23,7 @@ Then, what follows are some declarations on how to deal with panics and faults. 
 
 [source,rust]
 ----
-include::example$basic/src/main.rs[lines="10"]
+include::example$basic/src/main.rs[lines="8"]
 ----
 
 === Task declaration


### PR DESCRIPTION
I forgot to edit one broken reference in #2641. This PR amends this change. #2641 was closed before i noticed the mistake. Sorry! :)