### PR TITLE
Disable clippy error around generated main function

### DIFF
--- a/embassy-executor-macros/src/macros/main.rs
+++ b/embassy-executor-macros/src/macros/main.rs
@@ -161,6 +161,7 @@ pub fn run(args: TokenStream, item: TokenStream, arch: &Arch) -> TokenStream {
 
     let result = quote! {
         #[::embassy_executor::task()]
+        #[allow(clippy::future_not_send)]
         async fn __embassy_main(#fargs) #out {
             #f_body
         }


### PR DESCRIPTION
The current implementation of `embassy_executor::main` and generated code causes `clippy` to complain even when using an empty function (for demonstration purposes).
<img width="1093" alt="image" src="https://github.com/user-attachments/assets/df042118-1a23-45b4-b7ad-c2c4e9d65a54" />

```
error: future cannot be sent between threads safely
  --> src/main.rs:22:1
   |
22 | #[embassy_executor::main]
   | ^^^^^^^^^^^^^^^^^^^^^^^^^ future returned by `____embassy_main_task` is not `Send`
   |
note: captured value is not `Send`
  --> src/main.rs:23:15
   |
23 | async fn main(_spawner: Spawner) {}
   |               ^^^^^^^^ has type `embassy_executor::Spawner` which is not `Send`
   = note: `*mut ()` doesn't implement `core::marker::Send`
note: captured value is not `Send`
  --> src/main.rs:23:15
   |
23 | async fn main(_spawner: Spawner) {}
   |               ^^^^^^^^ has type `embassy_executor::Spawner` which is not `Send`
   = note: `*mut ()` doesn't implement `core::marker::Sync`
   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#future_not_send
   = note: `-D clippy::future-not-send` implied by `-D clippy::nursery`
   = help: to override `-D clippy::nursery` add `#[allow(clippy::future_not_send)]`
```

---

Currently the only way to make said error/warning go away is to put
```rs
#![allow(clippy::future_not_send)]
```
at the top of the module calling `embassy_executor::main`. 
Users unfortunately can't put the `allow` attribute like this (attribute gets removed during expansion).
```rs
#[embassy_executor::main]
#[allow(clippy::future_not_send)]
async fn main(_spawner: Spawner) {}
```
nor
```rs
#[allow(clippy::future_not_send)]
#[embassy_executor::main]
async fn main(_spawner: Spawner) {}
```

Adding the attribute directly in the expanded code makes `clippy` happy. 

Note: This might not be the ideal fix (maybe allowing `async fn main(_spawner: SendSpawner) {}` would work but I don't have enough knowledge on embassy to know if that's faceable or wished). 
Adding the attribute seems like a good compromise, being quick and easy to maintain (maybe using `expect` can be better but it requires a relatively new version of rust)