### PR TITLE
cyw43: make State::new a const fn

### DIFF
--- a/cyw43/src/events.rs
+++ b/cyw43/src/events.rs
@@ -296,10 +296,10 @@ pub struct Events {
 }
 
 impl Events {
-    pub fn new() -> Self {
+    pub const fn new() -> Self {
         Self {
             queue: EventQueue::new(),
-            mask: SharedEventMask::default(),
+            mask: SharedEventMask::new(),
         }
     }
 }
@@ -333,13 +333,18 @@ impl Message {
     }
 }
 
-#[derive(Default)]
 struct EventMask {
     mask: [u32; Self::WORD_COUNT],
 }
 
 impl EventMask {
     const WORD_COUNT: usize = ((Event::LAST as u32 + (u32::BITS - 1)) / u32::BITS) as usize;
+
+    const fn new() -> Self {
+        Self {
+            mask: [0; Self::WORD_COUNT],
+        }
+    }
 
     fn enable(&mut self, event: Event) {
         let n = event as u32;
@@ -366,13 +371,17 @@ impl EventMask {
     }
 }
 
-#[derive(Default)]
-
 pub struct SharedEventMask {
     mask: RefCell<EventMask>,
 }
 
 impl SharedEventMask {
+    pub const fn new() -> Self {
+        Self {
+            mask: RefCell::new(EventMask::new()),
+        }
+    }
+
     pub fn enable(&self, events: &[Event]) {
         let mut mask = self.mask.borrow_mut();
         for event in events {
@@ -396,5 +405,11 @@ impl SharedEventMask {
     pub fn is_enabled(&self, event: Event) -> bool {
         let mask = self.mask.borrow();
         mask.is_enabled(event)
+    }
+}
+
+impl Default for SharedEventMask {
+    fn default() -> Self {
+        Self::new()
     }
 }

--- a/cyw43/src/ioctl.rs
+++ b/cyw43/src/ioctl.rs
@@ -33,8 +33,8 @@ struct Wakers {
     runner: WakerRegistration,
 }
 
-impl Default for Wakers {
-    fn default() -> Self {
+impl Wakers {
+    const fn new() -> Self {
         Self {
             control: WakerRegistration::new(),
             runner: WakerRegistration::new(),
@@ -48,10 +48,10 @@ pub struct IoctlState {
 }
 
 impl IoctlState {
-    pub fn new() -> Self {
+    pub const fn new() -> Self {
         Self {
             state: Cell::new(IoctlStateInner::Done { resp_len: 0 }),
-            wakers: Default::default(),
+            wakers: RefCell::new(Wakers::new()),
         }
     }
 

--- a/cyw43/src/lib.rs
+++ b/cyw43/src/lib.rs
@@ -124,7 +124,7 @@ struct NetState {
 
 impl State {
     /// Create new driver state holder.
-    pub fn new() -> Self {
+    pub const fn new() -> Self {
         Self {
             ioctl_state: IoctlState::new(),
             net: NetState {


### PR DESCRIPTION
This allows using static_cell::ConstStaticCell for cyw43::State.