### PR TITLE
Add function to allow re-init rcc config for stm32

### DIFF
--- a/embassy-stm32/src/lib.rs
+++ b/embassy-stm32/src/lib.rs
@@ -213,6 +213,7 @@ macro_rules! bind_interrupts {
 
 // Reexports
 pub use _generated::{peripherals, Peripherals};
+use critical_section::CriticalSection;
 pub use embassy_hal_internal::{Peri, PeripheralType};
 #[cfg(feature = "unstable-pac")]
 pub use stm32_metapac as pac;
@@ -222,7 +223,6 @@ pub(crate) use stm32_metapac as pac;
 use crate::interrupt::Priority;
 #[cfg(feature = "rt")]
 pub use crate::pac::NVIC_PRIO_BITS;
-use critical_section::CriticalSection;
 
 /// `embassy-stm32` global configuration.
 #[non_exhaustive]

--- a/embassy-stm32/src/lib.rs
+++ b/embassy-stm32/src/lib.rs
@@ -213,7 +213,6 @@ macro_rules! bind_interrupts {
 
 // Reexports
 pub use _generated::{peripherals, Peripherals};
-use critical_section::CriticalSection;
 pub use embassy_hal_internal::{Peri, PeripheralType};
 #[cfg(feature = "unstable-pac")]
 pub use stm32_metapac as pac;
@@ -601,38 +600,9 @@ fn init_hw(config: Config) -> Peripherals {
             #[cfg(feature = "exti")]
             exti::init(cs);
 
-            init_rcc(cs, config.rcc);
+            rcc::init_rcc(cs, config.rcc);
         }
 
         p
     })
-}
-
-/// Re-initialize the `embassy-stm32` clock configuration with the provided configuration.
-///
-/// This is useful when you need to alter the CPU clock after configuring peripherals.
-/// For instance, configure an external clock via spi or i2c.
-///
-/// Please not this only re-configures the rcc and the time driver (not GPIO, EXTI, etc).
-///
-/// This should only be called after `init`.
-#[cfg(not(feature = "_dual-core"))]
-pub fn reinit(config: rcc::Config) {
-    critical_section::with(|cs| init_rcc(cs, config))
-}
-
-fn init_rcc(_cs: CriticalSection, config: rcc::Config) {
-    unsafe {
-        rcc::init(config);
-
-        // must be after rcc init
-        #[cfg(feature = "_time-driver")]
-        time_driver::init(_cs);
-
-        #[cfg(feature = "low-power")]
-        {
-            crate::rcc::REFCOUNT_STOP2 = 0;
-            crate::rcc::REFCOUNT_STOP1 = 0;
-        }
-    }
 }

--- a/embassy-stm32/src/lib.rs
+++ b/embassy-stm32/src/lib.rs
@@ -617,7 +617,6 @@ fn init_hw(config: Config) -> Peripherals {
     })
 }
 
-
 /// Re-initialize the `embassy-stm32` clock configuration with the provided configuration.
 ///
 /// This is useful when you need to alter the CPU clock after configuring peripherals.

--- a/embassy-stm32/src/lib.rs
+++ b/embassy-stm32/src/lib.rs
@@ -627,13 +627,13 @@ fn init_hw(config: Config) -> Peripherals {
 /// This should only be called after `init`.
 #[cfg(not(feature = "_dual-core"))]
 pub fn reinitialize_rcc(config: Config) {
-    critical_section::with(|cs| {
+    critical_section::with(|_cs| {
         unsafe {
             rcc::init(config.rcc);
 
             // must be after rcc init
             #[cfg(feature = "_time-driver")]
-            time_driver::init(cs);
+            time_driver::init(_cs);
 
             #[cfg(feature = "low-power")]
             {

--- a/embassy-stm32/src/lib.rs
+++ b/embassy-stm32/src/lib.rs
@@ -213,7 +213,6 @@ macro_rules! bind_interrupts {
 
 // Reexports
 pub use _generated::{peripherals, Peripherals};
-#[cfg(not(feature = "_dual-core"))]
 use critical_section::CriticalSection;
 pub use embassy_hal_internal::{Peri, PeripheralType};
 #[cfg(feature = "unstable-pac")]
@@ -622,7 +621,6 @@ pub fn reinit(config: rcc::Config) {
     critical_section::with(|cs| init_rcc(cs, config))
 }
 
-#[cfg(not(feature = "_dual-core"))]
 fn init_rcc(_cs: CriticalSection, config: rcc::Config) {
     unsafe {
         rcc::init(config);

--- a/embassy-stm32/src/lib.rs
+++ b/embassy-stm32/src/lib.rs
@@ -213,6 +213,7 @@ macro_rules! bind_interrupts {
 
 // Reexports
 pub use _generated::{peripherals, Peripherals};
+#[cfg(not(feature = "_dual-core"))]
 use critical_section::CriticalSection;
 pub use embassy_hal_internal::{Peri, PeripheralType};
 #[cfg(feature = "unstable-pac")]

--- a/embassy-stm32/src/rcc/mod.rs
+++ b/embassy-stm32/src/rcc/mod.rs
@@ -384,7 +384,7 @@ pub fn reinit(config: Config) {
     critical_section::with(|cs| init_rcc(cs, config))
 }
 
-fn init_rcc(_cs: CriticalSection, config: Config) {
+pub(crate) fn init_rcc(_cs: CriticalSection, config: Config) {
     unsafe {
         init(config);
 

--- a/embassy-stm32/src/rcc/mod.rs
+++ b/embassy-stm32/src/rcc/mod.rs
@@ -34,7 +34,6 @@ pub use _version::*;
 use stm32_metapac::RCC;
 
 pub use crate::_generated::{mux, Clocks};
-use crate::rcc;
 use crate::time::Hertz;
 
 #[cfg(feature = "low-power")]


### PR DESCRIPTION
I had a need to configure an external clock generator and then switch to it which means I needed to call init and then configure RCC.
After som input from the matrix chat this is what I came up with.

Not sure if this makes sense, and I did not find any test so I have not added tests.
Might make sense to add an example but as a meaningful example would require a specific external clock generator I am unsure how to proceed but it would be possible to add:

```rust
#[embassy_executor::main]
async fn main(_spawner: Spawner) {
    let p = embassy_stm32::init(Default::default());

    // Configure the external clock here

    let mut config = Config::default();
    {
        use embassy_stm32::rcc::*;
        config.rcc.hse = Some(Hse {
            freq: mhz(8),
            mode: HseMode::Bypass,
        });
        config.rcc.pll = Some(Pll {
            src: PllSource::HSE,
            prediv: PllPreDiv::DIV1,
            mul: PllMul::MUL9,
        });
        config.rcc.sys = Sysclk::PLL1_P;
        config.rcc.ahb_pre = AHBPrescaler::DIV1;
        config.rcc.apb1_pre = APBPrescaler::DIV2;
        config.rcc.apb2_pre = APBPrescaler::DIV1;
    }
    embassy_stm32::reinitialize_rcc(config);

    info!("end program");
}
```