### PR TITLE
pwm: enable pull-down resistors for pins in Drop implementation

### DIFF
--- a/embassy-rp/src/pwm.rs
+++ b/embassy-rp/src/pwm.rs
@@ -464,6 +464,10 @@ impl<'d> Drop for Pwm<'d> {
         pac::PWM.ch(self.slice).csr().write_clear(|w| w.set_en(false));
         if let Some(pin) = &self.pin_a {
             pin.gpio().ctrl().write(|w| w.set_funcsel(31));
+            // Enable pin PULL-DOWN
+            pin.pad_ctrl().modify(|w| {
+                w.set_pde(true);
+            });
         }
         if let Some(pin) = &self.pin_b {
             pin.gpio().ctrl().write(|w| w.set_funcsel(31));
@@ -471,6 +475,10 @@ impl<'d> Drop for Pwm<'d> {
             // Disable input mode. Only pin_b can be input, so not needed for pin_a
             pin.pad_ctrl().modify(|w| {
                 w.set_ie(false);
+            });
+            // Enable pin PULL-DOWN
+            pin.pad_ctrl().modify(|w| {
+                w.set_pde(true);
             });
         }
     }


### PR DESCRIPTION
Adresses #3615, appling a fix written by @vivi202 (I can take no credits!)

I could not reproduce the issue, but the reasoning behind the fix seems plausible. I tested the change by setting up and dropping Pwm, which to me behaves as expected.

After setting up and 50% duty cycle:
![image](https://github.com/user-attachments/assets/6ccfbab1-326d-4839-b1fb-eb2336288d44)

After dropping:
![image](https://github.com/user-attachments/assets/7f686c8f-01b5-46ec-bac1-28e293b24517)
