### PR TITLE
[MCXA]: Add optional gpio-based debugging for the custom executor

### DIFF
--- a/embassy-mcxa/src/executor.rs
+++ b/embassy-mcxa/src/executor.rs
@@ -1,12 +1,31 @@
 use core::marker::PhantomData;
-use core::sync::atomic::{AtomicBool, AtomicU8, Ordering};
+use core::sync::atomic::{AtomicBool, AtomicU8, AtomicU32, Ordering};
 
 use embassy_executor::{Spawner, raw};
+use embassy_hal_internal::Peri;
 
 use crate::clocks::config::CoreSleep;
+use crate::gpio::{DriveStrength, GpioPin, Level, Output, SlewRate};
+use crate::pac::gpio::vals::{Ptco, Ptso};
 
 static TASKS_PENDING: AtomicBool = AtomicBool::new(false);
 static EXECUTOR_ONCE: AtomicU8 = AtomicU8::new(0);
+
+/// Information stored in format:
+///
+/// ```
+/// 0bAxxx_xxxx_xxxx_xxxx_OOOO_OOOO_IIII_IIII
+/// ```
+///
+/// Where:
+///
+/// * A: 1 bit, "is active", so we can differentiate between "never set"
+///   and "use port 0 pin 0"
+/// * O: 8 bits, "pOrt number"
+/// * I: 8 bits, "pIn number"
+///
+/// Initially set to `0`, which makes "set lo" and "set hi" a no-op
+static DEBUG_GPIO: AtomicU32 = AtomicU32::new(0);
 
 const EXECUTOR_UNINIT: u8 = 0;
 const EXECUTOR_TAKEN: u8 = 1;
@@ -78,7 +97,9 @@ impl Executor {
                 if let Some(s) = sleep {
                     break s;
                 }
+                debug_lo();
                 do_wfe();
+                debug_hi();
                 crate::perf_counters::incr_wfe_sleeps();
             }
         };
@@ -90,7 +111,9 @@ impl Executor {
             CoreSleep::WfeUngated | CoreSleep::WfeGated => loop {
                 unsafe {
                     self.inner.poll();
+                    debug_lo();
                     do_wfe();
+                    debug_hi();
                     crate::perf_counters::incr_wfe_sleeps();
                 }
             },
@@ -105,13 +128,21 @@ impl Executor {
                     //
                     // We STAY in the CS for the deep sleep to ensure that we handle wake-up
                     // completely BEFORE yielding control flow back to interrupts.
-                    let do_wfe_sleep = critical_section::with(|cs| !crate::clocks::deep_sleep_if_possible(&cs));
+                    debug_lo();
+                    let do_wfe_sleep = critical_section::with(|cs| {
+                        let did_deep_sleep = crate::clocks::deep_sleep_if_possible(&cs);
+                        if did_deep_sleep {
+                            debug_hi();
+                        }
+                        !did_deep_sleep
+                    });
 
                     // Did we succeed at deep sleeping?
                     if do_wfe_sleep {
                         // Nope, WFE. We don't need a critical section here because we don't
                         // need to wait for clocks to resume before we service interrupts.
                         do_wfe();
+                        debug_hi();
                         crate::perf_counters::incr_wfe_sleeps();
                     } else {
                         // Yep!
@@ -128,4 +159,68 @@ impl Executor {
 unsafe fn do_wfe() {
     cortex_m::asm::dsb();
     cortex_m::asm::wfe();
+}
+
+/// Dedicate a pin to be used for introspecting the state of the custom executor.
+///
+/// This pin will be driven low prior to entering WFE (light or deep sleep),
+/// and be raised once control flow is returned to the executor.
+///
+/// For deep sleep, the pin will be raised *before* exiting the critical section,
+/// meaning that the level will go high before servicing any interrupts. For light
+/// sleep, no critical section is taken prior to deep sleep, so the pin will go
+/// high once the executor resumes, likely after processing any pending interrupts.
+///
+/// This exact behavior is not considered semver stable, and may change at any time.
+///
+/// This function consumes the given pin, overwriting any previous pin set as the executor
+/// debug pin. If this function is called multiple times, the previously assigned pin(s)
+/// will not be disabled, and will remain at their last updated state.
+pub fn set_executor_debug_gpio(pin: Peri<'static, impl GpioPin>) {
+    let pin_num = pin.pin();
+    let port_num = pin.port();
+    // Setup GPIO as output, initially high
+    let output = Output::new(pin, Level::High, DriveStrength::Normal, SlewRate::Slow);
+
+    let number = 0x8000_0000 | ((port_num as u32) << 8) | (pin_num as u32);
+    core::mem::forget(output);
+    DEBUG_GPIO.store(number, Ordering::Relaxed);
+}
+
+/// Set low if we have a debug gpio set, using raw pac methods
+fn debug_lo() {
+    let num = DEBUG_GPIO.load(Ordering::Relaxed);
+    if num == 0 {
+        return;
+    }
+    let port_num = (num >> 8) as u8;
+    let pin_num = (num & 0xFF) as usize;
+    match port_num {
+        0 => crate::pac::GPIO0.pcor(),
+        1 => crate::pac::GPIO1.pcor(),
+        2 => crate::pac::GPIO2.pcor(),
+        3 => crate::pac::GPIO3.pcor(),
+        4 => crate::pac::GPIO4.pcor(),
+        _ => return,
+    }
+    .write(|w| w.set_ptco(pin_num, Ptco::PTCO1));
+}
+
+/// Set high if we have a debug gpio set, using raw pac methods
+fn debug_hi() {
+    let num = DEBUG_GPIO.load(Ordering::Relaxed);
+    if num == 0 {
+        return;
+    }
+    let port_num = (num >> 8) as u8;
+    let pin_num = (num & 0xFF) as usize;
+    match port_num {
+        0 => crate::pac::GPIO0.psor(),
+        1 => crate::pac::GPIO1.psor(),
+        2 => crate::pac::GPIO2.psor(),
+        3 => crate::pac::GPIO3.psor(),
+        4 => crate::pac::GPIO4.psor(),
+        _ => return,
+    }
+    .write(|w| w.set_ptso(pin_num, Ptso::PTSO1));
 }

--- a/examples/mcxa/src/bin/power-deepsleep-gating.rs
+++ b/examples/mcxa/src/bin/power-deepsleep-gating.rs
@@ -97,6 +97,8 @@ async fn main(_spawner: Spawner) {
 
     let p = hal::init(cfg);
 
+    embassy_mcxa::executor::set_executor_debug_gpio(p.P1_12);
+
     let mut pin = p.P4_2;
     let mut clkout = p.CLKOUT;
     const M1_CONFIG: clkout::Config = clkout::Config {


### PR DESCRIPTION
This adds a GPIO-based debugging interface for the executor.

This allows us to see when the executor is deciding to WFE, and when it has control
flow returned to it after sleeping. This mimics the C SDK examples. We can make this
a feature in the future if we want to gate it out when unused in production.

Examples:

## Waking from deep sleep

<img width="1115" height="841" alt="Screenshot 2026-02-10 at 5 04 02 PM" src="https://github.com/user-attachments/assets/93e37f2a-7e74-476b-9bce-f5b2dc2d535e" />

## Going to deep sleep

<img width="1135" height="877" alt="Screenshot 2026-02-10 at 5 05 07 PM" src="https://github.com/user-attachments/assets/70f9f9e1-5593-4553-8c07-b19400d15e21" />

