### PR TITLE
STM32: USART: Add `eager_reads` config option

### DIFF
--- a/embassy-hal-internal/src/atomic_ring_buffer.rs
+++ b/embassy-hal-internal/src/atomic_ring_buffer.rs
@@ -133,6 +133,18 @@ impl RingBuffer {
         self.len.load(Ordering::Relaxed)
     }
 
+    /// Return number of items available to read.
+    pub fn available(&self) -> usize {
+        let end = self.end.load(Ordering::Relaxed);
+        let len = self.len.load(Ordering::Relaxed);
+        let start = self.start.load(Ordering::Relaxed);
+        if end >= start {
+            end - start
+        } else {
+            2 * len - start + end
+        }
+    }
+
     /// Check if buffer is full.
     pub fn is_full(&self) -> bool {
         let len = self.len.load(Ordering::Relaxed);
@@ -144,15 +156,7 @@ impl RingBuffer {
 
     /// Check if buffer is at least half full.
     pub fn is_half_full(&self) -> bool {
-        let len = self.len.load(Ordering::Relaxed);
-        let start = self.start.load(Ordering::Relaxed);
-        let end = self.end.load(Ordering::Relaxed);
-        let n = if end >= start {
-            end - start
-        } else {
-            2 * len - start + end
-        };
-        n >= len / 2
+        self.available() >= self.len.load(Ordering::Relaxed) / 2
     }
 
     /// Check if buffer is empty.

--- a/embassy-stm32/CHANGELOG.md
+++ b/embassy-stm32/CHANGELOG.md
@@ -27,7 +27,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - fix: Cut down the capabilities of the STM32L412 and L422 RTC as those are missing binary timer mode and underflow interrupt.
 - fix: Allow configuration of the internal pull up/down resistors on the pins for the Qei peripheral, as well as the Qei decoder mode.
 - feat: stm32/rcc/mco: Added support for IO driver strength when using Master Clock Out IO. This changes signature on Mco::new taking a McoConfig struct ([#4679](https://github.com/embassy-rs/embassy/pull/4679))
+- feat: derive Clone, Copy and defmt::Format for all SPI-related configs
 - feat: stm32/usart: add `eager_reads` option to control if buffered readers return as soon as possible or after more data is available ([#4668](https://github.com/embassy-rs/embassy/pull/4668))
+- feat: stm32/usart: add `de_assertion_time` and `de_deassertion_time` config options
+- change: stm32/uart: BufferedUartRx now returns all available bytes from the internal buffer
 
 ## 0.4.0 - 2025-08-26
 

--- a/embassy-stm32/CHANGELOG.md
+++ b/embassy-stm32/CHANGELOG.md
@@ -27,6 +27,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - fix: Cut down the capabilities of the STM32L412 and L422 RTC as those are missing binary timer mode and underflow interrupt.
 - fix: Allow configuration of the internal pull up/down resistors on the pins for the Qei peripheral, as well as the Qei decoder mode.
 - feat: stm32/rcc/mco: Added support for IO driver strength when using Master Clock Out IO. This changes signature on Mco::new taking a McoConfig struct ([#4679](https://github.com/embassy-rs/embassy/pull/4679))
+- feat: stm32/usart: add `eager_reads` option to control if buffered readers return as soon as possible or after more data is available ([#4668](https://github.com/embassy-rs/embassy/pull/4668))
 
 ## 0.4.0 - 2025-08-26
 

--- a/embassy-stm32/src/usart/buffered.rs
+++ b/embassy-stm32/src/usart/buffered.rs
@@ -1,7 +1,7 @@
 use core::future::poll_fn;
 use core::marker::PhantomData;
 use core::slice;
-use core::sync::atomic::{AtomicBool, AtomicU8, Ordering};
+use core::sync::atomic::{AtomicBool, AtomicU8, AtomicUsize, Ordering};
 use core::task::Poll;
 
 use embassy_embedded_hal::SetConfig;
@@ -68,8 +68,9 @@ unsafe fn on_interrupt(r: Regs, state: &'static State) {
             // FIXME: Should we disable any further RX interrupts when the buffer becomes full.
         }
 
-        if state.eager_reads.load(Ordering::Relaxed) {
-            if !state.rx_buf.is_empty() {
+        let eager = state.eager_reads.load(Ordering::Relaxed);
+        if eager > 0 {
+            if state.rx_buf.available() >= eager {
                 state.rx_waker.wake();
             }
         } else {
@@ -138,7 +139,7 @@ pub(super) struct State {
     tx_done: AtomicBool,
     tx_rx_refcount: AtomicU8,
     half_duplex_readback: AtomicBool,
-    eager_reads: AtomicBool,
+    eager_reads: AtomicUsize,
 }
 
 impl State {
@@ -151,7 +152,7 @@ impl State {
             tx_done: AtomicBool::new(true),
             tx_rx_refcount: AtomicU8::new(0),
             half_duplex_readback: AtomicBool::new(false),
-            eager_reads: AtomicBool::new(false),
+            eager_reads: AtomicUsize::new(0),
         }
     }
 }
@@ -427,7 +428,9 @@ impl<'d> BufferedUart<'d> {
         let state = T::buffered_state();
         let kernel_clock = T::frequency();
 
-        state.eager_reads.store(config.eager_reads, Ordering::Relaxed);
+        state
+            .eager_reads
+            .store(config.eager_reads.unwrap_or(0), Ordering::Relaxed);
         state.half_duplex_readback.store(
             config.duplex == Duplex::Half(HalfDuplexReadback::Readback),
             Ordering::Relaxed,
@@ -465,7 +468,9 @@ impl<'d> BufferedUart<'d> {
         let info = self.rx.info;
         let state = self.rx.state;
         state.tx_rx_refcount.store(2, Ordering::Relaxed);
-        state.eager_reads.store(config.eager_reads, Ordering::Relaxed);
+        state
+            .eager_reads
+            .store(config.eager_reads.unwrap_or(0), Ordering::Relaxed);
 
         info.rcc.enable_and_reset();
 
@@ -537,7 +542,10 @@ impl<'d> BufferedUart<'d> {
     pub fn set_config(&mut self, config: &Config) -> Result<(), ConfigError> {
         reconfigure(self.rx.info, self.rx.kernel_clock, config)?;
 
-        self.rx.state.eager_reads.store(config.eager_reads, Ordering::Relaxed);
+        self.rx
+            .state
+            .eager_reads
+            .store(config.eager_reads.unwrap_or(0), Ordering::Relaxed);
 
         self.rx.info.regs.cr1().modify(|w| {
             w.set_rxneie(true);
@@ -654,7 +662,9 @@ impl<'d> BufferedUartRx<'d> {
     pub fn set_config(&mut self, config: &Config) -> Result<(), ConfigError> {
         reconfigure(self.info, self.kernel_clock, config)?;
 
-        self.state.eager_reads.store(config.eager_reads, Ordering::Relaxed);
+        self.state
+            .eager_reads
+            .store(config.eager_reads.unwrap_or(0), Ordering::Relaxed);
 
         self.info.regs.cr1().modify(|w| {
             w.set_rxneie(true);

--- a/embassy-stm32/src/usart/ringbuffered.rs
+++ b/embassy-stm32/src/usart/ringbuffered.rs
@@ -26,9 +26,9 @@ use crate::Peri;
 /// contain enough bytes to fill the buffer passed by the caller of
 /// the function, or is empty.
 ///
-/// Waiting for bytes operates in one of two modes, depending on
-/// the behavior of the sender and the size of the buffer passed
-/// to the function:
+/// Waiting for bytes operates in one of three modes, depending on
+/// the behavior of the sender, the size of the buffer passed
+/// to the function, and the configuration:
 ///
 /// - If the sender sends intermittently, the 'idle line'
 /// condition will be detected when the sender stops, and any
@@ -47,7 +47,11 @@ use crate::Peri;
 /// interrupt when those specific buffer addresses have been
 /// written.
 ///
-/// In both cases this will result in variable latency due to the
+/// - If `eager_reads` is enabled in `config`, the UART interrupt
+/// is enabled on all data reception and the call will only wait
+/// for at least one byte to be available before returning.
+///
+/// In the first two cases this will result in variable latency due to the
 /// buffering effect. For example, if the baudrate is 2400 bps, and
 /// the configuration is 8 data bits, no parity bit, and one stop bit,
 /// then a byte will be received every ~4.16ms. If the ring buffer is
@@ -68,15 +72,10 @@ use crate::Peri;
 /// sending, but would be falsely triggered in the worst-case
 /// buffer delay scenario.
 ///
-/// Note: This latency is caused by the limited capabilities of the
-/// STM32 DMA controller; since it cannot generate an interrupt when
-/// it stores a byte into an empty ring buffer, or in any other
-/// configurable conditions, it is not possible to take notice of the
-/// contents of the ring buffer more quickly without introducing
-/// polling. As a result the latency can be reduced by calling the
-/// read functions repeatedly with smaller buffers to receive the
-/// available bytes, as each call to a read function will explicitly
-/// check the ring buffer for available bytes.
+/// Note: Enabling `eager_reads` with `RingBufferedUartRx` will enable
+/// an UART RXNE interrupt, which will cause an interrupt to occur on
+/// every received data byte. The data is still copied using DMA, but
+/// there is nevertheless additional processing overhead for each byte.
 pub struct RingBufferedUartRx<'d> {
     info: &'static Info,
     state: &'static State,
@@ -133,6 +132,7 @@ impl<'d> UartRx<'d, Async> {
 impl<'d> RingBufferedUartRx<'d> {
     /// Reconfigure the driver
     pub fn set_config(&mut self, config: &Config) -> Result<(), ConfigError> {
+        self.state.eager_reads.store(config.eager_reads, Ordering::Relaxed);
         reconfigure(self.info, self.kernel_clock, config)
     }
 
@@ -148,8 +148,8 @@ impl<'d> RingBufferedUartRx<'d> {
         let r = self.info.regs;
         // clear all interrupts and DMA Rx Request
         r.cr1().modify(|w| {
-            // disable RXNE interrupt
-            w.set_rxneie(false);
+            // use RXNE only when returning reads early
+            w.set_rxneie(self.state.eager_reads.load(Ordering::Relaxed));
             // enable parity interrupt if not ParityNone
             w.set_peie(w.pce());
             // enable idle line interrupt
@@ -248,39 +248,55 @@ impl<'d> RingBufferedUartRx<'d> {
     async fn wait_for_data_or_idle(&mut self) -> Result<(), Error> {
         compiler_fence(Ordering::SeqCst);
 
-        // Future which completes when idle line is detected
-        let s = self.state;
-        let uart = poll_fn(|cx| {
-            s.rx_waker.register(cx.waker());
+        loop {
+            // Future which completes when idle line is detected
+            let s = self.state;
+            let mut uart_init = false;
+            let uart = poll_fn(|cx| {
+                s.rx_waker.register(cx.waker());
 
-            compiler_fence(Ordering::SeqCst);
+                compiler_fence(Ordering::SeqCst);
 
-            if check_idle_and_errors(self.info.regs)? {
-                // Idle line is detected
-                Poll::Ready(Ok(()))
-            } else {
-                Poll::Pending
+                // We may have been woken by IDLE or, if eager_reads is set, by RXNE.
+                // However, DMA will clear RXNE, so we can't check directly, and because
+                // the other future borrows `ring_buf`, we can't check `len()` here either.
+                // Instead, return from this future and we'll check the length afterwards.
+                let eager = s.eager_reads.load(Ordering::Relaxed);
+
+                if check_idle_and_errors(self.info.regs)? || (eager && uart_init) {
+                    // Idle line is detected, or eager reads is set and some data is available.
+                    Poll::Ready(Ok(()))
+                } else {
+                    uart_init = true;
+                    Poll::Pending
+                }
+            });
+
+            let mut dma_init = false;
+            // Future which completes when the DMA controller indicates it
+            // has written to the ring buffer's middle byte, or last byte
+            let dma = poll_fn(|cx| {
+                self.ring_buf.set_waker(cx.waker());
+
+                let status = match dma_init {
+                    false => Poll::Pending,
+                    true => Poll::Ready(()),
+                };
+
+                dma_init = true;
+                status
+            });
+
+            match select(uart, dma).await {
+                Either::Left((result, _)) => {
+                    if self.ring_buf.len().unwrap_or(0) > 0 || result.is_err() {
+                        return result;
+                    } else {
+                        continue;
+                    }
+                }
+                Either::Right(((), _)) => return Ok(()),
             }
-        });
-
-        let mut dma_init = false;
-        // Future which completes when the DMA controller indicates it
-        // has written to the ring buffer's middle byte, or last byte
-        let dma = poll_fn(|cx| {
-            self.ring_buf.set_waker(cx.waker());
-
-            let status = match dma_init {
-                false => Poll::Pending,
-                true => Poll::Ready(()),
-            };
-
-            dma_init = true;
-            status
-        });
-
-        match select(uart, dma).await {
-            Either::Left((result, _)) => result,
-            Either::Right(((), _)) => Ok(()),
         }
     }
 


### PR DESCRIPTION
Add a new option to control the behaviour of `BufferedUartRx` and `RingBufferedUartRx`.

Currently, `BufferedUartRx` returns as soon as _any_ data is available in the buffer, even just a single byte, while `RingBufferedUartRx` returns either when line idle is detected or when the DMA internal buffer half-full or full position is written over.

In my case it's useful to have `BufferedUartRx` wait for more data so I can process larger packets (and typically complete packets due to the line idle), but in other cases it's useful for `RingBufferedUartRx` to return eagerly to reduce latency. This change allows choosing either behaviour and makes the two types consistent.

For `BufferedUartRx` the modification is fairly straightforward; `RingBuffer` gains `is_half_full()`, the interrupt handler wakes the waker if either "eager and buffer not empty" or "not eager and buffer half full" or "line idle". The RXNE interrupt is always enabled anyway.

For `RingBufferedUartRx` it's a bit trickier. We didn't use RXNE at all previously so it's now conditionally enabled when eager is set. The interrupt handler can't observe the RXNE bit since the DMA has already cleared it, so it always wakes the waker. The waker previously checked if IDLE was set and returned `NotReady` otherwise but now we'd like it to check if the DMA buffer has received any data (indicating the interrupt was due to a received word). However, the second future is waiting for DMA half/full completion, so holds a borrow on the DMA buffer. Instead, we always return `Ready` from the UART future whenever the interrupt fires and `eager` is configured, and then afterwards check if the DMA buffer contains any data and recreate the futures if not.

Currently this isn't tested but I think it's feature-complete, I plan to do some testing in the next couple of days.

CC @kpfleming @DrTobe 