### PR TITLE
feat: Check if SAI is running

### DIFF
--- a/embassy-stm32/src/sai/mod.rs
+++ b/embassy-stm32/src/sai/mod.rs
@@ -1019,6 +1019,14 @@ impl<'d, T: Instance, W: word::Word> Sai<'d, T, W> {
         }
     }
 
+    /// Determine whether the SAI DMA is running.
+    pub fn is_running(&mut self) -> bool {
+        match &mut self.ring_buffer {
+            RingBuffer::Writable(buffer) => buffer.is_running(),
+            RingBuffer::Readable(buffer) => buffer.is_running(),
+        }
+    }
+
     /// Write data to the SAI ringbuffer.
     ///
     /// The first write starts the DMA after filling the ring buffer with the provided data.


### PR DESCRIPTION
Useful for checking the state of SAI, e.g. for performing actions only if it is not running.

For example:
```rust
if !sai.is_running() {
    // Fill half of the SAI buffer with silence in the beginning. This starts running the SAI.
    // Prevents overruns.
    sai_amp.write(&[0u32; SAI_SAMPLE_COUNT / 2]).await.unwrap();
}

// Write actual samples.
sai.write(&samples).await.unwrap()
```