### PR TITLE
[embassy-rp] Add disable and enable tx and rx functions for UART

### DIFF
--- a/embassy-rp/src/uart/buffered.rs
+++ b/embassy-rp/src/uart/buffered.rs
@@ -134,6 +134,26 @@ impl<'d, T: Instance> BufferedUart<'d, T> {
         }
     }
 
+    /// Disable the UART receiver, if disabled in the middle of a reception, it will complete the current character
+    pub fn disable_rx(&mut self) {
+        UartRx::<'d, T, Async>::disable_inner();
+    }
+
+    /// Enable the UART receiver
+    pub fn enable_rx(&mut self) {
+        UartRx::<'d, T, Async>::enable_inner();
+    }
+
+    /// Disable the UART transmitter, if disabled in the middle of a transmission, it will complete the current character
+    pub fn disable_tx(&mut self) {
+        UartTx::<'d, T, Async>::disable_inner();
+    }
+
+    /// Enable the UART transmitter
+    pub fn enable_tx(&mut self) {
+        UartTx::<'d, T, Async>::enable_inner();
+    }
+
     /// Write to UART TX buffer blocking execution until done.
     pub fn blocking_write(&mut self, buffer: &[u8]) -> Result<usize, Error> {
         self.tx.blocking_write(buffer)

--- a/embassy-rp/src/uart/mod.rs
+++ b/embassy-rp/src/uart/mod.rs
@@ -171,6 +171,24 @@ impl<'d, T: Instance, M: Mode> UartTx<'d, T, M> {
         }
     }
 
+    fn disable_inner() {
+        T::regs().uartcr().modify(|t| t.set_txe(false));
+    }
+
+    fn enable_inner() {
+        T::regs().uartcr().modify(|t| t.set_txe(true));
+    }
+
+    /// Disable the UART transmitter, if disabled in the middle of a transmission, it will complete the current character
+    pub fn disable(&mut self) {
+        Self::disable_inner();
+    }
+
+    /// Enable the UART transmitter
+    pub fn enable(&mut self) {
+        Self::enable_inner();
+    }
+
     /// Transmit the provided buffer blocking execution until done.
     pub fn blocking_write(&mut self, buffer: &[u8]) -> Result<(), Error> {
         let r = T::regs();
@@ -284,6 +302,24 @@ impl<'d, T: Instance, M: Mode> UartRx<'d, T, M> {
             rx_dma,
             phantom: PhantomData,
         }
+    }
+
+    fn disable_inner() {
+        T::regs().uartcr().modify(|t| t.set_rxe(false));
+    }
+
+    fn enable_inner() {
+        T::regs().uartcr().modify(|t| t.set_rxe(true));
+    }
+
+    /// Disable the UART receiver, if disabled in the middle of a reception, it will complete the current character
+    pub fn disable(&mut self) {
+        Self::disable_inner();
+    }
+
+    /// Enable the UART receiver
+    pub fn enable(&mut self) {
+        Self::enable_inner();
     }
 
     /// Read from UART RX blocking execution until done.
@@ -1007,6 +1043,26 @@ impl<'d, T: Instance + 'd, M: Mode> Uart<'d, T, M> {
 }
 
 impl<'d, T: Instance, M: Mode> Uart<'d, T, M> {
+    /// Disable the UART receiver, if disabled in the middle of a reception, it will complete the current character
+    pub fn disable_rx(&mut self) {
+        UartRx::<'d, T, M>::disable_inner();
+    }
+
+    /// Enable the UART receiver
+    pub fn enable_rx(&mut self) {
+        UartRx::<'d, T, M>::enable_inner();
+    }
+
+    /// Disable the UART transmitter, if disabled in the middle of a transmission, it will complete the current character
+    pub fn disable_tx(&mut self) {
+        UartTx::<'d, T, M>::disable_inner();
+    }
+
+    /// Enable the UART transmitter
+    pub fn enable_tx(&mut self) {
+        UartTx::<'d, T, M>::enable_inner();
+    }
+
     /// Transmit the provided buffer blocking execution until done.
     pub fn blocking_write(&mut self, buffer: &[u8]) -> Result<(), Error> {
         self.tx.blocking_write(buffer)

--- a/examples/rp/src/bin/uart_rs485.rs
+++ b/examples/rp/src/bin/uart_rs485.rs
@@ -1,0 +1,62 @@
+//! This example shows how to use UART (Universal asynchronous receiver-transmitter) in the RP2040 chip.
+//!
+//! No specific hardware is specified in this example. Only output on pin 0 and pin 2, and input on pin 1 is tested.
+//! The Raspberry Pi Debug Probe (https://www.raspberrypi.com/products/debug-probe/) could be used
+//! with its UART port.
+
+#![no_std]
+#![no_main]
+
+use defmt::*;
+use embassy_executor::Spawner;
+use embassy_rp::bind_interrupts;
+use embassy_rp::gpio::{Level, Output};
+use embassy_rp::peripherals::UART0;
+use embassy_rp::uart::{BufferedInterruptHandler, BufferedUart, Config};
+use embedded_io_async::{Read, Write};
+use static_cell::StaticCell;
+use {defmt_rtt as _, panic_probe as _};
+
+static TX_BUF: StaticCell<[u8; 32]> = StaticCell::new();
+static RX_BUF: StaticCell<[u8; 32]> = StaticCell::new();
+
+bind_interrupts!(struct Irqs {
+    UART0_IRQ => BufferedInterruptHandler<UART0>;
+});
+
+#[embassy_executor::main]
+async fn main(_spawner: Spawner) {
+    let p = embassy_rp::init(Default::default());
+    let config = Config::default();
+    let mut uart = BufferedUart::new(
+        p.UART0,
+        p.PIN_0,
+        p.PIN_1,
+        Irqs,
+        TX_BUF.init([0; 32]),
+        RX_BUF.init([0; 32]),
+        config,
+    );
+    let mut data_enable = Output::new(p.PIN_2, Level::Low);
+
+    loop {
+        // When using a UART with an RS485 bus, often a transceiver is used which has a DE/nRE pin.
+        // Setting this DE/nRE pin high to allow transmitting data, could cause the RX pin to go low depending on the chip and hardware used.
+        // When done transmitting data and setting the DE/nRE pin low, the RX pin would go up again which will trigger a break condition in the UART receiver.
+        // This can be prevented by temporarily disabling the receiver of the UART, roughly as follows:
+        uart.disable_rx();
+        data_enable.set_high();
+
+        uart.write_all("hello there!\r\n".as_bytes()).await.unwrap();
+
+        data_enable.set_low();
+        uart.enable_rx();
+
+        let mut buf = [0; 16];
+        uart.read(&mut buf).await.unwrap();
+
+        info!("Rx: {:?}", buf);
+
+        cortex_m::asm::delay(1_000_000);
+    }
+}


### PR DESCRIPTION
When writing some Modbus code on top of the RP2040 UART I encountered break and framing errors. I traced this back to the fact that my hardware pulls down the RX pin whenever I am transmitting data.

The UART peripheral has support for disabling RX or TX without influencing the other. It seemed like a good addition to make this available.

I thought about creating a type that freezes the UartRx or UartTx so you cannot have it disabled and try to receive or send respectively but could not figure it out since I am still learning rust.

Also, it is my first PR here so some guidance might be necessary, thanks for that!