### PR TITLE
Uprev cyw43 and cyw43-pio for embassy-rp 0.2 release

### DIFF
--- a/cyw43-pio/CHANGELOG.md
+++ b/cyw43-pio/CHANGELOG.md
@@ -1,0 +1,17 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## Unreleased
+
+## 0.2.0 - 2024-08-05
+
+- Update to cyw43 0.2.0
+- Update to embassy-rp 0.2.0
+
+## 0.1.0 - 2024-01-11
+
+- First release

--- a/cyw43-pio/Cargo.toml
+++ b/cyw43-pio/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cyw43-pio"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2021"
 description = "RP2040 PIO SPI implementation for cyw43"
 keywords = ["embedded", "cyw43", "embassy-net", "embedded-hal-async", "wifi"]
@@ -15,7 +15,7 @@ documentation = "https://docs.embassy.dev/cyw43-pio"
 overclock = []
 
 [dependencies]
-cyw43 = { version = "0.1.0", path = "../cyw43" }
+cyw43 = { version = "0.2.0", path = "../cyw43" }
 embassy-rp = { version = "0.2.0", path = "../embassy-rp" }
 pio-proc = "0.2"
 pio = "0.2.1"

--- a/cyw43/CHANGELOG.md
+++ b/cyw43/CHANGELOG.md
@@ -1,0 +1,23 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## Unreleased
+
+## 0.2.0 - 2024-08-05
+
+- Update to new versions of embassy-{time,sync}
+- Add more fields to the BssInfo packet struct #2461
+- Extend the Scan API #2282
+- Reuse buf to reduce stack usage #2580
+- Add MAC address getter to cyw43 controller #2818
+- Add function to join WPA2 network with precomputed PSK. #2885
+- Add function to close soft AP. #3042
+- Fixing missing re-export #3211
+
+## 0.1.0 - 2024-01-11
+
+- First release

--- a/cyw43/Cargo.toml
+++ b/cyw43/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cyw43"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2021"
 description = "Rust driver for the CYW43439 WiFi chip, used in the Raspberry Pi Pico W."
 keywords = ["embedded", "cyw43", "embassy-net", "embedded-hal-async", "wifi"]

--- a/examples/rp/Cargo.toml
+++ b/examples/rp/Cargo.toml
@@ -16,8 +16,8 @@ embassy-net = { version = "0.4.0", path = "../../embassy-net", features = ["defm
 embassy-net-wiznet = { version = "0.1.0", path = "../../embassy-net-wiznet", features = ["defmt"] }
 embassy-futures = { version = "0.1.0", path = "../../embassy-futures" }
 embassy-usb-logger = { version = "0.2.0", path = "../../embassy-usb-logger" }
-cyw43 = { version = "0.1.0", path = "../../cyw43", features = ["defmt", "firmware-logs"] }
-cyw43-pio = { version = "0.1.0", path = "../../cyw43-pio", features = ["defmt", "overclock"] }
+cyw43 = { version = "0.2.0", path = "../../cyw43", features = ["defmt", "firmware-logs"] }
+cyw43-pio = { version = "0.2.0", path = "../../cyw43-pio", features = ["defmt", "overclock"] }
 
 defmt = "0.3"
 defmt-rtt = "0.4"


### PR DESCRIPTION
Need to bump these drivers, crates.io versions with `embassy-rp` 0.2 results in

```
Compiling cyw43-pio v0.1.0
error[E0107]: struct takes 0 generic arguments but 1 generic argument was supplied
   --> src/main.rs:25:36
    |
25  | ...tic, Output<'static, PIN_23>, PioSpi<'static, PIN_25, PIO0, 0, DMA_C...
    |         ^^^^^^          ------ help: remove this generic argument
    |         |
    |         expected 0 generic arguments
    |
note: struct defined here, with 0 generic parameters
   --> /home/nine/.cargo/registry/src/index.crates.io-6f17d22bba15001f/embassy-rp-0.2.0/src/gpio.rs:345:12
    |
345 | pub struct Output<'d> {
    |            ^^^^^^

error[E0277]: the trait bound `PIN_25: embassy_rp::gpio::Pin` is not satisfied
   --> src/main.rs:25:61
    |
25  | ..., PIN_23>, PioSpi<'static, PIN_25, PIO0, 0, DMA_CH0>>,
    |               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `embassy_rp::gpio::Pin` is not implemented for `PIN_25`
    |
help: trait impl with same name found
   --> /home/nine/.cargo/registry/src/index.crates.io-6f17d22bba15001f/embassy-rp-0.2.0/src/gpio.rs:953:1
    |
953 | impl_pin!(PIN_25, Bank::Bank0, 25);
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    = note: perhaps two different versions of crate `embassy_rp` are being used?
```

cargo tree when including cyw43/cyw43-pio shows why:

```
├── cyw43-pio v0.1.0
│   ├── cyw43 v0.1.0 (*)
│   ├── defmt v0.3.8 (*)
│   ├── embassy-rp v0.1.0
```