### PR TITLE
Embassy-rp Split Pwm driver to allow separate duty cycle control of each channel.

### DIFF
--- a/embassy-rp/src/pwm.rs
+++ b/embassy-rp/src/pwm.rs
@@ -407,10 +407,6 @@ pub struct PwmBatch(u32);
 
 impl PwmBatch {
     #[inline]
-    pub fn new() -> Self{
-        Self(0)
-    }
-    #[inline]
     /// Enable a PWM slice in this batch.
     pub fn enable(&mut self, pwm: &Pwm<'_>) {
         self.0 |= pwm.bit();

--- a/embassy-rp/src/pwm.rs
+++ b/embassy-rp/src/pwm.rs
@@ -407,6 +407,10 @@ pub struct PwmBatch(u32);
 
 impl PwmBatch {
     #[inline]
+    pub fn new() -> Self{
+        Self(0)
+    }
+    #[inline]
     /// Enable a PWM slice in this batch.
     pub fn enable(&mut self, pwm: &Pwm<'_>) {
         self.0 |= pwm.bit();

--- a/embassy-rp/src/pwm.rs
+++ b/embassy-rp/src/pwm.rs
@@ -369,6 +369,10 @@ impl PwmOutput {
     }
 }
 
+impl ErrorType for PwmOutput {
+    type Error = PwmError;
+}
+
 impl SetDutyCycle for PwmOutput {
     fn max_duty_cycle(&self) -> u16 {
         pac::PWM.ch(self.slice).top().read().top()

--- a/embassy-rp/src/pwm.rs
+++ b/embassy-rp/src/pwm.rs
@@ -345,8 +345,8 @@ impl<'d> Pwm<'d> {
         1 << self.slice as usize
     }
 
+    /// Splits the PWM driver into separate `PwmOutput` instances for channels A and B.
     #[inline]
-    /// Split Pwm driver to allow separate duty cycle control of each channel
     pub fn split(mut self) -> (Option<PwmOutput<'d>>, Option<PwmOutput<'d>>) {
         (
             self.pin_a
@@ -357,7 +357,9 @@ impl<'d> Pwm<'d> {
                 .map(|pin| PwmOutput::new(PwmChannelPin::B(pin), self.slice.clone(), true)),
         )
     }
-
+    /// Splits the PWM driver by reference to allow for separate duty cycle control
+    /// of each channel (A and B) without taking ownership of the PWM instance.
+    #[inline]
     pub fn split_by_ref(&mut self) -> (Option<PwmOutput<'_>>, Option<PwmOutput<'_>>) {
         (
             self.pin_a
@@ -404,7 +406,7 @@ impl<'d> Drop for PwmOutput<'d> {
                     });
 
                     pin.gpio().ctrl().write(|w| w.set_funcsel(31));
-                    ///Enable pin PULL-DOWN
+                    //Enable pin PULL-DOWN
                     pin.pad_ctrl().modify(|w| {
                         w.set_pde(true);
                     });
@@ -414,7 +416,7 @@ impl<'d> Drop for PwmOutput<'d> {
                         w.set_b(0);
                     });
                     pin.gpio().ctrl().write(|w| w.set_funcsel(31));
-                    ///Enable pin PULL-DOWN
+                    //Enable pin PULL-DOWN
                     pin.pad_ctrl().modify(|w| {
                         w.set_pde(true);
                     });


### PR DESCRIPTION
this PR allow independent controll of duty cycle for each channel in a pwm slice.
```rust 
    let pwm_ab= Pwm::new_output_ab(p.PWM_SLICE3, p.PIN_6, p.PIN_7, pwm_conf.clone());
    let (pwm_a,pwm_b)=pwm_ab.split();
    pwm_a.set_duty_cycle(dutya);
    pwm_b.set_duty_cycle(dutyb);
```