### PR TITLE
stm32 timer: fix 32bit timer off by one ARR error

### DIFF
--- a/embassy-stm32/src/timer/low_level.rs
+++ b/embassy-stm32/src/timer/low_level.rs
@@ -257,7 +257,10 @@ impl<'d, T: CoreInstance> Timer<'d, T> {
             TimerBits::Bits32 => {
                 let pclk_ticks_per_timer_period = (timer_f / f) as u64;
                 let psc: u16 = unwrap!(((pclk_ticks_per_timer_period - 1) / (1 << 32)).try_into());
-                let arr: u32 = unwrap!((pclk_ticks_per_timer_period / (psc as u64 + 1)).try_into());
+                let divide_by = pclk_ticks_per_timer_period / (u64::from(psc) + 1);
+
+                // the timer counts `0..=arr`, we want it to count `0..divide_by`
+                let arr: u32 = unwrap!(u32::try_from(divide_by - 1));
 
                 let regs = self.regs_gp32_unchecked();
                 regs.psc().write_value(psc);


### PR DESCRIPTION
Fixes off-by-one ARR value for 32 bit timers. Now the code is consistent with [16bit timers](https://github.com/ftk/embassy/blob/e7bfd7bac90d254ea6dee408564d5e0f8a80ca19/embassy-stm32/src/timer/low_level.rs#L245)