### PR TITLE
embassy-net: when std is set enable smoltcp/std

### DIFF
--- a/embassy-net/Cargo.toml
+++ b/embassy-net/Cargo.toml
@@ -24,7 +24,7 @@ features = ["defmt", "tcp", "udp", "raw", "dns", "dhcpv4", "proto-ipv6", "medium
 
 [features]
 default = []
-std = []
+std = ["smoltcp/std"]
 
 ## Enable defmt
 defmt = ["dep:defmt", "smoltcp/defmt", "embassy-net-driver/defmt", "heapless/defmt-03", "defmt?/ip_in_core"]


### PR DESCRIPTION
As explained in the title, this is mostly to solve some clippy issues with ManagedSlice's I've been running into.