### PR TITLE
QEI Pin Pull Up/Down Constructor

### DIFF
--- a/embassy-stm32/CHANGELOG.md
+++ b/embassy-stm32/CHANGELOG.md
@@ -25,6 +25,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - feat: Add USB CRS sync support for STM32C071
 - fix: RTC register definition for STM32L4P5 and L4Q5 as they use v3 register map.
 - fix: Cut down the capabilities of the STM32L412 and L422 RTC as those are missing binary timer mode and underflow interrupt.
+- feat: Allow specifying internal pull up/down resistors on the QEI pins.
 
 ## 0.4.0 - 2025-08-26
 

--- a/embassy-stm32/src/timer/qei.rs
+++ b/embassy-stm32/src/timer/qei.rs
@@ -29,9 +29,14 @@ pub struct QeiPin<'d, T, Channel, #[cfg(afio)] A> {
 impl<'d, T: GeneralInstance4Channel, C: QeiChannel, #[cfg(afio)] A> if_afio!(QeiPin<'d, T, C, A>) {
     /// Create a new QEI pin instance.
     pub fn new(pin: Peri<'d, if_afio!(impl TimerPin<T, C, A>)>) -> Self {
+        Self::new_with_pull(pin, Pull::None)
+    }
+
+    /// Create a new QEI pin instance with a configured internal pull up/down resistor.
+    pub fn new_with_pull(pin: Peri<'d, if_afio!(impl TimerPin<T, C, A>)>, pull: Pull) -> Self {
         critical_section::with(|_| {
             pin.set_low();
-            set_as_af!(pin, AfType::input(Pull::None));
+            set_as_af!(pin, AfType::input(pull));
         });
         QeiPin {
             pin: pin.into(),

--- a/embassy-stm32/src/timer/qei.rs
+++ b/embassy-stm32/src/timer/qei.rs
@@ -35,7 +35,6 @@ impl<'d, T: GeneralInstance4Channel, C: QeiChannel, #[cfg(afio)] A> if_afio!(Qei
     /// Create a new QEI pin instance with a configured internal pull up/down resistor.
     pub fn new_with_pull(pin: Peri<'d, if_afio!(impl TimerPin<T, C, A>)>, pull: Pull) -> Self {
         critical_section::with(|_| {
-            pin.set_low();
             set_as_af!(pin, AfType::input(pull));
         });
         QeiPin {


### PR DESCRIPTION
Related to #3721, and contains an alternate solution to part of #3728

This breaks from the convention of other drivers a bit, where they would specify the pull value in a `Config` struct for the peripheral. That's how it's being done in #3728, though that PR needs a rebase on `main`, and the change is a bit more complicated.

If we prefer #3728, then we could rebase it (I gave it a quick try just now though it was a bit non-trivial), or we could re-implement it on the latest `main`, as things have changed quite a lot in the 6 months since that PR was opened.

I also removed the call to `pin.set_low()` in the `QeiPin` constructor. I'm a bit confused on why the `pin.set_low();` call was needed. I tested a rotary encoder without it, and the count doesn't seem to be affected. Is there some other reason the pins need to be set low on construction?