### PR TITLE
Unify derivation of Clone, Copy and defmt::format for all *SPI configs

### DIFF
--- a/embassy-stm32/CHANGELOG.md
+++ b/embassy-stm32/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - fix: stm32/usart: fix bug with blocking flush in buffered uart ([#4648](https://github.com/embassy-rs/embassy/pull/4648))
 - fix: stm32/(ospi/hspi/xspi): Fix the alternate bytes register config sticking around for subsequent writes
 - feat: Configurable gpio speed for QSPI
+- feat: derive Clone, Copy and defmt::Format for all *SPI-related configs
 
 ## 0.4.0 - 2025-08-26
 

--- a/embassy-stm32/src/hspi/mod.rs
+++ b/embassy-stm32/src/hspi/mod.rs
@@ -86,6 +86,8 @@ impl Default for Config {
 }
 
 /// HSPI transfer configuration.
+#[derive(Clone, Copy)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub struct TransferConfig {
     /// Instruction width (IMODE)
     pub iwidth: HspiWidth,

--- a/embassy-stm32/src/ospi/enums.rs
+++ b/embassy-stm32/src/ospi/enums.rs
@@ -23,6 +23,7 @@ impl Into<u8> for OspiMode {
 /// Ospi lane width
 #[allow(dead_code)]
 #[derive(Copy, Clone)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub enum OspiWidth {
     /// None
     NONE,
@@ -71,6 +72,7 @@ impl Into<bool> for FlashSelection {
 #[allow(dead_code)]
 #[allow(missing_docs)]
 #[derive(Copy, Clone)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub enum WrapSize {
     None,
     _16Bytes,
@@ -95,6 +97,7 @@ impl Into<u8> for WrapSize {
 #[allow(missing_docs)]
 #[allow(dead_code)]
 #[derive(Copy, Clone)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub enum MemoryType {
     Micron,
     Macronix,
@@ -120,6 +123,7 @@ impl Into<u8> for MemoryType {
 /// Ospi memory size.
 #[allow(missing_docs)]
 #[derive(Copy, Clone)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub enum MemorySize {
     _1KiB,
     _2KiB,
@@ -180,6 +184,7 @@ impl Into<u8> for MemorySize {
 
 /// Ospi Address size
 #[derive(Copy, Clone)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub enum AddressSize {
     /// 8-bit address
     _8Bit,
@@ -205,6 +210,7 @@ impl Into<u8> for AddressSize {
 /// Time the Chip Select line stays high.
 #[allow(missing_docs)]
 #[derive(Copy, Clone)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub enum ChipSelectHighTime {
     _1Cycle,
     _2Cycle,
@@ -234,6 +240,7 @@ impl Into<u8> for ChipSelectHighTime {
 /// FIFO threshold.
 #[allow(missing_docs)]
 #[derive(Copy, Clone)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub enum FIFOThresholdLevel {
     _1Bytes,
     _2Bytes,
@@ -311,6 +318,7 @@ impl Into<u8> for FIFOThresholdLevel {
 /// Dummy cycle count
 #[allow(missing_docs)]
 #[derive(Copy, Clone)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub enum DummyCycles {
     _0,
     _1,

--- a/embassy-stm32/src/ospi/mod.rs
+++ b/embassy-stm32/src/ospi/mod.rs
@@ -23,6 +23,7 @@ use crate::{peripherals, Peri};
 
 /// OPSI driver config.
 #[derive(Clone, Copy)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub struct Config {
     /// Fifo threshold used by the peripheral to generate the interrupt indicating data
     /// or space is available in the FIFO
@@ -83,6 +84,8 @@ impl Default for Config {
 }
 
 /// OSPI transfer configuration.
+#[derive(Clone, Copy)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub struct TransferConfig {
     /// Instruction width (IMODE)
     pub iwidth: OspiWidth,

--- a/embassy-stm32/src/qspi/enums.rs
+++ b/embassy-stm32/src/qspi/enums.rs
@@ -23,6 +23,7 @@ impl From<QspiMode> for u8 {
 /// QSPI lane width
 #[allow(dead_code)]
 #[derive(Copy, Clone)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub enum QspiWidth {
     /// None
     NONE,
@@ -67,6 +68,7 @@ impl From<FlashSelection> for bool {
 /// QSPI memory size.
 #[allow(missing_docs)]
 #[derive(Copy, Clone)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub enum MemorySize {
     _1KiB,
     _2KiB,
@@ -127,6 +129,7 @@ impl From<MemorySize> for u8 {
 
 /// QSPI Address size
 #[derive(Copy, Clone)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub enum AddressSize {
     /// 8-bit address
     _8Bit,
@@ -152,6 +155,7 @@ impl From<AddressSize> for u8 {
 /// Time the Chip Select line stays high.
 #[allow(missing_docs)]
 #[derive(Copy, Clone)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub enum ChipSelectHighTime {
     _1Cycle,
     _2Cycle,
@@ -181,6 +185,7 @@ impl From<ChipSelectHighTime> for u8 {
 /// FIFO threshold.
 #[allow(missing_docs)]
 #[derive(Copy, Clone)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub enum FIFOThresholdLevel {
     _1Bytes,
     _2Bytes,
@@ -258,6 +263,7 @@ impl From<FIFOThresholdLevel> for u8 {
 /// Dummy cycle count
 #[allow(missing_docs)]
 #[derive(Copy, Clone)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub enum DummyCycles {
     _0,
     _1,
@@ -334,6 +340,7 @@ impl From<DummyCycles> for u8 {
 
 #[allow(missing_docs)]
 #[derive(Copy, Clone)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub enum SampleShifting {
     None,
     HalfCycle,

--- a/embassy-stm32/src/qspi/mod.rs
+++ b/embassy-stm32/src/qspi/mod.rs
@@ -18,6 +18,7 @@ use crate::{peripherals, Peri};
 
 /// QSPI transfer configuration.
 #[derive(Clone, Copy)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub struct TransferConfig {
     /// Instruction width (IMODE)
     pub iwidth: QspiWidth,
@@ -48,6 +49,7 @@ impl Default for TransferConfig {
 
 /// QSPI driver configuration.
 #[derive(Clone, Copy)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 #[non_exhaustive]
 pub struct Config {
     /// Flash memory size representend as 2^[0-32], as reasonable minimum 1KiB(9) was chosen.

--- a/embassy-stm32/src/xspi/enums.rs
+++ b/embassy-stm32/src/xspi/enums.rs
@@ -22,6 +22,7 @@ impl Into<u8> for XspiMode {
 
 /// Xspi lane width
 #[derive(Copy, Clone)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub enum XspiWidth {
     /// None
     NONE,
@@ -50,6 +51,7 @@ impl Into<u8> for XspiWidth {
 /// Wrap Size
 #[allow(missing_docs)]
 #[derive(Copy, Clone)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub enum WrapSize {
     None,
     _16Bytes,
@@ -73,6 +75,7 @@ impl Into<u8> for WrapSize {
 /// Memory Type
 #[allow(missing_docs)]
 #[derive(Copy, Clone)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub enum MemoryType {
     Micron,
     Macronix,
@@ -98,6 +101,7 @@ impl Into<u8> for MemoryType {
 /// Xspi memory size.
 #[allow(missing_docs)]
 #[derive(Copy, Clone)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub enum MemorySize {
     _1KiB,
     _2KiB,
@@ -158,6 +162,7 @@ impl Into<u8> for MemorySize {
 
 /// Xspi Address size
 #[derive(Copy, Clone)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub enum AddressSize {
     /// 8-bit address
     _8bit,
@@ -183,6 +188,7 @@ impl Into<u8> for AddressSize {
 /// Time the Chip Select line stays high.
 #[allow(missing_docs)]
 #[derive(Copy, Clone)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub enum ChipSelectHighTime {
     _1Cycle,
     _2Cycle,
@@ -212,6 +218,7 @@ impl Into<u8> for ChipSelectHighTime {
 /// FIFO threshold.
 #[allow(missing_docs)]
 #[derive(Copy, Clone)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub enum FIFOThresholdLevel {
     _1Bytes,
     _2Bytes,
@@ -289,6 +296,7 @@ impl Into<u8> for FIFOThresholdLevel {
 /// Dummy cycle count
 #[allow(missing_docs)]
 #[derive(Copy, Clone)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub enum DummyCycles {
     _0,
     _1,

--- a/embassy-stm32/src/xspi/mod.rs
+++ b/embassy-stm32/src/xspi/mod.rs
@@ -23,6 +23,7 @@ use crate::{peripherals, Peri};
 
 /// XPSI driver config.
 #[derive(Clone, Copy)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub struct Config {
     /// Fifo threshold used by the peripheral to generate the interrupt indicating data
     /// or space is available in the FIFO
@@ -80,6 +81,8 @@ impl Default for Config {
 }
 
 /// XSPI transfer configuration.
+#[derive(Clone, Copy)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub struct TransferConfig {
     /// Instruction width (IMODE)
     pub iwidth: XspiWidth,


### PR DESCRIPTION
Hi!

I'm in the middle of improving the error handling in OSPI and noticed this detail that makes the API tiny bit more cumbersome than it needs to be.

One can't use the same config for more than one transfer because read/write methods take it by ownership and `TransferConfig` doesn't implement `Clone` neither `Copy`.

This PR unifies what we derive for all config structs in all SPI implementations in `embassy-stm32` to `Clone`, `Copy` and `defmt::format` if the `defmt` feature is enabled.

It'd be best if could also change the read/write methods to merely borrow `TransferConfig`. None of them really need the ownership so it's just a question of changing the function signatures. However that would be a breaking change. Let me know if that's a desirable change and I'll be happy to submit a PR.
