### PR TITLE
Make adc v2 resolution public

### DIFF
--- a/embassy-stm32/src/adc/v2.rs
+++ b/embassy-stm32/src/adc/v2.rs
@@ -71,7 +71,7 @@ fn from_pclk2(freq: Hertz) -> Adcpre {
 /// ADC configuration
 #[derive(Default)]
 pub struct AdcConfig {
-    resolution: Option<Resolution>,
+    pub resolution: Option<Resolution>,
 }
 
 impl<T: Instance> super::SealedAnyInstance for T {


### PR DESCRIPTION
After #4867 ADCv2 resolution was made inaccessible, this resolves it.