### PR TITLE
nrf twim return errors in async_wait instead of waiting indefinitely 

### DIFF
--- a/embassy-nrf/src/twim.rs
+++ b/embassy-nrf/src/twim.rs
@@ -257,7 +257,7 @@ impl<'d, T: Instance> Twim<'d, T> {
     }
 
     /// Get Error instance, if any occurred.
-    fn check_errorsrc(&self) -> Result<(), Error> {
+    fn check_errorsrc() -> Result<(), Error> {
         let r = T::regs();
 
         let err = r.errorsrc().read();
@@ -347,7 +347,7 @@ impl<'d, T: Instance> Twim<'d, T> {
             if r.events_error().read() != 0 {
                 r.events_error().write_value(0);
                 r.tasks_stop().write_value(1);
-                if let Err(e) = self.check_errorsrc() {
+                if let Err(e) = Self::check_errorsrc() {
                     return Poll::Ready(Err(e));
                 } else {
                     return Poll::Ready(Err(Error::Bus));
@@ -510,7 +510,7 @@ impl<'d, T: Instance> Twim<'d, T> {
 
     fn check_operations(&mut self, operations: &[Operation<'_>]) -> Result<(), Error> {
         compiler_fence(SeqCst);
-        self.check_errorsrc()?;
+        Self::check_errorsrc()?;
 
         assert!(operations.len() == 1 || operations.len() == 2);
         match operations {

--- a/embassy-nrf/src/twim.rs
+++ b/embassy-nrf/src/twim.rs
@@ -85,8 +85,6 @@ pub enum Error {
     Overrun,
     /// Timeout error.
     Timeout,
-    /// Bus error.
-    Bus,
 }
 
 /// Interrupt handler.
@@ -350,7 +348,7 @@ impl<'d, T: Instance> Twim<'d, T> {
                 if let Err(e) = Self::check_errorsrc() {
                     return Poll::Ready(Err(e));
                 } else {
-                    return Poll::Ready(Err(Error::Bus));
+                    panic!("Found events_error bit without an error in errorsrc reg");
                 }
             }
 
@@ -917,7 +915,6 @@ impl embedded_hal_1::i2c::Error for Error {
             }
             Self::Overrun => embedded_hal_1::i2c::ErrorKind::Overrun,
             Self::Timeout => embedded_hal_1::i2c::ErrorKind::Other,
-            Self::Bus => embedded_hal_1::i2c::ErrorKind::Other,
         }
     }
 }

--- a/embassy-nrf/src/twim.rs
+++ b/embassy-nrf/src/twim.rs
@@ -347,13 +347,8 @@ impl<'d, T: Instance> Twim<'d, T> {
             if r.events_error().read() != 0 {
                 r.events_error().write_value(0);
                 r.tasks_stop().write_value(1);
-                let errorsrc = r.errorsrc().read();
-                if errorsrc.overrun() {
-                    return Poll::Ready(Err(Error::Overrun));
-                } else if errorsrc.anack() {
-                    return Poll::Ready(Err(Error::AddressNack));
-                } else if errorsrc.dnack() {
-                    return Poll::Ready(Err(Error::DataNack));
+                if let Err(e) = self.check_errorsrc() {
+                    return Poll::Ready(Err(e));
                 } else {
                     return Poll::Ready(Err(Error::Bus));
                 }


### PR DESCRIPTION
Similar to twis.rs they is no reason as far I can tell to stay in async_wait when an error occurs.
This helped to recover from some bus interference I had without putting with_timeout everywhere.