### PR TITLE
fix: enable RP2350 watchdog tick generator

### DIFF
--- a/embassy-rp/src/clocks.rs
+++ b/embassy-rp/src/clocks.rs
@@ -524,8 +524,13 @@ pub(crate) unsafe fn init(config: ClockConfig) {
     // Configure tick generator on the 2350
     #[cfg(feature = "_rp235x")]
     {
-        pac::TICKS.timer0_cycles().write(|w| w.0 = clk_ref_freq / 1_000_000);
+        let cycle_count = clk_ref_freq / 1_000_000;
+
+        pac::TICKS.timer0_cycles().write(|w| w.0 = cycle_count);
         pac::TICKS.timer0_ctrl().write(|w| w.set_enable(true));
+
+        pac::TICKS.watchdog_cycles().write(|w| w.0 = cycle_count);
+        pac::TICKS.watchdog_ctrl().write(|w| w.set_enable(true));
     }
 
     let (sys_src, sys_aux, clk_sys_freq) = {


### PR DESCRIPTION
In the RP2350 the watchdog tick generator was split from the main timer tick generator and now lives in the TICKS register block. Previously, embassy-rp enabled the TIMER0 tick generator but not the WATCHDOG tick generator. As a result the watchdog peripheral did not work as expected. This PR fixes this problem by enabling both tick generators inside the `init` function.

This also poses the more general question of whether the other tick generators should also be enabled during initialization.