### PR TITLE
Remove futures-util where unnecessary

### DIFF
--- a/embassy-sync/Cargo.toml
+++ b/embassy-sync/Cargo.toml
@@ -28,7 +28,7 @@ defmt = { version = "1.0.1", optional = true }
 log = { version = "0.4.14", optional = true }
 
 futures-sink = { version = "0.3", default-features = false, features = [] }
-futures-util = { version = "0.3.17", default-features = false }
+futures-core = { version = "0.3.31", default-features = false }
 critical-section = "1.1"
 heapless = "0.8"
 cfg-if = "1.0.0"

--- a/embassy-sync/src/channel.rs
+++ b/embassy-sync/src/channel.rs
@@ -443,7 +443,7 @@ where
     }
 }
 
-impl<'ch, M, T, const N: usize> futures_util::Stream for Receiver<'ch, M, T, N>
+impl<'ch, M, T, const N: usize> futures_core::Stream for Receiver<'ch, M, T, N>
 where
     M: RawMutex,
 {
@@ -962,7 +962,7 @@ where
     }
 }
 
-impl<M, T, const N: usize> futures_util::Stream for Channel<M, T, N>
+impl<M, T, const N: usize> futures_core::Stream for Channel<M, T, N>
 where
     M: RawMutex,
 {

--- a/embassy-sync/src/pubsub/subscriber.rs
+++ b/embassy-sync/src/pubsub/subscriber.rs
@@ -115,7 +115,7 @@ impl<'a, PSB: PubSubBehavior<T> + ?Sized, T: Clone> Unpin for Sub<'a, PSB, T> {}
 
 /// Warning: The stream implementation ignores lag results and returns all messages.
 /// This might miss some messages without you knowing it.
-impl<'a, PSB: PubSubBehavior<T> + ?Sized, T: Clone> futures_util::Stream for Sub<'a, PSB, T> {
+impl<'a, PSB: PubSubBehavior<T> + ?Sized, T: Clone> futures_core::Stream for Sub<'a, PSB, T> {
     type Item = T;
 
     fn poll_next(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {

--- a/embassy-time/Cargo.toml
+++ b/embassy-time/Cargo.toml
@@ -427,7 +427,7 @@ embedded-hal-02 = { package = "embedded-hal", version = "0.2.6" }
 embedded-hal-1 = { package = "embedded-hal", version = "1.0" }
 embedded-hal-async = { version = "1.0" }
 
-futures-util = { version = "0.3.17", default-features = false }
+futures-core = { version = "0.3.31", default-features = false }
 critical-section = "1.1"
 cfg-if = "1.0.0"
 

--- a/embassy-time/src/timer.rs
+++ b/embassy-time/src/timer.rs
@@ -2,8 +2,8 @@ use core::future::{poll_fn, Future};
 use core::pin::Pin;
 use core::task::{Context, Poll};
 
-use futures_util::stream::FusedStream;
-use futures_util::Stream;
+use futures_core::stream::FusedStream;
+use futures_core::Stream;
 
 use crate::{Duration, Instant};
 


### PR DESCRIPTION
Traits are reexported from futures-core, and futures-util takes relatively forever to build.