### PR TITLE
STM32 SPI: update SCK pin "af" config

### DIFF
--- a/embassy-stm32/src/gpio.rs
+++ b/embassy-stm32/src/gpio.rs
@@ -589,8 +589,8 @@ impl AfType {
 
 #[inline(never)]
 #[cfg(gpio_v1)]
-fn set_as_af(pin_port: u8, _af_num: u8, af_type: AfType) {
-    let pin = unsafe { AnyPin::steal(pin_port) };
+fn set_as_af(pin_port: u8, af_num: u8, af_type: AfType) {
+    let pin = unsafe { AnyPin::steal(pin_port, Some(af_num)) };
     let r = pin.block();
     let n = pin._pin() as usize;
 
@@ -647,7 +647,7 @@ impl AfType {
 #[inline(never)]
 #[cfg(gpio_v2)]
 fn set_as_af(pin_port: u8, af_num: u8, af_type: AfType) {
-    let pin = unsafe { AnyPin::steal(pin_port) };
+    let pin = unsafe { AnyPin::steal(pin_port, Some(af_num)) };
     let r = pin.block();
     let n = pin._pin() as usize;
 
@@ -661,7 +661,7 @@ fn set_as_af(pin_port: u8, af_num: u8, af_type: AfType) {
 #[inline(never)]
 #[cfg(gpio_v2)]
 fn set_speed(pin_port: u8, speed: Speed) {
-    let pin = unsafe { AnyPin::steal(pin_port) };
+    let pin = unsafe { AnyPin::steal(pin_port, None) };
     let r = pin.block();
     let n = pin._pin() as usize;
 
@@ -670,7 +670,7 @@ fn set_speed(pin_port: u8, speed: Speed) {
 
 #[inline(never)]
 fn set_as_analog(pin_port: u8) {
-    let pin = unsafe { AnyPin::steal(pin_port) };
+    let pin = unsafe { AnyPin::steal(pin_port, None) };
     let r = pin.block();
     let n = pin._pin() as usize;
 
@@ -686,7 +686,7 @@ fn set_as_analog(pin_port: u8) {
 
 #[inline(never)]
 fn get_pull(pin_port: u8) -> Pull {
-    let pin = unsafe { AnyPin::steal(pin_port) };
+    let pin = unsafe { AnyPin::steal(pin_port, None) };
     let r = pin.block();
     let n = pin._pin() as usize;
 
@@ -713,6 +713,8 @@ fn get_pull(pin_port: u8) -> Pull {
 
 pub(crate) trait SealedPin {
     fn pin_port(&self) -> u8;
+
+    fn pin_af_num(&self) -> Option<u8>;
 
     #[inline]
     fn _pin(&self) -> u8 {
@@ -808,6 +810,7 @@ pub trait Pin: Peripheral<P = Self> + Into<AnyPin> + SealedPin + Sized + 'static
     fn degrade(self) -> AnyPin {
         AnyPin {
             pin_port: self.pin_port(),
+            pin_af_num: self.pin_af_num(),
         }
     }
 }
@@ -815,6 +818,7 @@ pub trait Pin: Peripheral<P = Self> + Into<AnyPin> + SealedPin + Sized + 'static
 /// Type-erased GPIO pin
 pub struct AnyPin {
     pin_port: u8,
+    pin_af_num: Option<u8>,
 }
 
 impl AnyPin {
@@ -822,8 +826,11 @@ impl AnyPin {
     ///
     /// `pin_port` is `port_num * 16 + pin_num`, where `port_num` is 0 for port `A`, 1 for port `B`, etc...
     #[inline]
-    pub unsafe fn steal(pin_port: u8) -> Self {
-        Self { pin_port }
+    pub unsafe fn steal(pin_port: u8, af_num: Option<u8>) -> Self {
+        Self {
+            pin_port,
+            pin_af_num: af_num,
+        }
     }
 
     #[inline]
@@ -849,6 +856,11 @@ impl SealedPin for AnyPin {
     fn pin_port(&self) -> u8 {
         self.pin_port
     }
+
+    #[inline]
+    fn pin_af_num(&self) -> Option<u8> {
+        self.pin_af_num
+    }
 }
 
 // ====================
@@ -863,6 +875,11 @@ foreach_pin!(
             #[inline]
             fn pin_port(&self) -> u8 {
                 $port_num * 16 + $pin_num
+            }
+
+            #[inline]
+            fn pin_af_num(&self) -> Option<u8> {
+                None
             }
         }
 

--- a/embassy-stm32/src/spi/mod.rs
+++ b/embassy-stm32/src/spi/mod.rs
@@ -254,6 +254,10 @@ impl<'d, M: PeriMode> Spi<'d, M> {
             self.rise_fall_speed = config.rise_fall_speed;
             if let Some(sck) = self.sck.as_ref() {
                 sck.set_speed(config.rise_fall_speed);
+
+                if let Some(af_num) = sck.pin_af_num() {
+                    sck.set_as_af(af_num, config.sck_af());
+                }
             }
             if let Some(mosi) = self.mosi.as_ref() {
                 mosi.set_speed(config.rise_fall_speed);

--- a/embassy-stm32/src/spi/mod.rs
+++ b/embassy-stm32/src/spi/mod.rs
@@ -111,11 +111,28 @@ impl Config {
         )
     }
 }
+
+struct SckPinRef<'d> {
+    pin: PeripheralRef<'d, AnyPin>,
+    _af_num: u8,
+}
+
+impl<'d> SckPinRef<'d> {
+    pub fn new<T: Instance>(sck: impl Peripheral<P = impl SckPin<T>> + 'd, config: &Config) -> Self {
+        let pin_ref = sck.into_ref();
+        let af_num = pin_ref.af_num();
+        pin_ref.set_as_af(af_num, config.sck_af());
+        let pin = pin_ref.map_into();
+
+        Self { pin, _af_num: af_num }
+    }
+}
+
 /// SPI driver.
 pub struct Spi<'d, M: PeriMode> {
     pub(crate) info: &'static Info,
     kernel_clock: Hertz,
-    sck: Option<PeripheralRef<'d, AnyPin>>,
+    sck: Option<SckPinRef<'d>>,
     mosi: Option<PeripheralRef<'d, AnyPin>>,
     miso: Option<PeripheralRef<'d, AnyPin>>,
     tx_dma: Option<ChannelAndRequest<'d>>,
@@ -128,7 +145,7 @@ pub struct Spi<'d, M: PeriMode> {
 impl<'d, M: PeriMode> Spi<'d, M> {
     fn new_inner<T: Instance>(
         _peri: impl Peripheral<P = T> + 'd,
-        sck: Option<PeripheralRef<'d, AnyPin>>,
+        sck: Option<SckPinRef<'d>>,
         mosi: Option<PeripheralRef<'d, AnyPin>>,
         miso: Option<PeripheralRef<'d, AnyPin>>,
         tx_dma: Option<ChannelAndRequest<'d>>,
@@ -253,11 +270,8 @@ impl<'d, M: PeriMode> Spi<'d, M> {
         {
             self.rise_fall_speed = config.rise_fall_speed;
             if let Some(sck) = self.sck.as_ref() {
-                sck.set_speed(config.rise_fall_speed);
-
-                if let Some(af_num) = sck.pin_af_num() {
-                    sck.set_as_af(af_num, config.sck_af());
-                }
+                sck.pin.set_speed(config.rise_fall_speed);
+                sck.pin.set_as_af(sck._af_num, config.sck_af());
             }
             if let Some(mosi) = self.mosi.as_ref() {
                 mosi.set_speed(config.rise_fall_speed);
@@ -462,7 +476,7 @@ impl<'d> Spi<'d, Blocking> {
     ) -> Self {
         Self::new_inner(
             peri,
-            new_pin!(sck, config.sck_af()),
+            Some(SckPinRef::new(sck, &config)),
             new_pin!(mosi, AfType::output(OutputType::PushPull, config.rise_fall_speed)),
             new_pin!(miso, AfType::input(config.miso_pull)),
             None,
@@ -480,7 +494,7 @@ impl<'d> Spi<'d, Blocking> {
     ) -> Self {
         Self::new_inner(
             peri,
-            new_pin!(sck, config.sck_af()),
+            Some(SckPinRef::new(sck, &config)),
             None,
             new_pin!(miso, AfType::input(config.miso_pull)),
             None,
@@ -498,7 +512,7 @@ impl<'d> Spi<'d, Blocking> {
     ) -> Self {
         Self::new_inner(
             peri,
-            new_pin!(sck, config.sck_af()),
+            Some(SckPinRef::new(sck, &config)),
             new_pin!(mosi, AfType::output(OutputType::PushPull, config.rise_fall_speed)),
             None,
             None,
@@ -540,7 +554,7 @@ impl<'d> Spi<'d, Async> {
     ) -> Self {
         Self::new_inner(
             peri,
-            new_pin!(sck, config.sck_af()),
+            Some(SckPinRef::new(sck, &config)),
             new_pin!(mosi, AfType::output(OutputType::PushPull, config.rise_fall_speed)),
             new_pin!(miso, AfType::input(config.miso_pull)),
             new_dma!(tx_dma),
@@ -560,7 +574,7 @@ impl<'d> Spi<'d, Async> {
     ) -> Self {
         Self::new_inner(
             peri,
-            new_pin!(sck, config.sck_af()),
+            Some(SckPinRef::new(sck, &config)),
             None,
             new_pin!(miso, AfType::input(config.miso_pull)),
             #[cfg(any(spi_v1, spi_f1, spi_v2))]
@@ -582,7 +596,7 @@ impl<'d> Spi<'d, Async> {
     ) -> Self {
         Self::new_inner(
             peri,
-            new_pin!(sck, config.sck_af()),
+            Some(SckPinRef::new(sck, &config)),
             new_pin!(mosi, AfType::output(OutputType::PushPull, config.rise_fall_speed)),
             None,
             new_dma!(tx_dma),
@@ -872,7 +886,7 @@ impl<'d> Spi<'d, Async> {
 
 impl<'d, M: PeriMode> Drop for Spi<'d, M> {
     fn drop(&mut self) {
-        self.sck.as_ref().map(|x| x.set_as_disconnected());
+        self.sck.as_ref().map(|x| x.pin.set_as_disconnected());
         self.mosi.as_ref().map(|x| x.set_as_disconnected());
         self.miso.as_ref().map(|x| x.set_as_disconnected());
 


### PR DESCRIPTION
This PR fixes SPI's `set_config` so that it also updates the alternate pin settings of the SCK pin. This is required to properly update the "pull" polarity on the SCK pin after a config change.