### PR TITLE
fix: update bt-hci to 0.6

### DIFF
--- a/cyw43/CHANGELOG.md
+++ b/cyw43/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## Unreleased - ReleaseDate
 
 - Updated documentation for Control::join() #4678
-- Bump bt-hci to 0.5.0.
+- Bump bt-hci to 0.6.0.
 - Add error handling to HCI transport implementation.
 
 ## 0.5.0 - 2025-08-28

--- a/cyw43/Cargo.toml
+++ b/cyw43/Cargo.toml
@@ -36,7 +36,7 @@ heapless = "0.8.0"
 
 # Bluetooth deps
 embedded-io-async = { version = "0.6.0", optional = true }
-bt-hci = { version = "0.5.0", optional = true }
+bt-hci = { version = "0.6.0", optional = true }
 
 [package.metadata.embassy]
 build = [


### PR DESCRIPTION
Fixes an issue for controllers that emit unexpected command complete events.