### PR TITLE
rp23: Disable pad isolation on PWM A pins.

### DIFF
--- a/embassy-rp/src/pwm.rs
+++ b/embassy-rp/src/pwm.rs
@@ -106,6 +106,12 @@ impl<'d> Pwm<'d> {
 
         if let Some(pin) = &a {
             pin.gpio().ctrl().write(|w| w.set_funcsel(4));
+            pin.pad_ctrl().modify(|w| {
+                #[cfg(feature = "_rp235x")]
+                w.set_iso(false);
+                w.set_pue(b_pull == Pull::Up);
+                w.set_pde(b_pull == Pull::Down);
+            });
         }
         if let Some(pin) = &b {
             pin.gpio().ctrl().write(|w| w.set_funcsel(4));

--- a/embassy-rp/src/pwm.rs
+++ b/embassy-rp/src/pwm.rs
@@ -106,11 +106,9 @@ impl<'d> Pwm<'d> {
 
         if let Some(pin) = &a {
             pin.gpio().ctrl().write(|w| w.set_funcsel(4));
+            #[cfg(feature = "_rp235x")]
             pin.pad_ctrl().modify(|w| {
-                #[cfg(feature = "_rp235x")]
                 w.set_iso(false);
-                w.set_pue(b_pull == Pull::Up);
-                w.set_pde(b_pull == Pull::Down);
             });
         }
         if let Some(pin) = &b {


### PR DESCRIPTION
Also fixes minor bug for 2040 where A pins didn't have their pull up/down enabled.

Fixes #3370 