### PR TITLE
embassy-sync: remove T: Send for Signal<M, T>

### DIFF
--- a/embassy-sync/src/signal.rs
+++ b/embassy-sync/src/signal.rs
@@ -65,7 +65,7 @@ where
     }
 }
 
-impl<M, T: Send> Signal<M, T>
+impl<M, T> Signal<M, T>
 where
     M: RawMutex,
 {


### PR DESCRIPTION
The tests all pass with this locally, and I've also tested it in a project using a `NoopRawMutex`.

Closes #3051 
