### PR TITLE
fix(stm32): fix dma and idle line detection in ringbuffereduartrx

### DIFF
--- a/embassy-stm32/src/dma/dma_bdma.rs
+++ b/embassy-stm32/src/dma/dma_bdma.rs
@@ -777,6 +777,7 @@ impl<'a, W: Word> ReadableRingBuffer<'a, W> {
         let dir = Dir::PeripheralToMemory;
         let data_size = W::size();
 
+        options.half_transfer_ir = true;
         options.complete_transfer_ir = true;
         options.circular = true;
 


### PR DESCRIPTION
This change is required to address an issue in the RingBufferedUartRx DMA handling and idle line detection.

When an IRQ wakes the `select` future, both inner futures (`dma` and `uart`) in the select are re-polled. Previously, the `dma` future was polled first. Since it can't check if it was woken for valid reasons (due to API limitations), it could end the select future without clearing the IDLE flag, which is handled in the `uart` future.

The proposed fix reverses the polling order, starting with the `uart` future. This allows proper checking and clearing of the IDLE flag before considering the DMA status, preventing scenarios where the flag remains set across multiple read operations.

Additionally, this PR enables the half-transfer IRQ for the DMA to help prevent data loss at high baud rates. I don't think it introduces any side effects.