### PR TITLE
Add note about UART line breaks being different from ASCII

### DIFF
--- a/embassy-rp/src/uart/mod.rs
+++ b/embassy-rp/src/uart/mod.rs
@@ -515,6 +515,9 @@ impl<'d> UartRx<'d, Async> {
     /// * If you expect a message of 20 bytes + line break, and provide a 21-byte buffer:
     ///     * The first call to `read_to_break()` will return `Ok(20)`.
     ///     * The next call to `read_to_break()` will work as expected
+    ///
+    /// **NOTE**: In the UART context, a line break refers to a break condition (the line being held low for
+    /// for longer than a single character), not an ASCII line break.
     pub async fn read_to_break(&mut self, buffer: &mut [u8]) -> Result<usize, ReadToBreakError> {
         self.read_to_break_with_count(buffer, 0).await
     }
@@ -541,6 +544,9 @@ impl<'d> UartRx<'d, Async> {
     /// * If you expect a message of 20 bytes + line break, and provide a 21-byte buffer:
     ///     * The first call to `read_to_break()` will return `Ok(20)`.
     ///     * The next call to `read_to_break()` will work as expected
+    /// 
+    /// **NOTE**: In the UART context, a line break refers to a break condition (the line being held low for
+    /// for longer than a single character), not an ASCII line break.
     pub async fn read_to_break_with_count(
         &mut self,
         buffer: &mut [u8],


### PR DESCRIPTION
I confused myself for a while because I'm working with a GPS module that sends an ASCII line break character (\n) to indicate the end of a transmission. I initially thought `read_to_break` would read until it saw a line break character, but it actually does the (much more sensible) reading until a UART break condition is encountered. This adds that distinction to the docs.