### PR TITLE
Allow polling exited tasks

### DIFF
--- a/embassy-executor/src/raw/mod.rs
+++ b/embassy-executor/src/raw/mod.rs
@@ -161,10 +161,8 @@ pub struct TaskStorage<F: Future + 'static> {
     future: UninitCell<F>, // Valid if STATE_SPAWNED
 }
 
-unsafe fn poll_to_despawn(p: TaskRef) {
-    // The task's future has already been dropped, we just mark it as `!SPAWNED`.
-    let this = p.header();
-    this.state.despawn();
+unsafe fn poll_exited(_p: TaskRef) {
+    // Nothing to do, the task is already !SPAWNED and dequeued.
 }
 
 impl<F: Future + 'static> TaskStorage<F> {
@@ -221,7 +219,7 @@ impl<F: Future + 'static> TaskStorage<F> {
 
                 // We replace the poll_fn with a despawn function, so that the task is cleaned up
                 // when the executor polls it next.
-                this.raw.poll_fn.set(Some(poll_to_despawn));
+                this.raw.poll_fn.set(Some(poll_exited));
 
                 // Make sure we despawn last, so that other threads can only spawn the task
                 // after we're done with it.

--- a/embassy-executor/src/raw/mod.rs
+++ b/embassy-executor/src/raw/mod.rs
@@ -411,15 +411,6 @@ impl SyncExecutor {
         self.run_queue.dequeue_all(|p| {
             let task = p.header();
 
-            if !task.state.run_dequeue() {
-                // If task is not running, ignore it. This can happen in the following scenario:
-                //   - Task gets dequeued, poll starts
-                //   - While task is being polled, it gets woken. It gets placed in the queue.
-                //   - Task poll finishes, returning done=true
-                //   - RUNNING bit is cleared, but the task is already in the queue.
-                return;
-            }
-
             #[cfg(feature = "trace")]
             trace::task_exec_begin(self, &p);
 

--- a/embassy-executor/src/raw/run_queue_atomics.rs
+++ b/embassy-executor/src/raw/run_queue_atomics.rs
@@ -81,16 +81,8 @@ impl RunQueue {
             // safety: there are no concurrent accesses to `next`
             next = unsafe { task.header().run_queue_item.next.get() };
 
-            let run_task = task.header().state.run_dequeue();
-
-            if run_task {
-                // If task is not running, ignore it. This can happen in the following scenario:
-                //   - Task gets dequeued, poll starts
-                //   - While task is being polled, it gets woken. It gets placed in the queue.
-                //   - Task poll finishes, returning done=true
-                //   - RUNNING bit is cleared, but the task is already in the queue.
-                on_task(task);
-            }
+            task.header().state.run_dequeue();
+            on_task(task);
         }
     }
 }

--- a/embassy-executor/src/raw/run_queue_critical_section.rs
+++ b/embassy-executor/src/raw/run_queue_critical_section.rs
@@ -63,11 +63,19 @@ impl RunQueue {
             // If the task re-enqueues itself, the `next` pointer will get overwritten.
             // Therefore, first read the next pointer, and only then process the task.
 
-            // safety: we know if the task is enqueued, no one else will touch the `next` pointer.
-            let cs = unsafe { CriticalSection::new() };
-            next = task.header().run_queue_item.next.borrow(cs).get();
+            let run_task = critical_section::with(|cs| {
+                next = task.header().run_queue_item.next.borrow(cs).get();
+                task.header().state.run_dequeue(cs)
+            });
 
-            on_task(task);
+            if run_task {
+                // If task is not running, ignore it. This can happen in the following scenario:
+                //   - Task gets dequeued, poll starts
+                //   - While task is being polled, it gets woken. It gets placed in the queue.
+                //   - Task poll finishes, returning done=true
+                //   - RUNNING bit is cleared, but the task is already in the queue.
+                on_task(task);
+            }
         }
     }
 }

--- a/embassy-executor/src/raw/state_atomics.rs
+++ b/embassy-executor/src/raw/state_atomics.rs
@@ -52,8 +52,7 @@ impl State {
 
     /// Unmark the task as run-queued. Return whether the task is spawned.
     #[inline(always)]
-    pub fn run_dequeue(&self) -> bool {
-        let state = self.state.fetch_and(!STATE_RUN_QUEUED, Ordering::AcqRel);
-        state & STATE_SPAWNED != 0
+    pub fn run_dequeue(&self) {
+        self.state.fetch_and(!STATE_RUN_QUEUED, Ordering::AcqRel);
     }
 }

--- a/embassy-executor/src/raw/state_atomics_arm.rs
+++ b/embassy-executor/src/raw/state_atomics_arm.rs
@@ -75,11 +75,9 @@ impl State {
 
     /// Unmark the task as run-queued. Return whether the task is spawned.
     #[inline(always)]
-    pub fn run_dequeue(&self) -> bool {
+    pub fn run_dequeue(&self) {
         compiler_fence(Ordering::Release);
 
-        let r = self.spawned.load(Ordering::Relaxed);
         self.run_queued.store(false, Ordering::Relaxed);
-        r
     }
 }

--- a/embassy-executor/src/raw/state_critical_section.rs
+++ b/embassy-executor/src/raw/state_critical_section.rs
@@ -67,11 +67,7 @@ impl State {
 
     /// Unmark the task as run-queued. Return whether the task is spawned.
     #[inline(always)]
-    pub fn run_dequeue(&self) -> bool {
-        self.update(|s| {
-            let ok = *s & STATE_SPAWNED != 0;
-            *s &= !STATE_RUN_QUEUED;
-            ok
-        })
+    pub fn run_dequeue(&self, cs: CriticalSection<'_>) {
+        self.update_with_cs(cs, |s| *s &= !STATE_RUN_QUEUED)
     }
 }

--- a/embassy-executor/tests/test.rs
+++ b/embassy-executor/tests/test.rs
@@ -69,7 +69,6 @@ fn executor_task() {
         &[
             "pend",       // spawning a task pends the executor
             "poll task1", // poll only once.
-            "pend",       // task is done, wakes itself to exit
         ]
     )
 }
@@ -180,7 +179,6 @@ fn waking_after_completion_does_not_poll() {
             "pend",       // manual wake, single pend for two wakes
             "pend",       // respawning a task pends the executor
             "poll task1", //
-            "pend",       // task is done, wakes itself to exit
         ]
     )
 }
@@ -268,7 +266,6 @@ fn waking_with_old_waker_after_respawn() {
             "yield_now",  //
             "pend",       // manual wake, gets cleared by poll
             "poll task1", //
-            "pend",       // task is done, wakes itself to exit
         ]
     );
 }

--- a/embassy-executor/tests/test.rs
+++ b/embassy-executor/tests/test.rs
@@ -69,6 +69,7 @@ fn executor_task() {
         &[
             "pend",       // spawning a task pends the executor
             "poll task1", // poll only once.
+            "pend",       // task is done, wakes itself to exit
         ]
     )
 }
@@ -179,6 +180,7 @@ fn waking_after_completion_does_not_poll() {
             "pend",       // manual wake, single pend for two wakes
             "pend",       // respawning a task pends the executor
             "poll task1", //
+            "pend",       // task is done, wakes itself to exit
         ]
     )
 }
@@ -266,6 +268,7 @@ fn waking_with_old_waker_after_respawn() {
             "yield_now",  //
             "pend",       // manual wake, gets cleared by poll
             "poll task1", //
+            "pend",       // task is done, wakes itself to exit
         ]
     );
 }


### PR DESCRIPTION
This PR replaces `poll_fn` to a more "inert" one, making it okay to poll `!SPAWNED` tasks. I guess this PR changes the trace output for awoken-exited tasks, but it's probably for the better.

ESP32-S3: cycle count goes from `15749/100` to `14745/100`
ESP32-S2: cycle count goes from `25815/100` to `24809/100`