### PR TITLE
Add a function that waits for any SAI/ringbuffer write error

### DIFF
--- a/embassy-stm32/src/dma/dma_bdma.rs
+++ b/embassy-stm32/src/dma/dma_bdma.rs
@@ -1007,9 +1007,9 @@ impl<'a, W: Word> WritableRingBuffer<'a, W> {
     }
 
     /// Wait for any ring buffer write error.
-    pub async fn write_error(&mut self) -> Result<usize, Error> {
+    pub async fn wait_write_error(&mut self) -> Result<usize, Error> {
         self.ringbuf
-            .write_error(&mut DmaCtrlImpl(self.channel.reborrow()))
+            .wait_write_error(&mut DmaCtrlImpl(self.channel.reborrow()))
             .await
     }
 

--- a/embassy-stm32/src/dma/dma_bdma.rs
+++ b/embassy-stm32/src/dma/dma_bdma.rs
@@ -1006,6 +1006,13 @@ impl<'a, W: Word> WritableRingBuffer<'a, W> {
             .await
     }
 
+    /// Wait for any ring buffer write error.
+    pub async fn write_error(&mut self) -> Result<usize, Error> {
+        self.ringbuf
+            .write_error(&mut DmaCtrlImpl(self.channel.reborrow()))
+            .await
+    }
+
     /// The current length of the ringbuffer
     pub fn len(&mut self) -> Result<usize, Error> {
         Ok(self.ringbuf.len(&mut DmaCtrlImpl(self.channel.reborrow()))?)

--- a/embassy-stm32/src/dma/ringbuffer/mod.rs
+++ b/embassy-stm32/src/dma/ringbuffer/mod.rs
@@ -261,7 +261,7 @@ impl<'a, W: Word> WritableDmaRingBuffer<'a, W> {
     }
 
     /// Wait for any ring buffer write error.
-    pub async fn write_error(&mut self, dma: &mut impl DmaCtrl) -> Result<usize, Error> {
+    pub async fn wait_write_error(&mut self, dma: &mut impl DmaCtrl) -> Result<usize, Error> {
         poll_fn(|cx| {
             dma.set_waker(cx.waker());
 

--- a/embassy-stm32/src/sai/mod.rs
+++ b/embassy-stm32/src/sai/mod.rs
@@ -1009,10 +1009,10 @@ impl<'d, T: Instance, W: word::Word> Sai<'d, T, W> {
     /// experiences an overrun of the ring buffer. Then, instead of letting
     /// the SAI peripheral play the last written buffer over and over again, SAI
     /// can be muted or dropped instead.
-    pub async fn write_error(&mut self) -> Result<(), Error> {
+    pub async fn wait_write_error(&mut self) -> Result<(), Error> {
         match &mut self.ring_buffer {
             RingBuffer::Writable(buffer) => {
-                buffer.write_error().await?;
+                buffer.wait_write_error().await?;
                 Ok(())
             }
             _ => return Err(Error::NotATransmitter),

--- a/embassy-stm32/src/sai/mod.rs
+++ b/embassy-stm32/src/sai/mod.rs
@@ -1003,6 +1003,22 @@ impl<'d, T: Instance, W: word::Word> Sai<'d, T, W> {
         }
     }
 
+    /// Wait until any SAI write error occurs.
+    ///
+    /// One useful application for this is stopping playback as soon as the SAI
+    /// experiences an overrun of the ring buffer. Then, instead of letting
+    /// the SAI peripheral play the last written buffer over and over again, SAI
+    /// can be muted or dropped instead.
+    pub async fn write_error(&mut self) -> Result<(), Error> {
+        match &mut self.ring_buffer {
+            RingBuffer::Writable(buffer) => {
+                buffer.write_error().await?;
+                Ok(())
+            }
+            _ => return Err(Error::NotATransmitter),
+        }
+    }
+
     /// Write data to the SAI ringbuffer.
     ///
     /// The first write starts the DMA after filling the ring buffer with the provided data.


### PR DESCRIPTION
Below is a use case, where there is a `channel` that gets supplied with audio sample arrays to play on `sai`.
As soon as there is an overrun error, `sai` shall be dropped and freshly created, so that it doesn't play garbage.

```rust
let mut sai = make_a_new_sai();
let mut renew_sai = false;

loop {
    if renew_sai {
        renew_sai = false;
        drop(sai);
        sai = make_a_new_sai();
    }

    let channel_receive_fut = channel.receive();
    let sai_error_fut = sai.write_error();

    let samples = match select(channel_receive_fut, sai_error_fut).await {
        Either::First(x) => x,
        Either::Second(_) => {
            renew_sai = true;
            continue;
        }
    };

    sai.write(&samples).await.unwrap();
}
```