### PR TITLE
stm32: examples: Use unique crate name for stm32h7rs examples

### DIFF
--- a/examples/stm32h7rs/Cargo.toml
+++ b/examples/stm32h7rs/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 edition = "2021"
-name = "embassy-stm32h7-examples"
+name = "embassy-stm32h7rs-examples"
 version = "0.1.0"
 license = "MIT OR Apache-2.0"
 


### PR DESCRIPTION
Current name clashes with "regular" stm32h7 thus generating cargo warning:
```
warning: skipping duplicate package `embassy-stm32h7-examples` found at ...
```