### PR TITLE
Fix rp webusb example on windows

### DIFF
--- a/embassy-usb/src/msos.rs
+++ b/embassy-usb/src/msos.rs
@@ -110,10 +110,6 @@ impl<'d> MsOsDescriptorWriter<'d> {
             !self.is_empty(),
             "device features may only be added after the header is written"
         );
-        assert!(
-            self.config_mark.is_none(),
-            "device features must be added before the first configuration subset"
-        );
         self.write(desc);
     }
 


### PR DESCRIPTION
closes https://github.com/embassy-rs/embassy/issues/5079

Refer to the ticket for more details.

Fix is to follow the composite device MS OS structure [documented officially here](https://learn.microsoft.com/en-us/windows-hardware/drivers/usbcon/microsoft-os-2-0-descriptors-specification), but I also found [this more concrete example](https://github.com/hathach/tinyusb/discussions/823#discussioncomment-7473503) really helpful.

That is, we use the configuration and function subheaders to define just a specific interface/function and then tell windows to use the WINUSB driver for just those interface/functions.

To enable this structure I needed to remove the `"device features must be added before the first configuration subset"` assertion, but according to the MS OS specs, that assertion is incorrect.

I also renamed the vendor_code field and setter to ms_vendor_code (**breaking change**) as that is closer to the upstream field name `bMS_VendorCode` AND it helps to make it clear that the meaning is entirely unrelated to the vendor code used by the webusb BOS and the vendor code as in PID/VID.
But I'm happy to revert the setter change and/or the vendor_code field change if needed.

And finally, I needed to clear out windows' cache of the old broken descriptors from the example.
What I did was:
1. Download https://www.nirsoft.net/utils/usb_devices_view.html
2. Find the relevant entries
3. right click "uninstall selected devices"

Please perform these steps if you are testing both the before and after of this change, or have previously run the example.