### PR TITLE
Changed adc_dma.rs example to fix the location of an unwrap()

### DIFF
--- a/examples/stm32f4/src/bin/adc_dma.rs
+++ b/examples/stm32f4/src/bin/adc_dma.rs
@@ -11,7 +11,7 @@ use {defmt_rtt as _, panic_probe as _};
 #[embassy_executor::main]
 async fn main(spawner: Spawner) {
     let p = embassy_stm32::init(Default::default());
-    spawner.spawn(adc_task(p).unwrap());
+    spawner.spawn(adc_task(p)).unwrap();
 }
 
 #[embassy_executor::task]


### PR DESCRIPTION
unwrap() should be applied to the output of spawner.spawn().
Currently its applied to adc_task(p)