### PR TITLE
USB CRS sync support for STM32C071

### DIFF
--- a/embassy-stm32/CHANGELOG.md
+++ b/embassy-stm32/CHANGELOG.md
@@ -22,6 +22,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - fix: handle address and data-length errors in OSPI
 - feat: Allow OSPI DMA writes larger than 64kB using chunking
 - feat: More ADC enums for g0 PAC, API change for oversampling, allow separate sample times
+- feat: Add USB CRS sync support for STM32C071
 
 ## 0.4.0 - 2025-08-26
 

--- a/embassy-stm32/src/rcc/c0.rs
+++ b/embassy-stm32/src/rcc/c0.rs
@@ -49,6 +49,10 @@ pub struct Config {
     /// System Clock Configuration
     pub sys: Sysclk,
 
+    /// HSI48 Configuration
+    #[cfg(crs)]
+    pub hsi48: Option<super::Hsi48Config>,
+
     pub ahb_pre: AHBPrescaler,
     pub apb1_pre: APBPrescaler,
 
@@ -68,6 +72,8 @@ impl Config {
             }),
             hse: None,
             sys: Sysclk::HSISYS,
+            #[cfg(crs)]
+            hsi48: Some(crate::rcc::Hsi48Config::new()),
             ahb_pre: AHBPrescaler::DIV1,
             apb1_pre: APBPrescaler::DIV1,
             ls: crate::rcc::LsConfig::new(),
@@ -127,6 +133,10 @@ pub(crate) unsafe fn init(config: Config) {
         }
     };
 
+    // Configure HSI48 if required
+    #[cfg(crs)]
+    let hsi48 = config.hsi48.map(super::init_hsi48);
+
     let rtc = config.ls.init();
 
     let sys = match config.sys {
@@ -185,13 +195,13 @@ pub(crate) unsafe fn init(config: Config) {
         hsi: hsi,
         hsiker: hsiker,
         hse: hse,
+        #[cfg(crs)]
+        hsi48: hsi48,
         rtc: rtc,
 
         // TODO
         lsi: None,
         lse: None,
-        #[cfg(crs)]
-        hsi48: None,
     );
 
     RCC.ccipr()


### PR DESCRIPTION
Include `Hsi48Config` in the RCC config struct to provide support for USB CRS (similar to [STM32G0](https://github.com/embassy-rs/embassy/blob/main/embassy-stm32/src/rcc/g0.rs)). These changes were tested with an STM32C071G8 and an STM32C071KB and appear to work well.