### PR TITLE
STM32 XSPI: Disable alternate bytes if not requested

### DIFF
--- a/embassy-stm32/CHANGELOG.md
+++ b/embassy-stm32/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - fix: Fix vrefbuf building with log feature
 - fix: Fix performing a hash after performing a hmac
 - chore: Updated stm32-metapac and stm32-data dependencies
+- fix: Fix XSPI not disabling alternate bytes when they were previously enabled
 
 ## 0.3.0 - 2025-08-12
 

--- a/embassy-stm32/src/xspi/mod.rs
+++ b/embassy-stm32/src/xspi/mod.rs
@@ -429,6 +429,11 @@ impl<'d, T: Instance, M: PeriMode> Xspi<'d, T, M> {
                 w.set_abdtr(command.abdtr);
                 w.set_absize(CcrAbsize::from_bits(command.absize.into()));
             })
+        } else {
+            T::REGS.ccr().modify(|w| {
+                // disable alternate bytes
+                w.set_abmode(CcrAbmode::B_0X0);
+            })
         }
 
         // Configure dummy cycles


### PR DESCRIPTION
If a previous command used alternate bytes and the next command does not have them the alternate bytes need to be turned off. 