### PR TITLE
nrf: apply FICR.TRIMCNF values

### DIFF
--- a/embassy-nrf/CHANGELOG.md
+++ b/embassy-nrf/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 <!-- next-header -->
 ## Unreleased - ReleaseDate
+- changed: apply trimming values from FICR.TRIMCNF on nrf53/54l
 
 ## 0.8.0 - 2025-09-30
 

--- a/embassy-nrf/src/chips/nrf54l15_app.rs
+++ b/embassy-nrf/src/chips/nrf54l15_app.rs
@@ -94,6 +94,7 @@ pub mod pac {
     #[cfg(feature = "_s")]
     #[doc(no_inline)]
     pub use nrf_pac::{
+        FICR_NS as FICR,
         SICR_S as SICR,
         ICACHEDATA_S as ICACHEDATA,
         ICACHEINFO_S as ICACHEINFO,

--- a/embassy-nrf/src/lib.rs
+++ b/embassy-nrf/src/lib.rs
@@ -406,9 +406,10 @@ pub mod config {
     /// Settings for the internal capacitors.
     #[cfg(feature = "nrf5340-app-s")]
     pub struct InternalCapacitors {
-        /// Config for the internal capacitors on pins XC1 and XC2.
+        /// Config for the internal capacitors on pins XC1 and XC2. Pass `None` to not touch it.
         pub hfxo: Option<HfxoCapacitance>,
-        /// Config for the internal capacitors between pins XL1 and XL2.
+        /// Config for the internal capacitors between pins XL1 and XL2. Pass `None` to not touch
+        /// it.
         pub lfxo: Option<LfxoCapacitance>,
     }
 
@@ -416,6 +417,8 @@ pub mod config {
     #[cfg(feature = "nrf5340-app-s")]
     #[derive(Copy, Clone)]
     pub enum HfxoCapacitance {
+        /// Use external capacitors
+        External,
         /// 7.0 pF
         _7_0pF,
         /// 7.5 pF
@@ -475,8 +478,9 @@ pub mod config {
     #[cfg(feature = "nrf5340-app-s")]
     impl HfxoCapacitance {
         /// The capacitance value times two.
-        pub(crate) const fn value2(self) -> i32 {
+        pub(crate) fn value2(self) -> i32 {
             match self {
+                HfxoCapacitance::External => unreachable!(),
                 HfxoCapacitance::_7_0pF => 14,
                 HfxoCapacitance::_7_5pF => 15,
                 HfxoCapacitance::_8_0pF => 16,
@@ -506,11 +510,17 @@ pub mod config {
                 HfxoCapacitance::_20_0pF => 40,
             }
         }
+
+        pub(crate) fn external(self) -> bool {
+            matches!(self, Self::External)
+        }
     }
 
     /// Internal capacitance value for the LFXO.
     #[cfg(feature = "nrf5340-app-s")]
     pub enum LfxoCapacitance {
+        /// Use external capacitors
+        External = 0,
         /// 6 pF
         _6pF = 1,
         /// 7 pF
@@ -523,6 +533,7 @@ pub mod config {
     impl From<LfxoCapacitance> for super::pac::oscillators::vals::Intcap {
         fn from(t: LfxoCapacitance) -> Self {
             match t {
+                LfxoCapacitance::External => Self::EXTERNAL,
                 LfxoCapacitance::_6pF => Self::C6PF,
                 LfxoCapacitance::_7pF => Self::C7PF,
                 LfxoCapacitance::_9pF => Self::C9PF,
@@ -717,6 +728,29 @@ pub fn init(config: config::Config) -> Peripherals {
                 let _ = uicr_write(consts::UICR_HFXOCNT, 32);
             }
             needs_reset = true;
+        }
+    }
+
+    // Apply trimming values from the FICR.
+    #[cfg(any(
+        all(feature = "_nrf5340-app", feature = "_s"),
+        all(feature = "_nrf54l", feature = "_s"),
+        feature = "_nrf5340-net",
+    ))]
+    {
+        #[cfg(feature = "_nrf5340")]
+        let n = 32;
+        #[cfg(feature = "_nrf54l")]
+        let n = 64;
+        for i in 0..n {
+            let info = pac::FICR.trimcnf(i);
+            let addr = info.addr().read();
+            if addr == 0 || addr == 0xFFFF_FFFF {
+                break;
+            }
+            unsafe {
+                (addr as *mut u32).write_volatile(info.data().read());
+            }
         }
     }
 
@@ -953,17 +987,21 @@ pub fn init(config: config::Config) -> Peripherals {
     #[cfg(feature = "nrf5340-app-s")]
     {
         if let Some(cap) = config.internal_capacitors.hfxo {
-            let mut slope = pac::FICR.xosc32mtrim().read().slope() as i32;
-            let offset = pac::FICR.xosc32mtrim().read().offset() as i32;
-            // slope is a signed 5-bit integer
-            if slope >= 16 {
-                slope -= 32;
+            if cap.external() {
+                pac::OSCILLATORS.xosc32mcaps().write(|w| w.set_enable(false));
+            } else {
+                let mut slope = pac::FICR.xosc32mtrim().read().slope() as i32;
+                let offset = pac::FICR.xosc32mtrim().read().offset() as i32;
+                // slope is a signed 5-bit integer
+                if slope >= 16 {
+                    slope -= 32;
+                }
+                let capvalue = (((slope + 56) * (cap.value2() - 14)) + ((offset - 8) << 4) + 32) >> 6;
+                pac::OSCILLATORS.xosc32mcaps().write(|w| {
+                    w.set_capvalue(capvalue as u8);
+                    w.set_enable(true);
+                });
             }
-            let capvalue = (((slope + 56) * (cap.value2() - 14)) + ((offset - 8) << 4) + 32) >> 6;
-            pac::OSCILLATORS.xosc32mcaps().write(|w| {
-                w.set_capvalue(capvalue as u8);
-                w.set_enable(true);
-            });
         }
         if let Some(cap) = config.internal_capacitors.lfxo {
             pac::OSCILLATORS.xosc32ki().intcap().write(|w| w.set_intcap(cap.into()));

--- a/examples/nrf5340/src/bin/nrf5340dk_internal_caps.rs
+++ b/examples/nrf5340/src/bin/nrf5340dk_internal_caps.rs
@@ -1,0 +1,30 @@
+#![no_std]
+#![no_main]
+
+use defmt::info;
+use embassy_executor::Spawner;
+use embassy_nrf::config::{Config, HfclkSource, LfclkSource, LfxoCapacitance};
+use embassy_nrf::pac;
+use {defmt_rtt as _, panic_probe as _};
+
+fn print_xosc32mcaps() {
+    let value = pac::OSCILLATORS.xosc32mcaps().read();
+    info!("XOSC32MCAPS.ENABLE = {}", value.enable());
+    info!("XOSC32MCAPS.CAPVALUE = {}", value.capvalue());
+}
+
+#[embassy_executor::main]
+async fn main(_spawner: Spawner) {
+    info!("Before init:");
+    print_xosc32mcaps();
+
+    let mut config = Config::default();
+    config.hfclk_source = HfclkSource::Internal;
+    config.lfclk_source = LfclkSource::ExternalXtal;
+    config.internal_capacitors.hfxo = None; // keep the value from the FICR
+    config.internal_capacitors.lfxo = Some(LfxoCapacitance::_7pF);
+    let _p = embassy_nrf::init(config);
+
+    info!("After init:");
+    print_xosc32mcaps();
+}


### PR DESCRIPTION
Apparently, this is the way to set the internal HFXO capacitor value for the nrf5340dk. I also see it setting various undocumented registers for SAADC, COMP, TEMP, RADIO, etc.

Does the same thing as https://github.com/zephyrproject-rtos/hal_nordic/blob/2c0fd06a98bb9b89ac234b75b2c217742f0df1ba/nrfx/mdk/system_nrf5340_application.c#L97-L109.

Also adds the option to explicitly disable internal capacitors to override the TRIMCNF values.