### PR TITLE
stm32: fix low-power EXTI IRQ handler dropped edges

### DIFF
--- a/embassy-stm32/src/exti.rs
+++ b/embassy-stm32/src/exti.rs
@@ -41,9 +41,6 @@ fn exticr_regs() -> pac::afio::Afio {
 }
 
 unsafe fn on_irq() {
-    #[cfg(feature = "low-power")]
-    crate::low_power::on_wakeup_irq();
-
     #[cfg(not(any(exti_c0, exti_g0, exti_u0, exti_l5, exti_u5, exti_h5, exti_h50)))]
     let bits = EXTI.pr(0).read().0;
     #[cfg(any(exti_c0, exti_g0, exti_u0, exti_l5, exti_u5, exti_h5, exti_h50))]
@@ -68,6 +65,9 @@ unsafe fn on_irq() {
         EXTI.rpr(0).write_value(Lines(bits));
         EXTI.fpr(0).write_value(Lines(bits));
     }
+
+    #[cfg(feature = "low-power")]
+    crate::low_power::on_wakeup_irq();
 }
 
 struct BitIter(u32);


### PR DESCRIPTION
The STM32 low-power executor's `on-wakeup-irq` function was being called too early and causing the interrupt handler to miss edges.

The root cause is the EXTI IRQ pending bits being wiped before they were checked - specifically `EXTI.pr(0).read().0` did not contain a trigger once `on-wakeup-irq` was called.

Moving `on-wakeup-irq` to be called after checking the EXTI Pending register solved the issue.

Before this patch, the system would not wake up on a single edge:
<img width="1527" alt="Screenshot 2024-10-08 at 11 10 00 AM" src="https://github.com/user-attachments/assets/6e96d86e-ff5f-4d51-bbdf-c4e2d0a89b85">

After the patch, the edge is recognized and the system wakes:
<img width="1522" alt="Screenshot 2024-10-08 at 11 07 53 AM" src="https://github.com/user-attachments/assets/8b97e4e4-af3a-4038-846f-2a9d228824a8">

By the way - I'd sometimes found that when I pushed a physical button to trigger the interrupt, the interrupt would wake the system, but when I used a microcontroller to trigger a single edge, it would not. This was because of the button bounce adding additional edges which *re*-asserted the IRQ bit in time for it to be checked.
