### PR TITLE
embassy-boot-rp-examples: Remove duplicate features in embassy-executor dependency

### DIFF
--- a/examples/boot/application/rp/Cargo.toml
+++ b/examples/boot/application/rp/Cargo.toml
@@ -6,7 +6,7 @@ license = "MIT OR Apache-2.0"
 
 [dependencies]
 embassy-sync = { version = "0.6.2", path = "../../../../embassy-sync" }
-embassy-executor = { version = "0.7.0", path = "../../../../embassy-executor", features = ["arch-cortex-m", "executor-thread", "arch-cortex-m", "executor-thread"] }
+embassy-executor = { version = "0.7.0", path = "../../../../embassy-executor", features = ["arch-cortex-m", "executor-thread"] }
 embassy-time = { version = "0.4.0", path = "../../../../embassy-time", features = [] }
 embassy-rp = { version = "0.4.0", path = "../../../../embassy-rp", features = ["time-driver", "rp2040"] }
 embassy-boot-rp = { version = "0.5.0", path = "../../../../embassy-boot-rp", features = [] }


### PR DESCRIPTION
This PR removes duplicated features ("arch-cortex-m" and "executor-thread") from the `embassy-executor` dependency in Cargo.toml.