### PR TITLE
Bug: There are at most 18 channels for the STM32G4 ADCs.

### DIFF
--- a/embassy-stm32/src/adc/g4.rs
+++ b/embassy-stm32/src/adc/g4.rs
@@ -170,7 +170,7 @@ impl<'d, T: Instance> Adc<'d, T> {
 
     fn configure_differential_inputs(&mut self) {
         T::regs().difsel().modify(|w| {
-            for n in 0..20 {
+            for n in 0..18 {
                 w.set_difsel(n, Difsel::SINGLEENDED);
             }
         });


### PR DESCRIPTION
The max number of channels for the ADCs in STM32G4 MCUs is 18 instead of 20, this is causing panic behaviour in smt32-metapac.

