### PR TITLE
chore: temporarily disable pico tests

### DIFF
--- a/ci.sh
+++ b/ci.sh
@@ -362,6 +362,9 @@ rm out/tests/pimoroni-pico-plus-2/flash
 rm out/tests/pimoroni-pico-plus-2/i2c
 # The pico2 plus doesn't have the adcs hooked up like the picoW does.
 rm out/tests/pimoroni-pico-plus-2/adc
+# temporarily disabled
+rm out/tests/pimoroni-pico-plus-2/pwm
+
 # temporarily disabled, bad hardware connection.
 rm -f out/tests/rpi-pico/*
 

--- a/ci.sh
+++ b/ci.sh
@@ -362,6 +362,8 @@ rm out/tests/pimoroni-pico-plus-2/flash
 rm out/tests/pimoroni-pico-plus-2/i2c
 # The pico2 plus doesn't have the adcs hooked up like the picoW does.
 rm out/tests/pimoroni-pico-plus-2/adc
+# temporarily disabled, bad hardware connection.
+rm -f out/tests/rpi-pico/*
 
 if [[ -z "${TELEPROBE_TOKEN-}" ]]; then
     echo No teleprobe token found, skipping running HIL tests


### PR DESCRIPTION
Since we are merging code without these tests running, it makes sense to disable them until the physical board can be checked.