### PR TITLE
chore: Remove unused keyboard code from rp mouse example

### DIFF
--- a/examples/rp/src/bin/usb_hid_mouse.rs
+++ b/examples/rp/src/bin/usb_hid_mouse.rs
@@ -8,7 +8,6 @@ use embassy_executor::Spawner;
 use embassy_futures::join::join;
 use embassy_rp::bind_interrupts;
 use embassy_rp::clocks::RoscRng;
-use embassy_rp::gpio::{Input, Pull};
 use embassy_rp::peripherals::USB;
 use embassy_rp::usb::{Driver, InterruptHandler};
 use embassy_time::Timer;
@@ -74,12 +73,6 @@ async fn main(_spawner: Spawner) {
 
     // Run the USB device.
     let usb_fut = usb.run();
-
-    // Set up the signal pin that will be used to trigger the keyboard.
-    let mut signal_pin = Input::new(p.PIN_16, Pull::None);
-
-    // Enable the schmitt trigger to slightly debounce.
-    signal_pin.set_schmitt(true);
 
     let (reader, mut writer) = hid.split();
 


### PR DESCRIPTION
The usb mouse example included code copied from the keyboard example to set up
a button, which is not used in the mouse example. Remove it, to make the
example clearer.
