### PR TITLE
Documentation Link Fixes

### DIFF
--- a/docs/pages/basic_application.adoc
+++ b/docs/pages/basic_application.adoc
@@ -4,7 +4,7 @@ So you've got one of the examples running, but what now? Let's go through a simp
 
 == Main
 
-The full example can be found link:https://github.com/embassy-rs/embassy/tree/master/docs/examples/basic[here].
+The full example can be found link:https://github.com/embassy-rs/embassy/tree/main/docs/examples/basic[here].
 
 NOTE: If you’re using VS Code and rust-analyzer to view and edit the examples, you may need to make some changes to `.vscode/settings.json` to tell it which project we’re working on. Follow the instructions commented in that file to get rust-analyzer working correctly.
 

--- a/docs/pages/new_project.adoc
+++ b/docs/pages/new_project.adoc
@@ -1,6 +1,6 @@
 = Starting a new project
 
-Once you’ve successfully xref:getting_started.adoc[run some example projects], the next step is to make a standalone Embassy project.
+Once you’ve successfully xref:#_getting_started[run some example projects], the next step is to make a standalone Embassy project.
 
 == Tools for generating Embassy projects
 

--- a/docs/pages/nrf.adoc
+++ b/docs/pages/nrf.adoc
@@ -1,6 +1,6 @@
 = Embassy nRF HAL
 
-The link:https://github.com/embassy-rs/embassy/tree/master/embassy-nrf[Embassy nRF HAL] is based on the PACs (Peripheral Access Crate) from link:https://github.com/nrf-rs/[nrf-rs].
+The link:https://github.com/embassy-rs/embassy/tree/main/embassy-nrf[Embassy nRF HAL] is based on the PACs (Peripheral Access Crate) from link:https://github.com/nrf-rs/[nrf-rs].
 
 == Timer driver
 

--- a/docs/pages/overview.adoc
+++ b/docs/pages/overview.adoc
@@ -48,7 +48,7 @@ link:https://github.com/lora-rs/lora-rs[lora-rs] supports LoRa networking on a w
 link:https://docs.embassy.dev/embassy-usb/[embassy-usb] implements a device-side USB stack. Implementations for common classes such as USB serial (CDC ACM) and USB HID are available, and a rich builder API allows building your own.
 
 === Bootloader and DFU
-link:https://github.com/embassy-rs/embassy/tree/master/embassy-boot[embassy-boot] is a lightweight bootloader supporting firmware application upgrades in a power-fail-safe way, with trial boots and rollbacks.
+link:https://github.com/embassy-rs/embassy/tree/main/embassy-boot[embassy-boot] is a lightweight bootloader supporting firmware application upgrades in a power-fail-safe way, with trial boots and rollbacks.
 
 == What is DMA?
 

--- a/docs/pages/sharing_peripherals.adoc
+++ b/docs/pages/sharing_peripherals.adoc
@@ -8,7 +8,7 @@ The following examples shows different ways to use the on-board LED on a Raspber
 
 Using mutual exclusion is the simplest way to share a peripheral.
 
-TIP: Dependencies needed to run this example link:/book/dev/basic_application.html#_the_cargo_toml[can be found here].
+TIP: Dependencies needed to run this example link:#_the_cargo_toml[can be found here].
 [,rust]
 ----
 use defmt::*;
@@ -78,7 +78,7 @@ To indicate that the pin will be set to an Output. The `AnyPin` could have been 
 
 A channel is another way to ensure exclusive access to a resource. Using a channel is great in the cases where the access can happen at a later point in time, allowing you to enqueue operations and do other things.
 
-TIP: Dependencies needed to run this example link:/book/dev/basic_application.html#_the_cargo_toml[can be found here].
+TIP: Dependencies needed to run this example link:#_the_cargo_toml[can be found here].
 [,rust]
 ----
 use defmt::*;

--- a/docs/pages/stm32.adoc
+++ b/docs/pages/stm32.adoc
@@ -1,6 +1,6 @@
 = Embassy STM32 HAL
 
-The link:https://github.com/embassy-rs/embassy/tree/master/embassy-stm32[Embassy STM32 HAL] is based on the `stm32-metapac` project.
+The link:https://github.com/embassy-rs/embassy/tree/main/embassy-stm32[Embassy STM32 HAL] is based on the `stm32-metapac` project.
 
 == The infinite variant problem
 

--- a/docs/pages/time_keeping.adoc
+++ b/docs/pages/time_keeping.adoc
@@ -16,7 +16,7 @@ The `embassy::time::Timer` type provides two timing methods.
 
 An example of a delay is provided as follows:
 
-TIP: Dependencies needed to run this example link:/book/dev/basic_application.html#_the_cargo_toml[can be found here].
+TIP: Dependencies needed to run this example link:#_the_cargo_toml[can be found here].
 [,rust]
 ----
 use embassy::executor::{task, Executor};
@@ -41,7 +41,7 @@ that expect a generic delay implementation to be provided.
 
 An example of how this can be used:
 
-TIP: Dependencies needed to run this example link:/book/dev/basic_application.html#_the_cargo_toml[can be found here].
+TIP: Dependencies needed to run this example link:#_the_cargo_toml[can be found here].
 [,rust]
 ----
 use embassy::executor::{task, Executor};


### PR DESCRIPTION
This fixes some minor documentation link issues. Resolves problems where the links were still referencing the page they used to be on. It also fixes the master branch being renamed to main, so an interstitial is not shown on the Github side of things.