### PR TITLE
fix: avoid hang if calling now() before syscounter is enabled

### DIFF
--- a/embassy-nrf/CHANGELOG.md
+++ b/embassy-nrf/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 <!-- next-header -->
 ## Unreleased - ReleaseDate
 
+- bugfix: avoid hang if calling now() before syscounter is enabled on nrf54
+
 ## 0.9.0 - 2025-12-15
 
 - changed: apply trimming values from FICR.TRIMCNF on nrf53/54l

--- a/embassy-nrf/src/time_driver.rs
+++ b/embassy-nrf/src/time_driver.rs
@@ -79,6 +79,10 @@ fn calc_now(period: u32, counter: u32) -> u64 {
 #[cfg(feature = "_grtc")]
 fn syscounter() -> u64 {
     let r = rtc();
+    if !r.mode().read().syscounteren() {
+        return 0;
+    }
+
     r.syscounter(0).active().write(|w| w.set_active(true));
     loop {
         let countl: u32 = r.syscounter(0).syscounterl().read();


### PR DESCRIPTION
If the time driver now() is called before the syscounter is enabled on nrf54, it would hang. The fix checks if syscounter is enabled, and returns 0 if not.