### PR TITLE
feat: mmap mode for qspi and example

### DIFF
--- a/ci.sh
+++ b/ci.sh
@@ -231,6 +231,7 @@ cargo batch \
     --- build --release --manifest-path examples/stm32l0/Cargo.toml --target thumbv6m-none-eabi --out-dir out/examples/stm32l0 \
     --- build --release --manifest-path examples/stm32l1/Cargo.toml --target thumbv7m-none-eabi --out-dir out/examples/stm32l1 \
     --- build --release --manifest-path examples/stm32l4/Cargo.toml --target thumbv7em-none-eabi --out-dir out/examples/stm32l4 \
+    --- build --release --manifest-path examples/stm32l432/Cargo.toml --target thumbv7em-none-eabi --out-dir out/examples/stm32l432 \
     --- build --release --manifest-path examples/stm32l5/Cargo.toml --target thumbv8m.main-none-eabihf --out-dir out/examples/stm32l5 \
     --- build --release --manifest-path examples/stm32u0/Cargo.toml --target thumbv6m-none-eabi --out-dir out/examples/stm32u0 \
     --- build --release --manifest-path examples/stm32u5/Cargo.toml --target thumbv8m.main-none-eabihf --out-dir out/examples/stm32u5 \

--- a/examples/stm32l432/.cargo/config.toml
+++ b/examples/stm32l432/.cargo/config.toml
@@ -1,0 +1,13 @@
+[target.'cfg(all(target_arch = "arm", target_os = "none"))']
+# replace STM32F429ZITx with your chip as listed in `probe-rs chip list`
+#runner = "probe-rs run --chip STM32L475VGT6"
+#runner = "probe-rs run --chip STM32L475VG"
+#runner = "probe-rs run --chip STM32L4S5QI"
+runner = "probe-rs run --chip STM32L432KCUx --connect-under-reset --speed 3300"
+
+
+[build]
+target = "thumbv7em-none-eabi"
+
+[env]
+DEFMT_LOG = "trace"

--- a/examples/stm32l432/Cargo.toml
+++ b/examples/stm32l432/Cargo.toml
@@ -1,0 +1,30 @@
+[package]
+edition = "2021"
+name = "embassy-stm32l4-examples"
+version = "0.1.1"
+license = "MIT OR Apache-2.0"
+
+[dependencies]
+# Change stm32l4s5vi to your chip name, if necessary.
+embassy-stm32 = { version = "0.1.0", path = "../../embassy-stm32", features = [ "defmt", "unstable-pac", "stm32l432kc", "memory-x", "time-driver-any", "exti", "chrono"] }
+embassy-sync = { version = "0.6.1", path = "../../embassy-sync", features = [ "defmt" ] }
+embassy-executor = { version = "0.7.0", path = "../../embassy-executor", features = [ "task-arena-size-32768", "arch-cortex-m", "executor-thread", "defmt" ] }
+embassy-time = { version = "0.4.0", path = "../../embassy-time", features = [ "defmt", "defmt-timestamp-uptime", "tick-hz-32_768" ] }
+defmt = "0.3"
+defmt-rtt = "0.4"
+
+cortex-m = { version = "0.7.6", features = ["critical-section-single-core"] }
+cortex-m-rt = "0.7.0"
+embedded-hal = "0.2.6"
+embedded-hal-1 = { package = "embedded-hal", version = "1.0" }
+embedded-hal-async = { version = "1.0" }
+embedded-hal-bus = { version = "0.1", features = ["async"] }
+panic-probe = { version = "0.3", features = ["print-defmt"] }
+
+[profile.release]
+debug = 2
+
+[[bin]]
+name = "qspi_mmap"
+path = "src/bin/qspi_mmap.rs"
+test = false

--- a/examples/stm32l432/README.md
+++ b/examples/stm32l432/README.md
@@ -1,0 +1,30 @@
+
+# Examples for STM32L432 family
+
+Examples in this repo should work with [NUCLEO-L432KC](https://www.st.com/en/evaluation-tools/nucleo-l432kc.html) board.
+
+Run individual examples with
+```
+cargo run --bin <module-name>
+```
+for example
+```
+cargo run --bin blinky
+```
+
+
+
+## Checklist before running examples
+You might need to adjust `.cargo/config.toml`, `Cargo.toml` and possibly update pin numbers or peripherals to match the specific MCU or board you are using.
+
+* [ ] Update .cargo/config.toml with the correct probe-rs command to use your specific MCU. For example for L432KCU6 it should be `probe-rs run --chip STM32L432KCUx`. (use `probe-rs chip list` to find your chip)
+* [ ] Update Cargo.toml to have the correct `embassy-stm32` feature. For example for L432KCU6 it should be `stm32l432kc`. Look in the `Cargo.toml` file of the `embassy-stm32` project to find the correct feature flag for your chip.
+* [ ] If your board has a special clock or power configuration, make sure that it is set up appropriately.
+* [ ] If your board has different pin mapping, update any pin numbers or peripherals in the given example code to match your schematic
+
+If you are unsure, please drop by the Embassy Matrix chat for support, and let us know:
+
+* Which example you are trying to run
+* Which chip and board you are using
+
+Embassy Chat: https://matrix.to/#/#embassy-rs:matrix.org

--- a/examples/stm32l432/build.rs
+++ b/examples/stm32l432/build.rs
@@ -1,0 +1,5 @@
+fn main() {
+    println!("cargo:rustc-link-arg-bins=--nmagic");
+    println!("cargo:rustc-link-arg-bins=-Tlink.x");
+    println!("cargo:rustc-link-arg-bins=-Tdefmt.x");
+}

--- a/examples/stm32l432/src/bin/qspi_mmap.rs
+++ b/examples/stm32l432/src/bin/qspi_mmap.rs
@@ -1,0 +1,274 @@
+#![no_std]
+#![no_main]
+#![allow(dead_code)]
+/// This example demonstrates how to use the QSPI peripheral in both indirect-mode and memory-mapped mode.
+/// If you want to test this example, please pay attention to flash pins and check flash device datasheet
+/// to make sure operations in this example are compatible with your device, especially registers I/O operations.
+use defmt::info;
+use embassy_stm32::mode;
+use embassy_stm32::qspi::enums::{
+    AddressSize, ChipSelectHighTime, DummyCycles, FIFOThresholdLevel, MemorySize, QspiWidth,
+};
+use embassy_stm32::qspi::{self, Instance, TransferConfig};
+pub struct FlashMemory<I: Instance> {
+    qspi: qspi::Qspi<'static, I, mode::Async>,
+}
+use embassy_executor::Spawner;
+use embassy_time::Timer;
+use {defmt_rtt as _, panic_probe as _};
+
+const MEMORY_PAGE_SIZE: usize = 256;
+const CMD_READ_SR: u8 = 0x05;
+const CMD_READ_CR: u8 = 0x35;
+const CMD_QUAD_READ: u8 = 0x6B;
+const CMD_QUAD_WRITE_PG: u8 = 0x32;
+const CMD_READ_ID: u8 = 0x9F;
+const CMD_READ_MID: u8 = 0x90;
+const CMD_READ_UUID: u8 = 0x4B;
+const CMD_ENABLE_RESET: u8 = 0x66;
+const CMD_RESET: u8 = 0x99;
+const CMD_WRITE_ENABLE: u8 = 0x06;
+const CMD_SECTOR_ERASE: u8 = 0x20;
+
+const CMD_WRITE_SR: u8 = 0x01;
+
+impl<I: Instance> FlashMemory<I> {
+    pub fn new(qspi: qspi::Qspi<'static, I, mode::Async>) -> Self {
+        let mut memory = Self { qspi };
+
+        memory.reset_memory();
+        memory.enable_quad();
+
+        memory
+    }
+    fn enable_quad(&mut self) {
+        let sr = self.read_sr_lsb();
+        let cr = self.read_sr_msb();
+
+        self.write_sr(sr, cr | 0x02);
+    }
+    fn read_register(&mut self, cmd: u8) -> u8 {
+        let mut buffer = [0; 1];
+        let transaction = TransferConfig {
+            iwidth: QspiWidth::SING,
+            awidth: QspiWidth::NONE,
+            dwidth: QspiWidth::SING,
+            instruction: cmd,
+            address: None,
+            dummy: DummyCycles::_0,
+        };
+        self.qspi.blocking_read(&mut buffer, transaction);
+        buffer[0]
+    }
+
+    fn write_register(&mut self, cmd: u8, value: u8) {
+        let buffer = [value; 1];
+        let transaction: TransferConfig = TransferConfig {
+            iwidth: QspiWidth::SING,
+            awidth: QspiWidth::NONE,
+            dwidth: QspiWidth::SING,
+            instruction: cmd,
+            address: None,
+            dummy: DummyCycles::_0,
+        };
+        self.qspi.blocking_write(&buffer, transaction);
+    }
+    pub fn write_sr(&mut self, lsb: u8, msb: u8) {
+        let buffer = [lsb, msb];
+        let transaction: TransferConfig = TransferConfig {
+            iwidth: QspiWidth::SING,
+            awidth: QspiWidth::NONE,
+            dwidth: QspiWidth::SING,
+            instruction: CMD_WRITE_SR,
+            address: None,
+            dummy: DummyCycles::_0,
+        };
+        self.qspi.blocking_write(&buffer, transaction);
+    }
+
+    pub fn read_sr_lsb(&mut self) -> u8 {
+        self.read_register(CMD_READ_SR)
+    }
+    pub fn read_sr_msb(&mut self) -> u8 {
+        self.read_register(CMD_READ_CR)
+    }
+
+    pub fn reset_memory(&mut self) {
+        self.exec_command(CMD_ENABLE_RESET);
+        self.exec_command(CMD_RESET);
+        self.wait_write_finish();
+    }
+    fn exec_command(&mut self, cmd: u8) {
+        let transaction = TransferConfig {
+            iwidth: QspiWidth::SING,
+            awidth: QspiWidth::NONE,
+            dwidth: QspiWidth::NONE,
+            instruction: cmd,
+            address: None,
+            dummy: DummyCycles::_0,
+        };
+        self.qspi.blocking_command(transaction);
+    }
+    fn wait_write_finish(&mut self) {
+        while (self.read_sr_lsb() & 0x01) != 0 {}
+    }
+
+    pub fn read_mid(&mut self) -> [u8; 2] {
+        let mut buffer = [0; 2];
+        let transaction: TransferConfig = TransferConfig {
+            iwidth: QspiWidth::SING,
+            awidth: QspiWidth::SING,
+            dwidth: QspiWidth::SING,
+            instruction: CMD_READ_MID,
+            address: Some(0),
+            dummy: DummyCycles::_0,
+        };
+        self.qspi.blocking_read(&mut buffer, transaction);
+        buffer
+    }
+    pub fn read_uuid(&mut self) -> [u8; 16] {
+        let mut buffer = [0; 16];
+        let transaction: TransferConfig = TransferConfig {
+            iwidth: QspiWidth::SING,
+            awidth: QspiWidth::SING,
+            dwidth: QspiWidth::SING,
+            instruction: CMD_READ_UUID,
+            address: Some(0),
+            dummy: DummyCycles::_8,
+        };
+        self.qspi.blocking_read(&mut buffer, transaction);
+        buffer
+    }
+    pub fn read_id(&mut self) -> [u8; 3] {
+        let mut buffer = [0; 3];
+        let transaction: TransferConfig = TransferConfig {
+            iwidth: QspiWidth::SING,
+            awidth: QspiWidth::NONE,
+            dwidth: QspiWidth::SING,
+            instruction: CMD_READ_ID,
+            address: None,
+            dummy: DummyCycles::_0,
+        };
+        self.qspi.blocking_read(&mut buffer, transaction);
+        buffer
+    }
+
+    pub fn enable_mmap(&mut self) {
+        let transaction: TransferConfig = TransferConfig {
+            iwidth: QspiWidth::SING,
+            awidth: QspiWidth::SING,
+            dwidth: QspiWidth::QUAD,
+            instruction: CMD_QUAD_READ,
+            address: Some(0),
+            dummy: DummyCycles::_8,
+        };
+        self.qspi.enable_memory_map(&transaction);
+    }
+    fn perform_erase(&mut self, addr: u32, cmd: u8) {
+        let transaction = TransferConfig {
+            iwidth: QspiWidth::SING,
+            awidth: QspiWidth::SING,
+            dwidth: QspiWidth::NONE,
+            instruction: cmd,
+            address: Some(addr),
+            dummy: DummyCycles::_0,
+        };
+        self.enable_write();
+        self.qspi.blocking_command(transaction);
+        self.wait_write_finish();
+    }
+    pub fn enable_write(&mut self) {
+        self.exec_command(CMD_WRITE_ENABLE);
+    }
+    pub fn erase_sector(&mut self, addr: u32) {
+        self.perform_erase(addr, CMD_SECTOR_ERASE);
+    }
+    fn write_page(&mut self, addr: u32, buffer: &[u8], len: usize, use_dma: bool) {
+        assert!(
+            (len as u32 + (addr & 0x000000ff)) <= MEMORY_PAGE_SIZE as u32,
+            "write_page(): page write length exceeds page boundary (len = {}, addr = {:X}",
+            len,
+            addr
+        );
+
+        let transaction = TransferConfig {
+            iwidth: QspiWidth::SING,
+            awidth: QspiWidth::SING,
+            dwidth: QspiWidth::QUAD,
+            instruction: CMD_QUAD_WRITE_PG,
+            address: Some(addr),
+            dummy: DummyCycles::_0,
+        };
+        self.enable_write();
+        if use_dma {
+            self.qspi.blocking_write_dma(buffer, transaction);
+        } else {
+            self.qspi.blocking_write(buffer, transaction);
+        }
+        self.wait_write_finish();
+    }
+    pub fn write_memory(&mut self, addr: u32, buffer: &[u8], use_dma: bool) {
+        let mut left = buffer.len();
+        let mut place = addr;
+        let mut chunk_start = 0;
+
+        while left > 0 {
+            let max_chunk_size = MEMORY_PAGE_SIZE - (place & 0x000000ff) as usize;
+            let chunk_size = if left >= max_chunk_size { max_chunk_size } else { left };
+            let chunk = &buffer[chunk_start..(chunk_start + chunk_size)];
+            self.write_page(place, chunk, chunk_size, use_dma);
+            place += chunk_size as u32;
+            left -= chunk_size;
+            chunk_start += chunk_size;
+        }
+    }
+
+    pub fn read_memory(&mut self, addr: u32, buffer: &mut [u8], use_dma: bool) {
+        let transaction = TransferConfig {
+            iwidth: QspiWidth::SING,
+            awidth: QspiWidth::SING,
+            dwidth: QspiWidth::QUAD,
+            instruction: CMD_QUAD_READ,
+            address: Some(addr),
+            dummy: DummyCycles::_8,
+        };
+        if use_dma {
+            self.qspi.blocking_read_dma(buffer, transaction);
+        } else {
+            self.qspi.blocking_read(buffer, transaction);
+        }
+    }
+}
+
+const MEMORY_ADDR: u32 = 0x00000000 as u32;
+
+#[embassy_executor::main]
+async fn main(_spawner: Spawner) {
+    let p = embassy_stm32::init(Default::default());
+
+    let config = qspi::Config {
+        memory_size: MemorySize::_16MiB,
+        address_size: AddressSize::_24bit,
+        prescaler: 200,
+        cs_high_time: ChipSelectHighTime::_1Cycle,
+        fifo_threshold: FIFOThresholdLevel::_16Bytes,
+    };
+    let driver = qspi::Qspi::new_bank1(p.QUADSPI, p.PB1, p.PB0, p.PA7, p.PA6, p.PA3, p.PA2, p.DMA2_CH7, config);
+    let mut flash = FlashMemory::new(driver);
+    let mut wr_buf = [0u8; 256];
+    for i in 0..32 {
+        wr_buf[i] = i as u8;
+    }
+    let mut rd_buf = [0u8; 32];
+    flash.erase_sector(MEMORY_ADDR);
+    flash.write_memory(MEMORY_ADDR, &wr_buf, false);
+    flash.read_memory(MEMORY_ADDR, &mut rd_buf, false);
+
+    info!("data read from indirect mode: {}", rd_buf);
+    flash.enable_mmap();
+    let qspi_base = unsafe { core::slice::from_raw_parts(0x9000_0000 as *const u8, 32) };
+    info!("data read from mmap: {}", qspi_base);
+    loop {
+        Timer::after_millis(1000).await;
+    }
+}


### PR DESCRIPTION
This PR add `enable_memory_map`  for qspi HAL.

Included example is tested in the `stm32l432kcu6` device.