### PR TITLE
Add ADC4 circular DMA support and temperature calibration for STM32WBA

### DIFF
--- a/embassy-stm32/src/adc/adc4.rs
+++ b/embassy-stm32/src/adc/adc4.rs
@@ -21,8 +21,108 @@ const MAX_ADC_CLK_FREQ: Hertz = Hertz::mhz(55);
 
 /// Default VREF voltage used for sample conversion to millivolts.
 pub const VREF_DEFAULT_MV: u32 = 3300;
-/// VREF voltage used for factory calibration of VREFINTCAL register.
-pub const VREF_CALIB_MV: u32 = 3300;
+/// VREF voltage used for factory calibration of VREFINTCAL and TSCAL registers (3.0V).
+pub const VREF_CALIB_MV: u32 = 3000;
+
+/// Temperature at which TS_CAL1 was measured (30°C).
+pub const TS_CAL1_TEMP_C: i32 = 30;
+/// Temperature at which TS_CAL2 was measured (130°C).
+pub const TS_CAL2_TEMP_C: i32 = 130;
+
+/// Factory calibration values read from the DESIG peripheral.
+///
+/// These values are programmed during manufacturing and can be used
+/// for accurate temperature and voltage measurements.
+#[derive(Clone, Copy, Debug)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+pub struct Calibration {
+    /// Temperature sensor calibration value at 30°C (12-bit).
+    pub ts_cal1: u16,
+    /// Temperature sensor calibration value at 130°C (12-bit).
+    pub ts_cal2: u16,
+    /// Internal voltage reference calibration value (12-bit).
+    /// Measured at VDDA = 3.0V.
+    pub vrefint_cal: u16,
+}
+
+impl Calibration {
+    /// Read factory calibration values from the DESIG and VREFINTCAL peripherals.
+    ///
+    /// These values are unique to each chip and were measured during manufacturing
+    /// at VDDA = 3.0V.
+    #[cfg(stm32wba)]
+    pub fn read() -> Self {
+        Self {
+            ts_cal1: pac::DESIG.tscal1r().read().ts_cal1(),
+            ts_cal2: pac::DESIG.tscal2r().read().ts_cal2(),
+            vrefint_cal: pac::VREFINTCAL.data().read().vrefint_cal(),
+        }
+    }
+
+    /// Convert a temperature sensor ADC reading to temperature in millidegrees Celsius.
+    ///
+    /// This function applies VDDA compensation using the VREFINT reading to account
+    /// for differences between the actual supply voltage and the 3.0V calibration voltage.
+    ///
+    /// # Arguments
+    /// * `ts_data` - Raw ADC reading from the temperature sensor channel
+    /// * `vrefint_data` - Raw ADC reading from the VREFINT channel (for VDDA compensation)
+    ///
+    /// # Returns
+    /// Temperature in millidegrees Celsius (e.g., 25000 = 25.000°C)
+    ///
+    /// # Example
+    /// ```ignore
+    /// let cal = Calibration::read();
+    /// let temp_mc = cal.convert_to_millicelsius(temp_adc_reading, vrefint_adc_reading);
+    /// let temp_c = temp_mc / 1000;
+    /// let temp_frac = (temp_mc % 1000).unsigned_abs();
+    /// info!("Temperature: {}.{:03} C", temp_c, temp_frac);
+    /// ```
+    pub fn convert_to_millicelsius(&self, ts_data: u32, vrefint_data: u32) -> i32 {
+        // Compensate TS_DATA for actual VDDA vs calibration VDDA (3.0V)
+        // TS_DATA_compensated = TS_DATA * VREFINT_CAL / VREFINT_DATA
+        let ts_data_comp = if vrefint_data > 0 {
+            (ts_data * self.vrefint_cal as u32) / vrefint_data
+        } else {
+            ts_data
+        };
+
+        // Use i32 for signed arithmetic (temperature can be negative)
+        let ts_data_comp = ts_data_comp as i32;
+        let ts_cal1 = self.ts_cal1 as i32;
+        let ts_cal2 = self.ts_cal2 as i32;
+
+        // Calculate temperature in millidegrees
+        // Temp_mC = TS_CAL1_TEMP * 1000 + (TS_CAL2_TEMP - TS_CAL1_TEMP) * 1000 * (TS_DATA - TS_CAL1) / (TS_CAL2 - TS_CAL1)
+        let delta_temp = (TS_CAL2_TEMP_C - TS_CAL1_TEMP_C) * 1000; // 100000 millidegrees
+        let delta_cal = ts_cal2 - ts_cal1;
+
+        if delta_cal == 0 {
+            // Avoid division by zero - return raw estimate
+            return ts_data_comp * 10;
+        }
+
+        TS_CAL1_TEMP_C * 1000 + (delta_temp * (ts_data_comp - ts_cal1)) / delta_cal
+    }
+
+    /// Calculate the actual VDDA voltage in millivolts using VREFINT.
+    ///
+    /// The formula is: VDDA = 3000mV × VREFINT_CAL / VREFINT_DATA
+    ///
+    /// # Arguments
+    /// * `vrefint_data` - Raw ADC reading from the VREFINT channel
+    ///
+    /// # Returns
+    /// Actual VDDA voltage in millivolts
+    pub fn calculate_vdda_mv(&self, vrefint_data: u32) -> u32 {
+        if vrefint_data > 0 {
+            (VREF_CALIB_MV * self.vrefint_cal as u32) / vrefint_data
+        } else {
+            VREF_DEFAULT_MV
+        }
+    }
+}
 
 impl super::SealedSpecialConverter<super::VrefInt> for crate::peripherals::ADC4 {
     const CHANNEL: u8 = 0;
@@ -129,25 +229,44 @@ impl AdcRegs for crate::pac::adc::Adc4 {
     }
 
     fn configure_dma(&self, conversion_mode: ConversionMode) {
+        // Clear overrun and conversion flags
+        self.isr().modify(|reg| {
+            reg.set_ovr(true);
+            reg.set_eos(true);
+            reg.set_eoc(true);
+        });
+
         match conversion_mode {
             ConversionMode::Singular => {
-                self.isr().modify(|reg| {
-                    reg.set_ovr(true);
-                    reg.set_eos(true);
-                    reg.set_eoc(true);
-                });
-
                 self.cfgr1().modify(|reg| {
                     reg.set_dmaen(true);
                     reg.set_dmacfg(Dmacfg::ONE_SHOT);
+                    reg.set_discen(false);
                     #[cfg(stm32u5)]
-                    reg.set_chselrmod(false);
+                    {
+                        reg.set_cont(false);
+                        reg.set_chselrmod(false);
+                    }
                     #[cfg(stm32wba)]
-                    reg.set_chselrmod(Chselrmod::ENABLE_INPUT)
+                    {
+                        reg.set_cont(Cont::SINGLE);
+                        reg.set_chselrmod(Chselrmod::ENABLE_INPUT);
+                    }
                 });
             }
             #[cfg(any(adc_v2, adc_g4, adc_v3, adc_g0, adc_u0))]
-            _ => unreachable!(),
+            ConversionMode::Repeated(_) => unreachable!(),
+            #[cfg(stm32wba)]
+            ConversionMode::Repeated(_mode) => {
+                // Configure for circular DMA with continuous conversion
+                self.cfgr1().modify(|reg| {
+                    reg.set_dmaen(true);
+                    reg.set_dmacfg(Dmacfg::CIRCULAR); // Enable circular DMA mode
+                    reg.set_cont(Cont::CONTINUOUS); // Enable continuous conversion
+                    reg.set_discen(false); // Disable discontinuous mode
+                    reg.set_chselrmod(Chselrmod::ENABLE_INPUT);
+                });
+            }
         }
     }
 
@@ -157,10 +276,33 @@ impl AdcRegs for crate::pac::adc::Adc4 {
         self.chselr().write_value(Chselr(0_u32));
         #[cfg(stm32u5)]
         self.chselrmod0().write_value(Chselr(0_u32));
+
+        #[cfg(stm32wba)]
+        let mut first_sample_time: Option<SampleTime> = None;
+
         for (_i, ((channel, _), sample_time)) in sequence.enumerate() {
+            // For STM32WBA: SMPR only has 2 sample time slots (SMP1, SMP2).
+            // We use SMP1 for all channels with the first channel's sample time.
+            // For STM32U5: Each channel can have its own sample time.
+            #[cfg(stm32u5)]
             self.smpr().modify(|w| {
                 w.set_smp(_i, sample_time);
             });
+
+            #[cfg(stm32wba)]
+            {
+                // Set SMP1 (index 0) with the first channel's sample time, use it for all channels
+                if first_sample_time.is_none() {
+                    first_sample_time = Some(sample_time);
+                    self.smpr().modify(|w| {
+                        w.set_smp(0, sample_time); // Index 0 = SMP1
+                    });
+                }
+                // Set SMPSEL for this channel to use SMP1
+                self.smpr().modify(|w| {
+                    w.set_smpsel(channel as usize, Smpsel::SMP1);
+                });
+            }
 
             let channel_num = channel;
             if channel_num as i16 <= prev_channel {

--- a/embassy-stm32/src/adc/mod.rs
+++ b/embassy-stm32/src/adc/mod.rs
@@ -17,7 +17,7 @@
 #[cfg_attr(adc_c0, path = "c0.rs")]
 mod _version;
 
-#[cfg(any(adc_v2, adc_g4, adc_v3, adc_g0, adc_u0))]
+#[cfg(any(adc_v2, adc_g4, adc_v3, adc_g0, adc_u0, adc_wba))]
 mod ringbuffered;
 
 use core::marker::PhantomData;
@@ -29,7 +29,7 @@ pub use _version::*;
 use embassy_hal_internal::PeripheralType;
 #[cfg(any(adc_f1, adc_f3v1, adc_v1, adc_l0, adc_f3v2))]
 use embassy_sync::waitqueue::AtomicWaker;
-#[cfg(any(adc_v2, adc_g4, adc_v3, adc_g0, adc_u0))]
+#[cfg(any(adc_v2, adc_g4, adc_v3, adc_g0, adc_u0, adc_wba))]
 pub use ringbuffered::RingBufferedAdc;
 
 #[cfg(adc_u5)]
@@ -170,12 +170,12 @@ pub(crate) enum ConversionMode {
     ))]
     Singular,
     // Should match the cfg on "into_ring_buffered" below
-    #[cfg(any(adc_v2, adc_g4, adc_v3, adc_g0, adc_u0))]
+    #[cfg(any(adc_v2, adc_g4, adc_v3, adc_g0, adc_u0, adc_wba))]
     Repeated(RegularConversionMode),
 }
 
 // Should match the cfg on "into_ring_buffered" below
-#[cfg(any(adc_v2, adc_g4, adc_v3, adc_g0, adc_u0))]
+#[cfg(any(adc_v2, adc_g4, adc_v3, adc_g0, adc_u0, adc_wba))]
 // Conversion mode for regular ADC channels
 #[derive(Copy, Clone)]
 pub enum RegularConversionMode {
@@ -296,7 +296,7 @@ impl<'d, T: Instance> Adc<'d, T> {
         T::regs().stop();
     }
 
-    #[cfg(any(adc_v2, adc_g4, adc_v3, adc_g0, adc_u0))]
+    #[cfg(any(adc_v2, adc_g4, adc_v3, adc_g0, adc_u0, adc_wba))]
     /// Configures the ADC to use a DMA ring buffer for continuous data acquisition.
     ///
     /// Use the [`read`] method to retrieve measurements from the DMA ring buffer. The read buffer

--- a/embassy-stm32/src/adc/ringbuffered.rs
+++ b/embassy-stm32/src/adc/ringbuffered.rs
@@ -21,10 +21,19 @@ pub struct RingBufferedAdc<'d, T: Instance> {
 
 impl<'d, T: Instance> RingBufferedAdc<'d, T> {
     pub(crate) fn new(dma: Peri<'d, impl RxDma<T>>, dma_buf: &'d mut [u16]) -> Self {
-        //dma side setup
+        // DMA side setup - configuration differs between DMA/BDMA and GPDMA
+        // For DMA/BDMA: use circular mode via TransferOptions
+        // For GPDMA: circular mode is achieved via linked-list ping-pong
+        #[cfg(not(gpdma))]
         let opts = TransferOptions {
             half_transfer_ir: true,
             circular: true,
+            ..Default::default()
+        };
+
+        #[cfg(gpdma)]
+        let opts = TransferOptions {
+            half_transfer_ir: true,
             ..Default::default()
         };
 

--- a/examples/stm32wba/src/bin/adc_ring_buffered.rs
+++ b/examples/stm32wba/src/bin/adc_ring_buffered.rs
@@ -1,0 +1,181 @@
+//! ADC Ring Buffered Example - True Circular DMA for ADC4 Internal Channels
+//!
+//! This example demonstrates continuous ADC sampling using circular DMA with
+//! GPDMA linked-list mode. The ADC continuously samples internal channels
+//! (VREFINT, VCORE, Temperature) at 5000 samples/sec per channel.
+//!
+//! Temperature is calculated using factory calibration values (TS_CAL1, TS_CAL2)
+//! from the DESIG peripheral for accurate readings.
+//!
+//! Sample rate calculation (48 MHz ADC clock):
+//! - CYCLES12_5 sample time + 12.5 conversion = 25 cycles per raw sample
+//! - Samples128 averaging: 128 × 25 = 3200 cycles per averaged result
+//! - 3 channels: 3200 × 3 = 9600 cycles per complete set
+//! - Rate: 48 MHz / 9600 = 5000 sets/sec
+
+#![no_std]
+#![no_main]
+
+use defmt::*;
+use embassy_stm32::Config;
+use embassy_stm32::adc::adc4::Calibration;
+use embassy_stm32::adc::{Adc, AdcChannel, RegularConversionMode, RingBufferedAdc, adc4};
+use embassy_stm32::peripherals::ADC4;
+use embassy_stm32::rcc::{
+    AHB5Prescaler, AHBPrescaler, APBPrescaler, PllDiv, PllMul, PllPreDiv, PllSource, Sysclk, VoltageScale,
+};
+use {defmt_rtt as _, panic_probe as _};
+
+// DMA buffer size - must be large enough to prevent overruns
+// Buffer holds: [vrefint, vcore, temp, vrefint, vcore, temp, ...]
+// Size should be a multiple of number of channels (3) and large enough for processing
+const DMA_BUF_LEN: usize = 3 * 256; // 256 samples per channel
+
+#[embassy_executor::main]
+async fn main(_spawner: embassy_executor::Spawner) {
+    // Configure RCC with PLL1 - required for ADC4 clock
+    let mut config = Config::default();
+    config.rcc.pll1 = Some(embassy_stm32::rcc::Pll {
+        source: PllSource::HSI,
+        prediv: PllPreDiv::DIV1,  // PLLM = 1 → HSI / 1 = 16 MHz
+        mul: PllMul::MUL30,       // PLLN = 30 → 16 MHz * 30 = 480 MHz VCO
+        divr: Some(PllDiv::DIV5), // PLLR = 5 → 96 MHz (Sysclk)
+        divq: None,
+        divp: Some(PllDiv::DIV30), // PLLP = 30 → 16 MHz (ADC4 clock source)
+        frac: Some(0),
+    });
+
+    config.rcc.ahb_pre = AHBPrescaler::DIV1;
+    config.rcc.apb1_pre = APBPrescaler::DIV1;
+    config.rcc.apb2_pre = APBPrescaler::DIV1;
+    config.rcc.apb7_pre = APBPrescaler::DIV1;
+    config.rcc.ahb5_pre = AHB5Prescaler::DIV4;
+    config.rcc.voltage_scale = VoltageScale::RANGE1;
+    config.rcc.sys = Sysclk::PLL1_R;
+
+    let p = embassy_stm32::init(config);
+
+    info!("STM32WBA ADC4 Ring Buffered Example - Circular DMA @ 5000 samples/sec with Calibrated Temperature");
+
+    // Read factory calibration values
+    let calibration = Calibration::read();
+    info!(
+        "Calibration values: TS_CAL1={} (30C), TS_CAL2={} (130C), VREFINT_CAL={}",
+        calibration.ts_cal1, calibration.ts_cal2, calibration.vrefint_cal
+    );
+
+    // Initialize ADC4 with appropriate settings
+    // Samples128 averaging with CYCLES12_5 = 5000 samples/sec per channel
+    let mut adc = Adc::new_adc4(p.ADC4);
+    adc.set_resolution_adc4(adc4::Resolution::BITS12);
+    adc.set_averaging_adc4(adc4::Averaging::Samples128);
+
+    let max_count = adc4::resolution_to_max_count(adc4::Resolution::BITS12);
+
+    // Enable internal channels
+    let vrefint = adc.enable_vrefint_adc4();
+    let temperature = adc.enable_temperature_adc4();
+    let vcore = adc.enable_vcore_adc4();
+
+    // Degrade to AnyAdcChannel for use with DMA
+    // IMPORTANT: Order matters for ADC4 - must be ascending channel numbers
+    // VrefInt: Channel 0, VCORE: Channel 12, Temperature: Channel 13
+    let vrefint_ch = vrefint.degrade_adc();
+    let vcore_ch = vcore.degrade_adc();
+    let temp_ch = temperature.degrade_adc();
+
+    info!("Internal channels enabled, setting up ring buffer...");
+
+    // Create DMA buffer - must be static for ring-buffered operation
+    static mut DMA_BUF: [u16; DMA_BUF_LEN] = [0u16; DMA_BUF_LEN];
+
+    // Create the ring-buffered ADC with continuous mode
+    // Channels must be in ascending order for ADC4
+    // CYCLES12_5 + Samples128 averaging = 5000 samples/sec per channel
+    let mut ring_adc: RingBufferedAdc<ADC4> = adc.into_ring_buffered(
+        p.GPDMA1_CH1,
+        unsafe { &mut *core::ptr::addr_of_mut!(DMA_BUF) },
+        [
+            (vrefint_ch, adc4::SampleTime::CYCLES12_5), // Channel 0
+            (vcore_ch, adc4::SampleTime::CYCLES12_5),   // Channel 12
+            (temp_ch, adc4::SampleTime::CYCLES12_5),    // Channel 13
+        ]
+        .into_iter(),
+        RegularConversionMode::Continuous,
+    );
+
+    info!("Ring buffer configured, starting continuous sampling...");
+
+    // Read buffer - must be half the size of DMA buffer
+    let mut measurements = [0u16; DMA_BUF_LEN / 2];
+
+    // Track iterations and accumulated values for periodic logging
+    let mut iteration_count: u32 = 0;
+    let mut accumulated_vrefint: u32 = 0;
+    let mut accumulated_vcore: u32 = 0;
+    let mut accumulated_temp: u32 = 0;
+    let mut total_samples: u32 = 0;
+
+    // Log every N iterations (~1 second at 5000 samples/sec)
+    // Half buffer = 128 sample sets, 5000/128 ≈ 39 reads/sec
+    const LOG_INTERVAL: u32 = 39;
+
+    loop {
+        // Read from ring buffer - this will return when half buffer is filled
+        // IMPORTANT: Read continuously without delay to prevent overruns
+        match ring_adc.read(&mut measurements).await {
+            Ok(_) => {
+                // Process measurements - they come in channel order repeated:
+                // [vrefint, vcore, temp, vrefint, vcore, temp, ...]
+                let num_samples = measurements.len() / 3;
+
+                // Accumulate samples for each channel
+                for i in 0..num_samples {
+                    accumulated_vrefint += measurements[i * 3] as u32;
+                    accumulated_vcore += measurements[i * 3 + 1] as u32;
+                    accumulated_temp += measurements[i * 3 + 2] as u32;
+                }
+                total_samples += num_samples as u32;
+
+                iteration_count += 1;
+
+                // Log periodically to avoid flooding output
+                if iteration_count >= LOG_INTERVAL {
+                    let vrefint_avg = accumulated_vrefint / total_samples;
+                    let vcore_avg = accumulated_vcore / total_samples;
+                    let temp_avg = accumulated_temp / total_samples;
+
+                    // Calculate actual VDDA and convert readings to millivolts
+                    let vdda_mv = calibration.calculate_vdda_mv(vrefint_avg);
+                    let vcore_mv = (vdda_mv * vcore_avg) / max_count;
+
+                    // Convert temperature using factory calibration with VDDA compensation
+                    let temp_mc = calibration.convert_to_millicelsius(temp_avg, vrefint_avg);
+                    let temp_c = temp_mc / 1000;
+                    let temp_frac = (temp_mc % 1000).unsigned_abs();
+
+                    info!(
+                        "Averaged {} samples: VDDA={} mV | VCORE={} mV | Temp={}.{:03} C",
+                        total_samples, vdda_mv, vcore_mv, temp_c, temp_frac
+                    );
+
+                    // Reset accumulators
+                    iteration_count = 0;
+                    accumulated_vrefint = 0;
+                    accumulated_vcore = 0;
+                    accumulated_temp = 0;
+                    total_samples = 0;
+                }
+            }
+            Err(_e) => {
+                warn!("DMA overrun error - consider increasing buffer size or reducing sample rate");
+                // Reset accumulators on error
+                iteration_count = 0;
+                accumulated_vrefint = 0;
+                accumulated_vcore = 0;
+                accumulated_temp = 0;
+                total_samples = 0;
+            }
+        }
+    }
+}

--- a/examples/stm32wba6/src/bin/adc_ring_buffered.rs
+++ b/examples/stm32wba6/src/bin/adc_ring_buffered.rs
@@ -1,0 +1,184 @@
+//! ADC Ring Buffered Example - True Circular DMA for ADC4 Internal Channels
+//!
+//! This example demonstrates continuous ADC sampling using circular DMA with
+//! GPDMA linked-list mode. The ADC continuously samples internal channels
+//! (VREFINT, VCORE, Temperature) with maximum quality settings.
+//!
+//! Temperature is calculated using factory calibration values (TS_CAL1, TS_CAL2)
+//! from the DESIG peripheral for accurate readings.
+//!
+//! Sample rate calculation (48 MHz ADC clock):
+//! - CYCLES79_5 sample time + 12.5 conversion = 92 cycles per raw sample
+//! - Samples256 averaging: 256 × 92 = 23,552 cycles per averaged result
+//! - 3 channels: 23,552 × 3 = 70,656 cycles per complete set
+//! - Rate: 48 MHz / 70,656 ≈ 679 sets/sec
+//!
+//! Using longest available sample time (1.66 µs) and maximum averaging for
+//! excellent accuracy on internal channels (VREFINT, Temperature).
+
+#![no_std]
+#![no_main]
+
+use defmt::*;
+use embassy_stm32::Config;
+use embassy_stm32::adc::adc4::Calibration;
+use embassy_stm32::adc::{Adc, AdcChannel, RegularConversionMode, RingBufferedAdc, adc4};
+use embassy_stm32::peripherals::ADC4;
+use embassy_stm32::rcc::{
+    AHB5Prescaler, AHBPrescaler, APBPrescaler, PllDiv, PllMul, PllPreDiv, PllSource, Sysclk, VoltageScale,
+};
+use {defmt_rtt as _, panic_probe as _};
+
+// DMA buffer size - must be large enough to prevent overruns
+// Buffer holds: [vrefint, vcore, temp, vrefint, vcore, temp, ...]
+// Size should be a multiple of number of channels (3) and large enough for processing
+const DMA_BUF_LEN: usize = 3 * 256; // 256 samples per channel
+
+#[embassy_executor::main]
+async fn main(_spawner: embassy_executor::Spawner) {
+    // Configure RCC with PLL1 - required for ADC4 clock
+    let mut config = Config::default();
+    config.rcc.pll1 = Some(embassy_stm32::rcc::Pll {
+        source: PllSource::HSI,
+        prediv: PllPreDiv::DIV1,  // PLLM = 1 → HSI / 1 = 16 MHz
+        mul: PllMul::MUL30,       // PLLN = 30 → 16 MHz * 30 = 480 MHz VCO
+        divr: Some(PllDiv::DIV5), // PLLR = 5 → 96 MHz (Sysclk)
+        divq: None,
+        divp: Some(PllDiv::DIV30), // PLLP = 30 → 16 MHz (ADC4 clock source)
+        frac: Some(0),
+    });
+
+    config.rcc.ahb_pre = AHBPrescaler::DIV1;
+    config.rcc.apb1_pre = APBPrescaler::DIV1;
+    config.rcc.apb2_pre = APBPrescaler::DIV1;
+    config.rcc.apb7_pre = APBPrescaler::DIV1;
+    config.rcc.ahb5_pre = AHB5Prescaler::DIV4;
+    config.rcc.voltage_scale = VoltageScale::RANGE1;
+    config.rcc.sys = Sysclk::PLL1_R;
+
+    let p = embassy_stm32::init(config);
+
+    info!("STM32WBA6 ADC4 Ring Buffered Example - Circular DMA with Calibrated Temperature");
+
+    // Read factory calibration values
+    let calibration = Calibration::read();
+    info!(
+        "Calibration values: TS_CAL1={} (30C), TS_CAL2={} (130C), VREFINT_CAL={}",
+        calibration.ts_cal1, calibration.ts_cal2, calibration.vrefint_cal
+    );
+
+    // Initialize ADC4 with appropriate settings
+    // Maximum averaging (Samples256) with longest sample time for best accuracy
+    let mut adc = Adc::new_adc4(p.ADC4);
+    adc.set_resolution_adc4(adc4::Resolution::BITS12);
+    adc.set_averaging_adc4(adc4::Averaging::Samples256);
+
+    let max_count = adc4::resolution_to_max_count(adc4::Resolution::BITS12);
+
+    // Enable internal channels
+    let vrefint = adc.enable_vrefint_adc4();
+    let temperature = adc.enable_temperature_adc4();
+    let vcore = adc.enable_vcore_adc4();
+
+    // Degrade to AnyAdcChannel for use with DMA
+    // IMPORTANT: Order matters for ADC4 - must be ascending channel numbers
+    // VrefInt: Channel 0, VCORE: Channel 12, Temperature: Channel 13
+    let vrefint_ch = vrefint.degrade_adc();
+    let vcore_ch = vcore.degrade_adc();
+    let temp_ch = temperature.degrade_adc();
+
+    info!("Internal channels enabled, setting up ring buffer...");
+
+    // Create DMA buffer - must be static for ring-buffered operation
+    static mut DMA_BUF: [u16; DMA_BUF_LEN] = [0u16; DMA_BUF_LEN];
+
+    // Create the ring-buffered ADC with continuous mode
+    // Channels must be in ascending order for ADC4
+    // CYCLES79_5 (1.66 µs) - longest available sample time for internal channels
+    let mut ring_adc: RingBufferedAdc<ADC4> = adc.into_ring_buffered(
+        p.GPDMA1_CH1,
+        unsafe { &mut *core::ptr::addr_of_mut!(DMA_BUF) },
+        [
+            (vrefint_ch, adc4::SampleTime::CYCLES79_5), // Channel 0 - VREFINT
+            (vcore_ch, adc4::SampleTime::CYCLES79_5),   // Channel 12 - VCORE
+            (temp_ch, adc4::SampleTime::CYCLES79_5),    // Channel 13 - Temperature
+        ]
+        .into_iter(),
+        RegularConversionMode::Continuous,
+    );
+
+    info!("Ring buffer configured, starting continuous sampling...");
+
+    // Read buffer - must be half the size of DMA buffer
+    let mut measurements = [0u16; DMA_BUF_LEN / 2];
+
+    // Track iterations and accumulated values for periodic logging
+    let mut iteration_count: u32 = 0;
+    let mut accumulated_vrefint: u32 = 0;
+    let mut accumulated_vcore: u32 = 0;
+    let mut accumulated_temp: u32 = 0;
+    let mut total_samples: u32 = 0;
+
+    // Log every N iterations (~1 second at ~679 samples/sec)
+    // Half buffer = 128 sample sets, 679/128 ≈ 5.3 reads/sec
+    const LOG_INTERVAL: u32 = 5;
+
+    loop {
+        // Read from ring buffer - this will return when half buffer is filled
+        // IMPORTANT: Read continuously without delay to prevent overruns
+        match ring_adc.read(&mut measurements).await {
+            Ok(_) => {
+                // Process measurements - they come in channel order repeated:
+                // [vrefint, vcore, temp, vrefint, vcore, temp, ...]
+                let num_samples = measurements.len() / 3;
+
+                // Accumulate samples for each channel
+                for i in 0..num_samples {
+                    accumulated_vrefint += measurements[i * 3] as u32;
+                    accumulated_vcore += measurements[i * 3 + 1] as u32;
+                    accumulated_temp += measurements[i * 3 + 2] as u32;
+                }
+                total_samples += num_samples as u32;
+
+                iteration_count += 1;
+
+                // Log periodically to avoid flooding output
+                if iteration_count >= LOG_INTERVAL {
+                    let vrefint_avg = accumulated_vrefint / total_samples;
+                    let vcore_avg = accumulated_vcore / total_samples;
+                    let temp_avg = accumulated_temp / total_samples;
+
+                    // Calculate actual VDDA and convert readings to millivolts
+                    let vdda_mv = calibration.calculate_vdda_mv(vrefint_avg);
+                    let vcore_mv = (vdda_mv * vcore_avg) / max_count;
+
+                    // Convert temperature using factory calibration with VDDA compensation
+                    let temp_mc = calibration.convert_to_millicelsius(temp_avg, vrefint_avg);
+                    let temp_c = temp_mc / 1000;
+                    let temp_frac = (temp_mc % 1000).unsigned_abs();
+
+                    info!(
+                        "Averaged {} samples: VDDA={} mV | VCORE={} mV | Temp={}.{:03} C",
+                        total_samples, vdda_mv, vcore_mv, temp_c, temp_frac
+                    );
+
+                    // Reset accumulators
+                    iteration_count = 0;
+                    accumulated_vrefint = 0;
+                    accumulated_vcore = 0;
+                    accumulated_temp = 0;
+                    total_samples = 0;
+                }
+            }
+            Err(_e) => {
+                warn!("DMA overrun error - consider increasing buffer size or reducing sample rate");
+                // Reset accumulators on error
+                iteration_count = 0;
+                accumulated_vrefint = 0;
+                accumulated_vcore = 0;
+                accumulated_temp = 0;
+                total_samples = 0;
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- Implement true circular DMA for ADC4 using GPDMA linked-list mode with continuous conversion
- Add `Calibration` struct to `adc4` module for reading factory calibration values (TS_CAL1, TS_CAL2, VREFINT_CAL) from DESIG peripheral
- Add `convert_to_millicelsius()` for VDDA-compensated temperature conversion using the standard STM32 formula
- Add `calculate_vdda_mv()` to compute actual supply voltage from VREFINT readings
- Fix VREF_CALIB_MV constant to 3000mV (calibration voltage per datasheet)
- Add ring-buffered ADC examples for stm32wba and stm32wba6