### PR TITLE
Update smoltcp, embedded-nal-async to use the `core::net` IP addr types.

### DIFF
--- a/embassy-net-ppp/Cargo.toml
+++ b/embassy-net-ppp/Cargo.toml
@@ -20,7 +20,7 @@ log = { version = "0.4.14", optional = true }
 embedded-io-async = { version = "0.6.1" }
 embassy-net-driver-channel = { version = "0.3.0", path = "../embassy-net-driver-channel" }
 embassy-futures = { version = "0.1.0", path = "../embassy-futures" }
-ppproto = { version = "0.1.2"}
+ppproto = { version = "0.2.0"}
 embassy-sync = { version = "0.6.0", path = "../embassy-sync" }
 
 [package.metadata.embassy_docs]

--- a/embassy-net/Cargo.toml
+++ b/embassy-net/Cargo.toml
@@ -68,7 +68,7 @@ multicast = ["smoltcp/multicast"]
 defmt = { version = "0.3", optional = true }
 log = { version = "0.4.14", optional = true }
 
-smoltcp = { git="https://github.com/smoltcp-rs/smoltcp", rev="dd43c8f189178b0ab3bda798ed8578b5b0a6f094", default-features = false, features = [
+smoltcp = { git="https://github.com/smoltcp-rs/smoltcp", rev="b65e1b64dc9b66fa984a2ad34e90685cb0b606de", default-features = false, features = [
   "socket",
   "async",
 ] }
@@ -80,5 +80,5 @@ embedded-io-async = { version = "0.6.1" }
 
 managed = { version = "0.8.0", default-features = false, features = [ "map" ] }
 heapless = { version = "0.8", default-features = false }
-embedded-nal-async = { version = "0.7.1" }
+embedded-nal-async = "0.8.0"
 document-features = "0.2.7"

--- a/embassy-net/src/dns.rs
+++ b/embassy-net/src/dns.rs
@@ -73,8 +73,11 @@ impl<'a> embedded_nal_async::Dns for DnsSocket<'a> {
         &self,
         host: &str,
         addr_type: embedded_nal_async::AddrType,
-    ) -> Result<embedded_nal_async::IpAddr, Self::Error> {
-        use embedded_nal_async::{AddrType, IpAddr};
+    ) -> Result<core::net::IpAddr, Self::Error> {
+        use core::net::IpAddr;
+
+        use embedded_nal_async::AddrType;
+
         let (qtype, secondary_qtype) = match addr_type {
             AddrType::IPv4 => (DnsQueryType::A, None),
             AddrType::IPv6 => (DnsQueryType::Aaaa, None),
@@ -98,20 +101,16 @@ impl<'a> embedded_nal_async::Dns for DnsSocket<'a> {
         if let Some(first) = addrs.get(0) {
             Ok(match first {
                 #[cfg(feature = "proto-ipv4")]
-                IpAddress::Ipv4(addr) => IpAddr::V4(addr.0.into()),
+                IpAddress::Ipv4(addr) => IpAddr::V4(*addr),
                 #[cfg(feature = "proto-ipv6")]
-                IpAddress::Ipv6(addr) => IpAddr::V6(addr.0.into()),
+                IpAddress::Ipv6(addr) => IpAddr::V6(*addr),
             })
         } else {
             Err(Error::Failed)
         }
     }
 
-    async fn get_host_by_address(
-        &self,
-        _addr: embedded_nal_async::IpAddr,
-        _result: &mut [u8],
-    ) -> Result<usize, Self::Error> {
+    async fn get_host_by_address(&self, _addr: core::net::IpAddr, _result: &mut [u8]) -> Result<usize, Self::Error> {
         todo!()
     }
 }

--- a/embassy-net/src/tcp.rs
+++ b/embassy-net/src/tcp.rs
@@ -675,9 +675,8 @@ mod embedded_io_impls {
 pub mod client {
     use core::cell::{Cell, UnsafeCell};
     use core::mem::MaybeUninit;
+    use core::net::IpAddr;
     use core::ptr::NonNull;
-
-    use embedded_nal_async::IpAddr;
 
     use super::*;
 
@@ -715,17 +714,14 @@ pub mod client {
         type Error = Error;
         type Connection<'m> = TcpConnection<'m, N, TX_SZ, RX_SZ> where Self: 'm;
 
-        async fn connect<'a>(
-            &'a self,
-            remote: embedded_nal_async::SocketAddr,
-        ) -> Result<Self::Connection<'a>, Self::Error> {
+        async fn connect<'a>(&'a self, remote: core::net::SocketAddr) -> Result<Self::Connection<'a>, Self::Error> {
             let addr: crate::IpAddress = match remote.ip() {
                 #[cfg(feature = "proto-ipv4")]
-                IpAddr::V4(addr) => crate::IpAddress::Ipv4(crate::Ipv4Address::from_bytes(&addr.octets())),
+                IpAddr::V4(addr) => crate::IpAddress::Ipv4(addr),
                 #[cfg(not(feature = "proto-ipv4"))]
                 IpAddr::V4(_) => panic!("ipv4 support not enabled"),
                 #[cfg(feature = "proto-ipv6")]
-                IpAddr::V6(addr) => crate::IpAddress::Ipv6(crate::Ipv6Address::from_bytes(&addr.octets())),
+                IpAddr::V6(addr) => crate::IpAddress::Ipv6(addr),
                 #[cfg(not(feature = "proto-ipv6"))]
                 IpAddr::V6(_) => panic!("ipv6 support not enabled"),
             };

--- a/examples/nrf9160/src/bin/modem_tcp_client.rs
+++ b/examples/nrf9160/src/bin/modem_tcp_client.rs
@@ -9,7 +9,7 @@ use core::str::FromStr;
 
 use defmt::{info, unwrap, warn};
 use embassy_executor::Spawner;
-use embassy_net::{Ipv4Address, Ipv4Cidr, Stack, StackResources};
+use embassy_net::{Ipv4Cidr, Stack, StackResources};
 use embassy_net_nrf91::context::Status;
 use embassy_net_nrf91::{context, Runner, State, TraceBuffer, TraceReader};
 use embassy_nrf::buffered_uarte::{self, BufferedUarteTx};
@@ -70,18 +70,16 @@ fn status_to_config(status: &Status) -> embassy_net::ConfigV4 {
     let Some(IpAddr::V4(addr)) = status.ip else {
         panic!("Unexpected IP address");
     };
-    let addr = Ipv4Address(addr.octets());
 
-    let gateway = if let Some(IpAddr::V4(addr)) = status.gateway {
-        Some(Ipv4Address(addr.octets()))
-    } else {
-        None
+    let gateway = match status.gateway {
+        Some(IpAddr::V4(addr)) => Some(addr),
+        _ => None,
     };
 
     let mut dns_servers = Vec::new();
     for dns in status.dns.iter() {
         if let IpAddr::V4(ip) = dns {
-            unwrap!(dns_servers.push(Ipv4Address(ip.octets())));
+            unwrap!(dns_servers.push(*ip));
         }
     }
 

--- a/examples/rp/Cargo.toml
+++ b/examples/rp/Cargo.toml
@@ -12,7 +12,7 @@ embassy-executor = { version = "0.6.0", path = "../../embassy-executor", feature
 embassy-time = { version = "0.3.2", path = "../../embassy-time", features = ["defmt", "defmt-timestamp-uptime"] }
 embassy-rp = { version = "0.2.0", path = "../../embassy-rp", features = ["defmt", "unstable-pac", "time-driver", "critical-section-impl", "rp2040"] }
 embassy-usb = { version = "0.3.0", path = "../../embassy-usb", features = ["defmt"] }
-embassy-net = { version = "0.4.0", path = "../../embassy-net", features = ["defmt", "tcp", "udp", "raw", "dhcpv4", "medium-ethernet", "dns"] }
+embassy-net = { version = "0.4.0", path = "../../embassy-net", features = ["defmt", "tcp", "udp", "raw", "dhcpv4", "medium-ethernet", "dns", "proto-ipv4", "proto-ipv6", "multicast"] }
 embassy-net-wiznet = { version = "0.1.0", path = "../../embassy-net-wiznet", features = ["defmt"] }
 embassy-futures = { version = "0.1.0", path = "../../embassy-futures" }
 embassy-usb-logger = { version = "0.2.0", path = "../../embassy-usb-logger" }
@@ -25,7 +25,7 @@ fixed = "1.23.1"
 fixed-macro = "1.2"
 
 # for web request example
-reqwless = { version = "0.12.0", features = ["defmt",]}
+reqwless = { git="https://github.com/drogue-iot/reqwless", rev="673e8d2cfbaad79254ec51fa50cc8b697531fbff", features = ["defmt",]}
 serde = { version = "1.0.203", default-features = false, features = ["derive"] }
 serde-json-core = "0.5.1"
 

--- a/examples/rp23/Cargo.toml
+++ b/examples/rp23/Cargo.toml
@@ -24,8 +24,6 @@ defmt-rtt = "0.4"
 fixed = "1.23.1"
 fixed-macro = "1.2"
 
-# for web request example
-reqwless = { version = "0.12.0", features = ["defmt",]}
 serde = { version = "1.0.203", default-features = false, features = ["derive"] }
 serde-json-core = "0.5.1"
 

--- a/examples/std/src/bin/net_ppp.rs
+++ b/examples/std/src/bin/net_ppp.rs
@@ -16,7 +16,7 @@ use async_io::Async;
 use clap::Parser;
 use embassy_executor::{Executor, Spawner};
 use embassy_net::tcp::TcpSocket;
-use embassy_net::{Config, ConfigV4, Ipv4Address, Ipv4Cidr, Stack, StackResources};
+use embassy_net::{Config, ConfigV4, Ipv4Cidr, Stack, StackResources};
 use embassy_net_ppp::Runner;
 use embedded_io_async::Write;
 use futures::io::BufReader;
@@ -60,10 +60,10 @@ async fn ppp_task(stack: Stack<'static>, mut runner: Runner<'static>, port: Seri
             };
             let mut dns_servers = Vec::new();
             for s in ipv4.dns_servers.iter().flatten() {
-                let _ = dns_servers.push(Ipv4Address::from_bytes(&s.0));
+                let _ = dns_servers.push(*s);
             }
             let config = ConfigV4::Static(embassy_net::StaticConfigV4 {
-                address: Ipv4Cidr::new(Ipv4Address::from_bytes(&addr.0), 0),
+                address: Ipv4Cidr::new(addr, 0),
                 gateway: None,
                 dns_servers,
             });

--- a/examples/stm32h5/Cargo.toml
+++ b/examples/stm32h5/Cargo.toml
@@ -23,7 +23,7 @@ embedded-hal = "0.2.6"
 embedded-hal-1 = { package = "embedded-hal", version = "1.0" }
 embedded-hal-async = { version = "1.0" }
 embedded-io-async = { version = "0.6.1" }
-embedded-nal-async = { version = "0.7.1" }
+embedded-nal-async = "0.8.0"
 panic-probe = { version = "0.3", features = ["print-defmt"] }
 heapless = { version = "0.8", default-features = false }
 rand_core = "0.6.3"

--- a/examples/stm32h7/Cargo.toml
+++ b/examples/stm32h7/Cargo.toml
@@ -23,7 +23,7 @@ cortex-m-rt = "0.7.0"
 embedded-hal = "0.2.6"
 embedded-hal-1 = { package = "embedded-hal", version = "1.0" }
 embedded-hal-async = { version = "1.0" }
-embedded-nal-async = { version = "0.7.1" }
+embedded-nal-async = "0.8.0"
 embedded-io-async = { version = "0.6.1" }
 panic-probe = { version = "0.3", features = ["print-defmt"] }
 heapless = { version = "0.8", default-features = false }

--- a/examples/stm32h7/src/bin/eth_client.rs
+++ b/examples/stm32h7/src/bin/eth_client.rs
@@ -1,6 +1,8 @@
 #![no_std]
 #![no_main]
 
+use core::net::{Ipv4Addr, SocketAddr, SocketAddrV4};
+
 use defmt::*;
 use embassy_executor::Spawner;
 use embassy_net::tcp::client::{TcpClient, TcpClientState};
@@ -12,7 +14,7 @@ use embassy_stm32::rng::Rng;
 use embassy_stm32::{bind_interrupts, eth, peripherals, rng, Config};
 use embassy_time::Timer;
 use embedded_io_async::Write;
-use embedded_nal_async::{Ipv4Addr, SocketAddr, SocketAddrV4, TcpConnect};
+use embedded_nal_async::TcpConnect;
 use rand_core::RngCore;
 use static_cell::StaticCell;
 use {defmt_rtt as _, panic_probe as _};

--- a/examples/stm32h7/src/bin/eth_client_mii.rs
+++ b/examples/stm32h7/src/bin/eth_client_mii.rs
@@ -1,6 +1,8 @@
 #![no_std]
 #![no_main]
 
+use core::net::{Ipv4Addr, SocketAddr, SocketAddrV4};
+
 use defmt::*;
 use embassy_executor::Spawner;
 use embassy_net::tcp::client::{TcpClient, TcpClientState};
@@ -12,7 +14,7 @@ use embassy_stm32::rng::Rng;
 use embassy_stm32::{bind_interrupts, eth, peripherals, rng, Config};
 use embassy_time::Timer;
 use embedded_io_async::Write;
-use embedded_nal_async::{Ipv4Addr, SocketAddr, SocketAddrV4, TcpConnect};
+use embedded_nal_async::TcpConnect;
 use rand_core::RngCore;
 use static_cell::StaticCell;
 use {defmt_rtt as _, panic_probe as _};

--- a/examples/stm32h755cm4/Cargo.toml
+++ b/examples/stm32h755cm4/Cargo.toml
@@ -23,7 +23,7 @@ cortex-m-rt = "0.7.0"
 embedded-hal = "0.2.6"
 embedded-hal-1 = { package = "embedded-hal", version = "1.0" }
 embedded-hal-async = { version = "1.0" }
-embedded-nal-async = { version = "0.7.1" }
+embedded-nal-async = "0.8.0"
 embedded-io-async = { version = "0.6.1" }
 panic-probe = { version = "0.3", features = ["print-defmt"] }
 heapless = { version = "0.8", default-features = false }

--- a/examples/stm32h755cm7/Cargo.toml
+++ b/examples/stm32h755cm7/Cargo.toml
@@ -23,7 +23,7 @@ cortex-m-rt = "0.7.0"
 embedded-hal = "0.2.6"
 embedded-hal-1 = { package = "embedded-hal", version = "1.0" }
 embedded-hal-async = { version = "1.0" }
-embedded-nal-async = { version = "0.7.1" }
+embedded-nal-async = "0.8.0"
 embedded-io-async = { version = "0.6.1" }
 panic-probe = { version = "0.3", features = ["print-defmt"] }
 heapless = { version = "0.8", default-features = false }

--- a/examples/stm32h7rs/Cargo.toml
+++ b/examples/stm32h7rs/Cargo.toml
@@ -22,7 +22,7 @@ cortex-m-rt = "0.7.0"
 embedded-hal = "0.2.6"
 embedded-hal-1 = { package = "embedded-hal", version = "1.0" }
 embedded-hal-async = { version = "1.0" }
-embedded-nal-async = { version = "0.7.1" }
+embedded-nal-async = "0.8.0"
 embedded-io-async = { version = "0.6.1" }
 panic-probe = { version = "0.3", features = ["print-defmt"] }
 heapless = { version = "0.8", default-features = false }

--- a/examples/stm32l4/src/bin/spe_adin1110_http_server.rs
+++ b/examples/stm32l4/src/bin/spe_adin1110_http_server.rs
@@ -51,7 +51,7 @@ bind_interrupts!(struct Irqs {
 // MAC-address used by the adin1110
 const MAC: [u8; 6] = [0xaa, 0xbb, 0xcc, 0xdd, 0xee, 0xff];
 // Static IP settings
-const IP_ADDRESS: Ipv4Cidr = Ipv4Cidr::new(Ipv4Address([192, 168, 1, 5]), 24);
+const IP_ADDRESS: Ipv4Cidr = Ipv4Cidr::new(Ipv4Address::new(192, 168, 1, 5), 24);
 // Listen port for the webserver
 const HTTP_LISTEN_PORT: u16 = 80;
 


### PR DESCRIPTION
Depends on
- https://github.com/smoltcp-rs/smoltcp/pull/994
- https://github.com/drogue-iot/reqwless/pull/91


