### PR TITLE
RP: rp2040 overclocking

### DIFF
--- a/embassy-rp/src/clocks.rs
+++ b/embassy-rp/src/clocks.rs
@@ -160,7 +160,7 @@ pub enum CoreVoltage {
     V1_10 = 0b1011,
     /// 1.15V - Required for overclocking to 133-200MHz
     V1_15 = 0b1100,
-    /// 1.20V - Required for overclocking above 200MHz
+    /// 1.20V
     V1_20 = 0b1101,
     /// 1.25V
     V1_25 = 0b1110,

--- a/embassy-rp/src/pio_programs/clock_divider.rs
+++ b/embassy-rp/src/pio_programs/clock_divider.rs
@@ -1,0 +1,25 @@
+//! Helper functions for calculating PIO clock dividers
+
+use fixed::traits::ToFixed;
+use fixed::types::extra::U8;
+
+use crate::clocks::clk_sys_freq;
+
+/// Calculate a PIO clock divider value based on the desired target frequency.
+///
+/// # Arguments
+///
+/// * `target_hz` - The desired PIO clock frequency in Hz
+///
+/// # Returns
+///
+/// A fixed-point divider value suitable for use in a PIO state machine configuration
+#[inline]
+pub fn calculate_pio_clock_divider(target_hz: u32) -> fixed::FixedU32<U8> {
+    // Requires a non-zero frequency
+    assert!(target_hz > 0, "PIO clock frequency cannot be zero");
+
+    // Calculate the divider
+    let divider = (clk_sys_freq() + target_hz / 2) / target_hz;
+    divider.to_fixed()
+}

--- a/embassy-rp/src/pio_programs/mod.rs
+++ b/embassy-rp/src/pio_programs/mod.rs
@@ -1,5 +1,6 @@
 //! Pre-built pio programs for common interfaces
 
+pub mod clock_divider;
 pub mod hd44780;
 pub mod i2s;
 pub mod onewire;

--- a/embassy-rp/src/pio_programs/rotary_encoder.rs
+++ b/embassy-rp/src/pio_programs/rotary_encoder.rs
@@ -49,12 +49,12 @@ impl<'d, T: Instance, const SM: usize> PioEncoder<'d, T, SM> {
         cfg.set_in_pins(&[&pin_a, &pin_b]);
         cfg.fifo_join = FifoJoin::RxOnly;
         cfg.shift_in.direction = ShiftDirection::Left;
-        
+
         // Original: 10_000 at 125 MHz (12.5 KHz PIO clock)
         // Scale divider to maintain same PIO clock frequency at different system clocks
         let divider = (clk_sys_freq() as f32 / 12_500.0).to_fixed();
         cfg.clock_divider = divider;
-        
+
         cfg.use_program(&program.prg, &[]);
         sm.set_config(&cfg);
         sm.set_enable(true);

--- a/embassy-rp/src/pio_programs/stepper.rs
+++ b/embassy-rp/src/pio_programs/stepper.rs
@@ -6,6 +6,7 @@ use fixed::traits::ToFixed;
 use fixed::types::extra::U8;
 use fixed::FixedU32;
 
+use crate::clocks::clk_sys_freq;
 use crate::pio::{Common, Config, Direction, Instance, Irq, LoadedProgram, PioPin, StateMachine};
 use crate::Peri;
 
@@ -64,7 +65,7 @@ impl<'d, T: Instance, const SM: usize> PioStepper<'d, T, SM> {
         sm.set_pin_dirs(Direction::Out, &[&pin0, &pin1, &pin2, &pin3]);
         let mut cfg = Config::default();
         cfg.set_out_pins(&[&pin0, &pin1, &pin2, &pin3]);
-        cfg.clock_divider = (125_000_000 / (100 * 136)).to_fixed();
+        cfg.clock_divider = (clk_sys_freq() / (100 * 136)).to_fixed();
         cfg.use_program(&program.prg, &[]);
         sm.set_config(&cfg);
         sm.set_enable(true);
@@ -73,7 +74,7 @@ impl<'d, T: Instance, const SM: usize> PioStepper<'d, T, SM> {
 
     /// Set pulse frequency
     pub fn set_frequency(&mut self, freq: u32) {
-        let clock_divider: FixedU32<U8> = (125_000_000 / (freq * 136)).to_fixed();
+        let clock_divider: FixedU32<U8> = (clk_sys_freq() / (freq * 136)).to_fixed();
         assert!(clock_divider <= 65536, "clkdiv must be <= 65536");
         assert!(clock_divider >= 1, "clkdiv must be >= 1");
         self.sm.set_clock_divider(clock_divider);

--- a/examples/rp/src/bin/overclock.rs
+++ b/examples/rp/src/bin/overclock.rs
@@ -1,0 +1,60 @@
+#![no_std]
+#![no_main]
+
+use defmt::*;
+use embassy_executor::Spawner;
+use embassy_rp::clocks::{clk_sys_freq, ClockConfig};
+use embassy_rp::config::Config;
+use embassy_rp::gpio::{Level, Output};
+use embassy_time::{Duration, Instant, Timer};
+use {defmt_rtt as _, panic_probe as _};
+
+const COUNT_TO: i32 = 1_000_000;
+
+#[embassy_executor::main]
+async fn main(_spawner: Spawner) -> ! {
+    // Set up for clock frequency of 200 MHz
+    // We will need a clock config in the HAL config that supports this frequency
+    // The RP2040 can run at 200 MHz with a 12 MHz crystal
+    let config = Config::new(ClockConfig::crystal_freq(12_000_000, 200_000_000));
+
+    // Initialize the peripherals
+    let p = embassy_rp::init(config);
+
+    // Show CPU frequency for verification
+    let sys_freq = clk_sys_freq();
+    info!("System clock frequency: {} Hz", sys_freq);
+
+    // LED to indicate the system is running
+    let mut led = Output::new(p.PIN_25, Level::Low);
+
+    loop {
+        // Reset the counter at the start of measurement period
+        let mut counter = 0;
+
+        // Turn LED on while counting
+        led.set_high();
+
+        let start = Instant::now();
+
+        // Count to COUNT_TO
+        // This is a busy loop that will take some time to complete
+        while counter < COUNT_TO {
+            counter += 1;
+        }
+
+        let elapsed = start - Instant::now();
+
+        // Report the elapsed time
+        led.set_low();
+        info!(
+            "At {}Mhz: Elapsed time to count to {}: {}ms",
+            sys_freq / 1_000_000,
+            COUNT_TO,
+            elapsed.as_millis()
+        );
+
+        // Wait 2 seconds before starting the next measurement
+        Timer::after(Duration::from_secs(2)).await;
+    }
+}

--- a/examples/rp/src/bin/overclock.rs
+++ b/examples/rp/src/bin/overclock.rs
@@ -18,7 +18,7 @@ const COUNT_TO: i64 = 10_000_000;
 #[embassy_executor::main]
 async fn main(_spawner: Spawner) -> ! {
     // Set up for clock frequency of 200 MHz, setting all necessary defaults.
-    let config = Config::new(ClockConfig::crystal_freq(200_000_000));
+    let config = Config::new(ClockConfig::system_freq(200_000_000));
 
     // Show the voltage scale for verification
     info!("System core voltage: {}", Debug2Format(&config.clocks.core_voltage));

--- a/examples/rp/src/bin/overclock.rs
+++ b/examples/rp/src/bin/overclock.rs
@@ -1,6 +1,6 @@
 //! # Overclocking the RP2040 to 200 MHz
 //!
-//! This example demonstrates how to configure the RP2040 to run at 200 MHz using a higher level API.
+//! This example demonstrates how to configure the RP2040 to run at 200 MHz.
 
 #![no_std]
 #![no_main]
@@ -17,19 +17,18 @@ const COUNT_TO: i64 = 10_000_000;
 
 #[embassy_executor::main]
 async fn main(_spawner: Spawner) -> ! {
-    // Set up for clock frequency of 200 MHz
-    // This will set all the necessary defaults including slightly raised voltage
-    let config = Config::new(ClockConfig::at_sys_frequency_mhz(200));
+    // Set up for clock frequency of 200 MHz, setting all necessary defaults.
+    let config = Config::new(ClockConfig::crystal_freq(200_000_000));
 
     // Show the voltage scale for verification
-    info!("System core voltage: {}", Debug2Format(&config.clocks.voltage_scale));
+    info!("System core voltage: {}", Debug2Format(&config.clocks.core_voltage));
 
     // Initialize the peripherals
     let p = embassy_rp::init(config);
 
     // Show CPU frequency for verification
     let sys_freq = clk_sys_freq();
-    info!("System clock frequency: {} Hz", sys_freq);
+    info!("System clock frequency: {} MHz", sys_freq / 1_000_000);
 
     // LED to indicate the system is running
     let mut led = Output::new(p.PIN_25, Level::Low);

--- a/examples/rp/src/bin/overclock.rs
+++ b/examples/rp/src/bin/overclock.rs
@@ -14,7 +14,18 @@ const COUNT_TO: i64 = 10_000_000;
 #[embassy_executor::main]
 async fn main(_spawner: Spawner) -> ! {
     // Set up for clock frequency of 200 MHz
-    let config = Config::new(ClockConfig::with_speed_mhz(200));
+    // This will set all the necessary defaults including slightly raised voltage
+    // See embassy_rp::clocks::ClockConfig for more options, including full manual control
+    let config = Config::new(ClockConfig::at_sys_frequency_mhz(200));
+
+    // Show the voltage scale and brownout-detection for verification
+    info!("System core voltage: {}", Debug2Format(&config.clocks.voltage_scale));
+    // info!(
+    //     "Brownout detection: {}",
+    //     Debug2Format(&config.clocks.brownout_detection)
+    // );
+
+    // Initialize the peripherals
     let p = embassy_rp::init(config);
 
     // Show CPU frequency for verification

--- a/examples/rp/src/bin/overclock.rs
+++ b/examples/rp/src/bin/overclock.rs
@@ -1,9 +1,13 @@
+//! # Overclocking the RP2040 to 200 MHz
+//!
+//! This example demonstrates how to configure the RP2040 to run at 200 MHz using a higher level API.
+
 #![no_std]
 #![no_main]
 
 use defmt::*;
 use embassy_executor::Spawner;
-use embassy_rp::clocks::{clk_sys_freq, ClockConfig, VoltageScale};
+use embassy_rp::clocks::{clk_sys_freq, ClockConfig};
 use embassy_rp::config::Config;
 use embassy_rp::gpio::{Level, Output};
 use embassy_time::{Duration, Instant, Timer};
@@ -15,15 +19,10 @@ const COUNT_TO: i64 = 10_000_000;
 async fn main(_spawner: Spawner) -> ! {
     // Set up for clock frequency of 200 MHz
     // This will set all the necessary defaults including slightly raised voltage
-    // See embassy_rp::clocks::ClockConfig for more options, including full manual control
     let config = Config::new(ClockConfig::at_sys_frequency_mhz(200));
 
-    // Show the voltage scale and brownout-detection for verification
+    // Show the voltage scale for verification
     info!("System core voltage: {}", Debug2Format(&config.clocks.voltage_scale));
-    // info!(
-    //     "Brownout detection: {}",
-    //     Debug2Format(&config.clocks.brownout_detection)
-    // );
 
     // Initialize the peripherals
     let p = embassy_rp::init(config);
@@ -64,14 +63,3 @@ async fn main(_spawner: Spawner) -> ! {
         Timer::after(Duration::from_secs(2)).await;
     }
 }
-
-// let config = Config::new(ClockConfig::with_speed_mhz_test_voltage(125, Some(VoltageScale::V1_10)));
-// let config = Config::default();
-// let config = Config::new(ClockConfig::with_speed_mhz_test_voltage_extended_delay(
-//     200,                       // Standard 125MHz clock
-//     Some(VoltageScale::V1_15), // 1.15V voltage
-//     Some(1000),                // 1000μs (1ms) stabilization delay - significantly longer than default
-// ));
-// Initialize the peripherals
-
-// let p = embassy_rp::init(Default::default()); //testing the bog standard

--- a/examples/rp/src/bin/overclock_manual.rs
+++ b/examples/rp/src/bin/overclock_manual.rs
@@ -1,0 +1,81 @@
+//! # Overclocking the RP2040 to 200 MHz manually
+//!
+//! This example demonstrates how to manually configure the RP2040 to run at 200 MHz.
+
+#![no_std]
+#![no_main]
+
+use defmt::*;
+use embassy_executor::Spawner;
+use embassy_rp::clocks;
+use embassy_rp::clocks::{ClockConfig, PllConfig, VoltageScale};
+use embassy_rp::config::Config;
+use embassy_rp::gpio::{Level, Output};
+use embassy_time::{Duration, Instant, Timer};
+use {defmt_rtt as _, panic_probe as _};
+
+const COUNT_TO: i64 = 10_000_000;
+
+/// Configure the RP2040 for 200 MHz operation by manually specifying
+/// all the required parameters instead of using higher-level APIs.
+fn configure_manual_overclock() -> Config {
+    // Set the PLL configuration manually, starting from default values
+    let mut config = Config::default();
+
+    // Set the system clock to 200 MHz using a PLL with a reference frequency of 12 MHz
+    config.clocks = ClockConfig::manual_pll(
+        12_000_000,
+        PllConfig {
+            refdiv: 1,
+            fbdiv: 100,
+            post_div1: 3,
+            post_div2: 2,
+        },
+        // For 200 MHz, we need a voltage scale of 1.15V
+        Some(VoltageScale::V1_15),
+    );
+
+    config
+}
+
+#[embassy_executor::main]
+async fn main(_spawner: Spawner) -> ! {
+    // Initialize with our manual overclock configuration
+    let p = embassy_rp::init(configure_manual_overclock());
+
+    // Verify the actual system clock frequency
+    let sys_freq = clocks::clk_sys_freq();
+    info!("System clock frequency: {} MHz", sys_freq / 1_000_000);
+
+    // LED to indicate the system is running
+    let mut led = Output::new(p.PIN_25, Level::Low);
+
+    loop {
+        // Reset the counter at the start of measurement period
+        let mut counter = 0;
+
+        // Turn LED on while counting
+        led.set_high();
+
+        let start = Instant::now();
+
+        // This is a busy loop that will take some time to complete
+        while counter < COUNT_TO {
+            counter += 1;
+        }
+
+        let elapsed = Instant::now() - start;
+
+        // Report the elapsed time
+        led.set_low();
+        info!(
+            "At {}Mhz: Elapsed time to count to {}: {}ms",
+            sys_freq / 1_000_000,
+            counter,
+            elapsed.as_millis()
+        );
+
+        // Wait 2 seconds before starting the next measurement
+        Timer::after(Duration::from_secs(2)).await;
+    }
+}

--- a/examples/rp/src/bin/overclock_manual.rs
+++ b/examples/rp/src/bin/overclock_manual.rs
@@ -8,7 +8,7 @@
 use defmt::*;
 use embassy_executor::Spawner;
 use embassy_rp::clocks;
-use embassy_rp::clocks::{ClockConfig, PllConfig, VoltageScale};
+use embassy_rp::clocks::{ClockConfig, CoreVoltage, PllConfig};
 use embassy_rp::config::Config;
 use embassy_rp::gpio::{Level, Output};
 use embassy_time::{Duration, Instant, Timer};
@@ -16,23 +16,21 @@ use {defmt_rtt as _, panic_probe as _};
 
 const COUNT_TO: i64 = 10_000_000;
 
-/// Configure the RP2040 for 200 MHz operation by manually specifying
-/// all the required parameters instead of using higher-level APIs.
+/// Configure the RP2040 for 200 MHz operation by manually specifying the PLL settings.
 fn configure_manual_overclock() -> Config {
     // Set the PLL configuration manually, starting from default values
     let mut config = Config::default();
 
-    // Set the system clock to 200 MHz using a PLL with a reference frequency of 12 MHz
+    // Set the system clock to 200 MHz
     config.clocks = ClockConfig::manual_pll(
-        12_000_000,
+        12_000_000, // Crystal frequency, 12 MHz is common. If using custom, set to your value.
         PllConfig {
-            refdiv: 1,
-            fbdiv: 100,
-            post_div1: 3,
-            post_div2: 2,
+            refdiv: 1,    // Reference divider
+            fbdiv: 100,   // Feedback divider
+            post_div1: 3, // Post divider 1
+            post_div2: 2, // Post divider 2
         },
-        // For 200 MHz, we need a voltage scale of 1.15V
-        Some(VoltageScale::V1_15),
+        CoreVoltage::V1_15, // Core voltage, should be set to V1_15 for 200 MHz
     );
 
     config

--- a/tests/rp/src/bin/overclock.rs
+++ b/tests/rp/src/bin/overclock.rs
@@ -1,14 +1,23 @@
 #![no_std]
 #![no_main]
+#![cfg_attr(not(feature = "rp2040"), allow(unused_imports))]
+
 #[cfg(feature = "rp2040")]
 teleprobe_meta::target!(b"rpi-pico");
 
+#[cfg(feature = "rp2040")]
 use defmt::{assert, assert_eq, info};
+#[cfg(feature = "rp2040")]
 use embassy_executor::Spawner;
+#[cfg(feature = "rp2040")]
 use embassy_rp::config::Config;
+#[cfg(feature = "rp2040")]
 use embassy_rp::gpio::{Input, Pull};
+#[cfg(feature = "rp2040")]
 use embassy_rp::pwm::{Config as PwmConfig, Pwm};
+#[cfg(feature = "rp2040")]
 use embassy_time::{Instant, Timer};
+#[cfg(feature = "rp2040")]
 use {defmt_rtt as _, panic_probe as _};
 
 #[cfg(feature = "rp2040")]
@@ -58,5 +67,13 @@ async fn main(_spawner: Spawner) {
 
     info!("All tests passed at 200MHz!");
     info!("Overclock test successful");
+    cortex_m::asm::bkpt();
+}
+
+#[cfg(not(feature = "rp2040"))]
+#[embassy_executor::main]
+async fn main(_spawner: embassy_executor::Spawner) {
+    // This is an empty placeholder main function for non-RP2040 targets
+    // It should never be called since the test only runs on RP2040
     cortex_m::asm::bkpt();
 }

--- a/tests/rp/src/bin/overclock.rs
+++ b/tests/rp/src/bin/overclock.rs
@@ -31,7 +31,7 @@ async fn main(_spawner: Spawner) {
     // Initialize with 200MHz clock configuration for RP2040, other chips will use default clock
     #[cfg(feature = "rp2040")]
     {
-        config.clocks = ClockConfig::crystal_freq(200_000_000);
+        config.clocks = ClockConfig::system_freq(200_000_000);
         let voltage = config.clocks.core_voltage;
         assert!(matches!(voltage, CoreVoltage::V1_15), "Expected voltage scale V1_15");
     }

--- a/tests/rp/src/bin/overclock.rs
+++ b/tests/rp/src/bin/overclock.rs
@@ -6,7 +6,9 @@ teleprobe_meta::target!(b"rpi-pico");
 #[cfg(feature = "rp235xb")]
 teleprobe_meta::target!(b"pimoroni-pico-plus-2");
 
-use defmt::{assert, assert_eq, info};
+use defmt::info;
+#[cfg(feature = "rp2040")]
+use defmt::{assert, assert_eq};
 use embassy_executor::Spawner;
 use embassy_rp::clocks;
 #[cfg(feature = "rp2040")]
@@ -21,7 +23,10 @@ const COUNT_TO: i64 = 10_000_000;
 
 #[embassy_executor::main]
 async fn main(_spawner: Spawner) {
+    #[cfg(feature = "rp2040")]
     let mut config = Config::default();
+    #[cfg(not(feature = "rp2040"))]
+    let config = Config::default();
 
     // Initialize with 200MHz clock configuration for RP2040, other chips will use default clock
     #[cfg(feature = "rp2040")]

--- a/tests/rp/src/bin/overclock.rs
+++ b/tests/rp/src/bin/overclock.rs
@@ -14,7 +14,7 @@ use embassy_rp::clocks;
 #[cfg(feature = "rp2040")]
 use embassy_rp::clocks::ClockConfig;
 #[cfg(feature = "rp2040")]
-use embassy_rp::clocks::VoltageScale;
+use embassy_rp::clocks::CoreVoltage;
 use embassy_rp::config::Config;
 use embassy_time::Instant;
 use {defmt_rtt as _, panic_probe as _};
@@ -31,15 +31,15 @@ async fn main(_spawner: Spawner) {
     // Initialize with 200MHz clock configuration for RP2040, other chips will use default clock
     #[cfg(feature = "rp2040")]
     {
-        config.clocks = ClockConfig::at_sys_frequency_mhz(200);
-        let voltage = config.clocks.voltage_scale.unwrap();
-        assert!(matches!(voltage, VoltageScale::V1_15), "Expected voltage scale V1_15");
+        config.clocks = ClockConfig::crystal_freq(200_000_000);
+        let voltage = config.clocks.core_voltage;
+        assert!(matches!(voltage, CoreVoltage::V1_15), "Expected voltage scale V1_15");
     }
 
     let _p = embassy_rp::init(config);
 
+    // Test the system speed
     let (time_elapsed, clk_sys_freq) = {
-        // Test the system speed
         let mut counter = 0;
         let start = Instant::now();
         while counter < COUNT_TO {

--- a/tests/rp/src/bin/overclock.rs
+++ b/tests/rp/src/bin/overclock.rs
@@ -1,0 +1,62 @@
+#![no_std]
+#![no_main]
+#[cfg(feature = "rp2040")]
+teleprobe_meta::target!(b"rpi-pico");
+
+use defmt::{assert, assert_eq, info};
+use embassy_executor::Spawner;
+use embassy_rp::config::Config;
+use embassy_rp::gpio::{Input, Pull};
+use embassy_rp::pwm::{Config as PwmConfig, Pwm};
+use embassy_time::{Instant, Timer};
+use {defmt_rtt as _, panic_probe as _};
+
+#[cfg(feature = "rp2040")]
+#[embassy_executor::main]
+async fn main(_spawner: Spawner) {
+    // Initialize with 200MHz clock configuration for RP2040
+    let mut config = Config::default();
+    config.clocks = embassy_rp::clocks::ClockConfig::at_sys_frequency_mhz(200);
+
+    let p = embassy_rp::init(config);
+
+    info!("RP2040 overclocked to 200MHz!");
+    info!("System clock frequency: {} Hz", embassy_rp::clocks::clk_sys_freq());
+
+    // Test 1: Timer accuracy at 200MHz
+    info!("Testing timer accuracy at 200MHz...");
+    let start = Instant::now();
+    Timer::after_millis(100).await;
+    let end = Instant::now();
+    let ms = (end - start).as_millis();
+    info!("slept for {} ms", ms);
+    assert!(ms >= 99);
+    assert!(ms < 110);
+    info!("Timer test passed!");
+
+    // Test 2: PWM functionality at 200MHz
+    info!("Testing PWM functionality at 200MHz...");
+    let pwm_cfg = {
+        let mut c = PwmConfig::default();
+        c.divider = ((embassy_rp::clocks::clk_sys_freq() / 1_000_000) as u8).into();
+        c.top = 10000;
+        c.compare_a = 5000;
+        c.compare_b = 5000;
+        c
+    };
+
+    // Test PWM output
+    let pin1 = Input::new(p.PIN_9, Pull::None);
+    let _pwm = Pwm::new_output_a(p.PWM_SLICE3, p.PIN_6, pwm_cfg);
+    Timer::after_millis(1).await;
+    let initial_state = pin1.is_low();
+    Timer::after_millis(5).await;
+    assert_eq!(pin1.is_high(), initial_state);
+    Timer::after_millis(5).await;
+    assert_eq!(pin1.is_low(), initial_state);
+    info!("PWM test passed!");
+
+    info!("All tests passed at 200MHz!");
+    info!("Overclock test successful");
+    cortex_m::asm::bkpt();
+}


### PR DESCRIPTION
This PR introduces the ability to initialize the rp2040 with other frequencies than 125Mhz. A user can either use a higher level API to achieve a setting or set the PLL manually. See the two new examples for more details.

Should close #3919 

Disclosure for Review:
I have used AI Agents to help me code this and my level of experience is limited, most of what I touched I learned as I went. 
The agent I fed with the Pi Pico SDK as well as the datasheet, in the datasheet I tried to make sure I read up on all the things touched to see if i spot discrepancies. Those I found, I corrected.

I have tested:
- compile for rp2040
- compile for rp235x
- run blinky on both
- look for hardcoded 125Mhz throughout the HAL, fix that
- run my examples
- run a few of the other rp examples to see if i immediately spot a thing not working

EDIT:
- added tests for the calculations into the clocks module, found overflow issues and fixed them
- added a test to tests/rp 