### PR TITLE
embassy-usb-synopsys-otg: impl Sync for EpState

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -9,12 +9,14 @@
   "rust-analyzer.check.noDefaultFeatures": true,
   "rust-analyzer.cargo.noDefaultFeatures": true,
   "rust-analyzer.showUnlinkedFileNotification": false,
-  // uncomment the target of your chip.
+  // Uncomment the target of your chip.
   //"rust-analyzer.cargo.target": "thumbv6m-none-eabi",
   //"rust-analyzer.cargo.target": "thumbv7m-none-eabi",
   "rust-analyzer.cargo.target": "thumbv7em-none-eabi",
+  //"rust-analyzer.cargo.target": "thumbv7em-none-eabihf",
   //"rust-analyzer.cargo.target": "thumbv8m.main-none-eabihf",
   "rust-analyzer.cargo.features": [
+    // Comment out these features when working on the examples. Most example crates do not have any cargo features.
     "stm32f446re",
     "time-driver-any",
     "unstable-pac",
@@ -22,9 +24,10 @@
     "rt",
   ],
   "rust-analyzer.linkedProjects": [
-    // Uncomment ONE line for the chip you want to work on.
-    // This makes rust-analyzer work on the example crate and all its dependencies.
     "embassy-stm32/Cargo.toml",
+    // To work on the examples, comment the line above and all of the cargo.features lines,
+    // then uncomment ONE line below to select the chip you want to work on.
+    // This makes rust-analyzer work on the example crate and all its dependencies.
     // "examples/nrf52840-rtic/Cargo.toml",
     // "examples/nrf5340/Cargo.toml",
     // "examples/nrf-rtos-trace/Cargo.toml",


### PR DESCRIPTION
This restores the Send/Sync impls for EpState, which were incidentally removed in https://github.com/embassy-rs/embassy/pull/2881. This allows the Endpoints to be sent to tasks, e.g. as part of a custom class implementation.

Fixes #2957 