### PR TITLE
[embassy-time] Enable arch-std when std is selected

### DIFF
--- a/embassy-time-queue-utils/Cargo.toml
+++ b/embassy-time-queue-utils/Cargo.toml
@@ -52,6 +52,8 @@ generic-queue-128 = ["_generic-queue"]
 
 _generic-queue = []
 
+std = ["embassy-executor/arch-std"]
+
 [package.metadata.embassy_docs]
 src_base = "https://github.com/embassy-rs/embassy/blob/embassy-time-queue-utils-v$VERSION/embassy-time-queue-utils/src/"
 src_base_git = "https://github.com/embassy-rs/embassy/blob/$COMMIT/embassy-time-queue-utils/src/"

--- a/embassy-time/Cargo.toml
+++ b/embassy-time/Cargo.toml
@@ -45,7 +45,7 @@ defmt-timestamp-uptime-tus = ["defmt"]
 ## Create a `MockDriver` that can be manually advanced for testing purposes.
 mock-driver = ["tick-hz-1_000_000", "dep:embassy-time-queue-utils"]
 ## Create a time driver for `std` environments.
-std = ["tick-hz-1_000_000", "dep:embassy-time-queue-utils"]
+std = ["tick-hz-1_000_000", "dep:embassy-time-queue-utils", "embassy-time-queue-utils/std"]
 ## Create a time driver for WASM.
 wasm = ["dep:wasm-bindgen", "dep:js-sys", "dep:wasm-timer", "tick-hz-1_000_000", "dep:embassy-time-queue-utils"]
 


### PR DESCRIPTION
We've got a library that uses embassy-time. To run the tests, we enable the std feature of it.

On linux this works fine, but on windows this causes a linker error:
```
libembassy_executor-e28bd8c8eaa8888b.rlib(embassy_executor-e28bd8c8eaa8888b.embassy_executor.52b44d93bbaf442c-cgu.0.rcgu.o) : error LNK2019: unresolved external symbol __pender referenced in function _ZN16embassy_executor3raw6Pender4pend17h826e692e54cdf92eE
```

I've found that windows is little more strict about linking things. The pender is also missing on linux, but for some reason the linker doesn't mind there.

This PR activates the arch-std feature on the imported embassy-executor. This solves the issue.

A reason not to merge this is if we expect there are people who use embassy-time with the std feature activated, but then wants a non-std executor arch. I wouldn't know who would do that...