### PR TITLE
add RTR flag if it is remote frame

### DIFF
--- a/embassy-stm32/src/can/bxcan/registers.rs
+++ b/embassy-stm32/src/can/bxcan/registers.rs
@@ -2,7 +2,7 @@ use core::cmp::Ordering;
 use core::convert::Infallible;
 
 pub use embedded_can::{ExtendedId, Id, StandardId};
-use stm32_metapac::can::vals::Lec;
+use stm32_metapac::can::vals::{Lec, Rtr};
 
 use super::{Mailbox, TransmitStatus};
 use crate::can::enums::BusError;
@@ -306,6 +306,9 @@ impl Registers {
         mb.tir().write(|w| {
             w.0 = id.0;
             w.set_txrq(true);
+            if frame.header().rtr() {
+                w.set_rtr(Rtr::REMOTE);
+            }
         });
     }
 


### PR DESCRIPTION
Added RTR flag for transmit frame.
Previous version: remote frame will be sent as data frame with eight `0x00` bytes

Fixed issue from: https://github.com/embassy-rs/embassy/issues/3413

![image](https://github.com/user-attachments/assets/5bd57fac-c75a-4311-9244-60c97d3445e9)
