### PR TITLE
Add missing flavors to docs for mspm0

### DIFF
--- a/embassy-mspm0/Cargo.toml
+++ b/embassy-mspm0/Cargo.toml
@@ -14,6 +14,11 @@ src_base = "https://github.com/embassy-rs/embassy/blob/embassy-mspm0-v$VERSION/e
 src_base_git = "https://github.com/embassy-rs/embassy/blob/$COMMIT/embassy-mspm0/src/"
 
 features = ["defmt", "unstable-pac", "time-driver-any"]
+flavors = [
+    { regex_feature = "mspm0c.*", target = "thumbv6m-none-eabi" },
+    { regex_feature = "mspm0l.*", target = "thumbv6m-none-eabi" },
+    { regex_feature = "mspm0g.*", target = "thumbv6m-none-eabi" },
+]
 
 [package.metadata.docs.rs]
 features = ["defmt", "unstable-pac", "time-driver-any", "time", "mspm0g3507"]


### PR DESCRIPTION
Seems like this is missing for docs to generate for mspm0 and the rest.