### PR TITLE
fix: atomic waker does not call wake on the existing waker when registering a new one

### DIFF
--- a/embassy-sync/src/waitqueue/atomic_waker.rs
+++ b/embassy-sync/src/waitqueue/atomic_waker.rs
@@ -22,6 +22,10 @@ impl<M: RawMutex> GenericAtomicWaker<M> {
         self.waker.lock(|cell| {
             cell.set(match cell.replace(None) {
                 Some(w2) if (w2.will_wake(w)) => Some(w2),
+                Some(w2) => {
+                    w2.wake();
+                    Some(w.clone())
+                }
                 _ => Some(w.clone()),
             })
         })


### PR DESCRIPTION
There seems to be a difference in the behavior of `AtomicWaker` and `WakeRegistration`. In particular, `AtomicWaker` does not wake the existing waker if a new one is registered. Therefore, the waker from before has no chance to re-register itself.

- No call of `wake` [here](https://github.com/embassy-rs/embassy/blob/main/embassy-sync/src/waitqueue/atomic_waker.rs#L24)
- Call of `wake` [here](https://github.com/embassy-rs/embassy/blob/main/embassy-sync/src/waitqueue/waker_registration.rs#L35)

If this is intended, we could add some docs.