### PR TITLE
[MCXA] add missing path for embassy dependencies

### DIFF
--- a/embassy-mcxa/Cargo.toml
+++ b/embassy-mcxa/Cargo.toml
@@ -29,9 +29,9 @@ cortex-m = { version = "0.7", features = ["critical-section-single-core"] }
 cortex-m-rt = { version = "0.7", features = ["device"] }
 critical-section = "1.2.0"
 defmt = { version = "1.0", optional = true }
-embassy-embedded-hal = "0.5.0"
+embassy-embedded-hal = { version = "0.5.0", path = "../embassy-embedded-hal" }
 embassy-hal-internal = { version = "0.4.0", path = "../embassy-hal-internal", features = ["cortex-m", "prio-bits-3"] }
-embassy-sync = "0.7.2"
+embassy-sync = { version = "0.7.2", path = "../embassy-sync" }
 embedded-hal-1 = { package = "embedded-hal", version = "1.0" }
 embedded-hal-02 = { package = "embedded-hal", version = "0.2.6", features = ["unproven"] }
 embedded-hal-async = { version = "1.0" }
@@ -45,8 +45,8 @@ paste = "1.0.15"
 maitake-sync = { version = "0.2.2", default-features = false, features = ["critical-section", "no-cache-pad"] }
 
 # `time` dependencies
-embassy-time = { version = "0.5.0", optional = true }
-embassy-time-driver = { version = "0.2.1", optional = true }
+embassy-time = { version = "0.5.0", path = "../embassy-time", optional = true }
+embassy-time-driver = { version = "0.2.1", path = "../embassy-time-driver", optional = true }
 
 rand-core-06 = { package = "rand_core", version = "0.6" }
 rand-core-09 = { package = "rand_core", version = "0.9" }

--- a/examples/mcxa/Cargo.toml
+++ b/examples/mcxa/Cargo.toml
@@ -12,12 +12,12 @@ crc = "3.4.0"
 critical-section = "1.2.0"
 defmt = "1.0"
 defmt-rtt = "1.0"
-embassy-embedded-hal = "0.5.0"
-embassy-executor = { version = "0.9.0", features = ["arch-cortex-m", "executor-interrupt", "executor-thread"], default-features = false }
-embassy-mcxa = { path = "../../embassy-mcxa", features = ["defmt", "unstable-pac", "time"] }
-embassy-sync = "0.7.2"
-embassy-time = "0.5.0"
-embassy-time-driver = "0.2.1"
+embassy-embedded-hal = { version = "0.5.0", path = "../../embassy-embedded-hal" }
+embassy-executor = { version = "0.9.0", path = "../../embassy-executor", features = ["arch-cortex-m", "executor-interrupt", "executor-thread"], default-features = false }
+embassy-mcxa = { version = "0.1.0", path = "../../embassy-mcxa", features = ["defmt", "unstable-pac", "time"] }
+embassy-sync = { version = "0.7.2", path = "../../embassy-sync" }
+embassy-time = { version = "0.5.0", path = "../../embassy-time", features = ["defmt", "defmt-timestamp-uptime"] }
+embassy-time-driver = { version = "0.2.1", path = "../../embassy-time-driver", optional = true }
 embedded-io-async = "0.7.0"
 heapless = "0.9.2"
 panic-probe = { version = "1.0", features = ["print-defmt"] }


### PR DESCRIPTION
While at that, also enable timestamp on defmt output.