### PR TITLE
embassy-sync: Don't drop wakers in Signal::reset

### DIFF
--- a/embassy-sync/CHANGELOG.md
+++ b/embassy-sync/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 <!-- next-header -->
 ## Unreleased - ReleaseDate
+- Fix wakers getting dropped by `Signal::reset`
 
 ## 0.7.2 - 2025-08-26
 

--- a/embassy-sync/src/signal.rs
+++ b/embassy-sync/src/signal.rs
@@ -83,7 +83,7 @@ where
 
     /// Remove the queued value in this `Signal`, if any.
     pub fn reset(&self) {
-        self.state.lock(|cell| cell.set(State::None));
+        self.try_take();
     }
 
     fn poll_wait(&self, cx: &mut Context<'_>) -> Poll<T> {


### PR DESCRIPTION
Dropping wakers is a recipe for hangs, as was discovered on [matrix](https://matrix.to/#/!YoLPkieCYHGzdjUhOK:matrix.org/$l_xv_ruxW4G3yWKAC6g2cVQYZiCBqcfY_9204R9lo4c?via=matrix.org&via=beeper.com&via=mozilla.org).

Might be worth deprecating and removing the method altogether since `try_take` has the same effect.