### PR TITLE
[stm32] use enable_and_reset_without_stop for select peripherals + block_stop

### DIFF
--- a/embassy-stm32/src/adc/mod.rs
+++ b/embassy-stm32/src/adc/mod.rs
@@ -251,6 +251,7 @@ impl<'d, T: Instance> Adc<'d, T> {
         sequence: impl ExactSizeIterator<Item = (&'a mut AnyAdcChannel<'b, T>, <T::Regs as BasicAdcRegs>::SampleTime)>,
         readings: &mut [u16],
     ) {
+        let _scoped_block_stop = T::RCC_INFO.block_stop();
         assert!(sequence.len() != 0, "Asynchronous read sequence cannot be empty");
         assert!(
             sequence.len() == readings.len(),

--- a/embassy-stm32/src/adc/v3.rs
+++ b/embassy-stm32/src/adc/v3.rs
@@ -388,7 +388,7 @@ impl super::AdcRegs for crate::pac::adc::Adc {
 impl<'d, T: Instance<Regs = crate::pac::adc::Adc>> Adc<'d, T> {
     /// Enable the voltage regulator
     fn init_regulator() {
-        rcc::enable_and_reset::<T>();
+        rcc::enable_and_reset_without_stop::<T>();
         T::regs().cr().modify(|reg| {
             #[cfg(not(any(adc_g0, adc_u0)))]
             reg.set_deeppwd(false);

--- a/embassy-stm32/src/i2c/mod.rs
+++ b/embassy-stm32/src/i2c/mod.rs
@@ -226,7 +226,7 @@ impl<'d, M: Mode> I2c<'d, M, Master> {
     }
 
     fn enable_and_init(&mut self, config: Config) {
-        self.info.rcc.enable_and_reset();
+        self.info.rcc.enable_and_reset_without_stop();
         self.init(config);
     }
 }

--- a/embassy-stm32/src/i2c/v1.rs
+++ b/embassy-stm32/src/i2c/v1.rs
@@ -529,6 +529,7 @@ impl<'d, IM: MasterMode> I2c<'d, Async, IM> {
 
     /// Write.
     pub async fn write(&mut self, address: u8, write_buffer: &[u8]) -> Result<(), Error> {
+        let _scoped_block_stop = self.info.rcc.block_stop();
         self.write_frame(address, write_buffer, FrameOptions::FirstAndLastFrame)
             .await?;
 
@@ -537,6 +538,7 @@ impl<'d, IM: MasterMode> I2c<'d, Async, IM> {
 
     /// Read.
     pub async fn read(&mut self, address: u8, read_buffer: &mut [u8]) -> Result<(), Error> {
+        let _scoped_block_stop = self.info.rcc.block_stop();
         self.read_frame(address, read_buffer, FrameOptions::FirstAndLastFrame)
             .await?;
 
@@ -701,6 +703,7 @@ impl<'d, IM: MasterMode> I2c<'d, Async, IM> {
 
     /// Write, restart, read.
     pub async fn write_read(&mut self, address: u8, write_buffer: &[u8], read_buffer: &mut [u8]) -> Result<(), Error> {
+        let _scoped_block_stop = self.info.rcc.block_stop();
         // Check empty read buffer before starting transaction. Otherwise, we would not generate the
         // stop condition below.
         if read_buffer.is_empty() {
@@ -719,6 +722,7 @@ impl<'d, IM: MasterMode> I2c<'d, Async, IM> {
     ///
     /// [transaction contract]: embedded_hal_1::i2c::I2c::transaction
     pub async fn transaction(&mut self, address: u8, operations: &mut [Operation<'_>]) -> Result<(), Error> {
+        let _scoped_block_stop = self.info.rcc.block_stop();
         for (op, frame) in operation_frames(operations)? {
             match op {
                 Operation::Read(read_buffer) => self.read_frame(address, read_buffer, frame).await?,
@@ -1357,6 +1361,7 @@ impl<'d> I2c<'d, Async, MultiMaster> {
     /// (Read/Write) and the matched address. This method will suspend until
     /// an address match occurs.
     pub async fn listen(&mut self) -> Result<SlaveCommand, Error> {
+        let _scoped_block_stop = self.info.rcc.block_stop();
         trace!("I2C slave: starting async listen for address match");
         let state = self.state;
         let info = self.info;
@@ -1421,6 +1426,7 @@ impl<'d> I2c<'d, Async, MultiMaster> {
     ///
     /// Returns the number of bytes stored in the buffer (not total received).
     pub async fn respond_to_write(&mut self, buffer: &mut [u8]) -> Result<usize, Error> {
+        let _scoped_block_stop = self.info.rcc.block_stop();
         trace!("I2C slave: starting respond_to_write, buffer_len={}", buffer.len());
 
         if buffer.is_empty() {
@@ -1454,6 +1460,7 @@ impl<'d> I2c<'d, Async, MultiMaster> {
     ///
     /// Returns the total number of bytes transmitted (data + padding).
     pub async fn respond_to_read(&mut self, data: &[u8]) -> Result<usize, Error> {
+        let _scoped_block_stop = self.info.rcc.block_stop();
         trace!("I2C slave: starting respond_to_read, data_len={}", data.len());
 
         if data.is_empty() {

--- a/embassy-stm32/src/i2c/v2.rs
+++ b/embassy-stm32/src/i2c/v2.rs
@@ -1075,6 +1075,7 @@ impl<'d, IM: MasterMode> I2c<'d, Async, IM> {
 
     /// Write.
     pub async fn write(&mut self, address: u8, write: &[u8]) -> Result<(), Error> {
+        let _scoped_block_stop = self.info.rcc.block_stop();
         let timeout = self.timeout();
         if write.is_empty() {
             self.write_internal(address.into(), write, true, timeout)
@@ -1089,6 +1090,7 @@ impl<'d, IM: MasterMode> I2c<'d, Async, IM> {
     ///
     /// The buffers are concatenated in a single write transaction.
     pub async fn write_vectored(&mut self, address: Address, write: &[&[u8]]) -> Result<(), Error> {
+        let _scoped_block_stop = self.info.rcc.block_stop();
         let timeout = self.timeout();
 
         if write.is_empty() {
@@ -1120,6 +1122,7 @@ impl<'d, IM: MasterMode> I2c<'d, Async, IM> {
 
     /// Read.
     pub async fn read(&mut self, address: u8, buffer: &mut [u8]) -> Result<(), Error> {
+        let _scoped_block_stop = self.info.rcc.block_stop();
         let timeout = self.timeout();
 
         if buffer.is_empty() {
@@ -1132,6 +1135,7 @@ impl<'d, IM: MasterMode> I2c<'d, Async, IM> {
 
     /// Write, restart, read.
     pub async fn write_read(&mut self, address: u8, write: &[u8], read: &mut [u8]) -> Result<(), Error> {
+        let _scoped_block_stop = self.info.rcc.block_stop();
         let timeout = self.timeout();
 
         if write.is_empty() {
@@ -1157,6 +1161,7 @@ impl<'d, IM: MasterMode> I2c<'d, Async, IM> {
     ///
     /// [transaction contract]: embedded_hal_1::i2c::I2c::transaction
     pub async fn transaction(&mut self, addr: u8, operations: &mut [Operation<'_>]) -> Result<(), Error> {
+        let _scoped_block_stop = self.info.rcc.block_stop();
         if operations.is_empty() {
             return Err(Error::ZeroLengthTransfer);
         }
@@ -1677,6 +1682,7 @@ impl<'d, M: Mode> I2c<'d, M, MultiMaster> {
     ///
     /// The listen method is an asynchronous method but it does not require DMA to be asynchronous.
     pub async fn listen(&mut self) -> Result<SlaveCommand, Error> {
+        let _scoped_block_stop = self.info.rcc.block_stop();
         let state = self.state;
         self.info.regs.cr1().modify(|reg| {
             reg.set_addrie(true);
@@ -1733,12 +1739,14 @@ impl<'d> I2c<'d, Async, MultiMaster> {
     ///
     /// Returns the total number of bytes received.
     pub async fn respond_to_write(&mut self, buffer: &mut [u8]) -> Result<usize, Error> {
+        let _scoped_block_stop = self.info.rcc.block_stop();
         let timeout = self.timeout();
         timeout.with(self.read_dma_internal_slave(buffer, timeout)).await
     }
 
     /// Respond to a read request from an I2C master.
     pub async fn respond_to_read(&mut self, write: &[u8]) -> Result<SendStatus, Error> {
+        let _scoped_block_stop = self.info.rcc.block_stop();
         let timeout = self.timeout();
         timeout.with(self.write_dma_internal_slave(write, timeout)).await
     }

--- a/embassy-stm32/src/qspi/mod.rs
+++ b/embassy-stm32/src/qspi/mod.rs
@@ -111,7 +111,7 @@ impl<'d, T: Instance, M: PeriMode> Qspi<'d, T, M> {
         config: Config,
         fsel: FlashSelection,
     ) -> Self {
-        rcc::enable_and_reset::<T>();
+        rcc::enable_and_reset_without_stop::<T>();
 
         while T::REGS.sr().read().busy() {}
 
@@ -403,6 +403,7 @@ impl<'d, T: Instance> Qspi<'d, T, Async> {
 
     /// Async read data, using DMA.
     pub async fn read_dma(&mut self, buf: &mut [u8], transaction: TransferConfig) {
+        let _scoped_block_stop = T::RCC_INFO.block_stop();
         let transfer = self.start_read_transfer(transaction, buf);
         transfer.await;
     }
@@ -443,6 +444,7 @@ impl<'d, T: Instance> Qspi<'d, T, Async> {
 
     /// Async write data, using DMA.
     pub async fn write_dma(&mut self, buf: &[u8], transaction: TransferConfig) {
+        let _scoped_block_stop = T::RCC_INFO.block_stop();
         let transfer = self.start_write_transfer(transaction, buf);
         transfer.await;
     }

--- a/embassy-stm32/src/rcc/mod.rs
+++ b/embassy-stm32/src/rcc/mod.rs
@@ -498,6 +498,16 @@ pub fn enable_and_reset<T: RccPeripheral>() {
     T::RCC_INFO.enable_and_reset();
 }
 
+/// Enables and resets peripheral `T` without stopping the clock.
+///
+/// # Safety
+///
+/// Peripheral must not be in use.
+// TODO: should this be `unsafe`?
+pub fn enable_and_reset_without_stop<T: RccPeripheral>() {
+    T::RCC_INFO.enable_and_reset_without_stop();
+}
+
 /// Disables peripheral `T`.
 ///
 /// # Safety

--- a/embassy-stm32/src/spi/mod.rs
+++ b/embassy-stm32/src/spi/mod.rs
@@ -230,7 +230,7 @@ impl<'d, M: PeriMode, CM: CommunicationMode> Spi<'d, M, CM> {
         let cpol = config.raw_polarity();
         let lsbfirst = config.raw_byte_order();
 
-        self.info.rcc.enable_and_reset();
+        self.info.rcc.enable_and_reset_without_stop();
 
         /*
         - Software NSS management (SSM = 1)
@@ -848,6 +848,7 @@ impl<'d> Spi<'d, Async, Master> {
 impl<'d, CM: CommunicationMode> Spi<'d, Async, CM> {
     /// SPI write, using DMA.
     pub async fn write<W: Word>(&mut self, data: &[W]) -> Result<(), Error> {
+        let _scoped_block_stop = self.info.rcc.block_stop();
         if data.is_empty() {
             return Ok(());
         }
@@ -879,6 +880,7 @@ impl<'d, CM: CommunicationMode> Spi<'d, Async, CM> {
     /// SPI read, using DMA.
     #[cfg(any(spi_v4, spi_v5, spi_v6))]
     pub async fn read<W: Word>(&mut self, data: &mut [W]) -> Result<(), Error> {
+        let _scoped_block_stop = self.info.rcc.block_stop();
         if data.is_empty() {
             return Ok(());
         }
@@ -1013,6 +1015,7 @@ impl<'d, CM: CommunicationMode> Spi<'d, Async, CM> {
     }
 
     async fn transfer_inner<W: Word>(&mut self, read: *mut [W], write: *const [W]) -> Result<(), Error> {
+        let _scoped_block_stop = self.info.rcc.block_stop();
         assert_eq!(read.len(), write.len());
         if read.len() == 0 {
             return Ok(());

--- a/embassy-stm32/src/timer/low_level.rs
+++ b/embassy-stm32/src/timer/low_level.rs
@@ -243,7 +243,7 @@ impl<'d, T: CoreInstance> Drop for Timer<'d, T> {
 impl<'d, T: CoreInstance> Timer<'d, T> {
     /// Create a new timer driver.
     pub fn new(tim: Peri<'d, T>) -> Self {
-        rcc::enable_and_reset::<T>();
+        rcc::enable_and_reset_without_stop::<T>();
 
         Self { tim }
     }

--- a/embassy-stm32/src/timer/simple_pwm.rs
+++ b/embassy-stm32/src/timer/simple_pwm.rs
@@ -347,6 +347,7 @@ impl<'d, T: GeneralInstance4Channel> SimplePwm<'d, T> {
         channel: Channel,
         duty: &[W],
     ) {
+        let _scoped_block_stop = T::RCC_INFO.block_stop();
         self.inner.enable_channel(channel, true);
         self.inner.enable_channel(C::CHANNEL, true);
         self.inner.clamp_compare_value::<W>(channel);
@@ -368,6 +369,7 @@ impl<'d, T: GeneralInstance4Channel> SimplePwm<'d, T> {
         channel: Channel,
         duty: &[W],
     ) {
+        let _scoped_block_stop = T::RCC_INFO.block_stop();
         self.inner.enable_channel(channel, true);
         self.inner.clamp_compare_value::<W>(channel);
         self.inner.enable_update_dma(true);
@@ -411,6 +413,7 @@ impl<'d, T: GeneralInstance4Channel> SimplePwm<'d, T> {
         ending_channel: Channel,
         duty: &[W],
     ) {
+        let _scoped_block_stop = T::RCC_INFO.block_stop();
         [Channel::Ch1, Channel::Ch2, Channel::Ch3, Channel::Ch4]
             .iter()
             .filter(|ch| ch.index() >= starting_channel.index())


### PR DESCRIPTION
Start peripherals with enable_and_reset_without_stop to prevent call to `increment_stop_refcount`
Use block_stop to increment refcount in the method scope and prevent stop1/2 when an async method is being awaited
Implemented on:
- [x] adc v3
- [x] i2c v1/v2
- [x] qspi
- [x] spi
- [x] sdmmc
- [x] simple_pwm

Only select async methods use block_stop, hence the draft.