### PR TITLE
stm32-usb: Use the susprdy bit to show disconnect

### DIFF
--- a/embassy-stm32/src/usb/usb.rs
+++ b/embassy-stm32/src/usb/usb.rs
@@ -858,7 +858,8 @@ impl<'d, T: Instance> driver::EndpointOut for Endpoint<'d, T, Out> {
                     }
                 }
             }
-        }).await;
+        })
+        .await;
 
         CTR_TRIGGERED[index].store(false, Ordering::Relaxed);
 
@@ -932,7 +933,8 @@ impl<'d, T: Instance> driver::EndpointIn for Endpoint<'d, T, In> {
                     }
                 }
             }
-        }).await;
+        })
+        .await;
 
         CTR_TRIGGERED[index].store(false, Ordering::Relaxed);
 


### PR DESCRIPTION
The USB peripheral does not require a VBUS connection. When USB is unplugged from a self-powered USB device, the existing drivers and hardware set the susprdy and the suspen bits.

It's also notable that the frame number stops counting.

I chose to use the susprdy bit as a way to identify when USB is unplugged to allow USB writes or reads to return an error.

references:
https://github.com/embassy-rs/embassy/issues/3740
https://www.st.com/resource/en/reference_manual/rm0444-stm32g0x1-advanced-armbased-32bit-mcus-stmicroelectronics.pdf p. 1285