### PR TITLE
stm32: Add `get_frequency` to `SimplePwm` and `SimplePwmChannel`

### DIFF
--- a/embassy-stm32/src/timer/simple_pwm.rs
+++ b/embassy-stm32/src/timer/simple_pwm.rs
@@ -97,6 +97,11 @@ impl<'d, T: GeneralInstance4Channel> SimplePwmChannel<'d, T> {
         self.timer.get_channel_enable_state(self.channel)
     }
 
+    /// Get the frequency of the PWM channel.
+    pub fn get_frequency(&self) -> Hertz {
+        self.timer.get_frequency()
+    }
+
     /// Get max duty value.
     ///
     /// This value depends on the configured frequency and the timer's clock rate from RCC.
@@ -328,6 +333,11 @@ impl<'d, T: GeneralInstance4Channel> SimplePwm<'d, T> {
             1u8
         };
         self.inner.set_frequency_internal(freq * multiplier, 16);
+    }
+
+    /// Get the PWM driver frequency.
+    pub fn get_frequency(&self) -> Hertz {
+        self.inner.get_frequency()
     }
 
     /// Get max duty value.


### PR DESCRIPTION
Add `get_frequency` to `SimplePwm` and `SimplePwmChannel`.

Motivation for this change: I need to calculate a duty cycle based on a target pulse width. This needs the frequency of the channel, however this information is no longer available after passing `Hertz` into the `SimplePwm` constructor.

If this change is to be accepted, we'd likely want to implement it on all other targets too. Will look into it once we decide if this change is worth doing.