### PR TITLE
[MCXA] Switch over embassy-mcxa to use nxp-pac

### DIFF
--- a/embassy-mcxa/Cargo.toml
+++ b/embassy-mcxa/Cargo.toml
@@ -40,7 +40,7 @@ embedded-io = "0.7"
 embedded-io-async = { version = "0.7.0" }
 heapless = "0.9"
 maitake-sync = { version = "0.2.2", default-features = false, features = ["critical-section", "no-cache-pad"] }
-mcxa-pac = { version = "0.4.0", features = ["rt", "critical-section"] }
+nxp-pac = { git = "https://github.com/embassy-rs/nxp-pac.git", rev = "560e74384e20940a3c25e0435a6fbdc66644b558", features = ["rt", "mcxa256"] }
 nb = "1.1.0"
 paste = "1.0.15"
 
@@ -57,7 +57,7 @@ default = ["rt", "swd-swo-as-gpio"]
 
 # Base defmt feature enables core + panic handler
 # Use with one logger feature: defmt-rtt (preferred) or defmt-uart (fallback)
-defmt = ["dep:defmt", "mcxa-pac/defmt"]
+defmt = ["dep:defmt", "nxp-pac/defmt"]
 
 unstable-pac = []
 

--- a/embassy-mcxa/src/gpio.rs
+++ b/embassy-mcxa/src/gpio.rs
@@ -11,8 +11,11 @@ use embassy_hal_internal::{Peri, PeripheralType};
 use maitake_sync::WaitMap;
 use paste::paste;
 
+use crate::pac::common::{RW, Reg};
+use crate::pac::gpio::vals::{Irqc, Isf, Pdd, Pid, Ptco, Ptso};
 use crate::pac::interrupt;
-use crate::pac::port0::pcr0::{Dse, Inv, Mux, Pe, Ps, Sre};
+use crate::pac::port::regs::Pcr;
+use crate::pac::port::vals::{Dse, Ibe, Inv, Mux, Pe, Ps, Sre};
 
 struct BitIter(u32);
 
@@ -40,14 +43,13 @@ static PORT_WAIT_MAPS: [WaitMap<usize, ()>; PORT_COUNT] = [
     WaitMap::new(),
 ];
 
-fn irq_handler(port_index: usize, gpio_base: *const crate::pac::gpio0::RegisterBlock, perf_wake: fn()) {
-    let gpio = unsafe { &*gpio_base };
-    let isfr = gpio.isfr0().read().bits();
+fn irq_handler(port_index: usize, gpio: crate::pac::gpio::Gpio, perf_wake: fn()) {
+    let isfr = gpio.isfr0().read();
 
-    for pin in BitIter(isfr) {
+    for pin in BitIter(isfr.0) {
         // Clear all pending interrupts
-        gpio.isfr0().write(|w| unsafe { w.bits(1 << pin) });
-        gpio.icr(pin).modify(|_, w| w.irqc().irqc0()); // Disable interrupt
+        gpio.isfr0().write(|w| w.0 = 1 << pin);
+        gpio.icr(pin).modify(|w| w.set_irqc(Irqc::IRQC0)); // Disable interrupt
 
         // Wake the corresponding port waker
         if let Some(w) = PORT_WAIT_MAPS.get(port_index) {
@@ -60,51 +62,31 @@ fn irq_handler(port_index: usize, gpio_base: *const crate::pac::gpio0::RegisterB
 #[interrupt]
 fn GPIO0() {
     crate::perf_counters::incr_interrupt_gpio0();
-    irq_handler(
-        0,
-        crate::pac::Gpio0::ptr(),
-        crate::perf_counters::incr_interrupt_gpio0_wake,
-    );
+    irq_handler(0, crate::pac::GPIO0, crate::perf_counters::incr_interrupt_gpio0_wake);
 }
 
 #[interrupt]
 fn GPIO1() {
     crate::perf_counters::incr_interrupt_gpio1();
-    irq_handler(
-        1,
-        crate::pac::Gpio1::ptr(),
-        crate::perf_counters::incr_interrupt_gpio1_wake,
-    );
+    irq_handler(1, crate::pac::GPIO1, crate::perf_counters::incr_interrupt_gpio1_wake);
 }
 
 #[interrupt]
 fn GPIO2() {
     crate::perf_counters::incr_interrupt_gpio2();
-    irq_handler(
-        2,
-        crate::pac::Gpio2::ptr(),
-        crate::perf_counters::incr_interrupt_gpio2_wake,
-    );
+    irq_handler(2, crate::pac::GPIO2, crate::perf_counters::incr_interrupt_gpio2_wake);
 }
 
 #[interrupt]
 fn GPIO3() {
     crate::perf_counters::incr_interrupt_gpio3();
-    irq_handler(
-        3,
-        crate::pac::Gpio3::ptr(),
-        crate::perf_counters::incr_interrupt_gpio3_wake,
-    );
+    irq_handler(3, crate::pac::GPIO3, crate::perf_counters::incr_interrupt_gpio3_wake);
 }
 
 #[interrupt]
 fn GPIO4() {
     crate::perf_counters::incr_interrupt_gpio4();
-    irq_handler(
-        4,
-        crate::pac::Gpio4::ptr(),
-        crate::perf_counters::incr_interrupt_gpio4_wake,
-    );
+    irq_handler(4, crate::pac::GPIO4, crate::perf_counters::incr_interrupt_gpio4_wake);
 }
 
 pub(crate) unsafe fn interrupt_init() {
@@ -148,9 +130,9 @@ pub enum Pull {
 impl From<Pull> for (Pe, Ps) {
     fn from(pull: Pull) -> Self {
         match pull {
-            Pull::Disabled => (Pe::Pe0, Ps::Ps0),
-            Pull::Up => (Pe::Pe1, Ps::Ps1),
-            Pull::Down => (Pe::Pe1, Ps::Ps0),
+            Pull::Disabled => (Pe::PE0, Ps::PS0),
+            Pull::Up => (Pe::PE1, Ps::PS1),
+            Pull::Down => (Pe::PE1, Ps::PS0),
         }
     }
 }
@@ -164,8 +146,8 @@ pub enum SlewRate {
 impl From<SlewRate> for Sre {
     fn from(slew_rate: SlewRate) -> Self {
         match slew_rate {
-            SlewRate::Fast => Sre::Sre0,
-            SlewRate::Slow => Sre::Sre1,
+            SlewRate::Fast => Sre::SRE0,
+            SlewRate::Slow => Sre::SRE1,
         }
     }
 }
@@ -179,8 +161,8 @@ pub enum DriveStrength {
 impl From<DriveStrength> for Dse {
     fn from(strength: DriveStrength) -> Self {
         match strength {
-            DriveStrength::Normal => Dse::Dse0,
-            DriveStrength::Double => Dse::Dse1,
+            DriveStrength::Normal => Dse::DSE0,
+            DriveStrength::Double => Dse::DSE1,
         }
     }
 }
@@ -194,8 +176,8 @@ pub enum Inverter {
 impl From<Inverter> for Inv {
     fn from(strength: Inverter) -> Self {
         match strength {
-            Inverter::Disabled => Inv::Inv0,
-            Inverter::Enabled => Inv::Inv1,
+            Inverter::Disabled => Inv::INV0,
+            Inverter::Enabled => Inv::INV1,
         }
     }
 }
@@ -206,9 +188,9 @@ pub type Gpio = crate::peripherals::GPIO0;
 pub struct AnyPin {
     port: u8,
     pin: u8,
-    gpio: &'static crate::pac::gpio0::RegisterBlock,
-    port_reg: &'static crate::pac::port0::RegisterBlock,
-    pcr_reg: &'static crate::pac::port0::Pcr0,
+    gpio: crate::pac::gpio::Gpio,
+    port_reg: crate::pac::port::Port,
+    pcr_reg: Reg<Pcr, RW>,
 }
 
 impl AnyPin {
@@ -216,9 +198,9 @@ impl AnyPin {
     fn new(
         port: u8,
         pin: u8,
-        gpio: &'static crate::pac::gpio0::RegisterBlock,
-        port_reg: &'static crate::pac::port0::RegisterBlock,
-        pcr_reg: &'static crate::pac::port0::Pcr0,
+        gpio: crate::pac::gpio::Gpio,
+        port_reg: crate::pac::port::Port,
+        pcr_reg: Reg<Pcr, RW>,
     ) -> Self {
         Self {
             port,
@@ -230,7 +212,7 @@ impl AnyPin {
     }
 
     #[inline(always)]
-    fn gpio(&self) -> &'static crate::pac::gpio0::RegisterBlock {
+    fn gpio(&self) -> crate::pac::gpio::Gpio {
         self.gpio
     }
 
@@ -245,12 +227,12 @@ impl AnyPin {
     }
 
     #[inline(always)]
-    fn port_reg(&self) -> &'static crate::pac::port0::RegisterBlock {
+    fn port_reg(&self) -> crate::pac::port::Port {
         self.port_reg
     }
 
     #[inline(always)]
-    fn pcr_reg(&self) -> &'static crate::pac::port0::Pcr0 {
+    fn pcr_reg(&self) -> Reg<Pcr, RW> {
         self.pcr_reg
     }
 }
@@ -262,11 +244,11 @@ pub(crate) trait SealedPin {
 
     fn pin(&self) -> u8;
 
-    fn gpio(&self) -> &'static crate::pac::gpio0::RegisterBlock;
+    fn gpio(&self) -> crate::pac::gpio::Gpio;
 
-    fn port_reg(&self) -> &'static crate::pac::port0::RegisterBlock;
+    fn port_reg(&self) -> crate::pac::port::Port;
 
-    fn pcr_reg(&self) -> &'static crate::pac::port0::Pcr0;
+    fn pcr_reg(&self) -> Reg<Pcr, RW>;
 
     fn set_function(&self, function: Mux);
 
@@ -305,59 +287,60 @@ impl SealedPin for AnyPin {
     }
 
     #[inline(always)]
-    fn gpio(&self) -> &'static crate::pac::gpio0::RegisterBlock {
+    fn gpio(&self) -> crate::pac::gpio::Gpio {
         self.gpio()
     }
 
     #[inline(always)]
-    fn port_reg(&self) -> &'static crate::pac::port0::RegisterBlock {
+    fn port_reg(&self) -> crate::pac::port::Port {
         self.port_reg()
     }
 
     #[inline(always)]
-    fn pcr_reg(&self) -> &'static crate::pac::port0::Pcr0 {
+    fn pcr_reg(&self) -> Reg<Pcr, RW> {
         self.pcr_reg()
     }
 
     #[inline(always)]
     fn set_function(&self, function: Mux) {
-        self.pcr_reg().modify(|_, w| w.mux().variant(function));
+        self.pcr_reg().modify(|w| w.set_mux(function));
     }
 
     #[inline(always)]
     fn set_pull(&self, pull: Pull) {
         let (pull_enable, pull_select) = pull.into();
-        self.pcr_reg().modify(|_, w| {
-            w.pe().variant(pull_enable);
-            w.ps().variant(pull_select)
+        self.pcr_reg().modify(|w| {
+            w.set_pe(pull_enable);
+            w.set_ps(pull_select)
         });
     }
 
     #[inline(always)]
     fn set_drive_strength(&self, strength: Dse) {
-        self.pcr_reg().modify(|_, w| w.dse().variant(strength));
+        self.pcr_reg().modify(|w| w.set_dse(strength));
     }
 
     #[inline(always)]
     fn set_slew_rate(&self, slew_rate: Sre) {
-        self.pcr_reg().modify(|_, w| w.sre().variant(slew_rate));
+        self.pcr_reg().modify(|w| w.set_sre(slew_rate));
     }
 
     #[inline(always)]
     fn set_enable_input_buffer(&self, buffer_enabled: bool) {
-        self.pcr_reg().modify(|_, w| w.ibe().bit(buffer_enabled));
+        self.pcr_reg()
+            .modify(|w| w.set_ibe(if buffer_enabled { Ibe::IBE1 } else { Ibe::IBE0 }));
     }
 
     #[inline(always)]
     fn set_as_disabled(&self) {
         // Set GPIO direction as input
-        self.gpio().pddr().modify(|_, w| w.pdd(self.pin()).clear_bit());
+        self.gpio().pddr().modify(|w| w.set_pdd(self.pin() as usize, Pdd::PDD0));
         // Set input buffer as disabled
         self.set_enable_input_buffer(false);
         // Set mode as GPIO (vs other potential functions)
-        self.set_function(Mux::Mux0);
+        self.set_function(Mux::MUX0);
         // Set pin as disabled
-        self.gpio().pidr().modify(|_, w| w.pid(self.pin()).set_bit());
+        self.gpio().pidr().modify(|w| w.set_pid(self.pin() as usize, Pid::PID1));
     }
 }
 
@@ -378,68 +361,59 @@ macro_rules! impl_pin {
                 }
 
                 #[inline(always)]
-                fn gpio(&self) -> &'static crate::pac::gpio0::RegisterBlock {
-                    unsafe { &*crate::pac::$block::ptr() }
+                fn gpio(&self) -> crate::pac::gpio::Gpio {
+                    crate::pac::$block
                 }
 
                 #[inline(always)]
-                fn port_reg(&self) -> &'static crate::pac::port0::RegisterBlock {
-                    unsafe { &*crate::pac::[<Port $port>]::ptr() }
+                fn port_reg(&self) -> crate::pac::port::Port {
+                    crate::pac::[<PORT $port>]
                 }
 
                 #[inline(always)]
-                fn pcr_reg(&self) -> &'static crate::pac::port0::Pcr0 {
-                    self.port_reg().[<pcr $pin>]()
+                fn pcr_reg(&self) -> Reg<Pcr, RW> {
+                    self.port_reg().pcr($pin)
                 }
 
                 #[inline(always)]
                 fn set_function(&self, function: Mux) {
-                    unsafe {
-                        let port_reg = &*crate::pac::[<Port $port>]::ptr();
-                        port_reg.[<pcr $pin>]().modify(|_, w| {
-                            w.mux().variant(function)
-                        });
-                    }
+                    self.pcr_reg().modify(|w| w.set_mux(function));
                 }
 
                 #[inline(always)]
                 fn set_pull(&self, pull: Pull) {
-                    let port_reg = unsafe {&*crate::pac::[<Port $port>]::ptr()};
                     let (pull_enable, pull_select) = pull.into();
-                    port_reg.[<pcr $pin>]().modify(|_, w| {
-                        w.pe().variant(pull_enable);
-                        w.ps().variant(pull_select)
+                    self.pcr_reg().modify(|w| {
+                        w.set_pe(pull_enable);
+                        w.set_ps(pull_select);
                     });
                 }
 
                 #[inline(always)]
                 fn set_drive_strength(&self, strength: Dse) {
-                    let port_reg = unsafe {&*crate::pac::[<Port $port>]::ptr()};
-                    port_reg.[<pcr $pin>]().modify(|_, w| w.dse().variant(strength));
+                    self.pcr_reg().modify(|w| w.set_dse(strength));
                 }
 
                 #[inline(always)]
                 fn set_slew_rate(&self, slew_rate: Sre) {
-                    let port_reg = unsafe {&*crate::pac::[<Port $port>]::ptr()};
-                    port_reg.[<pcr $pin>]().modify(|_, w| w.sre().variant(slew_rate));
+                    self.pcr_reg().modify(|w| w.set_sre(slew_rate));
                 }
 
                 #[inline(always)]
                 fn set_enable_input_buffer(&self, buffer_enabled: bool) {
-                    let port_reg = unsafe {&*crate::pac::[<Port $port>]::ptr()};
-                    port_reg.[<pcr $pin>]().modify(|_, w| w.ibe().bit(buffer_enabled));
+                    self.pcr_reg().modify(|w| w.set_ibe(if buffer_enabled { Ibe::IBE1 } else { Ibe::IBE0 }));
                 }
 
                 #[inline(always)]
                 fn set_as_disabled(&self) {
                     // Set GPIO direction as input
-                    self.gpio().pddr().modify(|_, w| w.pdd(self.pin()).clear_bit());
+                    self.gpio().pddr().modify(|w| w.set_pdd(self.pin() as usize, Pdd::PDD0));
                     // Set input buffer as disabled
                     self.set_enable_input_buffer(false);
                     // Set mode as GPIO (vs other potential functions)
-                    self.set_function(Mux::Mux0);
+                    self.set_function(Mux::MUX0);
                     // Set pin as disabled
-                    self.gpio().pidr().modify(|_, w| w.pid(self.pin()).set_bit());
+                    self.gpio().pidr().modify(|w| w.set_pid(self.pin() as usize, Pid::PID1));
                 }
             }
 
@@ -454,7 +428,13 @@ macro_rules! impl_pin {
             impl crate::peripherals::$peri {
                 /// Convenience helper to obtain a type-erased handle to this pin.
                 pub fn degrade(&self) -> AnyPin {
-                    AnyPin::new(self.port(), self.pin(), self.gpio(), self.port_reg(), self.pcr_reg())
+                    AnyPin::new(
+                        self.port(),
+                        self.pin(),
+                        self.gpio(),
+                        self.port_reg(),
+                        self.pcr_reg(),
+                    )
                 }
             }
         }
@@ -462,177 +442,177 @@ macro_rules! impl_pin {
 }
 
 #[cfg(feature = "swd-as-gpio")]
-impl_pin!(P0_0, 0, 0, Gpio0);
+impl_pin!(P0_0, 0, 0, GPIO0);
 #[cfg(feature = "swd-as-gpio")]
-impl_pin!(P0_1, 0, 1, Gpio0);
+impl_pin!(P0_1, 0, 1, GPIO0);
 #[cfg(feature = "swd-swo-as-gpio")]
-impl_pin!(P0_2, 0, 2, Gpio0);
+impl_pin!(P0_2, 0, 2, GPIO0);
 #[cfg(feature = "jtag-extras-as-gpio")]
-impl_pin!(P0_3, 0, 3, Gpio0);
-impl_pin!(P0_4, 0, 4, Gpio0);
-impl_pin!(P0_5, 0, 5, Gpio0);
+impl_pin!(P0_3, 0, 3, GPIO0);
+impl_pin!(P0_4, 0, 4, GPIO0);
+impl_pin!(P0_5, 0, 5, GPIO0);
 #[cfg(feature = "jtag-extras-as-gpio")]
-impl_pin!(P0_6, 0, 6, Gpio0);
-impl_pin!(P0_7, 0, 7, Gpio0);
-impl_pin!(P0_8, 0, 8, Gpio0);
-impl_pin!(P0_9, 0, 9, Gpio0);
-impl_pin!(P0_10, 0, 10, Gpio0);
-impl_pin!(P0_11, 0, 11, Gpio0);
-impl_pin!(P0_12, 0, 12, Gpio0);
-impl_pin!(P0_13, 0, 13, Gpio0);
-impl_pin!(P0_14, 0, 14, Gpio0);
-impl_pin!(P0_15, 0, 15, Gpio0);
-impl_pin!(P0_16, 0, 16, Gpio0);
-impl_pin!(P0_17, 0, 17, Gpio0);
-impl_pin!(P0_18, 0, 18, Gpio0);
-impl_pin!(P0_19, 0, 19, Gpio0);
-impl_pin!(P0_20, 0, 20, Gpio0);
-impl_pin!(P0_21, 0, 21, Gpio0);
-impl_pin!(P0_22, 0, 22, Gpio0);
-impl_pin!(P0_23, 0, 23, Gpio0);
-impl_pin!(P0_24, 0, 24, Gpio0);
-impl_pin!(P0_25, 0, 25, Gpio0);
-impl_pin!(P0_26, 0, 26, Gpio0);
-impl_pin!(P0_27, 0, 27, Gpio0);
-impl_pin!(P0_28, 0, 28, Gpio0);
-impl_pin!(P0_29, 0, 29, Gpio0);
-impl_pin!(P0_30, 0, 30, Gpio0);
-impl_pin!(P0_31, 0, 31, Gpio0);
+impl_pin!(P0_6, 0, 6, GPIO0);
+impl_pin!(P0_7, 0, 7, GPIO0);
+impl_pin!(P0_8, 0, 8, GPIO0);
+impl_pin!(P0_9, 0, 9, GPIO0);
+impl_pin!(P0_10, 0, 10, GPIO0);
+impl_pin!(P0_11, 0, 11, GPIO0);
+impl_pin!(P0_12, 0, 12, GPIO0);
+impl_pin!(P0_13, 0, 13, GPIO0);
+impl_pin!(P0_14, 0, 14, GPIO0);
+impl_pin!(P0_15, 0, 15, GPIO0);
+impl_pin!(P0_16, 0, 16, GPIO0);
+impl_pin!(P0_17, 0, 17, GPIO0);
+impl_pin!(P0_18, 0, 18, GPIO0);
+impl_pin!(P0_19, 0, 19, GPIO0);
+impl_pin!(P0_20, 0, 20, GPIO0);
+impl_pin!(P0_21, 0, 21, GPIO0);
+impl_pin!(P0_22, 0, 22, GPIO0);
+impl_pin!(P0_23, 0, 23, GPIO0);
+impl_pin!(P0_24, 0, 24, GPIO0);
+impl_pin!(P0_25, 0, 25, GPIO0);
+impl_pin!(P0_26, 0, 26, GPIO0);
+impl_pin!(P0_27, 0, 27, GPIO0);
+impl_pin!(P0_28, 0, 28, GPIO0);
+impl_pin!(P0_29, 0, 29, GPIO0);
+impl_pin!(P0_30, 0, 30, GPIO0);
+impl_pin!(P0_31, 0, 31, GPIO0);
 
-impl_pin!(P1_0, 1, 0, Gpio1);
-impl_pin!(P1_1, 1, 1, Gpio1);
-impl_pin!(P1_2, 1, 2, Gpio1);
-impl_pin!(P1_3, 1, 3, Gpio1);
-impl_pin!(P1_4, 1, 4, Gpio1);
-impl_pin!(P1_5, 1, 5, Gpio1);
-impl_pin!(P1_6, 1, 6, Gpio1);
-impl_pin!(P1_7, 1, 7, Gpio1);
-impl_pin!(P1_8, 1, 8, Gpio1);
-impl_pin!(P1_9, 1, 9, Gpio1);
-impl_pin!(P1_10, 1, 10, Gpio1);
-impl_pin!(P1_11, 1, 11, Gpio1);
-impl_pin!(P1_12, 1, 12, Gpio1);
-impl_pin!(P1_13, 1, 13, Gpio1);
-impl_pin!(P1_14, 1, 14, Gpio1);
-impl_pin!(P1_15, 1, 15, Gpio1);
-impl_pin!(P1_16, 1, 16, Gpio1);
-impl_pin!(P1_17, 1, 17, Gpio1);
-impl_pin!(P1_18, 1, 18, Gpio1);
-impl_pin!(P1_19, 1, 19, Gpio1);
-impl_pin!(P1_20, 1, 20, Gpio1);
-impl_pin!(P1_21, 1, 21, Gpio1);
-impl_pin!(P1_22, 1, 22, Gpio1);
-impl_pin!(P1_23, 1, 23, Gpio1);
-impl_pin!(P1_24, 1, 24, Gpio1);
-impl_pin!(P1_25, 1, 25, Gpio1);
-impl_pin!(P1_26, 1, 26, Gpio1);
-impl_pin!(P1_27, 1, 27, Gpio1);
-impl_pin!(P1_28, 1, 28, Gpio1);
+impl_pin!(P1_0, 1, 0, GPIO1);
+impl_pin!(P1_1, 1, 1, GPIO1);
+impl_pin!(P1_2, 1, 2, GPIO1);
+impl_pin!(P1_3, 1, 3, GPIO1);
+impl_pin!(P1_4, 1, 4, GPIO1);
+impl_pin!(P1_5, 1, 5, GPIO1);
+impl_pin!(P1_6, 1, 6, GPIO1);
+impl_pin!(P1_7, 1, 7, GPIO1);
+impl_pin!(P1_8, 1, 8, GPIO1);
+impl_pin!(P1_9, 1, 9, GPIO1);
+impl_pin!(P1_10, 1, 10, GPIO1);
+impl_pin!(P1_11, 1, 11, GPIO1);
+impl_pin!(P1_12, 1, 12, GPIO1);
+impl_pin!(P1_13, 1, 13, GPIO1);
+impl_pin!(P1_14, 1, 14, GPIO1);
+impl_pin!(P1_15, 1, 15, GPIO1);
+impl_pin!(P1_16, 1, 16, GPIO1);
+impl_pin!(P1_17, 1, 17, GPIO1);
+impl_pin!(P1_18, 1, 18, GPIO1);
+impl_pin!(P1_19, 1, 19, GPIO1);
+impl_pin!(P1_20, 1, 20, GPIO1);
+impl_pin!(P1_21, 1, 21, GPIO1);
+impl_pin!(P1_22, 1, 22, GPIO1);
+impl_pin!(P1_23, 1, 23, GPIO1);
+impl_pin!(P1_24, 1, 24, GPIO1);
+impl_pin!(P1_25, 1, 25, GPIO1);
+impl_pin!(P1_26, 1, 26, GPIO1);
+impl_pin!(P1_27, 1, 27, GPIO1);
+impl_pin!(P1_28, 1, 28, GPIO1);
 #[cfg(feature = "dangerous-reset-as-gpio")]
-impl_pin!(P1_29, 1, 29, Gpio1);
+impl_pin!(P1_29, 1, 29, GPIO1);
 #[cfg(feature = "sosc-as-gpio")]
-impl_pin!(P1_30, 1, 30, Gpio1);
+impl_pin!(P1_30, 1, 30, GPIO1);
 #[cfg(feature = "sosc-as-gpio")]
-impl_pin!(P1_31, 1, 31, Gpio1);
+impl_pin!(P1_31, 1, 31, GPIO1);
 
-impl_pin!(P2_0, 2, 0, Gpio2);
-impl_pin!(P2_1, 2, 1, Gpio2);
-impl_pin!(P2_2, 2, 2, Gpio2);
-impl_pin!(P2_3, 2, 3, Gpio2);
-impl_pin!(P2_4, 2, 4, Gpio2);
-impl_pin!(P2_5, 2, 5, Gpio2);
-impl_pin!(P2_6, 2, 6, Gpio2);
-impl_pin!(P2_7, 2, 7, Gpio2);
-impl_pin!(P2_8, 2, 8, Gpio2);
-impl_pin!(P2_9, 2, 9, Gpio2);
-impl_pin!(P2_10, 2, 10, Gpio2);
-impl_pin!(P2_11, 2, 11, Gpio2);
-impl_pin!(P2_12, 2, 12, Gpio2);
-impl_pin!(P2_13, 2, 13, Gpio2);
-impl_pin!(P2_14, 2, 14, Gpio2);
-impl_pin!(P2_15, 2, 15, Gpio2);
-impl_pin!(P2_16, 2, 16, Gpio2);
-impl_pin!(P2_17, 2, 17, Gpio2);
-impl_pin!(P2_18, 2, 18, Gpio2);
-impl_pin!(P2_19, 2, 19, Gpio2);
-impl_pin!(P2_20, 2, 20, Gpio2);
-impl_pin!(P2_21, 2, 21, Gpio2);
-impl_pin!(P2_22, 2, 22, Gpio2);
-impl_pin!(P2_23, 2, 23, Gpio2);
-impl_pin!(P2_24, 2, 24, Gpio2);
-impl_pin!(P2_25, 2, 25, Gpio2);
-impl_pin!(P2_26, 2, 26, Gpio2);
-impl_pin!(P2_27, 2, 27, Gpio2);
-impl_pin!(P2_28, 2, 28, Gpio2);
-impl_pin!(P2_29, 2, 29, Gpio2);
-impl_pin!(P2_30, 2, 30, Gpio2);
-impl_pin!(P2_31, 2, 31, Gpio2);
+impl_pin!(P2_0, 2, 0, GPIO2);
+impl_pin!(P2_1, 2, 1, GPIO2);
+impl_pin!(P2_2, 2, 2, GPIO2);
+impl_pin!(P2_3, 2, 3, GPIO2);
+impl_pin!(P2_4, 2, 4, GPIO2);
+impl_pin!(P2_5, 2, 5, GPIO2);
+impl_pin!(P2_6, 2, 6, GPIO2);
+impl_pin!(P2_7, 2, 7, GPIO2);
+impl_pin!(P2_8, 2, 8, GPIO2);
+impl_pin!(P2_9, 2, 9, GPIO2);
+impl_pin!(P2_10, 2, 10, GPIO2);
+impl_pin!(P2_11, 2, 11, GPIO2);
+impl_pin!(P2_12, 2, 12, GPIO2);
+impl_pin!(P2_13, 2, 13, GPIO2);
+impl_pin!(P2_14, 2, 14, GPIO2);
+impl_pin!(P2_15, 2, 15, GPIO2);
+impl_pin!(P2_16, 2, 16, GPIO2);
+impl_pin!(P2_17, 2, 17, GPIO2);
+impl_pin!(P2_18, 2, 18, GPIO2);
+impl_pin!(P2_19, 2, 19, GPIO2);
+impl_pin!(P2_20, 2, 20, GPIO2);
+impl_pin!(P2_21, 2, 21, GPIO2);
+impl_pin!(P2_22, 2, 22, GPIO2);
+impl_pin!(P2_23, 2, 23, GPIO2);
+impl_pin!(P2_24, 2, 24, GPIO2);
+impl_pin!(P2_25, 2, 25, GPIO2);
+impl_pin!(P2_26, 2, 26, GPIO2);
+// impl_pin!(P2_27, 2, 27, GPIO2);
+// impl_pin!(P2_28, 2, 28, GPIO2);
+// impl_pin!(P2_29, 2, 29, GPIO2);
+// impl_pin!(P2_30, 2, 30, GPIO2);
+// impl_pin!(P2_31, 2, 31, GPIO2);
 
-impl_pin!(P3_0, 3, 0, Gpio3);
-impl_pin!(P3_1, 3, 1, Gpio3);
-impl_pin!(P3_2, 3, 2, Gpio3);
-impl_pin!(P3_3, 3, 3, Gpio3);
-impl_pin!(P3_4, 3, 4, Gpio3);
-impl_pin!(P3_5, 3, 5, Gpio3);
-impl_pin!(P3_6, 3, 6, Gpio3);
-impl_pin!(P3_7, 3, 7, Gpio3);
-impl_pin!(P3_8, 3, 8, Gpio3);
-impl_pin!(P3_9, 3, 9, Gpio3);
-impl_pin!(P3_10, 3, 10, Gpio3);
-impl_pin!(P3_11, 3, 11, Gpio3);
-impl_pin!(P3_12, 3, 12, Gpio3);
-impl_pin!(P3_13, 3, 13, Gpio3);
-impl_pin!(P3_14, 3, 14, Gpio3);
-impl_pin!(P3_15, 3, 15, Gpio3);
-impl_pin!(P3_16, 3, 16, Gpio3);
-impl_pin!(P3_17, 3, 17, Gpio3);
-impl_pin!(P3_18, 3, 18, Gpio3);
-impl_pin!(P3_19, 3, 19, Gpio3);
-impl_pin!(P3_20, 3, 20, Gpio3);
-impl_pin!(P3_21, 3, 21, Gpio3);
-impl_pin!(P3_22, 3, 22, Gpio3);
-impl_pin!(P3_23, 3, 23, Gpio3);
-impl_pin!(P3_24, 3, 24, Gpio3);
-impl_pin!(P3_25, 3, 25, Gpio3);
-impl_pin!(P3_26, 3, 26, Gpio3);
-impl_pin!(P3_27, 3, 27, Gpio3);
-impl_pin!(P3_28, 3, 28, Gpio3);
-impl_pin!(P3_29, 3, 29, Gpio3);
-impl_pin!(P3_30, 3, 30, Gpio3);
-impl_pin!(P3_31, 3, 31, Gpio3);
+impl_pin!(P3_0, 3, 0, GPIO3);
+impl_pin!(P3_1, 3, 1, GPIO3);
+impl_pin!(P3_2, 3, 2, GPIO3);
+impl_pin!(P3_3, 3, 3, GPIO3);
+impl_pin!(P3_4, 3, 4, GPIO3);
+impl_pin!(P3_5, 3, 5, GPIO3);
+impl_pin!(P3_6, 3, 6, GPIO3);
+impl_pin!(P3_7, 3, 7, GPIO3);
+impl_pin!(P3_8, 3, 8, GPIO3);
+impl_pin!(P3_9, 3, 9, GPIO3);
+impl_pin!(P3_10, 3, 10, GPIO3);
+impl_pin!(P3_11, 3, 11, GPIO3);
+impl_pin!(P3_12, 3, 12, GPIO3);
+impl_pin!(P3_13, 3, 13, GPIO3);
+impl_pin!(P3_14, 3, 14, GPIO3);
+impl_pin!(P3_15, 3, 15, GPIO3);
+impl_pin!(P3_16, 3, 16, GPIO3);
+impl_pin!(P3_17, 3, 17, GPIO3);
+impl_pin!(P3_18, 3, 18, GPIO3);
+impl_pin!(P3_19, 3, 19, GPIO3);
+impl_pin!(P3_20, 3, 20, GPIO3);
+impl_pin!(P3_21, 3, 21, GPIO3);
+impl_pin!(P3_22, 3, 22, GPIO3);
+impl_pin!(P3_23, 3, 23, GPIO3);
+impl_pin!(P3_24, 3, 24, GPIO3);
+impl_pin!(P3_25, 3, 25, GPIO3);
+impl_pin!(P3_26, 3, 26, GPIO3);
+impl_pin!(P3_27, 3, 27, GPIO3);
+impl_pin!(P3_28, 3, 28, GPIO3);
+impl_pin!(P3_29, 3, 29, GPIO3);
+impl_pin!(P3_30, 3, 30, GPIO3);
+impl_pin!(P3_31, 3, 31, GPIO3);
 
-impl_pin!(P4_0, 4, 0, Gpio4);
-impl_pin!(P4_1, 4, 1, Gpio4);
-impl_pin!(P4_2, 4, 2, Gpio4);
-impl_pin!(P4_3, 4, 3, Gpio4);
-impl_pin!(P4_4, 4, 4, Gpio4);
-impl_pin!(P4_5, 4, 5, Gpio4);
-impl_pin!(P4_6, 4, 6, Gpio4);
-impl_pin!(P4_7, 4, 7, Gpio4);
-impl_pin!(P4_8, 4, 8, Gpio4);
-impl_pin!(P4_9, 4, 9, Gpio4);
-impl_pin!(P4_10, 4, 10, Gpio4);
-impl_pin!(P4_11, 4, 11, Gpio4);
-impl_pin!(P4_12, 4, 12, Gpio4);
-impl_pin!(P4_13, 4, 13, Gpio4);
-impl_pin!(P4_14, 4, 14, Gpio4);
-impl_pin!(P4_15, 4, 15, Gpio4);
-impl_pin!(P4_16, 4, 16, Gpio4);
-impl_pin!(P4_17, 4, 17, Gpio4);
-impl_pin!(P4_18, 4, 18, Gpio4);
-impl_pin!(P4_19, 4, 19, Gpio4);
-impl_pin!(P4_20, 4, 20, Gpio4);
-impl_pin!(P4_21, 4, 21, Gpio4);
-impl_pin!(P4_22, 4, 22, Gpio4);
-impl_pin!(P4_23, 4, 23, Gpio4);
-impl_pin!(P4_24, 4, 24, Gpio4);
-impl_pin!(P4_25, 4, 25, Gpio4);
-impl_pin!(P4_26, 4, 26, Gpio4);
-impl_pin!(P4_27, 4, 27, Gpio4);
-impl_pin!(P4_28, 4, 28, Gpio4);
-impl_pin!(P4_29, 4, 29, Gpio4);
-impl_pin!(P4_30, 4, 30, Gpio4);
-impl_pin!(P4_31, 4, 31, Gpio4);
+impl_pin!(P4_0, 4, 0, GPIO4);
+impl_pin!(P4_1, 4, 1, GPIO4);
+impl_pin!(P4_2, 4, 2, GPIO4);
+impl_pin!(P4_3, 4, 3, GPIO4);
+impl_pin!(P4_4, 4, 4, GPIO4);
+impl_pin!(P4_5, 4, 5, GPIO4);
+impl_pin!(P4_6, 4, 6, GPIO4);
+impl_pin!(P4_7, 4, 7, GPIO4);
+// impl_pin!(P4_8, 4, 8, GPIO4);
+// impl_pin!(P4_9, 4, 9, GPIO4);
+// impl_pin!(P4_10, 4, 10, GPIO4);
+// impl_pin!(P4_11, 4, 11, GPIO4);
+// impl_pin!(P4_12, 4, 12, GPIO4);
+// impl_pin!(P4_13, 4, 13, GPIO4);
+// impl_pin!(P4_14, 4, 14, GPIO4);
+// impl_pin!(P4_15, 4, 15, GPIO4);
+// impl_pin!(P4_16, 4, 16, GPIO4);
+// impl_pin!(P4_17, 4, 17, GPIO4);
+// impl_pin!(P4_18, 4, 18, GPIO4);
+// impl_pin!(P4_19, 4, 19, GPIO4);
+// impl_pin!(P4_20, 4, 20, GPIO4);
+// impl_pin!(P4_21, 4, 21, GPIO4);
+// impl_pin!(P4_22, 4, 22, GPIO4);
+// impl_pin!(P4_23, 4, 23, GPIO4);
+// impl_pin!(P4_24, 4, 24, GPIO4);
+// impl_pin!(P4_25, 4, 25, GPIO4);
+// impl_pin!(P4_26, 4, 26, GPIO4);
+// impl_pin!(P4_27, 4, 27, GPIO4);
+// impl_pin!(P4_28, 4, 28, GPIO4);
+// impl_pin!(P4_29, 4, 29, GPIO4);
+// impl_pin!(P4_30, 4, 30, GPIO4);
+// impl_pin!(P4_31, 4, 31, GPIO4);
 
 /// A flexible pin that can be configured as input or output.
 pub struct Flex<'d> {
@@ -646,7 +626,7 @@ impl<'d> Flex<'d> {
     /// The pin remains unmodified. The initial output level is unspecified, but
     /// can be changed before the pin is put into output mode.
     pub fn new(pin: Peri<'d, impl GpioPin>) -> Self {
-        pin.set_function(Mux::Mux0);
+        pin.set_function(Mux::MUX0);
         Self {
             pin: pin.into(),
             _marker: PhantomData,
@@ -654,7 +634,7 @@ impl<'d> Flex<'d> {
     }
 
     #[inline]
-    fn gpio(&self) -> &'static crate::pac::gpio0::RegisterBlock {
+    fn gpio(&self) -> crate::pac::gpio::Gpio {
         self.pin.gpio()
     }
 
@@ -663,25 +643,31 @@ impl<'d> Flex<'d> {
         self.set_enable_input_buffer(true);
         self.gpio()
             .pddr()
-            .modify(|_, w| w.pdd(self.pin.pin_index()).clear_bit());
+            .modify(|w| w.set_pdd(self.pin.pin_index() as usize, Pdd::PDD0));
     }
 
     /// Put the pin into output mode.
     pub fn set_as_output(&mut self) {
         self.set_pull(Pull::Disabled);
-        self.gpio().pddr().modify(|_, w| w.pdd(self.pin.pin_index()).set_bit());
+        self.gpio()
+            .pddr()
+            .modify(|w| w.set_pdd(self.pin.pin_index() as usize, Pdd::PDD1));
     }
 
     /// Set output level to High.
     #[inline]
     pub fn set_high(&mut self) {
-        self.gpio().psor().write(|w| w.ptso(self.pin.pin_index()).set_bit());
+        self.gpio()
+            .psor()
+            .write(|w| w.set_ptso(self.pin.pin_index() as usize, Ptso::PTSO1));
     }
 
     /// Set output level to Low.
     #[inline]
     pub fn set_low(&mut self) {
-        self.gpio().pcor().write(|w| w.ptco(self.pin.pin_index()).set_bit());
+        self.gpio()
+            .pcor()
+            .write(|w| w.set_ptco(self.pin.pin_index() as usize, Ptco::PTCO1));
     }
 
     /// Set output level to the given `Level`.
@@ -696,13 +682,15 @@ impl<'d> Flex<'d> {
     /// Toggle output level.
     #[inline]
     pub fn toggle(&mut self) {
-        self.gpio().ptor().write(|w| w.ptto(self.pin.pin_index()).set_bit());
+        self.gpio()
+            .ptor()
+            .write(|w| w.set_ptto(self.pin.pin_index() as usize, true));
     }
 
     /// Get whether the pin input level is high.
     #[inline]
     pub fn is_high(&self) -> bool {
-        self.gpio().pdir().read().pdi(self.pin.pin_index()).bit_is_set()
+        self.gpio().pdir().read().pdi(self.pin.pin_index() as usize)
     }
 
     /// Get whether the pin input level is low.
@@ -752,7 +740,7 @@ impl<'d> Flex<'d> {
 /// Async methods
 impl<'d> Flex<'d> {
     /// Helper function that waits for a given interrupt trigger
-    async fn wait_for_inner(&mut self, level: crate::pac::gpio0::icr::Irqc) {
+    async fn wait_for_inner(&mut self, level: crate::pac::gpio::vals::Irqc) {
         // First, ensure that we have a waker that is ready for this port+pin
         let w = PORT_WAIT_MAPS[usize::from(self.pin.port)].wait(self.pin.pin.into());
         let mut w = pin!(w);
@@ -770,17 +758,14 @@ impl<'d> Flex<'d> {
         // Now that our waker is in the map, we can enable the appropriate interrupt
         //
         // Clear any existing pending interrupt on this pin
-        self.pin
-            .gpio()
-            .isfr0()
-            .write(|w| unsafe { w.bits(1 << self.pin.pin()) });
-        self.pin.gpio().icr(self.pin.pin().into()).write(|w| w.isf().isf1());
-
-        // Pin interrupt configuration
+        self.pin.gpio().isfr0().write(|w| w.0 = 1 << self.pin.pin());
         self.pin
             .gpio()
             .icr(self.pin.pin().into())
-            .modify(|_, w| w.irqc().variant(level));
+            .write(|w| w.set_isf(Isf::ISF1));
+
+        // Pin interrupt configuration
+        self.pin.gpio().icr(self.pin.pin().into()).modify(|w| w.set_irqc(level));
 
         // Finally, we can await the matching call to `.wake()` from the interrupt.
         //
@@ -792,31 +777,31 @@ impl<'d> Flex<'d> {
     /// Wait until the pin is high. If it is already high, return immediately.
     #[inline]
     pub fn wait_for_high(&mut self) -> impl Future<Output = ()> + use<'_, 'd> {
-        self.wait_for_inner(crate::pac::gpio0::icr::Irqc::Irqc12)
+        self.wait_for_inner(Irqc::IRQC12)
     }
 
     /// Wait until the pin is low. If it is already low, return immediately.
     #[inline]
     pub fn wait_for_low(&mut self) -> impl Future<Output = ()> + use<'_, 'd> {
-        self.wait_for_inner(crate::pac::gpio0::icr::Irqc::Irqc8)
+        self.wait_for_inner(Irqc::IRQC8)
     }
 
     /// Wait for the pin to undergo a transition from low to high.
     #[inline]
     pub fn wait_for_rising_edge(&mut self) -> impl Future<Output = ()> + use<'_, 'd> {
-        self.wait_for_inner(crate::pac::gpio0::icr::Irqc::Irqc9)
+        self.wait_for_inner(Irqc::IRQC9)
     }
 
     /// Wait for the pin to undergo a transition from high to low.
     #[inline]
     pub fn wait_for_falling_edge(&mut self) -> impl Future<Output = ()> + use<'_, 'd> {
-        self.wait_for_inner(crate::pac::gpio0::icr::Irqc::Irqc10)
+        self.wait_for_inner(Irqc::IRQC10)
     }
 
     /// Wait for the pin to undergo any transition, i.e low to high OR high to low.
     #[inline]
     pub fn wait_for_any_edge(&mut self) -> impl Future<Output = ()> + use<'_, 'd> {
-        self.wait_for_inner(crate::pac::gpio0::icr::Irqc::Irqc11)
+        self.wait_for_inner(Irqc::IRQC11)
     }
 }
 

--- a/embassy-mcxa/src/i2c/mod.rs
+++ b/embassy-mcxa/src/i2c/mod.rs
@@ -33,14 +33,14 @@ pub trait Instance: SealedInstance + PeripheralType + 'static + Send + Gate<Mrcc
 }
 
 struct Info {
-    regs: *const pac::lpi2c0::RegisterBlock,
+    regs: pac::lpi2c::Lpi2c,
     wait_cell: WaitCell,
 }
 
 impl Info {
     #[inline(always)]
-    fn regs(&self) -> &'static pac::lpi2c0::RegisterBlock {
-        unsafe { &*self.regs }
+    fn regs(&self) -> pac::lpi2c::Lpi2c {
+        self.regs
     }
 
     #[inline(always)]
@@ -58,8 +58,8 @@ macro_rules! impl_instance {
                 impl SealedInstance for crate::peripherals::[<LPI2C $n>] {
                     fn info() -> &'static Info {
                         static INFO: Info = Info {
-                            regs: pac::[<Lpi2c $n>]::ptr(),
-                            wait_cell:  WaitCell::new(),
+                            regs: pac::[<LPI2C $n>],
+                            wait_cell: WaitCell::new(),
                         };
                         &INFO
                     }
@@ -112,41 +112,41 @@ macro_rules! impl_pin {
                 self.set_pull(crate::gpio::Pull::Disabled);
                 self.set_slew_rate(crate::gpio::SlewRate::Fast.into());
                 self.set_drive_strength(crate::gpio::DriveStrength::Double.into());
-                self.set_function(crate::pac::port0::pcr0::Mux::$fn);
+                self.set_function(crate::pac::port::vals::Mux::$fn);
                 self.set_enable_input_buffer(true);
             }
         }
     };
 }
 
-impl_pin!(P0_16, LPI2C0, Mux2, SdaPin);
-impl_pin!(P0_17, LPI2C0, Mux2, SclPin);
-impl_pin!(P0_18, LPI2C0, Mux2, SclPin);
-impl_pin!(P0_19, LPI2C0, Mux2, SdaPin);
-impl_pin!(P1_0, LPI2C1, Mux3, SdaPin);
-impl_pin!(P1_1, LPI2C1, Mux3, SclPin);
-impl_pin!(P1_2, LPI2C1, Mux3, SdaPin);
-impl_pin!(P1_3, LPI2C1, Mux3, SclPin);
-impl_pin!(P1_8, LPI2C2, Mux3, SdaPin);
-impl_pin!(P1_9, LPI2C2, Mux3, SclPin);
-impl_pin!(P1_10, LPI2C2, Mux3, SdaPin);
-impl_pin!(P1_11, LPI2C2, Mux3, SclPin);
-impl_pin!(P1_12, LPI2C1, Mux2, SdaPin);
-impl_pin!(P1_13, LPI2C1, Mux2, SclPin);
-impl_pin!(P1_14, LPI2C1, Mux2, SclPin);
-impl_pin!(P1_15, LPI2C1, Mux2, SdaPin);
+impl_pin!(P0_16, LPI2C0, MUX2, SdaPin);
+impl_pin!(P0_17, LPI2C0, MUX2, SclPin);
+impl_pin!(P0_18, LPI2C0, MUX2, SclPin);
+impl_pin!(P0_19, LPI2C0, MUX2, SdaPin);
+impl_pin!(P1_0, LPI2C1, MUX3, SdaPin);
+impl_pin!(P1_1, LPI2C1, MUX3, SclPin);
+impl_pin!(P1_2, LPI2C1, MUX3, SdaPin);
+impl_pin!(P1_3, LPI2C1, MUX3, SclPin);
+impl_pin!(P1_8, LPI2C2, MUX3, SdaPin);
+impl_pin!(P1_9, LPI2C2, MUX3, SclPin);
+impl_pin!(P1_10, LPI2C2, MUX3, SdaPin);
+impl_pin!(P1_11, LPI2C2, MUX3, SclPin);
+impl_pin!(P1_12, LPI2C1, MUX2, SdaPin);
+impl_pin!(P1_13, LPI2C1, MUX2, SclPin);
+impl_pin!(P1_14, LPI2C1, MUX2, SclPin);
+impl_pin!(P1_15, LPI2C1, MUX2, SdaPin);
 // NOTE: P1_30 and P1_31 are typically used for the external oscillator
 // For now, we just don't give users these pins.
 //
-// impl_pin!(P1_30, LPI2C0, Mux3, SdaPin);
-// impl_pin!(P1_31, LPI2C0, Mux3, SclPin);
-impl_pin!(P3_27, LPI2C3, Mux2, SclPin);
-impl_pin!(P3_28, LPI2C3, Mux2, SdaPin);
-// impl_pin!(P3_29, LPI2C3, Mux2, HreqPin); What is this HREQ pin?
-impl_pin!(P3_30, LPI2C3, Mux2, SclPin);
-impl_pin!(P3_31, LPI2C3, Mux2, SdaPin);
-impl_pin!(P4_2, LPI2C2, Mux2, SdaPin);
-impl_pin!(P4_3, LPI2C0, Mux2, SclPin);
-impl_pin!(P4_4, LPI2C2, Mux2, SdaPin);
-impl_pin!(P4_5, LPI2C0, Mux2, SclPin);
-// impl_pin!(P4_6, LPI2C0, Mux2, HreqPin); What is this HREQ pin?
+// impl_pin!(P1_30, LPI2C0, MUX3, SdaPin);
+// impl_pin!(P1_31, LPI2C0, MUX3, SclPin);
+impl_pin!(P3_27, LPI2C3, MUX2, SclPin);
+impl_pin!(P3_28, LPI2C3, MUX2, SdaPin);
+// impl_pin!(P3_29, LPI2C3, MUX2, HreqPin); What is this HREQ pin?
+impl_pin!(P3_30, LPI2C3, MUX2, SclPin);
+impl_pin!(P3_31, LPI2C3, MUX2, SdaPin);
+impl_pin!(P4_2, LPI2C2, MUX2, SdaPin);
+impl_pin!(P4_3, LPI2C0, MUX2, SclPin);
+impl_pin!(P4_4, LPI2C2, MUX2, SdaPin);
+impl_pin!(P4_5, LPI2C0, MUX2, SclPin);
+// impl_pin!(P4_6, LPI2C0, MUX2, HreqPin); What is this HREQ pin?

--- a/embassy-mcxa/src/lib.rs
+++ b/embassy-mcxa/src/lib.rs
@@ -5,15 +5,14 @@
 // //! ## Feature flags
 // #![doc = document_features::document_features!(feature_label = r#"<span class="stab portability"><code>{feature}</code></span>"#)]
 
-pub mod clocks; // still provide clock helpers
-pub mod dma;
-pub mod gpio;
-
 pub mod adc;
 pub mod cdog;
 pub mod clkout;
+pub mod clocks; // still provide clock helpers
 pub mod config;
 pub mod crc;
+pub mod dma;
+pub mod gpio;
 pub mod i2c;
 pub mod i3c;
 pub mod lpuart;
@@ -447,9 +446,9 @@ embassy_hal_internal::interrupt_mod!(
 
 // Re-export interrupt traits and types
 #[cfg(feature = "unstable-pac")]
-pub use mcxa_pac as pac;
+pub use nxp_pac as pac;
 #[cfg(not(feature = "unstable-pac"))]
-pub(crate) use mcxa_pac as pac;
+pub(crate) use nxp_pac as pac;
 
 /// Initialize HAL with configuration (mirrors embassy-imxrt style). Minimal: just take peripherals.
 /// Also applies configurable NVIC priority for the OSTIMER OS_EVENT interrupt (no enabling).

--- a/embassy-mcxa/src/reset_reason.rs
+++ b/embassy-mcxa/src/reset_reason.rs
@@ -15,50 +15,17 @@ static RESET_REASON: AtomicU32 = AtomicU32::new(0);
 /// Reads the most recent reset reason from the Core Mode Controller
 /// (CMC).
 pub fn reset_reason() -> ResetReasonRaw {
-    let regs = unsafe { &*crate::pac::Cmc::steal() };
+    let regs = crate::pac::CMC;
 
     let reason = critical_section::with(|_| {
         let mut r = RESET_REASON.load(Ordering::Relaxed);
 
         if r == 0 {
             // Read status
-            r = regs.srs().read().bits();
+            r = regs.srs().read().0;
 
             // Clear status
-            regs.ssrs().write(|w| {
-                w.wakeup()
-                    .clear_bit_by_one()
-                    .por()
-                    .clear_bit_by_one()
-                    .warm()
-                    .clear_bit_by_one()
-                    .fatal()
-                    .clear_bit_by_one()
-                    .pin()
-                    .clear_bit_by_one()
-                    .dap()
-                    .clear_bit_by_one()
-                    .rstack()
-                    .clear_bit_by_one()
-                    .lpack()
-                    .clear_bit_by_one()
-                    .scg()
-                    .clear_bit_by_one()
-                    .wwdt0()
-                    .clear_bit_by_one()
-                    .sw()
-                    .clear_bit_by_one()
-                    .lockup()
-                    .clear_bit_by_one()
-                    .cdog0()
-                    .clear_bit_by_one()
-                    .cdog1()
-                    .clear_bit_by_one()
-                    .jtag()
-                    .clear_bit_by_one()
-                    .tamper()
-                    .clear_bit_by_one()
-            });
+            regs.ssrs().modify(|w| w.0 = r);
 
             RESET_REASON.store(r, Ordering::Relaxed);
         }

--- a/examples/mcxa/src/bin/adc_interrupt.rs
+++ b/examples/mcxa/src/bin/adc_interrupt.rs
@@ -9,9 +9,7 @@ use hal::clocks::PoweredClock;
 use hal::clocks::config::Div8;
 use hal::clocks::periph_helpers::{AdcClockSel, Div4};
 use hal::config::Config;
-use hal::pac::adc1::cfg::{Pwrsel, Refsel};
-use hal::pac::adc1::cmdl1::Mode;
-use hal::pac::adc1::ctrl::CalAvgs;
+use hal::pac::adc::vals::{CalAvgs, Mode, Pwrsel, Refsel};
 use hal::peripherals::ADC1;
 use {defmt_rtt as _, embassy_mcxa as hal, panic_probe as _};
 
@@ -30,11 +28,11 @@ async fn main(_spawner: Spawner) {
 
     let adc_config = adc::Config {
         enable_in_doze_mode: true,
-        conversion_average_mode: CalAvgs::Average128,
+        conversion_average_mode: CalAvgs::AVERAGE_128,
         enable_analog_preliminary: true,
         power_up_delay: 0x80,
-        reference_voltage_source: Refsel::Option3,
-        power_level_mode: Pwrsel::Lowest,
+        reference_voltage_source: Refsel::OPTION_3,
+        power_level_mode: Pwrsel::LOWEST,
         trigger_priority_policy: TriggerPriorityPolicy::ConvPreemptImmediatelyNotAutoResumed,
         enable_conv_pause: false,
         conv_pause_delay: 0,
@@ -46,7 +44,7 @@ async fn main(_spawner: Spawner) {
 
     adc.do_offset_calibration();
     adc.do_auto_calibration();
-    adc.set_resolution(Mode::Data16Bits);
+    adc.set_resolution(Mode::DATA_16_BITS);
 
     defmt::info!("ADC configuration done...");
     let mut ticker = Ticker::every(Duration::from_millis(100));

--- a/examples/mcxa/src/bin/adc_polling.rs
+++ b/examples/mcxa/src/bin/adc_polling.rs
@@ -9,10 +9,7 @@ use hal::clocks::PoweredClock;
 use hal::clocks::config::Div8;
 use hal::clocks::periph_helpers::{AdcClockSel, Div4};
 use hal::config::Config;
-use hal::pac::adc1::cfg::{Pwrsel, Refsel};
-use hal::pac::adc1::cmdl1::Mode;
-use hal::pac::adc1::ctrl::CalAvgs;
-use hal::pac::adc1::tctrl::Tcmd;
+use hal::pac::adc::vals::{CalAvgs, Mode, Pwrsel, Refsel, Tcmd};
 use {defmt_rtt as _, embassy_mcxa as hal, panic_probe as _};
 
 const G_LPADC_RESULT_SHIFT: u32 = 0;
@@ -28,11 +25,11 @@ async fn main(_spawner: Spawner) {
 
     let adc_config = adc::Config {
         enable_in_doze_mode: true,
-        conversion_average_mode: CalAvgs::Average128,
+        conversion_average_mode: CalAvgs::AVERAGE_128,
         enable_analog_preliminary: true,
         power_up_delay: 0x80,
-        reference_voltage_source: Refsel::Option3,
-        power_level_mode: Pwrsel::Lowest,
+        reference_voltage_source: Refsel::OPTION_3,
+        power_level_mode: Pwrsel::LOWEST,
         trigger_priority_policy: TriggerPriorityPolicy::ConvPreemptImmediatelyNotAutoResumed,
         enable_conv_pause: false,
         conv_pause_delay: 0,
@@ -46,13 +43,13 @@ async fn main(_spawner: Spawner) {
     adc.do_auto_calibration();
 
     let conv_command_config = ConvCommandConfig {
-        conversion_resolution_mode: Mode::Data16Bits,
+        conversion_resolution_mode: Mode::DATA_16_BITS,
         ..ConvCommandConfig::default()
     };
     adc.set_conv_command_config(1, &conv_command_config).unwrap();
 
-    let conv_trigger_config = ConvTriggerConfig {
-        target_command_id: Tcmd::ExecuteCmd1,
+    let conv_trigger_config: ConvTriggerConfig = ConvTriggerConfig {
+        target_command_id: Tcmd::EXECUTE_CMD1,
         enable_hardware_trigger: false,
         ..Default::default()
     };

--- a/examples/mcxa/src/bin/raw_dma_interleave_transfer.rs
+++ b/examples/mcxa/src/bin/raw_dma_interleave_transfer.rs
@@ -17,6 +17,7 @@
 use embassy_executor::Spawner;
 use embassy_mcxa::clocks::config::Div8;
 use embassy_mcxa::dma::DmaChannel;
+use embassy_mcxa::pac::edma_0_tcd::vals::Size;
 use static_cell::ConstStaticCell;
 use {defmt_rtt as _, embassy_mcxa as hal, panic_probe as _};
 
@@ -65,48 +66,45 @@ async fn main(_spawner: Spawner) {
 
         // Reset channel state
         t.ch_csr().write(|w| {
-            w.erq()
-                .disable()
-                .earq()
-                .disable()
-                .eei()
-                .no_error()
-                .ebw()
-                .disable()
-                .done()
-                .clear_bit_by_one()
+            w.set_erq(false);
+            w.set_earq(false);
+            w.set_eei(false);
+            w.set_ebw(false);
+            w.set_done(true);
         });
-        t.ch_es().write(|w| w.bits(0));
-        t.ch_int().write(|w| w.int().clear_bit_by_one());
+        t.ch_es().write(|w| w.0 = 0);
+        t.ch_int().write(|w| w.set_int(true));
 
         // Source/destination addresses
-        t.tcd_saddr().write(|w| w.saddr().bits(src.as_ptr() as u32));
-        t.tcd_daddr().write(|w| w.daddr().bits(dst.as_mut_ptr() as u32));
+        t.tcd_saddr().write(|w| w.set_saddr(src.as_ptr() as u32));
+        t.tcd_daddr().write(|w| w.set_daddr(dst.as_mut_ptr() as u32));
 
         // Custom offsets for interleaving
-        t.tcd_soff().write(|w| w.soff().bits(4)); // src: +4 bytes per read
-        t.tcd_doff().write(|w| w.doff().bits(8)); // dst: +8 bytes per write
+        t.tcd_soff().write(|w| w.set_soff(4)); // src: +4 bytes per read
+        t.tcd_doff().write(|w| w.set_doff(8)); // dst: +8 bytes per write
 
         // Attributes: 32-bit transfers (size = 2)
-        t.tcd_attr().write(|w| w.ssize().bits(2).dsize().bits(2));
+        t.tcd_attr().write(|w| {
+            w.set_ssize(Size::THIRTYTWO_BIT);
+            w.set_dsize(Size::THIRTYTWO_BIT);
+        });
 
         // Transfer entire source buffer in one minor loop
         let nbytes = (HALF_BUFF_LENGTH * 4) as u32;
-        t.tcd_nbytes_mloffno().write(|w| w.nbytes().bits(nbytes));
+        t.tcd_nbytes_mloffno().write(|w| w.set_nbytes(nbytes));
 
         // Reset source address after major loop
-        t.tcd_slast_sda().write(|w| w.slast_sda().bits(-(nbytes as i32) as u32));
+        t.tcd_slast_sda().write(|w| w.set_slast_sda(-(nbytes as i32) as u32));
         // Destination uses 2x offset, so adjust accordingly
         let dst_total = (HALF_BUFF_LENGTH * 8) as u32;
-        t.tcd_dlast_sga()
-            .write(|w| w.dlast_sga().bits(-(dst_total as i32) as u32));
+        t.tcd_dlast_sga().write(|w| w.set_dlast_sga(-(dst_total as i32) as u32));
 
         // Major loop count = 1
-        t.tcd_biter_elinkno().write(|w| w.biter().bits(1));
-        t.tcd_citer_elinkno().write(|w| w.citer().bits(1));
+        t.tcd_biter_elinkno().write(|w| w.set_biter(1));
+        t.tcd_citer_elinkno().write(|w| w.set_citer(1));
 
         // Enable interrupt on major loop completion
-        t.tcd_csr().write(|w| w.intmajor().set_bit());
+        t.tcd_csr().write(|w| w.set_intmajor(true));
 
         cortex_m::asm::dsb();
 

--- a/examples/mcxa/src/bin/raw_dma_ping_pong_transfer.rs
+++ b/examples/mcxa/src/bin/raw_dma_ping_pong_transfer.rs
@@ -146,7 +146,7 @@ async fn main(_spawner: Spawner) {
     let tcd = dma_ch0.tcd();
     // Wait for first half
     loop {
-        if tcd.tcd_saddr().read().bits() != src.as_ptr() as u32 {
+        if tcd.tcd_saddr().read().0 != src.as_ptr() as u32 {
             break;
         }
     }
@@ -161,7 +161,7 @@ async fn main(_spawner: Spawner) {
 
     // Wait for second half
     loop {
-        if tcd.tcd_saddr().read().bits() != unsafe { src.as_ptr().add(half_len) } as u32 {
+        if tcd.tcd_saddr().read().0 != unsafe { src.as_ptr().add(half_len) } as u32 {
             break;
         }
     }

--- a/examples/mcxa/src/bin/raw_dma_scatter_gather.rs
+++ b/examples/mcxa/src/bin/raw_dma_scatter_gather.rs
@@ -128,8 +128,8 @@ async fn main(_spawner: Spawner) {
 
     // Wait for first half
     loop {
-        if tcd.tcd_saddr().read().bits() != src_ptr as u32 {
-            defmt::info!("saddr: {=u32}", tcd.tcd_saddr().read().bits());
+        if tcd.tcd_saddr().read().0 != src_ptr as u32 {
+            defmt::info!("saddr: {=u32}", tcd.tcd_saddr().read().0);
             defmt::info!("srptr: {=u32}", src_ptr as u32);
             break;
         }


### PR DESCRIPTION
Beware big scary merge. I'll try to coordinate with other in-flight PR authors to get this merged smoothly without causing too much pain.

Implements https://github.com/embassy-rs/embassy/issues/5111.

I tried to touch everything as little as possible and not get distracted by any other cleanup I could do.

Rationale for changing over to nxp-pac is to eventually end up with a similar situation as with embassy-stm32, where we can easily share HAL drivers between embassy-nxp and embassy-mcxa. AFAIK there is no IP overlap between the families currently supported in embassy-nxp and MCXA. It would be great to be prepared regardless for when new IC's are added that do overlap.

Requires merging of https://github.com/embassy-rs/chiptool/pull/82 and https://github.com/embassy-rs/nxp-pac/pull/20.