### PR TITLE
docs: clarify capabilities of zerocopy channel

### DIFF
--- a/embassy-sync/src/zerocopy_channel.rs
+++ b/embassy-sync/src/zerocopy_channel.rs
@@ -1,10 +1,7 @@
 //! A zero-copy queue for sending values between asynchronous tasks.
 //!
-//! It can be used concurrently by multiple producers (senders) and multiple
-//! consumers (receivers), i.e. it is an  "MPMC channel".
-//!
-//! Receivers are competing for messages. So a message that is received by
-//! one receiver is not received by any other.
+//! It can be used concurrently by a producer (sender) and a
+//! consumer (receiver), i.e. it is an  "SPSC channel".
 //!
 //! This queue takes a Mutex type so that various
 //! targets can be attained. For example, a ThreadModeMutex can be used


### PR DESCRIPTION
Even though you can borrow() senders and receivers, they are borrow'ed &mut, so you cannot use more than one. And looking at the fn send implementation, it doesn't look like multiple senders would be safe, as it would hand out the same &mut slice to two senders? I've gone through this a few times in my head now and reached the same conclusion, but happy to be proven wrong!

(Specifically:  https://github.com/embassy-rs/embassy/blob/main/embassy-sync/src/zerocopy_channel.rs#L129) 