### PR TITLE
Minimise build profile tweaking in rp/rp235x examples

### DIFF
--- a/examples/rp/Cargo.toml
+++ b/examples/rp/Cargo.toml
@@ -58,11 +58,5 @@ rand = { version = "0.9.0", default-features = false }
 embedded-sdmmc = "0.7.0"
 
 [profile.release]
-debug = 2
-lto = true
-opt-level = 'z'
-
-[profile.dev]
-debug = 2
-lto = true
-opt-level = "z"
+# Enable generation of debug symbols even on release builds
+debug = true

--- a/examples/rp235x/Cargo.toml
+++ b/examples/rp235x/Cargo.toml
@@ -57,9 +57,6 @@ portable-atomic = { version = "1.5", features = ["critical-section"] }
 log = "0.4"
 embedded-sdmmc = "0.7.0"
 
-[profile.dev]
-debug = 2
-
 [profile.release]
-lto = true
-opt-level = "z"
+# Enable generation of debug symbols even on release builds
+debug = true


### PR DESCRIPTION
To avoid confusion around build profile tweaks (see #4346), remove optimisation/lto changes and just enable generation of debug symbols for release profiles.
Also add a comment explaining that it is intentional so it is less likely to be seen as a mistake in the examples.