### PR TITLE
[MCXA]: Don't read OsTimer before initialization

### DIFF
--- a/embassy-mcxa/src/lib.rs
+++ b/embassy-mcxa/src/lib.rs
@@ -467,15 +467,16 @@ pub fn init(cfg: crate::config::Config) -> Peripherals {
     // Configure clocks
     crate::clocks::init(cfg.clock_cfg).unwrap();
 
+    // Initialize embassy-time global driver backed by OSTIMER0
+    // NOTE: As early as possible, but MUST be before clocks!
+    crate::ostimer::init(cfg.time_interrupt_priority);
+
     unsafe {
         crate::gpio::interrupt_init();
     }
 
     // Initialize DMA controller (clock, reset, configuration)
     crate::dma::init();
-
-    // Initialize embassy-time global driver backed by OSTIMER0
-    crate::ostimer::init(cfg.time_interrupt_priority);
 
     // Enable GPIO clocks
     unsafe {


### PR DESCRIPTION
If we attempt to read the OsTimer prior to it being initialized, some kind of fault will occur.

https://github.com/embassy-rs/embassy/pull/5179 introduced a regression by enabling the `defmt-timestamp-uptime` feature, which caused prints in the SPLL setup to get the timestamp, causing a crash.

As a mitigation, we just return a time of zero until the OsTimer has actually been initialized.