### PR TITLE
stm32/timer: add set_period, improve psc/arr calc.

### DIFF
--- a/examples/stm32h7/src/bin/low_level_timer_api.rs
+++ b/examples/stm32h7/src/bin/low_level_timer_api.rs
@@ -5,7 +5,7 @@ use defmt::*;
 use embassy_executor::Spawner;
 use embassy_stm32::gpio::{AfType, Flex, OutputType, Speed};
 use embassy_stm32::time::{Hertz, khz};
-use embassy_stm32::timer::low_level::{OutputCompareMode, Timer as LLTimer};
+use embassy_stm32::timer::low_level::{OutputCompareMode, RoundTo, Timer as LLTimer};
 use embassy_stm32::timer::{Ch1, Ch2, Ch3, Ch4, Channel, GeneralInstance32bit4Channel, TimerPin};
 use embassy_stm32::{Config, Peri};
 use embassy_time::Timer;
@@ -123,7 +123,7 @@ impl<'d, T: GeneralInstance32bit4Channel> SimplePwm32<'d, T> {
     }
 
     pub fn set_frequency(&mut self, freq: Hertz) {
-        self.tim.set_frequency(freq);
+        self.tim.set_frequency(freq, RoundTo::Slower);
     }
 
     pub fn get_max_duty(&self) -> u32 {

--- a/examples/stm32l0/src/bin/dds.rs
+++ b/examples/stm32l0/src/bin/dds.rs
@@ -80,7 +80,7 @@ async fn main(_spawner: Spawner) {
     timer.set_counting_mode(CountingMode::EdgeAlignedUp);
 
     // set pwm sample frequency
-    timer.set_frequency(hz(15625));
+    timer.set_frequency(hz(15625), RoundTo::Slower);
 
     // enable outputs
     timer.enable_outputs();


### PR DESCRIPTION
- add set_period{,_ms,_us,_secs}. Allows setting non-integer hertz frequency.
- Add option to choose rounding mode if the exact requested period/freq can't be hit exactly (towards slower or towards faster timer).
- Fix panic when requested frequency is greater than the timer frequency.
