### PR TITLE
Bump rand core to 0.9.0

### DIFF
--- a/embassy-nrf/Cargo.toml
+++ b/embassy-nrf/Cargo.toml
@@ -155,7 +155,7 @@ log = { version = "0.4.14", optional = true }
 cortex-m-rt = ">=0.6.15,<0.8"
 cortex-m = "0.7.6"
 critical-section = "1.1"
-rand_core = "0.6.3"
+rand_core = "0.9.0-alpha.2"
 fixed = "1.10.0"
 embedded-storage = "0.3.1"
 embedded-storage-async = "0.4.1"

--- a/embassy-rp/Cargo.toml
+++ b/embassy-rp/Cargo.toml
@@ -128,7 +128,7 @@ embedded-io = { version = "0.6.1" }
 embedded-io-async = { version = "0.6.1" }
 embedded-storage = { version = "0.3" }
 embedded-storage-async = { version = "0.4.1" }
-rand_core = "0.6.4"
+rand_core = "0.9.0-alpha.2"
 fixed = "1.23.1"
 
 rp-pac = { git = "https://github.com/embassy-rs/rp-pac.git", rev = "a7f42d25517f7124ad3b4ed492dec8b0f50a0e6c", feature = ["rt"] }

--- a/embassy-stm32/Cargo.toml
+++ b/embassy-stm32/Cargo.toml
@@ -68,7 +68,7 @@ log = { version = "0.4.14", optional = true }
 cortex-m-rt = ">=0.6.15,<0.8"
 cortex-m = "0.7.6"
 futures-util = { version = "0.3.30", default-features = false }
-rand_core = "0.6.3"
+rand_core = "0.9.0-alpha.2"
 sdio-host = "0.5.0"
 critical-section = "1.1"
 #stm32-metapac = { version = "15" }

--- a/examples/nrf-rtos-trace/Cargo.toml
+++ b/examples/nrf-rtos-trace/Cargo.toml
@@ -23,7 +23,7 @@ embassy-nrf = { version = "0.2.0", path = "../../embassy-nrf", features = ["nrf5
 cortex-m = { version = "0.7.6", features = ["inline-asm", "critical-section-single-core"] }
 cortex-m-rt = "0.7.0"
 panic-probe = { version = "0.3" }
-rand = { version = "0.8.4", default-features = false }
+rand = { version = "0.9.0-alpha.2", default-features = false }
 serde = { version = "1.0.136", default-features = false }
 rtos-trace = "0.1.3"
 systemview-target = { version = "0.1.2", features = ["callbacks-app", "callbacks-os", "log", "cortex-m"] }

--- a/examples/nrf52840/Cargo.toml
+++ b/examples/nrf52840/Cargo.toml
@@ -25,7 +25,7 @@ static_cell = { version = "2" }
 cortex-m = { version = "0.7.6", features = ["inline-asm", "critical-section-single-core"] }
 cortex-m-rt = "0.7.0"
 panic-probe = { version = "0.3", features = ["print-defmt"] }
-rand = { version = "0.8.4", default-features = false }
+rand = { version = "0.9.0-alpha.2", default-features = false }
 embedded-storage = "0.3.1"
 usbd-hid = "0.8.1"
 serde = { version = "1.0.136", default-features = false }

--- a/examples/nrf5340/Cargo.toml
+++ b/examples/nrf5340/Cargo.toml
@@ -21,7 +21,7 @@ static_cell = "2"
 cortex-m = { version = "0.7.6", features = ["inline-asm", "critical-section-single-core"] }
 cortex-m-rt = "0.7.0"
 panic-probe = { version = "0.3", features = ["print-defmt"] }
-rand = { version = "0.8.4", default-features = false }
+rand = { version = "0.9.0-alpha.2", default-features = false }
 embedded-storage = "0.3.1"
 usbd-hid = "0.8.1"
 serde = { version = "1.0.136", default-features = false }

--- a/examples/rp/Cargo.toml
+++ b/examples/rp/Cargo.toml
@@ -56,7 +56,7 @@ portable-atomic = { version = "1.5", features = ["critical-section"] }
 log = "0.4"
 pio-proc = "0.2"
 pio = "0.2.1"
-rand = { version = "0.8.5", default-features = false }
+rand = { version = "0.9.0-alpha.2", default-features = false }
 embedded-sdmmc = "0.7.0"
 
 bt-hci = { version = "0.1.0", default-features = false, features = ["defmt"] }

--- a/examples/rp23/Cargo.toml
+++ b/examples/rp23/Cargo.toml
@@ -56,7 +56,7 @@ portable-atomic = { version = "1.5", features = ["critical-section"] }
 log = "0.4"
 pio-proc = "0.2"
 pio = "0.2.1"
-rand = { version = "0.8.5", default-features = false }
+rand = { version = "0.9.0-alpha.2", default-features = false }
 embedded-sdmmc = "0.7.0"
 
 bt-hci = { version = "0.1.0", default-features = false, features = ["defmt"] }

--- a/examples/stm32f7/Cargo.toml
+++ b/examples/stm32f7/Cargo.toml
@@ -24,7 +24,7 @@ embedded-hal = "0.2.6"
 panic-probe = { version = "0.3", features = ["print-defmt"] }
 heapless = { version = "0.8", default-features = false }
 nb = "1.0.0"
-rand_core = "0.6.3"
+rand_core = "0.9.0-alpha.2"
 critical-section = "1.1"
 embedded-storage = "0.3.1"
 static_cell = "2"

--- a/examples/stm32h5/Cargo.toml
+++ b/examples/stm32h5/Cargo.toml
@@ -26,7 +26,7 @@ embedded-io-async = { version = "0.6.1" }
 embedded-nal-async = { version = "0.7.1" }
 panic-probe = { version = "0.3", features = ["print-defmt"] }
 heapless = { version = "0.8", default-features = false }
-rand_core = "0.6.3"
+rand_core = "0.9.0-alpha.2"
 critical-section = "1.1"
 micromath = "2.0.0"
 stm32-fmc = "0.3.0"

--- a/examples/stm32h7/Cargo.toml
+++ b/examples/stm32h7/Cargo.toml
@@ -27,7 +27,7 @@ embedded-nal-async = { version = "0.7.1" }
 embedded-io-async = { version = "0.6.1" }
 panic-probe = { version = "0.3", features = ["print-defmt"] }
 heapless = { version = "0.8", default-features = false }
-rand_core = "0.6.3"
+rand_core = "0.9.0-alpha.2"
 critical-section = "1.1"
 micromath = "2.0.0"
 stm32-fmc = "0.3.0"

--- a/examples/stm32h755cm4/Cargo.toml
+++ b/examples/stm32h755cm4/Cargo.toml
@@ -27,7 +27,7 @@ embedded-nal-async = { version = "0.7.1" }
 embedded-io-async = { version = "0.6.1" }
 panic-probe = { version = "0.3", features = ["print-defmt"] }
 heapless = { version = "0.8", default-features = false }
-rand_core = "0.6.3"
+rand_core = "0.9.0-alpha.2"
 critical-section = "1.1"
 micromath = "2.0.0"
 stm32-fmc = "0.3.0"

--- a/examples/stm32l4/Cargo.toml
+++ b/examples/stm32l4/Cargo.toml
@@ -30,7 +30,7 @@ embedded-hal-bus = { version = "0.1", features = ["async"] }
 panic-probe = { version = "0.3", features = ["print-defmt"] }
 heapless = { version = "0.8", default-features = false }
 chrono = { version = "^0.4", default-features = false }
-rand = { version = "0.8.5", default-features = false }
+rand = { version = "0.9.0-alpha.2", default-features = false }
 static_cell = "2"
 
 micromath = "2.0.0"

--- a/examples/stm32l5/Cargo.toml
+++ b/examples/stm32l5/Cargo.toml
@@ -23,7 +23,7 @@ cortex-m = { version = "0.7.6", features = ["inline-asm", "critical-section-sing
 cortex-m-rt = "0.7.0"
 embedded-hal = "0.2.6"
 heapless = { version = "0.8", default-features = false }
-rand_core = { version = "0.6.3", default-features = false }
+rand_core = { version = "0.9.0-alpha.2", default-features = false }
 embedded-io-async = { version = "0.6.1" }
 static_cell = "2"
 

--- a/tests/rp/Cargo.toml
+++ b/tests/rp/Cargo.toml
@@ -35,7 +35,7 @@ static_cell = "2"
 portable-atomic = { version = "1.5", features = ["critical-section"] }
 pio = "0.2"
 pio-proc = "0.2"
-rand = { version = "0.8.5", default-features = false }
+rand = { version = "0.9.0-alpha.2", default-features = false }
 
 [profile.dev]
 debug = 2

--- a/tests/stm32/Cargo.toml
+++ b/tests/stm32/Cargo.toml
@@ -79,8 +79,8 @@ embedded-hal-async = { version = "1.0" }
 embedded-can = { version = "0.4" }
 micromath = "2.0.0"
 panic-probe = { version = "0.3.0", features = ["print-defmt"] }
-rand_core = { version = "0.6", default-features = false }
-rand_chacha = { version = "0.3", default-features = false }
+rand_core = { version = "0.9.0-alpha.2", default-features = false }
+rand_chacha = { version = "0.9.0-alpha.2", default-features = false }
 static_cell = "2"
 portable-atomic = { version = "1.5", features = [] }
 


### PR DESCRIPTION
A draft update of rand rand_core and rand_chacha to 0.9.0, it's a draft since 0.9.0 is still at `0.9.0-alpha.2`. Implemented `TryRngCore` to preserve `try_fill_bytes` API.