### PR TITLE
embassy-sync: Update `MultiWakerRegistration::register` docs

### DIFF
--- a/embassy-sync/src/waitqueue/multi_waker.rs
+++ b/embassy-sync/src/waitqueue/multi_waker.rs
@@ -15,7 +15,9 @@ impl<const N: usize> MultiWakerRegistration<N> {
         Self { wakers: Vec::new() }
     }
 
-    /// Register a waker. If the buffer is full the function returns it in the error
+    /// Register a waker.
+    ///
+    /// If the buffer is full, [wakes all the wakers](Self::wake), clears its buffer and registers the waker.
     pub fn register(&mut self, w: &Waker) {
         // If we already have some waker that wakes the same task as `w`, do nothing.
         // This avoids cloning wakers, and avoids unnecessary mass-wakes.


### PR DESCRIPTION
In 3081ecf301a54f8ed3d0f72350dd21f8ac9e1b18 `register` was changed to clear the buffer when it's full, but the docs weren't updated.