### PR TITLE
Add a basic "format all" script

### DIFF
--- a/fmtall.sh
+++ b/fmtall.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+set -euo pipefail
+
+# We need the nightly toolchain for this
+mv rust-toolchain-nightly.toml rust-toolchain.toml
+
+# Similar to the CI workflow, but don't just CHECK, actualy DO the formatting
+find . -name '*.rs' -not -path '*target*' | xargs rustfmt --skip-children --unstable-features --edition 2024
+
+# Put the toolchains back, copy back to nightly and do a clean checkout of rust-toolchain
+mv rust-toolchain.toml rust-toolchain-nightly.toml
+git checkout -- rust-toolchain.toml


### PR DESCRIPTION
This is mostly a copy of the CI `rustfmt.sh` script, but it actually does the formatting, and cleans up the toolchain swap.

I've found formatting PRs is sort of annoying without a nice tool like this, as the way the embassy repo enforces formatting is somewhat quirky.

There's definitely a better way to do this, but IMO this way is better than none.