### PR TITLE
feat(embassy-time): add Ticker::now_and_every

### DIFF
--- a/embassy-time/CHANGELOG.md
+++ b/embassy-time/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add `saturating_add` and `saturating_sub` to `Instant`
 - Add `Instant::try_from_*` constructor functions
 - Add `Duration::try_from_*` constructor functions
+- Add `Ticker::now_and_every` constructor function
 - Don't select `critical-section` impl for `std`
 - Manually implement the future for `with_timeout`
 - Add 133MHz tick rate to support PR2040 @ 133MHz when `TIMERx`'s `SOURCE` is set to `SYSCLK`

--- a/embassy-time/src/timer.rs
+++ b/embassy-time/src/timer.rs
@@ -246,6 +246,12 @@ impl Ticker {
         Self { expires_at, duration }
     }
 
+    /// Creates a new ticker that ticks immediately, and then at the specified duration interval.
+    pub fn now_and_every(duration: Duration) -> Self {
+        let expires_at = Instant::now();
+        Self { expires_at, duration }
+    }
+
     /// Resets the ticker back to its original state.
     /// This causes the ticker to go back to zero, even if the current tick isn't over yet.
     pub fn reset(&mut self) {


### PR DESCRIPTION
I use Ticker to run a process X seconds, but I'd like that process' first run to be immediately rather than X seconds after boot. In my situation, I can't just put the `ticker.next().await;` after the process, because I `select()` it with something else.