### PR TITLE
Fix small typos in docs

### DIFF
--- a/docs/pages/best_practices.adoc
+++ b/docs/pages/best_practices.adoc
@@ -35,7 +35,7 @@ After the processing, another 1024 byte buffer will be placed on the stack to be
 
 Pass the data by reference and not by value on both, the way in and the way out.
 For example, you could return a slice of the input buffer as the output.
-Requiring the lifetime of the input slice and the output slice to be the same, the memory safetly of this procedure will be enforced by the compiler.
+Requiring the lifetime of the input slice and the output slice to be the same, the memory safety of this procedure will be enforced by the compiler.
 
 [,rust]
 ----

--- a/docs/pages/layer_by_layer.adoc
+++ b/docs/pages/layer_by_layer.adoc
@@ -76,7 +76,7 @@ The async version looks very similar to the HAL version, apart from a few minor 
 * The peripheral initialization is done by the main macro, and is handed to the main task.
 * Before checking the button state, the application is awaiting a transition in the pin state (low -> high or high -> low).
 
-When `button.await_for_any_edge().await` is called, the executor will pause the main task and put the microcontroller in sleep mode, unless there are other tasks that can run. Internally, the Embassy HAL has configured the interrupt handler for the button (in `ExtiInput`), so that whenever an interrupt is raised, the task awaiting the button will be woken up.
+When `button.wait_for_any_edge().await` is called, the executor will pause the main task and put the microcontroller in sleep mode, unless there are other tasks that can run. Internally, the Embassy HAL has configured the interrupt handler for the button (in `ExtiInput`), so that whenever an interrupt is raised, the task awaiting the button will be woken up.
 
 The minimal overhead of the executor and the ability to run multiple tasks "concurrently" combined with the enormous simplification of the application, makes `async` a great fit for embedded.
 

--- a/docs/pages/overview.adoc
+++ b/docs/pages/overview.adoc
@@ -74,7 +74,7 @@ include::embassy_in_the_wild.adoc[leveloffset = 2]
 
 For more reading material on async Rust and Embassy:
 
-* link:https://tweedegolf.nl/en/blog/65/async-rust-vs-rtos-showdown[Comparsion of FreeRTOS and Embassy]
+* link:https://tweedegolf.nl/en/blog/65/async-rust-vs-rtos-showdown[Comparison of FreeRTOS and Embassy]
 * link:https://dev.to/apollolabsbin/series/20707[Tutorials]
 * link:https://blog.drogue.io/firmware-updates-part-1/[Firmware Updates with Embassy]
 


### PR DESCRIPTION
Replaces: 
- 'safetly' with 'safety'
- `button.await_for_any_edge()` with `button.wait_for_any_edge()`
- 'Comparsion' with 'Comparison'