### PR TITLE
embassy-usb: fix building with optional log feature

### DIFF
--- a/ci.sh
+++ b/ci.sh
@@ -186,6 +186,15 @@ cargo batch \
     --- build --release --manifest-path embassy-boot-nrf/Cargo.toml --target thumbv8m.main-none-eabihf --features embassy-nrf/nrf9161-ns \
     --- build --release --manifest-path embassy-boot-rp/Cargo.toml --target thumbv6m-none-eabi --features embassy-rp/rp2040 \
     --- build --release --manifest-path embassy-boot-stm32/Cargo.toml --target thumbv7em-none-eabi --features embassy-stm32/stm32l496zg \
+    --- build --release --manifest-path embassy-usb/Cargo.toml --target thumbv6m-none-eabi --no-default-features \
+    --- build --release --manifest-path embassy-usb/Cargo.toml --target thumbv6m-none-eabi \
+    --- build --release --manifest-path embassy-usb/Cargo.toml --target thumbv6m-none-eabi --features log \
+    --- build --release --manifest-path embassy-usb/Cargo.toml --target thumbv6m-none-eabi --features defmt \
+    --- build --release --manifest-path embassy-usb/Cargo.toml --target thumbv6m-none-eabi --features usbd-hid \
+    --- build --release --manifest-path embassy-usb/Cargo.toml --target thumbv6m-none-eabi --features max-interface-count-1 \
+    --- build --release --manifest-path embassy-usb/Cargo.toml --target thumbv6m-none-eabi --features max-interface-count-8 \
+    --- build --release --manifest-path embassy-usb/Cargo.toml --target thumbv6m-none-eabi --features max-handler-count-8 \
+    --- build --release --manifest-path embassy-usb/Cargo.toml --target thumbv6m-none-eabi --features max-handler-count-8 \
     --- build --release --manifest-path docs/examples/basic/Cargo.toml --target thumbv7em-none-eabi \
     --- build --release --manifest-path docs/examples/layer-by-layer/blinky-pac/Cargo.toml --target thumbv7em-none-eabi \
     --- build --release --manifest-path docs/examples/layer-by-layer/blinky-hal/Cargo.toml --target thumbv7em-none-eabi \

--- a/embassy-usb/src/class/uac1/speaker.rs
+++ b/embassy-usb/src/class/uac1/speaker.rs
@@ -579,7 +579,7 @@ impl<'d> Control<'d> {
 
         if endpoint_address != self.streaming_endpoint_address {
             debug!(
-                "Unhandled endpoint set request for endpoint {} and control {} with data {}",
+                "Unhandled endpoint set request for endpoint {} and control {} with data {:?}",
                 endpoint_address, control_selector, data
             );
             return None;

--- a/embassy-usb/src/types.rs
+++ b/embassy-usb/src/types.rs
@@ -18,6 +18,12 @@ impl From<InterfaceNumber> for u8 {
     }
 }
 
+impl core::fmt::Display for InterfaceNumber {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        write!(f, "{}", self.0)
+    }
+}
+
 /// A handle for a USB string descriptor that contains its index.
 #[derive(Copy, Clone, Eq, PartialEq)]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]


### PR DESCRIPTION
Trying to build embassy-usb before this fix:

```
cargo build --features log
   Compiling embassy-usb v0.3.0 (/home/nine/vc/rust/embassy_fmt_fixes/embassy-usb)
error[E0277]: `[u8]` doesn't implement `Display`
   --> src/class/uac1/speaker.rs:583:53
    |
583 |                 endpoint_address, control_selector, data
    |                                                     ^^^^ `[u8]` cannot be formatted with the default formatter
    |
    = help: the trait `Display` is not implemented for `[u8]`, which is required by `&[u8]: Display`
    = note: in format strings you may be able to use `{:?}` (or {:#?} for pretty-print) instead
    = note: this error originates in the macro `$crate::__private_api::format_args` which comes from the expansion of the macro `debug` (in Nightly builds, run with -Z macro-backtrace for more info)

error[E0277]: `InterfaceNumber` doesn't implement `Display`
   --> src/class/uac1/speaker.rs:737:13
    |
737 |             iface, alternate_setting
    |             ^^^^^ `InterfaceNumber` cannot be formatted with the default formatter
    |
    = help: the trait `Display` is not implemented for `InterfaceNumber`
    = note: in format strings you may be able to use `{:?}` (or {:#?} for pretty-print) instead
    = note: this error originates in the macro `$crate::__private_api::format_args` which comes from the expansion of the macro `debug` (in Nightly builds, run with -Z macro-backtrace for more info)

For more information about this error, try `rustc --explain E0277`.
error: could not compile `embassy-usb` (lib) due to 2 previous errors
```