### PR TITLE
Allow stm32 H7 and L5 families to use external SAI sync & allow recovering after dropping a DMA channel

### DIFF
--- a/embassy-stm32/src/dma/dma_bdma.rs
+++ b/embassy-stm32/src/dma/dma_bdma.rs
@@ -359,11 +359,13 @@ impl AnyChannel {
         match self.info().dma {
             #[cfg(dma)]
             DmaInfo::Dma(r) => {
+                let state: &ChannelState = &STATE[self.id as usize];
                 let ch = r.st(info.num);
 
                 // "Preceding reads and writes cannot be moved past subsequent writes."
                 fence(Ordering::SeqCst);
 
+                state.complete_count.store(0, Ordering::Release);
                 self.clear_irqs();
 
                 ch.par().write_value(peri_addr as u32);

--- a/embassy-stm32/src/sai/mod.rs
+++ b/embassy-stm32/src/sai/mod.rs
@@ -190,7 +190,7 @@ pub enum SyncInput {
     /// Syncs with the other A/B sub-block within the SAI unit
     Internal,
     /// Syncs with a sub-block in the other SAI unit
-    #[cfg(any(sai_v4_2pdm, sai_v4_4pdm))]
+    #[cfg(any(sai_v3_2pdm, sai_v3_4pdm, sai_v4_2pdm, sai_v4_4pdm))]
     External(SyncInputInstance),
 }
 
@@ -199,14 +199,14 @@ impl SyncInput {
         match self {
             SyncInput::None => vals::Syncen::ASYNCHRONOUS,
             SyncInput::Internal => vals::Syncen::INTERNAL,
-            #[cfg(any(sai_v4_2pdm, sai_v4_4pdm))]
+            #[cfg(any(sai_v3_2pdm, sai_v3_4pdm, sai_v4_2pdm, sai_v4_4pdm))]
             SyncInput::External(_) => vals::Syncen::EXTERNAL,
         }
     }
 }
 
 /// SAI instance to sync from.
-#[cfg(any(sai_v4_2pdm, sai_v4_4pdm))]
+#[cfg(any(sai_v3_2pdm, sai_v3_4pdm, sai_v4_2pdm, sai_v4_4pdm))]
 #[derive(Copy, Clone, PartialEq)]
 #[allow(missing_docs)]
 pub enum SyncInputInstance {
@@ -704,12 +704,12 @@ fn update_synchronous_config(config: &mut Config) {
     config.mode = Mode::Slave;
     config.sync_output = false;
 
-    #[cfg(any(sai_v1, sai_v2, sai_v3_2pdm, sai_v3_4pdm))]
+    #[cfg(any(sai_v1, sai_v2))]
     {
         config.sync_input = SyncInput::Internal;
     }
 
-    #[cfg(any(sai_v4_2pdm, sai_v4_4pdm))]
+    #[cfg(any(sai_v3_2pdm, sai_v3_4pdm, sai_v4_2pdm, sai_v4_4pdm))]
     {
         //this must either be Internal or External
         //The asynchronous sub-block on the same SAI needs to enable sync_output
@@ -870,7 +870,7 @@ impl<'d, T: Instance, W: word::Word> Sai<'d, T, W> {
 
         ch.cr2().modify(|w| w.set_fflush(true));
 
-        #[cfg(any(sai_v4_2pdm, sai_v4_4pdm))]
+        #[cfg(any(sai_v3_2pdm, sai_v3_4pdm, sai_v4_2pdm, sai_v4_4pdm))]
         {
             if let SyncInput::External(i) = config.sync_input {
                 T::REGS.gcr().modify(|w| {


### PR DESCRIPTION
In [sai/mod.rs](../blob/main/embassy-stm32/src/sai/mod.rs), modified `sai_v3_2pdm` and `sai_v3_4pdm` placement in the `#cfg[...]` conditional compilation statements to allow the corresponding L5 and H7 stm32 chips to use external SAI sync, as stated available in the ST reference manuals.

In [dma_bdma.rs](../blob/main/embassy-stm32/src/dma/dma_bdma.rs), added code to reset the complete_count variable defined in the global channel `STATE` defined in [dma/mod.rs](../blob/main/embassy-stm32/src/dma/mod.rs). For some reason re-creating a BDMA channel resets its global state, but re-creating a DMA channel does not, making BDMA peripherals like SAI4 recoverable after dropping their `Sai<'_, SAI4, W>` instance (like in #3205), but not DMA peripherals like SAI1 for example. One consequence of this is `Sai<'_, SAI1, W>` `Sai<'_, SAI2, W>` and `Sai<'_, SAI3, W>` peripherals are stuck in `Overrun` even after dropping and re-creating them.