### PR TITLE
Allow simultaneous use of ADC1 and ADC2 on STM32F3

### DIFF
--- a/embassy-stm32/src/adc/f3.rs
+++ b/embassy-stm32/src/adc/f3.rs
@@ -232,8 +232,7 @@ impl<'d, A: IsAdc12, B: IsAdc12> SharedAdc<'d, A, B> {
         adc_a: Peri<'d, A>,
         adc_b: Peri<'d, B>,
         _irq: impl interrupt::typelevel::Binding<A::Interrupt, SharedInterruptHandler<A, B>> + 'd,
-    ) -> Self
-    {
+    ) -> Self {
         let a = Adc::new_unbound(adc_a);
         let b = Adc::new_unbound(adc_b);
 
@@ -242,9 +241,6 @@ impl<'d, A: IsAdc12, B: IsAdc12> SharedAdc<'d, A, B> {
             A::Interrupt::enable();
         }
 
-        Self {
-            a,
-            b,
-        }
+        Self { a, b }
     }
 }


### PR DESCRIPTION
ADC1 and ADC2 share an interrupt handler on the STM32F3x. This new type allows us to create instance of each one using the shared interrupt. Tested and working on an STM32F303RCTx.