### PR TITLE
doc: Fix code blocks in book - basic application

### DIFF
--- a/docs/pages/basic_application.adoc
+++ b/docs/pages/basic_application.adoc
@@ -23,7 +23,7 @@ Then, what follows are some declarations on how to deal with panics and faults. 
 
 [source,rust]
 ----
-include::../examples/basic/src/main.rs[lines="8"]
+include::../examples/basic/src/main.rs[lines="9"]
 ----
 
 === Task declaration
@@ -32,7 +32,7 @@ After a bit of import declaration, the tasks run by the application should be de
 
 [source,rust]
 ----
-include::../examples/basic/src/main.rs[lines="10..18"]
+include::../examples/basic/src/main.rs[lines="12..23"]
 ----
 
 An embassy task must be declared `async`, and may NOT take generic arguments. In this case, we are handed the LED that should be blinked and the interval of the blinking.
@@ -47,7 +47,7 @@ We then initialize the HAL with a default config, which gives us a `Peripherals`
 
 [source,rust]
 ----
-include::../examples/basic/src/main.rs[lines="20..-1"]
+include::../examples/basic/src/main.rs[lines="26..-1"]
 ----
 
 What happens when the `blinker` task has been spawned and main returns? Well, the main entry point is actually just like any other task, except that you can only have one and it takes some specific type arguments. The magic lies within the `#[embassy_executor::main]` macro. The macro does the following:
@@ -64,7 +64,7 @@ The project definition needs to contain the embassy dependencies:
 
 [source,toml]
 ----
-include::../examples/basic/Cargo.toml[lines="9..11"]
+include::../examples/basic/Cargo.toml[lines="10..12"]
 ----
 
 Depending on your microcontroller, you may need to replace `embassy-nrf` with something else (`embassy-stm32` for STM32. Remember to update feature flags as well).


### PR DESCRIPTION
New references inferred from changes made in these commits:
8ff497e9bc2d9fa7402bc6f060ebc8909ad97a32 (main.rs changed)
3a6ea3a31c90179fb3cbd30c18e3a310e2ee647c (Cargo.toml changed)