### PR TITLE
use nightly waker_getters APIs

### DIFF
--- a/embassy-executor/src/lib.rs
+++ b/embassy-executor/src/lib.rs
@@ -1,4 +1,5 @@
 #![cfg_attr(not(any(feature = "arch-std", feature = "arch-wasm")), no_std)]
+#![cfg_attr(feature = "nightly", feature(waker_getters))]
 #![allow(clippy::new_without_default)]
 #![doc = include_str!("../README.md")]
 #![warn(missing_docs)]

--- a/embassy-executor/src/raw/waker.rs
+++ b/embassy-executor/src/raw/waker.rs
@@ -31,46 +31,36 @@ pub(crate) unsafe fn from_task(p: TaskRef) -> Waker {
 /// # Panics
 ///
 /// Panics if the waker is not created by the Embassy executor.
-#[cfg(not(feature = "nightly"))]
 pub fn task_from_waker(waker: &Waker) -> TaskRef {
-    // safety: OK because WakerHack has the same layout as Waker.
-    // This is not really guaranteed because the structs are `repr(Rust)`, it is
-    // indeed the case in the current implementation.
-    // TODO use waker_getters when stable. https://github.com/rust-lang/rust/issues/96992
-    let hack: &WakerHack = unsafe { core::mem::transmute(waker) };
-    if hack.vtable != &VTABLE {
-        panic!("Found waker not created by the Embassy executor. `embassy_time::Timer` only works with the Embassy executor.")
+    #[cfg(not(feature = "nightly"))]
+    {
+        struct WakerHack {
+            data: *const (),
+            vtable: &'static RawWakerVTable,
+        }
+
+        // safety: OK because WakerHack has the same layout as Waker.
+        // This is not really guaranteed because the structs are `repr(Rust)`, it is
+        // indeed the case in the current implementation.
+        // TODO use waker_getters when stable. https://github.com/rust-lang/rust/issues/96992
+        let hack: &WakerHack = unsafe { core::mem::transmute(waker) };
+        if hack.vtable != &VTABLE {
+            panic!("Found waker not created by the Embassy executor. `embassy_time::Timer` only works with the Embassy executor.")
+        }
+
+        // safety: our wakers are always created with `TaskRef::as_ptr`
+        unsafe { TaskRef::from_ptr(hack.data as *const TaskHeader) }
     }
 
-    // safety: our wakers are always created with `TaskRef::as_ptr`
-    unsafe { TaskRef::from_ptr(hack.data as *const TaskHeader) }
-}
+    #[cfg(feature = "nightly")]
+    {
+        let raw_waker = waker.as_raw();
 
-#[cfg(not(feature = "nightly"))]
-struct WakerHack {
-    data: *const (),
-    vtable: &'static RawWakerVTable,
-}
+        if raw_waker.vtable() != &VTABLE {
+            panic!("Found waker not created by the Embassy executor. `embassy_time::Timer` only works with the Embassy executor.")
+        }
 
-/// Get a task pointer from a waker.
-///
-/// This can be used as an optimization in wait queues to store task pointers
-/// (1 word) instead of full Wakers (2 words). This saves a bit of RAM and helps
-/// avoid dynamic dispatch.
-///
-/// You can use the returned task pointer to wake the task with [`wake_task`](super::wake_task).
-///
-/// # Panics
-///
-/// Panics if the waker is not created by the Embassy executor.
-#[cfg(feature = "nightly")]
-pub fn task_from_waker(waker: &Waker) -> TaskRef {
-    let raw_waker = waker.as_raw();
-
-    if raw_waker.vtable() != &VTABLE {
-        panic!("Found waker not created by the Embassy executor. `embassy_time::Timer` only works with the Embassy executor.")
+        // safety: our wakers are always created with `TaskRef::as_ptr`
+        unsafe { TaskRef::from_ptr(raw_waker.data() as *const TaskHeader) }
     }
-
-    // safety: our wakers are always created with `TaskRef::as_ptr`
-    unsafe { TaskRef::from_ptr(raw_waker.data() as *const TaskHeader) }
 }

--- a/embassy-executor/src/raw/waker.rs
+++ b/embassy-executor/src/raw/waker.rs
@@ -1,4 +1,3 @@
-use core::mem;
 use core::task::{RawWaker, RawWakerVTable, Waker};
 
 use super::{wake_task, TaskHeader, TaskRef};
@@ -38,7 +37,7 @@ pub fn task_from_waker(waker: &Waker) -> TaskRef {
     // This is not really guaranteed because the structs are `repr(Rust)`, it is
     // indeed the case in the current implementation.
     // TODO use waker_getters when stable. https://github.com/rust-lang/rust/issues/96992
-    let hack: &WakerHack = unsafe { mem::transmute(waker) };
+    let hack: &WakerHack = unsafe { core::mem::transmute(waker) };
     if hack.vtable != &VTABLE {
         panic!("Found waker not created by the Embassy executor. `embassy_time::Timer` only works with the Embassy executor.")
     }

--- a/embassy-executor/src/raw/waker.rs
+++ b/embassy-executor/src/raw/waker.rs
@@ -32,6 +32,7 @@ pub(crate) unsafe fn from_task(p: TaskRef) -> Waker {
 /// # Panics
 ///
 /// Panics if the waker is not created by the Embassy executor.
+#[cfg(not(feature = "nightly"))]
 pub fn task_from_waker(waker: &Waker) -> TaskRef {
     // safety: OK because WakerHack has the same layout as Waker.
     // This is not really guaranteed because the structs are `repr(Rust)`, it is
@@ -46,7 +47,31 @@ pub fn task_from_waker(waker: &Waker) -> TaskRef {
     unsafe { TaskRef::from_ptr(hack.data as *const TaskHeader) }
 }
 
+#[cfg(not(feature = "nightly"))]
 struct WakerHack {
     data: *const (),
     vtable: &'static RawWakerVTable,
+}
+
+/// Get a task pointer from a waker.
+///
+/// This can be used as an optimization in wait queues to store task pointers
+/// (1 word) instead of full Wakers (2 words). This saves a bit of RAM and helps
+/// avoid dynamic dispatch.
+///
+/// You can use the returned task pointer to wake the task with [`wake_task`](super::wake_task).
+///
+/// # Panics
+///
+/// Panics if the waker is not created by the Embassy executor.
+#[cfg(feature = "nightly")]
+pub fn task_from_waker(waker: &Waker) -> TaskRef {
+    let raw_waker = waker.as_raw();
+
+    if raw_waker.vtable() != &VTABLE {
+        panic!("Found waker not created by the Embassy executor. `embassy_time::Timer` only works with the Embassy executor.")
+    }
+
+    // safety: our wakers are always created with `TaskRef::as_ptr`
+    unsafe { TaskRef::from_ptr(raw_waker.data() as *const TaskHeader) }
 }


### PR DESCRIPTION
Since https://github.com/rust-lang/rust/issues/96992 has stalled, to prevent potential unsoundness caused by transmuting to &WakerHack, we can use nightly waker_getters APIs by gating it behind nightly feature in embassy-executor without waiting for it to be stablized.