### PR TITLE
Stm32: Fix opamp copy pasta mistake

### DIFF
--- a/embassy-stm32/src/opamp.rs
+++ b/embassy-stm32/src/opamp.rs
@@ -239,7 +239,7 @@ impl<'d, T: Instance> OpAmp<'d, T> {
 
         T::regs().csr().modify(|w| {
             w.set_vp_sel(VpSel::from_bits(pin.channel()));
-            w.set_vm_sel(VmSel::OUTPUT);
+            w.set_vm_sel(VmSel::PGA);
             w.set_pga_gain(pga_gain);
             w.set_opaintoen(true);
             w.set_opampen(true);


### PR DESCRIPTION
The opamp was refactored in #4089 but I think there was a copy paste error.

The old code:
https://github.com/embassy-rs/embassy/blob/d41eeeae79388f219bf6a84e2f7bde9f6b532516/embassy-stm32/src/opamp.rs#L149-L156

When a gain was selected (which is now always true in the new function), the VmSel is 0x10 (PGA). But in the new code it was left on OUTPUT.

I was seeing weird ADC values and this fixes it.