### PR TITLE
embassy-sync: fix clear() to wake senders

### DIFF
--- a/embassy-sync/src/channel.rs
+++ b/embassy-sync/src/channel.rs
@@ -562,6 +562,9 @@ impl<T, const N: usize> ChannelState<T, N> {
     }
 
     fn clear(&mut self) {
+        if self.queue.is_full() {
+            self.senders_waker.wake();
+        }
         self.queue.clear();
     }
 

--- a/embassy-sync/src/priority_channel.rs
+++ b/embassy-sync/src/priority_channel.rs
@@ -411,6 +411,9 @@ where
     }
 
     fn clear(&mut self) {
+        if self.queue.len() == self.queue.capacity() {
+            self.senders_waker.wake();
+        }
         self.queue.clear();
     }
 

--- a/embassy-sync/src/pubsub/mod.rs
+++ b/embassy-sync/src/pubsub/mod.rs
@@ -421,6 +421,9 @@ impl<T: Clone, const CAP: usize, const SUBS: usize, const PUBS: usize> PubSubSta
     }
 
     fn clear(&mut self) {
+        if self.is_full() {
+            self.publisher_wakers.wake();
+        }
         self.queue.clear();
     }
 

--- a/embassy-sync/src/zerocopy_channel.rs
+++ b/embassy-sync/src/zerocopy_channel.rs
@@ -287,6 +287,9 @@ impl State {
     }
 
     fn clear(&mut self) {
+        if self.full {
+            self.receive_waker.wake();
+        }
         self.front = 0;
         self.back = 0;
         self.full = false;


### PR DESCRIPTION
Calling clear() on `Channel`, `PriorityChannel`, `PubSub`, `zerocopy_channel::Channel` should wake the wakers of senders, as receive() do.