### PR TITLE
stm32/i2s: use plli2s1_r for all F7 variants

### DIFF
--- a/embassy-stm32/src/i2s.rs
+++ b/embassy-stm32/src/i2s.rs
@@ -557,11 +557,8 @@ impl<'d, W: Word> I2S<'d, W> {
 
         let regs = T::info().regs;
 
-        #[cfg(any(all(rcc_f4, not(stm32f410)), rcc_f2, all(rcc_f7, not(any(stm32f72x, stm32f73x)))))]
+        #[cfg(any(all(rcc_f4, not(stm32f410)), rcc_f2, rcc_f7))]
         let pclk = unsafe { crate::rcc::get_freqs() }.plli2s1_r.to_hertz().unwrap();
-        // STM32F72x/F73x route PLLI2SQ (not PLLI2SR) to the I2S peripheral
-        #[cfg(any(stm32f72x, stm32f73x))]
-        let pclk = unsafe { crate::rcc::get_freqs() }.plli2s1_q.to_hertz().unwrap();
         #[cfg(not(any(all(rcc_f4, not(stm32f410)), rcc_f2, rcc_f7)))]
         let pclk = T::frequency();
 


### PR DESCRIPTION
Follow-up to #5387: corrects the F72x/F73x clock source after hardware testing on STM32F732.

#5387 used `plli2s1_q` for STM32F72x/F73x based on a back-calculation that appeared to show Q as the clock source. This was a false positive — the driver was computing I2SDIV using the Q frequency, so the back-calculation naturally matched Q.

Retesting with PLLI2SQ=0 (invalid divider) and PLLI2SR=4 still produces correct 44.1kHz audio, confirming R is the clock source for all F7 variants, consistent with RM0431, the SVD, and ST's HAL.
