### PR TITLE
[embassy-embedded-hal] Clone on shared i2c

### DIFF
--- a/embassy-embedded-hal/CHANGELOG.md
+++ b/embassy-embedded-hal/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 <!-- next-header -->
 ## Unreleased - ReleaseDate
 
+- Shared I2c busses now impl `Clone`
+
 ## 0.5.0 - 2025-08-27
 
 ## 0.4.0 - 2025-08-03

--- a/embassy-embedded-hal/src/flash/partition/asynch.rs
+++ b/embassy-embedded-hal/src/flash/partition/asynch.rs
@@ -119,7 +119,7 @@ mod tests {
         let mut read_buf = [0; 8];
         partition.read(4, &mut read_buf).await.unwrap();
 
-        assert!(read_buf.iter().position(|&x| x != 0xAA).is_none());
+        assert!(!read_buf.iter().any(|&x| x != 0xAA));
     }
 
     #[futures_test::test]
@@ -133,7 +133,7 @@ mod tests {
         partition.write(4, &write_buf).await.unwrap();
 
         let flash = flash.try_lock().unwrap();
-        assert!(flash.mem[132..132 + 8].iter().position(|&x| x != 0xAA).is_none());
+        assert!(!flash.mem[132..132 + 8].iter().any(|&x| x != 0xAA));
     }
 
     #[futures_test::test]
@@ -146,6 +146,6 @@ mod tests {
         partition.erase(0, 128).await.unwrap();
 
         let flash = flash.try_lock().unwrap();
-        assert!(flash.mem[128..256].iter().position(|&x| x != 0xFF).is_none());
+        assert!(!flash.mem[128..256].iter().any(|&x| x != 0xFF));
     }
 }

--- a/embassy-embedded-hal/src/flash/partition/blocking.rs
+++ b/embassy-embedded-hal/src/flash/partition/blocking.rs
@@ -129,7 +129,7 @@ mod tests {
         let mut read_buf = [0; 8];
         partition.read(4, &mut read_buf).unwrap();
 
-        assert!(read_buf.iter().position(|&x| x != 0xAA).is_none());
+        assert!(!read_buf.iter().any(|&x| x != 0xAA));
     }
 
     #[test]
@@ -143,7 +143,7 @@ mod tests {
         partition.write(4, &write_buf).unwrap();
 
         let flash = flash.into_inner().take();
-        assert!(flash.mem[132..132 + 8].iter().position(|&x| x != 0xAA).is_none());
+        assert!(!flash.mem[132..132 + 8].iter().any(|&x| x != 0xAA));
     }
 
     #[test]
@@ -156,6 +156,6 @@ mod tests {
         partition.erase(0, 128).unwrap();
 
         let flash = flash.into_inner().take();
-        assert!(flash.mem[128..256].iter().position(|&x| x != 0xFF).is_none());
+        assert!(!flash.mem[128..256].iter().any(|&x| x != 0xFF));
     }
 }

--- a/embassy-embedded-hal/src/shared_bus/asynch/i2c.rs
+++ b/embassy-embedded-hal/src/shared_bus/asynch/i2c.rs
@@ -41,6 +41,12 @@ impl<'a, M: RawMutex, BUS> I2cDevice<'a, M, BUS> {
     }
 }
 
+impl<'a, M: RawMutex, BUS> Clone for I2cDevice<'a, M, BUS> {
+    fn clone(&self) -> Self {
+        Self { bus: self.bus }
+    }
+}
+
 impl<'a, M: RawMutex, BUS> i2c::ErrorType for I2cDevice<'a, M, BUS>
 where
     BUS: i2c::ErrorType,
@@ -110,6 +116,18 @@ impl<'a, M: RawMutex, BUS: SetConfig> I2cDeviceWithConfig<'a, M, BUS> {
     /// Change the device's config at runtime
     pub fn set_config(&mut self, config: BUS::Config) {
         self.config = config;
+    }
+}
+
+impl<'a, M: RawMutex, BUS: SetConfig> Clone for I2cDeviceWithConfig<'a, M, BUS>
+where
+    BUS::Config: Clone,
+{
+    fn clone(&self) -> Self {
+        Self {
+            bus: self.bus,
+            config: self.config.clone(),
+        }
     }
 }
 

--- a/embassy-embedded-hal/src/shared_bus/asynch/spi.rs
+++ b/embassy-embedded-hal/src/shared_bus/asynch/spi.rs
@@ -112,11 +112,11 @@ where
         cs_drop.defuse();
         let cs_res = self.cs.set_high();
 
-        let op_res = op_res.map_err(SpiDeviceError::Spi)?;
+        op_res.map_err(SpiDeviceError::Spi)?;
         flush_res.map_err(SpiDeviceError::Spi)?;
         cs_res.map_err(SpiDeviceError::Cs)?;
 
-        Ok(op_res)
+        Ok(())
     }
 }
 
@@ -203,10 +203,10 @@ where
         cs_drop.defuse();
         let cs_res = self.cs.set_high();
 
-        let op_res = op_res.map_err(SpiDeviceError::Spi)?;
+        op_res.map_err(SpiDeviceError::Spi)?;
         flush_res.map_err(SpiDeviceError::Spi)?;
         cs_res.map_err(SpiDeviceError::Cs)?;
 
-        Ok(op_res)
+        Ok(())
     }
 }

--- a/embassy-embedded-hal/src/shared_bus/blocking/i2c.rs
+++ b/embassy-embedded-hal/src/shared_bus/blocking/i2c.rs
@@ -81,33 +81,33 @@ where
     }
 }
 
-impl<'a, M, BUS, E> embedded_hal_02::blocking::i2c::Write for I2cDevice<'_, M, BUS>
+impl<M, BUS, E> embedded_hal_02::blocking::i2c::Write for I2cDevice<'_, M, BUS>
 where
     M: RawMutex,
     BUS: embedded_hal_02::blocking::i2c::Write<Error = E>,
 {
     type Error = I2cDeviceError<E>;
 
-    fn write<'w>(&mut self, addr: u8, bytes: &'w [u8]) -> Result<(), Self::Error> {
+    fn write(&mut self, addr: u8, bytes: &[u8]) -> Result<(), Self::Error> {
         self.bus
             .lock(|bus| bus.borrow_mut().write(addr, bytes).map_err(I2cDeviceError::I2c))
     }
 }
 
-impl<'a, M, BUS, E> embedded_hal_02::blocking::i2c::Read for I2cDevice<'_, M, BUS>
+impl<M, BUS, E> embedded_hal_02::blocking::i2c::Read for I2cDevice<'_, M, BUS>
 where
     M: RawMutex,
     BUS: embedded_hal_02::blocking::i2c::Read<Error = E>,
 {
     type Error = I2cDeviceError<E>;
 
-    fn read<'w>(&mut self, addr: u8, bytes: &'w mut [u8]) -> Result<(), Self::Error> {
+    fn read(&mut self, addr: u8, bytes: &mut [u8]) -> Result<(), Self::Error> {
         self.bus
             .lock(|bus| bus.borrow_mut().read(addr, bytes).map_err(I2cDeviceError::I2c))
     }
 }
 
-impl<'a, M, BUS, E> embedded_hal_02::blocking::i2c::WriteRead for I2cDevice<'_, M, BUS>
+impl<M, BUS, E> embedded_hal_02::blocking::i2c::WriteRead for I2cDevice<'_, M, BUS>
 where
     M: RawMutex,
     BUS: embedded_hal_02::blocking::i2c::WriteRead<Error = E>,

--- a/embassy-embedded-hal/src/shared_bus/blocking/i2c.rs
+++ b/embassy-embedded-hal/src/shared_bus/blocking/i2c.rs
@@ -36,6 +36,12 @@ impl<'a, M: RawMutex, BUS> I2cDevice<'a, M, BUS> {
     }
 }
 
+impl<'a, M: RawMutex, BUS> Clone for I2cDevice<'a, M, BUS> {
+    fn clone(&self) -> Self {
+        Self { bus: self.bus }
+    }
+}
+
 impl<'a, M: RawMutex, BUS> ErrorType for I2cDevice<'a, M, BUS>
 where
     BUS: ErrorType,
@@ -136,6 +142,18 @@ impl<'a, M: RawMutex, BUS: SetConfig> I2cDeviceWithConfig<'a, M, BUS> {
     /// Change the device's config at runtime
     pub fn set_config(&mut self, config: BUS::Config) {
         self.config = config;
+    }
+}
+
+impl<'a, M: RawMutex, BUS: SetConfig> Clone for I2cDeviceWithConfig<'a, M, BUS>
+where
+    BUS::Config: Clone,
+{
+    fn clone(&self) -> Self {
+        Self {
+            bus: self.bus,
+            config: self.config.clone(),
+        }
     }
 }
 

--- a/embassy-embedded-hal/src/shared_bus/blocking/spi.rs
+++ b/embassy-embedded-hal/src/shared_bus/blocking/spi.rs
@@ -82,11 +82,11 @@ where
             let flush_res = bus.flush();
             let cs_res = self.cs.set_high();
 
-            let op_res = op_res.map_err(SpiDeviceError::Spi)?;
+            op_res.map_err(SpiDeviceError::Spi)?;
             flush_res.map_err(SpiDeviceError::Spi)?;
             cs_res.map_err(SpiDeviceError::Cs)?;
 
-            Ok(op_res)
+            Ok(())
         })
     }
 }
@@ -158,10 +158,10 @@ where
             let flush_res = bus.flush();
             let cs_res = self.cs.set_high();
 
-            let op_res = op_res.map_err(SpiDeviceError::Spi)?;
+            op_res.map_err(SpiDeviceError::Spi)?;
             flush_res.map_err(SpiDeviceError::Spi)?;
             cs_res.map_err(SpiDeviceError::Cs)?;
-            Ok(op_res)
+            Ok(())
         })
     }
 }


### PR DESCRIPTION
I noticed Clone wasn't implemented even though there's no reason not to.
This makes the types easier to use.

Also, there's a bunch of clippy things that came up in the repo. Not sure if it's all new stuff.
Regardless, I fixed these in a separate commit.