### PR TITLE
RP2040: Add DMA transfer abort function

### DIFF
--- a/embassy-rp/src/dma.rs
+++ b/embassy-rp/src/dma.rs
@@ -173,7 +173,10 @@ impl<'a, C: Channel> Transfer<'a, C> {
     pub(crate) fn new(channel: impl Peripheral<P = C> + 'a, start_write_addr: u32) -> Self {
         into_ref!(channel);
 
-        Self { channel, start_write_addr }
+        Self {
+            channel,
+            start_write_addr,
+        }
     }
     /// Abort a DMA transfer early
     ///

--- a/embassy-rp/src/dma.rs
+++ b/embassy-rp/src/dma.rs
@@ -177,16 +177,15 @@ impl<'a, C: Channel> Transfer<'a, C> {
     /// Abort a DMA transfer early
     ///
     /// Returns the count of transfers still left to do and the data size of the transfers
-    pub fn abort(self) -> (u32, DataSize) {
+    pub fn abort(self) -> u32 {
         let p = self.channel.regs();
         let transfer_count = p.trans_count().read();
-        let data_size = p.ctrl_trig().read().data_size();
         pac::DMA
             .chan_abort()
             .modify(|m| m.set_chan_abort(1 << self.channel.number()));
         while p.ctrl_trig().read().busy() {}
 
-        (transfer_count, data_size)
+        transfer_count
     }
 }
 

--- a/embassy-rp/src/dma.rs
+++ b/embassy-rp/src/dma.rs
@@ -172,9 +172,7 @@ impl<'a, C: Channel> Transfer<'a, C> {
     pub(crate) fn new(channel: impl Peripheral<P = C> + 'a) -> Self {
         into_ref!(channel);
 
-        Self {
-            channel,
-        }
+        Self { channel }
     }
     /// Abort a DMA transfer early
     ///

--- a/embassy-rp/src/dma.rs
+++ b/embassy-rp/src/dma.rs
@@ -159,20 +159,33 @@ fn copy_inner<'a, C: Channel>(
     });
 
     compiler_fence(Ordering::SeqCst);
-    Transfer::new(ch)
+    Transfer::new(ch, to as u32)
 }
 
 /// DMA transfer driver.
 #[must_use = "futures do nothing unless you `.await` or poll them"]
 pub struct Transfer<'a, C: Channel> {
     channel: PeripheralRef<'a, C>,
+    start_write_addr: u32,
 }
 
 impl<'a, C: Channel> Transfer<'a, C> {
-    pub(crate) fn new(channel: impl Peripheral<P = C> + 'a) -> Self {
+    pub(crate) fn new(channel: impl Peripheral<P = C> + 'a, start_write_addr: u32) -> Self {
         into_ref!(channel);
 
-        Self { channel }
+        Self { channel, start_write_addr }
+    }
+    /// Abort a DMA transfer early
+    ///
+    /// Returns the count of bytes transfered up until this point
+    pub fn abort(&mut self) -> u32 {
+        let p = self.channel.regs();
+        pac::DMA
+            .chan_abort()
+            .modify(|m| m.set_chan_abort(1 << self.channel.number()));
+        while p.ctrl_trig().read().busy() {}
+
+        p.write_addr().read() - self.start_write_addr
     }
 }
 

--- a/embassy-rp/src/dma.rs
+++ b/embassy-rp/src/dma.rs
@@ -176,8 +176,8 @@ impl<'a, C: Channel> Transfer<'a, C> {
     }
     /// Abort a DMA transfer early
     ///
-    /// Returns the count of transfers still left to do and the data size of the transfers
-    pub fn abort(self) -> u32 {
+    /// Returns the count of transfers still left to do
+    pub fn abort(self) -> usize {
         let p = self.channel.regs();
         let transfer_count = p.trans_count().read();
         pac::DMA
@@ -185,7 +185,7 @@ impl<'a, C: Channel> Transfer<'a, C> {
             .modify(|m| m.set_chan_abort(1 << self.channel.number()));
         while p.ctrl_trig().read().busy() {}
 
-        transfer_count
+        transfer_count as usize
     }
 }
 

--- a/embassy-rp/src/pio/mod.rs
+++ b/embassy-rp/src/pio/mod.rs
@@ -367,7 +367,7 @@ impl<'d, PIO: Instance, const SM: usize> StateMachineRx<'d, PIO, SM> {
             w.set_en(true);
         });
         compiler_fence(Ordering::SeqCst);
-        Transfer::new(ch, data.as_ptr() as u32)
+        Transfer::new(ch)
     }
 }
 
@@ -449,7 +449,7 @@ impl<'d, PIO: Instance, const SM: usize> StateMachineTx<'d, PIO, SM> {
             w.set_en(true);
         });
         compiler_fence(Ordering::SeqCst);
-        Transfer::new(ch, data.as_ptr() as u32)
+        Transfer::new(ch)
     }
 }
 

--- a/embassy-rp/src/pio/mod.rs
+++ b/embassy-rp/src/pio/mod.rs
@@ -367,7 +367,7 @@ impl<'d, PIO: Instance, const SM: usize> StateMachineRx<'d, PIO, SM> {
             w.set_en(true);
         });
         compiler_fence(Ordering::SeqCst);
-        Transfer::new(ch)
+        Transfer::new(ch, data.as_ptr() as u32)
     }
 }
 
@@ -449,7 +449,7 @@ impl<'d, PIO: Instance, const SM: usize> StateMachineTx<'d, PIO, SM> {
             w.set_en(true);
         });
         compiler_fence(Ordering::SeqCst);
-        Transfer::new(ch)
+        Transfer::new(ch, data.as_ptr() as u32)
     }
 }
 


### PR DESCRIPTION
This PR adds an abort function to RP2040 DMA transfers, which also returns the amount of bytes transferred up until this point.
That can be useful in cases where a frame of dynamic length is read via PIO and the end of a frame is signaled via interrupt, so the code can stop the transfer and immediately know how long the frame was