### PR TITLE
nrf: Add RESET operations helpers for the nrf5340

### DIFF
--- a/embassy-nrf/src/lib.rs
+++ b/embassy-nrf/src/lib.rs
@@ -126,6 +126,9 @@ pub mod qspi;
 #[cfg(not(any(feature = "_nrf91", feature = "_nrf5340-app")))]
 pub mod radio;
 #[cfg(not(feature = "_nrf54l"))] // TODO
+#[cfg(feature = "_nrf5340")]
+pub mod reset;
+#[cfg(not(feature = "_nrf54l"))] // TODO
 #[cfg(not(any(feature = "_nrf5340-app", feature = "_nrf91")))]
 pub mod rng;
 #[cfg(not(feature = "_nrf54l"))] // TODO

--- a/embassy-nrf/src/reset.rs
+++ b/embassy-nrf/src/reset.rs
@@ -1,0 +1,82 @@
+//! Reset
+
+#![macro_use]
+
+use bitflags::bitflags;
+use nrf_pac::reset::regs::Resetreas;
+#[cfg(not(feature = "_nrf5340-net"))]
+use nrf_pac::reset::vals::Forceoff;
+
+use crate::chip::pac::RESET;
+
+bitflags! {
+    #[derive(Debug, Copy, Clone, PartialEq)]
+    /// Bitflag representation of the `RESETREAS` register
+    pub struct ResetReason: u32 {
+        /// Reset Pin
+        const RESETPIN = 1;
+        /// Application watchdog timer 0
+        const DOG0 = 1 << 1;
+        /// Application CTRL-AP
+        const CTRLAP = 1 << 2;
+        /// Application soft reset
+        const SREQ = 1 << 3;
+        /// Application CPU lockup
+        const LOCKUP = 1 << 4;
+        /// Wakeup from System OFF when wakeup is triggered by DETECT signal from GPIO
+        const OFF = 1 << 5;
+        /// Wakeup from System OFF when wakeup is triggered by ANADETECT signal from LPCOMP
+        const LPCOMP = 1 << 6;
+        /// Wakeup from System OFF when wakeup is triggered by entering the Debug Interface mode
+        const DIF = 1 << 7;
+        /// Network soft reset
+        #[cfg(feature = "_nrf5340-net")]
+        const LSREQ = 1 << 16;
+        /// Network CPU lockup
+        #[cfg(feature = "_nrf5340-net")]
+        const LLOCKUP = 1 << 17;
+        /// Network watchdog timer
+        #[cfg(feature = "_nrf5340-net")]
+        const LDOG = 1 << 18;
+        /// Force-OFF reset from application core
+        #[cfg(feature = "_nrf5340-net")]
+        const MFORCEOFF = 1 << 23;
+        /// Wakeup from System OFF mode due to NFC field being detected
+        const NFC = 1 << 24;
+        /// Application watchdog timer 1
+        const DOG1 = 1 << 25;
+        /// Wakeup from System OFF mode due to VBUS rising into valid range
+        const VBUS = 1 << 26;
+        /// Network CTRL-AP
+        #[cfg(feature = "_nrf5340-net")]
+        const LCTRLAP = 1 << 27;
+    }
+}
+
+/// Reads the bitflag of the reset reasons
+pub fn read_reasons() -> ResetReason {
+    ResetReason::from_bits_retain(RESET.resetreas().read().0)
+}
+
+/// Resets the reset reasons
+pub fn clear_reasons() {
+    RESET.resetreas().write(|w| *w = Resetreas(ResetReason::all().bits()));
+}
+
+/// Returns if the network core is held in reset
+#[cfg(not(feature = "_nrf5340-net"))]
+pub fn network_core_held() -> bool {
+    RESET.network().forceoff().read().forceoff() == Forceoff::HOLD
+}
+
+/// Releases the network core from the FORCEOFF state
+#[cfg(not(feature = "_nrf5340-net"))]
+pub fn release_network_core() {
+    RESET.network().forceoff().write(|w| w.set_forceoff(Forceoff::RELEASE));
+}
+
+/// Holds the network core in the FORCEOFF state
+#[cfg(not(feature = "_nrf5340-net"))]
+pub fn hold_network_core() {
+    RESET.network().forceoff().write(|w| w.set_forceoff(Forceoff::HOLD));
+}


### PR DESCRIPTION
This adds free function helpers for the Reset peripheral to `embassy-nrf` so that it's easier to handle the checking of reset reasons and controlling the network core without having to use the `pac` directly.

It collects the reset reasons under a bitflag so that it can be more easily checked in binaries, instead of constructing a massive if else.

e.g. of reset reasons
```rust
    use embassy_nrf::reset::{self, ResetReason};
    
    for reason in reset::read_reasons().iter() {
        let reas = match reason {
            ResetReason::RESETPIN => "Reset Pin",
            ResetReason::DOG0 => "Application watchdog timer 0",
            ResetReason::CTRLAP => "Application CTRL-AP",
            ResetReason::SREQ => "Application soft reset",
            ResetReason::LOCKUP => "Application CPU lockup",
            ResetReason::OFF => "Wakeup from System OFF when wakeup is triggered by DETECT signal from GPIO",
            ResetReason::LPCOMP => "Wakeup from System OFF when wakeup is triggered by ANADETECT signal from LPCOMP",
            ResetReason::DIF => "Wakeup from System OFF when wakeup is triggered by entering the Debug Interface mode",
            ResetReason::NFC => "Wakeup from System OFF mode due to NFC field being detected",
            ResetReason::DOG1 => "Application watchdog timer 1",
            ResetReason::VBUS => "Wakeup from System OFF mode due to VBUS rising into valid range",
            _ => "unknown",
        };

        defmt::info!("Detected Reset reason: {}", reas);
    }
    reset::clear_reasons();
```

e.g. of starting the network core from the application core
```rust
    // Start network core
    defmt::info!("Releasing network core");
    reset::release_network_core();
```