### PR TITLE
stm32: add DMA Channel driver API.

### DIFF
--- a/embassy-stm32/src/adc/g4.rs
+++ b/embassy-stm32/src/adc/g4.rs
@@ -475,7 +475,7 @@ impl<'d, T: Instance<Regs = crate::pac::adc::Adc>> Adc<'d, T> {
     /// This function is `unsafe` because it clones the ADC peripheral handle unchecked. Both the
     /// `RingBufferedAdc` and `InjectedAdc` take ownership of the handle and drop it independently.
     /// Ensure no other code concurrently accesses the same ADC instance in a conflicting way.
-    pub fn into_ring_buffered_and_injected<'a, 'b, const N: usize, D: RxDma<T> + crate::dma::TypedChannel>(
+    pub fn into_ring_buffered_and_injected<'a, 'b, const N: usize, D: RxDma<T>>(
         self,
         dma: Peri<'a, D>,
         dma_buf: &'a mut [u16],

--- a/embassy-stm32/src/adc/mod.rs
+++ b/embassy-stm32/src/adc/mod.rs
@@ -263,7 +263,7 @@ impl<'d, T: Instance> Adc<'d, T> {
     /// in order or require the sequence to have the same sample time for all channnels, depending
     /// on the number and properties of the channels in the sequence. This method will panic if
     /// the hardware cannot deliver the requested configuration.
-    pub async fn read<'a, 'b: 'a, D: RxDma<T> + crate::dma::TypedChannel>(
+    pub async fn read<'a, 'b: 'a, D: RxDma<T>>(
         &mut self,
         rx_dma: embassy_hal_internal::Peri<'a, D>,
         irq: impl crate::interrupt::typelevel::Binding<D::Interrupt, crate::dma::InterruptHandler<D>> + 'a,
@@ -297,15 +297,8 @@ impl<'d, T: Instance> Adc<'d, T> {
         T::regs().configure_dma(ConversionMode::Singular);
 
         let request = rx_dma.request();
-        let transfer = unsafe {
-            crate::dma::Transfer::new_read(
-                crate::dma::dma_into(rx_dma, &irq),
-                request,
-                T::regs().data(),
-                readings,
-                Default::default(),
-            )
-        };
+        let mut dma_channel = crate::dma::Channel::new(rx_dma, irq);
+        let transfer = unsafe { dma_channel.read(request, T::regs().data(), readings, Default::default()) };
 
         T::regs().start();
 
@@ -343,7 +336,7 @@ impl<'d, T: Instance> Adc<'d, T> {
     /// in order or require the sequence to have the same sample time for all channnels, depending
     /// on the number and properties of the channels in the sequence. This method will panic if
     /// the hardware cannot deliver the requested configuration.
-    pub fn into_ring_buffered<'a, 'b, D: RxDma<T> + crate::dma::TypedChannel>(
+    pub fn into_ring_buffered<'a, 'b, D: RxDma<T>>(
         self,
         dma: embassy_hal_internal::Peri<'a, D>,
         dma_buf: &'a mut [u16],

--- a/embassy-stm32/src/cordic/mod.rs
+++ b/embassy-stm32/src/cordic/mod.rs
@@ -3,7 +3,6 @@
 use embassy_hal_internal::drop::OnDrop;
 use embassy_hal_internal::{Peri, PeripheralType};
 
-use crate::dma::dma_into;
 use crate::pac::cordic::vals;
 use crate::{dma, peripherals, rcc};
 
@@ -388,8 +387,8 @@ impl<'d, T: Instance> Cordic<'d, T> {
         res1_only: bool,
     ) -> Result<usize, CordicError>
     where
-        W: WriteDma<T> + crate::dma::TypedChannel,
-        R: ReadDma<T> + crate::dma::TypedChannel,
+        W: WriteDma<T>,
+        R: ReadDma<T>,
     {
         if arg.is_empty() {
             return Ok(0);
@@ -419,16 +418,12 @@ impl<'d, T: Instance> Cordic<'d, T> {
         });
 
         unsafe {
-            let write_transfer = dma::Transfer::new_write(
-                dma_into(write_dma.reborrow(), &irq),
-                write_req,
-                arg,
-                T::regs().wdata().as_ptr() as *mut _,
-                Default::default(),
-            );
+            let mut write_channel = dma::Channel::new(write_dma.reborrow(), irq);
+            let write_transfer =
+                write_channel.write(write_req, arg, T::regs().wdata().as_ptr() as *mut _, Default::default());
 
-            let read_transfer = dma::Transfer::new_read(
-                dma_into(read_dma.reborrow(), &irq),
+            let mut read_channel = dma::Channel::new(read_dma.reborrow(), irq);
+            let read_transfer = read_channel.read(
                 read_req,
                 T::regs().rdata().as_ptr() as *mut _,
                 active_res_buf,
@@ -532,8 +527,8 @@ impl<'d, T: Instance> Cordic<'d, T> {
         res: &mut [u32],
     ) -> Result<usize, CordicError>
     where
-        W: WriteDma<T> + crate::dma::TypedChannel,
-        R: ReadDma<T> + crate::dma::TypedChannel,
+        W: WriteDma<T>,
+        R: ReadDma<T>,
     {
         if arg.is_empty() {
             return Ok(0);
@@ -565,16 +560,12 @@ impl<'d, T: Instance> Cordic<'d, T> {
         });
 
         unsafe {
-            let write_transfer = dma::Transfer::new_write(
-                dma_into(write_dma.reborrow(), &irq),
-                write_req,
-                arg,
-                T::regs().wdata().as_ptr() as *mut _,
-                Default::default(),
-            );
+            let mut write_channel = dma::Channel::new(write_dma.reborrow(), irq);
+            let write_transfer =
+                write_channel.write(write_req, arg, T::regs().wdata().as_ptr() as *mut _, Default::default());
 
-            let read_transfer = dma::Transfer::new_read(
-                dma_into(read_dma.reborrow(), &irq),
+            let mut read_channel = dma::Channel::new(read_dma.reborrow(), irq);
+            let read_transfer = read_channel.read(
                 read_req,
                 T::regs().rdata().as_ptr() as *mut _,
                 active_res_buf,

--- a/embassy-stm32/src/dcmi.rs
+++ b/embassy-stm32/src/dcmi.rs
@@ -6,7 +6,7 @@ use core::task::Poll;
 use embassy_hal_internal::PeripheralType;
 use embassy_sync::waitqueue::AtomicWaker;
 
-use crate::dma::{ChannelAndRequest, Transfer};
+use crate::dma::ChannelAndRequest;
 use crate::gpio::{AfType, Pull};
 use crate::interrupt::typelevel::Interrupt;
 use crate::{Peri, interrupt, rcc};
@@ -407,15 +407,7 @@ where
     pub async fn capture(&mut self, buffer: &mut [u32]) -> Result<(), Error> {
         let r = self.inner.regs();
         let src = r.dr().as_ptr() as *mut u32;
-        let dma_read = unsafe {
-            Transfer::new_read(
-                self.dma.channel.reborrow(),
-                self.dma.request,
-                src,
-                buffer,
-                Default::default(),
-            )
-        };
+        let dma_read = unsafe { self.dma.channel.read(self.dma.request, src, buffer, Default::default()) };
 
         Self::clear_interrupt_flags();
         Self::enable_irqs();

--- a/embassy-stm32/src/dma/gpdma/mod.rs
+++ b/embassy-stm32/src/dma/gpdma/mod.rs
@@ -5,12 +5,11 @@ use core::pin::Pin;
 use core::sync::atomic::{AtomicUsize, Ordering, fence};
 use core::task::{Context, Poll};
 
-use embassy_hal_internal::Peri;
 use embassy_sync::waitqueue::AtomicWaker;
 use linked_list::Table;
 
 use super::word::{Word, WordSize};
-use super::{AnyChannel, Dir, Request, STATE};
+use super::{Channel, Dir, Request, STATE};
 use crate::interrupt::typelevel::Interrupt;
 use crate::pac;
 use crate::pac::gpdma::vals;
@@ -146,75 +145,78 @@ pub(crate) unsafe fn init(cs: critical_section::CriticalSection, irq_priority: c
     crate::_generated::init_gpdma();
 }
 
-impl AnyChannel {
-    /// Safety: Must be called with a matching set of parameters for a valid dma channel
-    pub(crate) unsafe fn on_irq(&self) {
-        let info = self.info();
-        #[cfg(feature = "_dual-core")]
-        {
-            use embassy_hal_internal::interrupt::InterruptExt as _;
-            info.irq.enable();
+pub(crate) unsafe fn on_irq(id: u8) {
+    let info = super::info(id);
+    #[cfg(feature = "_dual-core")]
+    {
+        use embassy_hal_internal::interrupt::InterruptExt as _;
+        info.irq.enable();
+    }
+
+    let state = &STATE[id as usize];
+
+    let ch = info.dma.ch(info.num);
+    let sr = ch.sr().read();
+
+    if sr.dtef() {
+        panic!(
+            "DMA: data transfer error on DMA@{:08x} channel {}",
+            info.dma.as_ptr() as u32,
+            info.num
+        );
+    }
+    if sr.usef() {
+        panic!(
+            "DMA: user settings error on DMA@{:08x} channel {}",
+            info.dma.as_ptr() as u32,
+            info.num
+        );
+    }
+    if sr.ulef() {
+        panic!(
+            "DMA: link transfer error on DMA@{:08x} channel {}",
+            info.dma.as_ptr() as u32,
+            info.num
+        );
+    }
+
+    if sr.htf() {
+        ch.fcr().write(|w| w.set_htf(true));
+    }
+
+    if sr.tcf() {
+        ch.fcr().write(|w| w.set_tcf(true));
+
+        let lli_count = state.lli_state.count.load(Ordering::Acquire);
+        let complete = if lli_count > 0 {
+            let next_lli_index = state.lli_state.index.load(Ordering::Acquire) + 1;
+            let complete = next_lli_index >= lli_count;
+
+            state
+                .lli_state
+                .index
+                .store(if complete { 0 } else { next_lli_index }, Ordering::Release);
+
+            complete
+        } else {
+            true
+        };
+
+        if complete {
+            state.complete_count.fetch_add(1, Ordering::Release);
         }
+    }
 
-        let state = &STATE[self.id as usize];
+    if sr.suspf() {
+        // Disable all xxIEs to prevent the irq from firing again.
+        ch.cr().write(|_| {});
+    }
+    state.waker.wake();
+}
 
-        let ch = info.dma.ch(info.num);
-        let sr = ch.sr().read();
-
-        if sr.dtef() {
-            panic!(
-                "DMA: data transfer error on DMA@{:08x} channel {}",
-                info.dma.as_ptr() as u32,
-                info.num
-            );
-        }
-        if sr.usef() {
-            panic!(
-                "DMA: user settings error on DMA@{:08x} channel {}",
-                info.dma.as_ptr() as u32,
-                info.num
-            );
-        }
-        if sr.ulef() {
-            panic!(
-                "DMA: link transfer error on DMA@{:08x} channel {}",
-                info.dma.as_ptr() as u32,
-                info.num
-            );
-        }
-
-        if sr.htf() {
-            ch.fcr().write(|w| w.set_htf(true));
-        }
-
-        if sr.tcf() {
-            ch.fcr().write(|w| w.set_tcf(true));
-
-            let lli_count = state.lli_state.count.load(Ordering::Acquire);
-            let complete = if lli_count > 0 {
-                let next_lli_index = state.lli_state.index.load(Ordering::Acquire) + 1;
-                let complete = next_lli_index >= lli_count;
-
-                state
-                    .lli_state
-                    .index
-                    .store(if complete { 0 } else { next_lli_index }, Ordering::Release);
-
-                complete
-            } else {
-                true
-            };
-
-            if complete {
-                state.complete_count.fetch_add(1, Ordering::Release);
-            }
-        }
-
-        if sr.suspf() {
-            // Disable all xxIEs to prevent the irq from firing again.
-            ch.cr().write(|_| {});
-        }
-        state.waker.wake();
+impl<'d> Channel<'d> {
+    fn info(&self) -> &'static super::ChannelInfo {
+        super::info(self.id)
     }
 
     fn get_remaining_transfers(&self) -> u16 {
@@ -431,39 +433,143 @@ impl AnyChannel {
             Poll::Pending
         }
     }
+
+    /// Create a read DMA transfer (peripheral to memory).
+    pub unsafe fn read<'a, W: Word>(
+        &'a mut self,
+        request: Request,
+        peri_addr: *mut W,
+        buf: &'a mut [W],
+        options: TransferOptions,
+    ) -> Transfer<'a> {
+        self.read_raw(request, peri_addr, buf, options)
+    }
+
+    /// Create a read DMA transfer (peripheral to memory), using raw pointers.
+    pub unsafe fn read_raw<'a, MW: Word, PW: Word>(
+        &'a mut self,
+        request: Request,
+        peri_addr: *mut PW,
+        buf: *mut [MW],
+        options: TransferOptions,
+    ) -> Transfer<'a> {
+        let mem_len = buf.len();
+        assert!(mem_len > 0 && mem_len <= 0xFFFF);
+
+        self.configure(
+            request,
+            Dir::PeripheralToMemory,
+            peri_addr as *const u32,
+            buf as *mut MW as *mut u32,
+            mem_len,
+            true,
+            PW::size(),
+            MW::size(),
+            options,
+        );
+        self.start();
+
+        Transfer {
+            _wake_guard: self.info().wake_guard(),
+            channel: self.reborrow(),
+        }
+    }
+
+    /// Create a write DMA transfer (memory to peripheral).
+    pub unsafe fn write<'a, MW: Word, PW: Word>(
+        &'a mut self,
+        request: Request,
+        buf: &'a [MW],
+        peri_addr: *mut PW,
+        options: TransferOptions,
+    ) -> Transfer<'a> {
+        self.write_raw(request, buf, peri_addr, options)
+    }
+
+    /// Create a write DMA transfer (memory to peripheral), using raw pointers.
+    pub unsafe fn write_raw<'a, MW: Word, PW: Word>(
+        &'a mut self,
+        request: Request,
+        buf: *const [MW],
+        peri_addr: *mut PW,
+        options: TransferOptions,
+    ) -> Transfer<'a> {
+        let mem_len = buf.len();
+        assert!(mem_len > 0 && mem_len <= 0xFFFF);
+
+        self.configure(
+            request,
+            Dir::MemoryToPeripheral,
+            peri_addr as *const u32,
+            buf as *const MW as *mut u32,
+            mem_len,
+            true,
+            MW::size(),
+            PW::size(),
+            options,
+        );
+        self.start();
+
+        Transfer {
+            _wake_guard: self.info().wake_guard(),
+            channel: self.reborrow(),
+        }
+    }
+
+    /// Create a write DMA transfer (memory to peripheral), writing the same value repeatedly.
+    pub unsafe fn write_repeated<'a, MW: Word, PW: Word>(
+        &'a mut self,
+        request: Request,
+        repeated: &'a MW,
+        count: usize,
+        peri_addr: *mut PW,
+        options: TransferOptions,
+    ) -> Transfer<'a> {
+        assert!(count > 0 && count <= 0xFFFF);
+
+        self.configure(
+            request,
+            Dir::MemoryToPeripheral,
+            peri_addr as *const u32,
+            repeated as *const MW as *mut u32,
+            count,
+            false,
+            MW::size(),
+            PW::size(),
+            options,
+        );
+        self.start();
+
+        Transfer {
+            _wake_guard: self.info().wake_guard(),
+            channel: self.reborrow(),
+        }
+    }
+
+    /// Create a linked-list DMA transfer.
+    pub unsafe fn linked_list<'a, const ITEM_COUNT: usize>(
+        &'a mut self,
+        table: Table<ITEM_COUNT>,
+        options: TransferOptions,
+    ) -> LinkedListTransfer<'a, ITEM_COUNT> {
+        self.configure_linked_list(&table, options);
+        self.start();
+
+        LinkedListTransfer {
+            _wake_guard: self.info().wake_guard(),
+            channel: self.reborrow(),
+        }
+    }
 }
 
 /// Linked-list DMA transfer.
 #[must_use = "futures do nothing unless you `.await` or poll them"]
 pub struct LinkedListTransfer<'a, const ITEM_COUNT: usize> {
-    channel: Peri<'a, AnyChannel>,
+    channel: Channel<'a>,
     _wake_guard: WakeGuard,
 }
 
 impl<'a, const ITEM_COUNT: usize> LinkedListTransfer<'a, ITEM_COUNT> {
-    /// Create a new linked-list transfer.
-    pub unsafe fn new_linked_list<const N: usize>(
-        channel: Peri<'a, AnyChannel>,
-        table: Table<ITEM_COUNT>,
-        options: TransferOptions,
-    ) -> Self {
-        Self::new_inner_linked_list(channel, table, options)
-    }
-
-    unsafe fn new_inner_linked_list(
-        channel: Peri<'a, AnyChannel>,
-        table: Table<ITEM_COUNT>,
-        options: TransferOptions,
-    ) -> Self {
-        channel.configure_linked_list(&table, options);
-        channel.start();
-
-        Self {
-            _wake_guard: channel.info().wake_guard(),
-            channel,
-        }
-    }
-
     /// Request the transfer to pause, keeping the existing configuration for this channel.
     ///
     /// To resume the transfer, call [`request_resume`](Self::request_resume) again.
@@ -537,133 +643,11 @@ impl<'a, const ITEM_COUNT: usize> Future for LinkedListTransfer<'a, ITEM_COUNT> 
 /// DMA transfer.
 #[must_use = "futures do nothing unless you `.await` or poll them"]
 pub struct Transfer<'a> {
-    channel: Peri<'a, AnyChannel>,
+    channel: Channel<'a>,
     _wake_guard: WakeGuard,
 }
 
 impl<'a> Transfer<'a> {
-    /// Create a new read DMA transfer (peripheral to memory).
-    pub unsafe fn new_read<W: Word>(
-        channel: Peri<'a, AnyChannel>,
-        request: Request,
-        peri_addr: *mut W,
-        buf: &'a mut [W],
-        options: TransferOptions,
-    ) -> Self {
-        Self::new_read_raw(channel, request, peri_addr, buf, options)
-    }
-
-    /// Create a new read DMA transfer (peripheral to memory), using raw pointers.
-    pub unsafe fn new_read_raw<MW: Word, PW: Word>(
-        channel: Peri<'a, AnyChannel>,
-        request: Request,
-        peri_addr: *mut PW,
-        buf: *mut [MW],
-        options: TransferOptions,
-    ) -> Self {
-        Self::new_inner(
-            channel,
-            request,
-            Dir::PeripheralToMemory,
-            peri_addr as *const u32,
-            buf as *mut MW as *mut u32,
-            buf.len(),
-            true,
-            PW::size(),
-            MW::size(),
-            options,
-        )
-    }
-
-    /// Create a new write DMA transfer (memory to peripheral).
-    pub unsafe fn new_write<MW: Word, PW: Word>(
-        channel: Peri<'a, AnyChannel>,
-        request: Request,
-        buf: &'a [MW],
-        peri_addr: *mut PW,
-        options: TransferOptions,
-    ) -> Self {
-        Self::new_write_raw(channel, request, buf, peri_addr, options)
-    }
-
-    /// Create a new write DMA transfer (memory to peripheral), using raw pointers.
-    pub unsafe fn new_write_raw<MW: Word, PW: Word>(
-        channel: Peri<'a, AnyChannel>,
-        request: Request,
-        buf: *const [MW],
-        peri_addr: *mut PW,
-        options: TransferOptions,
-    ) -> Self {
-        Self::new_inner(
-            channel,
-            request,
-            Dir::MemoryToPeripheral,
-            peri_addr as *const u32,
-            buf as *const MW as *mut u32,
-            buf.len(),
-            true,
-            MW::size(),
-            PW::size(),
-            options,
-        )
-    }
-
-    /// Create a new write DMA transfer (memory to peripheral), writing the same value repeatedly.
-    pub unsafe fn new_write_repeated<MW: Word, PW: Word>(
-        channel: Peri<'a, AnyChannel>,
-        request: Request,
-        repeated: &'a MW,
-        count: usize,
-        peri_addr: *mut PW,
-        options: TransferOptions,
-    ) -> Self {
-        Self::new_inner(
-            channel,
-            request,
-            Dir::MemoryToPeripheral,
-            peri_addr as *const u32,
-            repeated as *const MW as *mut u32,
-            count,
-            false,
-            MW::size(),
-            PW::size(),
-            options,
-        )
-    }
-
-    unsafe fn new_inner(
-        channel: Peri<'a, AnyChannel>,
-        request: Request,
-        dir: Dir,
-        peri_addr: *const u32,
-        mem_addr: *mut u32,
-        mem_len: usize,
-        incr_mem: bool,
-        data_size: WordSize,
-        peripheral_size: WordSize,
-        options: TransferOptions,
-    ) -> Self {
-        assert!(mem_len > 0 && mem_len <= 0xFFFF);
-
-        channel.configure(
-            request,
-            dir,
-            peri_addr,
-            mem_addr,
-            mem_len,
-            incr_mem,
-            data_size,
-            peripheral_size,
-            options,
-        );
-        channel.start();
-
-        Self {
-            _wake_guard: channel.info().wake_guard(),
-            channel,
-        }
-    }
-
     /// Request the transfer to pause, keeping the existing configuration for this channel.
     /// To restart the transfer, call [`start`](Self::start) again.
     ///
@@ -707,6 +691,10 @@ impl<'a> Transfer<'a> {
         fence(Ordering::SeqCst);
 
         core::mem::forget(self);
+    }
+
+    pub(crate) unsafe fn unchecked_extend_lifetime(self) -> Transfer<'static> {
+        unsafe { core::mem::transmute(self) }
     }
 }
 

--- a/embassy-stm32/src/dma/gpdma/ringbuffered.rs
+++ b/embassy-stm32/src/dma/gpdma/ringbuffered.rs
@@ -6,16 +6,14 @@ use core::future::poll_fn;
 use core::sync::atomic::{Ordering, fence};
 use core::task::Waker;
 
-use embassy_hal_internal::Peri;
-
-use super::{AnyChannel, STATE, TransferOptions};
+use super::{Channel, STATE, TransferOptions};
 use crate::dma::gpdma::linked_list::{RunMode, Table};
 use crate::dma::ringbuffer::{DmaCtrl, Error, ReadableDmaRingBuffer, WritableDmaRingBuffer};
 use crate::dma::word::Word;
 use crate::dma::{Dir, Request};
 use crate::rcc::WakeGuard;
 
-struct DmaCtrlImpl<'a>(Peri<'a, AnyChannel>);
+struct DmaCtrlImpl<'a>(Channel<'a>);
 
 impl<'a> DmaCtrl for DmaCtrlImpl<'a> {
     fn get_remaining_transfers(&self) -> usize {
@@ -50,7 +48,7 @@ impl<'a> DmaCtrl for DmaCtrlImpl<'a> {
 
 /// Ringbuffer for receiving data using GPDMA linked-list mode.
 pub struct ReadableRingBuffer<'a, W: Word> {
-    channel: Peri<'a, AnyChannel>,
+    channel: Channel<'a>,
     _wake_guard: WakeGuard,
     ringbuf: ReadableDmaRingBuffer<'a, W>,
     table: Table<2>,
@@ -62,7 +60,7 @@ impl<'a, W: Word> ReadableRingBuffer<'a, W> {
     ///
     /// Transfer options are applied to the individual linked list items.
     pub unsafe fn new(
-        channel: Peri<'a, AnyChannel>,
+        channel: Channel<'a>,
         request: Request,
         peri_addr: *mut W,
         buffer: &'a mut [W],
@@ -191,7 +189,7 @@ impl<'a, W: Word> Drop for ReadableRingBuffer<'a, W> {
 
 /// Ringbuffer for writing data using GPDMA linked-list mode.
 pub struct WritableRingBuffer<'a, W: Word> {
-    channel: Peri<'a, AnyChannel>,
+    channel: Channel<'a>,
     _wake_guard: WakeGuard,
     ringbuf: WritableDmaRingBuffer<'a, W>,
     table: Table<2>,
@@ -203,7 +201,7 @@ impl<'a, W: Word> WritableRingBuffer<'a, W> {
     ///
     /// Transfer options are applied to the individual linked list items.
     pub unsafe fn new(
-        channel: Peri<'a, AnyChannel>,
+        channel: Channel<'a>,
         request: Request,
         peri_addr: *mut W,
         buffer: &'a mut [W],

--- a/embassy-stm32/src/dma/mod.rs
+++ b/embassy-stm32/src/dma/mod.rs
@@ -27,7 +27,7 @@ pub mod word;
 
 use core::marker::PhantomData;
 
-use embassy_hal_internal::{Peri, PeripheralType, impl_peripheral};
+use embassy_hal_internal::{Peri, PeripheralType};
 
 use crate::interrupt;
 
@@ -64,88 +64,81 @@ pub type Request = u8;
 #[cfg(not(any(dma_v2, bdma_v2, gpdma, dmamux)))]
 pub type Request = ();
 
-pub(crate) trait SealedChannel {
-    fn id(&self) -> u8;
+/// DMA channel driver
+pub struct Channel<'d> {
+    pub(crate) id: u8,
+    phantom: PhantomData<&'d ()>,
 }
 
-/// A Channel that has not been type-erased
-#[allow(private_bounds)]
-pub trait TypedChannel: Channel {
-    /// The interrupt type for this DMA channel.
-    type Interrupt: interrupt::typelevel::Interrupt;
+impl<'d> Channel<'d> {
+    /// Create a new DMA channel driver.
+    pub fn new<T: ChannelInstance>(
+        _ch: Peri<'d, T>,
+        _irq: impl interrupt::typelevel::Binding<T::Interrupt, crate::dma::InterruptHandler<T>> + 'd,
+    ) -> Self {
+        Self {
+            id: T::ID,
+            phantom: PhantomData,
+        }
+    }
 
-    #[doc(hidden)]
-    #[cfg_attr(not(feature = "rt"), allow(unused))]
-    unsafe fn on_irq();
+    /// Reborrow the channel, allowing it to be used in multiple places.
+    pub fn reborrow(&mut self) -> Channel<'_> {
+        Channel {
+            id: self.id,
+            phantom: PhantomData,
+        }
+    }
+
+    pub(crate) unsafe fn clone_unchecked(&self) -> Channel<'d> {
+        Channel {
+            id: self.id,
+            phantom: PhantomData,
+        }
+    }
+}
+
+pub(crate) trait SealedChannelInstance {
+    const ID: u8;
 }
 
 /// DMA channel.
 #[allow(private_bounds)]
-pub trait Channel: SealedChannel + PeripheralType + 'static {}
-
-/// Degrade a TypedChannel into an AnyChannel
-#[inline]
-pub fn dma_into<'a, T: TypedChannel, I: interrupt::typelevel::Binding<T::Interrupt, InterruptHandler<T>>>(
-    channel: Peri<'a, T>,
-    _irq: &I,
-) -> Peri<'a, AnyChannel> {
-    unsafe { Peri::new_unchecked(AnyChannel { id: channel.id() }) }
+pub trait ChannelInstance: SealedChannelInstance + PeripheralType + 'static {
+    /// The interrupt type for this DMA channel.
+    type Interrupt: interrupt::typelevel::Interrupt;
 }
 
 /// DMA interrupt handler.
 #[allow(private_bounds)]
-pub struct InterruptHandler<T: TypedChannel> {
+pub struct InterruptHandler<T: ChannelInstance> {
     _phantom: PhantomData<T>,
 }
 
-impl<T: TypedChannel> interrupt::typelevel::Handler<T::Interrupt> for InterruptHandler<T> {
+impl<T: ChannelInstance> interrupt::typelevel::Handler<T::Interrupt> for InterruptHandler<T> {
     unsafe fn on_interrupt() {
-        T::on_irq();
+        on_irq(T::ID)
     }
 }
 
 macro_rules! dma_channel_impl {
     ($channel_peri:ident, $index:expr, $irq:ty) => {
-        impl crate::dma::SealedChannel for crate::peripherals::$channel_peri {
-            fn id(&self) -> u8 {
-                $index
-            }
+        impl crate::dma::SealedChannelInstance for crate::peripherals::$channel_peri {
+            const ID: u8 = $index;
         }
 
-        impl crate::dma::TypedChannel for crate::peripherals::$channel_peri {
+        impl crate::dma::ChannelInstance for crate::peripherals::$channel_peri {
             type Interrupt = $irq;
-
-            unsafe fn on_irq() {
-                crate::dma::AnyChannel { id: $index }.on_irq();
-            }
         }
-
-        impl crate::dma::Channel for crate::peripherals::$channel_peri {}
     };
 }
 
-/// Type-erased DMA channel.
-pub struct AnyChannel {
-    pub(crate) id: u8,
-}
-impl_peripheral!(AnyChannel);
-
-impl AnyChannel {
-    fn info(&self) -> &ChannelInfo {
-        &crate::_generated::DMA_CHANNELS[self.id as usize]
-    }
-}
-
-impl SealedChannel for AnyChannel {
-    fn id(&self) -> u8 {
-        self.id
-    }
-}
-
-impl Channel for AnyChannel {}
-
 const CHANNEL_COUNT: usize = crate::_generated::DMA_CHANNELS.len();
 static STATE: [ChannelState; CHANNEL_COUNT] = [ChannelState::NEW; CHANNEL_COUNT];
+
+pub(crate) fn info(id: u8) -> &'static ChannelInfo {
+    &crate::_generated::DMA_CHANNELS[id as usize]
+}
 
 // safety: must be called only once at startup
 pub(crate) unsafe fn init(

--- a/embassy-stm32/src/macros.rs
+++ b/embassy-stm32/src/macros.rs
@@ -122,7 +122,7 @@ macro_rules! sel_trait_impl {
 macro_rules! dma_trait {
     ($signal:ident, $instance:path$(, $mode:path)?) => {
         #[doc = concat!(stringify!($signal), " DMA request trait")]
-        pub trait $signal<T: $instance $(, M: $mode)?>: crate::dma::Channel + crate::dma::TypedChannel {
+        pub trait $signal<T: $instance $(, M: $mode)?>: crate::dma::ChannelInstance {
             #[doc = concat!("Get the DMA request number needed to use this channel as", stringify!($signal))]
             /// Note: in some chips, ST calls this the "channel", and calls channels "streams".
             /// `embassy-stm32` always uses the "channel" and "request number" names.
@@ -157,11 +157,9 @@ macro_rules! dma_trait_impl {
 macro_rules! new_dma_nonopt {
     ($name:ident, $irqs:expr) => {{
         let dma = $name;
+        dma.remap();
         let request = dma.request();
-        crate::dma::ChannelAndRequest {
-            channel: crate::dma::dma_into(dma, &$irqs),
-            request,
-        }
+        crate::dma::ChannelAndRequest::new(dma, $irqs, request)
     }};
 }
 
@@ -170,10 +168,7 @@ macro_rules! new_dma {
         let dma = $name;
         dma.remap();
         let request = dma.request();
-        Some(crate::dma::ChannelAndRequest {
-            channel: crate::dma::dma_into(dma, &$irqs),
-            request,
-        })
+        Some(crate::dma::ChannelAndRequest::new(dma, $irqs, request))
     }};
 }
 

--- a/embassy-stm32/src/sdmmc/mod.rs
+++ b/embassy-stm32/src/sdmmc/mod.rs
@@ -869,11 +869,14 @@ impl<'d> Sdmmc<'d> {
         // SAFETY: No other functions use the dma
         #[cfg(sdmmc_v1)]
         let transfer = unsafe {
-            self.dma.read_unchecked(
-                regs.fifor().as_ptr() as *mut u32,
-                slice32_mut(buffer),
-                DMA_TRANSFER_OPTIONS,
-            )
+            self.dma
+                .clone_unchecked()
+                .read(
+                    regs.fifor().as_ptr() as *mut u32,
+                    slice32_mut(buffer),
+                    DMA_TRANSFER_OPTIONS,
+                )
+                .unchecked_extend_lifetime()
         };
         #[cfg(sdmmc_v2)]
         let transfer = {
@@ -929,11 +932,14 @@ impl<'d> Sdmmc<'d> {
         // SAFETY: No other functions use the dma
         #[cfg(sdmmc_v1)]
         let transfer = unsafe {
-            self.dma.write_unchecked(
-                slice32_ref(buffer),
-                regs.fifor().as_ptr() as *mut u32,
-                DMA_TRANSFER_OPTIONS,
-            )
+            self.dma
+                .clone_unchecked()
+                .write(
+                    slice32_ref(buffer),
+                    regs.fifor().as_ptr() as *mut u32,
+                    DMA_TRANSFER_OPTIONS,
+                )
+                .unchecked_extend_lifetime()
         };
         #[cfg(sdmmc_v2)]
         let transfer = {

--- a/embassy-stm32/src/sdmmc/sd.rs
+++ b/embassy-stm32/src/sdmmc/sd.rs
@@ -209,7 +209,7 @@ impl<'a, 'b> StorageDevice<'a, 'b, Card> {
     ///
     /// SD only.
     async fn switch_signalling_mode(
-        &self,
+        &mut self,
         cmd_block: &mut CmdBlock,
         signalling: Signalling,
     ) -> Result<Signalling, Error> {

--- a/embassy-stm32/src/timer/complementary_pwm.rs
+++ b/embassy-stm32/src/timer/complementary_pwm.rs
@@ -309,7 +309,7 @@ impl<'d, T: AdvancedInstance4Channel> ComplementaryPwm<'d, T> {
     ///
     /// Note:
     /// The DMA channel provided does not need to correspond to the requested channel.
-    pub async fn waveform<C: TimerChannel, W: Word + Into<T::Word>, D: super::Dma<T, C> + crate::dma::TypedChannel>(
+    pub async fn waveform<C: TimerChannel, W: Word + Into<T::Word>, D: super::Dma<T, C>>(
         &mut self,
         dma: Peri<'_, D>,
         irq: impl crate::interrupt::typelevel::Binding<D::Interrupt, crate::dma::InterruptHandler<D>> + '_,
@@ -329,7 +329,7 @@ impl<'d, T: AdvancedInstance4Channel> ComplementaryPwm<'d, T> {
     ///
     /// Note:
     /// you will need to provide corresponding TIMx_UP DMA channel to use this method.
-    pub async fn waveform_up<W: Word + Into<T::Word>, D: super::UpDma<T> + crate::dma::TypedChannel>(
+    pub async fn waveform_up<W: Word + Into<T::Word>, D: super::UpDma<T>>(
         &mut self,
         dma: Peri<'_, D>,
         irq: impl crate::interrupt::typelevel::Binding<D::Interrupt, crate::dma::InterruptHandler<D>> + '_,
@@ -372,7 +372,7 @@ impl<'d, T: AdvancedInstance4Channel> ComplementaryPwm<'d, T> {
     /// Also be aware that embassy timers use one of timers internally. It is possible to
     /// switch this timer by using `time-driver-timX` feature.
     ///
-    pub async fn waveform_up_multi_channel<W: Word + Into<T::Word>, D: super::UpDma<T> + crate::dma::TypedChannel>(
+    pub async fn waveform_up_multi_channel<W: Word + Into<T::Word>, D: super::UpDma<T>>(
         &mut self,
         dma: Peri<'_, D>,
         irq: impl crate::interrupt::typelevel::Binding<D::Interrupt, crate::dma::InterruptHandler<D>> + '_,

--- a/embassy-stm32/src/timer/simple_pwm.rs
+++ b/embassy-stm32/src/timer/simple_pwm.rs
@@ -444,7 +444,7 @@ impl<'d, T: GeneralInstance4Channel> SimplePwm<'d, T> {
     /// You will need to provide corresponding `TIMx_UP` DMA channel to use this method.
     /// Also be aware that embassy timers use one of timers internally. It is possible to
     /// switch this timer by using `time-driver-timX` feature.
-    pub async fn waveform_up<W: Word + Into<T::Word>, D: super::UpDma<T> + crate::dma::TypedChannel>(
+    pub async fn waveform_up<W: Word + Into<T::Word>, D: super::UpDma<T>>(
         &mut self,
         dma: Peri<'_, D>,
         irq: impl crate::interrupt::typelevel::Binding<D::Interrupt, crate::dma::InterruptHandler<D>> + '_,
@@ -487,7 +487,7 @@ impl<'d, T: GeneralInstance4Channel> SimplePwm<'d, T> {
     /// Also be aware that embassy timers use one of timers internally. It is possible to
     /// switch this timer by using `time-driver-timX` feature.
     ///
-    pub async fn waveform_up_multi_channel<W: Word + Into<T::Word>, D: super::UpDma<T> + crate::dma::TypedChannel>(
+    pub async fn waveform_up_multi_channel<W: Word + Into<T::Word>, D: super::UpDma<T>>(
         &mut self,
         dma: Peri<'_, D>,
         irq: impl crate::interrupt::typelevel::Binding<D::Interrupt, crate::dma::InterruptHandler<D>> + '_,


### PR DESCRIPTION
This changes the DMA API so that there's an actual "Channel" driver. 

- Functions to create transfers are methods in `Channel`.
- AnyChannel is removed.
- `Channel` serves as a "type-erased DMA channel with proof that the IRQ has been bound".