### PR TITLE
[embassy-net-nrf91] patch greater rx_data_len size

### DIFF
--- a/embassy-net-nrf91/Cargo.toml
+++ b/embassy-net-nrf91/Cargo.toml
@@ -10,8 +10,9 @@ repository = "https://github.com/embassy-rs/embassy"
 documentation = "https://docs.embassy.dev/embassy-net-nrf91"
 
 [features]
-defmt = [ "dep:defmt", "heapless/defmt-03" ]
-log = [ "dep:log" ]
+defmt = ["dep:defmt", "heapless/defmt-03"]
+log = ["dep:log"]
+nrf9151 = []
 
 [dependencies]
 defmt = { version = "0.3", optional = true }
@@ -21,9 +22,9 @@ nrf-pac = "0.1.0"
 cortex-m = "0.7.7"
 
 embassy-time = { version = "0.4.0", path = "../embassy-time" }
-embassy-sync = { version = "0.6.2", path = "../embassy-sync"}
-embassy-futures = { version = "0.1.0", path = "../embassy-futures"}
-embassy-net-driver-channel = { version = "0.3.0", path = "../embassy-net-driver-channel"}
+embassy-sync = { version = "0.6.2", path = "../embassy-sync" }
+embassy-futures = { version = "0.1.0", path = "../embassy-futures" }
+embassy-net-driver-channel = { version = "0.3.0", path = "../embassy-net-driver-channel" }
 
 heapless = "0.8"
 embedded-io = "0.6.1"

--- a/embassy-net-nrf91/README.md
+++ b/embassy-net-nrf91/README.md
@@ -7,3 +7,7 @@ See the [`examples`](https://github.com/embassy-rs/embassy/tree/main/examples/nr
 ## Interoperability
 
 This crate can run on any executor.
+
+## Features
+
+By default the nrf91 crate supports NRF9160 and similar. With newer generation of chips use feature `nrf9151` to support the new data sizes.

--- a/embassy-net-nrf91/src/lib.rs
+++ b/embassy-net-nrf91/src/lib.rs
@@ -346,8 +346,11 @@ impl StateInner {
                 self.rx_data_list = desc.data_list_ptr;
                 let rx_control_len = unsafe { addr_of!((*self.rx_control_list).len).read_volatile() };
                 let rx_data_len = unsafe { addr_of!((*self.rx_data_list).len).read_volatile() };
-                assert_eq!(rx_control_len, LIST_LEN);
-                assert_eq!(rx_data_len, LIST_LEN);
+                assert_eq!(rx_control_len, LIST_LEN, "control list length mismatch");
+                #[cfg(feature = "defmt")]
+                assert_eq!(rx_data_len, 32, "data list length mismatch");
+                #[cfg(not(feature = "defmt"))]
+                assert_eq!(rx_data_len, LIST_LEN, "data list length mismatch");
                 self.init = true;
 
                 debug!("IPC initialized OK!");


### PR DESCRIPTION
Switching from a NRF9160 MCU to the newer NRF9151 there were some changes regarding LTE connections. I used the same code on both boards.

1. the NRF9151 switched it's logic to use the external oscillator by default; this can be changed by setting HFXOSRC to `0` and reboot. In the same step it's also recommended and verified to use `hfclk_source = HfclkSource::Internal` in your init config, e.g.:
    ```
    let mut peripheral_config = embassy_nrf::config::Config::default();
    peripheral_config.hfclk_source = HfclkSource::Internal;
    peripheral_config.lfclk_source = LfclkSource::InternalRC;
    let p = embassy_nrf::init(peripheral_config);
    ```
Except of course if you got an explicit external clock in use. 

2. starting up the modem with correct configuration leads to a endless wait state while the modem starts up. Issue covered up here was a change in the `rx_control_len` from uint `16` to `32`. Changing this leads to usage as usual. 


Tested on the NRF9160-DK and a NRF9151 testboard. 

Done:
- describe errors and solution
- add nrf9151 feature to crate; crate can be used as is in older projects and patched for newer MCU
- patch rx_data_length
- assert_eq got unique error messages
- add feature note to Readme

TODO: examples to test and add to examples folder (possibly other PR in future)