### PR TITLE
stm32: allow using LSI/LSE as SYSCLK on g0/c0

### DIFF
--- a/embassy-stm32/src/rcc/c0.rs
+++ b/embassy-stm32/src/rcc/c0.rs
@@ -3,6 +3,7 @@ pub use crate::pac::rcc::vals::{
     Hpre as AHBPrescaler, Hsidiv as HsiSysDiv, Hsikerdiv as HsiKerDiv, Ppre as APBPrescaler, Sw as Sysclk,
 };
 use crate::pac::{FLASH, RCC};
+use crate::rcc::LSI_FREQ;
 use crate::time::Hertz;
 
 /// HSI speed
@@ -121,9 +122,13 @@ pub(crate) unsafe fn init(config: Config) {
         }
     };
 
+    let rtc = config.ls.init();
+
     let sys = match config.sys {
         Sysclk::HSISYS => unwrap!(hsisys),
         Sysclk::HSE => unwrap!(hse),
+        Sysclk::LSI => { assert!(config.ls.lsi); LSI_FREQ }
+        Sysclk::LSE => unwrap!(config.ls.lse).frequency,
         _ => unreachable!(),
     };
 
@@ -161,8 +166,6 @@ pub(crate) unsafe fn init(config: Config) {
     if config.hsi.is_none() {
         RCC.cr().modify(|w| w.set_hsion(false));
     }
-
-    let rtc = config.ls.init();
 
     config.mux.init();
 

--- a/embassy-stm32/src/rcc/c0.rs
+++ b/embassy-stm32/src/rcc/c0.rs
@@ -127,7 +127,10 @@ pub(crate) unsafe fn init(config: Config) {
     let sys = match config.sys {
         Sysclk::HSISYS => unwrap!(hsisys),
         Sysclk::HSE => unwrap!(hse),
-        Sysclk::LSI => { assert!(config.ls.lsi); LSI_FREQ }
+        Sysclk::LSI => {
+            assert!(config.ls.lsi);
+            LSI_FREQ
+        }
         Sysclk::LSE => unwrap!(config.ls.lse).frequency,
         _ => unreachable!(),
     };

--- a/embassy-stm32/src/rcc/g0.rs
+++ b/embassy-stm32/src/rcc/g0.rs
@@ -241,7 +241,10 @@ pub(crate) unsafe fn init(config: Config) {
         Sysclk::HSI => unwrap!(hsisys),
         Sysclk::HSE => unwrap!(hse),
         Sysclk::PLL1_R => unwrap!(pll.pll_r),
-        Sysclk::LSI => { assert!(config.ls.lsi); LSI_FREQ }
+        Sysclk::LSI => {
+            assert!(config.ls.lsi);
+            LSI_FREQ
+        }
         Sysclk::LSE => unwrap!(config.ls.lse).frequency,
         _ => unreachable!(),
     };

--- a/embassy-stm32/src/rcc/g0.rs
+++ b/embassy-stm32/src/rcc/g0.rs
@@ -5,6 +5,7 @@ pub use crate::pac::rcc::vals::{
     Pllr as PllRDiv, Pllsrc as PllSource, Ppre as APBPrescaler, Sw as Sysclk,
 };
 use crate::pac::{FLASH, PWR, RCC};
+use crate::rcc::LSI_FREQ;
 use crate::time::Hertz;
 
 /// HSI speed
@@ -234,10 +235,14 @@ pub(crate) unsafe fn init(config: Config) {
         })
         .unwrap_or_default();
 
+    let rtc = config.ls.init();
+
     let sys = match config.sys {
         Sysclk::HSI => unwrap!(hsisys),
         Sysclk::HSE => unwrap!(hse),
         Sysclk::PLL1_R => unwrap!(pll.pll_r),
+        Sysclk::LSI => { assert!(config.ls.lsi); LSI_FREQ }
+        Sysclk::LSE => unwrap!(config.ls.lse).frequency,
         _ => unreachable!(),
     };
 
@@ -285,8 +290,6 @@ pub(crate) unsafe fn init(config: Config) {
         assert!(sys <= Hertz(2_000_000));
         PWR.cr1().modify(|w| w.set_lpr(true));
     }
-
-    let rtc = config.ls.init();
 
     config.mux.init();
 


### PR DESCRIPTION
Resolves #3608, tested on a g031