### PR TITLE
Add small Delay to STM32F1 ADC to avoid lockup

### DIFF
--- a/embassy-stm32/src/adc/f1.rs
+++ b/embassy-stm32/src/adc/f1.rs
@@ -3,6 +3,7 @@ use core::marker::PhantomData;
 use core::task::Poll;
 
 use embassy_hal_internal::into_ref;
+use embassy_time::Timer;
 use embedded_hal_02::blocking::delay::DelayUs;
 
 use crate::adc::{Adc, AdcPin, Instance, SampleTime};
@@ -120,6 +121,8 @@ impl<'d, T: Instance> Adc<'d, T> {
             reg.set_swstart(true);
         });
         T::regs().cr1().modify(|w| w.set_eocie(true));
+
+        Timer::after_ticks(1).await;
 
         poll_fn(|cx| {
             T::state().waker.register(cx.waker());


### PR DESCRIPTION
Added a one tick delay to the `convert` function of the STM32F1 ADC implementation.
Prior the `convert` function didn't return a value causing a infinite await.

I'm only getting started with rust embedded, so please take the following statement cautious: I think this bug exists because the timer registers weren't set fast enough, causing the interrupt registration to be ignored.

related Issues:
- #2162