### PR TITLE
stm32/adc: allow DMA reads to loop through enabled channels

### DIFF
--- a/embassy-stm32/CHANGELOG.md
+++ b/embassy-stm32/CHANGELOG.md
@@ -94,6 +94,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - fix: stm32l47*/stm32l48* adc analog pin setup
 - fix: keep stm32/sai: make NODIV independent of MCKDIV
 - fix: Source system clock from MSIS before (de)configuring PLLs on STM32U5
+- feat: adc: allow DMA reads to loop through enabled channels
 
 ## 0.4.0 - 2025-08-26
 

--- a/embassy-stm32/src/adc/mod.rs
+++ b/embassy-stm32/src/adc/mod.rs
@@ -214,7 +214,7 @@ impl<'d, T: Instance> Adc<'d, T> {
     #[cfg(any(adc_g4, adc_v3, adc_g0, adc_h5, adc_h7rs, adc_u0, adc_v4, adc_u5, adc_wba, adc_c0))]
     /// Read one or multiple ADC regular channels using DMA.
     ///
-    /// `sequence` iterator and `readings` must have the same length.
+    /// `readings` must have a length that is a multiple of the length of the `sequence` iterator.
     ///
     /// Example
     /// ```rust,ignore
@@ -253,8 +253,8 @@ impl<'d, T: Instance> Adc<'d, T> {
     ) {
         assert!(sequence.len() != 0, "Asynchronous read sequence cannot be empty");
         assert!(
-            sequence.len() == readings.len(),
-            "Sequence length must be equal to readings length"
+            readings.len() % sequence.len() == 0,
+            "Readings length must be a multiple of sequence length"
         );
         assert!(
             sequence.len() <= 16,


### PR DESCRIPTION
This was [previously implemented for v3 ADCs](https://github.com/embassy-rs/embassy/pull/4306), but that was lost in the recent refactoring. I have gone through all the reference manuals to verify that this should be supported for all chips, but it has only been confirmed for the STM32H5 series.