### PR TITLE
Added an update future, to  be able to sync user code with interrupt

### DIFF
--- a/embassy-stm32/src/timer/simple_pwm.rs
+++ b/embassy-stm32/src/timer/simple_pwm.rs
@@ -163,7 +163,7 @@ impl<'d, T: GeneralInstance4Channel> SimplePwm<'d, T> {
 
     /// Return the update future, which an be used to wait up the update interrupt event
     /// The update interrupt is enabled by this function
-    pub fn get_update_future(&mut self) -> UpdateFuture<T> {
+    pub fn get_update_future(&self) -> UpdateFuture<T> {
         let regs = unsafe { crate::pac::timer::TimGp16::from_ptr(T::regs()) };
         regs.dier().modify(|w| w.set_uie(true));
         UpdateFuture {

--- a/embassy-stm32/src/timer/simple_pwm.rs
+++ b/embassy-stm32/src/timer/simple_pwm.rs
@@ -161,15 +161,14 @@ impl<'d, T: GeneralInstance4Channel> SimplePwm<'d, T> {
         self.inner.reset();
     }
 
-    /// Asynchronously wait until the counter value is updated to zero in the timer
+    /// Return the update future, which an be used to wait up the update interrupt event
     /// The update interrupt is enabled by this function
-    pub async fn wait_for_update(&mut self) -> u32 {
+    pub fn get_update_future(&mut self) -> UpdateFuture<T> {
         let regs = unsafe { crate::pac::timer::TimGp16::from_ptr(T::regs()) };
         regs.dier().modify(|w| w.set_uie(true));
         UpdateFuture {
             phantom: PhantomData::<T>,
         }
-        .await
     }
 
     /// Generate a sequence of PWM waveform
@@ -365,8 +364,9 @@ impl<'d, T: GeneralInstance4Channel> embedded_hal_02::Pwm for SimplePwm<'d, T> {
     }
 }
 
+/// The struct which can be used to await for a timer update interrupt event
 #[must_use = "futures do nothing unless you `.await` or poll them"]
-struct UpdateFuture<T: GeneralInstance4Channel> {
+pub struct UpdateFuture<T: GeneralInstance4Channel> {
     phantom: PhantomData<T>,
 }
 

--- a/embassy-stm32/src/timer/simple_pwm.rs
+++ b/embassy-stm32/src/timer/simple_pwm.rs
@@ -8,7 +8,6 @@ use super::low_level::{CountingMode, OutputCompareMode, OutputPolarity, Timer};
 use super::{Channel, Channel1Pin, Channel2Pin, Channel3Pin, Channel4Pin, GeneralInstance4Channel};
 use crate::gpio::{AfType, AnyPin, OutputType, Speed};
 use crate::interrupt::typelevel::Interrupt;
-use crate::pac::timer::regs::CntCore;
 use crate::time::Hertz;
 use crate::Peripheral;
 use core::future::Future;

--- a/embassy-stm32/src/timer/simple_pwm.rs
+++ b/embassy-stm32/src/timer/simple_pwm.rs
@@ -1,6 +1,9 @@
 //! Simple PWM driver.
 
+use core::future::Future;
 use core::marker::PhantomData;
+use core::pin::Pin;
+use core::task::{Context, Poll};
 
 use embassy_hal_internal::{into_ref, PeripheralRef};
 
@@ -10,9 +13,6 @@ use crate::gpio::{AfType, AnyPin, OutputType, Speed};
 use crate::interrupt::typelevel::Interrupt;
 use crate::time::Hertz;
 use crate::Peripheral;
-use core::future::Future;
-use core::pin::Pin;
-use core::task::{Context, Poll};
 
 /// Channel 1 marker type.
 pub enum Ch1 {}

--- a/examples/stm32g0/src/bin/pwm_update_interrupt.rs
+++ b/examples/stm32g0/src/bin/pwm_update_interrupt.rs
@@ -1,6 +1,5 @@
 #![no_std]
 #![no_main]
-use crate::peripherals::TIM3;
 use defmt::*;
 use embassy_executor::Spawner;
 use embassy_stm32::gpio::{Level, Output, OutputType, Speed};
@@ -11,6 +10,8 @@ use embassy_stm32::timer::{self, Channel};
 use embassy_stm32::{bind_interrupts, peripherals};
 use embassy_time::Timer;
 use {defmt_rtt as _, panic_probe as _};
+
+use crate::peripherals::TIM3;
 
 // This test is meant for the target nucleo G070 RB
 // On arduino pin d4 (pb5) a pwm signal of  1.0 hz can me measured, with increasing duty cycle

--- a/examples/stm32g0/src/bin/pwm_update_interrupt.rs
+++ b/examples/stm32g0/src/bin/pwm_update_interrupt.rs
@@ -1,0 +1,102 @@
+#![no_std]
+#![no_main]
+use crate::peripherals::TIM3;
+use defmt::*;
+use embassy_executor::Spawner;
+use embassy_stm32::gpio::{Level, Output, OutputType, Speed};
+use embassy_stm32::time::Hertz;
+use embassy_stm32::timer::low_level::CountingMode;
+use embassy_stm32::timer::simple_pwm::{PwmPin, SimplePwm};
+use embassy_stm32::timer::{self, Channel};
+use embassy_stm32::{bind_interrupts, peripherals};
+use embassy_time::Timer;
+use {defmt_rtt as _, panic_probe as _};
+
+// This test is meant for the target nucleo G070 RB
+// On arduino pin d4 (pb5) a pwm signal of  1.0 hz can me measured, with increasing duty cycle
+// On each update interrupt arduino pin d5 (pb4) will be made high for 1 ms.
+// With a logic scope one can measure these signals
+// The user led arduino pin d13 (pa5) will flash with exactly 1 hrz, with duty cycle 20%
+
+bind_interrupts!(
+    struct Irqs {
+      TIM3 => timer::UpdateInterruptHandler<TIM3>;
+    }
+);
+
+#[embassy_executor::task]
+async fn pwm_task(mut pwm_test: PwmTest) {
+    pwm_test.task().await;
+}
+
+pub struct PwmTest {
+    pwm3: SimplePwm<'static, peripherals::TIM3>,
+    led: Output<'static>,
+    d5_pb4: Output<'static>,
+    max3: u32,
+    duty: u32,
+    counter: usize,
+}
+
+impl PwmTest {
+    fn new(mut pwm3: SimplePwm<'static, peripherals::TIM3>, led: Output<'static>, d5_pb4: Output<'static>) -> Self {
+        let max3 = pwm3.get_max_duty();
+        pwm3.reset();
+        pwm3.enable_update_interrupt(true);
+        pwm3.enable(Channel::Ch2);
+        PwmTest {
+            pwm3,
+            max3,
+            duty: 4000,
+            counter: 0,
+            led,
+            d5_pb4,
+        }
+    }
+    async fn task(&mut self) {
+        loop {
+            self.duty = (self.duty + 200) % self.max3;
+            self.pwm3.set_duty(Channel::Ch2, self.duty);
+            // note that the update interrupt will be call exact 100 times per second!
+            self.pwm3.wait_for_update().await;
+            self.counter = (self.counter + 1) % 100;
+            self.d5_pb4.set_high();
+            match self.counter {
+                1 => info!("Update interrupt"),
+                10 => self.led.set_high(),
+                30 => self.led.set_low(),
+
+                _ => (),
+            }
+            Timer::after_millis(1).await;
+            self.d5_pb4.set_low();
+        }
+    }
+}
+
+#[embassy_executor::main]
+async fn main(spawner: Spawner) {
+    let p = embassy_stm32::init(Default::default());
+    info!("Testing the update interupt for a simple_pwm instance");
+    let d4_pb5 = PwmPin::new_ch2(p.PB5, OutputType::PushPull);
+    let pwm3 = SimplePwm::<'static>::new(
+        p.TIM3,
+        None,
+        Some(d4_pb5),
+        None,
+        None,
+        Hertz(100),
+        CountingMode::EdgeAlignedUp,
+    );
+    let led_g = Output::new(p.PA5, Level::High, Speed::Low);
+    let d5_pb4 = Output::new(p.PB4, Level::High, Speed::Low);
+    let pwm_test = PwmTest::new(pwm3, led_g, d5_pb4);
+    // note that the pwm_task is the owner of pwm_test.
+    // pwm_test is the owner of the pwm and the led.
+    spawner.spawn(pwm_task(pwm_test)).unwrap();
+
+    loop {
+        Timer::after_secs(10).await;
+        info!("Still alive");
+    }
+}

--- a/examples/stm32g0/src/bin/pwm_update_interrupt.rs
+++ b/examples/stm32g0/src/bin/pwm_update_interrupt.rs
@@ -58,7 +58,7 @@ impl PwmTest {
             self.duty = (self.duty + 200) % self.max3;
             self.pwm3.set_duty(Channel::Ch2, self.duty);
             // note that the update interrupt will be call exact 100 times per second!
-            self.pwm3.wait_for_update().await;
+            self.pwm3.get_update_future().await;
             self.counter = (self.counter + 1) % 100;
             self.d5_pb4.set_high();
             match self.counter {

--- a/examples/stm32g0/src/bin/pwm_update_interrupt.rs
+++ b/examples/stm32g0/src/bin/pwm_update_interrupt.rs
@@ -20,7 +20,8 @@ use {defmt_rtt as _, panic_probe as _};
 
 bind_interrupts!(
     struct Irqs {
-      TIM3 => timer::UpdateInterruptHandler<TIM3>;
+      // for stm32g070cb change TIM3_TIM4 to TIM3
+      TIM3_TIM4 => timer::UpdateInterruptHandler<TIM3>;
     }
 );
 


### PR DESCRIPTION
For motor control with SimplePwm it would be nice that in user land it is possible to run code in sync with the Pwm.
For example to measure the motor current on a exact moment, and exact in phase with the Pwm signal.
So I added an UpdateFuture, to  SimplePwm, making use of the already existing infrastructure (up_waker in State)
A test is added in stm32go named pwm_update_interrupt, to test the functionality 

To be able to sync multiple timers, so they have all the same phase I also added a reset function to the SimplePwm.
