### PR TITLE
Add support for rtc_v3h7rs

### DIFF
--- a/embassy-stm32/Cargo.toml
+++ b/embassy-stm32/Cargo.toml
@@ -81,7 +81,7 @@ futures-util = { version = "0.3.30", default-features = false }
 sdio-host = "0.9.0"
 critical-section = "1.1"
 #stm32-metapac = { version = "16" }
-stm32-metapac = { git = "https://github.com/embassy-rs/stm32-data-generated", tag = "stm32-data-7251801e3273011ce28a89e8f2e45eec2e419e26" }
+stm32-metapac = { git = "https://github.com/embassy-rs/stm32-data-generated", tag = "stm32-data-27ef8fba3483187e852eaf3796d827259f61e8ec" }
 
 vcell = "0.1.3"
 nb = "1.0.0"
@@ -110,7 +110,7 @@ proc-macro2 = "1.0.36"
 quote = "1.0.15"
 
 #stm32-metapac = { version = "16", default-features = false, features = ["metadata"]}
-stm32-metapac = { git = "https://github.com/embassy-rs/stm32-data-generated", tag = "stm32-data-7251801e3273011ce28a89e8f2e45eec2e419e26", default-features = false, features = ["metadata"] }
+stm32-metapac = { git = "https://github.com/embassy-rs/stm32-data-generated", tag = "stm32-data-27ef8fba3483187e852eaf3796d827259f61e8ec", default-features = false, features = ["metadata"] }
 
 [features]
 default = ["rt"]

--- a/embassy-stm32/src/rtc/mod.rs
+++ b/embassy-stm32/src/rtc/mod.rs
@@ -25,7 +25,7 @@ use crate::time::Hertz;
     ),
     path = "v2.rs"
 )]
-#[cfg_attr(any(rtc_v3, rtc_v3u5, rtc_v3l5), path = "v3.rs")]
+#[cfg_attr(any(rtc_v3, rtc_v3u5, rtc_v3l5, rtc_v3h7rs), path = "v3.rs")]
 mod _version;
 #[allow(unused_imports)]
 pub use _version::*;


### PR DESCRIPTION
Updates to be compatible with https://github.com/embassy-rs/stm32-data/pull/609

With these changes, I could successfully run the rtc stm32h7rs example.