### PR TITLE
[embassy-usb-dfu] Add verification support

### DIFF
--- a/ci.sh
+++ b/ci.sh
@@ -267,6 +267,7 @@ cargo batch \
     --- build --release --manifest-path examples/boot/application/stm32l4/Cargo.toml --target thumbv7em-none-eabi --features skip-include --artifact-dir out/examples/boot/stm32l4 \
     --- build --release --manifest-path examples/boot/application/stm32wl/Cargo.toml --target thumbv7em-none-eabi --features skip-include --artifact-dir out/examples/boot/stm32wl \
     --- build --release --manifest-path examples/boot/application/stm32wb-dfu/Cargo.toml --target thumbv7em-none-eabi --artifact-dir out/examples/boot/stm32wb-dfu \
+    --- build --release --manifest-path examples/boot/application/stm32wb-dfu-verify/Cargo.toml --target thumbv7em-none-eabi --artifact-dir out/examples/boot/stm32wb-dfu-verify \
     --- build --release --manifest-path examples/boot/bootloader/nrf/Cargo.toml --target thumbv7em-none-eabi --features embassy-nrf/nrf52840 \
     --- build --release --manifest-path examples/boot/bootloader/nrf/Cargo.toml --target thumbv8m.main-none-eabihf --features embassy-nrf/nrf9160-ns \
     --- build --release --manifest-path examples/boot/bootloader/nrf/Cargo.toml --target thumbv8m.main-none-eabihf --features embassy-nrf/nrf9120-ns \
@@ -275,6 +276,7 @@ cargo batch \
     --- build --release --manifest-path examples/boot/bootloader/rp/Cargo.toml --target thumbv6m-none-eabi \
     --- build --release --manifest-path examples/boot/bootloader/stm32/Cargo.toml --target thumbv7em-none-eabi --features embassy-stm32/stm32l496zg \
     --- build --release --manifest-path examples/boot/bootloader/stm32wb-dfu/Cargo.toml --target thumbv7em-none-eabi --features embassy-stm32/stm32wb55rg \
+    --- build --release --manifest-path examples/boot/bootloader/stm32wb-dfu-verify/Cargo.toml --target thumbv7em-none-eabi --features embassy-stm32/stm32wb55rg \
     --- build --release --manifest-path examples/boot/bootloader/stm32-dual-bank/Cargo.toml --target thumbv7em-none-eabi --features embassy-stm32/stm32h743zi \
     --- build --release --manifest-path examples/wasm/Cargo.toml --target wasm32-unknown-unknown --artifact-dir out/examples/wasm \
     --- build --release --manifest-path tests/stm32/Cargo.toml --target thumbv7m-none-eabi --features stm32f103c8 --artifact-dir out/tests/stm32f103c8 \

--- a/ci.sh
+++ b/ci.sh
@@ -267,7 +267,6 @@ cargo batch \
     --- build --release --manifest-path examples/boot/application/stm32l4/Cargo.toml --target thumbv7em-none-eabi --features skip-include --artifact-dir out/examples/boot/stm32l4 \
     --- build --release --manifest-path examples/boot/application/stm32wl/Cargo.toml --target thumbv7em-none-eabi --features skip-include --artifact-dir out/examples/boot/stm32wl \
     --- build --release --manifest-path examples/boot/application/stm32wb-dfu/Cargo.toml --target thumbv7em-none-eabi --artifact-dir out/examples/boot/stm32wb-dfu \
-    --- build --release --manifest-path examples/boot/application/stm32wb-dfu-verify/Cargo.toml --target thumbv7em-none-eabi --artifact-dir out/examples/boot/stm32wb-dfu-verify \
     --- build --release --manifest-path examples/boot/bootloader/nrf/Cargo.toml --target thumbv7em-none-eabi --features embassy-nrf/nrf52840 \
     --- build --release --manifest-path examples/boot/bootloader/nrf/Cargo.toml --target thumbv8m.main-none-eabihf --features embassy-nrf/nrf9160-ns \
     --- build --release --manifest-path examples/boot/bootloader/nrf/Cargo.toml --target thumbv8m.main-none-eabihf --features embassy-nrf/nrf9120-ns \

--- a/embassy-boot/src/firmware_updater/blocking.rs
+++ b/embassy-boot/src/firmware_updater/blocking.rs
@@ -196,6 +196,17 @@ impl<'d, DFU: NorFlash, STATE: NorFlash> BlockingFirmwareUpdater<'d, DFU, STATE>
         Ok(())
     }
 
+    /// Read a slice of data from the DFU storage peripheral, starting the read
+    /// operation at the given address offset, and reading `buf.len()` bytes.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the arguments are not aligned or out of bounds.
+    pub fn read_dfu(&mut self, offset: u32, buf: &mut [u8]) -> Result<(), FirmwareUpdaterError> {
+        self.dfu.read(offset, buf)?;
+        Ok(())
+    }
+
     /// Mark to trigger firmware swap on next boot.
     #[cfg(not(feature = "_verify"))]
     pub fn mark_updated(&mut self) -> Result<(), FirmwareUpdaterError> {

--- a/embassy-usb-dfu/Cargo.toml
+++ b/embassy-usb-dfu/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 edition = "2021"
 name = "embassy-usb-dfu"
-version = "0.1.0"
+version = "0.1.1"
 description = "An implementation of the USB DFU 1.1 protocol, using embassy-boot"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/embassy-rs/embassy"
@@ -43,3 +43,8 @@ esp32c3-hal = { version = "0.13.0", optional = true, default-features = false }
 dfu = []
 application = []
 defmt = ["dep:defmt", "embassy-boot/defmt", "embassy-usb/defmt"]
+ed25519-dalek = ["embassy-boot/ed25519-dalek", "_verify"]
+ed25519-salty = ["embassy-boot/ed25519-salty", "_verify"]
+
+# Internal features
+_verify = []

--- a/embassy-usb-dfu/README.md
+++ b/embassy-usb-dfu/README.md
@@ -4,3 +4,9 @@ An implementation of the USB DFU 1.1 protocol using embassy-boot. It has 2 compo
 
 * DFU protocol mode, enabled by the `dfu` feature. This mode corresponds to the transfer phase DFU protocol described by the USB IF. It supports DFU_DNLOAD requests if marked by the user, and will automatically reset the chip once a DFU transaction has been completed. It also responds to DFU_GETSTATUS, DFU_GETSTATE, DFU_ABORT, and DFU_CLRSTATUS with no user intervention.
 * DFU runtime mode, enabled by the `application feature`. This mode allows users to expose a DFU interface on their USB device, informing the host of the capability to DFU over USB, and allowing the host to reset the device into its bootloader to complete a DFU operation. Supports DFU_GETSTATUS and DFU_DETACH. When detach/reset is seen by the device as described by the standard, will write a new DFU magic number into the bootloader state in flash, and reset the system.
+
+## Verification
+
+Embassy-boot provides functionality to verify that an update binary has been correctly signed using ed25519 as described in https://embassy.dev/book/#_verification. Even though the linked procedure describes the signature being concatenated to the end of the update binary, embassy-boot does not force this and is flexible in terms of how the signature for a binary is distributed. The current implementation in embassy-usb-dfu does however assume that the signature is 64 bytes long and concatenated to the end of the update binary since this is the simplest way to make it work with the usb-dfu mechanism. I.e. embassy-usb-dfu does not currently offer the same flexibility as embassy-boot.
+
+To enable verification, you need to enable either the `ed25519-dalek` or the `ed25519-salty` feature with `ed25519-salty` being recommended.

--- a/embassy-usb-dfu/src/dfu.rs
+++ b/embassy-usb-dfu/src/dfu.rs
@@ -18,7 +18,7 @@ pub struct Control<'d, DFU: NorFlash, STATE: NorFlash, RST: Reset, const BLOCK_S
     status: Status,
     offset: usize,
     buf: AlignedBuffer<BLOCK_SIZE>,
-    _rst: PhantomData<RST>,
+    reset: RST,
 
     #[cfg(feature = "_verify")]
     public_key: &'static [u8; 32],
@@ -29,6 +29,7 @@ impl<'d, DFU: NorFlash, STATE: NorFlash, RST: Reset, const BLOCK_SIZE: usize> Co
     pub fn new(
         updater: BlockingFirmwareUpdater<'d, DFU, STATE>,
         attrs: DfuAttributes,
+        reset: RST,
         #[cfg(feature = "_verify")] public_key: &'static [u8; 32],
     ) -> Self {
         Self {
@@ -38,7 +39,7 @@ impl<'d, DFU: NorFlash, STATE: NorFlash, RST: Reset, const BLOCK_SIZE: usize> Co
             status: Status::Ok,
             offset: 0,
             buf: AlignedBuffer([0; BLOCK_SIZE]),
-            _rst: PhantomData,
+            reset,
 
             #[cfg(feature = "_verify")]
             public_key,

--- a/embassy-usb-dfu/src/dfu.rs
+++ b/embassy-usb-dfu/src/dfu.rs
@@ -38,8 +38,10 @@ impl<'d, DFU: NorFlash, STATE: NorFlash, RST: Reset, const BLOCK_SIZE: usize> Co
             status: Status::Ok,
             offset: 0,
             buf: AlignedBuffer([0; BLOCK_SIZE]),
-            public_key,
             _rst: PhantomData,
+
+            #[cfg(feature = "_verify")]
+            public_key,
         }
     }
 

--- a/examples/boot/application/stm32wb-dfu/Cargo.toml
+++ b/examples/boot/application/stm32wb-dfu/Cargo.toml
@@ -12,7 +12,7 @@ embassy-stm32 = { version = "0.2.0", path = "../../../../embassy-stm32", feature
 embassy-boot-stm32 = { version = "0.2.0", path = "../../../../embassy-boot-stm32", features = [] }
 embassy-embedded-hal = { version = "0.3.0", path = "../../../../embassy-embedded-hal" }
 embassy-usb = { version = "0.4.0", path = "../../../../embassy-usb" }
-embassy-usb-dfu = { version = "0.1.0", path = "../../../../embassy-usb-dfu", features = ["application", "cortex-m"] }
+embassy-usb-dfu = { version = "0.1.1", path = "../../../../embassy-usb-dfu", features = ["application", "cortex-m"] }
 
 defmt = { version = "0.3", optional = true }
 defmt-rtt = { version = "0.4", optional = true }

--- a/examples/boot/bootloader/stm32wb-dfu-verify/Cargo.toml
+++ b/examples/boot/bootloader/stm32wb-dfu-verify/Cargo.toml
@@ -1,0 +1,63 @@
+[package]
+edition = "2021"
+name = "stm32wb-dfu-verify-bootloader-example"
+version = "0.1.0"
+description = "Example USB DFUbootloader for the STM32WB series of chips"
+license = "MIT OR Apache-2.0"
+
+[dependencies]
+defmt = { version = "0.3", optional = true }
+defmt-rtt = { version = "0.4", optional = true }
+
+embassy-stm32 = { path = "../../../../embassy-stm32", features = [""] }
+embassy-boot-stm32 = { path = "../../../../embassy-boot-stm32" }
+cortex-m = { version = "0.7.6", features = ["inline-asm", "critical-section-single-core"] }
+embassy-sync = { version = "0.6.2", path = "../../../../embassy-sync" }
+cortex-m-rt = { version = "0.7" }
+embedded-storage = "0.3.1"
+embedded-storage-async = "0.4.0"
+cfg-if = "1.0.0"
+embassy-usb-dfu = { version = "0.1.0", path = "../../../../embassy-usb-dfu", features = ["dfu", "cortex-m", "ed25519-salty"] }
+embassy-usb = { version = "0.4.0", path = "../../../../embassy-usb", default-features = false }
+embassy-futures = { version = "0.1.1", path = "../../../../embassy-futures" }
+
+[features]
+defmt = [
+    "dep:defmt",
+    "dep:defmt-rtt",
+    "embassy-boot-stm32/defmt",
+    "embassy-stm32/defmt",
+    "embassy-usb/defmt",
+    "embassy-usb-dfu/defmt"
+]
+
+[profile.dev]
+debug = 2
+debug-assertions = true
+incremental = false
+opt-level = 'z'
+overflow-checks = true
+
+[profile.release]
+codegen-units = 1
+debug = 2
+debug-assertions = false
+incremental = false
+lto = 'fat'
+opt-level = 'z'
+overflow-checks = false
+
+# do not optimize proc-macro crates = faster builds from scratch
+[profile.dev.build-override]
+codegen-units = 8
+debug = false
+debug-assertions = false
+opt-level = 0
+overflow-checks = false
+
+[profile.release.build-override]
+codegen-units = 8
+debug = false
+debug-assertions = false
+opt-level = 0
+overflow-checks = false

--- a/examples/boot/bootloader/stm32wb-dfu-verify/Cargo.toml
+++ b/examples/boot/bootloader/stm32wb-dfu-verify/Cargo.toml
@@ -9,15 +9,22 @@ license = "MIT OR Apache-2.0"
 defmt = { version = "0.3", optional = true }
 defmt-rtt = { version = "0.4", optional = true }
 
-embassy-stm32 = { path = "../../../../embassy-stm32", features = [""] }
+embassy-stm32 = { path = "../../../../embassy-stm32", features = [] }
 embassy-boot-stm32 = { path = "../../../../embassy-boot-stm32" }
-cortex-m = { version = "0.7.6", features = ["inline-asm", "critical-section-single-core"] }
+cortex-m = { version = "0.7.6", features = [
+    "inline-asm",
+    "critical-section-single-core",
+] }
 embassy-sync = { version = "0.6.2", path = "../../../../embassy-sync" }
 cortex-m-rt = { version = "0.7" }
 embedded-storage = "0.3.1"
 embedded-storage-async = "0.4.0"
 cfg-if = "1.0.0"
-embassy-usb-dfu = { version = "0.1.0", path = "../../../../embassy-usb-dfu", features = ["dfu", "cortex-m", "ed25519-salty"] }
+embassy-usb-dfu = { version = "0.1.1", path = "../../../../embassy-usb-dfu", features = [
+    "dfu",
+    "cortex-m",
+    "ed25519-salty",
+] }
 embassy-usb = { version = "0.4.0", path = "../../../../embassy-usb", default-features = false }
 embassy-futures = { version = "0.1.1", path = "../../../../embassy-futures" }
 
@@ -28,7 +35,7 @@ defmt = [
     "embassy-boot-stm32/defmt",
     "embassy-stm32/defmt",
     "embassy-usb/defmt",
-    "embassy-usb-dfu/defmt"
+    "embassy-usb-dfu/defmt",
 ]
 
 [profile.dev]

--- a/examples/boot/bootloader/stm32wb-dfu-verify/README.md
+++ b/examples/boot/bootloader/stm32wb-dfu-verify/README.md
@@ -1,0 +1,37 @@
+# Bootloader for STM32
+
+This bootloader implementation uses `embassy-boot` and `embassy-usb-dfu` to manage firmware updates and interact with the flash memory on STM32WB55 devices.
+
+## Prerequisites
+
+- Rust toolchain with `cargo` installed
+- `cargo-flash` for flashing the bootloader
+- `dfu-util` for firmware updates
+- `cargo-binutils` for binary generation
+
+## Usage
+
+### 1. Flash the Bootloader
+
+First, flash the bootloader to your device:
+
+```
+cargo flash --features embassy-stm32/stm32wb55rg --release --chip STM32WB55RGVx
+```
+
+### 2. Build and Flash Application
+
+Generate your application binary and flash it using DFU:
+
+```
+cargo objcopy --release -- -O binary fw.bin
+dfu-util -d c0de:cafe -w -D fw.bin
+```
+
+## Troubleshooting
+
+- Make sure your device is in DFU mode before flashing
+- Verify the USB VID:PID matches your device (c0de:cafe)
+- Check USB connections if the device is not detected
+- Make sure the transfer size option of `dfu-util` matches the bootloader configuration. By default, `dfu-util` will use the transfer size reported by the device, but you can override it with the `-t` option if needed.
+- Make sure `control_buf` size is larger than or equal to the `usb_dfu` `BLOCK_SIZE` parameter (in this example, both are set to 4096 bytes).

--- a/examples/boot/bootloader/stm32wb-dfu-verify/build.rs
+++ b/examples/boot/bootloader/stm32wb-dfu-verify/build.rs
@@ -1,0 +1,27 @@
+use std::env;
+use std::fs::File;
+use std::io::Write;
+use std::path::PathBuf;
+
+fn main() {
+    // Put `memory.x` in our output directory and ensure it's
+    // on the linker search path.
+    let out = &PathBuf::from(env::var_os("OUT_DIR").unwrap());
+    File::create(out.join("memory.x"))
+        .unwrap()
+        .write_all(include_bytes!("memory.x"))
+        .unwrap();
+    println!("cargo:rustc-link-search={}", out.display());
+
+    // By default, Cargo will re-run a build script whenever
+    // any file in the project changes. By specifying `memory.x`
+    // here, we ensure the build script is only re-run when
+    // `memory.x` is changed.
+    println!("cargo:rerun-if-changed=memory.x");
+
+    println!("cargo:rustc-link-arg-bins=--nmagic");
+    println!("cargo:rustc-link-arg-bins=-Tlink.x");
+    if env::var("CARGO_FEATURE_DEFMT").is_ok() {
+        println!("cargo:rustc-link-arg-bins=-Tdefmt.x");
+    }
+}

--- a/examples/boot/bootloader/stm32wb-dfu-verify/memory.x
+++ b/examples/boot/bootloader/stm32wb-dfu-verify/memory.x
@@ -1,3 +1,10 @@
+/* 
+N.B. this memory map is different from the standard stm32wb-dfu example since the
+verification code requires more bootloader space. Thus, to use this bootloader
+example together with the standard "application" example, you would need to update
+memory.x for the application to match this memory map.
+*/
+
 MEMORY
 {
   /* NOTE 1 K = 1 KiBi = 1024 bytes */

--- a/examples/boot/bootloader/stm32wb-dfu-verify/memory.x
+++ b/examples/boot/bootloader/stm32wb-dfu-verify/memory.x
@@ -1,0 +1,18 @@
+MEMORY
+{
+  /* NOTE 1 K = 1 KiBi = 1024 bytes */
+  FLASH                             : ORIGIN = 0x08000000, LENGTH = 48K
+  BOOTLOADER_STATE                  : ORIGIN = 0x0800C000, LENGTH = 4K
+  ACTIVE                            : ORIGIN = 0x0800D000, LENGTH = 120K
+  DFU                               : ORIGIN = 0x0802B000, LENGTH = 120K
+  RAM                         (rwx) : ORIGIN = 0x20000000, LENGTH = 16K
+}
+
+__bootloader_state_start = ORIGIN(BOOTLOADER_STATE) - ORIGIN(FLASH);
+__bootloader_state_end = ORIGIN(BOOTLOADER_STATE) + LENGTH(BOOTLOADER_STATE) - ORIGIN(FLASH);
+
+__bootloader_active_start = ORIGIN(ACTIVE) - ORIGIN(FLASH);
+__bootloader_active_end = ORIGIN(ACTIVE) + LENGTH(ACTIVE) - ORIGIN(FLASH);
+
+__bootloader_dfu_start = ORIGIN(DFU) - ORIGIN(FLASH);
+__bootloader_dfu_end = ORIGIN(DFU) + LENGTH(DFU) - ORIGIN(FLASH);

--- a/examples/boot/bootloader/stm32wb-dfu-verify/src/key.pub
+++ b/examples/boot/bootloader/stm32wb-dfu-verify/src/key.pub
@@ -1,0 +1,1 @@
+#3kÒöê‚vJŸ;hÀtS­ob¦tÆÄPX©Tš˜Œ

--- a/examples/boot/bootloader/stm32wb-dfu-verify/src/main.rs
+++ b/examples/boot/bootloader/stm32wb-dfu-verify/src/main.rs
@@ -62,7 +62,7 @@ fn main() -> ! {
         let mut config_descriptor = [0; 256];
         let mut bos_descriptor = [0; 256];
         let mut control_buf = [0; 4096];
-        let mut state = Control::new(updater, DfuAttributes::CAN_DOWNLOAD, PUBLIC_SIGNING_KEY);
+        let mut state = Control::new(updater, DfuAttributes::CAN_DOWNLOAD, ResetImmediate, PUBLIC_SIGNING_KEY);
         let mut builder = Builder::new(
             driver,
             config,

--- a/examples/boot/bootloader/stm32wb-dfu-verify/src/main.rs
+++ b/examples/boot/bootloader/stm32wb-dfu-verify/src/main.rs
@@ -1,0 +1,113 @@
+#![no_std]
+#![no_main]
+
+use core::cell::RefCell;
+
+use cortex_m_rt::{entry, exception};
+#[cfg(feature = "defmt")]
+use defmt_rtt as _;
+use embassy_boot_stm32::*;
+use embassy_stm32::flash::{Flash, BANK1_REGION, WRITE_SIZE};
+use embassy_stm32::rcc::WPAN_DEFAULT;
+use embassy_stm32::usb::Driver;
+use embassy_stm32::{bind_interrupts, peripherals, usb};
+use embassy_sync::blocking_mutex::Mutex;
+use embassy_usb::{msos, Builder};
+use embassy_usb_dfu::consts::DfuAttributes;
+use embassy_usb_dfu::{usb_dfu, Control, ResetImmediate};
+
+bind_interrupts!(struct Irqs {
+    USB_LP => usb::InterruptHandler<peripherals::USB>;
+});
+
+// This is a randomly generated GUID to allow clients on Windows to find our device.
+//
+// N.B. Please replace with your own!
+const DEVICE_INTERFACE_GUIDS: &[&str] = &["{EAA9A5DC-30BA-44BC-9232-606CDC875321}"];
+
+// This is a randomly generated example key.
+//
+// N.B. Please replace with your own!
+static PUBLIC_SIGNING_KEY: &[u8; 32] = include_bytes!("key.pub");
+
+#[entry]
+fn main() -> ! {
+    let mut config = embassy_stm32::Config::default();
+    config.rcc = WPAN_DEFAULT;
+    let p = embassy_stm32::init(config);
+
+    // Prevent a hard fault when accessing flash 'too early' after boot.
+    #[cfg(feature = "defmt")]
+    for _ in 0..10000000 {
+        cortex_m::asm::nop();
+    }
+
+    let layout = Flash::new_blocking(p.FLASH).into_blocking_regions();
+    let flash = Mutex::new(RefCell::new(layout.bank1_region));
+
+    let config = BootLoaderConfig::from_linkerfile_blocking(&flash, &flash, &flash);
+    let active_offset = config.active.offset();
+    let bl = BootLoader::prepare::<_, _, _, 2048>(config);
+    if bl.state == State::DfuDetach {
+        let driver = Driver::new(p.USB, Irqs, p.PA12, p.PA11);
+        let mut config = embassy_usb::Config::new(0xc0de, 0xcafe);
+        config.manufacturer = Some("Embassy");
+        config.product = Some("USB-DFU Bootloader example");
+        config.serial_number = Some("1235678");
+
+        let fw_config = FirmwareUpdaterConfig::from_linkerfile_blocking(&flash, &flash);
+        let mut buffer = AlignedBuffer([0; WRITE_SIZE]);
+        let updater = BlockingFirmwareUpdater::new(fw_config, &mut buffer.0[..]);
+
+        let mut config_descriptor = [0; 256];
+        let mut bos_descriptor = [0; 256];
+        let mut control_buf = [0; 4096];
+        let mut state = Control::new(updater, DfuAttributes::CAN_DOWNLOAD, PUBLIC_SIGNING_KEY);
+        let mut builder = Builder::new(
+            driver,
+            config,
+            &mut config_descriptor,
+            &mut bos_descriptor,
+            &mut [],
+            &mut control_buf,
+        );
+
+        // We add MSOS headers so that the device automatically gets assigned the WinUSB driver on Windows.
+        // Otherwise users need to do this manually using a tool like Zadig.
+        //
+        // It seems it is important for the DFU class that these headers be on the Device level.
+        //
+        builder.msos_descriptor(msos::windows_version::WIN8_1, 2);
+        builder.msos_feature(msos::CompatibleIdFeatureDescriptor::new("WINUSB", ""));
+        builder.msos_feature(msos::RegistryPropertyFeatureDescriptor::new(
+            "DeviceInterfaceGUIDs",
+            msos::PropertyData::RegMultiSz(DEVICE_INTERFACE_GUIDS),
+        ));
+
+        usb_dfu::<_, _, _, ResetImmediate, 4096>(&mut builder, &mut state);
+
+        let mut dev = builder.build();
+        embassy_futures::block_on(dev.run());
+    }
+
+    unsafe { bl.load(BANK1_REGION.base + active_offset) }
+}
+
+#[no_mangle]
+#[cfg_attr(target_os = "none", link_section = ".HardFault.user")]
+unsafe extern "C" fn HardFault() {
+    cortex_m::peripheral::SCB::sys_reset();
+}
+
+#[exception]
+unsafe fn DefaultHandler(_: i16) -> ! {
+    const SCB_ICSR: *const u32 = 0xE000_ED04 as *const u32;
+    let irqn = core::ptr::read_volatile(SCB_ICSR) as u8 as i16 - 16;
+
+    panic!("DefaultHandler #{:?}", irqn);
+}
+
+#[panic_handler]
+fn panic(_info: &core::panic::PanicInfo) -> ! {
+    cortex_m::asm::udf();
+}

--- a/examples/boot/bootloader/stm32wb-dfu/Cargo.toml
+++ b/examples/boot/bootloader/stm32wb-dfu/Cargo.toml
@@ -17,7 +17,7 @@ cortex-m-rt = { version = "0.7" }
 embedded-storage = "0.3.1"
 embedded-storage-async = "0.4.0"
 cfg-if = "1.0.0"
-embassy-usb-dfu = { version = "0.1.0", path = "../../../../embassy-usb-dfu", features = ["dfu", "cortex-m"] }
+embassy-usb-dfu = { version = "0.1.1", path = "../../../../embassy-usb-dfu", features = ["dfu", "cortex-m"] }
 embassy-usb = { version = "0.4.0", path = "../../../../embassy-usb", default-features = false }
 embassy-futures = { version = "0.1.1", path = "../../../../embassy-futures" }
 

--- a/examples/boot/bootloader/stm32wb-dfu/src/main.rs
+++ b/examples/boot/bootloader/stm32wb-dfu/src/main.rs
@@ -20,7 +20,9 @@ bind_interrupts!(struct Irqs {
     USB_LP => usb::InterruptHandler<peripherals::USB>;
 });
 
-// This is a randomly generated GUID to allow clients on Windows to find our device
+// This is a randomly generated GUID to allow clients on Windows to find our device.
+//
+// N.B. Please replace with your own!
 const DEVICE_INTERFACE_GUIDS: &[&str] = &["{EAA9A5DC-30BA-44BC-9232-606CDC875321}"];
 
 #[entry]


### PR DESCRIPTION
This PR makes the ed25519-based verification support offered by `embassy-boot` available for use in `embassy-usb-dfu`. This will allow devices offering update support via USB DFU to verify that updates are correctly signed before installing them. Additionally, the PR adds an example showing how to use this new feature.