### PR TITLE
Impl `MultiwriteNorFlash` for `BlockingAsync`

### DIFF
--- a/embassy-embedded-hal/src/adapter/blocking_async.rs
+++ b/embassy-embedded-hal/src/adapter/blocking_async.rs
@@ -104,8 +104,10 @@ where
 }
 
 /// NOR flash wrapper
-use embedded_storage::nor_flash::{ErrorType, NorFlash, ReadNorFlash};
-use embedded_storage_async::nor_flash::{NorFlash as AsyncNorFlash, ReadNorFlash as AsyncReadNorFlash};
+use embedded_storage::nor_flash::{ErrorType, MultiwriteNorFlash, NorFlash, ReadNorFlash};
+use embedded_storage_async::nor_flash::{
+    MultiwriteNorFlash as AsyncMultiwriteNorFlash, NorFlash as AsyncNorFlash, ReadNorFlash as AsyncReadNorFlash,
+};
 
 impl<T> ErrorType for BlockingAsync<T>
 where
@@ -143,3 +145,5 @@ where
         self.wrapped.capacity()
     }
 }
+
+impl<T> AsyncMultiwriteNorFlash for BlockingAsync<T> where T: MultiwriteNorFlash {}


### PR DESCRIPTION
According to https://github.com/rust-embedded-community/embedded-storage/blob/master/src/nor_flash.rs#L191, `MultiwriteNorFlash` trait adds nothing to `NorFlash`, it should be safe to impl `MultiwriteNorFlash` for `BlockingAsync`