### PR TITLE
STM32 SDMMC multiple block read/write support

### DIFF
--- a/tests/stm32/src/bin/sdmmc.rs
+++ b/tests/stm32/src/bin/sdmmc.rs
@@ -34,8 +34,10 @@ async fn main(_spawner: Spawner) {
         pattern1[i] = i as u8;
         pattern2[i] = !i as u8;
     }
+    let patterns = [pattern1.clone(), pattern2.clone()];
 
     let mut block = DataBlock([0u8; 512]);
+    let mut blocks = [DataBlock([0u8; 512]), DataBlock([0u8; 512])];
 
     // ======== Try 4bit. ==============
     info!("initializing in 4-bit mode...");
@@ -84,6 +86,13 @@ async fn main(_spawner: Spawner) {
     s.read_block(block_idx, &mut block).await.unwrap();
     assert_eq!(block, pattern2);
 
+    info!("writing blocks [pattern1, pattern2]...");
+    s.write_blocks(block_idx, &patterns).await.unwrap();
+
+    info!("reading blocks...");
+    s.read_blocks(block_idx, &mut blocks).await.unwrap();
+    assert_eq!(&blocks, &patterns);
+
     drop(s);
 
     // ======== Try 1bit. ==============
@@ -116,9 +125,9 @@ async fn main(_spawner: Spawner) {
     info!("Card: {:#?}", Debug2Format(card));
     info!("Clock: {}", s.clock());
 
-    info!("reading pattern2 written in 4bit mode...");
+    info!("reading pattern1 written in 4bit mode...");
     s.read_block(block_idx, &mut block).await.unwrap();
-    assert_eq!(block, pattern2);
+    assert_eq!(block, pattern1);
 
     info!("writing pattern1...");
     s.write_block(block_idx, &pattern1).await.unwrap();
@@ -133,6 +142,13 @@ async fn main(_spawner: Spawner) {
     info!("reading...");
     s.read_block(block_idx, &mut block).await.unwrap();
     assert_eq!(block, pattern2);
+
+    info!("writing blocks [pattern1, pattern2]...");
+    s.write_blocks(block_idx, &patterns).await.unwrap();
+
+    info!("reading blocks...");
+    s.read_blocks(block_idx, &mut blocks).await.unwrap();
+    assert_eq!(&blocks, &patterns);
 
     drop(s);
 


### PR DESCRIPTION
Hello, I have added multiple block read and write support for the STM32 SDMMC peripheral.

This essentially adds CMD18 (multiple block read), CMD25 (multiple block write) and CMD12 (stop transmission) and sets the transfer up correctly.

I've tested this on SDMMCv2 devices.

I've also updated the `block_device_driver` implementation so it now supports multiple block read/writes. I also believe there is a preexisting issue that the `block_address` does not take into consideration the partition start offset, but I'll wait for confirmation from someone before modifying that.

Please let me know what you think as this PR greatly improves the read/write speeds, I would love to see it merged asap.

Kind regards