### PR TITLE
boot: flash-erase-zero feature for compatibility with STM32L0x1 devices

### DIFF
--- a/docs/pages/bootloader.adoc
+++ b/docs/pages/bootloader.adoc
@@ -19,6 +19,8 @@ The bootloader supports
 
 In general, the bootloader works on any platform that implements the `embedded-storage` traits for its internal flash, but may require custom initialization code to work.
 
+STM32L0x1 devices require the `flash-erase-zero` feature to be enabled.
+
 == Design
 
 image::bootloader_flash.png[Bootloader flash layout]

--- a/embassy-boot/Cargo.toml
+++ b/embassy-boot/Cargo.toml
@@ -47,6 +47,7 @@ ed25519-dalek = { version = "2", default-features = false, features = ["std", "r
 [features]
 ed25519-dalek = ["dep:ed25519-dalek", "_verify"]
 ed25519-salty = ["dep:salty", "_verify"]
+flash-erase-zero = []
 
 #Internal features
 _verify = []

--- a/embassy-boot/src/lib.rs
+++ b/embassy-boot/src/lib.rs
@@ -14,7 +14,11 @@ mod test_flash;
 
 // The expected value of the flash after an erase
 // TODO: Use the value provided by NorFlash when available
+#[cfg(not(feature = "flash-erase-zero"))]
 pub(crate) const STATE_ERASE_VALUE: u8 = 0xFF;
+#[cfg(feature = "flash-erase-zero")]
+pub(crate) const STATE_ERASE_VALUE: u8 = 0x00;
+
 pub use boot_loader::{BootError, BootLoader, BootLoaderConfig};
 pub use firmware_updater::{
     BlockingFirmwareState, BlockingFirmwareUpdater, FirmwareState, FirmwareUpdater, FirmwareUpdaterConfig,


### PR DESCRIPTION
Proposal for issue #3342, subject for discussion. Any feedback is welcome.
Allow compatibility with devices whose flash erase set bytes to 0x00 instead of 0xFF, using a new flash-erase-zero feature.