### PR TITLE
feat(mdns): Enable mdns support through smoltcp

### DIFF
--- a/embassy-net/Cargo.toml
+++ b/embassy-net/Cargo.toml
@@ -44,6 +44,8 @@ raw = ["smoltcp/socket-raw"]
 tcp = ["smoltcp/socket-tcp"]
 ## Enable DNS support
 dns = ["smoltcp/socket-dns", "smoltcp/proto-dns"]
+## Enable mDNS support
+mdns = ["dns", "smoltcp/socket-mdns"]
 ## Enable DHCPv4 support
 dhcpv4 = ["proto-ipv4", "medium-ethernet", "smoltcp/socket-dhcpv4"]
 ## Enable DHCPv4 support with hostname


### PR DESCRIPTION
Smoltcp supports mDNS but the feature was never used in embassy. Enabling it seems to be all what's required to resolve a `.local` address, in small local testing I did.

Should fix https://github.com/embassy-rs/embassy/issues/3177

cc @PhaestusFox