### PR TITLE
Add hpm-hal to HAL list, support for HPMicro microcontrollers

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ Rust's <a href="https://rust-lang.github.io/async-book/">async/await</a> allows 
     - Embassy HAL support for Espressif chips is being developed in the [esp-rs/esp-hal](https://github.com/esp-rs/esp-hal) repository.
     - Async WiFi, Bluetooth and ESP-NOW is being developed in the [esp-rs/esp-wifi](https://github.com/esp-rs/esp-wifi) repository.
   - <a href="https://github.com/ch32-rs/ch32-hal">ch32-hal</a>, for the WCH 32-bit RISC-V(CH32V) series of chips.
+  - <a href="https://github.com/hpmicro/hpm-hal">hpm-hal</a>, for all HPMicro microcontroller families.
 
 - **Time that Just Works** - 
 No more messing with hardware timers. <a href="https://docs.embassy.dev/embassy-time">embassy_time</a> provides Instant, Duration and Timer types that are globally available and never overflow.

--- a/docs/pages/hal.adoc
+++ b/docs/pages/hal.adoc
@@ -11,4 +11,6 @@ async traits in `embedded-hal` and `embedded-hal-async`. You can also use these 
 
 For the ESP32 series, there is an link:https://github.com/esp-rs/esp-hal[esp-hal] which you can use.
 
-For the WCH 32-bit RISC-V series, there is an link:https://github.com/ch32-rs/ch32-hal[ch32-hal], which you can use.
+For the WCH 32-bit RISC-V series, there is a link:https://github.com/ch32-rs/ch32-hal[ch32-hal], which you can use.
+
+For the HPM microcontrollers from HPMicro, there is an link:https://github.com/hpmicro/hpm-hal[hpm-hal], which you can use.

--- a/docs/pages/overview.adoc
+++ b/docs/pages/overview.adoc
@@ -31,6 +31,7 @@ The Embassy project maintains HALs for select hardware, but you can still use HA
 * link:https://docs.embassy.dev/embassy-rp/[embassy-rp], for the Raspberry Pi RP2040 microcontroller.
 * link:https://github.com/esp-rs[esp-rs], for the Espressif Systems ESP32 series of chips.
 * link:https://github.com/ch32-rs/ch32-hal[ch32-hal], for the WCH 32-bit RISC-V(CH32V) series of chips.
+* link:https://github.com/hpmicro/hpm-hal[hpm-hal], for all HPMicro microcontroller families.
 
 NOTE: A common question is if one can use the Embassy HALs standalone. Yes, it is possible! There are no dependency on the executor within the HALs. You can even use them without async,
 as they implement both the link:https://github.com/rust-embedded/embedded-hal[Embedded HAL] blocking and async traits.


### PR DESCRIPTION
Add [hpm-hal](https://github.com/hpmicro/hpm-hal) to HAL list, support for HPMicro's 32-bit RISC-V microcontrollers.

Supported chips and peripherals are listed at <https://github.com/hpmicro/hpm-hal>.

An stm32-data clone for HPMicro chips is at <https://github.com/hpmicro/hpm-data>.





