### PR TITLE
Fix `rotary_encoder_rfx` example to handle negative values

### DIFF
--- a/examples/rp235x/src/bin/pio_rotary_encoder_rxf.rs
+++ b/examples/rp235x/src/bin/pio_rotary_encoder_rxf.rs
@@ -88,8 +88,8 @@ impl<'d, T: Instance, const SM: usize> PioEncoder<'d, T, SM> {
         Self { sm }
     }
 
-    pub async fn read(&mut self) -> u32 {
-        self.sm.get_rxf_entry(0)
+    pub async fn read(&mut self) -> i32 {
+        self.sm.get_rxf_entry(0) as i32
     }
 }
 


### PR DESCRIPTION
The current example code shows negative values as `u32` as shown below. This pull request fixes it by simply casting to `i32`.

```
0.000395 INFO  Count: 7
└─ pio_rotary_encoder_rxf::____embassy_main_task::{async_fn#0} @ src\bin\pio_rotary_encoder_rxf.rs:109
1.000447 INFO  Count: 0
└─ pio_rotary_encoder_rxf::____embassy_main_task::{async_fn#0} @ src\bin\pio_rotary_encoder_rxf.rs:109
2.000466 INFO  Count: 0
└─ pio_rotary_encoder_rxf::____embassy_main_task::{async_fn#0} @ src\bin\pio_rotary_encoder_rxf.rs:109
3.000485 INFO  Count: 4294967295
└─ pio_rotary_encoder_rxf::____embassy_main_task::{async_fn#0} @ src\bin\pio_rotary_encoder_rxf.rs:109
4.000509 INFO  Count: 4294967295
└─ pio_rotary_encoder_rxf::____embassy_main_task::{async_fn#0} @ src\bin\pio_rotary_encoder_rxf.rs:109
5.000533 INFO  Count: 4294967294
└─ pio_rotary_encoder_rxf::____embassy_main_task::{async_fn#0} @ src\bin\pio_rotary_encoder_rxf.rs:109
```

(BTW, I think the first line should report `Count: 0`. It seems it reads a previous value in RX. Probably it should be initialized somehow? Since I don't know about embedded things well enough to fix this, this pull request doesn't address this...)