### PR TITLE
Add missing word "pin" in rp pwm documentation

### DIFF
--- a/embassy-rp/src/pwm.rs
+++ b/embassy-rp/src/pwm.rs
@@ -129,7 +129,7 @@ impl<'d> Pwm<'d> {
         Self::new_inner(slice.number(), None, None, Pull::None, config, Divmode::DIV)
     }
 
-    /// Create PWM driver with a single 'a' as output.
+    /// Create PWM driver with a single 'a' pin as output.
     #[inline]
     pub fn new_output_a<T: Slice>(
         slice: impl Peripheral<P = T> + 'd,


### PR DESCRIPTION
It is confusing to read without. The corrected line reads like its 'b' pin counterpart (few lines below).