### PR TITLE
[mspm0] fix open-drain config

### DIFF
--- a/embassy-mspm0/CHANGELOG.md
+++ b/embassy-mspm0/CHANGELOG.md
@@ -13,3 +13,4 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - feat: Add window watchdog implementation based on WWDT0, WWDT1 peripherals (#4574)
 - feat: Add MSPM0C1105/C1106 support
 - feat: Add adc implementation (#4646)
+- fix: gpio OutputOpenDrain config (#4735)

--- a/embassy-mspm0/src/gpio.rs
+++ b/embassy-mspm0/src/gpio.rs
@@ -156,7 +156,12 @@ impl<'d> Flex<'d> {
             w.set_pf(GPIO_PF);
             w.set_hiz1(true);
             w.set_pc(true);
-            w.set_inena(false);
+            w.set_inena(true);
+        });
+
+        // Enable output driver (DOE) - required for open-drain to drive low
+        self.pin.block().doeset31_0().write(|w| {
+            w.set_dio(self.pin.bit_index(), true);
         });
 
         self.set_pull(Pull::None);


### PR DESCRIPTION
## Fix GPIO OutputOpenDrain: Enable input buffer and output driver

### Problem
`OutputOpenDrain` pins always read as `LOW` even after `set_high()`.

(You can reproduce this by reverting e84f90178099a8326413ff39176d8e2d2b372dd6 and then running `cargo run --bin gpio_mode` on an MSPM0L1306 launchpad)

**Root causes:**
1. Input buffer (`INENA`) was disabled, preventing reads
2. Output driver (`DOE`) was not enabled, preventing active pull-down

### Solution
Modified `Flex::set_as_input_output()` in `gpio.rs`:

**1. Enable input buffer** (line 159):
```rust
pincm.modify(|w| {
    w.set_pf(GPIO_PF);
    w.set_hiz1(true);
    w.set_pc(true);
    w.set_inena(true); // Changed from false
});
```

**2. Enable output driver** (lines 162-165):
```rust
// Enable output driver (DOE) - required for open-drain to drive low
self.pin.block().doeset31_0().write(|w| {
    w.set_dio(self.pin.bit_index(), true);
});
```

### How open-drain works with this config (I think?)
- `HIZ1=true` + `INENA=true` + `DOE=true`
- When `DOUT=0` (set_low): Pin actively drives LOW
- When `DOUT=1` (set_high): `HIZ1` overrides output, pin floats (high-impedance)

### Testing
Tested on LP-MSPM0L1306:
```
❯ cargo run --bin gpio_mode
   Compiling embassy-mspm0-l1306-examples v0.1.0 (/Users/charlesguan/Development/embassy/examples/mspm0l1306)
    Finished `dev` profile [optimized + debuginfo] target(s) in 0.63s
     Running `probe-rs run --chip MSPM0L1306 --protocol=swd target/thumbv6m-none-eabi/debug/gpio_mode`
      Erasing ✔ 100% [####################]  17.00 KiB @  14.50 KiB/s (took 1s)
  Programming ✔ 100% [####################]  16.75 KiB @   3.41 KiB/s (took 5s)
                                                                                                 ...

=== Test 2: OutputOpenDrain + External Pull-up === (gpio_mode src/bin/gpio_mode.rs:36)
[INFO ] Hardware: PA0 connected to 3.3V via pull-up resistor (J9) (gpio_mode src/bin/gpio_mode.rs:37)
[INFO ] Initial (Low): is_high=false, get_level=Low, is_set_high=false (gpio_mode src/bin/gpio_mode.rs:40)
[INFO ] After set_high(): is_high=true, get_level=High, is_set_high=true (gpio_mode src/bin/gpio_mode.rs:49)
[INFO ] After set_low(): is_high=false, get_level=Low, is_set_low=true (gpio_mode src/bin/gpio_mode.rs:58)
[INFO ] After toggle(): is_high=true, get_level=High (gpio_mode src/bin/gpio_mode.rs:67)
[INFO ] 
```

I can also test on LP-MSPM0G3507 if helpful; also not sure if the `gpio_mode.rs` example is any-use, can remove it from the actual PR?