### PR TITLE
embassy-stm32: Rename PWM Input constructors, add warning on usable timer peripherals

### DIFF
--- a/embassy-stm32/src/timer/pwm_input.rs
+++ b/embassy-stm32/src/timer/pwm_input.rs
@@ -7,6 +7,10 @@ use crate::time::Hertz;
 use crate::Peri;
 
 /// PWM Input driver.
+///
+/// Only works with CH1 and CH2
+/// Note: Not all timer peripherals are supported
+/// Double check your chips reference manual
 pub struct PwmInput<'d, T: GeneralInstance4Channel> {
     channel: Channel,
     inner: Timer<'d, T>,
@@ -14,14 +18,14 @@ pub struct PwmInput<'d, T: GeneralInstance4Channel> {
 
 impl<'d, T: GeneralInstance4Channel> PwmInput<'d, T> {
     /// Create a new PWM input driver.
-    pub fn new(tim: Peri<'d, T>, pin: Peri<'d, impl TimerPin<T, Ch1>>, pull: Pull, freq: Hertz) -> Self {
+    pub fn new_ch1(tim: Peri<'d, T>, pin: Peri<'d, impl TimerPin<T, Ch1>>, pull: Pull, freq: Hertz) -> Self {
         pin.set_as_af(pin.af_num(), AfType::input(pull));
 
         Self::new_inner(tim, freq, Channel::Ch1, Channel::Ch2)
     }
 
     /// Create a new PWM input driver.
-    pub fn new_alt(tim: Peri<'d, T>, pin: Peri<'d, impl TimerPin<T, Ch2>>, pull: Pull, freq: Hertz) -> Self {
+    pub fn new_ch2(tim: Peri<'d, T>, pin: Peri<'d, impl TimerPin<T, Ch2>>, pull: Pull, freq: Hertz) -> Self {
         pin.set_as_af(pin.af_num(), AfType::input(pull));
 
         Self::new_inner(tim, freq, Channel::Ch2, Channel::Ch1)
@@ -37,6 +41,7 @@ impl<'d, T: GeneralInstance4Channel> PwmInput<'d, T> {
 
         // Configuration steps from ST RM0390 (STM32F446) chapter 17.3.6
         // or ST RM0008 (STM32F103) chapter 15.3.6 Input capture mode
+        // or ST RM0440 (STM32G4) chapter 30.4.8 PWM input mode
         inner.set_input_ti_selection(ch1, InputTISelection::Normal);
         inner.set_input_capture_mode(ch1, InputCaptureMode::Rising);
 

--- a/embassy-stm32/src/timer/pwm_input.rs
+++ b/embassy-stm32/src/timer/pwm_input.rs
@@ -8,7 +8,7 @@ use crate::Peri;
 
 /// PWM Input driver.
 ///
-/// Only works with CH1 and CH2
+/// Only works with CH1 or CH2
 /// Note: Not all timer peripherals are supported
 /// Double check your chips reference manual
 pub struct PwmInput<'d, T: GeneralInstance4Channel> {

--- a/examples/stm32f1/src/bin/pwm_input.rs
+++ b/examples/stm32f1/src/bin/pwm_input.rs
@@ -38,7 +38,7 @@ async fn main(spawner: Spawner) {
 
     unwrap!(spawner.spawn(blinky(p.PC13)));
 
-    let mut pwm_input = PwmInput::new(p.TIM2, p.PA0, Pull::None, khz(10));
+    let mut pwm_input = PwmInput::new_ch1(p.TIM2, p.PA0, Pull::None, khz(10));
     pwm_input.enable();
 
     loop {

--- a/examples/stm32f4/src/bin/pwm_input.rs
+++ b/examples/stm32f4/src/bin/pwm_input.rs
@@ -38,7 +38,7 @@ async fn main(spawner: Spawner) {
 
     unwrap!(spawner.spawn(blinky(p.PB2)));
 
-    let mut pwm_input = PwmInput::new(p.TIM3, p.PA6, Pull::None, khz(10));
+    let mut pwm_input = PwmInput::new_ch1(p.TIM3, p.PA6, Pull::None, khz(10));
     pwm_input.enable();
 
     loop {

--- a/examples/stm32g0/src/bin/pwm_input.rs
+++ b/examples/stm32g0/src/bin/pwm_input.rs
@@ -47,7 +47,7 @@ async fn main(spawner: Spawner) {
     pwm.ch1().set_duty_cycle_fraction(1, 4);
     pwm.ch1().enable();
 
-    let mut pwm_input = PwmInput::new(p.TIM2, p.PA0, Pull::None, khz(1000));
+    let mut pwm_input = PwmInput::new_ch1(p.TIM2, p.PA0, Pull::None, khz(1000));
     pwm_input.enable();
 
     loop {


### PR DESCRIPTION
Some timers don't support PWM Input mode. 
See below for STM32G4 RM0440:
<img width="588" alt="{430C5AA0-6125-4A27-A9D7-6312D2219B93}" src="https://github.com/user-attachments/assets/a9c3d8ae-ef0a-4ce5-974a-ea332879a8b9" />

And PWM Input is usable only with CH1 and CH2 on all families.
<img width="616" alt="{D1555EE1-1492-4F49-BBEC-B349992188F9}" src="https://github.com/user-attachments/assets/a177ca1a-d6af-43db-8e25-fe877d36b78f" />

