### PR TITLE
stm32/timer: add `low_level::Timer::get_clock_frequency()`

### DIFF
--- a/embassy-stm32/src/timer/low_level.rs
+++ b/embassy-stm32/src/timer/low_level.rs
@@ -321,6 +321,11 @@ impl<'d, T: CoreInstance> Timer<'d, T> {
             }
         }
     }
+
+    /// Get the clock frequency of the timer (before prescaler is applied).
+    pub fn get_clock_frequency(&self) -> Hertz {
+        T::frequency()
+    }
 }
 
 impl<'d, T: BasicNoCr2Instance> Timer<'d, T> {


### PR DESCRIPTION
When working with the low-level timer, it's often necessary to know the clock frequency that is fed into the timer, to correctly set values of ARR and CCR registers, in cases where the existing covenience methods are not sufficient.

(My use case is generating four one-shot pulses of different widths on the four timer channels to control an RC servo.)