### PR TITLE
add send_queue and recv_queue to embassy-net

### DIFF
--- a/embassy-net/src/tcp.rs
+++ b/embassy-net/src/tcp.rs
@@ -98,6 +98,13 @@ impl<'a> TcpReader<'a> {
     pub fn recv_capacity(&self) -> usize {
         self.io.recv_capacity()
     }
+
+    /// Return the amount of octets queued in the receive buffer. This value can be larger than
+    /// the slice read by the next `recv` or `peek` call because it includes all queued octets,
+    /// and not only the octets that may be returned as a contiguous slice.
+    pub fn recv_queue(&self) -> usize {
+        self.io.recv_queue()
+    }
 }
 
 impl<'a> TcpWriter<'a> {
@@ -132,6 +139,11 @@ impl<'a> TcpWriter<'a> {
     pub fn send_capacity(&self) -> usize {
         self.io.send_capacity()
     }
+
+    /// Return the amount of octets queued in the transmit buffer.
+    pub fn send_queue(&self) -> usize {
+        self.io.send_queue()
+    }
 }
 
 impl<'a> TcpSocket<'a> {
@@ -161,6 +173,18 @@ impl<'a> TcpSocket<'a> {
     /// Return the maximum number of bytes inside the transmit buffer.
     pub fn send_capacity(&self) -> usize {
         self.io.send_capacity()
+    }
+
+    /// Return the amount of octets queued in the transmit buffer.
+    pub fn send_queue(&self) -> usize {
+        self.io.send_queue()
+    }
+
+    /// Return the amount of octets queued in the receive buffer. This value can be larger than
+    /// the slice read by the next `recv` or `peek` call because it includes all queued octets,
+    /// and not only the octets that may be returned as a contiguous slice.
+    pub fn recv_queue(&self) -> usize {
+        self.io.recv_queue()
     }
 
     /// Call `f` with the largest contiguous slice of octets in the transmit buffer,
@@ -518,6 +542,14 @@ impl<'d> TcpIo<'d> {
 
     fn send_capacity(&self) -> usize {
         self.with(|s, _| s.send_capacity())
+    }
+
+    fn send_queue(&self) -> usize {
+        self.with(|s, _| s.send_queue())
+    }
+
+    fn recv_queue(&self) -> usize {
+        self.with(|s, _| s.recv_queue())
     }
 }
 


### PR DESCRIPTION
I need to know if queue is almost empty before sending low priority data.