### PR TITLE
stm32/can: remove bus error checking when can bus protocol handling is disabled

### DIFF
--- a/embassy-stm32/src/can/fdcan.rs
+++ b/embassy-stm32/src/can/fdcan.rs
@@ -698,7 +698,9 @@ impl RxMode {
             let ts = T::calc_timestamp(T::state().ns_per_timer_tick, ts);
             Some(Ok(Envelope { ts, frame }))
         } else if let Some(err) = T::registers().curr_error() {
-            // TODO: this is probably wrong
+            if T::registers().regs.cccr().read().pxhd() {
+                return None;
+            }
             Some(Err(err))
         } else {
             None
@@ -713,7 +715,9 @@ impl RxMode {
             let ts = T::calc_timestamp(T::state().ns_per_timer_tick, ts);
             Some(Ok(FdEnvelope { ts, frame }))
         } else if let Some(err) = T::registers().curr_error() {
-            // TODO: this is probably wrong
+            if T::registers().regs.cccr().read().pxhd() {
+                return None;
+            }
             Some(Err(err))
         } else {
             None
@@ -732,7 +736,9 @@ impl RxMode {
             let ts = info.calc_timestamp(state.ns_per_timer_tick, ts);
             Some(Ok((msg, ts)))
         } else if let Some(err) = info.regs.curr_error() {
-            // TODO: this is probably wrong
+            if info.regs.regs.cccr().read().pxhd() {
+                return None;
+            }
             Some(Err(err))
         } else {
             None


### PR DESCRIPTION
The `TODO` comment is indeed right.
If protocol exception handling is disabled, it makes no sense to check protocol status register for errors.

Tested on `STM32H503CB`, where without fix simple `read_fd().await` call in a loop would hang MCU indefinitely in error checking loop.

Still can't imagine why FDCAN controller sets bits into PSR register when it's specifically told not to handle bus errors by setting PXHD bit in CCCR, but whatever.

Maybe more complete overhaul for fdcan driver is needed.