### PR TITLE
fix: stm32/usb: Fixed STM32H5 build requiring time feature

### DIFF
--- a/embassy-stm32/CHANGELOG.md
+++ b/embassy-stm32/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 <!-- next-header -->
 ## Unreleased - ReleaseDate
 
+- fix: Fixed STM32H5 builds requiring time feature
+
 ## 0.4.0 - 2025-08-26
 
 - feat: stm32/sai: make NODIV independent of MCKDIV 

--- a/embassy-stm32/src/usb/usb.rs
+++ b/embassy-stm32/src/usb/usb.rs
@@ -912,7 +912,16 @@ impl<'d, T: Instance> driver::EndpointOut for Endpoint<'d, T, Out> {
         // Software should ensure that a small delay is included before accessing the SRAM contents. This delay should be
         // 800 ns in Full Speed mode and 6.4 μs in Low Speed mode.
         #[cfg(stm32h5)]
-        embassy_time::block_for(embassy_time::Duration::from_nanos(800));
+        {
+            #[cfg(feature = "time")]
+            embassy_time::block_for(embassy_time::Duration::from_nanos(800));
+            #[cfg(not(feature = "time"))]
+            {
+                let freq = unsafe { crate::rcc::get_freqs() }.sys.to_hertz().unwrap().0 as u64;
+                let cycles = freq * 800 / 1_000_000;
+                cortex_m::asm::delay(cycles as u32);
+            }
+        }
 
         RX_COMPLETE[index].store(false, Ordering::Relaxed);
 


### PR DESCRIPTION
A busy loop has been added for when the "time" feature is not enabled.

Fixes #4610 