### PR TITLE
Shrink task arena of nrf tests

### DIFF
--- a/tests/nrf/Cargo.toml
+++ b/tests/nrf/Cargo.toml
@@ -33,7 +33,7 @@ portable-atomic = { version = "1.6.0" }
 nrf51422 = ["embassy-nrf/nrf51",         "portable-atomic/unsafe-assume-single-core"]
 nrf52832 = ["embassy-nrf/nrf52832",      "easydma"]
 nrf52833 = ["embassy-nrf/nrf52833",      "easydma", "two-uarts"]
-nrf52840 = ["embassy-nrf/nrf52840",      "easydma", "two-uarts"]
+nrf52840 = ["embassy-nrf/nrf52840",      "easydma", "two-uarts", "embassy-executor/task-arena-size-16384"]
 nrf5340  = ["embassy-nrf/nrf5340-app-s", "easydma", "two-uarts"]
 nrf9160  = ["embassy-nrf/nrf9160-s",     "easydma", "two-uarts"]
 

--- a/tests/nrf/Cargo.toml
+++ b/tests/nrf/Cargo.toml
@@ -9,7 +9,7 @@ teleprobe-meta = "1"
 
 embassy-futures = { version = "0.1.0", path = "../../embassy-futures" }
 embassy-sync = { version = "0.6.1", path = "../../embassy-sync", features = ["defmt", ] }
-embassy-executor = { version = "0.6.3", path = "../../embassy-executor", features = ["arch-cortex-m", "executor-thread", "defmt", "task-arena-size-16384", "integrated-timers"] }
+embassy-executor = { version = "0.6.3", path = "../../embassy-executor", features = ["arch-cortex-m", "executor-thread", "defmt", "integrated-timers"] }
 embassy-time = { version = "0.3.2", path = "../../embassy-time", features = ["defmt",  "defmt-timestamp-uptime"] }
 embassy-nrf = { version = "0.2.0", path = "../../embassy-nrf", features = ["defmt",  "time-driver-rtc1", "gpiote", "unstable-pac"] }
 embedded-io-async = { version = "0.6.1", features = ["defmt-03"] }


### PR DESCRIPTION
nrf52832 is pretty much full, but I don't see any reason for that to be the status quo.

This PR frees up memory so that https://github.com/embassy-rs/embassy/pull/3622 should be able to compile.