### PR TITLE
STM32F1: Add I2S

### DIFF
--- a/embassy-stm32/CHANGELOG.md
+++ b/embassy-stm32/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 <!-- next-header -->
 ## Unreleased - ReleaseDate
 
+- feat: Added I²S for STM32F1 ([#4544](https://github.com/embassy-rs/embassy/pull/4544))
+
 ## 0.3.0 - 2025-08-12
 
 - feat: Added VREFBUF voltage reference buffer driver ([#4524](https://github.com/embassy-rs/embassy/pull/4524))

--- a/embassy-stm32/src/lib.rs
+++ b/embassy-stm32/src/lib.rs
@@ -87,7 +87,13 @@ pub mod hsem;
 pub mod hspi;
 #[cfg(i2c)]
 pub mod i2c;
-#[cfg(any(all(spi_v1, rcc_f4), spi_v3))]
+#[cfg(any(
+    all(spi_v1, rcc_f4),
+    all(stm32f103, any(flashsize_c, flashsize_d, flashsize_e)),
+    stm32f105,
+    stm32f107,
+    spi_v3,
+))]
 pub mod i2s;
 #[cfg(stm32wb)]
 pub mod ipcc;


### PR DESCRIPTION
The SPI cubedb XML files are shared across F1 devices that have and do not have I2S. Therefore, I didn't make the change in perimap or via the peripheral version cfg.
STM32F100 and F101 do not have I2S.
<img width="1111" height="666" alt="grafik" src="https://github.com/user-attachments/assets/38a6c32b-78ce-4efa-86b3-db4b07ec0412" />
