### PR TITLE
stm32/eth: allow external poll irq

### DIFF
--- a/embassy-stm32/CHANGELOG.md
+++ b/embassy-stm32/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased - ReleaseDate
 
+- feat: allow use of external pin to change link state.
 - change: stm32/eth: ethernet no longer has a hard dependency on station management, and station management can be used independently ([#4871](https://github.com/embassy-rs/embassy/pull/4871))
 - feat: allow embassy_executor::main for low power
 - feat: Add waveform methods to ComplementaryPwm

--- a/embassy-stm32/src/eth/v1/mod.rs
+++ b/embassy-stm32/src/eth/v1/mod.rs
@@ -94,7 +94,7 @@ macro_rules! config_pins {
     };
 }
 
-impl<'d, T: Instance, SMA: sma::Instance> Ethernet<'d, T, GenericPhy<Sma<'d, SMA>>> {
+impl<'d, T: Instance, SMA: sma::Instance> Ethernet<'d, T, GenericPhy<'d, Sma<'d, SMA>>> {
     /// Create a new RMII ethernet driver using 7 pins.
     ///
     /// This function uses a [`GenericPhy::new_auto`] as PHY, created using the

--- a/embassy-stm32/src/eth/v2/mod.rs
+++ b/embassy-stm32/src/eth/v2/mod.rs
@@ -60,7 +60,7 @@ macro_rules! config_pins {
     };
 }
 
-impl<'d, T: Instance, SMA: sma::Instance> Ethernet<'d, T, GenericPhy<Sma<'d, SMA>>> {
+impl<'d, T: Instance, SMA: sma::Instance> Ethernet<'d, T, GenericPhy<'d, Sma<'d, SMA>>> {
     /// Create a new RMII ethernet driver using 7 pins.
     ///
     /// This function uses a [`GenericPhy::new_auto`] as PHY, created using the

--- a/embassy-stm32/src/exti.rs
+++ b/embassy-stm32/src/exti.rs
@@ -225,13 +225,13 @@ impl<'d> embedded_hal_async::digital::Wait for ExtiInput<'d> {
 }
 
 #[must_use = "futures do nothing unless you `.await` or poll them"]
-struct ExtiInputFuture<'a> {
+pub(crate) struct ExtiInputFuture<'a> {
     pin: PinNumber,
     phantom: PhantomData<&'a mut AnyPin>,
 }
 
 impl<'a> ExtiInputFuture<'a> {
-    fn new(pin: PinNumber, port: PinNumber, rising: bool, falling: bool) -> Self {
+    pub(crate) fn new(pin: PinNumber, port: PinNumber, rising: bool, falling: bool) -> Self {
         critical_section::with(|_| {
             let pin = pin as usize;
             exticr_regs().exticr(pin / 4).modify(|w| w.set_exti(pin % 4, port));

--- a/examples/stm32f4/src/bin/eth.rs
+++ b/examples/stm32f4/src/bin/eth.rs
@@ -20,7 +20,7 @@ bind_interrupts!(struct Irqs {
     HASH_RNG => rng::InterruptHandler<peripherals::RNG>;
 });
 
-type Device = Ethernet<'static, ETH, GenericPhy<Sma<'static, ETH_SMA>>>;
+type Device = Ethernet<'static, ETH, GenericPhy<'static, Sma<'static, ETH_SMA>>>;
 
 #[embassy_executor::task]
 async fn net_task(mut runner: embassy_net::Runner<'static, Device>) -> ! {

--- a/examples/stm32f7/src/bin/eth.rs
+++ b/examples/stm32f7/src/bin/eth.rs
@@ -20,7 +20,7 @@ bind_interrupts!(struct Irqs {
     HASH_RNG => rng::InterruptHandler<peripherals::RNG>;
 });
 
-type Device = Ethernet<'static, ETH, GenericPhy<Sma<'static, ETH_SMA>>>;
+type Device = Ethernet<'static, ETH, GenericPhy<'static, Sma<'static, ETH_SMA>>>;
 
 #[embassy_executor::task]
 async fn net_task(mut runner: embassy_net::Runner<'static, Device>) -> ! {

--- a/examples/stm32h5/src/bin/eth.rs
+++ b/examples/stm32h5/src/bin/eth.rs
@@ -23,7 +23,7 @@ bind_interrupts!(struct Irqs {
     RNG => rng::InterruptHandler<peripherals::RNG>;
 });
 
-type Device = Ethernet<'static, ETH, GenericPhy<Sma<'static, ETH_SMA>>>;
+type Device = Ethernet<'static, ETH, GenericPhy<'static, Sma<'static, ETH_SMA>>>;
 
 #[embassy_executor::task]
 async fn net_task(mut runner: embassy_net::Runner<'static, Device>) -> ! {

--- a/examples/stm32h7/src/bin/eth.rs
+++ b/examples/stm32h7/src/bin/eth.rs
@@ -19,7 +19,7 @@ bind_interrupts!(struct Irqs {
     RNG => rng::InterruptHandler<peripherals::RNG>;
 });
 
-type Device = Ethernet<'static, ETH, GenericPhy<Sma<'static, ETH_SMA>>>;
+type Device = Ethernet<'static, ETH, GenericPhy<'static, Sma<'static, ETH_SMA>>>;
 
 #[embassy_executor::task]
 async fn net_task(mut runner: embassy_net::Runner<'static, Device>) -> ! {

--- a/examples/stm32h7/src/bin/eth_client.rs
+++ b/examples/stm32h7/src/bin/eth_client.rs
@@ -22,7 +22,7 @@ bind_interrupts!(struct Irqs {
     RNG => rng::InterruptHandler<peripherals::RNG>;
 });
 
-type Device = Ethernet<'static, ETH, GenericPhy<Sma<'static, ETH_SMA>>>;
+type Device = Ethernet<'static, ETH, GenericPhy<'static, Sma<'static, ETH_SMA>>>;
 
 #[embassy_executor::task]
 async fn net_task(mut runner: embassy_net::Runner<'static, Device>) -> ! {

--- a/examples/stm32h7/src/bin/eth_client_mii.rs
+++ b/examples/stm32h7/src/bin/eth_client_mii.rs
@@ -22,7 +22,7 @@ bind_interrupts!(struct Irqs {
     RNG => rng::InterruptHandler<peripherals::RNG>;
 });
 
-type Device = Ethernet<'static, ETH, GenericPhy<Sma<'static, ETH_SMA>>>;
+type Device = Ethernet<'static, ETH, GenericPhy<'static, Sma<'static, ETH_SMA>>>;
 
 #[embassy_executor::task]
 async fn net_task(mut runner: embassy_net::Runner<'static, Device>) -> ! {

--- a/examples/stm32h7rs/src/bin/eth.rs
+++ b/examples/stm32h7rs/src/bin/eth.rs
@@ -19,7 +19,7 @@ bind_interrupts!(struct Irqs {
     RNG => rng::InterruptHandler<peripherals::RNG>;
 });
 
-type Device = Ethernet<'static, ETH, GenericPhy<Sma<'static, ETH_SMA>>>;
+type Device = Ethernet<'static, ETH, GenericPhy<'static, Sma<'static, ETH_SMA>>>;
 
 #[embassy_executor::task]
 async fn net_task(mut runner: embassy_net::Runner<'static, Device>) -> ! {

--- a/tests/stm32/src/bin/eth.rs
+++ b/tests/stm32/src/bin/eth.rs
@@ -27,7 +27,7 @@ bind_interrupts!(struct Irqs {
     RNG => rng::InterruptHandler<peripherals::RNG>;
 });
 
-type Device = Ethernet<'static, ETH, GenericPhy<Sma<'static, ETH_SMA>>>;
+type Device = Ethernet<'static, ETH, GenericPhy<'static, Sma<'static, ETH_SMA>>>;
 
 #[embassy_executor::task]
 async fn net_task(mut runner: embassy_net::Runner<'static, Device>) -> ! {


### PR DESCRIPTION
This allows using an exti pin to trigger link state changes, which is supported by some phys.