### PR TITLE
rp: embassy-rp 0.4.0 release prep

### DIFF
--- a/cyw43-pio/CHANGELOG.md
+++ b/cyw43-pio/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+- Update embassy-rp to 0.4.0
+
 ## 0.3.0 - 2025-01-05
 
 - Update embassy-time to 0.4.0

--- a/cyw43-pio/Cargo.toml
+++ b/cyw43-pio/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cyw43-pio"
-version = "0.3.0"
+version = "0.4.0"
 edition = "2021"
 description = "RP2040 PIO SPI implementation for cyw43"
 keywords = ["embedded", "cyw43", "embassy-net", "embedded-hal-async", "wifi"]
@@ -11,7 +11,7 @@ documentation = "https://docs.embassy.dev/cyw43-pio"
 
 [dependencies]
 cyw43 = { version = "0.3.0", path = "../cyw43" }
-embassy-rp = { version = "0.3.0", path = "../embassy-rp" }
+embassy-rp = { version = "0.4.0", path = "../embassy-rp" }
 fixed = "1.23.1"
 defmt = { version = "0.3", optional = true }
 

--- a/embassy-boot-rp/Cargo.toml
+++ b/embassy-boot-rp/Cargo.toml
@@ -25,7 +25,7 @@ defmt = { version = "0.3", optional = true }
 log = { version = "0.4", optional = true }
 
 embassy-sync = { version = "0.6.2", path = "../embassy-sync" }
-embassy-rp = { version = "0.3.0", path = "../embassy-rp", default-features = false }
+embassy-rp = { version = "0.4.0", path = "../embassy-rp", default-features = false }
 embassy-boot = { version = "0.4.0", path = "../embassy-boot" }
 embassy-time = { version = "0.4.0", path = "../embassy-time" }
 

--- a/embassy-boot-rp/Cargo.toml
+++ b/embassy-boot-rp/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 edition = "2021"
 name = "embassy-boot-rp"
-version = "0.4.0"
+version = "0.5.0"
 description = "Bootloader lib for RP2040 chips"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/embassy-rs/embassy"

--- a/embassy-rp/CHANGELOG.md
+++ b/embassy-rp/CHANGELOG.md
@@ -7,12 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+## 0.4.0 - 2025-03-09
+
 - Add PIO functions. ([#3857](https://github.com/embassy-rs/embassy/pull/3857))  
   The functions added in this change are `get_addr` `get_tx_threshold`, `set_tx_threshold`, `get_rx_threshold`, `set_rx_threshold`, `set_thresholds`.
 - Expose the watchdog reset reason. ([#3877](https://github.com/embassy-rs/embassy/pull/3877))
 - Update pio-rs, reexport, move instr methods to SM. ([#3865](https://github.com/embassy-rs/embassy/pull/3865))
 - rp235x: add ImageDef features. ([#3890](https://github.com/embassy-rs/embassy/pull/3890))
 - doc: Fix "the the" ([#3903](https://github.com/embassy-rs/embassy/pull/3903))
+- pio: Add access to DMA engine byte swapping ([#3935](https://github.com/embassy-rs/embassy/pull/3935))
 
 ## 0.3.1 - 2025-02-06
 

--- a/embassy-rp/Cargo.toml
+++ b/embassy-rp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "embassy-rp"
-version = "0.3.0"
+version = "0.4.0"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 description = "Embassy Hardware Abstraction Layer (HAL) for the Raspberry Pi RP2040 microcontroller"

--- a/embassy-rp/Cargo.toml
+++ b/embassy-rp/Cargo.toml
@@ -164,7 +164,7 @@ embedded-hal-1 = { package = "embedded-hal", version = "1.0" }
 embedded-hal-async = { version = "1.0" }
 embedded-hal-nb = { version = "1.0" }
 
-pio = { git = "https://github.com/rp-rs/pio-rs", rev = "506a51b9bc135845e8544a0debd75847b73754dc" }
+pio = { version = "0.3" }
 rp2040-boot2 = "0.3"
 document-features = "0.2.10"
 sha2-const-stable = "0.1"

--- a/examples/boot/application/rp/Cargo.toml
+++ b/examples/boot/application/rp/Cargo.toml
@@ -9,7 +9,7 @@ embassy-sync = { version = "0.6.2", path = "../../../../embassy-sync" }
 embassy-executor = { version = "0.7.0", path = "../../../../embassy-executor", features = ["task-arena-size-16384", "arch-cortex-m", "executor-thread", "arch-cortex-m", "executor-thread"] }
 embassy-time = { version = "0.4.0", path = "../../../../embassy-time", features = [] }
 embassy-rp = { version = "0.4.0", path = "../../../../embassy-rp", features = ["time-driver", "rp2040"] }
-embassy-boot-rp = { version = "0.4.0", path = "../../../../embassy-boot-rp", features = [] }
+embassy-boot-rp = { version = "0.5.0", path = "../../../../embassy-boot-rp", features = [] }
 embassy-embedded-hal = { version = "0.3.0", path = "../../../../embassy-embedded-hal" }
 
 defmt = "0.3"

--- a/examples/boot/application/rp/Cargo.toml
+++ b/examples/boot/application/rp/Cargo.toml
@@ -8,7 +8,7 @@ license = "MIT OR Apache-2.0"
 embassy-sync = { version = "0.6.2", path = "../../../../embassy-sync" }
 embassy-executor = { version = "0.7.0", path = "../../../../embassy-executor", features = ["task-arena-size-16384", "arch-cortex-m", "executor-thread", "arch-cortex-m", "executor-thread"] }
 embassy-time = { version = "0.4.0", path = "../../../../embassy-time", features = [] }
-embassy-rp = { version = "0.3.0", path = "../../../../embassy-rp", features = ["time-driver", "rp2040"] }
+embassy-rp = { version = "0.4.0", path = "../../../../embassy-rp", features = ["time-driver", "rp2040"] }
 embassy-boot-rp = { version = "0.4.0", path = "../../../../embassy-boot-rp", features = [] }
 embassy-embedded-hal = { version = "0.3.0", path = "../../../../embassy-embedded-hal" }
 

--- a/examples/rp/Cargo.toml
+++ b/examples/rp/Cargo.toml
@@ -17,7 +17,7 @@ embassy-net-wiznet = { version = "0.2.0", path = "../../embassy-net-wiznet", fea
 embassy-futures = { version = "0.1.0", path = "../../embassy-futures" }
 embassy-usb-logger = { version = "0.4.0", path = "../../embassy-usb-logger" }
 cyw43 = { version = "0.3.0", path = "../../cyw43", features = ["defmt", "firmware-logs"] }
-cyw43-pio = { version = "0.3.0", path = "../../cyw43-pio", features = ["defmt"] }
+cyw43-pio = { version = "0.4.0", path = "../../cyw43-pio", features = ["defmt"] }
 
 defmt = "0.3"
 defmt-rtt = "0.4"

--- a/examples/rp/Cargo.toml
+++ b/examples/rp/Cargo.toml
@@ -10,7 +10,7 @@ embassy-embedded-hal = { version = "0.3.0", path = "../../embassy-embedded-hal",
 embassy-sync = { version = "0.6.2", path = "../../embassy-sync", features = ["defmt"] }
 embassy-executor = { version = "0.7.0", path = "../../embassy-executor", features = ["task-arena-size-98304", "arch-cortex-m", "executor-thread", "executor-interrupt", "defmt"] }
 embassy-time = { version = "0.4.0", path = "../../embassy-time", features = ["defmt", "defmt-timestamp-uptime"] }
-embassy-rp = { version = "0.3.0", path = "../../embassy-rp", features = ["defmt", "unstable-pac", "time-driver", "critical-section-impl", "rp2040"] }
+embassy-rp = { version = "0.4.0", path = "../../embassy-rp", features = ["defmt", "unstable-pac", "time-driver", "critical-section-impl", "rp2040"] }
 embassy-usb = { version = "0.4.0", path = "../../embassy-usb", features = ["defmt"] }
 embassy-net = { version = "0.7.0", path = "../../embassy-net", features = ["defmt", "icmp", "tcp", "udp", "raw", "dhcpv4", "medium-ethernet", "dns", "proto-ipv4", "proto-ipv6", "multicast"] }
 embassy-net-wiznet = { version = "0.2.0", path = "../../embassy-net-wiznet", features = ["defmt"] }

--- a/examples/rp235x/Cargo.toml
+++ b/examples/rp235x/Cargo.toml
@@ -17,7 +17,7 @@ embassy-net-wiznet = { version = "0.2.0", path = "../../embassy-net-wiznet", fea
 embassy-futures = { version = "0.1.0", path = "../../embassy-futures" }
 embassy-usb-logger = { version = "0.4.0", path = "../../embassy-usb-logger" }
 cyw43 = { version = "0.3.0", path = "../../cyw43", features = ["defmt", "firmware-logs"] }
-cyw43-pio = { version = "0.3.0", path = "../../cyw43-pio", features = ["defmt"] }
+cyw43-pio = { version = "0.4.0", path = "../../cyw43-pio", features = ["defmt"] }
 
 defmt = "0.3"
 defmt-rtt = "0.4"

--- a/examples/rp235x/Cargo.toml
+++ b/examples/rp235x/Cargo.toml
@@ -10,7 +10,7 @@ embassy-embedded-hal = { version = "0.3.0", path = "../../embassy-embedded-hal",
 embassy-sync = { version = "0.6.2", path = "../../embassy-sync", features = ["defmt"] }
 embassy-executor = { version = "0.7.0", path = "../../embassy-executor", features = ["task-arena-size-98304", "arch-cortex-m", "executor-thread", "executor-interrupt", "defmt"] }
 embassy-time = { version = "0.4.0", path = "../../embassy-time", features = ["defmt", "defmt-timestamp-uptime"] }
-embassy-rp = { version = "0.3.0", path = "../../embassy-rp", features = ["defmt", "unstable-pac", "time-driver", "critical-section-impl", "rp235xa", "binary-info"] }
+embassy-rp = { version = "0.4.0", path = "../../embassy-rp", features = ["defmt", "unstable-pac", "time-driver", "critical-section-impl", "rp235xa", "binary-info"] }
 embassy-usb = { version = "0.4.0", path = "../../embassy-usb", features = ["defmt"] }
 embassy-net = { version = "0.7.0", path = "../../embassy-net", features = ["defmt", "tcp", "udp", "raw", "dhcpv4", "medium-ethernet", "dns"] }
 embassy-net-wiznet = { version = "0.2.0", path = "../../embassy-net-wiznet", features = ["defmt"] }

--- a/tests/rp/Cargo.toml
+++ b/tests/rp/Cargo.toml
@@ -15,7 +15,7 @@ teleprobe-meta = "1.1"
 embassy-sync = { version = "0.6.2", path = "../../embassy-sync", features = ["defmt"] }
 embassy-executor = { version = "0.7.0", path = "../../embassy-executor", features = ["task-arena-size-32768", "arch-cortex-m", "executor-thread", "defmt"] }
 embassy-time = { version = "0.4.0", path = "../../embassy-time", features = ["defmt", ] }
-embassy-rp = { version = "0.3.0", path = "../../embassy-rp", features = [ "defmt", "unstable-pac", "time-driver", "critical-section-impl", "intrinsics", "rom-v2-intrinsics", "run-from-ram"]  }
+embassy-rp = { version = "0.4.0", path = "../../embassy-rp", features = [ "defmt", "unstable-pac", "time-driver", "critical-section-impl", "intrinsics", "rom-v2-intrinsics", "run-from-ram"]  }
 embassy-futures = { version = "0.1.0", path = "../../embassy-futures" }
 embassy-net = { version = "0.7.0", path = "../../embassy-net", features = ["defmt",  "tcp", "udp", "dhcpv4", "medium-ethernet"] }
 embassy-net-wiznet = { version = "0.2.0", path = "../../embassy-net-wiznet", features = ["defmt"] }


### PR DESCRIPTION
A new embassy-rp release should be ready to ship after these changes.

No code changes, just bumping crate numbers and updating changelogs.
I also updated cyw43-pio and embassy-boot-rp as they depends on the hal version, and I wanted to ensure CI was green