### PR TITLE
embassy-net: Add std and alloc features

### DIFF
--- a/embassy-net/Cargo.toml
+++ b/embassy-net/Cargo.toml
@@ -61,6 +61,10 @@ medium-ip = ["smoltcp/medium-ip"]
 medium-ieee802154 = ["smoltcp/medium-ieee802154"]
 ## Enable multicast support (for both ipv4 and/or ipv6 if enabled)
 multicast = ["smoltcp/multicast"]
+## Enable smoltcp std feature (necessary if using "managed" crate std feature)
+std = ["smoltcp/std"]
+## Enable smoltcp alloc feature (necessary if using "managed" crate alloc feature)
+alloc = ["smoltcp/alloc"]
 
 [dependencies]
 


### PR DESCRIPTION
This was necessary when I enabled `std` feature for `managed` used directly in my own project.
Not certain if this is the best way or there is some other approach I could take.
(including `smoltcp` on my own crate would work, but then it needs matching versions etc)

---

These are passed through to smoltcp, which otherwise won't handle some match cases when managed/std feature is enabled externally.

```
  --> .../index.crates.io-1949cf8c6b5b557f/smoltcp-0.12.0/src/iface/socket_set.rs:82:15
   |
82 |         match &mut self.sockets {
   |               ^^^^^^^^^^^^^^^^^ pattern `&mut ManagedSlice::Owned(_)` not covered
```