### PR TITLE
small tweak for USB HID reader

### DIFF
--- a/embassy-usb/CHANGELOG.md
+++ b/embassy-usb/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## Unreleased - ReleaseDate
 
 - Add support for USB HID Boot Protocol Mode 
+- `HidReader::run` does not consume itself anymore and only requires `&mut self`
 
 ## 0.5.1 - 2025-08-26
 

--- a/embassy-usb/src/class/hid.rs
+++ b/embassy-usb/src/class/hid.rs
@@ -331,7 +331,7 @@ impl<'d, D: Driver<'d>, const N: usize> HidWriter<'d, D, N> {
         assert!(report.len() <= N);
 
         let max_packet_size = usize::from(self.ep_in.info().max_packet_size);
-        let zlp_needed = report.len() < N && (report.len() % max_packet_size == 0);
+        let zlp_needed = report.len() < N && report.len().is_multiple_of(max_packet_size);
         for chunk in report.chunks(max_packet_size) {
             self.ep_in.write(chunk).await?;
         }
@@ -354,7 +354,7 @@ impl<'d, D: Driver<'d>, const N: usize> HidReader<'d, D, N> {
     ///
     /// If `use_report_ids` is true, the first byte of the report will be used as
     /// the `ReportId` value. Otherwise the `ReportId` value will be 0.
-    pub async fn run<T: RequestHandler>(mut self, use_report_ids: bool, handler: &mut T) -> ! {
+    pub async fn run<T: RequestHandler>(&mut self, use_report_ids: bool, handler: &mut T) -> ! {
         let offset = self.offset.load(Ordering::Acquire);
         assert!(offset == 0);
         let mut buf = [0; N];

--- a/examples/nrf52840/src/bin/usb_hid_keyboard.rs
+++ b/examples/nrf52840/src/bin/usb_hid_keyboard.rs
@@ -105,7 +105,7 @@ async fn main(_spawner: Spawner) {
 
     let mut button = Input::new(p.P0_11, Pull::Up);
 
-    let (reader, mut writer) = hid.split();
+    let (mut reader, mut writer) = hid.split();
 
     // Do stuff with the class!
     let in_fut = async {

--- a/examples/rp/src/bin/usb_hid_keyboard.rs
+++ b/examples/rp/src/bin/usb_hid_keyboard.rs
@@ -88,7 +88,7 @@ async fn main(_spawner: Spawner) {
     // Enable the schmitt trigger to slightly debounce.
     signal_pin.set_schmitt(true);
 
-    let (reader, mut writer) = hid.split();
+    let (mut reader, mut writer) = hid.split();
 
     // Do stuff with the class!
     let in_fut = async {

--- a/examples/rp/src/bin/usb_hid_mouse.rs
+++ b/examples/rp/src/bin/usb_hid_mouse.rs
@@ -84,7 +84,7 @@ async fn main(_spawner: Spawner) {
     // Run the USB device.
     let usb_fut = usb.run();
 
-    let (reader, mut writer) = hid.split();
+    let (mut reader, mut writer) = hid.split();
 
     // Do stuff with the class!
     let in_fut = async {

--- a/examples/rp235x/src/bin/usb_hid_keyboard.rs
+++ b/examples/rp235x/src/bin/usb_hid_keyboard.rs
@@ -88,7 +88,7 @@ async fn main(_spawner: Spawner) {
     // Enable the schmitt trigger to slightly debounce.
     signal_pin.set_schmitt(true);
 
-    let (reader, mut writer) = hid.split();
+    let (mut reader, mut writer) = hid.split();
 
     // Do stuff with the class!
     let in_fut = async {

--- a/examples/stm32f4/src/bin/usb_hid_keyboard.rs
+++ b/examples/stm32f4/src/bin/usb_hid_keyboard.rs
@@ -121,7 +121,7 @@ async fn main(_spawner: Spawner) {
     // Run the USB device.
     let usb_fut = usb.run();
 
-    let (reader, mut writer) = hid.split();
+    let (mut reader, mut writer) = hid.split();
 
     let mut button = ExtiInput::new(p.PC13, p.EXTI13, Pull::Down);
 


### PR DESCRIPTION
Allows running from a mutable reference, which was useful for stuffing the reader into local RTICv2 resources. I could not send it to a task by value because the reader is not sendable.