### PR TITLE
Add proper rxonly support for spi_v3 and force tx dma stream requirem…

### DIFF
--- a/embassy-stm32/Cargo.toml
+++ b/embassy-stm32/Cargo.toml
@@ -72,7 +72,7 @@ rand_core = "0.6.3"
 sdio-host = "0.5.0"
 critical-section = "1.1"
 #stm32-metapac = { version = "15" }
-stm32-metapac = { git = "https://github.com/embassy-rs/stm32-data-generated", tag = "stm32-data-34c0188a682b32c32ff147d377e0629b1ebe8318" }
+stm32-metapac = { git = "https://github.com/embassy-rs/stm32-data-generated", tag = "stm32-data-ad633a3e266151ea4d8fad630031a075ee02ab34" }
 
 vcell = "0.1.3"
 nb = "1.0.0"
@@ -97,7 +97,7 @@ proc-macro2 = "1.0.36"
 quote = "1.0.15"
 
 #stm32-metapac = { version = "15", default-features = false, features = ["metadata"]}
-stm32-metapac = { git = "https://github.com/embassy-rs/stm32-data-generated", tag = "stm32-data-34c0188a682b32c32ff147d377e0629b1ebe8318", default-features = false, features = ["metadata"]}
+stm32-metapac = { git = "https://github.com/embassy-rs/stm32-data-generated", tag = "stm32-data-ad633a3e266151ea4d8fad630031a075ee02ab34", default-features = false, features = ["metadata"]}
 
 [features]
 default = ["rt"]

--- a/embassy-stm32/src/dma/util.rs
+++ b/embassy-stm32/src/dma/util.rs
@@ -48,6 +48,7 @@ impl<'d> ChannelAndRequest<'d> {
         Transfer::new_write_raw(&mut self.channel, self.request, buf, peri_addr, options)
     }
 
+    #[allow(dead_code)]
     pub unsafe fn write_repeated<'a, W: Word>(
         &'a mut self,
         repeated: &'a W,

--- a/embassy-stm32/src/i2s.rs
+++ b/embassy-stm32/src/i2s.rs
@@ -169,7 +169,7 @@ impl<'d> I2S<'d> {
         ws: impl Peripheral<P = impl WsPin<T>> + 'd,
         ck: impl Peripheral<P = impl CkPin<T>> + 'd,
         mck: impl Peripheral<P = impl MckPin<T>> + 'd,
-        txdma: impl Peripheral<P = impl TxDma<T>> + 'd,
+        #[cfg(not(spi_v3))] txdma: impl Peripheral<P = impl TxDma<T>> + 'd,
         rxdma: impl Peripheral<P = impl RxDma<T>> + 'd,
         freq: Hertz,
         config: Config,
@@ -190,7 +190,15 @@ impl<'d> I2S<'d> {
 
         let mut spi_cfg = SpiConfig::default();
         spi_cfg.frequency = freq;
-        let spi = Spi::new_internal(peri, txdma, rxdma, spi_cfg);
+        let spi = Spi::new_internal(
+            peri,
+            #[cfg(not(spi_v3))]
+            new_dma!(txdma),
+            #[cfg(spi_v3)]
+            None,
+            new_dma!(rxdma),
+            spi_cfg,
+        );
 
         // TODO move i2s to the new mux infra.
         //#[cfg(all(rcc_f4, not(stm32f410)))]

--- a/embassy-stm32/src/spi/mod.rs
+++ b/embassy-stm32/src/spi/mod.rs
@@ -508,7 +508,7 @@ impl<'d> Spi<'d, Async> {
         peri: impl Peripheral<P = T> + 'd,
         sck: impl Peripheral<P = impl SckPin<T>> + 'd,
         miso: impl Peripheral<P = impl MisoPin<T>> + 'd,
-        #[cfg(any(spi_v1, spi_f1))] tx_dma: impl Peripheral<P = impl TxDma<T>> + 'd,
+        #[cfg(any(spi_v1, spi_f1, spi_v4, spi_v5))] tx_dma: impl Peripheral<P = impl TxDma<T>> + 'd,
         rx_dma: impl Peripheral<P = impl RxDma<T>> + 'd,
         config: Config,
     ) -> Self {
@@ -517,9 +517,9 @@ impl<'d> Spi<'d, Async> {
             new_pin!(sck, AFType::OutputPushPull, Speed::VeryHigh, config.sck_pull_mode()),
             None,
             new_pin!(miso, AFType::Input, Speed::VeryHigh),
-            #[cfg(any(spi_v1, spi_f1))]
+            #[cfg(any(spi_v1, spi_f1, spi_v4, spi_v5))]
             new_dma!(tx_dma),
-            #[cfg(any(spi_v2, spi_v3, spi_v4, spi_v5))]
+            #[cfg(any(spi_v2, spi_v3))]
             None,
             new_dma!(rx_dma),
             config,
@@ -626,7 +626,7 @@ impl<'d> Spi<'d, Async> {
     }
 
     /// SPI read, using DMA.
-    #[cfg(any(spi_v2, spi_v3, spi_v4, spi_v5))]
+    #[cfg(any(spi_v2, spi_v3))]
     pub async fn read<W: Word>(&mut self, data: &mut [W]) -> Result<(), Error> {
         if data.is_empty() {
             return Ok(());
@@ -723,7 +723,7 @@ impl<'d> Spi<'d, Async> {
     }
 
     /// SPI read, using DMA.
-    #[cfg(any(spi_v1, spi_f1))]
+    #[cfg(any(spi_v1, spi_f1, spi_v4, spi_v5))]
     pub async fn read<W: Word>(&mut self, data: &mut [W]) -> Result<(), Error> {
         if data.is_empty() {
             return Ok(());

--- a/embassy-stm32/src/spi/mod.rs
+++ b/embassy-stm32/src/spi/mod.rs
@@ -508,7 +508,7 @@ impl<'d> Spi<'d, Async> {
         peri: impl Peripheral<P = T> + 'd,
         sck: impl Peripheral<P = impl SckPin<T>> + 'd,
         miso: impl Peripheral<P = impl MisoPin<T>> + 'd,
-        #[cfg(any(spi_v1, spi_f1, spi_v4, spi_v5))] tx_dma: impl Peripheral<P = impl TxDma<T>> + 'd,
+        #[cfg(any(spi_v1, spi_f1, spi_v2))] tx_dma: impl Peripheral<P = impl TxDma<T>> + 'd,
         rx_dma: impl Peripheral<P = impl RxDma<T>> + 'd,
         config: Config,
     ) -> Self {
@@ -517,9 +517,9 @@ impl<'d> Spi<'d, Async> {
             new_pin!(sck, AFType::OutputPushPull, Speed::VeryHigh, config.sck_pull_mode()),
             None,
             new_pin!(miso, AFType::Input, Speed::VeryHigh),
-            #[cfg(any(spi_v1, spi_f1, spi_v4, spi_v5))]
+            #[cfg(any(spi_v1, spi_f1, spi_v2))]
             new_dma!(tx_dma),
-            #[cfg(any(spi_v2, spi_v3))]
+            #[cfg(any(spi_v3, spi_v4, spi_v5))]
             None,
             new_dma!(rx_dma),
             config,
@@ -626,7 +626,7 @@ impl<'d> Spi<'d, Async> {
     }
 
     /// SPI read, using DMA.
-    #[cfg(any(spi_v2, spi_v3))]
+    #[cfg(any(spi_v3, spi_v4, spi_v5))]
     pub async fn read<W: Word>(&mut self, data: &mut [W]) -> Result<(), Error> {
         if data.is_empty() {
             return Ok(());
@@ -644,6 +644,7 @@ impl<'d> Spi<'d, Async> {
             prev
         });
 
+        #[cfg(spi_v3)]
         let i2scfg = regs.i2scfgr().modify(|w| {
             w.i2smod().then(|| {
                 let prev = w.i2scfg();
@@ -713,6 +714,7 @@ impl<'d> Spi<'d, Async> {
             w.set_tsize(tsize);
         });
 
+        #[cfg(spi_v3)]
         if let Some(i2scfg) = i2scfg {
             regs.i2scfgr().modify(|w| {
                 w.set_i2scfg(i2scfg);
@@ -723,7 +725,7 @@ impl<'d> Spi<'d, Async> {
     }
 
     /// SPI read, using DMA.
-    #[cfg(any(spi_v1, spi_f1, spi_v4, spi_v5))]
+    #[cfg(any(spi_v1, spi_f1, spi_v2))]
     pub async fn read<W: Word>(&mut self, data: &mut [W]) -> Result<(), Error> {
         if data.is_empty() {
             return Ok(());

--- a/tests/stm32/src/bin/spi_dma.rs
+++ b/tests/stm32/src/bin/spi_dma.rs
@@ -8,27 +8,33 @@ use defmt::assert_eq;
 use embassy_executor::Spawner;
 use embassy_stm32::spi::{self, Spi};
 use embassy_stm32::time::Hertz;
+use embassy_stm32::{into_ref, Peripheral as _};
 
 #[embassy_executor::main]
 async fn main(_spawner: Spawner) {
     let p = embassy_stm32::init(config());
     info!("Hello World!");
 
-    let spi = peri!(p, SPI);
+    let spi_peri = peri!(p, SPI);
     let sck = peri!(p, SPI_SCK);
     let mosi = peri!(p, SPI_MOSI);
     let miso = peri!(p, SPI_MISO);
     let tx_dma = peri!(p, SPI_TX_DMA);
     let rx_dma = peri!(p, SPI_RX_DMA);
 
+    into_ref!(spi_peri, sck, mosi, miso, tx_dma, rx_dma);
+
     let mut spi_config = spi::Config::default();
     spi_config.frequency = Hertz(1_000_000);
 
     let mut spi = Spi::new(
-        spi, sck,  // Arduino D13
-        mosi, // Arduino D11
-        miso, // Arduino D12
-        tx_dma, rx_dma, spi_config,
+        spi_peri.reborrow(),
+        sck.reborrow(),  // Arduino D13
+        mosi.reborrow(), // Arduino D11
+        miso.reborrow(), // Arduino D12
+        tx_dma.reborrow(),
+        rx_dma.reborrow(),
+        spi_config,
     );
 
     let data: [u8; 9] = [0x00, 0xFF, 0xAA, 0x55, 0xC0, 0xFF, 0xEE, 0xC0, 0xDE];
@@ -75,6 +81,55 @@ async fn main(_spawner: Spawner) {
     spi.blocking_write(&buf).unwrap();
     spi.blocking_read(&mut buf).unwrap();
     spi.write(&buf).await.unwrap();
+
+    core::mem::drop(spi);
+
+    // test rx-only configuration
+
+    // stm32f207zg - spi_v1
+    // stm32f103c8 - spi_f1
+    // stm32g491re - spi_v2
+    // stm32h753zi - spi_v3
+    // stm32h563zi - spi_v4
+    // stm32wba52cg - spi_v5
+
+    #[cfg(any(stm32f207zg, stm32f103c8, stm32g491re, stm32h753zi, stm32h563zi, stm32wba52cg))]
+    {
+        let mut spi = {
+            #[cfg(stm32f207zg, stm32f103c8, stm32g491re)]
+            {
+                Spi::new_rxonly(
+                    spi_peri.reborrow(),
+                    sck.reborrow(),
+                    miso.reborrow(),
+                    tx_dma.reborrow(),
+                    rx_dma.reborrow(),
+                    spi_config,
+                )
+            }
+            #[cfg(stm32h753zi, stm32h563zi, stm32wba52cg)]
+            {
+                Spi::new_rxonly(
+                    spi_peri.reborrow(),
+                    sck.reborrow(),
+                    miso.reborrow(),
+                    rx_dma.reborrow(),
+                    spi_config,
+                )
+            }
+        };
+
+        use embassy_stm32::gpio;
+        let mut mosi = gpio::Output::new(mosi.reborrow(), gpio::Level::Low, gpio::Speed::Low);
+
+        mosi.set_high();
+        spi.read(&mut buf).await.unwrap();
+        assert_eq!(buf, [0xff; 9]);
+
+        mosi.set_low();
+        spi.read(&mut buf).await.unwrap();
+        assert_eq!(buf, [0x00; 9]);
+    };
 
     info!("Test OK");
     cortex_m::asm::bkpt();


### PR DESCRIPTION
This commit uses the Receive-only mode of the `spi_v3` to enable receiving without using a transmission DMA channel.
In addition, it forces the user to provide a TX DMA channel for older versions that require transmitting in order to enable the
master clock. It should be straightforward to port to the `spi_v2+` versions as well, I just don't currently have the hardware to properly test the changes, I have only tested the changes on the `spi_v3`.