### PR TITLE
Embassy-rp: Support custom DMA transfers

### DIFF
--- a/embassy-rp/src/dma.rs
+++ b/embassy-rp/src/dma.rs
@@ -69,6 +69,13 @@ impl<'d> Channel<'d> {
     }
 
     /// Get the channel register block.
+    #[cfg(feature = "unstable-pac")]
+    pub fn regs(&self) -> pac::dma::Channel {
+        pac::DMA.ch(self.number as _)
+    }
+
+    /// Get the channel register block.
+    #[cfg(not(feature = "unstable-pac"))]
     fn regs(&self) -> pac::dma::Channel {
         pac::DMA.ch(self.number as _)
     }


### PR DESCRIPTION
Support custom DMA transfers, by configuring the DMA registers directly.