### PR TITLE
Synchronise the feature sets and API between BXCAN and FDCAN.

### DIFF
--- a/embassy-stm32/src/can/bx/mod.rs
+++ b/embassy-stm32/src/can/bx/mod.rs
@@ -406,7 +406,7 @@ impl Registers {
             }
         }
     }
-    
+
     pub fn curr_error(&self) -> Option<BusError> {
         let err = { self.canregs.esr().read() };
         if err.boff() {
@@ -583,6 +583,16 @@ impl Registers {
             reg.set_rqcp(1, true);
             reg.set_rqcp(2, true);
         });
+    }
+
+    pub fn receive_frame_available(&self) -> bool {
+        if self.canregs.rfr(0).read().fmp() != 0 {
+            true
+        } else if self.canregs.rfr(1).read().fmp() != 0 {
+            true
+        } else {
+            false
+        }
     }
 
     pub fn receive_fifo(&self, fifo: crate::can::_version::bx::RxFifo) -> Option<Envelope> {

--- a/embassy-stm32/src/can/bx/mod.rs
+++ b/embassy-stm32/src/can/bx/mod.rs
@@ -40,12 +40,11 @@ pub type Header = crate::can::frame::Header;
 /// Data for a CAN Frame
 pub type Data = crate::can::frame::ClassicData;
 
-/// CAN Frame
-pub type Frame = crate::can::frame::ClassicFrame;
-
 use crate::can::_version::Envelope;
 use crate::can::bx::filter::MasterFilters;
 use crate::can::enums::BusError;
+/// CAN Frame
+pub use crate::can::frame::Frame;
 use crate::pac::can::vals::Lec;
 
 #[derive(Debug, Copy, Clone, Eq, PartialEq)]

--- a/embassy-stm32/src/can/bx/mod.rs
+++ b/embassy-stm32/src/can/bx/mod.rs
@@ -624,6 +624,7 @@ impl Registers {
         };
         let rdtr = fifo.rdtr().read();
         let data_len = rdtr.dlc();
+        let rtr = rir.rtr() == stm32_metapac::can::vals::Rtr::REMOTE;
 
         #[cfg(not(feature = "time"))]
         let ts = rdtr.time();
@@ -632,7 +633,7 @@ impl Registers {
         data[0..4].copy_from_slice(&fifo.rdlr().read().0.to_ne_bytes());
         data[4..8].copy_from_slice(&fifo.rdhr().read().0.to_ne_bytes());
 
-        let frame = Frame::new(Header::new(id, data_len, false), &data).unwrap();
+        let frame = Frame::new(Header::new(id, data_len, rtr), &data).unwrap();
         let envelope = Envelope { ts, frame };
 
         rfr.modify(|v| v.set_rfom(true));

--- a/embassy-stm32/src/can/bxcan.rs
+++ b/embassy-stm32/src/can/bxcan.rs
@@ -296,8 +296,8 @@ impl<'d, T: Instance> Can<'d, T> {
     ///
     /// Useful for doing separate transmit/receive tasks.
     pub fn split<'c>(&'c mut self) -> (CanTx<'d, T>, CanRx<'d, T>) {
-        let (tx, rx0, rx1) = self.can.split_by_ref();
-        (CanTx { tx }, CanRx { rx0, rx1 })
+        let (tx, rx) = self.can.split_by_ref();
+        (CanTx { tx }, CanRx { rx})
     }
 }
 
@@ -401,8 +401,7 @@ impl<'d, T: Instance> CanTx<'d, T> {
 /// CAN driver, receive half.
 #[allow(dead_code)]
 pub struct CanRx<'d, T: Instance> {
-    rx0: crate::can::bx::Rx0<BxcanInstance<'d, T>>,
-    rx1: crate::can::bx::Rx1<BxcanInstance<'d, T>>,
+    rx: crate::can::bx::Rx<BxcanInstance<'d, T>>,
 }
 
 impl<'d, T: Instance> CanRx<'d, T> {

--- a/embassy-stm32/src/can/common.rs
+++ b/embassy-stm32/src/can/common.rs
@@ -18,9 +18,13 @@ pub(crate) struct ClassicBufferedTxInner {
     pub tx_receiver: DynamicReceiver<'static, ClassicFrame>,
 }
 
+#[cfg(any(can_fdcan_v1, can_fdcan_h7))]
+
 pub(crate) struct FdBufferedRxInner {
     pub rx_sender: DynamicSender<'static, Result<(FdFrame, Timestamp), BusError>>,
 }
+
+#[cfg(any(can_fdcan_v1, can_fdcan_h7))]
 pub(crate) struct FdBufferedTxInner {
     pub tx_receiver: DynamicReceiver<'static, FdFrame>,
 }

--- a/embassy-stm32/src/can/common.rs
+++ b/embassy-stm32/src/can/common.rs
@@ -1,0 +1,51 @@
+use embassy_sync::channel::{DynamicReceiver, DynamicSender};
+
+use crate::can::_version::frame::*;
+use crate::can::_version::Timestamp;
+use crate::can::_version::enums::*;
+
+pub(crate) struct ClassicBufferedRxInner {
+    pub rx_sender: DynamicSender<'static, Result<(ClassicFrame, Timestamp), BusError>>,
+}
+pub(crate) struct ClassicBufferedTxInner {
+    pub tx_receiver: DynamicReceiver<'static, ClassicFrame>,
+}
+
+pub(crate) struct FdBufferedRxInner {
+    pub rx_sender: DynamicSender<'static, Result<(FdFrame, Timestamp), BusError>>,
+}
+pub(crate) struct FdBufferedTxInner {
+    pub tx_receiver: DynamicReceiver<'static, FdFrame>,
+}
+
+/// Sender that can be used for sending CAN frames.
+#[derive(Copy, Clone)]
+pub struct BufferedCanSender {
+    pub(crate) tx_buf: embassy_sync::channel::DynamicSender<'static, ClassicFrame>,
+    pub(crate) waker: fn(),
+}
+
+impl BufferedCanSender {
+    /// Async write frame to TX buffer.
+    pub fn try_write(&mut self, frame: ClassicFrame) -> Result<(), embassy_sync::channel::TrySendError<ClassicFrame>> {
+        self.tx_buf.try_send(frame)?;
+        (self.waker)();
+        Ok(())
+    }
+
+    /// Async write frame to TX buffer.
+    pub async fn write(&mut self, frame: ClassicFrame) {
+        self.tx_buf.send(frame).await;
+        (self.waker)();
+    }
+
+    /// Allows a poll_fn to poll until the channel is ready to write
+    pub fn poll_ready_to_send(&self, cx: &mut core::task::Context<'_>) -> core::task::Poll<()> {
+        self.tx_buf.poll_ready_to_send(cx)
+    }
+}
+
+/// Receiver that can be used for receiving CAN frames. Note, each CAN frame will only be received by one receiver.
+pub type BufferedCanReceiver =
+    embassy_sync::channel::DynamicReceiver<'static, Result<(ClassicFrame, Timestamp), BusError>>;
+

--- a/embassy-stm32/src/can/common.rs
+++ b/embassy-stm32/src/can/common.rs
@@ -1,8 +1,15 @@
 use embassy_sync::channel::{DynamicReceiver, DynamicSender};
 
-use crate::can::_version::frame::*;
-use crate::can::_version::Timestamp;
 use crate::can::_version::enums::*;
+use crate::can::_version::frame::*;
+
+/// Timestamp for incoming packets. Use Embassy time when enabled.
+#[cfg(feature = "time")]
+pub type Timestamp = embassy_time::Instant;
+
+/// Timestamp for incoming packets.
+#[cfg(not(feature = "time"))]
+pub type Timestamp = u16;
 
 pub(crate) struct ClassicBufferedRxInner {
     pub rx_sender: DynamicSender<'static, Result<(ClassicFrame, Timestamp), BusError>>,
@@ -48,4 +55,3 @@ impl BufferedCanSender {
 /// Receiver that can be used for receiving CAN frames. Note, each CAN frame will only be received by one receiver.
 pub type BufferedCanReceiver =
     embassy_sync::channel::DynamicReceiver<'static, Result<(ClassicFrame, Timestamp), BusError>>;
-

--- a/embassy-stm32/src/can/enums.rs
+++ b/embassy-stm32/src/can/enums.rs
@@ -40,3 +40,13 @@ pub enum FrameCreateError {
     /// Invalid ID.
     InvalidCanId,
 }
+
+/// Error returned by `try_read`
+#[derive(Debug)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+pub enum TryReadError {
+    /// Bus error
+    BusError(BusError),
+    /// Receive buffer is empty
+    Empty,
+}

--- a/embassy-stm32/src/can/fd/peripheral.rs
+++ b/embassy-stm32/src/can/fd/peripheral.rs
@@ -397,13 +397,13 @@ impl Registers {
 
     /// Moves out of ConfigMode and into specified mode
     #[inline]
-    pub fn into_mode(mut self, config: FdCanConfig, mode: crate::can::_version::FdcanOperatingMode) {
+    pub fn into_mode(mut self, config: FdCanConfig, mode: crate::can::_version::OperatingMode) {
         match mode {
-            crate::can::FdcanOperatingMode::InternalLoopbackMode => self.set_loopback_mode(LoopbackMode::Internal),
-            crate::can::FdcanOperatingMode::ExternalLoopbackMode => self.set_loopback_mode(LoopbackMode::External),
-            crate::can::FdcanOperatingMode::NormalOperationMode => self.set_normal_operations(true),
-            crate::can::FdcanOperatingMode::RestrictedOperationMode => self.set_restricted_operations(true),
-            crate::can::FdcanOperatingMode::BusMonitoringMode => self.set_bus_monitoring_mode(true),
+            crate::can::OperatingMode::InternalLoopbackMode => self.set_loopback_mode(LoopbackMode::Internal),
+            crate::can::OperatingMode::ExternalLoopbackMode => self.set_loopback_mode(LoopbackMode::External),
+            crate::can::OperatingMode::NormalOperationMode => self.set_normal_operations(true),
+            crate::can::OperatingMode::RestrictedOperationMode => self.set_restricted_operations(true),
+            crate::can::OperatingMode::BusMonitoringMode => self.set_bus_monitoring_mode(true),
         }
         self.leave_init_mode(config);
     }

--- a/embassy-stm32/src/can/fdcan.rs
+++ b/embassy-stm32/src/can/fdcan.rs
@@ -25,7 +25,8 @@ use fd::config::*;
 use fd::filter::*;
 pub use fd::{config, filter};
 use frame::*;
-pub use self::common::{BufferedCanSender, BufferedCanReceiver};
+
+pub use self::common::{BufferedCanReceiver, BufferedCanSender};
 
 /// Timestamp for incoming packets. Use Embassy time when enabled.
 #[cfg(feature = "time")]
@@ -415,7 +416,6 @@ pub struct BufferedCan<'d, T: Instance, const TX_BUF_SIZE: usize, const RX_BUF_S
     tx_buf: &'static TxBuf<TX_BUF_SIZE>,
     rx_buf: &'static RxBuf<RX_BUF_SIZE>,
 }
-
 
 impl<'c, 'd, T: Instance, const TX_BUF_SIZE: usize, const RX_BUF_SIZE: usize>
     BufferedCan<'d, T, TX_BUF_SIZE, RX_BUF_SIZE>

--- a/embassy-stm32/src/can/fdcan.rs
+++ b/embassy-stm32/src/can/fdcan.rs
@@ -507,7 +507,7 @@ pub struct BufferedCanFd<'d, T: Instance, const TX_BUF_SIZE: usize, const RX_BUF
 /// Sender that can be used for sending CAN frames.
 #[derive(Copy, Clone)]
 pub struct BufferedFdCanSender {
-    tx_buf: embassy_sync::channel::DynamicSender<'static, FdFrame>,
+    tx_buf: DynamicSender<'static, FdFrame>,
     waker: fn(),
 }
 
@@ -532,8 +532,7 @@ impl BufferedFdCanSender {
 }
 
 /// Receiver that can be used for receiving CAN frames. Note, each CAN frame will only be received by one receiver.
-pub type BufferedFdCanReceiver =
-    embassy_sync::channel::DynamicReceiver<'static, Result<(FdFrame, Timestamp), BusError>>;
+pub type BufferedFdCanReceiver = DynamicReceiver<'static, Result<(FdFrame, Timestamp), BusError>>;
 
 impl<'c, 'd, T: Instance, const TX_BUF_SIZE: usize, const RX_BUF_SIZE: usize>
     BufferedCanFd<'d, T, TX_BUF_SIZE, RX_BUF_SIZE>

--- a/embassy-stm32/src/can/frame.rs
+++ b/embassy-stm32/src/can/frame.rs
@@ -3,6 +3,14 @@ use bit_field::BitField;
 
 use crate::can::enums::FrameCreateError;
 
+/// Calculate proper timestamp when available.
+#[cfg(feature = "time")]
+pub type Timestamp = embassy_time::Instant;
+
+/// Raw register timestamp
+#[cfg(not(feature = "time"))]
+pub type Timestamp = u16;
+
 /// CAN Header, without meta data
 #[derive(Debug, Copy, Clone)]
 pub struct Header {
@@ -264,15 +272,14 @@ impl CanHeader for Frame {
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub struct Envelope {
     /// Reception time.
-    #[cfg(feature = "time")]
-    pub ts: embassy_time::Instant,
+    pub ts: Timestamp,
     /// The actual CAN frame.
     pub frame: Frame,
 }
 
 impl Envelope {
     /// Convert into a tuple
-    pub fn parts(self) -> (Frame, embassy_time::Instant) {
+    pub fn parts(self) -> (Frame, Timestamp) {
         (self.frame, self.ts)
     }
 }
@@ -442,15 +449,15 @@ impl CanHeader for FdFrame {
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub struct FdEnvelope {
     /// Reception time.
-    #[cfg(feature = "time")]
-    pub ts: embassy_time::Instant,
+    pub ts: Timestamp,
+
     /// The actual CAN frame.
     pub frame: FdFrame,
 }
 
 impl FdEnvelope {
     /// Convert into a tuple
-    pub fn parts(self) -> (FdFrame, embassy_time::Instant) {
+    pub fn parts(self) -> (FdFrame, Timestamp) {
         (self.frame, self.ts)
     }
 }

--- a/embassy-stm32/src/can/frame.rs
+++ b/embassy-stm32/src/can/frame.rs
@@ -136,19 +136,20 @@ impl ClassicData {
     }
 }
 
-/// Frame with up to 8 bytes of data payload as per Classic CAN
+/// Frame with up to 8 bytes of data payload as per Classic(non-FD) CAN
+/// For CAN-FD support use FdFrame
 #[derive(Debug, Copy, Clone)]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
-pub struct ClassicFrame {
+pub struct Frame {
     can_header: Header,
     data: ClassicData,
 }
 
-impl ClassicFrame {
+impl Frame {
     /// Create a new CAN classic Frame
     pub fn new(can_header: Header, raw_data: &[u8]) -> Result<Self, FrameCreateError> {
         let data = ClassicData::new(raw_data)?;
-        Ok(ClassicFrame { can_header, data: data })
+        Ok(Frame { can_header, data: data })
     }
 
     /// Creates a new data frame.
@@ -206,9 +207,9 @@ impl ClassicFrame {
     }
 }
 
-impl embedded_can::Frame for ClassicFrame {
+impl embedded_can::Frame for Frame {
     fn new(id: impl Into<embedded_can::Id>, raw_data: &[u8]) -> Option<Self> {
-        let frameopt = ClassicFrame::new(Header::new(id.into(), raw_data.len() as u8, false), raw_data);
+        let frameopt = Frame::new(Header::new(id.into(), raw_data.len() as u8, false), raw_data);
         match frameopt {
             Ok(frame) => Some(frame),
             Err(_) => None,
@@ -216,7 +217,7 @@ impl embedded_can::Frame for ClassicFrame {
     }
     fn new_remote(id: impl Into<embedded_can::Id>, len: usize) -> Option<Self> {
         if len <= 8 {
-            let frameopt = ClassicFrame::new(Header::new(id.into(), len as u8, true), &[0; 8]);
+            let frameopt = Frame::new(Header::new(id.into(), len as u8, true), &[0; 8]);
             match frameopt {
                 Ok(frame) => Some(frame),
                 Err(_) => None,
@@ -245,7 +246,7 @@ impl embedded_can::Frame for ClassicFrame {
     }
 }
 
-impl CanHeader for ClassicFrame {
+impl CanHeader for Frame {
     fn from_header(header: Header, data: &[u8]) -> Result<Self, FrameCreateError> {
         Self::new(header, data)
     }
@@ -255,10 +256,32 @@ impl CanHeader for ClassicFrame {
     }
 }
 
+/// Contains CAN frame and additional metadata.
+///
+/// Timestamp is available if `time` feature is enabled.
+/// For CAN-FD support use FdEnvelope
+#[derive(Debug, Clone)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+pub struct Envelope {
+    /// Reception time.
+    #[cfg(feature = "time")]
+    pub ts: embassy_time::Instant,
+    /// The actual CAN frame.
+    pub frame: Frame,
+}
+
+impl Envelope {
+    /// Convert into a tuple
+    pub fn parts(self) -> (Frame, embassy_time::Instant) {
+        (self.frame, self.ts)
+    }
+}
+
 /// Payload of a (FD)CAN data frame.
 ///
 /// Contains 0 to 64 Bytes of data.
 #[derive(Debug, Copy, Clone)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub struct FdData {
     pub(crate) bytes: [u8; 64],
 }
@@ -308,6 +331,7 @@ impl FdData {
 
 /// Frame with up to 8 bytes of data payload as per Fd CAN
 #[derive(Debug, Copy, Clone)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub struct FdFrame {
     can_header: Header,
     data: FdData,
@@ -408,5 +432,25 @@ impl CanHeader for FdFrame {
 
     fn header(&self) -> &Header {
         self.header()
+    }
+}
+
+/// Contains CAN FD frame and additional metadata.
+///
+/// Timestamp is available if `time` feature is enabled.
+#[derive(Debug, Clone)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+pub struct FdEnvelope {
+    /// Reception time.
+    #[cfg(feature = "time")]
+    pub ts: embassy_time::Instant,
+    /// The actual CAN frame.
+    pub frame: FdFrame,
+}
+
+impl FdEnvelope {
+    /// Convert into a tuple
+    pub fn parts(self) -> (FdFrame, embassy_time::Instant) {
+        (self.frame, self.ts)
     }
 }

--- a/examples/stm32f1/Cargo.toml
+++ b/examples/stm32f1/Cargo.toml
@@ -23,6 +23,7 @@ panic-probe = { version = "0.3", features = ["print-defmt"] }
 futures = { version = "0.3.17", default-features = false, features = ["async-await"] }
 heapless = { version = "0.8", default-features = false }
 nb = "1.0.0"
+static_cell = "2.0.0"
 
 [profile.dev]
 opt-level = "s"

--- a/examples/stm32f1/src/bin/can.rs
+++ b/examples/stm32f1/src/bin/can.rs
@@ -4,11 +4,12 @@
 use defmt::*;
 use embassy_executor::Spawner;
 use embassy_stm32::can::{
-    filter, Can, Fifo, Frame, Id, Rx0InterruptHandler, Rx1InterruptHandler, SceInterruptHandler, StandardId,
+    filter, Can, Envelope, Fifo, Frame, Id, Rx0InterruptHandler, Rx1InterruptHandler, SceInterruptHandler, StandardId,
     TxInterruptHandler,
 };
 use embassy_stm32::peripherals::CAN;
 use embassy_stm32::{bind_interrupts, Config};
+use static_cell::StaticCell;
 use {defmt_rtt as _, panic_probe as _};
 
 bind_interrupts!(struct Irqs {
@@ -21,12 +22,36 @@ bind_interrupts!(struct Irqs {
 // This example is configured to work with real CAN transceivers on B8/B9.
 // See other examples for loopback.
 
+fn handle_frame(env: Envelope, read_mode: &str) {
+    match env.frame.id() {
+        Id::Extended(id) => {
+            defmt::println!(
+                "{} Extended Frame id={:x} {:02x}",
+                read_mode,
+                id.as_raw(),
+                env.frame.data()
+            );
+        }
+        Id::Standard(id) => {
+            defmt::println!(
+                "{} Standard Frame id={:x} {:02x}",
+                read_mode,
+                id.as_raw(),
+                env.frame.data()
+            );
+        }
+    }
+}
+
 #[embassy_executor::main]
 async fn main(_spawner: Spawner) {
     let p = embassy_stm32::init(Config::default());
 
     // Set alternate pin mapping to B8/B9
     embassy_stm32::pac::AFIO.mapr().modify(|w| w.set_can1_remap(2));
+
+    static RX_BUF: StaticCell<embassy_stm32::can::RxBuf<10>> = StaticCell::new();
+    static TX_BUF: StaticCell<embassy_stm32::can::TxBuf<10>> = StaticCell::new();
 
     let mut can = Can::new(p.CAN, p.PB8, p.PB9, Irqs);
 
@@ -43,21 +68,72 @@ async fn main(_spawner: Spawner) {
     can.set_bitrate(250_000);
 
     can.enable().await;
-
     let mut i: u8 = 0;
+
+    /*
+       // Example for using buffered Tx and Rx without needing to
+       // split first as is done below.
+       let mut can = can.buffered(
+           TX_BUF.init(embassy_stm32::can::TxBuf::<10>::new()),
+           RX_BUF.init(embassy_stm32::can::RxBuf::<10>::new()));
+       loop {
+           let tx_frame = Frame::new_data(unwrap!(StandardId::new(i as _)), &[i, 0, 1, 2, 3, 4, 5, 6]).unwrap();
+           can.write(&tx_frame).await;
+
+           match can.read().await {
+               Ok((frame, ts)) => {
+                   handle_frame(Envelope { ts, frame }, "Buf");
+               }
+               Err(err) => {
+                   defmt::println!("Error {}", err);
+               }
+           }
+           i += 1;
+       }
+
+    */
+    let (mut tx, mut rx) = can.split();
+
+    // This example shows using the wait_not_empty API before try read
+    while i < 3 {
+        let tx_frame = Frame::new_data(unwrap!(StandardId::new(i as _)), &[i, 0, 1, 2, 3, 4, 5, 6]).unwrap();
+        tx.write(&tx_frame).await;
+
+        rx.wait_not_empty().await;
+        let env = rx.try_read().unwrap();
+        handle_frame(env, "Wait");
+        i += 1;
+    }
+
+    // This example shows using the full async non-buffered API
+    while i < 6 {
+        let tx_frame = Frame::new_data(unwrap!(StandardId::new(i as _)), &[i, 0, 1, 2, 3, 4, 5, 6]).unwrap();
+        tx.write(&tx_frame).await;
+
+        match rx.read().await {
+            Ok(env) => {
+                handle_frame(env, "NoBuf");
+            }
+            Err(err) => {
+                defmt::println!("Error {}", err);
+            }
+        }
+        i += 1;
+    }
+
+    // This example shows using buffered RX and TX. User passes in desired buffer (size)
+    // It's possible this way to have just RX or TX buffered.
+    let mut rx = rx.buffered(RX_BUF.init(embassy_stm32::can::RxBuf::<10>::new()));
+    let mut tx = tx.buffered(TX_BUF.init(embassy_stm32::can::TxBuf::<10>::new()));
+
     loop {
         let tx_frame = Frame::new_data(unwrap!(StandardId::new(i as _)), &[i, 0, 1, 2, 3, 4, 5, 6]).unwrap();
-        can.write(&tx_frame).await;
+        tx.write(&tx_frame).await;
 
-        match can.read().await {
-            Ok(env) => match env.frame.id() {
-                Id::Extended(id) => {
-                    defmt::println!("Extended Frame id={:x} {:02x}", id.as_raw(), env.frame.data());
-                }
-                Id::Standard(id) => {
-                    defmt::println!("Standard Frame id={:x} {:02x}", id.as_raw(), env.frame.data());
-                }
-            },
+        match rx.read().await {
+            Ok(envelope) => {
+                handle_frame(envelope, "Buf");
+            }
             Err(err) => {
                 defmt::println!("Error {}", err);
             }

--- a/examples/stm32h5/src/bin/can.rs
+++ b/examples/stm32h5/src/bin/can.rs
@@ -24,7 +24,7 @@ async fn main(_spawner: Spawner) {
 
     let peripherals = embassy_stm32::init(config);
 
-    let mut can = can::FdcanConfigurator::new(peripherals.FDCAN1, peripherals.PA11, peripherals.PA12, Irqs);
+    let mut can = can::CanConfigurator::new(peripherals.FDCAN1, peripherals.PA11, peripherals.PA12, Irqs);
 
     // 250k bps
     can.set_bitrate(250_000);
@@ -38,12 +38,13 @@ async fn main(_spawner: Spawner) {
     let mut last_read_ts = embassy_time::Instant::now();
 
     loop {
-        let frame = can::frame::ClassicFrame::new_extended(0x123456F, &[i; 8]).unwrap();
+        let frame = can::frame::Frame::new_extended(0x123456F, &[i; 8]).unwrap();
         info!("Writing frame");
         _ = can.write(&frame).await;
 
         match can.read().await {
-            Ok((rx_frame, ts)) => {
+            Ok(envelope) => {
+                let (rx_frame, ts) = envelope.parts();
                 let delta = (ts - last_read_ts).as_millis();
                 last_read_ts = ts;
                 info!(
@@ -69,12 +70,13 @@ async fn main(_spawner: Spawner) {
     let (mut tx, mut rx) = can.split();
     // With split
     loop {
-        let frame = can::frame::ClassicFrame::new_extended(0x123456F, &[i; 8]).unwrap();
+        let frame = can::frame::Frame::new_extended(0x123456F, &[i; 8]).unwrap();
         info!("Writing frame");
         _ = tx.write(&frame).await;
 
         match rx.read().await {
-            Ok((rx_frame, ts)) => {
+            Ok(envelope) => {
+                let (rx_frame, ts) = envelope.parts();
                 let delta = (ts - last_read_ts).as_millis();
                 last_read_ts = ts;
                 info!(

--- a/examples/stm32h7/src/bin/can.rs
+++ b/examples/stm32h7/src/bin/can.rs
@@ -24,7 +24,7 @@ async fn main(_spawner: Spawner) {
 
     let peripherals = embassy_stm32::init(config);
 
-    let mut can = can::FdcanConfigurator::new(peripherals.FDCAN1, peripherals.PA11, peripherals.PA12, Irqs);
+    let mut can = can::CanConfigurator::new(peripherals.FDCAN1, peripherals.PA11, peripherals.PA12, Irqs);
 
     // 250k bps
     can.set_bitrate(250_000);
@@ -38,12 +38,13 @@ async fn main(_spawner: Spawner) {
     let mut last_read_ts = embassy_time::Instant::now();
 
     loop {
-        let frame = can::frame::ClassicFrame::new_extended(0x123456F, &[i; 8]).unwrap();
+        let frame = can::frame::Frame::new_extended(0x123456F, &[i; 8]).unwrap();
         info!("Writing frame");
         _ = can.write(&frame).await;
 
         match can.read().await {
-            Ok((rx_frame, ts)) => {
+            Ok(envelope) => {
+                let (rx_frame, ts) = envelope.parts();
                 let delta = (ts - last_read_ts).as_millis();
                 last_read_ts = ts;
                 info!(
@@ -69,12 +70,13 @@ async fn main(_spawner: Spawner) {
     let (mut tx, mut rx) = can.split();
     // With split
     loop {
-        let frame = can::frame::ClassicFrame::new_extended(0x123456F, &[i; 8]).unwrap();
+        let frame = can::frame::Frame::new_extended(0x123456F, &[i; 8]).unwrap();
         info!("Writing frame");
         _ = tx.write(&frame).await;
 
         match rx.read().await {
-            Ok((rx_frame, ts)) => {
+            Ok(envelope) => {
+                let (rx_frame, ts) = envelope.parts();
                 let delta = (ts - last_read_ts).as_millis();
                 last_read_ts = ts;
                 info!(

--- a/tests/stm32/src/bin/can.rs
+++ b/tests/stm32/src/bin/can.rs
@@ -6,16 +6,18 @@
 #[path = "../common.rs"]
 mod common;
 use common::*;
-use defmt::assert;
 use embassy_executor::Spawner;
 use embassy_stm32::bind_interrupts;
 use embassy_stm32::can::bx::filter::Mask32;
-use embassy_stm32::can::bx::{Fifo, Frame, StandardId};
+use embassy_stm32::can::bx::Fifo;
 use embassy_stm32::can::{Can, Rx0InterruptHandler, Rx1InterruptHandler, SceInterruptHandler, TxInterruptHandler};
 use embassy_stm32::gpio::{Input, Pull};
 use embassy_stm32::peripherals::CAN1;
-use embassy_time::{Duration, Instant};
+use embassy_time::Duration;
 use {defmt_rtt as _, panic_probe as _};
+
+mod can_common;
+use can_common::*;
 
 bind_interrupts!(struct Irqs {
     CAN1_RX0 => Rx0InterruptHandler<CAN1>;
@@ -28,6 +30,11 @@ bind_interrupts!(struct Irqs {
 async fn main(_spawner: Spawner) {
     let p = embassy_stm32::init(config());
     info!("Hello World!");
+
+    let options = TestOptions {
+        max_latency: Duration::from_micros(1200),
+        max_buffered: 2,
+    };
 
     let can = peri!(p, CAN);
     let tx = peri!(p, CAN_TX);
@@ -58,40 +65,13 @@ async fn main(_spawner: Spawner) {
 
     info!("Can configured");
 
-    let mut i: u8 = 0;
-    loop {
-        let tx_frame = Frame::new_data(unwrap!(StandardId::new(i as _)), &[i]).unwrap();
+    run_can_tests(&mut can, &options).await;
 
-        info!("Transmitting frame...");
-        let tx_ts = Instant::now();
-        can.write(&tx_frame).await;
-
-        let envelope = can.read().await.unwrap();
-        info!("Frame received!");
-
-        info!("loopback time {}", envelope.ts);
-        info!("loopback frame {=u8}", envelope.frame.data()[0]);
-
-        let latency = envelope.ts.saturating_duration_since(tx_ts);
-        info!("loopback latency {} us", latency.as_micros());
-
-        // Theoretical minimum latency is 55us, actual is usually ~80us
-        const MIN_LATENCY: Duration = Duration::from_micros(50);
-        const MAX_LATENCY: Duration = Duration::from_micros(150);
-        assert!(
-            MIN_LATENCY <= latency && latency <= MAX_LATENCY,
-            "{} <= {} <= {}",
-            MIN_LATENCY,
-            latency,
-            MAX_LATENCY
-        );
-
-        i += 1;
-        if i > 10 {
-            break;
-        }
-    }
+    // Test again with a split
+    let (mut tx, mut rx) = can.split();
+    run_split_can_tests(&mut tx, &mut rx, &options).await;
 
     info!("Test OK");
+
     cortex_m::asm::bkpt();
 }

--- a/tests/stm32/src/bin/can_common.rs
+++ b/tests/stm32/src/bin/can_common.rs
@@ -1,0 +1,112 @@
+use defmt::{assert, *};
+use embassy_stm32::can;
+use embassy_time::{Duration, Instant};
+
+#[derive(Clone, Copy, Debug)]
+pub struct TestOptions {
+    pub max_latency: Duration,
+    pub max_buffered: u8,
+}
+
+pub async fn run_can_tests<'d, T: can::Instance>(can: &mut can::Can<'d, T>, options: &TestOptions) {
+    let mut i: u8 = 0;
+    loop {
+        //let tx_frame = can::frame::Frame::new_standard(0x123, &[i, 0x12 as u8, 0x34 as u8, 0x56 as u8, 0x78 as u8, 0x9A as u8, 0xBC as u8 ]).unwrap();
+        let tx_frame = can::frame::Frame::new_standard(0x123, &[i; 1]).unwrap();
+
+        //info!("Transmitting frame...");
+        let tx_ts = Instant::now();
+        can.write(&tx_frame).await;
+
+        let (frame, timestamp) = can.read().await.unwrap().parts();
+        //info!("Frame received!");
+
+        // Check data.
+        assert!(i == frame.data()[0], "{} == {}", i, frame.data()[0]);
+
+        //info!("loopback time {}", timestamp);
+        //info!("loopback frame {=u8}", frame.data()[0]);
+        let latency = timestamp.saturating_duration_since(tx_ts);
+        info!("loopback latency {} us", latency.as_micros());
+
+        // Theoretical minimum latency is 55us, actual is usually ~80us
+        const MIN_LATENCY: Duration = Duration::from_micros(50);
+        // Was failing at 150 but we are not getting a real time stamp. I'm not
+        // sure if there are other delays
+        assert!(
+            MIN_LATENCY <= latency && latency <= options.max_latency,
+            "{} <= {} <= {}",
+            MIN_LATENCY,
+            latency,
+            options.max_latency
+        );
+
+        i += 1;
+        if i > 5 {
+            break;
+        }
+    }
+
+    // Below here, check that we can receive from both FIFO0 and FIFO1
+    // Above we configured FIFO1 for extended ID packets. There are only 3 slots
+    // in each FIFO so make sure we write enough to fill them both up before reading.
+    for i in 0..options.max_buffered {
+        // Try filling up the RX FIFO0 buffers
+        //let tx_frame = if 0 != (i & 0x01) {
+        let tx_frame = if i < options.max_buffered / 2 {
+            info!("Transmitting standard frame {}", i);
+            can::frame::Frame::new_standard(0x123, &[i; 1]).unwrap()
+        } else {
+            info!("Transmitting extended frame {}", i);
+            can::frame::Frame::new_extended(0x1232344, &[i; 1]).unwrap()
+        };
+        can.write(&tx_frame).await;
+    }
+
+    // Try and receive all 6 packets
+    for _i in 0..options.max_buffered {
+        let (frame, _ts) = can.read().await.unwrap().parts();
+        match frame.id() {
+            embedded_can::Id::Extended(_id) => {
+                info!("Extended received! {}", frame.data()[0]);
+                //info!("Extended received! {:x} {} {}", id.as_raw(), frame.data()[0], i);
+            }
+            embedded_can::Id::Standard(_id) => {
+                info!("Standard received! {}", frame.data()[0]);
+                //info!("Standard received! {:x} {} {}", id.as_raw(), frame.data()[0], i);
+            }
+        }
+    }
+}
+
+pub async fn run_split_can_tests<'d, T: can::Instance>(
+    tx: &mut can::CanTx<'d, T>,
+    rx: &mut can::CanRx<'d, T>,
+    options: &TestOptions,
+) {
+    for i in 0..options.max_buffered {
+        // Try filling up the RX FIFO0 buffers
+        //let tx_frame = if 0 != (i & 0x01) {
+        let tx_frame = if i < options.max_buffered / 2 {
+            info!("Transmitting standard frame {}", i);
+            can::frame::Frame::new_standard(0x123, &[i; 1]).unwrap()
+        } else {
+            info!("Transmitting extended frame {}", i);
+            can::frame::Frame::new_extended(0x1232344, &[i; 1]).unwrap()
+        };
+        tx.write(&tx_frame).await;
+    }
+
+    // Try and receive all 6 packets
+    for _i in 0..options.max_buffered {
+        let (frame, _ts) = rx.read().await.unwrap().parts();
+        match frame.id() {
+            embedded_can::Id::Extended(_id) => {
+                info!("Extended received! {}", frame.data()[0]);
+            }
+            embedded_can::Id::Standard(_id) => {
+                info!("Standard received! {}", frame.data()[0]);
+            }
+        }
+    }
+}

--- a/tests/stm32/src/bin/fdcan.rs
+++ b/tests/stm32/src/bin/fdcan.rs
@@ -6,12 +6,14 @@
 #[path = "../common.rs"]
 mod common;
 use common::*;
-use defmt::assert;
 use embassy_executor::Spawner;
 use embassy_stm32::peripherals::*;
 use embassy_stm32::{bind_interrupts, can, Config};
-use embassy_time::{Duration, Instant};
+use embassy_time::Duration;
 use {defmt_rtt as _, panic_probe as _};
+
+mod can_common;
+use can_common::*;
 
 bind_interrupts!(struct Irqs2 {
     FDCAN2_IT0 => can::IT0InterruptHandler<FDCAN2>;
@@ -22,14 +24,8 @@ bind_interrupts!(struct Irqs1 {
     FDCAN1_IT1 => can::IT1InterruptHandler<FDCAN1>;
 });
 
-struct TestOptions {
-    config: Config,
-    max_latency: Duration,
-    second_fifo_working: bool,
-}
-
 #[cfg(any(feature = "stm32h755zi", feature = "stm32h753zi", feature = "stm32h563zi"))]
-fn options() -> TestOptions {
+fn options() -> (Config, TestOptions) {
     use embassy_stm32::rcc;
     info!("H75 config");
     let mut c = config();
@@ -38,15 +34,17 @@ fn options() -> TestOptions {
         mode: rcc::HseMode::Oscillator,
     });
     c.rcc.mux.fdcansel = rcc::mux::Fdcansel::HSE;
-    TestOptions {
-        config: c,
-        max_latency: Duration::from_micros(1200),
-        second_fifo_working: false,
-    }
+    (
+        c,
+        TestOptions {
+            max_latency: Duration::from_micros(1200),
+            max_buffered: 3,
+        },
+    )
 }
 
 #[cfg(any(feature = "stm32h7a3zi"))]
-fn options() -> TestOptions {
+fn options() -> (Config, TestOptions) {
     use embassy_stm32::rcc;
     info!("H7a config");
     let mut c = config();
@@ -55,29 +53,33 @@ fn options() -> TestOptions {
         mode: rcc::HseMode::Oscillator,
     });
     c.rcc.mux.fdcansel = rcc::mux::Fdcansel::HSE;
-    TestOptions {
-        config: c,
-        max_latency: Duration::from_micros(1200),
-        second_fifo_working: false,
-    }
+    (
+        c,
+        TestOptions {
+            max_latency: Duration::from_micros(1200),
+            max_buffered: 3,
+        },
+    )
 }
 
 #[cfg(any(feature = "stm32g491re", feature = "stm32g431cb"))]
-fn options() -> TestOptions {
+fn options() -> (Config, TestOptions) {
     info!("G4 config");
-    TestOptions {
-        config: config(),
-        max_latency: Duration::from_micros(500),
-        second_fifo_working: true,
-    }
+    (
+        config(),
+        TestOptions {
+            max_latency: Duration::from_micros(500),
+            max_buffered: 6,
+        },
+    )
 }
 
 #[embassy_executor::main]
 async fn main(_spawner: Spawner) {
     //let peripherals = embassy_stm32::init(config());
 
-    let options = options();
-    let peripherals = embassy_stm32::init(options.config);
+    let (config, options) = options();
+    let peripherals = embassy_stm32::init(config);
 
     let mut can = can::CanConfigurator::new(peripherals.FDCAN1, peripherals.PB8, peripherals.PB9, Irqs1);
     let mut can2 = can::CanConfigurator::new(peripherals.FDCAN2, peripherals.PB12, peripherals.PB13, Irqs2);
@@ -98,141 +100,16 @@ async fn main(_spawner: Spawner) {
     let mut can = can.into_internal_loopback_mode();
     let mut can2 = can2.into_internal_loopback_mode();
 
+    run_can_tests(&mut can, &options).await;
+    run_can_tests(&mut can2, &options).await;
+
     info!("CAN Configured");
-
-    let mut i: u8 = 0;
-    loop {
-        let tx_frame = can::frame::Frame::new_standard(0x123, &[i; 1]).unwrap();
-
-        info!("Transmitting frame...");
-        let tx_ts = Instant::now();
-        can.write(&tx_frame).await;
-
-        let (frame, timestamp) = can.read().await.unwrap().parts();
-        info!("Frame received!");
-
-        // Check data.
-        assert!(i == frame.data()[0], "{} == {}", i, frame.data()[0]);
-
-        info!("loopback time {}", timestamp);
-        info!("loopback frame {=u8}", frame.data()[0]);
-        let latency = timestamp.saturating_duration_since(tx_ts);
-        info!("loopback latency {} us", latency.as_micros());
-
-        // Theoretical minimum latency is 55us, actual is usually ~80us
-        const MIN_LATENCY: Duration = Duration::from_micros(50);
-        // Was failing at 150 but we are not getting a real time stamp. I'm not
-        // sure if there are other delays
-        assert!(
-            MIN_LATENCY <= latency && latency <= options.max_latency,
-            "{} <= {} <= {}",
-            MIN_LATENCY,
-            latency,
-            options.max_latency
-        );
-
-        i += 1;
-        if i > 10 {
-            break;
-        }
-    }
-
-    let mut i: u8 = 0;
-    loop {
-        let tx_frame = can::frame::Frame::new_standard(0x123, &[i; 1]).unwrap();
-
-        info!("Transmitting frame...");
-        let tx_ts = Instant::now();
-        can2.write(&tx_frame).await;
-
-        let (frame, timestamp) = can2.read().await.unwrap().parts();
-        info!("Frame received!");
-
-        //print_regs().await;
-        // Check data.
-        assert!(i == frame.data()[0], "{} == {}", i, frame.data()[0]);
-
-        info!("loopback time {}", timestamp);
-        info!("loopback frame {=u8}", frame.data()[0]);
-        let latency = timestamp.saturating_duration_since(tx_ts);
-        info!("loopback latency {} us", latency.as_micros());
-
-        // Theoretical minimum latency is 55us, actual is usually ~80us
-        const MIN_LATENCY: Duration = Duration::from_micros(50);
-        // Was failing at 150 but we are not getting a real time stamp. I'm not
-        // sure if there are other delays
-        assert!(
-            MIN_LATENCY <= latency && latency <= options.max_latency,
-            "{} <= {} <= {}",
-            MIN_LATENCY,
-            latency,
-            options.max_latency
-        );
-
-        i += 1;
-        if i > 10 {
-            break;
-        }
-    }
-
-    let max_buffered = if options.second_fifo_working { 6 } else { 3 };
-
-    // Below here, check that we can receive from both FIFO0 and FIFO0
-    // Above we configured FIFO1 for extended ID packets. There are only 3 slots
-    // in each FIFO so make sure we write enough to fill them both up before reading.
-    for i in 0..3 {
-        // Try filling up the RX FIFO0 buffers with standard packets
-        let tx_frame = can::frame::Frame::new_standard(0x123, &[i; 1]).unwrap();
-        info!("Transmitting frame {}", i);
-        can.write(&tx_frame).await;
-    }
-    for i in 3..max_buffered {
-        // Try filling up the RX FIFO0 buffers with extended packets
-        let tx_frame = can::frame::Frame::new_extended(0x1232344, &[i; 1]).unwrap();
-        info!("Transmitting frame {}", i);
-        can.write(&tx_frame).await;
-    }
-
-    // Try and receive all 6 packets
-    for i in 0..max_buffered {
-        let (frame, _ts) = can.read().await.unwrap().parts();
-        match frame.id() {
-            embedded_can::Id::Extended(id) => {
-                info!("Extended received! {:x} {} {}", id.as_raw(), frame.data()[0], i);
-            }
-            embedded_can::Id::Standard(id) => {
-                info!("Standard received! {:x} {} {}", id.as_raw(), frame.data()[0], i);
-            }
-        }
-    }
 
     // Test again with a split
     let (mut tx, mut rx) = can.split();
-    for i in 0..3 {
-        // Try filling up the RX FIFO0 buffers with standard packets
-        let tx_frame = can::frame::Frame::new_standard(0x123, &[i; 1]).unwrap();
-        info!("Transmitting frame {}", i);
-        tx.write(&tx_frame).await;
-    }
-    for i in 3..max_buffered {
-        // Try filling up the RX FIFO0 buffers with extended packets
-        let tx_frame = can::frame::Frame::new_extended(0x1232344, &[i; 1]).unwrap();
-        info!("Transmitting frame {}", i);
-        tx.write(&tx_frame).await;
-    }
-
-    // Try and receive all 6 packets
-    for i in 0..max_buffered {
-        let (frame, _ts) = rx.read().await.unwrap().parts();
-        match frame.id() {
-            embedded_can::Id::Extended(id) => {
-                info!("Extended received! {:x} {} {}", id.as_raw(), frame.data()[0], i);
-            }
-            embedded_can::Id::Standard(id) => {
-                info!("Standard received! {:x} {} {}", id.as_raw(), frame.data()[0], i);
-            }
-        }
-    }
+    let (mut tx2, mut rx2) = can2.split();
+    run_split_can_tests(&mut tx, &mut rx, &options).await;
+    run_split_can_tests(&mut tx2, &mut rx2, &options).await;
 
     info!("Test OK");
     cortex_m::asm::bkpt();


### PR DESCRIPTION
Now that both FDCAN and BXCAN are using stm32-metapac we can allow the same runtime features for both:

1. Same runtime API's
2. Same runtime features (optional interrupt+channel based FIFO)
3. Same Frame structure

Despite the branch name. This PR consists mainly of:

1. Preference for BXCAN API differences, because it has been out in the wild LOTS longer
2. Superset of features. i.e. more flexible buffering came from FDCAN.