### PR TITLE
STM32 CAN: Add mutable access for ID in Header and Frame structs

### DIFF
--- a/embassy-stm32/src/can/frame.rs
+++ b/embassy-stm32/src/can/frame.rs
@@ -59,6 +59,11 @@ impl Header {
         &self.id
     }
 
+    /// Get mutable reference to ID
+    pub fn id_mut(&mut self) -> &mut embedded_can::Id {
+        &mut self.id
+    }
+
     /// Return length as u8
     pub fn len(&self) -> u8 {
         self.len
@@ -205,6 +210,11 @@ impl Frame {
     /// Return ID
     pub fn id(&self) -> &embedded_can::Id {
         &self.can_header.id
+    }
+
+    /// Get mutable reference to ID
+    pub fn id_mut(&mut self) -> &mut embedded_can::Id {
+        &mut self.can_header.id
     }
 
     /// Get reference to data


### PR DESCRIPTION
In communication protocols like CANopen, the message ID is often a combination of a base arbitration ID and a specific node ID. To support a similar mechanism I need to modify the arbitration ID by adding the node ID before the message is transmitted.