### PR TITLE
Added VREFBUF-TRIM manual write. Known errata

### DIFF
--- a/embassy-stm32/src/vrefbuf/mod.rs
+++ b/embassy-stm32/src/vrefbuf/mod.rs
@@ -1,5 +1,4 @@
 //! Voltage Reference Buffer (VREFBUF)
-// use core::ptr::{read_volatile, write_volatile};
 use core::marker::PhantomData;
 
 use embassy_hal_internal::PeripheralType;
@@ -12,6 +11,26 @@ pub struct VoltageReferenceBuffer<'d, T: Instance> {
     vrefbuf: PhantomData<&'d mut T>,
 }
 
+#[cfg(rcc_wba)]
+#[repr(usize)]
+enum VRefBufTrim {
+    VRefBuf3Trim = 0x0BFA_07A8,
+    VRefBuf2Trim = 0x0BFA_07A9,
+    VRefBuf1Trim = 0x0BFA_07AA,
+    VRefBuf0Trim = 0x0BFA_07AB,
+}
+
+#[cfg(rcc_wba)]
+fn get_refbuf_trim(voltage_scale: Vrs) -> VRefBufTrim {
+    match voltage_scale {
+        Vrs::VREF0 => VRefBufTrim::VRefBuf0Trim,
+        Vrs::VREF1 => VRefBufTrim::VRefBuf1Trim,
+        Vrs::VREF2 => VRefBufTrim::VRefBuf2Trim,
+        Vrs::VREF3 => VRefBufTrim::VRefBuf3Trim,
+        _ => panic!("Incorrect Vrs setting!"),
+    }
+}
+
 impl<'d, T: Instance> VoltageReferenceBuffer<'d, T> {
     /// Creates an VREFBUF (Voltage Reference) instance with a voltage scale and impedance mode.
     ///
@@ -21,6 +40,15 @@ impl<'d, T: Instance> VoltageReferenceBuffer<'d, T> {
         {
             use crate::pac::RCC;
             RCC.apb7enr().modify(|w| w.set_vrefen(true));
+            // This is an errata for WBA6 devices. VREFBUF_TRIM value isn't set correctly
+            // [Link explaining it](https://www.st.com/resource/en/errata_sheet/es0644-stm32wba6xxx-device-errata-stmicroelectronics.pdf)
+            unsafe {
+                use crate::pac::VREFBUF;
+                let addr = get_refbuf_trim(voltage_scale) as usize;
+                let buf_trim_ptr = core::ptr::with_exposed_provenance::<u32>(addr);
+                let trim_val = core::ptr::read_volatile(buf_trim_ptr);
+                VREFBUF.ccr().write(|w| w.set_trim((trim_val & 0xFF) as u8));
+            }
         }
         #[cfg(any(rcc_u5, rcc_h50, rcc_h5))]
         {


### PR DESCRIPTION
VREFBUF has TRIM values at known memory locations.
<img width="1736" height="676" alt="Screenshot 2025-08-12 at 7 05 53 PM" src="https://github.com/user-attachments/assets/2ad2f088-7ff0-45f5-898a-26abc1387398" />

This PR updates the new VREFBUF implementation to provide proper support for its initialization.
<img width="1300" height="824" alt="Screenshot 2025-08-12 at 7 05 09 PM" src="https://github.com/user-attachments/assets/83dc3d83-3ece-4cd9-bee6-60af3387dd6c" />

Any feedback is welcome 😄 