### PR TITLE
embassy-stm32: Added ability for SPI driver to function in slave mode

### DIFF
--- a/embassy-stm32/src/spi/mod.rs
+++ b/embassy-stm32/src/spi/mod.rs
@@ -163,7 +163,7 @@ pub mod mode {
         const MASTER: vals::Master = vals::Master::SLAVE;
     }
 }
-use mode::CommunicationMode;
+use mode::{CommunicationMode, Master, Slave};
 
 /// SPI driver.
 pub struct Spi<'d, M: PeriMode, CM: CommunicationMode> {
@@ -512,27 +512,7 @@ impl<'d, M: PeriMode, CM: CommunicationMode> Spi<'d, M, CM> {
     }
 }
 
-impl<'d, CM: CommunicationMode> Spi<'d, Blocking, CM> {
-    /// Create a new blocking SPI driver.
-    pub fn new_blocking<T: Instance>(
-        peri: Peri<'d, T>,
-        sck: Peri<'d, impl SckPin<T>>,
-        mosi: Peri<'d, impl MosiPin<T>>,
-        miso: Peri<'d, impl MisoPin<T>>,
-        config: Config,
-    ) -> Self {
-        Self::new_inner(
-            peri,
-            new_pin!(sck, config.sck_af()),
-            new_pin!(mosi, AfType::output(OutputType::PushPull, config.rise_fall_speed)),
-            new_pin!(miso, AfType::input(config.miso_pull)),
-            None,
-            None,
-            None,
-            config,
-        )
-    }
-
+impl<'d> Spi<'d, Blocking, Slave> {
     /// Create a new blocking SPI slave driver.
     pub fn new_blocking_slave<T: Instance>(
         peri: Peri<'d, T>,
@@ -548,6 +528,28 @@ impl<'d, CM: CommunicationMode> Spi<'d, Blocking, CM> {
             new_pin!(mosi, AfType::output(OutputType::PushPull, config.rise_fall_speed)),
             new_pin!(miso, AfType::input(config.miso_pull)),
             new_pin!(cs, AfType::input(Pull::None)),
+            None,
+            None,
+            config,
+        )
+    }
+}
+
+impl<'d> Spi<'d, Blocking, Master> {
+    /// Create a new blocking SPI driver.
+    pub fn new_blocking<T: Instance>(
+        peri: Peri<'d, T>,
+        sck: Peri<'d, impl SckPin<T>>,
+        mosi: Peri<'d, impl MosiPin<T>>,
+        miso: Peri<'d, impl MisoPin<T>>,
+        config: Config,
+    ) -> Self {
+        Self::new_inner(
+            peri,
+            new_pin!(sck, config.sck_af()),
+            new_pin!(mosi, AfType::output(OutputType::PushPull, config.rise_fall_speed)),
+            new_pin!(miso, AfType::input(config.miso_pull)),
+            None,
             None,
             None,
             config,
@@ -613,29 +615,7 @@ impl<'d, CM: CommunicationMode> Spi<'d, Blocking, CM> {
     }
 }
 
-impl<'d, CM: CommunicationMode> Spi<'d, Async, CM> {
-    /// Create a new SPI driver.
-    pub fn new<T: Instance>(
-        peri: Peri<'d, T>,
-        sck: Peri<'d, impl SckPin<T>>,
-        mosi: Peri<'d, impl MosiPin<T>>,
-        miso: Peri<'d, impl MisoPin<T>>,
-        tx_dma: Peri<'d, impl TxDma<T>>,
-        rx_dma: Peri<'d, impl RxDma<T>>,
-        config: Config,
-    ) -> Self {
-        Self::new_inner(
-            peri,
-            new_pin!(sck, config.sck_af()),
-            new_pin!(mosi, AfType::output(OutputType::PushPull, config.rise_fall_speed)),
-            new_pin!(miso, AfType::input(config.miso_pull)),
-            None,
-            new_dma!(tx_dma),
-            new_dma!(rx_dma),
-            config,
-        )
-    }
-
+impl<'d> Spi<'d, Async, Slave> {
     /// Create a new SPI slave driver.
     pub fn new_slave<T: Instance>(
         peri: Peri<'d, T>,
@@ -653,6 +633,30 @@ impl<'d, CM: CommunicationMode> Spi<'d, Async, CM> {
             new_pin!(mosi, AfType::output(OutputType::PushPull, config.rise_fall_speed)),
             new_pin!(miso, AfType::input(config.miso_pull)),
             new_pin!(cs, AfType::input(Pull::None)),
+            new_dma!(tx_dma),
+            new_dma!(rx_dma),
+            config,
+        )
+    }
+}
+
+impl<'d> Spi<'d, Async, Master> {
+    /// Create a new SPI driver.
+    pub fn new<T: Instance>(
+        peri: Peri<'d, T>,
+        sck: Peri<'d, impl SckPin<T>>,
+        mosi: Peri<'d, impl MosiPin<T>>,
+        miso: Peri<'d, impl MisoPin<T>>,
+        tx_dma: Peri<'d, impl TxDma<T>>,
+        rx_dma: Peri<'d, impl RxDma<T>>,
+        config: Config,
+    ) -> Self {
+        Self::new_inner(
+            peri,
+            new_pin!(sck, config.sck_af()),
+            new_pin!(mosi, AfType::output(OutputType::PushPull, config.rise_fall_speed)),
+            new_pin!(miso, AfType::input(config.miso_pull)),
+            None,
             new_dma!(tx_dma),
             new_dma!(rx_dma),
             config,

--- a/embassy-stm32/src/spi/mod.rs
+++ b/embassy-stm32/src/spi/mod.rs
@@ -533,6 +533,27 @@ impl<'d, CM: CommunicationMode> Spi<'d, Blocking, CM> {
         )
     }
 
+    /// Create a new blocking SPI slave driver.
+    pub fn new_blocking_slave<T: Instance>(
+        peri: Peri<'d, T>,
+        sck: Peri<'d, impl SckPin<T>>,
+        mosi: Peri<'d, impl MosiPin<T>>,
+        miso: Peri<'d, impl MisoPin<T>>,
+        cs: Peri<'d, impl CsPin<T>>,
+        config: Config,
+    ) -> Self {
+        Self::new_inner(
+            peri,
+            new_pin!(sck, config.sck_af()),
+            new_pin!(mosi, AfType::output(OutputType::PushPull, config.rise_fall_speed)),
+            new_pin!(miso, AfType::input(config.miso_pull)),
+            new_pin!(cs, AfType::input(Pull::None)),
+            None,
+            None,
+            config,
+        )
+    }
+
     /// Create a new blocking SPI driver, in RX-only mode (only MISO pin, no MOSI).
     pub fn new_blocking_rxonly<T: Instance>(
         peri: Peri<'d, T>,
@@ -609,6 +630,29 @@ impl<'d, CM: CommunicationMode> Spi<'d, Async, CM> {
             new_pin!(mosi, AfType::output(OutputType::PushPull, config.rise_fall_speed)),
             new_pin!(miso, AfType::input(config.miso_pull)),
             None,
+            new_dma!(tx_dma),
+            new_dma!(rx_dma),
+            config,
+        )
+    }
+
+    /// Create a new SPI slave driver.
+    pub fn new_slave<T: Instance>(
+        peri: Peri<'d, T>,
+        sck: Peri<'d, impl SckPin<T>>,
+        mosi: Peri<'d, impl MosiPin<T>>,
+        miso: Peri<'d, impl MisoPin<T>>,
+        cs: Peri<'d, impl CsPin<T>>,
+        tx_dma: Peri<'d, impl TxDma<T>>,
+        rx_dma: Peri<'d, impl RxDma<T>>,
+        config: Config,
+    ) -> Self {
+        Self::new_inner(
+            peri,
+            new_pin!(sck, config.sck_af()),
+            new_pin!(mosi, AfType::output(OutputType::PushPull, config.rise_fall_speed)),
+            new_pin!(miso, AfType::input(config.miso_pull)),
+            new_pin!(cs, AfType::input(Pull::None)),
             new_dma!(tx_dma),
             new_dma!(rx_dma),
             config,

--- a/embassy-stm32/src/spi/mod.rs
+++ b/embassy-stm32/src/spi/mod.rs
@@ -1286,7 +1286,7 @@ impl embedded_hal_1::spi::Error for Error {
     }
 }
 
-impl<'d, W: Word, CM: CommunicationMode> embedded_hal_async::spi::SpiBus<W> for Spi<'d, Async, CM> {
+impl<'d, W: Word> embedded_hal_async::spi::SpiBus<W> for Spi<'d, Async, Master> {
     async fn flush(&mut self) -> Result<(), Self::Error> {
         Ok(())
     }

--- a/embassy-stm32/src/spi/mod.rs
+++ b/embassy-stm32/src/spi/mod.rs
@@ -231,7 +231,7 @@ impl<'d, M: PeriMode, CM: CommunicationMode> Spi<'d, M, CM> {
                 w.set_spe(true);
                 w.set_lsbfirst(lsbfirst);
                 w.set_ssi(CM::MASTER == vals::Mstr::MASTER);
-                w.set_ssm(true);
+                w.set_ssm(CM::MASTER == vals::Mstr::MASTER);
                 w.set_crcen(false);
                 w.set_bidimode(vals::Bidimode::UNIDIRECTIONAL);
                 // we're doing "fake rxonly", by actually writing one
@@ -257,7 +257,7 @@ impl<'d, M: PeriMode, CM: CommunicationMode> Spi<'d, M, CM> {
                 w.set_br(br);
                 w.set_lsbfirst(lsbfirst);
                 w.set_ssi(CM::MASTER == vals::Mstr::MASTER);
-                w.set_ssm(true);
+                w.set_ssm(CM::MASTER == vals::Mstr::MASTER);
                 w.set_crcen(false);
                 w.set_bidimode(vals::Bidimode::UNIDIRECTIONAL);
                 w.set_spe(true);
@@ -272,7 +272,7 @@ impl<'d, M: PeriMode, CM: CommunicationMode> Spi<'d, M, CM> {
                 w.set_cpha(cpha);
                 w.set_cpol(cpol);
                 w.set_lsbfirst(lsbfirst);
-                w.set_ssm(true);
+                w.set_ssm(CM::MASTER == vals::Master::MASTER);
                 w.set_master(CM::MASTER);
                 w.set_comm(vals::Comm::FULL_DUPLEX);
                 w.set_ssom(vals::Ssom::ASSERTED);

--- a/embassy-stm32/src/spi/mod.rs
+++ b/embassy-stm32/src/spi/mod.rs
@@ -757,7 +757,9 @@ impl<'d> Spi<'d, Async, Master> {
     ) -> Self {
         Self::new_inner(peri, None, None, None, None, tx_dma, rx_dma, config)
     }
+}
 
+impl<'d, CM: CommunicationMode> Spi<'d, Async, CM> {
     /// SPI write, using DMA.
     pub async fn write<W: Word>(&mut self, data: &[W]) -> Result<(), Error> {
         if data.is_empty() {

--- a/embassy-stm32/src/spi/mod.rs
+++ b/embassy-stm32/src/spi/mod.rs
@@ -1288,7 +1288,7 @@ impl embedded_hal_1::spi::Error for Error {
     }
 }
 
-impl<'d, W: Word> embedded_hal_async::spi::SpiBus<W> for Spi<'d, Async, Master> {
+impl<'d, W: Word, CM: CommunicationMode> embedded_hal_async::spi::SpiBus<W> for Spi<'d, Async, CM> {
     async fn flush(&mut self) -> Result<(), Self::Error> {
         Ok(())
     }


### PR DESCRIPTION
Hello!

This PR adds the ability to create an SPI driver instance in slave mode. I have taken inspiration from the I2C driver for the added traits. The original master SPI driver API is left intact. 

From the reference manual and STM32 HAL SPI driver source, it seems as though the only extra step required to run in slave mode is to disable the SSM and SSI bits in the SPI control registers. 

Two new functions are added to allow for construction of a slave blocking and non-blocking driver, namely `Spi::new_blocking_slave` and `Spi::new_slave` (with an extra NSS parameter of course).

I have tested this on the STM32F723ZE with success. Please let me know if I have missed something in the implementation as I am still quite new to driver development.

Cheers