### PR TITLE
nrf: Add basic skeleton for AAR and ECB peripherals

### DIFF
--- a/embassy-nrf/src/aar.rs
+++ b/embassy-nrf/src/aar.rs
@@ -7,7 +7,7 @@ use crate::peripherals::AAR;
 /// AAR (Accelerated Address Resolver)
 ///
 /// Note: This peripheral is current unimplemented!
-/// TODO: AAR shares resources with CCM
+/// TODO: AAR shares resources with CCM and ECB
 pub struct Aar<'d> {
     _p: PeripheralRef<'d, AAR>,
 }

--- a/embassy-nrf/src/aar.rs
+++ b/embassy-nrf/src/aar.rs
@@ -1,0 +1,13 @@
+//! Accelerated address resolver (AAR)
+//!
+use embassy_hal_internal::PeripheralRef;
+
+use crate::peripherals::AAR;
+
+/// AAR (Accelerated Address Resolver)
+///
+/// Note: This peripheral is current unimplemented!
+/// TODO: AAR shares resources with CCM
+pub struct Aar<'d> {
+    _p: PeripheralRef<'d, AAR>,
+}

--- a/embassy-nrf/src/chips/nrf51.rs
+++ b/embassy-nrf/src/chips/nrf51.rs
@@ -102,6 +102,8 @@ embassy_hal_internal::peripherals! {
 
     // Radio
     RADIO,
+
+    AAR,
 }
 
 impl_timer!(TIMER0, TIMER0, TIMER0);

--- a/embassy-nrf/src/chips/nrf51.rs
+++ b/embassy-nrf/src/chips/nrf51.rs
@@ -104,6 +104,7 @@ embassy_hal_internal::peripherals! {
     RADIO,
 
     AAR,
+    ECB,
 }
 
 impl_timer!(TIMER0, TIMER0, TIMER0);

--- a/embassy-nrf/src/chips/nrf52805.rs
+++ b/embassy-nrf/src/chips/nrf52805.rs
@@ -138,6 +138,7 @@ embassy_hal_internal::peripherals! {
     EGU1,
 
     AAR,
+    ECB,
 }
 
 impl_uarte!(UARTE0, UARTE0, UARTE0_UART0);

--- a/embassy-nrf/src/chips/nrf52805.rs
+++ b/embassy-nrf/src/chips/nrf52805.rs
@@ -136,6 +136,8 @@ embassy_hal_internal::peripherals! {
     // EGU
     EGU0,
     EGU1,
+
+    AAR,
 }
 
 impl_uarte!(UARTE0, UARTE0, UARTE0_UART0);

--- a/embassy-nrf/src/chips/nrf52810.rs
+++ b/embassy-nrf/src/chips/nrf52810.rs
@@ -144,6 +144,7 @@ embassy_hal_internal::peripherals! {
     EGU1,
 
     AAR,
+    ECB,
 }
 
 impl_uarte!(UARTE0, UARTE0, UARTE0_UART0);

--- a/embassy-nrf/src/chips/nrf52810.rs
+++ b/embassy-nrf/src/chips/nrf52810.rs
@@ -142,6 +142,8 @@ embassy_hal_internal::peripherals! {
     // EGU
     EGU0,
     EGU1,
+
+    AAR,
 }
 
 impl_uarte!(UARTE0, UARTE0, UARTE0_UART0);

--- a/embassy-nrf/src/chips/nrf52811.rs
+++ b/embassy-nrf/src/chips/nrf52811.rs
@@ -144,6 +144,7 @@ embassy_hal_internal::peripherals! {
     EGU1,
 
     AAR,
+    ECB,
 }
 
 impl_uarte!(UARTE0, UARTE0, UARTE0_UART0);

--- a/embassy-nrf/src/chips/nrf52811.rs
+++ b/embassy-nrf/src/chips/nrf52811.rs
@@ -142,6 +142,8 @@ embassy_hal_internal::peripherals! {
     // EGU
     EGU0,
     EGU1,
+
+    AAR,
 }
 
 impl_uarte!(UARTE0, UARTE0, UARTE0_UART0);

--- a/embassy-nrf/src/chips/nrf52820.rs
+++ b/embassy-nrf/src/chips/nrf52820.rs
@@ -143,6 +143,7 @@ embassy_hal_internal::peripherals! {
     EGU5,
 
     AAR,
+    ECB,
 }
 
 impl_usb!(USBD, USBD, USBD);

--- a/embassy-nrf/src/chips/nrf52820.rs
+++ b/embassy-nrf/src/chips/nrf52820.rs
@@ -141,6 +141,8 @@ embassy_hal_internal::peripherals! {
     EGU3,
     EGU4,
     EGU5,
+
+    AAR,
 }
 
 impl_usb!(USBD, USBD, USBD);

--- a/embassy-nrf/src/chips/nrf52832.rs
+++ b/embassy-nrf/src/chips/nrf52832.rs
@@ -155,6 +155,7 @@ embassy_hal_internal::peripherals! {
     RADIO,
 
     AAR,
+    ECB,
 
     // EGU
     EGU0,

--- a/embassy-nrf/src/chips/nrf52832.rs
+++ b/embassy-nrf/src/chips/nrf52832.rs
@@ -154,6 +154,8 @@ embassy_hal_internal::peripherals! {
     // Radio
     RADIO,
 
+    AAR,
+
     // EGU
     EGU0,
     EGU1,

--- a/embassy-nrf/src/chips/nrf52833.rs
+++ b/embassy-nrf/src/chips/nrf52833.rs
@@ -183,6 +183,7 @@ embassy_hal_internal::peripherals! {
     EGU5,
 
     AAR,
+    ECB,
 }
 
 impl_usb!(USBD, USBD, USBD);

--- a/embassy-nrf/src/chips/nrf52833.rs
+++ b/embassy-nrf/src/chips/nrf52833.rs
@@ -181,6 +181,8 @@ embassy_hal_internal::peripherals! {
     EGU3,
     EGU4,
     EGU5,
+
+    AAR,
 }
 
 impl_usb!(USBD, USBD, USBD);

--- a/embassy-nrf/src/chips/nrf52840.rs
+++ b/embassy-nrf/src/chips/nrf52840.rs
@@ -186,6 +186,7 @@ embassy_hal_internal::peripherals! {
     EGU5,
 
     AAR,
+    ECB,
 }
 
 impl_usb!(USBD, USBD, USBD);

--- a/embassy-nrf/src/chips/nrf52840.rs
+++ b/embassy-nrf/src/chips/nrf52840.rs
@@ -184,6 +184,8 @@ embassy_hal_internal::peripherals! {
     EGU3,
     EGU4,
     EGU5,
+
+    AAR,
 }
 
 impl_usb!(USBD, USBD, USBD);

--- a/embassy-nrf/src/chips/nrf5340_net.rs
+++ b/embassy-nrf/src/chips/nrf5340_net.rs
@@ -256,6 +256,7 @@ embassy_hal_internal::peripherals! {
     EGU0,
 
     AAR,
+    ECB,
 }
 
 impl_uarte!(SERIAL0, UARTE0, SERIAL0);

--- a/embassy-nrf/src/chips/nrf5340_net.rs
+++ b/embassy-nrf/src/chips/nrf5340_net.rs
@@ -254,6 +254,8 @@ embassy_hal_internal::peripherals! {
 
     // EGU
     EGU0,
+
+    AAR,
 }
 
 impl_uarte!(SERIAL0, UARTE0, SERIAL0);

--- a/embassy-nrf/src/ecb.rs
+++ b/embassy-nrf/src/ecb.rs
@@ -1,0 +1,14 @@
+//! ECB - AES electronic codebook mode encryption
+//!
+use embassy_hal_internal::PeripheralRef;
+
+use crate::peripherals::ECB;
+
+/// ECB - AES electronic codebook mode encryption.
+///
+/// Note: This peripheral is current unimplemented!
+/// TODO: ECB shares resources with AAR and CCM, while
+///       ECB will always have lowest priority.
+pub struct Ecb<'d> {
+    _p: PeripheralRef<'d, ECB>,
+}

--- a/embassy-nrf/src/lib.rs
+++ b/embassy-nrf/src/lib.rs
@@ -67,6 +67,8 @@ pub(crate) mod util;
 
 #[cfg(not(any(feature = "_nrf91", feature = "_nrf5340-app")))]
 pub mod aar;
+#[cfg(not(any(feature = "_nrf91", feature = "_nrf5340-app")))]
+pub mod ecb;
 
 #[cfg(feature = "_time-driver")]
 mod time_driver;

--- a/embassy-nrf/src/lib.rs
+++ b/embassy-nrf/src/lib.rs
@@ -65,6 +65,9 @@ compile_error!("feature `nfc-pins-as-gpio` is only valid for nRF52, or nRF53's a
 pub(crate) mod fmt;
 pub(crate) mod util;
 
+#[cfg(not(any(feature = "_nrf91", feature = "_nrf5340-app")))]
+pub mod aar;
+
 #[cfg(feature = "_time-driver")]
 mod time_driver;
 


### PR DESCRIPTION
Adds a simple skeleton drivers which would eventually allow getting rid of "unstable-pacs" dependency for applications utilizing [nrf-sdc](https://github.com/alexmoon/nrf-sdc/issues/32) crate.

Currently one needs to initialize `sdc` by referencing ECB and AAR peripherals via `unstable-pac`:
```rust
{
    let p = embassy_nrf::init(Default::default());
    // Requires `unstable-pac`
    let pac_p = pac::Peripherals::take().unwrap();

    let pac_p = pac::Peripherals::take().unwrap();
    let sdc_p = sdc::Peripherals::new(
        // Peripherals supplied via `unstable-pac`:
        pac_p.ECB, pac_p.AAR,
        // ...
        p.PPI_CH17, p.PPI_CH18, p.PPI_CH20, p.PPI_CH21, p.PPI_CH22, p.PPI_CH23, p.PPI_CH24,
        p.PPI_CH25, p.PPI_CH26, p.PPI_CH27, p.PPI_CH28, p.PPI_CH29,
    );
}
```

How should I deal with shared CCM / AAR resources as these two share the same registers?

Another driver required by nrf-sdc that isn't exposed as peripheralref is CLOCK.