### PR TITLE
embassy-sync: fixed some documentation typos

### DIFF
--- a/embassy-sync/src/once_lock.rs
+++ b/embassy-sync/src/once_lock.rs
@@ -1,4 +1,4 @@
-//! Syncronization primitive for initializing a value once, allowing others to await a reference to the value.
+//! Synchronization primitive for initializing a value once, allowing others to await a reference to the value.
 
 use core::cell::Cell;
 use core::future::poll_fn;
@@ -78,7 +78,7 @@ impl<T> OnceLock<T> {
     /// Set the underlying value. If the value is already set, this will return an error with the given value.
     pub fn init(&self, value: T) -> Result<(), T> {
         // Critical section is required to ensure that the value is
-        // not simultaniously initialized elsewhere at the same time.
+        // not simultaneously initialized elsewhere at the same time.
         critical_section::with(|_| {
             // If the value is not set, set it and return Ok.
             if !self.init.load(Ordering::Relaxed) {
@@ -99,7 +99,7 @@ impl<T> OnceLock<T> {
         F: FnOnce() -> T,
     {
         // Critical section is required to ensure that the value is
-        // not simultaniously initialized elsewhere at the same time.
+        // not simultaneously initialized elsewhere at the same time.
         critical_section::with(|_| {
             // If the value is not set, set it.
             if !self.init.load(Ordering::Relaxed) {

--- a/embassy-sync/src/priority_channel.rs
+++ b/embassy-sync/src/priority_channel.rs
@@ -335,7 +335,7 @@ where
 /// buffer is full, attempts to `send` new messages will wait until a message is
 /// received from the channel.
 ///
-/// Sent data may be reordered based on their priorty within the channel.
+/// Sent data may be reordered based on their priority within the channel.
 /// For example, in a [`Max`](heapless::binary_heap::Max) [`PriorityChannel`]
 /// containing `u32`'s, data sent in the following order `[1, 2, 3]` will be received as `[3, 2, 1]`.
 pub struct PriorityChannel<M, T, K, const N: usize>

--- a/embassy-sync/src/pubsub/mod.rs
+++ b/embassy-sync/src/pubsub/mod.rs
@@ -437,7 +437,7 @@ pub enum Error {
 trait SealedPubSubBehavior<T> {
     /// Try to get a message from the queue with the given message id.
     ///
-    /// If the message is not yet present and a context is given, then its waker is registered in the subsriber wakers.
+    /// If the message is not yet present and a context is given, then its waker is registered in the subscriber wakers.
     fn get_message_with_context(&self, next_message_id: &mut u64, cx: Option<&mut Context<'_>>) -> Poll<WaitResult<T>>;
 
     /// Get the amount of messages that are between the given the next_message_id and the most recent message.


### PR DESCRIPTION
This PR fixes some typos in the documentation comments discovered by `typos-cli`.