### PR TITLE
Fixed overflow on `pio_stepper.rs`

### DIFF
--- a/examples/rp/src/bin/pio_stepper.rs
+++ b/examples/rp/src/bin/pio_stepper.rs
@@ -154,7 +154,7 @@ async fn main(_spawner: Spawner) {
         stepper.step(1000).await;
 
         info!("CCW full steps, drop after 1 sec");
-        if let Err(_) = with_timeout(Duration::from_secs(1), stepper.step(i32::MIN)).await {
+        if let Err(_) = with_timeout(Duration::from_secs(1), stepper.step(-i32::MAX)).await {
             info!("Time's up!");
             Timer::after(Duration::from_secs(1)).await;
         }


### PR DESCRIPTION
Simple 4 character change to fix an overflow that occurs when negating `i32::MIN`.

## The problem
Overflow that occurs when negating `i32::MIN`.
This happens because a signed integer can hold one more negative number than it can positive numbers. So for an `i32` it's from `-2^31` to `2^31-1`. As a result, when `i32::MIN` (`-2^31`) is negated in the `step` impl, it becomes `2^31`, which is more than `i32::MAX` (`2^31-1`).

This would cause a panic in --dev and while it doesn't panic in --release, it causes an overflow which is confusing for a simple example.

## The solution
change `i32::MIN` to `-i32::MAX` which is equivalent to `i32::MIN+1`