### PR TITLE
stm32: make gpio-init-analog more generic

### DIFF
--- a/embassy-hal-internal/src/peripheral.rs
+++ b/embassy-hal-internal/src/peripheral.rs
@@ -28,7 +28,7 @@ impl<'a, T: PeripheralType> Peri<'a, T> {
     /// on the actual peripheral types instead.
     #[inline]
     #[doc(hidden)]
-    pub unsafe fn new_unchecked(inner: T) -> Self {
+    pub const unsafe fn new_unchecked(inner: T) -> Self {
         Self {
             inner,
             _lifetime: PhantomData,
@@ -46,14 +46,14 @@ impl<'a, T: PeripheralType> Peri<'a, T> {
     /// You should strongly prefer using `reborrow()` instead. It returns a
     /// `Peri` that borrows `self`, which allows the borrow checker
     /// to enforce this at compile time.
-    pub unsafe fn clone_unchecked(&self) -> Peri<'a, T> {
+    pub const unsafe fn clone_unchecked(&self) -> Peri<'a, T> {
         Peri::new_unchecked(self.inner)
     }
 
     /// Reborrow into a "child" Peri.
     ///
     /// `self` will stay borrowed until the child Peripheral is dropped.
-    pub fn reborrow(&mut self) -> Peri<'_, T> {
+    pub const fn reborrow(&mut self) -> Peri<'_, T> {
         // safety: we're returning the clone inside a new Peripheral that borrows
         // self, so user code can't use both at the same time.
         unsafe { self.clone_unchecked() }

--- a/embassy-stm32/src/gpio.rs
+++ b/embassy-stm32/src/gpio.rs
@@ -689,7 +689,7 @@ fn set_speed(pin_port: PinNumber, speed: Speed) {
 }
 
 #[inline(never)]
-fn set_as_analog(pin_port: PinNumber) {
+pub(crate) fn set_as_analog(pin_port: PinNumber) {
     let pin = unsafe { AnyPin::steal(pin_port) };
     let r = pin.block();
     let n = pin._pin() as usize;
@@ -861,19 +861,19 @@ impl AnyPin {
     ///
     /// `pin_port` is `port_num * 16 + pin_num`, where `port_num` is 0 for port `A`, 1 for port `B`, etc...
     #[inline]
-    pub unsafe fn steal(pin_port: PinNumber) -> Peri<'static, Self> {
+    pub const unsafe fn steal(pin_port: PinNumber) -> Peri<'static, Self> {
         Peri::new_unchecked(Self { pin_port })
     }
 
     #[inline]
-    fn _port(&self) -> PinNumber {
+    const fn _port(&self) -> PinNumber {
         self.pin_port / 16
     }
 
     /// Get the GPIO register block for this pin.
     #[cfg(feature = "unstable-pac")]
     #[inline]
-    pub fn block(&self) -> gpio::Gpio {
+    pub const fn block(&self) -> gpio::Gpio {
         crate::_generated::gpio_block(self._port() as _)
     }
 }


### PR DESCRIPTION
takes more cpu at init, but increases maintainability.