### PR TITLE
Add Clone and Copy to Error types

### DIFF
--- a/embassy-rp/src/i2c.rs
+++ b/embassy-rp/src/i2c.rs
@@ -12,7 +12,7 @@ use crate::interrupt::typelevel::{Binding, Interrupt};
 use crate::{interrupt, pac, peripherals, Peripheral};
 
 /// I2C error abort reason
-#[derive(Debug, PartialEq, Eq)]
+#[derive(Debug, PartialEq, Eq, Clone, Copy)]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub enum AbortReason {
     /// A bus operation was not acknowledged, e.g. due to the addressed device
@@ -28,7 +28,7 @@ pub enum AbortReason {
 }
 
 /// I2C error
-#[derive(Debug, PartialEq, Eq)]
+#[derive(Debug, PartialEq, Eq, Clone, Copy)]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub enum Error {
     /// I2C abort with error

--- a/embassy-rp/src/i2c_slave.rs
+++ b/embassy-rp/src/i2c_slave.rs
@@ -13,7 +13,7 @@ use crate::interrupt::typelevel::{Binding, Interrupt};
 use crate::{pac, Peripheral};
 
 /// I2C error
-#[derive(Debug, PartialEq, Eq)]
+#[derive(Debug, PartialEq, Eq, Clone, Copy)]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
 #[non_exhaustive]
 pub enum Error {

--- a/embassy-rp/src/rtc/datetime_chrono.rs
+++ b/embassy-rp/src/rtc/datetime_chrono.rs
@@ -10,7 +10,7 @@ pub type DayOfWeek = chrono::Weekday;
 /// Errors regarding the [`DateTime`] and [`DateTimeFilter`] structs.
 ///
 /// [`DateTimeFilter`]: struct.DateTimeFilter.html
-#[derive(Clone, Debug, PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum Error {
     /// The [DateTime] has an invalid year. The year must be between 0 and 4095.
     InvalidYear,

--- a/embassy-rp/src/rtc/datetime_no_deps.rs
+++ b/embassy-rp/src/rtc/datetime_no_deps.rs
@@ -3,7 +3,7 @@ use crate::pac::rtc::regs::{Rtc0, Rtc1, Setup0, Setup1};
 /// Errors regarding the [`DateTime`] and [`DateTimeFilter`] structs.
 ///
 /// [`DateTimeFilter`]: struct.DateTimeFilter.html
-#[derive(Clone, Debug, PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum Error {
     /// The [DateTime] contains an invalid year value. Must be between `0..=4095`.
     InvalidYear,

--- a/embassy-stm32/src/dsihost.rs
+++ b/embassy-stm32/src/dsihost.rs
@@ -388,7 +388,7 @@ impl<'d, T: Instance> DsiHost<'d, T> {
 
 /// Possible Error Types for DSI HOST
 #[non_exhaustive]
-#[derive(Debug)]
+#[derive(Debug, PartialEq, Eq, Clone, Copy)]
 pub enum Error {
     /// Waiting for FIFO empty flag timed out
     FifoTimeout,

--- a/embassy-stm32/src/i2c/mod.rs
+++ b/embassy-stm32/src/i2c/mod.rs
@@ -23,7 +23,7 @@ use crate::time::Hertz;
 use crate::{interrupt, peripherals};
 
 /// I2C error.
-#[derive(Debug, PartialEq, Eq)]
+#[derive(Debug, PartialEq, Eq, Copy, Clone)]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub enum Error {
     /// Bus error

--- a/embassy-stm32/src/rng.rs
+++ b/embassy-stm32/src/rng.rs
@@ -15,7 +15,7 @@ use crate::{interrupt, pac, peripherals, rcc, Peripheral};
 static RNG_WAKER: AtomicWaker = AtomicWaker::new();
 
 /// RNG error
-#[derive(Debug, PartialEq, Eq)]
+#[derive(Debug, PartialEq, Eq, Clone, Copy)]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub enum Error {
     /// Seed error.

--- a/embassy-stm32/src/sai/mod.rs
+++ b/embassy-stm32/src/sai/mod.rs
@@ -15,7 +15,7 @@ use crate::rcc::{self, RccPeripheral};
 use crate::{peripherals, Peripheral};
 
 /// SAI error
-#[derive(Debug, PartialEq, Eq)]
+#[derive(Debug, PartialEq, Eq, Clone, Copy)]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub enum Error {
     /// `write` called on a SAI in receive mode.

--- a/embassy-stm32/src/spi/mod.rs
+++ b/embassy-stm32/src/spi/mod.rs
@@ -18,7 +18,7 @@ use crate::time::Hertz;
 use crate::Peripheral;
 
 /// SPI error.
-#[derive(Debug, PartialEq, Eq)]
+#[derive(Debug, PartialEq, Eq, Clone, Copy)]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub enum Error {
     /// Invalid framing.

--- a/embassy-stm32/src/tsc/mod.rs
+++ b/embassy-stm32/src/tsc/mod.rs
@@ -83,7 +83,7 @@ const TSC_NUM_GROUPS: u32 = 7;
 const TSC_NUM_GROUPS: u32 = 8;
 
 /// Error type defined for TSC
-#[derive(Debug)]
+#[derive(Debug, Clone, Copy)]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub enum Error {
     /// Test error for TSC

--- a/embassy-sync/src/pubsub/mod.rs
+++ b/embassy-sync/src/pubsub/mod.rs
@@ -434,7 +434,7 @@ impl<T: Clone, const CAP: usize, const SUBS: usize, const PUBS: usize> PubSubSta
 }
 
 /// Error type for the [PubSubChannel]
-#[derive(Debug, PartialEq, Eq, Clone)]
+#[derive(Debug, PartialEq, Eq, Clone, Copy)]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub enum Error {
     /// All subscriber slots are used. To add another subscriber, first another subscriber must be dropped or


### PR DESCRIPTION
None of them these errors are `non-exaustative`, they are all small enough to be copy (I estimate none are larger than 4 bytes). All of them seem done and its not probable (to me) that large variants will be added in the future.