### PR TITLE
SpiDevice cancel safety: always set CS pin to high on drop

### DIFF
--- a/embassy-embedded-hal/Cargo.toml
+++ b/embassy-embedded-hal/Cargo.toml
@@ -22,6 +22,7 @@ time = ["dep:embassy-time"]
 default = ["time"]
 
 [dependencies]
+embassy-hal-internal = { version = "0.2.0", path = "../embassy-hal-internal" }
 embassy-futures = { version = "0.1.0", path = "../embassy-futures" }
 embassy-sync = { version = "0.6.2", path = "../embassy-sync" }
 embassy-time = { version = "0.4.0", path = "../embassy-time", optional = true }


### PR DESCRIPTION
Currently, if a transfer is dropped, the CS will stay in a low state, which seems to be undesired. This uses `OnDrop` to guarantee that CS will be high regardless what happens.

Note that it is currently still unsafe, at least for STM32, to drop an on-going SPI transfer. More investigation on this is TBD. Some suggestions on this would be nice, e.g., whether it's desired to implement cancel safety for SPI transfers.