### PR TITLE
rp: add missing `Debug` and `defmt::Format` `derive`s for ADC

### DIFF
--- a/embassy-hal-internal/src/macros.rs
+++ b/embassy-hal-internal/src/macros.rs
@@ -8,6 +8,8 @@ macro_rules! peripherals_definition {
                 $(#[$cfg])?
                 #[allow(non_camel_case_types)]
                 #[doc = concat!(stringify!($name), " peripheral")]
+                #[derive(Debug)]
+                #[cfg_attr(feature = "defmt", derive(defmt::Format))]
                 pub struct $name { _private: () }
 
                 $(#[$cfg])?

--- a/embassy-hal-internal/src/peripheral.rs
+++ b/embassy-hal-internal/src/peripheral.rs
@@ -14,6 +14,8 @@ use core::ops::Deref;
 ///   the driver code would be monomorphized two times. With Peri, the driver is generic
 ///   over a lifetime only. `SPI4` becomes `Peri<'static, SPI4>`, and `&mut SPI4` becomes
 ///   `Peri<'a, SPI4>`. Lifetimes don't cause monomorphization.
+#[derive(Debug)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub struct Peri<'a, T: PeripheralType> {
     inner: T,
     _lifetime: PhantomData<&'a mut T>,

--- a/embassy-nxp/Cargo.toml
+++ b/embassy-nxp/Cargo.toml
@@ -10,8 +10,11 @@ critical-section = "1.1.2"
 embassy-hal-internal = { version = "0.2.0", path = "../embassy-hal-internal", features = ["cortex-m", "prio-bits-2"] }
 embassy-sync = { version = "0.6.2", path = "../embassy-sync" }
 lpc55-pac = "0.5.0"
-defmt = "0.3.8"
+defmt = { version = "0.3.8", optional = true }
 
 [features]
 default = ["rt"]
 rt = ["lpc55-pac/rt"]
+
+## Enable [defmt support](https://docs.rs/defmt) and enables `defmt` debug-log messages and formatting in embassy drivers.
+defmt = ["dep:defmt", "embassy-hal-internal/defmt", "embassy-sync/defmt"]

--- a/embassy-rp/src/adc.rs
+++ b/embassy-rp/src/adc.rs
@@ -21,6 +21,8 @@ static WAKER: AtomicWaker = AtomicWaker::new();
 #[derive(Default)]
 pub struct Config {}
 
+#[derive(Debug)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 enum Source<'p> {
     Pin(Peri<'p, AnyPin>),
     TempSensor(Peri<'p, ADC_TEMP_SENSOR>),

--- a/embassy-rp/src/gpio.rs
+++ b/embassy-rp/src/gpio.rs
@@ -932,6 +932,8 @@ pub trait Pin: PeripheralType + Into<AnyPin> + SealedPin + Sized + 'static {
 }
 
 /// Type-erased GPIO pin
+#[derive(Debug)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub struct AnyPin {
     pin_bank: u8,
 }


### PR DESCRIPTION
this doesn't cover every `struct` & co. in `embassy-rp`, but at least it adds those needed for `Adc` and `adc::Channel`.