### PR TITLE
docs: fix rp235x pio_i2s example comment

### DIFF
--- a/examples/rp235x/src/bin/pio_i2s.rs
+++ b/examples/rp235x/src/bin/pio_i2s.rs
@@ -5,7 +5,7 @@
 //!   bclk : GPIO 18
 //!   lrc  : GPIO 19
 //!   din  : GPIO 20
-//! Then hold down the boot select button to trigger a rising triangle waveform.
+//! Then short GPIO 0 to GND to trigger a rising triangle waveform.
 
 #![no_std]
 #![no_main]
@@ -70,7 +70,7 @@ async fn main(_spawner: Spawner) {
         // but don't await the returned future, yet
         let dma_future = i2s.write(front_buffer);
 
-        // fade in audio when bootsel is pressed
+        // fade in audio when GPIO 0 pin is shorted to GND
         let fade_target = if fade_input.is_low() { i32::MAX } else { 0 };
 
         // fill back buffer with fresh audio samples before awaiting the dma future


### PR DESCRIPTION
The rp235x version of the pio_i2s example doesn't use the bootsel button as the fade-in trigger like the original, but it kept the comments.
Update the comments to reflect that GP0 is the trigger to avoid confusing the next person that reads this code.