### PR TITLE
Feat/add safeboot

### DIFF
--- a/embassy-boot-nrf/src/lib.rs
+++ b/embassy-boot-nrf/src/lib.rs
@@ -16,10 +16,10 @@ pub struct BootLoader<const BUFFER_SIZE: usize = PAGE_SIZE>;
 
 impl<const BUFFER_SIZE: usize> BootLoader<BUFFER_SIZE> {
     /// Inspect the bootloader state and perform actions required before booting, such as swapping firmware
-    pub fn prepare<ACTIVE: NorFlash, DFU: NorFlash, STATE: NorFlash>(
-        config: BootLoaderConfig<ACTIVE, DFU, STATE>,
+    pub fn prepare<ACTIVE: NorFlash, DFU: NorFlash, STATE: NorFlash, SAFE: NorFlash>(
+        config: BootLoaderConfig<ACTIVE, DFU, STATE, SAFE>,
     ) -> Self {
-        if let Ok(loader) = Self::try_prepare::<ACTIVE, DFU, STATE>(config) {
+        if let Ok(loader) = Self::try_prepare::<ACTIVE, DFU, STATE, SAFE>(config) {
             loader
         } else {
             // Use explicit panic instead of .expect() to ensure this gets routed via defmt/etc.
@@ -29,8 +29,8 @@ impl<const BUFFER_SIZE: usize> BootLoader<BUFFER_SIZE> {
     }
 
     /// Inspect the bootloader state and perform actions required before booting, such as swapping firmware
-    pub fn try_prepare<ACTIVE: NorFlash, DFU: NorFlash, STATE: NorFlash>(
-        config: BootLoaderConfig<ACTIVE, DFU, STATE>,
+    pub fn try_prepare<ACTIVE: NorFlash, DFU: NorFlash, STATE: NorFlash, SAFE: NorFlash>(
+        config: BootLoaderConfig<ACTIVE, DFU, STATE, SAFE>,
     ) -> Result<Self, BootError> {
         let mut aligned_buf = AlignedBuffer([0; BUFFER_SIZE]);
         let mut boot = embassy_boot::BootLoader::new(config);

--- a/embassy-boot-rp/src/lib.rs
+++ b/embassy-boot-rp/src/lib.rs
@@ -22,10 +22,10 @@ pub struct BootLoader<const BUFFER_SIZE: usize = ERASE_SIZE> {
 
 impl<const BUFFER_SIZE: usize> BootLoader<BUFFER_SIZE> {
     /// Inspect the bootloader state and perform actions required before booting, such as swapping firmware
-    pub fn prepare<ACTIVE: NorFlash, DFU: NorFlash, STATE: NorFlash>(
-        config: BootLoaderConfig<ACTIVE, DFU, STATE>,
+    pub fn prepare<ACTIVE: NorFlash, DFU: NorFlash, STATE: NorFlash, SAFE: NorFlash>(
+        config: BootLoaderConfig<ACTIVE, DFU, STATE, SAFE>,
     ) -> Self {
-        if let Ok(loader) = Self::try_prepare::<ACTIVE, DFU, STATE>(config) {
+        if let Ok(loader) = Self::try_prepare::<ACTIVE, DFU, STATE, SAFE>(config) {
             loader
         } else {
             // Use explicit panic instead of .expect() to ensure this gets routed via defmt/etc.
@@ -35,8 +35,8 @@ impl<const BUFFER_SIZE: usize> BootLoader<BUFFER_SIZE> {
     }
 
     /// Inspect the bootloader state and perform actions required before booting, such as swapping firmware
-    pub fn try_prepare<ACTIVE: NorFlash, DFU: NorFlash, STATE: NorFlash>(
-        config: BootLoaderConfig<ACTIVE, DFU, STATE>,
+    pub fn try_prepare<ACTIVE: NorFlash, DFU: NorFlash, STATE: NorFlash, SAFE: NorFlash>(
+        config: BootLoaderConfig<ACTIVE, DFU, STATE, SAFE>,
     ) -> Result<Self, BootError> {
         let mut aligned_buf = AlignedBuffer([0; BUFFER_SIZE]);
         let mut boot = embassy_boot::BootLoader::new(config);

--- a/embassy-boot-stm32/src/lib.rs
+++ b/embassy-boot-stm32/src/lib.rs
@@ -17,10 +17,10 @@ pub struct BootLoader {
 
 impl BootLoader {
     /// Inspect the bootloader state and perform actions required before booting, such as swapping firmware
-    pub fn prepare<ACTIVE: NorFlash, DFU: NorFlash, STATE: NorFlash, const BUFFER_SIZE: usize>(
-        config: BootLoaderConfig<ACTIVE, DFU, STATE>,
+    pub fn prepare<ACTIVE: NorFlash, DFU: NorFlash, STATE: NorFlash, SAFE: NorFlash, const BUFFER_SIZE: usize>(
+        config: BootLoaderConfig<ACTIVE, DFU, STATE, SAFE>,
     ) -> Self {
-        if let Ok(loader) = Self::try_prepare::<ACTIVE, DFU, STATE, BUFFER_SIZE>(config) {
+        if let Ok(loader) = Self::try_prepare::<ACTIVE, DFU, STATE, SAFE, BUFFER_SIZE>(config) {
             loader
         } else {
             // Use explicit panic instead of .expect() to ensure this gets routed via defmt/etc.
@@ -30,8 +30,8 @@ impl BootLoader {
     }
 
     /// Inspect the bootloader state and perform actions required before booting, such as swapping firmware
-    pub fn try_prepare<ACTIVE: NorFlash, DFU: NorFlash, STATE: NorFlash, const BUFFER_SIZE: usize>(
-        config: BootLoaderConfig<ACTIVE, DFU, STATE>,
+    pub fn try_prepare<ACTIVE: NorFlash, DFU: NorFlash, STATE: NorFlash, SAFE: NorFlash, const BUFFER_SIZE: usize>(
+        config: BootLoaderConfig<ACTIVE, DFU, STATE, SAFE>,
     ) -> Result<Self, BootError> {
         let mut aligned_buf = AlignedBuffer([0; BUFFER_SIZE]);
         let mut boot = embassy_boot::BootLoader::new(config);

--- a/embassy-boot/Cargo.toml
+++ b/embassy-boot/Cargo.toml
@@ -51,3 +51,5 @@ flash-erase-zero = []
 
 #Internal features
 _verify = []
+safe = []
+restore = []

--- a/embassy-boot/src/boot_loader.rs
+++ b/embassy-boot/src/boot_loader.rs
@@ -649,6 +649,7 @@ mod tests {
 
     #[test]
     #[should_panic]
+    #[cfg(not(feature = "safe"))]
     fn test_range_asserts() {
         const ACTIVE_SIZE: usize = 4194304 - 4096;
         const DFU_SIZE: usize = 4194304;
@@ -657,5 +658,20 @@ mod tests {
         static DFU: MemFlash<DFU_SIZE, 4, 4> = MemFlash::new(0xFF);
         static STATE: MemFlash<STATE_SIZE, 4, 4> = MemFlash::new(0xFF);
         assert_partitions(&ACTIVE, &DFU, &STATE, 4096);
+    }
+
+    #[test]
+    #[should_panic]
+    #[cfg(feature = "safe")]
+    fn test_range_asserts() {
+        const ACTIVE_SIZE: usize = 4194304 - 4096;
+        const DFU_SIZE: usize = 4194304;
+        const STATE_SIZE: usize = 4096;
+        const SAFE_SIZE: usize = ACTIVE_SIZE;
+        static ACTIVE: MemFlash<ACTIVE_SIZE, 4, 4> = MemFlash::new(0xFF);
+        static DFU: MemFlash<DFU_SIZE, 4, 4> = MemFlash::new(0xFF);
+        static STATE: MemFlash<STATE_SIZE, 4, 4> = MemFlash::new(0xFF);
+        static SAFE: MemFlash<SAFE_SIZE, 4, 4> = MemFlash::new(0xFF);
+        assert_partitions(&ACTIVE, &DFU, &STATE, &SAFE, 4096);
     }
 }

--- a/embassy-boot/src/boot_loader.rs
+++ b/embassy-boot/src/boot_loader.rs
@@ -555,7 +555,7 @@ impl<ACTIVE: NorFlash, DFU: NorFlash, STATE: NorFlash, SAFE: NorFlash> BootLoade
             /* Erase dfu page */
             self.dfu.erase(offset, offset + Self::PAGE_SIZE)?;
 
-            /* Copy safe page to active page */
+            /* Copy active page to dfu page */
             for offset_in_page in (0..Self::PAGE_SIZE).step_by(aligned_buf.len()) {
                 self.active.read(offset + offset_in_page as u32, aligned_buf)?;
                 self.dfu.write(offset + offset_in_page as u32, aligned_buf)?;
@@ -578,7 +578,7 @@ impl<ACTIVE: NorFlash, DFU: NorFlash, STATE: NorFlash, SAFE: NorFlash> BootLoade
             /* Erase active page */
             self.active.erase(offset, offset + Self::PAGE_SIZE)?;
 
-            /* Copy active page to dfu page */
+            /* Copy dfu page to active page */
             for offset_in_page in (0..Self::PAGE_SIZE).step_by(aligned_buf.len()) {
                 self.dfu.read(offset + offset_in_page as u32, aligned_buf)?;
                 self.active.write(offset + offset_in_page as u32, aligned_buf)?;

--- a/embassy-boot/src/lib.rs
+++ b/embassy-boot/src/lib.rs
@@ -87,7 +87,7 @@ where
         if magic.iter().all(|&b| b == RESTORE_MAGIC) {
             return State::Restore;
         }
-        return State::Boot:
+        return State::Boot;
     }
 }
 

--- a/embassy-boot/src/test_flash/asynch.rs
+++ b/embassy-boot/src/test_flash/asynch.rs
@@ -5,28 +5,32 @@ use embedded_storage_async::nor_flash::NorFlash;
 
 use crate::BootLoaderConfig;
 
-pub struct AsyncTestFlash<ACTIVE, DFU, STATE>
+pub struct AsyncTestFlash<ACTIVE, DFU, STATE, SAFE>
 where
     ACTIVE: NorFlash,
     DFU: NorFlash,
     STATE: NorFlash,
+    SAFE: NorFlash,
 {
     active: Mutex<NoopRawMutex, ACTIVE>,
     dfu: Mutex<NoopRawMutex, DFU>,
     state: Mutex<NoopRawMutex, STATE>,
+    safe: Mutex<NoopRawMutex, SAFE>,
 }
 
-impl<ACTIVE, DFU, STATE> AsyncTestFlash<ACTIVE, DFU, STATE>
+impl<ACTIVE, DFU, STATE, SAFE> AsyncTestFlash<ACTIVE, DFU, STATE, SAFE>
 where
     ACTIVE: NorFlash,
     DFU: NorFlash,
     STATE: NorFlash,
+    SAFE: NorFlash,
 {
-    pub fn new(config: BootLoaderConfig<ACTIVE, DFU, STATE>) -> Self {
+    pub fn new(config: BootLoaderConfig<ACTIVE, DFU, STATE, SAFE>) -> Self {
         Self {
             active: Mutex::new(config.active),
             dfu: Mutex::new(config.dfu),
             state: Mutex::new(config.state),
+            safe: Mutex::new(config.safe),
         }
     }
 
@@ -42,22 +46,28 @@ where
         Self::create_partition(&self.state)
     }
 
+    pub fn safe(&self) -> Partition<NoopRawMutex, SAFE> {
+        Self::create_partition(&self.safe)
+    }
+
     fn create_partition<T: NorFlash>(mutex: &Mutex<NoopRawMutex, T>) -> Partition<NoopRawMutex, T> {
         Partition::new(mutex, 0, unwrap!(mutex.try_lock()).capacity() as u32)
     }
 }
 
-impl<ACTIVE, DFU, STATE> AsyncTestFlash<ACTIVE, DFU, STATE>
+impl<ACTIVE, DFU, STATE, SAFE> AsyncTestFlash<ACTIVE, DFU, STATE, SAFE>
 where
     ACTIVE: NorFlash + embedded_storage::nor_flash::NorFlash,
     DFU: NorFlash + embedded_storage::nor_flash::NorFlash,
     STATE: NorFlash + embedded_storage::nor_flash::NorFlash,
+    SAFE: NorFlash + embedded_storage::nor_flash::NorFlash,
 {
-    pub fn into_blocking(self) -> super::BlockingTestFlash<ACTIVE, DFU, STATE> {
+    pub fn into_blocking(self) -> super::BlockingTestFlash<ACTIVE, DFU, STATE, SAFE> {
         let config = BootLoaderConfig {
             active: self.active.into_inner(),
             dfu: self.dfu.into_inner(),
             state: self.state.into_inner(),
+            safe: self.safe.into_inner(),
         };
         super::BlockingTestFlash::new(config)
     }

--- a/embassy-boot/src/test_flash/blocking.rs
+++ b/embassy-boot/src/test_flash/blocking.rs
@@ -7,28 +7,32 @@ use embedded_storage::nor_flash::NorFlash;
 
 use crate::BootLoaderConfig;
 
-pub struct BlockingTestFlash<ACTIVE, DFU, STATE>
+pub struct BlockingTestFlash<ACTIVE, DFU, STATE, SAFE>
 where
     ACTIVE: NorFlash,
     DFU: NorFlash,
     STATE: NorFlash,
+    SAFE: NorFlash,
 {
     active: Mutex<NoopRawMutex, RefCell<ACTIVE>>,
     dfu: Mutex<NoopRawMutex, RefCell<DFU>>,
     state: Mutex<NoopRawMutex, RefCell<STATE>>,
+    safe: Mutex<NoopRawMutex, RefCell<SAFE>>,
 }
 
-impl<ACTIVE, DFU, STATE> BlockingTestFlash<ACTIVE, DFU, STATE>
+impl<ACTIVE, DFU, STATE, SAFE> BlockingTestFlash<ACTIVE, DFU, STATE, SAFE>
 where
     ACTIVE: NorFlash,
     DFU: NorFlash,
     STATE: NorFlash,
+    SAFE: NorFlash,
 {
-    pub fn new(config: BootLoaderConfig<ACTIVE, DFU, STATE>) -> Self {
+    pub fn new(config: BootLoaderConfig<ACTIVE, DFU, STATE, SAFE>) -> Self {
         Self {
             active: Mutex::new(RefCell::new(config.active)),
             dfu: Mutex::new(RefCell::new(config.dfu)),
             state: Mutex::new(RefCell::new(config.state)),
+            safe: Mutex::new(RefCell::new(config.safe)),
         }
     }
 
@@ -44,6 +48,10 @@ where
         Self::create_partition(&self.state)
     }
 
+    pub fn safe(&self) -> BlockingPartition<NoopRawMutex, SAFE> {
+        Self::create_partition(&self.safe)
+    }
+
     pub fn create_partition<T: NorFlash>(
         mutex: &Mutex<NoopRawMutex, RefCell<T>>,
     ) -> BlockingPartition<NoopRawMutex, T> {
@@ -51,17 +59,19 @@ where
     }
 }
 
-impl<ACTIVE, DFU, STATE> BlockingTestFlash<ACTIVE, DFU, STATE>
+impl<ACTIVE, DFU, STATE, SAFE> BlockingTestFlash<ACTIVE, DFU, STATE, SAFE>
 where
     ACTIVE: NorFlash + embedded_storage_async::nor_flash::NorFlash,
     DFU: NorFlash + embedded_storage_async::nor_flash::NorFlash,
     STATE: NorFlash + embedded_storage_async::nor_flash::NorFlash,
+    SAFE: NorFlash + embedded_storage_async::nor_flash::NorFlash,
 {
-    pub fn into_async(self) -> super::AsyncTestFlash<ACTIVE, DFU, STATE> {
+    pub fn into_async(self) -> super::AsyncTestFlash<ACTIVE, DFU, STATE, SAFE> {
         let config = BootLoaderConfig {
             active: self.active.into_inner().into_inner(),
             dfu: self.dfu.into_inner().into_inner(),
             state: self.state.into_inner().into_inner(),
+            safe: self.safe.into_inner().into_inner(),
         };
         super::AsyncTestFlash::new(config)
     }


### PR DESCRIPTION
## Summary

This PR introduces three new operations to `embassy-boot`: `safe`, `restore`, and `backup`.
These operations enable more robust bootloader behavior and DFU workflows, particularly in scenarios requiring firmware fallback, recovery, or persistence.
The following features have been added:

---

## ✨ New Features

### 1. `safe`  
- Enabled via the `safe` Cargo feature  
- Copies a validated firmware image from the **safe partition** to the **active partition**  
- Assumes the safe partition contains a known-good firmware image  

### 2. `restore`  
- Enabled via the `restore` Cargo feature  
- Copies a firmware image from the **dfu partition** to the **active partition**  
- Always copies up to the size of the active partition  

### 3. `backup`  
- Also enabled via the `restore` Cargo feature  
- Copies the current **active partition** contents to the **dfu partition**  
- Always copies up to the size of the active partition  

---

## 🛠 Compatibility

- Introduced `DummySafe` and `DummySafeAsync` structures to maintain compatibility with existing applications that do not use the new features
- Updated the following target crates to integrate with the changes:
  - `embassy-boot-nrf`
  - `embassy-boot-stm32`
  - `embassy-boot-rp`

These changes are non-breaking and preserve behavior for existing users not opting into the new features.

---

## 🔍 Motivation

These additions provide firmware developers with:
- **Safe fallback options** for critical system recovery
- **Restore mechanisms** from DFU updates
- **Backup capabilities** before overwriting active firmware
