### PR TITLE
[embassy-nrf] Add `InputRef`, `OutputRef`, and `FlexRef`

### DIFF
--- a/embassy-nrf/src/gpiote.rs
+++ b/embassy-nrf/src/gpiote.rs
@@ -513,11 +513,11 @@ mod eh02 {
         type Error = Infallible;
 
         fn is_high(&self) -> Result<bool, Self::Error> {
-            Ok(self.pin.is_high())
+            Ok((*self.pin).is_high())
         }
 
         fn is_low(&self) -> Result<bool, Self::Error> {
-            Ok(self.pin.is_low())
+            Ok((*self.pin).is_low())
         }
     }
 }
@@ -528,11 +528,11 @@ impl<'d, 'i> embedded_hal_1::digital::ErrorType for InputChannel<'d, 'i> {
 
 impl<'d, 'i> embedded_hal_1::digital::InputPin for InputChannel<'d, 'i> {
     fn is_high(&mut self) -> Result<bool, Self::Error> {
-        Ok(self.pin.is_high())
+        Ok((*self.pin).is_high())
     }
 
     fn is_low(&mut self) -> Result<bool, Self::Error> {
-        Ok(self.pin.is_low())
+        Ok((*self.pin).is_low())
     }
 }
 

--- a/embassy-nrf/src/gpiote.rs
+++ b/embassy-nrf/src/gpiote.rs
@@ -7,7 +7,7 @@ use core::task::{Context, Poll};
 use embassy_hal_internal::{impl_peripheral, Peri, PeripheralType};
 use embassy_sync::waitqueue::AtomicWaker;
 
-use crate::gpio::{AnyPin, Flex, Input, Output, Pin as GpioPin, SealedPin as _};
+use crate::gpio::{AnyPin, Flex, Input, InputRef, OutputRef, Pin as GpioPin, SealedPin as _};
 use crate::interrupt::InterruptExt;
 #[cfg(not(feature = "_nrf51"))]
 use crate::pac::gpio::vals::Detectmode;
@@ -188,12 +188,12 @@ impl Iterator for BitIter {
 }
 
 /// GPIOTE channel driver in input mode
-pub struct InputChannel<'d> {
+pub struct InputChannel<'d, 'i> {
     ch: Peri<'d, AnyChannel>,
-    pin: Input<'d>,
+    pin: InputRef<'d, 'i>,
 }
 
-impl<'d> Drop for InputChannel<'d> {
+impl<'d, 'i> Drop for InputChannel<'d, 'i> {
     fn drop(&mut self) {
         let g = regs();
         let num = self.ch.number();
@@ -202,9 +202,9 @@ impl<'d> Drop for InputChannel<'d> {
     }
 }
 
-impl<'d> InputChannel<'d> {
+impl<'d, 'i> InputChannel<'d, 'i> {
     /// Create a new GPIOTE input channel driver.
-    pub fn new(ch: Peri<'d, impl Channel>, pin: Input<'d>, polarity: InputChannelPolarity) -> Self {
+    pub fn new(ch: Peri<'d, impl Channel>, pin: InputRef<'d, 'i>, polarity: InputChannelPolarity) -> Self {
         let g = regs();
         let num = ch.number();
 
@@ -258,12 +258,12 @@ impl<'d> InputChannel<'d> {
 }
 
 /// GPIOTE channel driver in output mode
-pub struct OutputChannel<'d> {
+pub struct OutputChannel<'d, 'o> {
     ch: Peri<'d, AnyChannel>,
-    _pin: Output<'d>,
+    _pin: OutputRef<'d, 'o>,
 }
 
-impl<'d> Drop for OutputChannel<'d> {
+impl<'d, 'o> Drop for OutputChannel<'d, 'o> {
     fn drop(&mut self) {
         let g = regs();
         let num = self.ch.number();
@@ -272,9 +272,9 @@ impl<'d> Drop for OutputChannel<'d> {
     }
 }
 
-impl<'d> OutputChannel<'d> {
+impl<'d, 'o> OutputChannel<'d, 'o> {
     /// Create a new GPIOTE output channel driver.
-    pub fn new(ch: Peri<'d, impl Channel>, pin: Output<'d>, polarity: OutputChannelPolarity) -> Self {
+    pub fn new(ch: Peri<'d, impl Channel>, pin: OutputRef<'d, 'o>, polarity: OutputChannelPolarity) -> Self {
         let g = regs();
         let num = ch.number();
 
@@ -509,7 +509,7 @@ impl_channel!(GPIOTE_CH7, 7);
 mod eh02 {
     use super::*;
 
-    impl<'d> embedded_hal_02::digital::v2::InputPin for InputChannel<'d> {
+    impl<'d, 'i> embedded_hal_02::digital::v2::InputPin for InputChannel<'d, 'i> {
         type Error = Infallible;
 
         fn is_high(&self) -> Result<bool, Self::Error> {
@@ -522,11 +522,11 @@ mod eh02 {
     }
 }
 
-impl<'d> embedded_hal_1::digital::ErrorType for InputChannel<'d> {
+impl<'d, 'i> embedded_hal_1::digital::ErrorType for InputChannel<'d, 'i> {
     type Error = Infallible;
 }
 
-impl<'d> embedded_hal_1::digital::InputPin for InputChannel<'d> {
+impl<'d, 'i> embedded_hal_1::digital::InputPin for InputChannel<'d, 'i> {
     fn is_high(&mut self) -> Result<bool, Self::Error> {
         Ok(self.pin.is_high())
     }

--- a/embassy-nrf/src/pwm.rs
+++ b/embassy-nrf/src/pwm.rs
@@ -54,7 +54,7 @@ impl<'d, 'o, T: Instance> SequencePwm<'d, 'o, T> {
     /// Create a new 1-channel PWM
     #[allow(unused_unsafe)]
     pub fn new_1ch(pwm: Peri<'d, T>, ch0: OutputRef<'d, 'o>, config: Config) -> Result<Self, Error> {
-        Self::new_inner(pwm, Some(ch0.into()), None, None, None, config)
+        Self::new_inner(pwm, Some(ch0), None, None, None, config)
     }
 
     /// Create a new 2-channel PWM
@@ -65,7 +65,7 @@ impl<'d, 'o, T: Instance> SequencePwm<'d, 'o, T> {
         ch1: OutputRef<'d, 'o>,
         config: Config,
     ) -> Result<Self, Error> {
-        Self::new_inner(pwm, Some(ch0.into()), Some(ch1.into()), None, None, config)
+        Self::new_inner(pwm, Some(ch0), Some(ch1), None, None, config)
     }
 
     /// Create a new 3-channel PWM
@@ -77,7 +77,7 @@ impl<'d, 'o, T: Instance> SequencePwm<'d, 'o, T> {
         ch2: OutputRef<'d, 'o>,
         config: Config,
     ) -> Result<Self, Error> {
-        Self::new_inner(pwm, Some(ch0.into()), Some(ch1.into()), Some(ch2.into()), None, config)
+        Self::new_inner(pwm, Some(ch0), Some(ch1), Some(ch2), None, config)
     }
 
     /// Create a new 4-channel PWM
@@ -90,14 +90,7 @@ impl<'d, 'o, T: Instance> SequencePwm<'d, 'o, T> {
         ch3: OutputRef<'d, 'o>,
         config: Config,
     ) -> Result<Self, Error> {
-        Self::new_inner(
-            pwm,
-            Some(ch0.into()),
-            Some(ch1.into()),
-            Some(ch2.into()),
-            Some(ch3.into()),
-            config,
-        )
+        Self::new_inner(pwm, Some(ch0), Some(ch1), Some(ch2), Some(ch3), config)
     }
 
     fn new_inner(
@@ -557,19 +550,19 @@ impl<'d, 'o, T: Instance> SimplePwm<'d, 'o, T> {
     /// Create a new 1-channel PWM
     #[allow(unused_unsafe)]
     pub fn new_1ch(pwm: Peri<'d, T>, ch0: OutputRef<'d, 'o>) -> Self {
-        unsafe { Self::new_inner(pwm, Some(ch0.into()), None, None, None) }
+        unsafe { Self::new_inner(pwm, Some(ch0), None, None, None) }
     }
 
     /// Create a new 2-channel PWM
     #[allow(unused_unsafe)]
     pub fn new_2ch(pwm: Peri<'d, T>, ch0: OutputRef<'d, 'o>, ch1: OutputRef<'d, 'o>) -> Self {
-        Self::new_inner(pwm, Some(ch0.into()), Some(ch1.into()), None, None)
+        Self::new_inner(pwm, Some(ch0), Some(ch1), None, None)
     }
 
     /// Create a new 3-channel PWM
     #[allow(unused_unsafe)]
     pub fn new_3ch(pwm: Peri<'d, T>, ch0: OutputRef<'d, 'o>, ch1: OutputRef<'d, 'o>, ch2: OutputRef<'d, 'o>) -> Self {
-        unsafe { Self::new_inner(pwm, Some(ch0.into()), Some(ch1.into()), Some(ch2.into()), None) }
+        unsafe { Self::new_inner(pwm, Some(ch0), Some(ch1), Some(ch2), None) }
     }
 
     /// Create a new 4-channel PWM
@@ -581,15 +574,7 @@ impl<'d, 'o, T: Instance> SimplePwm<'d, 'o, T> {
         ch2: OutputRef<'d, 'o>,
         ch3: OutputRef<'d, 'o>,
     ) -> Self {
-        unsafe {
-            Self::new_inner(
-                pwm,
-                Some(ch0.into()),
-                Some(ch1.into()),
-                Some(ch2.into()),
-                Some(ch3.into()),
-            )
-        }
+        unsafe { Self::new_inner(pwm, Some(ch0), Some(ch1), Some(ch2), Some(ch3)) }
     }
 
     fn new_inner(

--- a/embassy-nrf/src/pwm.rs
+++ b/embassy-nrf/src/pwm.rs
@@ -6,8 +6,7 @@ use core::sync::atomic::{compiler_fence, Ordering};
 
 use embassy_hal_internal::{Peri, PeripheralType};
 
-use crate::gpio::{convert_drive, AnyPin, OutputDrive, Pin as GpioPin, PselBits, SealedPin as _, DISCONNECTED};
-use crate::pac::gpio::vals as gpiovals;
+use crate::gpio::{OutputDrive, OutputRef, PselBits, DISCONNECTED};
 use crate::pac::pwm::vals;
 use crate::ppi::{Event, Task};
 use crate::util::slice_in_ram_or;
@@ -15,23 +14,23 @@ use crate::{interrupt, pac};
 
 /// SimplePwm is the traditional pwm interface you're probably used to, allowing
 /// to simply set a duty cycle across up to four channels.
-pub struct SimplePwm<'d, T: Instance> {
+pub struct SimplePwm<'d, 'o, T: Instance> {
     _peri: Peri<'d, T>,
     duty: [u16; 4],
-    ch0: Option<Peri<'d, AnyPin>>,
-    ch1: Option<Peri<'d, AnyPin>>,
-    ch2: Option<Peri<'d, AnyPin>>,
-    ch3: Option<Peri<'d, AnyPin>>,
+    ch0: Option<OutputRef<'d, 'o>>,
+    ch1: Option<OutputRef<'d, 'o>>,
+    ch2: Option<OutputRef<'d, 'o>>,
+    ch3: Option<OutputRef<'d, 'o>>,
 }
 
 /// SequencePwm allows you to offload the updating of a sequence of duty cycles
 /// to up to four channels, as well as repeat that sequence n times.
-pub struct SequencePwm<'d, T: Instance> {
+pub struct SequencePwm<'d, 'o, T: Instance> {
     _peri: Peri<'d, T>,
-    ch0: Option<Peri<'d, AnyPin>>,
-    ch1: Option<Peri<'d, AnyPin>>,
-    ch2: Option<Peri<'d, AnyPin>>,
-    ch3: Option<Peri<'d, AnyPin>>,
+    ch0: Option<OutputRef<'d, 'o>>,
+    ch1: Option<OutputRef<'d, 'o>>,
+    ch2: Option<OutputRef<'d, 'o>>,
+    ch3: Option<OutputRef<'d, 'o>>,
 }
 
 /// PWM error
@@ -51,10 +50,10 @@ const MAX_SEQUENCE_LEN: usize = 32767;
 /// The used pwm clock frequency
 pub const PWM_CLK_HZ: u32 = 16_000_000;
 
-impl<'d, T: Instance> SequencePwm<'d, T> {
+impl<'d, 'o, T: Instance> SequencePwm<'d, 'o, T> {
     /// Create a new 1-channel PWM
     #[allow(unused_unsafe)]
-    pub fn new_1ch(pwm: Peri<'d, T>, ch0: Peri<'d, impl GpioPin>, config: Config) -> Result<Self, Error> {
+    pub fn new_1ch(pwm: Peri<'d, T>, ch0: OutputRef<'d, 'o>, config: Config) -> Result<Self, Error> {
         Self::new_inner(pwm, Some(ch0.into()), None, None, None, config)
     }
 
@@ -62,8 +61,8 @@ impl<'d, T: Instance> SequencePwm<'d, T> {
     #[allow(unused_unsafe)]
     pub fn new_2ch(
         pwm: Peri<'d, T>,
-        ch0: Peri<'d, impl GpioPin>,
-        ch1: Peri<'d, impl GpioPin>,
+        ch0: OutputRef<'d, 'o>,
+        ch1: OutputRef<'d, 'o>,
         config: Config,
     ) -> Result<Self, Error> {
         Self::new_inner(pwm, Some(ch0.into()), Some(ch1.into()), None, None, config)
@@ -73,9 +72,9 @@ impl<'d, T: Instance> SequencePwm<'d, T> {
     #[allow(unused_unsafe)]
     pub fn new_3ch(
         pwm: Peri<'d, T>,
-        ch0: Peri<'d, impl GpioPin>,
-        ch1: Peri<'d, impl GpioPin>,
-        ch2: Peri<'d, impl GpioPin>,
+        ch0: OutputRef<'d, 'o>,
+        ch1: OutputRef<'d, 'o>,
+        ch2: OutputRef<'d, 'o>,
         config: Config,
     ) -> Result<Self, Error> {
         Self::new_inner(pwm, Some(ch0.into()), Some(ch1.into()), Some(ch2.into()), None, config)
@@ -85,10 +84,10 @@ impl<'d, T: Instance> SequencePwm<'d, T> {
     #[allow(unused_unsafe)]
     pub fn new_4ch(
         pwm: Peri<'d, T>,
-        ch0: Peri<'d, impl GpioPin>,
-        ch1: Peri<'d, impl GpioPin>,
-        ch2: Peri<'d, impl GpioPin>,
-        ch3: Peri<'d, impl GpioPin>,
+        ch0: OutputRef<'d, 'o>,
+        ch1: OutputRef<'d, 'o>,
+        ch2: OutputRef<'d, 'o>,
+        ch3: OutputRef<'d, 'o>,
         config: Config,
     ) -> Result<Self, Error> {
         Self::new_inner(
@@ -103,45 +102,25 @@ impl<'d, T: Instance> SequencePwm<'d, T> {
 
     fn new_inner(
         _pwm: Peri<'d, T>,
-        ch0: Option<Peri<'d, AnyPin>>,
-        ch1: Option<Peri<'d, AnyPin>>,
-        ch2: Option<Peri<'d, AnyPin>>,
-        ch3: Option<Peri<'d, AnyPin>>,
+        mut ch0: Option<OutputRef<'d, 'o>>,
+        mut ch1: Option<OutputRef<'d, 'o>>,
+        mut ch2: Option<OutputRef<'d, 'o>>,
+        mut ch3: Option<OutputRef<'d, 'o>>,
         config: Config,
     ) -> Result<Self, Error> {
         let r = T::regs();
 
-        if let Some(pin) = &ch0 {
+        if let Some(pin) = &mut ch0 {
             pin.set_low();
-            pin.conf().write(|w| {
-                w.set_dir(gpiovals::Dir::OUTPUT);
-                w.set_input(gpiovals::Input::DISCONNECT);
-                convert_drive(w, config.ch0_drive);
-            });
         }
-        if let Some(pin) = &ch1 {
+        if let Some(pin) = &mut ch1 {
             pin.set_low();
-            pin.conf().write(|w| {
-                w.set_dir(gpiovals::Dir::OUTPUT);
-                w.set_input(gpiovals::Input::DISCONNECT);
-                convert_drive(w, config.ch1_drive);
-            });
         }
-        if let Some(pin) = &ch2 {
+        if let Some(pin) = &mut ch2 {
             pin.set_low();
-            pin.conf().write(|w| {
-                w.set_dir(gpiovals::Dir::OUTPUT);
-                w.set_input(gpiovals::Input::DISCONNECT);
-                convert_drive(w, config.ch2_drive);
-            });
         }
-        if let Some(pin) = &ch3 {
+        if let Some(pin) = &mut ch3 {
             pin.set_low();
-            pin.conf().write(|w| {
-                w.set_dir(gpiovals::Dir::OUTPUT);
-                w.set_input(gpiovals::Input::DISCONNECT);
-                convert_drive(w, config.ch3_drive);
-            });
         }
 
         r.psel().out(0).write_value(ch0.psel_bits());
@@ -283,28 +262,24 @@ impl<'d, T: Instance> SequencePwm<'d, T> {
     }
 }
 
-impl<'a, T: Instance> Drop for SequencePwm<'a, T> {
+impl<'a, 'b, T: Instance> Drop for SequencePwm<'a, 'b, T> {
     fn drop(&mut self) {
         let r = T::regs();
 
-        if let Some(pin) = &self.ch0 {
+        if let Some(pin) = &mut self.ch0 {
             pin.set_low();
-            pin.conf().write(|_| ());
             r.psel().out(0).write_value(DISCONNECTED);
         }
-        if let Some(pin) = &self.ch1 {
+        if let Some(pin) = &mut self.ch1 {
             pin.set_low();
-            pin.conf().write(|_| ());
             r.psel().out(1).write_value(DISCONNECTED);
         }
-        if let Some(pin) = &self.ch2 {
+        if let Some(pin) = &mut self.ch2 {
             pin.set_low();
-            pin.conf().write(|_| ());
             r.psel().out(2).write_value(DISCONNECTED);
         }
-        if let Some(pin) = &self.ch3 {
+        if let Some(pin) = &mut self.ch3 {
             pin.set_low();
-            pin.conf().write(|_| ());
             r.psel().out(3).write_value(DISCONNECTED);
         }
     }
@@ -321,14 +296,6 @@ pub struct Config {
     pub prescaler: Prescaler,
     /// How a sequence is read from RAM and is spread to the compare register
     pub sequence_load: SequenceLoad,
-    /// Drive strength for the channel 0 line.
-    pub ch0_drive: OutputDrive,
-    /// Drive strength for the channel 1 line.
-    pub ch1_drive: OutputDrive,
-    /// Drive strength for the channel 2 line.
-    pub ch2_drive: OutputDrive,
-    /// Drive strength for the channel 3 line.
-    pub ch3_drive: OutputDrive,
 }
 
 impl Default for Config {
@@ -338,10 +305,6 @@ impl Default for Config {
             max_duty: 1000,
             prescaler: Prescaler::Div16,
             sequence_load: SequenceLoad::Common,
-            ch0_drive: OutputDrive::Standard,
-            ch1_drive: OutputDrive::Standard,
-            ch2_drive: OutputDrive::Standard,
-            ch3_drive: OutputDrive::Standard,
         }
     }
 }
@@ -384,13 +347,13 @@ impl<'s> Sequence<'s> {
 /// A single sequence that can be started and stopped.
 /// Takes one sequence along with its configuration.
 #[non_exhaustive]
-pub struct SingleSequencer<'d, 's, T: Instance> {
-    sequencer: Sequencer<'d, 's, T>,
+pub struct SingleSequencer<'d, 'o, 's, T: Instance> {
+    sequencer: Sequencer<'d, 'o, 's, T>,
 }
 
-impl<'d, 's, T: Instance> SingleSequencer<'d, 's, T> {
+impl<'d, 'o, 's, T: Instance> SingleSequencer<'d, 'o, 's, T> {
     /// Create a new sequencer
-    pub fn new(pwm: &'s mut SequencePwm<'d, T>, words: &'s [u16], config: SequenceConfig) -> Self {
+    pub fn new(pwm: &'s mut SequencePwm<'d, 'o, T>, words: &'s [u16], config: SequenceConfig) -> Self {
         Self {
             sequencer: Sequencer::new(pwm, Sequence::new(words, config), None),
         }
@@ -423,16 +386,16 @@ impl<'d, 's, T: Instance> SingleSequencer<'d, 's, T> {
 /// In the case where no second sequence is provided then the first sequence
 /// is used.
 #[non_exhaustive]
-pub struct Sequencer<'d, 's, T: Instance> {
-    _pwm: &'s mut SequencePwm<'d, T>,
+pub struct Sequencer<'d, 'o, 's, T: Instance> {
+    _pwm: &'s mut SequencePwm<'d, 'o, T>,
     sequence0: Sequence<'s>,
     sequence1: Option<Sequence<'s>>,
 }
 
-impl<'d, 's, T: Instance> Sequencer<'d, 's, T> {
+impl<'d, 'o, 's, T: Instance> Sequencer<'d, 'o, 's, T> {
     /// Create a new double sequence. In the absence of sequence 1, sequence 0
     /// will be used twice in the one loop.
-    pub fn new(pwm: &'s mut SequencePwm<'d, T>, sequence0: Sequence<'s>, sequence1: Option<Sequence<'s>>) -> Self {
+    pub fn new(pwm: &'s mut SequencePwm<'d, 'o, T>, sequence0: Sequence<'s>, sequence1: Option<Sequence<'s>>) -> Self {
         Sequencer {
             _pwm: pwm,
             sequence0,
@@ -511,7 +474,7 @@ impl<'d, 's, T: Instance> Sequencer<'d, 's, T> {
     }
 }
 
-impl<'d, 's, T: Instance> Drop for Sequencer<'d, 's, T> {
+impl<'d, 'o, 's, T: Instance> Drop for Sequencer<'d, 'o, 's, T> {
     fn drop(&mut self) {
         self.stop();
     }
@@ -590,27 +553,22 @@ pub enum CounterMode {
     UpAndDown,
 }
 
-impl<'d, T: Instance> SimplePwm<'d, T> {
+impl<'d, 'o, T: Instance> SimplePwm<'d, 'o, T> {
     /// Create a new 1-channel PWM
     #[allow(unused_unsafe)]
-    pub fn new_1ch(pwm: Peri<'d, T>, ch0: Peri<'d, impl GpioPin>) -> Self {
+    pub fn new_1ch(pwm: Peri<'d, T>, ch0: OutputRef<'d, 'o>) -> Self {
         unsafe { Self::new_inner(pwm, Some(ch0.into()), None, None, None) }
     }
 
     /// Create a new 2-channel PWM
     #[allow(unused_unsafe)]
-    pub fn new_2ch(pwm: Peri<'d, T>, ch0: Peri<'d, impl GpioPin>, ch1: Peri<'d, impl GpioPin>) -> Self {
+    pub fn new_2ch(pwm: Peri<'d, T>, ch0: OutputRef<'d, 'o>, ch1: OutputRef<'d, 'o>) -> Self {
         Self::new_inner(pwm, Some(ch0.into()), Some(ch1.into()), None, None)
     }
 
     /// Create a new 3-channel PWM
     #[allow(unused_unsafe)]
-    pub fn new_3ch(
-        pwm: Peri<'d, T>,
-        ch0: Peri<'d, impl GpioPin>,
-        ch1: Peri<'d, impl GpioPin>,
-        ch2: Peri<'d, impl GpioPin>,
-    ) -> Self {
+    pub fn new_3ch(pwm: Peri<'d, T>, ch0: OutputRef<'d, 'o>, ch1: OutputRef<'d, 'o>, ch2: OutputRef<'d, 'o>) -> Self {
         unsafe { Self::new_inner(pwm, Some(ch0.into()), Some(ch1.into()), Some(ch2.into()), None) }
     }
 
@@ -618,10 +576,10 @@ impl<'d, T: Instance> SimplePwm<'d, T> {
     #[allow(unused_unsafe)]
     pub fn new_4ch(
         pwm: Peri<'d, T>,
-        ch0: Peri<'d, impl GpioPin>,
-        ch1: Peri<'d, impl GpioPin>,
-        ch2: Peri<'d, impl GpioPin>,
-        ch3: Peri<'d, impl GpioPin>,
+        ch0: OutputRef<'d, 'o>,
+        ch1: OutputRef<'d, 'o>,
+        ch2: OutputRef<'d, 'o>,
+        ch3: OutputRef<'d, 'o>,
     ) -> Self {
         unsafe {
             Self::new_inner(
@@ -636,22 +594,16 @@ impl<'d, T: Instance> SimplePwm<'d, T> {
 
     fn new_inner(
         _pwm: Peri<'d, T>,
-        ch0: Option<Peri<'d, AnyPin>>,
-        ch1: Option<Peri<'d, AnyPin>>,
-        ch2: Option<Peri<'d, AnyPin>>,
-        ch3: Option<Peri<'d, AnyPin>>,
+        mut ch0: Option<OutputRef<'d, 'o>>,
+        mut ch1: Option<OutputRef<'d, 'o>>,
+        mut ch2: Option<OutputRef<'d, 'o>>,
+        mut ch3: Option<OutputRef<'d, 'o>>,
     ) -> Self {
         let r = T::regs();
 
-        for (i, ch) in [&ch0, &ch1, &ch2, &ch3].into_iter().enumerate() {
+        for (i, ch) in [&mut ch0, &mut ch1, &mut ch2, &mut ch3].into_iter().enumerate() {
             if let Some(pin) = ch {
                 pin.set_low();
-
-                pin.conf().write(|w| {
-                    w.set_dir(gpiovals::Dir::OUTPUT);
-                    w.set_input(gpiovals::Input::DISCONNECT);
-                    w.set_drive(gpiovals::Drive::S0S1);
-                });
             }
             r.psel().out(i).write_value(ch.psel_bits());
         }
@@ -793,61 +745,57 @@ impl<'d, T: Instance> SimplePwm<'d, T> {
 
     /// Sets the PWM-Channel0 output drive strength
     #[inline(always)]
-    pub fn set_ch0_drive(&self, drive: OutputDrive) {
-        if let Some(pin) = &self.ch0 {
-            pin.conf().modify(|w| convert_drive(w, drive));
+    pub fn set_ch0_drive(&mut self, drive: OutputDrive) {
+        if let Some(pin) = &mut self.ch0 {
+            pin.pin.set_as_output(drive);
         }
     }
 
     /// Sets the PWM-Channel1 output drive strength
     #[inline(always)]
-    pub fn set_ch1_drive(&self, drive: OutputDrive) {
-        if let Some(pin) = &self.ch1 {
-            pin.conf().modify(|w| convert_drive(w, drive));
+    pub fn set_ch1_drive(&mut self, drive: OutputDrive) {
+        if let Some(pin) = &mut self.ch1 {
+            pin.pin.set_as_output(drive);
         }
     }
 
     /// Sets the PWM-Channel2 output drive strength
     #[inline(always)]
-    pub fn set_ch2_drive(&self, drive: OutputDrive) {
-        if let Some(pin) = &self.ch2 {
-            pin.conf().modify(|w| convert_drive(w, drive));
+    pub fn set_ch2_drive(&mut self, drive: OutputDrive) {
+        if let Some(pin) = &mut self.ch2 {
+            pin.pin.set_as_output(drive);
         }
     }
 
     /// Sets the PWM-Channel3 output drive strength
     #[inline(always)]
-    pub fn set_ch3_drive(&self, drive: OutputDrive) {
-        if let Some(pin) = &self.ch3 {
-            pin.conf().modify(|w| convert_drive(w, drive));
+    pub fn set_ch3_drive(&mut self, drive: OutputDrive) {
+        if let Some(pin) = &mut self.ch3 {
+            pin.pin.set_as_output(drive);
         }
     }
 }
 
-impl<'a, T: Instance> Drop for SimplePwm<'a, T> {
+impl<'a, 'b, T: Instance> Drop for SimplePwm<'a, 'b, T> {
     fn drop(&mut self) {
         let r = T::regs();
 
         self.disable();
 
-        if let Some(pin) = &self.ch0 {
+        if let Some(pin) = &mut self.ch0 {
             pin.set_low();
-            pin.conf().write(|_| ());
             r.psel().out(0).write_value(DISCONNECTED);
         }
-        if let Some(pin) = &self.ch1 {
+        if let Some(pin) = &mut self.ch1 {
             pin.set_low();
-            pin.conf().write(|_| ());
             r.psel().out(1).write_value(DISCONNECTED);
         }
-        if let Some(pin) = &self.ch2 {
+        if let Some(pin) = &mut self.ch2 {
             pin.set_low();
-            pin.conf().write(|_| ());
             r.psel().out(2).write_value(DISCONNECTED);
         }
-        if let Some(pin) = &self.ch3 {
+        if let Some(pin) = &mut self.ch3 {
             pin.set_low();
-            pin.conf().write(|_| ());
             r.psel().out(3).write_value(DISCONNECTED);
         }
     }

--- a/examples/nrf52840/src/bin/egu.rs
+++ b/examples/nrf52840/src/bin/egu.rs
@@ -21,8 +21,8 @@ async fn main(_spawner: Spawner) {
     let btn1 = Input::new(p.P0_11, Pull::Up);
 
     let mut egu1 = Egu::new(p.EGU0);
-    let led1 = OutputChannel::new(p.GPIOTE_CH0, led1, OutputChannelPolarity::Toggle);
-    let btn1 = InputChannel::new(p.GPIOTE_CH1, btn1, InputChannelPolarity::LoToHi);
+    let led1 = OutputChannel::new(p.GPIOTE_CH0, led1.into(), OutputChannelPolarity::Toggle);
+    let btn1 = InputChannel::new(p.GPIOTE_CH1, btn1.into(), InputChannelPolarity::LoToHi);
 
     let trigger0 = egu1.trigger(TriggerNumber::Trigger0);
     let trigger1 = egu1.trigger(TriggerNumber::Trigger1);

--- a/examples/nrf52840/src/bin/gpiote_channel.rs
+++ b/examples/nrf52840/src/bin/gpiote_channel.rs
@@ -14,22 +14,22 @@ async fn main(_spawner: Spawner) {
 
     let ch1 = InputChannel::new(
         p.GPIOTE_CH0,
-        Input::new(p.P0_11, Pull::Up),
+        Input::new(p.P0_11, Pull::Up).into(),
         InputChannelPolarity::HiToLo,
     );
     let ch2 = InputChannel::new(
         p.GPIOTE_CH1,
-        Input::new(p.P0_12, Pull::Up),
+        Input::new(p.P0_12, Pull::Up).into(),
         InputChannelPolarity::LoToHi,
     );
     let ch3 = InputChannel::new(
         p.GPIOTE_CH2,
-        Input::new(p.P0_24, Pull::Up),
+        Input::new(p.P0_24, Pull::Up).into(),
         InputChannelPolarity::Toggle,
     );
     let ch4 = InputChannel::new(
         p.GPIOTE_CH3,
-        Input::new(p.P0_25, Pull::Up),
+        Input::new(p.P0_25, Pull::Up).into(),
         InputChannelPolarity::Toggle,
     );
 

--- a/examples/nrf52840/src/bin/i2s_monitor.rs
+++ b/examples/nrf52840/src/bin/i2s_monitor.rs
@@ -3,6 +3,7 @@
 
 use defmt::{debug, error, info};
 use embassy_executor::Spawner;
+use embassy_nrf::gpio::{Level, Output, OutputDrive};
 use embassy_nrf::i2s::{self, Channels, Config, DoubleBuffering, MasterClock, Sample as _, SampleWidth, I2S};
 use embassy_nrf::pwm::{Prescaler, SimplePwm};
 use embassy_nrf::{bind_interrupts, peripherals};
@@ -34,7 +35,12 @@ async fn main(_spawner: Spawner) {
         I2S::new_master(p.I2S, Irqs, p.P0_25, p.P0_26, p.P0_27, master_clock, config).input(p.P0_29, buffers);
 
     // Configure the PWM to use the pins corresponding to the RGB leds
-    let mut pwm = SimplePwm::new_3ch(p.PWM0, p.P0_23, p.P0_22, p.P0_24);
+    let mut pwm = SimplePwm::new_3ch(
+        p.PWM0,
+        Output::new(p.P0_23, Level::Low, OutputDrive::Standard).into(),
+        Output::new(p.P0_22, Level::Low, OutputDrive::Standard).into(),
+        Output::new(p.P0_24, Level::Low, OutputDrive::Standard).into(),
+    );
     pwm.set_prescaler(Prescaler::Div1);
     pwm.set_max_duty(255);
 

--- a/examples/nrf52840/src/bin/ppi.rs
+++ b/examples/nrf52840/src/bin/ppi.rs
@@ -18,34 +18,34 @@ async fn main(_spawner: Spawner) {
 
     let button1 = InputChannel::new(
         p.GPIOTE_CH0,
-        Input::new(p.P0_11, Pull::Up),
+        Input::new(p.P0_11, Pull::Up).into(),
         InputChannelPolarity::HiToLo,
     );
     let button2 = InputChannel::new(
         p.GPIOTE_CH1,
-        Input::new(p.P0_12, Pull::Up),
+        Input::new(p.P0_12, Pull::Up).into(),
         InputChannelPolarity::HiToLo,
     );
     let button3 = InputChannel::new(
         p.GPIOTE_CH2,
-        Input::new(p.P0_24, Pull::Up),
+        Input::new(p.P0_24, Pull::Up).into(),
         InputChannelPolarity::HiToLo,
     );
     let button4 = InputChannel::new(
         p.GPIOTE_CH3,
-        Input::new(p.P0_25, Pull::Up),
+        Input::new(p.P0_25, Pull::Up).into(),
         InputChannelPolarity::HiToLo,
     );
 
     let led1 = OutputChannel::new(
         p.GPIOTE_CH4,
-        Output::new(p.P0_13, Level::Low, OutputDrive::Standard),
+        Output::new(p.P0_13, Level::Low, OutputDrive::Standard).into(),
         OutputChannelPolarity::Toggle,
     );
 
     let led2 = OutputChannel::new(
         p.GPIOTE_CH5,
-        Output::new(p.P0_14, Level::Low, OutputDrive::Standard),
+        Output::new(p.P0_14, Level::Low, OutputDrive::Standard).into(),
         OutputChannelPolarity::Toggle,
     );
 

--- a/examples/nrf52840/src/bin/pwm.rs
+++ b/examples/nrf52840/src/bin/pwm.rs
@@ -3,6 +3,7 @@
 
 use defmt::*;
 use embassy_executor::Spawner;
+use embassy_nrf::gpio::{Level, Output, OutputDrive};
 use embassy_nrf::pwm::{Prescaler, SimplePwm};
 use embassy_time::Timer;
 use {defmt_rtt as _, panic_probe as _};
@@ -71,7 +72,11 @@ static DUTY: [u16; 1024] = [
 #[embassy_executor::main]
 async fn main(_spawner: Spawner) {
     let p = embassy_nrf::init(Default::default());
-    let mut pwm = SimplePwm::new_4ch(p.PWM0, p.P0_13, p.P0_14, p.P0_16, p.P0_15);
+    let ch0 = Output::new(p.P0_13, Level::Low, OutputDrive::Standard);
+    let ch1 = Output::new(p.P0_14, Level::Low, OutputDrive::Standard);
+    let ch2 = Output::new(p.P0_16, Level::Low, OutputDrive::Standard);
+    let ch3 = Output::new(p.P0_15, Level::Low, OutputDrive::Standard);
+    let mut pwm = SimplePwm::new_4ch(p.PWM0, ch0.into(), ch1.into(), ch2.into(), ch3.into());
     pwm.set_prescaler(Prescaler::Div1);
     pwm.set_max_duty(32767);
     info!("pwm initialized!");

--- a/examples/nrf52840/src/bin/pwm_double_sequence.rs
+++ b/examples/nrf52840/src/bin/pwm_double_sequence.rs
@@ -3,6 +3,7 @@
 
 use defmt::*;
 use embassy_executor::Spawner;
+use embassy_nrf::gpio::{Level, Output, OutputDrive};
 use embassy_nrf::pwm::{
     Config, Prescaler, Sequence, SequenceConfig, SequenceMode, SequencePwm, Sequencer, StartSequence,
 };
@@ -25,7 +26,11 @@ async fn main(_spawner: Spawner) {
     seq_config.refresh = 624;
     // thus our sequence takes 5 * 5000ms or 25 seconds
 
-    let mut pwm = unwrap!(SequencePwm::new_1ch(p.PWM0, p.P0_13, config));
+    let mut pwm = unwrap!(SequencePwm::new_1ch(
+        p.PWM0,
+        Output::new(p.P0_13, Level::Low, OutputDrive::Standard).into(),
+        config
+    ));
 
     let sequence_0 = Sequence::new(&seq_words_0, seq_config.clone());
     let sequence_1 = Sequence::new(&seq_words_1, seq_config);

--- a/examples/nrf52840/src/bin/pwm_sequence.rs
+++ b/examples/nrf52840/src/bin/pwm_sequence.rs
@@ -3,6 +3,7 @@
 
 use defmt::*;
 use embassy_executor::Spawner;
+use embassy_nrf::gpio::{Level, Output, OutputDrive};
 use embassy_nrf::pwm::{Config, Prescaler, SequenceConfig, SequencePwm, SingleSequenceMode, SingleSequencer};
 use embassy_time::Timer;
 use {defmt_rtt as _, panic_probe as _};
@@ -22,7 +23,11 @@ async fn main(_spawner: Spawner) {
     seq_config.refresh = 624;
     // thus our sequence takes 5 * 5000ms or 25 seconds
 
-    let mut pwm = unwrap!(SequencePwm::new_1ch(p.PWM0, p.P0_13, config,));
+    let mut pwm = unwrap!(SequencePwm::new_1ch(
+        p.PWM0,
+        Output::new(p.P0_13, Level::Low, OutputDrive::Standard).into(),
+        config,
+    ));
 
     let sequencer = SingleSequencer::new(&mut pwm, &seq_words, seq_config);
     unwrap!(sequencer.start(SingleSequenceMode::Times(1)));

--- a/examples/nrf52840/src/bin/pwm_sequence_ppi.rs
+++ b/examples/nrf52840/src/bin/pwm_sequence_ppi.rs
@@ -5,7 +5,7 @@ use core::future::pending;
 
 use defmt::*;
 use embassy_executor::Spawner;
-use embassy_nrf::gpio::{Input, Pull};
+use embassy_nrf::gpio::{Input, Level, Output, OutputDrive, Pull};
 use embassy_nrf::gpiote::{InputChannel, InputChannelPolarity};
 use embassy_nrf::ppi::Ppi;
 use embassy_nrf::pwm::{Config, Prescaler, SequenceConfig, SequencePwm, SingleSequenceMode, SingleSequencer};
@@ -25,20 +25,24 @@ async fn main(_spawner: Spawner) {
     let mut seq_config = SequenceConfig::default();
     seq_config.refresh = 30;
 
-    let mut pwm = unwrap!(SequencePwm::new_1ch(p.PWM0, p.P0_13, config));
+    let mut pwm = unwrap!(SequencePwm::new_1ch(
+        p.PWM0,
+        Output::new(p.P0_13, Level::Low, OutputDrive::Standard).into(),
+        config
+    ));
 
     // pwm.stop() deconfigures pins, and then the task_start_seq0 task cant work
     // so its going to have to start running in order load the configuration
 
     let button1 = InputChannel::new(
         p.GPIOTE_CH0,
-        Input::new(p.P0_11, Pull::Up),
+        Input::new(p.P0_11, Pull::Up).into(),
         InputChannelPolarity::HiToLo,
     );
 
     let button2 = InputChannel::new(
         p.GPIOTE_CH1,
-        Input::new(p.P0_12, Pull::Up),
+        Input::new(p.P0_12, Pull::Up).into(),
         InputChannelPolarity::HiToLo,
     );
 

--- a/examples/nrf52840/src/bin/pwm_sequence_ws2812b.rs
+++ b/examples/nrf52840/src/bin/pwm_sequence_ws2812b.rs
@@ -3,6 +3,7 @@
 
 use defmt::*;
 use embassy_executor::Spawner;
+use embassy_nrf::gpio::{Level, Output, OutputDrive};
 use embassy_nrf::pwm::{
     Config, Prescaler, SequenceConfig, SequenceLoad, SequencePwm, SingleSequenceMode, SingleSequencer,
 };
@@ -41,7 +42,11 @@ async fn main(_spawner: Spawner) {
     config.sequence_load = SequenceLoad::Common;
     config.prescaler = Prescaler::Div1;
     config.max_duty = 20; // 1.25us (1s / 16Mhz * 20)
-    let mut pwm = unwrap!(SequencePwm::new_1ch(p.PWM0, p.P1_05, config));
+    let mut pwm = unwrap!(SequencePwm::new_1ch(
+        p.PWM0,
+        Output::new(p.P1_05, Level::Low, OutputDrive::Standard).into(),
+        config
+    ));
 
     // Declare the bits of 24 bits in a buffer we'll be
     // mutating later.

--- a/examples/nrf52840/src/bin/pwm_servo.rs
+++ b/examples/nrf52840/src/bin/pwm_servo.rs
@@ -3,6 +3,7 @@
 
 use defmt::*;
 use embassy_executor::Spawner;
+use embassy_nrf::gpio::{Level, Output, OutputDrive};
 use embassy_nrf::pwm::{Prescaler, SimplePwm};
 use embassy_time::Timer;
 use {defmt_rtt as _, panic_probe as _};
@@ -10,7 +11,7 @@ use {defmt_rtt as _, panic_probe as _};
 #[embassy_executor::main]
 async fn main(_spawner: Spawner) {
     let p = embassy_nrf::init(Default::default());
-    let mut pwm = SimplePwm::new_1ch(p.PWM0, p.P0_05);
+    let mut pwm = SimplePwm::new_1ch(p.PWM0, Output::new(p.P0_05, Level::Low, OutputDrive::Standard).into());
     // sg90 microervo requires 50hz or 20ms period
     // set_period can only set down to 125khz so we cant use it directly
     // Div128 is 125khz or 0.000008s or 0.008ms, 20/0.008 is 2500 is top

--- a/examples/nrf5340/src/bin/gpiote_channel.rs
+++ b/examples/nrf5340/src/bin/gpiote_channel.rs
@@ -14,22 +14,22 @@ async fn main(_spawner: Spawner) {
 
     let ch1 = InputChannel::new(
         p.GPIOTE_CH0,
-        Input::new(p.P0_23, Pull::Up),
+        Input::new(p.P0_23, Pull::Up).into(),
         InputChannelPolarity::HiToLo,
     );
     let ch2 = InputChannel::new(
         p.GPIOTE_CH1,
-        Input::new(p.P0_24, Pull::Up),
+        Input::new(p.P0_24, Pull::Up).into(),
         InputChannelPolarity::LoToHi,
     );
     let ch3 = InputChannel::new(
         p.GPIOTE_CH2,
-        Input::new(p.P0_08, Pull::Up),
+        Input::new(p.P0_08, Pull::Up).into(),
         InputChannelPolarity::Toggle,
     );
     let ch4 = InputChannel::new(
         p.GPIOTE_CH3,
-        Input::new(p.P0_09, Pull::Up),
+        Input::new(p.P0_09, Pull::Up).into(),
         InputChannelPolarity::Toggle,
     );
 


### PR DESCRIPTION
Adds reference types for GPIOs so that they can be borrowed by drivers without being torn down when the driver is dropped. This allows, for example, an `Output` to be used in a `SimplePwm`, then the `SimplePwm` can be dropped and a `gpiote::OutputChannel` created using the same `Output` without its configuration being reset (and the pin disconnected) in between.