### PR TITLE
Fix h7 SAI example start sequence

### DIFF
--- a/examples/stm32h7/src/bin/sai.rs
+++ b/examples/stm32h7/src/bin/sai.rs
@@ -112,8 +112,10 @@ async fn main(_spawner: Spawner) {
     let mut buf = [0u32; HALF_DMA_BUFFER_LENGTH];
 
     loop {
-        sai_receiver.read(&mut buf).await.unwrap();
+        // write() must be called before read() to start the master (transmitter)
+        // clock used by the receiver
         sai_transmitter.write(&buf).await.unwrap();
+        sai_receiver.read(&mut buf).await.unwrap();
     }
 }
 


### PR DESCRIPTION
This commit fixes the start sequence of the stm32h7 SAI example, ensuring the master subblock is started via `transmitter.write()` before first calling `receiver.read()` for the slave subblock. See #4165.