### PR TITLE
feat: add set_nagle_enabled to TcpSocket

### DIFF
--- a/embassy-net/CHANGELOG.md
+++ b/embassy-net/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 <!-- next-header -->
 ## Unreleased - ReleaseDate
 
+- tcp: Add `set_nagle_enabled()` to control TcpSocket nagle algorithm.
+
 ## 0.7.1 - 2025-08-26
 
 No unreleased changes yet... Quick, go send a PR!

--- a/embassy-net/src/tcp.rs
+++ b/embassy-net/src/tcp.rs
@@ -373,6 +373,20 @@ impl<'a> TcpSocket<'a> {
         self.io.with_mut(|s, _| s.set_hop_limit(hop_limit))
     }
 
+    /// Enable or disable Nagles's algorithm.
+    ///
+    /// By default, Nagle's algorithm is enabled.
+    /// When enabled, Nagle’s Algorithm prevents sending segments smaller
+    /// than MSS if there is data in flight (sent but not acknowledged).
+    /// In other words, it ensures at most only one segment smaller than
+    /// MSS is in flight at a time.
+    /// It ensures better network utilization by preventing sending many
+    /// very small packets, at the cost of increased latency in some
+    /// situations, particularly when the remote peer has ACK delay enabled.
+    pub fn set_nagle_enabled(&mut self, enabled: bool) {
+        self.io.with_mut(|s, _| s.set_nagle_enabled(enabled))
+    }
+
     /// Get the local endpoint of the socket.
     ///
     /// Returns `None` if the socket is not bound (listening) or not connected.


### PR DESCRIPTION
Adding fn TcpSocket::set_nagle_enabled to control
the nagle algorithm for this socket.