### PR TITLE
executor: Add fallible from_waker getter

### DIFF
--- a/embassy-executor/CHANGELOG.md
+++ b/embassy-executor/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Migrate `cortex-ar` to `aarch32-cpu`. The feature name `arch-cortex-ar` remains the same and
   legacy ARM architectures are not supported.
 - Added `run_until` to `arch-std` variant of `Executor`.
+- Added `__try_embassy_time_queue_item_from_waker`
 
 ## 0.9.1 - 2025-08-31
 

--- a/embassy-executor/src/raw/mod.rs
+++ b/embassy-executor/src/raw/mod.rs
@@ -49,12 +49,18 @@ use self::run_queue::{RunQueue, RunQueueItem};
 use self::state::State;
 use self::util::{SyncUnsafeCell, UninitCell};
 pub use self::waker::task_from_waker;
+use self::waker::try_task_from_waker;
 use super::SpawnToken;
 use crate::{Metadata, SpawnError};
 
 #[unsafe(no_mangle)]
 extern "Rust" fn __embassy_time_queue_item_from_waker(waker: &Waker) -> &'static mut TimerQueueItem {
     unsafe { task_from_waker(waker).timer_queue_item() }
+}
+
+#[unsafe(no_mangle)]
+extern "Rust" fn __try_embassy_time_queue_item_from_waker(waker: &Waker) -> Option<&'static mut TimerQueueItem> {
+    unsafe { try_task_from_waker(waker).map(|task| task.timer_queue_item()) }
 }
 
 /// Raw task header for use in task pointers.

--- a/embassy-executor/src/raw/waker_turbo.rs
+++ b/embassy-executor/src/raw/waker_turbo.rs
@@ -25,6 +25,10 @@ pub fn task_from_waker(waker: &Waker) -> TaskRef {
     unsafe { TaskRef::from_ptr(ptr as *const TaskHeader) }
 }
 
+pub(crate) fn try_task_from_waker(waker: &Waker) -> Option<TaskRef> {
+    Some(task_from_waker(waker))
+}
+
 #[inline(never)]
 #[unsafe(no_mangle)]
 fn _turbo_wake(ptr: NonNull<()>) {


### PR DESCRIPTION
This PR adds a non-panicking way of accessing a task's `TimerQueueItem`. This allows using integrated timer queues with embassy executors along with some other method for `block_on` or others.

Split out of #4934