### PR TITLE
RP2350 TRNG Error Handling

### DIFF
--- a/embassy-rp/src/trng.rs
+++ b/embassy-rp/src/trng.rs
@@ -78,6 +78,9 @@ impl From<InverterChainLength> for u8 {
 /// failed entropy checks.
 /// For acceptable results with an average generation time of about 2 milliseconds, use ROSC chain length settings of 0 or
 /// 1 and sample count settings of 20-25.
+/// Larger sample count settings (e.g. 100) provide proportionately slower average generation times. These settings
+/// significantly reduce, but do not eliminate NIST test failures and entropy check failures. Results occasionally take an
+/// especially long time to generate.
 ///
 /// ---
 ///
@@ -108,9 +111,10 @@ pub struct Config {
 impl Default for Config {
     fn default() -> Self {
         Config {
-            disable_autocorrelation_test: true,
-            disable_crngt_test: true,
-            disable_von_neumann_balancer: true,
+            // WARNING: Disabling these tests increases likelihood of poor rng results.
+            disable_autocorrelation_test: false,
+            disable_crngt_test: false,
+            disable_von_neumann_balancer: false,
             sample_count: 25,
             inverter_chain_length: InverterChainLength::One,
         }
@@ -148,6 +152,7 @@ impl Default for Config {
 /// ```
 pub struct Trng<'d, T: Instance> {
     phantom: PhantomData<&'d mut T>,
+    config: Config,
 }
 
 /// 12.12.1. Overview
@@ -159,28 +164,12 @@ const TRNG_BLOCK_SIZE_BYTES: usize = TRNG_BLOCK_SIZE_BITS / 8;
 impl<'d, T: Instance> Trng<'d, T> {
     /// Create a new TRNG driver.
     pub fn new(_trng: Peri<'d, T>, _irq: impl Binding<T::Interrupt, InterruptHandler<T>> + 'd, config: Config) -> Self {
-        let regs = T::regs();
-
-        regs.rng_imr().write(|w| w.set_ehr_valid_int_mask(false));
-
-        let trng_config_register = regs.trng_config();
-        trng_config_register.write(|w| {
-            w.set_rnd_src_sel(config.inverter_chain_length.clone().into());
-        });
-
-        let sample_count_register = regs.sample_cnt1();
-        sample_count_register.write(|w| {
-            *w = config.sample_count;
-        });
-
-        let debug_control_register = regs.trng_debug_control();
-        debug_control_register.write(|w| {
-            w.set_auto_correlate_bypass(config.disable_autocorrelation_test);
-            w.set_trng_crngt_bypass(config.disable_crngt_test);
-            w.set_vnc_bypass(config.disable_von_neumann_balancer)
-        });
-
-        Trng { phantom: PhantomData }
+        let trng = Trng {
+            phantom: PhantomData,
+            config: config,
+        };
+        trng.initialize_rng();
+        trng
     }
 
     fn start_rng(&self) {
@@ -196,6 +185,29 @@ impl<'d, T: Instance> Trng<'d, T> {
         source_enable_register.write(|w| w.set_rnd_src_en(false));
         let reset_bits_counter_register = regs.rst_bits_counter();
         reset_bits_counter_register.write(|w| w.set_rst_bits_counter(true));
+    }
+
+    fn initialize_rng(&self) {
+        let regs = T::regs();
+
+        regs.rng_imr().write(|w| w.set_ehr_valid_int_mask(false));
+
+        let trng_config_register = regs.trng_config();
+        trng_config_register.write(|w| {
+            w.set_rnd_src_sel(self.config.inverter_chain_length.clone().into());
+        });
+
+        let sample_count_register = regs.sample_cnt1();
+        sample_count_register.write(|w| {
+            *w = self.config.sample_count;
+        });
+
+        let debug_control_register = regs.trng_debug_control();
+        debug_control_register.write(|w| {
+            w.set_auto_correlate_bypass(self.config.disable_autocorrelation_test);
+            w.set_trng_crngt_bypass(self.config.disable_crngt_test);
+            w.set_vnc_bypass(self.config.disable_von_neumann_balancer);
+        });
     }
 
     fn enable_irq(&self) {
@@ -218,6 +230,10 @@ impl<'d, T: Instance> Trng<'d, T> {
             if trng_valid_register.read().ehr_valid().not() {
                 if regs.rng_isr().read().autocorr_err() {
                     regs.trng_sw_reset().write(|w| w.set_trng_sw_reset(true));
+                    // Fixed delay is required after TRNG soft reset. This read is sufficient.
+                    regs.trng_sw_reset().read();
+                    self.initialize_rng();
+                    self.start_rng();
                 } else {
                     panic!("RNG not busy, but ehr is not valid!")
                 }
@@ -279,8 +295,11 @@ impl<'d, T: Instance> Trng<'d, T> {
                 if trng_busy_register.read().trng_busy() {
                     Poll::Pending
                 } else {
+                    // If woken up and EHR is *not* valid, assume the trng has been reset and reinitialize, restart.
                     if trng_valid_register.read().ehr_valid().not() {
-                        panic!("RNG not busy, but ehr is not valid!")
+                        self.initialize_rng();
+                        self.start_rng();
+                        return Poll::Pending;
                     }
                     self.read_ehr_registers_into_array(&mut buffer);
                     let remaining = destination_length - bytes_transferred;
@@ -380,25 +399,36 @@ impl<T: Instance> interrupt::typelevel::Handler<T::Interrupt> for InterruptHandl
     unsafe fn on_interrupt() {
         let regs = T::regs();
         let isr = regs.rng_isr().read();
-        // Clear ehr bit
-        regs.rng_icr().write(|w| {
-            w.set_ehr_valid(true);
-        });
         if isr.ehr_valid() {
+            regs.rng_icr().write(|w| {
+                w.set_ehr_valid(true);
+            });
             T::waker().wake();
-        } else {
+        } else if isr.crngt_err() {
+            warn!("TRNG CRNGT error! Increase sample count to reduce likelihood");
+            regs.rng_icr().write(|w| {
+                w.set_crngt_err(true);
+            });
+        } else if isr.vn_err() {
+            warn!("TRNG Von-Neumann balancer error! Increase sample count to reduce likelihood");
+            regs.rng_icr().write(|w| {
+                w.set_vn_err(true);
+            });
+        } else if isr.autocorr_err() {
             // 12.12.5. List of Registers
             // ...
             // TRNG: RNG_ISR Register
             // ...
             // AUTOCORR_ERR: 1 indicates Autocorrelation test failed four times in a row.
             // When set, RNG ceases functioning until next reset
-            if isr.autocorr_err() {
-                warn!("TRNG Autocorrect error! Resetting TRNG");
-                regs.trng_sw_reset().write(|w| {
-                    w.set_trng_sw_reset(true);
-                });
-            }
+            warn!("TRNG Autocorrect error! Resetting TRNG. Increase sample count to reduce likelihood");
+            regs.trng_sw_reset().write(|w| {
+                w.set_trng_sw_reset(true);
+            });
+            // Fixed delay is required after TRNG soft reset, this read is sufficient.
+            regs.trng_sw_reset().read();
+            // Wake up to reinitialize and restart the TRNG.
+            T::waker().wake();
         }
     }
 }


### PR DESCRIPTION
# What 

Expands upon the the initial implementation of the RP2350 TRNG driver introduced in this PR: https://github.com/embassy-rs/embassy/pull/3338 by setting more secure defaults and gracefully handling self-test errors.

# Why

On my Pico 2 W with the default configuration, the provided TRNG example returns very low entropy output and skips all self-tests.

When self-tests are *enabled*, the async implementation hangs after the first autocorrelation error (the trng isn't reinitialized after reset) and the blocking implementation panics.

# Evidence

## Before change:

Default sample rate with self-tests disabled, it works but low quality output (notice the repeating bytes):

```
0.000465 INFO  Random bytes async [170, 170, 170, 82, 85, 85, 85, 85, 149, 82, 85, 169, 86, 165, 170, 170, 86, 165, 170, 180, 182, 116, 45, 165, 85, 90, 86, 169, 165, 45, 173, 82, 43, 149, 90, 149, 90, 74, 41, 165, 212, 74, 149, 74, 173, 37, 45, 165, 90, 106, 213, 148, 74, 173, 181, 82, 45, 165]
└─ trng::____embassy_main_task::{async_fn#0} @ src/bin/trng.rs:33  
0.000710 INFO  Random bytes blocking [169, 84, 170, 84, 42, 149, 170, 170, 186, 90, 171, 85, 171, 170, 86, 85, 149, 170, 106, 85, 165, 82, 169, 181, 170, 178, 170, 165, 100, 85, 85, 85, 170, 170, 85, 171, 74, 85, 43, 149, 42, 173, 181, 214, 74, 169, 149, 82, 65, 165, 165, 42, 165, 170, 86, 181, 74, 149]
└─ trng::____embassy_main_task::{async_fn#0} @ src/bin/trng.rs:35  
0.000895 INFO  Random u32 2829757098 u64 6148633216617633066
└─ trng::____embassy_main_task::{async_fn#0} @ src/bin/trng.rs:38  
```

Default sample rate with self-tests enabled async. Hangs indefinitely

```
0.000644 WARN  TRNG Autocorrect error! Resetting TRNG
└─ embassy_rp::trng::{impl#7}::on_interrupt @ embassy-rp/src/trng.rs:397 
```

Default sample rate with self-tests enabled blocking. Panic!

```
0.000619 ERROR panicked at 'RNG not busy, but ehr is not valid!'
└─ embassy_rp::trng::{impl#4}::blocking_wait_for_successful_generation @ embassy-rp/src/trng.rs:222 
0.000651 ERROR panicked at .cargo/registry/src/index.crates.io-1949cf8c6b5b557f/defmt-1.0.1/src/lib.rs:385:5:
explicit panic
└─ panic_probe::print_defmt::print @ .cargo/registry/src/index.crates.io-1949cf8c6b5b557f/panic-probe-0.3.2/src/lib.rs:104 
```

## After change:

Default sample rate with self-tests enabled, many self-test errors observed on my hardware. Generation is very slow.

```
2.307753 WARN  TRNG Autocorrect error! Resetting TRNG. Increase sample count to reduce likelihood
└─ embassy_rp::trng::{impl#7}::on_interrupt @ embassy-rp/src/trng.rs:424 
2.308002 WARN  TRNG CRNGT error! Increase sample count to reduce likelihood
└─ embassy_rp::trng::{impl#7}::on_interrupt @ embassy-rp/src/trng.rs:408 
```

Increased sample rate of 96 with self-tests enabled, no self-test errors reported:
```
0.001533 INFO  Random bytes async [8, 235, 32, 87, 115, 21, 53, 208, 15, 30, 77, 37, 10, 25, 156, 6, 237, 162, 19, 65, 173, 6, 202, 190, 182, 93, 83, 57, 21, 5, 193, 31, 255, 113, 217, 106, 160, 29, 176, 17, 183, 213, 80, 229, 13, 14, 144, 124, 213, 137, 199, 47, 107, 243, 56, 203, 86, 65]
└─ trng::____embassy_main_task::{async_fn#0} @ src/bin/trng.rs:35  
0.002830 INFO  Random bytes blocking [45, 247, 79, 229, 207, 118, 228, 189, 103, 160, 249, 175, 82, 156, 84, 205, 147, 94, 194, 209, 227, 206, 115, 43, 253, 113, 218, 247, 233, 78, 255, 253, 255, 104, 123, 90, 165, 92, 80, 121, 115, 124, 229, 24, 149, 197, 135, 64, 130, 30, 40, 207, 66, 26, 28, 218, 42, 82]
└─ trng::____embassy_main_task::{async_fn#0} @ src/bin/trng.rs:37  
0.003713 INFO  Random u32 3062914049 u64 9261621118159602064
```