### PR TITLE
Add possibility to get the id of a task to be able to use it with rtos-trace

### DIFF
--- a/embassy-executor/src/spawner.rs
+++ b/embassy-executor/src/spawner.rs
@@ -34,6 +34,15 @@ impl<S> SpawnToken<S> {
         }
     }
 
+    /// Returns the task if available, otherwise 0
+    /// This can be used in combination with rtos-trace to match task names with id's
+    pub fn id(&self) -> u32 {
+        match self.raw_task {
+            None => 0,
+            Some(t) => t.as_ptr() as u32,
+        }
+    }
+
     /// Return a SpawnToken that represents a failed spawn.
     pub fn new_failed() -> Self {
         Self {


### PR DESCRIPTION
This can be used in combination with rtos-trace to match task names with id's
fixes: https://github.com/embassy-rs/embassy/issues/2793