### PR TITLE
Proper use of the ring buffer in writing methods

### DIFF
--- a/embassy-stm32/src/usart/buffered.rs
+++ b/embassy-stm32/src/usart/buffered.rs
@@ -688,22 +688,29 @@ impl<'d> BufferedUartTx<'d> {
 
             let empty = state.tx_buf.is_empty();
 
-            let mut tx_writer = unsafe { state.tx_buf.writer() };
-            let data = tx_writer.push_slice();
-            if data.is_empty() {
-                state.tx_waker.register(cx.waker());
+            if state.tx_buf.len() - state.tx_buf.available() < buf.len() {
                 return Poll::Pending;
             }
 
-            let n = data.len().min(buf.len());
-            data[..n].copy_from_slice(&buf[..n]);
-            tx_writer.push_done(n);
+            let mut written: usize = 0;
+            let mut tx_writer = unsafe { state.tx_buf.writer() };
+            while written != buf.len() {
+                let data = tx_writer.push_slice();
+                if data.is_empty() {
+                    state.tx_waker.register(cx.waker());
+                    return Poll::Pending;
+                }
+                let n = data.len().min(buf.len() - written);
+                data[..n].copy_from_slice(&buf[written..written + n]);
+                written = written + n;
+                tx_writer.push_done(n);
+            }
 
             if empty {
                 self.info.interrupt.pend();
             }
 
-            Poll::Ready(Ok(n))
+            Poll::Ready(Ok(written))
         })
         .await
     }
@@ -729,19 +736,23 @@ impl<'d> BufferedUartTx<'d> {
 
             let empty = state.tx_buf.is_empty();
 
+            let mut written: usize = 0;
             let mut tx_writer = unsafe { state.tx_buf.writer() };
-            let data = tx_writer.push_slice();
-            if !data.is_empty() {
-                let n = data.len().min(buf.len());
-                data[..n].copy_from_slice(&buf[..n]);
-                tx_writer.push_done(n);
-
-                if empty {
-                    self.info.interrupt.pend();
+            while written != buf.len() {
+                let data = tx_writer.push_slice();
+                if !data.is_empty() {
+                    let n = data.len().min(buf.len() - written);
+                    data[..n].copy_from_slice(&buf[written..written + n]);
+                    written = written + n;
+                    tx_writer.push_done(n);
                 }
-
-                return Ok(n);
             }
+
+            if empty {
+                self.info.interrupt.pend();
+            }
+
+            return Ok(written);
         }
     }
 


### PR DESCRIPTION
In the original version, if there was not enough slice size at the end of the buffer, the rest of the data was lost.