### PR TITLE
embassy-rp: pio: Add access to DMA engine byte swapping

### DIFF
--- a/cyw43-pio/src/lib.rs
+++ b/cyw43-pio/src/lib.rs
@@ -169,12 +169,12 @@ where
 
         self.sm.set_enable(true);
 
-        self.sm.tx().dma_push(self.dma.reborrow(), write).await;
+        self.sm.tx().dma_push(self.dma.reborrow(), write, false).await;
 
         let mut status = 0;
         self.sm
             .rx()
-            .dma_pull(self.dma.reborrow(), slice::from_mut(&mut status))
+            .dma_pull(self.dma.reborrow(), slice::from_mut(&mut status), false)
             .await;
         status
     }
@@ -201,13 +201,16 @@ where
         // self.cs.set_low();
         self.sm.set_enable(true);
 
-        self.sm.tx().dma_push(self.dma.reborrow(), slice::from_ref(&cmd)).await;
-        self.sm.rx().dma_pull(self.dma.reborrow(), read).await;
+        self.sm
+            .tx()
+            .dma_push(self.dma.reborrow(), slice::from_ref(&cmd), false)
+            .await;
+        self.sm.rx().dma_pull(self.dma.reborrow(), read, false).await;
 
         let mut status = 0;
         self.sm
             .rx()
-            .dma_pull(self.dma.reborrow(), slice::from_mut(&mut status))
+            .dma_pull(self.dma.reborrow(), slice::from_mut(&mut status), false)
             .await;
 
         #[cfg(feature = "defmt")]

--- a/embassy-rp/src/pio/mod.rs
+++ b/embassy-rp/src/pio/mod.rs
@@ -362,6 +362,7 @@ impl<'d, PIO: Instance, const SM: usize> StateMachineRx<'d, PIO, SM> {
         &'a mut self,
         ch: PeripheralRef<'a, C>,
         data: &'a mut [W],
+        bswap: bool,
     ) -> Transfer<'a, C> {
         let pio_no = PIO::PIO_NO;
         let p = ch.regs();
@@ -379,6 +380,7 @@ impl<'d, PIO: Instance, const SM: usize> StateMachineRx<'d, PIO, SM> {
             w.set_chain_to(ch.number());
             w.set_incr_read(false);
             w.set_incr_write(true);
+            w.set_bswap(bswap);
             w.set_en(true);
         });
         compiler_fence(Ordering::SeqCst);
@@ -447,7 +449,12 @@ impl<'d, PIO: Instance, const SM: usize> StateMachineTx<'d, PIO, SM> {
     }
 
     /// Prepare a DMA transfer to TX FIFO.
-    pub fn dma_push<'a, C: Channel, W: Word>(&'a mut self, ch: PeripheralRef<'a, C>, data: &'a [W]) -> Transfer<'a, C> {
+    pub fn dma_push<'a, C: Channel, W: Word>(
+        &'a mut self,
+        ch: PeripheralRef<'a, C>,
+        data: &'a [W],
+        bswap: bool,
+    ) -> Transfer<'a, C> {
         let pio_no = PIO::PIO_NO;
         let p = ch.regs();
         p.read_addr().write_value(data.as_ptr() as u32);
@@ -464,6 +471,7 @@ impl<'d, PIO: Instance, const SM: usize> StateMachineTx<'d, PIO, SM> {
             w.set_chain_to(ch.number());
             w.set_incr_read(true);
             w.set_incr_write(false);
+            w.set_bswap(bswap);
             w.set_en(true);
         });
         compiler_fence(Ordering::SeqCst);

--- a/embassy-rp/src/pio_programs/hd44780.rs
+++ b/embassy-rp/src/pio_programs/hd44780.rs
@@ -173,7 +173,7 @@ impl<'l, P: Instance, const S: usize> PioHD44780<'l, P, S> {
         sm.set_enable(true);
 
         // display on and cursor on and blinking, reset display
-        sm.tx().dma_push(dma.reborrow(), &[0x81u8, 0x0f, 1]).await;
+        sm.tx().dma_push(dma.reborrow(), &[0x81u8, 0x0f, 1], false).await;
 
         Self {
             dma: dma.map_into(),
@@ -198,6 +198,6 @@ impl<'l, P: Instance, const S: usize> PioHD44780<'l, P, S> {
         // set cursor to 1:15
         self.buf[38..].copy_from_slice(&[0x80, 0xcf]);
 
-        self.sm.tx().dma_push(self.dma.reborrow(), &self.buf).await;
+        self.sm.tx().dma_push(self.dma.reborrow(), &self.buf, false).await;
     }
 }

--- a/embassy-rp/src/pio_programs/i2s.rs
+++ b/embassy-rp/src/pio_programs/i2s.rs
@@ -90,6 +90,6 @@ impl<'a, P: Instance, const S: usize> PioI2sOut<'a, P, S> {
 
     /// Return an in-prograss dma transfer future. Awaiting it will guarentee a complete transfer.
     pub fn write<'b>(&'b mut self, buff: &'b [u32]) -> Transfer<'b, AnyChannel> {
-        self.sm.tx().dma_push(self.dma.reborrow(), buff)
+        self.sm.tx().dma_push(self.dma.reborrow(), buff, false)
     }
 }

--- a/embassy-rp/src/pio_programs/ws2812.rs
+++ b/embassy-rp/src/pio_programs/ws2812.rs
@@ -111,7 +111,7 @@ impl<'d, P: Instance, const S: usize, const N: usize> PioWs2812<'d, P, S, N> {
         }
 
         // DMA transfer
-        self.sm.tx().dma_push(self.dma.reborrow(), &words).await;
+        self.sm.tx().dma_push(self.dma.reborrow(), &words, false).await;
 
         Timer::after_micros(55).await;
     }

--- a/examples/rp/src/bin/pio_dma.rs
+++ b/examples/rp/src/bin/pio_dma.rs
@@ -72,8 +72,8 @@ async fn main(_spawner: Spawner) {
     loop {
         let (rx, tx) = sm.rx_tx();
         join(
-            tx.dma_push(dma_out_ref.reborrow(), &dout),
-            rx.dma_pull(dma_in_ref.reborrow(), &mut din),
+            tx.dma_push(dma_out_ref.reborrow(), &dout, false),
+            rx.dma_pull(dma_in_ref.reborrow(), &mut din, false),
         )
         .await;
         for i in 0..din.len() {

--- a/examples/rp235x/src/bin/pio_dma.rs
+++ b/examples/rp235x/src/bin/pio_dma.rs
@@ -72,8 +72,8 @@ async fn main(_spawner: Spawner) {
     loop {
         let (rx, tx) = sm.rx_tx();
         join(
-            tx.dma_push(dma_out_ref.reborrow(), &dout),
-            rx.dma_pull(dma_in_ref.reborrow(), &mut din),
+            tx.dma_push(dma_out_ref.reborrow(), &dout, false),
+            rx.dma_pull(dma_in_ref.reborrow(), &mut din, false),
         )
         .await;
         for i in 0..din.len() {


### PR DESCRIPTION
Changes the dma_pull/push function signatures to give callers access to the byte swap flag for their DMA transfers.