### PR TITLE
feat: Add 32-bit timer support for waveform function

### DIFF
--- a/embassy-stm32/src/cryp/mod.rs
+++ b/embassy-stm32/src/cryp/mod.rs
@@ -1785,9 +1785,9 @@ impl<'d, T: Instance, DmaIn, DmaOut> Cryp<'d, T, DmaIn, DmaOut> {
         assert_eq!(blocks.len() % block_size, 0);
         // Configure DMA to transfer input to crypto core.
         let dma_request = dma.request();
-        let dst_ptr = T::regs().din().as_ptr();
+        let dst_ptr: *mut u32 = T::regs().din().as_ptr();
         let num_words = blocks.len() / 4;
-        let src_ptr = ptr::slice_from_raw_parts(blocks.as_ptr().cast(), num_words);
+        let src_ptr: *const [u8] = ptr::slice_from_raw_parts(blocks.as_ptr().cast(), num_words);
         let options = TransferOptions {
             #[cfg(not(gpdma))]
             priority: crate::dma::Priority::High,
@@ -1825,9 +1825,9 @@ impl<'d, T: Instance, DmaIn, DmaOut> Cryp<'d, T, DmaIn, DmaOut> {
         assert_eq!((blocks.len() * 4) % block_size, 0);
         // Configure DMA to transfer input to crypto core.
         let dma_request = dma.request();
-        let dst_ptr = T::regs().din().as_ptr();
+        let dst_ptr: *mut u32 = T::regs().din().as_ptr();
         let num_words = blocks.len();
-        let src_ptr = ptr::slice_from_raw_parts(blocks.as_ptr().cast(), num_words);
+        let src_ptr: *const [u32] = ptr::slice_from_raw_parts(blocks.as_ptr().cast(), num_words);
         let options = TransferOptions {
             #[cfg(not(gpdma))]
             priority: crate::dma::Priority::High,

--- a/embassy-stm32/src/dma/dma_bdma.rs
+++ b/embassy-stm32/src/dma/dma_bdma.rs
@@ -340,7 +340,8 @@ impl AnyChannel {
         mem_addr: *mut u32,
         mem_len: usize,
         incr_mem: bool,
-        data_size: WordSize,
+        mem_size: WordSize,
+        peripheral_size: WordSize,
         options: TransferOptions,
     ) {
         let info = self.info();
@@ -380,8 +381,8 @@ impl AnyChannel {
                 });
                 ch.cr().write(|w| {
                     w.set_dir(dir.into());
-                    w.set_msize(data_size.into());
-                    w.set_psize(data_size.into());
+                    w.set_msize(mem_size.into());
+                    w.set_psize(peripheral_size.into());
                     w.set_pl(options.priority.into());
                     w.set_minc(incr_mem);
                     w.set_pinc(false);
@@ -414,8 +415,8 @@ impl AnyChannel {
                 ch.mar().write_value(mem_addr as u32);
                 ch.ndtr().write(|w| w.set_ndt(mem_len as u16));
                 ch.cr().write(|w| {
-                    w.set_psize(data_size.into());
-                    w.set_msize(data_size.into());
+                    w.set_psize(peripheral_size.into());
+                    w.set_msize(mem_size.into());
                     w.set_minc(incr_mem);
                     w.set_dir(dir.into());
                     w.set_teie(true);
@@ -602,27 +603,28 @@ impl<'a> Transfer<'a> {
             buf.len(),
             true,
             W::size(),
+            W::size(),
             options,
         )
     }
 
     /// Create a new write DMA transfer (memory to peripheral).
-    pub unsafe fn new_write<W: Word>(
+    pub unsafe fn new_write<MW: Word, PW: Word>(
         channel: impl Peripheral<P = impl Channel> + 'a,
         request: Request,
-        buf: &'a [W],
-        peri_addr: *mut W,
+        buf: &'a [MW],
+        peri_addr: *mut PW,
         options: TransferOptions,
     ) -> Self {
         Self::new_write_raw(channel, request, buf, peri_addr, options)
     }
 
     /// Create a new write DMA transfer (memory to peripheral), using raw pointers.
-    pub unsafe fn new_write_raw<W: Word>(
+    pub unsafe fn new_write_raw<W: Word, PW: Word>(
         channel: impl Peripheral<P = impl Channel> + 'a,
         request: Request,
         buf: *const [W],
-        peri_addr: *mut W,
+        peri_addr: *mut PW,
         options: TransferOptions,
     ) -> Self {
         into_ref!(channel);
@@ -635,6 +637,7 @@ impl<'a> Transfer<'a> {
             buf as *const W as *mut u32,
             buf.len(),
             true,
+            W::size(),
             W::size(),
             options,
         )
@@ -660,6 +663,7 @@ impl<'a> Transfer<'a> {
             count,
             false,
             W::size(),
+            W::size(),
             options,
         )
     }
@@ -673,15 +677,23 @@ impl<'a> Transfer<'a> {
         mem_len: usize,
         incr_mem: bool,
         data_size: WordSize,
+        peripheral_size: WordSize,
         options: TransferOptions,
     ) -> Self {
         assert!(mem_len > 0 && mem_len <= 0xFFFF);
 
         channel.configure(
-            _request, dir, peri_addr, mem_addr, mem_len, incr_mem, data_size, options,
+            _request,
+            dir,
+            peri_addr,
+            mem_addr,
+            mem_len,
+            incr_mem,
+            data_size,
+            peripheral_size,
+            options,
         );
         channel.start();
-
         Self { channel }
     }
 
@@ -813,6 +825,7 @@ impl<'a, W: Word> ReadableRingBuffer<'a, W> {
             buffer_ptr as *mut u32,
             len,
             true,
+            data_size,
             data_size,
             options,
         );
@@ -965,6 +978,7 @@ impl<'a, W: Word> WritableRingBuffer<'a, W> {
             buffer_ptr as *mut u32,
             len,
             true,
+            data_size,
             data_size,
             options,
         );

--- a/embassy-stm32/src/dma/dma_bdma.rs
+++ b/embassy-stm32/src/dma/dma_bdma.rs
@@ -620,10 +620,10 @@ impl<'a> Transfer<'a> {
     }
 
     /// Create a new write DMA transfer (memory to peripheral), using raw pointers.
-    pub unsafe fn new_write_raw<W: Word, PW: Word>(
+    pub unsafe fn new_write_raw<MW: Word, PW: Word>(
         channel: impl Peripheral<P = impl Channel> + 'a,
         request: Request,
-        buf: *const [W],
+        buf: *const [MW],
         peri_addr: *mut PW,
         options: TransferOptions,
     ) -> Self {
@@ -634,11 +634,11 @@ impl<'a> Transfer<'a> {
             request,
             Dir::MemoryToPeripheral,
             peri_addr as *const u32,
-            buf as *const W as *mut u32,
+            buf as *const MW as *mut u32,
             buf.len(),
             true,
-            W::size(),
-            W::size(),
+            MW::size(),
+            PW::size(),
             options,
         )
     }

--- a/embassy-stm32/src/timer/low_level.rs
+++ b/embassy-stm32/src/timer/low_level.rs
@@ -235,6 +235,10 @@ impl<'d, T: CoreInstance> Timer<'d, T> {
         self.regs_core().cnt().write(|r| r.set_cnt(0));
     }
 
+    pub fn get_bits(&self) -> TimerBits {
+        T::BITS
+    }
+
     /// Set the frequency of how many times per second the timer counts up to the max value or down to 0.
     ///
     /// This means that in the default edge-aligned mode,

--- a/embassy-stm32/src/timer/low_level.rs
+++ b/embassy-stm32/src/timer/low_level.rs
@@ -236,7 +236,7 @@ impl<'d, T: CoreInstance> Timer<'d, T> {
     }
 
     /// get the capability of the timer
-    pub fn get_bits(&self) -> TimerBits {
+    pub fn bits(&self) -> TimerBits {
         T::BITS
     }
 

--- a/embassy-stm32/src/timer/low_level.rs
+++ b/embassy-stm32/src/timer/low_level.rs
@@ -235,6 +235,7 @@ impl<'d, T: CoreInstance> Timer<'d, T> {
         self.regs_core().cnt().write(|r| r.set_cnt(0));
     }
 
+    /// get the capability of the timer
     pub fn get_bits(&self) -> TimerBits {
         T::BITS
     }

--- a/embassy-stm32/src/timer/simple_pwm.rs
+++ b/embassy-stm32/src/timer/simple_pwm.rs
@@ -365,7 +365,10 @@ macro_rules! impl_waveform_chx {
             /// Generate a sequence of PWM waveform
             ///
             /// Note:
-            /// you will need to provide corresponding TIMx_CHy DMA channel to use this method.
+            /// 1. you will need to provide corresponding TIMx_CHy DMA channel to use this method.
+            /// 2. Please make sure the duty data length is aligned to the timer data width(16-bit or 32-bit).
+            /// 3. Please notice the endianess of the duty data. STM32 use little endian,
+            ///    for example, 0x12345678 as u32 will be stored as [0x78, 0x56, 0x34, 0x12] in memory.
             pub async fn $fn_name(&mut self, dma: impl Peripheral<P = impl super::$dma_ch<T>>, duty: &[u8]) {
                 use crate::pac::timer::vals::Ccds;
 

--- a/embassy-stm32/src/timer/simple_pwm.rs
+++ b/embassy-stm32/src/timer/simple_pwm.rs
@@ -414,8 +414,10 @@ macro_rules! impl_waveform_chx {
                             )
                             .await
                         }
-                        #[cfg(not(any(stm32l0, bdma, gpdma)))]
+                        #[cfg(not(any(stm32l0)))]
                         TimerBits::Bits32 => {
+                            #[cfg(any(bdma, gpdma))]
+                            panic("unsupported timer bits");
                             Transfer::new_write(
                                 &mut dma,
                                 req,
@@ -424,10 +426,6 @@ macro_rules! impl_waveform_chx {
                                 dma_transfer_option,
                             )
                             .await
-                        }
-                        #[cfg(any(stm32l0, bdma, gpdma))]
-                        _ => {
-                            panic!("unsupported timer bits")
                         }
                     };
                 };

--- a/embassy-stm32/src/timer/simple_pwm.rs
+++ b/embassy-stm32/src/timer/simple_pwm.rs
@@ -416,8 +416,10 @@ macro_rules! impl_waveform_chx {
                         }
                         #[cfg(not(any(stm32l0)))]
                         TimerBits::Bits32 => {
+                            #[cfg(not(any(bdma, gpdma)))]
+                            panic!("unsupported timer bits");
+
                             #[cfg(any(bdma, gpdma))]
-                            panic("unsupported timer bits");
                             Transfer::new_write(
                                 &mut dma,
                                 req,

--- a/embassy-stm32/src/timer/simple_pwm.rs
+++ b/embassy-stm32/src/timer/simple_pwm.rs
@@ -409,7 +409,7 @@ macro_rules! impl_waveform_chx {
                         ..Default::default()
                     };
 
-                    match self.inner.get_bits() {
+                    match self.inner.bits() {
                         TimerBits::Bits16 => {
                             // the data must be aligned to double words
                             assert!(duty.len() % 2 == 0);

--- a/embassy-stm32/src/timer/simple_pwm.rs
+++ b/embassy-stm32/src/timer/simple_pwm.rs
@@ -423,6 +423,7 @@ macro_rules! impl_waveform_chx {
                             )
                             .await
                         }
+                        #[cfg(not(stm32l0))]
                         TimerBits::Bits32 => {
                             // the data must be aligned to quad words
                             assert!(duty.len() % 4 == 0);

--- a/embassy-stm32/src/timer/simple_pwm.rs
+++ b/embassy-stm32/src/timer/simple_pwm.rs
@@ -6,8 +6,7 @@ use core::mem::ManuallyDrop;
 use embassy_hal_internal::{into_ref, PeripheralRef};
 
 use super::low_level::{CountingMode, OutputCompareMode, OutputPolarity, Timer};
-use super::TimerBits;
-use super::{Channel, Channel1Pin, Channel2Pin, Channel3Pin, Channel4Pin, GeneralInstance4Channel};
+use super::{Channel, Channel1Pin, Channel2Pin, Channel3Pin, Channel4Pin, GeneralInstance4Channel, TimerBits};
 use crate::gpio::{AfType, AnyPin, OutputType, Speed};
 use crate::time::Hertz;
 use crate::Peripheral;


### PR DESCRIPTION
Currently `waveform_chx` function in  `SimplePwm` assume that all timer are 16-bit, which will cause some unexpected issue ( e.g. https://github.com/embassy-rs/embassy/issues/2522)

This PR add 32-bit timer support for waveform function by changing the input data from `&[u16]` to more general `&[u8]`, and use unsafe transmute to prepare `&[u16]` or `&[u32]` based on the timer size for DMA.

Approach in this PR is far from perfect. I think `constant generic type` may be a better solution, but will introduce significant changes to current timer HAL in `embassy-stm32`