### PR TITLE
Only write to the flash what was read from the file

### DIFF
--- a/examples/boot/application/rp/src/bin/a.rs
+++ b/examples/boot/application/rp/src/bin/a.rs
@@ -54,7 +54,7 @@ async fn main(_s: Spawner) {
     for chunk in APP_B.chunks(4096) {
         buf.0[..chunk.len()].copy_from_slice(chunk);
         defmt::info!("writing block at offset {}", offset);
-        writer.write(offset, &buf.0[..]).unwrap();
+        writer.write(offset, &buf.0[..chunk.len()]).unwrap();
         offset += chunk.len() as u32;
     }
     watchdog.feed();


### PR DESCRIPTION
The write method is given the full aligned buffer to write to flash even though it may not be fully populated. This change ensures only what has been read is written to flash. Preventing potential corrupted firmware and additional flash wear.