### PR TITLE
mspm0/gpio: use maitake-sync for gpio wakers

### DIFF
--- a/embassy-mspm0/CHANGELOG.md
+++ b/embassy-mspm0/CHANGELOG.md
@@ -24,3 +24,4 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - feat: add CPU accelerated division function (#4966)
 - feat: Add trng implementation (#5172)
 - fix: feature guard pins used for NRST and SWD (#5257)
+- feat: Move from GPIO waker arrays to maitake-sync wait map

--- a/embassy-mspm0/Cargo.toml
+++ b/embassy-mspm0/Cargo.toml
@@ -72,6 +72,11 @@ micromath = "2.0.0"
 # mspm0-metapac = { version = "" }
 mspm0-metapac = { git = "https://github.com/mspm0-rs/mspm0-data-generated/", tag = "mspm0-data-d9f54366c65cec47957065f42fe04542b852a8cd" }
 rand_core = "0.9"
+# Force no cache padding or the types are too large.
+maitake-sync = { version = "0.3.0", default-features = false, features = ["critical-section", "no-cache-pad"]}
+# maitake sync requires portable atomic. For Cortex-M0 it is fine to force a dependency on the critical section feature.
+# however on MSPM33 parts it may be desired to use hardware atomics instead.
+portable-atomic = { version = "1.13.1", features = ["critical-section"] }
 
 [build-dependencies]
 proc-macro2 = "1.0.94"

--- a/embassy-mspm0/src/gpio.rs
+++ b/embassy-mspm0/src/gpio.rs
@@ -2,11 +2,9 @@
 
 use core::convert::Infallible;
 use core::future::Future;
-use core::pin::Pin as FuturePin;
-use core::task::{Context, Poll};
 
 use embassy_hal_internal::{Peri, PeripheralType, impl_peripheral};
-use embassy_sync::waitqueue::AtomicWaker;
+use maitake_sync::WaitMap;
 
 use crate::pac::gpio::vals::*;
 use crate::pac::gpio::{self};
@@ -316,20 +314,71 @@ impl<'d> Flex<'d> {
 
     /// Wait for the pin to undergo a transition from low to high.
     #[inline]
-    pub async fn wait_for_rising_edge(&mut self) {
-        InputFuture::new(self.pin.reborrow(), Polarity::RISE).await
+    pub fn wait_for_rising_edge(&mut self) -> impl Future<Output = ()> {
+        // Per https://tweedegolf.nl/en/blog/235/debloat-your-async-rust
+        //
+        // We match the async pass-through suggestion to reduce async bloat.
+        self.wait_inner(Polarity::RISE)
     }
 
     /// Wait for the pin to undergo a transition from high to low.
     #[inline]
-    pub async fn wait_for_falling_edge(&mut self) {
-        InputFuture::new(self.pin.reborrow(), Polarity::FALL).await
+    pub fn wait_for_falling_edge(&mut self) -> impl Future<Output = ()> {
+        self.wait_inner(Polarity::FALL)
     }
 
     /// Wait for the pin to undergo any transition, i.e low to high OR high to low.
     #[inline]
-    pub async fn wait_for_any_edge(&mut self) {
-        InputFuture::new(self.pin.reborrow(), Polarity::RISE_FALL).await
+    pub fn wait_for_any_edge(&mut self) -> impl Future<Output = ()> {
+        self.wait_inner(Polarity::RISE_FALL)
+    }
+
+    async fn wait_inner(&mut self, polarity: Polarity) {
+        let pin = &self.pin;
+        let block = pin.block();
+
+        // Selecting the event to trigger. A RMW operation.
+        critical_section::with(|_cs| {
+            if pin.bit_index() >= 16 {
+                block.polarity31_16().modify(|w| {
+                    w.set_dio(pin.bit_index() - 16, polarity);
+                });
+            } else {
+                block.polarity15_0().modify(|w| {
+                    w.set_dio(pin.bit_index(), polarity);
+                });
+            };
+        });
+
+        // Clear previous edge events. This is done after setting the event to listen for to avoid a redundant write.
+        block.cpu_int().iclr().write(|w| {
+            w.set_dio(pin.bit_index(), true);
+        });
+
+        let key = pin.pin_port();
+        let result = GPIO_WAIT_MAP
+            .wait_for(key, || {
+                if pin.block().cpu_int().ris().read().dio(pin.bit_index()) {
+                    return true;
+                }
+
+                // Because pin singletons are Send, unmasking interrupts must be guarded by critical section.
+                critical_section::with(|_cs| {
+                    self.pin.block().cpu_int().imask().modify(|w| {
+                        w.set_dio(self.pin.bit_index(), true);
+                    });
+                });
+
+                false
+            })
+            .await;
+
+        // Because of the following no error can happen:
+        // 1. The map is never closed (Closed)
+        // 2. The data cannot already be consumed because wait_for registers the key.
+        // 3. wait_for always causes wait to be added to map (NeverAdded)
+        // 4. pin singletons ensure that a wait map entry is ever owned by one entity (Duplicate)
+        debug_assert!(result.is_ok(), "GPIO wait map should never result in error");
     }
 }
 
@@ -897,37 +946,13 @@ macro_rules! impl_pin {
     };
 }
 
-// TODO: Possible micro-op for C110X, not every pin is instantiated even on the 20 pin parts.
-//       This would mean cfg guarding to just cfg guarding every pin instance.
-static PORTA_WAKERS: [AtomicWaker; 32] = [const { AtomicWaker::new() }; 32];
-#[cfg(gpio_pb)]
-static PORTB_WAKERS: [AtomicWaker; 32] = [const { AtomicWaker::new() }; 32];
-#[cfg(gpio_pc)]
-static PORTC_WAKERS: [AtomicWaker; 32] = [const { AtomicWaker::new() }; 32];
+/// Wait map for GPIO wakers
+///
+/// This map must **never** be closed because gpio wakers may be used forever.
+static GPIO_WAIT_MAP: WaitMap<u8, ()> = WaitMap::new();
 
 pub(crate) trait SealedPin {
     fn pin_port(&self) -> u8;
-
-    fn port(&self) -> Port {
-        match self.pin_port() / 32 {
-            0 => Port::PortA,
-            #[cfg(gpio_pb)]
-            1 => Port::PortB,
-            #[cfg(gpio_pc)]
-            2 => Port::PortC,
-            _ => unreachable!(),
-        }
-    }
-
-    fn waker(&self) -> &AtomicWaker {
-        match self.port() {
-            Port::PortA => &PORTA_WAKERS[self.bit_index()],
-            #[cfg(gpio_pb)]
-            Port::PortB => &PORTB_WAKERS[self.bit_index()],
-            #[cfg(gpio_pc)]
-            Port::PortC => &PORTC_WAKERS[self.bit_index()],
-        }
-    }
 
     fn _pin_cm(&self) -> u8 {
         // Some parts like the MSPM0L222x have pincm mappings all over the place.
@@ -1000,85 +1025,6 @@ fn set_pf(pincm: usize, pf: u8, ty: PfType) {
     });
 }
 
-#[must_use = "futures do nothing unless you `.await` or poll them"]
-struct InputFuture<'d> {
-    pin: Peri<'d, AnyPin>,
-}
-
-impl<'d> InputFuture<'d> {
-    fn new(pin: Peri<'d, AnyPin>, polarity: Polarity) -> Self {
-        let block = pin.block();
-
-        // Before clearing any previous edge events, we must disable events.
-        //
-        // If we don't do this, it is possible that after we clear the interrupt, the current event
-        // the hardware is listening for may not be the same event we will configure. This may result
-        // in RIS being set. Then when interrupts are unmasked and RIS is set, we may get the wrong event
-        // causing an interrupt.
-        //
-        // Selecting which polarity events happen is a RMW operation.
-        critical_section::with(|_cs| {
-            if pin.bit_index() >= 16 {
-                block.polarity31_16().modify(|w| {
-                    w.set_dio(pin.bit_index() - 16, Polarity::DISABLE);
-                });
-            } else {
-                block.polarity15_0().modify(|w| {
-                    w.set_dio(pin.bit_index(), Polarity::DISABLE);
-                });
-            };
-        });
-
-        // First clear the bit for this event. Otherwise previous edge events may be recorded.
-        block.cpu_int().iclr().write(|w| {
-            w.set_dio(pin.bit_index(), true);
-        });
-
-        // Selecting which polarity events happen is a RMW operation.
-        critical_section::with(|_cs| {
-            // Tell the hardware which pin event we want to receive.
-            if pin.bit_index() >= 16 {
-                block.polarity31_16().modify(|w| {
-                    w.set_dio(pin.bit_index() - 16, polarity);
-                });
-            } else {
-                block.polarity15_0().modify(|w| {
-                    w.set_dio(pin.bit_index(), polarity);
-                });
-            };
-        });
-
-        Self { pin }
-    }
-}
-
-impl<'d> Future for InputFuture<'d> {
-    type Output = ();
-
-    fn poll(self: FuturePin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
-        // We need to register/re-register the waker for each poll because any
-        // calls to wake will deregister the waker.
-        let waker = self.pin.waker();
-        waker.register(cx.waker());
-
-        // The interrupt handler will mask the interrupt if the event has occurred.
-        if self.pin.block().cpu_int().ris().read().dio(self.pin.bit_index()) {
-            return Poll::Ready(());
-        }
-
-        // Unmasking the interrupt is a RMW operation.
-        //
-        // Guard with a critical section in case two different threads try to unmask at the same time.
-        critical_section::with(|_cs| {
-            self.pin.block().cpu_int().imask().modify(|w| {
-                w.set_dio(self.pin.bit_index(), true);
-            });
-        });
-
-        Poll::Pending
-    }
-}
-
 pub(crate) fn init(gpio: gpio::Gpio) {
     gpio.gprcm().rstctl().write(|w| {
         w.set_resetstkyclr(true);
@@ -1098,14 +1044,15 @@ pub(crate) fn init(gpio: gpio::Gpio) {
 }
 
 #[cfg(feature = "rt")]
-fn irq_handler(gpio: gpio::Gpio, wakers: &[AtomicWaker; 32]) {
+fn irq_handler(gpio: gpio::Gpio, port: Port) {
     use crate::BitIter;
     // Only consider pins which have interrupts unmasked.
 
     let bits = gpio.cpu_int().mis().read().0;
 
     for i in BitIter(bits) {
-        wakers[i as usize].wake();
+        let id = ((port as u8) * 32) + i as u8;
+        let _ = GPIO_WAIT_MAP.wake(&id, ());
 
         // Notify the future that an edge event has occurred by masking the interrupt for this pin.
         gpio.cpu_int().imask().modify(|w| {
@@ -1125,13 +1072,13 @@ compile_error!("gpiob_interrupt and gpiob_group are mutually exclusive cfgs");
 #[cfg(all(feature = "rt", gpioa_interrupt))]
 #[interrupt]
 fn GPIOA() {
-    irq_handler(pac::GPIOA, &PORTA_WAKERS);
+    irq_handler(pac::GPIOA, Port::PortA);
 }
 
 #[cfg(all(feature = "rt", gpiob_interrupt))]
 #[interrupt]
 fn GPIOB() {
-    irq_handler(pac::GPIOB, &PORTB_WAKERS);
+    irq_handler(pac::GPIOB, Port::PortB);
 }
 
 // These symbols are weakly defined as DefaultHandler and are called by the interrupt group implementation.
@@ -1142,19 +1089,19 @@ fn GPIOB() {
 #[unsafe(no_mangle)]
 #[allow(non_snake_case)]
 fn GPIOA() {
-    irq_handler(pac::GPIOA, &PORTA_WAKERS);
+    irq_handler(pac::GPIOA, Port::PortA);
 }
 
 #[cfg(all(feature = "rt", gpiob_group))]
 #[unsafe(no_mangle)]
 #[allow(non_snake_case)]
 fn GPIOB() {
-    irq_handler(pac::GPIOB, &PORTB_WAKERS);
+    irq_handler(pac::GPIOB, Port::PortB);
 }
 
 #[cfg(all(feature = "rt", gpioc_group))]
 #[allow(non_snake_case)]
 #[unsafe(no_mangle)]
 fn GPIOC() {
-    irq_handler(pac::GPIOC, &PORTC_WAKERS);
+    irq_handler(pac::GPIOC, Port::PortC);
 }

--- a/tests/mspm0/Cargo.toml
+++ b/tests/mspm0/Cargo.toml
@@ -30,7 +30,6 @@ embedded-io = { version = "0.7.1", features = ["defmt"] }
 embedded-io-async = { version = "0.7.0", features = ["defmt"] }
 panic-probe = { version = "1.0.0", features = ["print-defmt"] }
 static_cell = "2"
-portable-atomic = { version = "1.5", features = ["critical-section"] }
 
 [profile.dev]
 debug = 2


### PR DESCRIPTION
Fixes https://github.com/embassy-rs/embassy/issues/4015
~~https://github.com/hawkw/mycelium/pull/555 must be merged first.~~

I have verified this new setup works correctly on C1104. I will test on G3507 and maybe L2228 tomorrow. Keeping this a draft till the dependent pull request is merged.

I also consider this pull request to be a testbed for whether other embassy-hals may benefit from using maitake-sync, specifically `WakeMap`.

As discussed in https://github.com/embassy-rs/embassy/issues/4015, maitake-sync allows the cost of GPIO wakers to be paid by usage rather than statically, even if most pins are unused. Currently this disables the old method of statically allocated wakers. I would like some discussion whether this would be a good idea to mark as a choice (although I want to spin up an example using many pins to test this).

Here I have some numbers for RAM and flash usage on MSPM0C1104, for which statically allocated wakers waste 25% of RAM. For C1104, the blinky example is freed up nearly 25% of RAM. Unfortunately this increases the `.text` size. I suspect some optimization of what is inlined may help here.

Before waitmap (blinky):
```
   text    data     bss     dec     hex filename
   3944      80     408    4432    1150 blinky
```

i509vcb@verdigris:~/Dev/embassy/examples/mspm0c1104$ cargo objdump --release --bin blinky -- -C -t | grep '.bss'
    Finished `release` profile [optimized + debuginfo] target(s) in 0.05s
```
20000050 l     O .bss   00000040 blinky::__embassy_main::POOL::hdf4890576116d2f8
20000098 l     O .bss   00000100 embassy_mspm0::gpio::PORTA_WAKERS::h3e46d7edcc235649
20000090 l     O .bss   00000008 embassy_mspm0::dma::STATE::hc0d1f2780f4fe38c
20000199 l     O .bss   00000001 defmt_rtt::RTT_ENCODER::h5651992cc6ed4618 (.0)
2000019a l     O .bss   00000001 defmt_rtt::RTT_ENCODER::h5651992cc6ed4618 (.1)
2000019b l     O .bss   00000001 defmt_rtt::RTT_ENCODER::h5651992cc6ed4618 (.2)
2000019c l     O .bss   00000001 defmt_rtt::RTT_ENCODER::h5651992cc6ed4618 (.3)
2000019d l     O .bss   00000001 defmt_rtt::RTT_ENCODER::h5651992cc6ed4618 (.4)
20000198 g     O .bss   00000001 _EMBASSY_DEVICE_PERIPHERALS
20000050 g       .bss   00000000 __sbss
200001a0 g       .bss   00000000 __ebss
```

After waitmap (blinky):
```
   text    data     bss     dec     hex filename
   4204      80     168    4452    1164 blinky
```

i509vcb@verdigris:~/Dev/embassy/examples/mspm0c1104$ cargo objdump --release --bin blinky -- -C -t | grep '.bss'
    Finished `release` profile [optimized + debuginfo] target(s) in 0.05s
```
20000050 l     O .bss   00000040 blinky::__embassy_main::POOL::h1d50e2a13d16c60d
20000094 l     O .bss   00000014 embassy_mspm0::gpio::GPIO_WAIT_MAP::h2c627e5d7bbe0548
200000a8 l     O .bss   00000001 defmt_rtt::RTT_ENCODER::h6f41292e6a6b2194 (.0)
200000a9 l     O .bss   00000001 defmt_rtt::RTT_ENCODER::h6f41292e6a6b2194 (.1)
200000aa l     O .bss   00000001 defmt_rtt::RTT_ENCODER::h6f41292e6a6b2194 (.2)
200000ab l     O .bss   00000001 defmt_rtt::RTT_ENCODER::h6f41292e6a6b2194 (.3)
200000ac l     O .bss   00000001 defmt_rtt::RTT_ENCODER::h6f41292e6a6b2194 (.4)
20000090 g     O .bss   00000001 _EMBASSY_DEVICE_PERIPHERALS
20000050 g       .bss   00000000 __sbss
200000b0 g       .bss   00000000 __ebss
```

Before waitmap (button):
```
   text    data     bss     dec     hex filename
   4100      80     408    4588    11ec button
```

i509vcb@verdigris:~/Dev/embassy/examples/mspm0c1104$ cargo objdump --release --bin button -- -C -t | grep '.bss'
    Finished `release` profile [optimized + debuginfo] target(s) in 0.05s
```
20000098 l     O .bss   00000100 embassy_mspm0::gpio::PORTA_WAKERS::h3e46d7edcc235649
20000050 l     O .bss   00000040 button::__embassy_main::POOL::ha91ef408a93b6f8f
20000090 l     O .bss   00000008 embassy_mspm0::dma::STATE::hc0d1f2780f4fe38c
20000199 l     O .bss   00000001 defmt_rtt::RTT_ENCODER::h5651992cc6ed4618 (.0)
2000019a l     O .bss   00000001 defmt_rtt::RTT_ENCODER::h5651992cc6ed4618 (.1)
2000019b l     O .bss   00000001 defmt_rtt::RTT_ENCODER::h5651992cc6ed4618 (.2)
2000019c l     O .bss   00000001 defmt_rtt::RTT_ENCODER::h5651992cc6ed4618 (.3)
2000019d l     O .bss   00000001 defmt_rtt::RTT_ENCODER::h5651992cc6ed4618 (.4)
20000198 g     O .bss   00000001 _EMBASSY_DEVICE_PERIPHERALS
20000050 g       .bss   00000000 __sbss
200001a0 g       .bss   00000000 __ebss
```

After waitmap (button):
```
   text    data     bss     dec     hex filename
   5172      80     228    5480    1568 button
```

i509vcb@verdigris:~/Dev/embassy/examples/mspm0c1104$ cargo objdump --release --bin button -- -C -t | grep '.bss'
    Finished `release` profile [optimized + debuginfo] target(s) in 0.05s
```
20000050 l     O .bss   00000080 button::__embassy_main::POOL::h992edb0ed5a67f9b
200000d0 l     O .bss   00000001 defmt_rtt::RTT_ENCODER::h6f41292e6a6b2194 (.0)
200000d1 l     O .bss   00000001 defmt_rtt::RTT_ENCODER::h6f41292e6a6b2194 (.1)
200000d2 l     O .bss   00000001 defmt_rtt::RTT_ENCODER::h6f41292e6a6b2194 (.2)
200000d3 l     O .bss   00000001 defmt_rtt::RTT_ENCODER::h6f41292e6a6b2194 (.3)
200000d4 l     O .bss   00000001 defmt_rtt::RTT_ENCODER::h6f41292e6a6b2194 (.4)
200000d8 l     O .bss   00000014 embassy_mspm0::gpio::GPIO_WAIT_MAP::h2c627e5d7bbe0548
20000050 g       .bss   00000000 __sbss
200000ec g       .bss   00000000 __ebss
200000d5 g     O .bss   00000001 _EMBASSY_DEVICE_PERIPHERALS
```

@jamesmunns would appreciate review from you