### PR TITLE
Add Wiznet W6100 driver

### DIFF
--- a/embassy-net-wiznet/CHANGELOG.md
+++ b/embassy-net-wiznet/CHANGELOG.md
@@ -8,6 +8,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 <!-- next-header -->
 ## Unreleased - ReleaseDate
 
+- Added experimental W6100 driver with disabled MAC filter (does not currently work with it enabled)
+- Introduced `SOCKET_INTR_CLR` register which is needed on W6100 and later models (on W5100/W5500 this is shared with `SOCKET_INTR` and the address is the same)
+
 ## 0.2.1 - 2025-08-26
 
 ## 0.1.1 - 2025-08-14

--- a/embassy-net-wiznet/src/chip/mod.rs
+++ b/embassy-net-wiznet/src/chip/mod.rs
@@ -4,6 +4,8 @@ pub use w5500::W5500;
 mod w5100s;
 use embedded_hal_async::spi::SpiDevice;
 pub use w5100s::W5100S;
+mod w6100;
+pub use w6100::W6100;
 
 pub(crate) trait SealedChip {
     type Address;
@@ -29,6 +31,7 @@ pub(crate) trait SealedChip {
     const SOCKET_RX_DATA_READ_PTR: Self::Address;
     const SOCKET_INTR_MASK: Self::Address;
     const SOCKET_INTR: Self::Address;
+    const SOCKET_INTR_CLR: Self::Address;
 
     const SOCKET_MODE_VALUE: u8;
 

--- a/embassy-net-wiznet/src/chip/w5100s.rs
+++ b/embassy-net-wiznet/src/chip/w5100s.rs
@@ -29,6 +29,7 @@ impl super::SealedChip for W5100S {
     const SOCKET_RX_DATA_READ_PTR: Self::Address = SOCKET_BASE + 0x28;
     const SOCKET_INTR_MASK: Self::Address = SOCKET_BASE + 0x2C;
     const SOCKET_INTR: Self::Address = SOCKET_BASE + 0x02;
+    const SOCKET_INTR_CLR: Self::Address = SOCKET_BASE + 0x02;
 
     const SOCKET_MODE_VALUE: u8 = (1 << 2) | (1 << 6);
 

--- a/embassy-net-wiznet/src/chip/w5500.rs
+++ b/embassy-net-wiznet/src/chip/w5500.rs
@@ -33,6 +33,7 @@ impl super::SealedChip for W5500 {
     const SOCKET_RX_DATA_READ_PTR: Self::Address = (RegisterBlock::Socket0, 0x28);
     const SOCKET_INTR_MASK: Self::Address = (RegisterBlock::Socket0, 0x2C);
     const SOCKET_INTR: Self::Address = (RegisterBlock::Socket0, 0x02);
+    const SOCKET_INTR_CLR: Self::Address = (RegisterBlock::Socket0, 0x02);
 
     const SOCKET_MODE_VALUE: u8 = (1 << 2) | (1 << 7);
 

--- a/embassy-net-wiznet/src/chip/w6100.rs
+++ b/embassy-net-wiznet/src/chip/w6100.rs
@@ -1,0 +1,83 @@
+use embedded_hal_async::spi::{Operation, SpiDevice};
+
+#[repr(u8)]
+pub enum RegisterBlock {
+    Common = 0x00,
+    Socket0 = 0x01,
+    TxBuf = 0x02,
+    RxBuf = 0x03,
+}
+
+/// Wiznet W6100 chip.
+pub enum W6100 {}
+
+impl super::Chip for W6100 {}
+impl super::SealedChip for W6100 {
+    type Address = (RegisterBlock, u16);
+
+    const CHIP_VERSION: u8 = 0x46;
+
+    const COMMON_MODE: Self::Address = (RegisterBlock::Common, 0x2004);
+    const COMMON_MAC: Self::Address = (RegisterBlock::Common, 0x4120);
+    // SIMR (SOCKET Interrupt Mask Register)
+    const COMMON_SOCKET_INTR: Self::Address = (RegisterBlock::Common, 0x2114);
+    const COMMON_PHY_CFG: Self::Address = (RegisterBlock::Common, 0x3000);
+    const COMMON_VERSION: Self::Address = (RegisterBlock::Common, 0x0002);
+
+    const SOCKET_MODE: Self::Address = (RegisterBlock::Socket0, 0x0000);
+    const SOCKET_COMMAND: Self::Address = (RegisterBlock::Socket0, 0x0010);
+    const SOCKET_RXBUF_SIZE: Self::Address = (RegisterBlock::Socket0, 0x0220);
+    const SOCKET_TXBUF_SIZE: Self::Address = (RegisterBlock::Socket0, 0x0200);
+    const SOCKET_TX_FREE_SIZE: Self::Address = (RegisterBlock::Socket0, 0x0204);
+    const SOCKET_TX_DATA_WRITE_PTR: Self::Address = (RegisterBlock::Socket0, 0x020C);
+    const SOCKET_RECVD_SIZE: Self::Address = (RegisterBlock::Socket0, 0x0224);
+    const SOCKET_RX_DATA_READ_PTR: Self::Address = (RegisterBlock::Socket0, 0x0228);
+    // Sn_IMR (SOCKET n Interrupt Mask Register)
+    const SOCKET_INTR_MASK: Self::Address = (RegisterBlock::Socket0, 0x0024);
+    // Sn_IR (SOCKET n Interrupt Register)
+    const SOCKET_INTR: Self::Address = (RegisterBlock::Socket0, 0x0020);
+    // Sn_IRCLR (Sn_IR Clear Register)
+    const SOCKET_INTR_CLR: Self::Address = (RegisterBlock::Socket0, 0x0028);
+
+    // MACRAW mode. See Page 57 of https://docs.wiznet.io/img/products/w6100/w6100_ds_v105e.pdf
+    // Note: Bit 7 is MAC filter. On the W5500 this is normally turned ON however the W6100 will not successfully retrieve an IP address with this enabled. Disabling for now and will have live with the extra noise.
+    const SOCKET_MODE_VALUE: u8 = 0b0000_0111;
+
+    const BUF_SIZE: u16 = 0x1000;
+    const AUTO_WRAP: bool = true;
+
+    fn rx_addr(addr: u16) -> Self::Address {
+        (RegisterBlock::RxBuf, addr)
+    }
+
+    fn tx_addr(addr: u16) -> Self::Address {
+        (RegisterBlock::TxBuf, addr)
+    }
+
+    async fn bus_read<SPI: SpiDevice>(
+        spi: &mut SPI,
+        address: Self::Address,
+        data: &mut [u8],
+    ) -> Result<(), SPI::Error> {
+        let address_phase = address.1.to_be_bytes();
+        let control_phase = [(address.0 as u8) << 3];
+        let operations = &mut [
+            Operation::Write(&address_phase),
+            Operation::Write(&control_phase),
+            Operation::TransferInPlace(data),
+        ];
+        spi.transaction(operations).await
+    }
+
+    async fn bus_write<SPI: SpiDevice>(spi: &mut SPI, address: Self::Address, data: &[u8]) -> Result<(), SPI::Error> {
+        let address_phase = address.1.to_be_bytes();
+        let control_phase = [(address.0 as u8) << 3 | 0b0000_0100];
+        let data_phase = data;
+        let operations = &mut [
+            Operation::Write(&address_phase[..]),
+            Operation::Write(&control_phase),
+            Operation::Write(&data_phase),
+        ];
+        spi.transaction(operations).await
+    }
+}

--- a/embassy-net-wiznet/src/device.rs
+++ b/embassy-net-wiznet/src/device.rs
@@ -125,7 +125,7 @@ impl<C: Chip, SPI: SpiDevice> WiznetDevice<C, SPI> {
 
     async fn reset_interrupt(&mut self, code: Interrupt) -> Result<(), SPI::Error> {
         let data = [code as u8];
-        self.bus_write(C::SOCKET_INTR, &data).await
+        self.bus_write(C::SOCKET_INTR_CLR, &data).await
     }
 
     async fn get_tx_write_ptr(&mut self) -> Result<u16, SPI::Error> {


### PR DESCRIPTION
Tested with this device:
https://docs.wiznet.io/Product/iEthernet/W6100/w6100-evb-pico2

I've introduced a new register `SOCKET_INTR_CLR` as the W6100 (and presumably later devices) use a _different_ register to clear the socket interrupt. See `Sn_IRCLR` on page 61:
https://docs.wiznet.io/img/products/w6100/w6100_ds_v105e.pdf

On previous driver implementations (W5100/W5500) this register address is simply a duplicate of `SOCKET_INTR`.

Weirdly the MAC filter does not operate like the W5500 as having it turned on will stop DHCP working. I've left the MAC filter disabled but this does not affect the operation of this device (although it will cause more noise on the SPI bus).

For this reason I would still consider this driver experimental however I would like to start the conversation of getting this upstreamed.