### PR TITLE
Added remove_if to priority channel

### DIFF
--- a/embassy-sync/src/priority_channel.rs
+++ b/embassy-sync/src/priority_channel.rs
@@ -72,17 +72,6 @@ where
         self.channel.poll_ready_to_send(cx)
     }
 
-    /// Removes the elements from the channel that satisfy the predicate.
-    ///
-    /// See [`PriorityChannel::remove_if()`]
-    pub fn remove_if<F>(&self, predicate: F)
-    where
-        F: Fn(&T) -> bool,
-        T: Clone,
-    {
-        self.channel.remove_if(predicate)
-    }
-
     /// Returns the maximum number of elements the channel can hold.
     ///
     /// See [`PriorityChannel::capacity()`]


### PR DESCRIPTION
Added remove_if to priority channel. This allows removing items from the queue if there is a match in the predicate.
You can also do this on a sender, receiver and the channel directly itself.

In my sample code I use the following:
```
let send_ble_queue = QUEUE_CHANNEL.sender();
send_ble_queue.remove_if(|i| { i.handle == handle && i.is_single_instance() });
```

This is for my issue here: https://github.com/embassy-rs/embassy/issues/3431

