### PR TITLE
stm32/rcc: wait for peripheral clock to be active. also, hold the peripheral reset while enabling the clock.

### DIFF
--- a/embassy-stm32/build.rs
+++ b/embassy-stm32/build.rs
@@ -509,25 +509,20 @@ fn main() {
         if let Some(rcc) = &p.rcc {
             let en = rcc.enable.as_ref().unwrap();
 
-            let rst = match &rcc.reset {
+            let (start_rst, end_rst) = match &rcc.reset {
                 Some(rst) => {
                     let rst_reg = format_ident!("{}", rst.register.to_ascii_lowercase());
                     let set_rst_field = format_ident!("set_{}", rst.field.to_ascii_lowercase());
-                    quote! {
-                        crate::pac::RCC.#rst_reg().modify(|w| w.#set_rst_field(true));
-                        crate::pac::RCC.#rst_reg().modify(|w| w.#set_rst_field(false));
-                    }
+                    (
+                        quote! {
+                            crate::pac::RCC.#rst_reg().modify(|w| w.#set_rst_field(true));
+                        },
+                        quote! {
+                            crate::pac::RCC.#rst_reg().modify(|w| w.#set_rst_field(false));
+                        },
+                    )
                 }
-                None => TokenStream::new(),
-            };
-
-            let after_enable = if chip_name.starts_with("stm32f2") {
-                // Errata: ES0005 - 2.1.11 Delay after an RCC peripheral clock enabling
-                quote! {
-                    cortex_m::asm::dsb();
-                }
-            } else {
-                TokenStream::new()
+                None => (TokenStream::new(), TokenStream::new()),
             };
 
             let ptype = if let Some(reg) = &p.registers { reg.kind } else { "" };
@@ -596,9 +591,26 @@ fn main() {
                     fn enable_and_reset_with_cs(_cs: critical_section::CriticalSection) {
                         #before_enable
                         #incr_stop_refcount
+
+                        #start_rst
+
                         crate::pac::RCC.#en_reg().modify(|w| w.#set_en_field(true));
-                        #after_enable
-                        #rst
+                        // dummy read to ensure write is completed
+                        let _ = crate::pac::RCC.#en_reg().read();
+
+                        // wait two peripheral clock cycles before the clock is active
+                        // accomplish this with two dummy reads from the peripheral. this shouldn't
+                        // cause any side effects since the peripheral is in reset
+                        unsafe {
+                            //apparently volatile accesses to ZST like () can be optimized out. lol
+                            let ptr = crate::pac::#pname.as_ptr() as *const usize;
+                            let _ = ::core::ptr::read_volatile(ptr);
+                            let _ = ::core::ptr::read_volatile(ptr);
+                            // wait for memory accesses to finish
+                            ::core::arch::asm!("dmb");
+                        }
+
+                        #end_rst
                     }
                     fn disable_with_cs(_cs: critical_section::CriticalSection) {
                         #before_disable

--- a/embassy-stm32/build.rs
+++ b/embassy-stm32/build.rs
@@ -607,7 +607,7 @@ fn main() {
                             let _ = ::core::ptr::read_volatile(ptr);
                             let _ = ::core::ptr::read_volatile(ptr);
                             // wait for memory accesses to finish
-                            ::core::arch::asm!("dmb");
+                            cortex_m::asm::dsb();
                         }
 
                         #end_rst


### PR DESCRIPTION
Was looking through the RCC codegen when I was nerdsniped by the mention of an errata. After a bit of digging into it I discovered the situation already well described here: http://efton.sk/STM32/gotcha/g183.html including some forum posts where people have actually had issues: to be clear I haven't, and wasn't able to repro anything after some trying on my STM32G071, but that may be because that chip is too slow and/or simple. The only attempt at an Actually Correct implementation I found was here: https://community.st.com/t5/stm32-mcus-embedded-software/stm32-clock-and-delay-helper-functions/td-p/593082

Currently embassy-stm32 only mitigates this with a DSB on STM32F2: if nothing else it should be doing that on all chips since this is an errata on more chips than just F2 and a feature on everything else. Current RMs say you need to delay for 2 clock cycles (presumably peripheral clock cycles) for the peripheral clock to become active and peripheral read or write accesses to be supported. I'm not too confident about the approach taken in this PR, but I think it is at least overly conservative. I don't have much of an understanding of how exactly wait states and peripheral buses etc work.

I also changed the peripheral reset, starting it before the clock and stopping it after: I think a small "glitch" cooould have been possible before, if a peripheral had been configured and then disabled, the old config would have been enabled briefly between the clock enable and the reset. If nothing else this feels a little bit more robust to me.