### PR TITLE
[RP] Fix missing config.composite_with_iads = false; in webusb example

### DIFF
--- a/examples/rp/src/bin/usb_webusb.rs
+++ b/examples/rp/src/bin/usb_webusb.rs
@@ -51,12 +51,6 @@ async fn main(_spawner: Spawner) {
     config.max_power = 100;
     config.max_packet_size_0 = 64;
 
-    // Required for windows compatibility.
-    // https://developer.nordicsemi.com/nRF_Connect_SDK/doc/1.9.1/kconfig/CONFIG_CDC_ACM_IAD.html#help
-    config.device_class = 0xff;
-    config.device_sub_class = 0x00;
-    config.device_protocol = 0x00;
-
     // Create embassy-usb DeviceBuilder using the driver and config.
     // It needs some buffers for building the descriptors.
     let mut config_descriptor = [0; 256];

--- a/examples/rp235x/src/bin/usb_webusb.rs
+++ b/examples/rp235x/src/bin/usb_webusb.rs
@@ -51,12 +51,6 @@ async fn main(_spawner: Spawner) {
     config.max_power = 100;
     config.max_packet_size_0 = 64;
 
-    // Required for windows compatibility.
-    // https://developer.nordicsemi.com/nRF_Connect_SDK/doc/1.9.1/kconfig/CONFIG_CDC_ACM_IAD.html#help
-    config.device_class = 0xff;
-    config.device_sub_class = 0x00;
-    config.device_protocol = 0x00;
-
     // Create embassy-usb DeviceBuilder using the driver and config.
     // It needs some buffers for building the descriptors.
     let mut config_descriptor = [0; 256];


### PR DESCRIPTION
Running the usb-webusb example for the rp235x causes the following panic:
```
0.000395 ERROR panicked at /home/user/.cargo/git/checkouts/embassy-c08a80187403f815/6919732/embassy-usb/src/builder.rs:179:13:
if composite_with_iads is set, you must set device_class = 0xEF, device_sub_class = 0x02, device_protocol = 0x01
└─ panic_probe::print_defmt::print @ /home/jdickert/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/panic-probe-1.0.0/src/lib.rs:104 
```
Since the classes and protocol are not set to the necessary values, I think the `composite_with_iads` should simply be set to false in this case.

Also made the change in the RP2340 example.

fixes #4050
