### PR TITLE
[embassy-stm32] Capability to modify CAN frame data without copying.

### DIFF
--- a/embassy-stm32/src/can/frame.rs
+++ b/embassy-stm32/src/can/frame.rs
@@ -128,7 +128,7 @@ impl ClassicData {
     pub fn raw(&self) -> &[u8] {
         &self.bytes
     }
-    
+
     /// Raw mutable read access to data.
     pub fn raw_mut(&mut self) -> &mut [u8] {
         &mut self.bytes
@@ -213,7 +213,7 @@ impl Frame {
     pub fn data(&self) -> &[u8] {
         &self.data.raw()
     }
-    
+
     /// Get mutable reference to data
     pub fn data_mut(&mut self) -> &mut [u8] {
         self.data.raw_mut()
@@ -323,7 +323,7 @@ impl FdData {
     pub fn raw(&self) -> &[u8] {
         &self.bytes
     }
-    
+
     /// Raw mutable read access to data.
     pub fn raw_mut(&mut self) -> &mut [u8] {
         &mut self.bytes
@@ -407,7 +407,7 @@ impl FdFrame {
     pub fn data(&self) -> &[u8] {
         &self.data.raw()
     }
-    
+
     /// Get mutable reference to data
     pub fn data_mut(&mut self) -> &mut [u8] {
         self.data.raw_mut()

--- a/embassy-stm32/src/can/frame.rs
+++ b/embassy-stm32/src/can/frame.rs
@@ -128,6 +128,11 @@ impl ClassicData {
     pub fn raw(&self) -> &[u8] {
         &self.bytes
     }
+    
+    /// Raw mutable read access to data.
+    pub fn raw_mut(&mut self) -> &mut [u8] {
+        &mut self.bytes
+    }
 
     /// Checks if the length can be encoded in FDCAN DLC field.
     pub const fn is_valid_len(len: usize) -> bool {
@@ -207,6 +212,11 @@ impl Frame {
     /// Get reference to data
     pub fn data(&self) -> &[u8] {
         &self.data.raw()
+    }
+    
+    /// Get mutable reference to data
+    pub fn data_mut(&mut self) -> &mut [u8] {
+        self.data.raw_mut()
     }
 
     /// Get priority of frame
@@ -313,6 +323,11 @@ impl FdData {
     pub fn raw(&self) -> &[u8] {
         &self.bytes
     }
+    
+    /// Raw mutable read access to data.
+    pub fn raw_mut(&mut self) -> &mut [u8] {
+        &mut self.bytes
+    }
 
     /// Checks if the length can be encoded in FDCAN DLC field.
     pub const fn is_valid_len(len: usize) -> bool {
@@ -391,6 +406,11 @@ impl FdFrame {
     /// Get reference to data
     pub fn data(&self) -> &[u8] {
         &self.data.raw()
+    }
+    
+    /// Get mutable reference to data
+    pub fn data_mut(&mut self) -> &mut [u8] {
+        self.data.raw_mut()
     }
 }
 


### PR DESCRIPTION
Implemented the ability to take a changeable reference to data in a CAN frame.
There are no breaking changes.

Read more in issue #4075.