### PR TITLE
rp: add example code to flash bluetooth fw

### DIFF
--- a/examples/rp/src/bin/bluetooth.rs
+++ b/examples/rp/src/bin/bluetooth.rs
@@ -43,8 +43,10 @@ async fn main(spawner: Spawner) {
     // at hardcoded addresses, instead of baking them into the program with `include_bytes!`:
     //     probe-rs download 43439A0.bin --format bin --chip RP2040 --base-address 0x10100000
     //     probe-rs download 43439A0_clm.bin --format bin --chip RP2040 --base-address 0x10140000
+    //     probe-rs download 43439A0_btfw.bin --format bin --chip RP2040 --base-address 0x10141400
     //let fw = unsafe { core::slice::from_raw_parts(0x10100000 as *const u8, 224190) };
     //let clm = unsafe { core::slice::from_raw_parts(0x10140000 as *const u8, 4752) };
+    //let btfw = unsafe { core::slice::from_raw_parts(0x10141400 as *const u8, 6164) };
 
     let pwr = Output::new(p.PIN_23, Level::Low);
     let cs = Output::new(p.PIN_25, Level::High);


### PR DESCRIPTION
I guess this was copy-pasted from the wifi example.