### PR TITLE
nrf5340: Do not write to UICR from non-secure world

### DIFF
--- a/embassy-nrf/CHANGELOG.md
+++ b/embassy-nrf/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - added: support setting the duty cycles of all channels at once in `SimplePwm`
 - changed: updated to nrf-pac with nrf52/nrf53/nrf91 register layout more similar to nrf54
 - added: support for nrf54l peripherals: uart, gpiote, twim, twis, spim, spis, dppi, pwm, saadc
+- bugfix: Do not write to UICR from non-secure code on nrf53
 
 ## 0.8.0 - 2025-09-30
 

--- a/embassy-nrf/src/lib.rs
+++ b/embassy-nrf/src/lib.rs
@@ -922,7 +922,7 @@ pub fn init(config: config::Config) -> Peripherals {
         }
     }
 
-    #[cfg(any(feature = "_nrf52", feature = "_nrf5340-app"))]
+    #[cfg(any(feature = "_nrf52", all(feature = "_nrf5340-app", feature = "_s")))]
     unsafe {
         let value = if cfg!(feature = "nfc-pins-as-gpio") { 0 } else { 1 };
         let res = uicr_write_masked(consts::UICR_NFCPINS, value, 1);


### PR DESCRIPTION
Ref nRF5340 PS v1.6:
> UICR is only accessible by secure code. Any write from non-secure code will be faulted.