### PR TITLE
stm32/can: fix wrong negation of fdcan set_transmit_pause function parameter

### DIFF
--- a/embassy-stm32/src/can/fd/peripheral.rs
+++ b/embassy-stm32/src/can/fd/peripheral.rs
@@ -458,7 +458,7 @@ impl Registers {
     /// [`FdCanConfig::set_transmit_pause`]
     #[inline]
     pub fn set_transmit_pause(&self, enabled: bool) {
-        self.regs.cccr().modify(|w| w.set_txp(!enabled));
+        self.regs.cccr().modify(|w| w.set_txp(enabled));
     }
 
     /// Configures non-iso mode. See [`FdCanConfig::set_non_iso_mode`]


### PR DESCRIPTION
I'm using dual-core STM32H747BI.

The issue is that this method simply wrongly negates its parameter. 

In RM0399, it's stated that TXP bit _enables_ pause. The function negates boolean argument, so `set_transmit_pause(false)` will inevitably enable pause.

RM0399, page 2679:
![CleanShot 2025-01-17 at 6  08 10@2x](https://github.com/user-attachments/assets/c39575c7-9a19-4692-befb-adf980251f82)