### PR TITLE
embassy-rp: Make bit-depth of I2S PIO program configurable

### DIFF
--- a/examples/rp/src/bin/pio_i2s.rs
+++ b/examples/rp/src/bin/pio_i2s.rs
@@ -27,7 +27,6 @@ bind_interrupts!(struct Irqs {
 
 const SAMPLE_RATE: u32 = 48_000;
 const BIT_DEPTH: u32 = 16;
-const CHANNELS: u32 = 2;
 
 #[embassy_executor::main]
 async fn main(_spawner: Spawner) {
@@ -50,7 +49,6 @@ async fn main(_spawner: Spawner) {
         left_right_clock_pin,
         SAMPLE_RATE,
         BIT_DEPTH,
-        CHANNELS,
         &program,
     );
 

--- a/examples/rp235x/src/bin/pio_i2s.rs
+++ b/examples/rp235x/src/bin/pio_i2s.rs
@@ -27,7 +27,6 @@ bind_interrupts!(struct Irqs {
 
 const SAMPLE_RATE: u32 = 48_000;
 const BIT_DEPTH: u32 = 16;
-const CHANNELS: u32 = 2;
 
 #[embassy_executor::main]
 async fn main(_spawner: Spawner) {
@@ -50,7 +49,6 @@ async fn main(_spawner: Spawner) {
         left_right_clock_pin,
         SAMPLE_RATE,
         BIT_DEPTH,
-        CHANNELS,
         &program,
     );
 


### PR DESCRIPTION
The `PioI2sOutProgram` had a fixed 16bit sample depth, but that isn't reflected in the types name or the documentation.

The `PioI2sOut` output driver on the other hand accepts a `bit_depth` argument.
This was previously only used to calculate the clock frequency, while no other values than 16 made any sense.

This MR implements setting the sample bit-depth by setting it to scratch register `Y`, from where it is read by the PIO program. 

Also the channel argument is removed, since only 2 channels are supported.