### PR TITLE
STM32: USB: Only set pins to AF on chips where the USB signals have an AF mapping

### DIFF
--- a/embassy-stm32/CHANGELOG.md
+++ b/embassy-stm32/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 <!-- next-header -->
 ## Unreleased - ReleaseDate
 
+- fix: don't put USB pins into alternate mode on chips where USB is an additional function
+
 ## 0.5.0 - 2026-01-04
 - Add `receive_waveform` method in `InputCapture`, allowing asynchronous input capture with DMA.
 - fix: stm32: GPDMA driver reset ignored during channel configuration

--- a/embassy-stm32/src/usb/usb.rs
+++ b/embassy-stm32/src/usb/usb.rs
@@ -326,13 +326,13 @@ impl<'d, T: Instance> Driver<'d, T> {
         #[cfg(not(usb_v4))]
         regs.btable().write(|w| w.set_btable(0));
 
-        #[cfg(not(stm32l1))]
+        #[cfg(usb_alternate_function)]
         {
             use crate::gpio::{AfType, OutputType, Speed};
             set_as_af!(dp, AfType::output(OutputType::PushPull, Speed::VeryHigh));
             set_as_af!(dm, AfType::output(OutputType::PushPull, Speed::VeryHigh));
         }
-        #[cfg(stm32l1)]
+        #[cfg(not(usb_alternate_function))]
         let _ = (dp, dm); // suppress "unused" warnings.
 
         // Initialize the bus so that it signals that power is available


### PR DESCRIPTION
On STM32 C0, F0, F1, F3, G0, G4, some but not all H7 (72, 73, 7a, 7b, but not 74, 75, 7R, 7S), L0, L1, U0, U3, some U5 (those with HS but not LS), and WB*, the USB signals are not routed through the AF mux but are instead present as "additional functions", and the pin should be left in analog mode when used.

*: I haven't actually checked all chips in all families, so some families may also be split up, but the families not listed here definitely always use AF mux, and the families listed here definitely sometimes don't use AF mux, based on the data in stm32-data.

Currently in stm32-metapac this is encoded as `PeripheralPin`'s `af` member being `Option<u8>`; it's `None` when there's no AF mapping and otherwise `Some(u8)`. However, in `build.rs` we unwrap this to create the pin trait impl:

https://github.com/embassy-rs/embassy/blob/cc185218671dd13ce0dfaec45f14792812e9fdce/embassy-stm32/build.rs#L1481

and then in `usb.rs` we enable AF mode except specifically for L1 and U5 and WB:

https://github.com/embassy-rs/embassy/blob/cc185218671dd13ce0dfaec45f14792812e9fdce/embassy-stm32/src/usb/usb.rs#L329-L336

https://github.com/embassy-rs/embassy/blob/cc185218671dd13ce0dfaec45f14792812e9fdce/embassy-stm32/src/usb/otg.rs#L107-L112

(etc for other `new_` functions).

I noticed this because on my project, SPI1 happens to be AF0 for the pins that USB DM/DP are on, so when SPI was enabled (on some other pins) and USB was enabled, those pins were set to AF0, and the SPI peripheral started driving them alongside USB, which broke USB.

I think we could either:
* change the `pin_trait!` macro to generate a trait with an `Option<u8>` for `af_num()` and then only set the pin to AF mode in `set_as_af!()` when it's `Some`, which would work for other peripherals with this split as well (though I can't find any except _possibly_ UCPD on STM32H7R/S which I think is actually purely AF mux and has a confusing datasheet), but would require more changes in the codebase wherever `af_num()` is used,
* or this proposed option to add a new cfg `usb_alternate_function` that's set in build.rs and is used to gate the calls to setting pin AF.

There's not _that_ many calls to `af_num()` because most of them actually happen inside the `set_as_af!()` macro, so the first option might be OK too, I'm happy to change this PR if that's preferred.