### PR TITLE
chore: use `probe-rs` instead of `probe-run`

### DIFF
--- a/docs/examples/basic/.cargo/config.toml
+++ b/docs/examples/basic/.cargo/config.toml
@@ -1,6 +1,6 @@
 [target.'cfg(all(target_arch = "arm", target_os = "none"))']
-# replace nRF82840_xxAA with your chip as listed in `probe-run --list-chips`
-runner = "probe-run --chip nRF52840_xxAA"
+# replace nRF82840_xxAA with your chip as listed in `probe-rs chip list`
+runner = "probe-rs run --chip nRF52840_xxAA"
 
 [build]
 target = "thumbv7em-none-eabi"

--- a/docs/examples/layer-by-layer/.cargo/config.toml
+++ b/docs/examples/layer-by-layer/.cargo/config.toml
@@ -1,5 +1,6 @@
 [target.'cfg(all(target_arch = "arm", target_os = "none"))']
-runner = "probe-run --chip STM32L475VG"
+# replace your chip as listed in `probe-rs chip list`
+runner = "probe-rs run --chip STM32L475VG"
 
 rustflags = [
     "-C", "link-arg=--nmagic",

--- a/docs/pages/getting_started.adoc
+++ b/docs/pages/getting_started.adoc
@@ -66,7 +66,7 @@ If everything worked correctly, you should see a blinking LED on your board, and
 [source]
 ----
     Finished dev [unoptimized + debuginfo] target(s) in 1m 56s
-     Running `probe-run --chip STM32F407VGTx target/thumbv7em-none-eabi/debug/blinky`
+     Running `probe-rs run --chip STM32F407VGTx target/thumbv7em-none-eabi/debug/blinky`
 (HOST) INFO  flashing program (71.36 KiB)
 (HOST) INFO  success!
 ────────────────────────────────────────────────────────────────────────────────


### PR DESCRIPTION
I found a few remaining deprecated `probe-run` cases.