### PR TITLE
Fix using default_features instead of default-features in embassy boot

### DIFF
--- a/embassy-boot/Cargo.toml
+++ b/embassy-boot/Cargo.toml
@@ -27,7 +27,7 @@ features = ["defmt"]
 defmt = { version = "0.3", optional = true }
 digest = "0.10"
 log = { version = "0.4", optional = true }
-ed25519-dalek = { version = "2", default_features = false, features = ["digest"], optional = true }
+ed25519-dalek = { version = "2", default-features = false, features = ["digest"], optional = true }
 embassy-embedded-hal = { version = "0.2.0", path = "../embassy-embedded-hal" }
 embassy-sync = { version = "0.6.0", path = "../embassy-sync" }
 embedded-storage = "0.3.1"
@@ -42,7 +42,7 @@ rand = "0.8"
 futures = { version = "0.3", features = ["executor"] }
 sha1 = "0.10.5"
 critical-section = { version = "1.1.1", features = ["std"] }
-ed25519-dalek = { version = "2", default_features = false, features = ["std", "rand_core", "digest"]  }
+ed25519-dalek = { version = "2", default-features = false, features = ["std", "rand_core", "digest"]  }
 
 [features]
 ed25519-dalek = ["dep:ed25519-dalek", "_verify"]


### PR DESCRIPTION
using default_features is deprecated in the 2024 edition per the compiler warning.