### PR TITLE
Fix erroneous timeouts on successful async I2C target read/writes

### DIFF
--- a/embassy-stm32/src/i2c/v2.rs
+++ b/embassy-stm32/src/i2c/v2.rs
@@ -1196,7 +1196,7 @@ impl<'d> I2c<'d, Async, MultiMaster> {
 
         let regs = self.info.regs;
 
-        let dma_transfer = unsafe {
+        let mut dma_transfer = unsafe {
             regs.cr1().modify(|w| {
                 w.set_rxdmaen(true);
                 w.set_stopie(true);
@@ -1244,6 +1244,7 @@ impl<'d> I2c<'d, Async, MultiMaster> {
         })
         .await?;
 
+        dma_transfer.request_pause();
         dma_transfer.await;
 
         drop(on_drop);
@@ -1309,6 +1310,7 @@ impl<'d> I2c<'d, Async, MultiMaster> {
         })
         .await?;
 
+        dma_transfer.request_pause();
         dma_transfer.await;
 
         drop(on_drop);


### PR DESCRIPTION
I observed an issue where I2C target writes were timing out, even though they had completed successfully. I found that this was because it was possible to reach the dma_transfer.await statement in the cleanup at the end of read_dma_internal_slave, without that DMA transfer being reset or paused first.

This comes up when accepting I2C writes of arbitrary length, with some maximum. Writes shorter than the maximum are terminated by the stop condition on the bus, at which point the function should return the number of bytes written even if it was less than the size of the buffer. This change ensures that the function doesn't treat the existence of additional space in the DMA buffer as a block on returning.

I made the same change to write_dma_internal_slave function, as it also shouldn't fail to return just because there's leftover space in the DMA buffer.

Timeouts will continue to function properly, as respond_to_write and respond_to_write wrap the futures from the *_dma_internal_slave functions in a Timeout future.