### PR TITLE
Full RCC support for STM32F107

### DIFF
--- a/embassy-stm32/build.rs
+++ b/embassy-stm32/build.rs
@@ -1383,7 +1383,7 @@ fn main() {
     for e in rcc_registers.ir.enums {
         fn is_rcc_name(e: &str) -> bool {
             match e {
-                "Pllp" | "Pllq" | "Pllr" | "Pllm" | "Plln" => true,
+                "Pllp" | "Pllq" | "Pllr" | "Pllm" | "Plln" | "Prediv1" | "Prediv2" => true,
                 "Timpre" | "Pllrclkpre" => false,
                 e if e.ends_with("pre") || e.ends_with("pres") || e.ends_with("div") || e.ends_with("mul") => true,
                 _ => false,


### PR DESCRIPTION
STM32F107 has a two more PLLs than F013, which means using `f013.rs` config options doesn't let us configure the entire RCC.

My use case is to use STM32F107 for ethernet with an external HSE. 

This PR adds a special case for F107 with a fuller RCC config.