### PR TITLE
Migrate from cortex-ar to aarch32-cpu

### DIFF
--- a/embassy-executor/CHANGELOG.md
+++ b/embassy-executor/CHANGELOG.md
@@ -13,7 +13,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Upgraded rtos-trace
 - Added optional "highest priority" scheduling
 - Added optional "earliest deadline first" EDF scheduling
-- Bump `cortex-ar` to v0.3
+- Migrate `cortex-ar` to `aarch32-cpu`. The feature name `arch-cortex-ar` remains the same and
+  legacy ARM architectures are not supported.
 
 ## 0.9.1 - 2025-08-31
 

--- a/embassy-executor/Cargo.toml
+++ b/embassy-executor/Cargo.toml
@@ -102,7 +102,7 @@ portable-atomic = { version = "1.5", optional = true }
 cortex-m = { version = "0.7.6", optional = true }
 
 # arch-cortex-ar dependencies
-cortex-ar = { version = "0.3", optional = true }
+aarch32-cpu = { version = "0.1", optional = true }
 
 # arch-wasm dependencies
 wasm-bindgen = { version = "0.2.82", optional = true }
@@ -130,7 +130,7 @@ nightly = ["embassy-executor-macros/nightly"]
 ## Enable defmt logging
 defmt = ["dep:defmt"]
 
-## Enable log logging  
+## Enable log logging
 log = ["dep:log"]
 
 # Enables turbo wakers, which requires patching core. Not surfaced in the docs by default due to
@@ -145,7 +145,7 @@ arch-std = ["_arch"]
 ## Cortex-M
 arch-cortex-m = ["_arch", "dep:cortex-m"]
 ## Cortex-A/R
-arch-cortex-ar = ["_arch", "dep:cortex-ar"]
+arch-cortex-ar = ["_arch", "dep:aarch32-cpu", "dep:arm-targets"]
 ## RISC-V 32
 arch-riscv32 = ["_arch"]
 ## WASM
@@ -182,3 +182,6 @@ scheduler-priority = []
 ## Enable the embassy_time_driver dependency.
 ## This can unlock extra APIs, for example for the `sheduler-deadline`
 embassy-time-driver = ["dep:embassy-time-driver"]
+
+[build-dependencies]
+arm-targets = { version = "0.4", optional = true }

--- a/embassy-executor/build.rs
+++ b/embassy-executor/build.rs
@@ -4,4 +4,9 @@ mod common;
 fn main() {
     let mut rustc_cfgs = common::CfgSet::new();
     common::set_target_cfgs(&mut rustc_cfgs);
+
+    // This is used to exclude legacy architecture support. The raw executor needs to be used for
+    // those architectures because SEV/WFE are not supported.
+    #[cfg(feature = "arch-cortex-ar")]
+    arm_targets::process();
 }

--- a/embassy-executor/src/arch/cortex_ar.rs
+++ b/embassy-executor/src/arch/cortex_ar.rs
@@ -1,3 +1,6 @@
+#[cfg(arm_profile = "legacy")]
+compile_error!("`arch-cortex-ar` does not support the legacy ARM profile, WFE/SEV are not available.");
+
 #[cfg(feature = "executor-interrupt")]
 compile_error!("`executor-interrupt` is not supported with `arch-cortex-ar`.");
 
@@ -10,7 +13,7 @@ fn __pender(context: *mut ()) {
     #[cfg(feature = "executor-thread")]
     // Try to make Rust optimize the branching away if we only use thread mode.
     if !cfg!(feature = "executor-interrupt") || context == THREAD_PENDER {
-        cortex_ar::asm::sev();
+        aarch32_cpu::asm::sev();
         return;
     }
 }
@@ -23,7 +26,7 @@ mod thread {
 
     use core::marker::PhantomData;
 
-    use cortex_ar::asm::wfe;
+    use aarch32_cpu::asm::wfe;
     pub use embassy_executor_macros::main_cortex_ar as main;
 
     use crate::{Spawner, raw};


### PR DESCRIPTION
- Feature name `arch-cortex-ar` remains the same.
- Legacy ARM architectures are not supported.