### PR TITLE
fix STM32: wait for STOP flag in blocking_write_vectored

### DIFF
--- a/embassy-stm32/src/i2c/v2.rs
+++ b/embassy-stm32/src/i2c/v2.rs
@@ -582,9 +582,11 @@ impl<'d, M: Mode, IM: MasterMode> I2c<'d, M, IM> {
             }
         }
         // Wait until the write finishes
-        let result = self.wait_tc(timeout);
+        self.wait_tc(timeout)?;
         self.master_stop();
-        result
+        self.wait_stop(timeout)?;
+
+        Ok(())
     }
 }
 


### PR DESCRIPTION
One more addition to the already merged PR #4541
The blocking_write_vectored function had the same issue as the blocking_read and blocking_write functions. 
Confirmed now working on my test bench