### PR TITLE
wiznet: add version check to initialization sequence

### DIFF
--- a/embassy-net-wiznet/src/chip/mod.rs
+++ b/embassy-net-wiznet/src/chip/mod.rs
@@ -8,10 +8,17 @@ pub use w5100s::W5100S;
 pub(crate) trait SealedChip {
     type Address;
 
+    /// The version of the chip as reported by the VERSIONR register.
+    /// This is used to verify that the chip is supported by the driver,
+    /// and that SPI communication is working.
+    const CHIP_VERSION: u8;
+
     const COMMON_MODE: Self::Address;
     const COMMON_MAC: Self::Address;
     const COMMON_SOCKET_INTR: Self::Address;
     const COMMON_PHY_CFG: Self::Address;
+    const COMMON_VERSION: Self::Address;
+
     const SOCKET_MODE: Self::Address;
     const SOCKET_COMMAND: Self::Address;
     const SOCKET_RXBUF_SIZE: Self::Address;

--- a/embassy-net-wiznet/src/chip/w5100s.rs
+++ b/embassy-net-wiznet/src/chip/w5100s.rs
@@ -11,10 +11,13 @@ impl super::Chip for W5100S {}
 impl super::SealedChip for W5100S {
     type Address = u16;
 
+    const CHIP_VERSION: u8 = 0x51;
+
     const COMMON_MODE: Self::Address = 0x00;
     const COMMON_MAC: Self::Address = 0x09;
     const COMMON_SOCKET_INTR: Self::Address = 0x16;
     const COMMON_PHY_CFG: Self::Address = 0x3c;
+    const COMMON_VERSION: Self::Address = 0x80;
 
     const SOCKET_MODE: Self::Address = SOCKET_BASE + 0x00;
     const SOCKET_COMMAND: Self::Address = SOCKET_BASE + 0x01;

--- a/embassy-net-wiznet/src/chip/w5500.rs
+++ b/embassy-net-wiznet/src/chip/w5500.rs
@@ -15,10 +15,13 @@ impl super::Chip for W5500 {}
 impl super::SealedChip for W5500 {
     type Address = (RegisterBlock, u16);
 
+    const CHIP_VERSION: u8 = 0x04;
+
     const COMMON_MODE: Self::Address = (RegisterBlock::Common, 0x00);
     const COMMON_MAC: Self::Address = (RegisterBlock::Common, 0x09);
     const COMMON_SOCKET_INTR: Self::Address = (RegisterBlock::Common, 0x18);
     const COMMON_PHY_CFG: Self::Address = (RegisterBlock::Common, 0x2E);
+    const COMMON_VERSION: Self::Address = (RegisterBlock::Common, 0x39);
 
     const SOCKET_MODE: Self::Address = (RegisterBlock::Socket0, 0x00);
     const SOCKET_COMMAND: Self::Address = (RegisterBlock::Socket0, 0x01);

--- a/examples/rp/src/bin/ethernet_w5500_multisocket.rs
+++ b/examples/rp/src/bin/ethernet_w5500_multisocket.rs
@@ -63,7 +63,8 @@ async fn main(spawner: Spawner) {
         w5500_int,
         w5500_reset,
     )
-    .await;
+    .await
+    .unwrap();
     unwrap!(spawner.spawn(ethernet_task(runner)));
 
     // Generate random seed

--- a/examples/rp/src/bin/ethernet_w5500_tcp_client.rs
+++ b/examples/rp/src/bin/ethernet_w5500_tcp_client.rs
@@ -66,7 +66,8 @@ async fn main(spawner: Spawner) {
         w5500_int,
         w5500_reset,
     )
-    .await;
+    .await
+    .unwrap();
     unwrap!(spawner.spawn(ethernet_task(runner)));
 
     // Generate random seed

--- a/examples/rp/src/bin/ethernet_w5500_tcp_server.rs
+++ b/examples/rp/src/bin/ethernet_w5500_tcp_server.rs
@@ -65,7 +65,8 @@ async fn main(spawner: Spawner) {
         w5500_int,
         w5500_reset,
     )
-    .await;
+    .await
+    .unwrap();
     unwrap!(spawner.spawn(ethernet_task(runner)));
 
     // Generate random seed

--- a/examples/rp/src/bin/ethernet_w5500_udp.rs
+++ b/examples/rp/src/bin/ethernet_w5500_udp.rs
@@ -63,7 +63,8 @@ async fn main(spawner: Spawner) {
         w5500_int,
         w5500_reset,
     )
-    .await;
+    .await
+    .unwrap();
     unwrap!(spawner.spawn(ethernet_task(runner)));
 
     // Generate random seed

--- a/examples/stm32f4/src/bin/eth_w5500.rs
+++ b/examples/stm32f4/src/bin/eth_w5500.rs
@@ -80,7 +80,9 @@ async fn main(spawner: Spawner) -> ! {
     let mac_addr = [0x02, 234, 3, 4, 82, 231];
     static STATE: StaticCell<State<2, 2>> = StaticCell::new();
     let state = STATE.init(State::<2, 2>::new());
-    let (device, runner) = embassy_net_wiznet::new(mac_addr, state, spi, w5500_int, w5500_reset).await;
+    let (device, runner) = embassy_net_wiznet::new(mac_addr, state, spi, w5500_int, w5500_reset)
+        .await
+        .unwrap();
     unwrap!(spawner.spawn(ethernet_task(runner)));
 
     let config = embassy_net::Config::dhcpv4(Default::default());

--- a/tests/rp/src/bin/ethernet_w5100s_perf.rs
+++ b/tests/rp/src/bin/ethernet_w5100s_perf.rs
@@ -59,7 +59,8 @@ async fn main(spawner: Spawner) {
         w5500_int,
         w5500_reset,
     )
-    .await;
+    .await
+    .unwrap();
     unwrap!(spawner.spawn(ethernet_task(runner)));
 
     // Generate random seed


### PR DESCRIPTION
This performs a read from the Wiznet chips to check their respective version registers, returning an error if they mismatch.

Do note that this is largely untested because I'm trying to debug an issue with a chip at the moment, but it was asked that this gets PR'd in anyway since currently the initialization sequence only performs writes and no reads.