### PR TITLE
Fixes #5124 avoid hang when enabling ADC already enabled

### DIFF
--- a/embassy-stm32/src/adc/v4.rs
+++ b/embassy-stm32/src/adc/v4.rs
@@ -88,6 +88,9 @@ impl AdcRegs for crate::pac::adc::Adc {
     }
 
     fn enable(&self) {
+        if self.cr().read().aden() {
+            return;
+        }
         self.isr().write(|w| w.set_adrdy(true));
         self.cr().modify(|w| w.set_aden(true));
         while !self.isr().read().adrdy() {}


### PR DESCRIPTION
This PR fixes a regression introduced by commit e32f78f that causes ADC DMA reads to hang indefinitely on STM32 adc_v4 devices (see #5124).

### Fix

Make enable() idempotent on adc_v4 by returning early if the ADC is already enabled (ADEN = 1).
This prevents the deadlock.