### PR TITLE
stm32 adc: introduce blocking_read

### DIFF
--- a/embassy-stm32/src/adc/g4.rs
+++ b/embassy-stm32/src/adc/g4.rs
@@ -258,7 +258,7 @@ impl<'d, T: Instance> Adc<'d, T> {
     }
 
     /// Read an ADC pin.
-    pub fn read(&mut self, channel: &mut impl AdcChannel<T>) -> u16 {
+    pub fn blocking_read(&mut self, channel: &mut impl AdcChannel<T>) -> u16 {
         channel.setup();
 
         self.read_channel(channel.channel())

--- a/embassy-stm32/src/adc/v2.rs
+++ b/embassy-stm32/src/adc/v2.rs
@@ -178,7 +178,7 @@ where
         T::regs().dr().read().0 as u16
     }
 
-    pub fn read(&mut self, channel: &mut impl AdcChannel<T>) -> u16 {
+    pub fn blocking_read(&mut self, channel: &mut impl AdcChannel<T>) -> u16 {
         channel.setup();
 
         // Configure ADC

--- a/embassy-stm32/src/adc/v4.rs
+++ b/embassy-stm32/src/adc/v4.rs
@@ -318,12 +318,36 @@ impl<'d, T: Instance> Adc<'d, T> {
     }
 
     /// Read an ADC channel.
-    pub fn read(&mut self, channel: &mut impl AdcChannel<T>) -> u16 {
+    pub fn blocking_read(&mut self, channel: &mut impl AdcChannel<T>) -> u16 {
         self.read_channel(channel)
     }
 
-    /// Asynchronously read from sequence of ADC channels.
-    pub async fn read_async(
+    /// Read one or multiple ADC channels using DMA.
+    ///
+    /// `sequence` iterator and `readings` must have the same length.
+    ///
+    /// Example
+    /// ```rust,ignore
+    /// use embassy_stm32::adc::{Adc, AdcChannel}
+    ///
+    /// let mut adc = Adc::new(p.ADC1);
+    /// let mut adc_pin0 = p.PA0.degrade_adc();
+    /// let mut adc_pin2 = p.PA2.degrade_adc();
+    /// let mut measurements = [0u16; 2];
+    ///
+    /// adc.read_async(
+    ///     p.DMA2_CH0,
+    ///     [
+    ///         (&mut *adc_pin0, SampleTime::CYCLES112),
+    ///         (&mut *adc_pin2, SampleTime::CYCLES112),
+    ///     ]
+    ///     .into_iter(),
+    ///     &mut measurements,
+    /// )
+    /// .await;
+    /// defmt::info!("measurements: {}", measurements);
+    /// ```
+    pub async fn read(
         &mut self,
         rx_dma: &mut impl RxDma<T>,
         sequence: impl ExactSizeIterator<Item = (&mut AnyAdcChannel<T>, SampleTime)>,

--- a/examples/stm32f4/src/bin/adc.rs
+++ b/examples/stm32f4/src/bin/adc.rs
@@ -23,7 +23,7 @@ async fn main(_spawner: Spawner) {
     // Startup delay can be combined to the maximum of either
     delay.delay_us(Temperature::start_time_us().max(VrefInt::start_time_us()));
 
-    let vrefint_sample = adc.read(&mut vrefint);
+    let vrefint_sample = adc.blocking_read(&mut vrefint);
 
     let convert_to_millivolts = |sample| {
         // From http://www.st.com/resource/en/datasheet/DM00071990.pdf
@@ -50,16 +50,16 @@ async fn main(_spawner: Spawner) {
 
     loop {
         // Read pin
-        let v = adc.read(&mut pin);
+        let v = adc.blocking_read(&mut pin);
         info!("PC1: {} ({} mV)", v, convert_to_millivolts(v));
 
         // Read internal temperature
-        let v = adc.read(&mut temp);
+        let v = adc.blocking_read(&mut temp);
         let celcius = convert_to_celcius(v);
         info!("Internal temp: {} ({} C)", v, celcius);
 
         // Read internal voltage reference
-        let v = adc.read(&mut vrefint);
+        let v = adc.blocking_read(&mut vrefint);
         info!("VrefInt: {}", v);
 
         Timer::after_millis(100).await;

--- a/examples/stm32f4/src/bin/adc_dma.rs
+++ b/examples/stm32f4/src/bin/adc_dma.rs
@@ -44,7 +44,7 @@ async fn adc_task(mut p: Peripherals) {
     let _ = adc.start();
     let _ = adc2.start();
     loop {
-        match adc.read_exact(&mut buffer1).await {
+        match adc.read(&mut buffer1).await {
             Ok(_data) => {
                 let toc = Instant::now();
                 info!(
@@ -62,7 +62,7 @@ async fn adc_task(mut p: Peripherals) {
             }
         }
 
-        match adc2.read_exact(&mut buffer2).await {
+        match adc2.read(&mut buffer2).await {
             Ok(_data) => {
                 let toc = Instant::now();
                 info!(

--- a/examples/stm32f7/src/bin/adc.rs
+++ b/examples/stm32f7/src/bin/adc.rs
@@ -16,7 +16,7 @@ async fn main(_spawner: Spawner) {
     let mut pin = p.PA3;
 
     let mut vrefint = adc.enable_vrefint();
-    let vrefint_sample = adc.read(&mut vrefint);
+    let vrefint_sample = adc.blocking_read(&mut vrefint);
     let convert_to_millivolts = |sample| {
         // From http://www.st.com/resource/en/datasheet/DM00273119.pdf
         // 6.3.27 Reference voltage
@@ -26,7 +26,7 @@ async fn main(_spawner: Spawner) {
     };
 
     loop {
-        let v = adc.read(&mut pin);
+        let v = adc.blocking_read(&mut pin);
         info!("--> {} - {} mV", v, convert_to_millivolts(v));
         Timer::after_millis(100).await;
     }

--- a/examples/stm32g0/src/bin/adc.rs
+++ b/examples/stm32g0/src/bin/adc.rs
@@ -17,7 +17,7 @@ async fn main(_spawner: Spawner) {
     let mut pin = p.PA1;
 
     let mut vrefint = adc.enable_vrefint();
-    let vrefint_sample = adc.read(&mut vrefint);
+    let vrefint_sample = adc.blocking_read(&mut vrefint);
     let convert_to_millivolts = |sample| {
         // From https://www.st.com/resource/en/datasheet/stm32g031g8.pdf
         // 6.3.3 Embedded internal reference voltage
@@ -27,7 +27,7 @@ async fn main(_spawner: Spawner) {
     };
 
     loop {
-        let v = adc.read(&mut pin);
+        let v = adc.blocking_read(&mut pin);
         info!("--> {} - {} mV", v, convert_to_millivolts(v));
         Timer::after_millis(100).await;
     }

--- a/examples/stm32g0/src/bin/adc_dma.rs
+++ b/examples/stm32g0/src/bin/adc_dma.rs
@@ -24,7 +24,7 @@ async fn main(_spawner: Spawner) {
     let mut pa0 = p.PA0.degrade_adc();
 
     loop {
-        adc.read_async(
+        adc.read(
             &mut dma,
             [
                 (&mut vrefint_channel, SampleTime::CYCLES160_5),

--- a/examples/stm32g0/src/bin/adc_oversampling.rs
+++ b/examples/stm32g0/src/bin/adc_oversampling.rs
@@ -36,7 +36,7 @@ async fn main(_spawner: Spawner) {
     adc.oversampling_enable(true);
 
     loop {
-        let v = adc.read(&mut pin);
+        let v = adc.blocking_read(&mut pin);
         info!("--> {} ", v); //max 65520 = 0xFFF0
         Timer::after_millis(100).await;
     }

--- a/examples/stm32g4/src/bin/adc.rs
+++ b/examples/stm32g4/src/bin/adc.rs
@@ -32,7 +32,7 @@ async fn main(_spawner: Spawner) {
     adc.set_sample_time(SampleTime::CYCLES24_5);
 
     loop {
-        let measured = adc.read(&mut p.PA7);
+        let measured = adc.blocking_read(&mut p.PA7);
         info!("measured: {}", measured);
         Timer::after_millis(500).await;
     }

--- a/examples/stm32h7/src/bin/adc.rs
+++ b/examples/stm32h7/src/bin/adc.rs
@@ -51,9 +51,9 @@ async fn main(_spawner: Spawner) {
     let mut vrefint_channel = adc.enable_vrefint();
 
     loop {
-        let vrefint = adc.read(&mut vrefint_channel);
+        let vrefint = adc.blocking_read(&mut vrefint_channel);
         info!("vrefint: {}", vrefint);
-        let measured = adc.read(&mut p.PC0);
+        let measured = adc.blocking_read(&mut p.PC0);
         info!("measured: {}", measured);
         Timer::after_millis(500).await;
     }

--- a/examples/stm32h7/src/bin/adc_dma.rs
+++ b/examples/stm32h7/src/bin/adc_dma.rs
@@ -56,7 +56,7 @@ async fn main(_spawner: Spawner) {
     let mut pc0 = p.PC0.degrade_adc();
 
     loop {
-        adc.read_async(
+        adc.read(
             &mut dma,
             [
                 (&mut vrefint_channel, SampleTime::CYCLES387_5),

--- a/examples/stm32l4/src/bin/adc.rs
+++ b/examples/stm32l4/src/bin/adc.rs
@@ -23,7 +23,7 @@ fn main() -> ! {
     let mut channel = p.PC0;
 
     loop {
-        let v = adc.read(&mut channel);
+        let v = adc.blocking_read(&mut channel);
         info!("--> {}", v);
     }
 }

--- a/examples/stm32u0/src/bin/adc.rs
+++ b/examples/stm32u0/src/bin/adc.rs
@@ -23,7 +23,7 @@ fn main() -> ! {
     let mut channel = p.PC0;
 
     loop {
-        let v = adc.read(&mut channel);
+        let v = adc.blocking_read(&mut channel);
         info!("--> {}", v);
         embassy_time::block_for(Duration::from_millis(200));
     }

--- a/tests/stm32/src/bin/dac.rs
+++ b/tests/stm32/src/bin/dac.rs
@@ -38,7 +38,7 @@ async fn main(_spawner: Spawner) {
     dac.set(Value::Bit8(0));
     // Now wait a little to obtain a stable value
     Timer::after_millis(30).await;
-    let offset = adc.read(&mut adc_pin);
+    let offset = adc.blocking_read(&mut adc_pin);
 
     for v in 0..=255 {
         // First set the DAC output value
@@ -49,7 +49,7 @@ async fn main(_spawner: Spawner) {
         Timer::after_millis(30).await;
 
         // Need to steal the peripherals here because PA4 is obviously in use already
-        let measured = adc.read(&mut unsafe { embassy_stm32::Peripherals::steal() }.PA4);
+        let measured = adc.blocking_read(&mut unsafe { embassy_stm32::Peripherals::steal() }.PA4);
         // Calibrate and normalize the measurement to get close to the dac_output_val
         let measured_normalized = ((measured as i32 - offset as i32) / normalization_factor) as i16;
 


### PR DESCRIPTION
Unifies STM32 ADC `read` function naming.
Blocking reads will be named to `blocking_read` and async reads will be just `read`.