### PR TITLE
embassy-rp: add support for TX-only, no SCK SPI

### DIFF
--- a/embassy-rp/CHANGELOG.md
+++ b/embassy-rp/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add reset_to_usb_boot for rp235x ([#4705](https://github.com/embassy-rs/embassy/pull/4705))
 - Add fix #4822 in PIO onewire. Change to disable the state machine before setting y register ([#4824](https://github.com/embassy-rs/embassy/pull/4824))
 - Add PIO::Ws2812 color order support
+- Add TX-only, no SCK SPI support
 
 ## 0.8.0 - 2025-08-26
 

--- a/embassy-rp/src/spi.rs
+++ b/embassy-rp/src/spi.rs
@@ -308,6 +308,11 @@ impl<'d, T: Instance> Spi<'d, T, Blocking> {
         )
     }
 
+    /// Create an SPI driver in blocking mode supporting writes only, without SCK pin.
+    pub fn new_blocking_txonly_nosck(inner: Peri<'d, T>, mosi: Peri<'d, impl MosiPin<T> + 'd>, config: Config) -> Self {
+        Self::new_inner(inner, None, Some(mosi.into()), None, None, None, None, config)
+    }
+
     /// Create an SPI driver in blocking mode supporting reads only.
     pub fn new_blocking_rxonly(
         inner: Peri<'d, T>,
@@ -362,6 +367,26 @@ impl<'d, T: Instance> Spi<'d, T, Async> {
         Self::new_inner(
             inner,
             Some(clk.into()),
+            Some(mosi.into()),
+            None,
+            None,
+            Some(tx_dma.into()),
+            None,
+            config,
+        )
+    }
+
+    /// Create an SPI driver in async mode supporting DMA write operations only,
+    /// without SCK pin.
+    pub fn new_txonly_nosck(
+        inner: Peri<'d, T>,
+        mosi: Peri<'d, impl MosiPin<T> + 'd>,
+        tx_dma: Peri<'d, impl Channel>,
+        config: Config,
+    ) -> Self {
+        Self::new_inner(
+            inner,
+            None,
             Some(mosi.into()),
             None,
             None,


### PR DESCRIPTION
This adds support for setting up SPI for sending data only without a clock pin. I am using an [Adafruit MacroPad RP2040](https://www.adafruit.com/product/5100) which has NeoPixels on SPI0 with only one pin connected (TX0), with the other SPI0 pins all used for other peripherals. This will allow controlling the LEDs without having to create an unsafe `clone_unchecked` of the clock pin which is used elsewhere.