### PR TITLE
convert embassy-stm32::qspi::enums `Into` impls into equivalant `From` impls

### DIFF
--- a/embassy-stm32/src/qspi/enums.rs
+++ b/embassy-stm32/src/qspi/enums.rs
@@ -9,9 +9,9 @@ pub(crate) enum QspiMode {
     MemoryMapped,
 }
 
-impl Into<u8> for QspiMode {
-    fn into(self) -> u8 {
-        match self {
+impl From<QspiMode> for u8 {
+    fn from(val: QspiMode) -> Self {
+        match val {
             QspiMode::IndirectWrite => 0b00,
             QspiMode::IndirectRead => 0b01,
             QspiMode::AutoPolling => 0b10,
@@ -34,9 +34,9 @@ pub enum QspiWidth {
     QUAD,
 }
 
-impl Into<u8> for QspiWidth {
-    fn into(self) -> u8 {
-        match self {
+impl From<QspiWidth> for u8 {
+    fn from(val: QspiWidth) -> Self {
+        match val {
             QspiWidth::NONE => 0b00,
             QspiWidth::SING => 0b01,
             QspiWidth::DUAL => 0b10,
@@ -55,9 +55,9 @@ pub enum FlashSelection {
     Flash2,
 }
 
-impl Into<bool> for FlashSelection {
-    fn into(self) -> bool {
-        match self {
+impl From<FlashSelection> for bool {
+    fn from(val: FlashSelection) -> Self {
+        match val {
             FlashSelection::Flash1 => false,
             FlashSelection::Flash2 => true,
         }
@@ -94,9 +94,9 @@ pub enum MemorySize {
     Other(u8),
 }
 
-impl Into<u8> for MemorySize {
-    fn into(self) -> u8 {
-        match self {
+impl From<MemorySize> for u8 {
+    fn from(val: MemorySize) -> Self {
+        match val {
             MemorySize::_1KiB => 9,
             MemorySize::_2KiB => 10,
             MemorySize::_4KiB => 11,
@@ -138,9 +138,9 @@ pub enum AddressSize {
     _32bit,
 }
 
-impl Into<u8> for AddressSize {
-    fn into(self) -> u8 {
-        match self {
+impl From<AddressSize> for u8 {
+    fn from(val: AddressSize) -> Self {
+        match val {
             AddressSize::_8Bit => 0b00,
             AddressSize::_16Bit => 0b01,
             AddressSize::_24bit => 0b10,
@@ -163,9 +163,9 @@ pub enum ChipSelectHighTime {
     _8Cycle,
 }
 
-impl Into<u8> for ChipSelectHighTime {
-    fn into(self) -> u8 {
-        match self {
+impl From<ChipSelectHighTime> for u8 {
+    fn from(val: ChipSelectHighTime) -> Self {
+        match val {
             ChipSelectHighTime::_1Cycle => 0,
             ChipSelectHighTime::_2Cycle => 1,
             ChipSelectHighTime::_3Cycle => 2,
@@ -216,9 +216,9 @@ pub enum FIFOThresholdLevel {
     _32Bytes,
 }
 
-impl Into<u8> for FIFOThresholdLevel {
-    fn into(self) -> u8 {
-        match self {
+impl From<FIFOThresholdLevel> for u8 {
+    fn from(val: FIFOThresholdLevel) -> Self {
+        match val {
             FIFOThresholdLevel::_1Bytes => 0,
             FIFOThresholdLevel::_2Bytes => 1,
             FIFOThresholdLevel::_3Bytes => 2,
@@ -293,9 +293,9 @@ pub enum DummyCycles {
     _31,
 }
 
-impl Into<u8> for DummyCycles {
-    fn into(self) -> u8 {
-        match self {
+impl From<DummyCycles> for u8 {
+    fn from(val: DummyCycles) -> Self {
+        match val {
             DummyCycles::_0 => 0,
             DummyCycles::_1 => 1,
             DummyCycles::_2 => 2,


### PR DESCRIPTION
Convert manual `Into` impls in `embassy-stm32::qspi::enums` into equivalent `From` impls