### PR TITLE
embassy-rp: fix rom_data documentation format

### DIFF
--- a/embassy-rp/src/rom_data/mod.rs
+++ b/embassy-rp/src/rom_data/mod.rs
@@ -1,29 +1,29 @@
 #![cfg_attr(
     feature = "rp2040",
     doc = r"
-//! Functions and data from the RPI Bootrom.
-//!
-//! From the [RP2040 datasheet](https://datasheets.raspberrypi.org/rp2040/rp2040-datasheet.pdf), Section 2.8.2.1:
-//!
-//! > The Bootrom contains a number of public functions that provide useful
-//! > RP2040 functionality that might be needed in the absence of any other code
-//! > on the device, as well as highly optimized versions of certain key
-//! > functionality that would otherwise have to take up space in most user
-//! > binaries.
+Functions and data from the RPI Bootrom.
+
+From the [RP2040 datasheet](https://datasheets.raspberrypi.org/rp2040/rp2040-datasheet.pdf), Section 2.8.2.1:
+
+> The Bootrom contains a number of public functions that provide useful
+> RP2040 functionality that might be needed in the absence of any other code
+> on the device, as well as highly optimized versions of certain key
+> functionality that would otherwise have to take up space in most user
+> binaries.
 "
 )]
 #![cfg_attr(
     feature = "_rp235x",
     doc = r"
-//! Functions and data from the RPI Bootrom.
-//!
-//! From [Section 5.4](https://rptl.io/rp2350-datasheet#section_bootrom) of the
-//! RP2350 datasheet:
-//!
-//! > Whilst some ROM space is dedicated to the implementation of the boot
-//! > sequence and USB/UART boot interfaces, the bootrom also contains public
-//! > functions that provide useful RP2350 functionality that may be useful for
-//! > any code or runtime running on the device
+Functions and data from the RPI Bootrom.
+
+From [Section 5.4](https://rptl.io/rp2350-datasheet#section_bootrom) of the
+RP2350 datasheet:
+
+> Whilst some ROM space is dedicated to the implementation of the boot
+> sequence and USB/UART boot interfaces, the bootrom also contains public
+> functions that provide useful RP2350 functionality that may be useful for
+> any code or runtime running on the device
 "
 )]
 


### PR DESCRIPTION
This removes the `//!` doc comment markers from the [`rom_data`][rd] module documentation strings, as these appear in the generated output when using the `#[doc(...)]` attribute.

[rd]: https://docs.embassy.dev/embassy-rp/git/rp2040/rom_data/index.html