### PR TITLE
Enable input mode for PWM pins on RP235x and disable it on drop

### DIFF
--- a/embassy-rp/src/pwm.rs
+++ b/embassy-rp/src/pwm.rs
@@ -157,6 +157,11 @@ impl<'d> Pwm<'d> {
             pin.pad_ctrl().modify(|w| {
                 #[cfg(feature = "_rp235x")]
                 w.set_iso(false);
+                #[cfg(feature = "_rp235x")]
+                if divmode != Divmode::DIV {
+                    // Is in input mode and so must enable input mode for the pin
+                    w.set_ie(true);
+                }
                 w.set_pue(b_pull == Pull::Up);
                 w.set_pde(b_pull == Pull::Down);
             });
@@ -462,6 +467,11 @@ impl<'d> Drop for Pwm<'d> {
         }
         if let Some(pin) = &self.pin_b {
             pin.gpio().ctrl().write(|w| w.set_funcsel(31));
+            #[cfg(feature = "_rp235x")]
+            // Disable input mode. Only pin_b can be input, so not needed for pin_a
+            pin.pad_ctrl().modify(|w| {
+                w.set_ie(false);
+            });
         }
     }
 }


### PR DESCRIPTION
PWM input does not work on rp235xa. This PR fixes this by enabling input mode if using pwm in input mode

Test result with fix: Can confirm reading correct rate from generated function. Before fix reads 0Hz.

![image](https://github.com/user-attachments/assets/d008410f-944c-4d9c-92b0-161c0ae5c636)

Have a good look before merging, the code is based on AI agent suggestion. I am especially unsure if the drop implementation is as it ought to be, we will be setting IE to false even if the PWM was never initialized as input. But I found no convincing way that i liked to read the way it is set up without introducing more code so I left it like it is proposed here.

Here is an excerpt from the rp2350 datasheet backing up the viability of the fix itself: Chapter 9.3, outlining changes wrt rp2040:
![image](https://github.com/user-attachments/assets/9889b416-ef47-4a5b-b8e2-c7ab373d67a5)


