### PR TITLE
Add syntax highlighter

### DIFF
--- a/docs/index.adoc
+++ b/docs/index.adoc
@@ -5,6 +5,7 @@
 :toc-placement: left
 :toclevels: 2
 :imagesdir: images
+:source-highlighter: rouge
 
 # Embassy Book
 


### PR DESCRIPTION
This requires installing the [rouge gem](https://docs.asciidoctor.org/asciidoctor/latest/syntax-highlighting/rouge/), but it gives some basic syntax highlighting.

Assuming it already runs fine on your machine prior to this commit, you just need to run `gem install rouge` and add `:source-highlighter: rouge` to `index.adoc`

### Examples:
![image](https://github.com/user-attachments/assets/261827cc-777d-4db6-891c-60850814a516)
![image](https://github.com/user-attachments/assets/e0a595ed-3632-4a4b-a7ec-c7b338c06f2d)



I noticed a couple problems other than this, like the build script complaining about missing files, but seemingly still building fine without images. I did however have to replace this file because it doesn't seem to exist in the repo:

https://github.com/embassy-rs/embassy/blob/206a324cf4d612122356fb350b4a3b56391d6f20/docs/pages/overview.adoc?plain=1#L68C1-L73C1

