### PR TITLE
Remove personal preferences regarding editor settings

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,5 +1,4 @@
 {
-  "editor.formatOnSave": true,
   "[toml]": {
     "editor.formatOnSave": false
   },


### PR DESCRIPTION
I personally don't like using _format on save_. I also personally hit ctrl+s after basically every character I type. Other people use editors differently and have different preferences. That's why we let people choose what they prefer and not force it upon them when they open this repository in code.