### PR TITLE
excutor: fix Send unsoundness with `-> impl Future` tasks.

### DIFF
--- a/embassy-executor/tests/ui.rs
+++ b/embassy-executor/tests/ui.rs
@@ -17,6 +17,8 @@ fn ui() {
     t.compile_fail("tests/ui/nonstatic_struct_elided.rs");
     t.compile_fail("tests/ui/nonstatic_struct_generic.rs");
     t.compile_fail("tests/ui/not_async.rs");
+    t.compile_fail("tests/ui/spawn_nonsend.rs");
+    t.compile_fail("tests/ui/return_impl_future_nonsend.rs");
     if rustversion::cfg!(stable) {
         // output is slightly different on nightly
         t.compile_fail("tests/ui/bad_return_impl_future.rs");

--- a/embassy-executor/tests/ui/return_impl_future_nonsend.rs
+++ b/embassy-executor/tests/ui/return_impl_future_nonsend.rs
@@ -1,0 +1,21 @@
+#![cfg_attr(feature = "nightly", feature(impl_trait_in_assoc_type))]
+
+use core::future::Future;
+
+use embassy_executor::SendSpawner;
+
+#[embassy_executor::task]
+fn task() -> impl Future<Output = ()> {
+    // runs in spawning thread
+    let non_send: *mut () = core::ptr::null_mut();
+    async move {
+        // runs in executor thread
+        println!("{}", non_send as usize);
+    }
+}
+
+fn send_spawn(s: SendSpawner) {
+    s.spawn(task()).unwrap();
+}
+
+fn main() {}

--- a/embassy-executor/tests/ui/return_impl_future_nonsend.stderr
+++ b/embassy-executor/tests/ui/return_impl_future_nonsend.stderr
@@ -1,0 +1,17 @@
+error: future cannot be sent between threads safely
+  --> tests/ui/return_impl_future_nonsend.rs:18:13
+   |
+18 |     s.spawn(task()).unwrap();
+   |             ^^^^^^ future created by async block is not `Send`
+   |
+   = help: within `impl Sized`, the trait `Send` is not implemented for `*mut ()`
+note: captured value is not `Send`
+  --> tests/ui/return_impl_future_nonsend.rs:13:24
+   |
+13 |         println!("{}", non_send as usize);
+   |                        ^^^^^^^^ has type `*mut ()` which is not `Send`
+note: required by a bound in `SendSpawner::spawn`
+  --> src/spawner.rs
+   |
+   |     pub fn spawn<S: Send>(&self, token: SpawnToken<S>) -> Result<(), SpawnError> {
+   |                     ^^^^ required by this bound in `SendSpawner::spawn`

--- a/embassy-executor/tests/ui/return_impl_send.stderr
+++ b/embassy-executor/tests/ui/return_impl_send.stderr
@@ -91,14 +91,14 @@ error[E0277]: `impl Send` is not a future
   | ^^^^^^^^^^^^^^^^^^^^^^^^^ `impl Send` is not a future
   |
   = help: the trait `Future` is not implemented for `impl Send`
-note: required by a bound in `TaskPool::<F, N>::_spawn_async_fn`
+note: required by a bound in `TaskPool::<F, N>::spawn`
  --> src/raw/mod.rs
   |
   | impl<F: Future + 'static, const N: usize> TaskPool<F, N> {
-  |         ^^^^^^ required by this bound in `TaskPool::<F, N>::_spawn_async_fn`
+  |         ^^^^^^ required by this bound in `TaskPool::<F, N>::spawn`
 ...
-  |     pub unsafe fn _spawn_async_fn<FutFn>(&'static self, future: FutFn) -> SpawnToken<impl Sized>
-  |                   --------------- required by a bound in this associated function
+  |     pub fn spawn(&'static self, future: impl FnOnce() -> F) -> SpawnToken<impl Sized> {
+  |            ----- required by a bound in this associated function
   = note: this error originates in the attribute macro `embassy_executor::task` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: task futures must resolve to `()` or `!`

--- a/embassy-executor/tests/ui/spawn_nonsend.rs
+++ b/embassy-executor/tests/ui/spawn_nonsend.rs
@@ -1,0 +1,16 @@
+#![cfg_attr(feature = "nightly", feature(impl_trait_in_assoc_type))]
+
+use core::future::Future;
+
+use embassy_executor::SendSpawner;
+
+#[embassy_executor::task]
+async fn task(non_send: *mut ()) {
+    println!("{}", non_send as usize);
+}
+
+fn send_spawn(s: SendSpawner) {
+    s.spawn(task(core::ptr::null_mut())).unwrap();
+}
+
+fn main() {}

--- a/embassy-executor/tests/ui/spawn_nonsend.stderr
+++ b/embassy-executor/tests/ui/spawn_nonsend.stderr
@@ -1,0 +1,41 @@
+warning: unused import: `core::future::Future`
+ --> tests/ui/spawn_nonsend.rs:3:5
+  |
+3 | use core::future::Future;
+  |     ^^^^^^^^^^^^^^^^^^^^
+  |
+  = note: `#[warn(unused_imports)]` on by default
+
+error[E0277]: `*mut ()` cannot be sent between threads safely
+  --> tests/ui/spawn_nonsend.rs:13:13
+   |
+7  | #[embassy_executor::task]
+   | ------------------------- within this `impl Sized`
+...
+13 |     s.spawn(task(core::ptr::null_mut())).unwrap();
+   |       ----- ^^^^^^^^^^^^^^^^^^^^^^^^^^^ `*mut ()` cannot be sent between threads safely
+   |       |
+   |       required by a bound introduced by this call
+   |
+   = help: within `impl Sized`, the trait `Send` is not implemented for `*mut ()`
+note: required because it's used within this closure
+  --> tests/ui/spawn_nonsend.rs:7:1
+   |
+7  | #[embassy_executor::task]
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^
+note: required because it appears within the type `impl Sized`
+  --> src/raw/mod.rs
+   |
+   |     pub unsafe fn _spawn_async_fn<FutFn>(&'static self, future: FutFn) -> SpawnToken<impl Sized>
+   |                                                                                      ^^^^^^^^^^
+note: required because it appears within the type `impl Sized`
+  --> tests/ui/spawn_nonsend.rs:7:1
+   |
+7  | #[embassy_executor::task]
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^
+note: required by a bound in `SendSpawner::spawn`
+  --> src/spawner.rs
+   |
+   |     pub fn spawn<S: Send>(&self, token: SpawnToken<S>) -> Result<(), SpawnError> {
+   |                     ^^^^ required by this bound in `SendSpawner::spawn`
+   = note: this error originates in the attribute macro `embassy_executor::task` (in Nightly builds, run with -Z macro-backtrace for more info)


### PR DESCRIPTION
If the task is `-> impl Future`, we can't use `_spawn_async_fn` because its safety precondition isn't satisfied. Otherwise this can be exploited to send non-Send things. Fix is to use the regular `spawn()` which will require the entire future to be `Send`. Unfortunate, but there's no way around it.

Exploit code:

```rust
use std::{marker::PhantomData, thread::ThreadId};

use embassy_executor::{Executor, SendSpawner};
use static_cell::StaticCell;

fn main() {
    static EXECUTOR: StaticCell<Executor> = StaticCell::new();
    let executor = EXECUTOR.init(Executor::new());
    executor.run(|spawner| {
        let send_spawner = spawner.make_send();
        std::thread::spawn(move || evil_thread(send_spawner));
    })
}

fn evil_thread(spawner: SendSpawner) {
    spawner.spawn(bomb_task()).unwrap();
}

#[embassy_executor::task]
fn bomb_task() -> impl Future<Output = ()> {
    // runs in evil thread
    let bomb = ThreadBomb::new();
    async move {
        // runs in main thread
        bomb.poke();
    }
}

struct ThreadBomb {
    thread_id: ThreadId,
    not_send: PhantomData<*mut ()>,
}

impl ThreadBomb {
    pub fn new() -> Self {
        Self {
            thread_id: std::thread::current().id(),
            not_send: PhantomData,
        }
    }

    pub fn poke(&self) {
        if std::thread::current().id() != self.thread_id {
            panic!("boom")
        }
    }
}
```
