### PR TITLE
onewire: Fix failure to detect some devices when multiple family codes are on a shared bus

### DIFF
--- a/embassy-rp/src/pio_programs/onewire.rs
+++ b/embassy-rp/src/pio_programs/onewire.rs
@@ -232,7 +232,7 @@ impl<'d, PIO: Instance, const SM: usize> PioOneWire<'d, PIO, SM> {
         let mut value = 0;
         let mut last_zero = 0;
 
-        // The original Dallas app note used 1-based bit numbering with 0 being a 
+        // The original Dallas app note used 1-based bit numbering with 0 being a
         // sentinel value (ie None).  This is important if you have sensors with
         // both 0 and 1 as LSB of the family code.
         for bit in 1..=64 {


### PR DESCRIPTION
The original Dallas Semiconductor flowchart for the search algorithm used 1-based numbering for the bits, with 0 being a sentinel value representing "No discrepancy" or "No last zero".

https://www.ifi-ed.tu-clausthal.de/fileadmin/IFI-ED/documents/Dokumentationen/1-wire/App187_1WSearch.pdf

Before this fix, the code was using 0-based numbering, but also considered the search finished when the last discrepancy was in bit 0.  

This caused issues when DS18B20 (Temperature Sensor) and DS2431 (EEPROM) devices were used on a single bus because the family codes (0x28 and 0x2d, respectively) differ in the LSB.  The code could detect either temperature sensors or EEPROMs correctly, but if both were on the bus then the temperature sensors would never be detected by the search.

I considered two other ways to fix this:
* Keep zero-based numbering but use -1 as the sentinel value
* Make it more Rusty with Option<u8> for last_zero and last_discrepancy

Because the existing code seemed to be following the Dallas Semi flowchart pretty closely, I felt that just adjusting the bit numbering was the simplest and kept the same spirit.  Happy to redo this with Option<> if we feel that's a better way.

This was tested on actual hardware with a Pi Pico 2W:

916.072381 [INFO ] Scanning bus (neti neti/src/one_wire_poller.rs:91)
916.101292 [INFO ] Found device: 7b03049779f9a428 (neti neti/src/one_wire_poller.rs:101)
916.130308 [INFO ] Found device: cd0000006ca51528 (neti neti/src/one_wire_poller.rs:101)
916.159256 [INFO ] Found device: 6b03049779d1ff28 (neti neti/src/one_wire_poller.rs:101)
916.188099 [INFO ] Found device: da000022c5057f2d (neti neti/src/one_wire_poller.rs:101)
