### PR TITLE
chore: Wrap link_section attribute with unsafe

### DIFF
--- a/docs/pages/faq.adoc
+++ b/docs/pages/faq.adoc
@@ -268,7 +268,7 @@ General steps:
 1. Find out which memory region BDMA has access to. You can get this information from the bus matrix and the memory mapping table in the STM32 datasheet.
 2. Add the memory region to `memory.x`, you can modify the generated one from https://github.com/embassy-rs/stm32-data-generated/tree/main/data/chips.
 3. You might need to modify `build.rs` to make cargo pick up the modified `memory.x`.
-4. In your code, access the defined memory region using `#[link_section = ".xxx"]`
+4. In your code, access the defined memory region using `#[unsafe(link_section = ".xxx")]`
 5. Copy data to that region before using BDMA.
 
 See link:https://github.com/embassy-rs/embassy/blob/main/examples/stm32h7/src/bin/spi_bdma.rs[SMT32H7 SPI BDMA example] for more details.

--- a/embassy-rp/Cargo.toml
+++ b/embassy-rp/Cargo.toml
@@ -86,7 +86,7 @@ boot2-w25x10cl = []
 ## Have embassy-rp not provide the boot2 so you can use your own.
 ## Place your own in the ".boot2" section like:
 ## ```
-## #[link_section = ".boot2"]
+## #[unsafe(link_section = ".boot2")]
 ## #[used]
 ## static BOOT2: [u8; 256] = [0; 256]; // Provide your own with e.g. include_bytes!
 ## ```
@@ -109,7 +109,7 @@ imagedef-nonsecure-exe = []
 ## ```ignore
 ## use embassy_rp::block::ImageDef;
 ##
-## #[link_section = ".start_block"]
+## #[unsafe(link_section = ".start_block")]
 ## #[used]
 ## static IMAGE_DEF: ImageDef = ImageDef::secure_exe(); // Update this with your own implementation.
 ## ```

--- a/embassy-rp/src/bootsel.rs
+++ b/embassy-rp/src/bootsel.rs
@@ -36,7 +36,7 @@ mod ram_helpers {
     /// This function must live in ram. It uses inline asm to avoid any
     /// potential calls to ABI functions that might be in flash.
     #[inline(never)]
-    #[link_section = ".data.ram_func"]
+    #[unsafe(link_section = ".data.ram_func")]
     #[cfg(target_arch = "arm")]
     pub unsafe fn read_cs_status() -> GpioStatus {
         let result: u32;

--- a/embassy-rp/src/flash.rs
+++ b/embassy-rp/src/flash.rs
@@ -623,7 +623,7 @@ mod ram_helpers {
     /// Length of data must be a multiple of 4096
     /// addr must be aligned to 4096
     #[inline(never)]
-    #[link_section = ".data.ram_func"]
+    #[unsafe(link_section = ".data.ram_func")]
     #[cfg(feature = "rp2040")]
     unsafe fn write_flash_inner(addr: u32, len: u32, data: Option<&[u8]>, ptrs: *const FlashFunctionPointers) {
         #[cfg(target_arch = "arm")]
@@ -688,7 +688,7 @@ mod ram_helpers {
     /// Length of data must be a multiple of 4096
     /// addr must be aligned to 4096
     #[inline(never)]
-    #[link_section = ".data.ram_func"]
+    #[unsafe(link_section = ".data.ram_func")]
     #[cfg(feature = "_rp235x")]
     unsafe fn write_flash_inner(addr: u32, len: u32, data: Option<&[u8]>, ptrs: *const FlashFunctionPointers) {
         let data = data.map(|d| d.as_ptr()).unwrap_or(core::ptr::null());
@@ -807,7 +807,7 @@ mod ram_helpers {
     ///
     /// Credit: taken from `rp2040-flash` (also licensed Apache+MIT)
     #[inline(never)]
-    #[link_section = ".data.ram_func"]
+    #[unsafe(link_section = ".data.ram_func")]
     #[cfg(feature = "rp2040")]
     unsafe fn read_flash_inner(cmd: FlashCommand, ptrs: *const FlashFunctionPointers) {
         #[cfg(target_arch = "arm")]

--- a/embassy-rp/src/lib.rs
+++ b/embassy-rp/src/lib.rs
@@ -434,13 +434,13 @@ macro_rules! select_bootloader {
     ( $( $feature:literal => $loader:ident, )+ default => $default:ident ) => {
         $(
             #[cfg(feature = $feature)]
-            #[link_section = ".boot2"]
+            #[unsafe(link_section = ".boot2")]
             #[used]
             static BOOT2: [u8; 256] = rp2040_boot2::$loader;
         )*
 
         #[cfg(not(any( $( feature = $feature),* )))]
-        #[link_section = ".boot2"]
+        #[unsafe(link_section = ".boot2")]
         #[used]
         static BOOT2: [u8; 256] = rp2040_boot2::$default;
     }
@@ -463,13 +463,13 @@ macro_rules! select_imagedef {
     ( $( $feature:literal => $imagedef:ident, )+ default => $default:ident ) => {
         $(
             #[cfg(feature = $feature)]
-            #[link_section = ".start_block"]
+            #[unsafe(link_section = ".start_block")]
             #[used]
             static IMAGE_DEF: crate::block::ImageDef = crate::block::ImageDef::$imagedef();
         )*
 
         #[cfg(not(any( $( feature = $feature),* )))]
-        #[link_section = ".start_block"]
+        #[unsafe(link_section = ".start_block")]
         #[used]
         static IMAGE_DEF: crate::block::ImageDef = crate::block::ImageDef::$default();
     }

--- a/embassy-rp/src/multicore.rs
+++ b/embassy-rp/src/multicore.rs
@@ -90,7 +90,7 @@ impl<const SIZE: usize> Stack<SIZE> {
 
 #[cfg(all(feature = "rt", feature = "rp2040"))]
 #[interrupt]
-#[link_section = ".data.ram_func"]
+#[unsafe(link_section = ".data.ram_func")]
 unsafe fn SIO_IRQ_PROC1() {
     let sio = pac::SIO;
     // Clear IRQ
@@ -115,7 +115,7 @@ unsafe fn SIO_IRQ_PROC1() {
 
 #[cfg(all(feature = "rt", feature = "_rp235x"))]
 #[interrupt]
-#[link_section = ".data.ram_func"]
+#[unsafe(link_section = ".data.ram_func")]
 unsafe fn SIO_IRQ_FIFO() {
     let sio = pac::SIO;
     // Clear IRQ

--- a/embassy-stm32-wpan/src/tables.rs
+++ b/embassy-stm32-wpan/src/tables.rs
@@ -190,94 +190,94 @@ pub struct RefTable {
 }
 
 // --------------------- ref table ---------------------
-#[link_section = "TL_REF_TABLE"]
+#[unsafe(link_section = "TL_REF_TABLE")]
 pub static mut TL_REF_TABLE: MaybeUninit<RefTable> = MaybeUninit::uninit();
 
-#[link_section = "MB_MEM1"]
+#[unsafe(link_section = "MB_MEM1")]
 pub static mut TL_DEVICE_INFO_TABLE: Aligned<A4, MaybeUninit<DeviceInfoTable>> = Aligned(MaybeUninit::uninit());
 
-#[link_section = "MB_MEM1"]
+#[unsafe(link_section = "MB_MEM1")]
 pub static mut TL_BLE_TABLE: Aligned<A4, MaybeUninit<BleTable>> = Aligned(MaybeUninit::uninit());
 
-#[link_section = "MB_MEM1"]
+#[unsafe(link_section = "MB_MEM1")]
 pub static mut TL_THREAD_TABLE: Aligned<A4, MaybeUninit<ThreadTable>> = Aligned(MaybeUninit::uninit());
 
-#[link_section = "MB_MEM1"]
+#[unsafe(link_section = "MB_MEM1")]
 pub static mut TL_LLD_TESTS_TABLE: Aligned<A4, MaybeUninit<LldTestsTable>> = Aligned(MaybeUninit::uninit());
 
-#[link_section = "MB_MEM1"]
+#[unsafe(link_section = "MB_MEM1")]
 pub static mut TL_BLE_LLD_TABLE: Aligned<A4, MaybeUninit<BleLldTable>> = Aligned(MaybeUninit::uninit());
 
-#[link_section = "MB_MEM1"]
+#[unsafe(link_section = "MB_MEM1")]
 pub static mut TL_SYS_TABLE: Aligned<A4, MaybeUninit<SysTable>> = Aligned(MaybeUninit::uninit());
 
-#[link_section = "MB_MEM1"]
+#[unsafe(link_section = "MB_MEM1")]
 pub static mut TL_MEM_MANAGER_TABLE: Aligned<A4, MaybeUninit<MemManagerTable>> = Aligned(MaybeUninit::uninit());
 
-#[link_section = "MB_MEM1"]
+#[unsafe(link_section = "MB_MEM1")]
 pub static mut TL_TRACES_TABLE: Aligned<A4, MaybeUninit<TracesTable>> = Aligned(MaybeUninit::uninit());
 
-#[link_section = "MB_MEM1"]
+#[unsafe(link_section = "MB_MEM1")]
 pub static mut TL_MAC_802_15_4_TABLE: Aligned<A4, MaybeUninit<Mac802_15_4Table>> = Aligned(MaybeUninit::uninit());
 
-#[link_section = "MB_MEM1"]
+#[unsafe(link_section = "MB_MEM1")]
 pub static mut TL_ZIGBEE_TABLE: Aligned<A4, MaybeUninit<ZigbeeTable>> = Aligned(MaybeUninit::uninit());
 
 // --------------------- tables ---------------------
-#[link_section = "MB_MEM1"]
+#[unsafe(link_section = "MB_MEM1")]
 pub static mut FREE_BUF_QUEUE: Aligned<A4, MaybeUninit<LinkedListNode>> = Aligned(MaybeUninit::uninit());
 
 #[allow(dead_code)]
-#[link_section = "MB_MEM1"]
+#[unsafe(link_section = "MB_MEM1")]
 pub static mut TRACES_EVT_QUEUE: Aligned<A4, MaybeUninit<LinkedListNode>> = Aligned(MaybeUninit::uninit());
 
-#[link_section = "MB_MEM2"]
+#[unsafe(link_section = "MB_MEM2")]
 pub static mut CS_BUFFER: Aligned<A4, MaybeUninit<[u8; TL_PACKET_HEADER_SIZE + TL_EVT_HEADER_SIZE + TL_CS_EVT_SIZE]>> =
     Aligned(MaybeUninit::uninit());
 
-#[link_section = "MB_MEM2"]
+#[unsafe(link_section = "MB_MEM2")]
 pub static mut EVT_QUEUE: Aligned<A4, MaybeUninit<LinkedListNode>> = Aligned(MaybeUninit::uninit());
 
-#[link_section = "MB_MEM2"]
+#[unsafe(link_section = "MB_MEM2")]
 pub static mut SYSTEM_EVT_QUEUE: Aligned<A4, MaybeUninit<LinkedListNode>> = Aligned(MaybeUninit::uninit());
 
 // --------------------- app tables ---------------------
 #[cfg(feature = "mac")]
-#[link_section = "MB_MEM2"]
+#[unsafe(link_section = "MB_MEM2")]
 pub static mut MAC_802_15_4_CMD_BUFFER: Aligned<A4, MaybeUninit<CmdPacket>> = Aligned(MaybeUninit::uninit());
 
 #[cfg(feature = "mac")]
-#[link_section = "MB_MEM2"]
+#[unsafe(link_section = "MB_MEM2")]
 pub static mut MAC_802_15_4_NOTIF_RSP_EVT_BUFFER: MaybeUninit<
     Aligned<A4, [u8; TL_PACKET_HEADER_SIZE + TL_EVT_HEADER_SIZE + 255]>,
 > = MaybeUninit::uninit();
 
-#[link_section = "MB_MEM2"]
+#[unsafe(link_section = "MB_MEM2")]
 pub static mut EVT_POOL: Aligned<A4, MaybeUninit<[u8; POOL_SIZE]>> = Aligned(MaybeUninit::uninit());
 
-#[link_section = "MB_MEM2"]
+#[unsafe(link_section = "MB_MEM2")]
 pub static mut SYS_CMD_BUF: Aligned<A4, MaybeUninit<CmdPacket>> = Aligned(MaybeUninit::uninit());
 
-#[link_section = "MB_MEM2"]
+#[unsafe(link_section = "MB_MEM2")]
 pub static mut SYS_SPARE_EVT_BUF: Aligned<A4, MaybeUninit<[u8; TL_PACKET_HEADER_SIZE + TL_EVT_HEADER_SIZE + 255]>> =
     Aligned(MaybeUninit::uninit());
 
 #[cfg(feature = "mac")]
-#[link_section = "MB_MEM2"]
+#[unsafe(link_section = "MB_MEM2")]
 pub static mut MAC_802_15_4_CNFINDNOT: Aligned<A4, MaybeUninit<[u8; C_SIZE_CMD_STRING]>> =
     Aligned(MaybeUninit::uninit());
 
 #[cfg(feature = "ble")]
-#[link_section = "MB_MEM1"]
+#[unsafe(link_section = "MB_MEM1")]
 pub static mut BLE_CMD_BUFFER: Aligned<A4, MaybeUninit<CmdPacket>> = Aligned(MaybeUninit::uninit());
 
 #[cfg(feature = "ble")]
-#[link_section = "MB_MEM2"]
+#[unsafe(link_section = "MB_MEM2")]
 pub static mut BLE_SPARE_EVT_BUF: Aligned<A4, MaybeUninit<[u8; TL_PACKET_HEADER_SIZE + TL_EVT_HEADER_SIZE + 255]>> =
     Aligned(MaybeUninit::uninit());
 
 #[cfg(feature = "ble")]
-#[link_section = "MB_MEM2"]
+#[unsafe(link_section = "MB_MEM2")]
 //                                                 fuck these "magic" numbers from ST ---v---v
 pub static mut HCI_ACL_DATA_BUFFER: Aligned<A4, MaybeUninit<[u8; TL_PACKET_HEADER_SIZE + 5 + 251]>> =
     Aligned(MaybeUninit::uninit());

--- a/embassy-stm32/src/lib.rs
+++ b/embassy-stm32/src/lib.rs
@@ -331,7 +331,7 @@ mod dual_core {
     /// use core::mem::MaybeUninit;
     /// use embassy_stm32::{init_secondary, SharedData};
     ///
-    /// #[link_section = ".ram_d3"]
+    /// #[unsafe(link_section = ".ram_d3")]
     /// static SHARED_DATA: MaybeUninit<SharedData> = MaybeUninit::uninit();
     ///
     /// init_secondary(&SHARED_DATA);

--- a/examples/boot/application/stm32wl/src/bin/a.rs
+++ b/examples/boot/application/stm32wl/src/bin/a.rs
@@ -20,7 +20,7 @@ static APP_B: &[u8] = &[0, 1, 2, 3];
 #[cfg(not(feature = "skip-include"))]
 static APP_B: &[u8] = include_bytes!("../../b.bin");
 
-#[link_section = ".shared_data"]
+#[unsafe(link_section = ".shared_data")]
 static SHARED_DATA: MaybeUninit<SharedData> = MaybeUninit::uninit();
 
 #[embassy_executor::main]

--- a/examples/boot/application/stm32wl/src/bin/b.rs
+++ b/examples/boot/application/stm32wl/src/bin/b.rs
@@ -11,7 +11,7 @@ use embassy_stm32::SharedData;
 use embassy_time::Timer;
 use panic_reset as _;
 
-#[link_section = ".shared_data"]
+#[unsafe(link_section = ".shared_data")]
 static SHARED_DATA: MaybeUninit<SharedData> = MaybeUninit::uninit();
 
 #[embassy_executor::main]

--- a/examples/mimxrt6/build.rs
+++ b/examples/mimxrt6/build.rs
@@ -25,7 +25,7 @@ fn main() {
         .write_all(
             format!(
                 r##"
-#[link_section = ".biv"]
+#[unsafe(link_section = ".biv")]
 #[used]
 static BOOT_IMAGE_VERSION: u32 = 0x{:02x}{:02x}{:02x}00;
 "##,

--- a/examples/mimxrt6/src/lib.rs
+++ b/examples/mimxrt6/src/lib.rs
@@ -6,15 +6,15 @@ use {defmt_rtt as _, panic_probe as _};
 // auto-generated version information from Cargo.toml
 include!(concat!(env!("OUT_DIR"), "/biv.rs"));
 
-#[link_section = ".otfad"]
+#[unsafe(link_section = ".otfad")]
 #[used]
 static OTFAD: [u8; 256] = [0; 256];
 
 #[rustfmt::skip]
-#[link_section = ".fcb"]
+#[unsafe(link_section = ".fcb")]
 #[used]
 static FCB: FlexSPIFlashConfigurationBlock = FlexSPIFlashConfigurationBlock::build();
 
-#[link_section = ".keystore"]
+#[unsafe(link_section = ".keystore")]
 #[used]
 static KEYSTORE: [u8; 2048] = [0; 2048];

--- a/examples/rp235x/src/bin/blinky.rs
+++ b/examples/rp235x/src/bin/blinky.rs
@@ -14,7 +14,7 @@ use {defmt_rtt as _, panic_probe as _};
 
 // Program metadata for `picotool info`.
 // This isn't needed, but it's recomended to have these minimal entries.
-#[link_section = ".bi_entries"]
+#[unsafe(link_section = ".bi_entries")]
 #[used]
 pub static PICOTOOL_ENTRIES: [embassy_rp::binary_info::EntryAddr; 4] = [
     embassy_rp::binary_info::rp_program_name!(c"Blinky Example"),

--- a/examples/rp235x/src/bin/blinky_wifi.rs
+++ b/examples/rp235x/src/bin/blinky_wifi.rs
@@ -18,7 +18,7 @@ use {defmt_rtt as _, panic_probe as _};
 
 // Program metadata for `picotool info`.
 // This isn't needed, but it's recommended to have these minimal entries.
-#[link_section = ".bi_entries"]
+#[unsafe(link_section = ".bi_entries")]
 #[used]
 pub static PICOTOOL_ENTRIES: [embassy_rp::binary_info::EntryAddr; 4] = [
     embassy_rp::binary_info::rp_program_name!(c"Blinky Example"),

--- a/examples/rp235x/src/bin/blinky_wifi_pico_plus_2.rs
+++ b/examples/rp235x/src/bin/blinky_wifi_pico_plus_2.rs
@@ -18,7 +18,7 @@ use {defmt_rtt as _, panic_probe as _};
 
 // Program metadata for `picotool info`.
 // This isn't needed, but it's recomended to have these minimal entries.
-#[link_section = ".bi_entries"]
+#[unsafe(link_section = ".bi_entries")]
 #[used]
 pub static PICOTOOL_ENTRIES: [embassy_rp::binary_info::EntryAddr; 4] = [
     embassy_rp::binary_info::rp_program_name!(c"Blinky Example"),

--- a/examples/rp235x/src/bin/pio_rotary_encoder_rxf.rs
+++ b/examples/rp235x/src/bin/pio_rotary_encoder_rxf.rs
@@ -16,7 +16,7 @@ use pio::{Common, Config, FifoJoin, Instance, InterruptHandler, Pio, PioPin, Shi
 use {defmt_rtt as _, panic_probe as _};
 
 // Program metadata for `picotool info`
-#[link_section = ".bi_entries"]
+#[unsafe(link_section = ".bi_entries")]
 #[used]
 pub static PICOTOOL_ENTRIES: [embassy_rp::binary_info::EntryAddr; 4] = [
     embassy_rp::binary_info::rp_program_name!(c"example_pio_rotary_encoder_rxf"),

--- a/examples/stm32h7/src/bin/adc_dma.rs
+++ b/examples/stm32h7/src/bin/adc_dma.rs
@@ -8,7 +8,7 @@ use embassy_stm32::Config;
 use embassy_time::Timer;
 use {defmt_rtt as _, panic_probe as _};
 
-#[link_section = ".ram_d3"]
+#[unsafe(link_section = ".ram_d3")]
 static mut DMA_BUF: [u16; 2] = [0; 2];
 
 #[embassy_executor::main]

--- a/examples/stm32h7/src/bin/sai.rs
+++ b/examples/stm32h7/src/bin/sai.rs
@@ -16,9 +16,9 @@ const DMA_BUFFER_LENGTH: usize = HALF_DMA_BUFFER_LENGTH * 2; //  2 half-blocks
 const SAMPLE_RATE: u32 = 48000;
 
 //DMA buffer must be in special region. Refer https://embassy.dev/book/#_stm32_bdma_only_working_out_of_some_ram_regions
-#[link_section = ".sram1_bss"]
+#[unsafe(link_section = ".sram1_bss")]
 static mut TX_BUFFER: GroundedArrayCell<u32, DMA_BUFFER_LENGTH> = GroundedArrayCell::uninit();
-#[link_section = ".sram1_bss"]
+#[unsafe(link_section = ".sram1_bss")]
 static mut RX_BUFFER: GroundedArrayCell<u32, DMA_BUFFER_LENGTH> = GroundedArrayCell::uninit();
 
 #[embassy_executor::main]

--- a/examples/stm32h7/src/bin/spi_bdma.rs
+++ b/examples/stm32h7/src/bin/spi_bdma.rs
@@ -16,7 +16,7 @@ use static_cell::StaticCell;
 use {defmt_rtt as _, panic_probe as _};
 
 // Defined in memory.x
-#[link_section = ".ram_d3"]
+#[unsafe(link_section = ".ram_d3")]
 static mut RAM_D3: GroundedArrayCell<u8, 256> = GroundedArrayCell::uninit();
 
 #[embassy_executor::task]

--- a/examples/stm32h723/src/bin/spdifrx.rs
+++ b/examples/stm32h723/src/bin/spdifrx.rs
@@ -24,10 +24,10 @@ const HALF_DMA_BUFFER_LENGTH: usize = BLOCK_LENGTH * CHANNEL_COUNT;
 const DMA_BUFFER_LENGTH: usize = HALF_DMA_BUFFER_LENGTH * 2; //  2 half-blocks
 
 // DMA buffers must be in special regions. Refer https://embassy.dev/book/#_stm32_bdma_only_working_out_of_some_ram_regions
-#[link_section = ".sram1"]
+#[unsafe(link_section = ".sram1")]
 static mut SPDIFRX_BUFFER: GroundedArrayCell<u32, DMA_BUFFER_LENGTH> = GroundedArrayCell::uninit();
 
-#[link_section = ".sram4"]
+#[unsafe(link_section = ".sram4")]
 static mut SAI_BUFFER: GroundedArrayCell<u32, DMA_BUFFER_LENGTH> = GroundedArrayCell::uninit();
 
 #[embassy_executor::main]

--- a/examples/stm32h755cm4/src/bin/blinky.rs
+++ b/examples/stm32h755cm4/src/bin/blinky.rs
@@ -10,7 +10,7 @@ use embassy_stm32::SharedData;
 use embassy_time::Timer;
 use {defmt_rtt as _, panic_probe as _};
 
-#[link_section = ".ram_d3.shared_data"]
+#[unsafe(link_section = ".ram_d3.shared_data")]
 static SHARED_DATA: MaybeUninit<SharedData> = MaybeUninit::uninit();
 
 #[embassy_executor::main]

--- a/examples/stm32h755cm7/src/bin/blinky.rs
+++ b/examples/stm32h755cm7/src/bin/blinky.rs
@@ -10,7 +10,7 @@ use embassy_stm32::SharedData;
 use embassy_time::Timer;
 use {defmt_rtt as _, panic_probe as _};
 
-#[link_section = ".ram_d3.shared_data"]
+#[unsafe(link_section = ".ram_d3.shared_data")]
 static SHARED_DATA: MaybeUninit<SharedData> = MaybeUninit::uninit();
 
 #[embassy_executor::main]

--- a/examples/stm32wl/src/bin/blinky.rs
+++ b/examples/stm32wl/src/bin/blinky.rs
@@ -10,7 +10,7 @@ use embassy_stm32::SharedData;
 use embassy_time::Timer;
 use {defmt_rtt as _, panic_probe as _};
 
-#[link_section = ".shared_data"]
+#[unsafe(link_section = ".shared_data")]
 static SHARED_DATA: MaybeUninit<SharedData> = MaybeUninit::uninit();
 
 #[embassy_executor::main]

--- a/examples/stm32wl/src/bin/button.rs
+++ b/examples/stm32wl/src/bin/button.rs
@@ -9,7 +9,7 @@ use embassy_stm32::gpio::{Input, Level, Output, Pull, Speed};
 use embassy_stm32::SharedData;
 use {defmt_rtt as _, panic_probe as _};
 
-#[link_section = ".shared_data"]
+#[unsafe(link_section = ".shared_data")]
 static SHARED_DATA: MaybeUninit<SharedData> = MaybeUninit::uninit();
 
 #[entry]

--- a/examples/stm32wl/src/bin/button_exti.rs
+++ b/examples/stm32wl/src/bin/button_exti.rs
@@ -10,7 +10,7 @@ use embassy_stm32::gpio::Pull;
 use embassy_stm32::SharedData;
 use {defmt_rtt as _, panic_probe as _};
 
-#[link_section = ".shared_data"]
+#[unsafe(link_section = ".shared_data")]
 static SHARED_DATA: MaybeUninit<SharedData> = MaybeUninit::uninit();
 
 #[embassy_executor::main]

--- a/examples/stm32wl/src/bin/flash.rs
+++ b/examples/stm32wl/src/bin/flash.rs
@@ -9,7 +9,7 @@ use embassy_stm32::flash::Flash;
 use embassy_stm32::SharedData;
 use {defmt_rtt as _, panic_probe as _};
 
-#[link_section = ".shared_data"]
+#[unsafe(link_section = ".shared_data")]
 static SHARED_DATA: MaybeUninit<SharedData> = MaybeUninit::uninit();
 
 #[embassy_executor::main]

--- a/examples/stm32wl/src/bin/random.rs
+++ b/examples/stm32wl/src/bin/random.rs
@@ -14,7 +14,7 @@ bind_interrupts!(struct Irqs{
     RNG => rng::InterruptHandler<peripherals::RNG>;
 });
 
-#[link_section = ".shared_data"]
+#[unsafe(link_section = ".shared_data")]
 static SHARED_DATA: MaybeUninit<SharedData> = MaybeUninit::uninit();
 
 #[embassy_executor::main]

--- a/examples/stm32wl/src/bin/rtc.rs
+++ b/examples/stm32wl/src/bin/rtc.rs
@@ -12,7 +12,7 @@ use embassy_stm32::{Config, SharedData};
 use embassy_time::Timer;
 use {defmt_rtt as _, panic_probe as _};
 
-#[link_section = ".shared_data"]
+#[unsafe(link_section = ".shared_data")]
 static SHARED_DATA: MaybeUninit<SharedData> = MaybeUninit::uninit();
 
 #[embassy_executor::main]

--- a/examples/stm32wl/src/bin/uart_async.rs
+++ b/examples/stm32wl/src/bin/uart_async.rs
@@ -14,7 +14,7 @@ bind_interrupts!(struct Irqs{
     LPUART1 => InterruptHandler<peripherals::LPUART1>;
 });
 
-#[link_section = ".shared_data"]
+#[unsafe(link_section = ".shared_data")]
 static SHARED_DATA: MaybeUninit<SharedData> = MaybeUninit::uninit();
 
 /*


### PR DESCRIPTION
Rust 2024 edition requires marking several attributes as `unsafe`, and `link_section` is one of these.

https://doc.rust-lang.org/nightly/edition-guide/rust-2024/unsafe-attributes.html

As Embassy doesn't migrate to Rust 2024 edition, so this isn't a problem yet. However, if a user create a new Embassy project with the latest Rust toolchain, its edition is Rust 2024, so the compilation fails with this error:

```
error: unsafe attribute used without unsafe
  --> src/bin/tmp.rs:21:3
   |
21 | #[link_section = ".bi_entries"]
   |   ^^^^^^^^^^^^ usage of unsafe attribute
   |
help: wrap the attribute in `unsafe(...)`
   |
21 | #[unsafe(link_section = ".bi_entries")]
   |   +++++++                            +

error: could not compile `rp2350-blink` (bin "tmp") due to 1 previous error
```

In order to mark attributes as unsafe, Rust >=1.82 is needed. As Embassy uses Rust 1.85, it won't be a problem to introduce these `unsafe` without waiting for Rust 2024.