### PR TITLE
Do not reset expiration on tasks that are not running

### DIFF
--- a/embassy-executor/src/raw/mod.rs
+++ b/embassy-executor/src/raw/mod.rs
@@ -388,9 +388,6 @@ impl SyncExecutor {
             self.run_queue.dequeue_all(|p| {
                 let task = p.header();
 
-                #[cfg(feature = "integrated-timers")]
-                task.expires_at.set(u64::MAX);
-
                 if !task.state.run_dequeue() {
                     // If task is not running, ignore it. This can happen in the following scenario:
                     //   - Task gets dequeued, poll starts
@@ -399,6 +396,9 @@ impl SyncExecutor {
                     //   - RUNNING bit is cleared, but the task is already in the queue.
                     return;
                 }
+
+                #[cfg(feature = "integrated-timers")]
+                task.expires_at.set(u64::MAX);
 
                 #[cfg(feature = "rtos-trace")]
                 trace::task_exec_begin(p.as_ptr() as u32);


### PR DESCRIPTION
I think it's fine to move the reset back a bit. Tasks that don't expire aren't placed back into the timer queue. A task that has exited, resets its expiration in `TaskStorage::poll`, so it's not placed back into the queue, or it is removed in `next_expiration`. Otherwise, a task is running and we keep resetting its expiration as we did before.

This is weirdly enough a consistent 3 cycle improvement on Xtensa.