### PR TITLE
stm32/can: Add error messages to calc_can_timings

### DIFF
--- a/embassy-stm32/CHANGELOG.md
+++ b/embassy-stm32/CHANGELOG.md
@@ -84,6 +84,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - removal: ExtiInput no longer accepts AnyPin/AnyChannel; AnyChannel removed entirely
 - fix: build script ensures EXTI2_TSC is listed as the IRQ of EXTI2 even if the PAC doesn't
 - feat: stm32/lcd: added implementation
+- change: add error messages to can timing calculations ([#4961](https://github.com/embassy-rs/embassy/pull/4961))
 
 ## 0.4.0 - 2025-08-26
 

--- a/embassy-stm32/src/can/enums.rs
+++ b/embassy-stm32/src/can/enums.rs
@@ -88,33 +88,33 @@ pub enum RefCountOp {
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub enum TimingCalcError {
     /// Bitrate is lower than 1000
-    BitrateTooLow { 
-        /// The set bitrate 
-        bitrate: u32 
+    BitrateTooLow {
+        /// The set bitrate
+        bitrate: u32,
     },
     /// No solution possible
-    NoSolution { 
+    NoSolution {
         /// The sum of BS1 and BS2
-        bs1_bs2_sum: u8 
+        bs1_bs2_sum: u8,
     },
     /// Prescaler is not 1 < prescaler < 1024
-    InvalidPrescaler { 
-        /// The calculated prescaler value 
-        prescaler: u32 
+    InvalidPrescaler {
+        /// The calculated prescaler value
+        prescaler: u32,
     },
     /// BS1 or BS2 are not in the range 0 < BSx < BSx_MAX
-    BSNotInRange { 
+    BSNotInRange {
         /// The value of BS1
         bs1: u8,
         /// The value of BS2
-        bs2: u8 
+        bs2: u8,
     },
     /// Final bitrate doesn't match the requested bitrate
-    NoMatch { 
-        /// The requested bitrate 
+    NoMatch {
+        /// The requested bitrate
         requested: u32,
-        /// The calculated bitrate 
-        final_calculated: u32 
+        /// The calculated bitrate
+        final_calculated: u32,
     },
     /// core::num::NonZeroUxx::new error
     CoreNumNew,

--- a/embassy-stm32/src/can/util.rs
+++ b/embassy-stm32/src/can/util.rs
@@ -19,7 +19,10 @@ pub struct NominalBitTiming {
 }
 
 /// Calculate nominal CAN bit timing based on CAN bitrate and periphial clock frequency
-pub fn calc_can_timings(periph_clock: crate::time::Hertz, can_bitrate: u32) -> Result<NominalBitTiming, TimingCalcError> {
+pub fn calc_can_timings(
+    periph_clock: crate::time::Hertz,
+    can_bitrate: u32,
+) -> Result<NominalBitTiming, TimingCalcError> {
     const BS1_MAX: u8 = 16;
     const BS2_MAX: u8 = 8;
     const MAX_SAMPLE_POINT_PERMILL: u16 = 900;
@@ -101,7 +104,10 @@ pub fn calc_can_timings(periph_clock: crate::time::Hertz, can_bitrate: u32) -> R
     let calculated = periph_clock / (prescaler * (1 + bs1 + bs2) as u32);
     // Check if final bitrate matches the requested
     if can_bitrate != calculated {
-        return Err(TimingCalcError::NoMatch { requested: can_bitrate, final_calculated: calculated });
+        return Err(TimingCalcError::NoMatch {
+            requested: can_bitrate,
+            final_calculated: calculated,
+        });
     }
 
     // One is recommended by DS-015, CANOpen, and DeviceNet


### PR DESCRIPTION
When trying to use CAN-FD in the [stm32g4 can example](https://github.com/embassy-rs/embassy/blob/main/examples/stm32g4/src/bin/can.rs) by enabling the `use_fd` flag the code crashes with the following error message :
```
[...]
0.000030 [ERROR] panicked at C:\Users\ME\.cargo\registry\src\index.crates.io-1949cf8c6b5b557f\embassy-stm32-0.4.0\src\can\fdcan.rs:236:77: 
called `Option::unwrap()` on a `None` value (panic_probe panic-probe-1.0.0/src/lib.rs:104)
[...]
```
which doesn't really tell you what is wrong. In this PR I added some error variants to explain the issue a bit more. It now looks like this:
```
[...]
0.000030 [ERROR] panicked at C:\Users\ME\.cargo\git\checkouts\embassy-7317a4eaf224a633\e34c43d\embassy-stm32\src\can\fdcan.rs:240:77:
called `Result::unwrap()` on an `Err` value: NoMatch { requested: 1000000, final_calculated: 1011904 } (panic_probe panic-probe-1.0.0/src/lib.rs:104)
[...]
```
If there's a good way to make defmt show an even better error message for each error enum entry I can also add that too, I just couldn't find something like that in the defmt docs