### PR TITLE
embassy-boot: remove default features from embassy-embedded-hal

### DIFF
--- a/embassy-boot/Cargo.toml
+++ b/embassy-boot/Cargo.toml
@@ -28,7 +28,7 @@ defmt = { version = "0.3", optional = true }
 digest = "0.10"
 log = { version = "0.4", optional = true }
 ed25519-dalek = { version = "2", default-features = false, features = ["digest"], optional = true }
-embassy-embedded-hal = { version = "0.3.0", path = "../embassy-embedded-hal" }
+embassy-embedded-hal = { version = "0.3.0", path = "../embassy-embedded-hal", default-features = false }
 embassy-sync = { version = "0.6.2", path = "../embassy-sync" }
 embedded-storage = "0.3.1"
 embedded-storage-async = { version = "0.4.1" }


### PR DESCRIPTION
embassy-embedded-hal enables the time feature by default, which will require you to include the time driver if you use any of the functions that use it (for example spi::blocking), otherwise the binary fails to link.