### PR TITLE
Add rand-core v0.9 support.

### DIFF
--- a/embassy-imxrt/Cargo.toml
+++ b/embassy-imxrt/Cargo.toml
@@ -80,8 +80,10 @@ cortex-m = "0.7.6"
 critical-section = "1.1"
 embedded-io = { version = "0.6.1" }
 embedded-io-async = { version = "0.6.1" }
-rand_core = "0.6.4"
 fixed = "1.23.1"
+
+rand-core-06 = { package = "rand_core", version = "0.6" }
+rand-core-09 = { package = "rand_core", version = "0.9" }
 
 embedded-hal-02 = { package = "embedded-hal", version = "0.2.6", features = [
     "unproven",

--- a/embassy-nrf/Cargo.toml
+++ b/embassy-nrf/Cargo.toml
@@ -154,6 +154,9 @@ embedded-hal-async = { version = "1.0" }
 embedded-io = { version = "0.6.0" }
 embedded-io-async = { version = "0.6.1" }
 
+rand-core-06 = { package = "rand_core", version = "0.6" }
+rand-core-09 = { package = "rand_core", version = "0.9" }
+
 nrf-pac = "0.1.0"
 
 defmt = { version = "0.3", optional = true }
@@ -162,7 +165,6 @@ log = { version = "0.4.14", optional = true }
 cortex-m-rt = ">=0.6.15,<0.8"
 cortex-m = "0.7.6"
 critical-section = "1.1"
-rand_core = "0.6.3"
 fixed = "1.10.0"
 embedded-storage = "0.3.1"
 embedded-storage-async = "0.4.1"

--- a/embassy-nrf/src/rng.rs
+++ b/embassy-nrf/src/rng.rs
@@ -167,6 +167,21 @@ impl<'d, T: Instance> Rng<'d, T> {
 
         self.stop();
     }
+
+    /// Generate a random u32
+    pub fn blocking_next_u32(&mut self) -> u32 {
+        let mut bytes = [0; 4];
+        self.blocking_fill_bytes(&mut bytes);
+        // We don't care about the endianness, so just use the native one.
+        u32::from_ne_bytes(bytes)
+    }
+
+    /// Generate a random u64
+    pub fn blocking_next_u64(&mut self) -> u64 {
+        let mut bytes = [0; 8];
+        self.blocking_fill_bytes(&mut bytes);
+        u64::from_ne_bytes(bytes)
+    }
 }
 
 impl<'d, T: Instance> Drop for Rng<'d, T> {
@@ -180,31 +195,37 @@ impl<'d, T: Instance> Drop for Rng<'d, T> {
     }
 }
 
-impl<'d, T: Instance> rand_core::RngCore for Rng<'d, T> {
+impl<'d, T: Instance> rand_core_06::RngCore for Rng<'d, T> {
     fn fill_bytes(&mut self, dest: &mut [u8]) {
         self.blocking_fill_bytes(dest);
     }
-
     fn next_u32(&mut self) -> u32 {
-        let mut bytes = [0; 4];
-        self.blocking_fill_bytes(&mut bytes);
-        // We don't care about the endianness, so just use the native one.
-        u32::from_ne_bytes(bytes)
+        self.blocking_next_u32()
     }
-
     fn next_u64(&mut self) -> u64 {
-        let mut bytes = [0; 8];
-        self.blocking_fill_bytes(&mut bytes);
-        u64::from_ne_bytes(bytes)
+        self.blocking_next_u64()
     }
-
-    fn try_fill_bytes(&mut self, dest: &mut [u8]) -> Result<(), rand_core::Error> {
+    fn try_fill_bytes(&mut self, dest: &mut [u8]) -> Result<(), rand_core_06::Error> {
         self.blocking_fill_bytes(dest);
         Ok(())
     }
 }
 
-impl<'d, T: Instance> rand_core::CryptoRng for Rng<'d, T> {}
+impl<'d, T: Instance> rand_core_06::CryptoRng for Rng<'d, T> {}
+
+impl<'d, T: Instance> rand_core_09::RngCore for Rng<'d, T> {
+    fn fill_bytes(&mut self, dest: &mut [u8]) {
+        self.blocking_fill_bytes(dest);
+    }
+    fn next_u32(&mut self) -> u32 {
+        self.blocking_next_u32()
+    }
+    fn next_u64(&mut self) -> u64 {
+        self.blocking_next_u64()
+    }
+}
+
+impl<'d, T: Instance> rand_core_09::CryptoRng for Rng<'d, T> {}
 
 /// Peripheral static state
 pub(crate) struct State {

--- a/embassy-rp/Cargo.toml
+++ b/embassy-rp/Cargo.toml
@@ -157,7 +157,6 @@ embedded-io = { version = "0.6.1" }
 embedded-io-async = { version = "0.6.1" }
 embedded-storage = { version = "0.3" }
 embedded-storage-async = { version = "0.4.1" }
-rand_core = "0.6.4"
 fixed = "1.28.0"
 
 rp-pac = { version = "7.0.0" }
@@ -166,6 +165,9 @@ embedded-hal-02 = { package = "embedded-hal", version = "0.2.6", features = ["un
 embedded-hal-1 = { package = "embedded-hal", version = "1.0" }
 embedded-hal-async = { version = "1.0" }
 embedded-hal-nb = { version = "1.0" }
+
+rand-core-06 = { package = "rand_core", version = "0.6" }
+rand-core-09 = { package = "rand_core", version = "0.9" }
 
 pio = { version = "0.3" }
 rp2040-boot2 = "0.3"

--- a/embassy-rp/src/clocks.rs
+++ b/embassy-rp/src/clocks.rs
@@ -1776,7 +1776,8 @@ impl<'d, T: GpoutPin> Drop for Gpout<'d, T> {
 pub struct RoscRng;
 
 impl RoscRng {
-    fn next_u8() -> u8 {
+    /// Get a random u8
+    pub fn next_u8() -> u8 {
         let random_reg = pac::ROSC.randombit();
         let mut acc = 0;
         for _ in 0..u8::BITS {
@@ -1785,25 +1786,59 @@ impl RoscRng {
         }
         acc
     }
-}
 
-impl rand_core::RngCore for RoscRng {
-    fn try_fill_bytes(&mut self, dest: &mut [u8]) -> Result<(), rand_core::Error> {
-        Ok(self.fill_bytes(dest))
+    /// Get a random u32
+    pub fn next_u32(&mut self) -> u32 {
+        rand_core_09::impls::next_u32_via_fill(self)
     }
 
-    fn next_u32(&mut self) -> u32 {
-        rand_core::impls::next_u32_via_fill(self)
+    /// Get a random u64
+    pub fn next_u64(&mut self) -> u64 {
+        rand_core_09::impls::next_u64_via_fill(self)
     }
 
-    fn next_u64(&mut self) -> u64 {
-        rand_core::impls::next_u64_via_fill(self)
-    }
-
-    fn fill_bytes(&mut self, dest: &mut [u8]) {
+    /// Fill a slice with random bytes
+    pub fn fill_bytes(&mut self, dest: &mut [u8]) {
         dest.fill_with(Self::next_u8)
     }
 }
+
+impl rand_core_06::RngCore for RoscRng {
+    fn next_u32(&mut self) -> u32 {
+        self.next_u32()
+    }
+
+    fn next_u64(&mut self) -> u64 {
+        self.next_u64()
+    }
+
+    fn fill_bytes(&mut self, dest: &mut [u8]) {
+        self.fill_bytes(dest);
+    }
+
+    fn try_fill_bytes(&mut self, dest: &mut [u8]) -> Result<(), rand_core_06::Error> {
+        self.fill_bytes(dest);
+        Ok(())
+    }
+}
+
+impl rand_core_06::CryptoRng for RoscRng {}
+
+impl rand_core_09::RngCore for RoscRng {
+    fn next_u32(&mut self) -> u32 {
+        self.next_u32()
+    }
+
+    fn next_u64(&mut self) -> u64 {
+        self.next_u64()
+    }
+
+    fn fill_bytes(&mut self, dest: &mut [u8]) {
+        self.fill_bytes(dest);
+    }
+}
+
+impl rand_core_09::CryptoRng for RoscRng {}
 
 /// Enter the `DORMANT` sleep state. This will stop *all* internal clocks
 /// and can only be exited through resets, dormant-wake GPIO interrupts,

--- a/embassy-rp/src/trng.rs
+++ b/embassy-rp/src/trng.rs
@@ -7,7 +7,6 @@ use core::task::Poll;
 
 use embassy_hal_internal::{Peri, PeripheralType};
 use embassy_sync::waitqueue::AtomicWaker;
-use rand_core::Error;
 
 use crate::interrupt::typelevel::{Binding, Interrupt};
 use crate::peripherals::TRNG;
@@ -369,7 +368,7 @@ impl<'d, T: Instance> Trng<'d, T> {
     }
 }
 
-impl<'d, T: Instance> rand_core::RngCore for Trng<'d, T> {
+impl<'d, T: Instance> rand_core_06::RngCore for Trng<'d, T> {
     fn next_u32(&mut self) -> u32 {
         self.blocking_next_u32()
     }
@@ -379,16 +378,32 @@ impl<'d, T: Instance> rand_core::RngCore for Trng<'d, T> {
     }
 
     fn fill_bytes(&mut self, dest: &mut [u8]) {
-        self.blocking_fill_bytes(dest)
+        self.blocking_fill_bytes(dest);
     }
 
-    fn try_fill_bytes(&mut self, dest: &mut [u8]) -> Result<(), Error> {
+    fn try_fill_bytes(&mut self, dest: &mut [u8]) -> Result<(), rand_core_06::Error> {
         self.blocking_fill_bytes(dest);
         Ok(())
     }
 }
 
-impl<'d, T: Instance> rand_core::CryptoRng for Trng<'d, T> {}
+impl<'d, T: Instance> rand_core_06::CryptoRng for Trng<'d, T> {}
+
+impl<'d, T: Instance> rand_core_09::RngCore for Trng<'d, T> {
+    fn next_u32(&mut self) -> u32 {
+        self.blocking_next_u32()
+    }
+
+    fn next_u64(&mut self) -> u64 {
+        self.blocking_next_u64()
+    }
+
+    fn fill_bytes(&mut self, dest: &mut [u8]) {
+        self.blocking_fill_bytes(dest);
+    }
+}
+
+impl<'d, T: Instance> rand_core_09::CryptoRng for Trng<'d, T> {}
 
 /// TRNG interrupt handler.
 pub struct InterruptHandler<T: Instance> {

--- a/embassy-stm32/Cargo.toml
+++ b/embassy-stm32/Cargo.toml
@@ -63,13 +63,15 @@ embedded-can = "0.4"
 embedded-storage = "0.3.1"
 embedded-storage-async = { version = "0.4.1" }
 
+rand-core-06 = { package = "rand_core", version = "0.6" }
+rand-core-09 = { package = "rand_core", version = "0.9" }
+
 
 defmt = { version = "0.3", optional = true }
 log = { version = "0.4.14", optional = true }
 cortex-m-rt = ">=0.6.15,<0.8"
 cortex-m = "0.7.6"
 futures-util = { version = "0.3.30", default-features = false }
-rand_core = "0.6.3"
 sdio-host = "0.9.0"
 critical-section = "1.1"
 #stm32-metapac = { version = "16" }

--- a/examples/mimxrt6/Cargo.toml
+++ b/examples/mimxrt6/Cargo.toml
@@ -20,7 +20,6 @@ embedded-hal-async = "1.0.0"
 
 mimxrt600-fcb = "0.2.2"
 panic-probe = { version = "0.3", features = ["print-defmt"] }
-rand = { version = "0.8.5", default-features = false }
 
 # cargo build/run
 [profile.dev]

--- a/examples/mimxrt6/src/bin/rng.rs
+++ b/examples/mimxrt6/src/bin/rng.rs
@@ -7,7 +7,6 @@ use defmt::*;
 use embassy_executor::Spawner;
 use embassy_imxrt::rng::Rng;
 use embassy_imxrt::{bind_interrupts, peripherals, rng};
-use rand::RngCore;
 use {defmt_rtt as _, panic_probe as _};
 
 bind_interrupts!(struct Irqs {
@@ -29,10 +28,10 @@ async fn main(_spawner: Spawner) {
     // RngCore interface
     let mut random_bytes = [0; 16];
 
-    let random_u32 = rng.next_u32();
-    let random_u64 = rng.next_u64();
+    let random_u32 = rng.blocking_next_u32();
+    let random_u64 = rng.blocking_next_u64();
 
-    rng.fill_bytes(&mut random_bytes);
+    rng.blocking_fill_bytes(&mut random_bytes);
 
     info!("random_u32 {}", random_u32);
     info!("random_u64 {}", random_u64);

--- a/examples/nrf-rtos-trace/Cargo.toml
+++ b/examples/nrf-rtos-trace/Cargo.toml
@@ -23,7 +23,6 @@ embassy-nrf = { version = "0.3.1", path = "../../embassy-nrf", features = ["nrf5
 cortex-m = { version = "0.7.6", features = ["inline-asm", "critical-section-single-core"] }
 cortex-m-rt = "0.7.0"
 panic-probe = { version = "0.3" }
-rand = { version = "0.8.4", default-features = false }
 serde = { version = "1.0.136", default-features = false }
 rtos-trace = "0.1.3"
 systemview-target = { version = "0.1.2", features = ["callbacks-app", "callbacks-os", "log", "cortex-m"] }

--- a/examples/nrf52840/Cargo.toml
+++ b/examples/nrf52840/Cargo.toml
@@ -25,7 +25,7 @@ static_cell = { version = "2" }
 cortex-m = { version = "0.7.6", features = ["inline-asm", "critical-section-single-core"] }
 cortex-m-rt = "0.7.0"
 panic-probe = { version = "0.3", features = ["print-defmt"] }
-rand = { version = "0.8.4", default-features = false }
+rand = { version = "0.9.0", default-features = false }
 embedded-storage = "0.3.1"
 usbd-hid = "0.8.1"
 serde = { version = "1.0.136", default-features = false }

--- a/examples/nrf52840/src/bin/rng.rs
+++ b/examples/nrf52840/src/bin/rng.rs
@@ -22,7 +22,7 @@ async fn main(_spawner: Spawner) {
     defmt::info!("Some random bytes: {:?}", bytes);
 
     // Sync API with `rand`
-    defmt::info!("A random number from 1 to 10: {:?}", rng.gen_range(1..=10));
+    defmt::info!("A random number from 1 to 10: {:?}", rng.random_range(1..=10));
 
     let mut bytes = [0; 1024];
     rng.fill_bytes(&mut bytes).await;

--- a/examples/nrf5340/Cargo.toml
+++ b/examples/nrf5340/Cargo.toml
@@ -21,7 +21,6 @@ static_cell = "2"
 cortex-m = { version = "0.7.6", features = ["inline-asm", "critical-section-single-core"] }
 cortex-m-rt = "0.7.0"
 panic-probe = { version = "0.3", features = ["print-defmt"] }
-rand = { version = "0.8.4", default-features = false }
 embedded-storage = "0.3.1"
 usbd-hid = "0.8.1"
 serde = { version = "1.0.136", default-features = false }

--- a/examples/rp/Cargo.toml
+++ b/examples/rp/Cargo.toml
@@ -45,7 +45,6 @@ byte-slice-cast = { version = "1.2.0", default-features = false }
 smart-leds = "0.4.0"
 heapless = "0.8"
 usbd-hid = "0.8.1"
-rand_core = "0.6.4"
 
 embedded-hal-1 = { package = "embedded-hal", version = "1.0" }
 embedded-hal-async = "1.0"
@@ -55,7 +54,7 @@ embedded-storage = { version = "0.3" }
 static_cell = "2.1"
 portable-atomic = { version = "1.5", features = ["critical-section"] }
 log = "0.4"
-rand = { version = "0.8.5", default-features = false }
+rand = { version = "0.9.0", default-features = false }
 embedded-sdmmc = "0.7.0"
 
 [profile.release]

--- a/examples/rp/src/bin/ethernet_w5500_icmp.rs
+++ b/examples/rp/src/bin/ethernet_w5500_icmp.rs
@@ -21,7 +21,6 @@ use embassy_rp::peripherals::SPI0;
 use embassy_rp::spi::{Async, Config as SpiConfig, Spi};
 use embassy_time::{Delay, Instant, Timer};
 use embedded_hal_bus::spi::ExclusiveDevice;
-use rand::RngCore;
 use static_cell::StaticCell;
 use {defmt_rtt as _, panic_probe as _};
 

--- a/examples/rp/src/bin/ethernet_w5500_icmp_ping.rs
+++ b/examples/rp/src/bin/ethernet_w5500_icmp_ping.rs
@@ -23,7 +23,6 @@ use embassy_rp::peripherals::SPI0;
 use embassy_rp::spi::{Async, Config as SpiConfig, Spi};
 use embassy_time::{Delay, Duration};
 use embedded_hal_bus::spi::ExclusiveDevice;
-use rand::RngCore;
 use static_cell::StaticCell;
 use {defmt_rtt as _, panic_probe as _};
 

--- a/examples/rp/src/bin/ethernet_w5500_multisocket.rs
+++ b/examples/rp/src/bin/ethernet_w5500_multisocket.rs
@@ -18,7 +18,6 @@ use embassy_rp::spi::{Async, Config as SpiConfig, Spi};
 use embassy_time::{Delay, Duration};
 use embedded_hal_bus::spi::ExclusiveDevice;
 use embedded_io_async::Write;
-use rand::RngCore;
 use static_cell::StaticCell;
 use {defmt_rtt as _, panic_probe as _};
 

--- a/examples/rp/src/bin/ethernet_w5500_tcp_client.rs
+++ b/examples/rp/src/bin/ethernet_w5500_tcp_client.rs
@@ -20,7 +20,6 @@ use embassy_rp::spi::{Async, Config as SpiConfig, Spi};
 use embassy_time::{Delay, Duration, Timer};
 use embedded_hal_bus::spi::ExclusiveDevice;
 use embedded_io_async::Write;
-use rand::RngCore;
 use static_cell::StaticCell;
 use {defmt_rtt as _, panic_probe as _};
 

--- a/examples/rp/src/bin/ethernet_w5500_tcp_server.rs
+++ b/examples/rp/src/bin/ethernet_w5500_tcp_server.rs
@@ -19,7 +19,6 @@ use embassy_rp::spi::{Async, Config as SpiConfig, Spi};
 use embassy_time::{Delay, Duration};
 use embedded_hal_bus::spi::ExclusiveDevice;
 use embedded_io_async::Write;
-use rand::RngCore;
 use static_cell::StaticCell;
 use {defmt_rtt as _, panic_probe as _};
 

--- a/examples/rp/src/bin/ethernet_w5500_udp.rs
+++ b/examples/rp/src/bin/ethernet_w5500_udp.rs
@@ -18,7 +18,6 @@ use embassy_rp::peripherals::SPI0;
 use embassy_rp::spi::{Async, Config as SpiConfig, Spi};
 use embassy_time::Delay;
 use embedded_hal_bus::spi::ExclusiveDevice;
-use rand::RngCore;
 use static_cell::StaticCell;
 use {defmt_rtt as _, panic_probe as _};
 

--- a/examples/rp/src/bin/orchestrate_tasks.rs
+++ b/examples/rp/src/bin/orchestrate_tasks.rs
@@ -29,7 +29,6 @@ use embassy_sync::blocking_mutex::raw::CriticalSectionRawMutex;
 use embassy_sync::mutex::Mutex;
 use embassy_sync::{channel, signal};
 use embassy_time::{Duration, Timer};
-use rand::RngCore;
 use {defmt_rtt as _, panic_probe as _};
 
 // Hardware resource assignment. See other examples for different ways of doing this.

--- a/examples/rp/src/bin/sharing.rs
+++ b/examples/rp/src/bin/sharing.rs
@@ -27,7 +27,6 @@ use embassy_rp::{bind_interrupts, interrupt};
 use embassy_sync::blocking_mutex::raw::CriticalSectionRawMutex;
 use embassy_sync::{blocking_mutex, mutex};
 use embassy_time::{Duration, Ticker};
-use rand::RngCore;
 use static_cell::{ConstStaticCell, StaticCell};
 use {defmt_rtt as _, panic_probe as _};
 

--- a/examples/rp/src/bin/spi_gc9a01.rs
+++ b/examples/rp/src/bin/spi_gc9a01.rs
@@ -26,7 +26,6 @@ use embedded_graphics::primitives::{PrimitiveStyleBuilder, Rectangle};
 use mipidsi::models::GC9A01;
 use mipidsi::options::{ColorInversion, ColorOrder};
 use mipidsi::Builder;
-use rand_core::RngCore;
 use {defmt_rtt as _, panic_probe as _};
 
 const DISPLAY_FREQ: u32 = 64_000_000;

--- a/examples/rp/src/bin/usb_ethernet.rs
+++ b/examples/rp/src/bin/usb_ethernet.rs
@@ -17,7 +17,6 @@ use embassy_usb::class::cdc_ncm::embassy_net::{Device, Runner, State as NetState
 use embassy_usb::class::cdc_ncm::{CdcNcmClass, State};
 use embassy_usb::{Builder, Config, UsbDevice};
 use embedded_io_async::Write;
-use rand::RngCore;
 use static_cell::StaticCell;
 use {defmt_rtt as _, panic_probe as _};
 

--- a/examples/rp/src/bin/usb_hid_mouse.rs
+++ b/examples/rp/src/bin/usb_hid_mouse.rs
@@ -85,8 +85,8 @@ async fn main(_spawner: Spawner) {
             _ = Timer::after_secs(1).await;
             let report = MouseReport {
                 buttons: 0,
-                x: rng.gen_range(-100..100), // random small x movement
-                y: rng.gen_range(-100..100), // random small y movement
+                x: rng.random_range(-100..100), // random small x movement
+                y: rng.random_range(-100..100), // random small y movement
                 wheel: 0,
                 pan: 0,
             };

--- a/examples/rp/src/bin/wifi_ap_tcp_server.rs
+++ b/examples/rp/src/bin/wifi_ap_tcp_server.rs
@@ -19,7 +19,6 @@ use embassy_rp::peripherals::{DMA_CH0, PIO0};
 use embassy_rp::pio::{InterruptHandler, Pio};
 use embassy_time::Duration;
 use embedded_io_async::Write;
-use rand::RngCore;
 use static_cell::StaticCell;
 use {defmt_rtt as _, panic_probe as _};
 

--- a/examples/rp/src/bin/wifi_tcp_server.rs
+++ b/examples/rp/src/bin/wifi_tcp_server.rs
@@ -20,7 +20,6 @@ use embassy_rp::peripherals::{DMA_CH0, PIO0};
 use embassy_rp::pio::{InterruptHandler, Pio};
 use embassy_time::{Duration, Timer};
 use embedded_io_async::Write;
-use rand::RngCore;
 use static_cell::StaticCell;
 use {defmt_rtt as _, panic_probe as _};
 

--- a/examples/rp/src/bin/wifi_webrequest.rs
+++ b/examples/rp/src/bin/wifi_webrequest.rs
@@ -20,7 +20,6 @@ use embassy_rp::gpio::{Level, Output};
 use embassy_rp::peripherals::{DMA_CH0, PIO0};
 use embassy_rp::pio::{InterruptHandler, Pio};
 use embassy_time::{Duration, Timer};
-use rand::RngCore;
 use reqwless::client::{HttpClient, TlsConfig, TlsVerify};
 use reqwless::request::Method;
 use serde::Deserialize;

--- a/examples/rp235x/Cargo.toml
+++ b/examples/rp235x/Cargo.toml
@@ -55,7 +55,6 @@ embedded-storage = { version = "0.3" }
 static_cell = "2.1"
 portable-atomic = { version = "1.5", features = ["critical-section"] }
 log = "0.4"
-rand = { version = "0.8.5", default-features = false }
 embedded-sdmmc = "0.7.0"
 
 [profile.release]

--- a/examples/rp235x/src/bin/sharing.rs
+++ b/examples/rp235x/src/bin/sharing.rs
@@ -27,7 +27,6 @@ use embassy_rp::{bind_interrupts, interrupt};
 use embassy_sync::blocking_mutex::raw::CriticalSectionRawMutex;
 use embassy_sync::{blocking_mutex, mutex};
 use embassy_time::{Duration, Ticker};
-use rand::RngCore;
 use static_cell::{ConstStaticCell, StaticCell};
 use {defmt_rtt as _, panic_probe as _};
 

--- a/examples/rp235x/src/bin/trng.rs
+++ b/examples/rp235x/src/bin/trng.rs
@@ -10,7 +10,6 @@ use embassy_rp::gpio::{Level, Output};
 use embassy_rp::peripherals::TRNG;
 use embassy_rp::trng::Trng;
 use embassy_time::Timer;
-use rand::RngCore;
 use {defmt_rtt as _, panic_probe as _};
 
 bind_interrupts!(struct Irqs {
@@ -33,8 +32,8 @@ async fn main(_spawner: Spawner) {
         info!("Random bytes async {}", &randomness);
         trng.blocking_fill_bytes(&mut randomness);
         info!("Random bytes blocking {}", &randomness);
-        let random_u32 = trng.next_u32();
-        let random_u64 = trng.next_u64();
+        let random_u32 = trng.blocking_next_u32();
+        let random_u64 = trng.blocking_next_u64();
         info!("Random u32 {} u64 {}", random_u32, random_u64);
         // Random number of blinks between 0 and 31
         let blinks = random_u32 % 32;

--- a/examples/std/Cargo.toml
+++ b/examples/std/Cargo.toml
@@ -21,7 +21,7 @@ futures = { version = "0.3.17" }
 log = "0.4.14"
 nix = "0.26.2"
 clap = { version = "3.0.0-beta.5", features = ["derive"] }
-rand_core = { version = "0.6.3", features = ["std"] }
+rand_core = { version = "0.9.1", features = ["std", "os_rng"] }
 heapless = { version = "0.8", default-features = false }
 static_cell = "2"
 

--- a/examples/std/src/bin/net.rs
+++ b/examples/std/src/bin/net.rs
@@ -9,7 +9,7 @@ use embassy_time::Duration;
 use embedded_io_async::Write;
 use heapless::Vec;
 use log::*;
-use rand_core::{OsRng, RngCore};
+use rand_core::{OsRng, TryRngCore};
 use static_cell::StaticCell;
 
 #[derive(Parser)]
@@ -48,7 +48,7 @@ async fn main_task(spawner: Spawner) {
 
     // Generate random seed
     let mut seed = [0; 8];
-    OsRng.fill_bytes(&mut seed);
+    OsRng.try_fill_bytes(&mut seed).unwrap();
     let seed = u64::from_le_bytes(seed);
 
     // Init network stack

--- a/examples/std/src/bin/net_dns.rs
+++ b/examples/std/src/bin/net_dns.rs
@@ -5,7 +5,7 @@ use embassy_net::{Config, Ipv4Address, Ipv4Cidr, StackResources};
 use embassy_net_tuntap::TunTapDevice;
 use heapless::Vec;
 use log::*;
-use rand_core::{OsRng, RngCore};
+use rand_core::{OsRng, TryRngCore};
 use static_cell::StaticCell;
 
 #[derive(Parser)]
@@ -45,7 +45,7 @@ async fn main_task(spawner: Spawner) {
 
     // Generate random seed
     let mut seed = [0; 8];
-    OsRng.fill_bytes(&mut seed);
+    OsRng.try_fill_bytes(&mut seed).unwrap();
     let seed = u64::from_le_bytes(seed);
 
     // Init network stack

--- a/examples/std/src/bin/net_ppp.rs
+++ b/examples/std/src/bin/net_ppp.rs
@@ -23,7 +23,7 @@ use futures::io::BufReader;
 use heapless::Vec;
 use log::*;
 use nix::sys::termios;
-use rand_core::{OsRng, RngCore};
+use rand_core::{OsRng, TryRngCore};
 use static_cell::StaticCell;
 
 use crate::serial_port::SerialPort;
@@ -89,7 +89,7 @@ async fn main_task(spawner: Spawner) {
 
     // Generate random seed
     let mut seed = [0; 8];
-    OsRng.fill_bytes(&mut seed);
+    OsRng.try_fill_bytes(&mut seed).unwrap();
     let seed = u64::from_le_bytes(seed);
 
     // Init network stack

--- a/examples/std/src/bin/net_udp.rs
+++ b/examples/std/src/bin/net_udp.rs
@@ -5,7 +5,7 @@ use embassy_net::{Config, Ipv4Address, Ipv4Cidr, StackResources};
 use embassy_net_tuntap::TunTapDevice;
 use heapless::Vec;
 use log::*;
-use rand_core::{OsRng, RngCore};
+use rand_core::{OsRng, TryRngCore};
 use static_cell::StaticCell;
 
 #[derive(Parser)]
@@ -44,7 +44,7 @@ async fn main_task(spawner: Spawner) {
 
     // Generate random seed
     let mut seed = [0; 8];
-    OsRng.fill_bytes(&mut seed);
+    OsRng.try_fill_bytes(&mut seed).unwrap();
     let seed = u64::from_le_bytes(seed);
 
     // Init network stack

--- a/examples/std/src/bin/tcp_accept.rs
+++ b/examples/std/src/bin/tcp_accept.rs
@@ -7,7 +7,7 @@ use embassy_time::{Duration, Timer};
 use embedded_io_async::Write as _;
 use heapless::Vec;
 use log::*;
-use rand_core::{OsRng, RngCore};
+use rand_core::{OsRng, TryRngCore};
 use static_cell::StaticCell;
 
 #[derive(Parser)]
@@ -46,7 +46,7 @@ async fn main_task(spawner: Spawner) {
 
     // Generate random seed
     let mut seed = [0; 8];
-    OsRng.fill_bytes(&mut seed);
+    OsRng.try_fill_bytes(&mut seed).unwrap();
     let seed = u64::from_le_bytes(seed);
 
     // Init network stack

--- a/examples/stm32f7/Cargo.toml
+++ b/examples/stm32f7/Cargo.toml
@@ -24,7 +24,6 @@ embedded-hal = "0.2.6"
 panic-probe = { version = "0.3", features = ["print-defmt"] }
 heapless = { version = "0.8", default-features = false }
 nb = "1.0.0"
-rand_core = "0.6.3"
 critical-section = "1.1"
 embedded-storage = "0.3.1"
 static_cell = "2"

--- a/examples/stm32f7/src/bin/eth.rs
+++ b/examples/stm32f7/src/bin/eth.rs
@@ -12,7 +12,6 @@ use embassy_stm32::time::Hertz;
 use embassy_stm32::{bind_interrupts, eth, peripherals, rng, Config};
 use embassy_time::Timer;
 use embedded_io_async::Write;
-use rand_core::RngCore;
 use static_cell::StaticCell;
 use {defmt_rtt as _, panic_probe as _};
 

--- a/examples/stm32h5/Cargo.toml
+++ b/examples/stm32h5/Cargo.toml
@@ -26,7 +26,6 @@ embedded-io-async = { version = "0.6.1" }
 embedded-nal-async = "0.8.0"
 panic-probe = { version = "0.3", features = ["print-defmt"] }
 heapless = { version = "0.8", default-features = false }
-rand_core = "0.6.3"
 critical-section = "1.1"
 micromath = "2.0.0"
 stm32-fmc = "0.3.0"

--- a/examples/stm32h5/src/bin/eth.rs
+++ b/examples/stm32h5/src/bin/eth.rs
@@ -15,7 +15,6 @@ use embassy_stm32::time::Hertz;
 use embassy_stm32::{bind_interrupts, eth, peripherals, rng, Config};
 use embassy_time::Timer;
 use embedded_io_async::Write;
-use rand_core::RngCore;
 use static_cell::StaticCell;
 use {defmt_rtt as _, panic_probe as _};
 

--- a/examples/stm32h7/Cargo.toml
+++ b/examples/stm32h7/Cargo.toml
@@ -27,7 +27,6 @@ embedded-nal-async = "0.8.0"
 embedded-io-async = { version = "0.6.1" }
 panic-probe = { version = "0.3", features = ["print-defmt"] }
 heapless = { version = "0.8", default-features = false }
-rand_core = "0.6.3"
 critical-section = "1.1"
 micromath = "2.0.0"
 stm32-fmc = "0.3.0"

--- a/examples/stm32h7/src/bin/eth.rs
+++ b/examples/stm32h7/src/bin/eth.rs
@@ -11,7 +11,6 @@ use embassy_stm32::rng::Rng;
 use embassy_stm32::{bind_interrupts, eth, peripherals, rng, Config};
 use embassy_time::Timer;
 use embedded_io_async::Write;
-use rand_core::RngCore;
 use static_cell::StaticCell;
 use {defmt_rtt as _, panic_probe as _};
 

--- a/examples/stm32h7/src/bin/eth_client.rs
+++ b/examples/stm32h7/src/bin/eth_client.rs
@@ -14,7 +14,6 @@ use embassy_stm32::{bind_interrupts, eth, peripherals, rng, Config};
 use embassy_time::Timer;
 use embedded_io_async::Write;
 use embedded_nal_async::TcpConnect;
-use rand_core::RngCore;
 use static_cell::StaticCell;
 use {defmt_rtt as _, panic_probe as _};
 

--- a/examples/stm32h7/src/bin/eth_client_mii.rs
+++ b/examples/stm32h7/src/bin/eth_client_mii.rs
@@ -14,7 +14,6 @@ use embassy_stm32::{bind_interrupts, eth, peripherals, rng, Config};
 use embassy_time::Timer;
 use embedded_io_async::Write;
 use embedded_nal_async::TcpConnect;
-use rand_core::RngCore;
 use static_cell::StaticCell;
 use {defmt_rtt as _, panic_probe as _};
 

--- a/examples/stm32h723/Cargo.toml
+++ b/examples/stm32h723/Cargo.toml
@@ -24,7 +24,6 @@ embedded-nal-async = "0.8.0"
 embedded-io-async = { version = "0.6.1" }
 panic-probe = { version = "0.3", features = ["print-defmt"] }
 heapless = { version = "0.8", default-features = false }
-rand_core = "0.6.3"
 critical-section = "1.1"
 static_cell = "2"
 chrono = { version = "^0.4", default-features = false }

--- a/examples/stm32h742/Cargo.toml
+++ b/examples/stm32h742/Cargo.toml
@@ -51,7 +51,6 @@ embedded-hal = "0.2.6"
 panic-probe = { version = "0.3", features = ["print-defmt"] }
 heapless = { version = "0.8", default-features = false }
 nb = "1.0.0"
-rand_core = "0.6.3"
 critical-section = "1.1"
 embedded-storage = "0.3.1"
 static_cell = "2"

--- a/examples/stm32h755cm4/Cargo.toml
+++ b/examples/stm32h755cm4/Cargo.toml
@@ -27,7 +27,6 @@ embedded-nal-async = "0.8.0"
 embedded-io-async = { version = "0.6.1" }
 panic-probe = { version = "0.3", features = ["print-defmt"] }
 heapless = { version = "0.8", default-features = false }
-rand_core = "0.6.3"
 critical-section = "1.1"
 micromath = "2.0.0"
 stm32-fmc = "0.3.0"

--- a/examples/stm32h755cm7/Cargo.toml
+++ b/examples/stm32h755cm7/Cargo.toml
@@ -27,7 +27,6 @@ embedded-nal-async = "0.8.0"
 embedded-io-async = { version = "0.6.1" }
 panic-probe = { version = "0.3", features = ["print-defmt"] }
 heapless = { version = "0.8", default-features = false }
-rand_core = "0.6.3"
 critical-section = "1.1"
 micromath = "2.0.0"
 stm32-fmc = "0.3.0"

--- a/examples/stm32h7b0/Cargo.toml
+++ b/examples/stm32h7b0/Cargo.toml
@@ -26,7 +26,6 @@ embedded-nal-async = "0.8.0"
 embedded-io-async = { version = "0.6.1" }
 panic-probe = { version = "0.3", features = ["print-defmt"] }
 heapless = { version = "0.8", default-features = false }
-rand_core = "0.6.3"
 critical-section = "1.1"
 micromath = "2.0.0"
 stm32-fmc = "0.3.0"

--- a/examples/stm32h7rs/Cargo.toml
+++ b/examples/stm32h7rs/Cargo.toml
@@ -26,7 +26,6 @@ embedded-nal-async = "0.8.0"
 embedded-io-async = { version = "0.6.1" }
 panic-probe = { version = "0.3", features = ["print-defmt"] }
 heapless = { version = "0.8", default-features = false }
-rand_core = "0.6.3"
 critical-section = "1.1"
 micromath = "2.0.0"
 stm32-fmc = "0.3.0"

--- a/examples/stm32h7rs/src/bin/eth.rs
+++ b/examples/stm32h7rs/src/bin/eth.rs
@@ -11,7 +11,6 @@ use embassy_stm32::rng::Rng;
 use embassy_stm32::{bind_interrupts, eth, peripherals, rng, Config};
 use embassy_time::Timer;
 use heapless::Vec;
-use rand_core::RngCore;
 use static_cell::StaticCell;
 use {defmt_rtt as _, panic_probe as _};
 

--- a/examples/stm32l4/Cargo.toml
+++ b/examples/stm32l4/Cargo.toml
@@ -30,7 +30,6 @@ embedded-hal-bus = { version = "0.1", features = ["async"] }
 panic-probe = { version = "0.3", features = ["print-defmt"] }
 heapless = { version = "0.8", default-features = false }
 chrono = { version = "^0.4", default-features = false }
-rand = { version = "0.8.5", default-features = false }
 static_cell = "2"
 
 micromath = "2.0.0"

--- a/examples/stm32l4/src/bin/spe_adin1110_http_server.rs
+++ b/examples/stm32l4/src/bin/spe_adin1110_http_server.rs
@@ -38,7 +38,6 @@ use embedded_io::Write as bWrite;
 use embedded_io_async::Write;
 use heapless::Vec;
 use panic_probe as _;
-use rand::RngCore;
 use static_cell::StaticCell;
 
 bind_interrupts!(struct Irqs {

--- a/examples/stm32l5/Cargo.toml
+++ b/examples/stm32l5/Cargo.toml
@@ -23,7 +23,6 @@ cortex-m = { version = "0.7.6", features = ["inline-asm", "critical-section-sing
 cortex-m-rt = "0.7.0"
 embedded-hal = "0.2.6"
 heapless = { version = "0.8", default-features = false }
-rand_core = { version = "0.6.3", default-features = false }
 embedded-io-async = { version = "0.6.1" }
 static_cell = "2"
 

--- a/examples/stm32l5/src/bin/usb_ethernet.rs
+++ b/examples/stm32l5/src/bin/usb_ethernet.rs
@@ -12,7 +12,6 @@ use embassy_usb::class::cdc_ncm::embassy_net::{Device, Runner, State as NetState
 use embassy_usb::class::cdc_ncm::{CdcNcmClass, State};
 use embassy_usb::{Builder, UsbDevice};
 use embedded_io_async::Write;
-use rand_core::RngCore;
 use static_cell::StaticCell;
 use {defmt_rtt as _, panic_probe as _};
 

--- a/tests/rp/Cargo.toml
+++ b/tests/rp/Cargo.toml
@@ -38,7 +38,6 @@ embedded-io-async = { version = "0.6.1" }
 embedded-storage = { version = "0.3" }
 static_cell = "2"
 portable-atomic = { version = "1.5", features = ["critical-section"] }
-rand = { version = "0.8.5", default-features = false }
 
 # bootsel not currently supported on 2350
 [[bin]]

--- a/tests/rp/src/bin/ethernet_w5100s_perf.rs
+++ b/tests/rp/src/bin/ethernet_w5100s_perf.rs
@@ -14,7 +14,6 @@ use embassy_rp::peripherals::SPI0;
 use embassy_rp::spi::{Async, Config as SpiConfig, Spi};
 use embassy_time::Delay;
 use embedded_hal_bus::spi::ExclusiveDevice;
-use rand::RngCore;
 use static_cell::StaticCell;
 use {defmt_rtt as _, panic_probe as _};
 

--- a/tests/stm32/Cargo.toml
+++ b/tests/stm32/Cargo.toml
@@ -81,8 +81,8 @@ embedded-hal-async = { version = "1.0" }
 embedded-can = { version = "0.4" }
 micromath = "2.0.0"
 panic-probe = { version = "0.3.0", features = ["print-defmt"] }
-rand_core = { version = "0.6", default-features = false }
-rand_chacha = { version = "0.3", default-features = false }
+rand_core = { version = "0.9.1", default-features = false }
+rand_chacha = { version = "0.9.0", default-features = false }
 static_cell = "2"
 portable-atomic = { version = "1.5", features = [] }
 

--- a/tests/stm32/src/bin/eth.rs
+++ b/tests/stm32/src/bin/eth.rs
@@ -11,7 +11,6 @@ use embassy_stm32::eth::{Ethernet, GenericPhy, PacketQueue};
 use embassy_stm32::peripherals::ETH;
 use embassy_stm32::rng::Rng;
 use embassy_stm32::{bind_interrupts, eth, peripherals, rng};
-use rand_core::RngCore;
 use static_cell::StaticCell;
 use {defmt_rtt as _, panic_probe as _};
 

--- a/tests/utils/Cargo.toml
+++ b/tests/utils/Cargo.toml
@@ -4,5 +4,5 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-rand = "0.8"
+rand = "0.9"
 serial = "0.4"


### PR DESCRIPTION
- Implement rand-core v0.9 in HALs (keeping v0.6 support, same as we do with embedded-hal v0.2 and v1.0)
- Add inherent methods
- Switch most examples to use inherent methods instead of rand-core.
