### PR TITLE
stm32/(o|q)spi: command naming convention fix

### DIFF
--- a/embassy-stm32/src/ospi/mod.rs
+++ b/embassy-stm32/src/ospi/mod.rs
@@ -520,7 +520,7 @@ impl<'d, T: Instance, M: PeriMode> Ospi<'d, T, M> {
     }
 
     /// Function used to control or configure the target device without data transfer
-    pub async fn command(&mut self, command: &TransferConfig) -> Result<(), OspiError> {
+    pub fn blocking_command(&mut self, command: &TransferConfig) -> Result<(), OspiError> {
         // Wait for peripheral to be free
         while T::REGS.sr().read().busy() {}
 

--- a/embassy-stm32/src/qspi/mod.rs
+++ b/embassy-stm32/src/qspi/mod.rs
@@ -148,7 +148,7 @@ impl<'d, T: Instance, M: PeriMode> Qspi<'d, T, M> {
     }
 
     /// Do a QSPI command.
-    pub fn command(&mut self, transaction: TransferConfig) {
+    pub fn blocking_command(&mut self, transaction: TransferConfig) {
         #[cfg(not(stm32h7))]
         T::REGS.cr().modify(|v| v.set_dmaen(false));
         self.setup_transaction(QspiMode::IndirectWrite, &transaction, None);

--- a/examples/stm32f7/src/bin/qspi.rs
+++ b/examples/stm32f7/src/bin/qspi.rs
@@ -72,7 +72,7 @@ impl<I: Instance> FlashMemory<I> {
             address: None,
             dummy: DummyCycles::_0,
         };
-        self.qspi.command(transaction);
+        self.qspi.blocking_command(transaction);
     }
 
     pub fn reset_memory(&mut self) {
@@ -143,7 +143,7 @@ impl<I: Instance> FlashMemory<I> {
             dummy: DummyCycles::_0,
         };
         self.enable_write();
-        self.qspi.command(transaction);
+        self.qspi.blocking_command(transaction);
         self.wait_write_finish();
     }
 

--- a/examples/stm32h7b0/src/bin/ospi_memory_mapped.rs
+++ b/examples/stm32h7b0/src/bin/ospi_memory_mapped.rs
@@ -223,7 +223,7 @@ impl<I: Instance> FlashMemory<I> {
             dummy: DummyCycles::_0,
             ..Default::default()
         };
-        self.ospi.command(&transaction).await.unwrap();
+        self.ospi.blocking_command(&transaction).unwrap();
     }
 
     async fn exec_command(&mut self, cmd: u8) {
@@ -238,7 +238,7 @@ impl<I: Instance> FlashMemory<I> {
             ..Default::default()
         };
         // info!("Excuting command: {:x}", transaction.instruction);
-        self.ospi.command(&transaction).await.unwrap();
+        self.ospi.blocking_command(&transaction).unwrap();
     }
 
     pub async fn reset_memory(&mut self) {
@@ -318,7 +318,7 @@ impl<I: Instance> FlashMemory<I> {
             ..Default::default()
         };
         self.enable_write().await;
-        self.ospi.command(&transaction).await.unwrap();
+        self.ospi.blocking_command(&transaction).unwrap();
         self.wait_write_finish();
     }
 


### PR DESCRIPTION
The naming convention is to prefix blocking functions with blocking. As both command implementations are blocking the async for the ospi implementation should also be dropped.