### PR TITLE
embassy-executor: Don't enable critical-section/std for `arch-std`

### DIFF
--- a/embassy-executor/Cargo.toml
+++ b/embassy-executor/Cargo.toml
@@ -70,7 +70,7 @@ turbowakers = []
 #! ### Architecture
 _arch = [] # some arch was picked
 ## std
-arch-std = ["_arch", "critical-section/std"]
+arch-std = ["_arch"]
 ## Cortex-M
 arch-cortex-m = ["_arch", "dep:cortex-m"]
 ## RISC-V 32


### PR DESCRIPTION
I tried using embassy-executor with esp-idf-hal (i.e. on std), but found that esp-idf-hal enables a feature of critical-section that is mutually exclusive to `critical-section/std`, that is enabled by embassy-executor when using `arch-std`. I therefore don't think that embassy-executor should automatically select the critical-section implementation and leave it to the hal to decide, just like #4048 suggests for embassy-time.