### PR TITLE
stm32: OSPI ram support

### DIFF
--- a/embassy-stm32/CHANGELOG.md
+++ b/embassy-stm32/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - STM32: Prevent dropped DacChannel from disabling Dac peripheral if another DacChannel is still in scope ([#4577](https://github.com/embassy-rs/embassy/pull/4577))
+- feat: Added support for more OctoSPI configurations (e.g. APS6408 RAM) ([#4581](https://github.com/embassy-rs/embassy/pull/4581))
 
 ## 0.4.0 - 2025-08-26
 


### PR DESCRIPTION
Rebase of #4581

- **OSPI RAM Support**
- **Separate DQS functions**
- **Updated changelog**
- **changelog formatting**
