### PR TITLE
FIX: QSPI synchronous read operation hangs when FIFO is not full

### DIFF
--- a/embassy-stm32/src/qspi/mod.rs
+++ b/embassy-stm32/src/qspi/mod.rs
@@ -402,10 +402,7 @@ impl<'d, T: Instance> Qspi<'d, T, Async> {
 
         // STM32H7 does not have dmaen
         #[cfg(not(stm32h7))]
-        T::REGS.cr().modify(|v| {
-            v.set_en(true);
-            v.set_dmaen(true)
-        });
+        T::REGS.cr().modify(|v| v.set_dmaen(true));
         transfer
     }
 

--- a/embassy-stm32/src/qspi/mod.rs
+++ b/embassy-stm32/src/qspi/mod.rs
@@ -172,7 +172,7 @@ impl<'d, T: Instance, M: PeriMode> Qspi<'d, T, M> {
         });
 
         for b in buf {
-            while !T::REGS.sr().read().tcf() && !T::REGS.sr().read().ftf() {}
+            while !T::REGS.sr().read().tcf() && (T::REGS.sr().read().flevel() == 0) {}
             *b = unsafe { (T::REGS.dr().as_ptr() as *mut u8).read_volatile() };
         }
 
@@ -402,7 +402,10 @@ impl<'d, T: Instance> Qspi<'d, T, Async> {
 
         // STM32H7 does not have dmaen
         #[cfg(not(stm32h7))]
-        T::REGS.cr().modify(|v| v.set_dmaen(true));
+        T::REGS.cr().modify(|v| {
+            v.set_en(true);
+            v.set_dmaen(true)
+        });
         transfer
     }
 


### PR DESCRIPTION
The current QSPI synchronous read function uses tcf!=1 and ftf!=1 as the polling condition. However, this condition fails when the transfer is complete and the FIFO is not full, as both tcf and ftf will be 0. This causes the read loop to block indefinitely, leaving data unread in the FIFO.

This PR resolves the issue by using the correct polling condition: tcf!=1 and flevel==0. This ensures the loop terminates only when the transfer is complete and the FIFO is empty.

Monitoring the flevel register during the read operation confirmed that it remained at 15 (FIFO_SIZE-1) when the issue occurred, validating the hypothesis.