### PR TITLE
clean the SAADC's register while dropping

### DIFF
--- a/embassy-nrf/src/saadc.rs
+++ b/embassy-nrf/src/saadc.rs
@@ -465,6 +465,10 @@ impl<'d, const N: usize> Drop for Saadc<'d, N> {
     fn drop(&mut self) {
         let r = Self::regs();
         r.enable().write(|w| w.set_enable(false));
+        for i in 0..N {
+            r.ch(i).pselp().write(|w| w.set_pselp(InputChannel::NC));
+            r.ch(i).pseln().write(|w| w.set_pseln(InputChannel::NC));
+        }
     }
 }
 


### PR DESCRIPTION
I noticed that if the register of `SAADC` about channels does not clean or override by other analog input channel. The original pin's functionality will be influenced, which makes it difficult to reuse the pin for other purpose.

```rust
let p = embassy_nrf::init(Default::default());
{
    let cfg = ChannelConfig::single_ended(unsafe { P0_29::steal() });
    let saadc_config = saadc::Config::default();

    let mut adc = Saadc::new(p.SAADC, Irqs, saadc_config, [cfg]);
    adc.calibrate().await;

    let mut buf = [0i16; 1];
    adc.sample(&mut buf).await;
    defmt::info!("ADC value: {}", buf[0]);
    drop(adc);
}

let pin = Input::new(p.P0_29, Pull::Down);
let ch0 = InputChannel::new(p.GPIOTE_CH0, pin, InputChannelPolarity::Toggle);
ch0.wait().await;
```

The `ch0` never triggered unless I create another `SAADC` instance to override the first analog channel. 