### PR TITLE
Forward the "std" feature to the critical-section crate in embassy-sync.

### DIFF
--- a/embassy-sync/Cargo.toml
+++ b/embassy-sync/Cargo.toml
@@ -20,7 +20,7 @@ src_base_git = "https://github.com/embassy-rs/embassy/blob/$COMMIT/embassy-sync/
 target = "thumbv7em-none-eabi"
 
 [features]
-std = []
+std = ["critical-section/std"]
 turbowakers = []
 
 [dependencies]


### PR DESCRIPTION
Currently, using `embassy-sync` in unit tests on a non-embedded platform will result in linker errors when using the `CriticalSectionRawMutex`.

Without forwarding this feature, the user needs to understand that `embassy-sync` uses the `critical-section` crate, and add a dependency on it just to enable the feature.

With this change, users can just enable the `"std"` feature in a dev dependency on `embassy-sync`, and the linker error will be resolved.