### PR TITLE
Fix vrefbuf trace with log

### DIFF
--- a/ci.sh
+++ b/ci.sh
@@ -148,7 +148,7 @@ cargo batch \
     --- build --release --manifest-path embassy-stm32/Cargo.toml --target thumbv7em-none-eabi --features stm32h7b3ai,defmt,exti,time-driver-tim1,time \
     --- build --release --manifest-path embassy-stm32/Cargo.toml --target thumbv7em-none-eabi --features stm32h7r3z8,defmt,exti,time-driver-tim1,time \
     --- build --release --manifest-path embassy-stm32/Cargo.toml --target thumbv7em-none-eabi --features stm32h7r7a8,defmt,exti,time-driver-tim1,time \
-    --- build --release --manifest-path embassy-stm32/Cargo.toml --target thumbv7em-none-eabi --features stm32h7s3a8,defmt,exti,time-driver-tim1,time \
+    --- build --release --manifest-path embassy-stm32/Cargo.toml --target thumbv7em-none-eabi --features stm32h7s3a8,log,exti,time-driver-tim1,time \
     --- build --release --manifest-path embassy-stm32/Cargo.toml --target thumbv7em-none-eabi --features stm32h7s7z8,defmt,exti,time-driver-tim1,time \
     --- build --release --manifest-path embassy-stm32/Cargo.toml --target thumbv7em-none-eabi --features stm32l431cb,defmt,exti,time-driver-any,time \
     --- build --release --manifest-path embassy-stm32/Cargo.toml --target thumbv7em-none-eabi --features stm32l476vg,defmt,exti,time-driver-any,time \

--- a/embassy-stm32/CHANGELOG.md
+++ b/embassy-stm32/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 <!-- next-header -->
 ## Unreleased - ReleaseDate
 
+- fix: Fix vrefbuf building with log feature
+
 ## 0.3.0 - 2025-08-12
 
 - feat: Added VREFBUF voltage reference buffer driver ([#4524](https://github.com/embassy-rs/embassy/pull/4524))

--- a/embassy-stm32/src/vrefbuf/mod.rs
+++ b/embassy-stm32/src/vrefbuf/mod.rs
@@ -62,8 +62,8 @@ impl<'d, T: Instance> VoltageReferenceBuffer<'d, T> {
         }
         trace!(
             "Vrefbuf configured with voltage scale {} and impedance mode {}",
-            voltage_scale,
-            impedance_mode
+            voltage_scale as u8,
+            impedance_mode as u8,
         );
         VoltageReferenceBuffer { vrefbuf: PhantomData }
     }


### PR DESCRIPTION
This was failing with
```
error[E0277]: `stm32_metapac::vrefbuf::vals::Vrs` doesn't implement `Display`
  --> /home/matt/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/embassy-stm32-0.3.0/src/vrefbuf/mod.rs:46:13
   |
45 |             "Vrefbuf configured with voltage scale {} and impedance mode {}",
   |                                                    -- required by this formatting parameter
46 |             voltage_scale,
   |             ^^^^^^^^^^^^^ `stm32_metapac::vrefbuf::vals::Vrs` cannot be formatted with the default formatter
   |
   = help: the trait `Display` is not implemented for `stm32_metapac::vrefbuf::vals::Vrs`

```