### PR TITLE
Expose timer queue impls unconditionally, support timer queue items stored outside of tasks (e.g. RTOS-aware `block_on`)

### DIFF
--- a/embassy-time-queue-utils/CHANGELOG.md
+++ b/embassy-time-queue-utils/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## Unreleased - ReleaseDate
 
 - Fixed an issue where never-ending timers were not correctly removed from the timer queue
+- Both integrated and generic queue implementations are available for use, independent of their respective features.
+- Added `queue_integrated::Queue::schedule_wake_queue_item` to support timer queue item storage outside of embassy executor tasks.
 
 ## 0.3.0 - 2025-08-26
 

--- a/embassy-time-queue-utils/src/lib.rs
+++ b/embassy-time-queue-utils/src/lib.rs
@@ -2,12 +2,43 @@
 #![doc = include_str!("../README.md")]
 #![warn(missing_docs)]
 
-#[cfg(feature = "_generic-queue")]
+use core::task::Waker;
+
 pub mod queue_generic;
-#[cfg(not(feature = "_generic-queue"))]
 pub mod queue_integrated;
 
 #[cfg(feature = "_generic-queue")]
-pub use queue_generic::Queue;
+type QueueImpl = queue_generic::Queue;
 #[cfg(not(feature = "_generic-queue"))]
-pub use queue_integrated::Queue;
+type QueueImpl = queue_integrated::Queue;
+
+/// The default timer queue, configured by the crate's features.
+///
+/// If any of the `generic-queue-X` features are enabled, this implements a generic
+/// timer queue of capacity X. Otherwise, it implements an integrated timer queue.
+#[derive(Debug)]
+pub struct Queue {
+    queue: QueueImpl,
+}
+
+impl Queue {
+    /// Creates a new timer queue.
+    pub const fn new() -> Self {
+        Self {
+            queue: QueueImpl::new(),
+        }
+    }
+
+    /// Schedules a task to run at a specific time, and returns whether any changes were made.
+    ///
+    /// If this function returns `true`, the caller should find the next expiration time and set
+    /// a new alarm for that time.
+    pub fn schedule_wake(&mut self, at: u64, waker: &Waker) -> bool {
+        self.queue.schedule_wake(at, waker)
+    }
+
+    /// Dequeues expired timers and returns the next alarm time.
+    pub fn next_expiration(&mut self, now: u64) -> u64 {
+        self.queue.next_expiration(now)
+    }
+}

--- a/embassy-time-queue-utils/src/queue_generic.rs
+++ b/embassy-time-queue-utils/src/queue_generic.rs
@@ -47,7 +47,7 @@ impl<const QUEUE_SIZE: usize> ConstGenericQueue<QUEUE_SIZE> {
 
     /// Schedules a task to run at a specific time, and returns whether any changes were made.
     ///
-    /// If this function returns `true`, the called should find the next expiration time and set
+    /// If this function returns `true`, the caller should find the next expiration time and set
     /// a new alarm for that time.
     pub fn schedule_wake(&mut self, at: u64, waker: &Waker) -> bool {
         self.queue
@@ -135,7 +135,7 @@ impl Queue {
 
     /// Schedules a task to run at a specific time, and returns whether any changes were made.
     ///
-    /// If this function returns `true`, the called should find the next expiration time and set
+    /// If this function returns `true`, the caller should find the next expiration time and set
     /// a new alarm for that time.
     pub fn schedule_wake(&mut self, at: u64, waker: &Waker) -> bool {
         self.queue.schedule_wake(at, waker)


### PR DESCRIPTION
This PR is a backwards-compatible implementation that allows HAL implementers to mix queue implementations, which allows users to mix executors. This is mainly targeted at RTOS implementations which can use embassy-executor, and also provide their own `block_on` implementations simultaneously.