### PR TITLE
Adding IO drive strength constructor to Mco.

### DIFF
--- a/embassy-stm32/CHANGELOG.md
+++ b/embassy-stm32/CHANGELOG.md
@@ -23,6 +23,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - feat: Allow OSPI DMA writes larger than 64kB using chunking
 - feat: More ADC enums for g0 PAC, API change for oversampling, allow separate sample times
 - feat: Add USB CRS sync support for STM32C071
+- feat: stm32/rcc/mco: Added support for IO driver strength when using Master Clock Out IO. This changes signature on Mco::new taking a McoConfig struct ([#4679](https://github.com/embassy-rs/embassy/pull/4679))
 
 ## 0.4.0 - 2025-08-26
 

--- a/embassy-stm32/src/rcc/mco.rs
+++ b/embassy-stm32/src/rcc/mco.rs
@@ -91,16 +91,28 @@ pub struct Mco<'d, T: McoInstance> {
 
 impl<'d, T: McoInstance> Mco<'d, T> {
     /// Create a new MCO instance.
-    pub fn new(peri: Peri<'d, T>, pin: Peri<'d, impl McoPin<T>>, source: T::Source, prescaler: McoPrescaler) -> Self {
-        Self::new_with_speed(peri, pin, Speed::VeryHigh, source, prescaler)
-    }
-
-    pub fn new_with_speed(_peri: Peri<'d, T>, pin: Peri<'d, impl McoPin<T>>, speed: Speed, source: T::Source, prescaler: McoPrescaler) -> Self {
+    pub fn new(_peri: Peri<'d, T>, pin: Peri<'d, impl McoPin<T>>, source: T::Source, config: McoConfig) -> Self {
         critical_section::with(|_| unsafe {
-            T::_apply_clock_settings(source, prescaler);
-            set_as_af!(pin, AfType::output(OutputType::PushPull, speed));
+            T::_apply_clock_settings(source, config.prescaler);
+            set_as_af!(pin, AfType::output(OutputType::PushPull, config.speed));
         });
 
         Self { phantom: PhantomData }
+    }
+}
+
+pub struct McoConfig {
+    /// Master Clock Out prescaler
+    pub prescaler: McoPrescaler,
+    /// IO Drive Strength
+    pub speed: Speed,
+}
+
+impl Default for McoConfig {
+    fn default() -> Self {
+        Self {
+            prescaler: McoPrescaler::DIV1,
+            speed: Speed::VeryHigh,
+        }
     }
 }

--- a/embassy-stm32/src/rcc/mco.rs
+++ b/embassy-stm32/src/rcc/mco.rs
@@ -101,6 +101,7 @@ impl<'d, T: McoInstance> Mco<'d, T> {
     }
 }
 
+#[non_exhaustive]
 pub struct McoConfig {
     /// Master Clock Out prescaler
     pub prescaler: McoPrescaler,

--- a/embassy-stm32/src/rcc/mco.rs
+++ b/embassy-stm32/src/rcc/mco.rs
@@ -91,10 +91,14 @@ pub struct Mco<'d, T: McoInstance> {
 
 impl<'d, T: McoInstance> Mco<'d, T> {
     /// Create a new MCO instance.
-    pub fn new(_peri: Peri<'d, T>, pin: Peri<'d, impl McoPin<T>>, source: T::Source, prescaler: McoPrescaler) -> Self {
+    pub fn new(peri: Peri<'d, T>, pin: Peri<'d, impl McoPin<T>>, source: T::Source, prescaler: McoPrescaler) -> Self {
+        Self::new_with_speed(peri, pin, Speed::VeryHigh, source, prescaler)
+    }
+
+    pub fn new_with_speed(_peri: Peri<'d, T>, pin: Peri<'d, impl McoPin<T>>, speed: Speed, source: T::Source, prescaler: McoPrescaler) -> Self {
         critical_section::with(|_| unsafe {
             T::_apply_clock_settings(source, prescaler);
-            set_as_af!(pin, AfType::output(OutputType::PushPull, Speed::VeryHigh));
+            set_as_af!(pin, AfType::output(OutputType::PushPull, speed));
         });
 
         Self { phantom: PhantomData }

--- a/examples/stm32f4/src/bin/mco.rs
+++ b/examples/stm32f4/src/bin/mco.rs
@@ -4,7 +4,7 @@
 use defmt::*;
 use embassy_executor::Spawner;
 use embassy_stm32::gpio::{Level, Output, Speed};
-use embassy_stm32::rcc::{Mco, Mco1Source, Mco2Source, McoPrescaler};
+use embassy_stm32::rcc::{Mco, Mco1Source, Mco2Source, McoConfig, McoPrescaler};
 use embassy_time::Timer;
 use {defmt_rtt as _, panic_probe as _};
 
@@ -13,8 +13,20 @@ async fn main(_spawner: Spawner) {
     let p = embassy_stm32::init(Default::default());
     info!("Hello World!");
 
-    let _mco1 = Mco::new(p.MCO1, p.PA8, Mco1Source::HSI, McoPrescaler::DIV1);
-    let _mco2 = Mco::new(p.MCO2, p.PC9, Mco2Source::PLL, McoPrescaler::DIV4);
+    let config_mco1 = {
+        let mut config = McoConfig::default();
+        config.prescaler = McoPrescaler::DIV1;
+        config
+    };
+
+    let config_mco2 = {
+        let mut config = McoConfig::default();
+        config.prescaler = McoPrescaler::DIV4;
+        config
+    };
+
+    let _mco1 = Mco::new(p.MCO1, p.PA8, Mco1Source::HSI, config_mco1);
+    let _mco2 = Mco::new(p.MCO2, p.PC9, Mco2Source::PLL, config_mco2);
     let mut led = Output::new(p.PB7, Level::High, Speed::Low);
 
     loop {

--- a/examples/stm32h5/src/bin/mco.rs
+++ b/examples/stm32h5/src/bin/mco.rs
@@ -1,0 +1,23 @@
+#![no_std]
+#![no_main]
+
+use defmt::*;
+use embassy_executor::Spawner;
+use embassy_stm32::gpio::{ Speed };
+use embassy_stm32::rcc::{ Mco2Source, Mco, McoPrescaler };
+use {defmt_rtt as _, panic_probe as _};
+
+#[embassy_executor::main]
+async fn main(_spawner: Spawner) {
+    let p = embassy_stm32::init(Default::default());
+    
+    /* Default "VeryHigh" drive strength */
+    // let _mco = Mco::new(p.MCO2, p.PC9, Mco2Source::SYS, McoPrescaler::DIV2);
+
+    /* Configurable Drive Strength */
+    let _mco = Mco::new_with_speed(p.MCO2, p.PC9, Speed::Low, Mco2Source::SYS, McoPrescaler::DIV2);
+
+    info!("Clock out with low drive strength set on Master Clock Out 2 pin as AF on PC9");
+
+    loop { }
+}

--- a/examples/stm32h5/src/bin/mco.rs
+++ b/examples/stm32h5/src/bin/mco.rs
@@ -21,12 +21,7 @@ async fn main(_spawner: Spawner) {
         config
     };
 
-    let _mco = Mco::new(
-        p.MCO2,
-        p.PC9,
-        Mco2Source::SYS,
-        config
-    );
+    let _mco = Mco::new(p.MCO2, p.PC9, Mco2Source::SYS, config);
 
     info!("Clock out with low drive strength set on Master Clock Out 2 pin as AF on PC9");
 

--- a/examples/stm32h5/src/bin/mco.rs
+++ b/examples/stm32h5/src/bin/mco.rs
@@ -15,7 +15,18 @@ async fn main(_spawner: Spawner) {
     // let _mco = Mco::new(p.MCO2, p.PC9, Mco2Source::SYS, McoConfig::default());
 
     /* Choose Speed::Low drive strength */
-    let _mco = Mco::new(p.MCO2, p.PC9, Mco2Source::SYS, McoConfig { speed: Speed::Low, ..Default::default() });
+    let config = {
+        let mut config = McoConfig::default();
+        config.speed = Speed::Low;
+        config
+    };
+
+    let _mco = Mco::new(
+        p.MCO2,
+        p.PC9,
+        Mco2Source::SYS,
+        config
+    );
 
     info!("Clock out with low drive strength set on Master Clock Out 2 pin as AF on PC9");
 

--- a/examples/stm32h5/src/bin/mco.rs
+++ b/examples/stm32h5/src/bin/mco.rs
@@ -3,21 +3,21 @@
 
 use defmt::*;
 use embassy_executor::Spawner;
-use embassy_stm32::gpio::{ Speed };
-use embassy_stm32::rcc::{ Mco2Source, Mco, McoPrescaler };
+use embassy_stm32::gpio::Speed;
+use embassy_stm32::rcc::{Mco, Mco2Source, McoConfig};
 use {defmt_rtt as _, panic_probe as _};
 
 #[embassy_executor::main]
 async fn main(_spawner: Spawner) {
     let p = embassy_stm32::init(Default::default());
-    
-    /* Default "VeryHigh" drive strength */
-    // let _mco = Mco::new(p.MCO2, p.PC9, Mco2Source::SYS, McoPrescaler::DIV2);
 
-    /* Configurable Drive Strength */
-    let _mco = Mco::new_with_speed(p.MCO2, p.PC9, Speed::Low, Mco2Source::SYS, McoPrescaler::DIV2);
+    /* Default "VeryHigh" drive strength and prescaler DIV1 */
+    // let _mco = Mco::new(p.MCO2, p.PC9, Mco2Source::SYS, McoConfig::default());
+
+    /* Choose Speed::Low drive strength */
+    let _mco = Mco::new(p.MCO2, p.PC9, Mco2Source::SYS, McoConfig { speed: Speed::Low, ..Default::default() });
 
     info!("Clock out with low drive strength set on Master Clock Out 2 pin as AF on PC9");
 
-    loop { }
+    loop {}
 }

--- a/examples/stm32h7/src/bin/camera.rs
+++ b/examples/stm32h7/src/bin/camera.rs
@@ -5,7 +5,7 @@ use embassy_executor::Spawner;
 use embassy_stm32::dcmi::{self, *};
 use embassy_stm32::gpio::{Level, Output, Speed};
 use embassy_stm32::i2c::I2c;
-use embassy_stm32::rcc::{Mco, Mco1Source, McoPrescaler, McoConfig };
+use embassy_stm32::rcc::{Mco, Mco1Source, McoConfig, McoPrescaler};
 use embassy_stm32::{bind_interrupts, i2c, peripherals, Config};
 use embassy_time::Timer;
 use ov7725::*;
@@ -55,12 +55,7 @@ async fn main(_spawner: Spawner) {
         config
     };
 
-    let mco = Mco::new(
-        p.MCO1,
-        p.PA8,
-        Mco1Source::HSI,
-        mco_config,
-    );
+    let mco = Mco::new(p.MCO1, p.PA8, Mco1Source::HSI, mco_config);
 
     let mut led = Output::new(p.PE3, Level::High, Speed::Low);
     let cam_i2c = I2c::new(p.I2C1, p.PB8, p.PB9, Irqs, p.DMA1_CH1, p.DMA1_CH2, Default::default());

--- a/examples/stm32h7/src/bin/camera.rs
+++ b/examples/stm32h7/src/bin/camera.rs
@@ -5,7 +5,7 @@ use embassy_executor::Spawner;
 use embassy_stm32::dcmi::{self, *};
 use embassy_stm32::gpio::{Level, Output, Speed};
 use embassy_stm32::i2c::I2c;
-use embassy_stm32::rcc::{Mco, Mco1Source, McoPrescaler};
+use embassy_stm32::rcc::{Mco, Mco1Source, McoPrescaler, McoConfig };
 use embassy_stm32::{bind_interrupts, i2c, peripherals, Config};
 use embassy_time::Timer;
 use ov7725::*;
@@ -48,7 +48,19 @@ async fn main(_spawner: Spawner) {
     let p = embassy_stm32::init(config);
 
     defmt::info!("Hello World!");
-    let mco = Mco::new(p.MCO1, p.PA8, Mco1Source::HSI, McoPrescaler::DIV3);
+
+    let mco_config = {
+        let mut config = McoConfig::default();
+        config.prescaler = McoPrescaler::DIV3;
+        config
+    };
+
+    let mco = Mco::new(
+        p.MCO1,
+        p.PA8,
+        Mco1Source::HSI,
+        mco_config,
+    );
 
     let mut led = Output::new(p.PE3, Level::High, Speed::Low);
     let cam_i2c = I2c::new(p.I2C1, p.PB8, p.PB9, Irqs, p.DMA1_CH1, p.DMA1_CH2, Default::default());

--- a/examples/stm32h7/src/bin/mco.rs
+++ b/examples/stm32h7/src/bin/mco.rs
@@ -4,7 +4,7 @@
 use defmt::*;
 use embassy_executor::Spawner;
 use embassy_stm32::gpio::{Level, Output, Speed};
-use embassy_stm32::rcc::{Mco, Mco1Source, McoPrescaler};
+use embassy_stm32::rcc::{Mco, Mco1Source, McoConfig, McoPrescaler};
 use embassy_time::Timer;
 use {defmt_rtt as _, panic_probe as _};
 
@@ -15,7 +15,13 @@ async fn main(_spawner: Spawner) {
 
     let mut led = Output::new(p.PB14, Level::High, Speed::Low);
 
-    let _mco = Mco::new(p.MCO1, p.PA8, Mco1Source::HSI, McoPrescaler::DIV8);
+    let config = {
+        let mut config = McoConfig::default();
+        config.prescaler = McoPrescaler::DIV8;
+        config
+    };
+
+    let _mco = Mco::new(p.MCO1, p.PA8, Mco1Source::HSI, config);
 
     loop {
         info!("high");

--- a/examples/stm32h7rs/src/bin/mco.rs
+++ b/examples/stm32h7rs/src/bin/mco.rs
@@ -4,7 +4,7 @@
 use defmt::*;
 use embassy_executor::Spawner;
 use embassy_stm32::gpio::{Level, Output, Speed};
-use embassy_stm32::rcc::{Mco, Mco1Source, McoPrescaler};
+use embassy_stm32::rcc::{Mco, Mco1Source, McoConfig, McoPrescaler};
 use embassy_time::Timer;
 use {defmt_rtt as _, panic_probe as _};
 
@@ -15,7 +15,13 @@ async fn main(_spawner: Spawner) {
 
     let mut led = Output::new(p.PB14, Level::High, Speed::Low);
 
-    let _mco = Mco::new(p.MCO1, p.PA8, Mco1Source::HSI, McoPrescaler::DIV8);
+    let config = {
+        let mut config = McoConfig::default();
+        config.prescaler = McoPrescaler::DIV8;
+        config
+    };
+
+    let _mco = Mco::new(p.MCO1, p.PA8, Mco1Source::HSI, config);
 
     loop {
         info!("high");

--- a/examples/stm32l4/src/bin/mco.rs
+++ b/examples/stm32l4/src/bin/mco.rs
@@ -4,7 +4,7 @@
 use defmt::*;
 use embassy_executor::Spawner;
 use embassy_stm32::gpio::{Level, Output, Speed};
-use embassy_stm32::rcc::{Mco, McoPrescaler, McoSource};
+use embassy_stm32::rcc::{Mco, McoPrescaler, McoConfig, McoSource};
 use embassy_time::Timer;
 use {defmt_rtt as _, panic_probe as _};
 
@@ -13,7 +13,13 @@ async fn main(_spawner: Spawner) {
     let p = embassy_stm32::init(Default::default());
     info!("Hello World!");
 
-    let _mco = Mco::new(p.MCO, p.PA8, McoSource::HSI, McoPrescaler::DIV1);
+    let config = {
+        let mut config = McoConfig::default();
+        config.prescaler = McoPrescaler::DIV1;
+        config
+    };
+
+    let _mco = Mco::new(p.MCO, p.PA8, McoSource::HSI, config);
 
     let mut led = Output::new(p.PB14, Level::High, Speed::Low);
 

--- a/examples/stm32l4/src/bin/mco.rs
+++ b/examples/stm32l4/src/bin/mco.rs
@@ -4,7 +4,7 @@
 use defmt::*;
 use embassy_executor::Spawner;
 use embassy_stm32::gpio::{Level, Output, Speed};
-use embassy_stm32::rcc::{Mco, McoPrescaler, McoConfig, McoSource};
+use embassy_stm32::rcc::{Mco, McoConfig, McoPrescaler, McoSource};
 use embassy_time::Timer;
 use {defmt_rtt as _, panic_probe as _};
 


### PR DESCRIPTION
adding rcc::Mco::new_with_speed() constructor to control to allow lower drive strength on generated master clock out signal.

Simple usage example added.
