### PR TITLE
stm32: impl Display for time::Hertz

### DIFF
--- a/embassy-stm32/src/time.rs
+++ b/embassy-stm32/src/time.rs
@@ -1,11 +1,18 @@
 //! Time units
 
+use core::fmt::Display;
 use core::ops::{Div, Mul};
 
 /// Hertz
 #[derive(Eq, PartialEq, Ord, PartialOrd, Clone, Copy, Debug)]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub struct Hertz(pub u32);
+
+impl Display for Hertz {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        write!(f, "{} Hz", self.0)
+    }
+}
 
 impl Hertz {
     /// Create a `Hertz` from the given hertz.


### PR DESCRIPTION
fixes #3587 
> can you send a PR adding the Display impl, and an entry to ci.sh so this doesn't break again inthe future?

how should ci.sh be modified?

