### PR TITLE
rp: rp2350 pio pin fixes

### DIFF
--- a/embassy-rp/src/gpio.rs
+++ b/embassy-rp/src/gpio.rs
@@ -16,9 +16,9 @@ use crate::{interrupt, pac, peripherals, Peripheral, RegExt};
 const NEW_AW: AtomicWaker = AtomicWaker::new();
 
 #[cfg(any(feature = "rp2040", feature = "rp235xa"))]
-const BANK0_PIN_COUNT: usize = 30;
+pub(crate) const BANK0_PIN_COUNT: usize = 30;
 #[cfg(feature = "rp235xb")]
-const BANK0_PIN_COUNT: usize = 48;
+pub(crate) const BANK0_PIN_COUNT: usize = 48;
 
 static BANK0_WAKERS: [AtomicWaker; BANK0_PIN_COUNT] = [NEW_AW; BANK0_PIN_COUNT];
 #[cfg(feature = "qspi-as-gpio")]

--- a/embassy-rp/src/pio/mod.rs
+++ b/embassy-rp/src/pio/mod.rs
@@ -743,22 +743,21 @@ impl<'d, PIO: Instance + 'd, const SM: usize> StateMachine<'d, PIO, SM> {
             w.set_out_base(config.pins.out_base);
         });
 
-        #[cfg(feature = "_rp235x")]
+        //#[cfg(feature = "_rp235x")]
         {
             let mut low_ok = true;
             let mut high_ok = true;
-            for pin in [
-                config.pins.in_base,
-                config.pins.in_base + config.in_count,
-                config.pins.sideset_base,
-                config.pins.sideset_base + config.pins.sideset_count,
-                config.pins.set_base,
-                config.pins.set_base + config.pins.set_count,
-                config.pins.out_base,
-                config.pins.out_base + config.pins.out_count,
-            ] {
-                low_ok &= pin < 32;
-                high_ok &= pin >= 16;
+
+            let in_pins = config.pins.in_base..config.pins.in_base + config.in_count;
+            let side_pins = config.pins.sideset_base..config.pins.sideset_base + config.pins.sideset_count;
+            let set_pins = config.pins.set_base..config.pins.set_base + config.pins.set_count;
+            let out_pins = config.pins.out_base..config.pins.out_base + config.pins.out_count;
+
+            for pin_range in [in_pins, side_pins, set_pins, out_pins] {
+                for pin in pin_range {
+                    low_ok &= pin < 32;
+                    high_ok &= pin >= 16;
+                }
             }
 
             if !low_ok && !high_ok {

--- a/embassy-rp/src/pio/mod.rs
+++ b/embassy-rp/src/pio/mod.rs
@@ -827,7 +827,7 @@ impl<'d, PIO: Instance + 'd, const SM: usize> StateMachine<'d, PIO, SM> {
                     (Some(16..48), Some(16..48), Some(16..48), Some(16..48)) => true,
 
                     (i, side, set, out) => panic!(
-                        "All pins must either be < 31 or >16, in:{}, side:{}, set:{}, out:{}",
+                        "All pins must either be < 31 or >16, in:{:?}, side:{:?}, set:{:?}, out:{:?}",
                         i, side, set, out
                     ),
                 }

--- a/embassy-rp/src/pio/mod.rs
+++ b/embassy-rp/src/pio/mod.rs
@@ -833,8 +833,6 @@ impl<'d, PIO: Instance + 'd, const SM: usize> StateMachine<'d, PIO, SM> {
                 }
             };
 
-            info!("shift: {}", shift_gpio_base);
-
             if shift_gpio_base {
                 sm.pinctrl().write(|w| {
                     w.set_sideset_count(config.pins.sideset_count);

--- a/embassy-rp/src/pio/mod.rs
+++ b/embassy-rp/src/pio/mod.rs
@@ -743,7 +743,7 @@ impl<'d, PIO: Instance + 'd, const SM: usize> StateMachine<'d, PIO, SM> {
             w.set_out_base(config.pins.out_base);
         });
 
-        //#[cfg(feature = "_rp235x")]
+        #[cfg(feature = "_rp235x")]
         {
             let mut low_ok = true;
             let mut high_ok = true;

--- a/embassy-rp/src/pio/mod.rs
+++ b/embassy-rp/src/pio/mod.rs
@@ -792,42 +792,42 @@ impl<'d, PIO: Instance + 'd, const SM: usize> StateMachine<'d, PIO, SM> {
                 ) {
                     (None, None, None, None) => false,
 
-                    (Some(0..31), None, None, None) => false,
-                    (None, Some(0..31), None, None) => false,
-                    (None, None, Some(0..31), None) => false,
-                    (None, None, None, Some(0..31)) => false,
+                    (Some(..32), None, None, None) => false,
+                    (None, Some(..32), None, None) => false,
+                    (None, None, Some(..32), None) => false,
+                    (None, None, None, Some(..32)) => false,
 
-                    (Some(0..31), Some(0..31), None, None) => false,
-                    (None, Some(0..31), Some(0..31), None) => false,
-                    (None, None, Some(0..31), Some(0..31)) => false,
-                    (Some(0..31), None, None, Some(0..31)) => false,
+                    (Some(..32), Some(..32), None, None) => false,
+                    (None, Some(..32), Some(..32), None) => false,
+                    (None, None, Some(..32), Some(..32)) => false,
+                    (Some(..32), None, None, Some(..32)) => false,
 
-                    (None, Some(0..31), Some(0..31), Some(0..31)) => false,
-                    (Some(0..31), None, Some(0..31), Some(0..31)) => false,
-                    (Some(0..31), Some(0..31), None, Some(0..31)) => false,
-                    (Some(0..31), Some(0..31), Some(0..31), None) => false,
+                    (None, Some(..32), Some(..32), Some(..32)) => false,
+                    (Some(..32), None, Some(..32), Some(..32)) => false,
+                    (Some(..32), Some(..32), None, Some(..32)) => false,
+                    (Some(..32), Some(..32), Some(..32), None) => false,
 
-                    (Some(0..31), Some(0..31), Some(0..31), Some(0..31)) => false,
+                    (Some(..32), Some(..32), Some(..32), Some(..32)) => false,
 
-                    (Some(16..48), None, None, None) => true,
-                    (None, Some(16..48), None, None) => true,
-                    (None, None, Some(16..48), None) => true,
-                    (None, None, None, Some(16..48)) => true,
+                    (Some(16..), None, None, None) => true,
+                    (None, Some(16..), None, None) => true,
+                    (None, None, Some(16..), None) => true,
+                    (None, None, None, Some(16..)) => true,
 
-                    (Some(16..48), Some(16..48), None, None) => true,
-                    (None, Some(16..48), Some(16..48), None) => true,
-                    (None, None, Some(16..48), Some(16..48)) => true,
-                    (Some(16..48), None, None, Some(16..48)) => true,
+                    (Some(16..), Some(16..), None, None) => true,
+                    (None, Some(16..), Some(16..), None) => true,
+                    (None, None, Some(16..), Some(16..)) => true,
+                    (Some(16..), None, None, Some(16..)) => true,
 
-                    (None, Some(16..48), Some(16..48), Some(16..48)) => true,
-                    (Some(16..48), None, Some(16..48), Some(16..48)) => true,
-                    (Some(16..48), Some(16..48), None, Some(16..48)) => true,
-                    (Some(16..48), Some(16..48), Some(16..48), None) => true,
+                    (None, Some(16..), Some(16..), Some(16..)) => true,
+                    (Some(16..), None, Some(16..), Some(16..)) => true,
+                    (Some(16..), Some(16..), None, Some(16..)) => true,
+                    (Some(16..), Some(16..), Some(16..), None) => true,
 
-                    (Some(16..48), Some(16..48), Some(16..48), Some(16..48)) => true,
+                    (Some(16..), Some(16..), Some(16..), Some(16..)) => true,
 
                     (i, side, set, out) => panic!(
-                        "All pins must either be < 31 or >16, in:{:?}, side:{:?}, set:{:?}, out:{:?}",
+                        "All pins must either be <=31 or >=16, in:{:?}, side:{:?}, set:{:?}, out:{:?}",
                         i, side, set, out
                     ),
                 }

--- a/embassy-rp/src/pio/mod.rs
+++ b/embassy-rp/src/pio/mod.rs
@@ -764,13 +764,13 @@ impl<'d, PIO: Instance + 'd, const SM: usize> StateMachine<'d, PIO, SM> {
                 panic!(
                     "All pins must either be <32 or >=16, in:{:?}-{:?}, side:{:?}-{:?}, set:{:?}-{:?}, out:{:?}-{:?}",
                     config.pins.in_base,
-                    config.pins.in_base + config.in_count,
+                    config.pins.in_base + config.in_count - 1,
                     config.pins.sideset_base,
-                    config.pins.sideset_base + config.pins.sideset_count,
+                    config.pins.sideset_base + config.pins.sideset_count - 1,
                     config.pins.set_base,
-                    config.pins.set_base + config.pins.set_count,
+                    config.pins.set_base + config.pins.set_count - 1,
                     config.pins.out_base,
-                    config.pins.out_base + config.pins.out_count,
+                    config.pins.out_base + config.pins.out_count - 1,
                 )
             }
             let shift = if low_ok { 0 } else { 16 };


### PR DESCRIPTION
Disable pad isolation on any used pin.
Use GPIOBASE and offset pin bases if all pins are > 16, panic if some pins are < 16 and some are > 31