### PR TITLE
STM32F107: Fix inadvertent re-configuration of the SWJ/JTAG pins when activating the (R)MII interface

### DIFF
--- a/embassy-stm32/Cargo.toml
+++ b/embassy-stm32/Cargo.toml
@@ -81,7 +81,7 @@ futures-util = { version = "0.3.30", default-features = false }
 sdio-host = "0.9.0"
 critical-section = "1.1"
 #stm32-metapac = { version = "16" }
-stm32-metapac = { git = "https://github.com/embassy-rs/stm32-data-generated", tag = "stm32-data-85e2c0f43f3460b3305a2f97962bd39deed09d13" }
+stm32-metapac = { git = "https://github.com/embassy-rs/stm32-data-generated", tag = "stm32-data-f761780b74faf840220b367b15d556b9e10c2334" }
 
 vcell = "0.1.3"
 nb = "1.0.0"
@@ -110,7 +110,7 @@ proc-macro2 = "1.0.36"
 quote = "1.0.15"
 
 #stm32-metapac = { version = "16", default-features = false, features = ["metadata"]}
-stm32-metapac = { git = "https://github.com/embassy-rs/stm32-data-generated", tag = "stm32-data-85e2c0f43f3460b3305a2f97962bd39deed09d13", default-features = false, features = ["metadata"] }
+stm32-metapac = { git = "https://github.com/embassy-rs/stm32-data-generated", tag = "stm32-data-f761780b74faf840220b367b15d556b9e10c2334", default-features = false, features = ["metadata"] }
 
 [features]
 default = ["rt"]

--- a/embassy-stm32/src/eth/v1/mod.rs
+++ b/embassy-stm32/src/eth/v1/mod.rs
@@ -122,7 +122,10 @@ impl<'d, T: Instance, P: Phy> Ethernet<'d, T, P> {
 
             // Select RMII (Reduced Media Independent Interface)
             // Must be done prior to enabling peripheral clock
-            AFIO.mapr().modify(|w| w.set_mii_rmii_sel(true));
+            AFIO.mapr().modify(|w| {
+                w.set_mii_rmii_sel(true);
+                w.set_swj_cfg(crate::pac::afio::vals::SwjCfg::NO_OP);
+            });
 
             RCC.ahbenr().modify(|w| {
                 w.set_ethen(true);
@@ -316,7 +319,10 @@ impl<'d, T: Instance, P: Phy> Ethernet<'d, T, P> {
 
             // Select MII (Media Independent Interface)
             // Must be done prior to enabling peripheral clock
-            AFIO.mapr().modify(|w| w.set_mii_rmii_sel(false));
+            AFIO.mapr().modify(|w| {
+                w.set_mii_rmii_sel(false);
+                w.set_swj_cfg(crate::pac::afio::vals::SwjCfg::NO_OP);
+            });
 
             RCC.ahbenr().modify(|w| {
                 w.set_ethen(true);


### PR DESCRIPTION
AFIO_MAPR.SWJ_CFG must be written as 0b111 to leave its value unchanged.