### PR TITLE
embassy-sync: Add clear function to all channels

### DIFF
--- a/embassy-sync/CHANGELOG.md
+++ b/embassy-sync/CHANGELOG.md
@@ -7,9 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
-- Add `capacity`, `free_capacity`, `len`, `is_empty` and `is_full` functions to `Channel`.
-- Add `capacity`, `free_capacity`, `len`, `is_empty` and `is_full` functions to `PriorityChannel`.
-- Add `capacity`, `free_capacity`, `len`, `is_empty` and `is_full` functions to `PubSubChannel`.
+- Add `capacity`, `free_capacity`, `clear`, `len`, `is_empty` and `is_full` functions to `Channel`.
+- Add `capacity`, `free_capacity`, `clear`, `len`, `is_empty` and `is_full` functions to `PriorityChannel`.
+- Add `capacity`, `free_capacity`, `clear`, `len`, `is_empty` and `is_full` functions to `PubSubChannel`.
 - Made `PubSubBehavior` sealed
   - If you called `.publish_immediate(...)` on the queue directly before, then now call `.immediate_publisher().publish_immediate(...)`
 

--- a/embassy-sync/src/channel.rs
+++ b/embassy-sync/src/channel.rs
@@ -477,6 +477,10 @@ impl<T, const N: usize> ChannelState<T, N> {
         }
     }
 
+    fn clear(&mut self) {
+        self.queue.clear();
+    }
+
     fn len(&self) -> usize {
         self.queue.len()
     }
@@ -630,6 +634,11 @@ where
     /// This is equivalent to `capacity() - len()`
     pub fn free_capacity(&self) -> usize {
         N - self.len()
+    }
+
+    /// Clears all elements in the channel.
+    pub fn clear(&self) {
+        self.lock(|c| c.clear());
     }
 
     /// Returns the number of elements currently in the channel.

--- a/embassy-sync/src/priority_channel.rs
+++ b/embassy-sync/src/priority_channel.rs
@@ -315,6 +315,10 @@ where
         }
     }
 
+    fn clear(&mut self) {
+        self.queue.clear();
+    }
+
     fn len(&self) -> usize {
         self.queue.len()
     }
@@ -456,6 +460,11 @@ where
     /// This is equivalent to `capacity() - len()`
     pub fn free_capacity(&self) -> usize {
         N - self.len()
+    }
+
+    /// Clears all elements in the channel.
+    pub fn clear(&self) {
+        self.lock(|c| c.clear());
     }
 
     /// Returns the number of elements currently in the channel.

--- a/embassy-sync/src/pubsub/mod.rs
+++ b/embassy-sync/src/pubsub/mod.rs
@@ -173,6 +173,11 @@ impl<M: RawMutex, T: Clone, const CAP: usize, const SUBS: usize, const PUBS: usi
         CAP - self.len()
     }
 
+    /// Clears all elements in the channel.
+    pub fn clear(&self) {
+        self.inner.lock(|inner| inner.borrow_mut().clear());
+    }
+
     /// Returns the number of elements currently in the channel.
     pub fn len(&self) -> usize {
         self.inner.lock(|inner| inner.borrow().len())
@@ -268,6 +273,10 @@ impl<M: RawMutex, T: Clone, const CAP: usize, const SUBS: usize, const PUBS: usi
 
     fn free_capacity(&self) -> usize {
         self.free_capacity()
+    }
+
+    fn clear(&self) {
+        self.clear();
     }
 
     fn len(&self) -> usize {
@@ -407,6 +416,10 @@ impl<T: Clone, const CAP: usize, const SUBS: usize, const PUBS: usize> PubSubSta
         self.publisher_count -= 1;
     }
 
+    fn clear(&mut self) {
+        self.queue.clear();
+    }
+
     fn len(&self) -> usize {
         self.queue.len()
     }
@@ -459,6 +472,9 @@ trait SealedPubSubBehavior<T> {
     ///
     /// This is equivalent to `capacity() - len()`
     fn free_capacity(&self) -> usize;
+
+    /// Clears all elements in the channel.
+    fn clear(&self);
 
     /// Returns the number of elements currently in the channel.
     fn len(&self) -> usize;

--- a/embassy-sync/src/pubsub/publisher.rs
+++ b/embassy-sync/src/pubsub/publisher.rs
@@ -55,6 +55,11 @@ impl<'a, PSB: PubSubBehavior<T> + ?Sized, T: Clone> Pub<'a, PSB, T> {
         self.channel.free_capacity()
     }
 
+    /// Clears all elements in the ***channel***.
+    pub fn clear(&self) {
+        self.channel.clear();
+    }
+
     /// Returns the number of elements currently in the ***channel***.
     pub fn len(&self) -> usize {
         self.channel.len()
@@ -153,6 +158,11 @@ impl<'a, PSB: PubSubBehavior<T> + ?Sized, T: Clone> ImmediatePub<'a, PSB, T> {
     /// This is equivalent to `capacity() - len()`
     pub fn free_capacity(&self) -> usize {
         self.channel.free_capacity()
+    }
+
+    /// Clears all elements in the ***channel***.
+    pub fn clear(&self) {
+        self.channel.clear();
     }
 
     /// Returns the number of elements currently in the ***channel***.

--- a/embassy-sync/src/pubsub/subscriber.rs
+++ b/embassy-sync/src/pubsub/subscriber.rs
@@ -83,6 +83,11 @@ impl<'a, PSB: PubSubBehavior<T> + ?Sized, T: Clone> Sub<'a, PSB, T> {
         self.channel.free_capacity()
     }
 
+    /// Clears all elements in the ***channel***.
+    pub fn clear(&self) {
+        self.channel.clear();
+    }
+
     /// Returns the number of elements currently in the ***channel***.
     /// See [Self::available] for how many messages are available for this subscriber.
     pub fn len(&self) -> usize {


### PR DESCRIPTION
This PR adds a clear function to all channels that allows to delete all buffered elements. I'm not sure if this is a desired behaviour for the publishers and subscribers of the PubSubChannel, so request a change if there are concerns about it.