### PR TITLE
Fix usb-logger panic on usb disconnect

### DIFF
--- a/embassy-usb-logger/CHANGELOG.md
+++ b/embassy-usb-logger/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 <!-- next-header -->
 ## Unreleased - ReleaseDate
 
+- Fixed panic in `UsbLogger` when usb is disconnected
+
 ## 0.5.1 - 2025-08-26
 
 ## 0.5.0 - 2025-07-22


### PR DESCRIPTION
The embassy-usb-logger task panics on an `.unwrap()` as soon as the USB is disconnected. This catches the error and awaits a new connection. 