### PR TITLE
rp: i2c-slave example: fix twice-swapped sda/scl

### DIFF
--- a/examples/rp/src/bin/i2c_slave.rs
+++ b/examples/rp/src/bin/i2c_slave.rs
@@ -99,19 +99,19 @@ async fn main(spawner: Spawner) {
     let p = embassy_rp::init(Default::default());
     info!("Hello World!");
 
-    let d_sda = p.PIN_3;
-    let d_scl = p.PIN_2;
+    let d_sda = p.PIN_2;
+    let d_scl = p.PIN_3;
     let mut config = i2c_slave::Config::default();
     config.addr = DEV_ADDR as u16;
-    let device = i2c_slave::I2cSlave::new(p.I2C1, d_sda, d_scl, Irqs, config);
+    let device = i2c_slave::I2cSlave::new(p.I2C1, d_scl, d_sda, Irqs, config);
 
     unwrap!(spawner.spawn(device_task(device)));
 
-    let c_sda = p.PIN_1;
-    let c_scl = p.PIN_0;
+    let c_sda = p.PIN_0;
+    let c_scl = p.PIN_1;
     let mut config = i2c::Config::default();
     config.frequency = 1_000_000;
-    let controller = i2c::I2c::new_async(p.I2C0, c_sda, c_scl, Irqs, config);
+    let controller = i2c::I2c::new_async(p.I2C0, c_scl, c_sda, Irqs, config);
 
     unwrap!(spawner.spawn(controller_task(controller)));
 }


### PR DESCRIPTION
sda and scl were swapped twice. The code worked, but would be confusing trying to interface with pins externally.