### PR TITLE
Set the source and destination port for GPDMA and HPDMA

### DIFF
--- a/embassy-stm32/src/dma/gpdma/mod.rs
+++ b/embassy-stm32/src/dma/gpdma/mod.rs
@@ -270,6 +270,16 @@ impl AnyChannel {
             w.set_ddw(dst_size.into());
             w.set_sinc(dir == Dir::MemoryToPeripheral && incr_mem);
             w.set_dinc(dir == Dir::PeripheralToMemory && incr_mem);
+            w.set_dap(match dir {
+                Dir::MemoryToPeripheral => vals::Ap::PORT1, // Destination is peripheral on AHB for HPDMA
+                Dir::PeripheralToMemory => vals::Ap::PORT0, // Destination is memory on AXI for HPDMA
+                Dir::MemoryToMemory => panic!("memory-to-memory transfers not implemented for GPDMA"),
+            });
+            w.set_sap(match dir {
+                Dir::MemoryToPeripheral => vals::Ap::PORT0, // Source is memory on AXI for HPDMA
+                Dir::PeripheralToMemory => vals::Ap::PORT1, // Source is peripheral on AHB for HPDMA
+                Dir::MemoryToMemory => panic!("memory-to-memory transfers not implemented for GPDMA"),
+            });
         });
         ch.tr2().write(|w| {
             w.set_dreq(match dir {


### PR DESCRIPTION
This fixes the HPDMA throwing transfer errors. The DAP/SAP registers exist in the GPDMA but it seems to work without them set. The HPMDA has access to both the AXI and AHB bus so it needs them specified.

This was tested using the SPI3 peripheral. It can operate properly with both DMA providers.