### PR TITLE
low-power: add support for stm32u0

### DIFF
--- a/embassy-stm32/src/low_power.rs
+++ b/embassy-stm32/src/low_power.rs
@@ -70,6 +70,7 @@ use crate::rtc::Rtc;
 
 static mut EXECUTOR: Option<Executor> = None;
 
+#[cfg(not(stm32u0))]
 foreach_interrupt! {
     (RTC, rtc, $block:ident, WKUP, $irq:ident) => {
         #[interrupt]
@@ -80,7 +81,7 @@ foreach_interrupt! {
     };
 }
 
-// only relevant for stm32u0
+#[cfg(stm32u0)]
 foreach_interrupt! {
     (RTC, rtc, $block:ident, TAMP, $irq:ident) => {
         #[interrupt]
@@ -123,10 +124,10 @@ pub enum StopMode {
     Stop2,
 }
 
-#[cfg(any(stm32l4, stm32l5, stm32u5))]
+#[cfg(any(stm32l4, stm32l5, stm32u5, stm32u0))]
 use stm32_metapac::pwr::vals::Lpms;
 
-#[cfg(any(stm32l4, stm32l5, stm32u5))]
+#[cfg(any(stm32l4, stm32l5, stm32u5, stm32u0))]
 impl Into<Lpms> for StopMode {
     fn into(self) -> Lpms {
         match self {
@@ -197,7 +198,7 @@ impl Executor {
 
     #[allow(unused_variables)]
     fn configure_stop(&mut self, stop_mode: StopMode) {
-        #[cfg(any(stm32l4, stm32l5, stm32u5))]
+        #[cfg(any(stm32l4, stm32l5, stm32u5, stm32u0))]
         crate::pac::PWR.cr1().modify(|m| m.set_lpms(stop_mode.into()));
         #[cfg(stm32h5)]
         crate::pac::PWR.pmcr().modify(|v| {

--- a/embassy-stm32/src/low_power.rs
+++ b/embassy-stm32/src/low_power.rs
@@ -80,6 +80,17 @@ foreach_interrupt! {
     };
 }
 
+// only relevant for stm32u0
+foreach_interrupt! {
+    (RTC, rtc, $block:ident, TAMP, $irq:ident) => {
+        #[interrupt]
+        #[allow(non_snake_case)]
+        unsafe fn $irq() {
+            EXECUTOR.as_mut().unwrap().on_wakeup_irq();
+        }
+    };
+}
+
 #[allow(dead_code)]
 pub(crate) unsafe fn on_wakeup_irq() {
     EXECUTOR.as_mut().unwrap().on_wakeup_irq();

--- a/embassy-stm32/src/rcc/bd.rs
+++ b/embassy-stm32/src/rcc/bd.rs
@@ -159,6 +159,9 @@ impl LsConfig {
         } else {
             None
         };
+        #[cfg(rcc_u0)]
+        let lse_sysen = Some(lse_en);
+
         _ = lse_drv; // not all chips have it.
 
         // Disable backup domain write protection
@@ -199,7 +202,7 @@ impl LsConfig {
         }
         ok &= reg.lseon() == lse_en;
         ok &= reg.lsebyp() == lse_byp;
-        #[cfg(any(rcc_l5, rcc_u5, rcc_wle, rcc_wl5, rcc_wba))]
+        #[cfg(any(rcc_l5, rcc_u5, rcc_wle, rcc_wl5, rcc_wba, rcc_u0))]
         if let Some(lse_sysen) = lse_sysen {
             ok &= reg.lsesysen() == lse_sysen;
         }
@@ -251,7 +254,7 @@ impl LsConfig {
 
             while !bdcr().read().lserdy() {}
 
-            #[cfg(any(rcc_l5, rcc_u5, rcc_wle, rcc_wl5, rcc_wba))]
+            #[cfg(any(rcc_l5, rcc_u5, rcc_wle, rcc_wl5, rcc_wba, rcc_u0))]
             if let Some(lse_sysen) = lse_sysen {
                 bdcr().modify(|w| {
                     w.set_lsesysen(lse_sysen);

--- a/embassy-stm32/src/rtc/low_power.rs
+++ b/embassy-stm32/src/rtc/low_power.rs
@@ -65,7 +65,7 @@ pub(crate) enum WakeupPrescaler {
     Div16 = 16,
 }
 
-#[cfg(any(stm32f4, stm32l0, stm32g4, stm32l4, stm32l5, stm32wb, stm32h5, stm32g0, stm32u5))]
+#[cfg(any(stm32f4, stm32l0, stm32g4, stm32l4, stm32l5, stm32wb, stm32h5, stm32g0, stm32u5, stm32u0))]
 impl From<WakeupPrescaler> for crate::pac::rtc::vals::Wucksel {
     fn from(val: WakeupPrescaler) -> Self {
         use crate::pac::rtc::vals::Wucksel;
@@ -79,7 +79,7 @@ impl From<WakeupPrescaler> for crate::pac::rtc::vals::Wucksel {
     }
 }
 
-#[cfg(any(stm32f4, stm32l0, stm32g4, stm32l4, stm32l5, stm32wb, stm32h5, stm32g0, stm32u5))]
+#[cfg(any(stm32f4, stm32l0, stm32g4, stm32l4, stm32l5, stm32wb, stm32h5, stm32g0, stm32u5, stm32u0))]
 impl From<crate::pac::rtc::vals::Wucksel> for WakeupPrescaler {
     fn from(val: crate::pac::rtc::vals::Wucksel) -> Self {
         use crate::pac::rtc::vals::Wucksel;
@@ -223,7 +223,7 @@ impl Rtc {
         <RTC as crate::rtc::SealedInstance>::WakeupInterrupt::unpend();
         unsafe { <RTC as crate::rtc::SealedInstance>::WakeupInterrupt::enable() };
 
-        #[cfg(not(stm32u5))]
+        #[cfg(not(any(stm32u5, stm32u0)))]
         {
             use crate::pac::EXTI;
             EXTI.rtsr(0).modify(|w| w.set_line(RTC::EXTI_WAKEUP_LINE, true));

--- a/embassy-stm32/src/rtc/low_power.rs
+++ b/embassy-stm32/src/rtc/low_power.rs
@@ -65,7 +65,9 @@ pub(crate) enum WakeupPrescaler {
     Div16 = 16,
 }
 
-#[cfg(any(stm32f4, stm32l0, stm32g4, stm32l4, stm32l5, stm32wb, stm32h5, stm32g0, stm32u5, stm32u0))]
+#[cfg(any(
+    stm32f4, stm32l0, stm32g4, stm32l4, stm32l5, stm32wb, stm32h5, stm32g0, stm32u5, stm32u0
+))]
 impl From<WakeupPrescaler> for crate::pac::rtc::vals::Wucksel {
     fn from(val: WakeupPrescaler) -> Self {
         use crate::pac::rtc::vals::Wucksel;
@@ -79,7 +81,9 @@ impl From<WakeupPrescaler> for crate::pac::rtc::vals::Wucksel {
     }
 }
 
-#[cfg(any(stm32f4, stm32l0, stm32g4, stm32l4, stm32l5, stm32wb, stm32h5, stm32g0, stm32u5, stm32u0))]
+#[cfg(any(
+    stm32f4, stm32l0, stm32g4, stm32l4, stm32l5, stm32wb, stm32h5, stm32g0, stm32u5, stm32u0
+))]
 impl From<crate::pac::rtc::vals::Wucksel> for WakeupPrescaler {
     fn from(val: crate::pac::rtc::vals::Wucksel) -> Self {
         use crate::pac::rtc::vals::Wucksel;

--- a/embassy-stm32/src/rtc/mod.rs
+++ b/embassy-stm32/src/rtc/mod.rs
@@ -285,7 +285,7 @@ trait SealedInstance {
     const BACKUP_REGISTER_COUNT: usize;
 
     #[cfg(feature = "low-power")]
-    #[cfg(not(stm32u5))]
+    #[cfg(not(any(stm32u5, stm32u0)))]
     const EXTI_WAKEUP_LINE: usize;
 
     #[cfg(feature = "low-power")]

--- a/embassy-stm32/src/rtc/v3.rs
+++ b/embassy-stm32/src/rtc/v3.rs
@@ -144,7 +144,7 @@ impl SealedInstance for crate::peripherals::RTC {
     cfg_if::cfg_if!(
         if #[cfg(stm32g4)] {
             type WakeupInterrupt = crate::interrupt::typelevel::RTC_WKUP;
-        } else if #[cfg(any(stm32g0))] {
+        } else if #[cfg(any(stm32g0, stm32u0))] {
             type WakeupInterrupt = crate::interrupt::typelevel::RTC_TAMP;
         } else if #[cfg(any(stm32l5, stm32h5, stm32u5))] {
             type WakeupInterrupt = crate::interrupt::typelevel::RTC;

--- a/embassy-stm32/src/rtc/v3.rs
+++ b/embassy-stm32/src/rtc/v3.rs
@@ -139,7 +139,7 @@ impl SealedInstance for crate::peripherals::RTC {
             const EXTI_WAKEUP_LINE: usize = 17;
         }
     );
-        
+
     #[cfg(feature = "low-power")]
     cfg_if::cfg_if!(
         if #[cfg(stm32g4)] {

--- a/embassy-stm32/src/rtc/v3.rs
+++ b/embassy-stm32/src/rtc/v3.rs
@@ -133,14 +133,20 @@ impl SealedInstance for crate::peripherals::RTC {
     cfg_if::cfg_if!(
         if #[cfg(stm32g4)] {
             const EXTI_WAKEUP_LINE: usize = 20;
-            type WakeupInterrupt = crate::interrupt::typelevel::RTC_WKUP;
         } else if #[cfg(stm32g0)] {
             const EXTI_WAKEUP_LINE: usize = 19;
-            type WakeupInterrupt = crate::interrupt::typelevel::RTC_TAMP;
         } else if #[cfg(any(stm32l5, stm32h5))] {
             const EXTI_WAKEUP_LINE: usize = 17;
-            type WakeupInterrupt = crate::interrupt::typelevel::RTC;
-        } else if #[cfg(stm32u5)] {
+        }
+    );
+        
+    #[cfg(feature = "low-power")]
+    cfg_if::cfg_if!(
+        if #[cfg(stm32g4)] {
+            type WakeupInterrupt = crate::interrupt::typelevel::RTC_WKUP;
+        } else if #[cfg(any(stm32g0))] {
+            type WakeupInterrupt = crate::interrupt::typelevel::RTC_TAMP;
+        } else if #[cfg(any(stm32l5, stm32h5, stm32u5))] {
             type WakeupInterrupt = crate::interrupt::typelevel::RTC;
         }
     );


### PR DESCRIPTION
Adding low-power support for the stm32u0. This PR depends on embassy-rs/stm32-data#540.

I can measure ~9uA for a blinky with 0.5Hz LED frequency. During stop the power consumption is ~2uA when the LED is off. The measurements are on my Nucleo-U083RC.
![low-power-stop2-u0](https://github.com/user-attachments/assets/8e105393-22c8-4f2d-b476-d463299474e9)
![low-power-stop2-u0-2](https://github.com/user-attachments/assets/f93c1327-bb82-4d07-9e25-38685ef7ea53)
