### PR TITLE
STM32: Add BufferedUart::new permutations usefull for RS485

### DIFF
--- a/embassy-stm32/src/usart/buffered.rs
+++ b/embassy-stm32/src/usart/buffered.rs
@@ -246,6 +246,55 @@ impl<'d> BufferedUart<'d> {
         )
     }
 
+
+    /// Create a new bidirectional buffered UART driver with only RTS pin as the DE pin
+    pub fn new_with_rts_as_de<T: Instance>(
+        peri: impl Peripheral<P = T> + 'd,
+        _irq: impl interrupt::typelevel::Binding<T::Interrupt, InterruptHandler<T>> + 'd,
+        rx: impl Peripheral<P = impl RxPin<T>> + 'd,
+        tx: impl Peripheral<P = impl TxPin<T>> + 'd,
+        rts: impl Peripheral<P = impl RtsPin<T>> + 'd,
+        tx_buffer: &'d mut [u8],
+        rx_buffer: &'d mut [u8],
+        config: Config,
+    ) -> Result<Self, ConfigError> {
+        Self::new_inner(
+            peri,
+            new_pin!(rx, AfType::input(Pull::None)),
+            new_pin!(tx, AfType::output(OutputType::PushPull, Speed::Medium)),
+            None,
+            None,
+            new_pin!(rts, AfType::input(Pull::None)), // RTS mapped used as DE
+            tx_buffer,
+            rx_buffer,
+            config,
+        )
+    }
+
+    /// Create a new bidirectional buffered UART driver with only the request-to-send pin
+    pub fn new_with_rts<T: Instance>(
+        peri: impl Peripheral<P = T> + 'd,
+        _irq: impl interrupt::typelevel::Binding<T::Interrupt, InterruptHandler<T>> + 'd,
+        rx: impl Peripheral<P = impl RxPin<T>> + 'd,
+        tx: impl Peripheral<P = impl TxPin<T>> + 'd,
+        rts: impl Peripheral<P = impl RtsPin<T>> + 'd,
+        tx_buffer: &'d mut [u8],
+        rx_buffer: &'d mut [u8],
+        config: Config,
+    ) -> Result<Self, ConfigError> {
+        Self::new_inner(
+            peri,
+            new_pin!(rx, AfType::input(Pull::None)),
+            new_pin!(tx, AfType::output(OutputType::PushPull, Speed::Medium)),
+            new_pin!(rts, AfType::input(Pull::None)),
+            None, // no RTS
+            None, // no DE
+            tx_buffer,
+            rx_buffer,
+            config,
+        )
+    }
+
     /// Create a new bidirectional buffered UART driver with a driver-enable pin
     #[cfg(not(any(usart_v1, usart_v2)))]
     pub fn new_with_de<T: Instance>(

--- a/embassy-stm32/src/usart/buffered.rs
+++ b/embassy-stm32/src/usart/buffered.rs
@@ -246,7 +246,6 @@ impl<'d> BufferedUart<'d> {
         )
     }
 
-
     /// Create a new bidirectional buffered UART driver with only RTS pin as the DE pin
     pub fn new_with_rts_as_de<T: Instance>(
         peri: impl Peripheral<P = T> + 'd,

--- a/embassy-stm32/src/usart/buffered.rs
+++ b/embassy-stm32/src/usart/buffered.rs
@@ -246,7 +246,7 @@ impl<'d> BufferedUart<'d> {
         )
     }
 
-    /// Create a new bidirectional buffered UART driver with only RTS pin as the DE pin
+    /// Create a new bidirectional buffered UART driver with only the RTS pin as the DE pin
     pub fn new_with_rts_as_de<T: Instance>(
         peri: impl Peripheral<P = T> + 'd,
         _irq: impl interrupt::typelevel::Binding<T::Interrupt, InterruptHandler<T>> + 'd,
@@ -286,7 +286,7 @@ impl<'d> BufferedUart<'d> {
             new_pin!(rx, AfType::input(Pull::None)),
             new_pin!(tx, AfType::output(OutputType::PushPull, Speed::Medium)),
             new_pin!(rts, AfType::input(Pull::None)),
-            None, // no RTS
+            None, // no CTS
             None, // no DE
             tx_buffer,
             rx_buffer,


### PR DESCRIPTION
I've tested this on a STM32H5 and it works without issue.

The option to turn RTS into DE was added because it can be usefull to have this mapping since ST's own tools (like CubeMX) work as such, so the distinction between DE and RTS can an issue if for for example a hardware designer uses tools that do not apply this distinction; Also the fact that the official tooling do not apply this indicates the it may be actually just a naming difference, not a functional difference.

I did not add the same permutations required for the regular Async/Blocking uart but I can if it is required.