### PR TITLE
[embassy-net]: Add `serde:{Deserialize, Serialize}` for `embassy_net::Config`

### DIFF
--- a/embassy-net/Cargo.toml
+++ b/embassy-net/Cargo.toml
@@ -26,6 +26,9 @@ features = ["defmt", "tcp", "udp", "raw", "dns", "icmp", "dhcpv4", "proto-ipv6",
 ## Enable defmt
 defmt = ["dep:defmt", "smoltcp/defmt", "embassy-net-driver/defmt", "heapless/defmt-03", "defmt?/ip_in_core"]
 
+# Implement serde Serialize / Deserialize
+serde = ["dep:serde", "heapless/serde", "smoltcp/serde", "embassy-time/serde"]
+
 ## Trace all raw received and transmitted packets using defmt or log.
 packet-trace = []
 
@@ -81,3 +84,8 @@ managed = { version = "0.8.0", default-features = false, features = [ "map" ] }
 heapless = { version = "0.8", default-features = false }
 embedded-nal-async = "0.8.0"
 document-features = "0.2.7"
+serde = { version = "1.0.217", default-features = false, features = ["derive"], optional = true }
+
+# Patch until https://github.com/smoltcp-rs/smoltcp/pull/1042 is merged
+[patch.crates-io]
+smoltcp = { git = "https://github.com/smoltcp-rs/smoltcp", rev = "cf805ebe01b9054005e2fa3a8695ff9a9f0411a4" }

--- a/embassy-net/src/lib.rs
+++ b/embassy-net/src/lib.rs
@@ -12,6 +12,9 @@ compile_error!("You must enable at least one of the following features: proto-ip
 // This mod MUST go first, so that the others see its macros.
 pub(crate) mod fmt;
 
+#[cfg(feature = "serde")]
+use serde::{Deserialize, Serialize};
+
 #[cfg(feature = "dns")]
 pub mod dns;
 mod driver_util;
@@ -106,6 +109,7 @@ impl<const SOCK: usize> StackResources<SOCK> {
 /// Static IP address configuration.
 #[cfg(feature = "proto-ipv4")]
 #[derive(Debug, Clone, PartialEq, Eq)]
+#[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
 pub struct StaticConfigV4 {
     /// IP address and subnet mask.
     pub address: Ipv4Cidr,
@@ -118,6 +122,7 @@ pub struct StaticConfigV4 {
 /// Static IPv6 address configuration
 #[cfg(feature = "proto-ipv6")]
 #[derive(Debug, Clone, PartialEq, Eq)]
+#[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
 pub struct StaticConfigV6 {
     /// IP address and subnet mask.
     pub address: Ipv6Cidr,
@@ -130,6 +135,7 @@ pub struct StaticConfigV6 {
 /// DHCP configuration.
 #[cfg(feature = "dhcpv4")]
 #[derive(Debug, Clone, PartialEq, Eq)]
+#[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
 #[non_exhaustive]
 pub struct DhcpConfig {
     /// Maximum lease duration.
@@ -169,6 +175,7 @@ impl Default for DhcpConfig {
 
 /// Network stack configuration.
 #[derive(Debug, Clone, Default)]
+#[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
 #[non_exhaustive]
 pub struct Config {
     /// IPv4 configuration
@@ -220,6 +227,7 @@ impl Config {
 /// Network stack IPv4 configuration.
 #[cfg(feature = "proto-ipv4")]
 #[derive(Debug, Clone, Default)]
+#[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
 pub enum ConfigV4 {
     /// Do not configure IPv4.
     #[default]
@@ -234,6 +242,7 @@ pub enum ConfigV4 {
 /// Network stack IPv6 configuration.
 #[cfg(feature = "proto-ipv6")]
 #[derive(Debug, Clone, Default)]
+#[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
 pub enum ConfigV6 {
     /// Do not configure IPv6.
     #[default]

--- a/embassy-time/Cargo.toml
+++ b/embassy-time/Cargo.toml
@@ -431,6 +431,8 @@ cfg-if = "1.0.0"
 
 document-features = "0.2.7"
 
+serde = { version = "1.0.210", default-features = false, features = ["derive"], optional = true }
+
 # WASM dependencies
 wasm-bindgen = { version = "0.2.81", optional = true }
 js-sys = { version = "0.3", optional = true }

--- a/embassy-time/src/duration.rs
+++ b/embassy-time/src/duration.rs
@@ -6,6 +6,7 @@ use crate::GCD_1G;
 
 #[derive(Debug, Default, Copy, Clone, PartialEq, Eq, PartialOrd, Ord)]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
+#[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
 /// Represents the difference between two [Instant](struct.Instant.html)s
 pub struct Duration {
     pub(crate) ticks: u64,


### PR DESCRIPTION
This PR adds the `serde:{Deserialize, Serialize}` traits for `embassy_net::Config` and all of its underlying types.
This depends on:
-  https://github.com/smoltcp-rs/smoltcp/pull/1042 

for `Ipv[4|6]Cidr` types and `RetryConfig`.

My specific use case is to be able to communicate the running configuration from devices to an API, in JSON format, as well as saving the current configuration in NVS, using [Postcard](https://github.com/jamesmunns/postcard).