### PR TITLE
fix(stm32): handle half-duplex in ringbuffered read

### DIFF
--- a/embassy-stm32/src/usart/mod.rs
+++ b/embassy-stm32/src/usart/mod.rs
@@ -716,7 +716,6 @@ impl<'d> UartRx<'d, Async> {
 
         // make sure USART state is restored to neutral state when this future is dropped
         let on_drop = OnDrop::new(move || {
-            // defmt::trace!("Clear all USART interrupts and DMA Read Request");
             // clear all interrupts and DMA Rx Request
             r.cr1().modify(|w| {
                 // disable RXNE interrupt


### PR DESCRIPTION
This PR fixes an issue introduced in PR #3379, where the transmitter disable/receiver enable operation in half-duplex mode was moved from the flush method to the read methods. However, that PR did not account for the ringbuffered read method.