### PR TITLE
RP2350: Correct SRAM8 and SRAM9 base addresses in example memory.x

### DIFF
--- a/examples/rp235x/memory.x
+++ b/examples/rp235x/memory.x
@@ -17,8 +17,8 @@ MEMORY {
      * of access times.
      * Example: Separate stacks for core0 and core1.
      */
-    SRAM4 : ORIGIN = 0x20080000, LENGTH = 4K
-    SRAM5 : ORIGIN = 0x20081000, LENGTH = 4K
+    SRAM8 : ORIGIN = 0x20080000, LENGTH = 4K
+    SRAM9 : ORIGIN = 0x20081000, LENGTH = 4K
 }
 
 SECTIONS {


### PR DESCRIPTION
According to [datasheet](https://datasheets.raspberrypi.com/rp2350/rp2350-datasheet.pdf) (page 31), the base addresses specified as SRAM4 and SRAM5 in the example linker script should actually be SRAM8 and SRAM9.

There are 10 SRAM banks on the chip with the following base addresses:

- 0x20000000: SRAM_BASE
- 0x20000000: SRAM_STRIPED_BASE
- 0x20000000: SRAM0_BASE
- 0x20040000: SRAM4_BASE
- 0x20080000: SRAM_STRIPED_END
- 0x20080000: SRAM8_BASE
- 0x20081000: SRAM9_BASE
- 0x20082000: SRAM_END

If the example linker script is not incorrect, please share the reason as I haven't been able to find out why it's set that way.

