### PR TITLE
Bump rand core to 0.9.1 and rand to 0.9.0

### DIFF
--- a/embassy-nrf/Cargo.toml
+++ b/embassy-nrf/Cargo.toml
@@ -156,7 +156,7 @@ log = { version = "0.4.14", optional = true }
 cortex-m-rt = ">=0.6.15,<0.8"
 cortex-m = "0.7.6"
 critical-section = "1.1"
-rand_core = "0.6.3"
+rand_core = "0.9.1"
 fixed = "1.10.0"
 embedded-storage = "0.3.1"
 embedded-storage-async = "0.4.1"

--- a/embassy-nrf/src/rng.rs
+++ b/embassy-nrf/src/rng.rs
@@ -199,11 +199,6 @@ impl<'d, T: Instance> rand_core::RngCore for Rng<'d, T> {
         self.blocking_fill_bytes(&mut bytes);
         u64::from_ne_bytes(bytes)
     }
-
-    fn try_fill_bytes(&mut self, dest: &mut [u8]) -> Result<(), rand_core::Error> {
-        self.blocking_fill_bytes(dest);
-        Ok(())
-    }
 }
 
 impl<'d, T: Instance> rand_core::CryptoRng for Rng<'d, T> {}

--- a/embassy-rp/Cargo.toml
+++ b/embassy-rp/Cargo.toml
@@ -154,7 +154,7 @@ embedded-io = { version = "0.6.1" }
 embedded-io-async = { version = "0.6.1" }
 embedded-storage = { version = "0.3" }
 embedded-storage-async = { version = "0.4.1" }
-rand_core = "0.6.4"
+rand_core = "0.9.1"
 fixed = "1.28.0"
 
 rp-pac = { version = "7.0.0" }

--- a/embassy-rp/src/clocks.rs
+++ b/embassy-rp/src/clocks.rs
@@ -1050,10 +1050,6 @@ impl RoscRng {
 }
 
 impl rand_core::RngCore for RoscRng {
-    fn try_fill_bytes(&mut self, dest: &mut [u8]) -> Result<(), rand_core::Error> {
-        Ok(self.fill_bytes(dest))
-    }
-
     fn next_u32(&mut self) -> u32 {
         rand_core::impls::next_u32_via_fill(self)
     }

--- a/embassy-rp/src/trng.rs
+++ b/embassy-rp/src/trng.rs
@@ -7,7 +7,6 @@ use core::task::Poll;
 
 use embassy_hal_internal::Peripheral;
 use embassy_sync::waitqueue::AtomicWaker;
-use rand_core::Error;
 
 use crate::interrupt::typelevel::{Binding, Interrupt};
 use crate::peripherals::TRNG;
@@ -365,11 +364,6 @@ impl<'d, T: Instance> rand_core::RngCore for Trng<'d, T> {
 
     fn fill_bytes(&mut self, dest: &mut [u8]) {
         self.blocking_fill_bytes(dest)
-    }
-
-    fn try_fill_bytes(&mut self, dest: &mut [u8]) -> Result<(), Error> {
-        self.blocking_fill_bytes(dest);
-        Ok(())
     }
 }
 /// TRNG interrupt handler.

--- a/embassy-stm32/Cargo.toml
+++ b/embassy-stm32/Cargo.toml
@@ -69,7 +69,7 @@ log = { version = "0.4.14", optional = true }
 cortex-m-rt = ">=0.6.15,<0.8"
 cortex-m = "0.7.6"
 futures-util = { version = "0.3.30", default-features = false }
-rand_core = "0.6.3"
+rand_core = "0.9.1"
 sdio-host = "0.5.0"
 critical-section = "1.1"
 stm32-metapac = { version = "16" }

--- a/embassy-stm32/src/rng.rs
+++ b/embassy-stm32/src/rng.rs
@@ -213,11 +213,6 @@ impl<'d, T: Instance> RngCore for Rng<'d, T> {
             }
         }
     }
-
-    fn try_fill_bytes(&mut self, dest: &mut [u8]) -> Result<(), rand_core::Error> {
-        self.fill_bytes(dest);
-        Ok(())
-    }
 }
 
 impl<'d, T: Instance> CryptoRng for Rng<'d, T> {}

--- a/examples/nrf-rtos-trace/Cargo.toml
+++ b/examples/nrf-rtos-trace/Cargo.toml
@@ -23,7 +23,7 @@ embassy-nrf = { version = "0.3.1", path = "../../embassy-nrf", features = ["nrf5
 cortex-m = { version = "0.7.6", features = ["inline-asm", "critical-section-single-core"] }
 cortex-m-rt = "0.7.0"
 panic-probe = { version = "0.3" }
-rand = { version = "0.8.4", default-features = false }
+rand = { version = "0.9.0", default-features = false }
 serde = { version = "1.0.136", default-features = false }
 rtos-trace = "0.1.3"
 systemview-target = { version = "0.1.2", features = ["callbacks-app", "callbacks-os", "log", "cortex-m"] }

--- a/examples/nrf52840/Cargo.toml
+++ b/examples/nrf52840/Cargo.toml
@@ -25,7 +25,7 @@ static_cell = { version = "2" }
 cortex-m = { version = "0.7.6", features = ["inline-asm", "critical-section-single-core"] }
 cortex-m-rt = "0.7.0"
 panic-probe = { version = "0.3", features = ["print-defmt"] }
-rand = { version = "0.8.4", default-features = false }
+rand = { version = "0.9.0", default-features = false }
 embedded-storage = "0.3.1"
 usbd-hid = "0.8.1"
 serde = { version = "1.0.136", default-features = false }

--- a/examples/nrf52840/src/bin/rng.rs
+++ b/examples/nrf52840/src/bin/rng.rs
@@ -22,7 +22,7 @@ async fn main(_spawner: Spawner) {
     defmt::info!("Some random bytes: {:?}", bytes);
 
     // Sync API with `rand`
-    defmt::info!("A random number from 1 to 10: {:?}", rng.gen_range(1..=10));
+    defmt::info!("A random number from 1 to 10: {:?}", rng.random_range(1..=10));
 
     let mut bytes = [0; 1024];
     rng.fill_bytes(&mut bytes).await;

--- a/examples/nrf5340/Cargo.toml
+++ b/examples/nrf5340/Cargo.toml
@@ -21,7 +21,7 @@ static_cell = "2"
 cortex-m = { version = "0.7.6", features = ["inline-asm", "critical-section-single-core"] }
 cortex-m-rt = "0.7.0"
 panic-probe = { version = "0.3", features = ["print-defmt"] }
-rand = { version = "0.8.4", default-features = false }
+rand = { version = "0.9.0", default-features = false }
 embedded-storage = "0.3.1"
 usbd-hid = "0.8.1"
 serde = { version = "1.0.136", default-features = false }

--- a/examples/rp/Cargo.toml
+++ b/examples/rp/Cargo.toml
@@ -45,7 +45,7 @@ byte-slice-cast = { version = "1.2.0", default-features = false }
 smart-leds = "0.4.0"
 heapless = "0.8"
 usbd-hid = "0.8.1"
-rand_core = "0.6.4"
+rand_core = "0.9.1"
 
 embedded-hal-1 = { package = "embedded-hal", version = "1.0" }
 embedded-hal-async = "1.0"
@@ -55,7 +55,7 @@ embedded-storage = { version = "0.3" }
 static_cell = "2.1"
 portable-atomic = { version = "1.5", features = ["critical-section"] }
 log = "0.4"
-rand = { version = "0.8.5", default-features = false }
+rand = { version = "0.9.0", default-features = false }
 embedded-sdmmc = "0.7.0"
 
 [profile.release]

--- a/examples/rp/src/bin/usb_hid_mouse.rs
+++ b/examples/rp/src/bin/usb_hid_mouse.rs
@@ -85,8 +85,8 @@ async fn main(_spawner: Spawner) {
             _ = Timer::after_secs(1).await;
             let report = MouseReport {
                 buttons: 0,
-                x: rng.gen_range(-100..100), // random small x movement
-                y: rng.gen_range(-100..100), // random small y movement
+                x: rng.random_range(-100..100), // random small x movement
+                y: rng.random_range(-100..100), // random small y movement
                 wheel: 0,
                 pan: 0,
             };

--- a/examples/rp23/Cargo.toml
+++ b/examples/rp23/Cargo.toml
@@ -55,7 +55,7 @@ embedded-storage = { version = "0.3" }
 static_cell = "2.1"
 portable-atomic = { version = "1.5", features = ["critical-section"] }
 log = "0.4"
-rand = { version = "0.8.5", default-features = false }
+rand = { version = "0.9.0", default-features = false }
 embedded-sdmmc = "0.7.0"
 
 [profile.release]

--- a/examples/std/Cargo.toml
+++ b/examples/std/Cargo.toml
@@ -21,7 +21,7 @@ futures = { version = "0.3.17" }
 log = "0.4.14"
 nix = "0.26.2"
 clap = { version = "3.0.0-beta.5", features = ["derive"] }
-rand_core = { version = "0.6.3", features = ["std"] }
+rand_core = { version = "0.9.1", features = ["std", "os_rng"] }
 heapless = { version = "0.8", default-features = false }
 static_cell = "2"
 

--- a/examples/std/src/bin/net.rs
+++ b/examples/std/src/bin/net.rs
@@ -9,7 +9,7 @@ use embassy_time::Duration;
 use embedded_io_async::Write;
 use heapless::Vec;
 use log::*;
-use rand_core::{OsRng, RngCore};
+use rand_core::{OsRng, TryRngCore};
 use static_cell::StaticCell;
 
 #[derive(Parser)]
@@ -48,7 +48,7 @@ async fn main_task(spawner: Spawner) {
 
     // Generate random seed
     let mut seed = [0; 8];
-    OsRng.fill_bytes(&mut seed);
+    OsRng.try_fill_bytes(&mut seed).unwrap();
     let seed = u64::from_le_bytes(seed);
 
     // Init network stack

--- a/examples/std/src/bin/net_dns.rs
+++ b/examples/std/src/bin/net_dns.rs
@@ -5,7 +5,7 @@ use embassy_net::{Config, Ipv4Address, Ipv4Cidr, StackResources};
 use embassy_net_tuntap::TunTapDevice;
 use heapless::Vec;
 use log::*;
-use rand_core::{OsRng, RngCore};
+use rand_core::{OsRng, TryRngCore};
 use static_cell::StaticCell;
 
 #[derive(Parser)]
@@ -45,7 +45,7 @@ async fn main_task(spawner: Spawner) {
 
     // Generate random seed
     let mut seed = [0; 8];
-    OsRng.fill_bytes(&mut seed);
+    OsRng.try_fill_bytes(&mut seed).unwrap();
     let seed = u64::from_le_bytes(seed);
 
     // Init network stack

--- a/examples/std/src/bin/net_ppp.rs
+++ b/examples/std/src/bin/net_ppp.rs
@@ -23,7 +23,7 @@ use futures::io::BufReader;
 use heapless::Vec;
 use log::*;
 use nix::sys::termios;
-use rand_core::{OsRng, RngCore};
+use rand_core::{OsRng, TryRngCore};
 use static_cell::StaticCell;
 
 use crate::serial_port::SerialPort;
@@ -89,7 +89,7 @@ async fn main_task(spawner: Spawner) {
 
     // Generate random seed
     let mut seed = [0; 8];
-    OsRng.fill_bytes(&mut seed);
+    OsRng.try_fill_bytes(&mut seed).unwrap();
     let seed = u64::from_le_bytes(seed);
 
     // Init network stack

--- a/examples/std/src/bin/net_udp.rs
+++ b/examples/std/src/bin/net_udp.rs
@@ -5,7 +5,7 @@ use embassy_net::{Config, Ipv4Address, Ipv4Cidr, StackResources};
 use embassy_net_tuntap::TunTapDevice;
 use heapless::Vec;
 use log::*;
-use rand_core::{OsRng, RngCore};
+use rand_core::{OsRng, TryRngCore};
 use static_cell::StaticCell;
 
 #[derive(Parser)]
@@ -44,7 +44,7 @@ async fn main_task(spawner: Spawner) {
 
     // Generate random seed
     let mut seed = [0; 8];
-    OsRng.fill_bytes(&mut seed);
+    OsRng.try_fill_bytes(&mut seed).unwrap();
     let seed = u64::from_le_bytes(seed);
 
     // Init network stack

--- a/examples/std/src/bin/tcp_accept.rs
+++ b/examples/std/src/bin/tcp_accept.rs
@@ -7,7 +7,7 @@ use embassy_time::{Duration, Timer};
 use embedded_io_async::Write as _;
 use heapless::Vec;
 use log::*;
-use rand_core::{OsRng, RngCore};
+use rand_core::{OsRng, TryRngCore};
 use static_cell::StaticCell;
 
 #[derive(Parser)]
@@ -46,7 +46,7 @@ async fn main_task(spawner: Spawner) {
 
     // Generate random seed
     let mut seed = [0; 8];
-    OsRng.fill_bytes(&mut seed);
+    OsRng.try_fill_bytes(&mut seed).unwrap();
     let seed = u64::from_le_bytes(seed);
 
     // Init network stack

--- a/examples/stm32f7/Cargo.toml
+++ b/examples/stm32f7/Cargo.toml
@@ -24,7 +24,7 @@ embedded-hal = "0.2.6"
 panic-probe = { version = "0.3", features = ["print-defmt"] }
 heapless = { version = "0.8", default-features = false }
 nb = "1.0.0"
-rand_core = "0.6.3"
+rand_core = "0.9.1"
 critical-section = "1.1"
 embedded-storage = "0.3.1"
 static_cell = "2"

--- a/examples/stm32h5/Cargo.toml
+++ b/examples/stm32h5/Cargo.toml
@@ -26,7 +26,7 @@ embedded-io-async = { version = "0.6.1" }
 embedded-nal-async = "0.8.0"
 panic-probe = { version = "0.3", features = ["print-defmt"] }
 heapless = { version = "0.8", default-features = false }
-rand_core = "0.6.3"
+rand_core = "0.9.1"
 critical-section = "1.1"
 micromath = "2.0.0"
 stm32-fmc = "0.3.0"

--- a/examples/stm32h7/Cargo.toml
+++ b/examples/stm32h7/Cargo.toml
@@ -27,7 +27,7 @@ embedded-nal-async = "0.8.0"
 embedded-io-async = { version = "0.6.1" }
 panic-probe = { version = "0.3", features = ["print-defmt"] }
 heapless = { version = "0.8", default-features = false }
-rand_core = "0.6.3"
+rand_core = "0.9.1"
 critical-section = "1.1"
 micromath = "2.0.0"
 stm32-fmc = "0.3.0"

--- a/examples/stm32h723/Cargo.toml
+++ b/examples/stm32h723/Cargo.toml
@@ -24,7 +24,7 @@ embedded-nal-async = "0.8.0"
 embedded-io-async = { version = "0.6.1" }
 panic-probe = { version = "0.3", features = ["print-defmt"] }
 heapless = { version = "0.8", default-features = false }
-rand_core = "0.6.3"
+rand_core = "0.9.1"
 critical-section = "1.1"
 static_cell = "2"
 chrono = { version = "^0.4", default-features = false }

--- a/examples/stm32h755cm4/Cargo.toml
+++ b/examples/stm32h755cm4/Cargo.toml
@@ -27,7 +27,7 @@ embedded-nal-async = "0.8.0"
 embedded-io-async = { version = "0.6.1" }
 panic-probe = { version = "0.3", features = ["print-defmt"] }
 heapless = { version = "0.8", default-features = false }
-rand_core = "0.6.3"
+rand_core = "0.9.1"
 critical-section = "1.1"
 micromath = "2.0.0"
 stm32-fmc = "0.3.0"

--- a/examples/stm32h755cm7/Cargo.toml
+++ b/examples/stm32h755cm7/Cargo.toml
@@ -27,7 +27,7 @@ embedded-nal-async = "0.8.0"
 embedded-io-async = { version = "0.6.1" }
 panic-probe = { version = "0.3", features = ["print-defmt"] }
 heapless = { version = "0.8", default-features = false }
-rand_core = "0.6.3"
+rand_core = "0.9.1"
 critical-section = "1.1"
 micromath = "2.0.0"
 stm32-fmc = "0.3.0"

--- a/examples/stm32h7b0/Cargo.toml
+++ b/examples/stm32h7b0/Cargo.toml
@@ -26,7 +26,7 @@ embedded-nal-async = "0.8.0"
 embedded-io-async = { version = "0.6.1" }
 panic-probe = { version = "0.3", features = ["print-defmt"] }
 heapless = { version = "0.8", default-features = false }
-rand_core = "0.6.3"
+rand_core = "0.9.1"
 critical-section = "1.1"
 micromath = "2.0.0"
 stm32-fmc = "0.3.0"

--- a/examples/stm32h7rs/Cargo.toml
+++ b/examples/stm32h7rs/Cargo.toml
@@ -26,7 +26,7 @@ embedded-nal-async = "0.8.0"
 embedded-io-async = { version = "0.6.1" }
 panic-probe = { version = "0.3", features = ["print-defmt"] }
 heapless = { version = "0.8", default-features = false }
-rand_core = "0.6.3"
+rand_core = "0.9.1"
 critical-section = "1.1"
 micromath = "2.0.0"
 stm32-fmc = "0.3.0"

--- a/examples/stm32l4/Cargo.toml
+++ b/examples/stm32l4/Cargo.toml
@@ -30,7 +30,7 @@ embedded-hal-bus = { version = "0.1", features = ["async"] }
 panic-probe = { version = "0.3", features = ["print-defmt"] }
 heapless = { version = "0.8", default-features = false }
 chrono = { version = "^0.4", default-features = false }
-rand = { version = "0.8.5", default-features = false }
+rand = { version = "0.9.0", default-features = false }
 static_cell = "2"
 
 micromath = "2.0.0"

--- a/examples/stm32l5/Cargo.toml
+++ b/examples/stm32l5/Cargo.toml
@@ -23,7 +23,7 @@ cortex-m = { version = "0.7.6", features = ["inline-asm", "critical-section-sing
 cortex-m-rt = "0.7.0"
 embedded-hal = "0.2.6"
 heapless = { version = "0.8", default-features = false }
-rand_core = { version = "0.6.3", default-features = false }
+rand_core = { version = "0.9.1", default-features = false }
 embedded-io-async = { version = "0.6.1" }
 static_cell = "2"
 

--- a/tests/rp/Cargo.toml
+++ b/tests/rp/Cargo.toml
@@ -33,7 +33,7 @@ embedded-io-async = { version = "0.6.1" }
 embedded-storage = { version = "0.3" }
 static_cell = "2"
 portable-atomic = { version = "1.5", features = ["critical-section"] }
-rand = { version = "0.8.5", default-features = false }
+rand = { version = "0.9.0", default-features = false }
 
 [profile.dev]
 debug = 2

--- a/tests/stm32/Cargo.toml
+++ b/tests/stm32/Cargo.toml
@@ -79,8 +79,8 @@ embedded-hal-async = { version = "1.0" }
 embedded-can = { version = "0.4" }
 micromath = "2.0.0"
 panic-probe = { version = "0.3.0", features = ["print-defmt"] }
-rand_core = { version = "0.6", default-features = false }
-rand_chacha = { version = "0.3", default-features = false }
+rand_core = { version = "0.9.1", default-features = false }
+rand_chacha = { version = "0.9.0", default-features = false }
 static_cell = "2"
 portable-atomic = { version = "1.5", features = [] }
 

--- a/tests/utils/Cargo.toml
+++ b/tests/utils/Cargo.toml
@@ -4,5 +4,5 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-rand = "0.8"
+rand = "0.9"
 serial = "0.4"


### PR DESCRIPTION
This is kind of a follow-up on #3360.

Note that rand_core now provides a default implementation for TryRngCore so try_fill_bytes() is automatically implemented.
