### PR TITLE
Add the ADC5 to the DMA codegen for the STM32g4x3 and g4x4

### DIFF
--- a/embassy-stm32/build.rs
+++ b/embassy-stm32/build.rs
@@ -1412,6 +1412,13 @@ fn main() {
         signals.insert(("adc", "ADC4"), quote!(crate::adc::RxDma));
     }
 
+    if chip_name.starts_with("stm32g4") {
+        let line_number = chip_name.chars().skip(8).next().unwrap();
+        if line_number == '3' || line_number == '4' {
+            signals.insert(("adc", "ADC5"), quote!(crate::adc::RxDma));
+        }
+    }
+
     for p in METADATA.peripherals {
         if let Some(regs) = &p.registers {
             // FIXME: stm32u5a crash on Cordic driver


### PR DESCRIPTION
I was missing a DMA impl for ADC5. This fixes it for the g4x3 and the g4x4. The g4x1 only has 3 ADCs, so we need to look at the line as well.