### PR TITLE
Canfd improvements

### DIFF
--- a/embassy-stm32/CHANGELOG.md
+++ b/embassy-stm32/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - feat: stm32/adc/v3: allow DMA reads to loop through enable channels
 - fix: Fix XSPI not disabling alternate bytes when they were previously enabled
 - feat: stm32/fdcan add fn to enable TX buffer mode
+- fix: Fix stm32/fdcan repeatedly reporting the same error
 
 ## 0.3.0 - 2025-08-12
 

--- a/embassy-stm32/CHANGELOG.md
+++ b/embassy-stm32/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - chore: Updated stm32-metapac and stm32-data dependencies
 - feat: stm32/adc/v3: allow DMA reads to loop through enable channels
 - fix: Fix XSPI not disabling alternate bytes when they were previously enabled
+- feat: stm32/fdcan add fn to enable TX buffer mode
 
 ## 0.3.0 - 2025-08-12
 

--- a/embassy-stm32/src/can/fdcan.rs
+++ b/embassy-stm32/src/can/fdcan.rs
@@ -697,7 +697,6 @@ impl RxMode {
             let ts = info.regs.calc_timestamp(ns_per_timer_tick, ts);
             Some(Ok((msg, ts)))
         } else if let Some(err) = info.regs.curr_error() {
-            // TODO: this is probably wrong
             Some(Err(err))
         } else {
             None

--- a/embassy-stm32/src/can/fdcan.rs
+++ b/embassy-stm32/src/can/fdcan.rs
@@ -244,6 +244,11 @@ impl<'d> CanConfigurator<'d> {
         self.config = self.config.set_nominal_bit_timing(nbtr);
     }
 
+    /// Configures the transmit buffer to FIFO or priority mode.
+    pub fn set_tx_buffer_mode(&mut self, mode: crate::can::fd::config::TxBufferMode) {
+        self.config.tx_buffer_mode = mode;
+    }
+
     /// Configures the bit timings for VBR data calculated from supplied bitrate. This also sets confit to allow can FD and VBR
     pub fn set_fd_data_bitrate(&mut self, bitrate: u32, transceiver_delay_compensation: bool) {
         let bit_timing = util::calc_can_timings(self.periph_clock, bitrate).unwrap();


### PR DESCRIPTION
Fixes the error handling in the canfd peripheral to match the bxcan. An error will only be returned once even if it remains present instead of returning the error every time read is called. The error state is tracked using the interrupt flags. If the flag is set then the error is new and is reported.

Also adds a configuration function to set the TX buffer mode to allow usage in FIFO mode.