### PR TITLE
fix(stm32): disable transmitter during during half-duplex flush

### DIFF
--- a/embassy-stm32/src/usart/mod.rs
+++ b/embassy-stm32/src/usart/mod.rs
@@ -526,9 +526,12 @@ fn blocking_flush(info: &Info) -> Result<(), Error> {
     let r = info.regs;
     while !sr(r).read().tc() {}
 
-    // Enable Receiver after transmission complete for Half-Duplex mode
+    // Disable Transmitter and enable receiver after transmission complete for Half-Duplex mode
     if r.cr3().read().hdsel() {
-        r.cr1().modify(|reg| reg.set_re(true));
+        r.cr1().modify(|reg| {
+            reg.set_te(false);
+            reg.set_re(true);
+        });
     }
 
     Ok(())


### PR DESCRIPTION
This PR addresses an issue with half-duplex UART communication on STM32H7 (probably valid for all STM32s) where subsequent read cycles unexpectedly return both sent and received bytes, leading to potential data corruption. 
The fix involves disabling the transmitter (before enabling the receiver) after transmission flush in half-duplex mode.