### PR TITLE
Fix unsupported trace! call for EndpointAddress

### DIFF
--- a/embassy-stm32/src/usb/usb.rs
+++ b/embassy-stm32/src/usb/usb.rs
@@ -638,7 +638,7 @@ impl<'d, T: Instance> driver::Bus for Bus<'d, T> {
     }
 
     fn endpoint_set_enabled(&mut self, ep_addr: EndpointAddress, enabled: bool) {
-        trace!("set_enabled {:x} {}", ep_addr, enabled);
+        trace!("set_enabled {:?} {}", ep_addr, enabled);
         // This can race, so do a retry loop.
         let reg = T::regs().epr(ep_addr.index() as _);
         trace!("EPR before: {:04x}", reg.read().0);


### PR DESCRIPTION
Hi. For me embassy-stm32 does not compile for stm32f103 with log feature
It seems EndpointAddress does not implement LowerHex trait. I suggest simply replacing the call with debug.
Or I can create a PR with LowerHex and UpperHex implementations for EndpointAddress