### PR TITLE
Fix STM32G4 ADC calibration stability

### DIFF
--- a/embassy-stm32/src/adc/g4.rs
+++ b/embassy-stm32/src/adc/g4.rs
@@ -171,7 +171,7 @@ impl<'d, T: Instance> Adc<'d, T> {
             reg.set_advregen(true);
         });
 
-        blocking_delay_us(10);
+        blocking_delay_us(20);
     }
 
     fn configure_differential_inputs(&mut self) {
@@ -191,6 +191,8 @@ impl<'d, T: Instance> Adc<'d, T> {
 
         while T::regs().cr().read().adcal() {}
 
+        blocking_delay_us(20);
+
         T::regs().cr().modify(|w| {
             w.set_adcaldif(Adcaldif::DIFFERENTIAL);
         });
@@ -198,6 +200,8 @@ impl<'d, T: Instance> Adc<'d, T> {
         T::regs().cr().modify(|w| w.set_adcal(true));
 
         while T::regs().cr().read().adcal() {}
+
+        blocking_delay_us(20);
     }
 
     fn enable(&mut self) {


### PR DESCRIPTION
For reasons that I don't fully understand, ADC calibration fails on the STM32G4 when SYSCLK is too high.

The ADC calibration happens in two steps:
- single-ended calibration
- differential calibration

After the differential calibration is started, the blocking wait for `ADCAL` going to `0` never finishes.
Introducing a short delay between calibration steps fixes the issue.

Inspired by the solution from https://github.com/ChibiOS/ChibiOS/blob/master/os/hal/ports/STM32/LLD/ADCv3/hal_adc_lld.c#L160, which uses the same approach.

Also, power-up delay (waiting for ADVREG stability) has to be 20 us, as per the datasheet (was 10 us).

I have not found any relevant information in the RM, errata, or datasheet. ST examples that I found never calibrate both single-ended and differential back-to-back.