### PR TITLE
Add a comment to the pio rx fifo pull function

### DIFF
--- a/embassy-rp/src/pio/mod.rs
+++ b/embassy-rp/src/pio/mod.rs
@@ -324,6 +324,10 @@ impl<'d, PIO: Instance, const SM: usize> StateMachineRx<'d, PIO, SM> {
     }
 
     /// Pull data from RX FIFO.
+    ///
+    /// This function doesn't check if there is data available to be read.
+    /// If the rx FIFO is empty, an undefined value is returned. If you only
+    /// want to pull if data is available, use `try_pull` instead.
     pub fn pull(&mut self) -> u32 {
         PIO::PIO.rxf(SM).read()
     }


### PR DESCRIPTION
Accidentally calling `pull` on an empty RX FIFO can lead to difficult to debug errors.

I wonder if the `pull` function should be removed / deprecated, with a suggestion to use `try_pull` instead? As that would obviously be a breaking change, this PR only adds a hint to the doc comment for now.