### PR TITLE
Add `derive(Debug)` for `embassy_rp::i2c::I2c`

### DIFF
--- a/embassy-rp/src/i2c.rs
+++ b/embassy-rp/src/i2c.rs
@@ -76,6 +76,7 @@ impl Default for Config {
 pub const FIFO_SIZE: u8 = 16;
 
 /// I2C driver.
+#[derive(Debug)]
 pub struct I2c<'d, T: Instance, M: Mode> {
     phantom: PhantomData<(&'d mut T, M)>,
 }


### PR DESCRIPTION
i've split this in two commits since i'm not sure if you want to take the second one (enabling the warning without adding all the derives - on the other hand, if i'd add them then i'd turn it into a `deny`)