### PR TITLE
stm32: do not use private constructor

### DIFF
--- a/embassy-stm32/src/sai/mod.rs
+++ b/embassy-stm32/src/sai/mod.rs
@@ -936,7 +936,7 @@ impl<'d, T: Instance, W: word::Word> Sai<'d, T, W> {
                 w.set_nbslot(config.slot_count.0 as u8 - 1);
                 w.set_slotsz(config.slot_size.slotsz());
                 w.set_fboff(config.first_bit_offset.0 as u8);
-                w.set_sloten(vals::Sloten(config.slot_enable as u16));
+                w.set_sloten(vals::Sloten::from_bits(config.slot_enable as u16));
             });
 
             ch.cr1().modify(|w| w.set_saien(true));


### PR DESCRIPTION
I see compile errors using a recent git checkout of embassy with an stm32l431cb. Use the `from_bits` function instead.

```
error[E0603]: tuple struct constructor `Sloten` is private
    --> /usr/local/cargo/git/checkouts/embassy-9312dcb0ed774b29/17301c0/embassy-stm32/src/sai/mod.rs:939:36
     |
939  |                 w.set_sloten(vals::Sloten(config.slot_enable as u16));
     |                                    ^^^^^^ private tuple struct constructor
     |
    ::: /usr/local/cargo/git/checkouts/stm32-data-generated-cb34dad5f3150296/5ffbb82/stm32-metapac/src/chips/stm32l431cb/../../peripherals/sai_v2.rs:1523:23
     |
1523 |     pub struct Sloten(u16);
     |                       --- a constructor is private if any of the fields is private
     |
note: the tuple struct constructor `Sloten` is defined here
    --> /usr/local/cargo/git/checkouts/stm32-data-generated-cb34dad5f3150296/5ffbb82/stm32-metapac/src/chips/stm32l431cb/../../peripherals/sai_v2.rs:1523:5
     |
1523 |     pub struct Sloten(u16);
     |     ^^^^^^^^^^^^^^^^^
```