### PR TITLE
usb-synopsys-otg: ensure ep alloc fails when endpoint_count < MAX_EP_COUNT.

### DIFF
--- a/embassy-usb-synopsys-otg/src/lib.rs
+++ b/embassy-usb-synopsys-otg/src/lib.rs
@@ -382,8 +382,8 @@ impl<'d, const MAX_EP_COUNT: usize> Driver<'d, MAX_EP_COUNT> {
         }
 
         let eps = match D::dir() {
-            Direction::Out => &mut self.ep_out,
-            Direction::In => &mut self.ep_in,
+            Direction::Out => &mut self.ep_out[..self.instance.endpoint_count],
+            Direction::In => &mut self.ep_in[..self.instance.endpoint_count],
         };
 
         // Find free endpoint slot


### PR DESCRIPTION
Before, it would alloc the endpoint fine and then panic later due to out of range.
This ensures it falis at ep alloc time, and with a panic message that says
what's the actual problem: "no free endpoints available".
