### PR TITLE
net: refactor to simplify lifetimes/generics.

### DIFF
--- a/ci.sh
+++ b/ci.sh
@@ -290,8 +290,9 @@ cargo batch \
     $BUILD_EXTRA
 
 
-# temporarily disabled, bluepill board got bricked
+# temporarily disabled, these boards are dead.
 rm -rf out/tests/stm32f103c8
+rm -rf out/tests/nrf52840-dk
 
 rm out/tests/stm32wb55rg/wpan_mac
 rm out/tests/stm32wb55rg/wpan_ble

--- a/ci.sh
+++ b/ci.sh
@@ -47,7 +47,7 @@ cargo batch \
     --- build --release --manifest-path embassy-sync/Cargo.toml --target thumbv6m-none-eabi --features defmt \
     --- build --release --manifest-path embassy-time/Cargo.toml --target thumbv6m-none-eabi --features defmt,defmt-timestamp-uptime,generic-queue-8,mock-driver \
     --- build --release --manifest-path embassy-net/Cargo.toml --target thumbv7em-none-eabi --features defmt,tcp,udp,dns,proto-ipv4,medium-ethernet,packet-trace \
-    --- build --release --manifest-path embassy-net/Cargo.toml --target thumbv7em-none-eabi --features defmt,tcp,udp,dns,proto-ipv4,igmp,medium-ethernet \
+    --- build --release --manifest-path embassy-net/Cargo.toml --target thumbv7em-none-eabi --features defmt,tcp,udp,dns,proto-ipv4,multicast,medium-ethernet \
     --- build --release --manifest-path embassy-net/Cargo.toml --target thumbv7em-none-eabi --features defmt,tcp,udp,dns,dhcpv4,medium-ethernet \
     --- build --release --manifest-path embassy-net/Cargo.toml --target thumbv7em-none-eabi --features defmt,tcp,udp,dns,dhcpv4,medium-ethernet,dhcpv4-hostname \
     --- build --release --manifest-path embassy-net/Cargo.toml --target thumbv7em-none-eabi --features defmt,tcp,udp,dns,proto-ipv6,medium-ethernet \

--- a/embassy-net/Cargo.toml
+++ b/embassy-net/Cargo.toml
@@ -16,11 +16,11 @@ categories = [
 [package.metadata.embassy_docs]
 src_base = "https://github.com/embassy-rs/embassy/blob/embassy-net-v$VERSION/embassy-net/src/"
 src_base_git = "https://github.com/embassy-rs/embassy/blob/$COMMIT/embassy-net/src/"
-features = ["defmt", "tcp", "udp", "raw", "dns", "dhcpv4", "proto-ipv6", "medium-ethernet", "medium-ip", "medium-ieee802154", "igmp", "dhcpv4-hostname"]
+features = ["defmt", "tcp", "udp", "raw", "dns", "dhcpv4", "proto-ipv6", "medium-ethernet", "medium-ip", "medium-ieee802154", "multicast", "dhcpv4-hostname"]
 target = "thumbv7em-none-eabi"
 
 [package.metadata.docs.rs]
-features = ["defmt", "tcp", "udp", "raw", "dns", "dhcpv4", "proto-ipv6", "medium-ethernet", "medium-ip", "medium-ieee802154", "igmp", "dhcpv4-hostname"]
+features = ["defmt", "tcp", "udp", "raw", "dns", "dhcpv4", "proto-ipv6", "medium-ethernet", "medium-ip", "medium-ieee802154", "multicast", "dhcpv4-hostname"]
 
 [features]
 default = []
@@ -60,15 +60,15 @@ medium-ethernet = ["smoltcp/medium-ethernet"]
 medium-ip = ["smoltcp/medium-ip"]
 ## Enable the IEEE 802.15.4 medium
 medium-ieee802154 = ["smoltcp/medium-ieee802154"]
-## Enable IGMP support
-igmp = ["smoltcp/proto-igmp"]
+## Enable multicast support (for both ipv4 and/or ipv6 if enabled)
+multicast = ["smoltcp/multicast"]
 
 [dependencies]
 
 defmt = { version = "0.3", optional = true }
 log = { version = "0.4.14", optional = true }
 
-smoltcp = { version = "0.11.0", default-features = false, features = [
+smoltcp = { git="https://github.com/smoltcp-rs/smoltcp", rev="dd43c8f189178b0ab3bda798ed8578b5b0a6f094", default-features = false, features = [
   "socket",
   "async",
 ] }

--- a/embassy-net/README.md
+++ b/embassy-net/README.md
@@ -10,8 +10,9 @@ memory management designed to work well for embedded systems, aiming for a more 
 
 - IPv4, IPv6
 - Ethernet and bare-IP mediums.
-- TCP, UDP, DNS, DHCPv4, IGMPv4
+- TCP, UDP, DNS, DHCPv4
 - TCP sockets implement the `embedded-io` async traits.
+- Multicast
 
 See the [`smoltcp`](https://github.com/smoltcp-rs/smoltcp) README for a detailed list of implemented and
 unimplemented features of the network protocols.

--- a/embassy-net/src/dns.rs
+++ b/embassy-net/src/dns.rs
@@ -9,7 +9,7 @@ pub use smoltcp::socket::dns::{DnsQuery, Socket};
 pub(crate) use smoltcp::socket::dns::{GetQueryResultError, StartQueryError};
 pub use smoltcp::wire::{DnsQueryType, IpAddress};
 
-use crate::{Driver, Stack};
+use crate::Stack;
 
 /// Errors returned by DnsSocket.
 #[derive(Debug, PartialEq, Eq, Clone, Copy)]
@@ -44,21 +44,15 @@ impl From<StartQueryError> for Error {
 /// This exists only for compatibility with crates that use `embedded-nal-async`.
 /// Prefer using [`Stack::dns_query`](crate::Stack::dns_query) directly if you're
 /// not using `embedded-nal-async`.
-pub struct DnsSocket<'a, D>
-where
-    D: Driver + 'static,
-{
-    stack: &'a Stack<D>,
+pub struct DnsSocket<'a> {
+    stack: Stack<'a>,
 }
 
-impl<'a, D> DnsSocket<'a, D>
-where
-    D: Driver + 'static,
-{
+impl<'a> DnsSocket<'a> {
     /// Create a new DNS socket using the provided stack.
     ///
     /// NOTE: If using DHCP, make sure it has reconfigured the stack to ensure the DNS servers are updated.
-    pub fn new(stack: &'a Stack<D>) -> Self {
+    pub fn new(stack: Stack<'a>) -> Self {
         Self { stack }
     }
 
@@ -72,10 +66,7 @@ where
     }
 }
 
-impl<'a, D> embedded_nal_async::Dns for DnsSocket<'a, D>
-where
-    D: Driver + 'static,
-{
+impl<'a> embedded_nal_async::Dns for DnsSocket<'a> {
     type Error = Error;
 
     async fn get_host_by_name(
@@ -123,4 +114,8 @@ where
     ) -> Result<usize, Self::Error> {
         todo!()
     }
+}
+
+fn _assert_covariant<'a, 'b: 'a>(x: DnsSocket<'b>) -> DnsSocket<'a> {
+    x
 }

--- a/embassy-net/src/driver_util.rs
+++ b/embassy-net/src/driver_util.rs
@@ -74,7 +74,7 @@ where
 {
     fn consume<R, F>(self, f: F) -> R
     where
-        F: FnOnce(&mut [u8]) -> R,
+        F: FnOnce(&[u8]) -> R,
     {
         self.0.consume(|buf| {
             #[cfg(feature = "packet-trace")]

--- a/embassy-net/src/lib.rs
+++ b/embassy-net/src/lib.rs
@@ -12,9 +12,9 @@ compile_error!("You must enable at least one of the following features: proto-ip
 // This mod MUST go first, so that the others see its macros.
 pub(crate) mod fmt;
 
-mod device;
 #[cfg(feature = "dns")]
 pub mod dns;
+mod driver_util;
 #[cfg(feature = "raw")]
 pub mod raw;
 #[cfg(feature = "tcp")]
@@ -25,6 +25,7 @@ pub mod udp;
 
 use core::cell::RefCell;
 use core::future::{poll_fn, Future};
+use core::mem::MaybeUninit;
 use core::pin::pin;
 use core::task::{Context, Poll};
 
@@ -36,7 +37,7 @@ use embassy_time::{Instant, Timer};
 use heapless::Vec;
 #[cfg(feature = "dns")]
 pub use smoltcp::config::DNS_MAX_SERVER_COUNT;
-#[cfg(feature = "igmp")]
+#[cfg(feature = "multicast")]
 pub use smoltcp::iface::MulticastError;
 #[allow(unused_imports)]
 use smoltcp::iface::{Interface, SocketHandle, SocketSet, SocketStorage};
@@ -57,7 +58,7 @@ pub use smoltcp::wire::{Ipv4Address, Ipv4Cidr};
 #[cfg(feature = "proto-ipv6")]
 pub use smoltcp::wire::{Ipv6Address, Ipv6Cidr};
 
-use crate::device::DriverAdapter;
+use crate::driver_util::DriverAdapter;
 use crate::time::{instant_from_smoltcp, instant_to_smoltcp};
 
 const LOCAL_PORT_MIN: u16 = 1025;
@@ -69,33 +70,33 @@ const MAX_HOSTNAME_LEN: usize = 32;
 
 /// Memory resources needed for a network stack.
 pub struct StackResources<const SOCK: usize> {
-    sockets: [SocketStorage<'static>; SOCK],
+    sockets: MaybeUninit<[SocketStorage<'static>; SOCK]>,
+    inner: MaybeUninit<RefCell<Inner>>,
     #[cfg(feature = "dns")]
-    queries: [Option<dns::DnsQuery>; MAX_QUERIES],
+    queries: MaybeUninit<[Option<dns::DnsQuery>; MAX_QUERIES]>,
     #[cfg(feature = "dhcpv4-hostname")]
-    hostname: core::cell::UnsafeCell<HostnameResources>,
+    hostname: HostnameResources,
 }
 
 #[cfg(feature = "dhcpv4-hostname")]
 struct HostnameResources {
-    option: smoltcp::wire::DhcpOption<'static>,
-    data: [u8; MAX_HOSTNAME_LEN],
+    option: MaybeUninit<smoltcp::wire::DhcpOption<'static>>,
+    data: MaybeUninit<[u8; MAX_HOSTNAME_LEN]>,
 }
 
 impl<const SOCK: usize> StackResources<SOCK> {
     /// Create a new set of stack resources.
     pub const fn new() -> Self {
-        #[cfg(feature = "dns")]
-        const INIT: Option<dns::DnsQuery> = None;
         Self {
-            sockets: [SocketStorage::EMPTY; SOCK],
+            sockets: MaybeUninit::uninit(),
+            inner: MaybeUninit::uninit(),
             #[cfg(feature = "dns")]
-            queries: [INIT; MAX_QUERIES],
+            queries: MaybeUninit::uninit(),
             #[cfg(feature = "dhcpv4-hostname")]
-            hostname: core::cell::UnsafeCell::new(HostnameResources {
-                option: smoltcp::wire::DhcpOption { kind: 0, data: &[] },
-                data: [0; MAX_HOSTNAME_LEN],
-            }),
+            hostname: HostnameResources {
+                option: MaybeUninit::uninit(),
+                data: MaybeUninit::uninit(),
+            },
         }
     }
 }
@@ -239,16 +240,29 @@ pub enum ConfigV6 {
     Static(StaticConfigV6),
 }
 
-/// A network stack.
+/// Network stack runner.
 ///
-/// This is the main entry point for the network stack.
-pub struct Stack<D: Driver> {
-    pub(crate) socket: RefCell<SocketStack>,
-    inner: RefCell<Inner<D>>,
+/// You must call [`Runner::run()`] in a background task for the network stack to work.
+pub struct Runner<'d, D: Driver> {
+    driver: D,
+    stack: Stack<'d>,
 }
 
-struct Inner<D: Driver> {
-    device: D,
+/// Network stack handle
+///
+/// Use this to create sockets. It's `Copy`, so you can pass
+/// it by value instead of by reference.
+#[derive(Copy, Clone)]
+pub struct Stack<'d> {
+    inner: &'d RefCell<Inner>,
+}
+
+pub(crate) struct Inner {
+    pub(crate) sockets: SocketSet<'static>, // Lifetime type-erased.
+    pub(crate) iface: Interface,
+    pub(crate) waker: WakerRegistration,
+    hardware_address: HardwareAddress,
+    next_local_port: u16,
     link_up: bool,
     #[cfg(feature = "proto-ipv4")]
     static_v4: Option<StaticConfigV4>,
@@ -262,14 +276,83 @@ struct Inner<D: Driver> {
     #[cfg(feature = "dns")]
     dns_waker: WakerRegistration,
     #[cfg(feature = "dhcpv4-hostname")]
-    hostname: &'static mut core::cell::UnsafeCell<HostnameResources>,
+    hostname: *mut HostnameResources,
 }
 
-pub(crate) struct SocketStack {
-    pub(crate) sockets: SocketSet<'static>,
-    pub(crate) iface: Interface,
-    pub(crate) waker: WakerRegistration,
-    next_local_port: u16,
+fn _assert_covariant<'a, 'b: 'a>(x: Stack<'b>) -> Stack<'a> {
+    x
+}
+
+/// Create a new network stack.
+pub fn new<'d, D: Driver, const SOCK: usize>(
+    mut driver: D,
+    config: Config,
+    resources: &'d mut StackResources<SOCK>,
+    random_seed: u64,
+) -> (Stack<'d>, Runner<'d, D>) {
+    let (hardware_address, medium) = to_smoltcp_hardware_address(driver.hardware_address());
+    let mut iface_cfg = smoltcp::iface::Config::new(hardware_address);
+    iface_cfg.random_seed = random_seed;
+
+    let iface = Interface::new(
+        iface_cfg,
+        &mut DriverAdapter {
+            inner: &mut driver,
+            cx: None,
+            medium,
+        },
+        instant_to_smoltcp(Instant::now()),
+    );
+
+    unsafe fn transmute_slice<T>(x: &mut [T]) -> &'static mut [T] {
+        core::mem::transmute(x)
+    }
+
+    let sockets = resources.sockets.write([SocketStorage::EMPTY; SOCK]);
+    #[allow(unused_mut)]
+    let mut sockets: SocketSet<'static> = SocketSet::new(unsafe { transmute_slice(sockets) });
+
+    let next_local_port = (random_seed % (LOCAL_PORT_MAX - LOCAL_PORT_MIN) as u64) as u16 + LOCAL_PORT_MIN;
+
+    #[cfg(feature = "dns")]
+    let dns_socket = sockets.add(dns::Socket::new(
+        &[],
+        managed::ManagedSlice::Borrowed(unsafe {
+            transmute_slice(resources.queries.write([const { None }; MAX_QUERIES]))
+        }),
+    ));
+
+    let mut inner = Inner {
+        sockets,
+        iface,
+        waker: WakerRegistration::new(),
+        next_local_port,
+        hardware_address,
+        link_up: false,
+        #[cfg(feature = "proto-ipv4")]
+        static_v4: None,
+        #[cfg(feature = "proto-ipv6")]
+        static_v6: None,
+        #[cfg(feature = "dhcpv4")]
+        dhcp_socket: None,
+        config_waker: WakerRegistration::new(),
+        #[cfg(feature = "dns")]
+        dns_socket,
+        #[cfg(feature = "dns")]
+        dns_waker: WakerRegistration::new(),
+        #[cfg(feature = "dhcpv4-hostname")]
+        hostname: &mut resources.hostname,
+    };
+
+    #[cfg(feature = "proto-ipv4")]
+    inner.set_config_v4(config.ipv4);
+    #[cfg(feature = "proto-ipv6")]
+    inner.set_config_v6(config.ipv6);
+    inner.apply_static_config();
+
+    let inner = &*resources.inner.write(RefCell::new(inner));
+    let stack = Stack { inner };
+    (stack, Runner { driver, stack })
 }
 
 fn to_smoltcp_hardware_address(addr: driver::HardwareAddress) -> (HardwareAddress, Medium) {
@@ -292,89 +375,23 @@ fn to_smoltcp_hardware_address(addr: driver::HardwareAddress) -> (HardwareAddres
     }
 }
 
-impl<D: Driver> Stack<D> {
-    /// Create a new network stack.
-    pub fn new<const SOCK: usize>(
-        mut device: D,
-        config: Config,
-        resources: &'static mut StackResources<SOCK>,
-        random_seed: u64,
-    ) -> Self {
-        let (hardware_addr, medium) = to_smoltcp_hardware_address(device.hardware_address());
-        let mut iface_cfg = smoltcp::iface::Config::new(hardware_addr);
-        iface_cfg.random_seed = random_seed;
-
-        let iface = Interface::new(
-            iface_cfg,
-            &mut DriverAdapter {
-                inner: &mut device,
-                cx: None,
-                medium,
-            },
-            instant_to_smoltcp(Instant::now()),
-        );
-
-        let sockets = SocketSet::new(&mut resources.sockets[..]);
-
-        let next_local_port = (random_seed % (LOCAL_PORT_MAX - LOCAL_PORT_MIN) as u64) as u16 + LOCAL_PORT_MIN;
-
-        #[cfg_attr(feature = "medium-ieee802154", allow(unused_mut))]
-        let mut socket = SocketStack {
-            sockets,
-            iface,
-            waker: WakerRegistration::new(),
-            next_local_port,
-        };
-
-        let mut inner = Inner {
-            device,
-            link_up: false,
-            #[cfg(feature = "proto-ipv4")]
-            static_v4: None,
-            #[cfg(feature = "proto-ipv6")]
-            static_v6: None,
-            #[cfg(feature = "dhcpv4")]
-            dhcp_socket: None,
-            config_waker: WakerRegistration::new(),
-            #[cfg(feature = "dns")]
-            dns_socket: socket.sockets.add(dns::Socket::new(
-                &[],
-                managed::ManagedSlice::Borrowed(&mut resources.queries),
-            )),
-            #[cfg(feature = "dns")]
-            dns_waker: WakerRegistration::new(),
-            #[cfg(feature = "dhcpv4-hostname")]
-            hostname: &mut resources.hostname,
-        };
-
-        #[cfg(feature = "proto-ipv4")]
-        inner.set_config_v4(&mut socket, config.ipv4);
-        #[cfg(feature = "proto-ipv6")]
-        inner.set_config_v6(&mut socket, config.ipv6);
-        inner.apply_static_config(&mut socket);
-
-        Self {
-            socket: RefCell::new(socket),
-            inner: RefCell::new(inner),
-        }
+impl<'d> Stack<'d> {
+    fn with<R>(&self, f: impl FnOnce(&Inner) -> R) -> R {
+        f(&*self.inner.borrow())
     }
 
-    fn with<R>(&self, f: impl FnOnce(&SocketStack, &Inner<D>) -> R) -> R {
-        f(&*self.socket.borrow(), &*self.inner.borrow())
-    }
-
-    fn with_mut<R>(&self, f: impl FnOnce(&mut SocketStack, &mut Inner<D>) -> R) -> R {
-        f(&mut *self.socket.borrow_mut(), &mut *self.inner.borrow_mut())
+    fn with_mut<R>(&self, f: impl FnOnce(&mut Inner) -> R) -> R {
+        f(&mut *self.inner.borrow_mut())
     }
 
     /// Get the hardware address of the network interface.
     pub fn hardware_address(&self) -> HardwareAddress {
-        self.with(|_s, i| to_smoltcp_hardware_address(i.device.hardware_address()).0)
+        self.with(|i| i.hardware_address)
     }
 
     /// Get whether the link is up.
     pub fn is_link_up(&self) -> bool {
-        self.with(|_s, i| i.link_up)
+        self.with(|i| i.link_up)
     }
 
     /// Get whether the network stack has a valid IP configuration.
@@ -420,15 +437,14 @@ impl<D: Driver> Stack<D> {
     /// // provisioning space for 3 sockets here: one for DHCP, one for DNS, and one for your code (e.g. TCP).
     /// // If you use more sockets you must increase this. If you don't enable DHCP or DNS you can decrease it.
     /// static RESOURCES: StaticCell<embassy_net::StackResources<3>> = StaticCell::new();
-    /// static STACK: StaticCell<embassy_net::Stack> = StaticCell::new();
-    /// let stack = &*STACK.init(embassy_net::Stack::new(
-    ///    device,
+    /// let (stack, runner) = embassy_net::new(
+    ///    driver,
     ///    config,
     ///    RESOURCES.init(embassy_net::StackResources::new()),
     ///    seed
-    /// ));
-    /// // Launch network task that runs `stack.run().await`
-    /// spawner.spawn(net_task(stack)).unwrap();
+    /// );
+    /// // Launch network task that runs `runner.run().await`
+    /// spawner.spawn(net_task(runner)).unwrap();
     /// // Wait for DHCP config
     /// stack.wait_config_up().await;
     /// // use the network stack
@@ -448,7 +464,7 @@ impl<D: Driver> Stack<D> {
                 // when a config is applied (static or DHCP).
                 trace!("Waiting for config up");
 
-                self.with_mut(|_, i| {
+                self.with_mut(|i| {
                     i.config_waker.register(cx.waker());
                 });
 
@@ -464,43 +480,31 @@ impl<D: Driver> Stack<D> {
     /// acquire an IP address, or Some if it has.
     #[cfg(feature = "proto-ipv4")]
     pub fn config_v4(&self) -> Option<StaticConfigV4> {
-        self.with(|_, i| i.static_v4.clone())
+        self.with(|i| i.static_v4.clone())
     }
 
     /// Get the current IPv6 configuration.
     #[cfg(feature = "proto-ipv6")]
     pub fn config_v6(&self) -> Option<StaticConfigV6> {
-        self.with(|_, i| i.static_v6.clone())
+        self.with(|i| i.static_v6.clone())
     }
 
     /// Set the IPv4 configuration.
     #[cfg(feature = "proto-ipv4")]
     pub fn set_config_v4(&self, config: ConfigV4) {
-        self.with_mut(|s, i| {
-            i.set_config_v4(s, config);
-            i.apply_static_config(s);
+        self.with_mut(|i| {
+            i.set_config_v4(config);
+            i.apply_static_config();
         })
     }
 
     /// Set the IPv6 configuration.
     #[cfg(feature = "proto-ipv6")]
     pub fn set_config_v6(&self, config: ConfigV6) {
-        self.with_mut(|s, i| {
-            i.set_config_v6(s, config);
-            i.apply_static_config(s);
+        self.with_mut(|i| {
+            i.set_config_v6(config);
+            i.apply_static_config();
         })
-    }
-
-    /// Run the network stack.
-    ///
-    /// You must call this in a background task, to process network events.
-    pub async fn run(&self) -> ! {
-        poll_fn(|cx| {
-            self.with_mut(|s, i| i.poll(cx, s));
-            Poll::<()>::Pending
-        })
-        .await;
-        unreachable!()
     }
 
     /// Make a query for a given name and return the corresponding IP addresses.
@@ -528,11 +532,11 @@ impl<D: Driver> Stack<D> {
         }
 
         let query = poll_fn(|cx| {
-            self.with_mut(|s, i| {
-                let socket = s.sockets.get_mut::<dns::Socket>(i.dns_socket);
-                match socket.start_query(s.iface.context(), name, qtype) {
+            self.with_mut(|i| {
+                let socket = i.sockets.get_mut::<dns::Socket>(i.dns_socket);
+                match socket.start_query(i.iface.context(), name, qtype) {
                     Ok(handle) => {
-                        s.waker.wake();
+                        i.waker.wake();
                         Poll::Ready(Ok(handle))
                     }
                     Err(dns::StartQueryError::NoFreeSlot) => {
@@ -569,17 +573,17 @@ impl<D: Driver> Stack<D> {
         }
 
         let drop = OnDrop::new(|| {
-            self.with_mut(|s, i| {
-                let socket = s.sockets.get_mut::<dns::Socket>(i.dns_socket);
+            self.with_mut(|i| {
+                let socket = i.sockets.get_mut::<dns::Socket>(i.dns_socket);
                 socket.cancel_query(query);
-                s.waker.wake();
+                i.waker.wake();
                 i.dns_waker.wake();
             })
         });
 
         let res = poll_fn(|cx| {
-            self.with_mut(|s, i| {
-                let socket = s.sockets.get_mut::<dns::Socket>(i.dns_socket);
+            self.with_mut(|i| {
+                let socket = i.sockets.get_mut::<dns::Socket>(i.dns_socket);
                 match socket.get_query_result(query) {
                     Ok(addrs) => {
                         i.dns_waker.wake();
@@ -604,104 +608,34 @@ impl<D: Driver> Stack<D> {
     }
 }
 
-#[cfg(feature = "igmp")]
-impl<D: Driver> Stack<D> {
+#[cfg(feature = "multicast")]
+impl<'d> Stack<'d> {
     /// Join a multicast group.
-    pub async fn join_multicast_group<T>(&self, addr: T) -> Result<bool, MulticastError>
-    where
-        T: Into<IpAddress>,
-    {
-        let addr = addr.into();
-
-        poll_fn(move |cx| self.poll_join_multicast_group(addr, cx)).await
-    }
-
-    /// Join a multicast group.
-    ///
-    /// When the send queue is full, this method will return `Poll::Pending`
-    /// and register the current task to be notified when the queue has space available.
-    pub fn poll_join_multicast_group<T>(&self, addr: T, cx: &mut Context<'_>) -> Poll<Result<bool, MulticastError>>
-    where
-        T: Into<IpAddress>,
-    {
-        let addr = addr.into();
-
-        self.with_mut(|s, i| {
-            let (_hardware_addr, medium) = to_smoltcp_hardware_address(i.device.hardware_address());
-            let mut smoldev = DriverAdapter {
-                cx: Some(cx),
-                inner: &mut i.device,
-                medium,
-            };
-
-            match s
-                .iface
-                .join_multicast_group(&mut smoldev, addr, instant_to_smoltcp(Instant::now()))
-            {
-                Ok(announce_sent) => Poll::Ready(Ok(announce_sent)),
-                Err(MulticastError::Exhausted) => Poll::Pending,
-                Err(other) => Poll::Ready(Err(other)),
-            }
-        })
+    pub fn join_multicast_group(&self, addr: impl Into<IpAddress>) -> Result<(), MulticastError> {
+        self.with_mut(|i| i.iface.join_multicast_group(addr))
     }
 
     /// Leave a multicast group.
-    pub async fn leave_multicast_group<T>(&self, addr: T) -> Result<bool, MulticastError>
-    where
-        T: Into<IpAddress>,
-    {
-        let addr = addr.into();
-
-        poll_fn(move |cx| self.poll_leave_multicast_group(addr, cx)).await
-    }
-
-    /// Leave a multicast group.
-    ///
-    /// When the send queue is full, this method will return `Poll::Pending`
-    /// and register the current task to be notified when the queue has space available.
-    pub fn poll_leave_multicast_group<T>(&self, addr: T, cx: &mut Context<'_>) -> Poll<Result<bool, MulticastError>>
-    where
-        T: Into<IpAddress>,
-    {
-        let addr = addr.into();
-
-        self.with_mut(|s, i| {
-            let (_hardware_addr, medium) = to_smoltcp_hardware_address(i.device.hardware_address());
-            let mut smoldev = DriverAdapter {
-                cx: Some(cx),
-                inner: &mut i.device,
-                medium,
-            };
-
-            match s
-                .iface
-                .leave_multicast_group(&mut smoldev, addr, instant_to_smoltcp(Instant::now()))
-            {
-                Ok(leave_sent) => Poll::Ready(Ok(leave_sent)),
-                Err(MulticastError::Exhausted) => Poll::Pending,
-                Err(other) => Poll::Ready(Err(other)),
-            }
-        })
+    pub fn leave_multicast_group(&self, addr: impl Into<IpAddress>) -> Result<(), MulticastError> {
+        self.with_mut(|i| i.iface.leave_multicast_group(addr))
     }
 
     /// Get whether the network stack has joined the given multicast group.
-    pub fn has_multicast_group<T: Into<IpAddress>>(&self, addr: T) -> bool {
-        self.socket.borrow().iface.has_multicast_group(addr)
+    pub fn has_multicast_group(&self, addr: impl Into<IpAddress>) -> bool {
+        self.with(|i| i.iface.has_multicast_group(addr))
     }
 }
 
-impl SocketStack {
+impl Inner {
     #[allow(clippy::absurd_extreme_comparisons, dead_code)]
     pub fn get_local_port(&mut self) -> u16 {
         let res = self.next_local_port;
         self.next_local_port = if res >= LOCAL_PORT_MAX { LOCAL_PORT_MIN } else { res + 1 };
         res
     }
-}
 
-impl<D: Driver> Inner<D> {
     #[cfg(feature = "proto-ipv4")]
-    pub fn set_config_v4(&mut self, _s: &mut SocketStack, config: ConfigV4) {
+    pub fn set_config_v4(&mut self, config: ConfigV4) {
         // Handle static config.
         self.static_v4 = match config.clone() {
             ConfigV4::None => None,
@@ -717,12 +651,12 @@ impl<D: Driver> Inner<D> {
                 // Create the socket if it doesn't exist.
                 if self.dhcp_socket.is_none() {
                     let socket = smoltcp::socket::dhcpv4::Socket::new();
-                    let handle = _s.sockets.add(socket);
+                    let handle = self.sockets.add(socket);
                     self.dhcp_socket = Some(handle);
                 }
 
                 // Configure it
-                let socket = _s.sockets.get_mut::<dhcpv4::Socket>(unwrap!(self.dhcp_socket));
+                let socket = self.sockets.get_mut::<dhcpv4::Socket>(unwrap!(self.dhcp_socket));
                 socket.set_ignore_naks(c.ignore_naks);
                 socket.set_max_lease_duration(c.max_lease_duration.map(crate::time::duration_to_smoltcp));
                 socket.set_ports(c.server_port, c.client_port);
@@ -731,19 +665,20 @@ impl<D: Driver> Inner<D> {
                 socket.set_outgoing_options(&[]);
                 #[cfg(feature = "dhcpv4-hostname")]
                 if let Some(h) = c.hostname {
-                    // safety: we just did set_outgoing_options([]) so we know the socket is no longer holding a reference.
-                    let hostname = unsafe { &mut *self.hostname.get() };
+                    // safety:
+                    // - we just did set_outgoing_options([]) so we know the socket is no longer holding a reference.
+                    // - we know this pointer lives for as long as the stack exists, because `new()` borrows
+                    //   the resources for `'d`. Therefore it's OK to pass a reference to this to smoltcp.
+                    let hostname = unsafe { &mut *self.hostname };
 
                     // create data
-                    // safety: we know the buffer lives forever, new borrows the StackResources for 'static.
-                    // also we won't modify it until next call to this function.
-                    hostname.data[..h.len()].copy_from_slice(h.as_bytes());
-                    let data: &[u8] = &hostname.data[..h.len()];
-                    let data: &'static [u8] = unsafe { core::mem::transmute(data) };
+                    let data = hostname.data.write([0; MAX_HOSTNAME_LEN]);
+                    data[..h.len()].copy_from_slice(h.as_bytes());
+                    let data: &[u8] = &data[..h.len()];
 
                     // set the option.
-                    hostname.option = smoltcp::wire::DhcpOption { data, kind: 12 };
-                    socket.set_outgoing_options(core::slice::from_ref(&hostname.option));
+                    let option = hostname.option.write(smoltcp::wire::DhcpOption { data, kind: 12 });
+                    socket.set_outgoing_options(core::slice::from_ref(option));
                 }
 
                 socket.reset();
@@ -751,7 +686,7 @@ impl<D: Driver> Inner<D> {
             _ => {
                 // Remove DHCP socket if any.
                 if let Some(socket) = self.dhcp_socket {
-                    _s.sockets.remove(socket);
+                    self.sockets.remove(socket);
                     self.dhcp_socket = None;
                 }
             }
@@ -759,14 +694,14 @@ impl<D: Driver> Inner<D> {
     }
 
     #[cfg(feature = "proto-ipv6")]
-    pub fn set_config_v6(&mut self, _s: &mut SocketStack, config: ConfigV6) {
+    pub fn set_config_v6(&mut self, config: ConfigV6) {
         self.static_v6 = match config {
             ConfigV6::None => None,
             ConfigV6::Static(c) => Some(c),
         };
     }
 
-    fn apply_static_config(&mut self, s: &mut SocketStack) {
+    fn apply_static_config(&mut self) {
         let mut addrs = Vec::new();
         #[cfg(feature = "dns")]
         let mut dns_servers: Vec<_, 6> = Vec::new();
@@ -810,20 +745,20 @@ impl<D: Driver> Inner<D> {
         }
 
         // Apply addresses
-        s.iface.update_ip_addrs(|a| *a = addrs);
+        self.iface.update_ip_addrs(|a| *a = addrs);
 
         // Apply gateways
         #[cfg(feature = "proto-ipv4")]
         if let Some(gateway) = gateway_v4 {
-            unwrap!(s.iface.routes_mut().add_default_ipv4_route(gateway));
+            unwrap!(self.iface.routes_mut().add_default_ipv4_route(gateway));
         } else {
-            s.iface.routes_mut().remove_default_ipv4_route();
+            self.iface.routes_mut().remove_default_ipv4_route();
         }
         #[cfg(feature = "proto-ipv6")]
         if let Some(gateway) = gateway_v6 {
-            unwrap!(s.iface.routes_mut().add_default_ipv6_route(gateway));
+            unwrap!(self.iface.routes_mut().add_default_ipv6_route(gateway));
         } else {
-            s.iface.routes_mut().remove_default_ipv6_route();
+            self.iface.routes_mut().remove_default_ipv6_route();
         }
 
         // Apply DNS servers
@@ -835,7 +770,7 @@ impl<D: Driver> Inner<D> {
             } else {
                 dns_servers.len()
             };
-            s.sockets
+            self.sockets
                 .get_mut::<smoltcp::socket::dns::Socket>(self.dns_socket)
                 .update_servers(&dns_servers[..count]);
         }
@@ -843,10 +778,10 @@ impl<D: Driver> Inner<D> {
         self.config_waker.wake();
     }
 
-    fn poll(&mut self, cx: &mut Context<'_>, s: &mut SocketStack) {
-        s.waker.register(cx.waker());
+    fn poll<D: Driver>(&mut self, cx: &mut Context<'_>, driver: &mut D) {
+        self.waker.register(cx.waker());
 
-        let (_hardware_addr, medium) = to_smoltcp_hardware_address(self.device.hardware_address());
+        let (_hardware_addr, medium) = to_smoltcp_hardware_address(driver.hardware_address());
 
         #[cfg(any(feature = "medium-ethernet", feature = "medium-ieee802154"))]
         {
@@ -859,21 +794,21 @@ impl<D: Driver> Inner<D> {
                 _ => false,
             };
             if do_set {
-                s.iface.set_hardware_addr(_hardware_addr);
+                self.iface.set_hardware_addr(_hardware_addr);
             }
         }
 
         let timestamp = instant_to_smoltcp(Instant::now());
         let mut smoldev = DriverAdapter {
             cx: Some(cx),
-            inner: &mut self.device,
+            inner: driver,
             medium,
         };
-        s.iface.poll(timestamp, &mut smoldev, &mut s.sockets);
+        self.iface.poll(timestamp, &mut smoldev, &mut self.sockets);
 
         // Update link up
         let old_link_up = self.link_up;
-        self.link_up = self.device.link_state(cx) == LinkState::Up;
+        self.link_up = driver.link_state(cx) == LinkState::Up;
 
         // Print when changed
         if old_link_up != self.link_up {
@@ -885,7 +820,7 @@ impl<D: Driver> Inner<D> {
 
         #[cfg(feature = "dhcpv4")]
         if let Some(dhcp_handle) = self.dhcp_socket {
-            let socket = s.sockets.get_mut::<dhcpv4::Socket>(dhcp_handle);
+            let socket = self.sockets.get_mut::<dhcpv4::Socket>(dhcp_handle);
 
             if self.link_up {
                 if old_link_up != self.link_up {
@@ -914,14 +849,28 @@ impl<D: Driver> Inner<D> {
         }
 
         if apply_config {
-            self.apply_static_config(s);
+            self.apply_static_config();
         }
 
-        if let Some(poll_at) = s.iface.poll_at(timestamp, &mut s.sockets) {
+        if let Some(poll_at) = self.iface.poll_at(timestamp, &mut self.sockets) {
             let t = pin!(Timer::at(instant_from_smoltcp(poll_at)));
             if t.poll(cx).is_ready() {
                 cx.waker().wake_by_ref();
             }
         }
+    }
+}
+
+impl<'d, D: Driver> Runner<'d, D> {
+    /// Run the network stack.
+    ///
+    /// You must call this in a background task, to process network events.
+    pub async fn run(&mut self) -> ! {
+        poll_fn(|cx| {
+            self.stack.with_mut(|i| i.poll(cx, &mut self.driver));
+            Poll::<()>::Pending
+        })
+        .await;
+        unreachable!()
     }
 }

--- a/examples/nrf52840/src/bin/ethernet_enc28j60.rs
+++ b/examples/nrf52840/src/bin/ethernet_enc28j60.rs
@@ -4,7 +4,7 @@
 use defmt::*;
 use embassy_executor::Spawner;
 use embassy_net::tcp::TcpSocket;
-use embassy_net::{Stack, StackResources};
+use embassy_net::StackResources;
 use embassy_net_enc28j60::Enc28j60;
 use embassy_nrf::gpio::{Level, Output, OutputDrive};
 use embassy_nrf::rng::Rng;
@@ -23,11 +23,12 @@ bind_interrupts!(struct Irqs {
 
 #[embassy_executor::task]
 async fn net_task(
-    stack: &'static Stack<
+    mut runner: embassy_net::Runner<
+        'static,
         Enc28j60<ExclusiveDevice<Spim<'static, peripherals::SPI3>, Output<'static>, Delay>, Output<'static>>,
     >,
 ) -> ! {
-    stack.run().await
+    runner.run().await
 }
 
 #[embassy_executor::main]
@@ -67,12 +68,9 @@ async fn main(spawner: Spawner) {
 
     // Init network stack
     static RESOURCES: StaticCell<StackResources<3>> = StaticCell::new();
-    static STACK: StaticCell<
-        Stack<Enc28j60<ExclusiveDevice<Spim<'static, peripherals::SPI3>, Output<'static>, Delay>, Output<'static>>>,
-    > = StaticCell::new();
-    let stack = STACK.init(Stack::new(device, config, RESOURCES.init(StackResources::new()), seed));
+    let (stack, runner) = embassy_net::new(device, config, RESOURCES.init(StackResources::new()), seed);
 
-    unwrap!(spawner.spawn(net_task(stack)));
+    unwrap!(spawner.spawn(net_task(runner)));
 
     // And now we can use it!
 

--- a/examples/nrf52840/src/bin/usb_ethernet.rs
+++ b/examples/nrf52840/src/bin/usb_ethernet.rs
@@ -6,7 +6,7 @@ use core::mem;
 use defmt::*;
 use embassy_executor::Spawner;
 use embassy_net::tcp::TcpSocket;
-use embassy_net::{Stack, StackResources};
+use embassy_net::StackResources;
 use embassy_nrf::rng::Rng;
 use embassy_nrf::usb::vbus_detect::HardwareVbusDetect;
 use embassy_nrf::usb::Driver;
@@ -39,8 +39,8 @@ async fn usb_ncm_task(class: Runner<'static, MyDriver, MTU>) -> ! {
 }
 
 #[embassy_executor::task]
-async fn net_task(stack: &'static Stack<Device<'static, MTU>>) -> ! {
-    stack.run().await
+async fn net_task(mut runner: embassy_net::Runner<'static, Device<'static, MTU>>) -> ! {
+    runner.run().await
 }
 
 #[embassy_executor::main]
@@ -116,10 +116,9 @@ async fn main(spawner: Spawner) {
 
     // Init network stack
     static RESOURCES: StaticCell<StackResources<3>> = StaticCell::new();
-    static STACK: StaticCell<Stack<Device<'static, MTU>>> = StaticCell::new();
-    let stack = &*STACK.init(Stack::new(device, config, RESOURCES.init(StackResources::new()), seed));
+    let (stack, runner) = embassy_net::new(device, config, RESOURCES.init(StackResources::new()), seed);
 
-    unwrap!(spawner.spawn(net_task(stack)));
+    unwrap!(spawner.spawn(net_task(runner)));
 
     // And now we can use it!
 

--- a/examples/nrf52840/src/bin/wifi_esp_hosted.rs
+++ b/examples/nrf52840/src/bin/wifi_esp_hosted.rs
@@ -4,7 +4,7 @@
 use defmt::{info, unwrap, warn};
 use embassy_executor::Spawner;
 use embassy_net::tcp::TcpSocket;
-use embassy_net::{Stack, StackResources};
+use embassy_net::StackResources;
 use embassy_nrf::gpio::{Input, Level, Output, OutputDrive, Pull};
 use embassy_nrf::rng::Rng;
 use embassy_nrf::spim::{self, Spim};
@@ -36,8 +36,8 @@ async fn wifi_task(
 }
 
 #[embassy_executor::task]
-async fn net_task(stack: &'static Stack<hosted::NetDriver<'static>>) -> ! {
-    stack.run().await
+async fn net_task(mut runner: embassy_net::Runner<'static, hosted::NetDriver<'static>>) -> ! {
+    runner.run().await
 }
 
 #[embassy_executor::main]
@@ -90,10 +90,9 @@ async fn main(spawner: Spawner) {
 
     // Init network stack
     static RESOURCES: StaticCell<StackResources<3>> = StaticCell::new();
-    static STACK: StaticCell<Stack<hosted::NetDriver<'static>>> = StaticCell::new();
-    let stack = &*STACK.init(Stack::new(device, config, RESOURCES.init(StackResources::new()), seed));
+    let (stack, runner) = embassy_net::new(device, config, RESOURCES.init(StackResources::new()), seed);
 
-    unwrap!(spawner.spawn(net_task(stack)));
+    unwrap!(spawner.spawn(net_task(runner)));
 
     // And now we can use it!
 

--- a/examples/rp/src/bin/ethernet_w5500_multisocket.rs
+++ b/examples/rp/src/bin/ethernet_w5500_multisocket.rs
@@ -36,8 +36,8 @@ async fn ethernet_task(
 }
 
 #[embassy_executor::task]
-async fn net_task(stack: &'static Stack<Device<'static>>) -> ! {
-    stack.run().await
+async fn net_task(mut runner: embassy_net::Runner<'static, Device<'static>>) -> ! {
+    runner.run().await
 }
 
 #[embassy_executor::main]
@@ -71,17 +71,16 @@ async fn main(spawner: Spawner) {
     let seed = rng.next_u64();
 
     // Init network stack
-    static STACK: StaticCell<Stack<Device<'static>>> = StaticCell::new();
     static RESOURCES: StaticCell<StackResources<3>> = StaticCell::new();
-    let stack = &*STACK.init(Stack::new(
+    let (stack, runner) = embassy_net::new(
         device,
         embassy_net::Config::dhcpv4(Default::default()),
         RESOURCES.init(StackResources::new()),
         seed,
-    ));
+    );
 
     // Launch network task
-    unwrap!(spawner.spawn(net_task(&stack)));
+    unwrap!(spawner.spawn(net_task(runner)));
 
     info!("Waiting for DHCP...");
     let cfg = wait_for_config(stack).await;
@@ -89,12 +88,12 @@ async fn main(spawner: Spawner) {
     info!("IP address: {:?}", local_addr);
 
     // Create two sockets listening to the same port, to handle simultaneous connections
-    unwrap!(spawner.spawn(listen_task(&stack, 0, 1234)));
-    unwrap!(spawner.spawn(listen_task(&stack, 1, 1234)));
+    unwrap!(spawner.spawn(listen_task(stack, 0, 1234)));
+    unwrap!(spawner.spawn(listen_task(stack, 1, 1234)));
 }
 
 #[embassy_executor::task(pool_size = 2)]
-async fn listen_task(stack: &'static Stack<Device<'static>>, id: u8, port: u16) {
+async fn listen_task(stack: Stack<'static>, id: u8, port: u16) {
     let mut rx_buffer = [0; 4096];
     let mut tx_buffer = [0; 4096];
     let mut buf = [0; 4096];
@@ -131,7 +130,7 @@ async fn listen_task(stack: &'static Stack<Device<'static>>, id: u8, port: u16) 
     }
 }
 
-async fn wait_for_config(stack: &'static Stack<Device<'static>>) -> embassy_net::StaticConfigV4 {
+async fn wait_for_config(stack: Stack<'static>) -> embassy_net::StaticConfigV4 {
     loop {
         if let Some(config) = stack.config_v4() {
             return config.clone();

--- a/examples/rp/src/bin/ethernet_w5500_tcp_client.rs
+++ b/examples/rp/src/bin/ethernet_w5500_tcp_client.rs
@@ -38,8 +38,8 @@ async fn ethernet_task(
 }
 
 #[embassy_executor::task]
-async fn net_task(stack: &'static Stack<Device<'static>>) -> ! {
-    stack.run().await
+async fn net_task(mut runner: embassy_net::Runner<'static, Device<'static>>) -> ! {
+    runner.run().await
 }
 
 #[embassy_executor::main]
@@ -74,17 +74,16 @@ async fn main(spawner: Spawner) {
     let seed = rng.next_u64();
 
     // Init network stack
-    static STACK: StaticCell<Stack<Device<'static>>> = StaticCell::new();
     static RESOURCES: StaticCell<StackResources<3>> = StaticCell::new();
-    let stack = &*STACK.init(Stack::new(
+    let (stack, runner) = embassy_net::new(
         device,
         embassy_net::Config::dhcpv4(Default::default()),
         RESOURCES.init(StackResources::new()),
         seed,
-    ));
+    );
 
     // Launch network task
-    unwrap!(spawner.spawn(net_task(&stack)));
+    unwrap!(spawner.spawn(net_task(runner)));
 
     info!("Waiting for DHCP...");
     let cfg = wait_for_config(stack).await;
@@ -119,7 +118,7 @@ async fn main(spawner: Spawner) {
     }
 }
 
-async fn wait_for_config(stack: &'static Stack<Device<'static>>) -> embassy_net::StaticConfigV4 {
+async fn wait_for_config(stack: Stack<'static>) -> embassy_net::StaticConfigV4 {
     loop {
         if let Some(config) = stack.config_v4() {
             return config.clone();

--- a/examples/rp/src/bin/ethernet_w5500_tcp_server.rs
+++ b/examples/rp/src/bin/ethernet_w5500_tcp_server.rs
@@ -37,8 +37,8 @@ async fn ethernet_task(
 }
 
 #[embassy_executor::task]
-async fn net_task(stack: &'static Stack<Device<'static>>) -> ! {
-    stack.run().await
+async fn net_task(mut runner: embassy_net::Runner<'static, Device<'static>>) -> ! {
+    runner.run().await
 }
 
 #[embassy_executor::main]
@@ -73,17 +73,16 @@ async fn main(spawner: Spawner) {
     let seed = rng.next_u64();
 
     // Init network stack
-    static STACK: StaticCell<Stack<Device<'static>>> = StaticCell::new();
     static RESOURCES: StaticCell<StackResources<3>> = StaticCell::new();
-    let stack = &*STACK.init(Stack::new(
+    let (stack, runner) = embassy_net::new(
         device,
         embassy_net::Config::dhcpv4(Default::default()),
         RESOURCES.init(StackResources::new()),
         seed,
-    ));
+    );
 
     // Launch network task
-    unwrap!(spawner.spawn(net_task(&stack)));
+    unwrap!(spawner.spawn(net_task(runner)));
 
     info!("Waiting for DHCP...");
     let cfg = wait_for_config(stack).await;
@@ -128,7 +127,7 @@ async fn main(spawner: Spawner) {
     }
 }
 
-async fn wait_for_config(stack: &'static Stack<Device<'static>>) -> embassy_net::StaticConfigV4 {
+async fn wait_for_config(stack: Stack<'static>) -> embassy_net::StaticConfigV4 {
     loop {
         if let Some(config) = stack.config_v4() {
             return config.clone();

--- a/examples/rp/src/bin/ethernet_w5500_udp.rs
+++ b/examples/rp/src/bin/ethernet_w5500_udp.rs
@@ -36,8 +36,8 @@ async fn ethernet_task(
 }
 
 #[embassy_executor::task]
-async fn net_task(stack: &'static Stack<Device<'static>>) -> ! {
-    stack.run().await
+async fn net_task(mut runner: embassy_net::Runner<'static, Device<'static>>) -> ! {
+    runner.run().await
 }
 
 #[embassy_executor::main]
@@ -71,17 +71,16 @@ async fn main(spawner: Spawner) {
     let seed = rng.next_u64();
 
     // Init network stack
-    static STACK: StaticCell<Stack<Device<'static>>> = StaticCell::new();
     static RESOURCES: StaticCell<StackResources<3>> = StaticCell::new();
-    let stack = &*STACK.init(Stack::new(
+    let (stack, runner) = embassy_net::new(
         device,
         embassy_net::Config::dhcpv4(Default::default()),
         RESOURCES.init(StackResources::new()),
         seed,
-    ));
+    );
 
     // Launch network task
-    unwrap!(spawner.spawn(net_task(&stack)));
+    unwrap!(spawner.spawn(net_task(runner)));
 
     info!("Waiting for DHCP...");
     let cfg = wait_for_config(stack).await;
@@ -108,7 +107,7 @@ async fn main(spawner: Spawner) {
     }
 }
 
-async fn wait_for_config(stack: &'static Stack<Device<'static>>) -> embassy_net::StaticConfigV4 {
+async fn wait_for_config(stack: Stack<'static>) -> embassy_net::StaticConfigV4 {
     loop {
         if let Some(config) = stack.config_v4() {
             return config.clone();

--- a/examples/rp/src/bin/usb_ethernet.rs
+++ b/examples/rp/src/bin/usb_ethernet.rs
@@ -8,7 +8,7 @@
 use defmt::*;
 use embassy_executor::Spawner;
 use embassy_net::tcp::TcpSocket;
-use embassy_net::{Stack, StackResources};
+use embassy_net::StackResources;
 use embassy_rp::clocks::RoscRng;
 use embassy_rp::peripherals::USB;
 use embassy_rp::usb::{Driver, InterruptHandler};
@@ -40,8 +40,8 @@ async fn usb_ncm_task(class: Runner<'static, MyDriver, MTU>) -> ! {
 }
 
 #[embassy_executor::task]
-async fn net_task(stack: &'static Stack<Device<'static, MTU>>) -> ! {
-    stack.run().await
+async fn net_task(mut runner: embassy_net::Runner<'static, Device<'static, MTU>>) -> ! {
+    runner.run().await
 }
 
 #[embassy_executor::main]
@@ -108,11 +108,10 @@ async fn main(spawner: Spawner) {
     let seed = rng.next_u64();
 
     // Init network stack
-    static STACK: StaticCell<Stack<Device<'static, MTU>>> = StaticCell::new();
     static RESOURCES: StaticCell<StackResources<3>> = StaticCell::new();
-    let stack = &*STACK.init(Stack::new(device, config, RESOURCES.init(StackResources::new()), seed));
+    let (stack, runner) = embassy_net::new(device, config, RESOURCES.init(StackResources::new()), seed);
 
-    unwrap!(spawner.spawn(net_task(stack)));
+    unwrap!(spawner.spawn(net_task(runner)));
 
     // And now we can use it!
 

--- a/examples/rp/src/bin/wifi_scan.rs
+++ b/examples/rp/src/bin/wifi_scan.rs
@@ -10,7 +10,6 @@ use core::str;
 use cyw43_pio::PioSpi;
 use defmt::*;
 use embassy_executor::Spawner;
-use embassy_net::Stack;
 use embassy_rp::bind_interrupts;
 use embassy_rp::gpio::{Level, Output};
 use embassy_rp::peripherals::{DMA_CH0, PIO0};
@@ -28,8 +27,8 @@ async fn cyw43_task(runner: cyw43::Runner<'static, Output<'static>, PioSpi<'stat
 }
 
 #[embassy_executor::task]
-async fn net_task(stack: &'static Stack<cyw43::NetDriver<'static>>) -> ! {
-    stack.run().await
+async fn net_task(mut runner: embassy_net::Runner<'static, cyw43::NetDriver<'static>>) -> ! {
+    runner.run().await
 }
 
 #[embassy_executor::main]

--- a/examples/rp/src/bin/wifi_tcp_server.rs
+++ b/examples/rp/src/bin/wifi_tcp_server.rs
@@ -12,7 +12,7 @@ use cyw43_pio::PioSpi;
 use defmt::*;
 use embassy_executor::Spawner;
 use embassy_net::tcp::TcpSocket;
-use embassy_net::{Config, Stack, StackResources};
+use embassy_net::{Config, StackResources};
 use embassy_rp::bind_interrupts;
 use embassy_rp::clocks::RoscRng;
 use embassy_rp::gpio::{Level, Output};
@@ -37,8 +37,8 @@ async fn cyw43_task(runner: cyw43::Runner<'static, Output<'static>, PioSpi<'stat
 }
 
 #[embassy_executor::task]
-async fn net_task(stack: &'static Stack<cyw43::NetDriver<'static>>) -> ! {
-    stack.run().await
+async fn net_task(mut runner: embassy_net::Runner<'static, cyw43::NetDriver<'static>>) -> ! {
+    runner.run().await
 }
 
 #[embassy_executor::main]
@@ -84,16 +84,10 @@ async fn main(spawner: Spawner) {
     let seed = rng.next_u64();
 
     // Init network stack
-    static STACK: StaticCell<Stack<cyw43::NetDriver<'static>>> = StaticCell::new();
     static RESOURCES: StaticCell<StackResources<3>> = StaticCell::new();
-    let stack = &*STACK.init(Stack::new(
-        net_device,
-        config,
-        RESOURCES.init(StackResources::new()),
-        seed,
-    ));
+    let (stack, runner) = embassy_net::new(net_device, config, RESOURCES.init(StackResources::new()), seed);
 
-    unwrap!(spawner.spawn(net_task(stack)));
+    unwrap!(spawner.spawn(net_task(runner)));
 
     loop {
         match control

--- a/examples/rp/src/bin/wifi_webrequest.rs
+++ b/examples/rp/src/bin/wifi_webrequest.rs
@@ -13,7 +13,7 @@ use defmt::*;
 use embassy_executor::Spawner;
 use embassy_net::dns::DnsSocket;
 use embassy_net::tcp::client::{TcpClient, TcpClientState};
-use embassy_net::{Config, Stack, StackResources};
+use embassy_net::{Config, StackResources};
 use embassy_rp::bind_interrupts;
 use embassy_rp::clocks::RoscRng;
 use embassy_rp::gpio::{Level, Output};
@@ -40,8 +40,8 @@ async fn cyw43_task(runner: cyw43::Runner<'static, Output<'static>, PioSpi<'stat
 }
 
 #[embassy_executor::task]
-async fn net_task(stack: &'static Stack<cyw43::NetDriver<'static>>) -> ! {
-    stack.run().await
+async fn net_task(mut runner: embassy_net::Runner<'static, cyw43::NetDriver<'static>>) -> ! {
+    runner.run().await
 }
 
 #[embassy_executor::main]
@@ -87,16 +87,10 @@ async fn main(spawner: Spawner) {
     let seed = rng.next_u64();
 
     // Init network stack
-    static STACK: StaticCell<Stack<cyw43::NetDriver<'static>>> = StaticCell::new();
     static RESOURCES: StaticCell<StackResources<5>> = StaticCell::new();
-    let stack = &*STACK.init(Stack::new(
-        net_device,
-        config,
-        RESOURCES.init(StackResources::new()),
-        seed,
-    ));
+    let (stack, runner) = embassy_net::new(net_device, config, RESOURCES.init(StackResources::new()), seed);
 
-    unwrap!(spawner.spawn(net_task(stack)));
+    unwrap!(spawner.spawn(net_task(runner)));
 
     loop {
         match control

--- a/examples/std/src/bin/net.rs
+++ b/examples/std/src/bin/net.rs
@@ -1,7 +1,7 @@
 use clap::Parser;
 use embassy_executor::{Executor, Spawner};
 use embassy_net::tcp::TcpSocket;
-use embassy_net::{Config, Ipv4Address, Ipv4Cidr, Stack, StackResources};
+use embassy_net::{Config, Ipv4Address, Ipv4Cidr, StackResources};
 use embassy_net_tuntap::TunTapDevice;
 use embassy_time::Duration;
 use embedded_io_async::Write;
@@ -22,8 +22,8 @@ struct Opts {
 }
 
 #[embassy_executor::task]
-async fn net_task(stack: &'static Stack<TunTapDevice>) -> ! {
-    stack.run().await
+async fn net_task(mut runner: embassy_net::Runner<'static, TunTapDevice>) -> ! {
+    runner.run().await
 }
 
 #[embassy_executor::task]
@@ -50,12 +50,11 @@ async fn main_task(spawner: Spawner) {
     let seed = u64::from_le_bytes(seed);
 
     // Init network stack
-    static STACK: StaticCell<Stack<TunTapDevice>> = StaticCell::new();
     static RESOURCES: StaticCell<StackResources<3>> = StaticCell::new();
-    let stack = &*STACK.init(Stack::new(device, config, RESOURCES.init(StackResources::new()), seed));
+    let (stack, runner) = embassy_net::new(device, config, RESOURCES.init(StackResources::new()), seed);
 
     // Launch network task
-    spawner.spawn(net_task(stack)).unwrap();
+    spawner.spawn(net_task(runner)).unwrap();
 
     // Then we can use it!
     let mut rx_buffer = [0; 4096];

--- a/examples/std/src/bin/net_dns.rs
+++ b/examples/std/src/bin/net_dns.rs
@@ -1,7 +1,7 @@
 use clap::Parser;
 use embassy_executor::{Executor, Spawner};
 use embassy_net::dns::DnsQueryType;
-use embassy_net::{Config, Ipv4Address, Ipv4Cidr, Stack, StackResources};
+use embassy_net::{Config, Ipv4Address, Ipv4Cidr, StackResources};
 use embassy_net_tuntap::TunTapDevice;
 use heapless::Vec;
 use log::*;
@@ -20,8 +20,8 @@ struct Opts {
 }
 
 #[embassy_executor::task]
-async fn net_task(stack: &'static Stack<TunTapDevice>) -> ! {
-    stack.run().await
+async fn net_task(mut runner: embassy_net::Runner<'static, TunTapDevice>) -> ! {
+    runner.run().await
 }
 
 #[embassy_executor::task]
@@ -49,12 +49,11 @@ async fn main_task(spawner: Spawner) {
     let seed = u64::from_le_bytes(seed);
 
     // Init network stack
-    static STACK: StaticCell<Stack<TunTapDevice>> = StaticCell::new();
     static RESOURCES: StaticCell<StackResources<3>> = StaticCell::new();
-    let stack: &Stack<_> = &*STACK.init(Stack::new(device, config, RESOURCES.init(StackResources::new()), seed));
+    let (stack, runner) = embassy_net::new(device, config, RESOURCES.init(StackResources::new()), seed);
 
     // Launch network task
-    spawner.spawn(net_task(stack)).unwrap();
+    spawner.spawn(net_task(runner)).unwrap();
 
     let host = "example.com";
     info!("querying host {:?}...", host);

--- a/examples/std/src/bin/net_ppp.rs
+++ b/examples/std/src/bin/net_ppp.rs
@@ -37,16 +37,12 @@ struct Opts {
 }
 
 #[embassy_executor::task]
-async fn net_task(stack: &'static Stack<embassy_net_ppp::Device<'static>>) -> ! {
-    stack.run().await
+async fn net_task(mut runner: embassy_net::Runner<'static, embassy_net_ppp::Device<'static>>) -> ! {
+    runner.run().await
 }
 
 #[embassy_executor::task]
-async fn ppp_task(
-    stack: &'static Stack<embassy_net_ppp::Device<'static>>,
-    mut runner: Runner<'static>,
-    port: SerialPort,
-) -> ! {
+async fn ppp_task(stack: Stack<'static>, mut runner: Runner<'static>, port: SerialPort) -> ! {
     let port = Async::new(port).unwrap();
     let port = BufReader::new(port);
     let port = adapter::FromFutures::new(port);
@@ -97,17 +93,16 @@ async fn main_task(spawner: Spawner) {
     let seed = u64::from_le_bytes(seed);
 
     // Init network stack
-    static STACK: StaticCell<Stack<embassy_net_ppp::Device<'static>>> = StaticCell::new();
     static RESOURCES: StaticCell<StackResources<3>> = StaticCell::new();
-    let stack = &*STACK.init(Stack::new(
+    let (stack, net_runner) = embassy_net::new(
         device,
         Config::default(), // don't configure IP yet
         RESOURCES.init(StackResources::new()),
         seed,
-    ));
+    );
 
     // Launch network task
-    spawner.spawn(net_task(stack)).unwrap();
+    spawner.spawn(net_task(net_runner)).unwrap();
     spawner.spawn(ppp_task(stack, runner, port)).unwrap();
 
     // Then we can use it!

--- a/examples/std/src/bin/net_udp.rs
+++ b/examples/std/src/bin/net_udp.rs
@@ -1,7 +1,7 @@
 use clap::Parser;
 use embassy_executor::{Executor, Spawner};
 use embassy_net::udp::{PacketMetadata, UdpSocket};
-use embassy_net::{Config, Ipv4Address, Ipv4Cidr, Stack, StackResources};
+use embassy_net::{Config, Ipv4Address, Ipv4Cidr, StackResources};
 use embassy_net_tuntap::TunTapDevice;
 use heapless::Vec;
 use log::*;
@@ -20,8 +20,8 @@ struct Opts {
 }
 
 #[embassy_executor::task]
-async fn net_task(stack: &'static Stack<TunTapDevice>) -> ! {
-    stack.run().await
+async fn net_task(mut runner: embassy_net::Runner<'static, TunTapDevice>) -> ! {
+    runner.run().await
 }
 
 #[embassy_executor::task]
@@ -48,12 +48,11 @@ async fn main_task(spawner: Spawner) {
     let seed = u64::from_le_bytes(seed);
 
     // Init network stack
-    static STACK: StaticCell<Stack<TunTapDevice>> = StaticCell::new();
     static RESOURCES: StaticCell<StackResources<3>> = StaticCell::new();
-    let stack = &*STACK.init(Stack::new(device, config, RESOURCES.init(StackResources::new()), seed));
+    let (stack, runner) = embassy_net::new(device, config, RESOURCES.init(StackResources::new()), seed);
 
     // Launch network task
-    spawner.spawn(net_task(stack)).unwrap();
+    spawner.spawn(net_task(runner)).unwrap();
 
     // Then we can use it!
     let mut rx_meta = [PacketMetadata::EMPTY; 16];

--- a/examples/std/src/bin/tcp_accept.rs
+++ b/examples/std/src/bin/tcp_accept.rs
@@ -3,7 +3,7 @@ use core::fmt::Write as _;
 use clap::Parser;
 use embassy_executor::{Executor, Spawner};
 use embassy_net::tcp::TcpSocket;
-use embassy_net::{Config, Ipv4Address, Ipv4Cidr, Stack, StackResources};
+use embassy_net::{Config, Ipv4Address, Ipv4Cidr, StackResources};
 use embassy_net_tuntap::TunTapDevice;
 use embassy_time::{Duration, Timer};
 use embedded_io_async::Write as _;
@@ -24,8 +24,8 @@ struct Opts {
 }
 
 #[embassy_executor::task]
-async fn net_task(stack: &'static Stack<TunTapDevice>) -> ! {
-    stack.run().await
+async fn net_task(mut runner: embassy_net::Runner<'static, TunTapDevice>) -> ! {
+    runner.run().await
 }
 
 #[derive(Default)]
@@ -62,12 +62,11 @@ async fn main_task(spawner: Spawner) {
     let seed = u64::from_le_bytes(seed);
 
     // Init network stack
-    static STACK: StaticCell<Stack<TunTapDevice>> = StaticCell::new();
     static RESOURCES: StaticCell<StackResources<3>> = StaticCell::new();
-    let stack = &*STACK.init(Stack::new(device, config, RESOURCES.init(StackResources::new()), seed));
+    let (stack, runner) = embassy_net::new(device, config, RESOURCES.init(StackResources::new()), seed);
 
     // Launch network task
-    spawner.spawn(net_task(stack)).unwrap();
+    spawner.spawn(net_task(runner)).unwrap();
 
     // Then we can use it!
     let mut rx_buffer = [0; 4096];

--- a/examples/stm32f4/src/bin/eth.rs
+++ b/examples/stm32f4/src/bin/eth.rs
@@ -4,7 +4,7 @@
 use defmt::*;
 use embassy_executor::Spawner;
 use embassy_net::tcp::TcpSocket;
-use embassy_net::{Ipv4Address, Stack, StackResources};
+use embassy_net::{Ipv4Address, StackResources};
 use embassy_stm32::eth::generic_smi::GenericSMI;
 use embassy_stm32::eth::{Ethernet, PacketQueue};
 use embassy_stm32::peripherals::ETH;
@@ -24,8 +24,8 @@ bind_interrupts!(struct Irqs {
 type Device = Ethernet<'static, ETH, GenericSMI>;
 
 #[embassy_executor::task]
-async fn net_task(stack: &'static Stack<Device>) -> ! {
-    stack.run().await
+async fn net_task(mut runner: embassy_net::Runner<'static, Device>) -> ! {
+    runner.run().await
 }
 
 #[embassy_executor::main]
@@ -88,12 +88,11 @@ async fn main(spawner: Spawner) -> ! {
     //});
 
     // Init network stack
-    static STACK: StaticCell<Stack<Device>> = StaticCell::new();
     static RESOURCES: StaticCell<StackResources<3>> = StaticCell::new();
-    let stack = &*STACK.init(Stack::new(device, config, RESOURCES.init(StackResources::new()), seed));
+    let (stack, runner) = embassy_net::new(device, config, RESOURCES.init(StackResources::new()), seed);
 
     // Launch network task
-    unwrap!(spawner.spawn(net_task(stack)));
+    unwrap!(spawner.spawn(net_task(runner)));
 
     // Ensure DHCP configuration is up before trying connect
     stack.wait_config_up().await;
@@ -105,7 +104,7 @@ async fn main(spawner: Spawner) -> ! {
     let mut tx_buffer = [0; 4096];
 
     loop {
-        let mut socket = TcpSocket::new(&stack, &mut rx_buffer, &mut tx_buffer);
+        let mut socket = TcpSocket::new(stack, &mut rx_buffer, &mut tx_buffer);
 
         socket.set_timeout(Some(embassy_time::Duration::from_secs(10)));
 

--- a/examples/stm32f4/src/bin/eth_w5500.rs
+++ b/examples/stm32f4/src/bin/eth_w5500.rs
@@ -4,7 +4,7 @@
 use defmt::*;
 use embassy_executor::Spawner;
 use embassy_net::tcp::TcpSocket;
-use embassy_net::{Ipv4Address, Stack, StackResources};
+use embassy_net::{Ipv4Address, StackResources};
 use embassy_net_wiznet::chip::W5500;
 use embassy_net_wiznet::{Device, Runner, State};
 use embassy_stm32::exti::ExtiInput;
@@ -31,8 +31,8 @@ async fn ethernet_task(runner: Runner<'static, W5500, EthernetSPI, ExtiInput<'st
 }
 
 #[embassy_executor::task]
-async fn net_task(stack: &'static Stack<Device<'static>>) -> ! {
-    stack.run().await
+async fn net_task(mut runner: embassy_net::Runner<'static, Device<'static>>) -> ! {
+    runner.run().await
 }
 
 #[embassy_executor::main]
@@ -92,12 +92,11 @@ async fn main(spawner: Spawner) -> ! {
     //    gateway: Some(Ipv4Address::new(10, 42, 0, 1)),
     //});
 
-    static STACK: StaticCell<Stack<Device>> = StaticCell::new();
     static RESOURCES: StaticCell<StackResources<3>> = StaticCell::new();
-    let stack = &*STACK.init(Stack::new(device, config, RESOURCES.init(StackResources::new()), seed));
+    let (stack, runner) = embassy_net::new(device, config, RESOURCES.init(StackResources::new()), seed);
 
     // Launch network task
-    unwrap!(spawner.spawn(net_task(stack)));
+    unwrap!(spawner.spawn(net_task(runner)));
 
     // Ensure DHCP configuration is up before trying connect
     stack.wait_config_up().await;

--- a/examples/stm32f4/src/bin/usb_ethernet.rs
+++ b/examples/stm32f4/src/bin/usb_ethernet.rs
@@ -4,7 +4,7 @@
 use defmt::*;
 use embassy_executor::Spawner;
 use embassy_net::tcp::TcpSocket;
-use embassy_net::{Stack, StackResources};
+use embassy_net::StackResources;
 use embassy_stm32::rng::{self, Rng};
 use embassy_stm32::time::Hertz;
 use embassy_stm32::usb::Driver;
@@ -31,8 +31,8 @@ async fn usb_ncm_task(class: Runner<'static, UsbDriver, MTU>) -> ! {
 }
 
 #[embassy_executor::task]
-async fn net_task(stack: &'static Stack<Device<'static, MTU>>) -> ! {
-    stack.run().await
+async fn net_task(mut runner: embassy_net::Runner<'static, Device<'static, MTU>>) -> ! {
+    runner.run().await
 }
 
 bind_interrupts!(struct Irqs {
@@ -144,11 +144,10 @@ async fn main(spawner: Spawner) {
     let seed = u64::from_le_bytes(seed);
 
     // Init network stack
-    static STACK: StaticCell<Stack<Device<'static, MTU>>> = StaticCell::new();
     static RESOURCES: StaticCell<StackResources<3>> = StaticCell::new();
-    let stack = &*STACK.init(Stack::new(device, config, RESOURCES.init(StackResources::new()), seed));
+    let (stack, runner) = embassy_net::new(device, config, RESOURCES.init(StackResources::new()), seed);
 
-    unwrap!(spawner.spawn(net_task(stack)));
+    unwrap!(spawner.spawn(net_task(runner)));
 
     // And now we can use it!
 

--- a/examples/stm32f7/src/bin/eth.rs
+++ b/examples/stm32f7/src/bin/eth.rs
@@ -4,7 +4,7 @@
 use defmt::*;
 use embassy_executor::Spawner;
 use embassy_net::tcp::TcpSocket;
-use embassy_net::{Ipv4Address, Stack, StackResources};
+use embassy_net::{Ipv4Address, StackResources};
 use embassy_stm32::eth::generic_smi::GenericSMI;
 use embassy_stm32::eth::{Ethernet, PacketQueue};
 use embassy_stm32::peripherals::ETH;
@@ -25,8 +25,8 @@ bind_interrupts!(struct Irqs {
 type Device = Ethernet<'static, ETH, GenericSMI>;
 
 #[embassy_executor::task]
-async fn net_task(stack: &'static Stack<Device>) -> ! {
-    stack.run().await
+async fn net_task(mut runner: embassy_net::Runner<'static, Device>) -> ! {
+    runner.run().await
 }
 
 #[embassy_executor::main]
@@ -89,12 +89,11 @@ async fn main(spawner: Spawner) -> ! {
     //});
 
     // Init network stack
-    static STACK: StaticCell<Stack<Device>> = StaticCell::new();
     static RESOURCES: StaticCell<StackResources<3>> = StaticCell::new();
-    let stack = &*STACK.init(Stack::new(device, config, RESOURCES.init(StackResources::new()), seed));
+    let (stack, runner) = embassy_net::new(device, config, RESOURCES.init(StackResources::new()), seed);
 
     // Launch network task
-    unwrap!(spawner.spawn(net_task(stack)));
+    unwrap!(spawner.spawn(net_task(runner)));
 
     // Ensure DHCP configuration is up before trying connect
     stack.wait_config_up().await;
@@ -106,7 +105,7 @@ async fn main(spawner: Spawner) -> ! {
     let mut tx_buffer = [0; 4096];
 
     loop {
-        let mut socket = TcpSocket::new(&stack, &mut rx_buffer, &mut tx_buffer);
+        let mut socket = TcpSocket::new(stack, &mut rx_buffer, &mut tx_buffer);
 
         socket.set_timeout(Some(embassy_time::Duration::from_secs(10)));
 

--- a/examples/stm32h5/src/bin/eth.rs
+++ b/examples/stm32h5/src/bin/eth.rs
@@ -4,7 +4,7 @@
 use defmt::*;
 use embassy_executor::Spawner;
 use embassy_net::tcp::TcpSocket;
-use embassy_net::{Ipv4Address, Stack, StackResources};
+use embassy_net::{Ipv4Address, StackResources};
 use embassy_stm32::eth::generic_smi::GenericSMI;
 use embassy_stm32::eth::{Ethernet, PacketQueue};
 use embassy_stm32::peripherals::ETH;
@@ -28,8 +28,8 @@ bind_interrupts!(struct Irqs {
 type Device = Ethernet<'static, ETH, GenericSMI>;
 
 #[embassy_executor::task]
-async fn net_task(stack: &'static Stack<Device>) -> ! {
-    stack.run().await
+async fn net_task(mut runner: embassy_net::Runner<'static, Device>) -> ! {
+    runner.run().await
 }
 
 #[embassy_executor::main]
@@ -92,12 +92,11 @@ async fn main(spawner: Spawner) -> ! {
     //});
 
     // Init network stack
-    static STACK: StaticCell<Stack<Device>> = StaticCell::new();
     static RESOURCES: StaticCell<StackResources<3>> = StaticCell::new();
-    let stack = &*STACK.init(Stack::new(device, config, RESOURCES.init(StackResources::new()), seed));
+    let (stack, runner) = embassy_net::new(device, config, RESOURCES.init(StackResources::new()), seed);
 
     // Launch network task
-    unwrap!(spawner.spawn(net_task(&stack)));
+    unwrap!(spawner.spawn(net_task(runner)));
 
     // Ensure DHCP configuration is up before trying connect
     stack.wait_config_up().await;
@@ -109,7 +108,7 @@ async fn main(spawner: Spawner) -> ! {
     let mut tx_buffer = [0; 1024];
 
     loop {
-        let mut socket = TcpSocket::new(&stack, &mut rx_buffer, &mut tx_buffer);
+        let mut socket = TcpSocket::new(stack, &mut rx_buffer, &mut tx_buffer);
 
         socket.set_timeout(Some(embassy_time::Duration::from_secs(10)));
 

--- a/examples/stm32h7/src/bin/eth.rs
+++ b/examples/stm32h7/src/bin/eth.rs
@@ -4,7 +4,7 @@
 use defmt::*;
 use embassy_executor::Spawner;
 use embassy_net::tcp::TcpSocket;
-use embassy_net::{Ipv4Address, Stack, StackResources};
+use embassy_net::{Ipv4Address, StackResources};
 use embassy_stm32::eth::generic_smi::GenericSMI;
 use embassy_stm32::eth::{Ethernet, PacketQueue};
 use embassy_stm32::peripherals::ETH;
@@ -24,8 +24,8 @@ bind_interrupts!(struct Irqs {
 type Device = Ethernet<'static, ETH, GenericSMI>;
 
 #[embassy_executor::task]
-async fn net_task(stack: &'static Stack<Device>) -> ! {
-    stack.run().await
+async fn net_task(mut runner: embassy_net::Runner<'static, Device>) -> ! {
+    runner.run().await
 }
 
 #[embassy_executor::main]
@@ -91,12 +91,11 @@ async fn main(spawner: Spawner) -> ! {
     //});
 
     // Init network stack
-    static STACK: StaticCell<Stack<Device>> = StaticCell::new();
     static RESOURCES: StaticCell<StackResources<3>> = StaticCell::new();
-    let stack = &*STACK.init(Stack::new(device, config, RESOURCES.init(StackResources::new()), seed));
+    let (stack, runner) = embassy_net::new(device, config, RESOURCES.init(StackResources::new()), seed);
 
     // Launch network task
-    unwrap!(spawner.spawn(net_task(&stack)));
+    unwrap!(spawner.spawn(net_task(runner)));
 
     // Ensure DHCP configuration is up before trying connect
     stack.wait_config_up().await;
@@ -108,7 +107,7 @@ async fn main(spawner: Spawner) -> ! {
     let mut tx_buffer = [0; 1024];
 
     loop {
-        let mut socket = TcpSocket::new(&stack, &mut rx_buffer, &mut tx_buffer);
+        let mut socket = TcpSocket::new(stack, &mut rx_buffer, &mut tx_buffer);
 
         socket.set_timeout(Some(embassy_time::Duration::from_secs(10)));
 

--- a/examples/stm32h7/src/bin/eth_client.rs
+++ b/examples/stm32h7/src/bin/eth_client.rs
@@ -4,7 +4,7 @@
 use defmt::*;
 use embassy_executor::Spawner;
 use embassy_net::tcp::client::{TcpClient, TcpClientState};
-use embassy_net::{Stack, StackResources};
+use embassy_net::StackResources;
 use embassy_stm32::eth::generic_smi::GenericSMI;
 use embassy_stm32::eth::{Ethernet, PacketQueue};
 use embassy_stm32::peripherals::ETH;
@@ -25,8 +25,8 @@ bind_interrupts!(struct Irqs {
 type Device = Ethernet<'static, ETH, GenericSMI>;
 
 #[embassy_executor::task]
-async fn net_task(stack: &'static Stack<Device>) -> ! {
-    stack.run().await
+async fn net_task(mut runner: embassy_net::Runner<'static, Device>) -> ! {
+    runner.run().await
 }
 
 #[embassy_executor::main]
@@ -91,12 +91,11 @@ async fn main(spawner: Spawner) -> ! {
     //});
 
     // Init network stack
-    static STACK: StaticCell<Stack<Device>> = StaticCell::new();
     static RESOURCES: StaticCell<StackResources<3>> = StaticCell::new();
-    let stack = &*STACK.init(Stack::new(device, config, RESOURCES.init(StackResources::new()), seed));
+    let (stack, runner) = embassy_net::new(device, config, RESOURCES.init(StackResources::new()), seed);
 
     // Launch network task
-    unwrap!(spawner.spawn(net_task(stack)));
+    unwrap!(spawner.spawn(net_task(runner)));
 
     // Ensure DHCP configuration is up before trying connect
     stack.wait_config_up().await;
@@ -104,7 +103,7 @@ async fn main(spawner: Spawner) -> ! {
     info!("Network task initialized");
 
     let state: TcpClientState<1, 1024, 1024> = TcpClientState::new();
-    let client = TcpClient::new(&stack, &state);
+    let client = TcpClient::new(stack, &state);
 
     loop {
         // You need to start a server on the host machine, for example: `nc -l 8000`

--- a/examples/stm32h7/src/bin/eth_client_mii.rs
+++ b/examples/stm32h7/src/bin/eth_client_mii.rs
@@ -4,7 +4,7 @@
 use defmt::*;
 use embassy_executor::Spawner;
 use embassy_net::tcp::client::{TcpClient, TcpClientState};
-use embassy_net::{Stack, StackResources};
+use embassy_net::StackResources;
 use embassy_stm32::eth::generic_smi::GenericSMI;
 use embassy_stm32::eth::{Ethernet, PacketQueue};
 use embassy_stm32::peripherals::ETH;
@@ -25,8 +25,8 @@ bind_interrupts!(struct Irqs {
 type Device = Ethernet<'static, ETH, GenericSMI>;
 
 #[embassy_executor::task]
-async fn net_task(stack: &'static Stack<Device>) -> ! {
-    stack.run().await
+async fn net_task(mut runner: embassy_net::Runner<'static, Device>) -> ! {
+    runner.run().await
 }
 
 #[embassy_executor::main]
@@ -97,12 +97,11 @@ async fn main(spawner: Spawner) -> ! {
     //});
 
     // Init network stack
-    static STACK: StaticCell<Stack<Device>> = StaticCell::new();
     static RESOURCES: StaticCell<StackResources<3>> = StaticCell::new();
-    let stack = &*STACK.init(Stack::new(device, config, RESOURCES.init(StackResources::new()), seed));
+    let (stack, runner) = embassy_net::new(device, config, RESOURCES.init(StackResources::new()), seed);
 
     // Launch network task
-    unwrap!(spawner.spawn(net_task(stack)));
+    unwrap!(spawner.spawn(net_task(runner)));
 
     // Ensure DHCP configuration is up before trying connect
     stack.wait_config_up().await;
@@ -110,7 +109,7 @@ async fn main(spawner: Spawner) -> ! {
     info!("Network task initialized");
 
     let state: TcpClientState<1, 1024, 1024> = TcpClientState::new();
-    let client = TcpClient::new(&stack, &state);
+    let client = TcpClient::new(stack, &state);
 
     loop {
         // You need to start a server on the host machine, for example: `nc -l 8000`

--- a/examples/stm32l4/src/bin/spe_adin1110_http_server.rs
+++ b/examples/stm32l4/src/bin/spe_adin1110_http_server.rs
@@ -206,12 +206,11 @@ async fn main(spawner: Spawner) {
     };
 
     // Init network stack
-    static STACK: StaticCell<Stack<Device<'static>>> = StaticCell::new();
     static RESOURCES: StaticCell<StackResources<3>> = StaticCell::new();
-    let stack = &*STACK.init(Stack::new(device, ip_cfg, RESOURCES.init(StackResources::new()), seed));
+    let (stack, runner) = embassy_net::new(device, ip_cfg, RESOURCES.init(StackResources::new()), seed);
 
     // Launch network task
-    unwrap!(spawner.spawn(net_task(stack)));
+    unwrap!(spawner.spawn(net_task(runner)));
 
     let cfg = wait_for_config(stack).await;
     let local_addr = cfg.address.address();
@@ -274,7 +273,7 @@ async fn main(spawner: Spawner) {
     }
 }
 
-async fn wait_for_config(stack: &'static Stack<Device<'static>>) -> embassy_net::StaticConfigV4 {
+async fn wait_for_config(stack: Stack<'static>) -> embassy_net::StaticConfigV4 {
     loop {
         if let Some(config) = stack.config_v4() {
             return config;
@@ -323,8 +322,8 @@ async fn ethernet_task(runner: Runner<'static, SpeSpiCs, SpeInt, SpeRst>) -> ! {
 }
 
 #[embassy_executor::task]
-async fn net_task(stack: &'static Stack<Device<'static>>) -> ! {
-    stack.run().await
+async fn net_task(mut runner: embassy_net::Runner<'static, Device<'static>>) -> ! {
+    runner.run().await
 }
 
 // same panicking *behavior* as `panic-probe` but doesn't print a panic message

--- a/examples/stm32l5/src/bin/usb_ethernet.rs
+++ b/examples/stm32l5/src/bin/usb_ethernet.rs
@@ -4,7 +4,7 @@
 use defmt::*;
 use embassy_executor::Spawner;
 use embassy_net::tcp::TcpSocket;
-use embassy_net::{Stack, StackResources};
+use embassy_net::StackResources;
 use embassy_stm32::rng::Rng;
 use embassy_stm32::usb::Driver;
 use embassy_stm32::{bind_interrupts, peripherals, rng, usb, Config};
@@ -36,8 +36,8 @@ async fn usb_ncm_task(class: Runner<'static, MyDriver, MTU>) -> ! {
 }
 
 #[embassy_executor::task]
-async fn net_task(stack: &'static Stack<Device<'static, MTU>>) -> ! {
-    stack.run().await
+async fn net_task(mut runner: embassy_net::Runner<'static, Device<'static, MTU>>) -> ! {
+    runner.run().await
 }
 
 #[embassy_executor::main]
@@ -121,11 +121,10 @@ async fn main(spawner: Spawner) {
     let seed = rng.next_u64();
 
     // Init network stack
-    static STACK: StaticCell<Stack<Device<'static, MTU>>> = StaticCell::new();
     static RESOURCES: StaticCell<StackResources<3>> = StaticCell::new();
-    let stack = &*STACK.init(Stack::new(device, config, RESOURCES.init(StackResources::new()), seed));
+    let (stack, runner) = embassy_net::new(device, config, RESOURCES.init(StackResources::new()), seed);
 
-    unwrap!(spawner.spawn(net_task(stack)));
+    unwrap!(spawner.spawn(net_task(runner)));
 
     // And now we can use it!
 

--- a/tests/nrf/src/bin/ethernet_enc28j60_perf.rs
+++ b/tests/nrf/src/bin/ethernet_enc28j60_perf.rs
@@ -6,7 +6,7 @@ teleprobe_meta::timeout!(120);
 
 use defmt::{info, unwrap};
 use embassy_executor::Spawner;
-use embassy_net::{Stack, StackResources};
+use embassy_net::StackResources;
 use embassy_net_enc28j60::Enc28j60;
 use embassy_nrf::gpio::{Level, Output, OutputDrive};
 use embassy_nrf::rng::Rng;
@@ -25,8 +25,8 @@ bind_interrupts!(struct Irqs {
 type MyDriver = Enc28j60<ExclusiveDevice<Spim<'static, peripherals::SPI3>, Output<'static>, Delay>, Output<'static>>;
 
 #[embassy_executor::task]
-async fn net_task(stack: &'static Stack<MyDriver>) -> ! {
-    stack.run().await
+async fn net_task(mut runner: embassy_net::Runner<'static, MyDriver>) -> ! {
+    runner.run().await
 }
 
 #[embassy_executor::main]
@@ -65,11 +65,10 @@ async fn main(spawner: Spawner) {
     let seed = u64::from_le_bytes(seed);
 
     // Init network stack
-    static STACK: StaticCell<Stack<MyDriver>> = StaticCell::new();
     static RESOURCES: StaticCell<StackResources<2>> = StaticCell::new();
-    let stack = &*STACK.init(Stack::new(device, config, RESOURCES.init(StackResources::new()), seed));
+    let (stack, runner) = embassy_net::new(device, config, RESOURCES.init(StackResources::new()), seed);
 
-    unwrap!(spawner.spawn(net_task(stack)));
+    unwrap!(spawner.spawn(net_task(runner)));
 
     perf_client::run(
         stack,

--- a/tests/nrf/src/bin/wifi_esp_hosted_perf.rs
+++ b/tests/nrf/src/bin/wifi_esp_hosted_perf.rs
@@ -6,7 +6,7 @@ teleprobe_meta::timeout!(120);
 
 use defmt::{info, unwrap};
 use embassy_executor::Spawner;
-use embassy_net::{Config, Stack, StackResources};
+use embassy_net::{Config, StackResources};
 use embassy_nrf::gpio::{Input, Level, Output, OutputDrive, Pull};
 use embassy_nrf::rng::Rng;
 use embassy_nrf::spim::{self, Spim};
@@ -40,8 +40,8 @@ async fn wifi_task(
 type MyDriver = hosted::NetDriver<'static>;
 
 #[embassy_executor::task]
-async fn net_task(stack: &'static Stack<MyDriver>) -> ! {
-    stack.run().await
+async fn net_task(mut runner: embassy_net::Runner<'static, MyDriver>) -> ! {
+    runner.run().await
 }
 
 #[embassy_executor::main]
@@ -86,16 +86,15 @@ async fn main(spawner: Spawner) {
     let seed = u64::from_le_bytes(seed);
 
     // Init network stack
-    static STACK: StaticCell<Stack<MyDriver>> = StaticCell::new();
     static RESOURCES: StaticCell<StackResources<2>> = StaticCell::new();
-    let stack = &*STACK.init(Stack::new(
+    let (stack, runner) = embassy_net::new(
         device,
         Config::dhcpv4(Default::default()),
         RESOURCES.init(StackResources::new()),
         seed,
-    ));
+    );
 
-    unwrap!(spawner.spawn(net_task(stack)));
+    unwrap!(spawner.spawn(net_task(runner)));
 
     perf_client::run(
         stack,

--- a/tests/perf-client/src/lib.rs
+++ b/tests/perf-client/src/lib.rs
@@ -2,7 +2,6 @@
 
 use defmt::{assert, *};
 use embassy_futures::join::join;
-use embassy_net::driver::Driver;
 use embassy_net::tcp::TcpSocket;
 use embassy_net::{Ipv4Address, Stack};
 use embassy_time::{with_timeout, Duration, Timer};
@@ -13,7 +12,7 @@ pub struct Expected {
     pub updown_kbps: usize,
 }
 
-pub async fn run<D: Driver>(stack: &Stack<D>, expected: Expected) {
+pub async fn run(stack: Stack<'_>, expected: Expected) {
     info!("Waiting for DHCP up...");
     while stack.config_v4().is_none() {
         Timer::after_millis(100).await;
@@ -38,7 +37,7 @@ const DOWNLOAD_PORT: u16 = 4321;
 const UPLOAD_PORT: u16 = 4322;
 const UPLOAD_DOWNLOAD_PORT: u16 = 4323;
 
-async fn test_download<D: Driver>(stack: &Stack<D>) -> usize {
+async fn test_download(stack: Stack<'_>) -> usize {
     info!("Testing download...");
 
     let mut rx_buffer = [0; RX_BUFFER_SIZE];
@@ -78,7 +77,7 @@ async fn test_download<D: Driver>(stack: &Stack<D>) -> usize {
     kbps
 }
 
-async fn test_upload<D: Driver>(stack: &Stack<D>) -> usize {
+async fn test_upload(stack: Stack<'_>) -> usize {
     info!("Testing upload...");
 
     let mut rx_buffer = [0; RX_BUFFER_SIZE];
@@ -118,7 +117,7 @@ async fn test_upload<D: Driver>(stack: &Stack<D>) -> usize {
     kbps
 }
 
-async fn test_upload_download<D: Driver>(stack: &Stack<D>) -> usize {
+async fn test_upload_download(stack: Stack<'_>) -> usize {
     info!("Testing upload+download...");
 
     let mut rx_buffer = [0; RX_BUFFER_SIZE];

--- a/tests/rp/src/bin/ethernet_w5100s_perf.rs
+++ b/tests/rp/src/bin/ethernet_w5100s_perf.rs
@@ -5,7 +5,7 @@ teleprobe_meta::timeout!(120);
 
 use defmt::*;
 use embassy_executor::Spawner;
-use embassy_net::{Stack, StackResources};
+use embassy_net::StackResources;
 use embassy_net_wiznet::chip::W5100S;
 use embassy_net_wiznet::*;
 use embassy_rp::clocks::RoscRng;
@@ -32,8 +32,8 @@ async fn ethernet_task(
 }
 
 #[embassy_executor::task]
-async fn net_task(stack: &'static Stack<Device<'static>>) -> ! {
-    stack.run().await
+async fn net_task(mut runner: embassy_net::Runner<'static, Device<'static>>) -> ! {
+    runner.run().await
 }
 
 #[embassy_executor::main]
@@ -67,17 +67,16 @@ async fn main(spawner: Spawner) {
     let seed = rng.next_u64();
 
     // Init network stack
-    static STACK: StaticCell<Stack<Device<'static>>> = StaticCell::new();
     static RESOURCES: StaticCell<StackResources<2>> = StaticCell::new();
-    let stack = &*STACK.init(Stack::new(
+    let (stack, runner) = embassy_net::new(
         device,
         embassy_net::Config::dhcpv4(Default::default()),
         RESOURCES.init(StackResources::new()),
         seed,
-    ));
+    );
 
     // Launch network task
-    unwrap!(spawner.spawn(net_task(&stack)));
+    unwrap!(spawner.spawn(net_task(runner)));
 
     perf_client::run(
         stack,

--- a/tests/stm32/src/bin/eth.rs
+++ b/tests/stm32/src/bin/eth.rs
@@ -6,7 +6,7 @@
 mod common;
 use common::*;
 use embassy_executor::Spawner;
-use embassy_net::{Stack, StackResources};
+use embassy_net::StackResources;
 use embassy_stm32::eth::generic_smi::GenericSMI;
 use embassy_stm32::eth::{Ethernet, PacketQueue};
 use embassy_stm32::peripherals::ETH;
@@ -32,8 +32,8 @@ bind_interrupts!(struct Irqs {
 type Device = Ethernet<'static, ETH, GenericSMI>;
 
 #[embassy_executor::task]
-async fn net_task(stack: &'static Stack<Device>) -> ! {
-    stack.run().await
+async fn net_task(mut runner: embassy_net::Runner<'static, Device>) -> ! {
+    runner.run().await
 }
 
 #[embassy_executor::main]
@@ -99,12 +99,11 @@ async fn main(spawner: Spawner) {
     //});
 
     // Init network stack
-    static STACK: StaticCell<Stack<Device>> = StaticCell::new();
     static RESOURCES: StaticCell<StackResources<2>> = StaticCell::new();
-    let stack = &*STACK.init(Stack::new(device, config, RESOURCES.init(StackResources::new()), seed));
+    let (stack, runner) = embassy_net::new(device, config, RESOURCES.init(StackResources::new()), seed);
 
     // Launch network task
-    unwrap!(spawner.spawn(net_task(&stack)));
+    unwrap!(spawner.spawn(net_task(runner)));
 
     perf_client::run(
         stack,


### PR DESCRIPTION
Refactor embassy-net api. Advantages:

- Now there's a separate `Runner` struct. `run()` requires `&mut self`, this prevents the user from doing weird stuff like calling `run()` in two tasks concurrently.
- Stack is now Copy, so you can pass it by value everywhere. This means you need only one StaticCell (for the resources) instead of two (resources, stack).
- Stack is no longer generic over the driver, only the runner is. This makes code using embassy-net agnostic to what driver is in use, only the code creating the stack has to care.
- DnsSocket is not generic over the driver anymore.
- No forced `'static` litetime anymore. This means you can now dynamically create/teardown the network stack as many times as you want. If you run everything in a single task with `join` you don't need StaticCell at all.
- `Stack` and the sockets are all covariant over the lifetime now. This helps a bit with avoiding hairy lifetime errors.
