### PR TITLE
USB: fix comments about the config.max_packet_size_0 field

### DIFF
--- a/embassy-usb/src/builder.rs
+++ b/embassy-usb/src/builder.rs
@@ -38,11 +38,12 @@ pub struct Config<'a> {
 
     /// Maximum packet size in bytes for the control endpoint 0.
     ///
-    /// Valid values are 8, 16, 32 and 64. There's generally no need to change this from the default
-    /// value of 8 bytes unless a class uses control transfers for sending large amounts of data, in
-    /// which case using a larger packet size may be more efficient.
+    /// Valid values depend on the speed at which the bus is enumerated.
+    /// - low speed: 8
+    /// - full speed: 8, 16, 32, or 64
+    /// - high speed: 64
     ///
-    /// Default: 8 bytes
+    /// Default: 64 bytes
     pub max_packet_size_0: u8,
 
     /// Manufacturer name string descriptor.


### PR DESCRIPTION
Fix the comment about the default value: this defaults to 64 rather than 8 bytes.

It seems like the max packet size for endpoint 0 should normally be selected automatically, rather than being part of the config.  At best it seems like this setting should just be a hint that gets used if when the bus is operating at full speed.  The contents of the device descriptor should ideally be updated with the correct max packet size after bus enumeration completes.  In practice always using 64 is probably fine if low speed environments never need to be supported. (Super speed requires a max packet size of 512 bytes, which I didn't list in the comments here.)