### PR TITLE
add selective tracing support to SpawnerTraceExt

### DIFF
--- a/embassy-executor/Cargo.toml
+++ b/embassy-executor/Cargo.toml
@@ -95,8 +95,10 @@ executor-thread = []
 executor-interrupt = []
 ## Enable tracing support (adds some overhead)
 trace = []
-## Enable support for rtos-trace framework
+## Enable support for rtos-trace framework (traces all tasks by default)
 rtos-trace = ["dep:rtos-trace", "trace", "dep:embassy-time-driver"]
+## Only trace tasks that are explicitly marked for tracing (selective mode)
+rtos-trace-selective = ["rtos-trace"]
 
 #! ### Timer Item Payload Size
 #! Sets the size of the payload for timer items, allowing integrated timer implementors to store

--- a/embassy-executor/Cargo.toml
+++ b/embassy-executor/Cargo.toml
@@ -95,10 +95,12 @@ executor-thread = []
 executor-interrupt = []
 ## Enable tracing support (adds some overhead)
 trace = []
+## Enable selective tracing support
+trace-mode-selective = ["trace"]
 ## Enable support for rtos-trace framework (traces all tasks by default)
 rtos-trace = ["dep:rtos-trace", "trace", "dep:embassy-time-driver"]
 ## Only trace tasks that are explicitly marked for tracing (selective mode)
-rtos-trace-selective = ["rtos-trace"]
+rtos-trace-selective = ["rtos-trace", "trace-mode-selective"]
 
 #! ### Timer Item Payload Size
 #! Sets the size of the payload for timer items, allowing integrated timer implementors to store

--- a/embassy-executor/src/raw/mod.rs
+++ b/embassy-executor/src/raw/mod.rs
@@ -94,6 +94,8 @@ pub(crate) struct TaskHeader {
     #[cfg(feature = "trace")]
     pub(crate) id: u32,
     #[cfg(feature = "trace")]
+    pub(crate) trace_excluded: bool,
+    #[cfg(feature = "trace")]
     all_tasks_next: AtomicPtr<TaskHeader>,
 }
 
@@ -194,6 +196,8 @@ impl<F: Future + 'static> TaskStorage<F> {
                 name: None,
                 #[cfg(feature = "trace")]
                 id: 0,
+                #[cfg(feature = "trace")]
+                trace_excluded: cfg!(feature = "rtos-trace-selective"),
                 #[cfg(feature = "trace")]
                 all_tasks_next: AtomicPtr::new(core::ptr::null_mut()),
             },

--- a/embassy-executor/src/raw/mod.rs
+++ b/embassy-executor/src/raw/mod.rs
@@ -93,7 +93,7 @@ pub(crate) struct TaskHeader {
     pub(crate) name: Option<&'static str>,
     #[cfg(feature = "trace")]
     pub(crate) id: u32,
-    #[cfg(feature = "trace")]
+    #[cfg(feature = "trace-mode-selective")]
     pub(crate) trace_excluded: bool,
     #[cfg(feature = "trace")]
     all_tasks_next: AtomicPtr<TaskHeader>,
@@ -196,7 +196,7 @@ impl<F: Future + 'static> TaskStorage<F> {
                 name: None,
                 #[cfg(feature = "trace")]
                 id: 0,
-                #[cfg(feature = "trace")]
+                #[cfg(feature = "trace-mode-selective")]
                 trace_excluded: cfg!(feature = "rtos-trace-selective"),
                 #[cfg(feature = "trace")]
                 all_tasks_next: AtomicPtr::new(core::ptr::null_mut()),

--- a/embassy-executor/src/raw/trace.rs
+++ b/embassy-executor/src/raw/trace.rs
@@ -181,6 +181,12 @@ pub trait TaskRefTrace {
 
     /// Set the ID for a task
     fn set_id(&self, id: u32);
+
+    /// Check if a task is excluded from tracing
+    fn is_trace_excluded(&self) -> bool;
+
+    /// Set whether a task should be excluded from tracing
+    fn set_trace_excluded(&self, excluded: bool);
 }
 
 impl TaskRefTrace for TaskRef {
@@ -204,6 +210,41 @@ impl TaskRefTrace for TaskRef {
             let header_ptr = self.ptr.as_ptr() as *mut TaskHeader;
             (*header_ptr).id = id;
         }
+    }
+
+    fn is_trace_excluded(&self) -> bool {
+        self.header().trace_excluded
+    }
+
+    fn set_trace_excluded(&self, excluded: bool) {
+        unsafe {
+            let header_ptr = self.ptr.as_ptr() as *mut TaskHeader;
+            (*header_ptr).trace_excluded = excluded;
+        }
+    }
+}
+
+/// Helper function to determine if a task should be traced
+///
+/// This function supports two tracing modes based on feature flags:
+/// - `rtos-trace-selective`: Only trace tasks that are explicitly enabled for tracing
+/// - Default `rtos-trace`: Trace all tasks by default
+#[inline]
+fn should_trace_task(task: &TaskRef) -> bool {
+    #[cfg(feature = "rtos-trace-selective")]
+    {
+        // Only trace tasks that are explicitly enabled for tracing
+        !task.is_trace_excluded()
+    }
+    #[cfg(all(feature = "rtos-trace", not(feature = "rtos-trace-selective")))]
+    {
+        let _ = task; // Suppress unused parameter warning
+        true // Trace all tasks when rtos-trace feature is enabled without selective mode
+    }
+    #[cfg(not(feature = "rtos-trace"))]
+    {
+        let _ = task; // Suppress unused parameter warning
+        false // No tracing when rtos-trace is not enabled
     }
 }
 
@@ -283,10 +324,10 @@ pub(crate) fn task_new(executor: &SyncExecutor, task: &TaskRef) {
     }
 
     #[cfg(feature = "rtos-trace")]
-    rtos_trace::trace::task_new(task.as_ptr() as u32);
-
-    #[cfg(feature = "rtos-trace")]
-    TASK_TRACKER.add(*task);
+    if should_trace_task(task) {
+        rtos_trace::trace::task_new(task.as_ptr() as u32);
+        TASK_TRACKER.add(*task);
+    }
 }
 
 #[inline]
@@ -304,7 +345,9 @@ pub(crate) fn task_ready_begin(executor: &SyncExecutor, task: &TaskRef) {
         _embassy_trace_task_ready_begin(executor as *const _ as u32, task.as_ptr() as u32)
     }
     #[cfg(feature = "rtos-trace")]
-    rtos_trace::trace::task_ready_begin(task.as_ptr() as u32);
+    if should_trace_task(task) {
+        rtos_trace::trace::task_ready_begin(task.as_ptr() as u32);
+    }
 }
 
 #[inline]
@@ -314,7 +357,9 @@ pub(crate) fn task_exec_begin(executor: &SyncExecutor, task: &TaskRef) {
         _embassy_trace_task_exec_begin(executor as *const _ as u32, task.as_ptr() as u32)
     }
     #[cfg(feature = "rtos-trace")]
-    rtos_trace::trace::task_exec_begin(task.as_ptr() as u32);
+    if should_trace_task(task) {
+        rtos_trace::trace::task_exec_begin(task.as_ptr() as u32);
+    }
 }
 
 #[inline]
@@ -324,7 +369,9 @@ pub(crate) fn task_exec_end(executor: &SyncExecutor, task: &TaskRef) {
         _embassy_trace_task_exec_end(executor as *const _ as u32, task.as_ptr() as u32)
     }
     #[cfg(feature = "rtos-trace")]
-    rtos_trace::trace::task_exec_end();
+    if should_trace_task(task) {
+        rtos_trace::trace::task_exec_end();
+    }
 }
 
 #[inline]
@@ -384,14 +431,17 @@ where
 impl rtos_trace::RtosTraceOSCallbacks for crate::raw::SyncExecutor {
     fn task_list() {
         with_all_active_tasks(|task| {
-            let name = task.name().unwrap_or("unnamed task\0");
-            let info = rtos_trace::TaskInfo {
-                name,
-                priority: 0,
-                stack_base: 0,
-                stack_size: 0,
-            };
-            rtos_trace::trace::task_send_info(task.id(), info);
+            // Only send task info for tasks that should be traced
+            if should_trace_task(&task) {
+                let name = task.name().unwrap_or("unnamed task\0");
+                let info = rtos_trace::TaskInfo {
+                    name,
+                    priority: 0,
+                    stack_base: 0,
+                    stack_size: 0,
+                };
+                rtos_trace::trace::task_send_info(task.id(), info);
+            }
         });
     }
     fn time() -> u64 {

--- a/embassy-executor/src/raw/trace.rs
+++ b/embassy-executor/src/raw/trace.rs
@@ -213,14 +213,22 @@ impl TaskRefTrace for TaskRef {
     }
 
     fn is_trace_excluded(&self) -> bool {
-        self.header().trace_excluded
+        #[cfg(feature = "trace-mode-selective")]
+        {
+            self.header().trace_excluded
+        }
+        #[cfg(not(feature = "trace-mode-selective"))]
+        false
     }
 
     fn set_trace_excluded(&self, excluded: bool) {
+        #[cfg(feature = "trace-mode-selective")]
         unsafe {
             let header_ptr = self.ptr.as_ptr() as *mut TaskHeader;
             (*header_ptr).trace_excluded = excluded;
         }
+        #[cfg(not(feature = "trace-mode-selective"))]
+        let _ = excluded;
     }
 }
 


### PR DESCRIPTION
Add spawn_with_trace(), spawn_no_trace() and named variants to provide fine-grained control over task tracing. Supports both default tracing (rtos-trace) and selective tracing (rtos-trace-selective) modes while maintaining backward compatibility.