### PR TITLE
STM32 CRYP DMA

### DIFF
--- a/embassy-stm32/build.rs
+++ b/embassy-stm32/build.rs
@@ -1121,6 +1121,8 @@ fn main() {
         (("dac", "CH2"), quote!(crate::dac::DacDma2)),
         (("timer", "UP"), quote!(crate::timer::UpDma)),
         (("hash", "IN"), quote!(crate::hash::Dma)),
+        (("cryp", "IN"), quote!(crate::cryp::DmaIn)),
+        (("cryp", "OUT"), quote!(crate::cryp::DmaOut)),
         (("timer", "CH1"), quote!(crate::timer::Ch1Dma)),
         (("timer", "CH2"), quote!(crate::timer::Ch2Dma)),
         (("timer", "CH3"), quote!(crate::timer::Ch3Dma)),

--- a/examples/stm32f7/src/bin/cryp.rs
+++ b/examples/stm32f7/src/bin/cryp.rs
@@ -44,7 +44,9 @@ async fn main(_spawner: Spawner) -> ! {
     // Decrypt in hardware using AES-GCM 128-bit
     let mut gcm_decrypt = hw_cryp.start(&aes_gcm, Direction::Decrypt).await;
     hw_cryp.aad(&mut gcm_decrypt, aad, true).await;
-    hw_cryp.payload(&mut gcm_decrypt, &ciphertext, &mut plaintext, true).await;
+    hw_cryp
+        .payload(&mut gcm_decrypt, &ciphertext, &mut plaintext, true)
+        .await;
     let decrypt_tag = hw_cryp.finish(gcm_decrypt).await;
 
     let hw_end_time = Instant::now();

--- a/examples/stm32f7/src/bin/cryp.rs
+++ b/examples/stm32f7/src/bin/cryp.rs
@@ -6,11 +6,8 @@ use aes_gcm::aead::{AeadInPlace, KeyInit};
 use aes_gcm::Aes128Gcm;
 use defmt::info;
 use embassy_executor::Spawner;
-use embassy_stm32::{
-    bind_interrupts,
-    cryp::{self, *},
-};
-use embassy_stm32::{peripherals, Config};
+use embassy_stm32::cryp::{self, *};
+use embassy_stm32::{bind_interrupts, peripherals, Config};
 use embassy_time::Instant;
 use {defmt_rtt as _, panic_probe as _};
 

--- a/examples/stm32f7/src/bin/cryp.rs
+++ b/examples/stm32f7/src/bin/cryp.rs
@@ -6,10 +6,18 @@ use aes_gcm::aead::{AeadInPlace, KeyInit};
 use aes_gcm::Aes128Gcm;
 use defmt::info;
 use embassy_executor::Spawner;
-use embassy_stm32::cryp::*;
-use embassy_stm32::Config;
+use embassy_stm32::dma::NoDma;
+use embassy_stm32::{
+    bind_interrupts,
+    cryp::{self, *},
+};
+use embassy_stm32::{peripherals, Config};
 use embassy_time::Instant;
 use {defmt_rtt as _, panic_probe as _};
+
+bind_interrupts!(struct Irqs {
+    CRYP => cryp::InterruptHandler<peripherals::CRYP>;
+});
 
 #[embassy_executor::main]
 async fn main(_spawner: Spawner) -> ! {
@@ -19,7 +27,7 @@ async fn main(_spawner: Spawner) -> ! {
     let payload: &[u8] = b"hello world";
     let aad: &[u8] = b"additional data";
 
-    let hw_cryp = Cryp::new(p.CRYP);
+    let hw_cryp = Cryp::new(p.CRYP, NoDma, NoDma, Irqs);
     let key: [u8; 16] = [0; 16];
     let mut ciphertext: [u8; 11] = [0; 11];
     let mut plaintext: [u8; 11] = [0; 11];

--- a/tests/stm32/src/bin/cryp.rs
+++ b/tests/stm32/src/bin/cryp.rs
@@ -10,8 +10,16 @@ use aes_gcm::aead::{AeadInPlace, KeyInit};
 use aes_gcm::Aes128Gcm;
 use common::*;
 use embassy_executor::Spawner;
-use embassy_stm32::cryp::*;
+use embassy_stm32::{
+    bind_interrupts,
+    cryp::{self, *},
+    peripherals
+};
 use {defmt_rtt as _, panic_probe as _};
+
+bind_interrupts!(struct Irqs {
+    CRYP => cryp::InterruptHandler<peripherals::CRYP>;
+});
 
 #[embassy_executor::main]
 async fn main(_spawner: Spawner) {
@@ -22,27 +30,30 @@ async fn main(_spawner: Spawner) {
     const AAD1: &[u8] = b"additional data 1 stdargadrhaethaethjatjatjaetjartjstrjsfkk;'jopofyuisrteytweTASTUIKFUKIXTRDTEREharhaeryhaterjartjarthaethjrtjarthaetrhartjatejatrjsrtjartjyt1";
     const AAD2: &[u8] = b"additional data 2 stdhthsthsthsrthsrthsrtjdykjdukdyuldadfhsdghsdghsdghsadghjk'hioethjrtjarthaetrhartjatecfgjhzdfhgzdfhzdfghzdfhzdfhzfhjatrjsrtjartjytjfytjfyg";
 
-    let hw_cryp = Cryp::new(p.CRYP);
+    let in_dma = peri!(p, CRYP_IN_DMA);
+    let out_dma = peri!(p, CRYP_OUT_DMA);
+
+    let mut hw_cryp = Cryp::new(p.CRYP, in_dma, out_dma, Irqs);
     let key: [u8; 16] = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16];
     let mut ciphertext: [u8; PAYLOAD1.len() + PAYLOAD2.len()] = [0; PAYLOAD1.len() + PAYLOAD2.len()];
     let mut plaintext: [u8; PAYLOAD1.len() + PAYLOAD2.len()] = [0; PAYLOAD1.len() + PAYLOAD2.len()];
     let iv: [u8; 12] = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12];
 
-    // Encrypt in hardware using AES-GCM 128-bit
+    // Encrypt in hardware using AES-GCM 128-bit in blocking mode.
     let aes_gcm = AesGcm::new(&key, &iv);
-    let mut gcm_encrypt = hw_cryp.start(&aes_gcm, Direction::Encrypt);
+    let mut gcm_encrypt = hw_cryp.start_blocking(&aes_gcm, Direction::Encrypt);
     hw_cryp.aad_blocking(&mut gcm_encrypt, AAD1, false);
     hw_cryp.aad_blocking(&mut gcm_encrypt, AAD2, true);
     hw_cryp.payload_blocking(&mut gcm_encrypt, PAYLOAD1, &mut ciphertext[..PAYLOAD1.len()], false);
     hw_cryp.payload_blocking(&mut gcm_encrypt, PAYLOAD2, &mut ciphertext[PAYLOAD1.len()..], true);
     let encrypt_tag = hw_cryp.finish_blocking(gcm_encrypt);
 
-    // Decrypt in hardware using AES-GCM 128-bit
-    let mut gcm_decrypt = hw_cryp.start(&aes_gcm, Direction::Decrypt);
-    hw_cryp.aad_blocking(&mut gcm_decrypt, AAD1, false);
-    hw_cryp.aad_blocking(&mut gcm_decrypt, AAD2, true);
-    hw_cryp.payload_blocking(&mut gcm_decrypt, &ciphertext, &mut plaintext, true);
-    let decrypt_tag = hw_cryp.finish_blocking(gcm_decrypt);
+    // Decrypt in hardware using AES-GCM 128-bit in async (DMA) mode.
+    let mut gcm_decrypt = hw_cryp.start(&aes_gcm, Direction::Decrypt).await;
+    hw_cryp.aad(&mut gcm_decrypt, AAD1, false).await;
+    hw_cryp.aad(&mut gcm_decrypt, AAD2, true).await;
+    hw_cryp.payload(&mut gcm_decrypt, &ciphertext, &mut plaintext, true).await;
+    let decrypt_tag = hw_cryp.finish(gcm_decrypt).await;
 
     info!("AES-GCM Ciphertext: {:?}", ciphertext);
     info!("AES-GCM Plaintext: {:?}", plaintext);

--- a/tests/stm32/src/bin/cryp.rs
+++ b/tests/stm32/src/bin/cryp.rs
@@ -13,7 +13,7 @@ use embassy_executor::Spawner;
 use embassy_stm32::{
     bind_interrupts,
     cryp::{self, *},
-    peripherals
+    peripherals,
 };
 use {defmt_rtt as _, panic_probe as _};
 
@@ -52,7 +52,9 @@ async fn main(_spawner: Spawner) {
     let mut gcm_decrypt = hw_cryp.start(&aes_gcm, Direction::Decrypt).await;
     hw_cryp.aad(&mut gcm_decrypt, AAD1, false).await;
     hw_cryp.aad(&mut gcm_decrypt, AAD2, true).await;
-    hw_cryp.payload(&mut gcm_decrypt, &ciphertext, &mut plaintext, true).await;
+    hw_cryp
+        .payload(&mut gcm_decrypt, &ciphertext, &mut plaintext, true)
+        .await;
     let decrypt_tag = hw_cryp.finish(gcm_decrypt).await;
 
     info!("AES-GCM Ciphertext: {:?}", ciphertext);

--- a/tests/stm32/src/bin/cryp.rs
+++ b/tests/stm32/src/bin/cryp.rs
@@ -10,11 +10,8 @@ use aes_gcm::aead::{AeadInPlace, KeyInit};
 use aes_gcm::Aes128Gcm;
 use common::*;
 use embassy_executor::Spawner;
-use embassy_stm32::{
-    bind_interrupts,
-    cryp::{self, *},
-    peripherals,
-};
+use embassy_stm32::cryp::{self, *};
+use embassy_stm32::{bind_interrupts, peripherals};
 use {defmt_rtt as _, panic_probe as _};
 
 bind_interrupts!(struct Irqs {

--- a/tests/stm32/src/common.rs
+++ b/tests/stm32/src/common.rs
@@ -140,6 +140,7 @@ define_peris!(
 );
 #[cfg(any(feature = "stm32h755zi", feature = "stm32h753zi"))]
 define_peris!(
+    CRYP_IN_DMA = DMA1_CH0, CRYP_OUT_DMA = DMA1_CH1,
     UART = USART1, UART_TX = PB6, UART_RX = PB7, UART_TX_DMA = DMA1_CH0, UART_RX_DMA = DMA1_CH1,
     SPI = SPI1, SPI_SCK = PA5, SPI_MOSI = PB5, SPI_MISO = PA6, SPI_TX_DMA = DMA1_CH0, SPI_RX_DMA = DMA1_CH1,
     ADC = ADC1, DAC = DAC1, DAC_PIN = PA4,


### PR DESCRIPTION
Adds async CRYP API using DMA for STM32. STM32F7 example is updated to use async API. CRYP test is updated so that encryption occurs in blocking mode, then decryption occurs in async mode.