### PR TITLE
mspm0: add gpio handlers to l122x/l110x

### DIFF
--- a/embassy-mspm0/src/gpio.rs
+++ b/embassy-mspm0/src/gpio.rs
@@ -10,7 +10,7 @@ use embassy_sync::waitqueue::AtomicWaker;
 
 use crate::pac::gpio::vals::*;
 use crate::pac::gpio::{self};
-#[cfg(all(feature = "rt", mspm0c110x))]
+#[cfg(all(feature = "rt", any(mspm0c110x, mspm0l110x)))]
 use crate::pac::interrupt;
 use crate::pac::{self};
 
@@ -1120,7 +1120,7 @@ impl Iterator for BitIter {
 }
 
 // C110x has a dedicated interrupt just for GPIOA, as it does not have a GROUP1 interrupt.
-#[cfg(all(feature = "rt", mspm0c110x))]
+#[cfg(all(feature = "rt", any(mspm0c110x, mspm0l110x)))]
 #[interrupt]
 fn GPIOA() {
     gpioa_interrupt();

--- a/embassy-mspm0/src/int_group/l12xx.rs
+++ b/embassy-mspm0/src/int_group/l12xx.rs
@@ -41,9 +41,9 @@ fn GROUP1() {
 
     match group {
         Group1::GPIOA => crate::gpio::gpioa_interrupt(),
-        Group1::GPIOB => todo!("implement GPIOB"),
+        Group1::GPIOB => crate::gpio::gpiob_interrupt(),
         Group1::COMP0 => todo!("implement COMP0"),
         Group1::TRNG => todo!("implement TRNG"),
-        Group1::GPIOC => todo!("implement GPIOC"),
+        Group1::GPIOC => crate::gpio::gpioc_interrupt(),
     }
 }


### PR DESCRIPTION
Dumb mistake pretty much, should fix CI explosions.