### PR TITLE
stm32h7rs xspi 

### DIFF
--- a/embassy-stm32/Cargo.toml
+++ b/embassy-stm32/Cargo.toml
@@ -73,7 +73,7 @@ rand_core = "0.6.3"
 sdio-host = "0.5.0"
 critical-section = "1.1"
 #stm32-metapac = { version = "16" }
-stm32-metapac = { git = "https://github.com/embassy-rs/stm32-data-generated", tag = "stm32-data-4a964af03b298de30ff9f84fcfa890bcab4ce609" }
+stm32-metapac = { git = "https://github.com/embassy-rs/stm32-data-generated", tag = "stm32-data-a7a30c9d54e7415709c463a537501691784672db" }
 
 vcell = "0.1.3"
 nb = "1.0.0"
@@ -102,7 +102,7 @@ proc-macro2 = "1.0.36"
 quote = "1.0.15"
 
 #stm32-metapac = { version = "16", default-features = false, features = ["metadata"]}
-stm32-metapac = { git = "https://github.com/embassy-rs/stm32-data-generated", tag = "stm32-data-4a964af03b298de30ff9f84fcfa890bcab4ce609", default-features = false, features = ["metadata"] }
+stm32-metapac = { git = "https://github.com/embassy-rs/stm32-data-generated", tag = "stm32-data-a7a30c9d54e7415709c463a537501691784672db", default-features = false, features = ["metadata"] }
 
 [features]
 default = ["rt"]

--- a/embassy-stm32/build.rs
+++ b/embassy-stm32/build.rs
@@ -62,7 +62,13 @@ fn main() {
     // generate one singleton per peripheral (with many exceptions...)
     for p in METADATA.peripherals {
         if let Some(r) = &p.registers {
-            if r.kind == "adccommon" || r.kind == "sai" || r.kind == "ucpd" || r.kind == "otg" || r.kind == "octospi" {
+            if r.kind == "adccommon"
+                || r.kind == "sai"
+                || r.kind == "ucpd"
+                || r.kind == "otg"
+                || r.kind == "octospi"
+                || r.kind == "xspi"
+            {
                 // TODO: should we emit this for all peripherals? if so, we will need a list of all
                 // possible peripherals across all chips, so that we can declare the configs
                 // (replacing the hard-coded list of `peri_*` cfgs below)

--- a/embassy-stm32/build.rs
+++ b/embassy-stm32/build.rs
@@ -116,6 +116,7 @@ fn main() {
         "peri_usb_otg_fs",
         "peri_usb_otg_hs",
         "peri_octospi2",
+        "peri_xspi2",
     ]);
     cfgs.declare_all(&["mco", "mco1", "mco2"]);
 
@@ -1098,6 +1099,72 @@ fn main() {
         (("octospim", "P2_NCS"), quote!(crate::ospi::NSSPin)),
         (("octospim", "P2_CLK"), quote!(crate::ospi::SckPin)),
         (("octospim", "P2_NCLK"), quote!(crate::ospi::NckPin)),
+        (("xspi", "IO0"), quote!(crate::xspi::D0Pin)),
+        (("xspi", "IO1"), quote!(crate::xspi::D1Pin)),
+        (("xspi", "IO2"), quote!(crate::xspi::D2Pin)),
+        (("xspi", "IO3"), quote!(crate::xspi::D3Pin)),
+        (("xspi", "IO4"), quote!(crate::xspi::D4Pin)),
+        (("xspi", "IO5"), quote!(crate::xspi::D5Pin)),
+        (("xspi", "IO6"), quote!(crate::xspi::D6Pin)),
+        (("xspi", "IO7"), quote!(crate::xspi::D7Pin)),
+        (("xspi", "IO8"), quote!(crate::xspi::D8Pin)),
+        (("xspi", "IO9"), quote!(crate::xspi::D9Pin)),
+        (("xspi", "IO10"), quote!(crate::xspi::D10Pin)),
+        (("xspi", "IO11"), quote!(crate::xspi::D11Pin)),
+        (("xspi", "IO12"), quote!(crate::xspi::D12Pin)),
+        (("xspi", "IO13"), quote!(crate::xspi::D13Pin)),
+        (("xspi", "IO14"), quote!(crate::xspi::D14Pin)),
+        (("xspi", "IO15"), quote!(crate::xspi::D15Pin)),
+        (("xspi", "DQS0"), quote!(crate::xspi::DQS0Pin)),
+        (("xspi", "DQS1"), quote!(crate::xspi::DQS1Pin)),
+        (("xspi", "NCS1"), quote!(crate::xspi::NCS1Pin)),
+        (("xspi", "NCS2"), quote!(crate::xspi::NCS2Pin)),
+        (("xspi", "CLK"), quote!(crate::xspi::CLKPin)),
+        (("xspi", "NCLK"), quote!(crate::xspi::NCLKPin)),
+        (("xspim", "P1_IO0"), quote!(crate::xspi::D0Pin)),
+        (("xspim", "P1_IO1"), quote!(crate::xspi::D1Pin)),
+        (("xspim", "P1_IO2"), quote!(crate::xspi::D2Pin)),
+        (("xspim", "P1_IO3"), quote!(crate::xspi::D3Pin)),
+        (("xspim", "P1_IO4"), quote!(crate::xspi::D4Pin)),
+        (("xspim", "P1_IO5"), quote!(crate::xspi::D5Pin)),
+        (("xspim", "P1_IO6"), quote!(crate::xspi::D6Pin)),
+        (("xspim", "P1_IO7"), quote!(crate::xspi::D7Pin)),
+        (("xspim", "P1_IO8"), quote!(crate::xspi::D8Pin)),
+        (("xspim", "P1_IO9"), quote!(crate::xspi::D9Pin)),
+        (("xspim", "P1_IO10"), quote!(crate::xspi::D10Pin)),
+        (("xspim", "P1_IO11"), quote!(crate::xspi::D11Pin)),
+        (("xspim", "P1_IO12"), quote!(crate::xspi::D12Pin)),
+        (("xspim", "P1_IO13"), quote!(crate::xspi::D13Pin)),
+        (("xspim", "P1_IO14"), quote!(crate::xspi::D14Pin)),
+        (("xspim", "P1_IO15"), quote!(crate::xspi::D15Pin)),
+        (("xspim", "P1_DQS0"), quote!(crate::xspi::DQS0Pin)),
+        (("xspim", "P1_DQS1"), quote!(crate::xspi::DQS1Pin)),
+        (("xspim", "P1_NCS1"), quote!(crate::xspi::NCS1Pin)),
+        (("xspim", "P1_NCS2"), quote!(crate::xspi::NCS2Pin)),
+        (("xspim", "P1_CLK"), quote!(crate::xspi::CLKPin)),
+        (("xspim", "P1_NCLK"), quote!(crate::xspi::NCLKPin)),
+        (("xspim", "P2_IO0"), quote!(crate::xspi::D0Pin)),
+        (("xspim", "P2_IO1"), quote!(crate::xspi::D1Pin)),
+        (("xspim", "P2_IO2"), quote!(crate::xspi::D2Pin)),
+        (("xspim", "P2_IO3"), quote!(crate::xspi::D3Pin)),
+        (("xspim", "P2_IO4"), quote!(crate::xspi::D4Pin)),
+        (("xspim", "P2_IO5"), quote!(crate::xspi::D5Pin)),
+        (("xspim", "P2_IO6"), quote!(crate::xspi::D6Pin)),
+        (("xspim", "P2_IO7"), quote!(crate::xspi::D7Pin)),
+        (("xspim", "P2_IO8"), quote!(crate::xspi::D8Pin)),
+        (("xspim", "P2_IO9"), quote!(crate::xspi::D9Pin)),
+        (("xspim", "P2_IO10"), quote!(crate::xspi::D10Pin)),
+        (("xspim", "P2_IO11"), quote!(crate::xspi::D11Pin)),
+        (("xspim", "P2_IO12"), quote!(crate::xspi::D12Pin)),
+        (("xspim", "P2_IO13"), quote!(crate::xspi::D13Pin)),
+        (("xspim", "P2_IO14"), quote!(crate::xspi::D14Pin)),
+        (("xspim", "P2_IO15"), quote!(crate::xspi::D15Pin)),
+        (("xspim", "P2_DQS0"), quote!(crate::xspi::DQS0Pin)),
+        (("xspim", "P2_DQS1"), quote!(crate::xspi::DQS1Pin)),
+        (("xspim", "P2_NCS1"), quote!(crate::xspi::NCS1Pin)),
+        (("xspim", "P2_NCS2"), quote!(crate::xspi::NCS2Pin)),
+        (("xspim", "P2_CLK"), quote!(crate::xspi::CLKPin)),
+        (("xspim", "P2_NCLK"), quote!(crate::xspi::NCLKPin)),
         (("hspi", "IO0"), quote!(crate::hspi::D0Pin)),
         (("hspi", "IO1"), quote!(crate::hspi::D1Pin)),
         (("hspi", "IO2"), quote!(crate::hspi::D2Pin)),
@@ -1188,6 +1255,17 @@ fn main() {
                             });
                         }
                         peri = format_ident!("{}", "OCTOSPI1");
+                    }
+
+                    // XSPIM  is special
+                    if p.name == "XSPIM" {
+                        if pin.signal.starts_with("P1") {
+                            peri = format_ident!("{}", "XSPI1");
+                        } else if pin.signal.starts_with("P2") {
+                            peri = format_ident!("{}", "XSPI2");
+                        } else {
+                            panic! {"malformed XSPIM pin: {:?}", pin}
+                        }
                     }
 
                     g.extend(quote! {

--- a/embassy-stm32/build.rs
+++ b/embassy-stm32/build.rs
@@ -1123,8 +1123,8 @@ fn main() {
         (("xspi", "IO15"), quote!(crate::xspi::D15Pin)),
         (("xspi", "DQS0"), quote!(crate::xspi::DQS0Pin)),
         (("xspi", "DQS1"), quote!(crate::xspi::DQS1Pin)),
-        (("xspi", "NCS1"), quote!(crate::xspi::NCS1Pin)),
-        (("xspi", "NCS2"), quote!(crate::xspi::NCS2Pin)),
+        (("xspi", "NCS1"), quote!(crate::xspi::NCSPin)),
+        (("xspi", "NCS2"), quote!(crate::xspi::NCSPin)),
         (("xspi", "CLK"), quote!(crate::xspi::CLKPin)),
         (("xspi", "NCLK"), quote!(crate::xspi::NCLKPin)),
         (("xspim", "P1_IO0"), quote!(crate::xspi::D0Pin)),
@@ -1145,8 +1145,8 @@ fn main() {
         (("xspim", "P1_IO15"), quote!(crate::xspi::D15Pin)),
         (("xspim", "P1_DQS0"), quote!(crate::xspi::DQS0Pin)),
         (("xspim", "P1_DQS1"), quote!(crate::xspi::DQS1Pin)),
-        (("xspim", "P1_NCS1"), quote!(crate::xspi::NCS1Pin)),
-        (("xspim", "P1_NCS2"), quote!(crate::xspi::NCS2Pin)),
+        (("xspim", "P1_NCS1"), quote!(crate::xspi::NCSPin)),
+        (("xspim", "P1_NCS2"), quote!(crate::xspi::NCSPin)),
         (("xspim", "P1_CLK"), quote!(crate::xspi::CLKPin)),
         (("xspim", "P1_NCLK"), quote!(crate::xspi::NCLKPin)),
         (("xspim", "P2_IO0"), quote!(crate::xspi::D0Pin)),
@@ -1167,8 +1167,8 @@ fn main() {
         (("xspim", "P2_IO15"), quote!(crate::xspi::D15Pin)),
         (("xspim", "P2_DQS0"), quote!(crate::xspi::DQS0Pin)),
         (("xspim", "P2_DQS1"), quote!(crate::xspi::DQS1Pin)),
-        (("xspim", "P2_NCS1"), quote!(crate::xspi::NCS1Pin)),
-        (("xspim", "P2_NCS2"), quote!(crate::xspi::NCS2Pin)),
+        (("xspim", "P2_NCS1"), quote!(crate::xspi::NCSPin)),
+        (("xspim", "P2_NCS2"), quote!(crate::xspi::NCSPin)),
         (("xspim", "P2_CLK"), quote!(crate::xspi::CLKPin)),
         (("xspim", "P2_NCLK"), quote!(crate::xspi::NCLKPin)),
         (("hspi", "IO0"), quote!(crate::hspi::D0Pin)),
@@ -1272,6 +1272,18 @@ fn main() {
                         } else {
                             panic! {"malformed XSPIM pin: {:?}", pin}
                         }
+                    }
+
+                    // XSPI NCS pin to CSSEL mapping
+                    if pin.signal.ends_with("NCS1") {
+                        g.extend(quote! {
+                            sel_trait_impl!(crate::xspi::NCSEither, #peri, #pin_name, 0);
+                        })
+                    }
+                    if pin.signal.ends_with("NCS2") {
+                        g.extend(quote! {
+                            sel_trait_impl!(crate::xspi::NCSEither, #peri, #pin_name, 1);
+                        })
                     }
 
                     g.extend(quote! {

--- a/embassy-stm32/src/lib.rs
+++ b/embassy-stm32/src/lib.rs
@@ -127,6 +127,8 @@ pub mod usart;
 pub mod usb;
 #[cfg(iwdg)]
 pub mod wdg;
+#[cfg(xspi)]
+pub mod xspi;
 
 // This must go last, so that it sees all the impl_foo! macros defined earlier.
 pub(crate) mod _generated {

--- a/embassy-stm32/src/macros.rs
+++ b/embassy-stm32/src/macros.rs
@@ -60,6 +60,17 @@ macro_rules! pin_trait_impl {
     };
 }
 
+#[allow(unused_macros)]
+macro_rules! sel_trait_impl {
+    (crate::$mod:ident::$trait:ident$(<$mode:ident>)?, $instance:ident, $pin:ident, $sel:expr) => {
+        impl crate::$mod::$trait<crate::peripherals::$instance $(, crate::$mod::$mode)?> for crate::peripherals::$pin {
+            fn sel(&self) -> u8 {
+                $sel
+            }
+        }
+    };
+}
+
 // ====================
 
 macro_rules! dma_trait {

--- a/embassy-stm32/src/xspi/enums.rs
+++ b/embassy-stm32/src/xspi/enums.rs
@@ -160,9 +160,9 @@ impl Into<u8> for MemorySize {
 #[derive(Copy, Clone)]
 pub enum AddressSize {
     /// 8-bit address
-    _8Bit,
+    _8bit,
     /// 16-bit address
-    _16Bit,
+    _16bit,
     /// 24-bit address
     _24bit,
     /// 32-bit address
@@ -172,8 +172,8 @@ pub enum AddressSize {
 impl Into<u8> for AddressSize {
     fn into(self) -> u8 {
         match self {
-            AddressSize::_8Bit => 0b00,
-            AddressSize::_16Bit => 0b01,
+            AddressSize::_8bit => 0b00,
+            AddressSize::_16bit => 0b01,
             AddressSize::_24bit => 0b10,
             AddressSize::_32bit => 0b11,
         }

--- a/embassy-stm32/src/xspi/enums.rs
+++ b/embassy-stm32/src/xspi/enums.rs
@@ -1,10 +1,11 @@
 //! Enums used in Xspi configuration.
-#[allow(dead_code)]
 #[derive(Copy, Clone)]
 pub(crate) enum XspiMode {
     IndirectWrite,
     IndirectRead,
+    #[expect(dead_code)]
     AutoPolling,
+    #[expect(dead_code)]
     MemoryMapped,
 }
 
@@ -20,7 +21,6 @@ impl Into<u8> for XspiMode {
 }
 
 /// Xspi lane width
-#[allow(dead_code)]
 #[derive(Copy, Clone)]
 pub enum XspiWidth {
     /// None
@@ -47,27 +47,7 @@ impl Into<u8> for XspiWidth {
     }
 }
 
-/// Flash bank selection
-#[allow(dead_code)]
-#[derive(Copy, Clone)]
-pub enum FlashSelection {
-    /// Bank 1
-    Flash1,
-    /// Bank 2
-    Flash2,
-}
-
-impl Into<bool> for FlashSelection {
-    fn into(self) -> bool {
-        match self {
-            FlashSelection::Flash1 => false,
-            FlashSelection::Flash2 => true,
-        }
-    }
-}
-
 /// Wrap Size
-#[allow(dead_code)]
 #[allow(missing_docs)]
 #[derive(Copy, Clone)]
 pub enum WrapSize {
@@ -92,7 +72,6 @@ impl Into<u8> for WrapSize {
 
 /// Memory Type
 #[allow(missing_docs)]
-#[allow(dead_code)]
 #[derive(Copy, Clone)]
 pub enum MemoryType {
     Micron,

--- a/embassy-stm32/src/xspi/enums.rs
+++ b/embassy-stm32/src/xspi/enums.rs
@@ -1,0 +1,385 @@
+//! Enums used in Xspi configuration.
+#[allow(dead_code)]
+#[derive(Copy, Clone)]
+pub(crate) enum XspiMode {
+    IndirectWrite,
+    IndirectRead,
+    AutoPolling,
+    MemoryMapped,
+}
+
+impl Into<u8> for XspiMode {
+    fn into(self) -> u8 {
+        match self {
+            XspiMode::IndirectWrite => 0b00,
+            XspiMode::IndirectRead => 0b01,
+            XspiMode::AutoPolling => 0b10,
+            XspiMode::MemoryMapped => 0b11,
+        }
+    }
+}
+
+/// Xspi lane width
+#[allow(dead_code)]
+#[derive(Copy, Clone)]
+pub enum XspiWidth {
+    /// None
+    NONE,
+    /// Single lane
+    SING,
+    /// Dual lanes
+    DUAL,
+    /// Quad lanes
+    QUAD,
+    /// Eight lanes
+    OCTO,
+}
+
+impl Into<u8> for XspiWidth {
+    fn into(self) -> u8 {
+        match self {
+            XspiWidth::NONE => 0b00,
+            XspiWidth::SING => 0b01,
+            XspiWidth::DUAL => 0b10,
+            XspiWidth::QUAD => 0b11,
+            XspiWidth::OCTO => 0b100,
+        }
+    }
+}
+
+/// Flash bank selection
+#[allow(dead_code)]
+#[derive(Copy, Clone)]
+pub enum FlashSelection {
+    /// Bank 1
+    Flash1,
+    /// Bank 2
+    Flash2,
+}
+
+impl Into<bool> for FlashSelection {
+    fn into(self) -> bool {
+        match self {
+            FlashSelection::Flash1 => false,
+            FlashSelection::Flash2 => true,
+        }
+    }
+}
+
+/// Wrap Size
+#[allow(dead_code)]
+#[allow(missing_docs)]
+#[derive(Copy, Clone)]
+pub enum WrapSize {
+    None,
+    _16Bytes,
+    _32Bytes,
+    _64Bytes,
+    _128Bytes,
+}
+
+impl Into<u8> for WrapSize {
+    fn into(self) -> u8 {
+        match self {
+            WrapSize::None => 0x00,
+            WrapSize::_16Bytes => 0x02,
+            WrapSize::_32Bytes => 0x03,
+            WrapSize::_64Bytes => 0x04,
+            WrapSize::_128Bytes => 0x05,
+        }
+    }
+}
+
+/// Memory Type
+#[allow(missing_docs)]
+#[allow(dead_code)]
+#[derive(Copy, Clone)]
+pub enum MemoryType {
+    Micron,
+    Macronix,
+    Standard,
+    MacronixRam,
+    HyperBusMemory,
+    HyperBusRegister,
+}
+
+impl Into<u8> for MemoryType {
+    fn into(self) -> u8 {
+        match self {
+            MemoryType::Micron => 0x00,
+            MemoryType::Macronix => 0x01,
+            MemoryType::Standard => 0x02,
+            MemoryType::MacronixRam => 0x03,
+            MemoryType::HyperBusMemory => 0x04,
+            MemoryType::HyperBusRegister => 0x04,
+        }
+    }
+}
+
+/// Xspi memory size.
+#[allow(missing_docs)]
+#[derive(Copy, Clone)]
+pub enum MemorySize {
+    _1KiB,
+    _2KiB,
+    _4KiB,
+    _8KiB,
+    _16KiB,
+    _32KiB,
+    _64KiB,
+    _128KiB,
+    _256KiB,
+    _512KiB,
+    _1MiB,
+    _2MiB,
+    _4MiB,
+    _8MiB,
+    _16MiB,
+    _32MiB,
+    _64MiB,
+    _128MiB,
+    _256MiB,
+    _512MiB,
+    _1GiB,
+    _2GiB,
+    _4GiB,
+    Other(u8),
+}
+
+impl Into<u8> for MemorySize {
+    fn into(self) -> u8 {
+        match self {
+            MemorySize::_1KiB => 9,
+            MemorySize::_2KiB => 10,
+            MemorySize::_4KiB => 11,
+            MemorySize::_8KiB => 12,
+            MemorySize::_16KiB => 13,
+            MemorySize::_32KiB => 14,
+            MemorySize::_64KiB => 15,
+            MemorySize::_128KiB => 16,
+            MemorySize::_256KiB => 17,
+            MemorySize::_512KiB => 18,
+            MemorySize::_1MiB => 19,
+            MemorySize::_2MiB => 20,
+            MemorySize::_4MiB => 21,
+            MemorySize::_8MiB => 22,
+            MemorySize::_16MiB => 23,
+            MemorySize::_32MiB => 24,
+            MemorySize::_64MiB => 25,
+            MemorySize::_128MiB => 26,
+            MemorySize::_256MiB => 27,
+            MemorySize::_512MiB => 28,
+            MemorySize::_1GiB => 29,
+            MemorySize::_2GiB => 30,
+            MemorySize::_4GiB => 31,
+            MemorySize::Other(val) => val,
+        }
+    }
+}
+
+/// Xspi Address size
+#[derive(Copy, Clone)]
+pub enum AddressSize {
+    /// 8-bit address
+    _8Bit,
+    /// 16-bit address
+    _16Bit,
+    /// 24-bit address
+    _24bit,
+    /// 32-bit address
+    _32bit,
+}
+
+impl Into<u8> for AddressSize {
+    fn into(self) -> u8 {
+        match self {
+            AddressSize::_8Bit => 0b00,
+            AddressSize::_16Bit => 0b01,
+            AddressSize::_24bit => 0b10,
+            AddressSize::_32bit => 0b11,
+        }
+    }
+}
+
+/// Time the Chip Select line stays high.
+#[allow(missing_docs)]
+#[derive(Copy, Clone)]
+pub enum ChipSelectHighTime {
+    _1Cycle,
+    _2Cycle,
+    _3Cycle,
+    _4Cycle,
+    _5Cycle,
+    _6Cycle,
+    _7Cycle,
+    _8Cycle,
+}
+
+impl Into<u8> for ChipSelectHighTime {
+    fn into(self) -> u8 {
+        match self {
+            ChipSelectHighTime::_1Cycle => 0,
+            ChipSelectHighTime::_2Cycle => 1,
+            ChipSelectHighTime::_3Cycle => 2,
+            ChipSelectHighTime::_4Cycle => 3,
+            ChipSelectHighTime::_5Cycle => 4,
+            ChipSelectHighTime::_6Cycle => 5,
+            ChipSelectHighTime::_7Cycle => 6,
+            ChipSelectHighTime::_8Cycle => 7,
+        }
+    }
+}
+
+/// FIFO threshold.
+#[allow(missing_docs)]
+#[derive(Copy, Clone)]
+pub enum FIFOThresholdLevel {
+    _1Bytes,
+    _2Bytes,
+    _3Bytes,
+    _4Bytes,
+    _5Bytes,
+    _6Bytes,
+    _7Bytes,
+    _8Bytes,
+    _9Bytes,
+    _10Bytes,
+    _11Bytes,
+    _12Bytes,
+    _13Bytes,
+    _14Bytes,
+    _15Bytes,
+    _16Bytes,
+    _17Bytes,
+    _18Bytes,
+    _19Bytes,
+    _20Bytes,
+    _21Bytes,
+    _22Bytes,
+    _23Bytes,
+    _24Bytes,
+    _25Bytes,
+    _26Bytes,
+    _27Bytes,
+    _28Bytes,
+    _29Bytes,
+    _30Bytes,
+    _31Bytes,
+    _32Bytes,
+}
+
+impl Into<u8> for FIFOThresholdLevel {
+    fn into(self) -> u8 {
+        match self {
+            FIFOThresholdLevel::_1Bytes => 0,
+            FIFOThresholdLevel::_2Bytes => 1,
+            FIFOThresholdLevel::_3Bytes => 2,
+            FIFOThresholdLevel::_4Bytes => 3,
+            FIFOThresholdLevel::_5Bytes => 4,
+            FIFOThresholdLevel::_6Bytes => 5,
+            FIFOThresholdLevel::_7Bytes => 6,
+            FIFOThresholdLevel::_8Bytes => 7,
+            FIFOThresholdLevel::_9Bytes => 8,
+            FIFOThresholdLevel::_10Bytes => 9,
+            FIFOThresholdLevel::_11Bytes => 10,
+            FIFOThresholdLevel::_12Bytes => 11,
+            FIFOThresholdLevel::_13Bytes => 12,
+            FIFOThresholdLevel::_14Bytes => 13,
+            FIFOThresholdLevel::_15Bytes => 14,
+            FIFOThresholdLevel::_16Bytes => 15,
+            FIFOThresholdLevel::_17Bytes => 16,
+            FIFOThresholdLevel::_18Bytes => 17,
+            FIFOThresholdLevel::_19Bytes => 18,
+            FIFOThresholdLevel::_20Bytes => 19,
+            FIFOThresholdLevel::_21Bytes => 20,
+            FIFOThresholdLevel::_22Bytes => 21,
+            FIFOThresholdLevel::_23Bytes => 22,
+            FIFOThresholdLevel::_24Bytes => 23,
+            FIFOThresholdLevel::_25Bytes => 24,
+            FIFOThresholdLevel::_26Bytes => 25,
+            FIFOThresholdLevel::_27Bytes => 26,
+            FIFOThresholdLevel::_28Bytes => 27,
+            FIFOThresholdLevel::_29Bytes => 28,
+            FIFOThresholdLevel::_30Bytes => 29,
+            FIFOThresholdLevel::_31Bytes => 30,
+            FIFOThresholdLevel::_32Bytes => 31,
+        }
+    }
+}
+
+/// Dummy cycle count
+#[allow(missing_docs)]
+#[derive(Copy, Clone)]
+pub enum DummyCycles {
+    _0,
+    _1,
+    _2,
+    _3,
+    _4,
+    _5,
+    _6,
+    _7,
+    _8,
+    _9,
+    _10,
+    _11,
+    _12,
+    _13,
+    _14,
+    _15,
+    _16,
+    _17,
+    _18,
+    _19,
+    _20,
+    _21,
+    _22,
+    _23,
+    _24,
+    _25,
+    _26,
+    _27,
+    _28,
+    _29,
+    _30,
+    _31,
+}
+
+impl Into<u8> for DummyCycles {
+    fn into(self) -> u8 {
+        match self {
+            DummyCycles::_0 => 0,
+            DummyCycles::_1 => 1,
+            DummyCycles::_2 => 2,
+            DummyCycles::_3 => 3,
+            DummyCycles::_4 => 4,
+            DummyCycles::_5 => 5,
+            DummyCycles::_6 => 6,
+            DummyCycles::_7 => 7,
+            DummyCycles::_8 => 8,
+            DummyCycles::_9 => 9,
+            DummyCycles::_10 => 10,
+            DummyCycles::_11 => 11,
+            DummyCycles::_12 => 12,
+            DummyCycles::_13 => 13,
+            DummyCycles::_14 => 14,
+            DummyCycles::_15 => 15,
+            DummyCycles::_16 => 16,
+            DummyCycles::_17 => 17,
+            DummyCycles::_18 => 18,
+            DummyCycles::_19 => 19,
+            DummyCycles::_20 => 20,
+            DummyCycles::_21 => 21,
+            DummyCycles::_22 => 22,
+            DummyCycles::_23 => 23,
+            DummyCycles::_24 => 24,
+            DummyCycles::_25 => 25,
+            DummyCycles::_26 => 26,
+            DummyCycles::_27 => 27,
+            DummyCycles::_28 => 28,
+            DummyCycles::_29 => 29,
+            DummyCycles::_30 => 30,
+            DummyCycles::_31 => 31,
+        }
+    }
+}

--- a/embassy-stm32/src/xspi/mod.rs
+++ b/embassy-stm32/src/xspi/mod.rs
@@ -1,0 +1,1427 @@
+//! XSPI Serial Peripheral Interface
+//!
+
+#![macro_use]
+
+pub mod enums;
+
+use core::marker::PhantomData;
+
+use embassy_embedded_hal::{GetConfig, SetConfig};
+use embassy_hal_internal::{into_ref, PeripheralRef};
+pub use enums::*;
+
+use crate::dma::{word, ChannelAndRequest};
+use crate::gpio::{AfType, AnyPin, OutputType, Pull, SealedPin as _, Speed};
+use crate::mode::{Async, Blocking, Mode as PeriMode};
+use crate::pac::xspi::{vals::*, Xspi as Regs};
+#[cfg(xspim_v2_1)]
+use crate::pac::xspim::Xspim;
+use crate::rcc::{self, RccPeripheral};
+use crate::{peripherals, Peripheral};
+
+/// XPSI driver config.
+#[derive(Clone, Copy)]
+pub struct Config {
+    /// Fifo threshold used by the peripheral to generate the interrupt indicating data
+    /// or space is available in the FIFO
+    pub fifo_threshold: FIFOThresholdLevel,
+    /// Indicates the type of external device connected
+    pub memory_type: MemoryType, // Need to add an additional enum to provide this public interface
+    /// Defines the size of the external device connected to the XSPI corresponding
+    /// to the number of address bits required to access the device
+    pub device_size: MemorySize,
+    /// Sets the minimum number of clock cycles that the chip select signal must be held high
+    /// between commands
+    pub chip_select_high_time: ChipSelectHighTime,
+    /// Enables the free running clock
+    pub free_running_clock: bool,
+    /// Sets the clock level when the device is not selected
+    pub clock_mode: bool,
+    /// Indicates the wrap size corresponding to the external device configuration
+    pub wrap_size: WrapSize,
+    /// Specified the prescaler factor used for generating the external clock based
+    /// on the AHB clock
+    pub clock_prescaler: u8,
+    /// Allows the delay of 1/2 cycle the data sampling to account for external
+    /// signal delays
+    pub sample_shifting: bool,
+    /// Allows hold to 1/4 cycle the data
+    pub delay_hold_quarter_cycle: bool,
+    /// Enables the transaction boundary feature and defines the boundary to release
+    /// the chip select
+    pub chip_select_boundary: u8,
+    /// Enables communication regulation feature. Chip select is released when the other
+    /// XSpi requests access to the bus
+    pub max_transfer: u8,
+    /// Enables the refresh feature, chip select is released every refresh + 1 clock cycles
+    pub refresh: u32,
+}
+
+impl Default for Config {
+    fn default() -> Self {
+        Self {
+            fifo_threshold: FIFOThresholdLevel::_16Bytes, // 32 bytes FIFO, half capacity
+            memory_type: MemoryType::Micron,
+            device_size: MemorySize::Other(0),
+            chip_select_high_time: ChipSelectHighTime::_5Cycle,
+            free_running_clock: false,
+            clock_mode: false,
+            wrap_size: WrapSize::None,
+            clock_prescaler: 0,
+            sample_shifting: false,
+            delay_hold_quarter_cycle: false,
+            chip_select_boundary: 0, // Acceptable range 0 to 31
+            max_transfer: 0,
+            refresh: 0,
+        }
+    }
+}
+
+/// XSPI transfer configuration.
+pub struct TransferConfig {
+    /// Instruction width (IMODE)
+    pub iwidth: XspiWidth,
+    /// Instruction Id
+    pub instruction: Option<u32>,
+    /// Number of Instruction Bytes
+    pub isize: AddressSize,
+    /// Instruction Double Transfer rate enable
+    pub idtr: bool,
+
+    /// Address width (ADMODE)
+    pub adwidth: XspiWidth,
+    /// Device memory address
+    pub address: Option<u32>,
+    /// Number of Address Bytes
+    pub adsize: AddressSize,
+    /// Address Double Transfer rate enable
+    pub addtr: bool,
+
+    /// Alternate bytes width (ABMODE)
+    pub abwidth: XspiWidth,
+    /// Alternate Bytes
+    pub alternate_bytes: Option<u32>,
+    /// Number of Alternate Bytes
+    pub absize: AddressSize,
+    /// Alternate Bytes Double Transfer rate enable
+    pub abdtr: bool,
+
+    /// Data width (DMODE)
+    pub dwidth: XspiWidth,
+    /// Data buffer
+    pub ddtr: bool,
+
+    /// Number of dummy cycles (DCYC)
+    pub dummy: DummyCycles,
+}
+
+impl Default for TransferConfig {
+    fn default() -> Self {
+        Self {
+            iwidth: XspiWidth::NONE,
+            instruction: None,
+            isize: AddressSize::_8Bit,
+            idtr: false,
+
+            adwidth: XspiWidth::NONE,
+            address: None,
+            adsize: AddressSize::_8Bit,
+            addtr: false,
+
+            abwidth: XspiWidth::NONE,
+            alternate_bytes: None,
+            absize: AddressSize::_8Bit,
+            abdtr: false,
+
+            dwidth: XspiWidth::NONE,
+            ddtr: false,
+
+            dummy: DummyCycles::_0,
+        }
+    }
+}
+
+/// Error used for Xspi implementation
+#[derive(Debug)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+pub enum XspiError {
+    /// Peripheral configuration is invalid
+    InvalidConfiguration,
+    /// Operation configuration is invalid
+    InvalidCommand,
+    /// Size zero buffer passed to instruction
+    EmptyBuffer,
+}
+
+/// XSPI driver.
+pub struct Xspi<'d, T: Instance, M: PeriMode> {
+    _peri: PeripheralRef<'d, T>,
+    clk: Option<PeripheralRef<'d, AnyPin>>,
+    d0: Option<PeripheralRef<'d, AnyPin>>,
+    d1: Option<PeripheralRef<'d, AnyPin>>,
+    d2: Option<PeripheralRef<'d, AnyPin>>,
+    d3: Option<PeripheralRef<'d, AnyPin>>,
+    d4: Option<PeripheralRef<'d, AnyPin>>,
+    d5: Option<PeripheralRef<'d, AnyPin>>,
+    d6: Option<PeripheralRef<'d, AnyPin>>,
+    d7: Option<PeripheralRef<'d, AnyPin>>,
+    d8: Option<PeripheralRef<'d, AnyPin>>,
+    d9: Option<PeripheralRef<'d, AnyPin>>,
+    d10: Option<PeripheralRef<'d, AnyPin>>,
+    d11: Option<PeripheralRef<'d, AnyPin>>,
+    d12: Option<PeripheralRef<'d, AnyPin>>,
+    d13: Option<PeripheralRef<'d, AnyPin>>,
+    d14: Option<PeripheralRef<'d, AnyPin>>,
+    d15: Option<PeripheralRef<'d, AnyPin>>,
+    ncs1: Option<PeripheralRef<'d, AnyPin>>,
+    ncs2: Option<PeripheralRef<'d, AnyPin>>,
+    dqs0: Option<PeripheralRef<'d, AnyPin>>,
+    dqs1: Option<PeripheralRef<'d, AnyPin>>,
+    dma: Option<ChannelAndRequest<'d>>,
+    _phantom: PhantomData<M>,
+    config: Config,
+    width: XspiWidth,
+}
+
+impl<'d, T: Instance, M: PeriMode> Xspi<'d, T, M> {
+    /// Enter memory mode.
+    /// The Input `read_config` is used to configure the read operation in memory mode
+    pub fn enable_memory_mapped_mode(
+        &mut self,
+        read_config: TransferConfig,
+        write_config: TransferConfig,
+    ) -> Result<(), XspiError> {
+        // Use configure command to set read config
+        self.configure_command(&read_config, None)?;
+
+        let reg = T::REGS;
+        while reg.xspi_sr().read().busy() {}
+
+        reg.xspi_ccr().modify(|r| {
+            r.set_dqse(XspiCcrDqse::B_0X0);
+        });
+
+        // Set wrting configurations, there are separate registers for write configurations in memory mapped mode
+        reg.xspi_wccr().modify(|w| {
+            w.set_imode(XspiWccrImode::from_bits(write_config.iwidth.into()));
+            let idtr = match write_config.idtr {
+                true => XspiWccrIdtr::B_0X1,
+                false => XspiWccrIdtr::B_0X0,
+            };
+            w.set_idtr(idtr);
+            w.set_isize(XspiWccrIsize::from_bits(write_config.isize.into()));
+
+            w.set_admode(XspiWccrAdmode::from_bits(write_config.adwidth.into()));
+            let addtr = match write_config.idtr {
+                true => XspiWccrAddtr::B_0X1,
+                false => XspiWccrAddtr::B_0X0,
+            };
+            w.set_addtr(addtr);
+            w.set_adsize(XspiWccrAdsize::from_bits(write_config.adsize.into()));
+
+            w.set_dmode(XspiWccrDmode::from_bits(write_config.dwidth.into()));
+            let ddtr = match write_config.idtr {
+                true => XspiWccrDdtr::B_0X1,
+                false => XspiWccrDdtr::B_0X0,
+            };
+            w.set_ddtr(ddtr);
+
+            w.set_abmode(XspiWccrAbmode::from_bits(write_config.abwidth.into()));
+            w.set_dqse(XspiWccrDqse::B_0X1);
+        });
+
+        reg.xspi_wtcr().modify(|w| w.set_dcyc(write_config.dummy.into()));
+
+        // Enable memory mapped mode
+        reg.xspi_cr().modify(|r| {
+            r.set_fmode(Fmode::B_0X3);
+            r.set_tcen(Tcen::B_0X0);
+        });
+        Ok(())
+    }
+
+    /// Quit from memory mapped mode
+    pub fn disable_memory_mapped_mode(&mut self) {
+        let reg = T::REGS;
+
+        reg.xspi_cr().modify(|r| {
+            r.set_fmode(Fmode::B_0X0);
+            r.set_abort(Abort::B_0X1);
+            r.set_dmaen(Dmaen::B_0X0);
+            r.set_en(En::B_0X0);
+        });
+
+        // Clear transfer complete flag
+        reg.xspi_fcr().write(|w| w.set_ctcf(true));
+
+        // Re-enable ospi
+        reg.xspi_cr().modify(|r| {
+            r.set_en(En::B_0X1);
+        });
+    }
+
+    fn new_inner(
+        peri: impl Peripheral<P = T> + 'd,
+        d0: Option<PeripheralRef<'d, AnyPin>>,
+        d1: Option<PeripheralRef<'d, AnyPin>>,
+        d2: Option<PeripheralRef<'d, AnyPin>>,
+        d3: Option<PeripheralRef<'d, AnyPin>>,
+        d4: Option<PeripheralRef<'d, AnyPin>>,
+        d5: Option<PeripheralRef<'d, AnyPin>>,
+        d6: Option<PeripheralRef<'d, AnyPin>>,
+        d7: Option<PeripheralRef<'d, AnyPin>>,
+        d8: Option<PeripheralRef<'d, AnyPin>>,
+        d9: Option<PeripheralRef<'d, AnyPin>>,
+        d10: Option<PeripheralRef<'d, AnyPin>>,
+        d11: Option<PeripheralRef<'d, AnyPin>>,
+        d12: Option<PeripheralRef<'d, AnyPin>>,
+        d13: Option<PeripheralRef<'d, AnyPin>>,
+        d14: Option<PeripheralRef<'d, AnyPin>>,
+        d15: Option<PeripheralRef<'d, AnyPin>>,
+        clk: Option<PeripheralRef<'d, AnyPin>>,
+        ncs1: Option<PeripheralRef<'d, AnyPin>>,
+        ncs2: Option<PeripheralRef<'d, AnyPin>>,
+        dqs0: Option<PeripheralRef<'d, AnyPin>>,
+        dqs1: Option<PeripheralRef<'d, AnyPin>>,
+        dma: Option<ChannelAndRequest<'d>>,
+        config: Config,
+        width: XspiWidth,
+        dual_quad: bool,
+    ) -> Self {
+        into_ref!(peri);
+
+        #[cfg(xspim_v2_1)]
+        {
+            // RCC for xspim should be enabled before writing register
+            crate::pac::RCC.ahb5enr().modify(|w| w.set_iomngren(true));
+
+            // Disable XSPI peripheral first
+            T::REGS.xspi_cr().modify(|w| {
+                w.set_en(En::B_0X0);
+            });
+
+            // XSPI IO Manager has been enabled before
+            T::SPIM_REGS.xspim_cr().modify(|w| {
+                w.set_muxen(false);
+                w.set_req2ack_time(0xff);
+            });
+        }
+
+        // System configuration
+        rcc::enable_and_reset::<T>();
+        while T::REGS.xspi_sr().read().busy() {}
+
+        // Device configuration
+        T::REGS.xspi_dcr1().modify(|w| {
+            w.set_devsize(config.device_size.into());
+            w.set_mtyp(Mtyp::from_bits(config.memory_type.into()));
+            w.set_csht(Csht::from_bits(config.chip_select_high_time.into()));
+            w.set_frck(Frck::B_0X0);
+            w.set_ckmode(Ckmode::from_bits(config.clock_mode.into()));
+        });
+
+        T::REGS.xspi_dcr2().modify(|w| {
+            w.set_wrapsize(Wrapsize::from_bits(config.wrap_size.into()));
+        });
+
+        T::REGS.xspi_dcr3().modify(|w| {
+            w.set_csbound(Csbound::from_bits(config.chip_select_boundary.into()));
+            #[cfg(xspi_v2_1)]
+            {
+                w.set_maxtran(Maxtran::from_bits(config.max_transfer.into()));
+            }
+        });
+
+        T::REGS.xspi_dcr4().modify(|w| {
+            w.set_refresh(Refresh::from_bits(config.refresh.into()));
+        });
+
+        T::REGS.xspi_cr().modify(|w| {
+            w.set_fthres(Fthres::from_bits(config.fifo_threshold.into()));
+        });
+
+        // Wait for busy flag to clear
+        while T::REGS.xspi_sr().read().busy() {}
+
+        T::REGS.xspi_dcr2().modify(|w| {
+            w.set_prescaler(Prescaler::from_bits(config.clock_prescaler.into()));
+        });
+
+        T::REGS.xspi_cr().modify(|w| {
+            w.set_dmm(match dual_quad {
+                true => Dmm::B_0X1,
+                false => Dmm::B_0X0,
+            });
+        });
+
+        T::REGS.xspi_tcr().modify(|w| {
+            w.set_sshift(match config.sample_shifting {
+                true => XspiTcrSshift::B_0X1,
+                false => XspiTcrSshift::B_0X0,
+            });
+            w.set_dhqc(match config.delay_hold_quarter_cycle {
+                true => XspiTcrDhqc::B_0X1,
+                false => XspiTcrDhqc::B_0X0,
+            });
+        });
+
+        // Enable peripheral
+        T::REGS.xspi_cr().modify(|w| {
+            w.set_en(En::B_0X1);
+        });
+
+        // Free running clock needs to be set after peripheral enable
+        if config.free_running_clock {
+            T::REGS.xspi_dcr1().modify(|w| {
+                w.set_frck(match config.free_running_clock {
+                    true => Frck::B_0X1,
+                    false => Frck::B_0X0,
+                });
+            });
+        }
+
+        Self {
+            _peri: peri,
+            clk,
+            d0,
+            d1,
+            d2,
+            d3,
+            d4,
+            d5,
+            d6,
+            d7,
+            d8,
+            d9,
+            d10,
+            d11,
+            d12,
+            d13,
+            d14,
+            d15,
+            ncs1,
+            ncs2,
+            dqs0,
+            dqs1,
+            dma,
+            _phantom: PhantomData,
+            config,
+            width,
+        }
+    }
+
+    // Function to configure the peripheral for the requested command
+    fn configure_command(&mut self, command: &TransferConfig, data_len: Option<usize>) -> Result<(), XspiError> {
+        // Check that transaction doesn't use more than hardware initialized pins
+        if <enums::XspiWidth as Into<u8>>::into(command.iwidth) > <enums::XspiWidth as Into<u8>>::into(self.width)
+            || <enums::XspiWidth as Into<u8>>::into(command.adwidth) > <enums::XspiWidth as Into<u8>>::into(self.width)
+            || <enums::XspiWidth as Into<u8>>::into(command.abwidth) > <enums::XspiWidth as Into<u8>>::into(self.width)
+            || <enums::XspiWidth as Into<u8>>::into(command.dwidth) > <enums::XspiWidth as Into<u8>>::into(self.width)
+        {
+            return Err(XspiError::InvalidCommand);
+        }
+
+        T::REGS.xspi_cr().modify(|w| {
+            w.set_fmode(0.into());
+        });
+
+        // Configure alternate bytes
+        if let Some(ab) = command.alternate_bytes {
+            T::REGS.xspi_abr().write(|v| v.set_alternate(ab));
+            T::REGS.xspi_ccr().modify(|w| {
+                w.set_abmode(XspiCcrAbmode::from_bits(command.abwidth.into()));
+                w.set_abdtr(XspiCcrAbdtr::from_bits(command.abdtr.into()));
+                w.set_absize(XspiCcrAbsize::from_bits(command.absize.into()));
+            })
+        }
+
+        // Configure dummy cycles
+        T::REGS.xspi_tcr().modify(|w| {
+            w.set_dcyc(command.dummy.into());
+        });
+
+        // Configure data
+        if let Some(data_length) = data_len {
+            T::REGS.xspi_dlr().write(|v| {
+                v.set_dl((data_length - 1) as u32);
+            })
+        } else {
+            T::REGS.xspi_dlr().write(|v| {
+                v.set_dl((0) as u32);
+            })
+        }
+
+        // Configure instruction/address/data modes
+        T::REGS.xspi_ccr().modify(|w| {
+            w.set_imode(XspiCcrImode::from_bits(command.iwidth.into()));
+            w.set_idtr(match command.idtr {
+                true => XspiCcrIdtr::B_0X1,
+                false => XspiCcrIdtr::B_0X0,
+            });
+            w.set_isize(XspiCcrIsize::from_bits(command.isize.into()));
+
+            w.set_admode(XspiCcrAdmode::from_bits(command.adwidth.into()));
+            w.set_addtr(match command.idtr {
+                true => XspiCcrAddtr::B_0X1,
+                false => XspiCcrAddtr::B_0X0,
+            });
+            w.set_adsize(XspiCcrAdsize::from_bits(command.adsize.into()));
+
+            w.set_dmode(XspiCcrDmode::from_bits(command.dwidth.into()));
+            w.set_ddtr(match command.ddtr {
+                true => XspiCcrDdtr::B_0X1,
+                false => XspiCcrDdtr::B_0X0,
+            });
+        });
+
+        // Set information required to initiate transaction
+        if let Some(instruction) = command.instruction {
+            if let Some(address) = command.address {
+                T::REGS.xspi_ir().write(|v| {
+                    v.set_instruction(instruction);
+                });
+
+                T::REGS.xspi_ar().write(|v| {
+                    v.set_address(address);
+                });
+            } else {
+                // Double check requirements for delay hold and sample shifting
+                // if let None = command.data_len {
+                //     if self.config.delay_hold_quarter_cycle && command.idtr {
+                //         T::REGS.xspi_ccr().modify(|w| {
+                //             w.set_ddtr(true);
+                //         });
+                //     }
+                // }
+
+                warn!("instruction: {:#x}", instruction);
+                T::REGS.xspi_ir().write(|v| {
+                    v.set_instruction(instruction);
+                });
+            }
+        } else {
+            if let Some(address) = command.address {
+                T::REGS.xspi_ar().write(|v| {
+                    v.set_address(address);
+                });
+            } else {
+                // The only single phase transaction supported is instruction only
+                return Err(XspiError::InvalidCommand);
+            }
+        }
+
+        Ok(())
+    }
+
+    /// Function used to control or configure the target device without data transfer
+    pub fn blocking_command(&mut self, command: &TransferConfig) -> Result<(), XspiError> {
+        // Wait for peripheral to be free
+        while T::REGS.xspi_sr().read().busy() {}
+
+        // Need additional validation that command configuration doesn't have data set
+        self.configure_command(command, None)?;
+
+        // Transaction initiated by setting final configuration, i.e the instruction register
+        while !T::REGS.xspi_sr().read().tcf() {}
+        T::REGS.xspi_fcr().write(|w| {
+            w.set_ctcf(true);
+        });
+
+        Ok(())
+    }
+
+    /// Blocking read with byte by byte data transfer
+    pub fn blocking_read<W: Word>(&mut self, buf: &mut [W], transaction: TransferConfig) -> Result<(), XspiError> {
+        if buf.is_empty() {
+            return Err(XspiError::EmptyBuffer);
+        }
+
+        // Wait for peripheral to be free
+        while T::REGS.xspi_sr().read().busy() {}
+
+        // Ensure DMA is not enabled for this transaction
+        T::REGS.xspi_cr().modify(|w| {
+            w.set_dmaen(Dmaen::B_0X0);
+        });
+
+        // self.configure_command(&transaction, Some(buf.len()))?;
+        self.configure_command(&transaction, Some(buf.len())).unwrap();
+
+        let current_address = T::REGS.xspi_ar().read().address();
+        let current_instruction = T::REGS.xspi_ir().read().instruction();
+
+        // For a indirect read transaction, the transaction begins when the instruction/address is set
+        T::REGS
+            .xspi_cr()
+            .modify(|v| v.set_fmode(Fmode::from_bits(XspiMode::IndirectRead.into())));
+        if T::REGS.xspi_ccr().read().admode() == XspiCcrAdmode::B_0X0 {
+            T::REGS.xspi_ir().write(|v| v.set_instruction(current_instruction));
+        } else {
+            T::REGS.xspi_ar().write(|v| v.set_address(current_address));
+        }
+
+        for idx in 0..buf.len() {
+            while !T::REGS.xspi_sr().read().tcf() && !T::REGS.xspi_sr().read().ftf() {}
+            buf[idx] = unsafe { (T::REGS.xspi_dr().as_ptr() as *mut W).read_volatile() };
+        }
+
+        while !T::REGS.xspi_sr().read().tcf() {}
+        T::REGS.xspi_fcr().write(|v| v.set_ctcf(true));
+
+        Ok(())
+    }
+
+    /// Blocking write with byte by byte data transfer
+    pub fn blocking_write<W: Word>(&mut self, buf: &[W], transaction: TransferConfig) -> Result<(), XspiError> {
+        if buf.is_empty() {
+            return Err(XspiError::EmptyBuffer);
+        }
+
+        // Wait for peripheral to be free
+        while T::REGS.xspi_sr().read().busy() {}
+
+        T::REGS.xspi_cr().modify(|w| {
+            w.set_dmaen(Dmaen::B_0X0);
+        });
+
+        self.configure_command(&transaction, Some(buf.len()))?;
+
+        T::REGS
+            .xspi_cr()
+            .modify(|v| v.set_fmode(Fmode::from_bits(XspiMode::IndirectWrite.into())));
+
+        for idx in 0..buf.len() {
+            while !T::REGS.xspi_sr().read().ftf() {}
+            unsafe { (T::REGS.xspi_dr().as_ptr() as *mut W).write_volatile(buf[idx]) };
+        }
+
+        while !T::REGS.xspi_sr().read().tcf() {}
+        T::REGS.xspi_fcr().write(|v| v.set_ctcf(true));
+
+        Ok(())
+    }
+
+    /// Set new bus configuration
+    pub fn set_config(&mut self, config: &Config) {
+        // Wait for busy flag to clear
+        while T::REGS.xspi_sr().read().busy() {}
+
+        // Disable DMA channel while configuring the peripheral
+        T::REGS.xspi_cr().modify(|w| {
+            w.set_dmaen(Dmaen::B_0X0);
+        });
+
+        // Device configuration
+        T::REGS.xspi_dcr1().modify(|w| {
+            w.set_devsize(config.device_size.into());
+            w.set_mtyp(Mtyp::from_bits(config.memory_type.into()));
+            w.set_csht(Csht::from_bits(config.chip_select_high_time.into()));
+            w.set_frck(Frck::B_0X0);
+            w.set_ckmode(match config.clock_mode {
+                true => Ckmode::B_0X1,
+                false => Ckmode::B_0X0,
+            });
+        });
+
+        T::REGS.xspi_dcr2().modify(|w| {
+            w.set_wrapsize(Wrapsize::from_bits(config.wrap_size.into()));
+        });
+
+        T::REGS.xspi_dcr3().modify(|w| {
+            w.set_csbound(Csbound::from_bits(config.chip_select_boundary.into()));
+            #[cfg(xspi_v2_1)]
+            {
+                w.set_maxtran(Maxtran::from_bits(config.max_transfer.into()));
+            }
+        });
+
+        T::REGS.xspi_dcr4().modify(|w| {
+            w.set_refresh(Refresh::from_bits(config.refresh.into()));
+        });
+
+        T::REGS.xspi_cr().modify(|w| {
+            w.set_fthres(Fthres::from_bits(config.fifo_threshold.into()));
+        });
+
+        // Wait for busy flag to clear
+        while T::REGS.xspi_sr().read().busy() {}
+
+        T::REGS.xspi_dcr2().modify(|w| {
+            w.set_prescaler(Prescaler::from_bits(config.clock_prescaler.into()));
+        });
+
+        T::REGS.xspi_tcr().modify(|w| {
+            w.set_sshift(match config.sample_shifting {
+                true => XspiTcrSshift::B_0X1,
+                false => XspiTcrSshift::B_0X0,
+            });
+            w.set_dhqc(match config.delay_hold_quarter_cycle {
+                true => XspiTcrDhqc::B_0X1,
+                false => XspiTcrDhqc::B_0X0,
+            });
+        });
+
+        // Enable peripheral
+        T::REGS.xspi_cr().modify(|w| {
+            w.set_en(En::B_0X1);
+        });
+
+        // Free running clock needs to be set after peripheral enable
+        if config.free_running_clock {
+            T::REGS.xspi_dcr1().modify(|w| {
+                w.set_frck(match config.free_running_clock {
+                    true => Frck::B_0X1,
+                    false => Frck::B_0X0,
+                });
+            });
+        }
+
+        self.config = *config;
+    }
+
+    /// Get current configuration
+    pub fn get_config(&self) -> Config {
+        self.config
+    }
+}
+
+impl<'d, T: Instance> Xspi<'d, T, Blocking> {
+    /// Create new blocking XSPI driver for a single spi external chip
+    pub fn new_blocking_singlespi(
+        peri: impl Peripheral<P = T> + 'd,
+        clk: impl Peripheral<P = impl CLKPin<T>> + 'd,
+        d0: impl Peripheral<P = impl D0Pin<T>> + 'd,
+        d1: impl Peripheral<P = impl D1Pin<T>> + 'd,
+        ncs: impl Peripheral<P = impl NCS1Pin<T>> + 'd,
+        config: Config,
+    ) -> Self {
+        Self::new_inner(
+            peri,
+            new_pin!(d0, AfType::output(OutputType::PushPull, Speed::VeryHigh)),
+            new_pin!(d1, AfType::input(Pull::None)),
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            new_pin!(clk, AfType::output(OutputType::PushPull, Speed::VeryHigh)),
+            new_pin!(ncs, AfType::output(OutputType::OpenDrain, Speed::VeryHigh)),
+            None,
+            None,
+            None,
+            None,
+            config,
+            XspiWidth::SING,
+            false,
+        )
+    }
+
+    /// Create new blocking XSPI driver for a dualspi external chip
+    pub fn new_blocking_dualspi(
+        peri: impl Peripheral<P = T> + 'd,
+        clk: impl Peripheral<P = impl CLKPin<T>> + 'd,
+        d0: impl Peripheral<P = impl D0Pin<T>> + 'd,
+        d1: impl Peripheral<P = impl D1Pin<T>> + 'd,
+        ncs: impl Peripheral<P = impl NCS1Pin<T>> + 'd,
+        config: Config,
+    ) -> Self {
+        Self::new_inner(
+            peri,
+            new_pin!(d0, AfType::output(OutputType::PushPull, Speed::VeryHigh)),
+            new_pin!(d1, AfType::output(OutputType::PushPull, Speed::VeryHigh)),
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            new_pin!(clk, AfType::output(OutputType::PushPull, Speed::VeryHigh)),
+            new_pin!(
+                ncs,
+                AfType::output_pull(OutputType::PushPull, Speed::VeryHigh, Pull::Up)
+            ),
+            None,
+            None,
+            None,
+            None,
+            config,
+            XspiWidth::DUAL,
+            false,
+        )
+    }
+
+    /// Create new blocking XSPI driver for a quadspi external chip
+    pub fn new_blocking_quadspi(
+        peri: impl Peripheral<P = T> + 'd,
+        clk: impl Peripheral<P = impl CLKPin<T>> + 'd,
+        d0: impl Peripheral<P = impl D0Pin<T>> + 'd,
+        d1: impl Peripheral<P = impl D1Pin<T>> + 'd,
+        d2: impl Peripheral<P = impl D2Pin<T>> + 'd,
+        d3: impl Peripheral<P = impl D3Pin<T>> + 'd,
+        ncs: impl Peripheral<P = impl NCS1Pin<T>> + 'd,
+        config: Config,
+    ) -> Self {
+        Self::new_inner(
+            peri,
+            new_pin!(d0, AfType::output(OutputType::PushPull, Speed::VeryHigh)),
+            new_pin!(d1, AfType::output(OutputType::PushPull, Speed::VeryHigh)),
+            new_pin!(d2, AfType::output(OutputType::PushPull, Speed::VeryHigh)),
+            new_pin!(d3, AfType::output(OutputType::PushPull, Speed::VeryHigh)),
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            new_pin!(clk, AfType::output(OutputType::PushPull, Speed::VeryHigh)),
+            new_pin!(
+                ncs,
+                AfType::output_pull(OutputType::PushPull, Speed::VeryHigh, Pull::Up)
+            ),
+            None,
+            None,
+            None,
+            None,
+            config,
+            XspiWidth::QUAD,
+            false,
+        )
+    }
+
+    /// Create new blocking XSPI driver for two quadspi external chips
+    pub fn new_blocking_dualquadspi(
+        peri: impl Peripheral<P = T> + 'd,
+        clk: impl Peripheral<P = impl CLKPin<T>> + 'd,
+        d0: impl Peripheral<P = impl D0Pin<T>> + 'd,
+        d1: impl Peripheral<P = impl D1Pin<T>> + 'd,
+        d2: impl Peripheral<P = impl D2Pin<T>> + 'd,
+        d3: impl Peripheral<P = impl D3Pin<T>> + 'd,
+        d4: impl Peripheral<P = impl D4Pin<T>> + 'd,
+        d5: impl Peripheral<P = impl D5Pin<T>> + 'd,
+        d6: impl Peripheral<P = impl D6Pin<T>> + 'd,
+        d7: impl Peripheral<P = impl D7Pin<T>> + 'd,
+        ncs: impl Peripheral<P = impl NCS1Pin<T>> + 'd,
+        config: Config,
+    ) -> Self {
+        Self::new_inner(
+            peri,
+            new_pin!(d0, AfType::output(OutputType::PushPull, Speed::VeryHigh)),
+            new_pin!(d1, AfType::output(OutputType::PushPull, Speed::VeryHigh)),
+            new_pin!(d2, AfType::output(OutputType::PushPull, Speed::VeryHigh)),
+            new_pin!(d3, AfType::output(OutputType::PushPull, Speed::VeryHigh)),
+            new_pin!(d4, AfType::output(OutputType::PushPull, Speed::VeryHigh)),
+            new_pin!(d5, AfType::output(OutputType::PushPull, Speed::VeryHigh)),
+            new_pin!(d6, AfType::output(OutputType::PushPull, Speed::VeryHigh)),
+            new_pin!(d7, AfType::output(OutputType::PushPull, Speed::VeryHigh)),
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            new_pin!(clk, AfType::output(OutputType::PushPull, Speed::VeryHigh)),
+            new_pin!(
+                ncs,
+                AfType::output_pull(OutputType::PushPull, Speed::VeryHigh, Pull::Up)
+            ),
+            None,
+            None,
+            None,
+            None,
+            config,
+            XspiWidth::QUAD,
+            true,
+        )
+    }
+
+    /// Create new blocking XSPI driver for xspi external chips
+    pub fn new_blocking_xspi(
+        peri: impl Peripheral<P = T> + 'd,
+        clk: impl Peripheral<P = impl CLKPin<T>> + 'd,
+        d0: impl Peripheral<P = impl D0Pin<T>> + 'd,
+        d1: impl Peripheral<P = impl D1Pin<T>> + 'd,
+        d2: impl Peripheral<P = impl D2Pin<T>> + 'd,
+        d3: impl Peripheral<P = impl D3Pin<T>> + 'd,
+        d4: impl Peripheral<P = impl D4Pin<T>> + 'd,
+        d5: impl Peripheral<P = impl D5Pin<T>> + 'd,
+        d6: impl Peripheral<P = impl D6Pin<T>> + 'd,
+        d7: impl Peripheral<P = impl D7Pin<T>> + 'd,
+        ncs: impl Peripheral<P = impl NCS1Pin<T>> + 'd,
+        config: Config,
+    ) -> Self {
+        Self::new_inner(
+            peri,
+            new_pin!(d0, AfType::output(OutputType::PushPull, Speed::VeryHigh)),
+            new_pin!(d1, AfType::output(OutputType::PushPull, Speed::VeryHigh)),
+            new_pin!(d2, AfType::output(OutputType::PushPull, Speed::VeryHigh)),
+            new_pin!(d3, AfType::output(OutputType::PushPull, Speed::VeryHigh)),
+            new_pin!(d4, AfType::output(OutputType::PushPull, Speed::VeryHigh)),
+            new_pin!(d5, AfType::output(OutputType::PushPull, Speed::VeryHigh)),
+            new_pin!(d6, AfType::output(OutputType::PushPull, Speed::VeryHigh)),
+            new_pin!(d7, AfType::output(OutputType::PushPull, Speed::VeryHigh)),
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            new_pin!(clk, AfType::output(OutputType::PushPull, Speed::VeryHigh)),
+            new_pin!(
+                ncs,
+                AfType::output_pull(OutputType::PushPull, Speed::VeryHigh, Pull::Up)
+            ),
+            None,
+            None,
+            None,
+            None,
+            config,
+            XspiWidth::OCTO,
+            false,
+        )
+    }
+}
+
+impl<'d, T: Instance> Xspi<'d, T, Async> {
+    /// Create new blocking XSPI driver for a single spi external chip
+    pub fn new_singlespi(
+        peri: impl Peripheral<P = T> + 'd,
+        clk: impl Peripheral<P = impl CLKPin<T>> + 'd,
+        d0: impl Peripheral<P = impl D0Pin<T>> + 'd,
+        d1: impl Peripheral<P = impl D1Pin<T>> + 'd,
+        ncs: impl Peripheral<P = impl NCS1Pin<T>> + 'd,
+        dma: impl Peripheral<P = impl XDma<T>> + 'd,
+        config: Config,
+    ) -> Self {
+        Self::new_inner(
+            peri,
+            new_pin!(d0, AfType::output(OutputType::PushPull, Speed::VeryHigh)),
+            new_pin!(d1, AfType::input(Pull::None)),
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            new_pin!(clk, AfType::output(OutputType::PushPull, Speed::VeryHigh)),
+            new_pin!(ncs, AfType::output(OutputType::PushPull, Speed::VeryHigh)),
+            None,
+            None,
+            None,
+            new_dma!(dma),
+            config,
+            XspiWidth::SING,
+            false,
+        )
+    }
+
+    /// Create new blocking XSPI driver for a dualspi external chip
+    pub fn new_dualspi(
+        peri: impl Peripheral<P = T> + 'd,
+        clk: impl Peripheral<P = impl CLKPin<T>> + 'd,
+        d0: impl Peripheral<P = impl D0Pin<T>> + 'd,
+        d1: impl Peripheral<P = impl D1Pin<T>> + 'd,
+        ncs: impl Peripheral<P = impl NCS1Pin<T>> + 'd,
+        dma: impl Peripheral<P = impl XDma<T>> + 'd,
+        config: Config,
+    ) -> Self {
+        Self::new_inner(
+            peri,
+            new_pin!(d0, AfType::output(OutputType::PushPull, Speed::VeryHigh)),
+            new_pin!(d1, AfType::output(OutputType::PushPull, Speed::VeryHigh)),
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            new_pin!(clk, AfType::output(OutputType::PushPull, Speed::VeryHigh)),
+            new_pin!(
+                ncs,
+                AfType::output_pull(OutputType::PushPull, Speed::VeryHigh, Pull::Up)
+            ),
+            None,
+            None,
+            None,
+            new_dma!(dma),
+            config,
+            XspiWidth::DUAL,
+            false,
+        )
+    }
+
+    /// Create new blocking XSPI driver for a quadspi external chip
+    pub fn new_quadspi(
+        peri: impl Peripheral<P = T> + 'd,
+        clk: impl Peripheral<P = impl CLKPin<T>> + 'd,
+        d0: impl Peripheral<P = impl D0Pin<T>> + 'd,
+        d1: impl Peripheral<P = impl D1Pin<T>> + 'd,
+        d2: impl Peripheral<P = impl D2Pin<T>> + 'd,
+        d3: impl Peripheral<P = impl D3Pin<T>> + 'd,
+        ncs: impl Peripheral<P = impl NCS1Pin<T>> + 'd,
+        dma: impl Peripheral<P = impl XDma<T>> + 'd,
+        config: Config,
+    ) -> Self {
+        Self::new_inner(
+            peri,
+            new_pin!(d0, AfType::output(OutputType::PushPull, Speed::VeryHigh)),
+            new_pin!(d1, AfType::output(OutputType::PushPull, Speed::VeryHigh)),
+            new_pin!(d2, AfType::output(OutputType::PushPull, Speed::VeryHigh)),
+            new_pin!(d3, AfType::output(OutputType::PushPull, Speed::VeryHigh)),
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            new_pin!(clk, AfType::output(OutputType::PushPull, Speed::VeryHigh)),
+            new_pin!(
+                ncs,
+                AfType::output_pull(OutputType::PushPull, Speed::VeryHigh, Pull::Up)
+            ),
+            None,
+            None,
+            None,
+            new_dma!(dma),
+            config,
+            XspiWidth::QUAD,
+            false,
+        )
+    }
+
+    /// Create new blocking XSPI driver for two quadspi external chips
+    pub fn new_dualquadspi(
+        peri: impl Peripheral<P = T> + 'd,
+        clk: impl Peripheral<P = impl CLKPin<T>> + 'd,
+        d0: impl Peripheral<P = impl D0Pin<T>> + 'd,
+        d1: impl Peripheral<P = impl D1Pin<T>> + 'd,
+        d2: impl Peripheral<P = impl D2Pin<T>> + 'd,
+        d3: impl Peripheral<P = impl D3Pin<T>> + 'd,
+        d4: impl Peripheral<P = impl D4Pin<T>> + 'd,
+        d5: impl Peripheral<P = impl D5Pin<T>> + 'd,
+        d6: impl Peripheral<P = impl D6Pin<T>> + 'd,
+        d7: impl Peripheral<P = impl D7Pin<T>> + 'd,
+        ncs: impl Peripheral<P = impl NCS1Pin<T>> + 'd,
+        dma: impl Peripheral<P = impl XDma<T>> + 'd,
+        config: Config,
+    ) -> Self {
+        Self::new_inner(
+            peri,
+            new_pin!(d0, AfType::output(OutputType::PushPull, Speed::VeryHigh)),
+            new_pin!(d1, AfType::output(OutputType::PushPull, Speed::VeryHigh)),
+            new_pin!(d2, AfType::output(OutputType::PushPull, Speed::VeryHigh)),
+            new_pin!(d3, AfType::output(OutputType::PushPull, Speed::VeryHigh)),
+            new_pin!(d4, AfType::output(OutputType::PushPull, Speed::VeryHigh)),
+            new_pin!(d5, AfType::output(OutputType::PushPull, Speed::VeryHigh)),
+            new_pin!(d6, AfType::output(OutputType::PushPull, Speed::VeryHigh)),
+            new_pin!(d7, AfType::output(OutputType::PushPull, Speed::VeryHigh)),
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            new_pin!(clk, AfType::output(OutputType::PushPull, Speed::VeryHigh)),
+            new_pin!(
+                ncs,
+                AfType::output_pull(OutputType::PushPull, Speed::VeryHigh, Pull::Up)
+            ),
+            None,
+            None,
+            None,
+            new_dma!(dma),
+            config,
+            XspiWidth::QUAD,
+            true,
+        )
+    }
+
+    /// Create new blocking XSPI driver for xspi external chips
+    pub fn new_xspi(
+        peri: impl Peripheral<P = T> + 'd,
+        clk: impl Peripheral<P = impl CLKPin<T>> + 'd,
+        d0: impl Peripheral<P = impl D0Pin<T>> + 'd,
+        d1: impl Peripheral<P = impl D1Pin<T>> + 'd,
+        d2: impl Peripheral<P = impl D2Pin<T>> + 'd,
+        d3: impl Peripheral<P = impl D3Pin<T>> + 'd,
+        d4: impl Peripheral<P = impl D4Pin<T>> + 'd,
+        d5: impl Peripheral<P = impl D5Pin<T>> + 'd,
+        d6: impl Peripheral<P = impl D6Pin<T>> + 'd,
+        d7: impl Peripheral<P = impl D7Pin<T>> + 'd,
+        ncs: impl Peripheral<P = impl NCS1Pin<T>> + 'd,
+        dma: impl Peripheral<P = impl XDma<T>> + 'd,
+        config: Config,
+    ) -> Self {
+        Self::new_inner(
+            peri,
+            new_pin!(d0, AfType::output(OutputType::PushPull, Speed::VeryHigh)),
+            new_pin!(d1, AfType::output(OutputType::PushPull, Speed::VeryHigh)),
+            new_pin!(d2, AfType::output(OutputType::PushPull, Speed::VeryHigh)),
+            new_pin!(d3, AfType::output(OutputType::PushPull, Speed::VeryHigh)),
+            new_pin!(d4, AfType::output(OutputType::PushPull, Speed::VeryHigh)),
+            new_pin!(d5, AfType::output(OutputType::PushPull, Speed::VeryHigh)),
+            new_pin!(d6, AfType::output(OutputType::PushPull, Speed::VeryHigh)),
+            new_pin!(d7, AfType::output(OutputType::PushPull, Speed::VeryHigh)),
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            new_pin!(clk, AfType::output(OutputType::PushPull, Speed::VeryHigh)),
+            new_pin!(
+                ncs,
+                AfType::output_pull(OutputType::PushPull, Speed::VeryHigh, Pull::Up)
+            ),
+            None,
+            None,
+            None,
+            new_dma!(dma),
+            config,
+            XspiWidth::OCTO,
+            false,
+        )
+    }
+
+    /// Blocking read with DMA transfer
+    pub fn blocking_read_dma<W: Word>(&mut self, buf: &mut [W], transaction: TransferConfig) -> Result<(), XspiError> {
+        if buf.is_empty() {
+            return Err(XspiError::EmptyBuffer);
+        }
+
+        // Wait for peripheral to be free
+        while T::REGS.xspi_sr().read().busy() {}
+
+        self.configure_command(&transaction, Some(buf.len()))?;
+
+        let current_address = T::REGS.xspi_ar().read().address();
+        let current_instruction = T::REGS.xspi_ir().read().instruction();
+
+        // For a indirect read transaction, the transaction begins when the instruction/address is set
+        T::REGS
+            .xspi_cr()
+            .modify(|v| v.set_fmode(Fmode::from_bits(XspiMode::IndirectRead.into())));
+        if T::REGS.xspi_ccr().read().admode() == XspiCcrAdmode::B_0X0 {
+            T::REGS.xspi_ir().write(|v| v.set_instruction(current_instruction));
+        } else {
+            T::REGS.xspi_ar().write(|v| v.set_address(current_address));
+        }
+
+        let transfer = unsafe {
+            self.dma
+                .as_mut()
+                .unwrap()
+                .read(T::REGS.xspi_dr().as_ptr() as *mut W, buf, Default::default())
+        };
+
+        T::REGS.xspi_cr().modify(|w| w.set_dmaen(Dmaen::B_0X1));
+
+        transfer.blocking_wait();
+
+        finish_dma(T::REGS);
+
+        Ok(())
+    }
+
+    /// Blocking write with DMA transfer
+    pub fn blocking_write_dma<W: Word>(&mut self, buf: &[W], transaction: TransferConfig) -> Result<(), XspiError> {
+        if buf.is_empty() {
+            return Err(XspiError::EmptyBuffer);
+        }
+
+        // Wait for peripheral to be free
+        while T::REGS.xspi_sr().read().busy() {}
+
+        self.configure_command(&transaction, Some(buf.len()))?;
+        T::REGS
+            .xspi_cr()
+            .modify(|v| v.set_fmode(Fmode::from_bits(XspiMode::IndirectWrite.into())));
+
+        let transfer = unsafe {
+            self.dma
+                .as_mut()
+                .unwrap()
+                .write(buf, T::REGS.xspi_dr().as_ptr() as *mut W, Default::default())
+        };
+
+        T::REGS.xspi_cr().modify(|w| w.set_dmaen(Dmaen::B_0X1));
+
+        transfer.blocking_wait();
+
+        finish_dma(T::REGS);
+
+        Ok(())
+    }
+
+    /// Asynchronous read from external device
+    pub async fn read<W: Word>(&mut self, buf: &mut [W], transaction: TransferConfig) -> Result<(), XspiError> {
+        if buf.is_empty() {
+            return Err(XspiError::EmptyBuffer);
+        }
+
+        // Wait for peripheral to be free
+        while T::REGS.xspi_sr().read().busy() {}
+
+        self.configure_command(&transaction, Some(buf.len()))?;
+
+        let current_address = T::REGS.xspi_ar().read().address();
+        let current_instruction = T::REGS.xspi_ir().read().instruction();
+
+        // For a indirect read transaction, the transaction begins when the instruction/address is set
+        T::REGS
+            .xspi_cr()
+            .modify(|v| v.set_fmode(Fmode::from_bits(XspiMode::IndirectRead.into())));
+        if T::REGS.xspi_ccr().read().admode() == XspiCcrAdmode::B_0X0 {
+            T::REGS.xspi_ir().write(|v| v.set_instruction(current_instruction));
+        } else {
+            T::REGS.xspi_ar().write(|v| v.set_address(current_address));
+        }
+
+        let transfer = unsafe {
+            self.dma
+                .as_mut()
+                .unwrap()
+                .read(T::REGS.xspi_dr().as_ptr() as *mut W, buf, Default::default())
+        };
+
+        T::REGS.xspi_cr().modify(|w| w.set_dmaen(Dmaen::B_0X1));
+
+        transfer.await;
+
+        finish_dma(T::REGS);
+
+        Ok(())
+    }
+
+    /// Asynchronous write to external device
+    pub async fn write<W: Word>(&mut self, buf: &[W], transaction: TransferConfig) -> Result<(), XspiError> {
+        if buf.is_empty() {
+            return Err(XspiError::EmptyBuffer);
+        }
+
+        // Wait for peripheral to be free
+        while T::REGS.xspi_sr().read().busy() {}
+
+        self.configure_command(&transaction, Some(buf.len()))?;
+        T::REGS
+            .xspi_cr()
+            .modify(|v| v.set_fmode(Fmode::from_bits(XspiMode::IndirectWrite.into())));
+
+        let transfer = unsafe {
+            self.dma
+                .as_mut()
+                .unwrap()
+                .write(buf, T::REGS.xspi_dr().as_ptr() as *mut W, Default::default())
+        };
+
+        T::REGS.xspi_cr().modify(|w| w.set_dmaen(Dmaen::B_0X1));
+
+        transfer.await;
+
+        finish_dma(T::REGS);
+
+        Ok(())
+    }
+}
+
+impl<'d, T: Instance, M: PeriMode> Drop for Xspi<'d, T, M> {
+    fn drop(&mut self) {
+        self.clk.as_ref().map(|x| x.set_as_disconnected());
+        self.d0.as_ref().map(|x| x.set_as_disconnected());
+        self.d1.as_ref().map(|x| x.set_as_disconnected());
+        self.d2.as_ref().map(|x| x.set_as_disconnected());
+        self.d3.as_ref().map(|x| x.set_as_disconnected());
+        self.d4.as_ref().map(|x| x.set_as_disconnected());
+        self.d5.as_ref().map(|x| x.set_as_disconnected());
+        self.d6.as_ref().map(|x| x.set_as_disconnected());
+        self.d7.as_ref().map(|x| x.set_as_disconnected());
+        self.d8.as_ref().map(|x| x.set_as_disconnected());
+        self.d9.as_ref().map(|x| x.set_as_disconnected());
+        self.d10.as_ref().map(|x| x.set_as_disconnected());
+        self.d11.as_ref().map(|x| x.set_as_disconnected());
+        self.d12.as_ref().map(|x| x.set_as_disconnected());
+        self.d13.as_ref().map(|x| x.set_as_disconnected());
+        self.d14.as_ref().map(|x| x.set_as_disconnected());
+        self.d15.as_ref().map(|x| x.set_as_disconnected());
+        self.ncs1.as_ref().map(|x| x.set_as_disconnected());
+        self.ncs2.as_ref().map(|x| x.set_as_disconnected());
+        self.dqs0.as_ref().map(|x| x.set_as_disconnected());
+        self.dqs1.as_ref().map(|x| x.set_as_disconnected());
+
+        rcc::disable::<T>();
+    }
+}
+
+fn finish_dma(regs: Regs) {
+    while !regs.xspi_sr().read().tcf() {}
+    regs.xspi_fcr().write(|v| v.set_ctcf(true));
+
+    regs.xspi_cr().modify(|w| {
+        w.set_dmaen(Dmaen::B_0X0);
+    });
+}
+
+/// XSPI I/O manager instance trait.
+#[cfg(xspim_v2_1)]
+pub(crate) trait SealedXspimInstance {
+    const SPIM_REGS: Xspim;
+    const SPI_IDX: u8;
+}
+
+/// XSPI instance trait.
+pub(crate) trait SealedInstance {
+    const REGS: Regs;
+}
+
+/// XSPI instance trait.
+#[cfg(xspim_v2_1)]
+#[allow(private_bounds)]
+pub trait Instance: Peripheral<P = Self> + SealedInstance + RccPeripheral + SealedXspimInstance {}
+
+/// XSPI instance trait.
+#[cfg(not(xspim_v2_1))]
+#[allow(private_bounds)]
+pub trait Instance: Peripheral<P = Self> + SealedInstance + RccPeripheral {}
+
+pin_trait!(D0Pin, Instance);
+pin_trait!(D1Pin, Instance);
+pin_trait!(D2Pin, Instance);
+pin_trait!(D3Pin, Instance);
+pin_trait!(D4Pin, Instance);
+pin_trait!(D5Pin, Instance);
+pin_trait!(D6Pin, Instance);
+pin_trait!(D7Pin, Instance);
+pin_trait!(D8Pin, Instance);
+pin_trait!(D9Pin, Instance);
+pin_trait!(D10Pin, Instance);
+pin_trait!(D11Pin, Instance);
+pin_trait!(D12Pin, Instance);
+pin_trait!(D13Pin, Instance);
+pin_trait!(D14Pin, Instance);
+pin_trait!(D15Pin, Instance);
+pin_trait!(DQS0Pin, Instance);
+pin_trait!(DQS1Pin, Instance);
+pin_trait!(NCS1Pin, Instance);
+pin_trait!(NCS2Pin, Instance);
+pin_trait!(CLKPin, Instance);
+pin_trait!(NCLKPin, Instance);
+dma_trait!(XDma, Instance);
+
+// Hard-coded the xspi index, for SPIM
+#[cfg(xspim_v2_1)]
+impl SealedXspimInstance for peripherals::XSPI1 {
+    const SPIM_REGS: Xspim = crate::pac::XSPIM;
+    const SPI_IDX: u8 = 1;
+}
+
+// #[cfg(all(xspim_v2_1, peri_xspi2))]
+#[cfg(xspim_v2_1)]
+impl SealedXspimInstance for peripherals::XSPI2 {
+    const SPIM_REGS: Xspim = crate::pac::XSPIM;
+    const SPI_IDX: u8 = 2;
+}
+
+#[cfg(xspim_v2_1)]
+foreach_peripheral!(
+    (xspi, $inst:ident) => {
+        impl SealedInstance for peripherals::$inst {
+            const REGS: Regs = crate::pac::$inst;
+        }
+
+        impl Instance for peripherals::$inst {}
+    };
+);
+
+#[cfg(not(xspim_v2_1))]
+foreach_peripheral!(
+    (xspi, $inst:ident) => {
+        impl SealedInstance for peripherals::$inst {
+            const REGS: Regs = crate::pac::$inst;
+        }
+
+        impl Instance for peripherals::$inst {}
+    };
+);
+
+impl<'d, T: Instance, M: PeriMode> SetConfig for Xspi<'d, T, M> {
+    type Config = Config;
+    type ConfigError = ();
+    fn set_config(&mut self, config: &Self::Config) -> Result<(), ()> {
+        self.set_config(config);
+        Ok(())
+    }
+}
+
+impl<'d, T: Instance, M: PeriMode> GetConfig for Xspi<'d, T, M> {
+    type Config = Config;
+    fn get_config(&self) -> Self::Config {
+        self.get_config()
+    }
+}
+
+/// Word sizes usable for XSPI.
+#[allow(private_bounds)]
+pub trait Word: word::Word {}
+
+macro_rules! impl_word {
+    ($T:ty) => {
+        impl Word for $T {}
+    };
+}
+
+impl_word!(u8);
+impl_word!(u16);
+impl_word!(u32);

--- a/embassy-stm32/src/xspi/mod.rs
+++ b/embassy-stm32/src/xspi/mod.rs
@@ -8,7 +8,7 @@ pub mod enums;
 use core::marker::PhantomData;
 
 use embassy_embedded_hal::{GetConfig, SetConfig};
-use embassy_hal_internal::{into_ref, PeripheralRef};
+use embassy_hal_internal::PeripheralType;
 pub use enums::*;
 
 use crate::dma::{word, ChannelAndRequest};
@@ -19,7 +19,7 @@ use crate::pac::xspi::Xspi as Regs;
 #[cfg(xspim_v1)]
 use crate::pac::xspim::Xspim;
 use crate::rcc::{self, RccPeripheral};
-use crate::{peripherals, Peripheral};
+use crate::{peripherals, Peri};
 
 /// XPSI driver config.
 #[derive(Clone, Copy)]
@@ -157,28 +157,28 @@ pub enum XspiError {
 
 /// XSPI driver.
 pub struct Xspi<'d, T: Instance, M: PeriMode> {
-    _peri: PeripheralRef<'d, T>,
-    clk: Option<PeripheralRef<'d, AnyPin>>,
-    d0: Option<PeripheralRef<'d, AnyPin>>,
-    d1: Option<PeripheralRef<'d, AnyPin>>,
-    d2: Option<PeripheralRef<'d, AnyPin>>,
-    d3: Option<PeripheralRef<'d, AnyPin>>,
-    d4: Option<PeripheralRef<'d, AnyPin>>,
-    d5: Option<PeripheralRef<'d, AnyPin>>,
-    d6: Option<PeripheralRef<'d, AnyPin>>,
-    d7: Option<PeripheralRef<'d, AnyPin>>,
-    d8: Option<PeripheralRef<'d, AnyPin>>,
-    d9: Option<PeripheralRef<'d, AnyPin>>,
-    d10: Option<PeripheralRef<'d, AnyPin>>,
-    d11: Option<PeripheralRef<'d, AnyPin>>,
-    d12: Option<PeripheralRef<'d, AnyPin>>,
-    d13: Option<PeripheralRef<'d, AnyPin>>,
-    d14: Option<PeripheralRef<'d, AnyPin>>,
-    d15: Option<PeripheralRef<'d, AnyPin>>,
-    ncs1: Option<PeripheralRef<'d, AnyPin>>,
-    ncs2: Option<PeripheralRef<'d, AnyPin>>,
-    dqs0: Option<PeripheralRef<'d, AnyPin>>,
-    dqs1: Option<PeripheralRef<'d, AnyPin>>,
+    _peri: Peri<'d, T>,
+    clk: Option<Peri<'d, AnyPin>>,
+    d0: Option<Peri<'d, AnyPin>>,
+    d1: Option<Peri<'d, AnyPin>>,
+    d2: Option<Peri<'d, AnyPin>>,
+    d3: Option<Peri<'d, AnyPin>>,
+    d4: Option<Peri<'d, AnyPin>>,
+    d5: Option<Peri<'d, AnyPin>>,
+    d6: Option<Peri<'d, AnyPin>>,
+    d7: Option<Peri<'d, AnyPin>>,
+    d8: Option<Peri<'d, AnyPin>>,
+    d9: Option<Peri<'d, AnyPin>>,
+    d10: Option<Peri<'d, AnyPin>>,
+    d11: Option<Peri<'d, AnyPin>>,
+    d12: Option<Peri<'d, AnyPin>>,
+    d13: Option<Peri<'d, AnyPin>>,
+    d14: Option<Peri<'d, AnyPin>>,
+    d15: Option<Peri<'d, AnyPin>>,
+    ncs1: Option<Peri<'d, AnyPin>>,
+    ncs2: Option<Peri<'d, AnyPin>>,
+    dqs0: Option<Peri<'d, AnyPin>>,
+    dqs1: Option<Peri<'d, AnyPin>>,
     dma: Option<ChannelAndRequest<'d>>,
     _phantom: PhantomData<M>,
     config: Config,
@@ -251,35 +251,33 @@ impl<'d, T: Instance, M: PeriMode> Xspi<'d, T, M> {
     }
 
     fn new_inner(
-        peri: impl Peripheral<P = T> + 'd,
-        d0: Option<PeripheralRef<'d, AnyPin>>,
-        d1: Option<PeripheralRef<'d, AnyPin>>,
-        d2: Option<PeripheralRef<'d, AnyPin>>,
-        d3: Option<PeripheralRef<'d, AnyPin>>,
-        d4: Option<PeripheralRef<'d, AnyPin>>,
-        d5: Option<PeripheralRef<'d, AnyPin>>,
-        d6: Option<PeripheralRef<'d, AnyPin>>,
-        d7: Option<PeripheralRef<'d, AnyPin>>,
-        d8: Option<PeripheralRef<'d, AnyPin>>,
-        d9: Option<PeripheralRef<'d, AnyPin>>,
-        d10: Option<PeripheralRef<'d, AnyPin>>,
-        d11: Option<PeripheralRef<'d, AnyPin>>,
-        d12: Option<PeripheralRef<'d, AnyPin>>,
-        d13: Option<PeripheralRef<'d, AnyPin>>,
-        d14: Option<PeripheralRef<'d, AnyPin>>,
-        d15: Option<PeripheralRef<'d, AnyPin>>,
-        clk: Option<PeripheralRef<'d, AnyPin>>,
-        ncs1: Option<PeripheralRef<'d, AnyPin>>,
-        ncs2: Option<PeripheralRef<'d, AnyPin>>,
-        dqs0: Option<PeripheralRef<'d, AnyPin>>,
-        dqs1: Option<PeripheralRef<'d, AnyPin>>,
+        peri: Peri<'d, T>,
+        d0: Option<Peri<'d, AnyPin>>,
+        d1: Option<Peri<'d, AnyPin>>,
+        d2: Option<Peri<'d, AnyPin>>,
+        d3: Option<Peri<'d, AnyPin>>,
+        d4: Option<Peri<'d, AnyPin>>,
+        d5: Option<Peri<'d, AnyPin>>,
+        d6: Option<Peri<'d, AnyPin>>,
+        d7: Option<Peri<'d, AnyPin>>,
+        d8: Option<Peri<'d, AnyPin>>,
+        d9: Option<Peri<'d, AnyPin>>,
+        d10: Option<Peri<'d, AnyPin>>,
+        d11: Option<Peri<'d, AnyPin>>,
+        d12: Option<Peri<'d, AnyPin>>,
+        d13: Option<Peri<'d, AnyPin>>,
+        d14: Option<Peri<'d, AnyPin>>,
+        d15: Option<Peri<'d, AnyPin>>,
+        clk: Option<Peri<'d, AnyPin>>,
+        ncs1: Option<Peri<'d, AnyPin>>,
+        ncs2: Option<Peri<'d, AnyPin>>,
+        dqs0: Option<Peri<'d, AnyPin>>,
+        dqs1: Option<Peri<'d, AnyPin>>,
         dma: Option<ChannelAndRequest<'d>>,
         config: Config,
         width: XspiWidth,
         dual_quad: bool,
     ) -> Self {
-        into_ref!(peri);
-
         #[cfg(xspim_v1)]
         {
             // RCC for xspim should be enabled before writing register
@@ -656,11 +654,11 @@ impl<'d, T: Instance, M: PeriMode> Xspi<'d, T, M> {
 impl<'d, T: Instance> Xspi<'d, T, Blocking> {
     /// Create new blocking XSPI driver for a single spi external chip
     pub fn new_blocking_singlespi(
-        peri: impl Peripheral<P = T> + 'd,
-        clk: impl Peripheral<P = impl CLKPin<T>> + 'd,
-        d0: impl Peripheral<P = impl D0Pin<T>> + 'd,
-        d1: impl Peripheral<P = impl D1Pin<T>> + 'd,
-        ncs: impl Peripheral<P = impl NCS1Pin<T>> + 'd,
+        peri: Peri<'d, T>,
+        clk: Peri<'d, impl CLKPin<T>>,
+        d0: Peri<'d, impl D0Pin<T>>,
+        d1: Peri<'d, impl D1Pin<T>>,
+        ncs: Peri<'d, impl NCS1Pin<T>>,
         config: Config,
     ) -> Self {
         Self::new_inner(
@@ -695,11 +693,11 @@ impl<'d, T: Instance> Xspi<'d, T, Blocking> {
 
     /// Create new blocking XSPI driver for a dualspi external chip
     pub fn new_blocking_dualspi(
-        peri: impl Peripheral<P = T> + 'd,
-        clk: impl Peripheral<P = impl CLKPin<T>> + 'd,
-        d0: impl Peripheral<P = impl D0Pin<T>> + 'd,
-        d1: impl Peripheral<P = impl D1Pin<T>> + 'd,
-        ncs: impl Peripheral<P = impl NCS1Pin<T>> + 'd,
+        peri: Peri<'d, T>,
+        clk: Peri<'d, impl CLKPin<T>>,
+        d0: Peri<'d, impl D0Pin<T>>,
+        d1: Peri<'d, impl D1Pin<T>>,
+        ncs: Peri<'d, impl NCS1Pin<T>>,
         config: Config,
     ) -> Self {
         Self::new_inner(
@@ -737,13 +735,13 @@ impl<'d, T: Instance> Xspi<'d, T, Blocking> {
 
     /// Create new blocking XSPI driver for a quadspi external chip
     pub fn new_blocking_quadspi(
-        peri: impl Peripheral<P = T> + 'd,
-        clk: impl Peripheral<P = impl CLKPin<T>> + 'd,
-        d0: impl Peripheral<P = impl D0Pin<T>> + 'd,
-        d1: impl Peripheral<P = impl D1Pin<T>> + 'd,
-        d2: impl Peripheral<P = impl D2Pin<T>> + 'd,
-        d3: impl Peripheral<P = impl D3Pin<T>> + 'd,
-        ncs: impl Peripheral<P = impl NCS1Pin<T>> + 'd,
+        peri: Peri<'d, T>,
+        clk: Peri<'d, impl CLKPin<T>>,
+        d0: Peri<'d, impl D0Pin<T>>,
+        d1: Peri<'d, impl D1Pin<T>>,
+        d2: Peri<'d, impl D2Pin<T>>,
+        d3: Peri<'d, impl D3Pin<T>>,
+        ncs: Peri<'d, impl NCS1Pin<T>>,
         config: Config,
     ) -> Self {
         Self::new_inner(
@@ -781,17 +779,17 @@ impl<'d, T: Instance> Xspi<'d, T, Blocking> {
 
     /// Create new blocking XSPI driver for two quadspi external chips
     pub fn new_blocking_dualquadspi(
-        peri: impl Peripheral<P = T> + 'd,
-        clk: impl Peripheral<P = impl CLKPin<T>> + 'd,
-        d0: impl Peripheral<P = impl D0Pin<T>> + 'd,
-        d1: impl Peripheral<P = impl D1Pin<T>> + 'd,
-        d2: impl Peripheral<P = impl D2Pin<T>> + 'd,
-        d3: impl Peripheral<P = impl D3Pin<T>> + 'd,
-        d4: impl Peripheral<P = impl D4Pin<T>> + 'd,
-        d5: impl Peripheral<P = impl D5Pin<T>> + 'd,
-        d6: impl Peripheral<P = impl D6Pin<T>> + 'd,
-        d7: impl Peripheral<P = impl D7Pin<T>> + 'd,
-        ncs: impl Peripheral<P = impl NCS1Pin<T>> + 'd,
+        peri: Peri<'d, T>,
+        clk: Peri<'d, impl CLKPin<T>>,
+        d0: Peri<'d, impl D0Pin<T>>,
+        d1: Peri<'d, impl D1Pin<T>>,
+        d2: Peri<'d, impl D2Pin<T>>,
+        d3: Peri<'d, impl D3Pin<T>>,
+        d4: Peri<'d, impl D4Pin<T>>,
+        d5: Peri<'d, impl D5Pin<T>>,
+        d6: Peri<'d, impl D6Pin<T>>,
+        d7: Peri<'d, impl D7Pin<T>>,
+        ncs: Peri<'d, impl NCS1Pin<T>>,
         config: Config,
     ) -> Self {
         Self::new_inner(
@@ -829,17 +827,17 @@ impl<'d, T: Instance> Xspi<'d, T, Blocking> {
 
     /// Create new blocking XSPI driver for xspi external chips
     pub fn new_blocking_xspi(
-        peri: impl Peripheral<P = T> + 'd,
-        clk: impl Peripheral<P = impl CLKPin<T>> + 'd,
-        d0: impl Peripheral<P = impl D0Pin<T>> + 'd,
-        d1: impl Peripheral<P = impl D1Pin<T>> + 'd,
-        d2: impl Peripheral<P = impl D2Pin<T>> + 'd,
-        d3: impl Peripheral<P = impl D3Pin<T>> + 'd,
-        d4: impl Peripheral<P = impl D4Pin<T>> + 'd,
-        d5: impl Peripheral<P = impl D5Pin<T>> + 'd,
-        d6: impl Peripheral<P = impl D6Pin<T>> + 'd,
-        d7: impl Peripheral<P = impl D7Pin<T>> + 'd,
-        ncs: impl Peripheral<P = impl NCS1Pin<T>> + 'd,
+        peri: Peri<'d, T>,
+        clk: Peri<'d, impl CLKPin<T>>,
+        d0: Peri<'d, impl D0Pin<T>>,
+        d1: Peri<'d, impl D1Pin<T>>,
+        d2: Peri<'d, impl D2Pin<T>>,
+        d3: Peri<'d, impl D3Pin<T>>,
+        d4: Peri<'d, impl D4Pin<T>>,
+        d5: Peri<'d, impl D5Pin<T>>,
+        d6: Peri<'d, impl D6Pin<T>>,
+        d7: Peri<'d, impl D7Pin<T>>,
+        ncs: Peri<'d, impl NCS1Pin<T>>,
         config: Config,
     ) -> Self {
         Self::new_inner(
@@ -879,12 +877,12 @@ impl<'d, T: Instance> Xspi<'d, T, Blocking> {
 impl<'d, T: Instance> Xspi<'d, T, Async> {
     /// Create new blocking XSPI driver for a single spi external chip
     pub fn new_singlespi(
-        peri: impl Peripheral<P = T> + 'd,
-        clk: impl Peripheral<P = impl CLKPin<T>> + 'd,
-        d0: impl Peripheral<P = impl D0Pin<T>> + 'd,
-        d1: impl Peripheral<P = impl D1Pin<T>> + 'd,
-        ncs: impl Peripheral<P = impl NCS1Pin<T>> + 'd,
-        dma: impl Peripheral<P = impl XDma<T>> + 'd,
+        peri: Peri<'d, T>,
+        clk: Peri<'d, impl CLKPin<T>>,
+        d0: Peri<'d, impl D0Pin<T>>,
+        d1: Peri<'d, impl D1Pin<T>>,
+        ncs: Peri<'d, impl NCS1Pin<T>>,
+        dma: Peri<'d, impl XDma<T>>,
         config: Config,
     ) -> Self {
         Self::new_inner(
@@ -919,12 +917,12 @@ impl<'d, T: Instance> Xspi<'d, T, Async> {
 
     /// Create new blocking XSPI driver for a dualspi external chip
     pub fn new_dualspi(
-        peri: impl Peripheral<P = T> + 'd,
-        clk: impl Peripheral<P = impl CLKPin<T>> + 'd,
-        d0: impl Peripheral<P = impl D0Pin<T>> + 'd,
-        d1: impl Peripheral<P = impl D1Pin<T>> + 'd,
-        ncs: impl Peripheral<P = impl NCS1Pin<T>> + 'd,
-        dma: impl Peripheral<P = impl XDma<T>> + 'd,
+        peri: Peri<'d, T>,
+        clk: Peri<'d, impl CLKPin<T>>,
+        d0: Peri<'d, impl D0Pin<T>>,
+        d1: Peri<'d, impl D1Pin<T>>,
+        ncs: Peri<'d, impl NCS1Pin<T>>,
+        dma: Peri<'d, impl XDma<T>>,
         config: Config,
     ) -> Self {
         Self::new_inner(
@@ -962,14 +960,14 @@ impl<'d, T: Instance> Xspi<'d, T, Async> {
 
     /// Create new blocking XSPI driver for a quadspi external chip
     pub fn new_quadspi(
-        peri: impl Peripheral<P = T> + 'd,
-        clk: impl Peripheral<P = impl CLKPin<T>> + 'd,
-        d0: impl Peripheral<P = impl D0Pin<T>> + 'd,
-        d1: impl Peripheral<P = impl D1Pin<T>> + 'd,
-        d2: impl Peripheral<P = impl D2Pin<T>> + 'd,
-        d3: impl Peripheral<P = impl D3Pin<T>> + 'd,
-        ncs: impl Peripheral<P = impl NCS1Pin<T>> + 'd,
-        dma: impl Peripheral<P = impl XDma<T>> + 'd,
+        peri: Peri<'d, T>,
+        clk: Peri<'d, impl CLKPin<T>>,
+        d0: Peri<'d, impl D0Pin<T>>,
+        d1: Peri<'d, impl D1Pin<T>>,
+        d2: Peri<'d, impl D2Pin<T>>,
+        d3: Peri<'d, impl D3Pin<T>>,
+        ncs: Peri<'d, impl NCS1Pin<T>>,
+        dma: Peri<'d, impl XDma<T>>,
         config: Config,
     ) -> Self {
         Self::new_inner(
@@ -1007,18 +1005,18 @@ impl<'d, T: Instance> Xspi<'d, T, Async> {
 
     /// Create new blocking XSPI driver for two quadspi external chips
     pub fn new_dualquadspi(
-        peri: impl Peripheral<P = T> + 'd,
-        clk: impl Peripheral<P = impl CLKPin<T>> + 'd,
-        d0: impl Peripheral<P = impl D0Pin<T>> + 'd,
-        d1: impl Peripheral<P = impl D1Pin<T>> + 'd,
-        d2: impl Peripheral<P = impl D2Pin<T>> + 'd,
-        d3: impl Peripheral<P = impl D3Pin<T>> + 'd,
-        d4: impl Peripheral<P = impl D4Pin<T>> + 'd,
-        d5: impl Peripheral<P = impl D5Pin<T>> + 'd,
-        d6: impl Peripheral<P = impl D6Pin<T>> + 'd,
-        d7: impl Peripheral<P = impl D7Pin<T>> + 'd,
-        ncs: impl Peripheral<P = impl NCS1Pin<T>> + 'd,
-        dma: impl Peripheral<P = impl XDma<T>> + 'd,
+        peri: Peri<'d, T>,
+        clk: Peri<'d, impl CLKPin<T>>,
+        d0: Peri<'d, impl D0Pin<T>>,
+        d1: Peri<'d, impl D1Pin<T>>,
+        d2: Peri<'d, impl D2Pin<T>>,
+        d3: Peri<'d, impl D3Pin<T>>,
+        d4: Peri<'d, impl D4Pin<T>>,
+        d5: Peri<'d, impl D5Pin<T>>,
+        d6: Peri<'d, impl D6Pin<T>>,
+        d7: Peri<'d, impl D7Pin<T>>,
+        ncs: Peri<'d, impl NCS1Pin<T>>,
+        dma: Peri<'d, impl XDma<T>>,
         config: Config,
     ) -> Self {
         Self::new_inner(
@@ -1056,18 +1054,18 @@ impl<'d, T: Instance> Xspi<'d, T, Async> {
 
     /// Create new blocking XSPI driver for xspi external chips
     pub fn new_xspi(
-        peri: impl Peripheral<P = T> + 'd,
-        clk: impl Peripheral<P = impl CLKPin<T>> + 'd,
-        d0: impl Peripheral<P = impl D0Pin<T>> + 'd,
-        d1: impl Peripheral<P = impl D1Pin<T>> + 'd,
-        d2: impl Peripheral<P = impl D2Pin<T>> + 'd,
-        d3: impl Peripheral<P = impl D3Pin<T>> + 'd,
-        d4: impl Peripheral<P = impl D4Pin<T>> + 'd,
-        d5: impl Peripheral<P = impl D5Pin<T>> + 'd,
-        d6: impl Peripheral<P = impl D6Pin<T>> + 'd,
-        d7: impl Peripheral<P = impl D7Pin<T>> + 'd,
-        ncs: impl Peripheral<P = impl NCS1Pin<T>> + 'd,
-        dma: impl Peripheral<P = impl XDma<T>> + 'd,
+        peri: Peri<'d, T>,
+        clk: Peri<'d, impl CLKPin<T>>,
+        d0: Peri<'d, impl D0Pin<T>>,
+        d1: Peri<'d, impl D1Pin<T>>,
+        d2: Peri<'d, impl D2Pin<T>>,
+        d3: Peri<'d, impl D3Pin<T>>,
+        d4: Peri<'d, impl D4Pin<T>>,
+        d5: Peri<'d, impl D5Pin<T>>,
+        d6: Peri<'d, impl D6Pin<T>>,
+        d7: Peri<'d, impl D7Pin<T>>,
+        ncs: Peri<'d, impl NCS1Pin<T>>,
+        dma: Peri<'d, impl XDma<T>>,
         config: Config,
     ) -> Self {
         Self::new_inner(
@@ -1296,12 +1294,12 @@ pub(crate) trait SealedInstance {
 /// XSPI instance trait.
 #[cfg(xspim_v1)]
 #[allow(private_bounds)]
-pub trait Instance: Peripheral<P = Self> + SealedInstance + RccPeripheral + SealedXspimInstance {}
+pub trait Instance: SealedInstance + PeripheralType + RccPeripheral + SealedXspimInstance {}
 
 /// XSPI instance trait.
 #[cfg(not(xspim_v1))]
 #[allow(private_bounds)]
-pub trait Instance: Peripheral<P = Self> + SealedInstance + RccPeripheral {}
+pub trait Instance: SealedInstance + PeripheralType + RccPeripheral {}
 
 pin_trait!(D0Pin, Instance);
 pin_trait!(D1Pin, Instance);

--- a/examples/stm32h7rs/src/bin/xspi_memory_mapped.rs
+++ b/examples/stm32h7rs/src/bin/xspi_memory_mapped.rs
@@ -1,0 +1,448 @@
+#![no_main]
+#![no_std]
+
+//! For Nucleo STM32H7S3L8 MB1737, has MX25UW25645GXDI00
+//!
+//! TODO: Currently this only uses single SPI, pending flash chip documentation for octo SPI.
+
+use defmt::info;
+use embassy_executor::Spawner;
+use embassy_stm32::gpio::{Level, Output, Speed};
+use embassy_stm32::mode::Blocking;
+use embassy_stm32::time::Hertz;
+use embassy_stm32::xspi::{
+    AddressSize, ChipSelectHighTime, DummyCycles, FIFOThresholdLevel, Instance, MemorySize, MemoryType, TransferConfig,
+    WrapSize, Xspi, XspiWidth,
+};
+use embassy_stm32::Config;
+use embassy_time::Timer;
+use {defmt_rtt as _, panic_probe as _};
+
+#[embassy_executor::main]
+async fn main(_spawner: Spawner) {
+    // RCC config
+    let mut config = Config::default();
+    {
+        use embassy_stm32::rcc::*;
+        config.rcc.hse = Some(Hse {
+            freq: Hertz(24_000_000),
+            mode: HseMode::Oscillator,
+        });
+        config.rcc.pll1 = Some(Pll {
+            source: PllSource::HSE,
+            prediv: PllPreDiv::DIV3,
+            mul: PllMul::MUL150,
+            divp: Some(PllDiv::DIV2),
+            divq: None,
+            divr: None,
+        });
+        config.rcc.sys = Sysclk::PLL1_P; // 600 Mhz
+        config.rcc.ahb_pre = AHBPrescaler::DIV2; // 300 Mhz
+        config.rcc.apb1_pre = APBPrescaler::DIV2; // 150 Mhz
+        config.rcc.apb2_pre = APBPrescaler::DIV2; // 150 Mhz
+        config.rcc.apb4_pre = APBPrescaler::DIV2; // 150 Mhz
+        config.rcc.apb5_pre = APBPrescaler::DIV2; // 150 Mhz
+        config.rcc.voltage_scale = VoltageScale::HIGH;
+    }
+
+    // Initialize peripherals
+    let p = embassy_stm32::init(config);
+
+    let spi_config = embassy_stm32::xspi::Config {
+        fifo_threshold: FIFOThresholdLevel::_4Bytes,
+        memory_type: MemoryType::Macronix,
+        delay_hold_quarter_cycle: true,
+        // memory_type: MemoryType::Micron,
+        // delay_hold_quarter_cycle: false,
+        device_size: MemorySize::_32MiB,
+        chip_select_high_time: ChipSelectHighTime::_2Cycle,
+        free_running_clock: false,
+        clock_mode: false,
+        wrap_size: WrapSize::None,
+        // 300mhz / (4+1) = 60mhz. Unsure the limit, need to find a MX25UW25645GXDI00 datasheet.
+        clock_prescaler: 3,
+        sample_shifting: false,
+        chip_select_boundary: 0,
+        max_transfer: 0,
+        refresh: 0,
+    };
+
+    let mut cor = cortex_m::Peripherals::take().unwrap();
+
+    // Not necessary, but recommended if using XIP
+    cor.SCB.enable_icache();
+    cor.SCB.enable_dcache(&mut cor.CPUID);
+
+    let xspi = embassy_stm32::xspi::Xspi::new_blocking_xspi(
+        p.XSPI2, p.PN6, p.PN2, p.PN3, p.PN4, p.PN5, p.PN8, p.PN9, p.PN10, p.PN11, p.PN1, spi_config,
+    );
+
+    let mut flash = FlashMemory::new(xspi).await;
+
+    let flash_id = flash.read_id();
+    info!("FLASH ID: {=[u8]:x}", flash_id);
+
+    let mut wr_buf = [0u8; 8];
+    for i in 0..8 {
+        wr_buf[i] = 0x90 + i as u8;
+    }
+    let mut rd_buf = [0u8; 8];
+    flash.erase_sector(0).await;
+    flash.write_memory(0, &wr_buf, true).await;
+    flash.read_memory(0, &mut rd_buf, true);
+    info!("WRITE BUF: {=[u8]:#X}", wr_buf);
+    info!("READ BUF: {=[u8]:#X}", rd_buf);
+    flash.enable_mm().await;
+    info!("Enabled memory mapped mode");
+
+    let first_u32 = unsafe { *(0x70000000 as *const u32) };
+    assert_eq!(first_u32, 0x93929190);
+    info!("first_u32 {:08x}", first_u32);
+
+    let second_u32 = unsafe { *(0x70000004 as *const u32) };
+    assert_eq!(second_u32, 0x97969594);
+    info!("second_u32 {:08x}", first_u32);
+
+    flash.disable_mm().await;
+    info!("Disabled memory mapped mode");
+
+    info!("DONE");
+    // Output pin PE3
+    let mut led = Output::new(p.PE3, Level::Low, Speed::Low);
+
+    loop {
+        led.toggle();
+        Timer::after_millis(1000).await;
+    }
+}
+
+const MEMORY_PAGE_SIZE: usize = 8;
+
+const CMD_READ: u8 = 0x0B;
+const _CMD_QUAD_READ: u8 = 0x6B;
+
+const CMD_WRITE_PG: u8 = 0x02;
+const _CMD_QUAD_WRITE_PG: u8 = 0x32;
+
+const CMD_READ_ID: u8 = 0x9F;
+const CMD_READ_ID_OCTO: u16 = 0x9F60;
+
+const CMD_ENABLE_RESET: u8 = 0x66;
+const CMD_RESET: u8 = 0x99;
+
+const CMD_WRITE_ENABLE: u8 = 0x06;
+
+const CMD_CHIP_ERASE: u8 = 0xC7;
+const CMD_SECTOR_ERASE: u8 = 0x20;
+const CMD_BLOCK_ERASE_32K: u8 = 0x52;
+const CMD_BLOCK_ERASE_64K: u8 = 0xD8;
+
+const CMD_READ_SR: u8 = 0x05;
+const CMD_READ_CR: u8 = 0x35;
+
+const CMD_WRITE_SR: u8 = 0x01;
+const CMD_WRITE_CR: u8 = 0x31;
+
+/// Implementation of access to flash chip.
+///
+/// Chip commands are hardcoded as it depends on used chip.
+/// This targets a MX25UW25645GXDI00.
+pub struct FlashMemory<I: Instance> {
+    xspi: Xspi<'static, I, Blocking>,
+}
+
+impl<I: Instance> FlashMemory<I> {
+    pub async fn new(xspi: Xspi<'static, I, Blocking>) -> Self {
+        let mut memory = Self { xspi };
+
+        memory.reset_memory().await;
+        memory.enable_octo();
+        memory
+    }
+
+    async fn qpi_mode(&mut self) {
+        // Enter qpi mode
+        self.exec_command(0x38).await;
+
+        // Set read param
+        let transaction = TransferConfig {
+            iwidth: XspiWidth::QUAD,
+            dwidth: XspiWidth::QUAD,
+            instruction: Some(0xC0),
+            ..Default::default()
+        };
+        self.enable_write().await;
+        self.xspi.blocking_write(&[0x30_u8], transaction).unwrap();
+        self.wait_write_finish();
+    }
+
+    pub async fn disable_mm(&mut self) {
+        self.xspi.disable_memory_mapped_mode();
+    }
+
+    pub async fn enable_mm(&mut self) {
+        self.qpi_mode().await;
+
+        let read_config = TransferConfig {
+            iwidth: XspiWidth::SING,
+            isize: AddressSize::_8bit,
+            adwidth: XspiWidth::SING,
+            adsize: AddressSize::_24bit,
+            dwidth: XspiWidth::SING,
+            instruction: Some(CMD_READ as u32),
+            dummy: DummyCycles::_8,
+            ..Default::default()
+        };
+
+        let write_config = TransferConfig {
+            iwidth: XspiWidth::SING,
+            isize: AddressSize::_8bit,
+            adwidth: XspiWidth::SING,
+            adsize: AddressSize::_24bit,
+            dwidth: XspiWidth::SING,
+            instruction: Some(CMD_WRITE_PG as u32),
+            dummy: DummyCycles::_0,
+            ..Default::default()
+        };
+        self.xspi.enable_memory_mapped_mode(read_config, write_config).unwrap();
+    }
+
+    fn enable_octo(&mut self) {
+        let cr = self.read_cr();
+        // info!("Read cr: {:x}", cr);
+        self.write_cr(cr | 0x02);
+        // info!("Read cr after writing: {:x}", cr);
+    }
+
+    pub fn disable_octo(&mut self) {
+        let cr = self.read_cr();
+        self.write_cr(cr & (!(0x02)));
+    }
+
+    async fn exec_command_4(&mut self, cmd: u8) {
+        let transaction = TransferConfig {
+            iwidth: XspiWidth::QUAD,
+            adwidth: XspiWidth::NONE,
+            // adsize: AddressSize::_24bit,
+            dwidth: XspiWidth::NONE,
+            instruction: Some(cmd as u32),
+            address: None,
+            dummy: DummyCycles::_0,
+            ..Default::default()
+        };
+        self.xspi.blocking_command(&transaction).unwrap();
+    }
+
+    async fn exec_command(&mut self, cmd: u8) {
+        let transaction = TransferConfig {
+            iwidth: XspiWidth::SING,
+            adwidth: XspiWidth::NONE,
+            // adsize: AddressSize::_24bit,
+            dwidth: XspiWidth::NONE,
+            instruction: Some(cmd as u32),
+            address: None,
+            dummy: DummyCycles::_0,
+            ..Default::default()
+        };
+        // info!("Excuting command: {:x}", transaction.instruction);
+        self.xspi.blocking_command(&transaction).unwrap();
+    }
+
+    pub async fn reset_memory(&mut self) {
+        self.exec_command_4(CMD_ENABLE_RESET).await;
+        self.exec_command_4(CMD_RESET).await;
+        self.exec_command(CMD_ENABLE_RESET).await;
+        self.exec_command(CMD_RESET).await;
+        self.wait_write_finish();
+    }
+
+    pub async fn enable_write(&mut self) {
+        self.exec_command(CMD_WRITE_ENABLE).await;
+    }
+
+    pub fn read_id(&mut self) -> [u8; 3] {
+        let mut buffer = [0; 3];
+        let transaction: TransferConfig = TransferConfig {
+            iwidth: XspiWidth::SING,
+            isize: AddressSize::_8bit,
+            adwidth: XspiWidth::NONE,
+            // adsize: AddressSize::_24bit,
+            dwidth: XspiWidth::SING,
+            instruction: Some(CMD_READ_ID as u32),
+            ..Default::default()
+        };
+        // info!("Reading id: 0x{:X}", transaction.instruction);
+        self.xspi.blocking_read(&mut buffer, transaction).unwrap();
+        buffer
+    }
+
+    pub fn read_id_8(&mut self) -> [u8; 3] {
+        let mut buffer = [0; 3];
+        let transaction: TransferConfig = TransferConfig {
+            iwidth: XspiWidth::OCTO,
+            isize: AddressSize::_16bit,
+            adwidth: XspiWidth::OCTO,
+            address: Some(0),
+            adsize: AddressSize::_32bit,
+            dwidth: XspiWidth::OCTO,
+            instruction: Some(CMD_READ_ID_OCTO as u32),
+            dummy: DummyCycles::_4,
+            ..Default::default()
+        };
+        info!("Reading id: {:#X}", transaction.instruction);
+        self.xspi.blocking_read(&mut buffer, transaction).unwrap();
+        buffer
+    }
+
+    pub fn read_memory(&mut self, addr: u32, buffer: &mut [u8], use_dma: bool) {
+        let transaction = TransferConfig {
+            iwidth: XspiWidth::SING,
+            adwidth: XspiWidth::SING,
+            adsize: AddressSize::_24bit,
+            dwidth: XspiWidth::SING,
+            instruction: Some(CMD_READ as u32),
+            dummy: DummyCycles::_8,
+            // dwidth: XspiWidth::QUAD,
+            // instruction: Some(CMD_QUAD_READ as u32),
+            // dummy: DummyCycles::_8,
+            address: Some(addr),
+            ..Default::default()
+        };
+        if use_dma {
+            self.xspi.blocking_read(buffer, transaction).unwrap();
+        } else {
+            self.xspi.blocking_read(buffer, transaction).unwrap();
+        }
+    }
+
+    fn wait_write_finish(&mut self) {
+        while (self.read_sr() & 0x01) != 0 {}
+    }
+
+    async fn perform_erase(&mut self, addr: u32, cmd: u8) {
+        let transaction = TransferConfig {
+            iwidth: XspiWidth::SING,
+            adwidth: XspiWidth::SING,
+            adsize: AddressSize::_24bit,
+            dwidth: XspiWidth::NONE,
+            instruction: Some(cmd as u32),
+            address: Some(addr),
+            dummy: DummyCycles::_0,
+            ..Default::default()
+        };
+        self.enable_write().await;
+        self.xspi.blocking_command(&transaction).unwrap();
+        self.wait_write_finish();
+    }
+
+    pub async fn erase_sector(&mut self, addr: u32) {
+        self.perform_erase(addr, CMD_SECTOR_ERASE).await;
+    }
+
+    pub async fn erase_block_32k(&mut self, addr: u32) {
+        self.perform_erase(addr, CMD_BLOCK_ERASE_32K).await;
+    }
+
+    pub async fn erase_block_64k(&mut self, addr: u32) {
+        self.perform_erase(addr, CMD_BLOCK_ERASE_64K).await;
+    }
+
+    pub async fn erase_chip(&mut self) {
+        self.exec_command(CMD_CHIP_ERASE).await;
+    }
+
+    async fn write_page(&mut self, addr: u32, buffer: &[u8], len: usize, use_dma: bool) {
+        assert!(
+            (len as u32 + (addr & 0x000000ff)) <= MEMORY_PAGE_SIZE as u32,
+            "write_page(): page write length exceeds page boundary (len = {}, addr = {:X}",
+            len,
+            addr
+        );
+
+        let transaction = TransferConfig {
+            iwidth: XspiWidth::SING,
+            adsize: AddressSize::_24bit,
+            adwidth: XspiWidth::SING,
+            dwidth: XspiWidth::SING,
+            instruction: Some(CMD_WRITE_PG as u32),
+            // dwidth: XspiWidth::QUAD,
+            // instruction: Some(CMD_QUAD_WRITE_PG as u32),
+            address: Some(addr),
+            dummy: DummyCycles::_0,
+            ..Default::default()
+        };
+        self.enable_write().await;
+        if use_dma {
+            self.xspi.blocking_write(buffer, transaction).unwrap();
+        } else {
+            self.xspi.blocking_write(buffer, transaction).unwrap();
+        }
+        self.wait_write_finish();
+    }
+
+    pub async fn write_memory(&mut self, addr: u32, buffer: &[u8], use_dma: bool) {
+        let mut left = buffer.len();
+        let mut place = addr;
+        let mut chunk_start = 0;
+
+        while left > 0 {
+            let max_chunk_size = MEMORY_PAGE_SIZE - (place & 0x000000ff) as usize;
+            let chunk_size = if left >= max_chunk_size { max_chunk_size } else { left };
+            let chunk = &buffer[chunk_start..(chunk_start + chunk_size)];
+            self.write_page(place, chunk, chunk_size, use_dma).await;
+            place += chunk_size as u32;
+            left -= chunk_size;
+            chunk_start += chunk_size;
+        }
+    }
+
+    fn read_register(&mut self, cmd: u8) -> u8 {
+        let mut buffer = [0; 1];
+        let transaction: TransferConfig = TransferConfig {
+            iwidth: XspiWidth::SING,
+            isize: AddressSize::_8bit,
+            adwidth: XspiWidth::NONE,
+            adsize: AddressSize::_24bit,
+            dwidth: XspiWidth::SING,
+            instruction: Some(cmd as u32),
+            address: None,
+            dummy: DummyCycles::_0,
+            ..Default::default()
+        };
+        self.xspi.blocking_read(&mut buffer, transaction).unwrap();
+        // info!("Read w25q64 register: 0x{:x}", buffer[0]);
+        buffer[0]
+    }
+
+    fn write_register(&mut self, cmd: u8, value: u8) {
+        let buffer = [value; 1];
+        let transaction: TransferConfig = TransferConfig {
+            iwidth: XspiWidth::SING,
+            isize: AddressSize::_8bit,
+            instruction: Some(cmd as u32),
+            adsize: AddressSize::_24bit,
+            adwidth: XspiWidth::NONE,
+            dwidth: XspiWidth::SING,
+            address: None,
+            dummy: DummyCycles::_0,
+            ..Default::default()
+        };
+        self.xspi.blocking_write(&buffer, transaction).unwrap();
+    }
+
+    pub fn read_sr(&mut self) -> u8 {
+        self.read_register(CMD_READ_SR)
+    }
+
+    pub fn read_cr(&mut self) -> u8 {
+        self.read_register(CMD_READ_CR)
+    }
+
+    pub fn write_sr(&mut self, value: u8) {
+        self.write_register(CMD_WRITE_SR, value);
+    }
+
+    pub fn write_cr(&mut self, value: u8) {
+        self.write_register(CMD_WRITE_CR, value);
+    }
+}


### PR DESCRIPTION
This is based on an initial patch by @rickrogers-ionq . It works fine in single SPI mode in my (fairly brief) amount of testing, I haven't got octospi working yet (waiting for a datasheet for the flash part on the nucleo board).

I'm not sure if there's a better way to handle the NCS1/NCS2 switching in https://github.com/embassy-rs/embassy/commit/f094e34efd6c7d083937b11d388270325e4cc00c . When using a single chip, either NCS1 or NCS2 Pin can be provided, with CSSEL register set to the one being used. In future someone could add another interface to allow switching on the fly between two chips (the unused `ncs_alt`).