### PR TITLE
embasy-stm32: Allow large OSPI DMA writes with chunking

### DIFF
--- a/embassy-stm32/CHANGELOG.md
+++ b/embassy-stm32/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - feat: Configurable gpio speed for QSPI
 - feat: derive Clone, Copy and defmt::Format for all *SPI-related configs
 - fix: handle address and data-length errors in OSPI
+- feat: Allow OSPI DMA writes larger than 64kB using chunking
 
 ## 0.4.0 - 2025-08-26
 

--- a/embassy-stm32/src/ospi/mod.rs
+++ b/embassy-stm32/src/ospi/mod.rs
@@ -1198,16 +1198,19 @@ impl<'d, T: Instance> Ospi<'d, T, Async> {
             .cr()
             .modify(|v| v.set_fmode(vals::FunctionalMode::INDIRECT_WRITE));
 
-        let transfer = unsafe {
-            self.dma
-                .as_mut()
-                .unwrap()
-                .write(buf, T::REGS.dr().as_ptr() as *mut W, Default::default())
-        };
+        // TODO: implement this using a LinkedList DMA to offload the whole transfer off the CPU.
+        for chunk in buf.chunks(0xFFFF) {
+            let transfer = unsafe {
+                self.dma
+                    .as_mut()
+                    .unwrap()
+                    .write(chunk, T::REGS.dr().as_ptr() as *mut W, Default::default())
+            };
 
-        T::REGS.cr().modify(|w| w.set_dmaen(true));
+            T::REGS.cr().modify(|w| w.set_dmaen(true));
 
-        transfer.blocking_wait();
+            transfer.blocking_wait();
+        }
 
         finish_dma(T::REGS);
 
@@ -1268,16 +1271,19 @@ impl<'d, T: Instance> Ospi<'d, T, Async> {
             .cr()
             .modify(|v| v.set_fmode(vals::FunctionalMode::INDIRECT_WRITE));
 
-        let transfer = unsafe {
-            self.dma
-                .as_mut()
-                .unwrap()
-                .write(buf, T::REGS.dr().as_ptr() as *mut W, Default::default())
-        };
+        // TODO: implement this using a LinkedList DMA to offload the whole transfer off the CPU.
+        for chunk in buf.chunks(0xFFFF) {
+            let transfer = unsafe {
+                self.dma
+                    .as_mut()
+                    .unwrap()
+                    .write(chunk, T::REGS.dr().as_ptr() as *mut W, Default::default())
+            };
 
-        T::REGS.cr().modify(|w| w.set_dmaen(true));
+            T::REGS.cr().modify(|w| w.set_dmaen(true));
 
-        transfer.await;
+            transfer.await;
+        }
 
         finish_dma(T::REGS);
 


### PR DESCRIPTION
Currently, trying to write a buffer longer than `0xFFFF` panics here:

https://github.com/embassy-rs/embassy/blob/ec117e3b08e329c0d713dcd493822fbb547eb5aa/embassy-stm32/src/dma/gpdma/mod.rs#L612

Support writing longer buffers in OSPI by chunking them and dispatching multiple DMA transfers.

This requires slight participation from the CPU on every 64kB boundary. A more performant approach would be setting up a LinkedList DMA, but that's a bigger change. We may try to do that in a separate PR later.

We have successfully tested this on STM32U5AZJ.

cc @bschwind 