### PR TITLE
SAI pull down clock and data lines in receive mode

### DIFF
--- a/embassy-stm32/src/sai/mod.rs
+++ b/embassy-stm32/src/sai/mod.rs
@@ -661,12 +661,12 @@ fn get_af_types(mode: Mode, tx_rx: TxRx) -> (AfType, AfType) {
         //sd is defined by tx/rx mode
         match tx_rx {
             TxRx::Transmitter => AfType::output(OutputType::PushPull, Speed::VeryHigh),
-            TxRx::Receiver => AfType::input(Pull::None),
+            TxRx::Receiver => AfType::input(Pull::Down), // Ensure mute level when no input is connected.
         },
         //clocks (mclk, sck and fs) are defined by master/slave
         match mode {
             Mode::Master => AfType::output(OutputType::PushPull, Speed::VeryHigh),
-            Mode::Slave => AfType::input(Pull::None),
+            Mode::Slave => AfType::input(Pull::Down), // Ensure no clocks when no input is connected.
         },
     )
 }


### PR DESCRIPTION
Ensures that, when no external input is connected, the data line is in mute state, and no (spurious) clocks are received.

With a RaspberryPi 4 as a source (a few 10 Ohm of output resistance) in slave mode, the data line shows no signs of degradation. The pull-down is around 40 kOhm.

![SDS00001](https://github.com/user-attachments/assets/35218b65-da46-4180-8c90-c210be20cd29)
![SDS00002](https://github.com/user-attachments/assets/a9f761e3-da17-4d20-b7c2-15a48f162eb4)
