### PR TITLE
feat: Calibrating Differential ADC for G4

### DIFF
--- a/embassy-stm32/src/adc/g4.rs
+++ b/embassy-stm32/src/adc/g4.rs
@@ -191,6 +191,14 @@ impl<'d, T: Instance> Adc<'d, T> {
         T::regs().cr().modify(|w| w.set_adcal(true));
 
         while T::regs().cr().read().adcal() {}
+
+        T::regs().cr().modify(|w| {
+            w.set_adcaldif(Adcaldif::DIFFERENTIAL);
+        });
+
+        T::regs().cr().modify(|w| w.set_adcal(true));
+
+        while T::regs().cr().read().adcal() {}
     }
 
     fn enable(&mut self) {


### PR DESCRIPTION
This PR introduces a calibration step for the differential mode of the ADC in the STM32G4 series. Previously, the code only calibrated the single-ended mode. I've added the differential mode calibration immediately after the existing one. Although separating the calibration processes into individual functions might be a better approach, I opted to maintain compatibility with the existing code.

The changes have improved the differential DAC error on my STM32G431CBU6, so I believe it should work well. I've attached a screenshot from the reference manual that I used, hoping it will save you some time during the code review.

<img width="256" alt="image" src="https://github.com/user-attachments/assets/7412cd59-8e6b-4aca-bb62-b516a3535d18" />
