### PR TITLE
STM32F0 fix using HSI48 as SYSCLK on devices with CRS

### DIFF
--- a/embassy-stm32/src/rcc/f013.rs
+++ b/embassy-stm32/src/rcc/f013.rs
@@ -229,6 +229,9 @@ pub(crate) unsafe fn init(config: Config) {
         Sysclk::HSI => unwrap!(hsi),
         Sysclk::HSE => unwrap!(hse),
         Sysclk::PLL1_P => unwrap!(pll),
+        #[cfg(crs)]
+        Sysclk::HSI48 => unwrap!(hsi48),
+        #[cfg(not(crs))]
         _ => unreachable!(),
     };
 


### PR DESCRIPTION
Fixes #3651

Tested on STM32F072CB.