### PR TITLE
[embassy-executor]: Fix some intra-doc links

### DIFF
--- a/embassy-executor/src/arch/cortex_m.rs
+++ b/embassy-executor/src/arch/cortex_m.rs
@@ -143,7 +143,7 @@ mod interrupt {
     /// If this is not the case, you may use an interrupt from any unused peripheral.
     ///
     /// It is somewhat more complex to use, it's recommended to use the thread-mode
-    /// [`Executor`] instead, if it works for your use case.
+    /// [`Executor`](crate::Executor) instead, if it works for your use case.
     pub struct InterruptExecutor {
         started: Mutex<Cell<bool>>,
         executor: UnsafeCell<MaybeUninit<raw::Executor>>,
@@ -179,11 +179,11 @@ mod interrupt {
         /// The executor keeps running in the background through the interrupt.
         ///
         /// This returns a [`SendSpawner`] you can use to spawn tasks on it. A [`SendSpawner`]
-        /// is returned instead of a [`Spawner`](embassy_executor::Spawner) because the executor effectively runs in a
+        /// is returned instead of a [`Spawner`](crate::Spawner) because the executor effectively runs in a
         /// different "thread" (the interrupt), so spawning tasks on it is effectively
         /// sending them.
         ///
-        /// To obtain a [`Spawner`](embassy_executor::Spawner) for this executor, use [`Spawner::for_current_executor()`](embassy_executor::Spawner::for_current_executor()) from
+        /// To obtain a [`Spawner`](crate::Spawner) for this executor, use [`Spawner::for_current_executor()`](crate::Spawner::for_current_executor()) from
         /// a task running in it.
         ///
         /// # Interrupt requirements
@@ -195,6 +195,7 @@ mod interrupt {
         /// You must set the interrupt priority before calling this method. You MUST NOT
         /// do it after.
         ///
+        /// [`SendSpawner`]: crate::SendSpawner
         pub fn start(&'static self, irq: impl InterruptNumber) -> crate::SendSpawner {
             if critical_section::with(|cs| self.started.borrow(cs).replace(true)) {
                 panic!("InterruptExecutor::start() called multiple times on the same executor.");
@@ -215,7 +216,7 @@ mod interrupt {
 
         /// Get a SendSpawner for this executor
         ///
-        /// This returns a [`SendSpawner`] you can use to spawn tasks on this
+        /// This returns a [`SendSpawner`](crate::SendSpawner) you can use to spawn tasks on this
         /// executor.
         ///
         /// This MUST only be called on an executor that has already been started.

--- a/embassy-executor/src/raw/waker.rs
+++ b/embassy-executor/src/raw/waker.rs
@@ -26,7 +26,7 @@ pub(crate) unsafe fn from_task(p: TaskRef) -> Waker {
 /// (1 word) instead of full Wakers (2 words). This saves a bit of RAM and helps
 /// avoid dynamic dispatch.
 ///
-/// You can use the returned task pointer to wake the task with [`wake_task`](super::wake_task).
+/// You can use the returned task pointer to wake the task with [`wake_task`].
 ///
 /// # Panics
 ///


### PR DESCRIPTION
Just some intra-doc warnings I saw while working on other things.

We could potentially be looking for:

* `rustdoc::broken_intra_doc_links`
* `rustdoc::redundant_explicit_links`

in CI somehow (run rustdoc with `-D warnings`?) to avoid this.