### PR TITLE
Adds ADC4 for STM32WBA series

### DIFF
--- a/embassy-stm32/Cargo.toml
+++ b/embassy-stm32/Cargo.toml
@@ -81,7 +81,7 @@ futures-util = { version = "0.3.30", default-features = false }
 sdio-host = "0.9.0"
 critical-section = "1.1"
 #stm32-metapac = { version = "16" }
-stm32-metapac = { git = "https://github.com/embassy-rs/stm32-data-generated", tag = "stm32-data-0069be7389d0378d826003304d72a13008f3ebce" }
+stm32-metapac = { git = "https://github.com/embassy-rs/stm32-data-generated", tag = "stm32-data-019a3ce0ea3b5bd832ec2ad53465a0d80b0f4e0a" }
 
 vcell = "0.1.3"
 nb = "1.0.0"
@@ -110,7 +110,7 @@ proc-macro2 = "1.0.36"
 quote = "1.0.15"
 
 #stm32-metapac = { version = "16", default-features = false, features = ["metadata"]}
-stm32-metapac = { git = "https://github.com/embassy-rs/stm32-data-generated", tag = "stm32-data-0069be7389d0378d826003304d72a13008f3ebce", default-features = false, features = ["metadata"] }
+stm32-metapac = { git = "https://github.com/embassy-rs/stm32-data-generated", tag = "stm32-data-019a3ce0ea3b5bd832ec2ad53465a0d80b0f4e0a", default-features = false, features = ["metadata"] }
 
 [features]
 default = ["rt"]

--- a/embassy-stm32/build.rs
+++ b/embassy-stm32/build.rs
@@ -1490,6 +1490,10 @@ fn main() {
         signals.insert(("adc", "ADC4"), quote!(crate::adc::RxDma));
     }
 
+    if chip_name.starts_with("stm32wba") {
+        signals.insert(("adc", "ADC4"), quote!(crate::adc::RxDma4));
+    }
+
     if chip_name.starts_with("stm32g4") {
         let line_number = chip_name.chars().skip(8).next().unwrap();
         if line_number == '3' || line_number == '4' {

--- a/embassy-stm32/src/adc/adc4.rs
+++ b/embassy-stm32/src/adc/adc4.rs
@@ -1,10 +1,19 @@
+#[cfg(stm32u5)]
+use pac::adc::vals::{Adc4Dmacfg as Dmacfg, Adc4Exten as Exten, Adc4OversamplingRatio as OversamplingRatio};
 #[allow(unused)]
-use pac::adc::vals::{Adc4Dmacfg, Adc4Exten, Adc4OversamplingRatio};
+#[cfg(stm32wba)]
+use pac::adc::vals::{Chselrmod, Cont, Dmacfg, Exten, OversamplingRatio, Ovss, Smpsel};
 
 use super::{blocking_delay_us, AdcChannel, AnyAdcChannel, RxDma4, SealedAdcChannel};
 use crate::dma::Transfer;
-pub use crate::pac::adc::regs::Adc4Chselrmod0;
+#[cfg(stm32u5)]
+pub use crate::pac::adc::regs::Adc4Chselrmod0 as Chselr;
+#[cfg(stm32wba)]
+pub use crate::pac::adc::regs::Chselr;
+#[cfg(stm32u5)]
 pub use crate::pac::adc::vals::{Adc4Presc as Presc, Adc4Res as Resolution, Adc4SampleTime as SampleTime};
+#[cfg(stm32wba)]
+pub use crate::pac::adc::vals::{Presc, Res as Resolution, SampleTime};
 use crate::time::Hertz;
 use crate::{pac, rcc, Peri};
 
@@ -242,16 +251,27 @@ impl<'d, T: Instance> Adc4<'d, T> {
     fn configure(&mut self) {
         // single conversion mode, software trigger
         T::regs().cfgr1().modify(|w| {
+            #[cfg(stm32u5)]
             w.set_cont(false);
+            #[cfg(stm32wba)]
+            w.set_cont(Cont::SINGLE);
             w.set_discen(false);
-            w.set_exten(Adc4Exten::DISABLED);
+            w.set_exten(Exten::DISABLED);
+            #[cfg(stm32u5)]
             w.set_chselrmod(false);
+            #[cfg(stm32wba)]
+            w.set_chselrmod(Chselrmod::ENABLE_INPUT);
         });
 
         // only use one channel at the moment
         T::regs().smpr().modify(|w| {
+            #[cfg(stm32u5)]
             for i in 0..24 {
                 w.set_smpsel(i, false);
+            }
+            #[cfg(stm32wba)]
+            for i in 0..14 {
+                w.set_smpsel(i, Smpsel::SMP1);
             }
         });
     }
@@ -275,6 +295,7 @@ impl<'d, T: Instance> Adc4<'d, T> {
     }
 
     /// Enable reading the vbat internal channel.
+    #[cfg(stm32u5)]
     pub fn enable_vbat(&self) -> Vbat {
         T::regs().ccr().modify(|w| {
             w.set_vbaten(true);
@@ -289,6 +310,7 @@ impl<'d, T: Instance> Adc4<'d, T> {
     }
 
     /// Enable reading the vbat internal channel.
+    #[cfg(stm32u5)]
     pub fn enable_dac_channel(&self, dac: DacChannel) -> Dac {
         let mux;
         match dac {
@@ -317,17 +339,38 @@ impl<'d, T: Instance> Adc4<'d, T> {
     }
 
     /// Set hardware averaging.
+    #[cfg(stm32u5)]
     pub fn set_averaging(&mut self, averaging: Averaging) {
         let (enable, samples, right_shift) = match averaging {
-            Averaging::Disabled => (false, Adc4OversamplingRatio::OVERSAMPLE2X, 0),
-            Averaging::Samples2 => (true, Adc4OversamplingRatio::OVERSAMPLE2X, 1),
-            Averaging::Samples4 => (true, Adc4OversamplingRatio::OVERSAMPLE4X, 2),
-            Averaging::Samples8 => (true, Adc4OversamplingRatio::OVERSAMPLE8X, 3),
-            Averaging::Samples16 => (true, Adc4OversamplingRatio::OVERSAMPLE16X, 4),
-            Averaging::Samples32 => (true, Adc4OversamplingRatio::OVERSAMPLE32X, 5),
-            Averaging::Samples64 => (true, Adc4OversamplingRatio::OVERSAMPLE64X, 6),
-            Averaging::Samples128 => (true, Adc4OversamplingRatio::OVERSAMPLE128X, 7),
-            Averaging::Samples256 => (true, Adc4OversamplingRatio::OVERSAMPLE256X, 8),
+            Averaging::Disabled => (false, OversamplingRatio::OVERSAMPLE2X, 0),
+            Averaging::Samples2 => (true, OversamplingRatio::OVERSAMPLE2X, 1),
+            Averaging::Samples4 => (true, OversamplingRatio::OVERSAMPLE4X, 2),
+            Averaging::Samples8 => (true, OversamplingRatio::OVERSAMPLE8X, 3),
+            Averaging::Samples16 => (true, OversamplingRatio::OVERSAMPLE16X, 4),
+            Averaging::Samples32 => (true, OversamplingRatio::OVERSAMPLE32X, 5),
+            Averaging::Samples64 => (true, OversamplingRatio::OVERSAMPLE64X, 6),
+            Averaging::Samples128 => (true, OversamplingRatio::OVERSAMPLE128X, 7),
+            Averaging::Samples256 => (true, OversamplingRatio::OVERSAMPLE256X, 8),
+        };
+
+        T::regs().cfgr2().modify(|w| {
+            w.set_ovsr(samples);
+            w.set_ovss(right_shift);
+            w.set_ovse(enable)
+        })
+    }
+    #[cfg(stm32wba)]
+    pub fn set_averaging(&mut self, averaging: Averaging) {
+        let (enable, samples, right_shift) = match averaging {
+            Averaging::Disabled => (false, OversamplingRatio::OVERSAMPLE2X, Ovss::SHIFT0),
+            Averaging::Samples2 => (true, OversamplingRatio::OVERSAMPLE2X, Ovss::SHIFT1),
+            Averaging::Samples4 => (true, OversamplingRatio::OVERSAMPLE4X, Ovss::SHIFT2),
+            Averaging::Samples8 => (true, OversamplingRatio::OVERSAMPLE8X, Ovss::SHIFT3),
+            Averaging::Samples16 => (true, OversamplingRatio::OVERSAMPLE16X, Ovss::SHIFT4),
+            Averaging::Samples32 => (true, OversamplingRatio::OVERSAMPLE32X, Ovss::SHIFT5),
+            Averaging::Samples64 => (true, OversamplingRatio::OVERSAMPLE64X, Ovss::SHIFT6),
+            Averaging::Samples128 => (true, OversamplingRatio::OVERSAMPLE128X, Ovss::SHIFT7),
+            Averaging::Samples256 => (true, OversamplingRatio::OVERSAMPLE256X, Ovss::SHIFT8),
         };
 
         T::regs().cfgr2().modify(|w| {
@@ -342,10 +385,20 @@ impl<'d, T: Instance> Adc4<'d, T> {
         channel.setup();
 
         // Select channel
-        T::regs().chselrmod0().write_value(Adc4Chselrmod0(0_u32));
-        T::regs().chselrmod0().modify(|w| {
-            w.set_chsel(channel.channel() as usize, true);
-        });
+        #[cfg(stm32wba)]
+        {
+            T::regs().chselr().write_value(Chselr(0_u32));
+            T::regs().chselr().modify(|w| {
+                w.set_chsel0(channel.channel() as usize, true);
+            });
+        }
+        #[cfg(stm32u5)]
+        {
+            T::regs().chselrmod0().write_value(Chselr(0_u32));
+            T::regs().chselrmod0().modify(|w| {
+                w.set_chsel(channel.channel() as usize, true);
+            });
+        }
 
         // Reset interrupts
         T::regs().isr().modify(|reg| {
@@ -415,13 +468,19 @@ impl<'d, T: Instance> Adc4<'d, T> {
 
         T::regs().cfgr1().modify(|reg| {
             reg.set_dmaen(true);
-            reg.set_dmacfg(Adc4Dmacfg::ONE_SHOT);
+            reg.set_dmacfg(Dmacfg::ONE_SHOT);
+            #[cfg(stm32u5)]
             reg.set_chselrmod(false);
+            #[cfg(stm32wba)]
+            reg.set_chselrmod(Chselrmod::ENABLE_INPUT)
         });
 
         // Verify and activate sequence
         let mut prev_channel: i16 = -1;
-        T::regs().chselrmod0().write_value(Adc4Chselrmod0(0_u32));
+        #[cfg(stm32wba)]
+        T::regs().chselr().write_value(Chselr(0_u32));
+        #[cfg(stm32u5)]
+        T::regs().chselrmod0().write_value(Chselr(0_u32));
         for channel in sequence {
             let channel_num = channel.channel;
             if channel_num as i16 <= prev_channel {
@@ -429,6 +488,11 @@ impl<'d, T: Instance> Adc4<'d, T> {
             };
             prev_channel = channel_num as i16;
 
+            #[cfg(stm32wba)]
+            T::regs().chselr().modify(|w| {
+                w.set_chsel0(channel.channel as usize, true);
+            });
+            #[cfg(stm32u5)]
             T::regs().chselrmod0().modify(|w| {
                 w.set_chsel(channel.channel as usize, true);
             });

--- a/embassy-stm32/src/rcc/wba.rs
+++ b/embassy-stm32/src/rcc/wba.rs
@@ -176,6 +176,7 @@ pub(crate) unsafe fn init(config: Config) {
         // TODO
         lse: None,
         lsi: None,
+        pll1_p: None,
         pll1_q: None,
     );
 }

--- a/examples/stm32wba/src/bin/adc.rs
+++ b/examples/stm32wba/src/bin/adc.rs
@@ -1,0 +1,49 @@
+#![no_std]
+#![no_main]
+
+use defmt::*;
+use embassy_stm32::adc::{adc4, AdcChannel};
+use {defmt_rtt as _, panic_probe as _};
+
+#[embassy_executor::main]
+async fn main(_spawner: embassy_executor::Spawner) {
+    let config = embassy_stm32::Config::default();
+
+    let mut p = embassy_stm32::init(config);
+
+    // **** ADC4 init ****
+    let mut adc4 = adc4::Adc4::new(p.ADC4);
+    let mut adc4_pin1 = p.PA0; // A4
+    let mut adc4_pin2 = p.PA1; // A5
+    adc4.set_resolution(adc4::Resolution::BITS12);
+    adc4.set_averaging(adc4::Averaging::Samples256);
+    adc4.set_sample_time(adc4::SampleTime::CYCLES1_5);
+    let max4 = adc4::resolution_to_max_count(adc4::Resolution::BITS12);
+
+    // **** ADC4 blocking read ****
+    let raw: u16 = adc4.blocking_read(&mut adc4_pin1);
+    let volt: f32 = 3.0 * raw as f32 / max4 as f32;
+    info!("Read adc4 pin 1 {}", volt);
+
+    let raw: u16 = adc4.blocking_read(&mut adc4_pin2);
+    let volt: f32 = 3.3 * raw as f32 / max4 as f32;
+    info!("Read adc4 pin 2 {}", volt);
+
+    // **** ADC4 async read ****
+    let mut degraded41 = adc4_pin1.degrade_adc();
+    let mut degraded42 = adc4_pin2.degrade_adc();
+    let mut measurements = [0u16; 2];
+
+    // The channels must be in ascending order and can't repeat for ADC4
+    adc4.read(
+        p.GPDMA1_CH1.reborrow(),
+        [&mut degraded42, &mut degraded41].into_iter(),
+        &mut measurements,
+    )
+    .await
+    .unwrap();
+    let volt2: f32 = 3.3 * measurements[0] as f32 / max4 as f32;
+    let volt1: f32 = 3.0 * measurements[1] as f32 / max4 as f32;
+    info!("Async read 4 pin 1 {}", volt1);
+    info!("Async read 4 pin 2 {}", volt2);
+}


### PR DESCRIPTION
This adds ADC support for the WBA series, using the already existing ADC4 support for the U5 series.
This was tested on a WBA55CG. 
There are probably some simplifications to be made, but this at least works.

I haven't tested the u5 after these changes because I don't own one. 