### PR TITLE
Reduce footprint by preventing 64bit multiplication

### DIFF
--- a/embassy-stm32/src/rcc/u5.rs
+++ b/embassy-stm32/src/rcc/u5.rs
@@ -590,7 +590,7 @@ fn init_pll(instance: PllInstance, config: Option<Pll>, input: &PllInput, voltag
     };
 
     // Calculate the PLL VCO clock
-    let vco_freq = ref_freq * pll.mul;
+    let vco_freq = ref_freq * (pll.mul as u32);
     assert!(vco_freq >= vco_min && vco_freq <= vco_max);
 
     // Calculate output clocks.


### PR DESCRIPTION
This prevents an unneeded u64 multiplication 

Original footprint:
4.7KiB    embassy_stm32 embassy_stm32::rcc::_version::init_pll

After u32 cast:
836B    embassy_stm32 embassy_stm32::rcc::_version::init_pll