### PR TITLE
Fix API documentation for Ticker reset_at() function

### DIFF
--- a/embassy-time/src/timer.rs
+++ b/embassy-time/src/timer.rs
@@ -253,7 +253,7 @@ impl Ticker {
     }
 
     /// Reset the ticker at the deadline.
-    /// If the deadline is in the past, the ticker will fire instantly.
+    /// If the deadline is in the past, the ticker will fire before the next scheduled tick.
     pub fn reset_at(&mut self, deadline: Instant) {
         self.expires_at = deadline + self.duration;
     }


### PR DESCRIPTION
The documentation indicated reset_at() would fire immediately if the deadline is in the past. However, if the duration is further in the future than the deadline is in the past, the ticker won't fire immediately but just before the next scheduled tick.