### PR TITLE
Add PWM waveform generation using DMA burst mode

### DIFF
--- a/embassy-stm32/src/timer/simple_pwm.rs
+++ b/embassy-stm32/src/timer/simple_pwm.rs
@@ -388,9 +388,27 @@ impl<'d, T: GeneralInstance4Channel> SimplePwm<'d, T> {
     /// in sequence on each update event (UEV). The data is written via the DMAR register using the
     /// DMA base address (DBA) and burst length (DBL) configured in the DCR register.
     /// 
+    /// The `duty` buffer must be structured as a flattened 2D array in row-major order, where each row
+    /// represents a single update event and each column corresponds to a specific timer channel (starting
+    /// from `starting_channel` up to and including `ending_channel`).
+    ///
+    /// For example, if using channels 1 through 4, a buffer of 4 update steps might look like:
+    ///
+    /// ```rust
+    /// let dma_buf: [u16; 16] = [
+    ///     ch1_duty_1, ch2_duty_1, ch3_duty_1, ch4_duty_1, // update 1
+    ///     ch1_duty_2, ch2_duty_2, ch3_duty_2, ch4_duty_2, // update 2
+    ///     ch1_duty_3, ch2_duty_3, ch3_duty_3, ch4_duty_3, // update 3
+    ///     ch1_duty_4, ch2_duty_4, ch3_duty_4, ch4_duty_4, // update 4
+    /// ];
+    /// ```
+    ///
+    /// Each group of N values (where N = number of channels) is transferred on one update event,
+    /// updating the duty cycles of all selected channels simultaneously.
+    /// 
     /// Note:
     /// you will need to provide corresponding TIMx_UP DMA channel to use this method.
-    pub async fn waveform_up_multichannel(
+    pub async fn waveform_up_multi_channel(
         &mut self,
         dma: Peri<'_, impl super::UpDma<T>>,
         starting_channel: Channel,


### PR DESCRIPTION
This PR adds the waveform_up_multi_channel method, enabling PWM waveform generation using DMA burst transfers triggered by timer update events (UEV).

DMA operates through the DMAR register using configured DBA/DBL to update multiple CCRx registers in one transfer.

![image](https://github.com/user-attachments/assets/8bfc4d04-27ea-4e78-a533-f40d2fafb85b)
