### PR TITLE
Fix I2C target nbytes return, and alignment of repeated target reads

### DIFF
--- a/embassy-stm32/CHANGELOG.md
+++ b/embassy-stm32/CHANGELOG.md
@@ -53,6 +53,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - feat: stm32/spi: added support for slave mode ([#4388](https://github.com/embassy-rs/embassy/pull/4388))
 - chore: Updated stm32-metapac and stm32-data dependencies
 - adc: reogranize and cleanup somewhat. require sample_time to be passed on conversion
+- fix: stm32/i2c v2 slave: prevent misaligned reads, error false positives, and incorrect counts of bytes read/written
 
 ## 0.4.0 - 2025-08-26
 


### PR DESCRIPTION
The STM32 line has a very irritating behavior for target mode reads: if there's a byte leftover in TXDR when a read is terminated, TXE remains low indefinitely. Then, when the next target mode read occurs, that leftover byte is treated as the first byte of the next transfer, causing it to be misaligned.

When using DMA, the DMA request from the peripheral happens as soon as the peripheral starts sending the previous byte - before the STOP condition. So Read 1's DMA will pull in a byte before it learns that the byte is unneeded, triggering the problem.

From page 604 of the STM32L0x1 reference manual (it's the same for the whole line):

> When a STOP is received and the STOPIE bit is set in the I2C_CR1 register, the STOPF
flag is set in the I2C_ISR register and an interrupt is generated. In most applications, the
SBC bit is usually programmed to ‘0’. In this case, If TXE = 0 when the slave address is
received (ADDR = 1), the user can choose either to send the content of the I2C_TXDR
register as the first data byte, or to flush the I2C_TXDR register by setting the TXE bit in
order to program a new data byte. 

This change adds that flush of TXDR to the drop guard for write_dma_internal_slave, so that the next read won't pick up that garbage byte. It's a call to write(), not modify(), because you aren't meant to write back the other values in the ISR when resetting TXE or TXIS.

I also fixed the return values for write_dma_internal_slave and read_dma_internal_slave - they weren't factoring in leftover transfers. Unfortunately, reading nbytes from CR2 doesn't tell you the remaining transfers - there is no way to get that information from the I2C peripheral. But since we're using DMA, we can cheat and get the info from the DMA peripheral.

The one complication is that, because of the DMA request for the target read happening before the STOP condition, the remaining DMA transfers in write_dma_internal_slave would sometimes be off by 1 for the purposes of figuring out how many bytes were left untransmitted. Checking the status of the TXE flag before we clear it allows us to avoid the off by 1 error.

I can split this into two PRs if desired, but both fixes are very small and affect the same functions.

I included my previously merged PR [https://github.com/embassy-rs/embassy/pull/4849] in the changelog entry since that one was missing a changelog entry.