### PR TITLE
RP: Shut up missed warning boot2-none

### DIFF
--- a/embassy-rp/src/lib.rs
+++ b/embassy-rp/src/lib.rs
@@ -210,6 +210,7 @@ embassy_hal_internal::peripherals! {
     BOOTSEL,
 }
 
+#[cfg(not(feature = "boot2-none"))]
 macro_rules! select_bootloader {
     ( $( $feature:literal => $loader:ident, )+ default => $default:ident ) => {
         $(


### PR DESCRIPTION
Dang, my last PR was a bit too quick. Got a warning for unused macro when boot2-none is activated.
So this fixes it.