### PR TITLE
Upstream embassy-neorv32

### DIFF
--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -55,6 +55,8 @@
 #            - 'embassy-microchip/**'
 #             embassy-mspm0:
 #             - 'embassy-mspm0/**'
+#             embassy-neorv32:
+#             - 'embassy-neorv32/**'
 #             embassy-net:
 #             - 'embassy-net/**'
 #             embassy-net-adin1110:

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -18,6 +18,7 @@
   "rust-analyzer.cargo.target": "thumbv7em-none-eabi",
   //"rust-analyzer.cargo.target": "thumbv7em-none-eabihf",
   //"rust-analyzer.cargo.target": "thumbv8m.main-none-eabihf",
+  //"rust-analyzer.cargo.target": "riscv32imc-unknown-none-elf",
   "rust-analyzer.cargo.features": [
     // Comment out these features when working on the examples. Most example crates do not have any cargo features.
     "stm32f107rb",
@@ -37,6 +38,7 @@
     // "examples/mspm0g5187/Cargo.toml",
     // "examples/mspm0l1306/Cargo.toml",
     // "examples/mspm0l2228/Cargo.toml",
+    // "examples/neorv32/Cargo.toml",
     // "examples/nrf52840-rtic/Cargo.toml",
     // "examples/nrf5340/Cargo.toml",
     // "examples/nrf-rtos-trace/Cargo.toml",

--- a/docs/pages/neorv32.adoc
+++ b/docs/pages/neorv32.adoc
@@ -1,0 +1,17 @@
+= Embassy NEORV32 HAL
+
+The link:https://github.com/embassy-rs/embassy/tree/main/embassy-neorv32[Embassy NEORV32 HAL] is based on the PACs (Peripheral Access Crate) from link:https://crates.io/crates/neorv32-pac[neorv32-pac].
+
+== Timer driver
+
+The NEORV32 timer driver frequency must match configured main CPU clock frequency.
+Thus, the user must supply the correct `tick-hz-*` feature for `embassy-time`.
+
+== Peripherals
+
+The following peripherals have a HAL implementation at present
+
+* UART
+* GPIO
+* DMA
+* SysInfo

--- a/embassy-neorv32/CHANGELOG.md
+++ b/embassy-neorv32/CHANGELOG.md
@@ -1,0 +1,10 @@
+# Changelog for embassy-neorv32
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+<!-- next-header -->
+## Unreleased - ReleaseDate
+- Initial commit. Includes time-driver and UART, GPIO, DMA, and SysInfo peripheral drivers.

--- a/embassy-neorv32/Cargo.toml
+++ b/embassy-neorv32/Cargo.toml
@@ -1,0 +1,57 @@
+[package]
+name = "embassy-neorv32"
+version = "0.1.0"
+edition = "2024"
+license = "MIT OR Apache-2.0"
+description = "Embassy Hardware Abstraction Layer (HAL) for the open-source NEORV32 RISC-V microcontroller"
+repository = "https://github.com/embassy-rs/embassy"
+keywords = ["embedded", "hal", "risc-v", "neorv32","embassy"]
+categories = ["embedded", "hardware-support", "no-std"]
+documentation = "https://docs.embassy.dev/embassy-neorv32"
+
+[package.metadata.embassy]
+build = [
+    {target = "riscv32imc-unknown-none-elf", features = ["defmt"]},
+    {target = "riscv32imc-unknown-none-elf", features = ["defmt", "v-trap"]},
+]
+
+[package.metadata.embassy_docs]
+src_base = "https://github.com/embassy-rs/embassy/blob/embassy-neorv32-v$VERSION/embassy-neorv32/src/"
+src_base_git = "https://github.com/embassy-rs/embassy/blob/$COMMIT/embassy-neorv32/src/"
+
+features = ["defmt"]
+flavors = [
+    { regex_feature = ".*", target = "riscv32imc-unknown-none-elf" }
+]
+
+[features]
+default = ["time-driver", "rt"]
+defmt = ["dep:defmt"]
+rt = ["dep:riscv-rt", "neorv32-pac/rt"]
+v-trap = ["rt", "neorv32-pac/v-trap"]
+
+# Note: CLINT MTIMER always runs at main CPU frequency, thus tick-hz-* must match
+# But main CPU frequency is configurable, so defer tick rate choice to user
+time-driver = ["dep:embassy-time-driver", "dep:embassy-time-queue-utils", "rt"]
+
+[dependencies]
+neorv32-pac = { version = "0.1.0", features = [
+    "critical-section",
+] }
+riscv = { version = "0.16.0", features = ["critical-section-single-hart"] }
+riscv-rt = { version = "0.17.0", optional = true }
+critical-section = { version = "1.2.0" }
+defmt = { version = "1.0.1", optional = true }
+
+embassy-time-driver = { version = "0.2.1", path = "../embassy-time-driver", optional = true }
+embassy-time-queue-utils = { version = "0.3.0", path = "../embassy-time-queue-utils", optional = true }
+embassy-sync = { version = "0.7.2", path = "../embassy-sync" }
+embassy-hal-internal = { version = "0.4.0", path = "../embassy-hal-internal" } 
+
+embedded-hal-02 = { package = "embedded-hal", version = "0.2.7", features = [
+    "unproven",
+] }
+embedded-hal-1 = { package = "embedded-hal", version = "1.0" }
+embedded-hal-async = "1.0"
+embedded-io = "0.7.1"
+embedded-io-async = "0.7.0"

--- a/embassy-neorv32/README.md
+++ b/embassy-neorv32/README.md
@@ -1,0 +1,60 @@
+# Embassy NEORV32 HAL
+HALs implement safe, idiomatic Rust APIs to use the hardware capabilities, so raw register manipulation is not needed.
+
+The `embassy-neorv32` HAL targets the open-source [NEORV32](https://github.com/stnolting/neorv32)
+RISC-V microcontroller and implements both blocking and async APIs/drivers for most of the peripherals.
+Additionally, async and blocking traits from [embedded-hal](https://crates.io/crates/embedded-hal)
+are implemented where appropriate.
+
+## Support
+The HAL currently supports the following peripherals and features:
+
+### Peripherals
+- UART
+- GPIO
+- DMA
+- SYSINFO
+
+### Additional Features
+- Embassy time-driver via CLINT `mtimer`
+
+## Usage
+Please see the `examples/neorv32` folder for ideas on how to use this HAL in your own projects.  
+To run these examples, follow these steps:
+
+- Install [cargo-binutils](https://crates.io/crates/cargo-binutils)
+- Modify build target in `examples/neorv32/.cargo/config.toml` to match your configuration
+- Modify `examples/neorv32/memory.x` to match the size of your configured `DMEM` and `IMEM`
+- Modify `examples/neorv32/Cargo.toml` features `sim` and `fpga` such that
+the `tick-hz` feature for `embassy-time` matches your configuration
+- Modify `UART_BAUD` in `examples/neorv32/src/lib.rs` to match your host UART
+- Clone [neorv32 v1.12.6](https://github.com/stnolting/neorv32/tree/v1.12.6)
+- Continue with one of the series of steps below depending on if running in simulation or on FPGA
+
+### Simulation
+- Modify `BASE` in `examples/neorv32/run-sim` to your `neorv32` repo path (default in `$HOME` folder)
+- Install [GHDL](https://github.com/ghdl/ghdl) simulator
+- From the `examples/neorv32` folder, run `cargo run-sim --release --bin hello-world`
+- For more help, see [simulating the processor](https://stnolting.github.io/neorv32/ug/#_simulating_the_processor)
+
+### FPGA over UART bootloader
+- Modify `BASE` in `examples/neorv32/run-fpga` to your `neorv32` repo path (default in `$HOME` folder)
+- Install `picocom` (or modify `run-fpga` to use your preferred tool)
+- From the `examples/neorv32` folder, run `cargo run-fpga --release --bin hello-world`
+- Press reset button on FPGA
+- If using `picocom`, manually follow these steps within host terminal:
+- Type: Any key
+- Type: `u` (Upload)
+- Type: `<Ctrl+A> <Ctrl+S>` (send file)
+- Type: `hello-world-fpga <Enter>`
+- Wait for upload to complete (should see `*** exit status: 0 *** OK`)
+- Type: `e` (Execute)
+- For more help, see [bootloader](https://stnolting.github.io/neorv32/#_bootloader)
+
+## Version
+This HAL targets NEORV32 [v1.12.6](https://github.com/stnolting/neorv32/tree/v1.12.6).
+There is no guarantee it will work for different versions.
+
+## References
+- [NEORV32 Datasheet](https://stnolting.github.io/neorv32/)
+- [NEORV32 User Guide](https://stnolting.github.io/neorv32/ug/)

--- a/embassy-neorv32/build.rs
+++ b/embassy-neorv32/build.rs
@@ -1,0 +1,4 @@
+fn main() {
+    println!("cargo:rustc-env=RISCV_RT_BASE_ISA=rv32i");
+    println!("cargo:rerun-if-env-changed=RISCV_RT_BASE_ISA");
+}

--- a/embassy-neorv32/src/dma.rs
+++ b/embassy-neorv32/src/dma.rs
@@ -1,0 +1,366 @@
+//! Direct Memory Access (DMA)
+use core::marker::PhantomData;
+use core::pin::Pin;
+use core::sync::atomic::{AtomicBool, Ordering, fence};
+use core::task::{Context, Poll};
+
+use embassy_hal_internal::{Peri, PeripheralType};
+use embassy_sync::waitqueue::AtomicWaker;
+
+use crate::interrupt::typelevel::{Binding, Handler, Interrupt};
+use crate::peripherals::DMA;
+
+const U23_MAX: u32 = 0xff_ffff;
+
+/// DMA interrupt handler binding.
+pub struct InterruptHandler<T: Instance> {
+    _phantom: PhantomData<T>,
+}
+
+impl<T: Instance> Handler<T::Interrupt> for InterruptHandler<T> {
+    unsafe fn on_interrupt() {
+        // Acking the interrupt clears both the ERROR and DONE flags.
+        // In poll, we can check the BUSY flag to know if we are done,
+        // but still need a way to check for bus error.
+        //
+        // So we cache the ERROR flag before clearing it.
+        let err = T::info().reg.ctrl().read().dma_ctrl_error().bit_is_set();
+        T::info().err_flag.store(err, Ordering::Release);
+        T::info().reg.ctrl().modify(|_, w| w.dma_ctrl_ack().set_bit());
+
+        T::info().waker.wake();
+    }
+}
+
+/// DMA error.
+#[derive(Clone, Copy, Debug)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+pub enum Error {
+    /// The NEORV32 configuration does not support DMA.
+    NotSupported,
+    /// Indicates a bus error occurred during transfer.
+    BusError,
+}
+
+enum DataConfig {
+    ConstantByte,
+    ConstantWord,
+    IncrementingByte,
+    IncrementingWord,
+}
+
+impl From<DataConfig> for u32 {
+    fn from(config: DataConfig) -> Self {
+        match config {
+            DataConfig::ConstantByte => 0b00,
+            DataConfig::ConstantWord => 0b01,
+            DataConfig::IncrementingByte => 0b10,
+            DataConfig::IncrementingWord => 0b11,
+        }
+    }
+}
+
+struct TransferConfig {
+    num_elems: u32,
+    swap_byte_order: bool,
+    src_cfg: DataConfig,
+    dst_cfg: DataConfig,
+}
+
+impl TransferConfig {
+    fn new(num_elems: u32, swap_byte_order: bool, src_cfg: DataConfig, dst_cfg: DataConfig) -> Self {
+        // Hardware only supports 23 bits for num elements
+        assert!(num_elems > 0 && num_elems < U23_MAX);
+        Self {
+            num_elems,
+            swap_byte_order,
+            src_cfg,
+            dst_cfg,
+        }
+    }
+}
+
+impl From<TransferConfig> for u32 {
+    fn from(config: TransferConfig) -> Self {
+        (u32::from(config.dst_cfg) << 30)
+            | (u32::from(config.src_cfg) << 28)
+            | ((config.swap_byte_order as u32) << 27)
+            | (config.num_elems & U23_MAX)
+    }
+}
+
+enum Descriptor {
+    BaseAddress(u32),
+    Config(TransferConfig),
+}
+
+impl From<Descriptor> for u32 {
+    fn from(descriptor: Descriptor) -> Self {
+        match descriptor {
+            Descriptor::BaseAddress(addr) => addr,
+            Descriptor::Config(cfg) => cfg.into(),
+        }
+    }
+}
+
+/// DMA driver.
+///
+/// DMA is single-channel only so so the entire peripheral may only have a single owner.
+pub struct Dma<'d> {
+    info: Info,
+    _phantom: PhantomData<&'d ()>,
+}
+
+// Allows for use in a Mutex (to share safely between harts and tasks)
+unsafe impl<'d> Send for Dma<'d> {}
+
+impl<'d> Dma<'d> {
+    fn enable(&mut self) {
+        self.info.reg.ctrl().modify(|_, w| w.dma_ctrl_en().set_bit());
+    }
+
+    fn disable(&mut self) {
+        self.info.reg.ctrl().modify(|_, w| w.dma_ctrl_en().clear_bit());
+    }
+
+    fn start(&mut self) {
+        self.info.reg.ctrl().modify(|_, w| w.dma_ctrl_start().set_bit());
+    }
+
+    fn write_descriptor(&mut self, descriptor: Descriptor) {
+        // SAFETY: We are writing a valid descriptor
+        self.info.reg.desc().write(|w| unsafe { w.bits(descriptor.into()) });
+    }
+
+    fn busy(&self) -> bool {
+        self.info.reg.ctrl().read().dma_ctrl_busy().bit_is_set()
+    }
+
+    fn abort(&mut self) {
+        // Disable DMA and flush cache to ensure CPU sees most recent main memory
+        self.disable();
+        fence(Ordering::SeqCst);
+    }
+
+    /// Creates a new instance of a DMA driver.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`Error::NotSupported`] if DMA is not supported.
+    pub fn new<T: Instance>(
+        _instance: Peri<'d, T>,
+        _irq: impl Binding<T::Interrupt, InterruptHandler<T>> + 'd,
+    ) -> Result<Self, Error> {
+        if !crate::sysinfo::SysInfo::soc_config().has_dma() {
+            return Err(Error::NotSupported);
+        }
+
+        // SAFETY: Enabling DMA interrupts at this point is valid
+        unsafe { T::Interrupt::enable() }
+
+        Ok(Self {
+            info: T::info(),
+            _phantom: PhantomData,
+        })
+    }
+
+    /// Starts a transfer which reads from `src` until the `dst` buffer is filled.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the `dst` buffer length can not be represented in 23 bits.
+    pub fn read<'t, W: Word>(&'t mut self, src: &W, dst: &mut [W], swap_byte_order: bool) -> Transfer<'d, 't> {
+        Transfer::new(
+            self,
+            src as *const W as *const u32,
+            W::cfg_constant(),
+            dst.as_mut_ptr() as *mut u32,
+            W::cfg_increment(),
+            dst.len() as u32,
+            swap_byte_order,
+        )
+    }
+
+    /// Starts a transfer which writes all elements from the `src` buffer to `dst`.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the `src` buffer length can not be represented in 23 bits.
+    pub fn write<'t, W: Word>(&'t mut self, src: &[W], dst: &mut W, swap_byte_order: bool) -> Transfer<'d, 't> {
+        Transfer::new(
+            self,
+            src.as_ptr() as *const u32,
+            W::cfg_increment(),
+            dst as *mut W as *mut u32,
+            W::cfg_constant(),
+            src.len() as u32,
+            swap_byte_order,
+        )
+    }
+
+    /// Starts a transfer which copies all elements from the `src` buffer to the `dst` buffer.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the `src` buffer length does not match the `dst` buffer length,
+    /// or if the buffer length can not be represented in 23 bits.
+    pub fn copy<'t, W: Word>(&'t mut self, src: &[W], dst: &mut [W], swap_byte_order: bool) -> Transfer<'d, 't> {
+        assert!(src.len() == dst.len());
+        Transfer::new(
+            self,
+            src.as_ptr() as *const u32,
+            W::cfg_increment(),
+            dst.as_mut_ptr() as *mut u32,
+            W::cfg_increment(),
+            src.len() as u32,
+            swap_byte_order,
+        )
+    }
+}
+
+/// A DMA transfer.
+///
+/// The transfer should be awaited to ensure completion.
+///
+/// **Note**: The transfer will be aborted if cancelled/dropped before completion.
+#[must_use = "futures do nothing unless you `.await` or poll them"]
+pub struct Transfer<'d, 't> {
+    // Note: We use 2 unique lifetimes here so that Transfer holds a mutable reference to Dma
+    // (to prevent other transfers from being simultaneously created) for AT MOST as long as it lives.
+    //
+    // If we use a single lifetime, the borrow checker assumes the Transfer lives as long as Dma lives.
+    //
+    // Can think of it as 't represents Transfer lifetime and 'd represents Dma lifetime.
+    dma: &'t mut Dma<'d>,
+}
+
+impl<'d, 't> Transfer<'d, 't> {
+    fn new(
+        dma: &'t mut Dma<'d>,
+        src: *const u32,
+        src_cfg: DataConfig,
+        dst: *mut u32,
+        dst_cfg: DataConfig,
+        len: u32,
+        swap_byte_order: bool,
+    ) -> Self {
+        // Clear error flag and enable DMA
+        dma.info.err_flag.store(false, Ordering::Release);
+        dma.enable();
+
+        // Configure the transfer
+        let config = TransferConfig::new(len, swap_byte_order, src_cfg, dst_cfg);
+        let descriptors = [
+            Descriptor::BaseAddress(src as u32),
+            Descriptor::BaseAddress(dst as u32),
+            Descriptor::Config(config),
+        ];
+
+        // Write each descriptor
+        // We are assuming the descriptor FIFO is empty because this HAL does not allow partial transfers in the FIFO
+        for descriptor in descriptors {
+            dma.write_descriptor(descriptor);
+        }
+
+        // Flush cache to ensure DMA sees most recent main memory, then start transfer
+        fence(Ordering::SeqCst);
+        dma.start();
+        Self { dma }
+    }
+}
+
+impl<'d, 't> Drop for Transfer<'d, 't> {
+    // When the transfer is completed, or otherwise dropped or cancelled, always get here
+    // Regardless, we ensure the DMA is disabled (aborting the transfer if in progress) and flush cache
+    fn drop(&mut self) {
+        self.dma.abort();
+    }
+}
+
+impl<'d, 't> Future for Transfer<'d, 't> {
+    type Output = Result<(), Error>;
+    fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+        self.dma.info.waker.register(cx.waker());
+
+        if self.dma.busy() {
+            Poll::Pending
+        } else if self.dma.info.err_flag.load(Ordering::Acquire) {
+            Poll::Ready(Err(Error::BusError))
+        } else {
+            Poll::Ready(Ok(()))
+        }
+    }
+}
+
+trait SealedWord {
+    fn cfg_constant() -> DataConfig;
+    fn cfg_increment() -> DataConfig;
+}
+
+/// A DMA transfer word.
+///
+/// **Note**: The hardware supports transferring `u8` to `u32` (by zero-extending the `u8`),
+/// but does not seem to support transferring `u32` to `u8` (ideally it would truncate the 24 MSB).
+///
+/// So, for ease of use, the driver only supports `u8` <-> `u8` and `u32` <-> `u32` transfers.
+#[allow(private_bounds)]
+pub trait Word: SealedWord {}
+
+impl SealedWord for u8 {
+    #[inline(always)]
+    fn cfg_constant() -> DataConfig {
+        DataConfig::ConstantByte
+    }
+
+    #[inline(always)]
+    fn cfg_increment() -> DataConfig {
+        DataConfig::IncrementingByte
+    }
+}
+impl Word for u8 {}
+
+impl SealedWord for u32 {
+    #[inline(always)]
+    fn cfg_constant() -> DataConfig {
+        DataConfig::ConstantWord
+    }
+
+    #[inline(always)]
+    fn cfg_increment() -> DataConfig {
+        DataConfig::IncrementingWord
+    }
+}
+impl Word for u32 {}
+
+struct Info {
+    reg: &'static crate::pac::dma::RegisterBlock,
+    waker: &'static AtomicWaker,
+    err_flag: &'static AtomicBool,
+}
+
+trait SealedInstance {
+    fn info() -> Info;
+}
+
+/// A valid DMA peripheral.
+#[allow(private_bounds)]
+pub trait Instance: SealedInstance + PeripheralType {
+    type Interrupt: Interrupt;
+}
+
+impl SealedInstance for DMA {
+    fn info() -> Info {
+        static WAKER: AtomicWaker = AtomicWaker::new();
+        static ERR_FLAG: AtomicBool = AtomicBool::new(false);
+
+        Info {
+            // SAFETY: We are the sole users of the pointer and are sure to use it safely
+            reg: unsafe { &*crate::pac::Dma::ptr() },
+            waker: &WAKER,
+            err_flag: &ERR_FLAG,
+        }
+    }
+}
+impl Instance for DMA {
+    type Interrupt = crate::interrupt::typelevel::DMA;
+}

--- a/embassy-neorv32/src/gpio.rs
+++ b/embassy-neorv32/src/gpio.rs
@@ -1,0 +1,766 @@
+//! General-Purpose Input/Output (GPIO)
+use core::convert::Infallible;
+use core::future::poll_fn;
+use core::marker::PhantomData;
+use core::task::Poll;
+
+use critical_section::CriticalSection;
+use embassy_hal_internal::{Peri, PeripheralType};
+use embassy_sync::waitqueue::AtomicWaker;
+
+use crate::interrupt::typelevel::{Binding, Handler, Interrupt};
+use crate::peripherals::GPIO;
+
+// Max number of GPIO ports available
+const MAX_PORTS: usize = 32;
+
+/// GPIO interrupt handler binding.
+pub struct InterruptHandler<T: Instance> {
+    _phantom: PhantomData<T>,
+}
+
+impl<T: Instance> Handler<T::Interrupt> for InterruptHandler<T> {
+    unsafe fn on_interrupt() {
+        let pending = T::info().reg.irq_pending().read().bits();
+        let mut disabled = T::info().reg.irq_enable().read().bits();
+
+        // Wake and disable every port that has IRQ pending
+        for (i, waker) in T::info().wakers.iter().enumerate() {
+            let port_bit = 1 << i;
+            if (pending & port_bit) != 0 {
+                waker.wake();
+                disabled &= !port_bit;
+            }
+        }
+
+        // Clear pending
+        // SAFETY: Register is write 0 to clear, so we bitwise not `pending` to clear only those,
+        // assuring if a port becomes pending in the meantime we don't clobber it
+        T::info().reg.irq_pending().write(|w| unsafe { w.bits(!pending) });
+
+        // Disable interrupts for ports that were just pending
+        // SAFETY: We've ensured we've only cleared the bits of the interrupts we actually serviced
+        T::info().reg.irq_enable().write(|w| unsafe { w.bits(disabled) });
+    }
+}
+
+/// GPIO error.
+#[derive(Clone, Copy, Debug)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+pub enum Error {
+    /// The NEORV32 configuration does not support GPIO.
+    NotSupported,
+}
+
+/// GPIO driver.
+pub struct Gpio<'d, M: IoMode> {
+    info: Info,
+    _phantom: PhantomData<&'d M>,
+}
+
+impl<'d, M: IoMode> Gpio<'d, M> {
+    fn new_inner<T: Instance>(_instance: Peri<'d, T>) -> Result<Self, Error> {
+        if !crate::sysinfo::SysInfo::soc_config().has_gpio() {
+            return Err(Error::NotSupported);
+        }
+
+        Ok(Self {
+            info: T::info(),
+            _phantom: PhantomData,
+        })
+    }
+
+    /// Create a new instance of a port driver capable of simultaneous input and output.
+    pub fn new_port<T: PortInstance>(&self, _instance: Peri<'d, T>) -> Port<'d, M> {
+        Port::new(T::PORT, self.info.reg, &self.info.wakers[T::PORT as usize])
+    }
+
+    /// Create a new instance of an input-only port driver.
+    pub fn new_input<T: PortInstance>(&self, _instance: Peri<'d, T>) -> Input<'d, M> {
+        Input::new(T::PORT, self.info.reg, &self.info.wakers[T::PORT as usize])
+    }
+
+    /// Create a new instance of an output-only port driver.
+    pub fn new_output<T: PortInstance>(&self, _instance: Peri<'d, T>) -> Output<'d> {
+        Output::new(T::PORT, self.info.reg)
+    }
+}
+
+impl<'d> Gpio<'d, Blocking> {
+    /// Create a new instance of a blocking GPIO driver.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`Error::NotSupported`] if GPIO is not supported.
+    pub fn new_blocking<T: Instance>(_instance: Peri<'d, T>) -> Result<Self, Error> {
+        Self::new_inner(_instance)
+    }
+}
+
+impl<'d> Gpio<'d, Async> {
+    /// Create a new instance of an async GPIO driver.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`Error::NotSupported`] if GPIO is not supported.
+    pub fn new_async<T: Instance>(
+        _instance: Peri<'d, T>,
+        _irq: impl Binding<T::Interrupt, InterruptHandler<T>> + 'd,
+    ) -> Result<Self, Error> {
+        let gpio = Self::new_inner(_instance)?;
+        // SAFETY: It is valid to enable GPIO interrupt here
+        unsafe { T::Interrupt::enable() }
+        Ok(gpio)
+    }
+}
+
+/// A GPIO port.
+///
+/// On the NEORV32, ports are bidirectional represented by two (input/output) signals under the hood,
+/// corresponding to bits PORT_IN(i) and PORT_OUT(i) respectively.
+///
+/// Thus, a single port allows simultaneous input and output.
+pub struct Port<'d, M: IoMode> {
+    input: Input<'d, M>,
+    output: Output<'d>,
+}
+
+impl<'d, M: IoMode> Port<'d, M> {
+    fn new(port: u32, reg: &'static crate::pac::gpio::RegisterBlock, waker: &'static AtomicWaker) -> Self {
+        let input = Input::new(port, reg, waker);
+        let output = Output::new(port, reg);
+
+        Self { input, output }
+    }
+
+    /// Split the port into separate [Input] and [Output] ports for sharing between tasks.
+    pub fn split(self) -> (Input<'d, M>, Output<'d>) {
+        (self.input, self.output)
+    }
+
+    /// Split the port by mutable reference into separate [Input] and [Output] ports for sharing between tasks.
+    pub fn split_ref(&mut self) -> (&mut Input<'d, M>, &mut Output<'d>) {
+        (&mut self.input, &mut self.output)
+    }
+
+    /// Returns true if the port's input signal is low.
+    pub fn is_low(&self) -> bool {
+        self.input.is_low()
+    }
+
+    /// Returns true if the port's input signal is high.
+    pub fn is_high(&self) -> bool {
+        self.input.is_high()
+    }
+
+    /// Toggle the port's output signal between low and high.
+    pub fn toggle(&mut self) {
+        self.output.toggle();
+    }
+
+    /// Set the port's output signal low.
+    pub fn set_low(&mut self) {
+        self.output.set_low();
+    }
+
+    /// Set the port's output signal high.
+    pub fn set_high(&mut self) {
+        self.output.set_high();
+    }
+
+    /// Returns true if the port's output signal is set low.
+    pub fn is_set_low(&self) -> bool {
+        self.output.is_set_low()
+    }
+
+    /// Returns true if the port's output signal is set high.
+    pub fn is_set_high(&self) -> bool {
+        self.output.is_set_high()
+    }
+}
+
+impl<'d> Port<'d, Async> {
+    /// Wait until the port's input signal is low, returning immediately if it already is.
+    pub fn wait_for_low(&mut self) -> impl Future<Output = ()> {
+        self.input.wait_for_low()
+    }
+
+    /// Wait until the port's input signal is high, returning immediately if it already is.
+    pub fn wait_for_high(&mut self) -> impl Future<Output = ()> {
+        self.input.wait_for_high()
+    }
+
+    /// Wait for the port's input signal to transition from high to low.
+    ///
+    /// If the input signal is already low, this will not return until the signal transitions
+    /// from low to high then back to low again.
+    pub fn wait_for_falling_edge(&mut self) -> impl Future<Output = ()> {
+        self.input.wait_for_falling_edge()
+    }
+
+    /// Wait for the port's input signal to transition from low to high.
+    ///
+    /// If the input signal is already high, this will not return until the signal transitions
+    /// from high to low then back to high again.
+    pub fn wait_for_rising_edge(&mut self) -> impl Future<Output = ()> {
+        self.input.wait_for_rising_edge()
+    }
+
+    /// Wait for the port's input signal to undergo any state transition.
+    pub fn wait_for_any_edge(&mut self) -> impl Future<Output = ()> {
+        self.input.wait_for_any_edge()
+    }
+}
+
+pub struct Input<'d, M: IoMode> {
+    info: InputInfo,
+    _phantom: PhantomData<&'d M>,
+}
+
+// Allows for use in a Mutex (to share safely between harts and tasks)
+unsafe impl<'d, M: IoMode> Send for Input<'d, M> {}
+
+impl<'d, M: IoMode> Input<'d, M> {
+    fn new(port: u32, reg: &'static crate::pac::gpio::RegisterBlock, waker: &'static AtomicWaker) -> Self {
+        let info = InputInfo {
+            port_mask: 1 << port,
+            reg,
+            waker,
+        };
+
+        Self {
+            info,
+            _phantom: PhantomData,
+        }
+    }
+
+    fn irq_disable(&mut self, _cs: CriticalSection) {
+        // SAFETY: We only clear our bit. This is only called in a critical section so no risk of clobbering others.
+        self.info
+            .reg
+            .irq_enable()
+            .modify(|r, w| unsafe { w.bits(r.bits() & !self.info.port_mask) });
+    }
+
+    /// Returns true if the port's input signal is low.
+    pub fn is_low(&self) -> bool {
+        (self.info.reg.port_in().read().bits() & self.info.port_mask) == 0
+    }
+
+    /// Returns true if the port's input signal is high.
+    pub fn is_high(&self) -> bool {
+        !self.is_low()
+    }
+}
+
+impl<'d> Input<'d, Async> {
+    fn set_level_trigger(&mut self, _cs: CriticalSection) {
+        // SAFETY: We only clear our bit. This is only called in a critical section so no risk of clobbering others.
+        self.info
+            .reg
+            .irq_type()
+            .modify(|r, w| unsafe { w.bits(r.bits() & !self.info.port_mask) });
+    }
+
+    fn set_edge_trigger(&mut self, _cs: CriticalSection) {
+        // SAFETY: We only set our bit. This is only called in a critical section so no risk of clobbering others.
+        self.info
+            .reg
+            .irq_type()
+            .modify(|r, w| unsafe { w.bits(r.bits() | self.info.port_mask) });
+    }
+
+    fn set_trigger_polarity_low(&mut self, _cs: CriticalSection) {
+        // SAFETY: We only clear our bit. This is only called in a critical section so no risk of clobbering others.
+        self.info
+            .reg
+            .irq_polarity()
+            .modify(|r, w| unsafe { w.bits(r.bits() & !self.info.port_mask) });
+    }
+
+    fn set_trigger_polarity_high(&mut self, _cs: CriticalSection) {
+        // SAFETY: We only set our bit. This is only called in a critical section so no risk of clobbering others.
+        self.info
+            .reg
+            .irq_polarity()
+            .modify(|r, w| unsafe { w.bits(r.bits() | self.info.port_mask) });
+    }
+
+    fn irq_enable(&mut self, _cs: CriticalSection) {
+        // SAFETY: We only set our bit. This is only called in a critical section so no risk of clobbering others.
+        self.info
+            .reg
+            .irq_enable()
+            .modify(|r, w| unsafe { w.bits(r.bits() | self.info.port_mask) });
+    }
+
+    fn irq_enabled(&self) -> bool {
+        (self.info.reg.irq_enable().read().bits() & self.info.port_mask) != 0
+    }
+
+    async fn wait(&mut self) {
+        critical_section::with(|cs| self.irq_enable(cs));
+
+        poll_fn(|cx| {
+            self.info.waker.register(cx.waker());
+
+            // If irq is disabled, we know interrupt actually fired
+            if !self.irq_enabled() {
+                Poll::Ready(())
+            } else {
+                Poll::Pending
+            }
+        })
+        .await
+    }
+
+    /// Wait until the port's input signal is low, returning immediately if it already is.
+    pub async fn wait_for_low(&mut self) {
+        if !self.is_low() {
+            critical_section::with(|cs| {
+                self.set_level_trigger(cs);
+                self.set_trigger_polarity_low(cs)
+            });
+            self.wait().await
+        }
+    }
+
+    /// Wait until the port's input signal is high, returning immediately if it already is.
+    pub async fn wait_for_high(&mut self) {
+        if !self.is_high() {
+            critical_section::with(|cs| {
+                self.set_level_trigger(cs);
+                self.set_trigger_polarity_high(cs);
+            });
+            self.wait().await
+        }
+    }
+
+    /// Wait for the port's input signal to transition from high to low.
+    ///
+    /// If the input signal is already low, this will not return until the signal transitions
+    /// from low to high then back to low again.
+    pub async fn wait_for_falling_edge(&mut self) {
+        critical_section::with(|cs| {
+            self.set_edge_trigger(cs);
+            self.set_trigger_polarity_low(cs);
+        });
+        self.wait().await
+    }
+
+    /// Wait for the port's input signal to transition from low to high.
+    ///
+    /// If the input signal is already high, this will not return until the signal transitions
+    /// from high to low then back to high again.
+    pub async fn wait_for_rising_edge(&mut self) {
+        critical_section::with(|cs| {
+            self.set_edge_trigger(cs);
+            self.set_trigger_polarity_high(cs);
+        });
+        self.wait().await
+    }
+
+    /// Wait for the port's input signal to undergo any state transition.
+    pub async fn wait_for_any_edge(&mut self) {
+        if self.is_low() {
+            self.wait_for_rising_edge().await
+        } else {
+            self.wait_for_falling_edge().await
+        }
+    }
+}
+
+impl<'d, M: IoMode> Drop for Input<'d, M> {
+    fn drop(&mut self) {
+        critical_section::with(|cs| self.irq_disable(cs));
+    }
+}
+
+pub struct Output<'d> {
+    info: OutputInfo,
+    _phantom: PhantomData<&'d ()>,
+}
+
+// Allows for use in a Mutex (to share safely between harts and tasks)
+unsafe impl<'d> Send for Output<'d> {}
+
+impl<'d> Output<'d> {
+    fn new(port: u32, reg: &'static crate::pac::gpio::RegisterBlock) -> Self {
+        let info = OutputInfo {
+            port_mask: 1 << port,
+            reg,
+        };
+        Self {
+            info,
+            _phantom: PhantomData,
+        }
+    }
+
+    /// Toggle the port's output signal between low and high.
+    pub fn toggle(&mut self) {
+        if self.is_set_low() {
+            self.set_high();
+        } else {
+            self.set_low();
+        }
+    }
+
+    /// Set the port's output signal low.
+    pub fn set_low(&mut self) {
+        critical_section::with(|_| {
+            // SAFETY: We only clear our bit. This is only called in a critical section so no risk of clobbering others.
+            self.info
+                .reg
+                .port_out()
+                .modify(|r, w| unsafe { w.bits(r.bits() & !self.info.port_mask) })
+        });
+    }
+
+    /// Set the port's output signal high.
+    pub fn set_high(&mut self) {
+        critical_section::with(|_| {
+            // SAFETY: We only set our bit. This is only called in a critical section so no risk of clobbering others.
+            self.info
+                .reg
+                .port_out()
+                .modify(|r, w| unsafe { w.bits(r.bits() | self.info.port_mask) })
+        });
+    }
+
+    /// Returns true if the port's output signal is set low.
+    pub fn is_set_low(&self) -> bool {
+        (self.info.reg.port_out().read().bits() & self.info.port_mask) == 0
+    }
+
+    /// Returns true if the port's output signal is set high.
+    pub fn is_set_high(&self) -> bool {
+        !self.is_set_low()
+    }
+}
+
+trait SealedIoMode {}
+
+/// GPIO IO mode.
+#[allow(private_bounds)]
+pub trait IoMode: SealedIoMode {}
+
+/// Blocking GPIO.
+pub struct Blocking;
+impl SealedIoMode for Blocking {}
+impl IoMode for Blocking {}
+
+/// Async GPIO.
+pub struct Async;
+impl SealedIoMode for Async {}
+impl IoMode for Async {}
+
+struct Info {
+    reg: &'static crate::pac::gpio::RegisterBlock,
+    wakers: &'static [AtomicWaker; MAX_PORTS],
+}
+
+struct InputInfo {
+    port_mask: u32,
+    reg: &'static crate::pac::gpio::RegisterBlock,
+    waker: &'static AtomicWaker,
+}
+
+struct OutputInfo {
+    port_mask: u32,
+    reg: &'static crate::pac::gpio::RegisterBlock,
+}
+
+trait SealedInstance {
+    fn info() -> Info;
+}
+
+/// A valid GPIO peripheral.
+#[allow(private_bounds)]
+pub trait Instance: SealedInstance + PeripheralType {
+    type Interrupt: Interrupt;
+}
+
+impl SealedInstance for GPIO {
+    fn info() -> Info {
+        static WAKERS: [AtomicWaker; MAX_PORTS] = [const { AtomicWaker::new() }; MAX_PORTS];
+
+        Info {
+            // SAFETY: We have exclusive access to the GPIO register block
+            reg: unsafe { &*crate::pac::Gpio::ptr() },
+            wakers: &WAKERS,
+        }
+    }
+}
+impl Instance for GPIO {
+    type Interrupt = crate::interrupt::typelevel::GPIO;
+}
+
+trait SealedPortInstance {}
+
+/// A valid PORT peripheral.
+#[allow(private_bounds)]
+pub trait PortInstance: SealedPortInstance + PeripheralType {
+    const PORT: u32;
+}
+
+macro_rules! impl_port {
+    ($periph:ident, $port:expr) => {
+        impl SealedPortInstance for crate::peripherals::$periph {}
+        impl PortInstance for crate::peripherals::$periph {
+            const PORT: u32 = $port;
+        }
+    };
+}
+
+impl_port!(PORT0, 0);
+impl_port!(PORT1, 1);
+impl_port!(PORT2, 2);
+impl_port!(PORT3, 3);
+impl_port!(PORT4, 4);
+impl_port!(PORT5, 5);
+impl_port!(PORT6, 6);
+impl_port!(PORT7, 7);
+impl_port!(PORT8, 8);
+impl_port!(PORT9, 9);
+impl_port!(PORT10, 10);
+impl_port!(PORT11, 11);
+impl_port!(PORT12, 12);
+impl_port!(PORT13, 13);
+impl_port!(PORT14, 14);
+impl_port!(PORT15, 15);
+impl_port!(PORT16, 16);
+impl_port!(PORT17, 17);
+impl_port!(PORT18, 18);
+impl_port!(PORT19, 19);
+impl_port!(PORT20, 20);
+impl_port!(PORT21, 21);
+impl_port!(PORT22, 22);
+impl_port!(PORT23, 23);
+impl_port!(PORT24, 24);
+impl_port!(PORT25, 25);
+impl_port!(PORT26, 26);
+impl_port!(PORT27, 27);
+impl_port!(PORT28, 28);
+impl_port!(PORT29, 29);
+impl_port!(PORT30, 30);
+impl_port!(PORT31, 31);
+
+impl<'d, M: IoMode> embedded_hal_02::digital::v2::InputPin for Port<'d, M> {
+    type Error = Infallible;
+
+    fn is_high(&self) -> Result<bool, Self::Error> {
+        Ok(self.is_high())
+    }
+
+    fn is_low(&self) -> Result<bool, Self::Error> {
+        Ok(self.is_high())
+    }
+}
+
+impl<'d, M: IoMode> embedded_hal_02::digital::v2::OutputPin for Port<'d, M> {
+    type Error = Infallible;
+
+    fn set_high(&mut self) -> Result<(), Self::Error> {
+        self.set_high();
+        Ok(())
+    }
+
+    fn set_low(&mut self) -> Result<(), Self::Error> {
+        self.set_low();
+        Ok(())
+    }
+}
+
+impl<'d, M: IoMode> embedded_hal_02::digital::v2::StatefulOutputPin for Port<'d, M> {
+    fn is_set_high(&self) -> Result<bool, Self::Error> {
+        Ok(self.is_set_high())
+    }
+
+    fn is_set_low(&self) -> Result<bool, Self::Error> {
+        Ok(self.is_set_low())
+    }
+}
+
+impl<'d, M: IoMode> embedded_hal_02::digital::v2::ToggleableOutputPin for Port<'d, M> {
+    type Error = Infallible;
+
+    fn toggle(&mut self) -> Result<(), Self::Error> {
+        self.toggle();
+        Ok(())
+    }
+}
+
+impl<'d, M: IoMode> embedded_hal_02::digital::v2::InputPin for Input<'d, M> {
+    type Error = Infallible;
+
+    fn is_high(&self) -> Result<bool, Self::Error> {
+        Ok(self.is_high())
+    }
+
+    fn is_low(&self) -> Result<bool, Self::Error> {
+        Ok(self.is_high())
+    }
+}
+
+impl<'d> embedded_hal_02::digital::v2::OutputPin for Output<'d> {
+    type Error = Infallible;
+
+    fn set_high(&mut self) -> Result<(), Self::Error> {
+        self.set_high();
+        Ok(())
+    }
+
+    fn set_low(&mut self) -> Result<(), Self::Error> {
+        self.set_low();
+        Ok(())
+    }
+}
+
+impl<'d> embedded_hal_02::digital::v2::StatefulOutputPin for Output<'d> {
+    fn is_set_high(&self) -> Result<bool, Self::Error> {
+        Ok(self.is_set_high())
+    }
+
+    fn is_set_low(&self) -> Result<bool, Self::Error> {
+        Ok(self.is_set_low())
+    }
+}
+
+impl<'d> embedded_hal_02::digital::v2::ToggleableOutputPin for Output<'d> {
+    type Error = Infallible;
+
+    fn toggle(&mut self) -> Result<(), Self::Error> {
+        self.toggle();
+        Ok(())
+    }
+}
+
+impl<'d, M: IoMode> embedded_hal_1::digital::ErrorType for Port<'d, M> {
+    type Error = Infallible;
+}
+
+impl<'d, M: IoMode> embedded_hal_1::digital::InputPin for Port<'d, M> {
+    fn is_high(&mut self) -> Result<bool, Self::Error> {
+        Ok((*self).is_high())
+    }
+
+    fn is_low(&mut self) -> Result<bool, Self::Error> {
+        Ok((*self).is_low())
+    }
+}
+
+impl<'d, M: IoMode> embedded_hal_1::digital::OutputPin for Port<'d, M> {
+    fn set_high(&mut self) -> Result<(), Self::Error> {
+        self.set_high();
+        Ok(())
+    }
+
+    fn set_low(&mut self) -> Result<(), Self::Error> {
+        self.set_low();
+        Ok(())
+    }
+}
+
+impl<'d, M: IoMode> embedded_hal_1::digital::StatefulOutputPin for Port<'d, M> {
+    fn is_set_high(&mut self) -> Result<bool, Self::Error> {
+        Ok((*self).is_set_high())
+    }
+
+    fn is_set_low(&mut self) -> Result<bool, Self::Error> {
+        Ok((*self).is_set_low())
+    }
+}
+
+impl<'d> embedded_hal_async::digital::Wait for Port<'d, Async> {
+    async fn wait_for_high(&mut self) -> Result<(), Self::Error> {
+        self.wait_for_high().await;
+        Ok(())
+    }
+
+    async fn wait_for_low(&mut self) -> Result<(), Self::Error> {
+        self.wait_for_low().await;
+        Ok(())
+    }
+
+    async fn wait_for_rising_edge(&mut self) -> Result<(), Self::Error> {
+        self.wait_for_rising_edge().await;
+        Ok(())
+    }
+
+    async fn wait_for_falling_edge(&mut self) -> Result<(), Self::Error> {
+        self.wait_for_falling_edge().await;
+        Ok(())
+    }
+
+    async fn wait_for_any_edge(&mut self) -> Result<(), Self::Error> {
+        self.wait_for_any_edge().await;
+        Ok(())
+    }
+}
+
+impl<'d, M: IoMode> embedded_hal_1::digital::ErrorType for Input<'d, M> {
+    type Error = Infallible;
+}
+
+impl<'d, M: IoMode> embedded_hal_1::digital::InputPin for Input<'d, M> {
+    fn is_high(&mut self) -> Result<bool, Self::Error> {
+        Ok((*self).is_high())
+    }
+
+    fn is_low(&mut self) -> Result<bool, Self::Error> {
+        Ok((*self).is_low())
+    }
+}
+
+impl<'d> embedded_hal_async::digital::Wait for Input<'d, Async> {
+    async fn wait_for_high(&mut self) -> Result<(), Self::Error> {
+        self.wait_for_high().await;
+        Ok(())
+    }
+
+    async fn wait_for_low(&mut self) -> Result<(), Self::Error> {
+        self.wait_for_low().await;
+        Ok(())
+    }
+
+    async fn wait_for_rising_edge(&mut self) -> Result<(), Self::Error> {
+        self.wait_for_rising_edge().await;
+        Ok(())
+    }
+
+    async fn wait_for_falling_edge(&mut self) -> Result<(), Self::Error> {
+        self.wait_for_falling_edge().await;
+        Ok(())
+    }
+
+    async fn wait_for_any_edge(&mut self) -> Result<(), Self::Error> {
+        self.wait_for_any_edge().await;
+        Ok(())
+    }
+}
+
+impl<'d> embedded_hal_1::digital::ErrorType for Output<'d> {
+    type Error = Infallible;
+}
+
+impl<'d> embedded_hal_1::digital::OutputPin for Output<'d> {
+    fn set_high(&mut self) -> Result<(), Self::Error> {
+        self.set_high();
+        Ok(())
+    }
+
+    fn set_low(&mut self) -> Result<(), Self::Error> {
+        self.set_low();
+        Ok(())
+    }
+}
+
+impl<'d> embedded_hal_1::digital::StatefulOutputPin for Output<'d> {
+    fn is_set_high(&mut self) -> Result<bool, Self::Error> {
+        Ok((*self).is_set_high())
+    }
+
+    fn is_set_low(&mut self) -> Result<bool, Self::Error> {
+        Ok((*self).is_set_low())
+    }
+}

--- a/embassy-neorv32/src/interrupts.rs
+++ b/embassy-neorv32/src/interrupts.rs
@@ -1,0 +1,154 @@
+//! Peripheral Interrupts
+//!
+//! A lot of this is taken from `embassy-hal-internal` but tweaked for RISC-V.
+//! Ideally most of this could be merged back into `embassy-hal-internal`, but RISC-V interrupt
+//! handling can be a bit platform-dependent so will need to consider how to make it more
+//! flexible for all RISC-V platforms. For example, the NEORV32 contains custom `CoreInterrupt`
+//! sources for peripheral interrupts but on some platforms these might be external interrupts
+//! managed by a PLIC.
+
+/// Macro to bind interrupts to handlers.
+///
+/// This defines the right interrupt handlers, and creates a unit struct (like `struct Irqs;`)
+/// and implements the right binding for it. You can pass this struct to drivers to
+/// prove at compile-time that the right interrupts have been bound.
+///
+/// Example of how to bind one interrupt:
+///
+/// ```rust,ignore
+/// use embassy_neorv32::{bind_interrupts, trng, peripherals};
+///
+/// bind_interrupts!(struct Irqs {
+///     TRNG => trng::InterruptHandler<peripherals::TRNG>;
+/// });
+/// ```
+#[macro_export]
+macro_rules! bind_interrupts {
+    ($vis:vis struct $name:ident { $($irq:ident => $($handler:ty),*;)* }) => {
+            #[derive(Copy, Clone)]
+            $vis struct $name;
+
+        $(
+            #[allow(non_snake_case)]
+            #[riscv_rt::core_interrupt($crate::pac::interrupt::CoreInterrupt::$irq)]
+            fn $irq() {
+                $(
+                    // SAFETY: This macro ensures the given handler is being called from the correct IRQ
+                    unsafe { <$handler as $crate::interrupt::typelevel::Handler<$crate::interrupt::typelevel::$irq>>::on_interrupt(); }
+                )*
+            }
+
+            $(
+                // SAFETY: This macro ensures the given IRQ is bounded to given handler
+                unsafe impl $crate::interrupt::typelevel::Binding<$crate::interrupt::typelevel::$irq, $handler> for $name {}
+            )*
+        )*
+    };
+}
+
+/// Generate a standard `mod interrupt` for a RISC-V HAL.
+#[macro_export]
+macro_rules! interrupt_mod {
+    ($($irqs:ident),* $(,)?) => {
+        /// Interrupt definitions.
+        pub mod interrupt {
+            pub use $crate::pac::interrupt::CoreInterrupt;
+
+            /// Type-level interrupt infrastructure.
+            ///
+            /// This module contains one *type* per interrupt. This is used for checking at compile time that
+            /// the interrupts are correctly bound to HAL drivers.
+            ///
+            /// As an end user, you shouldn't need to use this module directly.
+            /// Use the [`crate::bind_interrupts!`] macro to bind interrupts.
+            pub mod typelevel {
+                trait SealedInterrupt {}
+
+                /// Type-level interrupt.
+                ///
+                /// This trait is implemented for all typelevel interrupt types in this module.
+                #[allow(private_bounds)]
+                pub trait Interrupt: SealedInterrupt {
+
+                    /// Interrupt enum variant.
+                    ///
+                    /// This allows going from typelevel interrupts (one type per interrupt) to
+                    /// non-typelevel interrupts (a single `Interrupt` enum type, with one variant per interrupt).
+                    const IRQ: super::CoreInterrupt;
+
+                    /// Enable the interrupt.
+                    ///
+                    /// # Safety
+                    ///
+                    /// Enabling interrupts might break critical sections or other synchronization mechanisms.
+                    ///
+                    /// Ensure that this is called in a safe context where interrupts can be enabled.
+                    #[inline]
+                    unsafe fn enable() {
+                        // SAFETY: Caller must uphold safety guarantees
+                        unsafe { riscv::interrupt::enable_interrupt(Self::IRQ) }
+                    }
+
+                    /// Disable the interrupt.
+                    #[inline]
+                    fn disable() {
+                        riscv::interrupt::disable_interrupt(Self::IRQ);
+                    }
+
+                    /// Check if interrupt is enabled.
+                    #[inline]
+                    fn is_enabled() -> bool {
+                        riscv::interrupt::is_interrupt_enabled(Self::IRQ)
+                    }
+
+                    /// Check if interrupt is pending.
+                    #[inline]
+                    fn is_pending() -> bool {
+                        riscv::interrupt::is_interrupt_pending(Self::IRQ)
+                    }
+                }
+
+                $(
+                    #[allow(non_camel_case_types)]
+                    #[doc=stringify!($irqs)]
+                    #[doc=" typelevel interrupt."]
+                    pub enum $irqs {}
+                    impl SealedInterrupt for $irqs{}
+                    impl Interrupt for $irqs {
+                        const IRQ: super::CoreInterrupt = super::CoreInterrupt::$irqs;
+                    }
+                )*
+
+                /// Interrupt handler trait.
+                ///
+                /// Drivers that need to handle interrupts implement this trait.
+                /// The user must ensure `on_interrupt()` is called every time the interrupt fires.
+                /// Drivers must use use [`Binding`] to assert at compile time that the user has done so.
+                pub trait Handler<I: Interrupt> {
+                    /// Interrupt handler function.
+                    ///
+                    /// Must be called every time the `I` interrupt fires, synchronously from
+                    /// the interrupt handler context.
+                    ///
+                    /// # Safety
+                    ///
+                    /// This function must ONLY be called from the interrupt handler for `I`.
+                    unsafe fn on_interrupt();
+                }
+
+                /// Compile-time assertion that an interrupt has been bound to a handler.
+                ///
+                /// For the vast majority of cases, you should use the `bind_interrupts!`
+                /// macro instead of writing `unsafe impl`s of this trait.
+                ///
+                /// # Safety
+                ///
+                /// By implementing this trait, you are asserting that you have arranged for `H::on_interrupt()`
+                /// to be called every time the `I` interrupt fires.
+                ///
+                /// This allows drivers to check bindings at compile-time.
+                pub unsafe trait Binding<I: Interrupt, H: Handler<I>> {}
+            }
+        }
+    };
+}

--- a/embassy-neorv32/src/lib.rs
+++ b/embassy-neorv32/src/lib.rs
@@ -1,0 +1,50 @@
+#![doc = include_str!("../README.md")]
+#![no_std]
+pub mod dma;
+pub mod gpio;
+pub mod interrupts;
+pub mod sysinfo;
+#[cfg(feature = "time-driver")]
+mod time_driver;
+pub mod uart;
+
+// Peripherals and interrupts supported by the NEORV32 chip
+mod chip {
+    #[rustfmt::skip]
+    embassy_hal_internal::peripherals!(
+        UART0, UART1,
+        GPIO,
+        PORT0, PORT1, PORT2, PORT3, PORT4, PORT5, PORT6, PORT7,
+        PORT8, PORT9, PORT10, PORT11, PORT12, PORT13, PORT14, PORT15,
+        PORT16, PORT17, PORT18, PORT19, PORT20, PORT21, PORT22, PORT23,
+        PORT24, PORT25, PORT26, PORT27, PORT28, PORT29, PORT30, PORT31,
+        DMA,
+    );
+    pub mod interrupts {
+        crate::interrupt_mod!(UART0, UART1, GPIO, DMA);
+    }
+}
+
+pub use chip::interrupts::*;
+pub use chip::{Peripherals, peripherals};
+pub use neorv32_pac as pac;
+
+/// Initialize the HAL. This must only be called from hart 0.
+///
+/// # Panics
+///
+/// Panics if this has already been called once before or not called from hart 0.
+///
+/// Panics if `time-driver` feature is enabled but `CLINT` is not supported.
+pub fn init() -> Peripherals {
+    // Attempt to take first so we panic before doing anything else
+    let p = Peripherals::take();
+
+    // SAFETY: We're not worried about breaking any critical sections here
+    unsafe { riscv::interrupt::enable() }
+
+    #[cfg(feature = "time-driver")]
+    time_driver::init();
+
+    p
+}

--- a/embassy-neorv32/src/sysinfo.rs
+++ b/embassy-neorv32/src/sysinfo.rs
@@ -1,0 +1,241 @@
+//! SysInfo
+//!
+//! As this is a read-only peripheral, this driver is designed to be free-standing for ease of use.
+//! All functions can be called directly on [`SysInfo`] without needing to instantiate a singleton.
+
+/// Processor boot mode.
+#[derive(Clone, Copy, Debug)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+pub enum BootMode {
+    /// Processor-internal BOOTROM as pre-initialized ROM.
+    Bootloader,
+    /// User-defined address.
+    CustomAddress,
+    /// Processor-internal IMEM as pre-initialized ROM.
+    ImemImage,
+    /// Unrecognized boot mode.
+    Unknown,
+}
+
+impl From<u8> for BootMode {
+    fn from(value: u8) -> Self {
+        match value {
+            0 => Self::Bootloader,
+            1 => Self::CustomAddress,
+            2 => Self::ImemImage,
+            _ => Self::Unknown,
+        }
+    }
+}
+
+/// SoC configuration.
+#[derive(Clone, Copy, Debug)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+pub struct SocConfig(u32);
+
+impl SocConfig {
+    #[inline(always)]
+    fn is_supported(&self, i: u32) -> bool {
+        self.0 & (1 << i) != 0
+    }
+
+    /// Returns raw 32-bit SoC config.
+    pub fn raw(&self) -> u32 {
+        self.0
+    }
+
+    /// Returns true if processor-internal bootloader is implemented.
+    pub fn has_bootloader(&self) -> bool {
+        self.is_supported(0)
+    }
+
+    /// Returns true if external bus interface (XBUS) is implemented.
+    pub fn has_xbus(&self) -> bool {
+        self.is_supported(1)
+    }
+
+    /// Returns true if processor-internal IMEM is implemented.
+    pub fn has_imem(&self) -> bool {
+        self.is_supported(2)
+    }
+
+    /// Returns true if processor-internal DMEM is implemented.
+    pub fn has_dmem(&self) -> bool {
+        self.is_supported(3)
+    }
+
+    /// Returns true if on-chip debugger is implemented.
+    pub fn has_ocd(&self) -> bool {
+        self.is_supported(4)
+    }
+
+    /// Returns true if processor-internal instruction cache is implemented.
+    pub fn has_icache(&self) -> bool {
+        self.is_supported(5)
+    }
+
+    /// Returns true if processor-internal data cache is implemented.
+    pub fn has_dcache(&self) -> bool {
+        self.is_supported(6)
+    }
+
+    /// Returns true if on-chip debugger authentication is implemented.
+    pub fn has_ocd_auth(&self) -> bool {
+        self.is_supported(11)
+    }
+
+    /// Returns true if processor-internal IMEM is implemented as pre-initialized ROM.
+    pub fn has_imem_as_rom(&self) -> bool {
+        self.is_supported(12)
+    }
+
+    /// Returns true if TWD is implemented.
+    pub fn has_twd(&self) -> bool {
+        self.is_supported(13)
+    }
+
+    /// Returns true if DMA is implemented.
+    pub fn has_dma(&self) -> bool {
+        self.is_supported(14)
+    }
+
+    /// Returns true if GPIO is implemented.
+    pub fn has_gpio(&self) -> bool {
+        self.is_supported(15)
+    }
+
+    /// Returns true if CLINT is implemented.
+    pub fn has_clint(&self) -> bool {
+        self.is_supported(16)
+    }
+
+    /// Returns true if UART0 is implemented.
+    pub fn has_uart0(&self) -> bool {
+        self.is_supported(17)
+    }
+
+    /// Returns true if SPI is implemented.
+    pub fn has_spi(&self) -> bool {
+        self.is_supported(18)
+    }
+
+    /// Returns true if TWI is implemented.
+    pub fn has_twi(&self) -> bool {
+        self.is_supported(19)
+    }
+
+    /// Returns true if PWM is implemented.
+    pub fn has_pwm(&self) -> bool {
+        self.is_supported(20)
+    }
+
+    /// Returns true if WDT is implemented.
+    pub fn has_wdt(&self) -> bool {
+        self.is_supported(21)
+    }
+
+    /// Returns true if CFS is implemented.
+    pub fn has_cfs(&self) -> bool {
+        self.is_supported(22)
+    }
+
+    /// Returns true if TRNG is implemented.
+    pub fn has_trng(&self) -> bool {
+        self.is_supported(23)
+    }
+
+    /// Returns true if SDI is implemented.
+    pub fn has_sdi(&self) -> bool {
+        self.is_supported(24)
+    }
+
+    /// Returns true if UART1 is implemented.
+    pub fn has_uart1(&self) -> bool {
+        self.is_supported(25)
+    }
+
+    /// Returns true if NEOLED is implemented.
+    pub fn has_neoled(&self) -> bool {
+        self.is_supported(26)
+    }
+
+    /// Returns true if TRACER is implemented.
+    pub fn has_tracer(&self) -> bool {
+        self.is_supported(27)
+    }
+
+    /// Returns true if GPTMR is implemented.
+    pub fn has_gptmr(&self) -> bool {
+        self.is_supported(28)
+    }
+
+    /// Returns true if SLINK is implemented.
+    pub fn has_slink(&self) -> bool {
+        self.is_supported(29)
+    }
+
+    /// Returns true if ONEWIRE is implemented.
+    pub fn has_onewire(&self) -> bool {
+        self.is_supported(30)
+    }
+
+    /// Returns true if NEORV32 is being simulated.
+    pub fn is_simulation(&self) -> bool {
+        self.is_supported(31)
+    }
+}
+
+/// SysInfo driver
+#[derive(Clone, Copy, Debug)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+pub struct SysInfo;
+
+impl SysInfo {
+    /// Returns the main CPU clock frequency (Hz).
+    pub fn clock_freq() -> u32 {
+        reg().clk().read().bits()
+    }
+
+    /// Returns the IMEM size in bytes.
+    pub fn imem_size() -> u32 {
+        1 << reg().mem().read().sysinfo_misc_imem().bits()
+    }
+
+    /// Returns the DMEM size in bytes.
+    pub fn dmem_size() -> u32 {
+        1 << reg().mem().read().sysinfo_misc_dmem().bits()
+    }
+
+    /// Returns the number of harts (cores).
+    pub fn num_harts() -> u8 {
+        reg().mem().read().sysinfo_misc_hart().bits()
+    }
+
+    /// Returns the boot mode configuration.
+    pub fn boot_mode() -> BootMode {
+        let raw = reg().mem().read().sysinfo_misc_boot().bits();
+        BootMode::from(raw)
+    }
+
+    /// Returns the number of internal bus timeout cycles.
+    pub fn bus_itmo_cycles() -> u32 {
+        1 << reg().mem().read().sysinfo_misc_itmo().bits()
+    }
+
+    /// Returns the number of external bus timeout cycles.
+    pub fn bus_etmo_cycles() -> u32 {
+        1 << reg().mem().read().sysinfo_misc_etmo().bits()
+    }
+
+    /// Returns the SoC config.
+    ///
+    /// Additional methods can be called to check if SoC features are implemented.
+    pub fn soc_config() -> SocConfig {
+        SocConfig(reg().soc().read().bits())
+    }
+}
+
+fn reg() -> &'static crate::pac::sysinfo::RegisterBlock {
+    // SAFETY: We only use this pointer internally and do so safely
+    unsafe { &*crate::pac::Sysinfo::ptr() }
+}

--- a/embassy-neorv32/src/time_driver.rs
+++ b/embassy-neorv32/src/time_driver.rs
@@ -1,0 +1,92 @@
+//! Time Driver
+//!
+//! Uses the CLINT MTIMER peripheral to manage time.
+//! This is intended to work on both a single-hart and dual-hart configuration.
+//!
+//! In the case of dual-hart, hart 0 will always be the owner of time-keeping,
+//! and is solely responsible for handling timer interrupts and waking tasks
+//! as appropriate on both harts' executors.
+use core::cell::RefCell;
+
+use embassy_sync::blocking_mutex::Mutex;
+use embassy_sync::blocking_mutex::raw::CriticalSectionRawMutex;
+use embassy_time_driver::Driver;
+use embassy_time_queue_utils::Queue;
+
+embassy_time_driver::time_driver_impl!(static DRIVER: MtimerDriver = MtimerDriver {
+    queue: Mutex::new(RefCell::new(Queue::new()))
+});
+
+#[riscv_rt::core_interrupt(crate::pac::interrupt::CoreInterrupt::MachineTimer)]
+fn machine_timer_handler() {
+    DRIVER.on_interrupt()
+}
+
+struct MtimerDriver {
+    queue: Mutex<CriticalSectionRawMutex, RefCell<Queue>>,
+}
+
+impl MtimerDriver {
+    fn on_interrupt(&self) {
+        clint().mtimer().mtimecmp0().write(u64::MAX);
+
+        critical_section::with(|cs| {
+            let mut queue = self.queue.borrow(cs).borrow_mut();
+
+            let mut next = queue.next_expiration(self.now());
+            while !self.set_alarm(next) {
+                next = queue.next_expiration(self.now());
+            }
+        });
+    }
+
+    fn set_alarm(&self, ts: u64) -> bool {
+        // Timestamp is in the past, so can't set the alarm
+        if ts <= self.now() {
+            false
+        // Otherwise try to set the alarm but double check the ts isn't in the past again
+        } else {
+            clint().mtimer().mtimecmp0().write(ts);
+            ts > self.now()
+        }
+    }
+}
+
+pub(crate) fn init() {
+    // CLINT is used for timer interrupts which is necessary for time keeping
+    if !crate::sysinfo::SysInfo::soc_config().has_clint() {
+        panic!("CLINT must be supported for time-driver to work");
+    }
+
+    // Ensure only hart 0 initializes time-driver
+    assert_eq!(riscv::register::mhartid::read(), 0);
+
+    // Set the compare value far, far in the future so interrupt won't trigger yet
+    clint().mtimer().mtimecmp0().write(u64::MAX);
+
+    // SAFETY: It is okay to enable mtimer interrupts here
+    unsafe { clint().mtimer().enable() };
+}
+
+impl Driver for MtimerDriver {
+    fn now(&self) -> u64 {
+        clint().mtimer().mtime().read()
+    }
+
+    fn schedule_wake(&self, at: u64, waker: &core::task::Waker) {
+        critical_section::with(|cs| {
+            let mut queue = self.queue.borrow(cs).borrow_mut();
+            if queue.schedule_wake(at, waker) {
+                let mut next = queue.next_expiration(self.now());
+                while !self.set_alarm(next) {
+                    next = queue.next_expiration(self.now());
+                }
+            }
+        })
+    }
+}
+
+fn clint() -> crate::pac::Clint {
+    // SAFETY: We are the only ones who use mtimecmp0 and mtimer, so we can manage it safely
+    unsafe { crate::pac::Clint::steal() }
+}

--- a/embassy-neorv32/src/uart.rs
+++ b/embassy-neorv32/src/uart.rs
@@ -1,0 +1,960 @@
+//! Universal Asynchronous Receiver and Transmitter (UART)
+use core::future::poll_fn;
+use core::marker::PhantomData;
+use core::sync::atomic::{AtomicBool, Ordering};
+use core::task::Poll;
+
+use embassy_hal_internal::{Peri, PeripheralType};
+use embassy_sync::waitqueue::AtomicWaker;
+
+use crate::dma::{self, Dma};
+use crate::interrupt::typelevel::{Binding, Handler, Interrupt};
+use crate::peripherals::{UART0, UART1};
+
+/// UART interrupt handler binding.
+pub struct InterruptHandler<T: Instance> {
+    _phantom: PhantomData<T>,
+}
+
+impl<T: Instance> Handler<T::Interrupt> for InterruptHandler<T> {
+    unsafe fn on_interrupt() {
+        // If RX FIFO is not empty, disable RX not empty IRQ and wake RX task
+        let rx_nempty_irq_set = T::info().reg.ctrl().read().uart_ctrl_irq_rx_nempty().bit_is_set();
+        let rx_nempty = T::info().reg.ctrl().read().uart_ctrl_rx_nempty().bit_is_set();
+
+        if rx_nempty_irq_set && rx_nempty {
+            T::info()
+                .reg
+                .ctrl()
+                .modify(|_, w| w.uart_ctrl_irq_rx_nempty().clear_bit());
+            T::info().rx_waker.wake();
+        }
+
+        // If RX FIFO is full, disable RX full IRQ and wake RX task
+        let rx_full_irq_set = T::info().reg.ctrl().read().uart_ctrl_irq_rx_full().bit_is_set();
+        let rx_full = T::info().reg.ctrl().read().uart_ctrl_rx_full().bit_is_set();
+
+        if rx_full_irq_set && rx_full {
+            T::info()
+                .reg
+                .ctrl()
+                .modify(|_, w| w.uart_ctrl_irq_rx_full().clear_bit());
+            T::info().rx_waker.wake();
+        }
+
+        // If TX FIFO is empty, disable TX empty IRQ and wake TX task
+        let tx_empty_irq_set = T::info().reg.ctrl().read().uart_ctrl_irq_tx_empty().bit_is_set();
+        let tx_empty = T::info().reg.ctrl().read().uart_ctrl_tx_empty().bit_is_set();
+
+        if tx_empty_irq_set && tx_empty {
+            T::info()
+                .reg
+                .ctrl()
+                .modify(|_, w| w.uart_ctrl_irq_tx_empty().clear_bit());
+            T::info().tx_waker.wake();
+        }
+    }
+}
+
+/// UART error.
+#[derive(Clone, Copy, Debug)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+pub enum Error {
+    /// The NEORV32 configuration does not support UART.
+    NotSupported,
+    /// A DMA error occurred.
+    Dma(dma::Error),
+}
+
+impl core::fmt::Display for Error {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        match self {
+            Error::NotSupported => write!(f, "The NEORV32 configuration does not support UART"),
+            Error::Dma(e) => write!(f, "A DMA error occurred: {e:?}"),
+        }
+    }
+}
+
+impl core::error::Error for Error {}
+
+/// UART driver.
+pub struct Uart<'d, M: IoMode> {
+    rx: UartRx<'d, M>,
+    tx: UartTx<'d, M>,
+}
+
+impl<'d, M: IoMode> Uart<'d, M> {
+    fn init<T: Instance>(_instance: Peri<'d, T>, baud_rate: u32, sim: bool, flow_control: bool) {
+        // Enable simulation mode if applicable
+        if sim {
+            T::info().reg.ctrl().modify(|_, w| w.uart_ctrl_sim_mode().set_bit());
+        }
+
+        // Enable flow control if applicable
+        if flow_control {
+            T::info().reg.ctrl().modify(|_, w| w.uart_ctrl_hwfc_en().set_bit());
+        }
+
+        // baud div is max 10-bits wide
+        const U10_MAX: u16 = 0x3ff;
+        let cpu_freq = crate::sysinfo::SysInfo::clock_freq();
+        let mut baud_div = cpu_freq / (2 * baud_rate);
+        let mut prsc_sel = 0;
+
+        // Calculate clock prescaler and baud rate prescaler
+        // See: https://github.com/stnolting/neorv32/blob/main/sw/lib/source/neorv32_uart.c#L47
+        while baud_div >= U10_MAX as u32 {
+            if prsc_sel == 2 || prsc_sel == 4 {
+                baud_div >>= 3;
+            } else {
+                baud_div >>= 1;
+            }
+            prsc_sel += 1;
+        }
+
+        // Set the clock and baudrate prescalers
+        // SAFETY: The calculation above ensures we are writing valid prscv and baud div
+        T::info().reg.ctrl().modify(|_, w| unsafe {
+            w.uart_ctrl_prsc()
+                .bits(prsc_sel)
+                .uart_ctrl_baud()
+                .bits((baud_div as u16 - 1) & U10_MAX)
+        });
+
+        // Enable UART
+        T::info().reg.ctrl().modify(|_, w| w.uart_ctrl_en().set_bit());
+    }
+
+    fn new_inner<T: Instance>(rx_dma: Option<Dma<'d>>, tx_dma: Option<Dma<'d>>) -> Result<Self, Error> {
+        let rx = UartRx::new_inner::<T>(rx_dma)?;
+        let tx = UartTx::new_inner::<T>(tx_dma)?;
+        Ok(Self { rx, tx })
+    }
+
+    fn blocking_flush(&mut self) {
+        self.tx.blocking_flush();
+    }
+
+    /// Reads a byte from RX FIFO, blocking if empty.
+    pub fn blocking_read_byte(&self) -> u8 {
+        self.rx.blocking_read_byte()
+    }
+
+    /// Reads bytes from RX FIFO until buffer is full, blocking if empty.
+    pub fn blocking_read(&self, buf: &mut [u8]) {
+        self.rx.blocking_read(buf);
+    }
+
+    /// Writes a byte to TX FIFO, blocking if full.
+    pub fn blocking_write_byte(&mut self, byte: u8) {
+        self.tx.blocking_write_byte(byte);
+    }
+
+    /// Writes bytes to TX FIFO, blocking if full.
+    pub fn blocking_write(&mut self, bytes: &[u8]) {
+        self.tx.blocking_write(bytes);
+    }
+
+    /// Splits the UART driver into separate [`UartRx`] and [`UartTx`] drivers.
+    ///
+    /// Helpful for sharing the UART among receiver/transmitter tasks.
+    pub fn split(self) -> (UartRx<'d, M>, UartTx<'d, M>) {
+        (self.rx, self.tx)
+    }
+
+    /// Splits the UART driver into separate [`UartRx`] and [`UartTx`] drivers by mutable reference.
+    ///
+    /// Helpful for sharing the UART among receiver/transmitter tasks without destroying the original [`Uart`] instance.
+    pub fn split_ref(&mut self) -> (&mut UartRx<'d, M>, &mut UartTx<'d, M>) {
+        (&mut self.rx, &mut self.tx)
+    }
+}
+
+impl<'d> Uart<'d, Blocking> {
+    /// Creates a new blocking UART driver with given baud rate.
+    ///
+    /// Enables simulation mode if `sim` is true and hardware flow control if `flow_control` is true.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`Error::NotSupported`] if UART is not supported.
+    pub fn new_blocking<T: Instance>(
+        _instance: Peri<'d, T>,
+        baud_rate: u32,
+        sim: bool,
+        flow_control: bool,
+    ) -> Result<Self, Error> {
+        Self::init(_instance, baud_rate, sim, flow_control);
+        Self::new_inner::<T>(None, None)
+    }
+}
+
+impl<'d> Uart<'d, Async> {
+    fn new_async_inner<T: Instance>(
+        _instance: Peri<'d, T>,
+        baud_rate: u32,
+        sim: bool,
+        flow_control: bool,
+        rx_dma: Option<Dma<'d>>,
+        tx_dma: Option<Dma<'d>>,
+    ) -> Result<Self, Error> {
+        let uart = Self::new_inner::<T>(rx_dma, tx_dma)?;
+        Self::init(_instance, baud_rate, sim, flow_control);
+        // SAFETY: It is valid to enable UART interrupt here
+        unsafe { T::Interrupt::enable() }
+        Ok(uart)
+    }
+
+    fn flush(&mut self) -> impl Future<Output = ()> {
+        self.tx.flush()
+    }
+
+    /// Creates a new async UART driver with given baud rate.
+    ///
+    /// Enables simulation mode if `sim` is true and hardware flow control if `flow_control` is true.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`Error::NotSupported`] if UART is not supported.
+    pub fn new_async<T: Instance>(
+        _instance: Peri<'d, T>,
+        baud_rate: u32,
+        sim: bool,
+        flow_control: bool,
+        _irq: impl Binding<T::Interrupt, InterruptHandler<T>> + 'd,
+    ) -> Result<Self, Error> {
+        Self::new_async_inner(_instance, baud_rate, sim, flow_control, None, None)
+    }
+
+    /// Creates a new async UART driver with given baud rate.
+    ///
+    /// Enables simulation mode if `sim` is true and hardware flow control if `flow_control` is true.
+    ///
+    /// Additionally provides the DMA peripheral for TX transfers.
+    /// See [`UartTx::new_async_with_dma`] for considerations on whether to use DMA or not.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`Error::NotSupported`] if UART is not supported.
+    ///
+    /// Returns [`Error::Dma`] if DMA is not supported.
+    pub fn new_async_with_tx_dma<T: Instance, D: dma::Instance>(
+        _instance: Peri<'d, T>,
+        baud_rate: u32,
+        sim: bool,
+        flow_control: bool,
+        dma: Peri<'d, D>,
+        _irq: impl Binding<T::Interrupt, InterruptHandler<T>> + Binding<D::Interrupt, dma::InterruptHandler<D>> + 'd,
+    ) -> Result<Self, Error> {
+        let dma = dma::Dma::new(dma, _irq).map_err(Error::Dma)?;
+        Self::new_async_inner(_instance, baud_rate, sim, flow_control, None, Some(dma))
+    }
+
+    /// Creates a new async UART driver with given baud rate.
+    ///
+    /// Enables simulation mode if `sim` is true and hardware flow control if `flow_control` is true.
+    ///
+    /// Additionally provides the DMA peripheral for RX transfers.
+    /// See [`UartRx::new_async_with_dma`] for considerations on whether to use DMA or not.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`Error::NotSupported`] if UART is not supported.
+    ///
+    /// Returns [`Error::Dma`] if DMA is not supported.
+    pub fn new_async_with_rx_dma<T: Instance, D: dma::Instance>(
+        _instance: Peri<'d, T>,
+        baud_rate: u32,
+        sim: bool,
+        flow_control: bool,
+        dma: Peri<'d, D>,
+        _irq: impl Binding<T::Interrupt, InterruptHandler<T>> + Binding<D::Interrupt, dma::InterruptHandler<D>> + 'd,
+    ) -> Result<Self, Error> {
+        let dma = dma::Dma::new(dma, _irq).map_err(Error::Dma)?;
+        Self::new_async_inner(_instance, baud_rate, sim, flow_control, Some(dma), None)
+    }
+
+    /// Reads bytes from RX FIFO until buffer is full.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`Error::Dma`] if DMA error occurred during transfer.
+    pub fn read(&mut self, buf: &mut [u8]) -> impl Future<Output = Result<(), Error>> {
+        self.rx.read(buf)
+    }
+
+    /// Writes bytes from buffer to TX FIFO.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`Error::Dma`] if DMA error occurred during transfer.
+    pub fn write(&mut self, bytes: &[u8]) -> impl Future<Output = Result<(), Error>> {
+        self.tx.write(bytes)
+    }
+}
+
+/// RX-only UART driver.
+pub struct UartRx<'d, M: IoMode> {
+    info: Info,
+    fifo_depth: usize,
+    dma: Option<dma::Dma<'d>>,
+    _phantom: PhantomData<&'d M>,
+}
+
+// Allows for use in a Mutex (to share safely between harts and tasks)
+// Revisit: Is this actually safe?
+// SAFETY: This is a consequence of the register block generated by the PAC being !Sync,
+// and since we hold a reference to it that makes us !Send
+unsafe impl<'d, M: IoMode> Send for UartRx<'d, M> {}
+
+impl<'d, M: IoMode> UartRx<'d, M> {
+    fn new_inner<T: Instance>(dma: Option<dma::Dma<'d>>) -> Result<Self, Error> {
+        if !T::supported() {
+            return Err(Error::NotSupported);
+        }
+
+        // Mark RX as active
+        T::info().active.rx.store(true, Ordering::Release);
+
+        // FIFO depth is part of DATA register, which has side effects when read, so we do it once and cache it
+        // FIFO depth is bits 11:8 of DATA
+        // Revisit: The SVD does not define FIFO depths as separate fields. Upstream patch?
+        // This is used to chunk up DMA transfers into sizes that will fit in the FIFO
+        let fifo_depth = (T::info().reg.data().read().bits() >> 8) & (0b1111);
+        let fifo_depth = 1 << fifo_depth;
+
+        Ok(Self {
+            info: T::info(),
+            fifo_depth,
+            dma,
+            _phantom: PhantomData,
+        })
+    }
+
+    fn read_inner(&self) -> u8 {
+        self.info.reg.data().read().bits() as u8
+    }
+
+    fn enable_irq_rx_nempty(&mut self) {
+        self.info
+            .reg
+            .ctrl()
+            .modify(|_, w| w.uart_ctrl_irq_rx_nempty().set_bit());
+    }
+
+    fn enable_irq_rx_full(&mut self) {
+        self.info.reg.ctrl().modify(|_, w| w.uart_ctrl_irq_rx_full().set_bit());
+    }
+
+    fn fifo_empty(&self) -> bool {
+        self.info.reg.ctrl().read().uart_ctrl_rx_nempty().bit_is_clear()
+    }
+
+    fn fifo_full(&self) -> bool {
+        self.info.reg.ctrl().read().uart_ctrl_rx_full().bit_is_set()
+    }
+
+    /// Reads a byte from RX FIFO, blocking if empty.
+    pub fn blocking_read_byte(&self) -> u8 {
+        while self.fifo_empty() {}
+        self.read_inner()
+    }
+
+    /// Reads bytes from RX FIFO until buffer is full, blocking if empty.
+    pub fn blocking_read(&self, buf: &mut [u8]) {
+        for byte in buf {
+            *byte = self.blocking_read_byte();
+        }
+    }
+}
+
+impl<'d> UartRx<'d, Blocking> {
+    /// Creates a new RX-only blocking UART driver with given baud rate.
+    ///
+    /// Enables hardware flow control if `flow_control` is true.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`Error::NotSupported`] if UART is not supported.
+    pub fn new_blocking<T: Instance>(
+        _instance: Peri<'d, T>,
+        baud_rate: u32,
+        flow_control: bool,
+    ) -> Result<Self, Error> {
+        let uart = Self::new_inner::<T>(None)?;
+        Uart::<Blocking>::init(_instance, baud_rate, false, flow_control);
+        Ok(uart)
+    }
+}
+
+impl<'d> UartRx<'d, Async> {
+    async fn wait_fifo_nempty(&mut self) {
+        poll_fn(|cx| {
+            self.info.rx_waker.register(cx.waker());
+            if !self.fifo_empty() {
+                Poll::Ready(())
+            } else {
+                // CS used here since interrupt modifies register
+                critical_section::with(|_| self.enable_irq_rx_nempty());
+                Poll::Pending
+            }
+        })
+        .await
+    }
+
+    async fn wait_fifo_full(&mut self) {
+        poll_fn(|cx| {
+            self.info.rx_waker.register(cx.waker());
+            if self.fifo_full() {
+                Poll::Ready(())
+            } else {
+                // CS used here since interrupt modifies register
+                critical_section::with(|_| self.enable_irq_rx_full());
+                Poll::Pending
+            }
+        })
+        .await
+    }
+
+    async fn read_chunk(&mut self, chunk: &mut [u8]) -> Result<(), Error> {
+        // If DMA available, use it to transfer data from RX FIFO to buffer
+        if let Some(dma) = &mut self.dma {
+            let src = self.info.reg.data().as_ptr() as *const u8;
+            // SAFETY: The PAC ensures the data register pointer is not-null and properly aligned
+            let src = unsafe { src.as_ref().unwrap_unchecked() };
+            dma.read(src, chunk, false).await.map_err(Error::Dma)?;
+
+        // Otherwise, manually read each byte from RX FIFO
+        } else {
+            for byte in chunk {
+                *byte = self.read_inner();
+            }
+        }
+
+        Ok(())
+    }
+
+    fn new_async_inner<T: Instance>(
+        _instance: Peri<'d, T>,
+        baud_rate: u32,
+        flow_control: bool,
+        dma: Option<Dma<'d>>,
+    ) -> Result<Self, Error> {
+        let uart = Self::new_inner::<T>(dma)?;
+        Uart::<Async>::init(_instance, baud_rate, false, flow_control);
+        // SAFETY: It is valid to enable UART interrupt here
+        unsafe { T::Interrupt::enable() }
+        Ok(uart)
+    }
+
+    /// Creates a new RX-only async UART driver with given baud rate.
+    ///
+    /// Enables hardware flow control if `flow_control` is true.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`Error::NotSupported`] if UART is not supported.
+    pub fn new_async<T: Instance>(
+        _instance: Peri<'d, T>,
+        baud_rate: u32,
+        flow_control: bool,
+        _irq: impl Binding<T::Interrupt, InterruptHandler<T>> + 'd,
+    ) -> Result<Self, Error> {
+        Self::new_async_inner(_instance, baud_rate, flow_control, None)
+    }
+
+    /// Creates a new RX-only async UART driver with given baud rate.
+    ///
+    /// Enables hardware flow control if `flow_control` is true.
+    ///
+    /// Additionally provides the DMA peripheral for transfers.
+    ///
+    /// **Note**: The DMA peripheral is limited in that it is single-channel only so you have to
+    /// decide which peripheral (if any) will use it. Without DMA, the driver will manually
+    /// copy each byte into the FIFO. However, depending on the configured FIFO size and how many
+    /// bytes you are expecting to transfer, this may be more efficient as there is overhead in
+    /// setting up the DMA transfer.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`Error::NotSupported`] if UART is not supported.
+    ///
+    /// Returns [`Error::Dma`] if DMA is not supported.
+    pub fn new_async_with_dma<T: Instance, D: dma::Instance>(
+        _instance: Peri<'d, T>,
+        baud_rate: u32,
+        flow_control: bool,
+        dma: Peri<'d, D>,
+        _irq: impl Binding<T::Interrupt, InterruptHandler<T>> + Binding<D::Interrupt, dma::InterruptHandler<D>> + 'd,
+    ) -> Result<Self, Error> {
+        let dma = dma::Dma::new(dma, _irq).map_err(Error::Dma)?;
+        Self::new_async_inner(_instance, baud_rate, flow_control, Some(dma))
+    }
+
+    /// Reads bytes from RX FIFO until buffer is full.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`Error::Dma`] if DMA error occurred during transfer.
+    pub async fn read(&mut self, buf: &mut [u8]) -> Result<(), Error> {
+        let mut chunks = buf.chunks_exact_mut(self.fifo_depth);
+
+        // For chunks that match the FIFO depth, we can wait for FIFO full
+        // then read all bytes from the FIFO in one shot
+        for chunk in chunks.by_ref() {
+            self.wait_fifo_full().await;
+            self.read_chunk(chunk).await?;
+        }
+
+        // But for the remainder need to interrupt every time the FIFO is not empty
+        // and manually read a single byte
+        for byte in chunks.into_remainder() {
+            self.wait_fifo_nempty().await;
+            *byte = self.read_inner();
+        }
+
+        Ok(())
+    }
+}
+
+impl<'d, M: IoMode> Drop for UartRx<'d, M> {
+    fn drop(&mut self) {
+        self.info.active.rx.store(false, Ordering::Release);
+        drop_uart(&self.info);
+    }
+}
+
+/// TX-only UART driver.
+pub struct UartTx<'d, M: IoMode> {
+    info: Info,
+    fifo_depth: usize,
+    dma: Option<dma::Dma<'d>>,
+    _phantom: PhantomData<&'d M>,
+}
+
+// Allows for use in a Mutex (to share safely between harts and tasks)
+// Revisit: Is this actually safe?
+// SAFETY: This is a consequence of the register block generated by the PAC being !Sync,
+// and since we hold a reference to it that makes us !Send
+unsafe impl<'d, M: IoMode> Send for UartTx<'d, M> {}
+
+impl<'d, M: IoMode> UartTx<'d, M> {
+    fn new_inner<T: Instance>(dma: Option<dma::Dma<'d>>) -> Result<Self, Error> {
+        if !T::supported() {
+            return Err(Error::NotSupported);
+        }
+
+        // Mark TX as active
+        T::info().active.rx.store(true, Ordering::Release);
+
+        // FIFO depth is part of DATA register, which has side effects when read, so we do it once and cache it
+        // FIFO depth is bits 15:12 of DATA
+        // Revisit: The SVD does not define FIFO depths as separate fields. Upstream patch?
+        // This is used to chunk up DMA transfers into sizes that will fit in the FIFO
+        let fifo_depth = (T::info().reg.data().read().bits() >> 12) & (0b1111);
+        let fifo_depth = 1 << fifo_depth;
+
+        Ok(Self {
+            info: T::info(),
+            dma,
+            fifo_depth,
+            _phantom: PhantomData,
+        })
+    }
+
+    fn write_inner(&mut self, byte: u8) {
+        // SAFETY: We are just writing a byte, the MSB bits are read-only
+        self.info.reg.data().write(|w| unsafe { w.bits(byte as u32) });
+    }
+
+    fn enable_irq_tx_empty(&mut self) {
+        self.info.reg.ctrl().modify(|_, w| w.uart_ctrl_irq_tx_empty().set_bit());
+    }
+
+    fn fifo_full(&self) -> bool {
+        self.info.reg.ctrl().read().uart_ctrl_tx_nfull().bit_is_clear()
+    }
+
+    fn busy(&self) -> bool {
+        self.info.reg.ctrl().read().uart_ctrl_tx_busy().bit_is_set()
+    }
+
+    fn blocking_flush(&mut self) {
+        while self.busy() {}
+    }
+
+    /// Writes a byte to TX FIFO, blocking if full.
+    pub fn blocking_write_byte(&mut self, byte: u8) {
+        while self.fifo_full() {}
+        self.write_inner(byte);
+        self.blocking_flush();
+    }
+
+    /// Writes bytes to TX FIFO, blocking if full.
+    pub fn blocking_write(&mut self, bytes: &[u8]) {
+        for byte in bytes {
+            while self.fifo_full() {}
+            self.write_inner(*byte);
+        }
+        self.blocking_flush();
+    }
+}
+
+impl<'d> UartTx<'d, Blocking> {
+    /// Creates a new TX-only blocking UART driver with given baud rate.
+    ///
+    /// Enables simulation mode if `sim` is true and hardware flow control if `flow_control` is true.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`Error::NotSupported`] if UART is not supported.
+    pub fn new_blocking<T: Instance>(
+        _instance: Peri<'d, T>,
+        baud_rate: u32,
+        sim: bool,
+        flow_control: bool,
+    ) -> Result<Self, Error> {
+        let uart = Self::new_inner::<T>(None)?;
+        Uart::<Blocking>::init(_instance, baud_rate, sim, flow_control);
+        Ok(uart)
+    }
+}
+
+impl<'d> UartTx<'d, Async> {
+    async fn write_chunk(&mut self, chunk: &[u8]) -> Result<(), Error> {
+        // If DMA available, use it to transfer data from buffer to TX FIFO
+        if let Some(dma) = &mut self.dma {
+            let dst = self.info.reg.data().as_ptr() as *mut u8;
+            // SAFETY: The PAC ensures the data register pointer is not-null and properly aligned
+            let dst = unsafe { dst.as_mut().unwrap_unchecked() };
+            dma.write(chunk, dst, false).await.map_err(Error::Dma)?;
+
+        // Otherwise, manually write each byte to TX FIFO
+        } else {
+            for byte in chunk.iter().copied() {
+                self.write_inner(byte);
+            }
+        }
+
+        Ok(())
+    }
+
+    fn new_async_inner<T: Instance>(
+        _instance: Peri<'d, T>,
+        baud_rate: u32,
+        sim: bool,
+        flow_control: bool,
+        dma: Option<Dma<'d>>,
+    ) -> Result<Self, Error> {
+        let uart = Self::new_inner::<T>(dma)?;
+        Uart::<Async>::init(_instance, baud_rate, sim, flow_control);
+        // SAFETY: It is valid to enable UART interrupt here
+        unsafe { T::Interrupt::enable() }
+        Ok(uart)
+    }
+
+    async fn flush(&mut self) {
+        poll_fn(|cx| {
+            self.info.tx_waker.register(cx.waker());
+            if !self.busy() {
+                Poll::Ready(())
+            } else {
+                // CS used here since interrupt modifies register
+                critical_section::with(|_| self.enable_irq_tx_empty());
+                Poll::Pending
+            }
+        })
+        .await
+    }
+
+    /// Creates a new TX-only async UART driver with given baud rate.
+    ///
+    /// Enables simulation mode if `sim` is true and hardware flow control if `flow_control` is true.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`Error::NotSupported`] if UART is not supported.
+    pub fn new_async<T: Instance>(
+        _instance: Peri<'d, T>,
+        baud_rate: u32,
+        sim: bool,
+        flow_control: bool,
+        _irq: impl Binding<T::Interrupt, InterruptHandler<T>> + 'd,
+    ) -> Result<Self, Error> {
+        Self::new_async_inner(_instance, baud_rate, sim, flow_control, None)
+    }
+
+    /// Creates a new TX-only async UART driver with given baud rate.
+    ///
+    /// Enables simulation mode if `sim` is true and hardware flow control if `flow_control` is true.
+    ///
+    /// Additionally provides the DMA peripheral for transfers.
+    ///
+    /// **Note**: The DMA peripheral is limited in that it is single-channel only so you have to
+    /// decide which peripheral (if any) will use it. Without DMA, the driver will manually
+    /// copy each byte into the FIFO. However, depending on the configured FIFO size and how many
+    /// bytes you are expecting to transfer, this may be more efficient as there is overhead in
+    /// setting up the DMA transfer.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`Error::NotSupported`] if UART is not supported.
+    ///
+    /// Returns [`Error::Dma`] if DMA is not supported.
+    pub fn new_async_with_dma<T: Instance, D: dma::Instance>(
+        _instance: Peri<'d, T>,
+        baud_rate: u32,
+        sim: bool,
+        flow_control: bool,
+        dma: Peri<'d, D>,
+        _irq: impl Binding<T::Interrupt, InterruptHandler<T>> + Binding<D::Interrupt, dma::InterruptHandler<D>> + 'd,
+    ) -> Result<Self, Error> {
+        let dma = dma::Dma::new(dma, _irq).map_err(Error::Dma)?;
+        Self::new_async_inner(_instance, baud_rate, sim, flow_control, Some(dma))
+    }
+
+    /// Writes bytes from buffer to TX FIFO.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`Error::Dma`] if DMA error occurred during transfer.
+    pub async fn write(&mut self, bytes: &[u8]) -> Result<(), Error> {
+        for chunk in bytes.chunks(self.fifo_depth) {
+            self.write_chunk(chunk).await?;
+            self.flush().await;
+        }
+
+        Ok(())
+    }
+}
+
+impl<'d, M: IoMode> Drop for UartTx<'d, M> {
+    fn drop(&mut self) {
+        self.info.active.tx.store(false, Ordering::Release);
+        drop_uart(&self.info);
+    }
+}
+
+fn drop_uart(info: &Info) {
+    // Only disable UART if both Rx and Tx have been dropped
+    critical_section::with(|_| {
+        if !info.active.rx.load(Ordering::Acquire) && !info.active.tx.load(Ordering::Acquire) {
+            info.reg.ctrl().modify(|_, w| w.uart_ctrl_en().clear_bit());
+        }
+    })
+}
+
+// Serves as a "reference-counter" so we know when Uart is completely dropped
+// Use two AtomicBools instead of AtomicU8 since fetch_add/fetch_sub are not available without A extension
+struct Active {
+    rx: AtomicBool,
+    tx: AtomicBool,
+}
+
+impl Active {
+    const fn new() -> Self {
+        Self {
+            rx: AtomicBool::new(false),
+            tx: AtomicBool::new(false),
+        }
+    }
+}
+
+struct Info {
+    // Note: uart0 and uart1 can both share uart0::RegisterBlock
+    // PAC is able to coerce uart1::ptr() to it with correct base address
+    reg: &'static crate::pac::uart0::RegisterBlock,
+    active: &'static Active,
+    rx_waker: &'static AtomicWaker,
+    tx_waker: &'static AtomicWaker,
+}
+
+trait SealedIoMode {}
+
+/// UART IO mode.
+#[allow(private_bounds)]
+pub trait IoMode: SealedIoMode {}
+
+/// Blocking UART.
+pub struct Blocking;
+impl SealedIoMode for Blocking {}
+impl IoMode for Blocking {}
+
+/// Async UART.
+pub struct Async;
+impl SealedIoMode for Async {}
+impl IoMode for Async {}
+
+trait SealedInstance {
+    fn info() -> Info;
+    fn supported() -> bool;
+}
+
+/// A valid UART peripheral.
+#[allow(private_bounds)]
+pub trait Instance: SealedInstance + PeripheralType {
+    type Interrupt: Interrupt;
+}
+
+macro_rules! impl_instance {
+    ($periph:ident, $rb:ident, $soc_cfg:ident) => {
+        impl SealedInstance for $periph {
+            fn info() -> Info {
+                static RX_WAKER: AtomicWaker = AtomicWaker::new();
+                static TX_WAKER: AtomicWaker = AtomicWaker::new();
+                static ACTIVE: Active = Active::new();
+
+                Info {
+                    // SAFETY: We are the sole users of the pointer and are sure to use it safely
+                    reg: unsafe { &*crate::pac::$rb::ptr() },
+                    active: &ACTIVE,
+                    rx_waker: &RX_WAKER,
+                    tx_waker: &TX_WAKER,
+                }
+            }
+
+            fn supported() -> bool {
+                crate::sysinfo::SysInfo::soc_config().$soc_cfg()
+            }
+        }
+        impl Instance for $periph {
+            type Interrupt = crate::interrupt::typelevel::$periph;
+        }
+    };
+}
+
+impl_instance!(UART0, Uart0, has_uart0);
+impl_instance!(UART1, Uart1, has_uart1);
+
+// Convenience for writing formatted strings to UART
+impl<'d, M: IoMode> core::fmt::Write for Uart<'d, M> {
+    fn write_str(&mut self, s: &str) -> core::fmt::Result {
+        self.blocking_write(s.as_bytes());
+        Ok(())
+    }
+}
+
+impl<'d, M: IoMode> core::fmt::Write for UartTx<'d, M> {
+    fn write_str(&mut self, s: &str) -> core::fmt::Result {
+        self.blocking_write(s.as_bytes());
+        Ok(())
+    }
+}
+
+impl<'d, M: IoMode> embedded_hal_02::blocking::serial::Write<u8> for Uart<'d, M> {
+    type Error = core::convert::Infallible;
+
+    fn bwrite_all(&mut self, buffer: &[u8]) -> Result<(), Self::Error> {
+        self.blocking_write(buffer);
+        Ok(())
+    }
+
+    fn bflush(&mut self) -> Result<(), Self::Error> {
+        self.blocking_flush();
+        Ok(())
+    }
+}
+
+impl<'d, M: IoMode> embedded_hal_02::blocking::serial::Write<u8> for UartTx<'d, M> {
+    type Error = core::convert::Infallible;
+
+    fn bwrite_all(&mut self, buffer: &[u8]) -> Result<(), Self::Error> {
+        self.blocking_write(buffer);
+        Ok(())
+    }
+
+    fn bflush(&mut self) -> Result<(), Self::Error> {
+        self.blocking_flush();
+        Ok(())
+    }
+}
+
+impl embedded_io::Error for Error {
+    fn kind(&self) -> embedded_io::ErrorKind {
+        embedded_io::ErrorKind::Other
+    }
+}
+
+impl<'d, M: IoMode> embedded_io::ErrorType for Uart<'d, M> {
+    type Error = Error;
+}
+
+impl<'d, M: IoMode> embedded_io::Read for Uart<'d, M> {
+    fn read(&mut self, buf: &mut [u8]) -> Result<usize, Self::Error> {
+        self.blocking_read(buf);
+        Ok(buf.len())
+    }
+}
+
+impl<'d> embedded_io_async::Read for Uart<'d, Async> {
+    async fn read(&mut self, buf: &mut [u8]) -> Result<usize, Self::Error> {
+        self.read(buf).await.map(|_| buf.len())
+    }
+}
+
+impl<'d, M: IoMode> embedded_io::Write for Uart<'d, M> {
+    fn write(&mut self, buf: &[u8]) -> Result<usize, Self::Error> {
+        self.blocking_write(buf);
+        Ok(buf.len())
+    }
+
+    fn flush(&mut self) -> Result<(), Self::Error> {
+        self.blocking_flush();
+        Ok(())
+    }
+}
+
+impl<'d> embedded_io_async::Write for Uart<'d, Async> {
+    async fn write(&mut self, buf: &[u8]) -> Result<usize, Self::Error> {
+        self.write(buf).await.map(|_| buf.len())
+    }
+
+    async fn flush(&mut self) -> Result<(), Self::Error> {
+        self.flush().await;
+        Ok(())
+    }
+}
+
+impl<'d, M: IoMode> embedded_io::ErrorType for UartTx<'d, M> {
+    type Error = Error;
+}
+
+impl<'d, M: IoMode> embedded_io::Write for UartTx<'d, M> {
+    fn write(&mut self, buf: &[u8]) -> Result<usize, Self::Error> {
+        self.blocking_write(buf);
+        Ok(buf.len())
+    }
+
+    fn flush(&mut self) -> Result<(), Self::Error> {
+        self.blocking_flush();
+        Ok(())
+    }
+}
+
+impl<'d> embedded_io_async::Write for UartTx<'d, Async> {
+    async fn write(&mut self, buf: &[u8]) -> Result<usize, Self::Error> {
+        self.write(buf).await.map(|_| buf.len())
+    }
+
+    async fn flush(&mut self) -> Result<(), Self::Error> {
+        self.flush().await;
+        Ok(())
+    }
+}
+
+impl<'d, M: IoMode> embedded_io::ErrorType for UartRx<'d, M> {
+    type Error = Error;
+}
+
+impl<'d, M: IoMode> embedded_io::Read for UartRx<'d, M> {
+    fn read(&mut self, buf: &mut [u8]) -> Result<usize, Self::Error> {
+        self.blocking_read(buf);
+        Ok(buf.len())
+    }
+}
+
+impl<'d> embedded_io_async::Read for UartRx<'d, Async> {
+    async fn read(&mut self, buf: &mut [u8]) -> Result<usize, Self::Error> {
+        self.read(buf).await.map(|_| buf.len())
+    }
+}

--- a/examples/neorv32/.cargo/config.toml
+++ b/examples/neorv32/.cargo/config.toml
@@ -1,0 +1,25 @@
+[alias]
+# Run examples
+run-sim = "run --config .cargo/runner.sim.toml --no-default-features --features sim"
+run-fpga = "run --config .cargo/runner.fpga.toml --no-default-features --features fpga"
+
+# Build examples
+build-sim = "build --no-default-features --features sim"
+build-fpga = "build --no-default-features --features fpga"
+
+# Report binary size of examples
+size-sim = "size --no-default-features --features sim,"
+size-fpga = "size --no-default-features --features fpga"
+
+# Display symbols of examples
+nm-sim = "nm --no-default-features --features sim,"
+nm-fpga = "nm --no-default-features --features fpga"
+
+# Perform objdump on examples
+objdump-sim = "objdump --no-default-features --features sim,"
+objdump-fpga = "objdump --no-default-features --features fpga"
+
+# Target can be modified depending on which extensions your NEORV32 config supports
+# imc was chosen as a reasonable default (to improve code size) but the HAL supports a minimal rv32i
+[build]
+target = "riscv32imc-unknown-none-elf"

--- a/examples/neorv32/.cargo/runner.fpga.toml
+++ b/examples/neorv32/.cargo/runner.fpga.toml
@@ -1,0 +1,2 @@
+[target.'cfg(target_os = "none")']
+runner = "./run-fpga"

--- a/examples/neorv32/.cargo/runner.sim.toml
+++ b/examples/neorv32/.cargo/runner.sim.toml
@@ -1,0 +1,2 @@
+[target.'cfg(target_os = "none")']
+runner = "./run-sim"

--- a/examples/neorv32/Cargo.toml
+++ b/examples/neorv32/Cargo.toml
@@ -1,0 +1,42 @@
+[package]
+name = "embassy-neorv32-examples"
+version = "0.1.0"
+edition = "2024"
+license = "MIT OR Apache-2.0"
+publish = false
+
+[profile.release]
+lto = true
+codegen-units = 1
+debug = true
+opt-level = "z"
+panic = "abort"
+incremental = false
+
+[features]
+default = ["fpga"]
+
+# *Note*: The time-driver implementation relies on the CLINT mtimer which always runs at
+# CPU frequency. Unfortunately, embassy-time requires us to pick a fixed static tick rate,
+# so you MUST ensure this matches your configured CPU frequency.
+#
+# Supported tick rates: https://docs.embassy.dev/embassy-time/git/default/index.html#tick-rate
+fpga = ["embassy-time/tick-hz-50_000_000"]
+sim = ["embassy-time/tick-hz-100_000_000"]
+
+[dependencies]
+# Embassy support
+embassy-neorv32 = { version = "0.1.0", path = "../../embassy-neorv32" }
+embassy-time = { version = "0.5.0", path = "../../embassy-time" }
+embassy-executor = { version = "0.9.1", path = "../../embassy-executor", features = ["executor-thread", "arch-riscv32"] }
+embassy-sync = { version = "0.7.2", path = "../../embassy-sync" }
+
+# Runtime/arch support
+riscv = "0.16.0"
+riscv-rt = "0.17.0"
+
+[package.metadata.embassy]
+build = [
+  { target = "riscv32imc-unknown-none-elf", artifact-dir = "out/examples/neorv32" }
+]
+

--- a/examples/neorv32/build.rs
+++ b/examples/neorv32/build.rs
@@ -1,0 +1,16 @@
+use std::path::PathBuf;
+use std::{env, fs};
+
+fn main() {
+    let out_dir = PathBuf::from(env::var("OUT_DIR").unwrap());
+
+    // Put the linker script somewhere the linker can find it.
+    fs::write(out_dir.join("memory.x"), include_bytes!("memory.x")).unwrap();
+    println!("cargo:rustc-link-search={}", out_dir.display());
+    println!("cargo:rustc-link-arg-bins=-Tlink.x");
+    println!("cargo:rerun-if-changed=memory.x");
+    println!("cargo:rerun-if-changed=build.rs");
+
+    println!("cargo:rustc-env=RISCV_RT_BASE_ISA=rv32i");
+    println!("cargo:rerun-if-env-changed=RISCV_RT_BASE_ISA");
+}

--- a/examples/neorv32/memory.x
+++ b/examples/neorv32/memory.x
@@ -1,0 +1,16 @@
+MEMORY
+{
+  /* Lengths should match the values set in neorv32_tb. */
+  IMEM : ORIGIN = 0x00000000, LENGTH = 32K
+  DMEM : ORIGIN = 0x80000000, LENGTH = 8K
+}
+
+REGION_ALIAS("REGION_TEXT", IMEM);
+REGION_ALIAS("REGION_RODATA", IMEM);
+REGION_ALIAS("REGION_DATA", DMEM);
+REGION_ALIAS("REGION_BSS", DMEM);
+REGION_ALIAS("REGION_HEAP", DMEM);
+REGION_ALIAS("REGION_STACK", DMEM);
+
+/* There does not appear to be much harm in setting this to 1 even for single-hart configurations. */
+_max_hart_id = 1;

--- a/examples/neorv32/run-fpga
+++ b/examples/neorv32/run-fpga
@@ -1,0 +1,19 @@
+#!/bin/bash
+
+# Set this to your neorv32 repo path
+BASE="$HOME/neorv32"
+
+# convert ELF to raw bin
+rust-objcopy $1 -O binary "$1.bin"
+
+# `image_gen` seems to require bin be padded to nearest 4 byte
+truncate -s $(( (($(stat -c%s "$1.bin")+3)/4)*4 )) "$1.bin"
+
+# Convert bin to fpga bootloader bin format neorv32 expects
+"$BASE/sw/image_gen/image_gen" -i "$1.bin" -o "$1-fpga" -t app_bin
+
+# Make it easier to find binary in picocom by cd'ing to the correct folder it's in
+cd -- "$(dirname -- "$1")"
+
+# Connect to bootloader over serial using picocom
+sudo picocom /dev/ttyUSB0 -b 19200 --imap lfcrlf --omap crlf --send-cmd="ascii-xfr -s -n"

--- a/examples/neorv32/run-sim
+++ b/examples/neorv32/run-sim
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+# Set this to your neorv32 repo path
+BASE="$HOME/neorv32"
+
+# convert ELF to raw bin
+rust-objcopy $1 -O binary "$1.bin"
+
+# `image_gen` seems to require bin be padded to nearest 4 byte
+truncate -s $(( (($(stat -c%s "$1.bin")+3)/4)*4 )) "$1.bin"
+
+# Generate the VHD image then place it in neorv32 core
+"$BASE/sw/image_gen/image_gen" -i "$1.bin" -o neorv32_application_image.vhd -t app_vhd
+mv neorv32_application_image.vhd "$BASE/rtl/core"
+
+# Run neorv32 sim script
+sh "$BASE/sim/ghdl.sh"

--- a/examples/neorv32/src/bin/blinky.rs
+++ b/examples/neorv32/src/bin/blinky.rs
@@ -1,0 +1,26 @@
+#![no_std]
+#![no_main]
+
+#[cfg(feature = "sim")]
+compile_error!("Blinky example not available in simulation.");
+
+use embassy_neorv32::gpio::Gpio;
+use embassy_neorv32::uart::UartTx;
+use embassy_neorv32_examples::*;
+use embassy_time::Timer;
+
+#[embassy_executor::main]
+async fn main(_spawner: embassy_executor::Spawner) {
+    let p = embassy_neorv32::init();
+
+    let mut uart = UartTx::new_blocking(p.UART0, UART_BAUD, UART_IS_SIM, false).expect("UART must be supported");
+
+    let gpio = Gpio::new_blocking(p.GPIO).expect("GPIO must be supported");
+    let mut output = gpio.new_output(p.PORT0);
+
+    uart.blocking_write(b"Starting blinky example...\n");
+    loop {
+        output.toggle();
+        Timer::after_millis(100).await;
+    }
+}

--- a/examples/neorv32/src/bin/button.rs
+++ b/examples/neorv32/src/bin/button.rs
@@ -1,0 +1,30 @@
+#![no_std]
+#![no_main]
+
+#[cfg(feature = "sim")]
+compile_error!("Button example not available in simulation.");
+
+use embassy_neorv32::gpio::{self, Gpio};
+use embassy_neorv32::uart::UartTx;
+use embassy_neorv32::{bind_interrupts, peripherals};
+use embassy_neorv32_examples::*;
+
+bind_interrupts!(struct Irqs {
+    GPIO => gpio::InterruptHandler<peripherals::GPIO>;
+});
+
+#[embassy_executor::main]
+async fn main(_spawner: embassy_executor::Spawner) {
+    let p = embassy_neorv32::init();
+
+    let mut uart = UartTx::new_blocking(p.UART0, UART_BAUD, UART_IS_SIM, false).expect("UART must be supported");
+
+    let gpio = Gpio::new_async(p.GPIO, Irqs).expect("GPIO must be supported");
+    let mut input = gpio.new_input(p.PORT0);
+
+    uart.blocking_write(b"Starting button example...\n");
+    loop {
+        input.wait_for_falling_edge().await;
+        uart.blocking_write(b"Button press detected\n");
+    }
+}

--- a/examples/neorv32/src/bin/dma.rs
+++ b/examples/neorv32/src/bin/dma.rs
@@ -1,0 +1,36 @@
+#![no_std]
+#![no_main]
+
+use embassy_neorv32::dma::{self, Dma};
+use embassy_neorv32::uart::UartTx;
+use embassy_neorv32::{bind_interrupts, peripherals};
+use embassy_neorv32_examples::*;
+
+bind_interrupts!(struct Irqs {
+    DMA => dma::InterruptHandler<peripherals::DMA>;
+});
+
+#[embassy_executor::main]
+async fn main(_spawner: embassy_executor::Spawner) {
+    let p = embassy_neorv32::init();
+
+    let mut uart = UartTx::new_blocking(p.UART0, UART_BAUD, UART_IS_SIM, false).expect("UART must be supported");
+
+    // Note: DMA is single-channel only, so only one driver can own it.
+    // Typically you would instantiate the DMA driver instance directly like this
+    // only when you want to perform memory-to-memory transfers.
+    //
+    // If you want peripheral drivers (such as UART) to use DMA, you would pass `p.DMA` to their
+    // constructors.
+    let mut dma = Dma::new(p.DMA, Irqs).expect("DMA must be supported");
+
+    let src = [0xAAu8; 1024];
+    let mut dst = [0xFFu8; 1024];
+
+    let res = dma.copy(&src, &mut dst, false).await;
+    match res {
+        Ok(()) if src == dst => uart.blocking_write(b"DMA transfer succeeded\n"),
+        Err(_) => uart.blocking_write(b"DMA transfer encountered an error\n"),
+        _ => uart.blocking_write(b"DMA transfer failed\n"),
+    }
+}

--- a/examples/neorv32/src/bin/doors-of-durin.rs
+++ b/examples/neorv32/src/bin/doors-of-durin.rs
@@ -1,0 +1,42 @@
+#![no_std]
+#![no_main]
+
+#[cfg(feature = "sim")]
+compile_error!("Doors of Durin example not available in simulation.");
+
+use embassy_neorv32::uart::{self, Uart};
+use embassy_neorv32::{bind_interrupts, peripherals};
+use embassy_neorv32_examples::*;
+
+bind_interrupts!(struct Irqs {
+    UART0 => uart::InterruptHandler<peripherals::UART0>;
+});
+
+#[embassy_executor::main]
+async fn main(_spawner: embassy_executor::Spawner) {
+    let p = embassy_neorv32::init();
+
+    // Setup async UART with no DMA (since we aren't expecting large amounts of data)
+    let mut uart = Uart::new_async(p.UART0, UART_BAUD, UART_IS_SIM, false, Irqs).expect("UART must be supported");
+
+    let description = b"\
+    Before you appear the Doors of Durin, providing passage into Moria.\n\
+    Upon the doors is a single Elvish inscription, roughly translated as:\n\
+    Speak, friend, and enter.\n\n\
+    What do you say?\n\
+    ";
+    uart.write(description).await.unwrap();
+
+    // Read characters from player until buffer is full
+    let mut friend = [0; 6];
+    uart.read(&mut friend).await.unwrap();
+
+    // Did they speak the Elvish word for friend?
+    if let Ok(friend) = str::from_utf8(&friend)
+        && friend == "Mellon"
+    {
+        uart.write(b"The doors begin to open.\n").await.unwrap();
+    } else {
+        uart.write(b"The doors remain closed.\n").await.unwrap();
+    }
+}

--- a/examples/neorv32/src/bin/hello-world.rs
+++ b/examples/neorv32/src/bin/hello-world.rs
@@ -1,0 +1,77 @@
+#![no_std]
+#![no_main]
+
+use embassy_neorv32::uart::{self, UartTx};
+use embassy_neorv32::{bind_interrupts, dma, peripherals};
+use embassy_neorv32_examples::*;
+
+bind_interrupts!(struct Irqs {
+    UART0 => uart::InterruptHandler<peripherals::UART0>;
+    DMA => dma::InterruptHandler<peripherals::DMA>;
+});
+
+const ROWS: usize = 9;
+const COLS: usize = 7;
+const CHARS: usize = 16;
+
+// Ported to Rust from:
+// https://github.com/stnolting/neorv32/blob/main/sw/lib/source/neorv32_aux.c#L605
+// This just creates a neat NEORV32 logo :)
+const LOGO: [u8; (ROWS * (1 + (COLS * CHARS))) + 1] = {
+    const LOGO_RAW: [[u16; COLS]; ROWS] = [
+        [0x0000, 0x0000, 0x0000, 0x0000, 0x0000, 0x0300, 0xc630],
+        [0x60c7, 0xfc7f, 0x87f8, 0xc0c7, 0xf87f, 0x8303, 0xfffc],
+        [0xf0cc, 0x00c0, 0xcc0c, 0xc0cc, 0x0cc0, 0xc30f, 0x000f],
+        [0xd8cc, 0x00c0, 0xcc0c, 0xc0c0, 0x0c01, 0x8303, 0x1f8c],
+        [0xcccf, 0xf8c0, 0xcff8, 0xc0c0, 0xf806, 0x030f, 0x1f8f],
+        [0xc6cc, 0x00c0, 0xcc18, 0x6180, 0x0c18, 0x0303, 0x1f8c],
+        [0xc3cc, 0x00c0, 0xcc0c, 0x330c, 0x0c60, 0x030f, 0x000f],
+        [0xc187, 0xfc7f, 0x8c06, 0x0c07, 0xf8ff, 0xc303, 0xfffc],
+        [0x0000, 0x0000, 0x0000, 0x0000, 0x0000, 0x0300, 0xc630],
+    ];
+
+    let mut bytes = [0; (ROWS * (1 + (COLS * CHARS))) + 1];
+    let mut i = 0;
+    let mut row = 0;
+
+    while row < ROWS {
+        bytes[i] = b'\n';
+        i += 1;
+
+        let mut col = 0;
+        while col < COLS {
+            let mut tmp = LOGO_RAW[row][col];
+
+            let mut char = 0;
+            while char < CHARS {
+                bytes[i] = if (tmp as i16) < 0 { b'#' } else { b' ' };
+                i += 1;
+                tmp <<= 1;
+                char += 1;
+            }
+
+            col += 1;
+        }
+
+        row += 1;
+    }
+
+    bytes[i] = b'\n';
+    bytes
+};
+
+#[embassy_executor::main]
+async fn main(_spawner: embassy_executor::Spawner) {
+    let p = embassy_neorv32::init();
+
+    // Setup async UART (TX only) with DMA (since the logo has a lot of data to transfer)
+    let mut uart = UartTx::new_async_with_dma(p.UART0, UART_BAUD, UART_IS_SIM, false, p.DMA, Irqs)
+        .expect("UART and DMA must be supported");
+
+    uart.write(&LOGO).await.unwrap();
+
+    // Note: '\n' seems necessary for UART writes for sim to flush output
+    // Note 2: Now as of v.12.6 UART TX doesn't seem to flush at all until simulation reaches its stop-time :(
+    // So if in simulation mode, need to wait until stop time is reached before any output will be visual
+    uart.write(b"Hello world! :)\n").await.unwrap();
+}

--- a/examples/neorv32/src/bin/sysinfo.rs
+++ b/examples/neorv32/src/bin/sysinfo.rs
@@ -1,0 +1,123 @@
+#![no_std]
+#![no_main]
+
+use core::fmt::Write;
+
+use embassy_neorv32::sysinfo::SysInfo;
+use embassy_neorv32::uart::UartTx;
+use embassy_neorv32_examples::*;
+
+#[embassy_executor::main]
+async fn main(_spawner: embassy_executor::Spawner) {
+    let p = embassy_neorv32::init();
+
+    let mut uart = UartTx::new_blocking(p.UART0, UART_BAUD, UART_IS_SIM, false).expect("UART must be supported");
+
+    // Print clock frequency
+    writeln!(&mut uart, "Clock frequency: {} MHz", SysInfo::clock_freq() / 1_000_000).unwrap();
+
+    // Print memory sizes
+    writeln!(&mut uart, "IMEM size: {} KiB", SysInfo::imem_size() / 1024).unwrap();
+    writeln!(&mut uart, "DMEM size: {} KiB", SysInfo::dmem_size() / 1024).unwrap();
+
+    // Print misc info
+    writeln!(&mut uart, "Num harts: {}", SysInfo::num_harts()).unwrap();
+    writeln!(&mut uart, "Boot mode: {:?}", SysInfo::boot_mode()).unwrap();
+    writeln!(&mut uart, "Internal bus timeout cycles: {}", SysInfo::bus_itmo_cycles()).unwrap();
+    writeln!(&mut uart, "External bus timeout cycles: {}", SysInfo::bus_etmo_cycles()).unwrap();
+
+    // Retrieve SoC Config
+    let soc_config = SysInfo::soc_config();
+
+    // Print processor features
+    uart.blocking_write(b"\nProcessor Features:\n");
+    if soc_config.has_imem() {
+        uart.blocking_write(b"Internal IMEM\n");
+    }
+    if soc_config.has_dmem() {
+        uart.blocking_write(b"Internal DMEM\n");
+    }
+    if soc_config.has_icache() {
+        uart.blocking_write(b"Internal ICACHE\n");
+    }
+    if soc_config.has_dcache() {
+        uart.blocking_write(b"Internal DCACHE\n");
+    }
+    if soc_config.has_imem_as_rom() {
+        uart.blocking_write(b"Internal IMEM as pre-initialized ROM\n");
+    }
+    if soc_config.has_bootloader() {
+        uart.blocking_write(b"Internal bootloader\n");
+    }
+    if soc_config.has_xbus() {
+        uart.blocking_write(b"External bus interface (XBUS)\n");
+    }
+    if soc_config.has_ocd() {
+        uart.blocking_write(b"On-chip debugger\n");
+    }
+    if soc_config.has_ocd_auth() {
+        uart.blocking_write(b"On-chip debugger authentication\n");
+    }
+
+    // Print supported peripherals
+    uart.blocking_write(b"\nPeripherals Supported:\n");
+    if soc_config.has_uart0() {
+        uart.blocking_write(b"UART0\n");
+    }
+    if soc_config.has_uart1() {
+        uart.blocking_write(b"UART1\n");
+    }
+    if soc_config.has_twi() {
+        uart.blocking_write(b"TWI\n");
+    }
+    if soc_config.has_twd() {
+        uart.blocking_write(b"TWD\n");
+    }
+    if soc_config.has_spi() {
+        uart.blocking_write(b"SPI\n");
+    }
+    if soc_config.has_sdi() {
+        uart.blocking_write(b"SDI\n");
+    }
+    if soc_config.has_gptmr() {
+        uart.blocking_write(b"GPTMR\n");
+    }
+    if soc_config.has_gpio() {
+        uart.blocking_write(b"GPIO\n");
+    }
+    if soc_config.has_pwm() {
+        uart.blocking_write(b"PWM\n");
+    }
+    if soc_config.has_wdt() {
+        uart.blocking_write(b"WDT\n");
+    }
+    if soc_config.has_dma() {
+        uart.blocking_write(b"DMA\n");
+    }
+    if soc_config.has_trng() {
+        uart.blocking_write(b"TRNG\n");
+    }
+    if soc_config.has_onewire() {
+        uart.blocking_write(b"ONEWIRE\n");
+    }
+    if soc_config.has_neoled() {
+        uart.blocking_write(b"NEOLED\n");
+    }
+    if soc_config.has_tracer() {
+        uart.blocking_write(b"TRACER\n");
+    }
+    if soc_config.has_slink() {
+        uart.blocking_write(b"SLINK\n");
+    }
+    if soc_config.has_clint() {
+        uart.blocking_write(b"CLINT\n");
+    }
+    if soc_config.has_cfs() {
+        uart.blocking_write(b"CFS\n");
+    }
+
+    // Are we in a simulation?
+    if soc_config.is_simulation() {
+        uart.blocking_write(b"\nThe matrix has you.\n");
+    }
+}

--- a/examples/neorv32/src/lib.rs
+++ b/examples/neorv32/src/lib.rs
@@ -1,0 +1,44 @@
+#![no_std]
+
+#[cfg(all(feature = "sim", feature = "fpga"))]
+compile_error!("Only one of `sim` or `fpga` features must be enabled.");
+
+#[cfg(not(any(feature = "sim", feature = "fpga")))]
+compile_error!("At least one of `sim` or `fpga` features must be enabled.");
+
+/// Baud rate UART host expects.
+pub const UART_BAUD: u32 = 19200;
+
+/// Represents if the UART peripheral should enter simulation mode.
+///
+/// Note: In earlier versions of NEORV32 serial output would flush immediately in simulation mode,
+/// but as of v1.12.6 output doesn't seem to flush at all until stop-time is reached.
+#[cfg(feature = "sim")]
+pub const UART_IS_SIM: bool = true;
+#[cfg(feature = "fpga")]
+pub const UART_IS_SIM: bool = false;
+
+// A helpful custom panic handler for printing panic message over UART
+#[panic_handler]
+fn panic_handler(info: &core::panic::PanicInfo) -> ! {
+    use core::fmt::Write;
+
+    let hart = riscv::register::mhartid::read();
+    // SAFETY: Don't have a choice if we want to display the panic message,
+    // but worst that can happen is the UART output gets corrupted
+    let p = unsafe { embassy_neorv32::Peripherals::steal() };
+    if let Ok(mut uart) = embassy_neorv32::uart::UartTx::new_blocking(p.UART0, UART_BAUD, UART_IS_SIM, false) {
+        writeln!(
+            &mut uart,
+            "\n\nHART {} PANIC: {} at {}",
+            hart,
+            info.message(),
+            info.location().unwrap()
+        )
+        .unwrap();
+    }
+
+    loop {
+        riscv::asm::wfi();
+    }
+}

--- a/rust-toolchain-nightly.toml
+++ b/rust-toolchain-nightly.toml
@@ -8,6 +8,7 @@ targets = [
     "thumbv7em-none-eabihf",
     "thumbv8m.main-none-eabihf",
     "riscv32imac-unknown-none-elf",
+    "riscv32imc-unknown-none-elf",
     "wasm32-unknown-unknown",
     "armv7a-none-eabi",
 ]

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -8,6 +8,7 @@ targets = [
     "thumbv7em-none-eabihf",
     "thumbv8m.main-none-eabihf",
     "riscv32imac-unknown-none-elf",
+    "riscv32imc-unknown-none-elf",
     "wasm32-unknown-unknown",
     "armv7a-none-eabi",
     "armv7r-none-eabi",


### PR DESCRIPTION
This PR begins upstreaming [embassy-neorv32](https://github.com/kurtjd/neorv32-rs/tree/main/embassy-neorv32), a HAL for the open-source [NEORV32](https://github.com/stnolting/neorv32) RISC-V microcontroller.

While the NEORV32 is quite niche compared to some of the other supported families here, I think it would be cool to have upstream support for a RISC-V microcontroller, at least to help serve as a reference for others targeting RISC-V chips.

This initial PR includes UART and GPIO peripherals (with DMA and SysInfo pulled in since UART is dependent on them), but future PRs will be made for upstreaming more peripherals that I currently have supported (not included here to keep this relatively small for ease of reviewing).