### PR TITLE
add set_as_analog to stm32 gpio Flex

### DIFF
--- a/embassy-stm32/src/gpio.rs
+++ b/embassy-stm32/src/gpio.rs
@@ -128,6 +128,15 @@ impl<'d> Flex<'d> {
         });
     }
 
+    /// Put the pin into analog mode
+    ///
+    /// This mode is used by ADC and COMP but usually there is no need to set this manually
+    /// as the mode change is handled by the driver.
+    #[inline]
+    pub fn set_as_analog(&mut self) {
+        self.pin.set_as_analog();
+    }
+
     /// Put the pin into AF mode, unchecked.
     ///
     /// This puts the pin into the AF mode, with the requested number, pull and speed. This is


### PR DESCRIPTION
Simple addition to Flex to allow analog mode to be set. I need this bc the way I work with a comparator. Ideally this would be handled by a comparator driver but I didn't manage to write that.

A case could be made for exposing `set_as_disconnected` too which would do the same thing right now but be semantically different.