### PR TITLE
embassy-nrf: allow direct access to the `gpiote::InputChannel` input pin

### DIFF
--- a/embassy-nrf/CHANGELOG.md
+++ b/embassy-nrf/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - added: Add basic RTC support for nRF54L
 - changed: apply trimming values from FICR.TRIMCNF on nrf53/54l
 - changed: do not panic on BufferedUarte overrun
+- added: allow direct access to the input pin of `gpiote::InputChannel`
 
 ## 0.8.0 - 2025-09-30
 

--- a/embassy-nrf/src/gpiote.rs
+++ b/embassy-nrf/src/gpiote.rs
@@ -259,6 +259,11 @@ impl<'d> InputChannel<'d> {
         .await;
     }
 
+    /// Get the associated input pin.
+    pub fn pin(&self) -> &Input<'_> {
+        &self.pin
+    }
+
     /// Returns the IN event, for use with PPI.
     pub fn event_in(&self) -> Event<'d> {
         let g = regs();


### PR DESCRIPTION
This PR allows direct access to the pin associated with a `embassy_nrf::gpiote::InputChannel`. This is useful for example if you subscribed to both rising and falling edges to determine the pin level, or to filter out excessively short high/low signals.

The PR does not allow mutable access to the pin, although I actually think it would be perfectly safe.

I also did not allow access to the output pin of a `OutputChannel`, because that is more harmful than useful. The output level set directly through the pin would be ignored.