### PR TITLE
Fix bootloader-rp's bootloader memory region overflow

### DIFF
--- a/examples/boot/bootloader/rp/memory.x
+++ b/examples/boot/bootloader/rp/memory.x
@@ -2,7 +2,7 @@ MEMORY
 {
   /* NOTE 1 K = 1 KiBi = 1024 bytes */
   BOOT2                             : ORIGIN = 0x10000000, LENGTH = 0x100
-  FLASH                             : ORIGIN = 0x10000100, LENGTH = 24K
+  FLASH                             : ORIGIN = 0x10000100, LENGTH = 24K - 0x100
   BOOTLOADER_STATE                  : ORIGIN = 0x10006000, LENGTH = 4K
   ACTIVE                            : ORIGIN = 0x10007000, LENGTH = 512K
   DFU                               : ORIGIN = 0x10087000, LENGTH = 516K


### PR DESCRIPTION
The bootloader region (`FLASH`) mentioned below overflows into the `BOOTLOADER_STATE` region by `0x100` bytes

```
0x10000100 + 24K = 0x10006100
```

https://github.com/embassy-rs/embassy/blob/32adddff9c7fc223853ada7e9ab5b7e06014a47c/examples/boot/bootloader/rp/memory.x#L3-L8