### PR TITLE
stm32: add i2s support for all versions, cleanup spi/i2s/sai versions.

### DIFF
--- a/embassy-stm32/CHANGELOG.md
+++ b/embassy-stm32/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - feat: Derive Clone, Copy for QSPI Config
 - fix: stm32/i2c in master mode (blocking): subsequent transmissions failed after a NACK was received
 - feat: stm32/timer: add set_polarity functions for main and complementary outputs in complementary_pwm
+- Add I2S support for STM32F1, STM32C0, STM32F0, STM32F3, STM32F7, STM32G0, STM32WL, STM32H5, STM32H7RS
 
 ## 0.4.0 - 2025-08-26
 

--- a/embassy-stm32/Cargo.toml
+++ b/embassy-stm32/Cargo.toml
@@ -173,8 +173,8 @@ cortex-m = "0.7.6"
 futures-util = { version = "0.3.30", default-features = false }
 sdio-host = "0.9.0"
 critical-section = "1.1"
-stm32-metapac = { version = "18" }
-#stm32-metapac = { git = "https://github.com/embassy-rs/stm32-data-generated", tag = "stm32-data-ecb93d42a6cbcd9e09cab74873908a2ca22327f7" }
+#stm32-metapac = { version = "18" }
+stm32-metapac = { git = "https://github.com/embassy-rs/stm32-data-generated", tag = "stm32-data-d8432edd0406495adec19d31923584e80b8e03cb" }
 
 vcell = "0.1.3"
 nb = "1.0.0"
@@ -202,8 +202,8 @@ proptest-state-machine = "0.3.0"
 proc-macro2 = "1.0.36"
 quote = "1.0.15"
 
-stm32-metapac = { version = "18", default-features = false, features = ["metadata"]}
-#stm32-metapac = { git = "https://github.com/embassy-rs/stm32-data-generated", tag = "stm32-data-ecb93d42a6cbcd9e09cab74873908a2ca22327f7", default-features = false, features = ["metadata"] }
+#stm32-metapac = { version = "18", default-features = false, features = ["metadata"]}
+stm32-metapac = { git = "https://github.com/embassy-rs/stm32-data-generated", tag = "stm32-data-d8432edd0406495adec19d31923584e80b8e03cb", default-features = false, features = ["metadata"] }
 
 [features]
 default = ["rt"]

--- a/embassy-stm32/src/adc/mod.rs
+++ b/embassy-stm32/src/adc/mod.rs
@@ -2,12 +2,12 @@
 
 #![macro_use]
 #![allow(missing_docs)] // TODO
-#![cfg_attr(adc_f3_v2, allow(unused))]
+#![cfg_attr(adc_f3v3, allow(unused))]
 
-#[cfg(not(any(adc_f3_v2, adc_wba)))]
+#[cfg(not(any(adc_f3v3, adc_wba)))]
 #[cfg_attr(adc_f1, path = "f1.rs")]
-#[cfg_attr(adc_f3, path = "f3.rs")]
-#[cfg_attr(adc_f3_v1_1, path = "f3_v1_1.rs")]
+#[cfg_attr(adc_f3v1, path = "f3.rs")]
+#[cfg_attr(adc_f3v2, path = "f3_v1_1.rs")]
 #[cfg_attr(adc_v1, path = "v1.rs")]
 #[cfg_attr(adc_l0, path = "v1.rs")]
 #[cfg_attr(adc_v2, path = "v2.rs")]
@@ -20,10 +20,10 @@ mod _version;
 use core::marker::PhantomData;
 
 #[allow(unused)]
-#[cfg(not(any(adc_f3_v2, adc_wba)))]
+#[cfg(not(any(adc_f3v3, adc_wba)))]
 pub use _version::*;
 use embassy_hal_internal::{impl_peripheral, PeripheralType};
-#[cfg(any(adc_f1, adc_f3, adc_v1, adc_l0, adc_f3_v1_1))]
+#[cfg(any(adc_f1, adc_f3v1, adc_v1, adc_l0, adc_f3v2))]
 use embassy_sync::waitqueue::AtomicWaker;
 
 #[cfg(any(adc_u5, adc_wba))]
@@ -31,7 +31,7 @@ use embassy_sync::waitqueue::AtomicWaker;
 pub mod adc4;
 
 pub use crate::pac::adc::vals;
-#[cfg(not(any(adc_f1, adc_f3_v2)))]
+#[cfg(not(any(adc_f1, adc_f3v3)))]
 pub use crate::pac::adc::vals::Res as Resolution;
 pub use crate::pac::adc::vals::SampleTime;
 use crate::peripherals;
@@ -47,16 +47,16 @@ dma_trait!(RxDma4, adc4::Instance);
 pub struct Adc<'d, T: Instance> {
     #[allow(unused)]
     adc: crate::Peri<'d, T>,
-    #[cfg(not(any(adc_f3_v2, adc_f3_v1_1, adc_wba)))]
+    #[cfg(not(any(adc_f3v3, adc_f3v2, adc_wba)))]
     sample_time: SampleTime,
 }
 
-#[cfg(any(adc_f1, adc_f3, adc_v1, adc_l0, adc_f3_v1_1))]
+#[cfg(any(adc_f1, adc_f3v1, adc_v1, adc_l0, adc_f3v2))]
 pub struct State {
     pub waker: AtomicWaker,
 }
 
-#[cfg(any(adc_f1, adc_f3, adc_v1, adc_l0, adc_f3_v1_1))]
+#[cfg(any(adc_f1, adc_f3v1, adc_v1, adc_l0, adc_f3v2))]
 impl State {
     pub const fn new() -> Self {
         Self {
@@ -69,10 +69,10 @@ trait SealedInstance {
     #[cfg(not(adc_wba))]
     #[allow(unused)]
     fn regs() -> crate::pac::adc::Adc;
-    #[cfg(not(any(adc_f1, adc_v1, adc_l0, adc_f3_v2, adc_f3_v1_1, adc_g0)))]
+    #[cfg(not(any(adc_f1, adc_v1, adc_l0, adc_f3v3, adc_f3v2, adc_g0)))]
     #[allow(unused)]
     fn common_regs() -> crate::pac::adccommon::AdcCommon;
-    #[cfg(any(adc_f1, adc_f3, adc_v1, adc_l0, adc_f3_v1_1))]
+    #[cfg(any(adc_f1, adc_f3v1, adc_v1, adc_l0, adc_f3v2))]
     fn state() -> &'static State;
 }
 
@@ -100,22 +100,8 @@ pub(crate) fn blocking_delay_us(us: u32) {
 
 /// ADC instance.
 #[cfg(not(any(
-    adc_f1,
-    adc_v1,
-    adc_l0,
-    adc_v2,
-    adc_v3,
-    adc_v4,
-    adc_g4,
-    adc_f3,
-    adc_f3_v1_1,
-    adc_g0,
-    adc_u0,
-    adc_h5,
-    adc_h7rs,
-    adc_u5,
-    adc_c0,
-    adc_wba,
+    adc_f1, adc_v1, adc_l0, adc_v2, adc_v3, adc_v4, adc_g4, adc_f3v1, adc_f3v2, adc_g0, adc_u0, adc_h5, adc_h7rs,
+    adc_u5, adc_c0, adc_wba,
 )))]
 #[allow(private_bounds)]
 pub trait Instance: SealedInstance + crate::PeripheralType {
@@ -123,22 +109,8 @@ pub trait Instance: SealedInstance + crate::PeripheralType {
 }
 /// ADC instance.
 #[cfg(any(
-    adc_f1,
-    adc_v1,
-    adc_l0,
-    adc_v2,
-    adc_v3,
-    adc_v4,
-    adc_g4,
-    adc_f3,
-    adc_f3_v1_1,
-    adc_g0,
-    adc_u0,
-    adc_h5,
-    adc_h7rs,
-    adc_u5,
-    adc_c0,
-    adc_wba,
+    adc_f1, adc_v1, adc_l0, adc_v2, adc_v3, adc_v4, adc_g4, adc_f3v1, adc_f3v2, adc_g0, adc_u0, adc_h5, adc_h7rs,
+    adc_u5, adc_c0, adc_wba,
 ))]
 #[allow(private_bounds)]
 pub trait Instance: SealedInstance + crate::PeripheralType + crate::rcc::RccPeripheral {
@@ -258,12 +230,12 @@ foreach_adc!(
                 crate::pac::$inst
             }
 
-            #[cfg(not(any(adc_f1, adc_v1, adc_l0, adc_f3_v2, adc_f3_v1_1, adc_g0, adc_u5, adc_wba)))]
+            #[cfg(not(any(adc_f1, adc_v1, adc_l0, adc_f3v3, adc_f3v2, adc_g0, adc_u5, adc_wba)))]
             fn common_regs() -> crate::pac::adccommon::AdcCommon {
                 return crate::pac::$common_inst
             }
 
-            #[cfg(any(adc_f1, adc_f3, adc_v1, adc_l0, adc_f3_v1_1))]
+            #[cfg(any(adc_f1, adc_f3v1, adc_v1, adc_l0, adc_f3v2))]
             fn state() -> &'static State {
                 static STATE: State = State::new();
                 &STATE
@@ -295,7 +267,7 @@ macro_rules! impl_adc_pin {
 /// Get the maximum reading value for this resolution.
 ///
 /// This is `2**n - 1`.
-#[cfg(not(any(adc_f1, adc_f3_v2)))]
+#[cfg(not(any(adc_f1, adc_f3v3)))]
 pub const fn resolution_to_max_count(res: Resolution) -> u32 {
     match res {
         #[cfg(adc_v4)]
@@ -309,7 +281,7 @@ pub const fn resolution_to_max_count(res: Resolution) -> u32 {
         Resolution::BITS12 => (1 << 12) - 1,
         Resolution::BITS10 => (1 << 10) - 1,
         Resolution::BITS8 => (1 << 8) - 1,
-        #[cfg(any(adc_v1, adc_v2, adc_v3, adc_l0, adc_c0, adc_g0, adc_f3, adc_f3_v1_1, adc_h5))]
+        #[cfg(any(adc_v1, adc_v2, adc_v3, adc_l0, adc_c0, adc_g0, adc_f3v1, adc_f3v2, adc_h5))]
         Resolution::BITS6 => (1 << 6) - 1,
         #[allow(unreachable_patterns)]
         _ => core::unreachable!(),

--- a/embassy-stm32/src/lib.rs
+++ b/embassy-stm32/src/lib.rs
@@ -87,7 +87,7 @@ pub mod hsem;
 pub mod hspi;
 #[cfg(i2c)]
 pub mod i2c;
-#[cfg(any(all(spi_v1, rcc_f4), spi_v3))]
+#[cfg(any(spi_v1_i2s, spi_v2_i2s, spi_v3_i2s, spi_v4_i2s, spi_v5_i2s))]
 pub mod i2s;
 #[cfg(stm32wb)]
 pub mod ipcc;

--- a/embassy-stm32/src/sai/mod.rs
+++ b/embassy-stm32/src/sai/mod.rs
@@ -8,6 +8,7 @@ use embassy_hal_internal::PeripheralType;
 pub use crate::dma::word;
 use crate::dma::{ringbuffer, Channel, ReadableRingBuffer, Request, TransferOptions, WritableRingBuffer};
 use crate::gpio::{AfType, AnyPin, OutputType, Pull, SealedPin as _, Speed};
+pub use crate::pac::sai::vals::Mckdiv as MasterClockDivider;
 use crate::pac::sai::{vals, Sai as Regs};
 use crate::rcc::{self, RccPeripheral};
 use crate::{peripherals, Peri};
@@ -45,7 +46,6 @@ pub enum Mode {
 }
 
 impl Mode {
-    #[cfg(any(sai_v1, sai_v1_4pdm, sai_v2, sai_v3_2pdm, sai_v3_4pdm, sai_v4_2pdm, sai_v4_4pdm))]
     const fn mode(&self, tx_rx: TxRx) -> vals::Mode {
         match tx_rx {
             TxRx::Transmitter => match self {
@@ -80,7 +80,6 @@ pub enum SlotSize {
 }
 
 impl SlotSize {
-    #[cfg(any(sai_v1, sai_v1_4pdm, sai_v2, sai_v3_2pdm, sai_v3_4pdm, sai_v4_2pdm, sai_v4_4pdm))]
     const fn slotsz(&self) -> vals::Slotsz {
         match self {
             SlotSize::DataSize => vals::Slotsz::DATA_SIZE,
@@ -103,7 +102,6 @@ pub enum DataSize {
 }
 
 impl DataSize {
-    #[cfg(any(sai_v1, sai_v1_4pdm, sai_v2, sai_v3_2pdm, sai_v3_4pdm, sai_v4_2pdm, sai_v4_4pdm))]
     const fn ds(&self) -> vals::Ds {
         match self {
             DataSize::Data8 => vals::Ds::BIT8,
@@ -128,7 +126,6 @@ pub enum FifoThreshold {
 }
 
 impl FifoThreshold {
-    #[cfg(any(sai_v1, sai_v1_4pdm, sai_v2, sai_v3_2pdm, sai_v3_4pdm, sai_v4_2pdm, sai_v4_4pdm))]
     const fn fth(&self) -> vals::Fth {
         match self {
             FifoThreshold::Empty => vals::Fth::EMPTY,
@@ -149,7 +146,6 @@ pub enum MuteValue {
 }
 
 impl MuteValue {
-    #[cfg(any(sai_v1, sai_v1_4pdm, sai_v2, sai_v3_2pdm, sai_v3_4pdm, sai_v4_2pdm, sai_v4_4pdm))]
     const fn muteval(&self) -> vals::Muteval {
         match self {
             MuteValue::Zero => vals::Muteval::SEND_ZERO,
@@ -168,7 +164,6 @@ pub enum Protocol {
 }
 
 impl Protocol {
-    #[cfg(any(sai_v1, sai_v1_4pdm, sai_v2, sai_v3_2pdm, sai_v3_4pdm, sai_v4_2pdm, sai_v4_4pdm))]
     const fn prtcfg(&self) -> vals::Prtcfg {
         match self {
             Protocol::Free => vals::Prtcfg::FREE,
@@ -226,7 +221,6 @@ pub enum StereoMono {
 }
 
 impl StereoMono {
-    #[cfg(any(sai_v1, sai_v1_4pdm, sai_v2, sai_v3_2pdm, sai_v3_4pdm, sai_v4_2pdm, sai_v4_4pdm))]
     const fn mono(&self) -> vals::Mono {
         match self {
             StereoMono::Stereo => vals::Mono::STEREO,
@@ -245,7 +239,6 @@ pub enum BitOrder {
 }
 
 impl BitOrder {
-    #[cfg(any(sai_v1, sai_v1_4pdm, sai_v2, sai_v3_2pdm, sai_v3_4pdm, sai_v4_2pdm, sai_v4_4pdm))]
     const fn lsbfirst(&self) -> vals::Lsbfirst {
         match self {
             BitOrder::LsbFirst => vals::Lsbfirst::LSB_FIRST,
@@ -264,7 +257,6 @@ pub enum FrameSyncOffset {
 }
 
 impl FrameSyncOffset {
-    #[cfg(any(sai_v1, sai_v1_4pdm, sai_v2, sai_v3_2pdm, sai_v3_4pdm, sai_v4_2pdm, sai_v4_4pdm))]
     const fn fsoff(&self) -> vals::Fsoff {
         match self {
             FrameSyncOffset::OnFirstBit => vals::Fsoff::ON_FIRST,
@@ -283,7 +275,6 @@ pub enum FrameSyncPolarity {
 }
 
 impl FrameSyncPolarity {
-    #[cfg(any(sai_v1, sai_v1_4pdm, sai_v2, sai_v3_2pdm, sai_v3_4pdm, sai_v4_2pdm, sai_v4_4pdm))]
     const fn fspol(&self) -> vals::Fspol {
         match self {
             FrameSyncPolarity::ActiveLow => vals::Fspol::FALLING_EDGE,
@@ -301,7 +292,6 @@ pub enum FrameSyncDefinition {
 }
 
 impl FrameSyncDefinition {
-    #[cfg(any(sai_v1, sai_v1_4pdm, sai_v2, sai_v3_2pdm, sai_v3_4pdm, sai_v4_2pdm, sai_v4_4pdm))]
     const fn fsdef(&self) -> bool {
         match self {
             FrameSyncDefinition::StartOfFrame => false,
@@ -319,7 +309,6 @@ pub enum ClockStrobe {
 }
 
 impl ClockStrobe {
-    #[cfg(any(sai_v1, sai_v1_4pdm, sai_v2, sai_v3_2pdm, sai_v3_4pdm, sai_v4_2pdm, sai_v4_4pdm))]
     const fn ckstr(&self) -> vals::Ckstr {
         match self {
             ClockStrobe::Falling => vals::Ckstr::FALLING_EDGE,
@@ -337,7 +326,6 @@ pub enum ComplementFormat {
 }
 
 impl ComplementFormat {
-    #[cfg(any(sai_v1, sai_v1_4pdm, sai_v2, sai_v3_2pdm, sai_v3_4pdm, sai_v4_2pdm, sai_v4_4pdm))]
     const fn cpl(&self) -> vals::Cpl {
         match self {
             ComplementFormat::OnesComplement => vals::Cpl::ONES_COMPLEMENT,
@@ -356,7 +344,6 @@ pub enum Companding {
 }
 
 impl Companding {
-    #[cfg(any(sai_v1, sai_v1_4pdm, sai_v2, sai_v3_2pdm, sai_v3_4pdm, sai_v4_2pdm, sai_v4_4pdm))]
     const fn comp(&self) -> vals::Comp {
         match self {
             Companding::None => vals::Comp::NO_COMPANDING,
@@ -375,201 +362,10 @@ pub enum OutputDrive {
 }
 
 impl OutputDrive {
-    #[cfg(any(sai_v1, sai_v1_4pdm, sai_v2, sai_v3_2pdm, sai_v3_4pdm, sai_v4_2pdm, sai_v4_4pdm))]
     const fn outdriv(&self) -> vals::Outdriv {
         match self {
             OutputDrive::OnStart => vals::Outdriv::ON_START,
             OutputDrive::Immediately => vals::Outdriv::IMMEDIATELY,
-        }
-    }
-}
-
-/// Master clock divider.
-#[derive(Copy, Clone, PartialEq)]
-#[allow(missing_docs)]
-#[cfg(any(sai_v1, sai_v2))]
-pub enum MasterClockDivider {
-    MasterClockDisabled,
-    Div1,
-    Div2,
-    Div4,
-    Div6,
-    Div8,
-    Div10,
-    Div12,
-    Div14,
-    Div16,
-    Div18,
-    Div20,
-    Div22,
-    Div24,
-    Div26,
-    Div28,
-    Div30,
-}
-
-/// Master clock divider.
-#[derive(Copy, Clone, PartialEq)]
-#[allow(missing_docs)]
-#[cfg(any(sai_v1_4pdm, sai_v3_2pdm, sai_v3_4pdm, sai_v4_2pdm, sai_v4_4pdm))]
-pub enum MasterClockDivider {
-    MasterClockDisabled,
-    Div1,
-    Div2,
-    Div3,
-    Div4,
-    Div5,
-    Div6,
-    Div7,
-    Div8,
-    Div9,
-    Div10,
-    Div11,
-    Div12,
-    Div13,
-    Div14,
-    Div15,
-    Div16,
-    Div17,
-    Div18,
-    Div19,
-    Div20,
-    Div21,
-    Div22,
-    Div23,
-    Div24,
-    Div25,
-    Div26,
-    Div27,
-    Div28,
-    Div29,
-    Div30,
-    Div31,
-    Div32,
-    Div33,
-    Div34,
-    Div35,
-    Div36,
-    Div37,
-    Div38,
-    Div39,
-    Div40,
-    Div41,
-    Div42,
-    Div43,
-    Div44,
-    Div45,
-    Div46,
-    Div47,
-    Div48,
-    Div49,
-    Div50,
-    Div51,
-    Div52,
-    Div53,
-    Div54,
-    Div55,
-    Div56,
-    Div57,
-    Div58,
-    Div59,
-    Div60,
-    Div61,
-    Div62,
-    Div63,
-}
-
-impl MasterClockDivider {
-    #[cfg(any(sai_v1, sai_v2))]
-    const fn mckdiv(&self) -> u8 {
-        match self {
-            MasterClockDivider::MasterClockDisabled => 0,
-            MasterClockDivider::Div1 => 0,
-            MasterClockDivider::Div2 => 1,
-            MasterClockDivider::Div4 => 2,
-            MasterClockDivider::Div6 => 3,
-            MasterClockDivider::Div8 => 4,
-            MasterClockDivider::Div10 => 5,
-            MasterClockDivider::Div12 => 6,
-            MasterClockDivider::Div14 => 7,
-            MasterClockDivider::Div16 => 8,
-            MasterClockDivider::Div18 => 9,
-            MasterClockDivider::Div20 => 10,
-            MasterClockDivider::Div22 => 11,
-            MasterClockDivider::Div24 => 12,
-            MasterClockDivider::Div26 => 13,
-            MasterClockDivider::Div28 => 14,
-            MasterClockDivider::Div30 => 15,
-        }
-    }
-
-    #[cfg(any(sai_v1_4pdm, sai_v3_2pdm, sai_v3_4pdm, sai_v4_2pdm, sai_v4_4pdm))]
-    const fn mckdiv(&self) -> u8 {
-        match self {
-            MasterClockDivider::MasterClockDisabled => 0,
-            MasterClockDivider::Div1 => 1,
-            MasterClockDivider::Div2 => 2,
-            MasterClockDivider::Div3 => 3,
-            MasterClockDivider::Div4 => 4,
-            MasterClockDivider::Div5 => 5,
-            MasterClockDivider::Div6 => 6,
-            MasterClockDivider::Div7 => 7,
-            MasterClockDivider::Div8 => 8,
-            MasterClockDivider::Div9 => 9,
-            MasterClockDivider::Div10 => 10,
-            MasterClockDivider::Div11 => 11,
-            MasterClockDivider::Div12 => 12,
-            MasterClockDivider::Div13 => 13,
-            MasterClockDivider::Div14 => 14,
-            MasterClockDivider::Div15 => 15,
-            MasterClockDivider::Div16 => 16,
-            MasterClockDivider::Div17 => 17,
-            MasterClockDivider::Div18 => 18,
-            MasterClockDivider::Div19 => 19,
-            MasterClockDivider::Div20 => 20,
-            MasterClockDivider::Div21 => 21,
-            MasterClockDivider::Div22 => 22,
-            MasterClockDivider::Div23 => 23,
-            MasterClockDivider::Div24 => 24,
-            MasterClockDivider::Div25 => 25,
-            MasterClockDivider::Div26 => 26,
-            MasterClockDivider::Div27 => 27,
-            MasterClockDivider::Div28 => 28,
-            MasterClockDivider::Div29 => 29,
-            MasterClockDivider::Div30 => 30,
-            MasterClockDivider::Div31 => 31,
-            MasterClockDivider::Div32 => 32,
-            MasterClockDivider::Div33 => 33,
-            MasterClockDivider::Div34 => 34,
-            MasterClockDivider::Div35 => 35,
-            MasterClockDivider::Div36 => 36,
-            MasterClockDivider::Div37 => 37,
-            MasterClockDivider::Div38 => 38,
-            MasterClockDivider::Div39 => 39,
-            MasterClockDivider::Div40 => 40,
-            MasterClockDivider::Div41 => 41,
-            MasterClockDivider::Div42 => 42,
-            MasterClockDivider::Div43 => 43,
-            MasterClockDivider::Div44 => 44,
-            MasterClockDivider::Div45 => 45,
-            MasterClockDivider::Div46 => 46,
-            MasterClockDivider::Div47 => 47,
-            MasterClockDivider::Div48 => 48,
-            MasterClockDivider::Div49 => 49,
-            MasterClockDivider::Div50 => 50,
-            MasterClockDivider::Div51 => 51,
-            MasterClockDivider::Div52 => 52,
-            MasterClockDivider::Div53 => 53,
-            MasterClockDivider::Div54 => 54,
-            MasterClockDivider::Div55 => 55,
-            MasterClockDivider::Div56 => 56,
-            MasterClockDivider::Div57 => 57,
-            MasterClockDivider::Div58 => 58,
-            MasterClockDivider::Div59 => 59,
-            MasterClockDivider::Div60 => 60,
-            MasterClockDivider::Div61 => 61,
-            MasterClockDivider::Div62 => 62,
-            MasterClockDivider::Div63 => 63,
         }
     }
 }
@@ -598,8 +394,7 @@ pub struct Config {
     pub frame_length: u8,
     pub clock_strobe: ClockStrobe,
     pub output_drive: OutputDrive,
-    pub master_clock_divider: MasterClockDivider,
-    pub nodiv: bool,
+    pub master_clock_divider: Option<MasterClockDivider>,
     pub is_high_impedance_on_inactive_slot: bool,
     pub fifo_threshold: FifoThreshold,
     pub companding: Companding,
@@ -628,8 +423,7 @@ impl Default for Config {
             frame_sync_active_level_length: word::U7(16),
             frame_sync_definition: FrameSyncDefinition::ChannelIdentification,
             frame_length: 32,
-            master_clock_divider: MasterClockDivider::MasterClockDisabled,
-            nodiv: false,
+            master_clock_divider: None,
             clock_strobe: ClockStrobe::Rising,
             output_drive: OutputDrive::Immediately,
             is_high_impedance_on_inactive_slot: false,
@@ -761,14 +555,10 @@ impl<'d, T: Instance, W: word::Word> Sai<'d, T, W> {
         mclk: Peri<'d, impl MclkPin<T, S>>,
         dma: Peri<'d, impl Channel + Dma<T, S>>,
         dma_buf: &'d mut [W],
-        mut config: Config,
+        config: Config,
     ) -> Self {
         let (_sd_af_type, ck_af_type) = get_af_types(config.mode, config.tx_rx);
         mclk.set_as_af(mclk.af_num(), ck_af_type);
-
-        if config.master_clock_divider == MasterClockDivider::MasterClockDisabled {
-            config.master_clock_divider = MasterClockDivider::Div1;
-        }
 
         Self::new_asynchronous(peri, sck, sd, fs, dma, dma_buf, config)
     }
@@ -851,10 +641,7 @@ impl<'d, T: Instance, W: word::Word> Sai<'d, T, W> {
     ) -> Self {
         let ch = T::REGS.ch(sub_block as usize);
 
-        #[cfg(any(sai_v1, sai_v1_4pdm, sai_v2, sai_v3_2pdm, sai_v3_4pdm, sai_v4_2pdm, sai_v4_4pdm))]
-        {
-            ch.cr1().modify(|w| w.set_saien(false));
-        }
+        ch.cr1().modify(|w| w.set_saien(false));
 
         ch.cr2().modify(|w| w.set_fflush(true));
 
@@ -877,55 +664,52 @@ impl<'d, T: Instance, W: word::Word> Sai<'d, T, W> {
             }
         }
 
-        #[cfg(any(sai_v1, sai_v1_4pdm, sai_v2, sai_v3_2pdm, sai_v3_4pdm, sai_v4_2pdm, sai_v4_4pdm))]
-        {
-            ch.cr1().modify(|w| {
-                w.set_mode(config.mode.mode(if Self::is_transmitter(&ring_buffer) {
-                    TxRx::Transmitter
-                } else {
-                    TxRx::Receiver
-                }));
-                w.set_prtcfg(config.protocol.prtcfg());
-                w.set_ds(config.data_size.ds());
-                w.set_lsbfirst(config.bit_order.lsbfirst());
-                w.set_ckstr(config.clock_strobe.ckstr());
-                w.set_syncen(config.sync_input.syncen());
-                w.set_mono(config.stereo_mono.mono());
-                w.set_outdriv(config.output_drive.outdriv());
-                w.set_mckdiv(config.master_clock_divider.mckdiv().into());
-                w.set_nodiv(config.nodiv);
-                w.set_dmaen(true);
-            });
+        ch.cr1().modify(|w| {
+            w.set_mode(config.mode.mode(if Self::is_transmitter(&ring_buffer) {
+                TxRx::Transmitter
+            } else {
+                TxRx::Receiver
+            }));
+            w.set_prtcfg(config.protocol.prtcfg());
+            w.set_ds(config.data_size.ds());
+            w.set_lsbfirst(config.bit_order.lsbfirst());
+            w.set_ckstr(config.clock_strobe.ckstr());
+            w.set_syncen(config.sync_input.syncen());
+            w.set_mono(config.stereo_mono.mono());
+            w.set_outdriv(config.output_drive.outdriv());
+            w.set_mckdiv(config.master_clock_divider.unwrap_or(MasterClockDivider::DIV1));
+            w.set_nodiv(config.master_clock_divider.is_none());
+            w.set_dmaen(true);
+        });
 
-            ch.cr2().modify(|w| {
-                w.set_fth(config.fifo_threshold.fth());
-                w.set_comp(config.companding.comp());
-                w.set_cpl(config.complement_format.cpl());
-                w.set_muteval(config.mute_value.muteval());
-                w.set_mutecnt(config.mute_detection_counter.0 as u8);
-                w.set_tris(config.is_high_impedance_on_inactive_slot);
-            });
+        ch.cr2().modify(|w| {
+            w.set_fth(config.fifo_threshold.fth());
+            w.set_comp(config.companding.comp());
+            w.set_cpl(config.complement_format.cpl());
+            w.set_muteval(config.mute_value.muteval());
+            w.set_mutecnt(config.mute_detection_counter.0 as u8);
+            w.set_tris(config.is_high_impedance_on_inactive_slot);
+        });
 
-            ch.frcr().modify(|w| {
-                w.set_fsoff(config.frame_sync_offset.fsoff());
-                w.set_fspol(config.frame_sync_polarity.fspol());
-                w.set_fsdef(config.frame_sync_definition.fsdef());
-                w.set_fsall(config.frame_sync_active_level_length.0 as u8 - 1);
-                w.set_frl(config.frame_length - 1);
-            });
+        ch.frcr().modify(|w| {
+            w.set_fsoff(config.frame_sync_offset.fsoff());
+            w.set_fspol(config.frame_sync_polarity.fspol());
+            w.set_fsdef(config.frame_sync_definition.fsdef());
+            w.set_fsall(config.frame_sync_active_level_length.0 as u8 - 1);
+            w.set_frl(config.frame_length - 1);
+        });
 
-            ch.slotr().modify(|w| {
-                w.set_nbslot(config.slot_count.0 as u8 - 1);
-                w.set_slotsz(config.slot_size.slotsz());
-                w.set_fboff(config.first_bit_offset.0 as u8);
-                w.set_sloten(vals::Sloten::from_bits(config.slot_enable as u16));
-            });
+        ch.slotr().modify(|w| {
+            w.set_nbslot(config.slot_count.0 as u8 - 1);
+            w.set_slotsz(config.slot_size.slotsz());
+            w.set_fboff(config.first_bit_offset.0 as u8);
+            w.set_sloten(vals::Sloten::from_bits(config.slot_enable as u16));
+        });
 
-            ch.cr1().modify(|w| w.set_saien(true));
+        ch.cr1().modify(|w| w.set_saien(true));
 
-            if ch.cr1().read().saien() == false {
-                panic!("SAI failed to enable. Check that config is valid (frame length, slot count, etc)");
-            }
+        if ch.cr1().read().saien() == false {
+            panic!("SAI failed to enable. Check that config is valid (frame length, slot count, etc)");
         }
 
         Self {

--- a/embassy-stm32/src/sai/mod.rs
+++ b/embassy-stm32/src/sai/mod.rs
@@ -182,7 +182,7 @@ pub enum SyncInput {
     /// Syncs with the other A/B sub-block within the SAI unit
     Internal,
     /// Syncs with a sub-block in the other SAI unit
-    #[cfg(any(sai_v3_2pdm, sai_v3_4pdm, sai_v4_2pdm, sai_v4_4pdm))]
+    #[cfg(any(sai_v3, sai_v4))]
     External(SyncInputInstance),
 }
 
@@ -191,14 +191,14 @@ impl SyncInput {
         match self {
             SyncInput::None => vals::Syncen::ASYNCHRONOUS,
             SyncInput::Internal => vals::Syncen::INTERNAL,
-            #[cfg(any(sai_v3_2pdm, sai_v3_4pdm, sai_v4_2pdm, sai_v4_4pdm))]
+            #[cfg(any(sai_v3, sai_v4))]
             SyncInput::External(_) => vals::Syncen::EXTERNAL,
         }
     }
 }
 
 /// SAI instance to sync from.
-#[cfg(any(sai_v3_2pdm, sai_v3_4pdm, sai_v4_2pdm, sai_v4_4pdm))]
+#[cfg(any(sai_v3, sai_v4))]
 #[derive(Copy, Clone, PartialEq)]
 #[allow(missing_docs)]
 pub enum SyncInputInstance {
@@ -500,7 +500,7 @@ fn update_synchronous_config(config: &mut Config) {
         config.sync_input = SyncInput::Internal;
     }
 
-    #[cfg(any(sai_v3_2pdm, sai_v3_4pdm, sai_v4_2pdm, sai_v4_4pdm))]
+    #[cfg(any(sai_v3, sai_v4))]
     {
         //this must either be Internal or External
         //The asynchronous sub-block on the same SAI needs to enable sync_output
@@ -645,7 +645,7 @@ impl<'d, T: Instance, W: word::Word> Sai<'d, T, W> {
 
         ch.cr2().modify(|w| w.set_fflush(true));
 
-        #[cfg(any(sai_v3_2pdm, sai_v3_4pdm, sai_v4_2pdm, sai_v4_4pdm))]
+        #[cfg(any(sai_v3, sai_v4))]
         {
             if let SyncInput::External(i) = config.sync_input {
                 T::REGS.gcr().modify(|w| {

--- a/embassy-stm32/src/spi/mod.rs
+++ b/embassy-stm32/src/spi/mod.rs
@@ -174,7 +174,7 @@ impl<'d, M: PeriMode> Spi<'d, M> {
         self.info.rcc.enable_and_reset();
 
         let regs = self.info.regs;
-        #[cfg(any(spi_v1, spi_f1))]
+        #[cfg(any(spi_v1, spi_v2))]
         {
             regs.cr2().modify(|w| {
                 w.set_ssoe(false);
@@ -198,7 +198,7 @@ impl<'d, M: PeriMode> Spi<'d, M> {
                 w.set_dff(<u8 as SealedWord>::CONFIG)
             });
         }
-        #[cfg(spi_v2)]
+        #[cfg(spi_v3)]
         {
             regs.cr2().modify(|w| {
                 let (ds, frxth) = <u8 as SealedWord>::CONFIG;
@@ -220,7 +220,7 @@ impl<'d, M: PeriMode> Spi<'d, M> {
                 w.set_spe(true);
             });
         }
-        #[cfg(any(spi_v3, spi_v4, spi_v5))]
+        #[cfg(any(spi_v4, spi_v5, spi_v6))]
         {
             regs.ifcr().write(|w| w.0 = 0xffff_ffff);
             regs.cfg2().modify(|w| {
@@ -274,7 +274,7 @@ impl<'d, M: PeriMode> Spi<'d, M> {
             }
         }
 
-        #[cfg(any(spi_v1, spi_f1, spi_v2))]
+        #[cfg(any(spi_v1, spi_v2, spi_v3))]
         self.info.regs.cr1().modify(|w| {
             w.set_cpha(cpha);
             w.set_cpol(cpol);
@@ -282,7 +282,7 @@ impl<'d, M: PeriMode> Spi<'d, M> {
             w.set_lsbfirst(lsbfirst);
         });
 
-        #[cfg(any(spi_v3, spi_v4, spi_v5))]
+        #[cfg(any(spi_v4, spi_v5, spi_v6))]
         {
             self.info.regs.cr1().modify(|w| {
                 w.set_spe(false);
@@ -306,11 +306,11 @@ impl<'d, M: PeriMode> Spi<'d, M> {
 
     /// Get current SPI configuration.
     pub fn get_current_config(&self) -> Config {
-        #[cfg(any(spi_v1, spi_f1, spi_v2))]
+        #[cfg(any(spi_v1, spi_v2, spi_v3))]
         let cfg = self.info.regs.cr1().read();
-        #[cfg(any(spi_v3, spi_v4, spi_v5))]
+        #[cfg(any(spi_v4, spi_v5, spi_v6))]
         let cfg = self.info.regs.cfg2().read();
-        #[cfg(any(spi_v3, spi_v4, spi_v5))]
+        #[cfg(any(spi_v4, spi_v5, spi_v6))]
         let cfg1 = self.info.regs.cfg1().read();
 
         let polarity = if cfg.cpol() == vals::Cpol::IDLE_LOW {
@@ -335,9 +335,9 @@ impl<'d, M: PeriMode> Spi<'d, M> {
             Some(pin) => pin.pull(),
         };
 
-        #[cfg(any(spi_v1, spi_f1, spi_v2))]
+        #[cfg(any(spi_v1, spi_v2, spi_v3))]
         let br = cfg.br();
-        #[cfg(any(spi_v3, spi_v4, spi_v5))]
+        #[cfg(any(spi_v4, spi_v5, spi_v6))]
         let br = cfg1.mbr();
 
         let frequency = compute_frequency(self.kernel_clock, br);
@@ -360,16 +360,16 @@ impl<'d, M: PeriMode> Spi<'d, M> {
             w.set_spe(false);
         });
 
-        #[cfg(any(spi_v1, spi_f1))]
+        #[cfg(any(spi_v1, spi_v2))]
         self.info.regs.cr1().modify(|reg| {
             reg.set_dff(word_size);
         });
-        #[cfg(spi_v2)]
+        #[cfg(spi_v3)]
         self.info.regs.cr2().modify(|w| {
             w.set_frxth(word_size.1);
             w.set_ds(word_size.0);
         });
-        #[cfg(any(spi_v3, spi_v4, spi_v5))]
+        #[cfg(any(spi_v4, spi_v5, spi_v6))]
         self.info.regs.cfg1().modify(|w| {
             w.set_dsize(word_size);
         });
@@ -380,7 +380,7 @@ impl<'d, M: PeriMode> Spi<'d, M> {
     /// Blocking write.
     pub fn blocking_write<W: Word>(&mut self, words: &[W]) -> Result<(), Error> {
         // needed in v3+ to avoid overrun causing the SPI RX state machine to get stuck...?
-        #[cfg(any(spi_v3, spi_v4, spi_v5))]
+        #[cfg(any(spi_v4, spi_v5, spi_v6))]
         self.info.regs.cr1().modify(|w| w.set_spe(false));
         self.set_word_size(W::CONFIG);
         self.info.regs.cr1().modify(|w| w.set_spe(true));
@@ -391,7 +391,7 @@ impl<'d, M: PeriMode> Spi<'d, M> {
             // This is the case when the SPI has been created with `new_(blocking_?)txonly_nosck`.
             // See https://github.com/embassy-rs/embassy/issues/2902
             // This is not documented as an errata by ST, and I've been unable to find anything online...
-            #[cfg(not(any(spi_v1, spi_f1)))]
+            #[cfg(not(any(spi_v1, spi_v2)))]
             write_word(self.info.regs, *word)?;
 
             // if we're doing tx only, after writing the last byte to FIFO we have to wait
@@ -401,14 +401,14 @@ impl<'d, M: PeriMode> Spi<'d, M> {
             // Luckily this doesn't affect SPIv2+.
             // See http://efton.sk/STM32/gotcha/g68.html
             // ST doesn't seem to document this in errata sheets (?)
-            #[cfg(any(spi_v1, spi_f1))]
+            #[cfg(any(spi_v1, spi_v2))]
             transfer_word(self.info.regs, *word)?;
         }
 
         // wait until last word is transmitted. (except on v1, see above)
-        #[cfg(not(any(spi_v1, spi_f1, spi_v2)))]
+        #[cfg(not(any(spi_v1, spi_v2, spi_v3)))]
         while !self.info.regs.sr().read().txc() {}
-        #[cfg(spi_v2)]
+        #[cfg(spi_v3)]
         while self.info.regs.sr().read().bsy() {}
 
         Ok(())
@@ -417,7 +417,7 @@ impl<'d, M: PeriMode> Spi<'d, M> {
     /// Blocking read.
     pub fn blocking_read<W: Word>(&mut self, words: &mut [W]) -> Result<(), Error> {
         // needed in v3+ to avoid overrun causing the SPI RX state machine to get stuck...?
-        #[cfg(any(spi_v3, spi_v4, spi_v5))]
+        #[cfg(any(spi_v4, spi_v5, spi_v6))]
         self.info.regs.cr1().modify(|w| w.set_spe(false));
         self.set_word_size(W::CONFIG);
         self.info.regs.cr1().modify(|w| w.set_spe(true));
@@ -433,7 +433,7 @@ impl<'d, M: PeriMode> Spi<'d, M> {
     /// This writes the contents of `data` on MOSI, and puts the received data on MISO in `data`, at the same time.
     pub fn blocking_transfer_in_place<W: Word>(&mut self, words: &mut [W]) -> Result<(), Error> {
         // needed in v3+ to avoid overrun causing the SPI RX state machine to get stuck...?
-        #[cfg(any(spi_v3, spi_v4, spi_v5))]
+        #[cfg(any(spi_v4, spi_v5, spi_v6))]
         self.info.regs.cr1().modify(|w| w.set_spe(false));
         self.set_word_size(W::CONFIG);
         self.info.regs.cr1().modify(|w| w.set_spe(true));
@@ -452,7 +452,7 @@ impl<'d, M: PeriMode> Spi<'d, M> {
     /// If `write` is shorter it is padded with zero bytes.
     pub fn blocking_transfer<W: Word>(&mut self, read: &mut [W], write: &[W]) -> Result<(), Error> {
         // needed in v3+ to avoid overrun causing the SPI RX state machine to get stuck...?
-        #[cfg(any(spi_v3, spi_v4, spi_v5))]
+        #[cfg(any(spi_v4, spi_v5, spi_v6))]
         self.info.regs.cr1().modify(|w| w.set_spe(false));
         self.set_word_size(W::CONFIG);
         self.info.regs.cr1().modify(|w| w.set_spe(true));
@@ -572,7 +572,7 @@ impl<'d> Spi<'d, Async> {
         peri: Peri<'d, T>,
         sck: Peri<'d, impl SckPin<T>>,
         miso: Peri<'d, impl MisoPin<T>>,
-        #[cfg(any(spi_v1, spi_f1, spi_v2))] tx_dma: Peri<'d, impl TxDma<T>>,
+        #[cfg(any(spi_v1, spi_v2, spi_v3))] tx_dma: Peri<'d, impl TxDma<T>>,
         rx_dma: Peri<'d, impl RxDma<T>>,
         config: Config,
     ) -> Self {
@@ -581,9 +581,9 @@ impl<'d> Spi<'d, Async> {
             new_pin!(sck, config.sck_af()),
             None,
             new_pin!(miso, AfType::input(config.miso_pull)),
-            #[cfg(any(spi_v1, spi_f1, spi_v2))]
+            #[cfg(any(spi_v1, spi_v2, spi_v3))]
             new_dma!(tx_dma),
-            #[cfg(any(spi_v3, spi_v4, spi_v5))]
+            #[cfg(any(spi_v4, spi_v5, spi_v6))]
             None,
             new_dma!(rx_dma),
             config,
@@ -677,7 +677,7 @@ impl<'d> Spi<'d, Async> {
         self.info.regs.cr1().modify(|w| {
             w.set_spe(true);
         });
-        #[cfg(any(spi_v3, spi_v4, spi_v5))]
+        #[cfg(any(spi_v4, spi_v5, spi_v6))]
         self.info.regs.cr1().modify(|w| {
             w.set_cstart(true);
         });
@@ -690,7 +690,7 @@ impl<'d> Spi<'d, Async> {
     }
 
     /// SPI read, using DMA.
-    #[cfg(any(spi_v3, spi_v4, spi_v5))]
+    #[cfg(any(spi_v4, spi_v5, spi_v6))]
     pub async fn read<W: Word>(&mut self, data: &mut [W]) -> Result<(), Error> {
         if data.is_empty() {
             return Ok(());
@@ -710,7 +710,7 @@ impl<'d> Spi<'d, Async> {
             prev
         });
 
-        #[cfg(spi_v3)]
+        #[cfg(spi_v4)]
         let i2scfg = regs.i2scfgr().modify(|w| {
             w.i2smod().then(|| {
                 let prev = w.i2scfg();
@@ -766,7 +766,7 @@ impl<'d> Spi<'d, Async> {
             w.set_tsize(0);
         });
 
-        #[cfg(spi_v3)]
+        #[cfg(spi_v4)]
         if let Some(i2scfg) = i2scfg {
             regs.i2scfgr().modify(|w| {
                 w.set_i2scfg(i2scfg);
@@ -777,7 +777,7 @@ impl<'d> Spi<'d, Async> {
     }
 
     /// SPI read, using DMA.
-    #[cfg(any(spi_v1, spi_f1, spi_v2))]
+    #[cfg(any(spi_v1, spi_v2, spi_v3))]
     pub async fn read<W: Word>(&mut self, data: &mut [W]) -> Result<(), Error> {
         if data.is_empty() {
             return Ok(());
@@ -790,7 +790,7 @@ impl<'d> Spi<'d, Async> {
         self.set_word_size(W::CONFIG);
 
         // SPIv3 clears rxfifo on SPE=0
-        #[cfg(not(any(spi_v3, spi_v4, spi_v5)))]
+        #[cfg(not(any(spi_v4, spi_v5, spi_v6)))]
         flush_rx_fifo(self.info.regs);
 
         set_rxdmaen(self.info.regs, true);
@@ -813,7 +813,7 @@ impl<'d> Spi<'d, Async> {
         self.info.regs.cr1().modify(|w| {
             w.set_spe(true);
         });
-        #[cfg(any(spi_v3, spi_v4, spi_v5))]
+        #[cfg(any(spi_v4, spi_v5, spi_v6))]
         self.info.regs.cr1().modify(|w| {
             w.set_cstart(true);
         });
@@ -838,7 +838,7 @@ impl<'d> Spi<'d, Async> {
         self.set_word_size(W::CONFIG);
 
         // SPIv3 clears rxfifo on SPE=0
-        #[cfg(not(any(spi_v3, spi_v4, spi_v5)))]
+        #[cfg(not(any(spi_v4, spi_v5, spi_v6)))]
         flush_rx_fifo(self.info.regs);
 
         set_rxdmaen(self.info.regs, true);
@@ -858,7 +858,7 @@ impl<'d> Spi<'d, Async> {
         self.info.regs.cr1().modify(|w| {
             w.set_spe(true);
         });
-        #[cfg(any(spi_v3, spi_v4, spi_v5))]
+        #[cfg(any(spi_v4, spi_v5, spi_v6))]
         self.info.regs.cr1().modify(|w| {
             w.set_cstart(true);
         });
@@ -898,9 +898,9 @@ impl<'d, M: PeriMode> Drop for Spi<'d, M> {
     }
 }
 
-#[cfg(not(any(spi_v3, spi_v4, spi_v5)))]
+#[cfg(not(any(spi_v4, spi_v5, spi_v6)))]
 use vals::Br;
-#[cfg(any(spi_v3, spi_v4, spi_v5))]
+#[cfg(any(spi_v4, spi_v5, spi_v6))]
 use vals::Mbr as Br;
 
 fn compute_baud_rate(kernel_clock: Hertz, freq: Hertz) -> Br {
@@ -941,21 +941,21 @@ pub(crate) trait RegsExt {
 
 impl RegsExt for Regs {
     fn tx_ptr<W>(&self) -> *mut W {
-        #[cfg(any(spi_v1, spi_f1))]
+        #[cfg(any(spi_v1, spi_v2))]
         let dr = self.dr();
-        #[cfg(spi_v2)]
+        #[cfg(spi_v3)]
         let dr = self.dr16();
-        #[cfg(any(spi_v3, spi_v4, spi_v5))]
+        #[cfg(any(spi_v4, spi_v5, spi_v6))]
         let dr = self.txdr32();
         dr.as_ptr() as *mut W
     }
 
     fn rx_ptr<W>(&self) -> *mut W {
-        #[cfg(any(spi_v1, spi_f1))]
+        #[cfg(any(spi_v1, spi_v2))]
         let dr = self.dr();
-        #[cfg(spi_v2)]
+        #[cfg(spi_v3)]
         let dr = self.dr16();
-        #[cfg(any(spi_v3, spi_v4, spi_v5))]
+        #[cfg(any(spi_v4, spi_v5, spi_v6))]
         let dr = self.rxdr32();
         dr.as_ptr() as *mut W
     }
@@ -965,22 +965,22 @@ fn check_error_flags(sr: regs::Sr, ovr: bool) -> Result<(), Error> {
     if sr.ovr() && ovr {
         return Err(Error::Overrun);
     }
-    #[cfg(not(any(spi_f1, spi_v3, spi_v4, spi_v5)))]
+    #[cfg(not(any(spi_v1, spi_v4, spi_v5, spi_v6)))]
     if sr.fre() {
         return Err(Error::Framing);
     }
-    #[cfg(any(spi_v3, spi_v4, spi_v5))]
+    #[cfg(any(spi_v4, spi_v5, spi_v6))]
     if sr.tifre() {
         return Err(Error::Framing);
     }
     if sr.modf() {
         return Err(Error::ModeFault);
     }
-    #[cfg(not(any(spi_v3, spi_v4, spi_v5)))]
+    #[cfg(not(any(spi_v4, spi_v5, spi_v6)))]
     if sr.crcerr() {
         return Err(Error::Crc);
     }
-    #[cfg(any(spi_v3, spi_v4, spi_v5))]
+    #[cfg(any(spi_v4, spi_v5, spi_v6))]
     if sr.crce() {
         return Err(Error::Crc);
     }
@@ -994,11 +994,11 @@ fn spin_until_tx_ready(regs: Regs, ovr: bool) -> Result<(), Error> {
 
         check_error_flags(sr, ovr)?;
 
-        #[cfg(not(any(spi_v3, spi_v4, spi_v5)))]
+        #[cfg(not(any(spi_v4, spi_v5, spi_v6)))]
         if sr.txe() {
             return Ok(());
         }
-        #[cfg(any(spi_v3, spi_v4, spi_v5))]
+        #[cfg(any(spi_v4, spi_v5, spi_v6))]
         if sr.txp() {
             return Ok(());
         }
@@ -1011,11 +1011,11 @@ fn spin_until_rx_ready(regs: Regs) -> Result<(), Error> {
 
         check_error_flags(sr, true)?;
 
-        #[cfg(not(any(spi_v3, spi_v4, spi_v5)))]
+        #[cfg(not(any(spi_v4, spi_v5, spi_v6)))]
         if sr.rxne() {
             return Ok(());
         }
-        #[cfg(any(spi_v3, spi_v4, spi_v5))]
+        #[cfg(any(spi_v4, spi_v5, spi_v6))]
         if sr.rxp() {
             return Ok(());
         }
@@ -1023,46 +1023,46 @@ fn spin_until_rx_ready(regs: Regs) -> Result<(), Error> {
 }
 
 pub(crate) fn flush_rx_fifo(regs: Regs) {
-    #[cfg(not(any(spi_v3, spi_v4, spi_v5)))]
+    #[cfg(not(any(spi_v4, spi_v5, spi_v6)))]
     while regs.sr().read().rxne() {
-        #[cfg(not(spi_v2))]
+        #[cfg(not(spi_v3))]
         let _ = regs.dr().read();
-        #[cfg(spi_v2)]
+        #[cfg(spi_v3)]
         let _ = regs.dr16().read();
     }
-    #[cfg(any(spi_v3, spi_v4, spi_v5))]
+    #[cfg(any(spi_v4, spi_v5, spi_v6))]
     while regs.sr().read().rxp() {
         let _ = regs.rxdr32().read();
     }
 }
 
 pub(crate) fn set_txdmaen(regs: Regs, val: bool) {
-    #[cfg(not(any(spi_v3, spi_v4, spi_v5)))]
+    #[cfg(not(any(spi_v4, spi_v5, spi_v6)))]
     regs.cr2().modify(|reg| {
         reg.set_txdmaen(val);
     });
-    #[cfg(any(spi_v3, spi_v4, spi_v5))]
+    #[cfg(any(spi_v4, spi_v5, spi_v6))]
     regs.cfg1().modify(|reg| {
         reg.set_txdmaen(val);
     });
 }
 
 pub(crate) fn set_rxdmaen(regs: Regs, val: bool) {
-    #[cfg(not(any(spi_v3, spi_v4, spi_v5)))]
+    #[cfg(not(any(spi_v4, spi_v5, spi_v6)))]
     regs.cr2().modify(|reg| {
         reg.set_rxdmaen(val);
     });
-    #[cfg(any(spi_v3, spi_v4, spi_v5))]
+    #[cfg(any(spi_v4, spi_v5, spi_v6))]
     regs.cfg1().modify(|reg| {
         reg.set_rxdmaen(val);
     });
 }
 
 fn finish_dma(regs: Regs) {
-    #[cfg(spi_v2)]
+    #[cfg(spi_v3)]
     while regs.sr().read().ftlvl().to_bits() > 0 {}
 
-    #[cfg(any(spi_v3, spi_v4, spi_v5))]
+    #[cfg(any(spi_v4, spi_v5, spi_v6))]
     {
         if regs.cr2().read().tsize() == 0 {
             while !regs.sr().read().txc() {}
@@ -1070,7 +1070,7 @@ fn finish_dma(regs: Regs) {
             while !regs.sr().read().eot() {}
         }
     }
-    #[cfg(not(any(spi_v3, spi_v4, spi_v5)))]
+    #[cfg(not(any(spi_v4, spi_v5, spi_v6)))]
     while regs.sr().read().bsy() {}
 
     // Disable the spi peripheral
@@ -1080,12 +1080,12 @@ fn finish_dma(regs: Regs) {
 
     // The peripheral automatically disables the DMA stream on completion without error,
     // but it does not clear the RXDMAEN/TXDMAEN flag in CR2.
-    #[cfg(not(any(spi_v3, spi_v4, spi_v5)))]
+    #[cfg(not(any(spi_v4, spi_v5, spi_v6)))]
     regs.cr2().modify(|reg| {
         reg.set_txdmaen(false);
         reg.set_rxdmaen(false);
     });
-    #[cfg(any(spi_v3, spi_v4, spi_v5))]
+    #[cfg(any(spi_v4, spi_v5, spi_v6))]
     regs.cfg1().modify(|reg| {
         reg.set_txdmaen(false);
         reg.set_rxdmaen(false);
@@ -1098,7 +1098,7 @@ fn transfer_word<W: Word>(regs: Regs, tx_word: W) -> Result<W, Error> {
     unsafe {
         ptr::write_volatile(regs.tx_ptr(), tx_word);
 
-        #[cfg(any(spi_v3, spi_v4, spi_v5))]
+        #[cfg(any(spi_v4, spi_v5, spi_v6))]
         regs.cr1().modify(|reg| reg.set_cstart(true));
     }
 
@@ -1117,7 +1117,7 @@ fn write_word<W: Word>(regs: Regs, tx_word: W) -> Result<(), Error> {
     unsafe {
         ptr::write_volatile(regs.tx_ptr(), tx_word);
 
-        #[cfg(any(spi_v3, spi_v4, spi_v5))]
+        #[cfg(any(spi_v4, spi_v5, spi_v6))]
         regs.cr1().modify(|reg| reg.set_cstart(true));
     }
     Ok(())
@@ -1225,7 +1225,7 @@ macro_rules! impl_word {
     };
 }
 
-#[cfg(any(spi_v1, spi_f1))]
+#[cfg(any(spi_v1, spi_v2))]
 mod word_impl {
     use super::*;
 
@@ -1235,7 +1235,7 @@ mod word_impl {
     impl_word!(u16, vals::Dff::BITS16);
 }
 
-#[cfg(spi_v2)]
+#[cfg(spi_v3)]
 mod word_impl {
     use super::*;
 
@@ -1256,7 +1256,7 @@ mod word_impl {
     impl_word!(u16, (vals::Ds::BITS16, vals::Frxth::HALF));
 }
 
-#[cfg(any(spi_v3, spi_v4, spi_v5))]
+#[cfg(any(spi_v4, spi_v5, spi_v6))]
 mod word_impl {
     use super::*;
 

--- a/examples/stm32h7/src/bin/sai.rs
+++ b/examples/stm32h7/src/bin/sai.rs
@@ -63,7 +63,7 @@ async fn main(_spawner: Spawner) {
     tx_config.tx_rx = TxRx::Transmitter;
     tx_config.sync_output = true;
     tx_config.clock_strobe = ClockStrobe::Falling;
-    tx_config.master_clock_divider = mclk_div;
+    tx_config.master_clock_divider = Some(mclk_div);
     tx_config.stereo_mono = StereoMono::Stereo;
     tx_config.data_size = DataSize::Data24;
     tx_config.bit_order = BitOrder::MsbFirst;
@@ -119,71 +119,7 @@ async fn main(_spawner: Spawner) {
     }
 }
 
-const fn mclk_div_from_u8(v: u8) -> MasterClockDivider {
-    match v {
-        1 => MasterClockDivider::Div1,
-        2 => MasterClockDivider::Div2,
-        3 => MasterClockDivider::Div3,
-        4 => MasterClockDivider::Div4,
-        5 => MasterClockDivider::Div5,
-        6 => MasterClockDivider::Div6,
-        7 => MasterClockDivider::Div7,
-        8 => MasterClockDivider::Div8,
-        9 => MasterClockDivider::Div9,
-        10 => MasterClockDivider::Div10,
-        11 => MasterClockDivider::Div11,
-        12 => MasterClockDivider::Div12,
-        13 => MasterClockDivider::Div13,
-        14 => MasterClockDivider::Div14,
-        15 => MasterClockDivider::Div15,
-        16 => MasterClockDivider::Div16,
-        17 => MasterClockDivider::Div17,
-        18 => MasterClockDivider::Div18,
-        19 => MasterClockDivider::Div19,
-        20 => MasterClockDivider::Div20,
-        21 => MasterClockDivider::Div21,
-        22 => MasterClockDivider::Div22,
-        23 => MasterClockDivider::Div23,
-        24 => MasterClockDivider::Div24,
-        25 => MasterClockDivider::Div25,
-        26 => MasterClockDivider::Div26,
-        27 => MasterClockDivider::Div27,
-        28 => MasterClockDivider::Div28,
-        29 => MasterClockDivider::Div29,
-        30 => MasterClockDivider::Div30,
-        31 => MasterClockDivider::Div31,
-        32 => MasterClockDivider::Div32,
-        33 => MasterClockDivider::Div33,
-        34 => MasterClockDivider::Div34,
-        35 => MasterClockDivider::Div35,
-        36 => MasterClockDivider::Div36,
-        37 => MasterClockDivider::Div37,
-        38 => MasterClockDivider::Div38,
-        39 => MasterClockDivider::Div39,
-        40 => MasterClockDivider::Div40,
-        41 => MasterClockDivider::Div41,
-        42 => MasterClockDivider::Div42,
-        43 => MasterClockDivider::Div43,
-        44 => MasterClockDivider::Div44,
-        45 => MasterClockDivider::Div45,
-        46 => MasterClockDivider::Div46,
-        47 => MasterClockDivider::Div47,
-        48 => MasterClockDivider::Div48,
-        49 => MasterClockDivider::Div49,
-        50 => MasterClockDivider::Div50,
-        51 => MasterClockDivider::Div51,
-        52 => MasterClockDivider::Div52,
-        53 => MasterClockDivider::Div53,
-        54 => MasterClockDivider::Div54,
-        55 => MasterClockDivider::Div55,
-        56 => MasterClockDivider::Div56,
-        57 => MasterClockDivider::Div57,
-        58 => MasterClockDivider::Div58,
-        59 => MasterClockDivider::Div59,
-        60 => MasterClockDivider::Div60,
-        61 => MasterClockDivider::Div61,
-        62 => MasterClockDivider::Div62,
-        63 => MasterClockDivider::Div63,
-        _ => panic!(),
-    }
+fn mclk_div_from_u8(v: u8) -> MasterClockDivider {
+    assert!((1..=63).contains(&v));
+    MasterClockDivider::from_bits(v)
 }

--- a/examples/stm32h723/src/bin/spdifrx.rs
+++ b/examples/stm32h723/src/bin/spdifrx.rs
@@ -168,7 +168,7 @@ fn new_sai_transmitter<'d>(
     sai_config.slot_enable = 0xFFFF; // All slots
     sai_config.data_size = sai::DataSize::Data32;
     sai_config.frame_length = (CHANNEL_COUNT * 32) as u8;
-    sai_config.master_clock_divider = hal::sai::MasterClockDivider::MasterClockDisabled;
+    sai_config.master_clock_divider = None;
 
     let (sub_block_tx, _) = hal::sai::split_subblocks(sai);
     Sai::new_asynchronous(sub_block_tx, sck, sd, fs, dma, buf, sai_config)


### PR DESCRIPTION
- **stm32/sai: update for new metapac, simplify cfgs.**
- **stm32: peri_v1_bar now enables cfgs peri_v1 and peri_v1_bar.**
- **stm32/spi: update for new version numbering, add i2s support for all versions.**
