### PR TITLE
remove checks for reserved I2c addresses

### DIFF
--- a/embassy-rp/src/i2c_slave.rs
+++ b/embassy-rp/src/i2c_slave.rs
@@ -6,9 +6,7 @@ use core::task::Poll;
 use embassy_hal_internal::into_ref;
 use pac::i2c;
 
-use crate::i2c::{
-    i2c_reserved_addr, set_up_i2c_pin, AbortReason, Instance, InterruptHandler, SclPin, SdaPin, FIFO_SIZE,
-};
+use crate::i2c::{set_up_i2c_pin, AbortReason, Instance, InterruptHandler, SclPin, SdaPin, FIFO_SIZE};
 use crate::interrupt::typelevel::{Binding, Interrupt};
 use crate::{pac, Peripheral};
 
@@ -97,7 +95,6 @@ impl<'d, T: Instance> I2cSlave<'d, T> {
     ) -> Self {
         into_ref!(_peri, scl, sda);
 
-        assert!(!i2c_reserved_addr(config.addr));
         assert!(config.addr != 0);
 
         // Configure SCL & SDA pins


### PR DESCRIPTION
There are some non-compliant devices that respond to reserved I2c addresses. rp2040 behaves sanely for these addresses, so let's just allow using them.

Closes #3809