### PR TITLE
rp: fix blocking I2C example regarding pull-up resistors

### DIFF
--- a/examples/rp/src/bin/i2c_blocking.rs
+++ b/examples/rp/src/bin/i2c_blocking.rs
@@ -49,10 +49,8 @@ async fn main(_spawner: Spawner) {
     let scl = p.PIN_15;
 
     info!("set up i2c ");
-    let mut config = Config::default();
-    // by default internal pullup resitors are disabled
-    config.sda_pullup = true;
-    config.scl_pullup = true;
+    // Default I2C config enables internal pull-up resistors.
+    let config = Config::default();
     let mut i2c = i2c::I2c::new_blocking(p.I2C1, scl, sda, config);
 
     use mcp23017::*;


### PR DESCRIPTION
This amends the [blocking I2C example](https://github.com/embassy-rs/embassy/blob/main/examples/rp/src/bin/i2c_blocking.rs) for embassy-rp.

Commit bbc3e49 added a pull-up configuration and a comment that pull-ups were not enabled by default. This was made out-of-date by badcdcc, which ensured pull-ups were enabled to reduce the disruption of the larger I2C configuration change (see #4564).

This PR removes the (now-unnecessary) pull-up configuration, and adds a comment to clarify that the default I2C configuration enables pull-ups.