### PR TITLE
cyw43: make sure to yield if doing busy-polling for interrupts.

### DIFF
--- a/cyw43/src/runner.rs
+++ b/cyw43/src/runner.rs
@@ -365,6 +365,13 @@ where
                     }
                     Either4::Fourth(()) => {
                         self.handle_irq(&mut buf).await;
+
+                        // If we do busy-polling, make sure to yield.
+                        // `handle_irq` will only do a 32bit read if there's no work to do, which is really fast.
+                        // Depending on optimization level, it is possible that the 32-bit read finishes on
+                        // first poll, so it never yields and we starve all other tasks.
+                        #[cfg(feature = "bluetooth")]
+                        embassy_futures::yield_now().await;
                     }
                 }
             } else {

--- a/examples/rp/Cargo.toml
+++ b/examples/rp/Cargo.toml
@@ -64,8 +64,11 @@ trouble-host = { version = "0.1.0", features = ["defmt", "gatt"] }
 
 [profile.release]
 debug = 2
+lto = true
+opt-level = 'z'
 
 [profile.dev]
+debug = 2
 lto = true
 opt-level = "z"
 


### PR DESCRIPTION
fixes #3237
