### PR TITLE
Add examples for stm32g0

### DIFF
--- a/examples/stm32g0/Cargo.toml
+++ b/examples/stm32g0/Cargo.toml
@@ -23,5 +23,7 @@ panic-probe = { version = "0.3", features = ["print-defmt"] }
 heapless = { version = "0.8", default-features = false }
 portable-atomic = { version = "1.5", features = ["unsafe-assume-single-core"] }
 
+embedded-io-async = { version = "0.6.1" }
+
 [profile.release]
 debug = 2

--- a/examples/stm32g0/Cargo.toml
+++ b/examples/stm32g0/Cargo.toml
@@ -8,7 +8,7 @@ license = "MIT OR Apache-2.0"
 # Change stm32g0b1re to your chip name, if necessary.
 embassy-stm32 = { version = "0.1.0", path = "../../embassy-stm32", features = [ "defmt", "time-driver-any", "stm32g0b1re", "memory-x", "unstable-pac", "exti"]  }
 embassy-sync = { version = "0.6.0", path = "../../embassy-sync", features = ["defmt"] }
-embassy-executor = { version = "0.5.0", path = "../../embassy-executor", features = ["arch-cortex-m", "executor-thread", "defmt", "integrated-timers"] }
+embassy-executor = { version = "0.5.0", path = "../../embassy-executor", features = ["arch-cortex-m", "executor-thread", "executor-interrupt", "defmt", "integrated-timers"] }
 embassy-time = { version = "0.3.1", path = "../../embassy-time", features = ["defmt", "defmt-timestamp-uptime", "tick-hz-32_768"] }
 embassy-usb = { version = "0.2.0", path = "../../embassy-usb", default-features = false, features = ["defmt"] }
 embassy-futures = { version = "0.1.0", path = "../../embassy-futures" }
@@ -24,6 +24,7 @@ heapless = { version = "0.8", default-features = false }
 portable-atomic = { version = "1.5", features = ["unsafe-assume-single-core"] }
 
 embedded-io-async = { version = "0.6.1" }
+static_cell = { version = "2" }
 
 [profile.release]
 debug = 2

--- a/examples/stm32g0/src/bin/adc.rs
+++ b/examples/stm32g0/src/bin/adc.rs
@@ -1,0 +1,36 @@
+#![no_std]
+#![no_main]
+
+use defmt::*;
+use embassy_executor::Spawner;
+use embassy_stm32::adc::{Adc, SampleTime};
+use embassy_stm32::peripherals::ADC1;
+use embassy_stm32::{adc, bind_interrupts};
+use embassy_time::Timer;
+use {defmt_rtt as _, panic_probe as _};
+
+#[embassy_executor::main]
+async fn main(_spawner: Spawner) {
+    let p = embassy_stm32::init(Default::default());
+    info!("Hello World!");
+
+    let mut adc = Adc::new(p.ADC1);
+    adc.set_sample_time(SampleTime::CYCLES79_5);
+    let mut pin = p.PA1;
+
+    let mut vrefint = adc.enable_vrefint();
+    let vrefint_sample = adc.read(&mut vrefint);
+    let convert_to_millivolts = |sample| {
+        // From https://www.st.com/resource/en/datasheet/stm32g031g8.pdf
+        // 6.3.3 Embedded internal reference voltage
+        const VREFINT_MV: u32 = 1212; // mV
+
+        (u32::from(sample) * VREFINT_MV / u32::from(vrefint_sample)) as u16
+    };
+
+    loop {
+        let v = adc.read(&mut pin);
+        info!("--> {} - {} mV", v, convert_to_millivolts(v));
+        Timer::after_millis(100).await;
+    }
+}

--- a/examples/stm32g0/src/bin/adc.rs
+++ b/examples/stm32g0/src/bin/adc.rs
@@ -4,8 +4,6 @@
 use defmt::*;
 use embassy_executor::Spawner;
 use embassy_stm32::adc::{Adc, SampleTime};
-use embassy_stm32::peripherals::ADC1;
-use embassy_stm32::{adc, bind_interrupts};
 use embassy_time::Timer;
 use {defmt_rtt as _, panic_probe as _};
 

--- a/examples/stm32g0/src/bin/multiprio.rs
+++ b/examples/stm32g0/src/bin/multiprio.rs
@@ -146,6 +146,4 @@ fn main() -> ! {
     executor.run(|spawner| {
         unwrap!(spawner.spawn(run_low()));
     });
-    
-
 }

--- a/examples/stm32g0/src/bin/multiprio.rs
+++ b/examples/stm32g0/src/bin/multiprio.rs
@@ -1,0 +1,151 @@
+//! This example showcases how to create multiple Executor instances to run tasks at
+//! different priority levels.
+//!
+//! Low priority executor runs in thread mode (not interrupt), and uses `sev` for signaling
+//! there's work in the queue, and `wfe` for waiting for work.
+//!
+//! Medium and high priority executors run in two interrupts with different priorities.
+//! Signaling work is done by pending the interrupt. No "waiting" needs to be done explicitly, since
+//! when there's work the interrupt will trigger and run the executor.
+//!
+//! Sample output below. Note that high priority ticks can interrupt everything else, and
+//! medium priority computations can interrupt low priority computations, making them to appear
+//! to take significantly longer time.
+//!
+//! ```not_rust
+//!     [med] Starting long computation
+//!     [med] done in 992 ms
+//!         [high] tick!
+//! [low] Starting long computation
+//!     [med] Starting long computation
+//!         [high] tick!
+//!         [high] tick!
+//!     [med] done in 993 ms
+//!     [med] Starting long computation
+//!         [high] tick!
+//!         [high] tick!
+//!     [med] done in 993 ms
+//! [low] done in 3972 ms
+//!     [med] Starting long computation
+//!         [high] tick!
+//!         [high] tick!
+//!     [med] done in 993 ms
+//! ```
+//!
+//! For comparison, try changing the code so all 3 tasks get spawned on the low priority executor.
+//! You will get an output like the following. Note that no computation is ever interrupted.
+//!
+//! ```not_rust
+//!         [high] tick!
+//!     [med] Starting long computation
+//!     [med] done in 496 ms
+//! [low] Starting long computation
+//! [low] done in 992 ms
+//!     [med] Starting long computation
+//!     [med] done in 496 ms
+//!         [high] tick!
+//! [low] Starting long computation
+//! [low] done in 992 ms
+//!         [high] tick!
+//!     [med] Starting long computation
+//!     [med] done in 496 ms
+//!         [high] tick!
+//! ```
+//!
+
+#![no_std]
+#![no_main]
+
+use cortex_m_rt::entry;
+use defmt::*;
+use embassy_executor::{Executor, InterruptExecutor};
+use embassy_stm32::interrupt;
+use embassy_stm32::interrupt::{InterruptExt, Priority};
+use embassy_time::{Instant, Timer};
+use static_cell::StaticCell;
+use {defmt_rtt as _, panic_probe as _};
+
+#[embassy_executor::task]
+async fn run_high() {
+    loop {
+        // info!("        [high] tick!");
+        Timer::after_ticks(27374).await;
+    }
+}
+
+#[embassy_executor::task]
+async fn run_med() {
+    loop {
+        let start = Instant::now();
+        info!("    [med] Starting long computation");
+
+        // Spin-wait to simulate a long CPU computation
+        embassy_time::block_for(embassy_time::Duration::from_secs(1)); // ~1 second
+
+        let end = Instant::now();
+        let ms = end.duration_since(start).as_ticks() / 33;
+        info!("    [med] done in {} ms", ms);
+
+        Timer::after_ticks(23421).await;
+    }
+}
+
+#[embassy_executor::task]
+async fn run_low() {
+    loop {
+        let start = Instant::now();
+        info!("[low] Starting long computation");
+
+        // Spin-wait to simulate a long CPU computation
+        embassy_time::block_for(embassy_time::Duration::from_secs(2)); // ~2 seconds
+
+        let end = Instant::now();
+        let ms = end.duration_since(start).as_ticks() / 33;
+        info!("[low] done in {} ms", ms);
+
+        Timer::after_ticks(32983).await;
+    }
+}
+
+static EXECUTOR_HIGH: InterruptExecutor = InterruptExecutor::new();
+static EXECUTOR_MED: InterruptExecutor = InterruptExecutor::new();
+static EXECUTOR_LOW: StaticCell<Executor> = StaticCell::new();
+
+#[interrupt]
+unsafe fn USART1() {
+    EXECUTOR_HIGH.on_interrupt()
+}
+
+#[interrupt]
+unsafe fn USART2() {
+    EXECUTOR_MED.on_interrupt()
+}
+
+#[entry]
+fn main() -> ! {
+    // Initialize and create handle for devicer peripherals
+    let _p = embassy_stm32::init(Default::default());
+
+    // STM32s don’t have any interrupts exclusively for software use, but they can all be triggered by software as well as
+    // by the peripheral, so we can just use any free interrupt vectors which aren’t used by the rest of your application.
+    // In this case we’re using UART1 and UART2, but there’s nothing special about them. Any otherwise unused interrupt
+    // vector would work exactly the same.
+
+    // High-priority executor: USART1, priority level 6
+    interrupt::USART1.set_priority(Priority::P6);
+    let spawner = EXECUTOR_HIGH.start(interrupt::USART1);
+    unwrap!(spawner.spawn(run_high()));
+
+    // Medium-priority executor: USART2, priority level 7
+    interrupt::USART2.set_priority(Priority::P7);
+    let spawner = EXECUTOR_MED.start(interrupt::USART2);
+    unwrap!(spawner.spawn(run_med()));
+
+    // Low priority executor: runs in thread mode, using WFE/SEV
+    let executor = EXECUTOR_LOW.init(Executor::new());
+    executor.run(|spawner| {
+        unwrap!(spawner.spawn(run_low()));
+    });
+    
+
+}

--- a/examples/stm32g0/src/bin/rtc.rs
+++ b/examples/stm32g0/src/bin/rtc.rs
@@ -24,7 +24,7 @@ async fn main(_spawner: Spawner) {
     loop {
         let now: DateTime = rtc.now().unwrap().into();
 
-         info!("{}:{}:{}", now.hour(), now.minute(), now.second());
+        info!("{}:{}:{}", now.hour(), now.minute(), now.second());
 
         Timer::after_millis(1000).await;
     }

--- a/examples/stm32g0/src/bin/rtc.rs
+++ b/examples/stm32g0/src/bin/rtc.rs
@@ -1,0 +1,31 @@
+#![no_std]
+#![no_main]
+
+use defmt::*;
+use embassy_executor::Spawner;
+use embassy_stm32::rtc::{DateTime, DayOfWeek, Rtc, RtcConfig};
+use embassy_stm32::Config;
+use embassy_time::Timer;
+use {defmt_rtt as _, panic_probe as _};
+
+#[embassy_executor::main]
+async fn main(_spawner: Spawner) {
+    let config = Config::default();
+    let p = embassy_stm32::init(config);
+
+    info!("Hello World!");
+
+    let now = DateTime::from(2023, 6, 14, DayOfWeek::Friday, 15, 59, 10);
+
+    let mut rtc = Rtc::new(p.RTC, RtcConfig::default());
+
+    rtc.set_datetime(now.unwrap()).expect("datetime not set");
+
+    loop {
+        let now: DateTime = rtc.now().unwrap().into();
+
+         info!("{}:{}:{}", now.hour(), now.minute(), now.second());
+
+        Timer::after_millis(1000).await;
+    }
+}

--- a/examples/stm32g0/src/bin/usart.rs
+++ b/examples/stm32g0/src/bin/usart.rs
@@ -1,0 +1,25 @@
+#![no_std]
+#![no_main]
+
+use defmt::*;
+use embassy_stm32::usart::{Config, Uart};
+use {defmt_rtt as _, panic_probe as _};
+
+#[cortex_m_rt::entry]
+fn main() -> ! {
+    info!("Hello World!");
+
+    let p = embassy_stm32::init(Default::default());
+
+    let config = Config::default();
+    let mut usart = Uart::new_blocking(p.USART2, p.PA3, p.PA2, config).unwrap();
+
+    unwrap!(usart.blocking_write(b"Hello Embassy World!\r\n"));
+    info!("wrote Hello, starting echo");
+
+    let mut buf = [0u8; 1];
+    loop {
+        unwrap!(usart.blocking_read(&mut buf));
+        unwrap!(usart.blocking_write(&buf));
+    }
+}

--- a/examples/stm32g0/src/bin/usart_buffered.rs
+++ b/examples/stm32g0/src/bin/usart_buffered.rs
@@ -21,7 +21,16 @@ async fn main(_spawner: Spawner) {
     config.baudrate = 115200;
     let mut tx_buf = [0u8; 256];
     let mut rx_buf = [0u8; 256];
-    let mut usart = BufferedUart::new(p.USART1, Irqs, p.PB7, p.PB6, &mut tx_buf, &mut rx_buf, config).unwrap();
+    let mut usart = BufferedUart::new(
+        p.USART1,
+        Irqs,
+        p.PB7,
+        p.PB6,
+        &mut tx_buf,
+        &mut rx_buf,
+        config,
+    )
+    .unwrap();
 
     usart.write_all(b"Hello Embassy World!\r\n").await.unwrap();
     info!("wrote Hello, starting echo");

--- a/examples/stm32g0/src/bin/usart_buffered.rs
+++ b/examples/stm32g0/src/bin/usart_buffered.rs
@@ -1,0 +1,34 @@
+#![no_std]
+#![no_main]
+
+use defmt::*;
+use embassy_executor::Spawner;
+use embassy_stm32::usart::{BufferedUart, Config};
+use embassy_stm32::{bind_interrupts, peripherals, usart};
+use embedded_io_async::{Read, Write};
+use {defmt_rtt as _, panic_probe as _};
+
+bind_interrupts!(struct Irqs {
+    USART1 => usart::BufferedInterruptHandler<peripherals::USART1>;
+});
+
+#[embassy_executor::main]
+async fn main(_spawner: Spawner) {
+    let p = embassy_stm32::init(Default::default());
+    info!("Hi!");
+
+    let mut config = Config::default();
+    config.baudrate = 115200;
+    let mut tx_buf = [0u8; 256];
+    let mut rx_buf = [0u8; 256];
+    let mut usart = BufferedUart::new(p.USART1, Irqs, p.PB7, p.PB6, &mut tx_buf, &mut rx_buf, config).unwrap();
+
+    usart.write_all(b"Hello Embassy World!\r\n").await.unwrap();
+    info!("wrote Hello, starting echo");
+
+    let mut buf = [0; 4];
+    loop {
+        usart.read_exact(&mut buf[..]).await.unwrap();
+        usart.write_all(&buf[..]).await.unwrap();
+    }
+}

--- a/examples/stm32g0/src/bin/usart_dma.rs
+++ b/examples/stm32g0/src/bin/usart_dma.rs
@@ -1,0 +1,27 @@
+#![no_std]
+#![no_main]
+
+use defmt::*;
+use embassy_executor::Spawner;
+use embassy_stm32::usart::{Config, Uart};
+use embassy_stm32::{bind_interrupts, peripherals, usart};
+use {defmt_rtt as _, panic_probe as _};
+
+bind_interrupts!(struct Irqs {
+    USART1 => usart::InterruptHandler<peripherals::USART1>;
+});
+
+#[embassy_executor::main]
+async fn main(_spawner: Spawner) {
+    let p = embassy_stm32::init(Default::default());
+    let mut usart = Uart::new(p.USART1, p.PB7, p.PB6, Irqs, p.DMA1_CH2, p.DMA1_CH3, Config::default()).unwrap();
+
+    usart.write(b"Hello Embassy World!\r\n").await.unwrap();
+    info!("wrote Hello, starting echo");
+
+    let mut buf = [0; 5];
+    loop {
+        usart.read(&mut buf[..]).await.unwrap();
+        usart.write(&buf[..]).await.unwrap();
+    }
+}

--- a/examples/stm32g0/src/bin/usart_dma.rs
+++ b/examples/stm32g0/src/bin/usart_dma.rs
@@ -14,7 +14,16 @@ bind_interrupts!(struct Irqs {
 #[embassy_executor::main]
 async fn main(_spawner: Spawner) {
     let p = embassy_stm32::init(Default::default());
-    let mut usart = Uart::new(p.USART1, p.PB7, p.PB6, Irqs, p.DMA1_CH2, p.DMA1_CH3, Config::default()).unwrap();
+    let mut usart = Uart::new(
+        p.USART1,
+        p.PB7,
+        p.PB6,
+        Irqs,
+        p.DMA1_CH2,
+        p.DMA1_CH3,
+        Config::default(),
+    )
+    .unwrap();
 
     usart.write(b"Hello Embassy World!\r\n").await.unwrap();
     info!("wrote Hello, starting echo");


### PR DESCRIPTION
Add `usart` `usart_dma`  `usart_buffered`  `irq` `multiprio` `adc` examples for stm32g0

Tested correctly with `STM32G031G8Ux`