### PR TITLE
embassy-stm32: wait for BSY flag to clear before flashing

### DIFF
--- a/embassy-stm32/src/flash/f1f3.rs
+++ b/embassy-stm32/src/flash/f1f3.rs
@@ -42,9 +42,11 @@ pub(crate) unsafe fn blocking_write(start_address: u32, buf: &[u8; WRITE_SIZE]) 
 
         // prevents parallelism errors
         fence(Ordering::SeqCst);
+
+        wait_ready_blocking()?;
     }
 
-    wait_ready_blocking()
+    Ok(())
 }
 
 pub(crate) unsafe fn blocking_erase_sector(sector: &FlashSector) -> Result<(), Error> {


### PR DESCRIPTION
While not waiting for the BSY flag to clear works on STM32F103C8T6, it does not on APM32F103C8T6. Only one half-word gets written while the other one gets lost.