### PR TITLE
Fix sync bounds on LazyLock and OnceLock

### DIFF
--- a/embassy-sync/Cargo.toml
+++ b/embassy-sync/Cargo.toml
@@ -43,3 +43,4 @@ futures-util = { version = "0.3.17", features = [ "channel", "sink" ] }
 # Enable critical-section implementation for std, for tests
 critical-section = { version = "1.1", features = ["std"] }
 static_cell = { version = "2" }
+trybuild = "1.0.105"

--- a/embassy-sync/src/lazy_lock.rs
+++ b/embassy-sync/src/lazy_lock.rs
@@ -31,7 +31,12 @@ union Data<T, F> {
     f: ManuallyDrop<F>,
 }
 
-unsafe impl<T, F> Sync for LazyLock<T, F> {}
+unsafe impl<T, F> Sync for LazyLock<T, F>
+where
+    T: Sync,
+    F: Sync,
+{
+}
 
 impl<T, F: FnOnce() -> T> LazyLock<T, F> {
     /// Create a new uninitialized `StaticLock`.

--- a/embassy-sync/src/once_lock.rs
+++ b/embassy-sync/src/once_lock.rs
@@ -42,7 +42,7 @@ pub struct OnceLock<T> {
     data: Cell<MaybeUninit<T>>,
 }
 
-unsafe impl<T> Sync for OnceLock<T> {}
+unsafe impl<T> Sync for OnceLock<T> where T: Sync {}
 
 impl<T> OnceLock<T> {
     /// Create a new uninitialized `OnceLock`.

--- a/embassy-sync/tests/ui.rs
+++ b/embassy-sync/tests/ui.rs
@@ -1,0 +1,13 @@
+// #[cfg(not(miri))]
+#[test]
+fn ui() {
+    let t = trybuild::TestCases::new();
+
+    // These test cases should fail to compile since OnceLock and LazyLock should not unconditionally implement sync
+    // for all types. These tests are regression tests against the following issues:
+    // * https://github.com/embassy-rs/embassy/issues/4307
+    // * https://github.com/embassy-rs/embassy/issues/3904
+    t.compile_fail("tests/ui/sync_impl/lazy_lock_function.rs");
+    t.compile_fail("tests/ui/sync_impl/lazy_lock_type.rs");
+    t.compile_fail("tests/ui/sync_impl/once_lock.rs");
+}

--- a/embassy-sync/tests/ui.rs
+++ b/embassy-sync/tests/ui.rs
@@ -1,4 +1,4 @@
-// #[cfg(not(miri))]
+#[cfg(not(miri))]
 #[test]
 fn ui() {
     let t = trybuild::TestCases::new();

--- a/embassy-sync/tests/ui/sync_impl/lazy_lock_function.rs
+++ b/embassy-sync/tests/ui/sync_impl/lazy_lock_function.rs
@@ -3,13 +3,9 @@ use embassy_sync::lazy_lock::LazyLock;
 fn main() {
     let x = 128u8;
     let x_ptr: *const u8 = core::ptr::addr_of!(x);
+    let closure_capturing_non_sync_variable = || unsafe { core::ptr::read(x_ptr) };
 
-    let closure_capturing_non_sync_variable = || {
-        unsafe {
-            core::ptr::read(x_ptr)
-        }
-    };
-
-    // This should fail to compile because the closure captures a non-Sync variable: x_ptr.
-    let _lazy_u8: LazyLock<u8, _> = LazyLock::new(closure_capturing_non_sync_variable);
+    check_sync(LazyLock::new(closure_capturing_non_sync_variable));
 }
+
+fn check_sync<T: Sync>(_lazy_lock: T) {}

--- a/embassy-sync/tests/ui/sync_impl/lazy_lock_function.rs
+++ b/embassy-sync/tests/ui/sync_impl/lazy_lock_function.rs
@@ -1,0 +1,15 @@
+use embassy_sync::lazy_lock::LazyLock;
+
+fn main() {
+    let x = 128u8;
+    let x_ptr: *const u8 = core::ptr::addr_of!(x);
+
+    let closure_capturing_non_sync_variable = || {
+        unsafe {
+            core::ptr::read(x_ptr)
+        }
+    };
+
+    // This should fail to compile because the closure captures a non-Sync variable: x_ptr.
+    let _lazy_u8: LazyLock<u8, _> = LazyLock::new(closure_capturing_non_sync_variable);
+}

--- a/embassy-sync/tests/ui/sync_impl/lazy_lock_function.stderr
+++ b/embassy-sync/tests/ui/sync_impl/lazy_lock_function.stderr
@@ -1,0 +1,24 @@
+error[E0277]: `*const u8` cannot be shared between threads safely
+  --> tests/ui/sync_impl/lazy_lock_function.rs:8:16
+   |
+6  |     let closure_capturing_non_sync_variable = || unsafe { core::ptr::read(x_ptr) };
+   |                                               -- within this `{closure@$DIR/tests/ui/sync_impl/lazy_lock_function.rs:6:47: 6:49}`
+7  |
+8  |     check_sync(LazyLock::new(closure_capturing_non_sync_variable));
+   |     ---------- ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `*const u8` cannot be shared between threads safely
+   |     |
+   |     required by a bound introduced by this call
+   |
+   = help: within `{closure@$DIR/tests/ui/sync_impl/lazy_lock_function.rs:6:47: 6:49}`, the trait `Sync` is not implemented for `*const u8`
+   = note: required because it appears within the type `&*const u8`
+note: required because it's used within this closure
+  --> tests/ui/sync_impl/lazy_lock_function.rs:6:47
+   |
+6  |     let closure_capturing_non_sync_variable = || unsafe { core::ptr::read(x_ptr) };
+   |                                               ^^
+   = note: required for `embassy_sync::lazy_lock::LazyLock<u8, {closure@$DIR/tests/ui/sync_impl/lazy_lock_function.rs:6:47: 6:49}>` to implement `Sync`
+note: required by a bound in `check_sync`
+  --> tests/ui/sync_impl/lazy_lock_function.rs:11:18
+   |
+11 | fn check_sync<T: Sync>(_lazy_lock: T) {}
+   |                  ^^^^ required by this bound in `check_sync`

--- a/embassy-sync/tests/ui/sync_impl/lazy_lock_type.rs
+++ b/embassy-sync/tests/ui/sync_impl/lazy_lock_type.rs
@@ -1,0 +1,6 @@
+use embassy_sync::lazy_lock::LazyLock;
+
+// *mut u8 is not Sync, so LazyLock should not implement Sync for this type. This should fail to compile.
+static GLOBAL: LazyLock<*mut u8> = LazyLock::new(|| core::ptr::null_mut());
+
+fn main() {}

--- a/embassy-sync/tests/ui/sync_impl/lazy_lock_type.stderr
+++ b/embassy-sync/tests/ui/sync_impl/lazy_lock_type.stderr
@@ -1,0 +1,9 @@
+error[E0277]: `*mut u8` cannot be shared between threads safely
+ --> tests/ui/sync_impl/lazy_lock_type.rs:4:16
+  |
+4 | static GLOBAL: LazyLock<*mut u8> = LazyLock::new(|| core::ptr::null_mut());
+  |                ^^^^^^^^^^^^^^^^^ `*mut u8` cannot be shared between threads safely
+  |
+  = help: the trait `Sync` is not implemented for `*mut u8`
+  = note: required for `embassy_sync::lazy_lock::LazyLock<*mut u8>` to implement `Sync`
+  = note: shared static variables must have a type that implements `Sync`

--- a/embassy-sync/tests/ui/sync_impl/once_lock.rs
+++ b/embassy-sync/tests/ui/sync_impl/once_lock.rs
@@ -1,0 +1,6 @@
+use embassy_sync::once_lock::OnceLock;
+
+// *mut u8 is not Sync, so OnceLock should not implement Sync for this type. This should fail to compile.
+static GLOBAL: OnceLock<*mut u8> = OnceLock::new();
+
+fn main() {}

--- a/embassy-sync/tests/ui/sync_impl/once_lock.stderr
+++ b/embassy-sync/tests/ui/sync_impl/once_lock.stderr
@@ -1,0 +1,9 @@
+error[E0277]: `*mut u8` cannot be shared between threads safely
+ --> tests/ui/sync_impl/once_lock.rs:4:16
+  |
+4 | static GLOBAL: OnceLock<*mut u8> = OnceLock::new();
+  |                ^^^^^^^^^^^^^^^^^ `*mut u8` cannot be shared between threads safely
+  |
+  = help: the trait `Sync` is not implemented for `*mut u8`
+  = note: required for `embassy_sync::once_lock::OnceLock<*mut u8>` to implement `Sync`
+  = note: shared static variables must have a type that implements `Sync`


### PR DESCRIPTION
This pull request introduces changes to ensure stricter `Sync` trait implementations for `LazyLock` and `OnceLock` types in the `embassy-sync` crate. It also adds regression tests to verify these changes and prevent incorrect usage of these types with non-`Sync` data. Additionally, a new dependency (`trybuild`) is added for compile-time testing.

### Stricter `Sync` Implementations:

* [`embassy-sync/src/lazy_lock.rs`](diffhunk://#diff-cd31bb3d341607967bd756da8f3d44ab3106dc08d38c7b4ec235230b584c2723L34-R39): Updated the `Sync` implementation for `LazyLock` to require both `T` and `F` to implement `Sync`.
* [`embassy-sync/src/once_lock.rs`](diffhunk://#diff-e8478b2fa15a8e88ebb2d2ea0faecdfc7223d2c3b8c5ccc0ce631aa432d74939L45-R45): Updated the `Sync` implementation for `OnceLock` to require `T` to implement `Sync`.

### Regression Tests for Compile-Time Errors:

* [`embassy-sync/tests/ui.rs`](diffhunk://#diff-b93a33ee71aaf155cb7b6f03478c2859084d60d09bb29b83e108f1b086a32e1fR1-R13): Added compile-fail tests using `trybuild` to ensure `LazyLock` and `OnceLock` do not unconditionally implement `Sync` for non-`Sync` types.
* [`embassy-sync/tests/ui/sync_impl/lazy_lock_function.rs`](diffhunk://#diff-8718c0de6b942640ffb134d6add1b5e573e2841c472cd6be7e5deece2e29a1ecR1-R15): Added a test case where a `LazyLock` is initialized with a closure capturing a non-`Sync` variable, which should fail to compile.
* [`embassy-sync/tests/ui/sync_impl/lazy_lock_type.rs`](diffhunk://#diff-294d2eb1b6946e68e6c4fd888f878c778449d58b7eddaf65770d4838422f484eR1-R6): Added a test case where `LazyLock` is used with a non-`Sync` type (`*mut u8`), which should fail to compile.
* [`embassy-sync/tests/ui/sync_impl/once_lock.rs`](diffhunk://#diff-fd48543eaaf2518651235c829ec4a185716da86bedf3e6f6a3ece260cb9164b9R1-R6): Added a test case where `OnceLock` is used with a non-`Sync` type (`*mut u8`), which should fail to compile.

### Dependency Addition:

* [`embassy-sync/Cargo.toml`](diffhunk://#diff-8ef39bee7253569f3e25944bb7297e3b70d36e6e5308c17c8b0bce9c2cc903f4R46): Added `trybuild` dependency for compile-time testing.

fixes #4307
fixes #3904