### PR TITLE
doc: fix embassy-time doc

### DIFF
--- a/embassy-time/Cargo.toml
+++ b/embassy-time/Cargo.toml
@@ -51,7 +51,7 @@ mock-driver = ["tick-hz-1_000_000", "dep:embassy-time-queue-utils"]
 #! To enable it, enable any of the features below.
 #! 
 #! The features also set how many timers are used for the generic queue. At most one
-#! `generic-queue-*` feature can be enabled. If none is enabled, a default of 64 timers is used.
+#! `generic-queue-*` feature can be enabled. If none is enabled, `queue_integrated` is used.
 #!
 #! When using embassy-time from libraries, you should *not* enable any `generic-queue-*` feature, to allow the
 #! end user to pick.


### PR DESCRIPTION
Current doc says if there's If no `generic-queue-*` feature is enabled, a default of 64 timers is used. But according to:

https://github.com/embassy-rs/embassy/blob/169f9c27aa33a279aad51a92b52fc047a54b82af/embassy-time-queue-utils/src/lib.rs#L5-L13

the `queue_integrated::Queue` is used in this case. So the default 64 timers actually do nothing:

https://github.com/embassy-rs/embassy/blob/169f9c27aa33a279aad51a92b52fc047a54b82af/embassy-time-queue-utils/src/queue_generic.rs#L112-L119

