### PR TITLE
feat(stm32): provide a `const` constructor on `rcc::Config`

### DIFF
--- a/embassy-stm32/src/rcc/bd.rs
+++ b/embassy-stm32/src/rcc/bd.rs
@@ -92,6 +92,16 @@ pub struct LsConfig {
 }
 
 impl LsConfig {
+    pub const fn new() -> Self {
+        // on L5, just the fact that LSI is enabled makes things crash.
+        // TODO: investigate.
+
+        #[cfg(not(stm32l5))]
+        return Self::default_lsi();
+        #[cfg(stm32l5)]
+        return Self::off();
+    }
+
     pub const fn default_lse() -> Self {
         Self {
             rtc: RtcClockSource::LSE,
@@ -124,13 +134,7 @@ impl LsConfig {
 
 impl Default for LsConfig {
     fn default() -> Self {
-        // on L5, just the fact that LSI is enabled makes things crash.
-        // TODO: investigate.
-
-        #[cfg(not(stm32l5))]
-        return Self::default_lsi();
-        #[cfg(stm32l5)]
-        return Self::off();
+        Self::new()
     }
 }
 

--- a/embassy-stm32/src/rcc/bd.rs
+++ b/embassy-stm32/src/rcc/bd.rs
@@ -92,6 +92,7 @@ pub struct LsConfig {
 }
 
 impl LsConfig {
+    /// Creates an [`LsConfig`] using the LSI when possible.
     pub const fn new() -> Self {
         // on L5, just the fact that LSI is enabled makes things crash.
         // TODO: investigate.

--- a/embassy-stm32/src/rcc/c0.rs
+++ b/embassy-stm32/src/rcc/c0.rs
@@ -60,7 +60,6 @@ pub struct Config {
 }
 
 impl Config {
-    #[inline]
     pub const fn new() -> Self {
         Config {
             hsi: Some(Hsi {
@@ -78,7 +77,6 @@ impl Config {
 }
 
 impl Default for Config {
-    #[inline]
     fn default() -> Config {
         Self::new()
     }

--- a/embassy-stm32/src/rcc/c0.rs
+++ b/embassy-stm32/src/rcc/c0.rs
@@ -59,9 +59,9 @@ pub struct Config {
     pub mux: super::mux::ClockMux,
 }
 
-impl Default for Config {
+impl Config {
     #[inline]
-    fn default() -> Config {
+    pub const fn new() -> Self {
         Config {
             hsi: Some(Hsi {
                 sys_div: HsiSysDiv::DIV4,
@@ -71,9 +71,16 @@ impl Default for Config {
             sys: Sysclk::HSISYS,
             ahb_pre: AHBPrescaler::DIV1,
             apb1_pre: APBPrescaler::DIV1,
-            ls: Default::default(),
-            mux: Default::default(),
+            ls: crate::rcc::LsConfig::new(),
+            mux: super::mux::ClockMux::default(),
         }
+    }
+}
+
+impl Default for Config {
+    #[inline]
+    fn default() -> Config {
+        Self::new()
     }
 }
 

--- a/embassy-stm32/src/rcc/f013.rs
+++ b/embassy-stm32/src/rcc/f013.rs
@@ -126,13 +126,13 @@ pub struct Config {
     pub ls: super::LsConfig,
 }
 
-impl Default for Config {
-    fn default() -> Self {
+impl Config {
+    pub const fn new() -> Self {
         Self {
             hsi: true,
             hse: None,
             #[cfg(crs)]
-            hsi48: Some(Default::default()),
+            hsi48: Some(crate::rcc::Hsi48Config::new()),
             sys: Sysclk::HSI,
             pll: None,
 
@@ -147,7 +147,7 @@ impl Default for Config {
             apb1_pre: APBPrescaler::DIV1,
             #[cfg(not(stm32f0))]
             apb2_pre: APBPrescaler::DIV1,
-            ls: Default::default(),
+            ls: crate::rcc::LsConfig::new(),
 
             #[cfg(stm32f1)]
             // ensure ADC is not out of range by default even if APB2 is maxxed out (36mhz)
@@ -163,8 +163,14 @@ impl Default for Config {
             #[cfg(stm32f107)]
             i2s3_src: I2s2src::SYS,
 
-            mux: Default::default(),
+            mux: super::mux::ClockMux::default(),
         }
+    }
+}
+
+impl Default for Config {
+    fn default() -> Self {
+        Self::new()
     }
 }
 

--- a/embassy-stm32/src/rcc/f247.rs
+++ b/embassy-stm32/src/rcc/f247.rs
@@ -108,8 +108,8 @@ pub struct Config {
     pub voltage: VoltageScale,
 }
 
-impl Default for Config {
-    fn default() -> Self {
+impl Config {
+    pub const fn new() -> Self {
         Self {
             hsi: true,
             hse: None,
@@ -127,12 +127,18 @@ impl Default for Config {
             apb1_pre: APBPrescaler::DIV1,
             apb2_pre: APBPrescaler::DIV1,
 
-            ls: Default::default(),
+            ls: crate::rcc::LsConfig::new(),
 
             #[cfg(stm32f2)]
             voltage: VoltageScale::Range3,
-            mux: Default::default(),
+            mux: super::mux::ClockMux::default(),
         }
+    }
+}
+
+impl Default for Config {
+    fn default() -> Self {
+        Self::new()
     }
 }
 

--- a/embassy-stm32/src/rcc/g0.rs
+++ b/embassy-stm32/src/rcc/g0.rs
@@ -97,9 +97,9 @@ pub struct Config {
     pub mux: super::mux::ClockMux,
 }
 
-impl Default for Config {
+impl Config {
     #[inline]
-    fn default() -> Config {
+    pub const fn new() -> Self {
         Config {
             hsi: Some(Hsi {
                 sys_div: HsiSysDiv::DIV1,
@@ -107,15 +107,22 @@ impl Default for Config {
             hse: None,
             sys: Sysclk::HSI,
             #[cfg(crs)]
-            hsi48: Some(Default::default()),
+            hsi48: Some(crate::rcc::Hsi48Config::new()),
             pll: None,
             ahb_pre: AHBPrescaler::DIV1,
             apb1_pre: APBPrescaler::DIV1,
             low_power_run: false,
-            ls: Default::default(),
+            ls: crate::rcc::LsConfig::new(),
             voltage_range: VoltageRange::RANGE1,
-            mux: Default::default(),
+            mux: super::mux::ClockMux::default(),
         }
+    }
+}
+
+impl Default for Config {
+    #[inline]
+    fn default() -> Config {
+        Self::new()
     }
 }
 

--- a/embassy-stm32/src/rcc/g0.rs
+++ b/embassy-stm32/src/rcc/g0.rs
@@ -98,7 +98,6 @@ pub struct Config {
 }
 
 impl Config {
-    #[inline]
     pub const fn new() -> Self {
         Config {
             hsi: Some(Hsi {
@@ -120,7 +119,6 @@ impl Config {
 }
 
 impl Default for Config {
-    #[inline]
     fn default() -> Config {
         Self::new()
     }

--- a/embassy-stm32/src/rcc/g4.rs
+++ b/embassy-stm32/src/rcc/g4.rs
@@ -92,7 +92,6 @@ pub struct Config {
 }
 
 impl Config {
-    #[inline]
     pub const fn new() -> Self {
         Config {
             hsi: true,
@@ -112,7 +111,6 @@ impl Config {
 }
 
 impl Default for Config {
-    #[inline]
     fn default() -> Config {
         Self::new()
     }

--- a/embassy-stm32/src/rcc/g4.rs
+++ b/embassy-stm32/src/rcc/g4.rs
@@ -91,23 +91,30 @@ pub struct Config {
     pub mux: super::mux::ClockMux,
 }
 
-impl Default for Config {
+impl Config {
     #[inline]
-    fn default() -> Config {
+    pub const fn new() -> Self {
         Config {
             hsi: true,
             hse: None,
             sys: Sysclk::HSI,
-            hsi48: Some(Default::default()),
+            hsi48: Some(crate::rcc::Hsi48Config::new()),
             pll: None,
             ahb_pre: AHBPrescaler::DIV1,
             apb1_pre: APBPrescaler::DIV1,
             apb2_pre: APBPrescaler::DIV1,
             low_power_run: false,
-            ls: Default::default(),
+            ls: crate::rcc::LsConfig::new(),
             boost: false,
-            mux: Default::default(),
+            mux: super::mux::ClockMux::default(),
         }
+    }
+}
+
+impl Default for Config {
+    #[inline]
+    fn default() -> Config {
+        Self::new()
     }
 }
 

--- a/embassy-stm32/src/rcc/h.rs
+++ b/embassy-stm32/src/rcc/h.rs
@@ -218,13 +218,13 @@ pub struct Config {
     pub mux: super::mux::ClockMux,
 }
 
-impl Default for Config {
-    fn default() -> Self {
+impl Config {
+    pub const fn new() -> Self {
         Self {
             hsi: Some(HSIPrescaler::DIV1),
             hse: None,
             csi: false,
-            hsi48: Some(Default::default()),
+            hsi48: Some(crate::rcc::Hsi48Config::new()),
             sys: Sysclk::HSI,
             pll1: None,
             pll2: None,
@@ -248,13 +248,19 @@ impl Default for Config {
             voltage_scale: VoltageScale::Scale0,
             #[cfg(rcc_h7rs)]
             voltage_scale: VoltageScale::HIGH,
-            ls: Default::default(),
+            ls: crate::rcc::LsConfig::new(),
 
             #[cfg(any(pwr_h7rm0399, pwr_h7rm0455, pwr_h7rm0468, pwr_h7rs))]
             supply_config: SupplyConfig::LDO,
 
-            mux: Default::default(),
+            mux: super::mux::ClockMux::default(),
         }
+    }
+}
+
+impl Default for Config {
+    fn default() -> Self {
+        Self::new()
     }
 }
 

--- a/embassy-stm32/src/rcc/hsi48.rs
+++ b/embassy-stm32/src/rcc/hsi48.rs
@@ -18,9 +18,15 @@ pub struct Hsi48Config {
     pub sync_from_usb: bool,
 }
 
+impl Hsi48Config {
+    pub const fn new() -> Self {
+        Self { sync_from_usb: false }
+    }
+}
+
 impl Default for Hsi48Config {
     fn default() -> Self {
-        Self { sync_from_usb: false }
+        Self::new()
     }
 }
 

--- a/embassy-stm32/src/rcc/l.rs
+++ b/embassy-stm32/src/rcc/l.rs
@@ -68,9 +68,9 @@ pub struct Config {
     pub mux: super::mux::ClockMux,
 }
 
-impl Default for Config {
+impl Config {
     #[inline]
-    fn default() -> Config {
+    pub const fn new() -> Self {
         Config {
             hse: None,
             hsi: false,
@@ -90,12 +90,19 @@ impl Default for Config {
             #[cfg(any(stm32l47x, stm32l48x, stm32l49x, stm32l4ax, rcc_l4plus, stm32l5))]
             pllsai2: None,
             #[cfg(crs)]
-            hsi48: Some(Default::default()),
-            ls: Default::default(),
+            hsi48: Some(crate::rcc::Hsi48Config::new()),
+            ls: crate::rcc::LsConfig::new(),
             #[cfg(any(stm32l0, stm32l1))]
             voltage_scale: VoltageScale::RANGE1,
-            mux: Default::default(),
+            mux: super::mux::ClockMux::default(),
         }
+    }
+}
+
+impl Default for Config {
+    #[inline]
+    fn default() -> Config {
+        Self::new()
     }
 }
 

--- a/embassy-stm32/src/rcc/l.rs
+++ b/embassy-stm32/src/rcc/l.rs
@@ -69,7 +69,6 @@ pub struct Config {
 }
 
 impl Config {
-    #[inline]
     pub const fn new() -> Self {
         Config {
             hse: None,
@@ -100,7 +99,6 @@ impl Config {
 }
 
 impl Default for Config {
-    #[inline]
     fn default() -> Config {
         Self::new()
     }

--- a/embassy-stm32/src/rcc/u5.rs
+++ b/embassy-stm32/src/rcc/u5.rs
@@ -97,14 +97,14 @@ pub struct Config {
     pub mux: super::mux::ClockMux,
 }
 
-impl Default for Config {
-    fn default() -> Self {
+impl Config {
+    pub const fn new() -> Self {
         Self {
             msis: Some(Msirange::RANGE_4MHZ),
             msik: Some(Msirange::RANGE_4MHZ),
             hse: None,
             hsi: false,
-            hsi48: Some(Default::default()),
+            hsi48: Some(crate::rcc::Hsi48Config::new()),
             pll1: None,
             pll2: None,
             pll3: None,
@@ -114,9 +114,15 @@ impl Default for Config {
             apb2_pre: APBPrescaler::DIV1,
             apb3_pre: APBPrescaler::DIV1,
             voltage_range: VoltageScale::RANGE1,
-            ls: Default::default(),
-            mux: Default::default(),
+            ls: crate::rcc::LsConfig::new(),
+            mux: super::mux::ClockMux::default(),
         }
+    }
+}
+
+impl Default for Config {
+    fn default() -> Self {
+        Self::new()
     }
 }
 

--- a/embassy-stm32/src/rcc/wba.rs
+++ b/embassy-stm32/src/rcc/wba.rs
@@ -38,7 +38,6 @@ pub struct Config {
 }
 
 impl Config {
-    #[inline]
     pub const fn new() -> Self {
         Config {
             hse: None,
@@ -56,7 +55,6 @@ impl Config {
 }
 
 impl Default for Config {
-    #[inline]
     fn default() -> Config {
         Self::new()
     }

--- a/embassy-stm32/src/rcc/wba.rs
+++ b/embassy-stm32/src/rcc/wba.rs
@@ -37,9 +37,9 @@ pub struct Config {
     pub mux: super::mux::ClockMux,
 }
 
-impl Default for Config {
+impl Config {
     #[inline]
-    fn default() -> Config {
+    pub const fn new() -> Self {
         Config {
             hse: None,
             hsi: true,
@@ -48,10 +48,17 @@ impl Default for Config {
             apb1_pre: APBPrescaler::DIV1,
             apb2_pre: APBPrescaler::DIV1,
             apb7_pre: APBPrescaler::DIV1,
-            ls: Default::default(),
+            ls: crate::rcc::LsConfig::new(),
             voltage_scale: VoltageScale::RANGE2,
-            mux: Default::default(),
+            mux: super::mux::ClockMux::default(),
         }
+    }
+}
+
+impl Default for Config {
+    #[inline]
+    fn default() -> Config {
+        Self::new()
     }
 }
 


### PR DESCRIPTION
## Description

Currently, the only way of instantiating an `embassy_stm32::rcc::Config` is through the `Default` trait, which makes it not instantiable from `const` contexts.

This PR introduces a `const` `embassy_stm32::rcc::Config::new()` constructor.

## How to review this PR

- This PR is better reviewed commit by commit: each commit targets one STM32 (sub-)family, except for the first one which *also* introduces a `const` constructor for `Hsi48Config` and `LsConfig`. I can easily split that first commit or, on the opposite, squash all this PR's commits into a single one if you prefer.
- Please do check that this PR is complete and that I didn't forget an STM32 family or some feature-gated field. I did do a basic sanity check by grepping for `::default(` in `embassy-stm32/src/rcc` (the remaining seems irrelevant to this PR).

## Issues references

Closes #4213.