### PR TITLE
stm32: flash: fix flash erase on stm32l4xx, stm32l5xx series

### DIFF
--- a/embassy-stm32/CHANGELOG.md
+++ b/embassy-stm32/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * **Fix(stm32h5):** Prevent a HardFault crash on STM32H5 devices by changing `uid()` to return `[u8; 12]` by value instead of a reference. (Fixes #2696)
 ## Unreleased - ReleaseDate
 
+- fix flash erase on L4 & L5
 - fix: Fixed STM32H5 builds requiring time feature
 - feat: Derive Clone, Copy for QSPI Config
 - fix: stm32/i2c in master mode (blocking): subsequent transmissions failed after a NACK was received

--- a/embassy-stm32/src/flash/l.rs
+++ b/embassy-stm32/src/flash/l.rs
@@ -96,14 +96,20 @@ pub(crate) unsafe fn blocking_erase_sector(sector: &FlashSector) -> Result<(), E
     #[cfg(any(flash_wl, flash_wb, flash_l4, flash_l5))]
     {
         let idx = (sector.start - super::FLASH_BASE as u32) / super::BANK1_REGION.erase_size as u32;
+        #[cfg(any(flash_l4, flash_l5))]
+        let pgn = super::BANK1_REGION.size as u32 / super::BANK1_REGION.erase_size as u32;
 
         #[cfg(flash_l4)]
-        let (idx, bank) = if idx > 255 { (idx - 256, true) } else { (idx, false) };
+        let (idx, bank) = if idx > (pgn - 1) {
+            (idx - pgn, true)
+        } else {
+            (idx, false)
+        };
 
         #[cfg(flash_l5)]
         let (idx, bank) = if pac::FLASH.optr().read().dbank() {
-            if idx > 255 {
-                (idx - 256, Some(true))
+            if idx > (pgn - 1) {
+                (idx - pgn, Some(true))
             } else {
                 (idx, Some(false))
             }


### PR DESCRIPTION
stm32l4xx, stm32l5xx flash layout has different pages(64/128/256) depends on BANK1_REGION.size and BANK1_REGION.erase_size.

replace hardcoded 256 pages to size/erase_size.