### PR TITLE
Add workaround for unreliable WFE/wakeup behavior for STM32 low_power modes

### DIFF
--- a/embassy-stm32/src/low_power.rs
+++ b/embassy-stm32/src/low_power.rs
@@ -263,6 +263,20 @@ impl Executor {
                 executor.inner.poll();
                 self.configure_pwr();
                 asm!("wfe");
+
+                // TODO Workaround to fix broken WFE/wakeup behavior: It has been observed that
+                // sometimes, WFE does not seem to enter the configured STOP mode properly.
+                // Instead, execution goes on immediately. In one test, this has been observed
+                // every other attempt. In these cases, the interrupt handler which forwards to
+                // `on_wakeup_irq` is not called, and the `time_driver.resume_time()` call is
+                // skipped. If the following `configure_pwr` call does not configure STOP mode,
+                // this may cause the following `WFE` to hang forever. It should be possible to
+                // observe how the interrupt handler is skipped by adding another `trace!` call
+                // below and inspect the logs.
+                // As a workaround, we call `on_wakeup_irq` manually here. If the interrupt
+                // handler has been called before and the `time_driver` is already running, this
+                // does nothing.
+                self.on_wakeup_irq();
             };
         }
     }


### PR DESCRIPTION
In https://github.com/embassy-rs/embassy/pull/3213, I had already experienced wakeup issues with the RTC-based low-power feature. Since we were running into that issue again, I have done some debugging. With a few more `trace!` calls in the corresponding code sections, I could observe that the `on_wakeup_irq` handler is not called for a considerable amount of `WFE` calls. The timings suggest that many of the `WFE` calls do not trigger the configured STOP mode at all. Instead, program execution seems to go on immediately. I have left a pretty long comment about that in the code.

In this PR, I can only offer a workaround which fixes the issue but I do not understand the root cause of the problem, why the `WFE` calls do not trigger the STOP mode in the first place. But from my perspective, this workaround fixes a large issue with a tiny overhead, so I would definitely like to see this merged.