### PR TITLE
[UCPD] Add support for non-SOP packets

### DIFF
--- a/examples/stm32g4/src/bin/usb_c_pd.rs
+++ b/examples/stm32g4/src/bin/usb_c_pd.rs
@@ -55,7 +55,7 @@ async fn main(_spawner: Spawner) {
 
     info!("Hello World!");
 
-    let mut ucpd = Ucpd::new(p.UCPD1, Irqs {}, p.PB6, p.PB4);
+    let mut ucpd = Ucpd::new(p.UCPD1, Irqs {}, p.PB6, p.PB4, Default::default());
     ucpd.cc_phy().set_pull(CcPull::Sink);
 
     info!("Waiting for USB connection...");

--- a/tests/stm32/src/bin/ucpd.rs
+++ b/tests/stm32/src/bin/ucpd.rs
@@ -106,8 +106,8 @@ async fn main(_spawner: Spawner) {
     info!("Hello World!");
 
     // Wire between PD0 and PA8
-    let ucpd1 = Ucpd::new(p.UCPD1, Irqs {}, p.PA8, p.PB15);
-    let ucpd2 = Ucpd::new(p.UCPD2, Irqs {}, p.PD0, p.PD2);
+    let ucpd1 = Ucpd::new(p.UCPD1, Irqs {}, p.PA8, p.PB15, Default::default());
+    let ucpd2 = Ucpd::new(p.UCPD2, Irqs {}, p.PD0, p.PD2, Default::default());
 
     join(
         source(ucpd1, p.DMA1_CH1, p.DMA1_CH2),


### PR DESCRIPTION
Allow capturing (and distinguishing) non-SOP packets as well. The default configuration will just configure SOP packets. For ease of use the default receive function signature is unchanged as for PD sinks (which is likely the common usage) just SOP is enough so no need to differentiate.