### PR TITLE
nxp/lpc55: move usart ALT pin definitions to impl_xx_pin macros

### DIFF
--- a/embassy-nxp/CHANGELOG.md
+++ b/embassy-nxp/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 <!-- next-header -->
 ## Unreleased - ReleaseDate
+- LPC55: Move ALT definitions for USART to TX/RX pin impls. 
 - LPC55: Remove internal match_iocon macro
 - LPC55: DMA Controller and asynchronous version of USART
 - Moved NXP LPC55S69 from `lpc55-pac` to `nxp-pac`


### PR DESCRIPTION
This should make a future move to the buildscript generating pin impls easier.

Also split impl_pin into specific TX and RX macros to make it clearer to read.

@eva-cosma @frihetselsker please verify I did not accidentally change mappings. I did verify both usart examples build.

Longer term some clean up could be nice since passing around `(Peri<'d, AnyPin>, PioFunc)` can get a little messy.