### PR TITLE
Fix N6 EXTI

### DIFF
--- a/embassy-stm32/src/exti/low_level.rs
+++ b/embassy-stm32/src/exti/low_level.rs
@@ -32,7 +32,7 @@ pub(super) fn configure_exti_pin(pin: PinNumber, port: PinNumber, trigger_edge: 
         let port = {
             const STM32_PORTI: PinNumber = 0x8;
             const STM32_PORTN: PinNumber = 0xD;
-            if port >= STM32_PORTN { 
+            if port >= STM32_PORTN {
                 port - (STM32_PORTN - STM32_PORTI) // N-Q = 8-12
             } else {
                 port // A-H = 0-7


### PR DESCRIPTION
The EXTI mapping looks like this for the STM32N6, but notice how it skips a few ports (I-M) after H. When the EXTI driver sets pin PN4 for example, it tries to set 13 (A=0, Z=25) when it should set 8. Because we're setting the wrong value, we never end up getting the interrupt.

This patch adjusts the port number if it's port N or above on the N6.

```Rust
A:0
B:1
C:2
D:3
E:4
F:5
G:6
H:7
N:8
O:9
P:10
Q:12
```