### PR TITLE
Add missing opamp external outputs for STM32G4

### DIFF
--- a/embassy-stm32/src/opamp.rs
+++ b/embassy-stm32/src/opamp.rs
@@ -251,10 +251,12 @@ foreach_peripheral!(
         impl_opamp_external_output!(OPAMP2, ADC2, 3);
     };
     (opamp, OPAMP3) => {
+        impl_opamp_external_output!(OPAMP3, ADC1, 12);
         impl_opamp_external_output!(OPAMP3, ADC3, 1);
     };
     // OPAMP4 only in STM32G4 Cat 3 devices
     (opamp, OPAMP4) => {
+        impl_opamp_external_output!(OPAMP4, ADC1, 11);
         impl_opamp_external_output!(OPAMP4, ADC4, 3);
     };
     // OPAMP5 only in STM32G4 Cat 3 devices
@@ -264,6 +266,7 @@ foreach_peripheral!(
     // OPAMP6 only in STM32G4 Cat 3/4 devices
     (opamp, OPAMP6) => {
         impl_opamp_external_output!(OPAMP6, ADC1, 14);
+        impl_opamp_external_output!(OPAMP6, ADC2, 14);
     };
 );
 


### PR DESCRIPTION
This PR adds the ability to use following opamp/ADC combinations when the opamp is configured in external output mode.
These are documented in the STM32G4 reference manual but currently missing in Embassy.
- `OPAMP3` with `ADC1` (output pin is `PB1`)
- `OPAMP4` with `ADC1` (output pin is `PB12`)
- `OPAMP6` with `ADC2` (output pin is `PB11`)

<img width="517" alt="Screenshot 2024-12-07 at 8 55 54 PM" src="https://github.com/user-attachments/assets/6af7e867-b012-4554-883c-2bd0a70ddccc">
