### PR TITLE
Fix of the buffered version of STM32 UART

### DIFF
--- a/embassy-stm32/src/usart/buffered.rs
+++ b/embassy-stm32/src/usart/buffered.rs
@@ -688,6 +688,10 @@ impl<'d> BufferedUartTx<'d> {
 
             let empty = state.tx_buf.is_empty();
 
+            if state.tx_buf.len() < buf.len() {
+                return Poll::Ready(Err(Error::BufferTooLong));
+            }
+
             if state.tx_buf.len() - state.tx_buf.available() < buf.len() {
                 return Poll::Pending;
             }


### PR DESCRIPTION
The ringbuffer was incorrectly used in the write (..) methods.