### PR TITLE
rp: allow sourcing gpout clock from LPOSC

### DIFF
--- a/embassy-rp/src/clocks.rs
+++ b/embassy-rp/src/clocks.rs
@@ -1647,6 +1647,9 @@ pub enum GpoutSrc {
     Rosc = ClkGpoutCtrlAuxsrc::ROSC_CLKSRC as _,
     /// XOSC.
     Xosc = ClkGpoutCtrlAuxsrc::XOSC_CLKSRC as _,
+    /// LPOSC.
+    #[cfg(feature = "_rp235x")]
+    Lposc = ClkGpoutCtrlAuxsrc::LPOSC_CLKSRC as _,
     /// SYS.
     Sys = ClkGpoutCtrlAuxsrc::CLK_SYS as _,
     /// USB.


### PR DESCRIPTION
The official pico-sdk [provides](https://github.com/raspberrypi/pico-sdk/blob/a1438dff1d38bd9c65dbd693f0e5db4b9ae91779/src/rp2350/hardware_regs/include/hardware/regs/clocks.h#L105) the same functionality.