### PR TITLE
Added STM32WBA6XXX devices as features

### DIFF
--- a/ci.sh
+++ b/ci.sh
@@ -169,6 +169,8 @@ cargo batch \
     --- build --release --manifest-path embassy-stm32/Cargo.toml --target thumbv8m.main-none-eabihf --features stm32h562ag,defmt,exti,time-driver-any,time \
     --- build --release --manifest-path embassy-stm32/Cargo.toml --target thumbv8m.main-none-eabihf --features stm32wba50ke,defmt,exti,time-driver-any,time \
     --- build --release --manifest-path embassy-stm32/Cargo.toml --target thumbv8m.main-none-eabihf --features stm32wba55ug,defmt,exti,time-driver-any,time \
+    --- build --release --manifest-path embassy-stm32/Cargo.toml --target thumbv8m.main-none-eabihf --features stm32wba62cg,defmt,exti,time-driver-any,time \
+    --- build --release --manifest-path embassy-stm32/Cargo.toml --target thumbv8m.main-none-eabihf --features stm32wba65ri,defmt,exti,time-driver-any,time \
     --- build --release --manifest-path embassy-stm32/Cargo.toml --target thumbv8m.main-none-eabihf --features stm32u5f9zj,defmt,exti,time-driver-any,time \
     --- build --release --manifest-path embassy-stm32/Cargo.toml --target thumbv8m.main-none-eabihf --features stm32u5g9nj,defmt,exti,time-driver-any,time \
     --- build --release --manifest-path embassy-stm32/Cargo.toml --target thumbv7em-none-eabi --features stm32wb35ce,defmt,exti,time-driver-any,time \

--- a/embassy-stm32/Cargo.toml
+++ b/embassy-stm32/Cargo.toml
@@ -81,7 +81,7 @@ futures-util = { version = "0.3.30", default-features = false }
 sdio-host = "0.9.0"
 critical-section = "1.1"
 #stm32-metapac = { version = "16" }
-stm32-metapac = { git = "https://github.com/embassy-rs/stm32-data-generated", tag = "stm32-data-8a502cec14512a6b833beb8f6e15f4a7b5ee7c06" }
+stm32-metapac = { git = "https://github.com/embassy-rs/stm32-data-generated", tag = "stm32-data-0069be7389d0378d826003304d72a13008f3ebce" }
 
 vcell = "0.1.3"
 nb = "1.0.0"
@@ -110,7 +110,7 @@ proc-macro2 = "1.0.36"
 quote = "1.0.15"
 
 #stm32-metapac = { version = "16", default-features = false, features = ["metadata"]}
-stm32-metapac = { git = "https://github.com/embassy-rs/stm32-data-generated", tag = "stm32-data-8a502cec14512a6b833beb8f6e15f4a7b5ee7c06", default-features = false, features = ["metadata"] }
+stm32-metapac = { git = "https://github.com/embassy-rs/stm32-data-generated", tag = "stm32-data-0069be7389d0378d826003304d72a13008f3ebce", default-features = false, features = ["metadata"] }
 
 [features]
 default = ["rt"]
@@ -1634,6 +1634,24 @@ stm32wba55he = [ "stm32-metapac/stm32wba55he" ]
 stm32wba55hg = [ "stm32-metapac/stm32wba55hg" ]
 stm32wba55ue = [ "stm32-metapac/stm32wba55ue" ]
 stm32wba55ug = [ "stm32-metapac/stm32wba55ug" ]
+stm32wba62cg = [ "stm32-metapac/stm32wba62cg" ]
+stm32wba62ci = [ "stm32-metapac/stm32wba62ci" ]
+stm32wba62mg = [ "stm32-metapac/stm32wba62mg" ]
+stm32wba62mi = [ "stm32-metapac/stm32wba62mi" ]
+stm32wba62pg = [ "stm32-metapac/stm32wba62pg" ]
+stm32wba62pi = [ "stm32-metapac/stm32wba62pi" ]
+stm32wba63cg = [ "stm32-metapac/stm32wba63cg" ]
+stm32wba63ci = [ "stm32-metapac/stm32wba63ci" ]
+stm32wba64cg = [ "stm32-metapac/stm32wba64cg" ]
+stm32wba64ci = [ "stm32-metapac/stm32wba64ci" ]
+stm32wba65cg = [ "stm32-metapac/stm32wba65cg" ]
+stm32wba65ci = [ "stm32-metapac/stm32wba65ci" ]
+stm32wba65mg = [ "stm32-metapac/stm32wba65mg" ]
+stm32wba65mi = [ "stm32-metapac/stm32wba65mi" ]
+stm32wba65pg = [ "stm32-metapac/stm32wba65pg" ]
+stm32wba65pi = [ "stm32-metapac/stm32wba65pi" ]
+stm32wba65rg = [ "stm32-metapac/stm32wba65rg" ]
+stm32wba65ri = [ "stm32-metapac/stm32wba65ri" ]
 stm32wl54cc-cm4 = [ "stm32-metapac/stm32wl54cc-cm4", "_dual-core", "_core-cm4" ]
 stm32wl54cc-cm0p = [ "stm32-metapac/stm32wl54cc-cm0p", "_dual-core", "_core-cm0p" ]
 stm32wl54jc-cm4 = [ "stm32-metapac/stm32wl54jc-cm4", "_dual-core", "_core-cm4" ]

--- a/embassy-stm32/src/rtc/mod.rs
+++ b/embassy-stm32/src/rtc/mod.rs
@@ -25,7 +25,7 @@ use crate::time::Hertz;
     ),
     path = "v2.rs"
 )]
-#[cfg_attr(any(rtc_v3, rtc_v3u5, rtc_v3l5, rtc_v3h7rs), path = "v3.rs")]
+#[cfg_attr(any(rtc_v3, rtc_v3u5, rtc_v3l5, rtc_v3h7rs, rtc_v3c0), path = "v3.rs")]
 mod _version;
 #[allow(unused_imports)]
 pub use _version::*;


### PR DESCRIPTION
Added the following
- new devices (a.k.a. features) from `stm32-data`
- within `ci.sh`: attempt to build 2 `stm32wba6[2|5]` devices
- handled a default rtc implementation if the generated peripherals didn't match the mapping.
- handled a new generated peripheral `rtc_v3c0` recently introduced to `stm32-data-generated`