### PR TITLE
embassy_stm32: implement optional FIFO scheduling for outgoing frames

### DIFF
--- a/embassy-stm32/src/can/bxcan/mod.rs
+++ b/embassy-stm32/src/can/bxcan/mod.rs
@@ -324,7 +324,13 @@ impl<'d, T: Instance> Can<'d, T> {
 
     /// Attempts to transmit a frame without blocking.
     ///
-    /// Returns [Err(TryWriteError::Full)] if all transmit mailboxes are full.
+    /// Returns [Err(TryWriteError::Full)] if the frame can not be queued for transmission now.
+    ///
+    /// If FIFO scheduling is enabled, any empty mailbox will be used.
+    ///
+    /// Otherwise, the frame will only be accepted if there is no frame with the same priority already queued.
+    /// This is done to work around a hardware limitation that could lead to out-of-order delivery
+    /// of frames with the same priority.
     pub fn try_write(&mut self, frame: &Frame) -> Result<TransmitStatus, TryWriteError> {
         self.split().0.try_write(frame)
     }
@@ -487,7 +493,13 @@ impl<'d, T: Instance> CanTx<'d, T> {
 
     /// Attempts to transmit a frame without blocking.
     ///
-    /// Returns [Err(TryWriteError::Full)] if all transmit mailboxes are full.
+    /// Returns [Err(TryWriteError::Full)] if the frame can not be queued for transmission now.
+    ///
+    /// If FIFO scheduling is enabled, any empty mailbox will be used.
+    ///
+    /// Otherwise, the frame will only be accepted if there is no frame with the same priority already queued.
+    /// This is done to work around a hardware limitation that could lead to out-of-order delivery
+    /// of frames with the same priority.
     pub fn try_write(&mut self, frame: &Frame) -> Result<TransmitStatus, TryWriteError> {
         Registers(T::regs()).transmit(frame).map_err(|_| TryWriteError::Full)
     }

--- a/embassy-stm32/src/can/bxcan/registers.rs
+++ b/embassy-stm32/src/can/bxcan/registers.rs
@@ -181,46 +181,85 @@ impl Registers {
         None
     }
 
+    /// Enables or disables FIFO scheduling of outgoing mailboxes.
+    ///
+    /// If this is enabled, mailboxes are scheduled based on the time when the transmit request bit of the mailbox was set.
+    ///
+    /// If this is disabled, mailboxes are scheduled based on the priority of the frame in the mailbox.
+    pub fn set_tx_fifo_scheduling(&mut self, enabled: bool) {
+        self.0.mcr().modify(|w| w.set_txfp(enabled))
+    }
+
+    /// Checks if FIFO scheduling of outgoing mailboxes is enabled.
+    pub fn tx_fifo_scheduling_enabled(&self) -> bool {
+        self.0.mcr().read().txfp()
+    }
+
     /// Puts a CAN frame in a transmit mailbox for transmission on the bus.
     ///
-    /// Frames are transmitted to the bus based on their priority (see [`FramePriority`]).
-    /// Transmit order is preserved for frames with identical priority.
+    /// The behavior of this function depends on wheter or not FIFO scheduling is enabled.
+    /// See [`Self::set_tx_fifo_scheduling()`] and [`Self::tx_fifo_scheduling_enabled()`].
+    ///
+    /// # Priority based scheduling
+    ///
+    /// If FIFO scheduling is disabled, frames are transmitted to the bus based on their
+    /// priority (see [`FramePriority`]). Transmit order is preserved for frames with identical
+    /// priority.
     ///
     /// If all transmit mailboxes are full, and `frame` has a higher priority than the
     /// lowest-priority message in the transmit mailboxes, transmission of the enqueued frame is
     /// cancelled and `frame` is enqueued instead. The frame that was replaced is returned as
     /// [`TransmitStatus::dequeued_frame`].
+    ///
+    /// # FIFO scheduling
+    ///
+    /// If FIFO scheduling is enabled, frames are transmitted in the order that they are passed to this function.
+    ///
+    /// If all transmit mailboxes are full, this function returns [`nb::Error::WouldBlock`].
     pub fn transmit(&mut self, frame: &Frame) -> nb::Result<TransmitStatus, Infallible> {
+        // Check if FIFO scheduling is enabled.
+        let fifo_scheduling = self.0.mcr().read().txfp();
+
         // Get the index of the next free mailbox or the one with the lowest priority.
         let tsr = self.0.tsr().read();
         let idx = tsr.code() as usize;
 
         let frame_is_pending = !tsr.tme(0) || !tsr.tme(1) || !tsr.tme(2);
-        let pending_frame = if frame_is_pending {
-            // High priority frames are transmitted first by the mailbox system.
-            // Frames with identical identifier shall be transmitted in FIFO order.
-            // The controller schedules pending frames of same priority based on the
-            // mailbox index instead. As a workaround check all pending mailboxes
-            // and only accept higher priority frames.
+        let all_frames_are_pending = !tsr.tme(0) && !tsr.tme(1) && !tsr.tme(2);
+
+        let pending_frame;
+        if fifo_scheduling && all_frames_are_pending {
+            // FIFO scheduling is enabled and all mailboxes are full.
+            // We will not drop a lower priority frame, we just report WouldBlock.
+            return Err(nb::Error::WouldBlock);
+        } else if !fifo_scheduling && frame_is_pending {
+            // Priority scheduling is enabled and alteast one mailbox is full.
+            //
+            // In this mode, the peripheral transmits high priority frames first.
+            // Frames with identical priority should be transmitted in FIFO order,
+            // but the controller schedules pending frames of same priority based on the
+            // mailbox index. As a workaround check all pending mailboxes and only accept
+            // higher priority frames.
             self.check_priority(0, frame.id().into())?;
             self.check_priority(1, frame.id().into())?;
             self.check_priority(2, frame.id().into())?;
 
-            let all_frames_are_pending = !tsr.tme(0) && !tsr.tme(1) && !tsr.tme(2);
             if all_frames_are_pending {
                 // No free mailbox is available. This can only happen when three frames with
                 // ascending priority (descending IDs) were requested for transmission and all
                 // of them are blocked by bus traffic with even higher priority.
                 // To prevent a priority inversion abort and replace the lowest priority frame.
-                self.read_pending_mailbox(idx)
+                pending_frame = self.read_pending_mailbox(idx);
             } else {
                 // There was a free mailbox.
-                None
+                pending_frame = None;
             }
         } else {
-            // All mailboxes are available: Send frame without performing any checks.
-            None
-        };
+            // Either we have FIFO scheduling and at-least one free mailbox,
+            // or we have priority scheduling and all mailboxes are free.
+            // No further checks are needed.
+            pending_frame = None
+        }
 
         self.write_mailbox(idx, frame);
 


### PR DESCRIPTION
This PR allows you to enable FIFO scheduling of the transmit mailboxes. This can be quite important to ensure in-order delivery of data.

It also allows to avoid a weird gotcha between `flush_any()` and `try_write()`: when `flush_any()` completes, a call to `try_write()` may still report `TryWriteError::Full`. In one application I'm working on, this is very undesirable. I also updated the documentation, which previously said this could not happen.

The PR also relaxes the restriction for queuing frames in priority based scheduling mode. Previously, you could not queue a frame if another frame with equal **or higher** priority was already queued. This was more strict than necessary to work around the hardware scheduling limitation. The only thing that should be avoided is to have two **equal** priority frames in the mailboxes at the same time.