### PR TITLE
Embassy-stm32: use constant array instead of match for PLL div/mul

### DIFF
--- a/embassy-stm32/build.rs
+++ b/embassy-stm32/build.rs
@@ -1434,8 +1434,8 @@ fn main() {
 
         if is_rcc_name(e.name) {
             let enum_name = format_ident!("{}", e.name);
-            let muls_ident = format_ident!("{}_MULS", enum_name);
-            let divs_ident = format_ident!("{}_DIVS", enum_name);
+            let muls_ident = format_ident!("{}_MULS", e.name.to_uppercase());
+            let divs_ident = format_ident!("{}_DIVS", e.name.to_uppercase());
 
             let mut mul_values = Vec::new();
             let mut div_values = Vec::new();
@@ -1474,7 +1474,7 @@ fn main() {
                 impl core::ops::Div<crate::pac::rcc::vals::#enum_name> for crate::time::Hertz {
                     type Output = crate::time::Hertz;
                     fn div(self, rhs: crate::pac::rcc::vals::#enum_name) -> Self::Output {
-                        let index = (rhs.to_bits() as usize);
+                        let index = rhs.to_bits() as usize;
                         self * #divs_ident[index] / #muls_ident[index]
                     }
                 }
@@ -1482,7 +1482,7 @@ fn main() {
                 impl core::ops::Mul<crate::pac::rcc::vals::#enum_name> for crate::time::Hertz {
                     type Output = crate::time::Hertz;
                     fn mul(self, rhs: crate::pac::rcc::vals::#enum_name) -> Self::Output {
-                        let index = (rhs.to_bits() as usize);
+                        let index = rhs.to_bits() as usize;
                         self * #muls_ident[index] / #divs_ident[index]
                     }
                 }

--- a/embassy-stm32/build.rs
+++ b/embassy-stm32/build.rs
@@ -1453,10 +1453,7 @@ fn main() {
                 min_val = v.value;
 
                 let Ok(val) = parse_num(v.name) else {
-                    panic!(
-                        "could not parse mul/div. enum={} variant={}",
-                        e.name, v.name
-                    )
+                    panic!("could not parse mul/div. enum={} variant={}", e.name, v.name)
                 };
                 let num = val.num;
                 let denom = val.denom;


### PR DESCRIPTION
# TL;DR
Change saves 1KB of code in debug and 1.2KB in release builds

## Why? 
As I was working with an example project I noticed that the `init_pll` function was taking a lot of space
digging deeper using `cargo bloat` I discovered that the abstraction to convert PLL DIV/MUL enums takes **1230 bytes**


Main issue comes from the fact that match statements are not a zero cost abstraction, ergo for large match statements (such as plln which has ~120 values), the size blows up quickly.

## Solution
This pull request replaces the proc macro with a constant array of the same style, and using the enum value as an index to this constant array.
RESERVED values output both 0 on mul and div, causing div/0 fault

## Testing
Using `cargo bloat` and `cargo bloat --release` I can see the following improvements for the following code section

Tested and ran on Nucleo STM32L432

profiles:

```toml
[profile.dev]
codegen-units = 1
debug = 2
debug-assertions = true # <-
incremental = false
opt-level = 2 # <-
overflow-checks = true # <-



[profile.release]
debug = 2
opt-level = "s"
lto = true
codegen-units = 1
```

```rust
...
  let mut config = Config::default();
    {
        use embassy_stm32::rcc::*;
        config.rcc.hsi48 = Some(Hsi48Config {
            sync_from_usb: true,
        }); // needed for USB
        config.rcc.sys = Sysclk::PLL1_R;
        config.rcc.hsi = true;
        config.rcc.pll = Some(Pll {
            source: PllSource::HSI,
            prediv: PllPreDiv::DIV2,
            mul: PllMul::MUL13,
            divp: None,
            divq: None,
            divr: Some(PllRDiv::DIV4), // sysclk 26Mhz (16/2)*13/4
        });
        config.rcc.mux.clk48sel = mux::Clk48sel::HSI48;

        config.rcc.mux.adcsel = mux::Adcsel::SYS;
    }
    let p = embassy_stm32::init(config);
...
```


## Results:
### pre modification debug
0.0%   1.8%    728B    embassy_stm32 embassy_stm32::rcc::_version::pll::init_pll
0.0%   2.0%    826B    embassy_stm32 embassy_stm32::_generated::<impl core::ops::arith::Mul<stm32_metapac::rcc::vals::Plln> for embassy_stm32::time::Hertz>::mul
0.0%   1.0%    404B    embassy_stm32 embassy_stm32::_generated::<impl core::ops::arith::Div<stm32_metapac::rcc::vals::Pllp> for embassy_stm32::time::Hertz>::div

Total bytes: **1958B**

### post modification debug
0.0%   2.3%    **992B**    embassy_stm32 embassy_stm32::rcc::_version::pll::init_pll

### pre modification release
0.2%   6.0%  **1.8KiB**            embassy_stm32 embassy_stm32::rcc::_version::pll::init_pll

### post modification release
0.0%   1.8%    **694B**    embassy_stm32 embassy_stm32::rcc::_version::pll::init_pll










