### PR TITLE
stm32/sai: make NODIV independent of MCKDIV

### DIFF
--- a/embassy-stm32/CHANGELOG.md
+++ b/embassy-stm32/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 <!-- next-header -->
 ## Unreleased - ReleaseDate
 
+- feat: stm32/sai: make NODIV independent of MCKDIV 
 - fix: stm32/i2c: pull-down was enabled instead of pull-none when no internal pull-up was needed.
 - feat: Improve blocking hash speed
 - fix: Fix vrefbuf building with log feature

--- a/embassy-stm32/src/sai/mod.rs
+++ b/embassy-stm32/src/sai/mod.rs
@@ -602,6 +602,7 @@ pub struct Config {
     pub clock_strobe: ClockStrobe,
     pub output_drive: OutputDrive,
     pub master_clock_divider: MasterClockDivider,
+    pub nodiv: bool,
     pub is_high_impedance_on_inactive_slot: bool,
     pub fifo_threshold: FifoThreshold,
     pub companding: Companding,
@@ -631,6 +632,7 @@ impl Default for Config {
             frame_sync_definition: FrameSyncDefinition::ChannelIdentification,
             frame_length: 32,
             master_clock_divider: MasterClockDivider::MasterClockDisabled,
+            nodiv: false,
             clock_strobe: ClockStrobe::Rising,
             output_drive: OutputDrive::Immediately,
             is_high_impedance_on_inactive_slot: false,
@@ -900,7 +902,7 @@ impl<'d, T: Instance, W: word::Word> Sai<'d, T, W> {
                 w.set_mono(config.stereo_mono.mono());
                 w.set_outdriv(config.output_drive.outdriv());
                 w.set_mckdiv(config.master_clock_divider.mckdiv().into());
-                w.set_nodiv(config.master_clock_divider == MasterClockDivider::MasterClockDisabled);
+                w.set_nodiv(config.nodiv);
                 w.set_dmaen(true);
             });
 


### PR DESCRIPTION
These values should clearly be made independent, at least in the WB55 microcontroller (and so I suspect in all the others) since NODIV implies no divider between the master clock and the bit clock, but it does NOT imply no divider between the SAI clock and the master clock. Quoting from the WB55 reference manual (RM0434 Rev 14, p. 1219):

> #### Clock generator programming when NODIV = 1
> When MCKDIV is different from 0, the frequency of the bit clock (SCK\_x) is given in the
> formula below:
> $`F_{SCK\_x} = F_{MCLK\_x} = \frac{F_{sai\_x\_ker\_ck}}{MCKDIV}`$

Tests I have performed with the WB55 show you can use `NODIV = 1` with `MCKDIV != disabled` and still get valid configurations and correct clock frequencies.
I'm not entirely sure about integrating this change though since CubeMX follows the same behaviour as Embassy currently (i.e. NODIV == MCKDIV disabled). 
