### PR TITLE
Fix clippy::bad_bit_mask

### DIFF
--- a/embassy-stm32/src/spdifrx/mod.rs
+++ b/embassy-stm32/src/spdifrx/mod.rs
@@ -223,7 +223,7 @@ impl<'d, T: Instance> Spdifrx<'d, T> {
         };
 
         for sample in data.as_mut() {
-            if (*sample & (0x0002_u32)) == 0x0001 {
+            if (*sample & (0x0002_u32)) != 0 {
                 // Discard invalid samples, setting them to mute level.
                 *sample = 0;
             } else {


### PR DESCRIPTION
I got this clippy lint in `src/spdifrx/mod.rs`. I'm not very confident, but I guess the intention was `0b0010` instead of `0x0001`. This pull request fixes it by replacing it with `!= 0`.

```
error: incompatible bit mask: `_ & 2` can never be equal to `1`
   --> src/spdifrx/mod.rs:226:16
    |
226 |             if (*sample & (0x0002_u32)) != 0x0001 {
    |                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#bad_bit_mask
    = note: `#[deny(clippy::bad_bit_mask)]` on by default
```