### PR TITLE
nrf, doc: Don't refer to `Default` impl of `saadc::ChannelConfig`

### DIFF
--- a/embassy-nrf/src/saadc.rs
+++ b/embassy-nrf/src/saadc.rs
@@ -78,7 +78,8 @@ impl Default for Config {
 
 /// Used to configure an individual SAADC peripheral channel.
 ///
-/// See the `Default` impl for suitable default values.
+/// Construct using the `single_ended` or `differential` methods.  These provide sensible defaults
+/// for the public fields, which can be overridden if required.
 #[non_exhaustive]
 pub struct ChannelConfig<'d> {
     /// Reference voltage of the SAADC input.


### PR DESCRIPTION
`saadc::ChannelConfig` does not implement the `Default` trait, so its documentation should not refer to it.  Modify the documentation to instead describe how the struct should be created and configured.