### PR TITLE
rp: add ImageDef features

### DIFF
--- a/embassy-rp/Cargo.toml
+++ b/embassy-rp/Cargo.toml
@@ -106,7 +106,7 @@ imagedef-nonsecure-exe = []
 
 ## Have embassy-rp not provide the Image Definition so you can use your own.
 ## Place your own in the ".start_block" section like:
-## ```
+## ```ignore
 ## use embassy_rp::block::ImageDef;
 ##
 ## #[link_section = ".start_block"]

--- a/embassy-rp/Cargo.toml
+++ b/embassy-rp/Cargo.toml
@@ -83,7 +83,7 @@ boot2-ram-memcpy = []
 boot2-w25q080 = []
 ## Use boot2 with support for Winbond W25X10CL SPI flash.
 boot2-w25x10cl = []
-## Have embassy not provide the boot2 so you can use your own.
+## Have embassy-rp not provide the boot2 so you can use your own.
 ## Place your own in the ".boot2" section like:
 ## ```
 ## #[link_section = ".boot2"]
@@ -91,6 +91,29 @@ boot2-w25x10cl = []
 ## static BOOT2: [u8; 256] = [0; 256]; // Provide your own with e.g. include_bytes!
 ## ```
 boot2-none = []
+
+#! ### Image Definition support
+#! RP2350's internal bootloader will only execute firmware if it has a valid Image Definition.
+#! There are other tags that can be used (for example, you can tag an image as "DATA")
+#! but programs will want to have an exe header. "SECURE_EXE" is usually what you want.
+#! Use imagedef-none if you want to configure the Image Definition manually
+#! If none are selected, imagedef-secure-exe will be used
+
+## Image is executable and starts in Secure mode
+imagedef-secure-exe = []
+## Image is executable and starts in Non-secure mode
+imagedef-nonsecure-exe = []
+
+## Have embassy-rp not provide the Image Definition so you can use your own.
+## Place your own in the ".start_block" section like:
+## ```
+## use embassy_rp::block::ImageDef;
+##
+## #[link_section = ".start_block"]
+## #[used]
+## static IMAGE_DEF: ImageDef = ImageDef::secure_exe(); // Update this with your own implementation.
+## ```
+imagedef-none = []
 
 ## Configure the hal for use with the rp2040
 rp2040 = ["rp-pac/rp2040"]

--- a/embassy-rp/src/lib.rs
+++ b/embassy-rp/src/lib.rs
@@ -456,6 +456,30 @@ select_bootloader! {
     default => BOOT_LOADER_W25Q080
 }
 
+#[cfg(all(not(feature = "imagedef-none"), feature = "_rp235x"))]
+macro_rules! select_imagedef {
+    ( $( $feature:literal => $imagedef:ident, )+ default => $default:ident ) => {
+        $(
+            #[cfg(feature = $feature)]
+            #[link_section = ".start_block"]
+            #[used]
+            static IMAGE_DEF: crate::block::ImageDef = crate::block::ImageDef::$imagedef();
+        )*
+
+        #[cfg(not(any( $( feature = $feature),* )))]
+        #[link_section = ".start_block"]
+        #[used]
+        static IMAGE_DEF: crate::block::ImageDef = crate::block::ImageDef::$default();
+    }
+}
+
+#[cfg(all(not(feature = "imagedef-none"), feature = "_rp235x"))]
+select_imagedef! {
+    "imagedef-secure-exe" => secure_exe,
+    "imagedef-nonsecure-exe" => non_secure_exe,
+    default => secure_exe
+}
+
 /// Installs a stack guard for the CORE0 stack in MPU region 0.
 /// Will fail if the MPU is already configured. This function requires
 /// a `_stack_end` symbol to be defined by the linker script, and expects

--- a/examples/rp23/src/bin/adc.rs
+++ b/examples/rp23/src/bin/adc.rs
@@ -8,14 +8,9 @@ use defmt::*;
 use embassy_executor::Spawner;
 use embassy_rp::adc::{Adc, Channel, Config, InterruptHandler};
 use embassy_rp::bind_interrupts;
-use embassy_rp::block::ImageDef;
 use embassy_rp::gpio::Pull;
 use embassy_time::Timer;
 use {defmt_rtt as _, panic_probe as _};
-
-#[link_section = ".start_block"]
-#[used]
-pub static IMAGE_DEF: ImageDef = ImageDef::secure_exe();
 
 bind_interrupts!(struct Irqs {
     ADC_IRQ_FIFO => InterruptHandler;

--- a/examples/rp23/src/bin/adc_dma.rs
+++ b/examples/rp23/src/bin/adc_dma.rs
@@ -8,14 +8,9 @@ use defmt::*;
 use embassy_executor::Spawner;
 use embassy_rp::adc::{Adc, Channel, Config, InterruptHandler};
 use embassy_rp::bind_interrupts;
-use embassy_rp::block::ImageDef;
 use embassy_rp::gpio::Pull;
 use embassy_time::{Duration, Ticker};
 use {defmt_rtt as _, panic_probe as _};
-
-#[link_section = ".start_block"]
-#[used]
-pub static IMAGE_DEF: ImageDef = ImageDef::secure_exe();
 
 bind_interrupts!(struct Irqs {
     ADC_IRQ_FIFO => InterruptHandler;

--- a/examples/rp23/src/bin/assign_resources.rs
+++ b/examples/rp23/src/bin/assign_resources.rs
@@ -14,15 +14,10 @@
 use assign_resources::assign_resources;
 use defmt::*;
 use embassy_executor::Spawner;
-use embassy_rp::block::ImageDef;
 use embassy_rp::gpio::{Level, Output};
 use embassy_rp::peripherals::{self, PIN_20, PIN_21};
 use embassy_time::Timer;
 use {defmt_rtt as _, panic_probe as _};
-
-#[link_section = ".start_block"]
-#[used]
-pub static IMAGE_DEF: ImageDef = ImageDef::secure_exe();
 
 #[embassy_executor::main]
 async fn main(spawner: Spawner) {

--- a/examples/rp23/src/bin/blinky.rs
+++ b/examples/rp23/src/bin/blinky.rs
@@ -7,15 +7,10 @@
 
 use defmt::*;
 use embassy_executor::Spawner;
-use embassy_rp::block::ImageDef;
 use embassy_rp::gpio;
 use embassy_time::Timer;
 use gpio::{Level, Output};
 use {defmt_rtt as _, panic_probe as _};
-
-#[link_section = ".start_block"]
-#[used]
-pub static IMAGE_DEF: ImageDef = ImageDef::secure_exe();
 
 // Program metadata for `picotool info`.
 // This isn't needed, but it's recomended to have these minimal entries.

--- a/examples/rp23/src/bin/blinky_two_channels.rs
+++ b/examples/rp23/src/bin/blinky_two_channels.rs
@@ -7,17 +7,12 @@
 /// [Link explaining it](https://www.physicsclassroom.com/class/sound/Lesson-3/Interference-and-Beats)
 use defmt::*;
 use embassy_executor::Spawner;
-use embassy_rp::block::ImageDef;
 use embassy_rp::gpio;
 use embassy_sync::blocking_mutex::raw::ThreadModeRawMutex;
 use embassy_sync::channel::{Channel, Sender};
 use embassy_time::{Duration, Ticker};
 use gpio::{AnyPin, Level, Output};
 use {defmt_rtt as _, panic_probe as _};
-
-#[link_section = ".start_block"]
-#[used]
-pub static IMAGE_DEF: ImageDef = ImageDef::secure_exe();
 
 enum LedState {
     Toggle,

--- a/examples/rp23/src/bin/blinky_two_tasks.rs
+++ b/examples/rp23/src/bin/blinky_two_tasks.rs
@@ -7,17 +7,12 @@
 /// [Link explaining it](https://www.physicsclassroom.com/class/sound/Lesson-3/Interference-and-Beats)
 use defmt::*;
 use embassy_executor::Spawner;
-use embassy_rp::block::ImageDef;
 use embassy_rp::gpio;
 use embassy_sync::blocking_mutex::raw::ThreadModeRawMutex;
 use embassy_sync::mutex::Mutex;
 use embassy_time::{Duration, Ticker};
 use gpio::{AnyPin, Level, Output};
 use {defmt_rtt as _, panic_probe as _};
-
-#[link_section = ".start_block"]
-#[used]
-pub static IMAGE_DEF: ImageDef = ImageDef::secure_exe();
 
 type LedType = Mutex<ThreadModeRawMutex, Option<Output<'static>>>;
 static LED: LedType = Mutex::new(None);

--- a/examples/rp23/src/bin/button.rs
+++ b/examples/rp23/src/bin/button.rs
@@ -6,13 +6,8 @@
 #![no_main]
 
 use embassy_executor::Spawner;
-use embassy_rp::block::ImageDef;
 use embassy_rp::gpio::{Input, Level, Output, Pull};
 use {defmt_rtt as _, panic_probe as _};
-
-#[link_section = ".start_block"]
-#[used]
-pub static IMAGE_DEF: ImageDef = ImageDef::secure_exe();
 
 #[embassy_executor::main]
 async fn main(_spawner: Spawner) {

--- a/examples/rp23/src/bin/debounce.rs
+++ b/examples/rp23/src/bin/debounce.rs
@@ -6,14 +6,9 @@
 
 use defmt::info;
 use embassy_executor::Spawner;
-use embassy_rp::block::ImageDef;
 use embassy_rp::gpio::{Input, Level, Pull};
 use embassy_time::{with_deadline, Duration, Instant, Timer};
 use {defmt_rtt as _, panic_probe as _};
-
-#[link_section = ".start_block"]
-#[used]
-pub static IMAGE_DEF: ImageDef = ImageDef::secure_exe();
 
 pub struct Debouncer<'a> {
     input: Input<'a>,

--- a/examples/rp23/src/bin/flash.rs
+++ b/examples/rp23/src/bin/flash.rs
@@ -5,15 +5,10 @@
 
 use defmt::*;
 use embassy_executor::Spawner;
-use embassy_rp::block::ImageDef;
 use embassy_rp::flash::{Async, ERASE_SIZE, FLASH_BASE};
 use embassy_rp::peripherals::FLASH;
 use embassy_time::Timer;
 use {defmt_rtt as _, panic_probe as _};
-
-#[link_section = ".start_block"]
-#[used]
-pub static IMAGE_DEF: ImageDef = ImageDef::secure_exe();
 
 const ADDR_OFFSET: u32 = 0x100000;
 const FLASH_SIZE: usize = 2 * 1024 * 1024;

--- a/examples/rp23/src/bin/gpio_async.rs
+++ b/examples/rp23/src/bin/gpio_async.rs
@@ -7,15 +7,10 @@
 
 use defmt::*;
 use embassy_executor::Spawner;
-use embassy_rp::block::ImageDef;
 use embassy_rp::gpio;
 use embassy_time::Timer;
 use gpio::{Input, Level, Output, Pull};
 use {defmt_rtt as _, panic_probe as _};
-
-#[link_section = ".start_block"]
-#[used]
-pub static IMAGE_DEF: ImageDef = ImageDef::secure_exe();
 
 /// It requires an external signal to be manually triggered on PIN 16. For
 /// example, this could be accomplished using an external power source with a

--- a/examples/rp23/src/bin/gpout.rs
+++ b/examples/rp23/src/bin/gpout.rs
@@ -7,14 +7,9 @@
 
 use defmt::*;
 use embassy_executor::Spawner;
-use embassy_rp::block::ImageDef;
 use embassy_rp::clocks;
 use embassy_time::Timer;
 use {defmt_rtt as _, panic_probe as _};
-
-#[link_section = ".start_block"]
-#[used]
-pub static IMAGE_DEF: ImageDef = ImageDef::secure_exe();
 
 #[embassy_executor::main]
 async fn main(_spawner: Spawner) {

--- a/examples/rp23/src/bin/i2c_async.rs
+++ b/examples/rp23/src/bin/i2c_async.rs
@@ -9,16 +9,11 @@
 use defmt::*;
 use embassy_executor::Spawner;
 use embassy_rp::bind_interrupts;
-use embassy_rp::block::ImageDef;
 use embassy_rp::i2c::{self, Config, InterruptHandler};
 use embassy_rp::peripherals::I2C1;
 use embassy_time::Timer;
 use embedded_hal_async::i2c::I2c;
 use {defmt_rtt as _, panic_probe as _};
-
-#[link_section = ".start_block"]
-#[used]
-pub static IMAGE_DEF: ImageDef = ImageDef::secure_exe();
 
 bind_interrupts!(struct Irqs {
     I2C1_IRQ => InterruptHandler<I2C1>;

--- a/examples/rp23/src/bin/i2c_async_embassy.rs
+++ b/examples/rp23/src/bin/i2c_async_embassy.rs
@@ -7,13 +7,8 @@
 #![no_main]
 
 use defmt::*;
-use embassy_rp::block::ImageDef;
 use embassy_rp::i2c::InterruptHandler;
 use {defmt_rtt as _, panic_probe as _};
-
-#[link_section = ".start_block"]
-#[used]
-pub static IMAGE_DEF: ImageDef = ImageDef::secure_exe();
 
 // Our anonymous hypotetical temperature sensor could be:
 // a 12-bit sensor, with 100ms startup time, range of -40*C - 125*C, and precision 0.25*C

--- a/examples/rp23/src/bin/i2c_blocking.rs
+++ b/examples/rp23/src/bin/i2c_blocking.rs
@@ -8,15 +8,10 @@
 
 use defmt::*;
 use embassy_executor::Spawner;
-use embassy_rp::block::ImageDef;
 use embassy_rp::i2c::{self, Config};
 use embassy_time::Timer;
 use embedded_hal_1::i2c::I2c;
 use {defmt_rtt as _, panic_probe as _};
-
-#[link_section = ".start_block"]
-#[used]
-pub static IMAGE_DEF: ImageDef = ImageDef::secure_exe();
 
 #[allow(dead_code)]
 mod mcp23017 {

--- a/examples/rp23/src/bin/i2c_slave.rs
+++ b/examples/rp23/src/bin/i2c_slave.rs
@@ -4,16 +4,11 @@
 
 use defmt::*;
 use embassy_executor::Spawner;
-use embassy_rp::block::ImageDef;
 use embassy_rp::peripherals::{I2C0, I2C1};
 use embassy_rp::{bind_interrupts, i2c, i2c_slave};
 use embassy_time::Timer;
 use embedded_hal_async::i2c::I2c;
 use {defmt_rtt as _, panic_probe as _};
-
-#[link_section = ".start_block"]
-#[used]
-pub static IMAGE_DEF: ImageDef = ImageDef::secure_exe();
 
 bind_interrupts!(struct Irqs {
     I2C0_IRQ => i2c::InterruptHandler<I2C0>;

--- a/examples/rp23/src/bin/interrupt.rs
+++ b/examples/rp23/src/bin/interrupt.rs
@@ -13,7 +13,6 @@ use core::cell::{Cell, RefCell};
 use defmt::*;
 use embassy_executor::Spawner;
 use embassy_rp::adc::{self, Adc, Blocking};
-use embassy_rp::block::ImageDef;
 use embassy_rp::gpio::Pull;
 use embassy_rp::interrupt;
 use embassy_rp::pwm::{Config, Pwm};
@@ -24,10 +23,6 @@ use embassy_time::{Duration, Ticker};
 use portable_atomic::{AtomicU32, Ordering};
 use static_cell::StaticCell;
 use {defmt_rtt as _, panic_probe as _};
-
-#[link_section = ".start_block"]
-#[used]
-pub static IMAGE_DEF: ImageDef = ImageDef::secure_exe();
 
 static COUNTER: AtomicU32 = AtomicU32::new(0);
 static PWM: Mutex<CriticalSectionRawMutex, RefCell<Option<Pwm>>> = Mutex::new(RefCell::new(None));

--- a/examples/rp23/src/bin/multicore.rs
+++ b/examples/rp23/src/bin/multicore.rs
@@ -7,7 +7,6 @@
 
 use defmt::*;
 use embassy_executor::Executor;
-use embassy_rp::block::ImageDef;
 use embassy_rp::gpio::{Level, Output};
 use embassy_rp::multicore::{spawn_core1, Stack};
 use embassy_sync::blocking_mutex::raw::CriticalSectionRawMutex;
@@ -15,10 +14,6 @@ use embassy_sync::channel::Channel;
 use embassy_time::Timer;
 use static_cell::StaticCell;
 use {defmt_rtt as _, panic_probe as _};
-
-#[link_section = ".start_block"]
-#[used]
-pub static IMAGE_DEF: ImageDef = ImageDef::secure_exe();
 
 static mut CORE1_STACK: Stack<4096> = Stack::new();
 static EXECUTOR0: StaticCell<Executor> = StaticCell::new();

--- a/examples/rp23/src/bin/multiprio.rs
+++ b/examples/rp23/src/bin/multiprio.rs
@@ -59,16 +59,11 @@
 use cortex_m_rt::entry;
 use defmt::{info, unwrap};
 use embassy_executor::{Executor, InterruptExecutor};
-use embassy_rp::block::ImageDef;
 use embassy_rp::interrupt;
 use embassy_rp::interrupt::{InterruptExt, Priority};
 use embassy_time::{Instant, Timer, TICK_HZ};
 use static_cell::StaticCell;
 use {defmt_rtt as _, panic_probe as _};
-
-#[link_section = ".start_block"]
-#[used]
-pub static IMAGE_DEF: ImageDef = ImageDef::secure_exe();
 
 #[embassy_executor::task]
 async fn run_high() {

--- a/examples/rp23/src/bin/otp.rs
+++ b/examples/rp23/src/bin/otp.rs
@@ -5,14 +5,9 @@
 
 use defmt::*;
 use embassy_executor::Spawner;
-use embassy_rp::block::ImageDef;
 use embassy_rp::otp;
 use embassy_time::Timer;
 use {defmt_rtt as _, panic_probe as _};
-
-#[link_section = ".start_block"]
-#[used]
-pub static IMAGE_DEF: ImageDef = ImageDef::secure_exe();
 
 #[embassy_executor::main]
 async fn main(_spawner: Spawner) {

--- a/examples/rp23/src/bin/pio_async.rs
+++ b/examples/rp23/src/bin/pio_async.rs
@@ -5,16 +5,11 @@
 use defmt::info;
 use embassy_executor::Spawner;
 use embassy_rp::bind_interrupts;
-use embassy_rp::block::ImageDef;
 use embassy_rp::peripherals::PIO0;
 use embassy_rp::pio::{Common, Config, InterruptHandler, Irq, Pio, PioPin, ShiftDirection, StateMachine};
 use fixed::traits::ToFixed;
 use fixed_macro::types::U56F8;
 use {defmt_rtt as _, panic_probe as _};
-
-#[link_section = ".start_block"]
-#[used]
-pub static IMAGE_DEF: ImageDef = ImageDef::secure_exe();
 
 bind_interrupts!(struct Irqs {
     PIO0_IRQ_0 => InterruptHandler<PIO0>;

--- a/examples/rp23/src/bin/pio_dma.rs
+++ b/examples/rp23/src/bin/pio_dma.rs
@@ -5,17 +5,12 @@
 use defmt::info;
 use embassy_executor::Spawner;
 use embassy_futures::join::join;
-use embassy_rp::block::ImageDef;
 use embassy_rp::peripherals::PIO0;
 use embassy_rp::pio::{Config, InterruptHandler, Pio, ShiftConfig, ShiftDirection};
 use embassy_rp::{bind_interrupts, Peripheral};
 use fixed::traits::ToFixed;
 use fixed_macro::types::U56F8;
 use {defmt_rtt as _, panic_probe as _};
-
-#[link_section = ".start_block"]
-#[used]
-pub static IMAGE_DEF: ImageDef = ImageDef::secure_exe();
 
 bind_interrupts!(struct Irqs {
     PIO0_IRQ_0 => InterruptHandler<PIO0>;

--- a/examples/rp23/src/bin/pio_hd44780.rs
+++ b/examples/rp23/src/bin/pio_hd44780.rs
@@ -8,17 +8,12 @@ use core::fmt::Write;
 
 use embassy_executor::Spawner;
 use embassy_rp::bind_interrupts;
-use embassy_rp::block::ImageDef;
 use embassy_rp::peripherals::PIO0;
 use embassy_rp::pio::{InterruptHandler, Pio};
 use embassy_rp::pio_programs::hd44780::{PioHD44780, PioHD44780CommandSequenceProgram, PioHD44780CommandWordProgram};
 use embassy_rp::pwm::{self, Pwm};
 use embassy_time::{Instant, Timer};
 use {defmt_rtt as _, panic_probe as _};
-
-#[link_section = ".start_block"]
-#[used]
-pub static IMAGE_DEF: ImageDef = ImageDef::secure_exe();
 
 bind_interrupts!(pub struct Irqs {
     PIO0_IRQ_0 => InterruptHandler<PIO0>;

--- a/examples/rp23/src/bin/pio_i2s.rs
+++ b/examples/rp23/src/bin/pio_i2s.rs
@@ -14,17 +14,12 @@ use core::mem;
 
 use embassy_executor::Spawner;
 use embassy_rp::bind_interrupts;
-use embassy_rp::block::ImageDef;
 use embassy_rp::gpio::{Input, Pull};
 use embassy_rp::peripherals::PIO0;
 use embassy_rp::pio::{InterruptHandler, Pio};
 use embassy_rp::pio_programs::i2s::{PioI2sOut, PioI2sOutProgram};
 use static_cell::StaticCell;
 use {defmt_rtt as _, panic_probe as _};
-
-#[link_section = ".start_block"]
-#[used]
-pub static IMAGE_DEF: ImageDef = ImageDef::secure_exe();
 
 bind_interrupts!(struct Irqs {
     PIO0_IRQ_0 => InterruptHandler<PIO0>;

--- a/examples/rp23/src/bin/pio_onewire.rs
+++ b/examples/rp23/src/bin/pio_onewire.rs
@@ -5,16 +5,11 @@
 use defmt::*;
 use embassy_executor::Spawner;
 use embassy_rp::bind_interrupts;
-use embassy_rp::block::ImageDef;
 use embassy_rp::peripherals::PIO0;
 use embassy_rp::pio::{self, InterruptHandler, Pio};
 use embassy_rp::pio_programs::onewire::{PioOneWire, PioOneWireProgram};
 use embassy_time::Timer;
 use {defmt_rtt as _, panic_probe as _};
-
-#[link_section = ".start_block"]
-#[used]
-pub static IMAGE_DEF: ImageDef = ImageDef::secure_exe();
 
 bind_interrupts!(struct Irqs {
     PIO0_IRQ_0 => InterruptHandler<PIO0>;

--- a/examples/rp23/src/bin/pio_pwm.rs
+++ b/examples/rp23/src/bin/pio_pwm.rs
@@ -6,16 +6,11 @@ use core::time::Duration;
 
 use embassy_executor::Spawner;
 use embassy_rp::bind_interrupts;
-use embassy_rp::block::ImageDef;
 use embassy_rp::peripherals::PIO0;
 use embassy_rp::pio::{InterruptHandler, Pio};
 use embassy_rp::pio_programs::pwm::{PioPwm, PioPwmProgram};
 use embassy_time::Timer;
 use {defmt_rtt as _, panic_probe as _};
-
-#[link_section = ".start_block"]
-#[used]
-pub static IMAGE_DEF: ImageDef = ImageDef::secure_exe();
 
 const REFRESH_INTERVAL: u64 = 20000;
 

--- a/examples/rp23/src/bin/pio_rotary_encoder.rs
+++ b/examples/rp23/src/bin/pio_rotary_encoder.rs
@@ -6,15 +6,10 @@
 use defmt::info;
 use embassy_executor::Spawner;
 use embassy_rp::bind_interrupts;
-use embassy_rp::block::ImageDef;
 use embassy_rp::peripherals::PIO0;
 use embassy_rp::pio::{InterruptHandler, Pio};
 use embassy_rp::pio_programs::rotary_encoder::{Direction, PioEncoder, PioEncoderProgram};
 use {defmt_rtt as _, panic_probe as _};
-
-#[link_section = ".start_block"]
-#[used]
-pub static IMAGE_DEF: ImageDef = ImageDef::secure_exe();
 
 bind_interrupts!(struct Irqs {
     PIO0_IRQ_0 => InterruptHandler<PIO0>;

--- a/examples/rp23/src/bin/pio_rotary_encoder_rxf.rs
+++ b/examples/rp23/src/bin/pio_rotary_encoder_rxf.rs
@@ -6,7 +6,6 @@
 
 use defmt::info;
 use embassy_executor::Spawner;
-use embassy_rp::block::ImageDef;
 use embassy_rp::gpio::Pull;
 use embassy_rp::peripherals::PIO0;
 use embassy_rp::{bind_interrupts, pio};
@@ -14,10 +13,6 @@ use embassy_time::Timer;
 use fixed::traits::ToFixed;
 use pio::{Common, Config, FifoJoin, Instance, InterruptHandler, Pio, PioPin, ShiftDirection, StateMachine};
 use {defmt_rtt as _, panic_probe as _};
-
-#[link_section = ".start_block"]
-#[used]
-pub static IMAGE_DEF: ImageDef = ImageDef::secure_exe();
 
 // Program metadata for `picotool info`
 #[link_section = ".bi_entries"]

--- a/examples/rp23/src/bin/pio_servo.rs
+++ b/examples/rp23/src/bin/pio_servo.rs
@@ -6,16 +6,11 @@ use core::time::Duration;
 
 use embassy_executor::Spawner;
 use embassy_rp::bind_interrupts;
-use embassy_rp::block::ImageDef;
 use embassy_rp::peripherals::PIO0;
 use embassy_rp::pio::{Instance, InterruptHandler, Pio};
 use embassy_rp::pio_programs::pwm::{PioPwm, PioPwmProgram};
 use embassy_time::Timer;
 use {defmt_rtt as _, panic_probe as _};
-
-#[link_section = ".start_block"]
-#[used]
-pub static IMAGE_DEF: ImageDef = ImageDef::secure_exe();
 
 const DEFAULT_MIN_PULSE_WIDTH: u64 = 1000; // uncalibrated default, the shortest duty cycle sent to a servo
 const DEFAULT_MAX_PULSE_WIDTH: u64 = 2000; // uncalibrated default, the longest duty cycle sent to a servo

--- a/examples/rp23/src/bin/pio_stepper.rs
+++ b/examples/rp23/src/bin/pio_stepper.rs
@@ -7,16 +7,11 @@
 use defmt::info;
 use embassy_executor::Spawner;
 use embassy_rp::bind_interrupts;
-use embassy_rp::block::ImageDef;
 use embassy_rp::peripherals::PIO0;
 use embassy_rp::pio::{InterruptHandler, Pio};
 use embassy_rp::pio_programs::stepper::{PioStepper, PioStepperProgram};
 use embassy_time::{with_timeout, Duration, Timer};
 use {defmt_rtt as _, panic_probe as _};
-
-#[link_section = ".start_block"]
-#[used]
-pub static IMAGE_DEF: ImageDef = ImageDef::secure_exe();
 
 bind_interrupts!(struct Irqs {
     PIO0_IRQ_0 => InterruptHandler<PIO0>;

--- a/examples/rp23/src/bin/pio_uart.rs
+++ b/examples/rp23/src/bin/pio_uart.rs
@@ -13,7 +13,6 @@
 use defmt::{info, panic, trace};
 use embassy_executor::Spawner;
 use embassy_futures::join::{join, join3};
-use embassy_rp::block::ImageDef;
 use embassy_rp::peripherals::{PIO0, USB};
 use embassy_rp::pio_programs::uart::{PioUartRx, PioUartRxProgram, PioUartTx, PioUartTxProgram};
 use embassy_rp::usb::{Driver, Instance, InterruptHandler};
@@ -25,10 +24,6 @@ use embassy_usb::driver::EndpointError;
 use embassy_usb::{Builder, Config};
 use embedded_io_async::{Read, Write};
 use {defmt_rtt as _, panic_probe as _};
-
-#[link_section = ".start_block"]
-#[used]
-pub static IMAGE_DEF: ImageDef = ImageDef::secure_exe();
 
 bind_interrupts!(struct Irqs {
     USBCTRL_IRQ => InterruptHandler<USB>;

--- a/examples/rp23/src/bin/pio_ws2812.rs
+++ b/examples/rp23/src/bin/pio_ws2812.rs
@@ -7,17 +7,12 @@
 use defmt::*;
 use embassy_executor::Spawner;
 use embassy_rp::bind_interrupts;
-use embassy_rp::block::ImageDef;
 use embassy_rp::peripherals::PIO0;
 use embassy_rp::pio::{InterruptHandler, Pio};
 use embassy_rp::pio_programs::ws2812::{PioWs2812, PioWs2812Program};
 use embassy_time::{Duration, Ticker};
 use smart_leds::RGB8;
 use {defmt_rtt as _, panic_probe as _};
-
-#[link_section = ".start_block"]
-#[used]
-pub static IMAGE_DEF: ImageDef = ImageDef::secure_exe();
 
 bind_interrupts!(struct Irqs {
     PIO0_IRQ_0 => InterruptHandler<PIO0>;

--- a/examples/rp23/src/bin/pwm.rs
+++ b/examples/rp23/src/bin/pwm.rs
@@ -9,15 +9,10 @@
 
 use defmt::*;
 use embassy_executor::Spawner;
-use embassy_rp::block::ImageDef;
 use embassy_rp::peripherals::{PIN_25, PIN_4, PWM_SLICE2, PWM_SLICE4};
 use embassy_rp::pwm::{Config, Pwm, SetDutyCycle};
 use embassy_time::Timer;
 use {defmt_rtt as _, panic_probe as _};
-
-#[link_section = ".start_block"]
-#[used]
-pub static IMAGE_DEF: ImageDef = ImageDef::secure_exe();
 
 #[embassy_executor::main]
 async fn main(spawner: Spawner) {

--- a/examples/rp23/src/bin/pwm_input.rs
+++ b/examples/rp23/src/bin/pwm_input.rs
@@ -5,15 +5,10 @@
 
 use defmt::*;
 use embassy_executor::Spawner;
-use embassy_rp::block::ImageDef;
 use embassy_rp::gpio::Pull;
 use embassy_rp::pwm::{Config, InputMode, Pwm};
 use embassy_time::{Duration, Ticker};
 use {defmt_rtt as _, panic_probe as _};
-
-#[link_section = ".start_block"]
-#[used]
-pub static IMAGE_DEF: ImageDef = ImageDef::secure_exe();
 
 #[embassy_executor::main]
 async fn main(_spawner: Spawner) {

--- a/examples/rp23/src/bin/pwm_tb6612fng_motor_driver.rs
+++ b/examples/rp23/src/bin/pwm_tb6612fng_motor_driver.rs
@@ -8,17 +8,12 @@
 use assign_resources::assign_resources;
 use defmt::*;
 use embassy_executor::Spawner;
-use embassy_rp::block::ImageDef;
 use embassy_rp::config::Config;
 use embassy_rp::gpio::Output;
 use embassy_rp::{gpio, peripherals, pwm};
 use embassy_time::{Duration, Timer};
 use tb6612fng::{DriveCommand, Motor, Tb6612fng};
 use {defmt_rtt as _, panic_probe as _};
-
-#[link_section = ".start_block"]
-#[used]
-pub static IMAGE_DEF: ImageDef = ImageDef::secure_exe();
 
 assign_resources! {
     motor: MotorResources {

--- a/examples/rp23/src/bin/rosc.rs
+++ b/examples/rp23/src/bin/rosc.rs
@@ -7,15 +7,10 @@
 
 use defmt::*;
 use embassy_executor::Spawner;
-use embassy_rp::block::ImageDef;
 use embassy_rp::{clocks, gpio};
 use embassy_time::Timer;
 use gpio::{Level, Output};
 use {defmt_rtt as _, panic_probe as _};
-
-#[link_section = ".start_block"]
-#[used]
-pub static IMAGE_DEF: ImageDef = ImageDef::secure_exe();
 
 #[embassy_executor::main]
 async fn main(_spawner: Spawner) {

--- a/examples/rp23/src/bin/shared_bus.rs
+++ b/examples/rp23/src/bin/shared_bus.rs
@@ -8,7 +8,6 @@ use embassy_embedded_hal::shared_bus::asynch::i2c::I2cDevice;
 use embassy_embedded_hal::shared_bus::asynch::spi::SpiDevice;
 use embassy_executor::Spawner;
 use embassy_rp::bind_interrupts;
-use embassy_rp::block::ImageDef;
 use embassy_rp::gpio::{AnyPin, Level, Output};
 use embassy_rp::i2c::{self, I2c, InterruptHandler};
 use embassy_rp::peripherals::{I2C1, SPI1};
@@ -18,10 +17,6 @@ use embassy_sync::mutex::Mutex;
 use embassy_time::Timer;
 use static_cell::StaticCell;
 use {defmt_rtt as _, panic_probe as _};
-
-#[link_section = ".start_block"]
-#[used]
-pub static IMAGE_DEF: ImageDef = ImageDef::secure_exe();
 
 type Spi1Bus = Mutex<NoopRawMutex, Spi<'static, SPI1, spi::Async>>;
 type I2c1Bus = Mutex<NoopRawMutex, I2c<'static, I2C1, i2c::Async>>;

--- a/examples/rp23/src/bin/sharing.rs
+++ b/examples/rp23/src/bin/sharing.rs
@@ -19,7 +19,6 @@ use core::sync::atomic::{AtomicU32, Ordering};
 use cortex_m_rt::entry;
 use defmt::info;
 use embassy_executor::{Executor, InterruptExecutor};
-use embassy_rp::block::ImageDef;
 use embassy_rp::clocks::RoscRng;
 use embassy_rp::interrupt::{InterruptExt, Priority};
 use embassy_rp::peripherals::UART0;
@@ -31,10 +30,6 @@ use embassy_time::{Duration, Ticker};
 use rand::RngCore;
 use static_cell::{ConstStaticCell, StaticCell};
 use {defmt_rtt as _, panic_probe as _};
-
-#[link_section = ".start_block"]
-#[used]
-pub static IMAGE_DEF: ImageDef = ImageDef::secure_exe();
 
 type UartAsyncMutex = mutex::Mutex<CriticalSectionRawMutex, UartTx<'static, UART0, uart::Async>>;
 

--- a/examples/rp23/src/bin/spi.rs
+++ b/examples/rp23/src/bin/spi.rs
@@ -7,15 +7,10 @@
 
 use defmt::*;
 use embassy_executor::Spawner;
-use embassy_rp::block::ImageDef;
 use embassy_rp::spi::Spi;
 use embassy_rp::{gpio, spi};
 use gpio::{Level, Output};
 use {defmt_rtt as _, panic_probe as _};
-
-#[link_section = ".start_block"]
-#[used]
-pub static IMAGE_DEF: ImageDef = ImageDef::secure_exe();
 
 #[embassy_executor::main]
 async fn main(_spawner: Spawner) {

--- a/examples/rp23/src/bin/spi_async.rs
+++ b/examples/rp23/src/bin/spi_async.rs
@@ -6,14 +6,9 @@
 
 use defmt::*;
 use embassy_executor::Spawner;
-use embassy_rp::block::ImageDef;
 use embassy_rp::spi::{Config, Spi};
 use embassy_time::Timer;
 use {defmt_rtt as _, panic_probe as _};
-
-#[link_section = ".start_block"]
-#[used]
-pub static IMAGE_DEF: ImageDef = ImageDef::secure_exe();
 
 #[embassy_executor::main]
 async fn main(_spawner: Spawner) {

--- a/examples/rp23/src/bin/spi_display.rs
+++ b/examples/rp23/src/bin/spi_display.rs
@@ -12,7 +12,6 @@ use defmt::*;
 use display_interface_spi::SPIInterface;
 use embassy_embedded_hal::shared_bus::blocking::spi::SpiDeviceWithConfig;
 use embassy_executor::Spawner;
-use embassy_rp::block::ImageDef;
 use embassy_rp::gpio::{Level, Output};
 use embassy_rp::spi;
 use embassy_rp::spi::{Blocking, Spi};
@@ -30,10 +29,6 @@ use mipidsi::models::ST7789;
 use mipidsi::options::{Orientation, Rotation};
 use mipidsi::Builder;
 use {defmt_rtt as _, panic_probe as _};
-
-#[link_section = ".start_block"]
-#[used]
-pub static IMAGE_DEF: ImageDef = ImageDef::secure_exe();
 
 use crate::touch::Touch;
 

--- a/examples/rp23/src/bin/spi_sdmmc.rs
+++ b/examples/rp23/src/bin/spi_sdmmc.rs
@@ -9,17 +9,12 @@
 use defmt::*;
 use embassy_embedded_hal::SetConfig;
 use embassy_executor::Spawner;
-use embassy_rp::block::ImageDef;
 use embassy_rp::spi::Spi;
 use embassy_rp::{gpio, spi};
 use embedded_hal_bus::spi::ExclusiveDevice;
 use embedded_sdmmc::sdcard::{DummyCsPin, SdCard};
 use gpio::{Level, Output};
 use {defmt_rtt as _, panic_probe as _};
-
-#[link_section = ".start_block"]
-#[used]
-pub static IMAGE_DEF: ImageDef = ImageDef::secure_exe();
 
 struct DummyTimesource();
 

--- a/examples/rp23/src/bin/trng.rs
+++ b/examples/rp23/src/bin/trng.rs
@@ -6,17 +6,12 @@
 use defmt::*;
 use embassy_executor::Spawner;
 use embassy_rp::bind_interrupts;
-use embassy_rp::block::ImageDef;
 use embassy_rp::gpio::{Level, Output};
 use embassy_rp::peripherals::TRNG;
 use embassy_rp::trng::Trng;
 use embassy_time::Timer;
 use rand::RngCore;
 use {defmt_rtt as _, panic_probe as _};
-
-#[link_section = ".start_block"]
-#[used]
-pub static IMAGE_DEF: ImageDef = ImageDef::secure_exe();
 
 bind_interrupts!(struct Irqs {
     TRNG_IRQ => embassy_rp::trng::InterruptHandler<TRNG>;

--- a/examples/rp23/src/bin/uart.rs
+++ b/examples/rp23/src/bin/uart.rs
@@ -8,13 +8,8 @@
 #![no_main]
 
 use embassy_executor::Spawner;
-use embassy_rp::block::ImageDef;
 use embassy_rp::uart;
 use {defmt_rtt as _, panic_probe as _};
-
-#[link_section = ".start_block"]
-#[used]
-pub static IMAGE_DEF: ImageDef = ImageDef::secure_exe();
 
 #[embassy_executor::main]
 async fn main(_spawner: Spawner) {

--- a/examples/rp23/src/bin/uart_buffered_split.rs
+++ b/examples/rp23/src/bin/uart_buffered_split.rs
@@ -10,17 +10,12 @@
 use defmt::*;
 use embassy_executor::Spawner;
 use embassy_rp::bind_interrupts;
-use embassy_rp::block::ImageDef;
 use embassy_rp::peripherals::UART0;
 use embassy_rp::uart::{BufferedInterruptHandler, BufferedUart, BufferedUartRx, Config};
 use embassy_time::Timer;
 use embedded_io_async::{Read, Write};
 use static_cell::StaticCell;
 use {defmt_rtt as _, panic_probe as _};
-
-#[link_section = ".start_block"]
-#[used]
-pub static IMAGE_DEF: ImageDef = ImageDef::secure_exe();
 
 bind_interrupts!(struct Irqs {
     UART0_IRQ => BufferedInterruptHandler<UART0>;

--- a/examples/rp23/src/bin/uart_r503.rs
+++ b/examples/rp23/src/bin/uart_r503.rs
@@ -4,16 +4,11 @@
 use defmt::{debug, error, info};
 use embassy_executor::Spawner;
 use embassy_rp::bind_interrupts;
-use embassy_rp::block::ImageDef;
 use embassy_rp::peripherals::UART0;
 use embassy_rp::uart::{Config, DataBits, InterruptHandler as UARTInterruptHandler, Parity, StopBits, Uart};
 use embassy_time::{with_timeout, Duration, Timer};
 use heapless::Vec;
 use {defmt_rtt as _, panic_probe as _};
-
-#[link_section = ".start_block"]
-#[used]
-pub static IMAGE_DEF: ImageDef = ImageDef::secure_exe();
 
 bind_interrupts!(pub struct Irqs {
     UART0_IRQ  => UARTInterruptHandler<UART0>;

--- a/examples/rp23/src/bin/uart_unidir.rs
+++ b/examples/rp23/src/bin/uart_unidir.rs
@@ -11,15 +11,10 @@
 use defmt::*;
 use embassy_executor::Spawner;
 use embassy_rp::bind_interrupts;
-use embassy_rp::block::ImageDef;
 use embassy_rp::peripherals::UART1;
 use embassy_rp::uart::{Async, Config, InterruptHandler, UartRx, UartTx};
 use embassy_time::Timer;
 use {defmt_rtt as _, panic_probe as _};
-
-#[link_section = ".start_block"]
-#[used]
-pub static IMAGE_DEF: ImageDef = ImageDef::secure_exe();
 
 bind_interrupts!(struct Irqs {
     UART1_IRQ => InterruptHandler<UART1>;

--- a/examples/rp23/src/bin/usb_hid_keyboard.rs
+++ b/examples/rp23/src/bin/usb_hid_keyboard.rs
@@ -7,7 +7,6 @@ use defmt::*;
 use embassy_executor::Spawner;
 use embassy_futures::join::join;
 use embassy_rp::bind_interrupts;
-use embassy_rp::block::ImageDef;
 use embassy_rp::gpio::{Input, Pull};
 use embassy_rp::peripherals::USB;
 use embassy_rp::usb::{Driver as UsbDriver, InterruptHandler};
@@ -16,10 +15,6 @@ use embassy_usb::control::OutResponse;
 use embassy_usb::{Builder, Config, Handler};
 use usbd_hid::descriptor::{KeyboardReport, SerializedDescriptor};
 use {defmt_rtt as _, panic_probe as _};
-
-#[link_section = ".start_block"]
-#[used]
-pub static IMAGE_DEF: ImageDef = ImageDef::secure_exe();
 
 bind_interrupts!(struct Irqs {
     USBCTRL_IRQ => InterruptHandler<USB>;

--- a/examples/rp23/src/bin/usb_webusb.rs
+++ b/examples/rp23/src/bin/usb_webusb.rs
@@ -21,7 +21,6 @@ use defmt::info;
 use embassy_executor::Spawner;
 use embassy_futures::join::join;
 use embassy_rp::bind_interrupts;
-use embassy_rp::block::ImageDef;
 use embassy_rp::peripherals::USB;
 use embassy_rp::usb::{Driver as UsbDriver, InterruptHandler};
 use embassy_usb::class::web_usb::{Config as WebUsbConfig, State, Url, WebUsb};
@@ -29,10 +28,6 @@ use embassy_usb::driver::{Driver, Endpoint, EndpointIn, EndpointOut};
 use embassy_usb::msos::{self, windows_version};
 use embassy_usb::{Builder, Config};
 use {defmt_rtt as _, panic_probe as _};
-
-#[link_section = ".start_block"]
-#[used]
-pub static IMAGE_DEF: ImageDef = ImageDef::secure_exe();
 
 bind_interrupts!(struct Irqs {
     USBCTRL_IRQ => InterruptHandler<USB>;

--- a/examples/rp23/src/bin/watchdog.rs
+++ b/examples/rp23/src/bin/watchdog.rs
@@ -7,16 +7,11 @@
 
 use defmt::info;
 use embassy_executor::Spawner;
-use embassy_rp::block::ImageDef;
 use embassy_rp::gpio;
 use embassy_rp::watchdog::*;
 use embassy_time::{Duration, Timer};
 use gpio::{Level, Output};
 use {defmt_rtt as _, panic_probe as _};
-
-#[link_section = ".start_block"]
-#[used]
-pub static IMAGE_DEF: ImageDef = ImageDef::secure_exe();
 
 #[embassy_executor::main]
 async fn main(_spawner: Spawner) {

--- a/examples/rp23/src/bin/wifi_blinky_pico_plus_2.rs
+++ b/examples/rp23/src/bin/wifi_blinky_pico_plus_2.rs
@@ -8,7 +8,6 @@
 use cyw43_pio::{PioSpi, RM2_CLOCK_DIVIDER};
 use defmt::*;
 use embassy_executor::Spawner;
-use embassy_rp::block::ImageDef;
 use embassy_rp::peripherals::{DMA_CH0, PIO0};
 use embassy_rp::pio::{InterruptHandler, Pio};
 use embassy_rp::{bind_interrupts, gpio};
@@ -16,10 +15,6 @@ use embassy_time::{Duration, Timer};
 use gpio::{Level, Output};
 use static_cell::StaticCell;
 use {defmt_rtt as _, panic_probe as _};
-
-#[link_section = ".start_block"]
-#[used]
-pub static IMAGE_DEF: ImageDef = ImageDef::secure_exe();
 
 // Program metadata for `picotool info`.
 // This isn't needed, but it's recomended to have these minimal entries.

--- a/examples/rp23/src/bin/zerocopy.rs
+++ b/examples/rp23/src/bin/zerocopy.rs
@@ -10,7 +10,6 @@ use defmt::*;
 use embassy_executor::Spawner;
 use embassy_rp::adc::{self, Adc, Async, Config, InterruptHandler};
 use embassy_rp::bind_interrupts;
-use embassy_rp::block::ImageDef;
 use embassy_rp::gpio::Pull;
 use embassy_rp::peripherals::DMA_CH0;
 use embassy_sync::blocking_mutex::raw::NoopRawMutex;
@@ -18,10 +17,6 @@ use embassy_sync::zerocopy_channel::{Channel, Receiver, Sender};
 use embassy_time::{Duration, Ticker, Timer};
 use static_cell::StaticCell;
 use {defmt_rtt as _, panic_probe as _};
-
-#[link_section = ".start_block"]
-#[used]
-pub static IMAGE_DEF: ImageDef = ImageDef::secure_exe();
 
 type SampleBuffer = [u16; 512];
 


### PR DESCRIPTION
It's a bit irritating having examples/projects that are basically identical between rp2040 and rp235x except for the ImageDef include and block definition.

This PR puts the most common definitions into embassy-rp in the same way that boot2 is handled.
If you don't select one of these imagedef features on rp235x, you'll get Secure Exe (which all the examples were using anyway).

One issue with the way this is presently implemented:
If you define an Image Definition in your program *and* you have one of these imagedef features enabled, you will end up with two Image Definitions in your binary (bin crate one will be first).
I don't think embassy-rp sets up a `block loop` of these Image Definitions, so I think the bootloader will use the first one, but I need to confirm this.
Maybe it would make more sense to not have an imagedef supplied by default instead, so it's an explicit opt-in for this?

The three features currently implemented are
- imagedef-secure-exe (execute firmware in Secure Mode)
- imagedef-nonsecure-exe (execute firmware in Non-Secure Mode)
- imagedef-none (no Image Definition provided - user must define their own)