### PR TITLE
stm32/dma remove redundant asserts

### DIFF
--- a/embassy-stm32/src/dma/dma_bdma.rs
+++ b/embassy-stm32/src/dma/dma_bdma.rs
@@ -992,7 +992,6 @@ impl<'d> Channel<'d> {
         options: TransferOptions,
     ) -> Transfer<'a> {
         let mem_len = buf.len();
-        assert!(mem_len > 0 && mem_len <= 0xFFFF);
 
         self.configure(
             request,
@@ -1032,7 +1031,6 @@ impl<'d> Channel<'d> {
         options: TransferOptions,
     ) -> Transfer<'a> {
         let mem_len = buf.len();
-        assert!(mem_len > 0 && mem_len <= 0xFFFF);
 
         self.configure(
             request,


### PR DESCRIPTION
These asserts are both made in the `configure()` method for dma and bdma. Mdma can do much larger transfers, currently prevented only be these asserts