### PR TITLE
fix(*): FirmwareUpdater::get_state in cases where WRITE_SIZE != 1

### DIFF
--- a/embassy-boot/src/firmware_updater/asynch.rs
+++ b/embassy-boot/src/firmware_updater/asynch.rs
@@ -304,7 +304,7 @@ impl<'d, STATE: NorFlash> FirmwareState<'d, STATE> {
     /// `mark_booted`.
     pub async fn get_state(&mut self) -> Result<State, FirmwareUpdaterError> {
         self.state.read(0, &mut self.aligned).await?;
-        Ok(State::from(&self.aligned))
+        Ok(State::from(&self.aligned[..STATE::WRITE_SIZE]))
     }
 
     /// Mark to trigger firmware swap on next boot.


### PR DESCRIPTION
Has previously been fixed for `set_magic`, but `get_state` seems to have been overlooked. 