### PR TITLE
embassy_rp: improve calculate_pio_clock_divider

### DIFF
--- a/embassy-rp/src/pio_programs/clock_divider.rs
+++ b/embassy-rp/src/pio_programs/clock_divider.rs
@@ -29,7 +29,7 @@ pub fn calculate_pio_clock_divider(target_hz: u32) -> fixed::FixedU32<U8> {
 /// A fixed-point divider value suitable for use in a PIO state machine configuration
 pub const fn calculate_pio_clock_divider_value(sys_hz: u32, target_hz: u32) -> fixed::FixedU32<U8> {
     // Requires a non-zero frequency
-    assert!(target_hz > 0, "PIO clock frequency cannot be zero");
+    core::assert!(target_hz > 0);
 
     // Compute the integer and fractional part of the divider.
     // Doing it this way allows us to avoid u64 division while
@@ -41,9 +41,9 @@ pub const fn calculate_pio_clock_divider_value(sys_hz: u32, target_hz: u32) -> f
     let result = integer << 8 | frac;
 
     // Ensure the result will fit in 16+8 bits.
-    assert!(result <= 0xffff_ff, "pio clock divider too big");
+    core::assert!(result <= 0xffff_ff);
     // The clock divider can't be used to go faster than the system clock.
-    assert!(result >= 0x0001_00, "pio clock divider cannot be less than 1");
+    core::assert!(result >= 0x0001_00);
 
     fixed::FixedU32::from_bits(result)
 }


### PR DESCRIPTION
The current implementation of `calculate_pio_clock_divider` only computes an integer divider, which is a missed opportunity since the return type explicitly represents an 8-bit fractional part.

This implementation ensures that the fractional part of the clock divider is accurately calculated. It uses additional u32 division/mod operations; I think this is preferable to one u64 division, but that would work as well. I don't have a great understanding of how division works on rp2040, so any advice is welcome.

 Other changes:
- Add additional asserts to catch out-of-bounds results.
- Make the version that accepts the system clock as a parameter `const` and public, so if anyone wants to hardcode the system frequency they can avoid any runtime computation.
- Remove the `inline` attributes because the function has grown quite a bit.
- Add unit tests to verify that the math works.

Fixes #5048.