### PR TITLE
Add a feature that disables panic messages

### DIFF
--- a/embassy-boot-nrf/Cargo.toml
+++ b/embassy-boot-nrf/Cargo.toml
@@ -41,6 +41,10 @@ defmt = [
     "embassy-boot/defmt",
     "embassy-nrf/defmt",
 ]
+no-panic-msgs = [
+    "embassy-boot/no-panic-msgs",
+    "embassy-nrf/no-panic-msgs",
+]
 softdevice = [
     "nrf-softdevice-mbr",
 ]

--- a/embassy-boot-rp/Cargo.toml
+++ b/embassy-boot-rp/Cargo.toml
@@ -45,6 +45,10 @@ log = [
     "embassy-boot/log",
     "embassy-rp/log",
 ]
+no-panic-msgs = [
+    "embassy-boot/no-panic-msgs",
+    "embassy-rp/no-panic-msgs",
+]
 
 [profile.dev]
 debug = 2

--- a/embassy-boot-stm32/Cargo.toml
+++ b/embassy-boot-stm32/Cargo.toml
@@ -36,6 +36,7 @@ cfg-if = "1.0.0"
 [features]
 defmt = ["dep:defmt", "embassy-boot/defmt", "embassy-stm32/defmt"]
 log = ["dep:log", "embassy-boot/log", "embassy-stm32/log"]
+no-panic-msgs = ["embassy-boot/no-panic-msgs", "embassy-stm32/no-panic-msgs"]
 
 [profile.dev]
 debug = 2

--- a/embassy-boot/Cargo.toml
+++ b/embassy-boot/Cargo.toml
@@ -48,5 +48,11 @@ ed25519-dalek = { version = "2", default_features = false, features = ["std", "r
 ed25519-dalek = ["dep:ed25519-dalek", "_verify"]
 ed25519-salty = ["dep:salty", "_verify"]
 
+## Disable panic messsages where possible, to reduce binary size.  Mutually exclusive with the `defmt` and `log`
+## features.
+## Panic messages are normally stored in the resulting binary as literal strings.  Removing them is useful for limiting
+## flash usage e.g. for bootloaders.
+no-panic-msgs = []
+
 #Internal features
 _verify = []

--- a/embassy-boot/src/fmt.rs
+++ b/embassy-boot/src/fmt.rs
@@ -3,17 +3,29 @@
 
 use core::fmt::{Debug, Display, LowerHex};
 
+#[cfg(feature = "no-panic-msgs")]
+#[macro_use]
+pub mod no_panic_msgs;
+
 #[cfg(all(feature = "defmt", feature = "log"))]
 compile_error!("You may not enable both `defmt` and `log` features.");
+
+#[cfg(all(feature = "no-panic-msgs", feature = "log"))]
+compile_error!("You may not enable both `no-panic-msgs` and `log` features.");
+
+#[cfg(all(feature = "no-panic-msgs", feature = "defmt"))]
+compile_error!("You may not enable both `no-panic-msgs` and `defmt` features.");
 
 #[collapse_debuginfo(yes)]
 macro_rules! assert {
     ($($x:tt)*) => {
         {
-            #[cfg(not(feature = "defmt"))]
+            #[cfg(not(any(feature = "defmt", feature = "no-panic-msgs")))]
             ::core::assert!($($x)*);
             #[cfg(feature = "defmt")]
             ::defmt::assert!($($x)*);
+            #[cfg(feature = "no-panic-msgs")]
+            $crate::fmt::no_panic_msgs::assert!($($x)*);
         }
     };
 }
@@ -22,10 +34,12 @@ macro_rules! assert {
 macro_rules! assert_eq {
     ($($x:tt)*) => {
         {
-            #[cfg(not(feature = "defmt"))]
+            #[cfg(not(any(feature = "defmt", feature = "no-panic-msgs")))]
             ::core::assert_eq!($($x)*);
             #[cfg(feature = "defmt")]
             ::defmt::assert_eq!($($x)*);
+            #[cfg(feature = "no-panic-msgs")]
+            $crate::fmt::no_panic_msgs::assert_eq!($($x)*);
         }
     };
 }
@@ -34,10 +48,12 @@ macro_rules! assert_eq {
 macro_rules! assert_ne {
     ($($x:tt)*) => {
         {
-            #[cfg(not(feature = "defmt"))]
+            #[cfg(not(any(feature = "defmt", feature = "no-panic-msgs")))]
             ::core::assert_ne!($($x)*);
             #[cfg(feature = "defmt")]
             ::defmt::assert_ne!($($x)*);
+            #[cfg(feature = "no-panic-msgs")]
+            $crate::fmt::no_panic_msgs::assert_ne!($($x)*);
         }
     };
 }
@@ -46,10 +62,12 @@ macro_rules! assert_ne {
 macro_rules! debug_assert {
     ($($x:tt)*) => {
         {
-            #[cfg(not(feature = "defmt"))]
+            #[cfg(not(any(feature = "defmt", feature = "no-panic-msgs")))]
             ::core::debug_assert!($($x)*);
             #[cfg(feature = "defmt")]
             ::defmt::debug_assert!($($x)*);
+            #[cfg(feature = "no-panic-msgs")]
+            $crate::fmt::no_panic_msgs::debug_assert!($($x)*);
         }
     };
 }
@@ -58,10 +76,12 @@ macro_rules! debug_assert {
 macro_rules! debug_assert_eq {
     ($($x:tt)*) => {
         {
-            #[cfg(not(feature = "defmt"))]
+            #[cfg(not(any(feature = "defmt", feature = "no-panic-msgs")))]
             ::core::debug_assert_eq!($($x)*);
             #[cfg(feature = "defmt")]
             ::defmt::debug_assert_eq!($($x)*);
+            #[cfg(feature = "no-panic-msgs")]
+            $crate::fmt::no_panic_msgs::debug_assert_eq!($($x)*);
         }
     };
 }
@@ -70,10 +90,12 @@ macro_rules! debug_assert_eq {
 macro_rules! debug_assert_ne {
     ($($x:tt)*) => {
         {
-            #[cfg(not(feature = "defmt"))]
+            #[cfg(not(any(feature = "defmt", feature = "no-panic-msgs")))]
             ::core::debug_assert_ne!($($x)*);
             #[cfg(feature = "defmt")]
             ::defmt::debug_assert_ne!($($x)*);
+            #[cfg(feature = "no-panic-msgs")]
+            $crate::fmt::no_panic_msgs::debug_assert_ne!($($x)*);
         }
     };
 }
@@ -82,15 +104,17 @@ macro_rules! debug_assert_ne {
 macro_rules! todo {
     ($($x:tt)*) => {
         {
-            #[cfg(not(feature = "defmt"))]
+            #[cfg(not(any(feature = "defmt", feature = "no-panic-msgs")))]
             ::core::todo!($($x)*);
             #[cfg(feature = "defmt")]
             ::defmt::todo!($($x)*);
+            #[cfg(feature = "no-panic-msgs")]
+            ::core::todo!();
         }
     };
 }
 
-#[cfg(not(feature = "defmt"))]
+#[cfg(not(any(feature = "defmt", feature = "no-panic-msgs")))]
 #[collapse_debuginfo(yes)]
 macro_rules! unreachable {
     ($($x:tt)*) => {
@@ -106,14 +130,24 @@ macro_rules! unreachable {
     };
 }
 
+#[cfg(feature = "no-panic-msgs")]
+#[collapse_debuginfo(yes)]
+macro_rules! unreachable {
+    ($($x:tt)*) => {
+        ::core::unreachable!()
+    };
+}
+
 #[collapse_debuginfo(yes)]
 macro_rules! panic {
     ($($x:tt)*) => {
         {
-            #[cfg(not(feature = "defmt"))]
+            #[cfg(not(any(feature = "defmt", feature = "no-panic-msgs")))]
             ::core::panic!($($x)*);
             #[cfg(feature = "defmt")]
             ::defmt::panic!($($x)*);
+            #[cfg(feature = "no-panic-msgs")]
+            ::core::panic!();
         }
     };
 }
@@ -126,7 +160,7 @@ macro_rules! trace {
             ::log::trace!($s $(, $x)*);
             #[cfg(feature = "defmt")]
             ::defmt::trace!($s $(, $x)*);
-            #[cfg(not(any(feature = "log", feature="defmt")))]
+            #[cfg(not(any(feature = "log", feature = "defmt")))]
             let _ = ($( & $x ),*);
         }
     };
@@ -140,7 +174,7 @@ macro_rules! debug {
             ::log::debug!($s $(, $x)*);
             #[cfg(feature = "defmt")]
             ::defmt::debug!($s $(, $x)*);
-            #[cfg(not(any(feature = "log", feature="defmt")))]
+            #[cfg(not(any(feature = "log", feature = "defmt")))]
             let _ = ($( & $x ),*);
         }
     };
@@ -154,7 +188,7 @@ macro_rules! info {
             ::log::info!($s $(, $x)*);
             #[cfg(feature = "defmt")]
             ::defmt::info!($s $(, $x)*);
-            #[cfg(not(any(feature = "log", feature="defmt")))]
+            #[cfg(not(any(feature = "log", feature = "defmt")))]
             let _ = ($( & $x ),*);
         }
     };
@@ -168,7 +202,7 @@ macro_rules! warn {
             ::log::warn!($s $(, $x)*);
             #[cfg(feature = "defmt")]
             ::defmt::warn!($s $(, $x)*);
-            #[cfg(not(any(feature = "log", feature="defmt")))]
+            #[cfg(not(any(feature = "log", feature = "defmt")))]
             let _ = ($( & $x ),*);
         }
     };
@@ -182,7 +216,7 @@ macro_rules! error {
             ::log::error!($s $(, $x)*);
             #[cfg(feature = "defmt")]
             ::defmt::error!($s $(, $x)*);
-            #[cfg(not(any(feature = "log", feature="defmt")))]
+            #[cfg(not(any(feature = "log", feature = "defmt")))]
             let _ = ($( & $x ),*);
         }
     };
@@ -196,7 +230,15 @@ macro_rules! unwrap {
     };
 }
 
-#[cfg(not(feature = "defmt"))]
+#[cfg(feature = "no-panic-msgs")]
+#[collapse_debuginfo(yes)]
+macro_rules! unwrap {
+    ($($x:tt)*) => {
+        $crate::fmt::no_panic_msgs::unwrap!($($x)*)
+    };
+}
+
+#[cfg(not(any(feature = "defmt", feature = "no-panic-msgs")))]
 #[collapse_debuginfo(yes)]
 macro_rules! unwrap {
     ($arg:expr) => {

--- a/embassy-boot/src/fmt/no_panic_msgs.rs
+++ b/embassy-boot/src/fmt/no_panic_msgs.rs
@@ -1,0 +1,67 @@
+//! Equivalents of panicking macros that discard their messages
+//!
+//! Enabled by the `no-panic-msgs` feature.  Panics that include messages waste valuable flash
+//! storage, and removing these messages are useful when failure is very unlikely, e.g. when
+//! running as part of a bootloader.
+
+macro_rules! assert {
+    ($cond:expr $(,$($rest:tt)+)?) => {
+        ::core::assert!($cond, "")
+    };
+}
+pub(crate) use assert;
+
+macro_rules! assert_eq {
+    ($left:expr, $right:expr $(,$($rest:tt)+)?) => {
+        ::core::assert_eq!($left, $right, "")
+    };
+}
+pub(crate) use assert_eq;
+
+macro_rules! assert_ne {
+    ($left:expr, $right:expr $(,$($rest:tt)+)?) => {
+        ::core::assert_ne!($left, $right, "")
+    };
+}
+pub(crate) use assert_ne;
+
+macro_rules! debug_assert {
+    ($cond:expr $(,$($rest:tt)+)?) => {
+        ::core::debug_assert!($cond, "")
+    };
+}
+pub(crate) use debug_assert;
+
+macro_rules! debug_assert_eq {
+    ($left:expr, $right:expr $(,$($rest:tt)+)?) => {
+        ::core::debug_assert_eq!($left, $right, "")
+    };
+}
+pub(crate) use debug_assert_eq;
+
+macro_rules! debug_assert_ne {
+    ($left:expr, $right:expr $(,$($rest:tt)+)?) => {
+        ::core::debug_assert_ne!($left, $right, "")
+    };
+}
+pub(crate) use debug_assert_ne;
+
+macro_rules! unwrap {
+    ($arg:expr) => {
+        match $crate::fmt::Try::into_result($arg) {
+            ::core::result::Result::Ok(t) => t,
+            ::core::result::Result::Err(_) => {
+                ::core::panic!();
+            }
+        }
+    };
+    ($arg:expr $(,$($rest:tt)+)?) => {
+        match $crate::fmt::Try::into_result($arg) {
+            ::core::result::Result::Ok(t) => t,
+            ::core::result::Result::Err(_) => {
+                ::core::panic!();
+            }
+        }
+    };
+}
+pub(crate) use unwrap;

--- a/embassy-nrf/Cargo.toml
+++ b/embassy-nrf/Cargo.toml
@@ -48,6 +48,12 @@ time = ["dep:embassy-time"]
 ## Enable defmt
 defmt = ["dep:defmt", "embassy-hal-internal/defmt", "embassy-sync/defmt", "embassy-usb-driver/defmt", "embassy-embedded-hal/defmt"]
 
+## Disable panic messsages where possible, to reduce binary size.  Mutually exclusive with the `defmt` and `log`
+## features.
+## Panic messages are normally stored in the resulting binary as literal strings.  Removing them is useful for limiting
+## flash usage e.g. for bootloaders.
+no-panic-msgs = []
+
 ## Reexport the PAC for the currently enabled chip at `embassy_nrf::pac` (unstable)
 unstable-pac = []
 # This is unstable because semver-minor (non-breaking) releases of embassy-nrf may major-bump (breaking) the PAC version.

--- a/embassy-nrf/src/fmt.rs
+++ b/embassy-nrf/src/fmt.rs
@@ -3,17 +3,29 @@
 
 use core::fmt::{Debug, Display, LowerHex};
 
+#[cfg(feature = "no-panic-msgs")]
+#[macro_use]
+pub mod no_panic_msgs;
+
 #[cfg(all(feature = "defmt", feature = "log"))]
 compile_error!("You may not enable both `defmt` and `log` features.");
+
+#[cfg(all(feature = "no-panic-msgs", feature = "log"))]
+compile_error!("You may not enable both `no-panic-msgs` and `log` features.");
+
+#[cfg(all(feature = "no-panic-msgs", feature = "defmt"))]
+compile_error!("You may not enable both `no-panic-msgs` and `defmt` features.");
 
 #[collapse_debuginfo(yes)]
 macro_rules! assert {
     ($($x:tt)*) => {
         {
-            #[cfg(not(feature = "defmt"))]
+            #[cfg(not(any(feature = "defmt", feature = "no-panic-msgs")))]
             ::core::assert!($($x)*);
             #[cfg(feature = "defmt")]
             ::defmt::assert!($($x)*);
+            #[cfg(feature = "no-panic-msgs")]
+            $crate::fmt::no_panic_msgs::assert!($($x)*);
         }
     };
 }
@@ -22,10 +34,12 @@ macro_rules! assert {
 macro_rules! assert_eq {
     ($($x:tt)*) => {
         {
-            #[cfg(not(feature = "defmt"))]
+            #[cfg(not(any(feature = "defmt", feature = "no-panic-msgs")))]
             ::core::assert_eq!($($x)*);
             #[cfg(feature = "defmt")]
             ::defmt::assert_eq!($($x)*);
+            #[cfg(feature = "no-panic-msgs")]
+            $crate::fmt::no_panic_msgs::assert_eq!($($x)*);
         }
     };
 }
@@ -34,10 +48,12 @@ macro_rules! assert_eq {
 macro_rules! assert_ne {
     ($($x:tt)*) => {
         {
-            #[cfg(not(feature = "defmt"))]
+            #[cfg(not(any(feature = "defmt", feature = "no-panic-msgs")))]
             ::core::assert_ne!($($x)*);
             #[cfg(feature = "defmt")]
             ::defmt::assert_ne!($($x)*);
+            #[cfg(feature = "no-panic-msgs")]
+            $crate::fmt::no_panic_msgs::assert_ne!($($x)*);
         }
     };
 }
@@ -46,10 +62,12 @@ macro_rules! assert_ne {
 macro_rules! debug_assert {
     ($($x:tt)*) => {
         {
-            #[cfg(not(feature = "defmt"))]
+            #[cfg(not(any(feature = "defmt", feature = "no-panic-msgs")))]
             ::core::debug_assert!($($x)*);
             #[cfg(feature = "defmt")]
             ::defmt::debug_assert!($($x)*);
+            #[cfg(feature = "no-panic-msgs")]
+            $crate::fmt::no_panic_msgs::debug_assert!($($x)*);
         }
     };
 }
@@ -58,10 +76,12 @@ macro_rules! debug_assert {
 macro_rules! debug_assert_eq {
     ($($x:tt)*) => {
         {
-            #[cfg(not(feature = "defmt"))]
+            #[cfg(not(any(feature = "defmt", feature = "no-panic-msgs")))]
             ::core::debug_assert_eq!($($x)*);
             #[cfg(feature = "defmt")]
             ::defmt::debug_assert_eq!($($x)*);
+            #[cfg(feature = "no-panic-msgs")]
+            $crate::fmt::no_panic_msgs::debug_assert_eq!($($x)*);
         }
     };
 }
@@ -70,10 +90,12 @@ macro_rules! debug_assert_eq {
 macro_rules! debug_assert_ne {
     ($($x:tt)*) => {
         {
-            #[cfg(not(feature = "defmt"))]
+            #[cfg(not(any(feature = "defmt", feature = "no-panic-msgs")))]
             ::core::debug_assert_ne!($($x)*);
             #[cfg(feature = "defmt")]
             ::defmt::debug_assert_ne!($($x)*);
+            #[cfg(feature = "no-panic-msgs")]
+            $crate::fmt::no_panic_msgs::debug_assert_ne!($($x)*);
         }
     };
 }
@@ -82,15 +104,17 @@ macro_rules! debug_assert_ne {
 macro_rules! todo {
     ($($x:tt)*) => {
         {
-            #[cfg(not(feature = "defmt"))]
+            #[cfg(not(any(feature = "defmt", feature = "no-panic-msgs")))]
             ::core::todo!($($x)*);
             #[cfg(feature = "defmt")]
             ::defmt::todo!($($x)*);
+            #[cfg(feature = "no-panic-msgs")]
+            ::core::todo!("");
         }
     };
 }
 
-#[cfg(not(feature = "defmt"))]
+#[cfg(not(any(feature = "defmt", feature = "no-panic-msgs")))]
 #[collapse_debuginfo(yes)]
 macro_rules! unreachable {
     ($($x:tt)*) => {
@@ -106,14 +130,24 @@ macro_rules! unreachable {
     };
 }
 
+#[cfg(feature = "no-panic-msgs")]
+#[collapse_debuginfo(yes)]
+macro_rules! unreachable {
+    ($($x:tt)*) => {
+        ::core::unreachable!("")
+    };
+}
+
 #[collapse_debuginfo(yes)]
 macro_rules! panic {
     ($($x:tt)*) => {
         {
-            #[cfg(not(feature = "defmt"))]
+            #[cfg(not(any(feature = "defmt", feature = "no-panic-msgs")))]
             ::core::panic!($($x)*);
             #[cfg(feature = "defmt")]
             ::defmt::panic!($($x)*);
+            #[cfg(feature = "no-panic-msgs")]
+            ::core::panic!();
         }
     };
 }
@@ -126,7 +160,7 @@ macro_rules! trace {
             ::log::trace!($s $(, $x)*);
             #[cfg(feature = "defmt")]
             ::defmt::trace!($s $(, $x)*);
-            #[cfg(not(any(feature = "log", feature="defmt")))]
+            #[cfg(not(any(feature = "log", feature = "defmt")))]
             let _ = ($( & $x ),*);
         }
     };
@@ -140,7 +174,7 @@ macro_rules! debug {
             ::log::debug!($s $(, $x)*);
             #[cfg(feature = "defmt")]
             ::defmt::debug!($s $(, $x)*);
-            #[cfg(not(any(feature = "log", feature="defmt")))]
+            #[cfg(not(any(feature = "log", feature = "defmt")))]
             let _ = ($( & $x ),*);
         }
     };
@@ -154,7 +188,7 @@ macro_rules! info {
             ::log::info!($s $(, $x)*);
             #[cfg(feature = "defmt")]
             ::defmt::info!($s $(, $x)*);
-            #[cfg(not(any(feature = "log", feature="defmt")))]
+            #[cfg(not(any(feature = "log", feature = "defmt")))]
             let _ = ($( & $x ),*);
         }
     };
@@ -168,7 +202,7 @@ macro_rules! warn {
             ::log::warn!($s $(, $x)*);
             #[cfg(feature = "defmt")]
             ::defmt::warn!($s $(, $x)*);
-            #[cfg(not(any(feature = "log", feature="defmt")))]
+            #[cfg(not(any(feature = "log", feature = "defmt")))]
             let _ = ($( & $x ),*);
         }
     };
@@ -182,7 +216,7 @@ macro_rules! error {
             ::log::error!($s $(, $x)*);
             #[cfg(feature = "defmt")]
             ::defmt::error!($s $(, $x)*);
-            #[cfg(not(any(feature = "log", feature="defmt")))]
+            #[cfg(not(any(feature = "log", feature = "defmt")))]
             let _ = ($( & $x ),*);
         }
     };
@@ -196,7 +230,15 @@ macro_rules! unwrap {
     };
 }
 
-#[cfg(not(feature = "defmt"))]
+#[cfg(feature = "no-panic-msgs")]
+#[collapse_debuginfo(yes)]
+macro_rules! unwrap {
+    ($($x:tt)*) => {
+        $crate::fmt::no_panic_msgs::unwrap!($($x)*)
+    };
+}
+
+#[cfg(not(any(feature = "defmt", feature = "no-panic-msgs")))]
 #[collapse_debuginfo(yes)]
 macro_rules! unwrap {
     ($arg:expr) => {

--- a/embassy-nrf/src/fmt/no_panic_msgs.rs
+++ b/embassy-nrf/src/fmt/no_panic_msgs.rs
@@ -1,0 +1,67 @@
+//! Equivalents of panicking macros that discard their messages
+//!
+//! Enabled by the `no-panic-msgs` feature.  Panics that include messages waste valuable flash
+//! storage, and removing these messages are useful when failure is very unlikely, e.g. when
+//! running as part of a bootloader.
+
+macro_rules! assert {
+    ($cond:expr $(,$($rest:tt)+)?) => {
+        ::core::assert!($cond, "")
+    };
+}
+pub(crate) use assert;
+
+macro_rules! assert_eq {
+    ($left:expr, $right:expr $(,$($rest:tt)+)?) => {
+        ::core::assert_eq!($left, $right, "")
+    };
+}
+pub(crate) use assert_eq;
+
+macro_rules! assert_ne {
+    ($left:expr, $right:expr $(,$($rest:tt)+)?) => {
+        ::core::assert_ne!($left, $right, "")
+    };
+}
+pub(crate) use assert_ne;
+
+macro_rules! debug_assert {
+    ($cond:expr $(,$($rest:tt)+)?) => {
+        ::core::debug_assert!($cond, "")
+    };
+}
+pub(crate) use debug_assert;
+
+macro_rules! debug_assert_eq {
+    ($left:expr, $right:expr $(,$($rest:tt)+)?) => {
+        ::core::debug_assert_eq!($left, $right, "")
+    };
+}
+pub(crate) use debug_assert_eq;
+
+macro_rules! debug_assert_ne {
+    ($left:expr, $right:expr $(,$($rest:tt)+)?) => {
+        ::core::debug_assert_ne!($left, $right, "")
+    };
+}
+pub(crate) use debug_assert_ne;
+
+macro_rules! unwrap {
+    ($arg:expr) => {
+        match $crate::fmt::Try::into_result($arg) {
+            ::core::result::Result::Ok(t) => t,
+            ::core::result::Result::Err(_) => {
+                ::core::panic!();
+            }
+        }
+    };
+    ($arg:expr $(,$($rest:tt)+)?) => {
+        match $crate::fmt::Try::into_result($arg) {
+            ::core::result::Result::Ok(t) => t,
+            ::core::result::Result::Err(_) => {
+                ::core::panic!();
+            }
+        }
+    };
+}
+pub(crate) use unwrap;

--- a/embassy-rp/Cargo.toml
+++ b/embassy-rp/Cargo.toml
@@ -28,6 +28,12 @@ rt = [ "rp-pac/rt" ]
 ## Enable [defmt support](https://docs.rs/defmt) and enables `defmt` debug-log messages and formatting in embassy drivers.
 defmt = ["dep:defmt", "embassy-usb-driver/defmt", "embassy-hal-internal/defmt"]
 
+## Disable panic messsages where possible, to reduce binary size.  Mutually exclusive with the `defmt` and `log`
+## features.
+## Panic messages are normally stored in the resulting binary as literal strings.  Removing them is useful for limiting
+## flash usage e.g. for bootloaders.
+no-panic-msgs = []
+
 ## Configure the critical section crate to use an implementation that is safe for multicore use on rp2040.
 critical-section-impl = ["critical-section/restore-state-u8"]
 

--- a/embassy-rp/src/fmt.rs
+++ b/embassy-rp/src/fmt.rs
@@ -3,17 +3,29 @@
 
 use core::fmt::{Debug, Display, LowerHex};
 
+#[cfg(feature = "no-panic-msgs")]
+#[macro_use]
+pub mod no_panic_msgs;
+
 #[cfg(all(feature = "defmt", feature = "log"))]
 compile_error!("You may not enable both `defmt` and `log` features.");
+
+#[cfg(all(feature = "no-panic-msgs", feature = "log"))]
+compile_error!("You may not enable both `no-panic-msgs` and `log` features.");
+
+#[cfg(all(feature = "no-panic-msgs", feature = "defmt"))]
+compile_error!("You may not enable both `no-panic-msgs` and `defmt` features.");
 
 #[collapse_debuginfo(yes)]
 macro_rules! assert {
     ($($x:tt)*) => {
         {
-            #[cfg(not(feature = "defmt"))]
+            #[cfg(not(any(feature = "defmt", feature = "no-panic-msgs")))]
             ::core::assert!($($x)*);
             #[cfg(feature = "defmt")]
             ::defmt::assert!($($x)*);
+            #[cfg(feature = "no-panic-msgs")]
+            $crate::fmt::no_panic_msgs::assert!($($x)*);
         }
     };
 }
@@ -22,10 +34,12 @@ macro_rules! assert {
 macro_rules! assert_eq {
     ($($x:tt)*) => {
         {
-            #[cfg(not(feature = "defmt"))]
+            #[cfg(not(any(feature = "defmt", feature = "no-panic-msgs")))]
             ::core::assert_eq!($($x)*);
             #[cfg(feature = "defmt")]
             ::defmt::assert_eq!($($x)*);
+            #[cfg(feature = "no-panic-msgs")]
+            $crate::fmt::no_panic_msgs::assert_eq!($($x)*);
         }
     };
 }
@@ -34,10 +48,12 @@ macro_rules! assert_eq {
 macro_rules! assert_ne {
     ($($x:tt)*) => {
         {
-            #[cfg(not(feature = "defmt"))]
+            #[cfg(not(any(feature = "defmt", feature = "no-panic-msgs")))]
             ::core::assert_ne!($($x)*);
             #[cfg(feature = "defmt")]
             ::defmt::assert_ne!($($x)*);
+            #[cfg(feature = "no-panic-msgs")]
+            $crate::fmt::no_panic_msgs::assert_ne!($($x)*);
         }
     };
 }
@@ -46,10 +62,12 @@ macro_rules! assert_ne {
 macro_rules! debug_assert {
     ($($x:tt)*) => {
         {
-            #[cfg(not(feature = "defmt"))]
+            #[cfg(not(any(feature = "defmt", feature = "no-panic-msgs")))]
             ::core::debug_assert!($($x)*);
             #[cfg(feature = "defmt")]
             ::defmt::debug_assert!($($x)*);
+            #[cfg(feature = "no-panic-msgs")]
+            $crate::fmt::no_panic_msgs::debug_assert!($($x)*);
         }
     };
 }
@@ -58,10 +76,12 @@ macro_rules! debug_assert {
 macro_rules! debug_assert_eq {
     ($($x:tt)*) => {
         {
-            #[cfg(not(feature = "defmt"))]
+            #[cfg(not(any(feature = "defmt", feature = "no-panic-msgs")))]
             ::core::debug_assert_eq!($($x)*);
             #[cfg(feature = "defmt")]
             ::defmt::debug_assert_eq!($($x)*);
+            #[cfg(feature = "no-panic-msgs")]
+            $crate::fmt::no_panic_msgs::debug_assert_eq!($($x)*);
         }
     };
 }
@@ -70,10 +90,12 @@ macro_rules! debug_assert_eq {
 macro_rules! debug_assert_ne {
     ($($x:tt)*) => {
         {
-            #[cfg(not(feature = "defmt"))]
+            #[cfg(not(any(feature = "defmt", feature = "no-panic-msgs")))]
             ::core::debug_assert_ne!($($x)*);
             #[cfg(feature = "defmt")]
             ::defmt::debug_assert_ne!($($x)*);
+            #[cfg(feature = "no-panic-msgs")]
+            $crate::fmt::no_panic_msgs::debug_assert_ne!($($x)*);
         }
     };
 }
@@ -82,15 +104,17 @@ macro_rules! debug_assert_ne {
 macro_rules! todo {
     ($($x:tt)*) => {
         {
-            #[cfg(not(feature = "defmt"))]
+            #[cfg(not(any(feature = "defmt", feature = "no-panic-msgs")))]
             ::core::todo!($($x)*);
             #[cfg(feature = "defmt")]
             ::defmt::todo!($($x)*);
+            #[cfg(feature = "no-panic-msgs")]
+            ::core::todo!("");
         }
     };
 }
 
-#[cfg(not(feature = "defmt"))]
+#[cfg(not(any(feature = "defmt", feature = "no-panic-msgs")))]
 #[collapse_debuginfo(yes)]
 macro_rules! unreachable {
     ($($x:tt)*) => {
@@ -106,14 +130,24 @@ macro_rules! unreachable {
     };
 }
 
+#[cfg(feature = "no-panic-msgs")]
+#[collapse_debuginfo(yes)]
+macro_rules! unreachable {
+    ($($x:tt)*) => {
+        ::core::unreachable!("")
+    };
+}
+
 #[collapse_debuginfo(yes)]
 macro_rules! panic {
     ($($x:tt)*) => {
         {
-            #[cfg(not(feature = "defmt"))]
+            #[cfg(not(any(feature = "defmt", feature = "no-panic-msgs")))]
             ::core::panic!($($x)*);
             #[cfg(feature = "defmt")]
             ::defmt::panic!($($x)*);
+            #[cfg(feature = "no-panic-msgs")]
+            ::core::panic!();
         }
     };
 }
@@ -126,7 +160,7 @@ macro_rules! trace {
             ::log::trace!($s $(, $x)*);
             #[cfg(feature = "defmt")]
             ::defmt::trace!($s $(, $x)*);
-            #[cfg(not(any(feature = "log", feature="defmt")))]
+            #[cfg(not(any(feature = "log", feature = "defmt")))]
             let _ = ($( & $x ),*);
         }
     };
@@ -140,7 +174,7 @@ macro_rules! debug {
             ::log::debug!($s $(, $x)*);
             #[cfg(feature = "defmt")]
             ::defmt::debug!($s $(, $x)*);
-            #[cfg(not(any(feature = "log", feature="defmt")))]
+            #[cfg(not(any(feature = "log", feature = "defmt")))]
             let _ = ($( & $x ),*);
         }
     };
@@ -154,7 +188,7 @@ macro_rules! info {
             ::log::info!($s $(, $x)*);
             #[cfg(feature = "defmt")]
             ::defmt::info!($s $(, $x)*);
-            #[cfg(not(any(feature = "log", feature="defmt")))]
+            #[cfg(not(any(feature = "log", feature = "defmt")))]
             let _ = ($( & $x ),*);
         }
     };
@@ -168,7 +202,7 @@ macro_rules! warn {
             ::log::warn!($s $(, $x)*);
             #[cfg(feature = "defmt")]
             ::defmt::warn!($s $(, $x)*);
-            #[cfg(not(any(feature = "log", feature="defmt")))]
+            #[cfg(not(any(feature = "log", feature = "defmt")))]
             let _ = ($( & $x ),*);
         }
     };
@@ -182,7 +216,7 @@ macro_rules! error {
             ::log::error!($s $(, $x)*);
             #[cfg(feature = "defmt")]
             ::defmt::error!($s $(, $x)*);
-            #[cfg(not(any(feature = "log", feature="defmt")))]
+            #[cfg(not(any(feature = "log", feature = "defmt")))]
             let _ = ($( & $x ),*);
         }
     };
@@ -196,7 +230,15 @@ macro_rules! unwrap {
     };
 }
 
-#[cfg(not(feature = "defmt"))]
+#[cfg(feature = "no-panic-msgs")]
+#[collapse_debuginfo(yes)]
+macro_rules! unwrap {
+    ($($x:tt)*) => {
+        $crate::fmt::no_panic_msgs::unwrap!($($x)*)
+    };
+}
+
+#[cfg(not(any(feature = "defmt", feature = "no-panic-msgs")))]
 #[collapse_debuginfo(yes)]
 macro_rules! unwrap {
     ($arg:expr) => {

--- a/embassy-rp/src/fmt/no_panic_msgs.rs
+++ b/embassy-rp/src/fmt/no_panic_msgs.rs
@@ -1,0 +1,67 @@
+//! Equivalents of panicking macros that discard their messages
+//!
+//! Enabled by the `no-panic-msgs` feature.  Panics that include messages waste valuable flash
+//! storage, and removing these messages are useful when failure is very unlikely, e.g. when
+//! running as part of a bootloader.
+
+macro_rules! assert {
+    ($cond:expr $(,$($rest:tt)+)?) => {
+        ::core::assert!($cond, "")
+    };
+}
+pub(crate) use assert;
+
+macro_rules! assert_eq {
+    ($left:expr, $right:expr $(,$($rest:tt)+)?) => {
+        ::core::assert_eq!($left, $right, "")
+    };
+}
+pub(crate) use assert_eq;
+
+macro_rules! assert_ne {
+    ($left:expr, $right:expr $(,$($rest:tt)+)?) => {
+        ::core::assert_ne!($left, $right, "")
+    };
+}
+pub(crate) use assert_ne;
+
+macro_rules! debug_assert {
+    ($cond:expr $(,$($rest:tt)+)?) => {
+        ::core::debug_assert!($cond, "")
+    };
+}
+pub(crate) use debug_assert;
+
+macro_rules! debug_assert_eq {
+    ($left:expr, $right:expr $(,$($rest:tt)+)?) => {
+        ::core::debug_assert_eq!($left, $right, "")
+    };
+}
+pub(crate) use debug_assert_eq;
+
+macro_rules! debug_assert_ne {
+    ($left:expr, $right:expr $(,$($rest:tt)+)?) => {
+        ::core::debug_assert_ne!($left, $right, "")
+    };
+}
+pub(crate) use debug_assert_ne;
+
+macro_rules! unwrap {
+    ($arg:expr) => {
+        match $crate::fmt::Try::into_result($arg) {
+            ::core::result::Result::Ok(t) => t,
+            ::core::result::Result::Err(_) => {
+                ::core::panic!();
+            }
+        }
+    };
+    ($arg:expr $(,$($rest:tt)+)?) => {
+        match $crate::fmt::Try::into_result($arg) {
+            ::core::result::Result::Ok(t) => t,
+            ::core::result::Result::Err(_) => {
+                ::core::panic!();
+            }
+        }
+    };
+}
+pub(crate) use unwrap;

--- a/embassy-stm32/Cargo.toml
+++ b/embassy-stm32/Cargo.toml
@@ -108,6 +108,12 @@ rt = ["stm32-metapac/rt"]
 ## Use [`defmt`](https://docs.rs/defmt/latest/defmt/) for logging
 defmt = ["dep:defmt", "embassy-sync/defmt", "embassy-embedded-hal/defmt", "embassy-hal-internal/defmt", "embedded-io-async/defmt-03", "embassy-usb-driver/defmt", "embassy-net-driver/defmt", "embassy-time?/defmt"]
 
+## Disable panic messsages where possible, to reduce binary size.  Mutually exclusive with the `defmt` and `log`
+## features.
+## Panic messages are normally stored in the resulting binary as literal strings.  Removing them is useful for limiting
+## flash usage e.g. for bootloaders.
+no-panic-msgs = []
+
 exti = []
 low-power = [ "dep:embassy-executor", "embassy-executor?/arch-cortex-m", "time" ]
 low-power-debug-with-sleep = []

--- a/embassy-stm32/src/fmt.rs
+++ b/embassy-stm32/src/fmt.rs
@@ -3,17 +3,29 @@
 
 use core::fmt::{Debug, Display, LowerHex};
 
+#[cfg(feature = "no-panic-msgs")]
+#[macro_use]
+pub mod no_panic_msgs;
+
 #[cfg(all(feature = "defmt", feature = "log"))]
 compile_error!("You may not enable both `defmt` and `log` features.");
+
+#[cfg(all(feature = "no-panic-msgs", feature = "log"))]
+compile_error!("You may not enable both `no-panic-msgs` and `log` features.");
+
+#[cfg(all(feature = "no-panic-msgs", feature = "defmt"))]
+compile_error!("You may not enable both `no-panic-msgs` and `defmt` features.");
 
 #[collapse_debuginfo(yes)]
 macro_rules! assert {
     ($($x:tt)*) => {
         {
-            #[cfg(not(feature = "defmt"))]
+            #[cfg(not(any(feature = "defmt", feature = "no-panic-msgs")))]
             ::core::assert!($($x)*);
             #[cfg(feature = "defmt")]
             ::defmt::assert!($($x)*);
+            #[cfg(feature = "no-panic-msgs")]
+            $crate::fmt::no_panic_msgs::assert!($($x)*);
         }
     };
 }
@@ -22,10 +34,12 @@ macro_rules! assert {
 macro_rules! assert_eq {
     ($($x:tt)*) => {
         {
-            #[cfg(not(feature = "defmt"))]
+            #[cfg(not(any(feature = "defmt", feature = "no-panic-msgs")))]
             ::core::assert_eq!($($x)*);
             #[cfg(feature = "defmt")]
             ::defmt::assert_eq!($($x)*);
+            #[cfg(feature = "no-panic-msgs")]
+            $crate::fmt::no_panic_msgs::assert_eq!($($x)*);
         }
     };
 }
@@ -34,10 +48,12 @@ macro_rules! assert_eq {
 macro_rules! assert_ne {
     ($($x:tt)*) => {
         {
-            #[cfg(not(feature = "defmt"))]
+            #[cfg(not(any(feature = "defmt", feature = "no-panic-msgs")))]
             ::core::assert_ne!($($x)*);
             #[cfg(feature = "defmt")]
             ::defmt::assert_ne!($($x)*);
+            #[cfg(feature = "no-panic-msgs")]
+            $crate::fmt::no_panic_msgs::assert_ne!($($x)*);
         }
     };
 }
@@ -46,10 +62,12 @@ macro_rules! assert_ne {
 macro_rules! debug_assert {
     ($($x:tt)*) => {
         {
-            #[cfg(not(feature = "defmt"))]
+            #[cfg(not(any(feature = "defmt", feature = "no-panic-msgs")))]
             ::core::debug_assert!($($x)*);
             #[cfg(feature = "defmt")]
             ::defmt::debug_assert!($($x)*);
+            #[cfg(feature = "no-panic-msgs")]
+            $crate::fmt::no_panic_msgs::debug_assert!($($x)*);
         }
     };
 }
@@ -58,10 +76,12 @@ macro_rules! debug_assert {
 macro_rules! debug_assert_eq {
     ($($x:tt)*) => {
         {
-            #[cfg(not(feature = "defmt"))]
+            #[cfg(not(any(feature = "defmt", feature = "no-panic-msgs")))]
             ::core::debug_assert_eq!($($x)*);
             #[cfg(feature = "defmt")]
             ::defmt::debug_assert_eq!($($x)*);
+            #[cfg(feature = "no-panic-msgs")]
+            $crate::fmt::no_panic_msgs::debug_assert_eq!($($x)*);
         }
     };
 }
@@ -70,10 +90,12 @@ macro_rules! debug_assert_eq {
 macro_rules! debug_assert_ne {
     ($($x:tt)*) => {
         {
-            #[cfg(not(feature = "defmt"))]
+            #[cfg(not(any(feature = "defmt", feature = "no-panic-msgs")))]
             ::core::debug_assert_ne!($($x)*);
             #[cfg(feature = "defmt")]
             ::defmt::debug_assert_ne!($($x)*);
+            #[cfg(feature = "no-panic-msgs")]
+            $crate::fmt::no_panic_msgs::debug_assert_ne!($($x)*);
         }
     };
 }
@@ -82,15 +104,17 @@ macro_rules! debug_assert_ne {
 macro_rules! todo {
     ($($x:tt)*) => {
         {
-            #[cfg(not(feature = "defmt"))]
+            #[cfg(not(any(feature = "defmt", feature = "no-panic-msgs")))]
             ::core::todo!($($x)*);
             #[cfg(feature = "defmt")]
             ::defmt::todo!($($x)*);
+            #[cfg(feature = "no-panic-msgs")]
+            ::core::todo!("");
         }
     };
 }
 
-#[cfg(not(feature = "defmt"))]
+#[cfg(not(any(feature = "defmt", feature = "no-panic-msgs")))]
 #[collapse_debuginfo(yes)]
 macro_rules! unreachable {
     ($($x:tt)*) => {
@@ -106,14 +130,24 @@ macro_rules! unreachable {
     };
 }
 
+#[cfg(feature = "no-panic-msgs")]
+#[collapse_debuginfo(yes)]
+macro_rules! unreachable {
+    ($($x:tt)*) => {
+        ::core::unreachable!("")
+    };
+}
+
 #[collapse_debuginfo(yes)]
 macro_rules! panic {
     ($($x:tt)*) => {
         {
-            #[cfg(not(feature = "defmt"))]
+            #[cfg(not(any(feature = "defmt", feature = "no-panic-msgs")))]
             ::core::panic!($($x)*);
             #[cfg(feature = "defmt")]
             ::defmt::panic!($($x)*);
+            #[cfg(feature = "no-panic-msgs")]
+            ::core::panic!();
         }
     };
 }
@@ -126,7 +160,7 @@ macro_rules! trace {
             ::log::trace!($s $(, $x)*);
             #[cfg(feature = "defmt")]
             ::defmt::trace!($s $(, $x)*);
-            #[cfg(not(any(feature = "log", feature="defmt")))]
+            #[cfg(not(any(feature = "log", feature = "defmt")))]
             let _ = ($( & $x ),*);
         }
     };
@@ -140,7 +174,7 @@ macro_rules! debug {
             ::log::debug!($s $(, $x)*);
             #[cfg(feature = "defmt")]
             ::defmt::debug!($s $(, $x)*);
-            #[cfg(not(any(feature = "log", feature="defmt")))]
+            #[cfg(not(any(feature = "log", feature = "defmt")))]
             let _ = ($( & $x ),*);
         }
     };
@@ -154,7 +188,7 @@ macro_rules! info {
             ::log::info!($s $(, $x)*);
             #[cfg(feature = "defmt")]
             ::defmt::info!($s $(, $x)*);
-            #[cfg(not(any(feature = "log", feature="defmt")))]
+            #[cfg(not(any(feature = "log", feature = "defmt")))]
             let _ = ($( & $x ),*);
         }
     };
@@ -168,7 +202,7 @@ macro_rules! warn {
             ::log::warn!($s $(, $x)*);
             #[cfg(feature = "defmt")]
             ::defmt::warn!($s $(, $x)*);
-            #[cfg(not(any(feature = "log", feature="defmt")))]
+            #[cfg(not(any(feature = "log", feature = "defmt")))]
             let _ = ($( & $x ),*);
         }
     };
@@ -182,7 +216,7 @@ macro_rules! error {
             ::log::error!($s $(, $x)*);
             #[cfg(feature = "defmt")]
             ::defmt::error!($s $(, $x)*);
-            #[cfg(not(any(feature = "log", feature="defmt")))]
+            #[cfg(not(any(feature = "log", feature = "defmt")))]
             let _ = ($( & $x ),*);
         }
     };
@@ -196,7 +230,15 @@ macro_rules! unwrap {
     };
 }
 
-#[cfg(not(feature = "defmt"))]
+#[cfg(feature = "no-panic-msgs")]
+#[collapse_debuginfo(yes)]
+macro_rules! unwrap {
+    ($($x:tt)*) => {
+        $crate::fmt::no_panic_msgs::unwrap!($($x)*)
+    };
+}
+
+#[cfg(not(any(feature = "defmt", feature = "no-panic-msgs")))]
 #[collapse_debuginfo(yes)]
 macro_rules! unwrap {
     ($arg:expr) => {

--- a/embassy-stm32/src/fmt/no_panic_msgs.rs
+++ b/embassy-stm32/src/fmt/no_panic_msgs.rs
@@ -1,0 +1,67 @@
+//! Equivalents of panicking macros that discard their messages
+//!
+//! Enabled by the `no-panic-msgs` feature.  Panics that include messages waste valuable flash
+//! storage, and removing these messages are useful when failure is very unlikely, e.g. when
+//! running as part of a bootloader.
+
+macro_rules! assert {
+    ($cond:expr $(,$($rest:tt)+)?) => {
+        ::core::assert!($cond, "")
+    };
+}
+pub(crate) use assert;
+
+macro_rules! assert_eq {
+    ($left:expr, $right:expr $(,$($rest:tt)+)?) => {
+        ::core::assert_eq!($left, $right, "")
+    };
+}
+pub(crate) use assert_eq;
+
+macro_rules! assert_ne {
+    ($left:expr, $right:expr $(,$($rest:tt)+)?) => {
+        ::core::assert_ne!($left, $right, "")
+    };
+}
+pub(crate) use assert_ne;
+
+macro_rules! debug_assert {
+    ($cond:expr $(,$($rest:tt)+)?) => {
+        ::core::debug_assert!($cond, "")
+    };
+}
+pub(crate) use debug_assert;
+
+macro_rules! debug_assert_eq {
+    ($left:expr, $right:expr $(,$($rest:tt)+)?) => {
+        ::core::debug_assert_eq!($left, $right, "")
+    };
+}
+pub(crate) use debug_assert_eq;
+
+macro_rules! debug_assert_ne {
+    ($left:expr, $right:expr $(,$($rest:tt)+)?) => {
+        ::core::debug_assert_ne!($left, $right, "")
+    };
+}
+pub(crate) use debug_assert_ne;
+
+macro_rules! unwrap {
+    ($arg:expr) => {
+        match $crate::fmt::Try::into_result($arg) {
+            ::core::result::Result::Ok(t) => t,
+            ::core::result::Result::Err(_) => {
+                ::core::panic!();
+            }
+        }
+    };
+    ($arg:expr $(,$($rest:tt)+)?) => {
+        match $crate::fmt::Try::into_result($arg) {
+            ::core::result::Result::Ok(t) => t,
+            ::core::result::Result::Err(_) => {
+                ::core::panic!();
+            }
+        }
+    };
+}
+pub(crate) use unwrap;


### PR DESCRIPTION
# Overview

Add a new feature that reduces binary size significantly for certain types of binaries.  For example, for the stm32 bootloader example, about 39% of the binary is just strings used for panicking, and as shown below, the binary size can easily be reduced from `10.1kiB` to `6.16kiB`.

This is usually not a problem for programs that use `defmt` as the existing `defmt` infra already removes most strings from the binary, but using `defmt` is not always desirable, e.g. for bootloaders.

For my own application, I need to fit a bootloader into `3 kiB` , and this change allowed me to go from `3.33 kiB` to `2.77 kiB`.

# Details

Without this feature enabled, here's the binary size for the stm32 bootloader example:

```
$ cargo build --release --features embassy-stm32/stm32f303re
$ bloaty --domain=vm /home/dflemstr/.cache/cargo/target/thumbv7em-none-eabi/release/stm32-bootloader-example
     VM SIZE    
 -------------- 
  83.0%  8.39Ki    .text
  11.7%  1.18Ki    .rodata
   3.9%     404    .vector_table
   1.4%     148    .bss
 100.0%  10.1Ki    TOTAL

$ strings -d /home/dflemstr/.cache/cargo/target/thumbv7em-none-eabi/release/stm32-bootloader-example
[...]
assertion failed: dfu.capacity() as u32 - active.capacity() as u32 >= page_sizeassertion failed: 2 + 2 * (active.capacity() as u32 / page_size) <=
    state.capacity() as u32 / STATE::WRITE_SIZE as u32Boot prepare error
FlashBadMagicNotAlignedOutOfBoundsOther
)called `Option::unwrap()` on a `None` value
    ,
assertion failed: n < 8usizecalled `Result::unwrap()` on an `Err` valueU
TryFromSliceError
assertion failed: self.lsinot yet implemented
assertion failed: max::HSE_OSC.contains(&hse.freq)
assertion failed: max::HSE_BYP.contains(&hse.freq)
assertion failed: max::HCLK.contains(&hclk)
assertion failed: max::PCLK1.contains(&pclk1)assertion failed: max::PCLK2.contains(&pclk2)assertion failed: !(adcpres == AdcHclkPrescaler::Div1 && config.ahb_pre != AHBPrescaler::DIV1)internal error: entered unreachable code@B
assertion failed: max::PLL_IN.contains(&in_freq)
assertion failed: max::PLL_OUT.contains(&out_freq)
```

With this feature enabled:

```
$ cargo build --release --features embassy-stm32/stm32f303re --features embassy-stm32/no-panic-msgs --features embassy-boot-stm32/no-panic-msgs
$ bloaty --domain=vm /home/dflemstr/.cache/cargo/target/thumbv7em-none-eabi/release/stm32-bootloader-example                                   
     VM SIZE    
 -------------- 
  86.9%  5.35Ki    .text
   6.4%     404    .vector_table
   4.4%     276    .rodata
   2.3%     148    .bss
 100.0%  6.16Ki    TOTAL

$ strings -d /home/dflemstr/.cache/cargo/target/thumbv7em-none-eabi/release/stm32-bootloader-example
[...]
called `Option::unwrap()` on a `None` valueassertion failed: n < 8usize
```

There are still some `.unwrap()`s and asserts left to be found, but this change removes most of them.