### PR TITLE
Fix the avr executor

### DIFF
--- a/embassy-executor/Cargo.toml
+++ b/embassy-executor/Cargo.toml
@@ -50,7 +50,7 @@ wasm-bindgen = { version = "0.2.82", optional = true }
 js-sys = { version = "0.3", optional = true }
 
 # arch-avr dependencies
-avr-device = { version = "0.5.3", optional = true }
+avr-device = { version = "0.7.0", optional = true }
 
 [dev-dependencies]
 critical-section = { version = "1.1", features = ["std"] }

--- a/embassy-executor/src/raw/mod.rs
+++ b/embassy-executor/src/raw/mod.rs
@@ -28,8 +28,10 @@ use core::marker::PhantomData;
 use core::mem;
 use core::pin::Pin;
 use core::ptr::NonNull;
-use core::sync::atomic::{AtomicPtr, Ordering};
+use core::sync::atomic::Ordering;
 use core::task::{Context, Poll};
+
+use portable_atomic::AtomicPtr;
 
 use self::run_queue::{RunQueue, RunQueueItem};
 use self::state::State;

--- a/embassy-executor/src/raw/mod.rs
+++ b/embassy-executor/src/raw/mod.rs
@@ -29,8 +29,10 @@ use core::mem;
 use core::pin::Pin;
 use core::ptr::NonNull;
 use core::sync::atomic::Ordering;
+#[cfg(not(feature = "arch-avr"))]
+use core::sync::atomic::AtomicPtr;
 use core::task::{Context, Poll};
-
+#[cfg(feature = "arch-avr")]
 use portable_atomic::AtomicPtr;
 
 use self::run_queue::{RunQueue, RunQueueItem};

--- a/embassy-executor/src/raw/mod.rs
+++ b/embassy-executor/src/raw/mod.rs
@@ -28,10 +28,11 @@ use core::marker::PhantomData;
 use core::mem;
 use core::pin::Pin;
 use core::ptr::NonNull;
-use core::sync::atomic::Ordering;
 #[cfg(not(feature = "arch-avr"))]
 use core::sync::atomic::AtomicPtr;
+use core::sync::atomic::Ordering;
 use core::task::{Context, Poll};
+
 #[cfg(feature = "arch-avr")]
 use portable_atomic::AtomicPtr;
 


### PR DESCRIPTION
Fixes the avr executor by exchanging the `core::sync::AtomicPtr` with `portable_atomic::AtomicPtr`