### PR TITLE
stm32-usb isochronous fix and overall better isochronous support

### DIFF
--- a/embassy-nrf/src/usb/mod.rs
+++ b/embassy-nrf/src/usb/mod.rs
@@ -771,7 +771,7 @@ impl Allocator {
         // Endpoint directions are allocated individually.
 
         let alloc_index = match ep_type {
-            EndpointType::Isochronous => 8,
+            EndpointType::Isochronous(_) => 8,
             EndpointType::Control => return Err(driver::EndpointAllocError),
             EndpointType::Interrupt | EndpointType::Bulk => {
                 // Find rightmost zero bit in 1..=7

--- a/embassy-rp/src/usb.rs
+++ b/embassy-rp/src/usb.rs
@@ -182,7 +182,7 @@ impl<'d, T: Instance> Driver<'d, T> {
 
         // as per datasheet, the maximum buffer size is 64, except for isochronous
         // endpoints, which are allowed to be up to 1023 bytes.
-        if (ep_type != EndpointType::Isochronous && max_packet_size > 64) || max_packet_size > 1023 {
+        if (!matches!(ep_type, EndpointType::Isochronous(_)) && max_packet_size > 64) || max_packet_size > 1023 {
             warn!("max_packet_size too high: {}", max_packet_size);
             return Err(EndpointAllocError);
         }
@@ -214,7 +214,7 @@ impl<'d, T: Instance> Driver<'d, T> {
             EndpointType::Bulk => pac::usb_dpram::vals::EpControlEndpointType::BULK,
             EndpointType::Control => pac::usb_dpram::vals::EpControlEndpointType::CONTROL,
             EndpointType::Interrupt => pac::usb_dpram::vals::EpControlEndpointType::INTERRUPT,
-            EndpointType::Isochronous => pac::usb_dpram::vals::EpControlEndpointType::ISOCHRONOUS,
+            EndpointType::Isochronous(_) => pac::usb_dpram::vals::EpControlEndpointType::ISOCHRONOUS,
         };
 
         match D::dir() {

--- a/embassy-stm32/src/usb/otg.rs
+++ b/embassy-stm32/src/usb/otg.rs
@@ -1152,7 +1152,7 @@ impl<'d, T: Instance> embassy_usb_driver::EndpointOut for Endpoint<'d, T, Out> {
                         w.set_pktcnt(1);
                     });
 
-                    if matches!(self.info.ep_type, EndpointType::Isochronous) {
+                    if matches!(self.info.ep_type, EndpointType::Isochronous(_)) {
                         // Isochronous endpoints must set the correct even/odd frame bit to
                         // correspond with the next frame's number.
                         let frame_number = T::regs().dsts().read().fnsof();
@@ -1380,7 +1380,7 @@ impl<'d, T: Instance> embassy_usb_driver::ControlPipe for ControlPipe<'d, T> {
 fn to_eptyp(ep_type: EndpointType) -> vals::Eptyp {
     match ep_type {
         EndpointType::Control => vals::Eptyp::CONTROL,
-        EndpointType::Isochronous => vals::Eptyp::ISOCHRONOUS,
+        EndpointType::Isochronous(_) => vals::Eptyp::ISOCHRONOUS,
         EndpointType::Bulk => vals::Eptyp::BULK,
         EndpointType::Interrupt => vals::Eptyp::INTERRUPT,
     }

--- a/embassy-stm32/src/usb/usb.rs
+++ b/embassy-stm32/src/usb/usb.rs
@@ -131,7 +131,7 @@ fn convert_type(t: EndpointType) -> EpType {
         EndpointType::Bulk => EpType::BULK,
         EndpointType::Control => EpType::CONTROL,
         EndpointType::Interrupt => EpType::INTERRUPT,
-        EndpointType::Isochronous => EpType::ISO,
+        EndpointType::Isochronous(_) => EpType::ISO,
     }
 }
 

--- a/embassy-usb/src/builder.rs
+++ b/embassy-usb/src/builder.rs
@@ -1,3 +1,4 @@
+use embassy_usb_driver::{IsochronousSynchronizationType, IsochronousUsageType};
 use heapless::Vec;
 
 use crate::config::MAX_HANDLER_COUNT;
@@ -473,12 +474,24 @@ impl<'a, 'd, D: Driver<'d>> InterfaceAltBuilder<'a, 'd, D> {
     ///
     /// Descriptors are written in the order builder functions are called. Note that some
     /// classes care about the order.
-    pub fn endpoint_isochronous_in(&mut self, max_packet_size: u16, interval_ms: u8) -> D::EndpointIn {
-        self.endpoint_in(EndpointType::Isochronous, max_packet_size, interval_ms)
+    pub fn endpoint_isochronous_in(
+        &mut self,
+        max_packet_size: u16,
+        interval_ms: u8,
+        sync: IsochronousSynchronizationType,
+        usage: IsochronousUsageType,
+    ) -> D::EndpointIn {
+        self.endpoint_in(EndpointType::Isochronous((sync, usage)), max_packet_size, interval_ms)
     }
 
     /// Allocate a ISOCHRONOUS OUT endpoint and write its descriptor.
-    pub fn endpoint_isochronous_out(&mut self, max_packet_size: u16, interval_ms: u8) -> D::EndpointOut {
-        self.endpoint_out(EndpointType::Isochronous, max_packet_size, interval_ms)
+    pub fn endpoint_isochronous_out(
+        &mut self,
+        max_packet_size: u16,
+        interval_ms: u8,
+        sync: IsochronousSynchronizationType,
+        usage: IsochronousUsageType,
+    ) -> D::EndpointOut {
+        self.endpoint_out(EndpointType::Isochronous((sync, usage)), max_packet_size, interval_ms)
     }
 }

--- a/embassy-usb/src/descriptor.rs
+++ b/embassy-usb/src/descriptor.rs
@@ -211,8 +211,8 @@ impl<'a> DescriptorWriter<'a> {
         self.write(
             descriptor_type::ENDPOINT,
             &[
-                endpoint.addr.into(),   // bEndpointAddress
-                endpoint.ep_type as u8, // bmAttributes
+                endpoint.addr.into(),                // bEndpointAddress
+                endpoint.ep_type.to_bm_attributes(), // bmAttributes
                 endpoint.max_packet_size as u8,
                 (endpoint.max_packet_size >> 8) as u8, // wMaxPacketSize
                 endpoint.interval_ms,                  // bInterval


### PR DESCRIPTION
This pull request fixes the stm32 isochronous issue that we have to set the odd/even frame bit every time.
If we don´t the usb frame is rejected.

Also update `EndpointType` because isochronous endpoint also needs synchronication and usage type information.
`EndpointType` is copied from https://github.com/rust-embedded-community/usb-device

embassy-usb/src/descriptor.rs is not done yet.
For class specific properties like USB AUDIO CLASS two extra bytes have to be added to the endpoint description.
Hacked example: https://github.com/vDorst/embassy/blob/i2s-no-mclk/embassy-usb/src/builder.rs#L467 and https://github.com/vDorst/embassy/blob/i2s-no-mclk/embassy-usb/src/builder.rs#L509.
What could be a good way to provide this information in a generic way?