### PR TITLE
AtomicWaker: take and wake

### DIFF
--- a/embassy-executor/tests/test.rs
+++ b/embassy-executor/tests/test.rs
@@ -156,8 +156,7 @@ fn waking_after_completion_does_not_poll() {
     let (executor, trace) = setup();
     executor.spawner().spawn(task1(trace.clone(), waker)).unwrap();
 
-    unsafe { executor.poll() };
-    waker.wake();
+    // Task registers waker, then exits
     unsafe { executor.poll() };
 
     // Exited task may be waken but is not polled
@@ -176,7 +175,6 @@ fn waking_after_completion_does_not_poll() {
             "pend",       // spawning a task pends the executor
             "poll task1", //
             "pend",       // manual wake, gets cleared by poll
-            "pend",       // manual wake, single pend for two wakes
             "pend",       // respawning a task pends the executor
             "poll task1", //
         ]

--- a/embassy-sync/CHANGELOG.md
+++ b/embassy-sync/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+- AtomicWaker now drops the Waker after waking it.
+
 ## 0.6.2 - 2025-01-15
 
 - Add dynamic dispatch variant of `Pipe`.

--- a/embassy-sync/src/waitqueue/atomic_waker.rs
+++ b/embassy-sync/src/waitqueue/atomic_waker.rs
@@ -32,11 +32,9 @@ impl<M: RawMutex> GenericAtomicWaker<M> {
 
     /// Wake the registered waker, if any.
     pub fn wake(&self) {
-        self.waker.lock(|cell| {
-            if let Some(w) = cell.take() {
-                w.wake();
-            }
-        })
+        if let Some(waker) = self.waker.lock(|cell| cell.take()) {
+            waker.wake();
+        }
     }
 }
 

--- a/embassy-sync/src/waitqueue/atomic_waker.rs
+++ b/embassy-sync/src/waitqueue/atomic_waker.rs
@@ -33,9 +33,8 @@ impl<M: RawMutex> GenericAtomicWaker<M> {
     /// Wake the registered waker, if any.
     pub fn wake(&self) {
         self.waker.lock(|cell| {
-            if let Some(w) = cell.replace(None) {
-                w.wake_by_ref();
-                cell.set(Some(w));
+            if let Some(w) = cell.take() {
+                w.wake();
             }
         })
     }


### PR DESCRIPTION
While in embassy tasks are static, in other environments it's usually not the norm. There, keeping the Waker may force the task that registered it to remain allocated, potentially indefinitely. Given that AtomicWaker is used in peripheral drivers that aren't tied to a particular async framework, letting go of the Waker once it's not needed is probably better than keeping it around.

I expect this change to surface some issues around Futures that only register the waker once and expect it to stick around.