### PR TITLE
update embedded-io-async to 0.7 in embassy-usb-driver

### DIFF
--- a/embassy-usb-driver/Cargo.toml
+++ b/embassy-usb-driver/Cargo.toml
@@ -20,7 +20,7 @@ features = ["defmt"]
 
 [dependencies]
 # TODO: remove before releasing embassy-usb-driver v0.3
-embedded-io-async = "0.6.1"
+embedded-io-async = "0.7.0"
 defmt = { version = "1", optional = true }
 
 [features]

--- a/embassy-usb-driver/src/lib.rs
+++ b/embassy-usb-driver/src/lib.rs
@@ -438,3 +438,13 @@ impl embedded_io_async::Error for EndpointError {
         }
     }
 }
+
+impl core::fmt::Display for EndpointError {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        match self {
+            Self::BufferOverflow => write!(f, "Buffer overflow"),
+            Self::Disabled => write!(f, "Endpoint disabled"),
+        }
+    }
+}
+impl core::error::Error for EndpointError {}


### PR DESCRIPTION
Until the embedded-io-async dependency is removed in embassy-usb-driver v0.3, we might as well update it to 0.7 to match the version in all the other embassy crates.