### PR TITLE
stm32: dma: support ringbuffers with format changes

### DIFF
--- a/embassy-stm32/src/dma/dma_bdma.rs
+++ b/embassy-stm32/src/dma/dma_bdma.rs
@@ -814,8 +814,19 @@ impl<'a, W: Word> ReadableRingBuffer<'a, W> {
     /// Create a new ring buffer.
     pub unsafe fn new(
         channel: Peri<'a, impl Channel>,
-        _request: Request,
+        request: Request,
         peri_addr: *mut W,
+        buffer: &'a mut [W],
+        options: TransferOptions,
+    ) -> Self {
+        Self::new_with_alignment::<W>(channel, request, peri_addr, buffer, options)
+    }
+
+    /// Create a new ring buffer with different alignment between memory and peripheral.
+    pub unsafe fn new_with_alignment<PW: Word>(
+        channel: Peri<'a, impl Channel>,
+        _request: Request,
+        peri_addr: *mut PW,
         buffer: &'a mut [W],
         mut options: TransferOptions,
     ) -> Self {
@@ -824,7 +835,8 @@ impl<'a, W: Word> ReadableRingBuffer<'a, W> {
         let buffer_ptr = buffer.as_mut_ptr();
         let len = buffer.len();
         let dir = Dir::PeripheralToMemory;
-        let data_size = W::size();
+        let mem_data_size = W::size();
+        let peri_data_size = PW::size();
 
         options.half_transfer_ir = true;
         options.complete_transfer_ir = true;
@@ -837,8 +849,8 @@ impl<'a, W: Word> ReadableRingBuffer<'a, W> {
             buffer_ptr as *mut u32,
             len,
             true,
-            data_size,
-            data_size,
+            mem_data_size,
+            peri_data_size,
             options,
         );
 
@@ -966,8 +978,19 @@ impl<'a, W: Word> WritableRingBuffer<'a, W> {
     /// Create a new ring buffer.
     pub unsafe fn new(
         channel: Peri<'a, impl Channel>,
-        _request: Request,
+        request: Request,
         peri_addr: *mut W,
+        buffer: &'a mut [W],
+        options: TransferOptions,
+    ) -> Self {
+        Self::new_with_alignment::<W>(channel, request, peri_addr, buffer, options)
+    }
+
+    /// Create a new ring buffer with different alignment between memory and peripheral.
+    pub unsafe fn new_with_alignment<PW: Word>(
+        channel: Peri<'a, impl Channel>,
+        _request: Request,
+        peri_addr: *mut PW,
         buffer: &'a mut [W],
         mut options: TransferOptions,
     ) -> Self {
@@ -975,7 +998,8 @@ impl<'a, W: Word> WritableRingBuffer<'a, W> {
 
         let len = buffer.len();
         let dir = Dir::MemoryToPeripheral;
-        let data_size = W::size();
+        let mem_data_size = W::size();
+        let peri_data_size = PW::size();
         let buffer_ptr = buffer.as_mut_ptr();
 
         options.half_transfer_ir = true;
@@ -989,8 +1013,8 @@ impl<'a, W: Word> WritableRingBuffer<'a, W> {
             buffer_ptr as *mut u32,
             len,
             true,
-            data_size,
-            data_size,
+            mem_data_size,
+            peri_data_size,
             options,
         );
 


### PR DESCRIPTION
This adds support for ringbuffers with different word sizes between the buffer and the peripheral, resulting in data conversion by the DMA engine. The DMA engine performs casts as described in the reference manual, which are what one expects (truncating if target too short, prepending 0s if target to long).

To avoid accidental casts and maintain the original behaviour I created a new constructor `new_with_aligment`. I am up for any name suggestions, ST calls these operations data alignments.