### PR TITLE
Fix perf regression on ESP32-S2/S3

### DIFF
--- a/embassy-executor/CHANGELOG.md
+++ b/embassy-executor/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## Unreleased - ReleaseDate
 
 - Added new metadata API for tasks
+- Fixed performance regression on some ESP32 MCUs.
 
 ## 0.9.0 - 2025-08-26
 

--- a/embassy-executor/src/raw/mod.rs
+++ b/embassy-executor/src/raw/mod.rs
@@ -12,8 +12,14 @@
 mod run_queue;
 
 #[cfg_attr(all(cortex_m, target_has_atomic = "32"), path = "state_atomics_arm.rs")]
-#[cfg_attr(all(not(cortex_m), target_has_atomic = "8"), path = "state_atomics.rs")]
-#[cfg_attr(not(target_has_atomic = "8"), path = "state_critical_section.rs")]
+#[cfg_attr(
+    all(not(cortex_m), any(target_has_atomic = "8", target_has_atomic = "32")),
+    path = "state_atomics.rs"
+)]
+#[cfg_attr(
+    not(any(target_has_atomic = "8", target_has_atomic = "32")),
+    path = "state_critical_section.rs"
+)]
 mod state;
 
 #[cfg(feature = "_any_trace")]

--- a/embassy-executor/src/raw/state_atomics.rs
+++ b/embassy-executor/src/raw/state_atomics.rs
@@ -1,4 +1,15 @@
-use core::sync::atomic::{AtomicU8, Ordering};
+// Prefer pointer-width atomic operations, as narrower ones may be slower.
+#[cfg(all(target_pointer_width = "32", target_has_atomic = "32"))]
+type AtomicState = core::sync::atomic::AtomicU32;
+#[cfg(not(all(target_pointer_width = "32", target_has_atomic = "32")))]
+type AtomicState = core::sync::atomic::AtomicU8;
+
+#[cfg(all(target_pointer_width = "32", target_has_atomic = "32"))]
+type StateBits = u32;
+#[cfg(not(all(target_pointer_width = "32", target_has_atomic = "32")))]
+type StateBits = u8;
+
+use core::sync::atomic::Ordering;
 
 #[derive(Clone, Copy)]
 pub(crate) struct Token(());
@@ -11,18 +22,18 @@ pub(crate) fn locked<R>(f: impl FnOnce(Token) -> R) -> R {
 }
 
 /// Task is spawned (has a future)
-pub(crate) const STATE_SPAWNED: u8 = 1 << 0;
+pub(crate) const STATE_SPAWNED: StateBits = 1 << 0;
 /// Task is in the executor run queue
-pub(crate) const STATE_RUN_QUEUED: u8 = 1 << 1;
+pub(crate) const STATE_RUN_QUEUED: StateBits = 1 << 1;
 
 pub(crate) struct State {
-    state: AtomicU8,
+    state: AtomicState,
 }
 
 impl State {
     pub const fn new() -> State {
         Self {
-            state: AtomicU8::new(0),
+            state: AtomicState::new(0),
         }
     }
 


### PR DESCRIPTION
This PR walks back a bit on #4244, which PR turned out to be a small perf hit on ESP32-S2, ESP32-S3 and possibly more.