### PR TITLE
[embassy-rp] Remove instance from rp spi and i2c

### DIFF
--- a/embassy-rp/CHANGELOG.md
+++ b/embassy-rp/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## Unreleased - ReleaseDate
 
 - DMA: clear channel `EN` bit before `chan_abort` on RP2350, per errata RP2350-E5 (see pico-sdk `dma_channel_abort` docs). Prevents the aborted channel from re-triggering.
+- breaking: Remove `<T: Instance>` from `Spi`, `I2c` and `I2cSlave` ([#4900](https://github.com/embassy-rs/embassy/pull/4900))
 
 ## 0.10.0 - 2026-03-10
 - Add AON Timer driver for RP2350 with configurable clock sources and alarm wake modes

--- a/embassy-rp/src/i2c.rs
+++ b/embassy-rp/src/i2c.rs
@@ -10,7 +10,8 @@ use embassy_sync::waitqueue::AtomicWaker;
 use pac::i2c;
 
 use crate::gpio::AnyPin;
-use crate::interrupt::typelevel::{Binding, Interrupt};
+use crate::interrupt::Interrupt;
+use crate::interrupt::typelevel::{Binding, Interrupt as _};
 use crate::{interrupt, pac, peripherals};
 
 /// I2C error abort reason
@@ -88,35 +89,44 @@ impl Default for Config {
 pub const FIFO_SIZE: u8 = 16;
 
 /// I2C driver.
-#[derive(Debug)]
-pub struct I2c<'d, T: Instance, M: Mode> {
-    phantom: PhantomData<(&'d mut T, M)>,
+pub struct I2c<'d, M: Mode> {
+    info: &'static Info,
+    phantom: PhantomData<(&'d mut (), M)>,
 }
 
-impl<'d, T: Instance> I2c<'d, T, Blocking> {
+impl<M: Mode> core::fmt::Debug for I2c<'_, M> {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("I2c")
+            .field("phantom", &self.phantom)
+            .finish_non_exhaustive()
+    }
+}
+
+impl<'d> I2c<'d, Blocking> {
     /// Create a new driver instance in blocking mode.
-    pub fn new_blocking(
-        peri: Peri<'d, T>,
+    pub fn new_blocking<T: Instance>(
+        _peri: Peri<'d, T>,
         scl: Peri<'d, impl SclPin<T>>,
         sda: Peri<'d, impl SdaPin<T>>,
         config: Config,
     ) -> Self {
-        Self::new_inner(peri, scl.into(), sda.into(), config)
+        Self::new_inner(T::info(), scl.into(), sda.into(), config)
     }
 }
 
-impl<'d, T: Instance> I2c<'d, T, Async> {
+impl<'d> I2c<'d, Async> {
     /// Create a new driver instance in async mode.
-    pub fn new_async(
-        peri: Peri<'d, T>,
+    pub fn new_async<T: Instance>(
+        _peri: Peri<'d, T>,
         scl: Peri<'d, impl SclPin<T>>,
         sda: Peri<'d, impl SdaPin<T>>,
         _irq: impl Binding<T::Interrupt, InterruptHandler<T>>,
         config: Config,
     ) -> Self {
-        let i2c = Self::new_inner(peri, scl.into(), sda.into(), config);
+        let info = T::info();
+        let i2c = Self::new_inner(info, scl.into(), sda.into(), config);
 
-        let r = T::regs();
+        let r = info.regs;
 
         // mask everything initially
         r.ic_intr_mask().write_value(i2c::regs::IcIntrMask(0));
@@ -136,7 +146,7 @@ impl<'d, T: Instance> I2c<'d, T, Async> {
     {
         future::poll_fn(|cx| {
             // Register prior to checking the condition
-            T::waker().register(cx.waker());
+            self.info.waker.register(cx.waker());
             let r = f(self);
 
             if r.is_pending() {
@@ -152,7 +162,7 @@ impl<'d, T: Instance> I2c<'d, T, Async> {
             return Err(Error::InvalidReadBufferLength);
         }
 
-        let p = T::regs();
+        let p = self.info.regs;
 
         let mut remaining = buffer.len();
         let mut remaining_queue = buffer.len();
@@ -161,7 +171,7 @@ impl<'d, T: Instance> I2c<'d, T, Async> {
 
         while remaining > 0 {
             // Waggle SCK - basically the same as write
-            let tx_fifo_space = Self::tx_fifo_capacity();
+            let tx_fifo_space = self.tx_fifo_capacity();
             let mut batch = 0;
 
             debug_assert!(remaining_queue > 0);
@@ -186,7 +196,7 @@ impl<'d, T: Instance> I2c<'d, T, Async> {
             let res = self
                 .wait_on(
                     |me| {
-                        let rxfifo = Self::rx_fifo_len();
+                        let rxfifo = me.rx_fifo_len();
                         if let Err(abort_reason) = me.read_and_clear_abort_reason() {
                             Poll::Ready(Err(abort_reason))
                         } else if rxfifo >= batch {
@@ -234,12 +244,12 @@ impl<'d, T: Instance> I2c<'d, T, Async> {
         bytes: impl IntoIterator<Item = u8>,
         send_stop: bool,
     ) -> Result<(), Error> {
-        let p = T::regs();
+        let p = self.info.regs;
 
         let mut bytes = bytes.into_iter().peekable();
 
         let res = 'xmit: loop {
-            let tx_fifo_space = Self::tx_fifo_capacity();
+            let tx_fifo_space = self.tx_fifo_capacity();
 
             for _ in 0..tx_fifo_space {
                 if let Some(byte) = bytes.next() {
@@ -260,7 +270,7 @@ impl<'d, T: Instance> I2c<'d, T, Async> {
                     |me| {
                         if let abort_reason @ Err(_) = me.read_and_clear_abort_reason() {
                             Poll::Ready(abort_reason)
-                        } else if !Self::tx_fifo_full() {
+                        } else if !me.tx_fifo_full() {
                             // resume if there's any space free in the tx fifo
                             Poll::Ready(Ok(()))
                         } else {
@@ -295,7 +305,7 @@ impl<'d, T: Instance> I2c<'d, T, Async> {
     /// Also handles an abort which arises while processing the tx fifo.
     async fn wait_stop_det(&mut self, had_abort: Result<(), Error>, do_stop: bool) -> Result<(), Error> {
         if had_abort.is_err() || do_stop {
-            let p = T::regs();
+            let p = self.info.regs;
 
             let had_abort2 = self
                 .wait_on(
@@ -329,7 +339,7 @@ impl<'d, T: Instance> I2c<'d, T, Async> {
 
     /// Read from address into buffer asynchronously.
     pub async fn read_async(&mut self, addr: impl Into<u16>, buffer: &mut [u8]) -> Result<(), Error> {
-        Self::setup(addr.into())?;
+        self.setup(addr.into())?;
         self.read_async_internal(buffer, true, true).await
     }
 
@@ -339,7 +349,7 @@ impl<'d, T: Instance> I2c<'d, T, Async> {
         addr: impl Into<u16>,
         bytes: impl IntoIterator<Item = u8>,
     ) -> Result<(), Error> {
-        Self::setup(addr.into())?;
+        self.setup(addr.into())?;
         self.write_async_internal(bytes, true).await
     }
 
@@ -350,7 +360,7 @@ impl<'d, T: Instance> I2c<'d, T, Async> {
         bytes: impl IntoIterator<Item = u8>,
         buffer: &mut [u8],
     ) -> Result<(), Error> {
-        Self::setup(addr.into())?;
+        self.setup(addr.into())?;
         self.write_async_internal(bytes, false).await?;
         self.read_async_internal(buffer, true, true).await
     }
@@ -364,10 +374,11 @@ pub struct InterruptHandler<T: Instance> {
 impl<T: Instance> interrupt::typelevel::Handler<T::Interrupt> for InterruptHandler<T> {
     // Mask interrupts and wake any task waiting for this interrupt
     unsafe fn on_interrupt() {
-        let i2c = T::regs();
+        let info = T::info();
+        let i2c = info.regs;
         i2c.ic_intr_mask().write_value(pac::i2c::regs::IcIntrMask::default());
 
-        T::waker().wake();
+        info.waker.wake();
     }
 }
 
@@ -389,9 +400,9 @@ where
     });
 }
 
-impl<'d, T: Instance + 'd, M: Mode> I2c<'d, T, M> {
-    fn new_inner(_peri: Peri<'d, T>, scl: Peri<'d, AnyPin>, sda: Peri<'d, AnyPin>, config: Config) -> Self {
-        let reset = T::reset();
+impl<'d, M: Mode> I2c<'d, M> {
+    fn new_inner(info: &'static Info, scl: Peri<'d, AnyPin>, sda: Peri<'d, AnyPin>, config: Config) -> Self {
+        let reset = (info.reset)();
         crate::reset::reset(reset);
         crate::reset::unreset_wait(reset);
 
@@ -399,7 +410,10 @@ impl<'d, T: Instance + 'd, M: Mode> I2c<'d, T, M> {
         set_up_i2c_pin(&scl, config.scl_pullup);
         set_up_i2c_pin(&sda, config.sda_pullup);
 
-        let mut me = Self { phantom: PhantomData };
+        let mut me = Self {
+            info,
+            phantom: PhantomData,
+        };
 
         if let Err(e) = me.set_config_inner(&config) {
             panic!("Error configuring i2c: {:?}", e);
@@ -413,7 +427,7 @@ impl<'d, T: Instance + 'd, M: Mode> I2c<'d, T, M> {
             return Err(ConfigError::FrequencyTooHigh);
         }
 
-        let p = T::regs();
+        let p = self.info.regs;
 
         p.ic_enable().write(|w| w.set_enable(false));
 
@@ -473,14 +487,14 @@ impl<'d, T: Instance + 'd, M: Mode> I2c<'d, T, M> {
         Ok(())
     }
 
-    fn setup(addr: u16) -> Result<(), Error> {
+    fn setup(&self, addr: u16) -> Result<(), Error> {
         if addr >= 0x400 {
             return Err(Error::AddressOutOfRange(addr));
         }
 
         let ten_bit = addr > 0x7F;
 
-        let p = T::regs();
+        let p = self.info.regs;
         p.ic_enable().write(|w| w.set_enable(false));
         p.ic_con().modify(|w| w.set_ic_10bitaddr_master(ten_bit));
         p.ic_tar().write(|w| w.set_ic_tar(addr));
@@ -489,24 +503,24 @@ impl<'d, T: Instance + 'd, M: Mode> I2c<'d, T, M> {
     }
 
     #[inline]
-    fn tx_fifo_full() -> bool {
-        Self::tx_fifo_capacity() == 0
+    fn tx_fifo_full(&self) -> bool {
+        self.tx_fifo_capacity() == 0
     }
 
     #[inline]
-    fn tx_fifo_capacity() -> u8 {
-        let p = T::regs();
+    fn tx_fifo_capacity(&self) -> u8 {
+        let p = self.info.regs;
         FIFO_SIZE - p.ic_txflr().read().txflr()
     }
 
     #[inline]
-    fn rx_fifo_len() -> u8 {
-        let p = T::regs();
+    fn rx_fifo_len(&self) -> u8 {
+        let p = self.info.regs;
         p.ic_rxflr().read().rxflr()
     }
 
     fn read_and_clear_abort_reason(&mut self) -> Result<(), Error> {
-        let p = T::regs();
+        let p = self.info.regs;
         let abort_reason = p.ic_tx_abrt_source().read();
         if abort_reason.0 != 0 {
             // Note clearing the abort flag also clears the reason, and this
@@ -536,14 +550,14 @@ impl<'d, T: Instance + 'd, M: Mode> I2c<'d, T, M> {
             return Err(Error::InvalidReadBufferLength);
         }
 
-        let p = T::regs();
+        let p = self.info.regs;
         let lastindex = read.len() - 1;
         for (i, byte) in read.iter_mut().enumerate() {
             let first = i == 0;
             let last = i == lastindex;
 
             // wait until there is space in the FIFO to write the next byte
-            while Self::tx_fifo_full() {}
+            while self.tx_fifo_full() {}
 
             p.ic_data_cmd().write(|w| {
                 w.set_restart(restart && first);
@@ -552,7 +566,7 @@ impl<'d, T: Instance + 'd, M: Mode> I2c<'d, T, M> {
                 w.set_cmd(true);
             });
 
-            while Self::rx_fifo_len() == 0 {
+            while self.rx_fifo_len() == 0 {
                 self.read_and_clear_abort_reason()?;
             }
 
@@ -567,7 +581,7 @@ impl<'d, T: Instance + 'd, M: Mode> I2c<'d, T, M> {
             return Err(Error::InvalidWriteBufferLength);
         }
 
-        let p = T::regs();
+        let p = self.info.regs;
 
         for (i, byte) in write.iter().enumerate() {
             let last = i == write.len() - 1;
@@ -609,27 +623,27 @@ impl<'d, T: Instance + 'd, M: Mode> I2c<'d, T, M> {
 
     /// Read from address into buffer blocking caller until done.
     pub fn blocking_read(&mut self, address: impl Into<u16>, read: &mut [u8]) -> Result<(), Error> {
-        Self::setup(address.into())?;
+        self.setup(address.into())?;
         self.read_blocking_internal(read, true, true)
         // Automatic Stop
     }
 
     /// Write to address from buffer blocking caller until done.
     pub fn blocking_write(&mut self, address: impl Into<u16>, write: &[u8]) -> Result<(), Error> {
-        Self::setup(address.into())?;
+        self.setup(address.into())?;
         self.write_blocking_internal(write, true)
     }
 
     /// Write to address from bytes and read from address into buffer blocking caller until done.
     pub fn blocking_write_read(&mut self, address: impl Into<u16>, write: &[u8], read: &mut [u8]) -> Result<(), Error> {
-        Self::setup(address.into())?;
+        self.setup(address.into())?;
         self.write_blocking_internal(write, false)?;
         self.read_blocking_internal(read, true, true)
         // Automatic Stop
     }
 }
 
-impl<'d, T: Instance, M: Mode> embedded_hal_02::blocking::i2c::Read for I2c<'d, T, M> {
+impl<'d, M: Mode> embedded_hal_02::blocking::i2c::Read for I2c<'d, M> {
     type Error = Error;
 
     fn read(&mut self, address: u8, buffer: &mut [u8]) -> Result<(), Self::Error> {
@@ -637,7 +651,7 @@ impl<'d, T: Instance, M: Mode> embedded_hal_02::blocking::i2c::Read for I2c<'d, 
     }
 }
 
-impl<'d, T: Instance, M: Mode> embedded_hal_02::blocking::i2c::Write for I2c<'d, T, M> {
+impl<'d, M: Mode> embedded_hal_02::blocking::i2c::Write for I2c<'d, M> {
     type Error = Error;
 
     fn write(&mut self, address: u8, bytes: &[u8]) -> Result<(), Self::Error> {
@@ -645,7 +659,7 @@ impl<'d, T: Instance, M: Mode> embedded_hal_02::blocking::i2c::Write for I2c<'d,
     }
 }
 
-impl<'d, T: Instance, M: Mode> embedded_hal_02::blocking::i2c::WriteRead for I2c<'d, T, M> {
+impl<'d, M: Mode> embedded_hal_02::blocking::i2c::WriteRead for I2c<'d, M> {
     type Error = Error;
 
     fn write_read(&mut self, address: u8, bytes: &[u8], buffer: &mut [u8]) -> Result<(), Self::Error> {
@@ -653,7 +667,7 @@ impl<'d, T: Instance, M: Mode> embedded_hal_02::blocking::i2c::WriteRead for I2c
     }
 }
 
-impl<'d, T: Instance, M: Mode> embedded_hal_02::blocking::i2c::Transactional for I2c<'d, T, M> {
+impl<'d, M: Mode> embedded_hal_02::blocking::i2c::Transactional for I2c<'d, M> {
     type Error = Error;
 
     fn exec(
@@ -661,7 +675,7 @@ impl<'d, T: Instance, M: Mode> embedded_hal_02::blocking::i2c::Transactional for
         address: u8,
         operations: &mut [embedded_hal_02::blocking::i2c::Operation<'_>],
     ) -> Result<(), Self::Error> {
-        Self::setup(address.into())?;
+        self.setup(address.into())?;
         for i in 0..operations.len() {
             let last = i == operations.len() - 1;
             match &mut operations[i] {
@@ -693,11 +707,11 @@ impl embedded_hal_1::i2c::Error for Error {
     }
 }
 
-impl<'d, T: Instance, M: Mode> embedded_hal_1::i2c::ErrorType for I2c<'d, T, M> {
+impl<'d, M: Mode> embedded_hal_1::i2c::ErrorType for I2c<'d, M> {
     type Error = Error;
 }
 
-impl<'d, T: Instance, M: Mode, A> embedded_hal_1::i2c::I2c<A> for I2c<'d, T, M>
+impl<'d, M: Mode, A> embedded_hal_1::i2c::I2c<A> for I2c<'d, M>
 where
     A: embedded_hal_1::i2c::AddressMode + Into<u16> + 'static,
 {
@@ -718,7 +732,7 @@ where
         address: A,
         operations: &mut [embedded_hal_1::i2c::Operation<'_>],
     ) -> Result<(), Self::Error> {
-        Self::setup(address.into())?;
+        self.setup(address.into())?;
         for i in 0..operations.len() {
             let last = i == operations.len() - 1;
             match &mut operations[i] {
@@ -730,10 +744,9 @@ where
     }
 }
 
-impl<'d, A, T> embedded_hal_async::i2c::I2c<A> for I2c<'d, T, Async>
+impl<'d, A> embedded_hal_async::i2c::I2c<A> for I2c<'d, Async>
 where
     A: embedded_hal_async::i2c::AddressMode + Into<u16> + 'static,
-    T: Instance + 'd,
 {
     async fn read(&mut self, address: A, read: &mut [u8]) -> Result<(), Self::Error> {
         self.read_async(address, read).await
@@ -757,7 +770,7 @@ where
         let addr: u16 = address.into();
 
         if !operations.is_empty() {
-            Self::setup(addr)?;
+            self.setup(addr)?;
         }
         let mut iterator = operations.iter_mut();
 
@@ -777,7 +790,7 @@ where
     }
 }
 
-impl<'d, T: Instance, M: Mode> embassy_embedded_hal::SetConfig for I2c<'d, T, M> {
+impl<'d, M: Mode> embassy_embedded_hal::SetConfig for I2c<'d, M> {
     type Config = Config;
     type ConfigError = ConfigError;
 
@@ -787,9 +800,14 @@ impl<'d, T: Instance, M: Mode> embassy_embedded_hal::SetConfig for I2c<'d, T, M>
 }
 
 pub(crate) trait SealedInstance {
-    fn regs() -> crate::pac::i2c::I2c;
-    fn reset() -> crate::pac::resets::regs::Peripherals;
-    fn waker() -> &'static AtomicWaker;
+    fn info() -> &'static Info;
+}
+
+pub(crate) struct Info {
+    pub(crate) regs: pac::i2c::I2c,
+    pub(crate) reset: fn() -> pac::resets::regs::Peripherals,
+    pub(crate) waker: AtomicWaker,
+    pub(crate) interrupt: Interrupt,
 }
 
 trait SealedMode {}
@@ -821,28 +839,23 @@ pub trait Instance: SealedInstance + PeripheralType {
 }
 
 macro_rules! impl_instance {
-    ($type:ident, $irq:ident, $reset:ident) => {
-        impl SealedInstance for peripherals::$type {
-            #[inline]
-            fn regs() -> pac::i2c::I2c {
-                pac::$type
-            }
-
-            #[inline]
-            fn reset() -> pac::resets::regs::Peripherals {
-                let mut ret = pac::resets::regs::Peripherals::default();
-                ret.$reset(true);
-                ret
-            }
-
-            #[inline]
-            fn waker() -> &'static AtomicWaker {
-                static WAKER: AtomicWaker = AtomicWaker::new();
-
-                &WAKER
+    ($inst:ident, $irq:ident, $reset:ident) => {
+        impl SealedInstance for peripherals::$inst {
+            fn info() -> &'static Info {
+                static INFO: Info = Info {
+                    regs: pac::$inst,
+                    reset: || {
+                        let mut ret = pac::resets::regs::Peripherals::default();
+                        ret.$reset(true);
+                        ret
+                    },
+                    waker: AtomicWaker::new(),
+                    interrupt: crate::interrupt::typelevel::$irq::IRQ,
+                };
+                &INFO
             }
         }
-        impl Instance for peripherals::$type {
+        impl Instance for peripherals::$inst {
             type Interrupt = crate::interrupt::typelevel::$irq;
         }
     };

--- a/embassy-rp/src/i2c_slave.rs
+++ b/embassy-rp/src/i2c_slave.rs
@@ -5,8 +5,9 @@ use core::task::Poll;
 
 use pac::i2c;
 
-use crate::i2c::{AbortReason, FIFO_SIZE, Instance, InterruptHandler, SclPin, SdaPin, set_up_i2c_pin};
-use crate::interrupt::typelevel::{Binding, Interrupt};
+use crate::i2c::{AbortReason, FIFO_SIZE, Info, Instance, InterruptHandler, SclPin, SdaPin, set_up_i2c_pin};
+use crate::interrupt::InterruptExt;
+use crate::interrupt::typelevel::Binding;
 use crate::{Peri, pac};
 
 /// I2C error
@@ -89,15 +90,16 @@ impl Default for Config {
 }
 
 /// I2CSlave driver.
-pub struct I2cSlave<'d, T: Instance> {
-    phantom: PhantomData<&'d mut T>,
+pub struct I2cSlave<'d> {
+    info: &'static Info,
     pending_byte: Option<u8>,
     config: Config,
+    phantom: PhantomData<&'d mut ()>,
 }
 
-impl<'d, T: Instance> I2cSlave<'d, T> {
+impl<'d> I2cSlave<'d> {
     /// Create a new instance.
-    pub fn new(
+    pub fn new<T: Instance>(
         _peri: Peri<'d, T>,
         scl: Peri<'d, impl SclPin<T>>,
         sda: Peri<'d, impl SdaPin<T>>,
@@ -111,9 +113,10 @@ impl<'d, T: Instance> I2cSlave<'d, T> {
         set_up_i2c_pin(&sda, config.sda_pullup);
 
         let mut ret = Self {
-            phantom: PhantomData,
+            info: T::info(),
             pending_byte: None,
             config,
+            phantom: PhantomData,
         };
 
         ret.reset();
@@ -125,9 +128,10 @@ impl<'d, T: Instance> I2cSlave<'d, T> {
     /// You can recover the bus by calling this function, but doing so will almost certainly cause
     /// an i/o error in the master.
     pub fn reset(&mut self) {
-        let p = T::regs();
+        let info = self.info;
+        let p = info.regs;
 
-        let reset = T::reset();
+        let reset = (info.reset)();
         crate::reset::reset(reset);
         crate::reset::unreset_wait(reset);
 
@@ -166,8 +170,8 @@ impl<'d, T: Instance> I2cSlave<'d, T> {
 
         // mask everything initially
         p.ic_intr_mask().write_value(i2c::regs::IcIntrMask(0));
-        T::Interrupt::unpend();
-        unsafe { T::Interrupt::enable() };
+        info.interrupt.unpend();
+        unsafe { info.interrupt.enable() };
     }
 
     /// Calls `f` to check if we are ready or not.
@@ -181,7 +185,7 @@ impl<'d, T: Instance> I2cSlave<'d, T> {
     {
         future::poll_fn(|cx| {
             // Register prior to checking the condition
-            T::waker().register(cx.waker());
+            self.info.waker.register(cx.waker());
             let r = f(self);
 
             if r.is_pending() {
@@ -195,7 +199,7 @@ impl<'d, T: Instance> I2cSlave<'d, T> {
 
     #[inline(always)]
     fn drain_fifo(&mut self, buffer: &mut [u8], offset: &mut usize) {
-        let p = T::regs();
+        let p = self.info.regs;
 
         if let Some(pending) = self.pending_byte.take() {
             buffer[*offset] = pending;
@@ -227,7 +231,7 @@ impl<'d, T: Instance> I2cSlave<'d, T> {
     /// Wait asynchronously for commands from an I2C master.
     /// `buffer` is provided in case master does a 'write', 'write read', or 'general call' and is unused for 'read'.
     pub async fn listen(&mut self, buffer: &mut [u8]) -> Result<Command, Error> {
-        let p = T::regs();
+        let p = self.info.regs;
 
         // set rx fifo watermark to 1 byte
         p.ic_rx_tl().write(|w| w.set_rx_tl(0));
@@ -295,7 +299,7 @@ impl<'d, T: Instance> I2cSlave<'d, T> {
 
     /// Respond to an I2C master READ command, asynchronously.
     pub async fn respond_to_read(&mut self, buffer: &[u8]) -> Result<ReadStatus, Error> {
-        let p = T::regs();
+        let p = self.info.regs;
 
         if buffer.is_empty() {
             return Err(Error::InvalidResponseBufferLength);
@@ -376,7 +380,7 @@ impl<'d, T: Instance> I2cSlave<'d, T> {
 
     #[inline(always)]
     fn read_and_clear_abort_reason(&mut self) -> Result<(), Error> {
-        let p = T::regs();
+        let p = self.info.regs;
         let abort_reason = p.ic_tx_abrt_source().read();
 
         if abort_reason.0 != 0 {

--- a/embassy-rp/src/spi.rs
+++ b/embassy-rp/src/spi.rs
@@ -41,11 +41,11 @@ impl Default for Config {
 }
 
 /// SPI driver.
-pub struct Spi<'d, T: Instance, M: Mode> {
-    inner: Peri<'d, T>,
+pub struct Spi<'d, M: Mode> {
+    info: &'static Info,
     tx_dma: Option<Channel<'d>>,
     rx_dma: Option<Channel<'d>>,
-    phantom: PhantomData<(&'d mut T, M)>,
+    phantom: PhantomData<(&'d mut (), M)>,
 }
 
 fn div_roundup(a: u32, b: u32) -> u32 {
@@ -71,9 +71,9 @@ fn calc_prescs(freq: u32) -> (u8, u8) {
     ((presc * 2) as u8, (postdiv - 1) as u8)
 }
 
-impl<'d, T: Instance, M: Mode> Spi<'d, T, M> {
-    fn new_inner(
-        inner: Peri<'d, T>,
+impl<'d, M: Mode> Spi<'d, M> {
+    fn new_inner<T: Instance>(
+        _spi: Peri<'d, T>,
         clk: Option<Peri<'d, AnyPin>>,
         mosi: Option<Peri<'d, AnyPin>>,
         miso: Option<Peri<'d, AnyPin>>,
@@ -82,9 +82,9 @@ impl<'d, T: Instance, M: Mode> Spi<'d, T, M> {
         rx_dma: Option<Channel<'d>>,
         config: Config,
     ) -> Self {
-        Self::apply_config(&inner, &config);
+        Self::apply_config(T::info(), &config);
 
-        let p = inner.regs();
+        let p = T::info().regs;
 
         // Always enable DREQ signals -- harmless if DMA is not listening
         p.dmacr().write(|reg| {
@@ -148,7 +148,7 @@ impl<'d, T: Instance, M: Mode> Spi<'d, T, M> {
             });
         }
         Self {
-            inner,
+            info: T::info(),
             tx_dma,
             rx_dma,
             phantom: PhantomData,
@@ -159,8 +159,8 @@ impl<'d, T: Instance, M: Mode> Spi<'d, T, M> {
     ///
     /// Driver should be disabled before making changes and re-enabled after the modifications
     /// are applied.
-    fn apply_config(inner: &Peri<'d, T>, config: &Config) {
-        let p = inner.regs();
+    fn apply_config(info: &Info, config: &Config) {
+        let p = info.regs;
         let (presc, postdiv) = calc_prescs(config.frequency);
 
         p.cpsr().write(|w| w.set_cpsdvsr(presc));
@@ -174,7 +174,7 @@ impl<'d, T: Instance, M: Mode> Spi<'d, T, M> {
 
     /// Write data to SPI blocking execution until done.
     pub fn blocking_write(&mut self, data: &[u8]) -> Result<(), Error> {
-        let p = self.inner.regs();
+        let p = self.info.regs;
         for &b in data {
             while !p.sr().read().tnf() {}
             p.dr().write(|w| w.set_data(b as _));
@@ -187,7 +187,7 @@ impl<'d, T: Instance, M: Mode> Spi<'d, T, M> {
 
     /// Transfer data in place to SPI blocking execution until done.
     pub fn blocking_transfer_in_place(&mut self, data: &mut [u8]) -> Result<(), Error> {
-        let p = self.inner.regs();
+        let p = self.info.regs;
         for b in data {
             while !p.sr().read().tnf() {}
             p.dr().write(|w| w.set_data(*b as _));
@@ -200,7 +200,7 @@ impl<'d, T: Instance, M: Mode> Spi<'d, T, M> {
 
     /// Read data from SPI blocking execution until done.
     pub fn blocking_read(&mut self, data: &mut [u8]) -> Result<(), Error> {
-        let p = self.inner.regs();
+        let p = self.info.regs;
         for b in data {
             while !p.sr().read().tnf() {}
             p.dr().write(|w| w.set_data(0));
@@ -213,7 +213,7 @@ impl<'d, T: Instance, M: Mode> Spi<'d, T, M> {
 
     /// Transfer data to SPI blocking execution until done.
     pub fn blocking_transfer(&mut self, read: &mut [u8], write: &[u8]) -> Result<(), Error> {
-        let p = self.inner.regs();
+        let p = self.info.regs;
         let len = read.len().max(write.len());
         for i in 0..len {
             let wb = write.get(i).copied().unwrap_or(0);
@@ -231,7 +231,7 @@ impl<'d, T: Instance, M: Mode> Spi<'d, T, M> {
 
     /// Block execution until SPI is done.
     pub fn flush(&mut self) -> Result<(), Error> {
-        let p = self.inner.regs();
+        let p = self.info.regs;
         while p.sr().read().bsy() {}
         Ok(())
     }
@@ -239,7 +239,7 @@ impl<'d, T: Instance, M: Mode> Spi<'d, T, M> {
     /// Set SPI frequency.
     pub fn set_frequency(&mut self, freq: u32) {
         let (presc, postdiv) = calc_prescs(freq);
-        let p = self.inner.regs();
+        let p = self.info.regs;
         // disable
         p.cr1().write(|w| w.set_sse(false));
 
@@ -255,30 +255,30 @@ impl<'d, T: Instance, M: Mode> Spi<'d, T, M> {
 
     /// Set SPI config.
     pub fn set_config(&mut self, config: &Config) {
-        let p = self.inner.regs();
+        let p = self.info.regs;
 
         // disable
         p.cr1().write(|w| w.set_sse(false));
 
         // change stuff
-        Self::apply_config(&self.inner, config);
+        Self::apply_config(self.info, config);
 
         // enable
         p.cr1().write(|w| w.set_sse(true));
     }
 }
 
-impl<'d, T: Instance> Spi<'d, T, Blocking> {
+impl<'d> Spi<'d, Blocking> {
     /// Create an SPI driver in blocking mode.
-    pub fn new_blocking(
-        inner: Peri<'d, T>,
+    pub fn new_blocking<T: Instance>(
+        spi: Peri<'d, T>,
         clk: Peri<'d, impl ClkPin<T> + 'd>,
         mosi: Peri<'d, impl MosiPin<T> + 'd>,
         miso: Peri<'d, impl MisoPin<T> + 'd>,
         config: Config,
     ) -> Self {
         Self::new_inner(
-            inner,
+            spi,
             Some(clk.into()),
             Some(mosi.into()),
             Some(miso.into()),
@@ -290,53 +290,39 @@ impl<'d, T: Instance> Spi<'d, T, Blocking> {
     }
 
     /// Create an SPI driver in blocking mode supporting writes only.
-    pub fn new_blocking_txonly(
-        inner: Peri<'d, T>,
+    pub fn new_blocking_txonly<T: Instance>(
+        spi: Peri<'d, T>,
         clk: Peri<'d, impl ClkPin<T> + 'd>,
         mosi: Peri<'d, impl MosiPin<T> + 'd>,
         config: Config,
     ) -> Self {
-        Self::new_inner(
-            inner,
-            Some(clk.into()),
-            Some(mosi.into()),
-            None,
-            None,
-            None,
-            None,
-            config,
-        )
+        Self::new_inner(spi, Some(clk.into()), Some(mosi.into()), None, None, None, None, config)
     }
 
     /// Create an SPI driver in blocking mode supporting writes only, without SCK pin.
-    pub fn new_blocking_txonly_nosck(inner: Peri<'d, T>, mosi: Peri<'d, impl MosiPin<T> + 'd>, config: Config) -> Self {
-        Self::new_inner(inner, None, Some(mosi.into()), None, None, None, None, config)
+    pub fn new_blocking_txonly_nosck<T: Instance>(
+        spi: Peri<'d, T>,
+        mosi: Peri<'d, impl MosiPin<T> + 'd>,
+        config: Config,
+    ) -> Self {
+        Self::new_inner(spi, None, Some(mosi.into()), None, None, None, None, config)
     }
 
     /// Create an SPI driver in blocking mode supporting reads only.
-    pub fn new_blocking_rxonly(
-        inner: Peri<'d, T>,
+    pub fn new_blocking_rxonly<T: Instance>(
+        spi: Peri<'d, T>,
         clk: Peri<'d, impl ClkPin<T> + 'd>,
         miso: Peri<'d, impl MisoPin<T> + 'd>,
         config: Config,
     ) -> Self {
-        Self::new_inner(
-            inner,
-            Some(clk.into()),
-            None,
-            Some(miso.into()),
-            None,
-            None,
-            None,
-            config,
-        )
+        Self::new_inner(spi, Some(clk.into()), None, Some(miso.into()), None, None, None, config)
     }
 }
 
-impl<'d, T: Instance> Spi<'d, T, Async> {
+impl<'d> Spi<'d, Async> {
     /// Create an SPI driver in async mode supporting DMA operations.
-    pub fn new<TxDma: ChannelInstance, RxDma: ChannelInstance>(
-        inner: Peri<'d, T>,
+    pub fn new<T: Instance, TxDma: ChannelInstance, RxDma: ChannelInstance>(
+        spi: Peri<'d, T>,
         clk: Peri<'d, impl ClkPin<T> + 'd>,
         mosi: Peri<'d, impl MosiPin<T> + 'd>,
         miso: Peri<'d, impl MisoPin<T> + 'd>,
@@ -350,7 +336,7 @@ impl<'d, T: Instance> Spi<'d, T, Async> {
         let tx_dma_ch = dma::Channel::new(tx_dma, irq);
         let rx_dma_ch = dma::Channel::new(rx_dma, irq);
         Self::new_inner(
-            inner,
+            spi,
             Some(clk.into()),
             Some(mosi.into()),
             Some(miso.into()),
@@ -362,8 +348,8 @@ impl<'d, T: Instance> Spi<'d, T, Async> {
     }
 
     /// Create an SPI driver in async mode supporting DMA write operations only.
-    pub fn new_txonly<TxDma: ChannelInstance>(
-        inner: Peri<'d, T>,
+    pub fn new_txonly<T: Instance, TxDma: ChannelInstance>(
+        spi: Peri<'d, T>,
         clk: Peri<'d, impl ClkPin<T> + 'd>,
         mosi: Peri<'d, impl MosiPin<T> + 'd>,
         tx_dma: Peri<'d, TxDma>,
@@ -372,7 +358,7 @@ impl<'d, T: Instance> Spi<'d, T, Async> {
     ) -> Self {
         let tx_dma_ch = dma::Channel::new(tx_dma, irq);
         Self::new_inner(
-            inner,
+            spi,
             Some(clk.into()),
             Some(mosi.into()),
             None,
@@ -385,29 +371,20 @@ impl<'d, T: Instance> Spi<'d, T, Async> {
 
     /// Create an SPI driver in async mode supporting DMA write operations only,
     /// without SCK pin.
-    pub fn new_txonly_nosck<TxDma: ChannelInstance>(
-        inner: Peri<'d, T>,
+    pub fn new_txonly_nosck<T: Instance, TxDma: ChannelInstance>(
+        spi: Peri<'d, T>,
         mosi: Peri<'d, impl MosiPin<T> + 'd>,
         tx_dma: Peri<'d, TxDma>,
         irq: impl interrupt::typelevel::Binding<TxDma::Interrupt, dma::InterruptHandler<TxDma>> + 'd,
         config: Config,
     ) -> Self {
         let tx_dma_ch = dma::Channel::new(tx_dma, irq);
-        Self::new_inner(
-            inner,
-            None,
-            Some(mosi.into()),
-            None,
-            None,
-            Some(tx_dma_ch),
-            None,
-            config,
-        )
+        Self::new_inner(spi, None, Some(mosi.into()), None, None, Some(tx_dma_ch), None, config)
     }
 
     /// Create an SPI driver in async mode supporting DMA read operations only.
-    pub fn new_rxonly<TxDma: ChannelInstance, RxDma: ChannelInstance>(
-        inner: Peri<'d, T>,
+    pub fn new_rxonly<T: Instance, TxDma: ChannelInstance, RxDma: ChannelInstance>(
+        spi: Peri<'d, T>,
         clk: Peri<'d, impl ClkPin<T> + 'd>,
         miso: Peri<'d, impl MisoPin<T> + 'd>,
         tx_dma: Peri<'d, TxDma>,
@@ -420,7 +397,7 @@ impl<'d, T: Instance> Spi<'d, T, Async> {
         let tx_dma_ch = dma::Channel::new(tx_dma, irq);
         let rx_dma_ch = dma::Channel::new(rx_dma, irq);
         Self::new_inner(
-            inner,
+            spi,
             Some(clk.into()),
             None,
             Some(miso.into()),
@@ -436,14 +413,16 @@ impl<'d, T: Instance> Spi<'d, T, Async> {
         let tx_transfer = unsafe {
             // If we don't assign future to a variable, the data register pointer
             // is held across an await and makes the future non-Send.
-            self.tx_dma
-                .as_mut()
-                .unwrap()
-                .write(buffer, self.inner.regs().dr().as_ptr() as *mut _, T::TX_DREQ, false)
+            self.tx_dma.as_mut().unwrap().write(
+                buffer,
+                self.info.regs.dr().as_ptr() as *mut _,
+                self.info.tx_dreq,
+                false,
+            )
         };
         tx_transfer.await;
 
-        let p = self.inner.regs();
+        let p = self.info.regs;
         while p.sr().read().bsy() {}
 
         // clear RX FIFO contents to prevent stale reads
@@ -463,10 +442,12 @@ impl<'d, T: Instance> Spi<'d, T, Async> {
         let rx_transfer = unsafe {
             // If we don't assign future to a variable, the data register pointer
             // is held across an await and makes the future non-Send.
-            self.rx_dma
-                .as_mut()
-                .unwrap()
-                .read(self.inner.regs().dr().as_ptr() as *const _, buffer, T::RX_DREQ, false)
+            self.rx_dma.as_mut().unwrap().read(
+                self.info.regs.dr().as_ptr() as *const _,
+                buffer,
+                self.info.rx_dreq,
+                false,
+            )
         };
 
         let tx_transfer = unsafe {
@@ -474,8 +455,8 @@ impl<'d, T: Instance> Spi<'d, T, Async> {
             // is held across an await and makes the future non-Send.
             self.tx_dma.as_mut().unwrap().write_zeros(
                 buffer.len(),
-                self.inner.regs().dr().as_ptr() as *mut u8,
-                T::TX_DREQ,
+                self.info.regs.dr().as_ptr() as *mut u8,
+                self.info.tx_dreq,
             )
         };
         join(tx_transfer, rx_transfer).await;
@@ -501,23 +482,25 @@ impl<'d, T: Instance> Spi<'d, T, Async> {
             self.rx_dma
                 .as_mut()
                 .unwrap()
-                .read(self.inner.regs().dr().as_ptr() as *const _, rx, T::RX_DREQ, false)
+                .read(self.info.regs.dr().as_ptr() as *const _, rx, self.info.rx_dreq, false)
         };
 
         let tx_ch = self.tx_dma.as_mut().unwrap();
         // If we don't assign future to a variable, the data register pointer
         // is held across an await and makes the future non-Send.
         let tx_transfer = async {
-            let p = self.inner.regs();
+            let p = self.info.regs;
             unsafe {
-                tx_ch.write(tx, p.dr().as_ptr() as *mut _, T::TX_DREQ, false).await;
+                tx_ch
+                    .write(tx, p.dr().as_ptr() as *mut _, self.info.tx_dreq, false)
+                    .await;
 
                 if rx.len() > tx.len() {
                     let write_bytes_len = rx.len() - tx.len();
                     // write dummy data
                     // this will disable incrementation of the buffers
                     tx_ch
-                        .write_zeros(write_bytes_len, p.dr().as_ptr() as *mut u8, T::TX_DREQ)
+                        .write_zeros(write_bytes_len, p.dr().as_ptr() as *mut u8, self.info.tx_dreq)
                         .await
                 }
             }
@@ -526,7 +509,7 @@ impl<'d, T: Instance> Spi<'d, T, Async> {
 
         // if tx > rx we should clear any overflow of the FIFO SPI buffer
         if tx.len() > rx.len() {
-            let p = self.inner.regs();
+            let p = self.info.regs;
             while p.sr().read().bsy() {}
 
             // clear RX FIFO contents to prevent stale reads
@@ -541,13 +524,16 @@ impl<'d, T: Instance> Spi<'d, T, Async> {
     }
 }
 
+struct Info {
+    regs: pac::spi::Spi,
+    tx_dreq: pac::dma::vals::TreqSel,
+    rx_dreq: pac::dma::vals::TreqSel,
+}
+
 trait SealedMode {}
 
 trait SealedInstance {
-    const TX_DREQ: pac::dma::vals::TreqSel;
-    const RX_DREQ: pac::dma::vals::TreqSel;
-
-    fn regs(&self) -> pac::spi::Spi;
+    fn info() -> &'static Info;
 }
 
 /// Mode.
@@ -559,31 +545,23 @@ pub trait Mode: SealedMode {}
 pub trait Instance: SealedInstance + PeripheralType {}
 
 macro_rules! impl_instance {
-    ($type:ident, $irq:ident, $tx_dreq:expr, $rx_dreq:expr) => {
-        impl SealedInstance for peripherals::$type {
-            const TX_DREQ: pac::dma::vals::TreqSel = $tx_dreq;
-            const RX_DREQ: pac::dma::vals::TreqSel = $rx_dreq;
-
-            fn regs(&self) -> pac::spi::Spi {
-                pac::$type
+    ($inst:ident, $tx_dreq:expr, $rx_dreq:expr) => {
+        impl SealedInstance for peripherals::$inst {
+            fn info() -> &'static Info {
+                static INFO: Info = Info {
+                    regs: pac::$inst,
+                    tx_dreq: $tx_dreq,
+                    rx_dreq: $rx_dreq,
+                };
+                &INFO
             }
         }
-        impl Instance for peripherals::$type {}
+        impl Instance for peripherals::$inst {}
     };
 }
 
-impl_instance!(
-    SPI0,
-    Spi0,
-    pac::dma::vals::TreqSel::Spi0Tx,
-    pac::dma::vals::TreqSel::Spi0Rx
-);
-impl_instance!(
-    SPI1,
-    Spi1,
-    pac::dma::vals::TreqSel::Spi1Tx,
-    pac::dma::vals::TreqSel::Spi1Rx
-);
+impl_instance!(SPI0, pac::dma::vals::TreqSel::Spi0Tx, pac::dma::vals::TreqSel::Spi0Rx);
+impl_instance!(SPI1, pac::dma::vals::TreqSel::Spi1Tx, pac::dma::vals::TreqSel::Spi1Rx);
 
 /// CLK pin.
 pub trait ClkPin<T: Instance>: GpioPin {}
@@ -684,7 +662,7 @@ impl_mode!(Async);
 
 // ====================
 
-impl<'d, T: Instance, M: Mode> embedded_hal_02::blocking::spi::Transfer<u8> for Spi<'d, T, M> {
+impl<'d, M: Mode> embedded_hal_02::blocking::spi::Transfer<u8> for Spi<'d, M> {
     type Error = Error;
     fn transfer<'w>(&mut self, words: &'w mut [u8]) -> Result<&'w [u8], Self::Error> {
         self.blocking_transfer_in_place(words)?;
@@ -692,7 +670,7 @@ impl<'d, T: Instance, M: Mode> embedded_hal_02::blocking::spi::Transfer<u8> for 
     }
 }
 
-impl<'d, T: Instance, M: Mode> embedded_hal_02::blocking::spi::Write<u8> for Spi<'d, T, M> {
+impl<'d, M: Mode> embedded_hal_02::blocking::spi::Write<u8> for Spi<'d, M> {
     type Error = Error;
 
     fn write(&mut self, words: &[u8]) -> Result<(), Self::Error> {
@@ -706,11 +684,11 @@ impl embedded_hal_1::spi::Error for Error {
     }
 }
 
-impl<'d, T: Instance, M: Mode> embedded_hal_1::spi::ErrorType for Spi<'d, T, M> {
+impl<'d, M: Mode> embedded_hal_1::spi::ErrorType for Spi<'d, M> {
     type Error = Error;
 }
 
-impl<'d, T: Instance, M: Mode> embedded_hal_1::spi::SpiBus<u8> for Spi<'d, T, M> {
+impl<'d, M: Mode> embedded_hal_1::spi::SpiBus<u8> for Spi<'d, M> {
     fn flush(&mut self) -> Result<(), Self::Error> {
         Ok(())
     }
@@ -732,7 +710,7 @@ impl<'d, T: Instance, M: Mode> embedded_hal_1::spi::SpiBus<u8> for Spi<'d, T, M>
     }
 }
 
-impl<'d, T: Instance> embedded_hal_async::spi::SpiBus<u8> for Spi<'d, T, Async> {
+impl<'d> embedded_hal_async::spi::SpiBus<u8> for Spi<'d, Async> {
     async fn flush(&mut self) -> Result<(), Self::Error> {
         Ok(())
     }
@@ -754,7 +732,7 @@ impl<'d, T: Instance> embedded_hal_async::spi::SpiBus<u8> for Spi<'d, T, Async> 
     }
 }
 
-impl<'d, T: Instance, M: Mode> SetConfig for Spi<'d, T, M> {
+impl<'d, M: Mode> SetConfig for Spi<'d, M> {
     type Config = Config;
     type ConfigError = ();
     fn set_config(&mut self, config: &Self::Config) -> Result<(), ()> {

--- a/examples/rp/src/bin/ethernet_w5500_icmp.rs
+++ b/examples/rp/src/bin/ethernet_w5500_icmp.rs
@@ -17,7 +17,7 @@ use embassy_net_wiznet::chip::W5500;
 use embassy_net_wiznet::*;
 use embassy_rp::clocks::RoscRng;
 use embassy_rp::gpio::{Input, Level, Output, Pull};
-use embassy_rp::peripherals::{DMA_CH0, DMA_CH1, SPI0};
+use embassy_rp::peripherals::{DMA_CH0, DMA_CH1};
 use embassy_rp::spi::{Async, Config as SpiConfig, Spi};
 use embassy_rp::{bind_interrupts, dma};
 use embassy_time::{Delay, Instant, Timer};
@@ -29,7 +29,7 @@ bind_interrupts!(struct Irqs {
     DMA_IRQ_0 => dma::InterruptHandler<DMA_CH0>, dma::InterruptHandler<DMA_CH1>;
 });
 
-type ExclusiveSpiDevice = ExclusiveDevice<Spi<'static, SPI0, Async>, Output<'static>, Delay>;
+type ExclusiveSpiDevice = ExclusiveDevice<Spi<'static, Async>, Output<'static>, Delay>;
 
 #[embassy_executor::task]
 async fn ethernet_task(runner: Runner<'static, W5500, ExclusiveSpiDevice, Input<'static>, Output<'static>>) -> ! {

--- a/examples/rp/src/bin/ethernet_w5500_icmp_ping.rs
+++ b/examples/rp/src/bin/ethernet_w5500_icmp_ping.rs
@@ -19,7 +19,7 @@ use embassy_net_wiznet::chip::W5500;
 use embassy_net_wiznet::*;
 use embassy_rp::clocks::RoscRng;
 use embassy_rp::gpio::{Input, Level, Output, Pull};
-use embassy_rp::peripherals::{DMA_CH0, DMA_CH1, SPI0};
+use embassy_rp::peripherals::{DMA_CH0, DMA_CH1};
 use embassy_rp::spi::{Async, Config as SpiConfig, Spi};
 use embassy_rp::{bind_interrupts, dma};
 use embassy_time::{Delay, Duration};
@@ -31,7 +31,7 @@ bind_interrupts!(struct Irqs {
     DMA_IRQ_0 => dma::InterruptHandler<DMA_CH0>, dma::InterruptHandler<DMA_CH1>;
 });
 
-type ExclusiveSpiDevice = ExclusiveDevice<Spi<'static, SPI0, Async>, Output<'static>, Delay>;
+type ExclusiveSpiDevice = ExclusiveDevice<Spi<'static, Async>, Output<'static>, Delay>;
 
 #[embassy_executor::task]
 async fn ethernet_task(runner: Runner<'static, W5500, ExclusiveSpiDevice, Input<'static>, Output<'static>>) -> ! {

--- a/examples/rp/src/bin/ethernet_w5500_multisocket.rs
+++ b/examples/rp/src/bin/ethernet_w5500_multisocket.rs
@@ -13,7 +13,7 @@ use embassy_net_wiznet::chip::W5500;
 use embassy_net_wiznet::*;
 use embassy_rp::clocks::RoscRng;
 use embassy_rp::gpio::{Input, Level, Output, Pull};
-use embassy_rp::peripherals::{DMA_CH0, DMA_CH1, SPI0};
+use embassy_rp::peripherals::{DMA_CH0, DMA_CH1};
 use embassy_rp::spi::{Async, Config as SpiConfig, Spi};
 use embassy_rp::{bind_interrupts, dma};
 use embassy_time::{Delay, Duration};
@@ -31,7 +31,7 @@ async fn ethernet_task(
     runner: Runner<
         'static,
         W5500,
-        ExclusiveDevice<Spi<'static, SPI0, Async>, Output<'static>, Delay>,
+        ExclusiveDevice<Spi<'static, Async>, Output<'static>, Delay>,
         Input<'static>,
         Output<'static>,
     >,

--- a/examples/rp/src/bin/ethernet_w5500_tcp_client.rs
+++ b/examples/rp/src/bin/ethernet_w5500_tcp_client.rs
@@ -15,7 +15,7 @@ use embassy_net_wiznet::chip::W5500;
 use embassy_net_wiznet::*;
 use embassy_rp::clocks::RoscRng;
 use embassy_rp::gpio::{Input, Level, Output, Pull};
-use embassy_rp::peripherals::{DMA_CH0, DMA_CH1, SPI0};
+use embassy_rp::peripherals::{DMA_CH0, DMA_CH1};
 use embassy_rp::spi::{Async, Config as SpiConfig, Spi};
 use embassy_rp::{bind_interrupts, dma};
 use embassy_time::{Delay, Duration, Timer};
@@ -33,7 +33,7 @@ async fn ethernet_task(
     runner: Runner<
         'static,
         W5500,
-        ExclusiveDevice<Spi<'static, SPI0, Async>, Output<'static>, Delay>,
+        ExclusiveDevice<Spi<'static, Async>, Output<'static>, Delay>,
         Input<'static>,
         Output<'static>,
     >,

--- a/examples/rp/src/bin/ethernet_w5500_tcp_server.rs
+++ b/examples/rp/src/bin/ethernet_w5500_tcp_server.rs
@@ -14,7 +14,7 @@ use embassy_net_wiznet::chip::W5500;
 use embassy_net_wiznet::*;
 use embassy_rp::clocks::RoscRng;
 use embassy_rp::gpio::{Input, Level, Output, Pull};
-use embassy_rp::peripherals::{DMA_CH0, DMA_CH1, SPI0};
+use embassy_rp::peripherals::{DMA_CH0, DMA_CH1};
 use embassy_rp::spi::{Async, Config as SpiConfig, Spi};
 use embassy_rp::{bind_interrupts, dma};
 use embassy_time::{Delay, Duration};
@@ -32,7 +32,7 @@ async fn ethernet_task(
     runner: Runner<
         'static,
         W5500,
-        ExclusiveDevice<Spi<'static, SPI0, Async>, Output<'static>, Delay>,
+        ExclusiveDevice<Spi<'static, Async>, Output<'static>, Delay>,
         Input<'static>,
         Output<'static>,
     >,

--- a/examples/rp/src/bin/ethernet_w5500_udp.rs
+++ b/examples/rp/src/bin/ethernet_w5500_udp.rs
@@ -14,7 +14,7 @@ use embassy_net_wiznet::chip::W5500;
 use embassy_net_wiznet::*;
 use embassy_rp::clocks::RoscRng;
 use embassy_rp::gpio::{Input, Level, Output, Pull};
-use embassy_rp::peripherals::{DMA_CH0, DMA_CH1, SPI0};
+use embassy_rp::peripherals::{DMA_CH0, DMA_CH1};
 use embassy_rp::spi::{Async, Config as SpiConfig, Spi};
 use embassy_rp::{bind_interrupts, dma};
 use embassy_time::Delay;
@@ -31,7 +31,7 @@ async fn ethernet_task(
     runner: Runner<
         'static,
         W5500,
-        ExclusiveDevice<Spi<'static, SPI0, Async>, Output<'static>, Delay>,
+        ExclusiveDevice<Spi<'static, Async>, Output<'static>, Delay>,
         Input<'static>,
         Output<'static>,
     >,

--- a/examples/rp/src/bin/i2c_slave.rs
+++ b/examples/rp/src/bin/i2c_slave.rs
@@ -18,7 +18,7 @@ bind_interrupts!(struct Irqs {
 const DEV_ADDR: u8 = 0x42;
 
 #[embassy_executor::task]
-async fn device_task(mut dev: i2c_slave::I2cSlave<'static, I2C1>) -> ! {
+async fn device_task(mut dev: i2c_slave::I2cSlave<'static>) -> ! {
     info!("Device start");
 
     let mut state = 0;
@@ -69,7 +69,7 @@ async fn device_task(mut dev: i2c_slave::I2cSlave<'static, I2C1>) -> ! {
 }
 
 #[embassy_executor::task]
-async fn controller_task(mut con: i2c::I2c<'static, I2C0, i2c::Async>) {
+async fn controller_task(mut con: i2c::I2c<'static, i2c::Async>) {
     info!("Controller start");
 
     loop {

--- a/examples/rp/src/bin/shared_bus.rs
+++ b/examples/rp/src/bin/shared_bus.rs
@@ -9,7 +9,7 @@ use embassy_embedded_hal::shared_bus::asynch::spi::SpiDevice;
 use embassy_executor::Spawner;
 use embassy_rp::gpio::{Level, Output};
 use embassy_rp::i2c::{self, I2c, InterruptHandler};
-use embassy_rp::peripherals::{DMA_CH0, DMA_CH1, I2C1, SPI1};
+use embassy_rp::peripherals::{DMA_CH0, DMA_CH1, I2C1};
 use embassy_rp::spi::{self, Spi};
 use embassy_rp::{bind_interrupts, dma};
 use embassy_sync::blocking_mutex::raw::NoopRawMutex;
@@ -18,8 +18,8 @@ use embassy_time::Timer;
 use static_cell::StaticCell;
 use {defmt_rtt as _, panic_probe as _};
 
-type Spi1Bus = Mutex<NoopRawMutex, Spi<'static, SPI1, spi::Async>>;
-type I2c1Bus = Mutex<NoopRawMutex, I2c<'static, I2C1, i2c::Async>>;
+type SpiBus = Mutex<NoopRawMutex, Spi<'static, spi::Async>>;
+type I2cBus = Mutex<NoopRawMutex, I2c<'static, i2c::Async>>;
 
 bind_interrupts!(struct Irqs {
     I2C1_IRQ => InterruptHandler<I2C1>;
@@ -33,7 +33,7 @@ async fn main(spawner: Spawner) {
 
     // Shared I2C bus
     let i2c = I2c::new_async(p.I2C1, p.PIN_15, p.PIN_14, Irqs, i2c::Config::default());
-    static I2C_BUS: StaticCell<I2c1Bus> = StaticCell::new();
+    static I2C_BUS: StaticCell<I2cBus> = StaticCell::new();
     let i2c_bus = I2C_BUS.init(Mutex::new(i2c));
 
     spawner.spawn(i2c_task_a(i2c_bus).unwrap());
@@ -44,7 +44,7 @@ async fn main(spawner: Spawner) {
     let spi = Spi::new(
         p.SPI1, p.PIN_10, p.PIN_11, p.PIN_12, p.DMA_CH0, p.DMA_CH1, Irqs, spi_cfg,
     );
-    static SPI_BUS: StaticCell<Spi1Bus> = StaticCell::new();
+    static SPI_BUS: StaticCell<SpiBus> = StaticCell::new();
     let spi_bus = SPI_BUS.init(Mutex::new(spi));
 
     // Chip select pins for the SPI devices
@@ -56,7 +56,7 @@ async fn main(spawner: Spawner) {
 }
 
 #[embassy_executor::task]
-async fn i2c_task_a(i2c_bus: &'static I2c1Bus) {
+async fn i2c_task_a(i2c_bus: &'static I2cBus) {
     let i2c_dev = I2cDevice::new(i2c_bus);
     let _sensor = DummyI2cDeviceDriver::new(i2c_dev, 0xC0);
     loop {
@@ -66,7 +66,7 @@ async fn i2c_task_a(i2c_bus: &'static I2c1Bus) {
 }
 
 #[embassy_executor::task]
-async fn i2c_task_b(i2c_bus: &'static I2c1Bus) {
+async fn i2c_task_b(i2c_bus: &'static I2cBus) {
     let i2c_dev = I2cDevice::new(i2c_bus);
     let _sensor = DummyI2cDeviceDriver::new(i2c_dev, 0xDE);
     loop {
@@ -76,7 +76,7 @@ async fn i2c_task_b(i2c_bus: &'static I2c1Bus) {
 }
 
 #[embassy_executor::task]
-async fn spi_task_a(spi_bus: &'static Spi1Bus, cs: Output<'static>) {
+async fn spi_task_a(spi_bus: &'static SpiBus, cs: Output<'static>) {
     let spi_dev = SpiDevice::new(spi_bus, cs);
     let _sensor = DummySpiDeviceDriver::new(spi_dev);
     loop {
@@ -86,7 +86,7 @@ async fn spi_task_a(spi_bus: &'static Spi1Bus, cs: Output<'static>) {
 }
 
 #[embassy_executor::task]
-async fn spi_task_b(spi_bus: &'static Spi1Bus, cs: Output<'static>) {
+async fn spi_task_b(spi_bus: &'static SpiBus, cs: Output<'static>) {
     let spi_dev = SpiDevice::new(spi_bus, cs);
     let _sensor = DummySpiDeviceDriver::new(spi_dev);
     loop {

--- a/examples/rp/src/bin/spi_gc9a01.rs
+++ b/examples/rp/src/bin/spi_gc9a01.rs
@@ -54,7 +54,7 @@ async fn main(_spawner: Spawner) {
     display_config.phase = spi::Phase::CaptureOnSecondTransition;
     display_config.polarity = spi::Polarity::IdleHigh;
 
-    let spi: Spi<'_, _, Blocking> = Spi::new_blocking_txonly(p.SPI1, clk, mosi, display_config.clone());
+    let spi: Spi<'_, Blocking> = Spi::new_blocking_txonly(p.SPI1, clk, mosi, display_config.clone());
     let spi_bus: Mutex<NoopRawMutex, _> = Mutex::new(RefCell::new(spi));
 
     let display_spi = SpiDeviceWithConfig::new(&spi_bus, Output::new(display_cs, Level::High), display_config);

--- a/examples/rp235x/src/bin/ethernet_w5500_icmp.rs
+++ b/examples/rp235x/src/bin/ethernet_w5500_icmp.rs
@@ -17,7 +17,7 @@ use embassy_net_wiznet::chip::W5500;
 use embassy_net_wiznet::*;
 use embassy_rp::clocks::RoscRng;
 use embassy_rp::gpio::{Input, Level, Output, Pull};
-use embassy_rp::peripherals::{DMA_CH0, DMA_CH1, SPI0};
+use embassy_rp::peripherals::{DMA_CH0, DMA_CH1};
 use embassy_rp::spi::{Async, Config as SpiConfig, Spi};
 use embassy_rp::{bind_interrupts, dma};
 use embassy_time::{Delay, Instant, Timer};
@@ -29,7 +29,7 @@ bind_interrupts!(struct Irqs {
     DMA_IRQ_0 => dma::InterruptHandler<DMA_CH0>, dma::InterruptHandler<DMA_CH1>;
 });
 
-type ExclusiveSpiDevice = ExclusiveDevice<Spi<'static, SPI0, Async>, Output<'static>, Delay>;
+type ExclusiveSpiDevice = ExclusiveDevice<Spi<'static, Async>, Output<'static>, Delay>;
 
 #[embassy_executor::task]
 async fn ethernet_task(runner: Runner<'static, W5500, ExclusiveSpiDevice, Input<'static>, Output<'static>>) -> ! {

--- a/examples/rp235x/src/bin/ethernet_w5500_icmp_ping.rs
+++ b/examples/rp235x/src/bin/ethernet_w5500_icmp_ping.rs
@@ -19,7 +19,7 @@ use embassy_net_wiznet::chip::W5500;
 use embassy_net_wiznet::*;
 use embassy_rp::clocks::RoscRng;
 use embassy_rp::gpio::{Input, Level, Output, Pull};
-use embassy_rp::peripherals::{DMA_CH0, DMA_CH1, SPI0};
+use embassy_rp::peripherals::{DMA_CH0, DMA_CH1};
 use embassy_rp::spi::{Async, Config as SpiConfig, Spi};
 use embassy_rp::{bind_interrupts, dma};
 use embassy_time::{Delay, Duration};
@@ -31,7 +31,7 @@ bind_interrupts!(struct Irqs {
     DMA_IRQ_0 => dma::InterruptHandler<DMA_CH0>, dma::InterruptHandler<DMA_CH1>;
 });
 
-type ExclusiveSpiDevice = ExclusiveDevice<Spi<'static, SPI0, Async>, Output<'static>, Delay>;
+type ExclusiveSpiDevice = ExclusiveDevice<Spi<'static, Async>, Output<'static>, Delay>;
 
 #[embassy_executor::task]
 async fn ethernet_task(runner: Runner<'static, W5500, ExclusiveSpiDevice, Input<'static>, Output<'static>>) -> ! {

--- a/examples/rp235x/src/bin/ethernet_w5500_multisocket.rs
+++ b/examples/rp235x/src/bin/ethernet_w5500_multisocket.rs
@@ -13,7 +13,7 @@ use embassy_net_wiznet::chip::W5500;
 use embassy_net_wiznet::*;
 use embassy_rp::clocks::RoscRng;
 use embassy_rp::gpio::{Input, Level, Output, Pull};
-use embassy_rp::peripherals::{DMA_CH0, DMA_CH1, SPI0};
+use embassy_rp::peripherals::{DMA_CH0, DMA_CH1};
 use embassy_rp::spi::{Async, Config as SpiConfig, Spi};
 use embassy_rp::{bind_interrupts, dma};
 use embassy_time::{Delay, Duration};
@@ -31,7 +31,7 @@ async fn ethernet_task(
     runner: Runner<
         'static,
         W5500,
-        ExclusiveDevice<Spi<'static, SPI0, Async>, Output<'static>, Delay>,
+        ExclusiveDevice<Spi<'static, Async>, Output<'static>, Delay>,
         Input<'static>,
         Output<'static>,
     >,

--- a/examples/rp235x/src/bin/ethernet_w5500_tcp_client.rs
+++ b/examples/rp235x/src/bin/ethernet_w5500_tcp_client.rs
@@ -15,7 +15,7 @@ use embassy_net_wiznet::chip::W5500;
 use embassy_net_wiznet::*;
 use embassy_rp::clocks::RoscRng;
 use embassy_rp::gpio::{Input, Level, Output, Pull};
-use embassy_rp::peripherals::{DMA_CH0, DMA_CH1, SPI0};
+use embassy_rp::peripherals::{DMA_CH0, DMA_CH1};
 use embassy_rp::spi::{Async, Config as SpiConfig, Spi};
 use embassy_rp::{bind_interrupts, dma};
 use embassy_time::{Delay, Duration, Timer};
@@ -33,7 +33,7 @@ async fn ethernet_task(
     runner: Runner<
         'static,
         W5500,
-        ExclusiveDevice<Spi<'static, SPI0, Async>, Output<'static>, Delay>,
+        ExclusiveDevice<Spi<'static, Async>, Output<'static>, Delay>,
         Input<'static>,
         Output<'static>,
     >,

--- a/examples/rp235x/src/bin/ethernet_w5500_tcp_server.rs
+++ b/examples/rp235x/src/bin/ethernet_w5500_tcp_server.rs
@@ -14,7 +14,7 @@ use embassy_net_wiznet::chip::W5500;
 use embassy_net_wiznet::*;
 use embassy_rp::clocks::RoscRng;
 use embassy_rp::gpio::{Input, Level, Output, Pull};
-use embassy_rp::peripherals::{DMA_CH0, DMA_CH1, SPI0};
+use embassy_rp::peripherals::{DMA_CH0, DMA_CH1};
 use embassy_rp::spi::{Async, Config as SpiConfig, Spi};
 use embassy_rp::{bind_interrupts, dma};
 use embassy_time::{Delay, Duration};
@@ -32,7 +32,7 @@ async fn ethernet_task(
     runner: Runner<
         'static,
         W5500,
-        ExclusiveDevice<Spi<'static, SPI0, Async>, Output<'static>, Delay>,
+        ExclusiveDevice<Spi<'static, Async>, Output<'static>, Delay>,
         Input<'static>,
         Output<'static>,
     >,

--- a/examples/rp235x/src/bin/ethernet_w5500_udp.rs
+++ b/examples/rp235x/src/bin/ethernet_w5500_udp.rs
@@ -14,7 +14,7 @@ use embassy_net_wiznet::chip::W5500;
 use embassy_net_wiznet::*;
 use embassy_rp::clocks::RoscRng;
 use embassy_rp::gpio::{Input, Level, Output, Pull};
-use embassy_rp::peripherals::{DMA_CH0, DMA_CH1, SPI0};
+use embassy_rp::peripherals::{DMA_CH0, DMA_CH1};
 use embassy_rp::spi::{Async, Config as SpiConfig, Spi};
 use embassy_rp::{bind_interrupts, dma};
 use embassy_time::Delay;
@@ -31,7 +31,7 @@ async fn ethernet_task(
     runner: Runner<
         'static,
         W5500,
-        ExclusiveDevice<Spi<'static, SPI0, Async>, Output<'static>, Delay>,
+        ExclusiveDevice<Spi<'static, Async>, Output<'static>, Delay>,
         Input<'static>,
         Output<'static>,
     >,

--- a/examples/rp235x/src/bin/i2c_slave.rs
+++ b/examples/rp235x/src/bin/i2c_slave.rs
@@ -18,7 +18,7 @@ bind_interrupts!(struct Irqs {
 const DEV_ADDR: u8 = 0x42;
 
 #[embassy_executor::task]
-async fn device_task(mut dev: i2c_slave::I2cSlave<'static, I2C1>) -> ! {
+async fn device_task(mut dev: i2c_slave::I2cSlave<'static>) -> ! {
     info!("Device start");
 
     let mut state = 0;
@@ -69,7 +69,7 @@ async fn device_task(mut dev: i2c_slave::I2cSlave<'static, I2C1>) -> ! {
 }
 
 #[embassy_executor::task]
-async fn controller_task(mut con: i2c::I2c<'static, I2C0, i2c::Async>) {
+async fn controller_task(mut con: i2c::I2c<'static, i2c::Async>) {
     info!("Controller start");
 
     loop {

--- a/examples/rp235x/src/bin/shared_bus.rs
+++ b/examples/rp235x/src/bin/shared_bus.rs
@@ -9,7 +9,7 @@ use embassy_embedded_hal::shared_bus::asynch::spi::SpiDevice;
 use embassy_executor::Spawner;
 use embassy_rp::gpio::{Level, Output};
 use embassy_rp::i2c::{self, I2c, InterruptHandler};
-use embassy_rp::peripherals::{DMA_CH0, DMA_CH1, I2C1, SPI1};
+use embassy_rp::peripherals::{DMA_CH0, DMA_CH1, I2C1};
 use embassy_rp::spi::{self, Spi};
 use embassy_rp::{bind_interrupts, dma};
 use embassy_sync::blocking_mutex::raw::NoopRawMutex;
@@ -18,8 +18,8 @@ use embassy_time::Timer;
 use static_cell::StaticCell;
 use {defmt_rtt as _, panic_probe as _};
 
-type Spi1Bus = Mutex<NoopRawMutex, Spi<'static, SPI1, spi::Async>>;
-type I2c1Bus = Mutex<NoopRawMutex, I2c<'static, I2C1, i2c::Async>>;
+type SpiBus = Mutex<NoopRawMutex, Spi<'static, spi::Async>>;
+type I2cBus = Mutex<NoopRawMutex, I2c<'static, i2c::Async>>;
 
 bind_interrupts!(struct Irqs {
     I2C1_IRQ => InterruptHandler<I2C1>;
@@ -33,7 +33,7 @@ async fn main(spawner: Spawner) {
 
     // Shared I2C bus
     let i2c = I2c::new_async(p.I2C1, p.PIN_15, p.PIN_14, Irqs, i2c::Config::default());
-    static I2C_BUS: StaticCell<I2c1Bus> = StaticCell::new();
+    static I2C_BUS: StaticCell<I2cBus> = StaticCell::new();
     let i2c_bus = I2C_BUS.init(Mutex::new(i2c));
 
     spawner.spawn(i2c_task_a(i2c_bus).unwrap());
@@ -44,7 +44,7 @@ async fn main(spawner: Spawner) {
     let spi = Spi::new(
         p.SPI1, p.PIN_10, p.PIN_11, p.PIN_12, p.DMA_CH0, p.DMA_CH1, Irqs, spi_cfg,
     );
-    static SPI_BUS: StaticCell<Spi1Bus> = StaticCell::new();
+    static SPI_BUS: StaticCell<SpiBus> = StaticCell::new();
     let spi_bus = SPI_BUS.init(Mutex::new(spi));
 
     // Chip select pins for the SPI devices
@@ -56,7 +56,7 @@ async fn main(spawner: Spawner) {
 }
 
 #[embassy_executor::task]
-async fn i2c_task_a(i2c_bus: &'static I2c1Bus) {
+async fn i2c_task_a(i2c_bus: &'static I2cBus) {
     let i2c_dev = I2cDevice::new(i2c_bus);
     let _sensor = DummyI2cDeviceDriver::new(i2c_dev, 0xC0);
     loop {
@@ -66,7 +66,7 @@ async fn i2c_task_a(i2c_bus: &'static I2c1Bus) {
 }
 
 #[embassy_executor::task]
-async fn i2c_task_b(i2c_bus: &'static I2c1Bus) {
+async fn i2c_task_b(i2c_bus: &'static I2cBus) {
     let i2c_dev = I2cDevice::new(i2c_bus);
     let _sensor = DummyI2cDeviceDriver::new(i2c_dev, 0xDE);
     loop {
@@ -76,7 +76,7 @@ async fn i2c_task_b(i2c_bus: &'static I2c1Bus) {
 }
 
 #[embassy_executor::task]
-async fn spi_task_a(spi_bus: &'static Spi1Bus, cs: Output<'static>) {
+async fn spi_task_a(spi_bus: &'static SpiBus, cs: Output<'static>) {
     let spi_dev = SpiDevice::new(spi_bus, cs);
     let _sensor = DummySpiDeviceDriver::new(spi_dev);
     loop {
@@ -86,7 +86,7 @@ async fn spi_task_a(spi_bus: &'static Spi1Bus, cs: Output<'static>) {
 }
 
 #[embassy_executor::task]
-async fn spi_task_b(spi_bus: &'static Spi1Bus, cs: Output<'static>) {
+async fn spi_task_b(spi_bus: &'static SpiBus, cs: Output<'static>) {
     let spi_dev = SpiDevice::new(spi_bus, cs);
     let _sensor = DummySpiDeviceDriver::new(spi_dev);
     loop {

--- a/examples/rp235x/src/bin/spi_display.rs
+++ b/examples/rp235x/src/bin/spi_display.rs
@@ -60,7 +60,7 @@ async fn main(_spawner: Spawner) {
     touch_config.phase = spi::Phase::CaptureOnSecondTransition;
     touch_config.polarity = spi::Polarity::IdleHigh;
 
-    let spi: Spi<'_, _, Blocking> = Spi::new_blocking(p.SPI1, clk, mosi, miso, touch_config.clone());
+    let spi: Spi<'_, Blocking> = Spi::new_blocking(p.SPI1, clk, mosi, miso, touch_config.clone());
     let spi_bus: Mutex<NoopRawMutex, _> = Mutex::new(RefCell::new(spi));
 
     let display_spi = SpiDeviceWithConfig::new(&spi_bus, Output::new(display_cs, Level::High), display_config);

--- a/tests/rp/src/bin/ethernet_w5100s_perf.rs
+++ b/tests/rp/src/bin/ethernet_w5100s_perf.rs
@@ -10,7 +10,7 @@ use embassy_net_wiznet::chip::W5100S;
 use embassy_net_wiznet::*;
 use embassy_rp::clocks::RoscRng;
 use embassy_rp::gpio::{Input, Level, Output, Pull};
-use embassy_rp::peripherals::{DMA_CH0, DMA_CH1, SPI0};
+use embassy_rp::peripherals::{DMA_CH0, DMA_CH1};
 use embassy_rp::spi::{Async, Config as SpiConfig, Spi};
 use embassy_rp::{bind_interrupts, dma};
 use embassy_time::Delay;
@@ -27,7 +27,7 @@ async fn ethernet_task(
     runner: Runner<
         'static,
         W5100S,
-        ExclusiveDevice<Spi<'static, SPI0, Async>, Output<'static>, Delay>,
+        ExclusiveDevice<Spi<'static, Async>, Output<'static>, Delay>,
         Input<'static>,
         Output<'static>,
     >,

--- a/tests/rp/src/bin/i2c.rs
+++ b/tests/rp/src/bin/i2c.rs
@@ -26,7 +26,7 @@ bind_interrupts!(struct Irqs {
 const DEV_ADDR: u8 = 0x42;
 
 #[embassy_executor::task]
-async fn device_task(mut dev: i2c_slave::I2cSlave<'static, I2C1>) -> ! {
+async fn device_task(mut dev: i2c_slave::I2cSlave<'static>) -> ! {
     info!("Device start");
 
     let mut count = 0xD0;
@@ -103,7 +103,7 @@ async fn device_task(mut dev: i2c_slave::I2cSlave<'static, I2C1>) -> ! {
     }
 }
 
-async fn controller_task(con: &mut i2c::I2c<'static, I2C0, i2c::Async>) {
+async fn controller_task(con: &mut i2c::I2c<'static, i2c::Async>) {
     info!("Controller start");
 
     {


### PR DESCRIPTION
A while back I made this (https://github.com/embassy-rs/embassy/pull/4155) change for the uart peripherals. The spi and i2c peripherals could still use this same change, so here is it.

The only thing I had to remove that somebody recently added (https://github.com/embassy-rs/embassy/pull/4405) was the `Debug` derive on the `I2c` type. I don't really understand the use-case of having it so I removed it since there is no easy way of keeping it. If there is a use-case for it I can try to find a way to manually implement it to get similar output.