### PR TITLE
allow custom bcd usb version

### DIFF
--- a/embassy-usb/src/builder.rs
+++ b/embassy-usb/src/builder.rs
@@ -8,6 +8,13 @@ use crate::types::{InterfaceNumber, StringIndex};
 use crate::{Handler, Interface, UsbDevice, MAX_INTERFACE_COUNT, STRING_INDEX_CUSTOM_START};
 
 #[derive(Debug, Copy, Clone)]
+/// Allows Configuring the Bcd USB version below 2.1
+pub enum BcdUsbVersion {
+    Two = 0x0200,
+    TwoOne = 0x0210,
+}
+
+#[derive(Debug, Copy, Clone)]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
 #[non_exhaustive]
 /// Configuration used when creating [`UsbDevice`].
@@ -18,7 +25,7 @@ pub struct Config<'a> {
     /// Device BCD USB version.
     ///
     /// Default: `0x0210` ("2.1")
-    pub bcd_usb: u16,
+    pub bcd_usb: BcdUsbVersion,
 
     /// Device class code assigned by USB.org. Set to `0xff` for vendor-specific
     /// devices that do not conform to any class.
@@ -113,7 +120,7 @@ impl<'a> Config<'a> {
             vendor_id: vid,
             product_id: pid,
             device_release: 0x0010,
-            bcd_usb: 0x0210,
+            bcd_usb: BcdUsbVersion::TwoOne,
             manufacturer: None,
             product: None,
             serial_number: None,

--- a/embassy-usb/src/builder.rs
+++ b/embassy-usb/src/builder.rs
@@ -17,7 +17,7 @@ pub struct Config<'a> {
 
     /// Device BCD USB version.
     ///
-    /// Default: `0x02` ("2.1")
+    /// Default: `0x0210` ("2.1")
     pub bcd_usb: u16,
 
     /// Device class code assigned by USB.org. Set to `0xff` for vendor-specific
@@ -113,7 +113,7 @@ impl<'a> Config<'a> {
             vendor_id: vid,
             product_id: pid,
             device_release: 0x0010,
-            bcd_usb: 0x02,
+            bcd_usb: 0x0210,
             manufacturer: None,
             product: None,
             serial_number: None,

--- a/embassy-usb/src/builder.rs
+++ b/embassy-usb/src/builder.rs
@@ -8,6 +8,8 @@ use crate::types::{InterfaceNumber, StringIndex};
 use crate::{Handler, Interface, UsbDevice, MAX_INTERFACE_COUNT, STRING_INDEX_CUSTOM_START};
 
 #[derive(Debug, Copy, Clone)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+#[non_exhaustive]
 /// Allows Configuring the Bcd USB version below 2.1
 pub enum BcdUsbVersion {
     Two = 0x0200,

--- a/embassy-usb/src/builder.rs
+++ b/embassy-usb/src/builder.rs
@@ -15,6 +15,11 @@ pub struct Config<'a> {
     pub(crate) vendor_id: u16,
     pub(crate) product_id: u16,
 
+    /// Device BCD USB version.
+    ///
+    /// Default: `0x02` ("2.1")
+    pub bcd_usb: u16,
+
     /// Device class code assigned by USB.org. Set to `0xff` for vendor-specific
     /// devices that do not conform to any class.
     ///
@@ -108,6 +113,7 @@ impl<'a> Config<'a> {
             vendor_id: vid,
             product_id: pid,
             device_release: 0x0010,
+            bcd_usb: 0x02,
             manufacturer: None,
             product: None,
             serial_number: None,

--- a/embassy-usb/src/builder.rs
+++ b/embassy-usb/src/builder.rs
@@ -11,7 +11,7 @@ use crate::{Handler, Interface, UsbDevice, MAX_INTERFACE_COUNT, STRING_INDEX_CUS
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
 #[non_exhaustive]
 /// Allows Configuring the Bcd USB version below 2.1
-pub enum BcdUsbVersion {
+pub enum UsbVersion {
     Two = 0x0200,
     TwoOne = 0x0210,
 }
@@ -27,7 +27,7 @@ pub struct Config<'a> {
     /// Device BCD USB version.
     ///
     /// Default: `0x0210` ("2.1")
-    pub bcd_usb: BcdUsbVersion,
+    pub bcd_usb: UsbVersion,
 
     /// Device class code assigned by USB.org. Set to `0xff` for vendor-specific
     /// devices that do not conform to any class.
@@ -122,7 +122,7 @@ impl<'a> Config<'a> {
             vendor_id: vid,
             product_id: pid,
             device_release: 0x0010,
-            bcd_usb: BcdUsbVersion::TwoOne,
+            bcd_usb: UsbVersion::TwoOne,
             manufacturer: None,
             product: None,
             serial_number: None,

--- a/embassy-usb/src/descriptor.rs
+++ b/embassy-usb/src/descriptor.rs
@@ -352,7 +352,7 @@ pub(crate) fn device_qualifier_descriptor(config: &Config) -> [u8; 10] {
     [
         10,   // bLength
         0x06, // bDescriptorType
-        0x10,
+        config.bcd_usb as u8,
         (config.bcd_usb as u16 >> 8) as u8, // bcdUSB
         config.device_class,                // bDeviceClass
         config.device_sub_class,            // bDeviceSubClass

--- a/embassy-usb/src/descriptor.rs
+++ b/embassy-usb/src/descriptor.rs
@@ -326,11 +326,11 @@ pub(crate) fn device_descriptor(config: &Config) -> [u8; 18] {
         18,   // bLength
         0x01, // bDescriptorType
         0x10,
-        0x02,                     // bcdUSB 2.1
-        config.device_class,      // bDeviceClass
-        config.device_sub_class,  // bDeviceSubClass
-        config.device_protocol,   // bDeviceProtocol
-        config.max_packet_size_0, // bMaxPacketSize0
+        (config.bcd_usb >> 8) as u8, // bcdUSB
+        config.device_class,         // bDeviceClass
+        config.device_sub_class,     // bDeviceSubClass
+        config.device_protocol,      // bDeviceProtocol
+        config.max_packet_size_0,    // bMaxPacketSize0
         config.vendor_id as u8,
         (config.vendor_id >> 8) as u8, // idVendor
         config.product_id as u8,
@@ -353,13 +353,13 @@ pub(crate) fn device_qualifier_descriptor(config: &Config) -> [u8; 10] {
         10,   // bLength
         0x06, // bDescriptorType
         0x10,
-        0x02,                     // bcdUSB 2.1
-        config.device_class,      // bDeviceClass
-        config.device_sub_class,  // bDeviceSubClass
-        config.device_protocol,   // bDeviceProtocol
-        config.max_packet_size_0, // bMaxPacketSize0
-        1,                        // bNumConfigurations
-        0,                        // Reserved
+        (config.bcd_usb >> 8) as u8, // bcdUSB
+        config.device_class,         // bDeviceClass
+        config.device_sub_class,     // bDeviceSubClass
+        config.device_protocol,      // bDeviceProtocol
+        config.max_packet_size_0,    // bMaxPacketSize0
+        1,                           // bNumConfigurations
+        0,                           // Reserved
     ]
 }
 

--- a/embassy-usb/src/descriptor.rs
+++ b/embassy-usb/src/descriptor.rs
@@ -325,7 +325,7 @@ pub(crate) fn device_descriptor(config: &Config) -> [u8; 18] {
     [
         18,   // bLength
         0x01, // bDescriptorType
-        0x10,
+        config.bcd_usb as u8,
         (config.bcd_usb >> 8) as u8, // bcdUSB
         config.device_class,         // bDeviceClass
         config.device_sub_class,     // bDeviceSubClass

--- a/embassy-usb/src/descriptor.rs
+++ b/embassy-usb/src/descriptor.rs
@@ -326,11 +326,11 @@ pub(crate) fn device_descriptor(config: &Config) -> [u8; 18] {
         18,   // bLength
         0x01, // bDescriptorType
         config.bcd_usb as u8,
-        (config.bcd_usb >> 8) as u8, // bcdUSB
-        config.device_class,         // bDeviceClass
-        config.device_sub_class,     // bDeviceSubClass
-        config.device_protocol,      // bDeviceProtocol
-        config.max_packet_size_0,    // bMaxPacketSize0
+        (config.bcd_usb as u16 >> 8) as u8, // bcdUSB
+        config.device_class,                // bDeviceClass
+        config.device_sub_class,            // bDeviceSubClass
+        config.device_protocol,             // bDeviceProtocol
+        config.max_packet_size_0,           // bMaxPacketSize0
         config.vendor_id as u8,
         (config.vendor_id >> 8) as u8, // idVendor
         config.product_id as u8,
@@ -353,13 +353,13 @@ pub(crate) fn device_qualifier_descriptor(config: &Config) -> [u8; 10] {
         10,   // bLength
         0x06, // bDescriptorType
         0x10,
-        (config.bcd_usb >> 8) as u8, // bcdUSB
-        config.device_class,         // bDeviceClass
-        config.device_sub_class,     // bDeviceSubClass
-        config.device_protocol,      // bDeviceProtocol
-        config.max_packet_size_0,    // bMaxPacketSize0
-        1,                           // bNumConfigurations
-        0,                           // Reserved
+        (config.bcd_usb as u16 >> 8) as u8, // bcdUSB
+        config.device_class,                // bDeviceClass
+        config.device_sub_class,            // bDeviceSubClass
+        config.device_protocol,             // bDeviceProtocol
+        config.max_packet_size_0,           // bMaxPacketSize0
+        1,                                  // bNumConfigurations
+        0,                                  // Reserved
     ]
 }
 


### PR DESCRIPTION
Allows a custom bcdusb version like 1.1 (0x011) but leaves the default to 2.0/2.1