### PR TITLE
low-power: propose new api

### DIFF
--- a/embassy-stm32/src/rtc/mod.rs
+++ b/embassy-stm32/src/rtc/mod.rs
@@ -43,6 +43,7 @@ pub enum RtcError {
     NotRunning,
 }
 
+#[derive(Clone)]
 /// Provides immutable access to the current time of the RTC.
 pub struct RtcTimeProvider {
     _private: (),

--- a/examples/stm32l5/src/bin/stop.rs
+++ b/examples/stm32l5/src/bin/stop.rs
@@ -25,11 +25,7 @@ async fn async_main(spawner: Spawner) {
     // when enabled the power-consumption is much higher during stop, but debugging and RTT is working
     // if you wan't to measure the power-consumption, or for production: uncomment this line
     // config.enable_debug_during_sleep = false;
-    let p = embassy_stm32::init(config);
-
-    // give the RTC to the executor...
-    let rtc = Rtc::new(p.RTC, RtcConfig::default());
-    embassy_stm32::low_power::stop_with_rtc(rtc);
+    let (p, _time_provider) = embassy_stm32::init_lp(config, RtcConfig::default());
 
     spawner.spawn(unwrap!(blinky(p.PC7.into())));
     spawner.spawn(unwrap!(timeout()));


### PR DESCRIPTION
This is the proposed new api, taken from this comment: https://github.com/embassy-rs/embassy/issues/4110#issuecomment-2875694219 by @Dirbaio:

> I think it'd be even better if embassy_stm32::init would take care of everything automatically, like it does with the regular time driver. It'd init the RTC (or at least part of it) to make the low-power time driver work, then the peripheral singleton p.RTC would still be available, the "user-visible" RTC driver would let the user do everything except stuff that would disrupt the time driver.

The problem is that, if the low power feature is enabled, the rtc will always be configured in embassy_stm32::init, regardless of whether the low-power executor is used. In other examples, the low power executor is not used, but the low power feature is enabled for all of them.