### PR TITLE
chore: bump embassy-executor to 0.9.1 to match released version

### DIFF
--- a/embassy-executor/Cargo.toml
+++ b/embassy-executor/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "embassy-executor"
-version = "0.9.0"
+version = "0.9.1"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 description = "async/await executor designed for embedded usage"


### PR DESCRIPTION
`embassy-executor` version 0.9.1 was released last week to address a performance regression on ESP32 MCUs. See #4617 and #4619.

`embassy-executor`'s version was never bumped on `main` or `embassy-executor-v0.9.x`, which causes issues when trying to patch embassy-executor with the one on GitHub. This patch just bumps the version to match the latest release to ease this use case.