### PR TITLE
Improve f247 PLL output frequency calculation precision

### DIFF
--- a/embassy-stm32/CHANGELOG.md
+++ b/embassy-stm32/CHANGELOG.md
@@ -15,6 +15,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add I2S support for STM32F1, STM32C0, STM32F0, STM32F3, STM32F7, STM32G0, STM32WL, STM32H5, STM32H7RS
 - fix: STM32: Prevent dropped DacChannel from disabling Dac peripheral if another DacChannel is still in scope ([#4577](https://github.com/embassy-rs/embassy/pull/4577))
 - feat: Added support for more OctoSPI configurations (e.g. APS6408 RAM) ([#4581](https://github.com/embassy-rs/embassy/pull/4581))
+- Improve the PLL output frequency calculation precision for the F2, F4, and F7
+  series.
 
 ## 0.4.0 - 2025-08-26
 

--- a/embassy-stm32/src/time.rs
+++ b/embassy-stm32/src/time.rs
@@ -136,3 +136,47 @@ impl From<MaybeHertz> for Option<Hertz> {
         }
     }
 }
+
+#[derive(Clone, Copy, Debug, Default)]
+/// Time scaling factor (multiplier/divider), may be an unreduced fraction
+pub(crate) struct Scale {
+    pub num: u32,
+    pub denom: u32,
+}
+
+impl Mul for Scale {
+    type Output = Scale;
+    fn mul(self, rhs: Self) -> Self::Output {
+        let num = self.num * rhs.num;
+        let denom = self.denom * rhs.denom;
+        Self { num, denom }
+    }
+}
+
+impl Mul<Scale> for Hertz {
+    type Output = Hertz;
+    fn mul(self, rhs: Scale) -> Self::Output {
+        self * rhs.num / rhs.denom
+    }
+}
+
+impl Div<Scale> for Hertz {
+    type Output = Hertz;
+    fn div(self, rhs: Scale) -> Self::Output {
+        self * rhs.denom / rhs.num
+    }
+}
+
+impl Mul<Scale> for u64 {
+    type Output = u64;
+    fn mul(self, rhs: Scale) -> Self::Output {
+        self * rhs.num as u64 / rhs.denom as u64
+    }
+}
+
+impl Div<Scale> for u64 {
+    type Output = u64;
+    fn div(self, rhs: Scale) -> Self::Output {
+        self * rhs.denom as u64 / rhs.num as u64
+    }
+}


### PR DESCRIPTION
It was really bugging me, okay?

The PLL frequency calculation will now produce the correct result for all integer output frequencies and a truncated result (e.g. 1234.5 -> 1234) for all non-integer output frequencies instead of accumulating an error.

I've tested this on an STM32F411CE.

I'm pretty confident that the "truncated or correct" guarantee is right, but I was a bit paranoid so I also brute forced all configurations (including many which would be unstable) of my F411CE's RCC to check: https://paste.rs/ZaZ3k.py

This addresses #3408 .