### PR TITLE
Dead-time computation in complementary PWM fixed

### DIFF
--- a/embassy-stm32/src/timer/complementary_pwm.rs
+++ b/embassy-stm32/src/timer/complementary_pwm.rs
@@ -300,7 +300,7 @@ mod tests {
             TestRun {
                 value: 400,
                 ckd: Ckd::DIV1,
-                bits: 32 + (400u16 / 8) as u8,
+                bits: 210,
             },
             TestRun {
                 value: 600,


### PR DESCRIPTION
Required DTG[7:5] bits added, tests also corrected