### PR TITLE
stm32: remove pointer-to-pointer-to-registers.

### DIFF
--- a/embassy-stm32/src/can/fd/peripheral.rs
+++ b/embassy-stm32/src/can/fd/peripheral.rs
@@ -20,8 +20,9 @@ enum LoopbackMode {
 }
 
 pub struct Registers {
-    pub regs: &'static crate::pac::can::Fdcan,
-    pub msgram: &'static crate::pac::fdcanram::Fdcanram,
+    pub regs: crate::pac::can::Fdcan,
+    pub msgram: crate::pac::fdcanram::Fdcanram,
+    #[allow(dead_code)]
     pub msg_ram_offset: usize,
 }
 

--- a/embassy-stm32/src/cryp/mod.rs
+++ b/embassy-stm32/src/cryp/mod.rs
@@ -51,16 +51,16 @@ pub trait Cipher<'c> {
     fn iv(&self) -> &[u8];
 
     /// Sets the processor algorithm mode according to the associated cipher.
-    fn set_algomode(&self, p: &pac::cryp::Cryp);
+    fn set_algomode(&self, p: pac::cryp::Cryp);
 
     /// Performs any key preparation within the processor, if necessary.
-    fn prepare_key(&self, _p: &pac::cryp::Cryp) {}
+    fn prepare_key(&self, _p: pac::cryp::Cryp) {}
 
     /// Performs any cipher-specific initialization.
-    fn init_phase_blocking<T: Instance, DmaIn, DmaOut>(&self, _p: &pac::cryp::Cryp, _cryp: &Cryp<T, DmaIn, DmaOut>) {}
+    fn init_phase_blocking<T: Instance, DmaIn, DmaOut>(&self, _p: pac::cryp::Cryp, _cryp: &Cryp<T, DmaIn, DmaOut>) {}
 
     /// Performs any cipher-specific initialization.
-    async fn init_phase<T: Instance, DmaIn, DmaOut>(&self, _p: &pac::cryp::Cryp, _cryp: &mut Cryp<'_, T, DmaIn, DmaOut>)
+    async fn init_phase<T: Instance, DmaIn, DmaOut>(&self, _p: pac::cryp::Cryp, _cryp: &mut Cryp<'_, T, DmaIn, DmaOut>)
     where
         DmaIn: crate::cryp::DmaIn<T>,
         DmaOut: crate::cryp::DmaOut<T>,
@@ -68,14 +68,14 @@ pub trait Cipher<'c> {
     }
 
     /// Called prior to processing the last data block for cipher-specific operations.
-    fn pre_final(&self, _p: &pac::cryp::Cryp, _dir: Direction, _padding_len: usize) -> [u32; 4] {
+    fn pre_final(&self, _p: pac::cryp::Cryp, _dir: Direction, _padding_len: usize) -> [u32; 4] {
         return [0; 4];
     }
 
     /// Called after processing the last data block for cipher-specific operations.
     fn post_final_blocking<T: Instance, DmaIn, DmaOut>(
         &self,
-        _p: &pac::cryp::Cryp,
+        _p: pac::cryp::Cryp,
         _cryp: &Cryp<T, DmaIn, DmaOut>,
         _dir: Direction,
         _int_data: &mut [u8; AES_BLOCK_SIZE],
@@ -87,7 +87,7 @@ pub trait Cipher<'c> {
     /// Called after processing the last data block for cipher-specific operations.
     async fn post_final<T: Instance, DmaIn, DmaOut>(
         &self,
-        _p: &pac::cryp::Cryp,
+        _p: pac::cryp::Cryp,
         _cryp: &mut Cryp<'_, T, DmaIn, DmaOut>,
         _dir: Direction,
         _int_data: &mut [u8; AES_BLOCK_SIZE],
@@ -142,7 +142,7 @@ impl<'c, const KEY_SIZE: usize> Cipher<'c> for TdesEcb<'c, KEY_SIZE> {
         self.iv
     }
 
-    fn set_algomode(&self, p: &pac::cryp::Cryp) {
+    fn set_algomode(&self, p: pac::cryp::Cryp) {
         #[cfg(cryp_v1)]
         {
             p.cr().modify(|w| w.set_algomode(0));
@@ -184,7 +184,7 @@ impl<'c, const KEY_SIZE: usize> Cipher<'c> for TdesCbc<'c, KEY_SIZE> {
         self.iv
     }
 
-    fn set_algomode(&self, p: &pac::cryp::Cryp) {
+    fn set_algomode(&self, p: pac::cryp::Cryp) {
         #[cfg(cryp_v1)]
         {
             p.cr().modify(|w| w.set_algomode(1));
@@ -226,7 +226,7 @@ impl<'c, const KEY_SIZE: usize> Cipher<'c> for DesEcb<'c, KEY_SIZE> {
         self.iv
     }
 
-    fn set_algomode(&self, p: &pac::cryp::Cryp) {
+    fn set_algomode(&self, p: pac::cryp::Cryp) {
         #[cfg(cryp_v1)]
         {
             p.cr().modify(|w| w.set_algomode(2));
@@ -267,7 +267,7 @@ impl<'c, const KEY_SIZE: usize> Cipher<'c> for DesCbc<'c, KEY_SIZE> {
         self.iv
     }
 
-    fn set_algomode(&self, p: &pac::cryp::Cryp) {
+    fn set_algomode(&self, p: pac::cryp::Cryp) {
         #[cfg(cryp_v1)]
         {
             p.cr().modify(|w| w.set_algomode(3));
@@ -308,7 +308,7 @@ impl<'c, const KEY_SIZE: usize> Cipher<'c> for AesEcb<'c, KEY_SIZE> {
         self.iv
     }
 
-    fn prepare_key(&self, p: &pac::cryp::Cryp) {
+    fn prepare_key(&self, p: pac::cryp::Cryp) {
         #[cfg(cryp_v1)]
         {
             p.cr().modify(|w| w.set_algomode(7));
@@ -322,7 +322,7 @@ impl<'c, const KEY_SIZE: usize> Cipher<'c> for AesEcb<'c, KEY_SIZE> {
         while p.sr().read().busy() {}
     }
 
-    fn set_algomode(&self, p: &pac::cryp::Cryp) {
+    fn set_algomode(&self, p: pac::cryp::Cryp) {
         #[cfg(cryp_v1)]
         {
             p.cr().modify(|w| w.set_algomode(2));
@@ -365,7 +365,7 @@ impl<'c, const KEY_SIZE: usize> Cipher<'c> for AesCbc<'c, KEY_SIZE> {
         self.iv
     }
 
-    fn prepare_key(&self, p: &pac::cryp::Cryp) {
+    fn prepare_key(&self, p: pac::cryp::Cryp) {
         #[cfg(cryp_v1)]
         {
             p.cr().modify(|w| w.set_algomode(7));
@@ -379,7 +379,7 @@ impl<'c, const KEY_SIZE: usize> Cipher<'c> for AesCbc<'c, KEY_SIZE> {
         while p.sr().read().busy() {}
     }
 
-    fn set_algomode(&self, p: &pac::cryp::Cryp) {
+    fn set_algomode(&self, p: pac::cryp::Cryp) {
         #[cfg(cryp_v1)]
         {
             p.cr().modify(|w| w.set_algomode(5));
@@ -421,7 +421,7 @@ impl<'c, const KEY_SIZE: usize> Cipher<'c> for AesCtr<'c, KEY_SIZE> {
         self.iv
     }
 
-    fn set_algomode(&self, p: &pac::cryp::Cryp) {
+    fn set_algomode(&self, p: pac::cryp::Cryp) {
         #[cfg(cryp_v1)]
         {
             p.cr().modify(|w| w.set_algomode(6));
@@ -469,29 +469,25 @@ impl<'c, const KEY_SIZE: usize> Cipher<'c> for AesGcm<'c, KEY_SIZE> {
         self.iv.as_slice()
     }
 
-    fn set_algomode(&self, p: &pac::cryp::Cryp) {
+    fn set_algomode(&self, p: pac::cryp::Cryp) {
         p.cr().modify(|w| w.set_algomode0(0));
         p.cr().modify(|w| w.set_algomode3(true));
     }
 
-    fn init_phase_blocking<T: Instance, DmaIn, DmaOut>(&self, p: &pac::cryp::Cryp, _cryp: &Cryp<T, DmaIn, DmaOut>) {
+    fn init_phase_blocking<T: Instance, DmaIn, DmaOut>(&self, p: pac::cryp::Cryp, _cryp: &Cryp<T, DmaIn, DmaOut>) {
         p.cr().modify(|w| w.set_gcm_ccmph(0));
         p.cr().modify(|w| w.set_crypen(true));
         while p.cr().read().crypen() {}
     }
 
-    async fn init_phase<T: Instance, DmaIn, DmaOut>(
-        &self,
-        p: &pac::cryp::Cryp,
-        _cryp: &mut Cryp<'_, T, DmaIn, DmaOut>,
-    ) {
+    async fn init_phase<T: Instance, DmaIn, DmaOut>(&self, p: pac::cryp::Cryp, _cryp: &mut Cryp<'_, T, DmaIn, DmaOut>) {
         p.cr().modify(|w| w.set_gcm_ccmph(0));
         p.cr().modify(|w| w.set_crypen(true));
         while p.cr().read().crypen() {}
     }
 
     #[cfg(cryp_v2)]
-    fn pre_final(&self, p: &pac::cryp::Cryp, dir: Direction, _padding_len: usize) -> [u32; 4] {
+    fn pre_final(&self, p: pac::cryp::Cryp, dir: Direction, _padding_len: usize) -> [u32; 4] {
         //Handle special GCM partial block process.
         if dir == Direction::Encrypt {
             p.cr().modify(|w| w.set_crypen(false));
@@ -505,7 +501,7 @@ impl<'c, const KEY_SIZE: usize> Cipher<'c> for AesGcm<'c, KEY_SIZE> {
     }
 
     #[cfg(any(cryp_v3, cryp_v4))]
-    fn pre_final(&self, p: &pac::cryp::Cryp, _dir: Direction, padding_len: usize) -> [u32; 4] {
+    fn pre_final(&self, p: pac::cryp::Cryp, _dir: Direction, padding_len: usize) -> [u32; 4] {
         //Handle special GCM partial block process.
         p.cr().modify(|w| w.set_npblb(padding_len as u8));
         [0; 4]
@@ -514,7 +510,7 @@ impl<'c, const KEY_SIZE: usize> Cipher<'c> for AesGcm<'c, KEY_SIZE> {
     #[cfg(cryp_v2)]
     fn post_final_blocking<T: Instance, DmaIn, DmaOut>(
         &self,
-        p: &pac::cryp::Cryp,
+        p: pac::cryp::Cryp,
         cryp: &Cryp<T, DmaIn, DmaOut>,
         dir: Direction,
         int_data: &mut [u8; AES_BLOCK_SIZE],
@@ -540,7 +536,7 @@ impl<'c, const KEY_SIZE: usize> Cipher<'c> for AesGcm<'c, KEY_SIZE> {
     #[cfg(cryp_v2)]
     async fn post_final<T: Instance, DmaIn, DmaOut>(
         &self,
-        p: &pac::cryp::Cryp,
+        p: pac::cryp::Cryp,
         cryp: &mut Cryp<'_, T, DmaIn, DmaOut>,
         dir: Direction,
         int_data: &mut [u8; AES_BLOCK_SIZE],
@@ -614,29 +610,25 @@ impl<'c, const KEY_SIZE: usize> Cipher<'c> for AesGmac<'c, KEY_SIZE> {
         self.iv.as_slice()
     }
 
-    fn set_algomode(&self, p: &pac::cryp::Cryp) {
+    fn set_algomode(&self, p: pac::cryp::Cryp) {
         p.cr().modify(|w| w.set_algomode0(0));
         p.cr().modify(|w| w.set_algomode3(true));
     }
 
-    fn init_phase_blocking<T: Instance, DmaIn, DmaOut>(&self, p: &pac::cryp::Cryp, _cryp: &Cryp<T, DmaIn, DmaOut>) {
+    fn init_phase_blocking<T: Instance, DmaIn, DmaOut>(&self, p: pac::cryp::Cryp, _cryp: &Cryp<T, DmaIn, DmaOut>) {
         p.cr().modify(|w| w.set_gcm_ccmph(0));
         p.cr().modify(|w| w.set_crypen(true));
         while p.cr().read().crypen() {}
     }
 
-    async fn init_phase<T: Instance, DmaIn, DmaOut>(
-        &self,
-        p: &pac::cryp::Cryp,
-        _cryp: &mut Cryp<'_, T, DmaIn, DmaOut>,
-    ) {
+    async fn init_phase<T: Instance, DmaIn, DmaOut>(&self, p: pac::cryp::Cryp, _cryp: &mut Cryp<'_, T, DmaIn, DmaOut>) {
         p.cr().modify(|w| w.set_gcm_ccmph(0));
         p.cr().modify(|w| w.set_crypen(true));
         while p.cr().read().crypen() {}
     }
 
     #[cfg(cryp_v2)]
-    fn pre_final(&self, p: &pac::cryp::Cryp, dir: Direction, _padding_len: usize) -> [u32; 4] {
+    fn pre_final(&self, p: pac::cryp::Cryp, dir: Direction, _padding_len: usize) -> [u32; 4] {
         //Handle special GCM partial block process.
         if dir == Direction::Encrypt {
             p.cr().modify(|w| w.set_crypen(false));
@@ -650,7 +642,7 @@ impl<'c, const KEY_SIZE: usize> Cipher<'c> for AesGmac<'c, KEY_SIZE> {
     }
 
     #[cfg(any(cryp_v3, cryp_v4))]
-    fn pre_final(&self, p: &pac::cryp::Cryp, _dir: Direction, padding_len: usize) -> [u32; 4] {
+    fn pre_final(&self, p: pac::cryp::Cryp, _dir: Direction, padding_len: usize) -> [u32; 4] {
         //Handle special GCM partial block process.
         p.cr().modify(|w| w.set_npblb(padding_len as u8));
         [0; 4]
@@ -659,7 +651,7 @@ impl<'c, const KEY_SIZE: usize> Cipher<'c> for AesGmac<'c, KEY_SIZE> {
     #[cfg(cryp_v2)]
     fn post_final_blocking<T: Instance, DmaIn, DmaOut>(
         &self,
-        p: &pac::cryp::Cryp,
+        p: pac::cryp::Cryp,
         cryp: &Cryp<T, DmaIn, DmaOut>,
         dir: Direction,
         int_data: &mut [u8; AES_BLOCK_SIZE],
@@ -685,7 +677,7 @@ impl<'c, const KEY_SIZE: usize> Cipher<'c> for AesGmac<'c, KEY_SIZE> {
     #[cfg(cryp_v2)]
     async fn post_final<T: Instance, DmaIn, DmaOut>(
         &self,
-        p: &pac::cryp::Cryp,
+        p: pac::cryp::Cryp,
         cryp: &mut Cryp<'_, T, DmaIn, DmaOut>,
         dir: Direction,
         int_data: &mut [u8; AES_BLOCK_SIZE],
@@ -815,12 +807,12 @@ impl<'c, const KEY_SIZE: usize, const TAG_SIZE: usize, const IV_SIZE: usize> Cip
         self.ctr.as_slice()
     }
 
-    fn set_algomode(&self, p: &pac::cryp::Cryp) {
+    fn set_algomode(&self, p: pac::cryp::Cryp) {
         p.cr().modify(|w| w.set_algomode0(1));
         p.cr().modify(|w| w.set_algomode3(true));
     }
 
-    fn init_phase_blocking<T: Instance, DmaIn, DmaOut>(&self, p: &pac::cryp::Cryp, cryp: &Cryp<T, DmaIn, DmaOut>) {
+    fn init_phase_blocking<T: Instance, DmaIn, DmaOut>(&self, p: pac::cryp::Cryp, cryp: &Cryp<T, DmaIn, DmaOut>) {
         p.cr().modify(|w| w.set_gcm_ccmph(0));
 
         cryp.write_bytes_blocking(Self::BLOCK_SIZE, &self.block0);
@@ -829,7 +821,7 @@ impl<'c, const KEY_SIZE: usize, const TAG_SIZE: usize, const IV_SIZE: usize> Cip
         while p.cr().read().crypen() {}
     }
 
-    async fn init_phase<T: Instance, DmaIn, DmaOut>(&self, p: &pac::cryp::Cryp, cryp: &mut Cryp<'_, T, DmaIn, DmaOut>)
+    async fn init_phase<T: Instance, DmaIn, DmaOut>(&self, p: pac::cryp::Cryp, cryp: &mut Cryp<'_, T, DmaIn, DmaOut>)
     where
         DmaIn: crate::cryp::DmaIn<T>,
         DmaOut: crate::cryp::DmaOut<T>,
@@ -847,7 +839,7 @@ impl<'c, const KEY_SIZE: usize, const TAG_SIZE: usize, const IV_SIZE: usize> Cip
     }
 
     #[cfg(cryp_v2)]
-    fn pre_final(&self, p: &pac::cryp::Cryp, dir: Direction, _padding_len: usize) -> [u32; 4] {
+    fn pre_final(&self, p: pac::cryp::Cryp, dir: Direction, _padding_len: usize) -> [u32; 4] {
         //Handle special CCM partial block process.
         let mut temp1 = [0; 4];
         if dir == Direction::Decrypt {
@@ -866,7 +858,7 @@ impl<'c, const KEY_SIZE: usize, const TAG_SIZE: usize, const IV_SIZE: usize> Cip
     }
 
     #[cfg(any(cryp_v3, cryp_v4))]
-    fn pre_final(&self, p: &pac::cryp::Cryp, _dir: Direction, padding_len: usize) -> [u32; 4] {
+    fn pre_final(&self, p: pac::cryp::Cryp, _dir: Direction, padding_len: usize) -> [u32; 4] {
         //Handle special GCM partial block process.
         p.cr().modify(|w| w.set_npblb(padding_len as u8));
         [0; 4]
@@ -875,7 +867,7 @@ impl<'c, const KEY_SIZE: usize, const TAG_SIZE: usize, const IV_SIZE: usize> Cip
     #[cfg(cryp_v2)]
     fn post_final_blocking<T: Instance, DmaIn, DmaOut>(
         &self,
-        p: &pac::cryp::Cryp,
+        p: pac::cryp::Cryp,
         cryp: &Cryp<T, DmaIn, DmaOut>,
         dir: Direction,
         int_data: &mut [u8; AES_BLOCK_SIZE],
@@ -912,7 +904,7 @@ impl<'c, const KEY_SIZE: usize, const TAG_SIZE: usize, const IV_SIZE: usize> Cip
     #[cfg(cryp_v2)]
     async fn post_final<T: Instance, DmaIn, DmaOut>(
         &self,
-        p: &pac::cryp::Cryp,
+        p: pac::cryp::Cryp,
         cryp: &mut Cryp<'_, T, DmaIn, DmaOut>,
         dir: Direction,
         int_data: &mut [u8; AES_BLOCK_SIZE],
@@ -1083,9 +1075,9 @@ impl<'d, T: Instance, DmaIn, DmaOut> Cryp<'d, T, DmaIn, DmaOut> {
         // Set data type to 8-bit. This will match software implementations.
         T::regs().cr().modify(|w| w.set_datatype(2));
 
-        ctx.cipher.prepare_key(&T::regs());
+        ctx.cipher.prepare_key(T::regs());
 
-        ctx.cipher.set_algomode(&T::regs());
+        ctx.cipher.set_algomode(T::regs());
 
         // Set encrypt/decrypt
         if dir == Direction::Encrypt {
@@ -1115,7 +1107,7 @@ impl<'d, T: Instance, DmaIn, DmaOut> Cryp<'d, T, DmaIn, DmaOut> {
         // Flush in/out FIFOs
         T::regs().cr().modify(|w| w.fflush());
 
-        ctx.cipher.init_phase_blocking(&T::regs(), self);
+        ctx.cipher.init_phase_blocking(T::regs(), self);
 
         self.store_context(&mut ctx);
 
@@ -1166,9 +1158,9 @@ impl<'d, T: Instance, DmaIn, DmaOut> Cryp<'d, T, DmaIn, DmaOut> {
         // Set data type to 8-bit. This will match software implementations.
         T::regs().cr().modify(|w| w.set_datatype(2));
 
-        ctx.cipher.prepare_key(&T::regs());
+        ctx.cipher.prepare_key(T::regs());
 
-        ctx.cipher.set_algomode(&T::regs());
+        ctx.cipher.set_algomode(T::regs());
 
         // Set encrypt/decrypt
         if dir == Direction::Encrypt {
@@ -1198,7 +1190,7 @@ impl<'d, T: Instance, DmaIn, DmaOut> Cryp<'d, T, DmaIn, DmaOut> {
         // Flush in/out FIFOs
         T::regs().cr().modify(|w| w.fflush());
 
-        ctx.cipher.init_phase(&T::regs(), self).await;
+        ctx.cipher.init_phase(T::regs(), self).await;
 
         self.store_context(&mut ctx);
 
@@ -1462,7 +1454,7 @@ impl<'d, T: Instance, DmaIn, DmaOut> Cryp<'d, T, DmaIn, DmaOut> {
         // Handle the final block, which is incomplete.
         if last_block_remainder > 0 {
             let padding_len = C::BLOCK_SIZE - last_block_remainder;
-            let temp1 = ctx.cipher.pre_final(&T::regs(), ctx.dir, padding_len);
+            let temp1 = ctx.cipher.pre_final(T::regs(), ctx.dir, padding_len);
 
             let mut intermediate_data: [u8; AES_BLOCK_SIZE] = [0; AES_BLOCK_SIZE];
             let mut last_block: [u8; AES_BLOCK_SIZE] = [0; AES_BLOCK_SIZE];
@@ -1478,7 +1470,7 @@ impl<'d, T: Instance, DmaIn, DmaOut> Cryp<'d, T, DmaIn, DmaOut> {
             let mut mask: [u8; 16] = [0; 16];
             mask[..last_block_remainder].fill(0xFF);
             ctx.cipher
-                .post_final_blocking(&T::regs(), self, ctx.dir, &mut intermediate_data, temp1, mask);
+                .post_final_blocking(T::regs(), self, ctx.dir, &mut intermediate_data, temp1, mask);
         }
 
         ctx.payload_len += input.len() as u64;
@@ -1559,7 +1551,7 @@ impl<'d, T: Instance, DmaIn, DmaOut> Cryp<'d, T, DmaIn, DmaOut> {
         // Handle the final block, which is incomplete.
         if last_block_remainder > 0 {
             let padding_len = C::BLOCK_SIZE - last_block_remainder;
-            let temp1 = ctx.cipher.pre_final(&T::regs(), ctx.dir, padding_len);
+            let temp1 = ctx.cipher.pre_final(T::regs(), ctx.dir, padding_len);
 
             let mut intermediate_data: [u8; AES_BLOCK_SIZE] = [0; AES_BLOCK_SIZE];
             let mut last_block: [u8; AES_BLOCK_SIZE] = [0; AES_BLOCK_SIZE];
@@ -1576,7 +1568,7 @@ impl<'d, T: Instance, DmaIn, DmaOut> Cryp<'d, T, DmaIn, DmaOut> {
             let mut mask: [u8; 16] = [0; 16];
             mask[..last_block_remainder].fill(0xFF);
             ctx.cipher
-                .post_final(&T::regs(), self, ctx.dir, &mut intermediate_data, temp1, mask)
+                .post_final(T::regs(), self, ctx.dir, &mut intermediate_data, temp1, mask)
                 .await;
         }
 
@@ -1758,7 +1750,7 @@ impl<'d, T: Instance, DmaIn, DmaOut> Cryp<'d, T, DmaIn, DmaOut> {
         self.load_key(ctx.cipher.key());
 
         // Prepare key if applicable.
-        ctx.cipher.prepare_key(&T::regs());
+        ctx.cipher.prepare_key(T::regs());
         T::regs().cr().write(|w| w.0 = ctx.cr);
 
         // Enable crypto processor.

--- a/embassy-stm32/src/dac/mod.rs
+++ b/embassy-stm32/src/dac/mod.rs
@@ -508,7 +508,7 @@ impl<'d, T: Instance, DMACh1, DMACh2> Dac<'d, T, DMACh1, DMACh2> {
 }
 
 trait SealedInstance {
-    fn regs() -> &'static crate::pac::dac::Dac;
+    fn regs() -> crate::pac::dac::Dac;
 }
 
 /// DAC instance.
@@ -523,8 +523,8 @@ pub trait DacPin<T: Instance, const C: u8>: crate::gpio::Pin + 'static {}
 foreach_peripheral!(
     (dac, $inst:ident) => {
         impl crate::dac::SealedInstance for peripherals::$inst {
-            fn regs() -> &'static crate::pac::dac::Dac {
-                &crate::pac::$inst
+            fn regs() -> crate::pac::dac::Dac {
+                crate::pac::$inst
             }
         }
 

--- a/embassy-stm32/src/dsihost.rs
+++ b/embassy-stm32/src/dsihost.rs
@@ -407,7 +407,7 @@ impl<'d, T: Instance> Drop for DsiHost<'d, T> {
 }
 
 trait SealedInstance: crate::rcc::SealedRccPeripheral {
-    fn regs() -> &'static crate::pac::dsihost::Dsihost;
+    fn regs() -> crate::pac::dsihost::Dsihost;
 }
 
 /// DSI instance trait.
@@ -419,8 +419,8 @@ pin_trait!(TePin, Instance);
 foreach_peripheral!(
     (dsihost, $inst:ident) => {
         impl crate::dsihost::SealedInstance for peripherals::$inst {
-            fn regs() -> &'static crate::pac::dsihost::Dsihost {
-                &crate::pac::$inst
+            fn regs() -> crate::pac::dsihost::Dsihost {
+                crate::pac::$inst
             }
         }
 

--- a/embassy-stm32/src/ltdc.rs
+++ b/embassy-stm32/src/ltdc.rs
@@ -93,7 +93,7 @@ impl<'d, T: Instance> Drop for Ltdc<'d, T> {
 }
 
 trait SealedInstance: crate::rcc::SealedRccPeripheral {
-    fn regs() -> &'static crate::pac::ltdc::Ltdc;
+    fn regs() -> crate::pac::ltdc::Ltdc;
 }
 
 /// DSI instance trait.
@@ -132,8 +132,8 @@ pin_trait!(B7Pin, Instance);
 foreach_peripheral!(
     (ltdc, $inst:ident) => {
         impl crate::ltdc::SealedInstance for peripherals::$inst {
-            fn regs() -> &'static crate::pac::ltdc::Ltdc {
-                &crate::pac::$inst
+            fn regs() -> crate::pac::ltdc::Ltdc {
+                crate::pac::$inst
             }
         }
 

--- a/embassy-stm32/src/rcc/f013.rs
+++ b/embassy-stm32/src/rcc/f013.rs
@@ -276,7 +276,7 @@ pub(crate) unsafe fn init(config: Config) {
 
     // Set prescalers
     // CFGR has been written before (PLL, PLL48) don't overwrite these settings
-    RCC.cfgr().modify(|w: &mut stm32_metapac::rcc::regs::Cfgr| {
+    RCC.cfgr().modify(|w| {
         #[cfg(not(stm32f0))]
         {
             w.set_ppre1(config.apb1_pre);

--- a/embassy-stm32/src/rtc/mod.rs
+++ b/embassy-stm32/src/rtc/mod.rs
@@ -320,7 +320,7 @@ impl Rtc {
     /// The registers retain their values during wakes from standby mode or system resets. They also
     /// retain their value when Vdd is switched off as long as V_BAT is powered.
     pub fn read_backup_register(&self, register: usize) -> Option<u32> {
-        RTC::read_backup_register(&RTC::regs(), register)
+        RTC::read_backup_register(RTC::regs(), register)
     }
 
     /// Set content of the backup register.
@@ -328,7 +328,7 @@ impl Rtc {
     /// The registers retain their values during wakes from standby mode or system resets. They also
     /// retain their value when Vdd is switched off as long as V_BAT is powered.
     pub fn write_backup_register(&self, register: usize, value: u32) {
-        RTC::write_backup_register(&RTC::regs(), register, value)
+        RTC::write_backup_register(RTC::regs(), register, value)
     }
 
     #[cfg(feature = "low-power")]
@@ -482,13 +482,13 @@ trait SealedInstance {
     ///
     /// The registers retain their values during wakes from standby mode or system resets. They also
     /// retain their value when Vdd is switched off as long as V_BAT is powered.
-    fn read_backup_register(rtc: &crate::pac::rtc::Rtc, register: usize) -> Option<u32>;
+    fn read_backup_register(rtc: crate::pac::rtc::Rtc, register: usize) -> Option<u32>;
 
     /// Set content of the backup register.
     ///
     /// The registers retain their values during wakes from standby mode or system resets. They also
     /// retain their value when Vdd is switched off as long as V_BAT is powered.
-    fn write_backup_register(rtc: &crate::pac::rtc::Rtc, register: usize, value: u32);
+    fn write_backup_register(rtc: crate::pac::rtc::Rtc, register: usize, value: u32);
 
     // fn apply_config(&mut self, rtc_config: RtcConfig);
 }

--- a/embassy-stm32/src/rtc/v2.rs
+++ b/embassy-stm32/src/rtc/v2.rs
@@ -95,7 +95,7 @@ impl super::Rtc {
 
     pub(super) fn write<F, R>(&self, init_mode: bool, f: F) -> R
     where
-        F: FnOnce(&crate::pac::rtc::Rtc) -> R,
+        F: FnOnce(crate::pac::rtc::Rtc) -> R,
     {
         let r = RTC::regs();
         // Disable write protection.
@@ -112,7 +112,7 @@ impl super::Rtc {
             while !r.isr().read().initf() {}
         }
 
-        let result = f(&r);
+        let result = f(r);
 
         if init_mode {
             r.isr().modify(|w| w.set_init(false)); // Exits init mode
@@ -140,7 +140,7 @@ impl SealedInstance for crate::peripherals::RTC {
     #[cfg(all(feature = "low-power", stm32l0))]
     type WakeupInterrupt = crate::interrupt::typelevel::RTC;
 
-    fn read_backup_register(rtc: &Rtc, register: usize) -> Option<u32> {
+    fn read_backup_register(rtc: Rtc, register: usize) -> Option<u32> {
         if register < Self::BACKUP_REGISTER_COUNT {
             Some(rtc.bkpr(register).read().bkp())
         } else {
@@ -148,7 +148,7 @@ impl SealedInstance for crate::peripherals::RTC {
         }
     }
 
-    fn write_backup_register(rtc: &Rtc, register: usize, value: u32) {
+    fn write_backup_register(rtc: Rtc, register: usize, value: u32) {
         if register < Self::BACKUP_REGISTER_COUNT {
             rtc.bkpr(register).write(|w| w.set_bkp(value));
         }

--- a/embassy-stm32/src/rtc/v3.rs
+++ b/embassy-stm32/src/rtc/v3.rs
@@ -97,7 +97,7 @@ impl super::Rtc {
 
     pub(super) fn write<F, R>(&self, init_mode: bool, f: F) -> R
     where
-        F: FnOnce(&crate::pac::rtc::Rtc) -> R,
+        F: FnOnce(crate::pac::rtc::Rtc) -> R,
     {
         let r = RTC::regs();
         // Disable write protection.
@@ -112,7 +112,7 @@ impl super::Rtc {
             while !r.icsr().read().initf() {}
         }
 
-        let result = f(&r);
+        let result = f(r);
 
         if init_mode {
             r.icsr().modify(|w| w.set_init(false)); // Exits init mode
@@ -143,7 +143,7 @@ impl SealedInstance for crate::peripherals::RTC {
         }
     );
 
-    fn read_backup_register(_rtc: &Rtc, register: usize) -> Option<u32> {
+    fn read_backup_register(_rtc: Rtc, register: usize) -> Option<u32> {
         #[allow(clippy::if_same_then_else)]
         if register < Self::BACKUP_REGISTER_COUNT {
             //Some(rtc.bkpr()[register].read().bits())
@@ -153,7 +153,7 @@ impl SealedInstance for crate::peripherals::RTC {
         }
     }
 
-    fn write_backup_register(_rtc: &Rtc, register: usize, _value: u32) {
+    fn write_backup_register(_rtc: Rtc, register: usize, _value: u32) {
         if register < Self::BACKUP_REGISTER_COUNT {
             // RTC3 backup registers come from the TAMP peripheral, not RTC. Not() even in the L412 PAC
             //self.rtc.bkpr()[register].write(|w| w.bits(value))


### PR DESCRIPTION
in chiptool pacs the register block struct is already a pointer, so
using pointers to it is redundant.
