### PR TITLE
STM32: set USB initialization delay to 1µs

### DIFF
--- a/embassy-stm32/src/usb/usb.rs
+++ b/embassy-stm32/src/usb/usb.rs
@@ -305,10 +305,8 @@ impl<'d, T: Instance> Driver<'d, T> {
             w.set_fres(true);
         });
 
-        #[cfg(feature = "time")]
-        embassy_time::block_for(embassy_time::Duration::from_millis(100));
-        #[cfg(not(feature = "time"))]
-        cortex_m::asm::delay(unsafe { crate::rcc::get_freqs() }.sys.to_hertz().unwrap().0 / 10);
+        // wait t_STARTUP = 1us
+        cortex_m::asm::delay(unsafe { crate::rcc::get_freqs() }.sys.to_hertz().unwrap().0 / 1_000_000);
 
         #[cfg(not(usb_v4))]
         regs.btable().write(|w| w.set_btable(0));


### PR DESCRIPTION
I scoured the device datasheets of the following devices. *All* state a `t_STARTUP` of max 1µs.

- STM32U073x8/B/C
- STM32H503xx
- STM32G0B1xB/xC/xE
- STM32F722xx STM32F723xx
- STM32F405xx, STM32F407xx
- STM32F21xxx
- STM32C071x8/xB
- STM32L462CE STM32L462RE STM32L462VE
- STM32L053x6 STM32L053x8
- STM32F303xD STM32F303xE
- STM32F102x8, STM32F102xB
- STM32F072x8 STM32F072xB

I did not find any device with a differently specified `t_STARTUP`.

Here is an example:
![grafik](https://github.com/user-attachments/assets/ed7d4419-a8a7-4348-ab6c-d58063d3d858)
