### PR TITLE
RP2040/235x: Fixed significant issue with i2c slave respond_to_read

### DIFF
--- a/embassy-rp/CHANGELOG.md
+++ b/embassy-rp/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 <!-- next-header -->
 
 ## Unreleased - ReleaseDate
+- Fix i2c_slave respond_to_read for buffers larger than one chunk
 
 - DMA: clear channel `EN` bit before `chan_abort` on RP2350, per errata RP2350-E5 (see pico-sdk `dma_channel_abort` docs). Prevents the aborted channel from re-triggering.
 
@@ -52,7 +53,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fix configuration of embassy_rp adc div register ([#4815](https://github.com/embassy-rs/embassy/pull/4815))
 - Add TX-only, no SCK SPI support
 - Remove atomic-polyfill with critical-section instead ([#4948](https://github.com/embassy-rs/embassy/pull/4948))
-- Fix i2c_slave respond_to_read for buffers larger than one chunk
 
 ## 0.8.0 - 2025-08-26
 

--- a/embassy-rp/CHANGELOG.md
+++ b/embassy-rp/CHANGELOG.md
@@ -52,6 +52,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fix configuration of embassy_rp adc div register ([#4815](https://github.com/embassy-rs/embassy/pull/4815))
 - Add TX-only, no SCK SPI support
 - Remove atomic-polyfill with critical-section instead ([#4948](https://github.com/embassy-rs/embassy/pull/4948))
+- Fix i2c_slave respond_to_read for buffers larger than one chunk
 
 ## 0.8.0 - 2025-08-26
 

--- a/embassy-rp/src/i2c_slave.rs
+++ b/embassy-rp/src/i2c_slave.rs
@@ -5,9 +5,7 @@ use core::task::Poll;
 
 use pac::i2c;
 
-use crate::i2c::{
-    AbortReason, FIFO_SIZE, Instance, InterruptHandler, SclPin, SdaPin, set_up_i2c_pin,
-};
+use crate::i2c::{AbortReason, FIFO_SIZE, Instance, InterruptHandler, SclPin, SdaPin, set_up_i2c_pin};
 use crate::interrupt::typelevel::{Binding, Interrupt};
 use crate::{Peri, pac};
 
@@ -322,9 +320,7 @@ impl<'d, T: Instance> I2cSlave<'d, T> {
                 }
 
                 if bytes_written < buffer.len() {
-                    for _ in 0..((FIFO_SIZE - p.ic_txflr().read().txflr()) as usize)
-                        .min(buffer.len() - bytes_written)
-                    {
+                    for _ in 0..((FIFO_SIZE - p.ic_txflr().read().txflr()) as usize).min(buffer.len() - bytes_written) {
                         p.ic_clr_rd_req().read();
                         p.ic_data_cmd().write(|w| w.set_dat(buffer[bytes_written]));
                         bytes_written += 1;

--- a/embassy-rp/src/i2c_slave.rs
+++ b/embassy-rp/src/i2c_slave.rs
@@ -5,7 +5,9 @@ use core::task::Poll;
 
 use pac::i2c;
 
-use crate::i2c::{AbortReason, FIFO_SIZE, Instance, InterruptHandler, SclPin, SdaPin, set_up_i2c_pin};
+use crate::i2c::{
+    AbortReason, FIFO_SIZE, Instance, InterruptHandler, SclPin, SdaPin, set_up_i2c_pin,
+};
 use crate::interrupt::typelevel::{Binding, Interrupt};
 use crate::{Peri, pac};
 
@@ -320,7 +322,9 @@ impl<'d, T: Instance> I2cSlave<'d, T> {
                 }
 
                 if bytes_written < buffer.len() {
-                    for _ in 0..((FIFO_SIZE - p.ic_txflr().read().txflr()) as usize).min(buffer.len() - bytes_written)  {
+                    for _ in 0..((FIFO_SIZE - p.ic_txflr().read().txflr()) as usize)
+                        .min(buffer.len() - bytes_written)
+                    {
                         p.ic_clr_rd_req().read();
                         p.ic_data_cmd().write(|w| w.set_dat(buffer[bytes_written]));
                         bytes_written += 1;


### PR DESCRIPTION
I2c slave reads larger than a single chunk are completely broken without this, as a full 16 bytes was being written to the FIFO on every poll rather than waiting for space. This just limits FIFO writes based on free space.

Tested on rp2040.