### PR TITLE
Enable critical-section/std on wasm

### DIFF
--- a/embassy-executor/Cargo.toml
+++ b/embassy-executor/Cargo.toml
@@ -79,7 +79,7 @@ arch-cortex-m = ["_arch", "dep:cortex-m"]
 ## RISC-V 32
 arch-riscv32 = ["_arch"]
 ## WASM
-arch-wasm = ["_arch", "dep:wasm-bindgen", "dep:js-sys"]
+arch-wasm = ["_arch", "dep:wasm-bindgen", "dep:js-sys", "critical-section/std"]
 ## AVR
 arch-avr = ["_arch", "dep:portable-atomic", "dep:avr-device"]
 

--- a/examples/wasm/Cargo.toml
+++ b/examples/wasm/Cargo.toml
@@ -16,7 +16,6 @@ wasm-logger = "0.2.0"
 wasm-bindgen = "0.2"
 web-sys = { version = "0.3", features = ["Document", "Element", "HtmlElement", "Node", "Window" ] }
 log = "0.4.11"
-critical-section = { version = "1.1", features = ["std"] }
 
 [profile.release]
 debug = 2


### PR DESCRIPTION
Without that feature one will find import errors on opening the webpage, that are hard to debug. The feature was indirectly enabled in the wasm example, however the reason wasn't documented and thus it was easy to miss.