### PR TITLE
feat(nrf/spim): erase Instance type from Spim

### DIFF
--- a/embassy-nrf/CHANGELOG.md
+++ b/embassy-nrf/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 <!-- next-header -->
 ## Unreleased - ReleaseDate
 
+- changed: erase Instance type from Spim
 - changed: nrf54l: Disable glitch detection and enable DC/DC in init.
 - changed: Add embassy-net-driver-channel implementation for IEEE 802.15.4
 - changed: add persist() method for gpio and ppi

--- a/examples/nrf52840/src/bin/ethernet_enc28j60.rs
+++ b/examples/nrf52840/src/bin/ethernet_enc28j60.rs
@@ -25,7 +25,7 @@ bind_interrupts!(struct Irqs {
 async fn net_task(
     mut runner: embassy_net::Runner<
         'static,
-        Enc28j60<ExclusiveDevice<Spim<'static, peripherals::SPI3>, Output<'static>, Delay>, Output<'static>>,
+        Enc28j60<ExclusiveDevice<Spim<'static>, Output<'static>, Delay>, Output<'static>>,
     >,
 ) -> ! {
     runner.run().await

--- a/examples/nrf52840/src/bin/wifi_esp_hosted.rs
+++ b/examples/nrf52840/src/bin/wifi_esp_hosted.rs
@@ -27,7 +27,7 @@ bind_interrupts!(struct Irqs {
 async fn wifi_task(
     runner: hosted::Runner<
         'static,
-        ExclusiveDevice<Spim<'static, peripherals::SPI3>, Output<'static>, Delay>,
+        ExclusiveDevice<Spim<'static>, Output<'static>, Delay>,
         Input<'static>,
         Output<'static>,
     >,

--- a/tests/nrf/src/bin/ethernet_enc28j60_perf.rs
+++ b/tests/nrf/src/bin/ethernet_enc28j60_perf.rs
@@ -22,7 +22,7 @@ bind_interrupts!(struct Irqs {
     RNG => embassy_nrf::rng::InterruptHandler<peripherals::RNG>;
 });
 
-type MyDriver = Enc28j60<ExclusiveDevice<Spim<'static, peripherals::SPI3>, Output<'static>, Delay>, Output<'static>>;
+type MyDriver = Enc28j60<ExclusiveDevice<Spim<'static>, Output<'static>, Delay>, Output<'static>>;
 
 #[embassy_executor::task]
 async fn net_task(mut runner: embassy_net::Runner<'static, MyDriver>) -> ! {

--- a/tests/nrf/src/bin/wifi_esp_hosted_perf.rs
+++ b/tests/nrf/src/bin/wifi_esp_hosted_perf.rs
@@ -29,7 +29,7 @@ const WIFI_PASSWORD: &str = "V8YxhKt5CdIAJFud";
 async fn wifi_task(
     runner: hosted::Runner<
         'static,
-        ExclusiveDevice<Spim<'static, peripherals::SPI3>, Output<'static>, Delay>,
+        ExclusiveDevice<Spim<'static>, Output<'static>, Delay>,
         Input<'static>,
         Output<'static>,
     >,


### PR DESCRIPTION
It was between this and adding an AnySpi (which would be theoretically more memory efficient but effectively the same), but it seems that embassy is going this type erasure route in general.

This can be made a few bytes more efficient by doing a long match on Interrupt to retrieve the instance, but that seems annoying to me.