### PR TITLE
Add feature "defmt" to embassy-embedded-hal

### DIFF
--- a/embassy-embedded-hal/Cargo.toml
+++ b/embassy-embedded-hal/Cargo.toml
@@ -24,6 +24,7 @@ features = ["std"]
 [features]
 std = []
 time = ["dep:embassy-time"]
+defmt = ["dep:defmt"]
 default = ["time"]
 
 [dependencies]


### PR DESCRIPTION
It seems that a "defmt" feature should indeed be available, see https://github.com/embassy-rs/embassy/blob/8c54df10422e2bbcd1bae1f2cd0f282d31ef1851/embassy-embedded-hal/src/shared_bus/mod.rs#L11 and https://github.com/embassy-rs/embassy/blob/8c54df10422e2bbcd1bae1f2cd0f282d31ef1851/embassy-embedded-hal/src/flash/partition/mod.rs#L13

Also, the defmt dependency is marked as optional.

This PR adds a "defmt" feature that pulls in the defmt dependency.

I hope this fixes some errors where `defmt::Format` is not implemented on the Error types.