### PR TITLE
Fix for #3493 - panic! in embassy-usb-synopsys-otg on second serial connection

### DIFF
--- a/embassy-usb-synopsys-otg/src/lib.rs
+++ b/embassy-usb-synopsys-otg/src/lib.rs
@@ -50,7 +50,10 @@ pub unsafe fn on_interrupt<const MAX_EP_COUNT: usize>(
             //
             // I'm guessing this may be some sort of timing issue so instead of panic-ing skip
             // invalid packet :‑(
-            error!("Skipping Invalid Packet (ep_num >= ep_count): ep_num: {} ep_count: {}", ep_num, ep_count);
+            error!(
+                "Skipping Invalid Packet (ep_num >= ep_count): ep_num: {} ep_count: {}",
+                ep_num, ep_count
+            );
             continue;
         }
 


### PR DESCRIPTION
Fix for #3493 - panic! in embassy-usb-synopsys-otg on second serial connection