### PR TITLE
[stm32f4] [adc] feat: Add async single adc readings

### DIFF
--- a/embassy-stm32/src/adc/mod.rs
+++ b/embassy-stm32/src/adc/mod.rs
@@ -21,7 +21,7 @@ use core::marker::PhantomData;
 #[allow(unused)]
 #[cfg(not(any(adc_f3_v2)))]
 pub use _version::*;
-#[cfg(any(adc_f1, adc_f3, adc_v1, adc_l0, adc_f3_v1_1))]
+#[cfg(any(adc_f1, adc_v2, adc_f3, adc_v1, adc_l0, adc_f3_v1_1))]
 use embassy_sync::waitqueue::AtomicWaker;
 
 #[cfg(adc_u5)]
@@ -46,12 +46,12 @@ pub struct Adc<'d, T: Instance> {
     sample_time: SampleTime,
 }
 
-#[cfg(any(adc_f1, adc_f3, adc_v1, adc_l0, adc_f3_v1_1))]
+#[cfg(any(adc_f1, adc_v2, adc_f3, adc_v1, adc_l0, adc_f3_v1_1))]
 pub struct State {
     pub waker: AtomicWaker,
 }
 
-#[cfg(any(adc_f1, adc_f3, adc_v1, adc_l0, adc_f3_v1_1))]
+#[cfg(any(adc_f1, adc_v2, adc_f3, adc_v1, adc_l0, adc_f3_v1_1))]
 impl State {
     pub const fn new() -> Self {
         Self {
@@ -66,7 +66,7 @@ trait SealedInstance {
     #[cfg(not(any(adc_f1, adc_v1, adc_l0, adc_f3_v2, adc_f3_v1_1, adc_g0)))]
     #[allow(unused)]
     fn common_regs() -> crate::pac::adccommon::AdcCommon;
-    #[cfg(any(adc_f1, adc_f3, adc_v1, adc_l0, adc_f3_v1_1))]
+    #[cfg(any(adc_f1, adc_v2, adc_f3, adc_v1, adc_l0, adc_f3_v1_1))]
     fn state() -> &'static State;
 }
 
@@ -208,7 +208,7 @@ foreach_adc!(
                 return crate::pac::$common_inst
             }
 
-            #[cfg(any(adc_f1, adc_f3, adc_v1, adc_l0, adc_f3_v1_1))]
+            #[cfg(any(adc_f1, adc_v2, adc_f3, adc_v1, adc_l0, adc_f3_v1_1))]
             fn state() -> &'static State {
                 static STATE: State = State::new();
                 &STATE

--- a/examples/stm32f4/src/bin/adc.rs
+++ b/examples/stm32f4/src/bin/adc.rs
@@ -24,6 +24,7 @@ async fn main(_spawner: Spawner) {
     delay.delay_us(Temperature::start_time_us().max(VrefInt::start_time_us()));
 
     let vrefint_sample = adc.blocking_read(&mut vrefint);
+    info!("VrefInt: {}", vrefint_sample);
 
     let convert_to_millivolts = |sample| {
         // From http://www.st.com/resource/en/datasheet/DM00071990.pdf
@@ -44,22 +45,21 @@ async fn main(_spawner: Spawner) {
         (sample_mv - V25) as f32 / AVG_SLOPE + 25.0
     };
 
-    info!("VrefInt: {}", vrefint_sample);
     const MAX_ADC_SAMPLE: u16 = (1 << 12) - 1;
     info!("VCCA: {} mV", convert_to_millivolts(MAX_ADC_SAMPLE));
 
     loop {
-        // Read pin
-        let v = adc.blocking_read(&mut pin);
+        // Read pin asynchronously
+        let v = adc.read(&mut pin).await;
         info!("PC1: {} ({} mV)", v, convert_to_millivolts(v));
 
-        // Read internal temperature
-        let v = adc.blocking_read(&mut temp);
+        // Read internal temperature asynchronously
+        let v = adc.read(&mut temp).await;
         let celcius = convert_to_celcius(v);
         info!("Internal temp: {} ({} C)", v, celcius);
 
-        // Read internal voltage reference
-        let v = adc.blocking_read(&mut vrefint);
+        // Read internal voltage reference asynchronously
+        let v = adc.read(&mut vrefint).await;
         info!("VrefInt: {}", v);
 
         Timer::after_millis(100).await;


### PR DESCRIPTION
In contrast to the ADC implementations of other series, the STM32F4 series does not yet have an API definition for the asynchronous reading of a single channel. Instead, only the read_blocking() method was available.

In this PR, the API was extended to include an asynchronous read() method. Internal refactorings were also carried out in order to standardize the logic for setting registers and avoid redundant code. The implementation is based on the ADC implementations of other series in embassy_stm32/adc/.

The new method allows asynchronous single conversions to be performed and the ADC to be operated asynchronously in discontinuous mode. This is particularly useful for sporadic queries of an ADC channel, as the read() approach is simpler and more efficient than using a ring buffer DMA transfer.

In addition, the ADC example for the STM32F4 series has been updated. It now demonstrates the use of the read_blocking() method at the beginning and shows the asynchronous use with the new read() method in the infinite loop. This makes it easier to understand the interface and its practical use.