### PR TITLE
Added USB core_id 0x1000 for STM32

### DIFF
--- a/embassy-stm32/src/usb/otg.rs
+++ b/embassy-stm32/src/usb/otg.rs
@@ -335,7 +335,7 @@ impl<'d, T: Instance> Bus<'d, T> {
 
         // Configuring Vbus sense and SOF output
         match core_id {
-            0x0000_1200 | 0x0000_1100 => self.inner.config_v1(),
+            0x0000_1200 | 0x0000_1100 | 0x0000_1000 => self.inner.config_v1(),
             0x0000_2000 | 0x0000_2100 | 0x0000_2300 | 0x0000_3000 | 0x0000_3100 => self.inner.config_v2v3(),
             0x0000_5000 => self.inner.config_v5(),
             _ => unimplemented!("Unknown USB core id {:X}", core_id),


### PR DESCRIPTION
I've been using a STM32F107RC for a project and I wanted to use the USB OTG that it has, but the core id that the microcontroller returned was 0x1000. I tested it out in the PCB and works.

Thanks