### PR TITLE
executor: add task metadata, misc trace improvements.

### DIFF
--- a/.github/ci/test.sh
+++ b/.github/ci/test.sh
@@ -12,7 +12,7 @@ export CARGO_TARGET_DIR=/ci/cache/target
 # used when pointing stm32-metapac to a CI-built one.
 export CARGO_NET_GIT_FETCH_WITH_CLI=true
 
-cargo test --manifest-path ./embassy-executor/Cargo.toml
+cargo test --manifest-path ./embassy-executor/Cargo.toml --features metadata-name
 cargo test --manifest-path ./embassy-futures/Cargo.toml
 cargo test --manifest-path ./embassy-sync/Cargo.toml
 cargo test --manifest-path ./embassy-embedded-hal/Cargo.toml

--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ async fn main(spawner: Spawner) {
     let p = embassy_nrf::init(Default::default());
 
     // Spawned tasks run in the background, concurrently.
-    spawner.spawn(blink(p.P0_13.into())).unwrap();
+    spawner.spawn(blink(p.P0_13.into()).unwrap());
 
     let mut button = Input::new(p.P0_11, Pull::Up);
     loop {

--- a/ci.sh
+++ b/ci.sh
@@ -31,7 +31,9 @@ cargo batch \
     --- build --release --manifest-path embassy-executor/Cargo.toml --target thumbv6m-none-eabi --features defmt \
     --- build --release --manifest-path embassy-executor/Cargo.toml --target thumbv6m-none-eabi --features defmt,arch-cortex-m,executor-thread,executor-interrupt \
     --- build --release --manifest-path embassy-executor/Cargo.toml --target thumbv7em-none-eabi --features arch-cortex-m \
+    --- build --release --manifest-path embassy-executor/Cargo.toml --target thumbv7em-none-eabi --features arch-cortex-m,trace \
     --- build --release --manifest-path embassy-executor/Cargo.toml --target thumbv7em-none-eabi --features arch-cortex-m,rtos-trace \
+    --- build --release --manifest-path embassy-executor/Cargo.toml --target thumbv7em-none-eabi --features arch-cortex-m,trace,rtos-trace \
     --- build --release --manifest-path embassy-executor/Cargo.toml --target thumbv7em-none-eabi --features arch-cortex-m,executor-thread \
     --- build --release --manifest-path embassy-executor/Cargo.toml --target thumbv7em-none-eabi --features arch-cortex-m,executor-interrupt \
     --- build --release --manifest-path embassy-executor/Cargo.toml --target thumbv7em-none-eabi --features arch-cortex-m,executor-thread,executor-interrupt \

--- a/ci.sh
+++ b/ci.sh
@@ -31,6 +31,7 @@ cargo batch \
     --- build --release --manifest-path embassy-executor/Cargo.toml --target thumbv6m-none-eabi --features defmt \
     --- build --release --manifest-path embassy-executor/Cargo.toml --target thumbv6m-none-eabi --features defmt,arch-cortex-m,executor-thread,executor-interrupt \
     --- build --release --manifest-path embassy-executor/Cargo.toml --target thumbv7em-none-eabi --features arch-cortex-m \
+    --- build --release --manifest-path embassy-executor/Cargo.toml --target thumbv7em-none-eabi --features arch-cortex-m,metadata-name \
     --- build --release --manifest-path embassy-executor/Cargo.toml --target thumbv7em-none-eabi --features arch-cortex-m,trace \
     --- build --release --manifest-path embassy-executor/Cargo.toml --target thumbv7em-none-eabi --features arch-cortex-m,rtos-trace \
     --- build --release --manifest-path embassy-executor/Cargo.toml --target thumbv7em-none-eabi --features arch-cortex-m,trace,rtos-trace \

--- a/docs/examples/basic/src/main.rs
+++ b/docs/examples/basic/src/main.rs
@@ -22,5 +22,5 @@ async fn main(spawner: Spawner) {
     let p = embassy_nrf::init(Default::default());
 
     let led = Output::new(p.P0_13, Level::Low, OutputDrive::Standard);
-    unwrap!(spawner.spawn(blinker(led, Duration::from_millis(300))));
+    spawner.spawn(unwrap!(blinker(led, Duration::from_millis(300))));
 }

--- a/docs/pages/sharing_peripherals.adoc
+++ b/docs/pages/sharing_peripherals.adoc
@@ -36,8 +36,8 @@ async fn main(spawner: Spawner) {
     let dt = 100 * 1_000_000;
     let k = 1.003;
 
-    unwrap!(spawner.spawn(toggle_led(&LED, Duration::from_nanos(dt))));
-    unwrap!(spawner.spawn(toggle_led(&LED, Duration::from_nanos((dt as f64 * k) as u64))));
+    spawner.spawn(unwrap!(toggle_led(&LED, Duration::from_nanos(dt))));
+    spawner.spawn(unwrap!(toggle_led(&LED, Duration::from_nanos((dt as f64 * k) as u64))));
 }
 
 // A pool size of 2 means you can spawn two instances of this task.
@@ -103,8 +103,8 @@ async fn main(spawner: Spawner) {
     let dt = 100 * 1_000_000;
     let k = 1.003;
 
-    unwrap!(spawner.spawn(toggle_led(CHANNEL.sender(), Duration::from_nanos(dt))));
-    unwrap!(spawner.spawn(toggle_led(CHANNEL.sender(), Duration::from_nanos((dt as f64 * k) as u64))));
+    spawner.spawn(unwrap!(toggle_led(CHANNEL.sender(), Duration::from_nanos(dt))));
+    spawner.spawn(unwrap!(toggle_led(CHANNEL.sender(), Duration::from_nanos((dt as f64 * k) as u64))));
 
     loop {
         match CHANNEL.receive().await {

--- a/embassy-executor-macros/src/macros/main.rs
+++ b/embassy-executor-macros/src/macros/main.rs
@@ -181,7 +181,7 @@ For example: `#[embassy_executor::main(entry = ..., executor = \"some_crate::Exe
                 let mut executor = #executor::new();
                 let executor = unsafe { __make_static(&mut executor) };
                 executor.run(|spawner| {
-                    spawner.must_spawn(__embassy_main(spawner));
+                    spawner.spawn(__embassy_main(spawner).unwrap());
                 })
             },
         ),
@@ -191,7 +191,7 @@ For example: `#[embassy_executor::main(entry = ..., executor = \"some_crate::Exe
                 let executor = ::std::boxed::Box::leak(::std::boxed::Box::new(#executor::new()));
 
                 executor.start(|spawner| {
-                    spawner.must_spawn(__embassy_main(spawner));
+                    spawner.spawn(__embassy_main(spawner).unwrap());
                 });
 
                 Ok(())

--- a/embassy-executor-macros/src/macros/task.rs
+++ b/embassy-executor-macros/src/macros/task.rs
@@ -234,7 +234,7 @@ pub fn run(args: TokenStream, item: TokenStream) -> TokenStream {
     if !errors.is_empty() {
         task_outer_body = quote! {
             #![allow(unused_variables, unreachable_code)]
-            let _x: #embassy_executor::SpawnToken<()> = ::core::todo!();
+            let _x: ::core::result::Result<#embassy_executor::SpawnToken<()>, #embassy_executor::SpawnError> = ::core::todo!();
             _x
         };
     }
@@ -248,7 +248,7 @@ pub fn run(args: TokenStream, item: TokenStream) -> TokenStream {
         #task_inner
 
         #(#task_outer_attrs)*
-        #visibility #unsafety fn #task_ident #generics (#fargs) -> #embassy_executor::SpawnToken<impl Sized> #where_clause{
+        #visibility #unsafety fn #task_ident #generics (#fargs) -> ::core::result::Result<#embassy_executor::SpawnToken<impl Sized>, #embassy_executor::SpawnError> #where_clause{
             #task_outer_body
         }
 

--- a/embassy-executor/Cargo.toml
+++ b/embassy-executor/Cargo.toml
@@ -115,7 +115,8 @@ arch-spin = ["_arch"]
 executor-thread = []
 ## Enable the interrupt-mode executor (available in Cortex-M only)
 executor-interrupt = []
-## Enable tracing support (adds some overhead)
-trace = []
+## Enable tracing hooks
+trace = ["_any_trace"]
 ## Enable support for rtos-trace framework
-rtos-trace = ["dep:rtos-trace", "trace", "dep:embassy-time-driver"]
+rtos-trace = ["dep:rtos-trace", "_any_trace", "dep:embassy-time-driver"]
+_any_trace = []

--- a/embassy-executor/Cargo.toml
+++ b/embassy-executor/Cargo.toml
@@ -109,6 +109,11 @@ arch-avr = ["_arch", "dep:portable-atomic", "dep:avr-device"]
 ## spin (architecture agnostic; never sleeps)
 arch-spin = ["_arch"]
 
+#! ### Metadata
+
+## Enable the `name` field in task metadata.
+metadata-name = []
+
 #! ### Executor
 
 ## Enable the thread-mode executor (using WFE/SEV in Cortex-M, WFI in other embedded archs)
@@ -118,5 +123,5 @@ executor-interrupt = []
 ## Enable tracing hooks
 trace = ["_any_trace"]
 ## Enable support for rtos-trace framework
-rtos-trace = ["dep:rtos-trace", "_any_trace", "dep:embassy-time-driver"]
+rtos-trace = ["_any_trace", "metadata-name", "dep:rtos-trace", "dep:embassy-time-driver"]
 _any_trace = []

--- a/embassy-executor/src/lib.rs
+++ b/embassy-executor/src/lib.rs
@@ -54,6 +54,9 @@ pub mod raw;
 mod spawner;
 pub use spawner::*;
 
+mod metadata;
+pub use metadata::*;
+
 /// Implementation details for embassy macros.
 /// Do not use. Used for macros and HALs only. Not covered by semver guarantees.
 #[doc(hidden)]

--- a/embassy-executor/src/metadata.rs
+++ b/embassy-executor/src/metadata.rs
@@ -1,0 +1,1 @@
+pub struct Metadata {}

--- a/embassy-executor/src/metadata.rs
+++ b/embassy-executor/src/metadata.rs
@@ -1,1 +1,55 @@
-pub struct Metadata {}
+#[cfg(feature = "metadata-name")]
+use core::cell::Cell;
+use core::future::{poll_fn, Future};
+use core::task::Poll;
+
+#[cfg(feature = "metadata-name")]
+use critical_section::Mutex;
+
+use crate::raw;
+
+/// Metadata associated with a task.
+pub struct Metadata {
+    #[cfg(feature = "metadata-name")]
+    name: Mutex<Cell<Option<&'static str>>>,
+}
+
+impl Metadata {
+    pub(crate) const fn new() -> Self {
+        Self {
+            #[cfg(feature = "metadata-name")]
+            name: Mutex::new(Cell::new(None)),
+        }
+    }
+
+    pub(crate) fn reset(&self) {
+        #[cfg(feature = "metadata-name")]
+        critical_section::with(|cs| self.name.borrow(cs).set(None));
+    }
+
+    /// Get the metadata for the current task.
+    ///
+    /// You can use this to read or modify the current task's metadata.
+    ///
+    /// This function is `async` just to get access to the current async
+    /// context. It returns instantly, it does not block/yield.
+    pub fn for_current_task() -> impl Future<Output = &'static Self> {
+        poll_fn(|cx| Poll::Ready(raw::task_from_waker(cx.waker()).metadata()))
+    }
+
+    /// Get this task's name
+    ///
+    /// NOTE: this takes a critical section.
+    #[cfg(feature = "metadata-name")]
+    pub fn name(&self) -> Option<&'static str> {
+        critical_section::with(|cs| self.name.borrow(cs).get())
+    }
+
+    /// Set this task's name
+    ///
+    /// NOTE: this takes a critical section.
+    #[cfg(feature = "metadata-name")]
+    pub fn set_name(&self, name: &'static str) {
+        critical_section::with(|cs| self.name.borrow(cs).set(Some(name)))
+    }
+}

--- a/embassy-executor/src/raw/mod.rs
+++ b/embassy-executor/src/raw/mod.rs
@@ -97,8 +97,6 @@ pub(crate) struct TaskHeader {
     #[cfg(feature = "trace")]
     pub(crate) name: Option<&'static str>,
     #[cfg(feature = "trace")]
-    pub(crate) id: u32,
-    #[cfg(feature = "trace")]
     all_tasks_next: AtomicPtr<TaskHeader>,
 }
 
@@ -148,6 +146,12 @@ impl TaskRef {
     pub(crate) fn as_ptr(self) -> *const TaskHeader {
         self.ptr.as_ptr()
     }
+
+    /// Returns the task ID.
+    /// This can be used in combination with rtos-trace to match task names with IDs
+    pub fn id(&self) -> u32 {
+        self.as_ptr() as u32
+    }
 }
 
 /// Raw storage in which a task can be spawned.
@@ -191,8 +195,6 @@ impl<F: Future + 'static> TaskStorage<F> {
                 timer_queue_item: TimerQueueItem::new(),
                 #[cfg(feature = "trace")]
                 name: None,
-                #[cfg(feature = "trace")]
-                id: 0,
                 #[cfg(feature = "trace")]
                 all_tasks_next: AtomicPtr::new(core::ptr::null_mut()),
             },

--- a/embassy-executor/src/raw/mod.rs
+++ b/embassy-executor/src/raw/mod.rs
@@ -16,7 +16,7 @@ mod run_queue;
 #[cfg_attr(not(target_has_atomic = "8"), path = "state_critical_section.rs")]
 mod state;
 
-#[cfg(feature = "trace")]
+#[cfg(feature = "_any_trace")]
 pub mod trace;
 pub(crate) mod util;
 #[cfg_attr(feature = "turbowakers", path = "waker_turbo.rs")]
@@ -94,9 +94,9 @@ pub(crate) struct TaskHeader {
 
     /// Integrated timer queue storage. This field should not be accessed outside of the timer queue.
     pub(crate) timer_queue_item: TimerQueueItem,
-    #[cfg(feature = "trace")]
+    #[cfg(feature = "_any_trace")]
     pub(crate) name: Option<&'static str>,
-    #[cfg(feature = "trace")]
+    #[cfg(feature = "rtos-trace")]
     all_tasks_next: AtomicPtr<TaskHeader>,
 }
 
@@ -193,9 +193,9 @@ impl<F: Future + 'static> TaskStorage<F> {
                 poll_fn: SyncUnsafeCell::new(None),
 
                 timer_queue_item: TimerQueueItem::new(),
-                #[cfg(feature = "trace")]
+                #[cfg(feature = "_any_trace")]
                 name: None,
-                #[cfg(feature = "trace")]
+                #[cfg(feature = "rtos-trace")]
                 all_tasks_next: AtomicPtr::new(core::ptr::null_mut()),
             },
             future: UninitCell::uninit(),
@@ -231,7 +231,7 @@ impl<F: Future + 'static> TaskStorage<F> {
         let mut cx = Context::from_waker(&waker);
         match future.poll(&mut cx) {
             Poll::Ready(_) => {
-                #[cfg(feature = "trace")]
+                #[cfg(feature = "_any_trace")]
                 let exec_ptr: *const SyncExecutor = this.raw.executor.load(Ordering::Relaxed);
 
                 // As the future has finished and this function will not be called
@@ -246,7 +246,7 @@ impl<F: Future + 'static> TaskStorage<F> {
                 // after we're done with it.
                 this.raw.state.despawn();
 
-                #[cfg(feature = "trace")]
+                #[cfg(feature = "_any_trace")]
                 trace::task_end(exec_ptr, &p);
             }
             Poll::Pending => {}
@@ -419,7 +419,7 @@ impl SyncExecutor {
     /// - `task` must NOT be already enqueued (in this executor or another one).
     #[inline(always)]
     unsafe fn enqueue(&self, task: TaskRef, l: state::Token) {
-        #[cfg(feature = "trace")]
+        #[cfg(feature = "_any_trace")]
         trace::task_ready_begin(self, &task);
 
         if self.run_queue.enqueue(task, l) {
@@ -432,7 +432,7 @@ impl SyncExecutor {
             .executor
             .store((self as *const Self).cast_mut(), Ordering::Relaxed);
 
-        #[cfg(feature = "trace")]
+        #[cfg(feature = "_any_trace")]
         trace::task_new(self, &task);
 
         state::locked(|l| {
@@ -444,23 +444,23 @@ impl SyncExecutor {
     ///
     /// Same as [`Executor::poll`], plus you must only call this on the thread this executor was created.
     pub(crate) unsafe fn poll(&'static self) {
-        #[cfg(feature = "trace")]
+        #[cfg(feature = "_any_trace")]
         trace::poll_start(self);
 
         self.run_queue.dequeue_all(|p| {
             let task = p.header();
 
-            #[cfg(feature = "trace")]
+            #[cfg(feature = "_any_trace")]
             trace::task_exec_begin(self, &p);
 
             // Run the task
             task.poll_fn.get().unwrap_unchecked()(p);
 
-            #[cfg(feature = "trace")]
+            #[cfg(feature = "_any_trace")]
             trace::task_exec_end(self, &p);
         });
 
-        #[cfg(feature = "trace")]
+        #[cfg(feature = "_any_trace")]
         trace::executor_idle(self)
     }
 }

--- a/embassy-executor/src/raw/mod.rs
+++ b/embassy-executor/src/raw/mod.rs
@@ -41,6 +41,7 @@ use self::state::State;
 use self::util::{SyncUnsafeCell, UninitCell};
 pub use self::waker::task_from_waker;
 use super::SpawnToken;
+use crate::Metadata;
 
 #[no_mangle]
 extern "Rust" fn __embassy_time_queue_item_from_waker(waker: &Waker) -> &'static mut TimerQueueItem {
@@ -94,8 +95,8 @@ pub(crate) struct TaskHeader {
 
     /// Integrated timer queue storage. This field should not be accessed outside of the timer queue.
     pub(crate) timer_queue_item: TimerQueueItem,
-    #[cfg(feature = "_any_trace")]
-    pub(crate) name: Option<&'static str>,
+    pub(crate) metadata: Metadata,
+
     #[cfg(feature = "rtos-trace")]
     all_tasks_next: AtomicPtr<TaskHeader>,
 }
@@ -125,6 +126,10 @@ impl TaskRef {
 
     pub(crate) fn header(self) -> &'static TaskHeader {
         unsafe { self.ptr.as_ref() }
+    }
+
+    pub(crate) fn metadata(self) -> &'static Metadata {
+        unsafe { &self.ptr.as_ref().metadata }
     }
 
     /// Returns a reference to the executor that the task is currently running on.
@@ -193,8 +198,7 @@ impl<F: Future + 'static> TaskStorage<F> {
                 poll_fn: SyncUnsafeCell::new(None),
 
                 timer_queue_item: TimerQueueItem::new(),
-                #[cfg(feature = "_any_trace")]
-                name: None,
+                metadata: Metadata::new(),
                 #[cfg(feature = "rtos-trace")]
                 all_tasks_next: AtomicPtr::new(core::ptr::null_mut()),
             },
@@ -281,6 +285,7 @@ impl<F: Future + 'static> AvailableTask<F> {
 
     fn initialize_impl<S>(self, future: impl FnOnce() -> F) -> SpawnToken<S> {
         unsafe {
+            self.task.raw.metadata.reset();
             self.task.raw.poll_fn.set(Some(TaskStorage::<F>::poll));
             self.task.future.write_in_place(future);
 

--- a/embassy-executor/src/raw/trace.rs
+++ b/embassy-executor/src/raw/trace.rs
@@ -128,7 +128,7 @@ impl TaskTracker {
     /// # Arguments
     /// * `task` - The task reference to add to the tracker
     pub fn add(&self, task: TaskRef) {
-        let task_ptr = task.as_ptr() as *mut TaskHeader;
+        let task_ptr = task.as_ptr();
 
         loop {
             let current_head = self.head.load(Ordering::Acquire);
@@ -138,7 +138,7 @@ impl TaskTracker {
 
             if self
                 .head
-                .compare_exchange(current_head, task_ptr, Ordering::Release, Ordering::Relaxed)
+                .compare_exchange(current_head, task_ptr.cast_mut(), Ordering::Release, Ordering::Relaxed)
                 .is_ok()
             {
                 break;

--- a/embassy-executor/src/raw/trace.rs
+++ b/embassy-executor/src/raw/trace.rs
@@ -176,12 +176,6 @@ pub trait TaskRefTrace {
 
     /// Set the name for a task
     fn set_name(&self, name: Option<&'static str>);
-
-    /// Get the ID for a task
-    fn id(&self) -> u32;
-
-    /// Set the ID for a task
-    fn set_id(&self, id: u32);
 }
 
 impl TaskRefTrace for TaskRef {
@@ -193,17 +187,6 @@ impl TaskRefTrace for TaskRef {
         unsafe {
             let header_ptr = self.ptr.as_ptr() as *mut TaskHeader;
             (*header_ptr).name = name;
-        }
-    }
-
-    fn id(&self) -> u32 {
-        self.header().id
-    }
-
-    fn set_id(&self, id: u32) {
-        unsafe {
-            let header_ptr = self.ptr.as_ptr() as *mut TaskHeader;
-            (*header_ptr).id = id;
         }
     }
 }

--- a/embassy-executor/src/raw/trace.rs
+++ b/embassy-executor/src/raw/trace.rs
@@ -168,32 +168,6 @@ impl TaskTracker {
     }
 }
 
-/// Extension trait for `TaskRef` that provides tracing functionality.
-///
-/// This trait is only available when the `trace` feature is enabled.
-/// It extends `TaskRef` with methods for accessing and modifying task identifiers
-/// and names, which are useful for debugging, logging, and performance analysis.
-pub trait TaskRefTrace {
-    /// Get the name for a task
-    fn name(&self) -> Option<&'static str>;
-
-    /// Set the name for a task
-    fn set_name(&self, name: Option<&'static str>);
-}
-
-impl TaskRefTrace for TaskRef {
-    fn name(&self) -> Option<&'static str> {
-        self.header().name
-    }
-
-    fn set_name(&self, name: Option<&'static str>) {
-        unsafe {
-            let header_ptr = self.ptr.as_ptr() as *mut TaskHeader;
-            (*header_ptr).name = name;
-        }
-    }
-}
-
 #[cfg(feature = "trace")]
 extern "Rust" {
     /// This callback is called when the executor begins polling. This will always
@@ -383,9 +357,8 @@ where
 impl rtos_trace::RtosTraceOSCallbacks for crate::raw::SyncExecutor {
     fn task_list() {
         with_all_active_tasks(|task| {
-            let name = task.name().unwrap_or("unnamed task\0");
             let info = rtos_trace::TaskInfo {
-                name,
+                name: task.metadata().name().unwrap_or("unnamed task\0"),
                 priority: 0,
                 stack_base: 0,
                 stack_size: 0,

--- a/embassy-executor/src/spawner.rs
+++ b/embassy-executor/src/spawner.rs
@@ -36,12 +36,12 @@ impl<S> SpawnToken<S> {
         }
     }
 
-    /// Returns the task id if available, otherwise 0
-    /// This can be used in combination with rtos-trace to match task names with id's
+    /// Returns the task ID if available, otherwise 0
+    /// This can be used in combination with rtos-trace to match task names with IDs
     pub fn id(&self) -> u32 {
         match self.raw_task {
             None => 0,
-            Some(t) => t.as_ptr() as u32,
+            Some(t) => t.id(),
         }
     }
 
@@ -223,10 +223,8 @@ impl SpawnerTraceExt for Spawner {
 
         match task {
             Some(task) => {
-                // Set the name and ID when trace is enabled
+                // Set the name when trace is enabled
                 task.set_name(Some(name));
-                let task_id = task.as_ptr() as u32;
-                task.set_id(task_id);
 
                 unsafe { self.executor.spawn(task) };
                 Ok(())

--- a/embassy-executor/tests/test.rs
+++ b/embassy-executor/tests/test.rs
@@ -326,3 +326,34 @@ fn recursive_task() {
         spawner.spawn(task1());
     }
 }
+
+#[cfg(feature = "metadata-name")]
+#[test]
+fn task_metadata() {
+    #[task]
+    async fn task1(expected_name: Option<&'static str>) {
+        use embassy_executor::Metadata;
+        assert_eq!(Metadata::for_current_task().await.name(), expected_name);
+    }
+
+    // check no task name
+    let (executor, _) = setup();
+    executor.spawner().spawn(task1(None)).unwrap();
+    unsafe { executor.poll() };
+
+    // check setting task name
+    let token = task1(Some("foo"));
+    token.metadata().set_name("foo");
+    executor.spawner().spawn(token).unwrap();
+    unsafe { executor.poll() };
+
+    let token = task1(Some("bar"));
+    token.metadata().set_name("bar");
+    executor.spawner().spawn(token).unwrap();
+    unsafe { executor.poll() };
+
+    // check name is cleared if the task pool slot is recycled.
+    let (executor, _) = setup();
+    executor.spawner().spawn(task1(None)).unwrap();
+    unsafe { executor.poll() };
+}

--- a/embassy-executor/tests/test.rs
+++ b/embassy-executor/tests/test.rs
@@ -65,7 +65,7 @@ fn executor_task() {
     }
 
     let (executor, trace) = setup();
-    executor.spawner().spawn(task1(trace.clone())).unwrap();
+    executor.spawner().spawn(task1(trace.clone()).unwrap());
 
     unsafe { executor.poll() };
     unsafe { executor.poll() };
@@ -93,7 +93,7 @@ fn executor_task_rpit() {
     }
 
     let (executor, trace) = setup();
-    executor.spawner().spawn(task1(trace.clone())).unwrap();
+    executor.spawner().spawn(task1(trace.clone()).unwrap());
 
     unsafe { executor.poll() };
     unsafe { executor.poll() };
@@ -120,7 +120,7 @@ fn executor_task_self_wake() {
     }
 
     let (executor, trace) = setup();
-    executor.spawner().spawn(task1(trace.clone())).unwrap();
+    executor.spawner().spawn(task1(trace.clone()).unwrap());
 
     unsafe { executor.poll() };
     unsafe { executor.poll() };
@@ -152,7 +152,7 @@ fn executor_task_self_wake_twice() {
     }
 
     let (executor, trace) = setup();
-    executor.spawner().spawn(task1(trace.clone())).unwrap();
+    executor.spawner().spawn(task1(trace.clone()).unwrap());
 
     unsafe { executor.poll() };
     unsafe { executor.poll() };
@@ -188,7 +188,7 @@ fn waking_after_completion_does_not_poll() {
     let waker = Box::leak(Box::new(AtomicWaker::new()));
 
     let (executor, trace) = setup();
-    executor.spawner().spawn(task1(trace.clone(), waker)).unwrap();
+    executor.spawner().spawn(task1(trace.clone(), waker).unwrap());
 
     unsafe { executor.poll() };
     waker.wake();
@@ -200,7 +200,7 @@ fn waking_after_completion_does_not_poll() {
     unsafe { executor.poll() }; // Clears running status
 
     // Can respawn waken-but-dead task
-    executor.spawner().spawn(task1(trace.clone(), waker)).unwrap();
+    executor.spawner().spawn(task1(trace.clone(), waker).unwrap());
 
     unsafe { executor.poll() };
 
@@ -250,7 +250,7 @@ fn waking_with_old_waker_after_respawn() {
     let waker = Box::leak(Box::new(AtomicWaker::new()));
 
     let (executor, trace) = setup();
-    executor.spawner().spawn(task1(trace.clone(), waker)).unwrap();
+    executor.spawner().spawn(task1(trace.clone(), waker).unwrap());
 
     unsafe { executor.poll() };
     unsafe { executor.poll() }; // progress to registering the waker
@@ -273,8 +273,7 @@ fn waking_with_old_waker_after_respawn() {
     let (other_executor, other_trace) = setup();
     other_executor
         .spawner()
-        .spawn(task1(other_trace.clone(), waker))
-        .unwrap();
+        .spawn(task1(other_trace.clone(), waker).unwrap());
 
     unsafe { other_executor.poll() }; // just run to the yield_now
     waker.wake(); // trigger old waker registration
@@ -323,7 +322,7 @@ fn recursive_task() {
     #[embassy_executor::task(pool_size = 2)]
     async fn task1() {
         let spawner = unsafe { Spawner::for_current_executor().await };
-        spawner.spawn(task1());
+        spawner.spawn(task1().unwrap());
     }
 }
 
@@ -338,22 +337,22 @@ fn task_metadata() {
 
     // check no task name
     let (executor, _) = setup();
-    executor.spawner().spawn(task1(None)).unwrap();
+    executor.spawner().spawn(task1(None).unwrap());
     unsafe { executor.poll() };
 
     // check setting task name
-    let token = task1(Some("foo"));
+    let token = task1(Some("foo")).unwrap();
     token.metadata().set_name("foo");
-    executor.spawner().spawn(token).unwrap();
+    executor.spawner().spawn(token);
     unsafe { executor.poll() };
 
-    let token = task1(Some("bar"));
+    let token = task1(Some("bar")).unwrap();
     token.metadata().set_name("bar");
-    executor.spawner().spawn(token).unwrap();
+    executor.spawner().spawn(token);
     unsafe { executor.poll() };
 
     // check name is cleared if the task pool slot is recycled.
     let (executor, _) = setup();
-    executor.spawner().spawn(task1(None)).unwrap();
+    executor.spawner().spawn(task1(None).unwrap());
     unsafe { executor.poll() };
 }

--- a/embassy-executor/tests/ui/return_impl_future_nonsend.rs
+++ b/embassy-executor/tests/ui/return_impl_future_nonsend.rs
@@ -15,7 +15,7 @@ fn task() -> impl Future<Output = ()> {
 }
 
 fn send_spawn(s: SendSpawner) {
-    s.spawn(task()).unwrap();
+    s.spawn(task().unwrap());
 }
 
 fn main() {}

--- a/embassy-executor/tests/ui/return_impl_future_nonsend.stderr
+++ b/embassy-executor/tests/ui/return_impl_future_nonsend.stderr
@@ -1,8 +1,8 @@
 error: future cannot be sent between threads safely
   --> tests/ui/return_impl_future_nonsend.rs:18:13
    |
-18 |     s.spawn(task()).unwrap();
-   |             ^^^^^^ future created by async block is not `Send`
+18 |     s.spawn(task().unwrap());
+   |             ^^^^^^^^^^^^^^^ future created by async block is not `Send`
    |
    = help: within `impl Sized`, the trait `Send` is not implemented for `*mut ()`
 note: captured value is not `Send`
@@ -13,5 +13,5 @@ note: captured value is not `Send`
 note: required by a bound in `SendSpawner::spawn`
   --> src/spawner.rs
    |
-   |     pub fn spawn<S: Send>(&self, token: SpawnToken<S>) -> Result<(), SpawnError> {
+   |     pub fn spawn<S: Send>(&self, token: SpawnToken<S>) {
    |                     ^^^^ required by this bound in `SendSpawner::spawn`

--- a/embassy-executor/tests/ui/return_impl_send.stderr
+++ b/embassy-executor/tests/ui/return_impl_send.stderr
@@ -97,7 +97,7 @@ note: required by a bound in `TaskPool::<F, N>::spawn`
   | impl<F: Future + 'static, const N: usize> TaskPool<F, N> {
   |         ^^^^^^ required by this bound in `TaskPool::<F, N>::spawn`
 ...
-  |     pub fn spawn(&'static self, future: impl FnOnce() -> F) -> SpawnToken<impl Sized> {
+  |     pub fn spawn(&'static self, future: impl FnOnce() -> F) -> Result<SpawnToken<impl Sized>, SpawnError> {
   |            ----- required by a bound in this associated function
   = note: this error originates in the attribute macro `embassy_executor::task` (in Nightly builds, run with -Z macro-backtrace for more info)
 

--- a/embassy-executor/tests/ui/spawn_nonsend.rs
+++ b/embassy-executor/tests/ui/spawn_nonsend.rs
@@ -10,7 +10,7 @@ async fn task(non_send: *mut ()) {
 }
 
 fn send_spawn(s: SendSpawner) {
-    s.spawn(task(core::ptr::null_mut())).unwrap();
+    s.spawn(task(core::ptr::null_mut()).unwrap());
 }
 
 fn main() {}

--- a/embassy-executor/tests/ui/spawn_nonsend.stderr
+++ b/embassy-executor/tests/ui/spawn_nonsend.stderr
@@ -12,8 +12,8 @@ error[E0277]: `*mut ()` cannot be sent between threads safely
 7  | #[embassy_executor::task]
    | ------------------------- within this `impl Sized`
 ...
-13 |     s.spawn(task(core::ptr::null_mut())).unwrap();
-   |       ----- ^^^^^^^^^^^^^^^^^^^^^^^^^^^ `*mut ()` cannot be sent between threads safely
+13 |     s.spawn(task(core::ptr::null_mut()).unwrap());
+   |       ----- ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `*mut ()` cannot be sent between threads safely
    |       |
    |       required by a bound introduced by this call
    |
@@ -26,8 +26,8 @@ note: required because it's used within this closure
 note: required because it appears within the type `impl Sized`
   --> src/raw/mod.rs
    |
-   |     pub unsafe fn _spawn_async_fn<FutFn>(&'static self, future: FutFn) -> SpawnToken<impl Sized>
-   |                                                                                      ^^^^^^^^^^
+   |     pub unsafe fn _spawn_async_fn<FutFn>(&'static self, future: FutFn) -> Result<SpawnToken<impl Sized>, SpawnError>
+   |                                                                                             ^^^^^^^^^^
 note: required because it appears within the type `impl Sized`
   --> tests/ui/spawn_nonsend.rs:7:1
    |
@@ -36,6 +36,6 @@ note: required because it appears within the type `impl Sized`
 note: required by a bound in `SendSpawner::spawn`
   --> src/spawner.rs
    |
-   |     pub fn spawn<S: Send>(&self, token: SpawnToken<S>) -> Result<(), SpawnError> {
+   |     pub fn spawn<S: Send>(&self, token: SpawnToken<S>) {
    |                     ^^^^ required by this bound in `SendSpawner::spawn`
    = note: this error originates in the attribute macro `embassy_executor::task` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/embassy-net/src/lib.rs
+++ b/embassy-net/src/lib.rs
@@ -464,7 +464,7 @@ impl<'d> Stack<'d> {
     ///    seed
     /// );
     /// // Launch network task that runs `runner.run().await`
-    /// spawner.spawn(net_task(runner)).unwrap();
+    /// spawner.spawn(net_task(runner).unwrap());
     /// // Wait for DHCP config
     /// stack.wait_config_up().await;
     /// // use the network stack

--- a/embassy-rp/src/multicore.rs
+++ b/embassy-rp/src/multicore.rs
@@ -38,11 +38,11 @@
 //!
 //!     embassy_rp::multicore::spawn_core1(p.CORE1, unsafe { &mut CORE1_STACK }, move || {
 //!         let executor1 = EXECUTOR1.init(Executor::new());
-//!         executor1.run(|spawner| spawner.spawn(core1_task()).unwrap());
+//!         executor1.run(|spawner| spawner.spawn(core1_task().unwrap()));
 //!     });
 //!
 //!     let executor0 = EXECUTOR0.init(Executor::new());
-//!     executor0.run(|spawner| spawner.spawn(core0_task()).unwrap())
+//!     executor0.run(|spawner| spawner.spawn(core0_task().unwrap()))
 //! }
 //! ```
 

--- a/embassy-stm32/src/low_power.rs
+++ b/embassy-stm32/src/low_power.rs
@@ -29,7 +29,7 @@
 //! #[cortex_m_rt::entry]
 //! fn main() -> ! {
 //!     Executor::take().run(|spawner| {
-//!         unwrap!(spawner.spawn(async_main(spawner)));
+//!         spawner.spawn(unwrap!(async_main(spawner)));
 //!     });
 //! }
 //!

--- a/examples/mimxrt6/src/bin/uart-async.rs
+++ b/examples/mimxrt6/src/bin/uart-async.rs
@@ -69,7 +69,7 @@ async fn main(spawner: Spawner) {
         Default::default(),
     )
     .unwrap();
-    spawner.must_spawn(usart4_task(usart4));
+    spawner.spawn(usart4_task(usart4).unwrap());
 
     let usart2 = Uart::new_with_rtscts(
         p.FLEXCOMM2,
@@ -83,5 +83,5 @@ async fn main(spawner: Spawner) {
         Default::default(),
     )
     .unwrap();
-    spawner.must_spawn(usart2_task(usart2));
+    spawner.spawn(usart2_task(usart2).unwrap());
 }

--- a/examples/mimxrt6/src/bin/uart.rs
+++ b/examples/mimxrt6/src/bin/uart.rs
@@ -48,8 +48,8 @@ async fn main(spawner: Spawner) {
     let usart4 = Uart::new_blocking(p.FLEXCOMM4, p.PIO0_29, p.PIO0_30, Default::default()).unwrap();
 
     let (_, usart4) = usart4.split();
-    spawner.must_spawn(usart4_task(usart4));
+    spawner.spawn(usart4_task(usart4).unwrap());
 
     let usart2 = UartTx::new_blocking(p.FLEXCOMM2, p.PIO0_15, Default::default()).unwrap();
-    spawner.must_spawn(usart2_task(usart2));
+    spawner.spawn(usart2_task(usart2).unwrap());
 }

--- a/examples/nrf-rtos-trace/src/bin/rtos_trace.rs
+++ b/examples/nrf-rtos-trace/src/bin/rtos_trace.rs
@@ -63,7 +63,7 @@ async fn main(spawner: Spawner) {
         ::log::set_max_level(::log::LevelFilter::Trace);
     }
 
-    spawner.spawn(run1()).unwrap();
-    spawner.spawn(run2()).unwrap();
-    spawner.spawn(run3()).unwrap();
+    spawner.spawn(run1().unwrap());
+    spawner.spawn(run2().unwrap());
+    spawner.spawn(run3().unwrap());
 }

--- a/examples/nrf52840/src/bin/channel.rs
+++ b/examples/nrf52840/src/bin/channel.rs
@@ -31,7 +31,7 @@ async fn main(spawner: Spawner) {
     let p = embassy_nrf::init(Default::default());
     let mut led = Output::new(p.P0_13, Level::Low, OutputDrive::Standard);
 
-    unwrap!(spawner.spawn(my_task()));
+    spawner.spawn(unwrap!(my_task()));
 
     loop {
         match CHANNEL.receive().await {

--- a/examples/nrf52840/src/bin/channel_sender_receiver.rs
+++ b/examples/nrf52840/src/bin/channel_sender_receiver.rs
@@ -45,6 +45,6 @@ async fn main(spawner: Spawner) {
     let p = embassy_nrf::init(Default::default());
     let channel = CHANNEL.init(Channel::new());
 
-    unwrap!(spawner.spawn(send_task(channel.sender())));
-    unwrap!(spawner.spawn(recv_task(p.P0_13.into(), channel.receiver())));
+    spawner.spawn(unwrap!(send_task(channel.sender())));
+    spawner.spawn(unwrap!(recv_task(p.P0_13.into(), channel.receiver())));
 }

--- a/examples/nrf52840/src/bin/ethernet_enc28j60.rs
+++ b/examples/nrf52840/src/bin/ethernet_enc28j60.rs
@@ -70,7 +70,7 @@ async fn main(spawner: Spawner) {
     static RESOURCES: StaticCell<StackResources<3>> = StaticCell::new();
     let (stack, runner) = embassy_net::new(device, config, RESOURCES.init(StackResources::new()), seed);
 
-    unwrap!(spawner.spawn(net_task(runner)));
+    spawner.spawn(unwrap!(net_task(runner)));
 
     // And now we can use it!
 

--- a/examples/nrf52840/src/bin/executor_fairness_test.rs
+++ b/examples/nrf52840/src/bin/executor_fairness_test.rs
@@ -36,7 +36,7 @@ async fn run3() {
 #[embassy_executor::main]
 async fn main(spawner: Spawner) {
     let _p = embassy_nrf::init(Default::default());
-    unwrap!(spawner.spawn(run1()));
-    unwrap!(spawner.spawn(run2()));
-    unwrap!(spawner.spawn(run3()));
+    spawner.spawn(unwrap!(run1()));
+    spawner.spawn(unwrap!(run2()));
+    spawner.spawn(unwrap!(run3()));
 }

--- a/examples/nrf52840/src/bin/gpiote_port.rs
+++ b/examples/nrf52840/src/bin/gpiote_port.rs
@@ -26,8 +26,8 @@ async fn main(spawner: Spawner) {
     let btn3 = Input::new(p.P0_24, Pull::Up);
     let btn4 = Input::new(p.P0_25, Pull::Up);
 
-    unwrap!(spawner.spawn(button_task(1, btn1)));
-    unwrap!(spawner.spawn(button_task(2, btn2)));
-    unwrap!(spawner.spawn(button_task(3, btn3)));
-    unwrap!(spawner.spawn(button_task(4, btn4)));
+    spawner.spawn(unwrap!(button_task(1, btn1)));
+    spawner.spawn(unwrap!(button_task(2, btn2)));
+    spawner.spawn(unwrap!(button_task(3, btn3)));
+    spawner.spawn(unwrap!(button_task(4, btn4)));
 }

--- a/examples/nrf52840/src/bin/manually_create_executor.rs
+++ b/examples/nrf52840/src/bin/manually_create_executor.rs
@@ -42,7 +42,7 @@ fn main() -> ! {
     // `run` calls the closure then runs the executor forever. It never returns.
     executor.run(|spawner| {
         // Here we get access to a spawner to spawn the initial tasks.
-        unwrap!(spawner.spawn(run1()));
-        unwrap!(spawner.spawn(run2()));
+        spawner.spawn(unwrap!(run1()));
+        spawner.spawn(unwrap!(run2()));
     });
 }

--- a/examples/nrf52840/src/bin/multiprio.rs
+++ b/examples/nrf52840/src/bin/multiprio.rs
@@ -130,16 +130,16 @@ fn main() -> ! {
     // High-priority executor: EGU1_SWI1, priority level 6
     interrupt::EGU1_SWI1.set_priority(Priority::P6);
     let spawner = EXECUTOR_HIGH.start(interrupt::EGU1_SWI1);
-    unwrap!(spawner.spawn(run_high()));
+    spawner.spawn(unwrap!(run_high()));
 
     // Medium-priority executor: EGU0_SWI0, priority level 7
     interrupt::EGU0_SWI0.set_priority(Priority::P7);
     let spawner = EXECUTOR_MED.start(interrupt::EGU0_SWI0);
-    unwrap!(spawner.spawn(run_med()));
+    spawner.spawn(unwrap!(run_med()));
 
     // Low priority executor: runs in thread mode, using WFE/SEV
     let executor = EXECUTOR_LOW.init(Executor::new());
     executor.run(|spawner| {
-        unwrap!(spawner.spawn(run_low()));
+        spawner.spawn(unwrap!(run_low()));
     });
 }

--- a/examples/nrf52840/src/bin/mutex.rs
+++ b/examples/nrf52840/src/bin/mutex.rs
@@ -30,7 +30,7 @@ async fn my_task() {
 #[embassy_executor::main]
 async fn main(spawner: Spawner) {
     let _p = embassy_nrf::init(Default::default());
-    unwrap!(spawner.spawn(my_task()));
+    spawner.spawn(unwrap!(my_task()));
 
     loop {
         Timer::after_millis(300).await;

--- a/examples/nrf52840/src/bin/pubsub.rs
+++ b/examples/nrf52840/src/bin/pubsub.rs
@@ -26,9 +26,9 @@ async fn main(spawner: Spawner) {
     // It's good to set up the subscribers before publishing anything.
     // A subscriber will only yield messages that have been published after its creation.
 
-    spawner.must_spawn(fast_logger(unwrap!(MESSAGE_BUS.subscriber())));
-    spawner.must_spawn(slow_logger(unwrap!(MESSAGE_BUS.dyn_subscriber())));
-    spawner.must_spawn(slow_logger_pure(unwrap!(MESSAGE_BUS.dyn_subscriber())));
+    spawner.spawn(fast_logger(unwrap!(MESSAGE_BUS.subscriber())).unwrap());
+    spawner.spawn(slow_logger(unwrap!(MESSAGE_BUS.dyn_subscriber())).unwrap());
+    spawner.spawn(slow_logger_pure(unwrap!(MESSAGE_BUS.dyn_subscriber())).unwrap());
 
     // Get a publisher
     let message_publisher = unwrap!(MESSAGE_BUS.publisher());

--- a/examples/nrf52840/src/bin/raw_spawn.rs
+++ b/examples/nrf52840/src/bin/raw_spawn.rs
@@ -42,8 +42,8 @@ fn main() -> ! {
     let run2_task = unsafe { make_static(&run2_task) };
 
     executor.run(|spawner| {
-        unwrap!(spawner.spawn(run1_task.spawn(|| run1())));
-        unwrap!(spawner.spawn(run2_task.spawn(|| run2())));
+        spawner.spawn(unwrap!(run1_task.spawn(|| run1())));
+        spawner.spawn(unwrap!(run2_task.spawn(|| run2())));
     });
 }
 

--- a/examples/nrf52840/src/bin/self_spawn.rs
+++ b/examples/nrf52840/src/bin/self_spawn.rs
@@ -14,12 +14,12 @@ mod config {
 async fn my_task(spawner: Spawner, n: u32) {
     Timer::after_secs(1).await;
     info!("Spawning self! {}", n);
-    unwrap!(spawner.spawn(my_task(spawner, n + 1)));
+    spawner.spawn(unwrap!(my_task(spawner, n + 1)));
 }
 
 #[embassy_executor::main]
 async fn main(spawner: Spawner) {
     let _p = embassy_nrf::init(Default::default());
     info!("Hello World!");
-    unwrap!(spawner.spawn(my_task(spawner, 0)));
+    spawner.spawn(unwrap!(my_task(spawner, 0)));
 }

--- a/examples/nrf52840/src/bin/self_spawn_current_executor.rs
+++ b/examples/nrf52840/src/bin/self_spawn_current_executor.rs
@@ -11,12 +11,12 @@ async fn my_task(n: u32) {
     Timer::after_secs(1).await;
     info!("Spawning self! {}", n);
     let spawner = unsafe { Spawner::for_current_executor().await };
-    unwrap!(spawner.spawn(my_task(n + 1)));
+    spawner.spawn(unwrap!(my_task(n + 1)));
 }
 
 #[embassy_executor::main]
 async fn main(spawner: Spawner) {
     let _p = embassy_nrf::init(Default::default());
     info!("Hello World!");
-    unwrap!(spawner.spawn(my_task(0)));
+    spawner.spawn(unwrap!(my_task(0)));
 }

--- a/examples/nrf52840/src/bin/timer.rs
+++ b/examples/nrf52840/src/bin/timer.rs
@@ -25,6 +25,6 @@ async fn run2() {
 #[embassy_executor::main]
 async fn main(spawner: Spawner) {
     let _p = embassy_nrf::init(Default::default());
-    unwrap!(spawner.spawn(run1()));
-    unwrap!(spawner.spawn(run2()));
+    spawner.spawn(unwrap!(run1()));
+    spawner.spawn(unwrap!(run2()));
 }

--- a/examples/nrf52840/src/bin/uart_split.rs
+++ b/examples/nrf52840/src/bin/uart_split.rs
@@ -30,7 +30,7 @@ async fn main(spawner: Spawner) {
 
     // Spawn a task responsible purely for reading
 
-    unwrap!(spawner.spawn(reader(rx)));
+    spawner.spawn(unwrap!(reader(rx)));
 
     // Message must be in SRAM
     {

--- a/examples/nrf52840/src/bin/usb_ethernet.rs
+++ b/examples/nrf52840/src/bin/usb_ethernet.rs
@@ -86,11 +86,11 @@ async fn main(spawner: Spawner) {
     // Build the builder.
     let usb = builder.build();
 
-    unwrap!(spawner.spawn(usb_task(usb)));
+    spawner.spawn(unwrap!(usb_task(usb)));
 
     static NET_STATE: StaticCell<NetState<MTU, 4, 4>> = StaticCell::new();
     let (runner, device) = class.into_embassy_net_device::<MTU, 4, 4>(NET_STATE.init(NetState::new()), our_mac_addr);
-    unwrap!(spawner.spawn(usb_ncm_task(runner)));
+    spawner.spawn(unwrap!(usb_ncm_task(runner)));
 
     let config = embassy_net::Config::dhcpv4(Default::default());
     // let config = embassy_net::Config::ipv4_static(embassy_net::StaticConfigV4 {
@@ -109,7 +109,7 @@ async fn main(spawner: Spawner) {
     static RESOURCES: StaticCell<StackResources<3>> = StaticCell::new();
     let (stack, runner) = embassy_net::new(device, config, RESOURCES.init(StackResources::new()), seed);
 
-    unwrap!(spawner.spawn(net_task(runner)));
+    spawner.spawn(unwrap!(net_task(runner)));
 
     // And now we can use it!
 

--- a/examples/nrf52840/src/bin/usb_serial_multitask.rs
+++ b/examples/nrf52840/src/bin/usb_serial_multitask.rs
@@ -76,8 +76,8 @@ async fn main(spawner: Spawner) {
     // Build the builder.
     let usb = builder.build();
 
-    unwrap!(spawner.spawn(usb_task(usb)));
-    unwrap!(spawner.spawn(echo_task(class)));
+    spawner.spawn(unwrap!(usb_task(usb)));
+    spawner.spawn(unwrap!(echo_task(class)));
 }
 
 struct Disconnected {}

--- a/examples/nrf52840/src/bin/wifi_esp_hosted.rs
+++ b/examples/nrf52840/src/bin/wifi_esp_hosted.rs
@@ -70,7 +70,7 @@ async fn main(spawner: Spawner) {
     )
     .await;
 
-    unwrap!(spawner.spawn(wifi_task(runner)));
+    spawner.spawn(unwrap!(wifi_task(runner)));
 
     unwrap!(control.init().await);
     unwrap!(control.connect(WIFI_NETWORK, WIFI_PASSWORD).await);
@@ -92,7 +92,7 @@ async fn main(spawner: Spawner) {
     static RESOURCES: StaticCell<StackResources<3>> = StaticCell::new();
     let (stack, runner) = embassy_net::new(device, config, RESOURCES.init(StackResources::new()), seed);
 
-    unwrap!(spawner.spawn(net_task(runner)));
+    spawner.spawn(unwrap!(net_task(runner)));
 
     // And now we can use it!
 

--- a/examples/nrf9160/src/bin/modem_tcp_client.rs
+++ b/examples/nrf9160/src/bin/modem_tcp_client.rs
@@ -112,7 +112,7 @@ async fn main(spawner: Spawner) {
 
     info!("Hello World!");
 
-    unwrap!(spawner.spawn(blink_task(p.P0_02.into())));
+    spawner.spawn(unwrap!(blink_task(p.P0_02.into())));
 
     let ipc_mem = unsafe {
         let ipc_start = &__start_ipc as *const u8 as *mut MaybeUninit<u8>;
@@ -138,8 +138,8 @@ async fn main(spawner: Spawner) {
     static TRACE: StaticCell<TraceBuffer> = StaticCell::new();
     let (device, control, runner, tracer) =
         embassy_net_nrf91::new_with_trace(STATE.init(State::new()), ipc_mem, TRACE.init(TraceBuffer::new())).await;
-    unwrap!(spawner.spawn(modem_task(runner)));
-    unwrap!(spawner.spawn(trace_task(uart, tracer)));
+    spawner.spawn(unwrap!(modem_task(runner)));
+    spawner.spawn(unwrap!(trace_task(uart, tracer)));
 
     let config = embassy_net::Config::default();
 
@@ -150,12 +150,12 @@ async fn main(spawner: Spawner) {
     static RESOURCES: StaticCell<StackResources<2>> = StaticCell::new();
     let (stack, runner) = embassy_net::new(device, config, RESOURCES.init(StackResources::<2>::new()), seed);
 
-    unwrap!(spawner.spawn(net_task(runner)));
+    spawner.spawn(unwrap!(net_task(runner)));
 
     static CONTROL: StaticCell<context::Control<'static>> = StaticCell::new();
     let control = CONTROL.init(context::Control::new(control, 0).await);
 
-    unwrap!(spawner.spawn(control_task(
+    spawner.spawn(unwrap!(control_task(
         control,
         context::Config {
             apn: b"iot.nat.es",

--- a/examples/rp/src/bin/assign_resources.rs
+++ b/examples/rp/src/bin/assign_resources.rs
@@ -26,15 +26,13 @@ async fn main(spawner: Spawner) {
     let p = embassy_rp::init(Default::default());
 
     // 1) Assigning a resource to a task by passing parts of the peripherals.
-    spawner
-        .spawn(double_blinky_manually_assigned(spawner, p.PIN_20, p.PIN_21))
-        .unwrap();
+    spawner.spawn(double_blinky_manually_assigned(spawner, p.PIN_20, p.PIN_21).unwrap());
 
     // 2) Using the assign-resources macro to assign resources to a task.
     // we perform the split, see further below for the definition of the resources struct
     let r = split_resources!(p);
     // and then we can use them
-    spawner.spawn(double_blinky_macro_assigned(spawner, r.leds)).unwrap();
+    spawner.spawn(double_blinky_macro_assigned(spawner, r.leds).unwrap());
 }
 
 // 1) Assigning a resource to a task by passing parts of the peripherals.

--- a/examples/rp/src/bin/blinky_two_channels.rs
+++ b/examples/rp/src/bin/blinky_two_channels.rs
@@ -27,8 +27,8 @@ async fn main(spawner: Spawner) {
     let dt = 100 * 1_000_000;
     let k = 1.003;
 
-    unwrap!(spawner.spawn(toggle_led(CHANNEL.sender(), Duration::from_nanos(dt))));
-    unwrap!(spawner.spawn(toggle_led(
+    spawner.spawn(unwrap!(toggle_led(CHANNEL.sender(), Duration::from_nanos(dt))));
+    spawner.spawn(unwrap!(toggle_led(
         CHANNEL.sender(),
         Duration::from_nanos((dt as f64 * k) as u64)
     )));

--- a/examples/rp/src/bin/blinky_two_tasks.rs
+++ b/examples/rp/src/bin/blinky_two_tasks.rs
@@ -30,8 +30,8 @@ async fn main(spawner: Spawner) {
     let dt = 100 * 1_000_000;
     let k = 1.003;
 
-    unwrap!(spawner.spawn(toggle_led(&LED, Duration::from_nanos(dt))));
-    unwrap!(spawner.spawn(toggle_led(&LED, Duration::from_nanos((dt as f64 * k) as u64))));
+    spawner.spawn(unwrap!(toggle_led(&LED, Duration::from_nanos(dt))));
+    spawner.spawn(unwrap!(toggle_led(&LED, Duration::from_nanos((dt as f64 * k) as u64))));
 }
 
 #[embassy_executor::task(pool_size = 2)]

--- a/examples/rp/src/bin/ethernet_w5500_icmp.rs
+++ b/examples/rp/src/bin/ethernet_w5500_icmp.rs
@@ -61,7 +61,7 @@ async fn main(spawner: Spawner) {
     )
     .await
     .unwrap();
-    unwrap!(spawner.spawn(ethernet_task(runner)));
+    spawner.spawn(unwrap!(ethernet_task(runner)));
 
     // Generate random seed
     let seed = rng.next_u64();
@@ -76,7 +76,7 @@ async fn main(spawner: Spawner) {
     );
 
     // Launch network task
-    unwrap!(spawner.spawn(net_task(runner)));
+    spawner.spawn(unwrap!(net_task(runner)));
 
     info!("Waiting for DHCP...");
     let cfg = wait_for_config(stack).await;

--- a/examples/rp/src/bin/ethernet_w5500_icmp_ping.rs
+++ b/examples/rp/src/bin/ethernet_w5500_icmp_ping.rs
@@ -63,7 +63,7 @@ async fn main(spawner: Spawner) {
     )
     .await
     .unwrap();
-    unwrap!(spawner.spawn(ethernet_task(runner)));
+    spawner.spawn(unwrap!(ethernet_task(runner)));
 
     // Generate random seed
     let seed = rng.next_u64();
@@ -78,7 +78,7 @@ async fn main(spawner: Spawner) {
     );
 
     // Launch network task
-    unwrap!(spawner.spawn(net_task(runner)));
+    spawner.spawn(unwrap!(net_task(runner)));
 
     info!("Waiting for DHCP...");
     let cfg = wait_for_config(stack).await;

--- a/examples/rp/src/bin/ethernet_w5500_multisocket.rs
+++ b/examples/rp/src/bin/ethernet_w5500_multisocket.rs
@@ -64,7 +64,7 @@ async fn main(spawner: Spawner) {
     )
     .await
     .unwrap();
-    unwrap!(spawner.spawn(ethernet_task(runner)));
+    spawner.spawn(unwrap!(ethernet_task(runner)));
 
     // Generate random seed
     let seed = rng.next_u64();
@@ -79,7 +79,7 @@ async fn main(spawner: Spawner) {
     );
 
     // Launch network task
-    unwrap!(spawner.spawn(net_task(runner)));
+    spawner.spawn(unwrap!(net_task(runner)));
 
     info!("Waiting for DHCP...");
     let cfg = wait_for_config(stack).await;
@@ -87,8 +87,8 @@ async fn main(spawner: Spawner) {
     info!("IP address: {:?}", local_addr);
 
     // Create two sockets listening to the same port, to handle simultaneous connections
-    unwrap!(spawner.spawn(listen_task(stack, 0, 1234)));
-    unwrap!(spawner.spawn(listen_task(stack, 1, 1234)));
+    spawner.spawn(unwrap!(listen_task(stack, 0, 1234)));
+    spawner.spawn(unwrap!(listen_task(stack, 1, 1234)));
 }
 
 #[embassy_executor::task(pool_size = 2)]

--- a/examples/rp/src/bin/ethernet_w5500_tcp_client.rs
+++ b/examples/rp/src/bin/ethernet_w5500_tcp_client.rs
@@ -67,7 +67,7 @@ async fn main(spawner: Spawner) {
     )
     .await
     .unwrap();
-    unwrap!(spawner.spawn(ethernet_task(runner)));
+    spawner.spawn(unwrap!(ethernet_task(runner)));
 
     // Generate random seed
     let seed = rng.next_u64();
@@ -82,7 +82,7 @@ async fn main(spawner: Spawner) {
     );
 
     // Launch network task
-    unwrap!(spawner.spawn(net_task(runner)));
+    spawner.spawn(unwrap!(net_task(runner)));
 
     info!("Waiting for DHCP...");
     let cfg = wait_for_config(stack).await;

--- a/examples/rp/src/bin/ethernet_w5500_tcp_server.rs
+++ b/examples/rp/src/bin/ethernet_w5500_tcp_server.rs
@@ -66,7 +66,7 @@ async fn main(spawner: Spawner) {
     )
     .await
     .unwrap();
-    unwrap!(spawner.spawn(ethernet_task(runner)));
+    spawner.spawn(unwrap!(ethernet_task(runner)));
 
     // Generate random seed
     let seed = rng.next_u64();
@@ -81,7 +81,7 @@ async fn main(spawner: Spawner) {
     );
 
     // Launch network task
-    unwrap!(spawner.spawn(net_task(runner)));
+    spawner.spawn(unwrap!(net_task(runner)));
 
     info!("Waiting for DHCP...");
     let cfg = wait_for_config(stack).await;

--- a/examples/rp/src/bin/ethernet_w5500_udp.rs
+++ b/examples/rp/src/bin/ethernet_w5500_udp.rs
@@ -64,7 +64,7 @@ async fn main(spawner: Spawner) {
     )
     .await
     .unwrap();
-    unwrap!(spawner.spawn(ethernet_task(runner)));
+    spawner.spawn(unwrap!(ethernet_task(runner)));
 
     // Generate random seed
     let seed = rng.next_u64();
@@ -79,7 +79,7 @@ async fn main(spawner: Spawner) {
     );
 
     // Launch network task
-    unwrap!(spawner.spawn(net_task(runner)));
+    spawner.spawn(unwrap!(net_task(runner)));
 
     info!("Waiting for DHCP...");
     let cfg = wait_for_config(stack).await;

--- a/examples/rp/src/bin/i2c_slave.rs
+++ b/examples/rp/src/bin/i2c_slave.rs
@@ -105,7 +105,7 @@ async fn main(spawner: Spawner) {
     config.addr = DEV_ADDR as u16;
     let device = i2c_slave::I2cSlave::new(p.I2C1, d_scl, d_sda, Irqs, config);
 
-    unwrap!(spawner.spawn(device_task(device)));
+    spawner.spawn(unwrap!(device_task(device)));
 
     let c_sda = p.PIN_0;
     let c_scl = p.PIN_1;
@@ -113,5 +113,5 @@ async fn main(spawner: Spawner) {
     config.frequency = 1_000_000;
     let controller = i2c::I2c::new_async(p.I2C0, c_scl, c_sda, Irqs, config);
 
-    unwrap!(spawner.spawn(controller_task(controller)));
+    spawner.spawn(unwrap!(controller_task(controller)));
 }

--- a/examples/rp/src/bin/interrupt.rs
+++ b/examples/rp/src/bin/interrupt.rs
@@ -51,7 +51,7 @@ async fn main(spawner: Spawner) {
     // No Mutex needed when sharing within the same executor/prio level
     static AVG: StaticCell<Cell<u32>> = StaticCell::new();
     let avg = AVG.init(Default::default());
-    spawner.must_spawn(processing(avg));
+    spawner.spawn(processing(avg).unwrap());
 
     let mut ticker = Ticker::every(Duration::from_secs(1));
     loop {

--- a/examples/rp/src/bin/multicore.rs
+++ b/examples/rp/src/bin/multicore.rs
@@ -35,12 +35,12 @@ fn main() -> ! {
         unsafe { &mut *core::ptr::addr_of_mut!(CORE1_STACK) },
         move || {
             let executor1 = EXECUTOR1.init(Executor::new());
-            executor1.run(|spawner| unwrap!(spawner.spawn(core1_task(led))));
+            executor1.run(|spawner| spawner.spawn(unwrap!(core1_task(led))));
         },
     );
 
     let executor0 = EXECUTOR0.init(Executor::new());
-    executor0.run(|spawner| unwrap!(spawner.spawn(core0_task())));
+    executor0.run(|spawner| spawner.spawn(unwrap!(core0_task())));
 }
 
 #[embassy_executor::task]

--- a/examples/rp/src/bin/multiprio.rs
+++ b/examples/rp/src/bin/multiprio.rs
@@ -130,16 +130,16 @@ fn main() -> ! {
     // High-priority executor: SWI_IRQ_1, priority level 2
     interrupt::SWI_IRQ_1.set_priority(Priority::P2);
     let spawner = EXECUTOR_HIGH.start(interrupt::SWI_IRQ_1);
-    unwrap!(spawner.spawn(run_high()));
+    spawner.spawn(unwrap!(run_high()));
 
     // Medium-priority executor: SWI_IRQ_0, priority level 3
     interrupt::SWI_IRQ_0.set_priority(Priority::P3);
     let spawner = EXECUTOR_MED.start(interrupt::SWI_IRQ_0);
-    unwrap!(spawner.spawn(run_med()));
+    spawner.spawn(unwrap!(run_med()));
 
     // Low priority executor: runs in thread mode, using WFE/SEV
     let executor = EXECUTOR_LOW.init(Executor::new());
     executor.run(|spawner| {
-        unwrap!(spawner.spawn(run_low()));
+        spawner.spawn(unwrap!(run_low()));
     });
 }

--- a/examples/rp/src/bin/orchestrate_tasks.rs
+++ b/examples/rp/src/bin/orchestrate_tasks.rs
@@ -129,13 +129,13 @@ async fn main(spawner: Spawner) {
     let p = embassy_rp::init(Default::default());
     let r = split_resources! {p};
 
-    spawner.spawn(orchestrate(spawner)).unwrap();
-    spawner.spawn(random_60s(spawner)).unwrap();
-    spawner.spawn(random_90s(spawner)).unwrap();
+    spawner.spawn(orchestrate(spawner).unwrap());
+    spawner.spawn(random_60s(spawner).unwrap());
+    spawner.spawn(random_90s(spawner).unwrap());
     // `random_30s` is not spawned here, butin the orchestrate task depending on state
-    spawner.spawn(usb_power(spawner, r.vbus)).unwrap();
-    spawner.spawn(vsys_voltage(spawner, r.vsys)).unwrap();
-    spawner.spawn(consumer(spawner)).unwrap();
+    spawner.spawn(usb_power(spawner, r.vbus).unwrap());
+    spawner.spawn(vsys_voltage(spawner, r.vsys).unwrap());
+    spawner.spawn(consumer(spawner).unwrap());
 }
 
 /// Main task that processes all events and updates system state.
@@ -198,7 +198,7 @@ async fn orchestrate(spawner: Spawner) {
                     drop(state);
                     if respawn_first_random_seed_task {
                         info!("(Re)-Starting the first random signal task");
-                        spawner.spawn(random_30s(spawner)).unwrap();
+                        spawner.spawn(random_30s(spawner).unwrap());
                     }
                 }
                 _ => {}

--- a/examples/rp/src/bin/pio_async.rs
+++ b/examples/rp/src/bin/pio_async.rs
@@ -125,7 +125,7 @@ async fn main(spawner: Spawner) {
     setup_pio_task_sm0(&mut common, &mut sm0, p.PIN_0);
     setup_pio_task_sm1(&mut common, &mut sm1);
     setup_pio_task_sm2(&mut common, &mut sm2);
-    spawner.spawn(pio_task_sm0(sm0)).unwrap();
-    spawner.spawn(pio_task_sm1(sm1)).unwrap();
-    spawner.spawn(pio_task_sm2(irq3, sm2)).unwrap();
+    spawner.spawn(pio_task_sm0(sm0).unwrap());
+    spawner.spawn(pio_task_sm1(sm1).unwrap());
+    spawner.spawn(pio_task_sm2(irq3, sm2).unwrap());
 }

--- a/examples/rp/src/bin/pio_rotary_encoder.rs
+++ b/examples/rp/src/bin/pio_rotary_encoder.rs
@@ -50,6 +50,6 @@ async fn main(spawner: Spawner) {
     let encoder0 = PioEncoder::new(&mut common, sm0, p.PIN_4, p.PIN_5, &prg);
     let encoder1 = PioEncoder::new(&mut common, sm1, p.PIN_6, p.PIN_7, &prg);
 
-    spawner.must_spawn(encoder_0(encoder0));
-    spawner.must_spawn(encoder_1(encoder1));
+    spawner.spawn(encoder_0(encoder0).unwrap());
+    spawner.spawn(encoder_1(encoder1).unwrap());
 }

--- a/examples/rp/src/bin/pwm.rs
+++ b/examples/rp/src/bin/pwm.rs
@@ -18,8 +18,8 @@ use {defmt_rtt as _, panic_probe as _};
 #[embassy_executor::main]
 async fn main(spawner: Spawner) {
     let p = embassy_rp::init(Default::default());
-    spawner.spawn(pwm_set_config(p.PWM_SLICE4, p.PIN_25)).unwrap();
-    spawner.spawn(pwm_set_dutycycle(p.PWM_SLICE2, p.PIN_4)).unwrap();
+    spawner.spawn(pwm_set_config(p.PWM_SLICE4, p.PIN_25).unwrap());
+    spawner.spawn(pwm_set_dutycycle(p.PWM_SLICE2, p.PIN_4).unwrap());
 }
 
 /// Demonstrate PWM by modifying & applying the config

--- a/examples/rp/src/bin/shared_bus.rs
+++ b/examples/rp/src/bin/shared_bus.rs
@@ -35,8 +35,8 @@ async fn main(spawner: Spawner) {
     static I2C_BUS: StaticCell<I2c1Bus> = StaticCell::new();
     let i2c_bus = I2C_BUS.init(Mutex::new(i2c));
 
-    spawner.must_spawn(i2c_task_a(i2c_bus));
-    spawner.must_spawn(i2c_task_b(i2c_bus));
+    spawner.spawn(i2c_task_a(i2c_bus).unwrap());
+    spawner.spawn(i2c_task_b(i2c_bus).unwrap());
 
     // Shared SPI bus
     let spi_cfg = spi::Config::default();
@@ -48,8 +48,8 @@ async fn main(spawner: Spawner) {
     let cs_a = Output::new(p.PIN_0, Level::High);
     let cs_b = Output::new(p.PIN_1, Level::High);
 
-    spawner.must_spawn(spi_task_a(spi_bus, cs_a));
-    spawner.must_spawn(spi_task_b(spi_bus, cs_b));
+    spawner.spawn(spi_task_a(spi_bus, cs_a).unwrap());
+    spawner.spawn(spi_task_b(spi_bus, cs_b).unwrap());
 }
 
 #[embassy_executor::task]

--- a/examples/rp/src/bin/sharing.rs
+++ b/examples/rp/src/bin/sharing.rs
@@ -68,7 +68,7 @@ fn main() -> ! {
     // High-priority executor: runs in interrupt mode
     interrupt::SWI_IRQ_0.set_priority(Priority::P3);
     let spawner = EXECUTOR_HI.start(interrupt::SWI_IRQ_0);
-    spawner.must_spawn(task_a(uart));
+    spawner.spawn(task_a(uart).unwrap());
 
     // Low priority executor: runs in thread mode
     let executor = EXECUTOR_LOW.init(Executor::new());
@@ -83,8 +83,8 @@ fn main() -> ! {
         static REF_CELL: ConstStaticCell<RefCell<MyType>> = ConstStaticCell::new(RefCell::new(MyType { inner: 0 }));
         let ref_cell = REF_CELL.take();
 
-        spawner.must_spawn(task_b(uart, cell, ref_cell));
-        spawner.must_spawn(task_c(cell, ref_cell));
+        spawner.spawn(task_b(uart, cell, ref_cell).unwrap());
+        spawner.spawn(task_c(cell, ref_cell).unwrap());
     });
 }
 

--- a/examples/rp/src/bin/uart_buffered_split.rs
+++ b/examples/rp/src/bin/uart_buffered_split.rs
@@ -33,7 +33,7 @@ async fn main(spawner: Spawner) {
     let uart = BufferedUart::new(uart, tx_pin, rx_pin, Irqs, tx_buf, rx_buf, Config::default());
     let (mut tx, rx) = uart.split();
 
-    unwrap!(spawner.spawn(reader(rx)));
+    spawner.spawn(unwrap!(reader(rx)));
 
     info!("Writing...");
     loop {

--- a/examples/rp/src/bin/uart_unidir.rs
+++ b/examples/rp/src/bin/uart_unidir.rs
@@ -27,7 +27,7 @@ async fn main(spawner: Spawner) {
     let mut uart_tx = UartTx::new(p.UART0, p.PIN_0, p.DMA_CH0, Config::default());
     let uart_rx = UartRx::new(p.UART1, p.PIN_5, Irqs, p.DMA_CH1, Config::default());
 
-    unwrap!(spawner.spawn(reader(uart_rx)));
+    spawner.spawn(unwrap!(reader(uart_rx)));
 
     info!("Writing...");
     loop {

--- a/examples/rp/src/bin/usb_ethernet.rs
+++ b/examples/rp/src/bin/usb_ethernet.rs
@@ -84,11 +84,11 @@ async fn main(spawner: Spawner) {
     // Build the builder.
     let usb = builder.build();
 
-    unwrap!(spawner.spawn(usb_task(usb)));
+    spawner.spawn(unwrap!(usb_task(usb)));
 
     static NET_STATE: StaticCell<NetState<MTU, 4, 4>> = StaticCell::new();
     let (runner, device) = class.into_embassy_net_device::<MTU, 4, 4>(NET_STATE.init(NetState::new()), our_mac_addr);
-    unwrap!(spawner.spawn(usb_ncm_task(runner)));
+    spawner.spawn(unwrap!(usb_ncm_task(runner)));
 
     let config = embassy_net::Config::dhcpv4(Default::default());
     //let config = embassy_net::Config::ipv4_static(embassy_net::StaticConfigV4 {
@@ -104,7 +104,7 @@ async fn main(spawner: Spawner) {
     static RESOURCES: StaticCell<StackResources<3>> = StaticCell::new();
     let (stack, runner) = embassy_net::new(device, config, RESOURCES.init(StackResources::new()), seed);
 
-    unwrap!(spawner.spawn(net_task(runner)));
+    spawner.spawn(unwrap!(net_task(runner)));
 
     // And now we can use it!
 

--- a/examples/rp/src/bin/usb_logger.rs
+++ b/examples/rp/src/bin/usb_logger.rs
@@ -25,7 +25,7 @@ async fn logger_task(driver: Driver<'static, USB>) {
 async fn main(spawner: Spawner) {
     let p = embassy_rp::init(Default::default());
     let driver = Driver::new(p.USB, Irqs);
-    spawner.spawn(logger_task(driver)).unwrap();
+    spawner.spawn(logger_task(driver).unwrap());
 
     let mut counter = 0;
     loop {

--- a/examples/rp/src/bin/usb_serial.rs
+++ b/examples/rp/src/bin/usb_serial.rs
@@ -69,7 +69,7 @@ async fn main(spawner: Spawner) {
     let usb = builder.build();
 
     // Run the USB device.
-    unwrap!(spawner.spawn(usb_task(usb)));
+    spawner.spawn(unwrap!(usb_task(usb)));
 
     // Do stuff with the class!
     loop {

--- a/examples/rp/src/bin/usb_serial_with_handler.rs
+++ b/examples/rp/src/bin/usb_serial_with_handler.rs
@@ -53,7 +53,7 @@ async fn logger_task(driver: Driver<'static, USB>) {
 async fn main(spawner: Spawner) {
     let p = embassy_rp::init(Default::default());
     let driver = Driver::new(p.USB, Irqs);
-    spawner.spawn(logger_task(driver)).unwrap();
+    spawner.spawn(logger_task(driver).unwrap());
 
     let mut counter = 0;
     loop {

--- a/examples/rp/src/bin/wifi_ap_tcp_server.rs
+++ b/examples/rp/src/bin/wifi_ap_tcp_server.rs
@@ -70,7 +70,7 @@ async fn main(spawner: Spawner) {
     static STATE: StaticCell<cyw43::State> = StaticCell::new();
     let state = STATE.init(cyw43::State::new());
     let (net_device, mut control, runner) = cyw43::new(state, pwr, spi, fw).await;
-    unwrap!(spawner.spawn(cyw43_task(runner)));
+    spawner.spawn(unwrap!(cyw43_task(runner)));
 
     control.init(clm).await;
     control
@@ -91,7 +91,7 @@ async fn main(spawner: Spawner) {
     static RESOURCES: StaticCell<StackResources<3>> = StaticCell::new();
     let (stack, runner) = embassy_net::new(net_device, config, RESOURCES.init(StackResources::new()), seed);
 
-    unwrap!(spawner.spawn(net_task(runner)));
+    spawner.spawn(unwrap!(net_task(runner)));
 
     //control.start_ap_open("cyw43", 5).await;
     control.start_ap_wpa2("cyw43", "password", 5).await;

--- a/examples/rp/src/bin/wifi_blinky.rs
+++ b/examples/rp/src/bin/wifi_blinky.rs
@@ -55,7 +55,7 @@ async fn main(spawner: Spawner) {
     static STATE: StaticCell<cyw43::State> = StaticCell::new();
     let state = STATE.init(cyw43::State::new());
     let (_net_device, mut control, runner) = cyw43::new(state, pwr, spi, fw).await;
-    unwrap!(spawner.spawn(cyw43_task(runner)));
+    spawner.spawn(unwrap!(cyw43_task(runner)));
 
     control.init(clm).await;
     control

--- a/examples/rp/src/bin/wifi_scan.rs
+++ b/examples/rp/src/bin/wifi_scan.rs
@@ -59,7 +59,7 @@ async fn main(spawner: Spawner) {
     static STATE: StaticCell<cyw43::State> = StaticCell::new();
     let state = STATE.init(cyw43::State::new());
     let (_net_device, mut control, runner) = cyw43::new(state, pwr, spi, fw).await;
-    unwrap!(spawner.spawn(cyw43_task(runner)));
+    spawner.spawn(unwrap!(cyw43_task(runner)));
 
     control.init(clm).await;
     control

--- a/examples/rp/src/bin/wifi_tcp_server.rs
+++ b/examples/rp/src/bin/wifi_tcp_server.rs
@@ -74,7 +74,7 @@ async fn main(spawner: Spawner) {
     static STATE: StaticCell<cyw43::State> = StaticCell::new();
     let state = STATE.init(cyw43::State::new());
     let (net_device, mut control, runner) = cyw43::new(state, pwr, spi, fw).await;
-    unwrap!(spawner.spawn(cyw43_task(runner)));
+    spawner.spawn(unwrap!(cyw43_task(runner)));
 
     control.init(clm).await;
     control
@@ -95,7 +95,7 @@ async fn main(spawner: Spawner) {
     static RESOURCES: StaticCell<StackResources<3>> = StaticCell::new();
     let (stack, runner) = embassy_net::new(net_device, config, RESOURCES.init(StackResources::new()), seed);
 
-    unwrap!(spawner.spawn(net_task(runner)));
+    spawner.spawn(unwrap!(net_task(runner)));
 
     while let Err(err) = control
         .join(WIFI_NETWORK, JoinOptions::new(WIFI_PASSWORD.as_bytes()))

--- a/examples/rp/src/bin/wifi_webrequest.rs
+++ b/examples/rp/src/bin/wifi_webrequest.rs
@@ -76,7 +76,7 @@ async fn main(spawner: Spawner) {
     static STATE: StaticCell<cyw43::State> = StaticCell::new();
     let state = STATE.init(cyw43::State::new());
     let (net_device, mut control, runner) = cyw43::new(state, pwr, spi, fw).await;
-    unwrap!(spawner.spawn(cyw43_task(runner)));
+    spawner.spawn(unwrap!(cyw43_task(runner)));
 
     control.init(clm).await;
     control
@@ -98,7 +98,7 @@ async fn main(spawner: Spawner) {
     static RESOURCES: StaticCell<StackResources<5>> = StaticCell::new();
     let (stack, runner) = embassy_net::new(net_device, config, RESOURCES.init(StackResources::new()), seed);
 
-    unwrap!(spawner.spawn(net_task(runner)));
+    spawner.spawn(unwrap!(net_task(runner)));
 
     while let Err(err) = control
         .join(WIFI_NETWORK, JoinOptions::new(WIFI_PASSWORD.as_bytes()))

--- a/examples/rp/src/bin/zerocopy.rs
+++ b/examples/rp/src/bin/zerocopy.rs
@@ -52,8 +52,8 @@ async fn main(spawner: Spawner) {
     let channel = CHANNEL.init(Channel::new(buf));
     let (sender, receiver) = channel.split();
 
-    spawner.must_spawn(consumer(receiver));
-    spawner.must_spawn(producer(sender, adc_parts));
+    spawner.spawn(consumer(receiver).unwrap());
+    spawner.spawn(producer(sender, adc_parts).unwrap());
 
     let mut ticker = Ticker::every(Duration::from_secs(1));
     loop {

--- a/examples/rp235x/src/bin/assign_resources.rs
+++ b/examples/rp235x/src/bin/assign_resources.rs
@@ -26,15 +26,13 @@ async fn main(spawner: Spawner) {
     let p = embassy_rp::init(Default::default());
 
     // 1) Assigning a resource to a task by passing parts of the peripherals.
-    spawner
-        .spawn(double_blinky_manually_assigned(spawner, p.PIN_20, p.PIN_21))
-        .unwrap();
+    spawner.spawn(double_blinky_manually_assigned(spawner, p.PIN_20, p.PIN_21).unwrap());
 
     // 2) Using the assign-resources macro to assign resources to a task.
     // we perform the split, see further below for the definition of the resources struct
     let r = split_resources!(p);
     // and then we can use them
-    spawner.spawn(double_blinky_macro_assigned(spawner, r.leds)).unwrap();
+    spawner.spawn(double_blinky_macro_assigned(spawner, r.leds).unwrap());
 }
 
 // 1) Assigning a resource to a task by passing parts of the peripherals.

--- a/examples/rp235x/src/bin/blinky_two_channels.rs
+++ b/examples/rp235x/src/bin/blinky_two_channels.rs
@@ -27,8 +27,8 @@ async fn main(spawner: Spawner) {
     let dt = 100 * 1_000_000;
     let k = 1.003;
 
-    unwrap!(spawner.spawn(toggle_led(CHANNEL.sender(), Duration::from_nanos(dt))));
-    unwrap!(spawner.spawn(toggle_led(
+    spawner.spawn(unwrap!(toggle_led(CHANNEL.sender(), Duration::from_nanos(dt))));
+    spawner.spawn(unwrap!(toggle_led(
         CHANNEL.sender(),
         Duration::from_nanos((dt as f64 * k) as u64)
     )));

--- a/examples/rp235x/src/bin/blinky_two_tasks.rs
+++ b/examples/rp235x/src/bin/blinky_two_tasks.rs
@@ -30,8 +30,8 @@ async fn main(spawner: Spawner) {
     let dt = 100 * 1_000_000;
     let k = 1.003;
 
-    unwrap!(spawner.spawn(toggle_led(&LED, Duration::from_nanos(dt))));
-    unwrap!(spawner.spawn(toggle_led(&LED, Duration::from_nanos((dt as f64 * k) as u64))));
+    spawner.spawn(unwrap!(toggle_led(&LED, Duration::from_nanos(dt))));
+    spawner.spawn(unwrap!(toggle_led(&LED, Duration::from_nanos((dt as f64 * k) as u64))));
 }
 
 #[embassy_executor::task(pool_size = 2)]

--- a/examples/rp235x/src/bin/blinky_wifi.rs
+++ b/examples/rp235x/src/bin/blinky_wifi.rs
@@ -71,7 +71,7 @@ async fn main(spawner: Spawner) {
     static STATE: StaticCell<cyw43::State> = StaticCell::new();
     let state = STATE.init(cyw43::State::new());
     let (_net_device, mut control, runner) = cyw43::new(state, pwr, spi, fw).await;
-    unwrap!(spawner.spawn(cyw43_task(runner)));
+    spawner.spawn(unwrap!(cyw43_task(runner)));
 
     control.init(clm).await;
     control

--- a/examples/rp235x/src/bin/blinky_wifi_pico_plus_2.rs
+++ b/examples/rp235x/src/bin/blinky_wifi_pico_plus_2.rs
@@ -68,7 +68,7 @@ async fn main(spawner: Spawner) {
     static STATE: StaticCell<cyw43::State> = StaticCell::new();
     let state = STATE.init(cyw43::State::new());
     let (_net_device, mut control, runner) = cyw43::new(state, pwr, spi, fw).await;
-    unwrap!(spawner.spawn(cyw43_task(runner)));
+    spawner.spawn(unwrap!(cyw43_task(runner)));
 
     control.init(clm).await;
     control

--- a/examples/rp235x/src/bin/i2c_slave.rs
+++ b/examples/rp235x/src/bin/i2c_slave.rs
@@ -105,7 +105,7 @@ async fn main(spawner: Spawner) {
     config.addr = DEV_ADDR as u16;
     let device = i2c_slave::I2cSlave::new(p.I2C1, d_sda, d_scl, Irqs, config);
 
-    unwrap!(spawner.spawn(device_task(device)));
+    spawner.spawn(unwrap!(device_task(device)));
 
     let c_sda = p.PIN_1;
     let c_scl = p.PIN_0;
@@ -113,5 +113,5 @@ async fn main(spawner: Spawner) {
     config.frequency = 1_000_000;
     let controller = i2c::I2c::new_async(p.I2C0, c_sda, c_scl, Irqs, config);
 
-    unwrap!(spawner.spawn(controller_task(controller)));
+    spawner.spawn(unwrap!(controller_task(controller)));
 }

--- a/examples/rp235x/src/bin/interrupt.rs
+++ b/examples/rp235x/src/bin/interrupt.rs
@@ -51,7 +51,7 @@ async fn main(spawner: Spawner) {
     // No Mutex needed when sharing within the same executor/prio level
     static AVG: StaticCell<Cell<u32>> = StaticCell::new();
     let avg = AVG.init(Default::default());
-    spawner.must_spawn(processing(avg));
+    spawner.spawn(processing(avg).unwrap());
 
     let mut ticker = Ticker::every(Duration::from_secs(1));
     loop {

--- a/examples/rp235x/src/bin/multicore.rs
+++ b/examples/rp235x/src/bin/multicore.rs
@@ -35,12 +35,12 @@ fn main() -> ! {
         unsafe { &mut *core::ptr::addr_of_mut!(CORE1_STACK) },
         move || {
             let executor1 = EXECUTOR1.init(Executor::new());
-            executor1.run(|spawner| unwrap!(spawner.spawn(core1_task(led))));
+            executor1.run(|spawner| spawner.spawn(unwrap!(core1_task(led))));
         },
     );
 
     let executor0 = EXECUTOR0.init(Executor::new());
-    executor0.run(|spawner| unwrap!(spawner.spawn(core0_task())));
+    executor0.run(|spawner| spawner.spawn(unwrap!(core0_task())));
 }
 
 #[embassy_executor::task]

--- a/examples/rp235x/src/bin/multiprio.rs
+++ b/examples/rp235x/src/bin/multiprio.rs
@@ -130,16 +130,16 @@ fn main() -> ! {
     // High-priority executor: SWI_IRQ_1, priority level 2
     interrupt::SWI_IRQ_1.set_priority(Priority::P2);
     let spawner = EXECUTOR_HIGH.start(interrupt::SWI_IRQ_1);
-    unwrap!(spawner.spawn(run_high()));
+    spawner.spawn(unwrap!(run_high()));
 
     // Medium-priority executor: SWI_IRQ_0, priority level 3
     interrupt::SWI_IRQ_0.set_priority(Priority::P3);
     let spawner = EXECUTOR_MED.start(interrupt::SWI_IRQ_0);
-    unwrap!(spawner.spawn(run_med()));
+    spawner.spawn(unwrap!(run_med()));
 
     // Low priority executor: runs in thread mode, using WFE/SEV
     let executor = EXECUTOR_LOW.init(Executor::new());
     executor.run(|spawner| {
-        unwrap!(spawner.spawn(run_low()));
+        spawner.spawn(unwrap!(run_low()));
     });
 }

--- a/examples/rp235x/src/bin/pio_async.rs
+++ b/examples/rp235x/src/bin/pio_async.rs
@@ -125,7 +125,7 @@ async fn main(spawner: Spawner) {
     setup_pio_task_sm0(&mut common, &mut sm0, p.PIN_0);
     setup_pio_task_sm1(&mut common, &mut sm1);
     setup_pio_task_sm2(&mut common, &mut sm2);
-    spawner.spawn(pio_task_sm0(sm0)).unwrap();
-    spawner.spawn(pio_task_sm1(sm1)).unwrap();
-    spawner.spawn(pio_task_sm2(irq3, sm2)).unwrap();
+    spawner.spawn(pio_task_sm0(sm0).unwrap());
+    spawner.spawn(pio_task_sm1(sm1).unwrap());
+    spawner.spawn(pio_task_sm2(irq3, sm2).unwrap());
 }

--- a/examples/rp235x/src/bin/pio_rotary_encoder.rs
+++ b/examples/rp235x/src/bin/pio_rotary_encoder.rs
@@ -50,6 +50,6 @@ async fn main(spawner: Spawner) {
     let encoder0 = PioEncoder::new(&mut common, sm0, p.PIN_4, p.PIN_5, &prg);
     let encoder1 = PioEncoder::new(&mut common, sm1, p.PIN_6, p.PIN_7, &prg);
 
-    spawner.must_spawn(encoder_0(encoder0));
-    spawner.must_spawn(encoder_1(encoder1));
+    spawner.spawn(encoder_0(encoder0).unwrap());
+    spawner.spawn(encoder_1(encoder1).unwrap());
 }

--- a/examples/rp235x/src/bin/pwm.rs
+++ b/examples/rp235x/src/bin/pwm.rs
@@ -18,8 +18,8 @@ use {defmt_rtt as _, panic_probe as _};
 #[embassy_executor::main]
 async fn main(spawner: Spawner) {
     let p = embassy_rp::init(Default::default());
-    spawner.spawn(pwm_set_config(p.PWM_SLICE4, p.PIN_25)).unwrap();
-    spawner.spawn(pwm_set_dutycycle(p.PWM_SLICE2, p.PIN_4)).unwrap();
+    spawner.spawn(pwm_set_config(p.PWM_SLICE4, p.PIN_25).unwrap());
+    spawner.spawn(pwm_set_dutycycle(p.PWM_SLICE2, p.PIN_4).unwrap());
 }
 
 /// Demonstrate PWM by modifying & applying the config

--- a/examples/rp235x/src/bin/shared_bus.rs
+++ b/examples/rp235x/src/bin/shared_bus.rs
@@ -35,8 +35,8 @@ async fn main(spawner: Spawner) {
     static I2C_BUS: StaticCell<I2c1Bus> = StaticCell::new();
     let i2c_bus = I2C_BUS.init(Mutex::new(i2c));
 
-    spawner.must_spawn(i2c_task_a(i2c_bus));
-    spawner.must_spawn(i2c_task_b(i2c_bus));
+    spawner.spawn(i2c_task_a(i2c_bus).unwrap());
+    spawner.spawn(i2c_task_b(i2c_bus).unwrap());
 
     // Shared SPI bus
     let spi_cfg = spi::Config::default();
@@ -48,8 +48,8 @@ async fn main(spawner: Spawner) {
     let cs_a = Output::new(p.PIN_0, Level::High);
     let cs_b = Output::new(p.PIN_1, Level::High);
 
-    spawner.must_spawn(spi_task_a(spi_bus, cs_a));
-    spawner.must_spawn(spi_task_b(spi_bus, cs_b));
+    spawner.spawn(spi_task_a(spi_bus, cs_a).unwrap());
+    spawner.spawn(spi_task_b(spi_bus, cs_b).unwrap());
 }
 
 #[embassy_executor::task]

--- a/examples/rp235x/src/bin/sharing.rs
+++ b/examples/rp235x/src/bin/sharing.rs
@@ -68,7 +68,7 @@ fn main() -> ! {
     // High-priority executor: runs in interrupt mode
     interrupt::SWI_IRQ_0.set_priority(Priority::P3);
     let spawner = EXECUTOR_HI.start(interrupt::SWI_IRQ_0);
-    spawner.must_spawn(task_a(uart));
+    spawner.spawn(task_a(uart).unwrap());
 
     // Low priority executor: runs in thread mode
     let executor = EXECUTOR_LOW.init(Executor::new());
@@ -83,8 +83,8 @@ fn main() -> ! {
         static REF_CELL: ConstStaticCell<RefCell<MyType>> = ConstStaticCell::new(RefCell::new(MyType { inner: 0 }));
         let ref_cell = REF_CELL.take();
 
-        spawner.must_spawn(task_b(uart, cell, ref_cell));
-        spawner.must_spawn(task_c(cell, ref_cell));
+        spawner.spawn(task_b(uart, cell, ref_cell).unwrap());
+        spawner.spawn(task_c(cell, ref_cell).unwrap());
     });
 }
 

--- a/examples/rp235x/src/bin/uart_buffered_split.rs
+++ b/examples/rp235x/src/bin/uart_buffered_split.rs
@@ -33,7 +33,7 @@ async fn main(spawner: Spawner) {
     let uart = BufferedUart::new(uart, tx_pin, rx_pin, Irqs, tx_buf, rx_buf, Config::default());
     let (mut tx, rx) = uart.split();
 
-    unwrap!(spawner.spawn(reader(rx)));
+    spawner.spawn(unwrap!(reader(rx)));
 
     info!("Writing...");
     loop {

--- a/examples/rp235x/src/bin/uart_unidir.rs
+++ b/examples/rp235x/src/bin/uart_unidir.rs
@@ -27,7 +27,7 @@ async fn main(spawner: Spawner) {
     let mut uart_tx = UartTx::new(p.UART0, p.PIN_0, p.DMA_CH0, Config::default());
     let uart_rx = UartRx::new(p.UART1, p.PIN_5, Irqs, p.DMA_CH1, Config::default());
 
-    unwrap!(spawner.spawn(reader(uart_rx)));
+    spawner.spawn(unwrap!(reader(uart_rx)));
 
     info!("Writing...");
     loop {

--- a/examples/rp235x/src/bin/zerocopy.rs
+++ b/examples/rp235x/src/bin/zerocopy.rs
@@ -52,8 +52,8 @@ async fn main(spawner: Spawner) {
     let channel = CHANNEL.init(Channel::new(buf));
     let (sender, receiver) = channel.split();
 
-    spawner.must_spawn(consumer(receiver));
-    spawner.must_spawn(producer(sender, adc_parts));
+    spawner.spawn(consumer(receiver).unwrap());
+    spawner.spawn(producer(sender, adc_parts).unwrap());
 
     let mut ticker = Ticker::every(Duration::from_secs(1));
     loop {

--- a/examples/std/src/bin/net.rs
+++ b/examples/std/src/bin/net.rs
@@ -56,7 +56,7 @@ async fn main_task(spawner: Spawner) {
     let (stack, runner) = embassy_net::new(device, config, RESOURCES.init(StackResources::new()), seed);
 
     // Launch network task
-    spawner.spawn(net_task(runner)).unwrap();
+    spawner.spawn(net_task(runner).unwrap());
 
     // Then we can use it!
     let mut rx_buffer = [0; 4096];
@@ -95,6 +95,6 @@ fn main() {
 
     let executor = EXECUTOR.init(Executor::new());
     executor.run(|spawner| {
-        spawner.spawn(main_task(spawner)).unwrap();
+        spawner.spawn(main_task(spawner).unwrap());
     });
 }

--- a/examples/std/src/bin/net_dns.rs
+++ b/examples/std/src/bin/net_dns.rs
@@ -53,7 +53,7 @@ async fn main_task(spawner: Spawner) {
     let (stack, runner) = embassy_net::new(device, config, RESOURCES.init(StackResources::new()), seed);
 
     // Launch network task
-    spawner.spawn(net_task(runner)).unwrap();
+    spawner.spawn(net_task(runner).unwrap());
 
     let host = "example.com";
     info!("querying host {:?}...", host);
@@ -78,6 +78,6 @@ fn main() {
 
     let executor = EXECUTOR.init(Executor::new());
     executor.run(|spawner| {
-        spawner.spawn(main_task(spawner)).unwrap();
+        spawner.spawn(main_task(spawner).unwrap());
     });
 }

--- a/examples/std/src/bin/net_ppp.rs
+++ b/examples/std/src/bin/net_ppp.rs
@@ -102,8 +102,8 @@ async fn main_task(spawner: Spawner) {
     );
 
     // Launch network task
-    spawner.spawn(net_task(net_runner)).unwrap();
-    spawner.spawn(ppp_task(stack, runner, port)).unwrap();
+    spawner.spawn(net_task(net_runner).unwrap());
+    spawner.spawn(ppp_task(stack, runner, port).unwrap());
 
     // Then we can use it!
     let mut rx_buffer = [0; 4096];
@@ -160,6 +160,6 @@ fn main() {
 
     let executor = EXECUTOR.init(Executor::new());
     executor.run(|spawner| {
-        spawner.spawn(main_task(spawner)).unwrap();
+        spawner.spawn(main_task(spawner).unwrap());
     });
 }

--- a/examples/std/src/bin/net_udp.rs
+++ b/examples/std/src/bin/net_udp.rs
@@ -52,7 +52,7 @@ async fn main_task(spawner: Spawner) {
     let (stack, runner) = embassy_net::new(device, config, RESOURCES.init(StackResources::new()), seed);
 
     // Launch network task
-    spawner.spawn(net_task(runner)).unwrap();
+    spawner.spawn(net_task(runner).unwrap());
 
     // Then we can use it!
     let mut rx_meta = [PacketMetadata::EMPTY; 16];
@@ -86,6 +86,6 @@ fn main() {
 
     let executor = EXECUTOR.init(Executor::new());
     executor.run(|spawner| {
-        spawner.spawn(main_task(spawner)).unwrap();
+        spawner.spawn(main_task(spawner).unwrap());
     });
 }

--- a/examples/std/src/bin/serial.rs
+++ b/examples/std/src/bin/serial.rs
@@ -50,6 +50,6 @@ fn main() {
 
     let executor = EXECUTOR.init(Executor::new());
     executor.run(|spawner| {
-        spawner.spawn(run()).unwrap();
+        spawner.spawn(run().unwrap());
     });
 }

--- a/examples/std/src/bin/tcp_accept.rs
+++ b/examples/std/src/bin/tcp_accept.rs
@@ -54,7 +54,7 @@ async fn main_task(spawner: Spawner) {
     let (stack, runner) = embassy_net::new(device, config, RESOURCES.init(StackResources::new()), seed);
 
     // Launch network task
-    spawner.spawn(net_task(runner)).unwrap();
+    spawner.spawn(net_task(runner).unwrap());
 
     // Then we can use it!
     let mut rx_buffer = [0; 4096];
@@ -101,6 +101,6 @@ fn main() {
 
     let executor = EXECUTOR.init(Executor::new());
     executor.run(|spawner| {
-        spawner.spawn(main_task(spawner)).unwrap();
+        spawner.spawn(main_task(spawner).unwrap());
     });
 }

--- a/examples/std/src/bin/tick.rs
+++ b/examples/std/src/bin/tick.rs
@@ -17,5 +17,5 @@ async fn main(spawner: Spawner) {
         .format_timestamp_nanos()
         .init();
 
-    spawner.spawn(run()).unwrap();
+    spawner.spawn(run().unwrap());
 }

--- a/examples/stm32f0/src/bin/button_controlled_blink.rs
+++ b/examples/stm32f0/src/bin/button_controlled_blink.rs
@@ -46,7 +46,7 @@ async fn main(spawner: Spawner) {
     BLINK_MS.store(del_var, Ordering::Relaxed);
 
     // Spawn LED blinking task
-    spawner.spawn(led_task(p.PA5.into())).unwrap();
+    spawner.spawn(led_task(p.PA5.into()).unwrap());
 
     loop {
         // Check if button got pressed

--- a/examples/stm32f0/src/bin/multiprio.rs
+++ b/examples/stm32f0/src/bin/multiprio.rs
@@ -134,16 +134,16 @@ fn main() -> ! {
     // High-priority executor: USART1, priority level 6
     interrupt::USART1.set_priority(Priority::P6);
     let spawner = EXECUTOR_HIGH.start(interrupt::USART1);
-    unwrap!(spawner.spawn(run_high()));
+    spawner.spawn(unwrap!(run_high()));
 
     // Medium-priority executor: USART2, priority level 7
     interrupt::USART2.set_priority(Priority::P7);
     let spawner = EXECUTOR_MED.start(interrupt::USART2);
-    unwrap!(spawner.spawn(run_med()));
+    spawner.spawn(unwrap!(run_med()));
 
     // Low priority executor: runs in thread mode, using WFE/SEV
     let executor = EXECUTOR_LOW.init(Executor::new());
     executor.run(|spawner| {
-        unwrap!(spawner.spawn(run_low()));
+        spawner.spawn(unwrap!(run_low()));
     });
 }

--- a/examples/stm32f1/src/bin/input_capture.rs
+++ b/examples/stm32f1/src/bin/input_capture.rs
@@ -37,7 +37,7 @@ async fn main(spawner: Spawner) {
     let p = embassy_stm32::init(Default::default());
     info!("Hello World!");
 
-    unwrap!(spawner.spawn(blinky(p.PC13)));
+    spawner.spawn(unwrap!(blinky(p.PC13)));
 
     let ch3 = CapturePin::new(p.PA2, Pull::None);
     let mut ic = InputCapture::new(p.TIM2, None, None, Some(ch3), None, Irqs, khz(1000), Default::default());

--- a/examples/stm32f1/src/bin/pwm_input.rs
+++ b/examples/stm32f1/src/bin/pwm_input.rs
@@ -36,7 +36,7 @@ async fn main(spawner: Spawner) {
     let p = embassy_stm32::init(Default::default());
     info!("Hello World!");
 
-    unwrap!(spawner.spawn(blinky(p.PC13)));
+    spawner.spawn(unwrap!(blinky(p.PC13)));
 
     let mut pwm_input = PwmInput::new_ch1(p.TIM2, p.PA0, Pull::None, khz(10));
     pwm_input.enable();

--- a/examples/stm32f3/src/bin/button_events.rs
+++ b/examples/stm32f3/src/bin/button_events.rs
@@ -113,8 +113,8 @@ async fn main(spawner: Spawner) {
     ];
     let leds = Leds::new(leds);
 
-    spawner.spawn(button_waiter(button)).unwrap();
-    spawner.spawn(led_blinker(leds)).unwrap();
+    spawner.spawn(button_waiter(button).unwrap());
+    spawner.spawn(led_blinker(leds).unwrap());
 }
 
 #[embassy_executor::task]

--- a/examples/stm32f3/src/bin/multiprio.rs
+++ b/examples/stm32f3/src/bin/multiprio.rs
@@ -135,16 +135,16 @@ fn main() -> ! {
     // High-priority executor: UART4, priority level 6
     interrupt::UART4.set_priority(Priority::P6);
     let spawner = EXECUTOR_HIGH.start(interrupt::UART4);
-    unwrap!(spawner.spawn(run_high()));
+    spawner.spawn(unwrap!(run_high()));
 
     // Medium-priority executor: UART5, priority level 7
     interrupt::UART5.set_priority(Priority::P7);
     let spawner = EXECUTOR_MED.start(interrupt::UART5);
-    unwrap!(spawner.spawn(run_med()));
+    spawner.spawn(unwrap!(run_med()));
 
     // Low priority executor: runs in thread mode, using WFE/SEV
     let executor = EXECUTOR_LOW.init(Executor::new());
     executor.run(|spawner| {
-        unwrap!(spawner.spawn(run_low()));
+        spawner.spawn(unwrap!(run_low()));
     });
 }

--- a/examples/stm32f4/src/bin/adc_dma.rs
+++ b/examples/stm32f4/src/bin/adc_dma.rs
@@ -11,7 +11,7 @@ use {defmt_rtt as _, panic_probe as _};
 #[embassy_executor::main]
 async fn main(spawner: Spawner) {
     let p = embassy_stm32::init(Default::default());
-    spawner.must_spawn(adc_task(p));
+    spawner.spawn(adc_task(p).unwrap());
 }
 
 #[embassy_executor::task]

--- a/examples/stm32f4/src/bin/eth.rs
+++ b/examples/stm32f4/src/bin/eth.rs
@@ -91,7 +91,7 @@ async fn main(spawner: Spawner) -> ! {
     let (stack, runner) = embassy_net::new(device, config, RESOURCES.init(StackResources::new()), seed);
 
     // Launch network task
-    unwrap!(spawner.spawn(net_task(runner)));
+    spawner.spawn(unwrap!(net_task(runner)));
 
     // Ensure DHCP configuration is up before trying connect
     stack.wait_config_up().await;

--- a/examples/stm32f4/src/bin/eth_w5500.rs
+++ b/examples/stm32f4/src/bin/eth_w5500.rs
@@ -83,7 +83,7 @@ async fn main(spawner: Spawner) -> ! {
     let (device, runner) = embassy_net_wiznet::new(mac_addr, state, spi, w5500_int, w5500_reset)
         .await
         .unwrap();
-    unwrap!(spawner.spawn(ethernet_task(runner)));
+    spawner.spawn(unwrap!(ethernet_task(runner)));
 
     let config = embassy_net::Config::dhcpv4(Default::default());
     //let config = embassy_net::Config::ipv4_static(embassy_net::StaticConfigV4 {
@@ -96,7 +96,7 @@ async fn main(spawner: Spawner) -> ! {
     let (stack, runner) = embassy_net::new(device, config, RESOURCES.init(StackResources::new()), seed);
 
     // Launch network task
-    unwrap!(spawner.spawn(net_task(runner)));
+    spawner.spawn(unwrap!(net_task(runner)));
 
     // Ensure DHCP configuration is up before trying connect
     stack.wait_config_up().await;

--- a/examples/stm32f4/src/bin/flash_async.rs
+++ b/examples/stm32f4/src/bin/flash_async.rs
@@ -21,7 +21,7 @@ async fn main(spawner: Spawner) {
     let mut f = Flash::new(p.FLASH, Irqs);
 
     // Led should blink uninterrupted during ~2sec erase operation
-    spawner.spawn(blinky(p.PB7.into())).unwrap();
+    spawner.spawn(blinky(p.PB7.into()).unwrap());
 
     // Test on bank 2 in order not to stall CPU.
     test_flash(&mut f, 1024 * 1024, 128 * 1024).await;

--- a/examples/stm32f4/src/bin/input_capture.rs
+++ b/examples/stm32f4/src/bin/input_capture.rs
@@ -37,7 +37,7 @@ async fn main(spawner: Spawner) {
     let p = embassy_stm32::init(Default::default());
     info!("Hello World!");
 
-    unwrap!(spawner.spawn(blinky(p.PB2)));
+    spawner.spawn(unwrap!(blinky(p.PB2)));
 
     let ch3 = CapturePin::new(p.PB10, Pull::None);
     let mut ic = InputCapture::new(p.TIM2, None, None, Some(ch3), None, Irqs, khz(1000), Default::default());

--- a/examples/stm32f4/src/bin/multiprio.rs
+++ b/examples/stm32f4/src/bin/multiprio.rs
@@ -135,16 +135,16 @@ fn main() -> ! {
     // High-priority executor: UART4, priority level 6
     interrupt::UART4.set_priority(Priority::P6);
     let spawner = EXECUTOR_HIGH.start(interrupt::UART4);
-    unwrap!(spawner.spawn(run_high()));
+    spawner.spawn(unwrap!(run_high()));
 
     // Medium-priority executor: UART5, priority level 7
     interrupt::UART5.set_priority(Priority::P7);
     let spawner = EXECUTOR_MED.start(interrupt::UART5);
-    unwrap!(spawner.spawn(run_med()));
+    spawner.spawn(unwrap!(run_med()));
 
     // Low priority executor: runs in thread mode, using WFE/SEV
     let executor = EXECUTOR_LOW.init(Executor::new());
     executor.run(|spawner| {
-        unwrap!(spawner.spawn(run_low()));
+        spawner.spawn(unwrap!(run_low()));
     });
 }

--- a/examples/stm32f4/src/bin/pwm_input.rs
+++ b/examples/stm32f4/src/bin/pwm_input.rs
@@ -36,7 +36,7 @@ async fn main(spawner: Spawner) {
     let p = embassy_stm32::init(Default::default());
     info!("Hello World!");
 
-    unwrap!(spawner.spawn(blinky(p.PB2)));
+    spawner.spawn(unwrap!(blinky(p.PB2)));
 
     let mut pwm_input = PwmInput::new_ch1(p.TIM3, p.PA6, Pull::None, khz(10));
     pwm_input.enable();

--- a/examples/stm32f4/src/bin/usb_ethernet.rs
+++ b/examples/stm32f4/src/bin/usb_ethernet.rs
@@ -118,11 +118,11 @@ async fn main(spawner: Spawner) {
     // Build the builder.
     let usb = builder.build();
 
-    unwrap!(spawner.spawn(usb_task(usb)));
+    spawner.spawn(unwrap!(usb_task(usb)));
 
     static NET_STATE: StaticCell<NetState<MTU, 4, 4>> = StaticCell::new();
     let (runner, device) = class.into_embassy_net_device::<MTU, 4, 4>(NET_STATE.init(NetState::new()), our_mac_addr);
-    unwrap!(spawner.spawn(usb_ncm_task(runner)));
+    spawner.spawn(unwrap!(usb_ncm_task(runner)));
 
     let config = embassy_net::Config::dhcpv4(Default::default());
     //let config = embassy_net::Config::ipv4_static(embassy_net::StaticConfigV4 {
@@ -141,7 +141,7 @@ async fn main(spawner: Spawner) {
     static RESOURCES: StaticCell<StackResources<3>> = StaticCell::new();
     let (stack, runner) = embassy_net::new(device, config, RESOURCES.init(StackResources::new()), seed);
 
-    unwrap!(spawner.spawn(net_task(runner)));
+    spawner.spawn(unwrap!(net_task(runner)));
 
     // And now we can use it!
 

--- a/examples/stm32f4/src/bin/usb_uac_speaker.rs
+++ b/examples/stm32f4/src/bin/usb_uac_speaker.rs
@@ -375,9 +375,9 @@ async fn main(spawner: Spawner) {
     }
 
     // Launch USB audio tasks.
-    unwrap!(spawner.spawn(usb_control_task(control_monitor)));
-    unwrap!(spawner.spawn(usb_streaming_task(stream, sender)));
-    unwrap!(spawner.spawn(usb_feedback_task(feedback)));
-    unwrap!(spawner.spawn(usb_task(usb_device)));
-    unwrap!(spawner.spawn(audio_receiver_task(receiver)));
+    spawner.spawn(unwrap!(usb_control_task(control_monitor)));
+    spawner.spawn(unwrap!(usb_streaming_task(stream, sender)));
+    spawner.spawn(unwrap!(usb_feedback_task(feedback)));
+    spawner.spawn(unwrap!(usb_task(usb_device)));
+    spawner.spawn(unwrap!(audio_receiver_task(receiver)));
 }

--- a/examples/stm32f7/src/bin/can.rs
+++ b/examples/stm32f7/src/bin/can.rs
@@ -64,7 +64,7 @@ async fn main(spawner: Spawner) {
 
     static CAN_TX: StaticCell<CanTx<'static>> = StaticCell::new();
     let tx = CAN_TX.init(tx);
-    spawner.spawn(send_can_message(tx)).unwrap();
+    spawner.spawn(send_can_message(tx).unwrap());
 
     loop {
         let envelope = rx.read().await.unwrap();

--- a/examples/stm32f7/src/bin/eth.rs
+++ b/examples/stm32f7/src/bin/eth.rs
@@ -91,7 +91,7 @@ async fn main(spawner: Spawner) -> ! {
     let (stack, runner) = embassy_net::new(device, config, RESOURCES.init(StackResources::new()), seed);
 
     // Launch network task
-    unwrap!(spawner.spawn(net_task(runner)));
+    spawner.spawn(unwrap!(net_task(runner)));
 
     // Ensure DHCP configuration is up before trying connect
     stack.wait_config_up().await;

--- a/examples/stm32g0/src/bin/input_capture.rs
+++ b/examples/stm32g0/src/bin/input_capture.rs
@@ -44,7 +44,7 @@ async fn main(spawner: Spawner) {
     let p = embassy_stm32::init(Default::default());
     info!("Hello World!");
 
-    unwrap!(spawner.spawn(blinky(p.PB1)));
+    spawner.spawn(unwrap!(blinky(p.PB1)));
 
     // Connect PB1 and PA8 with a 1k Ohm resistor
     let ch1_pin = PwmPin::new(p.PA8, OutputType::PushPull);

--- a/examples/stm32g0/src/bin/pwm_input.rs
+++ b/examples/stm32g0/src/bin/pwm_input.rs
@@ -40,7 +40,7 @@ bind_interrupts!(struct Irqs {
 async fn main(spawner: Spawner) {
     let p = embassy_stm32::init(Default::default());
 
-    unwrap!(spawner.spawn(blinky(p.PB1)));
+    spawner.spawn(unwrap!(blinky(p.PB1)));
     // Connect PA8 and PA6 with a 1k Ohm resistor
     let ch1_pin = PwmPin::new(p.PA8, OutputType::PushPull);
     let mut pwm = SimplePwm::new(p.TIM1, Some(ch1_pin), None, None, None, khz(1), Default::default());

--- a/examples/stm32g4/src/bin/i2c_slave.rs
+++ b/examples/stm32g4/src/bin/i2c_slave.rs
@@ -139,11 +139,11 @@ async fn main(spawner: Spawner) {
     let device =
         i2c::I2c::new(p.I2C2, d_scl, d_sda, Irqs, p.DMA1_CH1, p.DMA1_CH2, config).into_slave_multimaster(d_addr_config);
 
-    unwrap!(spawner.spawn(device_task(device)));
+    spawner.spawn(unwrap!(device_task(device)));
 
     let c_sda = p.PB8;
     let c_scl = p.PB7;
     let controller = i2c::I2c::new(p.I2C1, c_sda, c_scl, Irqs, p.DMA1_CH3, p.DMA1_CH4, config);
 
-    unwrap!(spawner.spawn(controller_task(controller)));
+    spawner.spawn(unwrap!(controller_task(controller)));
 }

--- a/examples/stm32h5/src/bin/eth.rs
+++ b/examples/stm32h5/src/bin/eth.rs
@@ -94,7 +94,7 @@ async fn main(spawner: Spawner) -> ! {
     let (stack, runner) = embassy_net::new(device, config, RESOURCES.init(StackResources::new()), seed);
 
     // Launch network task
-    unwrap!(spawner.spawn(net_task(runner)));
+    spawner.spawn(unwrap!(net_task(runner)));
 
     // Ensure DHCP configuration is up before trying connect
     stack.wait_config_up().await;

--- a/examples/stm32h5/src/bin/stop.rs
+++ b/examples/stm32h5/src/bin/stop.rs
@@ -18,7 +18,7 @@ use {defmt_rtt as _, panic_probe as _};
 #[cortex_m_rt::entry]
 fn main() -> ! {
     Executor::take().run(|spawner| {
-        unwrap!(spawner.spawn(async_main(spawner)));
+        spawner.spawn(unwrap!(async_main(spawner)));
     })
 }
 
@@ -43,8 +43,8 @@ async fn async_main(spawner: Spawner) {
     let rtc = RTC.init(rtc);
     embassy_stm32::low_power::stop_with_rtc(rtc);
 
-    unwrap!(spawner.spawn(blinky(p.PB4.into())));
-    unwrap!(spawner.spawn(timeout()));
+    spawner.spawn(unwrap!(blinky(p.PB4.into())));
+    spawner.spawn(unwrap!(timeout()));
 }
 
 #[embassy_executor::task]

--- a/examples/stm32h5/src/bin/usart.rs
+++ b/examples/stm32h5/src/bin/usart.rs
@@ -34,6 +34,6 @@ fn main() -> ! {
     let executor = EXECUTOR.init(Executor::new());
 
     executor.run(|spawner| {
-        unwrap!(spawner.spawn(main_task()));
+        spawner.spawn(unwrap!(main_task()));
     })
 }

--- a/examples/stm32h5/src/bin/usart_dma.rs
+++ b/examples/stm32h5/src/bin/usart_dma.rs
@@ -42,6 +42,6 @@ fn main() -> ! {
     let executor = EXECUTOR.init(Executor::new());
 
     executor.run(|spawner| {
-        unwrap!(spawner.spawn(main_task()));
+        spawner.spawn(unwrap!(main_task()));
     })
 }

--- a/examples/stm32h5/src/bin/usart_split.rs
+++ b/examples/stm32h5/src/bin/usart_split.rs
@@ -27,7 +27,7 @@ async fn main(spawner: Spawner) -> ! {
 
     let (mut tx, rx) = usart.split();
 
-    unwrap!(spawner.spawn(reader(rx)));
+    spawner.spawn(unwrap!(reader(rx)));
 
     loop {
         let buf = CHANNEL.receive().await;

--- a/examples/stm32h5/src/bin/usb_uac_speaker.rs
+++ b/examples/stm32h5/src/bin/usb_uac_speaker.rs
@@ -366,9 +366,9 @@ async fn main(spawner: Spawner) {
     }
 
     // Launch USB audio tasks.
-    unwrap!(spawner.spawn(usb_control_task(control_monitor)));
-    unwrap!(spawner.spawn(usb_streaming_task(stream, sender)));
-    unwrap!(spawner.spawn(usb_feedback_task(feedback)));
-    unwrap!(spawner.spawn(usb_task(usb_device)));
-    unwrap!(spawner.spawn(audio_receiver_task(receiver)));
+    spawner.spawn(unwrap!(usb_control_task(control_monitor)));
+    spawner.spawn(unwrap!(usb_streaming_task(stream, sender)));
+    spawner.spawn(unwrap!(usb_feedback_task(feedback)));
+    spawner.spawn(unwrap!(usb_task(usb_device)));
+    spawner.spawn(unwrap!(audio_receiver_task(receiver)));
 }

--- a/examples/stm32h7/src/bin/dac_dma.rs
+++ b/examples/stm32h7/src/bin/dac_dma.rs
@@ -53,8 +53,8 @@ async fn main(spawner: Spawner) {
     // Obtain two independent channels (p.DAC1 can only be consumed once, though!)
     let (dac_ch1, dac_ch2) = embassy_stm32::dac::Dac::new(p.DAC1, p.DMA1_CH3, p.DMA1_CH4, p.PA4, p.PA5).split();
 
-    spawner.spawn(dac_task1(p.TIM6, dac_ch1)).ok();
-    spawner.spawn(dac_task2(p.TIM7, dac_ch2)).ok();
+    spawner.spawn(dac_task1(p.TIM6, dac_ch1).unwrap());
+    spawner.spawn(dac_task2(p.TIM7, dac_ch2).unwrap());
 }
 
 #[embassy_executor::task]

--- a/examples/stm32h7/src/bin/eth.rs
+++ b/examples/stm32h7/src/bin/eth.rs
@@ -93,7 +93,7 @@ async fn main(spawner: Spawner) -> ! {
     let (stack, runner) = embassy_net::new(device, config, RESOURCES.init(StackResources::new()), seed);
 
     // Launch network task
-    unwrap!(spawner.spawn(net_task(runner)));
+    spawner.spawn(unwrap!(net_task(runner)));
 
     // Ensure DHCP configuration is up before trying connect
     stack.wait_config_up().await;

--- a/examples/stm32h7/src/bin/eth_client.rs
+++ b/examples/stm32h7/src/bin/eth_client.rs
@@ -95,7 +95,7 @@ async fn main(spawner: Spawner) -> ! {
     let (stack, runner) = embassy_net::new(device, config, RESOURCES.init(StackResources::new()), seed);
 
     // Launch network task
-    unwrap!(spawner.spawn(net_task(runner)));
+    spawner.spawn(unwrap!(net_task(runner)));
 
     // Ensure DHCP configuration is up before trying connect
     stack.wait_config_up().await;

--- a/examples/stm32h7/src/bin/eth_client_mii.rs
+++ b/examples/stm32h7/src/bin/eth_client_mii.rs
@@ -101,7 +101,7 @@ async fn main(spawner: Spawner) -> ! {
     let (stack, runner) = embassy_net::new(device, config, RESOURCES.init(StackResources::new()), seed);
 
     // Launch network task
-    unwrap!(spawner.spawn(net_task(runner)));
+    spawner.spawn(unwrap!(net_task(runner)));
 
     // Ensure DHCP configuration is up before trying connect
     stack.wait_config_up().await;

--- a/examples/stm32h7/src/bin/i2c_shared.rs
+++ b/examples/stm32h7/src/bin/i2c_shared.rs
@@ -95,9 +95,9 @@ async fn main(spawner: Spawner) {
 
     // Device 1, using embedded-hal-async compatible driver for TMP117
     let i2c_dev1 = I2cDevice::new(i2c_bus);
-    spawner.spawn(temperature(i2c_dev1)).unwrap();
+    spawner.spawn(temperature(i2c_dev1).unwrap());
 
     // Device 2, using embedded-hal-async compatible driver for SHTC3
     let i2c_dev2 = I2cDevice::new(i2c_bus);
-    spawner.spawn(humidity(i2c_dev2)).unwrap();
+    spawner.spawn(humidity(i2c_dev2).unwrap());
 }

--- a/examples/stm32h7/src/bin/multiprio.rs
+++ b/examples/stm32h7/src/bin/multiprio.rs
@@ -135,16 +135,16 @@ fn main() -> ! {
     // High-priority executor: UART4, priority level 6
     interrupt::UART4.set_priority(Priority::P6);
     let spawner = EXECUTOR_HIGH.start(interrupt::UART4);
-    unwrap!(spawner.spawn(run_high()));
+    spawner.spawn(unwrap!(run_high()));
 
     // Medium-priority executor: UART5, priority level 7
     interrupt::UART5.set_priority(Priority::P7);
     let spawner = EXECUTOR_MED.start(interrupt::UART5);
-    unwrap!(spawner.spawn(run_med()));
+    spawner.spawn(unwrap!(run_med()));
 
     // Low priority executor: runs in thread mode, using WFE/SEV
     let executor = EXECUTOR_LOW.init(Executor::new());
     executor.run(|spawner| {
-        unwrap!(spawner.spawn(run_low()));
+        spawner.spawn(unwrap!(run_low()));
     });
 }

--- a/examples/stm32h7/src/bin/signal.rs
+++ b/examples/stm32h7/src/bin/signal.rs
@@ -26,7 +26,7 @@ async fn my_sending_task() {
 #[embassy_executor::main]
 async fn main(spawner: Spawner) {
     let _p = embassy_stm32::init(Default::default());
-    unwrap!(spawner.spawn(my_sending_task()));
+    spawner.spawn(unwrap!(my_sending_task()));
 
     loop {
         let received_counter = SIGNAL.wait().await;

--- a/examples/stm32h7/src/bin/spi.rs
+++ b/examples/stm32h7/src/bin/spi.rs
@@ -66,6 +66,6 @@ fn main() -> ! {
     let executor = EXECUTOR.init(Executor::new());
 
     executor.run(|spawner| {
-        unwrap!(spawner.spawn(main_task(spi)));
+        spawner.spawn(unwrap!(main_task(spi)));
     })
 }

--- a/examples/stm32h7/src/bin/spi_bdma.rs
+++ b/examples/stm32h7/src/bin/spi_bdma.rs
@@ -80,6 +80,6 @@ fn main() -> ! {
     let executor = EXECUTOR.init(Executor::new());
 
     executor.run(|spawner| {
-        unwrap!(spawner.spawn(main_task(spi)));
+        spawner.spawn(unwrap!(main_task(spi)));
     })
 }

--- a/examples/stm32h7/src/bin/spi_dma.rs
+++ b/examples/stm32h7/src/bin/spi_dma.rs
@@ -63,6 +63,6 @@ fn main() -> ! {
     let executor = EXECUTOR.init(Executor::new());
 
     executor.run(|spawner| {
-        unwrap!(spawner.spawn(main_task(spi)));
+        spawner.spawn(unwrap!(main_task(spi)));
     })
 }

--- a/examples/stm32h7/src/bin/usart.rs
+++ b/examples/stm32h7/src/bin/usart.rs
@@ -34,6 +34,6 @@ fn main() -> ! {
     let executor = EXECUTOR.init(Executor::new());
 
     executor.run(|spawner| {
-        unwrap!(spawner.spawn(main_task()));
+        spawner.spawn(unwrap!(main_task()));
     })
 }

--- a/examples/stm32h7/src/bin/usart_dma.rs
+++ b/examples/stm32h7/src/bin/usart_dma.rs
@@ -42,6 +42,6 @@ fn main() -> ! {
     let executor = EXECUTOR.init(Executor::new());
 
     executor.run(|spawner| {
-        unwrap!(spawner.spawn(main_task()));
+        spawner.spawn(unwrap!(main_task()));
     })
 }

--- a/examples/stm32h7/src/bin/usart_split.rs
+++ b/examples/stm32h7/src/bin/usart_split.rs
@@ -27,7 +27,7 @@ async fn main(spawner: Spawner) -> ! {
 
     let (mut tx, rx) = usart.split();
 
-    unwrap!(spawner.spawn(reader(rx)));
+    spawner.spawn(unwrap!(reader(rx)));
 
     loop {
         let buf = CHANNEL.receive().await;

--- a/examples/stm32h735/src/bin/ltdc.rs
+++ b/examples/stm32h735/src/bin/ltdc.rs
@@ -47,7 +47,7 @@ async fn main(spawner: Spawner) {
 
     // blink the led on another task
     let led = Output::new(p.PC3, Level::High, Speed::Low);
-    unwrap!(spawner.spawn(led_task(led)));
+    spawner.spawn(unwrap!(led_task(led)));
 
     // numbers from STMicroelectronics/STM32CubeH7 STM32H735G-DK C-based example
     const RK043FN48H_HSYNC: u16 = 41; // Horizontal synchronization

--- a/examples/stm32h7rs/src/bin/eth.rs
+++ b/examples/stm32h7rs/src/bin/eth.rs
@@ -94,7 +94,7 @@ async fn main(spawner: Spawner) -> ! {
     let (stack, runner) = embassy_net::new(device, config, RESOURCES.init(StackResources::new()), seed);
 
     // Launch network task
-    unwrap!(spawner.spawn(net_task(runner)));
+    spawner.spawn(unwrap!(net_task(runner)));
 
     // Ensure DHCP configuration is up before trying connect
     //stack.wait_config_up().await;

--- a/examples/stm32h7rs/src/bin/multiprio.rs
+++ b/examples/stm32h7rs/src/bin/multiprio.rs
@@ -135,16 +135,16 @@ fn main() -> ! {
     // High-priority executor: UART4, priority level 6
     interrupt::UART4.set_priority(Priority::P6);
     let spawner = EXECUTOR_HIGH.start(interrupt::UART4);
-    unwrap!(spawner.spawn(run_high()));
+    spawner.spawn(unwrap!(run_high()));
 
     // Medium-priority executor: UART5, priority level 7
     interrupt::UART5.set_priority(Priority::P7);
     let spawner = EXECUTOR_MED.start(interrupt::UART5);
-    unwrap!(spawner.spawn(run_med()));
+    spawner.spawn(unwrap!(run_med()));
 
     // Low priority executor: runs in thread mode, using WFE/SEV
     let executor = EXECUTOR_LOW.init(Executor::new());
     executor.run(|spawner| {
-        unwrap!(spawner.spawn(run_low()));
+        spawner.spawn(unwrap!(run_low()));
     });
 }

--- a/examples/stm32h7rs/src/bin/signal.rs
+++ b/examples/stm32h7rs/src/bin/signal.rs
@@ -26,7 +26,7 @@ async fn my_sending_task() {
 #[embassy_executor::main]
 async fn main(spawner: Spawner) {
     let _p = embassy_stm32::init(Default::default());
-    unwrap!(spawner.spawn(my_sending_task()));
+    spawner.spawn(unwrap!(my_sending_task()));
 
     loop {
         let received_counter = SIGNAL.wait().await;

--- a/examples/stm32h7rs/src/bin/spi.rs
+++ b/examples/stm32h7rs/src/bin/spi.rs
@@ -44,6 +44,6 @@ fn main() -> ! {
     let executor = EXECUTOR.init(Executor::new());
 
     executor.run(|spawner| {
-        unwrap!(spawner.spawn(main_task(spi)));
+        spawner.spawn(unwrap!(main_task(spi)));
     })
 }

--- a/examples/stm32h7rs/src/bin/spi_dma.rs
+++ b/examples/stm32h7rs/src/bin/spi_dma.rs
@@ -41,6 +41,6 @@ fn main() -> ! {
     let executor = EXECUTOR.init(Executor::new());
 
     executor.run(|spawner| {
-        unwrap!(spawner.spawn(main_task(spi)));
+        spawner.spawn(unwrap!(main_task(spi)));
     })
 }

--- a/examples/stm32h7rs/src/bin/usart.rs
+++ b/examples/stm32h7rs/src/bin/usart.rs
@@ -34,6 +34,6 @@ fn main() -> ! {
     let executor = EXECUTOR.init(Executor::new());
 
     executor.run(|spawner| {
-        unwrap!(spawner.spawn(main_task()));
+        spawner.spawn(unwrap!(main_task()));
     })
 }

--- a/examples/stm32h7rs/src/bin/usart_dma.rs
+++ b/examples/stm32h7rs/src/bin/usart_dma.rs
@@ -42,6 +42,6 @@ fn main() -> ! {
     let executor = EXECUTOR.init(Executor::new());
 
     executor.run(|spawner| {
-        unwrap!(spawner.spawn(main_task()));
+        spawner.spawn(unwrap!(main_task()));
     })
 }

--- a/examples/stm32h7rs/src/bin/usart_split.rs
+++ b/examples/stm32h7rs/src/bin/usart_split.rs
@@ -27,7 +27,7 @@ async fn main(spawner: Spawner) -> ! {
 
     let (mut tx, rx) = usart.split();
 
-    unwrap!(spawner.spawn(reader(rx)));
+    spawner.spawn(unwrap!(reader(rx)));
 
     loop {
         let buf = CHANNEL.receive().await;

--- a/examples/stm32l0/src/bin/raw_spawn.rs
+++ b/examples/stm32l0/src/bin/raw_spawn.rs
@@ -42,8 +42,8 @@ fn main() -> ! {
     let run2_task = unsafe { make_static(&run2_task) };
 
     executor.run(|spawner| {
-        unwrap!(spawner.spawn(run1_task.spawn(|| run1())));
-        unwrap!(spawner.spawn(run2_task.spawn(|| run2())));
+        spawner.spawn(unwrap!(run1_task.spawn(|| run1())));
+        spawner.spawn(unwrap!(run2_task.spawn(|| run2())));
     });
 }
 

--- a/examples/stm32l4/src/bin/dac_dma.rs
+++ b/examples/stm32l4/src/bin/dac_dma.rs
@@ -24,8 +24,8 @@ async fn main(spawner: Spawner) {
     // Obtain two independent channels (p.DAC1 can only be consumed once, though!)
     let (dac_ch1, dac_ch2) = embassy_stm32::dac::Dac::new(p.DAC1, p.DMA1_CH3, p.DMA1_CH4, p.PA4, p.PA5).split();
 
-    spawner.spawn(dac_task1(p.TIM6, dac_ch1)).ok();
-    spawner.spawn(dac_task2(p.TIM7, dac_ch2)).ok();
+    spawner.spawn(dac_task1(p.TIM6, dac_ch1).unwrap());
+    spawner.spawn(dac_task2(p.TIM7, dac_ch2).unwrap());
 }
 
 #[embassy_executor::task]

--- a/examples/stm32l4/src/bin/spe_adin1110_http_server.rs
+++ b/examples/stm32l4/src/bin/spe_adin1110_http_server.rs
@@ -181,11 +181,11 @@ async fn main(spawner: Spawner) {
     .await;
 
     // Start task blink_led
-    unwrap!(spawner.spawn(heartbeat_led(led_uc3_yellow)));
+    spawner.spawn(unwrap!(heartbeat_led(led_uc3_yellow)));
     // Start task temperature measurement
-    unwrap!(spawner.spawn(temp_task(temp_sens_i2c, led_uc4_blue)));
+    spawner.spawn(unwrap!(temp_task(temp_sens_i2c, led_uc4_blue)));
     // Start ethernet task
-    unwrap!(spawner.spawn(ethernet_task(runner)));
+    spawner.spawn(unwrap!(ethernet_task(runner)));
 
     let mut rng = Rng::new(dp.RNG, Irqs);
     // Generate random seed
@@ -208,7 +208,7 @@ async fn main(spawner: Spawner) {
     let (stack, runner) = embassy_net::new(device, ip_cfg, RESOURCES.init(StackResources::new()), seed);
 
     // Launch network task
-    unwrap!(spawner.spawn(net_task(runner)));
+    spawner.spawn(unwrap!(net_task(runner)));
 
     let cfg = wait_for_config(stack).await;
     let local_addr = cfg.address.address();

--- a/examples/stm32l5/src/bin/stop.rs
+++ b/examples/stm32l5/src/bin/stop.rs
@@ -15,7 +15,7 @@ use {defmt_rtt as _, panic_probe as _};
 #[cortex_m_rt::entry]
 fn main() -> ! {
     Executor::take().run(|spawner| {
-        unwrap!(spawner.spawn(async_main(spawner)));
+        spawner.spawn(unwrap!(async_main(spawner)));
     })
 }
 
@@ -34,8 +34,8 @@ async fn async_main(spawner: Spawner) {
     let rtc = RTC.init(rtc);
     embassy_stm32::low_power::stop_with_rtc(rtc);
 
-    unwrap!(spawner.spawn(blinky(p.PC7.into())));
-    unwrap!(spawner.spawn(timeout()));
+    spawner.spawn(unwrap!(blinky(p.PC7.into())));
+    spawner.spawn(unwrap!(timeout()));
 }
 
 #[embassy_executor::task]

--- a/examples/stm32l5/src/bin/usb_ethernet.rs
+++ b/examples/stm32l5/src/bin/usb_ethernet.rs
@@ -96,11 +96,11 @@ async fn main(spawner: Spawner) {
     // Build the builder.
     let usb = builder.build();
 
-    unwrap!(spawner.spawn(usb_task(usb)));
+    spawner.spawn(unwrap!(usb_task(usb)));
 
     static NET_STATE: StaticCell<NetState<MTU, 4, 4>> = StaticCell::new();
     let (runner, device) = class.into_embassy_net_device::<MTU, 4, 4>(NET_STATE.init(NetState::new()), our_mac_addr);
-    unwrap!(spawner.spawn(usb_ncm_task(runner)));
+    spawner.spawn(unwrap!(usb_ncm_task(runner)));
 
     let config = embassy_net::Config::dhcpv4(Default::default());
     //let config = embassy_net::Config::ipv4_static(embassy_net::StaticConfigV4 {
@@ -117,7 +117,7 @@ async fn main(spawner: Spawner) {
     static RESOURCES: StaticCell<StackResources<3>> = StaticCell::new();
     let (stack, runner) = embassy_net::new(device, config, RESOURCES.init(StackResources::new()), seed);
 
-    unwrap!(spawner.spawn(net_task(runner)));
+    spawner.spawn(unwrap!(net_task(runner)));
 
     // And now we can use it!
 

--- a/examples/stm32u5/src/bin/ltdc.rs
+++ b/examples/stm32u5/src/bin/ltdc.rs
@@ -50,7 +50,7 @@ async fn main(spawner: Spawner) {
 
     // blink the led on another task
     let led = Output::new(p.PD2, Level::High, Speed::Low);
-    unwrap!(spawner.spawn(led_task(led)));
+    spawner.spawn(unwrap!(led_task(led)));
 
     // numbers from STM32U5G9J-DK2.ioc
     const RK050HR18H_HSYNC: u16 = 5; // Horizontal synchronization

--- a/examples/stm32wb/src/bin/mac_ffd.rs
+++ b/examples/stm32wb/src/bin/mac_ffd.rs
@@ -56,7 +56,7 @@ async fn main(spawner: Spawner) {
     let config = Config::default();
     let mbox = TlMbox::init(p.IPCC, Irqs, config);
 
-    spawner.spawn(run_mm_queue(mbox.mm_subsystem)).unwrap();
+    spawner.spawn(run_mm_queue(mbox.mm_subsystem).unwrap());
 
     let sys_event = mbox.sys_subsystem.read().await;
     info!("sys event: {}", sys_event.payload());

--- a/examples/stm32wb/src/bin/mac_ffd_net.rs
+++ b/examples/stm32wb/src/bin/mac_ffd_net.rs
@@ -62,7 +62,7 @@ async fn main(spawner: Spawner) {
     let config = Config::default();
     let mbox = TlMbox::init(p.IPCC, Irqs, config);
 
-    spawner.spawn(run_mm_queue(mbox.mm_subsystem)).unwrap();
+    spawner.spawn(run_mm_queue(mbox.mm_subsystem).unwrap());
 
     let sys_event = mbox.sys_subsystem.read().await;
     info!("sys event: {}", sys_event.payload());
@@ -168,7 +168,7 @@ async fn main(spawner: Spawner) {
     static RUNNER: StaticCell<Runner> = StaticCell::new();
     let runner = RUNNER.init(Runner::new(mbox.mac_subsystem, tx_queue));
 
-    spawner.spawn(run_mac(runner)).unwrap();
+    spawner.spawn(run_mac(runner).unwrap());
 
     let (driver, control) = mac::new(runner).await;
 

--- a/examples/stm32wb/src/bin/mac_rfd.rs
+++ b/examples/stm32wb/src/bin/mac_rfd.rs
@@ -58,7 +58,7 @@ async fn main(spawner: Spawner) {
     let config = Config::default();
     let mbox = TlMbox::init(p.IPCC, Irqs, config);
 
-    spawner.spawn(run_mm_queue(mbox.mm_subsystem)).unwrap();
+    spawner.spawn(run_mm_queue(mbox.mm_subsystem).unwrap());
 
     let sys_event = mbox.sys_subsystem.read().await;
     info!("sys event: {}", sys_event.payload());

--- a/examples/stm32wb/src/bin/tl_mbox_mac.rs
+++ b/examples/stm32wb/src/bin/tl_mbox_mac.rs
@@ -53,7 +53,7 @@ async fn main(spawner: Spawner) {
     let config = Config::default();
     let mbox = TlMbox::init(p.IPCC, Irqs, config);
 
-    spawner.spawn(run_mm_queue(mbox.mm_subsystem)).unwrap();
+    spawner.spawn(run_mm_queue(mbox.mm_subsystem).unwrap());
 
     let sys_event = mbox.sys_subsystem.read().await;
     info!("sys event: {}", sys_event.payload());

--- a/examples/wasm/src/lib.rs
+++ b/examples/wasm/src/lib.rs
@@ -24,5 +24,5 @@ async fn ticker() {
 #[embassy_executor::main]
 async fn main(spawner: Spawner) {
     wasm_logger::init(wasm_logger::Config::default());
-    spawner.spawn(ticker()).unwrap();
+    spawner.spawn(ticker().unwrap());
 }

--- a/tests/nrf/src/bin/ethernet_enc28j60_perf.rs
+++ b/tests/nrf/src/bin/ethernet_enc28j60_perf.rs
@@ -68,7 +68,7 @@ async fn main(spawner: Spawner) {
     static RESOURCES: StaticCell<StackResources<2>> = StaticCell::new();
     let (stack, runner) = embassy_net::new(device, config, RESOURCES.init(StackResources::new()), seed);
 
-    unwrap!(spawner.spawn(net_task(runner)));
+    spawner.spawn(unwrap!(net_task(runner)));
 
     perf_client::run(
         stack,

--- a/tests/nrf/src/bin/wifi_esp_hosted_perf.rs
+++ b/tests/nrf/src/bin/wifi_esp_hosted_perf.rs
@@ -74,7 +74,7 @@ async fn main(spawner: Spawner) {
     )
     .await;
 
-    unwrap!(spawner.spawn(wifi_task(runner)));
+    spawner.spawn(unwrap!(wifi_task(runner)));
 
     unwrap!(control.init().await);
     unwrap!(control.connect(WIFI_NETWORK, WIFI_PASSWORD).await);
@@ -94,7 +94,7 @@ async fn main(spawner: Spawner) {
         seed,
     );
 
-    unwrap!(spawner.spawn(net_task(runner)));
+    spawner.spawn(unwrap!(net_task(runner)));
 
     perf_client::run(
         stack,

--- a/tests/rp/src/bin/cyw43-perf.rs
+++ b/tests/rp/src/bin/cyw43-perf.rs
@@ -70,7 +70,7 @@ async fn main(spawner: Spawner) {
     static STATE: StaticCell<cyw43::State> = StaticCell::new();
     let state = STATE.init(cyw43::State::new());
     let (net_device, mut control, runner) = cyw43::new(state, pwr, spi, fw).await;
-    unwrap!(spawner.spawn(wifi_task(runner)));
+    spawner.spawn(unwrap!(wifi_task(runner)));
 
     control.init(clm).await;
     control
@@ -89,7 +89,7 @@ async fn main(spawner: Spawner) {
         seed,
     );
 
-    unwrap!(spawner.spawn(net_task(runner)));
+    spawner.spawn(unwrap!(net_task(runner)));
 
     loop {
         match control

--- a/tests/rp/src/bin/ethernet_w5100s_perf.rs
+++ b/tests/rp/src/bin/ethernet_w5100s_perf.rs
@@ -60,7 +60,7 @@ async fn main(spawner: Spawner) {
     )
     .await
     .unwrap();
-    unwrap!(spawner.spawn(ethernet_task(runner)));
+    spawner.spawn(unwrap!(ethernet_task(runner)));
 
     // Generate random seed
     let seed = rng.next_u64();
@@ -75,7 +75,7 @@ async fn main(spawner: Spawner) {
     );
 
     // Launch network task
-    unwrap!(spawner.spawn(net_task(runner)));
+    spawner.spawn(unwrap!(net_task(runner)));
 
     perf_client::run(
         stack,

--- a/tests/rp/src/bin/gpio_multicore.rs
+++ b/tests/rp/src/bin/gpio_multicore.rs
@@ -30,11 +30,11 @@ fn main() -> ! {
         unsafe { &mut *core::ptr::addr_of_mut!(CORE1_STACK) },
         move || {
             let executor1 = EXECUTOR1.init(Executor::new());
-            executor1.run(|spawner| unwrap!(spawner.spawn(core1_task(p.PIN_1))));
+            executor1.run(|spawner| spawner.spawn(unwrap!(core1_task(p.PIN_1))));
         },
     );
     let executor0 = EXECUTOR0.init(Executor::new());
-    executor0.run(|spawner| unwrap!(spawner.spawn(core0_task(p.PIN_0))));
+    executor0.run(|spawner| spawner.spawn(unwrap!(core0_task(p.PIN_0))));
 }
 
 #[embassy_executor::task]

--- a/tests/rp/src/bin/i2c.rs
+++ b/tests/rp/src/bin/i2c.rs
@@ -208,7 +208,7 @@ async fn controller_task(con: &mut i2c::I2c<'static, I2C0, i2c::Async>) {
         config.addr = DEV_ADDR as u16;
         let device = i2c_slave::I2cSlave::new(p.I2C1, d_sda, d_scl, Irqs, config);
 
-        spawner.must_spawn(device_task(device));
+        spawner.spawn(device_task(device).unwrap());
 
         let c_sda = p.PIN_21;
         let c_scl = p.PIN_20;

--- a/tests/rp/src/bin/multicore.rs
+++ b/tests/rp/src/bin/multicore.rs
@@ -27,11 +27,11 @@ fn main() -> ! {
         unsafe { &mut *core::ptr::addr_of_mut!(CORE1_STACK) },
         move || {
             let executor1 = EXECUTOR1.init(Executor::new());
-            executor1.run(|spawner| unwrap!(spawner.spawn(core1_task())));
+            executor1.run(|spawner| spawner.spawn(unwrap!(core1_task())));
         },
     );
     let executor0 = EXECUTOR0.init(Executor::new());
-    executor0.run(|spawner| unwrap!(spawner.spawn(core0_task())));
+    executor0.run(|spawner| spawner.spawn(unwrap!(core0_task())));
 }
 
 #[embassy_executor::task]

--- a/tests/rp/src/bin/spinlock_mutex_multicore.rs
+++ b/tests/rp/src/bin/spinlock_mutex_multicore.rs
@@ -27,11 +27,11 @@ fn main() -> ! {
         unsafe { &mut *core::ptr::addr_of_mut!(CORE1_STACK) },
         move || {
             let executor1 = EXECUTOR1.init(Executor::new());
-            executor1.run(|spawner| unwrap!(spawner.spawn(core1_task())));
+            executor1.run(|spawner| spawner.spawn(unwrap!(core1_task())));
         },
     );
     let executor0 = EXECUTOR0.init(Executor::new());
-    executor0.run(|spawner| unwrap!(spawner.spawn(core0_task())));
+    executor0.run(|spawner| spawner.spawn(unwrap!(core0_task())));
 }
 
 #[embassy_executor::task]

--- a/tests/stm32/src/bin/eth.rs
+++ b/tests/stm32/src/bin/eth.rs
@@ -101,7 +101,7 @@ async fn main(spawner: Spawner) {
     let (stack, runner) = embassy_net::new(device, config, RESOURCES.init(StackResources::new()), seed);
 
     // Launch network task
-    unwrap!(spawner.spawn(net_task(runner)));
+    spawner.spawn(unwrap!(net_task(runner)));
 
     perf_client::run(
         stack,

--- a/tests/stm32/src/bin/stop.rs
+++ b/tests/stm32/src/bin/stop.rs
@@ -19,7 +19,7 @@ use static_cell::StaticCell;
 #[entry]
 fn main() -> ! {
     Executor::take().run(|spawner| {
-        unwrap!(spawner.spawn(async_main(spawner)));
+        spawner.spawn(unwrap!(async_main(spawner)));
     });
 }
 
@@ -75,6 +75,6 @@ async fn async_main(spawner: Spawner) {
 
     stop_with_rtc(rtc);
 
-    spawner.spawn(task_1()).unwrap();
-    spawner.spawn(task_2()).unwrap();
+    spawner.spawn(task_1().unwrap());
+    spawner.spawn(task_2().unwrap());
 }

--- a/tests/stm32/src/bin/usart_rx_ringbuffered.rs
+++ b/tests/stm32/src/bin/usart_rx_ringbuffered.rs
@@ -46,8 +46,8 @@ async fn main(spawner: Spawner) {
     let rx = rx.into_ring_buffered(unsafe { &mut *core::ptr::addr_of_mut!(DMA_BUF) });
 
     info!("Spawning tasks");
-    spawner.spawn(transmit_task(tx)).unwrap();
-    spawner.spawn(receive_task(rx)).unwrap();
+    spawner.spawn(transmit_task(tx).unwrap());
+    spawner.spawn(receive_task(rx).unwrap());
 }
 
 #[embassy_executor::task]

--- a/tests/stm32/src/bin/wpan_ble.rs
+++ b/tests/stm32/src/bin/wpan_ble.rs
@@ -47,7 +47,7 @@ async fn main(spawner: Spawner) {
     let config = Config::default();
     let mut mbox = TlMbox::init(p.IPCC, Irqs, config);
 
-    spawner.spawn(run_mm_queue(mbox.mm_subsystem)).unwrap();
+    spawner.spawn(run_mm_queue(mbox.mm_subsystem).unwrap());
 
     let sys_event = mbox.sys_subsystem.read().await;
     info!("sys event: {}", sys_event.payload());

--- a/tests/stm32/src/bin/wpan_mac.rs
+++ b/tests/stm32/src/bin/wpan_mac.rs
@@ -40,7 +40,7 @@ async fn main(spawner: Spawner) {
     let config = Config::default();
     let mbox = TlMbox::init(p.IPCC, Irqs, config);
 
-    spawner.spawn(run_mm_queue(mbox.mm_subsystem)).unwrap();
+    spawner.spawn(run_mm_queue(mbox.mm_subsystem).unwrap());
 
     let sys_event = mbox.sys_subsystem.read().await;
     info!("sys event: {}", sys_event.payload());


### PR DESCRIPTION
- **executor: do not store task IDs in RAM, we can get it from the pointer every time.**
- **executor: allow trace and rtos-trace to coexist additively.**
- **executor: add "task metadata" concept, make name a task metadata.**
- **executor: do not deref a mut ptr to the entire taskheader.**
