### PR TITLE
Add comment warning for new users about changing pins on Ethernet for different devices + example of change

### DIFF
--- a/examples/stm32h7/src/bin/eth.rs
+++ b/examples/stm32h7/src/bin/eth.rs
@@ -70,15 +70,15 @@ async fn main(spawner: Spawner) -> ! {
         PACKETS.init(PacketQueue::<4, 4>::new()),
         p.ETH,
         Irqs,
-        p.PA1, // ref_clk
-        p.PA2, // mdio
-        p.PC1, // eth_mdc
-        p.PA7, // CRS_DV: Carrier Sense
-        p.PC4, // RX_D0: Received Bit 0
-        p.PC5, // RX_D1: Received Bit 1
-        p.PG13,// TX_D0: Transmit Bit 0
-        p.PB13,// TX_D1: Transmit Bit 1
-        p.PG11,// TX_EN: Transmit Enable
+        p.PA1,  // ref_clk
+        p.PA2,  // mdio
+        p.PC1,  // eth_mdc
+        p.PA7,  // CRS_DV: Carrier Sense
+        p.PC4,  // RX_D0: Received Bit 0
+        p.PC5,  // RX_D1: Received Bit 1
+        p.PG13, // TX_D0: Transmit Bit 0
+        p.PB13, // TX_D1: Transmit Bit 1
+        p.PG11, // TX_EN: Transmit Enable
         GenericSMI::new(0),
         mac_addr,
     );


### PR DESCRIPTION
Not all STM32H7 devices share the pins of the example. Added a warning and a specific example for STM32H747XIH