### PR TITLE
Support eMMC devices via SDMMC (STM32)

### DIFF
--- a/embassy-stm32/Cargo.toml
+++ b/embassy-stm32/Cargo.toml
@@ -70,7 +70,7 @@ cortex-m-rt = ">=0.6.15,<0.8"
 cortex-m = "0.7.6"
 futures-util = { version = "0.3.30", default-features = false }
 rand_core = "0.6.3"
-sdio-host = "0.6.0"
+sdio-host = "0.9.0"
 critical-section = "1.1"
 #stm32-metapac = { version = "16" }
 stm32-metapac = { git = "https://github.com/embassy-rs/stm32-data-generated", tag = "stm32-data-4a964af03b298de30ff9f84fcfa890bcab4ce609" }

--- a/embassy-stm32/Cargo.toml
+++ b/embassy-stm32/Cargo.toml
@@ -70,7 +70,7 @@ cortex-m-rt = ">=0.6.15,<0.8"
 cortex-m = "0.7.6"
 futures-util = { version = "0.3.30", default-features = false }
 rand_core = "0.6.3"
-sdio-host = "0.5.0"
+sdio-host = "0.6.0"
 critical-section = "1.1"
 #stm32-metapac = { version = "16" }
 stm32-metapac = { git = "https://github.com/embassy-rs/stm32-data-generated", tag = "stm32-data-4a964af03b298de30ff9f84fcfa890bcab4ce609" }

--- a/embassy-stm32/build.rs
+++ b/embassy-stm32/build.rs
@@ -1049,7 +1049,7 @@ fn main() {
         (("sdmmc", "D4"), quote!(crate::sdmmc::D4Pin)),
         (("sdmmc", "D5"), quote!(crate::sdmmc::D5Pin)),
         (("sdmmc", "D6"), quote!(crate::sdmmc::D6Pin)),
-        (("sdmmc", "D6"), quote!(crate::sdmmc::D7Pin)),
+        (("sdmmc", "D7"), quote!(crate::sdmmc::D7Pin)),
         (("sdmmc", "D8"), quote!(crate::sdmmc::D8Pin)),
         (("quadspi", "BK1_IO0"), quote!(crate::qspi::BK1D0Pin)),
         (("quadspi", "BK1_IO1"), quote!(crate::qspi::BK1D1Pin)),

--- a/embassy-stm32/src/sdmmc/mod.rs
+++ b/embassy-stm32/src/sdmmc/mod.rs
@@ -1292,12 +1292,12 @@ impl<'d, T: Instance> Sdmmc<'d, T> {
                 // TODO: Make this configurable
                 let mut timeout: u32 = 0x00FF_FFFF;
 
-                // Try to read card status (ACMD13)
+                let card = self.card.as_ref().unwrap();
                 while timeout > 0 {
-                    match self.read_sd_status().await {
-                        Ok(_) => return Ok(()),
-                        Err(Error::Timeout) => (), // Try again
-                        Err(e) => return Err(e),
+                    let status = self.read_status(card)?;
+
+                    if status.ready_for_data() {
+                        return Ok(());
                     }
                     timeout -= 1;
                 }

--- a/examples/stm32f4/src/bin/sdmmc.rs
+++ b/examples/stm32f4/src/bin/sdmmc.rs
@@ -59,7 +59,7 @@ async fn main(_spawner: Spawner) {
 
     let mut err = None;
     loop {
-        match sdmmc.init_card(mhz(24)).await {
+        match sdmmc.init_sd_card(mhz(24)).await {
             Ok(_) => break,
             Err(e) => {
                 if err != Some(e) {

--- a/examples/stm32f7/src/bin/sdmmc.rs
+++ b/examples/stm32f7/src/bin/sdmmc.rs
@@ -54,7 +54,7 @@ async fn main(_spawner: Spawner) {
     // Should print 400kHz for initialization
     info!("Configured clock: {}", sdmmc.clock().0);
 
-    unwrap!(sdmmc.init_card(mhz(25)).await);
+    unwrap!(sdmmc.init_sd_card(mhz(25)).await);
 
     let card = unwrap!(sdmmc.card());
 

--- a/examples/stm32h7/src/bin/sdmmc.rs
+++ b/examples/stm32h7/src/bin/sdmmc.rs
@@ -53,7 +53,7 @@ async fn main(_spawner: Spawner) -> ! {
     // Should print 400kHz for initialization
     info!("Configured clock: {}", sdmmc.clock().0);
 
-    unwrap!(sdmmc.init_card(mhz(25)).await);
+    unwrap!(sdmmc.init_sd_card(mhz(25)).await);
 
     let card = unwrap!(sdmmc.card());
 

--- a/tests/stm32/src/bin/sdmmc.rs
+++ b/tests/stm32/src/bin/sdmmc.rs
@@ -54,7 +54,7 @@ async fn main(_spawner: Spawner) {
 
     let mut err = None;
     loop {
-        match s.init_card(mhz(24)).await {
+        match s.init_sd_card(mhz(24)).await {
             Ok(_) => break,
             Err(e) => {
                 if err != Some(e) {
@@ -100,7 +100,7 @@ async fn main(_spawner: Spawner) {
 
     let mut err = None;
     loop {
-        match s.init_card(mhz(24)).await {
+        match s.init_sd_card(mhz(24)).await {
             Ok(_) => break,
             Err(e) => {
                 if err != Some(e) {


### PR DESCRIPTION
I've added support for eMMC memory devices in `embassy-stm32` using the SDMMC peripheral.

I've confirmed that this code works correctly for basic initialization, reads, and writes on a device that I've previously been using under `stm32f4xx-hal`, using 1, 4, and 8 data lanes, each with several different operating frequencies up to 24MHz.

Note that I don't have any appropriate hardware to test:
- `gpio_v1` config
- `sdmmc_v2` config
- SD card regressions