### PR TITLE
adc: extract adc4

### DIFF
--- a/embassy-stm32/Cargo.toml
+++ b/embassy-stm32/Cargo.toml
@@ -188,6 +188,7 @@ embedded-io = { version = "0.6.0" }
 embedded-io-async = { version = "0.6.1" }
 chrono = { version = "^0.4", default-features = false, optional = true }
 bit_field = "0.10.2"
+trait-set = "0.3.0"
 document-features = "0.2.7"
 
 static_assertions = { version = "1.1" }

--- a/embassy-stm32/build.rs
+++ b/embassy-stm32/build.rs
@@ -1602,13 +1602,13 @@ fn main() {
     .into();
 
     if chip_name.starts_with("stm32u5") {
-        signals.insert(("adc", "ADC4"), quote!(crate::adc::RxDma4));
+        signals.insert(("adc", "ADC4"), quote!(crate::adc::RxDma));
     } else {
         signals.insert(("adc", "ADC4"), quote!(crate::adc::RxDma));
     }
 
     if chip_name.starts_with("stm32wba") {
-        signals.insert(("adc", "ADC4"), quote!(crate::adc::RxDma4));
+        signals.insert(("adc", "ADC4"), quote!(crate::adc::RxDma));
     }
 
     if chip_name.starts_with("stm32g4") {

--- a/embassy-stm32/src/adc/adc4.rs
+++ b/embassy-stm32/src/adc/adc4.rs
@@ -4,8 +4,8 @@ use pac::adc::vals::{Adc4Dmacfg as Dmacfg, Adc4Exten as Exten, Adc4OversamplingR
 #[cfg(stm32wba)]
 use pac::adc::vals::{Chselrmod, Cont, Dmacfg, Exten, OversamplingRatio, Ovss, Smpsel};
 
-use super::{AdcChannel, AnyAdcChannel, RxDma4, blocking_delay_us};
-use crate::dma::Transfer;
+use super::blocking_delay_us;
+use crate::adc::ConversionMode;
 #[cfg(stm32u5)]
 pub use crate::pac::adc::regs::Adc4Chselrmod0 as Chselr;
 #[cfg(stm32wba)]
@@ -153,6 +153,121 @@ pub trait Instance: SealedInstance + crate::PeripheralType + crate::rcc::RccPeri
     type Interrupt: crate::interrupt::typelevel::Interrupt;
 }
 
+foreach_adc!(
+    (ADC4, $common_inst:ident, $clock:ident) => {
+        use crate::peripherals::ADC4;
+
+        impl super::BasicAnyInstance for ADC4 {
+            type SampleTime = SampleTime;
+        }
+
+        impl super::SealedAnyInstance for ADC4 {
+            fn dr() -> *mut u16 {
+                ADC4::regs().dr().as_ptr() as *mut u16
+            }
+
+            fn enable() {
+                ADC4::regs().isr().write(|w| w.set_adrdy(true));
+                ADC4::regs().cr().modify(|w| w.set_aden(true));
+                while !ADC4::regs().isr().read().adrdy() {}
+                ADC4::regs().isr().write(|w| w.set_adrdy(true));
+            }
+
+            fn start() {
+                // Start conversion
+                ADC4::regs().cr().modify(|reg| {
+                    reg.set_adstart(true);
+                });
+            }
+
+            fn stop() {
+                if ADC4::regs().cr().read().adstart() && !ADC4::regs().cr().read().addis() {
+                    ADC4::regs().cr().modify(|reg| {
+                        reg.set_adstp(true);
+                    });
+                    while ADC4::regs().cr().read().adstart() {}
+                }
+
+                // Reset configuration.
+                ADC4::regs().cfgr1().modify(|reg| {
+                    reg.set_dmaen(false);
+                });
+            }
+
+            fn configure_dma(conversion_mode: ConversionMode) {
+                match conversion_mode {
+                    ConversionMode::Singular => {
+                        ADC4::regs().isr().modify(|reg| {
+                            reg.set_ovr(true);
+                            reg.set_eos(true);
+                            reg.set_eoc(true);
+                        });
+
+                        ADC4::regs().cfgr1().modify(|reg| {
+                            reg.set_dmaen(true);
+                            reg.set_dmacfg(Dmacfg::ONE_SHOT);
+                            #[cfg(stm32u5)]
+                            reg.set_chselrmod(false);
+                            #[cfg(stm32wba)]
+                            reg.set_chselrmod(Chselrmod::ENABLE_INPUT)
+                        });
+                    }
+                    _ => unreachable!(),
+                }
+            }
+
+            fn configure_sequence(sequence: impl ExactSizeIterator<Item = ((u8, bool), SampleTime)>) {
+                let mut prev_channel: i16 = -1;
+                #[cfg(stm32wba)]
+                ADC4::regs().chselr().write_value(Chselr(0_u32));
+                #[cfg(stm32u5)]
+                ADC4::regs().chselrmod0().write_value(Chselr(0_u32));
+                for (_i, ((channel, _), sample_time)) in sequence.enumerate() {
+                    ADC4::regs().smpr().modify(|w| {
+                        w.set_smp(_i, sample_time);
+                    });
+
+                    let channel_num = channel;
+                    if channel_num as i16 <= prev_channel {
+                        return;
+                    };
+                    prev_channel = channel_num as i16;
+
+                    #[cfg(stm32wba)]
+                    ADC4::regs().chselr().modify(|w| {
+                        w.set_chsel0(channel as usize, true);
+                    });
+                    #[cfg(stm32u5)]
+                    ADC4::regs().chselrmod0().modify(|w| {
+                        w.set_chsel(channel as usize, true);
+                    });
+                }
+            }
+
+            fn convert() -> u16 {
+                // Reset interrupts
+                ADC4::regs().isr().modify(|reg| {
+                    reg.set_eos(true);
+                    reg.set_eoc(true);
+                });
+
+                // Start conversion
+                ADC4::regs().cr().modify(|reg| {
+                    reg.set_adstart(true);
+                });
+
+                while !ADC4::regs().isr().read().eos() {
+                    // spin
+                }
+
+                ADC4::regs().dr().read().0 as u16
+            }
+        }
+
+        impl super::AnyInstance for ADC4 {}
+    };
+);
+
 pub struct Adc4<'d, T: Instance> {
     #[allow(unused)]
     adc: crate::Peri<'d, T>,
@@ -164,9 +279,9 @@ pub enum Adc4Error {
     DMAError,
 }
 
-impl<'d, T: Instance> Adc4<'d, T> {
+impl<'d, T: Instance + super::AnyInstance> super::Adc<'d, T> {
     /// Create a new ADC driver.
-    pub fn new(adc: Peri<'d, T>) -> Self {
+    pub fn new_adc4(adc: Peri<'d, T>) -> Self {
         rcc::enable_and_reset::<T>();
         let prescaler = Prescaler::from_ker_ck(T::frequency());
 
@@ -200,7 +315,7 @@ impl<'d, T: Instance> Adc4<'d, T> {
 
         blocking_delay_us(1);
 
-        Self::enable();
+        T::enable();
 
         // single conversion mode, software trigger
         T::regs().cfgr1().modify(|w| {
@@ -231,15 +346,8 @@ impl<'d, T: Instance> Adc4<'d, T> {
         Self { adc }
     }
 
-    fn enable() {
-        T::regs().isr().write(|w| w.set_adrdy(true));
-        T::regs().cr().modify(|w| w.set_aden(true));
-        while !T::regs().isr().read().adrdy() {}
-        T::regs().isr().write(|w| w.set_adrdy(true));
-    }
-
     /// Enable reading the voltage reference internal channel.
-    pub fn enable_vrefint(&self) -> super::VrefInt {
+    pub fn enable_vrefint_adc4(&self) -> super::VrefInt {
         T::regs().ccr().modify(|w| {
             w.set_vrefen(true);
         });
@@ -248,7 +356,7 @@ impl<'d, T: Instance> Adc4<'d, T> {
     }
 
     /// Enable reading the temperature internal channel.
-    pub fn enable_temperature(&self) -> super::Temperature {
+    pub fn enable_temperature_adc4(&self) -> super::Temperature {
         T::regs().ccr().modify(|w| {
             w.set_vsensesel(true);
         });
@@ -258,7 +366,7 @@ impl<'d, T: Instance> Adc4<'d, T> {
 
     /// Enable reading the vbat internal channel.
     #[cfg(stm32u5)]
-    pub fn enable_vbat(&self) -> super::Vbat {
+    pub fn enable_vbat_adc4(&self) -> super::Vbat {
         T::regs().ccr().modify(|w| {
             w.set_vbaten(true);
         });
@@ -267,13 +375,13 @@ impl<'d, T: Instance> Adc4<'d, T> {
     }
 
     /// Enable reading the vbat internal channel.
-    pub fn enable_vcore(&self) -> super::Vcore {
+    pub fn enable_vcore_adc4(&self) -> super::Vcore {
         super::Vcore {}
     }
 
     /// Enable reading the vbat internal channel.
     #[cfg(stm32u5)]
-    pub fn enable_dac_channel(&self, dac: DacChannel) -> super::Dac {
+    pub fn enable_dac_channel_adc4(&self, dac: DacChannel) -> super::Dac {
         let mux;
         match dac {
             DacChannel::OUT1 => mux = false,
@@ -284,13 +392,13 @@ impl<'d, T: Instance> Adc4<'d, T> {
     }
 
     /// Set the ADC resolution.
-    pub fn set_resolution(&mut self, resolution: Resolution) {
+    pub fn set_resolution_adc4(&mut self, resolution: Resolution) {
         T::regs().cfgr1().modify(|w| w.set_res(resolution.into()));
     }
 
     /// Set hardware averaging.
     #[cfg(stm32u5)]
-    pub fn set_averaging(&mut self, averaging: Averaging) {
+    pub fn set_averaging_adc4(&mut self, averaging: Averaging) {
         let (enable, samples, right_shift) = match averaging {
             Averaging::Disabled => (false, OversamplingRatio::OVERSAMPLE2X, 0),
             Averaging::Samples2 => (true, OversamplingRatio::OVERSAMPLE2X, 1),
@@ -310,7 +418,7 @@ impl<'d, T: Instance> Adc4<'d, T> {
         })
     }
     #[cfg(stm32wba)]
-    pub fn set_averaging(&mut self, averaging: Averaging) {
+    pub fn set_averaging_adc4(&mut self, averaging: Averaging) {
         let (enable, samples, right_shift) = match averaging {
             Averaging::Disabled => (false, OversamplingRatio::OVERSAMPLE2X, Ovss::SHIFT0),
             Averaging::Samples2 => (true, OversamplingRatio::OVERSAMPLE2X, Ovss::SHIFT1),
@@ -328,169 +436,5 @@ impl<'d, T: Instance> Adc4<'d, T> {
             w.set_ovss(right_shift);
             w.set_ovse(enable)
         })
-    }
-
-    /// Read an ADC channel.
-    pub fn blocking_read(&mut self, channel: &mut impl AdcChannel<T>, sample_time: SampleTime) -> u16 {
-        T::regs().smpr().modify(|w| {
-            w.set_smp(0, sample_time);
-        });
-
-        channel.setup();
-
-        // Select channel
-        #[cfg(stm32wba)]
-        {
-            T::regs().chselr().write_value(Chselr(0_u32));
-            T::regs().chselr().modify(|w| {
-                w.set_chsel0(channel.channel() as usize, true);
-            });
-        }
-        #[cfg(stm32u5)]
-        {
-            T::regs().chselrmod0().write_value(Chselr(0_u32));
-            T::regs().chselrmod0().modify(|w| {
-                w.set_chsel(channel.channel() as usize, true);
-            });
-        }
-
-        // Reset interrupts
-        T::regs().isr().modify(|reg| {
-            reg.set_eos(true);
-            reg.set_eoc(true);
-        });
-
-        // Start conversion
-        T::regs().cr().modify(|reg| {
-            reg.set_adstart(true);
-        });
-
-        while !T::regs().isr().read().eos() {
-            // spin
-        }
-
-        T::regs().dr().read().0 as u16
-    }
-
-    /// Read one or multiple ADC channels using DMA.
-    ///
-    /// `sequence` iterator and `readings` must have the same length.
-    /// The channels in `sequence` must be in ascending order.
-    ///
-    /// Example
-    /// ```rust,ignore
-    /// use embassy_stm32::adc::adc4;
-    /// use embassy_stm32::adc::AdcChannel;
-    ///
-    /// let mut adc4 = adc4::Adc4::new(p.ADC4);
-    /// let mut adc4_pin1 = p.PC1;
-    /// let mut adc4_pin2 = p.PC0;
-    /// let mut.into()d41 = adc4_pin1.into();
-    /// let mut.into()d42 = adc4_pin2.into();
-    /// let mut measurements = [0u16; 2];
-    /// // not that the channels must be in ascending order
-    /// adc4.read(
-    ///     &mut p.GPDMA1_CH1,
-    ///    [
-    ///        &mut.into()d42,
-    ///        &mut.into()d41,
-    ///    ]
-    ///    .into_iter(),
-    ///    &mut measurements,
-    /// ).await.unwrap();
-    /// ```
-    pub async fn read(
-        &mut self,
-        rx_dma: Peri<'_, impl RxDma4<T>>,
-        sequence: impl ExactSizeIterator<Item = &mut AnyAdcChannel<T>>,
-        readings: &mut [u16],
-    ) -> Result<(), Adc4Error> {
-        assert!(sequence.len() != 0, "Asynchronous read sequence cannot be empty");
-        assert!(
-            sequence.len() == readings.len(),
-            "Sequence length must be equal to readings length"
-        );
-
-        // Ensure no conversions are ongoing
-        Self::cancel_conversions();
-
-        T::regs().isr().modify(|reg| {
-            reg.set_ovr(true);
-            reg.set_eos(true);
-            reg.set_eoc(true);
-        });
-
-        T::regs().cfgr1().modify(|reg| {
-            reg.set_dmaen(true);
-            reg.set_dmacfg(Dmacfg::ONE_SHOT);
-            #[cfg(stm32u5)]
-            reg.set_chselrmod(false);
-            #[cfg(stm32wba)]
-            reg.set_chselrmod(Chselrmod::ENABLE_INPUT)
-        });
-
-        // Verify and activate sequence
-        let mut prev_channel: i16 = -1;
-        #[cfg(stm32wba)]
-        T::regs().chselr().write_value(Chselr(0_u32));
-        #[cfg(stm32u5)]
-        T::regs().chselrmod0().write_value(Chselr(0_u32));
-        for channel in sequence {
-            let channel_num = channel.channel;
-            if channel_num as i16 <= prev_channel {
-                return Err(Adc4Error::InvalidSequence);
-            };
-            prev_channel = channel_num as i16;
-
-            #[cfg(stm32wba)]
-            T::regs().chselr().modify(|w| {
-                w.set_chsel0(channel.channel as usize, true);
-            });
-            #[cfg(stm32u5)]
-            T::regs().chselrmod0().modify(|w| {
-                w.set_chsel(channel.channel as usize, true);
-            });
-        }
-
-        let request = rx_dma.request();
-        let transfer = unsafe {
-            Transfer::new_read(
-                rx_dma,
-                request,
-                T::regs().dr().as_ptr() as *mut u16,
-                readings,
-                Default::default(),
-            )
-        };
-
-        // Start conversion
-        T::regs().cr().modify(|reg| {
-            reg.set_adstart(true);
-        });
-
-        transfer.await;
-
-        // Ensure conversions are finished.
-        Self::cancel_conversions();
-
-        // Reset configuration.
-        T::regs().cfgr1().modify(|reg| {
-            reg.set_dmaen(false);
-        });
-
-        if T::regs().isr().read().ovr() {
-            Err(Adc4Error::DMAError)
-        } else {
-            Ok(())
-        }
-    }
-
-    fn cancel_conversions() {
-        if T::regs().cr().read().adstart() && !T::regs().cr().read().addis() {
-            T::regs().cr().modify(|reg| {
-                reg.set_adstp(true);
-            });
-            while T::regs().cr().read().adstart() {}
-        }
     }
 }

--- a/embassy-stm32/src/adc/injected.rs
+++ b/embassy-stm32/src/adc/injected.rs
@@ -5,9 +5,9 @@ use core::sync::atomic::{Ordering, compiler_fence};
 use embassy_hal_internal::Peri;
 
 use super::{AnyAdcChannel, SampleTime};
-use crate::adc::Adc;
 #[allow(unused_imports)]
 use crate::adc::Instance;
+use crate::adc::{Adc, AnyInstance};
 
 /// Injected ADC sequence with owned channels.
 pub struct InjectedAdc<T: Instance, const N: usize> {
@@ -36,9 +36,9 @@ impl<T: Instance, const N: usize> InjectedAdc<T, N> {
     }
 }
 
-impl<T: Instance, const N: usize> Drop for InjectedAdc<T, N> {
+impl<T: Instance + AnyInstance, const N: usize> Drop for InjectedAdc<T, N> {
     fn drop(&mut self) {
-        Adc::<T>::stop();
+        T::stop();
         compiler_fence(Ordering::SeqCst);
     }
 }

--- a/examples/stm32u5/src/bin/adc.rs
+++ b/examples/stm32u5/src/bin/adc.rs
@@ -2,7 +2,7 @@
 #![no_main]
 
 use defmt::*;
-use embassy_stm32::adc::{self, AdcChannel, AdcConfig, SampleTime, adc4};
+use embassy_stm32::adc::{self, Adc, AdcChannel, AdcConfig, SampleTime, adc4};
 use {defmt_rtt as _, panic_probe as _};
 
 #[embassy_executor::main]
@@ -15,7 +15,7 @@ async fn main(_spawner: embassy_executor::Spawner) {
     let mut config = AdcConfig::default();
     config.averaging = Some(adc::Averaging::Samples1024);
     config.resolution = Some(adc::Resolution::BITS14);
-    let mut adc1 = adc::Adc::new_with_config(p.ADC1, config);
+    let mut adc1 = Adc::new_with_config(p.ADC1, config);
     let mut adc1_pin1 = p.PA3; // A0 on nucleo u5a5
     let mut adc1_pin2 = p.PA2; // A1
     let max1 = adc::resolution_to_max_count(adc::Resolution::BITS14);
@@ -24,17 +24,17 @@ async fn main(_spawner: embassy_executor::Spawner) {
     let mut config = AdcConfig::default();
     config.averaging = Some(adc::Averaging::Samples1024);
     config.resolution = Some(adc::Resolution::BITS14);
-    let mut adc2 = adc::Adc::new_with_config(p.ADC2, config);
+    let mut adc2 = Adc::new_with_config(p.ADC2, config);
     let mut adc2_pin1 = p.PC3; // A2
     let mut adc2_pin2 = p.PB0; // A3
     let max2 = adc::resolution_to_max_count(adc::Resolution::BITS14);
 
     // **** ADC4 init ****
-    let mut adc4 = adc4::Adc4::new(p.ADC4);
+    let mut adc4 = Adc::new_adc4(p.ADC4);
     let mut adc4_pin1 = p.PC1; // A4
     let mut adc4_pin2 = p.PC0; // A5
-    adc4.set_resolution(adc4::Resolution::BITS12);
-    adc4.set_averaging(adc4::Averaging::Samples256);
+    adc4.set_resolution_adc4(adc4::Resolution::BITS12);
+    adc4.set_averaging_adc4(adc4::Averaging::Samples256);
     let max4 = adc4::resolution_to_max_count(adc4::Resolution::BITS12);
 
     // **** ADC1 blocking read ****
@@ -95,11 +95,14 @@ async fn main(_spawner: embassy_executor::Spawner) {
     // The channels must be in ascending order and can't repeat for ADC4
     adc4.read(
         p.GPDMA1_CH1.reborrow(),
-        [&mut degraded42, &mut degraded41].into_iter(),
+        [
+            (&mut degraded42, adc4::SampleTime::CYCLES1_5),
+            (&mut degraded41, adc4::SampleTime::CYCLES1_5),
+        ]
+        .into_iter(),
         &mut measurements,
     )
-    .await
-    .unwrap();
+    .await;
     let volt2: f32 = 3.3 * measurements[0] as f32 / max4 as f32;
     let volt1: f32 = 3.3 * measurements[1] as f32 / max4 as f32;
     info!("Async read 4 pin 1 {}", volt1);

--- a/examples/stm32wba/src/bin/adc.rs
+++ b/examples/stm32wba/src/bin/adc.rs
@@ -2,7 +2,7 @@
 #![no_main]
 
 use defmt::*;
-use embassy_stm32::adc::{AdcChannel, adc4};
+use embassy_stm32::adc::{Adc, AdcChannel, SampleTime, adc4};
 use {defmt_rtt as _, panic_probe as _};
 
 #[embassy_executor::main]
@@ -12,11 +12,11 @@ async fn main(_spawner: embassy_executor::Spawner) {
     let mut p = embassy_stm32::init(config);
 
     // **** ADC4 init ****
-    let mut adc4 = adc4::Adc4::new(p.ADC4);
+    let mut adc4 = Adc::new_adc4(p.ADC4);
     let mut adc4_pin1 = p.PA0; // A4
     let mut adc4_pin2 = p.PA1; // A5
-    adc4.set_resolution(adc4::Resolution::BITS12);
-    adc4.set_averaging(adc4::Averaging::Samples256);
+    adc4.set_resolution_adc4(adc4::Resolution::BITS12);
+    adc4.set_averaging_adc4(adc4::Averaging::Samples256);
 
     let max4 = adc4::resolution_to_max_count(adc4::Resolution::BITS12);
 
@@ -37,11 +37,14 @@ async fn main(_spawner: embassy_executor::Spawner) {
     // The channels must be in ascending order and can't repeat for ADC4
     adc4.read(
         p.GPDMA1_CH1.reborrow(),
-        [&mut degraded42, &mut degraded41].into_iter(),
+        [
+            (&mut degraded42, SampleTime::CYCLES12_5),
+            (&mut degraded41, SampleTime::CYCLES12_5),
+        ]
+        .into_iter(),
         &mut measurements,
     )
-    .await
-    .unwrap();
+    .await;
     let volt2: f32 = 3.3 * measurements[0] as f32 / max4 as f32;
     let volt1: f32 = 3.0 * measurements[1] as f32 / max4 as f32;
     info!("Async read 4 pin 1 {}", volt1);

--- a/examples/stm32wba6/src/bin/adc.rs
+++ b/examples/stm32wba6/src/bin/adc.rs
@@ -2,7 +2,7 @@
 #![no_main]
 
 use defmt::*;
-use embassy_stm32::adc::{AdcChannel, adc4};
+use embassy_stm32::adc::{Adc, AdcChannel, SampleTime, adc4};
 use {defmt_rtt as _, panic_probe as _};
 
 #[embassy_executor::main]
@@ -12,11 +12,11 @@ async fn main(_spawner: embassy_executor::Spawner) {
     let mut p = embassy_stm32::init(config);
 
     // **** ADC4 init ****
-    let mut adc4 = adc4::Adc4::new(p.ADC4);
+    let mut adc4 = Adc::new_adc4(p.ADC4);
     let mut adc4_pin1 = p.PA0; // A4
     let mut adc4_pin2 = p.PA1; // A5
-    adc4.set_resolution(adc4::Resolution::BITS12);
-    adc4.set_averaging(adc4::Averaging::Samples256);
+    adc4.set_resolution_adc4(adc4::Resolution::BITS12);
+    adc4.set_averaging_adc4(adc4::Averaging::Samples256);
     let max4 = adc4::resolution_to_max_count(adc4::Resolution::BITS12);
 
     // **** ADC4 blocking read ****
@@ -36,11 +36,14 @@ async fn main(_spawner: embassy_executor::Spawner) {
     // The channels must be in ascending order and can't repeat for ADC4
     adc4.read(
         p.GPDMA1_CH1.reborrow(),
-        [&mut degraded42, &mut degraded41].into_iter(),
+        [
+            (&mut degraded42, SampleTime::CYCLES12_5),
+            (&mut degraded41, SampleTime::CYCLES12_5),
+        ]
+        .into_iter(),
         &mut measurements,
     )
-    .await
-    .unwrap();
+    .await;
     let volt2: f32 = 3.3 * measurements[0] as f32 / max4 as f32;
     let volt1: f32 = 3.0 * measurements[1] as f32 / max4 as f32;
     info!("Async read 4 pin 1 {}", volt1);


### PR DESCRIPTION
extract adc4 to the common adc struct. can be consolidated once negative trait bounds are mainlined.