### PR TITLE
mspm0: enable rx interrupts in buffered uart

### DIFF
--- a/embassy-mspm0/src/uart/buffered.rs
+++ b/embassy-mspm0/src/uart/buffered.rs
@@ -637,6 +637,10 @@ impl<'d> BufferedUart<'d> {
             self.tx.cts.is_some(),
         )?;
 
+        info.regs.cpu_int(0).imask().modify(|w| {
+            w.set_rxint(true);
+        });
+
         info.interrupt.unpend();
         unsafe { info.interrupt.enable() };
 
@@ -671,6 +675,10 @@ impl<'d> BufferedUartRx<'d> {
         init_buffers(info, state, None, Some(rx_buffer));
         super::enable(info.regs);
         super::configure(info, &self.state.state, config, true, self.rts.is_some(), false, false)?;
+
+        info.regs.cpu_int(0).imask().modify(|w| {
+            w.set_rxint(true);
+        });
 
         info.interrupt.unpend();
         unsafe { info.interrupt.enable() };
@@ -893,6 +901,10 @@ impl<'d> BufferedUartTx<'d> {
         init_buffers(info, state, Some(tx_buffer), None);
         super::enable(info.regs);
         super::configure(info, &state.state, config, false, false, true, self.cts.is_some())?;
+
+        info.regs.cpu_int(0).imask().modify(|w| {
+            w.set_rxint(true);
+        });
 
         info.interrupt.unpend();
         unsafe { info.interrupt.enable() };

--- a/examples/mspm0g3507/src/bin/uart_buffered.rs
+++ b/examples/mspm0g3507/src/bin/uart_buffered.rs
@@ -1,0 +1,53 @@
+//! Example of using buffered uart
+//!
+//! This uses the virtual COM port provided on the LP-MSPM0G3507 board.
+
+#![no_std]
+#![no_main]
+
+use defmt::*;
+use embassy_executor::Spawner;
+use embassy_mspm0::uart::{self, BufferedUart, Config};
+use embassy_mspm0::{bind_interrupts, peripherals};
+use embedded_io_async::{Read, Write};
+use {defmt_rtt as _, panic_halt as _};
+
+bind_interrupts!(
+    struct Irqs {
+        UART0 => uart::BufferedInterruptHandler<peripherals::UART0>;
+    }
+);
+
+#[embassy_executor::main]
+async fn main(_spawner: Spawner) -> ! {
+    info!("Hello world!");
+
+    let p = embassy_mspm0::init(Default::default());
+
+    let instance = p.UART0;
+    let tx = p.PA10;
+    let rx = p.PA11;
+    let mut tx_buf = [0u8; 32];
+    let mut rx_buf = [0u8; 32];
+
+    let config = Config::default();
+    let mut uart = unwrap!(BufferedUart::new(
+        instance,
+        tx,
+        rx,
+        Irqs,
+        &mut tx_buf,
+        &mut rx_buf,
+        config
+    ));
+
+    unwrap!(uart.blocking_write(b"Hello Embassy World (buffered)!\r\n"));
+    info!("wrote Hello, starting echo");
+
+    let mut buf = [0u8; 1];
+
+    loop {
+        unwrap!(uart.read(&mut buf).await);
+        unwrap!(uart.write(&buf).await);
+    }
+}


### PR DESCRIPTION
Without this, using the virtual COM port will not work.