### PR TITLE
STM32U5: Add flash bank selection when erasing a sector

### DIFF
--- a/embassy-stm32/Cargo.toml
+++ b/embassy-stm32/Cargo.toml
@@ -72,7 +72,7 @@ rand_core = "0.6.3"
 sdio-host = "0.5.0"
 critical-section = "1.1"
 #stm32-metapac = { version = "15" }
-stm32-metapac = { git = "https://github.com/embassy-rs/stm32-data-generated", tag = "stm32-data-04833817666290047257c65c6547d28e1bd10dc9" }
+stm32-metapac = { git = "https://github.com/embassy-rs/stm32-data-generated", tag = "stm32-data-ab0ec4c19f81854189bab8215544ccd1256e1045" }
 
 vcell = "0.1.3"
 nb = "1.0.0"
@@ -101,7 +101,7 @@ proc-macro2 = "1.0.36"
 quote = "1.0.15"
 
 #stm32-metapac = { version = "15", default-features = false, features = ["metadata"]}
-stm32-metapac = { git = "https://github.com/embassy-rs/stm32-data-generated", tag = "stm32-data-04833817666290047257c65c6547d28e1bd10dc9", default-features = false, features = ["metadata"] }
+stm32-metapac = { git = "https://github.com/embassy-rs/stm32-data-generated", tag = "stm32-data-ab0ec4c19f81854189bab8215544ccd1256e1045", default-features = false, features = ["metadata"] }
 
 [features]
 default = ["rt"]


### PR DESCRIPTION
This addresses the problem in https://github.com/embassy-rs/embassy/issues/3561
In the current implementation of `blocking_erase_sector` for U5 there is no selection of the flash bank that contains the page to be erased.
As a consequence, only pages in bank 1 can be erased.  If blocking_erase_sector is called for a page in bank 2, then the corresponding page in bank 1 is cleared.

The implementation mimics what has already implemented for H5.

This same problem has already been raised in the past, and exactly this fix has been proposed, but never implemented.  See here
https://github.com/embassy-rs/stm32-data/pull/464#issuecomment-2050792236

At the moment the bank swap is not supported