### PR TITLE
Fix `embassy_rp::spi::new_rxonly` not taking in required `tx_dma`

### DIFF
--- a/embassy-rp/src/spi.rs
+++ b/embassy-rp/src/spi.rs
@@ -359,17 +359,18 @@ impl<'d, T: Instance> Spi<'d, T, Async> {
         inner: impl Peripheral<P = T> + 'd,
         clk: impl Peripheral<P = impl ClkPin<T> + 'd> + 'd,
         miso: impl Peripheral<P = impl MisoPin<T> + 'd> + 'd,
+        tx_dma: impl Peripheral<P = impl Channel> + 'd,
         rx_dma: impl Peripheral<P = impl Channel> + 'd,
         config: Config,
     ) -> Self {
-        into_ref!(rx_dma, clk, miso);
+        into_ref!(tx_dma, rx_dma, clk, miso);
         Self::new_inner(
             inner,
             Some(clk.map_into()),
             None,
             Some(miso.map_into()),
             None,
-            None,
+            Some(tx_dma.map_into()),
             Some(rx_dma.map_into()),
             config,
         )


### PR DESCRIPTION
Fixes an issue with rxonly spi instances in embassy_rs::spi. DMA reads still (apparently) require a tx_dma channel to function.

Commit simply adds a required tx_dma parameter to `spi::new_rxonly`. I've tested this on an RP2040, using a MAX31855.