### PR TITLE
if dma transfer fails, retry

### DIFF
--- a/embassy-stm32/CHANGELOG.md
+++ b/embassy-stm32/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased - ReleaseDate
 
+- fix: ringuffered DMA does retry in write_exact if failed
 - feat: Add continuous waveform method to SimplePWM
 - change: remove waveform timer method
 - change: low power: store stop mode for dma channels

--- a/embassy-stm32/src/dma/gpdma/ringbuffered.rs
+++ b/embassy-stm32/src/dma/gpdma/ringbuffered.rs
@@ -245,9 +245,14 @@ impl<'a, W: Word> WritableRingBuffer<'a, W> {
 
     /// Write an exact number of elements to the ringbuffer.
     pub async fn write_exact(&mut self, buffer: &[W]) -> Result<usize, Error> {
-        self.ringbuf
+        match self.ringbuf
             .write_exact(&mut DmaCtrlImpl(self.channel.reborrow()), buffer)
-            .await
+            .await {
+                Ok(n) => Ok(n),
+                Err(_) => self.ringbuf
+                              .write_exact(&mut DmaCtrlImpl(self.channel.reborrow()), buffer)
+                              .await
+            }
     }
 
     /// Wait for any ring buffer write error.

--- a/embassy-stm32/src/dma/gpdma/ringbuffered.rs
+++ b/embassy-stm32/src/dma/gpdma/ringbuffered.rs
@@ -245,14 +245,18 @@ impl<'a, W: Word> WritableRingBuffer<'a, W> {
 
     /// Write an exact number of elements to the ringbuffer.
     pub async fn write_exact(&mut self, buffer: &[W]) -> Result<usize, Error> {
-        match self.ringbuf
+        match self
+            .ringbuf
             .write_exact(&mut DmaCtrlImpl(self.channel.reborrow()), buffer)
-            .await {
-                Ok(n) => Ok(n),
-                Err(_) => self.ringbuf
-                              .write_exact(&mut DmaCtrlImpl(self.channel.reborrow()), buffer)
-                              .await
+            .await
+        {
+            Ok(n) => Ok(n),
+            Err(_) => {
+                self.ringbuf
+                    .write_exact(&mut DmaCtrlImpl(self.channel.reborrow()), buffer)
+                    .await
             }
+        }
     }
 
     /// Wait for any ring buffer write error.


### PR DESCRIPTION
This a fix to the issue:
[STM32] GPDMA ringbuffer #4858

What this does:
If write fails, try it again. 

Circular ringbuffer has a bug, if it tries to write data to the ringbuffer, but its at the end of it, data doesnt fit, instead of writing to the buffer, data are just lost.
This is probably a workaround from an issue, that is deeper and I dont understand it. I just saw a problem, this fix fixed it perfectly, but its clearly a workaround(There shouldnt be a need for retry, if failed). 