### PR TITLE
Add PWM examples for stm32g0

### DIFF
--- a/examples/stm32g0/src/bin/input_capture.rs
+++ b/examples/stm32g0/src/bin/input_capture.rs
@@ -1,0 +1,67 @@
+//! Input capture example
+//!
+//! This example showcases how to use the input capture feature of the timer peripheral.
+//! Connect PB1 and PA6 with a 1k Ohm resistor or Connect PB1 and PA8 with a 1k Ohm resistor
+//! to see the output.
+//! When connecting PB1 (software pwm) and PA6 the output is around 10000 (it will be a bit bigger, around 10040)
+//! Output is 1000 when connecting PB1 (PWMOUT) and PA6.
+//!
+#![no_std]
+#![no_main]
+
+use defmt::*;
+use embassy_executor::Spawner;
+use embassy_stm32::gpio::{Level, Output, OutputType, Pull, Speed};
+use embassy_stm32::time::khz;
+use embassy_stm32::timer::input_capture::{CapturePin, InputCapture};
+use embassy_stm32::timer::simple_pwm::{PwmPin, SimplePwm};
+use embassy_stm32::timer::Channel;
+use embassy_stm32::{bind_interrupts, peripherals, timer};
+use embassy_time::Timer;
+use {defmt_rtt as _, panic_probe as _};
+
+// Connect PB1 and PA6 with a 1k Ohm resistor
+
+#[embassy_executor::task]
+async fn blinky(led: peripherals::PB1) {
+    let mut led = Output::new(led, Level::High, Speed::Low);
+
+    loop {
+        led.set_high();
+        Timer::after_millis(50).await;
+
+        led.set_low();
+        Timer::after_millis(50).await;
+    }
+}
+
+bind_interrupts!(struct Irqs {
+    TIM2 => timer::CaptureCompareInterruptHandler<peripherals::TIM2>;
+});
+
+#[embassy_executor::main]
+async fn main(spawner: Spawner) {
+    let p = embassy_stm32::init(Default::default());
+    info!("Hello World!");
+
+    unwrap!(spawner.spawn(blinky(p.PB1)));
+
+    // Connect PB1 and PA8 with a 1k Ohm resistor
+    let ch1 = PwmPin::new_ch1(p.PA8, OutputType::PushPull);
+    let mut pwm = SimplePwm::new(p.TIM1, Some(ch1), None, None, None, khz(1), Default::default());
+    pwm.enable(Channel::Ch1);
+    pwm.set_duty(Channel::Ch1, 50);
+
+    let ch1 = CapturePin::new_ch1(p.PA0, Pull::None);
+    let mut ic = InputCapture::new(p.TIM2, Some(ch1), None, None, None, Irqs, khz(1000), Default::default());
+
+    let mut old_capture = 0;
+
+    loop {
+        ic.wait_for_rising_edge(Channel::Ch1).await;
+
+        let capture_value = ic.get_capture_value(Channel::Ch1);
+        info!("{}", capture_value - old_capture);
+        old_capture = capture_value;
+    }
+}

--- a/examples/stm32g0/src/bin/pwm_complementary.rs
+++ b/examples/stm32g0/src/bin/pwm_complementary.rs
@@ -1,0 +1,58 @@
+//! PWM complementary example
+//!
+//! This example uses two complementary pwm outputs from TIM1 with different duty cycles
+//!   ___           ___
+//!      |_________|   |_________|    PA8
+//!       _________     _________
+//!   ___|         |___|         |    PA7
+//!   _________     _________
+//!            |___|         |___|    PB3
+//!             ___           ___
+//!   _________|   |_________|   |    PB0
+
+#![no_std]
+#![no_main]
+
+use defmt::info;
+use embassy_executor::Spawner;
+use embassy_stm32::gpio::OutputType;
+use embassy_stm32::time::khz;
+use embassy_stm32::timer::complementary_pwm::{ComplementaryPwm, ComplementaryPwmPin};
+use embassy_stm32::timer::simple_pwm::PwmPin;
+use embassy_stm32::timer::Channel;
+use embassy_stm32::Config as PeripheralConfig;
+use {defmt_rtt as _, panic_probe as _};
+
+#[embassy_executor::main]
+async fn main(_spawner: Spawner) {
+    let p = embassy_stm32::init(Default::default());
+
+    let ch1 = PwmPin::new_ch1(p.PA8, OutputType::PushPull);
+    let ch1n = ComplementaryPwmPin::new_ch1(p.PA7, OutputType::PushPull);
+    let ch2 = PwmPin::new_ch2(p.PB3, OutputType::PushPull);
+    let ch2n = ComplementaryPwmPin::new_ch2(p.PB0, OutputType::PushPull);
+
+    let mut pwm = ComplementaryPwm::new(
+        p.TIM1,
+        Some(ch1),
+        Some(ch1n),
+        Some(ch2),
+        Some(ch2n),
+        None,
+        None,
+        None,
+        None,
+        khz(100),
+        Default::default(),
+    );
+
+    let max = pwm.get_max_duty();
+    info!("Max duty: {}", max);
+
+    pwm.set_duty(Channel::Ch1, max / 4);
+    pwm.enable(Channel::Ch1);
+    pwm.set_duty(Channel::Ch2, max * 3 / 4);
+    pwm.enable(Channel::Ch2);
+
+    loop {}
+}

--- a/examples/stm32g0/src/bin/pwm_complementary.rs
+++ b/examples/stm32g0/src/bin/pwm_complementary.rs
@@ -20,7 +20,6 @@ use embassy_stm32::time::khz;
 use embassy_stm32::timer::complementary_pwm::{ComplementaryPwm, ComplementaryPwmPin};
 use embassy_stm32::timer::simple_pwm::PwmPin;
 use embassy_stm32::timer::Channel;
-use embassy_stm32::Config as PeripheralConfig;
 use {defmt_rtt as _, panic_probe as _};
 
 #[embassy_executor::main]

--- a/examples/stm32g0/src/bin/pwm_input.rs
+++ b/examples/stm32g0/src/bin/pwm_input.rs
@@ -1,0 +1,65 @@
+//! PWM input example
+//!
+//! This program demonstrates how to capture the parameters of the input waveform (frequency, width and duty cycle)
+//! Connect PB1 and PA6 with a 1k Ohm resistor or Connect PB1 and PA8 with a 1k Ohm resistor
+//! to see the output.
+//!
+
+#![no_std]
+#![no_main]
+
+use defmt::*;
+use embassy_executor::Spawner;
+use embassy_stm32::gpio::{Level, Output, OutputType, Pull, Speed};
+use embassy_stm32::time::khz;
+use embassy_stm32::timer::pwm_input::PwmInput;
+use embassy_stm32::timer::simple_pwm::{PwmPin, SimplePwm};
+use embassy_stm32::timer::Channel;
+use embassy_stm32::{bind_interrupts, peripherals, timer};
+use embassy_time::Timer;
+use {defmt_rtt as _, panic_probe as _};
+
+// Connect PB1 and PA6 with a 1k Ohm resistor
+#[embassy_executor::task]
+async fn blinky(led: peripherals::PB1) {
+    let mut led = Output::new(led, Level::High, Speed::Low);
+
+    loop {
+        led.set_high();
+        Timer::after_millis(50).await;
+
+        led.set_low();
+        Timer::after_millis(50).await;
+    }
+}
+
+bind_interrupts!(struct Irqs {
+    TIM2 => timer::CaptureCompareInterruptHandler<peripherals::TIM2>;
+});
+
+#[embassy_executor::main]
+async fn main(spawner: Spawner) {
+    let p = embassy_stm32::init(Default::default());
+
+    unwrap!(spawner.spawn(blinky(p.PB1)));
+    // Connect PA8 and PA6 with a 1k Ohm resistor
+    let ch1 = PwmPin::new_ch1(p.PA8, OutputType::PushPull);
+    let mut pwm = SimplePwm::new(p.TIM1, Some(ch1), None, None, None, khz(1), Default::default());
+    let max = pwm.get_max_duty();
+    pwm.set_duty(Channel::Ch1, max / 4);
+    pwm.enable(Channel::Ch1);
+
+    let mut pwm_input = PwmInput::new(p.TIM2, p.PA0, Pull::None, khz(1000));
+    pwm_input.enable();
+
+    loop {
+        Timer::after_millis(500).await;
+        let period = pwm_input.get_period_ticks();
+        let width = pwm_input.get_width_ticks();
+        let duty_cycle = pwm_input.get_duty_cycle();
+        info!(
+            "period ticks: {} width ticks: {} duty cycle: {}",
+            period, width, duty_cycle
+        );
+    }
+}


### PR DESCRIPTION
Add three `pwm` routines
`pwm_capture` is used to read the duty cycle, width and frequency of the input pwm.
`input_capture` is used to read the input edge frequency
`pwm_complementary` provides two sets of complementary pwm outputs with different duty cycles