### PR TITLE
STM32: Option to detect Ethernet PHY address automatically

### DIFF
--- a/embassy-stm32/src/eth/generic_smi.rs
+++ b/embassy-stm32/src/eth/generic_smi.rs
@@ -3,7 +3,7 @@
 use core::task::Context;
 
 #[cfg(feature = "time")]
-use embassy_time::{Delay, Duration, Timer};
+use embassy_time::{Duration, Timer};
 #[cfg(feature = "time")]
 use futures_util::FutureExt;
 
@@ -52,20 +52,46 @@ pub struct GenericSMI {
 impl GenericSMI {
     /// Construct the PHY. It assumes the address `phy_addr` in the SMI communication
     ///
-    /// Set `phy_addr` to `0xFF` for automatic detection (only with `time` feature enabled)
+    /// # Panics
+    /// `phy_addr` must be in range `0..32`
     pub fn new(phy_addr: u8) -> Self {
+        assert!(phy_addr < 32);
         Self {
             phy_addr,
             #[cfg(feature = "time")]
             poll_interval: Duration::from_millis(500),
         }
     }
+
+    /// Construct the PHY. Try to probe all addresses from 0 to 31 during initialization
+    ///
+    /// # Panics
+    /// Initialization panics if PHY didn't respond on any address
+    pub fn new_auto() -> Self {
+        Self {
+            phy_addr: 0xFF,
+            #[cfg(feature = "time")]
+            poll_interval: Duration::from_millis(500),
+        }
+    }
+}
+
+// TODO: Factor out to shared functionality
+fn blocking_delay_us(us: u32) {
+    #[cfg(feature = "time")]
+    embassy_time::block_for(Duration::from_micros(us as u64));
+    #[cfg(not(feature = "time"))]
+    {
+        let freq = unsafe { crate::rcc::get_freqs() }.sys.to_hertz().unwrap().0 as u64;
+        let us = us as u64;
+        let cycles = freq * us / 1_000_000;
+        cortex_m::asm::delay(cycles as u32);
+    }
 }
 
 unsafe impl PHY for GenericSMI {
     fn phy_reset<S: StationManagement>(&mut self, sm: &mut S) {
         // Detect SMI address
-        #[cfg(feature = "time")]
         if self.phy_addr == 0xFF {
             for addr in 0..32 {
                 sm.smi_write(addr, PHY_REG_BCR, PHY_REG_BCR_RESET);
@@ -75,7 +101,8 @@ unsafe impl PHY for GenericSMI {
                         self.phy_addr = addr;
                         return;
                     }
-                    embedded_hal_1::delay::DelayNs::delay_us(&mut Delay, 1000);
+                    // Give PHY a total of 100ms to respond
+                    blocking_delay_us(10000);
                 }
             }
             panic!("PHY did not respond");

--- a/embassy-stm32/src/eth/generic_smi.rs
+++ b/embassy-stm32/src/eth/generic_smi.rs
@@ -3,7 +3,7 @@
 use core::task::Context;
 
 #[cfg(feature = "time")]
-use embassy_time::{Duration, Timer};
+use embassy_time::{Duration, Timer, Delay};
 #[cfg(feature = "time")]
 use futures_util::FutureExt;
 
@@ -52,7 +52,7 @@ pub struct GenericSMI {
 impl GenericSMI {
     /// Construct the PHY. It assumes the address `phy_addr` in the SMI communication
     ///
-    /// Set `phy_addr` to `0xFF` for automatic detection
+    /// Set `phy_addr` to `0xFF` for automatic detection (only with `time` feature enabled)
     pub fn new(phy_addr: u8) -> Self {
         Self {
             phy_addr,
@@ -65,6 +65,7 @@ impl GenericSMI {
 unsafe impl PHY for GenericSMI {
     fn phy_reset<S: StationManagement>(&mut self, sm: &mut S) {
         // Detect SMI address
+        #[cfg(feature = "time")]
         if self.phy_addr == 0xFF {
             for addr in 0..32 {
                 sm.smi_write(addr, PHY_REG_BCR, PHY_REG_BCR_RESET);
@@ -74,14 +75,15 @@ unsafe impl PHY for GenericSMI {
                         self.phy_addr = addr;
                         return;
                     }
-                    cortex_m::asm::delay(1000);
+                    embedded_hal_1::delay::DelayNs::delay_us(&mut Delay, 1000);
+                    cortex_m::asm::delay(1000000);
                 }
             }
             panic!("PHY did not respond");
-        } else {
-            sm.smi_write(self.phy_addr, PHY_REG_BCR, PHY_REG_BCR_RESET);
-            while sm.smi_read(self.phy_addr, PHY_REG_BCR) & PHY_REG_BCR_RESET == PHY_REG_BCR_RESET {}
         }
+        
+        sm.smi_write(self.phy_addr, PHY_REG_BCR, PHY_REG_BCR_RESET);
+        while sm.smi_read(self.phy_addr, PHY_REG_BCR) & PHY_REG_BCR_RESET == PHY_REG_BCR_RESET {}
     }
 
     fn phy_init<S: StationManagement>(&mut self, sm: &mut S) {

--- a/embassy-stm32/src/eth/generic_smi.rs
+++ b/embassy-stm32/src/eth/generic_smi.rs
@@ -3,7 +3,7 @@
 use core::task::Context;
 
 #[cfg(feature = "time")]
-use embassy_time::{Duration, Timer, Delay};
+use embassy_time::{Delay, Duration, Timer};
 #[cfg(feature = "time")]
 use futures_util::FutureExt;
 
@@ -80,7 +80,7 @@ unsafe impl PHY for GenericSMI {
             }
             panic!("PHY did not respond");
         }
-        
+
         sm.smi_write(self.phy_addr, PHY_REG_BCR, PHY_REG_BCR_RESET);
         while sm.smi_read(self.phy_addr, PHY_REG_BCR) & PHY_REG_BCR_RESET == PHY_REG_BCR_RESET {}
     }

--- a/embassy-stm32/src/eth/generic_smi.rs
+++ b/embassy-stm32/src/eth/generic_smi.rs
@@ -76,7 +76,6 @@ unsafe impl PHY for GenericSMI {
                         return;
                     }
                     embedded_hal_1::delay::DelayNs::delay_us(&mut Delay, 1000);
-                    cortex_m::asm::delay(1000000);
                 }
             }
             panic!("PHY did not respond");

--- a/examples/stm32f4/src/bin/eth.rs
+++ b/examples/stm32f4/src/bin/eth.rs
@@ -76,7 +76,7 @@ async fn main(spawner: Spawner) -> ! {
         p.PG13,
         p.PB13,
         p.PG11,
-        GenericSMI::new(0),
+        GenericSMI::new_auto(),
         mac_addr,
     );
 

--- a/examples/stm32f7/src/bin/eth.rs
+++ b/examples/stm32f7/src/bin/eth.rs
@@ -77,7 +77,7 @@ async fn main(spawner: Spawner) -> ! {
         p.PG13,
         p.PB13,
         p.PG11,
-        GenericSMI::new(0),
+        GenericSMI::new_auto(),
         mac_addr,
     );
 

--- a/examples/stm32h5/src/bin/eth.rs
+++ b/examples/stm32h5/src/bin/eth.rs
@@ -80,7 +80,7 @@ async fn main(spawner: Spawner) -> ! {
         p.PG13,
         p.PB15,
         p.PG11,
-        GenericSMI::new(0),
+        GenericSMI::new_auto(),
         mac_addr,
     );
 

--- a/examples/stm32h7/src/bin/eth.rs
+++ b/examples/stm32h7/src/bin/eth.rs
@@ -79,7 +79,7 @@ async fn main(spawner: Spawner) -> ! {
         p.PG13, // TX_D0: Transmit Bit 0
         p.PB13, // TX_D1: Transmit Bit 1
         p.PG11, // TX_EN: Transmit Enable
-        GenericSMI::new(0),
+        GenericSMI::new_auto(),
         mac_addr,
     );
 

--- a/examples/stm32h7/src/bin/eth_client.rs
+++ b/examples/stm32h7/src/bin/eth_client.rs
@@ -81,7 +81,7 @@ async fn main(spawner: Spawner) -> ! {
         p.PG13,
         p.PB13,
         p.PG11,
-        GenericSMI::new(0),
+        GenericSMI::new_auto(),
         mac_addr,
     );
 

--- a/examples/stm32h7/src/bin/eth_client_mii.rs
+++ b/examples/stm32h7/src/bin/eth_client_mii.rs
@@ -86,7 +86,7 @@ async fn main(spawner: Spawner) -> ! {
         p.PC2,
         p.PE2,
         p.PG11,
-        GenericSMI::new(1),
+        GenericSMI::new_auto(),
         mac_addr,
     );
     info!("Device created");

--- a/tests/stm32/src/bin/eth.rs
+++ b/tests/stm32/src/bin/eth.rs
@@ -87,7 +87,7 @@ async fn main(spawner: Spawner) {
         #[cfg(feature = "stm32h563zi")]
         p.PB15,
         p.PG11,
-        GenericSMI::new(0),
+        GenericSMI::new_auto(),
         mac_addr,
     );
 


### PR DESCRIPTION
Currently `GenericSMI` can't detect ethernet PHY address and will stuck in eternal loop if address is incorrect. This PR adds automatic detection by probing all addresses from 0 to 31 with fixed attempt count and delay. Automatic detection enabled if `GenericSMI` was created with address `0xFF` 