### PR TITLE
stm32: can: fd: implement bus-off recovery

### DIFF
--- a/embassy-stm32/src/can/fd/peripheral.rs
+++ b/embassy-stm32/src/can/fd/peripheral.rs
@@ -368,6 +368,7 @@ impl Registers {
             w.set_rfne(0, true); // Rx Fifo 0 New Msg
             w.set_rfne(1, true); // Rx Fifo 1 New Msg
             w.set_tce(true); //  Tx Complete
+            w.set_boe(true); // Bus-Off Status Changed
         });
         self.regs.ile().modify(|w| {
             w.set_eint0(true); // Interrupt Line 0

--- a/embassy-stm32/src/can/fdcan.rs
+++ b/embassy-stm32/src/can/fdcan.rs
@@ -81,6 +81,14 @@ impl<T: Instance> interrupt::typelevel::Handler<T::IT0Interrupt> for IT0Interrup
         if ir.rfn(1) {
             T::state().rx_mode.on_interrupt::<T>(1);
         }
+
+        if ir.bo() {
+            regs.ir().write(|w| w.set_bo(true));
+            if regs.psr().read().bo() {
+                // Initiate bus-off recovery sequence by resetting CCCR.INIT
+                regs.cccr().modify(|w| w.set_init(false));
+            }
+        }
     }
 }
 


### PR DESCRIPTION
FDCAN has no automatic bus-off recovery, see RM0492 p. 1600:

<img width="973" alt="image" src="https://github.com/embassy-rs/embassy/assets/40573959/1e7a9e5b-7613-458b-98b2-e409682b1793">

Also cleaned up the interrupt handler a little