### PR TITLE
embassy-nrf: fix PWM loop count

### DIFF
--- a/embassy-nrf/src/pwm.rs
+++ b/embassy-nrf/src/pwm.rs
@@ -479,9 +479,8 @@ impl<'d, 's, T: Instance> Sequencer<'d, 's, T> {
         let seqstart_index = if start_seq == StartSequence::One { 1 } else { 0 };
 
         match times {
-            // just the one time, no loop count
-            SequenceMode::Loop(_) => {
-                r.loop_().write(|w| w.set_cnt(vals::LoopCnt::DISABLED));
+            SequenceMode::Loop(n) => {
+                r.loop_().write(|w| w.set_cnt(vals::LoopCnt(n)));
             }
             // to play infinitely, repeat the sequence one time, then have loops done self trigger seq0 again
             SequenceMode::Infinite => {


### PR DESCRIPTION
The PWM sequencer offers to run a sequence for a limited time by specifying `SingleSequenceMode::Times(n)` with `n > 0`.

Currently this value is ignored and the loop register is set to `1`.

This PR fixes the behaviour. It has been tested using a NRF9160 in secure mode.