### PR TITLE
embassy-sync fix for std

### DIFF
--- a/embassy-sync/Cargo.toml
+++ b/embassy-sync/Cargo.toml
@@ -20,7 +20,7 @@ src_base_git = "https://github.com/embassy-rs/embassy/blob/$COMMIT/embassy-sync/
 target = "thumbv7em-none-eabi"
 
 [features]
-std = []
+std = ["critical-section/std"]
 turbowakers = []
 
 [dependencies]


### PR DESCRIPTION
Enable the critical-section std feature when the embassy-sync std feature is selected. 

Without this fix, embassy-sync will not compile on std, due to missing (critical-section) symbols.