### PR TITLE
Fix USB ISO IN EP stat and ISO OUT buffer order

### DIFF
--- a/embassy-stm32/src/usb/usb.rs
+++ b/embassy-stm32/src/usb/usb.rs
@@ -363,10 +363,11 @@ impl<'d, T: Instance> Driver<'d, T> {
                 return false; // reserved for control pipe
             }
             let used = ep.used_out || ep.used_in;
-            if used && (ep.ep_type == EndpointType::Isochronous || ep.ep_type == EndpointType::Bulk) {
-                // Isochronous and bulk endpoints are double-buffered.
+            if used && (ep.ep_type == EndpointType::Isochronous) {
+                // Isochronous endpoints are always double-buffered.
                 // Their corresponding endpoint/channel registers are forced to be unidirectional.
                 // Do not reuse this index.
+                // FIXME: Bulk endpoints can be double buffered, but are not in the current implementation.
                 return false;
             }
 


### PR DESCRIPTION
Some issues existed in the ISO endpoint handling of this particular USB driver (e.g. used in STM32H5).
Prerequisite: ISO transfers on this driver are always double-buffered.

## ISO IN endpoints
Upon initialization, the ISO IN endpoint was in `NAK` state. This is forbidden, as it can only be `VALID` or `DISABLED`.
This changes the ISO IN endpoint state to `VALID` after init.

## ISO OUT endpoints
Reading from ISO OUT endpoints was performed from the wrong buffer location. They are swapped in this PR.

## General
Reading/writing ISO endpoints does not require changing the `EPR` register.