### PR TITLE
Support RGBW on PioWs2812

### DIFF
--- a/embassy-rp/src/pio_programs/ws2812.rs
+++ b/embassy-rp/src/pio_programs/ws2812.rs
@@ -2,7 +2,7 @@
 
 use embassy_time::Timer;
 use fixed::types::U24F8;
-use smart_leds::RGB8;
+use smart_leds::{RGB8, RGBW};
 
 use crate::clocks::clk_sys_freq;
 use crate::dma::{AnyChannel, Channel};
@@ -50,14 +50,14 @@ impl<'a, PIO: Instance> PioWs2812Program<'a, PIO> {
     }
 }
 
-/// Pio backed ws2812 driver
+/// Pio backed RGB ws2812 driver
 /// Const N is the number of ws2812 leds attached to this pin
-pub struct PioWs2812<'d, P: Instance, const S: usize, const N: usize> {
+pub struct RgbPioWs2812<'d, P: Instance, const S: usize, const N: usize> {
     dma: Peri<'d, AnyChannel>,
     sm: StateMachine<'d, P, S>,
 }
 
-impl<'d, P: Instance, const S: usize, const N: usize> PioWs2812<'d, P, S, N> {
+impl<'d, P: Instance, const S: usize, const N: usize> RgbPioWs2812<'d, P, S, N> {
     /// Configure a pio state machine to use the loaded ws2812 program.
     pub fn new(
         pio: &mut Common<'d, P>,
@@ -102,6 +102,69 @@ impl<'d, P: Instance, const S: usize, const N: usize> PioWs2812<'d, P, S, N> {
         let mut words = [0u32; N];
         for i in 0..N {
             let word = (u32::from(colors[i].g) << 24) | (u32::from(colors[i].r) << 16) | (u32::from(colors[i].b) << 8);
+            words[i] = word;
+        }
+
+        // DMA transfer
+        self.sm.tx().dma_push(self.dma.reborrow(), &words, false).await;
+
+        Timer::after_micros(55).await;
+    }
+}
+
+/// Pio backed RGBW ws2812 driver
+/// This version is intended for ws2812 leds with 4 addressable lights
+/// Const N is the number of ws2812 leds attached to this pin
+pub struct RgbwPioWs2812<'d, P: Instance, const S: usize, const N: usize> {
+    dma: Peri<'d, AnyChannel>,
+    sm: StateMachine<'d, P, S>,
+}
+
+impl<'d, P: Instance, const S: usize, const N: usize> RgbwPioWs2812<'d, P, S, N> {
+    /// Configure a pio state machine to use the loaded ws2812 program.
+    pub fn new(
+        pio: &mut Common<'d, P>,
+        mut sm: StateMachine<'d, P, S>,
+        dma: Peri<'d, impl Channel>,
+        pin: Peri<'d, impl PioPin>,
+        program: &PioWs2812Program<'d, P>,
+    ) -> Self {
+        // Setup sm0
+        let mut cfg = Config::default();
+
+        // Pin config
+        let out_pin = pio.make_pio_pin(pin);
+        cfg.set_out_pins(&[&out_pin]);
+        cfg.set_set_pins(&[&out_pin]);
+
+        cfg.use_program(&program.prg, &[&out_pin]);
+
+        // Clock config, measured in kHz to avoid overflows
+        let clock_freq = U24F8::from_num(clk_sys_freq() / 1000);
+        let ws2812_freq = U24F8::from_num(800);
+        let bit_freq = ws2812_freq * CYCLES_PER_BIT;
+        cfg.clock_divider = clock_freq / bit_freq;
+
+        // FIFO config
+        cfg.fifo_join = FifoJoin::TxOnly;
+        cfg.shift_out = ShiftConfig {
+            auto_fill: true,
+            threshold: 32,
+            direction: ShiftDirection::Left,
+        };
+
+        sm.set_config(&cfg);
+        sm.set_enable(true);
+
+        Self { dma: dma.into(), sm }
+    }
+
+    /// Write a buffer of [smart_leds::RGBW] to the ws2812 string
+    pub async fn write(&mut self, colors: &[RGBW<u8>; N]) {
+        // Precompute the word bytes from the colors
+        let mut words = [0u32; N];
+        for i in 0..N {
+            let word = (u32::from(colors[i].g) << 24) | (u32::from(colors[i].r) << 16) | (u32::from(colors[i].b) << 8) | u32::from(colors[i].a.0);
             words[i] = word;
         }
 

--- a/embassy-rp/src/pio_programs/ws2812.rs
+++ b/embassy-rp/src/pio_programs/ws2812.rs
@@ -52,12 +52,12 @@ impl<'a, PIO: Instance> PioWs2812Program<'a, PIO> {
 
 /// Pio backed RGB ws2812 driver
 /// Const N is the number of ws2812 leds attached to this pin
-pub struct RgbPioWs2812<'d, P: Instance, const S: usize, const N: usize> {
+pub struct PioWs2812<'d, P: Instance, const S: usize, const N: usize> {
     dma: Peri<'d, AnyChannel>,
     sm: StateMachine<'d, P, S>,
 }
 
-impl<'d, P: Instance, const S: usize, const N: usize> RgbPioWs2812<'d, P, S, N> {
+impl<'d, P: Instance, const S: usize, const N: usize> PioWs2812<'d, P, S, N> {
     /// Configure a pio state machine to use the loaded ws2812 program.
     pub fn new(
         pio: &mut Common<'d, P>,
@@ -164,7 +164,10 @@ impl<'d, P: Instance, const S: usize, const N: usize> RgbwPioWs2812<'d, P, S, N>
         // Precompute the word bytes from the colors
         let mut words = [0u32; N];
         for i in 0..N {
-            let word = (u32::from(colors[i].g) << 24) | (u32::from(colors[i].r) << 16) | (u32::from(colors[i].b) << 8) | u32::from(colors[i].a.0);
+            let word = (u32::from(colors[i].g) << 24)
+                | (u32::from(colors[i].r) << 16)
+                | (u32::from(colors[i].b) << 8)
+                | u32::from(colors[i].a.0);
             words[i] = word;
         }
 


### PR DESCRIPTION
Some ws2812 (aka neopixel) devices have an additional white led. The current pio program does not support these and can cause weird shifting issues due to using only 24 bits on the FIFO config threshold. Add an optional program that supports this white led, and supports using `smart_led::RGBW<u8>`

See [this repository](https://github.com/MatrixSenpai/ripple/blob/6dcf3a26aa6b17bc549177ae20b9e43c298fc95e/binary/src/ws2812/pio.rs#L50-L94) for the original working implementation.