### PR TITLE
Add `run_until` function to std Executor as to support grafeul shutdown.

### DIFF
--- a/embassy-executor/CHANGELOG.md
+++ b/embassy-executor/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added optional "earliest deadline first" EDF scheduling
 - Migrate `cortex-ar` to `aarch32-cpu`. The feature name `arch-cortex-ar` remains the same and
   legacy ARM architectures are not supported.
+- Added `run_until` to `arch-std` variant of `Executor`.
 
 ## 0.9.1 - 2025-08-31
 

--- a/embassy-executor/src/arch/std.rs
+++ b/embassy-executor/src/arch/std.rs
@@ -55,11 +55,24 @@ mod thread {
         ///
         /// This function never returns.
         pub fn run(&'static mut self, init: impl FnOnce(Spawner)) -> ! {
+            self.run_until(init, || false);
+            unreachable!()
+        }
+
+        /// Run the executor until a flag is raised.
+        ///
+        /// This function is identical to `Executor::run()` apart from offering a `done` flag to stop execution.
+        pub fn run_until(&'static mut self, init: impl FnOnce(Spawner), mut done: impl FnMut() -> bool) {
             init(self.inner.spawner());
 
             loop {
                 unsafe { self.inner.poll() };
-                self.signaler.wait()
+
+                if done() {
+                    break;
+                }
+
+                self.signaler.wait();
             }
         }
     }

--- a/examples/std/src/bin/tick_cancel.rs
+++ b/examples/std/src/bin/tick_cancel.rs
@@ -1,0 +1,47 @@
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::thread;
+use std::time::Duration;
+
+use embassy_executor::Executor;
+use embassy_time::Timer;
+use log::*;
+use static_cell::StaticCell;
+
+#[embassy_executor::task]
+async fn run() {
+    loop {
+        info!("tick");
+        Timer::after_secs(1).await;
+    }
+}
+
+static DONE: StaticCell<AtomicBool> = StaticCell::new();
+static EXECUTOR: StaticCell<Executor> = StaticCell::new();
+
+fn main() {
+    env_logger::builder()
+        .filter_level(log::LevelFilter::Debug)
+        .format_timestamp_nanos()
+        .init();
+
+    let done = DONE.init(AtomicBool::new(false));
+    let done_cb = || done.load(Ordering::Relaxed);
+
+    let server_thread = thread::spawn(move || {
+        let executor = EXECUTOR.init(Executor::new());
+        executor.run_until(
+            |spawner| {
+                spawner.spawn(run().unwrap());
+            },
+            done_cb,
+        );
+        info!("Executor finished");
+    });
+
+    thread::sleep(Duration::from_secs(5));
+
+    info!("Cancelling executor");
+    done.store(true, Ordering::Relaxed);
+
+    server_thread.join().unwrap();
+}


### PR DESCRIPTION
This is an alternative approach to https://github.com/embassy-rs/embassy/pull/4923 that strives to be simpler