### PR TITLE
executor: use WakerHack unconditionally even if `nightly` feature is enabled.

### DIFF
--- a/embassy-executor/Cargo.toml
+++ b/embassy-executor/Cargo.toml
@@ -57,9 +57,6 @@ avr-device = { version = "0.5.3", optional = true }
 critical-section = { version = "1.1", features = ["std"] }
 trybuild = "1.0"
 
-[build-dependencies]
-rustc_version = "0.4.1"
-
 [features]
 
 ## Enable nightly-only features

--- a/embassy-executor/build.rs
+++ b/embassy-executor/build.rs
@@ -96,15 +96,4 @@ fn main() {
 
     let mut rustc_cfgs = common::CfgSet::new();
     common::set_target_cfgs(&mut rustc_cfgs);
-
-    // Waker API changed on 2024-09-06
-    rustc_cfgs.declare("at_least_2024_09_06");
-    let Some(compiler) = common::compiler_info() else {
-        return;
-    };
-    if compiler.channel == rustc_version::Channel::Nightly
-        && compiler.commit_date.map(|d| d >= "2024-09-06").unwrap_or(false)
-    {
-        rustc_cfgs.enable("at_least_2024_09_06");
-    }
 }

--- a/embassy-executor/build_common.rs
+++ b/embassy-executor/build_common.rs
@@ -124,22 +124,3 @@ impl PartialOrd<&str> for CompilerDate {
         Self::parse(other).map(|other| self.cmp(&other))
     }
 }
-
-pub struct CompilerInfo {
-    #[allow(unused)]
-    pub version: rustc_version::Version,
-    pub channel: rustc_version::Channel,
-    pub commit_date: Option<CompilerDate>,
-}
-
-pub fn compiler_info() -> Option<CompilerInfo> {
-    let Ok(meta) = rustc_version::version_meta() else {
-        return None;
-    };
-
-    Some(CompilerInfo {
-        version: meta.semver,
-        channel: meta.channel,
-        commit_date: meta.commit_date.as_deref().and_then(CompilerDate::parse),
-    })
-}

--- a/embassy-executor/src/lib.rs
+++ b/embassy-executor/src/lib.rs
@@ -1,5 +1,4 @@
 #![cfg_attr(not(any(feature = "arch-std", feature = "arch-wasm")), no_std)]
-#![cfg_attr(all(feature = "nightly", not(at_least_2024_09_06)), feature(waker_getters))]
 #![allow(clippy::new_without_default)]
 #![doc = include_str!("../README.md")]
 #![warn(missing_docs)]


### PR DESCRIPTION
This ensures the executor compiles with all recent nightly versions,
including the stable-but-with-nightly-features-enabled xtensa rustc.
