### PR TITLE
cyw: get control init working

### DIFF
--- a/cyw43/src/consts.rs
+++ b/cyw43/src/consts.rs
@@ -76,6 +76,8 @@ pub(crate) const SDIO_FUNCTION_INT_MASK: u32 = 0x34;
 pub(crate) const SDIO_TO_SB_MAILBOX: u32 = 0x40;
 pub(crate) const SDIO_TO_SB_MAILBOX_DATA: u32 = 0x48;
 pub(crate) const SDIO_TO_HOST_MAILBOX_DATA: u32 = 0x4C;
+pub(crate) const SDIO_SLEEP_CSR: u32 = 0x1001F;
+pub(crate) const SBSDIO_SLPCSR_KEEP_WL_KS: u32 = 1 << 0;
 
 pub(crate) const SMB_DEV_INT: u32 = 1 << 3;
 pub(crate) const SMB_INT_ACK: u32 = 1 << 1;

--- a/cyw43/src/sdio.rs
+++ b/cyw43/src/sdio.rs
@@ -206,6 +206,8 @@ where
 
         let result = self.sdio.cmd52(arg).await.unwrap_or(u16::MAX) as u8;
 
+        // trace!("cmd52: 0x{:08x} 0x{:08x}", arg, result);
+
         result
     }
 
@@ -510,7 +512,7 @@ where
     }
 
     async fn wait_for_event(&mut self) {
-        Timer::after(Duration::from_millis(250)).await;
+        Timer::after(Duration::from_millis(10)).await;
         // self.sdio.wait_for_event().await;
     }
 }


### PR DESCRIPTION
this gets the control init working, but not the irqs.