### PR TITLE
Fix SPI:  SSM and SSOE in STM32 driver behavior, add nss_output_disable to SPI Config

### DIFF
--- a/embassy-stm32/CHANGELOG.md
+++ b/embassy-stm32/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased - ReleaseDate
 
+- fix: stm32: SPI driver SSOE and SSM manegment, add `nss_output_disable` to SPI Config
 - change: stm32: use typelevel timer type to allow dma for 32 bit timers
 - fix: fix incorrect handling of split interrupts in timer driver
 - feat: allow granular stop for regular usart


### PR DESCRIPTION
<img width="1623" height="1105" alt="image" src="https://github.com/user-attachments/assets/99eb1fd4-ec1a-451d-9616-84a5d6ecd10f" />

SSOE and SSM have defined behavior and cannot be hardcoded. I've added initialization logic for this registers and also field to SPI Config to disable NSS output to set SSM=0 SSOE=1