### PR TITLE
fix: stm32 i2c slave blocking r/w

### DIFF
--- a/embassy-stm32/Cargo.toml
+++ b/embassy-stm32/Cargo.toml
@@ -129,6 +129,7 @@ defmt = [
     "embassy-net-driver/defmt",
     "embassy-time?/defmt",
     "embassy-usb-synopsys-otg/defmt",
+    "stm32-metapac/defmt"
 ]
 
 exti = []


### PR DESCRIPTION
originally from #4316

- removed defmt:: and explicit defmt cfg checks
- rebased

closes #4316

This fixes an issue where the slave interface would time out when the
master goes from a short write to a read (e.g. when accessing memory
registers) with a START signal between. The previous implementation
would expect the full buffer length to be written before starting to
listen to new commands.

This also adds debug trace printing which helped during implemention and
testing.

Places error checking into a function inspired from a C implementation
of HAL.
