### PR TITLE
stm32 ringbuffered usart: don't teardown during reconfigure

### DIFF
--- a/embassy-stm32/src/usart/ringbuffered.rs
+++ b/embassy-stm32/src/usart/ringbuffered.rs
@@ -72,9 +72,8 @@ impl<'d, T: BasicInstance> RingBufferedUartRx<'d, T> {
         Err(err)
     }
 
-    /// Cleanly stop and reconfigure the driver
+    /// Reconfigure the driver
     pub fn set_config(&mut self, config: &Config) -> Result<(), ConfigError> {
-        self.teardown_uart();
         reconfigure::<T>(config)
     }
 


### PR DESCRIPTION
Closes https://github.com/embassy-rs/embassy/issues/2752

Unsatisfyingly, I don't know why this works or what has changed since the crates.io release. I have been poking at this for a while and I simply couldn't figure it out; I tried clearing sticky errors in all sorts of places but nothing worked. I would be interested if someone knows though.

It might also be valuable to test the min repro linked in the issue on some other chips as it might be a f2 specific thing.