### PR TITLE
nrf: expose regs on all peripherals

### DIFF
--- a/embassy-nrf/CHANGELOG.md
+++ b/embassy-nrf/CHANGELOG.md
@@ -11,12 +11,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - changed: Remove `T: Instance` generic params in all drivers.
 - changed: nrf54l: Disable glitch detection and enable DC/DC in init.
 - changed: Add embassy-net-driver-channel implementation for IEEE 802.15.4
-- changed: add persist() method for gpio and ppi
 - added: basic RTC driver
 - changed: add persist() method for gpio, gpiote, timer and ppi
 - changed: impl Drop for Timer
 - added: expose `regs` for timer driver
 - added: timer driver CC `clear_events` method
+- added: expose `regs` for all peripherals
 
 ## 0.7.0 - 2025-08-26
 

--- a/embassy-nrf/src/egu.rs
+++ b/embassy-nrf/src/egu.rs
@@ -38,6 +38,7 @@ impl<'d> Egu<'d> {
 }
 
 pub(crate) trait SealedInstance {
+    #[cfg(not(feature = "unstable-pac"))]
     fn regs() -> pac::egu::Egu;
 }
 
@@ -46,17 +47,25 @@ pub(crate) trait SealedInstance {
 pub trait Instance: SealedInstance + PeripheralType + 'static + Send {
     /// Interrupt for this peripheral.
     type Interrupt: interrupt::typelevel::Interrupt;
+    /// Direct access to the register block.
+    #[cfg(feature = "unstable-pac")]
+    fn regs() -> pac::egu::Egu;
 }
 
 macro_rules! impl_egu {
     ($type:ident, $pac_type:ident, $irq:ident) => {
         impl crate::egu::SealedInstance for peripherals::$type {
+            #[cfg(not(feature = "unstable-pac"))]
             fn regs() -> pac::egu::Egu {
                 pac::$pac_type
             }
         }
         impl crate::egu::Instance for peripherals::$type {
             type Interrupt = crate::interrupt::typelevel::$irq;
+            #[cfg(feature = "unstable-pac")]
+            fn regs() -> pac::egu::Egu {
+                pac::$pac_type
+            }
         }
     };
 }

--- a/embassy-nrf/src/i2s.rs
+++ b/embassy-nrf/src/i2s.rs
@@ -1160,6 +1160,7 @@ impl State {
 }
 
 pub(crate) trait SealedInstance {
+    #[cfg(not(feature = "unstable-pac"))]
     fn regs() -> pac::i2s::I2s;
     fn state() -> &'static State;
 }
@@ -1169,11 +1170,15 @@ pub(crate) trait SealedInstance {
 pub trait Instance: SealedInstance + PeripheralType + 'static + Send {
     /// Interrupt for this peripheral.
     type Interrupt: interrupt::typelevel::Interrupt;
+    /// Direct access to the register block.
+    #[cfg(feature = "unstable-pac")]
+    fn regs() -> pac::i2s::I2s;
 }
 
 macro_rules! impl_i2s {
     ($type:ident, $pac_type:ident, $irq:ident) => {
         impl crate::i2s::SealedInstance for peripherals::$type {
+            #[cfg(not(feature = "unstable-pac"))]
             fn regs() -> pac::i2s::I2s {
                 pac::$pac_type
             }
@@ -1184,6 +1189,10 @@ macro_rules! impl_i2s {
         }
         impl crate::i2s::Instance for peripherals::$type {
             type Interrupt = crate::interrupt::typelevel::$irq;
+            #[cfg(feature = "unstable-pac")]
+            fn regs() -> pac::i2s::I2s {
+                pac::$pac_type
+            }
         }
     };
 }

--- a/embassy-nrf/src/ipc.rs
+++ b/embassy-nrf/src/ipc.rs
@@ -341,6 +341,7 @@ impl State {
 }
 
 pub(crate) trait SealedInstance {
+    #[cfg(not(feature = "unstable-pac"))]
     fn regs() -> pac::ipc::Ipc;
     fn state() -> &'static State;
 }
@@ -350,11 +351,15 @@ pub(crate) trait SealedInstance {
 pub trait Instance: PeripheralType + SealedInstance + 'static + Send {
     /// Interrupt for this peripheral.
     type Interrupt: interrupt::typelevel::Interrupt;
+    /// Direct access to the register block.
+    #[cfg(feature = "unstable-pac")]
+    fn regs() -> pac::ipc::Ipc;
 }
 
 macro_rules! impl_ipc {
     ($type:ident, $pac_type:ident, $irq:ident) => {
         impl crate::ipc::SealedInstance for peripherals::$type {
+            #[cfg(not(feature = "unstable-pac"))]
             fn regs() -> pac::ipc::Ipc {
                 pac::$pac_type
             }
@@ -366,6 +371,10 @@ macro_rules! impl_ipc {
         }
         impl crate::ipc::Instance for peripherals::$type {
             type Interrupt = crate::interrupt::typelevel::$irq;
+            #[cfg(feature = "unstable-pac")]
+            fn regs() -> pac::ipc::Ipc {
+                pac::$pac_type
+            }
         }
     };
 }

--- a/embassy-nrf/src/pdm.rs
+++ b/embassy-nrf/src/pdm.rs
@@ -443,6 +443,7 @@ impl State {
 }
 
 pub(crate) trait SealedInstance {
+    #[cfg(not(feature = "unstable-pac"))]
     fn regs() -> crate::pac::pdm::Pdm;
     fn state() -> &'static State;
 }
@@ -452,11 +453,15 @@ pub(crate) trait SealedInstance {
 pub trait Instance: SealedInstance + PeripheralType + 'static + Send {
     /// Interrupt for this peripheral
     type Interrupt: interrupt::typelevel::Interrupt;
+    /// Direct access to the register block.
+    #[cfg(feature = "unstable-pac")]
+    fn regs() -> crate::pac::pdm::Pdm;
 }
 
 macro_rules! impl_pdm {
     ($type:ident, $pac_type:ident, $irq:ident) => {
         impl crate::pdm::SealedInstance for peripherals::$type {
+            #[cfg(not(feature = "unstable-pac"))]
             fn regs() -> crate::pac::pdm::Pdm {
                 pac::$pac_type
             }
@@ -467,6 +472,10 @@ macro_rules! impl_pdm {
         }
         impl crate::pdm::Instance for peripherals::$type {
             type Interrupt = crate::interrupt::typelevel::$irq;
+            #[cfg(feature = "unstable-pac")]
+            fn regs() -> crate::pac::pdm::Pdm {
+                pac::$pac_type
+            }
         }
     };
 }

--- a/embassy-nrf/src/pwm.rs
+++ b/embassy-nrf/src/pwm.rs
@@ -826,6 +826,7 @@ impl<'a> Drop for SimplePwm<'a> {
 }
 
 pub(crate) trait SealedInstance {
+    #[cfg(not(feature = "unstable-pac"))]
     fn regs() -> pac::pwm::Pwm;
 }
 
@@ -834,17 +835,25 @@ pub(crate) trait SealedInstance {
 pub trait Instance: SealedInstance + PeripheralType + 'static {
     /// Interrupt for this peripheral.
     type Interrupt: interrupt::typelevel::Interrupt;
+    /// Direct access to the register block.
+    #[cfg(feature = "unstable-pac")]
+    fn regs() -> pac::pwm::Pwm;
 }
 
 macro_rules! impl_pwm {
     ($type:ident, $pac_type:ident, $irq:ident) => {
         impl crate::pwm::SealedInstance for peripherals::$type {
+            #[cfg(not(feature = "unstable-pac"))]
             fn regs() -> pac::pwm::Pwm {
                 pac::$pac_type
             }
         }
         impl crate::pwm::Instance for peripherals::$type {
             type Interrupt = crate::interrupt::typelevel::$irq;
+            #[cfg(feature = "unstable-pac")]
+            fn regs() -> pac::pwm::Pwm {
+                pac::$pac_type
+            }
         }
     };
 }

--- a/embassy-nrf/src/qdec.rs
+++ b/embassy-nrf/src/qdec.rs
@@ -271,6 +271,7 @@ impl State {
 }
 
 pub(crate) trait SealedInstance {
+    #[cfg(not(feature = "unstable-pac"))]
     fn regs() -> pac::qdec::Qdec;
     fn state() -> &'static State;
 }
@@ -280,11 +281,15 @@ pub(crate) trait SealedInstance {
 pub trait Instance: SealedInstance + PeripheralType + 'static + Send {
     /// Interrupt for this peripheral.
     type Interrupt: interrupt::typelevel::Interrupt;
+    /// Direct access to the register block.
+    #[cfg(feature = "unstable-pac")]
+    fn regs() -> pac::qdec::Qdec;
 }
 
 macro_rules! impl_qdec {
     ($type:ident, $pac_type:ident, $irq:ident) => {
         impl crate::qdec::SealedInstance for peripherals::$type {
+            #[cfg(not(feature = "unstable-pac"))]
             fn regs() -> pac::qdec::Qdec {
                 pac::$pac_type
             }
@@ -295,6 +300,10 @@ macro_rules! impl_qdec {
         }
         impl crate::qdec::Instance for peripherals::$type {
             type Interrupt = crate::interrupt::typelevel::$irq;
+            #[cfg(feature = "unstable-pac")]
+            fn regs() -> pac::qdec::Qdec {
+                pac::$pac_type
+            }
         }
     };
 }

--- a/embassy-nrf/src/qspi.rs
+++ b/embassy-nrf/src/qspi.rs
@@ -651,6 +651,7 @@ impl State {
 }
 
 pub(crate) trait SealedInstance {
+    #[cfg(not(feature = "unstable-pac"))]
     fn regs() -> pac::qspi::Qspi;
     fn state() -> &'static State;
 }
@@ -660,11 +661,15 @@ pub(crate) trait SealedInstance {
 pub trait Instance: SealedInstance + PeripheralType + 'static + Send {
     /// Interrupt for this peripheral.
     type Interrupt: interrupt::typelevel::Interrupt;
+    /// Direct access to the register block.
+    #[cfg(feature = "unstable-pac")]
+    fn regs() -> pac::qspi::Qspi;
 }
 
 macro_rules! impl_qspi {
     ($type:ident, $pac_type:ident, $irq:ident) => {
         impl crate::qspi::SealedInstance for peripherals::$type {
+            #[cfg(not(feature = "unstable-pac"))]
             fn regs() -> pac::qspi::Qspi {
                 pac::$pac_type
             }
@@ -675,6 +680,10 @@ macro_rules! impl_qspi {
         }
         impl crate::qspi::Instance for peripherals::$type {
             type Interrupt = crate::interrupt::typelevel::$irq;
+            #[cfg(feature = "unstable-pac")]
+            fn regs() -> pac::qspi::Qspi {
+                pac::$pac_type
+            }
         }
     };
 }

--- a/embassy-nrf/src/radio/mod.rs
+++ b/embassy-nrf/src/radio/mod.rs
@@ -69,6 +69,7 @@ impl State {
 }
 
 pub(crate) trait SealedInstance {
+    #[cfg(not(feature = "unstable-pac"))]
     fn regs() -> crate::pac::radio::Radio;
     fn state() -> &'static State;
 }
@@ -76,6 +77,7 @@ pub(crate) trait SealedInstance {
 macro_rules! impl_radio {
     ($type:ident, $pac_type:ident, $irq:ident) => {
         impl crate::radio::SealedInstance for peripherals::$type {
+            #[cfg(not(feature = "unstable-pac"))]
             fn regs() -> crate::pac::radio::Radio {
                 pac::$pac_type
             }
@@ -88,6 +90,10 @@ macro_rules! impl_radio {
         }
         impl crate::radio::Instance for peripherals::$type {
             type Interrupt = crate::interrupt::typelevel::$irq;
+            #[cfg(feature = "unstable-pac")]
+            fn regs() -> crate::pac::radio::Radio {
+                pac::$pac_type
+            }
         }
     };
 }
@@ -97,4 +103,7 @@ macro_rules! impl_radio {
 pub trait Instance: SealedInstance + PeripheralType + 'static + Send {
     /// Interrupt for this peripheral.
     type Interrupt: interrupt::typelevel::Interrupt;
+    /// Direct access to the register block.
+    #[cfg(feature = "unstable-pac")]
+    fn regs() -> crate::pac::radio::Radio;
 }

--- a/embassy-nrf/src/rng.rs
+++ b/embassy-nrf/src/rng.rs
@@ -293,6 +293,7 @@ impl InnerState {
 }
 
 pub(crate) trait SealedInstance {
+    #[cfg(not(feature = "unstable-pac"))]
     fn regs() -> pac::rng::Rng;
     fn state() -> &'static State;
 }
@@ -302,11 +303,15 @@ pub(crate) trait SealedInstance {
 pub trait Instance: SealedInstance + PeripheralType + 'static + Send {
     /// Interrupt for this peripheral.
     type Interrupt: interrupt::typelevel::Interrupt;
+    /// Direct access to the register block.
+    #[cfg(feature = "unstable-pac")]
+    fn regs() -> pac::rng::Rng;
 }
 
 macro_rules! impl_rng {
     ($type:ident, $pac_type:ident, $irq:ident) => {
         impl crate::rng::SealedInstance for peripherals::$type {
+            #[cfg(not(feature = "unstable-pac"))]
             fn regs() -> crate::pac::rng::Rng {
                 pac::$pac_type
             }
@@ -317,6 +322,10 @@ macro_rules! impl_rng {
         }
         impl crate::rng::Instance for peripherals::$type {
             type Interrupt = crate::interrupt::typelevel::$irq;
+            #[cfg(feature = "unstable-pac")]
+            fn regs() -> crate::pac::rng::Rng {
+                pac::$pac_type
+            }
         }
     };
 }

--- a/embassy-nrf/src/spim.rs
+++ b/embassy-nrf/src/spim.rs
@@ -501,6 +501,7 @@ impl State {
 }
 
 pub(crate) trait SealedInstance {
+    #[cfg(not(feature = "unstable-pac"))]
     fn regs() -> pac::spim::Spim;
     fn state() -> &'static State;
 }
@@ -510,11 +511,15 @@ pub(crate) trait SealedInstance {
 pub trait Instance: SealedInstance + PeripheralType + 'static {
     /// Interrupt for this peripheral.
     type Interrupt: interrupt::typelevel::Interrupt;
+    /// Direct access to the register block.
+    #[cfg(feature = "unstable-pac")]
+    fn regs() -> pac::spim::Spim;
 }
 
 macro_rules! impl_spim {
     ($type:ident, $pac_type:ident, $irq:ident) => {
         impl crate::spim::SealedInstance for peripherals::$type {
+            #[cfg(not(feature = "unstable-pac"))]
             fn regs() -> pac::spim::Spim {
                 pac::$pac_type
             }
@@ -525,6 +530,10 @@ macro_rules! impl_spim {
         }
         impl crate::spim::Instance for peripherals::$type {
             type Interrupt = crate::interrupt::typelevel::$irq;
+            #[cfg(feature = "unstable-pac")]
+            fn regs() -> pac::spim::Spim {
+                pac::$pac_type
+            }
         }
     };
 }

--- a/embassy-nrf/src/spis.rs
+++ b/embassy-nrf/src/spis.rs
@@ -465,6 +465,7 @@ impl State {
 }
 
 pub(crate) trait SealedInstance {
+    #[cfg(not(feature = "unstable-pac"))]
     fn regs() -> pac::spis::Spis;
     fn state() -> &'static State;
 }
@@ -474,11 +475,15 @@ pub(crate) trait SealedInstance {
 pub trait Instance: SealedInstance + PeripheralType + 'static {
     /// Interrupt for this peripheral.
     type Interrupt: interrupt::typelevel::Interrupt;
+    /// Direct access to the register block.
+    #[cfg(feature = "unstable-pac")]
+    fn regs() -> pac::spis::Spis;
 }
 
 macro_rules! impl_spis {
     ($type:ident, $pac_type:ident, $irq:ident) => {
         impl crate::spis::SealedInstance for peripherals::$type {
+            #[cfg(not(feature = "unstable-pac"))]
             fn regs() -> pac::spis::Spis {
                 pac::$pac_type
             }
@@ -489,6 +494,10 @@ macro_rules! impl_spis {
         }
         impl crate::spis::Instance for peripherals::$type {
             type Interrupt = crate::interrupt::typelevel::$irq;
+            #[cfg(feature = "unstable-pac")]
+            fn regs() -> pac::spis::Spis {
+                pac::$pac_type
+            }
         }
     };
 }

--- a/embassy-nrf/src/twim.rs
+++ b/embassy-nrf/src/twim.rs
@@ -731,6 +731,7 @@ impl State {
 }
 
 pub(crate) trait SealedInstance {
+    #[cfg(not(feature = "unstable-pac"))]
     fn regs() -> pac::twim::Twim;
     fn state() -> &'static State;
 }
@@ -740,11 +741,15 @@ pub(crate) trait SealedInstance {
 pub trait Instance: SealedInstance + PeripheralType + 'static {
     /// Interrupt for this peripheral.
     type Interrupt: interrupt::typelevel::Interrupt;
+    /// Direct access to the register block.
+    #[cfg(feature = "unstable-pac")]
+    fn regs() -> pac::twim::Twim;
 }
 
 macro_rules! impl_twim {
     ($type:ident, $pac_type:ident, $irq:ident) => {
         impl crate::twim::SealedInstance for peripherals::$type {
+            #[cfg(not(feature = "unstable-pac"))]
             fn regs() -> pac::twim::Twim {
                 pac::$pac_type
             }
@@ -755,6 +760,10 @@ macro_rules! impl_twim {
         }
         impl crate::twim::Instance for peripherals::$type {
             type Interrupt = crate::interrupt::typelevel::$irq;
+            #[cfg(feature = "unstable-pac")]
+            fn regs() -> pac::twim::Twim {
+                pac::$pac_type
+            }
         }
     };
 }

--- a/embassy-nrf/src/twis.rs
+++ b/embassy-nrf/src/twis.rs
@@ -786,6 +786,7 @@ impl State {
 }
 
 pub(crate) trait SealedInstance {
+    #[cfg(not(feature = "unstable-pac"))]
     fn regs() -> pac::twis::Twis;
     fn state() -> &'static State;
 }
@@ -795,11 +796,15 @@ pub(crate) trait SealedInstance {
 pub trait Instance: SealedInstance + PeripheralType + 'static {
     /// Interrupt for this peripheral.
     type Interrupt: interrupt::typelevel::Interrupt;
+    /// Direct access to the register block.
+    #[cfg(feature = "unstable-pac")]
+    fn regs() -> pac::twis::Twis;
 }
 
 macro_rules! impl_twis {
     ($type:ident, $pac_type:ident, $irq:ident) => {
         impl crate::twis::SealedInstance for peripherals::$type {
+            #[cfg(not(feature = "unstable-pac"))]
             fn regs() -> pac::twis::Twis {
                 pac::$pac_type
             }
@@ -810,6 +815,10 @@ macro_rules! impl_twis {
         }
         impl crate::twis::Instance for peripherals::$type {
             type Interrupt = crate::interrupt::typelevel::$irq;
+            #[cfg(feature = "unstable-pac")]
+            fn regs() -> pac::twis::Twis {
+                pac::$pac_type
+            }
         }
     };
 }

--- a/embassy-nrf/src/uarte.rs
+++ b/embassy-nrf/src/uarte.rs
@@ -993,6 +993,7 @@ impl State {
 }
 
 pub(crate) trait SealedInstance {
+    #[cfg(not(feature = "unstable-pac"))]
     fn regs() -> pac::uarte::Uarte;
     fn state() -> &'static State;
     fn buffered_state() -> &'static crate::buffered_uarte::State;
@@ -1003,11 +1004,15 @@ pub(crate) trait SealedInstance {
 pub trait Instance: SealedInstance + PeripheralType + 'static + Send {
     /// Interrupt for this peripheral.
     type Interrupt: interrupt::typelevel::Interrupt;
+    /// Direct access to the register block.
+    #[cfg(feature = "unstable-pac")]
+    fn regs() -> pac::uarte::Uarte;
 }
 
 macro_rules! impl_uarte {
     ($type:ident, $pac_type:ident, $irq:ident) => {
         impl crate::uarte::SealedInstance for peripherals::$type {
+            #[cfg(not(feature = "unstable-pac"))]
             fn regs() -> pac::uarte::Uarte {
                 pac::$pac_type
             }
@@ -1022,6 +1027,10 @@ macro_rules! impl_uarte {
         }
         impl crate::uarte::Instance for peripherals::$type {
             type Interrupt = crate::interrupt::typelevel::$irq;
+            #[cfg(feature = "unstable-pac")]
+            fn regs() -> pac::uarte::Uarte {
+                pac::$pac_type
+            }
         }
     };
 }

--- a/embassy-nrf/src/usb/mod.rs
+++ b/embassy-nrf/src/usb/mod.rs
@@ -810,6 +810,7 @@ impl Allocator {
 }
 
 pub(crate) trait SealedInstance {
+    #[cfg(not(feature = "unstable-pac"))]
     fn regs() -> pac::usbd::Usbd;
 }
 
@@ -818,17 +819,25 @@ pub(crate) trait SealedInstance {
 pub trait Instance: SealedInstance + PeripheralType + 'static + Send {
     /// Interrupt for this peripheral.
     type Interrupt: interrupt::typelevel::Interrupt;
+    /// Direct access to the register block.
+    #[cfg(feature = "unstable-pac")]
+    fn regs() -> pac::usbd::Usbd;
 }
 
 macro_rules! impl_usb {
     ($type:ident, $pac_type:ident, $irq:ident) => {
         impl crate::usb::SealedInstance for peripherals::$type {
+            #[cfg(not(feature = "unstable-pac"))]
             fn regs() -> pac::usbd::Usbd {
                 pac::$pac_type
             }
         }
         impl crate::usb::Instance for peripherals::$type {
             type Interrupt = crate::interrupt::typelevel::$irq;
+            #[cfg(feature = "unstable-pac")]
+            fn regs() -> pac::usbd::Usbd {
+                pac::$pac_type
+            }
         }
     };
 }


### PR DESCRIPTION
This makes it easier to implement generic drivers externally. Mainly interested in timer but I did it for all of them.

Related: #2948