### PR TITLE
[STM32U5] Source system clock from MSIS before (de)configuring PLLs

### DIFF
--- a/embassy-stm32/CHANGELOG.md
+++ b/embassy-stm32/CHANGELOG.md
@@ -93,6 +93,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - stm32: Add blocking_listen for blocking I2C driver
 - fix: stm32l47*/stm32l48* adc analog pin setup
 - fix: keep stm32/sai: make NODIV independent of MCKDIV
+- fix: Source system clock from MSIS before (de)configuring PLLs on STM32U5
 
 ## 0.4.0 - 2025-08-26
 


### PR DESCRIPTION
Fixes https://github.com/embassy-rs/embassy/issues/5072