### PR TITLE
add new async digital traits for BlockingAsync

### DIFF
--- a/embassy-embedded-hal/Cargo.toml
+++ b/embassy-embedded-hal/Cargo.toml
@@ -6,16 +6,15 @@ license = "MIT OR Apache-2.0"
 description = "Collection of utilities to use `embedded-hal` and `embedded-storage` traits with Embassy."
 repository = "https://github.com/embassy-rs/embassy"
 documentation = "https://docs.embassy.dev/embassy-embedded-hal"
-categories = [
-    "embedded",
-    "no-std",
-    "asynchronous",
-]
+categories = ["embedded", "no-std", "asynchronous"]
 
 [package.metadata.embassy]
 build = [
-    {target = "thumbv7em-none-eabi", features = []},
-    {target = "thumbv7em-none-eabi", features = ["time"]},
+    { target = "thumbv7em-none-eabi", features = [
+    ] },
+    { target = "thumbv7em-none-eabi", features = [
+        "time",
+    ] },
 ]
 
 
@@ -47,3 +46,7 @@ defmt = { version = "1.0.1", optional = true }
 [dev-dependencies]
 critical-section = { version = "1.1.1", features = ["std"] }
 futures-test = "0.3.17"
+
+[patch.crates-io]
+embedded-hal = { git = "https://github.com/rust-embedded/embedded-hal" }
+embedded-hal-async = { git = "https://github.com/rust-embedded/embedded-hal" }

--- a/embassy-embedded-hal/src/adapter/blocking_async.rs
+++ b/embassy-embedded-hal/src/adapter/blocking_async.rs
@@ -139,3 +139,60 @@ where
 }
 
 impl<T> AsyncMultiwriteNorFlash for BlockingAsync<T> where T: MultiwriteNorFlash {}
+
+//
+// digital implementations
+//
+impl<T> embedded_hal_1::digital::ErrorType for BlockingAsync<T>
+where
+    T: embedded_hal_1::digital::ErrorType,
+{
+    type Error = T::Error;
+}
+
+impl<T> embedded_hal_async::digital::InputPin for BlockingAsync<T>
+where
+    T: embedded_hal_1::digital::InputPin,
+{
+    async fn is_high(&mut self) -> Result<bool, Self::Error> {
+        self.wrapped.is_high()
+    }
+
+    async fn is_low(&mut self) -> Result<bool, Self::Error> {
+        self.wrapped.is_low()
+    }
+}
+
+impl<T> embedded_hal_async::digital::OutputPin for BlockingAsync<T>
+where
+    T: embedded_hal_1::digital::OutputPin,
+{
+    async fn set_low(&mut self) -> Result<(), Self::Error> {
+        self.wrapped.set_low()
+    }
+
+    async fn set_high(&mut self) -> Result<(), Self::Error> {
+        self.wrapped.set_high()
+    }
+
+    async fn set_state(&mut self, state: embedded_hal_1::digital::PinState) -> Result<(), Self::Error> {
+        self.wrapped.set_state(state)
+    }
+}
+
+impl<T> embedded_hal_async::digital::StatefulOutputPin for BlockingAsync<T>
+where
+    T: embedded_hal_1::digital::StatefulOutputPin,
+{
+    async fn is_set_high(&mut self) -> Result<bool, Self::Error> {
+        self.wrapped.is_set_high()
+    }
+
+    async fn is_set_low(&mut self) -> Result<bool, Self::Error> {
+        self.wrapped.is_set_low()
+    }
+
+    async fn toggle(&mut self) -> Result<(), Self::Error> {
+        self.wrapped.toggle()
+    }
+}


### PR DESCRIPTION
currently these new traits are only in the git repo of embedded-hal and not published, so this requires using the creates from git

for my project I need these traits so I'm using the git version of embedded-hal and  I need an adapter. Once the new traits are in a published version I can remove the changes to `Cargo.toml` and make this PR no longer a draft. If this is approved I can also implement yielding versions of this.