### PR TITLE
Statically allocated task pools on stable

### DIFF
--- a/embassy-executor/Cargo.toml
+++ b/embassy-executor/Cargo.toml
@@ -36,6 +36,7 @@ rtos-trace = { version = "0.1.3", optional = true }
 embassy-executor-macros = { version = "0.6.2", path = "../embassy-executor-macros" }
 embassy-time-driver = { version = "0.2", path = "../embassy-time-driver", optional = true }
 critical-section = "1.1"
+elain = { version = "0.3.1" }
 
 document-features = "0.2.7"
 

--- a/embassy-executor/src/lib.rs
+++ b/embassy-executor/src/lib.rs
@@ -60,6 +60,8 @@ mod config {
 #[doc(hidden)]
 #[cfg(not(feature = "nightly"))]
 pub mod _export {
+    pub use elain;
+    pub use crate::raw::util::SyncUnsafeCell;
     use core::alloc::Layout;
     use core::cell::{Cell, UnsafeCell};
     use core::future::Future;

--- a/embassy-executor/src/lib.rs
+++ b/embassy-executor/src/lib.rs
@@ -60,8 +60,6 @@ mod config {
 #[doc(hidden)]
 #[cfg(not(feature = "nightly"))]
 pub mod _export {
-    pub use elain;
-    pub use crate::raw::util::SyncUnsafeCell;
     use core::alloc::Layout;
     use core::cell::{Cell, UnsafeCell};
     use core::future::Future;
@@ -69,7 +67,9 @@ pub mod _export {
     use core::ptr::null_mut;
 
     use critical_section::{CriticalSection, Mutex};
+    pub use elain;
 
+    pub use crate::raw::util::SyncUnsafeCell;
     use crate::raw::TaskPool;
 
     struct Arena<const N: usize> {

--- a/embassy-executor/src/raw/util.rs
+++ b/embassy-executor/src/raw/util.rs
@@ -29,6 +29,7 @@ impl<T> UninitCell<T> {
 
 unsafe impl<T> Sync for UninitCell<T> {}
 
+/// Wrapper around UnsafeCell that implements Sync
 #[repr(transparent)]
 pub struct SyncUnsafeCell<T> {
     value: UnsafeCell<T>,
@@ -37,6 +38,7 @@ pub struct SyncUnsafeCell<T> {
 unsafe impl<T: Sync> Sync for SyncUnsafeCell<T> {}
 
 impl<T> SyncUnsafeCell<T> {
+    /// Create a new SyncUnsafeCell
     #[inline]
     pub const fn new(value: T) -> Self {
         Self {
@@ -44,10 +46,12 @@ impl<T> SyncUnsafeCell<T> {
         }
     }
 
+    /// Set the underlying value
     pub unsafe fn set(&self, value: T) {
         *self.value.get() = value;
     }
 
+    /// Get the underlying value
     pub unsafe fn get(&self) -> T
     where
         T: Copy,


### PR DESCRIPTION
Not sure if this has been explored before, but had to try myself. Using `size_of` and `align_of` we can create a static variable with the same size and alignment as the task pool that we then transmute to use.

Example:

```rust
#[task]
async fn task1(a: u32, b: u32, #[cfg(any())] c: u32) {
    let (_, _) = (a, b);
}
```

Expanded:
```rust
#[doc(hidden)]
async fn __task1_task(a: u32, b: u32, #[cfg(any())] c: u32) {
    let (_, _) = (a, b);
}
fn task1(a: u32, b: u32, #[cfg(any())] c: u32) -> ::embassy_executor::SpawnToken<impl Sized> {
    trait _EmbassyInternalTaskFn<Args>: Copy {
        type Fut: ::core::future::Future + 'static;
    }
    impl<F, Fut, T0, T1> _EmbassyInternalTaskFn<(T0, T1)> for F
    where
        F: Copy + FnOnce(T0, T1) -> Fut,
        Fut: ::core::future::Future + 'static,
    {
        type Fut = Fut;
    }
    impl<F, Fut, T0, T1, T2> _EmbassyInternalTaskFn<(T0, T1, T2)> for F
    where
        F: Copy + FnOnce(T0, T1, T2) -> Fut,
        Fut: ::core::future::Future + 'static,
    {
        type Fut = Fut;
    }
    const fn __task_pool_size<F, Args>(_: F) -> usize
    where
        F: _EmbassyInternalTaskFn<Args>,
    {
        ::core::mem::size_of::<::embassy_executor::raw::TaskPool<F::Fut, POOL_SIZE>>()
    }
    const fn __task_pool_align<F, Args>(_: F) -> usize
    where
        F: _EmbassyInternalTaskFn<Args>,
    {
        ::core::mem::align_of::<::embassy_executor::raw::TaskPool<F::Fut, POOL_SIZE>>()
    }
    const fn __task_pool_new<F, Args>(_: F) -> ::embassy_executor::raw::TaskPool<F::Fut, POOL_SIZE>
    where
        F: _EmbassyInternalTaskFn<Args>,
    {
        ::embassy_executor::raw::TaskPool::new()
    }
    const fn __get_pool<F, Args>(
        _: F,
    ) -> &'static ::embassy_executor::raw::TaskPool<F::Fut, POOL_SIZE>
    where
        F: _EmbassyInternalTaskFn<Args>,
    {
        unsafe { ::core::mem::transmute(&POOL_BYTES) }
    }
    const POOL_SIZE: usize = 1;
    type PoolBytes = ::embassy_executor::_export::SyncUnsafeCell<(
        [::core::mem::MaybeUninit<u8>; __task_pool_size(__task1_task)],
        ::embassy_executor::_export::elain::Align<{ __task_pool_align(__task1_task) }>,
    )>;
    static POOL_BYTES: PoolBytes = unsafe { ::core::mem::transmute(__task_pool_new(__task1_task)) };
    unsafe {
        __get_pool(__task1_task)._spawn_async_fn(move || {
            __task1_task(
                a,
                b,
                #[cfg(any())]
                c,
            )
        })
    }
}

```