### PR TITLE
Enable autoreload_preload for Complementary PWM

### DIFF
--- a/embassy-stm32/src/timer/complementary_pwm.rs
+++ b/embassy-stm32/src/timer/complementary_pwm.rs
@@ -88,6 +88,7 @@ impl<'d, T: AdvancedInstance4Channel> ComplementaryPwm<'d, T> {
                 this.inner.set_output_compare_mode(channel, OutputCompareMode::PwmMode1);
                 this.inner.set_output_compare_preload(channel, true);
             });
+        this.inner.set_autoreload_preload(true);
 
         this
     }


### PR DESCRIPTION
Since the autoreload is configured for the CCR is makes sense to also use it for the ARR in Complementary PWM