### PR TITLE
stm32: Fix psc compile error with current stm32-data

### DIFF
--- a/embassy-stm32/Cargo.toml
+++ b/embassy-stm32/Cargo.toml
@@ -70,7 +70,7 @@ rand_core = "0.6.3"
 sdio-host = "0.5.0"
 critical-section = "1.1"
 #stm32-metapac = { version = "15" }
-stm32-metapac = { git = "https://github.com/embassy-rs/stm32-data-generated", tag = "stm32-data-c8b32ecae7d70cea2705095c4fc6bd5f59d238d5" }
+stm32-metapac = { git = "https://github.com/embassy-rs/stm32-data-generated", tag = "stm32-data-f84633553331c2d154ee72de779a40cbb10fd1bd" }
 vcell = "0.1.3"
 nb = "1.0.0"
 stm32-fmc = "0.3.0"
@@ -94,7 +94,7 @@ critical-section = { version = "1.1", features = ["std"] }
 proc-macro2 = "1.0.36"
 quote = "1.0.15"
 #stm32-metapac = { version = "15", default-features = false, features = ["metadata"]}
-stm32-metapac = { git = "https://github.com/embassy-rs/stm32-data-generated", tag = "stm32-data-c8b32ecae7d70cea2705095c4fc6bd5f59d238d5", default-features = false, features = ["metadata"]}
+stm32-metapac = { git = "https://github.com/embassy-rs/stm32-data-generated", tag = "stm32-data-f84633553331c2d154ee72de779a40cbb10fd1bd", default-features = false, features = ["metadata"]}
 
 
 [features]

--- a/embassy-stm32/src/time_driver.rs
+++ b/embassy-stm32/src/time_driver.rs
@@ -286,7 +286,7 @@ impl RtcDriver {
             Ok(n) => n,
         };
 
-        r.psc().write(|w| w.set_psc(psc));
+        r.psc().write_value(psc);
         r.arr().write(|w| w.set_arr(u16::MAX));
 
         // Set URS, generate update and clear URS

--- a/embassy-stm32/src/timer/mod.rs
+++ b/embassy-stm32/src/timer/mod.rs
@@ -97,7 +97,7 @@ pub(crate) mod sealed {
             let arr = unwrap!(u16::try_from(divide_by - 1));
 
             let regs = Self::regs_core();
-            regs.psc().write(|r| r.set_psc(psc));
+            regs.psc().write_value(psc);
             regs.arr().write(|r| r.set_arr(arr));
 
             regs.cr1().modify(|r| r.set_urs(vals::Urs::COUNTERONLY));
@@ -137,7 +137,7 @@ pub(crate) mod sealed {
 
             let regs = Self::regs_core();
             let arr = regs.arr().read().arr();
-            let psc = regs.psc().read().psc();
+            let psc = regs.psc().read();
 
             timer_f / arr / (psc + 1)
         }
@@ -378,7 +378,7 @@ pub(crate) mod sealed {
             let arr: u32 = unwrap!((pclk_ticks_per_timer_period / (psc as u64 + 1)).try_into());
 
             let regs = Self::regs_gp32();
-            regs.psc().write(|r| r.set_psc(psc));
+            regs.psc().write_value(psc);
             regs.arr().write_value(arr);
 
             regs.cr1().modify(|r| r.set_urs(vals::Urs::COUNTERONLY));
@@ -392,7 +392,7 @@ pub(crate) mod sealed {
 
             let regs = Self::regs_gp32();
             let arr = regs.arr().read();
-            let psc = regs.psc().read().psc();
+            let psc = regs.psc().read();
 
             timer_f / arr / (psc + 1)
         }


### PR DESCRIPTION
Commit https://github.com/embassy-rs/stm32-data/commit/cc525f1b252c91272529cbea1d3d4399b43c60b4 has changed the definition of the `psc` register.
Update timer/mod.rs to and time_driver.rs reflect the stm32-data change.

Fixes #2698 