### PR TITLE
embassy-rp: new DMA driver

### DIFF
--- a/embassy-rp/src/adc.rs
+++ b/embassy-rp/src/adc.rs
@@ -296,13 +296,13 @@ impl<'d> Adc<'d, Async> {
         }
         let auto_reset = ResetDmaConfig;
 
-        let dma = unsafe { dma::read(dma, r.fifo().as_ptr() as *const W, buf as *mut [W], TreqSel::ADC) };
+        let mut dma = unsafe { dma::read(dma, r.fifo().as_ptr() as *const W, buf as *mut [W], TreqSel::ADC) };
         // start conversions and wait for dma to finish. we can't report errors early
         // because there's no interrupt to signal them, and inspecting every element
         // of the fifo is too costly to do here.
         r.div().write_set(|w| w.set_int(div));
         r.cs().write_set(|w| w.set_start_many(true));
-        dma.await;
+        dma.wait().await;
         mem::drop(auto_reset);
         // we can't report errors before the conversions have ended since no interrupt
         // exists to report them early, and since they're exceedingly rare we probably don't

--- a/embassy-rp/src/flash.rs
+++ b/embassy-rp/src/flash.rs
@@ -85,7 +85,7 @@ pub struct BackgroundRead<'a, 'd, T: Instance, const FLASH_SIZE: usize> {
 impl<'a, 'd, T: Instance, const FLASH_SIZE: usize> Future for BackgroundRead<'a, 'd, T, FLASH_SIZE> {
     type Output = ();
     fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
-        Pin::new(&mut self.transfer).poll(cx)
+        Pin::new(&mut self.transfer.wait()).poll(cx)
     }
 }
 

--- a/embassy-rp/src/pio/mod.rs
+++ b/embassy-rp/src/pio/mod.rs
@@ -16,7 +16,7 @@ use crate::dma::{Channel, Transfer, Word};
 use crate::gpio::{self, AnyPin, Drive, Level, Pull, SealedPin, SlewRate};
 use crate::interrupt::typelevel::{Binding, Handler, Interrupt};
 use crate::relocate::RelocatedProgram;
-use crate::{pac, peripherals, RegExt};
+use crate::{dma, pac, peripherals, RegExt};
 
 mod instr;
 
@@ -391,6 +391,22 @@ impl<'d, PIO: Instance, const SM: usize> StateMachineRx<'d, PIO, SM> {
     }
 }
 
+impl<'d, PIO: Instance, const SM: usize, W: Word> dma::Target<W> for &mut StateMachineRx<'d, PIO, SM> {
+    const INCR_ADDR: bool = false;
+
+    const TREQ_SEL: u8 = PIO::PIO_NO * 8 + SM as u8 + 4;
+
+    fn transfer_count(&self) -> u32 {
+        u32::MAX
+    }
+}
+
+impl<'d, PIO: Instance, const SM: usize, W: Word> dma::TargetRef<W> for &mut StateMachineRx<'d, PIO, SM> {
+    fn as_ptr(&self) -> *const W {
+        PIO::PIO.rxf(SM).as_ptr() as *const W
+    }
+}
+
 /// Type representing a state machine TX FIFO.
 pub struct StateMachineTx<'d, PIO: Instance, const SM: usize> {
     pio: PhantomData<&'d mut PIO>,
@@ -479,6 +495,22 @@ impl<'d, PIO: Instance, const SM: usize> StateMachineTx<'d, PIO, SM> {
         });
         compiler_fence(Ordering::SeqCst);
         Transfer::new_inner(ch)
+    }
+}
+
+impl<'d, PIO: Instance, const SM: usize, W: Word> dma::Target<W> for &mut StateMachineTx<'d, PIO, SM> {
+    const INCR_ADDR: bool = false;
+
+    const TREQ_SEL: u8 = PIO::PIO_NO * 8 + SM as u8;
+
+    fn transfer_count(&self) -> u32 {
+        u32::MAX
+    }
+}
+
+impl<'d, PIO: Instance, const SM: usize, W: Word> dma::TargetMut<W> for &mut StateMachineTx<'d, PIO, SM> {
+    fn as_mut_ptr(&mut self) -> *mut W {
+        PIO::PIO.txf(SM).as_ptr() as *mut W
     }
 }
 

--- a/embassy-rp/src/pio/mod.rs
+++ b/embassy-rp/src/pio/mod.rs
@@ -387,7 +387,7 @@ impl<'d, PIO: Instance, const SM: usize> StateMachineRx<'d, PIO, SM> {
             w.set_en(true);
         });
         compiler_fence(Ordering::SeqCst);
-        Transfer::new(ch)
+        Transfer::new_inner(ch)
     }
 }
 
@@ -478,7 +478,7 @@ impl<'d, PIO: Instance, const SM: usize> StateMachineTx<'d, PIO, SM> {
             w.set_en(true);
         });
         compiler_fence(Ordering::SeqCst);
-        Transfer::new(ch)
+        Transfer::new_inner(ch)
     }
 }
 

--- a/embassy-rp/src/pio_programs/hd44780.rs
+++ b/embassy-rp/src/pio_programs/hd44780.rs
@@ -178,7 +178,7 @@ impl<'l, P: Instance, const S: usize> PioHD44780<'l, P, S> {
         sm.set_enable(true);
 
         // display on and cursor on and blinking, reset display
-        sm.tx().dma_push(dma.reborrow(), &[0x81u8, 0x0f, 1], false).await;
+        sm.tx().dma_push(dma.reborrow(), &[0x81u8, 0x0f, 1], false).wait().await;
 
         Self {
             dma: dma.into(),
@@ -203,6 +203,10 @@ impl<'l, P: Instance, const S: usize> PioHD44780<'l, P, S> {
         // set cursor to 1:15
         self.buf[38..].copy_from_slice(&[0x80, 0xcf]);
 
-        self.sm.tx().dma_push(self.dma.reborrow(), &self.buf, false).await;
+        self.sm
+            .tx()
+            .dma_push(self.dma.reborrow(), &self.buf, false)
+            .wait()
+            .await;
     }
 }

--- a/embassy-rp/src/pio_programs/ws2812.rs
+++ b/embassy-rp/src/pio_programs/ws2812.rs
@@ -106,7 +106,7 @@ impl<'d, P: Instance, const S: usize, const N: usize> PioWs2812<'d, P, S, N> {
         }
 
         // DMA transfer
-        self.sm.tx().dma_push(self.dma.reborrow(), &words, false).await;
+        self.sm.tx().dma_push(self.dma.reborrow(), &words, false).wait().await;
 
         Timer::after_micros(55).await;
     }
@@ -172,7 +172,7 @@ impl<'d, P: Instance, const S: usize, const N: usize> RgbwPioWs2812<'d, P, S, N>
         }
 
         // DMA transfer
-        self.sm.tx().dma_push(self.dma.reborrow(), &words, false).await;
+        self.sm.tx().dma_push(self.dma.reborrow(), &words, false).wait().await;
 
         Timer::after_micros(55).await;
     }


### PR DESCRIPTION
motivation: need better way to cancel dma mid flight and read remaining transfer count

dma transfer's are built using `TransferBuilder`

this should support wide range of configuration, repeating read/write, ring read/ring write, etc

configuration errors are caught in compile time