### PR TITLE
[embassy-usb-dfu] support function level WinUSB GUIDs

### DIFF
--- a/embassy-usb-dfu/src/application.rs
+++ b/embassy-usb-dfu/src/application.rs
@@ -2,7 +2,7 @@ use embassy_boot::BlockingFirmwareState;
 use embassy_time::{Duration, Instant};
 use embassy_usb::control::{InResponse, OutResponse, Recipient, RequestType};
 use embassy_usb::driver::Driver;
-use embassy_usb::{msos, Builder, Handler};
+use embassy_usb::{Builder, FunctionBuilder, Handler};
 use embedded_storage::nor_flash::NorFlash;
 
 use crate::consts::{
@@ -130,22 +130,13 @@ pub fn usb_dfu<'d, D: Driver<'d>, MARK: DfuMarker, RST: Reset>(
     builder: &mut Builder<'d, D>,
     handler: &'d mut Control<MARK, RST>,
     timeout: Duration,
-    winusb_guids: Option<&'d [&str]>,
+    func_modifier: impl Fn(&mut FunctionBuilder<'_, 'd, D>),
 ) {
     let mut func = builder.function(0x00, 0x00, 0x00);
-    if let Some(winusb_guids) = winusb_guids {
-        // We add MSOS headers so that the device automatically gets assigned the WinUSB driver on Windows.
-        // Otherwise users need to do this manually using a tool like Zadig.
-        //
-        // Adding them here on the function level appears to only be needed for compositive devices.
-        // In addition to being on the function level, they should also be added to the device level.
-        //
-        func.msos_feature(msos::CompatibleIdFeatureDescriptor::new("WINUSB", ""));
-        func.msos_feature(msos::RegistryPropertyFeatureDescriptor::new(
-            "DeviceInterfaceGUIDs",
-            msos::PropertyData::RegMultiSz(winusb_guids),
-        ));
-    }
+
+    // Here we give users the opportunity to add their own function level MSOS headers for instance.
+    // This is useful when DFU functionality is part of a composite USB device.
+    func_modifier(&mut func);
 
     let mut iface = func.interface();
     let mut alt = iface.alt_setting(USB_CLASS_APPN_SPEC, APPN_SPEC_SUBCLASS_DFU, DFU_PROTOCOL_RT, None);

--- a/embassy-usb-dfu/src/application.rs
+++ b/embassy-usb-dfu/src/application.rs
@@ -137,8 +137,9 @@ pub fn usb_dfu<'d, D: Driver<'d>, MARK: DfuMarker, RST: Reset>(
         // We add MSOS headers so that the device automatically gets assigned the WinUSB driver on Windows.
         // Otherwise users need to do this manually using a tool like Zadig.
         //
-        // Adding them here on the function level appears to only work for compositive devices though.
-        // For non-composite devices they should be placed on the device level instead.
+        // Adding them here on the function level appears to only be needed for compositive devices.
+        // In addition to being on the function level, they should also be added to the device level.
+        //
         func.msos_feature(msos::CompatibleIdFeatureDescriptor::new("WINUSB", ""));
         func.msos_feature(msos::RegistryPropertyFeatureDescriptor::new(
             "DeviceInterfaceGUIDs",

--- a/embassy-usb-dfu/src/dfu.rs
+++ b/embassy-usb-dfu/src/dfu.rs
@@ -193,8 +193,9 @@ pub fn usb_dfu<'d, D: Driver<'d>, DFU: NorFlash, STATE: NorFlash, RST: Reset, co
         // We add MSOS headers so that the device automatically gets assigned the WinUSB driver on Windows.
         // Otherwise users need to do this manually using a tool like Zadig.
         //
-        // Adding them here on the function level appears to only work for compositive devices though.
-        // For non-composite devices they should be placed on the device level instead.
+        // Adding them here on the function level appears to only be needed for compositive devices.
+        // In addition to being on the function level, they should also be added to the device level.
+        //
         func.msos_feature(msos::CompatibleIdFeatureDescriptor::new("WINUSB", ""));
         func.msos_feature(msos::RegistryPropertyFeatureDescriptor::new(
             "DeviceInterfaceGUIDs",

--- a/embassy-usb-dfu/src/dfu.rs
+++ b/embassy-usb-dfu/src/dfu.rs
@@ -1,7 +1,7 @@
 use embassy_boot::{AlignedBuffer, BlockingFirmwareUpdater, FirmwareUpdaterError};
 use embassy_usb::control::{InResponse, OutResponse, Recipient, RequestType};
 use embassy_usb::driver::Driver;
-use embassy_usb::{msos, Builder, Handler};
+use embassy_usb::{Builder, FunctionBuilder, Handler};
 use embedded_storage::nor_flash::{NorFlash, NorFlashErrorKind};
 
 use crate::consts::{
@@ -186,22 +186,13 @@ impl<'d, DFU: NorFlash, STATE: NorFlash, RST: Reset, const BLOCK_SIZE: usize> Ha
 pub fn usb_dfu<'d, D: Driver<'d>, DFU: NorFlash, STATE: NorFlash, RST: Reset, const BLOCK_SIZE: usize>(
     builder: &mut Builder<'d, D>,
     handler: &'d mut Control<'d, DFU, STATE, RST, BLOCK_SIZE>,
-    winusb_guids: Option<&'d [&str]>,
+    func_modifier: impl Fn(&mut FunctionBuilder<'_, 'd, D>),
 ) {
     let mut func = builder.function(USB_CLASS_APPN_SPEC, APPN_SPEC_SUBCLASS_DFU, DFU_PROTOCOL_DFU);
-    if let Some(winusb_guids) = winusb_guids {
-        // We add MSOS headers so that the device automatically gets assigned the WinUSB driver on Windows.
-        // Otherwise users need to do this manually using a tool like Zadig.
-        //
-        // Adding them here on the function level appears to only be needed for compositive devices.
-        // In addition to being on the function level, they should also be added to the device level.
-        //
-        func.msos_feature(msos::CompatibleIdFeatureDescriptor::new("WINUSB", ""));
-        func.msos_feature(msos::RegistryPropertyFeatureDescriptor::new(
-            "DeviceInterfaceGUIDs",
-            msos::PropertyData::RegMultiSz(winusb_guids),
-        ));
-    }
+
+    // Here we give users the opportunity to add their own function level MSOS headers for instance.
+    // This is useful when DFU functionality is part of a composite USB device.
+    func_modifier(&mut func);
 
     let mut iface = func.interface();
     let mut alt = iface.alt_setting(USB_CLASS_APPN_SPEC, APPN_SPEC_SUBCLASS_DFU, DFU_PROTOCOL_DFU, None);

--- a/examples/boot/application/stm32wb-dfu/src/main.rs
+++ b/examples/boot/application/stm32wb-dfu/src/main.rs
@@ -70,11 +70,15 @@ async fn main(_spawner: Spawner) {
         msos::PropertyData::RegMultiSz(DEVICE_INTERFACE_GUIDS),
     ));
 
-    // For non-composite devices:
-    usb_dfu(&mut builder, &mut state, Duration::from_millis(2500), None);
-
-    // Or for composite devices:
-    // usb_dfu(&mut builder, &mut state, Duration::from_millis(2500), Some(DEVICE_INTERFACE_GUIDS));
+    usb_dfu(&mut builder, &mut state, Duration::from_millis(2500), |func| {
+        // You likely don't have to add these function level headers if your USB device is not composite
+        // (i.e. if your device does not expose another interface in addition to DFU)
+        func.msos_feature(msos::CompatibleIdFeatureDescriptor::new("WINUSB", ""));
+        func.msos_feature(msos::RegistryPropertyFeatureDescriptor::new(
+            "DeviceInterfaceGUIDs",
+            msos::PropertyData::RegMultiSz(DEVICE_INTERFACE_GUIDS),
+        ));
+    });
 
     let mut dev = builder.build();
     dev.run().await

--- a/examples/boot/application/stm32wb-dfu/src/main.rs
+++ b/examples/boot/application/stm32wb-dfu/src/main.rs
@@ -59,13 +59,11 @@ async fn main(_spawner: Spawner) {
 
     // We add MSOS headers so that the device automatically gets assigned the WinUSB driver on Windows.
     // Otherwise users need to do this manually using a tool like Zadig.
-    builder.msos_descriptor(msos::windows_version::WIN8_1, 2);
-
-    // In the case of non-composite devices, it seems that feature headers need to be on the device level.
-    // (As is implemented here)
     //
-    // For composite devices however, they should be on the function level instead.
-    // (This is achieved by passing a GUID to the "usb_dfu" function)
+    // It seems these always need to be at added at the device level for this to work and for
+    // composite devices they also need to be added on the function level (as shown later).
+    //
+    builder.msos_descriptor(msos::windows_version::WIN8_1, 2);
     builder.msos_feature(msos::CompatibleIdFeatureDescriptor::new("WINUSB", ""));
     builder.msos_feature(msos::RegistryPropertyFeatureDescriptor::new(
         "DeviceInterfaceGUIDs",

--- a/examples/boot/application/stm32wb-dfu/src/main.rs
+++ b/examples/boot/application/stm32wb-dfu/src/main.rs
@@ -22,7 +22,9 @@ bind_interrupts!(struct Irqs {
     USB_LP => usb::InterruptHandler<peripherals::USB>;
 });
 
-// This is a randomly generated GUID to allow clients on Windows to find our device
+// This is a randomly generated GUID to allow clients on Windows to find your device.
+//
+// N.B. update to a custom GUID for your own device!
 const DEVICE_INTERFACE_GUIDS: &[&str] = &["{EAA9A5DC-30BA-44BC-9232-606CDC875321}"];
 
 #[embassy_executor::main]

--- a/examples/boot/bootloader/stm32wb-dfu/src/main.rs
+++ b/examples/boot/bootloader/stm32wb-dfu/src/main.rs
@@ -20,7 +20,9 @@ bind_interrupts!(struct Irqs {
     USB_LP => usb::InterruptHandler<peripherals::USB>;
 });
 
-// This is a randomly generated GUID to allow clients on Windows to find our device
+// This is a randomly generated GUID to allow clients on Windows to find your device.
+//
+// N.B. update to a custom GUID for your own device!
 const DEVICE_INTERFACE_GUIDS: &[&str] = &["{EAA9A5DC-30BA-44BC-9232-606CDC875321}"];
 
 #[entry]

--- a/examples/boot/bootloader/stm32wb-dfu/src/main.rs
+++ b/examples/boot/bootloader/stm32wb-dfu/src/main.rs
@@ -67,13 +67,11 @@ fn main() -> ! {
 
         // We add MSOS headers so that the device automatically gets assigned the WinUSB driver on Windows.
         // Otherwise users need to do this manually using a tool like Zadig.
-        builder.msos_descriptor(msos::windows_version::WIN8_1, 2);
-
-        // In the case of non-composite devices, it seems that feature headers need to be on the device level.
-        // (As is implemented here)
         //
-        // For composite devices however, they should be on the function level instead.
-        // (This is achieved by passing a GUID to the "usb_dfu" function)
+        // It seems these always need to be at added at the device level for this to work and for
+        // composite devices they also need to be added on the function level (as shown later).
+        //
+        builder.msos_descriptor(msos::windows_version::WIN8_1, 2);
         builder.msos_feature(msos::CompatibleIdFeatureDescriptor::new("WINUSB", ""));
         builder.msos_feature(msos::RegistryPropertyFeatureDescriptor::new(
             "DeviceInterfaceGUIDs",


### PR DESCRIPTION
This PR makes it possible to provide function level msos GUIDs to usb_dfu. This helps to ensure that composite DFU devices automatically get assigned the WinUSB driver on Windows.