### PR TITLE
STM32 - Adc V4 - Add asynchronous multi-channel read support

### DIFF
--- a/embassy-stm32/build.rs
+++ b/embassy-stm32/build.rs
@@ -1178,6 +1178,11 @@ fn main() {
 
     let signals: HashMap<_, _> = [
         // (kind, signal) => trait
+        (("adc", "ADC"), quote!(crate::adc::RxDma)),
+        (("adc", "ADC1"), quote!(crate::adc::RxDma)),
+        (("adc", "ADC2"), quote!(crate::adc::RxDma)),
+        (("adc", "ADC3"), quote!(crate::adc::RxDma)),
+        (("adc", "ADC4"), quote!(crate::adc::RxDma)),
         (("ucpd", "RX"), quote!(crate::ucpd::RxDma)),
         (("ucpd", "TX"), quote!(crate::ucpd::TxDma)),
         (("usart", "RX"), quote!(crate::usart::RxDma)),

--- a/embassy-stm32/src/adc/mod.rs
+++ b/embassy-stm32/src/adc/mod.rs
@@ -28,6 +28,8 @@ pub use crate::pac::adc::vals::Res as Resolution;
 pub use crate::pac::adc::vals::SampleTime;
 use crate::peripherals;
 
+dma_trait!(RxDma, Instance);
+
 /// Analog to Digital driver.
 pub struct Adc<'d, T: Instance> {
     #[allow(unused)]

--- a/embassy-stm32/src/adc/v4.rs
+++ b/embassy-stm32/src/adc/v4.rs
@@ -1,8 +1,12 @@
 #[allow(unused)]
 use pac::adc::vals::{Adcaldif, Boost, Difsel, Exten, Pcsel};
+use pac::adc::vals::{Adstp, Dmngt};
 use pac::adccommon::vals::Presc;
 
-use super::{blocking_delay_us, Adc, AdcChannel, Instance, Resolution, SampleTime};
+use super::{
+    blocking_delay_us, Adc, AdcChannel, AnyAdcChannel, Instance, Resolution, RxDma, SampleTime, SealedAdcChannel,
+};
+use crate::dma::Transfer;
 use crate::time::Hertz;
 use crate::{pac, rcc, Peripheral};
 
@@ -34,7 +38,7 @@ const VBAT_CHANNEL: u8 = 17;
 /// Internal voltage reference channel.
 pub struct VrefInt;
 impl<T: Instance> AdcChannel<T> for VrefInt {}
-impl<T: Instance> super::SealedAdcChannel<T> for VrefInt {
+impl<T: Instance> SealedAdcChannel<T> for VrefInt {
     fn channel(&self) -> u8 {
         VREF_CHANNEL
     }
@@ -43,7 +47,7 @@ impl<T: Instance> super::SealedAdcChannel<T> for VrefInt {
 /// Internal temperature channel.
 pub struct Temperature;
 impl<T: Instance> AdcChannel<T> for Temperature {}
-impl<T: Instance> super::SealedAdcChannel<T> for Temperature {
+impl<T: Instance> SealedAdcChannel<T> for Temperature {
     fn channel(&self) -> u8 {
         TEMP_CHANNEL
     }
@@ -52,7 +56,7 @@ impl<T: Instance> super::SealedAdcChannel<T> for Temperature {
 /// Internal battery voltage channel.
 pub struct Vbat;
 impl<T: Instance> AdcChannel<T> for Vbat {}
-impl<T: Instance> super::SealedAdcChannel<T> for Vbat {
+impl<T: Instance> SealedAdcChannel<T> for Vbat {
     fn channel(&self) -> u8 {
         VBAT_CHANNEL
     }
@@ -247,6 +251,11 @@ impl<'d, T: Instance> Adc<'d, T> {
         self.sample_time = sample_time;
     }
 
+    /// Get the ADC sample time.
+    pub fn sample_time(&self) -> SampleTime {
+        self.sample_time
+    }
+
     /// Set the ADC resolution.
     pub fn set_resolution(&mut self, resolution: Resolution) {
         T::regs().cfgr().modify(|reg| reg.set_res(resolution.into()));
@@ -273,25 +282,120 @@ impl<'d, T: Instance> Adc<'d, T> {
 
     /// Read an ADC channel.
     pub fn read(&mut self, channel: &mut impl AdcChannel<T>) -> u16 {
-        channel.setup();
-
-        self.read_channel(channel.channel())
+        self.read_channel(channel)
     }
 
-    fn read_channel(&mut self, channel: u8) -> u16 {
-        // Configure channel
-        Self::set_channel_sample_time(channel, self.sample_time);
+    /// Asynchronously read from sequence of ADC channels.
+    pub async fn read_async(
+        &mut self,
+        rx_dma: &mut impl RxDma<T>,
+        sequence: impl ExactSizeIterator<Item = (&mut AnyAdcChannel<T>, SampleTime)>,
+        data: &mut [u16],
+    ) {
+        assert!(sequence.len() != 0, "Asynchronous read sequence cannot be empty");
+
+        assert!(
+            sequence.len() <= 16,
+            "Asynchronous read sequence cannot be more than 16 in length"
+        );
+
+        // Ensure no conversions are ongoing
+        Self::cancel_conversions();
+
+        // Set sequence length
+        T::regs().sqr1().modify(|w| {
+            w.set_l(sequence.len() as u8 - 1);
+        });
+
+        // Configure channels and ranks
+        for (i, (channel, sample_time)) in sequence.enumerate() {
+            Self::configure_channel(channel, sample_time);
+            match i {
+                0..=3 => {
+                    T::regs().sqr1().modify(|w| {
+                        w.set_sq(i, channel.channel());
+                    });
+                }
+                4..=8 => {
+                    T::regs().sqr2().modify(|w| {
+                        w.set_sq(i - 4, channel.channel());
+                    });
+                }
+                9..=13 => {
+                    T::regs().sqr3().modify(|w| {
+                        w.set_sq(i - 9, channel.channel());
+                    });
+                }
+                14..=15 => {
+                    T::regs().sqr4().modify(|w| {
+                        w.set_sq(i - 14, channel.channel());
+                    });
+                }
+                _ => unreachable!(),
+            }
+        }
+
+        // Set continuous mode with oneshot dma.
+        // Clear overrun flag before starting transfer.
+
+        T::regs().isr().modify(|reg| {
+            reg.set_ovr(true);
+        });
+        T::regs().cfgr().modify(|reg| {
+            reg.set_cont(true);
+            reg.set_dmngt(Dmngt::DMA_ONESHOT);
+        });
+
+        let request = rx_dma.request();
+        let transfer = unsafe {
+            Transfer::new_read(
+                rx_dma,
+                request,
+                T::regs().dr().as_ptr() as *mut u16,
+                data,
+                Default::default(),
+            )
+        };
+
+        // Start conversion
+        T::regs().cr().modify(|reg| {
+            reg.set_adstart(true);
+        });
+
+        // Wait for conversion sequence to finish.
+        transfer.await;
+
+        // Ensure conversions are finished.
+        Self::cancel_conversions();
+
+        // Reset configuration.
+        T::regs().cfgr().modify(|reg| {
+            reg.set_cont(false);
+            reg.set_dmngt(Dmngt::from_bits(0));
+        });
+    }
+
+    fn configure_channel(channel: &mut impl AdcChannel<T>, sample_time: SampleTime) {
+        channel.setup();
+
+        let channel = channel.channel();
+
+        Self::set_channel_sample_time(channel, sample_time);
 
         #[cfg(stm32h7)]
         {
             T::regs().cfgr2().modify(|w| w.set_lshift(0));
             T::regs()
                 .pcsel()
-                .write(|w| w.set_pcsel(channel as _, Pcsel::PRESELECTED));
+                .modify(|w| w.set_pcsel(channel as _, Pcsel::PRESELECTED));
         }
+    }
 
-        T::regs().sqr1().write(|reg| {
-            reg.set_sq(0, channel);
+    fn read_channel(&mut self, channel: &mut impl AdcChannel<T>) -> u16 {
+        Self::configure_channel(channel, self.sample_time);
+
+        T::regs().sqr1().modify(|reg| {
+            reg.set_sq(0, channel.channel());
             reg.set_l(0);
         });
 
@@ -304,6 +408,15 @@ impl<'d, T: Instance> Adc<'d, T> {
             T::regs().smpr(0).modify(|reg| reg.set_smp(ch as _, sample_time));
         } else {
             T::regs().smpr(1).modify(|reg| reg.set_smp((ch - 10) as _, sample_time));
+        }
+    }
+
+    fn cancel_conversions() {
+        if T::regs().cr().read().adstart() && !T::regs().cr().read().addis() {
+            T::regs().cr().modify(|reg| {
+                reg.set_adstp(Adstp::STOP);
+            });
+            while T::regs().cr().read().adstart() {}
         }
     }
 }

--- a/examples/stm32h7/src/bin/adc_dma.rs
+++ b/examples/stm32h7/src/bin/adc_dma.rs
@@ -1,0 +1,76 @@
+#![no_std]
+#![no_main]
+
+use defmt::*;
+use embassy_executor::Spawner;
+use embassy_stm32::adc::{Adc, AdcChannel as _, SampleTime};
+use embassy_stm32::Config;
+use embassy_time::Timer;
+use {defmt_rtt as _, panic_probe as _};
+
+#[link_section = ".ram_d3"]
+static mut DMA_BUF: [u16; 2] = [0; 2];
+
+#[embassy_executor::main]
+async fn main(_spawner: Spawner) {
+    let mut read_buffer = unsafe { &mut DMA_BUF[..] };
+
+    let mut config = Config::default();
+    {
+        use embassy_stm32::rcc::*;
+        config.rcc.hsi = Some(HSIPrescaler::DIV1);
+        config.rcc.csi = true;
+        config.rcc.pll1 = Some(Pll {
+            source: PllSource::HSI,
+            prediv: PllPreDiv::DIV4,
+            mul: PllMul::MUL50,
+            divp: Some(PllDiv::DIV2),
+            divq: Some(PllDiv::DIV8), // SPI1 cksel defaults to pll1_q
+            divr: None,
+        });
+        config.rcc.pll2 = Some(Pll {
+            source: PllSource::HSI,
+            prediv: PllPreDiv::DIV4,
+            mul: PllMul::MUL50,
+            divp: Some(PllDiv::DIV8), // 100mhz
+            divq: None,
+            divr: None,
+        });
+        config.rcc.sys = Sysclk::PLL1_P; // 400 Mhz
+        config.rcc.ahb_pre = AHBPrescaler::DIV2; // 200 Mhz
+        config.rcc.apb1_pre = APBPrescaler::DIV2; // 100 Mhz
+        config.rcc.apb2_pre = APBPrescaler::DIV2; // 100 Mhz
+        config.rcc.apb3_pre = APBPrescaler::DIV2; // 100 Mhz
+        config.rcc.apb4_pre = APBPrescaler::DIV2; // 100 Mhz
+        config.rcc.voltage_scale = VoltageScale::Scale1;
+        config.rcc.mux.adcsel = mux::Adcsel::PLL2_P;
+    }
+    let p = embassy_stm32::init(config);
+
+    info!("Hello World!");
+
+    let mut adc = Adc::new(p.ADC3);
+
+    let mut dma = p.DMA1_CH1;
+    let mut vrefint_channel = adc.enable_vrefint().degrade_adc();
+    let mut pc0 = p.PC0.degrade_adc();
+
+    loop {
+        adc.read_async(
+            &mut dma,
+            [
+                (&mut vrefint_channel, SampleTime::CYCLES387_5),
+                (&mut pc0, SampleTime::CYCLES810_5),
+            ]
+            .into_iter(),
+            &mut read_buffer,
+        )
+        .await;
+
+        let vrefint = read_buffer[0];
+        let measured = read_buffer[1];
+        info!("vrefint: {}", vrefint);
+        info!("measured: {}", measured);
+        Timer::after_millis(500).await;
+    }
+}


### PR DESCRIPTION
This PR adds async support to the `adc v4` driver through a new `read_async` method that takes an `ExactSizedIterator` of `AnyChannel` `mut` references along with their sample times.
This can be used for single-channels as well, and is especially useful for large sampling times of many channels, which can waste important MCU time.
Tested on a `STM32H745VIIx` and compared with separate `read_channel` calls.