### PR TITLE
embassy-dfu-usb: Allow `application` and `dfu` feature at the same time

### DIFF
--- a/embassy-usb-dfu/CHANGELOG.md
+++ b/embassy-usb-dfu/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 <!-- next-header -->
 ## Unreleased - ReleaseDate
 
+- Allow enabling the `application` and `dfu` feature at the same time
+
 ## 0.2.0 - 2025-08-27
 
 - First release with changelog.

--- a/embassy-usb-dfu/src/application.rs
+++ b/embassy-usb-dfu/src/application.rs
@@ -1,3 +1,4 @@
+//! Application part of DFU logic
 use embassy_boot::BlockingFirmwareState;
 use embassy_time::{Duration, Instant};
 use embassy_usb::control::{InResponse, OutResponse, Recipient, RequestType};

--- a/embassy-usb-dfu/src/dfu.rs
+++ b/embassy-usb-dfu/src/dfu.rs
@@ -1,3 +1,4 @@
+//! DFU bootloader part of DFU logic
 use embassy_boot::{AlignedBuffer, BlockingFirmwareUpdater, FirmwareUpdaterError};
 use embassy_usb::control::{InResponse, OutResponse, Recipient, RequestType};
 use embassy_usb::driver::Driver;

--- a/embassy-usb-dfu/src/lib.rs
+++ b/embassy-usb-dfu/src/lib.rs
@@ -6,20 +6,14 @@ mod fmt;
 pub mod consts;
 
 #[cfg(feature = "dfu")]
-mod dfu;
-#[cfg(feature = "dfu")]
+pub mod dfu;
+#[cfg(all(feature = "dfu", not(feature = "application")))]
 pub use self::dfu::*;
 
 #[cfg(feature = "application")]
-mod application;
-#[cfg(feature = "application")]
+pub mod application;
+#[cfg(all(feature = "application", not(feature = "dfu")))]
 pub use self::application::*;
-
-#[cfg(any(
-    all(feature = "dfu", feature = "application"),
-    not(any(feature = "dfu", feature = "application"))
-))]
-compile_error!("usb-dfu must be compiled with exactly one of `dfu`, or `application` features");
 
 /// Provides a platform-agnostic interface for initiating a system reset.
 ///


### PR DESCRIPTION
Since there is no technical reason to disallow the use of both features at the same time, remove the artifical contraint to give developers more freedom with their implementations.