### PR TITLE
Fixed STM32WBA VREFBUF values to match reference manual

### DIFF
--- a/embassy-stm32/CHANGELOG.md
+++ b/embassy-stm32/CHANGELOG.md
@@ -39,6 +39,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - feat: stm32/fdcan: add ability to control automatic recovery from bus off ([#4821](https://github.com/embassy-rs/embassy/pull/4821))
 - low-power: update rtc api to allow reconfig
 - feat: Added RTC low-power support for STM32WLEx ([#4716](https://github.com/embassy-rs/embassy/pull/4716))
+- fix: Correct STM32WBA VREFBUFTRIM values
 
 ## 0.4.0 - 2025-08-26
 

--- a/embassy-stm32/src/vrefbuf/mod.rs
+++ b/embassy-stm32/src/vrefbuf/mod.rs
@@ -14,10 +14,10 @@ pub struct VoltageReferenceBuffer<'d, T: Instance> {
 #[cfg(rcc_wba)]
 fn get_refbuf_trim(voltage_scale: Vrs) -> usize {
     match voltage_scale {
-        Vrs::VREF0 => 0x0BFA_07A8usize,
-        Vrs::VREF1 => 0x0BFA_07A9usize,
-        Vrs::VREF2 => 0x0BFA_07AAusize,
-        Vrs::VREF3 => 0x0BFA_07ABusize,
+        Vrs::VREF0 => 0x0BFA_07ABusize,
+        Vrs::VREF1 => 0x0BFA_07AAusize,
+        Vrs::VREF2 => 0x0BFA_07A9usize,
+        Vrs::VREF3 => 0x0BFA_07A8usize,
         _ => panic!("Incorrect Vrs setting!"),
     }
 }


### PR DESCRIPTION
On RM0515 Rev 3 page 758 the VREFBUF calibration values are actually all flipped.

<img width="897" height="293" alt="Screenshot 2025-11-03 at 3 02 21 PM" src="https://github.com/user-attachments/assets/2db726ba-3d35-4ee3-b355-1372088f6961" />

This PR fixes that