### PR TITLE
Change build.rs to support using TIM DMA channel in stm32u5 series

### DIFF
--- a/embassy-stm32/build.rs
+++ b/embassy-stm32/build.rs
@@ -1274,6 +1274,11 @@ fn main() {
         (("timer", "CH2"), quote!(crate::timer::Ch2Dma)),
         (("timer", "CH3"), quote!(crate::timer::Ch3Dma)),
         (("timer", "CH4"), quote!(crate::timer::Ch4Dma)),
+        // For STM32U5 (maybe more?), the timer DMA channels are named differently
+        (("timer", "CC1"), quote!(crate::timer::Ch1Dma)),
+        (("timer", "CC2"), quote!(crate::timer::Ch2Dma)),
+        (("timer", "CC3"), quote!(crate::timer::Ch3Dma)),
+        (("timer", "CC4"), quote!(crate::timer::Ch4Dma)),
         (("cordic", "WRITE"), quote!(crate::cordic::WriteDma)), // FIXME: stm32u5a crash on Cordic driver
         (("cordic", "READ"), quote!(crate::cordic::ReadDma)),   // FIXME: stm32u5a crash on Cordic driver
     ]


### PR DESCRIPTION
At least for `STM32U545` series, the dma channel for TIM use `CCx` instead of `CHx`, to make using dma possible in HAL code, This PR add `CCx` naming to the `build.rs`.

https://github.com/embassy-rs/stm32-data-generated/blob/f1a9260b1acaa36b51facae69927a79322143ab8/stm32-metapac/src/chips/metadata_0755.rs#L3646