### PR TITLE
Fix 'clocok' typo in RCC docs

### DIFF
--- a/embassy-stm32/src/rcc/mod.rs
+++ b/embassy-stm32/src/rcc/mod.rs
@@ -111,7 +111,7 @@ mod util {
     }
 }
 
-/// Get the kernel clocok frequency of the peripheral `T`.
+/// Get the kernel clock frequency of the peripheral `T`.
 ///
 /// # Panics
 ///


### PR DESCRIPTION
Noticed a small typo while reading docs