### PR TITLE
embassy-mspm0:  add CPU accelerated float division function

### DIFF
--- a/embassy-mspm0/CHANGELOG.md
+++ b/embassy-mspm0/CHANGELOG.md
@@ -21,3 +21,4 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - feat: Add read_reset_cause function
 - feat: Add module Mathacl & example for mspm0g3507 (#4897)
 - feat: Add MSPM0G5187 supportt
+- feat: add CPU accelerated division function (#4966)

--- a/examples/mspm0g3507/src/bin/mathacl_ops.rs
+++ b/examples/mspm0g3507/src/bin/mathacl_ops.rs
@@ -1,6 +1,6 @@
 //! Example of using mathematical calculations performed by the MSPM0G3507 chip.
 //!
-//! It prints the result of basics trigonometric calculation.
+//! It prints the result of basics mathematical calculation.
 
 #![no_std]
 #![no_main]
@@ -9,7 +9,7 @@ use core::f32::consts::PI;
 
 use defmt::*;
 use embassy_executor::Spawner;
-use embassy_mspm0::mathacl::{Mathacl, Precision};
+use embassy_mspm0::mathacl::{IQType, Mathacl, Precision};
 use embassy_time::Timer;
 use {defmt_rtt as _, panic_halt as _};
 
@@ -22,15 +22,50 @@ async fn main(_spawner: Spawner) -> ! {
     let mut macl = Mathacl::new(d.MATHACL);
 
     // value radians [-PI; PI]
-    let rads = PI * 0.5;
-    match macl.sin(rads, Precision::High) {
-        Ok(res) => info!("sin({}) = {}", rads, res),
+    let op1 = PI * 0.5;
+    match macl.sin(op1, Precision::High) {
+        Ok(res) => info!("sin({}) = {}", op1, res),
         Err(e) => error!("sin Error: {:?}", e),
     }
 
-    match macl.cos(rads, Precision::Medium) {
-        Ok(res) => info!("cos({}) = {}", rads, res),
+    match macl.cos(op1, Precision::Medium) {
+        Ok(res) => info!("cos({}) = {}", op1, res),
         Err(e) => error!("cos Error: {:?}", e),
+    }
+
+    // 1 bit for the sign, 15 bits integer & 16 bits fractional part
+    let div_iq_s1 = IQType::from_f32(-1.0, 15, true).unwrap();
+    let div_iq_s2 = IQType::from_f32(3.0, 15, true).unwrap();
+    match macl.div_iq(div_iq_s1, div_iq_s2) {
+        Ok(res) => info!("div IQ signed {}/{} = {}", div_iq_s1.to_f32(), div_iq_s2.to_f32(), res),
+        Err(e) => error!("div IQ signed Error: {:?}", e),
+    }
+
+    // 16 bits integer & 16 bits fractional part
+    let div_iq_u1 = IQType::from_f32(1.0, 16, false).unwrap();
+    let div_iq_u2 = IQType::from_f32(3.0, 16, false).unwrap();
+    match macl.div_iq(div_iq_u1, div_iq_u2) {
+        Ok(res) => info!(
+            "div IQ unsigned {}/{} = {}",
+            div_iq_u1.to_f32(),
+            div_iq_u2.to_f32(),
+            res
+        ),
+        Err(e) => error!("div IQ unsigned Error: {:?}", e),
+    }
+
+    let div1_i32 = -5;
+    let div2_i32 = -2;
+    match macl.div_i32(div1_i32, div2_i32) {
+        Ok(res) => info!("div i32 {}/{} = {}", div1_i32, div2_i32, res),
+        Err(e) => error!("div i32 Error: {:?}", e),
+    }
+
+    let div1_u32 = 5;
+    let div2_u32 = 2;
+    match macl.div_u32(div1_u32, div2_u32) {
+        Ok(res) => info!("div u32 {}/{} = {}", div1_u32, div2_u32, res),
+        Err(e) => error!("div u32 Error: {:?}", e),
     }
 
     loop {


### PR DESCRIPTION
- mspm0-mathacl: add division example
- mspm0-mathacl: add CPU accelerated float division function
- using internal Mathacl Qval type for providing length of fractional part