### PR TITLE
embassy-executor: set expires_at to u64::MAX when task exits

### DIFF
--- a/embassy-executor/src/raw/mod.rs
+++ b/embassy-executor/src/raw/mod.rs
@@ -224,6 +224,9 @@ impl<F: Future + 'static> TaskStorage<F> {
                 // Make sure we despawn last, so that other threads can only spawn the task
                 // after we're done with it.
                 this.raw.state.despawn();
+
+                // Make sure the task is not woken up by the time driver.
+                this.raw.timer_queue_item.expires_at.set(u64::MAX);
             }
             Poll::Pending => {}
         }


### PR DESCRIPTION
Ensure the task is not woken up by the time driver by setting the expires_at value to u64::MAX. This change prevents potential issues with task scheduling and ensures proper task management.

FIX: #3875