### PR TITLE
Fixing missing re-export

### DIFF
--- a/cyw43/src/control.rs
+++ b/cyw43/src/control.rs
@@ -42,6 +42,7 @@ pub enum ScanType {
     Passive,
 }
 
+/// Scan options.
 #[derive(Clone)]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub struct ScanOptions {

--- a/cyw43/src/control.rs
+++ b/cyw43/src/control.rs
@@ -46,6 +46,7 @@ pub enum ScanType {
 #[derive(Clone)]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub struct ScanOptions {
+    /// SSID to scan for.
     pub ssid: Option<heapless::String<32>>,
     /// If set to `None`, all APs will be returned. If set to `Some`, only APs
     /// with the specified BSSID will be returned.

--- a/cyw43/src/lib.rs
+++ b/cyw43/src/lib.rs
@@ -28,7 +28,7 @@ use ioctl::IoctlState;
 
 use crate::bus::Bus;
 pub use crate::bus::SpiBusCyw43;
-pub use crate::control::{AddMulticastAddressError, Control, Error as ControlError, Scanner};
+pub use crate::control::{AddMulticastAddressError, Control, Error as ControlError, Scanner, ScanOptions};
 pub use crate::runner::Runner;
 pub use crate::structs::BssInfo;
 

--- a/cyw43/src/lib.rs
+++ b/cyw43/src/lib.rs
@@ -28,7 +28,7 @@ use ioctl::IoctlState;
 
 use crate::bus::Bus;
 pub use crate::bus::SpiBusCyw43;
-pub use crate::control::{AddMulticastAddressError, Control, Error as ControlError, Scanner, ScanOptions};
+pub use crate::control::{AddMulticastAddressError, Control, Error as ControlError, ScanOptions, Scanner};
 pub use crate::runner::Runner;
 pub use crate::structs::BssInfo;
 


### PR DESCRIPTION
cyw::ScanOptions