### PR TITLE
[MCXA]: Fully disable the pin when `set_as_disabled()` is called

### DIFF
--- a/embassy-mcxa/src/i2c/mod.rs
+++ b/embassy-mcxa/src/i2c/mod.rs
@@ -113,7 +113,7 @@ macro_rules! impl_pin {
                 self.set_slew_rate(crate::gpio::SlewRate::Fast.into());
                 self.set_drive_strength(crate::gpio::DriveStrength::Double.into());
                 self.set_function(crate::pac::port0::pcr0::Mux::$fn);
-                self.set_enable_input_buffer();
+                self.set_enable_input_buffer(true);
             }
         }
     };

--- a/embassy-mcxa/src/i3c/mod.rs
+++ b/embassy-mcxa/src/i3c/mod.rs
@@ -150,7 +150,7 @@ macro_rules! impl_pin {
                     self.set_slew_rate(crate::gpio::SlewRate::Fast.into());
                     self.set_drive_strength(crate::gpio::DriveStrength::Double.into());
                     self.set_function(crate::pac::port0::pcr0::Mux::$fn);
-                    self.set_enable_input_buffer();
+                    self.set_enable_input_buffer(true);
                 }
             }
         }

--- a/embassy-mcxa/src/lib.rs
+++ b/embassy-mcxa/src/lib.rs
@@ -506,6 +506,10 @@ pub fn init(cfg: crate::config::Config) -> Peripherals {
     }
     #[cfg(feature = "swd-swo-as-gpio")]
     {
+        use gpio::Input;
+
+        let _x = Input::new(peripherals.P0_2.reborrow(), gpio::Pull::Disabled);
+        core::mem::forget(_x);
         peripherals.P0_2.set_as_disabled();
     }
     #[cfg(feature = "jtag-extras-as-gpio")]

--- a/embassy-mcxa/src/lpuart/mod.rs
+++ b/embassy-mcxa/src/lpuart/mod.rs
@@ -391,7 +391,7 @@ macro_rules! impl_tx_pin {
                 self.set_slew_rate(crate::gpio::SlewRate::Fast.into());
                 self.set_drive_strength(crate::gpio::DriveStrength::Double.into());
                 self.set_function(crate::pac::port0::pcr0::Mux::$alt);
-                self.set_enable_input_buffer();
+                self.set_enable_input_buffer(true);
             }
         }
     };
@@ -406,7 +406,7 @@ macro_rules! impl_rx_pin {
                 self.set_slew_rate(crate::gpio::SlewRate::Fast.into());
                 self.set_drive_strength(crate::gpio::DriveStrength::Double.into());
                 self.set_function(crate::pac::port0::pcr0::Mux::$alt);
-                self.set_enable_input_buffer();
+                self.set_enable_input_buffer(true);
             }
         }
     };


### PR DESCRIPTION
Previously, we were marking the *GPIO mode* as disabled, but this didn't guarantee that the pin was SET to GPIO mode, nor did it guarantee that the input buffer was disabled (necessary for reducing power).

This fixes a regression introduced in https://github.com/embassy-rs/embassy/pull/5336, where we stopped setting the GPIOs to input mode to avoid activating the input buffer, however this meant that we were no longer setting the pins to GPIO mode (ALT0).