### PR TITLE
derive `defmt::Format` for interrupt enums

### DIFF
--- a/embassy-hal-internal/src/interrupt.rs
+++ b/embassy-hal-internal/src/interrupt.rs
@@ -102,6 +102,7 @@ macro_rules! interrupt_mod {
                     #[allow(non_camel_case_types)]
                     #[doc=stringify!($irqs)]
                     #[doc=" typelevel interrupt."]
+                    #[cfg_attr(feature = "defmt", derive(defmt::Format))]
                     pub enum $irqs {}
                     impl SealedInterrupt for $irqs{}
                     impl Interrupt for $irqs {


### PR DESCRIPTION
This PR derives the `defmt::Format` trait for enum interrupts if the `defmt` feature is enabled.

One concern: do all crates the define interrupt enums have a `defmt` feature? I'm hoping CI will tell me 😇