### PR TITLE
Fix STM32H7 SpiDeviceWithConfig does not properly apply the config

### DIFF
--- a/embassy-stm32/src/spi/mod.rs
+++ b/embassy-stm32/src/spi/mod.rs
@@ -284,6 +284,10 @@ impl<'d, M: PeriMode> Spi<'d, M> {
 
         #[cfg(any(spi_v3, spi_v4, spi_v5))]
         {
+            self.info.regs.cr1().modify(|w| {
+                w.set_spe(false);
+            });
+
             self.info.regs.cfg2().modify(|w| {
                 w.set_cpha(cpha);
                 w.set_cpol(cpol);
@@ -291,6 +295,10 @@ impl<'d, M: PeriMode> Spi<'d, M> {
             });
             self.info.regs.cfg1().modify(|w| {
                 w.set_mbr(br);
+            });
+
+            self.info.regs.cr1().modify(|w| {
+                w.set_spe(true);
             });
         }
         Ok(())


### PR DESCRIPTION
The new SPI configuration applied when using SpiDeviceWithConfig did previously not get applied as the SPI had to be disabled and re-enabled for it to have an effect. This is implemented by this PR and should resolve the issue.

It has been tested and is working on an STM32U5 which displayed the same problem that the STM32H7 has as described in #2259.

Closes #2259