### PR TITLE
Set embassy-rp target in docs-rs metadata

### DIFF
--- a/embassy-rp/Cargo.toml
+++ b/embassy-rp/Cargo.toml
@@ -20,7 +20,9 @@ flavors = [
 ]
 
 [package.metadata.docs.rs]
-features = ["defmt", "unstable-pac", "time-driver"]
+# TODO: it's not GREAT to set a specific target, but docs.rs builds will fail otherwise
+# for now, default to rp2040
+features = ["defmt", "unstable-pac", "time-driver", "rp2040"]
 
 [features]
 default = [ "rt" ]


### PR DESCRIPTION
Avoid docs.rs build failures like https://docs.rs/crate/embassy-rp/0.3.0/builds/1609962