### PR TITLE
stm32/i2c: remove busy waiting on BUSY flag in v2

### DIFF
--- a/embassy-stm32/CHANGELOG.md
+++ b/embassy-stm32/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - fix: Avoid generating timer update events when updating the frequency ([#4890](https://github.com/embassy-rs/embassy/pull/4890))
 - chore: cleanup low-power add time
 - fix: Allow setting SAI peripheral `frame_length` to `256`
+- fix: stm32/i2c fix busy waiting on BUSY flag in v2
 - fix: flash erase on dual-bank STM32Gxxx
 - feat: Add support for STM32N657X0
 - feat: timer: Add 32-bit timer support to SimplePwm waveform_up method following waveform pattern ([#4717](https://github.com/embassy-rs/embassy/pull/4717))

--- a/embassy-stm32/src/i2c/v2.rs
+++ b/embassy-stm32/src/i2c/v2.rs
@@ -199,13 +199,7 @@ impl<'d, M: Mode, IM: MasterMode> I2c<'d, M, IM> {
             while info.regs.cr2().read().start() {
                 timeout.check()?;
             }
-
-            // Wait for the bus to be free
-            while info.regs.isr().read().busy() {
-                timeout.check()?;
-            }
         }
-
         // Set START and prepare to send `bytes`. The
         // START bit can be set even if the bus is BUSY or
         // I2C is in slave mode.


### PR DESCRIPTION
This blocking wait is already not present in the master_read function, and the comment `The START bit can be set even if the bus is BUSY or I2C is in slave mode` a few lines below already contradicts its necessity.

I consider it a partial fix for #2299, but only one of the blocking loops is removed.