### PR TITLE
Make USB endpoint allocator methods accept an optional `EndpointAddress`

### DIFF
--- a/embassy-stm32/src/usb/otg.rs
+++ b/embassy-stm32/src/usb/otg.rs
@@ -231,19 +231,23 @@ impl<'d, T: Instance> embassy_usb_driver::Driver<'d> for Driver<'d, T> {
     fn alloc_endpoint_in(
         &mut self,
         ep_type: EndpointType,
+        ep_addr: Option<EndpointAddress>,
         max_packet_size: u16,
         interval_ms: u8,
     ) -> Result<Self::EndpointIn, EndpointAllocError> {
-        self.inner.alloc_endpoint_in(ep_type, max_packet_size, interval_ms)
+        self.inner
+            .alloc_endpoint_in(ep_type, ep_addr, max_packet_size, interval_ms)
     }
 
     fn alloc_endpoint_out(
         &mut self,
         ep_type: EndpointType,
+        ep_addr: Option<EndpointAddress>,
         max_packet_size: u16,
         interval_ms: u8,
     ) -> Result<Self::EndpointOut, EndpointAllocError> {
-        self.inner.alloc_endpoint_out(ep_type, max_packet_size, interval_ms)
+        self.inner
+            .alloc_endpoint_out(ep_type, ep_addr, max_packet_size, interval_ms)
     }
 
     fn start(self, control_max_packet_size: u16) -> (Self::Bus, Self::ControlPipe) {

--- a/embassy-usb-driver/src/lib.rs
+++ b/embassy-usb-driver/src/lib.rs
@@ -136,6 +136,7 @@ pub trait Driver<'a> {
     fn alloc_endpoint_out(
         &mut self,
         ep_type: EndpointType,
+        ep_addr: Option<EndpointAddress>,
         max_packet_size: u16,
         interval_ms: u8,
     ) -> Result<Self::EndpointOut, EndpointAllocError>;
@@ -153,6 +154,7 @@ pub trait Driver<'a> {
     fn alloc_endpoint_in(
         &mut self,
         ep_type: EndpointType,
+        ep_addr: Option<EndpointAddress>,
         max_packet_size: u16,
         interval_ms: u8,
     ) -> Result<Self::EndpointIn, EndpointAllocError>;

--- a/embassy-usb-synopsys-otg/src/lib.rs
+++ b/embassy-usb-synopsys-otg/src/lib.rs
@@ -345,6 +345,7 @@ impl<'d, const MAX_EP_COUNT: usize> Driver<'d, MAX_EP_COUNT> {
     fn alloc_endpoint<D: Dir>(
         &mut self,
         ep_type: EndpointType,
+        ep_addr: Option<EndpointAddress>,
         max_packet_size: u16,
         interval_ms: u8,
     ) -> Result<Endpoint<'d, D>, EndpointAllocError> {
@@ -379,15 +380,31 @@ impl<'d, const MAX_EP_COUNT: usize> Driver<'d, MAX_EP_COUNT> {
             Direction::In => &mut self.ep_in[..self.instance.endpoint_count],
         };
 
-        // Find free endpoint slot
-        let slot = eps.iter_mut().enumerate().find(|(i, ep)| {
-            if *i == 0 && ep_type != EndpointType::Control {
-                // reserved for control pipe
-                false
-            } else {
-                ep.is_none()
+        // Find endpoint slot
+        let slot = if let Some(addr) = ep_addr {
+            // Use the specified endpoint address
+            let requested_index = addr.index();
+            if requested_index >= self.instance.endpoint_count {
+                return Err(EndpointAllocError);
             }
-        });
+            if requested_index == 0 && ep_type != EndpointType::Control {
+                return Err(EndpointAllocError); // EP0 is reserved for control
+            }
+            if eps[requested_index].is_some() {
+                return Err(EndpointAllocError); // Already allocated
+            }
+            Some((requested_index, &mut eps[requested_index]))
+        } else {
+            // Find any free endpoint slot
+            eps.iter_mut().enumerate().find(|(i, ep)| {
+                if *i == 0 && ep_type != EndpointType::Control {
+                    // reserved for control pipe
+                    false
+                } else {
+                    ep.is_none()
+                }
+            })
+        };
 
         let index = match slot {
             Some((index, ep)) => {
@@ -438,27 +455,29 @@ impl<'d, const MAX_EP_COUNT: usize> embassy_usb_driver::Driver<'d> for Driver<'d
     fn alloc_endpoint_in(
         &mut self,
         ep_type: EndpointType,
+        ep_addr: Option<EndpointAddress>,
         max_packet_size: u16,
         interval_ms: u8,
     ) -> Result<Self::EndpointIn, EndpointAllocError> {
-        self.alloc_endpoint(ep_type, max_packet_size, interval_ms)
+        self.alloc_endpoint(ep_type, ep_addr, max_packet_size, interval_ms)
     }
 
     fn alloc_endpoint_out(
         &mut self,
         ep_type: EndpointType,
+        ep_addr: Option<EndpointAddress>,
         max_packet_size: u16,
         interval_ms: u8,
     ) -> Result<Self::EndpointOut, EndpointAllocError> {
-        self.alloc_endpoint(ep_type, max_packet_size, interval_ms)
+        self.alloc_endpoint(ep_type, ep_addr, max_packet_size, interval_ms)
     }
 
     fn start(mut self, control_max_packet_size: u16) -> (Self::Bus, Self::ControlPipe) {
         let ep_out = self
-            .alloc_endpoint(EndpointType::Control, control_max_packet_size, 0)
+            .alloc_endpoint(EndpointType::Control, None, control_max_packet_size, 0)
             .unwrap();
         let ep_in = self
-            .alloc_endpoint(EndpointType::Control, control_max_packet_size, 0)
+            .alloc_endpoint(EndpointType::Control, None, control_max_packet_size, 0)
             .unwrap();
         assert_eq!(ep_out.info.addr.index(), 0);
         assert_eq!(ep_in.info.addr.index(), 0);

--- a/embassy-usb/src/builder.rs
+++ b/embassy-usb/src/builder.rs
@@ -2,7 +2,7 @@ use heapless::Vec;
 
 use crate::config::MAX_HANDLER_COUNT;
 use crate::descriptor::{BosWriter, DescriptorWriter, SynchronizationType, UsageType};
-use crate::driver::{Driver, Endpoint, EndpointInfo, EndpointType};
+use crate::driver::{Driver, Endpoint, EndpointAddress, EndpointInfo, EndpointType};
 use crate::msos::{DeviceLevelDescriptor, FunctionLevelDescriptor, MsOsDescriptorWriter};
 use crate::types::{InterfaceNumber, StringIndex};
 use crate::{Handler, Interface, UsbDevice, MAX_INTERFACE_COUNT, STRING_INDEX_CUSTOM_START};
@@ -465,11 +465,17 @@ impl<'a, 'd, D: Driver<'d>> InterfaceAltBuilder<'a, 'd, D> {
     /// Allocate an IN endpoint, without writing its descriptor.
     ///
     /// Used for granular control over the order of endpoint and descriptor creation.
-    pub fn alloc_endpoint_in(&mut self, ep_type: EndpointType, max_packet_size: u16, interval_ms: u8) -> D::EndpointIn {
+    pub fn alloc_endpoint_in(
+        &mut self,
+        ep_type: EndpointType,
+        ep_addr: Option<EndpointAddress>,
+        max_packet_size: u16,
+        interval_ms: u8,
+    ) -> D::EndpointIn {
         let ep = self
             .builder
             .driver
-            .alloc_endpoint_in(ep_type, max_packet_size, interval_ms)
+            .alloc_endpoint_in(ep_type, ep_addr, max_packet_size, interval_ms)
             .expect("alloc_endpoint_in failed");
 
         ep
@@ -478,13 +484,14 @@ impl<'a, 'd, D: Driver<'d>> InterfaceAltBuilder<'a, 'd, D> {
     fn endpoint_in(
         &mut self,
         ep_type: EndpointType,
+        ep_addr: Option<EndpointAddress>,
         max_packet_size: u16,
         interval_ms: u8,
         synchronization_type: SynchronizationType,
         usage_type: UsageType,
         extra_fields: &[u8],
     ) -> D::EndpointIn {
-        let ep = self.alloc_endpoint_in(ep_type, max_packet_size, interval_ms);
+        let ep = self.alloc_endpoint_in(ep_type, ep_addr, max_packet_size, interval_ms);
         self.endpoint_descriptor(ep.info(), synchronization_type, usage_type, extra_fields);
 
         ep
@@ -496,13 +503,14 @@ impl<'a, 'd, D: Driver<'d>> InterfaceAltBuilder<'a, 'd, D> {
     pub fn alloc_endpoint_out(
         &mut self,
         ep_type: EndpointType,
+        ep_addr: Option<EndpointAddress>,
         max_packet_size: u16,
         interval_ms: u8,
     ) -> D::EndpointOut {
         let ep = self
             .builder
             .driver
-            .alloc_endpoint_out(ep_type, max_packet_size, interval_ms)
+            .alloc_endpoint_out(ep_type, ep_addr, max_packet_size, interval_ms)
             .expect("alloc_endpoint_out failed");
 
         ep
@@ -511,13 +519,14 @@ impl<'a, 'd, D: Driver<'d>> InterfaceAltBuilder<'a, 'd, D> {
     fn endpoint_out(
         &mut self,
         ep_type: EndpointType,
+        ep_addr: Option<EndpointAddress>,
         max_packet_size: u16,
         interval_ms: u8,
         synchronization_type: SynchronizationType,
         usage_type: UsageType,
         extra_fields: &[u8],
     ) -> D::EndpointOut {
-        let ep = self.alloc_endpoint_out(ep_type, max_packet_size, interval_ms);
+        let ep = self.alloc_endpoint_out(ep_type, ep_addr, max_packet_size, interval_ms);
         self.endpoint_descriptor(ep.info(), synchronization_type, usage_type, extra_fields);
 
         ep
@@ -527,9 +536,10 @@ impl<'a, 'd, D: Driver<'d>> InterfaceAltBuilder<'a, 'd, D> {
     ///
     /// Descriptors are written in the order builder functions are called. Note that some
     /// classes care about the order.
-    pub fn endpoint_bulk_in(&mut self, max_packet_size: u16) -> D::EndpointIn {
+    pub fn endpoint_bulk_in(&mut self, ep_addr: Option<EndpointAddress>, max_packet_size: u16) -> D::EndpointIn {
         self.endpoint_in(
             EndpointType::Bulk,
+            ep_addr,
             max_packet_size,
             0,
             SynchronizationType::NoSynchronization,
@@ -542,9 +552,10 @@ impl<'a, 'd, D: Driver<'d>> InterfaceAltBuilder<'a, 'd, D> {
     ///
     /// Descriptors are written in the order builder functions are called. Note that some
     /// classes care about the order.
-    pub fn endpoint_bulk_out(&mut self, max_packet_size: u16) -> D::EndpointOut {
+    pub fn endpoint_bulk_out(&mut self, ep_addr: Option<EndpointAddress>, max_packet_size: u16) -> D::EndpointOut {
         self.endpoint_out(
             EndpointType::Bulk,
+            ep_addr,
             max_packet_size,
             0,
             SynchronizationType::NoSynchronization,
@@ -557,9 +568,15 @@ impl<'a, 'd, D: Driver<'d>> InterfaceAltBuilder<'a, 'd, D> {
     ///
     /// Descriptors are written in the order builder functions are called. Note that some
     /// classes care about the order.
-    pub fn endpoint_interrupt_in(&mut self, max_packet_size: u16, interval_ms: u8) -> D::EndpointIn {
+    pub fn endpoint_interrupt_in(
+        &mut self,
+        ep_addr: Option<EndpointAddress>,
+        max_packet_size: u16,
+        interval_ms: u8,
+    ) -> D::EndpointIn {
         self.endpoint_in(
             EndpointType::Interrupt,
+            ep_addr,
             max_packet_size,
             interval_ms,
             SynchronizationType::NoSynchronization,
@@ -569,9 +586,15 @@ impl<'a, 'd, D: Driver<'d>> InterfaceAltBuilder<'a, 'd, D> {
     }
 
     /// Allocate a INTERRUPT OUT endpoint and write its descriptor.
-    pub fn endpoint_interrupt_out(&mut self, max_packet_size: u16, interval_ms: u8) -> D::EndpointOut {
+    pub fn endpoint_interrupt_out(
+        &mut self,
+        ep_addr: Option<EndpointAddress>,
+        max_packet_size: u16,
+        interval_ms: u8,
+    ) -> D::EndpointOut {
         self.endpoint_out(
             EndpointType::Interrupt,
+            ep_addr,
             max_packet_size,
             interval_ms,
             SynchronizationType::NoSynchronization,
@@ -586,6 +609,7 @@ impl<'a, 'd, D: Driver<'d>> InterfaceAltBuilder<'a, 'd, D> {
     /// classes care about the order.
     pub fn endpoint_isochronous_in(
         &mut self,
+        ep_addr: Option<EndpointAddress>,
         max_packet_size: u16,
         interval_ms: u8,
         synchronization_type: SynchronizationType,
@@ -594,6 +618,7 @@ impl<'a, 'd, D: Driver<'d>> InterfaceAltBuilder<'a, 'd, D> {
     ) -> D::EndpointIn {
         self.endpoint_in(
             EndpointType::Isochronous,
+            ep_addr,
             max_packet_size,
             interval_ms,
             synchronization_type,
@@ -605,6 +630,7 @@ impl<'a, 'd, D: Driver<'d>> InterfaceAltBuilder<'a, 'd, D> {
     /// Allocate a ISOCHRONOUS OUT endpoint and write its descriptor.
     pub fn endpoint_isochronous_out(
         &mut self,
+        ep_addr: Option<EndpointAddress>,
         max_packet_size: u16,
         interval_ms: u8,
         synchronization_type: SynchronizationType,
@@ -613,6 +639,7 @@ impl<'a, 'd, D: Driver<'d>> InterfaceAltBuilder<'a, 'd, D> {
     ) -> D::EndpointOut {
         self.endpoint_out(
             EndpointType::Isochronous,
+            ep_addr,
             max_packet_size,
             interval_ms,
             synchronization_type,

--- a/embassy-usb/src/class/cdc_acm.rs
+++ b/embassy-usb/src/class/cdc_acm.rs
@@ -254,14 +254,14 @@ impl<'d, D: Driver<'d>> CdcAcmClass<'d, D> {
             ],
         );
 
-        let comm_ep = alt.endpoint_interrupt_in(8, 255);
+        let comm_ep = alt.endpoint_interrupt_in(None, 8, 255);
 
         // Data interface
         let mut iface = func.interface();
         let data_if = iface.interface_number();
         let mut alt = iface.alt_setting(USB_CLASS_CDC_DATA, 0x00, CDC_PROTOCOL_NONE, None);
-        let read_ep = alt.endpoint_bulk_out(max_packet_size);
-        let write_ep = alt.endpoint_bulk_in(max_packet_size);
+        let read_ep = alt.endpoint_bulk_out(None, max_packet_size);
+        let write_ep = alt.endpoint_bulk_in(None, max_packet_size);
 
         drop(func);
 

--- a/embassy-usb/src/class/cdc_ncm/mod.rs
+++ b/embassy-usb/src/class/cdc_ncm/mod.rs
@@ -313,15 +313,15 @@ impl<'d, D: Driver<'d>> CdcNcmClass<'d, D> {
             ],
         );
 
-        let comm_ep = alt.endpoint_interrupt_in(8, 255);
+        let comm_ep = alt.endpoint_interrupt_in(None, 8, 255);
 
         // Data interface
         let mut iface = func.interface();
         let data_if = iface.interface_number();
         let _alt = iface.alt_setting(USB_CLASS_CDC_DATA, 0x00, CDC_PROTOCOL_NTB, None);
         let mut alt = iface.alt_setting(USB_CLASS_CDC_DATA, 0x00, CDC_PROTOCOL_NTB, None);
-        let read_ep = alt.endpoint_bulk_out(max_packet_size);
-        let write_ep = alt.endpoint_bulk_in(max_packet_size);
+        let read_ep = alt.endpoint_bulk_out(None, max_packet_size);
+        let write_ep = alt.endpoint_bulk_in(None, max_packet_size);
 
         drop(func);
 

--- a/embassy-usb/src/class/cmsis_dap_v2.rs
+++ b/embassy-usb/src/class/cmsis_dap_v2.rs
@@ -61,10 +61,10 @@ impl<'d, D: Driver<'d>> CmsisDapV2Class<'d, D> {
         ));
         let mut interface = function.interface();
         let mut alt = interface.alt_setting(0xFF, 0, 0, Some(iface_string));
-        let read_ep = alt.endpoint_bulk_out(max_packet_size);
-        let write_ep = alt.endpoint_bulk_in(max_packet_size);
+        let read_ep = alt.endpoint_bulk_out(None, max_packet_size);
+        let write_ep = alt.endpoint_bulk_in(None, max_packet_size);
         let trace_ep = if trace {
-            Some(alt.endpoint_bulk_in(max_packet_size))
+            Some(alt.endpoint_bulk_in(None, max_packet_size))
         } else {
             None
         };

--- a/embassy-usb/src/class/hid.rs
+++ b/embassy-usb/src/class/hid.rs
@@ -133,9 +133,9 @@ fn build<'d, D: Driver<'d>>(
         ],
     );
 
-    let ep_in = alt.endpoint_interrupt_in(config.max_packet_size, config.poll_ms);
+    let ep_in = alt.endpoint_interrupt_in(None, config.max_packet_size, config.poll_ms);
     let ep_out = if with_out_endpoint {
-        Some(alt.endpoint_interrupt_out(config.max_packet_size, config.poll_ms))
+        Some(alt.endpoint_interrupt_out(None, config.max_packet_size, config.poll_ms))
     } else {
         None
     };

--- a/embassy-usb/src/class/midi.rs
+++ b/embassy-usb/src/class/midi.rs
@@ -129,14 +129,14 @@ impl<'d, D: Driver<'d>> MidiClass<'d, D> {
         for i in 0..n_out_jacks {
             endpoint_data[2 + i as usize] = in_jack_id_emb(i);
         }
-        let read_ep = alt.endpoint_bulk_out(max_packet_size);
+        let read_ep = alt.endpoint_bulk_out(None, max_packet_size);
         alt.descriptor(CS_ENDPOINT, &endpoint_data[0..2 + n_out_jacks as usize]);
 
         endpoint_data[1] = n_in_jacks;
         for i in 0..n_in_jacks {
             endpoint_data[2 + i as usize] = out_jack_id_emb(i);
         }
-        let write_ep = alt.endpoint_bulk_in(max_packet_size);
+        let write_ep = alt.endpoint_bulk_in(None, max_packet_size);
         alt.descriptor(CS_ENDPOINT, &endpoint_data[0..2 + n_in_jacks as usize]);
 
         MidiClass { read_ep, write_ep }

--- a/embassy-usb/src/class/uac1/speaker.rs
+++ b/embassy-usb/src/class/uac1/speaker.rs
@@ -268,9 +268,10 @@ impl<'d, D: Driver<'d>> Speaker<'d, D> {
 
         alt.descriptor(CS_INTERFACE, &format_descriptor);
 
-        let streaming_endpoint = alt.alloc_endpoint_out(EndpointType::Isochronous, max_packet_size, 1);
+        let streaming_endpoint = alt.alloc_endpoint_out(EndpointType::Isochronous, None, max_packet_size, 1);
         let feedback_endpoint = alt.alloc_endpoint_in(
             EndpointType::Isochronous,
+            None,
             4, // Feedback packets are 24 bit (10.14 format).
             1,
         );

--- a/examples/rp/src/bin/usb_raw_bulk.rs
+++ b/examples/rp/src/bin/usb_raw_bulk.rs
@@ -96,8 +96,8 @@ async fn main(_spawner: Spawner) {
     let mut function = builder.function(0xFF, 0, 0);
     let mut interface = function.interface();
     let mut alt = interface.alt_setting(0xFF, 0, 0, None);
-    let mut read_ep = alt.endpoint_bulk_out(64);
-    let mut write_ep = alt.endpoint_bulk_in(64);
+    let mut read_ep = alt.endpoint_bulk_out(None, 64);
+    let mut write_ep = alt.endpoint_bulk_in(None, 64);
     drop(function);
 
     // Build the builder.

--- a/examples/rp/src/bin/usb_webusb.rs
+++ b/examples/rp/src/bin/usb_webusb.rs
@@ -125,8 +125,8 @@ impl<'d, D: Driver<'d>> WebEndpoints<'d, D> {
         let mut iface = func.interface();
         let mut alt = iface.alt_setting(0xff, 0x00, 0x00, None);
 
-        let write_ep = alt.endpoint_bulk_in(config.max_packet_size);
-        let read_ep = alt.endpoint_bulk_out(config.max_packet_size);
+        let write_ep = alt.endpoint_bulk_in(None, config.max_packet_size);
+        let read_ep = alt.endpoint_bulk_out(None, config.max_packet_size);
 
         WebEndpoints { write_ep, read_ep }
     }

--- a/examples/rp235x/src/bin/usb_webusb.rs
+++ b/examples/rp235x/src/bin/usb_webusb.rs
@@ -125,8 +125,8 @@ impl<'d, D: Driver<'d>> WebEndpoints<'d, D> {
         let mut iface = func.interface();
         let mut alt = iface.alt_setting(0xff, 0x00, 0x00, None);
 
-        let write_ep = alt.endpoint_bulk_in(config.max_packet_size);
-        let read_ep = alt.endpoint_bulk_out(config.max_packet_size);
+        let write_ep = alt.endpoint_bulk_in(None, config.max_packet_size);
+        let read_ep = alt.endpoint_bulk_out(None, config.max_packet_size);
 
         WebEndpoints { write_ep, read_ep }
     }


### PR DESCRIPTION
This PR adds an optional `ep_addr` to all USB endpoint allocation methods. If a method receives`None`, the old incremental allocation behavior applies.

This enables developers to select a specific endpoint index, enabling implementation and emulation of devices where endpoints are hardcoded (e.g. FTDI USB-to-serial adapters).

I am still testing this on the various platforms that I have on hand, just wanted to get this open for discussion re: modifying these interfaces; there are a few places where this parameter doesn't necessarily need to be exposed (we can default to `None`).