### PR TITLE
STM32: RTC subsecond support

### DIFF
--- a/embassy-stm32/src/rtc/mod.rs
+++ b/embassy-stm32/src/rtc/mod.rs
@@ -59,7 +59,7 @@ impl RtcTimeProvider {
     ///
     /// Will return an `RtcError::InvalidDateTime` if the stored value in the system is not a valid [`DayOfWeek`].
     pub fn now(&self) -> Result<DateTime, RtcError> {
-        self.read(|dr, tr, _| {
+        self.read(|dr, tr, _ss| {
             let second = bcd2_to_byte((tr.st(), tr.su()));
             let minute = bcd2_to_byte((tr.mnt(), tr.mnu()));
             let hour = bcd2_to_byte((tr.ht(), tr.hu()));
@@ -69,7 +69,17 @@ impl RtcTimeProvider {
             let month = bcd2_to_byte((dr.mt() as u8, dr.mu()));
             let year = bcd2_to_byte((dr.yt(), dr.yu())) as u16 + 2000_u16;
 
-            DateTime::from(year, month, day, weekday, hour, minute, second).map_err(RtcError::InvalidDateTime)
+            // Calculate second fraction and multiply to microseconds
+            // Formula from RM0410
+            #[cfg(not(rtc_v2f2))]
+            let us = {
+                let prediv = RTC::regs().prer().read().prediv_s() as f32;
+                (((prediv - _ss as f32) / (prediv + 1.0)) * 1e6).min(999_999.0) as u32
+            };
+            #[cfg(rtc_v2f2)]
+            let us = 0;
+
+            DateTime::from(year, month, day, weekday, hour, minute, second, us).map_err(RtcError::InvalidDateTime)
         })
     }
 

--- a/examples/stm32g0/src/bin/rtc.rs
+++ b/examples/stm32g0/src/bin/rtc.rs
@@ -15,7 +15,7 @@ async fn main(_spawner: Spawner) {
 
     info!("Hello World!");
 
-    let now = DateTime::from(2023, 6, 14, DayOfWeek::Friday, 15, 59, 10);
+    let now = DateTime::from(2023, 6, 14, DayOfWeek::Friday, 15, 59, 10, 0);
 
     let mut rtc = Rtc::new(p.RTC, RtcConfig::default());
 


### PR DESCRIPTION
RTC driver does not read subsecond register. This PR fixes that and also adds microsecond field to `DateTime` struct. 