### PR TITLE
embassy-nrf: add `gpiote::InputChannel::wait_for_high/low()`

### DIFF
--- a/embassy-nrf/CHANGELOG.md
+++ b/embassy-nrf/CHANGELOG.md
@@ -22,6 +22,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - bugfix: Do not write to UICR from non-secure code on nrf53
 - bugfix: Add delay to uart init anomaly fix
 - changed: `BufferedUarte::read_ready` now uses the same definition for 'empty' so following read calls will not block when true is returned
+- added: add `gpiote::InputChannel::wait_for_high()` and `wait_for_low()` to wait for specific signal level
+- changed: `gpiote::InputChannel::wait()` now takes a mutable reference to `self` to avoid interference from concurrent calls
+- changed: `gpiote::InputChannel::wait()` now ensures events are seen as soon as the function is called, even if the future is not polled
 
 ## 0.8.0 - 2025-09-30
 

--- a/embassy-nrf/src/gpiote.rs
+++ b/embassy-nrf/src/gpiote.rs
@@ -349,16 +349,73 @@ impl<'d> InputChannel<'d> {
     }
 
     /// Asynchronously wait for an event in this channel.
-    pub async fn wait(&self) {
-        let g = self.ch.regs();
-        let num = self.ch.number();
-        let waker = self.ch.waker();
+    ///
+    /// It is possible to call this function and await the returned future later.
+    /// If an even occurs in the mean time, the future will immediately report ready.
+    pub fn wait(&mut self) -> impl Future<Output = ()> {
+        // NOTE: This is `-> impl Future` and not an `async fn` on purpose.
+        // Otherwise, events will only be detected starting at the first poll of the returned future.
+        Self::wait_internal(&mut self.ch)
+    }
+
+    /// Asynchronously wait for the pin to become high.
+    ///
+    /// The channel must be configured with [`InputChannelPolarity::LoToHi`] or [`InputChannelPolarity::Toggle`].
+    /// If the channel is not configured to detect rising edges, it is unspecified when the returned future completes.
+    ///
+    /// It is possible to call this function and await the returned future later.
+    /// If an even occurs in the mean time, the future will immediately report ready.
+    pub fn wait_for_high(&mut self) -> impl Future<Output = ()> {
+        // NOTE: This is `-> impl Future` and not an `async fn` on purpose.
+        // Otherwise, events will only be detected starting at the first poll of the returned future.
+
+        // Subscribe to the event before checking the pin level.
+        let wait = Self::wait_internal(&mut self.ch);
+        let pin = &self.pin;
+        async move {
+            if pin.is_high() {
+                return;
+            }
+            wait.await;
+        }
+    }
+
+    /// Asynchronously wait for the pin to become low.
+    ///
+    /// The channel must be configured with [`InputChannelPolarity::HiToLo`] or [`InputChannelPolarity::Toggle`].
+    /// If the channel is not configured to detect falling edges, it is unspecified when the returned future completes.
+    ///
+    /// It is possible to call this function and await the returned future later.
+    /// If an even occurs in the mean time, the future will immediately report ready.
+    pub fn wait_for_low(&mut self) -> impl Future<Output = ()> {
+        // NOTE: This is `-> impl Future` and not an `async fn` on purpose.
+        // Otherwise, events will only be detected starting at the first poll of the returned future.
+
+        // Subscribe to the event before checking the pin level.
+        let wait = Self::wait_internal(&mut self.ch);
+        let pin = &self.pin;
+        async move {
+            if pin.is_low() {
+                return;
+            }
+            wait.await;
+        }
+    }
+
+    /// Internal implementation for `wait()` and friends.
+    fn wait_internal(channel: &mut Peri<'_, AnyChannel>) -> impl Future<Output = ()> {
+        // NOTE: This is `-> impl Future` and not an `async fn` on purpose.
+        // Otherwise, events will only be detected starting at the first poll of the returned future.
+
+        let g = channel.regs();
+        let num = channel.number();
+        let waker = channel.waker();
 
         // Enable interrupt
         g.events_in(num).write_value(0);
         g.intenset(INTNUM).write(|w| w.0 = 1 << num);
 
-        poll_fn(|cx| {
+        poll_fn(move |cx| {
             CHANNEL_WAKERS[waker].register(cx.waker());
 
             if g.events_in(num).read() != 0 {
@@ -367,7 +424,6 @@ impl<'d> InputChannel<'d> {
                 Poll::Pending
             }
         })
-        .await;
     }
 
     /// Get the associated input pin.

--- a/examples/nrf52840/src/bin/gpiote_channel.rs
+++ b/examples/nrf52840/src/bin/gpiote_channel.rs
@@ -12,10 +12,10 @@ async fn main(_spawner: Spawner) {
     let p = embassy_nrf::init(Default::default());
     info!("Starting!");
 
-    let ch1 = InputChannel::new(p.GPIOTE_CH0, p.P0_11, Pull::Up, InputChannelPolarity::HiToLo);
-    let ch2 = InputChannel::new(p.GPIOTE_CH1, p.P0_12, Pull::Up, InputChannelPolarity::LoToHi);
-    let ch3 = InputChannel::new(p.GPIOTE_CH2, p.P0_24, Pull::Up, InputChannelPolarity::Toggle);
-    let ch4 = InputChannel::new(p.GPIOTE_CH3, p.P0_25, Pull::Up, InputChannelPolarity::Toggle);
+    let mut ch1 = InputChannel::new(p.GPIOTE_CH0, p.P0_11, Pull::Up, InputChannelPolarity::HiToLo);
+    let mut ch2 = InputChannel::new(p.GPIOTE_CH1, p.P0_12, Pull::Up, InputChannelPolarity::LoToHi);
+    let mut ch3 = InputChannel::new(p.GPIOTE_CH2, p.P0_24, Pull::Up, InputChannelPolarity::Toggle);
+    let mut ch4 = InputChannel::new(p.GPIOTE_CH3, p.P0_25, Pull::Up, InputChannelPolarity::Toggle);
 
     let button1 = async {
         loop {

--- a/examples/nrf5340/src/bin/gpiote_channel.rs
+++ b/examples/nrf5340/src/bin/gpiote_channel.rs
@@ -12,10 +12,10 @@ async fn main(_spawner: Spawner) {
     let p = embassy_nrf::init(Default::default());
     info!("Starting!");
 
-    let ch1 = InputChannel::new(p.GPIOTE_CH0, p.P0_23, Pull::Up, InputChannelPolarity::HiToLo);
-    let ch2 = InputChannel::new(p.GPIOTE_CH1, p.P0_24, Pull::Up, InputChannelPolarity::LoToHi);
-    let ch3 = InputChannel::new(p.GPIOTE_CH2, p.P0_08, Pull::Up, InputChannelPolarity::Toggle);
-    let ch4 = InputChannel::new(p.GPIOTE_CH3, p.P0_09, Pull::Up, InputChannelPolarity::Toggle);
+    let mut ch1 = InputChannel::new(p.GPIOTE_CH0, p.P0_23, Pull::Up, InputChannelPolarity::HiToLo);
+    let mut ch2 = InputChannel::new(p.GPIOTE_CH1, p.P0_24, Pull::Up, InputChannelPolarity::LoToHi);
+    let mut ch3 = InputChannel::new(p.GPIOTE_CH2, p.P0_08, Pull::Up, InputChannelPolarity::Toggle);
+    let mut ch4 = InputChannel::new(p.GPIOTE_CH3, p.P0_09, Pull::Up, InputChannelPolarity::Toggle);
 
     let button1 = async {
         loop {

--- a/examples/nrf54l15/src/bin/gpiote_channel.rs
+++ b/examples/nrf54l15/src/bin/gpiote_channel.rs
@@ -12,10 +12,10 @@ async fn main(_spawner: Spawner) {
     let p = embassy_nrf::init(Default::default());
     info!("Starting!");
 
-    let ch1 = InputChannel::new(p.GPIOTE20_CH0, p.P1_13, Pull::Up, InputChannelPolarity::HiToLo);
-    let ch2 = InputChannel::new(p.GPIOTE20_CH1, p.P1_09, Pull::Up, InputChannelPolarity::LoToHi);
-    let ch3 = InputChannel::new(p.GPIOTE20_CH2, p.P1_08, Pull::Up, InputChannelPolarity::Toggle);
-    let ch4 = InputChannel::new(p.GPIOTE30_CH0, p.P0_04, Pull::Up, InputChannelPolarity::Toggle);
+    let mut ch1 = InputChannel::new(p.GPIOTE20_CH0, p.P1_13, Pull::Up, InputChannelPolarity::HiToLo);
+    let mut ch2 = InputChannel::new(p.GPIOTE20_CH1, p.P1_09, Pull::Up, InputChannelPolarity::LoToHi);
+    let mut ch3 = InputChannel::new(p.GPIOTE20_CH2, p.P1_08, Pull::Up, InputChannelPolarity::Toggle);
+    let mut ch4 = InputChannel::new(p.GPIOTE30_CH0, p.P0_04, Pull::Up, InputChannelPolarity::Toggle);
 
     let button1 = async {
         loop {


### PR DESCRIPTION
This PR turns `gpiote::InputChannel::wait()` into a `fn wait() -> impl Future` instead of an `async fn`. This guarantees that the interrupt is enabled and the event flag is cleared directly when the function is called, and not delayed until the future is polled.

This enables use cases like this:
```rust
let wait = input_channel.wait();
if input.pin().is_low() {
  return;
}
wait.await;
```

Which should give race-free waiting for a pin to become low.


Note: I also think this function should actually take `&mut self`. It clears the event flag, so multiple concurrent calls will interfere with each-other.

However, making it `&mut self` will actually break the use case above :p 

So.. do we :see_no_evil: about the `&self` or should I maybe directly implement functions like `wait_for_high()` and `wait_for_low()` to avoid races and still support the use case above?

Those functions might also actually want to change the event polarity though, or they would need to report an error if the polarity is wrong. Or we would need separate types for the different polarities, but that feels a bit overkill.