### PR TITLE
stm32: ensure the core runs on HSI clock while setting up rcc

### DIFF
--- a/embassy-stm32/src/rcc/c0.rs
+++ b/embassy-stm32/src/rcc/c0.rs
@@ -76,25 +76,29 @@ impl Default for Config {
 }
 
 pub(crate) unsafe fn init(config: Config) {
+    // Turn on the HSI
+    match config.hsi {
+        None => RCC.cr().modify(|w| w.set_hsion(true)),
+        Some(hsi) => RCC.cr().modify(|w| {
+            w.set_hsidiv(hsi.sys_div);
+            w.set_hsikerdiv(hsi.ker_div);
+            w.set_hsion(true);
+        }),
+    }
+    while !RCC.cr().read().hsirdy() {}
+
+    // Use the HSI clock as system clock during the actual clock setup
+    RCC.cfgr().modify(|w| w.set_sw(Sysclk::HSISYS));
+    while RCC.cfgr().read().sws() != Sysclk::HSISYS {}
+
     // Configure HSI
     let (hsi, hsisys, hsiker) = match config.hsi {
-        None => {
-            RCC.cr().modify(|w| w.set_hsion(false));
-            (None, None, None)
-        }
-        Some(hsi) => {
-            RCC.cr().modify(|w| {
-                w.set_hsidiv(hsi.sys_div);
-                w.set_hsikerdiv(hsi.ker_div);
-                w.set_hsion(true);
-            });
-            while !RCC.cr().read().hsirdy() {}
-            (
-                Some(HSI_FREQ),
-                Some(HSI_FREQ / hsi.sys_div),
-                Some(HSI_FREQ / hsi.ker_div),
-            )
-        }
+        None => (None, None, None),
+        Some(hsi) => (
+            Some(HSI_FREQ),
+            Some(HSI_FREQ / hsi.sys_div),
+            Some(HSI_FREQ / hsi.ker_div),
+        ),
     };
 
     // Configure HSE
@@ -150,6 +154,12 @@ pub(crate) unsafe fn init(config: Config) {
         w.set_hpre(config.ahb_pre);
         w.set_ppre(config.apb1_pre);
     });
+    while RCC.cfgr().read().sws() != config.sys {}
+
+    // Disable HSI if not used
+    if config.hsi.is_none() {
+        RCC.cr().modify(|w| w.set_hsion(false));
+    }
 
     let rtc = config.ls.init();
 

--- a/embassy-stm32/src/rcc/g4.rs
+++ b/embassy-stm32/src/rcc/g4.rs
@@ -117,17 +117,18 @@ pub struct PllFreq {
 }
 
 pub(crate) unsafe fn init(config: Config) {
+    // Turn on the HSI
+    RCC.cr().modify(|w| w.set_hsion(true));
+    while !RCC.cr().read().hsirdy() {}
+
+    // Use the HSI clock as system clock during the actual clock setup
+    RCC.cfgr().modify(|w| w.set_sw(Sysclk::HSI));
+    while RCC.cfgr().read().sws() != Sysclk::HSI {}
+
     // Configure HSI
     let hsi = match config.hsi {
-        false => {
-            RCC.cr().modify(|w| w.set_hsion(false));
-            None
-        }
-        true => {
-            RCC.cr().modify(|w| w.set_hsion(true));
-            while !RCC.cr().read().hsirdy() {}
-            Some(HSI_FREQ)
-        }
+        false => None,
+        true => Some(HSI_FREQ),
     };
 
     // Configure HSE
@@ -285,6 +286,12 @@ pub(crate) unsafe fn init(config: Config) {
         w.set_ppre1(config.apb1_pre);
         w.set_ppre2(config.apb2_pre);
     });
+    while RCC.cfgr().read().sws() != config.sys {}
+
+    // Disable HSI if not used
+    if !config.hsi {
+        RCC.cr().modify(|w| w.set_hsion(false));
+    }
 
     if config.low_power_run {
         assert!(sys <= Hertz(2_000_000));


### PR DESCRIPTION
This is the follow-up to PR #2829 applying the same modification to other stm32 series.

So just as commit 5ecc9b8, this runs the CPU on HSI clock during the whole RCC setup, and disable the HSI clock only after the RCC is fully setup (and only if the HSI clock is not in use).