### PR TITLE
Update stm32c0 HSI frequency

### DIFF
--- a/embassy-stm32/src/rcc/c0.rs
+++ b/embassy-stm32/src/rcc/c0.rs
@@ -6,7 +6,7 @@ use crate::pac::{FLASH, RCC};
 use crate::time::Hertz;
 
 /// HSI speed
-pub const HSI_FREQ: Hertz = Hertz(16_000_000);
+pub const HSI_FREQ: Hertz = Hertz(48_000_000);
 
 /// HSE Mode
 #[derive(Clone, Copy, Eq, PartialEq)]


### PR DESCRIPTION
The HSI frequency should be 48 MHz, not 16. I checked the datasheets for both STM32C011x4/x6 and STM32C031x4/x6.