### PR TITLE
usb-logger: improved doc

### DIFF
--- a/embassy-usb-logger/src/lib.rs
+++ b/embassy-usb-logger/src/lib.rs
@@ -167,7 +167,8 @@ impl<const N: usize, T: ReceiverHandler + Send + Sync> UsbLogger<N, T> {
 
     /// Creates the futures needed for the logger from a given class
     /// This can be used in cases where the usb device is already in use for another connection
-    pub async fn create_future_from_class<'d, D>(&'d self, class: CdcAcmClass<'d, D>)
+    /// Never returns.
+    pub async fn create_future_from_class<'d, D>(&'d self, class: CdcAcmClass<'d, D>) -> !
     where
         D: Driver<'d>,
     {
@@ -223,7 +224,7 @@ impl<'d, const N: usize> core::fmt::Write for Writer<'d, N> {
 /// # Usage
 ///
 /// ```
-/// embassy_usb_logger::run!(1024, log::LevelFilter::Info, driver);
+/// embassy_usb_logger::run!(1024, log::LevelFilter::Info, driver); //never returns
 /// ```
 ///
 /// # Safety
@@ -251,13 +252,14 @@ macro_rules! run {
 }
 
 /// Initialize the USB serial logger from a serial class and return the future to run it.
+/// The future never returns.
 ///
 /// Arguments specify the buffer size, log level and the serial class, respectively. You can optionally add a RecieverHandler.
 ///
 /// # Usage
 ///
 /// ```
-/// embassy_usb_logger::with_class!(1024, log::LevelFilter::Info, class);
+/// embassy_usb_logger::with_class!(1024, log::LevelFilter::Info, class).await; //never returns.
 /// ```
 ///
 /// # Safety
@@ -285,6 +287,7 @@ macro_rules! with_class {
 }
 
 /// Initialize the USB serial logger from a serial class and return the future to run it.
+/// The future never returns.
 /// This version of the macro allows for a custom style function to be passed in.
 /// The custom style function will be called for each log record and is responsible for writing the log message to the buffer.
 ///
@@ -298,6 +301,7 @@ macro_rules! with_class {
 ///     let level = record.level().as_str();
 ///     write!(writer, "[{level}] {}\r\n", record.args()).unwrap();
 /// });
+/// log_fut.await; // never returns
 /// ```
 ///
 /// # Safety


### PR DESCRIPTION
One of the docs macro examples was ';'-ing a future instead of awaiting.
Also added a few "never returns" to the doc.