### PR TITLE
Fix i2c repeated start on mspm0

### DIFF
--- a/embassy-mspm0/src/i2c.rs
+++ b/embassy-mspm0/src/i2c.rs
@@ -474,9 +474,7 @@ impl<'d, M: Mode> I2c<'d, M> {
             w.set_cblen(length as u16);
             w.set_start(false);
             w.set_ack(send_ack_nack);
-            if send_stop {
-                w.set_stop(true);
-            }
+            w.set_stop(send_stop);
         });
 
         Ok(())
@@ -509,9 +507,7 @@ impl<'d, M: Mode> I2c<'d, M> {
             w.set_burstrun(true);
             w.set_ack(send_ack_nack);
             w.set_start(true);
-            if send_stop {
-                w.set_stop(true);
-            }
+            w.set_stop(send_stop);
         });
 
         Ok(())
@@ -528,9 +524,7 @@ impl<'d, M: Mode> I2c<'d, M> {
             w.set_cblen(length as u16);
             w.set_burstrun(true);
             w.set_start(true);
-            if send_stop {
-                w.set_stop(true);
-            }
+            w.set_stop(send_stop);
         });
 
         Ok(())


### PR DESCRIPTION
I noticed that repeated start conditions were not being respected, which caused errors talking to devices which expect that to read registers with an offset (eeproms, sensors, etc).

Because modify() was used, and set_stop() was never set to false, once a stop bit had been requested, all transactions will send a stop bit.

This just changes the logic to properly set set_stop(). Verified with logic analyzer before/after.

Before: 

<img width="774" height="249" alt="Stop bit present for repeated-start transaction" src="https://github.com/user-attachments/assets/85e67fe4-8a6d-4106-99c2-9135e0956cd6" />

After:

<img width="1179" height="234" alt="Screenshot From 2026-02-07 19-59-09" src="https://github.com/user-attachments/assets/31e30333-3081-47e4-b102-76a093a26824" />

There might be an edge case I'm not thinking of which explains why it was done the other way - so I'm open to being told this is wrong - but it reliably fixed sensor communication for me.