### PR TITLE
Fix: Ensure I2C bus is free before master-write operation

### DIFF
--- a/embassy-stm32/src/i2c/v2.rs
+++ b/embassy-stm32/src/i2c/v2.rs
@@ -110,9 +110,9 @@ impl<'d, M: Mode> I2c<'d, M> {
         }
 
         // Wait for the bus to be free
-        while info.regs.isr().read().busy(){
+        while info.regs.isr().read().busy() {
             timeout.check()?;
-        };
+        }
 
         let reload = if reload {
             i2c::vals::Reload::NOTCOMPLETED

--- a/embassy-stm32/src/i2c/v2.rs
+++ b/embassy-stm32/src/i2c/v2.rs
@@ -109,6 +109,11 @@ impl<'d, M: Mode> I2c<'d, M> {
             timeout.check()?;
         }
 
+        // Wait for the bus to be free
+        while info.regs.isr().read().busy(){
+            timeout.check()?;
+        };
+
         let reload = if reload {
             i2c::vals::Reload::NOTCOMPLETED
         } else {


### PR DESCRIPTION
The I2C master-write function was failing when executed immediately after an I2C read operation, requiring manual delays to function correctly. This fix introduces a check to ensure the I2C bus is free before initiating the write operation.

According to the RM0399 manual for STM32H7 chips, the BUSY bit (Bit 15 in the I2C ISR register) indicates whether a communication is in progress on the bus. The BUSY bit is set by hardware when a START condition is detected and cleared when a STOP condition is detected or when PE = 0.

This fix prevents the write operation from starting until the BUSY bit is cleared.