### PR TITLE
feat(embassy-sync): Add `get_mut` for `LazyLock`

### DIFF
--- a/embassy-sync/CHANGELOG.md
+++ b/embassy-sync/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+- Add `get_mut` to `LazyLock`
+
 ## 0.7.0 - 2025-05-28
 
 - Add `remove_if` to `priority_channel::{Receiver, PriorityChannel}`.

--- a/embassy-sync/src/lazy_lock.rs
+++ b/embassy-sync/src/lazy_lock.rs
@@ -57,6 +57,14 @@ impl<T, F: FnOnce() -> T> LazyLock<T, F> {
         unsafe { &(*self.data.get()).value }
     }
 
+    /// Get a mutable reference to the underlying value, initializing it if it
+    /// has not been done already.
+    #[inline]
+    pub fn get_mut(&mut self) -> &mut T {
+        self.ensure_init_fast();
+        unsafe { &mut (*self.data.get()).value }
+    }
+
     /// Consume the `LazyLock`, returning the underlying value. The
     /// initialization function will be called if it has not been
     /// already.
@@ -120,6 +128,13 @@ mod tests {
         static VALUE: LazyLock<u32> = LazyLock::new(|| 20);
         let reference = VALUE.get();
         assert_eq!(reference, &20);
+    }
+    #[test]
+    fn test_lazy_lock_mutation() {
+        let mut value: LazyLock<u32> = LazyLock::new(|| 20);
+        *value.get_mut() = 21;
+        let reference = value.get();
+        assert_eq!(reference, &21);
     }
     #[test]
     fn test_lazy_lock_into_inner() {


### PR DESCRIPTION
This adds the possibility of obtaining `&mut T` from a `LazyLock`, while preserving the initialization contract. This is useful for mutating the inner value of the `LazyLock` without having to replace it entirely.

It should be sound and safe because it requires `&mut self`.

This enables a useful and safe pattern, for example, to maintain config singletons.
```rust
static CONFIG: RwLock<CriticalSectionRawMutex, LazyLock<Config>> =
    RwLock::new(LazyLock::new(Config::get));

// Async
pub async fn get_some_value() -> T {
  let guard = CONFIG.read().await;
  guard.get().some_value.clone()
}

pub async fn set_some_value(some_value: T) {
  let mut guard = CONFIG.write().await;
  guard.get_mut().some_value = some_value;
}

// Sync
pub fn get_some_value() -> T {
  let guard = CONFIG.try_read().unwrap();
  guard.get().some_value.clone()
}

pub fn set_some_value(some_value: T) {
  let mut guard = CONFIG.try_write().unwrap();
  guard.get_mut().some_value = some_value;
}

```