### PR TITLE
rp/pio: update pio-rs, reexport, move instr methods to SM.

### DIFF
--- a/cyw43-pio/Cargo.toml
+++ b/cyw43-pio/Cargo.toml
@@ -12,8 +12,6 @@ documentation = "https://docs.embassy.dev/cyw43-pio"
 [dependencies]
 cyw43 = { version = "0.3.0", path = "../cyw43" }
 embassy-rp = { version = "0.3.0", path = "../embassy-rp" }
-pio-proc = { git = "https://github.com/rp-rs/pio-rs", rev = "fa586448b0b223217eec8c92c19fe6823dd04cc4" }
-pio = { git = "https://github.com/rp-rs/pio-rs", rev = "fa586448b0b223217eec8c92c19fe6823dd04cc4" }
 fixed = "1.23.1"
 defmt = { version = "0.3", optional = true }
 

--- a/cyw43-pio/src/lib.rs
+++ b/cyw43-pio/src/lib.rs
@@ -8,7 +8,7 @@ use core::slice;
 use cyw43::SpiBusCyw43;
 use embassy_rp::dma::Channel;
 use embassy_rp::gpio::{Drive, Level, Output, Pull, SlewRate};
-use embassy_rp::pio::{instr, Common, Config, Direction, Instance, Irq, PioPin, ShiftDirection, StateMachine};
+use embassy_rp::pio::{Common, Config, Direction, Instance, Irq, PioPin, ShiftDirection, StateMachine};
 use embassy_rp::{Peripheral, PeripheralRef};
 use fixed::types::extra::U8;
 use fixed::FixedU32;
@@ -161,10 +161,10 @@ where
         defmt::trace!("write={} read={}", write_bits, read_bits);
 
         unsafe {
-            instr::set_x(&mut self.sm, write_bits as u32);
-            instr::set_y(&mut self.sm, read_bits as u32);
-            instr::set_pindir(&mut self.sm, 0b1);
-            instr::exec_jmp(&mut self.sm, self.wrap_target);
+            self.sm.set_x(write_bits as u32);
+            self.sm.set_y(read_bits as u32);
+            self.sm.set_pindir(0b1);
+            self.sm.exec_jmp(self.wrap_target);
         }
 
         self.sm.set_enable(true);
@@ -192,10 +192,10 @@ where
         defmt::trace!("cmd_read cmd = {:02x} len = {}", cmd, read.len());
 
         unsafe {
-            instr::set_y(&mut self.sm, read_bits as u32);
-            instr::set_x(&mut self.sm, write_bits as u32);
-            instr::set_pindir(&mut self.sm, 0b1);
-            instr::exec_jmp(&mut self.sm, self.wrap_target);
+            self.sm.set_y(read_bits as u32);
+            self.sm.set_x(write_bits as u32);
+            self.sm.set_pindir(0b1);
+            self.sm.exec_jmp(self.wrap_target);
         }
 
         // self.cs.set_low();

--- a/cyw43-pio/src/lib.rs
+++ b/cyw43-pio/src/lib.rs
@@ -8,11 +8,11 @@ use core::slice;
 use cyw43::SpiBusCyw43;
 use embassy_rp::dma::Channel;
 use embassy_rp::gpio::{Drive, Level, Output, Pull, SlewRate};
+use embassy_rp::pio::program::pio_asm;
 use embassy_rp::pio::{Common, Config, Direction, Instance, Irq, PioPin, ShiftDirection, StateMachine};
 use embassy_rp::{Peripheral, PeripheralRef};
 use fixed::types::extra::U8;
 use fixed::FixedU32;
-use pio_proc::pio_asm;
 
 /// SPI comms driven by PIO.
 pub struct PioSpi<'d, PIO: Instance, const SM: usize, DMA> {

--- a/embassy-rp/Cargo.toml
+++ b/embassy-rp/Cargo.toml
@@ -164,8 +164,7 @@ embedded-hal-1 = { package = "embedded-hal", version = "1.0" }
 embedded-hal-async = { version = "1.0" }
 embedded-hal-nb = { version = "1.0" }
 
-pio-proc = { git = "https://github.com/rp-rs/pio-rs", rev = "fa586448b0b223217eec8c92c19fe6823dd04cc4" }
-pio = { git = "https://github.com/rp-rs/pio-rs", rev = "fa586448b0b223217eec8c92c19fe6823dd04cc4" }
+pio = { git = "https://github.com/rp-rs/pio-rs", rev = "506a51b9bc135845e8544a0debd75847b73754dc" }
 rp2040-boot2 = "0.3"
 document-features = "0.2.10"
 sha2-const-stable = "0.1"

--- a/embassy-rp/Cargo.toml
+++ b/embassy-rp/Cargo.toml
@@ -157,7 +157,7 @@ embedded-storage-async = { version = "0.4.1" }
 rand_core = "0.6.4"
 fixed = "1.28.0"
 
-rp-pac = { version = "7.0.0", feature = ["rt"] }
+rp-pac = { version = "7.0.0" }
 
 embedded-hal-02 = { package = "embedded-hal", version = "0.2.6", features = ["unproven"] }
 embedded-hal-1 = { package = "embedded-hal", version = "1.0" }

--- a/embassy-rp/src/pio/instr.rs
+++ b/embassy-rp/src/pio/instr.rs
@@ -3,99 +3,101 @@ use pio::{InSource, InstructionOperands, JmpCondition, OutDestination, SetDestin
 
 use crate::pio::{Instance, StateMachine};
 
-/// Set value of scratch register X.
-pub unsafe fn set_x<PIO: Instance, const SM: usize>(sm: &mut StateMachine<PIO, SM>, value: u32) {
-    const OUT: u16 = InstructionOperands::OUT {
-        destination: OutDestination::X,
-        bit_count: 32,
+impl<'d, PIO: Instance, const SM: usize> StateMachine<'d, PIO, SM> {
+    /// Set value of scratch register X.
+    pub unsafe fn set_x(&mut self, value: u32) {
+        const OUT: u16 = InstructionOperands::OUT {
+            destination: OutDestination::X,
+            bit_count: 32,
+        }
+        .encode();
+        self.tx().push(value);
+        self.exec_instr(OUT);
     }
-    .encode();
-    sm.tx().push(value);
-    sm.exec_instr(OUT);
-}
 
-/// Get value of scratch register X.
-pub unsafe fn get_x<PIO: Instance, const SM: usize>(sm: &mut StateMachine<PIO, SM>) -> u32 {
-    const IN: u16 = InstructionOperands::IN {
-        source: InSource::X,
-        bit_count: 32,
+    /// Get value of scratch register X.
+    pub unsafe fn get_x(&mut self) -> u32 {
+        const IN: u16 = InstructionOperands::IN {
+            source: InSource::X,
+            bit_count: 32,
+        }
+        .encode();
+        self.exec_instr(IN);
+        self.rx().pull()
     }
-    .encode();
-    sm.exec_instr(IN);
-    sm.rx().pull()
-}
 
-/// Set value of scratch register Y.
-pub unsafe fn set_y<PIO: Instance, const SM: usize>(sm: &mut StateMachine<PIO, SM>, value: u32) {
-    const OUT: u16 = InstructionOperands::OUT {
-        destination: OutDestination::Y,
-        bit_count: 32,
+    /// Set value of scratch register Y.
+    pub unsafe fn set_y(&mut self, value: u32) {
+        const OUT: u16 = InstructionOperands::OUT {
+            destination: OutDestination::Y,
+            bit_count: 32,
+        }
+        .encode();
+        self.tx().push(value);
+        self.exec_instr(OUT);
     }
-    .encode();
-    sm.tx().push(value);
-    sm.exec_instr(OUT);
-}
 
-/// Get value of scratch register Y.
-pub unsafe fn get_y<PIO: Instance, const SM: usize>(sm: &mut StateMachine<PIO, SM>) -> u32 {
-    const IN: u16 = InstructionOperands::IN {
-        source: InSource::Y,
-        bit_count: 32,
+    /// Get value of scratch register Y.
+    pub unsafe fn get_y(&mut self) -> u32 {
+        const IN: u16 = InstructionOperands::IN {
+            source: InSource::Y,
+            bit_count: 32,
+        }
+        .encode();
+        self.exec_instr(IN);
+
+        self.rx().pull()
     }
-    .encode();
-    sm.exec_instr(IN);
 
-    sm.rx().pull()
-}
-
-/// Set instruction for pindir destination.
-pub unsafe fn set_pindir<PIO: Instance, const SM: usize>(sm: &mut StateMachine<PIO, SM>, data: u8) {
-    let set: u16 = InstructionOperands::SET {
-        destination: SetDestination::PINDIRS,
-        data,
+    /// Set instruction for pindir destination.
+    pub unsafe fn set_pindir(&mut self, data: u8) {
+        let set: u16 = InstructionOperands::SET {
+            destination: SetDestination::PINDIRS,
+            data,
+        }
+        .encode();
+        self.exec_instr(set);
     }
-    .encode();
-    sm.exec_instr(set);
-}
 
-/// Set instruction for pin destination.
-pub unsafe fn set_pin<PIO: Instance, const SM: usize>(sm: &mut StateMachine<PIO, SM>, data: u8) {
-    let set: u16 = InstructionOperands::SET {
-        destination: SetDestination::PINS,
-        data,
+    /// Set instruction for pin destination.
+    pub unsafe fn set_pin(&mut self, data: u8) {
+        let set: u16 = InstructionOperands::SET {
+            destination: SetDestination::PINS,
+            data,
+        }
+        .encode();
+        self.exec_instr(set);
     }
-    .encode();
-    sm.exec_instr(set);
-}
 
-/// Out instruction for pin destination.
-pub unsafe fn set_out_pin<PIO: Instance, const SM: usize>(sm: &mut StateMachine<PIO, SM>, data: u32) {
-    const OUT: u16 = InstructionOperands::OUT {
-        destination: OutDestination::PINS,
-        bit_count: 32,
+    /// Out instruction for pin destination.
+    pub unsafe fn set_out_pin(&mut self, data: u32) {
+        const OUT: u16 = InstructionOperands::OUT {
+            destination: OutDestination::PINS,
+            bit_count: 32,
+        }
+        .encode();
+        self.tx().push(data);
+        self.exec_instr(OUT);
     }
-    .encode();
-    sm.tx().push(data);
-    sm.exec_instr(OUT);
-}
 
-/// Out instruction for pindir destination.
-pub unsafe fn set_out_pindir<PIO: Instance, const SM: usize>(sm: &mut StateMachine<PIO, SM>, data: u32) {
-    const OUT: u16 = InstructionOperands::OUT {
-        destination: OutDestination::PINDIRS,
-        bit_count: 32,
+    /// Out instruction for pindir destination.
+    pub unsafe fn set_out_pindir(&mut self, data: u32) {
+        const OUT: u16 = InstructionOperands::OUT {
+            destination: OutDestination::PINDIRS,
+            bit_count: 32,
+        }
+        .encode();
+        self.tx().push(data);
+        self.exec_instr(OUT);
     }
-    .encode();
-    sm.tx().push(data);
-    sm.exec_instr(OUT);
-}
 
-/// Jump instruction to address.
-pub unsafe fn exec_jmp<PIO: Instance, const SM: usize>(sm: &mut StateMachine<PIO, SM>, to_addr: u8) {
-    let jmp: u16 = InstructionOperands::JMP {
-        address: to_addr,
-        condition: JmpCondition::Always,
+    /// Jump instruction to address.
+    pub unsafe fn exec_jmp(&mut self, to_addr: u8) {
+        let jmp: u16 = InstructionOperands::JMP {
+            address: to_addr,
+            condition: JmpCondition::Always,
+        }
+        .encode();
+        self.exec_instr(jmp);
     }
-    .encode();
-    sm.exec_instr(jmp);
 }

--- a/embassy-rp/src/pio/mod.rs
+++ b/embassy-rp/src/pio/mod.rs
@@ -20,6 +20,9 @@ use crate::{pac, peripherals, RegExt};
 
 mod instr;
 
+#[doc(inline)]
+pub use pio as program;
+
 /// Wakers for interrupts and FIFOs.
 pub struct Wakers([AtomicWaker; 12]);
 

--- a/embassy-rp/src/pio/mod.rs
+++ b/embassy-rp/src/pio/mod.rs
@@ -18,7 +18,7 @@ use crate::interrupt::typelevel::{Binding, Handler, Interrupt};
 use crate::relocate::RelocatedProgram;
 use crate::{pac, peripherals, RegExt};
 
-pub mod instr;
+mod instr;
 
 /// Wakers for interrupts and FIFOs.
 pub struct Wakers([AtomicWaker; 12]);
@@ -812,7 +812,7 @@ impl<'d, PIO: Instance + 'd, const SM: usize> StateMachine<'d, PIO, SM> {
         }
 
         if let Some(origin) = config.origin {
-            unsafe { instr::exec_jmp(self, origin) }
+            unsafe { self.exec_jmp(origin) }
         }
     }
 

--- a/embassy-rp/src/pio_programs/hd44780.rs
+++ b/embassy-rp/src/pio_programs/hd44780.rs
@@ -15,7 +15,7 @@ pub struct PioHD44780CommandWordProgram<'a, PIO: Instance> {
 impl<'a, PIO: Instance> PioHD44780CommandWordProgram<'a, PIO> {
     /// Load the program into the given pio
     pub fn new(common: &mut Common<'a, PIO>) -> Self {
-        let prg = pio_proc::pio_asm!(
+        let prg = pio::pio_asm!(
             r#"
                 .side_set 1 opt
                 .origin 20
@@ -46,7 +46,7 @@ impl<'a, PIO: Instance> PioHD44780CommandSequenceProgram<'a, PIO> {
     /// Load the program into the given pio
     pub fn new(common: &mut Common<'a, PIO>) -> Self {
         // many side sets are only there to free up a delay bit!
-        let prg = pio_proc::pio_asm!(
+        let prg = pio::pio_asm!(
             r#"
                 .origin 27
                 .side_set 1

--- a/embassy-rp/src/pio_programs/i2s.rs
+++ b/embassy-rp/src/pio_programs/i2s.rs
@@ -16,7 +16,7 @@ pub struct PioI2sOutProgram<'a, PIO: Instance> {
 impl<'a, PIO: Instance> PioI2sOutProgram<'a, PIO> {
     /// Load the program into the given pio
     pub fn new(common: &mut Common<'a, PIO>) -> Self {
-        let prg = pio_proc::pio_asm!(
+        let prg = pio::pio_asm!(
             ".side_set 2",
             "    set x, 14          side 0b01", // side 0bWB - W = Word Clock, B = Bit Clock
             "left_data:",

--- a/embassy-rp/src/pio_programs/onewire.rs
+++ b/embassy-rp/src/pio_programs/onewire.rs
@@ -1,6 +1,6 @@
 //! OneWire pio driver
 
-use crate::pio::{self, Common, Config, Instance, LoadedProgram, PioPin, ShiftConfig, ShiftDirection, StateMachine};
+use crate::pio::{Common, Config, Instance, LoadedProgram, PioPin, ShiftConfig, ShiftDirection, StateMachine};
 
 /// This struct represents an onewire driver program
 pub struct PioOneWireProgram<'a, PIO: Instance> {
@@ -10,7 +10,7 @@ pub struct PioOneWireProgram<'a, PIO: Instance> {
 impl<'a, PIO: Instance> PioOneWireProgram<'a, PIO> {
     /// Load the program into the given pio
     pub fn new(common: &mut Common<'a, PIO>) -> Self {
-        let prg = pio_proc::pio_asm!(
+        let prg = pio::pio_asm!(
             r#"
                 .wrap_target
                     again:
@@ -60,11 +60,11 @@ impl<'a, PIO: Instance> PioOneWireProgram<'a, PIO> {
 }
 
 /// Pio backed OneWire driver
-pub struct PioOneWire<'d, PIO: pio::Instance, const SM: usize> {
+pub struct PioOneWire<'d, PIO: Instance, const SM: usize> {
     sm: StateMachine<'d, PIO, SM>,
 }
 
-impl<'d, PIO: pio::Instance, const SM: usize> PioOneWire<'d, PIO, SM> {
+impl<'d, PIO: Instance, const SM: usize> PioOneWire<'d, PIO, SM> {
     /// Create a new instance the driver
     pub fn new(
         common: &mut Common<'d, PIO>,

--- a/embassy-rp/src/pio_programs/pwm.rs
+++ b/embassy-rp/src/pio_programs/pwm.rs
@@ -21,7 +21,7 @@ pub struct PioPwmProgram<'a, PIO: Instance> {
 impl<'a, PIO: Instance> PioPwmProgram<'a, PIO> {
     /// Load the program into the given pio
     pub fn new(common: &mut Common<'a, PIO>) -> Self {
-        let prg = pio_proc::pio_asm!(
+        let prg = pio::pio_asm!(
             ".side_set 1 opt"
                 "pull noblock    side 0"
                 "mov x, osr"

--- a/embassy-rp/src/pio_programs/rotary_encoder.rs
+++ b/embassy-rp/src/pio_programs/rotary_encoder.rs
@@ -3,7 +3,9 @@
 use fixed::traits::ToFixed;
 
 use crate::gpio::Pull;
-use crate::pio::{self, Common, Config, FifoJoin, Instance, LoadedProgram, PioPin, ShiftDirection, StateMachine};
+use crate::pio::{
+    Common, Config, Direction as PioDirection, FifoJoin, Instance, LoadedProgram, PioPin, ShiftDirection, StateMachine,
+};
 
 /// This struct represents an Encoder program loaded into pio instruction memory.
 pub struct PioEncoderProgram<'a, PIO: Instance> {
@@ -13,7 +15,7 @@ pub struct PioEncoderProgram<'a, PIO: Instance> {
 impl<'a, PIO: Instance> PioEncoderProgram<'a, PIO> {
     /// Load the program into the given pio
     pub fn new(common: &mut Common<'a, PIO>) -> Self {
-        let prg = pio_proc::pio_asm!("wait 1 pin 1", "wait 0 pin 1", "in pins, 2", "push",);
+        let prg = pio::pio_asm!("wait 1 pin 1", "wait 0 pin 1", "in pins, 2", "push",);
 
         let prg = common.load_program(&prg.program);
 
@@ -39,7 +41,7 @@ impl<'d, T: Instance, const SM: usize> PioEncoder<'d, T, SM> {
         let mut pin_b = pio.make_pio_pin(pin_b);
         pin_a.set_pull(Pull::Up);
         pin_b.set_pull(Pull::Up);
-        sm.set_pin_dirs(pio::Direction::In, &[&pin_a, &pin_b]);
+        sm.set_pin_dirs(PioDirection::In, &[&pin_a, &pin_b]);
 
         let mut cfg = Config::default();
         cfg.set_in_pins(&[&pin_a, &pin_b]);

--- a/embassy-rp/src/pio_programs/stepper.rs
+++ b/embassy-rp/src/pio_programs/stepper.rs
@@ -16,7 +16,7 @@ pub struct PioStepperProgram<'a, PIO: Instance> {
 impl<'a, PIO: Instance> PioStepperProgram<'a, PIO> {
     /// Load the program into the given pio
     pub fn new(common: &mut Common<'a, PIO>) -> Self {
-        let prg = pio_proc::pio_asm!(
+        let prg = pio::pio_asm!(
             "pull block",
             "mov x, osr",
             "pull block",

--- a/embassy-rp/src/pio_programs/uart.rs
+++ b/embassy-rp/src/pio_programs/uart.rs
@@ -19,7 +19,7 @@ pub struct PioUartTxProgram<'a, PIO: Instance> {
 impl<'a, PIO: Instance> PioUartTxProgram<'a, PIO> {
     /// Load the uart tx program into the given pio
     pub fn new(common: &mut Common<'a, PIO>) -> Self {
-        let prg = pio_proc::pio_asm!(
+        let prg = pio::pio_asm!(
             r#"
                 .side_set 1 opt
 
@@ -99,7 +99,7 @@ pub struct PioUartRxProgram<'a, PIO: Instance> {
 impl<'a, PIO: Instance> PioUartRxProgram<'a, PIO> {
     /// Load the uart rx program into the given pio
     pub fn new(common: &mut Common<'a, PIO>) -> Self {
-        let prg = pio_proc::pio_asm!(
+        let prg = pio::pio_asm!(
             r#"
                 ; Slightly more fleshed-out 8n1 UART receiver which handles framing errors and
                 ; break conditions more gracefully.

--- a/examples/rp/Cargo.toml
+++ b/examples/rp/Cargo.toml
@@ -55,8 +55,6 @@ embedded-storage = { version = "0.3" }
 static_cell = "2.1"
 portable-atomic = { version = "1.5", features = ["critical-section"] }
 log = "0.4"
-pio-proc = { git = "https://github.com/rp-rs/pio-rs", rev = "fa586448b0b223217eec8c92c19fe6823dd04cc4" }
-pio = { git = "https://github.com/rp-rs/pio-rs", rev = "fa586448b0b223217eec8c92c19fe6823dd04cc4" }
 rand = { version = "0.8.5", default-features = false }
 embedded-sdmmc = "0.7.0"
 

--- a/examples/rp/src/bin/pio_async.rs
+++ b/examples/rp/src/bin/pio_async.rs
@@ -6,6 +6,7 @@ use defmt::info;
 use embassy_executor::Spawner;
 use embassy_rp::bind_interrupts;
 use embassy_rp::peripherals::PIO0;
+use embassy_rp::pio::program::pio_asm;
 use embassy_rp::pio::{Common, Config, InterruptHandler, Irq, Pio, PioPin, ShiftDirection, StateMachine};
 use fixed::traits::ToFixed;
 use fixed_macro::types::U56F8;
@@ -19,7 +20,7 @@ fn setup_pio_task_sm0<'a>(pio: &mut Common<'a, PIO0>, sm: &mut StateMachine<'a, 
     // Setup sm0
 
     // Send data serially to pin
-    let prg = pio_proc::pio_asm!(
+    let prg = pio_asm!(
         ".origin 16",
         "set pindirs, 1",
         ".wrap_target",
@@ -53,7 +54,7 @@ fn setup_pio_task_sm1<'a>(pio: &mut Common<'a, PIO0>, sm: &mut StateMachine<'a, 
     // Setupm sm1
 
     // Read 0b10101 repeatedly until ISR is full
-    let prg = pio_proc::pio_asm!(
+    let prg = pio_asm!(
         //
         ".origin 8",
         "set x, 0x15",
@@ -83,7 +84,7 @@ fn setup_pio_task_sm2<'a>(pio: &mut Common<'a, PIO0>, sm: &mut StateMachine<'a, 
     // Setup sm2
 
     // Repeatedly trigger IRQ 3
-    let prg = pio_proc::pio_asm!(
+    let prg = pio_asm!(
         ".origin 0",
         ".wrap_target",
         "set x,10",

--- a/examples/rp/src/bin/pio_dma.rs
+++ b/examples/rp/src/bin/pio_dma.rs
@@ -6,6 +6,7 @@ use defmt::info;
 use embassy_executor::Spawner;
 use embassy_futures::join::join;
 use embassy_rp::peripherals::PIO0;
+use embassy_rp::pio::program::pio_asm;
 use embassy_rp::pio::{Config, InterruptHandler, Pio, ShiftConfig, ShiftDirection};
 use embassy_rp::{bind_interrupts, Peripheral};
 use fixed::traits::ToFixed;
@@ -32,7 +33,7 @@ async fn main(_spawner: Spawner) {
         ..
     } = Pio::new(pio, Irqs);
 
-    let prg = pio_proc::pio_asm!(
+    let prg = pio_asm!(
         ".origin 0",
         "set pindirs,1",
         ".wrap_target",

--- a/examples/rp23/Cargo.toml
+++ b/examples/rp23/Cargo.toml
@@ -55,8 +55,6 @@ embedded-storage = { version = "0.3" }
 static_cell = "2.1"
 portable-atomic = { version = "1.5", features = ["critical-section"] }
 log = "0.4"
-pio-proc = { git = "https://github.com/rp-rs/pio-rs", rev = "fa586448b0b223217eec8c92c19fe6823dd04cc4" }
-pio = { git = "https://github.com/rp-rs/pio-rs", rev = "fa586448b0b223217eec8c92c19fe6823dd04cc4" }
 rand = { version = "0.8.5", default-features = false }
 embedded-sdmmc = "0.7.0"
 

--- a/examples/rp23/src/bin/pio_async.rs
+++ b/examples/rp23/src/bin/pio_async.rs
@@ -6,6 +6,7 @@ use defmt::info;
 use embassy_executor::Spawner;
 use embassy_rp::bind_interrupts;
 use embassy_rp::peripherals::PIO0;
+use embassy_rp::pio::program::pio_asm;
 use embassy_rp::pio::{Common, Config, InterruptHandler, Irq, Pio, PioPin, ShiftDirection, StateMachine};
 use fixed::traits::ToFixed;
 use fixed_macro::types::U56F8;
@@ -19,7 +20,7 @@ fn setup_pio_task_sm0<'a>(pio: &mut Common<'a, PIO0>, sm: &mut StateMachine<'a, 
     // Setup sm0
 
     // Send data serially to pin
-    let prg = pio_proc::pio_asm!(
+    let prg = pio_asm!(
         ".origin 16",
         "set pindirs, 1",
         ".wrap_target",
@@ -53,7 +54,7 @@ fn setup_pio_task_sm1<'a>(pio: &mut Common<'a, PIO0>, sm: &mut StateMachine<'a, 
     // Setupm sm1
 
     // Read 0b10101 repeatedly until ISR is full
-    let prg = pio_proc::pio_asm!(
+    let prg = pio_asm!(
         //
         ".origin 8",
         "set x, 0x15",
@@ -83,7 +84,7 @@ fn setup_pio_task_sm2<'a>(pio: &mut Common<'a, PIO0>, sm: &mut StateMachine<'a, 
     // Setup sm2
 
     // Repeatedly trigger IRQ 3
-    let prg = pio_proc::pio_asm!(
+    let prg = pio_asm!(
         ".origin 0",
         ".wrap_target",
         "set x,10",

--- a/examples/rp23/src/bin/pio_dma.rs
+++ b/examples/rp23/src/bin/pio_dma.rs
@@ -6,6 +6,7 @@ use defmt::info;
 use embassy_executor::Spawner;
 use embassy_futures::join::join;
 use embassy_rp::peripherals::PIO0;
+use embassy_rp::pio::program::pio_asm;
 use embassy_rp::pio::{Config, InterruptHandler, Pio, ShiftConfig, ShiftDirection};
 use embassy_rp::{bind_interrupts, Peripheral};
 use fixed::traits::ToFixed;
@@ -32,7 +33,7 @@ async fn main(_spawner: Spawner) {
         ..
     } = Pio::new(pio, Irqs);
 
-    let prg = pio_proc::pio_asm!(
+    let prg = pio_asm!(
         ".origin 0",
         "set pindirs,1",
         ".wrap_target",

--- a/examples/rp23/src/bin/pio_rotary_encoder_rxf.rs
+++ b/examples/rp23/src/bin/pio_rotary_encoder_rxf.rs
@@ -8,6 +8,7 @@ use defmt::info;
 use embassy_executor::Spawner;
 use embassy_rp::gpio::Pull;
 use embassy_rp::peripherals::PIO0;
+use embassy_rp::pio::program::pio_asm;
 use embassy_rp::{bind_interrupts, pio};
 use embassy_time::Timer;
 use fixed::traits::ToFixed;
@@ -46,7 +47,7 @@ impl<'d, T: Instance, const SM: usize> PioEncoder<'d, T, SM> {
 
         sm.set_pin_dirs(pio::Direction::In, &[&pin_a, &pin_b]);
 
-        let prg = pio_proc::pio_asm!(
+        let prg = pio_asm!(
             "start:"
             // encoder count is stored in X
             "mov isr, x"

--- a/tests/rp/Cargo.toml
+++ b/tests/rp/Cargo.toml
@@ -33,8 +33,6 @@ embedded-io-async = { version = "0.6.1" }
 embedded-storage = { version = "0.3" }
 static_cell = "2"
 portable-atomic = { version = "1.5", features = ["critical-section"] }
-pio-proc = { git = "https://github.com/rp-rs/pio-rs", rev = "fa586448b0b223217eec8c92c19fe6823dd04cc4" }
-pio = { git = "https://github.com/rp-rs/pio-rs", rev = "fa586448b0b223217eec8c92c19fe6823dd04cc4" }
 rand = { version = "0.8.5", default-features = false }
 
 [profile.dev]

--- a/tests/rp/src/bin/pio_irq.rs
+++ b/tests/rp/src/bin/pio_irq.rs
@@ -6,6 +6,7 @@ use defmt::info;
 use embassy_executor::Spawner;
 use embassy_rp::bind_interrupts;
 use embassy_rp::peripherals::PIO0;
+use embassy_rp::pio::program::pio_asm;
 use embassy_rp::pio::{Config, InterruptHandler, Pio};
 use {defmt_rtt as _, panic_probe as _};
 
@@ -24,7 +25,7 @@ async fn main(_spawner: Spawner) {
         ..
     } = Pio::new(pio, Irqs);
 
-    let prg = pio_proc::pio_asm!(
+    let prg = pio_asm!(
         "irq set 0",
         "irq wait 0",
         "irq set 1",

--- a/tests/rp/src/bin/pio_multi_load.rs
+++ b/tests/rp/src/bin/pio_multi_load.rs
@@ -6,6 +6,7 @@ use defmt::info;
 use embassy_executor::Spawner;
 use embassy_rp::bind_interrupts;
 use embassy_rp::peripherals::PIO0;
+use embassy_rp::pio::program::pio_asm;
 use embassy_rp::pio::{Config, InterruptHandler, LoadError, Pio};
 use {defmt_rtt as _, panic_probe as _};
 
@@ -27,7 +28,7 @@ async fn main(_spawner: Spawner) {
     } = Pio::new(pio, Irqs);
 
     // load with explicit origin works
-    let prg1 = pio_proc::pio_asm!(
+    let prg1 = pio_asm!(
         ".origin 4"
         "nop",
         "nop",
@@ -46,15 +47,14 @@ async fn main(_spawner: Spawner) {
     assert_eq!(loaded1.wrap.target, 4);
 
     // load without origin chooses a free space
-    let prg2 = pio_proc::pio_asm!("nop", "nop", "nop", "nop", "nop", "nop", "nop", "irq 1", "nop", "nop",);
+    let prg2 = pio_asm!("nop", "nop", "nop", "nop", "nop", "nop", "nop", "irq 1", "nop", "nop",);
     let loaded2 = common.load_program(&prg2.program);
     assert_eq!(loaded2.origin, 14);
     assert_eq!(loaded2.wrap.source, 23);
     assert_eq!(loaded2.wrap.target, 14);
 
     // wrapping around the end of program space automatically works
-    let prg3 =
-        pio_proc::pio_asm!("nop", "nop", "nop", "nop", "nop", "nop", "nop", "nop", "nop", "nop", "nop", "irq 2",);
+    let prg3 = pio_asm!("nop", "nop", "nop", "nop", "nop", "nop", "nop", "nop", "nop", "nop", "nop", "irq 2",);
     let loaded3 = common.load_program(&prg3.program);
     assert_eq!(loaded3.origin, 24);
     assert_eq!(loaded3.wrap.source, 3);
@@ -88,13 +88,13 @@ async fn main(_spawner: Spawner) {
 
     // instruction memory is full now. all loads should fail.
     {
-        let prg = pio_proc::pio_asm!(".origin 0", "nop");
+        let prg = pio_asm!(".origin 0", "nop");
         match common.try_load_program(&prg.program) {
             Err(LoadError::AddressInUse(0)) => (),
             _ => panic!("program loaded when it shouldn't"),
         };
 
-        let prg = pio_proc::pio_asm!("nop");
+        let prg = pio_asm!("nop");
         match common.try_load_program(&prg.program) {
             Err(LoadError::InsufficientSpace) => (),
             _ => panic!("program loaded when it shouldn't"),
@@ -106,13 +106,13 @@ async fn main(_spawner: Spawner) {
         common.free_instr(loaded3.used_memory);
     }
     {
-        let prg = pio_proc::pio_asm!(".origin 0", "nop");
+        let prg = pio_asm!(".origin 0", "nop");
         match common.try_load_program(&prg.program) {
             Ok(_) => (),
             _ => panic!("program didn't loaded when it shouldn"),
         };
 
-        let prg = pio_proc::pio_asm!("nop");
+        let prg = pio_asm!("nop");
         match common.try_load_program(&prg.program) {
             Ok(_) => (),
             _ => panic!("program didn't loaded when it shouldn"),


### PR DESCRIPTION
- **rp/pio: move instructions to methods of the SM.**
- **rp: remove typo'd `feature` that was doing nothing.**
- **rp/pio: update pio-rs crate, reexport it so users don't get version mismatches.**

depends on https://github.com/rp-rs/pio-rs/pull/72