### PR TITLE
docs(cyw43): clarify Control::join() docs

### DIFF
--- a/cyw43/CHANGELOG.md
+++ b/cyw43/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 <!-- next-header -->
 ## Unreleased - ReleaseDate
 
+- Updated documentation for Control::join() #4678
+
 ## 0.5.0 - 2025-08-28
 
 - bump bt-hci to 0.4.0

--- a/cyw43/src/control.rs
+++ b/cyw43/src/control.rs
@@ -295,7 +295,7 @@ impl<'a> Control<'a> {
         self.ioctl_set_u32(Ioctl::SetPm, 0, mode_num).await;
     }
 
-    /// Join an unprotected network with the provided ssid.
+    /// Join a network with the provided SSID using the specified options.
     pub async fn join(&mut self, ssid: &str, options: JoinOptions<'_>) -> Result<(), Error> {
         self.set_iovar_u32("ampdu_ba_wsize", 8).await;
 


### PR DESCRIPTION
Update doc comment to clarify that Control::join() can be used to join
networks using the provided options, not only open networks.
