### PR TITLE
[sdmmc] Set `datatime` during initialization

### DIFF
--- a/embassy-stm32/src/sdmmc/mod.rs
+++ b/embassy-stm32/src/sdmmc/mod.rs
@@ -751,7 +751,6 @@ impl<'d, T: Instance> Sdmmc<'d, T> {
         Self::wait_idle();
         Self::clear_interrupt_flags();
 
-        regs.dtimer().write(|w| w.set_datatime(config.data_transfer_timeout));
         regs.dlenr().write(|w| w.set_datalength(length_bytes));
 
         #[cfg(sdmmc_v1)]
@@ -789,8 +788,6 @@ impl<'d, T: Instance> Sdmmc<'d, T> {
         Self::wait_idle();
         Self::clear_interrupt_flags();
 
-        regs.dtimer()
-            .write(|w| w.set_datatime(self.config.data_transfer_timeout));
         regs.dlenr().write(|w| w.set_datalength(length_bytes));
 
         #[cfg(sdmmc_v1)]
@@ -1349,6 +1346,8 @@ impl<'d, T: Instance> Sdmmc<'d, T> {
             #[cfg(sdmmc_v1)]
             w.set_bypass(_bypass);
         });
+        regs.dtimer()
+            .write(|w| w.set_datatime(self.config.data_transfer_timeout));
 
         regs.power().modify(|w| w.set_pwrctrl(PowerCtrl::On as u8));
         Self::cmd(common_cmd::idle(), false)?;


### PR DESCRIPTION
I've had the chance to test `embassy-stm32`'s eMMC support on an STM32L562 microcontroller, which works with `#[sdmmc_v2]`. I'm not sure if it's a behavior specific to that or the particular eMMC chip used, but I found that `Sdmmc` initialization would hang after sending the `SWITCH` command (used by `modify_ext_csd`). This is caused by an `R1b`-type response that took longer to clear the busy status than supported by the microcontroller's default timeout configuration. The immediately following `embassy-stm32` code wouldn't check or clear the timeout error flag, so it got stuck waiting for a completion that would never occur.

To solve this I've added a new `set_datatime` call into `init_internal`, prior to any `R1b` commands or datapath transactions. Furthermore, since values written to that register appear to be persistent across datapath transactions, I've removed it from `read_block` and `write_block` altogether (since there's no way to modify the configuration after initialization anyways).