### PR TITLE
Add examples for W5500-EVB-Pico2

### DIFF
--- a/examples/rp235x/Cargo.toml
+++ b/examples/rp235x/Cargo.toml
@@ -12,7 +12,7 @@ embassy-executor = { version = "0.8.0", path = "../../embassy-executor", feature
 embassy-time = { version = "0.4.0", path = "../../embassy-time", features = ["defmt", "defmt-timestamp-uptime"] }
 embassy-rp = { version = "0.7.0", path = "../../embassy-rp", features = ["defmt", "unstable-pac", "time-driver", "critical-section-impl", "rp235xa", "binary-info"] }
 embassy-usb = { version = "0.5.0", path = "../../embassy-usb", features = ["defmt"] }
-embassy-net = { version = "0.7.0", path = "../../embassy-net", features = ["defmt", "tcp", "udp", "raw", "dhcpv4", "medium-ethernet", "dns"] }
+embassy-net = { version = "0.7.0", path = "../../embassy-net", features = ["defmt", "icmp", "tcp", "udp", "raw", "dhcpv4", "medium-ethernet", "dns"] }
 embassy-net-wiznet = { version = "0.2.0", path = "../../embassy-net-wiznet", features = ["defmt"] }
 embassy-futures = { version = "0.1.0", path = "../../embassy-futures" }
 embassy-usb-logger = { version = "0.5.0", path = "../../embassy-usb-logger" }

--- a/examples/rp235x/src/bin/ethernet_w5500_icmp.rs
+++ b/examples/rp235x/src/bin/ethernet_w5500_icmp.rs
@@ -1,0 +1,143 @@
+//! This example implements an echo (ping) with an ICMP Socket and using defmt to report the results.
+//!
+//! Although there is a better way to execute pings using the child module ping of the icmp module,
+//! this example allows for other icmp messages like `Destination unreachable` to be sent aswell.
+//!
+//! Example written for the [`WIZnet W5500-EVB-Pico2`](https://docs.wiznet.io/Product/iEthernet/W5500/w5500-evb-pico2) board.
+
+#![no_std]
+#![no_main]
+
+use defmt::*;
+use embassy_executor::Spawner;
+use embassy_futures::yield_now;
+use embassy_net::icmp::{ChecksumCapabilities, IcmpEndpoint, IcmpSocket, Icmpv4Packet, Icmpv4Repr, PacketMetadata};
+use embassy_net::{Stack, StackResources};
+use embassy_net_wiznet::chip::W5500;
+use embassy_net_wiznet::*;
+use embassy_rp::clocks::RoscRng;
+use embassy_rp::gpio::{Input, Level, Output, Pull};
+use embassy_rp::peripherals::SPI0;
+use embassy_rp::spi::{Async, Config as SpiConfig, Spi};
+use embassy_time::{Delay, Instant, Timer};
+use embedded_hal_bus::spi::ExclusiveDevice;
+use static_cell::StaticCell;
+use {defmt_rtt as _, panic_probe as _};
+
+type ExclusiveSpiDevice = ExclusiveDevice<Spi<'static, SPI0, Async>, Output<'static>, Delay>;
+
+#[embassy_executor::task]
+async fn ethernet_task(runner: Runner<'static, W5500, ExclusiveSpiDevice, Input<'static>, Output<'static>>) -> ! {
+    runner.run().await
+}
+
+#[embassy_executor::task]
+async fn net_task(mut runner: embassy_net::Runner<'static, Device<'static>>) -> ! {
+    runner.run().await
+}
+
+#[embassy_executor::main]
+async fn main(spawner: Spawner) {
+    let p = embassy_rp::init(Default::default());
+    let mut rng = RoscRng;
+
+    let mut spi_cfg = SpiConfig::default();
+    spi_cfg.frequency = 50_000_000;
+    let (miso, mosi, clk) = (p.PIN_16, p.PIN_19, p.PIN_18);
+    let spi = Spi::new(p.SPI0, clk, mosi, miso, p.DMA_CH0, p.DMA_CH1, spi_cfg);
+    let cs = Output::new(p.PIN_17, Level::High);
+    let w5500_int = Input::new(p.PIN_21, Pull::Up);
+    let w5500_reset = Output::new(p.PIN_20, Level::High);
+
+    let mac_addr = [0x02, 0x00, 0x00, 0x00, 0x00, 0x00];
+    static STATE: StaticCell<State<8, 8>> = StaticCell::new();
+    let state = STATE.init(State::<8, 8>::new());
+    let (device, runner) = embassy_net_wiznet::new(
+        mac_addr,
+        state,
+        ExclusiveDevice::new(spi, cs, Delay),
+        w5500_int,
+        w5500_reset,
+    )
+    .await
+    .unwrap();
+    unwrap!(spawner.spawn(ethernet_task(runner)));
+
+    // Generate random seed
+    let seed = rng.next_u64();
+
+    // Init network stack
+    static RESOURCES: StaticCell<StackResources<3>> = StaticCell::new();
+    let (stack, runner) = embassy_net::new(
+        device,
+        embassy_net::Config::dhcpv4(Default::default()),
+        RESOURCES.init(StackResources::new()),
+        seed,
+    );
+
+    // Launch network task
+    unwrap!(spawner.spawn(net_task(runner)));
+
+    info!("Waiting for DHCP...");
+    let cfg = wait_for_config(stack).await;
+    let local_addr = cfg.address.address();
+    info!("IP address: {:?}", local_addr);
+
+    // Then we can use it!
+    let mut rx_buffer = [0; 256];
+    let mut tx_buffer = [0; 256];
+    let mut rx_meta = [PacketMetadata::EMPTY];
+    let mut tx_meta = [PacketMetadata::EMPTY];
+
+    // Identifier used for the ICMP socket
+    let ident = 42;
+
+    // Create and bind the socket
+    let mut socket = IcmpSocket::new(stack, &mut rx_meta, &mut rx_buffer, &mut tx_meta, &mut tx_buffer);
+    socket.bind(IcmpEndpoint::Ident(ident)).unwrap();
+
+    // Create the repr for the packet
+    let icmp_repr = Icmpv4Repr::EchoRequest {
+        ident,
+        seq_no: 0,
+        data: b"Hello, icmp!",
+    };
+
+    // Send the packet and store the starting instant to mesure latency later
+    let start = socket
+        .send_to_with(icmp_repr.buffer_len(), cfg.gateway.unwrap(), |buf| {
+            // Create and populate the packet buffer allocated by `send_to_with`
+            let mut icmp_packet = Icmpv4Packet::new_unchecked(buf);
+            icmp_repr.emit(&mut icmp_packet, &ChecksumCapabilities::default());
+            Instant::now() // Return the instant where the packet was sent
+        })
+        .await
+        .unwrap();
+
+    // Recieve and log the data of the reply
+    socket
+        .recv_from_with(|(buf, addr)| {
+            let packet = Icmpv4Packet::new_checked(buf).unwrap();
+            info!(
+                "Recieved {:?} from {} in {}ms",
+                packet.data(),
+                addr,
+                start.elapsed().as_millis()
+            );
+        })
+        .await
+        .unwrap();
+
+    loop {
+        Timer::after_secs(10).await;
+    }
+}
+
+async fn wait_for_config(stack: Stack<'static>) -> embassy_net::StaticConfigV4 {
+    loop {
+        if let Some(config) = stack.config_v4() {
+            return config.clone();
+        }
+        yield_now().await;
+    }
+}

--- a/examples/rp235x/src/bin/ethernet_w5500_icmp_ping.rs
+++ b/examples/rp235x/src/bin/ethernet_w5500_icmp_ping.rs
@@ -1,0 +1,134 @@
+//! This example implements a LAN ping scan with the ping utilities in the icmp module of embassy-net.
+//!
+//! Example written for the [`WIZnet W5500-EVB-Pico2`](https://docs.wiznet.io/Product/iEthernet/W5500/w5500-evb-pico2) board.
+
+#![no_std]
+#![no_main]
+
+use core::net::Ipv4Addr;
+use core::ops::Not;
+use core::str::FromStr;
+
+use defmt::*;
+use embassy_executor::Spawner;
+use embassy_futures::yield_now;
+use embassy_net::icmp::ping::{PingManager, PingParams};
+use embassy_net::icmp::PacketMetadata;
+use embassy_net::{Ipv4Cidr, Stack, StackResources};
+use embassy_net_wiznet::chip::W5500;
+use embassy_net_wiznet::*;
+use embassy_rp::clocks::RoscRng;
+use embassy_rp::gpio::{Input, Level, Output, Pull};
+use embassy_rp::peripherals::SPI0;
+use embassy_rp::spi::{Async, Config as SpiConfig, Spi};
+use embassy_time::{Delay, Duration};
+use embedded_hal_bus::spi::ExclusiveDevice;
+use static_cell::StaticCell;
+use {defmt_rtt as _, panic_probe as _};
+
+type ExclusiveSpiDevice = ExclusiveDevice<Spi<'static, SPI0, Async>, Output<'static>, Delay>;
+
+#[embassy_executor::task]
+async fn ethernet_task(runner: Runner<'static, W5500, ExclusiveSpiDevice, Input<'static>, Output<'static>>) -> ! {
+    runner.run().await
+}
+
+#[embassy_executor::task]
+async fn net_task(mut runner: embassy_net::Runner<'static, Device<'static>>) -> ! {
+    runner.run().await
+}
+
+#[embassy_executor::main]
+async fn main(spawner: Spawner) {
+    let p = embassy_rp::init(Default::default());
+    let mut rng = RoscRng;
+
+    let mut spi_cfg = SpiConfig::default();
+    spi_cfg.frequency = 50_000_000;
+    let (miso, mosi, clk) = (p.PIN_16, p.PIN_19, p.PIN_18);
+    let spi = Spi::new(p.SPI0, clk, mosi, miso, p.DMA_CH0, p.DMA_CH1, spi_cfg);
+    let cs = Output::new(p.PIN_17, Level::High);
+    let w5500_int = Input::new(p.PIN_21, Pull::Up);
+    let w5500_reset = Output::new(p.PIN_20, Level::High);
+
+    let mac_addr = [0x02, 0x00, 0x00, 0x00, 0x00, 0x00];
+    static STATE: StaticCell<State<8, 8>> = StaticCell::new();
+    let state = STATE.init(State::<8, 8>::new());
+    let (device, runner) = embassy_net_wiznet::new(
+        mac_addr,
+        state,
+        ExclusiveDevice::new(spi, cs, Delay),
+        w5500_int,
+        w5500_reset,
+    )
+    .await
+    .unwrap();
+    unwrap!(spawner.spawn(ethernet_task(runner)));
+
+    // Generate random seed
+    let seed = rng.next_u64();
+
+    // Init network stack
+    static RESOURCES: StaticCell<StackResources<3>> = StaticCell::new();
+    let (stack, runner) = embassy_net::new(
+        device,
+        embassy_net::Config::dhcpv4(Default::default()),
+        RESOURCES.init(StackResources::new()),
+        seed,
+    );
+
+    // Launch network task
+    unwrap!(spawner.spawn(net_task(runner)));
+
+    info!("Waiting for DHCP...");
+    let cfg = wait_for_config(stack).await;
+    let local_addr = cfg.address.address();
+    info!("IP address: {:?}", local_addr);
+    let gateway = cfg.gateway.unwrap();
+    let mask = cfg.address.netmask();
+    let lower_bound = (gateway.to_bits() & mask.to_bits()) + 1;
+    let upper_bound = gateway.to_bits() | mask.to_bits().not();
+    let addr_range = lower_bound..=upper_bound;
+
+    // Then we can use it!
+    let mut rx_buffer = [0; 256];
+    let mut tx_buffer = [0; 256];
+    let mut rx_meta = [PacketMetadata::EMPTY];
+    let mut tx_meta = [PacketMetadata::EMPTY];
+
+    // Create the ping manager instance
+    let mut ping_manager = PingManager::new(stack, &mut rx_meta, &mut rx_buffer, &mut tx_meta, &mut tx_buffer);
+    let addr = "192.168.8.1"; // Address to ping to
+                              // Create the PingParams with the target address
+    let mut ping_params = PingParams::new(Ipv4Addr::from_str(addr).unwrap());
+    // (optional) Set custom properties of the ping
+    ping_params.set_payload(b"Hello, Ping!"); // custom payload
+    ping_params.set_count(1); // ping 1 times per ping call
+    ping_params.set_timeout(Duration::from_millis(500)); // wait .5 seconds instead of 4
+
+    info!("Online hosts in {}:", Ipv4Cidr::from_netmask(gateway, mask).unwrap());
+    let mut total_online_hosts = 0u32;
+    for addr in addr_range {
+        let ip_addr = Ipv4Addr::from_bits(addr);
+        // Set the target address in the ping params
+        ping_params.set_target(ip_addr);
+        // Execute the ping with the given parameters and wait for the reply
+        match ping_manager.ping(&ping_params).await {
+            Ok(time) => {
+                info!("{} is online\n- latency: {}ms\n", ip_addr, time.as_millis());
+                total_online_hosts += 1;
+            }
+            _ => continue,
+        }
+    }
+    info!("Ping scan complete, total online hosts: {}", total_online_hosts);
+}
+
+async fn wait_for_config(stack: Stack<'static>) -> embassy_net::StaticConfigV4 {
+    loop {
+        if let Some(config) = stack.config_v4() {
+            return config.clone();
+        }
+        yield_now().await;
+    }
+}

--- a/examples/rp235x/src/bin/ethernet_w5500_multisocket.rs
+++ b/examples/rp235x/src/bin/ethernet_w5500_multisocket.rs
@@ -1,0 +1,139 @@
+//! This example shows how you can allow multiple simultaneous TCP connections, by having multiple sockets listening on the same port.
+//!
+//! Example written for the [`WIZnet W5500-EVB-Pico2`](https://docs.wiznet.io/Product/iEthernet/W5500/w5500-evb-pico2) board.
+
+#![no_std]
+#![no_main]
+
+use defmt::*;
+use embassy_executor::Spawner;
+use embassy_futures::yield_now;
+use embassy_net::{Stack, StackResources};
+use embassy_net_wiznet::chip::W5500;
+use embassy_net_wiznet::*;
+use embassy_rp::clocks::RoscRng;
+use embassy_rp::gpio::{Input, Level, Output, Pull};
+use embassy_rp::peripherals::SPI0;
+use embassy_rp::spi::{Async, Config as SpiConfig, Spi};
+use embassy_time::{Delay, Duration};
+use embedded_hal_bus::spi::ExclusiveDevice;
+use embedded_io_async::Write;
+use static_cell::StaticCell;
+use {defmt_rtt as _, panic_probe as _};
+
+#[embassy_executor::task]
+async fn ethernet_task(
+    runner: Runner<
+        'static,
+        W5500,
+        ExclusiveDevice<Spi<'static, SPI0, Async>, Output<'static>, Delay>,
+        Input<'static>,
+        Output<'static>,
+    >,
+) -> ! {
+    runner.run().await
+}
+
+#[embassy_executor::task]
+async fn net_task(mut runner: embassy_net::Runner<'static, Device<'static>>) -> ! {
+    runner.run().await
+}
+
+#[embassy_executor::main]
+async fn main(spawner: Spawner) {
+    let p = embassy_rp::init(Default::default());
+    let mut rng = RoscRng;
+
+    let mut spi_cfg = SpiConfig::default();
+    spi_cfg.frequency = 50_000_000;
+    let (miso, mosi, clk) = (p.PIN_16, p.PIN_19, p.PIN_18);
+    let spi = Spi::new(p.SPI0, clk, mosi, miso, p.DMA_CH0, p.DMA_CH1, spi_cfg);
+    let cs = Output::new(p.PIN_17, Level::High);
+    let w5500_int = Input::new(p.PIN_21, Pull::Up);
+    let w5500_reset = Output::new(p.PIN_20, Level::High);
+
+    let mac_addr = [0x02, 0x00, 0x00, 0x00, 0x00, 0x00];
+    static STATE: StaticCell<State<8, 8>> = StaticCell::new();
+    let state = STATE.init(State::<8, 8>::new());
+    let (device, runner) = embassy_net_wiznet::new(
+        mac_addr,
+        state,
+        ExclusiveDevice::new(spi, cs, Delay),
+        w5500_int,
+        w5500_reset,
+    )
+    .await
+    .unwrap();
+    unwrap!(spawner.spawn(ethernet_task(runner)));
+
+    // Generate random seed
+    let seed = rng.next_u64();
+
+    // Init network stack
+    static RESOURCES: StaticCell<StackResources<3>> = StaticCell::new();
+    let (stack, runner) = embassy_net::new(
+        device,
+        embassy_net::Config::dhcpv4(Default::default()),
+        RESOURCES.init(StackResources::new()),
+        seed,
+    );
+
+    // Launch network task
+    unwrap!(spawner.spawn(net_task(runner)));
+
+    info!("Waiting for DHCP...");
+    let cfg = wait_for_config(stack).await;
+    let local_addr = cfg.address.address();
+    info!("IP address: {:?}", local_addr);
+
+    // Create two sockets listening to the same port, to handle simultaneous connections
+    unwrap!(spawner.spawn(listen_task(stack, 0, 1234)));
+    unwrap!(spawner.spawn(listen_task(stack, 1, 1234)));
+}
+
+#[embassy_executor::task(pool_size = 2)]
+async fn listen_task(stack: Stack<'static>, id: u8, port: u16) {
+    let mut rx_buffer = [0; 4096];
+    let mut tx_buffer = [0; 4096];
+    let mut buf = [0; 4096];
+    loop {
+        let mut socket = embassy_net::tcp::TcpSocket::new(stack, &mut rx_buffer, &mut tx_buffer);
+        socket.set_timeout(Some(Duration::from_secs(10)));
+
+        info!("SOCKET {}: Listening on TCP:{}...", id, port);
+        if let Err(e) = socket.accept(port).await {
+            warn!("accept error: {:?}", e);
+            continue;
+        }
+        info!("SOCKET {}: Received connection from {:?}", id, socket.remote_endpoint());
+
+        loop {
+            let n = match socket.read(&mut buf).await {
+                Ok(0) => {
+                    warn!("read EOF");
+                    break;
+                }
+                Ok(n) => n,
+                Err(e) => {
+                    warn!("SOCKET {}: {:?}", id, e);
+                    break;
+                }
+            };
+            info!("SOCKET {}: rxd {}", id, core::str::from_utf8(&buf[..n]).unwrap());
+
+            if let Err(e) = socket.write_all(&buf[..n]).await {
+                warn!("write error: {:?}", e);
+                break;
+            }
+        }
+    }
+}
+
+async fn wait_for_config(stack: Stack<'static>) -> embassy_net::StaticConfigV4 {
+    loop {
+        if let Some(config) = stack.config_v4() {
+            return config.clone();
+        }
+        yield_now().await;
+    }
+}

--- a/examples/rp235x/src/bin/ethernet_w5500_tcp_client.rs
+++ b/examples/rp235x/src/bin/ethernet_w5500_tcp_client.rs
@@ -1,0 +1,127 @@
+//! This example implements a TCP client that attempts to connect to a host on port 1234 and send it some data once per second.
+//!
+//! Example written for the [`WIZnet W5500-EVB-Pico2`](https://docs.wiznet.io/Product/iEthernet/W5500/w5500-evb-pico2) board.
+
+#![no_std]
+#![no_main]
+
+use core::str::FromStr;
+
+use defmt::*;
+use embassy_executor::Spawner;
+use embassy_futures::yield_now;
+use embassy_net::{Stack, StackResources};
+use embassy_net_wiznet::chip::W5500;
+use embassy_net_wiznet::*;
+use embassy_rp::clocks::RoscRng;
+use embassy_rp::gpio::{Input, Level, Output, Pull};
+use embassy_rp::peripherals::SPI0;
+use embassy_rp::spi::{Async, Config as SpiConfig, Spi};
+use embassy_time::{Delay, Duration, Timer};
+use embedded_hal_bus::spi::ExclusiveDevice;
+use embedded_io_async::Write;
+use static_cell::StaticCell;
+use {defmt_rtt as _, panic_probe as _};
+
+#[embassy_executor::task]
+async fn ethernet_task(
+    runner: Runner<
+        'static,
+        W5500,
+        ExclusiveDevice<Spi<'static, SPI0, Async>, Output<'static>, Delay>,
+        Input<'static>,
+        Output<'static>,
+    >,
+) -> ! {
+    runner.run().await
+}
+
+#[embassy_executor::task]
+async fn net_task(mut runner: embassy_net::Runner<'static, Device<'static>>) -> ! {
+    runner.run().await
+}
+
+#[embassy_executor::main]
+async fn main(spawner: Spawner) {
+    let p = embassy_rp::init(Default::default());
+    let mut rng = RoscRng;
+    let mut led = Output::new(p.PIN_25, Level::Low);
+
+    let mut spi_cfg = SpiConfig::default();
+    spi_cfg.frequency = 50_000_000;
+    let (miso, mosi, clk) = (p.PIN_16, p.PIN_19, p.PIN_18);
+    let spi = Spi::new(p.SPI0, clk, mosi, miso, p.DMA_CH0, p.DMA_CH1, spi_cfg);
+    let cs = Output::new(p.PIN_17, Level::High);
+    let w5500_int = Input::new(p.PIN_21, Pull::Up);
+    let w5500_reset = Output::new(p.PIN_20, Level::High);
+
+    let mac_addr = [0x02, 0x00, 0x00, 0x00, 0x00, 0x00];
+    static STATE: StaticCell<State<8, 8>> = StaticCell::new();
+    let state = STATE.init(State::<8, 8>::new());
+    let (device, runner) = embassy_net_wiznet::new(
+        mac_addr,
+        state,
+        ExclusiveDevice::new(spi, cs, Delay),
+        w5500_int,
+        w5500_reset,
+    )
+    .await
+    .unwrap();
+    unwrap!(spawner.spawn(ethernet_task(runner)));
+
+    // Generate random seed
+    let seed = rng.next_u64();
+
+    // Init network stack
+    static RESOURCES: StaticCell<StackResources<3>> = StaticCell::new();
+    let (stack, runner) = embassy_net::new(
+        device,
+        embassy_net::Config::dhcpv4(Default::default()),
+        RESOURCES.init(StackResources::new()),
+        seed,
+    );
+
+    // Launch network task
+    unwrap!(spawner.spawn(net_task(runner)));
+
+    info!("Waiting for DHCP...");
+    let cfg = wait_for_config(stack).await;
+    let local_addr = cfg.address.address();
+    info!("IP address: {:?}", local_addr);
+
+    let mut rx_buffer = [0; 4096];
+    let mut tx_buffer = [0; 4096];
+    loop {
+        let mut socket = embassy_net::tcp::TcpSocket::new(stack, &mut rx_buffer, &mut tx_buffer);
+        socket.set_timeout(Some(Duration::from_secs(10)));
+
+        led.set_low();
+        info!("Connecting...");
+        let host_addr = embassy_net::Ipv4Address::from_str("192.168.0.118").unwrap();
+        if let Err(e) = socket.connect((host_addr, 1234)).await {
+            warn!("connect error: {:?}", e);
+            continue;
+        }
+        info!("Connected to {:?}", socket.remote_endpoint());
+        led.set_high();
+
+        let msg = b"Hello world!\n";
+        loop {
+            if let Err(e) = socket.write_all(msg).await {
+                warn!("write error: {:?}", e);
+                break;
+            }
+            info!("txd: {}", core::str::from_utf8(msg).unwrap());
+            Timer::after_secs(1).await;
+        }
+    }
+}
+
+async fn wait_for_config(stack: Stack<'static>) -> embassy_net::StaticConfigV4 {
+    loop {
+        if let Some(config) = stack.config_v4() {
+            return config.clone();
+        }
+        yield_now().await;
+    }
+}

--- a/examples/rp235x/src/bin/ethernet_w5500_tcp_server.rs
+++ b/examples/rp235x/src/bin/ethernet_w5500_tcp_server.rs
@@ -1,0 +1,136 @@
+//! This example implements a TCP echo server on port 1234 and using DHCP.
+//! Send it some data, you should see it echoed back and printed in the console.
+//!
+//! Example written for the [`WIZnet W5500-EVB-Pico2`](https://docs.wiznet.io/Product/iEthernet/W5500/w5500-evb-pico2) board.
+
+#![no_std]
+#![no_main]
+
+use defmt::*;
+use embassy_executor::Spawner;
+use embassy_futures::yield_now;
+use embassy_net::{Stack, StackResources};
+use embassy_net_wiznet::chip::W5500;
+use embassy_net_wiznet::*;
+use embassy_rp::clocks::RoscRng;
+use embassy_rp::gpio::{Input, Level, Output, Pull};
+use embassy_rp::peripherals::SPI0;
+use embassy_rp::spi::{Async, Config as SpiConfig, Spi};
+use embassy_time::{Delay, Duration};
+use embedded_hal_bus::spi::ExclusiveDevice;
+use embedded_io_async::Write;
+use static_cell::StaticCell;
+use {defmt_rtt as _, panic_probe as _};
+
+#[embassy_executor::task]
+async fn ethernet_task(
+    runner: Runner<
+        'static,
+        W5500,
+        ExclusiveDevice<Spi<'static, SPI0, Async>, Output<'static>, Delay>,
+        Input<'static>,
+        Output<'static>,
+    >,
+) -> ! {
+    runner.run().await
+}
+
+#[embassy_executor::task]
+async fn net_task(mut runner: embassy_net::Runner<'static, Device<'static>>) -> ! {
+    runner.run().await
+}
+
+#[embassy_executor::main]
+async fn main(spawner: Spawner) {
+    let p = embassy_rp::init(Default::default());
+    let mut rng = RoscRng;
+    let mut led = Output::new(p.PIN_25, Level::Low);
+
+    let mut spi_cfg = SpiConfig::default();
+    spi_cfg.frequency = 50_000_000;
+    let (miso, mosi, clk) = (p.PIN_16, p.PIN_19, p.PIN_18);
+    let spi = Spi::new(p.SPI0, clk, mosi, miso, p.DMA_CH0, p.DMA_CH1, spi_cfg);
+    let cs = Output::new(p.PIN_17, Level::High);
+    let w5500_int = Input::new(p.PIN_21, Pull::Up);
+    let w5500_reset = Output::new(p.PIN_20, Level::High);
+
+    let mac_addr = [0x02, 0x00, 0x00, 0x00, 0x00, 0x00];
+    static STATE: StaticCell<State<8, 8>> = StaticCell::new();
+    let state = STATE.init(State::<8, 8>::new());
+    let (device, runner) = embassy_net_wiznet::new(
+        mac_addr,
+        state,
+        ExclusiveDevice::new(spi, cs, Delay),
+        w5500_int,
+        w5500_reset,
+    )
+    .await
+    .unwrap();
+    unwrap!(spawner.spawn(ethernet_task(runner)));
+
+    // Generate random seed
+    let seed = rng.next_u64();
+
+    // Init network stack
+    static RESOURCES: StaticCell<StackResources<3>> = StaticCell::new();
+    let (stack, runner) = embassy_net::new(
+        device,
+        embassy_net::Config::dhcpv4(Default::default()),
+        RESOURCES.init(StackResources::new()),
+        seed,
+    );
+
+    // Launch network task
+    unwrap!(spawner.spawn(net_task(runner)));
+
+    info!("Waiting for DHCP...");
+    let cfg = wait_for_config(stack).await;
+    let local_addr = cfg.address.address();
+    info!("IP address: {:?}", local_addr);
+
+    let mut rx_buffer = [0; 4096];
+    let mut tx_buffer = [0; 4096];
+    let mut buf = [0; 4096];
+    loop {
+        let mut socket = embassy_net::tcp::TcpSocket::new(stack, &mut rx_buffer, &mut tx_buffer);
+        socket.set_timeout(Some(Duration::from_secs(10)));
+
+        led.set_low();
+        info!("Listening on TCP:1234...");
+        if let Err(e) = socket.accept(1234).await {
+            warn!("accept error: {:?}", e);
+            continue;
+        }
+        info!("Received connection from {:?}", socket.remote_endpoint());
+        led.set_high();
+
+        loop {
+            let n = match socket.read(&mut buf).await {
+                Ok(0) => {
+                    warn!("read EOF");
+                    break;
+                }
+                Ok(n) => n,
+                Err(e) => {
+                    warn!("{:?}", e);
+                    break;
+                }
+            };
+            info!("rxd {}", core::str::from_utf8(&buf[..n]).unwrap());
+
+            if let Err(e) = socket.write_all(&buf[..n]).await {
+                warn!("write error: {:?}", e);
+                break;
+            }
+        }
+    }
+}
+
+async fn wait_for_config(stack: Stack<'static>) -> embassy_net::StaticConfigV4 {
+    loop {
+        if let Some(config) = stack.config_v4() {
+            return config.clone();
+        }
+        yield_now().await;
+    }
+}

--- a/examples/rp235x/src/bin/ethernet_w5500_udp.rs
+++ b/examples/rp235x/src/bin/ethernet_w5500_udp.rs
@@ -1,0 +1,116 @@
+//! This example implements a UDP server listening on port 1234 and echoing back the data.
+//!
+//! Example written for the [`WIZnet W5500-EVB-Pico2`](https://docs.wiznet.io/Product/iEthernet/W5500/w5500-evb-pico2) board.
+
+#![no_std]
+#![no_main]
+
+use defmt::*;
+use embassy_executor::Spawner;
+use embassy_futures::yield_now;
+use embassy_net::udp::{PacketMetadata, UdpSocket};
+use embassy_net::{Stack, StackResources};
+use embassy_net_wiznet::chip::W5500;
+use embassy_net_wiznet::*;
+use embassy_rp::clocks::RoscRng;
+use embassy_rp::gpio::{Input, Level, Output, Pull};
+use embassy_rp::peripherals::SPI0;
+use embassy_rp::spi::{Async, Config as SpiConfig, Spi};
+use embassy_time::Delay;
+use embedded_hal_bus::spi::ExclusiveDevice;
+use static_cell::StaticCell;
+use {defmt_rtt as _, panic_probe as _};
+
+#[embassy_executor::task]
+async fn ethernet_task(
+    runner: Runner<
+        'static,
+        W5500,
+        ExclusiveDevice<Spi<'static, SPI0, Async>, Output<'static>, Delay>,
+        Input<'static>,
+        Output<'static>,
+    >,
+) -> ! {
+    runner.run().await
+}
+
+#[embassy_executor::task]
+async fn net_task(mut runner: embassy_net::Runner<'static, Device<'static>>) -> ! {
+    runner.run().await
+}
+
+#[embassy_executor::main]
+async fn main(spawner: Spawner) {
+    let p = embassy_rp::init(Default::default());
+    let mut rng = RoscRng;
+
+    let mut spi_cfg = SpiConfig::default();
+    spi_cfg.frequency = 50_000_000;
+    let (miso, mosi, clk) = (p.PIN_16, p.PIN_19, p.PIN_18);
+    let spi = Spi::new(p.SPI0, clk, mosi, miso, p.DMA_CH0, p.DMA_CH1, spi_cfg);
+    let cs = Output::new(p.PIN_17, Level::High);
+    let w5500_int = Input::new(p.PIN_21, Pull::Up);
+    let w5500_reset = Output::new(p.PIN_20, Level::High);
+
+    let mac_addr = [0x02, 0x00, 0x00, 0x00, 0x00, 0x00];
+    static STATE: StaticCell<State<8, 8>> = StaticCell::new();
+    let state = STATE.init(State::<8, 8>::new());
+    let (device, runner) = embassy_net_wiznet::new(
+        mac_addr,
+        state,
+        ExclusiveDevice::new(spi, cs, Delay),
+        w5500_int,
+        w5500_reset,
+    )
+    .await
+    .unwrap();
+    unwrap!(spawner.spawn(ethernet_task(runner)));
+
+    // Generate random seed
+    let seed = rng.next_u64();
+
+    // Init network stack
+    static RESOURCES: StaticCell<StackResources<3>> = StaticCell::new();
+    let (stack, runner) = embassy_net::new(
+        device,
+        embassy_net::Config::dhcpv4(Default::default()),
+        RESOURCES.init(StackResources::new()),
+        seed,
+    );
+
+    // Launch network task
+    unwrap!(spawner.spawn(net_task(runner)));
+
+    info!("Waiting for DHCP...");
+    let cfg = wait_for_config(stack).await;
+    let local_addr = cfg.address.address();
+    info!("IP address: {:?}", local_addr);
+
+    // Then we can use it!
+    let mut rx_buffer = [0; 4096];
+    let mut tx_buffer = [0; 4096];
+    let mut rx_meta = [PacketMetadata::EMPTY; 16];
+    let mut tx_meta = [PacketMetadata::EMPTY; 16];
+    let mut buf = [0; 4096];
+    loop {
+        let mut socket = UdpSocket::new(stack, &mut rx_meta, &mut rx_buffer, &mut tx_meta, &mut tx_buffer);
+        socket.bind(1234).unwrap();
+
+        loop {
+            let (n, ep) = socket.recv_from(&mut buf).await.unwrap();
+            if let Ok(s) = core::str::from_utf8(&buf[..n]) {
+                info!("rxd from {}: {}", ep, s);
+            }
+            socket.send_to(&buf[..n], ep).await.unwrap();
+        }
+    }
+}
+
+async fn wait_for_config(stack: Stack<'static>) -> embassy_net::StaticConfigV4 {
+    loop {
+        if let Some(config) = stack.config_v4() {
+            return config.clone();
+        }
+        yield_now().await;
+    }
+}


### PR DESCRIPTION
Adds examples for the Wiznet W5500-EVB-Pico2 evalboard. I have tested all of the examples with the new hardware and all are functional except for examples/rp235x/src/bin/ethernet_w5500_multisocket.rs here is an example of the failure:
```
0.115768 [INFO ] IPv4: DOWN (embassy_net embassy-net/src/lib.rs:750)
0.116362 [INFO ] Waiting for DHCP... (ethernet_w5500_multisocket src/bin/ethernet_w5500_multisocket.rs:84)
0.117179 [DEBUG] DHCP send DISCOVER to 255.255.255.255: Repr { message_type: Discover, transaction_id: 1508351018, secs: 0, client_hardware_address: 02-00-00-00-00-00, client_ip: 0.0.0.0, your_ip: 0.0.0.0, server_ip: 0.0.0.0, router: None, subnet_mask: None, relay_agent_ip: 0.0.0.0, broadcast: false, requested_ip: None, client_identifier: Some(02-00-00-00-00-00), server_identifier: None, parameter_request_list: Some([1, 3, 6]), dns_servers: None, max_size: Some(1432), lease_duration: None, renew_duration: None, rebind_duration: None, additional_options: [] } (smoltcp smoltcp-0.12.0/src/macros.rs:18)
2.123768 [INFO ] link_up = true (embassy_net embassy-net/src/lib.rs:838)
2.124070 [INFO ] IPv4: DOWN (embassy_net embassy-net/src/lib.rs:750)
2.125921 [DEBUG] DHCP send DISCOVER to 255.255.255.255: Repr { message_type: Discover, transaction_id: 1389185520, secs: 0, client_hardware_address: 02-00-00-00-00-00, client_ip: 0.0.0.0, your_ip: 0.0.0.0, server_ip: 0.0.0.0, router: None, subnet_mask: None, relay_agent_ip: 0.0.0.0, broadcast: false, requested_ip: None, client_identifier: Some(02-00-00-00-00-00), server_identifier: None, parameter_request_list: Some([1, 3, 6]), dns_servers: None, max_size: Some(1432), lease_duration: None, renew_duration: None, rebind_duration: None, additional_options: [] } (smoltcp smoltcp-0.12.0/src/macros.rs:18)
2.143864 [DEBUG] DHCP recv Offer from 192.168.0.1: Repr { message_type: Offer, transaction_id: 1389185520, secs: 0, client_hardware_address: 02-00-00-00-00-00, client_ip: 0.0.0.0, your_ip: 192.168.0.233, server_ip: 192.168.0.1, router: Some(192.168.0.1), subnet_mask: Some(255.255.255.0), relay_agent_ip: 0.0.0.0, broadcast: false, requested_ip: None, client_identifier: None, server_identifier: Some(192.168.0.1), parameter_request_list: None, dns_servers: Some([192.168.0.1]), max_size: None, lease_duration: Some(86400), renew_duration: Some(43200), rebind_duration: Some(75600), additional_options: [] } (smoltcp smoltcp-0.12.0/src/macros.rs:18)
2.146232 [DEBUG] DHCP send request to 255.255.255.255: Repr { message_type: Request, transaction_id: 495877001, secs: 0, client_hardware_address: 02-00-00-00-00-00, client_ip: 0.0.0.0, your_ip: 0.0.0.0, server_ip: 0.0.0.0, router: None, subnet_mask: None, relay_agent_ip: 0.0.0.0, broadcast: false, requested_ip: Some(192.168.0.233), client_identifier: Some(02-00-00-00-00-00), server_identifier: Some(192.168.0.1), parameter_request_list: Some([1, 3, 6]), dns_servers: None, max_size: Some(1432), lease_duration: None, renew_duration: None, rebind_duration: None, additional_options: [] } (smoltcp smoltcp-0.12.0/src/macros.rs:18)
2.163904 [DEBUG] DHCP recv Ack from 192.168.0.1: Repr { message_type: Ack, transaction_id: 495877001, secs: 0, client_hardware_address: 02-00-00-00-00-00, client_ip: 0.0.0.0, your_ip: 192.168.0.233, server_ip: 192.168.0.1, router: Some(192.168.0.1), subnet_mask: Some(255.255.255.0), relay_agent_ip: 0.0.0.0, broadcast: false, requested_ip: None, client_identifier: None, server_identifier: Some(192.168.0.1), parameter_request_list: None, dns_servers: Some([192.168.0.1]), max_size: None, lease_duration: Some(86400), renew_duration: Some(43200), rebind_duration: Some(75600), additional_options: [] } (smoltcp smoltcp-0.12.0/src/macros.rs:18)
2.166841 [DEBUG] IPv4: UP (embassy_net embassy-net/src/lib.rs:738)
2.166979 [DEBUG]    IP address:      192.168.0.233/24 (embassy_net embassy-net/src/lib.rs:739)
2.167246 [DEBUG]    Default gateway: Some(192.168.0.1) (embassy_net embassy-net/src/lib.rs:740)
2.167552 [DEBUG]    DNS server:      192.168.0.1 (embassy_net embassy-net/src/lib.rs:746)
2.169319 [INFO ] IP address: 192.168.0.233 (ethernet_w5500_multisocket src/bin/ethernet_w5500_multisocket.rs:87)
2.170526 [INFO ] SOCKET 1: Listening on TCP:1234... (ethernet_w5500_multisocket src/bin/ethernet_w5500_multisocket.rs:103)
2.171195 [ERROR] panicked at /home/rice/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/smoltcp-0.12.0/src/iface/socket_set.rs:83:42:
adding a socket to a full SocketSet (panic_probe panic-probe-1.0.0/src/lib.rs:104)
Firmware exited unexpectedly: Exception
 WARN probe_rs_debug::debug_info: UNWIND: Error while checking for exception context. The stack trace will not include the calling frames. : Probe(Register("No Stack Pointer register. Please report this as a bug."))
Core 0
    Frame 0: HardFault_ @ 0x10042204
       /home/rice/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/cortex-m-rt-0.7.5/src/lib.rs:1103:1
    Frame 1: UNWIND: Error while checking for exception context. The stack trace will not include the calling frames. : Probe(Register("No Stack Pointer register. Please report this as a bug.")) @ 0x10042204

Core 1
    Frame 0: is_valid_allocation_size @ 0x000000ec inline
       /home/rice/.rustup/toolchains/1.88-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/core/src/ub_checks.rs:134:54
    Frame 1: defmt_rtt::BUFFER @ 0xfa050000> @ 0x00000000fa050000
```

I have left the code in for discussion but it should not be merged in.

Thanks