### PR TITLE
[embassy-rp] Fix PIO freeze

### DIFF
--- a/embassy-rp/src/uart/mod.rs
+++ b/embassy-rp/src/uart/mod.rs
@@ -464,12 +464,12 @@ impl<'d> UartRx<'d, Async> {
             transfer,
             poll_fn(|cx| {
                 self.dma_state.rx_err_waker.register(cx.waker());
-                let rx_errs = critical_section::with(|_| {
-                    let val = self.dma_state.rx_errs.load(Ordering::Relaxed);
+                let old_rx_errs = critical_section::with(|_| {
+                    let old_val = self.dma_state.rx_errs.load(Ordering::Relaxed);
                     self.dma_state.rx_errs.store(0, Ordering::Relaxed);
-                    val
+                    old_val
                 });
-                match rx_errs {
+                match old_rx_errs {
                     0 => Poll::Pending,
                     e => Poll::Ready(Uartris(e as u32)),
                 }
@@ -482,9 +482,9 @@ impl<'d> UartRx<'d, Async> {
                 // We're here because the DMA finished, BUT if an error occurred on the LAST
                 // byte, then we may still need to grab the error state!
                 Uartris(critical_section::with(|_| {
-                    let val = self.dma_state.rx_errs.load(Ordering::Relaxed);
+                    let old_val = self.dma_state.rx_errs.load(Ordering::Relaxed);
                     self.dma_state.rx_errs.store(0, Ordering::Relaxed);
-                    val
+                    old_val
                 }) as u32)
             }
             Either::Second(e) => {
@@ -633,12 +633,12 @@ impl<'d> UartRx<'d, Async> {
                 transfer,
                 poll_fn(|cx| {
                     self.dma_state.rx_err_waker.register(cx.waker());
-                    let rx_errs = critical_section::with(|_| {
-                        let val = self.dma_state.rx_errs.load(Ordering::Relaxed);
+                    let old_rx_errs = critical_section::with(|_| {
+                        let old_val = self.dma_state.rx_errs.load(Ordering::Relaxed);
                         self.dma_state.rx_errs.store(0, Ordering::Relaxed);
-                        val
+                        old_val
                     });
-                    match rx_errs {
+                    match old_rx_errs {
                         0 => Poll::Pending,
                         e => Poll::Ready(Uartris(e as u32)),
                     }
@@ -652,9 +652,9 @@ impl<'d> UartRx<'d, Async> {
                     // We're here because the DMA finished, BUT if an error occurred on the LAST
                     // byte, then we may still need to grab the error state!
                     Uartris(critical_section::with(|_| {
-                        let val = self.dma_state.rx_errs.load(Ordering::Relaxed);
+                        let old_val = self.dma_state.rx_errs.load(Ordering::Relaxed);
                         self.dma_state.rx_errs.store(0, Ordering::Relaxed);
-                        val
+                        old_val
                     }) as u32)
                 }
                 Either::Second(e) => {


### PR DESCRIPTION
Fixes #5146.

The regression was introduced by #4948 which replaced the `atomic-polyfill` dependency with custom code. When the [fetch_sub](https://docs.rs/atomic-polyfill/1.0.3/atomic_polyfill/struct.AtomicU8.html#method.fetch_sub) function was replaced, the subtle detail that that function returned the *previous* value instead of the new one after the subtraction was missed resulting in an off-by-one bug in the `on_pio_drop` function.

An alternate PR or follow up could use the `portable-atomic` crate instead of `atomic-polyfill`.

This PR fixes the bug and renames some variables to make the distinction clearer. I did NOT change to returning the new value in case this code is ever replaced by `portable-atomic` or similar.