### PR TITLE
embassy-stm32: split rtc low-power wakeup and time functions

### DIFF
--- a/embassy-stm32/src/time_driver.rs
+++ b/embassy-stm32/src/time_driver.rs
@@ -14,7 +14,7 @@ use crate::interrupt::typelevel::Interrupt;
 use crate::pac::timer::vals;
 use crate::rcc::{self, SealedRccPeripheral};
 #[cfg(feature = "low-power")]
-use crate::rtc::Rtc;
+use crate::rtc::RtcControl;
 use crate::timer::{CoreInstance, GeneralInstance1Channel};
 use crate::{interrupt, peripherals};
 
@@ -213,7 +213,7 @@ pub(crate) struct RtcDriver {
     period: AtomicU32,
     alarm: Mutex<CriticalSectionRawMutex, AlarmState>,
     #[cfg(feature = "low-power")]
-    rtc: Mutex<CriticalSectionRawMutex, Cell<Option<&'static Rtc>>>,
+    rtc: Mutex<CriticalSectionRawMutex, Cell<Option<&'static RtcControl>>>,
     queue: Mutex<CriticalSectionRawMutex, RefCell<Queue>>,
 }
 
@@ -389,7 +389,7 @@ impl RtcDriver {
     */
     #[cfg(feature = "low-power")]
     /// Set the rtc but panic if it's already been set
-    pub(crate) fn set_rtc(&self, rtc: &'static Rtc) {
+    pub(crate) fn set_rtc(&self, rtc: &'static RtcControl) {
         critical_section::with(|cs| {
             rtc.stop_wakeup_alarm(cs);
 


### PR DESCRIPTION
Ref: #4110 

The current `rtc::Rtc` struct combines low-power wakeup management and application-level time access (`now()`, `set_datetime()`). This creates an ownership conflict when `embassy_stm32::low_power::stop_with_rtc` requires exclusive control of the `Rtc` instance, preventing the application from simultaneously accessing time functions.

Changes to existing API have been minimised.