### PR TITLE
Updated stm32-metapac for GPDMA1 fix on STM32WBA

### DIFF
--- a/embassy-stm32/Cargo.toml
+++ b/embassy-stm32/Cargo.toml
@@ -81,7 +81,7 @@ futures-util = { version = "0.3.30", default-features = false }
 sdio-host = "0.9.0"
 critical-section = "1.1"
 #stm32-metapac = { version = "16" }
-stm32-metapac = { git = "https://github.com/embassy-rs/stm32-data-generated", tag = "stm32-data-0cf2bd99dd5ebbaab9574b4fb42c12f358ff2ed8" }
+stm32-metapac = { git = "https://github.com/embassy-rs/stm32-data-generated", tag = "stm32-data-cad609e02a866422ffdbb8e07be26311cfdd07d9" }
 
 vcell = "0.1.3"
 nb = "1.0.0"
@@ -110,7 +110,7 @@ proc-macro2 = "1.0.36"
 quote = "1.0.15"
 
 #stm32-metapac = { version = "16", default-features = false, features = ["metadata"]}
-stm32-metapac = { git = "https://github.com/embassy-rs/stm32-data-generated", tag = "stm32-data-0cf2bd99dd5ebbaab9574b4fb42c12f358ff2ed8", default-features = false, features = ["metadata"] }
+stm32-metapac = { git = "https://github.com/embassy-rs/stm32-data-generated", tag = "stm32-data-cad609e02a866422ffdbb8e07be26311cfdd07d9", default-features = false, features = ["metadata"] }
 
 [features]
 default = ["rt"]


### PR DESCRIPTION
This PR updates `stm32-metapac` based on this [PR](https://github.com/embassy-rs/stm32-data/pull/655). With this in place more peripherals can use DMA channels on the STM32WBA series.