### PR TITLE
Add py32-hal and musb to docs and READMEs

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ Rust's <a href="https://rust-lang.github.io/async-book/">async/await</a> allows 
     - Embassy HAL support for Espressif chips, as well as Async WiFi, Bluetooth and ESP-NOW,  is being developed in the [esp-rs/esp-hal](https://github.com/esp-rs/esp-hal) repository.
   - <a href="https://github.com/ch32-rs/ch32-hal">ch32-hal</a>, for the WCH 32-bit RISC-V(CH32V) series of chips.
   - <a href="https://github.com/AlexCharlton/mpfs-hal">mpfs-hal</a>, for the Microchip PolarFire SoC.
+  - <a href="https://github.com/py32-rs/py32-hal">py32-hal</a>, for the Puya Semiconductor PY32 series of microcontrollers.
 
 - **Time that Just Works** - 
 No more messing with hardware timers. <a href="https://docs.embassy.dev/embassy-time">embassy_time</a> provides Instant, Duration and Timer types that are globally available and never overflow.

--- a/docs/pages/hal.adoc
+++ b/docs/pages/hal.adoc
@@ -14,3 +14,5 @@ For the ESP32 series, there is an link:https://github.com/esp-rs/esp-hal[esp-hal
 For the WCH 32-bit RISC-V series, there is an link:https://github.com/ch32-rs/ch32-hal[ch32-hal], which you can use.
 
 For the Microchip PolarFire SoC, there is link:https://github.com/AlexCharlton/mpfs-hal[mpfs-hal].
+
+For the Puya Semiconductor PY32 series, there is link:https://github.com/py32-rs/py32-hal[py32-hal].

--- a/docs/pages/overview.adoc
+++ b/docs/pages/overview.adoc
@@ -32,6 +32,7 @@ The Embassy project maintains HALs for select hardware, but you can still use HA
 * link:https://github.com/esp-rs[esp-rs], for the Espressif Systems ESP32 series of chips.
 * link:https://github.com/ch32-rs/ch32-hal[ch32-hal], for the WCH 32-bit RISC-V(CH32V) series of chips.
 * link:https://github.com/AlexCharlton/mpfs-hal[mpfs-hal], for the Microchip PolarFire SoC.
+* link:https://github.com/py32-rs/py32-hal[py32-hal], for the Puya Semiconductor PY32 series of chips.
 
 NOTE: A common question is if one can use the Embassy HALs standalone. Yes, it is possible! There are no dependency on the executor within the HALs. You can even use them without async,
 as they implement both the link:https://github.com/rust-embedded/embedded-hal[Embedded HAL] blocking and async traits.

--- a/embassy-usb/README.md
+++ b/embassy-usb/README.md
@@ -20,6 +20,11 @@ Async USB device stack for embedded devices in Rust.
 To add `embassy-usb` support for new hardware (i.e. a new MCU chip), you have to write a driver that implements
 the [`embassy-usb-driver`](https://crates.io/crates/embassy-usb-driver) traits.
 
+Before writing a new driver, you can first verify whether the chip uses a common USB IP. Several widely used USB IPs already have implementations available, such as:
+
+- **Synopsys OTG (dwc2)**: Available at [embassy-usb-synopsys-otg](https://crates.io/crates/embassy-usb-synopsys-otg). This IP is used by vendors like STMicroelectronics, Espressif, and others.
+- **Musbmhdrc (musb)**: Available at [musb](https://crates.io/crates/musb). This IP is used by vendors like TI, MediaTek, Puya, and others.
+
 Driver crates should depend only on `embassy-usb-driver`, not on the main `embassy-usb` crate.
 This allows existing drivers to continue working for newer `embassy-usb` major versions, without needing an update, if the driver
 trait has not had breaking changes.


### PR DESCRIPTION
This PR introduces [py32-hal](https://github.com/py32-rs/py32-hal) and [musb](https://github.com/decaday/musb) to the documentation and README files.

[py32-hal](https://github.com/py32-rs/py32-hal) already supports portions of the py32 series and most peripherals.
py32-hal drawing significant inspiration from embassy-stm32 (licensed under MIT). It also has a companion repository akin to stm32-data: [py32-data](https://github.com/py32-rs/py32-data). (Many thanks to the embassy project for its pioneering work in embedded Rust!)

I’ve also implemented `embassy-usb-driver` for musb (USB2.0 IP) [here](https://github.com/decaday/musb), a widely adopted USB IP by manufacturers like TI, MediaTek, Puya, and others.
Additionally, I’ve updated the "Adding support for new hardware" section of embassy-usb with relevant USB IP details.