### PR TITLE
feat(embassy-executor): add rtos-trace-all-tasks feature flag

### DIFF
--- a/embassy-executor/Cargo.toml
+++ b/embassy-executor/Cargo.toml
@@ -95,8 +95,10 @@ executor-thread = []
 executor-interrupt = []
 ## Enable tracing support (adds some overhead)
 trace = []
-## Enable support for rtos-trace framework
+## Enable support for rtos-trace framework (named tasks only by default)
 rtos-trace = ["dep:rtos-trace", "trace", "dep:embassy-time-driver"]
+## Include all tasks in tracing (not just the named ones)
+rtos-trace-all-tasks = ["rtos-trace"]
 
 #! ### Timer Item Payload Size
 #! Sets the size of the payload for timer items, allowing integrated timer implementors to store


### PR DESCRIPTION
Add a new feature flag `rtos-trace-all-tasks` that enables tracing of all tasks when using rtos-trace, not just named tasks. By default, rtos-trace only traces tasks that have been given explicit names. This new flag allows developers to trace anonymous tasks as well, which can be useful for debugging and profiling.

The implementation adds a `should_trace_task()` helper function that checks whether a task should be traced based on the enabled features. When `rtos-trace-all-tasks` is enabled, all tasks are traced. Otherwise, only named tasks are traced (preserving the existing behavior).

This change maintains backward compatibility - the default behavior remains unchanged unless the new feature flag is explicitly enabled.