### PR TITLE
Fixing the nrf54l drive configuration bug

### DIFF
--- a/embassy-nrf/src/gpio.rs
+++ b/embassy-nrf/src/gpio.rs
@@ -292,7 +292,7 @@ pub(crate) fn convert_drive(w: &mut pac::gpio::regs::PinCnf, drive: OutputDrive)
         }
 
         w.set_drive0(convert(drive.low));
-        w.set_drive0(convert(drive.high));
+        w.set_drive1(convert(drive.high));
     }
 }
 


### PR DESCRIPTION
Fixes a mistake that misconfigures the drive pins for the nrf54l I notice while working on the support for the nrf54l.