### PR TITLE
embassy-executor: introduce `Executor::id()`, `Spawner::executor_id()`

### DIFF
--- a/embassy-executor/src/raw/mod.rs
+++ b/embassy-executor/src/raw/mod.rs
@@ -555,6 +555,11 @@ impl Executor {
     pub fn spawner(&'static self) -> super::Spawner {
         super::Spawner::new(self)
     }
+
+    /// Get a unique ID for this Executor.
+    pub fn id(&'static self) -> usize {
+        &self.inner as *const SyncExecutor as usize
+    }
 }
 
 /// Wake a task by `TaskRef`.

--- a/embassy-executor/src/spawner.rs
+++ b/embassy-executor/src/spawner.rs
@@ -173,6 +173,11 @@ impl Spawner {
     pub fn make_send(&self) -> SendSpawner {
         SendSpawner::new(&self.executor.inner)
     }
+
+    /// Return the unique ID of this Spawner's Executor.
+    pub fn executor_id(&self) -> usize {
+        self.executor.id()
+    }
 }
 
 /// Handle to spawn tasks into an executor from any thread.


### PR DESCRIPTION
This adds a way to get a unique id for an `Executor`, and another to get that id through a `Spawner`.

The id is just an `Executor`'s inner `SyncSpawner` ref-as-pointer-as-usize.

I'd argue that due to the inner `SyncSpawner` ref being `&static`, no two `Executor` instances can have the same id.