### PR TITLE
Initial implementation of embedded_nal_async for UnconnectedUdp.

### DIFF
--- a/embassy-net/src/udp.rs
+++ b/embassy-net/src/udp.rs
@@ -593,6 +593,7 @@ impl core::fmt::Display for RecvError {
 impl core::error::Error for RecvError {}
 
 pub mod socket {
+    use core::error::Error;
     use core::net::SocketAddr;
     use embedded_nal_async::UnconnectedUdp;
     use super::*;
@@ -622,6 +623,14 @@ pub mod socket {
     pub enum UnconnectedUdpError {
         SendError(SendError),
         RecvError(RecvError),
+    }
+
+    impl Error for UnconnectedUdpError {}
+
+    impl core::fmt::Display for UnconnectedUdpError {
+        fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+            core::fmt::Debug::fmt(self, f)
+        }
     }
 }
 

--- a/embassy-net/src/udp.rs
+++ b/embassy-net/src/udp.rs
@@ -10,6 +10,7 @@ use xarxa::socket::udp;
 pub use xarxa::socket::udp::PacketMetadata;
 use xarxa::wire::IpListenEndpoint;
 
+
 use crate::{IpAddress, IpEndpoint, Stack, TryError};
 
 /// Metadata for a sent or received UDP packet.
@@ -101,6 +102,8 @@ pub enum RecvError {
 pub struct UdpSocket<'a> {
     stack: Stack<'a>,
     handle: SocketHandle,
+
+    bind_endpoint: Option<IpListenEndpoint>,
 }
 
 impl<'a> UdpSocket<'a> {
@@ -123,7 +126,7 @@ impl<'a> UdpSocket<'a> {
             ))
         });
 
-        Self { stack, handle }
+        Self { stack, handle, bind_endpoint: None }
     }
 
     /// Bind the socket to a local endpoint.
@@ -588,3 +591,61 @@ impl core::fmt::Display for RecvError {
     }
 }
 impl core::error::Error for RecvError {}
+
+pub mod socket {
+    use core::net::SocketAddr;
+    use embedded_nal_async::UnconnectedUdp;
+    use super::*;
+
+        impl<'a> UnconnectedUdp for UdpSocket<'a> {
+        type Error = UnconnectedUdpError;
+
+        async fn send(&mut self, local: SocketAddr, remote: SocketAddr, data: &[u8]) -> Result<(), Self::Error> {
+            self.send_to(data, remote).await
+                .map_err(UnconnectedUdpError::SendError)
+        }
+
+        async fn receive_into(&mut self, buffer: &mut [u8]) -> Result<(usize, SocketAddr, SocketAddr), Self::Error> {
+            self.recv_from(buffer).await
+                .map(|(size, meta)| {
+                    // Safety: 'reciving' always has local_address, can't receive without being bound.
+                    let local_socket_address: SocketAddr = SocketAddr::new(meta.local_address.unwrap().into(), self.bind_endpoint.unwrap().port);
+                    let remote_socket_address: SocketAddr = SocketAddr::new(meta.endpoint.addr.into(), meta.endpoint.port);
+                    (size, local_socket_address, remote_socket_address)
+                })
+                .map_err(UnconnectedUdpError::RecvError)
+        }
+    }
+
+    #[derive(PartialEq, Eq, Clone, Copy, Debug)]
+    #[cfg_attr(feature = "defmt", derive(defmt::Format))]
+    pub enum UnconnectedUdpError {
+        SendError(SendError),
+        RecvError(RecvError),
+    }
+}
+
+mod embedded_io_impls {
+    use embedded_io_async::ErrorKind;
+    use crate::udp::{RecvError, SendError};
+    use crate::udp::socket::UnconnectedUdpError;
+
+    impl embedded_io_async::Error for UnconnectedUdpError {
+        fn kind(&self) -> ErrorKind {
+            match self {
+                UnconnectedUdpError::SendError(send_error) => {
+                    match send_error {
+                        SendError::NoRoute => ErrorKind::NotFound,
+                        SendError::SocketNotBound => ErrorKind::Other,
+                        SendError::PacketTooLarge => ErrorKind::Other,
+                    }
+                }
+                UnconnectedUdpError::RecvError(receive_error) => {
+                    match receive_error {
+                        RecvError::Truncated => ErrorKind::BrokenPipe
+                    }
+                }
+            }
+        }
+    }
+}

--- a/embassy-net/src/udp.rs
+++ b/embassy-net/src/udp.rs
@@ -10,7 +10,6 @@ use xarxa::socket::udp;
 pub use xarxa::socket::udp::PacketMetadata;
 use xarxa::wire::IpListenEndpoint;
 
-
 use crate::{IpAddress, IpEndpoint, Stack, TryError};
 
 /// Metadata for a sent or received UDP packet.
@@ -126,7 +125,11 @@ impl<'a> UdpSocket<'a> {
             ))
         });
 
-        Self { stack, handle, bind_endpoint: None }
+        Self {
+            stack,
+            handle,
+            bind_endpoint: None,
+        }
     }
 
     /// Bind the socket to a local endpoint.
@@ -595,23 +598,27 @@ impl core::error::Error for RecvError {}
 pub mod socket {
     use core::error::Error;
     use core::net::SocketAddr;
+
     use embedded_nal_async::UnconnectedUdp;
+
     use super::*;
 
-        impl<'a> UnconnectedUdp for UdpSocket<'a> {
+    impl<'a> UnconnectedUdp for UdpSocket<'a> {
         type Error = UnconnectedUdpError;
 
         async fn send(&mut self, local: SocketAddr, remote: SocketAddr, data: &[u8]) -> Result<(), Self::Error> {
-            self.send_to(data, remote).await
-                .map_err(UnconnectedUdpError::SendError)
+            self.send_to(data, remote).await.map_err(UnconnectedUdpError::SendError)
         }
 
         async fn receive_into(&mut self, buffer: &mut [u8]) -> Result<(usize, SocketAddr, SocketAddr), Self::Error> {
-            self.recv_from(buffer).await
+            self.recv_from(buffer)
+                .await
                 .map(|(size, meta)| {
                     // Safety: 'reciving' always has local_address, can't receive without being bound.
-                    let local_socket_address: SocketAddr = SocketAddr::new(meta.local_address.unwrap().into(), self.bind_endpoint.unwrap().port);
-                    let remote_socket_address: SocketAddr = SocketAddr::new(meta.endpoint.addr.into(), meta.endpoint.port);
+                    let local_socket_address: SocketAddr =
+                        SocketAddr::new(meta.local_address.unwrap().into(), self.bind_endpoint.unwrap().port);
+                    let remote_socket_address: SocketAddr =
+                        SocketAddr::new(meta.endpoint.addr.into(), meta.endpoint.port);
                     (size, local_socket_address, remote_socket_address)
                 })
                 .map_err(UnconnectedUdpError::RecvError)
@@ -636,24 +643,21 @@ pub mod socket {
 
 mod embedded_io_impls {
     use embedded_io_async::ErrorKind;
-    use crate::udp::{RecvError, SendError};
+
     use crate::udp::socket::UnconnectedUdpError;
+    use crate::udp::{RecvError, SendError};
 
     impl embedded_io_async::Error for UnconnectedUdpError {
         fn kind(&self) -> ErrorKind {
             match self {
-                UnconnectedUdpError::SendError(send_error) => {
-                    match send_error {
-                        SendError::NoRoute => ErrorKind::NotFound,
-                        SendError::SocketNotBound => ErrorKind::Other,
-                        SendError::PacketTooLarge => ErrorKind::Other,
-                    }
-                }
-                UnconnectedUdpError::RecvError(receive_error) => {
-                    match receive_error {
-                        RecvError::Truncated => ErrorKind::BrokenPipe
-                    }
-                }
+                UnconnectedUdpError::SendError(send_error) => match send_error {
+                    SendError::NoRoute => ErrorKind::NotFound,
+                    SendError::SocketNotBound => ErrorKind::Other,
+                    SendError::PacketTooLarge => ErrorKind::Other,
+                },
+                UnconnectedUdpError::RecvError(receive_error) => match receive_error {
+                    RecvError::Truncated => ErrorKind::BrokenPipe,
+                },
             }
         }
     }

--- a/embassy-net/src/udp.rs
+++ b/embassy-net/src/udp.rs
@@ -606,7 +606,11 @@ pub mod socket {
     impl<'a> UnconnectedUdp for UdpSocket<'a> {
         type Error = UnconnectedUdpError;
 
-        async fn send(&mut self, local: SocketAddr, remote: SocketAddr, data: &[u8]) -> Result<(), Self::Error> {
+        async fn send(&mut self, _local: SocketAddr, remote: SocketAddr, data: &[u8]) -> Result<(), Self::Error> {
+            let remote: IpEndpoint = match remote {
+                SocketAddr::V4(v4) => v4.into(),
+                SocketAddr::V6(v6) => v6.into(),
+            };
             self.send_to(data, remote).await.map_err(UnconnectedUdpError::SendError)
         }
 

--- a/embassy-net/src/udp.rs
+++ b/embassy-net/src/udp.rs
@@ -609,8 +609,15 @@ pub mod socket {
 
         async fn send(&mut self, _local: SocketAddr, remote: SocketAddr, data: &[u8]) -> Result<(), Self::Error> {
             let remote: IpEndpoint = match remote {
+                #[cfg(feature = "proto-ipv4")]
                 SocketAddr::V4(v4) => v4.into(),
+                #[cfg(not(feature = "proto-ipv4"))]
+                SocketAddr::V4(_) => return Err(UnconnectedUdpError::SendError(SendError::NoRoute)),
+
+                #[cfg(feature = "proto-ipv6")]
                 SocketAddr::V6(v6) => v6.into(),
+                #[cfg(not(feature = "proto-ipv6"))]
+                SocketAddr::V6(_) => return Err(UnconnectedUdpError::SendError(SendError::NoRoute)),
             };
             self.send_to(data, remote).await.map_err(UnconnectedUdpError::SendError)
         }

--- a/embassy-net/src/udp.rs
+++ b/embassy-net/src/udp.rs
@@ -595,6 +595,7 @@ impl core::fmt::Display for RecvError {
 }
 impl core::error::Error for RecvError {}
 
+/// `embedded-nal-async` compatibility.
 pub mod socket {
     use core::error::Error;
     use core::net::SocketAddr;
@@ -629,10 +630,13 @@ pub mod socket {
         }
     }
 
+    /// Error returned by [`UnconnectedUdp`] operations.
     #[derive(PartialEq, Eq, Clone, Copy, Debug)]
     #[cfg_attr(feature = "defmt", derive(defmt::Format))]
     pub enum UnconnectedUdpError {
+        /// An error occurred while sending.
         SendError(SendError),
+        /// An error occurred while receiving.
         RecvError(RecvError),
     }
 

--- a/examples/stm32h7/Cargo.toml
+++ b/examples/stm32h7/Cargo.toml
@@ -12,7 +12,7 @@ embassy-sync = { version = "0.7.2", path = "../../embassy-sync", features = ["de
 embassy-embedded-hal = { version = "0.5.0", path = "../../embassy-embedded-hal" }
 embassy-executor = { version = "0.9.0", path = "../../embassy-executor", features = ["arch-cortex-m", "executor-thread", "executor-interrupt", "defmt"] }
 embassy-time = { version = "0.5.0", path = "../../embassy-time", features = ["defmt", "defmt-timestamp-uptime", "tick-hz-32_768"] }
-embassy-net = { version = "0.7.1", path = "../../embassy-net", features = ["defmt", "tcp", "dhcpv4", "medium-ethernet", "proto-ipv6", "dns"] }
+embassy-net = { version = "0.7.1", path = "../../embassy-net", features = ["defmt", "tcp", "udp", "dhcpv4", "medium-ethernet", "proto-ipv6", "dns"] }
 embassy-usb = { version = "0.5.1", path = "../../embassy-usb", features = ["defmt"] }
 embassy-futures = { version = "0.1.2", path = "../../embassy-futures" }
 

--- a/examples/stm32h7/Cargo.toml
+++ b/examples/stm32h7/Cargo.toml
@@ -12,7 +12,7 @@ embassy-sync = { version = "0.8.0", path = "../../embassy-sync", features = ["de
 embassy-embedded-hal = { version = "0.6.0", path = "../../embassy-embedded-hal" }
 embassy-executor = { version = "0.10.0", path = "../../embassy-executor", features = ["platform-cortex-m", "executor-thread", "executor-interrupt", "defmt"] }
 embassy-time = { version = "0.5.1", path = "../../embassy-time", features = ["defmt", "defmt-timestamp-uptime", "tick-hz-32_768"] }
-embassy-net = { version = "0.9.1", path = "../../embassy-net", features = ["defmt", "tcp", "dhcpv4", "medium-ethernet", "proto-ipv6", "dns"] }
+embassy-net = { version = "0.9.1", path = "../../embassy-net", features = ["defmt", "tcp", "udp", "dhcpv4", "medium-ethernet", "proto-ipv6", "dns"] }
 embassy-usb = { version = "0.6.0", path = "../../embassy-usb", features = ["defmt"] }
 embassy-futures = { version = "0.1.2", path = "../../embassy-futures" }
 cyw43 = { version = "0.7.0", path = "../../cyw43", features = ["defmt"] }

--- a/examples/stm32h7/src/bin/eth_client.rs
+++ b/examples/stm32h7/src/bin/eth_client.rs
@@ -1,12 +1,11 @@
 #![no_std]
 #![no_main]
 
-use embassy_net::udp::{PacketMetadata, UdpSocket};
 use core::net::{Ipv4Addr, SocketAddr, SocketAddrV4};
-
 use defmt::*;
 use embassy_executor::Spawner;
-use embassy_net::StackResources;
+use embassy_net::{Stack, StackResources};
+use embassy_net::udp::{PacketMetadata, UdpSocket};
 use embassy_net::tcp::client::{TcpClient, TcpClientState};
 use embassy_stm32::eth::{Ethernet, GenericPhy, PacketQueue};
 use embassy_stm32::peripherals::ETH;
@@ -18,6 +17,16 @@ use embedded_nal_async::{TcpConnect, UnconnectedUdp};
 use static_cell::StaticCell;
 use {defmt_rtt as _, panic_probe as _};
 use embassy_net::udp::socket::UnconnectedUdpError;
+use embassy_sync::blocking_mutex::raw::ThreadModeRawMutex;
+use embassy_sync::mutex::Mutex;
+
+enum TcpState {
+    Connecting,
+    Connected,
+}
+
+type MessageType = Mutex<ThreadModeRawMutex, Option<TcpState>>;
+static MESSAGE: MessageType = Mutex::new(None);
 
 bind_interrupts!(struct Irqs {
     ETH => eth::InterruptHandler;
@@ -87,9 +96,9 @@ async fn main(spawner: Spawner) -> ! {
 
     let config = embassy_net::Config::dhcpv4(Default::default());
     //let config = embassy_net::Config::ipv4_static(embassy_net::StaticConfigV4 {
-    //    address: Ipv4Cidr::new(Ipv4Address::new(10, 42, 0, 61), 24),
+    //    address: Ipv4Cidr::new(Ipv4Address::new(192, 168, 18, 64), 24),
     //    dns_servers: Vec::new(),
-    //    gateway: Some(Ipv4Address::new(10, 42, 0, 1)),
+    //    gateway: Some(Ipv4Address::new(192, 168, 18, 1)),
     //});
 
     // Init network stack
@@ -105,6 +114,53 @@ async fn main(spawner: Spawner) -> ! {
 
     info!("Network task initialized");
 
+    let state: TcpClientState<1, 1024, 1024> = TcpClientState::new();
+    let client = TcpClient::new(stack, &state);
+
+    let local_socket_address: SocketAddr = SocketAddrV4::new(config_v4.address.address().into(), 8001).into();
+    info!("udp local address: {}", local_socket_address);
+    let broadcast_socket_address: SocketAddr = SocketAddrV4::new(config_v4.address.broadcast().unwrap().into(), 8001).into();
+    info!("udp broadcast address: {}", broadcast_socket_address);
+
+    // You need to start a server on the host machine, for example: `nc -b -l 8001`
+    let udp_address = SocketAddr::V4(SocketAddrV4::new(Ipv4Addr::new(192, 168, 18, 41), 8001));
+
+    // You need to start a server on the host machine, for example: `nc -l 8000`
+    let tcp_address = SocketAddr::V4(SocketAddrV4::new(Ipv4Addr::new(192, 168, 18, 41), 8000));
+    
+    spawner.spawn(unwrap!(broadcast_task(stack, local_socket_address, broadcast_socket_address, udp_address, &MESSAGE)));
+
+    loop {
+        info!("connecting...");
+        {
+            *(MESSAGE.lock().await) = Some(TcpState::Connecting);
+        }
+        let r = client.connect(tcp_address).await;
+        if let Err(e) = r {
+            info!("tcp connect error: {:?}", e);
+            Timer::after_secs(1).await;
+            continue;
+        }
+
+        let mut connection = r.unwrap();
+        info!("tcp connected!");
+        {
+            *(MESSAGE.lock().await) = Some(TcpState::Connected);
+        }
+
+        loop {
+            let r = connection.write_all(b"Hello\n").await;
+            if let Err(e) = r {
+                info!("tcp write error: {:?}", e);
+                break;
+            }
+            Timer::after_secs(1).await;
+        }
+    }
+}
+
+#[embassy_executor::task]
+async fn broadcast_task(stack: Stack<'static>, local_socket_address: SocketAddr, broadcast_socket_address: SocketAddr, udp_address: SocketAddr, message: &'static MessageType) -> ! {
 
     let mut rx_meta = [PacketMetadata::EMPTY; 16];
     let mut rx_buffer = [0; 4096];
@@ -114,50 +170,28 @@ async fn main(spawner: Spawner) -> ! {
     let mut socket = UdpSocket::new(stack, &mut rx_meta, &mut rx_buffer, &mut tx_meta, &mut tx_buffer);
     socket.bind(8001).unwrap();
 
-    let local_socket_address: SocketAddr = SocketAddrV4::new(config_v4.address.address().into(), 8001).into();
-    info!("udp local address: {}", local_socket_address);
-    let broadcast_socket_address: SocketAddr = SocketAddrV4::new(config_v4.address.broadcast().unwrap().into(), 8001).into();
-    info!("udp broadcast address: {}", broadcast_socket_address);
-
-    let state: TcpClientState<1, 1024, 1024> = TcpClientState::new();
-    let client = TcpClient::new(stack, &state);
-
     loop {
-        // You need to start a server on the host machine, for example: `nc -l 8000`
-        let addr = SocketAddr::V4(SocketAddrV4::new(Ipv4Addr::new(192, 168, 18, 41), 8000));
+        let mut message_unlocked = message.lock().await;
+        if let Some(message_ref) = message_unlocked.as_mut() {
 
-        // You need to start a server on the host machine, for example: `nc -b -l 8001`
-        let udp_addr = SocketAddr::V4(SocketAddrV4::new(Ipv4Addr::new(192, 168, 18, 41), 8001));
-
-        info!("connecting...");
-
-        let r = socket.send(local_socket_address, broadcast_socket_address, b"Broadcast UDP\n").await;
-        if let Err(e) = r {
-            info!("udp broadcast error: {:?}", e);
-        }
-
-
-        let r = client.connect(addr).await;
-        if let Err(e) = r {
-            info!("tcp connect error: {:?}", e);
-            Timer::after_secs(1).await;
-            continue;
-        }
-        let mut connection = r.unwrap();
-        info!("tcp connected!");
-        loop {
-
-            let r = socket.send(local_socket_address, udp_addr, b"Hello UDP\n").await;
-            if let Err(e) = r {
-                info!("udp write error: {:?}", e);
+            match message_ref {
+                TcpState::Connecting => {
+                    let r = socket.send(local_socket_address, broadcast_socket_address, b"UDP: Waiting for TCP connect\n").await;
+                    if let Err(e) = r {
+                        info!("udp broadcast error: {:?}", e);
+                    }
+                }
+                TcpState::Connected => {
+                    let r = socket.send(local_socket_address, udp_address, b"UDP: TCP connection OK\n").await;
+                    if let Err(e) = r {
+                        info!("udp write error: {:?}", e);
+                    }
+                }
             }
-
-            let r = connection.write_all(b"Hello\n").await;
-            if let Err(e) = r {
-                info!("tcp write error: {:?}", e);
-                break;
-            }
-            Timer::after_secs(1).await;
         }
+        // release the mutex
+        drop(message_unlocked);
+
+        Timer::after_secs(1).await;
     }
 }

--- a/examples/stm32h7/src/bin/eth_client.rs
+++ b/examples/stm32h7/src/bin/eth_client.rs
@@ -117,9 +117,6 @@ async fn main(spawner: Spawner) -> ! {
 
     info!("Network task initialized");
 
-    let state: TcpClientState<1, 1024, 1024> = TcpClientState::new();
-    let client = TcpClient::new(stack, &state);
-
     let local_socket_address: SocketAddr = SocketAddrV4::new(config_v4.address.address().into(), 8001).into();
     info!("udp local address: {}", local_socket_address);
     let broadcast_socket_address: SocketAddr = SocketAddrV4::new(config_v4.address.broadcast().unwrap().into(), 8001).into();
@@ -132,11 +129,23 @@ async fn main(spawner: Spawner) -> ! {
     let tcp_address = SocketAddr::V4(SocketAddrV4::new(Ipv4Addr::new(192, 168, 18, 41), 8000));
 
     spawner.spawn(unwrap!(broadcast_task(stack, local_socket_address, broadcast_socket_address, udp_address, &MESSAGE)));
+    spawner.spawn(unwrap!(tcp_communication_task(stack, tcp_address, &MESSAGE)));
+
+    loop {
+        Timer::after_secs(1).await;
+    }
+}
+
+#[embassy_executor::task]
+async fn tcp_communication_task(stack: Stack<'static>, tcp_address: SocketAddr, message: &'static MessageType) -> ! {
+
+    let state: TcpClientState<1, 1024, 1024> = TcpClientState::new();
+    let client = TcpClient::new(stack, &state);
 
     loop {
         info!("connecting...");
         {
-            *(MESSAGE.lock().await) = Some(TcpState::Connecting);
+            *(message.lock().await) = Some(TcpState::Connecting);
         }
         let r = client.connect(tcp_address).await;
         if let Err(e) = r {
@@ -148,7 +157,7 @@ async fn main(spawner: Spawner) -> ! {
         let mut connection = r.unwrap();
         info!("tcp connected!");
         {
-            *(MESSAGE.lock().await) = Some(TcpState::Connected);
+            *(message.lock().await) = Some(TcpState::Connected);
         }
 
         loop {

--- a/examples/stm32h7/src/bin/eth_client.rs
+++ b/examples/stm32h7/src/bin/eth_client.rs
@@ -6,7 +6,8 @@ use core::net::{Ipv4Addr, SocketAddr, SocketAddrV4};
 use defmt::*;
 use defmt_rtt as _;
 use embassy_executor::Spawner;
-use embassy_net::StackResources;
+use embassy_net::{Stack, StackResources};
+use embassy_net::udp::{PacketMetadata, UdpSocket};
 use embassy_net::tcp::client::{TcpClient, TcpClientState};
 use embassy_stm32::eth::{Ethernet, GenericPhy, PacketQueue, Sma};
 use embassy_stm32::peripherals::{ETH, ETH_SMA};
@@ -18,6 +19,16 @@ use embedded_nal_async::{TcpConnect, UnconnectedUdp};
 use embassy_net::udp::socket::UnconnectedUdpError;
 use panic_probe as _;
 use static_cell::StaticCell;
+use embassy_sync::blocking_mutex::raw::ThreadModeRawMutex;
+use embassy_sync::mutex::Mutex;
+
+enum TcpState {
+    Connecting,
+    Connected,
+}
+
+type MessageType = Mutex<ThreadModeRawMutex, Option<TcpState>>;
+static MESSAGE: MessageType = Mutex::new(None);
 
 bind_interrupts!(struct Irqs {
     ETH => eth::InterruptHandler<ETH>;
@@ -88,9 +99,9 @@ async fn main(spawner: Spawner) -> ! {
 
     let config = embassy_net::Config::dhcpv4(Default::default());
     //let config = embassy_net::Config::ipv4_static(embassy_net::StaticConfigV4 {
-    //    address: Ipv4Cidr::new(Ipv4Address::new(10, 42, 0, 61), 24),
+    //    address: Ipv4Cidr::new(Ipv4Address::new(192, 168, 18, 64), 24),
     //    dns_servers: Vec::new(),
-    //    gateway: Some(Ipv4Address::new(10, 42, 0, 1)),
+    //    gateway: Some(Ipv4Address::new(192, 168, 18, 1)),
     //});
 
     // Init network stack
@@ -106,6 +117,53 @@ async fn main(spawner: Spawner) -> ! {
 
     info!("Network task initialized");
 
+    let state: TcpClientState<1, 1024, 1024> = TcpClientState::new();
+    let client = TcpClient::new(stack, &state);
+
+    let local_socket_address: SocketAddr = SocketAddrV4::new(config_v4.address.address().into(), 8001).into();
+    info!("udp local address: {}", local_socket_address);
+    let broadcast_socket_address: SocketAddr = SocketAddrV4::new(config_v4.address.broadcast().unwrap().into(), 8001).into();
+    info!("udp broadcast address: {}", broadcast_socket_address);
+
+    // You need to start a server on the host machine, for example: `nc -b -l 8001`
+    let udp_address = SocketAddr::V4(SocketAddrV4::new(Ipv4Addr::new(192, 168, 18, 41), 8001));
+
+    // You need to start a server on the host machine, for example: `nc -l 8000`
+    let tcp_address = SocketAddr::V4(SocketAddrV4::new(Ipv4Addr::new(192, 168, 18, 41), 8000));
+
+    spawner.spawn(unwrap!(broadcast_task(stack, local_socket_address, broadcast_socket_address, udp_address, &MESSAGE)));
+
+    loop {
+        info!("connecting...");
+        {
+            *(MESSAGE.lock().await) = Some(TcpState::Connecting);
+        }
+        let r = client.connect(tcp_address).await;
+        if let Err(e) = r {
+            info!("tcp connect error: {:?}", e);
+            Timer::after_secs(1).await;
+            continue;
+        }
+
+        let mut connection = r.unwrap();
+        info!("tcp connected!");
+        {
+            *(MESSAGE.lock().await) = Some(TcpState::Connected);
+        }
+
+        loop {
+            let r = connection.write_all(b"Hello\n").await;
+            if let Err(e) = r {
+                info!("tcp write error: {:?}", e);
+                break;
+            }
+            Timer::after_secs(1).await;
+        }
+    }
+}
+
+#[embassy_executor::task]
+async fn broadcast_task(stack: Stack<'static>, local_socket_address: SocketAddr, broadcast_socket_address: SocketAddr, udp_address: SocketAddr, message: &'static MessageType) -> ! {
 
     let mut rx_meta = [PacketMetadata::EMPTY; 16];
     let mut rx_buffer = [0; 4096];
@@ -115,50 +173,28 @@ async fn main(spawner: Spawner) -> ! {
     let mut socket = UdpSocket::new(stack, &mut rx_meta, &mut rx_buffer, &mut tx_meta, &mut tx_buffer);
     socket.bind(8001).unwrap();
 
-    let local_socket_address: SocketAddr = SocketAddrV4::new(config_v4.address.address().into(), 8001).into();
-    info!("udp local address: {}", local_socket_address);
-    let broadcast_socket_address: SocketAddr = SocketAddrV4::new(config_v4.address.broadcast().unwrap().into(), 8001).into();
-    info!("udp broadcast address: {}", broadcast_socket_address);
-
-    let state: TcpClientState<1, 1024, 1024> = TcpClientState::new();
-    let client = TcpClient::new(stack, &state);
-
     loop {
-        // You need to start a server on the host machine, for example: `nc -l 8000`
-        let addr = SocketAddr::V4(SocketAddrV4::new(Ipv4Addr::new(192, 168, 18, 41), 8000));
+        let mut message_unlocked = message.lock().await;
+        if let Some(message_ref) = message_unlocked.as_mut() {
 
-        // You need to start a server on the host machine, for example: `nc -b -l 8001`
-        let udp_addr = SocketAddr::V4(SocketAddrV4::new(Ipv4Addr::new(192, 168, 18, 41), 8001));
-
-        info!("connecting...");
-
-        let r = socket.send(local_socket_address, broadcast_socket_address, b"Broadcast UDP\n").await;
-        if let Err(e) = r {
-            info!("udp broadcast error: {:?}", e);
-        }
-
-
-        let r = client.connect(addr).await;
-        if let Err(e) = r {
-            info!("tcp connect error: {:?}", e);
-            Timer::after_secs(1).await;
-            continue;
-        }
-        let mut connection = r.unwrap();
-        info!("tcp connected!");
-        loop {
-
-            let r = socket.send(local_socket_address, udp_addr, b"Hello UDP\n").await;
-            if let Err(e) = r {
-                info!("udp write error: {:?}", e);
+            match message_ref {
+                TcpState::Connecting => {
+                    let r = socket.send(local_socket_address, broadcast_socket_address, b"UDP: Waiting for TCP connect\n").await;
+                    if let Err(e) = r {
+                        info!("udp broadcast error: {:?}", e);
+                    }
+                }
+                TcpState::Connected => {
+                    let r = socket.send(local_socket_address, udp_address, b"UDP: TCP connection OK\n").await;
+                    if let Err(e) = r {
+                        info!("udp write error: {:?}", e);
+                    }
+                }
             }
-
-            let r = connection.write_all(b"Hello\n").await;
-            if let Err(e) = r {
-                info!("tcp write error: {:?}", e);
-                break;
-            }
-            Timer::after_secs(1).await;
         }
+        // release the mutex
+        drop(message_unlocked);
+
+        Timer::after_secs(1).await;
     }
 }

--- a/examples/stm32h7/src/bin/eth_client.rs
+++ b/examples/stm32h7/src/bin/eth_client.rs
@@ -14,7 +14,8 @@ use embassy_stm32::rng::Rng;
 use embassy_stm32::{Config, bind_interrupts, eth, peripherals, rng};
 use embassy_time::Timer;
 use embedded_io_async::Write;
-use embedded_nal_async::TcpConnect;
+use embedded_nal_async::{TcpConnect, UnconnectedUdp};
+use embassy_net::udp::socket::UnconnectedUdpError;
 use panic_probe as _;
 use static_cell::StaticCell;
 
@@ -93,7 +94,7 @@ async fn main(spawner: Spawner) -> ! {
     //});
 
     // Init network stack
-    static RESOURCES: StaticCell<StackResources<3>> = StaticCell::new();
+    static RESOURCES: StaticCell<StackResources<4>> = StaticCell::new();
     let (stack, runner) = embassy_net::new(device, config, RESOURCES.init(StackResources::new()), seed);
 
     // Launch network task
@@ -101,29 +102,60 @@ async fn main(spawner: Spawner) -> ! {
 
     // Ensure DHCP configuration is up before trying connect
     stack.wait_config_up().await;
+    let config_v4 = unwrap!(stack.config_v4());
 
     info!("Network task initialized");
+
+
+    let mut rx_meta = [PacketMetadata::EMPTY; 16];
+    let mut rx_buffer = [0; 4096];
+    let mut tx_meta = [PacketMetadata::EMPTY; 16];
+    let mut tx_buffer = [0; 4096];
+
+    let mut socket = UdpSocket::new(stack, &mut rx_meta, &mut rx_buffer, &mut tx_meta, &mut tx_buffer);
+    socket.bind(8001).unwrap();
+
+    let local_socket_address: SocketAddr = SocketAddrV4::new(config_v4.address.address().into(), 8001).into();
+    info!("udp local address: {}", local_socket_address);
+    let broadcast_socket_address: SocketAddr = SocketAddrV4::new(config_v4.address.broadcast().unwrap().into(), 8001).into();
+    info!("udp broadcast address: {}", broadcast_socket_address);
 
     let state: TcpClientState<1, 1024, 1024> = TcpClientState::new();
     let client = TcpClient::new(stack, &state);
 
     loop {
         // You need to start a server on the host machine, for example: `nc -l 8000`
-        let addr = SocketAddr::V4(SocketAddrV4::new(Ipv4Addr::new(10, 42, 0, 1), 8000));
+        let addr = SocketAddr::V4(SocketAddrV4::new(Ipv4Addr::new(192, 168, 18, 41), 8000));
+
+        // You need to start a server on the host machine, for example: `nc -b -l 8001`
+        let udp_addr = SocketAddr::V4(SocketAddrV4::new(Ipv4Addr::new(192, 168, 18, 41), 8001));
 
         info!("connecting...");
+
+        let r = socket.send(local_socket_address, broadcast_socket_address, b"Broadcast UDP\n").await;
+        if let Err(e) = r {
+            info!("udp broadcast error: {:?}", e);
+        }
+
+
         let r = client.connect(addr).await;
         if let Err(e) = r {
-            info!("connect error: {:?}", e);
+            info!("tcp connect error: {:?}", e);
             Timer::after_secs(1).await;
             continue;
         }
         let mut connection = r.unwrap();
-        info!("connected!");
+        info!("tcp connected!");
         loop {
+
+            let r = socket.send(local_socket_address, udp_addr, b"Hello UDP\n").await;
+            if let Err(e) = r {
+                info!("udp write error: {:?}", e);
+            }
+
             let r = connection.write_all(b"Hello\n").await;
             if let Err(e) = r {
-                info!("write error: {:?}", e);
+                info!("tcp write error: {:?}", e);
                 break;
             }
             Timer::after_secs(1).await;

--- a/examples/stm32h7/src/bin/eth_client.rs
+++ b/examples/stm32h7/src/bin/eth_client.rs
@@ -6,7 +6,7 @@ use core::net::{Ipv4Addr, SocketAddr, SocketAddrV4};
 use defmt::*;
 use defmt_rtt as _;
 use embassy_executor::Spawner;
-use embassy_net::{Stack, StackResources};
+use embassy_net::{Ipv4Address, Ipv4Cidr, Stack, StackResources};
 use embassy_net::udp::{PacketMetadata, UdpSocket};
 use embassy_net::tcp::client::{TcpClient, TcpClientState};
 use embassy_stm32::eth::{Ethernet, GenericPhy, PacketQueue, Sma};
@@ -16,11 +16,11 @@ use embassy_stm32::{Config, bind_interrupts, eth, peripherals, rng};
 use embassy_time::Timer;
 use embedded_io_async::Write;
 use embedded_nal_async::{TcpConnect, UnconnectedUdp};
-use embassy_net::udp::socket::UnconnectedUdpError;
 use panic_probe as _;
 use static_cell::StaticCell;
 use embassy_sync::blocking_mutex::raw::ThreadModeRawMutex;
 use embassy_sync::mutex::Mutex;
+use heapless::Vec;
 
 enum TcpState {
     Connecting,
@@ -97,16 +97,21 @@ async fn main(spawner: Spawner) -> ! {
         p.PC1,
     );
 
-    let config = embassy_net::Config::dhcpv4(Default::default());
-    //let config = embassy_net::Config::ipv4_static(embassy_net::StaticConfigV4 {
-    //    address: Ipv4Cidr::new(Ipv4Address::new(192, 168, 18, 64), 24),
-    //    dns_servers: Vec::new(),
-    //    gateway: Some(Ipv4Address::new(192, 168, 18, 1)),
-    //});
+    const HAVE_DHCP: bool = true;
+
+    let net_config = if HAVE_DHCP {
+        embassy_net::Config::dhcpv4(Default::default())
+    } else {
+        embassy_net::Config::ipv4_static(embassy_net::StaticConfigV4 {
+            address: Ipv4Cidr::new(Ipv4Address::new(192, 168, 18, 64), 24),
+            dns_servers: Vec::new(),
+            gateway: Some(Ipv4Address::new(192, 168, 18, 1)),
+        })
+    };
 
     // Init network stack
     static RESOURCES: StaticCell<StackResources<4>> = StaticCell::new();
-    let (stack, runner) = embassy_net::new(device, config, RESOURCES.init(StackResources::new()), seed);
+    let (stack, runner) = embassy_net::new(device, net_config, RESOURCES.init(StackResources::new()), seed);
 
     // Launch network task
     spawner.spawn(unwrap!(net_task(runner)));
@@ -122,11 +127,13 @@ async fn main(spawner: Spawner) -> ! {
     let broadcast_socket_address: SocketAddr = SocketAddrV4::new(config_v4.address.broadcast().unwrap().into(), 8001).into();
     info!("udp broadcast address: {}", broadcast_socket_address);
 
+    const HOST_ADDRESS: Ipv4Addr = Ipv4Addr::new(192, 168, 18, 54);
+
     // You need to start a server on the host machine, for example: `nc -b -l 8001`
-    let udp_address = SocketAddr::V4(SocketAddrV4::new(Ipv4Addr::new(192, 168, 18, 41), 8001));
+    let udp_address = SocketAddr::V4(SocketAddrV4::new(HOST_ADDRESS, 8001));
 
     // You need to start a server on the host machine, for example: `nc -l 8000`
-    let tcp_address = SocketAddr::V4(SocketAddrV4::new(Ipv4Addr::new(192, 168, 18, 41), 8000));
+    let tcp_address = SocketAddr::V4(SocketAddrV4::new(HOST_ADDRESS, 8000));
 
     spawner.spawn(unwrap!(broadcast_task(stack, local_socket_address, broadcast_socket_address, udp_address, &MESSAGE)));
     spawner.spawn(unwrap!(tcp_communication_task(stack, tcp_address, &MESSAGE)));

--- a/examples/stm32h7/src/bin/eth_client.rs
+++ b/examples/stm32h7/src/bin/eth_client.rs
@@ -6,21 +6,21 @@ use core::net::{Ipv4Addr, SocketAddr, SocketAddrV4};
 use defmt::*;
 use defmt_rtt as _;
 use embassy_executor::Spawner;
-use embassy_net::{Ipv4Address, Ipv4Cidr, Stack, StackResources};
-use embassy_net::udp::{PacketMetadata, UdpSocket};
 use embassy_net::tcp::client::{TcpClient, TcpClientState};
+use embassy_net::udp::{PacketMetadata, UdpSocket};
+use embassy_net::{Ipv4Address, Ipv4Cidr, Stack, StackResources};
 use embassy_stm32::eth::{Ethernet, GenericPhy, PacketQueue, Sma};
 use embassy_stm32::peripherals::{ETH, ETH_SMA};
 use embassy_stm32::rng::Rng;
 use embassy_stm32::{Config, bind_interrupts, eth, peripherals, rng};
+use embassy_sync::blocking_mutex::raw::ThreadModeRawMutex;
+use embassy_sync::mutex::Mutex;
 use embassy_time::Timer;
 use embedded_io_async::Write;
 use embedded_nal_async::{TcpConnect, UnconnectedUdp};
+use heapless::Vec;
 use panic_probe as _;
 use static_cell::StaticCell;
-use embassy_sync::blocking_mutex::raw::ThreadModeRawMutex;
-use embassy_sync::mutex::Mutex;
-use heapless::Vec;
 
 enum TcpState {
     Connecting,
@@ -124,7 +124,8 @@ async fn main(spawner: Spawner) -> ! {
 
     let local_socket_address: SocketAddr = SocketAddrV4::new(config_v4.address.address().into(), 8001).into();
     info!("udp local address: {}", local_socket_address);
-    let broadcast_socket_address: SocketAddr = SocketAddrV4::new(config_v4.address.broadcast().unwrap().into(), 8001).into();
+    let broadcast_socket_address: SocketAddr =
+        SocketAddrV4::new(config_v4.address.broadcast().unwrap().into(), 8001).into();
     info!("udp broadcast address: {}", broadcast_socket_address);
 
     const HOST_ADDRESS: Ipv4Addr = Ipv4Addr::new(192, 168, 18, 54);
@@ -135,7 +136,13 @@ async fn main(spawner: Spawner) -> ! {
     // You need to start a server on the host machine, for example: `nc -l 8000`
     let tcp_address = SocketAddr::V4(SocketAddrV4::new(HOST_ADDRESS, 8000));
 
-    spawner.spawn(unwrap!(broadcast_task(stack, local_socket_address, broadcast_socket_address, udp_address, &MESSAGE)));
+    spawner.spawn(unwrap!(broadcast_task(
+        stack,
+        local_socket_address,
+        broadcast_socket_address,
+        udp_address,
+        &MESSAGE
+    )));
     spawner.spawn(unwrap!(tcp_communication_task(stack, tcp_address, &MESSAGE)));
 
     loop {
@@ -145,7 +152,6 @@ async fn main(spawner: Spawner) -> ! {
 
 #[embassy_executor::task]
 async fn tcp_communication_task(stack: Stack<'static>, tcp_address: SocketAddr, message: &'static MessageType) -> ! {
-
     let state: TcpClientState<1, 1024, 1024> = TcpClientState::new();
     let client = TcpClient::new(stack, &state);
 
@@ -179,8 +185,13 @@ async fn tcp_communication_task(stack: Stack<'static>, tcp_address: SocketAddr, 
 }
 
 #[embassy_executor::task]
-async fn broadcast_task(stack: Stack<'static>, local_socket_address: SocketAddr, broadcast_socket_address: SocketAddr, udp_address: SocketAddr, message: &'static MessageType) -> ! {
-
+async fn broadcast_task(
+    stack: Stack<'static>,
+    local_socket_address: SocketAddr,
+    broadcast_socket_address: SocketAddr,
+    udp_address: SocketAddr,
+    message: &'static MessageType,
+) -> ! {
     let mut rx_meta = [PacketMetadata::EMPTY; 16];
     let mut rx_buffer = [0; 4096];
     let mut tx_meta = [PacketMetadata::EMPTY; 16];
@@ -192,16 +203,23 @@ async fn broadcast_task(stack: Stack<'static>, local_socket_address: SocketAddr,
     loop {
         let mut message_unlocked = message.lock().await;
         if let Some(message_ref) = message_unlocked.as_mut() {
-
             match message_ref {
                 TcpState::Connecting => {
-                    let r = socket.send(local_socket_address, broadcast_socket_address, b"UDP: Waiting for TCP connect\n").await;
+                    let r = socket
+                        .send(
+                            local_socket_address,
+                            broadcast_socket_address,
+                            b"UDP: Waiting for TCP connect\n",
+                        )
+                        .await;
                     if let Err(e) = r {
                         info!("udp broadcast error: {:?}", e);
                     }
                 }
                 TcpState::Connected => {
-                    let r = socket.send(local_socket_address, udp_address, b"UDP: TCP connection OK\n").await;
+                    let r = socket
+                        .send(local_socket_address, udp_address, b"UDP: TCP connection OK\n")
+                        .await;
                     if let Err(e) = r {
                         info!("udp write error: {:?}", e);
                     }


### PR DESCRIPTION
For me this is useful so that it's possible to send broadcast UDP discovery packets to potential clients, without my application networking core depending on `embassy_net`.

This PR contains a few commits, the last commits may not be needed since they just add tasks, so feel free to cherry-pick at-will.

Not tested on anything else other than an stm32h743zi nucleo board, YMMV.

Notes:
* `bind_endpoint` was added to `UdpSocket` so it can track the bind port which is needed by the embedded_nal_async API.