### PR TITLE
Add generic-queue-* features back to embassy-time

### DIFF
--- a/embassy-time-queue-driver/Cargo.toml
+++ b/embassy-time-queue-driver/Cargo.toml
@@ -36,7 +36,7 @@ embassy-executor = { version = "0.6.3", path = "../embassy-executor" }
 #! The features also set how many timers are used for the generic queue. At most one
 #! `generic-queue-*` feature can be enabled. If none is enabled, a default of 64 timers is used.
 #!
-#! When using embassy-time from libraries, you should *not* enable any `generic-queue-*` feature, to allow the
+#! When using embassy-time-queue-driver from libraries, you should *not* enable any `generic-queue-*` feature, to allow the
 #! end user to pick.
 
 ## Generic Queue with 8 timers

--- a/embassy-time-queue-driver/src/lib.rs
+++ b/embassy-time-queue-driver/src/lib.rs
@@ -4,8 +4,7 @@
 
 //! This crate is an implementation detail of `embassy-time-driver`.
 //!
-//! As a HAL user, you should only depend on this crate if your application does not use
-//! `embassy-executor` and your HAL does not configure a generic queue by itself.
+//! As a HAL user, you should not need to depend on this crate directly.
 //!
 //! As a HAL implementer, you need to depend on this crate if you want to implement a time driver,
 //! but how you should do so is documented in `embassy-time-driver`.

--- a/embassy-time/CHANGELOG.md
+++ b/embassy-time/CHANGELOG.md
@@ -7,7 +7,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
-- The `generic-queue` and related features have been removed (moved to embassy-time-queue-driver)
 - embassy-time no longer provides an `embassy-time-queue-driver` implementation
 
 ## 0.3.2 - 2024-08-05

--- a/embassy-time/Cargo.toml
+++ b/embassy-time/Cargo.toml
@@ -42,6 +42,31 @@ defmt-timestamp-uptime-tus = ["defmt"]
 ## Create a `MockDriver` that can be manually advanced for testing purposes.
 mock-driver = ["tick-hz-1_000_000", "dep:embassy-time-queue-driver"]
 
+#! ### Generic Queue
+
+#! By default embassy-time uses a timer queue implementation that is faster but depends on `embassy-executor`.
+#! It will panic if you try to await any timer when using another executor.
+#! 
+#! Alternatively, you can choose to use a "generic" timer queue implementation that works on any executor.
+#! To enable it, enable any of the features below.
+#! 
+#! The features also set how many timers are used for the generic queue. At most one
+#! `generic-queue-*` feature can be enabled. If none is enabled, a default of 64 timers is used.
+#!
+#! When using embassy-time from libraries, you should *not* enable any `generic-queue-*` feature, to allow the
+#! end user to pick.
+
+## Generic Queue with 8 timers
+generic-queue-8 = ["embassy-time-queue-driver/generic-queue-8"]
+## Generic Queue with 16 timers
+generic-queue-16 = ["embassy-time-queue-driver/generic-queue-16"]
+## Generic Queue with 32 timers
+generic-queue-32 = ["embassy-time-queue-driver/generic-queue-32"]
+## Generic Queue with 64 timers
+generic-queue-64 = ["embassy-time-queue-driver/generic-queue-64"]
+## Generic Queue with 128 timers
+generic-queue-128 = ["embassy-time-queue-driver/generic-queue-128"]
+
 #! ### Tick Rate
 #!
 #! At most 1 `tick-*` feature can be enabled. If none is enabled, a default of 1MHz is used.


### PR DESCRIPTION
Hopefully this can reduce breakages caused by the version bump. I believe we still have to release embassy-time as a major upgrade, but migration should be just a bit smoother.

HALs can still override these, as they can override the features set on ETQD - they are allowed to just do their own thing. But now the users really don't have to import ETQD.