### PR TITLE
stm32/adc: add AnyAdcChannel type

### DIFF
--- a/embassy-stm32/src/adc/f1.rs
+++ b/embassy-stm32/src/adc/f1.rs
@@ -4,7 +4,7 @@ use core::task::Poll;
 
 use embassy_hal_internal::into_ref;
 
-use super::{blocking_delay_us, InternalChannel};
+use super::blocking_delay_us;
 use crate::adc::{Adc, AdcChannel, Instance, SampleTime};
 use crate::time::Hertz;
 use crate::{interrupt, Peripheral};
@@ -32,8 +32,6 @@ impl<T: Instance> interrupt::typelevel::Handler<T::Interrupt> for InterruptHandl
 }
 
 pub struct Vref;
-impl<T: Instance> InternalChannel<T> for Vref {}
-impl<T: Instance> super::SealedInternalChannel<T> for Vref {}
 impl<T: Instance> AdcChannel<T> for Vref {}
 impl<T: Instance> super::SealedAdcChannel<T> for Vref {
     fn channel(&self) -> u8 {
@@ -42,8 +40,6 @@ impl<T: Instance> super::SealedAdcChannel<T> for Vref {
 }
 
 pub struct Temperature;
-impl<T: Instance> InternalChannel<T> for Temperature {}
-impl<T: Instance> super::SealedInternalChannel<T> for Temperature {}
 impl<T: Instance> AdcChannel<T> for Temperature {}
 impl<T: Instance> super::SealedAdcChannel<T> for Temperature {
     fn channel(&self) -> u8 {

--- a/embassy-stm32/src/adc/f1.rs
+++ b/embassy-stm32/src/adc/f1.rs
@@ -5,7 +5,7 @@ use core::task::Poll;
 use embassy_hal_internal::into_ref;
 
 use super::blocking_delay_us;
-use crate::adc::{Adc, AdcPin, Instance, SampleTime};
+use crate::adc::{Adc, AdcChannel, Instance, SampleTime};
 use crate::time::Hertz;
 use crate::{interrupt, Peripheral};
 
@@ -32,16 +32,16 @@ impl<T: Instance> interrupt::typelevel::Handler<T::Interrupt> for InterruptHandl
 }
 
 pub struct Vref;
-impl<T: Instance> AdcPin<T> for Vref {}
-impl<T: Instance> super::SealedAdcPin<T> for Vref {
+impl<T: Instance> AdcChannel<T> for Vref {}
+impl<T: Instance> super::SealedAdcChannel<T> for Vref {
     fn channel(&self) -> u8 {
         17
     }
 }
 
 pub struct Temperature;
-impl<T: Instance> AdcPin<T> for Temperature {}
-impl<T: Instance> super::SealedAdcPin<T> for Temperature {
+impl<T: Instance> AdcChannel<T> for Temperature {}
+impl<T: Instance> super::SealedAdcChannel<T> for Temperature {
     fn channel(&self) -> u8 {
         16
     }
@@ -135,8 +135,8 @@ impl<'d, T: Instance> Adc<'d, T> {
         T::regs().dr().read().0 as u16
     }
 
-    pub async fn read(&mut self, pin: &mut impl AdcPin<T>) -> u16 {
-        Self::set_channel_sample_time(pin.channel(), self.sample_time);
+    pub async fn read(&mut self, channel: &mut impl AdcChannel<T>) -> u16 {
+        Self::set_channel_sample_time(channel.channel(), self.sample_time);
         T::regs().cr1().modify(|reg| {
             reg.set_scan(false);
             reg.set_discen(false);
@@ -151,7 +151,7 @@ impl<'d, T: Instance> Adc<'d, T> {
         });
 
         // Configure the channel to sample
-        T::regs().sqr3().write(|reg| reg.set_sq(0, pin.channel()));
+        T::regs().sqr3().write(|reg| reg.set_sq(0, channel.channel()));
         self.convert().await
     }
 

--- a/embassy-stm32/src/adc/f1.rs
+++ b/embassy-stm32/src/adc/f1.rs
@@ -4,7 +4,7 @@ use core::task::Poll;
 
 use embassy_hal_internal::into_ref;
 
-use super::blocking_delay_us;
+use super::{blocking_delay_us, InternalChannel};
 use crate::adc::{Adc, AdcChannel, Instance, SampleTime};
 use crate::time::Hertz;
 use crate::{interrupt, Peripheral};
@@ -32,6 +32,8 @@ impl<T: Instance> interrupt::typelevel::Handler<T::Interrupt> for InterruptHandl
 }
 
 pub struct Vref;
+impl<T: Instance> InternalChannel<T> for Vref {}
+impl<T: Instance> super::SealedInternalChannel<T> for Vref {}
 impl<T: Instance> AdcChannel<T> for Vref {}
 impl<T: Instance> super::SealedAdcChannel<T> for Vref {
     fn channel(&self) -> u8 {
@@ -40,6 +42,8 @@ impl<T: Instance> super::SealedAdcChannel<T> for Vref {
 }
 
 pub struct Temperature;
+impl<T: Instance> InternalChannel<T> for Temperature {}
+impl<T: Instance> super::SealedInternalChannel<T> for Temperature {}
 impl<T: Instance> AdcChannel<T> for Temperature {}
 impl<T: Instance> super::SealedAdcChannel<T> for Temperature {
     fn channel(&self) -> u8 {

--- a/embassy-stm32/src/adc/f3.rs
+++ b/embassy-stm32/src/adc/f3.rs
@@ -5,7 +5,7 @@ use core::task::Poll;
 use embassy_hal_internal::into_ref;
 
 use super::blocking_delay_us;
-use crate::adc::{Adc, AdcPin, Instance, SampleTime};
+use crate::adc::{Adc, AdcChannel, Instance, SampleTime};
 use crate::interrupt::typelevel::Interrupt;
 use crate::time::Hertz;
 use crate::{interrupt, Peripheral};
@@ -32,8 +32,8 @@ impl<T: Instance> interrupt::typelevel::Handler<T::Interrupt> for InterruptHandl
 }
 
 pub struct Vref;
-impl<T: Instance> AdcPin<T> for Vref {}
-impl<T: Instance> super::SealedAdcPin<T> for Vref {
+impl<T: Instance> AdcChannel<T> for Vref {}
+impl<T: Instance> super::SealedAdcChannel<T> for Vref {
     fn channel(&self) -> u8 {
         18
     }
@@ -47,8 +47,8 @@ impl Vref {
 }
 
 pub struct Temperature;
-impl<T: Instance> AdcPin<T> for Temperature {}
-impl<T: Instance> super::SealedAdcPin<T> for Temperature {
+impl<T: Instance> AdcChannel<T> for Temperature {}
+impl<T: Instance> super::SealedAdcChannel<T> for Temperature {
     fn channel(&self) -> u8 {
         16
     }
@@ -154,11 +154,11 @@ impl<'d, T: Instance> Adc<'d, T> {
         T::regs().dr().read().rdata()
     }
 
-    pub async fn read(&mut self, pin: &mut impl AdcPin<T>) -> u16 {
-        Self::set_channel_sample_time(pin.channel(), self.sample_time);
+    pub async fn read(&mut self, channel: &mut impl AdcChannel<T>) -> u16 {
+        Self::set_channel_sample_time(channel.channel(), self.sample_time);
 
         // Configure the channel to sample
-        T::regs().sqr1().write(|w| w.set_sq(0, pin.channel()));
+        T::regs().sqr1().write(|w| w.set_sq(0, channel.channel()));
         self.convert().await
     }
 

--- a/embassy-stm32/src/adc/f3.rs
+++ b/embassy-stm32/src/adc/f3.rs
@@ -4,7 +4,7 @@ use core::task::Poll;
 
 use embassy_hal_internal::into_ref;
 
-use super::blocking_delay_us;
+use super::{blocking_delay_us, InternalChannel};
 use crate::adc::{Adc, AdcChannel, Instance, SampleTime};
 use crate::interrupt::typelevel::Interrupt;
 use crate::time::Hertz;
@@ -32,6 +32,8 @@ impl<T: Instance> interrupt::typelevel::Handler<T::Interrupt> for InterruptHandl
 }
 
 pub struct Vref;
+impl<T: Instance> InternalChannel<T> for Vref {}
+impl<T: Instance> super::SealedInternalChannel<T> for Vref {}
 impl<T: Instance> AdcChannel<T> for Vref {}
 impl<T: Instance> super::SealedAdcChannel<T> for Vref {
     fn channel(&self) -> u8 {
@@ -47,6 +49,8 @@ impl Vref {
 }
 
 pub struct Temperature;
+impl<T: Instance> InternalChannel<T> for Temperature {}
+impl<T: Instance> super::SealedInternalChannel<T> for Temperature {}
 impl<T: Instance> AdcChannel<T> for Temperature {}
 impl<T: Instance> super::SealedAdcChannel<T> for Temperature {
     fn channel(&self) -> u8 {

--- a/embassy-stm32/src/adc/f3.rs
+++ b/embassy-stm32/src/adc/f3.rs
@@ -4,7 +4,7 @@ use core::task::Poll;
 
 use embassy_hal_internal::into_ref;
 
-use super::{blocking_delay_us, InternalChannel};
+use super::blocking_delay_us;
 use crate::adc::{Adc, AdcChannel, Instance, SampleTime};
 use crate::interrupt::typelevel::Interrupt;
 use crate::time::Hertz;
@@ -32,8 +32,6 @@ impl<T: Instance> interrupt::typelevel::Handler<T::Interrupt> for InterruptHandl
 }
 
 pub struct Vref;
-impl<T: Instance> InternalChannel<T> for Vref {}
-impl<T: Instance> super::SealedInternalChannel<T> for Vref {}
 impl<T: Instance> AdcChannel<T> for Vref {}
 impl<T: Instance> super::SealedAdcChannel<T> for Vref {
     fn channel(&self) -> u8 {
@@ -49,8 +47,6 @@ impl Vref {
 }
 
 pub struct Temperature;
-impl<T: Instance> InternalChannel<T> for Temperature {}
-impl<T: Instance> super::SealedInternalChannel<T> for Temperature {}
 impl<T: Instance> AdcChannel<T> for Temperature {}
 impl<T: Instance> super::SealedAdcChannel<T> for Temperature {
     fn channel(&self) -> u8 {

--- a/embassy-stm32/src/adc/f3_v1_1.rs
+++ b/embassy-stm32/src/adc/f3_v1_1.rs
@@ -6,7 +6,7 @@ use embassy_futures::yield_now;
 use embassy_hal_internal::into_ref;
 use embassy_time::Instant;
 
-use super::Resolution;
+use super::{InternalChannel, Resolution};
 use crate::adc::{Adc, AdcChannel, Instance, SampleTime};
 use crate::interrupt::typelevel::Interrupt;
 use crate::time::Hertz;
@@ -64,6 +64,8 @@ fn update_vref<T: Instance>(op: i8) {
 }
 
 pub struct Vref<T: Instance>(core::marker::PhantomData<T>);
+impl<T: Instance> InternalChannel<T> for Vref<T> {}
+impl<T: Instance> super::SealedInternalChannel<T> for Vref<T> {}
 impl<T: Instance> AdcChannel<T> for Vref<T> {}
 impl<T: Instance> super::SealedAdcChannel<T> for Vref<T> {
     fn channel(&self) -> u8 {
@@ -123,6 +125,8 @@ impl<T: Instance> Drop for Vref<T> {
 }
 
 pub struct Temperature<T: Instance>(core::marker::PhantomData<T>);
+impl<T: Instance> InternalChannel<T> for Temperature<T> {}
+impl<T: Instance> super::SealedInternalChannel<T> for Temperature<T> {}
 impl<T: Instance> AdcChannel<T> for Temperature<T> {}
 impl<T: Instance> super::SealedAdcChannel<T> for Temperature<T> {
     fn channel(&self) -> u8 {

--- a/embassy-stm32/src/adc/f3_v1_1.rs
+++ b/embassy-stm32/src/adc/f3_v1_1.rs
@@ -6,7 +6,7 @@ use embassy_futures::yield_now;
 use embassy_hal_internal::into_ref;
 use embassy_time::Instant;
 
-use super::{InternalChannel, Resolution};
+use super::Resolution;
 use crate::adc::{Adc, AdcChannel, Instance, SampleTime};
 use crate::interrupt::typelevel::Interrupt;
 use crate::time::Hertz;
@@ -64,8 +64,6 @@ fn update_vref<T: Instance>(op: i8) {
 }
 
 pub struct Vref<T: Instance>(core::marker::PhantomData<T>);
-impl<T: Instance> InternalChannel<T> for Vref<T> {}
-impl<T: Instance> super::SealedInternalChannel<T> for Vref<T> {}
 impl<T: Instance> AdcChannel<T> for Vref<T> {}
 impl<T: Instance> super::SealedAdcChannel<T> for Vref<T> {
     fn channel(&self) -> u8 {
@@ -125,8 +123,6 @@ impl<T: Instance> Drop for Vref<T> {
 }
 
 pub struct Temperature<T: Instance>(core::marker::PhantomData<T>);
-impl<T: Instance> InternalChannel<T> for Temperature<T> {}
-impl<T: Instance> super::SealedInternalChannel<T> for Temperature<T> {}
 impl<T: Instance> AdcChannel<T> for Temperature<T> {}
 impl<T: Instance> super::SealedAdcChannel<T> for Temperature<T> {
     fn channel(&self) -> u8 {

--- a/embassy-stm32/src/adc/f3_v1_1.rs
+++ b/embassy-stm32/src/adc/f3_v1_1.rs
@@ -7,7 +7,7 @@ use embassy_hal_internal::into_ref;
 use embassy_time::Instant;
 
 use super::Resolution;
-use crate::adc::{Adc, AdcPin, Instance, SampleTime};
+use crate::adc::{Adc, AdcChannel, Instance, SampleTime};
 use crate::interrupt::typelevel::Interrupt;
 use crate::time::Hertz;
 use crate::{interrupt, Peripheral};
@@ -64,8 +64,8 @@ fn update_vref<T: Instance>(op: i8) {
 }
 
 pub struct Vref<T: Instance>(core::marker::PhantomData<T>);
-impl<T: Instance> AdcPin<T> for Vref<T> {}
-impl<T: Instance> super::SealedAdcPin<T> for Vref<T> {
+impl<T: Instance> AdcChannel<T> for Vref<T> {}
+impl<T: Instance> super::SealedAdcChannel<T> for Vref<T> {
     fn channel(&self) -> u8 {
         17
     }
@@ -123,8 +123,8 @@ impl<T: Instance> Drop for Vref<T> {
 }
 
 pub struct Temperature<T: Instance>(core::marker::PhantomData<T>);
-impl<T: Instance> AdcPin<T> for Temperature<T> {}
-impl<T: Instance> super::SealedAdcPin<T> for Temperature<T> {
+impl<T: Instance> AdcChannel<T> for Temperature<T> {}
+impl<T: Instance> super::SealedAdcChannel<T> for Temperature<T> {
     fn channel(&self) -> u8 {
         16
     }
@@ -271,8 +271,8 @@ impl<'d, T: Instance> Adc<'d, T> {
         }
     }
 
-    pub async fn read(&mut self, pin: &mut impl AdcPin<T>) -> u16 {
-        self.set_sample_sequence(&[pin.channel()]).await;
+    pub async fn read(&mut self, channel: &mut impl AdcChannel<T>) -> u16 {
+        self.set_sample_sequence(&[channel.channel()]).await;
         self.convert().await
     }
 
@@ -283,18 +283,18 @@ impl<'d, T: Instance> Adc<'d, T> {
         }
     }
 
-    pub async fn set_sample_time(&mut self, pin: &mut impl AdcPin<T>, sample_time: SampleTime) {
-        if Self::get_channel_sample_time(pin.channel()) != sample_time {
+    pub async fn set_sample_time(&mut self, channel: &mut impl AdcChannel<T>, sample_time: SampleTime) {
+        if Self::get_channel_sample_time(channel.channel()) != sample_time {
             self.stop_adc().await;
             unsafe {
-                Self::set_channel_sample_time(pin.channel(), sample_time);
+                Self::set_channel_sample_time(channel.channel(), sample_time);
             }
             self.start_adc().await;
         }
     }
 
-    pub fn get_sample_time(&self, pin: &impl AdcPin<T>) -> SampleTime {
-        Self::get_channel_sample_time(pin.channel())
+    pub fn get_sample_time(&self, channel: &impl AdcChannel<T>) -> SampleTime {
+        Self::get_channel_sample_time(channel.channel())
     }
 
     /// Sets the channel sample time

--- a/embassy-stm32/src/adc/g4.rs
+++ b/embassy-stm32/src/adc/g4.rs
@@ -2,7 +2,7 @@
 use pac::adc::vals::{Adcaldif, Difsel, Exten};
 use pac::adccommon::vals::Presc;
 
-use super::{blocking_delay_us, Adc, AdcChannel, Instance, Resolution, SampleTime};
+use super::{blocking_delay_us, Adc, AdcChannel, Instance, InternalChannel, Resolution, SampleTime};
 use crate::time::Hertz;
 use crate::{pac, Peripheral};
 
@@ -33,6 +33,8 @@ const VBAT_CHANNEL: u8 = 17;
 // NOTE: Vrefint/Temperature/Vbat are not available on all ADCs, this currently cannot be modeled with stm32-data, so these are available from the software on all ADCs
 /// Internal voltage reference channel.
 pub struct VrefInt;
+impl<T: Instance> InternalChannel<T> for VrefInt {}
+impl<T: Instance> super::SealedInternalChannel<T> for VrefInt {}
 impl<T: Instance> AdcChannel<T> for VrefInt {}
 impl<T: Instance> super::SealedAdcChannel<T> for VrefInt {
     fn channel(&self) -> u8 {
@@ -42,6 +44,8 @@ impl<T: Instance> super::SealedAdcChannel<T> for VrefInt {
 
 /// Internal temperature channel.
 pub struct Temperature;
+impl<T: Instance> InternalChannel<T> for Temperature {}
+impl<T: Instance> super::SealedInternalChannel<T> for Temperature {}
 impl<T: Instance> AdcChannel<T> for Temperature {}
 impl<T: Instance> super::SealedAdcChannel<T> for Temperature {
     fn channel(&self) -> u8 {
@@ -51,6 +55,8 @@ impl<T: Instance> super::SealedAdcChannel<T> for Temperature {
 
 /// Internal battery voltage channel.
 pub struct Vbat;
+impl<T: Instance> InternalChannel<T> for Vbat {}
+impl<T: Instance> super::SealedInternalChannel<T> for Vbat {}
 impl<T: Instance> AdcChannel<T> for Vbat {}
 impl<T: Instance> super::SealedAdcChannel<T> for Vbat {
     fn channel(&self) -> u8 {

--- a/embassy-stm32/src/adc/g4.rs
+++ b/embassy-stm32/src/adc/g4.rs
@@ -2,7 +2,7 @@
 use pac::adc::vals::{Adcaldif, Difsel, Exten};
 use pac::adccommon::vals::Presc;
 
-use super::{blocking_delay_us, Adc, AdcChannel, Instance, InternalChannel, Resolution, SampleTime};
+use super::{blocking_delay_us, Adc, AdcChannel, Instance, Resolution, SampleTime};
 use crate::time::Hertz;
 use crate::{pac, Peripheral};
 
@@ -33,8 +33,6 @@ const VBAT_CHANNEL: u8 = 17;
 // NOTE: Vrefint/Temperature/Vbat are not available on all ADCs, this currently cannot be modeled with stm32-data, so these are available from the software on all ADCs
 /// Internal voltage reference channel.
 pub struct VrefInt;
-impl<T: Instance> InternalChannel<T> for VrefInt {}
-impl<T: Instance> super::SealedInternalChannel<T> for VrefInt {}
 impl<T: Instance> AdcChannel<T> for VrefInt {}
 impl<T: Instance> super::SealedAdcChannel<T> for VrefInt {
     fn channel(&self) -> u8 {
@@ -44,8 +42,6 @@ impl<T: Instance> super::SealedAdcChannel<T> for VrefInt {
 
 /// Internal temperature channel.
 pub struct Temperature;
-impl<T: Instance> InternalChannel<T> for Temperature {}
-impl<T: Instance> super::SealedInternalChannel<T> for Temperature {}
 impl<T: Instance> AdcChannel<T> for Temperature {}
 impl<T: Instance> super::SealedAdcChannel<T> for Temperature {
     fn channel(&self) -> u8 {
@@ -55,8 +51,6 @@ impl<T: Instance> super::SealedAdcChannel<T> for Temperature {
 
 /// Internal battery voltage channel.
 pub struct Vbat;
-impl<T: Instance> InternalChannel<T> for Vbat {}
-impl<T: Instance> super::SealedInternalChannel<T> for Vbat {}
 impl<T: Instance> AdcChannel<T> for Vbat {}
 impl<T: Instance> super::SealedAdcChannel<T> for Vbat {
     fn channel(&self) -> u8 {

--- a/embassy-stm32/src/adc/g4.rs
+++ b/embassy-stm32/src/adc/g4.rs
@@ -2,7 +2,7 @@
 use pac::adc::vals::{Adcaldif, Difsel, Exten};
 use pac::adccommon::vals::Presc;
 
-use super::{blocking_delay_us, Adc, AdcPin, Instance, InternalChannel, Resolution, SampleTime};
+use super::{blocking_delay_us, Adc, AdcChannel, Instance, Resolution, SampleTime};
 use crate::time::Hertz;
 use crate::{pac, Peripheral};
 
@@ -33,8 +33,8 @@ const VBAT_CHANNEL: u8 = 17;
 // NOTE: Vrefint/Temperature/Vbat are not available on all ADCs, this currently cannot be modeled with stm32-data, so these are available from the software on all ADCs
 /// Internal voltage reference channel.
 pub struct VrefInt;
-impl<T: Instance> InternalChannel<T> for VrefInt {}
-impl<T: Instance> super::SealedInternalChannel<T> for VrefInt {
+impl<T: Instance> AdcChannel<T> for VrefInt {}
+impl<T: Instance> super::SealedAdcChannel<T> for VrefInt {
     fn channel(&self) -> u8 {
         VREF_CHANNEL
     }
@@ -42,8 +42,8 @@ impl<T: Instance> super::SealedInternalChannel<T> for VrefInt {
 
 /// Internal temperature channel.
 pub struct Temperature;
-impl<T: Instance> InternalChannel<T> for Temperature {}
-impl<T: Instance> super::SealedInternalChannel<T> for Temperature {
+impl<T: Instance> AdcChannel<T> for Temperature {}
+impl<T: Instance> super::SealedAdcChannel<T> for Temperature {
     fn channel(&self) -> u8 {
         TEMP_CHANNEL
     }
@@ -51,8 +51,8 @@ impl<T: Instance> super::SealedInternalChannel<T> for Temperature {
 
 /// Internal battery voltage channel.
 pub struct Vbat;
-impl<T: Instance> InternalChannel<T> for Vbat {}
-impl<T: Instance> super::SealedInternalChannel<T> for Vbat {
+impl<T: Instance> AdcChannel<T> for Vbat {}
+impl<T: Instance> super::SealedAdcChannel<T> for Vbat {
     fn channel(&self) -> u8 {
         VBAT_CHANNEL
     }
@@ -258,18 +258,9 @@ impl<'d, T: Instance> Adc<'d, T> {
     }
 
     /// Read an ADC pin.
-    pub fn read<P>(&mut self, pin: &mut P) -> u16
-    where
-        P: AdcPin<T>,
-        P: crate::gpio::Pin,
-    {
-        pin.set_as_analog();
+    pub fn read(&mut self, channel: &mut impl AdcChannel<T>) -> u16 {
+        channel.setup();
 
-        self.read_channel(pin.channel())
-    }
-
-    /// Read an ADC internal channel.
-    pub fn read_internal(&mut self, channel: &mut impl InternalChannel<T>) -> u16 {
         self.read_channel(channel.channel())
     }
 

--- a/embassy-stm32/src/adc/mod.rs
+++ b/embassy-stm32/src/adc/mod.rs
@@ -128,7 +128,7 @@ pub trait Instance: SealedInstance + crate::Peripheral<P = Self> + crate::rcc::R
 pub trait AdcPin<T: Instance>: AdcChannel<T> + SealedAdcPin<T> {}
 /// ADC internal channel.
 #[allow(private_bounds)]
-pub trait InternalChannel<T>: SealedInternalChannel<T> {}
+pub trait InternalChannel<T>: AdcChannel<T> + SealedInternalChannel<T> {}
 /// ADC channel.
 #[allow(private_bounds)]
 pub trait AdcChannel<T>: SealedAdcChannel<T> + Sized {

--- a/embassy-stm32/src/adc/mod.rs
+++ b/embassy-stm32/src/adc/mod.rs
@@ -61,7 +61,7 @@ trait SealedInstance {
 }
 
 pub(crate) trait SealedAdcPin<T: Instance> {}
-
+pub(crate) trait SealedInternalChannel<T> {}
 pub(crate) trait SealedAdcChannel<T> {
     #[cfg(any(adc_v1, adc_l0, adc_v2, adc_g4, adc_v4))]
     fn setup(&mut self) {}
@@ -126,6 +126,9 @@ pub trait Instance: SealedInstance + crate::Peripheral<P = Self> + crate::rcc::R
 /// ADC pin.
 #[allow(private_bounds)]
 pub trait AdcPin<T: Instance>: AdcChannel<T> + SealedAdcPin<T> {}
+/// ADC internal channel.
+#[allow(private_bounds)]
+pub trait InternalChannel<T>: SealedInternalChannel<T> {}
 /// ADC channel.
 #[allow(private_bounds)]
 pub trait AdcChannel<T>: SealedAdcChannel<T> + Sized {

--- a/embassy-stm32/src/adc/mod.rs
+++ b/embassy-stm32/src/adc/mod.rs
@@ -15,6 +15,8 @@
 #[cfg_attr(adc_g4, path = "g4.rs")]
 mod _version;
 
+use core::marker::PhantomData;
+
 #[allow(unused)]
 #[cfg(not(adc_f3_v2))]
 pub use _version::*;
@@ -58,15 +60,12 @@ trait SealedInstance {
     fn state() -> &'static State;
 }
 
-pub(crate) trait SealedAdcPin<T: Instance> {
-    #[cfg(any(adc_v1, adc_l0, adc_v2))]
-    fn set_as_analog(&mut self) {}
+pub(crate) trait SealedAdcPin<T: Instance> {}
 
-    #[allow(unused)]
-    fn channel(&self) -> u8;
-}
+pub(crate) trait SealedAdcChannel<T> {
+    #[cfg(any(adc_v1, adc_l0, adc_v2, adc_g4, adc_v4))]
+    fn setup(&mut self) {}
 
-trait SealedInternalChannel<T> {
     #[allow(unused)]
     fn channel(&self) -> u8;
 }
@@ -126,10 +125,37 @@ pub trait Instance: SealedInstance + crate::Peripheral<P = Self> + crate::rcc::R
 
 /// ADC pin.
 #[allow(private_bounds)]
-pub trait AdcPin<T: Instance>: SealedAdcPin<T> {}
-/// ADC internal channel.
+pub trait AdcPin<T: Instance>: AdcChannel<T> + SealedAdcPin<T> {}
+/// ADC channel.
 #[allow(private_bounds)]
-pub trait InternalChannel<T>: SealedInternalChannel<T> {}
+pub trait AdcChannel<T>: SealedAdcChannel<T> + Sized {
+    #[allow(unused_mut)]
+    fn degrade_adc(mut self) -> AnyAdcChannel<T> {
+        #[cfg(any(adc_v1, adc_l0, adc_v2, adc_g4, adc_v4))]
+        self.setup();
+
+        AnyAdcChannel {
+            channel: self.channel(),
+            _phantom: PhantomData,
+        }
+    }
+}
+
+/// A type-erased channel for a given ADC instance.
+///
+/// This is useful in scenarios where you need the ADC channels to have the same type, such as
+/// storing them in an array.
+pub struct AnyAdcChannel<T> {
+    channel: u8,
+    _phantom: PhantomData<T>,
+}
+
+impl<T: Instance> AdcChannel<T> for AnyAdcChannel<T> {}
+impl<T: Instance> SealedAdcChannel<T> for AnyAdcChannel<T> {
+    fn channel(&self) -> u8 {
+        self.channel
+    }
+}
 
 foreach_adc!(
     ($inst:ident, $common_inst:ident, $clock:ident) => {
@@ -159,10 +185,12 @@ foreach_adc!(
 macro_rules! impl_adc_pin {
     ($inst:ident, $pin:ident, $ch:expr) => {
         impl crate::adc::AdcPin<peripherals::$inst> for crate::peripherals::$pin {}
+        impl crate::adc::SealedAdcPin<peripherals::$inst> for crate::peripherals::$pin {}
 
-        impl crate::adc::SealedAdcPin<peripherals::$inst> for crate::peripherals::$pin {
-            #[cfg(any(adc_v1, adc_l0, adc_v2))]
-            fn set_as_analog(&mut self) {
+        impl crate::adc::AdcChannel<peripherals::$inst> for crate::peripherals::$pin {}
+        impl crate::adc::SealedAdcChannel<peripherals::$inst> for crate::peripherals::$pin {
+            #[cfg(any(adc_v1, adc_l0, adc_v2, adc_g4, adc_v4))]
+            fn setup(&mut self) {
                 <Self as crate::gpio::SealedPin>::set_as_analog(self);
             }
 

--- a/embassy-stm32/src/adc/mod.rs
+++ b/embassy-stm32/src/adc/mod.rs
@@ -60,8 +60,6 @@ trait SealedInstance {
     fn state() -> &'static State;
 }
 
-pub(crate) trait SealedAdcPin<T: Instance> {}
-pub(crate) trait SealedInternalChannel<T> {}
 pub(crate) trait SealedAdcChannel<T> {
     #[cfg(any(adc_v1, adc_l0, adc_v2, adc_g4, adc_v4))]
     fn setup(&mut self) {}
@@ -123,12 +121,6 @@ pub trait Instance: SealedInstance + crate::Peripheral<P = Self> + crate::rcc::R
     type Interrupt: crate::interrupt::typelevel::Interrupt;
 }
 
-/// ADC pin.
-#[allow(private_bounds)]
-pub trait AdcPin<T: Instance>: AdcChannel<T> + SealedAdcPin<T> {}
-/// ADC internal channel.
-#[allow(private_bounds)]
-pub trait InternalChannel<T>: AdcChannel<T> + SealedInternalChannel<T> {}
 /// ADC channel.
 #[allow(private_bounds)]
 pub trait AdcChannel<T>: SealedAdcChannel<T> + Sized {
@@ -187,9 +179,6 @@ foreach_adc!(
 
 macro_rules! impl_adc_pin {
     ($inst:ident, $pin:ident, $ch:expr) => {
-        impl crate::adc::AdcPin<peripherals::$inst> for crate::peripherals::$pin {}
-        impl crate::adc::SealedAdcPin<peripherals::$inst> for crate::peripherals::$pin {}
-
         impl crate::adc::AdcChannel<peripherals::$inst> for crate::peripherals::$pin {}
         impl crate::adc::SealedAdcChannel<peripherals::$inst> for crate::peripherals::$pin {
             #[cfg(any(adc_v1, adc_l0, adc_v2, adc_g4, adc_v4))]

--- a/embassy-stm32/src/adc/v1.rs
+++ b/embassy-stm32/src/adc/v1.rs
@@ -6,7 +6,7 @@ use embassy_hal_internal::into_ref;
 #[cfg(adc_l0)]
 use stm32_metapac::adc::vals::Ckmode;
 
-use super::{blocking_delay_us, InternalChannel};
+use super::blocking_delay_us;
 use crate::adc::{Adc, AdcChannel, Instance, Resolution, SampleTime};
 use crate::interrupt::typelevel::Interrupt;
 use crate::peripherals::ADC1;
@@ -36,12 +36,6 @@ impl<T: Instance> interrupt::typelevel::Handler<T::Interrupt> for InterruptHandl
 pub struct Vbat;
 
 #[cfg(not(adc_l0))]
-impl InternalChannel<ADC1> for Vbat {}
-
-#[cfg(not(adc_l0))]
-impl super::SealedInternalChannel<ADC1> for Vbat {}
-
-#[cfg(not(adc_l0))]
 impl AdcChannel<ADC1> for Vbat {}
 
 #[cfg(not(adc_l0))]
@@ -52,8 +46,6 @@ impl super::SealedAdcChannel<ADC1> for Vbat {
 }
 
 pub struct Vref;
-impl InternalChannel<ADC1> for Vref {}
-impl super::SealedInternalChannel<ADC1> for Vref {}
 impl AdcChannel<ADC1> for Vref {}
 impl super::SealedAdcChannel<ADC1> for Vref {
     fn channel(&self) -> u8 {
@@ -62,8 +54,6 @@ impl super::SealedAdcChannel<ADC1> for Vref {
 }
 
 pub struct Temperature;
-impl InternalChannel<ADC1> for Temperature {}
-impl super::SealedInternalChannel<ADC1> for Temperature {}
 impl AdcChannel<ADC1> for Temperature {}
 impl super::SealedAdcChannel<ADC1> for Temperature {
     fn channel(&self) -> u8 {

--- a/embassy-stm32/src/adc/v1.rs
+++ b/embassy-stm32/src/adc/v1.rs
@@ -6,7 +6,7 @@ use embassy_hal_internal::into_ref;
 #[cfg(adc_l0)]
 use stm32_metapac::adc::vals::Ckmode;
 
-use super::blocking_delay_us;
+use super::{blocking_delay_us, InternalChannel};
 use crate::adc::{Adc, AdcChannel, Instance, Resolution, SampleTime};
 use crate::interrupt::typelevel::Interrupt;
 use crate::peripherals::ADC1;
@@ -36,6 +36,12 @@ impl<T: Instance> interrupt::typelevel::Handler<T::Interrupt> for InterruptHandl
 pub struct Vbat;
 
 #[cfg(not(adc_l0))]
+impl InternalChannel<ADC1> for Vbat {}
+
+#[cfg(not(adc_l0))]
+impl super::SealedInternalChannel<ADC1> for Vbat {}
+
+#[cfg(not(adc_l0))]
 impl AdcChannel<ADC1> for Vbat {}
 
 #[cfg(not(adc_l0))]
@@ -46,6 +52,8 @@ impl super::SealedAdcChannel<ADC1> for Vbat {
 }
 
 pub struct Vref;
+impl InternalChannel<ADC1> for Vref {}
+impl super::SealedInternalChannel<ADC1> for Vref {}
 impl AdcChannel<ADC1> for Vref {}
 impl super::SealedAdcChannel<ADC1> for Vref {
     fn channel(&self) -> u8 {
@@ -54,6 +62,8 @@ impl super::SealedAdcChannel<ADC1> for Vref {
 }
 
 pub struct Temperature;
+impl InternalChannel<ADC1> for Temperature {}
+impl super::SealedInternalChannel<ADC1> for Temperature {}
 impl AdcChannel<ADC1> for Temperature {}
 impl super::SealedAdcChannel<ADC1> for Temperature {
     fn channel(&self) -> u8 {

--- a/embassy-stm32/src/adc/v2.rs
+++ b/embassy-stm32/src/adc/v2.rs
@@ -1,6 +1,6 @@
 use embassy_hal_internal::into_ref;
 
-use super::{blocking_delay_us, InternalChannel};
+use super::blocking_delay_us;
 use crate::adc::{Adc, AdcChannel, Instance, Resolution, SampleTime};
 use crate::peripherals::ADC1;
 use crate::time::Hertz;
@@ -12,8 +12,6 @@ pub const VREF_DEFAULT_MV: u32 = 3300;
 pub const VREF_CALIB_MV: u32 = 3300;
 
 pub struct VrefInt;
-impl InternalChannel<ADC1> for VrefInt {}
-impl super::SealedInternalChannel<ADC1> for VrefInt {}
 impl AdcChannel<ADC1> for VrefInt {}
 impl super::SealedAdcChannel<ADC1> for VrefInt {
     fn channel(&self) -> u8 {
@@ -29,8 +27,6 @@ impl VrefInt {
 }
 
 pub struct Temperature;
-impl InternalChannel<ADC1> for Temperature {}
-impl super::SealedInternalChannel<ADC1> for Temperature {}
 impl AdcChannel<ADC1> for Temperature {}
 impl super::SealedAdcChannel<ADC1> for Temperature {
     fn channel(&self) -> u8 {
@@ -52,8 +48,6 @@ impl Temperature {
 }
 
 pub struct Vbat;
-impl InternalChannel<ADC1> for Vbat {}
-impl super::SealedInternalChannel<ADC1> for Vbat {}
 impl AdcChannel<ADC1> for Vbat {}
 impl super::SealedAdcChannel<ADC1> for Vbat {
     fn channel(&self) -> u8 {

--- a/embassy-stm32/src/adc/v2.rs
+++ b/embassy-stm32/src/adc/v2.rs
@@ -1,7 +1,7 @@
 use embassy_hal_internal::into_ref;
 
 use super::blocking_delay_us;
-use crate::adc::{Adc, AdcPin, Instance, Resolution, SampleTime};
+use crate::adc::{Adc, AdcChannel, Instance, Resolution, SampleTime};
 use crate::peripherals::ADC1;
 use crate::time::Hertz;
 use crate::Peripheral;
@@ -12,8 +12,8 @@ pub const VREF_DEFAULT_MV: u32 = 3300;
 pub const VREF_CALIB_MV: u32 = 3300;
 
 pub struct VrefInt;
-impl AdcPin<ADC1> for VrefInt {}
-impl super::SealedAdcPin<ADC1> for VrefInt {
+impl AdcChannel<ADC1> for VrefInt {}
+impl super::SealedAdcChannel<ADC1> for VrefInt {
     fn channel(&self) -> u8 {
         17
     }
@@ -27,8 +27,8 @@ impl VrefInt {
 }
 
 pub struct Temperature;
-impl AdcPin<ADC1> for Temperature {}
-impl super::SealedAdcPin<ADC1> for Temperature {
+impl AdcChannel<ADC1> for Temperature {}
+impl super::SealedAdcChannel<ADC1> for Temperature {
     fn channel(&self) -> u8 {
         cfg_if::cfg_if! {
             if #[cfg(any(stm32f2, stm32f40, stm32f41))] {
@@ -48,8 +48,8 @@ impl Temperature {
 }
 
 pub struct Vbat;
-impl AdcPin<ADC1> for Vbat {}
-impl super::SealedAdcPin<ADC1> for Vbat {
+impl AdcChannel<ADC1> for Vbat {}
+impl super::SealedAdcChannel<ADC1> for Vbat {
     fn channel(&self) -> u8 {
         18
     }
@@ -175,11 +175,11 @@ where
         T::regs().dr().read().0 as u16
     }
 
-    pub fn read(&mut self, pin: &mut impl AdcPin<T>) -> u16 {
-        pin.set_as_analog();
+    pub fn read(&mut self, channel: &mut impl AdcChannel<T>) -> u16 {
+        channel.setup();
 
         // Configure ADC
-        let channel = pin.channel();
+        let channel = channel.channel();
 
         // Select channel
         T::regs().sqr3().write(|reg| reg.set_sq(0, channel));

--- a/embassy-stm32/src/adc/v2.rs
+++ b/embassy-stm32/src/adc/v2.rs
@@ -1,6 +1,6 @@
 use embassy_hal_internal::into_ref;
 
-use super::blocking_delay_us;
+use super::{blocking_delay_us, InternalChannel};
 use crate::adc::{Adc, AdcChannel, Instance, Resolution, SampleTime};
 use crate::peripherals::ADC1;
 use crate::time::Hertz;
@@ -12,6 +12,8 @@ pub const VREF_DEFAULT_MV: u32 = 3300;
 pub const VREF_CALIB_MV: u32 = 3300;
 
 pub struct VrefInt;
+impl InternalChannel<ADC1> for VrefInt {}
+impl super::SealedInternalChannel<ADC1> for VrefInt {}
 impl AdcChannel<ADC1> for VrefInt {}
 impl super::SealedAdcChannel<ADC1> for VrefInt {
     fn channel(&self) -> u8 {
@@ -27,6 +29,8 @@ impl VrefInt {
 }
 
 pub struct Temperature;
+impl InternalChannel<ADC1> for Temperature {}
+impl super::SealedInternalChannel<ADC1> for Temperature {}
 impl AdcChannel<ADC1> for Temperature {}
 impl super::SealedAdcChannel<ADC1> for Temperature {
     fn channel(&self) -> u8 {
@@ -48,6 +52,8 @@ impl Temperature {
 }
 
 pub struct Vbat;
+impl InternalChannel<ADC1> for Vbat {}
+impl super::SealedInternalChannel<ADC1> for Vbat {}
 impl AdcChannel<ADC1> for Vbat {}
 impl super::SealedAdcChannel<ADC1> for Vbat {
     fn channel(&self) -> u8 {

--- a/embassy-stm32/src/adc/v3.rs
+++ b/embassy-stm32/src/adc/v3.rs
@@ -1,7 +1,7 @@
 use cfg_if::cfg_if;
 use embassy_hal_internal::into_ref;
 
-use super::blocking_delay_us;
+use super::{blocking_delay_us, InternalChannel};
 use crate::adc::{Adc, AdcChannel, Instance, Resolution, SampleTime};
 use crate::Peripheral;
 
@@ -11,6 +11,8 @@ pub const VREF_DEFAULT_MV: u32 = 3300;
 pub const VREF_CALIB_MV: u32 = 3000;
 
 pub struct VrefInt;
+impl<T: Instance> InternalChannel<T> for VrefInt {}
+impl<T: Instance> super::SealedInternalChannel<T> for VrefInt {}
 impl<T: Instance> AdcChannel<T> for VrefInt {}
 impl<T: Instance> super::SealedAdcChannel<T> for VrefInt {
     fn channel(&self) -> u8 {
@@ -30,6 +32,8 @@ impl<T: Instance> super::SealedAdcChannel<T> for VrefInt {
 }
 
 pub struct Temperature;
+impl<T: Instance> InternalChannel<T> for Temperature {}
+impl<T: Instance> super::SealedInternalChannel<T> for Temperature {}
 impl<T: Instance> AdcChannel<T> for Temperature {}
 impl<T: Instance> super::SealedAdcChannel<T> for Temperature {
     fn channel(&self) -> u8 {
@@ -49,6 +53,8 @@ impl<T: Instance> super::SealedAdcChannel<T> for Temperature {
 }
 
 pub struct Vbat;
+impl<T: Instance> InternalChannel<T> for Vbat {}
+impl<T: Instance> super::SealedInternalChannel<T> for Vbat {}
 impl<T: Instance> AdcChannel<T> for Vbat {}
 impl<T: Instance> super::SealedAdcChannel<T> for Vbat {
     fn channel(&self) -> u8 {
@@ -70,6 +76,8 @@ impl<T: Instance> super::SealedAdcChannel<T> for Vbat {
 cfg_if! {
     if #[cfg(adc_h5)] {
         pub struct VddCore;
+        impl<T: Instance> InternalChannel<T> for VddCore {}
+        impl<T: Instance> super::SealedInternalChannel<T> for VddCore {}
         impl<T: Instance> AdcChannel<T> for VddCore {}
         impl<T: Instance> super::SealedAdcChannel<T> for VddCore {
             fn channel(&self) -> u8 {
@@ -82,6 +90,8 @@ cfg_if! {
 cfg_if! {
     if #[cfg(adc_u0)] {
         pub struct DacOut;
+        impl<T: Instance> InternalChannel<T> for DacOut {}
+        impl<T: Instance> super::SealedInternalChannel<T> for DacOut {}
         impl<T: Instance> AdcChannel<T> for DacOut {}
         impl<T: Instance> super::SealedAdcChannel<T> for DacOut {
             fn channel(&self) -> u8 {

--- a/embassy-stm32/src/adc/v3.rs
+++ b/embassy-stm32/src/adc/v3.rs
@@ -1,7 +1,7 @@
 use cfg_if::cfg_if;
 use embassy_hal_internal::into_ref;
 
-use super::{blocking_delay_us, InternalChannel};
+use super::blocking_delay_us;
 use crate::adc::{Adc, AdcChannel, Instance, Resolution, SampleTime};
 use crate::Peripheral;
 
@@ -11,8 +11,6 @@ pub const VREF_DEFAULT_MV: u32 = 3300;
 pub const VREF_CALIB_MV: u32 = 3000;
 
 pub struct VrefInt;
-impl<T: Instance> InternalChannel<T> for VrefInt {}
-impl<T: Instance> super::SealedInternalChannel<T> for VrefInt {}
 impl<T: Instance> AdcChannel<T> for VrefInt {}
 impl<T: Instance> super::SealedAdcChannel<T> for VrefInt {
     fn channel(&self) -> u8 {
@@ -32,8 +30,6 @@ impl<T: Instance> super::SealedAdcChannel<T> for VrefInt {
 }
 
 pub struct Temperature;
-impl<T: Instance> InternalChannel<T> for Temperature {}
-impl<T: Instance> super::SealedInternalChannel<T> for Temperature {}
 impl<T: Instance> AdcChannel<T> for Temperature {}
 impl<T: Instance> super::SealedAdcChannel<T> for Temperature {
     fn channel(&self) -> u8 {
@@ -53,8 +49,6 @@ impl<T: Instance> super::SealedAdcChannel<T> for Temperature {
 }
 
 pub struct Vbat;
-impl<T: Instance> InternalChannel<T> for Vbat {}
-impl<T: Instance> super::SealedInternalChannel<T> for Vbat {}
 impl<T: Instance> AdcChannel<T> for Vbat {}
 impl<T: Instance> super::SealedAdcChannel<T> for Vbat {
     fn channel(&self) -> u8 {
@@ -76,8 +70,6 @@ impl<T: Instance> super::SealedAdcChannel<T> for Vbat {
 cfg_if! {
     if #[cfg(adc_h5)] {
         pub struct VddCore;
-        impl<T: Instance> InternalChannel<T> for VddCore {}
-        impl<T: Instance> super::SealedInternalChannel<T> for VddCore {}
         impl<T: Instance> AdcChannel<T> for VddCore {}
         impl<T: Instance> super::SealedAdcChannel<T> for VddCore {
             fn channel(&self) -> u8 {
@@ -90,8 +82,6 @@ cfg_if! {
 cfg_if! {
     if #[cfg(adc_u0)] {
         pub struct DacOut;
-        impl<T: Instance> InternalChannel<T> for DacOut {}
-        impl<T: Instance> super::SealedInternalChannel<T> for DacOut {}
         impl<T: Instance> AdcChannel<T> for DacOut {}
         impl<T: Instance> super::SealedAdcChannel<T> for DacOut {
             fn channel(&self) -> u8 {

--- a/embassy-stm32/src/adc/v4.rs
+++ b/embassy-stm32/src/adc/v4.rs
@@ -2,7 +2,7 @@
 use pac::adc::vals::{Adcaldif, Boost, Difsel, Exten, Pcsel};
 use pac::adccommon::vals::Presc;
 
-use super::{blocking_delay_us, Adc, AdcChannel, Instance, InternalChannel, Resolution, SampleTime};
+use super::{blocking_delay_us, Adc, AdcChannel, Instance, Resolution, SampleTime};
 use crate::time::Hertz;
 use crate::{pac, Peripheral};
 
@@ -33,8 +33,6 @@ const VBAT_CHANNEL: u8 = 17;
 // NOTE: Vrefint/Temperature/Vbat are not available on all ADCs, this currently cannot be modeled with stm32-data, so these are available from the software on all ADCs
 /// Internal voltage reference channel.
 pub struct VrefInt;
-impl<T: Instance> InternalChannel<T> for VrefInt {}
-impl<T: Instance> super::SealedInternalChannel<T> for VrefInt {}
 impl<T: Instance> AdcChannel<T> for VrefInt {}
 impl<T: Instance> super::SealedAdcChannel<T> for VrefInt {
     fn channel(&self) -> u8 {
@@ -44,8 +42,6 @@ impl<T: Instance> super::SealedAdcChannel<T> for VrefInt {
 
 /// Internal temperature channel.
 pub struct Temperature;
-impl<T: Instance> InternalChannel<T> for Temperature {}
-impl<T: Instance> super::SealedInternalChannel<T> for Temperature {}
 impl<T: Instance> AdcChannel<T> for Temperature {}
 impl<T: Instance> super::SealedAdcChannel<T> for Temperature {
     fn channel(&self) -> u8 {
@@ -55,8 +51,6 @@ impl<T: Instance> super::SealedAdcChannel<T> for Temperature {
 
 /// Internal battery voltage channel.
 pub struct Vbat;
-impl<T: Instance> InternalChannel<T> for Vbat {}
-impl<T: Instance> super::SealedInternalChannel<T> for Vbat {}
 impl<T: Instance> AdcChannel<T> for Vbat {}
 impl<T: Instance> super::SealedAdcChannel<T> for Vbat {
     fn channel(&self) -> u8 {

--- a/embassy-stm32/src/adc/v4.rs
+++ b/embassy-stm32/src/adc/v4.rs
@@ -2,7 +2,7 @@
 use pac::adc::vals::{Adcaldif, Boost, Difsel, Exten, Pcsel};
 use pac::adccommon::vals::Presc;
 
-use super::{blocking_delay_us, Adc, AdcChannel, Instance, Resolution, SampleTime};
+use super::{blocking_delay_us, Adc, AdcChannel, Instance, InternalChannel, Resolution, SampleTime};
 use crate::time::Hertz;
 use crate::{pac, Peripheral};
 
@@ -33,6 +33,8 @@ const VBAT_CHANNEL: u8 = 17;
 // NOTE: Vrefint/Temperature/Vbat are not available on all ADCs, this currently cannot be modeled with stm32-data, so these are available from the software on all ADCs
 /// Internal voltage reference channel.
 pub struct VrefInt;
+impl<T: Instance> InternalChannel<T> for VrefInt {}
+impl<T: Instance> super::SealedInternalChannel<T> for VrefInt {}
 impl<T: Instance> AdcChannel<T> for VrefInt {}
 impl<T: Instance> super::SealedAdcChannel<T> for VrefInt {
     fn channel(&self) -> u8 {
@@ -42,6 +44,8 @@ impl<T: Instance> super::SealedAdcChannel<T> for VrefInt {
 
 /// Internal temperature channel.
 pub struct Temperature;
+impl<T: Instance> InternalChannel<T> for Temperature {}
+impl<T: Instance> super::SealedInternalChannel<T> for Temperature {}
 impl<T: Instance> AdcChannel<T> for Temperature {}
 impl<T: Instance> super::SealedAdcChannel<T> for Temperature {
     fn channel(&self) -> u8 {
@@ -51,6 +55,8 @@ impl<T: Instance> super::SealedAdcChannel<T> for Temperature {
 
 /// Internal battery voltage channel.
 pub struct Vbat;
+impl<T: Instance> InternalChannel<T> for Vbat {}
+impl<T: Instance> super::SealedInternalChannel<T> for Vbat {}
 impl<T: Instance> AdcChannel<T> for Vbat {}
 impl<T: Instance> super::SealedAdcChannel<T> for Vbat {
     fn channel(&self) -> u8 {

--- a/embassy-stm32/src/opamp.rs
+++ b/embassy-stm32/src/opamp.rs
@@ -198,7 +198,7 @@ macro_rules! impl_opamp_external_output {
     ($inst:ident, $adc:ident, $ch:expr) => {
         foreach_adc!(
             ($adc, $common_inst:ident, $adc_clock:ident) => {
-                impl<'d> crate::adc::SealedAdcPin<crate::peripherals::$adc>
+                impl<'d> crate::adc::SealedAdcChannel<crate::peripherals::$adc>
                     for OpAmpOutput<'d, crate::peripherals::$inst>
                 {
                     fn channel(&self) -> u8 {
@@ -206,7 +206,7 @@ macro_rules! impl_opamp_external_output {
                     }
                 }
 
-                impl<'d> crate::adc::AdcPin<crate::peripherals::$adc>
+                impl<'d> crate::adc::AdcChannel<crate::peripherals::$adc>
                     for OpAmpOutput<'d, crate::peripherals::$inst>
                 {
                 }
@@ -244,7 +244,7 @@ macro_rules! impl_opamp_internal_output {
     ($inst:ident, $adc:ident, $ch:expr) => {
         foreach_adc!(
             ($adc, $common_inst:ident, $adc_clock:ident) => {
-                impl<'d> crate::adc::SealedAdcPin<crate::peripherals::$adc>
+                impl<'d> crate::adc::SealedAdcChannel<crate::peripherals::$adc>
                     for OpAmpInternalOutput<'d, crate::peripherals::$inst>
                 {
                     fn channel(&self) -> u8 {
@@ -252,7 +252,7 @@ macro_rules! impl_opamp_internal_output {
                     }
                 }
 
-                impl<'d> crate::adc::AdcPin<crate::peripherals::$adc>
+                impl<'d> crate::adc::AdcChannel<crate::peripherals::$adc>
                     for OpAmpInternalOutput<'d, crate::peripherals::$inst>
                 {
                 }

--- a/examples/stm32h7/src/bin/adc.rs
+++ b/examples/stm32h7/src/bin/adc.rs
@@ -51,7 +51,7 @@ async fn main(_spawner: Spawner) {
     let mut vrefint_channel = adc.enable_vrefint();
 
     loop {
-        let vrefint = adc.read_internal(&mut vrefint_channel);
+        let vrefint = adc.read(&mut vrefint_channel);
         info!("vrefint: {}", vrefint);
         let measured = adc.read(&mut p.PC0);
         info!("measured: {}", measured);


### PR DESCRIPTION
The main motivation for this was to allow for the use case of storing ADC channels in an array, which is difficult to do with the current API.

Summary of changes:
- Adds an `AdcChannel<T>` trait which contains a `fn setup` and `fn channel`. `fn channel` and `fn set_as_analog` is removed from `AdcPin`, and instead uses a supertrait. The logic for `set_as_analog` is moved to `fn setup`. This allows for a single `read` function for the ADC instead of having a separate `read_internal` function (in `g4.rs` and `v4.rs`)
- Places where an "internal channel" (like `Vref` or `Temperature`) implements `AdcPin` have been changed to implement `AdcChannel` instead.
- Adds the `AnyAdcChannel<T>` type, where `T` is an ADC instance. It implements `AdcChannel<T>`, which can be passed to `read`.

Even though `AdcPin` and `InternalChannel` are now empty traits with these changes, I decided to keep them, mainly to let users create abstractions that expect a specific type of ADC channel.