### PR TITLE
Stm32: Fix PLL config error

### DIFF
--- a/embassy-stm32/src/rcc/h.rs
+++ b/embassy-stm32/src/rcc/h.rs
@@ -513,7 +513,7 @@ pub(crate) unsafe fn init(config: Config) {
         |c| init_pll(1, Some(c), &pll_input),
     );
     #[cfg(any(rcc_h5, stm32h7, stm32h7rs))]
-    let pll3 = config.pll2.map_or_else(
+    let pll3 = config.pll3.map_or_else(
         || {
             disable_pll(2);
             PllOutput::default()


### PR DESCRIPTION
Fixes an error introduced in https://github.com/embassy-rs/embassy/pull/5368, which causes the config for pll2 to be assigned to pll3