### PR TITLE
Fix SetConfig implementation for STM32 I2C v2

### DIFF
--- a/embassy-stm32/src/i2c/v2.rs
+++ b/embassy-stm32/src/i2c/v2.rs
@@ -855,13 +855,22 @@ impl<'d, M: Mode> SetConfig for I2c<'d, M> {
     type Config = Hertz;
     type ConfigError = ();
     fn set_config(&mut self, config: &Self::Config) -> Result<(), ()> {
+        self.info.regs.cr1().modify(|reg| {
+            reg.set_pe(false);
+        });
+
         let timings = Timings::new(self.kernel_clock, *config);
+
         self.info.regs.timingr().write(|reg| {
             reg.set_presc(timings.prescale);
             reg.set_scll(timings.scll);
             reg.set_sclh(timings.sclh);
             reg.set_sdadel(timings.sdadel);
             reg.set_scldel(timings.scldel);
+        });
+
+        self.info.regs.cr1().modify(|reg| {
+            reg.set_pe(true);
         });
 
         Ok(())


### PR DESCRIPTION
The I2C peripheral needs to be disabled to change the timings register. This PR fixes the `SetConfig` implementation to disable the peripheral, set the timings, then re-enable it.

I took a glance at the v1 I2C implementation to see if this might be easy to add there, but that peripheral is sufficiently different that I did not feel comfortable changing it without a device to test on, which I don't have.

Fixes #3914.