### PR TITLE
[RP235x] Fix wrong funcsel on RP2350 GPOUT/GPIN

### DIFF
--- a/embassy-rp/src/clocks.rs
+++ b/embassy-rp/src/clocks.rs
@@ -854,7 +854,14 @@ impl<'d, T: GpinPin> Gpin<'d, T> {
     pub fn new(gpin: impl Peripheral<P = T> + 'd) -> Self {
         into_ref!(gpin);
 
+        #[cfg(feature = "rp2040")]
         gpin.gpio().ctrl().write(|w| w.set_funcsel(0x08));
+
+        // On RP2350 GPIN changed from F8 toF9
+        #[cfg(feature = "_rp235x")]
+        gpin.gpio().ctrl().write(|w| w.set_funcsel(0x09));
+
+
         #[cfg(feature = "_rp235x")]
         gpin.pad_ctrl().write(|w| {
             w.set_iso(false);
@@ -938,7 +945,14 @@ impl<'d, T: GpoutPin> Gpout<'d, T> {
     pub fn new(gpout: impl Peripheral<P = T> + 'd) -> Self {
         into_ref!(gpout);
 
+        #[cfg(feature = "rp2040")]
         gpout.gpio().ctrl().write(|w| w.set_funcsel(0x08));
+
+        // On RP2350 GPOUT changed from F8 toF9
+        #[cfg(feature = "_rp235x")]
+        gpout.gpio().ctrl().write(|w| w.set_funcsel(0x09));
+
+
         #[cfg(feature = "_rp235x")]
         gpout.pad_ctrl().write(|w| {
             w.set_iso(false);

--- a/embassy-rp/src/clocks.rs
+++ b/embassy-rp/src/clocks.rs
@@ -861,7 +861,6 @@ impl<'d, T: GpinPin> Gpin<'d, T> {
         #[cfg(feature = "_rp235x")]
         gpin.gpio().ctrl().write(|w| w.set_funcsel(0x09));
 
-
         #[cfg(feature = "_rp235x")]
         gpin.pad_ctrl().write(|w| {
             w.set_iso(false);
@@ -951,7 +950,6 @@ impl<'d, T: GpoutPin> Gpout<'d, T> {
         // On RP2350 GPOUT changed from F8 toF9
         #[cfg(feature = "_rp235x")]
         gpout.gpio().ctrl().write(|w| w.set_funcsel(0x09));
-
 
         #[cfg(feature = "_rp235x")]
         gpout.pad_ctrl().write(|w| {


### PR DESCRIPTION
The FUNCSEL value for GPOUT/GPIN has changed from RP2340 to RP2350. Embassy has been using 0x08 for both chips, therefore the GPOUT example did not work on the Pico 2.
This PR now distinguishes the two chips and sets FUNCSEL to 0x09 for the RP2350.

See RP2340 (left) and RP2350 (right) datasheets:
![RP_funcsel](https://github.com/user-attachments/assets/648e0fb1-745a-48e7-bf3c-403286384fb1)
