### PR TITLE
Update EndpointIn to allow arbitrary size writes

### DIFF
--- a/embassy-nrf/src/usb/mod.rs
+++ b/embassy-nrf/src/usb/mod.rs
@@ -597,8 +597,8 @@ impl<'d, T: Instance> driver::EndpointOut for Endpoint<'d, T, Out> {
     }
 }
 
-impl<'d, T: Instance> driver::EndpointIn for Endpoint<'d, T, In> {
-    async fn write(&mut self, buf: &[u8]) -> Result<(), EndpointError> {
+impl<'d, T: Instance> driver::EndpointInSinglePacket for Endpoint<'d, T, In> {
+    async fn write_one_packet(&mut self, buf: &[u8]) -> Result<(), EndpointError> {
         let i = self.info.addr.index();
         assert!(i != 0);
 

--- a/embassy-nrf/src/usb/mod.rs
+++ b/embassy-nrf/src/usb/mod.rs
@@ -598,7 +598,7 @@ impl<'d, T: Instance> driver::EndpointOut for Endpoint<'d, T, Out> {
 }
 
 impl<'d, T: Instance> driver::EndpointInSinglePacket for Endpoint<'d, T, In> {
-    async fn write_one_packet(&mut self, buf: &[u8]) -> Result<(), EndpointError> {
+    async fn write_packet(&mut self, buf: &[u8]) -> Result<(), EndpointError> {
         let i = self.info.addr.index();
         assert!(i != 0);
 

--- a/embassy-rp/src/usb.rs
+++ b/embassy-rp/src/usb.rs
@@ -573,7 +573,7 @@ impl<'d, T: Instance> driver::EndpointOut for Endpoint<'d, T, Out> {
 }
 
 impl<'d, T: Instance> driver::EndpointInSinglePacket for Endpoint<'d, T, In> {
-    async fn write_one_packet(&mut self, buf: &[u8]) -> Result<(), EndpointError> {
+    async fn write_packet(&mut self, buf: &[u8]) -> Result<(), EndpointError> {
         if buf.len() > self.info.max_packet_size as usize {
             return Err(EndpointError::BufferOverflow);
         }

--- a/embassy-rp/src/usb.rs
+++ b/embassy-rp/src/usb.rs
@@ -572,8 +572,8 @@ impl<'d, T: Instance> driver::EndpointOut for Endpoint<'d, T, Out> {
     }
 }
 
-impl<'d, T: Instance> driver::EndpointIn for Endpoint<'d, T, In> {
-    async fn write(&mut self, buf: &[u8]) -> Result<(), EndpointError> {
+impl<'d, T: Instance> driver::EndpointInSinglePacket for Endpoint<'d, T, In> {
+    async fn write_one_packet(&mut self, buf: &[u8]) -> Result<(), EndpointError> {
         if buf.len() > self.info.max_packet_size as usize {
             return Err(EndpointError::BufferOverflow);
         }

--- a/embassy-stm32/src/usb/otg.rs
+++ b/embassy-stm32/src/usb/otg.rs
@@ -1170,7 +1170,7 @@ impl<'d, T: Instance> embassy_usb_driver::EndpointOut for Endpoint<'d, T, Out> {
 // The Synopsis USB core does support issuing larger writes.  We should take advantage of
 // this in the future, but for now just do a simple one-packet-at-a-time implementation.
 impl<'d, T: Instance> embassy_usb_driver::EndpointInSinglePacket for Endpoint<'d, T, In> {
-    async fn write_one_packet(&mut self, buf: &[u8]) -> Result<(), EndpointError> {
+    async fn write_packet(&mut self, buf: &[u8]) -> Result<(), EndpointError> {
         trace!("write ep={:?} data={:?}", self.info.addr, buf);
 
         if buf.len() > self.info.max_packet_size as usize {

--- a/embassy-stm32/src/usb/otg.rs
+++ b/embassy-stm32/src/usb/otg.rs
@@ -1167,8 +1167,10 @@ impl<'d, T: Instance> embassy_usb_driver::EndpointOut for Endpoint<'d, T, Out> {
     }
 }
 
-impl<'d, T: Instance> embassy_usb_driver::EndpointIn for Endpoint<'d, T, In> {
-    async fn write(&mut self, buf: &[u8]) -> Result<(), EndpointError> {
+// The Synopsis USB core does support issuing larger writes.  We should take advantage of
+// this in the future, but for now just do a simple one-packet-at-a-time implementation.
+impl<'d, T: Instance> embassy_usb_driver::EndpointInSinglePacket for Endpoint<'d, T, In> {
+    async fn write_one_packet(&mut self, buf: &[u8]) -> Result<(), EndpointError> {
         trace!("write ep={:?} data={:?}", self.info.addr, buf);
 
         if buf.len() > self.info.max_packet_size as usize {

--- a/embassy-stm32/src/usb/usb.rs
+++ b/embassy-stm32/src/usb/usb.rs
@@ -762,8 +762,8 @@ impl<'d, T: Instance> driver::EndpointOut for Endpoint<'d, T, Out> {
     }
 }
 
-impl<'d, T: Instance> driver::EndpointIn for Endpoint<'d, T, In> {
-    async fn write(&mut self, buf: &[u8]) -> Result<(), EndpointError> {
+impl<'d, T: Instance> driver::EndpointInSinglePacket for Endpoint<'d, T, In> {
+    async fn write_one_packet(&mut self, buf: &[u8]) -> Result<(), EndpointError> {
         if buf.len() > self.info.max_packet_size as usize {
             return Err(EndpointError::BufferOverflow);
         }

--- a/embassy-stm32/src/usb/usb.rs
+++ b/embassy-stm32/src/usb/usb.rs
@@ -763,7 +763,7 @@ impl<'d, T: Instance> driver::EndpointOut for Endpoint<'d, T, Out> {
 }
 
 impl<'d, T: Instance> driver::EndpointInSinglePacket for Endpoint<'d, T, In> {
-    async fn write_one_packet(&mut self, buf: &[u8]) -> Result<(), EndpointError> {
+    async fn write_packet(&mut self, buf: &[u8]) -> Result<(), EndpointError> {
         if buf.len() > self.info.max_packet_size as usize {
             return Err(EndpointError::BufferOverflow);
         }

--- a/embassy-usb-driver/Cargo.toml
+++ b/embassy-usb-driver/Cargo.toml
@@ -22,3 +22,6 @@ features = ["defmt"]
 
 [dependencies]
 defmt = { version = "0.3", optional = true }
+
+[dev-dependencies]
+embassy-futures = { version = "0.1.0", path = "../embassy-futures" }

--- a/embassy-usb-driver/tests/test.rs
+++ b/embassy-usb-driver/tests/test.rs
@@ -1,0 +1,56 @@
+use embassy_usb_driver::*;
+
+struct TestEndpointIn {
+    info: EndpointInfo,
+    writes: Vec<Vec<u8>>,
+}
+
+impl Endpoint for TestEndpointIn {
+    fn info(&self) -> &EndpointInfo {
+        &self.info
+    }
+
+    async fn wait_enabled(&mut self) {}
+}
+
+impl EndpointInSinglePacket for TestEndpointIn {
+    async fn write_one_packet(&mut self, buf: &[u8]) -> Result<(), EndpointError> {
+        self.writes.push(buf.to_vec());
+        Ok(())
+    }
+}
+
+#[test]
+fn endpoint_in_single_packet() -> Result<(), EndpointError> {
+    let mut endpoint = TestEndpointIn {
+        info: EndpointInfo {
+            addr: EndpointAddress::from(0x81),
+            ep_type: EndpointType::Interrupt,
+            max_packet_size: 64,
+            interval_ms: 40,
+        },
+        writes: Vec::new(),
+    };
+
+    // Write 250 bytes.
+    let buf: [u8; 250] = std::array::from_fn(|n| n as u8);
+    embassy_futures::block_on(endpoint.write(&buf))?;
+
+    // The data should have been written as 3 64-byte packets, followed by a 58-byte packet.
+    let expected: [Vec<u8>; 4] = [
+        (0..64).collect(),
+        (64..128).collect(),
+        (128..192).collect(),
+        (192..250).collect(),
+    ];
+    assert_eq!(endpoint.writes, expected);
+
+    // A 0-length write should result in a 0-length call to write_one_packet()
+    endpoint.writes = Vec::new();
+    let buf: [u8; 0] = [];
+    embassy_futures::block_on(endpoint.write(&buf))?;
+    let expected: [Vec<u8>; 1] = [Vec::new()];
+    assert_eq!(endpoint.writes, expected);
+
+    Ok(())
+}


### PR DESCRIPTION
This updates the EndpointIn::write() API to support writes larger than the endpoint's maximum packet size.  A new EndpointInSinglePacket helper trait was added to support driver implementations that only allow writing a single packet at a time.  At the moment all of the provided drivers are still using this implementation, but they could be updated to write more data at once in the future.

This has not yet changed any code in embassy-usb to send larger packets.  I wasn't sure if it would be better to bump the
embassy-usb-driver version number before doing that, since this is a meaningful change, and we would want to ensure
that larger-sized writes aren't sent to older driver implementations that do not support this.