### PR TITLE
Make peripheral steal() const (#5334)

### DIFF
--- a/embassy-hal-internal/src/macros.rs
+++ b/embassy-hal-internal/src/macros.rs
@@ -20,7 +20,7 @@ macro_rules! peripherals_definition {
                     ///
                     /// You must ensure that you're only using one instance of this type at a time.
                     #[inline]
-                    pub unsafe fn steal() -> $crate::Peri<'static, Self> {
+                    pub const unsafe fn steal() -> $crate::Peri<'static, Self> {
                         $crate::Peri::new_unchecked(Self{ _private: ()})
                     }
                 }


### PR DESCRIPTION
By making steal() const, you can initialize a global static mutex to wrap the peripheral and allow tasks to acquire the mutex for temporary exclusive access.