### PR TITLE
cyw43: make bluetooth module public

### DIFF
--- a/cyw43/src/lib.rs
+++ b/cyw43/src/lib.rs
@@ -9,7 +9,8 @@
 pub(crate) mod fmt;
 
 #[cfg(feature = "bluetooth")]
-mod bluetooth;
+/// Bluetooth module.
+pub mod bluetooth;
 mod bus;
 mod consts;
 mod control;


### PR DESCRIPTION
The current implementation makes BtDriver and friends private, making it public will improve DX.