### PR TITLE
Add read_from_break method to STM32 UartRx

### DIFF
--- a/embassy-stm32/CHANGELOG.md
+++ b/embassy-stm32/CHANGELOG.md
@@ -23,6 +23,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - feat: Allow OSPI DMA writes larger than 64kB using chunking
 - feat: More ADC enums for g0 PAC, API change for oversampling, allow separate sample times
 - feat: Add USB CRS sync support for STM32C071
+- feat: Add read_from_break method to STM32 UartRx ([#4702](https://github.com/embassy-rs/embassy/pull/4702))
 
 ## 0.4.0 - 2025-08-26
 


### PR DESCRIPTION
For the purposes of receiving DMX (ANSI E1.11), or other protocols that may signal the start of a message with a break character:

This PR adds a new read method to `UartRx`, called `read_from_break`, with the following logic:
1. DMA transaction is set up but DMAR bit is not set
2. Overrun errors are ignored.
3. In UART interrupt handler, if a framing error (break) is detected and DMAR bit is not set, clear the error and set DMAR

Other logic remains the same, i.e. if a second break occurs before the read is complete, this is still a framing error.

I've validated this on an STM32L476RG (usart_v3) but no other chips or peripheral versions so far.
I did attempt to implement this outside of embassy code, but found the first few bytes were consistently missed unless handling this in the interrupt.

Please let me know if you think there's a better approach, or would like any changes!