### PR TITLE
Add the ability to reuse USB endpoints for multiple alternative functions

### DIFF
--- a/embassy-nrf/src/usb/mod.rs
+++ b/embassy-nrf/src/usb/mod.rs
@@ -14,10 +14,8 @@ use cortex_m::peripheral::NVIC;
 use embassy_hal_internal::{into_ref, PeripheralRef};
 use embassy_sync::waitqueue::AtomicWaker;
 use embassy_usb_driver as driver;
-use embassy_usb_driver::{
-    Direction, EndpointAddress, EndpointError, EndpointInfo, EndpointType, Event, SynchronizationType, Unsupported,
-    UsageType,
-};
+use embassy_usb_driver::{Direction, EndpointAddress, EndpointError, EndpointInfo, EndpointType, Event, Unsupported};
+pub use embassy_usb_driver::{SynchronizationType, UsageType};
 use pac::usbd::RegisterBlock;
 
 use self::vbus_detect::VbusDetect;

--- a/embassy-nrf/src/usb/mod.rs
+++ b/embassy-nrf/src/usb/mod.rs
@@ -171,10 +171,14 @@ impl<'d, T: Instance, V: VbusDetect + 'd> driver::Driver<'d> for Driver<'d, T, V
     }
 
     fn grow_endpoint_in_buffer(&mut self, ep: &mut Self::EndpointIn, new_max_packet_size: u16) {
+        let _ = new_max_packet_size;
+        let _ = ep;
         warn!("Not implemented yet!!!");
     }
 
     fn grow_endpoint_out_buffer(&mut self, ep: &mut Self::EndpointOut, new_max_packet_size: u16) {
+        let _ = new_max_packet_size;
+        let _ = ep;
         warn!("Not implemented yet!!!");
     }
 }
@@ -318,18 +322,26 @@ impl<'d, T: Instance, V: VbusDetect> driver::Bus for Bus<'d, T, V> {
     }
 
     fn endpoint_set_buffersize(&mut self, ep_addr: EndpointAddress, buf_size: u16) {
+        let _ = ep_addr;
+        let _ = buf_size;
         warn!("Not implemented yet!!!");
     }
 
     fn endpoint_set_sync_type(&mut self, ep_addr: EndpointAddress, synchronization_type: SynchronizationType) {
+        let _ = ep_addr;
+        let _ = synchronization_type;
         warn!("Not implemented yet!!!");
     }
 
     fn endpoint_set_usage_type(&mut self, ep_addr: EndpointAddress, usage_type: UsageType) {
+        let _ = ep_addr;
+        let _ = usage_type;
         warn!("Not implemented yet!!!");
     }
 
     fn endpoint_set_type(&mut self, ep_addr: EndpointAddress, ep_type: EndpointType) {
+        let _ = ep_addr;
+        let _ = ep_type;
         warn!("Not implemented yet!!!");
     }
 

--- a/embassy-nrf/src/usb/mod.rs
+++ b/embassy-nrf/src/usb/mod.rs
@@ -306,6 +306,14 @@ impl<'d, T: Instance, V: VbusDetect> driver::Bus for Bus<'d, T, V> {
         }
     }
 
+    fn endpoint_set_buffersize(&mut self, ep_addr: EndpointAddress, buf_size: usize) {
+        todo!();
+    }
+
+    fn endpoint_set_type(&mut self, ep_addr: EndpointAddress, ep_type :EndpointType) {
+        todo!();
+    }
+
     fn endpoint_set_enabled(&mut self, ep_addr: EndpointAddress, enabled: bool) {
         let regs = T::regs();
 

--- a/embassy-nrf/src/usb/mod.rs
+++ b/embassy-nrf/src/usb/mod.rs
@@ -14,7 +14,10 @@ use cortex_m::peripheral::NVIC;
 use embassy_hal_internal::{into_ref, PeripheralRef};
 use embassy_sync::waitqueue::AtomicWaker;
 use embassy_usb_driver as driver;
-use embassy_usb_driver::{Direction, EndpointAddress, EndpointError, EndpointInfo, EndpointType, Event, Unsupported};
+use embassy_usb_driver::{
+    Direction, EndpointAddress, EndpointError, EndpointInfo, EndpointType, Event, SynchronizationType, Unsupported,
+    UsageType,
+};
 use pac::usbd::RegisterBlock;
 
 use self::vbus_detect::VbusDetect;
@@ -166,6 +169,14 @@ impl<'d, T: Instance, V: VbusDetect + 'd> driver::Driver<'d> for Driver<'d, T, V
             },
         )
     }
+
+    fn grow_endpoint_in_buffer(&mut self, ep: &mut Self::EndpointIn, new_max_packet_size: u16) {
+        warn!("Not implemented yet!!!");
+    }
+
+    fn grow_endpoint_out_buffer(&mut self, ep: &mut Self::EndpointOut, new_max_packet_size: u16) {
+        warn!("Not implemented yet!!!");
+    }
 }
 
 /// USB bus.
@@ -307,11 +318,19 @@ impl<'d, T: Instance, V: VbusDetect> driver::Bus for Bus<'d, T, V> {
     }
 
     fn endpoint_set_buffersize(&mut self, ep_addr: EndpointAddress, buf_size: u16) {
-        todo!();
+        warn!("Not implemented yet!!!");
+    }
+
+    fn endpoint_set_sync_type(&mut self, ep_addr: EndpointAddress, synchronization_type: SynchronizationType) {
+        warn!("Not implemented yet!!!");
+    }
+
+    fn endpoint_set_usage_type(&mut self, ep_addr: EndpointAddress, usage_type: UsageType) {
+        warn!("Not implemented yet!!!");
     }
 
     fn endpoint_set_type(&mut self, ep_addr: EndpointAddress, ep_type: EndpointType) {
-        todo!();
+        warn!("Not implemented yet!!!");
     }
 
     fn endpoint_set_enabled(&mut self, ep_addr: EndpointAddress, enabled: bool) {

--- a/embassy-nrf/src/usb/mod.rs
+++ b/embassy-nrf/src/usb/mod.rs
@@ -306,11 +306,11 @@ impl<'d, T: Instance, V: VbusDetect> driver::Bus for Bus<'d, T, V> {
         }
     }
 
-    fn endpoint_set_buffersize(&mut self, ep_addr: EndpointAddress, buf_size: usize) {
+    fn endpoint_set_buffersize(&mut self, ep_addr: EndpointAddress, buf_size: u16) {
         todo!();
     }
 
-    fn endpoint_set_type(&mut self, ep_addr: EndpointAddress, ep_type :EndpointType) {
+    fn endpoint_set_type(&mut self, ep_addr: EndpointAddress, ep_type: EndpointType) {
         todo!();
     }
 

--- a/embassy-rp/src/usb.rs
+++ b/embassy-rp/src/usb.rs
@@ -205,6 +205,7 @@ impl<'d, T: Instance> Driver<'d, T> {
             return Err(EndpointAllocError);
         }
         self.ep_mem_free += len;
+        self.ep_mem_curr_addr = addr;
 
         let buf = EndpointBuffer {
             addr,
@@ -356,19 +357,21 @@ impl<'d, T: Instance> driver::Driver<'d> for Driver<'d, T> {
     }
 
     fn grow_endpoint_in_buffer(&mut self, ep: &mut Self::EndpointIn, new_size: u16) {
-        if self.ep_mem_curr_addr - ep.buf.len != ep.buf.addr {
+        if self.ep_mem_curr_addr != ep.buf.addr {
             panic!("Can only grow buffer if it's the last allocated buffer!");
         }
-        self.ep_mem_curr_addr = self.ep_mem_curr_addr - ep.buf.len + new_size;
+        self.ep_mem_free = self.ep_mem_curr_addr - ep.buf.len / 4 + new_size / 4;
         ep.buf.grow(new_size);
+        ep.info.max_packet_size = ep.buf.len;
     }
 
     fn grow_endpoint_out_buffer(&mut self, ep: &mut Self::EndpointOut, new_size: u16) {
-        if self.ep_mem_curr_addr - ep.buf.len != ep.buf.addr {
+        if self.ep_mem_curr_addr != ep.buf.addr {
             panic!("Can only grow buffer if it's the last allocated buffer!");
         }
-        self.ep_mem_curr_addr = self.ep_mem_curr_addr - ep.buf.len + new_size;
+        self.ep_mem_free = self.ep_mem_curr_addr - ep.buf.len / 4 + new_size / 4;
         ep.buf.grow(new_size);
+        ep.info.max_packet_size = ep.buf.len;
     }
 }
 

--- a/embassy-rp/src/usb.rs
+++ b/embassy-rp/src/usb.rs
@@ -6,16 +6,15 @@ use core::sync::atomic::{compiler_fence, Ordering};
 use core::task::Poll;
 
 use embassy_sync::waitqueue::AtomicWaker;
-use embassy_usb_driver::{self as driver};
 use embassy_usb_driver::{
-    Direction, EndpointAddress, EndpointAllocError, EndpointError, EndpointInfo, EndpointType, Event, Unsupported,
+    self as driver, Direction, EndpointAddress, EndpointAllocError, EndpointError, EndpointInfo, EndpointType, Event,
+    Unsupported,
 };
 pub use embassy_usb_driver::{SynchronizationType, UsageType};
 
 use crate::interrupt::typelevel::{Binding, Interrupt};
-use crate::{interrupt, pac, peripherals, Peripheral, RegExt};
-
 use crate::pac::usb_dpram::vals::EpControlEndpointType;
+use crate::{interrupt, pac, peripherals, Peripheral, RegExt};
 
 trait SealedInstance {
     fn regs() -> crate::pac::usb::Usb;

--- a/embassy-rp/src/usb.rs
+++ b/embassy-rp/src/usb.rs
@@ -449,6 +449,47 @@ impl<'d, T: Instance> driver::Bus for Bus<'d, T> {
         ctrl.read().stall()
     }
 
+    fn endpoint_set_buffersize(&mut self, ep_addr: EndpointAddress, buf_size: usize) {
+        todo!();
+        /*
+        trace!("set_buffersize {:?} {:?}", ep_addr, buf_size);
+        if ep_addr.index() == 0 {
+            return;
+        }
+
+        let n = ep_addr.index();
+        match ep_addr.direction() {
+            Direction::In => {
+                T::dpram().ep_in_control(n - 1).modify(|w| w.set_buffersize(buf_size));
+            }
+            Direction::Out => {
+                T::dpram().ep_out_control(n - 1).modify(|w| w.set_buffersize(buf_size));
+            }
+        }
+        */
+    }
+
+    fn endpoint_set_type(&mut self, ep_addr: EndpointAddress, ep_type: EndpointType) {
+        todo!();
+
+        /*
+        trace!("set_buffersize {:?} {:?}", ep_addr, ep_type);
+        if ep_addr.index() == 0 {
+            return;
+        }
+
+        let n = ep_addr.index();
+        match ep_addr.direction() {
+            Direction::In => {
+                T::dpram().ep_in_control(n - 1).modify(|w| w.endpoint_type(ep_type));
+            }
+            Direction::Out => {
+                T::dpram().ep_out_control(n - 1).modify(|w| w.endpoint_type(ep_type));
+            }
+        }
+        */
+    }
+
     fn endpoint_set_enabled(&mut self, ep_addr: EndpointAddress, enabled: bool) {
         trace!("set_enabled {:?} {}", ep_addr, enabled);
         if ep_addr.index() == 0 {

--- a/embassy-rp/src/usb.rs
+++ b/embassy-rp/src/usb.rs
@@ -10,6 +10,7 @@ use embassy_usb_driver::{self as driver};
 use embassy_usb_driver::{
     Direction, EndpointAddress, EndpointAllocError, EndpointError, EndpointInfo, EndpointType, Event, Unsupported,
 };
+pub use embassy_usb_driver::{SynchronizationType, UsageType};
 
 use crate::interrupt::typelevel::{Binding, Interrupt};
 use crate::{interrupt, pac, peripherals, Peripheral, RegExt};
@@ -493,17 +494,13 @@ impl<'d, T: Instance> driver::Bus for Bus<'d, T> {
         }
     }
 
-    fn endpoint_set_sync_type(
-        &mut self,
-        ep_addr: EndpointAddress,
-        synchronization_type: embassy_usb_driver::SynchronizationType,
-    ) {
+    fn endpoint_set_sync_type(&mut self, ep_addr: EndpointAddress, synchronization_type: SynchronizationType) {
         let _ = ep_addr;
         let _ = synchronization_type;
         // Not hardware related on rp2040
     }
 
-    fn endpoint_set_usage_type(&mut self, ep_addr: EndpointAddress, usage_type: embassy_usb_driver::UsageType) {
+    fn endpoint_set_usage_type(&mut self, ep_addr: EndpointAddress, usage_type: UsageType) {
         let _ = usage_type;
         let _ = ep_addr;
         // Not hardware related on rp2040

--- a/embassy-stm32/src/usb/otg.rs
+++ b/embassy-stm32/src/usb/otg.rs
@@ -1,7 +1,9 @@
 use core::marker::PhantomData;
 
 use embassy_hal_internal::{into_ref, Peripheral};
-use embassy_usb_driver::{EndpointAddress, EndpointAllocError, EndpointType, Event, SynchronizationType, Unsupported, UsageType};
+use embassy_usb_driver::{
+    EndpointAddress, EndpointAllocError, EndpointType, Event, SynchronizationType, Unsupported, UsageType,
+};
 use embassy_usb_synopsys_otg::otg_v1::vals::Dspd;
 use embassy_usb_synopsys_otg::otg_v1::Otg;
 pub use embassy_usb_synopsys_otg::Config;
@@ -236,10 +238,14 @@ impl<'d, T: Instance> embassy_usb_driver::Driver<'d> for Driver<'d, T> {
     }
 
     fn grow_endpoint_in_buffer(&mut self, ep: &mut Self::EndpointIn, new_max_packet_size: u16) {
+        let _ = new_max_packet_size;
+        let _ = ep;
         warn!("Not implemented yet!!!");
     }
 
     fn grow_endpoint_out_buffer(&mut self, ep: &mut Self::EndpointOut, new_max_packet_size: u16) {
+        let _ = new_max_packet_size;
+        let _ = ep;
         warn!("Not implemented yet!!!");
     }
 }
@@ -329,18 +335,26 @@ impl<'d, T: Instance> embassy_usb_driver::Bus for Bus<'d, T> {
     }
 
     fn endpoint_set_buffersize(&mut self, ep_addr: EndpointAddress, buf_size: u16) {
+        let _ = ep_addr;
+        let _ = buf_size;
         warn!("Not implemented yet!!!");
     }
 
     fn endpoint_set_sync_type(&mut self, ep_addr: EndpointAddress, synchronization_type: SynchronizationType) {
+        let _ = ep_addr;
+        let _ = synchronization_type;
         warn!("Not implemented yet!!!");
     }
 
     fn endpoint_set_usage_type(&mut self, ep_addr: EndpointAddress, usage_type: UsageType) {
+        let _ = ep_addr;
+        let _ = usage_type;
         warn!("Not implemented yet!!!");
     }
 
     fn endpoint_set_type(&mut self, ep_addr: EndpointAddress, ep_type: EndpointType) {
+        let _ = ep_addr;
+        let _ = ep_type;
         warn!("Not implemented yet!!!");
     }
 

--- a/embassy-stm32/src/usb/otg.rs
+++ b/embassy-stm32/src/usb/otg.rs
@@ -1,9 +1,8 @@
 use core::marker::PhantomData;
 
 use embassy_hal_internal::{into_ref, Peripheral};
-use embassy_usb_driver::{
-    EndpointAddress, EndpointAllocError, EndpointType, Event, SynchronizationType, Unsupported, UsageType,
-};
+use embassy_usb_driver::{EndpointAddress, EndpointAllocError, EndpointType, Event, Unsupported};
+pub use embassy_usb_driver::{SynchronizationType, UsageType};
 use embassy_usb_synopsys_otg::otg_v1::vals::Dspd;
 use embassy_usb_synopsys_otg::otg_v1::Otg;
 pub use embassy_usb_synopsys_otg::Config;

--- a/embassy-stm32/src/usb/otg.rs
+++ b/embassy-stm32/src/usb/otg.rs
@@ -1,7 +1,7 @@
 use core::marker::PhantomData;
 
 use embassy_hal_internal::{into_ref, Peripheral};
-use embassy_usb_driver::{EndpointAddress, EndpointAllocError, EndpointType, Event, Unsupported};
+use embassy_usb_driver::{EndpointAddress, EndpointAllocError, EndpointType, Event, SynchronizationType, Unsupported, UsageType};
 use embassy_usb_synopsys_otg::otg_v1::vals::Dspd;
 use embassy_usb_synopsys_otg::otg_v1::Otg;
 pub use embassy_usb_synopsys_otg::Config;
@@ -234,6 +234,14 @@ impl<'d, T: Instance> embassy_usb_driver::Driver<'d> for Driver<'d, T> {
             cp,
         )
     }
+
+    fn grow_endpoint_in_buffer(&mut self, ep: &mut Self::EndpointIn, new_max_packet_size: u16) {
+        warn!("Not implemented yet!!!");
+    }
+
+    fn grow_endpoint_out_buffer(&mut self, ep: &mut Self::EndpointOut, new_max_packet_size: u16) {
+        warn!("Not implemented yet!!!");
+    }
 }
 
 /// USB bus.
@@ -318,6 +326,22 @@ impl<'d, T: Instance> embassy_usb_driver::Bus for Bus<'d, T> {
 
     fn endpoint_is_stalled(&mut self, ep_addr: EndpointAddress) -> bool {
         self.inner.endpoint_is_stalled(ep_addr)
+    }
+
+    fn endpoint_set_buffersize(&mut self, ep_addr: EndpointAddress, buf_size: u16) {
+        warn!("Not implemented yet!!!");
+    }
+
+    fn endpoint_set_sync_type(&mut self, ep_addr: EndpointAddress, synchronization_type: SynchronizationType) {
+        warn!("Not implemented yet!!!");
+    }
+
+    fn endpoint_set_usage_type(&mut self, ep_addr: EndpointAddress, usage_type: UsageType) {
+        warn!("Not implemented yet!!!");
+    }
+
+    fn endpoint_set_type(&mut self, ep_addr: EndpointAddress, ep_type: EndpointType) {
+        warn!("Not implemented yet!!!");
     }
 
     fn endpoint_set_enabled(&mut self, ep_addr: EndpointAddress, enabled: bool) {

--- a/embassy-stm32/src/usb/usb.rs
+++ b/embassy-stm32/src/usb/usb.rs
@@ -519,6 +519,15 @@ impl<'d, T: Instance> driver::Driver<'d> for Driver<'d, T> {
             },
         )
     }
+
+    fn grow_endpoint_in_buffer(&mut self, ep: &mut Self::EndpointIn, new_max_packet_size: u16) {
+        warn!("Not implemented yet!!!");
+    }
+    
+
+    fn grow_endpoint_out_buffer(&mut self, ep: &mut Self::EndpointOut, new_max_packet_size: u16) {
+        warn!("Not implemented yet!!!");
+    }
 }
 
 /// USB bus.
@@ -643,11 +652,19 @@ impl<'d, T: Instance> driver::Bus for Bus<'d, T> {
     }
 
     fn endpoint_set_buffersize(&mut self, ep_addr: EndpointAddress, buf_size: u16) {
-        todo!();
+        warn!("Not implemented yet!!!");
+    }
+
+    fn endpoint_set_sync_type(&mut self, ep_addr: EndpointAddress, synchronization_type: SynchronizationType) {
+        warn!("Not implemented yet!!!");
+    }
+
+    fn endpoint_set_usage_type(&mut self, ep_addr: EndpointAddress, usage_type: UsageType) {
+        warn!("Not implemented yet!!!");
     }
 
     fn endpoint_set_type(&mut self, ep_addr: EndpointAddress, ep_type: EndpointType) {
-        todo!();
+        warn!("Not implemented yet!!!");
     }
 
     fn endpoint_set_enabled(&mut self, ep_addr: EndpointAddress, enabled: bool) {

--- a/embassy-stm32/src/usb/usb.rs
+++ b/embassy-stm32/src/usb/usb.rs
@@ -642,11 +642,11 @@ impl<'d, T: Instance> driver::Bus for Bus<'d, T> {
         }
     }
 
-    fn endpoint_set_buffersize(&mut self, ep_addr: EndpointAddress, buf_size: usize) {
+    fn endpoint_set_buffersize(&mut self, ep_addr: EndpointAddress, buf_size: u16) {
         todo!();
     }
 
-    fn endpoint_set_type(&mut self, ep_addr: EndpointAddress, ep_type :EndpointType) {
+    fn endpoint_set_type(&mut self, ep_addr: EndpointAddress, ep_type: EndpointType) {
         todo!();
     }
 

--- a/embassy-stm32/src/usb/usb.rs
+++ b/embassy-stm32/src/usb/usb.rs
@@ -521,11 +521,14 @@ impl<'d, T: Instance> driver::Driver<'d> for Driver<'d, T> {
     }
 
     fn grow_endpoint_in_buffer(&mut self, ep: &mut Self::EndpointIn, new_max_packet_size: u16) {
+        let _ = new_max_packet_size;
+        let _ = ep;
         warn!("Not implemented yet!!!");
     }
-    
 
     fn grow_endpoint_out_buffer(&mut self, ep: &mut Self::EndpointOut, new_max_packet_size: u16) {
+        let _ = new_max_packet_size;
+        let _ = ep;
         warn!("Not implemented yet!!!");
     }
 }
@@ -652,18 +655,26 @@ impl<'d, T: Instance> driver::Bus for Bus<'d, T> {
     }
 
     fn endpoint_set_buffersize(&mut self, ep_addr: EndpointAddress, buf_size: u16) {
+        let _ = ep_addr;
+        let _ = buf_size;
         warn!("Not implemented yet!!!");
     }
 
     fn endpoint_set_sync_type(&mut self, ep_addr: EndpointAddress, synchronization_type: SynchronizationType) {
+        let _ = ep_addr;
+        let _ = synchronization_type;
         warn!("Not implemented yet!!!");
     }
 
     fn endpoint_set_usage_type(&mut self, ep_addr: EndpointAddress, usage_type: UsageType) {
+        let _ = ep_addr;
+        let _ = usage_type;
         warn!("Not implemented yet!!!");
     }
 
     fn endpoint_set_type(&mut self, ep_addr: EndpointAddress, ep_type: EndpointType) {
+        let _ = ep_addr;
+        let _ = ep_type;
         warn!("Not implemented yet!!!");
     }
 

--- a/embassy-stm32/src/usb/usb.rs
+++ b/embassy-stm32/src/usb/usb.rs
@@ -642,6 +642,14 @@ impl<'d, T: Instance> driver::Bus for Bus<'d, T> {
         }
     }
 
+    fn endpoint_set_buffersize(&mut self, ep_addr: EndpointAddress, buf_size: usize) {
+        todo!();
+    }
+
+    fn endpoint_set_type(&mut self, ep_addr: EndpointAddress, ep_type :EndpointType) {
+        todo!();
+    }
+
     fn endpoint_set_enabled(&mut self, ep_addr: EndpointAddress, enabled: bool) {
         trace!("set_enabled {:x} {}", ep_addr, enabled);
         // This can race, so do a retry loop.

--- a/embassy-stm32/src/usb/usb.rs
+++ b/embassy-stm32/src/usb/usb.rs
@@ -11,6 +11,7 @@ use embassy_usb_driver as driver;
 use embassy_usb_driver::{
     Direction, EndpointAddress, EndpointAllocError, EndpointError, EndpointInfo, EndpointType, Event, Unsupported,
 };
+pub use embassy_usb_driver::{SynchronizationType, UsageType};
 
 use crate::pac::usb::regs;
 use crate::pac::usb::vals::{EpType, Stat};

--- a/embassy-usb-driver/src/lib.rs
+++ b/embassy-usb-driver/src/lib.rs
@@ -185,6 +185,12 @@ pub trait Bus {
     /// return it. See [`Event`] for the list of events this method should return.
     async fn poll(&mut self) -> Event;
 
+    /// Change buffersize of endpoint
+    fn endpoint_set_buffersize(&mut self, ep_addr: EndpointAddress, buf_size: usize);
+
+    /// Change type of endpoint
+    fn endpoint_set_type(&mut self, ep_addr: EndpointAddress, ep_type :EndpointType);
+
     /// Enable or disable an endpoint.
     fn endpoint_set_enabled(&mut self, ep_addr: EndpointAddress, enabled: bool);
 

--- a/embassy-usb-driver/src/lib.rs
+++ b/embassy-usb-driver/src/lib.rs
@@ -186,10 +186,10 @@ pub trait Bus {
     async fn poll(&mut self) -> Event;
 
     /// Change buffersize of endpoint
-    fn endpoint_set_buffersize(&mut self, ep_addr: EndpointAddress, buf_size: usize);
+    fn endpoint_set_buffersize(&mut self, ep_addr: EndpointAddress, buf_size: u16);
 
     /// Change type of endpoint
-    fn endpoint_set_type(&mut self, ep_addr: EndpointAddress, ep_type :EndpointType);
+    fn endpoint_set_type(&mut self, ep_addr: EndpointAddress, ep_type: EndpointType);
 
     /// Enable or disable an endpoint.
     fn endpoint_set_enabled(&mut self, ep_addr: EndpointAddress, enabled: bool);

--- a/embassy-usb-driver/src/lib.rs
+++ b/embassy-usb-driver/src/lib.rs
@@ -35,6 +35,40 @@ pub enum EndpointType {
     Interrupt = 0b11,
 }
 
+/// USB endpoint synchronization type. The values of this enum can be directly
+/// cast into `u8` to get the bmAttributes synchronization type bits.
+/// Values other than `NoSynchronization` are only allowed on isochronous endpoints.
+#[repr(u8)]
+#[derive(Copy, Clone, Eq, PartialEq, Debug)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+pub enum SynchronizationType {
+    /// No synchronization is used.
+    NoSynchronization = 0b00,
+    /// Unsynchronized, although sinks provide data rate feedback.
+    Asynchronous = 0b01,
+    /// Synchronized using feedback or feedforward data rate information.
+    Adaptive = 0b10,
+    /// Synchronized to the USB’s SOF.
+    Synchronous = 0b11,
+}
+
+/// USB endpoint usage type. The values of this enum can be directly cast into
+/// `u8` to get the bmAttributes usage type bits.
+/// Values other than `DataEndpoint` are only allowed on isochronous endpoints.
+#[repr(u8)]
+#[derive(Copy, Clone, Eq, PartialEq, Debug)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+pub enum UsageType {
+    /// Use the endpoint for regular data transfer.
+    DataEndpoint = 0b00,
+    /// Endpoint conveys explicit feedback information for one or more data endpoints.
+    FeedbackEndpoint = 0b01,
+    /// A data endpoint that also serves as an implicit feedback endpoint for one or more data endpoints.
+    ImplicitFeedbackDataEndpoint = 0b10,
+    /// Reserved usage type.
+    Reserved = 0b11,
+}
+
 /// Type-safe endpoint address.
 #[derive(Debug, Clone, Copy, Eq, PartialEq)]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]

--- a/embassy-usb-driver/src/lib.rs
+++ b/embassy-usb-driver/src/lib.rs
@@ -35,6 +35,18 @@ pub enum EndpointType {
     Interrupt = 0b11,
 }
 
+impl From<u8> for EndpointType {
+    fn from(value: u8) -> Self {
+        match value {
+            0b00 => Self::Control,
+            0b01 => Self::Isochronous,
+            0b10 => Self::Bulk,
+            0b11 => Self::Interrupt,
+            4_u8..=u8::MAX => unreachable!(),
+        }
+    }
+}
+
 /// USB endpoint synchronization type. The values of this enum can be directly
 /// cast into `u8` to get the bmAttributes synchronization type bits.
 /// Values other than `NoSynchronization` are only allowed on isochronous endpoints.
@@ -52,6 +64,18 @@ pub enum SynchronizationType {
     Synchronous = 0b11,
 }
 
+impl From<u8> for SynchronizationType {
+    fn from(value: u8) -> Self {
+        match value {
+            0b00 => Self::NoSynchronization,
+            0b01 => Self::Asynchronous,
+            0b10 => Self::Adaptive,
+            0b11 => Self::Synchronous,
+            4_u8..=u8::MAX => unreachable!(),
+        }
+    }
+}
+
 /// USB endpoint usage type. The values of this enum can be directly cast into
 /// `u8` to get the bmAttributes usage type bits.
 /// Values other than `DataEndpoint` are only allowed on isochronous endpoints.
@@ -67,6 +91,18 @@ pub enum UsageType {
     ImplicitFeedbackDataEndpoint = 0b10,
     /// Reserved usage type.
     Reserved = 0b11,
+}
+
+impl From<u8> for UsageType {
+    fn from(value: u8) -> Self {
+        match value {
+            0b00 => Self::DataEndpoint,
+            0b01 => Self::FeedbackEndpoint,
+            0b10 => Self::ImplicitFeedbackDataEndpoint,
+            0b11 => Self::Reserved,
+            4_u8..=u8::MAX => unreachable!(),
+        }
+    }
 }
 
 /// Type-safe endpoint address.

--- a/embassy-usb-driver/src/lib.rs
+++ b/embassy-usb-driver/src/lib.rs
@@ -236,6 +236,12 @@ pub trait Driver<'a> {
     /// This consumes the `Driver` instance, so it's no longer possible to allocate more
     /// endpoints.
     fn start(self, control_max_packet_size: u16) -> (Self::Bus, Self::ControlPipe);
+
+    /// Grows the endpoint buffer to the maximum size necessary to service all associated enpoint descriptors to the point of calling it
+    fn grow_endpoint_in_buffer(&mut self, ep: &mut Self::EndpointIn, new_size: u16);
+
+    /// Grows the endpoint buffer to the maximum size necessary to service all associated enpoint descriptors to the point of calling it
+    fn grow_endpoint_out_buffer(&mut self, ep: &mut Self::EndpointOut, new_size: u16);
 }
 
 /// USB bus trait.
@@ -254,6 +260,12 @@ pub trait Bus {
     /// This method should asynchronously wait for an event to happen, then
     /// return it. See [`Event`] for the list of events this method should return.
     async fn poll(&mut self) -> Event;
+
+    /// Change buffersize of endpoint
+    fn endpoint_set_sync_type(&mut self, ep_addr: EndpointAddress, synchronization_type: SynchronizationType);
+
+    /// Change buffersize of endpoint
+    fn endpoint_set_usage_type(&mut self, ep_addr: EndpointAddress, usage_type: UsageType);
 
     /// Change buffersize of endpoint
     fn endpoint_set_buffersize(&mut self, ep_addr: EndpointAddress, buf_size: u16);

--- a/embassy-usb-synopsys-otg/src/lib.rs
+++ b/embassy-usb-synopsys-otg/src/lib.rs
@@ -14,7 +14,8 @@ use core::task::Poll;
 
 use embassy_sync::waitqueue::AtomicWaker;
 use embassy_usb_driver::{
-    Bus as _, Direction, EndpointAddress, EndpointAllocError, EndpointError, EndpointIn, EndpointInfo, EndpointOut, EndpointType, Event, SynchronizationType, Unsupported, UsageType
+    Bus as _, Direction, EndpointAddress, EndpointAllocError, EndpointError, EndpointIn, EndpointInfo, EndpointOut,
+    EndpointType, Event, SynchronizationType, Unsupported, UsageType,
 };
 
 pub mod otg_v1;
@@ -497,10 +498,14 @@ impl<'d, const MAX_EP_COUNT: usize> embassy_usb_driver::Driver<'d> for Driver<'d
     }
 
     fn grow_endpoint_in_buffer(&mut self, ep: &mut Self::EndpointIn, new_max_packet_size: u16) {
+        let _ = new_max_packet_size;
+        let _ = ep;
         warn!("Not implemented yet!!!");
     }
 
     fn grow_endpoint_out_buffer(&mut self, ep: &mut Self::EndpointOut, new_max_packet_size: u16) {
+        let _ = new_max_packet_size;
+        let _ = ep;
         warn!("Not implemented yet!!!");
     }
 }
@@ -889,18 +894,26 @@ impl<'d, const MAX_EP_COUNT: usize> embassy_usb_driver::Bus for Bus<'d, MAX_EP_C
     }
 
     fn endpoint_set_buffersize(&mut self, ep_addr: EndpointAddress, buf_size: u16) {
+        let _ = ep_addr;
+        let _ = buf_size;
         warn!("Not implemented yet!!!");
     }
 
     fn endpoint_set_sync_type(&mut self, ep_addr: EndpointAddress, synchronization_type: SynchronizationType) {
+        let _ = ep_addr;
+        let _ = synchronization_type;
         warn!("Not implemented yet!!!");
     }
 
     fn endpoint_set_usage_type(&mut self, ep_addr: EndpointAddress, usage_type: UsageType) {
+        let _ = ep_addr;
+        let _ = usage_type;
         warn!("Not implemented yet!!!");
     }
 
     fn endpoint_set_type(&mut self, ep_addr: EndpointAddress, ep_type: EndpointType) {
+        let _ = ep_addr;
+        let _ = ep_type;
         warn!("Not implemented yet!!!");
     }
 

--- a/embassy-usb-synopsys-otg/src/lib.rs
+++ b/embassy-usb-synopsys-otg/src/lib.rs
@@ -14,8 +14,7 @@ use core::task::Poll;
 
 use embassy_sync::waitqueue::AtomicWaker;
 use embassy_usb_driver::{
-    Bus as _, Direction, EndpointAddress, EndpointAllocError, EndpointError, EndpointIn, EndpointInfo, EndpointOut,
-    EndpointType, Event, Unsupported,
+    Bus as _, Direction, EndpointAddress, EndpointAllocError, EndpointError, EndpointIn, EndpointInfo, EndpointOut, EndpointType, Event, SynchronizationType, Unsupported, UsageType
 };
 
 pub mod otg_v1;
@@ -496,6 +495,14 @@ impl<'d, const MAX_EP_COUNT: usize> embassy_usb_driver::Driver<'d> for Driver<'d
             },
         )
     }
+
+    fn grow_endpoint_in_buffer(&mut self, ep: &mut Self::EndpointIn, new_max_packet_size: u16) {
+        warn!("Not implemented yet!!!");
+    }
+
+    fn grow_endpoint_out_buffer(&mut self, ep: &mut Self::EndpointOut, new_max_packet_size: u16) {
+        warn!("Not implemented yet!!!");
+    }
 }
 
 /// USB bus.
@@ -879,6 +886,22 @@ impl<'d, const MAX_EP_COUNT: usize> embassy_usb_driver::Bus for Bus<'d, MAX_EP_C
             Direction::Out => regs.doepctl(ep_addr.index()).read().stall(),
             Direction::In => regs.diepctl(ep_addr.index()).read().stall(),
         }
+    }
+
+    fn endpoint_set_buffersize(&mut self, ep_addr: EndpointAddress, buf_size: u16) {
+        warn!("Not implemented yet!!!");
+    }
+
+    fn endpoint_set_sync_type(&mut self, ep_addr: EndpointAddress, synchronization_type: SynchronizationType) {
+        warn!("Not implemented yet!!!");
+    }
+
+    fn endpoint_set_usage_type(&mut self, ep_addr: EndpointAddress, usage_type: UsageType) {
+        warn!("Not implemented yet!!!");
+    }
+
+    fn endpoint_set_type(&mut self, ep_addr: EndpointAddress, ep_type: EndpointType) {
+        warn!("Not implemented yet!!!");
     }
 
     fn endpoint_set_enabled(&mut self, ep_addr: EndpointAddress, enabled: bool) {

--- a/embassy-usb-synopsys-otg/src/lib.rs
+++ b/embassy-usb-synopsys-otg/src/lib.rs
@@ -15,8 +15,9 @@ use core::task::Poll;
 use embassy_sync::waitqueue::AtomicWaker;
 use embassy_usb_driver::{
     Bus as _, Direction, EndpointAddress, EndpointAllocError, EndpointError, EndpointIn, EndpointInfo, EndpointOut,
-    EndpointType, Event, SynchronizationType, Unsupported, UsageType,
+    EndpointType, Event, Unsupported,
 };
+pub use embassy_usb_driver::{SynchronizationType, UsageType};
 
 pub mod otg_v1;
 

--- a/embassy-usb/src/builder.rs
+++ b/embassy-usb/src/builder.rs
@@ -475,7 +475,7 @@ impl<'a, 'd, D: Driver<'d>> InterfaceAltBuilder<'a, 'd, D> {
         synchronization_type: SynchronizationType,
         usage_type: UsageType,
         extra_fields: &[u8],
-        ep_allocated: &D::EndpointIn,
+        ep_allocated: &mut D::EndpointIn,
     ) {
         let ep_info = EndpointInfo {
             addr: ep_allocated.info().addr,
@@ -483,6 +483,9 @@ impl<'a, 'd, D: Driver<'d>> InterfaceAltBuilder<'a, 'd, D> {
             max_packet_size,
             interval_ms,
         };
+        self.builder
+            .driver
+            .grow_endpoint_in_buffer(ep_allocated, max_packet_size);
         self.endpoint_descriptor(&ep_info, synchronization_type, usage_type, extra_fields);
     }
 
@@ -527,7 +530,7 @@ impl<'a, 'd, D: Driver<'d>> InterfaceAltBuilder<'a, 'd, D> {
         synchronization_type: SynchronizationType,
         usage_type: UsageType,
         extra_fields: &[u8],
-        ep_allocated: &D::EndpointOut,
+        ep_allocated: &mut D::EndpointOut,
     ) {
         let ep_info = EndpointInfo {
             addr: ep_allocated.info().addr,
@@ -535,6 +538,9 @@ impl<'a, 'd, D: Driver<'d>> InterfaceAltBuilder<'a, 'd, D> {
             max_packet_size,
             interval_ms,
         };
+        self.builder
+            .driver
+            .grow_endpoint_out_buffer(ep_allocated, max_packet_size);
         self.endpoint_descriptor(&ep_info, synchronization_type, usage_type, extra_fields);
     }
 
@@ -557,7 +563,7 @@ impl<'a, 'd, D: Driver<'d>> InterfaceAltBuilder<'a, 'd, D> {
     ///
     /// Descriptors are written in the order builder functions are called. Note that some
     /// classes care about the order.
-    pub fn endpoint_bulk_in_allocated(&mut self, max_packet_size: u16, ep_allocated: &D::EndpointIn) {
+    pub fn endpoint_bulk_in_allocated(&mut self, max_packet_size: u16, ep_allocated: &mut D::EndpointIn) {
         self.endpoint_in_allocated(
             EndpointType::Bulk,
             max_packet_size,
@@ -588,7 +594,7 @@ impl<'a, 'd, D: Driver<'d>> InterfaceAltBuilder<'a, 'd, D> {
     ///
     /// Descriptors are written in the order builder functions are called. Note that some
     /// classes care about the order.
-    pub fn endpoint_bulk_out_allocated(&mut self, max_packet_size: u16, ep_allocated: &D::EndpointOut) {
+    pub fn endpoint_bulk_out_allocated(&mut self, max_packet_size: u16, ep_allocated: &mut D::EndpointOut) {
         self.endpoint_out_allocated(
             EndpointType::Bulk,
             max_packet_size,
@@ -623,7 +629,7 @@ impl<'a, 'd, D: Driver<'d>> InterfaceAltBuilder<'a, 'd, D> {
         &mut self,
         max_packet_size: u16,
         interval_ms: u8,
-        ep_allocated: &D::EndpointIn,
+        ep_allocated: &mut D::EndpointIn,
     ) {
         self.endpoint_in_allocated(
             EndpointType::Interrupt,
@@ -659,7 +665,7 @@ impl<'a, 'd, D: Driver<'d>> InterfaceAltBuilder<'a, 'd, D> {
         &mut self,
         max_packet_size: u16,
         interval_ms: u8,
-        ep_allocated: &D::EndpointOut,
+        ep_allocated: &mut D::EndpointOut,
     ) {
         self.endpoint_out_allocated(
             EndpointType::Interrupt,
@@ -705,7 +711,7 @@ impl<'a, 'd, D: Driver<'d>> InterfaceAltBuilder<'a, 'd, D> {
         synchronization_type: SynchronizationType,
         usage_type: UsageType,
         extra_fields: &[u8],
-        ep_allocated: &D::EndpointIn,
+        ep_allocated: &mut D::EndpointIn,
     ) {
         self.endpoint_in_allocated(
             EndpointType::Isochronous,
@@ -751,7 +757,7 @@ impl<'a, 'd, D: Driver<'d>> InterfaceAltBuilder<'a, 'd, D> {
         synchronization_type: SynchronizationType,
         usage_type: UsageType,
         extra_fields: &[u8],
-        ep_allocated: &D::EndpointOut,
+        ep_allocated: &mut D::EndpointOut,
     ) {
         self.endpoint_out_allocated(
             EndpointType::Isochronous,

--- a/embassy-usb/src/builder.rs
+++ b/embassy-usb/src/builder.rs
@@ -467,6 +467,25 @@ impl<'a, 'd, D: Driver<'d>> InterfaceAltBuilder<'a, 'd, D> {
         ep
     }
 
+    fn endpoint_in_allocated(
+        &mut self,
+        ep_type: EndpointType,
+        max_packet_size: u16,
+        interval_ms: u8,
+        synchronization_type: SynchronizationType,
+        usage_type: UsageType,
+        extra_fields: &[u8],
+        ep_allocated: &D::EndpointIn,
+    ) {
+        let ep_info = EndpointInfo {
+            addr: ep_allocated.info().addr,
+            ep_type,
+            max_packet_size,
+            interval_ms,
+        };
+        self.endpoint_descriptor(&ep_info, synchronization_type, usage_type, extra_fields);
+    }
+
     /// Allocate an OUT endpoint, without writing its descriptor.
     ///
     /// Use for granular control over the order of endpoint and descriptor creation.
@@ -500,6 +519,25 @@ impl<'a, 'd, D: Driver<'d>> InterfaceAltBuilder<'a, 'd, D> {
         ep
     }
 
+    fn endpoint_out_allocated(
+        &mut self,
+        ep_type: EndpointType,
+        max_packet_size: u16,
+        interval_ms: u8,
+        synchronization_type: SynchronizationType,
+        usage_type: UsageType,
+        extra_fields: &[u8],
+        ep_allocated: &D::EndpointOut,
+    ) {
+        let ep_info = EndpointInfo {
+            addr: ep_allocated.info().addr,
+            ep_type,
+            max_packet_size,
+            interval_ms,
+        };
+        self.endpoint_descriptor(&ep_info, synchronization_type, usage_type, extra_fields);
+    }
+
     /// Allocate a BULK IN endpoint and write its descriptor.
     ///
     /// Descriptors are written in the order builder functions are called. Note that some
@@ -515,6 +553,22 @@ impl<'a, 'd, D: Driver<'d>> InterfaceAltBuilder<'a, 'd, D> {
         )
     }
 
+    /// Reuse an allocated BULK IN endpoint and write its descriptor.
+    ///
+    /// Descriptors are written in the order builder functions are called. Note that some
+    /// classes care about the order.
+    pub fn endpoint_bulk_in_allocated(&mut self, max_packet_size: u16, ep_allocated: &D::EndpointIn) {
+        self.endpoint_in_allocated(
+            EndpointType::Bulk,
+            max_packet_size,
+            0,
+            SynchronizationType::NoSynchronization,
+            UsageType::DataEndpoint,
+            &[],
+            ep_allocated,
+        );
+    }
+
     /// Allocate a BULK OUT endpoint and write its descriptor.
     ///
     /// Descriptors are written in the order builder functions are called. Note that some
@@ -527,6 +581,22 @@ impl<'a, 'd, D: Driver<'d>> InterfaceAltBuilder<'a, 'd, D> {
             SynchronizationType::NoSynchronization,
             UsageType::DataEndpoint,
             &[],
+        )
+    }
+
+    /// Reuse an allocated BULK OUT endpoint and write its descriptor.
+    ///
+    /// Descriptors are written in the order builder functions are called. Note that some
+    /// classes care about the order.
+    pub fn endpoint_bulk_out_allocated(&mut self, max_packet_size: u16, ep_allocated: &D::EndpointOut) {
+        self.endpoint_out_allocated(
+            EndpointType::Bulk,
+            max_packet_size,
+            0,
+            SynchronizationType::NoSynchronization,
+            UsageType::DataEndpoint,
+            &[],
+            ep_allocated,
         )
     }
 
@@ -545,7 +615,31 @@ impl<'a, 'd, D: Driver<'d>> InterfaceAltBuilder<'a, 'd, D> {
         )
     }
 
+    /// Reuse an allocated INTERRUPT IN endpoint and write its descriptor.
+    ///
+    /// Descriptors are written in the order builder functions are called. Note that some
+    /// classes care about the order.
+    pub fn endpoint_interrupt_in_allocated(
+        &mut self,
+        max_packet_size: u16,
+        interval_ms: u8,
+        ep_allocated: &D::EndpointIn,
+    ) {
+        self.endpoint_in_allocated(
+            EndpointType::Interrupt,
+            max_packet_size,
+            interval_ms,
+            SynchronizationType::NoSynchronization,
+            UsageType::DataEndpoint,
+            &[],
+            ep_allocated,
+        )
+    }
+
     /// Allocate a INTERRUPT OUT endpoint and write its descriptor.
+    ///
+    /// Descriptors are written in the order builder functions are called. Note that some
+    /// classes care about the order.
     pub fn endpoint_interrupt_out(&mut self, max_packet_size: u16, interval_ms: u8) -> D::EndpointOut {
         self.endpoint_out(
             EndpointType::Interrupt,
@@ -554,6 +648,27 @@ impl<'a, 'd, D: Driver<'d>> InterfaceAltBuilder<'a, 'd, D> {
             SynchronizationType::NoSynchronization,
             UsageType::DataEndpoint,
             &[],
+        )
+    }
+
+    /// Reuse an allocated INTERRUPT OUT endpoint and write its descriptor.
+    ///
+    /// Descriptors are written in the order builder functions are called. Note that some
+    /// classes care about the order.
+    pub fn endpoint_interrupt_out_allocated(
+        &mut self,
+        max_packet_size: u16,
+        interval_ms: u8,
+        ep_allocated: &D::EndpointOut,
+    ) {
+        self.endpoint_out_allocated(
+            EndpointType::Interrupt,
+            max_packet_size,
+            interval_ms,
+            SynchronizationType::NoSynchronization,
+            UsageType::DataEndpoint,
+            &[],
+            ep_allocated,
         )
     }
 
@@ -579,7 +694,34 @@ impl<'a, 'd, D: Driver<'d>> InterfaceAltBuilder<'a, 'd, D> {
         )
     }
 
+    /// Reuse an allocated ISOCHRONOUS IN endpoint and write its descriptor.
+    ///
+    /// Descriptors are written in the order builder functions are called. Note that some
+    /// classes care about the order.
+    pub fn endpoint_isochronous_in_allocated(
+        &mut self,
+        max_packet_size: u16,
+        interval_ms: u8,
+        synchronization_type: SynchronizationType,
+        usage_type: UsageType,
+        extra_fields: &[u8],
+        ep_allocated: &D::EndpointIn,
+    ) {
+        self.endpoint_in_allocated(
+            EndpointType::Isochronous,
+            max_packet_size,
+            interval_ms,
+            synchronization_type,
+            usage_type,
+            extra_fields,
+            ep_allocated,
+        )
+    }
+
     /// Allocate a ISOCHRONOUS OUT endpoint and write its descriptor.
+    ///
+    /// Descriptors are written in the order builder functions are called. Note that some
+    /// classes care about the order.
     pub fn endpoint_isochronous_out(
         &mut self,
         max_packet_size: u16,
@@ -595,6 +737,30 @@ impl<'a, 'd, D: Driver<'d>> InterfaceAltBuilder<'a, 'd, D> {
             synchronization_type,
             usage_type,
             extra_fields,
+        )
+    }
+
+    /// Reuse an allocated ISOCHRONOUS OUT endpoint and write its descriptor.
+    ///
+    /// Descriptors are written in the order builder functions are called. Note that some
+    /// classes care about the order.
+    pub fn endpoint_isochronous_out_allocated(
+        &mut self,
+        max_packet_size: u16,
+        interval_ms: u8,
+        synchronization_type: SynchronizationType,
+        usage_type: UsageType,
+        extra_fields: &[u8],
+        ep_allocated: &D::EndpointOut,
+    ) {
+        self.endpoint_out_allocated(
+            EndpointType::Isochronous,
+            max_packet_size,
+            interval_ms,
+            synchronization_type,
+            usage_type,
+            extra_fields,
+            ep_allocated,
         )
     }
 }

--- a/embassy-usb/src/builder.rs
+++ b/embassy-usb/src/builder.rs
@@ -1,8 +1,8 @@
 use heapless::Vec;
 
 use crate::config::MAX_HANDLER_COUNT;
-use crate::descriptor::{BosWriter, DescriptorWriter, SynchronizationType, UsageType};
-use crate::driver::{Driver, Endpoint, EndpointInfo, EndpointType};
+use crate::descriptor::{BosWriter, DescriptorWriter};
+use crate::driver::{Driver, Endpoint, EndpointInfo, EndpointType, SynchronizationType, UsageType};
 use crate::msos::{DeviceLevelDescriptor, FunctionLevelDescriptor, MsOsDescriptorWriter};
 use crate::types::{InterfaceNumber, StringIndex};
 use crate::{Handler, Interface, UsbDevice, MAX_INTERFACE_COUNT, STRING_INDEX_CUSTOM_START};

--- a/embassy-usb/src/descriptor.rs
+++ b/embassy-usb/src/descriptor.rs
@@ -2,7 +2,7 @@
 use embassy_usb_driver::EndpointType;
 
 use crate::builder::Config;
-use crate::driver::EndpointInfo;
+use crate::driver::{EndpointInfo, SynchronizationType, UsageType};
 use crate::types::{InterfaceNumber, StringIndex};
 use crate::CONFIGURATION_VALUE;
 
@@ -37,40 +37,6 @@ pub mod capability_type {
     pub const SS_USB_DEVICE: u8 = 3;
     pub const CONTAINER_ID: u8 = 4;
     pub const PLATFORM: u8 = 5;
-}
-
-/// USB endpoint synchronization type. The values of this enum can be directly
-/// cast into `u8` to get the bmAttributes synchronization type bits.
-/// Values other than `NoSynchronization` are only allowed on isochronous endpoints.
-#[repr(u8)]
-#[derive(Copy, Clone, Eq, PartialEq, Debug)]
-#[cfg_attr(feature = "defmt", derive(defmt::Format))]
-pub enum SynchronizationType {
-    /// No synchronization is used.
-    NoSynchronization = 0b00,
-    /// Unsynchronized, although sinks provide data rate feedback.
-    Asynchronous = 0b01,
-    /// Synchronized using feedback or feedforward data rate information.
-    Adaptive = 0b10,
-    /// Synchronized to the USB’s SOF.
-    Synchronous = 0b11,
-}
-
-/// USB endpoint usage type. The values of this enum can be directly cast into
-/// `u8` to get the bmAttributes usage type bits.
-/// Values other than `DataEndpoint` are only allowed on isochronous endpoints.
-#[repr(u8)]
-#[derive(Copy, Clone, Eq, PartialEq, Debug)]
-#[cfg_attr(feature = "defmt", derive(defmt::Format))]
-pub enum UsageType {
-    /// Use the endpoint for regular data transfer.
-    DataEndpoint = 0b00,
-    /// Endpoint conveys explicit feedback information for one or more data endpoints.
-    FeedbackEndpoint = 0b01,
-    /// A data endpoint that also serves as an implicit feedback endpoint for one or more data endpoints.
-    ImplicitFeedbackDataEndpoint = 0b10,
-    /// Reserved usage type.
-    Reserved = 0b11,
 }
 
 /// A writer for USB descriptors.

--- a/embassy-usb/src/descriptor_reader.rs
+++ b/embassy-usb/src/descriptor_reader.rs
@@ -79,6 +79,8 @@ pub struct EndpointInfo {
     pub interface: InterfaceNumber,
     pub interface_alt: u8,
     pub ep_address: EndpointAddress,
+    pub ep_attributes: u8,
+    pub ep_max_packet_size: u16,
 }
 
 pub fn foreach_endpoint(data: &[u8], mut f: impl FnMut(EndpointInfo)) -> Result<(), ReadError> {
@@ -87,6 +89,7 @@ pub fn foreach_endpoint(data: &[u8], mut f: impl FnMut(EndpointInfo)) -> Result<
         interface: InterfaceNumber(0),
         interface_alt: 0,
         ep_address: EndpointAddress::from(0),
+        ep_max_packet_size: 0,
     };
     for res in Reader::new(data).read_descriptors() {
         let (kind, mut r) = res?;
@@ -102,6 +105,8 @@ pub fn foreach_endpoint(data: &[u8], mut f: impl FnMut(EndpointInfo)) -> Result<
             }
             descriptor_type::ENDPOINT => {
                 ep.ep_address = EndpointAddress::from(r.read_u8()?);
+                ep.ep_attributes = r.read_u8()?;
+                ep.ep_max_packet_size = r.read_u16()?;
                 f(ep);
             }
             _ => {}

--- a/embassy-usb/src/descriptor_reader.rs
+++ b/embassy-usb/src/descriptor_reader.rs
@@ -89,6 +89,7 @@ pub fn foreach_endpoint(data: &[u8], mut f: impl FnMut(EndpointInfo)) -> Result<
         interface: InterfaceNumber(0),
         interface_alt: 0,
         ep_address: EndpointAddress::from(0),
+        ep_attributes: 0,
         ep_max_packet_size: 0,
     };
     for res in Reader::new(data).read_descriptors() {

--- a/embassy-usb/src/lib.rs
+++ b/embassy-usb/src/lib.rs
@@ -6,7 +6,7 @@
 pub(crate) mod fmt;
 
 pub use embassy_usb_driver as driver;
-use embassy_usb_driver::EndpointType;
+use embassy_usb_driver::{EndpointType, SynchronizationType, UsageType};
 
 mod builder;
 pub mod class;
@@ -592,13 +592,15 @@ impl<'d, D: Driver<'d>> Inner<'d, D> {
 
                                 self.bus.endpoint_set_type(
                                     ep.ep_address,
-                                    match ep.ep_attributes & 0b11 {
-                                        0b00 => EndpointType::Control,
-                                        0b01 => EndpointType::Isochronous,
-                                        0b10 => EndpointType::Bulk,
-                                        0b11 => EndpointType::Interrupt,
-                                        4_u8..=u8::MAX => unreachable!(),
-                                    },
+                                    EndpointType::from((ep.ep_attributes >> 0) & 0b11),
+                                );
+                                self.bus.endpoint_set_sync_type(
+                                    ep.ep_address,
+                                    SynchronizationType::from((ep.ep_attributes >> 2) & 0b11),
+                                );
+                                self.bus.endpoint_set_usage_type(
+                                    ep.ep_address,
+                                    UsageType::from((ep.ep_attributes >> 4) & 0b11),
                                 );
                                 // TODO also implement this for other endpoint changes, like reconfiguration.
                                 // TODO add changes of buffersize, maybe always redo the memory layout or lay out addresses based on largest buffer and reconfigure start addresses and sizes only.

--- a/embassy-usb/src/lib.rs
+++ b/embassy-usb/src/lib.rs
@@ -587,6 +587,10 @@ impl<'d, D: Driver<'d>> Inner<'d, D> {
                             if ep.interface == iface_num {
                                 self.bus
                                     .endpoint_set_enabled(ep.ep_address, iface.current_alt_setting == ep.interface_alt);
+                                self.bus.endpoint_set_buffersize(ep.ep_address, ep.ep_max_packet_size);
+                                self.bus.endpoint_set_type(ep.ep_address, EndpointType::from(ep.ep_attributes & 0b11));
+                                // TODO also implement this for other endpoint changes, like reconfiguration.
+                                // TODO add changes of buffersize, maybe always redo the memory layout or lay out addresses based on largest buffer and reconfigure start addresses and sizes only.
                             }
                         })
                         .unwrap();

--- a/embassy-usb/src/lib.rs
+++ b/embassy-usb/src/lib.rs
@@ -472,7 +472,6 @@ impl<'d, D: Driver<'d>> Inner<'d, D> {
                 //Enable all endpoints if they're alt_function 0
                 foreach_endpoint(self.config_descriptor, |ep| {
                     if ep.interface_alt == 0 {
-                        self.bus.endpoint_set_enabled(ep.ep_address, true);
                         self.bus.endpoint_set_buffersize(ep.ep_address, ep.ep_max_packet_size);
 
                         self.bus
@@ -483,6 +482,7 @@ impl<'d, D: Driver<'d>> Inner<'d, D> {
                         );
                         self.bus
                             .endpoint_set_usage_type(ep.ep_address, UsageType::from((ep.ep_attributes >> 4) & 0b11));
+                        self.bus.endpoint_set_enabled(ep.ep_address, true);
                     }
                 })
                 .unwrap();
@@ -555,11 +555,30 @@ impl<'d, D: Driver<'d>> Inner<'d, D> {
                     debug!("SET_CONFIGURATION: configured");
                     self.device_state = UsbDeviceState::Configured;
 
+                    // Disable all endpoints.
+                    foreach_endpoint(self.config_descriptor, |ep| {
+                        self.bus.endpoint_set_enabled(ep.ep_address, false);
+                    })
+                    .unwrap();
+
                     // Enable all endpoints of selected alt settings.
                     foreach_endpoint(self.config_descriptor, |ep| {
                         let iface = &self.interfaces[ep.interface.0 as usize];
-                        self.bus
-                            .endpoint_set_enabled(ep.ep_address, iface.current_alt_setting == ep.interface_alt);
+                        if ep.interface_alt == iface.current_alt_setting {
+                            self.bus.endpoint_set_buffersize(ep.ep_address, ep.ep_max_packet_size);
+
+                            self.bus
+                                .endpoint_set_type(ep.ep_address, EndpointType::from((ep.ep_attributes >> 0) & 0b11));
+                            self.bus.endpoint_set_sync_type(
+                                ep.ep_address,
+                                SynchronizationType::from((ep.ep_attributes >> 2) & 0b11),
+                            );
+                            self.bus.endpoint_set_usage_type(
+                                ep.ep_address,
+                                UsageType::from((ep.ep_attributes >> 4) & 0b11),
+                            );
+                            self.bus.endpoint_set_enabled(ep.ep_address, true);
+                        }
                     })
                     .unwrap();
 
@@ -607,11 +626,18 @@ impl<'d, D: Driver<'d>> Inner<'d, D> {
 
                         iface.current_alt_setting = new_altsetting;
 
-                        // Enable/disable EPs of this interface as needed.
+                        // Disable all endpoints of selected interface.
                         foreach_endpoint(self.config_descriptor, |ep| {
-                            if ep.interface == iface_num {
-                                self.bus
-                                    .endpoint_set_enabled(ep.ep_address, iface.current_alt_setting == ep.interface_alt);
+                            if ep.interface.0 == iface_num.0 {
+                                self.bus.endpoint_set_enabled(ep.ep_address, false)
+                            };
+                        })
+                        .unwrap();
+
+                        // Enable all endpoints of selected interface and alt settings.
+                        foreach_endpoint(self.config_descriptor, |ep| {
+                            let iface = &self.interfaces[ep.interface.0 as usize];
+                            if ep.interface.0 == iface_num.0 && ep.interface_alt == iface.current_alt_setting {
                                 self.bus.endpoint_set_buffersize(ep.ep_address, ep.ep_max_packet_size);
 
                                 self.bus.endpoint_set_type(
@@ -626,10 +652,10 @@ impl<'d, D: Driver<'d>> Inner<'d, D> {
                                     ep.ep_address,
                                     UsageType::from((ep.ep_attributes >> 4) & 0b11),
                                 );
+                                self.bus.endpoint_set_enabled(ep.ep_address, true);
                             }
                         })
                         .unwrap();
-
                         // TODO check it is valid (not out of range)
 
                         for h in &mut self.handlers {


### PR DESCRIPTION
Solution for https://github.com/embassy-rs/embassy/pull/3212 and https://github.com/embassy-rs/embassy/issues/2994 .

This PR addresses the problem that currently endpoint addresses are automatically increased when building a USB descriptor. It adds a copy of each endpoint-creation function, adding the `_allocated` suffix. These functions accept a &mut reference to the already created endpoint and merely write a new endpoint descriptor. They also grow the buffer of the endpoint if the new descriptor has a higher `max_packet_size` than the already allocated endpoint. The methods handling interface reconfiguration also automatically adjust all endpoints to reflect the settings in the desciptor.
The relevant functions are only implemented for embassy-rp for now, the other packages have the methods implemented with a warning, so it works like before the PR.

Suggestions regarding commit rebasing, or different function names or how it works in general, are welcome :)