### PR TITLE
otg: Use chunks_exact for more efficient rx copy

### DIFF
--- a/embassy-usb-synopsys-otg/CHANGELOG.md
+++ b/embassy-usb-synopsys-otg/CHANGELOG.md
@@ -10,6 +10,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## 0.3.1 - 2025-08-26
 
+- Improve receive performance, more efficient copy from FIFO
+
 ## 0.3.0 - 2025-07-22
 
 - Bump `embassy-usb-driver` to v0.2.0


### PR DESCRIPTION
Most of the time was previously spent on individual memcpys for copy_from_slice, with chunks_exact the compiler can be smarter.