### PR TITLE
embassy-stm32-wpan BLE split

### DIFF
--- a/embassy-stm32-wpan/src/wb55/sub/ble.rs
+++ b/embassy-stm32-wpan/src/wb55/sub/ble.rs
@@ -89,7 +89,7 @@ impl<'a> Ble<'a> {
             },
             BleRx {
                 ipcc_ble_event_channel: self.ipcc_ble_event_channel,
-            }
+            },
         )
     }
 
@@ -162,7 +162,6 @@ impl<'a> hci::Controller for Ble<'a> {
     }
 }
 
-
 impl<'a> BleTx<'a> {
     /// `TL_BLE_SendCmd`
     pub async fn tl_write(&mut self, opcode: u16, payload: &[u8]) {
@@ -227,7 +226,7 @@ impl<'a> hci::Controller for BleTx<'a> {
     }
 
     async fn controller_read_into(&mut self, _buf: &mut [u8]) {
-        panic!("BleTx cannot read!"); 
+        panic!("BleTx cannot read!");
     }
 }
 


### PR DESCRIPTION
Hi ! 

I want to use BLE on an STM32WB55. But i faced an issue with current implementation, `ble.read()` function must be called continuously to catch BLE events or responses to commands sent. But i want to send BLE notifications asynchronously to BLE events.

My first try was to use an `embassy::select` on `ble.read()` and a channel (with data to send into). But, this leads to hardfault when `ble.read()` future is dropped at the bad time (HCI commands corruption)

So, in this pull request i implemented a split function for BLE. It's not perfect because it's still user's responsibility to ensure `ble.read()` function is called before send any other command. I think it can be implemented at the driver level (await a read before sending other command ?)