### PR TITLE
Flush SAI FIFO on init and disable

### DIFF
--- a/embassy-stm32/src/sai/mod.rs
+++ b/embassy-stm32/src/sai/mod.rs
@@ -1045,6 +1045,7 @@ impl<'d, T: Instance, W: word::Word> Drop for Sai<'d, T, W> {
     fn drop(&mut self) {
         let ch = T::REGS.ch(self.sub_block as usize);
         ch.cr1().modify(|w| w.set_saien(false));
+        ch.cr2().modify(|w| w.set_fflush(true));
         self.fs.as_ref().map(|x| x.set_as_disconnected());
         self.sd.as_ref().map(|x| x.set_as_disconnected());
         self.sck.as_ref().map(|x| x.set_as_disconnected());

--- a/embassy-stm32/src/sai/mod.rs
+++ b/embassy-stm32/src/sai/mod.rs
@@ -861,11 +861,14 @@ impl<'d, T: Instance, W: word::Word> Sai<'d, T, W> {
         ring_buffer: RingBuffer<'d, W>,
         config: Config,
     ) -> Self {
+        let ch = T::REGS.ch(sub_block as usize);
+
         #[cfg(any(sai_v1, sai_v2, sai_v3_2pdm, sai_v3_4pdm, sai_v4_2pdm, sai_v4_4pdm))]
         {
-            let ch = T::REGS.ch(sub_block as usize);
             ch.cr1().modify(|w| w.set_saien(false));
         }
+
+        ch.cr2().modify(|w| w.set_fflush(true));
 
         #[cfg(any(sai_v4_2pdm, sai_v4_4pdm))]
         {
@@ -888,7 +891,6 @@ impl<'d, T: Instance, W: word::Word> Sai<'d, T, W> {
 
         #[cfg(any(sai_v1, sai_v2, sai_v3_2pdm, sai_v3_4pdm, sai_v4_2pdm, sai_v4_4pdm))]
         {
-            let ch = T::REGS.ch(sub_block as usize);
             ch.cr1().modify(|w| {
                 w.set_mode(config.mode.mode(if Self::is_transmitter(&ring_buffer) {
                     TxRx::Transmitter


### PR DESCRIPTION
As per RM0468, p.2291:

![image](https://github.com/user-attachments/assets/3799fa1a-0783-4980-90cb-640d0176c2ef)

This also adds a FIFO flush on SAI init, just like the ST HAL.