### PR TITLE
Add a wait_for_update function to low_level timers

### DIFF
--- a/embassy-stm32/CHANGELOG.md
+++ b/embassy-stm32/CHANGELOG.md
@@ -13,6 +13,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - fix: stm32/i2c in master mode (blocking): subsequent transmissions failed after a NACK was received
 - feat: stm32/timer: add set_polarity functions for main and complementary outputs in complementary_pwm
 - Add I2S support for STM32F1, STM32C0, STM32F0, STM32F3, STM32F7, STM32G0, STM32WL, STM32H5, STM32H7RS
+- Added `low_level::Timer::new_with_interrupt` as well as a mode generic
+  parameter to `low_level::Timer` to distinguish between timers with and without
+  a update interrupt binding. Existing code should add
+  `timer::low_level::mode::NoIrq`.
+- Added `low_level::Timer::wait_for_update` to asynchronously wait for an update
+  interrupt.
+
 ### Fixed
 
 - STM32: Prevent dropped DacChannel from disabling Dac peripheral if another DacChannel is still in scope ([#4577](https://github.com/embassy-rs/embassy/pull/4577))

--- a/embassy-stm32/src/timer/complementary_pwm.rs
+++ b/embassy-stm32/src/timer/complementary_pwm.rs
@@ -4,7 +4,7 @@ use core::marker::PhantomData;
 
 pub use stm32_metapac::timer::vals::{Ckd, Ossi, Ossr};
 
-use super::low_level::{CountingMode, OutputPolarity, Timer};
+use super::low_level::{CountingMode, NoIrq, OutputPolarity, Timer};
 use super::simple_pwm::PwmPin;
 use super::{AdvancedInstance4Channel, Ch1, Ch2, Ch3, Ch4, Channel, TimerComplementaryPin};
 use crate::gpio::{AnyPin, OutputType};
@@ -40,7 +40,7 @@ impl<'d, T: AdvancedInstance4Channel, C: TimerChannel> ComplementaryPwmPin<'d, T
 
 /// PWM driver with support for standard and complementary outputs.
 pub struct ComplementaryPwm<'d, T: AdvancedInstance4Channel> {
-    inner: Timer<'d, T>,
+    inner: Timer<'d, T, NoIrq>,
 }
 
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]

--- a/embassy-stm32/src/timer/input_capture.rs
+++ b/embassy-stm32/src/timer/input_capture.rs
@@ -5,7 +5,7 @@ use core::marker::PhantomData;
 use core::pin::Pin;
 use core::task::{Context, Poll};
 
-use super::low_level::{CountingMode, FilterValue, InputCaptureMode, InputTISelection, Timer};
+use super::low_level::{CountingMode, FilterValue, InputCaptureMode, InputTISelection, NoIrq, Timer};
 use super::{CaptureCompareInterruptHandler, Channel, GeneralInstance4Channel, TimerPin};
 pub use super::{Ch1, Ch2, Ch3, Ch4};
 use crate::gpio::{AfType, AnyPin, Pull};
@@ -34,7 +34,7 @@ impl<'d, T: GeneralInstance4Channel, C: TimerChannel> CapturePin<'d, T, C> {
 
 /// Input capture driver.
 pub struct InputCapture<'d, T: GeneralInstance4Channel> {
-    inner: Timer<'d, T>,
+    inner: Timer<'d, T, NoIrq>,
 }
 
 impl<'d, T: GeneralInstance4Channel> InputCapture<'d, T> {

--- a/embassy-stm32/src/timer/one_pulse.rs
+++ b/embassy-stm32/src/timer/one_pulse.rs
@@ -7,7 +7,7 @@ use core::pin::Pin;
 use core::task::{Context, Poll};
 
 use super::low_level::{
-    CountingMode, FilterValue, InputCaptureMode, InputTISelection, SlaveMode, Timer, TriggerSource as Ts,
+    CountingMode, FilterValue, InputCaptureMode, InputTISelection, NoIrq, SlaveMode, Timer, TriggerSource as Ts,
 };
 use super::{CaptureCompareInterruptHandler, Channel, ExternalTriggerPin, GeneralInstance4Channel, TimerPin};
 pub use super::{Ch1, Ch2};
@@ -123,7 +123,7 @@ impl<'d, T: GeneralInstance4Channel, C: TriggerSource> TriggerPin<'d, T, C> {
 ///
 /// Generates a pulse after a trigger and some configurable delay.
 pub struct OnePulse<'d, T: GeneralInstance4Channel> {
-    inner: Timer<'d, T>,
+    inner: Timer<'d, T, NoIrq>,
 }
 
 impl<'d, T: GeneralInstance4Channel> OnePulse<'d, T> {
@@ -354,7 +354,7 @@ pub struct OnePulseChannels<'d, T: GeneralInstance4Channel> {
 /// It is not possible to change the pulse end tick because the end tick
 /// configuration is shared with all four channels.
 pub struct OnePulseChannel<'d, T: GeneralInstance4Channel> {
-    inner: ManuallyDrop<Timer<'d, T>>,
+    inner: ManuallyDrop<Timer<'d, T, NoIrq>>,
     channel: Channel,
 }
 

--- a/embassy-stm32/src/timer/pwm_input.rs
+++ b/embassy-stm32/src/timer/pwm_input.rs
@@ -1,6 +1,6 @@
 //! PWM Input driver.
 
-use super::low_level::{CountingMode, InputCaptureMode, InputTISelection, SlaveMode, Timer, TriggerSource};
+use super::low_level::{CountingMode, InputCaptureMode, InputTISelection, NoIrq, SlaveMode, Timer, TriggerSource};
 use super::{Ch1, Ch2, Channel, GeneralInstance4Channel, TimerPin};
 use crate::gpio::{AfType, Pull};
 use crate::time::Hertz;
@@ -13,7 +13,7 @@ use crate::Peri;
 /// Double check your chips reference manual
 pub struct PwmInput<'d, T: GeneralInstance4Channel> {
     channel: Channel,
-    inner: Timer<'d, T>,
+    inner: Timer<'d, T, NoIrq>,
 }
 
 impl<'d, T: GeneralInstance4Channel> PwmInput<'d, T> {

--- a/embassy-stm32/src/timer/qei.rs
+++ b/embassy-stm32/src/timer/qei.rs
@@ -4,7 +4,7 @@ use core::marker::PhantomData;
 
 use stm32_metapac::timer::vals;
 
-use super::low_level::Timer;
+use super::low_level::{NoIrq, Timer};
 pub use super::{Ch1, Ch2};
 use super::{GeneralInstance4Channel, TimerPin};
 use crate::gpio::{AfType, AnyPin, Pull};
@@ -53,7 +53,7 @@ impl SealedQeiChannel for Ch2 {}
 
 /// Quadrature decoder driver.
 pub struct Qei<'d, T: GeneralInstance4Channel> {
-    inner: Timer<'d, T>,
+    inner: Timer<'d, T, NoIrq>,
 }
 
 impl<'d, T: GeneralInstance4Channel> Qei<'d, T> {

--- a/embassy-stm32/src/timer/simple_pwm.rs
+++ b/embassy-stm32/src/timer/simple_pwm.rs
@@ -3,7 +3,7 @@
 use core::marker::PhantomData;
 use core::mem::ManuallyDrop;
 
-use super::low_level::{CountingMode, OutputCompareMode, OutputPolarity, Timer};
+use super::low_level::{CountingMode, NoIrq, OutputCompareMode, OutputPolarity, Timer};
 use super::{Ch1, Ch2, Ch3, Ch4, Channel, GeneralInstance4Channel, TimerBits, TimerChannel, TimerPin};
 #[cfg(gpio_v2)]
 use crate::gpio::Pull;
@@ -72,7 +72,7 @@ impl<'d, T: GeneralInstance4Channel, C: TimerChannel> PwmPin<'d, T, C> {
 /// It is not possible to change the pwm frequency because
 /// the frequency configuration is shared with all four channels.
 pub struct SimplePwmChannel<'d, T: GeneralInstance4Channel> {
-    timer: ManuallyDrop<Timer<'d, T>>,
+    timer: ManuallyDrop<Timer<'d, T, NoIrq>>,
     channel: Channel,
 }
 
@@ -173,7 +173,7 @@ pub struct SimplePwmChannels<'d, T: GeneralInstance4Channel> {
 
 /// Simple PWM driver.
 pub struct SimplePwm<'d, T: GeneralInstance4Channel> {
-    inner: Timer<'d, T>,
+    inner: Timer<'d, T, NoIrq>,
 }
 
 impl<'d, T: GeneralInstance4Channel> SimplePwm<'d, T> {

--- a/examples/stm32f4/src/bin/usb_uac_speaker.rs
+++ b/examples/stm32f4/src/bin/usb_uac_speaker.rs
@@ -6,6 +6,7 @@ use core::cell::{Cell, RefCell};
 use defmt::{panic, *};
 use embassy_executor::Spawner;
 use embassy_stm32::time::Hertz;
+use embassy_stm32::timer::low_level::NoIrq;
 use embassy_stm32::{bind_interrupts, interrupt, peripherals, timer, usb, Config};
 use embassy_sync::blocking_mutex::raw::{CriticalSectionRawMutex, NoopRawMutex};
 use embassy_sync::blocking_mutex::Mutex;
@@ -23,7 +24,7 @@ bind_interrupts!(struct Irqs {
     OTG_FS => usb::InterruptHandler<peripherals::USB_OTG_FS>;
 });
 
-static TIMER: Mutex<CriticalSectionRawMutex, RefCell<Option<timer::low_level::Timer<peripherals::TIM2>>>> =
+static TIMER: Mutex<CriticalSectionRawMutex, RefCell<Option<timer::low_level::Timer<peripherals::TIM2, NoIrq>>>> =
     Mutex::new(RefCell::new(None));
 
 // A counter signal that is written by the feedback timer, once every `FEEDBACK_REFRESH_PERIOD`.

--- a/examples/stm32h5/src/bin/usb_uac_speaker.rs
+++ b/examples/stm32h5/src/bin/usb_uac_speaker.rs
@@ -6,6 +6,7 @@ use core::cell::{Cell, RefCell};
 use defmt::{panic, *};
 use embassy_executor::Spawner;
 use embassy_stm32::time::Hertz;
+use embassy_stm32::timer::low_level::NoIrq;
 use embassy_stm32::{bind_interrupts, interrupt, peripherals, timer, usb, Config};
 use embassy_sync::blocking_mutex::raw::{CriticalSectionRawMutex, NoopRawMutex};
 use embassy_sync::blocking_mutex::Mutex;
@@ -23,7 +24,7 @@ bind_interrupts!(struct Irqs {
     USB_DRD_FS => usb::InterruptHandler<peripherals::USB>;
 });
 
-static TIMER: Mutex<CriticalSectionRawMutex, RefCell<Option<timer::low_level::Timer<peripherals::TIM5>>>> =
+static TIMER: Mutex<CriticalSectionRawMutex, RefCell<Option<timer::low_level::Timer<peripherals::TIM5, NoIrq>>>> =
     Mutex::new(RefCell::new(None));
 
 // A counter signal that is written by the feedback timer, once every `FEEDBACK_REFRESH_PERIOD`.

--- a/examples/stm32h7/src/bin/low_level_timer_api.rs
+++ b/examples/stm32h7/src/bin/low_level_timer_api.rs
@@ -5,7 +5,7 @@ use defmt::*;
 use embassy_executor::Spawner;
 use embassy_stm32::gpio::{AfType, Flex, OutputType, Speed};
 use embassy_stm32::time::{khz, Hertz};
-use embassy_stm32::timer::low_level::{OutputCompareMode, Timer as LLTimer};
+use embassy_stm32::timer::low_level::{NoIrq, OutputCompareMode, Timer as LLTimer};
 use embassy_stm32::timer::{Ch1, Ch2, Ch3, Ch4, Channel, GeneralInstance32bit4Channel, TimerPin};
 use embassy_stm32::{Config, Peri};
 use embassy_time::Timer;
@@ -57,7 +57,7 @@ async fn main(_spawner: Spawner) {
     }
 }
 pub struct SimplePwm32<'d, T: GeneralInstance32bit4Channel> {
-    tim: LLTimer<'d, T>,
+    tim: LLTimer<'d, T, NoIrq>,
     _ch1: Flex<'d>,
     _ch2: Flex<'d>,
     _ch3: Flex<'d>,


### PR DESCRIPTION
I am using this to implement a OPM pulse with a wait-for-completion. This is to reliably clock a HX711 without risking holding the clock line for too long. I also think exposing this interrupt as a future is more flexible than trying to have a module per conceptual timer use-case.

Let me know if there's something wrong with this approach, I think this code is correct but I also wrote it about half a year ago... I'm successfully using this code on an STM32F411CE at the moment.