### PR TITLE
Link back to Cargo.toml section.

### DIFF
--- a/docs/modules/ROOT/pages/sharing_peripherals.adoc
+++ b/docs/modules/ROOT/pages/sharing_peripherals.adoc
@@ -8,7 +8,7 @@ The following examples shows different ways to use the on-board LED on a Raspber
 
 Using mutual exclusion is the simplest way to share a peripheral.
 
-TIP: The depenencies you need to run this example link:/book/dev/basic_application.html#_the_cargo_toml[can be found here].
+TIP: Dependencies needed to run this example link:/book/dev/basic_application.html#_the_cargo_toml[can be found here].
 [,rust]
 ----
 use defmt::*;
@@ -78,7 +78,7 @@ To indicate that the pin will be set to an Output. The `AnyPin` could have been 
 
 A channel is another way to ensure exclusive access to a resource. Using a channel is great in the cases where the access can happen at a later point in time, allowing you to enqueue operations and do other things.
 
-TIP: The depenencies you need to run this example link:/book/dev/basic_application.html#_the_cargo_toml[can be found here].
+TIP: Dependencies needed to run this example link:/book/dev/basic_application.html#_the_cargo_toml[can be found here].
 [,rust]
 ----
 use defmt::*;

--- a/docs/modules/ROOT/pages/sharing_peripherals.adoc
+++ b/docs/modules/ROOT/pages/sharing_peripherals.adoc
@@ -8,6 +8,7 @@ The following examples shows different ways to use the on-board LED on a Raspber
 
 Using mutual exclusion is the simplest way to share a peripheral.
 
+TIP: The depenencies you need to run this example link:/book/dev/basic_application.html#_the_cargo_toml[can be found here].
 [,rust]
 ----
 use defmt::*;
@@ -77,6 +78,7 @@ To indicate that the pin will be set to an Output. The `AnyPin` could have been 
 
 A channel is another way to ensure exclusive access to a resource. Using a channel is great in the cases where the access can happen at a later point in time, allowing you to enqueue operations and do other things.
 
+TIP: The depenencies you need to run this example link:/book/dev/basic_application.html#_the_cargo_toml[can be found here].
 [,rust]
 ----
 use defmt::*;

--- a/docs/modules/ROOT/pages/time_keeping.adoc
+++ b/docs/modules/ROOT/pages/time_keeping.adoc
@@ -16,6 +16,7 @@ The `embassy::time::Timer` type provides two timing methods.
 
 An example of a delay is provided as follows:
 
+TIP: The depenencies you need to run this example link:/book/dev/basic_application.html#_the_cargo_toml[can be found here].
 [,rust]
 ----
 use embassy::executor::{task, Executor};
@@ -40,6 +41,7 @@ that expect a generic delay implementation to be provided.
 
 An example of how this can be used:
 
+TIP: The depenencies you need to run this example link:/book/dev/basic_application.html#_the_cargo_toml[can be found here].
 [,rust]
 ----
 use embassy::executor::{task, Executor};

--- a/docs/modules/ROOT/pages/time_keeping.adoc
+++ b/docs/modules/ROOT/pages/time_keeping.adoc
@@ -16,7 +16,7 @@ The `embassy::time::Timer` type provides two timing methods.
 
 An example of a delay is provided as follows:
 
-TIP: The depenencies you need to run this example link:/book/dev/basic_application.html#_the_cargo_toml[can be found here].
+TIP: Dependencies needed to run this example link:/book/dev/basic_application.html#_the_cargo_toml[can be found here].
 [,rust]
 ----
 use embassy::executor::{task, Executor};
@@ -41,7 +41,7 @@ that expect a generic delay implementation to be provided.
 
 An example of how this can be used:
 
-TIP: The depenencies you need to run this example link:/book/dev/basic_application.html#_the_cargo_toml[can be found here].
+TIP: Dependencies needed to run this example link:/book/dev/basic_application.html#_the_cargo_toml[can be found here].
 [,rust]
 ----
 use embassy::executor::{task, Executor};


### PR DESCRIPTION
This is mostly so that when someone comes into this project sideways (they are linked into the document directly, into a section that has a code example) they have context so they know what they need to build the project correctly.