### PR TITLE
stm32wb: Add rfwkpsel to ClockMux

### DIFF
--- a/embassy-stm32/Cargo.toml
+++ b/embassy-stm32/Cargo.toml
@@ -81,7 +81,7 @@ futures-util = { version = "0.3.30", default-features = false }
 sdio-host = "0.9.0"
 critical-section = "1.1"
 #stm32-metapac = { version = "16" }
-stm32-metapac = { git = "https://github.com/embassy-rs/stm32-data-generated", tag = "stm32-data-6e47f105286c0de07f641e22f27db060f1395e86" }
+stm32-metapac = { git = "https://github.com/embassy-rs/stm32-data-generated", tag = "stm32-data-dded8a33a460ae0eb182aee3ccb048beb659982b" }
 
 vcell = "0.1.3"
 nb = "1.0.0"
@@ -110,7 +110,7 @@ proc-macro2 = "1.0.36"
 quote = "1.0.15"
 
 #stm32-metapac = { version = "16", default-features = false, features = ["metadata"]}
-stm32-metapac = { git = "https://github.com/embassy-rs/stm32-data-generated", tag = "stm32-data-6e47f105286c0de07f641e22f27db060f1395e86", default-features = false, features = ["metadata"] }
+stm32-metapac = { git = "https://github.com/embassy-rs/stm32-data-generated", tag = "stm32-data-dded8a33a460ae0eb182aee3ccb048beb659982b", default-features = false, features = ["metadata"] }
 
 [features]
 default = ["rt"]

--- a/embassy-stm32/build.rs
+++ b/embassy-stm32/build.rs
@@ -505,6 +505,13 @@ fn main() {
                 field: "CLK48SEL",
             },
         );
+        clock_gen.chained_muxes.insert(
+            "RFWKP",
+            &PeripheralRccRegister {
+                register: "CSR",
+                field: "RFWKPSEL",
+            },
+        );
     }
     if chip_name.starts_with("stm32f7") {
         clock_gen.chained_muxes.insert(

--- a/embassy-stm32/src/ipcc.rs
+++ b/embassy-stm32/src/ipcc.rs
@@ -104,9 +104,6 @@ impl Ipcc {
         rcc::enable_and_reset::<IPCC>();
         IPCC::set_cpu2(true);
 
-        // set RF wake-up clock = LSE
-        crate::pac::RCC.csr().modify(|w| w.set_rfwkpsel(0b01));
-
         let regs = IPCC::regs();
 
         regs.cpu(0).cr().modify(|w| {


### PR DESCRIPTION
Fixes https://github.com/embassy-rs/embassy/issues/4421 by exposing rfwkpsel in `ClockMux`

~~Depends on https://github.com/embassy-rs/stm32-data/pull/643~~ Merged
~~Depends on https://github.com/embassy-rs/stm32-data/pull/648~~ Merged