### PR TITLE
Replace nrf5340's SAADC input pins with correct mappings

### DIFF
--- a/embassy-nrf/src/chips/nrf5340_app.rs
+++ b/embassy-nrf/src/chips/nrf5340_app.rs
@@ -463,14 +463,14 @@ impl_ppi_channel!(PPI_CH29, 29 => configurable);
 impl_ppi_channel!(PPI_CH30, 30 => configurable);
 impl_ppi_channel!(PPI_CH31, 31 => configurable);
 
-impl_saadc_input!(P0_13, ANALOG_INPUT0);
-impl_saadc_input!(P0_14, ANALOG_INPUT1);
-impl_saadc_input!(P0_15, ANALOG_INPUT2);
-impl_saadc_input!(P0_16, ANALOG_INPUT3);
-impl_saadc_input!(P0_17, ANALOG_INPUT4);
-impl_saadc_input!(P0_18, ANALOG_INPUT5);
-impl_saadc_input!(P0_19, ANALOG_INPUT6);
-impl_saadc_input!(P0_20, ANALOG_INPUT7);
+impl_saadc_input!(P0_04, ANALOG_INPUT0);
+impl_saadc_input!(P0_05, ANALOG_INPUT1);
+impl_saadc_input!(P0_06, ANALOG_INPUT2);
+impl_saadc_input!(P0_07, ANALOG_INPUT3);
+impl_saadc_input!(P0_25, ANALOG_INPUT4);
+impl_saadc_input!(P0_26, ANALOG_INPUT5);
+impl_saadc_input!(P0_27, ANALOG_INPUT6);
+impl_saadc_input!(P0_28, ANALOG_INPUT7);
 
 impl_egu!(EGU0, EGU0, EGU0);
 impl_egu!(EGU1, EGU1, EGU1);


### PR DESCRIPTION
Updated the SAADC pins to correct ones per [nordic's docs](https://docs.nordicsemi.com/bundle/ps_nrf5340/page/chapters/pin.html)