### PR TITLE
Fix task macros to work right with rustdoc (#5449)

### DIFF
--- a/embassy-executor-macros/src/macros/main.rs
+++ b/embassy-executor-macros/src/macros/main.rs
@@ -221,12 +221,19 @@ For example: `#[embassy_executor::main(entry = ..., executor = \"some_crate::Exe
     }
 
     let result = quote! {
+        #[cfg(not(doc))]
         #[::embassy_executor::task()]
         #[allow(clippy::future_not_send)]
         async fn __embassy_main(#fargs) #out {
             #f_body
         }
 
+        #[cfg(doc)]
+        async fn main(#fargs) #out {
+            #f_body
+        }
+
+        #[cfg(not(doc))]
         #entry
         #main_attrs
         fn main() -> #main_ret {


### PR DESCRIPTION
The main and task macros significantly transform the function. This makes it show up with the wrong name and/or return type, as well as not being an async fn in rustdoc.  Fix them to emit two versions of the fn, one with the original that is #[cfg(doc)] and the transformed version for #[cfg(not(doc))].  This way they appear in rustdoc correctly.