### PR TITLE
Remove binary_info blocks from most examples.

### DIFF
--- a/examples/rp23/src/bin/adc.rs
+++ b/examples/rp23/src/bin/adc.rs
@@ -1,4 +1,4 @@
-//! This example test the ADC (Analog to Digital Conversion) of the RS2040 pin 26, 27 and 28.
+//! This example test the ADC (Analog to Digital Conversion) of the RP2350A pins 26, 27 and 28.
 //! It also reads the temperature sensor in the chip.
 
 #![no_std]
@@ -16,16 +16,6 @@ use {defmt_rtt as _, panic_probe as _};
 #[link_section = ".start_block"]
 #[used]
 pub static IMAGE_DEF: ImageDef = ImageDef::secure_exe();
-
-// Program metadata for `picotool info`
-#[link_section = ".bi_entries"]
-#[used]
-pub static PICOTOOL_ENTRIES: [embassy_rp::binary_info::EntryAddr; 4] = [
-    embassy_rp::binary_info::rp_program_name!(c"example"),
-    embassy_rp::binary_info::rp_cargo_version!(),
-    embassy_rp::binary_info::rp_program_description!(c"Blinky"),
-    embassy_rp::binary_info::rp_program_build_attribute!(),
-];
 
 bind_interrupts!(struct Irqs {
     ADC_IRQ_FIFO => InterruptHandler;

--- a/examples/rp23/src/bin/adc_dma.rs
+++ b/examples/rp23/src/bin/adc_dma.rs
@@ -17,16 +17,6 @@ use {defmt_rtt as _, panic_probe as _};
 #[used]
 pub static IMAGE_DEF: ImageDef = ImageDef::secure_exe();
 
-// Program metadata for `picotool info`
-#[link_section = ".bi_entries"]
-#[used]
-pub static PICOTOOL_ENTRIES: [embassy_rp::binary_info::EntryAddr; 4] = [
-    embassy_rp::binary_info::rp_program_name!(c"example"),
-    embassy_rp::binary_info::rp_cargo_version!(),
-    embassy_rp::binary_info::rp_program_description!(c"Blinky"),
-    embassy_rp::binary_info::rp_program_build_attribute!(),
-];
-
 bind_interrupts!(struct Irqs {
     ADC_IRQ_FIFO => InterruptHandler;
 });

--- a/examples/rp23/src/bin/assign_resources.rs
+++ b/examples/rp23/src/bin/assign_resources.rs
@@ -24,16 +24,6 @@ use {defmt_rtt as _, panic_probe as _};
 #[used]
 pub static IMAGE_DEF: ImageDef = ImageDef::secure_exe();
 
-// Program metadata for `picotool info`
-#[link_section = ".bi_entries"]
-#[used]
-pub static PICOTOOL_ENTRIES: [embassy_rp::binary_info::EntryAddr; 4] = [
-    embassy_rp::binary_info::rp_program_name!(c"example"),
-    embassy_rp::binary_info::rp_cargo_version!(),
-    embassy_rp::binary_info::rp_program_description!(c"Blinky"),
-    embassy_rp::binary_info::rp_program_build_attribute!(),
-];
-
 #[embassy_executor::main]
 async fn main(spawner: Spawner) {
     // initialize the peripherals

--- a/examples/rp23/src/bin/blinky.rs
+++ b/examples/rp23/src/bin/blinky.rs
@@ -17,20 +17,23 @@ use {defmt_rtt as _, panic_probe as _};
 #[used]
 pub static IMAGE_DEF: ImageDef = ImageDef::secure_exe();
 
-// Program metadata for `picotool info`
+// Program metadata for `picotool info`.
+// This isn't needed, but it's recomended to have these minimal entries.
 #[link_section = ".bi_entries"]
 #[used]
 pub static PICOTOOL_ENTRIES: [embassy_rp::binary_info::EntryAddr; 4] = [
-    embassy_rp::binary_info::rp_program_name!(c"example"),
+    embassy_rp::binary_info::rp_program_name!(c"Blinky Example"),
+    embassy_rp::binary_info::rp_program_description!(
+        c"This example tests the RP Pico on board LED, connected to gpio 25"
+    ),
     embassy_rp::binary_info::rp_cargo_version!(),
-    embassy_rp::binary_info::rp_program_description!(c"Blinky"),
     embassy_rp::binary_info::rp_program_build_attribute!(),
 ];
 
 #[embassy_executor::main]
 async fn main(_spawner: Spawner) {
     let p = embassy_rp::init(Default::default());
-    let mut led = Output::new(p.PIN_2, Level::Low);
+    let mut led = Output::new(p.PIN_25, Level::Low);
 
     loop {
         info!("led on!");

--- a/examples/rp23/src/bin/blinky_two_channels.rs
+++ b/examples/rp23/src/bin/blinky_two_channels.rs
@@ -19,16 +19,6 @@ use {defmt_rtt as _, panic_probe as _};
 #[used]
 pub static IMAGE_DEF: ImageDef = ImageDef::secure_exe();
 
-// Program metadata for `picotool info`
-#[link_section = ".bi_entries"]
-#[used]
-pub static PICOTOOL_ENTRIES: [embassy_rp::binary_info::EntryAddr; 4] = [
-    embassy_rp::binary_info::rp_program_name!(c"example"),
-    embassy_rp::binary_info::rp_cargo_version!(),
-    embassy_rp::binary_info::rp_program_description!(c"Blinky"),
-    embassy_rp::binary_info::rp_program_build_attribute!(),
-];
-
 enum LedState {
     Toggle,
 }

--- a/examples/rp23/src/bin/blinky_two_tasks.rs
+++ b/examples/rp23/src/bin/blinky_two_tasks.rs
@@ -19,16 +19,6 @@ use {defmt_rtt as _, panic_probe as _};
 #[used]
 pub static IMAGE_DEF: ImageDef = ImageDef::secure_exe();
 
-// Program metadata for `picotool info`
-#[link_section = ".bi_entries"]
-#[used]
-pub static PICOTOOL_ENTRIES: [embassy_rp::binary_info::EntryAddr; 4] = [
-    embassy_rp::binary_info::rp_program_name!(c"example"),
-    embassy_rp::binary_info::rp_cargo_version!(),
-    embassy_rp::binary_info::rp_program_description!(c"Blinky"),
-    embassy_rp::binary_info::rp_program_build_attribute!(),
-];
-
 type LedType = Mutex<ThreadModeRawMutex, Option<Output<'static>>>;
 static LED: LedType = Mutex::new(None);
 

--- a/examples/rp23/src/bin/button.rs
+++ b/examples/rp23/src/bin/button.rs
@@ -14,16 +14,6 @@ use {defmt_rtt as _, panic_probe as _};
 #[used]
 pub static IMAGE_DEF: ImageDef = ImageDef::secure_exe();
 
-// Program metadata for `picotool info`
-#[link_section = ".bi_entries"]
-#[used]
-pub static PICOTOOL_ENTRIES: [embassy_rp::binary_info::EntryAddr; 4] = [
-    embassy_rp::binary_info::rp_program_name!(c"example"),
-    embassy_rp::binary_info::rp_cargo_version!(),
-    embassy_rp::binary_info::rp_program_description!(c"Blinky"),
-    embassy_rp::binary_info::rp_program_build_attribute!(),
-];
-
 #[embassy_executor::main]
 async fn main(_spawner: Spawner) {
     let p = embassy_rp::init(Default::default());

--- a/examples/rp23/src/bin/debounce.rs
+++ b/examples/rp23/src/bin/debounce.rs
@@ -15,16 +15,6 @@ use {defmt_rtt as _, panic_probe as _};
 #[used]
 pub static IMAGE_DEF: ImageDef = ImageDef::secure_exe();
 
-// Program metadata for `picotool info`
-#[link_section = ".bi_entries"]
-#[used]
-pub static PICOTOOL_ENTRIES: [embassy_rp::binary_info::EntryAddr; 4] = [
-    embassy_rp::binary_info::rp_program_name!(c"example"),
-    embassy_rp::binary_info::rp_cargo_version!(),
-    embassy_rp::binary_info::rp_program_description!(c"Blinky"),
-    embassy_rp::binary_info::rp_program_build_attribute!(),
-];
-
 pub struct Debouncer<'a> {
     input: Input<'a>,
     debounce: Duration,

--- a/examples/rp23/src/bin/flash.rs
+++ b/examples/rp23/src/bin/flash.rs
@@ -15,16 +15,6 @@ use {defmt_rtt as _, panic_probe as _};
 #[used]
 pub static IMAGE_DEF: ImageDef = ImageDef::secure_exe();
 
-// Program metadata for `picotool info`
-#[link_section = ".bi_entries"]
-#[used]
-pub static PICOTOOL_ENTRIES: [embassy_rp::binary_info::EntryAddr; 4] = [
-    embassy_rp::binary_info::rp_program_name!(c"example"),
-    embassy_rp::binary_info::rp_cargo_version!(),
-    embassy_rp::binary_info::rp_program_description!(c"Flash"),
-    embassy_rp::binary_info::rp_program_build_attribute!(),
-];
-
 const ADDR_OFFSET: u32 = 0x100000;
 const FLASH_SIZE: usize = 2 * 1024 * 1024;
 

--- a/examples/rp23/src/bin/gpio_async.rs
+++ b/examples/rp23/src/bin/gpio_async.rs
@@ -17,16 +17,6 @@ use {defmt_rtt as _, panic_probe as _};
 #[used]
 pub static IMAGE_DEF: ImageDef = ImageDef::secure_exe();
 
-// Program metadata for `picotool info`
-#[link_section = ".bi_entries"]
-#[used]
-pub static PICOTOOL_ENTRIES: [embassy_rp::binary_info::EntryAddr; 4] = [
-    embassy_rp::binary_info::rp_program_name!(c"example"),
-    embassy_rp::binary_info::rp_cargo_version!(),
-    embassy_rp::binary_info::rp_program_description!(c"Blinky"),
-    embassy_rp::binary_info::rp_program_build_attribute!(),
-];
-
 /// It requires an external signal to be manually triggered on PIN 16. For
 /// example, this could be accomplished using an external power source with a
 /// button so that it is possible to toggle the signal from low to high.

--- a/examples/rp23/src/bin/gpout.rs
+++ b/examples/rp23/src/bin/gpout.rs
@@ -16,16 +16,6 @@ use {defmt_rtt as _, panic_probe as _};
 #[used]
 pub static IMAGE_DEF: ImageDef = ImageDef::secure_exe();
 
-// Program metadata for `picotool info`
-#[link_section = ".bi_entries"]
-#[used]
-pub static PICOTOOL_ENTRIES: [embassy_rp::binary_info::EntryAddr; 4] = [
-    embassy_rp::binary_info::rp_program_name!(c"example"),
-    embassy_rp::binary_info::rp_cargo_version!(),
-    embassy_rp::binary_info::rp_program_description!(c"Blinky"),
-    embassy_rp::binary_info::rp_program_build_attribute!(),
-];
-
 #[embassy_executor::main]
 async fn main(_spawner: Spawner) {
     let p = embassy_rp::init(Default::default());

--- a/examples/rp23/src/bin/i2c_async.rs
+++ b/examples/rp23/src/bin/i2c_async.rs
@@ -20,16 +20,6 @@ use {defmt_rtt as _, panic_probe as _};
 #[used]
 pub static IMAGE_DEF: ImageDef = ImageDef::secure_exe();
 
-// Program metadata for `picotool info`
-#[link_section = ".bi_entries"]
-#[used]
-pub static PICOTOOL_ENTRIES: [embassy_rp::binary_info::EntryAddr; 4] = [
-    embassy_rp::binary_info::rp_program_name!(c"example"),
-    embassy_rp::binary_info::rp_cargo_version!(),
-    embassy_rp::binary_info::rp_program_description!(c"Blinky"),
-    embassy_rp::binary_info::rp_program_build_attribute!(),
-];
-
 bind_interrupts!(struct Irqs {
     I2C1_IRQ => InterruptHandler<I2C1>;
 });

--- a/examples/rp23/src/bin/i2c_async_embassy.rs
+++ b/examples/rp23/src/bin/i2c_async_embassy.rs
@@ -15,16 +15,6 @@ use {defmt_rtt as _, panic_probe as _};
 #[used]
 pub static IMAGE_DEF: ImageDef = ImageDef::secure_exe();
 
-// Program metadata for `picotool info`
-#[link_section = ".bi_entries"]
-#[used]
-pub static PICOTOOL_ENTRIES: [embassy_rp::binary_info::EntryAddr; 4] = [
-    embassy_rp::binary_info::rp_program_name!(c"example"),
-    embassy_rp::binary_info::rp_cargo_version!(),
-    embassy_rp::binary_info::rp_program_description!(c"Blinky"),
-    embassy_rp::binary_info::rp_program_build_attribute!(),
-];
-
 // Our anonymous hypotetical temperature sensor could be:
 // a 12-bit sensor, with 100ms startup time, range of -40*C - 125*C, and precision 0.25*C
 // It requires no configuration or calibration, works with all i2c bus speeds,

--- a/examples/rp23/src/bin/i2c_blocking.rs
+++ b/examples/rp23/src/bin/i2c_blocking.rs
@@ -18,16 +18,6 @@ use {defmt_rtt as _, panic_probe as _};
 #[used]
 pub static IMAGE_DEF: ImageDef = ImageDef::secure_exe();
 
-// Program metadata for `picotool info`
-#[link_section = ".bi_entries"]
-#[used]
-pub static PICOTOOL_ENTRIES: [embassy_rp::binary_info::EntryAddr; 4] = [
-    embassy_rp::binary_info::rp_program_name!(c"example"),
-    embassy_rp::binary_info::rp_cargo_version!(),
-    embassy_rp::binary_info::rp_program_description!(c"Blinky"),
-    embassy_rp::binary_info::rp_program_build_attribute!(),
-];
-
 #[allow(dead_code)]
 mod mcp23017 {
     pub const ADDR: u8 = 0x20; // default addr

--- a/examples/rp23/src/bin/i2c_slave.rs
+++ b/examples/rp23/src/bin/i2c_slave.rs
@@ -15,16 +15,6 @@ use {defmt_rtt as _, panic_probe as _};
 #[used]
 pub static IMAGE_DEF: ImageDef = ImageDef::secure_exe();
 
-// Program metadata for `picotool info`
-#[link_section = ".bi_entries"]
-#[used]
-pub static PICOTOOL_ENTRIES: [embassy_rp::binary_info::EntryAddr; 4] = [
-    embassy_rp::binary_info::rp_program_name!(c"example"),
-    embassy_rp::binary_info::rp_cargo_version!(),
-    embassy_rp::binary_info::rp_program_description!(c"Blinky"),
-    embassy_rp::binary_info::rp_program_build_attribute!(),
-];
-
 bind_interrupts!(struct Irqs {
     I2C0_IRQ => i2c::InterruptHandler<I2C0>;
     I2C1_IRQ => i2c::InterruptHandler<I2C1>;

--- a/examples/rp23/src/bin/interrupt.rs
+++ b/examples/rp23/src/bin/interrupt.rs
@@ -29,16 +29,6 @@ use {defmt_rtt as _, panic_probe as _};
 #[used]
 pub static IMAGE_DEF: ImageDef = ImageDef::secure_exe();
 
-// Program metadata for `picotool info`
-#[link_section = ".bi_entries"]
-#[used]
-pub static PICOTOOL_ENTRIES: [embassy_rp::binary_info::EntryAddr; 4] = [
-    embassy_rp::binary_info::rp_program_name!(c"example"),
-    embassy_rp::binary_info::rp_cargo_version!(),
-    embassy_rp::binary_info::rp_program_description!(c"Blinky"),
-    embassy_rp::binary_info::rp_program_build_attribute!(),
-];
-
 static COUNTER: AtomicU32 = AtomicU32::new(0);
 static PWM: Mutex<CriticalSectionRawMutex, RefCell<Option<Pwm>>> = Mutex::new(RefCell::new(None));
 static ADC: Mutex<CriticalSectionRawMutex, RefCell<Option<(Adc<Blocking>, adc::Channel)>>> =

--- a/examples/rp23/src/bin/multicore.rs
+++ b/examples/rp23/src/bin/multicore.rs
@@ -20,16 +20,6 @@ use {defmt_rtt as _, panic_probe as _};
 #[used]
 pub static IMAGE_DEF: ImageDef = ImageDef::secure_exe();
 
-// Program metadata for `picotool info`
-#[link_section = ".bi_entries"]
-#[used]
-pub static PICOTOOL_ENTRIES: [embassy_rp::binary_info::EntryAddr; 4] = [
-    embassy_rp::binary_info::rp_program_name!(c"example"),
-    embassy_rp::binary_info::rp_cargo_version!(),
-    embassy_rp::binary_info::rp_program_description!(c"Blinky"),
-    embassy_rp::binary_info::rp_program_build_attribute!(),
-];
-
 static mut CORE1_STACK: Stack<4096> = Stack::new();
 static EXECUTOR0: StaticCell<Executor> = StaticCell::new();
 static EXECUTOR1: StaticCell<Executor> = StaticCell::new();

--- a/examples/rp23/src/bin/multiprio.rs
+++ b/examples/rp23/src/bin/multiprio.rs
@@ -70,16 +70,6 @@ use {defmt_rtt as _, panic_probe as _};
 #[used]
 pub static IMAGE_DEF: ImageDef = ImageDef::secure_exe();
 
-// Program metadata for `picotool info`
-#[link_section = ".bi_entries"]
-#[used]
-pub static PICOTOOL_ENTRIES: [embassy_rp::binary_info::EntryAddr; 4] = [
-    embassy_rp::binary_info::rp_program_name!(c"example"),
-    embassy_rp::binary_info::rp_cargo_version!(),
-    embassy_rp::binary_info::rp_program_description!(c"Blinky"),
-    embassy_rp::binary_info::rp_program_build_attribute!(),
-];
-
 #[embassy_executor::task]
 async fn run_high() {
     loop {

--- a/examples/rp23/src/bin/otp.rs
+++ b/examples/rp23/src/bin/otp.rs
@@ -14,16 +14,6 @@ use {defmt_rtt as _, panic_probe as _};
 #[used]
 pub static IMAGE_DEF: ImageDef = ImageDef::secure_exe();
 
-// Program metadata for `picotool info`
-#[link_section = ".bi_entries"]
-#[used]
-pub static PICOTOOL_ENTRIES: [embassy_rp::binary_info::EntryAddr; 4] = [
-    embassy_rp::binary_info::rp_program_name!(c"OTP Read Example"),
-    embassy_rp::binary_info::rp_cargo_version!(),
-    embassy_rp::binary_info::rp_program_description!(c"OTP Read Example"),
-    embassy_rp::binary_info::rp_program_build_attribute!(),
-];
-
 #[embassy_executor::main]
 async fn main(_spawner: Spawner) {
     let _ = embassy_rp::init(Default::default());

--- a/examples/rp23/src/bin/pio_async.rs
+++ b/examples/rp23/src/bin/pio_async.rs
@@ -16,16 +16,6 @@ use {defmt_rtt as _, panic_probe as _};
 #[used]
 pub static IMAGE_DEF: ImageDef = ImageDef::secure_exe();
 
-// Program metadata for `picotool info`
-#[link_section = ".bi_entries"]
-#[used]
-pub static PICOTOOL_ENTRIES: [embassy_rp::binary_info::EntryAddr; 4] = [
-    embassy_rp::binary_info::rp_program_name!(c"example"),
-    embassy_rp::binary_info::rp_cargo_version!(),
-    embassy_rp::binary_info::rp_program_description!(c"Blinky"),
-    embassy_rp::binary_info::rp_program_build_attribute!(),
-];
-
 bind_interrupts!(struct Irqs {
     PIO0_IRQ_0 => InterruptHandler<PIO0>;
 });

--- a/examples/rp23/src/bin/pio_dma.rs
+++ b/examples/rp23/src/bin/pio_dma.rs
@@ -17,16 +17,6 @@ use {defmt_rtt as _, panic_probe as _};
 #[used]
 pub static IMAGE_DEF: ImageDef = ImageDef::secure_exe();
 
-// Program metadata for `picotool info`
-#[link_section = ".bi_entries"]
-#[used]
-pub static PICOTOOL_ENTRIES: [embassy_rp::binary_info::EntryAddr; 4] = [
-    embassy_rp::binary_info::rp_program_name!(c"example"),
-    embassy_rp::binary_info::rp_cargo_version!(),
-    embassy_rp::binary_info::rp_program_description!(c"Blinky"),
-    embassy_rp::binary_info::rp_program_build_attribute!(),
-];
-
 bind_interrupts!(struct Irqs {
     PIO0_IRQ_0 => InterruptHandler<PIO0>;
 });

--- a/examples/rp23/src/bin/pio_hd44780.rs
+++ b/examples/rp23/src/bin/pio_hd44780.rs
@@ -22,16 +22,6 @@ use {defmt_rtt as _, panic_probe as _};
 #[used]
 pub static IMAGE_DEF: ImageDef = ImageDef::secure_exe();
 
-// Program metadata for `picotool info`
-#[link_section = ".bi_entries"]
-#[used]
-pub static PICOTOOL_ENTRIES: [embassy_rp::binary_info::EntryAddr; 4] = [
-    embassy_rp::binary_info::rp_program_name!(c"example"),
-    embassy_rp::binary_info::rp_cargo_version!(),
-    embassy_rp::binary_info::rp_program_description!(c"Blinky"),
-    embassy_rp::binary_info::rp_program_build_attribute!(),
-];
-
 bind_interrupts!(pub struct Irqs {
     PIO0_IRQ_0 => InterruptHandler<PIO0>;
 });

--- a/examples/rp23/src/bin/pio_i2s.rs
+++ b/examples/rp23/src/bin/pio_i2s.rs
@@ -25,16 +25,6 @@ use {defmt_rtt as _, panic_probe as _};
 #[used]
 pub static IMAGE_DEF: ImageDef = ImageDef::secure_exe();
 
-// Program metadata for `picotool info`
-#[link_section = ".bi_entries"]
-#[used]
-pub static PICOTOOL_ENTRIES: [embassy_rp::binary_info::EntryAddr; 4] = [
-    embassy_rp::binary_info::rp_program_name!(c"example"),
-    embassy_rp::binary_info::rp_cargo_version!(),
-    embassy_rp::binary_info::rp_program_description!(c"Blinky"),
-    embassy_rp::binary_info::rp_program_build_attribute!(),
-];
-
 bind_interrupts!(struct Irqs {
     PIO0_IRQ_0 => InterruptHandler<PIO0>;
 });

--- a/examples/rp23/src/bin/pio_pwm.rs
+++ b/examples/rp23/src/bin/pio_pwm.rs
@@ -18,16 +18,6 @@ use {defmt_rtt as _, panic_probe as _};
 #[used]
 pub static IMAGE_DEF: ImageDef = ImageDef::secure_exe();
 
-// Program metadata for `picotool info`
-#[link_section = ".bi_entries"]
-#[used]
-pub static PICOTOOL_ENTRIES: [embassy_rp::binary_info::EntryAddr; 4] = [
-    embassy_rp::binary_info::rp_program_name!(c"example"),
-    embassy_rp::binary_info::rp_cargo_version!(),
-    embassy_rp::binary_info::rp_program_description!(c"Blinky"),
-    embassy_rp::binary_info::rp_program_build_attribute!(),
-];
-
 const REFRESH_INTERVAL: u64 = 20000;
 
 bind_interrupts!(struct Irqs {

--- a/examples/rp23/src/bin/pio_rotary_encoder.rs
+++ b/examples/rp23/src/bin/pio_rotary_encoder.rs
@@ -17,16 +17,6 @@ use {defmt_rtt as _, panic_probe as _};
 #[used]
 pub static IMAGE_DEF: ImageDef = ImageDef::secure_exe();
 
-// Program metadata for `picotool info`
-#[link_section = ".bi_entries"]
-#[used]
-pub static PICOTOOL_ENTRIES: [embassy_rp::binary_info::EntryAddr; 4] = [
-    embassy_rp::binary_info::rp_program_name!(c"example"),
-    embassy_rp::binary_info::rp_cargo_version!(),
-    embassy_rp::binary_info::rp_program_description!(c"Blinky"),
-    embassy_rp::binary_info::rp_program_build_attribute!(),
-];
-
 bind_interrupts!(struct Irqs {
     PIO0_IRQ_0 => InterruptHandler<PIO0>;
 });

--- a/examples/rp23/src/bin/pio_servo.rs
+++ b/examples/rp23/src/bin/pio_servo.rs
@@ -18,16 +18,6 @@ use {defmt_rtt as _, panic_probe as _};
 #[used]
 pub static IMAGE_DEF: ImageDef = ImageDef::secure_exe();
 
-// Program metadata for `picotool info`
-#[link_section = ".bi_entries"]
-#[used]
-pub static PICOTOOL_ENTRIES: [embassy_rp::binary_info::EntryAddr; 4] = [
-    embassy_rp::binary_info::rp_program_name!(c"example"),
-    embassy_rp::binary_info::rp_cargo_version!(),
-    embassy_rp::binary_info::rp_program_description!(c"Blinky"),
-    embassy_rp::binary_info::rp_program_build_attribute!(),
-];
-
 const DEFAULT_MIN_PULSE_WIDTH: u64 = 1000; // uncalibrated default, the shortest duty cycle sent to a servo
 const DEFAULT_MAX_PULSE_WIDTH: u64 = 2000; // uncalibrated default, the longest duty cycle sent to a servo
 const DEFAULT_MAX_DEGREE_ROTATION: u64 = 160; // 160 degrees is typical

--- a/examples/rp23/src/bin/pio_stepper.rs
+++ b/examples/rp23/src/bin/pio_stepper.rs
@@ -21,16 +21,6 @@ use {defmt_rtt as _, panic_probe as _};
 #[used]
 pub static IMAGE_DEF: ImageDef = ImageDef::secure_exe();
 
-// Program metadata for `picotool info`
-#[link_section = ".bi_entries"]
-#[used]
-pub static PICOTOOL_ENTRIES: [embassy_rp::binary_info::EntryAddr; 4] = [
-    embassy_rp::binary_info::rp_program_name!(c"example"),
-    embassy_rp::binary_info::rp_cargo_version!(),
-    embassy_rp::binary_info::rp_program_description!(c"Blinky"),
-    embassy_rp::binary_info::rp_program_build_attribute!(),
-];
-
 bind_interrupts!(struct Irqs {
     PIO0_IRQ_0 => InterruptHandler<PIO0>;
 });

--- a/examples/rp23/src/bin/pio_ws2812.rs
+++ b/examples/rp23/src/bin/pio_ws2812.rs
@@ -23,16 +23,6 @@ use {defmt_rtt as _, panic_probe as _};
 #[used]
 pub static IMAGE_DEF: ImageDef = ImageDef::secure_exe();
 
-// Program metadata for `picotool info`
-#[link_section = ".bi_entries"]
-#[used]
-pub static PICOTOOL_ENTRIES: [embassy_rp::binary_info::EntryAddr; 4] = [
-    embassy_rp::binary_info::rp_program_name!(c"example"),
-    embassy_rp::binary_info::rp_cargo_version!(),
-    embassy_rp::binary_info::rp_program_description!(c"Blinky"),
-    embassy_rp::binary_info::rp_program_build_attribute!(),
-];
-
 bind_interrupts!(struct Irqs {
     PIO0_IRQ_0 => InterruptHandler<PIO0>;
 });

--- a/examples/rp23/src/bin/pwm.rs
+++ b/examples/rp23/src/bin/pwm.rs
@@ -16,16 +16,6 @@ use {defmt_rtt as _, panic_probe as _};
 #[used]
 pub static IMAGE_DEF: ImageDef = ImageDef::secure_exe();
 
-// Program metadata for `picotool info`
-#[link_section = ".bi_entries"]
-#[used]
-pub static PICOTOOL_ENTRIES: [embassy_rp::binary_info::EntryAddr; 4] = [
-    embassy_rp::binary_info::rp_program_name!(c"example"),
-    embassy_rp::binary_info::rp_cargo_version!(),
-    embassy_rp::binary_info::rp_program_description!(c"Blinky"),
-    embassy_rp::binary_info::rp_program_build_attribute!(),
-];
-
 #[embassy_executor::main]
 async fn main(_spawner: Spawner) {
     let p = embassy_rp::init(Default::default());

--- a/examples/rp23/src/bin/pwm_input.rs
+++ b/examples/rp23/src/bin/pwm_input.rs
@@ -15,16 +15,6 @@ use {defmt_rtt as _, panic_probe as _};
 #[used]
 pub static IMAGE_DEF: ImageDef = ImageDef::secure_exe();
 
-// Program metadata for `picotool info`
-#[link_section = ".bi_entries"]
-#[used]
-pub static PICOTOOL_ENTRIES: [embassy_rp::binary_info::EntryAddr; 4] = [
-    embassy_rp::binary_info::rp_program_name!(c"example"),
-    embassy_rp::binary_info::rp_cargo_version!(),
-    embassy_rp::binary_info::rp_program_description!(c"Blinky"),
-    embassy_rp::binary_info::rp_program_build_attribute!(),
-];
-
 #[embassy_executor::main]
 async fn main(_spawner: Spawner) {
     let p = embassy_rp::init(Default::default());

--- a/examples/rp23/src/bin/rosc.rs
+++ b/examples/rp23/src/bin/rosc.rs
@@ -17,16 +17,6 @@ use {defmt_rtt as _, panic_probe as _};
 #[used]
 pub static IMAGE_DEF: ImageDef = ImageDef::secure_exe();
 
-// Program metadata for `picotool info`
-#[link_section = ".bi_entries"]
-#[used]
-pub static PICOTOOL_ENTRIES: [embassy_rp::binary_info::EntryAddr; 4] = [
-    embassy_rp::binary_info::rp_program_name!(c"example"),
-    embassy_rp::binary_info::rp_cargo_version!(),
-    embassy_rp::binary_info::rp_program_description!(c"Blinky"),
-    embassy_rp::binary_info::rp_program_build_attribute!(),
-];
-
 #[embassy_executor::main]
 async fn main(_spawner: Spawner) {
     let mut config = embassy_rp::config::Config::default();

--- a/examples/rp23/src/bin/shared_bus.rs
+++ b/examples/rp23/src/bin/shared_bus.rs
@@ -23,16 +23,6 @@ use {defmt_rtt as _, panic_probe as _};
 #[used]
 pub static IMAGE_DEF: ImageDef = ImageDef::secure_exe();
 
-// Program metadata for `picotool info`
-#[link_section = ".bi_entries"]
-#[used]
-pub static PICOTOOL_ENTRIES: [embassy_rp::binary_info::EntryAddr; 4] = [
-    embassy_rp::binary_info::rp_program_name!(c"example"),
-    embassy_rp::binary_info::rp_cargo_version!(),
-    embassy_rp::binary_info::rp_program_description!(c"Blinky"),
-    embassy_rp::binary_info::rp_program_build_attribute!(),
-];
-
 type Spi1Bus = Mutex<NoopRawMutex, Spi<'static, SPI1, spi::Async>>;
 type I2c1Bus = Mutex<NoopRawMutex, I2c<'static, I2C1, i2c::Async>>;
 

--- a/examples/rp23/src/bin/sharing.rs
+++ b/examples/rp23/src/bin/sharing.rs
@@ -36,16 +36,6 @@ use {defmt_rtt as _, panic_probe as _};
 #[used]
 pub static IMAGE_DEF: ImageDef = ImageDef::secure_exe();
 
-// Program metadata for `picotool info`
-#[link_section = ".bi_entries"]
-#[used]
-pub static PICOTOOL_ENTRIES: [embassy_rp::binary_info::EntryAddr; 4] = [
-    embassy_rp::binary_info::rp_program_name!(c"example"),
-    embassy_rp::binary_info::rp_cargo_version!(),
-    embassy_rp::binary_info::rp_program_description!(c"Blinky"),
-    embassy_rp::binary_info::rp_program_build_attribute!(),
-];
-
 type UartAsyncMutex = mutex::Mutex<CriticalSectionRawMutex, UartTx<'static, UART0, uart::Async>>;
 
 struct MyType {

--- a/examples/rp23/src/bin/spi.rs
+++ b/examples/rp23/src/bin/spi.rs
@@ -17,16 +17,6 @@ use {defmt_rtt as _, panic_probe as _};
 #[used]
 pub static IMAGE_DEF: ImageDef = ImageDef::secure_exe();
 
-// Program metadata for `picotool info`
-#[link_section = ".bi_entries"]
-#[used]
-pub static PICOTOOL_ENTRIES: [embassy_rp::binary_info::EntryAddr; 4] = [
-    embassy_rp::binary_info::rp_program_name!(c"example"),
-    embassy_rp::binary_info::rp_cargo_version!(),
-    embassy_rp::binary_info::rp_program_description!(c"Blinky"),
-    embassy_rp::binary_info::rp_program_build_attribute!(),
-];
-
 #[embassy_executor::main]
 async fn main(_spawner: Spawner) {
     let p = embassy_rp::init(Default::default());

--- a/examples/rp23/src/bin/spi_async.rs
+++ b/examples/rp23/src/bin/spi_async.rs
@@ -15,16 +15,6 @@ use {defmt_rtt as _, panic_probe as _};
 #[used]
 pub static IMAGE_DEF: ImageDef = ImageDef::secure_exe();
 
-// Program metadata for `picotool info`
-#[link_section = ".bi_entries"]
-#[used]
-pub static PICOTOOL_ENTRIES: [embassy_rp::binary_info::EntryAddr; 4] = [
-    embassy_rp::binary_info::rp_program_name!(c"example"),
-    embassy_rp::binary_info::rp_cargo_version!(),
-    embassy_rp::binary_info::rp_program_description!(c"Blinky"),
-    embassy_rp::binary_info::rp_program_build_attribute!(),
-];
-
 #[embassy_executor::main]
 async fn main(_spawner: Spawner) {
     let p = embassy_rp::init(Default::default());

--- a/examples/rp23/src/bin/spi_display.rs
+++ b/examples/rp23/src/bin/spi_display.rs
@@ -32,16 +32,6 @@ use {defmt_rtt as _, panic_probe as _};
 #[used]
 pub static IMAGE_DEF: ImageDef = ImageDef::secure_exe();
 
-// Program metadata for `picotool info`
-#[link_section = ".bi_entries"]
-#[used]
-pub static PICOTOOL_ENTRIES: [embassy_rp::binary_info::EntryAddr; 4] = [
-    embassy_rp::binary_info::rp_program_name!(c"example"),
-    embassy_rp::binary_info::rp_cargo_version!(),
-    embassy_rp::binary_info::rp_program_description!(c"Blinky"),
-    embassy_rp::binary_info::rp_program_build_attribute!(),
-];
-
 use crate::my_display_interface::SPIDeviceInterface;
 use crate::touch::Touch;
 

--- a/examples/rp23/src/bin/spi_sdmmc.rs
+++ b/examples/rp23/src/bin/spi_sdmmc.rs
@@ -21,16 +21,6 @@ use {defmt_rtt as _, panic_probe as _};
 #[used]
 pub static IMAGE_DEF: ImageDef = ImageDef::secure_exe();
 
-// Program metadata for `picotool info`
-#[link_section = ".bi_entries"]
-#[used]
-pub static PICOTOOL_ENTRIES: [embassy_rp::binary_info::EntryAddr; 4] = [
-    embassy_rp::binary_info::rp_program_name!(c"example"),
-    embassy_rp::binary_info::rp_cargo_version!(),
-    embassy_rp::binary_info::rp_program_description!(c"Blinky"),
-    embassy_rp::binary_info::rp_program_build_attribute!(),
-];
-
 struct DummyTimesource();
 
 impl embedded_sdmmc::TimeSource for DummyTimesource {

--- a/examples/rp23/src/bin/trng.rs
+++ b/examples/rp23/src/bin/trng.rs
@@ -18,16 +18,6 @@ use {defmt_rtt as _, panic_probe as _};
 #[used]
 pub static IMAGE_DEF: ImageDef = ImageDef::secure_exe();
 
-// Program metadata for `picotool info`
-#[link_section = ".bi_entries"]
-#[used]
-pub static PICOTOOL_ENTRIES: [embassy_rp::binary_info::EntryAddr; 4] = [
-    embassy_rp::binary_info::rp_program_name!(c"example"),
-    embassy_rp::binary_info::rp_cargo_version!(),
-    embassy_rp::binary_info::rp_program_description!(c"Blinky"),
-    embassy_rp::binary_info::rp_program_build_attribute!(),
-];
-
 bind_interrupts!(struct Irqs {
     TRNG_IRQ => embassy_rp::trng::InterruptHandler<TRNG>;
 });

--- a/examples/rp23/src/bin/uart.rs
+++ b/examples/rp23/src/bin/uart.rs
@@ -16,16 +16,6 @@ use {defmt_rtt as _, panic_probe as _};
 #[used]
 pub static IMAGE_DEF: ImageDef = ImageDef::secure_exe();
 
-// Program metadata for `picotool info`
-#[link_section = ".bi_entries"]
-#[used]
-pub static PICOTOOL_ENTRIES: [embassy_rp::binary_info::EntryAddr; 4] = [
-    embassy_rp::binary_info::rp_program_name!(c"example"),
-    embassy_rp::binary_info::rp_cargo_version!(),
-    embassy_rp::binary_info::rp_program_description!(c"Blinky"),
-    embassy_rp::binary_info::rp_program_build_attribute!(),
-];
-
 #[embassy_executor::main]
 async fn main(_spawner: Spawner) {
     let p = embassy_rp::init(Default::default());

--- a/examples/rp23/src/bin/uart_buffered_split.rs
+++ b/examples/rp23/src/bin/uart_buffered_split.rs
@@ -22,16 +22,6 @@ use {defmt_rtt as _, panic_probe as _};
 #[used]
 pub static IMAGE_DEF: ImageDef = ImageDef::secure_exe();
 
-// Program metadata for `picotool info`
-#[link_section = ".bi_entries"]
-#[used]
-pub static PICOTOOL_ENTRIES: [embassy_rp::binary_info::EntryAddr; 4] = [
-    embassy_rp::binary_info::rp_program_name!(c"example"),
-    embassy_rp::binary_info::rp_cargo_version!(),
-    embassy_rp::binary_info::rp_program_description!(c"Blinky"),
-    embassy_rp::binary_info::rp_program_build_attribute!(),
-];
-
 bind_interrupts!(struct Irqs {
     UART0_IRQ => BufferedInterruptHandler<UART0>;
 });

--- a/examples/rp23/src/bin/uart_r503.rs
+++ b/examples/rp23/src/bin/uart_r503.rs
@@ -15,16 +15,6 @@ use {defmt_rtt as _, panic_probe as _};
 #[used]
 pub static IMAGE_DEF: ImageDef = ImageDef::secure_exe();
 
-// Program metadata for `picotool info`
-#[link_section = ".bi_entries"]
-#[used]
-pub static PICOTOOL_ENTRIES: [embassy_rp::binary_info::EntryAddr; 4] = [
-    embassy_rp::binary_info::rp_program_name!(c"example"),
-    embassy_rp::binary_info::rp_cargo_version!(),
-    embassy_rp::binary_info::rp_program_description!(c"Blinky"),
-    embassy_rp::binary_info::rp_program_build_attribute!(),
-];
-
 bind_interrupts!(pub struct Irqs {
     UART0_IRQ  => UARTInterruptHandler<UART0>;
 });

--- a/examples/rp23/src/bin/uart_unidir.rs
+++ b/examples/rp23/src/bin/uart_unidir.rs
@@ -21,16 +21,6 @@ use {defmt_rtt as _, panic_probe as _};
 #[used]
 pub static IMAGE_DEF: ImageDef = ImageDef::secure_exe();
 
-// Program metadata for `picotool info`
-#[link_section = ".bi_entries"]
-#[used]
-pub static PICOTOOL_ENTRIES: [embassy_rp::binary_info::EntryAddr; 4] = [
-    embassy_rp::binary_info::rp_program_name!(c"example"),
-    embassy_rp::binary_info::rp_cargo_version!(),
-    embassy_rp::binary_info::rp_program_description!(c"Blinky"),
-    embassy_rp::binary_info::rp_program_build_attribute!(),
-];
-
 bind_interrupts!(struct Irqs {
     UART1_IRQ => InterruptHandler<UART1>;
 });

--- a/examples/rp23/src/bin/usb_webusb.rs
+++ b/examples/rp23/src/bin/usb_webusb.rs
@@ -34,16 +34,6 @@ use {defmt_rtt as _, panic_probe as _};
 #[used]
 pub static IMAGE_DEF: ImageDef = ImageDef::secure_exe();
 
-// Program metadata for `picotool info`
-#[link_section = ".bi_entries"]
-#[used]
-pub static PICOTOOL_ENTRIES: [embassy_rp::binary_info::EntryAddr; 4] = [
-    embassy_rp::binary_info::rp_program_name!(c"example"),
-    embassy_rp::binary_info::rp_cargo_version!(),
-    embassy_rp::binary_info::rp_program_description!(c"Blinky"),
-    embassy_rp::binary_info::rp_program_build_attribute!(),
-];
-
 bind_interrupts!(struct Irqs {
     USBCTRL_IRQ => InterruptHandler<USB>;
 });

--- a/examples/rp23/src/bin/watchdog.rs
+++ b/examples/rp23/src/bin/watchdog.rs
@@ -18,16 +18,6 @@ use {defmt_rtt as _, panic_probe as _};
 #[used]
 pub static IMAGE_DEF: ImageDef = ImageDef::secure_exe();
 
-// Program metadata for `picotool info`
-#[link_section = ".bi_entries"]
-#[used]
-pub static PICOTOOL_ENTRIES: [embassy_rp::binary_info::EntryAddr; 4] = [
-    embassy_rp::binary_info::rp_program_name!(c"example"),
-    embassy_rp::binary_info::rp_cargo_version!(),
-    embassy_rp::binary_info::rp_program_description!(c"Blinky"),
-    embassy_rp::binary_info::rp_program_build_attribute!(),
-];
-
 #[embassy_executor::main]
 async fn main(_spawner: Spawner) {
     let p = embassy_rp::init(Default::default());

--- a/examples/rp23/src/bin/zerocopy.rs
+++ b/examples/rp23/src/bin/zerocopy.rs
@@ -23,16 +23,6 @@ use {defmt_rtt as _, panic_probe as _};
 #[used]
 pub static IMAGE_DEF: ImageDef = ImageDef::secure_exe();
 
-// Program metadata for `picotool info`
-#[link_section = ".bi_entries"]
-#[used]
-pub static PICOTOOL_ENTRIES: [embassy_rp::binary_info::EntryAddr; 4] = [
-    embassy_rp::binary_info::rp_program_name!(c"example"),
-    embassy_rp::binary_info::rp_cargo_version!(),
-    embassy_rp::binary_info::rp_program_description!(c"Blinky"),
-    embassy_rp::binary_info::rp_program_build_attribute!(),
-];
-
 type SampleBuffer = [u16; 512];
 
 bind_interrupts!(struct Irqs {


### PR DESCRIPTION
I shouldn't have added these to begin with as they're not needed, and I forgot to customize them per example. I left the blinky example alone to show usage. Also fixed the pin for the blinky example, not sure when I broke that.

closes  #3333