### PR TITLE
[MCXA] Remove use of glob import

### DIFF
--- a/embassy-mcxa/DEVGUIDE.md
+++ b/embassy-mcxa/DEVGUIDE.md
@@ -249,3 +249,16 @@ enum RecvError {
     TransferTooLarge,
 }
 ```
+
+#### Avoid Wildcard/Glob imports
+
+We generally want to avoid the use of wildcard/glob imports, like:
+
+```rust
+use super::*;
+use other_module::*;
+```
+
+This can cause [surprising semver breakage], and make the code harder to read.
+
+[surprising semver breakage]: https://predr.ag/blog/breaking-semver-in-rust-by-adding-private-type-or-import/

--- a/embassy-mcxa/src/clocks/mod.rs
+++ b/embassy-mcxa/src/clocks/mod.rs
@@ -44,7 +44,6 @@ use config::{
     VddLevel,
 };
 use critical_section::CriticalSection;
-use paste::paste;
 use periph_helpers::{PreEnableParts, SPConfHelper};
 
 use crate::pac;
@@ -2182,11 +2181,13 @@ macro_rules! impl_cc_gate {
 /// This module contains implementations of MRCC APIs, specifically of the [`Gate`] trait,
 /// for various low level peripherals.
 pub(crate) mod gate {
+    use paste::paste;
+
+    use super::Gate;
     use super::periph_helpers::{
-        AdcConfig, I3cConfig, Lpi2cConfig, LpspiConfig, LpuartConfig, NoConfig, OsTimerConfig,
+        AdcConfig, CTimerConfig, I3cConfig, Lpi2cConfig, LpspiConfig, LpuartConfig, NoConfig, OsTimerConfig,
     };
-    use super::*;
-    use crate::clocks::periph_helpers::CTimerConfig;
+    use crate::pac;
 
     // These peripherals have no additional upstream clocks or configuration required
     // other than enabling through the MRCC gate. Currently, these peripherals will


### PR DESCRIPTION
This came up in https://github.com/embassy-rs/embassy/pull/5467, adding a devguide note for it.