### PR TITLE
RP: add option to provide your own boot2

### DIFF
--- a/embassy-rp/Cargo.toml
+++ b/embassy-rp/Cargo.toml
@@ -84,7 +84,7 @@ boot2-w25x10cl = []
 ## ```
 ## #[link_section = ".boot2"]
 ## #[used]
-## static BOOT2: [u8; 256] = ...;
+## static BOOT2: [u8; 256] = [0; 256]; // Provide your own with e.g. include_bytes!
 ## ```
 boot2-none = []
 

--- a/embassy-rp/Cargo.toml
+++ b/embassy-rp/Cargo.toml
@@ -79,6 +79,14 @@ boot2-ram-memcpy = []
 boot2-w25q080 = []
 ## Use boot2 with support for Winbond W25X10CL SPI flash.
 boot2-w25x10cl = []
+## Have embassy not provide the boot2 so you can use your own.
+## Place your own in the ".boot2" section like:
+## ```
+## #[link_section = ".boot2"]
+## #[used]
+## static BOOT2: [u8; 256] = ...;
+## ```
+boot2-none = []
 
 [dependencies]
 embassy-sync = { version = "0.6.0", path = "../embassy-sync" }

--- a/embassy-rp/src/lib.rs
+++ b/embassy-rp/src/lib.rs
@@ -226,6 +226,7 @@ macro_rules! select_bootloader {
     }
 }
 
+#[cfg(not(feature = "boot2-none"))]
 select_bootloader! {
     "boot2-at25sf128a" => BOOT_LOADER_AT25SF128A,
     "boot2-gd25q64cs" => BOOT_LOADER_GD25Q64CS,


### PR DESCRIPTION
In a project I need a custom boot2 and embassy gets in the way.
This PR adds an option to let embassy not provide it.
This is an active choice a user has to make, so it doesn't get in the way of existing code and ease of setup.