### PR TITLE
cyw43-pio: core clock speed based pio program selection

### DIFF
--- a/cyw43-pio/CHANGELOG.md
+++ b/cyw43-pio/CHANGELOG.md
@@ -7,7 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 <!-- next-header -->
 ## Unreleased - ReleaseDate
+
 - Select pio program based on core clock speed #4792
+
 ## 0.8.0 - 2025-08-28
 
 - Bump cyw43 version


### PR DESCRIPTION
Addresses https://github.com/embassy-rs/embassy/issues/4791.

Changes:
* Selects the GSPI pio program based on the effective pio clock speed, not the clock divider. The current approach assumes a clock speed of 133Mhz (RP2040 default) and has unexpected behavior with overclocked chips or stock RP2350 clock configuration. The implemented approach fixes these issues.
* Add an additional pio program "bucket" that allows the pico w2 (and other RP2350 & cyw43 based boards) to function with `DEFAULT_CLOCK_DIVIDER`.

Tests run using https://github.com/embassy-rs/embassy/blob/main/examples/rp/src/bin/wifi_scan.rs, copied into examples/rp235x for the 2 w tests.

pi pico 2 w

| Config | Clock divider | Pass? |
|--------|--------|--------|
| RP2350 @ 150Mhz core clock (stock) | DEFAULT_CLOCK_DIVIDER | :heavy_check_mark:  |
| RP2350 @ 150Mhz core clock (stock) | RM2_CLOCK_DIVIDER | :heavy_check_mark:  |
| RP2350 @ 200Mhz core clock| DEFAULT_CLOCK_DIVIDER | :heavy_check_mark:  |
| RP2350 @ 200Mhz core clock  | RM2_CLOCK_DIVIDER | :heavy_check_mark:  |
| RP2350 @ 50Mhz core clock | DEFAULT_CLOCK_DIVIDER | :heavy_check_mark:  |
| RP2350 @ 50Mhz core clock | RM2_CLOCK_DIVIDER | :heavy_check_mark:  |

pi pico w

| Config | Clock divider | Pass? |
|--------|--------|--------|
| RP2040 @ 133Mhz core clock (stock) | OVERCLOCK_CLOCK_DIVIDER | :heavy_check_mark:  |
| RP2040 @ 133Mhz core clock (stock) | DEFAULT_CLOCK_DIVIDER | :heavy_check_mark: |
| RP2040 @ 133Mhz core clock (stock) | RM2_CLOCK_DIVIDER | :heavy_check_mark:  |
| RP2040 @ 200Mhz core clock| DEFAULT_CLOCK_DIVIDER | :heavy_check_mark:  |
| RP2040 @ 200Mhz core clock  | RM2_CLOCK_DIVIDER | :heavy_check_mark:   |
| RP2040 @ 50Mhz core clock | DEFAULT_CLOCK_DIVIDER | :heavy_check_mark:  |
| RP2040 @ 50Mhz core clock | RM2_CLOCK_DIVIDER | :heavy_check_mark:   |