### PR TITLE
nrf: Enable TEMP driver for nrf5340-net

### DIFF
--- a/embassy-nrf/src/chips/nrf5340_net.rs
+++ b/embassy-nrf/src/chips/nrf5340_net.rs
@@ -201,6 +201,9 @@ embassy_hal_internal::peripherals! {
 
     // EGU
     EGU0,
+
+    // TEMP
+    TEMP,
 }
 
 impl_ipc!(IPC, IPC, IPC);

--- a/embassy-nrf/src/lib.rs
+++ b/embassy-nrf/src/lib.rs
@@ -149,7 +149,7 @@ pub mod spim;
 #[cfg(not(feature = "_nrf51"))]
 pub mod spis;
 #[cfg(not(feature = "_nrf54l"))] // TODO
-#[cfg(not(any(feature = "_nrf5340", feature = "_nrf91")))]
+#[cfg(not(any(feature = "_nrf5340-app", feature = "_nrf91")))]
 pub mod temp;
 #[cfg(not(feature = "_nrf54l"))] // TODO
 pub mod timer;


### PR DESCRIPTION
App core doesn't have a TEMP peripheral.