### PR TITLE
defined binaries to be built

### DIFF
--- a/examples/stm32g4/Cargo.toml
+++ b/examples/stm32g4/Cargo.toml
@@ -27,3 +27,48 @@ static_cell = "2.0.0"
 
 [profile.release]
 debug = 2
+
+[[bin]]
+name = "adc"
+test = false
+bench = false
+
+[[bin]]
+name = "blinky"
+test = false
+bench = false
+
+[[bin]]
+name = "button_exti"
+test = false
+bench = false
+
+[[bin]]
+name = "button"
+test = false
+bench = false
+
+[[bin]]
+name = "can"
+test = false
+bench = false
+
+[[bin]]
+name = "pll"
+test = false
+bench = false
+
+[[bin]]
+name = "pwm"
+test = false
+bench = false
+
+[[bin]]
+name = "usb_c_pd"
+test = false
+bench = false
+
+[[bin]]
+name = "usb_serial"
+test = false
+bench = false


### PR DESCRIPTION
Hi,

I found that when you open an example with VS Code (not the whole embassy directory, just the sub-folder), you get this weird `error[E0463]: can't find crate for 'test'`.  After some head banging, I found an easy fix: defining the binaries in the `Cargo.toml`.

Hope this helps,