### PR TITLE
[embassy-rp] Rewrite PIO onewire implementation

### DIFF
--- a/embassy-rp/src/pio_programs/onewire.rs
+++ b/embassy-rp/src/pio_programs/onewire.rs
@@ -12,7 +12,6 @@ pub struct PioOneWireProgram<'a, PIO: Instance> {
     prg: LoadedProgram<'a, PIO>,
     reset_addr: u8,
     next_bit_addr: u8,
-    search_addr: u8,
 }
 
 impl<'a, PIO: Instance> PioOneWireProgram<'a, PIO> {
@@ -53,35 +52,17 @@ impl<'a, PIO: Instance> PioOneWireProgram<'a, PIO> {
                     ; The low pulse was already done, we only need to delay and poll the bit in case we are reading
                     write_1:
                         nop                     side 0 [( 6 / CLK) - 1]     ; Delay before sampling the input pin
-                        in pins, 1              side 0 [(54 / CLK) - 1]     ; This writes the state of the pin into the ISR
+                        in pins, 1              side 0 [(48 / CLK) - 1]     ; This writes the state of the pin into the ISR
                         ; Fallthrough
 
                 ; This is the entry point when reading and writing data
                 public next_bit:
                     .wrap_target
-                        out x, 1                side 0 [(18 / CLK) - 1]     ; Stalls if no data available in TX FIFO and OSR
-                        jmp x--, write_1        side 1 [(12 / CLK) - 1]     ; Do the always low part of a bit, jump to write_1 if we want to write a 1 bit
-                        in null, 1              side 1 [(60 / CLK) - 1]     ; Do the remainder of the low part of a 0 bit
+                        out x, 1                side 0 [(12 / CLK) - 1]     ; Stalls if no data available in TX FIFO and OSR
+                        jmp x--, write_1        side 1 [( 6 / CLK) - 1]     ; Do the always low part of a bit, jump to write_1 if we want to write a 1 bit
+                        in null, 1              side 1 [(54 / CLK) - 1]     ; Do the remainder of the low part of a 0 bit
                                                                             ; This writes 0 into the ISR so that the shift count stays in sync
                     .wrap
-
-                public search:
-                        set x, 1                side 0 [(78 / CLK) - 1]     ; Set x to 1 for the inner loop
-                    search_inner:
-                    ; Read 2 bits
-                        nop                     side 1 [(12 / CLK) - 1]     ; Do the always low part of a bit
-                        nop                     side 0 [( 6 / CLK) - 1]     ; Delay before sampling the input pin
-                        in pins, 1              side 0 [(54 / CLK) - 1]     ; This writes the state of the pin into the ISR
-                        jmp x--, search_inner   side 0 [(18 / CLK) - 1]
-                        ; Fallthrough
-
-                    ; Write output
-                        out x, 1                side 0 [( 6 / CLK) - 1]     ; Stalls if no data available in TX FIFO and OSR
-                        jmp x--, search         side 1 [(12 / CLK) - 1]     ; Do the always low part of a bit, jump to search to write a 1 bit
-                        ; Fallthrough
-
-                        set x, 1                side 1 [(60 / CLK) - 1]     ; Set x to 1 for the inner loop, write the remainder of the low part of a 0 bit
-                        jmp search_inner        side 0 [(18 / CLK) - 1]
             "#
         );
 
@@ -89,7 +70,6 @@ impl<'a, PIO: Instance> PioOneWireProgram<'a, PIO> {
             prg: common.load_program(&prg.program),
             reset_addr: prg.public_defines.reset as u8,
             next_bit_addr: prg.public_defines.next_bit as u8,
-            search_addr: prg.public_defines.search as u8,
         }
     }
 }
@@ -98,7 +78,6 @@ pub struct PioOneWire<'d, PIO: Instance, const SM: usize> {
     sm: StateMachine<'d, PIO, SM>,
     cfg: Config<'d, PIO>,
     reset_addr: u8,
-    search_addr: u8,
     next_bit_addr: u8,
 }
 
@@ -119,13 +98,16 @@ impl<'d, PIO: Instance, const SM: usize> PioOneWire<'d, PIO, SM> {
         cfg.use_program(&program.prg, &[&pin]);
         cfg.set_in_pins(&[&pin]);
 
-        let byte_shift = ShiftConfig {
+        cfg.shift_in = ShiftConfig {
             auto_fill: true,
             direction: ShiftDirection::Right,
             threshold: 8,
         };
-        cfg.shift_in = byte_shift;
-        cfg.shift_out = byte_shift;
+        cfg.shift_out = ShiftConfig {
+            auto_fill: true,
+            direction: ShiftDirection::Right,
+            threshold: 8,
+        };
 
         let divider = (clk_sys_freq() / 1000000) as u16 * 6;
         cfg.clock_divider = divider.into();
@@ -142,11 +124,11 @@ impl<'d, PIO: Instance, const SM: usize> PioOneWire<'d, PIO, SM> {
             sm,
             cfg,
             reset_addr: program.reset_addr,
-            search_addr: program.search_addr,
             next_bit_addr: program.next_bit_addr,
         }
     }
 
+    /// Perform an initialization sequence, will return true if a presence pulse was detected from a device
     pub async fn reset(&mut self) -> bool {
         // The state machine immediately starts running when jumping to this address
         unsafe {
@@ -164,18 +146,18 @@ impl<'d, PIO: Instance, const SM: usize> PioOneWire<'d, PIO, SM> {
         found
     }
 
-    /// Write bytes over the wire
+    /// Write bytes to the onewire bus
     pub async fn write_bytes(&mut self, data: &[u8]) {
         let (rx, tx) = self.sm.rx_tx();
         for b in data {
             tx.wait_push(*b as u32).await;
 
-            // Empty the buffer that is always filled
+            // Empty the buffer that is being filled with every write
             let _ = rx.wait_pull().await;
         }
     }
 
-    /// Read bytes from the wire
+    /// Read bytes from the onewire bus
     pub async fn read_bytes(&mut self, data: &mut [u8]) {
         let (rx, tx) = self.sm.rx_tx();
         for b in data {
@@ -187,19 +169,29 @@ impl<'d, PIO: Instance, const SM: usize> PioOneWire<'d, PIO, SM> {
     }
 
     async fn search(&mut self, state: &mut PioOneWireSearch) -> Option<u64> {
-        let _ = self.reset().await;
-        self.write_bytes(&[0xF0]).await;
+        if !self.reset().await {
+            // No device present, no use in searching
+            state.finished = true;
+            return None;
+        }
+        self.write_bytes(&[0xF0]).await; // 0xF0 is the search rom command
 
-        let shift_cfg = self.prepare_search();
+        self.prepare_search();
 
         let (rx, tx) = self.sm.rx_tx();
 
-        let mut value = 0u64;
+        let mut value = 0;
         let mut last_zero = 0;
 
         for bit in 0..64 {
-            let push = match rx.wait_pull().await {
-                0b00 => {
+            // Write 2 dummy bits to read a bit and its complement
+            tx.wait_push(0x1).await;
+            tx.wait_push(0x1).await;
+            let in1 = rx.wait_pull().await;
+            let in2 = rx.wait_pull().await;
+            let push = match (in1, in2) {
+                (0, 0) => {
+                    // If both are 0, it means we have devices with 0 and 1 bits in this position
                     let write_value = if bit < state.last_discrepancy {
                         (state.last_rom & (1 << bit)) != 0
                     } else {
@@ -213,10 +205,11 @@ impl<'d, PIO: Instance, const SM: usize> PioOneWire<'d, PIO, SM> {
                         0
                     }
                 }
-                0b01 => 0,
-                0b10 => 1,
+                (0, 1) => 0, // Only devices with a 0 bit in this position
+                (1, 0) => 1, // Only devices with a 1 bit in this position
                 _ => {
-                    self.restore_after_search(&shift_cfg);
+                    // If both are 1, it means there is no device active and there is no point in continuing
+                    self.restore_after_search();
                     state.finished = true;
                     return None;
                 }
@@ -226,9 +219,10 @@ impl<'d, PIO: Instance, const SM: usize> PioOneWire<'d, PIO, SM> {
                 value |= 1 << 63;
             }
             tx.wait_push(push).await;
+            let _ = rx.wait_pull().await; // Discard the result of the write action
         }
 
-        self.restore_after_search(&shift_cfg);
+        self.restore_after_search();
 
         state.last_discrepancy = last_zero;
         state.finished = last_zero == 0;
@@ -236,44 +230,42 @@ impl<'d, PIO: Instance, const SM: usize> PioOneWire<'d, PIO, SM> {
         Some(value)
     }
 
-    fn prepare_search(&mut self) -> ShiftConfig {
-        let shift_cfg = self.cfg.shift_in;
-        self.cfg.shift_in = ShiftConfig {
-            auto_fill: true,
-            direction: ShiftDirection::Left,
-            threshold: 2,
-        };
-        self.cfg.shift_out = ShiftConfig {
-            auto_fill: true,
-            direction: ShiftDirection::Right,
-            threshold: 1,
-        };
+    fn prepare_search(&mut self) {
+        self.cfg.shift_in.threshold = 1;
+        self.cfg.shift_in.direction = ShiftDirection::Left;
+        self.cfg.shift_out.threshold = 1;
 
         self.sm.set_enable(false);
         self.sm.set_config(&self.cfg);
 
-        unsafe {
-            self.sm.exec_jmp(self.search_addr);
-        }
-        self.sm.set_enable(true);
-        shift_cfg
-    }
-
-    fn restore_after_search(&mut self, cfg: &ShiftConfig) {
-        self.cfg.shift_in = *cfg;
-        self.cfg.shift_out = *cfg;
-
-        self.sm.set_enable(false);
-        self.sm.set_config(&self.cfg);
+        // set_config jumps to the wrong address so jump to the right one here
         unsafe {
             self.sm.exec_jmp(self.next_bit_addr);
         }
+        self.sm.set_enable(true);
+    }
+
+    fn restore_after_search(&mut self) {
+        self.cfg.shift_in.threshold = 8;
+        self.cfg.shift_in.direction = ShiftDirection::Right;
+        self.cfg.shift_out.threshold = 8;
+
+        self.sm.set_enable(false);
+        self.sm.set_config(&self.cfg);
+
+        // Clear the state in case we aborted prematurely with some bits still in the shift registers
         self.sm.clear_fifos();
         self.sm.restart();
+
+        // set_config jumps to the wrong address so jump to the right one here
+        unsafe {
+            self.sm.exec_jmp(self.next_bit_addr);
+        }
         self.sm.set_enable(true);
     }
 }
 
+/// Onewire search state
 pub struct PioOneWireSearch {
     last_rom: u64,
     last_discrepancy: u8,
@@ -281,6 +273,7 @@ pub struct PioOneWireSearch {
 }
 
 impl PioOneWireSearch {
+    /// Create a new Onewire search state
     pub fn new() -> Self {
         Self {
             last_rom: 0,
@@ -289,6 +282,7 @@ impl PioOneWireSearch {
         }
     }
 
+    /// Search for the next address on the bus
     pub async fn next<PIO: Instance, const SM: usize>(&mut self, pio: &mut PioOneWire<'_, PIO, SM>) -> Option<u64> {
         if self.finished {
             None
@@ -297,6 +291,7 @@ impl PioOneWireSearch {
         }
     }
 
+    /// Is finished when all devices have been found
     pub fn is_finished(&self) -> bool {
         self.finished
     }

--- a/embassy-rp/src/pio_programs/onewire.rs
+++ b/embassy-rp/src/pio_programs/onewire.rs
@@ -27,8 +27,9 @@ impl<'a, PIO: Instance> PioOneWireProgram<'a, PIO> {
                 .origin 0
 
                 ; Tick rate is 1 tick per 6us, so all delays should be calculated back to that
-                ; All the instructions have a calculated delay in [], -1 for the instruction
-                ; The delay also be 0 which will take 6us for the instruction itself
+                ; All the instructions have a calculated delay XX in us as [(XX / CLK) - 1].
+                ; The - 1 is for the instruction which also takes one clock cyle.
+                ; The delay can be 0 which will result in just 6us for the instruction itself
                 .define CLK 6
 
                 ; Write the reset block after trigger
@@ -98,16 +99,13 @@ impl<'d, PIO: Instance, const SM: usize> PioOneWire<'d, PIO, SM> {
         cfg.use_program(&program.prg, &[&pin]);
         cfg.set_in_pins(&[&pin]);
 
-        cfg.shift_in = ShiftConfig {
+        let shift_cfg = ShiftConfig {
             auto_fill: true,
             direction: ShiftDirection::Right,
             threshold: 8,
         };
-        cfg.shift_out = ShiftConfig {
-            auto_fill: true,
-            direction: ShiftDirection::Right,
-            threshold: 8,
-        };
+        cfg.shift_in = shift_cfg;
+        cfg.shift_out = shift_cfg;
 
         let divider = (clk_sys_freq() / 1000000) as u16 * 6;
         cfg.clock_divider = divider.into();

--- a/embassy-rp/src/pio_programs/onewire.rs
+++ b/embassy-rp/src/pio_programs/onewire.rs
@@ -1,11 +1,18 @@
 //! OneWire pio driver
 
-use crate::pio::{Common, Config, Instance, LoadedProgram, PioPin, ShiftConfig, ShiftDirection, StateMachine};
+use crate::clocks::clk_sys_freq;
+use crate::gpio::Level;
+use crate::pio::{
+    Common, Config, Direction, Instance, LoadedProgram, PioPin, ShiftConfig, ShiftDirection, StateMachine,
+};
 use crate::Peri;
 
-/// This struct represents an onewire driver program
+/// This struct represents a onewire driver program
 pub struct PioOneWireProgram<'a, PIO: Instance> {
     prg: LoadedProgram<'a, PIO>,
+    reset_addr: u8,
+    next_bit_addr: u8,
+    search_addr: u8,
 }
 
 impl<'a, PIO: Instance> PioOneWireProgram<'a, PIO> {
@@ -13,56 +20,86 @@ impl<'a, PIO: Instance> PioOneWireProgram<'a, PIO> {
     pub fn new(common: &mut Common<'a, PIO>) -> Self {
         let prg = pio::pio_asm!(
             r#"
-                .wrap_target
-                    again:
-                        pull block
-                        mov x, osr
-                        jmp !x, read
-                        write:
-                            set pindirs, 1 
-                            set pins, 0  
-                            loop1: 
-                                jmp x--,loop1
-                            set pindirs, 0 [31]
-                            wait 1 pin 0 [31]
-                            pull block
-                            mov x, osr
-                            bytes1:
-                                pull block
-                                set y, 7    
-                                set pindirs, 1 
-                                bit1:
-                                    set pins, 0 [1]
-                                    out pins,1 [31]
-                                    set pins, 1 [20]
-                                    jmp y--,bit1
-                                jmp x--,bytes1
-                            set pindirs, 0 [31]
-                            jmp again
-                        read:
-                            pull block
-                            mov x, osr
-                            bytes2:
-                                set y, 7
-                                bit2:
-                                    set pindirs, 1 
-                                    set pins, 0 [1]  
-                                    set pindirs, 0 [5]
-                                    in pins,1 [10]   
-                                    jmp y--,bit2
-                            jmp x--,bytes2
-                .wrap
-            "#,
-        );
-        let prg = common.load_program(&prg.program);
+                ; We need to use the pins direction to simulate open drain output
+                ; This results in all the side-set values being swapped from the actual pin value
+                .side_set 1 pindirs
 
-        Self { prg }
+                ; Set the origin to 0 so we can correctly use jmp instructions externally
+                .origin 0
+
+                ; Tick rate is 1 tick per 6us, so all delays should be calculated back to that
+                ; All the instructions have a calculated delay in [], -1 for the instruction
+                ; The delay also be 0 which will take 6us for the instruction itself
+                .define CLK 6
+
+                ; Write the reset block after trigger
+                public reset:
+                        set x, 4                side 0 [(60 / CLK) - 1]     ; idle before reset
+                    reset_inner:                                            ; Repeat the following 5 times, so 5*96us = 480us in total
+                        nop                     side 1 [(90 / CLK) - 1]
+                        jmp x--, reset_inner    side 1 [( 6 / CLK) - 1]
+                        ; Fallthrough
+
+                    ; Check for presence of one or more devices.
+                    ; This samples 32 times with an interval of 12us after a 18us delay.
+                    ; If any bit is zero in the end value, there is a detection
+                    ; This whole function takes 480us
+                        set x, 31               side 0 [(24 / CLK) - 1]     ; Loop 32 times -> 32*12us = 384us
+                    presence_check:
+                        in pins, 1              side 0 [( 6 / CLK) - 1]     ; poll pin and push to isr
+                        jmp x--, presence_check side 0 [( 6 / CLK) - 1]
+                        jmp next_bit            side 0 [(72 / CLK) - 1]
+
+                    ; The low pulse was already done, we only need to delay and poll the bit in case we are reading
+                    write_1:
+                        nop                     side 0 [( 6 / CLK) - 1]     ; Delay before sampling the input pin
+                        in pins, 1              side 0 [(54 / CLK) - 1]     ; This writes the state of the pin into the ISR
+                        ; Fallthrough
+
+                ; This is the entry point when reading and writing data
+                public next_bit:
+                    .wrap_target
+                        out x, 1                side 0 [(18 / CLK) - 1]     ; Stalls if no data available in TX FIFO and OSR
+                        jmp x--, write_1        side 1 [(12 / CLK) - 1]     ; Do the always low part of a bit, jump to write_1 if we want to write a 1 bit
+                        in null, 1              side 1 [(60 / CLK) - 1]     ; Do the remainder of the low part of a 0 bit
+                                                                            ; This writes 0 into the ISR so that the shift count stays in sync
+                    .wrap
+
+                public search:
+                        set x, 1                side 0 [(78 / CLK) - 1]     ; Set x to 1 for the inner loop
+                    search_inner:
+                    ; Read 2 bits
+                        nop                     side 1 [(12 / CLK) - 1]     ; Do the always low part of a bit
+                        nop                     side 0 [( 6 / CLK) - 1]     ; Delay before sampling the input pin
+                        in pins, 1              side 0 [(54 / CLK) - 1]     ; This writes the state of the pin into the ISR
+                        jmp x--, search_inner   side 0 [(18 / CLK) - 1]
+                        ; Fallthrough
+
+                    ; Write output
+                        out x, 1                side 0 [( 6 / CLK) - 1]     ; Stalls if no data available in TX FIFO and OSR
+                        jmp x--, search         side 1 [(12 / CLK) - 1]     ; Do the always low part of a bit, jump to search to write a 1 bit
+                        ; Fallthrough
+
+                        set x, 1                side 1 [(60 / CLK) - 1]     ; Set x to 1 for the inner loop, write the remainder of the low part of a 0 bit
+                        jmp search_inner        side 0 [(18 / CLK) - 1]
+            "#
+        );
+
+        Self {
+            prg: common.load_program(&prg.program),
+            reset_addr: prg.public_defines.reset as u8,
+            next_bit_addr: prg.public_defines.next_bit as u8,
+            search_addr: prg.public_defines.search as u8,
+        }
     }
 }
-
 /// Pio backed OneWire driver
 pub struct PioOneWire<'d, PIO: Instance, const SM: usize> {
     sm: StateMachine<'d, PIO, SM>,
+    cfg: Config<'d, PIO>,
+    reset_addr: u8,
+    search_addr: u8,
+    next_bit_addr: u8,
 }
 
 impl<'d, PIO: Instance, const SM: usize> PioOneWire<'d, PIO, SM> {
@@ -74,37 +111,193 @@ impl<'d, PIO: Instance, const SM: usize> PioOneWire<'d, PIO, SM> {
         program: &PioOneWireProgram<'d, PIO>,
     ) -> Self {
         let pin = common.make_pio_pin(pin);
+
+        sm.set_pin_dirs(Direction::In, &[&pin]);
+        sm.set_pins(Level::Low, &[&pin]);
+
         let mut cfg = Config::default();
-        cfg.use_program(&program.prg, &[]);
-        cfg.set_out_pins(&[&pin]);
+        cfg.use_program(&program.prg, &[&pin]);
         cfg.set_in_pins(&[&pin]);
-        cfg.set_set_pins(&[&pin]);
-        cfg.shift_in = ShiftConfig {
+
+        let byte_shift = ShiftConfig {
             auto_fill: true,
             direction: ShiftDirection::Right,
             threshold: 8,
         };
-        cfg.clock_divider = 255_u8.into();
+        cfg.shift_in = byte_shift;
+        cfg.shift_out = byte_shift;
+
+        let divider = (clk_sys_freq() / 1000000) as u16 * 6;
+        cfg.clock_divider = divider.into();
+
         sm.set_config(&cfg);
+        sm.clear_fifos();
+        sm.restart();
+        unsafe {
+            sm.exec_jmp(program.next_bit_addr);
+        }
         sm.set_enable(true);
-        Self { sm }
+
+        Self {
+            sm,
+            cfg,
+            reset_addr: program.reset_addr,
+            search_addr: program.search_addr,
+            next_bit_addr: program.next_bit_addr,
+        }
+    }
+
+    pub async fn reset(&mut self) -> bool {
+        // The state machine immediately starts running when jumping to this address
+        unsafe {
+            self.sm.exec_jmp(self.reset_addr);
+        }
+
+        let rx = self.sm.rx();
+        let mut found = false;
+        for _ in 0..4 {
+            if rx.wait_pull().await != 0 {
+                found = true;
+            }
+        }
+
+        found
     }
 
     /// Write bytes over the wire
-    pub async fn write_bytes(&mut self, bytes: &[u8]) {
-        self.sm.tx().wait_push(250).await;
-        self.sm.tx().wait_push(bytes.len() as u32 - 1).await;
-        for b in bytes {
-            self.sm.tx().wait_push(*b as u32).await;
+    pub async fn write_bytes(&mut self, data: &[u8]) {
+        let (rx, tx) = self.sm.rx_tx();
+        for b in data {
+            tx.wait_push(*b as u32).await;
+
+            // Empty the buffer that is always filled
+            let _ = rx.wait_pull().await;
         }
     }
 
     /// Read bytes from the wire
-    pub async fn read_bytes(&mut self, bytes: &mut [u8]) {
-        self.sm.tx().wait_push(0).await;
-        self.sm.tx().wait_push(bytes.len() as u32 - 1).await;
-        for b in bytes.iter_mut() {
-            *b = (self.sm.rx().wait_pull().await >> 24) as u8;
+    pub async fn read_bytes(&mut self, data: &mut [u8]) {
+        let (rx, tx) = self.sm.rx_tx();
+        for b in data {
+            // Write all 1's so that we can read what the device responds
+            tx.wait_push(0xff).await;
+
+            *b = (rx.wait_pull().await >> 24) as u8;
         }
+    }
+
+    async fn search(&mut self, state: &mut PioOneWireSearch) -> Option<u64> {
+        let _ = self.reset().await;
+        self.write_bytes(&[0xF0]).await;
+
+        let shift_cfg = self.prepare_search();
+
+        let (rx, tx) = self.sm.rx_tx();
+
+        let mut value = 0u64;
+        let mut last_zero = 0;
+
+        for bit in 0..64 {
+            let push = match rx.wait_pull().await {
+                0b00 => {
+                    let write_value = if bit < state.last_discrepancy {
+                        (state.last_rom & (1 << bit)) != 0
+                    } else {
+                        bit == state.last_discrepancy
+                    };
+
+                    if write_value {
+                        1
+                    } else {
+                        last_zero = bit;
+                        0
+                    }
+                }
+                0b01 => 0,
+                0b10 => 1,
+                _ => {
+                    self.restore_after_search(&shift_cfg);
+                    state.finished = true;
+                    return None;
+                }
+            };
+            value >>= 1;
+            if push == 1 {
+                value |= 1 << 63;
+            }
+            tx.wait_push(push).await;
+        }
+
+        self.restore_after_search(&shift_cfg);
+
+        state.last_discrepancy = last_zero;
+        state.finished = last_zero == 0;
+        state.last_rom = value;
+        Some(value)
+    }
+
+    fn prepare_search(&mut self) -> ShiftConfig {
+        let shift_cfg = self.cfg.shift_in;
+        self.cfg.shift_in = ShiftConfig {
+            auto_fill: true,
+            direction: ShiftDirection::Left,
+            threshold: 2,
+        };
+        self.cfg.shift_out = ShiftConfig {
+            auto_fill: true,
+            direction: ShiftDirection::Right,
+            threshold: 1,
+        };
+
+        self.sm.set_enable(false);
+        self.sm.set_config(&self.cfg);
+
+        unsafe {
+            self.sm.exec_jmp(self.search_addr);
+        }
+        self.sm.set_enable(true);
+        shift_cfg
+    }
+
+    fn restore_after_search(&mut self, cfg: &ShiftConfig) {
+        self.cfg.shift_in = *cfg;
+        self.cfg.shift_out = *cfg;
+
+        self.sm.set_enable(false);
+        self.sm.set_config(&self.cfg);
+        unsafe {
+            self.sm.exec_jmp(self.next_bit_addr);
+        }
+        self.sm.clear_fifos();
+        self.sm.restart();
+        self.sm.set_enable(true);
+    }
+}
+
+pub struct PioOneWireSearch {
+    last_rom: u64,
+    last_discrepancy: u8,
+    finished: bool,
+}
+
+impl PioOneWireSearch {
+    pub fn new() -> Self {
+        Self {
+            last_rom: 0,
+            last_discrepancy: 0,
+            finished: false,
+        }
+    }
+
+    pub async fn next<PIO: Instance, const SM: usize>(&mut self, pio: &mut PioOneWire<'_, PIO, SM>) -> Option<u64> {
+        if self.finished {
+            None
+        } else {
+            pio.search(self).await
+        }
+    }
+
+    pub fn is_finished(&self) -> bool {
+        self.finished
     }
 }

--- a/examples/rp/src/bin/pio_onewire.rs
+++ b/examples/rp/src/bin/pio_onewire.rs
@@ -1,4 +1,4 @@
-//! This example shows how you can use PIO to read a `DS18B20` one-wire temperature sensor.
+//! This example shows how you can use PIO to read one or more `DS18B20` one-wire temperature sensors.
 
 #![no_std]
 #![no_main]
@@ -6,9 +6,10 @@ use defmt::*;
 use embassy_executor::Spawner;
 use embassy_rp::bind_interrupts;
 use embassy_rp::peripherals::PIO0;
-use embassy_rp::pio::{self, InterruptHandler, Pio};
-use embassy_rp::pio_programs::onewire::{PioOneWire, PioOneWireProgram};
+use embassy_rp::pio::{InterruptHandler, Pio};
+use embassy_rp::pio_programs::onewire::{PioOneWire, PioOneWireProgram, PioOneWireSearch};
 use embassy_time::Timer;
+use heapless::Vec;
 use {defmt_rtt as _, panic_probe as _};
 
 bind_interrupts!(struct Irqs {
@@ -21,63 +22,66 @@ async fn main(_spawner: Spawner) {
     let mut pio = Pio::new(p.PIO0, Irqs);
 
     let prg = PioOneWireProgram::new(&mut pio.common);
-    let onewire = PioOneWire::new(&mut pio.common, pio.sm0, p.PIN_2, &prg);
+    let mut onewire = PioOneWire::new(&mut pio.common, pio.sm0, p.PIN_2, &prg);
 
-    let mut sensor = Ds18b20::new(onewire);
+    info!("Starting onewire search");
+
+    let mut devices = Vec::<u64, 10>::new();
+    let mut search = PioOneWireSearch::new();
+    for _ in 0..10 {
+        if !search.is_finished() {
+            if let Some(address) = search.next(&mut onewire).await {
+                if crc8(&address.to_le_bytes()) == 0 {
+                    info!("Found addres: {:x}", address);
+                    let _ = devices.push(address);
+                } else {
+                    warn!("Found invalid address: {:x}", address);
+                }
+            }
+        }
+    }
+
+    info!("Search done, found {} devices", devices.len());
 
     loop {
-        sensor.start().await; // Start a new measurement
+        onewire.reset().await;
+        // Skip rom and trigger conversion, we can trigger all devices on the bus immediately
+        onewire.write_bytes(&[0xCC, 0x44]).await;
+
         Timer::after_secs(1).await; // Allow 1s for the measurement to finish
-        match sensor.temperature().await {
-            Ok(temp) => info!("temp = {:?} deg C", temp),
-            _ => error!("sensor error"),
+
+        // Read all devices one by one
+        for device in &devices {
+            onewire.reset().await;
+            onewire.write_bytes(&[0x55]).await; // Match rom
+            onewire.write_bytes(&device.to_le_bytes()).await;
+            onewire.write_bytes(&[0xBE]).await; // Read scratchpad
+
+            let mut data = [0; 9];
+            onewire.read_bytes(&mut data).await;
+            if crc8(&data) == 0 {
+                let temp = ((data[1] as u32) << 8 | data[0] as u32) as f32 / 16.;
+                info!("Read device {:x}: {} deg C", device, temp);
+            } else {
+                warn!("Reading device {:x} failed", device);
+            }
         }
         Timer::after_secs(1).await;
     }
 }
 
-/// DS18B20 temperature sensor driver
-pub struct Ds18b20<'d, PIO: pio::Instance, const SM: usize> {
-    wire: PioOneWire<'d, PIO, SM>,
-}
-
-impl<'d, PIO: pio::Instance, const SM: usize> Ds18b20<'d, PIO, SM> {
-    pub fn new(wire: PioOneWire<'d, PIO, SM>) -> Self {
-        Self { wire }
-    }
-
-    /// Calculate CRC8 of the data
-    fn crc8(data: &[u8]) -> u8 {
-        let mut temp;
-        let mut data_byte;
-        let mut crc = 0;
-        for b in data {
-            data_byte = *b;
-            for _ in 0..8 {
-                temp = (crc ^ data_byte) & 0x01;
-                crc >>= 1;
-                if temp != 0 {
-                    crc ^= 0x8C;
-                }
-                data_byte >>= 1;
+fn crc8(data: &[u8]) -> u8 {
+    let mut crc = 0;
+    for b in data {
+        let mut data_byte = *b;
+        for _ in 0..8 {
+            let temp = (crc ^ data_byte) & 0x01;
+            crc >>= 1;
+            if temp != 0 {
+                crc ^= 0x8C;
             }
-        }
-        crc
-    }
-
-    /// Start a new measurement. Allow at least 1000ms before getting `temperature`.
-    pub async fn start(&mut self) {
-        self.wire.write_bytes(&[0xCC, 0x44]).await;
-    }
-
-    /// Read the temperature. Ensure >1000ms has passed since `start` before calling this.
-    pub async fn temperature(&mut self) -> Result<f32, ()> {
-        self.wire.write_bytes(&[0xCC, 0xBE]).await;
-        let mut data = [0; 9];
-        self.wire.read_bytes(&mut data).await;
-        match Self::crc8(&data) == 0 {
-            true => Ok(((data[1] as u32) << 8 | data[0] as u32) as f32 / 16.),
-            false => Err(()),
+            data_byte >>= 1;
         }
     }
+    crc
 }


### PR DESCRIPTION
I encountered some issues testing the current implementation that led me to spent some time rewriting it.

This new implementation has a couple of improvements over the current one:
- It does not block if there is no device present on the bus
- It allows for better control when to perform a reset. The reset also performs the presence detection.
- There is a implementation of the search algorithm, this allows you to find addresses of the connected devices.
- The clock is now actually calculated based on the sys clock frequency

The only downside in my opinion is the unsafe calls to make the pio jump to the right instruction. But they should be safe since the state machine is disabled when performing the jumps.

Tested this with 0, 1 and 2 devices connected using the example program.