### PR TITLE
`embassy-rp`: add `set_pullup()` for `OutputOpenDrain`

### DIFF
--- a/embassy-rp/src/gpio.rs
+++ b/embassy-rp/src/gpio.rs
@@ -450,6 +450,16 @@ impl<'d> OutputOpenDrain<'d> {
         Self { pin }
     }
 
+    /// Set the pin's pull-up.
+    #[inline]
+    pub fn set_pullup(&mut self, enable: bool) {
+        if enable {
+            self.pin.set_pull(Pull::Up);
+        } else {
+            self.pin.set_pull(Pull::None);
+        }
+    }
+
     /// Set the pin's drive strength.
     #[inline]
     pub fn set_drive_strength(&mut self, strength: Drive) {


### PR DESCRIPTION
In case of OpenDrain Output, a Pull-Up resistor *MUST* be present on the signal. Usually it is a physical resistor on the board, but why not using the RP internal PU capability for it ? Could be handy for board with forgotten PU...

Note: Pull-Down is irrelevant here, so it is not proposed...