### PR TITLE
embassy-stm32 support g0 second flash bank

### DIFF
--- a/embassy-stm32/Cargo.toml
+++ b/embassy-stm32/Cargo.toml
@@ -73,7 +73,7 @@ rand_core = "0.6.3"
 sdio-host = "0.5.0"
 critical-section = "1.1"
 #stm32-metapac = { version = "15" }
-stm32-metapac = { git = "https://github.com/embassy-rs/stm32-data-generated", tag = "stm32-data-392e41259ffc5ffbfd79169ee80451114fb367fe" }
+stm32-metapac = { git = "https://github.com/embassy-rs/stm32-data-generated", tag = "stm32-data-d87131cfec93a6dbd21422ac36d43ce9562aab7f" }
 
 vcell = "0.1.3"
 nb = "1.0.0"
@@ -102,7 +102,7 @@ proc-macro2 = "1.0.36"
 quote = "1.0.15"
 
 #stm32-metapac = { version = "15", default-features = false, features = ["metadata"]}
-stm32-metapac = { git = "https://github.com/embassy-rs/stm32-data-generated", tag = "stm32-data-392e41259ffc5ffbfd79169ee80451114fb367fe", default-features = false, features = ["metadata"] }
+stm32-metapac = { git = "https://github.com/embassy-rs/stm32-data-generated", tag = "stm32-data-d87131cfec93a6dbd21422ac36d43ce9562aab7f", default-features = false, features = ["metadata"] }
 
 [features]
 default = ["rt"]

--- a/embassy-stm32/src/flash/g.rs
+++ b/embassy-stm32/src/flash/g.rs
@@ -20,7 +20,7 @@ pub(crate) unsafe fn lock() {
 }
 pub(crate) unsafe fn unlock() {
     // Wait, while the memory interface is busy.
-    while pac::FLASH.sr().read().bsy() {}
+    wait_busy();
 
     // Unlock flash
     if pac::FLASH.cr().read().lock() {
@@ -53,12 +53,16 @@ pub(crate) unsafe fn blocking_write(start_address: u32, buf: &[u8; WRITE_SIZE]) 
 
 pub(crate) unsafe fn blocking_erase_sector(sector: &FlashSector) -> Result<(), Error> {
     let idx = (sector.start - super::FLASH_BASE as u32) / super::BANK1_REGION.erase_size as u32;
-    while pac::FLASH.sr().read().bsy() {}
+    wait_busy();
     clear_all_err();
 
     interrupt::free(|_| {
         pac::FLASH.cr().modify(|w| {
             w.set_per(true);
+            w.set_bker(sector.bank == crate::flash::FlashBank::Bank2);
+            #[cfg(flash_g0x0)]
+            w.set_pnb(idx as u16);
+            #[cfg(not(flash_g0x0))]
             w.set_pnb(idx as u8);
             w.set_strt(true);
         });
@@ -93,4 +97,14 @@ pub(crate) unsafe fn clear_all_err() {
     // read and write back the same value.
     // This clears all "write 1 to clear" bits.
     pac::FLASH.sr().modify(|_| {});
+}
+
+#[cfg(any(flash_g0x0, flash_g0x1))]
+fn wait_busy(){
+    while pac::FLASH.sr().read().bsy() & pac::FLASH.sr().read().bsy2() {}
+}
+
+#[cfg(not(any(flash_g0x0, flash_g0x1)))]
+fn wait_busy(){
+    while pac::FLASH.sr().read().bsy() {}
 }

--- a/embassy-stm32/src/flash/g.rs
+++ b/embassy-stm32/src/flash/g.rs
@@ -59,6 +59,7 @@ pub(crate) unsafe fn blocking_erase_sector(sector: &FlashSector) -> Result<(), E
     interrupt::free(|_| {
         pac::FLASH.cr().modify(|w| {
             w.set_per(true);
+            #[cfg(any(flash_g0x0, flash_g0x1, flash_g4c3))]
             w.set_bker(sector.bank == crate::flash::FlashBank::Bank2);
             #[cfg(flash_g0x0)]
             w.set_pnb(idx as u16);
@@ -100,11 +101,11 @@ pub(crate) unsafe fn clear_all_err() {
 }
 
 #[cfg(any(flash_g0x0, flash_g0x1))]
-fn wait_busy(){
+fn wait_busy() {
     while pac::FLASH.sr().read().bsy() | pac::FLASH.sr().read().bsy2() {}
 }
 
 #[cfg(not(any(flash_g0x0, flash_g0x1)))]
-fn wait_busy(){
+fn wait_busy() {
     while pac::FLASH.sr().read().bsy() {}
 }

--- a/embassy-stm32/src/flash/g.rs
+++ b/embassy-stm32/src/flash/g.rs
@@ -101,7 +101,7 @@ pub(crate) unsafe fn clear_all_err() {
 
 #[cfg(any(flash_g0x0, flash_g0x1))]
 fn wait_busy(){
-    while pac::FLASH.sr().read().bsy() & pac::FLASH.sr().read().bsy2() {}
+    while pac::FLASH.sr().read().bsy() | pac::FLASH.sr().read().bsy2() {}
 }
 
 #[cfg(not(any(flash_g0x0, flash_g0x1)))]

--- a/embassy-stm32/src/flash/mod.rs
+++ b/embassy-stm32/src/flash/mod.rs
@@ -107,8 +107,8 @@ pub enum FlashBank {
 #[cfg_attr(
     not(any(
         flash_l0, flash_l1, flash_l4, flash_l5, flash_wl, flash_wb, flash_f0, flash_f1, flash_f2, flash_f3, flash_f4,
-        flash_f7, flash_g0x0, flash_g0x1, flash_g4c2, flash_g4c3, flash_g4c4, flash_h7, flash_h7ab, flash_u5, flash_h50, flash_u0,
-        flash_h5,
+        flash_f7, flash_g0x0, flash_g0x1, flash_g4c2, flash_g4c3, flash_g4c4, flash_h7, flash_h7ab, flash_u5,
+        flash_h50, flash_u0, flash_h5,
     )),
     path = "other.rs"
 )]

--- a/embassy-stm32/src/flash/mod.rs
+++ b/embassy-stm32/src/flash/mod.rs
@@ -97,7 +97,7 @@ pub enum FlashBank {
 #[cfg_attr(flash_f2, path = "f2.rs")]
 #[cfg_attr(flash_f4, path = "f4.rs")]
 #[cfg_attr(flash_f7, path = "f7.rs")]
-#[cfg_attr(any(flash_g0, flash_g4c2, flash_g4c3, flash_g4c4), path = "g.rs")]
+#[cfg_attr(any(flash_g0x0, flash_g0x1, flash_g4c2, flash_g4c3, flash_g4c4), path = "g.rs")]
 #[cfg_attr(flash_h7, path = "h7.rs")]
 #[cfg_attr(flash_h7ab, path = "h7.rs")]
 #[cfg_attr(flash_u5, path = "u5.rs")]
@@ -107,7 +107,7 @@ pub enum FlashBank {
 #[cfg_attr(
     not(any(
         flash_l0, flash_l1, flash_l4, flash_l5, flash_wl, flash_wb, flash_f0, flash_f1, flash_f2, flash_f3, flash_f4,
-        flash_f7, flash_g0, flash_g4c2, flash_g4c3, flash_g4c4, flash_h7, flash_h7ab, flash_u5, flash_h50, flash_u0,
+        flash_f7, flash_g0x0, flash_g0x1, flash_g4c2, flash_g4c3, flash_g4c4, flash_h7, flash_h7ab, flash_u5, flash_h50, flash_u0,
         flash_h5,
     )),
     path = "other.rs"


### PR DESCRIPTION
Integration of changes made in embassy-rs/stm32-data/pull/556: Addition of dual flash bank support for G0.
- Setting of bank select for erase bit in erase sector
- Waiting for both busy flags 

Would be nice to have some feedback on how to deal with the now diverging options/registers other than the conditional compilation