### PR TITLE
stm32/rtc: move lowpower stuff to a separate mod.

### DIFF
--- a/embassy-stm32/src/can/fd/peripheral.rs
+++ b/embassy-stm32/src/can/fd/peripheral.rs
@@ -20,8 +20,9 @@ enum LoopbackMode {
 }
 
 pub struct Registers {
-    pub regs: &'static crate::pac::can::Fdcan,
-    pub msgram: &'static crate::pac::fdcanram::Fdcanram,
+    pub regs: crate::pac::can::Fdcan,
+    pub msgram: crate::pac::fdcanram::Fdcanram,
+    #[allow(dead_code)]
     pub msg_ram_offset: usize,
 }
 

--- a/embassy-stm32/src/cryp/mod.rs
+++ b/embassy-stm32/src/cryp/mod.rs
@@ -51,16 +51,16 @@ pub trait Cipher<'c> {
     fn iv(&self) -> &[u8];
 
     /// Sets the processor algorithm mode according to the associated cipher.
-    fn set_algomode(&self, p: &pac::cryp::Cryp);
+    fn set_algomode(&self, p: pac::cryp::Cryp);
 
     /// Performs any key preparation within the processor, if necessary.
-    fn prepare_key(&self, _p: &pac::cryp::Cryp) {}
+    fn prepare_key(&self, _p: pac::cryp::Cryp) {}
 
     /// Performs any cipher-specific initialization.
-    fn init_phase_blocking<T: Instance, DmaIn, DmaOut>(&self, _p: &pac::cryp::Cryp, _cryp: &Cryp<T, DmaIn, DmaOut>) {}
+    fn init_phase_blocking<T: Instance, DmaIn, DmaOut>(&self, _p: pac::cryp::Cryp, _cryp: &Cryp<T, DmaIn, DmaOut>) {}
 
     /// Performs any cipher-specific initialization.
-    async fn init_phase<T: Instance, DmaIn, DmaOut>(&self, _p: &pac::cryp::Cryp, _cryp: &mut Cryp<'_, T, DmaIn, DmaOut>)
+    async fn init_phase<T: Instance, DmaIn, DmaOut>(&self, _p: pac::cryp::Cryp, _cryp: &mut Cryp<'_, T, DmaIn, DmaOut>)
     where
         DmaIn: crate::cryp::DmaIn<T>,
         DmaOut: crate::cryp::DmaOut<T>,
@@ -68,14 +68,14 @@ pub trait Cipher<'c> {
     }
 
     /// Called prior to processing the last data block for cipher-specific operations.
-    fn pre_final(&self, _p: &pac::cryp::Cryp, _dir: Direction, _padding_len: usize) -> [u32; 4] {
+    fn pre_final(&self, _p: pac::cryp::Cryp, _dir: Direction, _padding_len: usize) -> [u32; 4] {
         return [0; 4];
     }
 
     /// Called after processing the last data block for cipher-specific operations.
     fn post_final_blocking<T: Instance, DmaIn, DmaOut>(
         &self,
-        _p: &pac::cryp::Cryp,
+        _p: pac::cryp::Cryp,
         _cryp: &Cryp<T, DmaIn, DmaOut>,
         _dir: Direction,
         _int_data: &mut [u8; AES_BLOCK_SIZE],
@@ -87,7 +87,7 @@ pub trait Cipher<'c> {
     /// Called after processing the last data block for cipher-specific operations.
     async fn post_final<T: Instance, DmaIn, DmaOut>(
         &self,
-        _p: &pac::cryp::Cryp,
+        _p: pac::cryp::Cryp,
         _cryp: &mut Cryp<'_, T, DmaIn, DmaOut>,
         _dir: Direction,
         _int_data: &mut [u8; AES_BLOCK_SIZE],
@@ -142,7 +142,7 @@ impl<'c, const KEY_SIZE: usize> Cipher<'c> for TdesEcb<'c, KEY_SIZE> {
         self.iv
     }
 
-    fn set_algomode(&self, p: &pac::cryp::Cryp) {
+    fn set_algomode(&self, p: pac::cryp::Cryp) {
         #[cfg(cryp_v1)]
         {
             p.cr().modify(|w| w.set_algomode(0));
@@ -184,7 +184,7 @@ impl<'c, const KEY_SIZE: usize> Cipher<'c> for TdesCbc<'c, KEY_SIZE> {
         self.iv
     }
 
-    fn set_algomode(&self, p: &pac::cryp::Cryp) {
+    fn set_algomode(&self, p: pac::cryp::Cryp) {
         #[cfg(cryp_v1)]
         {
             p.cr().modify(|w| w.set_algomode(1));
@@ -226,7 +226,7 @@ impl<'c, const KEY_SIZE: usize> Cipher<'c> for DesEcb<'c, KEY_SIZE> {
         self.iv
     }
 
-    fn set_algomode(&self, p: &pac::cryp::Cryp) {
+    fn set_algomode(&self, p: pac::cryp::Cryp) {
         #[cfg(cryp_v1)]
         {
             p.cr().modify(|w| w.set_algomode(2));
@@ -267,7 +267,7 @@ impl<'c, const KEY_SIZE: usize> Cipher<'c> for DesCbc<'c, KEY_SIZE> {
         self.iv
     }
 
-    fn set_algomode(&self, p: &pac::cryp::Cryp) {
+    fn set_algomode(&self, p: pac::cryp::Cryp) {
         #[cfg(cryp_v1)]
         {
             p.cr().modify(|w| w.set_algomode(3));
@@ -308,7 +308,7 @@ impl<'c, const KEY_SIZE: usize> Cipher<'c> for AesEcb<'c, KEY_SIZE> {
         self.iv
     }
 
-    fn prepare_key(&self, p: &pac::cryp::Cryp) {
+    fn prepare_key(&self, p: pac::cryp::Cryp) {
         #[cfg(cryp_v1)]
         {
             p.cr().modify(|w| w.set_algomode(7));
@@ -322,7 +322,7 @@ impl<'c, const KEY_SIZE: usize> Cipher<'c> for AesEcb<'c, KEY_SIZE> {
         while p.sr().read().busy() {}
     }
 
-    fn set_algomode(&self, p: &pac::cryp::Cryp) {
+    fn set_algomode(&self, p: pac::cryp::Cryp) {
         #[cfg(cryp_v1)]
         {
             p.cr().modify(|w| w.set_algomode(2));
@@ -365,7 +365,7 @@ impl<'c, const KEY_SIZE: usize> Cipher<'c> for AesCbc<'c, KEY_SIZE> {
         self.iv
     }
 
-    fn prepare_key(&self, p: &pac::cryp::Cryp) {
+    fn prepare_key(&self, p: pac::cryp::Cryp) {
         #[cfg(cryp_v1)]
         {
             p.cr().modify(|w| w.set_algomode(7));
@@ -379,7 +379,7 @@ impl<'c, const KEY_SIZE: usize> Cipher<'c> for AesCbc<'c, KEY_SIZE> {
         while p.sr().read().busy() {}
     }
 
-    fn set_algomode(&self, p: &pac::cryp::Cryp) {
+    fn set_algomode(&self, p: pac::cryp::Cryp) {
         #[cfg(cryp_v1)]
         {
             p.cr().modify(|w| w.set_algomode(5));
@@ -421,7 +421,7 @@ impl<'c, const KEY_SIZE: usize> Cipher<'c> for AesCtr<'c, KEY_SIZE> {
         self.iv
     }
 
-    fn set_algomode(&self, p: &pac::cryp::Cryp) {
+    fn set_algomode(&self, p: pac::cryp::Cryp) {
         #[cfg(cryp_v1)]
         {
             p.cr().modify(|w| w.set_algomode(6));
@@ -469,29 +469,25 @@ impl<'c, const KEY_SIZE: usize> Cipher<'c> for AesGcm<'c, KEY_SIZE> {
         self.iv.as_slice()
     }
 
-    fn set_algomode(&self, p: &pac::cryp::Cryp) {
+    fn set_algomode(&self, p: pac::cryp::Cryp) {
         p.cr().modify(|w| w.set_algomode0(0));
         p.cr().modify(|w| w.set_algomode3(true));
     }
 
-    fn init_phase_blocking<T: Instance, DmaIn, DmaOut>(&self, p: &pac::cryp::Cryp, _cryp: &Cryp<T, DmaIn, DmaOut>) {
+    fn init_phase_blocking<T: Instance, DmaIn, DmaOut>(&self, p: pac::cryp::Cryp, _cryp: &Cryp<T, DmaIn, DmaOut>) {
         p.cr().modify(|w| w.set_gcm_ccmph(0));
         p.cr().modify(|w| w.set_crypen(true));
         while p.cr().read().crypen() {}
     }
 
-    async fn init_phase<T: Instance, DmaIn, DmaOut>(
-        &self,
-        p: &pac::cryp::Cryp,
-        _cryp: &mut Cryp<'_, T, DmaIn, DmaOut>,
-    ) {
+    async fn init_phase<T: Instance, DmaIn, DmaOut>(&self, p: pac::cryp::Cryp, _cryp: &mut Cryp<'_, T, DmaIn, DmaOut>) {
         p.cr().modify(|w| w.set_gcm_ccmph(0));
         p.cr().modify(|w| w.set_crypen(true));
         while p.cr().read().crypen() {}
     }
 
     #[cfg(cryp_v2)]
-    fn pre_final(&self, p: &pac::cryp::Cryp, dir: Direction, _padding_len: usize) -> [u32; 4] {
+    fn pre_final(&self, p: pac::cryp::Cryp, dir: Direction, _padding_len: usize) -> [u32; 4] {
         //Handle special GCM partial block process.
         if dir == Direction::Encrypt {
             p.cr().modify(|w| w.set_crypen(false));
@@ -505,7 +501,7 @@ impl<'c, const KEY_SIZE: usize> Cipher<'c> for AesGcm<'c, KEY_SIZE> {
     }
 
     #[cfg(any(cryp_v3, cryp_v4))]
-    fn pre_final(&self, p: &pac::cryp::Cryp, _dir: Direction, padding_len: usize) -> [u32; 4] {
+    fn pre_final(&self, p: pac::cryp::Cryp, _dir: Direction, padding_len: usize) -> [u32; 4] {
         //Handle special GCM partial block process.
         p.cr().modify(|w| w.set_npblb(padding_len as u8));
         [0; 4]
@@ -514,7 +510,7 @@ impl<'c, const KEY_SIZE: usize> Cipher<'c> for AesGcm<'c, KEY_SIZE> {
     #[cfg(cryp_v2)]
     fn post_final_blocking<T: Instance, DmaIn, DmaOut>(
         &self,
-        p: &pac::cryp::Cryp,
+        p: pac::cryp::Cryp,
         cryp: &Cryp<T, DmaIn, DmaOut>,
         dir: Direction,
         int_data: &mut [u8; AES_BLOCK_SIZE],
@@ -540,7 +536,7 @@ impl<'c, const KEY_SIZE: usize> Cipher<'c> for AesGcm<'c, KEY_SIZE> {
     #[cfg(cryp_v2)]
     async fn post_final<T: Instance, DmaIn, DmaOut>(
         &self,
-        p: &pac::cryp::Cryp,
+        p: pac::cryp::Cryp,
         cryp: &mut Cryp<'_, T, DmaIn, DmaOut>,
         dir: Direction,
         int_data: &mut [u8; AES_BLOCK_SIZE],
@@ -614,29 +610,25 @@ impl<'c, const KEY_SIZE: usize> Cipher<'c> for AesGmac<'c, KEY_SIZE> {
         self.iv.as_slice()
     }
 
-    fn set_algomode(&self, p: &pac::cryp::Cryp) {
+    fn set_algomode(&self, p: pac::cryp::Cryp) {
         p.cr().modify(|w| w.set_algomode0(0));
         p.cr().modify(|w| w.set_algomode3(true));
     }
 
-    fn init_phase_blocking<T: Instance, DmaIn, DmaOut>(&self, p: &pac::cryp::Cryp, _cryp: &Cryp<T, DmaIn, DmaOut>) {
+    fn init_phase_blocking<T: Instance, DmaIn, DmaOut>(&self, p: pac::cryp::Cryp, _cryp: &Cryp<T, DmaIn, DmaOut>) {
         p.cr().modify(|w| w.set_gcm_ccmph(0));
         p.cr().modify(|w| w.set_crypen(true));
         while p.cr().read().crypen() {}
     }
 
-    async fn init_phase<T: Instance, DmaIn, DmaOut>(
-        &self,
-        p: &pac::cryp::Cryp,
-        _cryp: &mut Cryp<'_, T, DmaIn, DmaOut>,
-    ) {
+    async fn init_phase<T: Instance, DmaIn, DmaOut>(&self, p: pac::cryp::Cryp, _cryp: &mut Cryp<'_, T, DmaIn, DmaOut>) {
         p.cr().modify(|w| w.set_gcm_ccmph(0));
         p.cr().modify(|w| w.set_crypen(true));
         while p.cr().read().crypen() {}
     }
 
     #[cfg(cryp_v2)]
-    fn pre_final(&self, p: &pac::cryp::Cryp, dir: Direction, _padding_len: usize) -> [u32; 4] {
+    fn pre_final(&self, p: pac::cryp::Cryp, dir: Direction, _padding_len: usize) -> [u32; 4] {
         //Handle special GCM partial block process.
         if dir == Direction::Encrypt {
             p.cr().modify(|w| w.set_crypen(false));
@@ -650,7 +642,7 @@ impl<'c, const KEY_SIZE: usize> Cipher<'c> for AesGmac<'c, KEY_SIZE> {
     }
 
     #[cfg(any(cryp_v3, cryp_v4))]
-    fn pre_final(&self, p: &pac::cryp::Cryp, _dir: Direction, padding_len: usize) -> [u32; 4] {
+    fn pre_final(&self, p: pac::cryp::Cryp, _dir: Direction, padding_len: usize) -> [u32; 4] {
         //Handle special GCM partial block process.
         p.cr().modify(|w| w.set_npblb(padding_len as u8));
         [0; 4]
@@ -659,7 +651,7 @@ impl<'c, const KEY_SIZE: usize> Cipher<'c> for AesGmac<'c, KEY_SIZE> {
     #[cfg(cryp_v2)]
     fn post_final_blocking<T: Instance, DmaIn, DmaOut>(
         &self,
-        p: &pac::cryp::Cryp,
+        p: pac::cryp::Cryp,
         cryp: &Cryp<T, DmaIn, DmaOut>,
         dir: Direction,
         int_data: &mut [u8; AES_BLOCK_SIZE],
@@ -685,7 +677,7 @@ impl<'c, const KEY_SIZE: usize> Cipher<'c> for AesGmac<'c, KEY_SIZE> {
     #[cfg(cryp_v2)]
     async fn post_final<T: Instance, DmaIn, DmaOut>(
         &self,
-        p: &pac::cryp::Cryp,
+        p: pac::cryp::Cryp,
         cryp: &mut Cryp<'_, T, DmaIn, DmaOut>,
         dir: Direction,
         int_data: &mut [u8; AES_BLOCK_SIZE],
@@ -815,12 +807,12 @@ impl<'c, const KEY_SIZE: usize, const TAG_SIZE: usize, const IV_SIZE: usize> Cip
         self.ctr.as_slice()
     }
 
-    fn set_algomode(&self, p: &pac::cryp::Cryp) {
+    fn set_algomode(&self, p: pac::cryp::Cryp) {
         p.cr().modify(|w| w.set_algomode0(1));
         p.cr().modify(|w| w.set_algomode3(true));
     }
 
-    fn init_phase_blocking<T: Instance, DmaIn, DmaOut>(&self, p: &pac::cryp::Cryp, cryp: &Cryp<T, DmaIn, DmaOut>) {
+    fn init_phase_blocking<T: Instance, DmaIn, DmaOut>(&self, p: pac::cryp::Cryp, cryp: &Cryp<T, DmaIn, DmaOut>) {
         p.cr().modify(|w| w.set_gcm_ccmph(0));
 
         cryp.write_bytes_blocking(Self::BLOCK_SIZE, &self.block0);
@@ -829,7 +821,7 @@ impl<'c, const KEY_SIZE: usize, const TAG_SIZE: usize, const IV_SIZE: usize> Cip
         while p.cr().read().crypen() {}
     }
 
-    async fn init_phase<T: Instance, DmaIn, DmaOut>(&self, p: &pac::cryp::Cryp, cryp: &mut Cryp<'_, T, DmaIn, DmaOut>)
+    async fn init_phase<T: Instance, DmaIn, DmaOut>(&self, p: pac::cryp::Cryp, cryp: &mut Cryp<'_, T, DmaIn, DmaOut>)
     where
         DmaIn: crate::cryp::DmaIn<T>,
         DmaOut: crate::cryp::DmaOut<T>,
@@ -847,7 +839,7 @@ impl<'c, const KEY_SIZE: usize, const TAG_SIZE: usize, const IV_SIZE: usize> Cip
     }
 
     #[cfg(cryp_v2)]
-    fn pre_final(&self, p: &pac::cryp::Cryp, dir: Direction, _padding_len: usize) -> [u32; 4] {
+    fn pre_final(&self, p: pac::cryp::Cryp, dir: Direction, _padding_len: usize) -> [u32; 4] {
         //Handle special CCM partial block process.
         let mut temp1 = [0; 4];
         if dir == Direction::Decrypt {
@@ -866,7 +858,7 @@ impl<'c, const KEY_SIZE: usize, const TAG_SIZE: usize, const IV_SIZE: usize> Cip
     }
 
     #[cfg(any(cryp_v3, cryp_v4))]
-    fn pre_final(&self, p: &pac::cryp::Cryp, _dir: Direction, padding_len: usize) -> [u32; 4] {
+    fn pre_final(&self, p: pac::cryp::Cryp, _dir: Direction, padding_len: usize) -> [u32; 4] {
         //Handle special GCM partial block process.
         p.cr().modify(|w| w.set_npblb(padding_len as u8));
         [0; 4]
@@ -875,7 +867,7 @@ impl<'c, const KEY_SIZE: usize, const TAG_SIZE: usize, const IV_SIZE: usize> Cip
     #[cfg(cryp_v2)]
     fn post_final_blocking<T: Instance, DmaIn, DmaOut>(
         &self,
-        p: &pac::cryp::Cryp,
+        p: pac::cryp::Cryp,
         cryp: &Cryp<T, DmaIn, DmaOut>,
         dir: Direction,
         int_data: &mut [u8; AES_BLOCK_SIZE],
@@ -912,7 +904,7 @@ impl<'c, const KEY_SIZE: usize, const TAG_SIZE: usize, const IV_SIZE: usize> Cip
     #[cfg(cryp_v2)]
     async fn post_final<T: Instance, DmaIn, DmaOut>(
         &self,
-        p: &pac::cryp::Cryp,
+        p: pac::cryp::Cryp,
         cryp: &mut Cryp<'_, T, DmaIn, DmaOut>,
         dir: Direction,
         int_data: &mut [u8; AES_BLOCK_SIZE],
@@ -1083,9 +1075,9 @@ impl<'d, T: Instance, DmaIn, DmaOut> Cryp<'d, T, DmaIn, DmaOut> {
         // Set data type to 8-bit. This will match software implementations.
         T::regs().cr().modify(|w| w.set_datatype(2));
 
-        ctx.cipher.prepare_key(&T::regs());
+        ctx.cipher.prepare_key(T::regs());
 
-        ctx.cipher.set_algomode(&T::regs());
+        ctx.cipher.set_algomode(T::regs());
 
         // Set encrypt/decrypt
         if dir == Direction::Encrypt {
@@ -1115,7 +1107,7 @@ impl<'d, T: Instance, DmaIn, DmaOut> Cryp<'d, T, DmaIn, DmaOut> {
         // Flush in/out FIFOs
         T::regs().cr().modify(|w| w.fflush());
 
-        ctx.cipher.init_phase_blocking(&T::regs(), self);
+        ctx.cipher.init_phase_blocking(T::regs(), self);
 
         self.store_context(&mut ctx);
 
@@ -1166,9 +1158,9 @@ impl<'d, T: Instance, DmaIn, DmaOut> Cryp<'d, T, DmaIn, DmaOut> {
         // Set data type to 8-bit. This will match software implementations.
         T::regs().cr().modify(|w| w.set_datatype(2));
 
-        ctx.cipher.prepare_key(&T::regs());
+        ctx.cipher.prepare_key(T::regs());
 
-        ctx.cipher.set_algomode(&T::regs());
+        ctx.cipher.set_algomode(T::regs());
 
         // Set encrypt/decrypt
         if dir == Direction::Encrypt {
@@ -1198,7 +1190,7 @@ impl<'d, T: Instance, DmaIn, DmaOut> Cryp<'d, T, DmaIn, DmaOut> {
         // Flush in/out FIFOs
         T::regs().cr().modify(|w| w.fflush());
 
-        ctx.cipher.init_phase(&T::regs(), self).await;
+        ctx.cipher.init_phase(T::regs(), self).await;
 
         self.store_context(&mut ctx);
 
@@ -1462,7 +1454,7 @@ impl<'d, T: Instance, DmaIn, DmaOut> Cryp<'d, T, DmaIn, DmaOut> {
         // Handle the final block, which is incomplete.
         if last_block_remainder > 0 {
             let padding_len = C::BLOCK_SIZE - last_block_remainder;
-            let temp1 = ctx.cipher.pre_final(&T::regs(), ctx.dir, padding_len);
+            let temp1 = ctx.cipher.pre_final(T::regs(), ctx.dir, padding_len);
 
             let mut intermediate_data: [u8; AES_BLOCK_SIZE] = [0; AES_BLOCK_SIZE];
             let mut last_block: [u8; AES_BLOCK_SIZE] = [0; AES_BLOCK_SIZE];
@@ -1478,7 +1470,7 @@ impl<'d, T: Instance, DmaIn, DmaOut> Cryp<'d, T, DmaIn, DmaOut> {
             let mut mask: [u8; 16] = [0; 16];
             mask[..last_block_remainder].fill(0xFF);
             ctx.cipher
-                .post_final_blocking(&T::regs(), self, ctx.dir, &mut intermediate_data, temp1, mask);
+                .post_final_blocking(T::regs(), self, ctx.dir, &mut intermediate_data, temp1, mask);
         }
 
         ctx.payload_len += input.len() as u64;
@@ -1559,7 +1551,7 @@ impl<'d, T: Instance, DmaIn, DmaOut> Cryp<'d, T, DmaIn, DmaOut> {
         // Handle the final block, which is incomplete.
         if last_block_remainder > 0 {
             let padding_len = C::BLOCK_SIZE - last_block_remainder;
-            let temp1 = ctx.cipher.pre_final(&T::regs(), ctx.dir, padding_len);
+            let temp1 = ctx.cipher.pre_final(T::regs(), ctx.dir, padding_len);
 
             let mut intermediate_data: [u8; AES_BLOCK_SIZE] = [0; AES_BLOCK_SIZE];
             let mut last_block: [u8; AES_BLOCK_SIZE] = [0; AES_BLOCK_SIZE];
@@ -1576,7 +1568,7 @@ impl<'d, T: Instance, DmaIn, DmaOut> Cryp<'d, T, DmaIn, DmaOut> {
             let mut mask: [u8; 16] = [0; 16];
             mask[..last_block_remainder].fill(0xFF);
             ctx.cipher
-                .post_final(&T::regs(), self, ctx.dir, &mut intermediate_data, temp1, mask)
+                .post_final(T::regs(), self, ctx.dir, &mut intermediate_data, temp1, mask)
                 .await;
         }
 
@@ -1758,7 +1750,7 @@ impl<'d, T: Instance, DmaIn, DmaOut> Cryp<'d, T, DmaIn, DmaOut> {
         self.load_key(ctx.cipher.key());
 
         // Prepare key if applicable.
-        ctx.cipher.prepare_key(&T::regs());
+        ctx.cipher.prepare_key(T::regs());
         T::regs().cr().write(|w| w.0 = ctx.cr);
 
         // Enable crypto processor.

--- a/embassy-stm32/src/dac/mod.rs
+++ b/embassy-stm32/src/dac/mod.rs
@@ -508,7 +508,7 @@ impl<'d, T: Instance, DMACh1, DMACh2> Dac<'d, T, DMACh1, DMACh2> {
 }
 
 trait SealedInstance {
-    fn regs() -> &'static crate::pac::dac::Dac;
+    fn regs() -> crate::pac::dac::Dac;
 }
 
 /// DAC instance.
@@ -523,8 +523,8 @@ pub trait DacPin<T: Instance, const C: u8>: crate::gpio::Pin + 'static {}
 foreach_peripheral!(
     (dac, $inst:ident) => {
         impl crate::dac::SealedInstance for peripherals::$inst {
-            fn regs() -> &'static crate::pac::dac::Dac {
-                &crate::pac::$inst
+            fn regs() -> crate::pac::dac::Dac {
+                crate::pac::$inst
             }
         }
 

--- a/embassy-stm32/src/dsihost.rs
+++ b/embassy-stm32/src/dsihost.rs
@@ -407,7 +407,7 @@ impl<'d, T: Instance> Drop for DsiHost<'d, T> {
 }
 
 trait SealedInstance: crate::rcc::SealedRccPeripheral {
-    fn regs() -> &'static crate::pac::dsihost::Dsihost;
+    fn regs() -> crate::pac::dsihost::Dsihost;
 }
 
 /// DSI instance trait.
@@ -419,8 +419,8 @@ pin_trait!(TePin, Instance);
 foreach_peripheral!(
     (dsihost, $inst:ident) => {
         impl crate::dsihost::SealedInstance for peripherals::$inst {
-            fn regs() -> &'static crate::pac::dsihost::Dsihost {
-                &crate::pac::$inst
+            fn regs() -> crate::pac::dsihost::Dsihost {
+                crate::pac::$inst
             }
         }
 

--- a/embassy-stm32/src/ltdc.rs
+++ b/embassy-stm32/src/ltdc.rs
@@ -93,7 +93,7 @@ impl<'d, T: Instance> Drop for Ltdc<'d, T> {
 }
 
 trait SealedInstance: crate::rcc::SealedRccPeripheral {
-    fn regs() -> &'static crate::pac::ltdc::Ltdc;
+    fn regs() -> crate::pac::ltdc::Ltdc;
 }
 
 /// DSI instance trait.
@@ -132,8 +132,8 @@ pin_trait!(B7Pin, Instance);
 foreach_peripheral!(
     (ltdc, $inst:ident) => {
         impl crate::ltdc::SealedInstance for peripherals::$inst {
-            fn regs() -> &'static crate::pac::ltdc::Ltdc {
-                &crate::pac::$inst
+            fn regs() -> crate::pac::ltdc::Ltdc {
+                crate::pac::$inst
             }
         }
 

--- a/embassy-stm32/src/rcc/f013.rs
+++ b/embassy-stm32/src/rcc/f013.rs
@@ -276,7 +276,7 @@ pub(crate) unsafe fn init(config: Config) {
 
     // Set prescalers
     // CFGR has been written before (PLL, PLL48) don't overwrite these settings
-    RCC.cfgr().modify(|w: &mut stm32_metapac::rcc::regs::Cfgr| {
+    RCC.cfgr().modify(|w| {
         #[cfg(not(stm32f0))]
         {
             w.set_ppre1(config.apb1_pre);

--- a/embassy-stm32/src/rtc/low_power.rs
+++ b/embassy-stm32/src/rtc/low_power.rs
@@ -1,0 +1,230 @@
+use super::{bcd2_to_byte, DateTimeError, Rtc, RtcError};
+use crate::peripherals::RTC;
+use crate::rtc::SealedInstance;
+
+/// Represents an instant in time that can be substracted to compute a duration
+pub(super) struct RtcInstant {
+    /// 0..59
+    second: u8,
+    /// 0..256
+    subsecond: u16,
+}
+
+impl RtcInstant {
+    #[cfg(not(rtc_v2f2))]
+    const fn from(second: u8, subsecond: u16) -> Result<Self, DateTimeError> {
+        if second > 59 {
+            Err(DateTimeError::InvalidSecond)
+        } else {
+            Ok(Self { second, subsecond })
+        }
+    }
+}
+
+#[cfg(feature = "defmt")]
+impl defmt::Format for RtcInstant {
+    fn format(&self, fmt: defmt::Formatter) {
+        defmt::write!(
+            fmt,
+            "{}:{}",
+            self.second,
+            RTC::regs().prer().read().prediv_s() - self.subsecond,
+        )
+    }
+}
+
+#[cfg(feature = "time")]
+impl core::ops::Sub for RtcInstant {
+    type Output = embassy_time::Duration;
+
+    fn sub(self, rhs: Self) -> Self::Output {
+        use embassy_time::{Duration, TICK_HZ};
+
+        let second = if self.second < rhs.second {
+            self.second + 60
+        } else {
+            self.second
+        };
+
+        let psc = RTC::regs().prer().read().prediv_s() as u32;
+
+        let self_ticks = second as u32 * (psc + 1) + (psc - self.subsecond as u32);
+        let other_ticks = rhs.second as u32 * (psc + 1) + (psc - rhs.subsecond as u32);
+        let rtc_ticks = self_ticks - other_ticks;
+
+        Duration::from_ticks(((rtc_ticks * TICK_HZ as u32) / (psc + 1)) as u64)
+    }
+}
+
+#[repr(u8)]
+#[derive(Clone, Copy, Debug)]
+pub(crate) enum WakeupPrescaler {
+    Div2 = 2,
+    Div4 = 4,
+    Div8 = 8,
+    Div16 = 16,
+}
+
+#[cfg(any(stm32f4, stm32l0, stm32g4, stm32l5, stm32wb, stm32h5, stm32g0))]
+impl From<WakeupPrescaler> for crate::pac::rtc::vals::Wucksel {
+    fn from(val: WakeupPrescaler) -> Self {
+        use crate::pac::rtc::vals::Wucksel;
+
+        match val {
+            WakeupPrescaler::Div2 => Wucksel::DIV2,
+            WakeupPrescaler::Div4 => Wucksel::DIV4,
+            WakeupPrescaler::Div8 => Wucksel::DIV8,
+            WakeupPrescaler::Div16 => Wucksel::DIV16,
+        }
+    }
+}
+
+#[cfg(any(stm32f4, stm32l0, stm32g4, stm32l5, stm32wb, stm32h5, stm32g0))]
+impl From<crate::pac::rtc::vals::Wucksel> for WakeupPrescaler {
+    fn from(val: crate::pac::rtc::vals::Wucksel) -> Self {
+        use crate::pac::rtc::vals::Wucksel;
+
+        match val {
+            Wucksel::DIV2 => WakeupPrescaler::Div2,
+            Wucksel::DIV4 => WakeupPrescaler::Div4,
+            Wucksel::DIV8 => WakeupPrescaler::Div8,
+            Wucksel::DIV16 => WakeupPrescaler::Div16,
+            _ => unreachable!(),
+        }
+    }
+}
+
+impl WakeupPrescaler {
+    pub fn compute_min(val: u32) -> Self {
+        *[
+            WakeupPrescaler::Div2,
+            WakeupPrescaler::Div4,
+            WakeupPrescaler::Div8,
+            WakeupPrescaler::Div16,
+        ]
+        .iter()
+        .find(|psc| **psc as u32 > val)
+        .unwrap_or(&WakeupPrescaler::Div16)
+    }
+}
+
+impl Rtc {
+    /// Return the current instant.
+    fn instant(&self) -> Result<RtcInstant, RtcError> {
+        self.time_provider().read(|_, tr, ss| {
+            let second = bcd2_to_byte((tr.st(), tr.su()));
+
+            RtcInstant::from(second, ss).map_err(RtcError::InvalidDateTime)
+        })
+    }
+
+    /// start the wakeup alarm and with a duration that is as close to but less than
+    /// the requested duration, and record the instant the wakeup alarm was started
+    pub(crate) fn start_wakeup_alarm(
+        &self,
+        requested_duration: embassy_time::Duration,
+        cs: critical_section::CriticalSection,
+    ) {
+        use embassy_time::{Duration, TICK_HZ};
+
+        #[cfg(any(rtc_v3, rtc_v3u5, rtc_v3l5))]
+        use crate::pac::rtc::vals::Calrf;
+
+        // Panic if the rcc mod knows we're not using low-power rtc
+        #[cfg(any(rcc_wb, rcc_f4, rcc_f410))]
+        unsafe { crate::rcc::get_freqs() }.rtc.unwrap();
+
+        let requested_duration = requested_duration.as_ticks().clamp(0, u32::MAX as u64);
+        let rtc_hz = Self::frequency().0 as u64;
+        let rtc_ticks = requested_duration * rtc_hz / TICK_HZ;
+        let prescaler = WakeupPrescaler::compute_min((rtc_ticks / u16::MAX as u64) as u32);
+
+        // adjust the rtc ticks to the prescaler and subtract one rtc tick
+        let rtc_ticks = rtc_ticks / prescaler as u64;
+        let rtc_ticks = rtc_ticks.clamp(0, (u16::MAX - 1) as u64).saturating_sub(1) as u16;
+
+        self.write(false, |regs| {
+            regs.cr().modify(|w| w.set_wute(false));
+
+            #[cfg(any(
+                rtc_v2f0, rtc_v2f2, rtc_v2f3, rtc_v2f4, rtc_v2f7, rtc_v2h7, rtc_v2l0, rtc_v2l1, rtc_v2l4, rtc_v2wb
+            ))]
+            {
+                regs.isr().modify(|w| w.set_wutf(false));
+                while !regs.isr().read().wutwf() {}
+            }
+
+            #[cfg(any(rtc_v3, rtc_v3u5, rtc_v3l5))]
+            {
+                regs.scr().write(|w| w.set_cwutf(Calrf::CLEAR));
+                while !regs.icsr().read().wutwf() {}
+            }
+
+            regs.cr().modify(|w| w.set_wucksel(prescaler.into()));
+            regs.wutr().write(|w| w.set_wut(rtc_ticks));
+            regs.cr().modify(|w| w.set_wute(true));
+            regs.cr().modify(|w| w.set_wutie(true));
+        });
+
+        let instant = self.instant().unwrap();
+        trace!(
+            "rtc: start wakeup alarm for {} ms (psc: {}, ticks: {}) at {}",
+            Duration::from_ticks(rtc_ticks as u64 * TICK_HZ * prescaler as u64 / rtc_hz).as_millis(),
+            prescaler as u32,
+            rtc_ticks,
+            instant,
+        );
+
+        assert!(self.stop_time.borrow(cs).replace(Some(instant)).is_none())
+    }
+
+    /// stop the wakeup alarm and return the time elapsed since `start_wakeup_alarm`
+    /// was called, otherwise none
+    pub(crate) fn stop_wakeup_alarm(&self, cs: critical_section::CriticalSection) -> Option<embassy_time::Duration> {
+        use crate::interrupt::typelevel::Interrupt;
+        #[cfg(any(rtc_v3, rtc_v3u5, rtc_v3l5))]
+        use crate::pac::rtc::vals::Calrf;
+
+        let instant = self.instant().unwrap();
+        if RTC::regs().cr().read().wute() {
+            trace!("rtc: stop wakeup alarm at {}", instant);
+
+            self.write(false, |regs| {
+                regs.cr().modify(|w| w.set_wutie(false));
+                regs.cr().modify(|w| w.set_wute(false));
+
+                #[cfg(any(
+                    rtc_v2f0, rtc_v2f2, rtc_v2f3, rtc_v2f4, rtc_v2f7, rtc_v2h7, rtc_v2l0, rtc_v2l1, rtc_v2l4, rtc_v2wb
+                ))]
+                regs.isr().modify(|w| w.set_wutf(false));
+
+                #[cfg(any(rtc_v3, rtc_v3u5, rtc_v3l5))]
+                regs.scr().write(|w| w.set_cwutf(Calrf::CLEAR));
+
+                // Check RM for EXTI and/or NVIC section, "Event event input mapping" or "EXTI interrupt/event mapping" or something similar,
+                // there is a table for every "Event input" / "EXTI Line".
+                // If you find the EXTI line related to "RTC wakeup" marks as "Configurable" (not "Direct"),
+                // then write 1 to related field of Pending Register, to clean it's pending state.
+                #[cfg(any(exti_v1, stm32h7, stm32wb))]
+                crate::pac::EXTI
+                    .pr(0)
+                    .modify(|w| w.set_line(RTC::EXTI_WAKEUP_LINE, true));
+
+                <RTC as crate::rtc::SealedInstance>::WakeupInterrupt::unpend();
+            });
+        }
+
+        self.stop_time.borrow(cs).take().map(|stop_time| instant - stop_time)
+    }
+
+    pub(crate) fn enable_wakeup_line(&self) {
+        use crate::interrupt::typelevel::Interrupt;
+        use crate::pac::EXTI;
+
+        <RTC as crate::rtc::SealedInstance>::WakeupInterrupt::unpend();
+        unsafe { <RTC as crate::rtc::SealedInstance>::WakeupInterrupt::enable() };
+
+        EXTI.rtsr(0).modify(|w| w.set_line(RTC::EXTI_WAKEUP_LINE, true));
+        EXTI.imr(0).modify(|w| w.set_line(RTC::EXTI_WAKEUP_LINE, true));
+    }
+}

--- a/embassy-stm32/src/rtc/mod.rs
+++ b/embassy-stm32/src/rtc/mod.rs
@@ -320,7 +320,7 @@ impl Rtc {
     /// The registers retain their values during wakes from standby mode or system resets. They also
     /// retain their value when Vdd is switched off as long as V_BAT is powered.
     pub fn read_backup_register(&self, register: usize) -> Option<u32> {
-        RTC::read_backup_register(&RTC::regs(), register)
+        RTC::read_backup_register(RTC::regs(), register)
     }
 
     /// Set content of the backup register.
@@ -328,7 +328,7 @@ impl Rtc {
     /// The registers retain their values during wakes from standby mode or system resets. They also
     /// retain their value when Vdd is switched off as long as V_BAT is powered.
     pub fn write_backup_register(&self, register: usize, value: u32) {
-        RTC::write_backup_register(&RTC::regs(), register, value)
+        RTC::write_backup_register(RTC::regs(), register, value)
     }
 
     #[cfg(feature = "low-power")]
@@ -482,13 +482,13 @@ trait SealedInstance {
     ///
     /// The registers retain their values during wakes from standby mode or system resets. They also
     /// retain their value when Vdd is switched off as long as V_BAT is powered.
-    fn read_backup_register(rtc: &crate::pac::rtc::Rtc, register: usize) -> Option<u32>;
+    fn read_backup_register(rtc: crate::pac::rtc::Rtc, register: usize) -> Option<u32>;
 
     /// Set content of the backup register.
     ///
     /// The registers retain their values during wakes from standby mode or system resets. They also
     /// retain their value when Vdd is switched off as long as V_BAT is powered.
-    fn write_backup_register(rtc: &crate::pac::rtc::Rtc, register: usize, value: u32);
+    fn write_backup_register(rtc: crate::pac::rtc::Rtc, register: usize, value: u32);
 
     // fn apply_config(&mut self, rtc_config: RtcConfig);
 }

--- a/embassy-stm32/src/rtc/mod.rs
+++ b/embassy-stm32/src/rtc/mod.rs
@@ -2,6 +2,9 @@
 mod datetime;
 
 #[cfg(feature = "low-power")]
+mod low_power;
+
+#[cfg(feature = "low-power")]
 use core::cell::Cell;
 
 #[cfg(feature = "low-power")]
@@ -9,8 +12,6 @@ use embassy_sync::blocking_mutex::raw::CriticalSectionRawMutex;
 #[cfg(feature = "low-power")]
 use embassy_sync::blocking_mutex::Mutex;
 
-#[cfg(not(rtc_v2f2))]
-use self::datetime::RtcInstant;
 use self::datetime::{day_of_week_from_u8, day_of_week_to_u8};
 pub use self::datetime::{DateTime, DayOfWeek, Error as DateTimeError};
 use crate::pac::rtc::regs::{Dr, Tr};
@@ -32,60 +33,6 @@ use embassy_hal_internal::Peripheral;
 
 use crate::peripherals::RTC;
 
-#[allow(dead_code)]
-#[repr(u8)]
-#[derive(Clone, Copy, Debug)]
-pub(crate) enum WakeupPrescaler {
-    Div2 = 2,
-    Div4 = 4,
-    Div8 = 8,
-    Div16 = 16,
-}
-
-#[cfg(any(stm32f4, stm32l0, stm32g4, stm32l5, stm32wb, stm32h5, stm32g0))]
-impl From<WakeupPrescaler> for crate::pac::rtc::vals::Wucksel {
-    fn from(val: WakeupPrescaler) -> Self {
-        use crate::pac::rtc::vals::Wucksel;
-
-        match val {
-            WakeupPrescaler::Div2 => Wucksel::DIV2,
-            WakeupPrescaler::Div4 => Wucksel::DIV4,
-            WakeupPrescaler::Div8 => Wucksel::DIV8,
-            WakeupPrescaler::Div16 => Wucksel::DIV16,
-        }
-    }
-}
-
-#[cfg(any(stm32f4, stm32l0, stm32g4, stm32l5, stm32wb, stm32h5, stm32g0))]
-impl From<crate::pac::rtc::vals::Wucksel> for WakeupPrescaler {
-    fn from(val: crate::pac::rtc::vals::Wucksel) -> Self {
-        use crate::pac::rtc::vals::Wucksel;
-
-        match val {
-            Wucksel::DIV2 => WakeupPrescaler::Div2,
-            Wucksel::DIV4 => WakeupPrescaler::Div4,
-            Wucksel::DIV8 => WakeupPrescaler::Div8,
-            Wucksel::DIV16 => WakeupPrescaler::Div16,
-            _ => unreachable!(),
-        }
-    }
-}
-
-#[cfg(feature = "low-power")]
-impl WakeupPrescaler {
-    pub fn compute_min(val: u32) -> Self {
-        *[
-            WakeupPrescaler::Div2,
-            WakeupPrescaler::Div4,
-            WakeupPrescaler::Div8,
-            WakeupPrescaler::Div16,
-        ]
-        .iter()
-        .find(|psc| **psc as u32 > val)
-        .unwrap_or(&WakeupPrescaler::Div16)
-    }
-}
-
 /// Errors that can occur on methods on [RtcClock]
 #[non_exhaustive]
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -106,15 +53,6 @@ pub struct RtcTimeProvider {
 }
 
 impl RtcTimeProvider {
-    #[cfg(not(rtc_v2f2))]
-    pub(crate) fn instant(&self) -> Result<RtcInstant, RtcError> {
-        self.read(|_, tr, ss| {
-            let second = bcd2_to_byte((tr.st(), tr.su()));
-
-            RtcInstant::from(second, ss).map_err(RtcError::InvalidDateTime)
-        })
-    }
-
     /// Return the current datetime.
     ///
     /// # Errors
@@ -165,8 +103,7 @@ impl RtcTimeProvider {
 /// RTC driver.
 pub struct Rtc {
     #[cfg(feature = "low-power")]
-    stop_time: Mutex<CriticalSectionRawMutex, Cell<Option<RtcInstant>>>,
-    #[cfg(not(feature = "low-power"))]
+    stop_time: Mutex<CriticalSectionRawMutex, Cell<Option<low_power::RtcInstant>>>,
     _private: (),
 }
 
@@ -210,7 +147,6 @@ impl Rtc {
         let mut this = Self {
             #[cfg(feature = "low-power")]
             stop_time: Mutex::const_new(CriticalSectionRawMutex::new(), Cell::new(None)),
-            #[cfg(not(feature = "low-power"))]
             _private: (),
         };
 
@@ -223,9 +159,8 @@ impl Rtc {
         // Wait for the clock to update after initialization
         #[cfg(not(rtc_v2f2))]
         {
-            let now = this.instant().unwrap();
-
-            while this.instant().unwrap().subsecond == now.subsecond {}
+            let now = this.time_provider().read(|_, _, ss| Ok(ss)).unwrap();
+            while now == this.time_provider().read(|_, _, ss| Ok(ss)).unwrap() {}
         }
 
         this
@@ -284,12 +219,6 @@ impl Rtc {
         Ok(())
     }
 
-    #[cfg(not(rtc_v2f2))]
-    /// Return the current instant.
-    fn instant(&self) -> Result<RtcInstant, RtcError> {
-        self.time_provider().instant()
-    }
-
     /// Return the current datetime.
     ///
     /// # Errors
@@ -329,119 +258,6 @@ impl Rtc {
     /// retain their value when Vdd is switched off as long as V_BAT is powered.
     pub fn write_backup_register(&self, register: usize, value: u32) {
         RTC::write_backup_register(RTC::regs(), register, value)
-    }
-
-    #[cfg(feature = "low-power")]
-    /// start the wakeup alarm and with a duration that is as close to but less than
-    /// the requested duration, and record the instant the wakeup alarm was started
-    pub(crate) fn start_wakeup_alarm(
-        &self,
-        requested_duration: embassy_time::Duration,
-        cs: critical_section::CriticalSection,
-    ) {
-        use embassy_time::{Duration, TICK_HZ};
-
-        #[cfg(any(rtc_v3, rtc_v3u5, rtc_v3l5))]
-        use crate::pac::rtc::vals::Calrf;
-
-        // Panic if the rcc mod knows we're not using low-power rtc
-        #[cfg(any(rcc_wb, rcc_f4, rcc_f410))]
-        unsafe { crate::rcc::get_freqs() }.rtc.unwrap();
-
-        let requested_duration = requested_duration.as_ticks().clamp(0, u32::MAX as u64);
-        let rtc_hz = Self::frequency().0 as u64;
-        let rtc_ticks = requested_duration * rtc_hz / TICK_HZ;
-        let prescaler = WakeupPrescaler::compute_min((rtc_ticks / u16::MAX as u64) as u32);
-
-        // adjust the rtc ticks to the prescaler and subtract one rtc tick
-        let rtc_ticks = rtc_ticks / prescaler as u64;
-        let rtc_ticks = rtc_ticks.clamp(0, (u16::MAX - 1) as u64).saturating_sub(1) as u16;
-
-        self.write(false, |regs| {
-            regs.cr().modify(|w| w.set_wute(false));
-
-            #[cfg(any(
-                rtc_v2f0, rtc_v2f2, rtc_v2f3, rtc_v2f4, rtc_v2f7, rtc_v2h7, rtc_v2l0, rtc_v2l1, rtc_v2l4, rtc_v2wb
-            ))]
-            {
-                regs.isr().modify(|w| w.set_wutf(false));
-                while !regs.isr().read().wutwf() {}
-            }
-
-            #[cfg(any(rtc_v3, rtc_v3u5, rtc_v3l5))]
-            {
-                regs.scr().write(|w| w.set_cwutf(Calrf::CLEAR));
-                while !regs.icsr().read().wutwf() {}
-            }
-
-            regs.cr().modify(|w| w.set_wucksel(prescaler.into()));
-            regs.wutr().write(|w| w.set_wut(rtc_ticks));
-            regs.cr().modify(|w| w.set_wute(true));
-            regs.cr().modify(|w| w.set_wutie(true));
-        });
-
-        let instant = self.instant().unwrap();
-        trace!(
-            "rtc: start wakeup alarm for {} ms (psc: {}, ticks: {}) at {}",
-            Duration::from_ticks(rtc_ticks as u64 * TICK_HZ * prescaler as u64 / rtc_hz).as_millis(),
-            prescaler as u32,
-            rtc_ticks,
-            instant,
-        );
-
-        assert!(self.stop_time.borrow(cs).replace(Some(instant)).is_none())
-    }
-
-    #[cfg(feature = "low-power")]
-    /// stop the wakeup alarm and return the time elapsed since `start_wakeup_alarm`
-    /// was called, otherwise none
-    pub(crate) fn stop_wakeup_alarm(&self, cs: critical_section::CriticalSection) -> Option<embassy_time::Duration> {
-        use crate::interrupt::typelevel::Interrupt;
-        #[cfg(any(rtc_v3, rtc_v3u5, rtc_v3l5))]
-        use crate::pac::rtc::vals::Calrf;
-
-        let instant = self.instant().unwrap();
-        if RTC::regs().cr().read().wute() {
-            trace!("rtc: stop wakeup alarm at {}", instant);
-
-            self.write(false, |regs| {
-                regs.cr().modify(|w| w.set_wutie(false));
-                regs.cr().modify(|w| w.set_wute(false));
-
-                #[cfg(any(
-                    rtc_v2f0, rtc_v2f2, rtc_v2f3, rtc_v2f4, rtc_v2f7, rtc_v2h7, rtc_v2l0, rtc_v2l1, rtc_v2l4, rtc_v2wb
-                ))]
-                regs.isr().modify(|w| w.set_wutf(false));
-
-                #[cfg(any(rtc_v3, rtc_v3u5, rtc_v3l5))]
-                regs.scr().write(|w| w.set_cwutf(Calrf::CLEAR));
-
-                // Check RM for EXTI and/or NVIC section, "Event event input mapping" or "EXTI interrupt/event mapping" or something similar,
-                // there is a table for every "Event input" / "EXTI Line".
-                // If you find the EXTI line related to "RTC wakeup" marks as "Configurable" (not "Direct"),
-                // then write 1 to related field of Pending Register, to clean it's pending state.
-                #[cfg(any(exti_v1, stm32h7, stm32wb))]
-                crate::pac::EXTI
-                    .pr(0)
-                    .modify(|w| w.set_line(RTC::EXTI_WAKEUP_LINE, true));
-
-                <RTC as crate::rtc::SealedInstance>::WakeupInterrupt::unpend();
-            });
-        }
-
-        self.stop_time.borrow(cs).take().map(|stop_time| instant - stop_time)
-    }
-
-    #[cfg(feature = "low-power")]
-    pub(crate) fn enable_wakeup_line(&self) {
-        use crate::interrupt::typelevel::Interrupt;
-        use crate::pac::EXTI;
-
-        <RTC as crate::rtc::SealedInstance>::WakeupInterrupt::unpend();
-        unsafe { <RTC as crate::rtc::SealedInstance>::WakeupInterrupt::enable() };
-
-        EXTI.rtsr(0).modify(|w| w.set_line(RTC::EXTI_WAKEUP_LINE, true));
-        EXTI.imr(0).modify(|w| w.set_line(RTC::EXTI_WAKEUP_LINE, true));
     }
 }
 

--- a/embassy-stm32/src/rtc/v2.rs
+++ b/embassy-stm32/src/rtc/v2.rs
@@ -95,7 +95,7 @@ impl super::Rtc {
 
     pub(super) fn write<F, R>(&self, init_mode: bool, f: F) -> R
     where
-        F: FnOnce(&crate::pac::rtc::Rtc) -> R,
+        F: FnOnce(crate::pac::rtc::Rtc) -> R,
     {
         let r = RTC::regs();
         // Disable write protection.
@@ -112,7 +112,7 @@ impl super::Rtc {
             while !r.isr().read().initf() {}
         }
 
-        let result = f(&r);
+        let result = f(r);
 
         if init_mode {
             r.isr().modify(|w| w.set_init(false)); // Exits init mode
@@ -140,7 +140,7 @@ impl SealedInstance for crate::peripherals::RTC {
     #[cfg(all(feature = "low-power", stm32l0))]
     type WakeupInterrupt = crate::interrupt::typelevel::RTC;
 
-    fn read_backup_register(rtc: &Rtc, register: usize) -> Option<u32> {
+    fn read_backup_register(rtc: Rtc, register: usize) -> Option<u32> {
         if register < Self::BACKUP_REGISTER_COUNT {
             Some(rtc.bkpr(register).read().bkp())
         } else {
@@ -148,7 +148,7 @@ impl SealedInstance for crate::peripherals::RTC {
         }
     }
 
-    fn write_backup_register(rtc: &Rtc, register: usize, value: u32) {
+    fn write_backup_register(rtc: Rtc, register: usize, value: u32) {
         if register < Self::BACKUP_REGISTER_COUNT {
             rtc.bkpr(register).write(|w| w.set_bkp(value));
         }

--- a/embassy-stm32/src/rtc/v3.rs
+++ b/embassy-stm32/src/rtc/v3.rs
@@ -97,7 +97,7 @@ impl super::Rtc {
 
     pub(super) fn write<F, R>(&self, init_mode: bool, f: F) -> R
     where
-        F: FnOnce(&crate::pac::rtc::Rtc) -> R,
+        F: FnOnce(crate::pac::rtc::Rtc) -> R,
     {
         let r = RTC::regs();
         // Disable write protection.
@@ -112,7 +112,7 @@ impl super::Rtc {
             while !r.icsr().read().initf() {}
         }
 
-        let result = f(&r);
+        let result = f(r);
 
         if init_mode {
             r.icsr().modify(|w| w.set_init(false)); // Exits init mode
@@ -143,7 +143,7 @@ impl SealedInstance for crate::peripherals::RTC {
         }
     );
 
-    fn read_backup_register(_rtc: &Rtc, register: usize) -> Option<u32> {
+    fn read_backup_register(_rtc: Rtc, register: usize) -> Option<u32> {
         #[allow(clippy::if_same_then_else)]
         if register < Self::BACKUP_REGISTER_COUNT {
             //Some(rtc.bkpr()[register].read().bits())
@@ -153,7 +153,7 @@ impl SealedInstance for crate::peripherals::RTC {
         }
     }
 
-    fn write_backup_register(_rtc: &Rtc, register: usize, _value: u32) {
+    fn write_backup_register(_rtc: Rtc, register: usize, _value: u32) {
         if register < Self::BACKUP_REGISTER_COUNT {
             // RTC3 backup registers come from the TAMP peripheral, not RTC. Not() even in the L412 PAC
             //self.rtc.bkpr()[register].write(|w| w.bits(value))


### PR DESCRIPTION
- **stm32: remove pointer-to-pointer-to-registers.**
- **stm32/rtc: move lowpower stuff to a separate mod.**
