### PR TITLE
[MCXA] Add Flash driver

### DIFF
--- a/embassy-mcxa/Cargo.toml
+++ b/embassy-mcxa/Cargo.toml
@@ -51,6 +51,7 @@ embassy-time-queue-utils = { version = "0.3.0", path = "../embassy-time-queue-ut
 
 rand-core-06 = { package = "rand_core", version = "0.6" }
 rand-core-09 = { package = "rand_core", version = "0.9" }
+embedded-storage = "0.3.1"
 
 [features]
 default = ["rt", "swd-swo-as-gpio"]

--- a/embassy-mcxa/src/flash.rs
+++ b/embassy-mcxa/src/flash.rs
@@ -1,0 +1,474 @@
+//! Flash driver for MCXA276 using ROM API.
+//!
+//! This module provides safe access to the MCXA276's internal flash memory through
+//! the ROM-resident flash driver API. The ROM API lives at a fixed address and exposes
+//! flash operations (init, erase, program, verify, read) via a function pointer table.
+//!
+//! # Flash Geometry (MCXA276)
+//!
+//! - Base address: `0x0000_0000`
+//! - Total size: 1 MB (`0x10_0000`)
+//! - Sector size: 8 KB (`0x2000`) — erase granularity
+//! - Page size: 128 bytes — program granularity
+//! - Phrase size: 16 bytes — minimum program unit
+//!
+//! # Safety
+//!
+//! All flash-modifying operations (erase, program) run inside a critical section
+//! to prevent interrupts from executing code in flash while it is being modified.
+//! After each modifying operation, speculation buffers and the LPCAC are cleared
+//! to ensure subsequent reads return fresh data.
+//!
+//! # Example
+//!
+//! ```no_run
+//! use embassy_mcxa::flash::Flash;
+//! use embedded_storage::nor_flash::{NorFlash, ReadNorFlash};
+//!
+//! let mut flash = Flash::new();
+//!
+//! // Erase a sector at offset 0xFE000 (near the end of 1 MB flash)
+//! flash.erase(0xFE000, 0x10_0000).unwrap();
+//!
+//! // Program 128 bytes at that offset
+//! let data = [0xABu8; 128];
+//! flash.write(0xFE000, &data).unwrap();
+//!
+//! // Read back
+//! let mut buf = [0u8; 128];
+//! flash.read(0xFE000, &mut buf).unwrap();
+//! assert_eq!(buf, data);
+//! ```
+
+use core::slice;
+
+use embedded_storage::nor_flash::{
+    ErrorType, MultiwriteNorFlash, NorFlash, NorFlashError, NorFlashErrorKind, ReadNorFlash,
+};
+
+// ---------------------------------------------------------------------------
+// Flash geometry constants
+// ---------------------------------------------------------------------------
+
+/// Base address of the internal program flash.
+pub const FLASH_BASE: u32 = 0x0000_0000;
+
+/// Total size of the internal program flash in bytes (1 MB).
+pub const FLASH_SIZE: usize = 0x10_0000;
+
+/// Sector size in bytes (8 KB) — erase granularity.
+pub const SECTOR_SIZE: usize = 0x2000;
+
+/// Page size in bytes (128) — program-page granularity.
+pub const PAGE_SIZE: usize = 128;
+
+/// Phrase size in bytes (16) — minimum program unit.
+pub const PHRASE_SIZE: usize = 16;
+
+// ---------------------------------------------------------------------------
+// ROM API constants
+// ---------------------------------------------------------------------------
+
+/// Base address of the ROM API bootloader tree for MCXA276.
+const ROM_API_BASE: u32 = 0x0300_5FE0;
+
+/// Flash erase key: `FOUR_CHAR_CODE('l','f','e','k')` in little-endian.
+const FLASH_ERASE_KEY: u32 = 0x6B65_666C;
+
+// ---------------------------------------------------------------------------
+// SYSCON register addresses for cache clearing
+// ---------------------------------------------------------------------------
+
+/// SYSCON base address (MCXA276).
+const SYSCON_BASE: u32 = 0x4009_1000;
+
+/// NVM_CTRL register offset from SYSCON base.
+const NVM_CTRL_OFFSET: u32 = 0x400;
+
+/// LPCAC_CTRL register offset from SYSCON base.
+const LPCAC_CTRL_OFFSET: u32 = 0x824;
+
+// NVM_CTRL bit masks
+const NVM_CTRL_DIS_FLASH_SPEC: u32 = 0x1;
+const NVM_CTRL_DIS_DATA_SPEC: u32 = 0x2;
+const NVM_CTRL_DIS_MBECC_ERR_INST: u32 = 0x0001_0000;
+const NVM_CTRL_DIS_MBECC_ERR_DATA: u32 = 0x0002_0000;
+
+// LPCAC_CTRL bit masks
+const LPCAC_CTRL_DIS_LPCAC: u32 = 0x1;
+const LPCAC_CTRL_CLR_LPCAC: u32 = 0x2;
+
+// ---------------------------------------------------------------------------
+// ROM API C-ABI structures
+// ---------------------------------------------------------------------------
+
+/// Flash FFR (Factory Failure Records) configuration, populated by `flash_init`.
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+struct FlashFfrConfig {
+    ffr_block_base: u32,
+    ffr_total_size: u32,
+    ffr_page_size: u32,
+    sector_size: u32,
+    cfpa_page_version: u32,
+    cfpa_page_offset: u32,
+}
+
+/// Flash driver configuration, populated by `flash_init`.
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+struct FlashConfig {
+    pflash_block_base: u32,
+    pflash_total_size: u32,
+    pflash_block_count: u32,
+    pflash_page_size: u32,
+    pflash_sector_size: u32,
+    ffr_config: FlashFfrConfig,
+}
+
+// Type aliases for ROM API function pointer signatures (C ABI).
+type FnFlashInit = unsafe extern "C" fn(config: *mut FlashConfig) -> i32;
+type FnFlashEraseSector = unsafe extern "C" fn(config: *mut FlashConfig, start: u32, len: u32, key: u32) -> i32;
+type FnFlashProgramPhrase = unsafe extern "C" fn(config: *mut FlashConfig, start: u32, src: *const u8, len: u32) -> i32;
+type FnFlashProgramPage = unsafe extern "C" fn(config: *mut FlashConfig, start: u32, src: *const u8, len: u32) -> i32;
+type FnFlashVerifyProgram = unsafe extern "C" fn(
+    config: *mut FlashConfig,
+    start: u32,
+    len: u32,
+    expected: *const u8,
+    failed_addr: *mut u32,
+    failed_data: *mut u32,
+) -> i32;
+type FnFlashVerifyErasePhrase = unsafe extern "C" fn(config: *mut FlashConfig, start: u32, len: u32) -> i32;
+type FnFlashVerifyErasePage = unsafe extern "C" fn(config: *mut FlashConfig, start: u32, len: u32) -> i32;
+type FnFlashVerifyEraseSector = unsafe extern "C" fn(config: *mut FlashConfig, start: u32, len: u32) -> i32;
+type FnFlashGetProperty = unsafe extern "C" fn(config: *mut FlashConfig, property: u32, value: *mut u32) -> i32;
+type FnFlashRead = unsafe extern "C" fn(config: *mut FlashConfig, start: u32, dest: *mut u8, len: u32) -> i32;
+
+/// ROM API flash driver interface vtable.
+///
+/// **Layout note**: On MCXA276, `FSL_FEATURE_ROMAPI_IFR == 0`, so the three
+/// IFR function pointers are *omitted*. `flash_read` and `version` follow
+/// immediately after `flash_get_property`.
+#[repr(C)]
+struct FlashDriverInterface {
+    flash_init: FnFlashInit,
+    flash_erase_sector: FnFlashEraseSector,
+    flash_program_phrase: FnFlashProgramPhrase,
+    flash_program_page: FnFlashProgramPage,
+    flash_verify_program: FnFlashVerifyProgram,
+    flash_verify_erase_phrase: FnFlashVerifyErasePhrase,
+    flash_verify_erase_page: FnFlashVerifyErasePage,
+    flash_verify_erase_sector: FnFlashVerifyEraseSector,
+    flash_get_property: FnFlashGetProperty,
+    // IFR functions omitted (FSL_FEATURE_ROMAPI_IFR == 0 on MCXA276)
+    flash_read: FnFlashRead,
+    version: u32,
+}
+
+/// Root of the ROM bootloader API tree.
+#[repr(C)]
+struct BootloaderTree {
+    run_bootloader: unsafe extern "C" fn(arg: *mut core::ffi::c_void),
+    flash_driver: *const FlashDriverInterface,
+    jump: unsafe extern "C" fn(arg: *mut core::ffi::c_void),
+}
+
+/// Returns a reference to the ROM API flash driver interface.
+#[inline(always)]
+fn flash_api() -> &'static FlashDriverInterface {
+    unsafe {
+        let tree = &*(ROM_API_BASE as *const BootloaderTree);
+        &*tree.flash_driver
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Error types
+// ---------------------------------------------------------------------------
+
+/// Errors that can occur during flash operations.
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+#[non_exhaustive]
+pub enum Error {
+    /// Address or range is outside the flash region.
+    OutOfBounds,
+    /// Address or length is not properly aligned.
+    Unaligned,
+    /// The ROM API returned a non-zero status code.
+    RomApi(i32),
+}
+
+/// Flash property identifiers (ROM API `flash_get_property`).
+#[repr(u32)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+pub enum FlashProperty {
+    /// Pflash sector size property.
+    PflashSectorSize = 0x00,
+    /// Pflash total size property.
+    PflashTotalSize = 0x01,
+    /// Pflash block size property.
+    PflashBlockSize = 0x02,
+    /// Pflash block count property.
+    PflashBlockCount = 0x03,
+    /// Pflash block base address property.
+    PflashBlockBaseAddr = 0x04,
+    /// Pflash page size property.
+    PflashPageSize = 0x30,
+    /// Pflash system frequency property.
+    PflashSystemFreq = 0x31,
+    /// FFR sector size property.
+    FfrSectorSize = 0x40,
+    /// FFR total size property.
+    FfrTotalSize = 0x41,
+    /// FFR block base address property.
+    FfrBlockBaseAddr = 0x42,
+    /// FFR page size property.
+    FfrPageSize = 0x43,
+}
+
+impl NorFlashError for Error {
+    fn kind(&self) -> NorFlashErrorKind {
+        match self {
+            Self::OutOfBounds => NorFlashErrorKind::OutOfBounds,
+            Self::Unaligned => NorFlashErrorKind::NotAligned,
+            Self::RomApi(_) => NorFlashErrorKind::Other,
+        }
+    }
+}
+
+/// Convert a ROM API status code to a `Result`.
+#[inline]
+fn check_status(status: i32) -> Result<(), Error> {
+    if status == 0 {
+        Ok(())
+    } else {
+        Err(Error::RomApi(status))
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Cache clearing helpers (must be called after erase/program)
+// ---------------------------------------------------------------------------
+
+/// Clear flash and data speculation buffers by toggling the disable bits
+/// in SYSCON->NVM_CTRL, matching the C `speculation_buffer_clear()`.
+#[inline]
+fn speculation_buffer_clear() {
+    unsafe {
+        let nvm_ctrl = (SYSCON_BASE + NVM_CTRL_OFFSET) as *mut u32;
+        let val = core::ptr::read_volatile(nvm_ctrl);
+
+        // Only proceed if MBECC error reporting is enabled for both inst and data
+        if (val & NVM_CTRL_DIS_MBECC_ERR_INST) == 0 && (val & NVM_CTRL_DIS_MBECC_ERR_DATA) == 0 {
+            // Toggle flash speculation disable
+            if (val & NVM_CTRL_DIS_FLASH_SPEC) == 0 {
+                core::ptr::write_volatile(nvm_ctrl, val | NVM_CTRL_DIS_FLASH_SPEC);
+                let v2 = core::ptr::read_volatile(nvm_ctrl);
+                core::ptr::write_volatile(nvm_ctrl, v2 & !NVM_CTRL_DIS_FLASH_SPEC);
+            }
+            // Toggle data speculation disable
+            let val = core::ptr::read_volatile(nvm_ctrl);
+            if (val & NVM_CTRL_DIS_DATA_SPEC) == 0 {
+                core::ptr::write_volatile(nvm_ctrl, val | NVM_CTRL_DIS_DATA_SPEC);
+                let v2 = core::ptr::read_volatile(nvm_ctrl);
+                core::ptr::write_volatile(nvm_ctrl, v2 & !NVM_CTRL_DIS_DATA_SPEC);
+            }
+        }
+    }
+}
+
+/// Clear LPCAC by setting the CLR_LPCAC bit in SYSCON->LPCAC_CTRL,
+/// matching the C `lpcac_clear()`.
+#[inline]
+fn lpcac_clear() {
+    unsafe {
+        let lpcac_ctrl = (SYSCON_BASE + LPCAC_CTRL_OFFSET) as *mut u32;
+        let val = core::ptr::read_volatile(lpcac_ctrl);
+        if (val & LPCAC_CTRL_DIS_LPCAC) == 0 {
+            core::ptr::write_volatile(lpcac_ctrl, val | LPCAC_CTRL_CLR_LPCAC);
+        }
+    }
+}
+
+/// Combined cache clearing: speculation buffers + LPCAC.
+#[inline]
+fn clear_caches() {
+    speculation_buffer_clear();
+    lpcac_clear();
+}
+
+// ---------------------------------------------------------------------------
+// Flash driver
+// ---------------------------------------------------------------------------
+
+/// Flash driver providing safe access to the MCXA276 internal flash via ROM API.
+///
+/// The driver holds an internal `FlashConfig` that is initialised by the ROM
+/// API's `flash_init` function during construction. All subsequent operations
+/// pass this config to the ROM API.
+pub struct Flash {
+    config: FlashConfig,
+}
+
+impl Flash {
+    /// Create and initialise a new flash driver.
+    ///
+    /// This calls the ROM API `flash_init` to populate the internal flash
+    /// configuration. Returns an error if the ROM API reports failure.
+    pub fn new() -> Result<Self, Error> {
+        let mut config = unsafe { core::mem::zeroed::<FlashConfig>() };
+        let status = unsafe { (flash_api().flash_init)(&mut config) };
+        check_status(status)?;
+        Ok(Self { config })
+    }
+
+    /// Erase flash sectors encompassing the given absolute address range.
+    ///
+    /// - `address`: absolute start address (must be sector-aligned).
+    /// - `len`: number of bytes to erase (must be a multiple of sector size).
+    ///
+    /// Runs inside a critical section and clears caches afterwards.
+    pub fn blocking_erase(&mut self, address: u32, len: u32) -> Result<(), Error> {
+        let status = cortex_m::interrupt::free(|_| unsafe {
+            (flash_api().flash_erase_sector)(&mut self.config, address, len, FLASH_ERASE_KEY)
+        });
+        clear_caches();
+        check_status(status)
+    }
+
+    /// Program a page of data at the given absolute address.
+    ///
+    /// - `address`: absolute start address (must be page-aligned).
+    /// - `data`: source buffer whose length must be a multiple of `PAGE_SIZE`.
+    ///
+    /// Runs inside a critical section and clears caches afterwards.
+    pub fn blocking_program(&mut self, address: u32, data: &[u8]) -> Result<(), Error> {
+        let status = cortex_m::interrupt::free(|_| unsafe {
+            (flash_api().flash_program_page)(&mut self.config, address, data.as_ptr(), data.len() as u32)
+        });
+        clear_caches();
+        check_status(status)
+    }
+
+    /// Verify that the programmed data at `address` matches `expected`.
+    ///
+    /// On mismatch, returns `Error::RomApi` with the ROM status code.
+    pub fn verify_program(&mut self, address: u32, expected: &[u8]) -> Result<(), Error> {
+        let mut failed_address: u32 = 0;
+        let mut failed_data: u32 = 0;
+        let status = unsafe {
+            (flash_api().flash_verify_program)(
+                &mut self.config,
+                address,
+                expected.len() as u32,
+                expected.as_ptr(),
+                &mut failed_address,
+                &mut failed_data,
+            )
+        };
+        check_status(status)
+    }
+
+    /// Verify that the sector(s) starting at `address` are erased.
+    pub fn verify_erase_sector(&mut self, address: u32, len: u32) -> Result<(), Error> {
+        let status = unsafe { (flash_api().flash_verify_erase_sector)(&mut self.config, address, len) };
+        check_status(status)
+    }
+
+    /// Read flash data using the ROM API.
+    ///
+    /// - `address`: absolute start address.
+    /// - `dest`: destination buffer.
+    pub fn blocking_read_rom(&mut self, address: u32, dest: &mut [u8]) -> Result<(), Error> {
+        let status =
+            unsafe { (flash_api().flash_read)(&mut self.config, address, dest.as_mut_ptr(), dest.len() as u32) };
+        check_status(status)
+    }
+
+    /// Read flash data by direct memory-mapped access (no ROM API call).
+    ///
+    /// - `offset`: byte offset from flash base (`0x0000_0000`).
+    /// - `dest`: destination buffer.
+    pub fn blocking_read(&self, offset: u32, dest: &mut [u8]) -> Result<(), Error> {
+        if offset as usize + dest.len() > FLASH_SIZE {
+            return Err(Error::OutOfBounds);
+        }
+        let src = unsafe { slice::from_raw_parts((FLASH_BASE + offset) as *const u8, dest.len()) };
+        dest.copy_from_slice(src);
+        Ok(())
+    }
+
+    /// Return the ROM API version.
+    pub fn rom_api_version(&self) -> u32 {
+        flash_api().version
+    }
+
+    /// Get a ROM API flash property value.
+    pub fn get_property(&mut self, property: FlashProperty) -> Result<u32, Error> {
+        let mut value: u32 = 0;
+        let status = unsafe { (flash_api().flash_get_property)(&mut self.config, property as u32, &mut value) };
+        check_status(status)?;
+        Ok(value)
+    }
+}
+
+// ---------------------------------------------------------------------------
+// embedded-storage trait implementations
+// ---------------------------------------------------------------------------
+
+impl ErrorType for Flash {
+    type Error = Error;
+}
+
+impl ReadNorFlash for Flash {
+    const READ_SIZE: usize = 1;
+
+    fn read(&mut self, offset: u32, bytes: &mut [u8]) -> Result<(), Self::Error> {
+        self.blocking_read(offset, bytes)
+    }
+
+    fn capacity(&self) -> usize {
+        FLASH_SIZE
+    }
+}
+
+impl NorFlash for Flash {
+    const WRITE_SIZE: usize = PAGE_SIZE;
+    const ERASE_SIZE: usize = SECTOR_SIZE;
+
+    fn erase(&mut self, from: u32, to: u32) -> Result<(), Self::Error> {
+        if to < from || to as usize > FLASH_SIZE {
+            return Err(Error::OutOfBounds);
+        }
+        if from as usize % Self::ERASE_SIZE != 0 || to as usize % Self::ERASE_SIZE != 0 {
+            return Err(Error::Unaligned);
+        }
+
+        // Erase one sector at a time
+        for sector_addr in (from..to).step_by(Self::ERASE_SIZE) {
+            self.blocking_erase(FLASH_BASE + sector_addr, SECTOR_SIZE as u32)?;
+        }
+        Ok(())
+    }
+
+    fn write(&mut self, offset: u32, bytes: &[u8]) -> Result<(), Self::Error> {
+        if offset as usize + bytes.len() > FLASH_SIZE {
+            return Err(Error::OutOfBounds);
+        }
+        if offset as usize % Self::WRITE_SIZE != 0 || bytes.len() % Self::WRITE_SIZE != 0 {
+            return Err(Error::Unaligned);
+        }
+
+        // Program one page at a time
+        for (i, chunk) in bytes.chunks(PAGE_SIZE).enumerate() {
+            let addr = FLASH_BASE + offset + (i * PAGE_SIZE) as u32;
+            self.blocking_program(addr, chunk)?;
+        }
+        Ok(())
+    }
+}
+
+impl MultiwriteNorFlash for Flash {}

--- a/embassy-mcxa/src/lib.rs
+++ b/embassy-mcxa/src/lib.rs
@@ -13,6 +13,7 @@ pub mod config;
 pub mod crc;
 pub mod ctimer;
 pub mod dma;
+pub mod flash;
 pub mod gpio;
 pub mod i2c;
 pub mod i3c;

--- a/examples/mcxa/Cargo.toml
+++ b/examples/mcxa/Cargo.toml
@@ -19,6 +19,7 @@ embassy-sync = { version = "0.7.2", path = "../../embassy-sync" }
 embassy-time = { version = "0.5.0", path = "../../embassy-time", features = ["defmt", "defmt-timestamp-uptime"] }
 embassy-time-driver = { version = "0.2.1", path = "../../embassy-time-driver", optional = true }
 embedded-io-async = "0.7.0"
+embedded-storage = "0.3.1"
 heapless = "0.9.2"
 panic-probe = { version = "1.0", features = ["print-defmt"] }
 rand_core = "0.9"

--- a/examples/mcxa/src/bin/flash_iap.rs
+++ b/examples/mcxa/src/bin/flash_iap.rs
@@ -1,0 +1,160 @@
+//! Flash IAP (In-Application Programming) example for MCXA276.
+//!
+//! Demonstrates the ROM API flash driver: init, erase, program, verify, and read.
+//!
+//! This example operates on sector `0x0C0000` (`SECTOR_INDEX_FROM_END = 32`),
+//! matching the C SDK `frdmmcxa276_romapi_flashiap` demo. The top-of-flash
+//! sectors (0x0FC000+) are avoided because they overlap the protected
+//! FFR / CFPA / CFPB configuration region on MCXA276.
+
+#![no_std]
+#![no_main]
+
+use embassy_executor::Spawner;
+use hal::config::Config;
+use hal::flash::{Flash, FlashProperty};
+use {defmt_rtt as _, embassy_mcxa as hal, panic_probe as _};
+
+/// Number of sectors from the end of flash to use as the test target.
+///
+/// The C SDK header defaults to 2, but on MCXA276 the top-of-flash region
+/// (0x0FC000+) is the protected FFR / CFPA / CFPB configuration area.
+/// Accessing it causes a fault. The C SDK demo for MCXA276 therefore uses
+/// 32, which targets sector 0x0C0000 — well below the protected zone.
+const SECTOR_INDEX_FROM_END: u32 = 32;
+
+#[embassy_executor::main]
+async fn main(_spawner: Spawner) {
+    let _p = hal::init(Config::default());
+
+    defmt::info!("Flash driver API tree demo application.");
+
+    // -----------------------------------------------------------------------
+    // 1. Initialise the flash driver via ROM API
+    // -----------------------------------------------------------------------
+    defmt::info!("\n Initializing flash driver.");
+    let mut flash = match Flash::new() {
+        Ok(f) => f,
+        Err(e) => {
+            defmt::error!("Flash init failed: {}", e);
+            halt();
+        }
+    };
+    defmt::info!("\n Flash init successfull!\n");
+
+    defmt::info!("\n Config flash memory access time.\n");
+
+    let pflash_block_base = match flash.get_property(FlashProperty::PflashBlockBaseAddr) {
+        Ok(v) => v,
+        Err(e) => {
+            defmt::error!("Flash get_property(base) failed: {}", e);
+            halt();
+        }
+    };
+    let pflash_sector_size = match flash.get_property(FlashProperty::PflashSectorSize) {
+        Ok(v) => v,
+        Err(e) => {
+            defmt::error!("Flash get_property(sector) failed: {}", e);
+            halt();
+        }
+    };
+    let pflash_total_size = match flash.get_property(FlashProperty::PflashTotalSize) {
+        Ok(v) => v,
+        Err(e) => {
+            defmt::error!("Flash get_property(total) failed: {}", e);
+            halt();
+        }
+    };
+    let pflash_page_size = match flash.get_property(FlashProperty::PflashPageSize) {
+        Ok(v) => v,
+        Err(e) => {
+            defmt::error!("Flash get_property(page) failed: {}", e);
+            halt();
+        }
+    };
+
+    // -----------------------------------------------------------------------
+    // 2. Compute the test address (second-to-last sector)
+    // -----------------------------------------------------------------------
+    defmt::info!("\n PFlash Information:");
+    defmt::info!("\n kFLASH_PropertyPflashBlockBaseAddr = 0x{:X}", pflash_block_base);
+    defmt::info!("\n kFLASH_PropertyPflashSectorSize = {}", pflash_sector_size);
+    defmt::info!("\n kFLASH_PropertyPflashTotalSize = {}", pflash_total_size);
+    defmt::info!("\n kFLASH_PropertyPflashPageSize = 0x{:X}", pflash_page_size);
+
+    let dest_addr: u32 = pflash_block_base + (pflash_total_size - (SECTOR_INDEX_FROM_END * pflash_sector_size));
+
+    // -----------------------------------------------------------------------
+    // 4. Erase the sector
+    // -----------------------------------------------------------------------
+    defmt::info!("\n Erase a sector of flash");
+    if let Err(e) = flash.blocking_erase(dest_addr, pflash_sector_size) {
+        defmt::error!("Erase failed: {}", e);
+        halt();
+    }
+
+    defmt::info!("\n Calling flash_verify_erase_sector() API.");
+    if let Err(e) = flash.verify_erase_sector(dest_addr, pflash_sector_size) {
+        defmt::error!("Erase verification failed: {}", e);
+        halt();
+    }
+    defmt::info!(
+        "\n Successfully erased sector: 0x{:x} -> 0x{:x}\n",
+        dest_addr,
+        dest_addr + pflash_sector_size
+    );
+
+    // Prepare user buffer (512 bytes = 128 u32s), matching the C example.
+    let mut write_buf = [0u8; 512];
+    for (i, chunk) in write_buf.chunks_exact_mut(4).enumerate() {
+        let val = (i as u32).to_le_bytes();
+        chunk.copy_from_slice(&val);
+    }
+
+    defmt::info!("\n Calling FLASH_Program() API.");
+    if let Err(e) = flash.blocking_program(dest_addr, &write_buf) {
+        defmt::error!("Program failed: {}", e);
+        halt();
+    }
+
+    defmt::info!("\n Calling FLASH_VerifyProgram() API.");
+    if let Err(e) = flash.verify_program(dest_addr, &write_buf) {
+        defmt::error!("Program verification failed: {}", e);
+        halt();
+    }
+
+    let mut read_buf = [0u8; 512];
+    let read_offset = dest_addr - pflash_block_base;
+    if let Err(e) = flash.blocking_read(read_offset, &mut read_buf) {
+        defmt::error!("Readback failed: {}", e);
+        halt();
+    }
+    if read_buf != write_buf {
+        defmt::error!("Readback mismatch detected.");
+        halt();
+    }
+
+    defmt::info!(
+        "\n Successfully programmed and verified location: 0x{:x} -> 0x{:x} \n",
+        dest_addr,
+        dest_addr + (write_buf.len() as u32)
+    );
+
+    if let Err(e) = flash.blocking_erase(dest_addr, pflash_sector_size) {
+        defmt::error!("Cleanup erase failed: {}", e);
+        halt();
+    }
+    defmt::info!("\n End of PFlash Example! \n");
+
+    loop {
+        cortex_m::asm::wfi();
+    }
+}
+
+/// Halt the CPU in an infinite loop (used on unrecoverable errors).
+fn halt() -> ! {
+    defmt::error!("HALTED DUE TO FLASH ERROR");
+    loop {
+        cortex_m::asm::wfi();
+    }
+}


### PR DESCRIPTION
This PR adds a flash driver for the MCXA276 family using the ROM API, including:

## Features
- ROM API-based flash operations (init, erase, program, verify, read)
- Flash property queries via `flash_get_property` (sector size, total size, page size, block base address)
- Cache clearing (speculation buffer + LPCAC) after erase/program operations
- Critical sections via `cortex_m::interrupt::free()` for flash-modifying operations
- `embedded-storage` trait implementations (`ReadNorFlash`, `NorFlash`, `MultiwriteNorFlash`)
- `defmt::Format` support behind `defmt` feature flag

## New Files
- `embassy-mcxa/src/flash.rs` — Flash driver implementation with ROM API bindings, safe wrappers, and embedded-storage traits

## Examples
- `flash_iap.rs` — Flash IAP (In-Application Programming) example demonstrating init, erase, verify erase, program, verify program, and read-back (matches the C SDK `frdmmcxa276_romapi_flashiap` demo)

## Changes to Existing Files
- `embassy-mcxa/Cargo.toml` — Added `embedded-storage = "0.3.1"` dependency
- `embassy-mcxa/src/lib.rs` — Exported `flash` module
- `examples/mcxa/Cargo.toml` — Added `embedded-storage = "0.3.1"` dependency
