### PR TITLE
embassy-rp::dma::Channel: Allow use of custom irq handler

### DIFF
--- a/cyw43-pio/src/lib.rs
+++ b/cyw43-pio/src/lib.rs
@@ -8,8 +8,9 @@ use core::slice;
 use cyw43::SpiBusCyw43;
 use embassy_rp::Peri;
 use embassy_rp::clocks::clk_sys_freq;
-use embassy_rp::dma::{Auto, Channel};
+use embassy_rp::dma::Channel;
 use embassy_rp::gpio::{Drive, Level, Output, Pull, SlewRate};
+use embassy_rp::mode::Async;
 use embassy_rp::pio::program::pio_asm;
 use embassy_rp::pio::{Common, Config, Direction, Instance, Irq, PioPin, ShiftDirection, StateMachine};
 use fixed::FixedU32;
@@ -20,8 +21,8 @@ pub struct PioSpi<'d, PIO: Instance, const SM: usize> {
     cs: Output<'d>,
     sm: StateMachine<'d, PIO, SM>,
     irq: Irq<'d, PIO, 0>,
-    dma_tx: Channel<'d, Auto>,
-    dma_rx: Channel<'d, Auto>,
+    dma_tx: Channel<'d, Async>,
+    dma_rx: Channel<'d, Async>,
     wrap_target: u8,
 }
 
@@ -58,8 +59,8 @@ where
         cs: Output<'d>,
         dio: Peri<'d, impl PioPin>,
         clk: Peri<'d, impl PioPin>,
-        dma_tx: Channel<'d, Auto>,
-        dma_rx: Channel<'d, Auto>,
+        dma_tx: Channel<'d, Async>,
+        dma_rx: Channel<'d, Async>,
     ) -> Self {
         let effective_pio_frequency = (clk_sys_freq() as f32 / clock_divider.to_num::<f32>()) as u32;
 

--- a/cyw43-pio/src/lib.rs
+++ b/cyw43-pio/src/lib.rs
@@ -8,7 +8,7 @@ use core::slice;
 use cyw43::SpiBusCyw43;
 use embassy_rp::Peri;
 use embassy_rp::clocks::clk_sys_freq;
-use embassy_rp::dma::Channel;
+use embassy_rp::dma::{Auto, Channel};
 use embassy_rp::gpio::{Drive, Level, Output, Pull, SlewRate};
 use embassy_rp::pio::program::pio_asm;
 use embassy_rp::pio::{Common, Config, Direction, Instance, Irq, PioPin, ShiftDirection, StateMachine};
@@ -20,8 +20,8 @@ pub struct PioSpi<'d, PIO: Instance, const SM: usize> {
     cs: Output<'d>,
     sm: StateMachine<'d, PIO, SM>,
     irq: Irq<'d, PIO, 0>,
-    dma_tx: Channel<'d>,
-    dma_rx: Channel<'d>,
+    dma_tx: Channel<'d, Auto>,
+    dma_rx: Channel<'d, Auto>,
     wrap_target: u8,
 }
 
@@ -58,8 +58,8 @@ where
         cs: Output<'d>,
         dio: Peri<'d, impl PioPin>,
         clk: Peri<'d, impl PioPin>,
-        dma_tx: Channel<'d>,
-        dma_rx: Channel<'d>,
+        dma_tx: Channel<'d, Auto>,
+        dma_rx: Channel<'d, Auto>,
     ) -> Self {
         let effective_pio_frequency = (clk_sys_freq() as f32 / clock_divider.to_num::<f32>()) as u32;
 

--- a/embassy-rp/src/adc.rs
+++ b/embassy-rp/src/adc.rs
@@ -242,7 +242,7 @@ impl<'d> Adc<'d, Async> {
         buf: &mut [W],
         fcs_err: bool,
         div: u16,
-        dma_ch: &mut dma::Channel<'_>,
+        dma_ch: &mut dma::Channel<'_, dma::Auto>,
     ) -> Result<(), Error> {
         #[cfg(feature = "rp2040")]
         let mut rrobin = 0_u8;
@@ -323,7 +323,7 @@ impl<'d> Adc<'d, Async> {
         ch: &mut [Channel<'_>],
         buf: &mut [S],
         div: u16,
-        dma: &mut dma::Channel<'_>,
+        dma: &mut dma::Channel<'_, dma::Auto>,
     ) -> Result<(), Error> {
         self.read_many_inner(ch.iter().map(|c| c.channel()), buf, false, div, dma)
             .await
@@ -339,7 +339,7 @@ impl<'d> Adc<'d, Async> {
         ch: &mut [Channel<'_>],
         buf: &mut [Sample],
         div: u16,
-        dma: &mut dma::Channel<'_>,
+        dma: &mut dma::Channel<'_, dma::Auto>,
     ) {
         // errors are reported in individual samples
         let _ = self
@@ -362,7 +362,7 @@ impl<'d> Adc<'d, Async> {
         ch: &mut Channel<'_>,
         buf: &mut [S],
         div: u16,
-        dma: &mut dma::Channel<'_>,
+        dma: &mut dma::Channel<'_, dma::Auto>,
     ) -> Result<(), Error> {
         self.read_many_inner([ch.channel()].into_iter(), buf, false, div, dma)
             .await
@@ -377,7 +377,7 @@ impl<'d> Adc<'d, Async> {
         ch: &mut Channel<'_>,
         buf: &mut [Sample],
         div: u16,
-        dma: &mut dma::Channel<'_>,
+        dma: &mut dma::Channel<'_, dma::Auto>,
     ) {
         // errors are reported in individual samples
         let _ = self

--- a/embassy-rp/src/adc.rs
+++ b/embassy-rp/src/adc.rs
@@ -12,7 +12,7 @@ use crate::interrupt::InterruptExt;
 use crate::interrupt::typelevel::Binding;
 use crate::pac::dma::vals::TreqSel;
 use crate::peripherals::{ADC, ADC_TEMP_SENSOR};
-use crate::{Peri, RegExt, dma, interrupt, pac, peripherals};
+use crate::{Peri, RegExt, dma, interrupt, mode, pac, peripherals};
 
 static WAKER: AtomicWaker = AtomicWaker::new();
 
@@ -242,7 +242,7 @@ impl<'d> Adc<'d, Async> {
         buf: &mut [W],
         fcs_err: bool,
         div: u16,
-        dma_ch: &mut dma::Channel<'_, dma::Auto>,
+        dma_ch: &mut dma::Channel<'_, mode::Async>,
     ) -> Result<(), Error> {
         #[cfg(feature = "rp2040")]
         let mut rrobin = 0_u8;
@@ -323,7 +323,7 @@ impl<'d> Adc<'d, Async> {
         ch: &mut [Channel<'_>],
         buf: &mut [S],
         div: u16,
-        dma: &mut dma::Channel<'_, dma::Auto>,
+        dma: &mut dma::Channel<'_, mode::Async>,
     ) -> Result<(), Error> {
         self.read_many_inner(ch.iter().map(|c| c.channel()), buf, false, div, dma)
             .await
@@ -339,7 +339,7 @@ impl<'d> Adc<'d, Async> {
         ch: &mut [Channel<'_>],
         buf: &mut [Sample],
         div: u16,
-        dma: &mut dma::Channel<'_, dma::Auto>,
+        dma: &mut dma::Channel<'_, mode::Async>,
     ) {
         // errors are reported in individual samples
         let _ = self
@@ -362,7 +362,7 @@ impl<'d> Adc<'d, Async> {
         ch: &mut Channel<'_>,
         buf: &mut [S],
         div: u16,
-        dma: &mut dma::Channel<'_, dma::Auto>,
+        dma: &mut dma::Channel<'_, mode::Async>,
     ) -> Result<(), Error> {
         self.read_many_inner([ch.channel()].into_iter(), buf, false, div, dma)
             .await
@@ -377,7 +377,7 @@ impl<'d> Adc<'d, Async> {
         ch: &mut Channel<'_>,
         buf: &mut [Sample],
         div: u16,
-        dma: &mut dma::Channel<'_, dma::Auto>,
+        dma: &mut dma::Channel<'_, mode::Async>,
     ) {
         // errors are reported in individual samples
         let _ = self

--- a/embassy-rp/src/dma.rs
+++ b/embassy-rp/src/dma.rs
@@ -40,18 +40,37 @@ pub(crate) unsafe fn init() {
     interrupt::DMA_IRQ_0.set_priority(interrupt::Priority::P3);
 }
 
-/// DMA channel driver.
-pub struct Channel<'d> {
-    number: u8,
-    phantom: PhantomData<&'d ()>,
+trait SealedMode {}
+
+/// Mode.
+#[allow(private_bounds)]
+pub trait Mode: SealedMode {}
+
+macro_rules! impl_mode {
+    ($name:ident) => {
+        impl SealedMode for $name {}
+        impl Mode for $name {}
+    };
 }
 
-impl<'d> Channel<'d> {
+/// Use built-in irq handler for DMA transwer completion.
+pub struct Auto;
+/// Handle transwer completion by polling or manual irq handler.
+pub struct Manual;
+
+impl_mode!(Auto);
+impl_mode!(Manual);
+
+/// DMA channel driver.
+pub struct Channel<'d, M: Mode> {
+    number: u8,
+    phantom: PhantomData<&'d M>,
+}
+
+impl<'d> Channel<'d, Manual> {
     /// Create a new DMA channel driver.
-    pub fn new<T: ChannelInstance>(
-        _ch: Peri<'d, T>,
-        _irq: impl interrupt::typelevel::Binding<T::Interrupt, InterruptHandler<T>> + 'd,
-    ) -> Self {
+    /// SAFETY: You are responsible for pooling/irq setup
+    pub unsafe fn new_manual<T: ChannelInstance>(_ch: Peri<'d, T>) -> Self {
         let number = T::number();
 
         // Enable interrupt for this channel
@@ -63,7 +82,9 @@ impl<'d> Channel<'d> {
             phantom: PhantomData,
         }
     }
+}
 
+impl<'d, M: Mode> Channel<'d, M> {
     /// Get the channel number.
     pub fn number(&self) -> u8 {
         self.number
@@ -87,9 +108,28 @@ impl<'d> Channel<'d> {
     }
 
     /// Reborrow the channel, allowing it to be used in multiple places.
-    pub fn reborrow(&mut self) -> Channel<'_> {
-        Channel {
+    pub fn reborrow(&mut self) -> Channel<'_, M> {
+        Channel::<M> {
             number: self.number,
+            phantom: PhantomData,
+        }
+    }
+}
+
+impl<'d> Channel<'d, Auto> {
+    /// Create a new DMA channel driver.
+    pub fn new<T: ChannelInstance>(
+        _ch: Peri<'d, T>,
+        _irq: impl interrupt::typelevel::Binding<T::Interrupt, InterruptHandler<T>> + 'd,
+    ) -> Self {
+        let number = T::number();
+
+        // Enable interrupt for this channel
+        pac::DMA.inte(0).write_set(|v| *v = 1 << number);
+        unsafe { T::Interrupt::enable() };
+
+        Self {
+            number,
             phantom: PhantomData,
         }
     }
@@ -254,11 +294,11 @@ impl<'d> Channel<'d> {
 /// DMA transfer driver.
 #[must_use = "futures do nothing unless you `.await` or poll them"]
 pub struct Transfer<'a> {
-    channel: Channel<'a>,
+    channel: Channel<'a, Auto>,
 }
 
 impl<'a> Transfer<'a> {
-    fn new(channel: Channel<'a>) -> Self {
+    fn new(channel: Channel<'a, Auto>) -> Self {
         Self { channel }
     }
 }

--- a/embassy-rp/src/dma.rs
+++ b/embassy-rp/src/dma.rs
@@ -11,6 +11,7 @@ use embassy_sync::waitqueue::AtomicWaker;
 use pac::dma::vals::DataSize;
 
 use crate::interrupt::typelevel::Interrupt;
+use crate::mode::{Async, Blocking, Mode};
 use crate::pac::dma::vals;
 use crate::{RegExt, interrupt, pac, peripherals};
 
@@ -40,37 +41,17 @@ pub(crate) unsafe fn init() {
     interrupt::DMA_IRQ_0.set_priority(interrupt::Priority::P3);
 }
 
-trait SealedMode {}
-
-/// Mode.
-#[allow(private_bounds)]
-pub trait Mode: SealedMode {}
-
-macro_rules! impl_mode {
-    ($name:ident) => {
-        impl SealedMode for $name {}
-        impl Mode for $name {}
-    };
-}
-
-/// Use built-in irq handler for DMA transwer completion.
-pub struct Auto;
-/// Handle transwer completion by polling or manual irq handler.
-pub struct Manual;
-
-impl_mode!(Auto);
-impl_mode!(Manual);
-
 /// DMA channel driver.
 pub struct Channel<'d, M: Mode> {
     number: u8,
     phantom: PhantomData<&'d M>,
 }
 
-impl<'d> Channel<'d, Manual> {
-    /// Create a new DMA channel driver.
-    /// SAFETY: You are responsible for pooling/irq setup
-    pub unsafe fn new_manual<T: ChannelInstance>(_ch: Peri<'d, T>) -> Self {
+impl<'d> Channel<'d, Blocking> {
+    /// Create a new DMA channel driver, in blocking mode.
+    ///
+    /// SAFETY: You are responsible for polling/irq setup.
+    pub unsafe fn new_blocking<T: ChannelInstance>(_ch: Peri<'d, T>) -> Self {
         let number = T::number();
 
         // Enable interrupt for this channel
@@ -116,7 +97,7 @@ impl<'d, M: Mode> Channel<'d, M> {
     }
 }
 
-impl<'d> Channel<'d, Auto> {
+impl<'d> Channel<'d, Async> {
     /// Create a new DMA channel driver.
     pub fn new<T: ChannelInstance>(
         _ch: Peri<'d, T>,
@@ -294,11 +275,11 @@ impl<'d> Channel<'d, Auto> {
 /// DMA transfer driver.
 #[must_use = "futures do nothing unless you `.await` or poll them"]
 pub struct Transfer<'a> {
-    channel: Channel<'a, Auto>,
+    channel: Channel<'a, Async>,
 }
 
 impl<'a> Transfer<'a> {
-    fn new(channel: Channel<'a, Auto>) -> Self {
+    fn new(channel: Channel<'a, Async>) -> Self {
         Self { channel }
     }
 }

--- a/embassy-rp/src/flash.rs
+++ b/embassy-rp/src/flash.rs
@@ -113,7 +113,7 @@ impl<'a, 'd, T: Instance, const FLASH_SIZE: usize> Drop for BackgroundRead<'a, '
 
 /// Flash driver.
 pub struct Flash<'d, T: Instance, M: Mode, const FLASH_SIZE: usize> {
-    dma: Option<dma::Channel<'d>>,
+    dma: Option<dma::Channel<'d, dma::Auto>>,
     phantom: PhantomData<(&'d mut T, M)>,
 }
 

--- a/embassy-rp/src/flash.rs
+++ b/embassy-rp/src/flash.rs
@@ -11,7 +11,7 @@ use embedded_storage::nor_flash::{
 };
 
 use crate::peripherals::FLASH;
-use crate::{dma, interrupt, pac};
+use crate::{dma, interrupt, mode, pac};
 
 /// Flash base address.
 pub const FLASH_BASE: *const u32 = 0x10000000 as _;
@@ -113,7 +113,7 @@ impl<'a, 'd, T: Instance, const FLASH_SIZE: usize> Drop for BackgroundRead<'a, '
 
 /// Flash driver.
 pub struct Flash<'d, T: Instance, M: Mode, const FLASH_SIZE: usize> {
-    dma: Option<dma::Channel<'d, dma::Auto>>,
+    dma: Option<dma::Channel<'d, mode::Async>>,
     phantom: PhantomData<(&'d mut T, M)>,
 }
 

--- a/embassy-rp/src/lib.rs
+++ b/embassy-rp/src/lib.rs
@@ -38,6 +38,7 @@ pub mod gpio;
 pub mod i2c;
 pub mod i2c_slave;
 pub mod interpolator;
+pub mod mode;
 pub mod multicore;
 #[cfg(feature = "_rp235x")]
 pub mod otp;

--- a/embassy-rp/src/mode.rs
+++ b/embassy-rp/src/mode.rs
@@ -1,0 +1,24 @@
+//! Operating modes for peripherals.
+
+trait SealedMode {}
+
+/// Operating mode for a peripheral.
+#[allow(private_bounds)]
+pub trait Mode: SealedMode {}
+
+/// Blocking mode.
+///
+/// No interrupt is bound, completion is handled by polling or by an
+/// interrupt handler set up by the user.
+pub struct Blocking;
+
+/// Async mode.
+///
+/// The built-in interrupt handler is bound, completion is handled by waking
+/// the task waiting on it.
+pub struct Async;
+
+impl SealedMode for Blocking {}
+impl Mode for Blocking {}
+impl SealedMode for Async {}
+impl Mode for Async {}

--- a/embassy-rp/src/pio/mod.rs
+++ b/embassy-rp/src/pio/mod.rs
@@ -15,7 +15,7 @@ use crate::dma::{self, Transfer, Word};
 use crate::gpio::{self, AnyPin, Drive, Level, Pull, SealedPin, SlewRate};
 use crate::interrupt::typelevel::{Binding, Handler, Interrupt};
 use crate::relocate::RelocatedProgram;
-use crate::{RegExt, pac, peripherals};
+use crate::{RegExt, mode, pac, peripherals};
 
 mod instr;
 
@@ -404,7 +404,7 @@ impl<'d, PIO: Instance, const SM: usize> StateMachineRx<'d, PIO, SM> {
     /// Prepare DMA transfer from RX FIFO.
     pub fn dma_pull<'a, W: Word>(
         &'a mut self,
-        ch: &'a mut dma::Channel<'_, dma::Auto>,
+        ch: &'a mut dma::Channel<'_, mode::Async>,
         data: &'a mut [W],
         bswap: bool,
     ) -> Transfer<'a> {
@@ -414,7 +414,7 @@ impl<'d, PIO: Instance, const SM: usize> StateMachineRx<'d, PIO, SM> {
     /// Prepare a repeated DMA transfer from RX FIFO.
     pub fn dma_pull_discard<'a, W: Word>(
         &'a mut self,
-        ch: &'a mut dma::Channel<'_, dma::Auto>,
+        ch: &'a mut dma::Channel<'_, mode::Async>,
         len: usize,
     ) -> Transfer<'a> {
         unsafe { ch.read_discard(PIO::PIO.rxf(SM).as_ptr(), len, Self::dreq()) }
@@ -488,7 +488,7 @@ impl<'d, PIO: Instance, const SM: usize> StateMachineTx<'d, PIO, SM> {
     /// Prepare a DMA transfer to TX FIFO.
     pub fn dma_push<'a, W: Word>(
         &'a mut self,
-        ch: &'a mut dma::Channel<'_, dma::Auto>,
+        ch: &'a mut dma::Channel<'_, mode::Async>,
         data: &'a [W],
         bswap: bool,
     ) -> Transfer<'a> {
@@ -498,7 +498,7 @@ impl<'d, PIO: Instance, const SM: usize> StateMachineTx<'d, PIO, SM> {
     /// Prepare a repeated DMA transfer to TX FIFO.
     pub fn dma_push_zeros<'a, W: Word>(
         &'a mut self,
-        ch: &'a mut dma::Channel<'_, dma::Auto>,
+        ch: &'a mut dma::Channel<'_, mode::Async>,
         len: usize,
     ) -> Transfer<'a> {
         unsafe { ch.write_zeros(len, PIO::PIO.txf(SM).as_ptr() as *mut W, Self::dreq()) }

--- a/embassy-rp/src/pio/mod.rs
+++ b/embassy-rp/src/pio/mod.rs
@@ -404,7 +404,7 @@ impl<'d, PIO: Instance, const SM: usize> StateMachineRx<'d, PIO, SM> {
     /// Prepare DMA transfer from RX FIFO.
     pub fn dma_pull<'a, W: Word>(
         &'a mut self,
-        ch: &'a mut dma::Channel<'_>,
+        ch: &'a mut dma::Channel<'_, dma::Auto>,
         data: &'a mut [W],
         bswap: bool,
     ) -> Transfer<'a> {
@@ -412,7 +412,11 @@ impl<'d, PIO: Instance, const SM: usize> StateMachineRx<'d, PIO, SM> {
     }
 
     /// Prepare a repeated DMA transfer from RX FIFO.
-    pub fn dma_pull_discard<'a, W: Word>(&'a mut self, ch: &'a mut dma::Channel<'_>, len: usize) -> Transfer<'a> {
+    pub fn dma_pull_discard<'a, W: Word>(
+        &'a mut self,
+        ch: &'a mut dma::Channel<'_, dma::Auto>,
+        len: usize,
+    ) -> Transfer<'a> {
         unsafe { ch.read_discard(PIO::PIO.rxf(SM).as_ptr(), len, Self::dreq()) }
     }
 }
@@ -484,7 +488,7 @@ impl<'d, PIO: Instance, const SM: usize> StateMachineTx<'d, PIO, SM> {
     /// Prepare a DMA transfer to TX FIFO.
     pub fn dma_push<'a, W: Word>(
         &'a mut self,
-        ch: &'a mut dma::Channel<'_>,
+        ch: &'a mut dma::Channel<'_, dma::Auto>,
         data: &'a [W],
         bswap: bool,
     ) -> Transfer<'a> {
@@ -492,7 +496,11 @@ impl<'d, PIO: Instance, const SM: usize> StateMachineTx<'d, PIO, SM> {
     }
 
     /// Prepare a repeated DMA transfer to TX FIFO.
-    pub fn dma_push_zeros<'a, W: Word>(&'a mut self, ch: &'a mut dma::Channel<'_>, len: usize) -> Transfer<'a> {
+    pub fn dma_push_zeros<'a, W: Word>(
+        &'a mut self,
+        ch: &'a mut dma::Channel<'_, dma::Auto>,
+        len: usize,
+    ) -> Transfer<'a> {
         unsafe { ch.write_zeros(len, PIO::PIO.txf(SM).as_ptr() as *mut W, Self::dreq()) }
     }
 }

--- a/embassy-rp/src/pio_programs/hd44780.rs
+++ b/embassy-rp/src/pio_programs/hd44780.rs
@@ -99,7 +99,7 @@ impl<'a, PIO: Instance> PioHD44780CommandSequenceProgram<'a, PIO> {
 
 /// Pio backed HD44780 driver
 pub struct PioHD44780<'l, P: Instance, const S: usize> {
-    dma: dma::Channel<'l>,
+    dma: dma::Channel<'l, dma::Auto>,
     sm: StateMachine<'l, P, S>,
 
     buf: [u8; 40],

--- a/embassy-rp/src/pio_programs/hd44780.rs
+++ b/embassy-rp/src/pio_programs/hd44780.rs
@@ -5,7 +5,7 @@ use crate::pio::{
     StateMachine,
 };
 use crate::pio_programs::clock_divider::calculate_pio_clock_divider;
-use crate::{Peri, dma, interrupt};
+use crate::{Peri, dma, interrupt, mode};
 
 /// This struct represents a HD44780 program that takes command words (<wait:24> <command:4> <0:4>)
 pub struct PioHD44780CommandWordProgram<'a, PIO: Instance> {
@@ -99,7 +99,7 @@ impl<'a, PIO: Instance> PioHD44780CommandSequenceProgram<'a, PIO> {
 
 /// Pio backed HD44780 driver
 pub struct PioHD44780<'l, P: Instance, const S: usize> {
-    dma: dma::Channel<'l, dma::Auto>,
+    dma: dma::Channel<'l, mode::Async>,
     sm: StateMachine<'l, P, S>,
 
     buf: [u8; 40],

--- a/embassy-rp/src/pio_programs/i2s.rs
+++ b/embassy-rp/src/pio_programs/i2s.rs
@@ -39,7 +39,7 @@ impl<'d, PIO: Instance> PioI2sInProgram<'d, PIO> {
 
 /// Pio backed I2S input driver
 pub struct PioI2sIn<'d, P: Instance, const S: usize> {
-    dma: dma::Channel<'d>,
+    dma: dma::Channel<'d, dma::Auto>,
     sm: StateMachine<'d, P, S>,
 }
 
@@ -157,7 +157,7 @@ impl<'d, PIO: Instance> PioI2sOutProgram<'d, PIO> {
 
 /// Pio backed I2S output driver
 pub struct PioI2sOut<'d, P: Instance, const S: usize> {
-    dma: dma::Channel<'d>,
+    dma: dma::Channel<'d, dma::Auto>,
     sm: StateMachine<'d, P, S>,
 }
 

--- a/embassy-rp/src/pio_programs/i2s.rs
+++ b/embassy-rp/src/pio_programs/i2s.rs
@@ -7,7 +7,7 @@ use crate::pio::{
     StateMachine,
 };
 use crate::pio_programs::clock_divider::calculate_pio_clock_divider;
-use crate::{Peri, dma, interrupt};
+use crate::{Peri, dma, interrupt, mode};
 
 /// This struct represents an I2S receiver & controller driver program
 pub struct PioI2sInProgram<'d, PIO: Instance> {
@@ -39,7 +39,7 @@ impl<'d, PIO: Instance> PioI2sInProgram<'d, PIO> {
 
 /// Pio backed I2S input driver
 pub struct PioI2sIn<'d, P: Instance, const S: usize> {
-    dma: dma::Channel<'d, dma::Auto>,
+    dma: dma::Channel<'d, mode::Async>,
     sm: StateMachine<'d, P, S>,
 }
 
@@ -157,7 +157,7 @@ impl<'d, PIO: Instance> PioI2sOutProgram<'d, PIO> {
 
 /// Pio backed I2S output driver
 pub struct PioI2sOut<'d, P: Instance, const S: usize> {
-    dma: dma::Channel<'d, dma::Auto>,
+    dma: dma::Channel<'d, mode::Async>,
     sm: StateMachine<'d, P, S>,
 }
 

--- a/embassy-rp/src/pio_programs/spi.rs
+++ b/embassy-rp/src/pio_programs/spi.rs
@@ -92,8 +92,8 @@ pub struct Spi<'d, PIO: Instance, const SM: usize, M: Mode> {
     cfg: crate::pio::Config<'d, PIO>,
     program: Option<PioSpiProgram<'d, PIO>>,
     clk_pin: Pin<'d, PIO>,
-    tx_dma: Option<dma::Channel<'d>>,
-    rx_dma: Option<dma::Channel<'d>>,
+    tx_dma: Option<dma::Channel<'d, dma::Auto>>,
+    rx_dma: Option<dma::Channel<'d, dma::Auto>>,
     phantom: PhantomData<M>,
 }
 
@@ -105,8 +105,8 @@ impl<'d, PIO: Instance, const SM: usize, M: Mode> Spi<'d, PIO, SM, M> {
         clk_pin: Peri<'d, impl PioPin>,
         mosi_pin: Peri<'d, impl PioPin>,
         miso_pin: Peri<'d, impl PioPin>,
-        tx_dma: Option<dma::Channel<'d>>,
-        rx_dma: Option<dma::Channel<'d>>,
+        tx_dma: Option<dma::Channel<'d, dma::Auto>>,
+        rx_dma: Option<dma::Channel<'d, dma::Auto>>,
         config: Config,
     ) -> Self {
         let program = PioSpiProgram::new(pio, config.phase);

--- a/embassy-rp/src/pio_programs/spi.rs
+++ b/embassy-rp/src/pio_programs/spi.rs
@@ -12,7 +12,7 @@ use crate::clocks::clk_sys_freq;
 use crate::gpio::Level;
 use crate::pio::{Common, Direction, Instance, LoadedProgram, Pin, PioPin, ShiftDirection, StateMachine};
 use crate::spi::{Async, Blocking, Config, Mode};
-use crate::{dma, interrupt};
+use crate::{dma, interrupt, mode};
 
 /// This struct represents an SPI program loaded into pio instruction memory.
 struct PioSpiProgram<'d, PIO: Instance> {
@@ -92,8 +92,8 @@ pub struct Spi<'d, PIO: Instance, const SM: usize, M: Mode> {
     cfg: crate::pio::Config<'d, PIO>,
     program: Option<PioSpiProgram<'d, PIO>>,
     clk_pin: Pin<'d, PIO>,
-    tx_dma: Option<dma::Channel<'d, dma::Auto>>,
-    rx_dma: Option<dma::Channel<'d, dma::Auto>>,
+    tx_dma: Option<dma::Channel<'d, mode::Async>>,
+    rx_dma: Option<dma::Channel<'d, mode::Async>>,
     phantom: PhantomData<M>,
 }
 
@@ -105,8 +105,8 @@ impl<'d, PIO: Instance, const SM: usize, M: Mode> Spi<'d, PIO, SM, M> {
         clk_pin: Peri<'d, impl PioPin>,
         mosi_pin: Peri<'d, impl PioPin>,
         miso_pin: Peri<'d, impl PioPin>,
-        tx_dma: Option<dma::Channel<'d, dma::Auto>>,
-        rx_dma: Option<dma::Channel<'d, dma::Auto>>,
+        tx_dma: Option<dma::Channel<'d, mode::Async>>,
+        rx_dma: Option<dma::Channel<'d, mode::Async>>,
         config: Config,
     ) -> Self {
         let program = PioSpiProgram::new(pio, config.phase);

--- a/embassy-rp/src/pio_programs/ws2812.rs
+++ b/embassy-rp/src/pio_programs/ws2812.rs
@@ -104,7 +104,7 @@ pub struct PioWs2812<'d, P: Instance, const S: usize, ORDER>
 where
     ORDER: RgbColorOrder,
 {
-    dma: dma::Channel<'d>,
+    dma: dma::Channel<'d, dma::Auto>,
     sm: StateMachine<'d, P, S>,
     _order: core::marker::PhantomData<ORDER>,
 }
@@ -213,7 +213,7 @@ pub struct RgbwPioWs2812<'d, P: Instance, const S: usize, ORDER>
 where
     ORDER: RgbwColorOrder,
 {
-    dma: dma::Channel<'d>,
+    dma: dma::Channel<'d, dma::Auto>,
     sm: StateMachine<'d, P, S>,
     _order: core::marker::PhantomData<ORDER>,
 }

--- a/embassy-rp/src/pio_programs/ws2812.rs
+++ b/embassy-rp/src/pio_programs/ws2812.rs
@@ -8,7 +8,7 @@ use crate::clocks::clk_sys_freq;
 use crate::pio::{
     Common, Config, FifoJoin, Instance, LoadedProgram, PioPin, ShiftConfig, ShiftDirection, StateMachine,
 };
-use crate::{Peri, dma, interrupt};
+use crate::{Peri, dma, interrupt, mode};
 
 const T1: u8 = 2; // start bit
 const T2: u8 = 5; // data bit
@@ -104,7 +104,7 @@ pub struct PioWs2812<'d, P: Instance, const S: usize, ORDER>
 where
     ORDER: RgbColorOrder,
 {
-    dma: dma::Channel<'d, dma::Auto>,
+    dma: dma::Channel<'d, mode::Async>,
     sm: StateMachine<'d, P, S>,
     _order: core::marker::PhantomData<ORDER>,
 }
@@ -213,7 +213,7 @@ pub struct RgbwPioWs2812<'d, P: Instance, const S: usize, ORDER>
 where
     ORDER: RgbwColorOrder,
 {
-    dma: dma::Channel<'d, dma::Auto>,
+    dma: dma::Channel<'d, mode::Async>,
     sm: StateMachine<'d, P, S>,
     _order: core::marker::PhantomData<ORDER>,
 }

--- a/embassy-rp/src/spi.rs
+++ b/embassy-rp/src/spi.rs
@@ -6,7 +6,7 @@ use embassy_futures::join::join;
 use embassy_hal_internal::{Peri, PeripheralType};
 pub use embedded_hal_02::spi::{Phase, Polarity};
 
-use crate::dma::{Channel, ChannelInstance};
+use crate::dma::{Auto, Channel, ChannelInstance};
 use crate::gpio::{AnyPin, Pin as GpioPin, SealedPin as _};
 use crate::{dma, interrupt, pac, peripherals};
 
@@ -43,8 +43,8 @@ impl Default for Config {
 /// SPI driver.
 pub struct Spi<'d, M: Mode> {
     info: &'static Info,
-    tx_dma: Option<Channel<'d>>,
-    rx_dma: Option<Channel<'d>>,
+    tx_dma: Option<Channel<'d, Auto>>,
+    rx_dma: Option<Channel<'d, Auto>>,
     phantom: PhantomData<(&'d mut (), M)>,
 }
 
@@ -78,8 +78,8 @@ impl<'d, M: Mode> Spi<'d, M> {
         mosi: Option<Peri<'d, AnyPin>>,
         miso: Option<Peri<'d, AnyPin>>,
         cs: Option<Peri<'d, AnyPin>>,
-        tx_dma: Option<Channel<'d>>,
-        rx_dma: Option<Channel<'d>>,
+        tx_dma: Option<Channel<'d, Auto>>,
+        rx_dma: Option<Channel<'d, Auto>>,
         config: Config,
     ) -> Self {
         Self::apply_config(T::info(), &config);

--- a/embassy-rp/src/spi.rs
+++ b/embassy-rp/src/spi.rs
@@ -6,9 +6,9 @@ use embassy_futures::join::join;
 use embassy_hal_internal::{Peri, PeripheralType};
 pub use embedded_hal_02::spi::{Phase, Polarity};
 
-use crate::dma::{Auto, Channel, ChannelInstance};
+use crate::dma::{Channel, ChannelInstance};
 use crate::gpio::{AnyPin, Pin as GpioPin, SealedPin as _};
-use crate::{dma, interrupt, pac, peripherals};
+use crate::{dma, interrupt, mode, pac, peripherals};
 
 /// SPI errors.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -43,8 +43,8 @@ impl Default for Config {
 /// SPI driver.
 pub struct Spi<'d, M: Mode> {
     info: &'static Info,
-    tx_dma: Option<Channel<'d, Auto>>,
-    rx_dma: Option<Channel<'d, Auto>>,
+    tx_dma: Option<Channel<'d, mode::Async>>,
+    rx_dma: Option<Channel<'d, mode::Async>>,
     phantom: PhantomData<(&'d mut (), M)>,
 }
 
@@ -78,8 +78,8 @@ impl<'d, M: Mode> Spi<'d, M> {
         mosi: Option<Peri<'d, AnyPin>>,
         miso: Option<Peri<'d, AnyPin>>,
         cs: Option<Peri<'d, AnyPin>>,
-        tx_dma: Option<Channel<'d, Auto>>,
-        rx_dma: Option<Channel<'d, Auto>>,
+        tx_dma: Option<Channel<'d, mode::Async>>,
+        rx_dma: Option<Channel<'d, mode::Async>>,
         config: Config,
     ) -> Self {
         Self::apply_config(T::info(), &config);

--- a/embassy-rp/src/uart/mod.rs
+++ b/embassy-rp/src/uart/mod.rs
@@ -152,7 +152,7 @@ pub struct Uart<'d, M: Mode> {
 /// UART TX driver.
 pub struct UartTx<'d, M: Mode> {
     info: &'static Info,
-    tx_dma: Option<dma::Channel<'d>>,
+    tx_dma: Option<dma::Channel<'d, dma::Auto>>,
     phantom: PhantomData<M>,
 }
 
@@ -160,12 +160,12 @@ pub struct UartTx<'d, M: Mode> {
 pub struct UartRx<'d, M: Mode> {
     info: &'static Info,
     dma_state: &'static DmaState,
-    rx_dma: Option<dma::Channel<'d>>,
+    rx_dma: Option<dma::Channel<'d, dma::Auto>>,
     phantom: PhantomData<M>,
 }
 
 impl<'d, M: Mode> UartTx<'d, M> {
-    fn new_inner(info: &'static Info, tx_dma: Option<Channel<'d>>) -> Self {
+    fn new_inner(info: &'static Info, tx_dma: Option<Channel<'d, dma::Auto>>) -> Self {
         Self {
             info,
             tx_dma,
@@ -284,7 +284,7 @@ impl<'d, M: Mode> UartRx<'d, M> {
         info: &'static Info,
         dma_state: &'static DmaState,
         has_irq: bool,
-        rx_dma: Option<dma::Channel<'d>>,
+        rx_dma: Option<dma::Channel<'d, dma::Auto>>,
     ) -> Self {
         debug_assert_eq!(has_irq, rx_dma.is_some());
         if has_irq {
@@ -868,8 +868,8 @@ impl<'d, M: Mode> Uart<'d, M> {
         mut rts: Option<Peri<'d, AnyPin>>,
         mut cts: Option<Peri<'d, AnyPin>>,
         has_irq: bool,
-        tx_dma: Option<dma::Channel<'d>>,
-        rx_dma: Option<dma::Channel<'d>>,
+        tx_dma: Option<dma::Channel<'d, dma::Auto>>,
+        rx_dma: Option<dma::Channel<'d, dma::Auto>>,
         config: Config,
     ) -> Self {
         Self::init(

--- a/embassy-rp/src/uart/mod.rs
+++ b/embassy-rp/src/uart/mod.rs
@@ -16,7 +16,7 @@ use crate::gpio::{AnyPin, SealedPin};
 use crate::interrupt::typelevel::{Binding, Interrupt as _};
 use crate::interrupt::{Interrupt, InterruptExt};
 use crate::pac::io::vals::{Inover, Outover};
-use crate::{RegExt, dma, interrupt, pac, peripherals};
+use crate::{RegExt, dma, interrupt, mode, pac, peripherals};
 
 mod buffered;
 pub use buffered::{BufferedInterruptHandler, BufferedUart, BufferedUartRx, BufferedUartTx};
@@ -152,7 +152,7 @@ pub struct Uart<'d, M: Mode> {
 /// UART TX driver.
 pub struct UartTx<'d, M: Mode> {
     info: &'static Info,
-    tx_dma: Option<dma::Channel<'d, dma::Auto>>,
+    tx_dma: Option<dma::Channel<'d, mode::Async>>,
     phantom: PhantomData<M>,
 }
 
@@ -160,12 +160,12 @@ pub struct UartTx<'d, M: Mode> {
 pub struct UartRx<'d, M: Mode> {
     info: &'static Info,
     dma_state: &'static DmaState,
-    rx_dma: Option<dma::Channel<'d, dma::Auto>>,
+    rx_dma: Option<dma::Channel<'d, mode::Async>>,
     phantom: PhantomData<M>,
 }
 
 impl<'d, M: Mode> UartTx<'d, M> {
-    fn new_inner(info: &'static Info, tx_dma: Option<Channel<'d, dma::Auto>>) -> Self {
+    fn new_inner(info: &'static Info, tx_dma: Option<Channel<'d, mode::Async>>) -> Self {
         Self {
             info,
             tx_dma,
@@ -284,7 +284,7 @@ impl<'d, M: Mode> UartRx<'d, M> {
         info: &'static Info,
         dma_state: &'static DmaState,
         has_irq: bool,
-        rx_dma: Option<dma::Channel<'d, dma::Auto>>,
+        rx_dma: Option<dma::Channel<'d, mode::Async>>,
     ) -> Self {
         debug_assert_eq!(has_irq, rx_dma.is_some());
         if has_irq {
@@ -868,8 +868,8 @@ impl<'d, M: Mode> Uart<'d, M> {
         mut rts: Option<Peri<'d, AnyPin>>,
         mut cts: Option<Peri<'d, AnyPin>>,
         has_irq: bool,
-        tx_dma: Option<dma::Channel<'d, dma::Auto>>,
-        rx_dma: Option<dma::Channel<'d, dma::Auto>>,
+        tx_dma: Option<dma::Channel<'d, mode::Async>>,
+        rx_dma: Option<dma::Channel<'d, mode::Async>>,
         config: Config,
     ) -> Self {
         Self::init(

--- a/examples/rp/src/bin/zerocopy.rs
+++ b/examples/rp/src/bin/zerocopy.rs
@@ -32,7 +32,7 @@ static MAX: AtomicU16 = AtomicU16::new(0);
 struct AdcParts {
     adc: Adc<'static, Async>,
     pin: adc::Channel<'static>,
-    dma: dma::Channel<'static>,
+    dma: dma::Channel<'static, dma::Auto>,
 }
 
 #[embassy_executor::main]

--- a/examples/rp/src/bin/zerocopy.rs
+++ b/examples/rp/src/bin/zerocopy.rs
@@ -11,7 +11,7 @@ use embassy_executor::Spawner;
 use embassy_rp::adc::{self, Adc, Async, Config, InterruptHandler};
 use embassy_rp::gpio::Pull;
 use embassy_rp::peripherals::DMA_CH0;
-use embassy_rp::{bind_interrupts, dma};
+use embassy_rp::{bind_interrupts, dma, mode};
 use embassy_sync::blocking_mutex::raw::NoopRawMutex;
 use embassy_sync::zerocopy_channel::{Channel, Receiver, Sender};
 use embassy_time::{Duration, Ticker, Timer};
@@ -32,7 +32,7 @@ static MAX: AtomicU16 = AtomicU16::new(0);
 struct AdcParts {
     adc: Adc<'static, Async>,
     pin: adc::Channel<'static>,
-    dma: dma::Channel<'static, dma::Auto>,
+    dma: dma::Channel<'static, mode::Async>,
 }
 
 #[embassy_executor::main]

--- a/examples/rp235x/src/bin/zerocopy.rs
+++ b/examples/rp235x/src/bin/zerocopy.rs
@@ -32,7 +32,7 @@ static MAX: AtomicU16 = AtomicU16::new(0);
 struct AdcParts {
     adc: Adc<'static, Async>,
     pin: adc::Channel<'static>,
-    dma: dma::Channel<'static>,
+    dma: dma::Channel<'static, dma::Auto>,
 }
 
 #[embassy_executor::main]

--- a/examples/rp235x/src/bin/zerocopy.rs
+++ b/examples/rp235x/src/bin/zerocopy.rs
@@ -11,7 +11,7 @@ use embassy_executor::Spawner;
 use embassy_rp::adc::{self, Adc, Async, Config, InterruptHandler};
 use embassy_rp::gpio::Pull;
 use embassy_rp::peripherals::DMA_CH0;
-use embassy_rp::{bind_interrupts, dma};
+use embassy_rp::{bind_interrupts, dma, mode};
 use embassy_sync::blocking_mutex::raw::NoopRawMutex;
 use embassy_sync::zerocopy_channel::{Channel, Receiver, Sender};
 use embassy_time::{Duration, Ticker, Timer};
@@ -32,7 +32,7 @@ static MAX: AtomicU16 = AtomicU16::new(0);
 struct AdcParts {
     adc: Adc<'static, Async>,
     pin: adc::Channel<'static>,
-    dma: dma::Channel<'static, dma::Auto>,
+    dma: dma::Channel<'static, mode::Async>,
 }
 
 #[embassy_executor::main]


### PR DESCRIPTION
Follow up to  https://github.com/embassy-rs/embassy/pull/5338.
Make it possible to use Channel with custom irq handler.

This change makes some type annotations necessary. Do let me know if there is a better way.

Misc: Make Channel number method pub to help with custom DMA handling code.