### PR TITLE
gpiov1: Do not call set_speed for AFType::Input

### DIFF
--- a/embassy-stm32/src/gpio.rs
+++ b/embassy-stm32/src/gpio.rs
@@ -661,6 +661,11 @@ pub(crate) trait SealedPin {
         self.set_as_analog();
     }
 
+    /// Sets the speed of the output pin.
+    ///
+    /// This should never be called for AFType::Input on the STM32F1 series, since MODE and
+    /// CNF bits are not independent. If the CNF bits are altered afterwards as well, this
+    /// will put the pin into output mode.
     #[inline]
     fn set_speed(&self, speed: Speed) {
         let pin = self._pin() as usize;

--- a/embassy-stm32/src/macros.rs
+++ b/embassy-stm32/src/macros.rs
@@ -106,7 +106,11 @@ macro_rules! new_pin {
     ($name:ident, $aftype:expr, $speed:expr, $pull:expr) => {{
         let pin = $name.into_ref();
         pin.set_as_af_pull(pin.af_num(), $aftype, $pull);
-        pin.set_speed($speed);
+        // Do not call set_speed on AFType::Input, as MODE and CNF bits are not independent
+        // for gpio_v1
+        if $aftype != crate::gpio::low_level::AFType::Input {
+            pin.set_speed($speed);
+        }
         Some(pin.map_into())
     }};
 }

--- a/embassy-stm32/src/macros.rs
+++ b/embassy-stm32/src/macros.rs
@@ -108,9 +108,10 @@ macro_rules! new_pin {
         pin.set_as_af_pull(pin.af_num(), $aftype, $pull);
         // Do not call set_speed on AFType::Input, as MODE and CNF bits are not independent
         // for gpio_v1
-        if $aftype != crate::gpio::AFType::Input {
-            pin.set_speed($speed);
-        }
+        match $aftype {
+            crate::gpio::AFType::Input => {},
+            _ => pin.set_speed($speed);
+        };
         Some(pin.map_into())
     }};
 }

--- a/embassy-stm32/src/macros.rs
+++ b/embassy-stm32/src/macros.rs
@@ -109,8 +109,10 @@ macro_rules! new_pin {
         // Do not call set_speed on AFType::Input, as MODE and CNF bits are not independent
         // for gpio_v1
         match $aftype {
-            crate::gpio::AFType::Input => {},
-            _ => {pin.set_speed($speed);},
+            crate::gpio::AFType::Input => {}
+            _ => {
+                pin.set_speed($speed);
+            }
         };
         Some(pin.map_into())
     }};

--- a/embassy-stm32/src/macros.rs
+++ b/embassy-stm32/src/macros.rs
@@ -108,7 +108,7 @@ macro_rules! new_pin {
         pin.set_as_af_pull(pin.af_num(), $aftype, $pull);
         // Do not call set_speed on AFType::Input, as MODE and CNF bits are not independent
         // for gpio_v1
-        if $aftype != crate::gpio::low_level::AFType::Input {
+        if $aftype != crate::gpio::AFType::Input {
             pin.set_speed($speed);
         }
         Some(pin.map_into())

--- a/embassy-stm32/src/macros.rs
+++ b/embassy-stm32/src/macros.rs
@@ -110,7 +110,7 @@ macro_rules! new_pin {
         // for gpio_v1
         match $aftype {
             crate::gpio::AFType::Input => {},
-            _ => pin.set_speed($speed);
+            _ => {pin.set_speed($speed);},
         };
         Some(pin.map_into())
     }};


### PR DESCRIPTION
Closes https://github.com/embassy-rs/embassy/issues/2942, where this was discussed in greater detail, along with alternatives.

Required for https://github.com/embassy-rs/embassy/pull/2943, so the correct config can be deduced from the registers.