### PR TITLE
feat: Add new feature to enable overclocking

### DIFF
--- a/embassy-stm32/Cargo.toml
+++ b/embassy-stm32/Cargo.toml
@@ -138,6 +138,10 @@ trustzone-secure = []
 ## There are no plans to make this stable.
 unstable-pac = []
 
+## Enable this feature to disable the overclocking check.
+## DO NOT ENABLE THIS FEATURE UNLESS YOU KNOW WHAT YOU'RE DOING.
+unchecked-overclocking = []
+
 #! ## Time
 
 ## Enables additional driver features that depend on embassy-time

--- a/embassy-stm32/src/fmt.rs
+++ b/embassy-stm32/src/fmt.rs
@@ -10,12 +10,15 @@ compile_error!("You may not enable both `defmt` and `log` features.");
 macro_rules! rcc_assert {
     ($($x:tt)*) => {
         {
-            if cfg!(feature = "unchecked-overclocking") {
+            #[cfg(not(feature = "unchecked-overclocking"))]
+            {
                 #[cfg(not(feature = "defmt"))]
                 ::core::assert!($($x)*);
                 #[cfg(feature = "defmt")]
                 ::defmt::assert!($($x)*);
-            } else {
+            }
+            #[cfg(feature = "unchecked-overclocking")]
+            {
                 #[cfg(feature = "log")]
                 ::log::warn!("`rcc_assert!` skipped: `unchecked-overclocking` feature is enabled.");
                 #[cfg(feature = "defmt")]

--- a/embassy-stm32/src/fmt.rs
+++ b/embassy-stm32/src/fmt.rs
@@ -7,6 +7,25 @@ use core::fmt::{Debug, Display, LowerHex};
 compile_error!("You may not enable both `defmt` and `log` features.");
 
 #[collapse_debuginfo(yes)]
+macro_rules! rcc_assert {
+    ($($x:tt)*) => {
+        {
+            if cfg!(feature = "unchecked-overclocking") {
+                #[cfg(not(feature = "defmt"))]
+                ::core::assert!($($x)*);
+                #[cfg(feature = "defmt")]
+                ::defmt::assert!($($x)*);
+            } else {
+                #[cfg(feature = "log")]
+                ::log::warn!("`rcc_assert!` skipped: `unchecked-overclocking` feature is enabled.");
+                #[cfg(feature = "defmt")]
+                ::defmt::warn!("`rcc_assert!` skipped: `unchecked-overclocking` feature is enabled.");
+            }
+        }
+    };
+}
+
+#[collapse_debuginfo(yes)]
 macro_rules! assert {
     ($($x:tt)*) => {
         {

--- a/embassy-stm32/src/rcc/c0.rs
+++ b/embassy-stm32/src/rcc/c0.rs
@@ -126,6 +126,7 @@ pub(crate) unsafe fn init(config: Config) {
         Sysclk::HSE => unwrap!(hse),
         _ => unreachable!(),
     };
+
     rcc_assert!(max::SYSCLK.contains(&sys));
 
     // Calculate the AHB frequency (HCLK), among other things so we can calculate the correct flash read latency.
@@ -133,7 +134,7 @@ pub(crate) unsafe fn init(config: Config) {
     rcc_assert!(max::HCLK.contains(&hclk));
 
     let (pclk1, pclk1_tim) = super::util::calc_pclk(hclk, config.apb1_pre);
-    rcc_assert(max::PCLK.contains(&pclk1));
+    rcc_assert!(max::PCLK.contains(&pclk1));
 
     let latency = match hclk.0 {
         ..=24_000_000 => Latency::WS0,

--- a/embassy-stm32/src/rcc/c0.rs
+++ b/embassy-stm32/src/rcc/c0.rs
@@ -109,12 +109,9 @@ pub(crate) unsafe fn init(config: Config) {
             None
         }
         Some(hse) => {
-            #[cfg(not(feature = "unchecked-overclocking"))]
-            {
-                match hse.mode {
-                    HseMode::Bypass => assert!(max::HSE_BYP.contains(&hse.freq)),
-                    HseMode::Oscillator => assert!(max::HSE_OSC.contains(&hse.freq)),
-                }
+            match hse.mode {
+                HseMode::Bypass => rcc_assert!(max::HSE_BYP.contains(&hse.freq)),
+                HseMode::Oscillator => rcc_assert!(max::HSE_OSC.contains(&hse.freq)),
             }
 
             RCC.cr().modify(|w| w.set_hsebyp(hse.mode != HseMode::Oscillator));
@@ -129,17 +126,14 @@ pub(crate) unsafe fn init(config: Config) {
         Sysclk::HSE => unwrap!(hse),
         _ => unreachable!(),
     };
-    #[cfg(not(feature = "unchecked-overclocking"))]
-    assert!(max::SYSCLK.contains(&sys));
+    rcc_assert!(max::SYSCLK.contains(&sys));
 
     // Calculate the AHB frequency (HCLK), among other things so we can calculate the correct flash read latency.
     let hclk = sys / config.ahb_pre;
-    #[cfg(not(feature = "unchecked-overclocking"))]
-    assert!(max::HCLK.contains(&hclk));
+    rcc_assert!(max::HCLK.contains(&hclk));
 
     let (pclk1, pclk1_tim) = super::util::calc_pclk(hclk, config.apb1_pre);
-    #[cfg(not(feature = "unchecked-overclocking"))]
-    assert!(max::PCLK.contains(&pclk1));
+    rcc_assert(max::PCLK.contains(&pclk1));
 
     let latency = match hclk.0 {
         ..=24_000_000 => Latency::WS0,

--- a/embassy-stm32/src/rcc/f013.rs
+++ b/embassy-stm32/src/rcc/f013.rs
@@ -157,9 +157,12 @@ pub(crate) unsafe fn init(config: Config) {
             None
         }
         Some(hse) => {
-            match hse.mode {
-                HseMode::Bypass => assert!(max::HSE_BYP.contains(&hse.freq)),
-                HseMode::Oscillator => assert!(max::HSE_OSC.contains(&hse.freq)),
+            #[cfg(not(feature = "unchecked-overclocking"))]
+            {
+                match hse.mode {
+                    HseMode::Bypass => assert!(max::HSE_BYP.contains(&hse.freq)),
+                    HseMode::Oscillator => assert!(max::HSE_OSC.contains(&hse.freq)),
+                }
             }
 
             RCC.cr().modify(|w| w.set_hsebyp(hse.mode != HseMode::Oscillator));
@@ -192,7 +195,9 @@ pub(crate) unsafe fn init(config: Config) {
             PllSource::HSI48 => (Pllsrc::HSI48_DIV_PREDIV, unwrap!(hsi48)),
         };
         let in_freq = src_freq / pll.prediv;
+        #[cfg(not(feature = "unchecked-overclocking"))]
         assert!(max::PLL_IN.contains(&in_freq));
+        #[cfg(not(feature = "unchecked-overclocking"))]
         let out_freq = in_freq * pll.mul;
         assert!(max::PLL_OUT.contains(&out_freq));
 
@@ -238,15 +243,16 @@ pub(crate) unsafe fn init(config: Config) {
     let (pclk2, pclk2_tim) = super::util::calc_pclk(hclk, config.apb2_pre);
     #[cfg(stm32f0)]
     let (pclk2, pclk2_tim) = (pclk1, pclk1_tim);
-
+    #[cfg(not(feature = "unchecked-overclocking"))]
     assert!(max::HCLK.contains(&hclk));
+    #[cfg(not(feature = "unchecked-overclocking"))]
     assert!(max::PCLK1.contains(&pclk1));
-    #[cfg(not(stm32f0))]
+    #[cfg(all(not(feature = "unchecked-overclocking"), not(stm32f0)))]
     assert!(max::PCLK2.contains(&pclk2));
 
     #[cfg(stm32f1)]
     let adc = pclk2 / config.adc_pre;
-    #[cfg(stm32f1)]
+    #[cfg(all(not(feature = "unchecked-overclocking"), stm32f1))]
     assert!(max::ADC.contains(&adc));
 
     // Set latency based on HCLK frquency

--- a/embassy-stm32/src/rcc/f013.rs
+++ b/embassy-stm32/src/rcc/f013.rs
@@ -238,6 +238,7 @@ pub(crate) unsafe fn init(config: Config) {
     let (pclk2, pclk2_tim) = super::util::calc_pclk(hclk, config.apb2_pre);
     #[cfg(stm32f0)]
     let (pclk2, pclk2_tim) = (pclk1, pclk1_tim);
+
     rcc_assert!(max::HCLK.contains(&hclk));
     rcc_assert!(max::PCLK1.contains(&pclk1));
     #[cfg(not(stm32f0))]

--- a/embassy-stm32/src/rcc/f247.rs
+++ b/embassy-stm32/src/rcc/f247.rs
@@ -169,12 +169,9 @@ pub(crate) unsafe fn init(config: Config) {
             None
         }
         Some(hse) => {
-            #[cfg(not(feature = "unchecked-overclocking"))]
-            {
-                match hse.mode {
-                    HseMode::Bypass => assert!(max::HSE_BYP.contains(&hse.freq)),
-                    HseMode::Oscillator => assert!(max::HSE_OSC.contains(&hse.freq)),
-                }
+            match hse.mode {
+                HseMode::Bypass => rcc_assert!(max::HSE_BYP.contains(&hse.freq)),
+                HseMode::Oscillator => rcc_assert!(max::HSE_OSC.contains(&hse.freq)),
             }
 
             RCC.cr().modify(|w| w.set_hsebyp(hse.mode != HseMode::Oscillator));
@@ -207,14 +204,11 @@ pub(crate) unsafe fn init(config: Config) {
     let hclk = sys / config.ahb_pre;
     let (pclk1, pclk1_tim) = super::util::calc_pclk(hclk, config.apb1_pre);
     let (pclk2, pclk2_tim) = super::util::calc_pclk(hclk, config.apb2_pre);
-    #[cfg(not(feature = "unchecked-overclocking"))]
-    assert!(max::SYSCLK.contains(&sys));
-    #[cfg(not(feature = "unchecked-overclocking"))]
-    assert!(max::HCLK.contains(&hclk));
-    #[cfg(not(feature = "unchecked-overclocking"))]
-    assert!(max::PCLK1.contains(&pclk1));
-    #[cfg(not(feature = "unchecked-overclocking"))]
-    assert!(max::PCLK2.contains(&pclk2));
+
+    rcc_assert!(max::SYSCLK.contains(&sys));
+    rcc_assert!(max::HCLK.contains(&hclk));
+    rcc_assert!(max::PCLK1.contains(&pclk1));
+    rcc_assert!(max::PCLK2.contains(&pclk2));
 
     let rtc = config.ls.init();
 

--- a/embassy-stm32/src/rcc/f247.rs
+++ b/embassy-stm32/src/rcc/f247.rs
@@ -169,9 +169,12 @@ pub(crate) unsafe fn init(config: Config) {
             None
         }
         Some(hse) => {
-            match hse.mode {
-                HseMode::Bypass => assert!(max::HSE_BYP.contains(&hse.freq)),
-                HseMode::Oscillator => assert!(max::HSE_OSC.contains(&hse.freq)),
+            #[cfg(not(feature = "unchecked-overclocking"))]
+            {
+                match hse.mode {
+                    HseMode::Bypass => assert!(max::HSE_BYP.contains(&hse.freq)),
+                    HseMode::Oscillator => assert!(max::HSE_OSC.contains(&hse.freq)),
+                }
             }
 
             RCC.cr().modify(|w| w.set_hsebyp(hse.mode != HseMode::Oscillator));
@@ -204,10 +207,13 @@ pub(crate) unsafe fn init(config: Config) {
     let hclk = sys / config.ahb_pre;
     let (pclk1, pclk1_tim) = super::util::calc_pclk(hclk, config.apb1_pre);
     let (pclk2, pclk2_tim) = super::util::calc_pclk(hclk, config.apb2_pre);
-
+    #[cfg(not(feature = "unchecked-overclocking"))]
     assert!(max::SYSCLK.contains(&sys));
+    #[cfg(not(feature = "unchecked-overclocking"))]
     assert!(max::HCLK.contains(&hclk));
+    #[cfg(not(feature = "unchecked-overclocking"))]
     assert!(max::PCLK1.contains(&pclk1));
+    #[cfg(not(feature = "unchecked-overclocking"))]
     assert!(max::PCLK2.contains(&pclk2));
 
     let rtc = config.ls.init();

--- a/embassy-stm32/src/rcc/g0.rs
+++ b/embassy-stm32/src/rcc/g0.rs
@@ -139,12 +139,9 @@ pub(crate) unsafe fn init(config: Config) {
             None
         }
         Some(hse) => {
-            #[cfg(not(feature = "unchecked-overclocking"))]
-            {
-                match hse.mode {
-                    HseMode::Bypass => assert!(max::HSE_BYP.contains(&hse.freq)),
-                    HseMode::Oscillator => assert!(max::HSE_OSC.contains(&hse.freq)),
-                }
+            match hse.mode {
+                HseMode::Bypass => rcc_assert!(max::HSE_BYP.contains(&hse.freq)),
+                HseMode::Oscillator => rcc_assert!(max::HSE_OSC.contains(&hse.freq)),
             }
 
             RCC.cr().modify(|w| w.set_hsebyp(hse.mode != HseMode::Oscillator));
@@ -172,11 +169,9 @@ pub(crate) unsafe fn init(config: Config) {
             while RCC.cr().read().pllrdy() {}
 
             let in_freq = src_freq / pll_config.prediv;
-            #[cfg(not(feature = "unchecked-overclocking"))]
-            assert!(max::PLL_IN.contains(&in_freq));
+            rcc_assert!(max::PLL_IN.contains(&in_freq));
             let internal_freq = in_freq * pll_config.mul;
-            #[cfg(not(feature = "unchecked-overclocking"))]
-            assert!(max::PLL_VCO.contains(&internal_freq));
+            rcc_assert!(max::PLL_VCO.contains(&internal_freq));
 
             RCC.pllcfgr().write(|w| {
                 w.set_plln(pll_config.mul);
@@ -190,8 +185,7 @@ pub(crate) unsafe fn init(config: Config) {
                     w.set_pllpen(true);
                 });
                 let freq = internal_freq / div_p;
-                #[cfg(not(feature = "unchecked-overclocking"))]
-                assert!(max::PLL_P.contains(&freq));
+                rcc_assert!(max::PLL_P.contains(&freq));
                 freq
             });
 
@@ -201,8 +195,7 @@ pub(crate) unsafe fn init(config: Config) {
                     w.set_pllqen(true);
                 });
                 let freq = internal_freq / div_q;
-                #[cfg(not(feature = "unchecked-overclocking"))]
-                assert!(max::PLL_Q.contains(&freq));
+                rcc_assert!(max::PLL_Q.contains(&freq));
                 freq
             });
 
@@ -212,8 +205,7 @@ pub(crate) unsafe fn init(config: Config) {
                     w.set_pllren(true);
                 });
                 let freq = internal_freq / div_r;
-                #[cfg(not(feature = "unchecked-overclocking"))]
-                assert!(max::PLL_R.contains(&freq));
+                rcc_assert!(max::PLL_R.contains(&freq));
                 freq
             });
 
@@ -235,17 +227,14 @@ pub(crate) unsafe fn init(config: Config) {
         Sysclk::PLL1_R => unwrap!(pll.pll_r),
         _ => unreachable!(),
     };
-    #[cfg(not(feature = "unchecked-overclocking"))]
-    assert!(max::SYSCLK.contains(&sys));
+    rcc_assert!(max::SYSCLK.contains(&sys));
 
     // Calculate the AHB frequency (HCLK), among other things so we can calculate the correct flash read latency.
     let hclk = sys / config.ahb_pre;
-    #[cfg(not(feature = "unchecked-overclocking"))]
-    assert!(max::HCLK.contains(&hclk));
+    rcc_assert!(max::HCLK.contains(&hclk));
 
     let (pclk1, pclk1_tim) = super::util::calc_pclk(hclk, config.apb1_pre);
-    #[cfg(not(feature = "unchecked-overclocking"))]
-    assert!(max::PCLK.contains(&pclk1));
+    rcc_assert!(max::PCLK.contains(&pclk1));
 
     let latency = match (config.voltage_range, hclk.0) {
         (VoltageRange::RANGE1, ..=24_000_000) => Latency::WS0,

--- a/embassy-stm32/src/rcc/g0.rs
+++ b/embassy-stm32/src/rcc/g0.rs
@@ -227,6 +227,7 @@ pub(crate) unsafe fn init(config: Config) {
         Sysclk::PLL1_R => unwrap!(pll.pll_r),
         _ => unreachable!(),
     };
+
     rcc_assert!(max::SYSCLK.contains(&sys));
 
     // Calculate the AHB frequency (HCLK), among other things so we can calculate the correct flash read latency.

--- a/embassy-stm32/src/rcc/g0.rs
+++ b/embassy-stm32/src/rcc/g0.rs
@@ -139,9 +139,12 @@ pub(crate) unsafe fn init(config: Config) {
             None
         }
         Some(hse) => {
-            match hse.mode {
-                HseMode::Bypass => assert!(max::HSE_BYP.contains(&hse.freq)),
-                HseMode::Oscillator => assert!(max::HSE_OSC.contains(&hse.freq)),
+            #[cfg(not(feature = "unchecked-overclocking"))]
+            {
+                match hse.mode {
+                    HseMode::Bypass => assert!(max::HSE_BYP.contains(&hse.freq)),
+                    HseMode::Oscillator => assert!(max::HSE_OSC.contains(&hse.freq)),
+                }
             }
 
             RCC.cr().modify(|w| w.set_hsebyp(hse.mode != HseMode::Oscillator));
@@ -169,9 +172,10 @@ pub(crate) unsafe fn init(config: Config) {
             while RCC.cr().read().pllrdy() {}
 
             let in_freq = src_freq / pll_config.prediv;
+            #[cfg(not(feature = "unchecked-overclocking"))]
             assert!(max::PLL_IN.contains(&in_freq));
             let internal_freq = in_freq * pll_config.mul;
-
+            #[cfg(not(feature = "unchecked-overclocking"))]
             assert!(max::PLL_VCO.contains(&internal_freq));
 
             RCC.pllcfgr().write(|w| {
@@ -186,6 +190,7 @@ pub(crate) unsafe fn init(config: Config) {
                     w.set_pllpen(true);
                 });
                 let freq = internal_freq / div_p;
+                #[cfg(not(feature = "unchecked-overclocking"))]
                 assert!(max::PLL_P.contains(&freq));
                 freq
             });
@@ -196,6 +201,7 @@ pub(crate) unsafe fn init(config: Config) {
                     w.set_pllqen(true);
                 });
                 let freq = internal_freq / div_q;
+                #[cfg(not(feature = "unchecked-overclocking"))]
                 assert!(max::PLL_Q.contains(&freq));
                 freq
             });
@@ -206,6 +212,7 @@ pub(crate) unsafe fn init(config: Config) {
                     w.set_pllren(true);
                 });
                 let freq = internal_freq / div_r;
+                #[cfg(not(feature = "unchecked-overclocking"))]
                 assert!(max::PLL_R.contains(&freq));
                 freq
             });
@@ -228,14 +235,16 @@ pub(crate) unsafe fn init(config: Config) {
         Sysclk::PLL1_R => unwrap!(pll.pll_r),
         _ => unreachable!(),
     };
-
+    #[cfg(not(feature = "unchecked-overclocking"))]
     assert!(max::SYSCLK.contains(&sys));
 
     // Calculate the AHB frequency (HCLK), among other things so we can calculate the correct flash read latency.
     let hclk = sys / config.ahb_pre;
+    #[cfg(not(feature = "unchecked-overclocking"))]
     assert!(max::HCLK.contains(&hclk));
 
     let (pclk1, pclk1_tim) = super::util::calc_pclk(hclk, config.apb1_pre);
+    #[cfg(not(feature = "unchecked-overclocking"))]
     assert!(max::PCLK.contains(&pclk1));
 
     let latency = match (config.voltage_range, hclk.0) {

--- a/embassy-stm32/src/rcc/g4.rs
+++ b/embassy-stm32/src/rcc/g4.rs
@@ -140,9 +140,12 @@ pub(crate) unsafe fn init(config: Config) {
             None
         }
         Some(hse) => {
-            match hse.mode {
-                HseMode::Bypass => assert!(max::HSE_BYP.contains(&hse.freq)),
-                HseMode::Oscillator => assert!(max::HSE_OSC.contains(&hse.freq)),
+            #[cfg(not(feature = "unchecked-overclocking"))]
+            {
+                match hse.mode {
+                    HseMode::Bypass => assert!(max::HSE_BYP.contains(&hse.freq)),
+                    HseMode::Oscillator => assert!(max::HSE_OSC.contains(&hse.freq)),
+                }
             }
 
             RCC.cr().modify(|w| w.set_hsebyp(hse.mode != HseMode::Oscillator));
@@ -169,9 +172,11 @@ pub(crate) unsafe fn init(config: Config) {
             while RCC.cr().read().pllrdy() {}
 
             let in_freq = src_freq / pll_config.prediv;
+            #[cfg(not(feature = "unchecked-overclocking"))]
             assert!(max::PLL_IN.contains(&in_freq));
             let internal_freq = in_freq * pll_config.mul;
 
+            #[cfg(not(feature = "unchecked-overclocking"))]
             assert!(max::PLL_VCO.contains(&internal_freq));
 
             RCC.pllcfgr().write(|w| {
@@ -186,6 +191,7 @@ pub(crate) unsafe fn init(config: Config) {
                     w.set_pllpen(true);
                 });
                 let freq = internal_freq / div_p;
+                #[cfg(not(feature = "unchecked-overclocking"))]
                 assert!(max::PLL_P.contains(&freq));
                 freq
             });
@@ -196,6 +202,7 @@ pub(crate) unsafe fn init(config: Config) {
                     w.set_pllqen(true);
                 });
                 let freq = internal_freq / div_q;
+                #[cfg(not(feature = "unchecked-overclocking"))]
                 assert!(max::PLL_Q.contains(&freq));
                 freq
             });
@@ -206,6 +213,7 @@ pub(crate) unsafe fn init(config: Config) {
                     w.set_pllren(true);
                 });
                 let freq = internal_freq / div_r;
+                #[cfg(not(feature = "unchecked-overclocking"))]
                 assert!(max::PLL_R.contains(&freq));
                 freq
             });
@@ -229,15 +237,17 @@ pub(crate) unsafe fn init(config: Config) {
         _ => unreachable!(),
     };
 
+    #[cfg(not(feature = "unchecked-overclocking"))]
     assert!(max::SYSCLK.contains(&sys));
 
     // Calculate the AHB frequency (HCLK), among other things so we can calculate the correct flash read latency.
     let hclk = sys / config.ahb_pre;
+    #[cfg(not(feature = "unchecked-overclocking"))]
     assert!(max::HCLK.contains(&hclk));
 
     let (pclk1, pclk1_tim) = super::util::calc_pclk(hclk, config.apb1_pre);
     let (pclk2, pclk2_tim) = super::util::calc_pclk(hclk, config.apb2_pre);
-    assert!(max::PCLK.contains(&pclk2));
+    #[cfg(not(feature = "unchecked-overclocking"))]
     assert!(max::PCLK.contains(&pclk2));
 
     // Configure Core Boost mode ([RM0440] p234 – inverted because setting r1mode to 0 enables boost mode!)


### PR DESCRIPTION
Add new feature `unchecked-overclocking` to disables all assertions during RCC register initialization.