### PR TITLE
[net] add explicit lifetime to tcp socket split() function

### DIFF
--- a/embassy-net/src/tcp.rs
+++ b/embassy-net/src/tcp.rs
@@ -235,7 +235,7 @@ impl<'a> TcpSocket<'a> {
     }
 
     /// Split the socket into reader and a writer halves.
-    pub fn split(&mut self) -> (TcpReader<'_>, TcpWriter<'_>) {
+    pub fn split<'b>(&'b mut self) -> (TcpReader<'a>, TcpWriter<'a>) {
         (TcpReader { io: self.io }, TcpWriter { io: self.io })
     }
 


### PR DESCRIPTION
I added explicit lifetimes to the `TcpSocket::split()` function. 

old version:

```rust
    pub fn split(&mut self) -> (TcpReader<'_>, TcpWriter<'_>) {
        (TcpReader { io: self.io }, TcpWriter { io: self.io })
    }
```

In the old version the lifetime of the `TcpReader ` and `TcpWriter ` seems to be the lifetime of `&mut self`. By adding explicit lifetimes users of this function have more flexibility. 

What do you think about this change?