### PR TITLE
Fix embassy-futures test failure

### DIFF
--- a/.github/ci/test.sh
+++ b/.github/ci/test.sh
@@ -8,6 +8,7 @@ export RUSTUP_HOME=/ci/cache/rustup
 export CARGO_HOME=/ci/cache/cargo
 export CARGO_TARGET_DIR=/ci/cache/target
 
+cargo test --manifest-path ./embassy-futures/Cargo.toml
 cargo test --manifest-path ./embassy-sync/Cargo.toml
 cargo test --manifest-path ./embassy-embedded-hal/Cargo.toml
 cargo test --manifest-path ./embassy-hal-internal/Cargo.toml

--- a/embassy-futures/src/yield_now.rs
+++ b/embassy-futures/src/yield_now.rs
@@ -9,10 +9,16 @@ use core::task::{Context, Poll};
 /// hold, while still allowing other tasks to run concurrently (not monopolizing
 /// the executor thread).
 ///
-/// ```rust,no_run
+/// ```rust
+/// # use embassy_futures::{block_on, yield_now};
+/// # async fn test_fn() {
+/// # let mut iter_count: u32 = 0;
+/// # let mut some_condition = || { iter_count += 1; iter_count > 10 };
 /// while !some_condition() {
 ///     yield_now().await;
 /// }
+/// # }
+/// # block_on(test_fn());
 /// ```
 ///
 /// The downside is this will spin in a busy loop, using 100% of the CPU, while


### PR DESCRIPTION
Running `cargo test` in embassy-futures was failing.  The `no_run` tag on this doc example caused it to still try and compile this example, just not run it, and compilation failed.  This updates the example so that it can successfully compile and run.