### PR TITLE
[avr] create initial example

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -10,6 +10,7 @@
   "rust-analyzer.cargo.noDefaultFeatures": true,
   "rust-analyzer.showUnlinkedFileNotification": false,
   // Uncomment the target of your chip.
+  //"rust-analyzer.cargo.target": "avr-unknown-gnu-atmega328",
   //"rust-analyzer.cargo.target": "thumbv6m-none-eabi",
   //"rust-analyzer.cargo.target": "thumbv7m-none-eabi",
   "rust-analyzer.cargo.target": "thumbv7em-none-eabi",
@@ -28,6 +29,7 @@
     // To work on the examples, comment the line above and all of the cargo.features lines,
     // then uncomment ONE line below to select the chip you want to work on.
     // This makes rust-analyzer work on the example crate and all its dependencies.
+    // "examples/avr/Cargo.toml",
     // "examples/nrf52840-rtic/Cargo.toml",
     // "examples/nrf5340/Cargo.toml",
     // "examples/nrf-rtos-trace/Cargo.toml",

--- a/embassy-executor/Cargo.toml
+++ b/embassy-executor/Cargo.toml
@@ -50,7 +50,7 @@ wasm-bindgen = { version = "0.2.82", optional = true }
 js-sys = { version = "0.3", optional = true }
 
 # arch-avr dependencies
-avr-device = { version = "0.5.3", optional = true }
+avr-device = { version = "0.5.3", features = ["critical-section-impl", "rt"], optional = true }
 
 [dev-dependencies]
 critical-section = { version = "1.1", features = ["std"] }

--- a/embassy-executor/Cargo.toml
+++ b/embassy-executor/Cargo.toml
@@ -50,7 +50,7 @@ wasm-bindgen = { version = "0.2.82", optional = true }
 js-sys = { version = "0.3", optional = true }
 
 # arch-avr dependencies
-avr-device = { version = "0.5.3", features = ["critical-section-impl", "rt"], optional = true }
+avr-device = { version = "0.6", features = ["critical-section-impl", "rt"], optional = true }
 
 [dev-dependencies]
 critical-section = { version = "1.1", features = ["std"] }

--- a/examples/avr/.cargo/config.toml
+++ b/examples/avr/.cargo/config.toml
@@ -1,0 +1,8 @@
+[build]
+target = "avr-unknown-gnu-atmega328"
+
+[target.'cfg(target_arch = "avr")']
+runner = "ravedude uno -cb 57600"
+
+[unstable]
+build-std = ["core"]

--- a/examples/avr/Cargo.toml
+++ b/examples/avr/Cargo.toml
@@ -5,7 +5,7 @@ version = "0.1.0"
 license = "MIT OR Apache-2.0"
 
 [dependencies]
-avr-device = { version = "0.5", features = ["atmega328p"] }
+avr-device = { version = "0.6", features = ["atmega328p"] }
 embassy-executor = { version = "0.7.0", path = "../../embassy-executor", features = ["arch-avr", "executor-thread", "nightly"] }
 panic-halt = "1"
 

--- a/examples/avr/Cargo.toml
+++ b/examples/avr/Cargo.toml
@@ -1,0 +1,22 @@
+[package]
+edition = "2021"
+name = "embassy-avr-examples"
+version = "0.1.0"
+license = "MIT OR Apache-2.0"
+
+[dependencies]
+avr-device = { version = "0.5", features = ["atmega328p"] }
+embassy-executor = { version = "0.7.0", path = "../../embassy-executor", features = ["arch-avr", "executor-thread", "nightly"] }
+panic-halt = "1"
+
+[profile.dev]
+panic = "abort"
+lto = true
+opt-level = "s"
+
+[profile.release]
+panic = "abort"
+codegen-units = 1
+debug = true
+lto = true
+opt-level = "s"

--- a/examples/avr/README.md
+++ b/examples/avr/README.md
@@ -1,0 +1,15 @@
+# Examples for AVR microcontrollers
+Run individual examples with
+```
+cargo run --bin <module-name> --release
+```
+for example
+```
+cargo run --bin blinky
+```
+
+## Checklist before running examples
+You may need to adjust `.cargo/config.toml`, `Cargo.toml` and possibly update pin numbers or peripherals to match the specific MCU or board you are using.
+
+* [ ] Update `.cargo/config.toml` with the correct target and runner command for your hardware. (use `ravedude --help` to list supported boards)
+* [ ] Update `Cargo.toml` to use the correct `avr-device` feature for your processor.

--- a/examples/avr/rust-toolchain.toml
+++ b/examples/avr/rust-toolchain.toml
@@ -1,0 +1,4 @@
+[toolchain]
+channel = "nightly-2024-12-10"
+components = ["rust-src"]
+profile = "minimal"

--- a/examples/avr/src/bin/blinky.rs
+++ b/examples/avr/src/bin/blinky.rs
@@ -1,0 +1,13 @@
+#![no_std]
+#![no_main]
+#![feature(impl_trait_in_assoc_type)]
+
+use embassy_executor::Spawner;
+use panic_halt as _;
+
+#[embassy_executor::main]
+async fn main(_spawner: Spawner) {
+    loop {
+        // TODO
+    }
+}

--- a/rust-toolchain-nightly.toml
+++ b/rust-toolchain-nightly.toml
@@ -2,6 +2,7 @@
 channel = "nightly-2024-12-10"
 components = [ "rust-src", "rustfmt", "llvm-tools", "miri" ]
 targets = [
+    "avr-unknown-gnu-atmega328",
     "thumbv7em-none-eabi",
     "thumbv7m-none-eabi",
     "thumbv6m-none-eabi",


### PR DESCRIPTION
This commit adds a minimal example demonstrating how to create an embassy executor.  This gets the infrastructure in place for future work to add missing pieces like a timer driver.