### PR TITLE
[MCXA] switch i2c examples to LPI2C2

### DIFF
--- a/examples/mcxa/src/bin/i2c-async.rs
+++ b/examples/mcxa/src/bin/i2c-async.rs
@@ -7,12 +7,12 @@ use hal::bind_interrupts;
 use hal::clocks::config::Div8;
 use hal::config::Config;
 use hal::i2c::controller::{self, I2c, InterruptHandler, Speed};
-use hal::peripherals::LPI2C3;
+use hal::peripherals::LPI2C2;
 use {defmt_rtt as _, embassy_mcxa as hal, panic_probe as _};
 
 bind_interrupts!(
     struct Irqs {
-        LPI2C3 => InterruptHandler<LPI2C3>;
+        LPI2C2 => InterruptHandler<LPI2C2>;
     }
 );
 
@@ -27,7 +27,7 @@ async fn main(_spawner: Spawner) {
 
     let mut config = controller::Config::default();
     config.speed = Speed::Standard;
-    let mut i2c = I2c::new_async(p.LPI2C3, p.P3_27, p.P3_28, Irqs, config).unwrap();
+    let mut i2c = I2c::new_async(p.LPI2C2, p.P1_9, p.P1_8, Irqs, config).unwrap();
     let mut buf = [0u8; 2];
 
     loop {

--- a/examples/mcxa/src/bin/i2c-blocking.rs
+++ b/examples/mcxa/src/bin/i2c-blocking.rs
@@ -20,7 +20,7 @@ async fn main(_spawner: Spawner) {
 
     let mut config = controller::Config::default();
     config.speed = Speed::Standard;
-    let i2c = I2c::new_blocking(p.LPI2C3, p.P3_27, p.P3_28, config).unwrap();
+    let i2c = I2c::new_blocking(p.LPI2C2, p.P1_9, p.P1_8, config).unwrap();
     let mut tmp = Tmp108::new_with_a0_gnd(i2c);
 
     loop {


### PR DESCRIPTION
By using LPI2C2, we can run the example successfully without requiring external HW. The embedded P3T1755 sensor is sw-compatible with TMP108 in I2C mode.