### PR TITLE
rp: Add unreleased changes to changelog

### DIFF
--- a/embassy-rp/CHANGELOG.md
+++ b/embassy-rp/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+- Add PIO functions. ([#3857](https://github.com/embassy-rs/embassy/pull/3857))  
+  The functions added in this change are `get_addr` `get_tx_threshold`, `set_tx_threshold`, `get_rx_threshold`, `set_rx_threshold`, `set_thresholds`.
+- Expose the watchdog reset reason. ([#3877](https://github.com/embassy-rs/embassy/pull/3877))
+- Update pio-rs, reexport, move instr methods to SM. ([#3865](https://github.com/embassy-rs/embassy/pull/3865))
+- rp235x: add ImageDef features. ([#3890](https://github.com/embassy-rs/embassy/pull/3890))
+- doc: Fix "the the" ([#3903](https://github.com/embassy-rs/embassy/pull/3903))
+
 ## 0.3.1 - 2025-02-06
 
 Small release fixing a few gnarly bugs, upgrading is strongly recommended.


### PR DESCRIPTION
Starting prep for an `embassy-rp` release.

Before the next crates.io publish of `embassy-rp` we also need a new release of the pio crates - `embassy-rp` currently depends on a git rev of `pio-rs`. This will be blocked on https://github.com/rp-rs/pio-rs/pull/73