### PR TITLE
embassy-rp: impl rand_core::CryptoRng for Trng

### DIFF
--- a/embassy-rp/src/trng.rs
+++ b/embassy-rp/src/trng.rs
@@ -368,6 +368,9 @@ impl<'d, T: Instance> rand_core::RngCore for Trng<'d, T> {
         Ok(())
     }
 }
+
+impl<'d, T: Instance> rand_core::CryptoRng for Trng<'d, T> {}
+
 /// TRNG interrupt handler.
 pub struct InterruptHandler<T: Instance> {
     _trng: PhantomData<T>,


### PR DESCRIPTION
Per discussion in https://github.com/embassy-rs/embassy/pull/3338/files#r2040704590 the Trng implementation satisfies the requirements for CryptoRng, so it is reasonable to implement this marker trait.