### PR TITLE
stm32: Use `unsafe` block in IRQ handler

### DIFF
--- a/embassy-stm32/src/lib.rs
+++ b/embassy-stm32/src/lib.rs
@@ -196,11 +196,13 @@ macro_rules! bind_interrupts {
             $(#[cfg($cond_irq)])?
             $(#[doc = $doc])*
             unsafe extern "C" fn $irq() {
-                $(
-                    $(#[cfg($cond_handler)])?
-                    <$handler as $crate::interrupt::typelevel::Handler<$crate::interrupt::typelevel::$irq>>::on_interrupt();
+                unsafe {
+                    $(
+                        $(#[cfg($cond_handler)])?
+                        <$handler as $crate::interrupt::typelevel::Handler<$crate::interrupt::typelevel::$irq>>::on_interrupt();
 
-                )*
+                    )*
+                }
             }
 
             $(#[cfg($cond_irq)])?


### PR DESCRIPTION
When developing against `embassy-stm32` locally with a cargo path dependency, this produces a slightly annoying `unsafe_op_in_unsafe_fn` warning - add an unsafe block to resolve this.