### PR TITLE
stm32: Improvements to CRC HAL.

### DIFF
--- a/embassy-stm32/src/crc/v1.rs
+++ b/embassy-stm32/src/crc/v1.rs
@@ -23,22 +23,16 @@ impl<'d> Crc<'d> {
         PAC_CRC.cr().write(|w| w.set_reset(true));
     }
 
-    /// Feeds a word to the peripheral and returns the current CRC value
+    /// Feeds a word into the CRC peripheral. Returns the computed CRC.
     pub fn feed_word(&mut self, word: u32) -> u32 {
         // write a single byte to the device, and return the result
-        #[cfg(not(crc_v1))]
-        PAC_CRC.dr32().write_value(word);
-        #[cfg(crc_v1)]
         PAC_CRC.dr().write_value(word);
         self.read()
     }
 
-    /// Feed a slice of words to the peripheral and return the result.
+    /// Feeds a slice of words into the CRC peripheral. Returns the computed CRC.
     pub fn feed_words(&mut self, words: &[u32]) -> u32 {
         for word in words {
-            #[cfg(not(crc_v1))]
-            PAC_CRC.dr32().write_value(*word);
-            #[cfg(crc_v1)]
             PAC_CRC.dr().write_value(*word);
         }
 
@@ -46,12 +40,6 @@ impl<'d> Crc<'d> {
     }
 
     /// Read the CRC result value.
-    #[cfg(not(crc_v1))]
-    pub fn read(&self) -> u32 {
-        PAC_CRC.dr32().read()
-    }
-    /// Read the CRC result value.
-    #[cfg(crc_v1)]
     pub fn read(&self) -> u32 {
         PAC_CRC.dr().read()
     }

--- a/embassy-stm32/src/crc/v2v3.rs
+++ b/embassy-stm32/src/crc/v2v3.rs
@@ -9,7 +9,7 @@ pub struct Crc<'d> {
     _config: Config,
 }
 
-/// CRC configuration errlr
+/// CRC configuration error
 #[derive(Debug)]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub enum ConfigError {
@@ -34,9 +34,9 @@ pub enum InputReverseConfig {
     None,
     /// Reverse bytes
     Byte,
-    /// Reverse 16-bit halfwords.
+    /// Reverse 16-bit halfwords
     Halfword,
-    /// Reverse 32-bit words.
+    /// Reverse 32-bit words
     Word,
 }
 
@@ -127,45 +127,52 @@ impl<'d> Crc<'d> {
                 PolySize::Width32 => vals::Polysize::POLYSIZE32,
             });
         });
-
-        self.reset();
     }
 
-    /// Feeds a byte into the CRC peripheral. Returns the computed checksum.
-    pub fn feed_byte(&mut self, byte: u8) -> u32 {
-        PAC_CRC.dr8().write_value(byte);
+    /// Read the CRC result value.
+    pub fn read(&self) -> u32 {
         PAC_CRC.dr32().read()
     }
 
-    /// Feeds an slice of bytes into the CRC peripheral. Returns the computed checksum.
+    /// Feeds a byte into the CRC peripheral. Returns the computed CRC.
+    pub fn feed_byte(&mut self, byte: u8) -> u32 {
+        PAC_CRC.dr8().write_value(byte);
+        self.read()
+    }
+
+    /// Feeds a slice of bytes into the CRC peripheral. Returns the computed CRC.
     pub fn feed_bytes(&mut self, bytes: &[u8]) -> u32 {
         for byte in bytes {
             PAC_CRC.dr8().write_value(*byte);
         }
-        PAC_CRC.dr32().read()
+        self.read()
     }
-    /// Feeds a halfword into the CRC peripheral. Returns the computed checksum.
+
+    /// Feeds a halfword into the CRC peripheral. Returns the computed CRC.
     pub fn feed_halfword(&mut self, halfword: u16) -> u32 {
         PAC_CRC.dr16().write_value(halfword);
-        PAC_CRC.dr32().read()
+        self.read()
     }
-    /// Feeds an slice of halfwords into the CRC peripheral. Returns the computed checksum.
+
+    /// Feeds a slice of halfwords into the CRC peripheral. Returns the computed CRC.
     pub fn feed_halfwords(&mut self, halfwords: &[u16]) -> u32 {
         for halfword in halfwords {
             PAC_CRC.dr16().write_value(*halfword);
         }
-        PAC_CRC.dr32().read()
+        self.read()
     }
-    /// Feeds a words into the CRC peripheral. Returns the computed checksum.
+
+    /// Feeds a word into the CRC peripheral. Returns the computed CRC.
     pub fn feed_word(&mut self, word: u32) -> u32 {
         PAC_CRC.dr32().write_value(word as u32);
-        PAC_CRC.dr32().read()
+        self.read()
     }
-    /// Feeds an slice of words into the CRC peripheral. Returns the computed checksum.
+
+    /// Feeds a slice of words into the CRC peripheral. Returns the computed CRC.
     pub fn feed_words(&mut self, words: &[u32]) -> u32 {
         for word in words {
             PAC_CRC.dr32().write_value(*word as u32);
         }
-        PAC_CRC.dr32().read()
+        self.read()
     }
 }


### PR DESCRIPTION
* Corrects spelling and grammar errors in documentation.

* Removes non-v1 code from v1-only source file.

* Adds 'read' operation for v2/v3, to be consistent with v1.

* Removes 'reset' from the v2/v3 'reconfigure' operation to match the documentation (the only user is the 'new' function which already issues a reset).