### PR TITLE
nrf5340: configure LFCLK

### DIFF
--- a/embassy-nrf/Cargo.toml
+++ b/embassy-nrf/Cargo.toml
@@ -57,6 +57,9 @@ nfc-pins-as-gpio = []
 ##  * nRF52820, nRF52833, nRF52840: P0_18
 reset-pin-as-gpio = []
 
+## Allow using the LFXO pins as regular GPIO pins (P0_00/P0_01 on nRF53)
+lfxo-pins-as-gpio = []
+
 ## Implements the MultiwriteNorFlash trait for QSPI. Should only be enabled if your external
 ## flash supports the semantics described [here](https://docs.rs/embedded-storage/0.3.1/embedded_storage/nor_flash/trait.MultiwriteNorFlash.html)
 qspi-multiwrite-flash = []

--- a/embassy-nrf/src/chips/nrf5340_app.rs
+++ b/embassy-nrf/src/chips/nrf5340_app.rs
@@ -262,9 +262,9 @@ embassy_hal_internal::peripherals! {
     PPI_GROUP5,
 
     // GPIO port 0
-    #[cfg(any(not(feature = "_nrf5340"), feature = "lfxo-pins-as-gpio"))]
+    #[cfg(feature = "lfxo-pins-as-gpio")]
     P0_00,
-    #[cfg(any(not(feature = "_nrf5340"), feature = "lfxo-pins-as-gpio"))]
+    #[cfg(feature = "lfxo-pins-as-gpio")]
     P0_01,
     #[cfg(feature = "nfc-pins-as-gpio")]
     P0_02,
@@ -370,9 +370,9 @@ impl_pdm!(PDM0, PDM0, PDM0);
 impl_qdec!(QDEC0, QDEC0, QDEC0);
 impl_qdec!(QDEC1, QDEC1, QDEC1);
 
-#[cfg(any(not(feature = "_nrf5340"), feature = "lfxo-pins-as-gpio"))]
+#[cfg(feature = "lfxo-pins-as-gpio")]
 impl_pin!(P0_00, 0, 0);
-#[cfg(any(not(feature = "_nrf5340"), feature = "lfxo-pins-as-gpio"))]
+#[cfg(feature = "lfxo-pins-as-gpio")]
 impl_pin!(P0_01, 0, 1);
 #[cfg(feature = "nfc-pins-as-gpio")]
 impl_pin!(P0_02, 0, 2);

--- a/embassy-nrf/src/chips/nrf5340_app.rs
+++ b/embassy-nrf/src/chips/nrf5340_app.rs
@@ -262,7 +262,9 @@ embassy_hal_internal::peripherals! {
     PPI_GROUP5,
 
     // GPIO port 0
+    #[cfg(any(not(feature = "_nrf5340"), feature = "lfxo-pins-as-gpio"))]
     P0_00,
+    #[cfg(any(not(feature = "_nrf5340"), feature = "lfxo-pins-as-gpio"))]
     P0_01,
     #[cfg(feature = "nfc-pins-as-gpio")]
     P0_02,
@@ -368,7 +370,9 @@ impl_pdm!(PDM0, PDM0, PDM0);
 impl_qdec!(QDEC0, QDEC0, QDEC0);
 impl_qdec!(QDEC1, QDEC1, QDEC1);
 
+#[cfg(any(not(feature = "_nrf5340"), feature = "lfxo-pins-as-gpio"))]
 impl_pin!(P0_00, 0, 0);
+#[cfg(any(not(feature = "_nrf5340"), feature = "lfxo-pins-as-gpio"))]
 impl_pin!(P0_01, 0, 1);
 #[cfg(feature = "nfc-pins-as-gpio")]
 impl_pin!(P0_02, 0, 2);

--- a/embassy-nrf/src/lib.rs
+++ b/embassy-nrf/src/lib.rs
@@ -65,7 +65,7 @@ compile_error!("feature `reset-pin-as-gpio` is only valid for nRF52 series chips
 #[cfg(all(feature = "nfc-pins-as-gpio", not(any(feature = "_nrf52", feature = "_nrf5340-app"))))]
 compile_error!("feature `nfc-pins-as-gpio` is only valid for nRF52, or nRF53's application core.");
 
-#[cfg(all(feature = "lfxo-pins-as-gpio", not(any(feature = "_nrf5340"))))]
+#[cfg(all(feature = "lfxo-pins-as-gpio", not(feature = "_nrf5340")))]
 compile_error!("feature `lfxo-pins-as-gpio` is only valid for nRF53 series chips.");
 
 // This mod MUST go first, so that the others see its macros.
@@ -285,24 +285,16 @@ pub mod config {
         /// Internal RC oscillator
         InternalRC,
         /// Synthesized from the high frequency clock source.
-        #[cfg(not(any(feature = "_nrf91")))]
+        #[cfg(not(feature = "_nrf91"))]
         Synthesized,
         /// External source from xtal.
-        #[cfg(not(all(feature = "_nrf5340", feature = "lfxo-pins-as-gpio")))]
+        #[cfg(not(feature = "lfxo-pins-as-gpio"))]
         ExternalXtal,
         /// External source from xtal with low swing applied.
-        #[cfg(not(any(
-            all(feature = "_nrf5340", feature = "lfxo-pins-as-gpio"),
-            feature = "_nrf91",
-            feature = "_nrf54l"
-        )))]
+        #[cfg(not(any(feature = "lfxo-pins-as-gpio", feature = "_nrf91", feature = "_nrf54l")))]
         ExternalLowSwing,
         /// External source from xtal with full swing applied.
-        #[cfg(not(any(
-            all(feature = "_nrf5340", feature = "lfxo-pins-as-gpio"),
-            feature = "_nrf91",
-            feature = "_nrf54l"
-        )))]
+        #[cfg(not(any(feature = "lfxo-pins-as-gpio", feature = "_nrf91", feature = "_nrf54l")))]
         ExternalFullSwing,
     }
 


### PR DESCRIPTION
Previously, `config.lfclk_source` was ignored on the nRF5340. This configures the LFCLK and also enables the Synthesized and External*Swing sources. And since the LFXO pins are shared with GPIO (P0.00 and P0.01), I've added the `lfxo-pins-as-gpio` feature.

I've only been able to test the ExternalXtal source.