### PR TITLE
nrf/i2s: allow master mode without MCK pin

### DIFF
--- a/embassy-nrf/CHANGELOG.md
+++ b/embassy-nrf/CHANGELOG.md
@@ -23,6 +23,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - bugfix: Do not write to UICR from non-secure code on nrf53
 - bugfix: Add delay to uart init anomaly fix
 - changed: `BufferedUarte::read_ready` now uses the same definition for 'empty' so following read calls will not block when true is returned
+- changed: allow configuring I2S in master mode without master clock output pin
 
 ## 0.8.0 - 2025-09-30
 

--- a/embassy-nrf/CHANGELOG.md
+++ b/embassy-nrf/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - added: System OFF support for the nRF54L series.
 - bugfix: usb: don't re-arm OUT endpoints twice per packet, which could silently drop received packets under load.
 - bugfix: usb: apply the nRF52840 Erratum 199 workaround around USBD EasyDMA transfers.
+- changed: allow configuring I2S in master mode without master clock output pin
 
 ## 0.11.0 - 2026-06-16
 

--- a/embassy-nrf/src/i2s.rs
+++ b/embassy-nrf/src/i2s.rs
@@ -422,7 +422,7 @@ impl<'d> I2S<'d> {
     pub fn new_master<T: Instance>(
         _i2s: Peri<'d, T>,
         _irq: impl interrupt::typelevel::Binding<T::Interrupt, InterruptHandler<T>> + 'd,
-        mck: Peri<'d, impl GpioPin>,
+        mck: Option<Peri<'d, impl GpioPin>>,
         sck: Peri<'d, impl GpioPin>,
         lrck: Peri<'d, impl GpioPin>,
         master_clock: MasterClock,
@@ -434,7 +434,7 @@ impl<'d> I2S<'d> {
         Self {
             r: T::regs(),
             state: T::state(),
-            mck: Some(mck.into()),
+            mck: mck.map(|mck| mck.into()),
             sck: sck.into(),
             lrck: lrck.into(),
             sdin: None,

--- a/embassy-nrf/src/i2s.rs
+++ b/embassy-nrf/src/i2s.rs
@@ -423,13 +423,36 @@ pub struct I2S<'d> {
 }
 
 impl<'d> I2S<'d> {
-    /// Create a new I2S in master mode
+    /// Create a new I2S in master mode without an MCK output pin.
     pub fn new_master<T: Instance>(
-        _i2s: Peri<'d, T>,
+        i2s: Peri<'d, T>,
+        _irq: impl interrupt::typelevel::Binding<T::Interrupt, InterruptHandler<T>> + 'd,
+        sck: Peri<'d, impl GpioPin>,
+        lrck: Peri<'d, impl GpioPin>,
+        master_clock: MasterClock,
+        config: Config,
+    ) -> Self {
+        Self::new_inner(i2s, None, sck.into(), lrck.into(), master_clock, config)
+    }
+
+    /// Create a new I2S in master mode with an MCK output pin.
+    pub fn new_master_with_mck<T: Instance>(
+        i2s: Peri<'d, T>,
         _irq: impl interrupt::typelevel::Binding<T::Interrupt, InterruptHandler<T>> + 'd,
         mck: Peri<'d, impl GpioPin>,
         sck: Peri<'d, impl GpioPin>,
         lrck: Peri<'d, impl GpioPin>,
+        master_clock: MasterClock,
+        config: Config,
+    ) -> Self {
+        Self::new_inner(i2s, Some(mck.into()), sck.into(), lrck.into(), master_clock, config)
+    }
+
+    fn new_inner<T: Instance>(
+        _i2s: Peri<'d, T>,
+        mck: Option<Peri<'d, AnyPin>>,
+        sck: Peri<'d, AnyPin>,
+        lrck: Peri<'d, AnyPin>,
         master_clock: MasterClock,
         config: Config,
     ) -> Self {
@@ -439,9 +462,9 @@ impl<'d> I2S<'d> {
         Self {
             r: T::regs(),
             state: T::state(),
-            mck: Some(mck.into()),
-            sck: sck.into(),
-            lrck: lrck.into(),
+            mck,
+            sck,
+            lrck,
             sdin: None,
             sdout: None,
             master_clock: Some(master_clock),

--- a/examples/nrf52840/src/bin/i2s_effect.rs
+++ b/examples/nrf52840/src/bin/i2s_effect.rs
@@ -34,7 +34,7 @@ async fn main(_spawner: Spawner) {
 
     let buffers_out = MultiBuffering::<Sample, NUM_BUFFERS, NUM_SAMPLES>::new();
     let buffers_in = MultiBuffering::<Sample, NUM_BUFFERS, NUM_SAMPLES>::new();
-    let mut full_duplex_stream = I2S::new_master(p.I2S, Irqs, p.P0_25, p.P0_26, p.P0_27, master_clock, config)
+    let mut full_duplex_stream = I2S::new_master_with_mck(p.I2S, Irqs, p.P0_25, p.P0_26, p.P0_27, master_clock, config)
         .full_duplex(p.P0_29, p.P0_28, buffers_out, buffers_in);
 
     let mut modulator = SineOsc::new();

--- a/examples/nrf52840/src/bin/i2s_monitor.rs
+++ b/examples/nrf52840/src/bin/i2s_monitor.rs
@@ -32,7 +32,7 @@ async fn main(_spawner: Spawner) {
 
     let buffers = DoubleBuffering::<Sample, NUM_SAMPLES>::new();
     let mut input_stream =
-        I2S::new_master(p.I2S, Irqs, p.P0_25, p.P0_26, p.P0_27, master_clock, config).input(p.P0_29, buffers);
+        I2S::new_master_with_mck(p.I2S, Irqs, p.P0_25, p.P0_26, p.P0_27, master_clock, config).input(p.P0_29, buffers);
 
     // Configure the PWM to use the pins corresponding to the RGB leds
     let mut pwm = SimplePwm::new_3ch(p.PWM0, p.P0_23, p.P0_22, p.P0_24, &Default::default());

--- a/examples/nrf52840/src/bin/i2s_waveform.rs
+++ b/examples/nrf52840/src/bin/i2s_waveform.rs
@@ -33,7 +33,7 @@ async fn main(_spawner: Spawner) {
 
     let buffers = DoubleBuffering::<Sample, NUM_SAMPLES>::new();
     let mut output_stream =
-        I2S::new_master(p.I2S, Irqs, p.P0_25, p.P0_26, p.P0_27, master_clock, config).output(p.P0_28, buffers);
+        I2S::new_master_with_mck(p.I2S, Irqs, p.P0_25, p.P0_26, p.P0_27, master_clock, config).output(p.P0_28, buffers);
 
     let mut waveform = Waveform::new(1.0 / sample_rate as f32);
 


### PR DESCRIPTION
Outputting the generated master clock is optional as per Nordic docs: "The MCK signal can be routed to an output pin (specified in PSEL.MCK) to supply external I2S devices that require the MCK to be supplied from the outside." [1]

Some I2S DACs, such as MAX98357A, don't require a master clock input so it can be left disconnected. nRF Connect SDK supports this.

[1] https://docs.nordicsemi.com/bundle/ps_nrf52833/page/i2s.html
[2] https://www.analog.com/media/en/technical-documentation/data-sheets/max98357a-max98357b.pdf

---

Not sure whether this API is ideal as it requires the caller to write `None::<Peri<'static, AnyPin>>`. Maybe these functions should be changed to take AnyPin like some other APIs?