### PR TITLE
mspm0: add uart tests

### DIFF
--- a/ci.sh
+++ b/ci.sh
@@ -308,6 +308,7 @@ cargo batch \
     --- build --release --manifest-path tests/nrf/Cargo.toml --target thumbv7em-none-eabi --features nrf52840 --artifact-dir out/tests/nrf52840-dk \
     --- build --release --manifest-path tests/nrf/Cargo.toml --target thumbv8m.main-none-eabihf --features nrf5340 --artifact-dir out/tests/nrf5340-dk \
     --- build --release --manifest-path tests/nrf/Cargo.toml --target thumbv8m.main-none-eabihf --features nrf9160 --artifact-dir out/tests/nrf9160-dk \
+    --- build --release --manifest-path tests/mspm0/Cargo.toml --target thumbv6m-none-eabi --features mspm0g3507 --artifact-dir out/tests/mspm0g3507 \
     --- build --release --manifest-path tests/riscv32/Cargo.toml --target riscv32imac-unknown-none-elf \
     $BUILD_EXTRA
 
@@ -321,6 +322,9 @@ DEFMT_RTT_BUFFER_SIZE="72" cargo batch \
 rm -rf out/tests/stm32f103c8
 rm -rf out/tests/nrf52840-dk
 rm -rf out/tests/nrf52833-dk
+
+# disabled because these boards are not on the shelf
+rm -rf out/tests/mspm0g3507
 
 rm out/tests/stm32wb55rg/wpan_mac
 rm out/tests/stm32wb55rg/wpan_ble

--- a/tests/mspm0/.cargo/config.toml
+++ b/tests/mspm0/.cargo/config.toml
@@ -1,0 +1,8 @@
+[target.'cfg(all(target_arch = "arm", target_os = "none"))']
+runner = "teleprobe local run --chip MSPM0G3507 --protocol swd --elf"
+
+[build]
+target = "thumbv6m-none-eabi"
+
+[env]
+DEFMT_LOG = "trace,embassy_hal_internal=debug"

--- a/tests/mspm0/Cargo.toml
+++ b/tests/mspm0/Cargo.toml
@@ -1,0 +1,58 @@
+[package]
+edition = "2021"
+name = "embassy-mspm0-tests"
+version = "0.1.0"
+license = "MIT OR Apache-2.0"
+
+[features]
+mspm0g3507 = [ "embassy-mspm0/mspm0g350x" ]
+
+[dependencies]
+teleprobe-meta = "1.1"
+
+embassy-sync = { version = "0.6.2", path = "../../embassy-sync", features = [ "defmt" ] }
+embassy-executor = { version = "0.7.0", path = "../../embassy-executor", features = [ "arch-cortex-m", "executor-thread", "defmt" ] }
+embassy-time = { version = "0.4.0", path = "../../embassy-time", features = [ "defmt" ] }
+embassy-mspm0 = { version = "0.1.0", path = "../../embassy-mspm0", features = [ "rt", "defmt", "unstable-pac", "time-driver-any" ]  }
+embassy-embedded-hal = { version = "0.3.0", path = "../../embassy-embedded-hal/"}
+
+defmt = "1.0.1"
+defmt-rtt = "1.0.0"
+
+cortex-m = { version = "0.7.6", features = [ "inline-asm", "critical-section-single-core" ]}
+cortex-m-rt = "0.7.0"
+embedded-hal = { package = "embedded-hal", version = "1.0" }
+embedded-hal-async = { version = "1.0" }
+panic-probe = { version = "0.3.0", features = ["print-defmt"] }
+static_cell = "2"
+portable-atomic = { version = "1.5", features = ["critical-section"] }
+
+[profile.dev]
+debug = 2
+debug-assertions = true
+opt-level = 's'
+overflow-checks = true
+
+[profile.release]
+codegen-units = 1
+debug = 2
+debug-assertions = false
+incremental = false
+lto = "fat"
+opt-level = 's'
+overflow-checks = false
+
+# do not optimize proc-macro crates = faster builds from scratch
+[profile.dev.build-override]
+codegen-units = 8
+debug = false
+debug-assertions = false
+opt-level = 0
+overflow-checks = false
+
+[profile.release.build-override]
+codegen-units = 8
+debug = false
+debug-assertions = false
+opt-level = 0
+overflow-checks = false

--- a/tests/mspm0/build.rs
+++ b/tests/mspm0/build.rs
@@ -1,0 +1,24 @@
+use std::error::Error;
+use std::path::PathBuf;
+use std::{env, fs};
+
+fn main() -> Result<(), Box<dyn Error>> {
+    let out = PathBuf::from(env::var("OUT_DIR").unwrap());
+
+    #[cfg(feature = "mspm0g3507")]
+    let memory_x = include_bytes!("memory_g3507.x");
+
+    fs::write(out.join("memory.x"), memory_x).unwrap();
+
+    println!("cargo:rustc-link-search={}", out.display());
+    println!("cargo:rerun-if-changed=link_ram.x");
+    // copy main linker script.
+    fs::write(out.join("link_ram.x"), include_bytes!("../link_ram_cortex_m.x")).unwrap();
+
+    println!("cargo:rustc-link-arg-bins=--nmagic");
+    println!("cargo:rustc-link-arg-bins=-Tlink_ram.x");
+    println!("cargo:rustc-link-arg-bins=-Tdefmt.x");
+    println!("cargo:rustc-link-arg-bins=-Tteleprobe.x");
+
+    Ok(())
+}

--- a/tests/mspm0/memory_g3507.x
+++ b/tests/mspm0/memory_g3507.x
@@ -1,0 +1,6 @@
+MEMORY
+{
+  FLASH : ORIGIN = 0x00000000, LENGTH = 128K
+  /* Select non-parity range of SRAM due to SRAM_ERR_01 errata in SLAZ758 */
+  RAM   : ORIGIN = 0x20200000, LENGTH = 32K
+}

--- a/tests/mspm0/src/bin/uart.rs
+++ b/tests/mspm0/src/bin/uart.rs
@@ -1,0 +1,83 @@
+#![no_std]
+#![no_main]
+
+#[cfg(feature = "mspm0g3507")]
+teleprobe_meta::target!(b"lp-mspm0g3507");
+
+use defmt::{assert_eq, unwrap, *};
+use embassy_executor::Spawner;
+use embassy_mspm0::mode::Blocking;
+use embassy_mspm0::uart::{ClockSel, Config, Error, Uart};
+use {defmt_rtt as _, panic_probe as _};
+
+fn read<const N: usize>(uart: &mut Uart<'_, Blocking>) -> Result<[u8; N], Error> {
+    let mut buf = [255; N];
+    uart.blocking_read(&mut buf)?;
+    Ok(buf)
+}
+
+#[embassy_executor::main]
+async fn main(_spawner: Spawner) {
+    let p = embassy_mspm0::init(Default::default());
+    info!("Hello World!");
+
+    // TODO: Allow creating a looped-back UART (so pins are not needed).
+    // Do not select default UART since the virtual COM port is attached to UART0.
+    #[cfg(feature = "mspm0g3507")]
+    let (mut tx, mut rx, mut uart) = (p.PA8, p.PA9, p.UART1);
+
+    const MFCLK_BUAD_RATES: &[u32] = &[1200, 2400, 4800, 9600, 19200, 38400, 57600, 115200];
+
+    for &rate in MFCLK_BUAD_RATES {
+        info!("{} baud using MFCLK", rate);
+
+        let mut config = Config::default();
+        // MSPM0 hardware supports a loopback mode to allow self test.
+        config.loop_back_enable = true;
+        config.baudrate = rate;
+
+        let mut uart = unwrap!(Uart::new_blocking(
+            uart.reborrow(),
+            rx.reborrow(),
+            tx.reborrow(),
+            config
+        ));
+
+        // We can't send too many bytes, they have to fit in the FIFO.
+        // This is because we aren't sending+receiving at the same time.
+
+        let data = [0xC0, 0xDE];
+        unwrap!(uart.blocking_write(&data));
+        assert_eq!(unwrap!(read(&mut uart)), data);
+    }
+
+    // 9600 is the maximum possible value for 32.768 kHz.
+    const LFCLK_BAUD_RATES: &[u32] = &[1200, 2400, 4800, 9600];
+
+    for &rate in LFCLK_BAUD_RATES {
+        info!("{} baud using LFCLK", rate);
+
+        let mut config = Config::default();
+        // MSPM0 hardware supports a loopback mode to allow self test.
+        config.loop_back_enable = true;
+        config.baudrate = rate;
+        config.clock_source = ClockSel::LfClk;
+
+        let mut uart = expect!(Uart::new_blocking(
+            uart.reborrow(),
+            rx.reborrow(),
+            tx.reborrow(),
+            config,
+        ));
+
+        // We can't send too many bytes, they have to fit in the FIFO.
+        // This is because we aren't sending+receiving at the same time.
+
+        let data = [0xC0, 0xDE];
+        unwrap!(uart.blocking_write(&data));
+        assert_eq!(unwrap!(read(&mut uart)), data);
+    }
+
+    info!("Test OK");
+    cortex_m::asm::bkpt();
+}


### PR DESCRIPTION
This also fixes a bug in the uart clock calculation where it could select an oversampling faster than what the hardware is providing.

Depends on https://github.com/embassy-rs/teleprobe/pull/29
