### PR TITLE
nxp/lpc55: eliminate match_iocon

### DIFF
--- a/embassy-nxp/CHANGELOG.md
+++ b/embassy-nxp/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 <!-- next-header -->
 ## Unreleased - ReleaseDate
+- LPC55: Remove internal match_iocon macro
 - LPC55: DMA Controller and asynchronous version of USART
 - Moved NXP LPC55S69 from `lpc55-pac` to `nxp-pac`
 - First release with changelog.

--- a/embassy-nxp/src/usart/lpc55.rs
+++ b/embassy-nxp/src/usart/lpc55.rs
@@ -11,7 +11,7 @@ use embassy_sync::waitqueue::AtomicWaker;
 use embedded_io::{self, ErrorKind};
 
 use crate::dma::{AnyChannel, Channel};
-use crate::gpio::{AnyPin, Bank, SealedPin, match_iocon};
+use crate::gpio::{AnyPin, SealedPin};
 use crate::interrupt::Interrupt;
 use crate::interrupt::typelevel::{Binding, Interrupt as _};
 use crate::pac::flexcomm::Flexcomm as FlexcommReg;
@@ -555,29 +555,25 @@ impl<'d, M: Mode> Usart<'d, M> {
 
     fn pin_config<T: Instance>(tx: Option<Peri<'_, AnyPin>>, rx: Option<Peri<'_, AnyPin>>) {
         if let Some(tx_pin) = tx {
-            match_iocon!(register, tx_pin.pin_bank(), tx_pin.pin_number(), {
-                register.modify(|w| {
-                    w.set_func(T::tx_pin_func());
-                    w.set_mode(iocon::vals::PioMode::INACTIVE);
-                    w.set_slew(iocon::vals::PioSlew::STANDARD);
-                    w.set_invert(false);
-                    w.set_digimode(iocon::vals::PioDigimode::DIGITAL);
-                    w.set_od(iocon::vals::PioOd::NORMAL);
-                });
-            })
+            tx_pin.pio().modify(|w| {
+                w.set_func(T::tx_pin_func());
+                w.set_mode(iocon::vals::PioMode::INACTIVE);
+                w.set_slew(iocon::vals::PioSlew::STANDARD);
+                w.set_invert(false);
+                w.set_digimode(iocon::vals::PioDigimode::DIGITAL);
+                w.set_od(iocon::vals::PioOd::NORMAL);
+            });
         }
 
         if let Some(rx_pin) = rx {
-            match_iocon!(register, rx_pin.pin_bank(), rx_pin.pin_number(), {
-                register.modify(|w| {
-                    w.set_func(T::rx_pin_func());
-                    w.set_mode(iocon::vals::PioMode::INACTIVE);
-                    w.set_slew(iocon::vals::PioSlew::STANDARD);
-                    w.set_invert(false);
-                    w.set_digimode(iocon::vals::PioDigimode::DIGITAL);
-                    w.set_od(iocon::vals::PioOd::NORMAL);
-                });
-            })
+            rx_pin.pio().modify(|w| {
+                w.set_func(T::rx_pin_func());
+                w.set_mode(iocon::vals::PioMode::INACTIVE);
+                w.set_slew(iocon::vals::PioSlew::STANDARD);
+                w.set_invert(false);
+                w.set_digimode(iocon::vals::PioDigimode::DIGITAL);
+                w.set_od(iocon::vals::PioOd::NORMAL);
+            });
         };
     }
 


### PR DESCRIPTION
It is easier to have SealedPin provide a way to get to the Pio icon registers.

@george-cosma @frihetselsker 