### PR TITLE
usb: add the Endpoint::is_enabled function

### DIFF
--- a/embassy-nrf/src/usb/mod.rs
+++ b/embassy-nrf/src/usb/mod.rs
@@ -472,6 +472,11 @@ impl<'d, Dir: EndpointDir> driver::Endpoint for Endpoint<'d, Dir> {
     async fn wait_enabled(&mut self) {
         self.wait_enabled_state(true).await
     }
+
+    fn is_enabled(&self) -> bool {
+        let ep_addr = self.info.addr.index();
+        Dir::is_enabled(self.regs, ep_addr)
+    }
 }
 
 #[allow(private_bounds)]

--- a/embassy-rp/src/usb/device.rs
+++ b/embassy-rp/src/usb/device.rs
@@ -504,6 +504,11 @@ impl<'d, T: Instance> driver::Endpoint for Endpoint<'d, T, In> {
         .await;
         trace!("wait_enabled IN OK");
     }
+
+    fn is_enabled(&self) -> bool {
+        let index = self.info.addr.index();
+        T::dpram().ep_in_control(index - 1).read().enable()
+    }
 }
 
 impl<'d, T: Instance> driver::Endpoint for Endpoint<'d, T, Out> {
@@ -521,6 +526,11 @@ impl<'d, T: Instance> driver::Endpoint for Endpoint<'d, T, Out> {
         })
         .await;
         trace!("wait_enabled OUT OK");
+    }
+
+    fn is_enabled(&self) -> bool {
+        let index = self.info.addr.index();
+        T::dpram().ep_in_control(index - 1).read().enable()
     }
 }
 

--- a/embassy-stm32/src/usb/usb.rs
+++ b/embassy-stm32/src/usb/usb.rs
@@ -858,6 +858,11 @@ impl<'d, T: Instance> driver::Endpoint for Endpoint<'d, T, In> {
         .await;
         trace!("wait_enabled IN OK");
     }
+
+    fn is_enabled(&self) -> bool {
+        let index = self.info.addr.index();
+        T::regs().epr(index).read().stat_tx() != Stat::DISABLED
+    }
 }
 
 impl<'d, T: Instance> driver::Endpoint for Endpoint<'d, T, Out> {
@@ -879,6 +884,11 @@ impl<'d, T: Instance> driver::Endpoint for Endpoint<'d, T, Out> {
         })
         .await;
         trace!("wait_enabled OUT OK");
+    }
+
+    fn is_enabled(&self) -> bool {
+        let index = self.info.addr.index();
+        T::regs().epr(index).read().stat_rx() != Stat::DISABLED
     }
 }
 

--- a/embassy-usb-driver/src/lib.rs
+++ b/embassy-usb-driver/src/lib.rs
@@ -255,6 +255,9 @@ pub trait Endpoint {
 
     /// Wait for the endpoint to be enabled.
     async fn wait_enabled(&mut self);
+
+    /// Check if the endpoint is enabled.
+    fn is_enabled(&self) -> bool;
 }
 
 /// OUT Endpoint trait.

--- a/embassy-usb-synopsys-otg/src/lib.rs
+++ b/embassy-usb-synopsys-otg/src/lib.rs
@@ -1122,6 +1122,11 @@ impl<'d> embassy_usb_driver::Endpoint for Endpoint<'d, In> {
         })
         .await
     }
+
+    fn is_enabled(&self) -> bool {
+        let ep_index = self.info.addr.index();
+        self.regs.diepctl(ep_index).read().usbaep()
+    }
 }
 
 impl<'d> embassy_usb_driver::Endpoint for Endpoint<'d, Out> {
@@ -1142,6 +1147,11 @@ impl<'d> embassy_usb_driver::Endpoint for Endpoint<'d, Out> {
             }
         })
         .await
+    }
+
+    fn is_enabled(&self) -> bool {
+        let ep_index = self.info.addr.index();
+        self.regs.diepctl(ep_index).read().usbaep()
     }
 }
 


### PR DESCRIPTION
I found myself calling `wait_enabled()` with a timeout to try to determine if the endpoint is enabled, which is silly when we can just read the register.

Closes #3427