### PR TITLE
embassy-sync: Update `Pipe::try_write` docs

### DIFF
--- a/embassy-sync/src/pipe.rs
+++ b/embassy-sync/src/pipe.rs
@@ -393,7 +393,7 @@ where
     /// Attempt to immediately write some bytes to the pipe.
     ///
     /// This method will either write a nonzero amount of bytes to the pipe immediately,
-    /// or return an error if the pipe is empty. See [`write`](Self::write) for a variant
+    /// or return an error if the pipe is full. See [`write`](Self::write) for a variant
     /// that waits instead of returning an error.
     pub fn try_write(&self, buf: &[u8]) -> Result<usize, TryWriteError> {
         self.try_write_with_context(None, buf)


### PR DESCRIPTION
The description was probably copied from `Pipe::try_read`. However, when writing, an error is produced if the `Pipe` is full, not if it is empty.