### PR TITLE
low-power: improve debug logic

### DIFF
--- a/embassy-stm32/src/exti.rs
+++ b/embassy-stm32/src/exti.rs
@@ -74,7 +74,7 @@ unsafe fn on_irq() {
     }
 
     #[cfg(feature = "low-power")]
-    crate::low_power::Executor::on_wakeup_irq();
+    crate::low_power::Executor::on_wakeup_irq_or_event();
 }
 
 struct BitIter(u32);

--- a/embassy-stm32/src/i2c/v2.rs
+++ b/embassy-stm32/src/i2c/v2.rs
@@ -73,7 +73,7 @@ pub(crate) unsafe fn on_interrupt<T: Instance>() {
     // restore the clocks to their last configured state as
     // much is lost in STOP modes
     #[cfg(all(feature = "low-power", stm32wlex))]
-    crate::low_power::Executor::on_wakeup_irq();
+    crate::low_power::Executor::on_wakeup_irq_or_event();
 
     let regs = T::info().regs;
     let isr = regs.isr().read();

--- a/embassy-stm32/src/rcc/mod.rs
+++ b/embassy-stm32/src/rcc/mod.rs
@@ -172,7 +172,7 @@ pub(crate) struct RccInfo {
 /// E.g. if `StopMode::Stop1` is selected, the peripheral prevents the chip from entering Stop1 mode.
 #[cfg(feature = "low-power")]
 #[allow(dead_code)]
-#[derive(Debug, Clone, Copy, PartialEq, Default)]
+#[derive(Debug, Clone, Copy, PartialEq, Default, defmt::Format)]
 pub enum StopMode {
     #[default]
     /// Peripheral prevents chip from entering Stop1 or executor will enter Stop1

--- a/embassy-stm32/src/time_driver.rs
+++ b/embassy-stm32/src/time_driver.rs
@@ -329,6 +329,12 @@ impl RtcDriver {
         regs_gp16().cr1().modify(|w| w.set_cen(true));
     }
 
+    #[cfg(feature = "low-power")]
+    /// Returns whether time is currently stopped
+    pub(crate) fn is_stopped(&self) -> bool {
+        !regs_gp16().cr1().read().cen()
+    }
+
     fn set_alarm(&self, cs: CriticalSection, timestamp: u64) -> bool {
         let r = regs_gp16();
 

--- a/embassy-stm32/src/timer/mod.rs
+++ b/embassy-stm32/src/timer/mod.rs
@@ -406,7 +406,7 @@ pub struct UpdateInterruptHandler<T: CoreInstance> {
 impl<T: CoreInstance> interrupt::typelevel::Handler<T::UpdateInterrupt> for UpdateInterruptHandler<T> {
     unsafe fn on_interrupt() {
         #[cfg(feature = "low-power")]
-        crate::low_power::Executor::on_wakeup_irq();
+        crate::low_power::Executor::on_wakeup_irq_or_event();
 
         let regs = crate::pac::timer::TimCore::from_ptr(T::regs());
 
@@ -436,7 +436,7 @@ impl<T: GeneralInstance1Channel> interrupt::typelevel::Handler<T::CaptureCompare
 {
     unsafe fn on_interrupt() {
         #[cfg(feature = "low-power")]
-        crate::low_power::Executor::on_wakeup_irq();
+        crate::low_power::Executor::on_wakeup_irq_or_event();
 
         let regs = crate::pac::timer::TimGp16::from_ptr(T::regs());
 


### PR DESCRIPTION
improves the stop messages (less confusing) and always run the wakeup irq handler on a poll loop.