### PR TITLE
doc: Tweak the example `rust-toolchain.toml`

### DIFF
--- a/docs/pages/new_project.adoc
+++ b/docs/pages/new_project.adoc
@@ -150,7 +150,7 @@ stm32g474-example
 # Before upgrading check that everything is available on all tier1 targets here:
 # https://rust-lang.github.io/rustup-components-history
 [toolchain]
-channel = "nightly-2023-11-01"
+channel = "1.85"
 components = [ "rust-src", "rustfmt", "llvm-tools", "miri" ]
 targets = ["thumbv7em-none-eabi"]
 ----

--- a/docs/pages/project_structure.adoc
+++ b/docs/pages/project_structure.adoc
@@ -85,9 +85,9 @@ A minimal example:
 [source,toml]
 ----
 [toolchain]
-channel = "nightly-2023-08-19" # <- as of writing, this is the exact rust version embassy uses
+channel = "1.85" # <- as of writing, this is the exact rust version embassy uses
 components = [ "rust-src", "rustfmt" ] # <- optionally add "llvm-tools-preview" for some extra features like "cargo size"
 targets = [
-    "thumbv6m-none-eabi" # <-change for your platform
+    "thumbv6m-none-eabi" # <- change for your platform
 ]
 ----


### PR DESCRIPTION
The [document](https://embassy.dev/book/#_project_structure) shows an example of `rust-toolchain.toml` with toolchain version `nightly-2023-08-19`. I think this can pick some other version than nightly to let the reader know Embassy can use the stable toolchain.


```toml
[toolchain]
channel = "nightly-2023-08-19" # <- as of writing, this is the exact rust version embassy uses
components = [ "rust-src", "rustfmt" ] # <- optionally add "llvm-tools-preview" for some extra features like "cargo size"
targets = [
    "thumbv6m-none-eabi" # <-change for your platform
]
```

This pull request uses the same version as https://github.com/embassy-rs/embassy/blob/main/rust-toolchain.toml