### PR TITLE
Enables half transfer ir when constructing a ReadableDmaRingBuffer

### DIFF
--- a/embassy-stm32/src/dma/dma_bdma.rs
+++ b/embassy-stm32/src/dma/dma_bdma.rs
@@ -904,6 +904,7 @@ impl<'a, W: Word> WritableRingBuffer<'a, W> {
         let data_size = W::size();
         let buffer_ptr = buffer.as_mut_ptr();
 
+        options.half_transfer_ir = true;
         options.complete_transfer_ir = true;
         options.circular = true;
 


### PR DESCRIPTION
The half transfer irq needs to be enabled in order for the hardware to notify the waker when the transfer is at half. This is needed to ensure no overuns occur when using `ReadableDmaRingBuffer`'s `read_exact`. Otherwise we are only notified when the DMA has completed its cycle and is on its way to start overwriting the data. The docs in the dma_bdma buf module also seem to imply that the half transfer irq must be enabled for proper operation. The only consumers of the `ReadableDmaRingBuffer` api are the sai module and the `RingBufferedUartRx`. The former enables the irq manually when constructing the transfer options while the latter does not. This may also be the cause for #1441.