### PR TITLE
Hide embedded-hal 0.2 implementations behind a feature

### DIFF
--- a/embassy-embedded-hal/Cargo.toml
+++ b/embassy-embedded-hal/Cargo.toml
@@ -20,13 +20,14 @@ target = "x86_64-unknown-linux-gnu"
 [features]
 time = ["dep:embassy-time"]
 default = ["time"]
+embedded-hal-02 = ["dep:embedded-hal-02"]
 
 [dependencies]
 embassy-hal-internal = { version = "0.2.0", path = "../embassy-hal-internal" }
 embassy-futures = { version = "0.1.0", path = "../embassy-futures" }
 embassy-sync = { version = "0.6.2", path = "../embassy-sync" }
 embassy-time = { version = "0.4.0", path = "../embassy-time", optional = true }
-embedded-hal-02 = { package = "embedded-hal", version = "0.2.6", features = [
+embedded-hal-02 = { package = "embedded-hal", version = "0.2.6", optional = true, features = [
     "unproven",
 ] }
 embedded-hal-1 = { package = "embedded-hal", version = "1.0" }

--- a/embassy-embedded-hal/src/adapter/blocking_async.rs
+++ b/embassy-embedded-hal/src/adapter/blocking_async.rs
@@ -1,5 +1,3 @@
-use embedded_hal_02::blocking;
-
 /// Wrapper that implements async traits using blocking implementations.
 ///
 /// This allows driver writers to depend on the async traits while still supporting embedded-hal peripheral implementations.
@@ -21,18 +19,24 @@ impl<T> BlockingAsync<T> {
 //
 // I2C implementations
 //
+#[cfg(feature = "embedded-hal-02")]
 impl<T, E> embedded_hal_1::i2c::ErrorType for BlockingAsync<T>
 where
     E: embedded_hal_1::i2c::Error + 'static,
-    T: blocking::i2c::WriteRead<Error = E> + blocking::i2c::Read<Error = E> + blocking::i2c::Write<Error = E>,
+    T: embedded_hal_02::blocking::i2c::WriteRead<Error = E>
+        + embedded_hal_02::blocking::i2c::Read<Error = E>
+        + embedded_hal_02::blocking::i2c::Write<Error = E>,
 {
     type Error = E;
 }
 
+#[cfg(feature = "embedded-hal-02")]
 impl<T, E> embedded_hal_async::i2c::I2c for BlockingAsync<T>
 where
     E: embedded_hal_1::i2c::Error + 'static,
-    T: blocking::i2c::WriteRead<Error = E> + blocking::i2c::Read<Error = E> + blocking::i2c::Write<Error = E>,
+    T: embedded_hal_02::blocking::i2c::WriteRead<Error = E>
+        + embedded_hal_02::blocking::i2c::Read<Error = E>
+        + embedded_hal_02::blocking::i2c::Write<Error = E>,
 {
     async fn read(&mut self, address: u8, read: &mut [u8]) -> Result<(), Self::Error> {
         self.wrapped.read(address, read)
@@ -61,18 +65,20 @@ where
 // SPI implementatinos
 //
 
+#[cfg(feature = "embedded-hal-02")]
 impl<T, E> embedded_hal_async::spi::ErrorType for BlockingAsync<T>
 where
     E: embedded_hal_1::spi::Error,
-    T: blocking::spi::Transfer<u8, Error = E> + blocking::spi::Write<u8, Error = E>,
+    T: embedded_hal_02::blocking::spi::Transfer<u8, Error = E> + embedded_hal_02::blocking::spi::Write<u8, Error = E>,
 {
     type Error = E;
 }
 
+#[cfg(feature = "embedded-hal-02")]
 impl<T, E> embedded_hal_async::spi::SpiBus<u8> for BlockingAsync<T>
 where
     E: embedded_hal_1::spi::Error + 'static,
-    T: blocking::spi::Transfer<u8, Error = E> + blocking::spi::Write<u8, Error = E>,
+    T: embedded_hal_02::blocking::spi::Transfer<u8, Error = E> + embedded_hal_02::blocking::spi::Write<u8, Error = E>,
 {
     async fn flush(&mut self) -> Result<(), Self::Error> {
         Ok(())

--- a/embassy-embedded-hal/src/shared_bus/blocking/i2c.rs
+++ b/embassy-embedded-hal/src/shared_bus/blocking/i2c.rs
@@ -75,6 +75,7 @@ where
     }
 }
 
+#[cfg(feature = "embedded-hal-02")]
 impl<'a, M, BUS, E> embedded_hal_02::blocking::i2c::Write for I2cDevice<'_, M, BUS>
 where
     M: RawMutex,
@@ -88,6 +89,7 @@ where
     }
 }
 
+#[cfg(feature = "embedded-hal-02")]
 impl<'a, M, BUS, E> embedded_hal_02::blocking::i2c::Read for I2cDevice<'_, M, BUS>
 where
     M: RawMutex,
@@ -101,6 +103,7 @@ where
     }
 }
 
+#[cfg(feature = "embedded-hal-02")]
 impl<'a, M, BUS, E> embedded_hal_02::blocking::i2c::WriteRead for I2cDevice<'_, M, BUS>
 where
     M: RawMutex,

--- a/embassy-imxrt/Cargo.toml
+++ b/embassy-imxrt/Cargo.toml
@@ -62,6 +62,8 @@ mimxrt685s = ["mimxrt685s-pac", "_mimxrt685s"]
 ## MIMXRT633S
 mimxrt633s = ["mimxrt633s-pac", "_mimxrt633s"]
 
+embedded-hal-02 = ["dep:embedded-hal-02"]
+
 [dependencies]
 embassy-sync = { version = "0.6.2", path = "../embassy-sync" }
 embassy-time-driver = { version = "0.2", path = "../embassy-time-driver", optional = true }
@@ -85,7 +87,7 @@ fixed = "1.23.1"
 rand-core-06 = { package = "rand_core", version = "0.6" }
 rand-core-09 = { package = "rand_core", version = "0.9" }
 
-embedded-hal-02 = { package = "embedded-hal", version = "0.2.6", features = [
+embedded-hal-02 = { package = "embedded-hal", version = "0.2.6", optional = true, features = [
     "unproven",
 ] }
 embedded-hal-1 = { package = "embedded-hal", version = "1.0" }

--- a/embassy-imxrt/src/flexcomm/uart.rs
+++ b/embassy-imxrt/src/flexcomm/uart.rs
@@ -860,6 +860,7 @@ impl<'a> Uart<'a, Async> {
     }
 }
 
+#[cfg(feature = "embedded-hal-02")]
 impl embedded_hal_02::serial::Read<u8> for UartRx<'_, Blocking> {
     type Error = Error;
 
@@ -874,6 +875,7 @@ impl embedded_hal_02::serial::Read<u8> for UartRx<'_, Blocking> {
     }
 }
 
+#[cfg(feature = "embedded-hal-02")]
 impl embedded_hal_02::serial::Write<u8> for UartTx<'_, Blocking> {
     type Error = Error;
 
@@ -894,6 +896,7 @@ impl embedded_hal_02::serial::Write<u8> for UartTx<'_, Blocking> {
     }
 }
 
+#[cfg(feature = "embedded-hal-02")]
 impl embedded_hal_02::blocking::serial::Write<u8> for UartTx<'_, Blocking> {
     type Error = Error;
 
@@ -906,6 +909,7 @@ impl embedded_hal_02::blocking::serial::Write<u8> for UartTx<'_, Blocking> {
     }
 }
 
+#[cfg(feature = "embedded-hal-02")]
 impl embedded_hal_02::serial::Read<u8> for Uart<'_, Blocking> {
     type Error = Error;
 
@@ -914,6 +918,7 @@ impl embedded_hal_02::serial::Read<u8> for Uart<'_, Blocking> {
     }
 }
 
+#[cfg(feature = "embedded-hal-02")]
 impl embedded_hal_02::serial::Write<u8> for Uart<'_, Blocking> {
     type Error = Error;
 
@@ -926,6 +931,7 @@ impl embedded_hal_02::serial::Write<u8> for Uart<'_, Blocking> {
     }
 }
 
+#[cfg(feature = "embedded-hal-02")]
 impl embedded_hal_02::blocking::serial::Write<u8> for Uart<'_, Blocking> {
     type Error = Error;
 
@@ -992,6 +998,7 @@ impl embedded_hal_nb::serial::Write for UartTx<'_, Blocking> {
     }
 }
 
+#[cfg(feature = "embedded-hal-02")]
 impl embedded_hal_nb::serial::Read for Uart<'_, Blocking> {
     fn read(&mut self) -> core::result::Result<u8, nb::Error<Self::Error>> {
         embedded_hal_02::serial::Read::read(&mut self.rx)

--- a/embassy-imxrt/src/gpio.rs
+++ b/embassy-imxrt/src/gpio.rs
@@ -782,6 +782,7 @@ static GPIO_WAKERS: [Option<&PortWaker>; PORT_COUNT] = [
     Some(&port7_waker::WAKER),
 ];
 
+#[cfg(feature = "embedded-hal-02")]
 impl embedded_hal_02::digital::v2::InputPin for Flex<'_, SenseEnabled> {
     type Error = Infallible;
 
@@ -796,6 +797,7 @@ impl embedded_hal_02::digital::v2::InputPin for Flex<'_, SenseEnabled> {
     }
 }
 
+#[cfg(feature = "embedded-hal-02")]
 impl<S: Sense> embedded_hal_02::digital::v2::OutputPin for Flex<'_, S> {
     type Error = Infallible;
 
@@ -812,6 +814,7 @@ impl<S: Sense> embedded_hal_02::digital::v2::OutputPin for Flex<'_, S> {
     }
 }
 
+#[cfg(feature = "embedded-hal-02")]
 impl embedded_hal_02::digital::v2::StatefulOutputPin for Flex<'_, SenseEnabled> {
     #[inline]
     fn is_set_high(&self) -> Result<bool, Self::Error> {
@@ -824,6 +827,7 @@ impl embedded_hal_02::digital::v2::StatefulOutputPin for Flex<'_, SenseEnabled> 
     }
 }
 
+#[cfg(feature = "embedded-hal-02")]
 impl<S: Sense> embedded_hal_02::digital::v2::ToggleableOutputPin for Flex<'_, S> {
     type Error = Infallible;
 
@@ -834,6 +838,7 @@ impl<S: Sense> embedded_hal_02::digital::v2::ToggleableOutputPin for Flex<'_, S>
     }
 }
 
+#[cfg(feature = "embedded-hal-02")]
 impl embedded_hal_02::digital::v2::InputPin for Input<'_> {
     type Error = Infallible;
 
@@ -848,6 +853,7 @@ impl embedded_hal_02::digital::v2::InputPin for Input<'_> {
     }
 }
 
+#[cfg(feature = "embedded-hal-02")]
 impl embedded_hal_02::digital::v2::OutputPin for Output<'_> {
     type Error = Infallible;
 
@@ -864,6 +870,7 @@ impl embedded_hal_02::digital::v2::OutputPin for Output<'_> {
     }
 }
 
+#[cfg(feature = "embedded-hal-02")]
 impl embedded_hal_02::digital::v2::StatefulOutputPin for Output<'_> {
     #[inline]
     fn is_set_high(&self) -> Result<bool, Self::Error> {
@@ -876,6 +883,7 @@ impl embedded_hal_02::digital::v2::StatefulOutputPin for Output<'_> {
     }
 }
 
+#[cfg(feature = "embedded-hal-02")]
 impl embedded_hal_02::digital::v2::ToggleableOutputPin for Output<'_> {
     type Error = Infallible;
 

--- a/embassy-nrf/Cargo.toml
+++ b/embassy-nrf/Cargo.toml
@@ -139,6 +139,8 @@ _nrf52832_anomaly_109 = []
 # watchdog timer
 _multi_wdt = []
 
+embedded-hal-02 = ["dep:embedded-hal-02"]
+
 [dependencies]
 embassy-time-driver = { version = "0.2", path = "../embassy-time-driver", optional = true }
 embassy-time-queue-utils = { version = "0.1", path = "../embassy-time-queue-utils", optional = true }
@@ -148,7 +150,7 @@ embassy-hal-internal = { version = "0.2.0", path = "../embassy-hal-internal", fe
 embassy-embedded-hal = { version = "0.3.0", path = "../embassy-embedded-hal", default-features = false }
 embassy-usb-driver = { version = "0.1.0", path = "../embassy-usb-driver" }
 
-embedded-hal-02 = { package = "embedded-hal", version = "0.2.6", features = ["unproven"] }
+embedded-hal-02 = { package = "embedded-hal", version = "0.2.6", optional = true, features = ["unproven"] }
 embedded-hal-1 = { package = "embedded-hal", version = "1.0" }
 embedded-hal-async = { version = "1.0" }
 embedded-io = { version = "0.6.0" }

--- a/embassy-nrf/src/gpio.rs
+++ b/embassy-nrf/src/gpio.rs
@@ -613,6 +613,7 @@ macro_rules! impl_pin {
 
 // ====================
 
+#[cfg(feature = "embedded-hal-02")]
 mod eh02 {
     use super::*;
 

--- a/embassy-nrf/src/gpiote.rs
+++ b/embassy-nrf/src/gpiote.rs
@@ -506,6 +506,7 @@ impl_channel!(GPIOTE_CH7, 7);
 
 // ====================
 
+#[cfg(feature = "embedded-hal-02")]
 mod eh02 {
     use super::*;
 

--- a/embassy-nrf/src/spim.rs
+++ b/embassy-nrf/src/spim.rs
@@ -12,7 +12,7 @@ use core::task::Poll;
 use embassy_embedded_hal::SetConfig;
 use embassy_hal_internal::{Peri, PeripheralType};
 use embassy_sync::waitqueue::AtomicWaker;
-pub use embedded_hal_02::spi::{Mode, Phase, Polarity, MODE_0, MODE_1, MODE_2, MODE_3};
+pub use embedded_hal_1::spi::{Mode, Phase, Polarity, MODE_0, MODE_1, MODE_2, MODE_3};
 pub use pac::spim::vals::{Frequency, Order as BitOrder};
 
 use crate::chip::{EASY_DMA_SIZE, FORCE_COPY_BUFFER_SIZE};
@@ -523,6 +523,7 @@ macro_rules! impl_spim {
 
 // ====================
 
+#[cfg(feature = "embedded-hal-02")]
 mod eh02 {
     use super::*;
 

--- a/embassy-nrf/src/spis.rs
+++ b/embassy-nrf/src/spis.rs
@@ -9,7 +9,7 @@ use core::task::Poll;
 use embassy_embedded_hal::SetConfig;
 use embassy_hal_internal::{Peri, PeripheralType};
 use embassy_sync::waitqueue::AtomicWaker;
-pub use embedded_hal_02::spi::{Mode, Phase, Polarity, MODE_0, MODE_1, MODE_2, MODE_3};
+pub use embedded_hal_1::spi::{Mode, Phase, Polarity, MODE_0, MODE_1, MODE_2, MODE_3};
 pub use pac::spis::vals::Order as BitOrder;
 
 use crate::chip::{EASY_DMA_SIZE, FORCE_COPY_BUFFER_SIZE};

--- a/embassy-nrf/src/twim.rs
+++ b/embassy-nrf/src/twim.rs
@@ -756,6 +756,7 @@ macro_rules! impl_twim {
 
 // ====================
 
+#[cfg(feature = "embedded-hal-02")]
 mod eh02 {
     use super::*;
 

--- a/embassy-nrf/src/uarte.rs
+++ b/embassy-nrf/src/uarte.rs
@@ -994,6 +994,7 @@ macro_rules! impl_uarte {
 
 // ====================
 
+#[cfg(feature = "embedded-hal-02")]
 mod eh02 {
     use super::*;
 

--- a/embassy-rp/Cargo.toml
+++ b/embassy-rp/Cargo.toml
@@ -135,6 +135,8 @@ _test = []
 ## program and other details.
 binary-info = ["rt", "dep:rp-binary-info", "rp-binary-info?/binary-info"]
 
+embedded-hal-02 = ["dep:embedded-hal-02"]
+
 [dependencies]
 embassy-sync = { version = "0.6.2", path = "../embassy-sync" }
 embassy-time-driver = { version = "0.2", path = "../embassy-time-driver", optional = true }
@@ -161,7 +163,7 @@ fixed = "1.28.0"
 
 rp-pac = { version = "7.0.0" }
 
-embedded-hal-02 = { package = "embedded-hal", version = "0.2.6", features = ["unproven"] }
+embedded-hal-02 = { package = "embedded-hal", version = "0.2.6", optional = true, features = ["unproven"] }
 embedded-hal-1 = { package = "embedded-hal", version = "1.0" }
 embedded-hal-async = { version = "1.0" }
 embedded-hal-nb = { version = "1.0" }

--- a/embassy-rp/src/gpio.rs
+++ b/embassy-rp/src/gpio.rs
@@ -1064,6 +1064,7 @@ impl_pin!(PIN_QSPI_SD3, Bank::Qspi, 5);
 
 // ====================
 
+#[cfg(feature = "embedded-hal-02")]
 mod eh02 {
     use super::*;
 

--- a/embassy-rp/src/i2c.rs
+++ b/embassy-rp/src/i2c.rs
@@ -613,6 +613,7 @@ impl<'d, T: Instance + 'd, M: Mode> I2c<'d, T, M> {
     }
 }
 
+#[cfg(feature = "embedded-hal-02")]
 impl<'d, T: Instance, M: Mode> embedded_hal_02::blocking::i2c::Read for I2c<'d, T, M> {
     type Error = Error;
 
@@ -621,6 +622,7 @@ impl<'d, T: Instance, M: Mode> embedded_hal_02::blocking::i2c::Read for I2c<'d, 
     }
 }
 
+#[cfg(feature = "embedded-hal-02")]
 impl<'d, T: Instance, M: Mode> embedded_hal_02::blocking::i2c::Write for I2c<'d, T, M> {
     type Error = Error;
 
@@ -629,6 +631,7 @@ impl<'d, T: Instance, M: Mode> embedded_hal_02::blocking::i2c::Write for I2c<'d,
     }
 }
 
+#[cfg(feature = "embedded-hal-02")]
 impl<'d, T: Instance, M: Mode> embedded_hal_02::blocking::i2c::WriteRead for I2c<'d, T, M> {
     type Error = Error;
 
@@ -637,6 +640,7 @@ impl<'d, T: Instance, M: Mode> embedded_hal_02::blocking::i2c::WriteRead for I2c
     }
 }
 
+#[cfg(feature = "embedded-hal-02")]
 impl<'d, T: Instance, M: Mode> embedded_hal_02::blocking::i2c::Transactional for I2c<'d, T, M> {
     type Error = Error;
 

--- a/embassy-rp/src/spi.rs
+++ b/embassy-rp/src/spi.rs
@@ -4,7 +4,7 @@ use core::marker::PhantomData;
 use embassy_embedded_hal::SetConfig;
 use embassy_futures::join::join;
 use embassy_hal_internal::{Peri, PeripheralType};
-pub use embedded_hal_02::spi::{Phase, Polarity};
+pub use embedded_hal_1::spi::{Phase, Polarity};
 
 use crate::dma::{AnyChannel, Channel};
 use crate::gpio::{AnyPin, Pin as GpioPin, SealedPin as _};
@@ -639,6 +639,7 @@ impl_mode!(Async);
 
 // ====================
 
+#[cfg(feature = "embedded-hal-02")]
 impl<'d, T: Instance, M: Mode> embedded_hal_02::blocking::spi::Transfer<u8> for Spi<'d, T, M> {
     type Error = Error;
     fn transfer<'w>(&mut self, words: &'w mut [u8]) -> Result<&'w [u8], Self::Error> {
@@ -647,6 +648,7 @@ impl<'d, T: Instance, M: Mode> embedded_hal_02::blocking::spi::Transfer<u8> for 
     }
 }
 
+#[cfg(feature = "embedded-hal-02")]
 impl<'d, T: Instance, M: Mode> embedded_hal_02::blocking::spi::Write<u8> for Spi<'d, T, M> {
     type Error = Error;
 

--- a/embassy-rp/src/uart/buffered.rs
+++ b/embassy-rp/src/uart/buffered.rs
@@ -723,6 +723,7 @@ impl embedded_io::Write for BufferedUartTx {
     }
 }
 
+#[cfg(feature = "embedded-hal-02")]
 impl embedded_hal_02::serial::Read<u8> for BufferedUartRx {
     type Error = Error;
 
@@ -748,6 +749,7 @@ impl embedded_hal_02::serial::Read<u8> for BufferedUartRx {
     }
 }
 
+#[cfg(feature = "embedded-hal-02")]
 impl embedded_hal_02::blocking::serial::Write<u8> for BufferedUartTx {
     type Error = Error;
 
@@ -767,6 +769,7 @@ impl embedded_hal_02::blocking::serial::Write<u8> for BufferedUartTx {
     }
 }
 
+#[cfg(feature = "embedded-hal-02")]
 impl embedded_hal_02::serial::Read<u8> for BufferedUart {
     type Error = Error;
 
@@ -775,6 +778,7 @@ impl embedded_hal_02::serial::Read<u8> for BufferedUart {
     }
 }
 
+#[cfg(feature = "embedded-hal-02")]
 impl embedded_hal_02::blocking::serial::Write<u8> for BufferedUart {
     type Error = Error;
 
@@ -806,6 +810,7 @@ impl embedded_hal_nb::serial::ErrorType for BufferedUart {
     type Error = Error;
 }
 
+#[cfg(feature = "embedded-hal-02")]
 impl embedded_hal_nb::serial::Read for BufferedUartRx {
     fn read(&mut self) -> nb::Result<u8, Self::Error> {
         embedded_hal_02::serial::Read::read(self)
@@ -822,6 +827,7 @@ impl embedded_hal_nb::serial::Write for BufferedUartTx {
     }
 }
 
+#[cfg(feature = "embedded-hal-02")]
 impl embedded_hal_nb::serial::Read for BufferedUart {
     fn read(&mut self) -> Result<u8, nb::Error<Self::Error>> {
         embedded_hal_02::serial::Read::read(&mut self.rx)

--- a/embassy-rp/src/uart/mod.rs
+++ b/embassy-rp/src/uart/mod.rs
@@ -1111,6 +1111,7 @@ impl<'d> Uart<'d, Async> {
     }
 }
 
+#[cfg(feature = "embedded-hal-02")]
 impl<'d, M: Mode> embedded_hal_02::serial::Read<u8> for UartRx<'d, M> {
     type Error = Error;
     fn read(&mut self) -> Result<u8, nb::Error<Self::Error>> {
@@ -1135,6 +1136,7 @@ impl<'d, M: Mode> embedded_hal_02::serial::Read<u8> for UartRx<'d, M> {
     }
 }
 
+#[cfg(feature = "embedded-hal-02")]
 impl<'d, M: Mode> embedded_hal_02::serial::Write<u8> for UartTx<'d, M> {
     type Error = Error;
 
@@ -1157,6 +1159,7 @@ impl<'d, M: Mode> embedded_hal_02::serial::Write<u8> for UartTx<'d, M> {
     }
 }
 
+#[cfg(feature = "embedded-hal-02")]
 impl<'d, M: Mode> embedded_hal_02::blocking::serial::Write<u8> for UartTx<'d, M> {
     type Error = Error;
 
@@ -1169,6 +1172,7 @@ impl<'d, M: Mode> embedded_hal_02::blocking::serial::Write<u8> for UartTx<'d, M>
     }
 }
 
+#[cfg(feature = "embedded-hal-02")]
 impl<'d, M: Mode> embedded_hal_02::serial::Read<u8> for Uart<'d, M> {
     type Error = Error;
 
@@ -1177,6 +1181,7 @@ impl<'d, M: Mode> embedded_hal_02::serial::Read<u8> for Uart<'d, M> {
     }
 }
 
+#[cfg(feature = "embedded-hal-02")]
 impl<'d, M: Mode> embedded_hal_02::serial::Write<u8> for Uart<'d, M> {
     type Error = Error;
 
@@ -1189,6 +1194,7 @@ impl<'d, M: Mode> embedded_hal_02::serial::Write<u8> for Uart<'d, M> {
     }
 }
 
+#[cfg(feature = "embedded-hal-02")]
 impl<'d, M: Mode> embedded_hal_02::blocking::serial::Write<u8> for Uart<'d, M> {
     type Error = Error;
 
@@ -1271,6 +1277,7 @@ impl<'d> embedded_io::Write for UartTx<'d, Blocking> {
     }
 }
 
+#[cfg(feature = "embedded-hal-02")]
 impl<'d, M: Mode> embedded_hal_nb::serial::Read for Uart<'d, M> {
     fn read(&mut self) -> Result<u8, nb::Error<Self::Error>> {
         embedded_hal_02::serial::Read::read(&mut self.rx)

--- a/embassy-stm32/Cargo.toml
+++ b/embassy-stm32/Cargo.toml
@@ -60,7 +60,7 @@ embassy-usb-driver = { version = "0.1.0", path = "../embassy-usb-driver" }
 embassy-usb-synopsys-otg = { version = "0.2.0", path = "../embassy-usb-synopsys-otg" }
 embassy-executor = { version = "0.7.0", path = "../embassy-executor", optional = true }
 
-embedded-hal-02 = { package = "embedded-hal", version = "0.2.6", features = ["unproven"] }
+embedded-hal-02 = { package = "embedded-hal", version = "0.2.6", optional = true, features = ["unproven"] }
 embedded-hal-1 = { package = "embedded-hal", version = "1.0" }
 embedded-hal-async = { version = "1.0" }
 embedded-hal-nb = { version = "1.0" }
@@ -1654,3 +1654,5 @@ stm32wle5cc = [ "stm32-metapac/stm32wle5cc" ]
 stm32wle5j8 = [ "stm32-metapac/stm32wle5j8" ]
 stm32wle5jb = [ "stm32-metapac/stm32wle5jb" ]
 stm32wle5jc = [ "stm32-metapac/stm32wle5jc" ]
+
+embedded-hal-02 = ["dep:embedded-hal-02"]

--- a/embassy-stm32/src/exti.rs
+++ b/embassy-stm32/src/exti.rs
@@ -171,6 +171,7 @@ impl<'d> ExtiInput<'d> {
     }
 }
 
+#[cfg(feature = "embedded-hal-02")]
 impl<'d> embedded_hal_02::digital::v2::InputPin for ExtiInput<'d> {
     type Error = Infallible;
 

--- a/embassy-stm32/src/flash/f4.rs
+++ b/embassy-stm32/src/flash/f4.rs
@@ -286,8 +286,8 @@ fn pa12_is_output_pull_low() -> bool {
 
 #[cfg(test)]
 mod tests {
-    use super::*;
-    use crate::flash::{get_sector, FlashBank};
+    #[cfg(stm32f429)]
+    use crate::flash::{get_sector, FlashBank, FlashSector};
 
     #[test]
     #[cfg(stm32f429)]

--- a/embassy-stm32/src/gpio.rs
+++ b/embassy-stm32/src/gpio.rs
@@ -870,6 +870,7 @@ pub(crate) unsafe fn init(_cs: CriticalSection) {
     crate::_generated::init_gpio();
 }
 
+#[cfg(feature = "embedded-hal-02")]
 impl<'d> embedded_hal_02::digital::v2::InputPin for Input<'d> {
     type Error = Infallible;
 
@@ -884,6 +885,7 @@ impl<'d> embedded_hal_02::digital::v2::InputPin for Input<'d> {
     }
 }
 
+#[cfg(feature = "embedded-hal-02")]
 impl<'d> embedded_hal_02::digital::v2::OutputPin for Output<'d> {
     type Error = Infallible;
 
@@ -900,6 +902,7 @@ impl<'d> embedded_hal_02::digital::v2::OutputPin for Output<'d> {
     }
 }
 
+#[cfg(feature = "embedded-hal-02")]
 impl<'d> embedded_hal_02::digital::v2::StatefulOutputPin for Output<'d> {
     #[inline]
     fn is_set_high(&self) -> Result<bool, Self::Error> {
@@ -913,6 +916,7 @@ impl<'d> embedded_hal_02::digital::v2::StatefulOutputPin for Output<'d> {
     }
 }
 
+#[cfg(feature = "embedded-hal-02")]
 impl<'d> embedded_hal_02::digital::v2::ToggleableOutputPin for Output<'d> {
     type Error = Infallible;
     #[inline]
@@ -922,6 +926,7 @@ impl<'d> embedded_hal_02::digital::v2::ToggleableOutputPin for Output<'d> {
     }
 }
 
+#[cfg(feature = "embedded-hal-02")]
 impl<'d> embedded_hal_02::digital::v2::InputPin for OutputOpenDrain<'d> {
     type Error = Infallible;
 
@@ -934,6 +939,7 @@ impl<'d> embedded_hal_02::digital::v2::InputPin for OutputOpenDrain<'d> {
     }
 }
 
+#[cfg(feature = "embedded-hal-02")]
 impl<'d> embedded_hal_02::digital::v2::OutputPin for OutputOpenDrain<'d> {
     type Error = Infallible;
 
@@ -950,6 +956,7 @@ impl<'d> embedded_hal_02::digital::v2::OutputPin for OutputOpenDrain<'d> {
     }
 }
 
+#[cfg(feature = "embedded-hal-02")]
 impl<'d> embedded_hal_02::digital::v2::StatefulOutputPin for OutputOpenDrain<'d> {
     #[inline]
     fn is_set_high(&self) -> Result<bool, Self::Error> {
@@ -963,6 +970,7 @@ impl<'d> embedded_hal_02::digital::v2::StatefulOutputPin for OutputOpenDrain<'d>
     }
 }
 
+#[cfg(feature = "embedded-hal-02")]
 impl<'d> embedded_hal_02::digital::v2::ToggleableOutputPin for OutputOpenDrain<'d> {
     type Error = Infallible;
     #[inline]
@@ -972,6 +980,7 @@ impl<'d> embedded_hal_02::digital::v2::ToggleableOutputPin for OutputOpenDrain<'
     }
 }
 
+#[cfg(feature = "embedded-hal-02")]
 impl<'d> embedded_hal_02::digital::v2::InputPin for Flex<'d> {
     type Error = Infallible;
 
@@ -986,6 +995,7 @@ impl<'d> embedded_hal_02::digital::v2::InputPin for Flex<'d> {
     }
 }
 
+#[cfg(feature = "embedded-hal-02")]
 impl<'d> embedded_hal_02::digital::v2::OutputPin for Flex<'d> {
     type Error = Infallible;
 
@@ -1002,6 +1012,7 @@ impl<'d> embedded_hal_02::digital::v2::OutputPin for Flex<'d> {
     }
 }
 
+#[cfg(feature = "embedded-hal-02")]
 impl<'d> embedded_hal_02::digital::v2::StatefulOutputPin for Flex<'d> {
     #[inline]
     fn is_set_high(&self) -> Result<bool, Self::Error> {
@@ -1015,6 +1026,7 @@ impl<'d> embedded_hal_02::digital::v2::StatefulOutputPin for Flex<'d> {
     }
 }
 
+#[cfg(feature = "embedded-hal-02")]
 impl<'d> embedded_hal_02::digital::v2::ToggleableOutputPin for Flex<'d> {
     type Error = Infallible;
     #[inline]

--- a/embassy-stm32/src/i2c/mod.rs
+++ b/embassy-stm32/src/i2c/mod.rs
@@ -347,6 +347,7 @@ foreach_peripheral!(
     };
 );
 
+#[cfg(feature = "embedded-hal-02")]
 impl<'d, M: Mode> embedded_hal_02::blocking::i2c::Read for I2c<'d, M> {
     type Error = Error;
 
@@ -355,6 +356,7 @@ impl<'d, M: Mode> embedded_hal_02::blocking::i2c::Read for I2c<'d, M> {
     }
 }
 
+#[cfg(feature = "embedded-hal-02")]
 impl<'d, M: Mode> embedded_hal_02::blocking::i2c::Write for I2c<'d, M> {
     type Error = Error;
 
@@ -363,6 +365,7 @@ impl<'d, M: Mode> embedded_hal_02::blocking::i2c::Write for I2c<'d, M> {
     }
 }
 
+#[cfg(feature = "embedded-hal-02")]
 impl<'d, M: Mode> embedded_hal_02::blocking::i2c::WriteRead for I2c<'d, M> {
     type Error = Error;
 

--- a/embassy-stm32/src/spi/mod.rs
+++ b/embassy-stm32/src/spi/mod.rs
@@ -6,7 +6,7 @@ use core::ptr;
 
 use embassy_embedded_hal::SetConfig;
 use embassy_futures::join::join;
-pub use embedded_hal_02::spi::{Mode, Phase, Polarity, MODE_0, MODE_1, MODE_2, MODE_3};
+pub use embedded_hal_1::spi::{Mode, Phase, Polarity, MODE_0, MODE_1, MODE_2, MODE_3};
 
 use crate::dma::{word, ChannelAndRequest};
 use crate::gpio::{AfType, AnyPin, OutputType, Pull, SealedPin as _, Speed};
@@ -1125,6 +1125,7 @@ fn write_word<W: Word>(regs: Regs, tx_word: W) -> Result<(), Error> {
 
 // Note: It is not possible to impl these traits generically in embedded-hal 0.2 due to a conflict with
 // some marker traits. For details, see https://github.com/rust-embedded/embedded-hal/pull/289
+#[cfg(feature = "embedded-hal-02")]
 macro_rules! impl_blocking {
     ($w:ident) => {
         impl<'d, M: PeriMode> embedded_hal_02::blocking::spi::Write<$w> for Spi<'d, M> {
@@ -1146,7 +1147,9 @@ macro_rules! impl_blocking {
     };
 }
 
+#[cfg(feature = "embedded-hal-02")]
 impl_blocking!(u8);
+#[cfg(feature = "embedded-hal-02")]
 impl_blocking!(u16);
 
 impl<'d, M: PeriMode> embedded_hal_1::spi::ErrorType for Spi<'d, M> {

--- a/embassy-stm32/src/timer/complementary_pwm.rs
+++ b/embassy-stm32/src/timer/complementary_pwm.rs
@@ -147,6 +147,7 @@ impl<'d, T: AdvancedInstance4Channel> ComplementaryPwm<'d, T> {
     }
 }
 
+#[cfg(feature = "embedded-hal-02")]
 impl<'d, T: AdvancedInstance4Channel> embedded_hal_02::Pwm for ComplementaryPwm<'d, T> {
     type Channel = Channel;
     type Time = Hertz;

--- a/embassy-stm32/src/timer/simple_pwm.rs
+++ b/embassy-stm32/src/timer/simple_pwm.rs
@@ -519,6 +519,7 @@ impl<'d, T: GeneralInstance4Channel> embedded_hal_1::pwm::SetDutyCycle for Simpl
     }
 }
 
+#[cfg(feature = "embedded-hal-02")]
 impl<'d, T: GeneralInstance4Channel> embedded_hal_02::Pwm for SimplePwm<'d, T> {
     type Channel = Channel;
     type Time = Hertz;

--- a/embassy-stm32/src/usart/buffered.rs
+++ b/embassy-stm32/src/usart/buffered.rs
@@ -902,6 +902,7 @@ impl<'d> embedded_io::Write for BufferedUartTx<'d> {
     }
 }
 
+#[cfg(feature = "embedded-hal-02")]
 impl<'d> embedded_hal_02::serial::Read<u8> for BufferedUartRx<'d> {
     type Error = Error;
 
@@ -921,6 +922,7 @@ impl<'d> embedded_hal_02::serial::Read<u8> for BufferedUartRx<'d> {
     }
 }
 
+#[cfg(feature = "embedded-hal-02")]
 impl<'d> embedded_hal_02::blocking::serial::Write<u8> for BufferedUartTx<'d> {
     type Error = Error;
 
@@ -940,6 +942,7 @@ impl<'d> embedded_hal_02::blocking::serial::Write<u8> for BufferedUartTx<'d> {
     }
 }
 
+#[cfg(feature = "embedded-hal-02")]
 impl<'d> embedded_hal_02::serial::Read<u8> for BufferedUart<'d> {
     type Error = Error;
 
@@ -948,6 +951,7 @@ impl<'d> embedded_hal_02::serial::Read<u8> for BufferedUart<'d> {
     }
 }
 
+#[cfg(feature = "embedded-hal-02")]
 impl<'d> embedded_hal_02::blocking::serial::Write<u8> for BufferedUart<'d> {
     type Error = Error;
 
@@ -979,6 +983,7 @@ impl<'d> embedded_hal_nb::serial::ErrorType for BufferedUartRx<'d> {
     type Error = Error;
 }
 
+#[cfg(feature = "embedded-hal-02")]
 impl<'d> embedded_hal_nb::serial::Read for BufferedUartRx<'d> {
     fn read(&mut self) -> nb::Result<u8, Self::Error> {
         embedded_hal_02::serial::Read::read(self)
@@ -995,6 +1000,7 @@ impl<'d> embedded_hal_nb::serial::Write for BufferedUartTx<'d> {
     }
 }
 
+#[cfg(feature = "embedded-hal-02")]
 impl<'d> embedded_hal_nb::serial::Read for BufferedUart<'d> {
     fn read(&mut self) -> Result<u8, nb::Error<Self::Error>> {
         embedded_hal_02::serial::Read::read(&mut self.rx)

--- a/embassy-stm32/src/usart/mod.rs
+++ b/embassy-stm32/src/usart/mod.rs
@@ -1798,6 +1798,7 @@ fn configure(
     Ok(())
 }
 
+#[cfg(feature = "embedded-hal-02")]
 impl<'d, M: Mode> embedded_hal_02::serial::Read<u8> for UartRx<'d, M> {
     type Error = Error;
     fn read(&mut self) -> Result<u8, nb::Error<Self::Error>> {
@@ -1805,6 +1806,7 @@ impl<'d, M: Mode> embedded_hal_02::serial::Read<u8> for UartRx<'d, M> {
     }
 }
 
+#[cfg(feature = "embedded-hal-02")]
 impl<'d, M: Mode> embedded_hal_02::blocking::serial::Write<u8> for UartTx<'d, M> {
     type Error = Error;
     fn bwrite_all(&mut self, buffer: &[u8]) -> Result<(), Self::Error> {
@@ -1815,6 +1817,7 @@ impl<'d, M: Mode> embedded_hal_02::blocking::serial::Write<u8> for UartTx<'d, M>
     }
 }
 
+#[cfg(feature = "embedded-hal-02")]
 impl<'d, M: Mode> embedded_hal_02::serial::Read<u8> for Uart<'d, M> {
     type Error = Error;
     fn read(&mut self) -> Result<u8, nb::Error<Self::Error>> {
@@ -1822,6 +1825,7 @@ impl<'d, M: Mode> embedded_hal_02::serial::Read<u8> for Uart<'d, M> {
     }
 }
 
+#[cfg(feature = "embedded-hal-02")]
 impl<'d, M: Mode> embedded_hal_02::blocking::serial::Write<u8> for Uart<'d, M> {
     type Error = Error;
     fn bwrite_all(&mut self, buffer: &[u8]) -> Result<(), Self::Error> {

--- a/embassy-time/Cargo.toml
+++ b/embassy-time/Cargo.toml
@@ -36,6 +36,8 @@ defmt-timestamp-uptime-ts = ["defmt"]
 defmt-timestamp-uptime-tms = ["defmt"]
 defmt-timestamp-uptime-tus = ["defmt"]
 
+embedded-hal-02 = ["dep:embedded-hal-02"]
+
 #! ### Time Drivers
 
 #! Usually, time drivers are defined by a HAL, or a companion crate to the HAL. For `std` and WASM
@@ -423,7 +425,7 @@ embassy-time-queue-utils = { version = "0.1", path = "../embassy-time-queue-util
 defmt = { version = "1.0.1", optional = true }
 log = { version = "0.4.14", optional = true }
 
-embedded-hal-02 = { package = "embedded-hal", version = "0.2.6" }
+embedded-hal-02 = { package = "embedded-hal", version = "0.2.6", optional = true }
 embedded-hal-1 = { package = "embedded-hal", version = "1.0" }
 embedded-hal-async = { version = "1.0" }
 

--- a/embassy-time/src/delay.rs
+++ b/embassy-time/src/delay.rs
@@ -44,36 +44,42 @@ impl embedded_hal_async::delay::DelayNs for Delay {
     }
 }
 
+#[cfg(feature = "embedded-hal-02")]
 impl embedded_hal_02::blocking::delay::DelayMs<u8> for Delay {
     fn delay_ms(&mut self, ms: u8) {
         block_for(Duration::from_millis(ms as u64))
     }
 }
 
+#[cfg(feature = "embedded-hal-02")]
 impl embedded_hal_02::blocking::delay::DelayMs<u16> for Delay {
     fn delay_ms(&mut self, ms: u16) {
         block_for(Duration::from_millis(ms as u64))
     }
 }
 
+#[cfg(feature = "embedded-hal-02")]
 impl embedded_hal_02::blocking::delay::DelayMs<u32> for Delay {
     fn delay_ms(&mut self, ms: u32) {
         block_for(Duration::from_millis(ms as u64))
     }
 }
 
+#[cfg(feature = "embedded-hal-02")]
 impl embedded_hal_02::blocking::delay::DelayUs<u8> for Delay {
     fn delay_us(&mut self, us: u8) {
         block_for(Duration::from_micros(us as u64))
     }
 }
 
+#[cfg(feature = "embedded-hal-02")]
 impl embedded_hal_02::blocking::delay::DelayUs<u16> for Delay {
     fn delay_us(&mut self, us: u16) {
         block_for(Duration::from_micros(us as u64))
     }
 }
 
+#[cfg(feature = "embedded-hal-02")]
 impl embedded_hal_02::blocking::delay::DelayUs<u32> for Delay {
     fn delay_us(&mut self, us: u32) {
         block_for(Duration::from_micros(us as u64))

--- a/examples/nrf-rtos-trace/build.rs
+++ b/examples/nrf-rtos-trace/build.rs
@@ -31,6 +31,4 @@ fn main() {
 
     println!("cargo:rustc-link-arg-bins=--nmagic");
     println!("cargo:rustc-link-arg-bins=-Tlink.x");
-    #[cfg(feature = "defmt")]
-    println!("cargo:rustc-link-arg-bins=-Tdefmt.x");
 }

--- a/examples/nrf52840-rtic/src/bin/blinky.rs
+++ b/examples/nrf52840-rtic/src/bin/blinky.rs
@@ -1,6 +1,5 @@
 #![no_std]
 #![no_main]
-#![feature(type_alias_impl_trait)]
 
 use {defmt_rtt as _, panic_probe as _};
 

--- a/examples/stm32f4/Cargo.toml
+++ b/examples/stm32f4/Cargo.toml
@@ -9,7 +9,7 @@ license = "MIT OR Apache-2.0"
 embassy-stm32 = { version = "0.2.0", path = "../../embassy-stm32", features = ["defmt", "stm32f429zi", "unstable-pac", "memory-x", "time-driver-tim4", "exti", "chrono"] }
 embassy-sync = { version = "0.6.2", path = "../../embassy-sync", features = ["defmt"] }
 embassy-executor = { version = "0.7.0", path = "../../embassy-executor", features = ["arch-cortex-m", "executor-thread", "executor-interrupt", "defmt"] }
-embassy-time = { version = "0.4.0", path = "../../embassy-time", features = ["defmt", "defmt-timestamp-uptime", "tick-hz-32_768"] }
+embassy-time = { version = "0.4.0", path = "../../embassy-time", features = ["defmt", "defmt-timestamp-uptime", "tick-hz-32_768", "embedded-hal-02"] }
 embassy-usb = { version = "0.4.0", path = "../../embassy-usb", features = ["defmt" ] }
 embassy-net = { version = "0.7.0", path = "../../embassy-net", features = ["defmt", "tcp", "dhcpv4", "medium-ethernet", ] }
 embassy-net-wiznet = { version = "0.2.0", path = "../../embassy-net-wiznet", features = ["defmt"] }

--- a/examples/stm32h7/Cargo.toml
+++ b/examples/stm32h7/Cargo.toml
@@ -10,7 +10,7 @@ embassy-stm32 = { version = "0.2.0", path = "../../embassy-stm32", features = ["
 embassy-sync = { version = "0.6.2", path = "../../embassy-sync", features = ["defmt"] }
 embassy-embedded-hal = { version = "0.3.0", path = "../../embassy-embedded-hal" }
 embassy-executor = { version = "0.7.0", path = "../../embassy-executor", features = ["arch-cortex-m", "executor-thread", "executor-interrupt", "defmt"] }
-embassy-time = { version = "0.4.0", path = "../../embassy-time", features = ["defmt", "defmt-timestamp-uptime", "tick-hz-32_768"] }
+embassy-time = { version = "0.4.0", path = "../../embassy-time", features = ["defmt", "defmt-timestamp-uptime", "tick-hz-32_768", "embedded-hal-02"] }
 embassy-net = { version = "0.7.0", path = "../../embassy-net", features = ["defmt", "tcp", "dhcpv4", "medium-ethernet", "proto-ipv6", "dns"] }
 embassy-usb = { version = "0.4.0", path = "../../embassy-usb", features = ["defmt"] }
 embassy-futures = { version = "0.1.0", path = "../../embassy-futures" }

--- a/examples/stm32l4/Cargo.toml
+++ b/examples/stm32l4/Cargo.toml
@@ -6,7 +6,7 @@ license = "MIT OR Apache-2.0"
 
 [dependencies]
 # Change stm32l4s5vi to your chip name, if necessary.
-embassy-stm32 = { version = "0.2.0", path = "../../embassy-stm32", features = [ "defmt", "unstable-pac", "stm32l4r5zi", "memory-x", "time-driver-any", "exti", "chrono", "dual-bank"]  }
+embassy-stm32 = { version = "0.2.0", path = "../../embassy-stm32", features = [ "defmt", "unstable-pac", "stm32l4r5zi", "memory-x", "time-driver-any", "exti", "chrono", "dual-bank", "embedded-hal-02"]  }
 embassy-sync = { version = "0.6.2", path = "../../embassy-sync", features = ["defmt"] }
 embassy-executor = { version = "0.7.0", path = "../../embassy-executor", features = ["arch-cortex-m", "executor-thread", "defmt"] }
 embassy-time = { version = "0.4.0", path = "../../embassy-time", features = ["defmt", "defmt-timestamp-uptime", "tick-hz-32_768", ] }

--- a/examples/stm32l4/Cargo.toml
+++ b/examples/stm32l4/Cargo.toml
@@ -10,7 +10,7 @@ embassy-stm32 = { version = "0.2.0", path = "../../embassy-stm32", features = [ 
 embassy-sync = { version = "0.6.2", path = "../../embassy-sync", features = ["defmt"] }
 embassy-executor = { version = "0.7.0", path = "../../embassy-executor", features = ["arch-cortex-m", "executor-thread", "defmt"] }
 embassy-time = { version = "0.4.0", path = "../../embassy-time", features = ["defmt", "defmt-timestamp-uptime", "tick-hz-32_768", ] }
-embassy-embedded-hal = { version = "0.3.0", path = "../../embassy-embedded-hal" }
+embassy-embedded-hal = { version = "0.3.0", path = "../../embassy-embedded-hal", features = ["embedded-hal-02"] }
 embassy-usb = { version = "0.4.0", path = "../../embassy-usb", features = ["defmt"] }
 embassy-net-adin1110 = { version = "0.3.0", path = "../../embassy-net-adin1110" }
 embassy-net = { version = "0.7.0", path = "../../embassy-net", features = ["defmt",  "udp", "tcp", "dhcpv4", "medium-ethernet"] }


### PR DESCRIPTION
Motivation:
    Make it easy to ensure that one does not use embedded-hal 0.2 API by mistake.
    Show intent to deprecate embedded-hal 0.2 compatibility eventually.

I've cargo check-ed all modified crates and examples. All of those that pass on master also pass with this change.
Do tell me what else needs to be done. Entries in changelogs?

I've also fixed some warnings that I've stumbled upon.