### PR TITLE
Only lock once to wake a task

### DIFF
--- a/embassy-executor/src/raw/run_queue_atomics.rs
+++ b/embassy-executor/src/raw/run_queue_atomics.rs
@@ -45,7 +45,7 @@ impl RunQueue {
     ///
     /// `item` must NOT be already enqueued in any queue.
     #[inline(always)]
-    pub(crate) unsafe fn enqueue(&self, task: TaskRef) -> bool {
+    pub(crate) unsafe fn enqueue(&self, task: TaskRef, _: super::state::Token) -> bool {
         let mut was_empty = false;
 
         self.head

--- a/embassy-executor/src/raw/run_queue_critical_section.rs
+++ b/embassy-executor/src/raw/run_queue_critical_section.rs
@@ -44,13 +44,11 @@ impl RunQueue {
     ///
     /// `item` must NOT be already enqueued in any queue.
     #[inline(always)]
-    pub(crate) unsafe fn enqueue(&self, task: TaskRef) -> bool {
-        critical_section::with(|cs| {
-            let prev = self.head.borrow(cs).replace(Some(task));
-            task.header().run_queue_item.next.borrow(cs).set(prev);
+    pub(crate) unsafe fn enqueue(&self, task: TaskRef, cs: CriticalSection<'_>) -> bool {
+        let prev = self.head.borrow(cs).replace(Some(task));
+        task.header().run_queue_item.next.borrow(cs).set(prev);
 
-            prev.is_none()
-        })
+        prev.is_none()
     }
 
     /// Empty the queue, then call `on_task` for each task that was in the queue.


### PR DESCRIPTION
Waker::wake previously used two critical sections on targets without atomic CAS.

- One to update the task state
- One to call `RunQueue::enqueue`

This PR refactors `State::run_enqueue` to take a closure instead of returning a boolean. The closure is called when we previously returned `true`. This change allows as to run the closure in a critical section, saving the cost of locking a second time.