### PR TITLE
stm32/qspi: autodeduce transfer len from buffer len.

### DIFF
--- a/embassy-stm32/src/qspi/mod.rs
+++ b/embassy-stm32/src/qspi/mod.rs
@@ -27,8 +27,6 @@ pub struct TransferConfig {
     pub address: Option<u32>,
     /// Number of dummy cycles (DCYC)
     pub dummy: DummyCycles,
-    /// Length of data
-    pub data_len: Option<usize>,
 }
 
 impl Default for TransferConfig {
@@ -40,7 +38,6 @@ impl Default for TransferConfig {
             instruction: 0,
             address: None,
             dummy: DummyCycles::_0,
-            data_len: None,
         }
     }
 }
@@ -231,7 +228,7 @@ impl<'d, T: Instance, Dma> Qspi<'d, T, Dma> {
     pub fn command(&mut self, transaction: TransferConfig) {
         #[cfg(not(stm32h7))]
         T::REGS.cr().modify(|v| v.set_dmaen(false));
-        self.setup_transaction(QspiMode::IndirectWrite, &transaction);
+        self.setup_transaction(QspiMode::IndirectWrite, &transaction, None);
 
         while !T::REGS.sr().read().tcf() {}
         T::REGS.fcr().modify(|v| v.set_ctcf(true));
@@ -241,21 +238,19 @@ impl<'d, T: Instance, Dma> Qspi<'d, T, Dma> {
     pub fn blocking_read(&mut self, buf: &mut [u8], transaction: TransferConfig) {
         #[cfg(not(stm32h7))]
         T::REGS.cr().modify(|v| v.set_dmaen(false));
-        self.setup_transaction(QspiMode::IndirectWrite, &transaction);
+        self.setup_transaction(QspiMode::IndirectWrite, &transaction, Some(buf.len()));
 
-        if let Some(len) = transaction.data_len {
-            let current_ar = T::REGS.ar().read().address();
-            T::REGS.ccr().modify(|v| {
-                v.set_fmode(QspiMode::IndirectRead.into());
-            });
-            T::REGS.ar().write(|v| {
-                v.set_address(current_ar);
-            });
+        let current_ar = T::REGS.ar().read().address();
+        T::REGS.ccr().modify(|v| {
+            v.set_fmode(QspiMode::IndirectRead.into());
+        });
+        T::REGS.ar().write(|v| {
+            v.set_address(current_ar);
+        });
 
-            for idx in 0..len {
-                while !T::REGS.sr().read().tcf() && !T::REGS.sr().read().ftf() {}
-                buf[idx] = unsafe { (T::REGS.dr().as_ptr() as *mut u8).read_volatile() };
-            }
+        for b in buf {
+            while !T::REGS.sr().read().tcf() && !T::REGS.sr().read().ftf() {}
+            *b = unsafe { (T::REGS.dr().as_ptr() as *mut u8).read_volatile() };
         }
 
         while !T::REGS.sr().read().tcf() {}
@@ -268,17 +263,15 @@ impl<'d, T: Instance, Dma> Qspi<'d, T, Dma> {
         #[cfg(not(stm32h7))]
         T::REGS.cr().modify(|v| v.set_dmaen(false));
 
-        self.setup_transaction(QspiMode::IndirectWrite, &transaction);
+        self.setup_transaction(QspiMode::IndirectWrite, &transaction, Some(buf.len()));
 
-        if let Some(len) = transaction.data_len {
-            T::REGS.ccr().modify(|v| {
-                v.set_fmode(QspiMode::IndirectWrite.into());
-            });
+        T::REGS.ccr().modify(|v| {
+            v.set_fmode(QspiMode::IndirectWrite.into());
+        });
 
-            for idx in 0..len {
-                while !T::REGS.sr().read().ftf() {}
-                unsafe { (T::REGS.dr().as_ptr() as *mut u8).write_volatile(buf[idx]) };
-            }
+        for &b in buf {
+            while !T::REGS.sr().read().ftf() {}
+            unsafe { (T::REGS.dr().as_ptr() as *mut u8).write_volatile(b) };
         }
 
         while !T::REGS.sr().read().tcf() {}
@@ -290,7 +283,7 @@ impl<'d, T: Instance, Dma> Qspi<'d, T, Dma> {
     where
         Dma: QuadDma<T>,
     {
-        self.setup_transaction(QspiMode::IndirectWrite, &transaction);
+        self.setup_transaction(QspiMode::IndirectWrite, &transaction, Some(buf.len()));
 
         T::REGS.ccr().modify(|v| {
             v.set_fmode(QspiMode::IndirectRead.into());
@@ -323,7 +316,7 @@ impl<'d, T: Instance, Dma> Qspi<'d, T, Dma> {
     where
         Dma: QuadDma<T>,
     {
-        self.setup_transaction(QspiMode::IndirectWrite, &transaction);
+        self.setup_transaction(QspiMode::IndirectWrite, &transaction, Some(buf.len()));
 
         T::REGS.ccr().modify(|v| {
             v.set_fmode(QspiMode::IndirectWrite.into());
@@ -347,7 +340,7 @@ impl<'d, T: Instance, Dma> Qspi<'d, T, Dma> {
         transfer.blocking_wait();
     }
 
-    fn setup_transaction(&mut self, fmode: QspiMode, transaction: &TransferConfig) {
+    fn setup_transaction(&mut self, fmode: QspiMode, transaction: &TransferConfig, data_len: Option<usize>) {
         T::REGS.fcr().modify(|v| {
             v.set_csmf(true);
             v.set_ctcf(true);
@@ -357,7 +350,7 @@ impl<'d, T: Instance, Dma> Qspi<'d, T, Dma> {
 
         while T::REGS.sr().read().busy() {}
 
-        if let Some(len) = transaction.data_len {
+        if let Some(len) = data_len {
             T::REGS.dlr().write(|v| v.set_dl(len as u32 - 1));
         }
 


### PR DESCRIPTION
mirrors change made in #2672.
