### PR TITLE
fix: use correct pin count for the nrf54 chip family

### DIFF
--- a/embassy-nrf/src/gpiote.rs
+++ b/embassy-nrf/src/gpiote.rs
@@ -29,17 +29,14 @@ const CHANNEL_COUNT: usize = 12;
 /// Max channels per port
 const CHANNELS_PER_PORT: usize = 8;
 
-#[cfg(any(
-    feature = "nrf52833",
-    feature = "nrf52840",
-    feature = "_nrf5340",
-    feature = "_nrf54l15",
-    feature = "_nrf54l10",
-    feature = "_nrf54l05"
-))]
+#[cfg(any(feature = "nrf52833", feature = "nrf52840", feature = "_nrf5340"))]
 const PIN_COUNT: usize = 48;
+#[cfg(any(feature = "_nrf54l15", feature = "_nrf54l10", feature = "_nrf54l05"))]
+// Highest pin index is P2.10 => (2 * 32 + 10) = 74
+const PIN_COUNT: usize = 75;
 #[cfg(feature = "_nrf54lm20")]
-const PIN_COUNT: usize = 66;
+// Highest pin index is P3.12 => (3 * 32 + 12) = 108
+const PIN_COUNT: usize = 109;
 #[cfg(not(any(
     feature = "nrf52833",
     feature = "nrf52840",


### PR DESCRIPTION
Fixes pin counts for chips from the nrf54 family. Using GPIOTE with P2 currently results in a out-of-bounds panic which this fixes.

Additional note: I noticed that most of the peripheral domains only have around 10 pins,
so the current way of allocating `32 * N_DOMAINS` will produce more holes than non-holes.
Maybe it would make sense to calculate pin indices on a per-chip basis so this can be optimized? Not sure if true packing would have a noticeable impact on access latency, but I guess we could go down to `* 16` for some of the chips at least.
