### PR TITLE
Add helper methods for the low-power interrupt timer.

### DIFF
--- a/embassy-stm32/src/lptim/timer/mod.rs
+++ b/embassy-stm32/src/lptim/timer/mod.rs
@@ -82,6 +82,31 @@ impl<'d, T: Instance> Timer<'d, T> {
     pub fn get_max_compare_value(&self) -> u16 {
         T::regs().arr().read().arr()
     }
+
+    /// Enable the timer interrupt.
+    pub fn enable_interrupt(&self) {
+        T::regs().dier().modify(|w| w.set_arrmie(true));
+    }
+
+    /// Disable the timer interrupt.
+    pub fn disable_interrupt(&self) {
+        T::regs().dier().modify(|w| w.set_arrmie(false));
+    }
+
+    /// Check if the timer interrupt is enabled.
+    pub fn is_interrupt_enabled(&self) -> bool {
+        T::regs().dier().read().arrmie()
+    }
+
+    /// Check if the timer interrupt is pending.
+    pub fn is_interrupt_pending(&self) -> bool {
+        T::regs().isr().read().arrm()
+    }
+
+    /// Clear the timer interrupt.
+    pub fn clear_interrupt(&self) {
+        T::regs().icr().write(|w| w.set_arrmcf(true));
+    }
 }
 
 #[cfg(any(lptim_v2a, lptim_v2b))]

--- a/embassy-stm32/src/lptim/timer/mod.rs
+++ b/embassy-stm32/src/lptim/timer/mod.rs
@@ -82,31 +82,6 @@ impl<'d, T: Instance> Timer<'d, T> {
     pub fn get_max_compare_value(&self) -> u16 {
         T::regs().arr().read().arr()
     }
-
-    /// Enable the timer interrupt.
-    pub fn enable_interrupt(&self) {
-        T::regs().dier().modify(|w| w.set_arrmie(true));
-    }
-
-    /// Disable the timer interrupt.
-    pub fn disable_interrupt(&self) {
-        T::regs().dier().modify(|w| w.set_arrmie(false));
-    }
-
-    /// Check if the timer interrupt is enabled.
-    pub fn is_interrupt_enabled(&self) -> bool {
-        T::regs().dier().read().arrmie()
-    }
-
-    /// Check if the timer interrupt is pending.
-    pub fn is_interrupt_pending(&self) -> bool {
-        T::regs().isr().read().arrm()
-    }
-
-    /// Clear the timer interrupt.
-    pub fn clear_interrupt(&self) {
-        T::regs().icr().write(|w| w.set_arrmcf(true));
-    }
 }
 
 #[cfg(any(lptim_v2a, lptim_v2b))]
@@ -140,6 +115,31 @@ impl<'d, T: Instance> Timer<'d, T> {
             .ccmr(0)
             .modify(|w| w.set_ccsel(channel.index(), direction.into()));
     }
+
+    /// Enable the timer interrupt.
+    pub fn enable_interrupt(&self) {
+        T::regs().dier().modify(|w| w.set_arrmie(true));
+    }
+
+    /// Disable the timer interrupt.
+    pub fn disable_interrupt(&self) {
+        T::regs().dier().modify(|w| w.set_arrmie(false));
+    }
+
+    /// Check if the timer interrupt is enabled.
+    pub fn is_interrupt_enabled(&self) -> bool {
+        T::regs().dier().read().arrmie()
+    }
+
+    /// Check if the timer interrupt is pending.
+    pub fn is_interrupt_pending(&self) -> bool {
+        T::regs().isr().read().arrm()
+    }
+
+    /// Clear the timer interrupt.
+    pub fn clear_interrupt(&self) {
+        T::regs().icr().write(|w| w.set_arrmcf(true));
+    }
 }
 
 #[cfg(not(any(lptim_v2a, lptim_v2b)))]
@@ -152,5 +152,30 @@ impl<'d, T: Instance> Timer<'d, T> {
     /// Get compare value for a channel.
     pub fn get_compare_value(&self) -> u16 {
         T::regs().cmp().read().cmp()
+    }
+
+    /// Enable the timer interrupt.
+    pub fn enable_interrupt(&self) {
+        T::regs().ier().modify(|w| w.set_arrmie(true));
+    }
+
+    /// Disable the timer interrupt.
+    pub fn disable_interrupt(&self) {
+        T::regs().ier().modify(|w| w.set_arrmie(false));
+    }
+
+    /// Check if the timer interrupt is enabled.
+    pub fn is_interrupt_enabled(&self) -> bool {
+        T::regs().ier().read().arrmie()
+    }
+
+    /// Check if the timer interrupt is pending.
+    pub fn is_interrupt_pending(&self) -> bool {
+        T::regs().isr().read().arrm()
+    }
+
+    /// Clear the timer interrupt.
+    pub fn clear_interrupt(&self) {
+        T::regs().icr().write(|w| w.set_arrmcf(true));
     }
 }


### PR DESCRIPTION
This pull request adds new methods to manage and interact with timer interrupts in the `embassy_stm32::lptim::timer::Timer` implementation. These changes provide functionality to enable, disable, check, and clear timer interrupts assuming that the default interrupt for `LPTIMx` timers should be the auto-reload match interrupt.

Enhancements to timer interrupt management:

* [`embassy-stm32/src/lptim/timer/mod.rs`](diffhunk://#diff-5c9e3bc25433dd27a2ad3d6db1bbdec1e4a111e98e2beeed28a4c0c585b21ab1R85-R109): Added methods `enable_interrupt`, `disable_interrupt`, `is_interrupt_enabled`, `is_interrupt_pending`, and `clear_interrupt` to provide comprehensive control and status checks for timer interrupts.