### PR TITLE
Disallow SAI start without an initial write

### DIFF
--- a/embassy-stm32/src/dma/dma_bdma.rs
+++ b/embassy-stm32/src/dma/dma_bdma.rs
@@ -828,7 +828,6 @@ impl<'a, W: Word> ReadableRingBuffer<'a, W> {
     /// You must call this after creating it for it to work.
     pub fn start(&mut self) {
         self.channel.start();
-        self.clear();
     }
 
     /// Clear all data in the ring buffer.
@@ -981,7 +980,6 @@ impl<'a, W: Word> WritableRingBuffer<'a, W> {
     /// You must call this after creating it for it to work.
     pub fn start(&mut self) {
         self.channel.start();
-        self.clear();
     }
 
     /// Clear all data in the ring buffer.
@@ -991,7 +989,6 @@ impl<'a, W: Word> WritableRingBuffer<'a, W> {
 
     /// Write elements directly to the raw buffer.
     /// This can be used to fill the buffer before starting the DMA transfer.
-    #[allow(dead_code)]
     pub fn write_immediate(&mut self, buf: &[W]) -> Result<(usize, usize), Error> {
         self.ringbuf.write_immediate(buf)
     }

--- a/examples/stm32h7/src/bin/sai.rs
+++ b/examples/stm32h7/src/bin/sai.rs
@@ -107,7 +107,7 @@ async fn main(_spawner: Spawner) {
 
     let mut sai_receiver = Sai::new_synchronous(sub_block_rx, p.PE3, p.DMA1_CH1, rx_buffer, rx_config);
 
-    sai_receiver.start();
+    sai_receiver.start().unwrap();
 
     let mut buf = [0u32; HALF_DMA_BUFFER_LENGTH];
 

--- a/examples/stm32h7/src/bin/sai.rs
+++ b/examples/stm32h7/src/bin/sai.rs
@@ -108,7 +108,6 @@ async fn main(_spawner: Spawner) {
     let mut sai_receiver = Sai::new_synchronous(sub_block_rx, p.PE3, p.DMA1_CH1, rx_buffer, rx_config);
 
     sai_receiver.start();
-    sai_transmitter.start();
 
     let mut buf = [0u32; HALF_DMA_BUFFER_LENGTH];
 


### PR DESCRIPTION
Previously, when starting the SAI (and its ring buffer + DMA channel), then writing data to the ring buffer later, the SAI DMA has already been running for some (undeterministic) amount of time. It only makes sense to start the DMA after there is already data in the transmit ring buffer present.

This PR disables `start` for SAI in transmit mode, and starts the DMA just after the transmit ring buffer was filled with an initial amount of data.