### PR TITLE
embassy-usb-dfu: Modify Reset trait

### DIFF
--- a/embassy-usb-dfu/src/application.rs
+++ b/embassy-usb-dfu/src/application.rs
@@ -81,10 +81,15 @@ impl<MARK: DfuMarker, RST: Reset> Handler for Control<MARK, RST> {
 
         match Request::try_from(req.request) {
             Ok(Request::Detach) => {
-                trace!("Received DETACH, awaiting USB reset");
                 self.detach_start = Some(Instant::now());
                 self.timeout = Some(Duration::from_millis(req.value as u64));
                 self.state = State::AppDetach;
+                if self.attrs.contains(DfuAttributes::WILL_DETACH) {
+                    trace!("Received DETACH, performing reset");
+                    self.reset();
+                } else {
+                    trace!("Received DETACH, awaiting USB reset");
+                }
                 Some(OutResponse::Accepted)
             }
             _ => None,

--- a/embassy-usb-dfu/src/lib.rs
+++ b/embassy-usb-dfu/src/lib.rs
@@ -26,10 +26,10 @@ compile_error!("usb-dfu must be compiled with exactly one of `dfu`, or `applicat
 /// This crate exposes `ResetImmediate` when compiled with cortex-m or esp32c3 support, which immediately issues a
 /// reset request without interfacing with any other peripherals.
 ///
-/// If alternate behaviour is desired, a custom implementation of Reset can be provided as a type argument to the usb_dfu function.
+/// If alternate behaviour is desired, a custom implementation of Reset can be provided as an argument to the usb_dfu function.
 pub trait Reset {
     /// Reset the device.
-    fn sys_reset() -> !;
+    fn sys_reset(&self);
 }
 
 /// Reset immediately.
@@ -38,7 +38,7 @@ pub struct ResetImmediate;
 
 #[cfg(feature = "esp32c3-hal")]
 impl Reset for ResetImmediate {
-    fn sys_reset() -> ! {
+    fn sys_reset(&self) {
         esp32c3_hal::reset::software_reset();
         loop {}
     }
@@ -50,7 +50,7 @@ pub struct ResetImmediate;
 
 #[cfg(feature = "cortex-m")]
 impl Reset for ResetImmediate {
-    fn sys_reset() -> ! {
+    fn sys_reset(&self) {
         cortex_m::peripheral::SCB::sys_reset()
     }
 }

--- a/examples/boot/application/stm32wb-dfu/src/main.rs
+++ b/examples/boot/application/stm32wb-dfu/src/main.rs
@@ -44,7 +44,7 @@ async fn main(_spawner: Spawner) {
     let mut config_descriptor = [0; 256];
     let mut bos_descriptor = [0; 256];
     let mut control_buf = [0; 64];
-    let mut state = Control::new(firmware_state, DfuAttributes::CAN_DOWNLOAD);
+    let mut state = Control::new(firmware_state, DfuAttributes::CAN_DOWNLOAD, ResetImmediate);
     let mut builder = Builder::new(
         driver,
         config,
@@ -54,7 +54,7 @@ async fn main(_spawner: Spawner) {
         &mut control_buf,
     );
 
-    usb_dfu::<_, _, ResetImmediate>(&mut builder, &mut state, Duration::from_millis(2500));
+    usb_dfu(&mut builder, &mut state, Duration::from_millis(2500));
 
     let mut dev = builder.build();
     dev.run().await

--- a/examples/boot/bootloader/stm32wb-dfu/src/main.rs
+++ b/examples/boot/bootloader/stm32wb-dfu/src/main.rs
@@ -55,7 +55,7 @@ fn main() -> ! {
         let mut config_descriptor = [0; 256];
         let mut bos_descriptor = [0; 256];
         let mut control_buf = [0; 4096];
-        let mut state = Control::new(updater, DfuAttributes::CAN_DOWNLOAD);
+        let mut state = Control::new(updater, DfuAttributes::CAN_DOWNLOAD, ResetImmediate);
         let mut builder = Builder::new(
             driver,
             config,
@@ -77,7 +77,7 @@ fn main() -> ! {
             msos::PropertyData::RegMultiSz(DEVICE_INTERFACE_GUIDS),
         ));
 
-        usb_dfu::<_, _, _, ResetImmediate, 4096>(&mut builder, &mut state);
+        usb_dfu::<_, _, _, _, 4096>(&mut builder, &mut state);
 
         let mut dev = builder.build();
         embassy_futures::block_on(dev.run());


### PR DESCRIPTION
Modify the `Reset` trait's `reset` function to return `()` instead of `!` and adds a `&self` parameter. This makes it easier to implement cleanup before resetting the whole chip.

I also tacked on a change to reset immediately if `WILL_DETACH` is set, instead of waiting for a USB reset from the host since the WinUSB driver isn't capable of generating this USB reset.