### PR TITLE
Add `embassy-net` `defmt` derives for config structs

### DIFF
--- a/embassy-net/Cargo.toml
+++ b/embassy-net/Cargo.toml
@@ -24,7 +24,7 @@ features = ["defmt", "tcp", "udp", "raw", "dns", "icmp", "dhcpv4", "proto-ipv6",
 
 [features]
 ## Enable defmt
-defmt = ["dep:defmt", "smoltcp/defmt", "embassy-net-driver/defmt", "heapless/defmt-03", "defmt?/ip_in_core"]
+defmt = ["dep:defmt", "smoltcp/defmt", "embassy-net-driver/defmt", "embassy-time/defmt", "heapless/defmt-03", "defmt?/ip_in_core"]
 
 ## Trace all raw received and transmitted packets using defmt or log.
 packet-trace = []

--- a/embassy-net/src/lib.rs
+++ b/embassy-net/src/lib.rs
@@ -106,6 +106,7 @@ impl<const SOCK: usize> StackResources<SOCK> {
 /// Static IP address configuration.
 #[cfg(feature = "proto-ipv4")]
 #[derive(Debug, Clone, PartialEq, Eq)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub struct StaticConfigV4 {
     /// IP address and subnet mask.
     pub address: Ipv4Cidr,
@@ -118,6 +119,7 @@ pub struct StaticConfigV4 {
 /// Static IPv6 address configuration
 #[cfg(feature = "proto-ipv6")]
 #[derive(Debug, Clone, PartialEq, Eq)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub struct StaticConfigV6 {
     /// IP address and subnet mask.
     pub address: Ipv6Cidr,
@@ -130,6 +132,7 @@ pub struct StaticConfigV6 {
 /// DHCP configuration.
 #[cfg(feature = "dhcpv4")]
 #[derive(Debug, Clone, PartialEq, Eq)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 #[non_exhaustive]
 pub struct DhcpConfig {
     /// Maximum lease duration.
@@ -169,6 +172,7 @@ impl Default for DhcpConfig {
 
 /// Network stack configuration.
 #[derive(Debug, Clone, Default)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 #[non_exhaustive]
 pub struct Config {
     /// IPv4 configuration
@@ -220,6 +224,7 @@ impl Config {
 /// Network stack IPv4 configuration.
 #[cfg(feature = "proto-ipv4")]
 #[derive(Debug, Clone, Default)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub enum ConfigV4 {
     /// Do not configure IPv4.
     #[default]
@@ -234,6 +239,7 @@ pub enum ConfigV4 {
 /// Network stack IPv6 configuration.
 #[cfg(feature = "proto-ipv6")]
 #[derive(Debug, Clone, Default)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub enum ConfigV6 {
     /// Do not configure IPv6.
     #[default]


### PR DESCRIPTION
This PR adds some missing `defmt` derives to `embassy-net` so that IP address and other configuration can more easily be inspected.