### PR TITLE
usb::hid::RequestHandler::set_report(&mut self, ...)

### DIFF
--- a/embassy-usb/src/class/hid.rs
+++ b/embassy-usb/src/class/hid.rs
@@ -378,7 +378,7 @@ pub trait RequestHandler {
     /// Reads the value of report `id` into `buf` returning the size.
     ///
     /// Returns `None` if `id` is invalid or no data is available.
-    fn get_report(&self, id: ReportId, buf: &mut [u8]) -> Option<usize> {
+    fn get_report(&mut self, id: ReportId, buf: &mut [u8]) -> Option<usize> {
         let _ = (id, buf);
         None
     }
@@ -394,7 +394,7 @@ pub trait RequestHandler {
     /// If `id` is `None`, get the idle rate for all reports. Returning `None`
     /// will reject the control request. Any duration at or above 1.024 seconds
     /// or below 4ms will be returned as an indefinite idle rate.
-    fn get_idle_ms(&self, id: Option<ReportId>) -> Option<u32> {
+    fn get_idle_ms(&mut self, id: Option<ReportId>) -> Option<u32> {
         let _ = id;
         None
     }
@@ -403,7 +403,7 @@ pub trait RequestHandler {
     ///
     /// If `id` is `None`, set the idle rate of all input reports to `dur`. If
     /// an indefinite duration is requested, `dur` will be set to `u32::MAX`.
-    fn set_idle_ms(&self, id: Option<ReportId>, duration_ms: u32) {
+    fn set_idle_ms(&mut self, id: Option<ReportId>, duration_ms: u32) {
         let _ = (id, duration_ms);
     }
 }

--- a/embassy-usb/src/class/hid.rs
+++ b/embassy-usb/src/class/hid.rs
@@ -37,7 +37,7 @@ pub struct Config<'d> {
     pub report_descriptor: &'d [u8],
 
     /// Handler for control requests.
-    pub request_handler: Option<&'d dyn RequestHandler>,
+    pub request_handler: Option<&'d mut dyn RequestHandler>,
 
     /// Configures how frequently the host should poll for reading/writing HID reports.
     ///
@@ -299,7 +299,7 @@ impl<'d, D: Driver<'d>, const N: usize> HidReader<'d, D, N> {
     ///
     /// If `use_report_ids` is true, the first byte of the report will be used as
     /// the `ReportId` value. Otherwise the `ReportId` value will be 0.
-    pub async fn run<T: RequestHandler>(mut self, use_report_ids: bool, handler: &T) -> ! {
+    pub async fn run<T: RequestHandler>(mut self, use_report_ids: bool, handler: &mut T) -> ! {
         let offset = self.offset.load(Ordering::Acquire);
         assert!(offset == 0);
         let mut buf = [0; N];
@@ -384,7 +384,7 @@ pub trait RequestHandler {
     }
 
     /// Sets the value of report `id` to `data`.
-    fn set_report(&self, id: ReportId, data: &[u8]) -> OutResponse {
+    fn set_report(&mut self, id: ReportId, data: &[u8]) -> OutResponse {
         let _ = (id, data);
         OutResponse::Rejected
     }
@@ -411,7 +411,7 @@ pub trait RequestHandler {
 struct Control<'d> {
     if_num: InterfaceNumber,
     report_descriptor: &'d [u8],
-    request_handler: Option<&'d dyn RequestHandler>,
+    request_handler: Option<&'d mut dyn RequestHandler>,
     out_report_offset: &'d AtomicUsize,
     hid_descriptor: [u8; 9],
 }
@@ -420,7 +420,7 @@ impl<'d> Control<'d> {
     fn new(
         if_num: InterfaceNumber,
         report_descriptor: &'d [u8],
-        request_handler: Option<&'d dyn RequestHandler>,
+        request_handler: Option<&'d mut dyn RequestHandler>,
         out_report_offset: &'d AtomicUsize,
     ) -> Self {
         Control {
@@ -468,7 +468,7 @@ impl<'d> Handler for Control<'d> {
         trace!("HID control_out {:?} {=[u8]:x}", req, data);
         match req.request {
             HID_REQ_SET_IDLE => {
-                if let Some(handler) = self.request_handler {
+                if let Some(handler) = self.request_handler.as_mut() {
                     let id = req.value as u8;
                     let id = (id != 0).then_some(ReportId::In(id));
                     let dur = u32::from(req.value >> 8);
@@ -477,7 +477,7 @@ impl<'d> Handler for Control<'d> {
                 }
                 Some(OutResponse::Accepted)
             }
-            HID_REQ_SET_REPORT => match (ReportId::try_from(req.value), self.request_handler) {
+            HID_REQ_SET_REPORT => match (ReportId::try_from(req.value), self.request_handler.as_mut()) {
                 (Ok(id), Some(handler)) => Some(handler.set_report(id, data)),
                 _ => Some(OutResponse::Rejected),
             },
@@ -513,7 +513,7 @@ impl<'d> Handler for Control<'d> {
                 match req.request {
                     HID_REQ_GET_REPORT => {
                         let size = match ReportId::try_from(req.value) {
-                            Ok(id) => self.request_handler.and_then(|x| x.get_report(id, buf)),
+                            Ok(id) => self.request_handler.as_mut().and_then(|x| x.get_report(id, buf)),
                             Err(_) => None,
                         };
 
@@ -524,7 +524,7 @@ impl<'d> Handler for Control<'d> {
                         }
                     }
                     HID_REQ_GET_IDLE => {
-                        if let Some(handler) = self.request_handler {
+                        if let Some(handler) = self.request_handler.as_mut() {
                             let id = req.value as u8;
                             let id = (id != 0).then_some(ReportId::In(id));
                             if let Some(dur) = handler.get_idle_ms(id) {

--- a/examples/nrf52840/src/bin/usb_hid_keyboard.rs
+++ b/examples/nrf52840/src/bin/usb_hid_keyboard.rs
@@ -148,7 +148,7 @@ async fn main(_spawner: Spawner) {
 struct MyRequestHandler {}
 
 impl RequestHandler for MyRequestHandler {
-    fn get_report(&self, id: ReportId, _buf: &mut [u8]) -> Option<usize> {
+    fn get_report(&mut self, id: ReportId, _buf: &mut [u8]) -> Option<usize> {
         info!("Get report for {:?}", id);
         None
     }
@@ -158,11 +158,11 @@ impl RequestHandler for MyRequestHandler {
         OutResponse::Accepted
     }
 
-    fn set_idle_ms(&self, id: Option<ReportId>, dur: u32) {
+    fn set_idle_ms(&mut self, id: Option<ReportId>, dur: u32) {
         info!("Set idle rate for {:?} to {:?}", id, dur);
     }
 
-    fn get_idle_ms(&self, id: Option<ReportId>) -> Option<u32> {
+    fn get_idle_ms(&mut self, id: Option<ReportId>) -> Option<u32> {
         info!("Get idle rate for {:?}", id);
         None
     }

--- a/examples/nrf52840/src/bin/usb_hid_keyboard.rs
+++ b/examples/nrf52840/src/bin/usb_hid_keyboard.rs
@@ -54,7 +54,7 @@ async fn main(_spawner: Spawner) {
     let mut bos_descriptor = [0; 256];
     let mut msos_descriptor = [0; 256];
     let mut control_buf = [0; 64];
-    let request_handler = MyRequestHandler {};
+    let mut request_handler = MyRequestHandler {};
     let mut device_handler = MyDeviceHandler::new();
 
     let mut state = State::new();
@@ -73,7 +73,7 @@ async fn main(_spawner: Spawner) {
     // Create classes on the builder.
     let config = embassy_usb::class::hid::Config {
         report_descriptor: KeyboardReport::desc(),
-        request_handler: Some(&request_handler),
+        request_handler: None,
         poll_ms: 60,
         max_packet_size: 64,
     };
@@ -137,7 +137,7 @@ async fn main(_spawner: Spawner) {
     };
 
     let out_fut = async {
-        reader.run(false, &request_handler).await;
+        reader.run(false, &mut request_handler).await;
     };
 
     // Run everything concurrently.
@@ -153,7 +153,7 @@ impl RequestHandler for MyRequestHandler {
         None
     }
 
-    fn set_report(&self, id: ReportId, data: &[u8]) -> OutResponse {
+    fn set_report(&mut self, id: ReportId, data: &[u8]) -> OutResponse {
         info!("Set report for {:?}: {=[u8]}", id, data);
         OutResponse::Accepted
     }

--- a/examples/nrf52840/src/bin/usb_hid_mouse.rs
+++ b/examples/nrf52840/src/bin/usb_hid_mouse.rs
@@ -47,7 +47,7 @@ async fn main(_spawner: Spawner) {
     let mut bos_descriptor = [0; 256];
     let mut msos_descriptor = [0; 256];
     let mut control_buf = [0; 64];
-    let request_handler = MyRequestHandler {};
+    let mut request_handler = MyRequestHandler {};
 
     let mut state = State::new();
 
@@ -63,7 +63,7 @@ async fn main(_spawner: Spawner) {
     // Create classes on the builder.
     let config = embassy_usb::class::hid::Config {
         report_descriptor: MouseReport::desc(),
-        request_handler: Some(&request_handler),
+        request_handler: Some(&mut request_handler),
         poll_ms: 60,
         max_packet_size: 8,
     };
@@ -110,7 +110,7 @@ impl RequestHandler for MyRequestHandler {
         None
     }
 
-    fn set_report(&self, id: ReportId, data: &[u8]) -> OutResponse {
+    fn set_report(&mut self, id: ReportId, data: &[u8]) -> OutResponse {
         info!("Set report for {:?}: {=[u8]}", id, data);
         OutResponse::Accepted
     }

--- a/examples/nrf52840/src/bin/usb_hid_mouse.rs
+++ b/examples/nrf52840/src/bin/usb_hid_mouse.rs
@@ -105,7 +105,7 @@ async fn main(_spawner: Spawner) {
 struct MyRequestHandler {}
 
 impl RequestHandler for MyRequestHandler {
-    fn get_report(&self, id: ReportId, _buf: &mut [u8]) -> Option<usize> {
+    fn get_report(&mut self, id: ReportId, _buf: &mut [u8]) -> Option<usize> {
         info!("Get report for {:?}", id);
         None
     }
@@ -115,11 +115,11 @@ impl RequestHandler for MyRequestHandler {
         OutResponse::Accepted
     }
 
-    fn set_idle_ms(&self, id: Option<ReportId>, dur: u32) {
+    fn set_idle_ms(&mut self, id: Option<ReportId>, dur: u32) {
         info!("Set idle rate for {:?} to {:?}", id, dur);
     }
 
-    fn get_idle_ms(&self, id: Option<ReportId>) -> Option<u32> {
+    fn get_idle_ms(&mut self, id: Option<ReportId>) -> Option<u32> {
         info!("Get idle rate for {:?}", id);
         None
     }

--- a/examples/rp/src/bin/usb_hid_keyboard.rs
+++ b/examples/rp/src/bin/usb_hid_keyboard.rs
@@ -41,7 +41,7 @@ async fn main(_spawner: Spawner) {
     // You can also add a Microsoft OS descriptor.
     let mut msos_descriptor = [0; 256];
     let mut control_buf = [0; 64];
-    let request_handler = MyRequestHandler {};
+    let mut request_handler = MyRequestHandler {};
     let mut device_handler = MyDeviceHandler::new();
 
     let mut state = State::new();
@@ -60,7 +60,7 @@ async fn main(_spawner: Spawner) {
     // Create classes on the builder.
     let config = embassy_usb::class::hid::Config {
         report_descriptor: KeyboardReport::desc(),
-        request_handler: Some(&request_handler),
+        request_handler: None,
         poll_ms: 60,
         max_packet_size: 64,
     };
@@ -114,7 +114,7 @@ async fn main(_spawner: Spawner) {
     };
 
     let out_fut = async {
-        reader.run(false, &request_handler).await;
+        reader.run(false, &mut request_handler).await;
     };
 
     // Run everything concurrently.
@@ -130,7 +130,7 @@ impl RequestHandler for MyRequestHandler {
         None
     }
 
-    fn set_report(&self, id: ReportId, data: &[u8]) -> OutResponse {
+    fn set_report(&mut self, id: ReportId, data: &[u8]) -> OutResponse {
         info!("Set report for {:?}: {=[u8]}", id, data);
         OutResponse::Accepted
     }

--- a/examples/rp/src/bin/usb_hid_keyboard.rs
+++ b/examples/rp/src/bin/usb_hid_keyboard.rs
@@ -125,7 +125,7 @@ async fn main(_spawner: Spawner) {
 struct MyRequestHandler {}
 
 impl RequestHandler for MyRequestHandler {
-    fn get_report(&self, id: ReportId, _buf: &mut [u8]) -> Option<usize> {
+    fn get_report(&mut self, id: ReportId, _buf: &mut [u8]) -> Option<usize> {
         info!("Get report for {:?}", id);
         None
     }
@@ -135,11 +135,11 @@ impl RequestHandler for MyRequestHandler {
         OutResponse::Accepted
     }
 
-    fn set_idle_ms(&self, id: Option<ReportId>, dur: u32) {
+    fn set_idle_ms(&mut self, id: Option<ReportId>, dur: u32) {
         info!("Set idle rate for {:?} to {:?}", id, dur);
     }
 
-    fn get_idle_ms(&self, id: Option<ReportId>) -> Option<u32> {
+    fn get_idle_ms(&mut self, id: Option<ReportId>) -> Option<u32> {
         info!("Get idle rate for {:?}", id);
         None
     }

--- a/examples/rp/src/bin/usb_hid_mouse.rs
+++ b/examples/rp/src/bin/usb_hid_mouse.rs
@@ -117,7 +117,7 @@ async fn main(_spawner: Spawner) {
 struct MyRequestHandler {}
 
 impl RequestHandler for MyRequestHandler {
-    fn get_report(&self, id: ReportId, _buf: &mut [u8]) -> Option<usize> {
+    fn get_report(&mut self, id: ReportId, _buf: &mut [u8]) -> Option<usize> {
         info!("Get report for {:?}", id);
         None
     }
@@ -127,11 +127,11 @@ impl RequestHandler for MyRequestHandler {
         OutResponse::Accepted
     }
 
-    fn set_idle_ms(&self, id: Option<ReportId>, dur: u32) {
+    fn set_idle_ms(&mut self, id: Option<ReportId>, dur: u32) {
         info!("Set idle rate for {:?} to {:?}", id, dur);
     }
 
-    fn get_idle_ms(&self, id: Option<ReportId>) -> Option<u32> {
+    fn get_idle_ms(&mut self, id: Option<ReportId>) -> Option<u32> {
         info!("Get idle rate for {:?}", id);
         None
     }

--- a/examples/rp/src/bin/usb_hid_mouse.rs
+++ b/examples/rp/src/bin/usb_hid_mouse.rs
@@ -44,7 +44,7 @@ async fn main(_spawner: Spawner) {
     // You can also add a Microsoft OS descriptor.
     let mut msos_descriptor = [0; 256];
     let mut control_buf = [0; 64];
-    let request_handler = MyRequestHandler {};
+    let mut request_handler = MyRequestHandler {};
     let mut device_handler = MyDeviceHandler::new();
 
     let mut state = State::new();
@@ -63,7 +63,7 @@ async fn main(_spawner: Spawner) {
     // Create classes on the builder.
     let config = embassy_usb::class::hid::Config {
         report_descriptor: MouseReport::desc(),
-        request_handler: Some(&request_handler),
+        request_handler: None,
         poll_ms: 60,
         max_packet_size: 64,
     };
@@ -106,7 +106,7 @@ async fn main(_spawner: Spawner) {
     };
 
     let out_fut = async {
-        reader.run(false, &request_handler).await;
+        reader.run(false, &mut request_handler).await;
     };
 
     // Run everything concurrently.
@@ -122,7 +122,7 @@ impl RequestHandler for MyRequestHandler {
         None
     }
 
-    fn set_report(&self, id: ReportId, data: &[u8]) -> OutResponse {
+    fn set_report(&mut self, id: ReportId, data: &[u8]) -> OutResponse {
         info!("Set report for {:?}: {=[u8]}", id, data);
         OutResponse::Accepted
     }

--- a/examples/stm32f4/src/bin/usb_hid_keyboard.rs
+++ b/examples/stm32f4/src/bin/usb_hid_keyboard.rs
@@ -76,7 +76,7 @@ async fn main(_spawner: Spawner) {
     let mut msos_descriptor = [0; 256];
     let mut control_buf = [0; 64];
 
-    let request_handler = MyRequestHandler {};
+    let mut request_handler = MyRequestHandler {};
     let mut device_handler = MyDeviceHandler::new();
 
     let mut state = State::new();
@@ -95,7 +95,7 @@ async fn main(_spawner: Spawner) {
     // Create classes on the builder.
     let config = embassy_usb::class::hid::Config {
         report_descriptor: KeyboardReport::desc(),
-        request_handler: Some(&request_handler),
+        request_handler: None,
         poll_ms: 60,
         max_packet_size: 8,
     };
@@ -148,7 +148,7 @@ async fn main(_spawner: Spawner) {
     };
 
     let out_fut = async {
-        reader.run(false, &request_handler).await;
+        reader.run(false, &mut request_handler).await;
     };
 
     // Run everything concurrently.
@@ -164,7 +164,7 @@ impl RequestHandler for MyRequestHandler {
         None
     }
 
-    fn set_report(&self, id: ReportId, data: &[u8]) -> OutResponse {
+    fn set_report(&mut self, id: ReportId, data: &[u8]) -> OutResponse {
         info!("Set report for {:?}: {=[u8]}", id, data);
         OutResponse::Accepted
     }

--- a/examples/stm32f4/src/bin/usb_hid_keyboard.rs
+++ b/examples/stm32f4/src/bin/usb_hid_keyboard.rs
@@ -159,7 +159,7 @@ async fn main(_spawner: Spawner) {
 struct MyRequestHandler {}
 
 impl RequestHandler for MyRequestHandler {
-    fn get_report(&self, id: ReportId, _buf: &mut [u8]) -> Option<usize> {
+    fn get_report(&mut self, id: ReportId, _buf: &mut [u8]) -> Option<usize> {
         info!("Get report for {:?}", id);
         None
     }
@@ -169,11 +169,11 @@ impl RequestHandler for MyRequestHandler {
         OutResponse::Accepted
     }
 
-    fn set_idle_ms(&self, id: Option<ReportId>, dur: u32) {
+    fn set_idle_ms(&mut self, id: Option<ReportId>, dur: u32) {
         info!("Set idle rate for {:?} to {:?}", id, dur);
     }
 
-    fn get_idle_ms(&self, id: Option<ReportId>) -> Option<u32> {
+    fn get_idle_ms(&mut self, id: Option<ReportId>) -> Option<u32> {
         info!("Get idle rate for {:?}", id);
         None
     }

--- a/examples/stm32f4/src/bin/usb_hid_mouse.rs
+++ b/examples/stm32f4/src/bin/usb_hid_mouse.rs
@@ -68,7 +68,7 @@ async fn main(_spawner: Spawner) {
     let mut bos_descriptor = [0; 256];
     let mut control_buf = [0; 64];
 
-    let request_handler = MyRequestHandler {};
+    let mut request_handler = MyRequestHandler {};
 
     let mut state = State::new();
 
@@ -84,7 +84,7 @@ async fn main(_spawner: Spawner) {
     // Create classes on the builder.
     let config = embassy_usb::class::hid::Config {
         report_descriptor: MouseReport::desc(),
-        request_handler: Some(&request_handler),
+        request_handler: Some(&mut request_handler),
         poll_ms: 60,
         max_packet_size: 8,
     };
@@ -131,7 +131,7 @@ impl RequestHandler for MyRequestHandler {
         None
     }
 
-    fn set_report(&self, id: ReportId, data: &[u8]) -> OutResponse {
+    fn set_report(&mut self, id: ReportId, data: &[u8]) -> OutResponse {
         info!("Set report for {:?}: {=[u8]}", id, data);
         OutResponse::Accepted
     }

--- a/examples/stm32f4/src/bin/usb_hid_mouse.rs
+++ b/examples/stm32f4/src/bin/usb_hid_mouse.rs
@@ -126,7 +126,7 @@ async fn main(_spawner: Spawner) {
 struct MyRequestHandler {}
 
 impl RequestHandler for MyRequestHandler {
-    fn get_report(&self, id: ReportId, _buf: &mut [u8]) -> Option<usize> {
+    fn get_report(&mut self, id: ReportId, _buf: &mut [u8]) -> Option<usize> {
         info!("Get report for {:?}", id);
         None
     }
@@ -136,11 +136,11 @@ impl RequestHandler for MyRequestHandler {
         OutResponse::Accepted
     }
 
-    fn set_idle_ms(&self, id: Option<ReportId>, dur: u32) {
+    fn set_idle_ms(&mut self, id: Option<ReportId>, dur: u32) {
         info!("Set idle rate for {:?} to {:?}", id, dur);
     }
 
-    fn get_idle_ms(&self, id: Option<ReportId>) -> Option<u32> {
+    fn get_idle_ms(&mut self, id: Option<ReportId>) -> Option<u32> {
         info!("Get idle rate for {:?}", id);
         None
     }

--- a/examples/stm32l5/src/bin/usb_hid_mouse.rs
+++ b/examples/stm32l5/src/bin/usb_hid_mouse.rs
@@ -54,7 +54,7 @@ async fn main(_spawner: Spawner) {
     let mut config_descriptor = [0; 256];
     let mut bos_descriptor = [0; 256];
     let mut control_buf = [0; 64];
-    let request_handler = MyRequestHandler {};
+    let mut request_handler = MyRequestHandler {};
 
     let mut state = State::new();
 
@@ -70,7 +70,7 @@ async fn main(_spawner: Spawner) {
     // Create classes on the builder.
     let config = embassy_usb::class::hid::Config {
         report_descriptor: MouseReport::desc(),
-        request_handler: Some(&request_handler),
+        request_handler: Some(&mut request_handler),
         poll_ms: 60,
         max_packet_size: 8,
     };
@@ -117,7 +117,7 @@ impl RequestHandler for MyRequestHandler {
         None
     }
 
-    fn set_report(&self, id: ReportId, data: &[u8]) -> OutResponse {
+    fn set_report(&mut self, id: ReportId, data: &[u8]) -> OutResponse {
         info!("Set report for {:?}: {=[u8]}", id, data);
         OutResponse::Accepted
     }

--- a/examples/stm32l5/src/bin/usb_hid_mouse.rs
+++ b/examples/stm32l5/src/bin/usb_hid_mouse.rs
@@ -112,7 +112,7 @@ async fn main(_spawner: Spawner) {
 struct MyRequestHandler {}
 
 impl RequestHandler for MyRequestHandler {
-    fn get_report(&self, id: ReportId, _buf: &mut [u8]) -> Option<usize> {
+    fn get_report(&mut self, id: ReportId, _buf: &mut [u8]) -> Option<usize> {
         info!("Get report for {:?}", id);
         None
     }
@@ -122,11 +122,11 @@ impl RequestHandler for MyRequestHandler {
         OutResponse::Accepted
     }
 
-    fn set_idle_ms(&self, id: Option<ReportId>, dur: u32) {
+    fn set_idle_ms(&mut self, id: Option<ReportId>, dur: u32) {
         info!("Set idle rate for {:?} to {:?}", id, dur);
     }
 
-    fn get_idle_ms(&self, id: Option<ReportId>) -> Option<u32> {
+    fn get_idle_ms(&mut self, id: Option<ReportId>) -> Option<u32> {
         info!("Get idle rate for {:?}", id);
         None
     }


### PR DESCRIPTION
Goal is to be able to act upon an outside report.
For example a report could show that CapsLock and NumLock are on, but we may only want to do an action if there is a change in those states. This can be done by keeping and comparing with a previous report in the RequestHandler.

I've updated the examples that were using that API.