### PR TITLE
Usbh prereq 

### DIFF
--- a/embassy-usb-synopsys-otg/src/otg_v1.rs
+++ b/embassy-usb-synopsys-otg/src/otg_v1.rs
@@ -3929,23 +3929,23 @@ pub mod regs {
     #[derive(Copy, Clone, Eq, PartialEq)]
     pub struct Hctsiz(pub u32);
     impl Hctsiz {
-        #[doc = "Transfer size"]
+        #[doc = "Transfer size for non-isochronuous/interrupt pipes"]
         #[inline(always)]
         pub const fn xfrsiz(&self) -> u32 {
             let val = (self.0 >> 0usize) & 0x0007_ffff;
             val as u32
         }
-        #[doc = "Transfer size"]
+        #[doc = "Transfer size for non-isochronuous/interrupt pipes"]
         #[inline(always)]
         pub fn set_xfrsiz(&mut self, val: u32) {
             self.0 = (self.0 & !(0x0007_ffff << 0usize)) | (((val as u32) & 0x0007_ffff) << 0usize);
         }
-        #[doc = "NTD descriptor list length (xfersiz[15:8], note val+1 is actual length)"]
+        #[doc = "NTD descriptor list length for isochronuous & interrupt pipes (xfersiz[15:8], note val+1 is actual length)"]
         #[inline(always)]
         pub const fn ntdl(&self) -> u8 {
             (self.0 >> 8) as u8
         }
-        #[doc = "NTD descriptor list length (xfrsiz[15:8], note val-1 is actual length)"]
+        #[doc = "NTD descriptor list length for isochronuous & interrupt pipes (xfrsiz[15:8], note val-1 is actual length)"]
         #[inline(always)]
         pub fn set_ntdl(&mut self, val: u8) {
             self.0 = (self.0 & !(0xFF << 8)) | ((val as u32) << 8)
@@ -4015,15 +4015,16 @@ pub mod regs {
         pub fn set_cqtd(&mut self, val: u8) {
             self.0 = (self.0 & !(0x3f << 3)) | (val as u32 & 0x3F) << 3;
         }
-        #[doc = "DMA base address"]
+        #[doc = "QTD list base address"]
         #[inline(always)]
-        pub const fn dmaaddr(&self) -> u32 {
-            self.0 >> 9
+        pub const fn qtdaddr(&self) -> u32 {
+            self.0 & 0xFFFFFE00
         }
-        #[doc = "DMA base address"]
+        #[doc = "QTD list base address"]
         #[inline(always)]
-        pub fn set_dmaaddr(&mut self, val: u32) {
-            self.0 = (self.0 & !0xFFFFFE00) | val << 9;
+        pub fn set_qtdaddr(&mut self, val: u32) {
+            debug_assert!(val & 0xFFFFFE00 == val, "QTD list needs to be 512 byte aligned");
+            self.0 = (self.0 & !0xFFFFFE00) | val;
         }
     }
     impl Default for Hcdma {

--- a/embassy-usb-synopsys-otg/src/otg_v1.rs
+++ b/embassy-usb-synopsys-otg/src/otg_v1.rs
@@ -3492,7 +3492,7 @@ pub mod regs {
         #[doc = "Host frame list base address"]
         #[inline(always)]
         pub const fn hflbaddr(&self) -> u32 {
-            return self.0;
+            self.0
         }
         #[doc = "Host frame list base address"]
         #[inline(always)]
@@ -4328,6 +4328,15 @@ pub mod vals {
         #[inline(always)]
         pub const fn to_bits(self) -> u8 {
             unsafe { core::mem::transmute(self) }
+        }
+        #[inline(always)]
+        pub const fn as_value(self) -> u8 {
+            match self {
+                Self::LEN8 => 8,
+                Self::LEN16 => 16,
+                Self::LEN32 => 32,
+                Self::LEN64 => 64,
+            }
         }
     }
     impl From<u8> for FrameListLen {

--- a/embassy-usb-synopsys-otg/src/otg_v1.rs
+++ b/embassy-usb-synopsys-otg/src/otg_v1.rs
@@ -389,6 +389,8 @@ impl Otg {
     }
 }
 pub mod regs {
+    use super::vals::FrameListLen;
+
     #[doc = "Core ID register"]
     #[repr(transparent)]
     #[derive(Copy, Clone, Eq, PartialEq)]
@@ -3482,6 +3484,28 @@ pub mod regs {
             Haintmsk(0)
         }
     }
+    #[doc = "Host frame list base address"]
+    #[repr(transparent)]
+    #[derive(Copy, Clone, Eq, PartialEq)]
+    pub struct Hflbaddr(pub u32);
+    impl Hflbaddr {
+        #[doc = "Host frame list base address"]
+        #[inline(always)]
+        pub const fn hflbaddr(&self) -> u32 {
+            return self.0;
+        }
+        #[doc = "Host frame list base address"]
+        #[inline(always)]
+        pub fn set_hflbaddr(&mut self, val: u32) {
+            self.0 = val
+        }
+    }
+    impl Default for Hflbaddr {
+        #[inline(always)]
+        fn default() -> Hflbaddr {
+            Hflbaddr(0)
+        }
+    }
     #[doc = "Host channel characteristics register"]
     #[repr(transparent)]
     #[derive(Copy, Clone, Eq, PartialEq)]
@@ -3630,6 +3654,28 @@ pub mod regs {
         #[inline(always)]
         pub fn set_fslss(&mut self, val: bool) {
             self.0 = (self.0 & !(0x01 << 2usize)) | (((val as u32) & 0x01) << 2usize);
+        }
+        #[doc = "Period scheduling enable"]
+        #[inline(always)]
+        pub fn set_perschedena(&mut self, val: bool) {
+            self.0 = (self.0 & !(0x01 << 25)) | ((val as u32) << 25);
+        }
+        #[doc = "Period scheduling enable"]
+        #[inline(always)]
+        pub fn perschedena(&mut self) -> bool {
+            let val = (self.0 >> 25) & 0x1;
+            val != 0
+        }
+        #[doc = "Frame list length (x+3 pow 2)"]
+        #[inline(always)]
+        pub fn frlistlen(&self) -> FrameListLen {
+            let val = (self.0 << 24) & 0x2;
+            (val as u8).into()
+        }
+        #[doc = "Frame list length (x+3 pow 2)"]
+        #[inline(always)]
+        pub fn set_frlistlen(&mut self, val: FrameListLen) {
+            self.0 = (self.0 & !(0x2 << 24)) | ((val as u32) & 0x2) << 24
         }
     }
     impl Default for Hcfg {
@@ -4265,6 +4311,38 @@ pub mod regs {
     }
 }
 pub mod vals {
+    #[repr(u8)]
+    #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+    #[allow(non_camel_case_types)]
+    pub enum FrameListLen {
+        LEN8 = 0x0,
+        LEN16 = 0x1,
+        LEN32 = 0x2,
+        LEN64 = 0x3,
+    }
+    impl FrameListLen {
+        #[inline(always)]
+        pub const fn from_bits(val: u8) -> FrameListLen {
+            unsafe { core::mem::transmute(val & 0x03) }
+        }
+        #[inline(always)]
+        pub const fn to_bits(self) -> u8 {
+            unsafe { core::mem::transmute(self) }
+        }
+    }
+    impl From<u8> for FrameListLen {
+        #[inline(always)]
+        fn from(val: u8) -> FrameListLen {
+            FrameListLen::from_bits(val)
+        }
+    }
+    impl From<FrameListLen> for u8 {
+        #[inline(always)]
+        fn from(val: FrameListLen) -> u8 {
+            FrameListLen::to_bits(val)
+        }
+    }
+
     #[repr(u8)]
     #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
     #[allow(non_camel_case_types)]

--- a/embassy-usb-synopsys-otg/src/otg_v1.rs
+++ b/embassy-usb-synopsys-otg/src/otg_v1.rs
@@ -3955,6 +3955,17 @@ pub mod regs {
         pub fn set_dpid(&mut self, val: u8) {
             self.0 = (self.0 & !(0x03 << 29usize)) | (((val as u32) & 0x03) << 29usize);
         }
+        #[doc = "Do Ping"]
+        #[inline(always)]
+        pub const fn doping(&self) -> bool {
+            let val = (self.0 >> 31usize) & 0x01;
+            val != 0
+        }
+        #[doc = "Do Ping"]
+        #[inline(always)]
+        pub fn set_doping(&mut self, val: bool) {
+            self.0 = (self.0 & !(0x01 << 31usize)) | (((val as u32) & 0x01) << 31usize);
+        }
     }
     impl Default for Hctsiz {
         #[inline(always)]

--- a/embassy-usb-synopsys-otg/src/otg_v1.rs
+++ b/embassy-usb-synopsys-otg/src/otg_v1.rs
@@ -272,11 +272,17 @@ impl Otg {
         assert!(n < 12usize);
         unsafe { Reg::from_ptr(self.ptr.add(0x0510usize + n * 32usize) as _) }
     }
-    #[doc = "Host channel DMA address register"]
+    #[doc = "Host channel DMA address register (config)"]
     #[inline(always)]
-    pub const fn hcdma(self, n: usize) -> Reg<u32, RW> {
+    pub const fn hcdma(self, n: usize) -> Reg<regs::Hcdma, RW> {
         assert!(n < 12usize);
         unsafe { Reg::from_ptr(self.ptr.add(0x0514usize + n * 32usize) as _) }
+    }
+    #[doc = "Host channel DMA address register (buffer)"]
+    #[inline(always)]
+    pub const fn hcdmab(self, n: usize) -> Reg<u32, RW> {
+        assert!(n < 12usize);
+        unsafe { Reg::from_ptr(self.ptr.add(0x051cusize + n * 32usize) as _) }
     }
     #[doc = "Device configuration register"]
     #[inline(always)]
@@ -1032,6 +1038,7 @@ pub mod regs {
         pub fn set_xfrsiz(&mut self, val: u32) {
             self.0 = (self.0 & !(0x0007_ffff << 0usize)) | (((val as u32) & 0x0007_ffff) << 0usize);
         }
+
         #[doc = "Packet count"]
         #[inline(always)]
         pub const fn pktcnt(&self) -> u16 {
@@ -3933,6 +3940,26 @@ pub mod regs {
         pub fn set_xfrsiz(&mut self, val: u32) {
             self.0 = (self.0 & !(0x0007_ffff << 0usize)) | (((val as u32) & 0x0007_ffff) << 0usize);
         }
+        #[doc = "NTD descriptor list length (xfersiz[15:8], note val+1 is actual length)"]
+        #[inline(always)]
+        pub const fn ntdl(&self) -> u8 {
+            (self.0 >> 8) as u8
+        }
+        #[doc = "NTD descriptor list length (xfrsiz[15:8], note val-1 is actual length)"]
+        #[inline(always)]
+        pub fn set_ntdl(&mut self, val: u8) {
+            self.0 = (self.0 & !(0xFF << 8)) | ((val as u32) << 8)
+        }
+        #[doc = "Schedule info for isochronuous & interrupt pipes (xfrsiz[7:0])"]
+        #[inline(always)]
+        pub const fn schedinfo(&self) -> u8 {
+            self.0 as u8
+        }
+        #[doc = "Schedule info for isochronuous & interrupt pipes (xfrsiz[7:0])"]
+        #[inline(always)]
+        pub fn set_schedinfo(&mut self, val: u8) {
+            self.0 = (self.0 & !(0xFF << 8)) | ((val as u32) << 8)
+        }
         #[doc = "Packet count"]
         #[inline(always)]
         pub const fn pktcnt(&self) -> u16 {
@@ -3973,6 +4000,39 @@ pub mod regs {
             Hctsiz(0)
         }
     }
+    #[doc = "Host channel DMA config register"]
+    #[repr(transparent)]
+    #[derive(Copy, Clone, Eq, PartialEq)]
+    pub struct Hcdma(pub u32);
+    impl Hcdma {
+        #[doc = "Current QTD (transfer descriptor) index"]
+        #[inline(always)]
+        pub const fn cqtd(&self) -> u8 {
+            ((self.0 >> 3) & 0x3F) as u8
+        }
+        #[doc = "Current QTD (transfer descriptor) index"]
+        #[inline(always)]
+        pub fn set_cqtd(&mut self, val: u8) {
+            self.0 = (self.0 & !(0x3f << 3)) | (val as u32 & 0x3F) << 3;
+        }
+        #[doc = "DMA base address"]
+        #[inline(always)]
+        pub const fn dmaaddr(&self) -> u32 {
+            self.0 >> 9
+        }
+        #[doc = "DMA base address"]
+        #[inline(always)]
+        pub fn set_dmaaddr(&mut self, val: u32) {
+            self.0 = (self.0 & !0xFFFFFE00) | val << 9;
+        }
+    }
+    impl Default for Hcdma {
+        #[inline(always)]
+        fn default() -> Hcdma {
+            Hcdma(0)
+        }
+    }
+
     #[doc = "Host frame interval register"]
     #[repr(transparent)]
     #[derive(Copy, Clone, Eq, PartialEq)]

--- a/embassy-usb-synopsys-otg/src/otg_v1.rs
+++ b/embassy-usb-synopsys-otg/src/otg_v1.rs
@@ -273,6 +273,11 @@ impl Otg {
     pub const fn haint(self) -> Reg<regs::Haint, R> {
         unsafe { Reg::from_ptr(self.ptr.add(0x0414usize) as _) }
     }
+    #[doc = "Host Frame Scheduling List Register"]
+    #[inline(always)]
+    pub const fn hflbaddr(self) -> Reg<regs::Hflbaddr, RW> {
+        unsafe { Reg::from_ptr(self.ptr.add(0x41cusize) as _) }
+    }
     #[doc = "Host all channels interrupt mask register"]
     #[inline(always)]
     pub const fn haintmsk(self) -> Reg<regs::Haintmsk, RW> {
@@ -313,13 +318,13 @@ impl Otg {
         assert!(n < 12usize);
         unsafe { Reg::from_ptr(self.ptr.add(0x0510usize + n * 32usize) as _) }
     }
-    #[doc = "Host channel DMA address register (config for scatter/gather)"]
+    #[doc = "Host channel DMA address register (config for scatter/gather, ptr for buffer-dma)"]
     #[inline(always)]
     pub const fn hcdma(self, n: usize) -> Reg<regs::Hcdma, RW> {
         assert!(n < 12usize);
         unsafe { Reg::from_ptr(self.ptr.add(0x0514usize + n * 32usize) as _) }
     }
-    #[doc = "Host channel DMA address register (buffer)"]
+    #[doc = "Host channel DMA address register (addr buffer; unknown use)"]
     #[inline(always)]
     pub const fn hcdmab(self, n: usize) -> Reg<u32, RW> {
         assert!(n < 12usize);
@@ -2675,6 +2680,18 @@ pub mod regs {
         pub fn set_datafsusp(&mut self, val: bool) {
             self.0 = (self.0 & !(0x01 << 22usize)) | (((val as u32) & 0x01) << 22usize);
         }
+        #[doc = "Reset detected"]
+        #[inline(always)]
+        pub const fn resetdet(&self) -> bool {
+            let val = (self.0 >> 23usize) & 0x01;
+            val != 0
+        }
+        #[doc = "Reset detected"]
+        #[inline(always)]
+        pub fn set_resetdet(&mut self, val: bool) {
+            self.0 = (self.0 & !(0x01 << 23usize)) | (((val as u32) & 0x01) << 23usize);
+        }
+
         #[doc = "Host port interrupt"]
         #[inline(always)]
         pub const fn hprtint(&self) -> bool {
@@ -4379,7 +4396,7 @@ pub mod regs {
             let val = (self.0 >> 2usize) & 0x01;
             val != 0
         }
-        #[doc = "Port enable"]
+        #[doc = "Port enable (write 1 to disable)"]
         #[inline(always)]
         pub fn set_pena(&mut self, val: bool) {
             self.0 = (self.0 & !(0x01 << 2usize)) | (((val as u32) & 0x01) << 2usize);

--- a/embassy-usb-synopsys-otg/src/otg_v1.rs
+++ b/embassy-usb-synopsys-otg/src/otg_v1.rs
@@ -1,4 +1,6 @@
 //! Register definitions for Synopsys DesignWare USB OTG core
+//! This core is well known for being poorly documented publicly, but register descriptions are available at:
+//!  https://www.intel.com/content/www/us/en/programmable/hps/agilex5/index_frames.html under USBOTG
 
 #![allow(missing_docs)]
 
@@ -324,7 +326,7 @@ impl Otg {
         assert!(n < 12usize);
         unsafe { Reg::from_ptr(self.ptr.add(0x0514usize + n * 32usize) as _) }
     }
-    #[doc = "Host channel DMA address register (addr buffer; unknown use)"]
+    #[doc = "Host channel DMA address register (addr buffer for current transfer; used to debug ddma)"]
     #[inline(always)]
     pub const fn hcdmab(self, n: usize) -> Reg<u32, RW> {
         assert!(n < 12usize);
@@ -3809,6 +3811,7 @@ pub mod regs {
         }
         #[doc = "Odd frame"]
         #[inline(always)]
+        /// Indicates to the USBOTG core that the (iso or intr) transaction must be performed on an odd (micro)frame
         pub const fn oddfrm(&self) -> bool {
             let val = (self.0 >> 29usize) & 0x01;
             val != 0
@@ -4631,7 +4634,7 @@ pub mod vals {
         }
         #[inline(always)]
         pub const fn to_bits(self) -> u8 {
-            unsafe { core::mem::transmute(self) }
+            self as u8
         }
         #[inline(always)]
         pub const fn as_value(self) -> u8 {
@@ -4672,7 +4675,7 @@ pub mod vals {
         }
         #[inline(always)]
         pub const fn to_bits(self) -> u8 {
-            unsafe { core::mem::transmute(self) }
+            self as u8
         }
     }
     impl From<u8> for Dpid {
@@ -4737,7 +4740,7 @@ pub mod vals {
         }
         #[inline(always)]
         pub const fn to_bits(self) -> u8 {
-            unsafe { core::mem::transmute(self) }
+            self as u8
         }
     }
     impl From<u8> for Eptyp {
@@ -4772,7 +4775,7 @@ pub mod vals {
         }
         #[inline(always)]
         pub const fn to_bits(self) -> u8 {
-            unsafe { core::mem::transmute(self) }
+            self as u8
         }
     }
     impl From<u8> for Pfivl {
@@ -4820,7 +4823,7 @@ pub mod vals {
         }
         #[inline(always)]
         pub const fn to_bits(self) -> u8 {
-            unsafe { core::mem::transmute(self) }
+            self as u8
         }
     }
     impl From<u8> for Pktstsd {
@@ -4867,7 +4870,7 @@ pub mod vals {
         }
         #[inline(always)]
         pub const fn to_bits(self) -> u8 {
-            unsafe { core::mem::transmute(self) }
+            self as u8
         }
     }
     impl From<u8> for Pktstsh {

--- a/embassy-usb-synopsys-otg/src/otg_v1.rs
+++ b/embassy-usb-synopsys-otg/src/otg_v1.rs
@@ -1725,7 +1725,7 @@ pub mod regs {
         #[doc = "Data"]
         #[inline(always)]
         pub fn set_data(&mut self, val: u32) {
-            self.0 = (self.0 & !(0xffff_ffff << 0usize)) | (((val as u32) & 0xffff_ffff) << 0usize);
+            self.0 = val
         }
     }
     impl Default for Fifo {
@@ -3876,7 +3876,7 @@ pub mod regs {
         }
         #[doc = "Period scheduling enable"]
         #[inline(always)]
-        pub fn perschedena(&mut self) -> bool {
+        pub fn perschedena(&self) -> bool {
             let val = (self.0 >> 26) & 0x1;
             val != 0
         }

--- a/embassy-usb-synopsys-otg/src/otg_v1.rs
+++ b/embassy-usb-synopsys-otg/src/otg_v1.rs
@@ -3855,13 +3855,23 @@ pub mod regs {
         #[doc = "Period scheduling enable"]
         #[inline(always)]
         pub fn set_perschedena(&mut self, val: bool) {
-            self.0 = (self.0 & !(0x01 << 25)) | ((val as u32) << 25);
+            self.0 = (self.0 & !(0x01 << 26)) | ((val as u32) << 26);
         }
         #[doc = "Period scheduling enable"]
         #[inline(always)]
         pub fn perschedena(&mut self) -> bool {
-            let val = (self.0 >> 25) & 0x1;
+            let val = (self.0 >> 26) & 0x1;
             val != 0
+        }
+        #[doc = "Descriptor DMA-mode enable (qtd)"]
+        #[inline(always)]
+        pub fn descdma(&self) -> bool {
+            (self.0 << 23) & 0x1 != 0
+        }
+        #[doc = "Descriptor DMA-mode enable (qtd)"]
+        #[inline(always)]
+        pub fn set_descdma(&mut self, val: bool) {
+            self.0 = (self.0 & !(0x1 << 23)) | (val as u32) << 23
         }
         #[doc = "Frame list length (x+3 pow 2)"]
         #[inline(always)]

--- a/embassy-usb-synopsys-otg/src/otg_v1.rs
+++ b/embassy-usb-synopsys-otg/src/otg_v1.rs
@@ -191,10 +191,51 @@ impl Otg {
     pub const fn cid(self) -> Reg<regs::Cid, RW> {
         unsafe { Reg::from_ptr(self.ptr.add(0x3cusize) as _) }
     }
+    #[doc = "Synopsis ID Register"]
+    #[inline(always)]
+    pub const fn snpsid(self) -> Reg<u32, R> {
+        unsafe { Reg::from_ptr(self.ptr.add(0x40usize) as _) }
+    }
+    // TODO: https://github.com/nfeske/dwc_otg/blob/177687793c884a9ffc2e5b08acf99cf75990a88c/dwc_otg/dwc_otg_regs.h#L724
+    #[doc = "User HW Config 1 register"]
+    #[inline(always)]
+    pub const fn hwcfg1(self) -> Reg<u32, R> {
+        unsafe { Reg::from_ptr(self.ptr.add(0x44usize) as _) }
+    }
+    #[doc = "User HW Config 2 register"]
+    #[inline(always)]
+    pub const fn hwcfg2(self) -> Reg<u32, R> {
+        unsafe { Reg::from_ptr(self.ptr.add(0x48usize) as _) }
+    }
+    #[doc = "User HW Config 3 register"]
+    #[inline(always)]
+    pub const fn hwcfg3(self) -> Reg<u32, R> {
+        unsafe { Reg::from_ptr(self.ptr.add(0x4cusize) as _) }
+    }
+    #[doc = "User HW Config 4 register"]
+    #[inline(always)]
+    pub const fn hwcfg4(self) -> Reg<u32, R> {
+        unsafe { Reg::from_ptr(self.ptr.add(0x50usize) as _) }
+    }
     #[doc = "OTG core LPM configuration register"]
     #[inline(always)]
     pub const fn glpmcfg(self) -> Reg<regs::Glpmcfg, RW> {
         unsafe { Reg::from_ptr(self.ptr.add(0x54usize) as _) }
+    }
+    #[doc = "Global PowerDn Register"]
+    #[inline(always)]
+    pub const fn gpwrdn(self) -> Reg<u32, RW> {
+        unsafe { Reg::from_ptr(self.ptr.add(0x58usize) as _) }
+    }
+    #[doc = "Global DFIFO SW Config Register"]
+    #[inline(always)]
+    pub const fn gdfifocfg(self) -> Reg<u32, RW> {
+        unsafe { Reg::from_ptr(self.ptr.add(0x5cusize) as _) }
+    }
+    #[doc = "ADP (Attach Detection Protocol) Control Register"]
+    #[inline(always)]
+    pub const fn adpctl(self) -> Reg<regs::AdpCtl, RW> {
+        unsafe { Reg::from_ptr(self.ptr.add(0x60usize) as _) }
     }
     #[doc = "Host periodic transmit FIFO size register"]
     #[inline(always)]
@@ -272,7 +313,7 @@ impl Otg {
         assert!(n < 12usize);
         unsafe { Reg::from_ptr(self.ptr.add(0x0510usize + n * 32usize) as _) }
     }
-    #[doc = "Host channel DMA address register (config)"]
+    #[doc = "Host channel DMA address register (config for scatter/gather)"]
     #[inline(always)]
     pub const fn hcdma(self, n: usize) -> Reg<regs::Hcdma, RW> {
         assert!(n < 12usize);
@@ -408,11 +449,6 @@ pub mod regs {
             let val = (self.0 >> 0usize) & 0xffff_ffff;
             val as u32
         }
-        #[doc = "Product ID field"]
-        #[inline(always)]
-        pub fn set_product_id(&mut self, val: u32) {
-            self.0 = (self.0 & !(0xffff_ffff << 0usize)) | (((val as u32) & 0xffff_ffff) << 0usize);
-        }
     }
     impl Default for Cid {
         #[inline(always)]
@@ -420,6 +456,160 @@ pub mod regs {
             Cid(0)
         }
     }
+
+    #[doc = "Core ID register"]
+    #[repr(transparent)]
+    #[derive(Copy, Clone, Eq, PartialEq)]
+    pub struct AdpCtl(pub u32);
+    impl AdpCtl {
+        #[doc = "Probe Discharge time (times for TADP_DSCHG)"]
+        #[inline(always)]
+        pub const fn prb_dschg(&self) -> u8 {
+            self.0 as u8 & 0b11
+        }
+        #[doc = "Probe Discharge time (times for TADP_DSCHG)"]
+        #[inline(always)]
+        pub fn set_prb_dschg(&mut self, val: u8) {
+            self.0 = (self.0 & !(0b11u32)) | ((val as u32) & 0b11);
+        }
+        #[doc = "Probe Delta (resolution for RTIM)"]
+        #[inline(always)]
+        pub const fn prb_delta(&self) -> u8 {
+            (self.0 >> 2) as u8 & 0b11
+        }
+        #[doc = "Probe Delta (resolution for RTIM)"]
+        #[inline(always)]
+        pub fn set_prb_delta(&mut self, val: u8) {
+            self.0 = (self.0 & !(0b11 << 2)) | (((val as u32) & 0b11) << 2usize);
+        }
+        #[doc = "Probe Period (TADP_PRD)"]
+        #[inline(always)]
+        pub const fn prb_per(&self) -> u8 {
+            (self.0 >> 4) as u8 & 0b11
+        }
+        #[doc = "Probe Period (TADP_PRD)"]
+        #[inline(always)]
+        pub fn set_prb_per(&mut self, val: u8) {
+            self.0 = (self.0 & !(0b11 << 4)) | (((val as u32) & 0b11) << 4usize);
+        }
+        #[doc = "Probe Period (TADP_PRD)"]
+        #[inline(always)]
+        pub const fn rtim(&self) -> u16 {
+            (self.0 >> 6) as u16 & 0x7ff
+        }
+        #[doc = "Probe Period (TADP_PRD)"]
+        #[inline(always)]
+        pub fn set_rtim(&mut self, val: u16) {
+            self.0 = (self.0 & !(0x7ff << 6)) | (((val as u32) & 0x7ff) << 6usize);
+        }
+        #[doc = "Enable Probe"]
+        #[inline(always)]
+        pub const fn enaprb(&self) -> bool {
+            (self.0 >> 17) & 0b1 != 0
+        }
+        #[doc = "Enable Probe"]
+        #[inline(always)]
+        pub fn set_enaprb(&mut self, val: bool) {
+            self.0 = (self.0 & !(0b1 << 17)) | ((val as u32) << 17usize);
+        }
+        #[doc = "Enable Sense"]
+        #[inline(always)]
+        pub const fn enasns(&self) -> bool {
+            (self.0 >> 18) & 0b1 != 0
+        }
+        #[doc = "Enable Sense"]
+        #[inline(always)]
+        pub fn set_enasns(&mut self, val: bool) {
+            self.0 = (self.0 & !(0b1 << 18)) | ((val as u32) << 18usize);
+        }
+        #[doc = "ADP Reset"]
+        #[inline(always)]
+        pub const fn adpres(&self) -> bool {
+            (self.0 >> 19) & 0b1 != 0
+        }
+        #[doc = "ADP Reset"]
+        #[inline(always)]
+        pub fn set_adpres(&mut self, val: bool) {
+            self.0 = (self.0 & !(0b1 << 19)) | ((val as u32) << 19usize);
+        }
+        #[doc = "ADP Enable"]
+        #[inline(always)]
+        pub const fn adpen(&self) -> bool {
+            (self.0 >> 20) & 0b1 != 0
+        }
+        #[doc = "ADP Enable"]
+        #[inline(always)]
+        pub fn set_adpen(&mut self, val: bool) {
+            self.0 = (self.0 & !(0b1 << 20)) | ((val as u32) << 20usize);
+        }
+        #[doc = "ADP Probe Interrupt Enable"]
+        #[inline(always)]
+        pub const fn adp_prb_int(&self) -> bool {
+            (self.0 >> 21) & 0b1 != 0
+        }
+        #[doc = "ADP Probe Interrupt Enable"]
+        #[inline(always)]
+        pub fn set_adp_prb_int(&mut self, val: bool) {
+            self.0 = (self.0 & !(0b1 << 21)) | ((val as u32) << 21usize);
+        }
+        #[doc = "ADP Sense Interrupt Enable"]
+        #[inline(always)]
+        pub const fn adp_sns_int(&self) -> bool {
+            (self.0 >> 22) & 0b1 != 0
+        }
+        #[doc = "ADP Sense Interrupt Enable"]
+        #[inline(always)]
+        pub fn set_adp_sns_int(&mut self, val: bool) {
+            self.0 = (self.0 & !(0b1 << 22)) | ((val as u32) << 22usize);
+        }
+        #[doc = "ADP Timeout Interrupt Enable"]
+        #[inline(always)]
+        pub const fn adp_tmout_int(&self) -> bool {
+            (self.0 >> 23) & 0b1 != 0
+        }
+        #[doc = "ADP Timeout Interrupt Enable"]
+        #[inline(always)]
+        pub fn set_adp_tmout_int(&mut self, val: bool) {
+            self.0 = (self.0 & !(0b1 << 23)) | ((val as u32) << 23usize);
+        }
+        #[doc = "ADP Probe Interrupt Mask"]
+        #[inline(always)]
+        pub const fn adp_prb_msk(&self) -> bool {
+            (self.0 >> 24) & 0b1 != 0
+        }
+        #[doc = "ADP Probe Interrupt Mask"]
+        #[inline(always)]
+        pub fn set_adp_prb_msk(&mut self, val: bool) {
+            self.0 = (self.0 & !(0b1 << 24)) | ((val as u32) << 24usize);
+        }
+        #[doc = "ADP Timeout Interrupt Mask"]
+        #[inline(always)]
+        pub const fn adp_tmout_msk(&self) -> bool {
+            (self.0 >> 25) & 0b1 != 0
+        }
+        #[doc = "ADP Timeout Interrupt Mask"]
+        #[inline(always)]
+        pub fn set_adp_tmout_msk(&mut self, val: bool) {
+            self.0 = (self.0 & !(0b1 << 25)) | ((val as u32) << 25usize);
+        }
+        #[doc = "Access Request"]
+        #[inline(always)]
+        pub const fn ar(&self) -> u8 {
+            (self.0 >> 26) as u8 & 0b11
+        }
+        #[doc = "Access Request"]
+        #[inline(always)]
+        pub fn set_ar(&mut self, val: u8) {
+            self.0 = (self.0 & !(0b11 << 26)) | ((val as u32) << 26usize);
+        }
+    }
+    impl Default for AdpCtl {
+        #[inline(always)]
+        fn default() -> AdpCtl {
+            AdpCtl(0)
+        }
+    }
+
     #[doc = "Device all endpoints interrupt register"]
     #[repr(transparent)]
     #[derive(Copy, Clone, Eq, PartialEq)]

--- a/embassy-usb-synopsys-otg/src/otg_v1.rs
+++ b/embassy-usb-synopsys-otg/src/otg_v1.rs
@@ -4250,6 +4250,16 @@ pub mod regs {
         pub fn set_frivl(&mut self, val: u16) {
             self.0 = (self.0 & !(0xffff << 0usize)) | (((val as u32) & 0xffff) << 0usize);
         }
+        #[doc = "Dynamic Loading Control"]
+        #[inline(always)]
+        pub const fn rldctrl(&self) -> bool {
+            (self.0 >> 16usize) & 0x1 != 0
+        }
+        #[doc = "Dynamic Loading Control"]
+        #[inline(always)]
+        pub fn set_rldctrl(&mut self, val: bool) {
+            self.0 = (self.0 & !(0b1 << 16usize)) | ((val as u32) << 16usize);
+        }
     }
     impl Default for Hfir {
         #[inline(always)]

--- a/embassy-usb-synopsys-otg/src/otg_v1.rs
+++ b/embassy-usb-synopsys-otg/src/otg_v1.rs
@@ -454,6 +454,11 @@ pub mod regs {
             let val = (self.0 >> 0usize) & 0xffff_ffff;
             val as u32
         }
+        #[doc = "Product ID field"]
+        #[inline(always)]
+        pub fn set_product_id(&mut self, val: u32) {
+            self.0 = val
+        }
     }
     impl Default for Cid {
         #[inline(always)]


### PR DESCRIPTION
This is a follow-up to #3253 now that I've finished a reference implementation based on `usbh`. 
It should now have all registers required make Host HS/FS/LS FIFO/Buffer-DMA/Scatter-gather-DMA driver on an ESP32* and similar devices that have a Synopsys USBOTG core.

The only registers missing are `GHWCFG{1..=4}`, I've added them as u32, but some may be needed to do feature detection of e.g. HS phy, scatter-gather dma support, number of EPs.

If desired I can either make a later follow-up for the GHWCFG or include it in this one (may take a few days).

I also found a source for register documentation so I've added it to the module description.

The reference implementation still needs to be cleaned up and is planned to be added in a pull-request to esp-rs, since it's not async. In the future I may port it to embassy if embassy adopts a standard host trait (I know there is a proposal in #3307)