### PR TITLE
nrf54l15 Rramc (Nvmc) support

### DIFF
--- a/embassy-nrf/src/chips/nrf54l15_app.rs
+++ b/embassy-nrf/src/chips/nrf54l15_app.rs
@@ -201,9 +201,15 @@ pub mod pac {
 pub const EASY_DMA_SIZE: usize = (1 << 16) - 1;
 //pub const FORCE_COPY_BUFFER_SIZE: usize = 1024;
 
-//pub const FLASH_SIZE: usize = 1024 * 1024;
+// 1.5 MB NVM
+#[allow(unused)]
+pub const FLASH_SIZE: usize = 1536 * 1024;
 
 embassy_hal_internal::peripherals! {
+    #[cfg(feature = "_s")]
+    // RRAMC
+    RRAMC,
+
     // GPIO port 0
     P0_00,
     P0_01,

--- a/embassy-nrf/src/lib.rs
+++ b/embassy-nrf/src/lib.rs
@@ -98,8 +98,12 @@ pub mod ipc;
     feature = "_nrf5340-app"
 ))]
 pub mod nfct;
-#[cfg(not(feature = "_nrf54l"))] // TODO
+#[cfg(not(feature = "_nrf54l"))]
 pub mod nvmc;
+#[cfg(feature = "nrf54l15-app-s")]
+pub mod rramc;
+#[cfg(feature = "nrf54l15-app-s")]
+pub use rramc as nvmc;
 #[cfg(not(feature = "_nrf54l"))] // TODO
 #[cfg(any(
     feature = "nrf52810",

--- a/embassy-nrf/src/rramc.rs
+++ b/embassy-nrf/src/rramc.rs
@@ -1,0 +1,176 @@
+//! Resistive Random-Access Memory Controller driver.
+
+use core::{ptr, slice};
+
+use embedded_storage::nor_flash::{
+    ErrorType, MultiwriteNorFlash, NorFlash, NorFlashError, NorFlashErrorKind, ReadNorFlash,
+};
+
+use crate::peripherals::RRAMC;
+use crate::{pac, Peri};
+
+//
+// Export Nvmc alias and page size for downstream compatibility
+//
+/// RRAM-backed `Nvmc` compatibile driver.
+pub type Nvmc<'d> = Rramc<'d>;
+/// Emulated page size.  RRAM does not use pages. This exists only for downstream compatibility.
+pub const PAGE_SIZE: usize = 4096;
+
+// In bytes, one line is 128 bits
+const WRITE_LINE_SIZE: usize = 16;
+
+/// Size of RRAM flash in bytes.
+pub const FLASH_SIZE: usize = crate::chip::FLASH_SIZE;
+
+/// Error type for RRAMC operations.
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+pub enum Error {
+    /// Operation using a location not in flash.
+    OutOfBounds,
+    /// Unaligned operation or using unaligned buffers.
+    Unaligned,
+}
+
+impl NorFlashError for Error {
+    fn kind(&self) -> NorFlashErrorKind {
+        match self {
+            Self::OutOfBounds => NorFlashErrorKind::OutOfBounds,
+            Self::Unaligned => NorFlashErrorKind::NotAligned,
+        }
+    }
+}
+
+/// Resistive Random-Access Memory Controller (RRAMC) that implements the `embedded-storage`
+/// traits.
+pub struct Rramc<'d> {
+    _p: Peri<'d, RRAMC>,
+}
+
+impl<'d> Rramc<'d> {
+    /// Create Rramc driver.
+    pub fn new(_p: Peri<'d, RRAMC>) -> Self {
+        Self { _p }
+    }
+
+    fn regs() -> pac::rramc::Rramc {
+        pac::RRAMC
+    }
+
+    fn wait_ready(&mut self) {
+        let p = Self::regs();
+        while !p.ready().read().ready() {}
+    }
+
+    fn wait_ready_write(&mut self) {
+        let p = Self::regs();
+        while !p.readynext().read().readynext() {}
+        while !p.bufstatus().writebufempty().read().empty() {}
+    }
+
+    fn enable_read(&self) {
+        Self::regs().config().write(|w| w.set_wen(false));
+    }
+
+    fn enable_write(&self) {
+        Self::regs().config().write(|w| w.set_wen(true));
+    }
+}
+
+//
+// RRAM is not NOR flash, but many crates require embedded-storage NorFlash traits. We therefore
+// implement the traits for downstream compatibility.
+//
+
+impl<'d> MultiwriteNorFlash for Rramc<'d> {}
+
+impl<'d> ErrorType for Rramc<'d> {
+    type Error = Error;
+}
+
+impl<'d> ReadNorFlash for Rramc<'d> {
+    const READ_SIZE: usize = 1;
+
+    fn read(&mut self, offset: u32, bytes: &mut [u8]) -> Result<(), Self::Error> {
+        if offset as usize >= FLASH_SIZE || offset as usize + bytes.len() > FLASH_SIZE {
+            return Err(Error::OutOfBounds);
+        }
+
+        let flash_data = unsafe { slice::from_raw_parts(offset as *const u8, bytes.len()) };
+        bytes.copy_from_slice(flash_data);
+        Ok(())
+    }
+
+    fn capacity(&self) -> usize {
+        FLASH_SIZE
+    }
+}
+
+impl<'d> NorFlash for Rramc<'d> {
+    const WRITE_SIZE: usize = WRITE_LINE_SIZE;
+    const ERASE_SIZE: usize = PAGE_SIZE;
+
+    // RRAM can overwrite in-place, so emulate page erases by overwriting the page bytes with 0xFF.
+    fn erase(&mut self, from: u32, to: u32) -> Result<(), Self::Error> {
+        if to < from || to as usize > FLASH_SIZE {
+            return Err(Error::OutOfBounds);
+        }
+        if from as usize % Self::ERASE_SIZE != 0 || to as usize % Self::ERASE_SIZE != 0 {
+            return Err(Error::Unaligned);
+        }
+
+        self.enable_write();
+        self.wait_ready();
+
+        // Treat each emulated page separately so callers can rely on post‑erase read‑back
+        // returning 0xFF just like on real NOR flash.
+        let buf = [0xFFu8; Self::WRITE_SIZE];
+        for page_addr in (from..to).step_by(Self::ERASE_SIZE) {
+            let page_end = page_addr + Self::ERASE_SIZE as u32;
+            for line_addr in (page_addr..page_end).step_by(Self::WRITE_SIZE) {
+                unsafe {
+                    let src = buf.as_ptr() as *const u32;
+                    let dst = line_addr as *mut u32;
+                    for i in 0..(Self::WRITE_SIZE / 4) {
+                        core::ptr::write_volatile(dst.add(i), core::ptr::read_unaligned(src.add(i)));
+                    }
+                }
+                self.wait_ready_write();
+            }
+        }
+
+        self.enable_read();
+        self.wait_ready();
+        Ok(())
+    }
+
+    fn write(&mut self, offset: u32, bytes: &[u8]) -> Result<(), Self::Error> {
+        if offset as usize + bytes.len() > FLASH_SIZE {
+            return Err(Error::OutOfBounds);
+        }
+        if offset as usize % Self::WRITE_SIZE != 0 || bytes.len() % Self::WRITE_SIZE != 0 {
+            return Err(Error::Unaligned);
+        }
+
+        self.enable_write();
+        self.wait_ready();
+
+        unsafe {
+            let p_src = bytes.as_ptr() as *const u32;
+            let p_dst = offset as *mut u32;
+            let words = bytes.len() / 4;
+            for i in 0..words {
+                let w = ptr::read_unaligned(p_src.add(i));
+                ptr::write_volatile(p_dst.add(i), w);
+                if (i + 1) % (Self::WRITE_SIZE / 4) == 0 {
+                    self.wait_ready_write();
+                }
+            }
+        }
+
+        self.enable_read();
+        self.wait_ready();
+        Ok(())
+    }
+}

--- a/examples/nrf54l15/Cargo.toml
+++ b/examples/nrf54l15/Cargo.toml
@@ -16,5 +16,7 @@ panic-probe = { version = "1.0.0", features = ["print-defmt"] }
 cortex-m = { version = "0.7.6", features = ["inline-asm", "critical-section-single-core"] }
 cortex-m-rt = "0.7.0"
 
+embedded-storage = "0.3.1"
+
 [profile.release]
 debug = 2

--- a/examples/nrf54l15/src/bin/nvmc.rs
+++ b/examples/nrf54l15/src/bin/nvmc.rs
@@ -1,0 +1,44 @@
+#![no_std]
+#![no_main]
+
+use defmt::{info, unwrap};
+use embassy_executor::Spawner;
+use embassy_nrf::nvmc::{Nvmc, PAGE_SIZE};
+use embedded_storage::nor_flash::{NorFlash, ReadNorFlash};
+use {defmt_rtt as _, panic_probe as _};
+
+#[embassy_executor::main]
+async fn main(_spawner: Spawner) {
+    let p = embassy_nrf::init(Default::default());
+    info!("Hello RRAMC NVMC!");
+
+    let mut f = Nvmc::new(p.RRAMC);
+
+    const ADDR: u32 = 0x80000;
+    let mut buf = [0u8; 4];
+
+    info!("Reading...");
+    unwrap!(f.read(ADDR, &mut buf));
+    info!("Read: {=[u8]:x}", buf);
+
+    info!("Erasing...");
+    unwrap!(f.erase(ADDR, ADDR + PAGE_SIZE as u32));
+
+    info!("Reading...");
+    unwrap!(f.read(ADDR, &mut buf));
+    info!("Read: {=[u8]:x}", buf);
+
+    info!("Writing...");
+    // 16 B (128-bit) write minimum
+    let out: [u8; 16] = [
+        0xaa, 0xaa, 0xaa, 0xaa, 0xbb, 0xbb, 0xbb, 0xbb, 0xcc, 0xcc, 0xcc, 0xcc, 0xdd, 0xdd, 0xdd, 0xdd,
+    ];
+    unwrap!(f.write(ADDR, &out));
+
+    info!("Reading...");
+    // Can read arbitrary sizes
+    for addr in (ADDR..ADDR + 16).step_by(4) {
+        unwrap!(f.read(addr, &mut buf));
+        info!("Read: {=[u8]:x}", buf);
+    }
+}


### PR DESCRIPTION
Adding basic support for RRAMC to nrf54l15 (nrf54l15-app-s only). Exposed as Nvmc for downstream compatibility. 

I am submitting this as a Draft PR as I am unsure how it fits with [4393](https://github.com/embassy-rs/embassy/pull/4393). 