### PR TITLE
embassy-usb: fix `core::intrinsics` deprecate warning in nightly.

### DIFF
--- a/embassy-usb/src/class/cdc_ncm/mod.rs
+++ b/embassy-usb/src/class/cdc_ncm/mod.rs
@@ -14,9 +14,8 @@
 //!   This is due to regex spaghetti: <https://android.googlesource.com/platform/frameworks/base/+/refs/tags/android-mainline-12.0.0_r84/core/res/res/values/config.xml#417>
 //!   and this nonsense in the linux kernel: <https://github.com/torvalds/linux/blob/c00c5e1d157bec0ef0b0b59aa5482eb8dc7e8e49/drivers/net/usb/usbnet.c#L1751-L1757>
 
-use core::intrinsics::copy_nonoverlapping;
 use core::mem::{size_of, MaybeUninit};
-use core::ptr::addr_of;
+use core::ptr::{addr_of, copy_nonoverlapping};
 
 use crate::control::{self, InResponse, OutResponse, Recipient, Request, RequestType};
 use crate::driver::{Driver, Endpoint, EndpointError, EndpointIn, EndpointOut};


### PR DESCRIPTION
It seems changed in Rust https://github.com/rust-lang/rust/pull/135003.
The compiler suggest to use `core::mem::copy_nonoverlapping`.
But that seems not exists so I used `core::ptr::copy_nonoverlapping` which is used in other parts in Embassy.

Replaced `core::intrinsics::copy_nonoverlapping` with the `core::ptr::copy_nonoverlapping`.

This fixed this warning.

```
   Compiling embassy-usb v0.4.0 (embassy/embassy-usb)
warning: use of deprecated module `core::intrinsics`: import this function via `std::mem` instead
  --> embassy/embassy-usb/src/class/cdc_ncm/mod.rs:17:23
   |
17 | use core::intrinsics::copy_nonoverlapping;
   |                       ^^^^^^^^^^^^^^^^^^^
```
