### PR TITLE
fix: gracefully handle missing control responses from lte modem

### DIFF
--- a/embassy-net-nrf91/Cargo.toml
+++ b/embassy-net-nrf91/Cargo.toml
@@ -11,7 +11,7 @@ documentation = "https://docs.embassy.dev/embassy-net-nrf91"
 publish = true
 
 [features]
-defmt = ["dep:defmt", "heapless/defmt"]
+defmt = ["dep:defmt", "heapless/defmt", "embassy-time/defmt"]
 log = ["dep:log"]
 
 [dependencies]

--- a/embassy-net-nrf91/src/lib.rs
+++ b/embassy-net-nrf91/src/lib.rs
@@ -200,10 +200,10 @@ async fn new_internal<'a>(
     compiler_fence(Ordering::SeqCst);
 
     let power = pac::POWER_S;
-    // POWER.LTEMODEM.STARTN = 0
-    // TODO: The reg is missing in the PAC??
-    let startn = unsafe { (power.as_ptr() as *mut u32).add(0x610 / 4) };
-    unsafe { startn.write_volatile(0) }
+    power
+        .ltemodem()
+        .startn()
+        .write(|w| w.set_startn(pac::power::vals::Startn::START));
 
     unsafe { NVIC::unmask(pac::Interrupt::IPC) };
 


### PR DESCRIPTION
In some cases, the LTE modem may not respond with control free messages
if IP packets are sent quickly. Whether or not this is related to the
speed which they are sent, a requirement by the modem, or just a bug, is
not known.

This change adds a workaround so that the driver can recover from these
cases by adding a timeout to the allocated IPC buffer. If the modem has
not responded within this timeout, it is very likely due to a bug in the
modem, and the driver will allow new requests to use the buffer.