### PR TITLE
Add timer set polarity functions for main and complementary outputs in complementary_pwm

### DIFF
--- a/embassy-stm32/CHANGELOG.md
+++ b/embassy-stm32/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - fix: Fixed STM32H5 builds requiring time feature
 - feat: Derive Clone, Copy for QSPI Config
 - fix: stm32/i2c in master mode (blocking): subsequent transmissions failed after a NACK was received
+- feat: stm32/timer: add set_polarity functions for main and complementary outputs in complementary_pwm
 
 ## 0.4.0 - 2025-08-26
 

--- a/embassy-stm32/src/timer/complementary_pwm.rs
+++ b/embassy-stm32/src/timer/complementary_pwm.rs
@@ -185,6 +185,16 @@ impl<'d, T: AdvancedInstance4Channel> ComplementaryPwm<'d, T> {
         self.inner.set_complementary_output_polarity(channel, polarity);
     }
 
+    /// Set the main output polarity for a given channel.
+    pub fn set_main_polarity(&mut self, channel: Channel, polarity: OutputPolarity) {
+        self.inner.set_output_polarity(channel, polarity);
+    }
+
+    /// Set the complementary output polarity for a given channel.
+    pub fn set_complementary_polarity(&mut self, channel: Channel, polarity: OutputPolarity) {
+        self.inner.set_complementary_output_polarity(channel, polarity);
+    }
+
     /// Set the dead time as a proportion of max_duty
     pub fn set_dead_time(&mut self, value: u16) {
         let (ckd, value) = compute_dead_time_value(value);


### PR DESCRIPTION
Add independent polarity setters to complementary_pwm. Previously, set_polarity updated both main and complementary outputs together. These new functions let users modify the main or complementary output separately, supporting use cases where only one output’s polarity should change.