### PR TITLE
Allow configuring the pull up/down resistors and Qei mode for the Qei peripheral

### DIFF
--- a/embassy-stm32/CHANGELOG.md
+++ b/embassy-stm32/CHANGELOG.md
@@ -25,6 +25,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - feat: Add USB CRS sync support for STM32C071
 - fix: RTC register definition for STM32L4P5 and L4Q5 as they use v3 register map.
 - fix: Cut down the capabilities of the STM32L412 and L422 RTC as those are missing binary timer mode and underflow interrupt.
+- fix: Allow configuration of the internal pull up/down resistors on the pins for the Qei peripheral, as well as the Qei decoder mode.
 
 ## 0.4.0 - 2025-08-26
 

--- a/embassy-stm32/src/timer/qei.rs
+++ b/embassy-stm32/src/timer/qei.rs
@@ -88,15 +88,6 @@ impl<'d, T: GeneralInstance4Channel> Qei<'d, T> {
         tim: Peri<'d, T>,
         ch1: Peri<'d, if_afio!(impl TimerPin<T, CH1, A>)>,
         ch2: Peri<'d, if_afio!(impl TimerPin<T, CH2, A>)>,
-    ) -> Self {
-        Self::new_with_config(tim, ch1, ch2, Default::default())
-    }
-    /// Create a new quadrature decoder driver, with a given [`Config`].
-    #[allow(unused)]
-    pub fn new_with_config<CH1: QeiChannel, CH2: QeiChannel, #[cfg(afio)] A>(
-        tim: Peri<'d, T>,
-        ch1: Peri<'d, if_afio!(impl TimerPin<T, CH1, A>)>,
-        ch2: Peri<'d, if_afio!(impl TimerPin<T, CH2, A>)>,
         config: Config,
     ) -> Self {
         // Configure the pins to be used for the QEI peripheral.

--- a/embassy-stm32/src/timer/qei.rs
+++ b/embassy-stm32/src/timer/qei.rs
@@ -1,7 +1,5 @@
 //! Quadrature decoder using a timer.
 
-use core::marker::PhantomData;
-
 use stm32_metapac::timer::vals;
 
 use super::low_level::Timer;
@@ -17,27 +15,6 @@ pub enum Direction {
     Upcounting,
     /// Counting down.
     Downcounting,
-}
-
-/// Wrapper for using a pin with QEI.
-pub struct QeiPin<'d, T, Channel, #[cfg(afio)] A> {
-    #[allow(unused)]
-    pin: Peri<'d, AnyPin>,
-    phantom: PhantomData<if_afio!((T, Channel, A))>,
-}
-
-impl<'d, T: GeneralInstance4Channel, C: QeiChannel, #[cfg(afio)] A> if_afio!(QeiPin<'d, T, C, A>) {
-    /// Create a new QEI pin instance.
-    pub fn new(pin: Peri<'d, if_afio!(impl TimerPin<T, C, A>)>) -> Self {
-        critical_section::with(|_| {
-            pin.set_low();
-            set_as_af!(pin, AfType::input(Pull::None));
-        });
-        QeiPin {
-            pin: pin.into(),
-            phantom: PhantomData,
-        }
-    }
 }
 
 trait SealedQeiChannel: TimerChannel {}

--- a/tests/stm32/src/bin/afio.rs
+++ b/tests/stm32/src/bin/afio.rs
@@ -12,8 +12,9 @@ use embassy_stm32::time::khz;
 use embassy_stm32::timer::complementary_pwm::{ComplementaryPwm, ComplementaryPwmPin};
 use embassy_stm32::timer::input_capture::{CapturePin, InputCapture};
 use embassy_stm32::timer::pwm_input::PwmInput;
-use embassy_stm32::timer::qei::{Qei, QeiPin};
+use embassy_stm32::timer::qei::Qei;
 use embassy_stm32::timer::simple_pwm::{PwmPin, SimplePwm};
+use embassy_stm32::timer::{Ch1, Ch2};
 use embassy_stm32::usart::{Uart, UartRx, UartTx};
 use embassy_stm32::{bind_interrupts, Peripherals};
 
@@ -258,7 +259,12 @@ async fn main(_spawner: Spawner) {
     {
         // partial remap
         reset_afio_registers();
-        Qei::new::<AfioRemap<1>>(p.TIM1.reborrow(), p.PA8.reborrow(), p.PA9.reborrow());
+        Qei::new::<Ch1, Ch2, AfioRemap<1>>(
+            p.TIM1.reborrow(),
+            p.PA8.reborrow(),
+            p.PA9.reborrow(),
+            Default::default(),
+        );
         defmt::assert_eq!(AFIO.mapr().read().tim1_remap(), 1);
     }
 

--- a/tests/stm32/src/bin/afio.rs
+++ b/tests/stm32/src/bin/afio.rs
@@ -260,8 +260,8 @@ async fn main(_spawner: Spawner) {
         reset_afio_registers();
         Qei::new::<AfioRemap<1>>(
             p.TIM1.reborrow(),
-            QeiPin::new(p.PA8.reborrow()),
-            QeiPin::new(p.PA9.reborrow()),
+            p.PA8.reborrow(),
+            p.PA9.reborrow(),
         );
         defmt::assert_eq!(AFIO.mapr().read().tim1_remap(), 1);
     }

--- a/tests/stm32/src/bin/afio.rs
+++ b/tests/stm32/src/bin/afio.rs
@@ -258,11 +258,7 @@ async fn main(_spawner: Spawner) {
     {
         // partial remap
         reset_afio_registers();
-        Qei::new::<AfioRemap<1>>(
-            p.TIM1.reborrow(),
-            p.PA8.reborrow(),
-            p.PA9.reborrow(),
-        );
+        Qei::new::<AfioRemap<1>>(p.TIM1.reborrow(), p.PA8.reborrow(), p.PA9.reborrow());
         defmt::assert_eq!(AFIO.mapr().read().tim1_remap(), 1);
     }
 


### PR DESCRIPTION
This is basically #3728 (thanks to [leehambley](https://github.com/leehambley) for getting it started) but with individually configurable pulls for each encoder channel, and based on a more recent embassy commit.

Related to #3721