### PR TITLE
Feat/blinky example init fix

### DIFF
--- a/examples/stm32wba6/src/bin/blinky.rs
+++ b/examples/stm32wba6/src/bin/blinky.rs
@@ -40,7 +40,8 @@ async fn main(_spawner: Spawner) {
     let p = embassy_stm32::init(config);
     info!("Hello World!");
 
-    let mut led = Output::new(p.PB4, Level::High, Speed::Low);
+    // LD2 - PC4
+    let mut led = Output::new(p.PC4, Level::High, Speed::Low);
 
     loop {
         info!("high");


### PR DESCRIPTION
The blinky example for stm32wba6 was crashing when running `cargo run --bin blinky` because it was missing some initialization logic present in other examples. 
The PIN number for the LED was updated to PC4 which corresponds to LD2. 
