### PR TITLE
Make SpiDevice generic over Word size and implement u16 transfer

### DIFF
--- a/embassy-embedded-hal/src/shared_bus/asynch/spi.rs
+++ b/embassy-embedded-hal/src/shared_bus/asynch/spi.rs
@@ -55,13 +55,14 @@ where
     type Error = SpiDeviceError<BUS::Error, CS::Error>;
 }
 
-impl<M, BUS, CS> spi::SpiDevice for SpiDevice<'_, M, BUS, CS>
+impl<M, BUS, CS, Word> spi::SpiDevice<Word> for SpiDevice<'_, M, BUS, CS>
 where
     M: RawMutex,
-    BUS: spi::SpiBus,
+    BUS: spi::SpiBus<Word>,
     CS: OutputPin,
+    Word: Copy + 'static,
 {
-    async fn transaction(&mut self, operations: &mut [spi::Operation<'_, u8>]) -> Result<(), Self::Error> {
+    async fn transaction(&mut self, operations: &mut [spi::Operation<'_, Word>]) -> Result<(), Self::Error> {
         if cfg!(not(feature = "time")) && operations.iter().any(|op| matches!(op, Operation::DelayNs(_))) {
             return Err(SpiDeviceError::DelayNotSupported);
         }
@@ -138,13 +139,14 @@ where
     type Error = SpiDeviceError<BUS::Error, CS::Error>;
 }
 
-impl<M, BUS, CS> spi::SpiDevice for SpiDeviceWithConfig<'_, M, BUS, CS>
+impl<M, BUS, CS, Word> spi::SpiDevice<Word> for SpiDeviceWithConfig<'_, M, BUS, CS>
 where
     M: RawMutex,
-    BUS: spi::SpiBus + SetConfig,
+    BUS: spi::SpiBus<Word> + SetConfig,
     CS: OutputPin,
+    Word: Copy + 'static,
 {
-    async fn transaction(&mut self, operations: &mut [spi::Operation<'_, u8>]) -> Result<(), Self::Error> {
+    async fn transaction(&mut self, operations: &mut [spi::Operation<'_, Word>]) -> Result<(), Self::Error> {
         if cfg!(not(feature = "time")) && operations.iter().any(|op| matches!(op, Operation::DelayNs(_))) {
             return Err(SpiDeviceError::DelayNotSupported);
         }

--- a/embassy-embedded-hal/src/shared_bus/blocking/spi.rs
+++ b/embassy-embedded-hal/src/shared_bus/blocking/spi.rs
@@ -103,7 +103,7 @@ pub struct SpiDeviceWithConfig<'a, M: RawMutex, BUS: SetConfig, CS, Word: Copy +
     _word: core::marker::PhantomData<Word>,
 }
 
-impl<'a, M: RawMutex, BUS: SetConfig, CS, Word: Copy + 'static> SpiDeviceWithConfig<'a, M, BUS, CS, Word> {
+impl<'a, M: RawMutex, BUS: SetConfig, CS> SpiDeviceWithConfig<'a, M, BUS, CS> {
     /// Create a new `SpiDeviceWithConfig`.
     pub fn new(bus: &'a Mutex<M, RefCell<BUS>>, cs: CS, config: BUS::Config) -> Self {
         Self {

--- a/embassy-embedded-hal/src/shared_bus/blocking/spi.rs
+++ b/embassy-embedded-hal/src/shared_bus/blocking/spi.rs
@@ -37,8 +37,11 @@ pub struct SpiDevice<'a, M: RawMutex, BUS, CS, Word> {
 impl<'a, M: RawMutex, BUS, CS, Word> SpiDevice<'a, M, BUS, CS, Word> {
     /// Create a new `SpiDevice`.
     pub fn new(bus: &'a Mutex<M, RefCell<BUS>>, cs: CS) -> Self {
-        Self { bus, cs
-            , _word: core::marker::PhantomData}
+        Self {
+            bus,
+            cs,
+            _word: core::marker::PhantomData,
+        }
     }
 }
 
@@ -93,7 +96,8 @@ where
     }
 }
 
-impl<'d, M, BUS, CS, BusErr, CsErr, Word> embedded_hal_02::blocking::spi::Transfer<u8> for SpiDevice<'_, M, BUS, CS, Word>
+impl<'d, M, BUS, CS, BusErr, CsErr, Word> embedded_hal_02::blocking::spi::Transfer<u8>
+    for SpiDevice<'_, M, BUS, CS, Word>
 where
     M: RawMutex,
     BUS: embedded_hal_02::blocking::spi::Transfer<u8, Error = BusErr>,
@@ -134,11 +138,12 @@ where
     }
 }
 
-impl<'d, M, BUS, CS, BusErr, CsErr, Word> embedded_hal_02::blocking::spi::Transfer<u16> for SpiDevice<'_, M, BUS, CS, Word>
-    where
-        M: RawMutex,
-        BUS: embedded_hal_02::blocking::spi::Transfer<u16, Error = BusErr>,
-        CS: OutputPin<Error = CsErr>,
+impl<'d, M, BUS, CS, BusErr, CsErr, Word> embedded_hal_02::blocking::spi::Transfer<u16>
+    for SpiDevice<'_, M, BUS, CS, Word>
+where
+    M: RawMutex,
+    BUS: embedded_hal_02::blocking::spi::Transfer<u16, Error = BusErr>,
+    CS: OutputPin<Error = CsErr>,
 {
     type Error = SpiDeviceError<BusErr, CsErr>;
     fn transfer<'w>(&mut self, words: &'w mut [u16]) -> Result<&'w [u16], Self::Error> {
@@ -155,10 +160,10 @@ impl<'d, M, BUS, CS, BusErr, CsErr, Word> embedded_hal_02::blocking::spi::Transf
 }
 
 impl<'d, M, BUS, CS, BusErr, CsErr, Word> embedded_hal_02::blocking::spi::Write<u16> for SpiDevice<'_, M, BUS, CS, Word>
-    where
-        M: RawMutex,
-        BUS: embedded_hal_02::blocking::spi::Write<u16, Error = BusErr>,
-        CS: OutputPin<Error = CsErr>,
+where
+    M: RawMutex,
+    BUS: embedded_hal_02::blocking::spi::Write<u16, Error = BusErr>,
+    CS: OutputPin<Error = CsErr>,
 {
     type Error = SpiDeviceError<BusErr, CsErr>;
 
@@ -190,7 +195,12 @@ pub struct SpiDeviceWithConfig<'a, M: RawMutex, BUS: SetConfig, CS, Word> {
 impl<'a, M: RawMutex, BUS: SetConfig, CS, Word> SpiDeviceWithConfig<'a, M, BUS, CS, Word> {
     /// Create a new `SpiDeviceWithConfig`.
     pub fn new(bus: &'a Mutex<M, RefCell<BUS>>, cs: CS, config: BUS::Config) -> Self {
-        Self { bus, cs, config, _word: core::marker::PhantomData }
+        Self {
+            bus,
+            cs,
+            config,
+            _word: core::marker::PhantomData,
+        }
     }
 
     /// Change the device's config at runtime

--- a/embassy-embedded-hal/src/shared_bus/blocking/spi.rs
+++ b/embassy-embedded-hal/src/shared_bus/blocking/spi.rs
@@ -28,13 +28,13 @@ use crate::shared_bus::SpiDeviceError;
 use crate::SetConfig;
 
 /// SPI device on a shared bus.
-pub struct SpiDevice<'a, M: RawMutex, BUS, CS, Word> {
+pub struct SpiDevice<'a, M: RawMutex, BUS, CS, Word: Copy + 'static = u8> {
     bus: &'a Mutex<M, RefCell<BUS>>,
     cs: CS,
     _word: core::marker::PhantomData<Word>,
 }
 
-impl<'a, M: RawMutex, BUS, CS, Word> SpiDevice<'a, M, BUS, CS, Word> {
+impl<'a, M: RawMutex, BUS, CS, Word: Copy + 'static> SpiDevice<'a, M, BUS, CS, Word> {
     /// Create a new `SpiDevice`.
     pub fn new(bus: &'a Mutex<M, RefCell<BUS>>, cs: CS) -> Self {
         Self {
@@ -49,6 +49,7 @@ impl<'a, M: RawMutex, BUS, CS, Word> spi::ErrorType for SpiDevice<'a, M, BUS, CS
 where
     BUS: spi::ErrorType,
     CS: OutputPin,
+    Word: Copy + 'static,
 {
     type Error = SpiDeviceError<BUS::Error, CS::Error>;
 }
@@ -102,6 +103,7 @@ where
     M: RawMutex,
     BUS: embedded_hal_02::blocking::spi::Transfer<u8, Error = BusErr>,
     CS: OutputPin<Error = CsErr>,
+    Word: Copy + 'static,
 {
     type Error = SpiDeviceError<BusErr, CsErr>;
     fn transfer<'w>(&mut self, words: &'w mut [u8]) -> Result<&'w [u8], Self::Error> {
@@ -122,6 +124,7 @@ where
     M: RawMutex,
     BUS: embedded_hal_02::blocking::spi::Write<u8, Error = BusErr>,
     CS: OutputPin<Error = CsErr>,
+    Word: Copy + 'static,
 {
     type Error = SpiDeviceError<BusErr, CsErr>;
 
@@ -144,6 +147,7 @@ where
     M: RawMutex,
     BUS: embedded_hal_02::blocking::spi::Transfer<u16, Error = BusErr>,
     CS: OutputPin<Error = CsErr>,
+    Word: Copy + 'static,
 {
     type Error = SpiDeviceError<BusErr, CsErr>;
     fn transfer<'w>(&mut self, words: &'w mut [u16]) -> Result<&'w [u16], Self::Error> {
@@ -164,6 +168,7 @@ where
     M: RawMutex,
     BUS: embedded_hal_02::blocking::spi::Write<u16, Error = BusErr>,
     CS: OutputPin<Error = CsErr>,
+    Word: Copy + 'static,
 {
     type Error = SpiDeviceError<BusErr, CsErr>;
 
@@ -185,14 +190,14 @@ where
 /// This is like [`SpiDevice`], with an additional bus configuration that's applied
 /// to the bus before each use using [`SetConfig`]. This allows different
 /// devices on the same bus to use different communication settings.
-pub struct SpiDeviceWithConfig<'a, M: RawMutex, BUS: SetConfig, CS, Word> {
+pub struct SpiDeviceWithConfig<'a, M: RawMutex, BUS: SetConfig, CS, Word: Copy + 'static = u8> {
     bus: &'a Mutex<M, RefCell<BUS>>,
     cs: CS,
     config: BUS::Config,
     _word: core::marker::PhantomData<Word>,
 }
 
-impl<'a, M: RawMutex, BUS: SetConfig, CS, Word> SpiDeviceWithConfig<'a, M, BUS, CS, Word> {
+impl<'a, M: RawMutex, BUS: SetConfig, CS, Word: Copy + 'static> SpiDeviceWithConfig<'a, M, BUS, CS, Word> {
     /// Create a new `SpiDeviceWithConfig`.
     pub fn new(bus: &'a Mutex<M, RefCell<BUS>>, cs: CS, config: BUS::Config) -> Self {
         Self {

--- a/embassy-embedded-hal/src/shared_bus/blocking/spi.rs
+++ b/embassy-embedded-hal/src/shared_bus/blocking/spi.rs
@@ -96,22 +96,16 @@ where
 /// This is like [`SpiDevice`], with an additional bus configuration that's applied
 /// to the bus before each use using [`SetConfig`]. This allows different
 /// devices on the same bus to use different communication settings.
-pub struct SpiDeviceWithConfig<'a, M: RawMutex, BUS: SetConfig, CS, Word: Copy + 'static = u8> {
+pub struct SpiDeviceWithConfig<'a, M: RawMutex, BUS: SetConfig, CS> {
     bus: &'a Mutex<M, RefCell<BUS>>,
     cs: CS,
     config: BUS::Config,
-    _word: core::marker::PhantomData<Word>,
 }
 
 impl<'a, M: RawMutex, BUS: SetConfig, CS> SpiDeviceWithConfig<'a, M, BUS, CS> {
     /// Create a new `SpiDeviceWithConfig`.
     pub fn new(bus: &'a Mutex<M, RefCell<BUS>>, cs: CS, config: BUS::Config) -> Self {
-        Self {
-            bus,
-            cs,
-            config,
-            _word: core::marker::PhantomData,
-        }
+        Self { bus, cs, config }
     }
 
     /// Change the device's config at runtime
@@ -120,17 +114,16 @@ impl<'a, M: RawMutex, BUS: SetConfig, CS> SpiDeviceWithConfig<'a, M, BUS, CS> {
     }
 }
 
-impl<'a, M, BUS, CS, Word> spi::ErrorType for SpiDeviceWithConfig<'a, M, BUS, CS, Word>
+impl<'a, M, BUS, CS> spi::ErrorType for SpiDeviceWithConfig<'a, M, BUS, CS>
 where
     M: RawMutex,
     BUS: spi::ErrorType + SetConfig,
     CS: OutputPin,
-    Word: Copy + 'static,
 {
     type Error = SpiDeviceError<BUS::Error, CS::Error>;
 }
 
-impl<BUS, M, CS, Word> embedded_hal_1::spi::SpiDevice<Word> for SpiDeviceWithConfig<'_, M, BUS, CS, Word>
+impl<BUS, M, CS, Word> embedded_hal_1::spi::SpiDevice<Word> for SpiDeviceWithConfig<'_, M, BUS, CS>
 where
     M: RawMutex,
     BUS: SpiBus<Word> + SetConfig,

--- a/embassy-embedded-hal/src/shared_bus/blocking/spi.rs
+++ b/embassy-embedded-hal/src/shared_bus/blocking/spi.rs
@@ -33,17 +33,14 @@ pub struct SpiDevice<'a, M: RawMutex, BUS, CS> {
     cs: CS,
 }
 
-impl<'a, M: RawMutex, BUS, CS> SpiDevice<'a, M, BUS, CS, > {
+impl<'a, M: RawMutex, BUS, CS> SpiDevice<'a, M, BUS, CS> {
     /// Create a new `SpiDevice`.
     pub fn new(bus: &'a Mutex<M, RefCell<BUS>>, cs: CS) -> Self {
-        Self {
-            bus,
-            cs,
-        }
+        Self { bus, cs }
     }
 }
 
-impl<'a, M: RawMutex, BUS, CS> spi::ErrorType for SpiDevice<'a, M, BUS, CS, >
+impl<'a, M: RawMutex, BUS, CS> spi::ErrorType for SpiDevice<'a, M, BUS, CS>
 where
     BUS: spi::ErrorType,
     CS: OutputPin,
@@ -51,7 +48,7 @@ where
     type Error = SpiDeviceError<BUS::Error, CS::Error>;
 }
 
-impl<BUS, M, CS, Word> embedded_hal_1::spi::SpiDevice<Word> for SpiDevice<'_, M, BUS, CS, >
+impl<BUS, M, CS, Word> embedded_hal_1::spi::SpiDevice<Word> for SpiDevice<'_, M, BUS, CS>
 where
     M: RawMutex,
     BUS: SpiBus<Word>,
@@ -93,7 +90,6 @@ where
         })
     }
 }
-
 
 /// SPI device on a shared bus, with its own configuration.
 ///


### PR DESCRIPTION
It's not particularly complicated, this allows to be more in line with other implementations like ExclusiveDevice which also has an u16 word size