### PR TITLE
Add adc oversampling and adc differential for g4

### DIFF
--- a/embassy-stm32/src/adc/g4.rs
+++ b/embassy-stm32/src/adc/g4.rs
@@ -1,11 +1,12 @@
-#[allow(unused)]
-
-use pac::adccommon::vals::Presc;
 #[cfg(stm32h7)]
+#[allow(unused)]
 use pac::adc::vals::{Adcaldif, Difsel, Exten};
+
 #[cfg(stm32g4)]
+#[allow(unused)]
 use pac::adc::vals::{Adcaldif, Difsel, Exten, Rovsm, Trovs};
 
+use pac::adccommon::vals::Presc;
 use super::{blocking_delay_us, Adc, AdcChannel, Instance, Resolution, SampleTime};
 use crate::time::Hertz;
 use crate::{pac, rcc, Peripheral};

--- a/embassy-stm32/src/adc/g4.rs
+++ b/embassy-stm32/src/adc/g4.rs
@@ -1,10 +1,10 @@
 #[allow(unused)]
+use pac::adccommon::vals::Presc;
 
-#[cfg(stm32g4)]
-use pac::adc::vals::{Adcaldif, Difsel, Exten, Rovsm, Trovs};
 #[cfg(stm32h7)]
 use pac::adc::vals::{Adcaldif, Difsel, Exten};
-use pac::adccommon::vals::Presc;
+#[cfg(stm32g4)]
+use pac::adc::vals::{Adcaldif, Difsel, Exten, Rovsm, Trovs};
 
 use super::{blocking_delay_us, Adc, AdcChannel, Instance, Resolution, SampleTime};
 use crate::time::Hertz;
@@ -241,10 +241,17 @@ impl<'d, T: Instance> Adc<'d, T> {
     /// channel on the other ADC unusable. The only exception is when ADC master and the slave
     /// operate in interleaved mode.
     #[cfg(stm32g4)]
-    pub fn set_differential_channel(&mut self, ch: usize ,enable: bool) {
+    pub fn set_differential_channel(&mut self, ch: usize, enable: bool) {
         T::regs().cr().modify(|w| w.set_aden(false)); // disable adc
         T::regs().difsel().modify(|w| {
-            w.set_difsel(ch, if enable { Difsel::DIFFERENTIAL } else { Difsel::SINGLEENDED });
+            w.set_difsel(
+                ch,
+                if enable {
+                    Difsel::DIFFERENTIAL
+                } else {
+                    Difsel::SINGLEENDED
+                },
+            );
         });
         T::regs().cr().modify(|w| w.set_aden(true));
     }
@@ -268,8 +275,8 @@ impl<'d, T: Instance> Adc<'d, T> {
 
     /// Enable oversampling in regular mode.
     #[cfg(stm32g4)]
-    pub fn enable_regular_oversampling_mode(&mut self,mode:Rovsm,trig_mode:Trovs, enable: bool) {
-        T::regs().cfgr2().modify(|reg| reg.set_trovs(trig_mode)); 
+    pub fn enable_regular_oversampling_mode(&mut self, mode: Rovsm, trig_mode: Trovs, enable: bool) {
+        T::regs().cfgr2().modify(|reg| reg.set_trovs(trig_mode));
         T::regs().cfgr2().modify(|reg| reg.set_rovsm(mode));
         T::regs().cfgr2().modify(|reg| reg.set_rovse(enable));
     }
@@ -286,7 +293,6 @@ impl<'d, T: Instance> Adc<'d, T> {
     //     T::regs().cfgr2().modify(|reg| reg.set_rovse(enable));
     //     T::regs().cfgr2().modify(|reg| reg.set_jovse(enable));
     // }
-
 
     /// Set the ADC sample time.
     pub fn set_sample_time(&mut self, sample_time: SampleTime) {

--- a/embassy-stm32/src/adc/g4.rs
+++ b/embassy-stm32/src/adc/g4.rs
@@ -1,6 +1,6 @@
 #[allow(unused)]
-use pac::adccommon::vals::Presc;
 
+use pac::adccommon::vals::Presc;
 #[cfg(stm32h7)]
 use pac::adc::vals::{Adcaldif, Difsel, Exten};
 #[cfg(stm32g4)]

--- a/embassy-stm32/src/adc/g4.rs
+++ b/embassy-stm32/src/adc/g4.rs
@@ -1,11 +1,4 @@
-#[allow(unused)]
-#[cfg(stm32g4)]
-use pac::adc::vals::{Adcaldif, Difsel, Exten, Rovsm, Trovs};
-
-#[allow(unused)]
-#[cfg(not(stm32g4))]
-use pac::adc::vals::{Adcaldif, Difsel, Exten};
-
+use pac::adc::vals::*;
 use pac::adccommon::vals::Presc;
 use super::{blocking_delay_us, Adc, AdcChannel, Instance, Resolution, SampleTime};
 use crate::time::Hertz;

--- a/embassy-stm32/src/adc/g4.rs
+++ b/embassy-stm32/src/adc/g4.rs
@@ -1,10 +1,10 @@
-#[cfg(stm32h7)]
 #[allow(unused)]
-use pac::adc::vals::{Adcaldif, Difsel, Exten};
-
 #[cfg(stm32g4)]
-#[allow(unused)]
 use pac::adc::vals::{Adcaldif, Difsel, Exten, Rovsm, Trovs};
+
+#[allow(unused)]
+#[cfg(not(stm32g4))]
+use pac::adc::vals::{Adcaldif, Difsel, Exten};
 
 use pac::adccommon::vals::Presc;
 use super::{blocking_delay_us, Adc, AdcChannel, Instance, Resolution, SampleTime};
@@ -142,7 +142,6 @@ impl<'d, T: Instance> Adc<'d, T> {
         T::common_regs().ccr().modify(|w| w.set_presc(prescaler.presc()));
 
         let frequency = Hertz(T::frequency().0 / prescaler.divisor());
-        info!("ADC frequency set to {} Hz", frequency.0);
 
         if frequency > MAX_ADC_CLK_FREQ {
             panic!("Maximal allowed frequency for the ADC is {} MHz and it varies with different packages, refer to ST docs for more information.", MAX_ADC_CLK_FREQ.0 /  1_000_000 );

--- a/embassy-stm32/src/adc/mod.rs
+++ b/embassy-stm32/src/adc/mod.rs
@@ -26,6 +26,7 @@ use embassy_sync::waitqueue::AtomicWaker;
 #[cfg(not(any(adc_f1, adc_f3_v2)))]
 pub use crate::pac::adc::vals::Res as Resolution;
 pub use crate::pac::adc::vals::SampleTime;
+pub use crate::pac::adc::vals ;
 use crate::peripherals;
 
 dma_trait!(RxDma, Instance);

--- a/embassy-stm32/src/adc/mod.rs
+++ b/embassy-stm32/src/adc/mod.rs
@@ -23,10 +23,10 @@ pub use _version::*;
 #[cfg(any(adc_f1, adc_f3, adc_v1, adc_l0, adc_f3_v1_1))]
 use embassy_sync::waitqueue::AtomicWaker;
 
+pub use crate::pac::adc::vals;
 #[cfg(not(any(adc_f1, adc_f3_v2)))]
 pub use crate::pac::adc::vals::Res as Resolution;
 pub use crate::pac::adc::vals::SampleTime;
-pub use crate::pac::adc::vals ;
 use crate::peripherals;
 
 dma_trait!(RxDma, Instance);

--- a/examples/stm32g4/src/bin/adc_differential.rs
+++ b/examples/stm32g4/src/bin/adc_differential.rs
@@ -1,0 +1,47 @@
+//! adc differential mode example
+//!
+//! This example uses adc1 in differential mode
+//! p:pa0 n:pa1
+
+#![no_std]
+#![no_main]
+
+use defmt::*;
+use embassy_executor::Spawner;
+use embassy_stm32::adc::{Adc, SampleTime};
+use embassy_stm32::Config;
+use embassy_time::Timer;
+use {defmt_rtt as _, panic_probe as _};
+
+#[embassy_executor::main]
+async fn main(_spawner: Spawner) {
+    let mut config = Config::default();
+    {
+        use embassy_stm32::rcc::*;
+        config.rcc.pll = Some(Pll {
+            source: PllSource::HSI,
+            prediv: PllPreDiv::DIV4,
+            mul: PllMul::MUL85,
+            divp: None,
+            divq: None,
+            // Main system clock at 170 MHz
+            divr: Some(PllRDiv::DIV2),
+        });
+        config.rcc.mux.adc12sel = mux::Adcsel::SYS;
+        config.rcc.sys = Sysclk::PLL1_R;
+    }
+    let mut p = embassy_stm32::init(config);
+
+    let mut adc = Adc::new(p.ADC1);
+    adc.set_sample_time(SampleTime::CYCLES247_5);
+    adc.set_differential(&mut p.PA0, true); //p:pa0,n:pa1
+
+    // can also use
+    // adc.set_differential_channel(1, true);
+    info!("adc initialized");
+    loop {
+        let measured = adc.blocking_read(&mut p.PA0);
+        info!("data: {}", measured);
+        Timer::after_millis(500).await;
+    }
+}

--- a/examples/stm32g4/src/bin/adc_oversampling.rs
+++ b/examples/stm32g4/src/bin/adc_oversampling.rs
@@ -1,0 +1,57 @@
+//! adc oversampling example
+//!
+//! This example uses adc oversampling to achieve 16bit data
+
+#![no_std]
+#![no_main]
+
+use defmt::*;
+use embassy_executor::Spawner;
+use embassy_stm32::adc::vals::{Rovsm, Trovs};
+use embassy_stm32::adc::{Adc, SampleTime};
+use embassy_stm32::Config;
+use embassy_time::Timer;
+use {defmt_rtt as _, panic_probe as _};
+
+#[embassy_executor::main]
+async fn main(_spawner: Spawner) {
+    let mut config = Config::default();
+    {
+        use embassy_stm32::rcc::*;
+        config.rcc.pll = Some(Pll {
+            source: PllSource::HSI,
+            prediv: PllPreDiv::DIV4,
+            mul: PllMul::MUL85,
+            divp: None,
+            divq: None,
+            // Main system clock at 170 MHz
+            divr: Some(PllRDiv::DIV2),
+        });
+        config.rcc.mux.adc12sel = mux::Adcsel::SYS;
+        config.rcc.sys = Sysclk::PLL1_R;
+    }
+    let mut p = embassy_stm32::init(config);
+
+    let mut adc = Adc::new(p.ADC1);
+    adc.set_sample_time(SampleTime::CYCLES6_5);
+    // From https://www.st.com/resource/en/reference_manual/rm0440-stm32g4-series-advanced-armbased-32bit-mcus-stmicroelectronics.pdf
+    // page652 Oversampler
+    // Table 172. Maximum output results vs N and M. Grayed values indicates truncation
+    // 0x00 oversampling ratio X2
+    // 0x01 oversampling ratio X4
+    // 0x02 oversampling ratio X8
+    // 0x03 oversampling ratio X16
+    // 0x04 oversampling ratio X32
+    // 0x05 oversampling ratio X64
+    // 0x06 oversampling ratio X128
+    // 0x07 oversampling ratio X256
+    adc.set_oversampling_ratio(0x03); // ratio X3
+    adc.set_oversampling_shift(0b0000); // no shift
+    adc.enable_regular_oversampling_mode(Rovsm::RESUMED, Trovs::AUTOMATIC, true);
+
+    loop {
+        let measured = adc.blocking_read(&mut p.PA0);
+        info!("data: 0x{:X}", measured); //max 0xFFF0 -> 65520
+        Timer::after_millis(500).await;
+    }
+}


### PR DESCRIPTION
Add oversampling in regular mode .
Add adc differential use `pa0` and `pa1`.
Verify no errors with `stm32g431cbu6`