### PR TITLE
fix(embassy-stm32): Remove duplicate fn call, vestigial from earlier refcount implementation

### DIFF
--- a/embassy-stm32/CHANGELOG.md
+++ b/embassy-stm32/CHANGELOG.md
@@ -13,9 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - fix: stm32/i2c in master mode (blocking): subsequent transmissions failed after a NACK was received
 - feat: stm32/timer: add set_polarity functions for main and complementary outputs in complementary_pwm
 - Add I2S support for STM32F1, STM32C0, STM32F0, STM32F3, STM32F7, STM32G0, STM32WL, STM32H5, STM32H7RS
-### Fixed
-
-- STM32: Prevent dropped DacChannel from disabling Dac peripheral if another DacChannel is still in scope ([#4577](https://github.com/embassy-rs/embassy/pull/4577))
+- fix: STM32: Prevent dropped DacChannel from disabling Dac peripheral if another DacChannel is still in scope ([#4577](https://github.com/embassy-rs/embassy/pull/4577))
 - feat: Added support for more OctoSPI configurations (e.g. APS6408 RAM) ([#4581](https://github.com/embassy-rs/embassy/pull/4581))
 
 ## 0.4.0 - 2025-08-26

--- a/embassy-stm32/src/dac/mod.rs
+++ b/embassy-stm32/src/dac/mod.rs
@@ -575,8 +575,6 @@ impl<'d, T: Instance, M: PeriMode> Dac<'d, T, M> {
         dma_ch2: Option<ChannelAndRequest<'d>>,
         #[cfg(any(dac_v3, dac_v4, dac_v5, dac_v6, dac_v7))] mode: Mode,
     ) -> Self {
-        // Enable twice to increment the DAC refcount for each channel.
-        rcc::enable_and_reset::<T>();
         rcc::enable_and_reset::<T>();
 
         let mut ch1 = DacCh1 {


### PR DESCRIPTION
Refs: #4577