### PR TITLE
Correct the temperature reading to preserve the sign bits

### DIFF
--- a/examples/rp/src/bin/pio_onewire.rs
+++ b/examples/rp/src/bin/pio_onewire.rs
@@ -61,7 +61,7 @@ async fn main(_spawner: Spawner) {
             let mut data = [0; 9];
             onewire.read_bytes(&mut data).await;
             if crc8(&data) == 0 {
-                let temp = ((data[1] as u32) << 8 | data[0] as u32) as f32 / 16.;
+                let temp = ((data[1] as i16) << 8 | data[0] as i16) as f32 / 16.;
                 info!("Read device {:x}: {} deg C", device, temp);
             } else {
                 warn!("Reading device {:x} failed", device);

--- a/examples/rp/src/bin/pio_onewire_parasite.rs
+++ b/examples/rp/src/bin/pio_onewire_parasite.rs
@@ -63,7 +63,7 @@ async fn main(_spawner: Spawner) {
             let mut data = [0; 9];
             onewire.read_bytes(&mut data).await;
             if crc8(&data) == 0 {
-                let temp = ((data[1] as u32) << 8 | data[0] as u32) as f32 / 16.;
+                let temp = ((data[1] as i16) << 8 | data[0] as i16) as f32 / 16.;
                 info!("Read device {:x}: {} deg C", device, temp);
             } else {
                 warn!("Reading device {:x} failed. {:02x}", device, data);

--- a/examples/rp235x/src/bin/pio_onewire.rs
+++ b/examples/rp235x/src/bin/pio_onewire.rs
@@ -61,7 +61,7 @@ async fn main(_spawner: Spawner) {
             let mut data = [0; 9];
             onewire.read_bytes(&mut data).await;
             if crc8(&data) == 0 {
-                let temp = ((data[1] as u32) << 8 | data[0] as u32) as f32 / 16.;
+                let temp = ((data[1] as i16) << 8 | data[0] as i16) as f32 / 16.;
                 info!("Read device {:x}: {} deg C", device, temp);
             } else {
                 warn!("Reading device {:x} failed", device);

--- a/examples/rp235x/src/bin/pio_onewire_parasite.rs
+++ b/examples/rp235x/src/bin/pio_onewire_parasite.rs
@@ -63,7 +63,7 @@ async fn main(_spawner: Spawner) {
             let mut data = [0; 9];
             onewire.read_bytes(&mut data).await;
             if crc8(&data) == 0 {
-                let temp = ((data[1] as u32) << 8 | data[0] as u32) as f32 / 16.;
+                let temp = ((data[1] as i16) << 8 | data[0] as i16) as f32 / 16.;
                 info!("Read device {:x}: {} deg C", device, temp);
             } else {
                 warn!("Reading device {:x} failed. {:02x}", device, data);

--- a/examples/stm32g0/src/bin/onewire_ds18b20.rs
+++ b/examples/stm32g0/src/bin/onewire_ds18b20.rs
@@ -267,7 +267,7 @@ where
         }
 
         match Self::crc8(&data) == 0 {
-            true => Ok(((data[1] as u16) << 8 | data[0] as u16) as f32 / 16.),
+            true => Ok(((data[1] as i16) << 8 | data[0] as i16) as f32 / 16.),
             false => Err(()),
         }
     }


### PR DESCRIPTION
The examples with code to show reading temperature from DS18B20 devices incorrectly stage the bytes to an incorrect type and lose the temperature sign.  Fixes #4825 . 