### PR TITLE
doc: add RMK to embassy in the wild

### DIFF
--- a/docs/modules/ROOT/pages/embassy_in_the_wild.adoc
+++ b/docs/modules/ROOT/pages/embassy_in_the_wild.adoc
@@ -2,6 +2,9 @@
 
 Here are known examples of real-world projects which make use of Embassy. Feel free to link:https://github.com/embassy-rs/embassy/blob/main/docs/modules/ROOT/pages/embassy_in_the_wild.adoc[add more]!
 
+* link:https://github.com/haobogu/rmk/[RMK: A feature-rich Rust keyboard firmware]
+** RMK has built-in layer support, wireless(BLE) support, real-time key editing support using vial, and more! 
+** Targets STM32, RP2040, nRF52 and ESP32 MCUs
 * link:https://github.com/cbruiz/printhor/[Printhor: The highly reliable but not necessarily functional 3D printer firmware]
 ** Targets some STM32 MCUs
 * link:https://github.com/card-io-ecg/card-io-fw[Card/IO firmware] - firmware for an open source ECG device


### PR DESCRIPTION
add [RMK](https://github.com/haobogu/rmk) to embassy in the wild 💓

RMK is a keyboard firmware project which based on embassy.