### PR TITLE
Small USB-related fixes

### DIFF
--- a/embassy-stm32/src/usb/usb.rs
+++ b/embassy-stm32/src/usb/usb.rs
@@ -895,7 +895,7 @@ impl<'d, T: Instance> driver::EndpointOut for Endpoint<'d, T, Out> {
         // Software should ensure that a small delay is included before accessing the SRAM contents. This delay should be
         // 800 ns in Full Speed mode and 6.4 μs in Low Speed mode.
         #[cfg(stm32h5)]
-        embassy_time::Timer::after_nanos(800).await;
+        embassy_time::block_for(embassy_time::Duration::from_nanos(800));
 
         RX_COMPLETE[index].store(false, Ordering::Relaxed);
 

--- a/embassy-stm32/src/usb/usb.rs
+++ b/embassy-stm32/src/usb/usb.rs
@@ -7,7 +7,6 @@ use core::task::Poll;
 
 use embassy_hal_internal::into_ref;
 use embassy_sync::waitqueue::AtomicWaker;
-use embassy_time::Timer;
 use embassy_usb_driver as driver;
 use embassy_usb_driver::{
     Direction, EndpointAddress, EndpointAllocError, EndpointError, EndpointInfo, EndpointType, Event, Unsupported,
@@ -896,7 +895,7 @@ impl<'d, T: Instance> driver::EndpointOut for Endpoint<'d, T, Out> {
         // Software should ensure that a small delay is included before accessing the SRAM contents. This delay should be
         // 800 ns in Full Speed mode and 6.4 μs in Low Speed mode.
         #[cfg(stm32h5)]
-        Timer::after_nanos(800).await;
+        embassy_time::Timer::after_nanos(800).await;
 
         RX_COMPLETE[index].store(false, Ordering::Relaxed);
 

--- a/embassy-usb/src/class/uac1/speaker.rs
+++ b/embassy-usb/src/class/uac1/speaker.rs
@@ -348,7 +348,7 @@ pub struct AudioSettings {
 impl Default for AudioSettings {
     fn default() -> Self {
         AudioSettings {
-            muted: [true; MAX_AUDIO_CHANNEL_COUNT],
+            muted: [false; MAX_AUDIO_CHANNEL_COUNT],
             volume_8q8_db: [MAX_VOLUME_DB * VOLUME_STEPS_PER_DB; MAX_AUDIO_CHANNEL_COUNT],
         }
     }


### PR DESCRIPTION
- Fixes errata, found for STM32H5: "During OUT transfers, the correct transfer interrupt (CTR) is triggered a little before the last USB SRAM accesses have completed. If the software responds quickly to the interrupt, the full buffer contents may not be correct."
A delay of 800 ns is recommended as a workaround.
- Fixes default mute state of the UAC1 class. For hosts that don't use the control interface (e.g. Android) there is no way to get the device out of mute.