### PR TITLE
stm32: flash: fix flash erase on stm32f3xx series

### DIFF
--- a/embassy-stm32/src/flash/f1f3.rs
+++ b/embassy-stm32/src/flash/f1f3.rs
@@ -64,8 +64,8 @@ pub(crate) unsafe fn blocking_erase_sector(sector: &FlashSector) -> Result<(), E
     // BSY bit, because there is a one-cycle delay between
     // setting the STRT bit and the BSY bit being asserted
     // by hardware. See STM32F105xx, STM32F107xx device errata,
-    // section 2.2.8
-    #[cfg(stm32f1)]
+    // section 2.2.8, and also RM0316 Rev 10 section 4.2.3 for
+    // STM32F3xx series.
     pac::FLASH.cr().read();
 
     let mut ret: Result<(), Error> = wait_ready_blocking();


### PR DESCRIPTION
Fix for flash erase not working on STM32F3 series (tested on STM32F303K8 specifically).

STM32F3xx series also needs a wait of at least one clock cycle before reading the BSY bit during a flash erase - previously this was only applied to STM32F1xx series.

This was causing an erase failure due to the `wait_ready_blocking` not actually waiting until the erase operation is complete, and as a result the EOP bit was not set when checked.