### PR TITLE
Derive `Clone` for `hash::Context`

### DIFF
--- a/embassy-stm32/src/hash/mod.rs
+++ b/embassy-stm32/src/hash/mod.rs
@@ -101,6 +101,7 @@ pub enum DataType {
 
 /// Stores the state of the HASH peripheral for suspending/resuming
 /// digest calculation.
+#[derive(Clone)]
 pub struct Context<'c> {
     first_word_sent: bool,
     key_sent: bool,


### PR DESCRIPTION
The HASH accelerator on STM32 microcontrollers can be used for HMAC if a key is provided. One significant use case of HMAC is as a PRF for the PBKDF2 algorithm, but this requires that the hashing state can be recursively "branched" multiple times.

Implementing `Clone` on `hash::Context` makes this use case possible.