### PR TITLE
STM32H5xx ADC

### DIFF
--- a/embassy-stm32/Cargo.toml
+++ b/embassy-stm32/Cargo.toml
@@ -72,7 +72,7 @@ rand_core = "0.6.3"
 sdio-host = "0.5.0"
 critical-section = "1.1"
 #stm32-metapac = { version = "15" }
-stm32-metapac = { git = "https://github.com/embassy-rs/stm32-data-generated", tag = "stm32-data-7bb5f235587c3a6886a7be1c8f58fdf22c5257f3" }
+stm32-metapac = { git = "https://github.com/embassy-rs/stm32-data-generated", tag = "stm32-data-55b491ee982e52f80a21276a0ccbde4907982b5d" }
 
 vcell = "0.1.3"
 nb = "1.0.0"
@@ -101,7 +101,7 @@ proc-macro2 = "1.0.36"
 quote = "1.0.15"
 
 #stm32-metapac = { version = "15", default-features = false, features = ["metadata"]}
-stm32-metapac = { git = "https://github.com/embassy-rs/stm32-data-generated", tag = "stm32-data-7bb5f235587c3a6886a7be1c8f58fdf22c5257f3", default-features = false, features = ["metadata"] }
+stm32-metapac = { git = "https://github.com/embassy-rs/stm32-data-generated", tag = "stm32-data-55b491ee982e52f80a21276a0ccbde4907982b5d", default-features = false, features = ["metadata"] }
 
 [features]
 default = ["rt"]

--- a/embassy-stm32/src/lib.rs
+++ b/embassy-stm32/src/lib.rs
@@ -440,7 +440,7 @@ fn init_hw(config: Config) -> Peripherals {
                 cr.set_stop(config.enable_debug_during_sleep);
                 cr.set_standby(config.enable_debug_during_sleep);
             }
-            #[cfg(any(dbgmcu_f0, dbgmcu_c0, dbgmcu_g0, dbgmcu_u5, dbgmcu_wba, dbgmcu_l5))]
+            #[cfg(any(dbgmcu_f0, dbgmcu_c0, dbgmcu_g0, dbgmcu_u0, dbgmcu_u5, dbgmcu_wba, dbgmcu_l5))]
             {
                 cr.set_dbg_stop(config.enable_debug_during_sleep);
                 cr.set_dbg_standby(config.enable_debug_during_sleep);

--- a/examples/stm32h5/src/bin/adc.rs
+++ b/examples/stm32h5/src/bin/adc.rs
@@ -1,0 +1,59 @@
+#![no_std]
+#![no_main]
+
+use defmt::*;
+use embassy_executor::Spawner;
+use embassy_stm32::adc::{Adc, SampleTime};
+use embassy_stm32::Config;
+use embassy_time::Timer;
+use {defmt_rtt as _, panic_probe as _};
+
+#[embassy_executor::main]
+async fn main(_spawner: Spawner) {
+    let mut config = Config::default();
+    {
+        use embassy_stm32::rcc::*;
+        config.rcc.hsi = Some(HSIPrescaler::DIV1);
+        config.rcc.csi = true;
+        config.rcc.pll1 = Some(Pll {
+            source: PllSource::HSI,
+            prediv: PllPreDiv::DIV4,
+            mul: PllMul::MUL25,
+            divp: Some(PllDiv::DIV2),
+            divq: Some(PllDiv::DIV4), // SPI1 cksel defaults to pll1_q
+            divr: None,
+        });
+        config.rcc.pll2 = Some(Pll {
+            source: PllSource::HSI,
+            prediv: PllPreDiv::DIV4,
+            mul: PllMul::MUL25,
+            divp: None,
+            divq: None,
+            divr: Some(PllDiv::DIV4), // 100mhz
+        });
+        config.rcc.sys = Sysclk::PLL1_P; // 200 Mhz
+        config.rcc.ahb_pre = AHBPrescaler::DIV1; // 200 Mhz
+        config.rcc.apb1_pre = APBPrescaler::DIV2; // 100 Mhz
+        config.rcc.apb2_pre = APBPrescaler::DIV2; // 100 Mhz
+        config.rcc.apb3_pre = APBPrescaler::DIV2; // 100 Mhz
+        config.rcc.voltage_scale = VoltageScale::Scale1;
+        config.rcc.mux.adcdacsel = mux::Adcdacsel::PLL2_R;
+    }
+    let mut p = embassy_stm32::init(config);
+
+    info!("Hello World!");
+
+    let mut adc = Adc::new(p.ADC1);
+
+    adc.set_sample_time(SampleTime::CYCLES24_5);
+
+    let mut vrefint_channel = adc.enable_vrefint();
+
+    loop {
+        let vrefint = adc.blocking_read(&mut vrefint_channel);
+        info!("vrefint: {}", vrefint);
+        let measured = adc.blocking_read(&mut p.PA0);
+        info!("measured: {}", measured);
+        Timer::after_millis(500).await;
+    }
+}


### PR DESCRIPTION
This updates `stm32-metapac` to include changes enabling the ADC peripherals in the STM32Hxx family of parts. An example has also been added and was tested as working on an Nucleo-H533 dev board.

Fixes #2938