### PR TITLE
stm32: generate singletons only for pins that actually exist.

### DIFF
--- a/embassy-stm32/Cargo.toml
+++ b/embassy-stm32/Cargo.toml
@@ -73,7 +73,7 @@ rand_core = "0.6.3"
 sdio-host = "0.5.0"
 critical-section = "1.1"
 #stm32-metapac = { version = "15" }
-stm32-metapac = { git = "https://github.com/embassy-rs/stm32-data-generated", tag = "stm32-data-fad4bc0f2baac29ecebb5153d2997b649b71025f" }
+stm32-metapac = { git = "https://github.com/embassy-rs/stm32-data-generated", tag = "stm32-data-db71f6aa03b7db26548b461d3844fc404d40c98c" }
 
 vcell = "0.1.3"
 nb = "1.0.0"
@@ -102,7 +102,7 @@ proc-macro2 = "1.0.36"
 quote = "1.0.15"
 
 #stm32-metapac = { version = "15", default-features = false, features = ["metadata"]}
-stm32-metapac = { git = "https://github.com/embassy-rs/stm32-data-generated", tag = "stm32-data-fad4bc0f2baac29ecebb5153d2997b649b71025f", default-features = false, features = ["metadata"] }
+stm32-metapac = { git = "https://github.com/embassy-rs/stm32-data-generated", tag = "stm32-data-db71f6aa03b7db26548b461d3844fc404d40c98c", default-features = false, features = ["metadata"] }
 
 [features]
 default = ["rt"]

--- a/examples/stm32u0/src/bin/spi.rs
+++ b/examples/stm32u0/src/bin/spi.rs
@@ -18,7 +18,7 @@ fn main() -> ! {
 
     let mut spi = Spi::new_blocking(p.SPI3, p.PC10, p.PC12, p.PC11, spi_config);
 
-    let mut cs = Output::new(p.PE0, Level::High, Speed::VeryHigh);
+    let mut cs = Output::new(p.PC13, Level::High, Speed::VeryHigh);
 
     loop {
         let mut buf = [0x0Au8; 4];

--- a/examples/stm32u5/src/bin/blinky.rs
+++ b/examples/stm32u5/src/bin/blinky.rs
@@ -12,7 +12,8 @@ async fn main(_spawner: Spawner) -> ! {
     let p = embassy_stm32::init(Default::default());
     info!("Hello World!");
 
-    let mut led = Output::new(p.PH7, Level::Low, Speed::Medium);
+    // replace PC13 with the right pin for your board.
+    let mut led = Output::new(p.PC13, Level::Low, Speed::Medium);
 
     loop {
         defmt::info!("on!");


### PR DESCRIPTION
Before we'd generate all pins Px0..Px15 for each GPIOx port. This changes
codegen to only generate singletons for actually-existing pins.

(AFs were already previously filtered, so these non-existing pins were already mostly useless)
