### PR TITLE
tests: disable rtc for h563 on non-stop

### DIFF
--- a/embassy-stm32/Cargo.toml
+++ b/embassy-stm32/Cargo.toml
@@ -313,6 +313,7 @@ single-bank = []
 
 ## internal use only
 _split-pins-enabled = []
+_allow-disable-rtc = []
 
 ## internal use only
 _dual-core = []

--- a/tests/stm32/Cargo.toml
+++ b/tests/stm32/Cargo.toml
@@ -73,7 +73,7 @@ teleprobe-meta = "1"
 embassy-sync = { version = "0.7.2", path = "../../embassy-sync", features = ["defmt"] }
 embassy-executor = { version = "0.9.0", path = "../../embassy-executor", features = ["arch-cortex-m", "executor-thread", "defmt"] }
 embassy-time = { version = "0.5.0", path = "../../embassy-time", features = ["defmt", "tick-hz-131_072", "defmt-timestamp-uptime"] }
-embassy-stm32 = { version = "0.4.0", path = "../../embassy-stm32", features = [ "defmt", "unstable-pac", "memory-x", "time-driver-any"]  }
+embassy-stm32 = { version = "0.4.0", path = "../../embassy-stm32", features = [ "defmt", "unstable-pac", "memory-x", "time-driver-any", "_allow-disable-rtc"]  }
 embassy-futures = { version = "0.1.2", path = "../../embassy-futures" }
 embassy-stm32-wpan = { version = "0.1.0", path = "../../embassy-stm32-wpan", optional = true, features = ["defmt", "stm32wb55rg", "ble"] }
 embassy-net = { version = "0.7.1", path = "../../embassy-net", features = ["defmt",  "tcp", "udp", "dhcpv4", "medium-ethernet"] }

--- a/tests/stm32/src/bin/rtc.rs
+++ b/tests/stm32/src/bin/rtc.rs
@@ -19,6 +19,10 @@ use embassy_time::Timer;
 async fn main(_spawner: Spawner) {
     let mut config = config();
     config.rcc.ls = LsConfig::default_lse();
+    #[cfg(feature = "stop")]
+    {
+        config.rtc._disable_rtc = false;
+    }
 
     let p = init_with_config(config);
     info!("Hello World!");

--- a/tests/stm32/src/bin/stop.rs
+++ b/tests/stm32/src/bin/stop.rs
@@ -49,6 +49,7 @@ async fn async_main(spawner: Spawner) {
 
     let mut config = Config::default();
     config.rcc.ls = LsConfig::default_lse();
+    config.rtc._disable_rtc = false;
 
     // System Clock seems cannot be greater than 16 MHz
     #[cfg(any(feature = "stm32h563zi", feature = "stm32h503rb"))]

--- a/tests/stm32/src/common.rs
+++ b/tests/stm32/src/common.rs
@@ -468,6 +468,8 @@ pub fn config() -> Config {
         config.rcc.apb3_pre = APBPrescaler::DIV1;
         config.rcc.sys = Sysclk::PLL1_P;
         config.rcc.voltage_scale = VoltageScale::Scale0;
+
+        config.rtc._disable_rtc = true;
     }
 
     #[cfg(feature = "stm32h503rb")]


### PR DESCRIPTION
Prevent cordic tests from failing on h563 when the rtc is enabled.