### PR TITLE
rp/flash: implement `embedded_storage_async::nor_flash::MultiwriteNorFlash`

### DIFF
--- a/embassy-rp/src/flash.rs
+++ b/embassy-rp/src/flash.rs
@@ -374,6 +374,11 @@ impl<'d, T: Instance, M: Mode, const FLASH_SIZE: usize> ReadNorFlash for Flash<'
 
 impl<'d, T: Instance, M: Mode, const FLASH_SIZE: usize> MultiwriteNorFlash for Flash<'d, T, M, FLASH_SIZE> {}
 
+impl<'d, T: Instance, const FLASH_SIZE: usize> embedded_storage_async::nor_flash::MultiwriteNorFlash
+    for Flash<'d, T, Async, FLASH_SIZE>
+{
+}
+
 impl<'d, T: Instance, M: Mode, const FLASH_SIZE: usize> NorFlash for Flash<'d, T, M, FLASH_SIZE> {
     const WRITE_SIZE: usize = WRITE_SIZE;
 


### PR DESCRIPTION
The documented requirement for this marker trait are the same for the [blocking](https://docs.rs/embedded-storage/latest/embedded_storage/nor_flash/trait.MultiwriteNorFlash.html) and [async](https://docs.rs/embedded-storage-async/latest/embedded_storage_async/nor_flash/trait.MultiwriteNorFlash.html) versions so I assume it is fine to implement this even though the RP2040 doesn't support asynchronously writing to the flash.