### PR TITLE
feat(rp): add output enable inversion API (gpio, pio)

### DIFF
--- a/embassy-rp/CHANGELOG.md
+++ b/embassy-rp/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 <!-- next-header -->
 ## Unreleased - ReleaseDate
+- Add output enable inversion API (gpio, pio)
 
 ## 0.9.0 - 2025-11-27
 

--- a/embassy-rp/src/gpio.rs
+++ b/embassy-rp/src/gpio.rs
@@ -722,6 +722,18 @@ impl<'d> Flex<'d> {
         });
     }
 
+    /// Configure the output enable inversion of this pin
+    #[inline]
+    pub fn set_output_enable_inversion(&mut self, invert: bool) {
+        self.pin.gpio().ctrl().modify(|w| {
+            w.set_oeover(if invert {
+                pac::io::vals::Oeover::INVERT
+            } else {
+                pac::io::vals::Oeover::NORMAL
+            })
+        })
+    }
+
     /// Configure the output logic inversion of this pin.
     #[inline]
     pub fn set_output_inversion(&mut self, invert: bool) {

--- a/embassy-rp/src/pio/mod.rs
+++ b/embassy-rp/src/pio/mod.rs
@@ -292,6 +292,18 @@ impl<'l, PIO: Instance> Pin<'l, PIO> {
         });
     }
 
+    /// Configure the output enable inversion of this pin
+    #[inline]
+    pub fn set_output_enable_inversion(&mut self, invert: bool) {
+        self.pin.gpio().ctrl().modify(|w| {
+            w.set_oeover(if invert {
+                pac::io::vals::Oeover::INVERT
+            } else {
+                pac::io::vals::Oeover::NORMAL
+            })
+        })
+    }
+
     /// Set the pin's input sync bypass.
     pub fn set_input_sync_bypass(&mut self, bypass: bool) {
         let mask = 1 << self.pin();


### PR DESCRIPTION
## Summary

Adds `set_output_enable_inversion` API to both GPIO and PIO pin types, providing control over output enable signal polarity.

## Changes

- Added `set_output_enable_inversion(&mut self, invert: bool)` method to GPIO pins
- Added `set_output_enable_inversion(&mut self, invert: bool)` method to PIO pins
