### PR TITLE
start referencing examples in embassy-stm32

### DIFF
--- a/embassy-stm32/src/adc/mod.rs
+++ b/embassy-stm32/src/adc/mod.rs
@@ -1,4 +1,8 @@
 //! Analog to Digital Converter (ADC)
+//!
+//! ## Examples
+//!
+//! - [STM32F4](https://github.com/embassy-rs/embassy/blob/main/examples/stm32f4/src/bin/adc.rs)
 
 #![macro_use]
 #![allow(missing_docs)] // TODO

--- a/embassy-stm32/src/can/mod.rs
+++ b/embassy-stm32/src/can/mod.rs
@@ -1,4 +1,8 @@
 //! Controller Area Network (CAN)
+//!
+//! ## Examples
+//!
+//! - [STM32F4](https://github.com/embassy-rs/embassy/blob/main/examples/stm32f4/src/bin/can.rs)
 #![macro_use]
 
 #[cfg_attr(can_bxcan, path = "bxcan/mod.rs")]

--- a/embassy-stm32/src/dac/mod.rs
+++ b/embassy-stm32/src/dac/mod.rs
@@ -1,4 +1,8 @@
 //! Digital to Analog Converter (DAC)
+//!
+//! ## Examples
+//!
+//! - [STM32F4](https://github.com/embassy-rs/embassy/blob/main/examples/stm32f4/src/bin/dac.rs)
 #![macro_use]
 
 use core::marker::PhantomData;

--- a/embassy-stm32/src/eth/mod.rs
+++ b/embassy-stm32/src/eth/mod.rs
@@ -1,6 +1,9 @@
 //! Ethernet (ETH)
 //!
+//! ## Examples
+//!
 //! - [STM32F4](https://github.com/embassy-rs/embassy/blob/main/examples/stm32f4/src/bin/eth.rs)
+//! - [STM32F4 Eth Compliance](https://github.com/embassy-rs/embassy/blob/main/examples/stm32f4/src/bin/eth_compliance_test.rs)
 #![macro_use]
 
 #[cfg_attr(any(eth_v1a, eth_v1b, eth_v1c), path = "v1/mod.rs")]

--- a/embassy-stm32/src/eth/mod.rs
+++ b/embassy-stm32/src/eth/mod.rs
@@ -1,4 +1,6 @@
 //! Ethernet (ETH)
+//!
+//! - [STM32F4](https://github.com/embassy-rs/embassy/blob/main/examples/stm32f4/src/bin/eth.rs)
 #![macro_use]
 
 #[cfg_attr(any(eth_v1a, eth_v1b, eth_v1c), path = "v1/mod.rs")]

--- a/embassy-stm32/src/exti.rs
+++ b/embassy-stm32/src/exti.rs
@@ -1,4 +1,8 @@
 //! External Interrupts (EXTI)
+//!
+//! ## Examples
+//!
+//! - [STM32F4 Button EXTI](https://github.com/embassy-rs/embassy/blob/main/examples/stm32f4/src/bin/button_exti.rs)
 use core::convert::Infallible;
 use core::future::Future;
 use core::marker::PhantomData;

--- a/embassy-stm32/src/flash/mod.rs
+++ b/embassy-stm32/src/flash/mod.rs
@@ -1,4 +1,9 @@
 //! Flash memory (FLASH)
+//!
+//! ## Examples
+//!
+//! - [STM32F4 Flash](https://github.com/embassy-rs/embassy/blob/main/examples/stm32f4/src/bin/flash.rs)
+//! - [STM32F4 Flash Async](https://github.com/embassy-rs/embassy/blob/main/examples/stm32f4/src/bin/flash_async.rs)
 use embedded_storage::nor_flash::{NorFlashError, NorFlashErrorKind};
 
 #[cfg(flash_f4)]

--- a/embassy-stm32/src/gpio.rs
+++ b/embassy-stm32/src/gpio.rs
@@ -1,4 +1,8 @@
 //! General-purpose Input/Output (GPIO)
+//!
+//! ## Examples
+//!
+//! - [STM32F0 Blinky](https://github.com/embassy-rs/embassy/blob/main/examples/stm32f0/src/bin/blinky.rs)
 
 #![macro_use]
 use core::convert::Infallible;

--- a/embassy-stm32/src/i2c/mod.rs
+++ b/embassy-stm32/src/i2c/mod.rs
@@ -1,4 +1,10 @@
 //! Inter-Integrated-Circuit (I2C)
+//!
+//! ## Examples
+//!
+//! - [STM32F4](https://github.com/embassy-rs/embassy/blob/main/examples/stm32f4/src/bin/i2c.rs)
+//! - [STM32F4 Async](https://github.com/embassy-rs/embassy/blob/main/examples/stm32f4/src/bin/i2c_async.rs)
+//! - [STM32F4 DMA](https://github.com/embassy-rs/embassy/blob/main/examples/stm32f4/src/bin/i2c_dma.rs)
 #![macro_use]
 
 #[cfg_attr(i2c_v1, path = "v1.rs")]

--- a/embassy-stm32/src/rtc/mod.rs
+++ b/embassy-stm32/src/rtc/mod.rs
@@ -1,4 +1,8 @@
 //! Real Time Clock (RTC)
+//!
+//! ## Examples
+//!
+//! - [STM32F4](https://github.com/embassy-rs/embassy/blob/main/examples/stm32f4/src/bin/rtc.rs)
 mod datetime;
 
 #[cfg(feature = "low-power")]

--- a/embassy-stm32/src/sdmmc/mod.rs
+++ b/embassy-stm32/src/sdmmc/mod.rs
@@ -1,4 +1,8 @@
 //! Secure Digital / MultiMedia Card (SDMMC)
+//!
+//! ## Examples
+//!
+//! - [STM32F4](https://github.com/embassy-rs/embassy/blob/main/examples/stm32f4/src/bin/sdmmc.rs)
 #![macro_use]
 
 use core::default::Default;

--- a/embassy-stm32/src/spi/mod.rs
+++ b/embassy-stm32/src/spi/mod.rs
@@ -1,4 +1,9 @@
 //! Serial Peripheral Interface (SPI)
+//!
+//! ## Examples
+//!
+//! - [STM32F4](https://github.com/embassy-rs/embassy/blob/main/examples/stm32f4/src/bin/spi.rs)
+//! - [STM32F4 DMA](https://github.com/embassy-rs/embassy/blob/main/examples/stm32f4/src/bin/spi_dma.rs)
 #![macro_use]
 
 use core::marker::PhantomData;

--- a/embassy-stm32/src/timer/mod.rs
+++ b/embassy-stm32/src/timer/mod.rs
@@ -1,5 +1,9 @@
 //! Timers, PWM, quadrature decoder.
-
+//!
+//! ## Examples
+//!
+//! - [STM32F4 PWM](https://github.com/embassy-rs/embassy/blob/main/examples/stm32f4/src/bin/pwm.rs)
+//! - [STM32F4 Input Capture](https://github.com/embassy-rs/embassy/blob/main/examples/stm32f4/src/bin/input_capture.rs)
 use core::marker::PhantomData;
 
 use embassy_hal_internal::Peripheral;

--- a/embassy-stm32/src/usart/mod.rs
+++ b/embassy-stm32/src/usart/mod.rs
@@ -1,4 +1,10 @@
 //! Universal Synchronous/Asynchronous Receiver Transmitter (USART, UART, LPUART)
+//!
+//! ## Examples
+//!
+//! - [STM32F4 USART](https://github.com/embassy-rs/embassy/blob/main/examples/stm32f4/src/bin/usart.rs)
+//! - [STM32F4 USART Buffered](https://github.com/embassy-rs/embassy/blob/main/examples/stm32f4/src/bin/usart_buffered.rs)
+//! - [STM32F4 USART DMA](https://github.com/embassy-rs/embassy/blob/main/examples/stm32f4/src/bin/usart_dma.rs)
 #![macro_use]
 #![warn(missing_docs)]
 

--- a/embassy-stm32/src/usb/mod.rs
+++ b/embassy-stm32/src/usb/mod.rs
@@ -1,4 +1,10 @@
 //! Universal Serial Bus (USB)
+//!
+//! ## Examples
+//!
+//! - [STM32F4 USB Serial](https://github.com/embassy-rs/embassy/blob/main/examples/stm32f4/src/bin/usb_serial.rs)
+//! - [STM32F4 USB Keyboard](https://github.com/embassy-rs/embassy/blob/main/examples/stm32f4/src/bin/usb_hid_keyboard.rs)
+//! - [STM32F4 USB Mouse](https://github.com/embassy-rs/embassy/blob/main/examples/stm32f4/src/bin/usb_hid_mouse.rs)
 
 #[cfg_attr(usb, path = "usb.rs")]
 #[cfg_attr(otg, path = "otg.rs")]

--- a/embassy-stm32/src/wdg/mod.rs
+++ b/embassy-stm32/src/wdg/mod.rs
@@ -1,4 +1,8 @@
 //! Watchdog Timer (IWDG, WWDG)
+//!
+//! ## Examples
+//!
+//! [STM32F0](https://github.com/embassy-rs/embassy/blob/main/examples/stm32f0/src/bin/wdg.rs)
 use core::marker::PhantomData;
 
 use embassy_hal_internal::{into_ref, Peripheral};


### PR DESCRIPTION
I think some references in the docs itself to the examples would be extremely useful. This is a first attempt for embassy-stm32. There are a lot of examples, so I always used STM32F4 for now, which seems to contain the most examples.