### PR TITLE
Allow bos_descriptor_buf to be a zero-length slice

### DIFF
--- a/embassy-usb/src/descriptor.rs
+++ b/embassy-usb/src/descriptor.rs
@@ -308,6 +308,9 @@ impl<'a> BosWriter<'a> {
     }
 
     pub(crate) fn bos(&mut self) {
+        if (self.writer.buf.len() - self.writer.position) < 5 {
+            return;
+        }
         self.num_caps_mark = Some(self.writer.position + 4);
         self.writer.write(
             descriptor_type::BOS,
@@ -350,6 +353,9 @@ impl<'a> BosWriter<'a> {
     }
 
     pub(crate) fn end_bos(&mut self) {
+        if self.writer.position == 0 {
+            return;
+        }
         self.num_caps_mark = None;
         let position = self.writer.position as u16;
         self.writer.buf[2..4].copy_from_slice(&position.to_le_bytes());


### PR DESCRIPTION
As discussed on the Matrix room, having a zero-length `bos_descriptor_buf` currently crashes the embassy-usb builder.
This should fix it, by checking for enough bytes in the buf, before taking any actions.