### PR TITLE
stm32/spi: issue correct DMA word length when reading to prevent hang

### DIFF
--- a/embassy-stm32/src/spi/mod.rs
+++ b/embassy-stm32/src/spi/mod.rs
@@ -783,7 +783,7 @@ impl<'d> Spi<'d, Async> {
         let rx_f = unsafe { self.rx_dma.as_mut().unwrap().read(rx_src, data, Default::default()) };
 
         let tx_dst = self.info.regs.tx_ptr();
-        let clock_byte = 0x00u8;
+        let clock_byte = W::default();
         let tx_f = unsafe {
             self.tx_dma
                 .as_mut()
@@ -1195,7 +1195,7 @@ trait SealedWord {
 
 /// Word sizes usable for SPI.
 #[allow(private_bounds)]
-pub trait Word: word::Word + SealedWord {}
+pub trait Word: word::Word + SealedWord + Default {}
 
 macro_rules! impl_word {
     ($T:ty, $config:expr) => {


### PR DESCRIPTION
Currently, when calling read() of the SPI bus, DMA always transmits u8 for the clocking bit, which will cause bus hang if SPI transfer size > 8bit. Use matching word size for TX DMA instead.

Tested on STM32G431CBU6.

A small example to reproduce this problem:

```rust
    let mut spi_config = spi::Config::default();
    spi_config.frequency = Hertz(1_000_000);
    spi_config.mode = MODE_0;
    let mut my_spi = spi::Spi::new(
        p.SPI2, p.PB13, p.PB15, p.PB14, p.DMA1_CH5, p.DMA1_CH4, spi_config,
    );

    loop {
        let mut buf = [0u16; 2];
        my_spi.read(&mut buf).await.unwrap();
        Timer::after_millis(300).await;
    }
```