### PR TITLE
stm32: Assert in BufferedUart that the buffers are not empty.

### DIFF
--- a/embassy-stm32/src/usart/buffered.rs
+++ b/embassy-stm32/src/usart/buffered.rs
@@ -457,8 +457,10 @@ impl<'d> BufferedUart<'d> {
 
         info.rcc.enable_and_reset();
 
+        assert!(!tx_buffer.is_empty());
         let len = tx_buffer.len();
         unsafe { state.tx_buf.init(tx_buffer.as_mut_ptr(), len) };
+        assert!(!rx_buffer.is_empty());
         let len = rx_buffer.len();
         unsafe { state.rx_buf.init(rx_buffer.as_mut_ptr(), len) };
 


### PR DESCRIPTION
I struggled using BufferedUart (could not receive any data) and it turned out that the cause was that I was passing empty slices as the buffers... RingBufferedUartRx already has an assertion to catch this (which is how I discovered the issue).