### PR TITLE
Fix CAN error handling

### DIFF
--- a/embassy-stm32/src/can/bxcan/mod.rs
+++ b/embassy-stm32/src/can/bxcan/mod.rs
@@ -191,6 +191,7 @@ impl<'d, T: Instance> Can<'d, T> {
                 w.set_bofie(true);
                 w.set_epvie(true);
                 w.set_ewgie(true);
+                w.set_lecie(true);
             });
 
             T::regs().mcr().write(|w| {

--- a/embassy-stm32/src/can/bxcan/mod.rs
+++ b/embassy-stm32/src/can/bxcan/mod.rs
@@ -76,7 +76,7 @@ impl<T: Instance> interrupt::typelevel::Handler<T::SCEInterrupt> for SceInterrup
             // Disable the interrupt, but don't acknowledge the error, so that it can be
             // forwarded off the the bus message consumer. If we don't provide some way for
             // downstream code to determine that it has already provided this bus error instance
-            // to the bus message consumer, we are doomed to re-provide a single error instance for 
+            // to the bus message consumer, we are doomed to re-provide a single error instance for
             // an indefinite amount of time.
             let ier = T::regs().ier();
             ier.modify(|i| i.set_errie(false));

--- a/embassy-stm32/src/can/bxcan/registers.rs
+++ b/embassy-stm32/src/can/bxcan/registers.rs
@@ -148,10 +148,10 @@ impl Registers {
         if !self.0.msr().read().erri() {
             // This ensures that once a single error instance has
             // been acknowledged and forwared to the bus message consumer
-            // we don't continue to re-forward the same error occurrance for an 
+            // we don't continue to re-forward the same error occurrance for an
             // in-definite amount of time.
             return None;
-        } 
+        }
 
         // Since we have not already acknowledge the error, and the interrupt was
         // disabled in the ISR, we will acknowledge the current error and re-enable the interrupt


### PR DESCRIPTION
I've stumbled across an issue with the bxCAN async implementation, whereby if in a loop you are polling read() for events, and an error exists on the bus (any error), you end up with a situation where the processor will never sleep and is instead caught in an infinite loop of returning the same CAN peripheral error(s).

The issue is the current_error function returns a value if there is any errors set in the ESR register. However, that register is read only, and those errors persist until either the peripheral is reset, or the condition causing the error on the bus has been resolved and the TEC/REC counters are decremented via the successful reception/transmission of messages. 

Ideally, I believe the curr_error fn should only return an error if the ERRI flag is set in the MSR, at which point it should be cleared and the error value returned. If the same error condition exists on the bus during the next transmit/receive, the ERRI flag would be set again and the consumer would be notified again of the error condition. 

To put this in some context, here is a generic scenario based on an actual production use case (of the original draft implementation I provided) today:

1. A task is setup to poll the bus for messages, deserializing messages received and placing them on a channel, as well as serializing messages from the application channel and transmitting them on the bus.
2. When the CAN task identifies one of a set of error conditions (bus off, bus passive, bus warning, no ack) the CAN task puts the bus to sleep and returns a bus unavailable error to the application. This is because there are nodes (CANOpen NMT) on the bus that may be the only  node powered up at specific times. If the node ignores these errors it will end up with the CAN peripheral in bus off, which requires a significant number of messages received to clear, or would require a full peripheral reset. Sleeping the bus also has the side benefit of a small amount of power savings.
3. It is impractical to stop polling the peripheral for new messages as once another node has appeared on the bus and has transmitted a message, the peripheral will wakeup, triggering the SCE interrupt, and the device can resume communications, as required. In the current implementation of the CAN peripheral, the only way to receive that notification is via polling the read() fn.

I've done some looking into what I believe is the best way to solve the issue, and I've noticed a few things;
1. The ERRI is acknowledged in the ISR itself. I understand this is so once the context of the handler is yielded, we don't end up with another interrupt triggered before the poll_fn body within the read fn is executed.
2. The next most obvious solution would be to disable the error interrupt within the SCE ISR, and NOT acknowledge the interrupt (clearing ERRI in MSR). This would allow the curr_error function to check the ERRI bit, and if set clear ERRI, re-enable the interrupt and return the appropriate error, and in all other cases return None. This is the implementation included with this PR.
3. The Error Warning/Passive/BusOff/LEC error interrupts were not enabled by default. This sets up a race condition where sometimes an error message would be delivered to the caller of the read() fn and other times not, depending on if the error condition was identified on the bus before the ESR register was read in the read()->try_read()->curr_error() call chain or not. If it wasn't the only waker that would be triggered is the frame RX waker, which, depending on the bus state, may never be fired.