### PR TITLE
Correct LPUART buffered interrupt enabling

### DIFF
--- a/embassy-mcxa/src/lpuart/buffered.rs
+++ b/embassy-mcxa/src/lpuart/buffered.rs
@@ -9,7 +9,8 @@ use embassy_sync::waitqueue::AtomicWaker;
 
 use super::*;
 use crate::clocks::WakeGuard;
-use crate::interrupt::{self, typelevel::Interrupt};
+use crate::interrupt::typelevel::Interrupt;
+use crate::interrupt::{self};
 
 // ============================================================================
 // STATIC STATE MANAGEMENT


### PR DESCRIPTION
PR https://github.com/embassy-rs/embassy/pull/5178 introduced a regression where the LPUART interrupt would not be enabled when necessary. This was caught by @diondokter during regression testing.
