### PR TITLE
Force use 1.83 for Xtensa

### DIFF
--- a/.github/ci/build-xtensa.sh
+++ b/.github/ci/build-xtensa.sh
@@ -13,7 +13,7 @@ export CARGO_TARGET_DIR=/ci/cache/target
 export CARGO_NET_GIT_FETCH_WITH_CLI=true
 
 cargo install espup
-/ci/cache/cargo/bin/espup install
+/ci/cache/cargo/bin/espup install --toolchain-version 1.83.0.1
 
 # Restore lockfiles
 if [ -f /ci/cache/lockfiles.tar ]; then


### PR DESCRIPTION
For compatibility reasons with the released esp-hal, we're reverting espup to install 1.82 by default. This PR ensures that the embassy CI survives this change.