### PR TITLE
Stm32 usart: implement pin config for cts, tx, rts and de

### DIFF
--- a/embassy-stm32/src/usart/buffered.rs
+++ b/embassy-stm32/src/usart/buffered.rs
@@ -13,8 +13,8 @@ use embassy_sync::waitqueue::AtomicWaker;
 use super::DePin;
 use super::{
     clear_interrupt_flags, configure, half_duplex_set_rx_tx_before_write, rdr, reconfigure, send_break, set_baudrate,
-    sr, tdr, Config, ConfigError, CtsPin, Duplex, Error, HalfDuplexReadback, Info, Instance, Regs,
-    RtsPin, RxPin, TxPin,
+    sr, tdr, Config, ConfigError, CtsPin, Duplex, Error, HalfDuplexReadback, Info, Instance, Regs, RtsPin, RxPin,
+    TxPin,
 };
 use crate::gpio::{AfType, AnyPin, Pull, SealedPin as _};
 use crate::interrupt::{self, InterruptExt};

--- a/embassy-stm32/src/usart/buffered.rs
+++ b/embassy-stm32/src/usart/buffered.rs
@@ -13,7 +13,7 @@ use embassy_sync::waitqueue::AtomicWaker;
 use super::DePin;
 use super::{
     clear_interrupt_flags, configure, half_duplex_set_rx_tx_before_write, rdr, reconfigure, send_break, set_baudrate,
-    sr, tdr, Config, ConfigError, CtsPin, Duplex, Error, HalfDuplexConfig, HalfDuplexReadback, Info, Instance, Regs,
+    sr, tdr, Config, ConfigError, CtsPin, Duplex, Error, HalfDuplexReadback, Info, Instance, Regs,
     RtsPin, RxPin, TxPin,
 };
 use crate::gpio::{AfType, AnyPin, Pull, SealedPin as _};
@@ -346,7 +346,6 @@ impl<'d> BufferedUart<'d> {
         rx_buffer: &'d mut [u8],
         mut config: Config,
         readback: HalfDuplexReadback,
-        half_duplex: HalfDuplexConfig,
     ) -> Result<Self, ConfigError> {
         #[cfg(not(any(usart_v1, usart_v2)))]
         {
@@ -357,7 +356,7 @@ impl<'d> BufferedUart<'d> {
         Self::new_inner(
             peri,
             None,
-            new_pin!(tx, half_duplex.af_type()),
+            new_pin!(tx, config.tx_af()),
             None,
             None,
             None,
@@ -386,14 +385,13 @@ impl<'d> BufferedUart<'d> {
         rx_buffer: &'d mut [u8],
         mut config: Config,
         readback: HalfDuplexReadback,
-        half_duplex: HalfDuplexConfig,
     ) -> Result<Self, ConfigError> {
         config.swap_rx_tx = true;
         config.duplex = Duplex::Half(readback);
 
         Self::new_inner(
             peri,
-            new_pin!(rx, half_duplex.af_type()),
+            new_pin!(rx, config.rx_af()),
             None,
             None,
             None,

--- a/embassy-stm32/src/usart/buffered.rs
+++ b/embassy-stm32/src/usart/buffered.rs
@@ -16,7 +16,7 @@ use super::{
     sr, tdr, Config, ConfigError, CtsPin, Duplex, Error, HalfDuplexConfig, HalfDuplexReadback, Info, Instance, Regs,
     RtsPin, RxPin, TxPin,
 };
-use crate::gpio::{AfType, AnyPin, OutputType, Pull, SealedPin as _, Speed};
+use crate::gpio::{AfType, AnyPin, Pull, SealedPin as _};
 use crate::interrupt::{self, InterruptExt};
 use crate::time::Hertz;
 
@@ -217,8 +217,8 @@ impl<'d> BufferedUart<'d> {
     ) -> Result<Self, ConfigError> {
         Self::new_inner(
             peri,
-            new_pin!(rx, AfType::input(config.rx_pull)),
-            new_pin!(tx, AfType::output(OutputType::PushPull, Speed::Medium)),
+            new_pin!(rx, config.rx_af()),
+            new_pin!(tx, config.tx_af()),
             None,
             None,
             None,
@@ -242,10 +242,10 @@ impl<'d> BufferedUart<'d> {
     ) -> Result<Self, ConfigError> {
         Self::new_inner(
             peri,
-            new_pin!(rx, AfType::input(Pull::None)),
-            new_pin!(tx, AfType::output(OutputType::PushPull, Speed::Medium)),
-            new_pin!(rts, AfType::output(OutputType::PushPull, Speed::Medium)),
-            new_pin!(cts, AfType::input(Pull::None)),
+            new_pin!(rx, config.rx_af()),
+            new_pin!(tx, config.tx_af()),
+            new_pin!(rts, config.rts_config.af_type()),
+            new_pin!(cts, AfType::input(config.cts_pull)),
             None,
             tx_buffer,
             rx_buffer,
@@ -266,8 +266,8 @@ impl<'d> BufferedUart<'d> {
     ) -> Result<Self, ConfigError> {
         Self::new_inner(
             peri,
-            new_pin!(rx, AfType::input(Pull::None)),
-            new_pin!(tx, AfType::output(OutputType::PushPull, Speed::Medium)),
+            new_pin!(rx, config.rx_af()),
+            new_pin!(tx, config.tx_af()),
             None,
             None,
             new_pin!(rts, AfType::input(Pull::None)), // RTS mapped used as DE
@@ -290,8 +290,8 @@ impl<'d> BufferedUart<'d> {
     ) -> Result<Self, ConfigError> {
         Self::new_inner(
             peri,
-            new_pin!(rx, AfType::input(Pull::None)),
-            new_pin!(tx, AfType::output(OutputType::PushPull, Speed::Medium)),
+            new_pin!(rx, config.rx_af()),
+            new_pin!(tx, config.tx_af()),
             new_pin!(rts, AfType::input(Pull::None)),
             None, // no CTS
             None, // no DE
@@ -315,11 +315,11 @@ impl<'d> BufferedUart<'d> {
     ) -> Result<Self, ConfigError> {
         Self::new_inner(
             peri,
-            new_pin!(rx, AfType::input(config.rx_pull)),
-            new_pin!(tx, AfType::output(OutputType::PushPull, Speed::Medium)),
+            new_pin!(rx, config.rx_af()),
+            new_pin!(tx, config.tx_af()),
             None,
             None,
-            new_pin!(de, AfType::output(OutputType::PushPull, Speed::Medium)),
+            new_pin!(de, config.de_config.af_type()),
             tx_buffer,
             rx_buffer,
             config,

--- a/embassy-stm32/src/usart/mod.rs
+++ b/embassy-stm32/src/usart/mod.rs
@@ -450,13 +450,7 @@ impl<'d> UartTx<'d, Async> {
         tx_dma: Peri<'d, impl TxDma<T>>,
         config: Config,
     ) -> Result<Self, ConfigError> {
-        Self::new_inner(
-            peri,
-            new_pin!(tx, config.tx_af()),
-            None,
-            new_dma!(tx_dma),
-            config,
-        )
+        Self::new_inner(peri, new_pin!(tx, config.tx_af()), None, new_dma!(tx_dma), config)
     }
 
     /// Create a new tx-only UART with a clear-to-send pin
@@ -508,13 +502,7 @@ impl<'d> UartTx<'d, Blocking> {
         tx: Peri<'d, impl TxPin<T>>,
         config: Config,
     ) -> Result<Self, ConfigError> {
-        Self::new_inner(
-            peri,
-            new_pin!(tx, config.tx_af()),
-            None,
-            None,
-            config,
-        )
+        Self::new_inner(peri, new_pin!(tx, config.tx_af()), None, None, config)
     }
 
     /// Create a new blocking tx-only UART with a clear-to-send pin
@@ -682,13 +670,7 @@ impl<'d> UartRx<'d, Async> {
         rx_dma: Peri<'d, impl RxDma<T>>,
         config: Config,
     ) -> Result<Self, ConfigError> {
-        Self::new_inner(
-            peri,
-            new_pin!(rx, config.rx_af()),
-            None,
-            new_dma!(rx_dma),
-            config,
-        )
+        Self::new_inner(peri, new_pin!(rx, config.rx_af()), None, new_dma!(rx_dma), config)
     }
 
     /// Create a new rx-only UART with a request-to-send pin

--- a/embassy-stm32/src/usart/mod.rs
+++ b/embassy-stm32/src/usart/mod.rs
@@ -142,12 +142,6 @@ pub enum HalfDuplexReadback {
 pub enum OutputConfig {
     /// Push pull allows for faster baudrates, no internal pullup
     PushPull,
-    #[cfg(not(gpio_v1))]
-    /// Push pull with internal pull up resistor
-    PushPullPullUp,
-    #[cfg(not(gpio_v1))]
-    /// Push pull with internal pull down resistor
-    PushPullPullDown,
     /// Open drain output using external pull down resistor
     OpenDrainExternal,
     #[cfg(not(gpio_v1))]
@@ -159,10 +153,6 @@ impl OutputConfig {
     const fn af_type(self) -> AfType {
         match self {
             OutputConfig::PushPull => AfType::output(OutputType::PushPull, Speed::Medium),
-            #[cfg(not(gpio_v1))]
-            OutputConfig::PushPullPullUp => AfType::output_pull(OutputType::OpenDrain, Speed::Medium, Pull::Up),
-            #[cfg(not(gpio_v1))]
-            OutputConfig::PushPullPullDown => AfType::output_pull(OutputType::OpenDrain, Speed::Medium, Pull::Down),
             OutputConfig::OpenDrainExternal => AfType::output(OutputType::OpenDrain, Speed::Medium),
             #[cfg(not(gpio_v1))]
             OutputConfig::OpenDrainInternal => AfType::output_pull(OutputType::OpenDrain, Speed::Medium, Pull::Up),

--- a/embassy-stm32/src/usart/mod.rs
+++ b/embassy-stm32/src/usart/mod.rs
@@ -142,20 +142,20 @@ pub enum HalfDuplexReadback {
 pub enum OutputConfig {
     /// Push pull allows for faster baudrates, no internal pullup
     PushPull,
-    /// Open drain output using external pull down resistor
-    OpenDrainExternal,
+    /// Open drain output (external pull up needed)
+    OpenDrain,
     #[cfg(not(gpio_v1))]
-    /// Open drain output using internal pull up resistor
-    OpenDrainInternal,
+    /// Open drain output with internal pull up resistor
+    OpenDrainPullUp,
 }
 
 impl OutputConfig {
     const fn af_type(self) -> AfType {
         match self {
             OutputConfig::PushPull => AfType::output(OutputType::PushPull, Speed::Medium),
-            OutputConfig::OpenDrainExternal => AfType::output(OutputType::OpenDrain, Speed::Medium),
+            OutputConfig::OpenDrain => AfType::output(OutputType::OpenDrain, Speed::Medium),
             #[cfg(not(gpio_v1))]
-            OutputConfig::OpenDrainInternal => AfType::output_pull(OutputType::OpenDrain, Speed::Medium, Pull::Up),
+            OutputConfig::OpenDrainPullUp => AfType::output_pull(OutputType::OpenDrain, Speed::Medium, Pull::Up),
         }
     }
 }

--- a/examples/stm32g0/src/bin/onewire_ds18b20.rs
+++ b/examples/stm32g0/src/bin/onewire_ds18b20.rs
@@ -8,7 +8,7 @@ use defmt::*;
 use embassy_executor::Spawner;
 use embassy_stm32::mode::Async;
 use embassy_stm32::usart::{
-    BufferedUartRx, BufferedUartTx, Config, ConfigError, HalfDuplexConfig, RingBufferedUartRx, UartTx,
+    BufferedUartRx, BufferedUartTx, Config, ConfigError, OutputConfig, RingBufferedUartRx, UartTx,
 };
 use embassy_stm32::{bind_interrupts, peripherals, usart};
 use embassy_time::{Duration, Timer};
@@ -21,16 +21,18 @@ fn create_onewire(p: embassy_stm32::Peripherals) -> OneWire<UartTx<'static, Asyn
         USART1 => usart::InterruptHandler<peripherals::USART1>;
     });
 
+    let mut config = Config::default();
+    config.tx_config = OutputConfig::OpenDrainExternal;
+
     let usart = Uart::new_half_duplex(
         p.USART1,
         p.PA9,
         Irqs,
         p.DMA1_CH1,
         p.DMA1_CH2,
-        Config::default(),
+        config,
         // Enable readback so we can read sensor pulling data low while transmission is in progress
         usart::HalfDuplexReadback::Readback,
-        HalfDuplexConfig::OpenDrainExternal,
     )
     .unwrap();
 
@@ -50,6 +52,8 @@ fn create_onewire(p: embassy_stm32::Peripherals) -> OneWire<BufferedUartTx<'stat
     });
 
     const BUFFER_SIZE: usize = 16;
+    let mut config = Confi::default();
+    config.tx_config = OutputConfig::OpenDrainExternal;
     let tx_buf: &mut [u8; BUFFER_SIZE] = singleton!(TX_BUF: [u8; BUFFER_SIZE] = [0; BUFFER_SIZE]).unwrap();
     let rx_buf: &mut [u8; BUFFER_SIZE] = singleton!(RX_BUF: [u8; BUFFER_SIZE] = [0; BUFFER_SIZE]).unwrap();
     let usart = BufferedUart::new_half_duplex(
@@ -58,10 +62,9 @@ fn create_onewire(p: embassy_stm32::Peripherals) -> OneWire<BufferedUartTx<'stat
         Irqs,
         tx_buf,
         rx_buf,
-        Config::default(),
+        config,
         // Enable readback so we can read sensor pulling data low while transmission is in progress
         usart::HalfDuplexReadback::Readback,
-        HalfDuplexConfig::OpenDrainExternal,
     )
     .unwrap();
     let (tx, rx) = usart.split();

--- a/examples/stm32g0/src/bin/onewire_ds18b20.rs
+++ b/examples/stm32g0/src/bin/onewire_ds18b20.rs
@@ -22,7 +22,7 @@ fn create_onewire(p: embassy_stm32::Peripherals) -> OneWire<UartTx<'static, Asyn
     });
 
     let mut config = Config::default();
-    config.tx_config = OutputConfig::OpenDrainExternal;
+    config.tx_config = OutputConfig::OpenDrain;
 
     let usart = Uart::new_half_duplex(
         p.USART1,
@@ -53,7 +53,7 @@ fn create_onewire(p: embassy_stm32::Peripherals) -> OneWire<BufferedUartTx<'stat
 
     const BUFFER_SIZE: usize = 16;
     let mut config = Confi::default();
-    config.tx_config = OutputConfig::OpenDrainExternal;
+    config.tx_config = OutputConfig::OpenDrain;
     let tx_buf: &mut [u8; BUFFER_SIZE] = singleton!(TX_BUF: [u8; BUFFER_SIZE] = [0; BUFFER_SIZE]).unwrap();
     let rx_buf: &mut [u8; BUFFER_SIZE] = singleton!(RX_BUF: [u8; BUFFER_SIZE] = [0; BUFFER_SIZE]).unwrap();
     let usart = BufferedUart::new_half_duplex(


### PR DESCRIPTION
Allows pin configuration for cts, tx, rts and de pin in usart::Config. The configuration is applied in all Uart drivers.

Also I removed the now rendundant HalfDuplexConfig which I used as base for the pin config implementation.