### PR TITLE
chore: prepare crate releases

### DIFF
--- a/cyw43-pio/CHANGELOG.md
+++ b/cyw43-pio/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 <!-- next-header -->
 ## Unreleased - ReleaseDate
 
+## 0.6.1 - 2025-08-26
+
 ## 0.6.0 - 2025-08-04
 
 ## 0.5.1 - 2025-07-16

--- a/cyw43-pio/Cargo.toml
+++ b/cyw43-pio/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cyw43-pio"
-version = "0.6.0"
+version = "0.6.1"
 edition = "2021"
 description = "RP2040 PIO SPI implementation for cyw43"
 keywords = ["embedded", "cyw43", "embassy-net", "embedded-hal-async", "wifi"]
@@ -11,7 +11,7 @@ documentation = "https://docs.embassy.dev/cyw43-pio"
 
 [dependencies]
 cyw43 = { version = "0.4.0", path = "../cyw43" }
-embassy-rp = { version = "0.7.0", path = "../embassy-rp" }
+embassy-rp = { version = "0.7.1", path = "../embassy-rp" }
 fixed = "1.23.1"
 defmt = { version = "1.0.1", optional = true }
 

--- a/cyw43/CHANGELOG.md
+++ b/cyw43/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 <!-- next-header -->
 ## Unreleased - ReleaseDate
 
+## 0.4.1 - 2025-08-26
+
 - bump bt-hci to 0.4.0
 
 ## 0.4.0 - 2025-07-15

--- a/cyw43/Cargo.toml
+++ b/cyw43/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cyw43"
-version = "0.4.0"
+version = "0.4.1"
 edition = "2021"
 description = "Rust driver for the CYW43439 WiFi chip, used in the Raspberry Pi Pico W."
 keywords = ["embedded", "cyw43", "embassy-net", "embedded-hal-async", "wifi"]
@@ -18,7 +18,7 @@ bluetooth = ["dep:bt-hci", "dep:embedded-io-async"]
 firmware-logs = []
 
 [dependencies]
-embassy-time = { version = "0.4.0", path = "../embassy-time"}
+embassy-time = { version = "0.5.0", path = "../embassy-time"}
 embassy-sync = { version = "0.7.1", path = "../embassy-sync"}
 embassy-futures = { version = "0.1.0", path = "../embassy-futures"}
 embassy-net-driver-channel = { version = "0.3.1", path = "../embassy-net-driver-channel"}

--- a/docs/examples/basic/Cargo.toml
+++ b/docs/examples/basic/Cargo.toml
@@ -7,9 +7,9 @@ license = "MIT OR Apache-2.0"
 
 publish = false
 [dependencies]
-embassy-executor = { version = "0.8.0", path = "../../../embassy-executor", features = ["defmt", "arch-cortex-m", "executor-thread"] }
-embassy-time = { version = "0.4.0", path = "../../../embassy-time", features = ["defmt"] }
-embassy-nrf = { version = "0.6.0", path = "../../../embassy-nrf", features = ["defmt", "nrf52840", "time-driver-rtc1", "gpiote"] }
+embassy-executor = { version = "0.9.0", path = "../../../embassy-executor", features = ["defmt", "arch-cortex-m", "executor-thread"] }
+embassy-time = { version = "0.5.0", path = "../../../embassy-time", features = ["defmt"] }
+embassy-nrf = { version = "0.7.0", path = "../../../embassy-nrf", features = ["defmt", "nrf52840", "time-driver-rtc1", "gpiote"] }
 
 defmt = "1.0.1"
 defmt-rtt = "1.0.0"

--- a/embassy-boot-nrf/CHANGELOG.md
+++ b/embassy-boot-nrf/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 <!-- next-header -->
 ## Unreleased - ReleaseDate
 
+## 0.7.1 - 2025-08-26
+
 ## 0.1.1 - 2025-08-15
 
 - First release with changelog.

--- a/embassy-boot-nrf/Cargo.toml
+++ b/embassy-boot-nrf/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 edition = "2021"
 name = "embassy-boot-nrf"
-version = "0.7.0"
+version = "0.7.1"
 description = "Bootloader lib for nRF chips"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/embassy-rs/embassy"
@@ -36,8 +36,8 @@ defmt = { version = "1.0.1", optional = true }
 log = { version = "0.4.17", optional = true }
 
 embassy-sync = { version = "0.7.1", path = "../embassy-sync" }
-embassy-nrf = { version = "0.6.0", path = "../embassy-nrf", default-features = false }
-embassy-boot = { version = "0.6.0", path = "../embassy-boot" }
+embassy-nrf = { version = "0.7.0", path = "../embassy-nrf", default-features = false }
+embassy-boot = { version = "0.6.1", path = "../embassy-boot" }
 cortex-m = { version = "0.7.6" }
 cortex-m-rt = { version = "0.7" }
 embedded-storage = "0.3.1"

--- a/embassy-boot-rp/CHANGELOG.md
+++ b/embassy-boot-rp/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 <!-- next-header -->
 ## Unreleased - ReleaseDate
 
+## 0.7.1 - 2025-08-26
+
 ## 0.1.1 - 2025-08-15
 
 - First release with changelog.

--- a/embassy-boot-rp/Cargo.toml
+++ b/embassy-boot-rp/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 edition = "2021"
 name = "embassy-boot-rp"
-version = "0.7.0"
+version = "0.7.1"
 description = "Bootloader lib for RP2040 chips"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/embassy-rs/embassy"
@@ -31,9 +31,9 @@ defmt = { version = "1.0.1", optional = true }
 log = { version = "0.4", optional = true }
 
 embassy-sync = { version = "0.7.1", path = "../embassy-sync" }
-embassy-rp = { version = "0.7.0", path = "../embassy-rp", default-features = false }
-embassy-boot = { version = "0.6.0", path = "../embassy-boot" }
-embassy-time = { version = "0.4.0", path = "../embassy-time" }
+embassy-rp = { version = "0.7.1", path = "../embassy-rp", default-features = false }
+embassy-boot = { version = "0.6.1", path = "../embassy-boot" }
+embassy-time = { version = "0.5.0", path = "../embassy-time" }
 
 cortex-m = { version = "0.7.6" }
 cortex-m-rt = { version = "0.7" }

--- a/embassy-boot-stm32/CHANGELOG.md
+++ b/embassy-boot-stm32/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 <!-- next-header -->
 ## Unreleased - ReleaseDate
 
+## 0.5.1 - 2025-08-26
+
 ## 0.1.1 - 2025-08-15
 
 - First release with changelog.

--- a/embassy-boot-stm32/Cargo.toml
+++ b/embassy-boot-stm32/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 edition = "2021"
 name = "embassy-boot-stm32"
-version = "0.5.0"
+version = "0.5.1"
 description = "Bootloader lib for STM32 chips"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/embassy-rs/embassy"
@@ -31,8 +31,8 @@ defmt = { version = "1.0.1", optional = true }
 log = { version = "0.4", optional = true }
 
 embassy-sync = { version = "0.7.1", path = "../embassy-sync" }
-embassy-stm32 = { version = "0.3.0", path = "../embassy-stm32", default-features = false }
-embassy-boot = { version = "0.6.0", path = "../embassy-boot" }
+embassy-stm32 = { version = "0.4.0", path = "../embassy-stm32", default-features = false }
+embassy-boot = { version = "0.6.1", path = "../embassy-boot" }
 cortex-m = { version = "0.7.6" }
 cortex-m-rt = { version = "0.7" }
 embedded-storage = "0.3.1"

--- a/embassy-boot/CHANGELOG.md
+++ b/embassy-boot/CHANGELOG.md
@@ -8,4 +8,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 <!-- next-header -->
 ## Unreleased - ReleaseDate
 
+## 0.6.1 - 2025-08-26
+
 - First release with changelog.

--- a/embassy-boot/Cargo.toml
+++ b/embassy-boot/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 edition = "2021"
 name = "embassy-boot"
-version = "0.6.0"
+version = "0.6.1"
 description = "A lightweight bootloader supporting firmware updates in a power-fail-safe way, with trial boots and rollbacks."
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/embassy-rs/embassy"
@@ -28,7 +28,7 @@ defmt = { version = "1.0.1", optional = true }
 digest = "0.10"
 log = { version = "0.4", optional = true }
 ed25519-dalek = { version = "2", default-features = false, features = ["digest"], optional = true }
-embassy-embedded-hal = { version = "0.4.0", path = "../embassy-embedded-hal" }
+embassy-embedded-hal = { version = "0.4.1", path = "../embassy-embedded-hal" }
 embassy-sync = { version = "0.7.1", path = "../embassy-sync" }
 embedded-storage = "0.3.1"
 embedded-storage-async = { version = "0.4.1" }

--- a/embassy-embedded-hal/CHANGELOG.md
+++ b/embassy-embedded-hal/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 <!-- next-header -->
 ## Unreleased - ReleaseDate
 
+## 0.4.1 - 2025-08-26
+
 ## 0.4.0 - 2025-08-03
 
 - `SpiDevice` cancel safety: always set CS pin to high on drop

--- a/embassy-embedded-hal/Cargo.toml
+++ b/embassy-embedded-hal/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "embassy-embedded-hal"
-version = "0.4.0"
+version = "0.4.1"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 description = "Collection of utilities to use `embedded-hal` and `embedded-storage` traits with Embassy."
@@ -31,7 +31,7 @@ time = ["dep:embassy-time"]
 embassy-hal-internal = { version = "0.3.0", path = "../embassy-hal-internal" }
 embassy-futures = { version = "0.1.0", path = "../embassy-futures" }
 embassy-sync = { version = "0.7.1", path = "../embassy-sync" }
-embassy-time = { version = "0.4.0", path = "../embassy-time", optional = true }
+embassy-time = { version = "0.5.0", path = "../embassy-time", optional = true }
 embedded-hal-02 = { package = "embedded-hal", version = "0.2.6", features = [
     "unproven",
 ] }

--- a/embassy-executor/CHANGELOG.md
+++ b/embassy-executor/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 <!-- next-header -->
 ## Unreleased - ReleaseDate
 
+## 0.9.0 - 2025-08-26
+
 - Added `extern "Rust" fn __embassy_time_queue_item_from_waker`
 - Removed `TaskRef::dangling`
 - Added `embassy_time_queue_utils` as a dependency

--- a/embassy-executor/Cargo.toml
+++ b/embassy-executor/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "embassy-executor"
-version = "0.8.0"
+version = "0.9.0"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 description = "async/await executor designed for embedded usage"
@@ -54,7 +54,7 @@ log = { version = "0.4.14", optional = true }
 rtos-trace = { version = "0.1.3", optional = true }
 
 embassy-executor-macros = { version = "0.7.0", path = "../embassy-executor-macros" }
-embassy-time-driver = { version = "0.2", path = "../embassy-time-driver", optional = true }
+embassy-time-driver = { version = "0.2.1", path = "../embassy-time-driver", optional = true }
 embassy-executor-timer-queue = { version = "0.1", path = "../embassy-executor-timer-queue" }
 critical-section = "1.1"
 

--- a/embassy-imxrt/Cargo.toml
+++ b/embassy-imxrt/Cargo.toml
@@ -71,11 +71,11 @@ mimxrt633s = ["mimxrt633s-pac", "_mimxrt633s"]
 
 [dependencies]
 embassy-sync = { version = "0.7.1", path = "../embassy-sync" }
-embassy-time-driver = { version = "0.2", path = "../embassy-time-driver", optional = true }
+embassy-time-driver = { version = "0.2.1", path = "../embassy-time-driver", optional = true }
 embassy-time-queue-utils = { version = "0.2", path = "../embassy-time-queue-utils", optional = true }
-embassy-time = { version = "0.4", path = "../embassy-time", optional = true }
+embassy-time = { version = "0.5.0", path = "../embassy-time", optional = true }
 embassy-hal-internal = { version = "0.3.0", path = "../embassy-hal-internal", features = ["cortex-m", "prio-bits-3"] }
-embassy-embedded-hal = { version = "0.4.0", path = "../embassy-embedded-hal", default-features = false }
+embassy-embedded-hal = { version = "0.4.1", path = "../embassy-embedded-hal", default-features = false }
 embassy-futures = { version = "0.1.1", path = "../embassy-futures" }
 
 defmt = { version = "1.0.1", optional = true }

--- a/embassy-mspm0/Cargo.toml
+++ b/embassy-mspm0/Cargo.toml
@@ -45,14 +45,14 @@ rustdoc-args = ["--cfg", "docsrs"]
 
 [dependencies]
 embassy-sync = { version = "0.7.1", path = "../embassy-sync" }
-embassy-time = { version = "0.4.0", path = "../embassy-time", optional = true }
+embassy-time = { version = "0.5.0", path = "../embassy-time", optional = true }
 # TODO: Support other tick rates
-embassy-time-driver = { version = "0.2", path = "../embassy-time-driver", optional = true, features = ["tick-hz-32_768"] }
+embassy-time-driver = { version = "0.2.1", path = "../embassy-time-driver", optional = true, features = ["tick-hz-32_768"] }
 embassy-time-queue-utils = { version = "0.2", path = "../embassy-time-queue-utils", optional = true }
 embassy-futures = { version = "0.1.0", path = "../embassy-futures" }
 embassy-hal-internal = { version = "0.3.0", path = "../embassy-hal-internal", features = ["cortex-m", "prio-bits-2"] }
-embassy-embedded-hal = { version = "0.4.0", path = "../embassy-embedded-hal", default-features = false }
-embassy-executor = { version = "0.8.0", path = "../embassy-executor", optional = true }
+embassy-embedded-hal = { version = "0.4.1", path = "../embassy-embedded-hal", default-features = false }
+embassy-executor = { version = "0.9.0", path = "../embassy-executor", optional = true }
 
 embedded-hal-02 = { package = "embedded-hal", version = "0.2.6", features = ["unproven"] }
 embedded-hal = { version = "1.0" }

--- a/embassy-net-adin1110/CHANGELOG.md
+++ b/embassy-net-adin1110/CHANGELOG.md
@@ -8,4 +8,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 <!-- next-header -->
 ## Unreleased - ReleaseDate
 
+## 0.3.1 - 2025-08-26
+
 - First release with changelog.

--- a/embassy-net-adin1110/Cargo.toml
+++ b/embassy-net-adin1110/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "embassy-net-adin1110"
-version = "0.3.0"
+version = "0.3.1"
 description = "embassy-net driver for the ADIN1110 ethernet chip"
 keywords = ["embedded", "ADIN1110", "embassy-net", "embedded-hal-async", "ethernet"]
 categories = ["embedded", "hardware-support", "no-std", "network-programming", "asynchronous"]
@@ -17,7 +17,7 @@ embedded-hal-1 = { package = "embedded-hal", version = "1.0" }
 embedded-hal-async = { version = "1.0" }
 embedded-hal-bus = { version = "0.1", features = ["async"] }
 embassy-net-driver-channel = { version = "0.3.1", path = "../embassy-net-driver-channel" }
-embassy-time = { version = "0.4.0", path = "../embassy-time" }
+embassy-time = { version = "0.5.0", path = "../embassy-time" }
 embassy-futures = { version = "0.1.0", path = "../embassy-futures" }
 bitfield = "0.14.0"
 

--- a/embassy-net-enc28j60/CHANGELOG.md
+++ b/embassy-net-enc28j60/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 <!-- next-header -->
 ## Unreleased - ReleaseDate
 
+## 0.2.1 - 2025-08-26
+
 ## 0.1.1 - 2025-08-16
 
 - First release with changelog.

--- a/embassy-net-enc28j60/Cargo.toml
+++ b/embassy-net-enc28j60/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "embassy-net-enc28j60"
-version = "0.2.0"
+version = "0.2.1"
 description = "embassy-net driver for the ENC28J60 ethernet chip"
 keywords = ["embedded", "enc28j60", "embassy-net", "embedded-hal-async", "ethernet"]
 categories = ["embedded", "hardware-support", "no-std", "network-programming", "asynchronous"]
@@ -13,7 +13,7 @@ documentation = "https://docs.embassy.dev/embassy-net-enc28j60"
 embedded-hal = { version = "1.0" }
 embedded-hal-async = { version = "1.0" }
 embassy-net-driver = { version = "0.2.0", path = "../embassy-net-driver" }
-embassy-time = { version = "0.4.0", path = "../embassy-time" }
+embassy-time = { version = "0.5.0", path = "../embassy-time" }
 embassy-futures = { version = "0.1.0", path = "../embassy-futures" }
 
 defmt = { version = "1.0.1", optional = true }

--- a/embassy-net-esp-hosted/CHANGELOG.md
+++ b/embassy-net-esp-hosted/CHANGELOG.md
@@ -8,4 +8,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 <!-- next-header -->
 ## Unreleased - ReleaseDate
 
+## 0.2.1 - 2025-08-26
+
 - First release with changelog.

--- a/embassy-net-esp-hosted/Cargo.toml
+++ b/embassy-net-esp-hosted/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "embassy-net-esp-hosted"
-version = "0.2.0"
+version = "0.2.1"
 edition = "2021"
 description = "embassy-net driver for ESP-Hosted"
 keywords = ["embedded", "esp-hosted", "embassy-net", "embedded-hal-async", "wifi"]
@@ -17,7 +17,7 @@ log = ["dep:log"]
 defmt = { version = "1.0.1", optional = true }
 log = { version = "0.4.14", optional = true }
 
-embassy-time = { version = "0.4.0", path = "../embassy-time" }
+embassy-time = { version = "0.5.0", path = "../embassy-time" }
 embassy-sync = { version = "0.7.1", path = "../embassy-sync"}
 embassy-futures = { version = "0.1.0", path = "../embassy-futures"}
 embassy-net-driver-channel = { version = "0.3.1", path = "../embassy-net-driver-channel"}

--- a/embassy-net-nrf91/Cargo.toml
+++ b/embassy-net-nrf91/Cargo.toml
@@ -21,7 +21,7 @@ log = { version = "0.4.14", optional = true }
 nrf-pac = "0.1.0"
 cortex-m = "0.7.7"
 
-embassy-time = { version = "0.4.0", path = "../embassy-time" }
+embassy-time = { version = "0.5.0", path = "../embassy-time" }
 embassy-sync = { version = "0.7.1", path = "../embassy-sync" }
 embassy-futures = { version = "0.1.0", path = "../embassy-futures" }
 embassy-net-driver-channel = { version = "0.3.1", path = "../embassy-net-driver-channel" }

--- a/embassy-net-wiznet/CHANGELOG.md
+++ b/embassy-net-wiznet/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 <!-- next-header -->
 ## Unreleased - ReleaseDate
 
+## 0.2.1 - 2025-08-26
+
 ## 0.1.1 - 2025-08-14
 
 - First release with changelog.

--- a/embassy-net-wiznet/Cargo.toml
+++ b/embassy-net-wiznet/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "embassy-net-wiznet"
-version = "0.2.0"
+version = "0.2.1"
 description = "embassy-net driver for WIZnet SPI Ethernet chips"
 keywords = ["embedded", "embassy-net", "embedded-hal-async", "ethernet", "async"]
 categories = ["embedded", "hardware-support", "no-std", "network-programming", "asynchronous"]
@@ -13,7 +13,7 @@ documentation = "https://docs.embassy.dev/embassy-net-wiznet"
 embedded-hal = { version = "1.0" }
 embedded-hal-async = { version = "1.0" }
 embassy-net-driver-channel = { version = "0.3.1", path = "../embassy-net-driver-channel" }
-embassy-time = { version = "0.4.0", path = "../embassy-time" }
+embassy-time = { version = "0.5.0", path = "../embassy-time" }
 embassy-futures = { version = "0.1.0", path = "../embassy-futures" }
 defmt = { version = "1.0.1", optional = true }
 

--- a/embassy-net/CHANGELOG.md
+++ b/embassy-net/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 <!-- next-header -->
 ## Unreleased - ReleaseDate
 
+## 0.7.1 - 2025-08-26
+
 No unreleased changes yet... Quick, go send a PR!
 
 ## 0.7 - 2025-05-06

--- a/embassy-net/Cargo.toml
+++ b/embassy-net/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "embassy-net"
-version = "0.7.0"
+version = "0.7.1"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 description = "Async TCP/IP network stack for embedded systems"
@@ -92,7 +92,7 @@ smoltcp = { version = "0.12.0", default-features = false, features = [
 ] }
 
 embassy-net-driver = { version = "0.2.0", path = "../embassy-net-driver" }
-embassy-time = { version = "0.4.0", path = "../embassy-time" }
+embassy-time = { version = "0.5.0", path = "../embassy-time" }
 embassy-sync = { version = "0.7.1", path = "../embassy-sync" }
 embedded-io-async = { version = "0.6.1" }
 

--- a/embassy-nrf/CHANGELOG.md
+++ b/embassy-nrf/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 <!-- next-header -->
 ## Unreleased - ReleaseDate
 
+## 0.7.0 - 2025-08-26
+
 - bugfix: use correct analog input SAADC pins on nrf5340
 
 ## 0.6.0 - 2025-08-04

--- a/embassy-nrf/Cargo.toml
+++ b/embassy-nrf/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "embassy-nrf"
-version = "0.6.0"
+version = "0.7.0"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 description = "Embassy Hardware Abstraction Layer (HAL) for nRF series microcontrollers"
@@ -170,12 +170,12 @@ _nrf52832_anomaly_109 = []
 _multi_wdt = []
 
 [dependencies]
-embassy-time-driver = { version = "0.2", path = "../embassy-time-driver", optional = true }
+embassy-time-driver = { version = "0.2.1", path = "../embassy-time-driver", optional = true }
 embassy-time-queue-utils = { version = "0.2", path = "../embassy-time-queue-utils", optional = true }
-embassy-time = { version = "0.4.0", path = "../embassy-time", optional = true }
+embassy-time = { version = "0.5.0", path = "../embassy-time", optional = true }
 embassy-sync = { version = "0.7.1", path = "../embassy-sync" }
 embassy-hal-internal = { version = "0.3.0", path = "../embassy-hal-internal", features = ["cortex-m", "prio-bits-3"] }
-embassy-embedded-hal = { version = "0.4.0", path = "../embassy-embedded-hal", default-features = false }
+embassy-embedded-hal = { version = "0.4.1", path = "../embassy-embedded-hal", default-features = false }
 embassy-usb-driver = { version = "0.2.0", path = "../embassy-usb-driver" }
 
 embedded-hal-02 = { package = "embedded-hal", version = "0.2.6", features = ["unproven"] }

--- a/embassy-nxp/Cargo.toml
+++ b/embassy-nxp/Cargo.toml
@@ -30,8 +30,8 @@ embassy-hal-internal = { version = "0.3.0", path = "../embassy-hal-internal", fe
 embassy-sync = { version = "0.7.1", path = "../embassy-sync" }
 defmt = { version = "1", optional = true }
 log = { version = "0.4.27", optional = true }
-embassy-time = { version = "0.4.0", path = "../embassy-time", optional = true }
-embassy-time-driver = { version = "0.2", path = "../embassy-time-driver", optional = true }
+embassy-time = { version = "0.5.0", path = "../embassy-time", optional = true }
+embassy-time-driver = { version = "0.2.1", path = "../embassy-time-driver", optional = true }
 embassy-time-queue-utils = { version = "0.2", path = "../embassy-time-queue-utils", optional = true }
 embedded-io = "0.6.1"
 embedded-hal-02 = { package = "embedded-hal", version = "0.2.6", features = ["unproven"] }

--- a/embassy-rp/CHANGELOG.md
+++ b/embassy-rp/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 <!-- next-header -->
 ## Unreleased - ReleaseDate
+
+## 0.7.1 - 2025-08-26
 - add `i2c` internal pullup options ([#4564](https://github.com/embassy-rs/embassy/pull/4564))
 
 ## 0.7.0 - 2025-08-04

--- a/embassy-rp/Cargo.toml
+++ b/embassy-rp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "embassy-rp"
-version = "0.7.0"
+version = "0.7.1"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 description = "Embassy Hardware Abstraction Layer (HAL) for the Raspberry Pi RP2040 or RP235x microcontroller"
@@ -148,12 +148,12 @@ binary-info = ["rt", "dep:rp-binary-info", "rp-binary-info?/binary-info"]
 
 [dependencies]
 embassy-sync = { version = "0.7.1", path = "../embassy-sync" }
-embassy-time-driver = { version = "0.2", path = "../embassy-time-driver", optional = true }
+embassy-time-driver = { version = "0.2.1", path = "../embassy-time-driver", optional = true }
 embassy-time-queue-utils = { version = "0.2", path = "../embassy-time-queue-utils", optional = true }
-embassy-time = { version = "0.4.0", path = "../embassy-time" }
+embassy-time = { version = "0.5.0", path = "../embassy-time" }
 embassy-futures = { version = "0.1.0", path = "../embassy-futures" }
 embassy-hal-internal = { version = "0.3.0", path = "../embassy-hal-internal", features = ["cortex-m", "prio-bits-2"] }
-embassy-embedded-hal = { version = "0.4.0", path = "../embassy-embedded-hal" }
+embassy-embedded-hal = { version = "0.4.1", path = "../embassy-embedded-hal" }
 embassy-usb-driver = { version = "0.2.0", path = "../embassy-usb-driver" }
 atomic-polyfill = "1.0.1"
 defmt = { version = "1.0.1", optional = true }

--- a/embassy-stm32-wpan/Cargo.toml
+++ b/embassy-stm32-wpan/Cargo.toml
@@ -26,12 +26,12 @@ features = ["stm32wb55rg", "ble", "mac"]
 features = ["stm32wb55rg", "ble", "mac"]
 
 [dependencies]
-embassy-stm32 = { version = "0.3.0", path = "../embassy-stm32" }
+embassy-stm32 = { version = "0.4.0", path = "../embassy-stm32" }
 embassy-sync = { version = "0.7.1", path = "../embassy-sync" }
-embassy-time = { version = "0.4.0", path = "../embassy-time", optional = true }
+embassy-time = { version = "0.5.0", path = "../embassy-time", optional = true }
 embassy-futures = { version = "0.1.0", path = "../embassy-futures" }
 embassy-hal-internal = { version = "0.3.0", path = "../embassy-hal-internal" }
-embassy-embedded-hal = { version = "0.4.0", path = "../embassy-embedded-hal" }
+embassy-embedded-hal = { version = "0.4.1", path = "../embassy-embedded-hal" }
 embassy-net-driver = { version = "0.2.0", path = "../embassy-net-driver", optional=true }
 
 defmt = { version = "1.0.1", optional = true }

--- a/embassy-stm32/CHANGELOG.md
+++ b/embassy-stm32/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 <!-- next-header -->
 ## Unreleased - ReleaseDate
 
+## 0.4.0 - 2025-08-26
+
 - fix: stm32/i2c: pull-down was enabled instead of pull-none when no internal pull-up was needed.
 - feat: Improve blocking hash speed
 - fix: Fix vrefbuf building with log feature

--- a/embassy-stm32/Cargo.toml
+++ b/embassy-stm32/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "embassy-stm32"
-version = "0.3.0"
+version = "0.4.0"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 description = "Embassy Hardware Abstraction Layer (HAL) for ST STM32 series microcontrollers"
@@ -142,16 +142,16 @@ rustdoc-args = ["--cfg", "docsrs"]
 
 [dependencies]
 embassy-sync = { version = "0.7.1", path = "../embassy-sync" }
-embassy-time = { version = "0.4.0", path = "../embassy-time", optional = true }
-embassy-time-driver = { version = "0.2", path = "../embassy-time-driver", optional = true }
+embassy-time = { version = "0.5.0", path = "../embassy-time", optional = true }
+embassy-time-driver = { version = "0.2.1", path = "../embassy-time-driver", optional = true }
 embassy-time-queue-utils = { version = "0.2", path = "../embassy-time-queue-utils", optional = true }
 embassy-futures = { version = "0.1.0", path = "../embassy-futures" }
 embassy-hal-internal = { version = "0.3.0", path = "../embassy-hal-internal", features = ["cortex-m", "prio-bits-4"] }
-embassy-embedded-hal = { version = "0.4.0", path = "../embassy-embedded-hal", default-features = false }
+embassy-embedded-hal = { version = "0.4.1", path = "../embassy-embedded-hal", default-features = false }
 embassy-net-driver = { version = "0.2.0", path = "../embassy-net-driver" }
 embassy-usb-driver = { version = "0.2.0", path = "../embassy-usb-driver" }
 embassy-usb-synopsys-otg = { version = "0.3.0", path = "../embassy-usb-synopsys-otg" }
-embassy-executor = { version = "0.8.0", path = "../embassy-executor", optional = true }
+embassy-executor = { version = "0.9.0", path = "../embassy-executor", optional = true }
 
 embedded-hal-02 = { package = "embedded-hal", version = "0.2.6", features = ["unproven"] }
 embedded-hal-1 = { package = "embedded-hal", version = "1.0" }

--- a/embassy-time-driver/CHANGELOG.md
+++ b/embassy-time-driver/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 <!-- next-header -->
 ## Unreleased - ReleaseDate
 
+## 0.2.1 - 2025-08-26
+
 - Allow inlining on time driver boundary
 - add 133MHz tick rate to support PR2040 @ 133MHz when `TIMERx`'s `SOURCE` is set to `SYSCLK`
 

--- a/embassy-time-driver/Cargo.toml
+++ b/embassy-time-driver/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "embassy-time-driver"
-version = "0.2.0"
+version = "0.2.1"
 edition = "2021"
 description = "Driver trait for embassy-time"
 repository = "https://github.com/embassy-rs/embassy"

--- a/embassy-time/CHANGELOG.md
+++ b/embassy-time/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 <!-- next-header -->
 ## Unreleased - ReleaseDate
 
+## 0.5.0 - 2025-08-26
+
 - Allow inlining on time driver boundary
 - Add `saturating_add` and `saturating_sub` to `Instant`
 - Add `Instant::try_from_*` constructor functions

--- a/embassy-time/Cargo.toml
+++ b/embassy-time/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "embassy-time"
-version = "0.4.0"
+version = "0.5.0"
 edition = "2021"
 description = "Instant and Duration for embedded no-std systems, with async timer support"
 repository = "https://github.com/embassy-rs/embassy"
@@ -423,7 +423,7 @@ tick-hz-5_242_880_000 = ["embassy-time-driver/tick-hz-5_242_880_000"]
 #! </details>
 
 [dependencies]
-embassy-time-driver = { version = "0.2", path = "../embassy-time-driver" }
+embassy-time-driver = { version = "0.2.1", path = "../embassy-time-driver" }
 embassy-time-queue-utils = { version = "0.2", path = "../embassy-time-queue-utils", optional = true}
 
 defmt = { version = "1.0.1", optional = true }

--- a/embassy-usb-dfu/CHANGELOG.md
+++ b/embassy-usb-dfu/CHANGELOG.md
@@ -8,4 +8,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 <!-- next-header -->
 ## Unreleased - ReleaseDate
 
+## 0.1.1 - 2025-08-26
+
 - First release with changelog.

--- a/embassy-usb-dfu/Cargo.toml
+++ b/embassy-usb-dfu/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 edition = "2021"
 name = "embassy-usb-dfu"
-version = "0.1.0"
+version = "0.1.1"
 description = "An implementation of the USB DFU 1.1 protocol, using embassy-boot"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/embassy-rs/embassy"
@@ -37,10 +37,10 @@ log = { version = "0.4.17", optional = true }
 
 bitflags = "2.4.1"
 cortex-m = { version = "0.7.7", features = ["inline-asm"], optional = true }
-embassy-boot = { version = "0.6.0", path = "../embassy-boot" }
+embassy-boot = { version = "0.6.1", path = "../embassy-boot" }
 embassy-futures = { version = "0.1.1", path = "../embassy-futures" }
 embassy-sync = { version = "0.7.1", path = "../embassy-sync" }
-embassy-time = { version = "0.4.0", path = "../embassy-time" }
+embassy-time = { version = "0.5.0", path = "../embassy-time" }
 embassy-usb = { version = "0.5.0", path = "../embassy-usb", default-features = false }
 embedded-storage = { version = "0.3.1" }
 esp32c3-hal = { version = "0.13.0", optional = true, default-features = false }

--- a/examples/lpc55s69/Cargo.toml
+++ b/examples/lpc55s69/Cargo.toml
@@ -8,9 +8,9 @@ publish = false
 
 [dependencies]
 embassy-nxp = { version = "0.1.0", path = "../../embassy-nxp", features = ["lpc55", "rt", "defmt", "time-driver-rtc"] }
-embassy-executor = { version = "0.8.0", path = "../../embassy-executor", features = ["arch-cortex-m", "executor-thread", "executor-interrupt"] }
+embassy-executor = { version = "0.9.0", path = "../../embassy-executor", features = ["arch-cortex-m", "executor-thread", "executor-interrupt"] }
 embassy-sync = { version = "0.7.1", path = "../../embassy-sync", features = ["defmt"] }
-embassy-time = { version = "0.4.0", path = "../../embassy-time", features = ["defmt", "tick-hz-32_768"] }
+embassy-time = { version = "0.5.0", path = "../../embassy-time", features = ["defmt", "tick-hz-32_768"] }
 panic-halt = "1.0.0"
 cortex-m = { version = "0.7.6", features = ["inline-asm", "critical-section-single-core"] }
 cortex-m-rt = { version = "0.7.0"}

--- a/examples/mimxrt1011/Cargo.toml
+++ b/examples/mimxrt1011/Cargo.toml
@@ -11,10 +11,10 @@ cortex-m-rt = "0.7.3"
 defmt = "1.0.1"
 defmt-rtt = "1.0.0"
 
-embassy-executor = { version = "0.8.0", path = "../../embassy-executor", features = ["arch-cortex-m", "executor-thread", "executor-interrupt", "defmt"] }
+embassy-executor = { version = "0.9.0", path = "../../embassy-executor", features = ["arch-cortex-m", "executor-thread", "executor-interrupt", "defmt"] }
 embassy-futures = { version = "0.1.1", path = "../../embassy-futures" }
 embassy-nxp = { version = "0.1.0", path = "../../embassy-nxp", features = ["defmt", "mimxrt1011", "unstable-pac", "time-driver-pit"] }
-embassy-time = { version = "0.4", path = "../../embassy-time", features = ["defmt", ] } # "defmt-timestamp-uptime" # RT1011 hard faults currently with this enabled.
+embassy-time = { version = "0.5.0", path = "../../embassy-time", features = ["defmt", ] } # "defmt-timestamp-uptime" # RT1011 hard faults currently with this enabled.
 embassy-sync = { version = "0.7.1", path = "../../embassy-sync", features = ["defmt"] }
 embedded-hal-1 = { package = "embedded-hal", version = "1.0" }
 embedded-hal-async = "1.0.0"

--- a/examples/mimxrt1062-evk/Cargo.toml
+++ b/examples/mimxrt1062-evk/Cargo.toml
@@ -11,10 +11,10 @@ cortex-m-rt = "0.7.3"
 defmt = "1.0.1"
 defmt-rtt = "1.0.0"
 
-embassy-executor = { version = "0.8.0", path = "../../embassy-executor", features = ["arch-cortex-m", "executor-thread", "executor-interrupt", "defmt"] }
+embassy-executor = { version = "0.9.0", path = "../../embassy-executor", features = ["arch-cortex-m", "executor-thread", "executor-interrupt", "defmt"] }
 embassy-futures = { version = "0.1.1", path = "../../embassy-futures" }
 embassy-nxp = { version = "0.1.0", path = "../../embassy-nxp", features = ["defmt", "mimxrt1062", "unstable-pac", "time-driver-pit"] }
-embassy-time = { version = "0.4", path = "../../embassy-time", features = ["defmt", ] } # "defmt-timestamp-uptime"
+embassy-time = { version = "0.5.0", path = "../../embassy-time", features = ["defmt", ] } # "defmt-timestamp-uptime"
 embassy-sync = { version = "0.7.1", path = "../../embassy-sync", features = ["defmt"] }
 embedded-hal-1 = { package = "embedded-hal", version = "1.0" }
 embedded-hal-async = "1.0.0"

--- a/examples/mimxrt6/Cargo.toml
+++ b/examples/mimxrt6/Cargo.toml
@@ -11,10 +11,10 @@ cortex-m-rt = "0.7.3"
 defmt = "1.0.1"
 defmt-rtt = "1.0.0"
 
-embassy-executor = { version = "0.8.0", path = "../../embassy-executor", features = ["arch-cortex-m", "executor-thread", "executor-interrupt", "defmt"] }
+embassy-executor = { version = "0.9.0", path = "../../embassy-executor", features = ["arch-cortex-m", "executor-thread", "executor-interrupt", "defmt"] }
 embassy-futures = { version = "0.1.1", path = "../../embassy-futures" }
 embassy-imxrt = { version = "0.1.0", path = "../../embassy-imxrt", features = ["defmt", "mimxrt685s", "unstable-pac", "time", "time-driver-os-timer"] }
-embassy-time = { version = "0.4", path = "../../embassy-time", features = ["defmt", "defmt-timestamp-uptime"] }
+embassy-time = { version = "0.5.0", path = "../../embassy-time", features = ["defmt", "defmt-timestamp-uptime"] }
 embassy-sync = { version = "0.7.1", path = "../../embassy-sync", features = ["defmt"] }
 embedded-hal-1 = { package = "embedded-hal", version = "1.0" }
 embedded-hal-async = "1.0.0"

--- a/examples/mspm0g3507/Cargo.toml
+++ b/examples/mspm0g3507/Cargo.toml
@@ -7,9 +7,9 @@ publish = false
 
 [dependencies]
 embassy-mspm0 = { version = "0.1.0", path = "../../embassy-mspm0", features = ["mspm0g3507pm", "defmt", "rt", "time-driver-any"] }
-embassy-executor = { version = "0.8.0", path = "../../embassy-executor", features = ["arch-cortex-m", "executor-thread", "executor-interrupt"] }
+embassy-executor = { version = "0.9.0", path = "../../embassy-executor", features = ["arch-cortex-m", "executor-thread", "executor-interrupt"] }
 embassy-sync = { version = "0.7.1", path = "../../embassy-sync", features = ["defmt"] }
-embassy-time = { version = "0.4.0", path = "../../embassy-time", features = ["defmt"] }
+embassy-time = { version = "0.5.0", path = "../../embassy-time", features = ["defmt"] }
 panic-halt = "1.0.0"
 cortex-m = { version = "0.7.6", features = ["inline-asm", "critical-section-single-core"] }
 cortex-m-rt = { version = "0.7.0"}

--- a/examples/mspm0g3519/Cargo.toml
+++ b/examples/mspm0g3519/Cargo.toml
@@ -7,9 +7,9 @@ publish = false
 
 [dependencies]
 embassy-mspm0 = { version = "0.1.0", path = "../../embassy-mspm0", features = ["mspm0g3519pz", "defmt", "rt", "time-driver-any"] }
-embassy-executor = { version = "0.8.0", path = "../../embassy-executor", features = ["arch-cortex-m", "executor-thread", "executor-interrupt"] }
+embassy-executor = { version = "0.9.0", path = "../../embassy-executor", features = ["arch-cortex-m", "executor-thread", "executor-interrupt"] }
 embassy-sync = { version = "0.7.1", path = "../../embassy-sync", features = ["defmt"] }
-embassy-time = { version = "0.4.0", path = "../../embassy-time", features = ["defmt"] }
+embassy-time = { version = "0.5.0", path = "../../embassy-time", features = ["defmt"] }
 panic-halt = "1.0.0"
 cortex-m = { version = "0.7.6", features = ["inline-asm", "critical-section-single-core"] }
 cortex-m-rt = { version = "0.7.0"}

--- a/examples/mspm0l1306/Cargo.toml
+++ b/examples/mspm0l1306/Cargo.toml
@@ -7,9 +7,9 @@ publish = false
 
 [dependencies]
 embassy-mspm0 = { version = "0.1.0", path = "../../embassy-mspm0", features = ["mspm0l1306rhb", "defmt", "rt", "time-driver-any"] }
-embassy-executor = { version = "0.8.0", path = "../../embassy-executor", features = ["arch-cortex-m", "executor-thread", "executor-interrupt"] }
+embassy-executor = { version = "0.9.0", path = "../../embassy-executor", features = ["arch-cortex-m", "executor-thread", "executor-interrupt"] }
 embassy-sync = { version = "0.7.1", path = "../../embassy-sync", features = ["defmt"] }
-embassy-time = { version = "0.4.0", path = "../../embassy-time", features = ["defmt"] }
+embassy-time = { version = "0.5.0", path = "../../embassy-time", features = ["defmt"] }
 panic-halt = "1.0.0"
 cortex-m = { version = "0.7.6", features = ["inline-asm", "critical-section-single-core"] }
 cortex-m-rt = { version = "0.7.0"}

--- a/examples/mspm0l2228/Cargo.toml
+++ b/examples/mspm0l2228/Cargo.toml
@@ -7,9 +7,9 @@ publish = false
 
 [dependencies]
 embassy-mspm0 = { version = "0.1.0", path = "../../embassy-mspm0", features = ["mspm0l2228pn", "defmt", "rt", "time-driver-any"] }
-embassy-executor = { version = "0.8.0", path = "../../embassy-executor", features = ["arch-cortex-m", "executor-thread", "executor-interrupt"] }
+embassy-executor = { version = "0.9.0", path = "../../embassy-executor", features = ["arch-cortex-m", "executor-thread", "executor-interrupt"] }
 embassy-sync = { version = "0.7.1", path = "../../embassy-sync", features = ["defmt"] }
-embassy-time = { version = "0.4.0", path = "../../embassy-time", features = ["defmt"] }
+embassy-time = { version = "0.5.0", path = "../../embassy-time", features = ["defmt"] }
 panic-halt = "1.0.0"
 cortex-m = { version = "0.7.6", features = ["inline-asm", "critical-section-single-core"] }
 cortex-m-rt = { version = "0.7.0"}

--- a/examples/nrf-rtos-trace/Cargo.toml
+++ b/examples/nrf-rtos-trace/Cargo.toml
@@ -17,9 +17,9 @@ log = [
 
 [dependencies]
 embassy-sync = { version = "0.7.1", path = "../../embassy-sync" }
-embassy-executor = { version = "0.8.0", path = "../../embassy-executor", features = ["arch-cortex-m", "executor-thread", "rtos-trace"] }
-embassy-time = { version = "0.4.0", path = "../../embassy-time" }
-embassy-nrf = { version = "0.6.0", path = "../../embassy-nrf", features = ["nrf52840", "time-driver-rtc1", "gpiote", "unstable-pac"] }
+embassy-executor = { version = "0.9.0", path = "../../embassy-executor", features = ["arch-cortex-m", "executor-thread", "rtos-trace"] }
+embassy-time = { version = "0.5.0", path = "../../embassy-time" }
+embassy-nrf = { version = "0.7.0", path = "../../embassy-nrf", features = ["nrf52840", "time-driver-rtc1", "gpiote", "unstable-pac"] }
 
 cortex-m = { version = "0.7.6", features = ["inline-asm", "critical-section-single-core"] }
 cortex-m-rt = "0.7.0"

--- a/examples/nrf51/Cargo.toml
+++ b/examples/nrf51/Cargo.toml
@@ -6,9 +6,9 @@ license = "MIT OR Apache-2.0"
 publish = false
 
 [dependencies]
-embassy-executor = { version = "0.8.0", path = "../../embassy-executor", features = ["arch-cortex-m", "executor-thread", "executor-interrupt", "defmt"] }
-embassy-time = { version = "0.4.0", path = "../../embassy-time", features = ["defmt", "defmt-timestamp-uptime"] }
-embassy-nrf = { version = "0.6.0", path = "../../embassy-nrf", features = ["defmt", "nrf51", "gpiote", "time-driver-rtc1", "unstable-pac", "time", "rt"] }
+embassy-executor = { version = "0.9.0", path = "../../embassy-executor", features = ["arch-cortex-m", "executor-thread", "executor-interrupt", "defmt"] }
+embassy-time = { version = "0.5.0", path = "../../embassy-time", features = ["defmt", "defmt-timestamp-uptime"] }
+embassy-nrf = { version = "0.7.0", path = "../../embassy-nrf", features = ["defmt", "nrf51", "gpiote", "time-driver-rtc1", "unstable-pac", "time", "rt"] }
 
 defmt = "1.0.1"
 defmt-rtt = "1.0.0"

--- a/examples/nrf52810/Cargo.toml
+++ b/examples/nrf52810/Cargo.toml
@@ -8,9 +8,9 @@ publish = false
 [dependencies]
 embassy-futures = { version = "0.1.0", path = "../../embassy-futures" }
 embassy-sync = { version = "0.7.1", path = "../../embassy-sync", features = ["defmt"] }
-embassy-executor = { version = "0.8.0", path = "../../embassy-executor", features = ["arch-cortex-m", "executor-thread", "executor-interrupt", "defmt"] }
-embassy-time = { version = "0.4.0", path = "../../embassy-time", features = ["defmt", "defmt-timestamp-uptime"] }
-embassy-nrf = { version = "0.6.0", path = "../../embassy-nrf", features = ["defmt", "nrf52810", "time-driver-rtc1", "gpiote", "unstable-pac", "time"] }
+embassy-executor = { version = "0.9.0", path = "../../embassy-executor", features = ["arch-cortex-m", "executor-thread", "executor-interrupt", "defmt"] }
+embassy-time = { version = "0.5.0", path = "../../embassy-time", features = ["defmt", "defmt-timestamp-uptime"] }
+embassy-nrf = { version = "0.7.0", path = "../../embassy-nrf", features = ["defmt", "nrf52810", "time-driver-rtc1", "gpiote", "unstable-pac", "time"] }
 
 defmt = "1.0.1"
 defmt-rtt = "1.0.0"

--- a/examples/nrf52840-rtic/Cargo.toml
+++ b/examples/nrf52840-rtic/Cargo.toml
@@ -10,9 +10,9 @@ rtic = { version = "2", features = ["thumbv7-backend"] }
 
 embassy-futures = { version = "0.1.0", path = "../../embassy-futures" }
 embassy-sync = { version = "0.7.1", path = "../../embassy-sync", features = ["defmt"] }
-embassy-time = { version = "0.4.0", path = "../../embassy-time", features = [ "defmt", "defmt-timestamp-uptime"] }
+embassy-time = { version = "0.5.0", path = "../../embassy-time", features = [ "defmt", "defmt-timestamp-uptime"] }
 embassy-time-queue-utils = { version = "0.2", path = "../../embassy-time-queue-utils", features = ["generic-queue-8"] }
-embassy-nrf = { version = "0.6.0", path = "../../embassy-nrf", features = [ "defmt", "nrf52840", "time-driver-rtc1", "gpiote", "unstable-pac", "time"] }
+embassy-nrf = { version = "0.7.0", path = "../../embassy-nrf", features = [ "defmt", "nrf52840", "time-driver-rtc1", "gpiote", "unstable-pac", "time"] }
 
 defmt = "1.0.1"
 defmt-rtt = "1.0.0"

--- a/examples/nrf52840/Cargo.toml
+++ b/examples/nrf52840/Cargo.toml
@@ -8,15 +8,15 @@ publish = false
 [dependencies]
 embassy-futures = { version = "0.1.0", path = "../../embassy-futures" }
 embassy-sync = { version = "0.7.1", path = "../../embassy-sync", features = ["defmt"] }
-embassy-executor = { version = "0.8.0", path = "../../embassy-executor", features = ["arch-cortex-m", "executor-thread", "executor-interrupt", "defmt"] }
-embassy-time = { version = "0.4.0", path = "../../embassy-time", features = ["defmt", "defmt-timestamp-uptime"] }
-embassy-nrf = { version = "0.6.0", path = "../../embassy-nrf", features = ["defmt", "nrf52840", "time-driver-rtc1", "gpiote", "unstable-pac", "time"] }
-embassy-net = { version = "0.7.0", path = "../../embassy-net", features = ["defmt", "tcp", "dhcpv4", "medium-ethernet"] }
+embassy-executor = { version = "0.9.0", path = "../../embassy-executor", features = ["arch-cortex-m", "executor-thread", "executor-interrupt", "defmt"] }
+embassy-time = { version = "0.5.0", path = "../../embassy-time", features = ["defmt", "defmt-timestamp-uptime"] }
+embassy-nrf = { version = "0.7.0", path = "../../embassy-nrf", features = ["defmt", "nrf52840", "time-driver-rtc1", "gpiote", "unstable-pac", "time"] }
+embassy-net = { version = "0.7.1", path = "../../embassy-net", features = ["defmt", "tcp", "dhcpv4", "medium-ethernet"] }
 embassy-usb = { version = "0.5.0", path = "../../embassy-usb", features = ["defmt"] }
 embedded-io = { version = "0.6.0", features = ["defmt-03"]  }
 embedded-io-async = { version = "0.6.1", features = ["defmt-03"] }
-embassy-net-esp-hosted = { version = "0.2.0", path = "../../embassy-net-esp-hosted", features = ["defmt"] }
-embassy-net-enc28j60 = { version = "0.2.0", path = "../../embassy-net-enc28j60", features = ["defmt"] }
+embassy-net-esp-hosted = { version = "0.2.1", path = "../../embassy-net-esp-hosted", features = ["defmt"] }
+embassy-net-enc28j60 = { version = "0.2.1", path = "../../embassy-net-enc28j60", features = ["defmt"] }
 
 defmt = "1.0.1"
 defmt-rtt = "1.0.0"

--- a/examples/nrf5340/Cargo.toml
+++ b/examples/nrf5340/Cargo.toml
@@ -8,10 +8,10 @@ publish = false
 [dependencies]
 embassy-futures = { version = "0.1.0", path = "../../embassy-futures" }
 embassy-sync = { version = "0.7.1", path = "../../embassy-sync", features = ["defmt"] }
-embassy-executor = { version = "0.8.0", path = "../../embassy-executor", features = ["arch-cortex-m", "executor-thread", "defmt"] }
-embassy-time = { version = "0.4.0", path = "../../embassy-time", features = ["defmt", "defmt-timestamp-uptime"] }
-embassy-nrf = { version = "0.6.0", path = "../../embassy-nrf", features = ["defmt", "nrf5340-app-s", "time-driver-rtc1", "gpiote", "unstable-pac"] }
-embassy-net = { version = "0.7.0", path = "../../embassy-net", features = ["defmt", "tcp", "dhcpv4", "medium-ethernet"] }
+embassy-executor = { version = "0.9.0", path = "../../embassy-executor", features = ["arch-cortex-m", "executor-thread", "defmt"] }
+embassy-time = { version = "0.5.0", path = "../../embassy-time", features = ["defmt", "defmt-timestamp-uptime"] }
+embassy-nrf = { version = "0.7.0", path = "../../embassy-nrf", features = ["defmt", "nrf5340-app-s", "time-driver-rtc1", "gpiote", "unstable-pac"] }
+embassy-net = { version = "0.7.1", path = "../../embassy-net", features = ["defmt", "tcp", "dhcpv4", "medium-ethernet"] }
 embassy-usb = { version = "0.5.0", path = "../../embassy-usb", features = ["defmt"] }
 embedded-io-async = { version = "0.6.1" }
 

--- a/examples/nrf54l15/Cargo.toml
+++ b/examples/nrf54l15/Cargo.toml
@@ -6,9 +6,9 @@ license = "MIT OR Apache-2.0"
 publish = false
 
 [dependencies]
-embassy-executor = { version = "0.8.0", path = "../../embassy-executor", features = ["arch-cortex-m", "executor-thread", "executor-interrupt", "defmt"] }
-embassy-time = { version = "0.4.0", path = "../../embassy-time", features = ["defmt", "defmt-timestamp-uptime"] }
-embassy-nrf = { version = "0.6.0", path = "../../embassy-nrf", features = ["defmt", "nrf54l15-app-s", "time-driver-rtc1", "gpiote", "unstable-pac", "time"] }
+embassy-executor = { version = "0.9.0", path = "../../embassy-executor", features = ["arch-cortex-m", "executor-thread", "executor-interrupt", "defmt"] }
+embassy-time = { version = "0.5.0", path = "../../embassy-time", features = ["defmt", "defmt-timestamp-uptime"] }
+embassy-nrf = { version = "0.7.0", path = "../../embassy-nrf", features = ["defmt", "nrf54l15-app-s", "time-driver-rtc1", "gpiote", "unstable-pac", "time"] }
 
 defmt = "1.0.1"
 defmt-rtt = "1.0.0"

--- a/examples/nrf9160/Cargo.toml
+++ b/examples/nrf9160/Cargo.toml
@@ -6,11 +6,11 @@ license = "MIT OR Apache-2.0"
 publish = false
 
 [dependencies]
-embassy-executor = { version = "0.8.0", path = "../../embassy-executor", features = ["arch-cortex-m", "executor-thread", "executor-interrupt", "defmt"] }
-embassy-time = { version = "0.4.0", path = "../../embassy-time", features = ["defmt", "defmt-timestamp-uptime"] }
-embassy-nrf = { version = "0.6.0", path = "../../embassy-nrf", features = ["defmt", "nrf9160-s", "time-driver-rtc1", "gpiote", "unstable-pac", "time"] }
+embassy-executor = { version = "0.9.0", path = "../../embassy-executor", features = ["arch-cortex-m", "executor-thread", "executor-interrupt", "defmt"] }
+embassy-time = { version = "0.5.0", path = "../../embassy-time", features = ["defmt", "defmt-timestamp-uptime"] }
+embassy-nrf = { version = "0.7.0", path = "../../embassy-nrf", features = ["defmt", "nrf9160-s", "time-driver-rtc1", "gpiote", "unstable-pac", "time"] }
 embassy-net-nrf91 = { version = "0.1.0", path = "../../embassy-net-nrf91", features = ["defmt"] }
-embassy-net = { version = "0.7.0", path = "../../embassy-net", features = ["defmt", "tcp", "proto-ipv4", "medium-ip"] }
+embassy-net = { version = "0.7.1", path = "../../embassy-net", features = ["defmt", "tcp", "proto-ipv4", "medium-ip"] }
 
 defmt = "1.0.1"
 defmt-rtt = "1.0.0"

--- a/examples/rp/Cargo.toml
+++ b/examples/rp/Cargo.toml
@@ -7,14 +7,14 @@ license = "MIT OR Apache-2.0"
 publish = false
 
 [dependencies]
-embassy-embedded-hal = { version = "0.4.0", path = "../../embassy-embedded-hal", features = ["defmt"] }
+embassy-embedded-hal = { version = "0.4.1", path = "../../embassy-embedded-hal", features = ["defmt"] }
 embassy-sync = { version = "0.7.1", path = "../../embassy-sync", features = ["defmt"] }
-embassy-executor = { version = "0.8.0", path = "../../embassy-executor", features = ["arch-cortex-m", "executor-thread", "executor-interrupt", "defmt"] }
-embassy-time = { version = "0.4.0", path = "../../embassy-time", features = ["defmt", "defmt-timestamp-uptime"] }
-embassy-rp = { version = "0.7.0", path = "../../embassy-rp", features = ["defmt", "unstable-pac", "time-driver", "critical-section-impl", "rp2040"] }
+embassy-executor = { version = "0.9.0", path = "../../embassy-executor", features = ["arch-cortex-m", "executor-thread", "executor-interrupt", "defmt"] }
+embassy-time = { version = "0.5.0", path = "../../embassy-time", features = ["defmt", "defmt-timestamp-uptime"] }
+embassy-rp = { version = "0.7.1", path = "../../embassy-rp", features = ["defmt", "unstable-pac", "time-driver", "critical-section-impl", "rp2040"] }
 embassy-usb = { version = "0.5.0", path = "../../embassy-usb", features = ["defmt"] }
-embassy-net = { version = "0.7.0", path = "../../embassy-net", features = ["defmt", "icmp", "tcp", "udp", "raw", "dhcpv4", "medium-ethernet", "dns", "proto-ipv4", "proto-ipv6", "multicast"] }
-embassy-net-wiznet = { version = "0.2.0", path = "../../embassy-net-wiznet", features = ["defmt"] }
+embassy-net = { version = "0.7.1", path = "../../embassy-net", features = ["defmt", "icmp", "tcp", "udp", "raw", "dhcpv4", "medium-ethernet", "dns", "proto-ipv4", "proto-ipv6", "multicast"] }
+embassy-net-wiznet = { version = "0.2.1", path = "../../embassy-net-wiznet", features = ["defmt"] }
 embassy-futures = { version = "0.1.0", path = "../../embassy-futures" }
 embassy-usb-logger = { version = "0.5.0", path = "../../embassy-usb-logger" }
 cyw43 = { version = "0.4.0", path = "../../cyw43", features = ["defmt", "firmware-logs"] }

--- a/examples/rp235x/Cargo.toml
+++ b/examples/rp235x/Cargo.toml
@@ -7,14 +7,14 @@ license = "MIT OR Apache-2.0"
 publish = false
 
 [dependencies]
-embassy-embedded-hal = { version = "0.4.0", path = "../../embassy-embedded-hal", features = ["defmt"] }
+embassy-embedded-hal = { version = "0.4.1", path = "../../embassy-embedded-hal", features = ["defmt"] }
 embassy-sync = { version = "0.7.1", path = "../../embassy-sync", features = ["defmt"] }
-embassy-executor = { version = "0.8.0", path = "../../embassy-executor", features = ["arch-cortex-m", "executor-thread", "executor-interrupt", "defmt"] }
-embassy-time = { version = "0.4.0", path = "../../embassy-time", features = ["defmt", "defmt-timestamp-uptime"] }
-embassy-rp = { version = "0.7.0", path = "../../embassy-rp", features = ["defmt", "unstable-pac", "time-driver", "critical-section-impl", "rp235xa", "binary-info"] }
+embassy-executor = { version = "0.9.0", path = "../../embassy-executor", features = ["arch-cortex-m", "executor-thread", "executor-interrupt", "defmt"] }
+embassy-time = { version = "0.5.0", path = "../../embassy-time", features = ["defmt", "defmt-timestamp-uptime"] }
+embassy-rp = { version = "0.7.1", path = "../../embassy-rp", features = ["defmt", "unstable-pac", "time-driver", "critical-section-impl", "rp235xa", "binary-info"] }
 embassy-usb = { version = "0.5.0", path = "../../embassy-usb", features = ["defmt"] }
-embassy-net = { version = "0.7.0", path = "../../embassy-net", features = ["defmt", "icmp", "tcp", "udp", "raw", "dhcpv4", "medium-ethernet", "dns"] }
-embassy-net-wiznet = { version = "0.2.0", path = "../../embassy-net-wiznet", features = ["defmt"] }
+embassy-net = { version = "0.7.1", path = "../../embassy-net", features = ["defmt", "icmp", "tcp", "udp", "raw", "dhcpv4", "medium-ethernet", "dns"] }
+embassy-net-wiznet = { version = "0.2.1", path = "../../embassy-net-wiznet", features = ["defmt"] }
 embassy-futures = { version = "0.1.0", path = "../../embassy-futures" }
 embassy-usb-logger = { version = "0.5.0", path = "../../embassy-usb-logger" }
 cyw43 = { version = "0.4.0", path = "../../cyw43", features = ["defmt", "firmware-logs"] }

--- a/examples/std/Cargo.toml
+++ b/examples/std/Cargo.toml
@@ -7,9 +7,9 @@ publish = false
 
 [dependencies]
 embassy-sync = { version = "0.7.1", path = "../../embassy-sync", features = ["log"] }
-embassy-executor = { version = "0.8.0", path = "../../embassy-executor", features = ["arch-std", "executor-thread", "log"] }
-embassy-time = { version = "0.4.0", path = "../../embassy-time", features = ["log", "std", ] }
-embassy-net = { version = "0.7.0", path = "../../embassy-net", features=[ "log", "medium-ethernet", "medium-ip", "tcp", "udp", "dns", "dhcpv4", "proto-ipv6"] }
+embassy-executor = { version = "0.9.0", path = "../../embassy-executor", features = ["arch-std", "executor-thread", "log"] }
+embassy-time = { version = "0.5.0", path = "../../embassy-time", features = ["log", "std", ] }
+embassy-net = { version = "0.7.1", path = "../../embassy-net", features=[ "log", "medium-ethernet", "medium-ip", "tcp", "udp", "dns", "dhcpv4", "proto-ipv6"] }
 embassy-net-tuntap = { version = "0.1.0", path = "../../embassy-net-tuntap" }
 embassy-net-ppp = { version = "0.2.0", path = "../../embassy-net-ppp", features = ["log"]}
 embedded-io-async = { version = "0.6.1" }

--- a/examples/stm32c0/Cargo.toml
+++ b/examples/stm32c0/Cargo.toml
@@ -7,10 +7,10 @@ publish = false
 
 [dependencies]
 # Change stm32c031c6 to your chip name, if necessary.
-embassy-stm32 = { version = "0.3.0", path = "../../embassy-stm32", features = [ "defmt", "time-driver-any", "stm32c031c6", "memory-x", "unstable-pac", "exti", "chrono"]  }
+embassy-stm32 = { version = "0.4.0", path = "../../embassy-stm32", features = [ "defmt", "time-driver-any", "stm32c031c6", "memory-x", "unstable-pac", "exti", "chrono"]  }
 embassy-sync = { version = "0.7.1", path = "../../embassy-sync", features = ["defmt"] }
-embassy-executor = { version = "0.8.0", path = "../../embassy-executor", features = ["arch-cortex-m", "executor-thread", "defmt"] }
-embassy-time = { version = "0.4.0", path = "../../embassy-time", features = ["defmt", "defmt-timestamp-uptime", "tick-hz-32_768"] }
+embassy-executor = { version = "0.9.0", path = "../../embassy-executor", features = ["arch-cortex-m", "executor-thread", "defmt"] }
+embassy-time = { version = "0.5.0", path = "../../embassy-time", features = ["defmt", "defmt-timestamp-uptime", "tick-hz-32_768"] }
 
 defmt = "1.0.1"
 defmt-rtt = "1.0.0"

--- a/examples/stm32f0/Cargo.toml
+++ b/examples/stm32f0/Cargo.toml
@@ -7,15 +7,15 @@ publish = false
 
 [dependencies]
 # Change stm32f091rc to your chip name, if necessary.
-embassy-stm32 = { version = "0.3.0", path = "../../embassy-stm32", features = [ "defmt", "memory-x", "stm32f091rc", "time-driver-tim2", "exti", "unstable-pac"] }
+embassy-stm32 = { version = "0.4.0", path = "../../embassy-stm32", features = [ "defmt", "memory-x", "stm32f091rc", "time-driver-tim2", "exti", "unstable-pac"] }
 cortex-m = { version = "0.7.6", features = ["inline-asm", "critical-section-single-core"] }
 cortex-m-rt = "0.7.0"
 defmt = "1.0.1"
 defmt-rtt = "1.0.0"
 panic-probe = { version = "1.0.0", features = ["print-defmt"] }
 embassy-sync = { version = "0.7.1", path = "../../embassy-sync", features = ["defmt"] }
-embassy-executor = { version = "0.8.0", path = "../../embassy-executor", features = ["arch-cortex-m", "executor-thread", "executor-interrupt", "defmt"] }
-embassy-time = { version = "0.4.0", path = "../../embassy-time", features = ["defmt", "defmt-timestamp-uptime", "tick-hz-32_768"] }
+embassy-executor = { version = "0.9.0", path = "../../embassy-executor", features = ["arch-cortex-m", "executor-thread", "executor-interrupt", "defmt"] }
+embassy-time = { version = "0.5.0", path = "../../embassy-time", features = ["defmt", "defmt-timestamp-uptime", "tick-hz-32_768"] }
 static_cell = "2"
 portable-atomic = { version = "1.5", features = ["unsafe-assume-single-core"] }
 

--- a/examples/stm32f1/Cargo.toml
+++ b/examples/stm32f1/Cargo.toml
@@ -7,10 +7,10 @@ publish = false
 
 [dependencies]
 # Change stm32f103c8 to your chip name, if necessary.
-embassy-stm32 = { version = "0.3.0", path = "../../embassy-stm32", features = [ "defmt", "stm32f103c8", "unstable-pac", "memory-x", "time-driver-any" ]  }
+embassy-stm32 = { version = "0.4.0", path = "../../embassy-stm32", features = [ "defmt", "stm32f103c8", "unstable-pac", "memory-x", "time-driver-any" ]  }
 embassy-sync = { version = "0.7.1", path = "../../embassy-sync", features = ["defmt"] }
-embassy-executor = { version = "0.8.0", path = "../../embassy-executor", features = ["arch-cortex-m", "executor-thread", "defmt"] }
-embassy-time = { version = "0.4.0", path = "../../embassy-time", features = ["defmt", "defmt-timestamp-uptime", "tick-hz-32_768"] }
+embassy-executor = { version = "0.9.0", path = "../../embassy-executor", features = ["arch-cortex-m", "executor-thread", "defmt"] }
+embassy-time = { version = "0.5.0", path = "../../embassy-time", features = ["defmt", "defmt-timestamp-uptime", "tick-hz-32_768"] }
 embassy-usb = { version = "0.5.0", path = "../../embassy-usb", features = ["defmt"] }
 embassy-futures = { version = "0.1.0", path = "../../embassy-futures" }
 

--- a/examples/stm32f2/Cargo.toml
+++ b/examples/stm32f2/Cargo.toml
@@ -7,10 +7,10 @@ publish = false
 
 [dependencies]
 # Change stm32f207zg to your chip name, if necessary.
-embassy-stm32 = { version = "0.3.0", path = "../../embassy-stm32", features = [ "defmt", "stm32f207zg", "unstable-pac", "memory-x", "time-driver-any", "exti"]  }
+embassy-stm32 = { version = "0.4.0", path = "../../embassy-stm32", features = [ "defmt", "stm32f207zg", "unstable-pac", "memory-x", "time-driver-any", "exti"]  }
 embassy-sync = { version = "0.7.1", path = "../../embassy-sync", features = ["defmt"] }
-embassy-executor = { version = "0.8.0", path = "../../embassy-executor", features = ["arch-cortex-m", "executor-thread", "defmt"] }
-embassy-time = { version = "0.4.0", path = "../../embassy-time", features = ["defmt", "defmt-timestamp-uptime", "tick-hz-32_768"] }
+embassy-executor = { version = "0.9.0", path = "../../embassy-executor", features = ["arch-cortex-m", "executor-thread", "defmt"] }
+embassy-time = { version = "0.5.0", path = "../../embassy-time", features = ["defmt", "defmt-timestamp-uptime", "tick-hz-32_768"] }
 
 defmt = "1.0.1"
 defmt-rtt = "1.0.0"

--- a/examples/stm32f3/Cargo.toml
+++ b/examples/stm32f3/Cargo.toml
@@ -7,10 +7,10 @@ publish = false
 
 [dependencies]
 # Change stm32f303ze to your chip name, if necessary.
-embassy-stm32 = { version = "0.3.0", path = "../../embassy-stm32", features = [ "defmt", "stm32f303ze", "unstable-pac", "memory-x", "time-driver-tim2", "exti"]  }
+embassy-stm32 = { version = "0.4.0", path = "../../embassy-stm32", features = [ "defmt", "stm32f303ze", "unstable-pac", "memory-x", "time-driver-tim2", "exti"]  }
 embassy-sync = { version = "0.7.1", path = "../../embassy-sync", features = ["defmt"] }
-embassy-executor = { version = "0.8.0", path = "../../embassy-executor", features = ["arch-cortex-m", "executor-thread", "executor-interrupt", "defmt"] }
-embassy-time = { version = "0.4.0", path = "../../embassy-time", features = ["defmt", "defmt-timestamp-uptime", "tick-hz-32_768"] }
+embassy-executor = { version = "0.9.0", path = "../../embassy-executor", features = ["arch-cortex-m", "executor-thread", "executor-interrupt", "defmt"] }
+embassy-time = { version = "0.5.0", path = "../../embassy-time", features = ["defmt", "defmt-timestamp-uptime", "tick-hz-32_768"] }
 embassy-usb = { version = "0.5.0", path = "../../embassy-usb", features = ["defmt"] }
 embassy-futures = { version = "0.1.0", path = "../../embassy-futures" }
 

--- a/examples/stm32f334/Cargo.toml
+++ b/examples/stm32f334/Cargo.toml
@@ -7,9 +7,9 @@ publish = false
 
 [dependencies]
 embassy-sync = { version = "0.7.1", path = "../../embassy-sync", features = ["defmt"] }
-embassy-executor = { version = "0.8.0", path = "../../embassy-executor", features = ["arch-cortex-m", "executor-thread", "executor-interrupt", "defmt"] }
-embassy-time = { version = "0.4.0", path = "../../embassy-time", features = ["defmt", "defmt-timestamp-uptime", "tick-hz-32_768"] }
-embassy-stm32 = { version = "0.3.0", path = "../../embassy-stm32", features = [ "defmt", "stm32f334r8", "unstable-pac", "memory-x", "time-driver-any", "exti"]  }
+embassy-executor = { version = "0.9.0", path = "../../embassy-executor", features = ["arch-cortex-m", "executor-thread", "executor-interrupt", "defmt"] }
+embassy-time = { version = "0.5.0", path = "../../embassy-time", features = ["defmt", "defmt-timestamp-uptime", "tick-hz-32_768"] }
+embassy-stm32 = { version = "0.4.0", path = "../../embassy-stm32", features = [ "defmt", "stm32f334r8", "unstable-pac", "memory-x", "time-driver-any", "exti"]  }
 embassy-usb = { version = "0.5.0", path = "../../embassy-usb", features = ["defmt"] }
 embassy-futures = { version = "0.1.0", path = "../../embassy-futures" }
 

--- a/examples/stm32f4/Cargo.toml
+++ b/examples/stm32f4/Cargo.toml
@@ -7,13 +7,13 @@ publish = false
 
 [dependencies]
 # Change stm32f429zi to your chip name, if necessary.
-embassy-stm32 = { version = "0.3.0", path = "../../embassy-stm32", features = ["defmt", "stm32f429zi", "unstable-pac", "memory-x", "time-driver-tim4", "exti", "chrono"] }
+embassy-stm32 = { version = "0.4.0", path = "../../embassy-stm32", features = ["defmt", "stm32f429zi", "unstable-pac", "memory-x", "time-driver-tim4", "exti", "chrono"] }
 embassy-sync = { version = "0.7.1", path = "../../embassy-sync", features = ["defmt"] }
-embassy-executor = { version = "0.8.0", path = "../../embassy-executor", features = ["arch-cortex-m", "executor-thread", "executor-interrupt", "defmt"] }
-embassy-time = { version = "0.4.0", path = "../../embassy-time", features = ["defmt", "defmt-timestamp-uptime", "tick-hz-32_768"] }
+embassy-executor = { version = "0.9.0", path = "../../embassy-executor", features = ["arch-cortex-m", "executor-thread", "executor-interrupt", "defmt"] }
+embassy-time = { version = "0.5.0", path = "../../embassy-time", features = ["defmt", "defmt-timestamp-uptime", "tick-hz-32_768"] }
 embassy-usb = { version = "0.5.0", path = "../../embassy-usb", features = ["defmt" ] }
-embassy-net = { version = "0.7.0", path = "../../embassy-net", features = ["defmt", "tcp", "dhcpv4", "medium-ethernet", ] }
-embassy-net-wiznet = { version = "0.2.0", path = "../../embassy-net-wiznet", features = ["defmt"] }
+embassy-net = { version = "0.7.1", path = "../../embassy-net", features = ["defmt", "tcp", "dhcpv4", "medium-ethernet", ] }
+embassy-net-wiznet = { version = "0.2.1", path = "../../embassy-net-wiznet", features = ["defmt"] }
 embassy-futures = { version = "0.1.0", path = "../../embassy-futures" }
 
 defmt = "1.0.1"

--- a/examples/stm32f469/Cargo.toml
+++ b/examples/stm32f469/Cargo.toml
@@ -7,9 +7,9 @@ publish = false
 
 [dependencies]
 # Specific examples only for stm32f469
-embassy-stm32 = { version = "0.3.0", path = "../../embassy-stm32", features = ["defmt", "stm32f469ni", "unstable-pac", "memory-x", "time-driver-any", "exti", "chrono"] }
-embassy-executor = { version = "0.8.0", path = "../../embassy-executor", features = ["arch-cortex-m", "executor-thread", "executor-interrupt", "defmt"] }
-embassy-time = { version = "0.4.0", path = "../../embassy-time", features = ["defmt", "defmt-timestamp-uptime", "tick-hz-32_768"] }
+embassy-stm32 = { version = "0.4.0", path = "../../embassy-stm32", features = ["defmt", "stm32f469ni", "unstable-pac", "memory-x", "time-driver-any", "exti", "chrono"] }
+embassy-executor = { version = "0.9.0", path = "../../embassy-executor", features = ["arch-cortex-m", "executor-thread", "executor-interrupt", "defmt"] }
+embassy-time = { version = "0.5.0", path = "../../embassy-time", features = ["defmt", "defmt-timestamp-uptime", "tick-hz-32_768"] }
 
 defmt = "1.0.1"
 defmt-rtt = "1.0.0"

--- a/examples/stm32g0/Cargo.toml
+++ b/examples/stm32g0/Cargo.toml
@@ -7,10 +7,10 @@ publish = false
 
 [dependencies]
 # Change stm32g0b1re to your chip name, if necessary.
-embassy-stm32 = { version = "0.3.0", path = "../../embassy-stm32", features = [ "defmt", "time-driver-any", "stm32g0b1re", "memory-x", "unstable-pac", "exti"]  }
+embassy-stm32 = { version = "0.4.0", path = "../../embassy-stm32", features = [ "defmt", "time-driver-any", "stm32g0b1re", "memory-x", "unstable-pac", "exti"]  }
 embassy-sync = { version = "0.7.1", path = "../../embassy-sync", features = ["defmt"] }
-embassy-executor = { version = "0.8.0", path = "../../embassy-executor", features = ["arch-cortex-m", "executor-thread", "defmt"] }
-embassy-time = { version = "0.4.0", path = "../../embassy-time", features = ["defmt", "defmt-timestamp-uptime", "tick-hz-32_768"] }
+embassy-executor = { version = "0.9.0", path = "../../embassy-executor", features = ["arch-cortex-m", "executor-thread", "defmt"] }
+embassy-time = { version = "0.5.0", path = "../../embassy-time", features = ["defmt", "defmt-timestamp-uptime", "tick-hz-32_768"] }
 embassy-usb = { version = "0.5.0", path = "../../embassy-usb", default-features = false, features = ["defmt"] }
 embassy-futures = { version = "0.1.0", path = "../../embassy-futures" }
 

--- a/examples/stm32g4/Cargo.toml
+++ b/examples/stm32g4/Cargo.toml
@@ -7,10 +7,10 @@ publish = false
 
 [dependencies]
 # Change stm32g491re to your chip name, if necessary.
-embassy-stm32 = { version = "0.3.0", path = "../../embassy-stm32", features = [ "defmt", "time-driver-any", "stm32g491re", "memory-x", "unstable-pac", "exti"]  }
+embassy-stm32 = { version = "0.4.0", path = "../../embassy-stm32", features = [ "defmt", "time-driver-any", "stm32g491re", "memory-x", "unstable-pac", "exti"]  }
 embassy-sync = { version = "0.7.1", path = "../../embassy-sync", features = ["defmt"] }
-embassy-executor = { version = "0.8.0", path = "../../embassy-executor", features = ["arch-cortex-m", "executor-thread", "defmt"] }
-embassy-time = { version = "0.4.0", path = "../../embassy-time", features = ["defmt", "defmt-timestamp-uptime", "tick-hz-32_768"] }
+embassy-executor = { version = "0.9.0", path = "../../embassy-executor", features = ["arch-cortex-m", "executor-thread", "defmt"] }
+embassy-time = { version = "0.5.0", path = "../../embassy-time", features = ["defmt", "defmt-timestamp-uptime", "tick-hz-32_768"] }
 embassy-usb = { version = "0.5.0", path = "../../embassy-usb", features = ["defmt"] }
 embassy-futures = { version = "0.1.0", path = "../../embassy-futures" }
 usbd-hid = "0.8.1"

--- a/examples/stm32h5/Cargo.toml
+++ b/examples/stm32h5/Cargo.toml
@@ -7,11 +7,11 @@ publish = false
 
 [dependencies]
 # Change stm32h563zi to your chip name, if necessary.
-embassy-stm32 = { version = "0.3.0", path = "../../embassy-stm32", features = ["defmt", "stm32h563zi", "memory-x", "time-driver-any", "exti", "unstable-pac", "low-power"] }
+embassy-stm32 = { version = "0.4.0", path = "../../embassy-stm32", features = ["defmt", "stm32h563zi", "memory-x", "time-driver-any", "exti", "unstable-pac", "low-power"] }
 embassy-sync = { version = "0.7.1", path = "../../embassy-sync", features = ["defmt"] }
-embassy-executor = { version = "0.8.0", path = "../../embassy-executor", features = ["arch-cortex-m", "executor-thread", "defmt"] }
-embassy-time = { version = "0.4.0", path = "../../embassy-time", features = ["defmt", "defmt-timestamp-uptime", "tick-hz-32_768"] }
-embassy-net = { version = "0.7.0", path = "../../embassy-net", features = ["defmt", "tcp", "dhcpv4", "medium-ethernet", "proto-ipv6"] }
+embassy-executor = { version = "0.9.0", path = "../../embassy-executor", features = ["arch-cortex-m", "executor-thread", "defmt"] }
+embassy-time = { version = "0.5.0", path = "../../embassy-time", features = ["defmt", "defmt-timestamp-uptime", "tick-hz-32_768"] }
+embassy-net = { version = "0.7.1", path = "../../embassy-net", features = ["defmt", "tcp", "dhcpv4", "medium-ethernet", "proto-ipv6"] }
 embassy-usb = { version = "0.5.0", path = "../../embassy-usb", features = ["defmt"] }
 embassy-futures = { version = "0.1.0", path = "../../embassy-futures" }
 

--- a/examples/stm32h7/Cargo.toml
+++ b/examples/stm32h7/Cargo.toml
@@ -7,12 +7,12 @@ publish = false
 
 [dependencies]
 # Change stm32h743bi to your chip name, if necessary.
-embassy-stm32 = { version = "0.3.0", path = "../../embassy-stm32", features = ["defmt", "stm32h743bi", "time-driver-tim2", "exti", "memory-x", "unstable-pac", "chrono"] }
+embassy-stm32 = { version = "0.4.0", path = "../../embassy-stm32", features = ["defmt", "stm32h743bi", "time-driver-tim2", "exti", "memory-x", "unstable-pac", "chrono"] }
 embassy-sync = { version = "0.7.1", path = "../../embassy-sync", features = ["defmt"] }
-embassy-embedded-hal = { version = "0.4.0", path = "../../embassy-embedded-hal" }
-embassy-executor = { version = "0.8.0", path = "../../embassy-executor", features = ["arch-cortex-m", "executor-thread", "executor-interrupt", "defmt"] }
-embassy-time = { version = "0.4.0", path = "../../embassy-time", features = ["defmt", "defmt-timestamp-uptime", "tick-hz-32_768"] }
-embassy-net = { version = "0.7.0", path = "../../embassy-net", features = ["defmt", "tcp", "dhcpv4", "medium-ethernet", "proto-ipv6", "dns"] }
+embassy-embedded-hal = { version = "0.4.1", path = "../../embassy-embedded-hal" }
+embassy-executor = { version = "0.9.0", path = "../../embassy-executor", features = ["arch-cortex-m", "executor-thread", "executor-interrupt", "defmt"] }
+embassy-time = { version = "0.5.0", path = "../../embassy-time", features = ["defmt", "defmt-timestamp-uptime", "tick-hz-32_768"] }
+embassy-net = { version = "0.7.1", path = "../../embassy-net", features = ["defmt", "tcp", "dhcpv4", "medium-ethernet", "proto-ipv6", "dns"] }
 embassy-usb = { version = "0.5.0", path = "../../embassy-usb", features = ["defmt"] }
 embassy-futures = { version = "0.1.0", path = "../../embassy-futures" }
 

--- a/examples/stm32h723/Cargo.toml
+++ b/examples/stm32h723/Cargo.toml
@@ -7,10 +7,10 @@ publish = false
 
 [dependencies]
 # Change stm32h723zg to your chip name, if necessary.
-embassy-stm32 = { version = "0.3.0", path = "../../embassy-stm32", features = ["defmt", "stm32h723zg", "time-driver-tim2", "exti", "memory-x", "unstable-pac", "chrono"] }
+embassy-stm32 = { version = "0.4.0", path = "../../embassy-stm32", features = ["defmt", "stm32h723zg", "time-driver-tim2", "exti", "memory-x", "unstable-pac", "chrono"] }
 embassy-sync = { version = "0.7.1", path = "../../embassy-sync", features = ["defmt"] }
-embassy-executor = { version = "0.8.0", path = "../../embassy-executor", features = ["arch-cortex-m", "executor-thread", "executor-interrupt", "defmt"] }
-embassy-time = { version = "0.4.0", path = "../../embassy-time", features = ["defmt", "defmt-timestamp-uptime", "tick-hz-32_768"] }
+embassy-executor = { version = "0.9.0", path = "../../embassy-executor", features = ["arch-cortex-m", "executor-thread", "executor-interrupt", "defmt"] }
+embassy-time = { version = "0.5.0", path = "../../embassy-time", features = ["defmt", "defmt-timestamp-uptime", "tick-hz-32_768"] }
 embassy-futures = { version = "0.1.0", path = "../../embassy-futures" }
 
 defmt = "1.0.1"

--- a/examples/stm32h735/Cargo.toml
+++ b/examples/stm32h735/Cargo.toml
@@ -6,11 +6,11 @@ license = "MIT OR Apache-2.0"
 publish = false
 
 [dependencies]
-embassy-stm32 = { version = "0.3.0", path = "../../embassy-stm32", features = ["defmt", "stm32h735ig", "time-driver-tim2", "exti", "memory-x", "unstable-pac", "chrono"] }
+embassy-stm32 = { version = "0.4.0", path = "../../embassy-stm32", features = ["defmt", "stm32h735ig", "time-driver-tim2", "exti", "memory-x", "unstable-pac", "chrono"] }
 embassy-sync = { version = "0.7.1", path = "../../embassy-sync", features = ["defmt"] }
-embassy-embedded-hal = { version = "0.4.0", path = "../../embassy-embedded-hal" }
-embassy-executor = { version = "0.8.0", path = "../../embassy-executor", features = ["arch-cortex-m", "executor-thread", "executor-interrupt", "defmt"] }
-embassy-time = { version = "0.4.0", path = "../../embassy-time", features = ["defmt", "defmt-timestamp-uptime", "tick-hz-32_768"] }
+embassy-embedded-hal = { version = "0.4.1", path = "../../embassy-embedded-hal" }
+embassy-executor = { version = "0.9.0", path = "../../embassy-executor", features = ["arch-cortex-m", "executor-thread", "executor-interrupt", "defmt"] }
+embassy-time = { version = "0.5.0", path = "../../embassy-time", features = ["defmt", "defmt-timestamp-uptime", "tick-hz-32_768"] }
 embassy-futures = { version = "0.1.0", path = "../../embassy-futures" }
 
 defmt = "1.0.1"

--- a/examples/stm32h742/Cargo.toml
+++ b/examples/stm32h742/Cargo.toml
@@ -7,7 +7,7 @@ publish = false
 
 [dependencies]
 # Change stm32f777zi to your chip name, if necessary.
-embassy-stm32 = { version = "0.3.0", path = "../../embassy-stm32", features = [
+embassy-stm32 = { version = "0.4.0", path = "../../embassy-stm32", features = [
     "defmt",
     "stm32h742vi",
     "memory-x",
@@ -18,17 +18,17 @@ embassy-stm32 = { version = "0.3.0", path = "../../embassy-stm32", features = [
 embassy-sync = { version = "0.7.1", path = "../../embassy-sync", features = [
     "defmt",
 ] }
-embassy-executor = { version = "0.8.0", path = "../../embassy-executor", features = [
+embassy-executor = { version = "0.9.0", path = "../../embassy-executor", features = [
     "arch-cortex-m",
     "executor-thread",
     "defmt",
 ] }
-embassy-time = { version = "0.4.0", path = "../../embassy-time", features = [
+embassy-time = { version = "0.5.0", path = "../../embassy-time", features = [
     "defmt",
     "defmt-timestamp-uptime",
     "tick-hz-32_768",
 ] }
-embassy-net = { version = "0.7.0", path = "../../embassy-net", features = [
+embassy-net = { version = "0.7.1", path = "../../embassy-net", features = [
     "defmt",
     "tcp",
     "dhcpv4",

--- a/examples/stm32h755cm4/Cargo.toml
+++ b/examples/stm32h755cm4/Cargo.toml
@@ -7,12 +7,12 @@ publish = false
 
 [dependencies]
 # Change stm32h755zi-cm4 to your chip name, if necessary.
-embassy-stm32 = { version = "0.3.0", path = "../../embassy-stm32", features = ["defmt", "stm32h755zi-cm4", "time-driver-tim2", "exti", "memory-x", "unstable-pac", "chrono"] }
+embassy-stm32 = { version = "0.4.0", path = "../../embassy-stm32", features = ["defmt", "stm32h755zi-cm4", "time-driver-tim2", "exti", "memory-x", "unstable-pac", "chrono"] }
 embassy-sync = { version = "0.7.1", path = "../../embassy-sync", features = ["defmt"] }
-embassy-embedded-hal = { version = "0.4.0", path = "../../embassy-embedded-hal" }
-embassy-executor = { version = "0.8.0", path = "../../embassy-executor", features = ["arch-cortex-m", "executor-thread", "executor-interrupt", "defmt"] }
-embassy-time = { version = "0.4.0", path = "../../embassy-time", features = ["defmt", "defmt-timestamp-uptime", "tick-hz-32_768"] }
-embassy-net = { version = "0.7.0", path = "../../embassy-net", features = ["defmt", "tcp", "dhcpv4", "medium-ethernet", "proto-ipv6", "dns"] }
+embassy-embedded-hal = { version = "0.4.1", path = "../../embassy-embedded-hal" }
+embassy-executor = { version = "0.9.0", path = "../../embassy-executor", features = ["arch-cortex-m", "executor-thread", "executor-interrupt", "defmt"] }
+embassy-time = { version = "0.5.0", path = "../../embassy-time", features = ["defmt", "defmt-timestamp-uptime", "tick-hz-32_768"] }
+embassy-net = { version = "0.7.1", path = "../../embassy-net", features = ["defmt", "tcp", "dhcpv4", "medium-ethernet", "proto-ipv6", "dns"] }
 embassy-usb = { version = "0.5.0", path = "../../embassy-usb", features = ["defmt"] }
 embassy-futures = { version = "0.1.0", path = "../../embassy-futures" }
 

--- a/examples/stm32h755cm7/Cargo.toml
+++ b/examples/stm32h755cm7/Cargo.toml
@@ -7,12 +7,12 @@ publish = false
 
 [dependencies]
 # Change stm32h743bi to your chip name, if necessary.
-embassy-stm32 = { version = "0.3.0", path = "../../embassy-stm32", features = ["defmt", "stm32h755zi-cm7", "time-driver-tim3", "exti", "memory-x", "unstable-pac", "chrono"] }
+embassy-stm32 = { version = "0.4.0", path = "../../embassy-stm32", features = ["defmt", "stm32h755zi-cm7", "time-driver-tim3", "exti", "memory-x", "unstable-pac", "chrono"] }
 embassy-sync = { version = "0.7.1", path = "../../embassy-sync", features = ["defmt"] }
-embassy-embedded-hal = { version = "0.4.0", path = "../../embassy-embedded-hal" }
-embassy-executor = { version = "0.8.0", path = "../../embassy-executor", features = ["arch-cortex-m", "executor-thread", "executor-interrupt", "defmt"] }
-embassy-time = { version = "0.4.0", path = "../../embassy-time", features = ["defmt", "defmt-timestamp-uptime", "tick-hz-32_768"] }
-embassy-net = { version = "0.7.0", path = "../../embassy-net", features = ["defmt", "tcp", "dhcpv4", "medium-ethernet", "proto-ipv6", "dns"] }
+embassy-embedded-hal = { version = "0.4.1", path = "../../embassy-embedded-hal" }
+embassy-executor = { version = "0.9.0", path = "../../embassy-executor", features = ["arch-cortex-m", "executor-thread", "executor-interrupt", "defmt"] }
+embassy-time = { version = "0.5.0", path = "../../embassy-time", features = ["defmt", "defmt-timestamp-uptime", "tick-hz-32_768"] }
+embassy-net = { version = "0.7.1", path = "../../embassy-net", features = ["defmt", "tcp", "dhcpv4", "medium-ethernet", "proto-ipv6", "dns"] }
 embassy-usb = { version = "0.5.0", path = "../../embassy-usb", features = ["defmt"] }
 embassy-futures = { version = "0.1.0", path = "../../embassy-futures" }
 

--- a/examples/stm32h7b0/Cargo.toml
+++ b/examples/stm32h7b0/Cargo.toml
@@ -6,12 +6,12 @@ license = "MIT OR Apache-2.0"
 publish = false
 
 [dependencies]
-embassy-stm32 = { version = "0.3.0", path = "../../embassy-stm32", features = ["defmt", "stm32h7b0vb", "time-driver-tim2", "exti", "memory-x", "unstable-pac", "chrono"] }
+embassy-stm32 = { version = "0.4.0", path = "../../embassy-stm32", features = ["defmt", "stm32h7b0vb", "time-driver-tim2", "exti", "memory-x", "unstable-pac", "chrono"] }
 embassy-sync = { version = "0.7.1", path = "../../embassy-sync", features = ["defmt"] }
-embassy-embedded-hal = { version = "0.4.0", path = "../../embassy-embedded-hal" }
-embassy-executor = { version = "0.8.0", path = "../../embassy-executor", features = ["arch-cortex-m", "executor-thread", "executor-interrupt", "defmt"] }
-embassy-time = { version = "0.4.0", path = "../../embassy-time", features = ["defmt", "defmt-timestamp-uptime", "tick-hz-32_768"] }
-embassy-net = { version = "0.7.0", path = "../../embassy-net", features = ["defmt", "tcp", "dhcpv4", "medium-ethernet", "proto-ipv6", "dns"] }
+embassy-embedded-hal = { version = "0.4.1", path = "../../embassy-embedded-hal" }
+embassy-executor = { version = "0.9.0", path = "../../embassy-executor", features = ["arch-cortex-m", "executor-thread", "executor-interrupt", "defmt"] }
+embassy-time = { version = "0.5.0", path = "../../embassy-time", features = ["defmt", "defmt-timestamp-uptime", "tick-hz-32_768"] }
+embassy-net = { version = "0.7.1", path = "../../embassy-net", features = ["defmt", "tcp", "dhcpv4", "medium-ethernet", "proto-ipv6", "dns"] }
 embassy-usb = { version = "0.5.0", path = "../../embassy-usb", features = ["defmt"] }
 embassy-futures = { version = "0.1.0", path = "../../embassy-futures" }
 

--- a/examples/stm32h7rs/Cargo.toml
+++ b/examples/stm32h7rs/Cargo.toml
@@ -7,11 +7,11 @@ publish = false
 
 [dependencies]
 # Change stm32h743bi to your chip name, if necessary.
-embassy-stm32 = { version = "0.3.0", path = "../../embassy-stm32", features = ["defmt", "stm32h7s3l8", "time-driver-tim2", "exti", "memory-x", "unstable-pac", "chrono"] }
+embassy-stm32 = { version = "0.4.0", path = "../../embassy-stm32", features = ["defmt", "stm32h7s3l8", "time-driver-tim2", "exti", "memory-x", "unstable-pac", "chrono"] }
 embassy-sync = { version = "0.7.1", path = "../../embassy-sync", features = ["defmt"] }
-embassy-executor = { version = "0.8.0", path = "../../embassy-executor", features = ["arch-cortex-m", "executor-thread", "executor-interrupt", "defmt"] }
-embassy-time = { version = "0.4.0", path = "../../embassy-time", features = ["defmt", "defmt-timestamp-uptime", "tick-hz-32_768"] }
-embassy-net = { version = "0.7.0", path = "../../embassy-net", features = ["defmt", "udp", "medium-ethernet", "medium-ip", "proto-ipv4"] }
+embassy-executor = { version = "0.9.0", path = "../../embassy-executor", features = ["arch-cortex-m", "executor-thread", "executor-interrupt", "defmt"] }
+embassy-time = { version = "0.5.0", path = "../../embassy-time", features = ["defmt", "defmt-timestamp-uptime", "tick-hz-32_768"] }
+embassy-net = { version = "0.7.1", path = "../../embassy-net", features = ["defmt", "udp", "medium-ethernet", "medium-ip", "proto-ipv4"] }
 embassy-usb = { version = "0.5.0", path = "../../embassy-usb", features = ["defmt"] }
 embassy-futures = { version = "0.1.0", path = "../../embassy-futures" }
 

--- a/examples/stm32l0/Cargo.toml
+++ b/examples/stm32l0/Cargo.toml
@@ -7,10 +7,10 @@ publish = false
 
 [dependencies]
 # Change stm32l072cz to your chip name, if necessary.
-embassy-stm32 = { version = "0.3.0", path = "../../embassy-stm32", features = ["defmt", "stm32l073rz", "unstable-pac", "time-driver-any", "exti", "memory-x"]  }
+embassy-stm32 = { version = "0.4.0", path = "../../embassy-stm32", features = ["defmt", "stm32l073rz", "unstable-pac", "time-driver-any", "exti", "memory-x"]  }
 embassy-sync = { version = "0.7.1", path = "../../embassy-sync", features = ["defmt"] }
-embassy-executor = { version = "0.8.0", path = "../../embassy-executor", features = ["arch-cortex-m", "executor-thread", "defmt"] }
-embassy-time = { version = "0.4.0", path = "../../embassy-time", features = ["defmt", "defmt-timestamp-uptime", "tick-hz-32_768"] }
+embassy-executor = { version = "0.9.0", path = "../../embassy-executor", features = ["arch-cortex-m", "executor-thread", "defmt"] }
+embassy-time = { version = "0.5.0", path = "../../embassy-time", features = ["defmt", "defmt-timestamp-uptime", "tick-hz-32_768"] }
 
 defmt = "1.0.1"
 defmt-rtt = "1.0.0"

--- a/examples/stm32l1/Cargo.toml
+++ b/examples/stm32l1/Cargo.toml
@@ -7,9 +7,9 @@ publish = false
 
 [dependencies]
 embassy-sync = { version = "0.7.1", path = "../../embassy-sync", features = ["defmt"] }
-embassy-executor = { version = "0.8.0", path = "../../embassy-executor", features = ["arch-cortex-m", "executor-thread", "defmt"] }
-embassy-time = { version = "0.4.0", path = "../../embassy-time", features = ["defmt", "defmt-timestamp-uptime", "tick-hz-32_768"] }
-embassy-stm32 = { version = "0.3.0", path = "../../embassy-stm32", features = [ "defmt", "stm32l151cb-a", "time-driver-any", "memory-x"]  }
+embassy-executor = { version = "0.9.0", path = "../../embassy-executor", features = ["arch-cortex-m", "executor-thread", "defmt"] }
+embassy-time = { version = "0.5.0", path = "../../embassy-time", features = ["defmt", "defmt-timestamp-uptime", "tick-hz-32_768"] }
+embassy-stm32 = { version = "0.4.0", path = "../../embassy-stm32", features = [ "defmt", "stm32l151cb-a", "time-driver-any", "memory-x"]  }
 embassy-usb = { version = "0.5.0", path = "../../embassy-usb", features = ["defmt"] }
 embassy-futures = { version = "0.1.0", path = "../../embassy-futures" }
 

--- a/examples/stm32l432/Cargo.toml
+++ b/examples/stm32l432/Cargo.toml
@@ -7,10 +7,10 @@ publish = false
 
 [dependencies]
 # Change stm32l4s5vi to your chip name, if necessary.
-embassy-stm32 = { version = "0.3.0", path = "../../embassy-stm32", features = [ "defmt", "unstable-pac", "stm32l432kc", "memory-x", "time-driver-any", "exti", "chrono"] }
+embassy-stm32 = { version = "0.4.0", path = "../../embassy-stm32", features = [ "defmt", "unstable-pac", "stm32l432kc", "memory-x", "time-driver-any", "exti", "chrono"] }
 embassy-sync = { version = "0.7.1", path = "../../embassy-sync", features = [ "defmt" ] }
-embassy-executor = { version = "0.8.0", path = "../../embassy-executor", features = [ "arch-cortex-m", "executor-thread", "defmt" ] }
-embassy-time = { version = "0.4.0", path = "../../embassy-time", features = [ "defmt", "defmt-timestamp-uptime", "tick-hz-32_768" ] }
+embassy-executor = { version = "0.9.0", path = "../../embassy-executor", features = [ "arch-cortex-m", "executor-thread", "defmt" ] }
+embassy-time = { version = "0.5.0", path = "../../embassy-time", features = [ "defmt", "defmt-timestamp-uptime", "tick-hz-32_768" ] }
 defmt = "1.0.1"
 defmt-rtt = "1.0.0"
 

--- a/examples/stm32l5/Cargo.toml
+++ b/examples/stm32l5/Cargo.toml
@@ -7,12 +7,12 @@ publish = false
 
 [dependencies]
 # Change stm32l552ze to your chip name, if necessary.
-embassy-stm32 = { version = "0.3.0", path = "../../embassy-stm32", features = [ "defmt", "unstable-pac", "stm32l552ze", "time-driver-any", "exti", "memory-x", "low-power", "dual-bank"]  }
+embassy-stm32 = { version = "0.4.0", path = "../../embassy-stm32", features = [ "defmt", "unstable-pac", "stm32l552ze", "time-driver-any", "exti", "memory-x", "low-power", "dual-bank"]  }
 embassy-sync = { version = "0.7.1", path = "../../embassy-sync", features = ["defmt"] }
-embassy-executor = { version = "0.8.0", path = "../../embassy-executor", features = ["arch-cortex-m", "executor-thread", "defmt"] }
-embassy-time = { version = "0.4.0", path = "../../embassy-time", features = ["defmt", "defmt-timestamp-uptime", "tick-hz-32_768"] }
+embassy-executor = { version = "0.9.0", path = "../../embassy-executor", features = ["arch-cortex-m", "executor-thread", "defmt"] }
+embassy-time = { version = "0.5.0", path = "../../embassy-time", features = ["defmt", "defmt-timestamp-uptime", "tick-hz-32_768"] }
 embassy-usb = { version = "0.5.0", path = "../../embassy-usb", features = ["defmt"] }
-embassy-net = { version = "0.7.0", path = "../../embassy-net", features = ["defmt",  "tcp", "dhcpv4", "medium-ethernet"] }
+embassy-net = { version = "0.7.1", path = "../../embassy-net", features = ["defmt",  "tcp", "dhcpv4", "medium-ethernet"] }
 embassy-futures = { version = "0.1.0", path = "../../embassy-futures" }
 usbd-hid = "0.8.1"
 

--- a/examples/stm32u0/Cargo.toml
+++ b/examples/stm32u0/Cargo.toml
@@ -7,10 +7,10 @@ publish = false
 
 [dependencies]
 # Change stm32u083rc to your chip name, if necessary.
-embassy-stm32 = { version = "0.3.0", path = "../../embassy-stm32", features = [ "defmt", "time-driver-any", "stm32u083rc", "memory-x", "unstable-pac", "exti", "chrono"]  }
+embassy-stm32 = { version = "0.4.0", path = "../../embassy-stm32", features = [ "defmt", "time-driver-any", "stm32u083rc", "memory-x", "unstable-pac", "exti", "chrono"]  }
 embassy-sync = { version = "0.7.1", path = "../../embassy-sync", features = ["defmt"] }
-embassy-executor = { version = "0.8.0", path = "../../embassy-executor", features = ["arch-cortex-m", "executor-thread", "defmt"] }
-embassy-time = { version = "0.4.0", path = "../../embassy-time", features = ["defmt", "defmt-timestamp-uptime", "tick-hz-32_768"] }
+embassy-executor = { version = "0.9.0", path = "../../embassy-executor", features = ["arch-cortex-m", "executor-thread", "defmt"] }
+embassy-time = { version = "0.5.0", path = "../../embassy-time", features = ["defmt", "defmt-timestamp-uptime", "tick-hz-32_768"] }
 embassy-usb = { version = "0.5.0", path = "../../embassy-usb", default-features = false, features = ["defmt"] }
 embassy-futures = { version = "0.1.0", path = "../../embassy-futures" }
 

--- a/examples/stm32u5/Cargo.toml
+++ b/examples/stm32u5/Cargo.toml
@@ -7,10 +7,10 @@ publish = false
 
 [dependencies]
 # Change stm32u5g9zj to your chip name, if necessary.
-embassy-stm32 = { version = "0.3.0", path = "../../embassy-stm32", features = ["defmt", "unstable-pac", "stm32u5g9zj", "time-driver-any", "memory-x" ]  }
+embassy-stm32 = { version = "0.4.0", path = "../../embassy-stm32", features = ["defmt", "unstable-pac", "stm32u5g9zj", "time-driver-any", "memory-x" ]  }
 embassy-sync = { version = "0.7.1", path = "../../embassy-sync", features = ["defmt"] }
-embassy-executor = { version = "0.8.0", path = "../../embassy-executor", features = ["arch-cortex-m", "executor-thread", "defmt"] }
-embassy-time = { version = "0.4.0", path = "../../embassy-time", features = ["defmt", "defmt-timestamp-uptime", "tick-hz-32_768"] }
+embassy-executor = { version = "0.9.0", path = "../../embassy-executor", features = ["arch-cortex-m", "executor-thread", "defmt"] }
+embassy-time = { version = "0.5.0", path = "../../embassy-time", features = ["defmt", "defmt-timestamp-uptime", "tick-hz-32_768"] }
 embassy-usb = { version = "0.5.0", path = "../../embassy-usb", features = ["defmt"] }
 embassy-futures = { version = "0.1.0", path = "../../embassy-futures" }
 

--- a/examples/stm32wb/Cargo.toml
+++ b/examples/stm32wb/Cargo.toml
@@ -7,12 +7,12 @@ publish = false
 
 [dependencies]
 # Change stm32wb55rg to your chip name in both dependencies, if necessary.
-embassy-stm32 = { version = "0.3.0", path = "../../embassy-stm32", features = [ "defmt", "stm32wb55rg", "time-driver-any", "memory-x", "exti"]  }
+embassy-stm32 = { version = "0.4.0", path = "../../embassy-stm32", features = [ "defmt", "stm32wb55rg", "time-driver-any", "memory-x", "exti"]  }
 embassy-stm32-wpan = { version = "0.1.0", path = "../../embassy-stm32-wpan", features = ["defmt", "stm32wb55rg"] }
 embassy-sync = { version = "0.7.1", path = "../../embassy-sync", features = ["defmt"] }
-embassy-executor = { version = "0.8.0", path = "../../embassy-executor", features = ["arch-cortex-m", "executor-thread", "defmt"] }
-embassy-time = { version = "0.4.0", path = "../../embassy-time", features = ["defmt", "defmt-timestamp-uptime", "tick-hz-32_768"] }
-embassy-net = { version = "0.7.0", path = "../../embassy-net", features = ["defmt", "udp", "proto-ipv6", "medium-ieee802154", ], optional = true }
+embassy-executor = { version = "0.9.0", path = "../../embassy-executor", features = ["arch-cortex-m", "executor-thread", "defmt"] }
+embassy-time = { version = "0.5.0", path = "../../embassy-time", features = ["defmt", "defmt-timestamp-uptime", "tick-hz-32_768"] }
+embassy-net = { version = "0.7.1", path = "../../embassy-net", features = ["defmt", "udp", "proto-ipv6", "medium-ieee802154", ], optional = true }
 
 defmt = "1.0.1"
 defmt-rtt = "1.0.0"

--- a/examples/stm32wba6/Cargo.toml
+++ b/examples/stm32wba6/Cargo.toml
@@ -6,10 +6,10 @@ license = "MIT OR Apache-2.0"
 publish = false
 
 [dependencies]
-embassy-stm32 = { version = "0.3.0", path = "../../embassy-stm32", features = [ "defmt", "stm32wba65ri", "time-driver-any", "memory-x", "exti"]  }
+embassy-stm32 = { version = "0.4.0", path = "../../embassy-stm32", features = [ "defmt", "stm32wba65ri", "time-driver-any", "memory-x", "exti"]  }
 embassy-sync = { version = "0.7.1", path = "../../embassy-sync", features = ["defmt"] }
-embassy-executor = { version = "0.8.0", path = "../../embassy-executor", features = ["arch-cortex-m", "executor-thread", "defmt"] }
-embassy-time = { version = "0.4.0", path = "../../embassy-time", features = ["defmt", "defmt-timestamp-uptime", "tick-hz-32_768"] }
+embassy-executor = { version = "0.9.0", path = "../../embassy-executor", features = ["arch-cortex-m", "executor-thread", "defmt"] }
+embassy-time = { version = "0.5.0", path = "../../embassy-time", features = ["defmt", "defmt-timestamp-uptime", "tick-hz-32_768"] }
 embassy-usb = { version = "0.5.0", path = "../../embassy-usb", features = ["defmt"] }
 embassy-futures = { version = "0.1.0", path = "../../embassy-futures" }
 

--- a/examples/stm32wl/Cargo.toml
+++ b/examples/stm32wl/Cargo.toml
@@ -7,11 +7,11 @@ publish = false
 
 [dependencies]
 # Change stm32wl55jc-cm4 to your chip name, if necessary.
-embassy-stm32 = { version = "0.3.0", path = "../../embassy-stm32", features = ["defmt", "stm32wl55jc-cm4", "time-driver-any", "memory-x", "unstable-pac", "exti", "chrono"] }
+embassy-stm32 = { version = "0.4.0", path = "../../embassy-stm32", features = ["defmt", "stm32wl55jc-cm4", "time-driver-any", "memory-x", "unstable-pac", "exti", "chrono"] }
 embassy-sync = { version = "0.7.1", path = "../../embassy-sync", features = ["defmt"] }
-embassy-executor = { version = "0.8.0", path = "../../embassy-executor", features = ["arch-cortex-m", "executor-thread", "defmt"] }
-embassy-time = { version = "0.4.0", path = "../../embassy-time", features = ["defmt", "defmt-timestamp-uptime", "tick-hz-32_768"] }
-embassy-embedded-hal = { version = "0.4.0", path = "../../embassy-embedded-hal" }
+embassy-executor = { version = "0.9.0", path = "../../embassy-executor", features = ["arch-cortex-m", "executor-thread", "defmt"] }
+embassy-time = { version = "0.5.0", path = "../../embassy-time", features = ["defmt", "defmt-timestamp-uptime", "tick-hz-32_768"] }
+embassy-embedded-hal = { version = "0.4.1", path = "../../embassy-embedded-hal" }
 
 defmt = "1.0.1"
 defmt-rtt = "1.0.0"

--- a/examples/wasm/Cargo.toml
+++ b/examples/wasm/Cargo.toml
@@ -10,8 +10,8 @@ crate-type = ["cdylib"]
 
 [dependencies]
 embassy-sync = { version = "0.7.1", path = "../../embassy-sync", features = ["log"] }
-embassy-executor = { version = "0.8.0", path = "../../embassy-executor", features = ["arch-wasm", "executor-thread", "log"] }
-embassy-time = { version = "0.4.0", path = "../../embassy-time", features = ["log", "wasm", ] }
+embassy-executor = { version = "0.9.0", path = "../../embassy-executor", features = ["arch-wasm", "executor-thread", "log"] }
+embassy-time = { version = "0.5.0", path = "../../embassy-time", features = ["log", "wasm", ] }
 
 wasm-logger = "0.2.0"
 wasm-bindgen = "0.2"

--- a/tests/mspm0/Cargo.toml
+++ b/tests/mspm0/Cargo.toml
@@ -13,11 +13,11 @@ mspm0g3519 = [ "embassy-mspm0/mspm0g3519pz" ]
 teleprobe-meta = "1.1"
 
 embassy-sync = { version = "0.7.1", path = "../../embassy-sync", features = [ "defmt" ] }
-embassy-executor = { version = "0.8.0", path = "../../embassy-executor", features = [ "arch-cortex-m", "executor-thread", "defmt" ] }
+embassy-executor = { version = "0.9.0", path = "../../embassy-executor", features = [ "arch-cortex-m", "executor-thread", "defmt" ] }
 embassy-futures = { version = "0.1.0", path = "../../embassy-futures" }
-embassy-time = { version = "0.4.0", path = "../../embassy-time", features = [ "defmt" ] }
+embassy-time = { version = "0.5.0", path = "../../embassy-time", features = [ "defmt" ] }
 embassy-mspm0 = { version = "0.1.0", path = "../../embassy-mspm0", features = [ "rt", "defmt", "unstable-pac", "time-driver-any" ]  }
-embassy-embedded-hal = { version = "0.4.0", path = "../../embassy-embedded-hal/"}
+embassy-embedded-hal = { version = "0.4.1", path = "../../embassy-embedded-hal/"}
 
 defmt = "1.0.1"
 defmt-rtt = "1.0.0"

--- a/tests/nrf/Cargo.toml
+++ b/tests/nrf/Cargo.toml
@@ -10,13 +10,13 @@ teleprobe-meta = "1"
 
 embassy-futures = { version = "0.1.0", path = "../../embassy-futures" }
 embassy-sync = { version = "0.7.1", path = "../../embassy-sync", features = ["defmt", ] }
-embassy-executor = { version = "0.8.0", path = "../../embassy-executor", features = ["arch-cortex-m", "executor-thread", "defmt"] }
-embassy-time = { version = "0.4.0", path = "../../embassy-time", features = ["defmt",  "defmt-timestamp-uptime"] }
-embassy-nrf = { version = "0.6.0", path = "../../embassy-nrf", features = ["defmt",  "time-driver-rtc1", "gpiote", "unstable-pac"] }
+embassy-executor = { version = "0.9.0", path = "../../embassy-executor", features = ["arch-cortex-m", "executor-thread", "defmt"] }
+embassy-time = { version = "0.5.0", path = "../../embassy-time", features = ["defmt",  "defmt-timestamp-uptime"] }
+embassy-nrf = { version = "0.7.0", path = "../../embassy-nrf", features = ["defmt",  "time-driver-rtc1", "gpiote", "unstable-pac"] }
 embedded-io-async = { version = "0.6.1", features = ["defmt-03"] }
-embassy-net = { version = "0.7.0", path = "../../embassy-net", features = ["defmt", "tcp", "dhcpv4", "medium-ethernet", ] }
-embassy-net-esp-hosted = { version = "0.2.0", path = "../../embassy-net-esp-hosted", features = ["defmt"] }
-embassy-net-enc28j60 = { version = "0.2.0", path = "../../embassy-net-enc28j60", features = ["defmt"] }
+embassy-net = { version = "0.7.1", path = "../../embassy-net", features = ["defmt", "tcp", "dhcpv4", "medium-ethernet", ] }
+embassy-net-esp-hosted = { version = "0.2.1", path = "../../embassy-net-esp-hosted", features = ["defmt"] }
+embassy-net-enc28j60 = { version = "0.2.1", path = "../../embassy-net-enc28j60", features = ["defmt"] }
 embedded-hal-async = { version = "1.0" }
 embedded-hal-bus = { version = "0.1", features = ["async"] }
 static_cell = "2"

--- a/tests/perf-client/Cargo.toml
+++ b/tests/perf-client/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2021"
 publish = false
 
 [dependencies]
-embassy-net = { version = "0.7.0", path = "../../embassy-net", features = ["defmt", "tcp", "dhcpv4"] }
-embassy-time = { version = "0.4.0", path = "../../embassy-time", features = ["defmt", ] }
+embassy-net = { version = "0.7.1", path = "../../embassy-net", features = ["defmt", "tcp", "dhcpv4"] }
+embassy-time = { version = "0.5.0", path = "../../embassy-time", features = ["defmt", ] }
 embassy-futures = { version = "0.1.0", path = "../../embassy-futures" }
 defmt = "1.0.1"

--- a/tests/riscv32/Cargo.toml
+++ b/tests/riscv32/Cargo.toml
@@ -8,8 +8,8 @@ publish = false
 [dependencies]
 critical-section = { version = "1.1.1", features = ["restore-state-bool"] }
 embassy-sync = { version = "0.7.1", path = "../../embassy-sync" }
-embassy-executor = { version = "0.8.0", path = "../../embassy-executor", features = ["arch-riscv32", "executor-thread"] }
-embassy-time = { version = "0.4.0", path = "../../embassy-time" }
+embassy-executor = { version = "0.9.0", path = "../../embassy-executor", features = ["arch-riscv32", "executor-thread"] }
+embassy-time = { version = "0.5.0", path = "../../embassy-time" }
 embassy-futures = { version = "0.1.0", path = "../../embassy-futures" }
 
 riscv-rt = "0.12.2"

--- a/tests/rp/Cargo.toml
+++ b/tests/rp/Cargo.toml
@@ -14,13 +14,13 @@ rp235xb = ["embassy-rp/rp235xb"]
 teleprobe-meta = "1.1"
 
 embassy-sync = { version = "0.7.1", path = "../../embassy-sync", features = ["defmt"] }
-embassy-executor = { version = "0.8.0", path = "../../embassy-executor", features = ["arch-cortex-m", "executor-thread", "defmt"] }
-embassy-time = { version = "0.4.0", path = "../../embassy-time", features = ["defmt", ] }
-embassy-rp = { version = "0.7.0", path = "../../embassy-rp", features = [ "defmt", "unstable-pac", "time-driver", "critical-section-impl", "intrinsics", "rom-v2-intrinsics", "run-from-ram"]  }
+embassy-executor = { version = "0.9.0", path = "../../embassy-executor", features = ["arch-cortex-m", "executor-thread", "defmt"] }
+embassy-time = { version = "0.5.0", path = "../../embassy-time", features = ["defmt", ] }
+embassy-rp = { version = "0.7.1", path = "../../embassy-rp", features = [ "defmt", "unstable-pac", "time-driver", "critical-section-impl", "intrinsics", "rom-v2-intrinsics", "run-from-ram"]  }
 embassy-futures = { version = "0.1.0", path = "../../embassy-futures" }
-embassy-net = { version = "0.7.0", path = "../../embassy-net", features = ["defmt",  "tcp", "udp", "dhcpv4", "medium-ethernet"] }
-embassy-net-wiznet = { version = "0.2.0", path = "../../embassy-net-wiznet", features = ["defmt"] }
-embassy-embedded-hal = { version = "0.4.0", path = "../../embassy-embedded-hal/"}
+embassy-net = { version = "0.7.1", path = "../../embassy-net", features = ["defmt",  "tcp", "udp", "dhcpv4", "medium-ethernet"] }
+embassy-net-wiznet = { version = "0.2.1", path = "../../embassy-net-wiznet", features = ["defmt"] }
+embassy-embedded-hal = { version = "0.4.1", path = "../../embassy-embedded-hal/"}
 cyw43 = { path = "../../cyw43", features = ["defmt", "firmware-logs"] }
 cyw43-pio = { path = "../../cyw43-pio", features = ["defmt"] }
 perf-client = { path = "../perf-client" }

--- a/tests/stm32/Cargo.toml
+++ b/tests/stm32/Cargo.toml
@@ -66,12 +66,12 @@ cm0 = ["portable-atomic/unsafe-assume-single-core"]
 teleprobe-meta = "1"
 
 embassy-sync = { version = "0.7.1", path = "../../embassy-sync", features = ["defmt"] }
-embassy-executor = { version = "0.8.0", path = "../../embassy-executor", features = ["arch-cortex-m", "executor-thread", "defmt"] }
-embassy-time = { version = "0.4.0", path = "../../embassy-time", features = ["defmt", "tick-hz-131_072", "defmt-timestamp-uptime"] }
-embassy-stm32 = { version = "0.3.0", path = "../../embassy-stm32", features = [ "defmt", "unstable-pac", "memory-x", "time-driver-any"]  }
+embassy-executor = { version = "0.9.0", path = "../../embassy-executor", features = ["arch-cortex-m", "executor-thread", "defmt"] }
+embassy-time = { version = "0.5.0", path = "../../embassy-time", features = ["defmt", "tick-hz-131_072", "defmt-timestamp-uptime"] }
+embassy-stm32 = { version = "0.4.0", path = "../../embassy-stm32", features = [ "defmt", "unstable-pac", "memory-x", "time-driver-any"]  }
 embassy-futures = { version = "0.1.0", path = "../../embassy-futures" }
 embassy-stm32-wpan = { version = "0.1.0", path = "../../embassy-stm32-wpan", optional = true, features = ["defmt", "stm32wb55rg", "ble"] }
-embassy-net = { version = "0.7.0", path = "../../embassy-net", features = ["defmt",  "tcp", "udp", "dhcpv4", "medium-ethernet"] }
+embassy-net = { version = "0.7.1", path = "../../embassy-net", features = ["defmt",  "tcp", "udp", "dhcpv4", "medium-ethernet"] }
 perf-client = { path = "../perf-client" }
 
 defmt = "1.0.1"


### PR DESCRIPTION
Releasing embassy-time-driver and corresponding  dependencies.

CC @bugadani 

```
# Please inspect changes and run the following commands when happy:                                                                                                                                                                                                                   
git tag embassy-time-driver-v0.2.1                                                                                                                                                                                                                                                    
git tag embassy-time-v0.5.0                                                                                                                                                                                                                                                           
git tag embassy-stm32-v0.4.0                                                                                                                                                                                                                                                          
git tag embassy-rp-v0.7.1                                                                                                                                                                                                                                                             
git tag embassy-nrf-v0.7.0                                                                                                                                                                                                                                                            
git tag embassy-executor-v0.9.0                                                                                                                                                                                                                                                       
git tag embassy-usb-dfu-v0.1.1                                                                                                                                                                                                                                                        
git tag embassy-net-wiznet-v0.2.1                                                                                                          
git tag embassy-net-esp-hosted-v0.2.1                                                                                                                                                                                                                                                 
git tag embassy-net-enc28j60-v0.2.1                                                                                                        
git tag embassy-net-adin1110-v0.3.1                                                                                                        
git tag embassy-net-v0.7.1                                                                                                                                                                                                                                                            
git tag embassy-embedded-hal-v0.4.1                                                                                                                                                                                                                                                   
git tag embassy-boot-rp-v0.7.1                                                                                                                                                                                                                                                        
git tag cyw43-v0.4.1                                                                                                                                                                                                                                                                  
git tag embassy-boot-stm32-v0.5.1                                                                                                                                                                                                                                                     
git tag cyw43-pio-v0.6.1                                                                                                                                                                                                                                                              
git tag embassy-boot-nrf-v0.7.1                                                                                                                                                                                                                                                       
git tag embassy-boot-v0.6.1                                                                                                                                                                                                                                                           
                                                                                                                                                                                                                                                                                      
# Run these commands to publish the crate and dependents:                                                                                  
cargo publish --manifest-path /home/lulf/dev/embassy/embassy-time-driver/Cargo.toml                                                        
cargo publish --manifest-path /home/lulf/dev/embassy/embassy-time/Cargo.toml --features defmt,defmt-timestamp-uptime,mock-driver --target thumbv6m-none-eabi                                                                                                                          
cargo publish --manifest-path /home/lulf/dev/embassy/embassy-stm32/Cargo.toml --features defmt,dual-bank,exti,stm32l552ze,time,time-driver-any --target thumbv8m.main-none-eabihf                                                                                                     
cargo publish --manifest-path /home/lulf/dev/embassy/embassy-rp/Cargo.toml --features defmt,rp2040,time-driver --target thumbv6m-none-eabi                                                                                                                                            
cargo publish --manifest-path /home/lulf/dev/embassy/embassy-nrf/Cargo.toml --features gpiote,nrf51,time,time-driver-rtc1 --target thumbv6m-none-eabi                                                                                                                                 
cargo publish --manifest-path /home/lulf/dev/embassy/embassy-executor/Cargo.toml --target thumbv7em-none-eabi                                                                                                                                                                         
cargo publish --manifest-path /home/lulf/dev/embassy/embassy-usb-dfu/Cargo.toml --features defmt,cortex-m,dfu --target thumbv7em-none-eabi                                                                                                                                            
cargo publish --manifest-path /home/lulf/dev/embassy/embassy-net-wiznet/Cargo.toml                                                                                                                                                                                                    
cargo publish --manifest-path /home/lulf/dev/embassy/embassy-net-esp-hosted/Cargo.toml                                                                                                                                                                                                
cargo publish --manifest-path /home/lulf/dev/embassy/embassy-net-enc28j60/Cargo.toml                                                                                                                                                                                                  
cargo publish --manifest-path /home/lulf/dev/embassy/embassy-net-adin1110/Cargo.toml                                                                                                                                                                                                  
cargo publish --manifest-path /home/lulf/dev/embassy/embassy-net/Cargo.toml --features defmt,dns,medium-ethernet,packet-trace,proto-ipv4,tcp,udp --target thumbv7em-none-eabi                                                                                                         
cargo publish --manifest-path /home/lulf/dev/embassy/embassy-embedded-hal/Cargo.toml --target thumbv7em-none-eabi                                                                                                                                                                     
cargo publish --manifest-path /home/lulf/dev/embassy/embassy-boot-rp/Cargo.toml --features embassy-rp/rp2040 --target thumbv6m-none-eabi                                                                                                                                              
cargo publish --manifest-path /home/lulf/dev/embassy/cyw43/Cargo.toml --target thumbv6m-none-eabi                                                                                                                                                                                     
cargo publish --manifest-path /home/lulf/dev/embassy/embassy-boot-stm32/Cargo.toml --features embassy-stm32/stm32l496zg --target thumbv7em-none-eabi                                                                                                                                  
cargo publish --manifest-path /home/lulf/dev/embassy/cyw43-pio/Cargo.toml --features embassy-rp/rp2040 --target thumbv6m-none-eabi                                                                                                                                                    
cargo publish --manifest-path /home/lulf/dev/embassy/embassy-boot-nrf/Cargo.toml --features embassy-nrf/nrf52840 --target thumbv7em-none-eabi                                                                                                                                         
cargo publish --manifest-path /home/lulf/dev/embassy/embassy-boot/Cargo.toml                                                                                                                                                                                                          
                                                                                                                                                                                                                                                                                      
# Run this command to push changes and tags:
git push --tags
```
