### PR TITLE
Generate pins for all opamp pin naming schemes

### DIFF
--- a/embassy-stm32/Cargo.toml
+++ b/embassy-stm32/Cargo.toml
@@ -81,7 +81,7 @@ futures-util = { version = "0.3.30", default-features = false }
 sdio-host = "0.9.0"
 critical-section = "1.1"
 #stm32-metapac = { version = "16" }
-stm32-metapac = { git = "https://github.com/embassy-rs/stm32-data-generated", tag = "stm32-data-27ef8fba3483187e852eaf3796d827259f61e8ec" }
+stm32-metapac = { git = "https://github.com/embassy-rs/stm32-data-generated", tag = "stm32-data-778e3d102186ebb12a8c8b60b7cafdd15858bab3" }
 
 vcell = "0.1.3"
 nb = "1.0.0"
@@ -110,7 +110,7 @@ proc-macro2 = "1.0.36"
 quote = "1.0.15"
 
 #stm32-metapac = { version = "16", default-features = false, features = ["metadata"]}
-stm32-metapac = { git = "https://github.com/embassy-rs/stm32-data-generated", tag = "stm32-data-27ef8fba3483187e852eaf3796d827259f61e8ec", default-features = false, features = ["metadata"] }
+stm32-metapac = { git = "https://github.com/embassy-rs/stm32-data-generated", tag = "stm32-data-778e3d102186ebb12a8c8b60b7cafdd15858bab3", default-features = false, features = ["metadata"] }
 
 [features]
 default = ["rt"]

--- a/embassy-stm32/build.rs
+++ b/embassy-stm32/build.rs
@@ -1402,31 +1402,30 @@ fn main() {
                 }
 
                 if regs.kind == "opamp" {
-                    if pin.signal.starts_with("VP") {
-                        // Impl NonInvertingPin for the VP* signals (VP0, VP1, VP2, etc)
-                        let peri = format_ident!("{}", p.name);
-                        let pin_name = format_ident!("{}", pin.pin);
-                        let ch: u8 = pin.signal.strip_prefix("VP").unwrap().parse().unwrap();
-
+                    let peri = format_ident!("{}", p.name);
+                    let pin_name = format_ident!("{}", pin.pin);
+                    if let Some(ch_str) = pin
+                        .signal
+                        .strip_prefix("VP")
+                        .or_else(|| pin.signal.strip_prefix("VINP"))
+                    {
+                        // Impl NonInvertingPin for VP, VP0, VP1 etc. or VINP, VINP0, VINP1 etc.
+                        let ch = ch_str.parse::<u8>().unwrap_or(0);
                         g.extend(quote! {
-                            impl_opamp_vp_pin!( #peri, #pin_name, #ch);
-                        })
-                    } else if pin.signal.starts_with("VINM") {
-                        // Impl NonInvertingPin for the VINM* signals ( VINM0, VINM1, etc)
-                        // STM32G4
-                        let peri = format_ident!("{}", p.name);
-                        let pin_name = format_ident!("{}", pin.pin);
-                        let ch: Result<u8, _> = pin.signal.strip_prefix("VINM").unwrap().parse();
-
-                        if let Ok(ch) = ch {
-                            g.extend(quote! {
-                                impl_opamp_vn_pin!( #peri, #pin_name, #ch);
-                            })
-                        }
+                            impl_opamp_vp_pin!( #peri, #pin_name, #ch );
+                        });
+                    } else if let Some(ch_str) = pin
+                        .signal
+                        .strip_prefix("VM")
+                        .or_else(|| pin.signal.strip_prefix("VINM"))
+                    {
+                        // Impl InvertingPin for VM, VM0, VM1 etc. or VINM, VINM0, VINM1 etc.
+                        let ch = ch_str.parse::<u8>().unwrap_or(0);
+                        g.extend(quote! {
+                            impl_opamp_vn_pin!( #peri, #pin_name, #ch);
+                        });
                     } else if pin.signal == "VOUT" {
                         // Impl OutputPin for the VOUT pin
-                        let peri = format_ident!("{}", p.name);
-                        let pin_name = format_ident!("{}", pin.pin);
                         g.extend(quote! {
                             impl_opamp_vout_pin!( #peri, #pin_name );
                         })


### PR DESCRIPTION
The new code implements the corresponding traits for the opamp pin naming schemes of all families, which are
VP/VM/VINP/VINM/VPx/VMx/VINPx/VINMx.

The same pin must not be used for multiple channels for the same opamp. For example, if VINM0 and VINM1 of the same opamp were assigned to the same pin, the channel would not be unique, meaning that the traits would be implemented in a conflicting manner. This also applies to VP/VM/VINP/VINM, which are interpreted as channel 0.