### PR TITLE
executor: add executor selection to #[embassy_executor::main]

### DIFF
--- a/embassy-executor-macros/src/lib.rs
+++ b/embassy-executor-macros/src/lib.rs
@@ -173,3 +173,27 @@ pub fn main_std(args: TokenStream, item: TokenStream) -> TokenStream {
 pub fn main_wasm(args: TokenStream, item: TokenStream) -> TokenStream {
     main::run(args.into(), item.into(), &main::ARCH_WASM).into()
 }
+
+/// Creates a new `executor` instance and declares an application entry point for an unspecified architecture, spawning the corresponding function body as an async task.
+///
+/// The following restrictions apply:
+///
+/// * The function must accept exactly 1 parameter, an `embassy_executor::Spawner` handle that it can use to spawn additional tasks.
+/// * The function must be declared `async`.
+/// * The function must not use generics.
+/// * Only a single `main` task may be declared.
+///
+/// A user-defined entry macro and executor type must be provided via the `entry` and `executor` arguments of the `main` macro.
+///
+/// ## Examples
+/// Spawning a task:
+/// ``` rust
+/// #[embassy_executor::main(entry = "your_hal::entry", executor = "your_hal::Executor")]
+/// async fn main(_s: embassy_executor::Spawner) {
+///     // Function body
+/// }
+/// ```
+#[proc_macro_attribute]
+pub fn main_unspecified(args: TokenStream, item: TokenStream) -> TokenStream {
+    main::run(args.into(), item.into(), &main::ARCH_UNSPECIFIED).into()
+}

--- a/embassy-executor-macros/src/macros/main.rs
+++ b/embassy-executor-macros/src/macros/main.rs
@@ -16,42 +16,57 @@ enum Flavor {
 pub(crate) struct Arch {
     default_entry: Option<&'static str>,
     flavor: Flavor,
+    executor_required: bool,
 }
 
 pub static ARCH_AVR: Arch = Arch {
     default_entry: Some("avr_device::entry"),
     flavor: Flavor::Standard,
+    executor_required: false,
 };
 
 pub static ARCH_RISCV: Arch = Arch {
     default_entry: Some("riscv_rt::entry"),
     flavor: Flavor::Standard,
+    executor_required: false,
 };
 
 pub static ARCH_CORTEX_M: Arch = Arch {
     default_entry: Some("cortex_m_rt::entry"),
     flavor: Flavor::Standard,
+    executor_required: false,
 };
 
 pub static ARCH_SPIN: Arch = Arch {
     default_entry: None,
     flavor: Flavor::Standard,
+    executor_required: false,
 };
 
 pub static ARCH_STD: Arch = Arch {
     default_entry: None,
     flavor: Flavor::Standard,
+    executor_required: false,
 };
 
 pub static ARCH_WASM: Arch = Arch {
     default_entry: Some("wasm_bindgen::prelude::wasm_bindgen(start)"),
     flavor: Flavor::Wasm,
+    executor_required: false,
+};
+
+pub static ARCH_UNSPECIFIED: Arch = Arch {
+    default_entry: None,
+    flavor: Flavor::Standard,
+    executor_required: true,
 };
 
 #[derive(Debug, FromMeta, Default)]
 struct Args {
     #[darling(default)]
     entry: Option<String>,
+    #[darling(default)]
+    executor: Option<String>,
 }
 
 pub fn run(args: TokenStream, item: TokenStream, arch: &Arch) -> TokenStream {
@@ -112,9 +127,10 @@ pub fn run(args: TokenStream, item: TokenStream, arch: &Arch) -> TokenStream {
         error(&mut errors, &f.sig, "main function must have 1 argument: the spawner.");
     }
 
-    let entry = match args.entry.as_deref().or(arch.default_entry) {
-        None => TokenStream::new(),
-        Some(x) => match TokenStream::from_str(x) {
+    let entry = match (args.entry.as_deref(), arch.default_entry.as_deref()) {
+        (None, None) => TokenStream::new(),
+        (Some(x), _) | (None, Some(x)) if x == "" => TokenStream::new(),
+        (Some(x), _) | (None, Some(x)) => match TokenStream::from_str(x) {
             Ok(x) => quote!(#[#x]),
             Err(e) => {
                 error(&mut errors, &f.sig, e);
@@ -122,6 +138,28 @@ pub fn run(args: TokenStream, item: TokenStream, arch: &Arch) -> TokenStream {
             }
         },
     };
+
+    let executor = match (args.executor.as_deref(), arch.executor_required) {
+        (None, true) => {
+            error(
+                &mut errors,
+                &f.sig,
+                "\
+No architecture selected for embassy-executor. Make sure you've enabled one of the `arch-*` features in your Cargo.toml.
+
+Alternatively, if you would like to use a custom executor implementation, specify it with the `executor` argument.
+For example: `#[embassy_executor::main(entry = ..., executor = \"some_crate::Executor\")]",
+            );
+            ""
+        }
+        (Some(x), _) => x,
+        (None, _) => "::embassy_executor::Executor",
+    };
+
+    let executor = TokenStream::from_str(executor).unwrap_or_else(|e| {
+        error(&mut errors, &f.sig, e);
+        TokenStream::new()
+    });
 
     let f_body = f.body;
     let out = &f.sig.output;
@@ -134,7 +172,7 @@ pub fn run(args: TokenStream, item: TokenStream, arch: &Arch) -> TokenStream {
                     ::core::mem::transmute(t)
                 }
 
-                let mut executor = ::embassy_executor::Executor::new();
+                let mut executor = #executor::new();
                 let executor = unsafe { __make_static(&mut executor) };
                 executor.run(|spawner| {
                     spawner.must_spawn(__embassy_main(spawner));
@@ -144,7 +182,7 @@ pub fn run(args: TokenStream, item: TokenStream, arch: &Arch) -> TokenStream {
         Flavor::Wasm => (
             quote!(Result<(), wasm_bindgen::JsValue>),
             quote! {
-                let executor = ::std::boxed::Box::leak(::std::boxed::Box::new(::embassy_executor::Executor::new()));
+                let executor = ::std::boxed::Box::leak(::std::boxed::Box::new(#executor::new()));
 
                 executor.start(|spawner| {
                     spawner.must_spawn(__embassy_main(spawner));

--- a/embassy-executor/src/lib.rs
+++ b/embassy-executor/src/lib.rs
@@ -44,6 +44,8 @@ mod arch;
 #[cfg(feature = "_arch")]
 #[allow(unused_imports)] // don't warn if the module is empty.
 pub use arch::*;
+#[cfg(not(feature = "_arch"))]
+pub use embassy_executor_macros::main_unspecified as main;
 
 pub mod raw;
 


### PR DESCRIPTION
I ended up making a custom executor for the wch ch58x HAL. (ref https://github.com/embassy-rs/embassy/issues/4030)

When an architecture isn't selected, the embassy_executor::main macro is currently undefined, requiring the user or the HAL to define their own main function. While that is acceptable, I'd like to propose the ability to specify an executor in the macro.

Currently this PR does the bare minimum to allow an executor to be specified, but does not re-export the macro through embassy-executor as I'm not sure what the best way to handle architecture here is. I'm hoping someone can weigh in with a good direction to take this, or reject it outright before I give it too much time. Thanks!