### PR TITLE
Use from_bits with LoopCnt

### DIFF
--- a/embassy-nrf/src/pwm.rs
+++ b/embassy-nrf/src/pwm.rs
@@ -480,7 +480,7 @@ impl<'d, 's, T: Instance> Sequencer<'d, 's, T> {
 
         match times {
             SequenceMode::Loop(n) => {
-                r.loop_().write(|w| w.set_cnt(vals::LoopCnt(n)));
+                r.loop_().write(|w| w.set_cnt(vals::LoopCnt::from_bits(n)));
             }
             // to play infinitely, repeat the sequence one time, then have loops done self trigger seq0 again
             SequenceMode::Infinite => {


### PR DESCRIPTION
Tiny change to make `embassy-nrf` ready for future `nrf-pac` updates (e.g. nrf54 updates). Since the release of `nrf-pac` in Jan 2025, `chiptool` has been updated to make the inner integer in Newtypes private. `LoopCnt(n)` will thus break when the pacs are updated in the future with new versions of `chiptool`. `LoopCnt::from_bits(n)` is already supported and currently used in the `pwm` module. 