### PR TITLE
Replace STM32WBA52CGUxT by STM32WBA55CGUx

### DIFF
--- a/examples/stm32wba/.cargo/config.toml
+++ b/examples/stm32wba/.cargo/config.toml
@@ -1,5 +1,5 @@
 [target.'cfg(all(target_arch = "arm", target_os = "none"))']
-runner = "probe-rs run --chip STM32WBA52CGUxT"
+runner = "probe-rs run --chip STM32WBA55CGUx"
 
 [build]
 target = "thumbv8m.main-none-eabihf"


### PR DESCRIPTION
The WBA55 Nucleo bardd officially replaces the WBA52.
Even if WBA52 SoC is still part of the ST CubeFW, the SW connectivity projects for WBA52 are no longer delivered.
WBA55 Nucleo board is now the reference entry board.