### PR TITLE
rp: Fix indexing for pins >31 on rp235xb

### DIFF
--- a/embassy-rp/src/gpio.rs
+++ b/embassy-rp/src/gpio.rs
@@ -965,7 +965,7 @@ macro_rules! impl_pin {
         impl SealedPin for peripherals::$name {
             #[inline]
             fn pin_bank(&self) -> u8 {
-                ($bank as u8) * 64 + $pin_num
+                ($bank as u8) * 128 + $pin_num
             }
         }
 


### PR DESCRIPTION
Does not handle using PIO with pins > 31, which is still broken.