### PR TITLE
Update blinky_wifi example name

### DIFF
--- a/examples/rp235x/src/bin/blinky.rs
+++ b/examples/rp235x/src/bin/blinky.rs
@@ -1,6 +1,6 @@
 //! This example test the RP Pico on board LED.
 //!
-//! It does not work with the RP Pico W board. See wifi_blinky.rs.
+//! It does not work with the RP Pico W board. See `blinky_wifi.rs`.
 
 #![no_std]
 #![no_main]


### PR DESCRIPTION
The RP pico w 2 blinky example is currently called `blinky_wifi`. Updates the comment in `blinky.rs` to match that.