### PR TITLE
fix(stm32/hsem): Update stm32-metapac to get HSEM: Instance

### DIFF
--- a/embassy-stm32/Cargo.toml
+++ b/embassy-stm32/Cargo.toml
@@ -204,11 +204,11 @@ aligned = "0.4.3"
 heapless = "0.9.1"
 
 # stm32-metapac = { version = "19" }
-stm32-metapac = { git = "https://github.com/embassy-rs/stm32-data-generated", tag = "stm32-data-8c7312f9831c8113a0956a7cd5e745c22bc3f4f2" }
+stm32-metapac = { git = "https://github.com/embassy-rs/stm32-data-generated", tag = "stm32-data-1cd248899f8c956357e94eaa637e24dd9ba1de56" }
 
 [build-dependencies]
 # stm32-metapac = { version = "19", default-features = false, features = ["metadata"]}
-stm32-metapac = { git = "https://github.com/embassy-rs/stm32-data-generated", tag = "stm32-data-8c7312f9831c8113a0956a7cd5e745c22bc3f4f2", default-features = false, features = ["metadata"] }
+stm32-metapac = { git = "https://github.com/embassy-rs/stm32-data-generated", tag = "stm32-data-1cd248899f8c956357e94eaa637e24dd9ba1de56", default-features = false, features = ["metadata"] }
 
 proc-macro2 = "1.0.36"
 quote = "1.0.15"


### PR DESCRIPTION
Closes #5457. A previous change removed the `impl Instance` for HSEM from embassy-stm32::hsem when any of the stm32h7* features are enabled. embassy-rs/stm32-data#731 updates stm32-data-generated to include interrupts for the HSEM peripheral in the output, which allows HSEM: Instance once more.

Fixes: 141685f6f7ff5e78fb08d3aefb67be5d16485ceb