### PR TITLE
STM32 CAN: Make `data()` return correct length slice

### DIFF
--- a/embassy-stm32/src/can/bxcan/registers.rs
+++ b/embassy-stm32/src/can/bxcan/registers.rs
@@ -299,9 +299,9 @@ impl Registers {
         mb.tdtr().write(|w| w.set_dlc(frame.header().len() as u8));
 
         mb.tdlr()
-            .write(|w| w.0 = u32::from_ne_bytes(unwrap!(frame.data()[0..4].try_into())));
+            .write(|w| w.0 = u32::from_ne_bytes(unwrap!(frame.raw_data()[0..4].try_into())));
         mb.tdhr()
-            .write(|w| w.0 = u32::from_ne_bytes(unwrap!(frame.data()[4..8].try_into())));
+            .write(|w| w.0 = u32::from_ne_bytes(unwrap!(frame.raw_data()[4..8].try_into())));
         let id: IdReg = frame.id().into();
         mb.tir().write(|w| {
             w.0 = id.0;

--- a/embassy-stm32/src/can/fd/peripheral.rs
+++ b/embassy-stm32/src/can/fd/peripheral.rs
@@ -190,7 +190,7 @@ impl Registers {
                 DataLength::Fdcan(len) => len,
                 DataLength::Classic(len) => len,
             };
-            if len as usize > ClassicData::MAX_DATA_LEN {
+            if len as usize > 8 {
                 return None;
             }
 

--- a/embassy-stm32/src/can/fd/peripheral.rs
+++ b/embassy-stm32/src/can/fd/peripheral.rs
@@ -75,7 +75,7 @@ impl Registers {
         let mailbox = self.tx_buffer_element(bufidx);
         mailbox.reset();
         put_tx_header(mailbox, header);
-        put_tx_data(mailbox, &buffer[..header.len() as usize]);
+        put_tx_data(mailbox, buffer);
 
         // Set <idx as Mailbox> as ready to transmit
         self.regs.txbar().modify(|w| w.set_ar(bufidx, true));

--- a/embassy-stm32/src/can/frame.rs
+++ b/embassy-stm32/src/can/frame.rs
@@ -212,6 +212,11 @@ impl Frame {
         &self.data.raw()[..self.can_header.len as usize]
     }
 
+    /// Get reference to underlying 8-byte raw data buffer
+    pub(crate) fn raw_data(&self) -> &[u8] {
+        self.data.raw()
+    }
+
     /// Get mutable reference to data
     pub fn data_mut(&mut self) -> &mut [u8] {
         &mut self.data.raw_mut()[..self.can_header.len as usize]

--- a/embassy-stm32/src/can/frame.rs
+++ b/embassy-stm32/src/can/frame.rs
@@ -104,15 +104,13 @@ pub trait CanHeader: Sized {
 #[derive(Debug, Copy, Clone)]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub struct ClassicData {
-    pub(crate) bytes: [u8; Self::MAX_DATA_LEN],
+    pub(crate) bytes: [u8; 8],
 }
 
 impl ClassicData {
-    pub(crate) const MAX_DATA_LEN: usize = 8;
     /// Creates a data payload from a raw byte slice.
     ///
-    /// Returns `None` if `data` is more than 64 bytes (which is the maximum) or
-    /// cannot be represented with an FDCAN DLC.
+    /// Returns `FrameCreateError` if `data` is more than 8 bytes (which is the maximum).
     pub fn new(data: &[u8]) -> Result<Self, FrameCreateError> {
         if data.len() > 8 {
             return Err(FrameCreateError::InvalidDataLength);
@@ -211,12 +209,12 @@ impl Frame {
 
     /// Get reference to data
     pub fn data(&self) -> &[u8] {
-        &self.data.raw()
+        &self.data.raw()[..self.can_header.len as usize]
     }
 
     /// Get mutable reference to data
     pub fn data_mut(&mut self) -> &mut [u8] {
-        self.data.raw_mut()
+        &mut self.data.raw_mut()[..self.can_header.len as usize]
     }
 
     /// Get priority of frame
@@ -260,7 +258,7 @@ impl embedded_can::Frame for Frame {
         self.can_header.len as usize
     }
     fn data(&self) -> &[u8] {
-        &self.data.raw()
+        &self.data()
     }
 }
 
@@ -405,12 +403,12 @@ impl FdFrame {
 
     /// Get reference to data
     pub fn data(&self) -> &[u8] {
-        &self.data.raw()
+        &self.data.raw()[..self.can_header.len as usize]
     }
 
     /// Get mutable reference to data
     pub fn data_mut(&mut self) -> &mut [u8] {
-        self.data.raw_mut()
+        &mut self.data.raw_mut()[..self.can_header.len as usize]
     }
 }
 
@@ -448,7 +446,7 @@ impl embedded_can::Frame for FdFrame {
         self.can_header.len as usize
     }
     fn data(&self) -> &[u8] {
-        &self.data.raw()
+        &self.data()
     }
 }
 

--- a/embassy-stm32/src/opamp.rs
+++ b/embassy-stm32/src/opamp.rs
@@ -435,11 +435,13 @@ impl<'d, T: Instance> OpAmp<'d, T> {
 
             T::regs().csr().modify(|w| match pair {
                 OpAmpDifferentialPair::P => {
-                    defmt::info!("p calibration. offset: {}", mid);
+                    #[cfg(feature = "defmt")]
+                    defmt::debug!("opamp p calibration. offset: {}", mid);
                     w.set_trimoffsetp(mid);
                 }
                 OpAmpDifferentialPair::N => {
-                    defmt::info!("n calibration. offset: {}", mid);
+                    #[cfg(feature = "defmt")]
+                    defmt::debug!("opamp n calibration. offset: {}", mid);
                     w.set_trimoffsetn(mid);
                 }
             });


### PR DESCRIPTION
Currently `data()` always returns an 8- or 64-byte slice, even though the actual CAN frame contains less data. The remaining bytes will be zero, so the user must check the frame DLC to see how many bytes were actually sent by the remote end. With this change the slice is the same length as was transmitted, with no extra bytes.

Additionally removed the `ClassicData::MAX_DATA_LEN` constant because almost all instances were using a hardcoded `8` anyway, and the `FdData` only ever uses `64` and doesn't have an equivalent `MAX_DATA_LEN`. Happy to make everything use `MAX_DATA_LEN` instead if that's preferred.

Finally fixed a missing cfg gate on a defmt call that broke the build on G4 without defmt feature.