### PR TITLE
stm32: i2c should enable with stop

### DIFF
--- a/embassy-stm32/src/i2c/mod.rs
+++ b/embassy-stm32/src/i2c/mod.rs
@@ -226,7 +226,7 @@ impl<'d, M: Mode> I2c<'d, M, Master> {
     }
 
     fn enable_and_init(&mut self, config: Config) {
-        self.info.rcc.enable_and_reset_without_stop();
+        self.info.rcc.enable_and_reset();
         self.init(config);
     }
 }


### PR DESCRIPTION
An I2C peripheral will loose its register values at some stop level.  We need to prevent that level if its used.