### PR TITLE
embassy-stm32: Add frequency and gpio speed to Config for i2c and i2s

### DIFF
--- a/embassy-stm32/src/i2c/config.rs
+++ b/embassy-stm32/src/i2c/config.rs
@@ -1,6 +1,7 @@
 #[cfg(gpio_v2)]
 use crate::gpio::Pull;
 use crate::gpio::{AfType, OutputType, Speed};
+use crate::time::Hertz;
 
 #[repr(u8)]
 #[derive(Copy, Clone)]

--- a/embassy-stm32/src/i2c/config.rs
+++ b/embassy-stm32/src/i2c/config.rs
@@ -109,6 +109,10 @@ impl SlaveAddrConfig {
 #[non_exhaustive]
 #[derive(Copy, Clone)]
 pub struct Config {
+    /// Frequency
+    pub frequency: Hertz,
+    /// GPIO Speed
+    pub gpio_speed: Speed,
     /// Enable internal pullup on SDA.
     ///
     /// Using external pullup resistors is recommended for I2C. If you do
@@ -129,6 +133,8 @@ pub struct Config {
 impl Default for Config {
     fn default() -> Self {
         Self {
+            frequency: Hertz::khz(100),
+            gpio_speed: Speed::Medium,
             #[cfg(gpio_v2)]
             sda_pullup: false,
             #[cfg(gpio_v2)]
@@ -142,11 +148,11 @@ impl Default for Config {
 impl Config {
     pub(super) fn scl_af(&self) -> AfType {
         #[cfg(gpio_v1)]
-        return AfType::output(OutputType::OpenDrain, Speed::Medium);
+        return AfType::output(OutputType::OpenDrain, self.gpio_speed);
         #[cfg(gpio_v2)]
         return AfType::output_pull(
             OutputType::OpenDrain,
-            Speed::Medium,
+            self.gpio_speed,
             match self.scl_pullup {
                 true => Pull::Up,
                 false => Pull::Down,
@@ -156,11 +162,11 @@ impl Config {
 
     pub(super) fn sda_af(&self) -> AfType {
         #[cfg(gpio_v1)]
-        return AfType::output(OutputType::OpenDrain, Speed::Medium);
+        return AfType::output(OutputType::OpenDrain, self.gpio_speed);
         #[cfg(gpio_v2)]
         return AfType::output_pull(
             OutputType::OpenDrain,
-            Speed::Medium,
+            self.gpio_speed,
             match self.sda_pullup {
                 true => Pull::Up,
                 false => Pull::Down,

--- a/embassy-stm32/src/i2c/mod.rs
+++ b/embassy-stm32/src/i2c/mod.rs
@@ -158,7 +158,6 @@ impl<'d> I2c<'d, Async, Master> {
             + 'd,
         tx_dma: Peri<'d, impl TxDma<T>>,
         rx_dma: Peri<'d, impl RxDma<T>>,
-        freq: Hertz,
         config: Config,
     ) -> Self {
         Self::new_inner(
@@ -167,7 +166,6 @@ impl<'d> I2c<'d, Async, Master> {
             new_pin!(sda, config.sda_af()),
             new_dma!(tx_dma),
             new_dma!(rx_dma),
-            freq,
             config,
         )
     }
@@ -179,7 +177,6 @@ impl<'d> I2c<'d, Blocking, Master> {
         peri: Peri<'d, T>,
         scl: Peri<'d, impl SclPin<T>>,
         sda: Peri<'d, impl SdaPin<T>>,
-        freq: Hertz,
         config: Config,
     ) -> Self {
         Self::new_inner(
@@ -188,7 +185,6 @@ impl<'d> I2c<'d, Blocking, Master> {
             new_pin!(sda, config.sda_af()),
             None,
             None,
-            freq,
             config,
         )
     }
@@ -202,7 +198,6 @@ impl<'d, M: Mode> I2c<'d, M, Master> {
         sda: Option<Peri<'d, AnyPin>>,
         tx_dma: Option<ChannelAndRequest<'d>>,
         rx_dma: Option<ChannelAndRequest<'d>>,
-        freq: Hertz,
         config: Config,
     ) -> Self {
         unsafe { T::EventInterrupt::enable() };
@@ -224,14 +219,14 @@ impl<'d, M: Mode> I2c<'d, M, Master> {
                 sda,
             },
         };
-        this.enable_and_init(freq, config);
+        this.enable_and_init(config);
 
         this
     }
 
-    fn enable_and_init(&mut self, freq: Hertz, config: Config) {
+    fn enable_and_init(&mut self, config: Config) {
         self.info.rcc.enable_and_reset();
-        self.init(freq, config);
+        self.init(config);
     }
 }
 

--- a/embassy-stm32/src/i2c/v2.rs
+++ b/embassy-stm32/src/i2c/v2.rs
@@ -93,13 +93,13 @@ pub(crate) unsafe fn on_interrupt<T: Instance>() {
 }
 
 impl<'d, M: Mode, IM: MasterMode> I2c<'d, M, IM> {
-    pub(crate) fn init(&mut self, freq: Hertz, _config: Config) {
+    pub(crate) fn init(&mut self, config: Config) {
         self.info.regs.cr1().modify(|reg| {
             reg.set_pe(false);
             reg.set_anfoff(false);
         });
 
-        let timings = Timings::new(self.kernel_clock, freq.into());
+        let timings = Timings::new(self.kernel_clock, config.frequency.into());
 
         self.info.regs.timingr().write(|reg| {
             reg.set_presc(timings.prescale);

--- a/embassy-stm32/src/i2c/v2.rs
+++ b/embassy-stm32/src/i2c/v2.rs
@@ -1320,9 +1320,9 @@ struct Timings {
 }
 
 impl Timings {
-    fn new(i2cclk: Hertz, freq: Hertz) -> Self {
+    fn new(i2cclk: Hertz, frequency: Hertz) -> Self {
         let i2cclk = i2cclk.0;
-        let freq = freq.0;
+        let frequency = frequency.0;
         // Refer to RM0433 Rev 7 Figure 539 for setup and hold timing:
         //
         // t_I2CCLK = 1 / PCLK1
@@ -1332,13 +1332,13 @@ impl Timings {
         //
         // t_SYNC1 + t_SYNC2 > 4 * t_I2CCLK
         // t_SCL ~= t_SYNC1 + t_SYNC2 + t_SCLL + t_SCLH
-        let ratio = i2cclk / freq;
+        let ratio = i2cclk / frequency;
 
         // For the standard-mode configuration method, we must have a ratio of 4
         // or higher
         assert!(ratio >= 4, "The I2C PCLK must be at least 4 times the bus frequency!");
 
-        let (presc_reg, scll, sclh, sdadel, scldel) = if freq > 100_000 {
+        let (presc_reg, scll, sclh, sdadel, scldel) = if frequency > 100_000 {
             // Fast-mode (Fm) or Fast-mode Plus (Fm+)
             // here we pick SCLL + 1 = 2 * (SCLH + 1)
 
@@ -1352,7 +1352,7 @@ impl Timings {
             let sclh = ((ratio / presc) - 3) / 3;
             let scll = (2 * (sclh + 1)) - 1;
 
-            let (sdadel, scldel) = if freq > 400_000 {
+            let (sdadel, scldel) = if frequency > 400_000 {
                 // Fast-mode Plus (Fm+)
                 assert!(i2cclk >= 17_000_000); // See table in datsheet
 

--- a/embassy-stm32/src/spi/mod.rs
+++ b/embassy-stm32/src/spi/mod.rs
@@ -71,7 +71,7 @@ pub struct Config {
     pub miso_pull: Pull,
     /// signal rise/fall speed (slew rate) - defaults to `Medium`.
     /// Increase for high SPI speeds. Change to `Low` to reduce ringing.
-    pub rise_fall_speed: Speed,
+    pub gpio_speed: Speed,
 }
 
 impl Default for Config {
@@ -81,7 +81,7 @@ impl Default for Config {
             bit_order: BitOrder::MsbFirst,
             frequency: Hertz(1_000_000),
             miso_pull: Pull::None,
-            rise_fall_speed: Speed::VeryHigh,
+            gpio_speed: Speed::VeryHigh,
         }
     }
 }
@@ -110,14 +110,14 @@ impl Config {
 
     #[cfg(gpio_v1)]
     fn sck_af(&self) -> AfType {
-        AfType::output(OutputType::PushPull, self.rise_fall_speed)
+        AfType::output(OutputType::PushPull, self.gpio_speed)
     }
 
     #[cfg(gpio_v2)]
     fn sck_af(&self) -> AfType {
         AfType::output_pull(
             OutputType::PushPull,
-            self.rise_fall_speed,
+            self.gpio_speed,
             match self.mode.polarity {
                 Polarity::IdleLow => Pull::Down,
                 Polarity::IdleHigh => Pull::Up,
@@ -136,7 +136,7 @@ pub struct Spi<'d, M: PeriMode> {
     rx_dma: Option<ChannelAndRequest<'d>>,
     _phantom: PhantomData<M>,
     current_word_size: word_impl::Config,
-    rise_fall_speed: Speed,
+    gpio_speed: Speed,
 }
 
 impl<'d, M: PeriMode> Spi<'d, M> {
@@ -159,7 +159,7 @@ impl<'d, M: PeriMode> Spi<'d, M> {
             rx_dma,
             current_word_size: <u8 as SealedWord>::CONFIG,
             _phantom: PhantomData,
-            rise_fall_speed: config.rise_fall_speed,
+            gpio_speed: config.gpio_speed,
         };
         this.enable_and_init(config);
         this
@@ -265,12 +265,12 @@ impl<'d, M: PeriMode> Spi<'d, M> {
 
         #[cfg(gpio_v2)]
         {
-            self.rise_fall_speed = config.rise_fall_speed;
+            self.gpio_speed = config.gpio_speed;
             if let Some(sck) = self.sck.as_ref() {
-                sck.set_speed(config.rise_fall_speed);
+                sck.set_speed(config.gpio_speed);
             }
             if let Some(mosi) = self.mosi.as_ref() {
-                mosi.set_speed(config.rise_fall_speed);
+                mosi.set_speed(config.gpio_speed);
             }
         }
 
@@ -347,7 +347,7 @@ impl<'d, M: PeriMode> Spi<'d, M> {
             bit_order,
             frequency,
             miso_pull,
-            rise_fall_speed: self.rise_fall_speed,
+            gpio_speed: self.gpio_speed,
         }
     }
 
@@ -481,7 +481,7 @@ impl<'d> Spi<'d, Blocking> {
         Self::new_inner(
             peri,
             new_pin!(sck, config.sck_af()),
-            new_pin!(mosi, AfType::output(OutputType::PushPull, config.rise_fall_speed)),
+            new_pin!(mosi, AfType::output(OutputType::PushPull, config.gpio_speed)),
             new_pin!(miso, AfType::input(config.miso_pull)),
             None,
             None,
@@ -517,7 +517,7 @@ impl<'d> Spi<'d, Blocking> {
         Self::new_inner(
             peri,
             new_pin!(sck, config.sck_af()),
-            new_pin!(mosi, AfType::output(OutputType::PushPull, config.rise_fall_speed)),
+            new_pin!(mosi, AfType::output(OutputType::PushPull, config.gpio_speed)),
             None,
             None,
             None,
@@ -536,7 +536,7 @@ impl<'d> Spi<'d, Blocking> {
         Self::new_inner(
             peri,
             None,
-            new_pin!(mosi, AfType::output(OutputType::PushPull, config.rise_fall_speed)),
+            new_pin!(mosi, AfType::output(OutputType::PushPull, config.gpio_speed)),
             None,
             None,
             None,
@@ -559,7 +559,7 @@ impl<'d> Spi<'d, Async> {
         Self::new_inner(
             peri,
             new_pin!(sck, config.sck_af()),
-            new_pin!(mosi, AfType::output(OutputType::PushPull, config.rise_fall_speed)),
+            new_pin!(mosi, AfType::output(OutputType::PushPull, config.gpio_speed)),
             new_pin!(miso, AfType::input(config.miso_pull)),
             new_dma!(tx_dma),
             new_dma!(rx_dma),
@@ -601,7 +601,7 @@ impl<'d> Spi<'d, Async> {
         Self::new_inner(
             peri,
             new_pin!(sck, config.sck_af()),
-            new_pin!(mosi, AfType::output(OutputType::PushPull, config.rise_fall_speed)),
+            new_pin!(mosi, AfType::output(OutputType::PushPull, config.gpio_speed)),
             None,
             new_dma!(tx_dma),
             None,
@@ -621,7 +621,7 @@ impl<'d> Spi<'d, Async> {
         Self::new_inner(
             peri,
             None,
-            new_pin!(mosi, AfType::output(OutputType::PushPull, config.rise_fall_speed)),
+            new_pin!(mosi, AfType::output(OutputType::PushPull, config.gpio_speed)),
             None,
             new_dma!(tx_dma),
             None,

--- a/examples/stm32f4/src/bin/i2c.rs
+++ b/examples/stm32f4/src/bin/i2c.rs
@@ -4,7 +4,6 @@
 use defmt::*;
 use embassy_executor::Spawner;
 use embassy_stm32::i2c::{Error, I2c};
-use embassy_stm32::time::Hertz;
 use {defmt_rtt as _, panic_probe as _};
 
 const ADDRESS: u8 = 0x5F;
@@ -15,7 +14,7 @@ async fn main(_spawner: Spawner) {
     info!("Hello world!");
     let p = embassy_stm32::init(Default::default());
 
-    let mut i2c = I2c::new_blocking(p.I2C2, p.PB10, p.PB11, Hertz(100_000), Default::default());
+    let mut i2c = I2c::new_blocking(p.I2C2, p.PB10, p.PB11, Default::default());
 
     let mut data = [0u8; 1];
 

--- a/examples/stm32f4/src/bin/i2c_async.rs
+++ b/examples/stm32f4/src/bin/i2c_async.rs
@@ -7,7 +7,6 @@
 use defmt::*;
 use embassy_executor::Spawner;
 use embassy_stm32::i2c::I2c;
-use embassy_stm32::time::Hertz;
 use embassy_stm32::{bind_interrupts, i2c, peripherals};
 use {defmt_rtt as _, panic_probe as _};
 
@@ -30,7 +29,6 @@ async fn main(_spawner: Spawner) {
         Irqs,
         p.DMA1_CH6,
         p.DMA1_CH0,
-        Hertz(100_000),
         Default::default(),
     );
 

--- a/examples/stm32f4/src/bin/i2c_async.rs
+++ b/examples/stm32f4/src/bin/i2c_async.rs
@@ -22,15 +22,7 @@ async fn main(_spawner: Spawner) {
     info!("Hello world!");
     let p = embassy_stm32::init(Default::default());
 
-    let mut i2c = I2c::new(
-        p.I2C1,
-        p.PB8,
-        p.PB7,
-        Irqs,
-        p.DMA1_CH6,
-        p.DMA1_CH0,
-        Default::default(),
-    );
+    let mut i2c = I2c::new(p.I2C1, p.PB8, p.PB7, Irqs, p.DMA1_CH6, p.DMA1_CH0, Default::default());
 
     loop {
         let a1454_read_sensor_command = [0x1F];

--- a/examples/stm32f4/src/bin/i2c_comparison.rs
+++ b/examples/stm32f4/src/bin/i2c_comparison.rs
@@ -10,7 +10,6 @@
 use defmt::*;
 use embassy_executor::Spawner;
 use embassy_stm32::i2c::I2c;
-use embassy_stm32::time::Hertz;
 use embassy_stm32::{bind_interrupts, i2c, peripherals};
 use embassy_time::Instant;
 use futures_util::future::try_join3;
@@ -55,7 +54,6 @@ async fn main(_spawner: Spawner) {
         Irqs,
         p.DMA1_CH6,
         p.DMA1_CH0,
-        Hertz(100_000),
         Default::default(),
     );
 
@@ -66,7 +64,6 @@ async fn main(_spawner: Spawner) {
         Irqs,
         p.DMA1_CH7,
         p.DMA1_CH3,
-        Hertz(100_000),
         Default::default(),
     );
 
@@ -77,7 +74,6 @@ async fn main(_spawner: Spawner) {
         Irqs,
         p.DMA1_CH4,
         p.DMA1_CH2,
-        Hertz(100_000),
         Default::default(),
     );
 

--- a/examples/stm32f4/src/bin/i2c_comparison.rs
+++ b/examples/stm32f4/src/bin/i2c_comparison.rs
@@ -47,35 +47,11 @@ async fn main(_spawner: Spawner) {
     info!("Setting up peripherals.");
     let p = embassy_stm32::init(Default::default());
 
-    let mut i2c1 = I2c::new(
-        p.I2C1,
-        p.PB8,
-        p.PB7,
-        Irqs,
-        p.DMA1_CH6,
-        p.DMA1_CH0,
-        Default::default(),
-    );
+    let mut i2c1 = I2c::new(p.I2C1, p.PB8, p.PB7, Irqs, p.DMA1_CH6, p.DMA1_CH0, Default::default());
 
-    let mut i2c2 = I2c::new(
-        p.I2C2,
-        p.PB10,
-        p.PB11,
-        Irqs,
-        p.DMA1_CH7,
-        p.DMA1_CH3,
-        Default::default(),
-    );
+    let mut i2c2 = I2c::new(p.I2C2, p.PB10, p.PB11, Irqs, p.DMA1_CH7, p.DMA1_CH3, Default::default());
 
-    let mut i2c3 = I2c::new(
-        p.I2C3,
-        p.PA8,
-        p.PC9,
-        Irqs,
-        p.DMA1_CH4,
-        p.DMA1_CH2,
-        Default::default(),
-    );
+    let mut i2c3 = I2c::new(p.I2C3, p.PA8, p.PC9, Irqs, p.DMA1_CH4, p.DMA1_CH2, Default::default());
 
     let a1454_read_sensor_command = [0x1F];
     let mut i2c1_buffer: [u8; 4] = [0, 0, 0, 0];

--- a/examples/stm32f4/src/bin/i2s_dma.rs
+++ b/examples/stm32f4/src/bin/i2s_dma.rs
@@ -72,7 +72,6 @@ async fn main(_spawner: Spawner) {
         p.PB3,  // ck
         p.DMA1_CH7,
         &mut dma_buffer,
-        Hertz(48_000),
         i2s_config,
     );
     i2s.start();

--- a/examples/stm32g0/src/bin/i2c_async.rs
+++ b/examples/stm32g0/src/bin/i2c_async.rs
@@ -22,15 +22,7 @@ async fn main(_spawner: Spawner) {
     let p = embassy_stm32::init(Default::default());
 
     let mut data = [0u8; 2];
-    let mut i2c = I2c::new(
-        p.I2C1,
-        p.PB8,
-        p.PB9,
-        Irqs,
-        p.DMA1_CH1,
-        p.DMA1_CH2,
-        Default::default(),
-    );
+    let mut i2c = I2c::new(p.I2C1, p.PB8, p.PB9, Irqs, p.DMA1_CH1, p.DMA1_CH2, Default::default());
 
     loop {
         match i2c.write_read(TMP117_ADDR, &[TMP117_TEMP_RESULT], &mut data).await {

--- a/examples/stm32g0/src/bin/i2c_async.rs
+++ b/examples/stm32g0/src/bin/i2c_async.rs
@@ -4,7 +4,6 @@
 use defmt::*;
 use embassy_executor::Spawner;
 use embassy_stm32::i2c::{self, I2c};
-use embassy_stm32::time::Hertz;
 use embassy_stm32::{bind_interrupts, peripherals};
 use embassy_time::{Duration, Timer};
 use {defmt_rtt as _, panic_probe as _};
@@ -30,7 +29,6 @@ async fn main(_spawner: Spawner) {
         Irqs,
         p.DMA1_CH1,
         p.DMA1_CH2,
-        Hertz(100_000),
         Default::default(),
     );
 

--- a/examples/stm32g4/src/bin/i2c_slave.rs
+++ b/examples/stm32g4/src/bin/i2c_slave.rs
@@ -6,7 +6,6 @@ use defmt::*;
 use embassy_executor::Spawner;
 use embassy_stm32::i2c::{Address, OwnAddresses, SlaveCommandKind};
 use embassy_stm32::mode::Async;
-use embassy_stm32::time::Hertz;
 use embassy_stm32::{bind_interrupts, i2c, peripherals};
 use embassy_time::Timer;
 use {defmt_rtt as _, panic_probe as _};
@@ -127,8 +126,8 @@ async fn main(spawner: Spawner) {
     let p = embassy_stm32::init(Default::default());
     info!("Hello World!");
 
-    let speed = Hertz::khz(400);
-    let config = i2c::Config::default();
+    let mut config = i2c::Config::default();
+    config.frequency = Hertz::khz(400);
 
     let d_addr_config = i2c::SlaveAddrConfig {
         addr: OwnAddresses::OA1(Address::SevenBit(DEV_ADDR)),
@@ -136,14 +135,14 @@ async fn main(spawner: Spawner) {
     };
     let d_sda = p.PA8;
     let d_scl = p.PA9;
-    let device = i2c::I2c::new(p.I2C2, d_scl, d_sda, Irqs, p.DMA1_CH1, p.DMA1_CH2, speed, config)
+    let device = i2c::I2c::new(p.I2C2, d_scl, d_sda, Irqs, p.DMA1_CH1, p.DMA1_CH2, config)
         .into_slave_multimaster(d_addr_config);
 
     unwrap!(spawner.spawn(device_task(device)));
 
     let c_sda = p.PB8;
     let c_scl = p.PB7;
-    let controller = i2c::I2c::new(p.I2C1, c_sda, c_scl, Irqs, p.DMA1_CH3, p.DMA1_CH4, speed, config);
+    let controller = i2c::I2c::new(p.I2C1, c_sda, c_scl, Irqs, p.DMA1_CH3, p.DMA1_CH4, config);
 
     unwrap!(spawner.spawn(controller_task(controller)));
 }

--- a/examples/stm32g4/src/bin/i2c_slave.rs
+++ b/examples/stm32g4/src/bin/i2c_slave.rs
@@ -135,8 +135,8 @@ async fn main(spawner: Spawner) {
     };
     let d_sda = p.PA8;
     let d_scl = p.PA9;
-    let device = i2c::I2c::new(p.I2C2, d_scl, d_sda, Irqs, p.DMA1_CH1, p.DMA1_CH2, config)
-        .into_slave_multimaster(d_addr_config);
+    let device =
+        i2c::I2c::new(p.I2C2, d_scl, d_sda, Irqs, p.DMA1_CH1, p.DMA1_CH2, config).into_slave_multimaster(d_addr_config);
 
     unwrap!(spawner.spawn(device_task(device)));
 

--- a/examples/stm32g4/src/bin/i2c_slave.rs
+++ b/examples/stm32g4/src/bin/i2c_slave.rs
@@ -6,6 +6,7 @@ use defmt::*;
 use embassy_executor::Spawner;
 use embassy_stm32::i2c::{Address, OwnAddresses, SlaveCommandKind};
 use embassy_stm32::mode::Async;
+use embassy_stm32::time::Hertz;
 use embassy_stm32::{bind_interrupts, i2c, peripherals};
 use embassy_time::Timer;
 use {defmt_rtt as _, panic_probe as _};

--- a/examples/stm32h5/src/bin/i2c.rs
+++ b/examples/stm32h5/src/bin/i2c.rs
@@ -4,7 +4,6 @@
 use defmt::*;
 use embassy_executor::Spawner;
 use embassy_stm32::i2c::{Error, I2c};
-use embassy_stm32::time::Hertz;
 use embassy_stm32::{bind_interrupts, i2c, peripherals};
 use {defmt_rtt as _, panic_probe as _};
 
@@ -28,7 +27,6 @@ async fn main(_spawner: Spawner) {
         Irqs,
         p.GPDMA1_CH4,
         p.GPDMA1_CH5,
-        Hertz(100_000),
         Default::default(),
     );
 

--- a/examples/stm32h7/src/bin/camera.rs
+++ b/examples/stm32h7/src/bin/camera.rs
@@ -51,15 +51,7 @@ async fn main(_spawner: Spawner) {
     let mco = Mco::new(p.MCO1, p.PA8, Mco1Source::HSI, McoPrescaler::DIV3);
 
     let mut led = Output::new(p.PE3, Level::High, Speed::Low);
-    let cam_i2c = I2c::new(
-        p.I2C1,
-        p.PB8,
-        p.PB9,
-        Irqs,
-        p.DMA1_CH1,
-        p.DMA1_CH2,
-        Default::default(),
-    );
+    let cam_i2c = I2c::new(p.I2C1, p.PB8, p.PB9, Irqs, p.DMA1_CH1, p.DMA1_CH2, Default::default());
 
     let mut camera = Ov7725::new(cam_i2c, mco);
 

--- a/examples/stm32h7/src/bin/camera.rs
+++ b/examples/stm32h7/src/bin/camera.rs
@@ -6,7 +6,6 @@ use embassy_stm32::dcmi::{self, *};
 use embassy_stm32::gpio::{Level, Output, Speed};
 use embassy_stm32::i2c::I2c;
 use embassy_stm32::rcc::{Mco, Mco1Source, McoPrescaler};
-use embassy_stm32::time::khz;
 use embassy_stm32::{bind_interrupts, i2c, peripherals, Config};
 use embassy_time::Timer;
 use ov7725::*;
@@ -59,7 +58,6 @@ async fn main(_spawner: Spawner) {
         Irqs,
         p.DMA1_CH1,
         p.DMA1_CH2,
-        khz(100),
         Default::default(),
     );
 

--- a/examples/stm32h7/src/bin/i2c.rs
+++ b/examples/stm32h7/src/bin/i2c.rs
@@ -4,7 +4,6 @@
 use defmt::*;
 use embassy_executor::Spawner;
 use embassy_stm32::i2c::{Error, I2c};
-use embassy_stm32::time::Hertz;
 use embassy_stm32::{bind_interrupts, i2c, peripherals};
 use {defmt_rtt as _, panic_probe as _};
 
@@ -28,7 +27,6 @@ async fn main(_spawner: Spawner) {
         Irqs,
         p.DMA1_CH4,
         p.DMA1_CH5,
-        Hertz(100_000),
         Default::default(),
     );
 

--- a/examples/stm32h7/src/bin/i2c.rs
+++ b/examples/stm32h7/src/bin/i2c.rs
@@ -20,15 +20,7 @@ async fn main(_spawner: Spawner) {
     info!("Hello world!");
     let p = embassy_stm32::init(Default::default());
 
-    let mut i2c = I2c::new(
-        p.I2C2,
-        p.PB10,
-        p.PB11,
-        Irqs,
-        p.DMA1_CH4,
-        p.DMA1_CH5,
-        Default::default(),
-    );
+    let mut i2c = I2c::new(p.I2C2, p.PB10, p.PB11, Irqs, p.DMA1_CH4, p.DMA1_CH5, Default::default());
 
     let mut data = [0u8; 1];
 

--- a/examples/stm32h7/src/bin/i2c_shared.rs
+++ b/examples/stm32h7/src/bin/i2c_shared.rs
@@ -8,7 +8,6 @@ use embassy_embedded_hal::shared_bus::blocking::i2c::I2cDevice;
 use embassy_executor::Spawner;
 use embassy_stm32::i2c::{self, I2c};
 use embassy_stm32::mode::Async;
-use embassy_stm32::time::Hertz;
 use embassy_stm32::{bind_interrupts, peripherals};
 use embassy_sync::blocking_mutex::raw::NoopRawMutex;
 use embassy_sync::blocking_mutex::NoopMutex;
@@ -97,7 +96,6 @@ async fn main(spawner: Spawner) {
         Irqs,
         p.DMA1_CH4,
         p.DMA1_CH5,
-        Hertz(100_000),
         Default::default(),
     );
     let i2c_bus = NoopMutex::new(RefCell::new(i2c));

--- a/examples/stm32h7/src/bin/i2c_shared.rs
+++ b/examples/stm32h7/src/bin/i2c_shared.rs
@@ -89,15 +89,7 @@ async fn humidity(mut i2c: I2cDevice<'static, NoopRawMutex, I2c<'static, Async, 
 async fn main(spawner: Spawner) {
     let p = embassy_stm32::init(Default::default());
 
-    let i2c = I2c::new(
-        p.I2C1,
-        p.PB8,
-        p.PB9,
-        Irqs,
-        p.DMA1_CH4,
-        p.DMA1_CH5,
-        Default::default(),
-    );
+    let i2c = I2c::new(p.I2C1, p.PB8, p.PB9, Irqs, p.DMA1_CH4, p.DMA1_CH5, Default::default());
     let i2c_bus = NoopMutex::new(RefCell::new(i2c));
     let i2c_bus = I2C_BUS.init(i2c_bus);
 

--- a/examples/stm32h7rs/src/bin/i2c.rs
+++ b/examples/stm32h7rs/src/bin/i2c.rs
@@ -4,7 +4,6 @@
 use defmt::*;
 use embassy_executor::Spawner;
 use embassy_stm32::i2c::{Error, I2c};
-use embassy_stm32::time::Hertz;
 use embassy_stm32::{bind_interrupts, i2c, peripherals};
 use {defmt_rtt as _, panic_probe as _};
 
@@ -28,7 +27,6 @@ async fn main(_spawner: Spawner) {
         Irqs,
         p.GPDMA1_CH4,
         p.GPDMA1_CH5,
-        Hertz(100_000),
         Default::default(),
     );
 

--- a/examples/stm32l4/src/bin/i2c.rs
+++ b/examples/stm32l4/src/bin/i2c.rs
@@ -4,7 +4,6 @@
 use defmt::*;
 use embassy_executor::Spawner;
 use embassy_stm32::i2c::I2c;
-use embassy_stm32::time::Hertz;
 use {defmt_rtt as _, panic_probe as _};
 
 const ADDRESS: u8 = 0x5F;
@@ -13,7 +12,7 @@ const WHOAMI: u8 = 0x0F;
 #[embassy_executor::main]
 async fn main(_spawner: Spawner) {
     let p = embassy_stm32::init(Default::default());
-    let mut i2c = I2c::new_blocking(p.I2C2, p.PB10, p.PB11, Hertz(100_000), Default::default());
+    let mut i2c = I2c::new_blocking(p.I2C2, p.PB10, p.PB11, Default::default());
 
     let mut data = [0u8; 1];
     unwrap!(i2c.blocking_write_read(ADDRESS, &[WHOAMI], &mut data));

--- a/examples/stm32l4/src/bin/i2c_blocking_async.rs
+++ b/examples/stm32l4/src/bin/i2c_blocking_async.rs
@@ -5,7 +5,6 @@ use defmt::*;
 use embassy_embedded_hal::adapter::BlockingAsync;
 use embassy_executor::Spawner;
 use embassy_stm32::i2c::I2c;
-use embassy_stm32::time::Hertz;
 use embedded_hal_async::i2c::I2c as I2cTrait;
 use {defmt_rtt as _, panic_probe as _};
 
@@ -15,7 +14,7 @@ const WHOAMI: u8 = 0x0F;
 #[embassy_executor::main]
 async fn main(_spawner: Spawner) {
     let p = embassy_stm32::init(Default::default());
-    let i2c = I2c::new_blocking(p.I2C2, p.PB10, p.PB11, Hertz(100_000), Default::default());
+    let i2c = I2c::new_blocking(p.I2C2, p.PB10, p.PB11, Default::default());
     let mut i2c = BlockingAsync::new(i2c);
 
     let mut data = [0u8; 1];

--- a/examples/stm32l4/src/bin/i2c_dma.rs
+++ b/examples/stm32l4/src/bin/i2c_dma.rs
@@ -4,7 +4,6 @@
 use defmt::*;
 use embassy_executor::Spawner;
 use embassy_stm32::i2c::I2c;
-use embassy_stm32::time::Hertz;
 use embassy_stm32::{bind_interrupts, i2c, peripherals};
 use {defmt_rtt as _, panic_probe as _};
 
@@ -26,7 +25,6 @@ async fn main(_spawner: Spawner) {
         Irqs,
         p.DMA1_CH4,
         p.DMA1_CH5,
-        Hertz(100_000),
         Default::default(),
     );
 

--- a/examples/stm32l4/src/bin/i2c_dma.rs
+++ b/examples/stm32l4/src/bin/i2c_dma.rs
@@ -18,15 +18,7 @@ bind_interrupts!(struct Irqs {
 #[embassy_executor::main]
 async fn main(_spawner: Spawner) {
     let p = embassy_stm32::init(Default::default());
-    let mut i2c = I2c::new(
-        p.I2C2,
-        p.PB10,
-        p.PB11,
-        Irqs,
-        p.DMA1_CH4,
-        p.DMA1_CH5,
-        Default::default(),
-    );
+    let mut i2c = I2c::new(p.I2C2, p.PB10, p.PB11, Irqs, p.DMA1_CH4, p.DMA1_CH5, Default::default());
 
     let mut data = [0u8; 1];
     unwrap!(i2c.write_read(ADDRESS, &[WHOAMI], &mut data).await);

--- a/examples/stm32l4/src/bin/spe_adin1110_http_server.rs
+++ b/examples/stm32l4/src/bin/spe_adin1110_http_server.rs
@@ -115,7 +115,6 @@ async fn main(spawner: Spawner) {
         Irqs,
         dp.DMA1_CH6,
         dp.DMA1_CH7,
-        Hertz(100_000),
         I2C_Config::default(),
     );
 

--- a/examples/stm32u0/src/bin/i2c.rs
+++ b/examples/stm32u0/src/bin/i2c.rs
@@ -4,7 +4,6 @@
 use defmt::*;
 use embassy_executor::Spawner;
 use embassy_stm32::i2c::I2c;
-use embassy_stm32::time::Hertz;
 use {defmt_rtt as _, panic_probe as _};
 
 const ADDRESS: u8 = 0x5F;
@@ -13,7 +12,7 @@ const WHOAMI: u8 = 0x0F;
 #[embassy_executor::main]
 async fn main(_spawner: Spawner) {
     let p = embassy_stm32::init(Default::default());
-    let mut i2c = I2c::new_blocking(p.I2C2, p.PB10, p.PB11, Hertz(100_000), Default::default());
+    let mut i2c = I2c::new_blocking(p.I2C2, p.PB10, p.PB11, Default::default());
 
     let mut data = [0u8; 1];
     unwrap!(i2c.blocking_write_read(ADDRESS, &[WHOAMI], &mut data));

--- a/examples/stm32u5/src/bin/i2c.rs
+++ b/examples/stm32u5/src/bin/i2c.rs
@@ -4,7 +4,6 @@
 use defmt::{info, unwrap};
 use embassy_executor::Spawner;
 use embassy_stm32::i2c::I2c;
-use embassy_stm32::time::Hertz;
 use {defmt_rtt as _, panic_probe as _};
 
 const HTS221_ADDRESS: u8 = 0x5F;
@@ -13,7 +12,7 @@ const WHOAMI: u8 = 0x0F;
 #[embassy_executor::main]
 async fn main(_spawner: Spawner) {
     let p = embassy_stm32::init(Default::default());
-    let mut i2c = I2c::new_blocking(p.I2C2, p.PF1, p.PF0, Hertz(100_000), Default::default());
+    let mut i2c = I2c::new_blocking(p.I2C2, p.PF1, p.PF0, Default::default());
 
     let mut data = [0u8; 1];
     unwrap!(i2c.blocking_write_read(HTS221_ADDRESS, &[WHOAMI], &mut data));


### PR DESCRIPTION
Fixes [#4510](https://github.com/embassy-rs/embassy/issues/4513)
Also did a little bit cleanup to unify naming for config params.