### PR TITLE
Aligned STM32WBA with U5 flash HAL

### DIFF
--- a/embassy-stm32/src/flash/mod.rs
+++ b/embassy-stm32/src/flash/mod.rs
@@ -101,7 +101,7 @@ compile_error!("The 'eeprom' cfg is enabled for a non-L0/L1 chip family. This is
 #[cfg_attr(any(flash_g0x0, flash_g0x1, flash_g4c2, flash_g4c3, flash_g4c4), path = "g.rs")]
 #[cfg_attr(flash_h7, path = "h7.rs")]
 #[cfg_attr(flash_h7ab, path = "h7.rs")]
-#[cfg_attr(flash_u5, path = "u5.rs")]
+#[cfg_attr(any(flash_u5, flash_wba), path = "u5.rs")]
 #[cfg_attr(flash_h5, path = "h5.rs")]
 #[cfg_attr(flash_h50, path = "h50.rs")]
 #[cfg_attr(flash_u0, path = "u0.rs")]
@@ -109,7 +109,7 @@ compile_error!("The 'eeprom' cfg is enabled for a non-L0/L1 chip family. This is
     not(any(
         flash_l0, flash_l1, flash_l4, flash_l5, flash_wl, flash_wb, flash_f0, flash_f1, flash_f2, flash_f3, flash_f4,
         flash_f7, flash_g0x0, flash_g0x1, flash_g4c2, flash_g4c3, flash_g4c4, flash_h7, flash_h7ab, flash_u5,
-        flash_h50, flash_u0, flash_h5,
+        flash_wba, flash_h50, flash_u0, flash_h5,
     )),
     path = "other.rs"
 )]


### PR DESCRIPTION
- U5 and STM32WBA share the same TrustZone capability
- WBA should also have this enabled.