### PR TITLE
Update rust-toolchain-nightly.toml to compile with changes to fmt.rs

### DIFF
--- a/rust-toolchain-nightly.toml
+++ b/rust-toolchain-nightly.toml
@@ -1,5 +1,5 @@
 [toolchain]
-channel = "nightly-2024-05-20"
+channel = "nightly-2024-06-18"
 components = [ "rust-src", "rustfmt", "llvm-tools", "miri" ]
 targets = [
     "thumbv7em-none-eabi",


### PR DESCRIPTION
The changes to the fmt.rs files won't build with the nightly version referenced in rust-toolchain-nightly.toml right now. Update to current nightly to compile.