### PR TITLE
Configurable DMA Request Priority

### DIFF
--- a/embassy-stm32/src/dma/dma_bdma.rs
+++ b/embassy-stm32/src/dma/dma_bdma.rs
@@ -10,8 +10,7 @@ use super::ringbuffer::{DmaCtrl, OverrunError, ReadableDmaRingBuffer, WritableDm
 use super::word::{Word, WordSize};
 use super::{AnyChannel, Channel, Dir, Request, STATE};
 use crate::interrupt::typelevel::Interrupt;
-use crate::interrupt;
-use crate::pac;
+use crate::{interrupt, pac};
 
 pub(crate) struct ChannelInfo {
     pub(crate) dma: DmaInfo,
@@ -74,6 +73,44 @@ impl Default for TransferOptions {
             circular: false,
             half_transfer_ir: false,
             complete_transfer_ir: true,
+        }
+    }
+}
+
+/// DMA request priority
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+pub enum Priority {
+    /// Low Priority
+    Low,
+    /// Medium Priority
+    Medium,
+    /// High Priority
+    High,
+    /// Very High Priority
+    VeryHigh,
+}
+
+#[cfg(dma)]
+impl From<Priority> for pac::dma::vals::Pl {
+    fn from(value: Priority) -> Self {
+        match value {
+            Priority::Low => pac::dma::vals::Pl::LOW,
+            Priority::Medium => pac::dma::vals::Pl::MEDIUM,
+            Priority::High => pac::dma::vals::Pl::HIGH,
+            Priority::VeryHigh => pac::dma::vals::Pl::VERYHIGH,
+        }
+    }
+}
+
+#[cfg(bdma)]
+impl From<Priority> for pac::bdma::vals::Pl {
+    fn from(value: Priority) -> Self {
+        match value {
+            Priority::Low => pac::bdma::vals::Pl::LOW,
+            Priority::Medium => pac::bdma::vals::Pl::MEDIUM,
+            Priority::High => pac::bdma::vals::Pl::HIGH,
+            Priority::VeryHigh => pac::bdma::vals::Pl::VERYHIGH,
         }
     }
 }
@@ -173,31 +210,6 @@ mod dma_only {
             }
         }
     }
-
-    /// DMA request priority
-    #[derive(Debug, Copy, Clone, PartialEq, Eq)]
-    #[cfg_attr(feature = "defmt", derive(defmt::Format))]
-    pub enum Priority {
-        /// Low Priority
-        Low,
-        /// Medium Priority
-        Medium,
-        /// High Priority
-        High,
-        /// Very High Priority
-        VeryHigh,
-    }
-
-    impl From<Priority> for vals::Pl {
-        fn from(value: Priority) -> Self {
-            match value {
-                Priority::Low => vals::Pl::LOW,
-                Priority::Medium => vals::Pl::MEDIUM,
-                Priority::High => vals::Pl::HIGH,
-                Priority::VeryHigh => vals::Pl::VERYHIGH,
-            }
-        }
-    }
 }
 
 #[cfg(bdma)]
@@ -221,31 +233,6 @@ mod bdma_only {
             match raw {
                 Dir::MemoryToPeripheral => Self::FROMMEMORY,
                 Dir::PeripheralToMemory => Self::FROMPERIPHERAL,
-            }
-        }
-    }
-
-    /// DMA request priority
-    #[derive(Debug, Copy, Clone, PartialEq, Eq)]
-    #[cfg_attr(feature = "defmt", derive(defmt::Format))]
-    pub enum Priority {
-        /// Low Priority
-        Low,
-        /// Medium Priority
-        Medium,
-        /// High Priority
-        High,
-        /// Very High Priority
-        VeryHigh,
-    }
-
-    impl From<Priority> for vals::Pl {
-        fn from(value: Priority) -> Self {
-            match value {
-                Priority::Low => vals::Pl::LOW,
-                Priority::Medium => vals::Pl::MEDIUM,
-                Priority::High => vals::Pl::HIGH,
-                Priority::VeryHigh => vals::Pl::VERYHIGH,
             }
         }
     }

--- a/embassy-stm32/src/dma/dma_bdma.rs
+++ b/embassy-stm32/src/dma/dma_bdma.rs
@@ -10,7 +10,7 @@ use super::ringbuffer::{DmaCtrl, OverrunError, ReadableDmaRingBuffer, WritableDm
 use super::word::{Word, WordSize};
 use super::{AnyChannel, Channel, Dir, Request, STATE};
 use crate::interrupt::typelevel::Interrupt;
-use crate::interrupt::Priority;
+use crate::interrupt;
 use crate::pac;
 
 pub(crate) struct ChannelInfo {
@@ -45,6 +45,8 @@ pub struct TransferOptions {
     /// FIFO threshold for DMA FIFO mode. If none, direct mode is used.
     #[cfg(dma)]
     pub fifo_threshold: Option<FifoThreshold>,
+    /// Request priority level
+    pub priority: Priority,
     /// Enable circular DMA
     ///
     /// Note:
@@ -68,6 +70,7 @@ impl Default for TransferOptions {
             flow_ctrl: FlowControl::Dma,
             #[cfg(dma)]
             fifo_threshold: None,
+            priority: Priority::VeryHigh,
             circular: false,
             half_transfer_ir: false,
             complete_transfer_ir: true,
@@ -170,6 +173,31 @@ mod dma_only {
             }
         }
     }
+
+    /// DMA request priority
+    #[derive(Debug, Copy, Clone, PartialEq, Eq)]
+    #[cfg_attr(feature = "defmt", derive(defmt::Format))]
+    pub enum Priority {
+        /// Low Priority
+        Low,
+        /// Medium Priority
+        Medium,
+        /// High Priority
+        High,
+        /// Very High Priority
+        VeryHigh,
+    }
+
+    impl From<Priority> for vals::Pl {
+        fn from(value: Priority) -> Self {
+            match value {
+                Priority::Low => vals::Pl::LOW,
+                Priority::Medium => vals::Pl::MEDIUM,
+                Priority::High => vals::Pl::HIGH,
+                Priority::VeryHigh => vals::Pl::VERYHIGH,
+            }
+        }
+    }
 }
 
 #[cfg(bdma)]
@@ -196,6 +224,31 @@ mod bdma_only {
             }
         }
     }
+
+    /// DMA request priority
+    #[derive(Debug, Copy, Clone, PartialEq, Eq)]
+    #[cfg_attr(feature = "defmt", derive(defmt::Format))]
+    pub enum Priority {
+        /// Low Priority
+        Low,
+        /// Medium Priority
+        Medium,
+        /// High Priority
+        High,
+        /// Very High Priority
+        VeryHigh,
+    }
+
+    impl From<Priority> for vals::Pl {
+        fn from(value: Priority) -> Self {
+            match value {
+                Priority::Low => vals::Pl::LOW,
+                Priority::Medium => vals::Pl::MEDIUM,
+                Priority::High => vals::Pl::HIGH,
+                Priority::VeryHigh => vals::Pl::VERYHIGH,
+            }
+        }
+    }
 }
 
 pub(crate) struct ChannelState {
@@ -213,8 +266,8 @@ impl ChannelState {
 /// safety: must be called only once
 pub(crate) unsafe fn init(
     cs: critical_section::CriticalSection,
-    #[cfg(dma)] dma_priority: Priority,
-    #[cfg(bdma)] bdma_priority: Priority,
+    #[cfg(dma)] dma_priority: interrupt::Priority,
+    #[cfg(bdma)] bdma_priority: interrupt::Priority,
 ) {
     foreach_interrupt! {
         ($peri:ident, dma, $block:ident, $signal_name:ident, $irq:ident) => {
@@ -334,7 +387,7 @@ impl AnyChannel {
                     w.set_dir(dir.into());
                     w.set_msize(data_size.into());
                     w.set_psize(data_size.into());
-                    w.set_pl(pac::dma::vals::Pl::VERYHIGH);
+                    w.set_pl(options.priority.into());
                     w.set_minc(incr_mem);
                     w.set_pinc(false);
                     w.set_teie(true);
@@ -374,7 +427,7 @@ impl AnyChannel {
                     w.set_tcie(options.complete_transfer_ir);
                     w.set_htie(options.half_transfer_ir);
                     w.set_circ(options.circular);
-                    w.set_pl(pac::bdma::vals::Pl::VERYHIGH);
+                    w.set_pl(options.priority.into());
                     w.set_en(false); // don't start yet
                 });
             }

--- a/embassy-stm32/src/dma/mod.rs
+++ b/embassy-stm32/src/dma/mod.rs
@@ -23,7 +23,7 @@ use core::mem;
 
 use embassy_hal_internal::{impl_peripheral, Peripheral};
 
-use crate::interrupt::Priority;
+use crate::interrupt;
 
 #[derive(Debug, Copy, Clone, PartialEq, Eq)]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
@@ -131,9 +131,9 @@ pub(crate) fn slice_ptr_parts_mut<T>(slice: *mut [T]) -> (usize, usize) {
 // safety: must be called only once at startup
 pub(crate) unsafe fn init(
     cs: critical_section::CriticalSection,
-    #[cfg(bdma)] bdma_priority: Priority,
-    #[cfg(dma)] dma_priority: Priority,
-    #[cfg(gpdma)] gpdma_priority: Priority,
+    #[cfg(bdma)] bdma_priority: interrupt::Priority,
+    #[cfg(dma)] dma_priority: interrupt::Priority,
+    #[cfg(gpdma)] gpdma_priority: interrupt::Priority,
 ) {
     #[cfg(any(dma, bdma))]
     dma_bdma::init(

--- a/embassy-stm32/src/sdmmc/mod.rs
+++ b/embassy-stm32/src/sdmmc/mod.rs
@@ -240,6 +240,7 @@ const DMA_TRANSFER_OPTIONS: crate::dma::TransferOptions = crate::dma::TransferOp
     mburst: crate::dma::Burst::Incr4,
     flow_ctrl: crate::dma::FlowControl::Peripheral,
     fifo_threshold: Some(crate::dma::FifoThreshold::Full),
+    priority: crate::dma::Priority::VeryHigh,
     circular: false,
     half_transfer_ir: false,
     complete_transfer_ir: true,

--- a/embassy-stm32/src/sdmmc/mod.rs
+++ b/embassy-stm32/src/sdmmc/mod.rs
@@ -247,6 +247,7 @@ const DMA_TRANSFER_OPTIONS: crate::dma::TransferOptions = crate::dma::TransferOp
 };
 #[cfg(all(sdmmc_v1, not(dma)))]
 const DMA_TRANSFER_OPTIONS: crate::dma::TransferOptions = crate::dma::TransferOptions {
+    priority: crate::dma::Priority::VeryHigh,
     circular: false,
     half_transfer_ir: false,
     complete_transfer_ir: true,


### PR DESCRIPTION
Adds DMA request priority as transfer option, while maintaining the current setting of `VERYHIGH` as the default.

Currently, all DMA transfers are set to the highest priority level and is not configurable. This is acceptable for most use cases but there are cases where priority must be configured for peripheral DMA to work properly, such as the CRYP peripheral. From ST manual RM0410:

> It is important that DMA controller empties the cryptographic processor output FIFO before filling up the cryptographic processor input FIFO. To achieve this, the DMA controller should be configured so that the transfer from the cryptographic peripheral to the memory has a higher priority than the transfer from the memory to the cryptographic peripheral.