### PR TITLE
rp: add current_core api

### DIFF
--- a/embassy-rp/src/multicore.rs
+++ b/embassy-rp/src/multicore.rs
@@ -57,6 +57,26 @@ const PAUSE_TOKEN: u32 = 0xDEADBEEF;
 const RESUME_TOKEN: u32 = !0xDEADBEEF;
 static IS_CORE1_INIT: AtomicBool = AtomicBool::new(false);
 
+/// Represents a partiticular CPU core (SIO_CPUID)
+#[derive(Debug, PartialEq, Eq, Clone, Copy, Hash)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+#[repr(u8)]
+pub enum CoreId {
+    /// Core 0
+    Core0 = 0x0,
+    /// Core 1
+    Core1 = 0x1,
+}
+
+/// Gets which core we are currently executing from
+pub fn current_core() -> CoreId {
+    if pac::SIO.cpuid().read() == 0 {
+        CoreId::Core0
+    } else {
+        CoreId::Core1
+    }
+}
+
 #[inline(always)]
 unsafe fn core1_setup(stack_bottom: *mut usize) {
     if install_stack_guard(stack_bottom).is_err() {


### PR DESCRIPTION
This PR adds a new API within the embassy-rp multicore module to get which core the code is currently executing on. This is similar to functionality already present in the embassy-stm32 crate.