### PR TITLE
Add a (optional) way to measure CPU load on Cortex M executor

### DIFF
--- a/embassy-executor/Cargo.toml
+++ b/embassy-executor/Cargo.toml
@@ -38,6 +38,8 @@ embassy-time-driver = { version = "0.1.0", path = "../embassy-time-driver", opti
 embassy-time-queue-driver = { version = "0.1.0", path = "../embassy-time-queue-driver", optional = true }
 critical-section = "1.1"
 
+embassy-time = { version = "0.3.0", path = "../embassy-time", optional = true }
+
 document-features = "0.2.7"
 
 # needed for AVR
@@ -69,6 +71,9 @@ turbowakers = []
 
 ## Use the executor-integrated `embassy-time` timer queue.
 integrated-timers = ["dep:embassy-time-driver", "dep:embassy-time-queue-driver"]
+
+## Use embassy-time to measure CPU load
+measure-cpu-load = ["dep:embassy-time"]
 
 #! ### Architecture
 _arch = [] # some arch was picked

--- a/embassy-executor/Cargo.toml
+++ b/embassy-executor/Cargo.toml
@@ -38,8 +38,6 @@ embassy-time-driver = { version = "0.1.0", path = "../embassy-time-driver", opti
 embassy-time-queue-driver = { version = "0.1.0", path = "../embassy-time-queue-driver", optional = true }
 critical-section = "1.1"
 
-embassy-time = { version = "0.3.0", path = "../embassy-time", optional = true }
-
 document-features = "0.2.7"
 
 # needed for AVR
@@ -73,7 +71,7 @@ turbowakers = []
 integrated-timers = ["dep:embassy-time-driver", "dep:embassy-time-queue-driver"]
 
 ## Use embassy-time to measure CPU load
-measure-cpu-load = ["dep:embassy-time"]
+measure-cpu-load = ["dep:embassy-time-driver"]
 
 #! ### Architecture
 _arch = [] # some arch was picked

--- a/embassy-executor/src/arch/cortex_m.rs
+++ b/embassy-executor/src/arch/cortex_m.rs
@@ -85,6 +85,24 @@ mod thread {
             }
         }
 
+        #[cfg(feature = "measure-cpu-load")]
+        /// Create a new Executor with a given CPU load measurement function.
+        pub fn new_with_cpu_load(f: fn(u64, u64)) -> Self {
+            Self {
+                inner: raw::Executor::new(THREAD_PENDER as *mut ()),
+                not_send: PhantomData,
+
+                #[cfg(feature = "measure-cpu-load")]
+                measure: Some( f ),
+            }
+        }
+
+        #[cfg(feature = "measure-cpu-load")]
+        /// Sets the CPU load measurement function.
+        pub fn measure_cpu_load(&mut self, f: fn(u64, u64)) {
+            self.measure = Some( f );
+        }
+
         /// Run the executor.
         ///
         /// The `init` closure is called with a [`Spawner`] that spawns tasks on
@@ -127,8 +145,6 @@ mod thread {
                             previous = wakeup;
                         }
                     }
-
-
 
                     self.inner.poll();
 

--- a/embassy-executor/src/arch/cortex_m.rs
+++ b/embassy-executor/src/arch/cortex_m.rs
@@ -136,11 +136,14 @@ mod thread {
             loop {
                 unsafe {
                     #[cfg(feature = "measure-cpu-load")]
+                    if self.measure.is_some() {
+                        wakeup = embassy_time_driver::now();
+                    }
                     {
                         if let Some( f ) = self.measure {
                             wakeup = embassy_time_driver::now();
 
-                            f( (wakeup - previous).as_ticks(), (sleep - previous).as_ticks() );
+                            f(  );
 
                             previous = wakeup;
                         }
@@ -149,8 +152,15 @@ mod thread {
                     self.inner.poll();
 
                     #[cfg(feature = "measure-cpu-load")]
-                    if self.measure.is_some() {
+                    if let Some( f ) = self.measure {
                         sleep = embassy_time_driver::now();
+
+                        let tc = sleep - previous;
+                        let ts = wakeup - previous;
+
+                        f( ts, tc )
+
+                        previous = sleep;
                     }
 
                     asm!("wfe");

--- a/embassy-executor/src/arch/cortex_m.rs
+++ b/embassy-executor/src/arch/cortex_m.rs
@@ -130,9 +130,6 @@ mod thread {
             #[cfg(feature = "measure-cpu-load")]
             let mut wakeup = previous;
 
-            #[cfg(feature = "measure-cpu-load")]
-            let mut sleep = previous;
-
             loop {
                 unsafe {
                     #[cfg(feature = "measure-cpu-load")]
@@ -144,7 +141,7 @@ mod thread {
 
                     #[cfg(feature = "measure-cpu-load")]
                     if let Some( f ) = self.measure {
-                        sleep = embassy_time_driver::now();
+                        let sleep = embassy_time_driver::now();
 
                         let tc = sleep - previous;
                         let ts = wakeup - previous;

--- a/embassy-executor/src/arch/cortex_m.rs
+++ b/embassy-executor/src/arch/cortex_m.rs
@@ -93,14 +93,14 @@ mod thread {
                 not_send: PhantomData,
 
                 #[cfg(feature = "measure-cpu-load")]
-                measure: Some( f ),
+                measure: Some(f),
             }
         }
 
         #[cfg(feature = "measure-cpu-load")]
         /// Sets the CPU load measurement function.
         pub fn measure_cpu_load(&mut self, f: fn(u64, u64)) {
-            self.measure = Some( f );
+            self.measure = Some(f);
         }
 
         /// Run the executor.
@@ -140,13 +140,13 @@ mod thread {
                     self.inner.poll();
 
                     #[cfg(feature = "measure-cpu-load")]
-                    if let Some( f ) = self.measure {
+                    if let Some(f) = self.measure {
                         let sleep = embassy_time_driver::now();
 
                         let tc = sleep - previous;
                         let ts = wakeup - previous;
 
-                        f( ts, tc );
+                        f(ts, tc);
 
                         previous = sleep;
                     }

--- a/embassy-executor/src/arch/cortex_m.rs
+++ b/embassy-executor/src/arch/cortex_m.rs
@@ -139,15 +139,6 @@ mod thread {
                     if self.measure.is_some() {
                         wakeup = embassy_time_driver::now();
                     }
-                    {
-                        if let Some( f ) = self.measure {
-                            wakeup = embassy_time_driver::now();
-
-                            f(  );
-
-                            previous = wakeup;
-                        }
-                    }
 
                     self.inner.poll();
 
@@ -158,7 +149,7 @@ mod thread {
                         let tc = sleep - previous;
                         let ts = wakeup - previous;
 
-                        f( ts, tc )
+                        f( ts, tc );
 
                         previous = sleep;
                     }

--- a/embassy-executor/src/arch/cortex_m.rs
+++ b/embassy-executor/src/arch/cortex_m.rs
@@ -125,7 +125,7 @@ mod thread {
             init(self.inner.spawner());
 
             #[cfg(feature = "measure-cpu-load")]
-            let mut previous = embassy_time::Instant::now();
+            let mut previous = embassy_time_driver::now();
 
             #[cfg(feature = "measure-cpu-load")]
             let mut wakeup = previous;
@@ -138,7 +138,7 @@ mod thread {
                     #[cfg(feature = "measure-cpu-load")]
                     {
                         if let Some( f ) = self.measure {
-                            wakeup = embassy_time::Instant::now();
+                            wakeup = embassy_time_driver::now();
 
                             f( (wakeup - previous).as_ticks(), (sleep - previous).as_ticks() );
 
@@ -150,7 +150,7 @@ mod thread {
 
                     #[cfg(feature = "measure-cpu-load")]
                     if self.measure.is_some() {
-                        sleep = embassy_time::Instant::now();
+                        sleep = embassy_time_driver::now();
                     }
 
                     asm!("wfe");

--- a/embassy-executor/src/arch/cortex_m.rs
+++ b/embassy-executor/src/arch/cortex_m.rs
@@ -125,7 +125,7 @@ mod thread {
             init(self.inner.spawner());
 
             #[cfg(feature = "measure-cpu-load")]
-            let mut previous = Instant::now();
+            let mut previous = embassy_time::Instant::now();
 
             #[cfg(feature = "measure-cpu-load")]
             let mut wakeup = previous;
@@ -138,7 +138,7 @@ mod thread {
                     #[cfg(feature = "measure-cpu-load")]
                     {
                         if let Some( f ) = self.measure {
-                            wakeup = Instant::now();
+                            wakeup = embassy_time::Instant::now();
 
                             f( (wakeup - previous).as_ticks(), (sleep - previous).as_ticks() );
 
@@ -150,7 +150,7 @@ mod thread {
 
                     #[cfg(feature = "measure-cpu-load")]
                     if self.measure.is_some() {
-                        sleep = Instant::now();
+                        sleep = embassy_time::Instant::now();
                     }
 
                     asm!("wfe");

--- a/examples/stm32f7/Cargo.toml
+++ b/examples/stm32f7/Cargo.toml
@@ -8,7 +8,7 @@ license = "MIT OR Apache-2.0"
 # Change stm32f777zi to your chip name, if necessary.
 embassy-stm32 = { version = "0.1.0", path = "../../embassy-stm32", features = ["defmt", "stm32f777zi", "memory-x", "unstable-pac", "time-driver-any", "exti"]  }
 embassy-sync = { version = "0.5.0", path = "../../embassy-sync", features = ["defmt"] }
-embassy-executor = { version = "0.5.0", path = "../../embassy-executor", features = ["task-arena-size-32768", "arch-cortex-m", "executor-thread", "defmt", "integrated-timers"] }
+embassy-executor = { version = "0.5.0", path = "../../embassy-executor", features = ["task-arena-size-32768", "arch-cortex-m", "executor-thread", "defmt", "integrated-timers", "measure-cpu-load"] }
 embassy-time = { version = "0.3.0", path = "../../embassy-time", features = ["defmt", "defmt-timestamp-uptime", "tick-hz-32_768"] }
 embassy-net = { version = "0.4.0", path = "../../embassy-net", features = ["defmt", "tcp", "dhcpv4", "medium-ethernet"] }
 embedded-io-async = { version = "0.6.1" }

--- a/examples/stm32f7/src/bin/cpuload.rs
+++ b/examples/stm32f7/src/bin/cpuload.rs
@@ -8,10 +8,8 @@ use embassy_time::Timer;
 use static_cell::StaticCell;
 use {defmt_rtt as _, panic_probe as _};
 
-
 /// Global executor.
 static EXECUTOR: StaticCell<Executor> = StaticCell::new();
-
 
 #[cortex_m_rt::entry]
 fn main() -> ! {
@@ -50,7 +48,6 @@ async fn asyncmain(_spawner: Spawner) -> ! {
         Timer::after_millis(DELAY).await;
     }
 }
-
 
 /// Sync function that receives the CPU load variables.
 /// `ts`: Sleep time. The amount of timer cycles between the last sleep and the most recent wakeup.

--- a/examples/stm32f7/src/bin/cpuload.rs
+++ b/examples/stm32f7/src/bin/cpuload.rs
@@ -5,9 +5,9 @@ use defmt::info;
 use embassy_executor::{Executor, Spawner};
 use embassy_stm32::Config;
 use embassy_time::Timer;
+use static_cell::StaticCell;
 use {defmt_rtt as _, panic_probe as _};
 
-use static_cell::StaticCell;
 
 /// Global executor.
 static EXECUTOR: StaticCell<Executor> = StaticCell::new();
@@ -19,13 +19,13 @@ fn main() -> ! {
     let mut executor = embassy_executor::Executor::new();
 
     // Set the measure function.
-    executor.measure_cpu_load( measure );
+    executor.measure_cpu_load(measure);
 
     // Initialize the singleton.
     let executor = EXECUTOR.init(executor);
 
     executor.run(|spawner| {
-        spawner.must_spawn( asyncmain(spawner.clone()) );
+        spawner.must_spawn(asyncmain(spawner.clone()));
     })
 }
 
@@ -36,7 +36,7 @@ async fn asyncmain(_spawner: Spawner) -> ! {
 
     // Modify these values to see the change in CPU load.
     const ITERS: usize = 10_000_000;
-    const DELAY: u64 = 10;
+    const DELAY: u64 = 1000;
 
     info!("Hello World!");
 
@@ -47,7 +47,7 @@ async fn asyncmain(_spawner: Spawner) -> ! {
         }
 
         // Go to sleep.
-        Timer::after_millis( DELAY ).await;
+        Timer::after_millis(DELAY).await;
     }
 }
 

--- a/examples/stm32f7/src/bin/cpuload.rs
+++ b/examples/stm32f7/src/bin/cpuload.rs
@@ -1,0 +1,71 @@
+#![no_std]
+#![no_main]
+
+use defmt::info;
+use embassy_executor::{Executor, Spawner};
+use embassy_stm32::Config;
+use embassy_time::Timer;
+use {defmt_rtt as _, panic_probe as _};
+
+use static_cell::StaticCell;
+
+/// Global executor.
+static EXECUTOR: StaticCell<Executor> = StaticCell::new();
+
+
+#[cortex_m_rt::entry]
+fn main() -> ! {
+    // Create the executor.
+    let mut executor = embassy_executor::Executor::new();
+
+    // Set the measure function.
+    executor.measure_cpu_load( measure );
+
+    // Initialize the singleton.
+    let executor = EXECUTOR.init(executor);
+
+    executor.run(|spawner| {
+        spawner.must_spawn( asyncmain(spawner.clone()) );
+    })
+}
+
+#[embassy_executor::task]
+async fn asyncmain(_spawner: Spawner) -> ! {
+    let config = Config::default();
+    let _p = embassy_stm32::init(config);
+
+    // Modify these values to see the change in CPU load.
+    const ITERS: usize = 10_000_000;
+    const DELAY: u64 = 10;
+
+    info!("Hello World!");
+
+    loop {
+        // Do some work.
+        for _ in 0..ITERS {
+            cortex_m::asm::nop();
+        }
+
+        // Go to sleep.
+        Timer::after_millis( DELAY ).await;
+    }
+}
+
+
+/// Sync function that receives the CPU load variables.
+/// `ts`: Sleep time. The amount of timer cycles between the last sleep and the most recent wakeup.
+/// `tc`: Cycle time. The amount of timer cycles between the last sleep and now.
+/// The formulas to calculate the CPU load are:
+///   - Fraction = 1 - (ts / tc).
+///   - Percent  = 100 - ((100 * ts) / tc)
+/// The current implementation only measures the load for the current poll cycle. Some cycles can be very short
+/// in the order of milliseconds or even microseconds. To reduce the effect of these short cycles on the CPU load
+/// values, it is recommended to store a series of cycles and then do a rolling average with the last handful
+/// of measurements weighted with the duration of the cycle.
+fn measure(ts: u64, tc: u64) {
+    // Calculate the load.
+    let load = 100 - ((100 * ts) / tc);
+
+    // Report the CPU load.
+    defmt::info!("CPU load: {}% [{} - {}]", load, ts, tc);
+}


### PR DESCRIPTION
This PR adds an opt-in way to create an Executor with very basic CPU load measurements. An example for the STM32F7 MCU is included.

Pros:
  - Builtin method that measures CPU load of a poll cycle
  - Each executor has its own independent measurement, no synchronization needed
  - It's opt-in, no changes to the executor if the feature is not used
  - No additional dependencies

Cons:
  - Adds a small delay before the executor starts polling and before the executor goes to sleep
  - The data provided is very simple, the user must implement their own logic to use the data properly
  - Not compatible with `#[embassy_executor::main]` macro