### PR TITLE
Removed reference to ADC3 for STM32G4x1 if the peripheral does not exist

### DIFF
--- a/ci.sh
+++ b/ci.sh
@@ -161,6 +161,7 @@ cargo batch \
     --- build --release --manifest-path embassy-stm32/Cargo.toml --target thumbv8m.main-none-eabihf --features stm32l552ze,dual-bank,defmt,exti,time-driver-any,low-power,time \
     --- build --release --manifest-path embassy-stm32/Cargo.toml --target thumbv6m-none-eabi --features stm32wl54jc-cm0p,defmt,exti,time-driver-any,time \
     --- build --release --manifest-path embassy-stm32/Cargo.toml --target thumbv7em-none-eabi --features stm32wle5jb,defmt,exti,time-driver-any,time \
+    --- build --release --manifest-path embassy-stm32/Cargo.toml --target thumbv7em-none-eabi --features stm32g431kb,defmt,exti,time-driver-any,time \
     --- build --release --manifest-path embassy-stm32/Cargo.toml --target thumbv7em-none-eabi --features stm32g474pe,dual-bank,defmt,exti,time-driver-any,time \
     --- build --release --manifest-path embassy-stm32/Cargo.toml --target thumbv7m-none-eabi --features stm32f107vc,defmt,exti,time-driver-any,time \
     --- build --release --manifest-path embassy-stm32/Cargo.toml --target thumbv7m-none-eabi --features stm32f103re,defmt,exti,time-driver-any,time \

--- a/embassy-stm32/src/adc/g4.rs
+++ b/embassy-stm32/src/adc/g4.rs
@@ -545,10 +545,12 @@ mod g4 {
         const CHANNEL: u8 = 17;
     }
 
+    #[cfg(peri_adc3_common)]
     impl VrefChannel for crate::peripherals::ADC3 {
         const CHANNEL: u8 = 18;
     }
 
+    #[cfg(peri_adc3_common)]
     impl VBatChannel for crate::peripherals::ADC3 {
         const CHANNEL: u8 = 17;
     }


### PR DESCRIPTION
Fixes regression introduced in https://github.com/embassy-rs/embassy/pull/4390 for STM32G431 and STM32G441, which do not have an ADC3. Results in the build failing.

STM32G491 and STM32G4A1 do have the instance, so this is the easiest way to gate these `impl`s.