### PR TITLE
Remove "cargo install probe-rs", point users to probe.rs instead.

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,12 +100,7 @@ Examples are found in the `examples/` folder separated by the chip manufacturer 
 
 ### Running examples
 
-- Install `probe-rs`.
-
-```bash
-cargo install probe-rs --features cli
-```
-
+- Install `probe-rs` following the instructions at <https://probe.rs>.
 - Change directory to the sample's base directory. For example:
 
 ```bash

--- a/cyw43/README.md
+++ b/cyw43/README.md
@@ -23,7 +23,7 @@ TODO:
 
 ## Running the examples
 
-- `cargo install probe-rs --features cli`
+- Install `probe-rs` following the instructions at <https://probe.rs>.
 - `cd examples/rp`
 ### Example 1: Scan the wifi stations
 - `cargo run --release --bin wifi_scan`


### PR DESCRIPTION
Fixes #2965
