### PR TITLE
nrf54lm20: Fix RAM size in example

### DIFF
--- a/examples/nrf54lm20/memory.x
+++ b/examples/nrf54lm20/memory.x
@@ -1,5 +1,12 @@
 MEMORY
 {
   FLASH : ORIGIN = 0x00000000, LENGTH = 2036K
-  RAM : ORIGIN = 0x20000000, LENGTH = 512K
+
+  /*
+   * Actual RAM size is 512K, but:
+   *
+   * 0x2007df40 - 0x2007fe40: VPR saved context
+   * 0x2007ff00 - 0x2007ffff: Protected RAM
+   */
+  RAM : ORIGIN = 0x20000000, LENGTH = 0x7fd40
 }


### PR DESCRIPTION
Accessing the protected part of RAM fails with a fault, the area where the VPR context is saved can be accessed, but should probably be avoided.

Based on <https://docs.nordicsemi.com/bundle/ps_nrf54LM20A/page/chapters/memory.html>.