### PR TITLE
rp: implement usb stall

### DIFF
--- a/embassy-rp/src/usb.rs
+++ b/embassy-rp/src/usb.rs
@@ -412,12 +412,38 @@ impl<'d, T: Instance> driver::Bus for Bus<'d, T> {
         .await
     }
 
-    fn endpoint_set_stalled(&mut self, _ep_addr: EndpointAddress, _stalled: bool) {
-        todo!();
+    fn endpoint_set_stalled(&mut self, ep_addr: EndpointAddress, stalled: bool) {
+        let n = ep_addr.index();
+
+        if n == 0 {
+            T::regs().ep_stall_arm().modify(|w| {
+                if ep_addr.is_in() {
+                    w.set_ep0_in(stalled);
+                } else {
+                    w.set_ep0_out(stalled);
+                }
+            });
+        }
+
+        let ctrl = if ep_addr.is_in() {
+            T::dpram().ep_in_buffer_control(n)
+        } else {
+            T::dpram().ep_out_buffer_control(n)
+        };
+
+        ctrl.modify(|w| w.set_stall(stalled));
     }
 
-    fn endpoint_is_stalled(&mut self, _ep_addr: EndpointAddress) -> bool {
-        todo!();
+    fn endpoint_is_stalled(&mut self, ep_addr: EndpointAddress) -> bool {
+        let n = ep_addr.index();
+
+        let ctrl = if ep_addr.is_in() {
+            T::dpram().ep_in_buffer_control(n)
+        } else {
+            T::dpram().ep_out_buffer_control(n)
+        };
+
+        ctrl.read().stall()
     }
 
     fn endpoint_set_enabled(&mut self, ep_addr: EndpointAddress, enabled: bool) {

--- a/embassy-rp/src/usb.rs
+++ b/embassy-rp/src/usb.rs
@@ -432,6 +432,9 @@ impl<'d, T: Instance> driver::Bus for Bus<'d, T> {
         };
 
         ctrl.modify(|w| w.set_stall(stalled));
+
+        let wakers = if ep_addr.is_in() { &EP_IN_WAKERS } else { &EP_OUT_WAKERS };
+        wakers[n].wake();
     }
 
     fn endpoint_is_stalled(&mut self, ep_addr: EndpointAddress) -> bool {


### PR DESCRIPTION
This implements endpoint stalling for `embassy-rp` - the current use-case being that Windows will stall a USB MSD implementation, possibly due to implementation error, or possibly while it's probing the device. This allows us to continue past the stall, rather than panicking.

Tested by running this on a pico implementing a MSD - interested to hear if there are other approaches to testing USB implementations (particularly stalls / error handling).