### PR TITLE
fix stm32 i2c: wait for STOP flag in blocking read to terminate read transaction

### DIFF
--- a/embassy-stm32/src/i2c/v2.rs
+++ b/embassy-stm32/src/i2c/v2.rs
@@ -408,6 +408,7 @@ impl<'d, M: Mode, IM: MasterMode> I2c<'d, M, IM> {
                 *byte = self.info.regs.rxdr().read().rxdata();
             }
         }
+        self.wait_stop(timeout)?;
         Ok(())
     }
 

--- a/embassy-stm32/src/i2c/v2.rs
+++ b/embassy-stm32/src/i2c/v2.rs
@@ -464,11 +464,13 @@ impl<'d, M: Mode, IM: MasterMode> I2c<'d, M, IM> {
             }
         }
         // Wait until the write finishes
-        let result = self.wait_tc(timeout);
+        self.wait_tc(timeout)?;
         if send_stop {
             self.master_stop();
+            self.wait_stop(timeout)?;
         }
-        result
+
+        Ok(())
     }
 
     // =========================


### PR DESCRIPTION
This PR fixes a bug where subsequent blocking I2C reads would fail with a timeout.

The read_internal function, which uses Stop::Automatic, was returning before the STOP condition was actually complete on the bus. This created a race condition where the next transaction would start while the bus was still busy.

The fix is to call wait_stop() at the end of the read. This ensures the transaction is fully terminated and the bus is idle before the function returns.

Fixes #4540 