### PR TITLE
embassy-rp::pio::StateMachine: Functions for custom DMA

### DIFF
--- a/embassy-rp/src/pio/mod.rs
+++ b/embassy-rp/src/pio/mod.rs
@@ -842,6 +842,16 @@ impl<'d, PIO: Instance + 'd, const SM: usize> StateMachine<'d, PIO, SM> {
         PIO::PIO.txf(SM).as_ptr()
     }
 
+    /// Get dma Treq of rx fifo
+    pub fn rx_treq(&self) -> crate::pac::dma::vals::TreqSel {
+        StateMachineRx::<PIO, SM>::dreq()
+    }
+
+    /// Get dma Treq of tx fifo
+    pub fn tx_treq(&self) -> crate::pac::dma::vals::TreqSel {
+        StateMachineTx::<PIO, SM>::dreq()
+    }
+
     /// Read current instruction address for this state machine
     pub fn get_addr(&self) -> u8 {
         let addr = Self::this_sm().addr();


### PR DESCRIPTION
Add functions that are useful when writing custom(outside of embassy) pio program that uses custom DMA handling logic.