### PR TITLE
Add a config option to make the VDDIO2 supply line valid

### DIFF
--- a/embassy-stm32/src/gpio.rs
+++ b/embassy-stm32/src/gpio.rs
@@ -779,13 +779,6 @@ pub(crate) unsafe fn init(_cs: CriticalSection) {
     <crate::peripherals::AFIO as crate::rcc::SealedRccPeripheral>::enable_and_reset_with_cs(_cs);
 
     crate::_generated::init_gpio();
-
-    // Setting this bit is mandatory to use PG[15:2].
-    #[cfg(stm32u5)]
-    crate::pac::PWR.svmcr().modify(|w| {
-        w.set_io2sv(true);
-        w.set_io2vmen(true);
-    });
 }
 
 impl<'d> embedded_hal_02::digital::v2::InputPin for Input<'d> {

--- a/embassy-stm32/src/lib.rs
+++ b/embassy-stm32/src/lib.rs
@@ -286,7 +286,8 @@ pub fn init(config: Config) -> Peripherals {
         {
             crate::pac::PWR.cr2().modify(|w| {
                 // The official documentation states that we should ideally enable VDDIO2
-                // through the PVME2 bit, but it looks like this bit
+                // through the PVME2 bit, but it looks like this isn't required,
+                // and CubeMX itself skips this step.
                 w.set_iosv(config.enable_independent_io_supply);
             });
         }

--- a/examples/stm32l4/src/bin/spe_adin1110_http_server.rs
+++ b/examples/stm32l4/src/bin/spe_adin1110_http_server.rs
@@ -93,12 +93,6 @@ async fn main(spawner: Spawner) {
 
     let dp = embassy_stm32::init(config);
 
-    // RM0432rev9, 5.1.2: Independent I/O supply rail
-    // After reset, the I/Os supplied by VDDIO2 are logically and electrically isolated and
-    // therefore are not available. The isolation must be removed before using any I/O from
-    // PG[15:2], by setting the IOSV bit in the PWR_CR2 register, once the VDDIO2 supply is present
-    pac::PWR.cr2().modify(|w| w.set_iosv(true));
-
     let reset_status = pac::RCC.bdcr().read().0;
     defmt::println!("bdcr before: 0x{:X}", reset_status);
 

--- a/tests/stm32/src/common.rs
+++ b/tests/stm32/src/common.rs
@@ -251,13 +251,6 @@ define_peris!(
 );
 
 pub fn config() -> Config {
-    // Setting this bit is mandatory to use PG[15:2].
-    #[cfg(feature = "stm32u5a5zj")]
-    embassy_stm32::pac::PWR.svmcr().modify(|w| {
-        w.set_io2sv(true);
-        w.set_io2vmen(true);
-    });
-
     #[allow(unused_mut)]
     let mut config = Config::default();
 


### PR DESCRIPTION
On STM32L4[7-A]xx, STM32L5xxx and STM32U5xxx chips, the GPIOG[2..15] pins are only available once the IOSV bit has been set in PWR->CR2 (U5 chips have the bit in a funkier register).

This is meant to allow the user to have control over this power supply, so the GPIOG pins are initially insulated, until the user wishes to un-insulate them (or something like that?). For most applications, though, the VDDIO2 line is connected to the VDD line, and this behavior only gets in the way and causes confusing issues.

This PR adds an option in `embassy_stm32::Config`, called `enable_independent_io_supply`, which simply enables the IOSV bit. It is only available on chips for which I could find a mention of IOSV (STM32L4 and STM32L5) or IO2SV (STM32U5).

-----

This part of the behavior of the L4 chips seems to be a bit under-documented, so I don't really know how reliable this solution is.

I only have an `stm32l4a6zg` nucleo board to test this on, and the documentation does state that the `stm32l41xx` through `stm32l47xx` chips don't have/need this bit, so I need someone with one of these boards to test the `stm32l4/usart` example with this patch to check that setting the `IOSV` bit on them doesn't break anything.

Fixes #2708