### PR TITLE
Fix watchdog CTRL register getting overwritten

### DIFF
--- a/embassy-rp/src/watchdog.rs
+++ b/embassy-rp/src/watchdog.rs
@@ -46,7 +46,7 @@ impl Watchdog {
     /// or when JTAG is accessing bus fabric
     pub fn pause_on_debug(&mut self, pause: bool) {
         let watchdog = pac::WATCHDOG;
-        watchdog.ctrl().write(|w| {
+        watchdog.ctrl().modify(|w| {
             w.set_pause_dbg0(pause);
             w.set_pause_dbg1(pause);
             w.set_pause_jtag(pause);
@@ -60,7 +60,7 @@ impl Watchdog {
 
     fn enable(&self, bit: bool) {
         let watchdog = pac::WATCHDOG;
-        watchdog.ctrl().write(|w| w.set_enable(bit))
+        watchdog.ctrl().modify(|w| w.set_enable(bit))
     }
 
     // Configure which hardware will be reset by the watchdog


### PR DESCRIPTION
My first PR! As encouraged by @9names on Matrix, this is a PR to change `write()` calls to `modify()` when manipulating the rp2040's watchdog control register. Dumping out the registers after this change matches the expected behavior from the datasheet.

Previously, when calling a function like `watchdog.pause_on_debug()` or even `watchdog.start()` it would stomp on the register's previously set bits and potentially break the watchdog. If `start` was called after `pause_on_debug`, it would run but the bits set by `pause_on_debug` would be gone. Conversely, if `pause_on_debug` was called after `start`, it would also zero out the enable bit, thus pausing the watchdog (at least in terms of the behavior I've observed).

I've left the call to `write` in `trigger_reset` as is, because there is already a call to `pause_on_debug(false)` clearing those bits, so semantically it made sense to keep `write`.