### PR TITLE
Add async API to TSC

### DIFF
--- a/embassy-stm32/src/tsc/mod.rs
+++ b/embassy-stm32/src/tsc/mod.rs
@@ -75,6 +75,7 @@ pub use enums::*;
 
 use crate::gpio::{AfType, AnyPin, OutputType, Speed};
 use crate::interrupt::typelevel::Interrupt;
+use crate::mode::{Async, Blocking, Mode as PeriMode};
 use crate::rcc::{self, RccPeripheral};
 use crate::{interrupt, peripherals, Peripheral};
 
@@ -92,23 +93,6 @@ pub enum Error {
     /// Test error for TSC
     Test,
 }
-
-/// Async acquisition API marker
-pub struct Async;
-/// Blocking acquisition API marker
-pub struct Blocking;
-
-trait SealedDriverKind {}
-
-impl SealedDriverKind for Async {}
-impl SealedDriverKind for Blocking {}
-
-#[allow(private_bounds)]
-/// Driver variant marker for the TSC peripheral
-pub trait DriverKind: SealedDriverKind {}
-
-impl DriverKind for Async {}
-impl DriverKind for Blocking {}
 
 /// TSC interrupt handler.
 pub struct InterruptHandler<T: Instance> {
@@ -522,7 +506,7 @@ pub enum G7 {}
 pub enum G8 {}
 
 /// TSC driver
-pub struct Tsc<'d, T: Instance, K: DriverKind> {
+pub struct Tsc<'d, T: Instance, K: PeriMode> {
     _peri: PeripheralRef<'d, T>,
     _g1: Option<PinGroup<'d, T, G1>>,
     _g2: Option<PinGroup<'d, T, G2>>,
@@ -703,7 +687,7 @@ impl<'d, T: Instance> Tsc<'d, T, Blocking> {
     }
 }
 
-impl<'d, T: Instance, K: DriverKind> Tsc<'d, T, K> {
+impl<'d, T: Instance, K: PeriMode> Tsc<'d, T, K> {
     /// Create new TSC driver
     fn check_shields(
         g1: &Option<PinGroup<'d, T, G1>>,
@@ -969,7 +953,7 @@ impl<'d, T: Instance, K: DriverKind> Tsc<'d, T, K> {
     }
 }
 
-impl<'d, T: Instance, K: DriverKind> Drop for Tsc<'d, T, K> {
+impl<'d, T: Instance, K: PeriMode> Drop for Tsc<'d, T, K> {
     fn drop(&mut self) {
         rcc::disable::<T>();
     }

--- a/embassy-stm32/src/tsc/mod.rs
+++ b/embassy-stm32/src/tsc/mod.rs
@@ -65,19 +65,18 @@
 /// Enums defined for peripheral parameters
 pub mod enums;
 
+use core::future::poll_fn;
 use core::marker::PhantomData;
+use core::task::Poll;
 
 use embassy_hal_internal::{into_ref, PeripheralRef};
+use embassy_sync::waitqueue::AtomicWaker;
 pub use enums::*;
 
 use crate::gpio::{AfType, AnyPin, OutputType, Speed};
-use crate::interrupt;
 use crate::interrupt::typelevel::Interrupt;
 use crate::rcc::{self, RccPeripheral};
-use crate::{peripherals, Peripheral};
-use core::future::poll_fn;
-use core::task::Poll;
-use embassy_sync::waitqueue::AtomicWaker;
+use crate::{interrupt, peripherals, Peripheral};
 
 #[cfg(tsc_v1)]
 const TSC_NUM_GROUPS: u32 = 6;

--- a/examples/stm32u5/src/bin/tsc.rs
+++ b/examples/stm32u5/src/bin/tsc.rs
@@ -2,10 +2,8 @@
 #![no_main]
 
 use defmt::*;
-use embassy_stm32::{
-    bind_interrupts,
-    tsc::{self, *},
-};
+use embassy_stm32::bind_interrupts;
+use embassy_stm32::tsc::{self, *};
 use embassy_time::Timer;
 use {defmt_rtt as _, panic_probe as _};
 

--- a/examples/stm32u5/src/bin/tsc.rs
+++ b/examples/stm32u5/src/bin/tsc.rs
@@ -50,9 +50,8 @@ async fn main(_spawner: embassy_executor::Spawner) {
     g7.set_io2(context.PE3, PinType::Sample);
     g7.set_io3(context.PE4, PinType::Channel);
 
-    let mut touch_controller = tsc::Tsc::new(
+    let mut touch_controller = tsc::Tsc::new_async(
         context.TSC,
-        Irqs,
         Some(g1),
         Some(g2),
         None,
@@ -62,6 +61,7 @@ async fn main(_spawner: embassy_executor::Spawner) {
         Some(g7),
         None,
         config,
+        Irqs,
     );
 
     touch_controller.discharge_io(true);

--- a/examples/stm32u5/src/bin/tsc.rs
+++ b/examples/stm32u5/src/bin/tsc.rs
@@ -2,9 +2,16 @@
 #![no_main]
 
 use defmt::*;
-use embassy_stm32::tsc::{self, *};
+use embassy_stm32::{
+    bind_interrupts,
+    tsc::{self, *},
+};
 use embassy_time::Timer;
 use {defmt_rtt as _, panic_probe as _};
+
+bind_interrupts!(struct Irqs {
+    TSC => InterruptHandler<embassy_stm32::peripherals::TSC>;
+});
 
 #[cortex_m_rt::exception]
 unsafe fn HardFault(_: &cortex_m_rt::ExceptionFrame) -> ! {
@@ -47,6 +54,7 @@ async fn main(_spawner: embassy_executor::Spawner) {
 
     let mut touch_controller = tsc::Tsc::new(
         context.TSC,
+        Irqs,
         Some(g1),
         Some(g2),
         None,
@@ -67,7 +75,7 @@ async fn main(_spawner: embassy_executor::Spawner) {
     let mut group_seven_val = 0;
     info!("Starting touch_controller interface");
     loop {
-        touch_controller.poll_for_acquisition();
+        touch_controller.pend_for_acquisition().await;
         touch_controller.discharge_io(true);
         Timer::after_millis(1).await;
 


### PR DESCRIPTION
First punt at contributing peripheral code, I hope it's close to where it needs to be.

Based off what I read in `rng.rs`, on the advice of @kkoppul2

Some questions I have:

- What, if anything, should happen to the existing `start_it` and `poll_for_acquisition` methods
- Is it okay that this _requires_ Irqs be linked up to use the TSC? Or should it be optional?