### PR TITLE
STM32 fix: Disable SPI before modifying CPOL/CPHA in set_config for v1/v2/v3

### DIFF
--- a/embassy-stm32/src/spi/mod.rs
+++ b/embassy-stm32/src/spi/mod.rs
@@ -381,12 +381,20 @@ impl<'d, M: PeriMode, CM: CommunicationMode> Spi<'d, M, CM> {
         }
 
         #[cfg(any(spi_v1, spi_v2, spi_v3))]
-        self.info.regs.cr1().modify(|w| {
-            w.set_cpha(cpha);
-            w.set_cpol(cpol);
-            w.set_br(br);
-            w.set_lsbfirst(lsbfirst);
-        });
+        {
+            self.info.regs.cr1().modify(|w| {
+                w.set_spe(false);
+            });
+            self.info.regs.cr1().modify(|w| {
+                w.set_cpha(cpha);
+                w.set_cpol(cpol);
+                w.set_br(br);
+                w.set_lsbfirst(lsbfirst);
+            });
+            self.info.regs.cr1().modify(|w| {
+                w.set_spe(true);
+            });
+        }
 
         #[cfg(any(spi_v4, spi_v5, spi_v6))]
         {


### PR DESCRIPTION
On STM32 SPI v1/v2/v3 peripherals, the CPOL and CPHA bits in the CR1 register can only be modified when SPE (SPI Enable) is set to 0. 
When set_config() is called while SPE=1, the write to CPOL/CPHA may silently fail or produce undefined behavior. This causes issues when using SpiDeviceWithConfig to dynamically switch between different SPI modes for multiple devices on a shared bus (e.g., one device requiring MODE_0 and another requiring MODE_1 as in my use case).

Fix:  Disable SPI (SPE=0) before modifying the configuration, then re-enable it (SPE=1) afterward. This matches the existing behavior in the spi_v4/v5/v6 code path.

This change has the side-effect of always leaving SPE=1 after set_config() returns, even if it was previously disabled. However, this is consistent with the existing v4/v5/v6 implementation, which has the same behavior.