### PR TITLE
embassy-time: some `driver_std` fixes

### DIFF
--- a/embassy-time/CHANGELOG.md
+++ b/embassy-time/CHANGELOG.md
@@ -17,6 +17,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add `Instant::try_from_nanos`
 - Added 375KHz tick rate support
 - Upgrade embassy-executor to 0.10.0
+- driver_std: convert to using `LazyLock`
+- driver_std: wrap timer iteration in critical section
+- driver_std: also check timer queue within `schedule_wake()`
 
 ## 0.5.0 - 2025-08-26
 

--- a/embassy-time/src/driver_std.rs
+++ b/embassy-time/src/driver_std.rs
@@ -41,7 +41,7 @@ fn alarm_thread() {
     loop {
         let now = DRIVER.now();
 
-        let next_alarm = DRIVER.queue.lock().unwrap().next_expiration(now);
+        let next_alarm = critical_section::with(|_cs| DRIVER.queue.lock().unwrap().next_expiration(now));
 
         // Ensure we don't overflow
         let until = zero

--- a/embassy-time/src/driver_std.rs
+++ b/embassy-time/src/driver_std.rs
@@ -31,7 +31,10 @@ impl Driver for TimeDriver {
     fn schedule_wake(&self, at: u64, waker: &core::task::Waker) {
         let mut queue = self.queue.lock().unwrap();
         if queue.schedule_wake(at, waker) {
-            self.signaler.signal();
+            let next_alarm = critical_section::with(|_cs| queue.next_expiration(self.now()));
+            if next_alarm < u64::MAX {
+                self.signaler.signal();
+            }
         }
     }
 }


### PR DESCRIPTION
I stumbled across a few oddities with the `embassy-time` std driver:

1. Both `now()` and `schedule_wake()` were locking `inner`. That made any use of `now()` within a waker cause a deadlock.

   => fixed by splitting `inner` into its fields `queue` and `zero_instant`, and using `LazyLock` for initialization.

3. The `alarm_thread()` iterates the timer queue while holding the queue lock, but outside a critical section. Now if:
    1. another thread holds a critical section and calls `schedule_wake()`, it is blocked on the queue lock
    2. `alarm_thread()` wakes a waker that in its `wake()` enters a critical section
    4. the two threads dead-lock

    => fixed by wrapping the queue iteration in a critical section.

3. Previously, `schedule_wake()` would just pass the `Waker` to the queue's `schedule_wake()` and signal the alarm thread. If two consecutive `Wakers` are scheduled, the first before `now` and the second after `now`, only the first would get woken (as soon as `alarm_thread()` processes the signal).
   This behaves differently than all the other time driver implementations, that all call `queue.next_iteration()` within `schedule_wake()` and thus execute already passed timeouts right away, causing two wakeups.

   While I believe consistent behavior alone justifies this change, it is also necessary for using the `embassy-time` machinery outside of tasks, because a `Waker` cannot re-schedule itself to a later timeout in its `wake()`, as calling `schedule_wake()` while the queue lock is held causes a deadlock. So a waker can only check if it should wake (through `now()` and its context). Through first setting it with `at=0` (already passed), which `wakes()` once and then drops the waker from the queue, it can be set again with any `at`.

    => fixed by also calling `queue.next_iteration()` within `schedule_wake()`.

