### PR TITLE
Use cyw43 FW file size instead of magic numbers

### DIFF
--- a/examples/rp/src/bin/bluetooth.rs
+++ b/examples/rp/src/bin/bluetooth.rs
@@ -44,9 +44,13 @@ async fn main(spawner: Spawner) {
     //     probe-rs download 43439A0.bin --format bin --chip RP2040 --base-address 0x10100000
     //     probe-rs download 43439A0_clm.bin --format bin --chip RP2040 --base-address 0x10140000
     //     probe-rs download 43439A0_btfw.bin --format bin --chip RP2040 --base-address 0x10141400
-    //let fw = unsafe { core::slice::from_raw_parts(0x10100000 as *const u8, 224190) };
-    //let clm = unsafe { core::slice::from_raw_parts(0x10140000 as *const u8, 4752) };
-    //let btfw = unsafe { core::slice::from_raw_parts(0x10141400 as *const u8, 6164) };
+    //
+    //const FW_SZ:usize = include_bytes!("../../../../cyw43-firmware/43439A0.bin").len();
+    //const CLM_SZ:usize = include_bytes!("../../../../cyw43-firmware/43439A0_clm.bin").len();
+    //const BTFW_SZ:usize = include_bytes!("../../../../cyw43-firmware/43439A0_btfw.bin").len();
+    //let fw = unsafe { core::slice::from_raw_parts(0x10100000 as *const u8, FW_SZ) };
+    //let clm = unsafe { core::slice::from_raw_parts(0x10140000 as *const u8, CLM_SZ) };
+    //let btfw = unsafe { core::slice::from_raw_parts(0x10141400 as *const u8, BTFW_SZ) };
 
     let pwr = Output::new(p.PIN_23, Level::Low);
     let cs = Output::new(p.PIN_25, Level::High);

--- a/examples/rp/src/bin/wifi_ap_tcp_server.rs
+++ b/examples/rp/src/bin/wifi_ap_tcp_server.rs
@@ -49,10 +49,13 @@ async fn main(spawner: Spawner) {
 
     // To make flashing faster for development, you may want to flash the firmwares independently
     // at hardcoded addresses, instead of baking them into the program with `include_bytes!`:
-    //     probe-rs download 43439A0.bin --binary-format bin --chip RP2040 --base-address 0x10100000
-    //     probe-rs download 43439A0_clm.bin --binary-format bin --chip RP2040 --base-address 0x10140000
-    //let fw = unsafe { core::slice::from_raw_parts(0x10100000 as *const u8, 230321) };
-    //let clm = unsafe { core::slice::from_raw_parts(0x10140000 as *const u8, 4752) };
+    //     probe-rs download 43439A0.bin --binary-format bin --chip RP2040 --base-address 0x101b0000
+    //     probe-rs download 43439A0_clm.bin --binary-format bin --chip RP2040 --base-address 0x101f8000
+    //
+    //const FW_SZ: usize = include_bytes!("../../../../cyw43-firmware/43439A0.bin").len();
+    //const CLM_SZ: usize = include_bytes!("../../../../cyw43-firmware/43439A0_clm.bin").len();
+    //let fw = unsafe { core::slice::from_raw_parts(0x101b0000 as *const u8, FW_SZ) };
+    //let clm = unsafe { core::slice::from_raw_parts(0x101f8000 as *const u8, CLM_SZ) };
 
     let pwr = Output::new(p.PIN_23, Level::Low);
     let cs = Output::new(p.PIN_25, Level::High);

--- a/examples/rp/src/bin/wifi_blinky.rs
+++ b/examples/rp/src/bin/wifi_blinky.rs
@@ -33,10 +33,13 @@ async fn main(spawner: Spawner) {
 
     // To make flashing faster for development, you may want to flash the firmwares independently
     // at hardcoded addresses, instead of baking them into the program with `include_bytes!`:
-    //     probe-rs download ../../cyw43-firmware/43439A0.bin --binary-format bin --chip RP2040 --base-address 0x10100000
-    //     probe-rs download ../../cyw43-firmware/43439A0_clm.bin --binary-format bin --chip RP2040 --base-address 0x10140000
-    //let fw = unsafe { core::slice::from_raw_parts(0x10100000 as *const u8, 230321) };
-    //let clm = unsafe { core::slice::from_raw_parts(0x10140000 as *const u8, 4752) };
+    //     probe-rs download 43439A0.bin --binary-format bin --chip RP2040 --base-address 0x101b0000
+    //     probe-rs download 43439A0_clm.bin --binary-format bin --chip RP2040 --base-address 0x101f8000
+    //
+    //const FW_SZ: usize = include_bytes!("../../../../cyw43-firmware/43439A0.bin").len();
+    //const CLM_SZ: usize = include_bytes!("../../../../cyw43-firmware/43439A0_clm.bin").len();
+    //let fw = unsafe { core::slice::from_raw_parts(0x101b0000 as *const u8, FW_SZ) };
+    //let clm = unsafe { core::slice::from_raw_parts(0x101f8000 as *const u8, CLM_SZ) };
 
     let pwr = Output::new(p.PIN_23, Level::Low);
     let cs = Output::new(p.PIN_25, Level::High);

--- a/examples/rp/src/bin/wifi_scan.rs
+++ b/examples/rp/src/bin/wifi_scan.rs
@@ -42,10 +42,13 @@ async fn main(spawner: Spawner) {
 
     // To make flashing faster for development, you may want to flash the firmwares independently
     // at hardcoded addresses, instead of baking them into the program with `include_bytes!`:
-    //     probe-rs download 43439A0.bin --binary-format bin --chip RP2040 --base-address 0x10100000
-    //     probe-rs download 43439A0_clm.bin --binary-format bin --chip RP2040 --base-address 0x10140000
-    //let fw = unsafe { core::slice::from_raw_parts(0x10100000 as *const u8, 230321) };
-    //let clm = unsafe { core::slice::from_raw_parts(0x10140000 as *const u8, 4752) };
+    //     probe-rs download 43439A0.bin --binary-format bin --chip RP2040 --base-address 0x101b0000
+    //     probe-rs download 43439A0_clm.bin --binary-format bin --chip RP2040 --base-address 0x101f8000
+    //
+    //const FW_SZ: usize = include_bytes!("../../../../cyw43-firmware/43439A0.bin").len();
+    //const CLM_SZ: usize = include_bytes!("../../../../cyw43-firmware/43439A0_clm.bin").len();
+    //let fw = unsafe { core::slice::from_raw_parts(0x101b0000 as *const u8, FW_SZ) };
+    //let clm = unsafe { core::slice::from_raw_parts(0x101f8000 as *const u8, CLM_SZ) };
 
     let pwr = Output::new(p.PIN_23, Level::Low);
     let cs = Output::new(p.PIN_25, Level::High);

--- a/examples/rp/src/bin/wifi_tcp_server.rs
+++ b/examples/rp/src/bin/wifi_tcp_server.rs
@@ -53,10 +53,13 @@ async fn main(spawner: Spawner) {
 
     // To make flashing faster for development, you may want to flash the firmwares independently
     // at hardcoded addresses, instead of baking them into the program with `include_bytes!`:
-    //     probe-rs download 43439A0.bin --binary-format bin --chip RP2040 --base-address 0x10100000
-    //     probe-rs download 43439A0_clm.bin --binary-format bin --chip RP2040 --base-address 0x10140000
-    //let fw = unsafe { core::slice::from_raw_parts(0x10100000 as *const u8, 230321) };
-    //let clm = unsafe { core::slice::from_raw_parts(0x10140000 as *const u8, 4752) };
+    //     probe-rs download 43439A0.bin --binary-format bin --chip RP2040 --base-address 0x101b0000
+    //     probe-rs download 43439A0_clm.bin --binary-format bin --chip RP2040 --base-address 0x101f8000
+    //
+    //const FW_SZ: usize = include_bytes!("../../../../cyw43-firmware/43439A0.bin").len();
+    //const CLM_SZ: usize = include_bytes!("../../../../cyw43-firmware/43439A0_clm.bin").len();
+    //let fw = unsafe { core::slice::from_raw_parts(0x101b0000 as *const u8, FW_SZ) };
+    //let clm = unsafe { core::slice::from_raw_parts(0x101f8000 as *const u8, CLM_SZ) };
 
     let pwr = Output::new(p.PIN_23, Level::Low);
     let cs = Output::new(p.PIN_25, Level::High);

--- a/examples/rp/src/bin/wifi_webrequest.rs
+++ b/examples/rp/src/bin/wifi_webrequest.rs
@@ -53,12 +53,16 @@ async fn main(spawner: Spawner) {
 
     let fw = include_bytes!("../../../../cyw43-firmware/43439A0.bin");
     let clm = include_bytes!("../../../../cyw43-firmware/43439A0_clm.bin");
+
     // To make flashing faster for development, you may want to flash the firmwares independently
     // at hardcoded addresses, instead of baking them into the program with `include_bytes!`:
-    //     probe-rs download 43439A0.bin --binary-format bin --chip RP2040 --base-address 0x10100000
-    //     probe-rs download 43439A0_clm.bin --binary-format bin --chip RP2040 --base-address 0x10140000
-    // let fw = unsafe { core::slice::from_raw_parts(0x10100000 as *const u8, 230321) };
-    // let clm = unsafe { core::slice::from_raw_parts(0x10140000 as *const u8, 4752) };
+    //     probe-rs download 43439A0.bin --binary-format bin --chip RP2040 --base-address 0x101b0000
+    //     probe-rs download 43439A0_clm.bin --binary-format bin --chip RP2040 --base-address 0x101f8000
+    //
+    //const FW_SZ: usize = include_bytes!("../../../../cyw43-firmware/43439A0.bin").len();
+    //const CLM_SZ: usize = include_bytes!("../../../../cyw43-firmware/43439A0_clm.bin").len();
+    //let fw = unsafe { core::slice::from_raw_parts(0x101b0000 as *const u8, FW_SZ) };
+    //let clm = unsafe { core::slice::from_raw_parts(0x101f8000 as *const u8, CLM_SZ) };
 
     let pwr = Output::new(p.PIN_23, Level::Low);
     let cs = Output::new(p.PIN_25, Level::High);


### PR DESCRIPTION
This should remove the possibility of the firmware slice length being incorrect when the firmware is updated next time.
Would be nice to also have a test that runs the bluetooth firmware so we can have an assert that the firmware blobs don't overlap -  I don't expect this to be a serious concern though.
Resolves #3470