### PR TITLE
put scl/sda into high state during TWIM initialization

### DIFF
--- a/embassy-nrf/src/twim.rs
+++ b/embassy-nrf/src/twim.rs
@@ -138,6 +138,8 @@ impl<'d> Twim<'d> {
         let r = T::regs();
 
         // Configure pins
+        sda.set_high();
+        scl.set_high();
         sda.conf().write(|w| {
             w.set_dir(gpiovals::Dir::OUTPUT);
             w.set_input(gpiovals::Input::CONNECT);


### PR DESCRIPTION
The initial state of the pins was causing an address NACK on the first I2C operation of a newly flashed/rebooted device. This has fixed it in my testing.