### PR TITLE
Update opamp code to current stm32-metapac

### DIFF
--- a/embassy-stm32/Cargo.toml
+++ b/embassy-stm32/Cargo.toml
@@ -73,7 +73,7 @@ rand_core = "0.6.3"
 sdio-host = "0.9.0"
 critical-section = "1.1"
 #stm32-metapac = { version = "16" }
-stm32-metapac = { git = "https://github.com/embassy-rs/stm32-data-generated", tag = "stm32-data-380f03cb71f43a242adc45e83607a380ffe0447b" }
+stm32-metapac = { git = "https://github.com/embassy-rs/stm32-data-generated", tag = "stm32-data-9385c0824aff194913a2eab3c957791d0de06771" }
 
 vcell = "0.1.3"
 nb = "1.0.0"
@@ -102,7 +102,7 @@ proc-macro2 = "1.0.36"
 quote = "1.0.15"
 
 #stm32-metapac = { version = "16", default-features = false, features = ["metadata"]}
-stm32-metapac = { git = "https://github.com/embassy-rs/stm32-data-generated", tag = "stm32-data-380f03cb71f43a242adc45e83607a380ffe0447b", default-features = false, features = ["metadata"] }
+stm32-metapac = { git = "https://github.com/embassy-rs/stm32-data-generated", tag = "stm32-data-9385c0824aff194913a2eab3c957791d0de06771", default-features = false, features = ["metadata"] }
 
 [features]
 default = ["rt"]

--- a/embassy-stm32/src/adc/mod.rs
+++ b/embassy-stm32/src/adc/mod.rs
@@ -11,7 +11,7 @@
 #[cfg_attr(adc_v1, path = "v1.rs")]
 #[cfg_attr(adc_l0, path = "v1.rs")]
 #[cfg_attr(adc_v2, path = "v2.rs")]
-#[cfg_attr(any(adc_v3, adc_g0, adc_h5, adc_u0), path = "v3.rs")]
+#[cfg_attr(any(adc_v3, adc_g0, adc_h5, adc_h7rs, adc_u0), path = "v3.rs")]
 #[cfg_attr(any(adc_v4, adc_u5), path = "v4.rs")]
 #[cfg_attr(adc_g4, path = "g4.rs")]
 #[cfg_attr(adc_c0, path = "c0.rs")]
@@ -108,6 +108,7 @@ pub(crate) fn blocking_delay_us(us: u32) {
     adc_g0,
     adc_u0,
     adc_h5,
+    adc_h7rs,
     adc_u5,
     adc_c0
 )))]
@@ -129,6 +130,7 @@ pub trait Instance: SealedInstance + crate::PeripheralType {
     adc_g0,
     adc_u0,
     adc_h5,
+    adc_h7rs,
     adc_u5,
     adc_c0
 ))]

--- a/embassy-stm32/src/adc/v3.rs
+++ b/embassy-stm32/src/adc/v3.rs
@@ -19,7 +19,7 @@ impl<T: Instance> SealedAdcChannel<T> for VrefInt {
         cfg_if! {
             if #[cfg(adc_g0)] {
                 let val = 13;
-            } else if #[cfg(adc_h5)] {
+            } else if #[cfg(any(adc_h5, adc_h7rs))] {
                 let val = 17;
             } else if #[cfg(adc_u0)] {
                 let val = 12;
@@ -38,7 +38,7 @@ impl<T: Instance> SealedAdcChannel<T> for Temperature {
         cfg_if! {
             if #[cfg(adc_g0)] {
                 let val = 12;
-            } else if #[cfg(adc_h5)] {
+            } else if #[cfg(any(adc_h5, adc_h7rs))] {
                 let val = 16;
             } else if #[cfg(adc_u0)] {
                 let val = 11;
@@ -57,9 +57,9 @@ impl<T: Instance> SealedAdcChannel<T> for Vbat {
         cfg_if! {
             if #[cfg(adc_g0)] {
                 let val = 14;
-            } else if #[cfg(adc_h5)] {
+            } else if #[cfg(any(adc_h5, adc_h7rs))] {
                 let val = 2;
-            } else if #[cfg(adc_h5)] {
+            } else if #[cfg(any(adc_h5, adc_h7rs))] {
                 let val = 13;
             } else {
                 let val = 18;
@@ -70,7 +70,7 @@ impl<T: Instance> SealedAdcChannel<T> for Vbat {
 }
 
 cfg_if! {
-    if #[cfg(adc_h5)] {
+    if #[cfg(any(adc_h5, adc_h7rs))] {
         pub struct VddCore;
         impl<T: Instance> AdcChannel<T> for VddCore {}
         impl<T: Instance> super::SealedAdcChannel<T> for VddCore {
@@ -171,7 +171,7 @@ impl<'d, T: Instance> Adc<'d, T> {
                 T::regs().ccr().modify(|reg| {
                     reg.set_tsen(true);
                 });
-            } else if #[cfg(adc_h5)] {
+            } else if #[cfg(any(adc_h5, adc_h7rs))] {
                 T::common_regs().ccr().modify(|reg| {
                     reg.set_tsen(true);
                 });
@@ -191,7 +191,7 @@ impl<'d, T: Instance> Adc<'d, T> {
                 T::regs().ccr().modify(|reg| {
                     reg.set_vbaten(true);
                 });
-            } else if #[cfg(adc_h5)] {
+            } else if #[cfg(any(adc_h5, adc_h7rs))] {
                 T::common_regs().ccr().modify(|reg| {
                     reg.set_vbaten(true);
                 });
@@ -414,7 +414,7 @@ impl<'d, T: Instance> Adc<'d, T> {
     fn configure_channel(channel: &mut impl AdcChannel<T>, sample_time: SampleTime) {
         // RM0492, RM0481, etc.
         // "This option bit must be set to 1 when ADCx_INP0 or ADCx_INN1 channel is selected."
-        #[cfg(adc_h5)]
+        #[cfg(any(adc_h5, adc_h7rs))]
         if channel.channel() == 0 {
             T::regs().or().modify(|reg| reg.set_op0(true));
         }
@@ -447,7 +447,7 @@ impl<'d, T: Instance> Adc<'d, T> {
 
         // RM0492, RM0481, etc.
         // "This option bit must be set to 1 when ADCx_INP0 or ADCx_INN1 channel is selected."
-        #[cfg(adc_h5)]
+        #[cfg(any(adc_h5, adc_h7rs))]
         if channel.channel() == 0 {
             T::regs().or().modify(|reg| reg.set_op0(false));
         }
@@ -475,7 +475,7 @@ impl<'d, T: Instance> Adc<'d, T> {
             if #[cfg(any(adc_g0, adc_u0))] {
                 // On G0 and U6 all channels use the same sampling time.
                 T::regs().smpr().modify(|reg| reg.set_smp1(sample_time.into()));
-            } else if #[cfg(adc_h5)] {
+            } else if #[cfg(any(adc_h5, adc_h7rs))] {
                 match _ch {
                     0..=9 => T::regs().smpr1().modify(|w| w.set_smp(_ch as usize % 10, sample_time.into())),
                     _ => T::regs().smpr2().modify(|w| w.set_smp(_ch as usize % 10, sample_time.into())),


### PR DESCRIPTION
Some trivial enums have been removed from the OpAmp API in stm32-metapac, this PR updates the HAL accordingly.