### PR TITLE
net/tcp: fix flush() waiting forever if socket is reset with pending write data

### DIFF
--- a/embassy-net/src/tcp.rs
+++ b/embassy-net/src/tcp.rs
@@ -515,7 +515,7 @@ impl<'d> TcpIo<'d> {
     async fn flush(&mut self) -> Result<(), Error> {
         poll_fn(move |cx| {
             self.with_mut(|s, _| {
-                let data_pending = s.send_queue() > 0;
+                let data_pending = (s.send_queue() > 0) && s.state() != tcp::State::Closed;
                 let fin_pending = matches!(
                     s.state(),
                     tcp::State::FinWait1 | tcp::State::Closing | tcp::State::LastAck


### PR DESCRIPTION
If a remote connection crashes, the remote OS sends a packet with the RST flag set.
However, if the embassy_net TcpSocket then flushes, this blocks forever, as despite the socket state being `Closed`, there's data in the send queue, and thus the flush method keeps returning Poll::Pending.

My fix for this is to check if the state is `Closed`, and if so, the [`data_pending`](https://github.com/sammhicks/embassy/blob/e6f4db507d62178ddb05a4569a9f9352a25222e0/embassy-net/src/tcp.rs#L518) flag is not set, thus if `fin_pending` and `rst_pending` are both false, the flush completes.

This should possibly be fixed upstream, i.e. in `smoltcp`, by a tcp socket clearing its send queue if it's reset, but I'm not sure.