### PR TITLE
Optimize embedded_hal_async::delay::DelayNs impl

### DIFF
--- a/embassy-time/src/delay.rs
+++ b/embassy-time/src/delay.rs
@@ -1,3 +1,5 @@
+use core::future::Future;
+
 use super::{Duration, Instant};
 use crate::Timer;
 
@@ -32,16 +34,16 @@ impl embedded_hal_1::delay::DelayNs for Delay {
 }
 
 impl embedded_hal_async::delay::DelayNs for Delay {
-    async fn delay_ns(&mut self, ns: u32) {
-        Timer::after_nanos(ns as _).await
+    fn delay_ns(&mut self, ns: u32) -> impl Future<Output = ()> {
+        Timer::after_nanos(ns as _)
     }
 
-    async fn delay_us(&mut self, us: u32) {
-        Timer::after_micros(us as _).await
+    fn delay_us(&mut self, us: u32) -> impl Future<Output = ()> {
+        Timer::after_micros(us as _)
     }
 
-    async fn delay_ms(&mut self, ms: u32) {
-        Timer::after_millis(ms as _).await
+    fn delay_ms(&mut self, ms: u32) -> impl Future<Output = ()> {
+        Timer::after_millis(ms as _)
     }
 }
 


### PR DESCRIPTION
Modify `async fn` to return `impl Future`.

`async { xx.await }` is not zero cost, so such invalid packaging should be avoided without affecting correctness.