### PR TITLE
embassy-rp::dma: Rm pub(crate) from Channel::{regs,number}

### DIFF
--- a/embassy-rp/src/dma.rs
+++ b/embassy-rp/src/dma.rs
@@ -69,8 +69,13 @@ impl<'d> Channel<'d> {
     }
 
     /// Get the channel register block.
-    pub(crate) fn regs(&self) -> pac::dma::Channel {
+    fn regs(&self) -> pac::dma::Channel {
         pac::DMA.ch(self.number as _)
+    }
+
+    /// Get next write address.
+    pub fn write_addr(&self) -> u32 {
+        self.regs().write_addr().read()
     }
 
     /// Reborrow the channel, allowing it to be used in multiple places.

--- a/embassy-rp/src/uart/mod.rs
+++ b/embassy-rp/src/uart/mod.rs
@@ -679,7 +679,7 @@ impl<'d> UartRx<'d, Async> {
                 let eval = sval + buffer.len();
 
                 // This is the address where the DMA would write to next
-                let next_addr = self.rx_dma.as_mut().unwrap().regs().write_addr().read() as usize;
+                let next_addr = self.rx_dma.as_mut().unwrap().write_addr() as usize;
 
                 // If we DON'T end up inside the range, something has gone really wrong.
                 // Note that it's okay that `eval` is one past the end of the slice, as


### PR DESCRIPTION
I'm not 100% sure of this change. Feedback is welcome.

I don't see the need  for `pub(crate)` for `Channel::regs(&self)` or `Channel::number(&self)`.
Former has single use that I've replaced with new `pub fn write_addr(&self)` and later has no uses.
I feel that those would only be needed to be used inside dma module or outside of embassy-rp crate itself. Making `pub(crate)` useless for in both cases.

Tests: I've cargo checked code and rp/rp235x examples.