### PR TITLE
Impl Drop for stm32 Rng

### DIFF
--- a/embassy-stm32/src/rng.rs
+++ b/embassy-stm32/src/rng.rs
@@ -186,6 +186,15 @@ impl<'d, T: Instance> Rng<'d, T> {
     }
 }
 
+impl<'d, T: Instance> Drop for Rng<'d, T> {
+    fn drop(&mut self) {
+        T::regs().cr().modify(|reg| {
+            reg.set_rngen(false);
+        });
+        rcc::disable::<T>();
+    }
+}
+
 impl<'d, T: Instance> RngCore for Rng<'d, T> {
     fn next_u32(&mut self) -> u32 {
         loop {


### PR DESCRIPTION
This disables the RNG in the CR::RNGEN register and calls `rcc::disable` to possibly disable the corresponding clock if the refcount goes to zero. Using the "low-power" feature, I have verified that this allows to enter STOP2 mode again after the RNG has been dropped.