### PR TITLE
Fix stm32 buffered half-duplex uart receive

### DIFF
--- a/embassy-stm32/src/usart/buffered.rs
+++ b/embassy-stm32/src/usart/buffered.rs
@@ -87,6 +87,8 @@ unsafe fn on_interrupt(r: Regs, state: &'static State) {
 
         r.cr1().modify(|w| {
             w.set_tcie(false);
+            // Reenable receiver for half-duplex if it was disabled
+            w.set_re(true);
         });
 
         state.tx_done.store(true, Ordering::Release);

--- a/embassy-stm32/src/usart/mod.rs
+++ b/embassy-stm32/src/usart/mod.rs
@@ -651,7 +651,7 @@ pub fn send_break(regs: &Regs) {
 /// In case of readback, keep Receiver enabled
 fn half_duplex_set_rx_tx_before_write(r: &Regs, enable_readback: bool) {
     let mut cr1 = r.cr1().read();
-    if r.cr3().read().hdsel() && !cr1.te() {
+    if r.cr3().read().hdsel() {
         cr1.set_te(true);
         cr1.set_re(enable_readback);
         r.cr1().write_value(cr1);


### PR DESCRIPTION
This fixes an issue described in #3679 comments where receiver was never reenabled.