### PR TITLE
set PLLI2S M and SRC for f4 chips which support it

### DIFF
--- a/embassy-stm32/src/rcc/f247.rs
+++ b/embassy-stm32/src/rcc/f247.rs
@@ -414,6 +414,11 @@ fn init_pll(instance: PllInstance, config: Option<Pll>, input: &PllInput) -> Pll
         }),
         #[cfg(any(all(stm32f4, not(stm32f410)), stm32f7))]
         PllInstance::Plli2s => RCC.plli2scfgr().write(|w| {
+            #[cfg(any(stm32f411, stm32f412, stm32f413, stm32f446))]
+            w.set_pllm(pll.prediv);
+            #[cfg(any(stm32f412, stm32f413))]
+            w.set_pllsrc(input.source);
+
             write_fields!(w);
         }),
         #[cfg(stm32f2)]

--- a/embassy-stm32/src/rcc/f247.rs
+++ b/embassy-stm32/src/rcc/f247.rs
@@ -414,9 +414,9 @@ fn init_pll(instance: PllInstance, config: Option<Pll>, input: &PllInput) -> Pll
         }),
         #[cfg(any(all(stm32f4, not(stm32f410)), stm32f7))]
         PllInstance::Plli2s => RCC.plli2scfgr().write(|w| {
-            #[cfg(any(stm32f411, stm32f412, stm32f413, stm32f446))]
+            #[cfg(any(stm32f411, stm32f412, stm32f413, stm32f423, stm32f446))]
             w.set_pllm(pll.prediv);
-            #[cfg(any(stm32f412, stm32f413))]
+            #[cfg(any(stm32f412, stm32f413, stm32f423))]
             w.set_pllsrc(input.source);
 
             write_fields!(w);


### PR DESCRIPTION
A `TODO` in embassy-stm32/src/rcc/f247.rs notes the need to support PLLM and plli2s_src for f4 chips which support them; this commit aims to rectify that, though there may be more that must be done (e.g., I'm not sure if this applies only to f4 chips or extends to f7, etc.). See #3681.