### PR TITLE
Fix STM32 SPI examples

### DIFF
--- a/examples/stm32f3/src/bin/spi_dma.rs
+++ b/examples/stm32f3/src/bin/spi_dma.rs
@@ -21,11 +21,17 @@ async fn main(_spawner: Spawner) {
 
     let mut spi = Spi::new(p.SPI1, p.PB3, p.PB5, p.PB4, p.DMA1_CH3, p.DMA1_CH2, spi_config);
 
+    let mut read_buffer = [0; 128];
+    let mut write_buffer = [0; 128];
+
     for n in 0u32.. {
         let mut write: String<128> = String::new();
-        let mut read = [0; 128];
         core::write!(&mut write, "Hello DMA World {}!\r\n", n).unwrap();
-        spi.transfer(&mut read[0..write.len()], write.as_bytes()).await.ok();
-        info!("read via spi+dma: {}", from_utf8(&read).unwrap());
+        let read_buffer = &mut read_buffer[..write.len()];
+        let write_buffer = &mut write_buffer[..write.len()];
+        write_buffer.clone_from_slice(write.as_bytes());
+
+        spi.transfer(read_buffer, write_buffer).await.ok();
+        info!("read via spi+dma: {}", from_utf8(read_buffer).unwrap());
     }
 }

--- a/examples/stm32f4/src/bin/spi_dma.rs
+++ b/examples/stm32f4/src/bin/spi_dma.rs
@@ -21,11 +21,17 @@ async fn main(_spawner: Spawner) {
 
     let mut spi = Spi::new(p.SPI1, p.PB3, p.PB5, p.PB4, p.DMA2_CH3, p.DMA2_CH2, spi_config);
 
+    let mut read_buffer = [0; 128];
+    let mut write_buffer = [0; 128];
+
     for n in 0u32.. {
         let mut write: String<128> = String::new();
-        let mut read = [0; 128];
         core::write!(&mut write, "Hello DMA World {}!\r\n", n).unwrap();
-        spi.transfer(&mut read[0..write.len()], write.as_bytes()).await.ok();
-        info!("read via spi+dma: {}", from_utf8(&read).unwrap());
+        let read_buffer = &mut read_buffer[..write.len()];
+        let write_buffer = &mut write_buffer[..write.len()];
+        write_buffer.clone_from_slice(write.as_bytes());
+
+        spi.transfer(read_buffer, write_buffer).await.ok();
+        info!("read via spi+dma: {}", from_utf8(read_buffer).unwrap());
     }
 }

--- a/examples/stm32h7/src/bin/spi_dma.rs
+++ b/examples/stm32h7/src/bin/spi_dma.rs
@@ -14,10 +14,13 @@ use heapless::String;
 use static_cell::StaticCell;
 use {defmt_rtt as _, panic_probe as _};
 
+#[link_section = ".ram_d3"]
+static mut RAM_D3: [u8; 256] = [0u8; 256];
+
 #[embassy_executor::task]
 async fn main_task(mut spi: spi::Spi<'static, Async>) {
-    let mut read_buffer = [0; 128];
-    let mut write_buffer = [0; 128];
+    let read_buffer = unsafe { &mut RAM_D3[0..128] };
+    let write_buffer = unsafe { &mut RAM_D3[128..256] };
 
     for n in 0u32.. {
         let mut write: String<128> = String::new();

--- a/examples/stm32h7/src/bin/spi_dma.rs
+++ b/examples/stm32h7/src/bin/spi_dma.rs
@@ -16,13 +16,18 @@ use {defmt_rtt as _, panic_probe as _};
 
 #[embassy_executor::task]
 async fn main_task(mut spi: spi::Spi<'static, Async>) {
+    let mut read_buffer = [0; 128];
+    let mut write_buffer = [0; 128];
+
     for n in 0u32.. {
         let mut write: String<128> = String::new();
-        let mut read = [0; 128];
         core::write!(&mut write, "Hello DMA World {}!\r\n", n).unwrap();
-        // transfer will slice the &mut read down to &write's actual length.
-        spi.transfer(&mut read, write.as_bytes()).await.ok();
-        info!("read via spi+dma: {}", from_utf8(&read).unwrap());
+        let read_buffer = &mut read_buffer[..write.len()];
+        let write_buffer = &mut write_buffer[..write.len()];
+        write_buffer.clone_from_slice(write.as_bytes());
+
+        spi.transfer(read_buffer, write_buffer).await.ok();
+        info!("read via spi+dma: {}", from_utf8(read_buffer).unwrap());
     }
 }
 

--- a/examples/stm32h7rs/src/bin/spi_dma.rs
+++ b/examples/stm32h7rs/src/bin/spi_dma.rs
@@ -16,13 +16,18 @@ use {defmt_rtt as _, panic_probe as _};
 
 #[embassy_executor::task]
 async fn main_task(mut spi: spi::Spi<'static, Async>) {
+    let mut read_buffer = [0; 128];
+    let mut write_buffer = [0; 128];
+
     for n in 0u32.. {
         let mut write: String<128> = String::new();
-        let mut read = [0; 128];
         core::write!(&mut write, "Hello DMA World {}!\r\n", n).unwrap();
-        // transfer will slice the &mut read down to &write's actual length.
-        spi.transfer(&mut read, write.as_bytes()).await.ok();
-        info!("read via spi+dma: {}", from_utf8(&read).unwrap());
+        let read_buffer = &mut read_buffer[..write.len()];
+        let write_buffer = &mut write_buffer[..write.len()];
+        write_buffer.clone_from_slice(write.as_bytes());
+
+        spi.transfer(read_buffer, write_buffer).await.ok();
+        info!("read via spi+dma: {}", from_utf8(read_buffer).unwrap());
     }
 }
 


### PR DESCRIPTION
In their current state, these examples fail with:

```
     ERROR panicked at /home/phoracek/.cargo/git/checkouts/embassy-9312dcb0ed774b29/5f8f867/embassy-stm32/src/spi/mod.rs:769:9:
     assertion `left == right` failed
       left: 128
      right: 20
```

It is due to `String::as_bytes` returning slice shrinked to the occupied size of the string.

With this change, these examples are aligned with the BDMA example, using read and write buffers.