### PR TITLE
Fix flash erase on dualbank STM32Gxxx

### DIFF
--- a/embassy-stm32/CHANGELOG.md
+++ b/embassy-stm32/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased - ReleaseDate
 
+- fix: flash erase on dual-bank STM32Gxxx
 - feat: Add support for STM32N657X0
 - feat: timer: Add 32-bit timer support to SimplePwm waveform_up method following waveform pattern ([#4717](https://github.com/embassy-rs/embassy/pull/4717))
 - feat: Add support for injected ADC measurements for g4 ([#4840](https://github.com/embassy-rs/embassy/pull/4840))

--- a/embassy-stm32/src/flash/g.rs
+++ b/embassy-stm32/src/flash/g.rs
@@ -44,7 +44,6 @@ pub(crate) unsafe fn blocking_write(start_address: u32, buf: &[u8; WRITE_SIZE]) 
 }
 
 pub(crate) unsafe fn blocking_erase_sector(sector: &FlashSector) -> Result<(), Error> {
-    let idx = (sector.start - super::FLASH_BASE as u32) / super::BANK1_REGION.erase_size as u32;
     wait_busy();
     clear_all_err();
 
@@ -54,9 +53,9 @@ pub(crate) unsafe fn blocking_erase_sector(sector: &FlashSector) -> Result<(), E
             #[cfg(any(flash_g0x0, flash_g0x1, flash_g4c3))]
             w.set_bker(sector.bank == crate::flash::FlashBank::Bank2);
             #[cfg(flash_g0x0)]
-            w.set_pnb(idx as u16);
+            w.set_pnb(sector.index_in_bank as u16);
             #[cfg(not(flash_g0x0))]
-            w.set_pnb(idx as u8);
+            w.set_pnb(sector.index_in_bank as u8);
             w.set_strt(true);
         });
     });


### PR DESCRIPTION
Erasure on a dual-bank page would use the wrong page ID. The erase would silently fail, but writing the same page would result in a program error.

See #4400.

Tested on STM32G0B1RC.