### PR TITLE
stm32: ensure the core runs on HSI clock while setting up rcc

### DIFF
--- a/embassy-stm32/src/rcc/f247.rs
+++ b/embassy-stm32/src/rcc/f247.rs
@@ -146,17 +146,18 @@ pub(crate) unsafe fn init(config: Config) {
         while !PWR.csr1().read().odswrdy() {}
     }
 
+    // Turn on the HSI
+    RCC.cr().modify(|w| w.set_hsion(true));
+    while !RCC.cr().read().hsirdy() {}
+
+    // Use the HSI clock as system clock during the actual clock setup
+    RCC.cfgr().modify(|w| w.set_sw(Sysclk::HSI));
+    while RCC.cfgr().read().sws() != Sysclk::HSI {}
+
     // Configure HSI
     let hsi = match config.hsi {
-        false => {
-            RCC.cr().modify(|w| w.set_hsion(false));
-            None
-        }
-        true => {
-            RCC.cr().modify(|w| w.set_hsion(true));
-            while !RCC.cr().read().hsirdy() {}
-            Some(HSI_FREQ)
-        }
+        false => None,
+        true => Some(HSI_FREQ),
     };
 
     // Configure HSE
@@ -259,6 +260,11 @@ pub(crate) unsafe fn init(config: Config) {
         w.set_ppre2(config.apb2_pre);
     });
     while RCC.cfgr().read().sws() != config.sys {}
+
+    // Disable HSI if not used
+    if !config.hsi {
+        RCC.cr().modify(|w| w.set_hsion(false));
+    }
 
     config.mux.init();
 


### PR DESCRIPTION
I'm working on a project with a bootloader that does it's things then jump to the main firmware, and I've got issues with the stm32 core locking up when the main firmware starts.
The issue is that both the bootloader and the main firmware are initializing the system clock to use a PLL (based on HSE clock).
When the main firmware starts, the core is already running using the PLL (setup by the bootloader), then the main firmware calls embassy_stm32::init() which setup the PLL by first turning it off (causing the CPU to stop running !!!) before setting it up and turning it on again.

With this patch, rcc::init() will first setup the core to run on the HSI clock, then do the whole clock setup, then switch the core to the requested clock (PLL, HSE...), and then turning off the HSI clock (if requested).
This ensures that the core always have a valid clock source during the whole process of setting up the rcc.

This may also help with config as described in #2806, which use PLL/HSE and disable HSI. The current code was first turning the HSI OFF (while the core is probably running on it), and then setup the requested clock. With this patch, the HSI clock will only be turned off after the requested clock was setup.

On a freshly reset core, this patch won't have any impact (the core is already running on HSI at reset), except for the fact that the HSI will be turned off later in the process, after the rcc was setup as requested.

Note that this patch only applies to F2/F4/F7 series, but if this is accepted, I can make a similar change to other series.