### PR TITLE
Fix a bug where CDC ACM BufferedReceiver repeats data when its future is dropped

### DIFF
--- a/embassy-usb/CHANGELOG.md
+++ b/embassy-usb/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Add support for USB HID Boot Protocol Mode 
 - Bump usbd-hid from 0.8.1 to 0.9.0
+- Fix a bug where CDC ACM BufferedReceiver repeats data when its future is dropped
 
 ## 0.5.1 - 2025-08-26
 

--- a/embassy-usb/src/class/cdc_acm.rs
+++ b/embassy-usb/src/class/cdc_acm.rs
@@ -545,9 +545,12 @@ impl<'d, D: Driver<'d>> embedded_io_async::Read for BufferedReceiver<'d, D> {
             return self.receiver.read_packet(buf).await;
         }
 
-        // Otherwise read a packet into the internal buffer, and return some of it to the caller
-        self.start = 0;
+        // Otherwise read a packet into the internal buffer, and return some of it to the caller.
+        //
+        // It's important that `start` and `end` be updated in this order so they're left in a
+        // consistent state if the `read` future is dropped mid-execution, e.g. from a timeout.
         self.end = self.receiver.read_packet(&mut self.buffer).await?;
+        self.start = 0;
         return Ok(self.read_from_buffer(buf));
     }
 }


### PR DESCRIPTION
This PR fixes a bug where the CDC ACM `BufferedReceiver` can repeat previously received data when its `read` future is dropped.

Under the current implementation of `read`, if there's no buffered data and the provided buffer isn't large enough to contain an entire packet, `self.start` is set to `0` before awaiting a new packet while `self.end` is only updated after a packet arrives. If the `read` future is dropped at the await point, `start` has been reset to `0` but `end` retains its old value, causing the next call to `read` to repeat the previously received packet.

A scenario where you might run into this bug (where I ran into it) is if you want to read with a timeout, e.g.

```
with_timeout(Duration::from_secs(1), buffered_receiver.read(&mut buf))
```

If the read times out, the `read` future is dropped mid-execution and the `BufferedReceiver` is left in an inconsistent state.

My fix is to reorder the assignments so they're only updated after receiving a new packet.