### PR TITLE
otg: fix corruption in CONTROL OUT transfers in stm32f4.       

### DIFF
--- a/embassy-stm32/Cargo.toml
+++ b/embassy-stm32/Cargo.toml
@@ -110,7 +110,17 @@ default = ["rt"]
 rt = ["stm32-metapac/rt"]
 
 ## Use [`defmt`](https://docs.rs/defmt/latest/defmt/) for logging
-defmt = ["dep:defmt", "embassy-sync/defmt", "embassy-embedded-hal/defmt", "embassy-hal-internal/defmt", "embedded-io-async/defmt-03", "embassy-usb-driver/defmt", "embassy-net-driver/defmt", "embassy-time?/defmt"]
+defmt = [
+    "dep:defmt",
+    "embassy-sync/defmt",
+    "embassy-embedded-hal/defmt",
+    "embassy-hal-internal/defmt",
+    "embedded-io-async/defmt-03",
+    "embassy-usb-driver/defmt",
+    "embassy-net-driver/defmt",
+    "embassy-time?/defmt",
+    "embassy-usb-synopsys-otg/defmt",
+]
 
 exti = []
 low-power = [ "dep:embassy-executor", "embassy-executor?/arch-cortex-m", "time" ]

--- a/embassy-stm32/src/usb/otg.rs
+++ b/embassy-stm32/src/usb/otg.rs
@@ -24,7 +24,6 @@ pub struct InterruptHandler<T: Instance> {
 
 impl<T: Instance> interrupt::typelevel::Handler<T::Interrupt> for InterruptHandler<T> {
     unsafe fn on_interrupt() {
-        trace!("irq");
         let r = T::regs();
         let state = T::state();
 

--- a/embassy-stm32/src/usb/otg.rs
+++ b/embassy-stm32/src/usb/otg.rs
@@ -27,9 +27,7 @@ impl<T: Instance> interrupt::typelevel::Handler<T::Interrupt> for InterruptHandl
         let r = T::regs();
         let state = T::state();
 
-        let setup_late_cnak = quirk_setup_late_cnak(r);
-
-        on_interrupt_impl(r, state, T::ENDPOINT_COUNT, setup_late_cnak);
+        on_interrupt_impl(r, state, T::ENDPOINT_COUNT);
     }
 }
 
@@ -86,7 +84,6 @@ impl<'d, T: Instance> Driver<'d, T> {
             extra_rx_fifo_words: RX_FIFO_EXTRA_SIZE_WORDS,
             endpoint_count: T::ENDPOINT_COUNT,
             phy_type: PhyType::InternalFullSpeed,
-            quirk_setup_late_cnak: quirk_setup_late_cnak(regs),
             calculate_trdt_fn: calculate_trdt::<T>,
         };
 
@@ -116,16 +113,13 @@ impl<'d, T: Instance> Driver<'d, T> {
         dp.set_as_af(dp.af_num(), AfType::output(OutputType::PushPull, Speed::VeryHigh));
         dm.set_as_af(dm.af_num(), AfType::output(OutputType::PushPull, Speed::VeryHigh));
 
-        let regs = T::regs();
-
         let instance = OtgInstance {
-            regs,
+            regs: T::regs(),
             state: T::state(),
             fifo_depth_words: T::FIFO_DEPTH_WORDS,
             extra_rx_fifo_words: RX_FIFO_EXTRA_SIZE_WORDS,
             endpoint_count: T::ENDPOINT_COUNT,
             phy_type: PhyType::InternalHighSpeed,
-            quirk_setup_late_cnak: quirk_setup_late_cnak(regs),
             calculate_trdt_fn: calculate_trdt::<T>,
         };
 
@@ -165,8 +159,6 @@ impl<'d, T: Instance> Driver<'d, T> {
             ulpi_d7
         );
 
-        let regs = T::regs();
-
         let instance = OtgInstance {
             regs: T::regs(),
             state: T::state(),
@@ -174,7 +166,6 @@ impl<'d, T: Instance> Driver<'d, T> {
             extra_rx_fifo_words: RX_FIFO_EXTRA_SIZE_WORDS,
             endpoint_count: T::ENDPOINT_COUNT,
             phy_type: PhyType::ExternalFullSpeed,
-            quirk_setup_late_cnak: quirk_setup_late_cnak(regs),
             calculate_trdt_fn: calculate_trdt::<T>,
         };
 
@@ -216,8 +207,6 @@ impl<'d, T: Instance> Driver<'d, T> {
             ulpi_d7
         );
 
-        let regs = T::regs();
-
         let instance = OtgInstance {
             regs: T::regs(),
             state: T::state(),
@@ -225,7 +214,6 @@ impl<'d, T: Instance> Driver<'d, T> {
             extra_rx_fifo_words: RX_FIFO_EXTRA_SIZE_WORDS,
             endpoint_count: T::ENDPOINT_COUNT,
             phy_type: PhyType::ExternalHighSpeed,
-            quirk_setup_late_cnak: quirk_setup_late_cnak(regs),
             calculate_trdt_fn: calculate_trdt::<T>,
         };
 
@@ -577,8 +565,4 @@ fn calculate_trdt<T: Instance>(speed: Dspd) -> u8 {
         }
         _ => unimplemented!(),
     }
-}
-
-fn quirk_setup_late_cnak(r: Otg) -> bool {
-    r.cid().read().0 & 0xf000 == 0x1000
 }

--- a/embassy-usb-synopsys-otg/src/lib.rs
+++ b/embassy-usb-synopsys-otg/src/lib.rs
@@ -9,7 +9,7 @@ mod fmt;
 use core::cell::UnsafeCell;
 use core::future::poll_fn;
 use core::marker::PhantomData;
-use core::sync::atomic::{AtomicBool, AtomicU16, Ordering};
+use core::sync::atomic::{AtomicBool, AtomicU16, AtomicU32, Ordering};
 use core::task::Poll;
 
 use embassy_sync::waitqueue::AtomicWaker;
@@ -25,18 +25,17 @@ pub mod otg_v1;
 use otg_v1::{regs, vals, Otg};
 
 /// Handle interrupts.
-pub unsafe fn on_interrupt<const MAX_EP_COUNT: usize>(
-    r: Otg,
-    state: &State<MAX_EP_COUNT>,
-    ep_count: usize,
-    quirk_setup_late_cnak: bool,
-) {
+pub unsafe fn on_interrupt<const MAX_EP_COUNT: usize>(r: Otg, state: &State<MAX_EP_COUNT>, ep_count: usize) {
     trace!("irq");
 
     let ints = r.gintsts().read();
     if ints.wkupint() || ints.usbsusp() || ints.usbrst() || ints.enumdne() || ints.otgint() || ints.srqint() {
         // Mask interrupts and notify `Bus` to process them
-        r.gintmsk().write(|_| {});
+        r.gintmsk().write(|w| {
+            w.set_iepint(true);
+            w.set_oepint(true);
+            w.set_rxflvlm(true);
+        });
         state.bus_waker.wake();
     }
 
@@ -64,19 +63,9 @@ pub unsafe fn on_interrupt<const MAX_EP_COUNT: usize>(
                     while r.grstctl().read().txfflsh() {}
                 }
 
-                if state.cp_state.setup_ready.load(Ordering::Relaxed) == false {
-                    // SAFETY: exclusive access ensured by atomic bool
-                    let data = unsafe { &mut *state.cp_state.setup_data.get() };
-                    data[0..4].copy_from_slice(&r.fifo(0).read().0.to_ne_bytes());
-                    data[4..8].copy_from_slice(&r.fifo(0).read().0.to_ne_bytes());
-                    state.cp_state.setup_ready.store(true, Ordering::Release);
-                    state.ep_states[0].out_waker.wake();
-                } else {
-                    error!("received SETUP before previous finished processing");
-                    // discard FIFO
-                    r.fifo(0).read();
-                    r.fifo(0).read();
-                }
+                let data = &state.cp_state.setup_data;
+                data[0].store(r.fifo(0).read().data(), Ordering::Relaxed);
+                data[1].store(r.fifo(0).read().data(), Ordering::Relaxed);
             }
             vals::Pktstsd::OUT_DATA_RX => {
                 trace!("OUT_DATA_RX ep={} len={}", ep_num, len);
@@ -110,11 +99,6 @@ pub unsafe fn on_interrupt<const MAX_EP_COUNT: usize>(
             }
             vals::Pktstsd::SETUP_DATA_DONE => {
                 trace!("SETUP_DATA_DONE ep={}", ep_num);
-
-                if quirk_setup_late_cnak {
-                    // Clear NAK to indicate we are ready to receive more data
-                    r.doepctl(ep_num).modify(|w| w.set_cnak(true));
-                }
             }
             x => trace!("unknown PKTSTS: {}", x.to_bits()),
         }
@@ -151,25 +135,30 @@ pub unsafe fn on_interrupt<const MAX_EP_COUNT: usize>(
         }
     }
 
-    // not needed? reception handled in rxflvl
-    // OUT endpoint interrupt
-    // if ints.oepint() {
-    //     let mut ep_mask = r.daint().read().oepint();
-    //     let mut ep_num = 0;
+    // out endpoint interrupt
+    if ints.oepint() {
+        trace!("oepint");
+        let mut ep_mask = r.daint().read().oepint();
+        let mut ep_num = 0;
 
-    //     while ep_mask != 0 {
-    //         if ep_mask & 1 != 0 {
-    //             let ep_ints = r.doepint(ep_num).read();
-    //             // clear all
-    //             r.doepint(ep_num).write_value(ep_ints);
-    //             state.ep_out_wakers[ep_num].wake();
-    //             trace!("out ep={} irq val={:08x}", ep_num, ep_ints.0);
-    //         }
+        // Iterate over endpoints while there are non-zero bits in the mask
+        while ep_mask != 0 {
+            if ep_mask & 1 != 0 {
+                let ep_ints = r.doepint(ep_num).read();
+                // clear all
+                r.doepint(ep_num).write_value(ep_ints);
 
-    //         ep_mask >>= 1;
-    //         ep_num += 1;
-    //     }
-    // }
+                if ep_ints.stup() {
+                    state.cp_state.setup_ready.store(true, Ordering::Release);
+                }
+                state.ep_states[ep_num].out_waker.wake();
+                trace!("out ep={} irq val={:08x}", ep_num, ep_ints.0);
+            }
+
+            ep_mask >>= 1;
+            ep_num += 1;
+        }
+    }
 }
 
 /// USB PHY type
@@ -236,7 +225,7 @@ unsafe impl Sync for EpState {}
 
 struct ControlPipeSetupState {
     /// Holds received SETUP packets. Available if [Ep0State::setup_ready] is true.
-    setup_data: UnsafeCell<[u8; 8]>,
+    setup_data: [AtomicU32; 2],
     setup_ready: AtomicBool,
 }
 
@@ -265,7 +254,7 @@ impl<const EP_COUNT: usize> State<EP_COUNT> {
 
         Self {
             cp_state: ControlPipeSetupState {
-                setup_data: UnsafeCell::new([0u8; 8]),
+                setup_data: [const { AtomicU32::new(0) }; 2],
                 setup_ready: AtomicBool::new(false),
             },
             ep_states: [NEW_EP_STATE; EP_COUNT],
@@ -480,7 +469,6 @@ impl<'d, const MAX_EP_COUNT: usize> embassy_usb_driver::Driver<'d> for Driver<'d
         trace!("start");
 
         let regs = self.instance.regs;
-        let quirk_setup_late_cnak = self.instance.quirk_setup_late_cnak;
         let cp_setup_state = &self.instance.state.cp_state;
         (
             Bus {
@@ -496,7 +484,6 @@ impl<'d, const MAX_EP_COUNT: usize> embassy_usb_driver::Driver<'d> for Driver<'d
                 ep_out,
                 ep_in,
                 regs,
-                quirk_setup_late_cnak,
             },
         )
     }
@@ -632,6 +619,11 @@ impl<'d, const MAX_EP_COUNT: usize> Bus<'d, MAX_EP_COUNT> {
             w.set_xfrcm(true);
         });
 
+        // Unmask SETUP received EP interrupt
+        r.doepmsk().write(|w| {
+            w.set_stupm(true);
+        });
+
         // Unmask and clear core interrupts
         self.restore_irqs();
         r.gintsts().write_value(regs::Gintsts(0xFFFF_FFFF));
@@ -743,7 +735,7 @@ impl<'d, const MAX_EP_COUNT: usize> Bus<'d, MAX_EP_COUNT> {
                     regs.doeptsiz(index).modify(|w| {
                         w.set_xfrsiz(ep.max_packet_size as _);
                         if index == 0 {
-                            w.set_rxdpid_stupcnt(1);
+                            w.set_rxdpid_stupcnt(3);
                         } else {
                             w.set_pktcnt(1);
                         }
@@ -755,8 +747,7 @@ impl<'d, const MAX_EP_COUNT: usize> Bus<'d, MAX_EP_COUNT> {
         // Enable IRQs for allocated endpoints
         regs.daintmsk().modify(|w| {
             w.set_iepm(ep_irq_mask(&self.ep_in));
-            // OUT interrupts not used, handled in RXFLVL
-            // w.set_oepm(ep_irq_mask(&self.ep_out));
+            w.set_oepm(ep_irq_mask(&self.ep_out));
         });
     }
 
@@ -1242,7 +1233,6 @@ pub struct ControlPipe<'d> {
     setup_state: &'d ControlPipeSetupState,
     ep_in: Endpoint<'d, In>,
     ep_out: Endpoint<'d, Out>,
-    quirk_setup_late_cnak: bool,
 }
 
 impl<'d> embassy_usb_driver::ControlPipe for ControlPipe<'d> {
@@ -1255,21 +1245,20 @@ impl<'d> embassy_usb_driver::ControlPipe for ControlPipe<'d> {
             self.ep_out.state.out_waker.register(cx.waker());
 
             if self.setup_state.setup_ready.load(Ordering::Relaxed) {
-                let data = unsafe { *self.setup_state.setup_data.get() };
+                let mut data = [0; 8];
+                data[0..4].copy_from_slice(&self.setup_state.setup_data[0].load(Ordering::Relaxed).to_ne_bytes());
+                data[4..8].copy_from_slice(&self.setup_state.setup_data[1].load(Ordering::Relaxed).to_ne_bytes());
                 self.setup_state.setup_ready.store(false, Ordering::Release);
 
                 // EP0 should not be controlled by `Bus` so this RMW does not need a critical section
-                // Receive 1 SETUP packet
                 self.regs.doeptsiz(self.ep_out.info.addr.index()).modify(|w| {
-                    w.set_rxdpid_stupcnt(1);
+                    w.set_rxdpid_stupcnt(3);
                 });
 
                 // Clear NAK to indicate we are ready to receive more data
-                if !self.quirk_setup_late_cnak {
-                    self.regs
-                        .doepctl(self.ep_out.info.addr.index())
-                        .modify(|w| w.set_cnak(true));
-                }
+                self.regs
+                    .doepctl(self.ep_out.info.addr.index())
+                    .modify(|w| w.set_cnak(true));
 
                 trace!("SETUP received: {:?}", Bytes(&data));
                 Poll::Ready(data)
@@ -1389,8 +1378,6 @@ pub struct OtgInstance<'d, const MAX_EP_COUNT: usize> {
     pub phy_type: PhyType,
     /// Extra RX FIFO words needed by some implementations.
     pub extra_rx_fifo_words: u16,
-    /// Whether to set up late cnak
-    pub quirk_setup_late_cnak: bool,
     /// Function to calculate TRDT value based on some internal clock speed.
     pub calculate_trdt_fn: fn(speed: vals::Dspd) -> u8,
 }

--- a/embassy-usb-synopsys-otg/src/otg_v1.rs
+++ b/embassy-usb-synopsys-otg/src/otg_v1.rs
@@ -108,287 +108,287 @@ impl Otg {
     }
     #[doc = "Control and status register"]
     #[inline(always)]
-    pub const fn gotgctl(self) -> Reg<regs::Gotgctl, RW> {
+    pub fn gotgctl(self) -> Reg<regs::Gotgctl, RW> {
         unsafe { Reg::from_ptr(self.ptr.add(0x0usize) as _) }
     }
     #[doc = "Interrupt register"]
     #[inline(always)]
-    pub const fn gotgint(self) -> Reg<regs::Gotgint, RW> {
+    pub fn gotgint(self) -> Reg<regs::Gotgint, RW> {
         unsafe { Reg::from_ptr(self.ptr.add(0x04usize) as _) }
     }
     #[doc = "AHB configuration register"]
     #[inline(always)]
-    pub const fn gahbcfg(self) -> Reg<regs::Gahbcfg, RW> {
+    pub fn gahbcfg(self) -> Reg<regs::Gahbcfg, RW> {
         unsafe { Reg::from_ptr(self.ptr.add(0x08usize) as _) }
     }
     #[doc = "USB configuration register"]
     #[inline(always)]
-    pub const fn gusbcfg(self) -> Reg<regs::Gusbcfg, RW> {
+    pub fn gusbcfg(self) -> Reg<regs::Gusbcfg, RW> {
         unsafe { Reg::from_ptr(self.ptr.add(0x0cusize) as _) }
     }
     #[doc = "Reset register"]
     #[inline(always)]
-    pub const fn grstctl(self) -> Reg<regs::Grstctl, RW> {
+    pub fn grstctl(self) -> Reg<regs::Grstctl, RW> {
         unsafe { Reg::from_ptr(self.ptr.add(0x10usize) as _) }
     }
     #[doc = "Core interrupt register"]
     #[inline(always)]
-    pub const fn gintsts(self) -> Reg<regs::Gintsts, RW> {
+    pub fn gintsts(self) -> Reg<regs::Gintsts, RW> {
         unsafe { Reg::from_ptr(self.ptr.add(0x14usize) as _) }
     }
     #[doc = "Interrupt mask register"]
     #[inline(always)]
-    pub const fn gintmsk(self) -> Reg<regs::Gintmsk, RW> {
+    pub fn gintmsk(self) -> Reg<regs::Gintmsk, RW> {
         unsafe { Reg::from_ptr(self.ptr.add(0x18usize) as _) }
     }
     #[doc = "Receive status debug read register"]
     #[inline(always)]
-    pub const fn grxstsr(self) -> Reg<regs::Grxsts, R> {
+    pub fn grxstsr(self) -> Reg<regs::Grxsts, R> {
         unsafe { Reg::from_ptr(self.ptr.add(0x1cusize) as _) }
     }
     #[doc = "Status read and pop register"]
     #[inline(always)]
-    pub const fn grxstsp(self) -> Reg<regs::Grxsts, R> {
+    pub fn grxstsp(self) -> Reg<regs::Grxsts, R> {
         unsafe { Reg::from_ptr(self.ptr.add(0x20usize) as _) }
     }
     #[doc = "Receive FIFO size register"]
     #[inline(always)]
-    pub const fn grxfsiz(self) -> Reg<regs::Grxfsiz, RW> {
+    pub fn grxfsiz(self) -> Reg<regs::Grxfsiz, RW> {
         unsafe { Reg::from_ptr(self.ptr.add(0x24usize) as _) }
     }
     #[doc = "Endpoint 0 transmit FIFO size register (device mode)"]
     #[inline(always)]
-    pub const fn dieptxf0(self) -> Reg<regs::Fsiz, RW> {
+    pub fn dieptxf0(self) -> Reg<regs::Fsiz, RW> {
         unsafe { Reg::from_ptr(self.ptr.add(0x28usize) as _) }
     }
     #[doc = "Non-periodic transmit FIFO size register (host mode)"]
     #[inline(always)]
-    pub const fn hnptxfsiz(self) -> Reg<regs::Fsiz, RW> {
+    pub fn hnptxfsiz(self) -> Reg<regs::Fsiz, RW> {
         unsafe { Reg::from_ptr(self.ptr.add(0x28usize) as _) }
     }
     #[doc = "Non-periodic transmit FIFO/queue status register (host mode)"]
     #[inline(always)]
-    pub const fn hnptxsts(self) -> Reg<regs::Hnptxsts, R> {
+    pub fn hnptxsts(self) -> Reg<regs::Hnptxsts, R> {
         unsafe { Reg::from_ptr(self.ptr.add(0x2cusize) as _) }
     }
     #[doc = "OTG I2C access register"]
     #[inline(always)]
-    pub const fn gi2cctl(self) -> Reg<regs::Gi2cctl, RW> {
+    pub fn gi2cctl(self) -> Reg<regs::Gi2cctl, RW> {
         unsafe { Reg::from_ptr(self.ptr.add(0x30usize) as _) }
     }
     #[doc = "General core configuration register, for core_id 0x0000_1xxx"]
     #[inline(always)]
-    pub const fn gccfg_v1(self) -> Reg<regs::GccfgV1, RW> {
+    pub fn gccfg_v1(self) -> Reg<regs::GccfgV1, RW> {
         unsafe { Reg::from_ptr(self.ptr.add(0x38usize) as _) }
     }
     #[doc = "General core configuration register, for core_id 0x0000_\\[23\\]xxx"]
     #[inline(always)]
-    pub const fn gccfg_v2(self) -> Reg<regs::GccfgV2, RW> {
+    pub fn gccfg_v2(self) -> Reg<regs::GccfgV2, RW> {
         unsafe { Reg::from_ptr(self.ptr.add(0x38usize) as _) }
     }
     #[doc = "General core configuration register, for core_id 0x0000_5xxx"]
     #[inline(always)]
-    pub const fn gccfg_v3(self) -> Reg<regs::GccfgV3, RW> {
+    pub fn gccfg_v3(self) -> Reg<regs::GccfgV3, RW> {
         unsafe { Reg::from_ptr(self.ptr.add(0x38usize) as _) }
     }
     #[doc = "Core ID register"]
     #[inline(always)]
-    pub const fn cid(self) -> Reg<regs::Cid, RW> {
+    pub fn cid(self) -> Reg<regs::Cid, RW> {
         unsafe { Reg::from_ptr(self.ptr.add(0x3cusize) as _) }
     }
     #[doc = "OTG core LPM configuration register"]
     #[inline(always)]
-    pub const fn glpmcfg(self) -> Reg<regs::Glpmcfg, RW> {
+    pub fn glpmcfg(self) -> Reg<regs::Glpmcfg, RW> {
         unsafe { Reg::from_ptr(self.ptr.add(0x54usize) as _) }
     }
     #[doc = "Host periodic transmit FIFO size register"]
     #[inline(always)]
-    pub const fn hptxfsiz(self) -> Reg<regs::Fsiz, RW> {
+    pub fn hptxfsiz(self) -> Reg<regs::Fsiz, RW> {
         unsafe { Reg::from_ptr(self.ptr.add(0x0100usize) as _) }
     }
     #[doc = "Device IN endpoint transmit FIFO size register"]
     #[inline(always)]
-    pub const fn dieptxf(self, n: usize) -> Reg<regs::Fsiz, RW> {
+    pub fn dieptxf(self, n: usize) -> Reg<regs::Fsiz, RW> {
         assert!(n < 7usize);
         unsafe { Reg::from_ptr(self.ptr.add(0x0104usize + n * 4usize) as _) }
     }
     #[doc = "Host configuration register"]
     #[inline(always)]
-    pub const fn hcfg(self) -> Reg<regs::Hcfg, RW> {
+    pub fn hcfg(self) -> Reg<regs::Hcfg, RW> {
         unsafe { Reg::from_ptr(self.ptr.add(0x0400usize) as _) }
     }
     #[doc = "Host frame interval register"]
     #[inline(always)]
-    pub const fn hfir(self) -> Reg<regs::Hfir, RW> {
+    pub fn hfir(self) -> Reg<regs::Hfir, RW> {
         unsafe { Reg::from_ptr(self.ptr.add(0x0404usize) as _) }
     }
     #[doc = "Host frame number/frame time remaining register"]
     #[inline(always)]
-    pub const fn hfnum(self) -> Reg<regs::Hfnum, R> {
+    pub fn hfnum(self) -> Reg<regs::Hfnum, R> {
         unsafe { Reg::from_ptr(self.ptr.add(0x0408usize) as _) }
     }
     #[doc = "Periodic transmit FIFO/queue status register"]
     #[inline(always)]
-    pub const fn hptxsts(self) -> Reg<regs::Hptxsts, RW> {
+    pub fn hptxsts(self) -> Reg<regs::Hptxsts, RW> {
         unsafe { Reg::from_ptr(self.ptr.add(0x0410usize) as _) }
     }
     #[doc = "Host all channels interrupt register"]
     #[inline(always)]
-    pub const fn haint(self) -> Reg<regs::Haint, R> {
+    pub fn haint(self) -> Reg<regs::Haint, R> {
         unsafe { Reg::from_ptr(self.ptr.add(0x0414usize) as _) }
     }
     #[doc = "Host all channels interrupt mask register"]
     #[inline(always)]
-    pub const fn haintmsk(self) -> Reg<regs::Haintmsk, RW> {
+    pub fn haintmsk(self) -> Reg<regs::Haintmsk, RW> {
         unsafe { Reg::from_ptr(self.ptr.add(0x0418usize) as _) }
     }
     #[doc = "Host port control and status register"]
     #[inline(always)]
-    pub const fn hprt(self) -> Reg<regs::Hprt, RW> {
+    pub fn hprt(self) -> Reg<regs::Hprt, RW> {
         unsafe { Reg::from_ptr(self.ptr.add(0x0440usize) as _) }
     }
     #[doc = "Host channel characteristics register"]
     #[inline(always)]
-    pub const fn hcchar(self, n: usize) -> Reg<regs::Hcchar, RW> {
+    pub fn hcchar(self, n: usize) -> Reg<regs::Hcchar, RW> {
         assert!(n < 12usize);
         unsafe { Reg::from_ptr(self.ptr.add(0x0500usize + n * 32usize) as _) }
     }
     #[doc = "Host channel split control register"]
     #[inline(always)]
-    pub const fn hcsplt(self, n: usize) -> Reg<u32, RW> {
+    pub fn hcsplt(self, n: usize) -> Reg<u32, RW> {
         assert!(n < 12usize);
         unsafe { Reg::from_ptr(self.ptr.add(0x0504usize + n * 32usize) as _) }
     }
     #[doc = "Host channel interrupt register"]
     #[inline(always)]
-    pub const fn hcint(self, n: usize) -> Reg<regs::Hcint, RW> {
+    pub fn hcint(self, n: usize) -> Reg<regs::Hcint, RW> {
         assert!(n < 12usize);
         unsafe { Reg::from_ptr(self.ptr.add(0x0508usize + n * 32usize) as _) }
     }
     #[doc = "Host channel mask register"]
     #[inline(always)]
-    pub const fn hcintmsk(self, n: usize) -> Reg<regs::Hcintmsk, RW> {
+    pub fn hcintmsk(self, n: usize) -> Reg<regs::Hcintmsk, RW> {
         assert!(n < 12usize);
         unsafe { Reg::from_ptr(self.ptr.add(0x050cusize + n * 32usize) as _) }
     }
     #[doc = "Host channel transfer size register"]
     #[inline(always)]
-    pub const fn hctsiz(self, n: usize) -> Reg<regs::Hctsiz, RW> {
+    pub fn hctsiz(self, n: usize) -> Reg<regs::Hctsiz, RW> {
         assert!(n < 12usize);
         unsafe { Reg::from_ptr(self.ptr.add(0x0510usize + n * 32usize) as _) }
     }
     #[doc = "Host channel DMA address register"]
     #[inline(always)]
-    pub const fn hcdma(self, n: usize) -> Reg<u32, RW> {
+    pub fn hcdma(self, n: usize) -> Reg<u32, RW> {
         assert!(n < 12usize);
         unsafe { Reg::from_ptr(self.ptr.add(0x0514usize + n * 32usize) as _) }
     }
     #[doc = "Device configuration register"]
     #[inline(always)]
-    pub const fn dcfg(self) -> Reg<regs::Dcfg, RW> {
+    pub fn dcfg(self) -> Reg<regs::Dcfg, RW> {
         unsafe { Reg::from_ptr(self.ptr.add(0x0800usize) as _) }
     }
     #[doc = "Device control register"]
     #[inline(always)]
-    pub const fn dctl(self) -> Reg<regs::Dctl, RW> {
+    pub fn dctl(self) -> Reg<regs::Dctl, RW> {
         unsafe { Reg::from_ptr(self.ptr.add(0x0804usize) as _) }
     }
     #[doc = "Device status register"]
     #[inline(always)]
-    pub const fn dsts(self) -> Reg<regs::Dsts, R> {
+    pub fn dsts(self) -> Reg<regs::Dsts, R> {
         unsafe { Reg::from_ptr(self.ptr.add(0x0808usize) as _) }
     }
     #[doc = "Device IN endpoint common interrupt mask register"]
     #[inline(always)]
-    pub const fn diepmsk(self) -> Reg<regs::Diepmsk, RW> {
+    pub fn diepmsk(self) -> Reg<regs::Diepmsk, RW> {
         unsafe { Reg::from_ptr(self.ptr.add(0x0810usize) as _) }
     }
     #[doc = "Device OUT endpoint common interrupt mask register"]
     #[inline(always)]
-    pub const fn doepmsk(self) -> Reg<regs::Doepmsk, RW> {
+    pub fn doepmsk(self) -> Reg<regs::Doepmsk, RW> {
         unsafe { Reg::from_ptr(self.ptr.add(0x0814usize) as _) }
     }
     #[doc = "Device all endpoints interrupt register"]
     #[inline(always)]
-    pub const fn daint(self) -> Reg<regs::Daint, R> {
+    pub fn daint(self) -> Reg<regs::Daint, R> {
         unsafe { Reg::from_ptr(self.ptr.add(0x0818usize) as _) }
     }
     #[doc = "All endpoints interrupt mask register"]
     #[inline(always)]
-    pub const fn daintmsk(self) -> Reg<regs::Daintmsk, RW> {
+    pub fn daintmsk(self) -> Reg<regs::Daintmsk, RW> {
         unsafe { Reg::from_ptr(self.ptr.add(0x081cusize) as _) }
     }
     #[doc = "Device VBUS discharge time register"]
     #[inline(always)]
-    pub const fn dvbusdis(self) -> Reg<regs::Dvbusdis, RW> {
+    pub fn dvbusdis(self) -> Reg<regs::Dvbusdis, RW> {
         unsafe { Reg::from_ptr(self.ptr.add(0x0828usize) as _) }
     }
     #[doc = "Device VBUS pulsing time register"]
     #[inline(always)]
-    pub const fn dvbuspulse(self) -> Reg<regs::Dvbuspulse, RW> {
+    pub fn dvbuspulse(self) -> Reg<regs::Dvbuspulse, RW> {
         unsafe { Reg::from_ptr(self.ptr.add(0x082cusize) as _) }
     }
     #[doc = "Device IN endpoint FIFO empty interrupt mask register"]
     #[inline(always)]
-    pub const fn diepempmsk(self) -> Reg<regs::Diepempmsk, RW> {
+    pub fn diepempmsk(self) -> Reg<regs::Diepempmsk, RW> {
         unsafe { Reg::from_ptr(self.ptr.add(0x0834usize) as _) }
     }
     #[doc = "Device IN endpoint control register"]
     #[inline(always)]
-    pub const fn diepctl(self, n: usize) -> Reg<regs::Diepctl, RW> {
+    pub fn diepctl(self, n: usize) -> Reg<regs::Diepctl, RW> {
         assert!(n < 16usize);
         unsafe { Reg::from_ptr(self.ptr.add(0x0900usize + n * 32usize) as _) }
     }
     #[doc = "Device IN endpoint interrupt register"]
     #[inline(always)]
-    pub const fn diepint(self, n: usize) -> Reg<regs::Diepint, RW> {
+    pub fn diepint(self, n: usize) -> Reg<regs::Diepint, RW> {
         assert!(n < 16usize);
         unsafe { Reg::from_ptr(self.ptr.add(0x0908usize + n * 32usize) as _) }
     }
     #[doc = "Device IN endpoint transfer size register"]
     #[inline(always)]
-    pub const fn dieptsiz(self, n: usize) -> Reg<regs::Dieptsiz, RW> {
+    pub fn dieptsiz(self, n: usize) -> Reg<regs::Dieptsiz, RW> {
         assert!(n < 16usize);
         unsafe { Reg::from_ptr(self.ptr.add(0x0910usize + n * 32usize) as _) }
     }
     #[doc = "Device IN endpoint transmit FIFO status register"]
     #[inline(always)]
-    pub const fn dtxfsts(self, n: usize) -> Reg<regs::Dtxfsts, R> {
+    pub fn dtxfsts(self, n: usize) -> Reg<regs::Dtxfsts, R> {
         assert!(n < 16usize);
         unsafe { Reg::from_ptr(self.ptr.add(0x0918usize + n * 32usize) as _) }
     }
     #[doc = "Device OUT endpoint control register"]
     #[inline(always)]
-    pub const fn doepctl(self, n: usize) -> Reg<regs::Doepctl, RW> {
+    pub fn doepctl(self, n: usize) -> Reg<regs::Doepctl, RW> {
         assert!(n < 16usize);
         unsafe { Reg::from_ptr(self.ptr.add(0x0b00usize + n * 32usize) as _) }
     }
     #[doc = "Device OUT endpoint interrupt register"]
     #[inline(always)]
-    pub const fn doepint(self, n: usize) -> Reg<regs::Doepint, RW> {
+    pub fn doepint(self, n: usize) -> Reg<regs::Doepint, RW> {
         assert!(n < 16usize);
         unsafe { Reg::from_ptr(self.ptr.add(0x0b08usize + n * 32usize) as _) }
     }
     #[doc = "Device OUT endpoint transfer size register"]
     #[inline(always)]
-    pub const fn doeptsiz(self, n: usize) -> Reg<regs::Doeptsiz, RW> {
+    pub fn doeptsiz(self, n: usize) -> Reg<regs::Doeptsiz, RW> {
         assert!(n < 16usize);
         unsafe { Reg::from_ptr(self.ptr.add(0x0b10usize + n * 32usize) as _) }
     }
     #[doc = "Device OUT/IN endpoint DMA address register"]
     #[inline(always)]
-    pub const fn doepdma(self, n: usize) -> Reg<u32, RW> {
+    pub fn doepdma(self, n: usize) -> Reg<u32, RW> {
         assert!(n < 16usize);
         unsafe { Reg::from_ptr(self.ptr.add(0x0b14usize + n * 32usize) as _) }
     }
     #[doc = "Power and clock gating control register"]
     #[inline(always)]
-    pub const fn pcgcctl(self) -> Reg<regs::Pcgcctl, RW> {
+    pub fn pcgcctl(self) -> Reg<regs::Pcgcctl, RW> {
         unsafe { Reg::from_ptr(self.ptr.add(0x0e00usize) as _) }
     }
     #[doc = "Device endpoint / host channel FIFO register"]
     #[inline(always)]
-    pub const fn fifo(self, n: usize) -> Reg<regs::Fifo, RW> {
+    pub fn fifo(self, n: usize) -> Reg<regs::Fifo, RW> {
         assert!(n < 16usize);
         unsafe { Reg::from_ptr(self.ptr.add(0x1000usize + n * 4096usize) as _) }
     }


### PR DESCRIPTION

The RM says we have to process STUP (and therefore clear CNAK to start the data stage)
in the DOEPINT STUP interrupt. Seems doing it in RXFLVL when we receive the data is
too early. This makes it work consistently on all chips, so the quirk is no longer needed.

Fixes #3493
Fixes #3459


- **otg: fix build with defmt enabled.**
- **otg: improve trace logging, print bytes as hex.**
- **otg: fix corruption in CONTROL OUT transfers in stm32f4.**
