### PR TITLE
Fix ScanType enum export

### DIFF
--- a/cyw43/src/control.rs
+++ b/cyw43/src/control.rs
@@ -35,10 +35,15 @@ pub struct Control<'a> {
     ioctl_state: &'a IoctlState,
 }
 
+/// WiFi scan type.
 #[derive(Copy, Clone, Debug)]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub enum ScanType {
+    /// Active scan: the station actively transmits probes that make APs respond.
+    /// Faster, but uses more power.
     Active,
+    /// Passive scan: the station doesn't transmit any probes, just listens for beacons.
+    /// Slower, but uses less power.
     Passive,
 }
 

--- a/cyw43/src/lib.rs
+++ b/cyw43/src/lib.rs
@@ -30,7 +30,7 @@ use ioctl::IoctlState;
 use crate::bus::Bus;
 pub use crate::bus::SpiBusCyw43;
 pub use crate::control::{
-    AddMulticastAddressError, Control, Error as ControlError, JoinAuth, JoinOptions, ScanOptions, Scanner,
+    AddMulticastAddressError, Control, Error as ControlError, JoinAuth, JoinOptions, ScanOptions, ScanType, Scanner,
 };
 pub use crate::runner::Runner;
 pub use crate::structs::BssInfo;


### PR DESCRIPTION
Exports the ScanType enum, which is needed to build the ScanOptions struct