### PR TITLE
Fix PSRAM max_select timing (convert microseconds to femtoseconds and divide by 64 cycles)

### DIFF
--- a/embassy-rp/src/psram.rs
+++ b/embassy-rp/src/psram.rs
@@ -458,7 +458,7 @@ impl<'d> Psram<'d> {
         // - Max select must be <= 8 us. The value is given in multiples of 64 system clocks.
         // - Min deselect must be >= 18ns. The value is given in system clock cycles - ceil(divisor / 2).
         let clock_period_fs: u64 = 1_000_000_000_000_000_u64 / u64::from(clock_hz);
-        let max_select: u8 = ((config.max_select_us as u64 * 1_000_000) / clock_period_fs) as u8;
+        let max_select: u8 = (((config.max_select_us as u64 * 1_000_000_000) / clock_period_fs) / 64) as u8;
         let min_deselect: u32 = ((config.min_deselect_ns as u64 * 1_000_000 + (clock_period_fs - 1)) / clock_period_fs
             - u64::from(divisor + 1) / 2) as u32;
 


### PR DESCRIPTION
This PR fixes the `max_select` timing (https://github.com/embassy-rs/embassy/issues/5269) by correcting the units, improving memory performance.