### PR TITLE
stm32/uart impl ReadReady for RingbufferdUart

### DIFF
--- a/embassy-stm32/src/dma/ringbuffer/mod.rs
+++ b/embassy-stm32/src/dma/ringbuffer/mod.rs
@@ -21,6 +21,10 @@ pub trait DmaCtrl {
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub enum Error {
     Overrun,
+    /// the newly read DMA positions don't make sense compared to the previous
+    /// ones. This can usually only occur due to wrong Driver implementation, if
+    /// the driver author (or the user using raw metapac code) directly resets
+    /// the channel for instance.
     DmaUnsynced,
 }
 

--- a/embassy-stm32/src/usart/mod.rs
+++ b/embassy-stm32/src/usart/mod.rs
@@ -1689,7 +1689,6 @@ impl embedded_hal_nb::serial::Error for Error {
             Self::Overrun => embedded_hal_nb::serial::ErrorKind::Overrun,
             Self::Parity => embedded_hal_nb::serial::ErrorKind::Parity,
             Self::BufferTooLong => embedded_hal_nb::serial::ErrorKind::Other,
-            Self::DmaUnsynced => embedded_hal_nb::serial::ErrorKind::Other,
         }
     }
 }

--- a/embassy-stm32/src/usart/mod.rs
+++ b/embassy-stm32/src/usart/mod.rs
@@ -260,8 +260,6 @@ pub enum Error {
     Parity,
     /// Buffer too large for DMA
     BufferTooLong,
-    // TODO: ask what this is and document it (dvdsk)
-    DmaUnsynced,
 }
 
 enum ReadCompletionEvent {

--- a/embassy-stm32/src/usart/mod.rs
+++ b/embassy-stm32/src/usart/mod.rs
@@ -260,6 +260,8 @@ pub enum Error {
     Parity,
     /// Buffer too large for DMA
     BufferTooLong,
+    // TODO: ask what this is and document it (dvdsk)
+    DmaUnsynced,
 }
 
 enum ReadCompletionEvent {
@@ -1689,6 +1691,7 @@ impl embedded_hal_nb::serial::Error for Error {
             Self::Overrun => embedded_hal_nb::serial::ErrorKind::Overrun,
             Self::Parity => embedded_hal_nb::serial::ErrorKind::Parity,
             Self::BufferTooLong => embedded_hal_nb::serial::ErrorKind::Other,
+            Self::DmaUnsynced => embedded_hal_nb::serial::ErrorKind::Other,
         }
     }
 }

--- a/embassy-stm32/src/usart/ringbuffered.rs
+++ b/embassy-stm32/src/usart/ringbuffered.rs
@@ -5,6 +5,7 @@ use core::task::Poll;
 
 use embassy_embedded_hal::SetConfig;
 use embassy_hal_internal::PeripheralRef;
+use embedded_io_async::ReadReady;
 use futures_util::future::{select, Either};
 
 use super::{clear_interrupt_flags, rdr, reconfigure, sr, Config, ConfigError, Error, Info, State, UartRx};
@@ -260,5 +261,15 @@ impl embedded_io_async::ErrorType for RingBufferedUartRx<'_> {
 impl embedded_io_async::Read for RingBufferedUartRx<'_> {
     async fn read(&mut self, buf: &mut [u8]) -> Result<usize, Self::Error> {
         self.read(buf).await
+    }
+}
+
+impl ReadReady for RingBufferedUartRx<'_> {
+    fn read_ready(&mut self) -> Result<bool, Self::Error> {
+        let len = self.ring_buf.len().map_err(|e| match e {
+            crate::dma::ringbuffer::Error::Overrun => Self::Error::Overrun,
+            crate::dma::ringbuffer::Error::DmaUnsynced => Self::Error::DmaUnsynced,
+        })?;
+        Ok(len > 0)
     }
 }

--- a/embassy-stm32/src/usart/ringbuffered.rs
+++ b/embassy-stm32/src/usart/ringbuffered.rs
@@ -268,7 +268,14 @@ impl ReadReady for RingBufferedUartRx<'_> {
     fn read_ready(&mut self) -> Result<bool, Self::Error> {
         let len = self.ring_buf.len().map_err(|e| match e {
             crate::dma::ringbuffer::Error::Overrun => Self::Error::Overrun,
-            crate::dma::ringbuffer::Error::DmaUnsynced => Self::Error::DmaUnsynced,
+            crate::dma::ringbuffer::Error::DmaUnsynced => {
+                error!(
+                    "Ringbuffer error: DmaUNsynced, driver implementation is 
+                    probably bugged please open an issue"
+                );
+                // we report this as overrun since its recoverable in the same way
+                Self::Error::Overrun
+            }
         })?;
         Ok(len > 0)
     }


### PR DESCRIPTION
I am unsure what `DmaUnsynced` means and need some help with that. For now I have added it as a separate variant for `uart::Error`. Since I do not know what it means it still needs documentation making this a draft.