### PR TITLE
Fix return value of `fdcan` `write`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ Cargo.lock
 third_party
 /Cargo.toml
 out/
+.zed

--- a/embassy-stm32/src/can/fd/peripheral.rs
+++ b/embassy-stm32/src/can/fd/peripheral.rs
@@ -200,7 +200,7 @@ impl Registers {
             if header_reg.rtr().bit() {
                 F::new_remote(id, len as usize)
             } else {
-                F::new(id, &data)
+                F::new(id, &data[0..(len as usize)])
             }
         } else {
             // Abort request failed because the frame was already sent (or being sent) on


### PR DESCRIPTION
Currently the return value of `write` is broken, it never returns the previous dequeued frame even when present.

This happens because a slice of length 64 is always passed to Frame::new from within the `abort_pending_mailbox` function, causing `Frame::new` to return None.

The fix is to take a subslice of length `data_length` and pass that to `Frame::new`.