### PR TITLE
Better error message for missing HW-timer

### DIFF
--- a/embassy-stm32/build.rs
+++ b/embassy-stm32/build.rs
@@ -328,7 +328,9 @@ fn main() {
     let time_driver_irq_decl = if !time_driver_singleton.is_empty() {
         cfgs.enable(format!("time_driver_{}", time_driver_singleton.to_lowercase()));
 
-        let p = peripheral_map.get(time_driver_singleton).unwrap();
+        let Some(p) = peripheral_map.get(time_driver_singleton) else {
+            panic!("Tried to select {time_driver_singleton}, which is not available on this device");
+        };
         let irqs: BTreeSet<_> = p
             .interrupts
             .iter()


### PR DESCRIPTION
Replaced the default "called `Option::unwrap()` on a `None` value" with a more helpful message that informs the programmer that the selected timer is missing.

Code change suggested by James Munns, verified by me that it works.