### PR TITLE
Improve stm32 ucpd packet reception

### DIFF
--- a/embassy-stm32/src/ucpd.rs
+++ b/embassy-stm32/src/ucpd.rs
@@ -347,15 +347,14 @@ impl<'d, T: Instance> PdPhy<'d, T> {
                 .read(r.rxdr().as_ptr() as *mut u8, buf, TransferOptions::default())
         };
 
-        // Clear interrupt flags (possibly set from last receive).
-        r.icr().write(|w| {
-            w.set_rxorddetcf(true);
-            w.set_rxovrcf(true);
-            w.set_rxmsgendcf(true);
-        });
-
         let _on_drop = OnDrop::new(|| {
             Self::enable_rx_interrupt(false);
+            // Clear interrupt flags
+            r.icr().write(|w| {
+                w.set_rxorddetcf(true);
+                w.set_rxovrcf(true);
+                w.set_rxmsgendcf(true);
+            });
         });
 
         poll_fn(|cx| {

--- a/embassy-stm32/src/ucpd.rs
+++ b/embassy-stm32/src/ucpd.rs
@@ -169,6 +169,9 @@ impl<'d, T: Instance> Ucpd<'d, T> {
         // Enable hard reset receive interrupt.
         r.imr().modify(|w| w.set_rxhrstdetie(true));
 
+        // Enable PD packet reception
+        r.cr().modify(|w| w.set_phyrxen(true));
+
         // Both parts must be dropped before the peripheral can be disabled.
         T::state().drop_not_ready.store(true, Ordering::Relaxed);
 
@@ -319,6 +322,7 @@ pub struct PdPhy<'d, T: Instance> {
 
 impl<'d, T: Instance> Drop for PdPhy<'d, T> {
     fn drop(&mut self) {
+        T::REGS.cr().modify(|w| w.set_phyrxen(false));
         // Check if the Type-C part was dropped already.
         let drop_not_ready = &T::state().drop_not_ready;
         if drop_not_ready.load(Ordering::Relaxed) {
@@ -350,9 +354,7 @@ impl<'d, T: Instance> PdPhy<'d, T> {
             w.set_rxmsgendcf(true);
         });
 
-        r.cr().modify(|w| w.set_phyrxen(true));
         let _on_drop = OnDrop::new(|| {
-            r.cr().modify(|w| w.set_phyrxen(false));
             Self::enable_rx_interrupt(false);
         });
 


### PR DESCRIPTION
When using stm32g071b-disco as a PD interceptor i noticed especially GoodCrc packets got missed and sometimes corrupted packets were received. This PR seems to fix both issues :)