### PR TITLE
executor: always name main task `main`, not just with rtos-trace.

### DIFF
--- a/embassy-executor-macros/Cargo.toml
+++ b/embassy-executor-macros/Cargo.toml
@@ -23,3 +23,4 @@ proc-macro = true
 
 [features]
 nightly = []
+metadata-name = []

--- a/embassy-executor-macros/src/macros/main.rs
+++ b/embassy-executor-macros/src/macros/main.rs
@@ -170,7 +170,7 @@ For example: `#[embassy_executor::main(entry = ..., executor = \"some_crate::Exe
     let f_body = f.body;
     let out = &f.sig.output;
 
-    let name_main_task = if cfg!(feature = "rtos-trace") {
+    let name_main_task = if cfg!(feature = "metadata-name") {
         quote!(
             main_task.metadata().set_name("main\0");
         )

--- a/embassy-executor/CHANGELOG.md
+++ b/embassy-executor/CHANGELOG.md
@@ -8,8 +8,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 <!-- next-header -->
 ## Unreleased - ReleaseDate
 
-- Added new metadata API for tasks
-- Named main task when rtos-trace feature is enabled.
+- Added new metadata API for tasks.
+- Main task automatically gets a name of `main` when the `metadata-name` feature is enabled.
 - Upgraded rtos-trace
 
 ## 0.9.1 - 2025-08-31

--- a/embassy-executor/Cargo.toml
+++ b/embassy-executor/Cargo.toml
@@ -112,7 +112,7 @@ arch-spin = ["_arch"]
 #! ### Metadata
 
 ## Enable the `name` field in task metadata.
-metadata-name = []
+metadata-name = ["embassy-executor-macros/metadata-name"]
 
 #! ### Executor
 


### PR DESCRIPTION
Also fixes the warning about the `rtos-trace` feature not existing in embassy-executor-macros.
