### PR TITLE
Remove redundant import

### DIFF
--- a/embassy-stm32/src/usart/buffered.rs
+++ b/embassy-stm32/src/usart/buffered.rs
@@ -1,5 +1,4 @@
 use core::slice;
-use core::sync::atomic::AtomicBool;
 
 use embassy_hal_internal::atomic_ring_buffer::RingBuffer;
 use embassy_sync::waitqueue::AtomicWaker;


### PR DESCRIPTION
This is already imported from `usart/mod.rs`.  See https://github.com/embassy-rs/embassy/pull/2860/files#diff-151b9b1fe1768dbef0afc20204cf1f80ba50431b242e6807c845260546ef4245L7