### PR TITLE
STM32 - Update Cargo.toml : replace STM32WBA52CGU by STM32WBA55CG

### DIFF
--- a/examples/stm32wba/Cargo.toml
+++ b/examples/stm32wba/Cargo.toml
@@ -5,7 +5,7 @@ version = "0.1.0"
 license = "MIT OR Apache-2.0"
 
 [dependencies]
-embassy-stm32 = { version = "0.2.0", path = "../../embassy-stm32", features = [ "defmt", "stm32wba52cg", "time-driver-any", "memory-x", "exti"]  }
+embassy-stm32 = { version = "0.2.0", path = "../../embassy-stm32", features = [ "defmt", "stm32wba55cg", "time-driver-any", "memory-x", "exti"]  }
 embassy-sync = { version = "0.6.2", path = "../../embassy-sync", features = ["defmt"] }
 embassy-executor = { version = "0.7.0", path = "../../embassy-executor", features = ["task-arena-size-32768", "arch-cortex-m", "executor-thread", "defmt"] }
 embassy-time = { version = "0.4.0", path = "../../embassy-time", features = ["defmt", "defmt-timestamp-uptime", "tick-hz-32_768"] }


### PR DESCRIPTION
Following PR https://github.com/embassy-rs/embassy/pull/3852 , I forgot to update the dependency.

The WBA55 Nucleo board officially replaces the WBA52.
Even if WBA52 SoC is still part of the ST CubeFW, the SW connectivity projects for WBA52 are no longer delivered.
WBA55 Nucleo board is now the reference entry board.