### PR TITLE
removed the rp2040 flag from the dormant function

### DIFF
--- a/embassy-rp/src/clocks.rs
+++ b/embassy-rp/src/clocks.rs
@@ -63,7 +63,6 @@
 //! // Set other parameters as needed...
 //! ```
 
-#[cfg(feature = "rp2040")]
 use core::arch::asm;
 use core::marker::PhantomData;
 #[cfg(feature = "rp2040")]
@@ -73,7 +72,6 @@ use core::sync::atomic::{AtomicU32, Ordering};
 use pac::clocks::vals::*;
 
 use crate::gpio::{AnyPin, SealedPin};
-#[cfg(feature = "rp2040")]
 use crate::pac::common::{Reg, RW};
 use crate::{pac, reset, Peri};
 
@@ -1844,7 +1842,7 @@ impl rand_core_09::CryptoRng for RoscRng {}
 /// and can only be exited through resets, dormant-wake GPIO interrupts,
 /// and RTC interrupts. If RTC is clocked from an internal clock source
 /// it will be stopped and not function as a wakeup source.
-#[cfg(all(target_arch = "arm", feature = "rp2040"))]
+#[cfg(all(target_arch = "arm"))]
 pub fn dormant_sleep() {
     struct Set<T: Copy, F: Fn()>(Reg<T, RW>, T, F);
 


### PR DESCRIPTION
It doesn't seem like there's any working option for low power modes on the rp235x.

The dormant_sleep() function is enabled in the rp2040, and disabled in the rp235x with a conditional compilation flag.  The datasheet for the rp2350(page 489) says that the state is still supported.

removing the flag and enabling the necessary dependencies for it seemed like the low hanging fruit.

I tried it on my project (https://github.com/Nicholas-L-Johnson/flip-card) and it works well, with 1/10 of the power usage compared to just .await-ing everything, and wakes as expected on GPIO high signal.