### PR TITLE
[embassy-nrf] add task shutdown for timer, shut it down on BufferedUarte, fix power consumption

### DIFF
--- a/embassy-nrf/src/buffered_uarte/v1.rs
+++ b/embassy-nrf/src/buffered_uarte/v1.rs
@@ -856,6 +856,8 @@ impl<'a> Drop for BufferedUarteRx<'a> {
         let r = self.r;
 
         self.timer.stop();
+        // workaround errata 78
+        self.timer.shutdown();
 
         r.intenclr().write(|w| {
             w.set_rxdrdy(true);

--- a/embassy-nrf/src/timer.rs
+++ b/embassy-nrf/src/timer.rs
@@ -173,6 +173,12 @@ impl<'d> Timer<'d> {
         self.r.tasks_clear().write_value(1)
     }
 
+    /// Shuts down the timer.
+    /// This task is deprecated, but needed to workaround errata 78
+    pub fn shutdown(&self) {
+        self.r.tasks_shutdown().write_value(1)
+    }
+
     /// Returns the START task, for use with PPI.
     ///
     /// When triggered, this task starts the timer.


### PR DESCRIPTION
Apparently my NRF52832 QFAAE chip was affected by errata 78, leading to #5051

https://docs.nordicsemi.com/bundle/errata_nRF52832_Rev2/page/ERR/nRF52832/Rev2/latest/anomaly_832_78.html

The fix is to add support for the (deprecated) shutdown task for the timer and call it on Drop for the BufferedUarte


fixes #5051