### PR TITLE
Allow inlining on time driver boundary

### DIFF
--- a/embassy-time-driver/src/lib.rs
+++ b/embassy-time-driver/src/lib.rs
@@ -139,11 +139,13 @@ extern "Rust" {
 }
 
 /// See [`Driver::now`]
+#[inline]
 pub fn now() -> u64 {
     unsafe { _embassy_time_now() }
 }
 
 /// Schedule the given waker to be woken at `at`.
+#[inline]
 pub fn schedule_wake(at: u64, waker: &Waker) {
     unsafe { _embassy_time_schedule_wake(at, waker) }
 }
@@ -157,11 +159,13 @@ macro_rules! time_driver_impl {
         static $name: $t = $val;
 
         #[no_mangle]
+        #[inline]
         fn _embassy_time_now() -> u64 {
             <$t as $crate::Driver>::now(&$name)
         }
 
         #[no_mangle]
+        #[inline]
         fn _embassy_time_schedule_wake(at: u64, waker: &core::task::Waker) {
             <$t as $crate::Driver>::schedule_wake(&$name, at, waker);
         }

--- a/embassy-time/src/instant.rs
+++ b/embassy-time/src/instant.rs
@@ -17,6 +17,7 @@ impl Instant {
     pub const MAX: Instant = Instant { ticks: u64::MAX };
 
     /// Returns an Instant representing the current time.
+    #[inline]
     pub fn now() -> Instant {
         Instant {
             ticks: embassy_time_driver::now(),


### PR DESCRIPTION
A bit of ghidra-browsing revealed that embassy_time_driver::now is not always inlined, if ever - calling `embassy_time::Instant::now()` got compiled to 3 different calls in my application until it reached my implementation.