### PR TITLE
Pubsub cleanup

### DIFF
--- a/cyw43/src/runner.rs
+++ b/cyw43/src/runner.rs
@@ -1,6 +1,5 @@
 use embassy_futures::select::{select3, Either3};
 use embassy_net_driver_channel as ch;
-use embassy_sync::pubsub::PubSubBehavior;
 use embassy_time::{block_for, Duration, Timer};
 use embedded_hal_1::digital::OutputPin;
 
@@ -438,13 +437,16 @@ where
                     // publish() is a deadlock risk in the current design as awaiting here prevents ioctls
                     // The `Runner` always yields when accessing the device, so consumers always have a chance to receive the event
                     // (if they are actively awaiting the queue)
-                    self.events.queue.publish_immediate(events::Message::new(
-                        Status {
-                            event_type: evt_type,
-                            status,
-                        },
-                        event_payload,
-                    ));
+                    self.events
+                        .queue
+                        .immediate_publisher()
+                        .publish_immediate(events::Message::new(
+                            Status {
+                                event_type: evt_type,
+                                status,
+                            },
+                            event_payload,
+                        ));
                 }
             }
             CHANNEL_TYPE_DATA => {

--- a/embassy-sync/CHANGELOG.md
+++ b/embassy-sync/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add `capacity`, `free_capacity`, `len`, `is_empty` and `is_full` functions to `PriorityChannel`.
 - Add `capacity`, `free_capacity`, `len`, `is_empty` and `is_full` functions to `PubSubChannel`.
 - Made `PubSubBehavior` sealed
+  - If you called `.publish_immediate(...)` on the queue directly before, then now call `.immediate_publisher().publish_immediate(...)`
 
 ## 0.5.0 - 2023-12-04
 

--- a/embassy-sync/CHANGELOG.md
+++ b/embassy-sync/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add `capacity`, `free_capacity`, `len`, `is_empty` and `is_full` functions to `Channel`.
 - Add `capacity`, `free_capacity`, `len`, `is_empty` and `is_full` functions to `PriorityChannel`.
 - Add `capacity`, `free_capacity`, `len`, `is_empty` and `is_full` functions to `PubSubChannel`.
+- Made `PubSubBehavior` sealed
 
 ## 0.5.0 - 2023-12-04
 

--- a/embassy-sync/src/pubsub/publisher.rs
+++ b/embassy-sync/src/pubsub/publisher.rs
@@ -43,12 +43,31 @@ impl<'a, PSB: PubSubBehavior<T> + ?Sized, T: Clone> Pub<'a, PSB, T> {
         self.channel.publish_with_context(message, None)
     }
 
-    /// The amount of messages that can still be published without having to wait or without having to lag the subscribers
+    /// Returns the maximum number of elements the ***channel*** can hold.
+    pub fn capacity(&self) -> usize {
+        self.channel.capacity()
+    }
+
+    /// Returns the free capacity of the ***channel***.
     ///
-    /// *Note: In the time between checking this and a publish action, other publishers may have had time to publish something.
-    /// So checking doesn't give any guarantees.*
-    pub fn space(&self) -> usize {
-        self.channel.space()
+    /// This is equivalent to `capacity() - len()`
+    pub fn free_capacity(&self) -> usize {
+        self.channel.free_capacity()
+    }
+
+    /// Returns the number of elements currently in the ***channel***.
+    pub fn len(&self) -> usize {
+        self.channel.len()
+    }
+
+    /// Returns whether the ***channel*** is empty.
+    pub fn is_empty(&self) -> bool {
+        self.channel.is_empty()
+    }
+
+    /// Returns whether the ***channel*** is full.
+    pub fn is_full(&self) -> bool {
+        self.channel.is_full()
     }
 }
 
@@ -124,12 +143,31 @@ impl<'a, PSB: PubSubBehavior<T> + ?Sized, T: Clone> ImmediatePub<'a, PSB, T> {
         self.channel.publish_with_context(message, None)
     }
 
-    /// The amount of messages that can still be published without having to wait or without having to lag the subscribers
+    /// Returns the maximum number of elements the ***channel*** can hold.
+    pub fn capacity(&self) -> usize {
+        self.channel.capacity()
+    }
+
+    /// Returns the free capacity of the ***channel***.
     ///
-    /// *Note: In the time between checking this and a publish action, other publishers may have had time to publish something.
-    /// So checking doesn't give any guarantees.*
-    pub fn space(&self) -> usize {
-        self.channel.space()
+    /// This is equivalent to `capacity() - len()`
+    pub fn free_capacity(&self) -> usize {
+        self.channel.free_capacity()
+    }
+
+    /// Returns the number of elements currently in the ***channel***.
+    pub fn len(&self) -> usize {
+        self.channel.len()
+    }
+
+    /// Returns whether the ***channel*** is empty.
+    pub fn is_empty(&self) -> bool {
+        self.channel.is_empty()
+    }
+
+    /// Returns whether the ***channel*** is full.
+    pub fn is_full(&self) -> bool {
+        self.channel.is_full()
     }
 }
 

--- a/embassy-sync/src/pubsub/subscriber.rs
+++ b/embassy-sync/src/pubsub/subscriber.rs
@@ -65,9 +65,38 @@ impl<'a, PSB: PubSubBehavior<T> + ?Sized, T: Clone> Sub<'a, PSB, T> {
         }
     }
 
-    /// The amount of messages this subscriber hasn't received yet
+    /// The amount of messages this subscriber hasn't received yet. This is like [Self::len] but specifically
+    /// for this subscriber.
     pub fn available(&self) -> u64 {
         self.channel.available(self.next_message_id)
+    }
+
+    /// Returns the maximum number of elements the ***channel*** can hold.
+    pub fn capacity(&self) -> usize {
+        self.channel.capacity()
+    }
+
+    /// Returns the free capacity of the ***channel***.
+    ///
+    /// This is equivalent to `capacity() - len()`
+    pub fn free_capacity(&self) -> usize {
+        self.channel.free_capacity()
+    }
+
+    /// Returns the number of elements currently in the ***channel***.
+    /// See [Self::available] for how many messages are available for this subscriber.
+    pub fn len(&self) -> usize {
+        self.channel.len()
+    }
+
+    /// Returns whether the ***channel*** is empty.
+    pub fn is_empty(&self) -> bool {
+        self.channel.is_empty()
+    }
+
+    /// Returns whether the ***channel*** is full.
+    pub fn is_full(&self) -> bool {
+        self.channel.is_full()
     }
 }
 


### PR DESCRIPTION
Exposes the new length functions on the pubs and subs and seals the pubsubbehavior trait (which users shouldn't (need to) touch).

I guess there's more to clean up or at least things I'd have made different now, but there's nothing that really *needs* more work.

For posterity:

- I think it's weird that `DynSubscriber<T>` and `Subscriber<T>` both deref as `Sub<Channel, T>`.
- Same for publisher
- I'd make the shared functions into a trait and let each of the higher level types implement those traits
- This would be a breaking change, but likely one that doesn't break anyone