### PR TITLE
Implement readable / writable types for TCP socket splits and raw sockets

### DIFF
--- a/embassy-net/src/raw.rs
+++ b/embassy-net/src/raw.rs
@@ -62,11 +62,37 @@ impl<'a> RawSocket<'a> {
         })
     }
 
+    /// Wait until the socket becomes readable.
+    ///
+    /// A socket is readable when a packet has been received, or when there are queued packets in
+    /// the buffer.
+    pub async fn wait_recv_ready(&self) {
+        poll_fn(move |cx| self.poll_recv_ready(cx)).await
+    }
+
     /// Receive a datagram.
     ///
     /// This method will wait until a datagram is received.
     pub async fn recv(&self, buf: &mut [u8]) -> Result<usize, RecvError> {
         poll_fn(move |cx| self.poll_recv(buf, cx)).await
+    }
+
+    /// Wait until a datagram can be read.
+    ///
+    /// When no datagram is readable, this method will return `Poll::Pending` and
+    /// register the current task to be notified when a datagram is received.
+    ///
+    /// When a datagram is received, this method will return `Poll::Ready`.
+    pub fn poll_recv_ready(&self, cx: &mut Context<'_>) -> Poll<()> {
+        self.with_mut(|s, _| {
+            if s.can_recv() {
+                Poll::Ready(())
+            } else {
+                // socket buffer is empty wait until at least one byte has arrived
+                s.register_recv_waker(cx.waker());
+                Poll::Pending
+            }
+        })
     }
 
     /// Receive a datagram.
@@ -80,6 +106,33 @@ impl<'a> RawSocket<'a> {
             Err(raw::RecvError::Truncated) => Poll::Ready(Err(RecvError::Truncated)),
             Err(raw::RecvError::Exhausted) => {
                 s.register_recv_waker(cx.waker());
+                Poll::Pending
+            }
+        })
+    }
+
+    /// Wait until the socket becomes writable.
+    ///
+    /// A socket becomes writable when there is space in the buffer, from initial memory or after
+    /// dispatching datagrams on a full buffer.
+    pub async fn wait_send_ready(&self) {
+        poll_fn(move |cx| self.poll_send_ready(cx)).await
+    }
+
+    /// Wait until a datagram can be sent.
+    ///
+    /// When no datagram can be sent (i.e. the buffer is full), this method will return
+    /// `Poll::Pending` and register the current task to be notified when
+    /// space is freed in the buffer after a datagram has been dispatched.
+    ///
+    /// When a datagram can be sent, this method will return `Poll::Ready`.
+    pub fn poll_send_ready(&self, cx: &mut Context<'_>) -> Poll<()> {
+        self.with_mut(|s, _| {
+            if s.can_send() {
+                Poll::Ready(())
+            } else {
+                // socket buffer is full wait until a datagram has been dispatched
+                s.register_send_waker(cx.waker());
                 Poll::Pending
             }
         })

--- a/embassy-net/src/tcp.rs
+++ b/embassy-net/src/tcp.rs
@@ -73,6 +73,16 @@ pub struct TcpWriter<'a> {
 }
 
 impl<'a> TcpReader<'a> {
+    /// Wait until the socket becomes readable.
+    ///
+    /// A socket becomes readable when the receive half of the full-duplex connection is open
+    /// (see [`may_recv()`](TcpSocket::may_recv)), and there is some pending data in the receive buffer.
+    ///
+    /// This is the equivalent of [read](#method.read), without buffering any data.
+    pub async fn wait_read_ready(&self) {
+        poll_fn(move |cx| self.io.poll_read_ready(cx)).await
+    }
+
     /// Read data from the socket.
     ///
     /// Returns how many bytes were read, or an error. If no data is available, it waits
@@ -115,6 +125,16 @@ impl<'a> TcpReader<'a> {
 }
 
 impl<'a> TcpWriter<'a> {
+    /// Wait until the socket becomes writable.
+    ///
+    /// A socket becomes writable when the transmit half of the full-duplex connection is open
+    /// (see [`may_send()`](TcpSocket::may_send)), and the transmit buffer is not full.
+    ///
+    /// This is the equivalent of [write](#method.write), without sending any data.
+    pub async fn wait_write_ready(&self) {
+        poll_fn(move |cx| self.io.poll_write_ready(cx)).await
+    }
+
     /// Write data to the socket.
     ///
     /// Returns how many bytes were written, or an error. If the socket is not ready to


### PR DESCRIPTION
Pretty much copy pasted the logic from #3368 for additional types, which are:

- `TcpReader::wait_read_ready()`
- `TcpWriter::wait_send_ready()`
- `RawSocket::wait_recv_ready()`
- `RawSocket::wait_send_ready()`

@ivmarkov Does this cover every type that could make use of readable / writable?