### PR TITLE
Implement low-power feature for STM32L4 MCUs

### DIFF
--- a/embassy-stm32/src/low_power.rs
+++ b/embassy-stm32/src/low_power.rs
@@ -109,10 +109,10 @@ pub enum StopMode {
     Stop2,
 }
 
-#[cfg(stm32l5)]
+#[cfg(any(stm32l4, stm32l5))]
 use stm32_metapac::pwr::vals::Lpms;
 
-#[cfg(stm32l5)]
+#[cfg(any(stm32l4, stm32l5))]
 impl Into<Lpms> for StopMode {
     fn into(self) -> Lpms {
         match self {
@@ -181,7 +181,7 @@ impl Executor {
 
     #[allow(unused_variables)]
     fn configure_stop(&mut self, stop_mode: StopMode) {
-        #[cfg(stm32l5)]
+        #[cfg(any(stm32l4, stm32l5))]
         crate::pac::PWR.cr1().modify(|m| m.set_lpms(stop_mode.into()));
         #[cfg(stm32h5)]
         crate::pac::PWR.pmcr().modify(|v| {

--- a/embassy-stm32/src/rtc/low_power.rs
+++ b/embassy-stm32/src/rtc/low_power.rs
@@ -65,7 +65,7 @@ pub(crate) enum WakeupPrescaler {
     Div16 = 16,
 }
 
-#[cfg(any(stm32f4, stm32l0, stm32g4, stm32l5, stm32wb, stm32h5, stm32g0))]
+#[cfg(any(stm32f4, stm32l0, stm32g4, stm32l4, stm32l5, stm32wb, stm32h5, stm32g0))]
 impl From<WakeupPrescaler> for crate::pac::rtc::vals::Wucksel {
     fn from(val: WakeupPrescaler) -> Self {
         use crate::pac::rtc::vals::Wucksel;
@@ -79,7 +79,7 @@ impl From<WakeupPrescaler> for crate::pac::rtc::vals::Wucksel {
     }
 }
 
-#[cfg(any(stm32f4, stm32l0, stm32g4, stm32l5, stm32wb, stm32h5, stm32g0))]
+#[cfg(any(stm32f4, stm32l0, stm32g4, stm32l4, stm32l5, stm32wb, stm32h5, stm32g0))]
 impl From<crate::pac::rtc::vals::Wucksel> for WakeupPrescaler {
     fn from(val: crate::pac::rtc::vals::Wucksel) -> Self {
         use crate::pac::rtc::vals::Wucksel;

--- a/embassy-stm32/src/rtc/v2.rs
+++ b/embassy-stm32/src/rtc/v2.rs
@@ -131,10 +131,13 @@ impl SealedInstance for crate::peripherals::RTC {
     #[cfg(all(feature = "low-power", stm32f4))]
     const EXTI_WAKEUP_LINE: usize = 22;
 
+    #[cfg(all(feature = "low-power", stm32l4))]
+    const EXTI_WAKEUP_LINE: usize = 20;
+
     #[cfg(all(feature = "low-power", stm32l0))]
     const EXTI_WAKEUP_LINE: usize = 20;
 
-    #[cfg(all(feature = "low-power", stm32f4))]
+    #[cfg(all(feature = "low-power", any(stm32f4, stm32l4)))]
     type WakeupInterrupt = crate::interrupt::typelevel::RTC_WKUP;
 
     #[cfg(all(feature = "low-power", stm32l0))]


### PR DESCRIPTION
This PR enables the `low-power` feature on STM32L4 devices by implementing the required traits and setting the correct `WakeupInterrupt` and `EXTI_WAKEUP_LINE`.

I have tested this on a NUCLEO-L452RE board with a program inspired by the `stm32l5/stop.rs` example. With `enable_debug_during_sleep = false` and the LED turned off, the current consumption drops down to around 3uA when the delays are large enough to allow STOP2 mode. Waking up works as well (normally, see below).

### Issues / Open Questions

#### RTC version on STM32L41/42xxx devices
Both the RM0394 reference manual for STM32L4 devices and the AN4759 application note which is also mentioned in embassy-stm32's comments indicate that STM32L41/L42xxx devices use another RTC. Until now, I have not understood how the correct RTC implementation is chosen in embassy's build process, but I can see that the `rtc/v1.rs` file seems to be missing although it is (still) referenced in `rtc/mod.rs`. Altogether, I do not know if the implementation I have done is working for these devices, too. Can someone shed some light upon this?

#### Wake-Up Issues
I have experienced some wake-up issues. Concretely, the device does not wake-up when the first delay is short and prevents STOP2 mode. In a few cases, my `stop.rs` example hung already after a few seconds (so it was definitely not caused by the 30s timeout task). In any case, I do not think that this issue is caused by any changes I did for this PR. Therefore, I am wondering if this also happens on other STM32 families. Unfortunately, I do not have any other device at hand currently. Has anybody experienced something similar on another device type?