### PR TITLE
embassy-time: don't select `critical-section` impl for std

### DIFF
--- a/embassy-time/Cargo.toml
+++ b/embassy-time/Cargo.toml
@@ -45,7 +45,7 @@ defmt-timestamp-uptime-tus = ["defmt"]
 ## Create a `MockDriver` that can be manually advanced for testing purposes.
 mock-driver = ["tick-hz-1_000_000", "dep:embassy-time-queue-utils"]
 ## Create a time driver for `std` environments.
-std = ["tick-hz-1_000_000", "critical-section/std", "dep:embassy-time-queue-utils"]
+std = ["tick-hz-1_000_000", "dep:embassy-time-queue-utils"]
 ## Create a time driver for WASM.
 wasm = ["dep:wasm-bindgen", "dep:js-sys", "dep:wasm-timer", "tick-hz-1_000_000", "dep:embassy-time-queue-utils"]
 


### PR DESCRIPTION
`embassy-time`'s `std` feature currently hard enables the `critical-section/std` feature.

We're actually using a [custom critical section implementation](https://github.com/ariel-os/ariel-os/pull/647/files#diff-7346c3b136948881fb50a6a1d11062be5fd86c728ed33f723aea63449776d2de) on `std`, which conflicts with the one `embassy-time` selects here.

As far as I can tell, selecting the impl in `embassy-time` is not needed in-tree, so just drop it.