### PR TITLE
stm32/i2c: fix failure of subsequent transmissions after NACK

### DIFF
--- a/embassy-stm32/CHANGELOG.md
+++ b/embassy-stm32/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - fix: Fixed STM32H5 builds requiring time feature
 - feat: Derive Clone, Copy for QSPI Config
+- fix: stm32/i2c in master mode (blocking): subsequent transmissions failed after a NACK was received
 
 ## 0.4.0 - 2025-08-26
 

--- a/embassy-stm32/src/i2c/v2.rs
+++ b/embassy-stm32/src/i2c/v2.rs
@@ -454,7 +454,8 @@ impl<'d, M: Mode, IM: MasterMode> I2c<'d, M, IM> {
                 // (START has been ACKed or last byte when
                 // through)
                 if let Err(err) = self.wait_txis(timeout) {
-                    if send_stop {
+                    if send_stop && err != Error::Nack {
+                        // STOP is sent automatically if a NACK was received
                         self.master_stop();
                     }
                     return Err(err);
@@ -548,7 +549,9 @@ impl<'d, M: Mode, IM: MasterMode> I2c<'d, M, IM> {
                     (idx != last_slice_index) || (slice_len > 255),
                     timeout,
                 ) {
-                    self.master_stop();
+                    if err != Error::Nack {
+                        self.master_stop();
+                    }
                     return Err(err);
                 }
             }
@@ -561,7 +564,9 @@ impl<'d, M: Mode, IM: MasterMode> I2c<'d, M, IM> {
                         (number != last_chunk_idx) || (idx != last_slice_index),
                         timeout,
                     ) {
-                        self.master_stop();
+                        if err != Error::Nack {
+                            self.master_stop();
+                        }
                         return Err(err);
                     }
                 }
@@ -571,7 +576,9 @@ impl<'d, M: Mode, IM: MasterMode> I2c<'d, M, IM> {
                     // (START has been ACKed or last byte when
                     // through)
                     if let Err(err) = self.wait_txis(timeout) {
-                        self.master_stop();
+                        if err != Error::Nack {
+                            self.master_stop();
+                        }
                         return Err(err);
                     }
 


### PR DESCRIPTION
When a slave responds with a NACK in blocking I²C master mode, all subsequent transmissions send only the address followed immediately by a STOP.

This happens because the current implementation sets I2C_CR2.STOP = 1 whenever any error (including a NACK) occurs.

According to the reference manual: "If a NACK is received: […] a STOP condition is automatically sent […]"

As a result, the STOP bit is already set when the next transmission starts.

This bug was not triggered until #4454 was merged.