### PR TITLE
feat: STM32 Allow to modify the receiver filters from `BufferedCan`, `CanRx`, and `BufferedCanRx`

### DIFF
--- a/embassy-stm32/src/can/bxcan/mod.rs
+++ b/embassy-stm32/src/can/bxcan/mod.rs
@@ -502,6 +502,14 @@ impl<'d, const TX_BUF_SIZE: usize, const RX_BUF_SIZE: usize> BufferedCan<'d, TX_
     pub fn reader(&self) -> BufferedCanReceiver {
         self.rx.reader()
     }
+
+    /// Accesses the filter banks owned by this CAN peripheral.
+    ///
+    /// To modify filters of a slave peripheral, `modify_filters` has to be called on the master
+    /// peripheral instead.
+    pub fn modify_filters(&mut self) -> MasterFilters<'_> {
+        self.rx.modify_filters()
+    }
 }
 
 /// CAN driver, transmit half.
@@ -733,6 +741,14 @@ impl<'d> CanRx<'d> {
     ) -> BufferedCanRx<'d, RX_BUF_SIZE> {
         BufferedCanRx::new(self.info, self.state, self, rxb)
     }
+
+    /// Accesses the filter banks owned by this CAN peripheral.
+    ///
+    /// To modify filters of a slave peripheral, `modify_filters` has to be called on the master
+    /// peripheral instead.
+    pub fn modify_filters(&mut self) -> MasterFilters<'_> {
+        unsafe { MasterFilters::new(self.info) }
+    }
 }
 
 /// User supplied buffer for RX Buffering
@@ -742,16 +758,16 @@ pub type RxBuf<const BUF_SIZE: usize> = Channel<CriticalSectionRawMutex, Result<
 pub struct BufferedCanRx<'d, const RX_BUF_SIZE: usize> {
     info: &'static Info,
     state: &'static State,
-    _rx: CanRx<'d>,
+    rx: CanRx<'d>,
     rx_buf: &'static RxBuf<RX_BUF_SIZE>,
 }
 
 impl<'d, const RX_BUF_SIZE: usize> BufferedCanRx<'d, RX_BUF_SIZE> {
-    fn new(info: &'static Info, state: &'static State, _rx: CanRx<'d>, rx_buf: &'static RxBuf<RX_BUF_SIZE>) -> Self {
+    fn new(info: &'static Info, state: &'static State, rx: CanRx<'d>, rx_buf: &'static RxBuf<RX_BUF_SIZE>) -> Self {
         BufferedCanRx {
             info,
             state,
-            _rx,
+            rx,
             rx_buf,
         }
         .setup()
@@ -810,6 +826,14 @@ impl<'d, const RX_BUF_SIZE: usize> BufferedCanRx<'d, RX_BUF_SIZE> {
     /// Returns a receiver that can be used for receiving CAN frames. Note, each CAN frame will only be received by one receiver.
     pub fn reader(&self) -> BufferedCanReceiver {
         self.rx_buf.receiver().into()
+    }
+
+    /// Accesses the filter banks owned by this CAN peripheral.
+    ///
+    /// To modify filters of a slave peripheral, `modify_filters` has to be called on the master
+    /// peripheral instead.
+    pub fn modify_filters(&mut self) -> MasterFilters<'_> {
+        self.rx.modify_filters()
     }
 }
 


### PR DESCRIPTION
I want to split up my CAN interface on my STM32 to handle sending and receiving in different tasks. However I also want to be able to change the receive filters while the peripheral is split. Currently the `modify_filters` method is only available on the combined struct. This PR also makes it available on `BufferedCan`, `CanRx`, and `BufferedCanRx`.

From what I could tell from the reference manual and implementation, the filter registers are only used from the `MasterFilter` struct. So I think it should be fine to make them also accessible from the split off `Rx` half, since there is still only one struct that can access them.