### PR TITLE
Use probe-rs as default runner for rp23 examples

### DIFF
--- a/examples/rp23/.cargo/config.toml
+++ b/examples/rp23/.cargo/config.toml
@@ -1,7 +1,7 @@
 [target.'cfg(all(target_arch = "arm", target_os = "none"))']
-#runner = "probe-rs run --chip RP2040"
+runner = "probe-rs run --chip RP235x"
 #runner = "elf2uf2-rs -d"
-runner = "picotool load -u -v -x -t elf"
+#runner = "picotool load -u -v -x -t elf"
 
 [build]
 target = "thumbv8m.main-none-eabihf"


### PR DESCRIPTION
Now that probe-rs supports RP235x targets we should use it for rp23 examples