### PR TITLE
Correct ADC channels for RP235XB

### DIFF
--- a/embassy-rp/src/adc.rs
+++ b/embassy-rp/src/adc.rs
@@ -58,11 +58,21 @@ impl<'p> Channel<'p> {
     }
 
     fn channel(&self) -> u8 {
+        #[cfg(any(feature = "rp2040", feature = "rp235xa"))]
+        const CH_OFFSET: u8 = 26;
+        #[cfg(feature = "rp235xb")]
+        const CH_OFFSET: u8 = 40;
+
+        #[cfg(any(feature = "rp2040", feature = "rp235xa"))]
+        const TS_CHAN: u8 = 4;
+        #[cfg(feature = "rp235xb")]
+        const TS_CHAN: u8 = 8;
+
         match &self.0 {
             // this requires adc pins to be sequential and matching the adc channels,
-            // which is the case for rp2040
-            Source::Pin(p) => p._pin() - 26,
-            Source::TempSensor(_) => 4,
+            // which is the case for rp2040/rp235xy
+            Source::Pin(p) => p._pin() - CH_OFFSET,
+            Source::TempSensor(_) => TS_CHAN,
         }
     }
 }


### PR DESCRIPTION
The ADC channel offset and temperature sensor channel were only correct for RP2040 and RP235XA, this PR makes them also correct for RP235XB.

Based on [this table in the RP2350 datasheet](https://datasheets.raspberrypi.com/rp2350/rp2350-datasheet.pdf#%5B%7B%22num%22%3A1067%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C115%2C742.498%2Cnull%5D).