### PR TITLE
integrated-timers: Dequeue in alarm_callback

### DIFF
--- a/embassy-executor/src/raw/mod.rs
+++ b/embassy-executor/src/raw/mod.rs
@@ -397,9 +397,6 @@ impl SyncExecutor {
         self.run_queue.dequeue_all(|p| {
             let task = p.header();
 
-            #[cfg(feature = "integrated-timers")]
-            self.timer_queue.notify_task_started(p);
-
             if !task.state.run_dequeue() {
                 // If task is not running, ignore it. This can happen in the following scenario:
                 //   - Task gets dequeued, poll starts
@@ -408,6 +405,9 @@ impl SyncExecutor {
                 //   - RUNNING bit is cleared, but the task is already in the queue.
                 return;
             }
+
+            #[cfg(feature = "integrated-timers")]
+            self.timer_queue.notify_task_started(p);
 
             #[cfg(feature = "rtos-trace")]
             trace::task_exec_begin(p.as_ptr() as u32);

--- a/embassy-executor/src/raw/mod.rs
+++ b/embassy-executor/src/raw/mod.rs
@@ -54,8 +54,6 @@ pub(crate) struct TaskHeader {
     #[cfg(feature = "integrated-timers")]
     pub(crate) expires_at: Mutex<Cell<u64>>,
     #[cfg(feature = "integrated-timers")]
-    pub(crate) next_expiration: SyncUnsafeCell<u64>,
-    #[cfg(feature = "integrated-timers")]
     pub(crate) timer_queue_item: timer_queue::TimerQueueItem,
 }
 
@@ -128,8 +126,6 @@ impl<F: Future + 'static> TaskStorage<F> {
 
                 #[cfg(feature = "integrated-timers")]
                 expires_at: Mutex::new(Cell::new(0)),
-                #[cfg(feature = "integrated-timers")]
-                next_expiration: SyncUnsafeCell::new(0),
                 #[cfg(feature = "integrated-timers")]
                 timer_queue_item: timer_queue::TimerQueueItem::new(),
             },
@@ -402,7 +398,7 @@ impl SyncExecutor {
             let task = p.header();
 
             #[cfg(feature = "integrated-timers")]
-            task.next_expiration.set(u64::MAX);
+            self.timer_queue.notify_task_started(p);
 
             if !task.state.run_dequeue() {
                 // If task is not running, ignore it. This can happen in the following scenario:

--- a/embassy-executor/src/raw/timer_queue.rs
+++ b/embassy-executor/src/raw/timer_queue.rs
@@ -1,69 +1,61 @@
-use core::cell::Cell;
 use core::cmp::min;
 
-use critical_section::{CriticalSection, Mutex};
-
+use super::util::SyncUnsafeCell;
 use super::{AlarmHandle, TaskRef};
 
 pub(crate) struct TimerQueueItem {
-    next: Mutex<Cell<Option<TaskRef>>>,
+    next: SyncUnsafeCell<Option<TaskRef>>,
 }
 
 impl TimerQueueItem {
     pub const fn new() -> Self {
         Self {
-            next: Mutex::new(Cell::new(None)),
+            next: SyncUnsafeCell::new(None),
         }
     }
 }
 
 pub(crate) struct TimerQueue {
-    head: Mutex<Cell<Option<TaskRef>>>,
+    head: SyncUnsafeCell<Option<TaskRef>>,
     alarm: AlarmHandle,
 }
 
 impl TimerQueue {
     pub const fn new(alarm: AlarmHandle) -> Self {
         Self {
-            head: Mutex::new(Cell::new(None)),
+            head: SyncUnsafeCell::new(None),
             alarm,
         }
     }
 
     pub(crate) unsafe fn notify_task_exited(&self, p: TaskRef) {
         let task = p.header();
-        critical_section::with(|cs| {
-            task.expires_at.borrow(cs).set(u64::MAX);
-            self.dispatch(cs, super::wake_task);
-        });
+        task.expires_at.set(u64::MAX);
+        self.dispatch(super::wake_task);
     }
 
     pub(crate) unsafe fn notify_task_started(&self, p: TaskRef) {
         let task = p.header();
-        critical_section::with(|cs| {
-            task.expires_at.borrow(cs).set(u64::MAX);
-        });
+        task.expires_at.set(u64::MAX);
     }
 
     pub(crate) unsafe fn update(&self, p: TaskRef, at: u64) {
         let task = p.header();
-        critical_section::with(|cs| {
-            if at < task.expires_at.borrow(cs).get() {
-                task.expires_at.borrow(cs).set(at);
-                if task.state.timer_enqueue() {
-                    let prev = self.head.borrow(cs).replace(Some(p));
-                    task.timer_queue_item.next.borrow(cs).set(prev);
-                }
-                self.dispatch(cs, super::wake_task);
+        if at < task.expires_at.get() {
+            task.expires_at.set(at);
+            if task.state.timer_enqueue() {
+                let prev = self.head.replace(Some(p));
+                task.timer_queue_item.next.set(prev);
             }
-        });
+            self.dispatch(super::wake_task);
+        }
     }
 
-    unsafe fn dequeue_expired_internal(&self, now: u64, cs: CriticalSection<'_>, on_task: fn(TaskRef)) -> bool {
+    unsafe fn dequeue_expired_internal(&self, now: u64, on_task: fn(TaskRef)) -> bool {
         let mut changed = false;
-        self.retain(cs, |p| {
+        self.retain(|p| {
             let task = p.header();
-            if task.expires_at.borrow(cs).get() <= now {
+            if task.expires_at.get() <= now {
                 on_task(p);
                 changed = true;
                 false
@@ -75,32 +67,30 @@ impl TimerQueue {
     }
 
     pub(crate) unsafe fn dequeue_expired(&self, now: u64, on_task: fn(TaskRef)) {
-        critical_section::with(|cs| {
-            if self.dequeue_expired_internal(now, cs, on_task) {
-                self.dispatch(cs, on_task);
-            }
-        });
+        if self.dequeue_expired_internal(now, on_task) {
+            self.dispatch(on_task);
+        }
     }
 
-    unsafe fn retain(&self, cs: CriticalSection<'_>, mut f: impl FnMut(TaskRef) -> bool) {
+    unsafe fn retain(&self, mut f: impl FnMut(TaskRef) -> bool) {
         let mut prev = &self.head;
-        while let Some(p) = prev.borrow(cs).get() {
+        while let Some(p) = prev.get() {
             let task = p.header();
             if f(p) {
                 prev = &task.timer_queue_item.next;
             } else {
-                prev.borrow(cs).set(task.timer_queue_item.next.borrow(cs).get());
+                prev.set(task.timer_queue_item.next.get());
                 task.state.timer_dequeue();
             }
         }
     }
 
-    unsafe fn next_expiration(&self, cs: CriticalSection<'_>) -> u64 {
+    unsafe fn next_expiration(&self) -> u64 {
         let mut res = u64::MAX;
 
-        self.retain(cs, |p| {
+        self.retain(|p| {
             let task = p.header();
-            let expires = task.expires_at.borrow(cs).get();
+            let expires = task.expires_at.get();
             res = min(res, expires);
             expires != u64::MAX
         });
@@ -108,13 +98,13 @@ impl TimerQueue {
         res
     }
 
-    unsafe fn dispatch(&self, cs: CriticalSection<'_>, cb: fn(TaskRef)) {
+    unsafe fn dispatch(&self, cb: fn(TaskRef)) {
         // If this is already in the past, set_alarm might return false.
-        let next_expiration = self.next_expiration(cs);
+        let next_expiration = self.next_expiration();
         if !embassy_time_driver::set_alarm(self.alarm, next_expiration) {
             // Time driver did not schedule the alarm,
             // so we need to dequeue expired timers manually.
-            self.dequeue_expired_internal(embassy_time_driver::now(), cs, cb);
+            self.dequeue_expired_internal(embassy_time_driver::now(), cb);
         }
     }
 }

--- a/embassy-executor/src/raw/timer_queue.rs
+++ b/embassy-executor/src/raw/timer_queue.rs
@@ -28,9 +28,10 @@ impl TimerQueue {
         }
     }
 
-    pub(crate) unsafe fn update(&self, p: TaskRef) {
+    pub(crate) unsafe fn update(&self, p: TaskRef, at: u64) {
         let task = p.header();
-        if task.next_expiration.get() != u64::MAX {
+        if at < task.next_expiration.get() {
+            task.next_expiration.set(at);
             critical_section::with(|cs| {
                 if task.state.timer_enqueue() {
                     let prev = self.head.borrow(cs).replace(Some(p));

--- a/embassy-executor/src/raw/timer_queue.rs
+++ b/embassy-executor/src/raw/timer_queue.rs
@@ -109,8 +109,7 @@ impl TimerQueue {
     }
 
     unsafe fn dispatch(&self, cs: CriticalSection<'_>, cb: fn(TaskRef)) {
-        // If this is already in the past, set_alarm might return false
-        // In that case do another poll loop iteration.
+        // If this is already in the past, set_alarm might return false.
         let next_expiration = self.next_expiration(cs);
         if !embassy_time_driver::set_alarm(self.alarm, next_expiration) {
             // Time driver did not schedule the alarm,

--- a/embassy-executor/src/raw/timer_queue.rs
+++ b/embassy-executor/src/raw/timer_queue.rs
@@ -19,13 +19,23 @@ impl TimerQueueItem {
 
 pub(crate) struct TimerQueue {
     head: Mutex<Cell<Option<TaskRef>>>,
+    rescan: Mutex<Cell<bool>>,
 }
 
 impl TimerQueue {
     pub const fn new() -> Self {
         Self {
             head: Mutex::new(Cell::new(None)),
+            rescan: Mutex::new(Cell::new(true)),
         }
+    }
+
+    pub(crate) unsafe fn notify_task_exited(&self, p: TaskRef) {
+        let task = p.header();
+        task.next_expiration.set(u64::MAX);
+        critical_section::with(|cs| {
+            self.rescan.borrow(cs).set(true);
+        });
     }
 
     pub(crate) unsafe fn update(&self, p: TaskRef, at: u64) {
@@ -33,6 +43,7 @@ impl TimerQueue {
         if at < task.next_expiration.get() {
             task.next_expiration.set(at);
             critical_section::with(|cs| {
+                self.rescan.borrow(cs).set(true);
                 if task.state.timer_enqueue() {
                     let prev = self.head.borrow(cs).replace(Some(p));
                     task.timer_queue_item.next.borrow(cs).set(prev);
@@ -44,6 +55,10 @@ impl TimerQueue {
     pub(crate) unsafe fn next_expiration(&self) -> u64 {
         let mut res = u64::MAX;
         critical_section::with(|cs| {
+            let rescan = self.rescan.borrow(cs).replace(false);
+            if !rescan {
+                return;
+            }
             self.retain(cs, |p| {
                 let task = p.header();
                 let expires = task.next_expiration.get();
@@ -57,15 +72,20 @@ impl TimerQueue {
 
     pub(crate) unsafe fn dequeue_expired(&self, now: u64, on_task: impl Fn(TaskRef)) {
         critical_section::with(|cs| {
+            let mut changed = false;
             self.retain(cs, |p| {
                 let task = p.header();
                 if task.expires_at.borrow(cs).get() <= now {
                     on_task(p);
+                    changed = true;
                     false
                 } else {
                     true
                 }
             });
+            if changed {
+                self.rescan.borrow(cs).set(true);
+            }
         });
     }
 

--- a/embassy-executor/src/raw/util.rs
+++ b/embassy-executor/src/raw/util.rs
@@ -54,4 +54,8 @@ impl<T> SyncUnsafeCell<T> {
     {
         *self.value.get()
     }
+
+    pub unsafe fn replace(&self, value: T) -> T {
+        core::mem::replace(&mut *self.value.get(), value)
+    }
 }

--- a/embassy-executor/src/raw/util.rs
+++ b/embassy-executor/src/raw/util.rs
@@ -55,6 +55,7 @@ impl<T> SyncUnsafeCell<T> {
         *self.value.get()
     }
 
+    #[cfg(feature = "integrated-timers")]
     pub unsafe fn replace(&self, value: T) -> T {
         core::mem::replace(&mut *self.value.get(), value)
     }

--- a/embassy-stm32/src/time_driver.rs
+++ b/embassy-stm32/src/time_driver.rs
@@ -434,7 +434,7 @@ impl RtcDriver {
         regs_gp16().cnt().write(|w| w.set_cnt(cnt as u16));
 
         // Now, recompute all alarms
-        for i in 0..ALARM_COUNT {
+        for i in 0..self.alarm_count.load(Ordering::Relaxed) as usize {
             let alarm_handle = unsafe { AlarmHandle::new(i as u8) };
             let alarm = self.get_alarm(cs, alarm_handle);
 

--- a/embassy-stm32/src/time_driver.rs
+++ b/embassy-stm32/src/time_driver.rs
@@ -438,7 +438,10 @@ impl RtcDriver {
             let alarm_handle = unsafe { AlarmHandle::new(i as u8) };
             let alarm = self.get_alarm(cs, alarm_handle);
 
-            self.set_alarm(alarm_handle, alarm.timestamp.get());
+            if !self.set_alarm(alarm_handle, alarm.timestamp.get()) {
+                // If the alarm timestamp has passed, we need to trigger it
+                self.trigger_alarm(i, cs);
+            }
         }
     }
 


### PR DESCRIPTION
Before: Test OK, count=8537, cycles=140564/100
After: Test OK, count=70747, cycles=16961/100

Still somewhat slower than generic queue but at least not by 10x (it clocks in at `count=70666, cycles=16981/100`).

<details><summary>Benchmark source</summary>
<p>

```rust
//! Embassy executor benchmark, used to try out optimization ideas.

//% CHIPS: esp32c2 esp32c3 esp32c6 esp32h2 esp32s2 esp32s3
//% FEATURES: esp-hal-embassy/integrated-timers

#![no_std]
#![no_main]

use core::{
    future::Future,
    pin::Pin,
    task::{Context, Poll},
};

use embassy_executor::{raw::TaskStorage, Spawner};
use esp_backtrace as _;
use esp_hal::{
    prelude::*,
    time::Duration,
    timer::{systimer::SystemTimer, OneShotTimer},
};
use esp_println::println;

static mut COUNTER: u32 = 0;

const CLOCK: CpuClock = CpuClock::max();
const TEST_MILLIS: u64 = 50;

#[handler]
fn timer_handler() {
    let c = unsafe { COUNTER } as u64;
    let cpu_clock = CLOCK.hz() as u64;
    let timer_ticks_per_second = SystemTimer::ticks_per_second();
    let cpu_cycles_per_timer_ticks = cpu_clock / timer_ticks_per_second;
    println!(
        "Test OK, count={}, cycles={}/100",
        c,
        (100 * timer_ticks_per_second * cpu_cycles_per_timer_ticks * TEST_MILLIS / 1000) / c
    );
    loop {}
}

struct Task1 {}
impl Future for Task1 {
    type Output = ();

    fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
        unsafe { COUNTER += 1 };
        cx.waker().wake_by_ref();
        Poll::Pending
    }
}

static TASK1: TaskStorage<Task1> = TaskStorage::new();

#[embassy_executor::task]
async fn task2() {
    loop {
        embassy_time::Timer::after(embassy_time::Duration::from_millis(1)).await;
    }
}

#[esp_hal_embassy::main]
async fn main(spawner: Spawner) {
    let peripherals = esp_hal::init({
        let mut config = esp_hal::Config::default();
        config.cpu_clock = CLOCK;
        config
    });
    let systimer = SystemTimer::new(peripherals.SYSTIMER);
    esp_hal_embassy::init(systimer.alarm0);
    println!("Embassy initialized!");

    spawner.spawn(TASK1.spawn(|| Task1 {})).unwrap();
    spawner.spawn(task2()).unwrap();

    println!("Starting test");

    let mut timer = OneShotTimer::new(systimer.alarm1);
    timer.set_interrupt_handler(timer_handler);
    timer.enable_interrupt(true);
    timer.schedule(Duration::millis(TEST_MILLIS)).unwrap();
}

```

</p>
</details> 
