### PR TITLE
Make BDMA work in polled mode without interrupts

### DIFF
--- a/embassy-stm32/src/dma/dma_bdma.rs
+++ b/embassy-stm32/src/dma/dma_bdma.rs
@@ -495,7 +495,11 @@ impl AnyChannel {
                 let ch = r.ch(info.num);
                 let en = ch.cr().read().en();
                 let circular = ch.cr().read().circ();
-                let tcif = state.complete_count.load(Ordering::Acquire) != 0;
+                let isr = r.isr().read();
+                let cr = r.ch(info.num).cr();
+                let tcif =
+                    state.complete_count.load(Ordering::Acquire) != 0 || (isr.tcif(info.num) && cr.read().tcie());
+
                 en && (circular || !tcif)
             }
         }


### PR DESCRIPTION
During the initialization of an RTIC app it was noticed that the BDMA needed interrupts to operate. 
This PR fixes this which allows it to function in an interrupts-off environment with a polling executor.

Basically to allow the use of `block_on` while initializing an RTIC app.

The condition is used in two places now, however when in interrupt driven mode it uses the original one and in polling mode it uses the new one.
Maybe one should break out the check to not write this twice.