### PR TITLE
stm32/usart: sending break character

### DIFF
--- a/embassy-stm32/src/usart/buffered.rs
+++ b/embassy-stm32/src/usart/buffered.rs
@@ -12,8 +12,8 @@ use embassy_sync::waitqueue::AtomicWaker;
 #[cfg(not(any(usart_v1, usart_v2)))]
 use super::DePin;
 use super::{
-    clear_interrupt_flags, configure, rdr, reconfigure, sr, tdr, Config, ConfigError, CtsPin, Error, Info, Instance,
-    Regs, RtsPin, RxPin, TxPin,
+    clear_interrupt_flags, configure, rdr, reconfigure, send_break, sr, tdr, Config, ConfigError, CtsPin, Error, Info,
+    Instance, Regs, RtsPin, RxPin, TxPin,
 };
 use crate::gpio::{AfType, AnyPin, OutputType, Pull, SealedPin as _, Speed};
 use crate::interrupt::{self, InterruptExt};
@@ -359,6 +359,11 @@ impl<'d> BufferedUart<'d> {
 
         Ok(())
     }
+
+    /// Send break character
+    pub fn send_break(&self) {
+        self.tx.send_break()
+    }
 }
 
 impl<'d> BufferedUartRx<'d> {
@@ -537,6 +542,11 @@ impl<'d> BufferedUartTx<'d> {
         });
 
         Ok(())
+    }
+
+    /// Send break character
+    pub fn send_break(&self) {
+        send_break(&self.info.regs);
     }
 }
 


### PR DESCRIPTION
Add function to send break character on STM32 USARTs.
Function is currently sync and first busy-waits until previous break has been sent (should be rare?, usart v3&v4 seems to have interrupt for sent break character).
Then sending break character is requested and it should be sent as soon as the current character is transmitted.