### PR TITLE
Spi::new, apply IO driver strength

### DIFF
--- a/embassy-stm32/CHANGELOG.md
+++ b/embassy-stm32/CHANGELOG.md
@@ -93,6 +93,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - stm32: Add blocking_listen for blocking I2C driver
 - fix: stm32l47*/stm32l48* adc analog pin setup
 - fix: keep stm32/sai: make NODIV independent of MCKDIV
+- fix: instantiation with Spi::new did not apply IO driver strength from config (speed)
 
 ## 0.4.0 - 2025-08-26
 

--- a/embassy-stm32/src/spi/mod.rs
+++ b/embassy-stm32/src/spi/mod.rs
@@ -325,6 +325,16 @@ impl<'d, M: PeriMode, CM: CommunicationMode> Spi<'d, M, CM> {
                 w.set_spe(true);
             });
         }
+        #[cfg(gpio_v2)]
+        {
+            self.gpio_speed = config.gpio_speed;
+            if let Some(sck) = self.sck.as_ref() {
+                sck.set_speed(config.gpio_speed);
+            }
+            if let Some(mosi) = self.mosi.as_ref() {
+                mosi.set_speed(config.gpio_speed);
+            }
+        }
         #[cfg(any(spi_v4, spi_v5, spi_v6))]
         {
             let ssoe = CM::MASTER == vals::Master::MASTER && !config.nss_output_disable;


### PR DESCRIPTION
instantiation with Spi::new did not apply IO driver strength from config (speed)