### PR TITLE
STM32 USB Type-C/USB Power Delivery Interface (UCPD)

### DIFF
--- a/embassy-stm32/build.rs
+++ b/embassy-stm32/build.rs
@@ -764,6 +764,8 @@ fn main() {
     #[rustfmt::skip]
     let signals: HashMap<_, _> = [
                 // (kind, signal) => trait
+        (("ucpd", "CC1"), quote!(crate::ucpd::Cc1Pin)),
+        (("ucpd", "CC2"), quote!(crate::ucpd::Cc2Pin)),
         (("usart", "TX"), quote!(crate::usart::TxPin)),
         (("usart", "RX"), quote!(crate::usart::RxPin)),
         (("usart", "CTS"), quote!(crate::usart::CtsPin)),
@@ -1102,6 +1104,8 @@ fn main() {
 
     let signals: HashMap<_, _> = [
         // (kind, signal) => trait
+        (("ucpd", "RX"), quote!(crate::ucpd::RxDma)),
+        (("ucpd", "TX"), quote!(crate::ucpd::TxDma)),
         (("usart", "RX"), quote!(crate::usart::RxDma)),
         (("usart", "TX"), quote!(crate::usart::TxDma)),
         (("lpuart", "RX"), quote!(crate::usart::RxDma)),

--- a/embassy-stm32/src/lib.rs
+++ b/embassy-stm32/src/lib.rs
@@ -283,9 +283,8 @@ pub fn init(config: Config) -> Peripherals {
         }
 
         unsafe {
-            // TODO: refactor into mod ucpd
             #[cfg(ucpd)]
-            ucpd_init(
+            ucpd::init(
                 cs,
                 #[cfg(peri_ucpd1)]
                 config.enable_ucpd1_dead_battery,
@@ -333,42 +332,4 @@ pub fn init(config: Config) -> Peripherals {
 
         p
     })
-}
-
-#[cfg(ucpd)]
-/// Safety: must only be called when all UCPDs are disabled (e.g. at startup)
-unsafe fn ucpd_init(
-    _cs: critical_section::CriticalSection,
-    #[cfg(peri_ucpd1)] ucpd1_db_enable: bool,
-    #[cfg(peri_ucpd2)] ucpd2_db_enable: bool,
-) {
-    #[cfg(stm32g0x1)]
-    {
-        // according to RM0444 (STM32G0x1) section 8.1.1:
-        // when UCPD is disabled setting the strobe will disable dead battery
-        // (which is enabled after reset) but if UCPD is enabled, setting the
-        // strobe will apply the CC pin configuration from the control register
-        // (which is why we need to be careful about when we call this)
-        crate::pac::SYSCFG.cfgr1().modify(|w| {
-            w.set_ucpd1_strobe(ucpd1_db_enable);
-            w.set_ucpd2_strobe(ucpd2_db_enable);
-        });
-    }
-
-    #[cfg(any(stm32g4, stm32l5))]
-    {
-        crate::pac::PWR.cr3().modify(|w| {
-            #[cfg(stm32g4)]
-            w.set_ucpd1_dbdis(!ucpd1_db_enable);
-            #[cfg(stm32l5)]
-            w.set_ucpd_dbdis(!ucpd1_db_enable);
-        })
-    }
-
-    #[cfg(any(stm32h5, stm32u5))]
-    {
-        crate::pac::PWR.ucpdr().modify(|w| {
-            w.set_ucpd_dbdis(!ucpd1_db_enable);
-        })
-    }
 }

--- a/embassy-stm32/src/lib.rs
+++ b/embassy-stm32/src/lib.rs
@@ -73,6 +73,8 @@ pub mod sai;
 pub mod sdmmc;
 #[cfg(spi)]
 pub mod spi;
+#[cfg(ucpd)]
+pub mod ucpd;
 #[cfg(uid)]
 pub mod uid;
 #[cfg(usart)]

--- a/embassy-stm32/src/ucpd.rs
+++ b/embassy-stm32/src/ucpd.rs
@@ -172,6 +172,7 @@ impl<'d, T: Instance> Drop for CcPhy<'d, T> {
             drop_not_ready.store(true, Ordering::Relaxed);
         } else {
             r.cfgr1().write(|w| w.set_ucpden(false));
+            T::disable();
         }
     }
 }
@@ -287,6 +288,7 @@ impl<'d, T: Instance> Drop for PdPhy<'d, T> {
             drop_not_ready.store(true, Ordering::Relaxed);
         } else {
             r.cfgr1().write(|w| w.set_ucpden(false));
+            T::disable();
         }
     }
 }

--- a/embassy-stm32/src/ucpd.rs
+++ b/embassy-stm32/src/ucpd.rs
@@ -30,6 +30,7 @@ use crate::rcc::RccPeripheral;
 
 /// Pull-up or Pull-down resistor state of both CC lines.
 #[derive(Debug, Clone, Copy, PartialEq)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub enum CcPull {
     /// Analog PHY for CC pin disabled.
     Disabled,
@@ -209,6 +210,7 @@ impl<'d, T: Instance> Ucpd<'d, T> {
 
 /// Receive Error.
 #[derive(Debug, Clone, Copy)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub enum RxError {
     /// Incorrect CRC or truncated message (a line becoming static before EOP is met).
     Crc,
@@ -219,6 +221,7 @@ pub enum RxError {
 
 /// Transmit Error.
 #[derive(Debug, Clone, Copy)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub enum TxError {
     /// Concurrent receive in progress or excessive noise on the line.
     Discarded,

--- a/embassy-stm32/src/ucpd.rs
+++ b/embassy-stm32/src/ucpd.rs
@@ -95,9 +95,13 @@ impl<'d, T: Instance> Ucpd<'d, T> {
     pub fn new(
         _peri: impl Peripheral<P = T> + 'd,
         _irq: impl interrupt::typelevel::Binding<T::Interrupt, InterruptHandler<T>> + 'd,
-        _cc1: impl Peripheral<P = impl Cc1Pin<T>> + 'd,
-        _cc2: impl Peripheral<P = impl Cc2Pin<T>> + 'd,
+        cc1: impl Peripheral<P = impl Cc1Pin<T>> + 'd,
+        cc2: impl Peripheral<P = impl Cc2Pin<T>> + 'd,
     ) -> Self {
+        into_ref!(cc1, cc2);
+        cc1.set_as_analog();
+        cc2.set_as_analog();
+
         T::enable_and_reset();
         T::Interrupt::unpend();
         unsafe { T::Interrupt::enable() };

--- a/embassy-stm32/src/ucpd.rs
+++ b/embassy-stm32/src/ucpd.rs
@@ -484,8 +484,8 @@ impl<'d, T: Instance> PdPhy<'d, T> {
 
         // Clear the hardreset interrupt flags.
         T::REGS.icr().write(|w| {
-            w.set_txmsgdisccf(true);
-            w.set_txmsgsentcf(true);
+            w.set_hrstdisccf(true);
+            w.set_hrstsentcf(true);
         });
 
         // Trigger hard reset transmission.

--- a/embassy-stm32/src/ucpd.rs
+++ b/embassy-stm32/src/ucpd.rs
@@ -112,10 +112,8 @@ impl<'d, T: Instance> Ucpd<'d, T> {
             // Prescaler to produce a target half-bit frequency of 600kHz which is required
             // to produce transmit with a nominal nominal bit rate of 300Kbps+-10% using
             // biphase mark coding (BMC, aka differential manchester coding).
-            // A divider of 13 gives the target frequency closest to spec (~615kHz, 1.625us)
-            // but we go with the (hopefully well tested) default value used by the Cube HAL
-            // which is 14 divides the clock down to ~571kHz, 1.75us.
-            w.set_hbitclkdiv(14 - 1);
+            // A divider of 13 gives the target frequency closest to spec (~615kHz, 1.625us).
+            w.set_hbitclkdiv(13 - 1);
 
             // Time window for detecting non-idle (12-20us).
             // 1.75us * 8 = 14us.

--- a/embassy-stm32/src/ucpd.rs
+++ b/embassy-stm32/src/ucpd.rs
@@ -22,9 +22,10 @@ use embassy_hal_internal::drop::OnDrop;
 use embassy_hal_internal::{into_ref, Peripheral, PeripheralRef};
 use embassy_sync::waitqueue::AtomicWaker;
 
+use crate::dma::AnyChannel;
 use crate::interrupt;
-pub use crate::pac::ucpd::vals::TypecVstateCc as CcVState;
 use crate::pac::ucpd::vals::{Anamode, Ccenable, PscUsbpdclk};
+pub use crate::pac::ucpd::vals::{Phyccsel as CcSel, TypecVstateCc as CcVState};
 use crate::rcc::RccPeripheral;
 
 /// Pull-up or Pull-down resistor state of both CC lines.
@@ -177,6 +178,50 @@ impl<'d, T: Instance> Ucpd<'d, T> {
             })
         });
     }
+
+    /// Returns PD receiver and transmitter.
+    pub fn pd(
+        &mut self,
+        rx_dma: impl Peripheral<P = impl RxDma<T>> + 'd,
+        tx_dma: impl Peripheral<P = impl TxDma<T>> + 'd,
+        cc_sel: CcSel,
+    ) -> (PdRx<'_, T>, PdTx<'_, T>) {
+        into_ref!(rx_dma, tx_dma);
+        let rx_dma_req = rx_dma.request();
+        let tx_dma_req = tx_dma.request();
+        (
+            PdRx {
+                _ucpd: self,
+                dma_ch: rx_dma.map_into(),
+                dma_req: rx_dma_req,
+            },
+            PdTx {
+                _ucpd: self,
+                dma_ch: tx_dma.map_into(),
+                dma_req: tx_dma_req,
+            },
+        )
+    }
+}
+
+/// Power Delivery (PD) Receiver.
+pub struct PdRx<'d, T: Instance> {
+    _ucpd: &'d Ucpd<'d, T>,
+    dma_ch: PeripheralRef<'d, AnyChannel>,
+    dma_req: Request,
+}
+
+impl<'d, T: Instance> Drop for PdRx<'d, T> {
+    fn drop(&mut self) {
+        T::REGS.cr().modify(|w| w.set_phyrxen(false));
+    }
+}
+
+/// Power Delivery (PD) Transmitter.
+pub struct PdTx<'d, T: Instance> {
+    _ucpd: &'d Ucpd<'d, T>,
+    dma_ch: PeripheralRef<'d, AnyChannel>,
+    dma_req: Request,
 }
 
 /// Interrupt handler.

--- a/embassy-stm32/src/ucpd.rs
+++ b/embassy-stm32/src/ucpd.rs
@@ -269,18 +269,12 @@ impl<'d, T: Instance> PdPhy<'d, T> {
 
         // Keep the DMA transfer alive so its drop code does not stop it right away.
         let dma = unsafe {
-            // Disable the DMA complete interrupt because the end of packet is
-            // signaled by the UCPD receiver. When the DMA buffer is too short
-            // DMA stops by itself and the overrun RXOVR flag of UCPD is set.
-            let mut transfer_options = TransferOptions::default();
-            transfer_options.complete_transfer_ir = false;
-
             Transfer::new_read(
                 &self.rx_dma_ch,
                 self.rx_dma_req,
                 r.rxdr().as_ptr() as *mut u8,
                 buf,
-                transfer_options,
+                TransferOptions::default(),
             )
         };
 

--- a/embassy-stm32/src/ucpd.rs
+++ b/embassy-stm32/src/ucpd.rs
@@ -1,10 +1,165 @@
 //! USB Type-C/USB Power Delivery Interface (UCPD)
 
-use core::marker::PhantomData;
+// Implementation Notes
+//
+// As of Feb. 2024 the UCPD peripheral is availalbe on: G0, G4, H5, L5, U5
+//
+// Cube HAL LL Driver (g0):
+// https://github.com/STMicroelectronics/stm32g0xx_hal_driver/blob/v1.4.6/Inc/stm32g0xx_ll_ucpd.h
+// https://github.com/STMicroelectronics/stm32g0xx_hal_driver/blob/v1.4.6/Src/stm32g0xx_ll_ucpd.c
+// Except for a the `LL_UCPD_RxAnalogFilterEnable/Disable()` functions the Cube HAL implementation of
+// all families is the same.
+//
+// Dead battery pull-down resistors functionality is enabled by default on startup and must
+// be disabled by setting a bit in PWR/SYSCFG registers. The exact name and location for that
+// bit is different for each familily.
 
-use crate::interrupt;
+use core::future::poll_fn;
+use core::marker::PhantomData;
+use core::task::Poll;
+
 use crate::rcc::RccPeripheral;
+use crate::{interrupt, pac};
+use embassy_hal_internal::{into_ref, Peripheral, PeripheralRef};
 use embassy_sync::waitqueue::AtomicWaker;
+use pac::ucpd::vals::{Anamode, Ccenable, PscUsbpdclk};
+
+pub use pac::ucpd::vals::TypecVstateCc as CcVState;
+
+/// Pull-up or Pull-down resistor state of both CC lines.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub enum CcPull {
+    /// Analog PHY for CC pin disabled.
+    Disabled,
+
+    /// Rd=5.1k pull-down resistor enabled when the corresponding DBCC pin is high.
+    SinkDeadBattery,
+
+    /// Rd=5.1k pull-down resistor.
+    Sink,
+
+    /// Rp=56k pull-up resistor to indicate default USB power.
+    SourceDefaultUsb,
+
+    /// Rp=22k pull-up resistor to indicate support for up to 1.5A.
+    Source1_5A,
+
+    /// Rp=10k pull-up resistor to indicate support for up to 3.0A.
+    Source3_0A,
+}
+
+/// UCPD driver.
+pub struct Ucpd<'d, T: Instance> {
+    _peri: PeripheralRef<'d, T>,
+}
+
+impl<'d, T: Instance> Ucpd<'d, T> {
+    /// Creates a new UCPD driver instance.
+    pub fn new(
+        peri: impl Peripheral<P = T> + 'd,
+        _cc1: impl Peripheral<P = impl Cc1Pin<T>> + 'd,
+        _cc2: impl Peripheral<P = impl Cc2Pin<T>> + 'd,
+        cc_pull: CcPull,
+    ) -> Self {
+        T::enable_and_reset();
+
+        let r = T::REGS;
+        r.cfgr1().write(|w| {
+            // "The receiver is designed to work in the clock frequency range from 6 to 18 MHz.
+            // However, the optimum performance is ensured in the range from 6 to 12 MHz"
+            // UCPD is driven by HSI16 (16MHz internal oscillator), which we need to divide by 2.
+            w.set_psc_usbpdclk(PscUsbpdclk::DIV2);
+
+            // Prescaler to produce a target half-bit frequency of 600kHz which is required
+            // to produce transmit with a nominal nominal bit rate of 300Kbps+-10% using
+            // biphase mark coding (BMC, aka differential manchester coding).
+            // A divider of 13 gives the target frequency closest to spec (~615kHz, 1.625us)
+            // but we go with the (hopefully well tested) default value used by the Cube HAL
+            // which is 14 divides the clock down to ~571kHz, 1.75us.
+            w.set_hbitclkdiv(14 - 1);
+
+            // Time window for detecting non-idle (12-20us).
+            // 1.75us * 8 = 14us.
+            w.set_transwin(8 - 1);
+
+            // Time from the end of last bit of a Frame until the start of the first bit of the
+            // next Preamble (min 25us).
+            // 1.75us * 17 = ~30us
+            w.set_ifrgap(17 - 1);
+
+            // TODO: Only receive SOP messages
+            w.set_rxordseten(0x1);
+
+            // Enable DMA and the peripheral
+            w.set_txdmaen(true);
+            w.set_rxdmaen(true);
+            w.set_ucpden(true);
+        });
+
+        r.cr().write(|w| {
+            w.set_anamode(if cc_pull == CcPull::Sink {
+                Anamode::SINK
+            } else {
+                Anamode::SOURCE
+            });
+            w.set_anasubmode(match cc_pull {
+                CcPull::SourceDefaultUsb => 1,
+                CcPull::Source1_5A => 2,
+                CcPull::Source3_0A => 3,
+                _ => 0,
+            });
+            w.set_ccenable(if cc_pull != CcPull::SinkDeadBattery {
+                Ccenable::BOTH
+            } else {
+                Ccenable::DISABLED
+            });
+        });
+
+        // Disable dead-battery pull-down resistors which are enabled by default on boot.
+        critical_section::with(|_| {
+            // TODO: other families
+            #[cfg(stm32g4)]
+            pac::PWR
+                .cr3()
+                .modify(|w| w.set_ucpd1_dbdis(cc_pull != CcPull::SinkDeadBattery));
+        });
+
+        into_ref!(peri);
+        Self { _peri: peri }
+    }
+
+    /// Returns the current voltage level of CC1 and CC2 pin as tuple.
+    ///
+    /// Interpretation of the voltage levels depends on the configured CC line
+    /// pull-up/pull-down resistance.
+    pub fn cc_vstate(&self) -> (CcVState, CcVState) {
+        let sr = T::REGS.sr().read();
+        (sr.typec_vstate_cc1(), sr.typec_vstate_cc2())
+    }
+
+    /// Waits for a change in voltage state on either CC line.
+    pub async fn wait_for_cc_change(&mut self) {
+        let r = T::REGS;
+        poll_fn(|cx| {
+            let sr = r.sr().read();
+            if sr.typecevt1() || sr.typecevt2() {
+                r.icr().write(|w| {
+                    w.set_typecevt1cf(true);
+                    w.set_typecevt2cf(true);
+                });
+                Poll::Ready(())
+            } else {
+                T::waker().register(cx.waker());
+                r.imr().modify(|w| {
+                    w.set_typecevt1ie(true);
+                    w.set_typecevt2ie(true);
+                });
+                Poll::Pending
+            }
+        })
+        .await;
+    }
+}
 
 /// Interrupt handler.
 pub struct InterruptHandler<T: Instance> {
@@ -13,11 +168,17 @@ pub struct InterruptHandler<T: Instance> {
 
 impl<T: Instance> interrupt::typelevel::Handler<T::Interrupt> for InterruptHandler<T> {
     unsafe fn on_interrupt() {
-        let sr = T::REGS.sr().read();
+        let r = T::REGS;
+        let sr = r.sr().read();
 
-        // TODO: Disable interrupt which have fired.
+        if sr.typecevt1() || sr.typecevt2() {
+            r.imr().modify(|w| {
+                w.set_typecevt1ie(true);
+                w.set_typecevt2ie(true);
+            });
+        }
 
-        // Wake the task to handle and re-enabled interrupts.
+        // Wake the task to clear and re-enabled interrupts.
         T::waker().wake();
     }
 }

--- a/embassy-stm32/src/ucpd.rs
+++ b/embassy-stm32/src/ucpd.rs
@@ -1,20 +1,49 @@
 //! USB Type-C/USB Power Delivery Interface (UCPD)
 
+use core::marker::PhantomData;
+
+use crate::interrupt;
 use crate::rcc::RccPeripheral;
+use embassy_sync::waitqueue::AtomicWaker;
+
+/// Interrupt handler.
+pub struct InterruptHandler<T: Instance> {
+    _phantom: PhantomData<T>,
+}
+
+impl<T: Instance> interrupt::typelevel::Handler<T::Interrupt> for InterruptHandler<T> {
+    unsafe fn on_interrupt() {
+        let sr = T::REGS.sr().read();
+
+        // TODO: Disable interrupt which have fired.
+
+        // Wake the task to handle and re-enabled interrupts.
+        T::waker().wake();
+    }
+}
 
 /// UCPD instance trait.
 pub trait Instance: sealed::Instance + RccPeripheral {}
 
 pub(crate) mod sealed {
     pub trait Instance {
+        type Interrupt: crate::interrupt::typelevel::Interrupt;
         const REGS: crate::pac::ucpd::Ucpd;
+        fn waker() -> &'static embassy_sync::waitqueue::AtomicWaker;
     }
 }
 
-foreach_peripheral!(
-    (ucpd, $inst:ident) => {
+foreach_interrupt!(
+    ($inst:ident, ucpd, UCPD, GLOBAL, $irq:ident) => {
         impl sealed::Instance for crate::peripherals::$inst {
+            type Interrupt = crate::interrupt::typelevel::$irq;
+
             const REGS: crate::pac::ucpd::Ucpd = crate::pac::$inst;
+
+            fn waker() -> &'static AtomicWaker {
+                static WAKER: AtomicWaker = AtomicWaker::new();
+                &WAKER
+            }
         }
 
         impl Instance for crate::peripherals::$inst {}

--- a/embassy-stm32/src/ucpd.rs
+++ b/embassy-stm32/src/ucpd.rs
@@ -1,0 +1,28 @@
+//! USB Type-C/USB Power Delivery Interface (UCPD)
+
+use crate::rcc::RccPeripheral;
+
+/// UCPD instance trait.
+pub trait Instance: sealed::Instance + RccPeripheral {}
+
+pub(crate) mod sealed {
+    pub trait Instance {
+        const REGS: crate::pac::ucpd::Ucpd;
+    }
+}
+
+foreach_peripheral!(
+    (ucpd, $inst:ident) => {
+        impl sealed::Instance for crate::peripherals::$inst {
+            const REGS: crate::pac::ucpd::Ucpd = crate::pac::$inst;
+        }
+
+        impl Instance for crate::peripherals::$inst {}
+    };
+);
+
+pin_trait!(Cc1Pin, Instance);
+pin_trait!(Cc2Pin, Instance);
+
+dma_trait!(TxDma, Instance);
+dma_trait!(RxDma, Instance);

--- a/examples/stm32g4/src/bin/usb_c_pd.rs
+++ b/examples/stm32g4/src/bin/usb_c_pd.rs
@@ -1,7 +1,7 @@
 #![no_std]
 #![no_main]
 
-use defmt::{info, Format};
+use defmt::{error, info, Format};
 use embassy_executor::Spawner;
 use embassy_stm32::ucpd::{self, CcPull, CcSel, CcVState, Ucpd};
 use embassy_stm32::Config;
@@ -69,5 +69,12 @@ async fn main(_spawner: Spawner) {
     };
     let mut pd_phy = ucpd.pd_phy(p.DMA1_CH1, p.DMA1_CH2, cc_sel);
 
-    loop {}
+    loop {
+        // Enough space for the longest non-extended data message.
+        let mut buf = [0_u8; 30];
+        match pd_phy.receive(buf.as_mut()).await {
+            Ok(n) => info!("USB PD RX: {=[u8]:?}", &buf[..n]),
+            Err(e) => error!("USB PD RX: {}", e),
+        }
+    }
 }

--- a/examples/stm32g4/src/bin/usb_c_pd.rs
+++ b/examples/stm32g4/src/bin/usb_c_pd.rs
@@ -1,0 +1,62 @@
+#![no_std]
+#![no_main]
+
+use defmt::{info, Format};
+use embassy_executor::Spawner;
+use embassy_stm32::{
+    ucpd::{self, CcPull, CcVState, Ucpd},
+    Config,
+};
+use embassy_time::{with_timeout, Duration};
+use {defmt_rtt as _, panic_probe as _};
+
+#[derive(Debug, Format)]
+enum CableOrientation {
+    Normal,
+    Flipped,
+    DebugAccessoryMode,
+}
+
+// Returns true when the cable
+async fn wait_attached<'d, T: ucpd::Instance>(ucpd: &mut Ucpd<'d, T>) -> CableOrientation {
+    loop {
+        let (cc1, cc2) = ucpd.cc_vstate();
+        if cc1 == CcVState::LOWEST && cc2 == CcVState::LOWEST {
+            // Detached, wait until attached by monitoring the CC lines.
+            ucpd.wait_for_cc_change().await;
+            continue;
+        }
+
+        // Attached, wait for CC lines to be stable for tCCDebounce (100..200ms).
+        if with_timeout(Duration::from_millis(100), ucpd.wait_for_cc_change())
+            .await
+            .is_ok()
+        {
+            // State has changed, restart detection procedure.
+            continue;
+        };
+
+        // State was stable for the complete debounce period, check orientation.
+        return match (cc1, cc2) {
+            (_, CcVState::LOWEST) => CableOrientation::Normal,  // CC1 connected
+            (CcVState::LOWEST, _) => CableOrientation::Flipped, // CC2 connected
+            _ => CableOrientation::DebugAccessoryMode,          // Both connected (special cable)
+        };
+    }
+}
+
+#[embassy_executor::main]
+async fn main(_spawner: Spawner) {
+    // TODO: Disable DBCC pin functionality by default but have flag in the config to keep it enabled when required.
+    let p = embassy_stm32::init(Config::default());
+
+    info!("Hello World!");
+
+    let mut ucpd = Ucpd::new(p.UCPD1, p.PB6, p.PB4, CcPull::Sink);
+
+    info!("Waiting for USB connection...");
+    let cable_orientation = wait_attached(&mut ucpd).await;
+    info!("USB cable connected, orientation: {}", cable_orientation);
+
+    loop {}
+}

--- a/examples/stm32g4/src/bin/usb_c_pd.rs
+++ b/examples/stm32g4/src/bin/usb_c_pd.rs
@@ -67,7 +67,7 @@ async fn main(_spawner: Spawner) {
         }
         CableOrientation::DebugAccessoryMode => panic!("No PD communication in DAM"),
     };
-    let (mut _rx, mut _tx) = ucpd.pd(p.DMA1_CH1, p.DMA1_CH2, cc_sel);
+    let mut pd_phy = ucpd.pd_phy(p.DMA1_CH1, p.DMA1_CH2, cc_sel);
 
     loop {}
 }

--- a/examples/stm32g4/src/bin/usb_c_pd.rs
+++ b/examples/stm32g4/src/bin/usb_c_pd.rs
@@ -49,8 +49,9 @@ async fn wait_attached<T: ucpd::Instance>(cc_phy: &mut CcPhy<'_, T>) -> CableOri
 
 #[embassy_executor::main]
 async fn main(_spawner: Spawner) {
-    // TODO: Disable DBCC pin functionality by default but have flag in the config to keep it enabled when required.
-    let p = embassy_stm32::init(Config::default());
+    let mut config = Config::default();
+    config.enable_ucpd1_dead_battery = true;
+    let p = embassy_stm32::init(config);
 
     info!("Hello World!");
 

--- a/examples/stm32g4/src/bin/usb_c_pd.rs
+++ b/examples/stm32g4/src/bin/usb_c_pd.rs
@@ -4,9 +4,13 @@
 use defmt::{error, info, Format};
 use embassy_executor::Spawner;
 use embassy_stm32::ucpd::{self, CcPhy, CcPull, CcSel, CcVState, Ucpd};
-use embassy_stm32::Config;
+use embassy_stm32::{bind_interrupts, peripherals, Config};
 use embassy_time::{with_timeout, Duration};
 use {defmt_rtt as _, panic_probe as _};
+
+bind_interrupts!(struct Irqs {
+    UCPD1 => ucpd::InterruptHandler<peripherals::UCPD1>;
+});
 
 #[derive(Debug, Format)]
 enum CableOrientation {
@@ -50,7 +54,7 @@ async fn main(_spawner: Spawner) {
 
     info!("Hello World!");
 
-    let mut ucpd = Ucpd::new(p.UCPD1, p.PB6, p.PB4);
+    let mut ucpd = Ucpd::new(p.UCPD1, Irqs {}, p.PB6, p.PB4);
     ucpd.cc_phy().set_pull(CcPull::Sink);
 
     info!("Waiting for USB connection...");


### PR DESCRIPTION
Draft until my [hardware for testing arrives](https://www.cnx-software.com/2024/03/01/weact-stm32g4-tiny-board-stm32g4-mixed-signal-microcontroller/).

- [x] Type-C Pull-Up/Pull-Down resistor configuration
- [x] Type-C CC voltage detection
- [x] PD message reception
- [x] PD message transmission
- [x] Check for received hard reset in `transmit()` and `receive()`
- [x] Method to send a hard reset
- [x] Dead-battery resistor disable for other families than G4, see #2683
- [x] Allow to change and monitor CC resistors and voltages when PD phy is enabled (required for PD 3.0 collision detection, PD2.0 does not need this)
- [x] ~~Support for SOP' and SOP'' cable messages~~ Follow up PR
- [x] Testing!