### PR TITLE
rtc: use consistent api between stop and non-stop

### DIFF
--- a/embassy-stm32/src/low_power.rs
+++ b/embassy-stm32/src/low_power.rs
@@ -61,8 +61,6 @@ use crate::time_driver::get_driver;
 
 const THREAD_PENDER: usize = usize::MAX;
 
-use crate::rtc::Rtc;
-
 static mut EXECUTOR: Option<Executor> = None;
 
 /// Prevent the device from going into the stop mode if held
@@ -131,11 +129,6 @@ foreach_interrupt! {
             Executor::on_wakeup_irq();
         }
     };
-}
-
-/// Reconfigure the RTC, if set.
-pub fn reconfigure_rtc<R>(f: impl FnOnce(&mut Rtc) -> R) -> R {
-    get_driver().reconfigure_rtc(f)
 }
 
 /// Get whether the core is ready to enter the given stop mode.

--- a/embassy-stm32/src/rtc/low_power.rs
+++ b/embassy-stm32/src/rtc/low_power.rs
@@ -4,7 +4,7 @@ use embassy_time::{Duration, TICK_HZ};
 use super::{DateTimeError, Rtc, RtcError, bcd2_to_byte};
 use crate::interrupt::typelevel::Interrupt;
 use crate::peripherals::RTC;
-use crate::rtc::SealedInstance;
+use crate::rtc::{RtcTimeProvider, SealedInstance};
 
 /// Represents an instant in time that can be substracted to compute a duration
 pub(super) struct RtcInstant {
@@ -117,7 +117,7 @@ impl WakeupPrescaler {
 impl Rtc {
     /// Return the current instant.
     fn instant(&self) -> Result<RtcInstant, RtcError> {
-        self.time_provider().read(|_, tr, ss| {
+        RtcTimeProvider::new().read(|_, tr, ss| {
             let second = bcd2_to_byte((tr.st(), tr.su()));
 
             RtcInstant::from(second, ss).map_err(RtcError::InvalidDateTime)

--- a/embassy-stm32/src/time_driver.rs
+++ b/embassy-stm32/src/time_driver.rs
@@ -215,7 +215,7 @@ pub(crate) struct RtcDriver {
     period: AtomicU32,
     alarm: Mutex<CriticalSectionRawMutex, AlarmState>,
     #[cfg(feature = "low-power")]
-    rtc: Mutex<CriticalSectionRawMutex, RefCell<Option<Rtc>>>,
+    pub(crate) rtc: Mutex<CriticalSectionRawMutex, RefCell<Option<Rtc>>>,
     #[cfg(feature = "low-power")]
     /// The minimum pause time beyond which the executor will enter a low-power state.
     min_stop_pause: Mutex<CriticalSectionRawMutex, Cell<embassy_time::Duration>>,
@@ -418,12 +418,6 @@ impl RtcDriver {
         rtc.stop_wakeup_alarm(cs);
 
         assert!(self.rtc.borrow(cs).replace(Some(rtc)).is_none());
-    }
-
-    #[cfg(feature = "low-power")]
-    /// Reconfigure the rtc
-    pub(crate) fn reconfigure_rtc<R>(&self, f: impl FnOnce(&mut Rtc) -> R) -> R {
-        critical_section::with(|cs| f(self.rtc.borrow(cs).borrow_mut().as_mut().unwrap()))
     }
 
     #[cfg(feature = "low-power")]

--- a/examples/stm32c0/src/bin/rtc.rs
+++ b/examples/stm32c0/src/bin/rtc.rs
@@ -21,12 +21,12 @@ async fn main(_spawner: Spawner) {
         .and_hms_opt(10, 30, 15)
         .unwrap();
 
-    let mut rtc = Rtc::new(p.RTC, RtcConfig::default());
+    let (mut rtc, time_provider) = Rtc::new(p.RTC, RtcConfig::default());
 
     rtc.set_datetime(now.into()).expect("datetime not set");
 
     loop {
-        let now: NaiveDateTime = rtc.now().unwrap().into();
+        let now: NaiveDateTime = time_provider.now().unwrap().into();
 
         info!("{}", now.and_utc().timestamp());
 

--- a/examples/stm32f4/src/bin/rtc.rs
+++ b/examples/stm32f4/src/bin/rtc.rs
@@ -21,12 +21,12 @@ async fn main(_spawner: Spawner) {
         .and_hms_opt(10, 30, 15)
         .unwrap();
 
-    let mut rtc = Rtc::new(p.RTC, RtcConfig::default());
+    let (mut rtc, time_provider) = Rtc::new(p.RTC, RtcConfig::default());
 
     rtc.set_datetime(now.into()).expect("datetime not set");
 
     loop {
-        let now: NaiveDateTime = rtc.now().unwrap().into();
+        let now: NaiveDateTime = time_provider.now().unwrap().into();
 
         info!("{}", now.and_utc().timestamp());
 

--- a/examples/stm32g0/src/bin/rtc.rs
+++ b/examples/stm32g0/src/bin/rtc.rs
@@ -17,12 +17,12 @@ async fn main(_spawner: Spawner) {
 
     let now = DateTime::from(2023, 6, 14, DayOfWeek::Friday, 15, 59, 10, 0);
 
-    let mut rtc = Rtc::new(p.RTC, RtcConfig::default());
+    let (mut rtc, time_provider) = Rtc::new(p.RTC, RtcConfig::default());
 
     rtc.set_datetime(now.unwrap()).expect("datetime not set");
 
     loop {
-        let now: DateTime = rtc.now().unwrap().into();
+        let now: DateTime = time_provider.now().unwrap().into();
 
         info!("{}:{}:{}", now.hour(), now.minute(), now.second());
 

--- a/examples/stm32h7/src/bin/rtc.rs
+++ b/examples/stm32h7/src/bin/rtc.rs
@@ -23,7 +23,7 @@ async fn main(_spawner: Spawner) {
         .and_hms_opt(10, 30, 15)
         .unwrap();
 
-    let mut rtc = Rtc::new(p.RTC, RtcConfig::default());
+    let (mut rtc, time_provider) = Rtc::new(p.RTC, RtcConfig::default());
     info!("Got RTC! {:?}", now.and_utc().timestamp());
 
     rtc.set_datetime(now.into()).expect("datetime not set");
@@ -31,6 +31,6 @@ async fn main(_spawner: Spawner) {
     // In reality the delay would be much longer
     Timer::after_millis(20000).await;
 
-    let then: NaiveDateTime = rtc.now().unwrap().into();
+    let then: NaiveDateTime = time_provider.now().unwrap().into();
     info!("Got RTC! {:?}", then.and_utc().timestamp());
 }

--- a/examples/stm32h7rs/src/bin/rtc.rs
+++ b/examples/stm32h7rs/src/bin/rtc.rs
@@ -23,7 +23,7 @@ async fn main(_spawner: Spawner) {
         .and_hms_opt(10, 30, 15)
         .unwrap();
 
-    let mut rtc = Rtc::new(p.RTC, RtcConfig::default());
+    let (mut rtc, time_provider) = Rtc::new(p.RTC, RtcConfig::default());
     info!("Got RTC! {:?}", now.and_utc().timestamp());
 
     rtc.set_datetime(now.into()).expect("datetime not set");
@@ -31,6 +31,6 @@ async fn main(_spawner: Spawner) {
     // In reality the delay would be much longer
     Timer::after_millis(20000).await;
 
-    let then: NaiveDateTime = rtc.now().unwrap().into();
+    let then: NaiveDateTime = time_provider.now().unwrap().into();
     info!("Got RTC! {:?}", then.and_utc().timestamp());
 }

--- a/examples/stm32l4/src/bin/rtc.rs
+++ b/examples/stm32l4/src/bin/rtc.rs
@@ -39,7 +39,7 @@ async fn main(_spawner: Spawner) {
         .and_hms_opt(10, 30, 15)
         .unwrap();
 
-    let mut rtc = Rtc::new(p.RTC, RtcConfig::default());
+    let (mut rtc, time_provider) = Rtc::new(p.RTC, RtcConfig::default());
     info!("Got RTC! {:?}", now.and_utc().timestamp());
 
     rtc.set_datetime(now.into()).expect("datetime not set");
@@ -47,6 +47,6 @@ async fn main(_spawner: Spawner) {
     // In reality the delay would be much longer
     Timer::after_millis(20000).await;
 
-    let then: NaiveDateTime = rtc.now().unwrap().into();
+    let then: NaiveDateTime = time_provider.now().unwrap().into();
     info!("Got RTC! {:?}", then.and_utc().timestamp());
 }

--- a/examples/stm32u0/src/bin/rtc.rs
+++ b/examples/stm32u0/src/bin/rtc.rs
@@ -36,7 +36,7 @@ async fn main(_spawner: Spawner) {
         .and_hms_opt(10, 30, 15)
         .unwrap();
 
-    let mut rtc = Rtc::new(p.RTC, RtcConfig::default());
+    let (mut rtc, time_provider) = Rtc::new(p.RTC, RtcConfig::default());
     info!("Got RTC! {:?}", now.and_utc().timestamp());
 
     rtc.set_datetime(now.into()).expect("datetime not set");
@@ -44,6 +44,6 @@ async fn main(_spawner: Spawner) {
     // In reality the delay would be much longer
     Timer::after_millis(20000).await;
 
-    let then: NaiveDateTime = rtc.now().unwrap().into();
+    let then: NaiveDateTime = time_provider.now().unwrap().into();
     info!("Got RTC! {:?}", then.and_utc().timestamp());
 }

--- a/examples/stm32wl/src/bin/rtc.rs
+++ b/examples/stm32wl/src/bin/rtc.rs
@@ -44,7 +44,7 @@ async fn main(_spawner: Spawner) {
         .and_hms_opt(10, 30, 15)
         .unwrap();
 
-    let mut rtc = Rtc::new(p.RTC, RtcConfig::default());
+    let (mut rtc, time_provider) = Rtc::new(p.RTC, RtcConfig::default());
     info!("Got RTC! {:?}", now.and_utc().timestamp());
 
     rtc.set_datetime(now.into()).expect("datetime not set");
@@ -52,6 +52,6 @@ async fn main(_spawner: Spawner) {
     // In reality the delay would be much longer
     Timer::after_millis(20000).await;
 
-    let then: NaiveDateTime = rtc.now().unwrap().into();
+    let then: NaiveDateTime = time_provider.now().unwrap().into();
     info!("Got RTC! {:?}", then.and_utc().timestamp());
 }

--- a/tests/stm32/Cargo.toml
+++ b/tests/stm32/Cargo.toml
@@ -94,6 +94,7 @@ rand_core = { version = "0.9.1", default-features = false }
 rand_chacha = { version = "0.9.0", default-features = false }
 static_cell = "2"
 portable-atomic = { version = "1.5", features = [] }
+critical-section = "1.1"
 
 chrono = { version = "^0.4", default-features = false, optional = true}
 sha2 = { version = "0.10.8", default-features = false }

--- a/tests/stm32/src/bin/stop.rs
+++ b/tests/stm32/src/bin/stop.rs
@@ -10,8 +10,9 @@ use common::*;
 use cortex_m_rt::entry;
 use embassy_executor::Spawner;
 use embassy_stm32::Config;
-use embassy_stm32::low_power::{Executor, StopMode, reconfigure_rtc, stop_ready};
+use embassy_stm32::low_power::{Executor, StopMode, stop_ready};
 use embassy_stm32::rcc::LsConfig;
+use embassy_stm32::rtc::Rtc;
 use embassy_time::Timer;
 
 #[entry]
@@ -56,7 +57,7 @@ async fn async_main(spawner: Spawner) {
         config.rcc.hsi = Some(HSIPrescaler::DIV4); // 64 MHz HSI will need a /4
     }
 
-    let _p = init_with_config(config);
+    let p = init_with_config(config);
     info!("Hello World!");
 
     let now = NaiveDate::from_ymd_opt(2020, 5, 15)
@@ -64,7 +65,11 @@ async fn async_main(spawner: Spawner) {
         .and_hms_opt(10, 30, 15)
         .unwrap();
 
-    reconfigure_rtc(|rtc| rtc.set_datetime(now.into()).expect("datetime not set"));
+    let (rtc, _time_provider) = Rtc::new(p.RTC);
+
+    critical_section::with(|cs| {
+        rtc.borrow_mut(cs).set_datetime(now.into()).expect("datetime not set");
+    });
 
     spawner.spawn(task_1().unwrap());
     spawner.spawn(task_2().unwrap());


### PR DESCRIPTION
replace `reconfigure_rtc` with a mutex.