### PR TITLE
stm32h723: fix SRAM2 in example linker script

### DIFF
--- a/examples/stm32h723/memory.x
+++ b/examples/stm32h723/memory.x
@@ -44,7 +44,7 @@ MEMORY
   /*   buffers, for storing application data in lower-power modes.              */
   /* - Zero wait-states.                                                        */
   SRAM1   : ORIGIN = 0x30000000, LENGTH = 16K
-  SRAM2   : ORIGIN = 0x30040000, LENGTH = 16K
+  SRAM2   : ORIGIN = 0x30004000, LENGTH = 16K
   SRAM4   : ORIGIN = 0x38000000, LENGTH = 16K
 
   /* Backup SRAM */


### PR DESCRIPTION
The new address is the one given in Table 6 in the reference manual (RM0468).