### PR TITLE
stm32/spi: fix blocking_write on nosck spi.

### DIFF
--- a/tests/stm32/src/bin/spi.rs
+++ b/tests/stm32/src/bin/spi.rs
@@ -94,19 +94,11 @@ async fn main(_spawner: Spawner) {
     drop(spi);
 
     // Test tx-only nosck.
-    #[cfg(feature = "spi-v1")]
-    {
-        let mut spi = Spi::new_blocking_txonly_nosck(&mut spi_peri, &mut mosi, spi_config);
-        spi.blocking_transfer(&mut buf, &data).unwrap();
-        spi.blocking_transfer_in_place(&mut buf).unwrap();
-        spi.blocking_write(&buf).unwrap();
-        spi.blocking_read(&mut buf).unwrap();
-        spi.blocking_transfer::<u8>(&mut [], &[]).unwrap();
-        spi.blocking_transfer_in_place::<u8>(&mut []).unwrap();
-        spi.blocking_read::<u8>(&mut []).unwrap();
-        spi.blocking_write::<u8>(&[]).unwrap();
-        drop(spi);
-    }
+    let mut spi = Spi::new_blocking_txonly_nosck(&mut spi_peri, &mut mosi, spi_config);
+    spi.blocking_write(&buf).unwrap();
+    spi.blocking_write::<u8>(&[]).unwrap();
+    spi.blocking_write(&buf).unwrap();
+    drop(spi);
 
     info!("Test OK");
     cortex_m::asm::bkpt();

--- a/tests/stm32/src/bin/spi_dma.rs
+++ b/tests/stm32/src/bin/spi_dma.rs
@@ -132,19 +132,16 @@ async fn main(_spawner: Spawner) {
     drop(spi);
 
     // Test tx-only nosck.
-    #[cfg(feature = "spi-v1")]
-    {
-        let mut spi = Spi::new_txonly_nosck(&mut spi_peri, &mut mosi, &mut tx_dma, spi_config);
-        spi.blocking_write(&buf).unwrap();
-        spi.write(&buf).await.unwrap();
-        spi.blocking_write(&buf).unwrap();
-        spi.blocking_write(&buf).unwrap();
-        spi.write(&buf).await.unwrap();
-        spi.write(&buf).await.unwrap();
-        spi.write::<u8>(&[]).await.unwrap();
-        spi.blocking_write::<u8>(&[]).unwrap();
-        drop(spi);
-    }
+    let mut spi = Spi::new_txonly_nosck(&mut spi_peri, &mut mosi, &mut tx_dma, spi_config);
+    spi.blocking_write(&buf).unwrap();
+    spi.write(&buf).await.unwrap();
+    spi.blocking_write(&buf).unwrap();
+    spi.blocking_write(&buf).unwrap();
+    spi.write(&buf).await.unwrap();
+    spi.write(&buf).await.unwrap();
+    spi.write::<u8>(&[]).await.unwrap();
+    spi.blocking_write::<u8>(&[]).unwrap();
+    drop(spi);
 
     info!("Test OK");
     cortex_m::asm::bkpt();


### PR DESCRIPTION
Fixes #2902.
