### PR TITLE
docs: mention which crate has cargo size and nm

### DIFF
--- a/docs/pages/faq.adoc
+++ b/docs/pages/faq.adoc
@@ -189,7 +189,7 @@ If you end up doing this, please update this section with more specific examples
 
 === For Static Memory Usage
 
-Tools like `cargo size` and `cargo nm` can tell you the size of any globals or other static usage. Specifically you will want to see the size of the `.data` and `.bss` sections, which together make up the total global/static memory usage.
+Tools like `cargo size` and `cargo nm` from `cargo-binutils` can tell you the size of any globals or other static usage. Specifically you will want to see the size of the `.data` and `.bss` sections, which together make up the total global/static memory usage.
 
 === For Max Stack Usage
 


### PR DESCRIPTION
There's a cargo-size crate which is extremely unhelpful when trying to get the task done that cargo size from cargo-binutils does.