### PR TITLE
Add reset_to_usb_boot to rp235x

### DIFF
--- a/embassy-rp/CHANGELOG.md
+++ b/embassy-rp/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add PIO onewire parasite power strong pullup
 - add `wait_for_alarm` and `alarm_scheduled` methods to rtc module ([#4216](https://github.com/embassy-rs/embassy/pull/4216))
 - rp235x: use msplim for stack guard instead of MPU
+- Add reset_to_usb_boot for rp235x ([#4705](https://github.com/embassy-rs/embassy/pull/4705))
 
 ## 0.8.0 - 2025-08-26
 


### PR DESCRIPTION
This adds the reset_to_usb_boot function to the rp235x. The code has just been translated from the original C++ [here](https://github.com/raspberrypi/pico-sdk/blob/master/src/rp2_common/pico_bootrom/bootrom.c#L35-L51).