### PR TITLE
chore: update cyw43 bt-hci version

### DIFF
--- a/cyw43/Cargo.toml
+++ b/cyw43/Cargo.toml
@@ -36,7 +36,7 @@ heapless = "0.8.0"
 
 # Bluetooth deps
 embedded-io-async = { version = "0.6.0", optional = true }
-bt-hci = { version = "0.2.0", optional = true }
+bt-hci = { version = "0.3.0", optional = true }
 
 [package.metadata.embassy_docs]
 src_base = "https://github.com/embassy-rs/embassy/blob/cyw43-v$VERSION/cyw43/src/"


### PR DESCRIPTION
The new version contains some fixes to hci serialization.
