### PR TITLE
nrf: fix wrong order configuring gpios.

### DIFF
--- a/embassy-nrf/src/buffered_uarte.rs
+++ b/embassy-nrf/src/buffered_uarte.rs
@@ -306,6 +306,7 @@ impl<'d, U: UarteInstance, T: TimerInstance> BufferedUarte<'d, U, T> {
 
         U::Interrupt::pend();
         unsafe { U::Interrupt::enable() };
+        U::regs().enable.write(|w| w.enable().enabled());
 
         U::state().tx_rx_refcount.store(2, Ordering::Relaxed);
 
@@ -407,6 +408,7 @@ impl<'d, U: UarteInstance> BufferedUarteTx<'d, U> {
 
         U::Interrupt::pend();
         unsafe { U::Interrupt::enable() };
+        U::regs().enable.write(|w| w.enable().enabled());
 
         U::state().tx_rx_refcount.store(1, Ordering::Relaxed);
 
@@ -604,6 +606,7 @@ impl<'d, U: UarteInstance, T: TimerInstance> BufferedUarteRx<'d, U, T> {
 
         U::Interrupt::pend();
         unsafe { U::Interrupt::enable() };
+        U::regs().enable.write(|w| w.enable().enabled());
 
         U::state().tx_rx_refcount.store(1, Ordering::Relaxed);
 

--- a/embassy-nrf/src/uarte.rs
+++ b/embassy-nrf/src/uarte.rs
@@ -221,6 +221,7 @@ impl<'d, T: Instance> Uarte<'d, T> {
 
         T::Interrupt::unpend();
         unsafe { T::Interrupt::enable() };
+        r.enable.write(|w| w.enable().enabled());
 
         let s = T::state();
         s.tx_rx_refcount.store(2, Ordering::Relaxed);
@@ -319,9 +320,7 @@ pub(crate) fn configure(r: &RegisterBlock, config: Config, hardware_flow_control
     r.psel.cts.write(|w| w.connect().disconnected());
     r.psel.rts.write(|w| w.connect().disconnected());
 
-    // Enable
     apply_workaround_for_enable_anomaly(r);
-    r.enable.write(|w| w.enable().enabled());
 }
 
 impl<'d, T: Instance> UarteTx<'d, T> {
@@ -369,6 +368,7 @@ impl<'d, T: Instance> UarteTx<'d, T> {
 
         T::Interrupt::unpend();
         unsafe { T::Interrupt::enable() };
+        r.enable.write(|w| w.enable().enabled());
 
         let s = T::state();
         s.tx_rx_refcount.store(1, Ordering::Relaxed);
@@ -567,6 +567,7 @@ impl<'d, T: Instance> UarteRx<'d, T> {
 
         T::Interrupt::unpend();
         unsafe { T::Interrupt::enable() };
+        r.enable.write(|w| w.enable().enabled());
 
         let s = T::state();
         s.tx_rx_refcount.store(1, Ordering::Relaxed);


### PR DESCRIPTION
Docs say "PSEL.RXD, PSEL.RTS, PSEL.RTS, and PSEL.TXD must only be configured when the UARTE is disabled."
For some reason nrf52 doesn't care but nrf91 does.
