### PR TITLE
Add function to get the active HSEM interrupt

### DIFF
--- a/embassy-stm32/src/hsem/mod.rs
+++ b/embassy-stm32/src/hsem/mod.rs
@@ -158,6 +158,11 @@ impl<'d, T: Instance> HardwareSemaphore<'d, T> {
             .modify(|w| w.set_ise(sem_x, enable));
     }
 
+    /// Gets the interrupt flag for the semaphore.
+    pub fn is_interrupt_active(&mut self, core_id: CoreId, sem_x: usize) -> bool {
+        T::regs().isr(core_id_to_index(core_id)).read().isf(sem_x)
+    }
+
     /// Clears the interrupt flag for the semaphore.
     pub fn clear_interrupt(&mut self, core_id: CoreId, sem_x: usize) {
         T::regs()


### PR DESCRIPTION
You could already enable and clear it, but you could never check which semaphore was activating the interrupt. This adds a function so you can check