### PR TITLE
Add missing `PartialEq` and `Eq` trait derives to `embassy-net` config structs

### DIFF
--- a/embassy-net/src/lib.rs
+++ b/embassy-net/src/lib.rs
@@ -171,7 +171,7 @@ impl Default for DhcpConfig {
 }
 
 /// Network stack configuration.
-#[derive(Debug, Clone, Default)]
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
 #[non_exhaustive]
 pub struct Config {
@@ -223,7 +223,7 @@ impl Config {
 
 /// Network stack IPv4 configuration.
 #[cfg(feature = "proto-ipv4")]
-#[derive(Debug, Clone, Default)]
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub enum ConfigV4 {
     /// Do not configure IPv4.
@@ -238,7 +238,7 @@ pub enum ConfigV4 {
 
 /// Network stack IPv6 configuration.
 #[cfg(feature = "proto-ipv6")]
-#[derive(Debug, Clone, Default)]
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub enum ConfigV6 {
     /// Do not configure IPv6.


### PR DESCRIPTION
This PR adds missing equality comparison traits to some of the `embassy-net` `Config`-related structs, enabling config change detection routines ("detect user switch from DHCP to static configuration in the web UI.")