### PR TITLE
embassy-sync, executor/arch-wasm: don't select critical-section impl for std

### DIFF
--- a/embassy-executor/Cargo.toml
+++ b/embassy-executor/Cargo.toml
@@ -76,7 +76,7 @@ arch-cortex-m = ["_arch", "dep:cortex-m"]
 ## RISC-V 32
 arch-riscv32 = ["_arch"]
 ## WASM
-arch-wasm = ["_arch", "dep:wasm-bindgen", "dep:js-sys", "critical-section/std"]
+arch-wasm = ["_arch", "dep:wasm-bindgen", "dep:js-sys"]
 ## AVR
 arch-avr = ["_arch", "dep:portable-atomic", "dep:avr-device"]
 ## spin (architecture agnostic; never sleeps)

--- a/embassy-sync/Cargo.toml
+++ b/embassy-sync/Cargo.toml
@@ -20,7 +20,7 @@ src_base_git = "https://github.com/embassy-rs/embassy/blob/$COMMIT/embassy-sync/
 target = "thumbv7em-none-eabi"
 
 [features]
-std = ["critical-section/std"]
+std = []
 turbowakers = []
 
 [dependencies]


### PR DESCRIPTION
These are the last ones.