### PR TITLE
Bump `heapless` to v0.9

### DIFF
--- a/cyw43/Cargo.toml
+++ b/cyw43/Cargo.toml
@@ -10,7 +10,7 @@ repository = "https://github.com/embassy-rs/embassy"
 documentation = "https://docs.embassy.dev/cyw43"
 
 [features]
-defmt = ["dep:defmt", "heapless/defmt-03", "embassy-time/defmt", "bt-hci?/defmt", "embedded-io-async?/defmt-03"]
+defmt = ["dep:defmt", "heapless/defmt", "embassy-time/defmt", "bt-hci?/defmt", "embedded-io-async?/defmt-03"]
 log = ["dep:log"]
 bluetooth = ["dep:bt-hci", "dep:embedded-io-async"]
 
@@ -32,7 +32,7 @@ futures = { version = "0.3.17", default-features = false, features = ["async-awa
 
 embedded-hal-1 = { package = "embedded-hal", version = "1.0" }
 num_enum = { version = "0.5.7", default-features = false }
-heapless = "0.8.0"
+heapless = "0.9.0"
 
 # Bluetooth deps
 embedded-io-async = { version = "0.6.0", optional = true }

--- a/embassy-net-adin1110/Cargo.toml
+++ b/embassy-net-adin1110/Cargo.toml
@@ -10,7 +10,7 @@ repository = "https://github.com/embassy-rs/embassy"
 documentation = "https://docs.embassy.dev/embassy-net-adin1110"
 
 [dependencies]
-heapless = "0.8"
+heapless = "0.9"
 defmt = { version = "1.0.1", optional = true }
 log = { version = "0.4", default-features = false, optional = true }
 embedded-hal-1 = { package = "embedded-hal", version = "1.0" }

--- a/embassy-net-esp-hosted/Cargo.toml
+++ b/embassy-net-esp-hosted/Cargo.toml
@@ -10,7 +10,7 @@ repository = "https://github.com/embassy-rs/embassy"
 documentation = "https://docs.embassy.dev/embassy-net-esp-hosted"
 
 [features]
-defmt = ["dep:defmt", "heapless/defmt-03"]
+defmt = ["dep:defmt", "heapless/defmt"]
 log = ["dep:log"]
 
 [dependencies]
@@ -26,7 +26,7 @@ embedded-hal = { version = "1.0" }
 embedded-hal-async = { version = "1.0" }
 
 noproto = "0.1.0"
-heapless = "0.8"
+heapless = "0.9"
 
 [package.metadata.embassy_docs]
 src_base = "https://github.com/embassy-rs/embassy/blob/embassy-net-esp-hosted-v$VERSION/embassy-net-esp-hosted/src/"

--- a/embassy-net-nrf91/Cargo.toml
+++ b/embassy-net-nrf91/Cargo.toml
@@ -10,7 +10,7 @@ repository = "https://github.com/embassy-rs/embassy"
 documentation = "https://docs.embassy.dev/embassy-net-nrf91"
 
 [features]
-defmt = ["dep:defmt", "heapless/defmt-03"]
+defmt = ["dep:defmt", "heapless/defmt"]
 log = ["dep:log"]
 
 [dependencies]
@@ -25,7 +25,7 @@ embassy-sync = { version = "0.7.1", path = "../embassy-sync" }
 embassy-futures = { version = "0.1.0", path = "../embassy-futures" }
 embassy-net-driver-channel = { version = "0.3.1", path = "../embassy-net-driver-channel" }
 
-heapless = "0.8"
+heapless = "0.9"
 embedded-io = "0.6.1"
 at-commands = "0.5.4"
 

--- a/embassy-net/Cargo.toml
+++ b/embassy-net/Cargo.toml
@@ -24,7 +24,7 @@ features = ["defmt", "tcp", "udp", "raw", "dns", "icmp", "dhcpv4", "proto-ipv6",
 
 [features]
 ## Enable defmt
-defmt = ["dep:defmt", "smoltcp/defmt", "embassy-net-driver/defmt", "embassy-time/defmt", "heapless/defmt-03", "defmt?/ip_in_core"]
+defmt = ["dep:defmt", "smoltcp/defmt", "embassy-net-driver/defmt", "embassy-time/defmt", "heapless/defmt", "defmt?/ip_in_core"]
 
 ## Trace all raw received and transmitted packets using defmt or log.
 packet-trace = []
@@ -82,6 +82,6 @@ embassy-sync = { version = "0.7.1", path = "../embassy-sync" }
 embedded-io-async = { version = "0.6.1" }
 
 managed = { version = "0.8.0", default-features = false, features = [ "map" ] }
-heapless = { version = "0.8", default-features = false }
+heapless = { version = "0.9", default-features = false }
 embedded-nal-async = "0.8.0"
 document-features = "0.2.7"

--- a/embassy-stm32-wpan/Cargo.toml
+++ b/embassy-stm32-wpan/Cargo.toml
@@ -31,7 +31,7 @@ defmt = { version = "1.0.1", optional = true }
 log = { version = "0.4.17", optional = true }
 
 cortex-m = "0.7.6"
-heapless = "0.8"
+heapless = "0.9"
 aligned = "0.4.1"
 
 bit_field = "0.10.2"

--- a/embassy-sync/Cargo.toml
+++ b/embassy-sync/Cargo.toml
@@ -30,7 +30,7 @@ log = { version = "0.4.14", optional = true }
 futures-sink = { version = "0.3", default-features = false, features = [] }
 futures-core = { version = "0.3.31", default-features = false }
 critical-section = "1.1"
-heapless = "0.8"
+heapless = "0.9"
 cfg-if = "1.0.0"
 embedded-io-async = { version = "0.6.1" }
 

--- a/embassy-time-queue-utils/Cargo.toml
+++ b/embassy-time-queue-utils/Cargo.toml
@@ -21,7 +21,7 @@ categories = [
 links = "embassy-time-queue"
 
 [dependencies]
-heapless = "0.8"
+heapless = "0.9"
 embassy-executor = { version = "0.8", path = "../embassy-executor" }
 
 [features]

--- a/embassy-usb/Cargo.toml
+++ b/embassy-usb/Cargo.toml
@@ -53,7 +53,7 @@ embassy-net-driver-channel = { version = "0.3.1", path = "../embassy-net-driver-
 
 defmt = { version = "1", optional = true }
 log = { version = "0.4.14", optional = true }
-heapless = "0.8"
+heapless = "0.9"
 embedded-io-async = "0.6.1"
 
 # for HID

--- a/examples/nrf9160/Cargo.toml
+++ b/examples/nrf9160/Cargo.toml
@@ -14,7 +14,7 @@ embassy-net = { version = "0.7.0", path = "../../embassy-net", features = ["defm
 defmt = "1.0.1"
 defmt-rtt = "1.0.0"
 
-heapless = "0.8"
+heapless = "0.9"
 cortex-m = { version = "0.7.6", features = ["inline-asm", "critical-section-single-core"] }
 cortex-m-rt = "0.7.0"
 panic-probe = { version = "1.0.0", features = ["print-defmt"] }

--- a/examples/rp/Cargo.toml
+++ b/examples/rp/Cargo.toml
@@ -43,7 +43,7 @@ mipidsi = "0.8.0"
 display-interface = "0.5.0"
 byte-slice-cast = { version = "1.2.0", default-features = false }
 smart-leds = "0.4.0"
-heapless = "0.8"
+heapless = "0.9"
 usbd-hid = "0.8.1"
 
 embedded-hal-1 = { package = "embedded-hal", version = "1.0" }

--- a/examples/rp235x/Cargo.toml
+++ b/examples/rp235x/Cargo.toml
@@ -44,7 +44,7 @@ mipidsi = "0.8.0"
 display-interface = "0.5.0"
 byte-slice-cast = { version = "1.2.0", default-features = false }
 smart-leds = "0.3.0"
-heapless = "0.8"
+heapless = "0.9"
 usbd-hid = "0.8.1"
 
 embedded-hal-1 = { package = "embedded-hal", version = "1.0" }

--- a/examples/std/Cargo.toml
+++ b/examples/std/Cargo.toml
@@ -22,7 +22,7 @@ log = "0.4.14"
 nix = "0.26.2"
 clap = { version = "3.0.0-beta.5", features = ["derive"] }
 rand_core = { version = "0.9.1", features = ["std", "os_rng"] }
-heapless = { version = "0.8", default-features = false }
+heapless = { version = "0.9", default-features = false }
 static_cell = "2"
 
 [profile.release]

--- a/examples/stm32c0/Cargo.toml
+++ b/examples/stm32c0/Cargo.toml
@@ -18,7 +18,7 @@ cortex-m = { version = "0.7.6", features = ["critical-section-single-core"] }
 cortex-m-rt = "0.7.0"
 embedded-hal = "0.2.6"
 panic-probe = { version = "1.0.0", features = ["print-defmt"] }
-heapless = { version = "0.8", default-features = false }
+heapless = { version = "0.9", default-features = false }
 chrono = { version = "^0.4", default-features = false}
 
 [profile.release]

--- a/examples/stm32f1/Cargo.toml
+++ b/examples/stm32f1/Cargo.toml
@@ -20,7 +20,7 @@ cortex-m = { version = "0.7.6", features = ["inline-asm", "critical-section-sing
 cortex-m-rt = "0.7.0"
 embedded-hal = "0.2.6"
 panic-probe = { version = "1.0.0", features = ["print-defmt"] }
-heapless = { version = "0.8", default-features = false }
+heapless = { version = "0.9", default-features = false }
 nb = "1.0.0"
 static_cell = "2.0.0"
 

--- a/examples/stm32f2/Cargo.toml
+++ b/examples/stm32f2/Cargo.toml
@@ -18,7 +18,7 @@ cortex-m = { version = "0.7.6", features = ["inline-asm", "critical-section-sing
 cortex-m-rt = "0.7.0"
 embedded-hal = "0.2.6"
 panic-probe = { version = "1.0.0", features = ["print-defmt"] }
-heapless = { version = "0.8", default-features = false }
+heapless = { version = "0.9", default-features = false }
 nb = "1.0.0"
 
 [profile.release]

--- a/examples/stm32f3/Cargo.toml
+++ b/examples/stm32f3/Cargo.toml
@@ -20,7 +20,7 @@ cortex-m = { version = "0.7.6", features = ["inline-asm", "critical-section-sing
 cortex-m-rt = "0.7.0"
 embedded-hal = "0.2.6"
 panic-probe = { version = "1.0.0", features = ["print-defmt"] }
-heapless = { version = "0.8", default-features = false }
+heapless = { version = "0.9", default-features = false }
 nb = "1.0.0"
 embedded-storage = "0.3.1"
 static_cell = "2"

--- a/examples/stm32f334/Cargo.toml
+++ b/examples/stm32f334/Cargo.toml
@@ -19,7 +19,7 @@ cortex-m = { version = "0.7.6", features = ["inline-asm", "critical-section-sing
 cortex-m-rt = "0.7.0"
 embedded-hal = "0.2.6"
 panic-probe = { version = "1.0.0", features = ["print-defmt"] }
-heapless = { version = "0.8", default-features = false }
+heapless = { version = "0.9", default-features = false }
 nb = "1.0.0"
 embedded-storage = "0.3.1"
 static_cell = "2"

--- a/examples/stm32f4/Cargo.toml
+++ b/examples/stm32f4/Cargo.toml
@@ -26,7 +26,7 @@ embedded-io = { version = "0.6.0" }
 embedded-io-async = { version = "0.6.1" }
 panic-probe = { version = "1.0.0", features = ["print-defmt"] }
 futures-util = { version = "0.3.30", default-features = false }
-heapless = { version = "0.8", default-features = false }
+heapless = { version = "0.9", default-features = false }
 critical-section = "1.1"
 nb = "1.0.0"
 embedded-storage = "0.3.1"

--- a/examples/stm32f7/Cargo.toml
+++ b/examples/stm32f7/Cargo.toml
@@ -22,7 +22,7 @@ cortex-m = { version = "0.7.6", features = ["inline-asm", "critical-section-sing
 cortex-m-rt = "0.7.0"
 embedded-hal = "0.2.6"
 panic-probe = { version = "1.0.0", features = ["print-defmt"] }
-heapless = { version = "0.8", default-features = false }
+heapless = { version = "0.9", default-features = false }
 nb = "1.0.0"
 critical-section = "1.1"
 embedded-storage = "0.3.1"

--- a/examples/stm32g0/Cargo.toml
+++ b/examples/stm32g0/Cargo.toml
@@ -20,7 +20,7 @@ cortex-m = { version = "0.7.6", features = ["inline-asm", "critical-section-sing
 cortex-m-rt = "0.7.0"
 embedded-hal = "0.2.6"
 panic-probe = { version = "1.0.0", features = ["print-defmt"] }
-heapless = { version = "0.8", default-features = false }
+heapless = { version = "0.9", default-features = false }
 portable-atomic = { version = "1.5", features = ["unsafe-assume-single-core"] }
 
 embedded-io-async = { version = "0.6.1" }

--- a/examples/stm32g4/Cargo.toml
+++ b/examples/stm32g4/Cargo.toml
@@ -22,7 +22,7 @@ cortex-m-rt = "0.7.0"
 embedded-hal = "0.2.6"
 embedded-can = { version = "0.4" }
 panic-probe = { version = "1.0.0", features = ["print-defmt"] }
-heapless = { version = "0.8", default-features = false }
+heapless = { version = "0.9", default-features = false }
 static_cell = "2.0.0"
 
 [profile.release]

--- a/examples/stm32h5/Cargo.toml
+++ b/examples/stm32h5/Cargo.toml
@@ -25,7 +25,7 @@ embedded-hal-async = { version = "1.0" }
 embedded-io-async = { version = "0.6.1" }
 embedded-nal-async = "0.8.0"
 panic-probe = { version = "1.0.0", features = ["print-defmt"] }
-heapless = { version = "0.8", default-features = false }
+heapless = { version = "0.9", default-features = false }
 critical-section = "1.1"
 micromath = "2.0.0"
 stm32-fmc = "0.3.0"

--- a/examples/stm32h7/Cargo.toml
+++ b/examples/stm32h7/Cargo.toml
@@ -26,7 +26,7 @@ embedded-hal-async = { version = "1.0" }
 embedded-nal-async = "0.8.0"
 embedded-io-async = { version = "0.6.1" }
 panic-probe = { version = "1.0.0", features = ["print-defmt"] }
-heapless = { version = "0.8", default-features = false }
+heapless = { version = "0.9", default-features = false }
 critical-section = "1.1"
 micromath = "2.0.0"
 stm32-fmc = "0.3.0"

--- a/examples/stm32h723/Cargo.toml
+++ b/examples/stm32h723/Cargo.toml
@@ -23,7 +23,7 @@ embedded-hal-async = { version = "1.0" }
 embedded-nal-async = "0.8.0"
 embedded-io-async = { version = "0.6.1" }
 panic-probe = { version = "1.0.0", features = ["print-defmt"] }
-heapless = { version = "0.8", default-features = false }
+heapless = { version = "0.9", default-features = false }
 critical-section = "1.1"
 static_cell = "2"
 chrono = { version = "^0.4", default-features = false }

--- a/examples/stm32h735/Cargo.toml
+++ b/examples/stm32h735/Cargo.toml
@@ -18,7 +18,7 @@ defmt-rtt = "1.0.0"
 cortex-m = { version = "0.7.6", features = ["inline-asm", "critical-section-single-core"] }
 cortex-m-rt = "0.7.0"
 panic-probe = { version = "1.0.0", features = ["print-defmt"] }
-heapless = { version = "0.8", default-features = false }
+heapless = { version = "0.9", default-features = false }
 embedded-graphics = { version = "0.8.1" }
 tinybmp = { version = "0.5" }
 

--- a/examples/stm32h742/Cargo.toml
+++ b/examples/stm32h742/Cargo.toml
@@ -49,7 +49,7 @@ cortex-m = { version = "0.7.6", features = [
 cortex-m-rt = "0.7.0"
 embedded-hal = "0.2.6"
 panic-probe = { version = "1.0.0", features = ["print-defmt"] }
-heapless = { version = "0.8", default-features = false }
+heapless = { version = "0.9", default-features = false }
 nb = "1.0.0"
 critical-section = "1.1"
 embedded-storage = "0.3.1"

--- a/examples/stm32h755cm4/Cargo.toml
+++ b/examples/stm32h755cm4/Cargo.toml
@@ -26,7 +26,7 @@ embedded-hal-async = { version = "1.0" }
 embedded-nal-async = "0.8.0"
 embedded-io-async = { version = "0.6.1" }
 panic-probe = { version = "1.0.0", features = ["print-defmt"] }
-heapless = { version = "0.8", default-features = false }
+heapless = { version = "0.9", default-features = false }
 critical-section = "1.1"
 micromath = "2.0.0"
 stm32-fmc = "0.3.0"

--- a/examples/stm32h755cm7/Cargo.toml
+++ b/examples/stm32h755cm7/Cargo.toml
@@ -26,7 +26,7 @@ embedded-hal-async = { version = "1.0" }
 embedded-nal-async = "0.8.0"
 embedded-io-async = { version = "0.6.1" }
 panic-probe = { version = "1.0.0", features = ["print-defmt"] }
-heapless = { version = "0.8", default-features = false }
+heapless = { version = "0.9", default-features = false }
 critical-section = "1.1"
 micromath = "2.0.0"
 stm32-fmc = "0.3.0"

--- a/examples/stm32h7b0/Cargo.toml
+++ b/examples/stm32h7b0/Cargo.toml
@@ -25,7 +25,7 @@ embedded-hal-async = { version = "1.0" }
 embedded-nal-async = "0.8.0"
 embedded-io-async = { version = "0.6.1" }
 panic-probe = { version = "1.0.0", features = ["print-defmt"] }
-heapless = { version = "0.8", default-features = false }
+heapless = { version = "0.9", default-features = false }
 critical-section = "1.1"
 micromath = "2.0.0"
 stm32-fmc = "0.3.0"

--- a/examples/stm32h7rs/Cargo.toml
+++ b/examples/stm32h7rs/Cargo.toml
@@ -25,7 +25,7 @@ embedded-hal-async = { version = "1.0" }
 embedded-nal-async = "0.8.0"
 embedded-io-async = { version = "0.6.1" }
 panic-probe = { version = "1.0.0", features = ["print-defmt"] }
-heapless = { version = "0.8", default-features = false }
+heapless = { version = "0.9", default-features = false }
 critical-section = "1.1"
 micromath = "2.0.0"
 stm32-fmc = "0.3.0"

--- a/examples/stm32l0/Cargo.toml
+++ b/examples/stm32l0/Cargo.toml
@@ -21,7 +21,7 @@ embedded-io-async = { version = "0.6.1" }
 cortex-m = { version = "0.7.6", features = ["inline-asm", "critical-section-single-core"] }
 cortex-m-rt = "0.7.0"
 panic-probe = { version = "1.0.0", features = ["print-defmt"] }
-heapless = { version = "0.8", default-features = false }
+heapless = { version = "0.9", default-features = false }
 embedded-hal = "0.2.6"
 static_cell = { version = "2" }
 portable-atomic = { version = "1.5", features = ["unsafe-assume-single-core"] }

--- a/examples/stm32l1/Cargo.toml
+++ b/examples/stm32l1/Cargo.toml
@@ -19,7 +19,7 @@ cortex-m = { version = "0.7.6", features = ["inline-asm", "critical-section-sing
 cortex-m-rt = "0.7.0"
 embedded-hal = "0.2.6"
 panic-probe = { version = "1.0.0", features = ["print-defmt"] }
-heapless = { version = "0.8", default-features = false }
+heapless = { version = "0.9", default-features = false }
 embedded-storage = "0.3.1"
 
 [profile.release]

--- a/examples/stm32l4/Cargo.toml
+++ b/examples/stm32l4/Cargo.toml
@@ -28,7 +28,7 @@ embedded-hal-1 = { package = "embedded-hal", version = "1.0" }
 embedded-hal-async = { version = "1.0" }
 embedded-hal-bus = { version = "0.1", features = ["async"] }
 panic-probe = { version = "1.0.0", features = ["print-defmt"] }
-heapless = { version = "0.8", default-features = false }
+heapless = { version = "0.9", default-features = false }
 chrono = { version = "^0.4", default-features = false }
 static_cell = "2"
 

--- a/examples/stm32l5/Cargo.toml
+++ b/examples/stm32l5/Cargo.toml
@@ -22,7 +22,7 @@ panic-probe = { version = "1.0.0", features = ["print-defmt"] }
 cortex-m = { version = "0.7.6", features = ["inline-asm", "critical-section-single-core"] }
 cortex-m-rt = "0.7.0"
 embedded-hal = "0.2.6"
-heapless = { version = "0.8", default-features = false }
+heapless = { version = "0.9", default-features = false }
 embedded-io-async = { version = "0.6.1" }
 static_cell = "2"
 

--- a/examples/stm32u0/Cargo.toml
+++ b/examples/stm32u0/Cargo.toml
@@ -20,7 +20,7 @@ cortex-m = { version = "0.7.6", features = ["critical-section-single-core"] }
 cortex-m-rt = "0.7.0"
 embedded-hal = "0.2.6"
 panic-probe = { version = "1.0.0", features = ["print-defmt"] }
-heapless = { version = "0.8", default-features = false }
+heapless = { version = "0.9", default-features = false }
 
 micromath = "2.0.0"
 chrono = { version = "0.4.38", default-features = false }

--- a/examples/stm32u5/Cargo.toml
+++ b/examples/stm32u5/Cargo.toml
@@ -20,7 +20,7 @@ cortex-m = { version = "0.7.6", features = ["inline-asm", "critical-section-sing
 cortex-m-rt = "0.7.0"
 embedded-hal = "0.2.6"
 panic-probe = { version = "1.0.0", features = ["print-defmt"] }
-heapless = { version = "0.8", default-features = false }
+heapless = { version = "0.9", default-features = false }
 embedded-graphics = { version = "0.8.1" }
 tinybmp = { version = "0.6.0" }
 

--- a/examples/stm32wb/Cargo.toml
+++ b/examples/stm32wb/Cargo.toml
@@ -20,7 +20,7 @@ cortex-m = { version = "0.7.6", features = ["inline-asm", "critical-section-sing
 cortex-m-rt = "0.7.0"
 embedded-hal = "1.0.0"
 panic-probe = { version = "1.0.0", features = ["print-defmt"] }
-heapless = { version = "0.8", default-features = false }
+heapless = { version = "0.9", default-features = false }
 static_cell = "2"
 
 [features]

--- a/examples/stm32wba/Cargo.toml
+++ b/examples/stm32wba/Cargo.toml
@@ -18,7 +18,7 @@ cortex-m = { version = "0.7.6", features = ["inline-asm", "critical-section-sing
 cortex-m-rt = "0.7.0"
 embedded-hal = "1.0.0"
 panic-probe = { version = "1.0.0", features = ["print-defmt"] }
-heapless = { version = "0.8", default-features = false }
+heapless = { version = "0.9", default-features = false }
 static_cell = "2"
 
 [profile.release]

--- a/examples/stm32wba6/Cargo.toml
+++ b/examples/stm32wba6/Cargo.toml
@@ -19,7 +19,7 @@ cortex-m = { version = "0.7.6", features = ["inline-asm", "critical-section-sing
 cortex-m-rt = "0.7.0"
 embedded-hal = "1.0.0"
 panic-probe = { version = "1.0.0", features = ["print-defmt"] }
-heapless = { version = "0.8", default-features = false }
+heapless = { version = "0.9", default-features = false }
 static_cell = "2"
 
 [profile.release]

--- a/examples/stm32wl/Cargo.toml
+++ b/examples/stm32wl/Cargo.toml
@@ -20,7 +20,7 @@ cortex-m-rt = "0.7.0"
 embedded-hal = "0.2.6"
 embedded-storage = "0.3.1"
 panic-probe = { version = "1.0.0", features = ["print-defmt"] }
-heapless = { version = "0.8", default-features = false }
+heapless = { version = "0.9", default-features = false }
 chrono = { version = "^0.4", default-features = false }
 
 [profile.release]


### PR DESCRIPTION
`heapless` just released v0.9.1, this PR bumps all `heapless` dependency to 0.9-compatible version