### PR TITLE
Add ability to create STM32 timer channels with full pin configuration

### DIFF
--- a/embassy-stm32/src/lptim/pwm.rs
+++ b/embassy-stm32/src/lptim/pwm.rs
@@ -10,7 +10,9 @@ use super::OutputPin;
 #[cfg(any(lptim_v2a, lptim_v2b))]
 use super::{channel::Channel, timer::ChannelDirection, Channel1Pin, Channel2Pin};
 use super::{BasicInstance, Instance};
-use crate::gpio::{AfType, AnyPin, OutputType, Pull, Speed};
+#[cfg(gpio_v2)]
+use crate::gpio::Pull;
+use crate::gpio::{AfType, AnyPin, OutputType, Speed};
 use crate::time::Hertz;
 use crate::Peripheral;
 
@@ -33,13 +35,17 @@ pub struct PwmPin<'d, T, C> {
 ///
 /// This configures the pwm pin settings
 pub struct PwmPinConfig {
+    /// PWM Pin output type
     pub output_type: OutputType,
+    /// PWM Pin speed
     pub speed: Speed,
+    /// PWM Pin pull type
+    #[cfg(gpio_v2)]
     pub pull: Pull,
 }
 
 macro_rules! channel_impl {
-    ($new_chx:ident, $channel:ident, $pin_trait:ident) => {
+    ($new_chx:ident, $new_chx_with_config:ident, $channel:ident, $pin_trait:ident) => {
         impl<'d, T: BasicInstance> PwmPin<'d, T, $channel> {
             #[doc = concat!("Create a new ", stringify!($channel), " PWM pin instance.")]
             pub fn $new_chx(pin: impl Peripheral<P = impl $pin_trait<T>> + 'd) -> Self {
@@ -66,6 +72,9 @@ macro_rules! channel_impl {
                     pin.set_low();
                     pin.set_as_af(
                         pin.af_num(),
+                        #[cfg(gpio_v1)]
+                        AfType::output(pin_config.output_type, pin_config.speed),
+                        #[cfg(gpio_v2)]
                         AfType::output_pull(pin_config.output_type, pin_config.speed, pin_config.pull),
                     );
                 });
@@ -79,11 +88,11 @@ macro_rules! channel_impl {
 }
 
 #[cfg(not(any(lptim_v2a, lptim_v2b)))]
-channel_impl!(new, Output, OutputPin);
+channel_impl!(new, new_with_config, Output, OutputPin);
 #[cfg(any(lptim_v2a, lptim_v2b))]
-channel_impl!(new_ch1, Ch1, Channel1Pin);
+channel_impl!(new_ch1, new_ch1_with_config, Ch1, Channel1Pin);
 #[cfg(any(lptim_v2a, lptim_v2b))]
-channel_impl!(new_ch2, Ch2, Channel2Pin);
+channel_impl!(new_ch2, new_ch2_with_config, Ch2, Channel2Pin);
 
 /// PWM driver.
 pub struct Pwm<'d, T: Instance> {

--- a/embassy-stm32/src/lptim/pwm.rs
+++ b/embassy-stm32/src/lptim/pwm.rs
@@ -62,7 +62,7 @@ macro_rules! channel_impl {
                     phantom: PhantomData,
                 }
             }
-            #[doc = concat!("Create a new ", stringify!($channel), "_with_config PWM pin instance.")]
+            #[doc = concat!("Create a new ", stringify!($channel), " PWM pin instance with config.")]
             pub fn $new_chx_with_config(
                 pin: impl Peripheral<P = impl $pin_trait<T>> + 'd,
                 pin_config: PwmPinConfig,

--- a/embassy-stm32/src/timer/simple_pwm.rs
+++ b/embassy-stm32/src/timer/simple_pwm.rs
@@ -7,7 +7,7 @@ use embassy_hal_internal::{into_ref, PeripheralRef};
 
 use super::low_level::{CountingMode, OutputCompareMode, OutputPolarity, Timer};
 use super::{Channel, Channel1Pin, Channel2Pin, Channel3Pin, Channel4Pin, GeneralInstance4Channel, TimerBits};
-use crate::gpio::{AfType, AnyPin, OutputType, Speed};
+use crate::gpio::{AfType, AnyPin, OutputType, Pull, Speed};
 use crate::time::Hertz;
 use crate::Peripheral;
 
@@ -28,6 +28,15 @@ pub struct PwmPin<'d, T, C> {
     phantom: PhantomData<(T, C)>,
 }
 
+/// PWM pin config
+///
+/// This configures the pwm pin settings
+pub struct PwmPinConfig {
+    pub output_type: OutputType,
+    pub speed: Speed,
+    pub pull: Pull,
+}
+
 macro_rules! channel_impl {
     ($new_chx:ident, $channel:ident, $pin_trait:ident) => {
         impl<'d, T: GeneralInstance4Channel> PwmPin<'d, T, $channel> {
@@ -37,6 +46,24 @@ macro_rules! channel_impl {
                 critical_section::with(|_| {
                     pin.set_low();
                     pin.set_as_af(pin.af_num(), AfType::output(output_type, Speed::VeryHigh));
+                });
+                PwmPin {
+                    _pin: pin.map_into(),
+                    phantom: PhantomData,
+                }
+            }
+            #[doc = concat!("Create a new ", stringify!($channel), "_with_config PWM pin instance.")]
+            pub fn $new_chx_with_config(
+                pin: impl Peripheral<P = impl $pin_trait<T>> + 'd,
+                pin_config: PwmPinConfig,
+            ) -> Self {
+                into_ref!(pin);
+                critical_section::with(|_| {
+                    pin.set_low();
+                    pin.set_as_af(
+                        pin.af_num(),
+                        AfType::output_pull(pin_config.output_type, pin_config.speed, pin_config.pull),
+                    );
                 });
                 PwmPin {
                     _pin: pin.map_into(),

--- a/embassy-stm32/src/timer/simple_pwm.rs
+++ b/embassy-stm32/src/timer/simple_pwm.rs
@@ -7,7 +7,9 @@ use embassy_hal_internal::{into_ref, PeripheralRef};
 
 use super::low_level::{CountingMode, OutputCompareMode, OutputPolarity, Timer};
 use super::{Channel, Channel1Pin, Channel2Pin, Channel3Pin, Channel4Pin, GeneralInstance4Channel, TimerBits};
-use crate::gpio::{AfType, AnyPin, OutputType, Pull, Speed};
+#[cfg(gpio_v2)]
+use crate::gpio::Pull;
+use crate::gpio::{AfType, AnyPin, OutputType, Speed};
 use crate::time::Hertz;
 use crate::Peripheral;
 
@@ -32,13 +34,17 @@ pub struct PwmPin<'d, T, C> {
 ///
 /// This configures the pwm pin settings
 pub struct PwmPinConfig {
+    /// PWM Pin output type
     pub output_type: OutputType,
+    /// PWM Pin speed
     pub speed: Speed,
+    /// PWM Pin pull type
+    #[cfg(gpio_v2)]
     pub pull: Pull,
 }
 
 macro_rules! channel_impl {
-    ($new_chx:ident, $channel:ident, $pin_trait:ident) => {
+    ($new_chx:ident, $new_chx_with_config:ident, $channel:ident, $pin_trait:ident) => {
         impl<'d, T: GeneralInstance4Channel> PwmPin<'d, T, $channel> {
             #[doc = concat!("Create a new ", stringify!($channel), " PWM pin instance.")]
             pub fn $new_chx(pin: impl Peripheral<P = impl $pin_trait<T>> + 'd, output_type: OutputType) -> Self {
@@ -52,6 +58,7 @@ macro_rules! channel_impl {
                     phantom: PhantomData,
                 }
             }
+
             #[doc = concat!("Create a new ", stringify!($channel), "_with_config PWM pin instance.")]
             pub fn $new_chx_with_config(
                 pin: impl Peripheral<P = impl $pin_trait<T>> + 'd,
@@ -62,6 +69,9 @@ macro_rules! channel_impl {
                     pin.set_low();
                     pin.set_as_af(
                         pin.af_num(),
+                        #[cfg(gpio_v1)]
+                        AfType::output(pin_config.output_type, pin_config.speed),
+                        #[cfg(gpio_v2)]
                         AfType::output_pull(pin_config.output_type, pin_config.speed, pin_config.pull),
                     );
                 });
@@ -74,10 +84,10 @@ macro_rules! channel_impl {
     };
 }
 
-channel_impl!(new_ch1, Ch1, Channel1Pin);
-channel_impl!(new_ch2, Ch2, Channel2Pin);
-channel_impl!(new_ch3, Ch3, Channel3Pin);
-channel_impl!(new_ch4, Ch4, Channel4Pin);
+channel_impl!(new_ch1, new_ch1_with_config, Ch1, Channel1Pin);
+channel_impl!(new_ch2, new_ch2_with_config, Ch2, Channel2Pin);
+channel_impl!(new_ch3, new_ch3_with_config, Ch3, Channel3Pin);
+channel_impl!(new_ch4, new_ch4_with_config, Ch4, Channel4Pin);
 
 /// A single channel of a pwm, obtained from [`SimplePwm::split`],
 /// [`SimplePwm::channel`], [`SimplePwm::ch1`], etc.

--- a/embassy-stm32/src/timer/simple_pwm.rs
+++ b/embassy-stm32/src/timer/simple_pwm.rs
@@ -59,7 +59,7 @@ macro_rules! channel_impl {
                 }
             }
 
-            #[doc = concat!("Create a new ", stringify!($channel), "_with_config PWM pin instance.")]
+            #[doc = concat!("Create a new ", stringify!($channel), " PWM pin instance with config.")]
             pub fn $new_chx_with_config(
                 pin: impl Peripheral<P = impl $pin_trait<T>> + 'd,
                 pin_config: PwmPinConfig,


### PR DESCRIPTION
Currently there is no way to specify either timer or lptimer pwm channel pin configuration. This PR adds the ability for specifying the pins output type, pull, and speed depending on the gpio version.