### PR TITLE
add STSPHSRX & STSPHST handler

### DIFF
--- a/embassy-usb-synopsys-otg/CHANGELOG.md
+++ b/embassy-usb-synopsys-otg/CHANGELOG.md
@@ -8,6 +8,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 <!-- next-header -->
 ## Unreleased - ReleaseDate
 
+## 0.3.2 - 2025-10-16
+
+- add STSPHSRX & STSPHST handler
+
 ## 0.3.1 - 2025-08-26
 
 - Improve receive performance, more efficient copy from FIFO

--- a/embassy-usb-synopsys-otg/src/lib.rs
+++ b/embassy-usb-synopsys-otg/src/lib.rs
@@ -103,6 +103,10 @@ pub unsafe fn on_interrupt<const MAX_EP_COUNT: usize>(r: Otg, state: &State<MAX_
             }
             vals::Pktstsd::OUT_DATA_DONE => {
                 trace!("OUT_DATA_DONE ep={}", ep_num);
+                if status.stsphst() == 0x01 && r.doepint(ep_num).read().stsphsrx() {
+                    trace!("STSPHST bit set, Clear STSPHSRX Int");
+                    r.doepint(ep_num).write(|w| w.set_stsphsrx(true));
+                }
             }
             vals::Pktstsd::SETUP_DATA_DONE => {
                 trace!("SETUP_DATA_DONE ep={}", ep_num);

--- a/embassy-usb-synopsys-otg/src/otg_v1.rs
+++ b/embassy-usb-synopsys-otg/src/otg_v1.rs
@@ -1268,6 +1268,17 @@ pub mod regs {
         pub fn set_otepdis(&mut self, val: bool) {
             self.0 = (self.0 & !(0x01 << 4usize)) | (((val as u32) & 0x01) << 4usize);
         }
+        #[doc = "STSPHSRX"]
+        #[inline(always)]
+        pub const fn stsphsrx(&self) -> bool {
+            let val = (self.0 >> 5usize) & 0x01;
+            val != 0
+        }
+        #[doc = "STSPHSRX"]
+        #[inline(always)]
+        pub fn set_stsphsrx(&mut self, val: bool) {
+            self.0 = (self.0 & !(0x01 << 5usize)) | (((val as u32) & 0x01) << 5usize);
+        }
         #[doc = "B2BSTUP"]
         #[inline(always)]
         pub const fn b2bstup(&self) -> bool {
@@ -3389,6 +3400,12 @@ pub mod regs {
         #[inline(always)]
         pub fn set_frmnum(&mut self, val: u8) {
             self.0 = (self.0 & !(0x0f << 21usize)) | (((val as u32) & 0x0f) << 21usize);
+        }
+        #[doc = "Status phase start (device mode)"]
+        #[inline(always)]
+        pub const fn stsphst(&self) -> u8 {
+            let val = (self.0 >> 27usize) & 0x01;
+            val as u8
         }
     }
     impl Default for Grxsts {


### PR DESCRIPTION
in case we get stsphst int with OUT_DATA_DONE, need clear doepint stsphsrx bit, else will block subsequent setup packet receive.

[TRACE] irq (embassy_usb_synopsys_otg embassy-usb-synopsys-otg/src/lib.rs:29) 
[TRACE] === status 01040400 (embassy_usb_synopsys_otg embassy-usb-synopsys-otg/src/lib.rs:45) 
[TRACE] OUT_DATA_RX ep=0 len=64 (embassy_usb_synopsys_otg embassy-usb-synopsys-otg/src/lib.rs:71) 
[TRACE] === status 01060000 (embassy_usb_synopsys_otg embassy-usb-synopsys-otg/src/lib.rs:45) 
[TRACE] OUT_DATA_DONE ep=0 (embassy_usb_synopsys_otg embassy-usb-synopsys-otg/src/lib.rs:99) 
[TRACE] === status 09060000 (embassy_usb_synopsys_otg embassy-usb-synopsys-otg/src/lib.rs:45) 
[TRACE] OUT_DATA_DONE ep=0 (embassy_usb_synopsys_otg embassy-usb-synopsys-otg/src/lib.rs:99) 
[TRACE] control: data_out (embassy_usb_synopsys_otg embassy-usb-synopsys-otg/src/lib.rs:1313) 
[TRACE] read start len=64 (embassy_usb_synopsys_otg embassy-usb-synopsys-otg/src/lib.rs:1083)