### PR TITLE
rp2040: Rename PWM_CH to PWM_SLICE

### DIFF
--- a/embassy-rp/src/lib.rs
+++ b/embassy-rp/src/lib.rs
@@ -183,14 +183,14 @@ embassy_hal_internal::peripherals! {
     DMA_CH10,
     DMA_CH11,
 
-    PWM_CH0,
-    PWM_CH1,
-    PWM_CH2,
-    PWM_CH3,
-    PWM_CH4,
-    PWM_CH5,
-    PWM_CH6,
-    PWM_CH7,
+    PWM_SLICE0,
+    PWM_SLICE1,
+    PWM_SLICE2,
+    PWM_SLICE3,
+    PWM_SLICE4,
+    PWM_SLICE5,
+    PWM_SLICE6,
+    PWM_SLICE7,
 
     USB,
 

--- a/embassy-rp/src/pwm.rs
+++ b/embassy-rp/src/pwm.rs
@@ -326,14 +326,14 @@ macro_rules! channel {
     };
 }
 
-channel!(PWM_CH0, 0);
-channel!(PWM_CH1, 1);
-channel!(PWM_CH2, 2);
-channel!(PWM_CH3, 3);
-channel!(PWM_CH4, 4);
-channel!(PWM_CH5, 5);
-channel!(PWM_CH6, 6);
-channel!(PWM_CH7, 7);
+channel!(PWM_SLICE0, 0);
+channel!(PWM_SLICE1, 1);
+channel!(PWM_SLICE2, 2);
+channel!(PWM_SLICE3, 3);
+channel!(PWM_SLICE4, 4);
+channel!(PWM_SLICE5, 5);
+channel!(PWM_SLICE6, 6);
+channel!(PWM_SLICE7, 7);
 
 /// PWM Pin A.
 pub trait PwmPinA<T: Channel>: GpioPin {}
@@ -346,33 +346,33 @@ macro_rules! impl_pin {
     };
 }
 
-impl_pin!(PIN_0, PWM_CH0, PwmPinA);
-impl_pin!(PIN_1, PWM_CH0, PwmPinB);
-impl_pin!(PIN_2, PWM_CH1, PwmPinA);
-impl_pin!(PIN_3, PWM_CH1, PwmPinB);
-impl_pin!(PIN_4, PWM_CH2, PwmPinA);
-impl_pin!(PIN_5, PWM_CH2, PwmPinB);
-impl_pin!(PIN_6, PWM_CH3, PwmPinA);
-impl_pin!(PIN_7, PWM_CH3, PwmPinB);
-impl_pin!(PIN_8, PWM_CH4, PwmPinA);
-impl_pin!(PIN_9, PWM_CH4, PwmPinB);
-impl_pin!(PIN_10, PWM_CH5, PwmPinA);
-impl_pin!(PIN_11, PWM_CH5, PwmPinB);
-impl_pin!(PIN_12, PWM_CH6, PwmPinA);
-impl_pin!(PIN_13, PWM_CH6, PwmPinB);
-impl_pin!(PIN_14, PWM_CH7, PwmPinA);
-impl_pin!(PIN_15, PWM_CH7, PwmPinB);
-impl_pin!(PIN_16, PWM_CH0, PwmPinA);
-impl_pin!(PIN_17, PWM_CH0, PwmPinB);
-impl_pin!(PIN_18, PWM_CH1, PwmPinA);
-impl_pin!(PIN_19, PWM_CH1, PwmPinB);
-impl_pin!(PIN_20, PWM_CH2, PwmPinA);
-impl_pin!(PIN_21, PWM_CH2, PwmPinB);
-impl_pin!(PIN_22, PWM_CH3, PwmPinA);
-impl_pin!(PIN_23, PWM_CH3, PwmPinB);
-impl_pin!(PIN_24, PWM_CH4, PwmPinA);
-impl_pin!(PIN_25, PWM_CH4, PwmPinB);
-impl_pin!(PIN_26, PWM_CH5, PwmPinA);
-impl_pin!(PIN_27, PWM_CH5, PwmPinB);
-impl_pin!(PIN_28, PWM_CH6, PwmPinA);
-impl_pin!(PIN_29, PWM_CH6, PwmPinB);
+impl_pin!(PIN_0, PWM_SLICE0, PwmPinA);
+impl_pin!(PIN_1, PWM_SLICE0, PwmPinB);
+impl_pin!(PIN_2, PWM_SLICE1, PwmPinA);
+impl_pin!(PIN_3, PWM_SLICE1, PwmPinB);
+impl_pin!(PIN_4, PWM_SLICE2, PwmPinA);
+impl_pin!(PIN_5, PWM_SLICE2, PwmPinB);
+impl_pin!(PIN_6, PWM_SLICE3, PwmPinA);
+impl_pin!(PIN_7, PWM_SLICE3, PwmPinB);
+impl_pin!(PIN_8, PWM_SLICE4, PwmPinA);
+impl_pin!(PIN_9, PWM_SLICE4, PwmPinB);
+impl_pin!(PIN_10, PWM_SLICE5, PwmPinA);
+impl_pin!(PIN_11, PWM_SLICE5, PwmPinB);
+impl_pin!(PIN_12, PWM_SLICE6, PwmPinA);
+impl_pin!(PIN_13, PWM_SLICE6, PwmPinB);
+impl_pin!(PIN_14, PWM_SLICE7, PwmPinA);
+impl_pin!(PIN_15, PWM_SLICE7, PwmPinB);
+impl_pin!(PIN_16, PWM_SLICE0, PwmPinA);
+impl_pin!(PIN_17, PWM_SLICE0, PwmPinB);
+impl_pin!(PIN_18, PWM_SLICE1, PwmPinA);
+impl_pin!(PIN_19, PWM_SLICE1, PwmPinB);
+impl_pin!(PIN_20, PWM_SLICE2, PwmPinA);
+impl_pin!(PIN_21, PWM_SLICE2, PwmPinB);
+impl_pin!(PIN_22, PWM_SLICE3, PwmPinA);
+impl_pin!(PIN_23, PWM_SLICE3, PwmPinB);
+impl_pin!(PIN_24, PWM_SLICE4, PwmPinA);
+impl_pin!(PIN_25, PWM_SLICE4, PwmPinB);
+impl_pin!(PIN_26, PWM_SLICE5, PwmPinA);
+impl_pin!(PIN_27, PWM_SLICE5, PwmPinB);
+impl_pin!(PIN_28, PWM_SLICE6, PwmPinA);
+impl_pin!(PIN_29, PWM_SLICE6, PwmPinB);

--- a/examples/rp/src/bin/pio_hd44780.rs
+++ b/examples/rp/src/bin/pio_hd44780.rs
@@ -35,7 +35,7 @@ async fn main(_spawner: Spawner) {
     // allowing direct connection of the display to the RP2040 without level shifters.
     let p = embassy_rp::init(Default::default());
 
-    let _pwm = Pwm::new_output_b(p.PWM_CH7, p.PIN_15, {
+    let _pwm = Pwm::new_output_b(p.PWM_SLICE7, p.PIN_15, {
         let mut c = pwm::Config::default();
         c.divider = 125.into();
         c.top = 100;

--- a/examples/rp/src/bin/pwm.rs
+++ b/examples/rp/src/bin/pwm.rs
@@ -18,7 +18,7 @@ async fn main(_spawner: Spawner) {
     let mut c: Config = Default::default();
     c.top = 0x8000;
     c.compare_b = 8;
-    let mut pwm = Pwm::new_output_b(p.PWM_CH4, p.PIN_25, c.clone());
+    let mut pwm = Pwm::new_output_b(p.PWM_SLICE4, p.PIN_25, c.clone());
 
     loop {
         info!("current LED duty cycle: {}/32768", c.compare_b);

--- a/examples/rp/src/bin/pwm_input.rs
+++ b/examples/rp/src/bin/pwm_input.rs
@@ -14,7 +14,7 @@ async fn main(_spawner: Spawner) {
     let p = embassy_rp::init(Default::default());
 
     let cfg: Config = Default::default();
-    let pwm = Pwm::new_input(p.PWM_CH2, p.PIN_5, InputMode::RisingEdge, cfg);
+    let pwm = Pwm::new_input(p.PWM_SLICE2, p.PIN_5, InputMode::RisingEdge, cfg);
 
     let mut ticker = Ticker::every(Duration::from_secs(1));
     loop {

--- a/examples/stm32f4/src/bin/ws2812_pwm.rs
+++ b/examples/stm32f4/src/bin/ws2812_pwm.rs
@@ -81,10 +81,10 @@ async fn main(_spawner: Spawner) {
 
     let color_list = &[&turn_off, &dim_white];
 
-    let pwm_channel = Channel::Ch1;
+    let PWM_SLICEannel = Channel::Ch1;
 
     // make sure PWM output keep low on first start
-    ws2812_pwm.set_duty(pwm_channel, 0);
+    ws2812_pwm.set_duty(PWM_SLICEannel, 0);
 
     // flip color at 2 Hz
     let mut ticker = Ticker::every(Duration::from_millis(500));
@@ -92,7 +92,7 @@ async fn main(_spawner: Spawner) {
     loop {
         for &color in color_list {
             // with &mut, we can easily reuse same DMA channel multiple times
-            ws2812_pwm.waveform_up(&mut dp.DMA1_CH2, pwm_channel, color).await;
+            ws2812_pwm.waveform_up(&mut dp.DMA1_CH2, PWM_SLICEannel, color).await;
             // ws2812 need at least 50 us low level input to confirm the input data and change it's state
             Timer::after_micros(50).await;
             // wait until ticker tick

--- a/tests/rp/src/bin/pwm.rs
+++ b/tests/rp/src/bin/pwm.rs
@@ -28,7 +28,7 @@ async fn main(_spawner: Spawner) {
 
     // Test free-running clock
     {
-        let pwm = Pwm::new_free(&mut p.PWM_CH3, cfg.clone());
+        let pwm = Pwm::new_free(&mut p.PWM_SLICE3, cfg.clone());
         cortex_m::asm::delay(125);
         let ctr = pwm.counter();
         assert!(ctr > 0);
@@ -46,7 +46,7 @@ async fn main(_spawner: Spawner) {
         // Test output from A
         {
             let pin1 = Input::new(&mut p9, Pull::None);
-            let _pwm = Pwm::new_output_a(&mut p.PWM_CH3, &mut p6, cfg.clone());
+            let _pwm = Pwm::new_output_a(&mut p.PWM_SLICE3, &mut p6, cfg.clone());
             Timer::after_millis(1).await;
             assert_eq!(pin1.is_low(), invert_a);
             Timer::after_millis(5).await;
@@ -60,7 +60,7 @@ async fn main(_spawner: Spawner) {
         // Test output from B
         {
             let pin2 = Input::new(&mut p11, Pull::None);
-            let _pwm = Pwm::new_output_b(&mut p.PWM_CH3, &mut p7, cfg.clone());
+            let _pwm = Pwm::new_output_b(&mut p.PWM_SLICE3, &mut p7, cfg.clone());
             Timer::after_millis(1).await;
             assert_ne!(pin2.is_low(), invert_a);
             Timer::after_millis(5).await;
@@ -75,7 +75,7 @@ async fn main(_spawner: Spawner) {
         {
             let pin1 = Input::new(&mut p9, Pull::None);
             let pin2 = Input::new(&mut p11, Pull::None);
-            let _pwm = Pwm::new_output_ab(&mut p.PWM_CH3, &mut p6, &mut p7, cfg.clone());
+            let _pwm = Pwm::new_output_ab(&mut p.PWM_SLICE3, &mut p6, &mut p7, cfg.clone());
             Timer::after_millis(1).await;
             assert_eq!(pin1.is_low(), invert_a);
             assert_ne!(pin2.is_low(), invert_a);
@@ -94,7 +94,7 @@ async fn main(_spawner: Spawner) {
     // Test level-gated
     {
         let mut pin2 = Output::new(&mut p11, Level::Low);
-        let pwm = Pwm::new_input(&mut p.PWM_CH3, &mut p7, InputMode::Level, cfg.clone());
+        let pwm = Pwm::new_input(&mut p.PWM_SLICE3, &mut p7, InputMode::Level, cfg.clone());
         assert_eq!(pwm.counter(), 0);
         Timer::after_millis(5).await;
         assert_eq!(pwm.counter(), 0);
@@ -110,7 +110,7 @@ async fn main(_spawner: Spawner) {
     // Test rising-gated
     {
         let mut pin2 = Output::new(&mut p11, Level::Low);
-        let pwm = Pwm::new_input(&mut p.PWM_CH3, &mut p7, InputMode::RisingEdge, cfg.clone());
+        let pwm = Pwm::new_input(&mut p.PWM_SLICE3, &mut p7, InputMode::RisingEdge, cfg.clone());
         assert_eq!(pwm.counter(), 0);
         Timer::after_millis(5).await;
         assert_eq!(pwm.counter(), 0);
@@ -125,7 +125,7 @@ async fn main(_spawner: Spawner) {
     // Test falling-gated
     {
         let mut pin2 = Output::new(&mut p11, Level::High);
-        let pwm = Pwm::new_input(&mut p.PWM_CH3, &mut p7, InputMode::FallingEdge, cfg.clone());
+        let pwm = Pwm::new_input(&mut p.PWM_SLICE3, &mut p7, InputMode::FallingEdge, cfg.clone());
         assert_eq!(pwm.counter(), 0);
         Timer::after_millis(5).await;
         assert_eq!(pwm.counter(), 0);


### PR DESCRIPTION
This pull request renames the `PWM_CH` data type that represents a PWM slice to `PWM_SLICE`. The purpose is to reduce the confusion between the PWM channel and PWM slice.

RP2040 has 8 PWM slices with two channels each (A and B).

It closes #2758 and https://github.com/UPB-FILS-MA/upb-fils-ma.github.io/issues/84.