### PR TITLE
fix docu typos, linker addr example

### DIFF
--- a/docs/pages/getting_started.adoc
+++ b/docs/pages/getting_started.adoc
@@ -131,7 +131,10 @@ If you’re using a raspberry pi pico-w, make sure you’re running `+cargo run 
 
 If you’re using an rp2040 debug probe (e.g. the pico probe) and are having issues after running `probe-rs info`, unplug and reconnect the probe, letting it power cycle. Running `probe-rs info` is link:https://github.com/probe-rs/probe-rs/issues/1849[known to put the pico probe into an unusable state].
 
-If you’re still having problems, check the link:https://embassy.dev/book/#_frequently_asked_questions[FAQ], or ask for help in the link:https://matrix.to/#/#embassy-rs:matrix.org[Embassy Chat Room].
+:embassy-dev-faq-link-with-hash: https://embassy.dev/book/#_frequently_asked_questions
+:embassy-matrix-channel: https://matrix.to/#/#embassy-rs:matrix.org
+
+If you’re still having problems, check the {embassy-dev-faq-link-with-hash}[FAQ], or ask for help in the {embassy-matrix-channel}[Embassy Chat Room].
 
 == What's next?
 

--- a/embassy-boot-stm32/Cargo.toml
+++ b/embassy-boot-stm32/Cargo.toml
@@ -13,7 +13,7 @@ categories = [
 ]
 
 [package.metadata.embassy_docs]
-src_base = "https://github.com/embassy-rs/embassy/blob/embassy-boot-nrf-v$VERSION/embassy-boot-stm32/src/"
+src_base = "https://github.com/embassy-rs/embassy/blob/embassy-boot-stm32-v$VERSION/embassy-boot-stm32/src/"
 src_base_git = "https://github.com/embassy-rs/embassy/blob/$COMMIT/embassy-boot-stm32/src/"
 features = ["embassy-stm32/stm32f429zi"]
 target = "thumbv7em-none-eabi"

--- a/embassy-stm32/README.md
+++ b/embassy-stm32/README.md
@@ -35,4 +35,4 @@ This crate can run on any executor.
 Optionally, some features requiring [`embassy-time`](https://crates.io/crates/embassy-time) can be activated with the `time` feature. If you enable it,
 you must link an `embassy-time` driver in your project.
 
-The `low-power` feature integrates specifically with `embassy-executor`, it can't be ued on other executors for now.
+The `low-power` feature integrates specifically with `embassy-executor`, it can't be used on other executors for now.

--- a/examples/boot/bootloader/stm32/memory.x
+++ b/examples/boot/bootloader/stm32/memory.x
@@ -2,7 +2,7 @@ MEMORY
 {
   /* NOTE 1 K = 1 KiBi = 1024 bytes */
   FLASH                             : ORIGIN = 0x08000000, LENGTH = 24K
-  BOOTLOADER_STATE                  : ORIGIN = 0x08006000, LENGTH = 4K
+  BOOTLOADER_STATE                  : ORIGIN = 0x08006000, LENGTH = 8K
   ACTIVE                            : ORIGIN = 0x08008000, LENGTH = 32K
   DFU                               : ORIGIN = 0x08010000, LENGTH = 36K
   RAM                         (rwx) : ORIGIN = 0x20000000, LENGTH = 16K


### PR DESCRIPTION
This fixes a couple of typos, and adjusts memory range for bootloader example.

While the bootloader example is unlikely to be used alone - ./examples/boot/application/stm32h7/flash-boot.sh for example overwrites it temporarily with different file altogether, it might be less confusing to anyone wondering why the numbers don't match. 