### PR TITLE
Fix `VrefInt` channel on `adc_l0`

### DIFF
--- a/embassy-stm32/src/adc/v1.rs
+++ b/embassy-stm32/src/adc/v1.rs
@@ -47,14 +47,8 @@ impl super::SealedSpecialConverter<super::Vbat> for crate::peripherals::ADC1 {
     const CHANNEL: u8 = 18;
 }
 
-#[cfg(not(adc_l0))]
 impl super::SealedSpecialConverter<super::VrefInt> for crate::peripherals::ADC1 {
     const CHANNEL: u8 = 17;
-}
-
-#[cfg(adc_l0)]
-impl super::SealedSpecialConverter<super::VrefInt> for crate::peripherals::ADC1 {
-    const CHANNEL: u8 = 18;
 }
 
 #[cfg(not(adc_l0))]


### PR DESCRIPTION
All STM32L0 chips use channel 17 for `VrefInt`.

This is probably just a fix to a typo introduced in c90e4b3135283070bddc6a8e64df3139909ac8ce. 