### PR TITLE
This commit implements support for Ticker to fire immediately in `embassy-time`.

### DIFF
--- a/embassy-time/src/timer.rs
+++ b/embassy-time/src/timer.rs
@@ -264,6 +264,11 @@ impl Ticker {
         self.expires_at = Instant::now() + after + self.duration;
     }
 
+    /// Resets the ticker to fire immediately.
+    pub fn reset_to_now(&mut self) {
+        self.expires_at = Instant::now();
+    }
+
     /// Waits for the next tick.
     ///
     /// ## Cancel safety


### PR DESCRIPTION
- `reset_to_now` function added to Ticker