### PR TITLE
Forward transaction() from blocking I2cDevice to underlying bus

### DIFF
--- a/embassy-embedded-hal/src/shared_bus/blocking/i2c.rs
+++ b/embassy-embedded-hal/src/shared_bus/blocking/i2c.rs
@@ -67,9 +67,11 @@ where
     }
 
     fn transaction<'a>(&mut self, address: u8, operations: &mut [Operation<'a>]) -> Result<(), Self::Error> {
-        let _ = address;
-        let _ = operations;
-        todo!()
+        self.bus.lock(|bus| {
+            bus.borrow_mut()
+                .transaction(address, operations)
+                .map_err(I2cDeviceError::I2c)
+        })
     }
 }
 
@@ -171,8 +173,10 @@ where
     }
 
     fn transaction<'a>(&mut self, address: u8, operations: &mut [Operation<'a>]) -> Result<(), Self::Error> {
-        let _ = address;
-        let _ = operations;
-        todo!()
+        self.bus.lock(|bus| {
+            let mut bus = bus.borrow_mut();
+            bus.set_config(&self.config).map_err(|_| I2cDeviceError::Config)?;
+            bus.transaction(address, operations).map_err(I2cDeviceError::I2c)
+        })
     }
 }


### PR DESCRIPTION
This implements `transaction()` for the blocking `I2cDevice` in `embassy-embedded-hal` in the same way that the remaining methods from the `I2c` trait are forwarded to the underlying bus.

It mirrors the already existing forwarding of `transaction()` in the implementation of the asynchronous `I2cDevice`.

This is part of an upcoming series of PRs that may eventually solve #1417.