### PR TITLE
net: add all combinations of wait methods for link/config up/down.

### DIFF
--- a/embassy-net-esp-hosted/src/control.rs
+++ b/embassy-net-esp-hosted/src/control.rs
@@ -120,7 +120,7 @@ impl<'a> Control<'a> {
             pwd: unwrap!(String::try_from(password)),
             bssid: String::new(),
             listen_interval: 3,
-            is_wpa3_supported: false,
+            is_wpa3_supported: true,
         };
         ioctl!(self, ReqConnectAp, RespConnectAp, req, resp);
         self.state_ch.set_link_state(LinkState::Up);

--- a/embassy-net-esp-hosted/src/lib.rs
+++ b/embassy-net-esp-hosted/src/lib.rs
@@ -137,7 +137,7 @@ where
     let (ch_runner, device) = ch::new(&mut state.ch, ch::driver::HardwareAddress::Ethernet([0; 6]));
     let state_ch = ch_runner.state_runner();
 
-    let mut runner = Runner {
+    let runner = Runner {
         ch: ch_runner,
         state_ch,
         shared: &state.shared,
@@ -148,7 +148,6 @@ where
         spi,
         heartbeat_deadline: Instant::now() + HEARTBEAT_MAX_GAP,
     };
-    runner.init().await;
 
     (device, Control::new(state_ch, &state.shared), runner)
 }
@@ -174,8 +173,6 @@ where
     IN: InputPin + Wait,
     OUT: OutputPin,
 {
-    async fn init(&mut self) {}
-
     /// Run the packet processing.
     pub async fn run(mut self) -> ! {
         debug!("resetting...");


### PR DESCRIPTION
- **net-esp-hosted: remove useless fn init.**
- **net-esp-hosted: set wpa3_supported=true.**
- **net: add all combinations of wait methods for link/config up/down.**
