### PR TITLE
executor: arch-std: Make `Signaler` public.

### DIFF
--- a/embassy-executor/src/arch/std.rs
+++ b/embassy-executor/src/arch/std.rs
@@ -64,12 +64,26 @@ mod thread {
         }
     }
 
+    /// `Signaler` is used in `__pender()`;
+    ///
+    /// This is only needed when creating a [`raw::Executor`].
+    ///
+    /// # Example
+    /// ```rust
+    /// let signaler = Box::leak(Box::new(Signaler::new()));
+    /// let executor = &*Box::leak(Box::new(Executor::new(signaler)));
+    ///
+    /// executor.spawner().spawn(/* EmbassyTask(Arguments) */).unwrap();
+    ///
+    /// unsafe { executor.poll() };
+    /// ```
     pub struct Signaler {
         mutex: Mutex<bool>,
         condvar: Condvar,
     }
 
     impl Signaler {
+        /// Create a new Signaler.
         pub fn new() -> Self {
             Self {
                 mutex: Mutex::new(false),

--- a/embassy-executor/src/arch/std.rs
+++ b/embassy-executor/src/arch/std.rs
@@ -64,13 +64,13 @@ mod thread {
         }
     }
 
-    struct Signaler {
+    pub struct Signaler {
         mutex: Mutex<bool>,
         condvar: Condvar,
     }
 
     impl Signaler {
-        fn new() -> Self {
+        pub fn new() -> Self {
             Self {
                 mutex: Mutex::new(false),
                 condvar: Condvar::new(),


### PR DESCRIPTION
When you have the feature = `arch-std` enabled.
Then the executor code creates the function `__pender()`. But this function used `Signaler` internally.
The problem is that `Signaler` is currently private.

Make it public so that it can be used to create one for the `raw::Executor::new()`.