### PR TITLE
Synopsys: Make max EP count configurable

### DIFF
--- a/embassy-stm32/src/usb/otg.rs
+++ b/embassy-stm32/src/usb/otg.rs
@@ -7,13 +7,15 @@ use embassy_usb_synopsys_otg::otg_v1::Otg;
 pub use embassy_usb_synopsys_otg::Config;
 use embassy_usb_synopsys_otg::{
     on_interrupt as on_interrupt_impl, Bus as OtgBus, ControlPipe, Driver as OtgDriver, Endpoint, In, OtgInstance, Out,
-    PhyType, State, MAX_EP_COUNT,
+    PhyType, State,
 };
 
 use crate::gpio::AFType;
 use crate::interrupt;
 use crate::interrupt::typelevel::Interrupt;
 use crate::rcc::{RccPeripheral, SealedRccPeripheral};
+
+const MAX_EP_COUNT: usize = 9;
 
 /// Interrupt handler.
 pub struct InterruptHandler<T: Instance> {
@@ -54,7 +56,7 @@ const RX_FIFO_EXTRA_SIZE_WORDS: u16 = 30;
 /// USB driver.
 pub struct Driver<'d, T: Instance> {
     phantom: PhantomData<&'d mut T>,
-    inner: OtgDriver<'d>,
+    inner: OtgDriver<'d, MAX_EP_COUNT>,
 }
 
 impl<'d, T: Instance> Driver<'d, T> {
@@ -190,7 +192,7 @@ impl<'d, T: Instance> embassy_usb_driver::Driver<'d> for Driver<'d, T> {
 /// USB bus.
 pub struct Bus<'d, T: Instance> {
     phantom: PhantomData<&'d mut T>,
-    inner: OtgBus<'d>,
+    inner: OtgBus<'d, MAX_EP_COUNT>,
     inited: bool,
 }
 


### PR DESCRIPTION
The first two commits regroup things to hopefully eliminate some bounds checks. The third commit makes the max EP count configurable. Unfortunately we can't use a flavour-trait, doing so would require generic const exprs I believe, or is straight impossible. I believe this solution is more flexible than a cfg feature as it gives more control to HAL authors.