### PR TITLE
embassy-net: fix minor typo in doc

### DIFF
--- a/embassy-net/src/lib.rs
+++ b/embassy-net/src/lib.rs
@@ -414,7 +414,7 @@ impl<D: Driver> Stack<D> {
     /// ```ignore
     /// let config = embassy_net::Config::dhcpv4(Default::default());
     ///// Init network stack
-    /// static RESOURCES: StaticCell<embassy_net::StackResources<2> = StaticCell::new();
+    /// static RESOURCES: StaticCell<embassy_net::StackResources<2>> = StaticCell::new();
     /// static STACK: StaticCell<embassy_net::Stack> = StaticCell::new();
     /// let stack = &*STACK.init(embassy_net::Stack::new(
     ///    device,


### PR DESCRIPTION
Added a missing closing angle bracket in the documentation.