### PR TITLE
preserve user attributes

### DIFF
--- a/embassy-executor-macros/src/macros/main.rs
+++ b/embassy-executor-macros/src/macros/main.rs
@@ -155,6 +155,11 @@ pub fn run(args: TokenStream, item: TokenStream, arch: &Arch) -> TokenStream {
         ),
     };
 
+    let mut main_attrs = TokenStream::new();
+    for attr in f.attrs {
+        main_attrs.extend(quote!(#attr));
+    }
+
     if !errors.is_empty() {
         main_body = quote! {loop{}};
     }
@@ -167,6 +172,7 @@ pub fn run(args: TokenStream, item: TokenStream, arch: &Arch) -> TokenStream {
         }
 
         #entry
+        #main_attrs
         fn main() -> #main_ret {
             #main_body
         }


### PR DESCRIPTION
This change preserves the user attributes on the user entry point.
For example, for my Cortex-A target, I do not have an entry point, or there might be device specific entry points.
However, I use `#[export_name = "main"]` so my debugger can find/use the entry point. Without this change, this
attribute was discarded.