### PR TITLE
hal-internal: restrict Peripheral impl to &mut T, mark trait unsafe

### DIFF
--- a/embassy-hal-internal/src/macros.rs
+++ b/embassy-hal-internal/src/macros.rs
@@ -122,7 +122,7 @@ macro_rules! into_ref {
 #[macro_export]
 macro_rules! impl_peripheral {
     ($type:ident) => {
-        impl $crate::Peripheral for $type {
+        unsafe impl $crate::Peripheral for $type {
             type P = $type;
 
             #[inline]


### PR DESCRIPTION
Fixes issue #3997. Alternate solutions include: #3999.

This PR simply restricts the generic `T: DerefMut` implementation to simply `&mut T`, which should be much more well behaved and is more explicitly in-line with the stated goal of the trait. Any code that previously used the `DerefMut` implementation can still obtain a mutable reference from that trait (now with a sensible lifetime), so I don't think there is any loss of sound functionality.

I've also marked the trait as unsafe, since implementing it for e.g. MutexGuard is unsound.

(I am, in part, opening this PR to see if this solution breaks anything in the builds.)