### PR TITLE
mspm0: add mspm0c1105/6

### DIFF
--- a/ci.sh
+++ b/ci.sh
@@ -190,18 +190,19 @@ cargo batch \
     --- build --release --manifest-path embassy-nxp/Cargo.toml --target thumbv8m.main-none-eabihf --features lpc55,defmt \
     --- build --release --manifest-path embassy-nxp/Cargo.toml --target thumbv7em-none-eabihf --features mimxrt1011,rt,defmt,time-driver-pit \
     --- build --release --manifest-path embassy-nxp/Cargo.toml --target thumbv7em-none-eabihf --features mimxrt1062,rt,defmt,time-driver-pit \
-    --- build --release --manifest-path embassy-mspm0/Cargo.toml --target thumbv6m-none-eabi --features mspm0c1104dgs20,defmt,time-driver-any \
-    --- build --release --manifest-path embassy-mspm0/Cargo.toml --target thumbv6m-none-eabi --features mspm0g3507pm,defmt,time-driver-any \
-    --- build --release --manifest-path embassy-mspm0/Cargo.toml --target thumbv6m-none-eabi --features mspm0g3519pz,defmt,time-driver-any \
-    --- build --release --manifest-path embassy-mspm0/Cargo.toml --target thumbv6m-none-eabi --features mspm0l1306rhb,defmt,time-driver-any \
-    --- build --release --manifest-path embassy-mspm0/Cargo.toml --target thumbv6m-none-eabi --features mspm0l2228pn,defmt,time-driver-any \
-    --- build --release --manifest-path embassy-mspm0/Cargo.toml --target thumbv6m-none-eabi --features mspm0l1345dgs28,defmt,time-driver-any \
-    --- build --release --manifest-path embassy-mspm0/Cargo.toml --target thumbv6m-none-eabi --features mspm0l1106dgs28,defmt,time-driver-any \
-    --- build --release --manifest-path embassy-mspm0/Cargo.toml --target thumbv6m-none-eabi --features mspm0l1228pm,defmt,time-driver-any \
-    --- build --release --manifest-path embassy-mspm0/Cargo.toml --target thumbv6m-none-eabi --features mspm0g1107ycj,defmt,time-driver-any \
-    --- build --release --manifest-path embassy-mspm0/Cargo.toml --target thumbv6m-none-eabi --features mspm0g3105rhb,defmt,time-driver-any \
-    --- build --release --manifest-path embassy-mspm0/Cargo.toml --target thumbv6m-none-eabi --features mspm0g1505pt,defmt,time-driver-any \
-    --- build --release --manifest-path embassy-mspm0/Cargo.toml --target thumbv6m-none-eabi --features mspm0g1519rhb,defmt,time-driver-any \
+    --- build --release --manifest-path embassy-mspm0/Cargo.toml --target thumbv6m-none-eabi --features mspm0c1104dgs20,rt,defmt,time-driver-any \
+    --- build --release --manifest-path embassy-mspm0/Cargo.toml --target thumbv6m-none-eabi --features mspm0c1106rgz,rt,defmt,time-driver-any \
+    --- build --release --manifest-path embassy-mspm0/Cargo.toml --target thumbv6m-none-eabi --features mspm0g3507pm,rt,defmt,time-driver-any \
+    --- build --release --manifest-path embassy-mspm0/Cargo.toml --target thumbv6m-none-eabi --features mspm0g3519pz,rt,defmt,time-driver-any \
+    --- build --release --manifest-path embassy-mspm0/Cargo.toml --target thumbv6m-none-eabi --features mspm0l1306rhb,rt,defmt,time-driver-any \
+    --- build --release --manifest-path embassy-mspm0/Cargo.toml --target thumbv6m-none-eabi --features mspm0l2228pn,rt,defmt,time-driver-any \
+    --- build --release --manifest-path embassy-mspm0/Cargo.toml --target thumbv6m-none-eabi --features mspm0l1345dgs28,rt,defmt,time-driver-any \
+    --- build --release --manifest-path embassy-mspm0/Cargo.toml --target thumbv6m-none-eabi --features mspm0l1106dgs28,rt,defmt,time-driver-any \
+    --- build --release --manifest-path embassy-mspm0/Cargo.toml --target thumbv6m-none-eabi --features mspm0l1228pm,rt,defmt,time-driver-any \
+    --- build --release --manifest-path embassy-mspm0/Cargo.toml --target thumbv6m-none-eabi --features mspm0g1107ycj,rt,defmt,time-driver-any \
+    --- build --release --manifest-path embassy-mspm0/Cargo.toml --target thumbv6m-none-eabi --features mspm0g3105rhb,rt,defmt,time-driver-any \
+    --- build --release --manifest-path embassy-mspm0/Cargo.toml --target thumbv6m-none-eabi --features mspm0g1505pt,rt,defmt,time-driver-any \
+    --- build --release --manifest-path embassy-mspm0/Cargo.toml --target thumbv6m-none-eabi --features mspm0g1519rhb,rt,defmt,time-driver-any \
     --- build --release --manifest-path cyw43/Cargo.toml --target thumbv6m-none-eabi --features ''\
     --- build --release --manifest-path cyw43/Cargo.toml --target thumbv6m-none-eabi --features 'log' \
     --- build --release --manifest-path cyw43/Cargo.toml --target thumbv6m-none-eabi --features 'defmt' \

--- a/embassy-mspm0/CHANGELOG.md
+++ b/embassy-mspm0/CHANGELOG.md
@@ -7,7 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 <!-- next-header -->
 ## Unreleased - ReleaseDate
-
+ 
 - feat: Add I2C Controller (blocking & async) + examples for mspm0l1306, mspm0g3507 (tested MCUs) (#4435)
 - fix gpio interrupt not being set for mspm0l110x
 - feat: Add window watchdog implementation based on WWDT0, WWDT1 peripherals (#4574)
+- feat: Add MSPM0C1105/C1106 support

--- a/embassy-mspm0/Cargo.toml
+++ b/embassy-mspm0/Cargo.toml
@@ -69,7 +69,7 @@ cortex-m = "0.7.6"
 critical-section = "1.2.0"
 
 # mspm0-metapac = { version = "" }
-mspm0-metapac = { git = "https://github.com/mspm0-rs/mspm0-data-generated/", tag = "mspm0-data-fe17d879548757ca29821da66a1bebf2debd4846" }
+mspm0-metapac = { git = "https://github.com/mspm0-rs/mspm0-data-generated/", tag = "mspm0-data-d7bf3d01ac0780e716a45b0474234d39443dc5cf" }
 
 [build-dependencies]
 proc-macro2 = "1.0.94"
@@ -77,7 +77,7 @@ quote = "1.0.40"
 cfg_aliases = "0.2.1"
 
 # mspm0-metapac = { version = "", default-features = false, features = ["metadata"] }
-mspm0-metapac = { git = "https://github.com/mspm0-rs/mspm0-data-generated/", tag = "mspm0-data-fe17d879548757ca29821da66a1bebf2debd4846", default-features = false, features = ["metadata"] }
+mspm0-metapac = { git = "https://github.com/mspm0-rs/mspm0-data-generated/", tag = "mspm0-data-d7bf3d01ac0780e716a45b0474234d39443dc5cf", default-features = false, features = ["metadata"] }
 
 [features]
 default = ["rt"]
@@ -159,6 +159,24 @@ mspm0c1104dsg = ["mspm0-metapac/mspm0c1104dsg"]
 mspm0c1104dyy = ["mspm0-metapac/mspm0c1104dyy"]
 mspm0c1104ruk = ["mspm0-metapac/mspm0c1104ruk"]
 mspm0c1104ycj = ["mspm0-metapac/mspm0c1104ycj"]
+mspm0c1105pt = ["mspm0-metapac/mspm0c1105pt"]
+mspm0c1105rgz = ["mspm0-metapac/mspm0c1105rgz"]
+mspm0c1105rhb = ["mspm0-metapac/mspm0c1105rhb"]
+mspm0c1105dgs32 = ["mspm0-metapac/mspm0c1105dgs32"]
+mspm0c1105dgs28 = ["mspm0-metapac/mspm0c1105dgs28"]
+mspm0c1105rge = ["mspm0-metapac/mspm0c1105rge"]
+mspm0c1105dgs20 = ["mspm0-metapac/mspm0c1105dgs20"]
+mspm0c1105ruk = ["mspm0-metapac/mspm0c1105ruk"]
+mspm0c1105zcm = ["mspm0-metapac/mspm0c1105zcm"]
+mspm0c1106pt = ["mspm0-metapac/mspm0c1106pt"]
+mspm0c1106rgz = ["mspm0-metapac/mspm0c1106rgz"]
+mspm0c1106rhb = ["mspm0-metapac/mspm0c1106rhb"]
+mspm0c1106dgs32 = ["mspm0-metapac/mspm0c1106dgs32"]
+mspm0c1106dgs28 = ["mspm0-metapac/mspm0c1106dgs28"]
+mspm0c1106rge = ["mspm0-metapac/mspm0c1106rge"]
+mspm0c1106dgs20 = ["mspm0-metapac/mspm0c1106dgs20"]
+mspm0c1106ruk = ["mspm0-metapac/mspm0c1106ruk"]
+mspm0c1106zcm = ["mspm0-metapac/mspm0c1106zcm"]
 mspm0g1105dgs28 = ["mspm0-metapac/mspm0g1105dgs28"]
 mspm0g1105pm = ["mspm0-metapac/mspm0g1105pm"]
 mspm0g1105pt = ["mspm0-metapac/mspm0g1105pt"]

--- a/embassy-mspm0/build.rs
+++ b/embassy-mspm0/build.rs
@@ -79,8 +79,12 @@ fn get_chip_cfgs(chip_name: &str) -> Vec<String> {
     let mut cfgs = Vec::new();
 
     // GPIO on C110x is special as it does not belong to an interrupt group.
-    if chip_name.starts_with("mspm0c110") || chip_name.starts_with("msps003f") {
+    if chip_name.starts_with("mspm0c1103") || chip_name.starts_with("mspm0c1104") || chip_name.starts_with("msps003f") {
         cfgs.push("mspm0c110x".to_string());
+    }
+
+    if chip_name.starts_with("mspm0c1105") || chip_name.starts_with("mspm0c1106") {
+        cfgs.push("mspm0c1105_c1106".to_string());
     }
 
     // Family ranges (temporary until int groups are generated)
@@ -537,6 +541,8 @@ fn generate_interrupts() -> TokenStream {
         pub fn enable_group_interrupts(_cs: critical_section::CriticalSection) {
             use crate::interrupt::typelevel::Interrupt;
 
+            // This is empty for C1105/6
+            #[allow(unused_unsafe)]
             unsafe {
                 #(#group_interrupt_enables)*
             }

--- a/embassy-mspm0/src/gpio.rs
+++ b/embassy-mspm0/src/gpio.rs
@@ -10,7 +10,7 @@ use embassy_sync::waitqueue::AtomicWaker;
 
 use crate::pac::gpio::vals::*;
 use crate::pac::gpio::{self};
-#[cfg(all(feature = "rt", any(mspm0c110x, mspm0l110x)))]
+#[cfg(all(feature = "rt", any(mspm0c110x, mspm0c1105_c1106, mspm0l110x)))]
 use crate::pac::interrupt;
 use crate::pac::{self};
 
@@ -1108,24 +1108,30 @@ fn irq_handler(gpio: gpio::Gpio, wakers: &[AtomicWaker; 32]) {
 // C110x and L110x have a dedicated interrupts just for GPIOA.
 //
 // These chips do not have a GROUP1 interrupt.
-#[cfg(all(feature = "rt", any(mspm0c110x, mspm0l110x)))]
+#[cfg(all(feature = "rt", any(mspm0c110x, mspm0c1105_c1106, mspm0l110x)))]
 #[interrupt]
 fn GPIOA() {
     irq_handler(pac::GPIOA, &PORTA_WAKERS);
+}
+
+#[cfg(all(feature = "rt", mspm0c1105_c1106))]
+#[interrupt]
+fn GPIOB() {
+    irq_handler(pac::GPIOB, &PORTB_WAKERS);
 }
 
 // These symbols are weakly defined as DefaultHandler and are called by the interrupt group implementation.
 //
 // Defining these as no_mangle is required so that the linker will pick these over the default handler.
 
-#[cfg(all(feature = "rt", not(any(mspm0c110x, mspm0l110x))))]
+#[cfg(all(feature = "rt", not(any(mspm0c110x, mspm0c1105_c1106, mspm0l110x))))]
 #[no_mangle]
 #[allow(non_snake_case)]
 fn GPIOA() {
     irq_handler(pac::GPIOA, &PORTA_WAKERS);
 }
 
-#[cfg(all(feature = "rt", gpio_pb))]
+#[cfg(all(feature = "rt", gpio_pb, not(mspm0c1105_c1106)))]
 #[no_mangle]
 #[allow(non_snake_case)]
 fn GPIOB() {

--- a/embassy-mspm0/src/i2c.rs
+++ b/embassy-mspm0/src/i2c.rs
@@ -195,7 +195,7 @@ impl Config {
             .unwrap();
     }
 
-    #[cfg(any(mspm0c110x))]
+    #[cfg(any(mspm0c110x, mspm0c1105_c1106))]
     fn calculate_clock_source(&self) -> u32 {
         // Assume that BusClk has default value.
         // TODO: calculate BusClk more precisely.


### PR DESCRIPTION
C1105 and C1106 are C1104 with 8KB of ram (7KB more) and 32 or 64KB of flash.

These also add an RTC and COMP peripheral, so these aren't technically the same chip family as C1103/4

Also added rt feature to the build checks for all mspm0 parts.