### PR TITLE
stm32: block stop2 for wle and misc fixes

### DIFF
--- a/embassy-stm32/src/i2c/mod.rs
+++ b/embassy-stm32/src/i2c/mod.rs
@@ -129,7 +129,7 @@ impl<'d> Drop for I2CDropGuard<'d> {
             x.set_as_disconnected()
         }
 
-        self.info.rcc.disable();
+        self.info.rcc.disable_without_stop();
     }
 }
 

--- a/embassy-stm32/src/spi/mod.rs
+++ b/embassy-stm32/src/spi/mod.rs
@@ -1126,7 +1126,7 @@ impl<'d, M: PeriMode, CM: CommunicationMode> Drop for Spi<'d, M, CM> {
         self.miso.as_ref().map(|x| x.set_as_disconnected());
         self.nss.as_ref().map(|x| x.set_as_disconnected());
 
-        self.info.rcc.disable();
+        self.info.rcc.disable_without_stop();
     }
 }
 


### PR DESCRIPTION
alternative to #5060 and some other fixes. 

unconditionally block stop2 for wle if any peripheral is held.