### PR TITLE
Allow building executor on v1.82 xtensa toolchains

### DIFF
--- a/embassy-executor/Cargo.toml
+++ b/embassy-executor/Cargo.toml
@@ -58,7 +58,7 @@ critical-section = { version = "1.1", features = ["std"] }
 trybuild = "1.0"
 
 [build-dependencies]
-rustc_version = "0.4.1"
+autocfg = "1.4.0"
 
 [features]
 

--- a/embassy-executor/build.rs
+++ b/embassy-executor/build.rs
@@ -97,14 +97,9 @@ fn main() {
     let mut rustc_cfgs = common::CfgSet::new();
     common::set_target_cfgs(&mut rustc_cfgs);
 
-    // Waker API changed on 2024-09-06
-    rustc_cfgs.declare("at_least_2024_09_06");
-    let Some(compiler) = common::compiler_info() else {
-        return;
-    };
-    if compiler.channel == rustc_version::Channel::Nightly
-        && compiler.commit_date.map(|d| d >= "2024-09-06").unwrap_or(false)
-    {
-        rustc_cfgs.enable("at_least_2024_09_06");
+    rustc_cfgs.declare("stable_waker_getters");
+    let autocfg = autocfg::new();
+    if autocfg.probe_expression("core::task::Waker::new") {
+        rustc_cfgs.enable("stable_waker_getters");
     }
 }

--- a/embassy-executor/build_common.rs
+++ b/embassy-executor/build_common.rs
@@ -124,22 +124,3 @@ impl PartialOrd<&str> for CompilerDate {
         Self::parse(other).map(|other| self.cmp(&other))
     }
 }
-
-pub struct CompilerInfo {
-    #[allow(unused)]
-    pub version: rustc_version::Version,
-    pub channel: rustc_version::Channel,
-    pub commit_date: Option<CompilerDate>,
-}
-
-pub fn compiler_info() -> Option<CompilerInfo> {
-    let Ok(meta) = rustc_version::version_meta() else {
-        return None;
-    };
-
-    Some(CompilerInfo {
-        version: meta.semver,
-        channel: meta.channel,
-        commit_date: meta.commit_date.as_deref().and_then(CompilerDate::parse),
-    })
-}

--- a/embassy-executor/src/lib.rs
+++ b/embassy-executor/src/lib.rs
@@ -1,5 +1,5 @@
 #![cfg_attr(not(any(feature = "arch-std", feature = "arch-wasm")), no_std)]
-#![cfg_attr(all(feature = "nightly", not(at_least_2024_09_06)), feature(waker_getters))]
+#![cfg_attr(all(feature = "nightly", not(stable_waker_getters)), feature(waker_getters))]
 #![allow(clippy::new_without_default)]
 #![doc = include_str!("../README.md")]
 #![warn(missing_docs)]

--- a/embassy-executor/src/raw/waker.rs
+++ b/embassy-executor/src/raw/waker.rs
@@ -50,13 +50,13 @@ pub fn task_from_waker(waker: &Waker) -> TaskRef {
 
         #[cfg(feature = "nightly")]
         {
-            #[cfg(not(at_least_2024_09_06))]
+            #[cfg(not(stable_waker_getters))]
             {
                 let raw_waker = waker.as_raw();
                 (raw_waker.vtable(), raw_waker.data())
             }
 
-            #[cfg(at_least_2024_09_06)]
+            #[cfg(stable_waker_getters)]
             {
                 (waker.vtable(), waker.data())
             }


### PR DESCRIPTION
This is a followup for #3508 that does not rely on the compiler build date, since the Xtensa toolchain's build dates don't match the official ones. In particular, the Xtensa 1.82 releases were built in late October, but still have the old api.