### PR TITLE
[embassy-time] Feature gate embedded-hal 0.2

### DIFF
--- a/embassy-time/CHANGELOG.md
+++ b/embassy-time/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+- `embedded-hal 0.2` support is now locked behind the `embedded-hal-02` feature, to be removed in a future breaking version.
+
 ## 0.3.2 - 2024-08-05
 
 - Implement with_timeout()/with_deadline() method style call on Future

--- a/embassy-time/Cargo.toml
+++ b/embassy-time/Cargo.toml
@@ -27,6 +27,9 @@ features = ["defmt", "std"]
 std = ["tick-hz-1_000_000", "critical-section/std"]
 wasm = ["dep:wasm-bindgen", "dep:js-sys", "dep:wasm-timer", "tick-hz-1_000_000"]
 
+## Implement traits from the old `embedded_hal 0.2` library
+embedded-hal-02 = ["dep:embedded-hal-02"]
+
 ## Display the time since startup next to defmt log messages.
 ## At most 1 `defmt-timestamp-uptime-*` feature can be used.
 ## `defmt-timestamp-uptime` is provided for backwards compatibility (provides the same format as `uptime-us`).
@@ -412,7 +415,7 @@ embassy-time-queue-driver = { version = "0.1.0", path = "../embassy-time-queue-d
 defmt = { version = "0.3", optional = true }
 log = { version = "0.4.14", optional = true }
 
-embedded-hal-02 = { package = "embedded-hal", version = "0.2.6" }
+embedded-hal-02 = { package = "embedded-hal", version = "0.2.6", optional = true }
 embedded-hal-1 = { package = "embedded-hal", version = "1.0" }
 embedded-hal-async = { version = "1.0" }
 

--- a/embassy-time/src/delay.rs
+++ b/embassy-time/src/delay.rs
@@ -44,38 +44,43 @@ impl embedded_hal_async::delay::DelayNs for Delay {
     }
 }
 
-impl embedded_hal_02::blocking::delay::DelayMs<u8> for Delay {
-    fn delay_ms(&mut self, ms: u8) {
-        block_for(Duration::from_millis(ms as u64))
-    }
-}
+#[cfg(feature = "embedded-hal-02")]
+mod embedded_hal_02_impls {
+    use super::{block_for, Delay, Duration};
 
-impl embedded_hal_02::blocking::delay::DelayMs<u16> for Delay {
-    fn delay_ms(&mut self, ms: u16) {
-        block_for(Duration::from_millis(ms as u64))
+    impl embedded_hal_02::blocking::delay::DelayMs<u8> for Delay {
+        fn delay_ms(&mut self, ms: u8) {
+            block_for(Duration::from_millis(ms as u64))
+        }
     }
-}
 
-impl embedded_hal_02::blocking::delay::DelayMs<u32> for Delay {
-    fn delay_ms(&mut self, ms: u32) {
-        block_for(Duration::from_millis(ms as u64))
+    impl embedded_hal_02::blocking::delay::DelayMs<u16> for Delay {
+        fn delay_ms(&mut self, ms: u16) {
+            block_for(Duration::from_millis(ms as u64))
+        }
     }
-}
 
-impl embedded_hal_02::blocking::delay::DelayUs<u8> for Delay {
-    fn delay_us(&mut self, us: u8) {
-        block_for(Duration::from_micros(us as u64))
+    impl embedded_hal_02::blocking::delay::DelayMs<u32> for Delay {
+        fn delay_ms(&mut self, ms: u32) {
+            block_for(Duration::from_millis(ms as u64))
+        }
     }
-}
 
-impl embedded_hal_02::blocking::delay::DelayUs<u16> for Delay {
-    fn delay_us(&mut self, us: u16) {
-        block_for(Duration::from_micros(us as u64))
+    impl embedded_hal_02::blocking::delay::DelayUs<u8> for Delay {
+        fn delay_us(&mut self, us: u8) {
+            block_for(Duration::from_micros(us as u64))
+        }
     }
-}
 
-impl embedded_hal_02::blocking::delay::DelayUs<u32> for Delay {
-    fn delay_us(&mut self, us: u32) {
-        block_for(Duration::from_micros(us as u64))
+    impl embedded_hal_02::blocking::delay::DelayUs<u16> for Delay {
+        fn delay_us(&mut self, us: u16) {
+            block_for(Duration::from_micros(us as u64))
+        }
+    }
+
+    impl embedded_hal_02::blocking::delay::DelayUs<u32> for Delay {
+        fn delay_us(&mut self, us: u32) {
+            block_for(Duration::from_micros(us as u64))
+        }
     }
 }


### PR DESCRIPTION
This avoids pulling in this old version of `embedded-hal` for anyone who doesn't need it, which leads to reduced compile times especially with the removal of the `nb` dep.