### PR TITLE
mspm0: only cfg guard time driver in peripherals struct, but generate singleton types always

### DIFF
--- a/embassy-mspm0/Cargo.toml
+++ b/embassy-mspm0/Cargo.toml
@@ -73,7 +73,7 @@ critical-section = "1.2.0"
 micromath = "2.0.0"
 
 # mspm0-metapac = { version = "" }
-mspm0-metapac = { git = "https://github.com/mspm0-rs/mspm0-data-generated/", tag = "mspm0-data-e91edd86813aa94cbb6737d34e4f1d22b8487cb6" }
+mspm0-metapac = { git = "https://github.com/mspm0-rs/mspm0-data-generated/", tag = "mspm0-data-e79606acd8945f4106255c19e0d48876d6a0eafe" }
 
 [build-dependencies]
 proc-macro2 = "1.0.94"
@@ -81,7 +81,7 @@ quote = "1.0.40"
 cfg_aliases = "0.2.1"
 
 # mspm0-metapac = { version = "", default-features = false, features = ["metadata"] }
-mspm0-metapac = { git = "https://github.com/mspm0-rs/mspm0-data-generated/", tag = "mspm0-data-e91edd86813aa94cbb6737d34e4f1d22b8487cb6", default-features = false, features = ["metadata"] }
+mspm0-metapac = { git = "https://github.com/mspm0-rs/mspm0-data-generated/", tag = "mspm0-data-e79606acd8945f4106255c19e0d48876d6a0eafe", default-features = false, features = ["metadata"] }
 
 [features]
 default = ["rt"]


### PR DESCRIPTION
Also remove some of the useless singletons which are generated.