### PR TITLE
nrf: use DETECTMODE_SEC in GPIOTE in secure mode

### DIFF
--- a/embassy-nrf/CHANGELOG.md
+++ b/embassy-nrf/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - changed: apply trimming values from FICR.TRIMCNF on nrf53/54l
 - changed: do not panic on BufferedUarte overrun
 - added: allow direct access to the input pin of `gpiote::InputChannel`
+- bugfix: use DETECTMODE_SEC in GPIOTE in secure mode
 
 ## 0.8.0 - 2025-09-30
 

--- a/embassy-nrf/src/gpiote.rs
+++ b/embassy-nrf/src/gpiote.rs
@@ -77,6 +77,9 @@ pub(crate) fn init(irq_prio: crate::interrupt::Priority) {
 
         for &p in ports {
             // Enable latched detection
+            #[cfg(feature = "_s")]
+            p.detectmode_sec().write(|w| w.set_detectmode(Detectmode::LDETECT));
+            #[cfg(not(feature = "_s"))]
             p.detectmode().write(|w| w.set_detectmode(Detectmode::LDETECT));
             // Clear latch
             p.latch().write(|w| w.0 = 0xFFFFFFFF)


### PR DESCRIPTION
On nrf53, DETECTMODE only applies to pins assigned to non-secure. This was causing an issue where all GPIO futures would randomly get "stuck".