### PR TITLE
embassy-stm32: Added sample shifting to qspi config

### DIFF
--- a/embassy-stm32/src/qspi/enums.rs
+++ b/embassy-stm32/src/qspi/enums.rs
@@ -331,3 +331,19 @@ impl From<DummyCycles> for u8 {
         }
     }
 }
+
+#[allow(missing_docs)]
+#[derive(Copy, Clone)]
+pub enum SampleShifting {
+    None,
+    HalfCycle
+}
+
+impl From<SampleShifting> for bool {
+    fn from(value: SampleShifting) -> Self {
+        match value {
+            SampleShifting::None => false,
+            SampleShifting::HalfCycle => true
+        }
+    }
+}

--- a/embassy-stm32/src/qspi/enums.rs
+++ b/embassy-stm32/src/qspi/enums.rs
@@ -336,14 +336,14 @@ impl From<DummyCycles> for u8 {
 #[derive(Copy, Clone)]
 pub enum SampleShifting {
     None,
-    HalfCycle
+    HalfCycle,
 }
 
 impl From<SampleShifting> for bool {
     fn from(value: SampleShifting) -> Self {
         match value {
             SampleShifting::None => false,
-            SampleShifting::HalfCycle => true
+            SampleShifting::HalfCycle => true,
         }
     }
 }

--- a/embassy-stm32/src/qspi/mod.rs
+++ b/embassy-stm32/src/qspi/mod.rs
@@ -58,6 +58,8 @@ pub struct Config {
     pub fifo_threshold: FIFOThresholdLevel,
     /// Minimum number of cycles that chip select must be high between issued commands
     pub cs_high_time: ChipSelectHighTime,
+    /// Shift sampling point of input data (none, or half-cycle)
+    pub sample_shifting: SampleShifting,
 }
 
 impl Default for Config {
@@ -68,6 +70,7 @@ impl Default for Config {
             prescaler: 128,
             fifo_threshold: FIFOThresholdLevel::_17Bytes,
             cs_high_time: ChipSelectHighTime::_5Cycle,
+            sample_shifting: SampleShifting::None
         }
     }
 }
@@ -120,7 +123,7 @@ impl<'d, T: Instance, M: PeriMode> Qspi<'d, T, M> {
         T::REGS.cr().modify(|w| {
             w.set_en(true);
             //w.set_tcen(false);
-            w.set_sshift(false);
+            w.set_sshift(config.sample_shifting.into());
             w.set_fthres(config.fifo_threshold.into());
             w.set_prescaler(config.prescaler);
             w.set_fsel(fsel.into());

--- a/embassy-stm32/src/qspi/mod.rs
+++ b/embassy-stm32/src/qspi/mod.rs
@@ -70,7 +70,7 @@ impl Default for Config {
             prescaler: 128,
             fifo_threshold: FIFOThresholdLevel::_17Bytes,
             cs_high_time: ChipSelectHighTime::_5Cycle,
-            sample_shifting: SampleShifting::None
+            sample_shifting: SampleShifting::None,
         }
     }
 }

--- a/examples/stm32f7/src/bin/qspi.rs
+++ b/examples/stm32f7/src/bin/qspi.rs
@@ -279,6 +279,7 @@ async fn main(_spawner: Spawner) -> ! {
         prescaler: 16,
         cs_high_time: ChipSelectHighTime::_1Cycle,
         fifo_threshold: FIFOThresholdLevel::_16Bytes,
+        sample_shifting: SampleShifting::None,
     };
     let driver = Qspi::new_bank1(
         p.QUADSPI, p.PF8, p.PF9, p.PE2, p.PF6, p.PF10, p.PB10, p.DMA2_CH7, config,

--- a/examples/stm32h742/src/bin/qspi.rs
+++ b/examples/stm32h742/src/bin/qspi.rs
@@ -272,6 +272,7 @@ async fn main(_spawner: Spawner) -> ! {
         prescaler: 16,
         cs_high_time: ChipSelectHighTime::_1Cycle,
         fifo_threshold: FIFOThresholdLevel::_16Bytes,
+        sample_shifting: SampleShifting::None,
     };
     let driver = Qspi::new_blocking_bank1(p.QUADSPI, p.PD11, p.PD12, p.PE2, p.PD13, p.PB2, p.PB10, config);
     let mut flash = FlashMemory::new(driver);

--- a/examples/stm32l432/src/bin/qspi_mmap.rs
+++ b/examples/stm32l432/src/bin/qspi_mmap.rs
@@ -7,7 +7,8 @@
 use defmt::info;
 use embassy_stm32::mode;
 use embassy_stm32::qspi::enums::{
-    AddressSize, ChipSelectHighTime, DummyCycles, FIFOThresholdLevel, MemorySize, QspiWidth,
+    AddressSize, ChipSelectHighTime, DummyCycles, FIFOThresholdLevel, MemorySize, QspiWidth, 
+    SampleShifting
 };
 use embassy_stm32::qspi::{self, Instance, TransferConfig};
 pub struct FlashMemory<I: Instance> {
@@ -252,6 +253,7 @@ async fn main(_spawner: Spawner) {
         prescaler: 200,
         cs_high_time: ChipSelectHighTime::_1Cycle,
         fifo_threshold: FIFOThresholdLevel::_16Bytes,
+        sample_shifting: SampleShifting::None,
     };
     let driver = qspi::Qspi::new_bank1(p.QUADSPI, p.PB1, p.PB0, p.PA7, p.PA6, p.PA3, p.PA2, p.DMA2_CH7, config);
     let mut flash = FlashMemory::new(driver);

--- a/examples/stm32l432/src/bin/qspi_mmap.rs
+++ b/examples/stm32l432/src/bin/qspi_mmap.rs
@@ -7,8 +7,7 @@
 use defmt::info;
 use embassy_stm32::mode;
 use embassy_stm32::qspi::enums::{
-    AddressSize, ChipSelectHighTime, DummyCycles, FIFOThresholdLevel, MemorySize, QspiWidth, 
-    SampleShifting
+    AddressSize, ChipSelectHighTime, DummyCycles, FIFOThresholdLevel, MemorySize, QspiWidth, SampleShifting,
 };
 use embassy_stm32::qspi::{self, Instance, TransferConfig};
 pub struct FlashMemory<I: Instance> {


### PR DESCRIPTION
I noticed the sample shifting configuration for the stm32 QSPI driver is missing as `QUADSPI.cr().sshift()` is always set to `false` on initialization [here](https://github.com/embassy-rs/embassy/blob/main/embassy-stm32/src/qspi/mod.rs#L123). 

This PR adds the sample shifting option found in the STM32 CubeIDE to the existing embassy-stm32 QSPI Config.