### PR TITLE
Rename package for embassy-stm32h755cm4 and cm7 example

### DIFF
--- a/examples/stm32h755cm4/Cargo.toml
+++ b/examples/stm32h755cm4/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 edition = "2021"
-name = "embassy-stm32h7-examples"
+name = "embassy-stm32h755cm4-examples"
 version = "0.1.0"
 license = "MIT OR Apache-2.0"
 

--- a/examples/stm32h755cm7/Cargo.toml
+++ b/examples/stm32h755cm7/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 edition = "2021"
-name = "embassy-stm32h7-examples"
+name = "embassy-stm32h755cm7-examples"
 version = "0.1.0"
 license = "MIT OR Apache-2.0"
 


### PR DESCRIPTION
Fixes cargo warnings:
```
warning: skipping duplicate package `embassy-stm32h7-examples` found at `.cargo/git/checkouts/embassy-9312dcb0ed774b29/46aa206/examples/stm32h755cm4`
warning: skipping duplicate package `embassy-stm32h7-examples` found at `.cargo/git/checkouts/embassy-9312dcb0ed774b29/46aa206/examples/stm32h7`
```