### PR TITLE
stm32: don't reset RCC_BDCR due to LSESYSEN bit

### DIFF
--- a/embassy-stm32/src/rcc/bd.rs
+++ b/embassy-stm32/src/rcc/bd.rs
@@ -273,6 +273,12 @@ impl LsConfig {
         {
             ok &= lsecfgr.lsebyp() == lse_byp;
         }
+        #[cfg(any(rcc_l5, rcc_u5, rcc_wle, rcc_wl5, rcc_wba, rcc_u0))]
+        if let Some(lse_sysen) = lse_sysen
+            && !lse_sysen
+        {
+            ok &= !reg.lsesysen();
+        }
         #[cfg(not(any(rcc_f1, rcc_f1cl, rcc_f100, rcc_f2, rcc_f4, rcc_f410, rcc_l1, rcc_n6)))]
         if let Some(lse_drv) = lse_drv {
             ok &= reg.lsedrv() == lse_drv.into();
@@ -282,21 +288,22 @@ impl LsConfig {
             ok &= lsecfgr.lsedrv() == lse_drv.into();
         }
 
+        // After a power-on reset LSESYSEN will be set to 0
+        // even if VBAT was present and kept the RTC running
+        #[cfg(any(rcc_l5, rcc_u5, rcc_wle, rcc_wl5, rcc_wba, rcc_u0))]
+        if ok
+            && let Some(lse_sysen) = lse_sysen
+            && lse_sysen
+        {
+            bdcr().modify(|w| {
+                w.set_lsesysen(true);
+            });
+
+            while !bdcr().read().lsesysrdy() {}
+        }
+
         // if configuration is OK, we're done.
         if ok {
-            // After a power-on reset LSESYSEN will be set to 0
-            // even if VBAT was present and kept the RTC running
-            #[cfg(any(rcc_l5, rcc_u5, rcc_wle, rcc_wl5, rcc_wba, rcc_u0))]
-            if let Some(lse_sysen) = lse_sysen {
-                bdcr().modify(|w| {
-                    w.set_lsesysen(lse_sysen);
-                });
-
-                if lse_sysen {
-                    while !bdcr().read().lsesysrdy() {}
-                }
-            }
-
             trace!("BDCR ok: {:08x}", bdcr().read().0);
             return rtc_clk;
         }


### PR DESCRIPTION
If accepted, this closes: https://github.com/embassy-rs/embassy/issues/5120

This PR proposes that we don't do a full backup domain reset, if only the LSESYSEN bit is different. We can set this bit to the desired value, and leave the rest intact. 
