### PR TITLE
nrf: Fix bunch of low-hanging clippy lint warnings

### DIFF
--- a/embassy-nrf/src/buffered_uarte.rs
+++ b/embassy-nrf/src/buffered_uarte.rs
@@ -219,6 +219,7 @@ impl<'d, U: UarteInstance, T: TimerInstance> BufferedUarte<'d, U, T> {
     /// # Panics
     ///
     /// Panics if `rx_buffer.len()` is odd.
+    #[allow(clippy::too_many_arguments)]
     pub fn new(
         uarte: impl Peripheral<P = U> + 'd,
         timer: impl Peripheral<P = T> + 'd,
@@ -254,6 +255,7 @@ impl<'d, U: UarteInstance, T: TimerInstance> BufferedUarte<'d, U, T> {
     /// # Panics
     ///
     /// Panics if `rx_buffer.len()` is odd.
+    #[allow(clippy::too_many_arguments)]
     pub fn new_with_rtscts(
         uarte: impl Peripheral<P = U> + 'd,
         timer: impl Peripheral<P = T> + 'd,
@@ -286,6 +288,7 @@ impl<'d, U: UarteInstance, T: TimerInstance> BufferedUarte<'d, U, T> {
         )
     }
 
+    #[allow(clippy::too_many_arguments)]
     fn new_inner(
         peri: PeripheralRef<'d, U>,
         timer: PeripheralRef<'d, T>,
@@ -534,6 +537,7 @@ impl<'d, U: UarteInstance, T: TimerInstance> BufferedUarteRx<'d, U, T> {
     /// # Panics
     ///
     /// Panics if `rx_buffer.len()` is odd.
+    #[allow(clippy::too_many_arguments)]
     pub fn new(
         uarte: impl Peripheral<P = U> + 'd,
         timer: impl Peripheral<P = T> + 'd,
@@ -564,6 +568,7 @@ impl<'d, U: UarteInstance, T: TimerInstance> BufferedUarteRx<'d, U, T> {
     /// # Panics
     ///
     /// Panics if `rx_buffer.len()` is odd.
+    #[allow(clippy::too_many_arguments)]
     pub fn new_with_rts(
         uarte: impl Peripheral<P = U> + 'd,
         timer: impl Peripheral<P = T> + 'd,
@@ -590,6 +595,7 @@ impl<'d, U: UarteInstance, T: TimerInstance> BufferedUarteRx<'d, U, T> {
         )
     }
 
+    #[allow(clippy::too_many_arguments)]
     fn new_inner(
         peri: PeripheralRef<'d, U>,
         timer: PeripheralRef<'d, T>,
@@ -614,6 +620,7 @@ impl<'d, U: UarteInstance, T: TimerInstance> BufferedUarteRx<'d, U, T> {
         this
     }
 
+    #[allow(clippy::too_many_arguments)]
     fn new_innerer(
         peri: PeripheralRef<'d, U>,
         timer: PeripheralRef<'d, T>,

--- a/embassy-nrf/src/gpio.rs
+++ b/embassy-nrf/src/gpio.rs
@@ -534,11 +534,13 @@ mod eh02 {
         type Error = Infallible;
 
         fn set_high(&mut self) -> Result<(), Self::Error> {
-            Ok(self.set_high())
+            self.set_high();
+            Ok(())
         }
 
         fn set_low(&mut self) -> Result<(), Self::Error> {
-            Ok(self.set_low())
+            self.set_low();
+            Ok(())
         }
     }
 
@@ -580,11 +582,13 @@ mod eh02 {
         type Error = Infallible;
 
         fn set_high(&mut self) -> Result<(), Self::Error> {
-            Ok(self.set_high())
+            self.set_high();
+            Ok(())
         }
 
         fn set_low(&mut self) -> Result<(), Self::Error> {
-            Ok(self.set_low())
+            self.set_low();
+            Ok(())
         }
     }
 
@@ -628,11 +632,13 @@ impl<'d> embedded_hal_1::digital::ErrorType for Output<'d> {
 
 impl<'d> embedded_hal_1::digital::OutputPin for Output<'d> {
     fn set_high(&mut self) -> Result<(), Self::Error> {
-        Ok(self.set_high())
+        self.set_high();
+        Ok(())
     }
 
     fn set_low(&mut self) -> Result<(), Self::Error> {
-        Ok(self.set_low())
+        self.set_low();
+        Ok(())
     }
 }
 
@@ -665,11 +671,13 @@ impl<'d> embedded_hal_1::digital::InputPin for Flex<'d> {
 
 impl<'d> embedded_hal_1::digital::OutputPin for Flex<'d> {
     fn set_high(&mut self) -> Result<(), Self::Error> {
-        Ok(self.set_high())
+        self.set_high();
+        Ok(())
     }
 
     fn set_low(&mut self) -> Result<(), Self::Error> {
-        Ok(self.set_low())
+        self.set_low();
+        Ok(())
     }
 }
 

--- a/embassy-nrf/src/wdt.rs
+++ b/embassy-nrf/src/wdt.rs
@@ -184,8 +184,9 @@ impl WatchdogHandle {
 
     /// Steal a watchdog handle by index.
     ///
-    /// Safety: watchdog must be initialized, index must be between 0 and N-1 where
-    /// N is the handle count when initializing.
+    /// # Safety
+    /// Watchdog must be initialized and `index` must be between `0` and `N-1`
+    /// where `N` is the handle count when initializing.
     pub unsafe fn steal(index: u8) -> Self {
         Self { index }
     }


### PR DESCRIPTION
Watchdog and gpio ones are obvious, though maybe we could still keep the uarte warnings so someone has intention to look whether it's possible to refactor the ppi arguments into struct?