### PR TITLE
Clarify docs for signal and watch

### DIFF
--- a/embassy-sync/src/signal.rs
+++ b/embassy-sync/src/signal.rs
@@ -6,7 +6,7 @@ use core::task::{Context, Poll, Waker};
 use crate::blocking_mutex::raw::RawMutex;
 use crate::blocking_mutex::Mutex;
 
-/// Single-slot signaling primitive.
+/// Single-slot signaling primitive for a _single_ consumer.
 ///
 /// This is similar to a [`Channel`](crate::channel::Channel) with a buffer size of 1, except
 /// "sending" to it (calling [`Signal::signal`]) when full will overwrite the previous value instead
@@ -17,6 +17,7 @@ use crate::blocking_mutex::Mutex;
 /// updates.
 ///
 /// For more advanced use cases, you might want to use [`Channel`](crate::channel::Channel) instead.
+/// For multiple consumers, use [`Watch`](crate::watch::Watch) instead.
 ///
 /// Signals are generally declared as `static`s and then borrowed as required.
 ///
@@ -106,7 +107,7 @@ where
         })
     }
 
-    /// Future that completes when this Signal has been signaled.
+    /// Future that completes when this Signal has been signaled, taking the value out of the signal.
     pub fn wait(&self) -> impl Future<Output = T> + '_ {
         poll_fn(move |cx| self.poll_wait(cx))
     }

--- a/embassy-sync/src/watch.rs
+++ b/embassy-sync/src/watch.rs
@@ -10,7 +10,7 @@ use crate::blocking_mutex::raw::RawMutex;
 use crate::blocking_mutex::Mutex;
 use crate::waitqueue::MultiWakerRegistration;
 
-/// The `Watch` is a single-slot signaling primitive that allows multiple receivers to concurrently await
+/// The `Watch` is a single-slot signaling primitive that allows _multiple_ (`N`) receivers to concurrently await
 /// changes to the value. Unlike a [`Signal`](crate::signal::Signal), `Watch` supports multiple receivers,
 /// and unlike a [`PubSubChannel`](crate::pubsub::PubSubChannel), `Watch` immediately overwrites the previous
 /// value when a new one is sent, without waiting for all receivers to read the previous value.
@@ -298,7 +298,7 @@ impl<M: RawMutex, T: Clone, const N: usize> WatchBehavior<T> for Watch<M, T, N> 
 }
 
 impl<M: RawMutex, T: Clone, const N: usize> Watch<M, T, N> {
-    /// Create a new `Watch` channel.
+    /// Create a new `Watch` channel for `N` receivers.
     pub const fn new() -> Self {
         Self {
             mutex: Mutex::new(RefCell::new(WatchState {


### PR DESCRIPTION
This is an attempt at clarifying the documentation around `Signal` and `Watch` after searching for a bug where `Signal` had been used instead of `Watch` with multiple consumers.

`Watch` was lacking any description of the generic parameter `N`, which is the number of receivers. I have added that at two places.

`Signal` was lacking the description from the top-level docs that it is intended for a _single_ consumer. The `wait` function was not explicit about taking the value from the signal (though it could be inferred since the Future returns  `T`).

Let me know if there is anything I can change to improve this PR. 

Also, maybe we could add some clarification on why Signal does not implement the Receiver like Watch does? Watch does seem to check how many consumers there are, while Signal lets you add multiple consumers, leading to "unexpected" behavior.