### PR TITLE
Remove Generics from `embassy-rp` `Pwm` struct

### DIFF
--- a/examples/rp/src/bin/interrupt.rs
+++ b/examples/rp/src/bin/interrupt.rs
@@ -15,7 +15,6 @@ use embassy_executor::Spawner;
 use embassy_rp::adc::{self, Adc, Blocking};
 use embassy_rp::gpio::Pull;
 use embassy_rp::interrupt;
-use embassy_rp::peripherals::PWM_SLICE4;
 use embassy_rp::pwm::{Config, Pwm};
 use embassy_sync::blocking_mutex::raw::CriticalSectionRawMutex;
 use embassy_sync::blocking_mutex::Mutex;
@@ -26,7 +25,7 @@ use static_cell::StaticCell;
 use {defmt_rtt as _, panic_probe as _};
 
 static COUNTER: AtomicU32 = AtomicU32::new(0);
-static PWM: Mutex<CriticalSectionRawMutex, RefCell<Option<Pwm<PWM_SLICE4>>>> = Mutex::new(RefCell::new(None));
+static PWM: Mutex<CriticalSectionRawMutex, RefCell<Option<Pwm>>> = Mutex::new(RefCell::new(None));
 static ADC: Mutex<CriticalSectionRawMutex, RefCell<Option<(Adc<Blocking>, adc::Channel)>>> =
     Mutex::new(RefCell::new(None));
 static ADC_VALUES: Channel<CriticalSectionRawMutex, u16, 2048> = Channel::new();


### PR DESCRIPTION
This is based on the conversation on Element with @Dirbaio to the problem of being able to add different PWM stucts withing the same array.

https://matrix.to/#/!YoLPkieCYHGzdjUhOK:matrix.org/$fJxGz19y7xLRKlmtc-wOyqP-IXiaZ5IPY5OxoWwwFL4?via=matrix.org&via=tchncs.de&via=grusbv.com

Essentially:

```rust
        let mut pwm_config = Config::default();

        // Initial PWM duty cycle (bightness) - Range 0.0 (0) to 1.0 (65535)
        let duty_cycle = 0.5;
        pwm_config.compare_b = (duty_cycle * u16::MAX as f32) as u16;

        // (<LED ID>, <LED PIN>, <LED KIND>, <HANDLE>)
        let leds = [
            (
                0,
                0,
                "pwm",
                Pwm::new_output_a(slices.slice0, leds.led0, pwm_config),
            ),
            (
                1,
                6,
                "pwm",
                Pwm::new_output_a(slices.slice1, leds.led1, pwm_config),
            ),
            (
                2,
                7,
                "pwm",
                Pwm::new_output_a(slices.slice2, leds.led2, pwm_config),
            ),
            (
                3,
                8,
                "pwm",
                Pwm::new_output_a(slices.slice3, leds.led3, pwm_config),
            ),
        ];


```

This is not tested, I'm not really sure how to test it in the scope of this project. Also, please add any feedback! I kind of struggled through this using various resources to explain things like ChatGPT, so I'm not fully confident in this!