### PR TITLE
Implement the dual external flash feature for stm32 qspi

### DIFF
--- a/embassy-stm32/src/qspi/mod.rs
+++ b/embassy-stm32/src/qspi/mod.rs
@@ -69,9 +69,8 @@ pub struct Config {
     pub sample_shifting: SampleShifting,
     /// GPIO Speed
     pub gpio_speed: Speed,
-    /// Dual flash mode 
+    /// Dual flash mode
     pub dual_flash: bool,
-
 }
 
 impl Default for Config {
@@ -101,7 +100,7 @@ pub struct Qspi<'d, T: Instance, M: PeriMode> {
     bk2d0: Option<Flex<'d>>,
     bk2d1: Option<Flex<'d>>,
     bk2d2: Option<Flex<'d>>,
-    bk2d3: Option<Flex<'d>>,    
+    bk2d3: Option<Flex<'d>>,
     bk1nss: Option<Flex<'d>>,
     bk2nss: Option<Flex<'d>>,
     dma: Option<ChannelAndRequest<'d>>,
@@ -119,7 +118,7 @@ impl<'d, T: Instance, M: PeriMode> Qspi<'d, T, M> {
         bk2d0: Option<Flex<'d>>,
         bk2d1: Option<Flex<'d>>,
         bk2d2: Option<Flex<'d>>,
-        bk2d3: Option<Flex<'d>>,        
+        bk2d3: Option<Flex<'d>>,
         sck: Option<Flex<'d>>,
         bk1nss: Option<Flex<'d>>,
         bk2nss: Option<Flex<'d>>,
@@ -169,9 +168,9 @@ impl<'d, T: Instance, M: PeriMode> Qspi<'d, T, M> {
             bk2d0,
             bk2d1,
             bk2d2,
-            bk2d3,            
+            bk2d3,
             bk1nss,
-            bk2nss,            
+            bk2nss,
             dma,
             _phantom: PhantomData,
             config,
@@ -390,8 +389,6 @@ impl<'d, T: Instance> Qspi<'d, T, Blocking> {
             None,
             None,
             None,
-
-
             new_pin!(sck, AfType::output(OutputType::PushPull, config.gpio_speed)),
             new_pin!(
                 nss,
@@ -425,14 +422,12 @@ impl<'d, T: Instance> Qspi<'d, T, Blocking> {
             new_pin!(d1, AfType::output(OutputType::PushPull, config.gpio_speed)),
             new_pin!(d2, AfType::output(OutputType::PushPull, config.gpio_speed)),
             new_pin!(d3, AfType::output(OutputType::PushPull, config.gpio_speed)),
-
             new_pin!(sck, AfType::output(OutputType::PushPull, config.gpio_speed)),
             None,
             new_pin!(
                 nss,
                 AfType::output_pull(OutputType::PushPull, config.gpio_speed, Pull::Up)
             ),
-
             None,
             config,
             FlashSelection::Flash2,
@@ -449,9 +444,9 @@ impl<'d, T: Instance> Qspi<'d, T, Blocking> {
         bk2d0: Peri<'d, impl BK2D0Pin<T>>,
         bk2d1: Peri<'d, impl BK2D1Pin<T>>,
         bk2d2: Peri<'d, impl BK2D2Pin<T>>,
-        bk2d3: Peri<'d, impl BK2D3Pin<T>>,        
+        bk2d3: Peri<'d, impl BK2D3Pin<T>>,
         sck: Peri<'d, impl SckPin<T>>,
-        bk1nss: Peri<'d, impl BK1NSSPin<T>>, 
+        bk1nss: Peri<'d, impl BK1NSSPin<T>>,
         bk2nss: Peri<'d, impl BK2NSSPin<T>>,
         config: Config,
     ) -> Self {
@@ -460,20 +455,19 @@ impl<'d, T: Instance> Qspi<'d, T, Blocking> {
             new_pin!(bk1d0, AfType::output(OutputType::PushPull, config.gpio_speed)),
             new_pin!(bk1d1, AfType::output(OutputType::PushPull, config.gpio_speed)),
             new_pin!(bk1d2, AfType::output(OutputType::PushPull, config.gpio_speed)),
-            new_pin!(bk1d3, AfType::output(OutputType::PushPull, config.gpio_speed)),   
+            new_pin!(bk1d3, AfType::output(OutputType::PushPull, config.gpio_speed)),
             new_pin!(bk2d0, AfType::output(OutputType::PushPull, config.gpio_speed)),
             new_pin!(bk2d1, AfType::output(OutputType::PushPull, config.gpio_speed)),
             new_pin!(bk2d2, AfType::output(OutputType::PushPull, config.gpio_speed)),
-            new_pin!(bk2d3, AfType::output(OutputType::PushPull, config.gpio_speed)),                     
+            new_pin!(bk2d3, AfType::output(OutputType::PushPull, config.gpio_speed)),
             new_pin!(sck, AfType::output(OutputType::PushPull, config.gpio_speed)),
-            new_pin!(bk1nss, AfType::output(OutputType::PushPull, config.gpio_speed)),                     
-            new_pin!(bk2nss, AfType::output(OutputType::PushPull, config.gpio_speed)),                     
+            new_pin!(bk1nss, AfType::output(OutputType::PushPull, config.gpio_speed)),
+            new_pin!(bk2nss, AfType::output(OutputType::PushPull, config.gpio_speed)),
             None,
             config,
             FlashSelection::Flash1, // Dual bank mode, so DFM is set and both banks are used
-        )    
+        )
     }
-    
 }
 
 impl<'d, T: Instance> Qspi<'d, T, Async> {


### PR DESCRIPTION
Hi All!

I am trying to implement the stm32 dual flash feature for use with the qspi module. I got some pointers from @Dirbaio on Matrix for what was initially needed, essentially some new constructors for the memory banks. It has resulted in this branch. I am having some problems getting it to work though. As soon as I set the dual flash flag to true(this flag was already implemented), the quad spi keeps getting stuck at busy after the first qspi command: 
<img width="1101" height="554" alt="image" src="https://github.com/user-attachments/assets/60759001-2fd7-4f57-9eb8-ff9ba529a259" />

Im not sure if its the qspi setup or how the external memflash is implemented. My test code is based on the embassy example here:
https://github.com/embassy-rs/embassy/blob/main/examples/stm32h742/src/bin/qspi.rs

I came across the following in the stm32 reference manual regarding reading and writing in dual flash mode: 
<img width="938" height="730" alt="image" src="https://github.com/user-attachments/assets/7e50fdcc-1b80-4259-a2ca-4dbf7137addd" />

I am not that well versed on the embassy qspi code. Will the above require a change to how the transactions are setup before the read/write commands are executed?

(PS: if I set the dual flash flag to false, I can read and write to the (first) external flash just fine, so Im pretty sure the flash specific commands are all set correct.)

Anyone got some input?


 