### PR TITLE
Remove more BXCAN generics.

### DIFF
--- a/embassy-stm32/src/can/bxcan/mod.rs
+++ b/embassy-stm32/src/can/bxcan/mod.rs
@@ -6,7 +6,7 @@ use core::marker::PhantomData;
 use core::task::Poll;
 
 use embassy_hal_internal::interrupt::InterruptExt;
-use embassy_hal_internal::{into_ref, PeripheralRef};
+use embassy_hal_internal::into_ref;
 use embassy_sync::blocking_mutex::raw::CriticalSectionRawMutex;
 use embassy_sync::channel::Channel;
 use embassy_sync::waitqueue::AtomicWaker;
@@ -91,11 +91,13 @@ impl<T: Instance> interrupt::typelevel::Handler<T::SCEInterrupt> for SceInterrup
 }
 
 /// Configuration proxy returned by [`Can::modify_config`].
-pub struct CanConfig<'a, T: Instance> {
-    can: PhantomData<&'a mut T>,
+pub struct CanConfig<'a> {
+    phantom: PhantomData<&'a ()>,
+    info: &'static Info,
+    periph_clock: crate::time::Hertz,
 }
 
-impl<T: Instance> CanConfig<'_, T> {
+impl CanConfig<'_> {
     /// Configures the bit timings.
     ///
     /// You can use <http://www.bittiming.can-wiki.info/> to calculate the `btr` parameter. Enter
@@ -109,7 +111,7 @@ impl<T: Instance> CanConfig<'_, T> {
     /// Then copy the `CAN_BUS_TIME` register value from the table and pass it as the `btr`
     /// parameter to this method.
     pub fn set_bit_timing(self, bt: crate::can::util::NominalBitTiming) -> Self {
-        Registers(T::regs()).set_bit_timing(bt);
+        self.info.regs.set_bit_timing(bt);
         self
     }
 
@@ -117,20 +119,20 @@ impl<T: Instance> CanConfig<'_, T> {
     ///
     /// This is a helper that internally calls `set_bit_timing()`[Self::set_bit_timing].
     pub fn set_bitrate(self, bitrate: u32) -> Self {
-        let bit_timing = util::calc_can_timings(T::frequency(), bitrate).unwrap();
+        let bit_timing = util::calc_can_timings(self.periph_clock, bitrate).unwrap();
         self.set_bit_timing(bit_timing)
     }
 
     /// Enables or disables loopback mode: Internally connects the TX and RX
     /// signals together.
     pub fn set_loopback(self, enabled: bool) -> Self {
-        Registers(T::regs()).set_loopback(enabled);
+        self.info.regs.set_loopback(enabled);
         self
     }
 
     /// Enables or disables silent mode: Disconnects the TX signal from the pin.
     pub fn set_silent(self, enabled: bool) -> Self {
-        Registers(T::regs()).set_silent(enabled);
+        self.info.regs.set_silent(enabled);
         self
     }
 
@@ -141,23 +143,24 @@ impl<T: Instance> CanConfig<'_, T> {
     ///
     /// Automatic retransmission is enabled by default.
     pub fn set_automatic_retransmit(self, enabled: bool) -> Self {
-        Registers(T::regs()).set_automatic_retransmit(enabled);
+        self.info.regs.set_automatic_retransmit(enabled);
         self
     }
 }
 
-impl<T: Instance> Drop for CanConfig<'_, T> {
+impl Drop for CanConfig<'_> {
     #[inline]
     fn drop(&mut self) {
-        Registers(T::regs()).leave_init_mode();
+        self.info.regs.leave_init_mode();
     }
 }
 
 /// CAN driver
-pub struct Can<'d, T: Instance> {
-    _peri: PeripheralRef<'d, T>,
+pub struct Can<'d> {
+    phantom: PhantomData<&'d ()>,
     info: &'static Info,
     state: &'static State,
+    periph_clock: crate::time::Hertz,
 }
 
 /// Error returned by `try_write`
@@ -168,11 +171,11 @@ pub enum TryWriteError {
     Full,
 }
 
-impl<'d, T: Instance> Can<'d, T> {
+impl<'d> Can<'d> {
     /// Creates a new Bxcan instance, keeping the peripheral in sleep mode.
     /// You must call [Can::enable_non_blocking] to use the peripheral.
-    pub fn new(
-        peri: impl Peripheral<P = T> + 'd,
+    pub fn new<T: Instance>(
+        _peri: impl Peripheral<P = T> + 'd,
         rx: impl Peripheral<P = impl RxPin<T>> + 'd,
         tx: impl Peripheral<P = impl TxPin<T>> + 'd,
         _irqs: impl interrupt::typelevel::Binding<T::TXInterrupt, TxInterruptHandler<T>>
@@ -181,7 +184,7 @@ impl<'d, T: Instance> Can<'d, T> {
             + interrupt::typelevel::Binding<T::SCEInterrupt, SceInterruptHandler<T>>
             + 'd,
     ) -> Self {
-        into_ref!(peri, rx, tx);
+        into_ref!(_peri, rx, tx);
         let info = T::info();
         let regs = &T::info().regs;
 
@@ -226,15 +229,16 @@ impl<'d, T: Instance> Can<'d, T> {
         Registers(T::regs()).leave_init_mode();
 
         Self {
-            _peri: peri,
+            phantom: PhantomData,
             info: T::info(),
             state: T::state(),
+            periph_clock: T::frequency(),
         }
     }
 
     /// Set CAN bit rate.
     pub fn set_bitrate(&mut self, bitrate: u32) {
-        let bit_timing = util::calc_can_timings(T::frequency(), bitrate).unwrap();
+        let bit_timing = util::calc_can_timings(self.periph_clock, bitrate).unwrap();
         self.modify_config().set_bit_timing(bit_timing);
     }
 
@@ -242,10 +246,14 @@ impl<'d, T: Instance> Can<'d, T> {
     ///
     /// Calling this method will enter initialization mode. You must enable the peripheral
     /// again afterwards with [`enable`](Self::enable).
-    pub fn modify_config(&mut self) -> CanConfig<'_, T> {
-        Registers(T::regs()).enter_init_mode();
+    pub fn modify_config(&mut self) -> CanConfig<'_> {
+        self.info.regs.enter_init_mode();
 
-        CanConfig { can: PhantomData }
+        CanConfig {
+            phantom: self.phantom,
+            info: self.info,
+            periph_clock: self.periph_clock,
+        }
     }
 
     /// Enables the peripheral and synchronizes with the bus.
@@ -253,7 +261,7 @@ impl<'d, T: Instance> Can<'d, T> {
     /// This will wait for 11 consecutive recessive bits (bus idle state).
     /// Contrary to enable method from bxcan library, this will not freeze the executor while waiting.
     pub async fn enable(&mut self) {
-        while Registers(T::regs()).enable_non_blocking().is_err() {
+        while self.info.regs.enable_non_blocking().is_err() {
             // SCE interrupt is only generated for entering sleep mode, but not leaving.
             // Yield to allow other tasks to execute while can bus is initializing.
             embassy_futures::yield_now().await;
@@ -263,7 +271,7 @@ impl<'d, T: Instance> Can<'d, T> {
     /// Enables or disables the peripheral from automatically wakeup when a SOF is detected on the bus
     /// while the peripheral is in sleep mode
     pub fn set_automatic_wakeup(&mut self, enabled: bool) {
-        Registers(T::regs()).set_automatic_wakeup(enabled);
+        self.info.regs.set_automatic_wakeup(enabled);
     }
 
     /// Manually wake the peripheral from sleep mode.
@@ -313,12 +321,12 @@ impl<'d, T: Instance> Can<'d, T> {
     ///
     /// FIFO scheduling is disabled by default.
     pub fn set_tx_fifo_scheduling(&mut self, enabled: bool) {
-        Registers(T::regs()).set_tx_fifo_scheduling(enabled)
+        self.info.regs.set_tx_fifo_scheduling(enabled)
     }
 
     /// Checks if FIFO scheduling of outgoing frames is enabled.
     pub fn tx_fifo_scheduling_enabled(&self) -> bool {
-        Registers(T::regs()).tx_fifo_scheduling_enabled()
+        self.info.regs.tx_fifo_scheduling_enabled()
     }
 
     /// Queues the message to be sent.
@@ -448,13 +456,13 @@ impl<'d, T: Instance> Can<'d, T> {
     }
 }
 
-impl<'d, T: FilterOwner> Can<'d, T> {
+impl<'d> Can<'d> {
     /// Accesses the filter banks owned by this CAN peripheral.
     ///
     /// To modify filters of a slave peripheral, `modify_filters` has to be called on the master
     /// peripheral instead.
-    pub fn modify_filters(&mut self) -> MasterFilters<'_, T> {
-        unsafe { MasterFilters::new(self.info.regs.0) }
+    pub fn modify_filters(&mut self) -> MasterFilters<'_> {
+        unsafe { MasterFilters::new(self.info) }
     }
 }
 
@@ -819,12 +827,14 @@ impl<'d, const RX_BUF_SIZE: usize> Drop for BufferedCanRx<'d, RX_BUF_SIZE> {
     }
 }
 
-impl<'d, T: Instance> Drop for Can<'d, T> {
+impl Drop for Can<'_> {
     fn drop(&mut self) {
         // Cannot call `free()` because it moves the instance.
         // Manually reset the peripheral.
-        T::regs().mcr().write(|w| w.set_reset(true));
-        rcc::disable::<T>();
+        self.info.regs.0.mcr().write(|w| w.set_reset(true));
+        self.info.regs.enter_init_mode();
+        self.info.regs.leave_init_mode();
+        //rcc::disable::<T>();
     }
 }
 
@@ -1031,6 +1041,11 @@ pub(crate) struct Info {
     rx1_interrupt: crate::interrupt::Interrupt,
     sce_interrupt: crate::interrupt::Interrupt,
     tx_waker: fn(),
+
+    /// The total number of filter banks available to the instance.
+    ///
+    /// This is usually either 14 or 28, and should be specified in the chip's reference manual or datasheet.
+    num_filter_banks: u8,
 }
 
 trait SealedInstance {
@@ -1095,6 +1110,7 @@ foreach_peripheral!(
                     rx1_interrupt: crate::_generated::peripheral_interrupts::$inst::RX1::IRQ,
                     sce_interrupt: crate::_generated::peripheral_interrupts::$inst::SCE::IRQ,
                     tx_waker: crate::_generated::peripheral_interrupts::$inst::TX::pend,
+                    num_filter_banks: peripherals::$inst::NUM_FILTER_BANKS,
                 };
                 &INFO
             }
@@ -1146,6 +1162,11 @@ foreach_peripheral!(
                 }
                 unsafe impl MasterInstance for peripherals::CAN1 {}
             }
+        }
+    };
+    (can, CAN2) => {
+        unsafe impl FilterOwner for peripherals::CAN2 {
+            const NUM_FILTER_BANKS: u8 = 0;
         }
     };
     (can, CAN3) => {

--- a/embassy-stm32/src/can/bxcan/registers.rs
+++ b/embassy-stm32/src/can/bxcan/registers.rs
@@ -11,7 +11,7 @@ use crate::can::frame::{Envelope, Frame, Header};
 pub(crate) struct Registers(pub crate::pac::can::Can);
 
 impl Registers {
-    pub fn enter_init_mode(&mut self) {
+    pub fn enter_init_mode(&self) {
         self.0.mcr().modify(|reg| {
             reg.set_sleep(false);
             reg.set_inrq(true);
@@ -25,7 +25,7 @@ impl Registers {
     }
 
     // Leaves initialization mode, enters sleep mode.
-    pub fn leave_init_mode(&mut self) {
+    pub fn leave_init_mode(&self) {
         self.0.mcr().modify(|reg| {
             reg.set_sleep(true);
             reg.set_inrq(false);
@@ -38,7 +38,7 @@ impl Registers {
         }
     }
 
-    pub fn set_bit_timing(&mut self, bt: crate::can::util::NominalBitTiming) {
+    pub fn set_bit_timing(&self, bt: crate::can::util::NominalBitTiming) {
         let prescaler = u16::from(bt.prescaler) & 0x1FF;
         let seg1 = u8::from(bt.seg1);
         let seg2 = u8::from(bt.seg2) & 0x7F;
@@ -84,7 +84,7 @@ impl Registers {
     /// receive the frame. If enabled, [`Interrupt::Wakeup`] will also be triggered by the incoming
     /// frame.
     #[allow(dead_code)]
-    pub fn set_automatic_wakeup(&mut self, enabled: bool) {
+    pub fn set_automatic_wakeup(&self, enabled: bool) {
         self.0.mcr().modify(|reg| reg.set_awum(enabled));
     }
 
@@ -96,7 +96,7 @@ impl Registers {
     /// If this returns [`WouldBlock`][nb::Error::WouldBlock], the peripheral will enable itself
     /// in the background. The peripheral is enabled and ready to use when this method returns
     /// successfully.
-    pub fn enable_non_blocking(&mut self) -> nb::Result<(), Infallible> {
+    pub fn enable_non_blocking(&self) -> nb::Result<(), Infallible> {
         let msr = self.0.msr().read();
         if msr.slak() {
             self.0.mcr().modify(|reg| {
@@ -186,7 +186,7 @@ impl Registers {
     /// If this is enabled, mailboxes are scheduled based on the time when the transmit request bit of the mailbox was set.
     ///
     /// If this is disabled, mailboxes are scheduled based on the priority of the frame in the mailbox.
-    pub fn set_tx_fifo_scheduling(&mut self, enabled: bool) {
+    pub fn set_tx_fifo_scheduling(&self, enabled: bool) {
         self.0.mcr().modify(|w| w.set_txfp(enabled))
     }
 

--- a/examples/stm32f7/src/bin/can.rs
+++ b/examples/stm32f7/src/bin/can.rs
@@ -45,7 +45,7 @@ async fn main(spawner: Spawner) {
     let rx_pin = Input::new(&mut p.PA15, Pull::Up);
     core::mem::forget(rx_pin);
 
-    static CAN: StaticCell<Can<'static, CAN3>> = StaticCell::new();
+    static CAN: StaticCell<Can<'static>> = StaticCell::new();
     let can = CAN.init(Can::new(p.CAN3, p.PA8, p.PA15, Irqs));
     can.modify_filters().enable_bank(0, Fifo::Fifo0, Mask32::accept_all());
 

--- a/tests/stm32/src/bin/can.rs
+++ b/tests/stm32/src/bin/can.rs
@@ -18,10 +18,6 @@ use {defmt_rtt as _, panic_probe as _};
 mod can_common;
 use can_common::*;
 
-type Can<'d> = embassy_stm32::can::Can<'d, embassy_stm32::peripherals::CAN1>;
-type CanTx<'d> = embassy_stm32::can::CanTx<'d>;
-type CanRx<'d> = embassy_stm32::can::CanRx<'d>;
-
 bind_interrupts!(struct Irqs {
     CAN1_RX0 => Rx0InterruptHandler<CAN1>;
     CAN1_RX1 => Rx1InterruptHandler<CAN1>;
@@ -50,7 +46,7 @@ async fn main(_spawner: Spawner) {
     let rx_pin = Input::new(&mut rx, Pull::Up);
     core::mem::forget(rx_pin);
 
-    let mut can = Can::new(can, rx, tx, Irqs);
+    let mut can = embassy_stm32::can::Can::new(can, rx, tx, Irqs);
 
     info!("Configuring can...");
 

--- a/tests/stm32/src/bin/can_common.rs
+++ b/tests/stm32/src/bin/can_common.rs
@@ -8,7 +8,7 @@ pub struct TestOptions {
     pub max_buffered: u8,
 }
 
-pub async fn run_can_tests<'d>(can: &mut crate::Can<'d>, options: &TestOptions) {
+pub async fn run_can_tests<'d>(can: &mut can::Can<'d>, options: &TestOptions) {
     //pub async fn run_can_tests<'d, T: can::Instance>(can: &mut can::Can<'d, T>, options: &TestOptions) {
     let mut i: u8 = 0;
     loop {
@@ -80,7 +80,7 @@ pub async fn run_can_tests<'d>(can: &mut crate::Can<'d>, options: &TestOptions) 
     }
 }
 
-pub async fn run_split_can_tests<'d>(tx: &mut crate::CanTx<'d>, rx: &mut crate::CanRx<'d>, options: &TestOptions) {
+pub async fn run_split_can_tests<'d>(tx: &mut can::CanTx<'d>, rx: &mut can::CanRx<'d>, options: &TestOptions) {
     for i in 0..options.max_buffered {
         // Try filling up the RX FIFO0 buffers
         //let tx_frame = if 0 != (i & 0x01) {

--- a/tests/stm32/src/bin/fdcan.rs
+++ b/tests/stm32/src/bin/fdcan.rs
@@ -15,10 +15,6 @@ use {defmt_rtt as _, panic_probe as _};
 mod can_common;
 use can_common::*;
 
-type Can<'d> = can::Can<'d>;
-type CanTx<'d> = can::CanTx<'d>;
-type CanRx<'d> = can::CanRx<'d>;
-
 bind_interrupts!(struct Irqs2 {
     FDCAN2_IT0 => can::IT0InterruptHandler<FDCAN2>;
     FDCAN2_IT1 => can::IT1InterruptHandler<FDCAN2>;


### PR DESCRIPTION
Remove the rest of the generics in BXCAN. This covers the non-split Can and CanConfig structs.