### PR TITLE
Fix STM32 UART: Add separate TX waker and only clear idle flag in RingBufferedUartRx

### DIFF
--- a/embassy-stm32/src/usart/ringbuffered.rs
+++ b/embassy-stm32/src/usart/ringbuffered.rs
@@ -16,6 +16,7 @@ use crate::gpio::{AnyPin, SealedPin as _};
 use crate::mode::Async;
 use crate::time::Hertz;
 use crate::usart::{Regs, Sr};
+use crate::pac::usart::regs;
 
 /// Rx-only Ring-buffered UART Driver
 ///

--- a/embassy-stm32/src/usart/ringbuffered.rs
+++ b/embassy-stm32/src/usart/ringbuffered.rs
@@ -254,9 +254,12 @@ fn clear_idle_flag(r: Regs) -> Sr {
 
     // This read also clears the error and idle interrupt flags on v1.
     unsafe { rdr(r).read_volatile() };
-    let mut clear_idle = regs::Icr(0);
-    clear_idle.set_idle(true);
-    r.icr().write_value(clear_idle);
+    #[cfg(any(usart_v3, usart_v4))]
+    {
+        let mut clear_idle = regs::Icr(0);
+        clear_idle.set_idle(true);
+        r.icr().write_value(clear_idle);
+    }
 
     r.cr1().modify(|w| w.set_idleie(true));
 

--- a/embassy-stm32/src/usart/ringbuffered.rs
+++ b/embassy-stm32/src/usart/ringbuffered.rs
@@ -9,14 +9,15 @@ use embedded_io_async::ReadReady;
 use futures_util::future::{select, Either};
 
 use super::{
-    clear_interrupt_flags, rdr, reconfigure, set_baudrate, sr, Config, ConfigError, Error, Info, State, UartRx,
+    rdr, reconfigure, set_baudrate, sr, Config, ConfigError, Error, Info, State, UartRx,
 };
 use crate::dma::ReadableRingBuffer;
 use crate::gpio::{AnyPin, SealedPin as _};
 use crate::mode::Async;
+#[cfg(any(usart_v3, usart_v4))]
+use crate::pac::usart::regs;
 use crate::time::Hertz;
 use crate::usart::{Regs, Sr};
-use crate::pac::usart::regs;
 
 /// Rx-only Ring-buffered UART Driver
 ///

--- a/embassy-stm32/src/usart/ringbuffered.rs
+++ b/embassy-stm32/src/usart/ringbuffered.rs
@@ -254,7 +254,9 @@ fn clear_idle_flag(r: Regs) -> Sr {
 
     // This read also clears the error and idle interrupt flags on v1.
     unsafe { rdr(r).read_volatile() };
-    clear_interrupt_flags(r, sr);
+    let mut clear_idle = regs::Icr(0);
+    clear_idle.set_idle(true);
+    r.icr().write_value(clear_idle);
 
     r.cr1().modify(|w| w.set_idleie(true));
 

--- a/embassy-stm32/src/usart/ringbuffered.rs
+++ b/embassy-stm32/src/usart/ringbuffered.rs
@@ -8,9 +8,7 @@ use embassy_hal_internal::PeripheralRef;
 use embedded_io_async::ReadReady;
 use futures_util::future::{select, Either};
 
-use super::{
-    rdr, reconfigure, set_baudrate, sr, Config, ConfigError, Error, Info, State, UartRx,
-};
+use super::{rdr, reconfigure, set_baudrate, sr, Config, ConfigError, Error, Info, State, UartRx};
 use crate::dma::ReadableRingBuffer;
 use crate::gpio::{AnyPin, SealedPin as _};
 use crate::mode::Async;


### PR DESCRIPTION
This resolves an issue whereby one is unable to use a `UartTx` and a `RingBufferedUartRx` in parallel in separate tasks.

Firstly, it changes `clear_idle_flag` to ONLY clear the idle flag as the name suggests it should. Currently, it clears ALL set flags including TC which is checked by `UartTx::flush`. If the TX and RX are being used in parallel, it is possible for the RX to clear the TC flag before the TX can check it, which causes `UartTx::flush` to hang forever.

Secondly, it adds a separate `tx_waker`, otherwise when TX and RX are used in parallel they contend for the currently lone `rx_waker` and can overwrite each others wakers, causing hanging.