### PR TITLE
Changed the rp2040/rp235x VCO max to 1600 MHz

### DIFF
--- a/embassy-rp/src/clocks.rs
+++ b/embassy-rp/src/clocks.rs
@@ -2094,8 +2094,8 @@ mod tests {
         assert!(!invalid_config.is_valid(12_000_000));
 
         // Test a valid high VCO configuration
-        invalid_config.fbdiv = 133; // 12MHz * 133 = 1596MHz, first integer below the limit
-        assert!(invalid_config.is_valid(12_000_000));
+        invalid_config.fbdiv = 160; // 10MHz * 160 = 1600MHz, exactly at the limit
+        assert!(invalid_config.is_valid(10_000_000));
     }
 
     #[cfg(feature = "rp2040")]


### PR DESCRIPTION
The rp code allows VCO frequency up to 1800 MHz, which is outside of the range specified by the datasheets (750 - 1600 MHz).  This pr changes that to 1600 Mhz.

Changes:

- Added variables for VCO min and max.
- Modified code to use the VCO_MIN and VCO_MAX variables.

Testing:

- I ran overclock and overclock_manual examples on a rpi pico, they both clock to 200 MHz.
- I couldn't figure out how to run the unit tests, but I assume they will get run by the ci?

Related Issues:

- https://github.com/embassy-rs/embassy/issues/4850
