### PR TITLE
stm32: simplify low-power wake guard

### DIFF
--- a/embassy-stm32/build.rs
+++ b/embassy-stm32/build.rs
@@ -2133,7 +2133,7 @@ fn main() {
         #[cfg(feature = "_dual-core")]
         let irq_pac = quote!(crate::pac::Interrupt::#irq_ident);
 
-        g.extend(quote!(dma_channel_impl!(#name, #idx, #stop_mode, #irq_type);));
+        g.extend(quote!(dma_channel_impl!(#name, #idx, #irq_type);));
 
         let dma = format_ident!("{}", ch.dma);
         let ch_num = ch.channel as usize;
@@ -2168,6 +2168,8 @@ fn main() {
             crate::dma::ChannelInfo {
                 dma: #dma_info,
                 num: #ch_num,
+                #[cfg(feature = "low-power")]
+                stop_mode: crate::rcc::StopMode::#stop_mode,
                 #dmamux
             },
         });
@@ -2177,6 +2179,8 @@ fn main() {
                 dma: #dma_info,
                 num: #ch_num,
                 irq: #irq_pac,
+                #[cfg(feature = "low-power")]
+                stop_mode: crate::rcc::StopMode::#stop_mode,
                 #dmamux
             },
         });

--- a/embassy-stm32/src/dma/gpdma/ringbuffered.rs
+++ b/embassy-stm32/src/dma/gpdma/ringbuffered.rs
@@ -13,7 +13,7 @@ use crate::dma::gpdma::linked_list::{RunMode, Table};
 use crate::dma::ringbuffer::{DmaCtrl, Error, ReadableDmaRingBuffer, WritableDmaRingBuffer};
 use crate::dma::word::Word;
 use crate::dma::{Dir, Request};
-use crate::rcc::BusyPeripheral;
+use crate::rcc::WakeGuard;
 
 struct DmaCtrlImpl<'a>(Peri<'a, AnyChannel>);
 
@@ -50,7 +50,8 @@ impl<'a> DmaCtrl for DmaCtrlImpl<'a> {
 
 /// Ringbuffer for receiving data using GPDMA linked-list mode.
 pub struct ReadableRingBuffer<'a, W: Word> {
-    channel: BusyPeripheral<Peri<'a, AnyChannel>>,
+    channel: Peri<'a, AnyChannel>,
+    _wake_guard: WakeGuard,
     ringbuf: ReadableDmaRingBuffer<'a, W>,
     table: Table<2>,
     options: TransferOptions,
@@ -70,7 +71,8 @@ impl<'a, W: Word> ReadableRingBuffer<'a, W> {
         let table = Table::<2>::new_ping_pong::<W>(request, peri_addr, buffer, Dir::PeripheralToMemory);
 
         Self {
-            channel: BusyPeripheral::new(channel),
+            _wake_guard: channel.info().wake_guard(),
+            channel,
             ringbuf: ReadableDmaRingBuffer::new(buffer),
             table,
             options,
@@ -189,7 +191,8 @@ impl<'a, W: Word> Drop for ReadableRingBuffer<'a, W> {
 
 /// Ringbuffer for writing data using GPDMA linked-list mode.
 pub struct WritableRingBuffer<'a, W: Word> {
-    channel: BusyPeripheral<Peri<'a, AnyChannel>>,
+    channel: Peri<'a, AnyChannel>,
+    _wake_guard: WakeGuard,
     ringbuf: WritableDmaRingBuffer<'a, W>,
     table: Table<2>,
     options: TransferOptions,
@@ -209,7 +212,8 @@ impl<'a, W: Word> WritableRingBuffer<'a, W> {
         let table = Table::<2>::new_ping_pong::<W>(request, peri_addr, buffer, Dir::MemoryToPeripheral);
 
         Self {
-            channel: BusyPeripheral::new(channel),
+            _wake_guard: channel.info().wake_guard(),
+            channel,
             ringbuf: WritableDmaRingBuffer::new(buffer),
             table,
             options,

--- a/embassy-stm32/src/hsem/mod.rs
+++ b/embassy-stm32/src/hsem/mod.rs
@@ -106,7 +106,7 @@ impl<'a, T: Instance> HardwareSemaphoreChannel<'a, T> {
     /// The 2-step lock procedure consists in a write to lock the semaphore, followed by a read to
     /// check if the lock has been successful, carried out from the HSEM_Rx register.
     pub async fn lock(&mut self, process_id: u8) -> HardwareSemaphoreMutex<'a, T> {
-        let _scoped_block_stop = T::RCC_INFO.block_stop();
+        let _scoped_wake_guard = T::RCC_INFO.wake_guard();
         let core_id = CoreId::current();
 
         poll_fn(|cx| {

--- a/embassy-stm32/src/i2c/v1.rs
+++ b/embassy-stm32/src/i2c/v1.rs
@@ -540,7 +540,7 @@ impl<'d, IM: MasterMode> I2c<'d, Async, IM> {
 
     /// Write.
     pub async fn write(&mut self, address: u8, write_buffer: &[u8]) -> Result<(), Error> {
-        let _scoped_block_stop = self.info.rcc.block_stop();
+        let _scoped_wake_guard = self.info.rcc.wake_guard();
         self.write_frame(address, write_buffer, FrameOptions::FirstAndLastFrame)
             .await?;
 
@@ -549,7 +549,7 @@ impl<'d, IM: MasterMode> I2c<'d, Async, IM> {
 
     /// Read.
     pub async fn read(&mut self, address: u8, read_buffer: &mut [u8]) -> Result<(), Error> {
-        let _scoped_block_stop = self.info.rcc.block_stop();
+        let _scoped_wake_guard = self.info.rcc.wake_guard();
         self.read_frame(address, read_buffer, FrameOptions::FirstAndLastFrame)
             .await?;
 
@@ -714,7 +714,7 @@ impl<'d, IM: MasterMode> I2c<'d, Async, IM> {
 
     /// Write, restart, read.
     pub async fn write_read(&mut self, address: u8, write_buffer: &[u8], read_buffer: &mut [u8]) -> Result<(), Error> {
-        let _scoped_block_stop = self.info.rcc.block_stop();
+        let _scoped_wake_guard = self.info.rcc.wake_guard();
         // Check empty read buffer before starting transaction. Otherwise, we would not generate the
         // stop condition below.
         if read_buffer.is_empty() {
@@ -733,7 +733,7 @@ impl<'d, IM: MasterMode> I2c<'d, Async, IM> {
     ///
     /// [transaction contract]: embedded_hal_1::i2c::I2c::transaction
     pub async fn transaction(&mut self, address: u8, operations: &mut [Operation<'_>]) -> Result<(), Error> {
-        let _scoped_block_stop = self.info.rcc.block_stop();
+        let _scoped_wake_guard = self.info.rcc.wake_guard();
         for (op, frame) in operation_frames(operations)? {
             match op {
                 Operation::Read(read_buffer) => self.read_frame(address, read_buffer, frame).await?,
@@ -1372,7 +1372,7 @@ impl<'d> I2c<'d, Async, MultiMaster> {
     /// (Read/Write) and the matched address. This method will suspend until
     /// an address match occurs.
     pub async fn listen(&mut self) -> Result<SlaveCommand, Error> {
-        let _scoped_block_stop = self.info.rcc.block_stop();
+        let _scoped_wake_guard = self.info.rcc.wake_guard();
         trace!("I2C slave: starting async listen for address match");
         let state = self.state;
         let info = self.info;
@@ -1437,7 +1437,7 @@ impl<'d> I2c<'d, Async, MultiMaster> {
     ///
     /// Returns the number of bytes stored in the buffer (not total received).
     pub async fn respond_to_write(&mut self, buffer: &mut [u8]) -> Result<usize, Error> {
-        let _scoped_block_stop = self.info.rcc.block_stop();
+        let _scoped_wake_guard = self.info.rcc.wake_guard();
         trace!("I2C slave: starting respond_to_write, buffer_len={}", buffer.len());
 
         if buffer.is_empty() {
@@ -1471,7 +1471,7 @@ impl<'d> I2c<'d, Async, MultiMaster> {
     ///
     /// Returns the total number of bytes transmitted (data + padding).
     pub async fn respond_to_read(&mut self, data: &[u8]) -> Result<usize, Error> {
-        let _scoped_block_stop = self.info.rcc.block_stop();
+        let _scoped_wake_guard = self.info.rcc.wake_guard();
         trace!("I2C slave: starting respond_to_read, data_len={}", data.len());
 
         if data.is_empty() {

--- a/embassy-stm32/src/i2c/v2.rs
+++ b/embassy-stm32/src/i2c/v2.rs
@@ -1075,7 +1075,7 @@ impl<'d, IM: MasterMode> I2c<'d, Async, IM> {
 
     /// Write.
     pub async fn write(&mut self, address: u8, write: &[u8]) -> Result<(), Error> {
-        let _scoped_block_stop = self.info.rcc.block_stop();
+        let _scoped_wake_guard = self.info.rcc.wake_guard();
         let timeout = self.timeout();
         if write.is_empty() {
             self.write_internal(address.into(), write, true, timeout)
@@ -1090,7 +1090,7 @@ impl<'d, IM: MasterMode> I2c<'d, Async, IM> {
     ///
     /// The buffers are concatenated in a single write transaction.
     pub async fn write_vectored(&mut self, address: Address, write: &[&[u8]]) -> Result<(), Error> {
-        let _scoped_block_stop = self.info.rcc.block_stop();
+        let _scoped_wake_guard = self.info.rcc.wake_guard();
         let timeout = self.timeout();
 
         if write.is_empty() {
@@ -1122,7 +1122,7 @@ impl<'d, IM: MasterMode> I2c<'d, Async, IM> {
 
     /// Read.
     pub async fn read(&mut self, address: u8, buffer: &mut [u8]) -> Result<(), Error> {
-        let _scoped_block_stop = self.info.rcc.block_stop();
+        let _scoped_wake_guard = self.info.rcc.wake_guard();
         let timeout = self.timeout();
 
         if buffer.is_empty() {
@@ -1135,7 +1135,7 @@ impl<'d, IM: MasterMode> I2c<'d, Async, IM> {
 
     /// Write, restart, read.
     pub async fn write_read(&mut self, address: u8, write: &[u8], read: &mut [u8]) -> Result<(), Error> {
-        let _scoped_block_stop = self.info.rcc.block_stop();
+        let _scoped_wake_guard = self.info.rcc.wake_guard();
         let timeout = self.timeout();
 
         if write.is_empty() {
@@ -1161,7 +1161,7 @@ impl<'d, IM: MasterMode> I2c<'d, Async, IM> {
     ///
     /// [transaction contract]: embedded_hal_1::i2c::I2c::transaction
     pub async fn transaction(&mut self, addr: u8, operations: &mut [Operation<'_>]) -> Result<(), Error> {
-        let _scoped_block_stop = self.info.rcc.block_stop();
+        let _scoped_wake_guard = self.info.rcc.wake_guard();
         if operations.is_empty() {
             return Err(Error::ZeroLengthTransfer);
         }
@@ -1746,7 +1746,7 @@ impl<'d> I2c<'d, Async, MultiMaster> {
     ///
     /// The listen method is an asynchronous method but it does not require DMA to be asynchronous.
     pub async fn listen(&mut self) -> Result<SlaveCommand, Error> {
-        let _scoped_block_stop = self.info.rcc.block_stop();
+        let _scoped_wake_guard = self.info.rcc.wake_guard();
         let state = self.state;
         self.info.regs.cr1().modify(|reg| {
             reg.set_addrie(true);
@@ -1772,14 +1772,14 @@ impl<'d> I2c<'d, Async, MultiMaster> {
     ///
     /// Returns the total number of bytes received.
     pub async fn respond_to_write(&mut self, buffer: &mut [u8]) -> Result<usize, Error> {
-        let _scoped_block_stop = self.info.rcc.block_stop();
+        let _scoped_wake_guard = self.info.rcc.wake_guard();
         let timeout = self.timeout();
         timeout.with(self.read_dma_internal_slave(buffer, timeout)).await
     }
 
     /// Respond to a read request from an I2C master.
     pub async fn respond_to_read(&mut self, write: &[u8]) -> Result<SendStatus, Error> {
-        let _scoped_block_stop = self.info.rcc.block_stop();
+        let _scoped_wake_guard = self.info.rcc.wake_guard();
         let timeout = self.timeout();
         timeout.with(self.write_dma_internal_slave(write, timeout)).await
     }

--- a/embassy-stm32/src/ipcc.rs
+++ b/embassy-stm32/src/ipcc.rs
@@ -157,7 +157,7 @@ impl<'a> IpccTxChannel<'a> {
 
     /// Wait for the tx channel to become clear
     pub async fn flush(&mut self) {
-        let _scoped_block_stop = IPCC::RCC_INFO.block_stop();
+        let _scoped_wake_guard = IPCC::RCC_INFO.wake_guard();
         let regs = IPCC::regs();
         let core = CoreId::current();
 
@@ -212,7 +212,7 @@ impl<'a> IpccRxChannel<'a> {
 
     /// Receive data from an IPCC channel. The closure is called to read the data when appropriate.
     pub async fn receive<R>(&mut self, mut f: impl FnMut() -> Option<R>) -> R {
-        let _scoped_block_stop = IPCC::RCC_INFO.block_stop();
+        let _scoped_wake_guard = IPCC::RCC_INFO.wake_guard();
         let regs = IPCC::regs();
         let core = CoreId::current();
 

--- a/embassy-stm32/src/low_power.rs
+++ b/embassy-stm32/src/low_power.rs
@@ -52,7 +52,7 @@ use embassy_executor::*;
 #[cfg(not(feature = "_lp-time-driver"))]
 use crate::interrupt;
 pub use crate::rcc::StopMode;
-use crate::rcc::{BusyPeripheral, REFCOUNT_STOP1, REFCOUNT_STOP2};
+use crate::rcc::{REFCOUNT_STOP1, REFCOUNT_STOP2};
 #[cfg(feature = "low-power")]
 use crate::time_driver::LPTimeDriver;
 use crate::time_driver::get_driver;
@@ -77,30 +77,6 @@ fn __pender(context: *mut ()) {
             TASKS_PENDING.store(true, Ordering::Release);
             core::arch::asm!("sev");
             return;
-        }
-    }
-}
-
-/// Prevent the device from going into the stop mode if held
-pub struct DeviceBusy {
-    _stop_mode: BusyPeripheral<StopMode>,
-}
-
-impl DeviceBusy {
-    /// Create a new DeviceBusy with stop1.
-    pub fn new_stop1() -> Self {
-        Self::new(StopMode::Stop1)
-    }
-
-    /// Create a new DeviceBusy with stop2.
-    pub fn new_stop2() -> Self {
-        Self::new(StopMode::Stop2)
-    }
-
-    /// Create a new DeviceBusy.
-    pub fn new(stop_mode: StopMode) -> Self {
-        Self {
-            _stop_mode: BusyPeripheral::new(stop_mode),
         }
     }
 }

--- a/embassy-stm32/src/qspi/mod.rs
+++ b/embassy-stm32/src/qspi/mod.rs
@@ -405,7 +405,7 @@ impl<'d, T: Instance> Qspi<'d, T, Async> {
 
     /// Async read data, using DMA.
     pub async fn read_dma(&mut self, buf: &mut [u8], transaction: TransferConfig) {
-        let _scoped_block_stop = T::RCC_INFO.block_stop();
+        let _scoped_wake_guard = T::RCC_INFO.wake_guard();
         let transfer = self.start_read_transfer(transaction, buf);
         transfer.await;
     }
@@ -446,7 +446,7 @@ impl<'d, T: Instance> Qspi<'d, T, Async> {
 
     /// Async write data, using DMA.
     pub async fn write_dma(&mut self, buf: &[u8], transaction: TransferConfig) {
-        let _scoped_block_stop = T::RCC_INFO.block_stop();
+        let _scoped_wake_guard = T::RCC_INFO.wake_guard();
         let transfer = self.start_write_transfer(transaction, buf);
         transfer.await;
     }

--- a/embassy-stm32/src/sdmmc/sd.rs
+++ b/embassy-stm32/src/sdmmc/sd.rs
@@ -106,7 +106,7 @@ impl<'a, 'b> StorageDevice<'a, 'b, Card> {
 
     /// Initializes the card into a known state (or at least tries to).
     async fn acquire(&mut self, cmd_block: &mut CmdBlock, freq: Hertz) -> Result<(), Error> {
-        let _scoped_block_stop = self.sdmmc.info.rcc.block_stop();
+        let _scoped_wake_guard = self.sdmmc.info.rcc.wake_guard();
         let regs = self.sdmmc.info.regs;
 
         // Get the bus width configured in the Sdmmc peripheral
@@ -317,7 +317,7 @@ impl<'a, 'b> StorageDevice<'a, 'b, Emmc> {
     }
 
     async fn acquire(&mut self, _cmd_block: &mut CmdBlock, freq: Hertz) -> Result<(), Error> {
-        let _scoped_block_stop = self.sdmmc.info.rcc.block_stop();
+        let _scoped_wake_guard = self.sdmmc.info.rcc.wake_guard();
         let regs = self.sdmmc.info.regs;
 
         let bus_width = self.sdmmc.bus_width();
@@ -415,7 +415,7 @@ impl<'a, 'b, A: Addressable> StorageDevice<'a, 'b, A> {
     /// Read a data block.
     #[inline]
     pub async fn read_block(&mut self, block_idx: u32, data_block: &mut DataBlock) -> Result<(), Error> {
-        let _scoped_block_stop = self.sdmmc.info.rcc.block_stop();
+        let _scoped_wake_guard = self.sdmmc.info.rcc.wake_guard();
         let card_capacity = self.info.get_capacity();
 
         // Always read 1 block of 512 bytes
@@ -441,7 +441,7 @@ impl<'a, 'b, A: Addressable> StorageDevice<'a, 'b, A> {
     /// Read multiple data blocks.
     #[inline]
     pub async fn read_blocks(&mut self, block_idx: u32, blocks: &mut [DataBlock]) -> Result<(), Error> {
-        let _scoped_block_stop = self.sdmmc.info.rcc.block_stop();
+        let _scoped_wake_guard = self.sdmmc.info.rcc.wake_guard();
         let card_capacity = self.info.get_capacity();
 
         // NOTE(unsafe) reinterpret buffer as &mut [u32]
@@ -480,7 +480,7 @@ impl<'a, 'b, A: Addressable> StorageDevice<'a, 'b, A> {
     where
         CardStatus<A::Ext>: From<u32>,
     {
-        let _scoped_block_stop = self.sdmmc.info.rcc.block_stop();
+        let _scoped_wake_guard = self.sdmmc.info.rcc.wake_guard();
 
         // Always read 1 block of 512 bytes
         //  cards are byte addressed hence the blockaddress is in multiples of 512 bytes
@@ -524,7 +524,7 @@ impl<'a, 'b, A: Addressable> StorageDevice<'a, 'b, A> {
     where
         CardStatus<A::Ext>: From<u32>,
     {
-        let _scoped_block_stop = self.sdmmc.info.rcc.block_stop();
+        let _scoped_wake_guard = self.sdmmc.info.rcc.wake_guard();
 
         // NOTE(unsafe) reinterpret buffer as &[u32]
         let buffer = unsafe {

--- a/embassy-stm32/src/sdmmc/sdio.rs
+++ b/embassy-stm32/src/sdmmc/sdio.rs
@@ -97,7 +97,7 @@ impl<'a, 'b> SerialDataInterface<'a, 'b> {
 
     /// Initializes the card into a known state (or at least tries to).
     async fn acquire(&mut self, _freq: Hertz) -> Result<(), Error> {
-        let _scoped_block_stop = self.sdmmc.info.rcc.block_stop();
+        let _scoped_wake_guard = self.sdmmc.info.rcc.wake_guard();
 
         let _bus_width = match self.sdmmc.bus_width() {
             BusWidth::Eight => return Err(Error::BusWidth),
@@ -140,7 +140,7 @@ impl<'a, 'b> SerialDataInterface<'a, 'b> {
 
     /// Read in block mode using cmd53
     pub async fn cmd53_block_read(&mut self, arg: u32, blocks: &mut [DataBlock]) -> Result<(), Error> {
-        let _scoped_block_stop = self.sdmmc.info.rcc.block_stop();
+        let _scoped_wake_guard = self.sdmmc.info.rcc.wake_guard();
 
         // NOTE(unsafe) reinterpret buffer as &mut [u32]
         let buffer = unsafe {
@@ -161,7 +161,7 @@ impl<'a, 'b> SerialDataInterface<'a, 'b> {
 
     /// Read in multibyte mode using cmd53
     pub async fn cmd53_byte_read(&mut self, arg: u32, buffer: &mut Aligned<A4, [u8]>) -> Result<(), Error> {
-        let _scoped_block_stop = self.sdmmc.info.rcc.block_stop();
+        let _scoped_wake_guard = self.sdmmc.info.rcc.wake_guard();
 
         // trace!("byte read start (len): {:#x} ({})", arg, buffer.len());
 
@@ -180,7 +180,7 @@ impl<'a, 'b> SerialDataInterface<'a, 'b> {
 
     /// Write in block mode using cmd53
     pub async fn cmd53_block_write(&mut self, arg: u32, blocks: &[DataBlock]) -> Result<(), Error> {
-        let _scoped_block_stop = self.sdmmc.info.rcc.block_stop();
+        let _scoped_wake_guard = self.sdmmc.info.rcc.wake_guard();
 
         // NOTE(unsafe) reinterpret buffer as &mut [u32]
         let buffer = unsafe {
@@ -206,7 +206,7 @@ impl<'a, 'b> SerialDataInterface<'a, 'b> {
 
     /// Write in multibyte mode using cmd53
     pub async fn cmd53_byte_write(&mut self, arg: u32, buffer: &Aligned<A4, [u8]>) -> Result<(), Error> {
-        let _scoped_block_stop = self.sdmmc.info.rcc.block_stop();
+        let _scoped_wake_guard = self.sdmmc.info.rcc.wake_guard();
 
         #[cfg(sdmmc_v1)]
         self.sdmmc.cmd(cmd::<R1>(53, arg), true, true)?;

--- a/embassy-stm32/src/spi/mod.rs
+++ b/embassy-stm32/src/spi/mod.rs
@@ -926,7 +926,7 @@ impl<'d> Spi<'d, Async, Master> {
 impl<'d, CM: CommunicationMode> Spi<'d, Async, CM> {
     /// SPI write, using DMA.
     pub async fn write<W: Word>(&mut self, data: &[W]) -> Result<(), Error> {
-        let _scoped_block_stop = self.info.rcc.block_stop();
+        let _scoped_wake_guard = self.info.rcc.wake_guard();
         if data.is_empty() {
             return Ok(());
         }
@@ -958,7 +958,7 @@ impl<'d, CM: CommunicationMode> Spi<'d, Async, CM> {
     /// SPI read, using DMA.
     #[cfg(any(spi_v4, spi_v5, spi_v6))]
     pub async fn read<W: Word>(&mut self, data: &mut [W]) -> Result<(), Error> {
-        let _scoped_block_stop = self.info.rcc.block_stop();
+        let _scoped_wake_guard = self.info.rcc.wake_guard();
         if data.is_empty() {
             return Ok(());
         }
@@ -1046,7 +1046,7 @@ impl<'d, CM: CommunicationMode> Spi<'d, Async, CM> {
     /// SPI read, using DMA.
     #[cfg(any(spi_v1, spi_v2, spi_v3))]
     pub async fn read<W: Word>(&mut self, data: &mut [W]) -> Result<(), Error> {
-        let _scoped_block_stop = self.info.rcc.block_stop();
+        let _scoped_wake_guard = self.info.rcc.wake_guard();
         if data.is_empty() {
             return Ok(());
         }
@@ -1094,7 +1094,7 @@ impl<'d, CM: CommunicationMode> Spi<'d, Async, CM> {
     }
 
     async fn transfer_inner<W: Word>(&mut self, read: *mut [W], write: *const [W]) -> Result<(), Error> {
-        let _scoped_block_stop = self.info.rcc.block_stop();
+        let _scoped_wake_guard = self.info.rcc.wake_guard();
         assert_eq!(read.len(), write.len());
         if read.len() == 0 {
             return Ok(());
@@ -1146,7 +1146,7 @@ impl<'d, CM: CommunicationMode> Spi<'d, Async, CM> {
     /// The transfer runs for `max(read.len(), write.len())` bytes. If `read` is shorter extra bytes are ignored.
     /// If `write` is shorter it is padded with zero bytes.
     pub async fn transfer<W: Word>(&mut self, read: &mut [W], write: &[W]) -> Result<(), Error> {
-        let _scoped_block_stop = self.info.rcc.block_stop();
+        let _scoped_wake_guard = self.info.rcc.wake_guard();
 
         self.transfer_inner(read, write).await
     }
@@ -1155,7 +1155,7 @@ impl<'d, CM: CommunicationMode> Spi<'d, Async, CM> {
     ///
     /// This writes the contents of `data` on MOSI, and puts the received data on MISO in `data`, at the same time.
     pub async fn transfer_in_place<W: Word>(&mut self, data: &mut [W]) -> Result<(), Error> {
-        let _scoped_block_stop = self.info.rcc.block_stop();
+        let _scoped_wake_guard = self.info.rcc.wake_guard();
 
         self.transfer_inner(data, data).await
     }

--- a/embassy-stm32/src/usart/mod.rs
+++ b/embassy-stm32/src/usart/mod.rs
@@ -493,7 +493,7 @@ impl<'d> UartTx<'d, Async> {
 
     /// Initiate an asynchronous UART write
     pub async fn write(&mut self, buffer: &[u8]) -> Result<(), Error> {
-        let _scoped_block_stop = self.info.rcc.block_stop();
+        let _scoped_wake_guard = self.info.rcc.wake_guard();
 
         let r = self.info.regs;
 
@@ -512,7 +512,7 @@ impl<'d> UartTx<'d, Async> {
 
     /// Wait until transmission complete
     pub async fn flush(&mut self) -> Result<(), Error> {
-        let _scoped_block_stop = self.info.rcc.block_stop();
+        let _scoped_wake_guard = self.info.rcc.wake_guard();
 
         flush(&self.info, &self.state).await
     }
@@ -736,7 +736,7 @@ impl<'d> UartRx<'d, Async> {
 
     /// Initiate an asynchronous UART read
     pub async fn read(&mut self, buffer: &mut [u8]) -> Result<(), Error> {
-        let _scoped_block_stop = self.info.rcc.block_stop();
+        let _scoped_wake_guard = self.info.rcc.wake_guard();
 
         self.inner_read(buffer, false).await?;
 
@@ -745,7 +745,7 @@ impl<'d> UartRx<'d, Async> {
 
     /// Initiate an asynchronous read with idle line detection enabled
     pub async fn read_until_idle(&mut self, buffer: &mut [u8]) -> Result<usize, Error> {
-        let _scoped_block_stop = self.info.rcc.block_stop();
+        let _scoped_wake_guard = self.info.rcc.wake_guard();
 
         self.inner_read(buffer, true).await
     }


### PR DESCRIPTION
- Rename BusyPeripheral to WakeGuard
- Remove generic param in WakeGuard, make it store just the stop mode.
- Remove trait StoppablePeripheral
- Remove DeviceBusy, it's basically the same as WakeGuard.
