### PR TITLE
 probe-rs download 43439A0.bin --format bin deprecated

### DIFF
--- a/examples/rp/src/bin/wifi_ap_tcp_server.rs
+++ b/examples/rp/src/bin/wifi_ap_tcp_server.rs
@@ -46,8 +46,8 @@ async fn main(spawner: Spawner) {
 
     // To make flashing faster for development, you may want to flash the firmwares independently
     // at hardcoded addresses, instead of baking them into the program with `include_bytes!`:
-    //     probe-rs download 43439A0.bin --format bin --chip RP2040 --base-address 0x10100000
-    //     probe-rs download 43439A0_clm.bin --format bin --chip RP2040 --base-address 0x10140000
+    //     probe-rs download 43439A0.bin ---binary-format --chip RP2040 --base-address 0x10100000
+    //     probe-rs download 43439A0_clm.bin ---binary-format --chip RP2040 --base-address 0x10140000
     //let fw = unsafe { core::slice::from_raw_parts(0x10100000 as *const u8, 230321) };
     //let clm = unsafe { core::slice::from_raw_parts(0x10140000 as *const u8, 4752) };
 

--- a/examples/rp/src/bin/wifi_blinky.rs
+++ b/examples/rp/src/bin/wifi_blinky.rs
@@ -33,8 +33,8 @@ async fn main(spawner: Spawner) {
 
     // To make flashing faster for development, you may want to flash the firmwares independently
     // at hardcoded addresses, instead of baking them into the program with `include_bytes!`:
-    //     probe-rs download 43439A0.bin --format bin --chip RP2040 --base-address 0x10100000
-    //     probe-rs download 43439A0_clm.bin --format bin --chip RP2040 --base-address 0x10140000
+    //     probe-rs download 43439A0.bin ---binary-format --chip RP2040 --base-address 0x10100000
+    //     probe-rs download 43439A0_clm.bin ---binary-format --chip RP2040 --base-address 0x10140000
     //let fw = unsafe { core::slice::from_raw_parts(0x10100000 as *const u8, 230321) };
     //let clm = unsafe { core::slice::from_raw_parts(0x10140000 as *const u8, 4752) };
 

--- a/examples/rp/src/bin/wifi_scan.rs
+++ b/examples/rp/src/bin/wifi_scan.rs
@@ -43,8 +43,8 @@ async fn main(spawner: Spawner) {
 
     // To make flashing faster for development, you may want to flash the firmwares independently
     // at hardcoded addresses, instead of baking them into the program with `include_bytes!`:
-    //     probe-rs download 43439A0.bin --format bin --chip RP2040 --base-address 0x10100000
-    //     probe-rs download 43439A0_clm.bin --format bin --chip RP2040 --base-address 0x10140000
+    //     probe-rs download 43439A0.bin ---binary-format --chip RP2040 --base-address 0x10100000
+    //     probe-rs download 43439A0_clm.bin ---binary-format --chip RP2040 --base-address 0x10140000
     //let fw = unsafe { core::slice::from_raw_parts(0x10100000 as *const u8, 230321) };
     //let clm = unsafe { core::slice::from_raw_parts(0x10140000 as *const u8, 4752) };
 

--- a/examples/rp/src/bin/wifi_tcp_server.rs
+++ b/examples/rp/src/bin/wifi_tcp_server.rs
@@ -49,8 +49,8 @@ async fn main(spawner: Spawner) {
 
     // To make flashing faster for development, you may want to flash the firmwares independently
     // at hardcoded addresses, instead of baking them into the program with `include_bytes!`:
-    //     probe-rs download 43439A0.bin --format bin --chip RP2040 --base-address 0x10100000
-    //     probe-rs download 43439A0_clm.bin --format bin --chip RP2040 --base-address 0x10140000
+    //     probe-rs download 43439A0.bin ---binary-format --chip RP2040 --base-address 0x10100000
+    //     probe-rs download 43439A0_clm.bin ---binary-format --chip RP2040 --base-address 0x10140000
     //let fw = unsafe { core::slice::from_raw_parts(0x10100000 as *const u8, 230321) };
     //let clm = unsafe { core::slice::from_raw_parts(0x10140000 as *const u8, 4752) };
 

--- a/tests/rp/src/bin/cyw43-perf.rs
+++ b/tests/rp/src/bin/cyw43-perf.rs
@@ -45,8 +45,8 @@ async fn main(spawner: Spawner) {
     }
 
     // cyw43 firmware needs to be flashed manually:
-    //     probe-rs download 43439A0.bin     --format bin --chip RP2040 --base-address 0x101b0000
-    //     probe-rs download 43439A0_clm.bin --format bin --chip RP2040 --base-address 0x101f8000
+    //     probe-rs download 43439A0.bin     ---binary-format --chip RP2040 --base-address 0x101b0000
+    //     probe-rs download 43439A0_clm.bin ---binary-format --chip RP2040 --base-address 0x101f8000
     let fw = unsafe { core::slice::from_raw_parts(0x101b0000 as *const u8, 230321) };
     let clm = unsafe { core::slice::from_raw_parts(0x101f8000 as *const u8, 4752) };
 


### PR DESCRIPTION
probe-rs download 43439A0.bin --format bin --chip RP2040 --base-address 0x10100000
-->
Error: --format has been renamed to --binary-format. Please use --binary-format bin instead of --format bin