### PR TITLE
nrf52840: fix naming of LED states in examples

### DIFF
--- a/examples/nrf52840/src/bin/channel.rs
+++ b/examples/nrf52840/src/bin/channel.rs
@@ -35,8 +35,8 @@ async fn main(spawner: Spawner) {
 
     loop {
         match CHANNEL.receive().await {
-            LedState::On => led.set_high(),
-            LedState::Off => led.set_low(),
+            LedState::On => led.set_low(),
+            LedState::Off => led.set_high(),
         }
     }
 }

--- a/examples/nrf52840/src/bin/channel_sender_receiver.rs
+++ b/examples/nrf52840/src/bin/channel_sender_receiver.rs
@@ -33,8 +33,8 @@ async fn recv_task(led: AnyPin, receiver: Receiver<'static, NoopRawMutex, LedSta
 
     loop {
         match receiver.receive().await {
-            LedState::On => led.set_high(),
-            LedState::Off => led.set_low(),
+            LedState::On => led.set_low(),
+            LedState::Off => led.set_high(),
         }
     }
 }


### PR DESCRIPTION
The LEDs on the nrf52840 DK are active low.

Documentation: https://docs.nordicsemi.com/bundle/ug_nrf52840_dk/page/UG/dk/hw_buttons_leds.html

Note, the LEDs on the Raspberry Pi Pico (2) are active high, no change is needed there.