### PR TITLE
Correctly gate `time` feature of embassy-embedded-hal in embassy-nrf

### DIFF
--- a/embassy-nrf/Cargo.toml
+++ b/embassy-nrf/Cargo.toml
@@ -32,7 +32,7 @@ default = ["rt"]
 rt = ["nrf-pac/rt"]
 
 ## Enable features requiring `embassy-time`
-time = ["dep:embassy-time"]
+time = ["dep:embassy-time", "embassy-embedded-hal/time"]
 
 ## Enable defmt
 defmt = ["dep:defmt", "embassy-hal-internal/defmt", "embassy-sync/defmt", "embassy-usb-driver/defmt", "embassy-embedded-hal/defmt"]
@@ -119,7 +119,7 @@ _nrf52 = ["_ppi"]
 _nrf51 = ["_ppi"]
 _nrf91 = []
 
-_time-driver = ["dep:embassy-time-driver", "embassy-time-driver?/tick-hz-32_768", "dep:embassy-time-queue-utils"]
+_time-driver = ["dep:embassy-time-driver", "embassy-time-driver?/tick-hz-32_768", "dep:embassy-time-queue-utils", "embassy-embedded-hal/time"]
 
 # trustzone state.
 _s = []

--- a/embassy-nrf/Cargo.toml
+++ b/embassy-nrf/Cargo.toml
@@ -139,7 +139,7 @@ embassy-time-queue-utils = { version = "0.1", path = "../embassy-time-queue-util
 embassy-time = { version = "0.4.0", path = "../embassy-time", optional = true }
 embassy-sync = { version = "0.6.1", path = "../embassy-sync" }
 embassy-hal-internal = {version = "0.2.0", path = "../embassy-hal-internal", features = ["cortex-m", "prio-bits-3"] }
-embassy-embedded-hal = {version = "0.2.0", path = "../embassy-embedded-hal" }
+embassy-embedded-hal = {version = "0.2.0", path = "../embassy-embedded-hal", default-features = false }
 embassy-usb-driver = {version = "0.1.0", path = "../embassy-usb-driver" }
 
 embedded-hal-02 = { package = "embedded-hal", version = "0.2.6", features = ["unproven"] }


### PR DESCRIPTION
Hi there,

This is another small fix to hopefully enable embassy-nrf to be built without a time driver.

This should allow embassy-nrf to not pull in embassy-time if a time driver or time feature is not needed.

As far as I could tell the time feature of embassy-embedded-hal is used only for spi delays, and so those would become panics when embassy-nrf is built without a time feature. This isn't ideal, but a better implementation would probably involve a shared bus that takes a delay implementation, which would be a PR for another day :)

Rust features are hard to reason about so let me know if anything needs changing.