### PR TITLE
[nRF] Make empty definition consistent on BufferedUarte

### DIFF
--- a/embassy-nrf/CHANGELOG.md
+++ b/embassy-nrf/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - changed: updated to nrf-pac with nrf52/nrf53/nrf91 register layout more similar to nrf54
 - added: support for nrf54l peripherals: uart, gpiote, twim, twis, spim, spis, dppi, pwm, saadc
 - bugfix: Do not write to UICR from non-secure code on nrf53
+- changed: `BufferedUarte::read_ready` now uses the same definition for 'empty' so following read calls will not block when true is returned
 
 ## 0.8.0 - 2025-09-30
 


### PR DESCRIPTION
Fixes #4774

I think this works? (On my device at least)
But maybe this is super wrong. I've not looked at this driver before, so maybe some details escape me