### PR TITLE
Prepare embassy-sync 0.7

### DIFF
--- a/cyw43/Cargo.toml
+++ b/cyw43/Cargo.toml
@@ -19,7 +19,7 @@ firmware-logs = []
 
 [dependencies]
 embassy-time = { version = "0.4.0", path = "../embassy-time"}
-embassy-sync = { version = "0.6.2", path = "../embassy-sync"}
+embassy-sync = { version = "0.7.0", path = "../embassy-sync"}
 embassy-futures = { version = "0.1.0", path = "../embassy-futures"}
 embassy-net-driver-channel = { version = "0.3.0", path = "../embassy-net-driver-channel"}
 

--- a/embassy-boot-nrf/Cargo.toml
+++ b/embassy-boot-nrf/Cargo.toml
@@ -24,7 +24,7 @@ target = "thumbv7em-none-eabi"
 defmt = { version = "1.0.1", optional = true }
 log = { version = "0.4.17", optional = true }
 
-embassy-sync = { version = "0.6.2", path = "../embassy-sync" }
+embassy-sync = { version = "0.7.0", path = "../embassy-sync" }
 embassy-nrf = { version = "0.3.1", path = "../embassy-nrf", default-features = false }
 embassy-boot = { version = "0.4.0", path = "../embassy-boot" }
 cortex-m = { version = "0.7.6" }

--- a/embassy-boot-rp/Cargo.toml
+++ b/embassy-boot-rp/Cargo.toml
@@ -24,7 +24,7 @@ features = ["embassy-rp/rp2040"]
 defmt = { version = "1.0.1", optional = true }
 log = { version = "0.4", optional = true }
 
-embassy-sync = { version = "0.6.2", path = "../embassy-sync" }
+embassy-sync = { version = "0.7.0", path = "../embassy-sync" }
 embassy-rp = { version = "0.4.0", path = "../embassy-rp", default-features = false }
 embassy-boot = { version = "0.4.0", path = "../embassy-boot" }
 embassy-time = { version = "0.4.0", path = "../embassy-time" }

--- a/embassy-boot-stm32/Cargo.toml
+++ b/embassy-boot-stm32/Cargo.toml
@@ -24,7 +24,7 @@ target = "thumbv7em-none-eabi"
 defmt = { version = "1.0.1", optional = true }
 log = { version = "0.4", optional = true }
 
-embassy-sync = { version = "0.6.2", path = "../embassy-sync" }
+embassy-sync = { version = "0.7.0", path = "../embassy-sync" }
 embassy-stm32 = { version = "0.2.0", path = "../embassy-stm32", default-features = false }
 embassy-boot = { version = "0.4.0", path = "../embassy-boot" }
 cortex-m = { version = "0.7.6" }

--- a/embassy-boot/Cargo.toml
+++ b/embassy-boot/Cargo.toml
@@ -29,7 +29,7 @@ digest = "0.10"
 log = { version = "0.4", optional = true }
 ed25519-dalek = { version = "2", default-features = false, features = ["digest"], optional = true }
 embassy-embedded-hal = { version = "0.3.0", path = "../embassy-embedded-hal" }
-embassy-sync = { version = "0.6.2", path = "../embassy-sync" }
+embassy-sync = { version = "0.7.0", path = "../embassy-sync" }
 embedded-storage = "0.3.1"
 embedded-storage-async = { version = "0.4.1" }
 salty = { version = "0.3", optional = true }

--- a/embassy-embedded-hal/Cargo.toml
+++ b/embassy-embedded-hal/Cargo.toml
@@ -24,7 +24,7 @@ default = ["time"]
 [dependencies]
 embassy-hal-internal = { version = "0.2.0", path = "../embassy-hal-internal" }
 embassy-futures = { version = "0.1.0", path = "../embassy-futures" }
-embassy-sync = { version = "0.6.2", path = "../embassy-sync" }
+embassy-sync = { version = "0.7.0", path = "../embassy-sync" }
 embassy-time = { version = "0.4.0", path = "../embassy-time", optional = true }
 embedded-hal-02 = { package = "embedded-hal", version = "0.2.6", features = [
     "unproven",

--- a/embassy-imxrt/Cargo.toml
+++ b/embassy-imxrt/Cargo.toml
@@ -63,7 +63,7 @@ mimxrt685s = ["mimxrt685s-pac", "_mimxrt685s"]
 mimxrt633s = ["mimxrt633s-pac", "_mimxrt633s"]
 
 [dependencies]
-embassy-sync = { version = "0.6.2", path = "../embassy-sync" }
+embassy-sync = { version = "0.7.0", path = "../embassy-sync" }
 embassy-time-driver = { version = "0.2", path = "../embassy-time-driver", optional = true }
 embassy-time-queue-utils = { version = "0.1", path = "../embassy-time-queue-utils", optional = true }
 embassy-time = { version = "0.4", path = "../embassy-time", optional = true }

--- a/embassy-mspm0/Cargo.toml
+++ b/embassy-mspm0/Cargo.toml
@@ -25,7 +25,7 @@ features = ["defmt", "unstable-pac", "time-driver-any", "time", "mspm0g3507"]
 rustdoc-args = ["--cfg", "docsrs"]
 
 [dependencies]
-embassy-sync = { version = "0.6.2", path = "../embassy-sync" }
+embassy-sync = { version = "0.7.0", path = "../embassy-sync" }
 embassy-time = { version = "0.4.0", path = "../embassy-time", optional = true }
 # TODO: Support other tick rates
 embassy-time-driver = { version = "0.2", path = "../embassy-time-driver", optional = true, features = ["tick-hz-32_768"] }

--- a/embassy-net-driver-channel/Cargo.toml
+++ b/embassy-net-driver-channel/Cargo.toml
@@ -25,6 +25,6 @@ features = ["defmt"]
 defmt = { version = "1.0.1", optional = true }
 log = { version = "0.4.14", optional = true }
 
-embassy-sync = { version = "0.6.2", path = "../embassy-sync" }
+embassy-sync = { version = "0.7.0", path = "../embassy-sync" }
 embassy-futures = { version = "0.1.0", path = "../embassy-futures" }
 embassy-net-driver = { version = "0.2.0", path = "../embassy-net-driver" }

--- a/embassy-net-esp-hosted/Cargo.toml
+++ b/embassy-net-esp-hosted/Cargo.toml
@@ -18,7 +18,7 @@ defmt = { version = "1.0.1", optional = true }
 log = { version = "0.4.14", optional = true }
 
 embassy-time = { version = "0.4.0", path = "../embassy-time" }
-embassy-sync = { version = "0.6.2", path = "../embassy-sync"}
+embassy-sync = { version = "0.7.0", path = "../embassy-sync"}
 embassy-futures = { version = "0.1.0", path = "../embassy-futures"}
 embassy-net-driver-channel = { version = "0.3.0", path = "../embassy-net-driver-channel"}
 

--- a/embassy-net-nrf91/Cargo.toml
+++ b/embassy-net-nrf91/Cargo.toml
@@ -21,7 +21,7 @@ nrf-pac = "0.1.0"
 cortex-m = "0.7.7"
 
 embassy-time = { version = "0.4.0", path = "../embassy-time" }
-embassy-sync = { version = "0.6.2", path = "../embassy-sync" }
+embassy-sync = { version = "0.7.0", path = "../embassy-sync" }
 embassy-futures = { version = "0.1.0", path = "../embassy-futures" }
 embassy-net-driver-channel = { version = "0.3.0", path = "../embassy-net-driver-channel" }
 

--- a/embassy-net-ppp/Cargo.toml
+++ b/embassy-net-ppp/Cargo.toml
@@ -21,7 +21,7 @@ embedded-io-async = { version = "0.6.1" }
 embassy-net-driver-channel = { version = "0.3.0", path = "../embassy-net-driver-channel" }
 embassy-futures = { version = "0.1.0", path = "../embassy-futures" }
 ppproto = { version = "0.2.1"}
-embassy-sync = { version = "0.6.2", path = "../embassy-sync" }
+embassy-sync = { version = "0.7.0", path = "../embassy-sync" }
 
 [package.metadata.embassy_docs]
 src_base = "https://github.com/embassy-rs/embassy/blob/embassy-net-ppp-v$VERSION/embassy-net-ppp/src/"

--- a/embassy-net/Cargo.toml
+++ b/embassy-net/Cargo.toml
@@ -78,7 +78,7 @@ smoltcp = { version = "0.12.0", default-features = false, features = [
 
 embassy-net-driver = { version = "0.2.0", path = "../embassy-net-driver" }
 embassy-time = { version = "0.4.0", path = "../embassy-time" }
-embassy-sync = { version = "0.6.2", path = "../embassy-sync" }
+embassy-sync = { version = "0.7.0", path = "../embassy-sync" }
 embedded-io-async = { version = "0.6.1" }
 
 managed = { version = "0.8.0", default-features = false, features = [ "map" ] }

--- a/embassy-nrf/Cargo.toml
+++ b/embassy-nrf/Cargo.toml
@@ -143,7 +143,7 @@ _multi_wdt = []
 embassy-time-driver = { version = "0.2", path = "../embassy-time-driver", optional = true }
 embassy-time-queue-utils = { version = "0.1", path = "../embassy-time-queue-utils", optional = true }
 embassy-time = { version = "0.4.0", path = "../embassy-time", optional = true }
-embassy-sync = { version = "0.6.2", path = "../embassy-sync" }
+embassy-sync = { version = "0.7.0", path = "../embassy-sync" }
 embassy-hal-internal = { version = "0.2.0", path = "../embassy-hal-internal", features = ["cortex-m", "prio-bits-3"] }
 embassy-embedded-hal = { version = "0.3.0", path = "../embassy-embedded-hal", default-features = false }
 embassy-usb-driver = { version = "0.1.0", path = "../embassy-usb-driver" }

--- a/embassy-nxp/Cargo.toml
+++ b/embassy-nxp/Cargo.toml
@@ -8,7 +8,7 @@ cortex-m = "0.7.7"
 cortex-m-rt = "0.7.0"
 critical-section = "1.1.2"
 embassy-hal-internal = { version = "0.2.0", path = "../embassy-hal-internal", features = ["cortex-m", "prio-bits-2"] }
-embassy-sync = { version = "0.6.2", path = "../embassy-sync" }
+embassy-sync = { version = "0.7.0", path = "../embassy-sync" }
 lpc55-pac = "0.5.0"
 defmt = { version = "1", optional = true }
 

--- a/embassy-rp/Cargo.toml
+++ b/embassy-rp/Cargo.toml
@@ -136,7 +136,7 @@ _test = []
 binary-info = ["rt", "dep:rp-binary-info", "rp-binary-info?/binary-info"]
 
 [dependencies]
-embassy-sync = { version = "0.6.2", path = "../embassy-sync" }
+embassy-sync = { version = "0.7.0", path = "../embassy-sync" }
 embassy-time-driver = { version = "0.2", path = "../embassy-time-driver", optional = true }
 embassy-time-queue-utils = { version = "0.1", path = "../embassy-time-queue-utils", optional = true }
 embassy-time = { version = "0.4.0", path = "../embassy-time" }

--- a/embassy-stm32-wpan/Cargo.toml
+++ b/embassy-stm32-wpan/Cargo.toml
@@ -20,7 +20,7 @@ features = ["stm32wb55rg", "ble", "mac"]
 
 [dependencies]
 embassy-stm32 = { version = "0.2.0", path = "../embassy-stm32" }
-embassy-sync = { version = "0.6.2", path = "../embassy-sync" }
+embassy-sync = { version = "0.7.0", path = "../embassy-sync" }
 embassy-time = { version = "0.4.0", path = "../embassy-time", optional = true }
 embassy-futures = { version = "0.1.0", path = "../embassy-futures" }
 embassy-hal-internal = { version = "0.2.0", path = "../embassy-hal-internal" }

--- a/embassy-stm32/Cargo.toml
+++ b/embassy-stm32/Cargo.toml
@@ -48,7 +48,7 @@ features = ["defmt", "unstable-pac", "exti", "time-driver-any", "time", "stm32h7
 rustdoc-args = ["--cfg", "docsrs"]
 
 [dependencies]
-embassy-sync = { version = "0.6.2", path = "../embassy-sync" }
+embassy-sync = { version = "0.7.0", path = "../embassy-sync" }
 embassy-time = { version = "0.4.0", path = "../embassy-time", optional = true }
 embassy-time-driver = { version = "0.2", path = "../embassy-time-driver", optional = true }
 embassy-time-queue-utils = { version = "0.1", path = "../embassy-time-queue-utils", optional = true }

--- a/embassy-sync/CHANGELOG.md
+++ b/embassy-sync/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+## 0.7.0 - 2025-05-22
+
 - Add `remove_if` to `priority_channel::{Receiver, PriorityChannel}`.
 - impl `Stream` for `channel::{Receiver, Channel}`.
 - Fix channels to wake senders on `clear()`.

--- a/embassy-sync/CHANGELOG.md
+++ b/embassy-sync/CHANGELOG.md
@@ -7,6 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+- Add `remove_if` to `priority_channel::{Receiver, PriorityChannel}`.
+- impl `Stream` for `channel::{Receiver, Channel}`.
+- Fix channels to wake senders on `clear()`.
+  For `Channel`, `PriorityChannel`, `PubSub`, `zerocopy_channel::Channel`.
+- Allow `zerocopy_channel::Channel` to auto-implement `Sync`/`Send`.
+- Add `must_use` to `MutexGuard`.
+- Add a `RwLock`.
+- Add `lock_mut` to `blocking_mutex::Mutex`.
+- Don't select a critical-section implementation when `std` feature is enabled.
+- Improve waker documentation.
+- Improve `Signal` and `Watch` documentation.
+- Update to defmt 1.0. This remains compatible with latest defmt 0.3.
+
 ## 0.6.2 - 2025-01-15
 
 - Add dynamic dispatch variant of `Pipe`.

--- a/embassy-sync/Cargo.toml
+++ b/embassy-sync/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "embassy-sync"
-version = "0.6.2"
+version = "0.7.0"
 edition = "2021"
 description = "no-std, no-alloc synchronization primitives with async support"
 repository = "https://github.com/embassy-rs/embassy"

--- a/embassy-usb-dfu/Cargo.toml
+++ b/embassy-usb-dfu/Cargo.toml
@@ -33,7 +33,7 @@ bitflags = "2.4.1"
 cortex-m = { version = "0.7.7", features = ["inline-asm"], optional = true }
 embassy-boot = { version = "0.4.0", path = "../embassy-boot" }
 embassy-futures = { version = "0.1.1", path = "../embassy-futures" }
-embassy-sync = { version = "0.6.2", path = "../embassy-sync" }
+embassy-sync = { version = "0.7.0", path = "../embassy-sync" }
 embassy-time = { version = "0.4.0", path = "../embassy-time" }
 embassy-usb = { version = "0.4.0", path = "../embassy-usb", default-features = false }
 embedded-storage = { version = "0.3.1" }

--- a/embassy-usb-logger/Cargo.toml
+++ b/embassy-usb-logger/Cargo.toml
@@ -16,6 +16,6 @@ target = "thumbv7em-none-eabi"
 
 [dependencies]
 embassy-usb = { version = "0.4.0", path = "../embassy-usb" }
-embassy-sync = { version = "0.6.2", path = "../embassy-sync" }
+embassy-sync = { version = "0.7.0", path = "../embassy-sync" }
 embassy-futures = { version = "0.1.0", path = "../embassy-futures" }
 log = "0.4"

--- a/embassy-usb-synopsys-otg/Cargo.toml
+++ b/embassy-usb-synopsys-otg/Cargo.toml
@@ -18,7 +18,7 @@ target = "thumbv7em-none-eabi"
 [dependencies]
 critical-section = "1.1"
 
-embassy-sync = { version = "0.6.2", path = "../embassy-sync" }
+embassy-sync = { version = "0.7.0", path = "../embassy-sync" }
 embassy-usb-driver = { version = "0.1.0", path = "../embassy-usb-driver" }
 
 defmt = { version = "1.0.1", optional = true }

--- a/embassy-usb/Cargo.toml
+++ b/embassy-usb/Cargo.toml
@@ -48,7 +48,7 @@ max-handler-count-8 = []
 [dependencies]
 embassy-futures = { version = "0.1.0", path = "../embassy-futures" }
 embassy-usb-driver = { version = "0.1.0", path = "../embassy-usb-driver" }
-embassy-sync = { version = "0.6.2", path = "../embassy-sync" }
+embassy-sync = { version = "0.7.0", path = "../embassy-sync" }
 embassy-net-driver-channel = { version = "0.3.0", path = "../embassy-net-driver-channel" }
 
 defmt = { version = "1", optional = true }

--- a/examples/boot/application/nrf/Cargo.toml
+++ b/examples/boot/application/nrf/Cargo.toml
@@ -5,7 +5,7 @@ version = "0.1.0"
 license = "MIT OR Apache-2.0"
 
 [dependencies]
-embassy-sync = { version = "0.6.2", path = "../../../../embassy-sync" }
+embassy-sync = { version = "0.7.0", path = "../../../../embassy-sync" }
 embassy-executor = { version = "0.7.0", path = "../../../../embassy-executor", features = ["arch-cortex-m", "executor-thread", "arch-cortex-m", "executor-thread"] }
 embassy-time = { version = "0.4.0", path = "../../../../embassy-time", features = [] }
 embassy-nrf = { version = "0.3.1", path = "../../../../embassy-nrf", features = ["time-driver-rtc1", "gpiote", ] }

--- a/examples/boot/application/rp/Cargo.toml
+++ b/examples/boot/application/rp/Cargo.toml
@@ -5,7 +5,7 @@ version = "0.1.0"
 license = "MIT OR Apache-2.0"
 
 [dependencies]
-embassy-sync = { version = "0.6.2", path = "../../../../embassy-sync" }
+embassy-sync = { version = "0.7.0", path = "../../../../embassy-sync" }
 embassy-executor = { version = "0.7.0", path = "../../../../embassy-executor", features = ["arch-cortex-m", "executor-thread"] }
 embassy-time = { version = "0.4.0", path = "../../../../embassy-time", features = [] }
 embassy-rp = { version = "0.4.0", path = "../../../../embassy-rp", features = ["time-driver", "rp2040"] }

--- a/examples/boot/application/stm32f3/Cargo.toml
+++ b/examples/boot/application/stm32f3/Cargo.toml
@@ -5,7 +5,7 @@ version = "0.1.0"
 license = "MIT OR Apache-2.0"
 
 [dependencies]
-embassy-sync = { version = "0.6.2", path = "../../../../embassy-sync" }
+embassy-sync = { version = "0.7.0", path = "../../../../embassy-sync" }
 embassy-executor = { version = "0.7.0", path = "../../../../embassy-executor", features = ["arch-cortex-m", "executor-thread"] }
 embassy-time = { version = "0.4.0", path = "../../../../embassy-time", features = [ "tick-hz-32_768"] }
 embassy-stm32 = { version = "0.2.0", path = "../../../../embassy-stm32", features = ["stm32f303re", "time-driver-any", "exti"]  }

--- a/examples/boot/application/stm32f7/Cargo.toml
+++ b/examples/boot/application/stm32f7/Cargo.toml
@@ -5,7 +5,7 @@ version = "0.1.0"
 license = "MIT OR Apache-2.0"
 
 [dependencies]
-embassy-sync = { version = "0.6.2", path = "../../../../embassy-sync" }
+embassy-sync = { version = "0.7.0", path = "../../../../embassy-sync" }
 embassy-executor = { version = "0.7.0", path = "../../../../embassy-executor", features = ["arch-cortex-m", "executor-thread"] }
 embassy-time = { version = "0.4.0", path = "../../../../embassy-time", features = [ "tick-hz-32_768"] }
 embassy-stm32 = { version = "0.2.0", path = "../../../../embassy-stm32", features = ["stm32f767zi", "time-driver-any", "exti", "single-bank"]  }

--- a/examples/boot/application/stm32h7/Cargo.toml
+++ b/examples/boot/application/stm32h7/Cargo.toml
@@ -5,7 +5,7 @@ version = "0.1.0"
 license = "MIT OR Apache-2.0"
 
 [dependencies]
-embassy-sync = { version = "0.6.2", path = "../../../../embassy-sync" }
+embassy-sync = { version = "0.7.0", path = "../../../../embassy-sync" }
 embassy-executor = { version = "0.7.0", path = "../../../../embassy-executor", features = ["arch-cortex-m", "executor-thread"] }
 embassy-time = { version = "0.4.0", path = "../../../../embassy-time", features = [ "tick-hz-32_768"] }
 embassy-stm32 = { version = "0.2.0", path = "../../../../embassy-stm32", features = ["stm32h743zi", "time-driver-any", "exti"]  }

--- a/examples/boot/application/stm32l0/Cargo.toml
+++ b/examples/boot/application/stm32l0/Cargo.toml
@@ -5,7 +5,7 @@ version = "0.1.0"
 license = "MIT OR Apache-2.0"
 
 [dependencies]
-embassy-sync = { version = "0.6.2", path = "../../../../embassy-sync" }
+embassy-sync = { version = "0.7.0", path = "../../../../embassy-sync" }
 embassy-executor = { version = "0.7.0", path = "../../../../embassy-executor", features = ["arch-cortex-m", "executor-thread"] }
 embassy-time = { version = "0.4.0", path = "../../../../embassy-time", features = [ "tick-hz-32_768"] }
 embassy-stm32 = { version = "0.2.0", path = "../../../../embassy-stm32", features = ["stm32l072cz", "time-driver-any", "exti", "memory-x"]  }

--- a/examples/boot/application/stm32l1/Cargo.toml
+++ b/examples/boot/application/stm32l1/Cargo.toml
@@ -5,7 +5,7 @@ version = "0.1.0"
 license = "MIT OR Apache-2.0"
 
 [dependencies]
-embassy-sync = { version = "0.6.2", path = "../../../../embassy-sync" }
+embassy-sync = { version = "0.7.0", path = "../../../../embassy-sync" }
 embassy-executor = { version = "0.7.0", path = "../../../../embassy-executor", features = ["arch-cortex-m", "executor-thread"] }
 embassy-time = { version = "0.4.0", path = "../../../../embassy-time", features = [ "tick-hz-32_768"] }
 embassy-stm32 = { version = "0.2.0", path = "../../../../embassy-stm32", features = ["stm32l151cb-a", "time-driver-any", "exti"]  }

--- a/examples/boot/application/stm32l4/Cargo.toml
+++ b/examples/boot/application/stm32l4/Cargo.toml
@@ -5,7 +5,7 @@ version = "0.1.0"
 license = "MIT OR Apache-2.0"
 
 [dependencies]
-embassy-sync = { version = "0.6.2", path = "../../../../embassy-sync" }
+embassy-sync = { version = "0.7.0", path = "../../../../embassy-sync" }
 embassy-executor = { version = "0.7.0", path = "../../../../embassy-executor", features = ["arch-cortex-m", "executor-thread"] }
 embassy-time = { version = "0.4.0", path = "../../../../embassy-time", features = [ "tick-hz-32_768"] }
 embassy-stm32 = { version = "0.2.0", path = "../../../../embassy-stm32", features = ["stm32l475vg", "time-driver-any", "exti"]  }

--- a/examples/boot/application/stm32wb-dfu/Cargo.toml
+++ b/examples/boot/application/stm32wb-dfu/Cargo.toml
@@ -5,7 +5,7 @@ version = "0.1.0"
 license = "MIT OR Apache-2.0"
 
 [dependencies]
-embassy-sync = { version = "0.6.2", path = "../../../../embassy-sync" }
+embassy-sync = { version = "0.7.0", path = "../../../../embassy-sync" }
 embassy-executor = { version = "0.7.0", path = "../../../../embassy-executor", features = ["arch-cortex-m", "executor-thread"] }
 embassy-time = { version = "0.4.0", path = "../../../../embassy-time", features = [ "tick-hz-32_768"] }
 embassy-stm32 = { version = "0.2.0", path = "../../../../embassy-stm32", features = ["stm32wb55rg", "time-driver-any", "exti"]  }

--- a/examples/boot/application/stm32wl/Cargo.toml
+++ b/examples/boot/application/stm32wl/Cargo.toml
@@ -5,7 +5,7 @@ version = "0.1.0"
 license = "MIT OR Apache-2.0"
 
 [dependencies]
-embassy-sync = { version = "0.6.2", path = "../../../../embassy-sync" }
+embassy-sync = { version = "0.7.0", path = "../../../../embassy-sync" }
 embassy-executor = { version = "0.7.0", path = "../../../../embassy-executor", features = ["arch-cortex-m", "executor-thread"] }
 embassy-time = { version = "0.4.0", path = "../../../../embassy-time", features = [ "tick-hz-32_768"] }
 embassy-stm32 = { version = "0.2.0", path = "../../../../embassy-stm32", features = ["stm32wl55jc-cm4", "time-driver-any", "exti"]  }

--- a/examples/boot/bootloader/nrf/Cargo.toml
+++ b/examples/boot/bootloader/nrf/Cargo.toml
@@ -12,7 +12,7 @@ defmt-rtt = { version = "1.0.0", optional = true }
 embassy-nrf = { path = "../../../../embassy-nrf", features = [] }
 embassy-boot-nrf = { path = "../../../../embassy-boot-nrf" }
 cortex-m = { version = "0.7.6", features = ["inline-asm", "critical-section-single-core"] }
-embassy-sync = { version = "0.6.2", path = "../../../../embassy-sync" }
+embassy-sync = { version = "0.7.0", path = "../../../../embassy-sync" }
 cortex-m-rt = { version = "0.7" }
 cfg-if = "1.0.0"
 

--- a/examples/boot/bootloader/rp/Cargo.toml
+++ b/examples/boot/bootloader/rp/Cargo.toml
@@ -11,7 +11,7 @@ defmt-rtt = { version = "1.0.0", optional = true }
 
 embassy-rp = { path = "../../../../embassy-rp", features = ["rp2040"] }
 embassy-boot-rp = { path = "../../../../embassy-boot-rp" }
-embassy-sync = { version = "0.6.2", path = "../../../../embassy-sync" }
+embassy-sync = { version = "0.7.0", path = "../../../../embassy-sync" }
 embassy-time = { path = "../../../../embassy-time", features = [] }
 
 cortex-m = { version = "0.7.6", features = ["inline-asm", "critical-section-single-core"] }

--- a/examples/boot/bootloader/stm32-dual-bank/Cargo.toml
+++ b/examples/boot/bootloader/stm32-dual-bank/Cargo.toml
@@ -15,7 +15,7 @@ cortex-m = { version = "0.7.6", features = [
   "inline-asm",
   "critical-section-single-core",
 ] }
-embassy-sync = { version = "0.6.2", path = "../../../../embassy-sync" }
+embassy-sync = { version = "0.7.0", path = "../../../../embassy-sync" }
 cortex-m-rt = { version = "0.7" }
 embedded-storage = "0.3.1"
 embedded-storage-async = "0.4.0"

--- a/examples/boot/bootloader/stm32/Cargo.toml
+++ b/examples/boot/bootloader/stm32/Cargo.toml
@@ -12,7 +12,7 @@ defmt-rtt = { version = "1.0.0", optional = true }
 embassy-stm32 = { path = "../../../../embassy-stm32", features = [] }
 embassy-boot-stm32 = { path = "../../../../embassy-boot-stm32" }
 cortex-m = { version = "0.7.6", features = ["inline-asm", "critical-section-single-core"] }
-embassy-sync = { version = "0.6.2", path = "../../../../embassy-sync" }
+embassy-sync = { version = "0.7.0", path = "../../../../embassy-sync" }
 cortex-m-rt = { version = "0.7" }
 embedded-storage = "0.3.1"
 embedded-storage-async = "0.4.0"

--- a/examples/boot/bootloader/stm32wb-dfu/Cargo.toml
+++ b/examples/boot/bootloader/stm32wb-dfu/Cargo.toml
@@ -12,7 +12,7 @@ defmt-rtt = { version = "1.0.0", optional = true }
 embassy-stm32 = { path = "../../../../embassy-stm32", features = [] }
 embassy-boot-stm32 = { path = "../../../../embassy-boot-stm32" }
 cortex-m = { version = "0.7.6", features = ["inline-asm", "critical-section-single-core"] }
-embassy-sync = { version = "0.6.2", path = "../../../../embassy-sync" }
+embassy-sync = { version = "0.7.0", path = "../../../../embassy-sync" }
 cortex-m-rt = { version = "0.7" }
 embedded-storage = "0.3.1"
 embedded-storage-async = "0.4.0"

--- a/examples/lpc55s69/Cargo.toml
+++ b/examples/lpc55s69/Cargo.toml
@@ -8,7 +8,7 @@ license = "MIT OR Apache-2.0"
 [dependencies]
 embassy-nxp = { version = "0.1.0", path = "../../embassy-nxp", features = ["rt"] }
 embassy-executor = { version = "0.7.0", path = "../../embassy-executor", features = ["arch-cortex-m", "executor-thread", "executor-interrupt"] }
-embassy-sync = { version = "0.6.2", path = "../../embassy-sync", features = ["defmt"] }
+embassy-sync = { version = "0.7.0", path = "../../embassy-sync", features = ["defmt"] }
 embassy-time = { version = "0.4.0", path = "../../embassy-time", features = ["defmt"] }
 panic-halt = "1.0.0"
 cortex-m = { version = "0.7.6", features = ["inline-asm", "critical-section-single-core"] }

--- a/examples/mimxrt6/Cargo.toml
+++ b/examples/mimxrt6/Cargo.toml
@@ -14,7 +14,7 @@ embassy-executor = { version = "0.7.0", path = "../../embassy-executor", feature
 embassy-futures = { version = "0.1.1", path = "../../embassy-futures" }
 embassy-imxrt = { version = "0.1.0", path = "../../embassy-imxrt", features = ["defmt", "mimxrt685s", "unstable-pac", "time", "time-driver-os-timer"] }
 embassy-time = { version = "0.4", path = "../../embassy-time", features = ["defmt", "defmt-timestamp-uptime"] }
-embassy-sync = { version = "0.6.2", path = "../../embassy-sync", features = ["defmt"] }
+embassy-sync = { version = "0.7.0", path = "../../embassy-sync", features = ["defmt"] }
 embedded-hal-1 = { package = "embedded-hal", version = "1.0" }
 embedded-hal-async = "1.0.0"
 

--- a/examples/mspm0c1104/Cargo.toml
+++ b/examples/mspm0c1104/Cargo.toml
@@ -7,7 +7,7 @@ license = "MIT OR Apache-2.0"
 [dependencies]
 embassy-mspm0 = { version = "0.1.0", path = "../../embassy-mspm0", features = ["mspm0c1104dgs20", "defmt", "rt", "time-driver-any"] }
 embassy-executor = { version = "0.7.0", path = "../../embassy-executor", features = ["arch-cortex-m", "executor-thread", "executor-interrupt"] }
-embassy-sync = { version = "0.6.2", path = "../../embassy-sync", features = ["defmt"] }
+embassy-sync = { version = "0.7.0", path = "../../embassy-sync", features = ["defmt"] }
 embassy-time = { version = "0.4.0", path = "../../embassy-time", features = ["defmt"] }
 panic-halt = "1.0.0"
 cortex-m = { version = "0.7.6", features = ["inline-asm", "critical-section-single-core"] }

--- a/examples/mspm0g3507/Cargo.toml
+++ b/examples/mspm0g3507/Cargo.toml
@@ -7,7 +7,7 @@ license = "MIT OR Apache-2.0"
 [dependencies]
 embassy-mspm0 = { version = "0.1.0", path = "../../embassy-mspm0", features = ["mspm0g3507pm", "defmt", "rt", "time-driver-any"] }
 embassy-executor = { version = "0.7.0", path = "../../embassy-executor", features = ["arch-cortex-m", "executor-thread", "executor-interrupt"] }
-embassy-sync = { version = "0.6.2", path = "../../embassy-sync", features = ["defmt"] }
+embassy-sync = { version = "0.7.0", path = "../../embassy-sync", features = ["defmt"] }
 embassy-time = { version = "0.4.0", path = "../../embassy-time", features = ["defmt"] }
 panic-halt = "1.0.0"
 cortex-m = { version = "0.7.6", features = ["inline-asm", "critical-section-single-core"] }

--- a/examples/mspm0g3519/Cargo.toml
+++ b/examples/mspm0g3519/Cargo.toml
@@ -7,7 +7,7 @@ license = "MIT OR Apache-2.0"
 [dependencies]
 embassy-mspm0 = { version = "0.1.0", path = "../../embassy-mspm0", features = ["mspm0g3519pz", "defmt", "rt", "time-driver-any"] }
 embassy-executor = { version = "0.7.0", path = "../../embassy-executor", features = ["arch-cortex-m", "executor-thread", "executor-interrupt"] }
-embassy-sync = { version = "0.6.2", path = "../../embassy-sync", features = ["defmt"] }
+embassy-sync = { version = "0.7.0", path = "../../embassy-sync", features = ["defmt"] }
 embassy-time = { version = "0.4.0", path = "../../embassy-time", features = ["defmt"] }
 panic-halt = "1.0.0"
 cortex-m = { version = "0.7.6", features = ["inline-asm", "critical-section-single-core"] }

--- a/examples/mspm0l1306/Cargo.toml
+++ b/examples/mspm0l1306/Cargo.toml
@@ -7,7 +7,7 @@ license = "MIT OR Apache-2.0"
 [dependencies]
 embassy-mspm0 = { version = "0.1.0", path = "../../embassy-mspm0", features = ["mspm0l1306rhb", "defmt", "rt", "time-driver-any"] }
 embassy-executor = { version = "0.7.0", path = "../../embassy-executor", features = ["arch-cortex-m", "executor-thread", "executor-interrupt"] }
-embassy-sync = { version = "0.6.2", path = "../../embassy-sync", features = ["defmt"] }
+embassy-sync = { version = "0.7.0", path = "../../embassy-sync", features = ["defmt"] }
 embassy-time = { version = "0.4.0", path = "../../embassy-time", features = ["defmt"] }
 panic-halt = "1.0.0"
 cortex-m = { version = "0.7.6", features = ["inline-asm", "critical-section-single-core"] }

--- a/examples/mspm0l2228/Cargo.toml
+++ b/examples/mspm0l2228/Cargo.toml
@@ -7,7 +7,7 @@ license = "MIT OR Apache-2.0"
 [dependencies]
 embassy-mspm0 = { version = "0.1.0", path = "../../embassy-mspm0", features = ["mspm0l2228pn", "defmt", "rt", "time-driver-any"] }
 embassy-executor = { version = "0.7.0", path = "../../embassy-executor", features = ["arch-cortex-m", "executor-thread", "executor-interrupt"] }
-embassy-sync = { version = "0.6.2", path = "../../embassy-sync", features = ["defmt"] }
+embassy-sync = { version = "0.7.0", path = "../../embassy-sync", features = ["defmt"] }
 embassy-time = { version = "0.4.0", path = "../../embassy-time", features = ["defmt"] }
 panic-halt = "1.0.0"
 cortex-m = { version = "0.7.6", features = ["inline-asm", "critical-section-single-core"] }

--- a/examples/nrf-rtos-trace/Cargo.toml
+++ b/examples/nrf-rtos-trace/Cargo.toml
@@ -15,7 +15,7 @@ log = [
 ]
 
 [dependencies]
-embassy-sync = { version = "0.6.2", path = "../../embassy-sync" }
+embassy-sync = { version = "0.7.0", path = "../../embassy-sync" }
 embassy-executor = { version = "0.7.0", path = "../../embassy-executor", features = ["arch-cortex-m", "executor-thread", "rtos-trace"] }
 embassy-time = { version = "0.4.0", path = "../../embassy-time" }
 embassy-nrf = { version = "0.3.1", path = "../../embassy-nrf", features = ["nrf52840", "time-driver-rtc1", "gpiote", "unstable-pac"] }

--- a/examples/nrf52810/Cargo.toml
+++ b/examples/nrf52810/Cargo.toml
@@ -6,7 +6,7 @@ license = "MIT OR Apache-2.0"
 
 [dependencies]
 embassy-futures = { version = "0.1.0", path = "../../embassy-futures" }
-embassy-sync = { version = "0.6.2", path = "../../embassy-sync", features = ["defmt"] }
+embassy-sync = { version = "0.7.0", path = "../../embassy-sync", features = ["defmt"] }
 embassy-executor = { version = "0.7.0", path = "../../embassy-executor", features = ["arch-cortex-m", "executor-thread", "executor-interrupt", "defmt"] }
 embassy-time = { version = "0.4.0", path = "../../embassy-time", features = ["defmt", "defmt-timestamp-uptime"] }
 embassy-nrf = { version = "0.3.1", path = "../../embassy-nrf", features = ["defmt", "nrf52810", "time-driver-rtc1", "gpiote", "unstable-pac", "time"] }

--- a/examples/nrf52840-rtic/Cargo.toml
+++ b/examples/nrf52840-rtic/Cargo.toml
@@ -8,7 +8,7 @@ license = "MIT OR Apache-2.0"
 rtic = { version = "2", features = ["thumbv7-backend"] }
 
 embassy-futures = { version = "0.1.0", path = "../../embassy-futures" }
-embassy-sync = { version = "0.6.2", path = "../../embassy-sync", features = ["defmt"] }
+embassy-sync = { version = "0.7.0", path = "../../embassy-sync", features = ["defmt"] }
 embassy-time = { version = "0.4.0", path = "../../embassy-time", features = [ "defmt", "defmt-timestamp-uptime"] }
 embassy-time-queue-utils = { version = "0.1", path = "../../embassy-time-queue-utils", features = ["generic-queue-8"] }
 embassy-nrf = { version = "0.3.1", path = "../../embassy-nrf", features = [ "defmt", "nrf52840", "time-driver-rtc1", "gpiote", "unstable-pac", "time"] }

--- a/examples/nrf52840/Cargo.toml
+++ b/examples/nrf52840/Cargo.toml
@@ -6,7 +6,7 @@ license = "MIT OR Apache-2.0"
 
 [dependencies]
 embassy-futures = { version = "0.1.0", path = "../../embassy-futures" }
-embassy-sync = { version = "0.6.2", path = "../../embassy-sync", features = ["defmt"] }
+embassy-sync = { version = "0.7.0", path = "../../embassy-sync", features = ["defmt"] }
 embassy-executor = { version = "0.7.0", path = "../../embassy-executor", features = ["arch-cortex-m", "executor-thread", "executor-interrupt", "defmt"] }
 embassy-time = { version = "0.4.0", path = "../../embassy-time", features = ["defmt", "defmt-timestamp-uptime"] }
 embassy-nrf = { version = "0.3.1", path = "../../embassy-nrf", features = ["defmt", "nrf52840", "time-driver-rtc1", "gpiote", "unstable-pac", "time"] }

--- a/examples/nrf5340/Cargo.toml
+++ b/examples/nrf5340/Cargo.toml
@@ -6,7 +6,7 @@ license = "MIT OR Apache-2.0"
 
 [dependencies]
 embassy-futures = { version = "0.1.0", path = "../../embassy-futures" }
-embassy-sync = { version = "0.6.2", path = "../../embassy-sync", features = ["defmt"] }
+embassy-sync = { version = "0.7.0", path = "../../embassy-sync", features = ["defmt"] }
 embassy-executor = { version = "0.7.0", path = "../../embassy-executor", features = ["arch-cortex-m", "executor-thread", "defmt"] }
 embassy-time = { version = "0.4.0", path = "../../embassy-time", features = ["defmt", "defmt-timestamp-uptime"] }
 embassy-nrf = { version = "0.3.1", path = "../../embassy-nrf", features = ["defmt", "nrf5340-app-s", "time-driver-rtc1", "gpiote", "unstable-pac"] }

--- a/examples/rp/Cargo.toml
+++ b/examples/rp/Cargo.toml
@@ -7,7 +7,7 @@ license = "MIT OR Apache-2.0"
 
 [dependencies]
 embassy-embedded-hal = { version = "0.3.0", path = "../../embassy-embedded-hal", features = ["defmt"] }
-embassy-sync = { version = "0.6.2", path = "../../embassy-sync", features = ["defmt"] }
+embassy-sync = { version = "0.7.0", path = "../../embassy-sync", features = ["defmt"] }
 embassy-executor = { version = "0.7.0", path = "../../embassy-executor", features = ["arch-cortex-m", "executor-thread", "executor-interrupt", "defmt"] }
 embassy-time = { version = "0.4.0", path = "../../embassy-time", features = ["defmt", "defmt-timestamp-uptime"] }
 embassy-rp = { version = "0.4.0", path = "../../embassy-rp", features = ["defmt", "unstable-pac", "time-driver", "critical-section-impl", "rp2040"] }

--- a/examples/rp235x/Cargo.toml
+++ b/examples/rp235x/Cargo.toml
@@ -7,7 +7,7 @@ license = "MIT OR Apache-2.0"
 
 [dependencies]
 embassy-embedded-hal = { version = "0.3.0", path = "../../embassy-embedded-hal", features = ["defmt"] }
-embassy-sync = { version = "0.6.2", path = "../../embassy-sync", features = ["defmt"] }
+embassy-sync = { version = "0.7.0", path = "../../embassy-sync", features = ["defmt"] }
 embassy-executor = { version = "0.7.0", path = "../../embassy-executor", features = ["arch-cortex-m", "executor-thread", "executor-interrupt", "defmt"] }
 embassy-time = { version = "0.4.0", path = "../../embassy-time", features = ["defmt", "defmt-timestamp-uptime"] }
 embassy-rp = { version = "0.4.0", path = "../../embassy-rp", features = ["defmt", "unstable-pac", "time-driver", "critical-section-impl", "rp235xa", "binary-info"] }

--- a/examples/std/Cargo.toml
+++ b/examples/std/Cargo.toml
@@ -5,7 +5,7 @@ version = "0.1.0"
 license = "MIT OR Apache-2.0"
 
 [dependencies]
-embassy-sync = { version = "0.6.2", path = "../../embassy-sync", features = ["log"] }
+embassy-sync = { version = "0.7.0", path = "../../embassy-sync", features = ["log"] }
 embassy-executor = { version = "0.7.0", path = "../../embassy-executor", features = ["arch-std", "executor-thread", "log"] }
 embassy-time = { version = "0.4.0", path = "../../embassy-time", features = ["log", "std", ] }
 embassy-net = { version = "0.7.0", path = "../../embassy-net", features=[ "log", "medium-ethernet", "medium-ip", "tcp", "udp", "dns", "dhcpv4", "proto-ipv6"] }

--- a/examples/stm32c0/Cargo.toml
+++ b/examples/stm32c0/Cargo.toml
@@ -7,7 +7,7 @@ license = "MIT OR Apache-2.0"
 [dependencies]
 # Change stm32c031c6 to your chip name, if necessary.
 embassy-stm32 = { version = "0.2.0", path = "../../embassy-stm32", features = [ "defmt", "time-driver-any", "stm32c031c6", "memory-x", "unstable-pac", "exti"]  }
-embassy-sync = { version = "0.6.2", path = "../../embassy-sync", features = ["defmt"] }
+embassy-sync = { version = "0.7.0", path = "../../embassy-sync", features = ["defmt"] }
 embassy-executor = { version = "0.7.0", path = "../../embassy-executor", features = ["arch-cortex-m", "executor-thread", "defmt"] }
 embassy-time = { version = "0.4.0", path = "../../embassy-time", features = ["defmt", "defmt-timestamp-uptime", "tick-hz-32_768"] }
 

--- a/examples/stm32f0/Cargo.toml
+++ b/examples/stm32f0/Cargo.toml
@@ -12,7 +12,7 @@ cortex-m-rt = "0.7.0"
 defmt = "1.0.1"
 defmt-rtt = "1.0.0"
 panic-probe = { version = "1.0.0", features = ["print-defmt"] }
-embassy-sync = { version = "0.6.2", path = "../../embassy-sync", features = ["defmt"] }
+embassy-sync = { version = "0.7.0", path = "../../embassy-sync", features = ["defmt"] }
 embassy-executor = { version = "0.7.0", path = "../../embassy-executor", features = ["arch-cortex-m", "executor-thread", "executor-interrupt", "defmt"] }
 embassy-time = { version = "0.4.0", path = "../../embassy-time", features = ["defmt", "defmt-timestamp-uptime", "tick-hz-32_768"] }
 static_cell = "2"

--- a/examples/stm32f1/Cargo.toml
+++ b/examples/stm32f1/Cargo.toml
@@ -7,7 +7,7 @@ license = "MIT OR Apache-2.0"
 [dependencies]
 # Change stm32f103c8 to your chip name, if necessary.
 embassy-stm32 = { version = "0.2.0", path = "../../embassy-stm32", features = [ "defmt", "stm32f103c8", "unstable-pac", "memory-x", "time-driver-any" ]  }
-embassy-sync = { version = "0.6.2", path = "../../embassy-sync", features = ["defmt"] }
+embassy-sync = { version = "0.7.0", path = "../../embassy-sync", features = ["defmt"] }
 embassy-executor = { version = "0.7.0", path = "../../embassy-executor", features = ["arch-cortex-m", "executor-thread", "defmt"] }
 embassy-time = { version = "0.4.0", path = "../../embassy-time", features = ["defmt", "defmt-timestamp-uptime", "tick-hz-32_768"] }
 embassy-usb = { version = "0.4.0", path = "../../embassy-usb", features = ["defmt"] }

--- a/examples/stm32f2/Cargo.toml
+++ b/examples/stm32f2/Cargo.toml
@@ -7,7 +7,7 @@ license = "MIT OR Apache-2.0"
 [dependencies]
 # Change stm32f207zg to your chip name, if necessary.
 embassy-stm32 = { version = "0.2.0", path = "../../embassy-stm32", features = [ "defmt", "stm32f207zg", "unstable-pac", "memory-x", "time-driver-any", "exti"]  }
-embassy-sync = { version = "0.6.2", path = "../../embassy-sync", features = ["defmt"] }
+embassy-sync = { version = "0.7.0", path = "../../embassy-sync", features = ["defmt"] }
 embassy-executor = { version = "0.7.0", path = "../../embassy-executor", features = ["arch-cortex-m", "executor-thread", "defmt"] }
 embassy-time = { version = "0.4.0", path = "../../embassy-time", features = ["defmt", "defmt-timestamp-uptime", "tick-hz-32_768"] }
 

--- a/examples/stm32f3/Cargo.toml
+++ b/examples/stm32f3/Cargo.toml
@@ -7,7 +7,7 @@ license = "MIT OR Apache-2.0"
 [dependencies]
 # Change stm32f303ze to your chip name, if necessary.
 embassy-stm32 = { version = "0.2.0", path = "../../embassy-stm32", features = [ "defmt", "stm32f303ze", "unstable-pac", "memory-x", "time-driver-tim2", "exti"]  }
-embassy-sync = { version = "0.6.2", path = "../../embassy-sync", features = ["defmt"] }
+embassy-sync = { version = "0.7.0", path = "../../embassy-sync", features = ["defmt"] }
 embassy-executor = { version = "0.7.0", path = "../../embassy-executor", features = ["arch-cortex-m", "executor-thread", "executor-interrupt", "defmt"] }
 embassy-time = { version = "0.4.0", path = "../../embassy-time", features = ["defmt", "defmt-timestamp-uptime", "tick-hz-32_768"] }
 embassy-usb = { version = "0.4.0", path = "../../embassy-usb", features = ["defmt"] }

--- a/examples/stm32f334/Cargo.toml
+++ b/examples/stm32f334/Cargo.toml
@@ -5,7 +5,7 @@ version = "0.1.0"
 license = "MIT OR Apache-2.0"
 
 [dependencies]
-embassy-sync = { version = "0.6.2", path = "../../embassy-sync", features = ["defmt"] }
+embassy-sync = { version = "0.7.0", path = "../../embassy-sync", features = ["defmt"] }
 embassy-executor = { version = "0.7.0", path = "../../embassy-executor", features = ["arch-cortex-m", "executor-thread", "executor-interrupt", "defmt"] }
 embassy-time = { version = "0.4.0", path = "../../embassy-time", features = ["defmt", "defmt-timestamp-uptime", "tick-hz-32_768"] }
 embassy-stm32 = { version = "0.2.0", path = "../../embassy-stm32", features = [ "defmt", "stm32f334r8", "unstable-pac", "memory-x", "time-driver-any", "exti"]  }

--- a/examples/stm32f4/Cargo.toml
+++ b/examples/stm32f4/Cargo.toml
@@ -7,7 +7,7 @@ license = "MIT OR Apache-2.0"
 [dependencies]
 # Change stm32f429zi to your chip name, if necessary.
 embassy-stm32 = { version = "0.2.0", path = "../../embassy-stm32", features = ["defmt", "stm32f429zi", "unstable-pac", "memory-x", "time-driver-tim4", "exti", "chrono"] }
-embassy-sync = { version = "0.6.2", path = "../../embassy-sync", features = ["defmt"] }
+embassy-sync = { version = "0.7.0", path = "../../embassy-sync", features = ["defmt"] }
 embassy-executor = { version = "0.7.0", path = "../../embassy-executor", features = ["arch-cortex-m", "executor-thread", "executor-interrupt", "defmt"] }
 embassy-time = { version = "0.4.0", path = "../../embassy-time", features = ["defmt", "defmt-timestamp-uptime", "tick-hz-32_768"] }
 embassy-usb = { version = "0.4.0", path = "../../embassy-usb", features = ["defmt" ] }

--- a/examples/stm32f7/Cargo.toml
+++ b/examples/stm32f7/Cargo.toml
@@ -7,7 +7,7 @@ license = "MIT OR Apache-2.0"
 [dependencies]
 # Change stm32f777zi to your chip name, if necessary.
 embassy-stm32 = { version = "0.2.0", path = "../../embassy-stm32", features = ["defmt", "stm32f777zi", "memory-x", "unstable-pac", "time-driver-any", "exti", "single-bank"]  }
-embassy-sync = { version = "0.6.2", path = "../../embassy-sync", features = ["defmt"] }
+embassy-sync = { version = "0.7.0", path = "../../embassy-sync", features = ["defmt"] }
 embassy-executor = { version = "0.7.0", path = "../../embassy-executor", features = ["arch-cortex-m", "executor-thread", "defmt"] }
 embassy-time = { version = "0.4.0", path = "../../embassy-time", features = ["defmt", "defmt-timestamp-uptime", "tick-hz-32_768"] }
 embassy-net = { version = "0.7.0", path = "../../embassy-net", features = ["defmt", "tcp", "dhcpv4", "medium-ethernet"] }

--- a/examples/stm32g0/Cargo.toml
+++ b/examples/stm32g0/Cargo.toml
@@ -7,7 +7,7 @@ license = "MIT OR Apache-2.0"
 [dependencies]
 # Change stm32g0b1re to your chip name, if necessary.
 embassy-stm32 = { version = "0.2.0", path = "../../embassy-stm32", features = [ "defmt", "time-driver-any", "stm32g0b1re", "memory-x", "unstable-pac", "exti"]  }
-embassy-sync = { version = "0.6.2", path = "../../embassy-sync", features = ["defmt"] }
+embassy-sync = { version = "0.7.0", path = "../../embassy-sync", features = ["defmt"] }
 embassy-executor = { version = "0.7.0", path = "../../embassy-executor", features = ["arch-cortex-m", "executor-thread", "defmt"] }
 embassy-time = { version = "0.4.0", path = "../../embassy-time", features = ["defmt", "defmt-timestamp-uptime", "tick-hz-32_768"] }
 embassy-usb = { version = "0.4.0", path = "../../embassy-usb", default-features = false, features = ["defmt"] }

--- a/examples/stm32g4/Cargo.toml
+++ b/examples/stm32g4/Cargo.toml
@@ -7,7 +7,7 @@ license = "MIT OR Apache-2.0"
 [dependencies]
 # Change stm32g491re to your chip name, if necessary.
 embassy-stm32 = { version = "0.2.0", path = "../../embassy-stm32", features = [ "defmt", "time-driver-any", "stm32g491re", "memory-x", "unstable-pac", "exti"]  }
-embassy-sync = { version = "0.6.2", path = "../../embassy-sync", features = ["defmt"] }
+embassy-sync = { version = "0.7.0", path = "../../embassy-sync", features = ["defmt"] }
 embassy-executor = { version = "0.7.0", path = "../../embassy-executor", features = ["arch-cortex-m", "executor-thread", "defmt"] }
 embassy-time = { version = "0.4.0", path = "../../embassy-time", features = ["defmt", "defmt-timestamp-uptime", "tick-hz-32_768"] }
 embassy-usb = { version = "0.4.0", path = "../../embassy-usb", features = ["defmt"] }

--- a/examples/stm32h5/Cargo.toml
+++ b/examples/stm32h5/Cargo.toml
@@ -7,7 +7,7 @@ license = "MIT OR Apache-2.0"
 [dependencies]
 # Change stm32h563zi to your chip name, if necessary.
 embassy-stm32 = { version = "0.2.0", path = "../../embassy-stm32", features = ["defmt", "stm32h563zi", "memory-x", "time-driver-any", "exti", "unstable-pac", "low-power"] }
-embassy-sync = { version = "0.6.2", path = "../../embassy-sync", features = ["defmt"] }
+embassy-sync = { version = "0.7.0", path = "../../embassy-sync", features = ["defmt"] }
 embassy-executor = { version = "0.7.0", path = "../../embassy-executor", features = ["arch-cortex-m", "executor-thread", "defmt"] }
 embassy-time = { version = "0.4.0", path = "../../embassy-time", features = ["defmt", "defmt-timestamp-uptime", "tick-hz-32_768"] }
 embassy-net = { version = "0.7.0", path = "../../embassy-net", features = ["defmt", "tcp", "dhcpv4", "medium-ethernet", "proto-ipv6"] }

--- a/examples/stm32h7/Cargo.toml
+++ b/examples/stm32h7/Cargo.toml
@@ -7,7 +7,7 @@ license = "MIT OR Apache-2.0"
 [dependencies]
 # Change stm32h743bi to your chip name, if necessary.
 embassy-stm32 = { version = "0.2.0", path = "../../embassy-stm32", features = ["defmt", "stm32h743bi", "time-driver-tim2", "exti", "memory-x", "unstable-pac", "chrono"] }
-embassy-sync = { version = "0.6.2", path = "../../embassy-sync", features = ["defmt"] }
+embassy-sync = { version = "0.7.0", path = "../../embassy-sync", features = ["defmt"] }
 embassy-embedded-hal = { version = "0.3.0", path = "../../embassy-embedded-hal" }
 embassy-executor = { version = "0.7.0", path = "../../embassy-executor", features = ["arch-cortex-m", "executor-thread", "executor-interrupt", "defmt"] }
 embassy-time = { version = "0.4.0", path = "../../embassy-time", features = ["defmt", "defmt-timestamp-uptime", "tick-hz-32_768"] }

--- a/examples/stm32h723/Cargo.toml
+++ b/examples/stm32h723/Cargo.toml
@@ -7,7 +7,7 @@ license = "MIT OR Apache-2.0"
 [dependencies]
 # Change stm32h723zg to your chip name, if necessary.
 embassy-stm32 = { version = "0.2.0", path = "../../embassy-stm32", features = ["defmt", "stm32h723zg", "time-driver-tim2", "exti", "memory-x", "unstable-pac", "chrono"] }
-embassy-sync = { version = "0.6.2", path = "../../embassy-sync", features = ["defmt"] }
+embassy-sync = { version = "0.7.0", path = "../../embassy-sync", features = ["defmt"] }
 embassy-executor = { version = "0.7.0", path = "../../embassy-executor", features = ["arch-cortex-m", "executor-thread", "executor-interrupt", "defmt"] }
 embassy-time = { version = "0.4.0", path = "../../embassy-time", features = ["defmt", "defmt-timestamp-uptime", "tick-hz-32_768"] }
 embassy-futures = { version = "0.1.0", path = "../../embassy-futures" }

--- a/examples/stm32h735/Cargo.toml
+++ b/examples/stm32h735/Cargo.toml
@@ -6,7 +6,7 @@ license = "MIT OR Apache-2.0"
 
 [dependencies]
 embassy-stm32 = { version = "0.2.0", path = "../../embassy-stm32", features = ["defmt", "stm32h735ig", "time-driver-tim2", "exti", "memory-x", "unstable-pac", "chrono"] }
-embassy-sync = { version = "0.6.2", path = "../../embassy-sync", features = ["defmt"] }
+embassy-sync = { version = "0.7.0", path = "../../embassy-sync", features = ["defmt"] }
 embassy-embedded-hal = { version = "0.3.0", path = "../../embassy-embedded-hal" }
 embassy-executor = { version = "0.7.0", path = "../../embassy-executor", features = ["arch-cortex-m", "executor-thread", "executor-interrupt", "defmt"] }
 embassy-time = { version = "0.4.0", path = "../../embassy-time", features = ["defmt", "defmt-timestamp-uptime", "tick-hz-32_768"] }

--- a/examples/stm32h742/Cargo.toml
+++ b/examples/stm32h742/Cargo.toml
@@ -14,7 +14,7 @@ embassy-stm32 = { version = "0.2.0", path = "../../embassy-stm32", features = [
     "time-driver-any",
     "exti",
 ] }
-embassy-sync = { version = "0.6.2", path = "../../embassy-sync", features = [
+embassy-sync = { version = "0.7.0", path = "../../embassy-sync", features = [
     "defmt",
 ] }
 embassy-executor = { version = "0.7.0", path = "../../embassy-executor", features = [

--- a/examples/stm32h755cm4/Cargo.toml
+++ b/examples/stm32h755cm4/Cargo.toml
@@ -7,7 +7,7 @@ license = "MIT OR Apache-2.0"
 [dependencies]
 # Change stm32h755zi-cm4 to your chip name, if necessary.
 embassy-stm32 = { version = "0.2.0", path = "../../embassy-stm32", features = ["defmt", "stm32h755zi-cm4", "time-driver-tim2", "exti", "memory-x", "unstable-pac", "chrono"] }
-embassy-sync = { version = "0.6.2", path = "../../embassy-sync", features = ["defmt"] }
+embassy-sync = { version = "0.7.0", path = "../../embassy-sync", features = ["defmt"] }
 embassy-embedded-hal = { version = "0.3.0", path = "../../embassy-embedded-hal" }
 embassy-executor = { version = "0.7.0", path = "../../embassy-executor", features = ["arch-cortex-m", "executor-thread", "executor-interrupt", "defmt"] }
 embassy-time = { version = "0.4.0", path = "../../embassy-time", features = ["defmt", "defmt-timestamp-uptime", "tick-hz-32_768"] }

--- a/examples/stm32h755cm7/Cargo.toml
+++ b/examples/stm32h755cm7/Cargo.toml
@@ -7,7 +7,7 @@ license = "MIT OR Apache-2.0"
 [dependencies]
 # Change stm32h743bi to your chip name, if necessary.
 embassy-stm32 = { version = "0.2.0", path = "../../embassy-stm32", features = ["defmt", "stm32h755zi-cm7", "time-driver-tim3", "exti", "memory-x", "unstable-pac", "chrono"] }
-embassy-sync = { version = "0.6.2", path = "../../embassy-sync", features = ["defmt"] }
+embassy-sync = { version = "0.7.0", path = "../../embassy-sync", features = ["defmt"] }
 embassy-embedded-hal = { version = "0.3.0", path = "../../embassy-embedded-hal" }
 embassy-executor = { version = "0.7.0", path = "../../embassy-executor", features = ["arch-cortex-m", "executor-thread", "executor-interrupt", "defmt"] }
 embassy-time = { version = "0.4.0", path = "../../embassy-time", features = ["defmt", "defmt-timestamp-uptime", "tick-hz-32_768"] }

--- a/examples/stm32h7b0/Cargo.toml
+++ b/examples/stm32h7b0/Cargo.toml
@@ -6,7 +6,7 @@ license = "MIT OR Apache-2.0"
 
 [dependencies]
 embassy-stm32 = { version = "0.2.0", path = "../../embassy-stm32", features = ["defmt", "stm32h7b0vb", "time-driver-tim2", "exti", "memory-x", "unstable-pac", "chrono"] }
-embassy-sync = { version = "0.6.2", path = "../../embassy-sync", features = ["defmt"] }
+embassy-sync = { version = "0.7.0", path = "../../embassy-sync", features = ["defmt"] }
 embassy-embedded-hal = { version = "0.3.0", path = "../../embassy-embedded-hal" }
 embassy-executor = { version = "0.7.0", path = "../../embassy-executor", features = ["arch-cortex-m", "executor-thread", "executor-interrupt", "defmt"] }
 embassy-time = { version = "0.4.0", path = "../../embassy-time", features = ["defmt", "defmt-timestamp-uptime", "tick-hz-32_768"] }

--- a/examples/stm32h7rs/Cargo.toml
+++ b/examples/stm32h7rs/Cargo.toml
@@ -7,7 +7,7 @@ license = "MIT OR Apache-2.0"
 [dependencies]
 # Change stm32h743bi to your chip name, if necessary.
 embassy-stm32 = { version = "0.2.0", path = "../../embassy-stm32", features = ["defmt", "stm32h7s3l8", "time-driver-tim2", "exti", "memory-x", "unstable-pac", "chrono"] }
-embassy-sync = { version = "0.6.2", path = "../../embassy-sync", features = ["defmt"] }
+embassy-sync = { version = "0.7.0", path = "../../embassy-sync", features = ["defmt"] }
 embassy-executor = { version = "0.7.0", path = "../../embassy-executor", features = ["arch-cortex-m", "executor-thread", "executor-interrupt", "defmt"] }
 embassy-time = { version = "0.4.0", path = "../../embassy-time", features = ["defmt", "defmt-timestamp-uptime", "tick-hz-32_768"] }
 embassy-net = { version = "0.7.0", path = "../../embassy-net", features = ["defmt", "udp", "medium-ethernet", "medium-ip", "proto-ipv4"] }

--- a/examples/stm32l0/Cargo.toml
+++ b/examples/stm32l0/Cargo.toml
@@ -7,7 +7,7 @@ license = "MIT OR Apache-2.0"
 [dependencies]
 # Change stm32l072cz to your chip name, if necessary.
 embassy-stm32 = { version = "0.2.0", path = "../../embassy-stm32", features = ["defmt", "stm32l073rz", "unstable-pac", "time-driver-any", "exti", "memory-x"]  }
-embassy-sync = { version = "0.6.2", path = "../../embassy-sync", features = ["defmt"] }
+embassy-sync = { version = "0.7.0", path = "../../embassy-sync", features = ["defmt"] }
 embassy-executor = { version = "0.7.0", path = "../../embassy-executor", features = ["arch-cortex-m", "executor-thread", "defmt"] }
 embassy-time = { version = "0.4.0", path = "../../embassy-time", features = ["defmt", "defmt-timestamp-uptime", "tick-hz-32_768"] }
 

--- a/examples/stm32l1/Cargo.toml
+++ b/examples/stm32l1/Cargo.toml
@@ -5,7 +5,7 @@ version = "0.1.0"
 license = "MIT OR Apache-2.0"
 
 [dependencies]
-embassy-sync = { version = "0.6.2", path = "../../embassy-sync", features = ["defmt"] }
+embassy-sync = { version = "0.7.0", path = "../../embassy-sync", features = ["defmt"] }
 embassy-executor = { version = "0.7.0", path = "../../embassy-executor", features = ["arch-cortex-m", "executor-thread", "defmt"] }
 embassy-time = { version = "0.4.0", path = "../../embassy-time", features = ["defmt", "defmt-timestamp-uptime", "tick-hz-32_768"] }
 embassy-stm32 = { version = "0.2.0", path = "../../embassy-stm32", features = [ "defmt", "stm32l151cb-a", "time-driver-any", "memory-x"]  }

--- a/examples/stm32l4/Cargo.toml
+++ b/examples/stm32l4/Cargo.toml
@@ -7,7 +7,7 @@ license = "MIT OR Apache-2.0"
 [dependencies]
 # Change stm32l4s5vi to your chip name, if necessary.
 embassy-stm32 = { version = "0.2.0", path = "../../embassy-stm32", features = [ "defmt", "unstable-pac", "stm32l4r5zi", "memory-x", "time-driver-any", "exti", "chrono", "dual-bank"]  }
-embassy-sync = { version = "0.6.2", path = "../../embassy-sync", features = ["defmt"] }
+embassy-sync = { version = "0.7.0", path = "../../embassy-sync", features = ["defmt"] }
 embassy-executor = { version = "0.7.0", path = "../../embassy-executor", features = ["arch-cortex-m", "executor-thread", "defmt"] }
 embassy-time = { version = "0.4.0", path = "../../embassy-time", features = ["defmt", "defmt-timestamp-uptime", "tick-hz-32_768", ] }
 embassy-embedded-hal = { version = "0.3.0", path = "../../embassy-embedded-hal" }

--- a/examples/stm32l432/Cargo.toml
+++ b/examples/stm32l432/Cargo.toml
@@ -7,7 +7,7 @@ license = "MIT OR Apache-2.0"
 [dependencies]
 # Change stm32l4s5vi to your chip name, if necessary.
 embassy-stm32 = { version = "0.2.0", path = "../../embassy-stm32", features = [ "defmt", "unstable-pac", "stm32l432kc", "memory-x", "time-driver-any", "exti", "chrono"] }
-embassy-sync = { version = "0.6.2", path = "../../embassy-sync", features = [ "defmt" ] }
+embassy-sync = { version = "0.7.0", path = "../../embassy-sync", features = [ "defmt" ] }
 embassy-executor = { version = "0.7.0", path = "../../embassy-executor", features = [ "arch-cortex-m", "executor-thread", "defmt" ] }
 embassy-time = { version = "0.4.0", path = "../../embassy-time", features = [ "defmt", "defmt-timestamp-uptime", "tick-hz-32_768" ] }
 defmt = "1.0.1"

--- a/examples/stm32l5/Cargo.toml
+++ b/examples/stm32l5/Cargo.toml
@@ -7,7 +7,7 @@ license = "MIT OR Apache-2.0"
 [dependencies]
 # Change stm32l552ze to your chip name, if necessary.
 embassy-stm32 = { version = "0.2.0", path = "../../embassy-stm32", features = [ "defmt", "unstable-pac", "stm32l552ze", "time-driver-any", "exti", "memory-x", "low-power", "dual-bank"]  }
-embassy-sync = { version = "0.6.2", path = "../../embassy-sync", features = ["defmt"] }
+embassy-sync = { version = "0.7.0", path = "../../embassy-sync", features = ["defmt"] }
 embassy-executor = { version = "0.7.0", path = "../../embassy-executor", features = ["arch-cortex-m", "executor-thread", "defmt"] }
 embassy-time = { version = "0.4.0", path = "../../embassy-time", features = ["defmt", "defmt-timestamp-uptime", "tick-hz-32_768"] }
 embassy-usb = { version = "0.4.0", path = "../../embassy-usb", features = ["defmt"] }

--- a/examples/stm32u0/Cargo.toml
+++ b/examples/stm32u0/Cargo.toml
@@ -7,7 +7,7 @@ license = "MIT OR Apache-2.0"
 [dependencies]
 # Change stm32u083rc to your chip name, if necessary.
 embassy-stm32 = { version = "0.2.0", path = "../../embassy-stm32", features = [ "defmt", "time-driver-any", "stm32u083rc", "memory-x", "unstable-pac", "exti", "chrono"]  }
-embassy-sync = { version = "0.6.2", path = "../../embassy-sync", features = ["defmt"] }
+embassy-sync = { version = "0.7.0", path = "../../embassy-sync", features = ["defmt"] }
 embassy-executor = { version = "0.7.0", path = "../../embassy-executor", features = ["arch-cortex-m", "executor-thread", "defmt"] }
 embassy-time = { version = "0.4.0", path = "../../embassy-time", features = ["defmt", "defmt-timestamp-uptime", "tick-hz-32_768"] }
 embassy-usb = { version = "0.4.0", path = "../../embassy-usb", default-features = false, features = ["defmt"] }

--- a/examples/stm32u5/Cargo.toml
+++ b/examples/stm32u5/Cargo.toml
@@ -7,7 +7,7 @@ license = "MIT OR Apache-2.0"
 [dependencies]
 # Change stm32u5g9zj to your chip name, if necessary.
 embassy-stm32 = { version = "0.2.0", path = "../../embassy-stm32", features = ["defmt", "unstable-pac", "stm32u5g9zj", "time-driver-any", "memory-x" ]  }
-embassy-sync = { version = "0.6.2", path = "../../embassy-sync", features = ["defmt"] }
+embassy-sync = { version = "0.7.0", path = "../../embassy-sync", features = ["defmt"] }
 embassy-executor = { version = "0.7.0", path = "../../embassy-executor", features = ["arch-cortex-m", "executor-thread", "defmt"] }
 embassy-time = { version = "0.4.0", path = "../../embassy-time", features = ["defmt", "defmt-timestamp-uptime", "tick-hz-32_768"] }
 embassy-usb = { version = "0.4.0", path = "../../embassy-usb", features = ["defmt"] }

--- a/examples/stm32wb/Cargo.toml
+++ b/examples/stm32wb/Cargo.toml
@@ -8,7 +8,7 @@ license = "MIT OR Apache-2.0"
 # Change stm32wb55rg to your chip name in both dependencies, if necessary.
 embassy-stm32 = { version = "0.2.0", path = "../../embassy-stm32", features = [ "defmt", "stm32wb55rg", "time-driver-any", "memory-x", "exti"]  }
 embassy-stm32-wpan = { version = "0.1.0", path = "../../embassy-stm32-wpan", features = ["defmt", "stm32wb55rg"] }
-embassy-sync = { version = "0.6.2", path = "../../embassy-sync", features = ["defmt"] }
+embassy-sync = { version = "0.7.0", path = "../../embassy-sync", features = ["defmt"] }
 embassy-executor = { version = "0.7.0", path = "../../embassy-executor", features = ["arch-cortex-m", "executor-thread", "defmt"] }
 embassy-time = { version = "0.4.0", path = "../../embassy-time", features = ["defmt", "defmt-timestamp-uptime", "tick-hz-32_768"] }
 embassy-net = { version = "0.7.0", path = "../../embassy-net", features = ["defmt", "udp", "proto-ipv6", "medium-ieee802154", ], optional = true }

--- a/examples/stm32wba/Cargo.toml
+++ b/examples/stm32wba/Cargo.toml
@@ -6,7 +6,7 @@ license = "MIT OR Apache-2.0"
 
 [dependencies]
 embassy-stm32 = { version = "0.2.0", path = "../../embassy-stm32", features = [ "defmt", "stm32wba55cg", "time-driver-any", "memory-x", "exti"]  }
-embassy-sync = { version = "0.6.2", path = "../../embassy-sync", features = ["defmt"] }
+embassy-sync = { version = "0.7.0", path = "../../embassy-sync", features = ["defmt"] }
 embassy-executor = { version = "0.7.0", path = "../../embassy-executor", features = ["arch-cortex-m", "executor-thread", "defmt"] }
 embassy-time = { version = "0.4.0", path = "../../embassy-time", features = ["defmt", "defmt-timestamp-uptime", "tick-hz-32_768"] }
 embassy-net = { version = "0.7.0", path = "../../embassy-net", features = ["defmt", "udp", "proto-ipv6", "medium-ieee802154", ], optional = true }

--- a/examples/stm32wl/Cargo.toml
+++ b/examples/stm32wl/Cargo.toml
@@ -7,7 +7,7 @@ license = "MIT OR Apache-2.0"
 [dependencies]
 # Change stm32wl55jc-cm4 to your chip name, if necessary.
 embassy-stm32 = { version = "0.2.0", path = "../../embassy-stm32", features = ["defmt", "stm32wl55jc-cm4", "time-driver-any", "memory-x", "unstable-pac", "exti", "chrono"] }
-embassy-sync = { version = "0.6.2", path = "../../embassy-sync", features = ["defmt"] }
+embassy-sync = { version = "0.7.0", path = "../../embassy-sync", features = ["defmt"] }
 embassy-executor = { version = "0.7.0", path = "../../embassy-executor", features = ["arch-cortex-m", "executor-thread", "defmt"] }
 embassy-time = { version = "0.4.0", path = "../../embassy-time", features = ["defmt", "defmt-timestamp-uptime", "tick-hz-32_768"] }
 embassy-embedded-hal = { version = "0.3.0", path = "../../embassy-embedded-hal" }

--- a/examples/wasm/Cargo.toml
+++ b/examples/wasm/Cargo.toml
@@ -8,7 +8,7 @@ license = "MIT OR Apache-2.0"
 crate-type = ["cdylib"]
 
 [dependencies]
-embassy-sync = { version = "0.6.2", path = "../../embassy-sync", features = ["log"] }
+embassy-sync = { version = "0.7.0", path = "../../embassy-sync", features = ["log"] }
 embassy-executor = { version = "0.7.0", path = "../../embassy-executor", features = ["arch-wasm", "executor-thread", "log"] }
 embassy-time = { version = "0.4.0", path = "../../embassy-time", features = ["log", "wasm", ] }
 

--- a/tests/mspm0/Cargo.toml
+++ b/tests/mspm0/Cargo.toml
@@ -10,7 +10,7 @@ mspm0g3507 = [ "embassy-mspm0/mspm0g3507pm" ]
 [dependencies]
 teleprobe-meta = "1.1"
 
-embassy-sync = { version = "0.6.2", path = "../../embassy-sync", features = [ "defmt" ] }
+embassy-sync = { version = "0.7.0", path = "../../embassy-sync", features = [ "defmt" ] }
 embassy-executor = { version = "0.7.0", path = "../../embassy-executor", features = [ "arch-cortex-m", "executor-thread", "defmt" ] }
 embassy-time = { version = "0.4.0", path = "../../embassy-time", features = [ "defmt" ] }
 embassy-mspm0 = { version = "0.1.0", path = "../../embassy-mspm0", features = [ "rt", "defmt", "unstable-pac", "time-driver-any" ]  }

--- a/tests/nrf/Cargo.toml
+++ b/tests/nrf/Cargo.toml
@@ -8,7 +8,7 @@ license = "MIT OR Apache-2.0"
 teleprobe-meta = "1"
 
 embassy-futures = { version = "0.1.0", path = "../../embassy-futures" }
-embassy-sync = { version = "0.6.2", path = "../../embassy-sync", features = ["defmt", ] }
+embassy-sync = { version = "0.7.0", path = "../../embassy-sync", features = ["defmt", ] }
 embassy-executor = { version = "0.7.0", path = "../../embassy-executor", features = ["arch-cortex-m", "executor-thread", "defmt"] }
 embassy-time = { version = "0.4.0", path = "../../embassy-time", features = ["defmt",  "defmt-timestamp-uptime"] }
 embassy-nrf = { version = "0.3.1", path = "../../embassy-nrf", features = ["defmt",  "time-driver-rtc1", "gpiote", "unstable-pac"] }

--- a/tests/riscv32/Cargo.toml
+++ b/tests/riscv32/Cargo.toml
@@ -6,7 +6,7 @@ license = "MIT OR Apache-2.0"
 
 [dependencies]
 critical-section = { version = "1.1.1", features = ["restore-state-bool"] }
-embassy-sync = { version = "0.6.2", path = "../../embassy-sync" }
+embassy-sync = { version = "0.7.0", path = "../../embassy-sync" }
 embassy-executor = { version = "0.7.0", path = "../../embassy-executor", features = ["arch-riscv32", "executor-thread"] }
 embassy-time = { version = "0.4.0", path = "../../embassy-time" }
 embassy-futures = { version = "0.1.0", path = "../../embassy-futures" }

--- a/tests/rp/Cargo.toml
+++ b/tests/rp/Cargo.toml
@@ -12,7 +12,7 @@ rp235xb = ["embassy-rp/rp235xb"]
 [dependencies]
 teleprobe-meta = "1.1"
 
-embassy-sync = { version = "0.6.2", path = "../../embassy-sync", features = ["defmt"] }
+embassy-sync = { version = "0.7.0", path = "../../embassy-sync", features = ["defmt"] }
 embassy-executor = { version = "0.7.0", path = "../../embassy-executor", features = ["arch-cortex-m", "executor-thread", "defmt"] }
 embassy-time = { version = "0.4.0", path = "../../embassy-time", features = ["defmt", ] }
 embassy-rp = { version = "0.4.0", path = "../../embassy-rp", features = [ "defmt", "unstable-pac", "time-driver", "critical-section-impl", "intrinsics", "rom-v2-intrinsics", "run-from-ram"]  }

--- a/tests/stm32/Cargo.toml
+++ b/tests/stm32/Cargo.toml
@@ -61,7 +61,7 @@ cm0 = ["portable-atomic/unsafe-assume-single-core"]
 [dependencies]
 teleprobe-meta = "1"
 
-embassy-sync = { version = "0.6.2", path = "../../embassy-sync", features = ["defmt"] }
+embassy-sync = { version = "0.7.0", path = "../../embassy-sync", features = ["defmt"] }
 embassy-executor = { version = "0.7.0", path = "../../embassy-executor", features = ["arch-cortex-m", "executor-thread", "defmt"] }
 embassy-time = { version = "0.4.0", path = "../../embassy-time", features = ["defmt", "tick-hz-131_072", "defmt-timestamp-uptime"] }
 embassy-stm32 = { version = "0.2.0", path = "../../embassy-stm32", features = [ "defmt", "unstable-pac", "memory-x", "time-driver-any"]  }


### PR DESCRIPTION
I've updated the changelog for embassy-sync (I'd like to see a crates.io release with the zerocopy-channel fix).
I think this needs a major bump because of the critical-section std change.

If there are other planned pending embassy-sync changes please don't let this rush a release.