### PR TITLE
stm32 i2c v1 - expose async receive_byte and transmit_byte functions

### DIFF
--- a/embassy-stm32/src/i2c/mod.rs
+++ b/embassy-stm32/src/i2c/mod.rs
@@ -12,7 +12,7 @@ use core::iter;
 use core::marker::PhantomData;
 
 #[cfg(i2c_v1)]
-pub use _version::ReceiveResult;
+pub use _version::{ReceiveResult, TransmitResult};
 pub use config::*;
 use embassy_hal_internal::Peri;
 use embassy_sync::waitqueue::AtomicWaker;

--- a/embassy-stm32/src/i2c/mod.rs
+++ b/embassy-stm32/src/i2c/mod.rs
@@ -11,6 +11,8 @@ use core::future::Future;
 use core::iter;
 use core::marker::PhantomData;
 
+#[cfg(i2c_v1)]
+pub use _version::ReceiveResult;
 pub use config::*;
 use embassy_hal_internal::Peri;
 use embassy_sync::waitqueue::AtomicWaker;


### PR DESCRIPTION
This is part of my efforts to use a stm32 to emulate a MCP23017. Related: 
- https://github.com/stm32-rs/stm32f1xx-hal/discussions/558
- #5260 

Emulating a MCP23017 involves processing reads and writes where the amount of data read or written is not known in advance. This is why I (am pretty sure) I need single byte functions to process read and write requests.

Some things that I think need to be reviewed:
- Is it ok to expose thse functions as `pub`?
- Did I implement the async properly (I copied and pasted from the async `listen` fn)? 
- Is it okay  to not handle zero byte reads?

I am using these changes in my MCP23017 emulator project and they work.