### PR TITLE
stm32: add async flash support for G0/G4

### DIFF
--- a/embassy-stm32/src/flash/g.rs
+++ b/embassy-stm32/src/flash/g.rs
@@ -1,15 +1,41 @@
 use core::ptr::write_volatile;
+#[cfg(any(flash_g4c2, flash_g4c3, flash_g4c4))]
+use core::sync::atomic::AtomicBool;
 use core::sync::atomic::{Ordering, fence};
 
 use cortex_m::interrupt;
+use embassy_sync::waitqueue::AtomicWaker;
+use pac::flash::regs::Sr;
 
 use super::{FlashSector, WRITE_SIZE};
 use crate::flash::Error;
 use crate::pac;
 
+static WAKER: AtomicWaker = AtomicWaker::new();
+
+// G4 has data cache that needs to be handled during flash operations
+#[cfg(any(flash_g4c2, flash_g4c3, flash_g4c4))]
+static DATA_CACHE_WAS_ENABLED: AtomicBool = AtomicBool::new(false);
+
+pub(crate) unsafe fn on_interrupt() {
+    // Clear IRQ flags (EOP and error flags are write-1-to-clear)
+    pac::FLASH.sr().write(|w| {
+        w.set_eop(true);
+        w.set_operr(true);
+        w.set_progerr(true);
+        w.set_wrperr(true);
+        w.set_pgaerr(true);
+        w.set_sizerr(true);
+        w.set_pgserr(true);
+    });
+
+    WAKER.wake();
+}
+
 pub(crate) unsafe fn lock() {
     pac::FLASH.cr().modify(|w| w.set_lock(true));
 }
+
 pub(crate) unsafe fn unlock() {
     // Wait, while the memory interface is busy.
     wait_busy();
@@ -21,16 +47,48 @@ pub(crate) unsafe fn unlock() {
     }
 }
 
+pub(crate) unsafe fn enable_write() {
+    assert_eq!(0, WRITE_SIZE % 4);
+    save_data_cache_state();
+
+    pac::FLASH.cr().write(|w| {
+        w.set_pg(true);
+        w.set_eopie(true);
+        w.set_errie(true);
+    });
+}
+
+pub(crate) unsafe fn disable_write() {
+    pac::FLASH.cr().write(|w| {
+        w.set_pg(false);
+        w.set_eopie(false);
+        w.set_errie(false);
+    });
+    restore_data_cache_state();
+}
+
 pub(crate) unsafe fn enable_blocking_write() {
     assert_eq!(0, WRITE_SIZE % 4);
+    save_data_cache_state();
     pac::FLASH.cr().write(|w| w.set_pg(true));
 }
 
 pub(crate) unsafe fn disable_blocking_write() {
     pac::FLASH.cr().write(|w| w.set_pg(false));
+    restore_data_cache_state();
+}
+
+pub(crate) async unsafe fn write(start_address: u32, buf: &[u8; WRITE_SIZE]) -> Result<(), Error> {
+    write_start(start_address, buf);
+    wait_ready().await
 }
 
 pub(crate) unsafe fn blocking_write(start_address: u32, buf: &[u8; WRITE_SIZE]) -> Result<(), Error> {
+    write_start(start_address, buf);
+    wait_ready_blocking()
+}
+
+unsafe fn write_start(start_address: u32, buf: &[u8; WRITE_SIZE]) {
     let mut address = start_address;
     for val in buf.chunks(4) {
         write_volatile(address as *mut u32, u32::from_le_bytes(unwrap!(val.try_into())));
@@ -39,13 +97,45 @@ pub(crate) unsafe fn blocking_write(start_address: u32, buf: &[u8; WRITE_SIZE]) 
         // prevents parallelism errors
         fence(Ordering::SeqCst);
     }
+}
 
-    wait_ready_blocking()
+pub(crate) async unsafe fn erase_sector(sector: &FlashSector) -> Result<(), Error> {
+    wait_busy();
+    clear_all_err();
+    save_data_cache_state();
+
+    interrupt::free(|_| {
+        pac::FLASH.cr().modify(|w| {
+            w.set_per(true);
+            #[cfg(any(flash_g0x0, flash_g0x1, flash_g4c3))]
+            w.set_bker(sector.bank == crate::flash::FlashBank::Bank2);
+            #[cfg(flash_g0x0)]
+            w.set_pnb(sector.index_in_bank as u16);
+            #[cfg(not(flash_g0x0))]
+            w.set_pnb(sector.index_in_bank as u8);
+            w.set_eopie(true);
+            w.set_errie(true);
+            w.set_strt(true);
+        });
+    });
+
+    let ret: Result<(), Error> = wait_ready().await;
+
+    pac::FLASH.cr().modify(|w| {
+        w.set_per(false);
+        w.set_eopie(false);
+        w.set_errie(false);
+    });
+    clear_all_err();
+    restore_data_cache_state();
+
+    ret
 }
 
 pub(crate) unsafe fn blocking_erase_sector(sector: &FlashSector) -> Result<(), Error> {
     wait_busy();
     clear_all_err();
+    save_data_cache_state();
 
     interrupt::free(|_| {
         pac::FLASH.cr().modify(|w| {
@@ -62,27 +152,51 @@ pub(crate) unsafe fn blocking_erase_sector(sector: &FlashSector) -> Result<(), E
 
     let ret: Result<(), Error> = wait_ready_blocking();
     pac::FLASH.cr().modify(|w| w.set_per(false));
+    clear_all_err();
+    restore_data_cache_state();
     ret
 }
 
+pub(crate) async fn wait_ready() -> Result<(), Error> {
+    use core::future::poll_fn;
+    use core::task::Poll;
+
+    poll_fn(|cx| {
+        WAKER.register(cx.waker());
+
+        let sr = pac::FLASH.sr().read();
+        if !sr.bsy() {
+            Poll::Ready(get_result(sr))
+        } else {
+            Poll::Pending
+        }
+    })
+    .await
+}
+
 pub(crate) unsafe fn wait_ready_blocking() -> Result<(), Error> {
-    while pac::FLASH.sr().read().bsy() {}
+    loop {
+        let sr = pac::FLASH.sr().read();
+        if !sr.bsy() {
+            return get_result(sr);
+        }
+    }
+}
 
-    let sr = pac::FLASH.sr().read();
-
+fn get_result(sr: Sr) -> Result<(), Error> {
     if sr.progerr() {
-        return Err(Error::Prog);
+        Err(Error::Prog)
+    } else if sr.wrperr() {
+        Err(Error::Protected)
+    } else if sr.pgaerr() {
+        Err(Error::Unaligned)
+    } else if sr.sizerr() {
+        Err(Error::Size)
+    } else if sr.pgserr() {
+        Err(Error::Seq)
+    } else {
+        Ok(())
     }
-
-    if sr.wrperr() {
-        return Err(Error::Protected);
-    }
-
-    if sr.pgaerr() {
-        return Err(Error::Unaligned);
-    }
-
-    Ok(())
 }
 
 pub(crate) unsafe fn clear_all_err() {
@@ -100,6 +214,34 @@ fn wait_busy() {
 fn wait_busy() {
     while pac::FLASH.sr().read().bsy() {}
 }
+
+// G4 data cache handling - must disable during flash operations
+#[cfg(any(flash_g4c2, flash_g4c3, flash_g4c4))]
+fn save_data_cache_state() {
+    let dcen = pac::FLASH.acr().read().dcen();
+    DATA_CACHE_WAS_ENABLED.store(dcen, Ordering::Relaxed);
+    if dcen {
+        pac::FLASH.acr().modify(|w| w.set_dcen(false));
+    }
+}
+
+#[cfg(any(flash_g4c2, flash_g4c3, flash_g4c4))]
+fn restore_data_cache_state() {
+    // Restore data cache if it was enabled
+    if DATA_CACHE_WAS_ENABLED.load(Ordering::Relaxed) {
+        // Reset data cache before re-enabling
+        pac::FLASH.acr().modify(|w| w.set_dcrst(true));
+        pac::FLASH.acr().modify(|w| w.set_dcrst(false));
+        pac::FLASH.acr().modify(|w| w.set_dcen(true));
+    }
+}
+
+// G0 doesn't have data cache, use no-op functions
+#[cfg(any(flash_g0x0, flash_g0x1))]
+fn save_data_cache_state() {}
+
+#[cfg(any(flash_g0x0, flash_g0x1))]
+fn restore_data_cache_state() {}
 
 #[cfg(all(bank_setup_configurable, any(flash_g4c2, flash_g4c3, flash_g4c4)))]
 pub(crate) fn check_bank_setup() {

--- a/embassy-stm32/src/flash/mod.rs
+++ b/embassy-stm32/src/flash/mod.rs
@@ -1,14 +1,18 @@
 //! Flash memory (FLASH)
 use embedded_storage::nor_flash::{NorFlashError, NorFlashErrorKind};
 
-#[cfg(any(flash_f4, flash_h7, flash_h7ab))]
+#[cfg(any(
+    flash_f4, flash_g0x0, flash_g0x1, flash_g4c2, flash_g4c3, flash_g4c4, flash_h7, flash_h7ab
+))]
 mod asynch;
 #[cfg(flash)]
 mod common;
 #[cfg(eeprom)]
 mod eeprom;
 
-#[cfg(any(flash_f4, flash_h7, flash_h7ab))]
+#[cfg(any(
+    flash_f4, flash_g0x0, flash_g0x1, flash_g4c2, flash_g4c3, flash_g4c4, flash_h7, flash_h7ab
+))]
 pub use asynch::InterruptHandler;
 #[cfg(flash)]
 pub use common::*;

--- a/examples/stm32g0/src/bin/flash_async.rs
+++ b/examples/stm32g0/src/bin/flash_async.rs
@@ -1,0 +1,89 @@
+#![no_std]
+#![no_main]
+
+use defmt::{info, unwrap};
+use embassy_executor::Spawner;
+use embassy_stm32::flash::{Flash, InterruptHandler};
+use embassy_stm32::gpio::{AnyPin, Level, Output, Speed};
+use embassy_stm32::{Peri, bind_interrupts};
+use embassy_time::Timer;
+use {defmt_rtt as _, panic_probe as _};
+
+bind_interrupts!(struct Irqs {
+    FLASH => InterruptHandler;
+});
+
+#[embassy_executor::main]
+async fn main(spawner: Spawner) {
+    let p = embassy_stm32::init(Default::default());
+    info!("Hello Flash!");
+
+    let mut f = Flash::new(p.FLASH, Irqs);
+
+    // Led should blink uninterrupted during erase operation
+    spawner.spawn(unwrap!(blinky(p.PB7.into())));
+
+    // Test on bank 2 so the CPU doesn't stall (code runs from bank 1).
+    // G0B1RE has 512KB dual-bank flash: bank 2 starts at 256KB offset.
+    // Erase 4KB (2 pages at 2KB each).
+    test_flash(&mut f, 256 * 1024, 4 * 1024).await;
+}
+
+#[embassy_executor::task]
+async fn blinky(p: Peri<'static, AnyPin>) {
+    let mut led = Output::new(p, Level::High, Speed::Low);
+
+    loop {
+        info!("high");
+        led.set_high();
+        Timer::after_millis(300).await;
+
+        info!("low");
+        led.set_low();
+        Timer::after_millis(300).await;
+    }
+}
+
+async fn test_flash(f: &mut Flash<'_>, offset: u32, size: u32) {
+    info!("Testing offset: {=u32:#X}, size: {=u32:#X}", offset, size);
+
+    info!("Reading...");
+    let mut buf = [0u8; 32];
+    unwrap!(f.blocking_read(offset, &mut buf));
+    info!("Read: {=[u8]:x}", buf);
+
+    info!("Erasing...");
+    unwrap!(f.erase(offset, offset + size).await);
+
+    info!("Reading...");
+    let mut buf = [0u8; 32];
+    unwrap!(f.blocking_read(offset, &mut buf));
+    info!("Read after erase: {=[u8]:x}", buf);
+
+    info!("Writing...");
+    // G0 write size is 8 bytes (double-word)
+    unwrap!(
+        f.write(
+            offset,
+            &[
+                1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28,
+                29, 30, 31, 32
+            ]
+        )
+        .await
+    );
+
+    info!("Reading...");
+    let mut buf = [0u8; 32];
+    unwrap!(f.blocking_read(offset, &mut buf));
+    info!("Read: {=[u8]:x}", buf);
+    assert_eq!(
+        &buf[..],
+        &[
+            1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29,
+            30, 31, 32
+        ]
+    );
+
+    info!("Flash async test passed!");
+}

--- a/examples/stm32g474/.cargo/config.toml
+++ b/examples/stm32g474/.cargo/config.toml
@@ -1,0 +1,8 @@
+[target.'cfg(all(target_arch = "arm", target_os = "none"))']
+runner = "probe-rs run --chip STM32G474RETx"
+
+[build]
+target = "thumbv7em-none-eabi"
+
+[env]
+DEFMT_LOG = "trace"

--- a/examples/stm32g474/Cargo.toml
+++ b/examples/stm32g474/Cargo.toml
@@ -1,0 +1,28 @@
+[package]
+edition = "2024"
+name = "embassy-stm32g474-examples"
+version = "0.1.0"
+license = "MIT OR Apache-2.0"
+publish = false
+
+[dependencies]
+embassy-stm32 = { path = "../../embassy-stm32", features = [ "defmt", "time-driver-any", "stm32g474re", "memory-x", "unstable-pac", "exti", "dual-bank"]  }
+embassy-sync = { path = "../../embassy-sync", features = ["defmt"] }
+embassy-executor = { path = "../../embassy-executor", features = ["arch-cortex-m", "executor-thread", "defmt"] }
+embassy-time = { path = "../../embassy-time", features = ["defmt", "defmt-timestamp-uptime", "tick-hz-32_768"] }
+embassy-futures = { path = "../../embassy-futures" }
+
+defmt = "1.0.1"
+defmt-rtt = "1.0.0"
+
+cortex-m = { version = "0.7.6", features = ["critical-section-single-core"] }
+cortex-m-rt = "0.7.0"
+panic-probe = { version = "1.0.0", features = ["print-defmt"] }
+
+[profile.release]
+debug = 2
+
+[package.metadata.embassy]
+build = [
+  { target = "thumbv7em-none-eabi", artifact-dir = "out/examples/stm32g474" }
+]

--- a/examples/stm32g474/build.rs
+++ b/examples/stm32g474/build.rs
@@ -1,0 +1,5 @@
+fn main() {
+    println!("cargo:rustc-link-arg-bins=--nmagic");
+    println!("cargo:rustc-link-arg-bins=-Tlink.x");
+    println!("cargo:rustc-link-arg-bins=-Tdefmt.x");
+}

--- a/examples/stm32g474/src/bin/flash_async.rs
+++ b/examples/stm32g474/src/bin/flash_async.rs
@@ -1,0 +1,88 @@
+#![no_std]
+#![no_main]
+
+use defmt::{info, unwrap};
+use embassy_executor::Spawner;
+use embassy_stm32::flash::{Flash, InterruptHandler};
+use embassy_stm32::gpio::{AnyPin, Level, Output, Speed};
+use embassy_stm32::{Peri, bind_interrupts};
+use embassy_time::Timer;
+use {defmt_rtt as _, panic_probe as _};
+
+bind_interrupts!(struct Irqs {
+    FLASH => InterruptHandler;
+});
+
+#[embassy_executor::main]
+async fn main(spawner: Spawner) {
+    let p = embassy_stm32::init(Default::default());
+    info!("Hello Flash!");
+
+    let mut f = Flash::new(p.FLASH, Irqs);
+
+    // Led should blink uninterrupted during erase operation
+    spawner.spawn(unwrap!(blinky(p.PA5.into())));
+
+    // Test on bank 2 so the CPU doesn't stall (code runs from bank 1).
+    // G474RE in dual-bank mode: bank 2 starts at 256KB offset.
+    // Erase 4KB (2 pages at 2KB each in dual-bank mode).
+    test_flash(&mut f, 256 * 1024, 4 * 1024).await;
+}
+
+#[embassy_executor::task]
+async fn blinky(p: Peri<'static, AnyPin>) {
+    let mut led = Output::new(p, Level::High, Speed::Low);
+
+    loop {
+        info!("high");
+        led.set_high();
+        Timer::after_millis(300).await;
+
+        info!("low");
+        led.set_low();
+        Timer::after_millis(300).await;
+    }
+}
+
+async fn test_flash(f: &mut Flash<'_>, offset: u32, size: u32) {
+    info!("Testing offset: {=u32:#X}, size: {=u32:#X}", offset, size);
+
+    info!("Reading...");
+    let mut buf = [0u8; 32];
+    unwrap!(f.blocking_read(offset, &mut buf));
+    info!("Read: {=[u8]:x}", buf);
+
+    info!("Erasing...");
+    unwrap!(f.erase(offset, offset + size).await);
+
+    info!("Reading...");
+    let mut buf = [0u8; 32];
+    unwrap!(f.blocking_read(offset, &mut buf));
+    info!("Read after erase: {=[u8]:x}", buf);
+
+    info!("Writing...");
+    unwrap!(
+        f.write(
+            offset,
+            &[
+                1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28,
+                29, 30, 31, 32
+            ]
+        )
+        .await
+    );
+
+    info!("Reading...");
+    let mut buf = [0u8; 32];
+    unwrap!(f.blocking_read(offset, &mut buf));
+    info!("Read: {=[u8]:x}", buf);
+    assert_eq!(
+        &buf[..],
+        &[
+            1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29,
+            30, 31, 32
+        ]
+    );
+
+    info!("Flash async test passed!");
+}


### PR DESCRIPTION
Add async flash operations for STM32G0 and STM32G4 series, enabling non-blocking erase and write operations when using dual-bank flash (code runs from bank 1 while operating on bank 2).

Changes:
- Add WAKER, on_interrupt, async write/erase/wait_ready to g.rs
- Add data cache handling for G4 (disable during flash ops, reset after)
- Enable async flash module for G0/G4 in mod.rs
- Add flash_async example for G0
- Add new stm32g474 example directory with flash_async example

Tested on NUCLEO-G474RE.