### PR TITLE
Add `map` method

### DIFF
--- a/.github/ci/test-nightly.sh
+++ b/.github/ci/test-nightly.sh
@@ -11,3 +11,4 @@ mv rust-toolchain-nightly.toml rust-toolchain.toml
 
 MIRIFLAGS=-Zmiri-ignore-leaks cargo miri test --manifest-path ./embassy-executor/Cargo.toml
 MIRIFLAGS=-Zmiri-ignore-leaks cargo miri test --manifest-path ./embassy-executor/Cargo.toml --features nightly
+MIRIFLAGS=-Zmiri-ignore-leaks cargo miri test --manifest-path ./embassy-sync/Cargo.toml


### PR DESCRIPTION
As requested in https://github.com/embassy-rs/embassy/issues/2768#issuecomment-2038277704.

Personally, I have never ever created a synchronization primitive so I have no clue if this implementation is sound. Everything was basically a copy and paste from the `futures` crate.

The "sound" part should be double checked for the `Send` and `Sync` implementations.