### PR TITLE
stm32/ltdc: Fix cfbll value for stm32f7

### DIFF
--- a/embassy-stm32/src/ltdc.rs
+++ b/embassy-stm32/src/ltdc.rs
@@ -425,9 +425,9 @@ impl<'d, T: Instance> Ltdc<'d, T> {
         // framebuffer pitch and line length
         layer.cfblr().modify(|w| {
             w.set_cfbp(width * bytes_per_pixel);
-            #[cfg(not(any(stm32u5,stm32f7)))]
+            #[cfg(not(any(stm32u5, stm32f7)))]
             w.set_cfbll(width * bytes_per_pixel + 7);
-            #[cfg(any(stm32u5,stm32f7))]
+            #[cfg(any(stm32u5, stm32f7))]
             w.set_cfbll(width * bytes_per_pixel + 3);
         });
 


### PR DESCRIPTION
For STM32F7 family, the CFBLL field of the LTDC_LxCFBLR register should be: length of one line of pixels in bytes + 3.

This is described in both of the applicable reference manuals:
- F72xx / F73xx (No LTDC)
- F74xx / F75xx: RM0385 Section 18.7.23
- F76xx / F77xx: RM0410 Section 19.7.23

> Bits 12:0 CFBLL[12:0]: color frame buffer line length
> These bits define the length of one line of pixels in bytes + 3.
> The line length is computed as follows:
> active high width * number of bytes per pixel + 3.

Fix tested on STM32F746NG Discovery with RK043FN48H LCD-TFT.