### PR TITLE
embassy-rp: uart: Increase RX FIFO watermark

### DIFF
--- a/embassy-rp/src/uart/mod.rs
+++ b/embassy-rp/src/uart/mod.rs
@@ -913,7 +913,7 @@ impl<'d, T: Instance + 'd, M: Mode> Uart<'d, T, M> {
         });
 
         r.uartifls().write(|w| {
-            w.set_rxiflsel(0b000);
+            w.set_rxiflsel(0b100);
             w.set_txiflsel(0b000);
         });
 


### PR DESCRIPTION
rebase of #3933

Change the UART RX FIFO depth from 1/8 to 7/8.  This should allow for
buffered receipt of uart data with a lower IRQ load.

The PL011 fifo is pretty smart about the fifo, it has an automatic
timeout (which triggers an interrupt) of about 4 characters worth of
time, so setting this threshold doesn't affect the behavior of receipt
of a partially filled fifo.

This should not have any affect on the DMA mode, as the DMA will
generally drain the fifo as data becomes available.

The constraint for the fifo threshold should be determined by expected
interrupt latency.  The IRQ needs to be able to drain the fifo before it
fills.  As such, the proper threshold depends on system design and data
rate.  At full speed (7.8 Mbaud), the remaining 8 characters will come
in in about 10us, which is probably insufficient. But, the time is quite
adequate at lower speeds.
