### PR TITLE
stm32/i2c: disable pullup instead of pulling down

### DIFF
--- a/embassy-stm32/src/i2c/mod.rs
+++ b/embassy-stm32/src/i2c/mod.rs
@@ -88,7 +88,7 @@ impl Config {
             Speed::Medium,
             match self.scl_pullup {
                 true => Pull::Up,
-                false => Pull::Down,
+                false => Pull::None,
             },
         );
     }
@@ -102,7 +102,7 @@ impl Config {
             Speed::Medium,
             match self.sda_pullup {
                 true => Pull::Up,
-                false => Pull::Down,
+                false => Pull::None,
             },
         );
     }


### PR DESCRIPTION
In https://github.com/embassy-rs/embassy/pull/3006 it was changed, that i2c gpios are set to [`Pull::Down`](https://github.com/embassy-rs/embassy/pull/3006/files#diff-1b049bff4df5ffd83afbc0ca47e2fc15d4defdca34d546c1602f799e7a66b1baR86) instead of the previous [`Pull::None`](https://github.com/embassy-rs/embassy/pull/3006/files#diff-1b049bff4df5ffd83afbc0ca47e2fc15d4defdca34d546c1602f799e7a66b1baL138), when [`Config::scl_pullup`](https://github.com/embassy-rs/embassy/blame/456c226b29799f7db56ab60b0ae3d95cc7d6a32a/embassy-stm32/src/i2c/mod.rs#L72) is set to `false` (which is the default). 

I don't think this was an intended change and I can't think of a scenario, where a `Pull::Down` is needed for the I2C bus. 

This merge request changes it to be `Pull::None` again. 