### PR TITLE
executor: Make state implementations and their conditions match

### DIFF
--- a/embassy-executor/src/raw/mod.rs
+++ b/embassy-executor/src/raw/mod.rs
@@ -11,7 +11,7 @@
 #[cfg_attr(not(target_has_atomic = "ptr"), path = "run_queue_critical_section.rs")]
 mod run_queue;
 
-#[cfg_attr(all(cortex_m, target_has_atomic = "8"), path = "state_atomics_arm.rs")]
+#[cfg_attr(all(cortex_m, target_has_atomic = "32"), path = "state_atomics_arm.rs")]
 #[cfg_attr(all(not(cortex_m), target_has_atomic = "8"), path = "state_atomics.rs")]
 #[cfg_attr(not(target_has_atomic = "8"), path = "state_critical_section.rs")]
 mod state;

--- a/embassy-executor/src/raw/state_atomics.rs
+++ b/embassy-executor/src/raw/state_atomics.rs
@@ -1,4 +1,4 @@
-use core::sync::atomic::{AtomicU32, Ordering};
+use core::sync::atomic::{AtomicU8, Ordering};
 
 #[derive(Clone, Copy)]
 pub(crate) struct Token(());
@@ -11,18 +11,18 @@ pub(crate) fn locked<R>(f: impl FnOnce(Token) -> R) -> R {
 }
 
 /// Task is spawned (has a future)
-pub(crate) const STATE_SPAWNED: u32 = 1 << 0;
+pub(crate) const STATE_SPAWNED: u8 = 1 << 0;
 /// Task is in the executor run queue
-pub(crate) const STATE_RUN_QUEUED: u32 = 1 << 1;
+pub(crate) const STATE_RUN_QUEUED: u8 = 1 << 1;
 
 pub(crate) struct State {
-    state: AtomicU32,
+    state: AtomicU8,
 }
 
 impl State {
     pub const fn new() -> State {
         Self {
-            state: AtomicU32::new(0),
+            state: AtomicU8::new(0),
         }
     }
 

--- a/embassy-executor/src/raw/state_critical_section.rs
+++ b/embassy-executor/src/raw/state_critical_section.rs
@@ -4,12 +4,12 @@ pub(crate) use critical_section::{with as locked, CriticalSection as Token};
 use critical_section::{CriticalSection, Mutex};
 
 /// Task is spawned (has a future)
-pub(crate) const STATE_SPAWNED: u32 = 1 << 0;
+pub(crate) const STATE_SPAWNED: u8 = 1 << 0;
 /// Task is in the executor run queue
-pub(crate) const STATE_RUN_QUEUED: u32 = 1 << 1;
+pub(crate) const STATE_RUN_QUEUED: u8 = 1 << 1;
 
 pub(crate) struct State {
-    state: Mutex<Cell<u32>>,
+    state: Mutex<Cell<u8>>,
 }
 
 impl State {
@@ -19,11 +19,11 @@ impl State {
         }
     }
 
-    fn update<R>(&self, f: impl FnOnce(&mut u32) -> R) -> R {
+    fn update<R>(&self, f: impl FnOnce(&mut u8) -> R) -> R {
         critical_section::with(|cs| self.update_with_cs(cs, f))
     }
 
-    fn update_with_cs<R>(&self, cs: CriticalSection<'_>, f: impl FnOnce(&mut u32) -> R) -> R {
+    fn update_with_cs<R>(&self, cs: CriticalSection<'_>, f: impl FnOnce(&mut u8) -> R) -> R {
         let s = self.state.borrow(cs);
         let mut val = s.get();
         let r = f(&mut val);


### PR DESCRIPTION
Hi!

I am playing around with embassy on AVR (an ATmega328p) and stumbled into some oddities. There are three implementations of the executor state that are conditionally selected based on the existance of 8-bit atomics. All of them however use 32-bit integers.

Since only 2 bits are actually used, I have modified the non ARM specific ones to use a u8 instead of a u32.  In the case of AVR, there are no 8-bit atomics but using a u8 with a critical section instead of u32 still save around 60-bytes or so in a minimal test.

I might be missing something obvious so feel free to reject the pull request.