### PR TITLE
stm32: disable HSI if not used

### DIFF
--- a/embassy-stm32/src/rcc/l.rs
+++ b/embassy-stm32/src/rcc/l.rs
@@ -385,6 +385,11 @@ pub(crate) unsafe fn init(config: Config) {
         while !RCC.extcfgr().read().c2hpref() {}
     }
 
+    // Disable HSI if not used
+    if !config.hsi {
+        RCC.cr().modify(|w| w.set_hsion(false));
+    }
+
     config.mux.init();
 
     set_clocks!(

--- a/embassy-stm32/src/rcc/u5.rs
+++ b/embassy-stm32/src/rcc/u5.rs
@@ -467,6 +467,11 @@ pub(crate) unsafe fn init(config: Config) {
     let lse = config.ls.lse.map(|l| l.frequency);
     let lsi = config.ls.lsi.then_some(LSI_FREQ);
 
+    // Disable HSI if not used
+    if !config.hsi {
+        RCC.cr().modify(|w| w.set_hsion(false));
+    }
+
     config.mux.init();
 
     set_clocks!(

--- a/embassy-stm32/src/rcc/wba.rs
+++ b/embassy-stm32/src/rcc/wba.rs
@@ -269,6 +269,11 @@ pub(crate) unsafe fn init(config: Config) {
 
     let lsi = config.ls.lsi.then_some(LSI_FREQ);
 
+    // Disable HSI if not used
+    if !config.hsi {
+        RCC.cr().modify(|w| w.set_hsion(false));
+    }
+
     config.mux.init();
 
     set_clocks!(


### PR DESCRIPTION
https://github.com/embassy-rs/embassy/issues/5102

STM32L, U, and W MCUs will not disable HSI upon calling reinit.
It should be safe to disable it at the end of the initialization.