### PR TITLE
rp: expose critical section internals

### DIFF
--- a/embassy-rp/src/critical_section_impl.rs
+++ b/embassy-rp/src/critical_section_impl.rs
@@ -2,7 +2,8 @@
 
 use core::sync::atomic::{AtomicU8, Ordering};
 
-use crate::{multicore::CoreId, pac};
+use crate::multicore::CoreId;
+use crate::pac;
 
 struct RpSpinlockCs;
 critical_section::set_impl!(RpSpinlockCs);
@@ -97,7 +98,7 @@ impl RpSpinlockCs {
 /// Gets which core currently holds the spinlock. Useful in combination with
 /// [`manually_release`] to determine if the current core needs to release the
 /// critical section.
-/// 
+///
 /// Returns `None` if neither core currenly holds the lock.
 pub fn current_lock_owner() -> Option<CoreId> {
     match LOCK_OWNER.load(Ordering::Acquire) {
@@ -112,7 +113,7 @@ pub fn current_lock_owner() -> Option<CoreId> {
 /// would be no other way for the lock to be relased.
 ///
 /// # Safety
-/// 
+///
 /// Only call this function if you are sure that the current core holds
 /// the lock and the critical section would never otherwise be released.
 #[inline(always)]

--- a/embassy-rp/src/lib.rs
+++ b/embassy-rp/src/lib.rs
@@ -13,7 +13,7 @@ pub(crate) mod fmt;
 pub use rp_binary_info as binary_info;
 
 #[cfg(feature = "critical-section-impl")]
-mod critical_section_impl;
+pub mod critical_section_impl;
 
 #[cfg(feature = "rp2040")]
 mod intrinsics;

--- a/embassy-rp/src/multicore.rs
+++ b/embassy-rp/src/multicore.rs
@@ -57,6 +57,26 @@ const PAUSE_TOKEN: u32 = 0xDEADBEEF;
 const RESUME_TOKEN: u32 = !0xDEADBEEF;
 static IS_CORE1_INIT: AtomicBool = AtomicBool::new(false);
 
+/// Represents a partiticular CPU core (SIO_CPUID)
+#[derive(Debug, PartialEq, Eq, Clone, Copy, Hash)]
+#[repr(u8)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+pub enum CoreId {
+    /// Core 0
+    Core0 = 0x0,
+    /// Core 1
+    Core1 = 0x1,
+}
+
+/// Gets which core we are currently executing from
+pub fn current_core() -> CoreId {
+    if pac::SIO.cpuid().read() == 0 {
+        CoreId::Core0
+    } else {
+        CoreId::Core1
+    }
+}
+
 #[inline(always)]
 unsafe fn core1_setup(stack_bottom: *mut usize) {
     if install_stack_guard(stack_bottom).is_err() {


### PR DESCRIPTION
This PR exposes an API for working with the critical_section implementation in embassy-rp. This is useful in the context of panic handlers because if a core panics from within a critical section, there is currently no mechanism to release it manually.

This commit also introduces a `CoreId` enum, similar to the one from embassy-stm32. This allows user code to query which core currently holds the critical section; a necessary function for safely calling `manually_release` from within a panic handler.