### PR TITLE
Embassy RP: RP235x Fix MPU region enablement in stack guard installation

### DIFF
--- a/embassy-rp/src/lib.rs
+++ b/embassy-rp/src/lib.rs
@@ -567,7 +567,7 @@ unsafe fn install_stack_guard(stack_bottom: *mut usize) -> Result<(), ()> {
     unsafe {
         core.MPU.ctrl.write(5); // enable mpu with background default map
         core.MPU.rbar.write(stack_bottom as u32 & !0xff); // set address
-        core.MPU.rlar.write(1); // enable region
+        core.MPU.rlar.write(((stack_bottom as usize + 255) as u32) | 1);
     }
     Ok(())
 }


### PR DESCRIPTION
Updated the MPU region enablement logic in the `install_stack_guard` function to correctly set the region limit by using the stack bottom address plus 256 minus one, ensuring proper memory protection configuration.

- See Table 235 MPU_RLAR Register in [RP2350 documentation](https://datasheets.raspberrypi.com/rp2350/rp2350-datasheet.pdf) (Page 195)
- See Section 4.5 MPU_RLAR in [armv8m MPU documentation](https://www.scribd.com/document/414130259/Armv8m-Architecture-Memory-Protection-Unit-100699-0100-00-En) (Page 4-33)