### PR TITLE
Add cancel safety notes to Ticker

### DIFF
--- a/embassy-time/src/timer.rs
+++ b/embassy-time/src/timer.rs
@@ -200,6 +200,10 @@ impl Future for Timer {
 ///     }
 /// }
 /// ```
+///
+/// ## Cancel safety
+/// It is safe to cancel waiting for the next tick,
+/// meaning no tick is lost if the Future is dropped.
 pub struct Ticker {
     expires_at: Instant,
     duration: Duration,
@@ -231,6 +235,9 @@ impl Ticker {
     }
 
     /// Waits for the next tick.
+    ///
+    /// ## Cancel safety
+    /// The produced Future is cancel safe, meaning no tick is lost if the Future is dropped.
     pub fn next(&mut self) -> impl Future<Output = ()> + Send + Sync + '_ {
         poll_fn(|cx| {
             if self.expires_at <= Instant::now() {


### PR DESCRIPTION
This just adds a section about cancel safety to the embassy-time Ticker struct and the corresponding method to get a Future for the next tick. 

When looking at the source its quite clear that the Ticker is cancel safe, but it would be nice to have a note in the docs, so people don't have to think about it.