### PR TITLE
Bump avr-device dependency from 0.7.0 to 0.8.1

### DIFF
--- a/embassy-executor/Cargo.toml
+++ b/embassy-executor/Cargo.toml
@@ -109,7 +109,7 @@ wasm-bindgen = { version = "0.2.82", optional = true }
 js-sys = { version = "0.3", optional = true }
 
 # arch-avr dependencies
-avr-device = { version = "0.7.0", optional = true }
+avr-device = { version = "0.8.1", optional = true }
 
 
 [dependencies.cordyceps]


### PR DESCRIPTION
The embassy-executor's AVR support uses avr_device::interrupt::{disable, enable} and avr_device::asm::sleep, all of which remain API-compatible in 0.8.x.