### PR TITLE
prepare release for `embassy-rp` & dependencies

### DIFF
--- a/embassy-embedded-hal/CHANGELOG.md
+++ b/embassy-embedded-hal/CHANGELOG.md
@@ -5,7 +5,8 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## Unreleased
+<!-- next-header -->
+## Unreleased - ReleaseDate
 
 - `SpiDevice` cancel safety: always set CS pin to high on drop
 - Update `embassy-sync` to v0.7.0

--- a/embassy-embedded-hal/CHANGELOG.md
+++ b/embassy-embedded-hal/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+- `SpiDevice` cancel safety: always set CS pin to high on drop
+- Update `embassy-sync` to v0.7.0
+
 ## 0.3.0 - 2025-01-05
 
 - The `std` feature has been removed

--- a/embassy-embedded-hal/release.toml
+++ b/embassy-embedded-hal/release.toml
@@ -1,0 +1,5 @@
+pre-release-replacements = [
+    {file="CHANGELOG.md", search="Unreleased", replace="{{version}}", min=1},
+    {file="CHANGELOG.md", search="ReleaseDate", replace="{{date}}", min=1},
+    {file="CHANGELOG.md", search="<!-- next-header -->", replace="<!-- next-header -->\n## Unreleased - ReleaseDate\n", exactly=1},
+]

--- a/embassy-executor/CHANGELOG.md
+++ b/embassy-executor/CHANGELOG.md
@@ -7,7 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## unreleased
 
+- Added `SpawnToken::id`
+- Task pools are now statically allocated on stable rust. All `task-arena-size-*` features have been removed and are no longer necessary.
+- New trace hooks: `_embassy_trace_poll_start` & `_embassy_trace_task_end`
+- Added task naming capability to tracing infrastructure
+- Added `Executor::id` & `Spawner::executor_id`
+- Disable `critical-section/std` for arch-std
+- Added possibility to select an executor in `#[embassy_executor::main]`
+- Fix AVR executor
+- executor: Make state implementations and their conditions match
 - Added support for Cortex-A and Cortex-R
+- Added support for `-> impl Future<Output = ()>` in `#[task]`
+- Fixed `Send` unsoundness with `-> impl Future` tasks
+- Marked `Spawner::for_current_executor` as `unsafe`
 
 ## 0.7.0 - 2025-01-02
 

--- a/embassy-executor/CHANGELOG.md
+++ b/embassy-executor/CHANGELOG.md
@@ -5,7 +5,8 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## unreleased
+<!-- next-header -->
+## Unreleased - ReleaseDate
 
 - Added `SpawnToken::id`
 - Task pools are now statically allocated on stable rust. All `task-arena-size-*` features have been removed and are no longer necessary.

--- a/embassy-executor/release.toml
+++ b/embassy-executor/release.toml
@@ -1,0 +1,5 @@
+pre-release-replacements = [
+    {file="CHANGELOG.md", search="Unreleased", replace="{{version}}", min=1},
+    {file="CHANGELOG.md", search="ReleaseDate", replace="{{date}}", min=1},
+    {file="CHANGELOG.md", search="<!-- next-header -->", replace="<!-- next-header -->\n## Unreleased - ReleaseDate\n", exactly=1},
+]

--- a/embassy-futures/CHANGELOG.md
+++ b/embassy-futures/CHANGELOG.md
@@ -1,0 +1,13 @@
+# Changelog for embassy-futures
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## Unreleased
+
+- Preserve location information for `defmt` in `fmt` calls ([#3085](https://github.com/embassy-rs/embassy/pull/3085))
+- Fixed soundness issue in `select_slice` ([#3328](https://github.com/embassy-rs/embassy/pull/3328))
+- Added `select5` and `select6` ([#3430](https://github.com/embassy-rs/embassy/pull/3430))
+- Added `is_x` methods for all `EitherN` enum variants (#[3650](https://github.com/embassy-rs/embassy/pull/3650))

--- a/embassy-futures/CHANGELOG.md
+++ b/embassy-futures/CHANGELOG.md
@@ -5,7 +5,8 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## Unreleased
+<!-- next-header -->
+## Unreleased - ReleaseDate
 
 - Preserve location information for `defmt` in `fmt` calls ([#3085](https://github.com/embassy-rs/embassy/pull/3085))
 - Fixed soundness issue in `select_slice` ([#3328](https://github.com/embassy-rs/embassy/pull/3328))

--- a/embassy-futures/release.toml
+++ b/embassy-futures/release.toml
@@ -1,0 +1,5 @@
+pre-release-replacements = [
+    {file="CHANGELOG.md", search="Unreleased", replace="{{version}}", min=1},
+    {file="CHANGELOG.md", search="ReleaseDate", replace="{{date}}", min=1},
+    {file="CHANGELOG.md", search="<!-- next-header -->", replace="<!-- next-header -->\n## Unreleased - ReleaseDate\n", exactly=1},
+]

--- a/embassy-net-driver-channel/CHANGELOG.md
+++ b/embassy-net-driver-channel/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+- Update `embassy-sync` to v0.7.0
+
 ## 0.3.0 - 2024-08-05
 
 - Add collapse_debuginfo to fmt.rs macros.

--- a/embassy-net-driver-channel/CHANGELOG.md
+++ b/embassy-net-driver-channel/CHANGELOG.md
@@ -5,7 +5,8 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## Unreleased
+<!-- next-header -->
+## Unreleased - ReleaseDate
 
 - Update `embassy-sync` to v0.7.0
 

--- a/embassy-net-driver-channel/release.toml
+++ b/embassy-net-driver-channel/release.toml
@@ -1,0 +1,5 @@
+pre-release-replacements = [
+    {file="CHANGELOG.md", search="Unreleased", replace="{{version}}", min=1},
+    {file="CHANGELOG.md", search="ReleaseDate", replace="{{date}}", min=1},
+    {file="CHANGELOG.md", search="<!-- next-header -->", replace="<!-- next-header -->\n## Unreleased - ReleaseDate\n", exactly=1},
+]

--- a/embassy-rp/CHANGELOG.md
+++ b/embassy-rp/CHANGELOG.md
@@ -5,7 +5,8 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## Unreleased
+<!-- next-header -->
+## Unreleased - ReleaseDate
 
 - Fix wrong `funcsel` on RP2350 gpout/gpin ([#3975](https://github.com/embassy-rs/embassy/pull/3975))
 - Fix potential race condition in `ADC::wait_for_ready` ([#4012](https://github.com/embassy-rs/embassy/pull/4012))

--- a/embassy-rp/CHANGELOG.md
+++ b/embassy-rp/CHANGELOG.md
@@ -7,6 +7,32 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+- Fix wrong `funcsel` on RP2350 gpout/gpin ([#3975](https://github.com/embassy-rs/embassy/pull/3975))
+- Fix potential race condition in `ADC::wait_for_ready` ([#4012](https://github.com/embassy-rs/embassy/pull/4012))
+- `flash`: rename `BOOTROM_BASE` to `BOOTRAM_BASE` ([#4014](https://github.com/embassy-rs/embassy/pull/4014))
+- Remove `Peripheral` trait & rename `PeripheralRef` to `Peri` ([#3999](https://github.com/embassy-rs/embassy/pull/3999))
+- Fix watchdog count on RP235x ([#4021](https://github.com/embassy-rs/embassy/pull/4021))
+- I2C: ensure that wakers are registered before checking status of `wait_on` helpers ([#4043](https://github.com/embassy-rs/embassy/pull/4043))
+- Modify `Uarte` and `BufferedUarte` initialization to take pins before interrupts ([#3983](https://github.com/embassy-rs/embassy/pull/3983))
+- `uart`: increase RX FIFO watermark from 1/8 to 7/8 ([#4055](https://github.com/embassy-rs/embassy/pull/4055))
+- Add `spinlock_mutex` ([#4017](https://github.com/embassy-rs/embassy/pull/4017))
+- Enable input mode for PWM pins on RP235x and disable it on drop ([#4093](https://github.com/embassy-rs/embassy/pull/4093))
+- Add `impl rand_core::CryptoRng for Trng` ([#4096](https://github.com/embassy-rs/embassy/pull/4096))
+- `pwm`: enable pull-down resistors for pins in `Drop` implementation ([#4115](https://github.com/embassy-rs/embassy/pull/4115))
+- Rewrite PIO onewire implementation ([#4128](https://github.com/embassy-rs/embassy/pull/4128))
+- Implement RP2040 overclocking ([#4150](https://github.com/embassy-rs/embassy/pull/4150))
+- Implement RP235x overclocking ([#4187](https://github.com/embassy-rs/embassy/pull/4187))
+- `trng`: improve error handling ([#4139](https://github.com/embassy-rs/embassy/pull/4139))
+- Remove `<T: Instance>` from `Uart` and `BufferedUart` ([#4155](https://github.com/embassy-rs/embassy/pull/4155))
+- Make bit-depth of I2S PIO program configurable ([#4193](https://github.com/embassy-rs/embassy/pull/4193))
+- Add the possibility to document `bind_interrupts` `struct`s ([#4206](https://github.com/embassy-rs/embassy/pull/4206))
+- Add missing `Debug` and `defmt::Format` `derive`s for ADC & `AnyPin` ([#4205](https://github.com/embassy-rs/embassy/pull/4205))
+- Add `rand-core` v0.9 support ([#4217](https://github.com/embassy-rs/embassy/pull/4217))
+- Update `embassy-sync` to v0.7.0 ([#4234](https://github.com/embassy-rs/embassy/pull/4234))
+- Add compatibility with ws2812 leds that have 4 addressable lights ([#4236](https://github.com/embassy-rs/embassy/pull/4236))
+- Implement input/output inversion ([#4237](https://github.com/embassy-rs/embassy/pull/4237))
+- Add `multicore::current_core` API ([#4362](https://github.com/embassy-rs/embassy/pull/4362))
+
 ## 0.4.0 - 2025-03-09
 
 - Add PIO functions. ([#3857](https://github.com/embassy-rs/embassy/pull/3857))  

--- a/embassy-rp/release.toml
+++ b/embassy-rp/release.toml
@@ -1,0 +1,5 @@
+pre-release-replacements = [
+    {file="CHANGELOG.md", search="Unreleased", replace="{{version}}", min=1},
+    {file="CHANGELOG.md", search="ReleaseDate", replace="{{date}}", min=1},
+    {file="CHANGELOG.md", search="<!-- next-header -->", replace="<!-- next-header -->\n## Unreleased - ReleaseDate\n", exactly=1},
+]

--- a/embassy-time-driver/CHANGELOG.md
+++ b/embassy-time-driver/CHANGELOG.md
@@ -5,7 +5,8 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## Unreleased
+<!-- next-header -->
+## Unreleased - ReleaseDate
 
 - Allow inlining on time driver boundary
 - add 133MHz tick rate to support PR2040 @ 133MHz when `TIMERx`'s `SOURCE` is set to `SYSCLK`

--- a/embassy-time-driver/CHANGELOG.md
+++ b/embassy-time-driver/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+- Allow inlining on time driver boundary
+- add 133MHz tick rate to support PR2040 @ 133MHz when `TIMERx`'s `SOURCE` is set to `SYSCLK`
+
 ## 0.2.0 - 2025-01-02
 
 - The `allocate_alarm`, `set_alarm_callback`, `set_alarm` functions have been removed.

--- a/embassy-time-driver/release.toml
+++ b/embassy-time-driver/release.toml
@@ -1,0 +1,5 @@
+pre-release-replacements = [
+    {file="CHANGELOG.md", search="Unreleased", replace="{{version}}", min=1},
+    {file="CHANGELOG.md", search="ReleaseDate", replace="{{date}}", min=1},
+    {file="CHANGELOG.md", search="<!-- next-header -->", replace="<!-- next-header -->\n## Unreleased - ReleaseDate\n", exactly=1},
+]

--- a/embassy-time/CHANGELOG.md
+++ b/embassy-time/CHANGELOG.md
@@ -5,7 +5,8 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## Unreleased
+<!-- next-header -->
+## Unreleased - ReleaseDate
 
 - Allow inlining on time driver boundary
 - Add `saturating_add` and `saturating_sub` to `Instant`

--- a/embassy-time/CHANGELOG.md
+++ b/embassy-time/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+- Allow inlining on time driver boundary
+- Add `saturating_add` and `saturating_sub` to `Instant`
+- Add `Instant::try_from_*` constructor functions
+- Add `Duration::try_from_*` constructor functions
+- Don't select `critical-section` impl for `std`
+- Manually implement the future for `with_timeout`
+- Add 133MHz tick rate to support PR2040 @ 133MHz when `TIMERx`'s `SOURCE` is set to `SYSCLK`
+
 ## 0.4.0 - 2025-01-02
 
 - `embassy-time-driver` updated from v0.1 to v0.2.

--- a/embassy-time/release.toml
+++ b/embassy-time/release.toml
@@ -1,0 +1,5 @@
+pre-release-replacements = [
+    {file="CHANGELOG.md", search="Unreleased", replace="{{version}}", min=1},
+    {file="CHANGELOG.md", search="ReleaseDate", replace="{{date}}", min=1},
+    {file="CHANGELOG.md", search="<!-- next-header -->", replace="<!-- next-header -->\n## Unreleased - ReleaseDate\n", exactly=1},
+]

--- a/embassy-usb-driver/CHANGELOG.md
+++ b/embassy-usb-driver/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## Unreleased
+<!-- next-header -->
+## Unreleased - ReleaseDate
 
 - Add `embedded_io_async::Error` implementation for `EndpointError` ([#4176](https://github.com/embassy-rs/embassy/pull/4176))

--- a/embassy-usb-driver/CHANGELOG.md
+++ b/embassy-usb-driver/CHANGELOG.md
@@ -1,0 +1,10 @@
+# Changelog for embassy-usb-driver
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## Unreleased
+
+- Add `embedded_io_async::Error` implementation for `EndpointError` ([#4176](https://github.com/embassy-rs/embassy/pull/4176))

--- a/embassy-usb-driver/release.toml
+++ b/embassy-usb-driver/release.toml
@@ -1,0 +1,5 @@
+pre-release-replacements = [
+    {file="CHANGELOG.md", search="Unreleased", replace="{{version}}", min=1},
+    {file="CHANGELOG.md", search="ReleaseDate", replace="{{date}}", min=1},
+    {file="CHANGELOG.md", search="<!-- next-header -->", replace="<!-- next-header -->\n## Unreleased - ReleaseDate\n", exactly=1},
+]

--- a/embassy-usb/CHANGELOG.md
+++ b/embassy-usb/CHANGELOG.md
@@ -5,7 +5,8 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## Unreleased
+<!-- next-header -->
+## Unreleased - ReleaseDate
 
 - `UAC1`: unmute by default ([#3992](https://github.com/embassy-rs/embassy/pull/3992))
 - `cdc_acm`: `State::new` is now `const` ([#4000](https://github.com/embassy-rs/embassy/pull/4000))

--- a/embassy-usb/CHANGELOG.md
+++ b/embassy-usb/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+- `UAC1`: unmute by default ([#3992](https://github.com/embassy-rs/embassy/pull/3992))
+- `cdc_acm`: `State::new` is now `const` ([#4000](https://github.com/embassy-rs/embassy/pull/4000))
+- Add support for CMSIS-DAP v2 USB class ([#4107](https://github.com/embassy-rs/embassy/pull/4107))
+- Reduce `UsbDevice` builder logs to `trace` ([#4130](https://github.com/embassy-rs/embassy/pull/4130))
+- Implement `embedded-io-async` traits for USB CDC ACM ([#4176](https://github.com/embassy-rs/embassy/pull/4176))
+- Update `embassy-sync` to v0.7.0
+
 ## 0.4.0 - 2025-01-15
 
 - Change config defaults to to composite with IADs. This ensures embassy-usb Just Works in more cases when using classes with multiple interfaces, or multiple classes. (breaking change)

--- a/embassy-usb/release.toml
+++ b/embassy-usb/release.toml
@@ -1,0 +1,5 @@
+pre-release-replacements = [
+    {file="CHANGELOG.md", search="Unreleased", replace="{{version}}", min=1},
+    {file="CHANGELOG.md", search="ReleaseDate", replace="{{date}}", min=1},
+    {file="CHANGELOG.md", search="<!-- next-header -->", replace="<!-- next-header -->\n## Unreleased - ReleaseDate\n", exactly=1},
+]

--- a/release/bump-dependency.sh
+++ b/release/bump-dependency.sh
@@ -8,4 +8,4 @@
 #
 CRATE=$1
 TARGET_VER=$2
-find . -name "Cargo.toml" | xargs sed -rie "s/($CRATE = \{.*version = \")[0-9]+.[0-9]+.?[0-9]*(\".*)/\1$TARGET_VER\2/g"
+find . -name "Cargo.toml" | xargs sed -ri "s/($CRATE = \{.*version = \")[0-9]+.[0-9]+.?[0-9]*(\".*)/\1$TARGET_VER\2/g"


### PR DESCRIPTION
see the individual commit messages for further details.

what this PR does for the affected crates:
* it adds changelog entries for the new releases
* it adds release automation using [`cargo-release`](https://crates.io/crates/cargo-release)
* it fixes `release/bump-dependency.sh` (inadvertently created backup files, leading to lots of untracked files)

what this PR does *not* do:
* it does *not* run `release/bump-dependency.sh` for the crates (should only be done after the release of each crate)
* it does *not* enter a version number or release date in `CHANGELOG.md` (now taken care of by `cargo-release`)
* it does *not* prepare a new release for `embassy-sync`: while there were already new commits again there was just a release a few days ago so it's probably not yet needed?
* it does *not* add `cargo-release` setup for any other embassy crates. i'm floating this here as a test balloon

suggested flow of this PR for reviewers with commit access to the repo & release rights on crates.io:
1. review & merge the PR
2. install `cargo-release` (`cargo binstall cargo-release`)
3. run the following steps from latest `main` (after the merge) in a clean repo:

```bash
pushd embassy-futures
cargo release patch --execute
popd
# no need for this since it's just a patch: ./release/bump-dependency.sh embassy-futures 0.1.2
# if you do it anyway you should also do this: git commit -am 'update to `embassy-usb` v0.1.2'

pushd embassy-usb-driver
cargo release patch --execute
popd
# no need for this since it's just a patch: ./release/bump-dependency.sh embassy-usb-driver 0.1.1
# if you do it anyway you should also do this: git commit -am 'update to `embassy-usb-driver` v0.1.1'

pushd embassy-net-driver-channel
cargo release minor --execute # or possibly also patch if `embassy-sync` has no impact on the public API & cross-crate compatibility?
popd
./release/bump-dependency.sh embassy-net-driver-channel 0.4.0
git commit -am 'update to `embassy-net-driver-channel` v0.4.0'

# no commit for this in this PR since it has no changelog
pushd embassy-hal-internal
cargo release minor --execute
popd
./release/bump-dependency.sh embassy-hal-internal 0.3.0
git commit -am 'update to `embassy-hal-internal` v0.3.0'

pushd embassy-executor-macros
cargo release minor --execute
popd
./release/bump-dependency.sh embassy-executor-macros 0.7.0
git commit -am 'update to `embassy-executor-macros` v0.7.0'

pushd embassy-executor
cargo release minor --execute
popd
./release/bump-dependency.sh embassy-executor 0.8.0
git commit -am 'update to `embassy-executor` v0.8.0'

pushd embassy-time-driver
cargo release patch --execute
popd
# no need for this since it's just a patch: ./release/bump-dependency.sh embassy-time-driver 0.2.1
# if you do it anyway you should also do this: git commit -am 'update to `embassy-time-driver` v0.2.1'

pushd embassy-time
cargo release patch --execute
popd
# no need for this since it's just a patch: ./release/bump-dependency.sh embassy-time 0.4.1
# if you do it anyway you should also do this: git commit -am 'update to `embassy-time` v0.4.1'

pushd embassy-embedded-hal
cargo release patch --execute
popd
./release/bump-dependency.sh embassy-embedded-hal 0.4.0
git commit -am 'update to `embassy-embedded-hal` v0.4.0'

pushd embassy-rp
cargo release minor --execute
popd
./release/bump-dependency.sh embassy-rp 0.5.0
git commit -am 'update to `embassy-executor-macros` v0.5.0'

git push --tags # push all version commits & tags
```