### PR TITLE
embassy-rp: doc comment spelling pass

### DIFF
--- a/embassy-rp/CHANGELOG.md
+++ b/embassy-rp/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 <!-- next-header -->
 ## Unreleased - ReleaseDate
 
-- Fix typo in interrupt comment
+- Fix several minor typos in documentation
 - Add PIO SPI
 - Add PIO I2S input
 - Add PIO onewire parasite power strong pullup

--- a/embassy-rp/src/block.rs
+++ b/embassy-rp/src/block.rs
@@ -240,7 +240,7 @@ impl UnpartitionedSpace {
         }
     }
 
-    /// Create a new unpartition space from run-time values.
+    /// Create a new unpartitioned space from run-time values.
     ///
     /// Get these from the ROM function `get_partition_table_info` with an argument of `PT_INFO`.
     pub const fn from_raw(permissions_and_location: u32, permissions_and_flags: u32) -> Self {
@@ -714,7 +714,7 @@ impl PartitionTableBlock {
         new_table
     }
 
-    /// Add a a SHA256 hash of the Block
+    /// Add a SHA256 hash of the Block
     ///
     /// Adds a `HASH_DEF` covering all the previous items in the Block, and a
     /// `HASH_VALUE` with a SHA-256 hash of them.

--- a/embassy-rp/src/clocks.rs
+++ b/embassy-rp/src/clocks.rs
@@ -267,7 +267,7 @@ impl CoreVoltage {
     }
 }
 
-/// CLock configuration.
+/// Clock configuration.
 #[non_exhaustive]
 pub struct ClockConfig {
     /// Ring oscillator configuration.

--- a/embassy-rp/src/i2c_slave.rs
+++ b/embassy-rp/src/i2c_slave.rs
@@ -52,7 +52,7 @@ pub enum ReadStatus {
     Done,
     /// Transaction Incomplete, controller trying to read more bytes than were provided
     NeedMoreBytes,
-    /// Transaction Complere, but controller stopped reading bytes before we ran out
+    /// Transaction Complete, but controller stopped reading bytes before we ran out
     LeftoverBytes(u16),
 }
 
@@ -240,7 +240,7 @@ impl<'d, T: Instance> I2cSlave<'d, T> {
 
                 if p.ic_rxflr().read().rxflr() > 0 || me.pending_byte.is_some() {
                     me.drain_fifo(buffer, &mut len);
-                    // we're recieving data, set rx fifo watermark to 12 bytes (3/4 full) to reduce interrupt noise
+                    // we're receiving data, set rx fifo watermark to 12 bytes (3/4 full) to reduce interrupt noise
                     p.ic_rx_tl().write(|w| w.set_rx_tl(11));
                 }
 

--- a/embassy-rp/src/multicore.rs
+++ b/embassy-rp/src/multicore.rs
@@ -58,7 +58,7 @@ const PAUSE_TOKEN: u32 = 0xDEADBEEF;
 const RESUME_TOKEN: u32 = !0xDEADBEEF;
 static IS_CORE1_INIT: AtomicBool = AtomicBool::new(false);
 
-/// Represents a partiticular CPU core (SIO_CPUID)
+/// Represents a particular CPU core (SIO_CPUID)
 #[derive(Debug, PartialEq, Eq, Clone, Copy, Hash)]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
 #[repr(u8)]

--- a/embassy-rp/src/pio/mod.rs
+++ b/embassy-rp/src/pio/mod.rs
@@ -62,7 +62,7 @@ pub enum FifoJoin {
     #[cfg(feature = "_rp235x")]
     RxAsControl,
     /// FJOIN_RX_PUT | FJOIN_RX_GET: RX can be used as a scratch register,
-    /// not accesible from the CPU
+    /// not accessible from the CPU
     #[cfg(feature = "_rp235x")]
     PioScratch,
 }

--- a/embassy-rp/src/pio_programs/i2s.rs
+++ b/embassy-rp/src/pio_programs/i2s.rs
@@ -1,4 +1,4 @@
-//! Pio backed I2s output and output drivers
+//! Pio backed I2S output and output drivers
 
 use fixed::traits::ToFixed;
 
@@ -9,7 +9,7 @@ use crate::pio::{
     Common, Config, Direction, FifoJoin, Instance, LoadedProgram, PioPin, ShiftConfig, ShiftDirection, StateMachine,
 };
 
-/// This struct represents an i2s receiver & controller driver program
+/// This struct represents an I2S receiver & controller driver program
 pub struct PioI2sInProgram<'d, PIO: Instance> {
     prg: LoadedProgram<'d, PIO>,
 }
@@ -35,7 +35,7 @@ impl<'d, PIO: Instance> PioI2sInProgram<'d, PIO> {
     }
 }
 
-/// Pio backed I2s input driver
+/// Pio backed I2S input driver
 pub struct PioI2sIn<'d, P: Instance, const S: usize> {
     dma: Peri<'d, AnyChannel>,
     sm: StateMachine<'d, P, S>,
@@ -50,7 +50,7 @@ impl<'d, P: Instance, const S: usize> PioI2sIn<'d, P, S> {
         // Whether or not to use the MCU's internal pull-down resistor, as the
         // Pico 2 is known to have problems with the inbuilt pulldowns, many
         // opt to just use an external pull down resistor to meet requirements of common
-        // i2s microphones such as the INMP441
+        // I2S microphones such as the INMP441
         data_pulldown: bool,
         data_pin: Peri<'d, impl PioPin>,
         bit_clock_pin: Peri<'d, impl PioPin>,
@@ -90,13 +90,13 @@ impl<'d, P: Instance, const S: usize> PioI2sIn<'d, P, S> {
         Self { dma: dma.into(), sm }
     }
 
-    /// Return an in-prograss dma transfer future. Awaiting it will guarentee a complete transfer.
+    /// Return an in-progress dma transfer future. Awaiting it will guarantee a complete transfer.
     pub fn read<'b>(&'b mut self, buff: &'b mut [u32]) -> Transfer<'b, AnyChannel> {
         self.sm.rx().dma_pull(self.dma.reborrow(), buff, false)
     }
 }
 
-/// This struct represents an i2s output driver program
+/// This struct represents an I2S output driver program
 ///
 /// The sample bit-depth is set through scratch register `Y`.
 /// `Y` has to be set to sample bit-depth - 2.
@@ -128,14 +128,14 @@ impl<'d, PIO: Instance> PioI2sOutProgram<'d, PIO> {
     }
 }
 
-/// Pio backed I2s output driver
+/// Pio backed I2S output driver
 pub struct PioI2sOut<'d, P: Instance, const S: usize> {
     dma: Peri<'d, AnyChannel>,
     sm: StateMachine<'d, P, S>,
 }
 
 impl<'d, P: Instance, const S: usize> PioI2sOut<'d, P, S> {
-    /// Configure a state machine to output I2s
+    /// Configure a state machine to output I2S
     pub fn new(
         common: &mut Common<'d, P>,
         mut sm: StateMachine<'d, P, S>,
@@ -179,7 +179,7 @@ impl<'d, P: Instance, const S: usize> PioI2sOut<'d, P, S> {
         Self { dma: dma.into(), sm }
     }
 
-    /// Return an in-prograss dma transfer future. Awaiting it will guarentee a complete transfer.
+    /// Return an in-progress dma transfer future. Awaiting it will guarantee a complete transfer.
     pub fn write<'b>(&'b mut self, buff: &'b [u32]) -> Transfer<'b, AnyChannel> {
         self.sm.tx().dma_push(self.dma.reborrow(), buff, false)
     }

--- a/embassy-rp/src/pio_programs/pwm.rs
+++ b/embassy-rp/src/pio_programs/pwm.rs
@@ -67,7 +67,7 @@ impl<'d, T: Instance, const SM: usize> PioPwm<'d, T, SM> {
         Self { sm, pin }
     }
 
-    /// Enable's the PIO program, continuing the wave generation from the PIO program.
+    /// Enables the PIO program, continuing the wave generation from the PIO program.
     pub fn start(&mut self) {
         self.sm.set_enable(true);
     }

--- a/embassy-rp/src/pio_programs/spi.rs
+++ b/embassy-rp/src/pio_programs/spi.rs
@@ -1,4 +1,4 @@
-//! PIO backed SPi drivers
+//! PIO backed SPI drivers
 
 use core::marker::PhantomData;
 
@@ -83,7 +83,7 @@ pub enum Error {
     // No errors for now
 }
 
-/// PIO based Spi driver.
+/// PIO based SPI driver.
 /// Unlike other PIO programs, the PIO SPI driver owns and holds a reference to
 /// the PIO memory it uses. This is so that it can be reconfigured at runtime if
 /// desired.

--- a/embassy-rp/src/pio_programs/uart.rs
+++ b/embassy-rp/src/pio_programs/uart.rs
@@ -130,7 +130,7 @@ impl<'d, PIO: Instance> PioUartRxProgram<'d, PIO> {
     }
 }
 
-/// PIO backed Uart reciever
+/// PIO backed Uart receiver
 pub struct PioUartRx<'d, PIO: Instance, const SM: usize> {
     sm_rx: StateMachine<'d, PIO, SM>,
 }

--- a/embassy-rp/src/rom_data/rp2040.rs
+++ b/embassy-rp/src/rom_data/rp2040.rs
@@ -30,7 +30,7 @@ const DATA_TABLE: *const u16 = 0x0000_0016 as _;
 /// Address of the version number of the ROM.
 const VERSION_NUMBER: *const u8 = 0x0000_0013 as _;
 
-/// Retrive rom content from a table using a code.
+/// Retrieve rom content from a table using a code.
 fn rom_table_lookup<T>(table: *const u16, tag: RomFnTableCode) -> T {
     unsafe {
         let rom_table_lookup_ptr: *const u32 = rom_hword_as_ptr(ROM_TABLE_LOOKUP_PTR);

--- a/embassy-rp/src/rtc/mod.rs
+++ b/embassy-rp/src/rtc/mod.rs
@@ -47,7 +47,7 @@ impl<'d, T: Instance> Rtc<'d, T> {
         Self { inner }
     }
 
-    /// Enable or disable the leap year check. The rp2040 chip will always add a Feb 29th on every year that is divisable by 4, but this may be incorrect (e.g. on century years). This function allows you to disable this check.
+    /// Enable or disable the leap year check. The rp2040 chip will always add a Feb 29th on every year that is divisible by 4, but this may be incorrect (e.g. on century years). This function allows you to disable this check.
     ///
     /// Leap year checking is enabled by default.
     pub fn set_leap_year_check(&mut self, leap_year_check_enabled: bool) {

--- a/embassy-rp/src/spi.rs
+++ b/embassy-rp/src/spi.rs
@@ -157,7 +157,7 @@ impl<'d, T: Instance, M: Mode> Spi<'d, T, M> {
 
     /// Private function to apply SPI configuration (phase, polarity, frequency) settings.
     ///
-    /// Driver should be disabled before making changes and reenabled after the modifications
+    /// Driver should be disabled before making changes and re-enabled after the modifications
     /// are applied.
     fn apply_config(inner: &Peri<'d, T>, config: &Config) {
         let p = inner.regs();

--- a/embassy-rp/src/uart/mod.rs
+++ b/embassy-rp/src/uart/mod.rs
@@ -315,7 +315,7 @@ impl<'d, M: Mode> UartRx<'d, M> {
     }
 
     /// Returns Ok(len) if no errors occurred. Returns Err((len, err)) if an error was
-    /// encountered. in both cases, `len` is the number of *good* bytes copied into
+    /// encountered. In both cases, `len` is the number of *good* bytes copied into
     /// `buffer`.
     fn drain_fifo(&mut self, buffer: &mut [u8]) -> Result<usize, (usize, Error)> {
         let r = self.info.regs;


### PR DESCRIPTION
All changes but one are to documentation comments, and one to an ordinary comment.