### PR TITLE
Make embedded-hal v0.2 optional for embassy-time and embassy-embedded-hal

### DIFF
--- a/embassy-embedded-hal/Cargo.toml
+++ b/embassy-embedded-hal/Cargo.toml
@@ -24,7 +24,7 @@ features = ["std"]
 [features]
 std = []
 time = ["dep:embassy-time"]
-default = ["time"]
+default = ["time", "embedded-hal-02"]
 
 #! Support legacy for embedded hal 0.2 traits 
 embedded-hal-02 = ["dep:embedded-hal-02"]

--- a/embassy-embedded-hal/Cargo.toml
+++ b/embassy-embedded-hal/Cargo.toml
@@ -26,14 +26,17 @@ std = []
 time = ["dep:embassy-time"]
 default = ["time"]
 
+#! Support legacy for embedded hal 0.2 traits 
+embedded-hal-02 = ["dep:embedded-hal-02"]
+
 [dependencies]
 embassy-futures = { version = "0.1.0", path = "../embassy-futures" }
 embassy-sync = { version = "0.5.0", path = "../embassy-sync" }
 embassy-time = { version = "0.3.0", path = "../embassy-time", optional = true }
 embedded-hal-02 = { package = "embedded-hal", version = "0.2.6", features = [
     "unproven",
-] }
-embedded-hal-1 = { package = "embedded-hal", version = "1.0" }
+], optional = true }
+embedded-hal = "1.0" 
 embedded-hal-async = { version = "1.0" }
 embedded-storage = "0.3.1"
 embedded-storage-async = { version = "0.4.1" }

--- a/embassy-embedded-hal/src/adapter/blocking_async.rs
+++ b/embassy-embedded-hal/src/adapter/blocking_async.rs
@@ -15,7 +15,7 @@ impl<T> BlockingAsync<T> {
         Self { wrapped }
     }
 }
-#[cfg(feature = "embedded_hal_02")]
+#[cfg(feature = "embedded-hal-02")]
 mod embedded_hal_02 {
     use embedded_hal_02::blocking;
 
@@ -105,7 +105,7 @@ mod embedded_hal_02 {
         }
     }
 }
-#[cfg(not(feature = "embedded_hal_02"))]
+#[cfg(not(feature = "embedded-hal-02"))]
 mod embedded_hal {
     use super::BlockingAsync;
 

--- a/embassy-embedded-hal/src/adapter/blocking_async.rs
+++ b/embassy-embedded-hal/src/adapter/blocking_async.rs
@@ -17,8 +17,9 @@ impl<T> BlockingAsync<T> {
 }
 #[cfg(feature = "embedded_hal_02")]
 mod embedded_hal_02 {
-    use super::BlockingAsync;
     use embedded_hal_02::blocking;
+
+    use super::BlockingAsync;
     //
     // I2C implementations
     //

--- a/embassy-embedded-hal/src/adapter/yielding_async.rs
+++ b/embassy-embedded-hal/src/adapter/yielding_async.rs
@@ -18,9 +18,9 @@ impl<T> YieldingAsync<T> {
 //
 // I2C implementations
 //
-impl<T> embedded_hal_1::i2c::ErrorType for YieldingAsync<T>
+impl<T> embedded_hal::i2c::ErrorType for YieldingAsync<T>
 where
-    T: embedded_hal_1::i2c::ErrorType,
+    T: embedded_hal::i2c::ErrorType,
 {
     type Error = T::Error;
 }
@@ -50,7 +50,7 @@ where
     async fn transaction(
         &mut self,
         address: u8,
-        operations: &mut [embedded_hal_1::i2c::Operation<'_>],
+        operations: &mut [embedded_hal::i2c::Operation<'_>],
     ) -> Result<(), Self::Error> {
         self.wrapped.transaction(address, operations).await?;
         yield_now().await;

--- a/embassy-embedded-hal/src/shared_bus/asynch/spi.rs
+++ b/embassy-embedded-hal/src/shared_bus/asynch/spi.rs
@@ -27,8 +27,8 @@
 
 use embassy_sync::blocking_mutex::raw::RawMutex;
 use embassy_sync::mutex::Mutex;
-use embedded_hal_1::digital::OutputPin;
-use embedded_hal_1::spi::Operation;
+use embedded_hal::digital::OutputPin;
+use embedded_hal::spi::Operation;
 use embedded_hal_async::spi;
 
 use crate::shared_bus::SpiDeviceError;

--- a/embassy-embedded-hal/src/shared_bus/blocking/i2c.rs
+++ b/embassy-embedded-hal/src/shared_bus/blocking/i2c.rs
@@ -75,8 +75,14 @@ where
     }
 }
 
-#[cfg(feature = "embedded_hal_02")]
+#[cfg(feature = "embedded-hal-02")]
 mod embedded_hal_02 {
+    use embassy_sync::blocking_mutex::raw::RawMutex;
+
+    use crate::shared_bus::I2cDeviceError;
+
+    use super::I2cDevice;
+
     impl<'a, M, BUS, E> embedded_hal_02::blocking::i2c::Write for I2cDevice<'_, M, BUS>
     where
         M: RawMutex,

--- a/embassy-embedded-hal/src/shared_bus/blocking/i2c.rs
+++ b/embassy-embedded-hal/src/shared_bus/blocking/i2c.rs
@@ -19,7 +19,7 @@ use core::cell::RefCell;
 
 use embassy_sync::blocking_mutex::raw::RawMutex;
 use embassy_sync::blocking_mutex::Mutex;
-use embedded_hal_1::i2c::{ErrorType, I2c, Operation};
+use embedded_hal::i2c::{ErrorType, I2c, Operation};
 
 use crate::shared_bus::I2cDeviceError;
 use crate::SetConfig;
@@ -75,45 +75,48 @@ where
     }
 }
 
-impl<'a, M, BUS, E> embedded_hal_02::blocking::i2c::Write for I2cDevice<'_, M, BUS>
-where
-    M: RawMutex,
-    BUS: embedded_hal_02::blocking::i2c::Write<Error = E>,
-{
-    type Error = I2cDeviceError<E>;
+#[cfg(feature = "embedded_hal_02")]
+mod embedded_hal_02 {
+    impl<'a, M, BUS, E> embedded_hal_02::blocking::i2c::Write for I2cDevice<'_, M, BUS>
+    where
+        M: RawMutex,
+        BUS: embedded_hal_02::blocking::i2c::Write<Error = E>,
+    {
+        type Error = I2cDeviceError<E>;
 
-    fn write<'w>(&mut self, addr: u8, bytes: &'w [u8]) -> Result<(), Self::Error> {
-        self.bus
-            .lock(|bus| bus.borrow_mut().write(addr, bytes).map_err(I2cDeviceError::I2c))
+        fn write<'w>(&mut self, addr: u8, bytes: &'w [u8]) -> Result<(), Self::Error> {
+            self.bus
+                .lock(|bus| bus.borrow_mut().write(addr, bytes).map_err(I2cDeviceError::I2c))
+        }
     }
-}
 
-impl<'a, M, BUS, E> embedded_hal_02::blocking::i2c::Read for I2cDevice<'_, M, BUS>
-where
-    M: RawMutex,
-    BUS: embedded_hal_02::blocking::i2c::Read<Error = E>,
-{
-    type Error = I2cDeviceError<E>;
+    impl<'a, M, BUS, E> embedded_hal_02::blocking::i2c::Read for I2cDevice<'_, M, BUS>
+    where
+        M: RawMutex,
+        BUS: embedded_hal_02::blocking::i2c::Read<Error = E>,
+    {
+        type Error = I2cDeviceError<E>;
 
-    fn read<'w>(&mut self, addr: u8, bytes: &'w mut [u8]) -> Result<(), Self::Error> {
-        self.bus
-            .lock(|bus| bus.borrow_mut().read(addr, bytes).map_err(I2cDeviceError::I2c))
+        fn read<'w>(&mut self, addr: u8, bytes: &'w mut [u8]) -> Result<(), Self::Error> {
+            self.bus
+                .lock(|bus| bus.borrow_mut().read(addr, bytes).map_err(I2cDeviceError::I2c))
+        }
     }
-}
 
-impl<'a, M, BUS, E> embedded_hal_02::blocking::i2c::WriteRead for I2cDevice<'_, M, BUS>
-where
-    M: RawMutex,
-    BUS: embedded_hal_02::blocking::i2c::WriteRead<Error = E>,
-{
-    type Error = I2cDeviceError<E>;
+    impl<'a, M, BUS, E> embedded_hal_02::blocking::i2c::WriteRead for I2cDevice<'_, M, BUS>
+    where
+        M: RawMutex,
+        BUS: embedded_hal_02::blocking::i2c::WriteRead<Error = E>,
+    {
+        type Error = I2cDeviceError<E>;
 
-    fn write_read<'w>(&mut self, addr: u8, bytes: &'w [u8], buffer: &'w mut [u8]) -> Result<(), Self::Error> {
-        self.bus.lock(|bus| {
-            bus.borrow_mut()
-                .write_read(addr, bytes, buffer)
-                .map_err(I2cDeviceError::I2c)
-        })
+        fn write_read<'w>(&mut self, addr: u8, bytes: &'w [u8], buffer: &'w mut [u8]) -> Result<(), Self::Error> {
+            self.bus.lock(|bus| {
+                bus.borrow_mut()
+                    .write_read(addr, bytes, buffer)
+                    .map_err(I2cDeviceError::I2c)
+            })
+        }
     }
 }
 

--- a/embassy-embedded-hal/src/shared_bus/blocking/i2c.rs
+++ b/embassy-embedded-hal/src/shared_bus/blocking/i2c.rs
@@ -79,9 +79,8 @@ where
 mod embedded_hal_02 {
     use embassy_sync::blocking_mutex::raw::RawMutex;
 
-    use crate::shared_bus::I2cDeviceError;
-
     use super::I2cDevice;
+    use crate::shared_bus::I2cDeviceError;
 
     impl<'a, M, BUS, E> embedded_hal_02::blocking::i2c::Write for I2cDevice<'_, M, BUS>
     where

--- a/embassy-embedded-hal/src/shared_bus/blocking/spi.rs
+++ b/embassy-embedded-hal/src/shared_bus/blocking/spi.rs
@@ -90,8 +90,15 @@ where
     }
 }
 
-#[cfg(feature = "embedded_hal_02")]
+#[cfg(feature = "embedded-hal-02")]
 mod embedded_hal_02 {
+    use embassy_sync::blocking_mutex::raw::RawMutex;
+    use embedded_hal_02::digital::v2::OutputPin;
+
+    use crate::shared_bus::SpiDeviceError;
+
+    use super::SpiDevice;
+
     impl<'d, M, BUS, CS, BusErr, CsErr> embedded_hal_02::blocking::spi::Transfer<u8> for SpiDevice<'_, M, BUS, CS>
     where
         M: RawMutex,

--- a/embassy-embedded-hal/src/shared_bus/blocking/spi.rs
+++ b/embassy-embedded-hal/src/shared_bus/blocking/spi.rs
@@ -95,9 +95,8 @@ mod embedded_hal_02 {
     use embassy_sync::blocking_mutex::raw::RawMutex;
     use embedded_hal_02::digital::v2::OutputPin;
 
-    use crate::shared_bus::SpiDeviceError;
-
     use super::SpiDevice;
+    use crate::shared_bus::SpiDeviceError;
 
     impl<'d, M, BUS, CS, BusErr, CsErr> embedded_hal_02::blocking::spi::Transfer<u8> for SpiDevice<'_, M, BUS, CS>
     where

--- a/embassy-embedded-hal/src/shared_bus/mod.rs
+++ b/embassy-embedded-hal/src/shared_bus/mod.rs
@@ -1,7 +1,7 @@
 //! Shared bus implementations
 use core::fmt::Debug;
 
-use embedded_hal_1::{i2c, spi};
+use embedded_hal::{i2c, spi};
 
 pub mod asynch;
 pub mod blocking;

--- a/embassy-time/CHANGELOG.md
+++ b/embassy-time/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+- Put `embedded-hal v0.2` dependency behind a feature flag.
+
 ## 0.3.0 - 2024-01-11
 
 - Update `embedded-hal-async` to `1.0.0`

--- a/embassy-time/Cargo.toml
+++ b/embassy-time/Cargo.toml
@@ -40,6 +40,9 @@ mock-driver = ["tick-hz-1_000_000"]
 ## To use this you must have a time driver provided.
 generic-queue = []
 
+#! Support legacy for embedded hal 0.2 traits 
+embedded-hal-02 = ["dep:embedded-hal-02"]
+
 #! The following features set how many timers are used for the generic queue. At most one
 #! `generic-queue-*` feature can be enabled. If none is enabled, a default of 64 timers is used.
 #!
@@ -404,8 +407,8 @@ embassy-time-queue-driver = { version = "0.1.0", path = "../embassy-time-queue-d
 defmt = { version = "0.3", optional = true }
 log = { version = "0.4.14", optional = true }
 
-embedded-hal-02 = { package = "embedded-hal", version = "0.2.6" }
-embedded-hal-1 = { package = "embedded-hal", version = "1.0" }
+embedded-hal-02 = { package = "embedded-hal", version = "0.2.6", optional = true }
+embedded-hal = "1.0"
 embedded-hal-async = { version = "1.0" }
 
 futures-util = { version = "0.3.17", default-features = false }

--- a/embassy-time/Cargo.toml
+++ b/embassy-time/Cargo.toml
@@ -24,6 +24,7 @@ target = "x86_64-unknown-linux-gnu"
 features = ["defmt", "std"]
 
 [features]
+default = ["embedded-hal-02"]
 std = ["tick-hz-1_000_000", "critical-section/std"]
 wasm = ["dep:wasm-bindgen", "dep:js-sys", "dep:wasm-timer", "tick-hz-1_000_000"]
 

--- a/embassy-time/src/delay.rs
+++ b/embassy-time/src/delay.rs
@@ -16,7 +16,7 @@ pub fn block_for(duration: Duration) {
 #[derive(Clone)]
 pub struct Delay;
 
-impl embedded_hal_1::delay::DelayNs for Delay {
+impl embedded_hal::delay::DelayNs for Delay {
     fn delay_ns(&mut self, ns: u32) {
         block_for(Duration::from_nanos(ns as u64))
     }
@@ -43,39 +43,41 @@ impl embedded_hal_async::delay::DelayNs for Delay {
         Timer::after_millis(ms as _).await
     }
 }
-
-impl embedded_hal_02::blocking::delay::DelayMs<u8> for Delay {
-    fn delay_ms(&mut self, ms: u8) {
-        block_for(Duration::from_millis(ms as u64))
+#[cfg(feature = "embedded_hal_02")]
+mod embedded_hal_02 {
+    impl embedded_hal_02::blocking::delay::DelayMs<u8> for Delay {
+        fn delay_ms(&mut self, ms: u8) {
+            block_for(Duration::from_millis(ms as u64))
+        }
     }
-}
 
-impl embedded_hal_02::blocking::delay::DelayMs<u16> for Delay {
-    fn delay_ms(&mut self, ms: u16) {
-        block_for(Duration::from_millis(ms as u64))
+    impl embedded_hal_02::blocking::delay::DelayMs<u16> for Delay {
+        fn delay_ms(&mut self, ms: u16) {
+            block_for(Duration::from_millis(ms as u64))
+        }
     }
-}
 
-impl embedded_hal_02::blocking::delay::DelayMs<u32> for Delay {
-    fn delay_ms(&mut self, ms: u32) {
-        block_for(Duration::from_millis(ms as u64))
+    impl embedded_hal_02::blocking::delay::DelayMs<u32> for Delay {
+        fn delay_ms(&mut self, ms: u32) {
+            block_for(Duration::from_millis(ms as u64))
+        }
     }
-}
 
-impl embedded_hal_02::blocking::delay::DelayUs<u8> for Delay {
-    fn delay_us(&mut self, us: u8) {
-        block_for(Duration::from_micros(us as u64))
+    impl embedded_hal_02::blocking::delay::DelayUs<u8> for Delay {
+        fn delay_us(&mut self, us: u8) {
+            block_for(Duration::from_micros(us as u64))
+        }
     }
-}
 
-impl embedded_hal_02::blocking::delay::DelayUs<u16> for Delay {
-    fn delay_us(&mut self, us: u16) {
-        block_for(Duration::from_micros(us as u64))
+    impl embedded_hal_02::blocking::delay::DelayUs<u16> for Delay {
+        fn delay_us(&mut self, us: u16) {
+            block_for(Duration::from_micros(us as u64))
+        }
     }
-}
 
-impl embedded_hal_02::blocking::delay::DelayUs<u32> for Delay {
-    fn delay_us(&mut self, us: u32) {
-        block_for(Duration::from_micros(us as u64))
+    impl embedded_hal_02::blocking::delay::DelayUs<u32> for Delay {
+        fn delay_us(&mut self, us: u32) {
+            block_for(Duration::from_micros(us as u64))
+        }
     }
 }

--- a/embassy-time/src/delay.rs
+++ b/embassy-time/src/delay.rs
@@ -43,8 +43,10 @@ impl embedded_hal_async::delay::DelayNs for Delay {
         Timer::after_millis(ms as _).await
     }
 }
-#[cfg(feature = "embedded_hal_02")]
+#[cfg(feature = "embedded-hal-02")]
 mod embedded_hal_02 {
+    use crate::{block_for, Delay, Duration};
+
     impl embedded_hal_02::blocking::delay::DelayMs<u8> for Delay {
         fn delay_ms(&mut self, ms: u8) {
             block_for(Duration::from_millis(ms as u64))


### PR DESCRIPTION
For now it is enabled by default, but could probably be disabled in the next major version.