### PR TITLE
rp/adc: fix potential race condition

### DIFF
--- a/embassy-rp/src/adc.rs
+++ b/embassy-rp/src/adc.rs
@@ -205,11 +205,13 @@ impl<'d> Adc<'d, Async> {
 
     fn wait_for_ready() -> impl Future<Output = ()> {
         let r = Self::regs();
-        r.inte().write(|w| w.set_fifo(true));
-        compiler_fence(Ordering::SeqCst);
 
         poll_fn(move |cx| {
             WAKER.register(cx.waker());
+
+            r.inte().write(|w| w.set_fifo(true));
+            compiler_fence(Ordering::SeqCst);
+
             if r.cs().read().ready() {
                 return Poll::Ready(());
             }


### PR DESCRIPTION
This commit rearranges the `Adc::wait_for_ready` function to make sure that wakers are registered before the interrupt is enabled, and keeps enabling the interrupt until the ADC is ready.

It's not actually clear to me how this race condition materializes, but when running code from RAM on RP2350B I noticed that the waker is lost almost every single time. More investigation is needed to determine a root cause, but this patch seems to fix the issue. 

The datasheet is not entirely clear as to exactly when the IRQ fires. It only explicitly says that the IRQ is raised when the FIFO length reaches FCS_THRESH, but FCS_EN is never set by the ADC driver for one shot samples so it's not obvious to me why the FIFO IRQ is raised at all in this case.

Any insight would be appreciated.