### PR TITLE
[MCXA] CTIMER: Add Ctimer PWM driver

### DIFF
--- a/embassy-mcxa/src/clocks/mod.rs
+++ b/embassy-mcxa/src/clocks/mod.rs
@@ -1937,6 +1937,7 @@ macro_rules! impl_cc_gate {
 pub(crate) mod gate {
     use super::periph_helpers::{AdcConfig, I3cConfig, Lpi2cConfig, LpuartConfig, NoConfig, OsTimerConfig};
     use super::*;
+    use crate::clocks::periph_helpers::CTimerConfig;
 
     // These peripherals have no additional upstream clocks or configuration required
     // other than enabling through the MRCC gate. Currently, these peripherals will
@@ -1958,7 +1959,11 @@ pub(crate) mod gate {
     impl_cc_gate!(ADC3, mrcc_glb_cc1, mrcc_glb_rst1, adc3, AdcConfig);
 
     impl_cc_gate!(I3C0, mrcc_glb_cc0, mrcc_glb_rst0, i3c0, I3cConfig);
-
+    impl_cc_gate!(CTIMER0, mrcc_glb_cc0, mrcc_glb_rst0, ctimer0, CTimerConfig);
+    impl_cc_gate!(CTIMER1, mrcc_glb_cc0, mrcc_glb_rst0, ctimer1, CTimerConfig);
+    impl_cc_gate!(CTIMER2, mrcc_glb_cc0, mrcc_glb_rst0, ctimer2, CTimerConfig);
+    impl_cc_gate!(CTIMER3, mrcc_glb_cc0, mrcc_glb_rst0, ctimer3, CTimerConfig);
+    impl_cc_gate!(CTIMER4, mrcc_glb_cc0, mrcc_glb_rst0, ctimer4, CTimerConfig);
     impl_cc_gate!(OSTIMER0, mrcc_glb_cc1, mrcc_glb_rst1, ostimer0, OsTimerConfig);
 
     // TRNG peripheral - uses NoConfig since it has no selectable clock source

--- a/embassy-mcxa/src/ctimer/mod.rs
+++ b/embassy-mcxa/src/ctimer/mod.rs
@@ -1,0 +1,424 @@
+//! CTimer driver.
+
+use core::marker::PhantomData;
+
+use embassy_hal_internal::{Peri, PeripheralType};
+use maitake_sync::WaitCell;
+
+use crate::clkout::Div4;
+use crate::clocks::periph_helpers::{CTimerClockSel, CTimerConfig};
+use crate::clocks::{ClockError, Gate, PoweredClock, WakeGuard, enable_and_reset};
+use crate::gpio::{GpioPin, SealedPin};
+use crate::{interrupt, pac};
+
+pub mod pwm;
+
+/// Error information type
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+#[non_exhaustive]
+pub enum Error {
+    /// Clock configuration error.
+    ClockSetup(ClockError),
+
+    /// Other internal errors or unexpected state.
+    Other,
+}
+
+/// CTimer configuration
+#[derive(Debug, Copy, Clone)]
+#[non_exhaustive]
+pub struct Config {
+    /// Powered clock configuration
+    pub power: PoweredClock,
+    /// CTimer clock source
+    pub source: CTimerClockSel,
+    /// CTimer pre-divider
+    pub div: Div4,
+}
+
+impl Default for Config {
+    fn default() -> Self {
+        Self {
+            power: PoweredClock::NormalEnabledDeepSleepDisabled,
+            source: CTimerClockSel::FroLfDiv,
+            div: const { Div4::no_div() },
+        }
+    }
+}
+
+/// CTimer core driver.
+#[derive(Clone)]
+pub struct CTimer<'d> {
+    info: &'static Info,
+    _freq: u32,
+    _wg: Option<WakeGuard>,
+    _phantom: PhantomData<&'d mut ()>,
+}
+
+impl<'d> CTimer<'d> {
+    /// Create a new instance of the CTimer core cdriver.
+    pub fn new<T: Instance>(_peri: Peri<'d, T>, config: Config) -> Result<Self, Error> {
+        // Enable clocks
+        let conf = CTimerConfig {
+            power: config.power,
+            source: config.source,
+            div: config.div,
+            instance: T::CLOCK_INSTANCE,
+        };
+
+        let parts = unsafe { enable_and_reset::<T>(&conf).map_err(Error::ClockSetup)? };
+
+        let inst = Self {
+            info: T::info(),
+            _freq: parts.freq,
+            _wg: parts.wake_guard,
+            _phantom: PhantomData,
+        };
+
+        // Enable CTimer
+        inst.info.regs().tcr().modify(|w| w.set_cen(true));
+
+        Ok(inst)
+    }
+}
+
+/// CTimer interrupt handler.
+pub struct InterruptHandler<T: Instance> {
+    _phantom: PhantomData<T>,
+}
+
+impl<T: Instance> interrupt::typelevel::Handler<T::Interrupt> for InterruptHandler<T> {
+    unsafe fn on_interrupt() {
+        // Clear interrupt status
+        let r = T::info().regs().ir().read().0;
+        T::info().regs().ir().write(|w| w.0 = r);
+        T::info().wait_cell().wake();
+    }
+}
+
+struct Info {
+    regs: pac::ctimer::Ctimer,
+    wait_cell: WaitCell,
+}
+
+impl Info {
+    #[inline(always)]
+    fn regs(&self) -> pac::ctimer::Ctimer {
+        self.regs
+    }
+
+    #[inline(always)]
+    fn wait_cell(&self) -> &WaitCell {
+        &self.wait_cell
+    }
+}
+
+unsafe impl Sync for Info {}
+
+trait SealedInstance {
+    fn info() -> &'static Info;
+}
+
+/// CTimer Instance
+#[allow(private_bounds)]
+pub trait Instance: SealedInstance + PeripheralType + 'static + Send + Gate<MrccPeriphConfig = CTimerConfig> {
+    /// Interrupt for this I2C instance.
+    type Interrupt: interrupt::typelevel::Interrupt;
+    /// Clock instance
+    const CLOCK_INSTANCE: crate::clocks::periph_helpers::CTimerInstance;
+}
+
+macro_rules! impl_instance {
+    ($peri:ident, $clock:ident) => {
+        impl SealedInstance for crate::peripherals::$peri {
+            fn info() -> &'static Info {
+                static INFO: Info = Info {
+                    regs: pac::$peri,
+                    wait_cell: WaitCell::new(),
+                };
+                &INFO
+            }
+        }
+
+        impl Instance for crate::peripherals::$peri {
+            type Interrupt = crate::interrupt::typelevel::$peri;
+            const CLOCK_INSTANCE: crate::clocks::periph_helpers::CTimerInstance =
+                crate::clocks::periph_helpers::CTimerInstance::$clock;
+        }
+    };
+}
+
+impl_instance!(CTIMER0, CTimer0);
+impl_instance!(CTIMER1, CTimer1);
+impl_instance!(CTIMER2, CTimer2);
+impl_instance!(CTIMER3, CTimer3);
+impl_instance!(CTIMER4, CTimer4);
+
+trait SealedPwmChannel<T: Instance> {
+    fn number(&self) -> usize;
+}
+
+/// CTimer channel
+#[allow(private_bounds)]
+pub trait PwmChannel<T: Instance>: SealedPwmChannel<T> + PeripheralType + Into<AnyChannel> + 'static + Send {}
+
+macro_rules! impl_channel {
+    ($ch:ident, $peri:ident, $n:literal) => {
+        impl SealedPwmChannel<crate::peripherals::$peri> for crate::peripherals::$ch {
+            #[inline(always)]
+            fn number(&self) -> usize {
+                $n
+            }
+        }
+
+        impl PwmChannel<crate::peripherals::$peri> for crate::peripherals::$ch {}
+
+        impl From<crate::peripherals::$ch> for AnyChannel {
+            fn from(value: crate::peripherals::$ch) -> Self {
+                Self {
+                    number: value.number(),
+                }
+            }
+        }
+    };
+}
+
+impl_channel!(CTIMER0_CH0, CTIMER0, 0);
+impl_channel!(CTIMER0_CH1, CTIMER0, 1);
+impl_channel!(CTIMER0_CH2, CTIMER0, 2);
+impl_channel!(CTIMER0_CH3, CTIMER0, 3);
+
+impl_channel!(CTIMER1_CH0, CTIMER1, 0);
+impl_channel!(CTIMER1_CH1, CTIMER1, 1);
+impl_channel!(CTIMER1_CH2, CTIMER1, 2);
+impl_channel!(CTIMER1_CH3, CTIMER1, 3);
+
+impl_channel!(CTIMER2_CH0, CTIMER2, 0);
+impl_channel!(CTIMER2_CH1, CTIMER2, 1);
+impl_channel!(CTIMER2_CH2, CTIMER2, 2);
+impl_channel!(CTIMER2_CH3, CTIMER2, 3);
+
+impl_channel!(CTIMER3_CH0, CTIMER3, 0);
+impl_channel!(CTIMER3_CH1, CTIMER3, 1);
+impl_channel!(CTIMER3_CH2, CTIMER3, 2);
+impl_channel!(CTIMER3_CH3, CTIMER3, 3);
+
+impl_channel!(CTIMER4_CH0, CTIMER4, 0);
+impl_channel!(CTIMER4_CH1, CTIMER4, 1);
+impl_channel!(CTIMER4_CH2, CTIMER4, 2);
+impl_channel!(CTIMER4_CH3, CTIMER4, 3);
+
+/// Type-erase CTIMER channel
+pub struct AnyChannel {
+    number: usize,
+}
+
+impl AnyChannel {
+    fn number(&self) -> usize {
+        self.number
+    }
+}
+
+embassy_hal_internal::impl_peripheral!(AnyChannel);
+
+/// Seal a trait
+trait SealedInputPin {
+    #[allow(dead_code)]
+    fn number(&self) -> usize;
+}
+
+/// Seal a trait
+trait SealedOutputPin<T: Instance> {
+    fn number(&self) -> usize;
+}
+
+/// CTimer input pin.
+#[allow(private_bounds)]
+pub trait InputPin: GpioPin + SealedInputPin + PeripheralType {
+    fn mux(&self);
+}
+
+/// CTimer output pin.
+#[allow(private_bounds)]
+pub trait OutputPin<T: Instance>: GpioPin + SealedOutputPin<T> + PeripheralType {
+    fn mux(&self);
+}
+
+macro_rules! impl_input_pin {
+    ($pin:ident, $fn:ident, $n:expr) => {
+        impl SealedInputPin for crate::peripherals::$pin {
+            #[inline(always)]
+            fn number(&self) -> usize {
+                $n
+            }
+        }
+
+        impl InputPin for crate::peripherals::$pin {
+            #[inline(always)]
+            fn mux(&self) {
+                self.set_pull(crate::gpio::Pull::Disabled);
+                self.set_slew_rate(crate::gpio::SlewRate::Fast.into());
+                self.set_drive_strength(crate::gpio::DriveStrength::Double.into());
+                self.set_function(crate::pac::port::vals::Mux::$fn);
+                self.set_enable_input_buffer(true);
+            }
+        }
+    };
+}
+
+macro_rules! impl_output_pin {
+    ($pin:ident, $peri:ident, $fn:ident, $n:expr) => {
+        impl SealedOutputPin<crate::peripherals::$peri> for crate::peripherals::$pin {
+            #[inline(always)]
+            fn number(&self) -> usize {
+                $n
+            }
+        }
+
+        impl OutputPin<crate::peripherals::$peri> for crate::peripherals::$pin {
+            #[inline(always)]
+            fn mux(&self) {
+                self.set_pull(crate::gpio::Pull::Disabled);
+                self.set_slew_rate(crate::gpio::SlewRate::Fast.into());
+                self.set_drive_strength(crate::gpio::DriveStrength::Normal.into());
+                self.set_function(crate::pac::port::vals::Mux::$fn);
+                self.set_enable_input_buffer(false);
+            }
+        }
+    };
+}
+
+// Input pins
+
+#[cfg(feature = "swd-as-gpio")]
+impl_input_pin!(P0_0, MUX4, 0);
+#[cfg(feature = "swd-as-gpio")]
+impl_input_pin!(P0_1, MUX4, 1);
+#[cfg(feature = "jtag-extras-as-gpio")]
+impl_input_pin!(P0_6, MUX4, 2);
+
+impl_input_pin!(P0_20, MUX4, 0);
+impl_input_pin!(P0_21, MUX4, 1);
+impl_input_pin!(P0_22, MUX4, 2);
+impl_input_pin!(P0_23, MUX4, 3);
+
+impl_input_pin!(P1_0, MUX4, 4);
+impl_input_pin!(P1_1, MUX4, 5);
+impl_input_pin!(P1_2, MUX5, 0);
+impl_input_pin!(P1_3, MUX5, 1);
+impl_input_pin!(P1_6, MUX4, 6);
+impl_input_pin!(P1_7, MUX4, 7);
+impl_input_pin!(P1_8, MUX4, 8);
+impl_input_pin!(P1_9, MUX4, 9);
+impl_input_pin!(P1_14, MUX4, 10);
+impl_input_pin!(P1_15, MUX4, 11);
+
+#[cfg(feature = "sosc-as-gpio")]
+impl_input_pin!(P1_30, MUX4, 16);
+#[cfg(feature = "sosc-as-gpio")]
+impl_input_pin!(P1_31, MUX4, 17);
+
+impl_input_pin!(P2_0, MUX4, 16);
+impl_input_pin!(P2_1, MUX4, 17);
+impl_input_pin!(P2_2, MUX4, 12);
+impl_input_pin!(P2_3, MUX4, 13);
+impl_input_pin!(P2_4, MUX4, 14);
+impl_input_pin!(P2_5, MUX4, 15);
+impl_input_pin!(P2_6, MUX4, 18);
+impl_input_pin!(P2_7, MUX4, 19);
+
+impl_input_pin!(P3_0, MUX4, 16);
+impl_input_pin!(P3_1, MUX4, 17);
+impl_input_pin!(P3_8, MUX4, 4);
+impl_input_pin!(P3_9, MUX4, 5);
+impl_input_pin!(P3_14, MUX4, 6);
+impl_input_pin!(P3_15, MUX4, 7);
+impl_input_pin!(P3_16, MUX4, 8);
+impl_input_pin!(P3_17, MUX4, 9);
+impl_input_pin!(P3_22, MUX4, 10);
+impl_input_pin!(P3_27, MUX4, 13);
+impl_input_pin!(P3_28, MUX4, 12);
+impl_input_pin!(P3_29, MUX4, 3);
+
+impl_input_pin!(P4_6, MUX4, 6);
+impl_input_pin!(P4_7, MUX4, 7);
+
+// Output pins
+#[cfg(feature = "swd-swo-as-gpio")]
+impl_output_pin!(P0_2, CTIMER0, MUX4, 0);
+#[cfg(feature = "jtag-extras-as-gpio")]
+impl_output_pin!(P0_3, CTIMER0, MUX4, 1);
+impl_output_pin!(P0_16, CTIMER0, MUX4, 0);
+impl_output_pin!(P0_17, CTIMER0, MUX4, 1);
+impl_output_pin!(P0_18, CTIMER0, MUX4, 2);
+impl_output_pin!(P0_19, CTIMER0, MUX4, 3);
+impl_output_pin!(P0_22, CTIMER0, MUX5, 0);
+impl_output_pin!(P0_23, CTIMER0, MUX5, 1);
+
+impl_output_pin!(P1_0, CTIMER0, MUX5, 2);
+impl_output_pin!(P1_1, CTIMER0, MUX5, 3);
+impl_output_pin!(P1_2, CTIMER1, MUX4, 0);
+impl_output_pin!(P1_3, CTIMER1, MUX4, 1);
+impl_output_pin!(P1_4, CTIMER1, MUX4, 2);
+impl_output_pin!(P1_5, CTIMER1, MUX4, 3);
+impl_output_pin!(P1_6, CTIMER4, MUX5, 0);
+impl_output_pin!(P1_7, CTIMER4, MUX5, 1);
+impl_output_pin!(P1_8, CTIMER0, MUX5, 2);
+impl_output_pin!(P1_9, CTIMER0, MUX5, 3);
+impl_output_pin!(P1_10, CTIMER2, MUX4, 0);
+impl_output_pin!(P1_11, CTIMER2, MUX4, 1);
+impl_output_pin!(P1_12, CTIMER2, MUX4, 2);
+impl_output_pin!(P1_13, CTIMER2, MUX4, 3);
+impl_output_pin!(P1_14, CTIMER3, MUX5, 0);
+impl_output_pin!(P1_15, CTIMER3, MUX5, 1);
+
+impl_output_pin!(P2_0, CTIMER2, MUX5, 0);
+impl_output_pin!(P2_1, CTIMER2, MUX5, 1);
+impl_output_pin!(P2_2, CTIMER2, MUX5, 2);
+impl_output_pin!(P2_3, CTIMER2, MUX5, 3);
+impl_output_pin!(P2_4, CTIMER1, MUX5, 0);
+impl_output_pin!(P2_5, CTIMER1, MUX5, 1);
+impl_output_pin!(P2_6, CTIMER1, MUX5, 2);
+impl_output_pin!(P2_7, CTIMER1, MUX5, 3);
+impl_output_pin!(P2_10, CTIMER3, MUX4, 2);
+impl_output_pin!(P2_11, CTIMER3, MUX4, 3);
+impl_output_pin!(P2_12, CTIMER4, MUX4, 0);
+impl_output_pin!(P2_12, CTIMER0, MUX5, 0);
+impl_output_pin!(P2_13, CTIMER4, MUX4, 1);
+impl_output_pin!(P2_13, CTIMER0, MUX5, 1);
+impl_output_pin!(P2_15, CTIMER4, MUX5, 3);
+impl_output_pin!(P2_15, CTIMER0, MUX5, 2);
+impl_output_pin!(P2_16, CTIMER3, MUX5, 0);
+impl_output_pin!(P2_16, CTIMER0, MUX5, 2);
+impl_output_pin!(P2_17, CTIMER3, MUX5, 1);
+impl_output_pin!(P2_17, CTIMER0, MUX5, 3);
+impl_output_pin!(P2_19, CTIMER3, MUX4, 3);
+impl_output_pin!(P2_20, CTIMER2, MUX4, 0);
+impl_output_pin!(P2_21, CTIMER2, MUX4, 1);
+impl_output_pin!(P2_23, CTIMER2, MUX4, 3);
+
+impl_output_pin!(P3_2, CTIMER4, MUX4, 0);
+impl_output_pin!(P3_6, CTIMER4, MUX4, 2);
+impl_output_pin!(P3_7, CTIMER4, MUX4, 3);
+impl_output_pin!(P3_10, CTIMER1, MUX4, 0);
+impl_output_pin!(P3_11, CTIMER1, MUX4, 1);
+impl_output_pin!(P3_12, CTIMER1, MUX4, 2);
+impl_output_pin!(P3_13, CTIMER1, MUX4, 3);
+impl_output_pin!(P3_18, CTIMER2, MUX4, 0);
+impl_output_pin!(P3_19, CTIMER2, MUX4, 1);
+impl_output_pin!(P3_20, CTIMER2, MUX4, 2);
+impl_output_pin!(P3_21, CTIMER2, MUX4, 3);
+impl_output_pin!(P3_27, CTIMER3, MUX5, 1);
+impl_output_pin!(P3_28, CTIMER3, MUX5, 2);
+#[cfg(feature = "dangerous-reset-as-gpio")]
+impl_output_pin!(P3_29, CTIMER3, MUX5, 3);
+#[cfg(feature = "sosc-as-gpio")]
+impl_output_pin!(P3_30, CTIMER0, MUX4, 2);
+#[cfg(feature = "sosc-as-gpio")]
+impl_output_pin!(P3_31, CTIMER0, MUX4, 3);
+
+impl_output_pin!(P4_2, CTIMER4, MUX4, 0);
+impl_output_pin!(P4_3, CTIMER4, MUX4, 1);
+impl_output_pin!(P4_4, CTIMER4, MUX4, 2);
+impl_output_pin!(P4_5, CTIMER4, MUX4, 3);

--- a/embassy-mcxa/src/ctimer/pwm.rs
+++ b/embassy-mcxa/src/ctimer/pwm.rs
@@ -1,0 +1,357 @@
+//! CTimer-based PWM driver
+
+use embassy_hal_internal::Peri;
+pub use embedded_hal_1::pwm::SetDutyCycle;
+use embedded_hal_1::pwm::{Error, ErrorKind, ErrorType};
+
+use super::{AnyChannel, CTimer, Info, Instance, OutputPin, PwmChannel};
+use crate::gpio::{AnyPin, SealedPin};
+use crate::pac::ctimer::vals::{
+    Mr0i, Mr0r, Mr0s, Mr1i, Mr1r, Mr1s, Mr2i, Mr2r, Mr2s, Mr3i, Mr3r, Mr3s, Pwmen0, Pwmen1, Pwmen2, Pwmen3,
+};
+
+/// PWM error.
+#[derive(Debug)]
+pub enum PwmError {
+    /// Invalid Duty Cycle.
+    InvalidDutyCycle,
+    /// Invalid Channel Number.
+    InvalidChannel,
+    /// Channel mismatch
+    ChannelMismatch,
+}
+
+impl Error for PwmError {
+    fn kind(&self) -> ErrorKind {
+        match self {
+            PwmError::InvalidDutyCycle => ErrorKind::Other,
+            PwmError::InvalidChannel => ErrorKind::Other,
+            PwmError::ChannelMismatch => ErrorKind::Other,
+        }
+    }
+}
+
+/// Pwm Configuration
+#[derive(Debug, Copy, Clone)]
+#[non_exhaustive]
+pub struct Config {
+    /// The point at which the counter wraps around.
+    ///
+    /// This value represents the maximum possible period.
+    pub freq: u16,
+
+    /// Duty cycle.
+    pub duty_cycle: u16,
+}
+
+impl Default for Config {
+    fn default() -> Self {
+        Self {
+            freq: 20_000,
+            duty_cycle: 0,
+        }
+    }
+}
+
+/// Pwm driver
+pub struct Pwm<'d> {
+    info: &'static Info,
+    period_ch: Peri<'d, AnyChannel>,
+    match_ch: Peri<'d, AnyChannel>,
+    pin: Peri<'d, AnyPin>,
+    source_freq: u32,
+    pwm_freq: u16,
+    max_period: u16,
+}
+
+impl<'d> Pwm<'d> {
+    /// Create Pwm driver with a single pin as output.
+    ///
+    /// Upon `Drop`, the external `pin` will be placed into `Disabled`
+    /// state.
+    pub fn new<T: Instance, MATCH: PwmChannel<T>, PIN: OutputPin<T>>(
+        ctimer: CTimer<'d>,
+        period_ch: Peri<'d, impl PwmChannel<T>>,
+        match_ch: Peri<'d, MATCH>,
+        pin: Peri<'d, PIN>,
+        config: Config,
+    ) -> Result<Self, PwmError>
+    where
+        (T, MATCH, PIN): ValidMatchConfig,
+    {
+        if period_ch.number() > 3 || match_ch.number() > 3 {
+            return Err(PwmError::InvalidChannel);
+        }
+
+        if pin.number() != match_ch.number() {
+            return Err(PwmError::ChannelMismatch);
+        }
+
+        pin.mux();
+
+        let mut inst = Self {
+            info: T::info(),
+            period_ch: period_ch.into(),
+            match_ch: match_ch.into(),
+            source_freq: ctimer._freq,
+            pwm_freq: config.freq,
+            pin: pin.into(),
+            max_period: 0,
+        };
+
+        inst.set_configuration(&config)?;
+
+        Ok(inst)
+    }
+
+    fn enable(&mut self) {
+        self.info.regs().tcr().modify(|w| w.set_cen(true));
+    }
+
+    fn disable(&mut self) {
+        self.info.regs().tcr().modify(|w| w.set_cen(false));
+    }
+
+    fn set_configuration(&mut self, config: &Config) -> Result<(), PwmError> {
+        // Enable PWM mode on the match channel
+        self.info.regs().pwmc().modify(|w| match self.match_ch.number() {
+            0 => {
+                w.set_pwmen0(Pwmen0::PWM);
+            }
+            1 => {
+                w.set_pwmen1(Pwmen1::PWM);
+            }
+            2 => {
+                w.set_pwmen2(Pwmen2::PWM);
+            }
+            3 => {
+                w.set_pwmen3(Pwmen3::PWM);
+            }
+            _ => unreachable!(),
+        });
+
+        self.info.regs().mcr().modify(|w| {
+            // Clear stop, reset, and interrupt bits for the PWM channel
+            match self.match_ch.number() {
+                0 => {
+                    w.set_mr0i(Mr0i::MR0I_0);
+                    w.set_mr0r(Mr0r::MR0R_0);
+                    w.set_mr0s(Mr0s::MR0S_0);
+                }
+                1 => {
+                    w.set_mr1i(Mr1i::MR1I_0);
+                    w.set_mr1r(Mr1r::MR1R_0);
+                    w.set_mr1s(Mr1s::MRIS_0);
+                }
+                2 => {
+                    w.set_mr2i(Mr2i::MR2I_0);
+                    w.set_mr2r(Mr2r::MR2R_0);
+                    w.set_mr2s(Mr2s::MR2S_0);
+                }
+                3 => {
+                    w.set_mr3i(Mr3i::MR3I_0);
+                    w.set_mr3r(Mr3r::MR3R_0);
+                    w.set_mr3s(Mr3s::MR3S_0);
+                }
+                _ => unreachable!(),
+            }
+
+            match self.period_ch.number() {
+                0 => {
+                    w.set_mr0r(Mr0r::MR0R_1);
+                }
+                1 => {
+                    w.set_mr1r(Mr1r::MR1R_1);
+                }
+                2 => {
+                    w.set_mr2r(Mr2r::MR2R_1);
+                }
+                3 => {
+                    w.set_mr3r(Mr3r::MR3R_1);
+                }
+                _ => unreachable!(),
+            }
+        });
+
+        // Configure PWM period
+        let period = self.source_freq / u32::from(self.pwm_freq) - 1;
+        self.max_period = period as u16;
+        self.info
+            .regs()
+            .mr(self.period_ch.number())
+            .write(|w| w.set_match_(period));
+
+        // Configure PWM duty cycle
+        let duty_cycle = ((period + 1) * (100 - u32::from(config.duty_cycle))) / 100;
+
+        self.info
+            .regs()
+            .mr(self.match_ch.number())
+            .write(|w| w.set_match_(u32::from(duty_cycle)));
+
+        // REVISIT: do we need interrupts?
+
+        // Start CTimer
+        self.enable();
+
+        Ok(())
+    }
+}
+
+impl<'d> Drop for Pwm<'d> {
+    fn drop(&mut self) {
+        self.disable();
+        self.pin.set_as_disabled();
+    }
+}
+
+impl<'d> ErrorType for Pwm<'d> {
+    type Error = PwmError;
+}
+
+impl<'d> SetDutyCycle for Pwm<'d> {
+    fn max_duty_cycle(&self) -> u16 {
+        self.max_period
+    }
+
+    fn set_duty_cycle(&mut self, duty: u16) -> Result<(), Self::Error> {
+        let max_duty = self.max_duty_cycle();
+
+        if duty > max_duty {
+            return Err(PwmError::InvalidDutyCycle);
+        }
+
+        self.info
+            .regs()
+            .mr(usize::from(self.match_ch.number()))
+            .write(|w| w.set_match_(u32::from(duty)));
+
+        Ok(())
+    }
+}
+
+impl<'d> embassy_embedded_hal::SetConfig for Pwm<'d> {
+    type Config = Config;
+    type ConfigError = PwmError;
+
+    fn set_config(&mut self, config: &Self::Config) -> Result<(), Self::ConfigError> {
+        self.set_configuration(config)
+    }
+}
+
+trait SealedValidMatchConfig {}
+
+/// Valid match channel + pin configuration marker trait
+#[allow(private_bounds)]
+pub trait ValidMatchConfig: SealedValidMatchConfig {}
+
+macro_rules! impl_valid_match {
+    ($peri:ident, $ch:ident, $pin:ident, $n:literal) => {
+        impl SealedValidMatchConfig
+            for (
+                crate::peripherals::$peri,
+                crate::peripherals::$ch,
+                crate::peripherals::$pin,
+            )
+        {
+        }
+
+        impl ValidMatchConfig
+            for (
+                crate::peripherals::$peri,
+                crate::peripherals::$ch,
+                crate::peripherals::$pin,
+            )
+        {
+        }
+    };
+}
+
+// CTIMER0 match channels
+#[cfg(feature = "swd-swo-as-gpio")]
+impl_valid_match!(CTIMER0, CTIMER0_CH0, P0_2, 0);
+#[cfg(feature = "jtag-extras-as-gpio")]
+impl_valid_match!(CTIMER0, CTIMER0_CH1, P0_3, 1);
+
+impl_valid_match!(CTIMER0, CTIMER0_CH0, P0_16, 0);
+impl_valid_match!(CTIMER0, CTIMER0_CH1, P0_17, 1);
+impl_valid_match!(CTIMER0, CTIMER0_CH2, P0_18, 2);
+impl_valid_match!(CTIMER0, CTIMER0_CH3, P0_19, 3);
+
+impl_valid_match!(CTIMER0, CTIMER0_CH0, P0_22, 0);
+impl_valid_match!(CTIMER0, CTIMER0_CH1, P0_23, 1);
+impl_valid_match!(CTIMER0, CTIMER0_CH2, P1_0, 2);
+impl_valid_match!(CTIMER0, CTIMER0_CH3, P1_1, 3);
+
+#[cfg(feature = "sosc-as-gpio")]
+impl_valid_match!(CTIMER0, CTIMER0_CH2, P3_30, 2);
+#[cfg(feature = "sosc-as-gpio")]
+impl_valid_match!(CTIMER0, CTIMER0_CH3, P3_31, 3);
+
+// CTIMER1 match channels
+impl_valid_match!(CTIMER1, CTIMER1_CH0, P1_2, 0);
+impl_valid_match!(CTIMER1, CTIMER1_CH1, P1_3, 1);
+impl_valid_match!(CTIMER1, CTIMER1_CH2, P1_4, 2);
+impl_valid_match!(CTIMER1, CTIMER1_CH3, P1_5, 3);
+
+impl_valid_match!(CTIMER1, CTIMER1_CH0, P2_4, 0);
+impl_valid_match!(CTIMER1, CTIMER1_CH1, P2_5, 1);
+impl_valid_match!(CTIMER1, CTIMER1_CH2, P2_6, 2);
+impl_valid_match!(CTIMER1, CTIMER1_CH3, P2_7, 3);
+
+impl_valid_match!(CTIMER1, CTIMER1_CH0, P3_10, 0);
+impl_valid_match!(CTIMER1, CTIMER1_CH1, P3_11, 1);
+impl_valid_match!(CTIMER1, CTIMER1_CH2, P3_12, 2);
+impl_valid_match!(CTIMER1, CTIMER1_CH3, P3_13, 3);
+
+// CTIMER2 match channels
+impl_valid_match!(CTIMER2, CTIMER2_CH0, P1_10, 0);
+impl_valid_match!(CTIMER2, CTIMER2_CH1, P1_11, 1);
+impl_valid_match!(CTIMER2, CTIMER2_CH2, P1_12, 2);
+impl_valid_match!(CTIMER2, CTIMER2_CH3, P1_13, 3);
+
+impl_valid_match!(CTIMER2, CTIMER2_CH0, P2_0, 0);
+impl_valid_match!(CTIMER2, CTIMER2_CH1, P2_1, 1);
+impl_valid_match!(CTIMER2, CTIMER2_CH2, P2_2, 2);
+impl_valid_match!(CTIMER2, CTIMER2_CH3, P2_3, 3);
+
+impl_valid_match!(CTIMER2, CTIMER2_CH0, P2_20, 0);
+impl_valid_match!(CTIMER2, CTIMER2_CH1, P2_21, 1);
+impl_valid_match!(CTIMER2, CTIMER2_CH3, P2_23, 3);
+
+impl_valid_match!(CTIMER2, CTIMER2_CH0, P3_18, 0);
+impl_valid_match!(CTIMER2, CTIMER2_CH1, P3_19, 1);
+impl_valid_match!(CTIMER2, CTIMER2_CH2, P3_20, 2);
+impl_valid_match!(CTIMER2, CTIMER2_CH3, P3_21, 3);
+
+// CTIMER3 match channels
+impl_valid_match!(CTIMER3, CTIMER3_CH0, P1_14, 0);
+impl_valid_match!(CTIMER3, CTIMER3_CH1, P1_15, 1);
+impl_valid_match!(CTIMER3, CTIMER3_CH2, P2_10, 2);
+impl_valid_match!(CTIMER3, CTIMER3_CH3, P2_11, 3);
+
+impl_valid_match!(CTIMER3, CTIMER3_CH0, P2_16, 0);
+impl_valid_match!(CTIMER3, CTIMER3_CH1, P2_17, 1);
+impl_valid_match!(CTIMER3, CTIMER3_CH2, P2_19, 3);
+
+impl_valid_match!(CTIMER3, CTIMER3_CH0, P3_27, 1);
+impl_valid_match!(CTIMER3, CTIMER3_CH2, P3_28, 2);
+#[cfg(feature = "dangerous-reset-as-gpio")]
+impl_valid_match!(CTIMER3, CTIMER3_CH3, P3_29, 3);
+
+// CTIMER4 match channels
+impl_valid_match!(CTIMER4, CTIMER4_CH0, P1_6, 0);
+impl_valid_match!(CTIMER4, CTIMER4_CH1, P1_7, 1);
+
+impl_valid_match!(CTIMER4, CTIMER4_CH0, P2_12, 0);
+impl_valid_match!(CTIMER4, CTIMER4_CH1, P2_13, 1);
+impl_valid_match!(CTIMER4, CTIMER4_CH3, P2_15, 3);
+
+impl_valid_match!(CTIMER4, CTIMER4_CH0, P3_2, 0);
+impl_valid_match!(CTIMER4, CTIMER4_CH2, P3_6, 2);
+impl_valid_match!(CTIMER4, CTIMER4_CH3, P3_7, 3);
+
+impl_valid_match!(CTIMER4, CTIMER4_CH0, P4_2, 0);
+impl_valid_match!(CTIMER4, CTIMER4_CH1, P4_3, 1);
+impl_valid_match!(CTIMER4, CTIMER4_CH2, P4_4, 2);
+impl_valid_match!(CTIMER4, CTIMER4_CH3, P4_5, 3);

--- a/embassy-mcxa/src/lib.rs
+++ b/embassy-mcxa/src/lib.rs
@@ -11,6 +11,7 @@ pub mod clkout;
 pub mod clocks; // still provide clock helpers
 pub mod config;
 pub mod crc;
+pub mod ctimer;
 pub mod dma;
 pub mod gpio;
 pub mod i2c;
@@ -52,10 +53,39 @@ embassy_hal_internal::peripherals!(
     CRC0,
 
     CTIMER0,
+
+    CTIMER0_CH0,
+    CTIMER0_CH1,
+    CTIMER0_CH2,
+    CTIMER0_CH3,
+
     CTIMER1,
+
+    CTIMER1_CH0,
+    CTIMER1_CH1,
+    CTIMER1_CH2,
+    CTIMER1_CH3,
+
     CTIMER2,
+
+    CTIMER2_CH0,
+    CTIMER2_CH1,
+    CTIMER2_CH2,
+    CTIMER2_CH3,
+
     CTIMER3,
+
+    CTIMER3_CH0,
+    CTIMER3_CH1,
+    CTIMER3_CH2,
+    CTIMER3_CH3,
+
     CTIMER4,
+
+    CTIMER4_CH0,
+    CTIMER4_CH1,
+    CTIMER4_CH2,
+    CTIMER4_CH3,
 
     DBGMAILBOX,
     DMA0,

--- a/examples/mcxa/src/bin/pwm.rs
+++ b/examples/mcxa/src/bin/pwm.rs
@@ -1,0 +1,51 @@
+#![no_std]
+#![no_main]
+
+use embassy_executor::Spawner;
+use embassy_time::Timer;
+use hal::clocks::config::Div8;
+use hal::config::Config;
+use hal::ctimer::CTimer;
+use hal::ctimer::pwm::{Pwm, SetDutyCycle};
+use {defmt_rtt as _, embassy_mcxa as hal, panic_probe as _};
+
+#[embassy_executor::main]
+async fn main(_spawner: Spawner) {
+    let mut config = Config::default();
+    config.clock_cfg.sirc.fro_lf_div = Div8::from_divisor(1);
+
+    let mut p = hal::init(config);
+
+    defmt::info!("Pwm example");
+
+    let led_ctimer = CTimer::new(p.CTIMER2.reborrow(), Default::default()).unwrap();
+    let mut red_pwm = Pwm::new(
+        led_ctimer.clone(),
+        p.CTIMER2_CH3,
+        p.CTIMER2_CH0,
+        p.P3_18,
+        Default::default(),
+    )
+    .unwrap();
+    let mut green_pwm = Pwm::new(led_ctimer, p.CTIMER2_CH2, p.CTIMER2_CH1, p.P3_19, Default::default()).unwrap();
+
+    let pin_ctimer = CTimer::new(p.CTIMER1.reborrow(), Default::default()).unwrap();
+    let mut pin_pwm = Pwm::new(pin_ctimer, p.CTIMER1_CH0, p.CTIMER1_CH2, p.P3_12, Default::default()).unwrap();
+
+    let mut duty: u8 = 0;
+    let mut delta: i8 = 1;
+
+    loop {
+        // Fade LED in and out
+        red_pwm.set_duty_cycle_percent(duty).unwrap();
+        green_pwm.set_duty_cycle_percent(100 - duty).unwrap();
+        pin_pwm.set_duty_cycle_percent(duty).unwrap();
+        duty = ((duty as i8) + delta) as u8;
+
+        if duty == 100 || duty == 0 {
+            delta *= -1;
+        }
+
+        Timer::after_millis(10).await;
+    }
+}


### PR DESCRIPTION
Still some work left on this, for now creating as a draft PR.

@jamesmunns, are there any elegant ways to ensure `match_ch` and `pin` agree on the CTimer channel being used?

Closes https://github.com/OpenDevicePartnership/embassy-mcxa/issues/69
Closes https://github.com/OpenDevicePartnership/embassy-mcxa/issues/113