### PR TITLE
embassy-stm32: Fix temperature ADC channel for STM32L0 series

### DIFF
--- a/embassy-stm32/src/adc/v1.rs
+++ b/embassy-stm32/src/adc/v1.rs
@@ -56,7 +56,11 @@ pub struct Temperature;
 impl AdcChannel<ADC1> for Temperature {}
 impl super::SealedAdcChannel<ADC1> for Temperature {
     fn channel(&self) -> u8 {
-        16
+        if cfg!(adc_l0) {
+            18
+        } else {
+            16
+        }
     }
 }
 


### PR DESCRIPTION
Some STM32 MCUs feature an internal temperature sensor which is connected to a ADC channel. 

It seems that in `adc/v1.rs`, the `AdcChannel` implementation for `Temperature` is using channel 16. However, for STM32L0-series MCUs it seems the internal temperature sensor is consistently connected to `ADC_IN18`. 

![image](https://github.com/user-attachments/assets/479e0b69-a643-410c-94e8-1e117b9f604c)
_(excerpt from https://www.st.com/resource/en/datasheet/stm32l011d4.pdf)_

While looking through the datasheets, I realized that STM32L0x0-series (value line) seems _not_ to feature a temperature sensor, however I was not sure how to handle this. STM32L0x1 (access line), STM32L0x2 (USB) and STM32L0x3 (USB & LCD) comprise the temperature sensor. 

This MR suggest to rely on a compile-time `cfg` to select the channel used for measuring the temperature.  