### PR TITLE
Add I2S support for ST chips with spi_v2 hardware

### DIFF
--- a/embassy-stm32/CHANGELOG.md
+++ b/embassy-stm32/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - chore: Updated stm32-metapac and stm32-data dependencies
 - feat: stm32/adc/v3: allow DMA reads to loop through enable channels
 - fix: Fix XSPI not disabling alternate bytes when they were previously enabled
+- feat: Add I2S support for STM32 chips with spi_v2 hardware. ([#4573](https://github.com/embassy-rs/embassy/pull/4573)).
 
 ## 0.3.0 - 2025-08-12
 

--- a/embassy-stm32/src/i2s.rs
+++ b/embassy-stm32/src/i2s.rs
@@ -72,7 +72,7 @@ impl From<ringbuffer::Error> for Error {
 }
 
 impl Standard {
-    #[cfg(any(spi_v1, spi_v3, spi_f1))]
+    #[cfg(any(spi_v1, spi_v2, spi_v3, spi_f1))]
     const fn i2sstd(&self) -> vals::I2sstd {
         match self {
             Standard::Philips => vals::I2sstd::PHILIPS,
@@ -83,7 +83,7 @@ impl Standard {
         }
     }
 
-    #[cfg(any(spi_v1, spi_v3, spi_f1))]
+    #[cfg(any(spi_v1, spi_v2, spi_v3, spi_f1))]
     const fn pcmsync(&self) -> vals::Pcmsync {
         match self {
             Standard::PcmLongSync => vals::Pcmsync::LONG,
@@ -106,7 +106,7 @@ pub enum Format {
 }
 
 impl Format {
-    #[cfg(any(spi_v1, spi_v3, spi_f1))]
+    #[cfg(any(spi_v1, spi_v2, spi_v3, spi_f1))]
     const fn datlen(&self) -> vals::Datlen {
         match self {
             Format::Data16Channel16 => vals::Datlen::BITS16,
@@ -116,7 +116,7 @@ impl Format {
         }
     }
 
-    #[cfg(any(spi_v1, spi_v3, spi_f1))]
+    #[cfg(any(spi_v1, spi_v2, spi_v3, spi_f1))]
     const fn chlen(&self) -> vals::Chlen {
         match self {
             Format::Data16Channel16 => vals::Chlen::BITS16,
@@ -137,7 +137,7 @@ pub enum ClockPolarity {
 }
 
 impl ClockPolarity {
-    #[cfg(any(spi_v1, spi_v3, spi_f1))]
+    #[cfg(any(spi_v1, spi_v2, spi_v3, spi_f1))]
     const fn ckpol(&self) -> vals::Ckpol {
         match self {
             ClockPolarity::IdleHigh => vals::Ckpol::IDLE_HIGH,
@@ -492,12 +492,11 @@ impl<'d, W: Word> I2S<'d, W> {
 
         let (odd, div) = compute_baud_rate(pclk, config.frequency, config.master_clock, config.format);
 
-        #[cfg(any(spi_v1, spi_v3, spi_f1))]
+        #[cfg(any(spi_v1, spi_v2, spi_v3, spi_f1))]
         {
             #[cfg(spi_v3)]
             {
                 regs.cr1().modify(|w| w.set_spe(false));
-
                 reset_incompatible_bitfields::<T>();
             }
 
@@ -525,7 +524,7 @@ impl<'d, W: Word> I2S<'d, W> {
             // 5. The I2SE bit in SPI_I2SCFGR register must be set.
 
             let clk_reg = {
-                #[cfg(any(spi_v1, spi_f1))]
+                #[cfg(any(spi_v1, spi_v2, spi_f1))]
                 {
                     regs.i2spr()
                 }
@@ -567,7 +566,7 @@ impl<'d, W: Word> I2S<'d, W> {
                     (Mode::Slave, Function::FullDuplex) => I2scfg::SLAVE_FULL_DUPLEX,
                 });
 
-                #[cfg(any(spi_v1, spi_f1))]
+                #[cfg(any(spi_v1, spi_v2, spi_f1))]
                 w.set_i2se(true);
             });
 

--- a/embassy-stm32/src/lib.rs
+++ b/embassy-stm32/src/lib.rs
@@ -87,7 +87,7 @@ pub mod hsem;
 pub mod hspi;
 #[cfg(i2c)]
 pub mod i2c;
-#[cfg(any(all(spi_v1, rcc_f4), spi_v3))]
+#[cfg(any(all(spi_v1, rcc_f4), spi_v2, spi_v3))]
 pub mod i2s;
 #[cfg(stm32wb)]
 pub mod ipcc;

--- a/examples/stm32g0/src/bin/i2s_dma.rs
+++ b/examples/stm32g0/src/bin/i2s_dma.rs
@@ -1,0 +1,70 @@
+// This example is written for an STM32G0B1 chip communicating with an external
+// DAC. Remap pins, change clock speeds, etc. as necessary for your own
+// hardware.
+//
+// NOTE: This example outputs potentially loud audio. Please run responsibly.
+
+#![no_std]
+#![no_main]
+
+use embassy_executor::Spawner;
+use embassy_stm32::i2s::{Config, Format, I2S};
+use {defmt_rtt as _, panic_probe as _};
+
+#[embassy_executor::main]
+async fn main(_spawner: Spawner) {
+    let config = {
+        use embassy_stm32::rcc::*;
+
+        let mut config = embassy_stm32::Config::default();
+        config.rcc.hsi = Some(Hsi {
+            sys_div: HsiSysDiv::DIV1,
+        });
+        config.rcc.pll = Some(Pll {
+            source: PllSource::HSI,
+            prediv: PllPreDiv::DIV1,
+            mul: PllMul::MUL16,
+            divp: None,
+            divq: Some(PllQDiv::DIV2), // 16 / 1 * 16 / 2 = 128 MHz
+            divr: Some(PllRDiv::DIV4), // 16 / 1 * 16 / 4 = 64 MHz
+        });
+        config.rcc.sys = Sysclk::PLL1_R;
+
+        config.rcc.ahb_pre = AHBPrescaler::DIV1;
+        config.rcc.apb1_pre = APBPrescaler::DIV1;
+
+        config.enable_debug_during_sleep = true;
+
+        config
+    };
+
+    let p = embassy_stm32::init(config);
+
+    // stereo wavetable generation
+    let mut wavetable = [0u16; 1200];
+    for (i, frame) in wavetable.chunks_mut(2).enumerate() {
+        frame[0] = ((((i / 150) % 2) * 2048) as i16 - 1024) as u16; // 160 Hz square wave in left channel
+        frame[1] = ((((i / 100) % 2) * 2048) as i16 - 1024) as u16; // 240 Hz square wave in right channel
+    }
+
+    // i2s configuration
+    let mut dma_buffer = [0u16; 2400];
+
+    let mut i2s_config = Config::default();
+    i2s_config.format = Format::Data16Channel32;
+    i2s_config.master_clock = false;
+    let mut i2s = I2S::new_txonly_nomck(
+        p.SPI2,
+        p.PB15,  // sd
+        p.PA8,   // ws
+        p.PB10,  // ck
+        p.DMA1_CH1,
+        &mut dma_buffer,
+        i2s_config,
+    );
+    i2s.start();
+
+    loop {
+        i2s.write(&wavetable).await.ok();
+    }
+}


### PR DESCRIPTION
[Problem]
STM32 chips with spi_v2 hardware support I2S, but it was not previously enabled.

[Solution]
- Enabled is2 support for spi_v2 hardware. Note: this depends on register fixes in stm32-data.
- Added an example based on embassy\examples\stm32f4\src\bin\i2s_dma.rs

[Testing]
I ran the example on a NUCLEO-G0B1RE with an I2S dac and heard the correct tones.

Note: This depends on [this PR](https://github.com/embassy-rs/stm32-data/pull/663) in stm32-data