### PR TITLE
executor: improve macro error messages, add compile-fail / ui tests.

### DIFF
--- a/.github/ci/test-nightly.sh
+++ b/.github/ci/test-nightly.sh
@@ -9,6 +9,9 @@ export CARGO_HOME=/ci/cache/cargo
 export CARGO_TARGET_DIR=/ci/cache/target
 mv rust-toolchain-nightly.toml rust-toolchain.toml
 
+cargo test --manifest-path ./embassy-executor/Cargo.toml
+cargo test --manifest-path ./embassy-executor/Cargo.toml --features nightly
+
 MIRIFLAGS=-Zmiri-ignore-leaks cargo miri test --manifest-path ./embassy-executor/Cargo.toml
 MIRIFLAGS=-Zmiri-ignore-leaks cargo miri test --manifest-path ./embassy-executor/Cargo.toml --features nightly
 MIRIFLAGS=-Zmiri-ignore-leaks cargo miri test --manifest-path ./embassy-sync/Cargo.toml

--- a/.github/ci/test.sh
+++ b/.github/ci/test.sh
@@ -12,6 +12,7 @@ export CARGO_TARGET_DIR=/ci/cache/target
 # used when pointing stm32-metapac to a CI-built one.
 export CARGO_NET_GIT_FETCH_WITH_CLI=true
 
+cargo test --manifest-path ./embassy-executor/Cargo.toml
 cargo test --manifest-path ./embassy-futures/Cargo.toml
 cargo test --manifest-path ./embassy-sync/Cargo.toml
 cargo test --manifest-path ./embassy-embedded-hal/Cargo.toml

--- a/embassy-executor/Cargo.toml
+++ b/embassy-executor/Cargo.toml
@@ -55,7 +55,7 @@ avr-device = { version = "0.5.3", optional = true }
 
 [dev-dependencies]
 critical-section = { version = "1.1", features = ["std"] }
-
+trybuild = "1.0"
 
 [features]
 

--- a/embassy-executor/tests/ui.rs
+++ b/embassy-executor/tests/ui.rs
@@ -1,0 +1,23 @@
+#[cfg(not(miri))]
+#[test]
+fn ui() {
+    let t = trybuild::TestCases::new();
+    t.compile_fail("tests/ui/abi.rs");
+    t.compile_fail("tests/ui/bad_return.rs");
+    t.compile_fail("tests/ui/generics.rs");
+    t.compile_fail("tests/ui/impl_trait_nested.rs");
+    t.compile_fail("tests/ui/impl_trait.rs");
+    t.compile_fail("tests/ui/impl_trait_static.rs");
+    t.compile_fail("tests/ui/nonstatic_ref_anon_nested.rs");
+    t.compile_fail("tests/ui/nonstatic_ref_anon.rs");
+    t.compile_fail("tests/ui/nonstatic_ref_elided.rs");
+    t.compile_fail("tests/ui/nonstatic_ref_generic.rs");
+    t.compile_fail("tests/ui/nonstatic_struct_anon.rs");
+    #[cfg(not(feature = "nightly"))] // we can't catch this case with the macro, so the output changes on nightly.
+    t.compile_fail("tests/ui/nonstatic_struct_elided.rs");
+    t.compile_fail("tests/ui/nonstatic_struct_generic.rs");
+    t.compile_fail("tests/ui/not_async.rs");
+    t.compile_fail("tests/ui/self_ref.rs");
+    t.compile_fail("tests/ui/self.rs");
+    t.compile_fail("tests/ui/where_clause.rs");
+}

--- a/embassy-executor/tests/ui/abi.rs
+++ b/embassy-executor/tests/ui/abi.rs
@@ -1,0 +1,8 @@
+#![cfg_attr(feature = "nightly", feature(impl_trait_in_assoc_type))]
+
+struct Foo<'a>(&'a ());
+
+#[embassy_executor::task]
+async extern "C" fn task() {}
+
+fn main() {}

--- a/embassy-executor/tests/ui/abi.stderr
+++ b/embassy-executor/tests/ui/abi.stderr
@@ -1,0 +1,5 @@
+error: task functions must not have an ABI qualifier
+ --> tests/ui/abi.rs:6:1
+  |
+6 | async extern "C" fn task() {}
+  | ^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/embassy-executor/tests/ui/bad_return.rs
+++ b/embassy-executor/tests/ui/bad_return.rs
@@ -1,0 +1,10 @@
+#![cfg_attr(feature = "nightly", feature(impl_trait_in_assoc_type))]
+
+struct Foo<'a>(&'a ());
+
+#[embassy_executor::task]
+async fn task() -> u32 {
+    5
+}
+
+fn main() {}

--- a/embassy-executor/tests/ui/bad_return.stderr
+++ b/embassy-executor/tests/ui/bad_return.stderr
@@ -1,0 +1,5 @@
+error: task functions must either not return a value, return `()` or return `!`
+ --> tests/ui/bad_return.rs:6:1
+  |
+6 | async fn task() -> u32 {
+  | ^^^^^^^^^^^^^^^^^^^^^^

--- a/embassy-executor/tests/ui/generics.rs
+++ b/embassy-executor/tests/ui/generics.rs
@@ -1,0 +1,8 @@
+#![cfg_attr(feature = "nightly", feature(impl_trait_in_assoc_type))]
+
+struct Foo<'a>(&'a ());
+
+#[embassy_executor::task]
+async fn task<T: Sized>(_t: T) {}
+
+fn main() {}

--- a/embassy-executor/tests/ui/generics.stderr
+++ b/embassy-executor/tests/ui/generics.stderr
@@ -1,0 +1,5 @@
+error: task functions must not be generic
+ --> tests/ui/generics.rs:6:1
+  |
+6 | async fn task<T: Sized>(_t: T) {}
+  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/embassy-executor/tests/ui/impl_trait.rs
+++ b/embassy-executor/tests/ui/impl_trait.rs
@@ -1,0 +1,6 @@
+#![cfg_attr(feature = "nightly", feature(impl_trait_in_assoc_type))]
+
+#[embassy_executor::task]
+async fn foo(_x: impl Sized) {}
+
+fn main() {}

--- a/embassy-executor/tests/ui/impl_trait.stderr
+++ b/embassy-executor/tests/ui/impl_trait.stderr
@@ -1,0 +1,5 @@
+error: `impl Trait` is not allowed in task arguments. It is syntax sugar for generics, and tasks can't be generic.
+ --> tests/ui/impl_trait.rs:4:18
+  |
+4 | async fn foo(_x: impl Sized) {}
+  |                  ^^^^^^^^^^

--- a/embassy-executor/tests/ui/impl_trait_nested.rs
+++ b/embassy-executor/tests/ui/impl_trait_nested.rs
@@ -1,0 +1,8 @@
+#![cfg_attr(feature = "nightly", feature(impl_trait_in_assoc_type))]
+
+struct Foo<T>(T);
+
+#[embassy_executor::task]
+async fn foo(_x: Foo<impl Sized + 'static>) {}
+
+fn main() {}

--- a/embassy-executor/tests/ui/impl_trait_nested.stderr
+++ b/embassy-executor/tests/ui/impl_trait_nested.stderr
@@ -1,0 +1,5 @@
+error: `impl Trait` is not allowed in task arguments. It is syntax sugar for generics, and tasks can't be generic.
+ --> tests/ui/impl_trait_nested.rs:6:22
+  |
+6 | async fn foo(_x: Foo<impl Sized + 'static>) {}
+  |                      ^^^^^^^^^^^^^^^^^^^^

--- a/embassy-executor/tests/ui/impl_trait_static.rs
+++ b/embassy-executor/tests/ui/impl_trait_static.rs
@@ -1,0 +1,6 @@
+#![cfg_attr(feature = "nightly", feature(impl_trait_in_assoc_type))]
+
+#[embassy_executor::task]
+async fn foo(_x: impl Sized + 'static) {}
+
+fn main() {}

--- a/embassy-executor/tests/ui/impl_trait_static.stderr
+++ b/embassy-executor/tests/ui/impl_trait_static.stderr
@@ -1,0 +1,5 @@
+error: `impl Trait` is not allowed in task arguments. It is syntax sugar for generics, and tasks can't be generic.
+ --> tests/ui/impl_trait_static.rs:4:18
+  |
+4 | async fn foo(_x: impl Sized + 'static) {}
+  |                  ^^^^^^^^^^^^^^^^^^^^

--- a/embassy-executor/tests/ui/nonstatic_ref_anon.rs
+++ b/embassy-executor/tests/ui/nonstatic_ref_anon.rs
@@ -1,0 +1,6 @@
+#![cfg_attr(feature = "nightly", feature(impl_trait_in_assoc_type))]
+
+#[embassy_executor::task]
+async fn foo(_x: &'_ u32) {}
+
+fn main() {}

--- a/embassy-executor/tests/ui/nonstatic_ref_anon.stderr
+++ b/embassy-executor/tests/ui/nonstatic_ref_anon.stderr
@@ -1,0 +1,5 @@
+error: Arguments for tasks must live forever. Try using the `'static` lifetime.
+ --> tests/ui/nonstatic_ref_anon.rs:4:19
+  |
+4 | async fn foo(_x: &'_ u32) {}
+  |                   ^^

--- a/embassy-executor/tests/ui/nonstatic_ref_anon_nested.rs
+++ b/embassy-executor/tests/ui/nonstatic_ref_anon_nested.rs
@@ -1,0 +1,6 @@
+#![cfg_attr(feature = "nightly", feature(impl_trait_in_assoc_type))]
+
+#[embassy_executor::task]
+async fn foo(_x: &'static &'_ u32) {}
+
+fn main() {}

--- a/embassy-executor/tests/ui/nonstatic_ref_anon_nested.stderr
+++ b/embassy-executor/tests/ui/nonstatic_ref_anon_nested.stderr
@@ -1,0 +1,5 @@
+error: Arguments for tasks must live forever. Try using the `'static` lifetime.
+ --> tests/ui/nonstatic_ref_anon_nested.rs:4:28
+  |
+4 | async fn foo(_x: &'static &'_ u32) {}
+  |                            ^^

--- a/embassy-executor/tests/ui/nonstatic_ref_elided.rs
+++ b/embassy-executor/tests/ui/nonstatic_ref_elided.rs
@@ -1,0 +1,6 @@
+#![cfg_attr(feature = "nightly", feature(impl_trait_in_assoc_type))]
+
+#[embassy_executor::task]
+async fn foo(_x: &u32) {}
+
+fn main() {}

--- a/embassy-executor/tests/ui/nonstatic_ref_elided.stderr
+++ b/embassy-executor/tests/ui/nonstatic_ref_elided.stderr
@@ -1,0 +1,5 @@
+error: Arguments for tasks must live forever. Try using the `'static` lifetime.
+ --> tests/ui/nonstatic_ref_elided.rs:4:18
+  |
+4 | async fn foo(_x: &u32) {}
+  |                  ^

--- a/embassy-executor/tests/ui/nonstatic_ref_generic.rs
+++ b/embassy-executor/tests/ui/nonstatic_ref_generic.rs
@@ -1,0 +1,6 @@
+#![cfg_attr(feature = "nightly", feature(impl_trait_in_assoc_type))]
+
+#[embassy_executor::task]
+async fn foo<'a>(_x: &'a u32) {}
+
+fn main() {}

--- a/embassy-executor/tests/ui/nonstatic_ref_generic.stderr
+++ b/embassy-executor/tests/ui/nonstatic_ref_generic.stderr
@@ -1,0 +1,11 @@
+error: task functions must not be generic
+ --> tests/ui/nonstatic_ref_generic.rs:4:1
+  |
+4 | async fn foo<'a>(_x: &'a u32) {}
+  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: Arguments for tasks must live forever. Try using the `'static` lifetime.
+ --> tests/ui/nonstatic_ref_generic.rs:4:23
+  |
+4 | async fn foo<'a>(_x: &'a u32) {}
+  |                       ^^

--- a/embassy-executor/tests/ui/nonstatic_struct_anon.rs
+++ b/embassy-executor/tests/ui/nonstatic_struct_anon.rs
@@ -1,0 +1,8 @@
+#![cfg_attr(feature = "nightly", feature(impl_trait_in_assoc_type))]
+
+struct Foo<'a>(&'a ());
+
+#[embassy_executor::task]
+async fn task(_x: Foo<'_>) {}
+
+fn main() {}

--- a/embassy-executor/tests/ui/nonstatic_struct_anon.stderr
+++ b/embassy-executor/tests/ui/nonstatic_struct_anon.stderr
@@ -1,0 +1,5 @@
+error: Arguments for tasks must live forever. Try using the `'static` lifetime.
+ --> tests/ui/nonstatic_struct_anon.rs:6:23
+  |
+6 | async fn task(_x: Foo<'_>) {}
+  |                       ^^

--- a/embassy-executor/tests/ui/nonstatic_struct_elided.rs
+++ b/embassy-executor/tests/ui/nonstatic_struct_elided.rs
@@ -1,0 +1,8 @@
+#![cfg_attr(feature = "nightly", feature(impl_trait_in_assoc_type))]
+
+struct Foo<'a>(&'a ());
+
+#[embassy_executor::task]
+async fn task(_x: Foo) {}
+
+fn main() {}

--- a/embassy-executor/tests/ui/nonstatic_struct_elided.stderr
+++ b/embassy-executor/tests/ui/nonstatic_struct_elided.stderr
@@ -1,0 +1,10 @@
+error[E0726]: implicit elided lifetime not allowed here
+ --> tests/ui/nonstatic_struct_elided.rs:6:19
+  |
+6 | async fn task(_x: Foo) {}
+  |                   ^^^ expected lifetime parameter
+  |
+help: indicate the anonymous lifetime
+  |
+6 | async fn task(_x: Foo<'_>) {}
+  |                      ++++

--- a/embassy-executor/tests/ui/nonstatic_struct_generic.rs
+++ b/embassy-executor/tests/ui/nonstatic_struct_generic.rs
@@ -1,0 +1,8 @@
+#![cfg_attr(feature = "nightly", feature(impl_trait_in_assoc_type))]
+
+struct Foo<'a>(&'a ());
+
+#[embassy_executor::task]
+async fn task<'a>(_x: Foo<'a>) {}
+
+fn main() {}

--- a/embassy-executor/tests/ui/nonstatic_struct_generic.stderr
+++ b/embassy-executor/tests/ui/nonstatic_struct_generic.stderr
@@ -1,0 +1,11 @@
+error: task functions must not be generic
+ --> tests/ui/nonstatic_struct_generic.rs:6:1
+  |
+6 | async fn task<'a>(_x: Foo<'a>) {}
+  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: Arguments for tasks must live forever. Try using the `'static` lifetime.
+ --> tests/ui/nonstatic_struct_generic.rs:6:27
+  |
+6 | async fn task<'a>(_x: Foo<'a>) {}
+  |                           ^^

--- a/embassy-executor/tests/ui/not_async.rs
+++ b/embassy-executor/tests/ui/not_async.rs
@@ -1,0 +1,8 @@
+#![cfg_attr(feature = "nightly", feature(impl_trait_in_assoc_type))]
+
+struct Foo<'a>(&'a ());
+
+#[embassy_executor::task]
+fn task() {}
+
+fn main() {}

--- a/embassy-executor/tests/ui/not_async.stderr
+++ b/embassy-executor/tests/ui/not_async.stderr
@@ -1,0 +1,5 @@
+error: task functions must be async
+ --> tests/ui/not_async.rs:6:1
+  |
+6 | fn task() {}
+  | ^^^^^^^^^

--- a/embassy-executor/tests/ui/self.rs
+++ b/embassy-executor/tests/ui/self.rs
@@ -1,0 +1,8 @@
+#![cfg_attr(feature = "nightly", feature(impl_trait_in_assoc_type))]
+
+struct Foo<'a>(&'a ());
+
+#[embassy_executor::task]
+async fn task(self) {}
+
+fn main() {}

--- a/embassy-executor/tests/ui/self.stderr
+++ b/embassy-executor/tests/ui/self.stderr
@@ -1,0 +1,13 @@
+error: task functions must not have `self` arguments
+ --> tests/ui/self.rs:6:15
+  |
+6 | async fn task(self) {}
+  |               ^^^^
+
+error: `self` parameter is only allowed in associated functions
+ --> tests/ui/self.rs:6:15
+  |
+6 | async fn task(self) {}
+  |               ^^^^ not semantically valid as function parameter
+  |
+  = note: associated functions are those in `impl` or `trait` definitions

--- a/embassy-executor/tests/ui/self_ref.rs
+++ b/embassy-executor/tests/ui/self_ref.rs
@@ -1,0 +1,8 @@
+#![cfg_attr(feature = "nightly", feature(impl_trait_in_assoc_type))]
+
+struct Foo<'a>(&'a ());
+
+#[embassy_executor::task]
+async fn task(&mut self) {}
+
+fn main() {}

--- a/embassy-executor/tests/ui/self_ref.stderr
+++ b/embassy-executor/tests/ui/self_ref.stderr
@@ -1,0 +1,13 @@
+error: task functions must not have `self` arguments
+ --> tests/ui/self_ref.rs:6:15
+  |
+6 | async fn task(&mut self) {}
+  |               ^^^^^^^^^
+
+error: `self` parameter is only allowed in associated functions
+ --> tests/ui/self_ref.rs:6:15
+  |
+6 | async fn task(&mut self) {}
+  |               ^^^^^^^^^ not semantically valid as function parameter
+  |
+  = note: associated functions are those in `impl` or `trait` definitions

--- a/embassy-executor/tests/ui/where_clause.rs
+++ b/embassy-executor/tests/ui/where_clause.rs
@@ -1,0 +1,12 @@
+#![cfg_attr(feature = "nightly", feature(impl_trait_in_assoc_type))]
+
+struct Foo<'a>(&'a ());
+
+#[embassy_executor::task]
+async fn task()
+where
+    (): Sized,
+{
+}
+
+fn main() {}

--- a/embassy-executor/tests/ui/where_clause.stderr
+++ b/embassy-executor/tests/ui/where_clause.stderr
@@ -1,0 +1,7 @@
+error: task functions must not have `where` clauses
+ --> tests/ui/where_clause.rs:6:1
+  |
+6 | / async fn task()
+7 | | where
+8 | |     (): Sized,
+  | |______________^


### PR DESCRIPTION
- **executor-macros: improve error messages.**
- **executor: add compile-fail / ui tests.**
