### PR TITLE
Bump usbd-hid from 0.7.0 to 0.8.1 to fix compile errors in rp examples

### DIFF
--- a/embassy-usb/Cargo.toml
+++ b/embassy-usb/Cargo.toml
@@ -56,5 +56,5 @@ log = { version = "0.4.14", optional = true }
 heapless = "0.8"
 
 # for HID
-usbd-hid = { version = "0.7.0", optional = true }
+usbd-hid = { version = "0.8.1", optional = true }
 ssmarshal = { version = "1.0", default-features = false, optional = true }

--- a/examples/nrf52840/Cargo.toml
+++ b/examples/nrf52840/Cargo.toml
@@ -27,7 +27,7 @@ cortex-m-rt = "0.7.0"
 panic-probe = { version = "0.3", features = ["print-defmt"] }
 rand = { version = "0.8.4", default-features = false }
 embedded-storage = "0.3.1"
-usbd-hid = "0.7.0"
+usbd-hid = "0.8.1"
 serde = { version = "1.0.136", default-features = false }
 embedded-hal = { version = "1.0" }
 embedded-hal-async = { version = "1.0" }

--- a/examples/nrf5340/Cargo.toml
+++ b/examples/nrf5340/Cargo.toml
@@ -23,7 +23,7 @@ cortex-m-rt = "0.7.0"
 panic-probe = { version = "0.3", features = ["print-defmt"] }
 rand = { version = "0.8.4", default-features = false }
 embedded-storage = "0.3.1"
-usbd-hid = "0.7.0"
+usbd-hid = "0.8.1"
 serde = { version = "1.0.136", default-features = false }
 
 [profile.release]

--- a/examples/rp/Cargo.toml
+++ b/examples/rp/Cargo.toml
@@ -44,7 +44,7 @@ display-interface = "0.4.1"
 byte-slice-cast = { version = "1.2.0", default-features = false }
 smart-leds = "0.3.0"
 heapless = "0.8"
-usbd-hid = "0.7.0"
+usbd-hid = "0.8.1"
 
 embedded-hal-1 = { package = "embedded-hal", version = "1.0" }
 embedded-hal-async = "1.0"

--- a/examples/stm32f4/Cargo.toml
+++ b/examples/stm32f4/Cargo.toml
@@ -30,7 +30,7 @@ heapless = { version = "0.8", default-features = false }
 nb = "1.0.0"
 embedded-storage = "0.3.1"
 micromath = "2.0.0"
-usbd-hid = "0.7.0"
+usbd-hid = "0.8.1"
 static_cell = "2"
 chrono = { version = "^0.4", default-features = false}
 

--- a/examples/stm32g4/Cargo.toml
+++ b/examples/stm32g4/Cargo.toml
@@ -12,7 +12,7 @@ embassy-executor = { version = "0.5.0", path = "../../embassy-executor", feature
 embassy-time = { version = "0.3.1", path = "../../embassy-time", features = ["defmt", "defmt-timestamp-uptime", "tick-hz-32_768"] }
 embassy-usb = { version = "0.2.0", path = "../../embassy-usb", features = ["defmt"] }
 embassy-futures = { version = "0.1.0", path = "../../embassy-futures" }
-usbd-hid = "0.7.0"
+usbd-hid = "0.8.1"
 
 defmt = "0.3"
 defmt-rtt = "0.4"

--- a/examples/stm32l5/Cargo.toml
+++ b/examples/stm32l5/Cargo.toml
@@ -13,7 +13,7 @@ embassy-time = { version = "0.3.1", path = "../../embassy-time", features = ["de
 embassy-usb = { version = "0.2.0", path = "../../embassy-usb", features = ["defmt"] }
 embassy-net = { version = "0.4.0", path = "../../embassy-net", features = ["defmt",  "tcp", "dhcpv4", "medium-ethernet"] }
 embassy-futures = { version = "0.1.0", path = "../../embassy-futures" }
-usbd-hid = "0.7.0"
+usbd-hid = "0.8.1"
 
 defmt = "0.3"
 defmt-rtt = "0.4"


### PR DESCRIPTION
Running `cargo build` in `examples/rp` gives the following error:
```
error[E0277]: the trait bound `usbd_hid_descriptors::MainItemKind: From<std::string::String>` is not satisfied
   --> /home/julian/.cargo/registry/src/index.crates.io-6f17d22bba15001f/usbd-hid-macros-0.6.0/src/spec.rs:512:43
    |
512 |             self.set_item(name, item_kind.into(), settings, bits, quirks);
    |                                           ^^^^ the trait `From<std::string::String>` is not implemented for `usbd_hid_descriptors::MainItemKind`, which is required by `std::string::String: Into<_>`
    |
    = help: the trait `From<&str>` is implemented for `usbd_hid_descriptors::MainItemKind`
    = help: for that trait implementation, expected `&str`, found `std::string::String`
    = note: required for `std::string::String` to implement `Into<usbd_hid_descriptors::MainItemKind>`
```

Bumping udbd-hid from 0.7.0 to 0.8.1 seems to fix the problem.