### PR TITLE
Add STM32F1 AFIO remap

### DIFF
--- a/embassy-stm32/CHANGELOG.md
+++ b/embassy-stm32/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Modify BufferedUart initialization to take pins before interrupts ([#3983](https://github.com/embassy-rs/embassy/pull/3983))
 - Added a 'single-bank' and a 'dual-bank' feature so chips with configurable flash bank setups are be supported in embassy ([#4125](https://github.com/embassy-rs/embassy/pull/4125))
 - Add automatic setting of remap bits when using alternate DMA channels on STM32F0 and STM32F3 devices ([#3653](https://github.com/embassy-rs/embassy/pull/3653))
+- Add support for STM32F1 GPIO remapping (AFIO) ([#4430](https://github.com/embassy-rs/embassy/pull/4430))
 
 ## 0.2.0 - 2025-01-10
 

--- a/embassy-stm32/build.rs
+++ b/embassy-stm32/build.rs
@@ -1330,7 +1330,7 @@ fn main() {
                         if METADATA.peripherals.iter().any(|p| p.name == "OCTOSPI2") {
                             peri = format_ident!("{}", "OCTOSPI2");
                             g.extend(quote! {
-                                pin_trait_impl!(#tr, #peri, #pin_name, #af);
+                                pin_trait_impl!(#tr, #peri, #pin_name, #af, {});
                             });
                         }
                         peri = format_ident!("{}", "OCTOSPI1");
@@ -1359,8 +1359,19 @@ fn main() {
                         })
                     }
 
+                    // Add AFIO remap for STM32F1
+                    // AFIO_MAPR.SWJ_CFG needs to be set to NO_OP to leave it unchanged
+                    let swj_cfg = pin
+                        .afio
+                        .as_ref()
+                        .filter(|afio| afio.register == "MAPR")
+                        .map(|_| quote!(w.set_swj_cfg(crate::pac::afio::vals::SwjCfg::NO_OP);))
+                        .unwrap_or_else(|| quote!());
+
+                    let remap = generate_remap(pin.afio.as_ref().into_iter(), "AFIO", swj_cfg);
+
                     g.extend(quote! {
-                        pin_trait_impl!(#tr, #peri, #pin_name, #af);
+                        pin_trait_impl!(#tr, #peri, #pin_name, #af, {#remap});
                     })
                 }
 
@@ -1551,31 +1562,8 @@ fn main() {
                             quote!(())
                         };
 
-                        let mut remap = quote!();
-                        for remap_info in ch.remap {
-                            let register = format_ident!("{}", remap_info.register.to_lowercase());
-                            let setter = format_ident!("set_{}", remap_info.field.to_lowercase());
-
-                            let field_metadata = METADATA
-                                .peripherals
-                                .iter()
-                                .filter(|p| p.name == "SYSCFG")
-                                .flat_map(|p| p.registers.as_ref().unwrap().ir.fieldsets.iter())
-                                .filter(|f| f.name.eq_ignore_ascii_case(remap_info.register))
-                                .flat_map(|f| f.fields.iter())
-                                .find(|f| f.name.eq_ignore_ascii_case(remap_info.field))
-                                .unwrap();
-
-                            let value = if field_metadata.bit_size == 1 {
-                                let bool_value = format_ident!("{}", remap_info.value > 0);
-                                quote!(#bool_value)
-                            } else {
-                                let value = remap_info.value;
-                                quote!(#value.into())
-                            };
-
-                            remap.extend(quote!(crate::pac::SYSCFG.#register().modify(|w| w.#setter(#value));));
-                        }
+                        // Add remap for some STM32F0 and STM32F3
+                        let remap = generate_remap(ch.remap.iter(), "SYSCFG", quote!());
 
                         let channel = format_ident!("{}", channel);
                         g.extend(quote! {
@@ -2267,4 +2255,44 @@ fn gcd(a: u32, b: u32) -> u32 {
         return a;
     }
     gcd(b, a % b)
+}
+
+fn generate_remap(
+    remap_info: impl Iterator<Item = &'static stm32_metapac::metadata::RemapInfo>,
+    peripheral_name: &str,
+    additional_op: TokenStream,
+) -> TokenStream {
+    let peripheral = format_ident!("{}", peripheral_name);
+    let mut remap_tokens = quote!();
+    for remap in remap_info {
+        let register = format_ident!("{}", remap.register.to_lowercase());
+        let setter = format_ident!("set_{}", remap.field.to_lowercase());
+
+        let field_metadata = METADATA
+            .peripherals
+            .iter()
+            .filter(|p| p.name == peripheral_name)
+            .flat_map(|p| p.registers.as_ref().unwrap().ir.fieldsets.iter())
+            .filter(|f| f.name.eq_ignore_ascii_case(remap.register))
+            .flat_map(|f| f.fields.iter())
+            .find(|f| f.name.eq_ignore_ascii_case(remap.field))
+            .unwrap();
+
+        let value = if field_metadata.bit_size == 1 {
+            let bool_value = format_ident!("{}", remap.value > 0);
+            quote!(#bool_value)
+        } else {
+            let number_value = remap.value;
+            quote!(#number_value.into())
+        };
+
+        remap_tokens.extend(quote! {
+            crate::pac::#peripheral.#register().modify(|w| {
+                w.#setter(#value);
+                #additional_op
+            });
+        });
+    }
+
+    remap_tokens
 }

--- a/embassy-stm32/src/can/bxcan/mod.rs
+++ b/embassy-stm32/src/can/bxcan/mod.rs
@@ -195,6 +195,7 @@ impl<'d> Can<'d> {
         let regs = &T::info().regs;
 
         rx.set_as_af(rx.af_num(), AfType::input(Pull::None));
+        rx.afio_remap();
         tx.set_as_af(tx.af_num(), AfType::output(OutputType::PushPull, Speed::VeryHigh));
 
         rcc::enable_and_reset::<T>();

--- a/embassy-stm32/src/eth/v1/mod.rs
+++ b/embassy-stm32/src/eth/v1/mod.rs
@@ -150,6 +150,7 @@ impl<'d, T: Instance, P: Phy> Ethernet<'d, T, P> {
         {
             config_in_pins!(ref_clk, rx_d0, rx_d1);
             config_af_pins!(mdio, mdc, tx_d0, tx_d1, tx_en);
+            rx_d0.afio_remap();
         }
 
         #[cfg(any(eth_v1b, eth_v1c))]
@@ -347,6 +348,7 @@ impl<'d, T: Instance, P: Phy> Ethernet<'d, T, P> {
         {
             config_in_pins!(rx_clk, tx_clk, rx_d0, rx_d1, rx_d2, rx_d3, rxdv);
             config_af_pins!(mdio, mdc, tx_d0, tx_d1, tx_d2, tx_d3, tx_en);
+            rx_d0.afio_remap();
         }
 
         #[cfg(any(eth_v1b, eth_v1c))]

--- a/embassy-stm32/src/macros.rs
+++ b/embassy-stm32/src/macros.rs
@@ -46,15 +46,22 @@ macro_rules! pin_trait {
         pub trait $signal<T: $instance $(, M: $mode)?>: crate::gpio::Pin {
             #[doc = concat!("Get the AF number needed to use this pin as ", stringify!($signal))]
             fn af_num(&self) -> u8;
+
+            #[doc = concat!("Configures AFIO_MAPR/AFIO_MAPR2 on STM32F1 to use this pin as ", stringify!($signal))]
+            fn afio_remap(&self);
         }
     };
 }
 
 macro_rules! pin_trait_impl {
-    (crate::$mod:ident::$trait:ident$(<$mode:ident>)?, $instance:ident, $pin:ident, $af:expr) => {
+    (crate::$mod:ident::$trait:ident$(<$mode:ident>)?, $instance:ident, $pin:ident, $af:expr, $remap:expr) => {
         impl crate::$mod::$trait<crate::peripherals::$instance $(, crate::$mod::$mode)?> for crate::peripherals::$pin {
             fn af_num(&self) -> u8 {
                 $af
+            }
+
+            fn afio_remap(&self) {
+                $remap;
             }
         }
     };
@@ -134,6 +141,7 @@ macro_rules! new_dma {
 macro_rules! new_pin {
     ($name:ident, $af_type:expr) => {{
         let pin = $name;
+        pin.afio_remap();
         pin.set_as_af(pin.af_num(), $af_type);
         Some(pin.into())
     }};

--- a/embassy-stm32/src/timer/input_capture.rs
+++ b/embassy-stm32/src/timer/input_capture.rs
@@ -25,6 +25,7 @@ impl<'d, T: GeneralInstance4Channel, C: TimerChannel> CapturePin<'d, T, C> {
     /// Create a new capture pin instance.
     pub fn new(pin: Peri<'d, impl TimerPin<T, C>>, pull: Pull) -> Self {
         pin.set_as_af(pin.af_num(), AfType::input(pull));
+        pin.afio_remap();
         CapturePin {
             _pin: pin.into(),
             phantom: PhantomData,

--- a/embassy-stm32/src/timer/one_pulse.rs
+++ b/embassy-stm32/src/timer/one_pulse.rs
@@ -70,6 +70,9 @@ trait SealedTimerTriggerPin<T, S>: crate::gpio::Pin {}
 pub trait TimerTriggerPin<T, S>: SealedTimerTriggerPin<T, S> {
     /// Get the AF number needed to use this pin as a trigger source.
     fn af_num(&self) -> u8;
+
+    /// Configures AFIO_MAPR/AFIO_MAPR2 on STM32F1 to use this pin as a trigger source.
+    fn afio_remap(&self);
 }
 
 impl<T, P, C> TimerTriggerPin<T, C> for P
@@ -81,6 +84,10 @@ where
     fn af_num(&self) -> u8 {
         TimerPin::af_num(self)
     }
+
+    fn afio_remap(&self) {
+        TimerPin::afio_remap(self);
+    }
 }
 
 impl<T, P> TimerTriggerPin<T, Ext> for P
@@ -90,6 +97,10 @@ where
 {
     fn af_num(&self) -> u8 {
         ExternalTriggerPin::af_num(self)
+    }
+
+    fn afio_remap(&self) {
+        ExternalTriggerPin::afio_remap(self);
     }
 }
 
@@ -112,6 +123,7 @@ impl<'d, T: GeneralInstance4Channel, C: TriggerSource> TriggerPin<'d, T, C> {
     /// "Create a new Ch1 trigger pin instance.
     pub fn new(pin: Peri<'d, impl TimerTriggerPin<T, C>>, pull: Pull) -> Self {
         pin.set_as_af(pin.af_num(), AfType::input(pull));
+        pin.afio_remap();
         TriggerPin {
             _pin: pin.into(),
             phantom: PhantomData,

--- a/embassy-stm32/src/timer/pwm_input.rs
+++ b/embassy-stm32/src/timer/pwm_input.rs
@@ -20,6 +20,7 @@ impl<'d, T: GeneralInstance4Channel> PwmInput<'d, T> {
     /// Create a new PWM input driver.
     pub fn new_ch1(tim: Peri<'d, T>, pin: Peri<'d, impl TimerPin<T, Ch1>>, pull: Pull, freq: Hertz) -> Self {
         pin.set_as_af(pin.af_num(), AfType::input(pull));
+        pin.afio_remap();
 
         Self::new_inner(tim, freq, Channel::Ch1, Channel::Ch2)
     }
@@ -27,6 +28,7 @@ impl<'d, T: GeneralInstance4Channel> PwmInput<'d, T> {
     /// Create a new PWM input driver.
     pub fn new_ch2(tim: Peri<'d, T>, pin: Peri<'d, impl TimerPin<T, Ch2>>, pull: Pull, freq: Hertz) -> Self {
         pin.set_as_af(pin.af_num(), AfType::input(pull));
+        pin.afio_remap();
 
         Self::new_inner(tim, freq, Channel::Ch2, Channel::Ch1)
     }

--- a/embassy-stm32/src/timer/qei.rs
+++ b/embassy-stm32/src/timer/qei.rs
@@ -26,11 +26,12 @@ pub struct QeiPin<'d, T, Channel> {
 }
 
 impl<'d, T: GeneralInstance4Channel, C: QeiChannel> QeiPin<'d, T, C> {
-    /// Create a new  QEI pin instance.
+    /// Create a new QEI pin instance.
     pub fn new(pin: Peri<'d, impl TimerPin<T, C>>) -> Self {
         critical_section::with(|_| {
             pin.set_low();
             pin.set_as_af(pin.af_num(), AfType::input(Pull::None));
+            pin.afio_remap();
         });
         QeiPin {
             _pin: pin.into(),

--- a/embassy-stm32/src/timer/simple_pwm.rs
+++ b/embassy-stm32/src/timer/simple_pwm.rs
@@ -40,6 +40,7 @@ impl<'d, T: GeneralInstance4Channel, C: TimerChannel> PwmPin<'d, T, C> {
         critical_section::with(|_| {
             pin.set_low();
             pin.set_as_af(pin.af_num(), AfType::output(output_type, Speed::VeryHigh));
+            pin.afio_remap();
         });
         PwmPin {
             _pin: pin.into(),
@@ -58,6 +59,7 @@ impl<'d, T: GeneralInstance4Channel, C: TimerChannel> PwmPin<'d, T, C> {
                 #[cfg(gpio_v2)]
                 AfType::output_pull(pin_config.output_type, pin_config.speed, pin_config.pull),
             );
+            pin.afio_remap();
         });
         PwmPin {
             _pin: pin.into(),


### PR DESCRIPTION
This sets the AFIO_MAPR/AFIO_MAPR2 registers on STM32F1 automatically when configuring a peripheral, which supports remapping.

The AFIO clock is already enabled on all AFIO devices here: https://github.com/embassy-rs/embassy/blob/2cae242f51cd1553ca9deb1cfd73daed606c5476/embassy-stm32/src/gpio.rs#L868