### PR TITLE
fix: add adc ref to rp channel creation funcs

### DIFF
--- a/embassy-rp/src/adc.rs
+++ b/embassy-rp/src/adc.rs
@@ -33,7 +33,7 @@ pub struct Channel<'p>(Source<'p>);
 
 impl<'p> Channel<'p> {
     /// Create a new ADC channel from pin with the provided [Pull] configuration.
-    pub fn new_pin(pin: Peri<'p, impl AdcPin + 'p>, pull: Pull) -> Self {
+    pub fn new_pin(_adc: &Adc<'_, impl Mode>, pin: Peri<'p, impl AdcPin + 'p>, pull: Pull) -> Self {
         pin.pad_ctrl().modify(|w| {
             #[cfg(feature = "_rp235x")]
             w.set_iso(false);
@@ -51,7 +51,7 @@ impl<'p> Channel<'p> {
     }
 
     /// Create a new ADC channel for the internal temperature sensor.
-    pub fn new_temp_sensor(s: Peri<'p, ADC_TEMP_SENSOR>) -> Self {
+    pub fn new_temp_sensor(_adc: &Adc<'_, impl Mode>, s: Peri<'p, ADC_TEMP_SENSOR>) -> Self {
         let r = pac::ADC;
         r.cs().write_set(|w| w.set_ts_en(true));
         Self(Source::TempSensor(s))

--- a/examples/rp/src/bin/adc.rs
+++ b/examples/rp/src/bin/adc.rs
@@ -24,10 +24,10 @@ async fn main(_spawner: Spawner) {
     let p = embassy_rp::init(Default::default());
     let mut adc = Adc::new(p.ADC, Irqs, Config::default());
 
-    let mut p26 = Channel::new_pin(p.PIN_26, Pull::None);
-    let mut p27 = Channel::new_pin(p.PIN_27, Pull::None);
-    let mut p28 = Channel::new_pin(p.PIN_28, Pull::None);
-    let mut ts = Channel::new_temp_sensor(p.ADC_TEMP_SENSOR);
+    let mut p26 = Channel::new_pin(&adc, p.PIN_26, Pull::None);
+    let mut p27 = Channel::new_pin(&adc, p.PIN_27, Pull::None);
+    let mut p28 = Channel::new_pin(&adc, p.PIN_28, Pull::None);
+    let mut ts = Channel::new_temp_sensor(&adc, p.ADC_TEMP_SENSOR);
 
     loop {
         let level = adc.read(&mut p26).await.unwrap();

--- a/examples/rp/src/bin/adc_dma.rs
+++ b/examples/rp/src/bin/adc_dma.rs
@@ -23,12 +23,12 @@ async fn main(_spawner: Spawner) {
 
     let mut adc = Adc::new(p.ADC, Irqs, Config::default());
     let mut dma = p.DMA_CH0;
-    let mut pin = Channel::new_pin(p.PIN_26, Pull::Up);
+    let mut pin = Channel::new_pin(&adc, p.PIN_26, Pull::Up);
     let mut pins = [
-        Channel::new_pin(p.PIN_27, Pull::Down),
-        Channel::new_pin(p.PIN_28, Pull::None),
-        Channel::new_pin(p.PIN_29, Pull::Up),
-        Channel::new_temp_sensor(p.ADC_TEMP_SENSOR),
+        Channel::new_pin(&adc, p.PIN_27, Pull::Down),
+        Channel::new_pin(&adc, p.PIN_28, Pull::None),
+        Channel::new_pin(&adc, p.PIN_29, Pull::Up),
+        Channel::new_temp_sensor(&adc, p.ADC_TEMP_SENSOR),
     ];
 
     const BLOCK_SIZE: usize = 100;

--- a/examples/rp/src/bin/interrupt.rs
+++ b/examples/rp/src/bin/interrupt.rs
@@ -35,7 +35,7 @@ async fn main(spawner: Spawner) {
     let p = embassy_rp::init(Default::default());
 
     let adc = Adc::new_blocking(p.ADC, Default::default());
-    let p26 = adc::Channel::new_pin(p.PIN_26, Pull::None);
+    let p26 = adc::Channel::new_pin(&adc, p.PIN_26, Pull::None);
     ADC.lock(|a| a.borrow_mut().replace((adc, p26)));
 
     let pwm = Pwm::new_output_b(p.PWM_SLICE4, p.PIN_25, Default::default());

--- a/examples/rp/src/bin/orchestrate_tasks.rs
+++ b/examples/rp/src/bin/orchestrate_tasks.rs
@@ -306,7 +306,7 @@ pub async fn usb_power(_spawner: Spawner, r: Vbus) {
 pub async fn vsys_voltage(_spawner: Spawner, r: Vsys) {
     let mut adc = Adc::new(r.adc, Irqs, Config::default());
     let vsys_in = r.pin_29;
-    let mut channel = Channel::new_pin(vsys_in, Pull::None);
+    let mut channel = Channel::new_pin(&adc, vsys_in, Pull::None);
     let sender = EVENT_CHANNEL.sender();
 
     loop {

--- a/examples/rp/src/bin/zerocopy.rs
+++ b/examples/rp/src/bin/zerocopy.rs
@@ -39,9 +39,11 @@ async fn main(spawner: Spawner) {
     let p = embassy_rp::init(Default::default());
     info!("Here we go!");
 
+    let adc = Adc::new(p.ADC, Irqs, Config::default());
+    let pin = adc::Channel::new_pin(&adc, p.PIN_29, Pull::None);
     let adc_parts = AdcParts {
-        adc: Adc::new(p.ADC, Irqs, Config::default()),
-        pin: adc::Channel::new_pin(p.PIN_29, Pull::None),
+        adc,
+        pin,
         dma: p.DMA_CH0,
     };
 


### PR DESCRIPTION
Potential fix for #4558.
I've applied the change for both new_pin() and new_temp_sensor(), but in my testing it seems that it's only necessary for new_temp_sensor(), at least on rp2040.

It's really an API question whether we should include it for symmetry between the different calls, or only include it for the function that it's necessary for.

Will convert it from draft once this has an answer, but I thought it was worth showing what effect it will have on examples.