### PR TITLE
[MCXA] Update to latest nxp-pac

### DIFF
--- a/embassy-mcxa/Cargo.toml
+++ b/embassy-mcxa/Cargo.toml
@@ -41,7 +41,7 @@ embedded-io = "0.7"
 embedded-io-async = { version = "0.7.0" }
 heapless = "0.9"
 maitake-sync = { version = "0.2.2", default-features = false, features = ["critical-section", "no-cache-pad"] }
-nxp-pac = { git = "https://github.com/embassy-rs/nxp-pac.git", rev = "560e74384e20940a3c25e0435a6fbdc66644b558", features = ["rt", "mcxa256"] }
+nxp-pac = { git = "https://github.com/embassy-rs/nxp-pac.git", rev = "746b2092c6fb92e3fe5810575bb826320a34191c", features = ["rt", "mcxa256"] }
 nb = "1.1.0"
 paste = "1.0.15"
 

--- a/embassy-mcxa/src/ctimer/capture.rs
+++ b/embassy-mcxa/src/ctimer/capture.rs
@@ -6,9 +6,7 @@ use core::ops::{Add, Sub};
 use core::sync::atomic::Ordering;
 
 use embassy_hal_internal::Peri;
-use nxp_pac::ctimer::vals::{
-    Cap0fe, Cap0i, Cap0re, Cap1fe, Cap1i, Cap1re, Cap2fe, Cap2i, Cap2re, Cap3fe, Cap3i, Cap3re,
-};
+use nxp_pac::ctimer::vals::{Capfe, Capi, Capre};
 
 use super::{AnyChannel, CTimer, CTimerChannel, Channel, Info, InputPin, Instance};
 use crate::clocks::WakeGuard;
@@ -209,50 +207,50 @@ impl<'d> Capture<'d> {
             match self.ch.number() {
                 Channel::Zero => match config.edge {
                     Edge::Both => {
-                        w.set_cap0re(Cap0re::CAPORE_1);
-                        w.set_cap0fe(Cap0fe::CAPOFE_1);
+                        w.set_cap0re(Capre::CAPRE1);
+                        w.set_cap0fe(Capfe::CAPFE1);
                     }
                     Edge::RisingEdge => {
-                        w.set_cap0re(Cap0re::CAPORE_1);
+                        w.set_cap0re(Capre::CAPRE1);
                     }
                     Edge::FallingEdge => {
-                        w.set_cap0fe(Cap0fe::CAPOFE_1);
+                        w.set_cap0fe(Capfe::CAPFE1);
                     }
                 },
                 Channel::One => match config.edge {
                     Edge::Both => {
-                        w.set_cap1re(Cap1re::CAP1RE_1);
-                        w.set_cap1fe(Cap1fe::CAP1FE_1);
+                        w.set_cap1re(Capre::CAPRE1);
+                        w.set_cap1fe(Capfe::CAPFE1);
                     }
                     Edge::RisingEdge => {
-                        w.set_cap1re(Cap1re::CAP1RE_1);
+                        w.set_cap1re(Capre::CAPRE1);
                     }
                     Edge::FallingEdge => {
-                        w.set_cap1fe(Cap1fe::CAP1FE_1);
+                        w.set_cap1fe(Capfe::CAPFE1);
                     }
                 },
                 Channel::Two => match config.edge {
                     Edge::Both => {
-                        w.set_cap2re(Cap2re::CAP2RE_1);
-                        w.set_cap2fe(Cap2fe::CAP2FE_1);
+                        w.set_cap2re(Capre::CAPRE1);
+                        w.set_cap2fe(Capfe::CAPFE1);
                     }
                     Edge::RisingEdge => {
-                        w.set_cap2re(Cap2re::CAP2RE_1);
+                        w.set_cap2re(Capre::CAPRE1);
                     }
                     Edge::FallingEdge => {
-                        w.set_cap2fe(Cap2fe::CAP2FE_1);
+                        w.set_cap2fe(Capfe::CAPFE1);
                     }
                 },
                 Channel::Three => match config.edge {
                     Edge::Both => {
-                        w.set_cap3re(Cap3re::CAP3RE_1);
-                        w.set_cap3fe(Cap3fe::CAP3FE_1);
+                        w.set_cap3re(Capre::CAPRE1);
+                        w.set_cap3fe(Capfe::CAPFE1);
                     }
                     Edge::RisingEdge => {
-                        w.set_cap3re(Cap3re::CAP3RE_1);
+                        w.set_cap3re(Capre::CAPRE1);
                     }
                     Edge::FallingEdge => {
-                        w.set_cap3fe(Cap3fe::CAP3FE_1);
+                        w.set_cap3fe(Capfe::CAPFE1);
                     }
                 },
             };
@@ -271,16 +269,16 @@ impl<'d> Capture<'d> {
             .wait_for(|| {
                 self.info.regs().ccr().modify(|w| match self.ch.number() {
                     Channel::Zero => {
-                        w.set_cap0i(Cap0i::CAPOI_1);
+                        w.set_cap0i(Capi::CAPI1);
                     }
                     Channel::One => {
-                        w.set_cap1i(Cap1i::CAP1I_1);
+                        w.set_cap1i(Capi::CAPI1);
                     }
                     Channel::Two => {
-                        w.set_cap2i(Cap2i::CAP2I_1);
+                        w.set_cap2i(Capi::CAPI1);
                     }
                     Channel::Three => {
-                        w.set_cap3i(Cap3i::CAP3I_1);
+                        w.set_cap3i(Capi::CAPI1);
                     }
                 });
 
@@ -317,22 +315,22 @@ impl<T: Instance> interrupt::typelevel::Handler<T::Interrupt> for InterruptHandl
         let mut mask = 0;
         T::info().regs().ccr().modify(|w| {
             if ir.cr0int() {
-                w.set_cap0i(Cap0i::CAP0I_0);
+                w.set_cap0i(Capi::CAPI0);
                 mask |= 1 << 0;
             }
 
             if ir.cr1int() {
-                w.set_cap1i(Cap1i::CAP1I_0);
+                w.set_cap1i(Capi::CAPI0);
                 mask |= 1 << 1;
             }
 
             if ir.cr2int() {
-                w.set_cap2i(Cap2i::CAP2I_0);
+                w.set_cap2i(Capi::CAPI0);
                 mask |= 1 << 2;
             }
 
             if ir.cr3int() {
-                w.set_cap3i(Cap3i::CAP3I_0);
+                w.set_cap3i(Capi::CAPI0);
                 mask |= 1 << 3;
             }
         });

--- a/embassy-mcxa/src/ctimer/pwm.rs
+++ b/embassy-mcxa/src/ctimer/pwm.rs
@@ -6,10 +6,7 @@ use embedded_hal_1::pwm::{Error, ErrorKind, ErrorType};
 
 use super::{AnyChannel, CTimer, CTimerChannel, Channel, Info, Instance, OutputPin};
 use crate::gpio::{AnyPin, SealedPin};
-use crate::pac::ctimer::vals::{
-    Mr0i, Mr0r, Mr0rl, Mr0s, Mr1i, Mr1r, Mr1rl, Mr1s, Mr2i, Mr2r, Mr2rl, Mr2s, Mr3i, Mr3r, Mr3rl, Mr3s, Pwmen0, Pwmen1,
-    Pwmen2, Pwmen3,
-};
+use crate::pac::ctimer::vals::{Mri, Mrr, Mrrl, Mrs, Pwmen};
 
 /// PWM error.
 #[derive(Debug)]
@@ -79,16 +76,16 @@ impl<'d> Pwm<'d> {
     fn set_pwm_mode(&self) {
         self.info.regs().pwmc().modify(|w| match self.duty_ch.number() {
             Channel::Zero => {
-                w.set_pwmen0(Pwmen0::PWM);
+                w.set_pwmen0(Pwmen::PWM);
             }
             Channel::One => {
-                w.set_pwmen1(Pwmen1::PWM);
+                w.set_pwmen1(Pwmen::PWM);
             }
             Channel::Two => {
-                w.set_pwmen2(Pwmen2::PWM);
+                w.set_pwmen2(Pwmen::PWM);
             }
             Channel::Three => {
-                w.set_pwmen3(Pwmen3::PWM);
+                w.set_pwmen3(Pwmen::PWM);
             }
         });
     }
@@ -98,39 +95,39 @@ impl<'d> Pwm<'d> {
             // Clear stop, reset, and interrupt bits for the PWM channel
             match self.duty_ch.number() {
                 Channel::Zero => {
-                    w.set_mr0i(Mr0i::MR0I_0);
-                    w.set_mr0r(Mr0r::MR0R_0);
-                    w.set_mr0s(Mr0s::MR0S_0);
+                    w.set_mr0i(Mri::MRI0);
+                    w.set_mr0r(Mrr::MRR0);
+                    w.set_mr0s(Mrs::MRS0);
                 }
                 Channel::One => {
-                    w.set_mr1i(Mr1i::MR1I_0);
-                    w.set_mr1r(Mr1r::MR1R_0);
-                    w.set_mr1s(Mr1s::MRIS_0);
+                    w.set_mr1i(Mri::MRI0);
+                    w.set_mr1r(Mrr::MRR0);
+                    w.set_mr1s(Mrs::MRS0);
                 }
                 Channel::Two => {
-                    w.set_mr2i(Mr2i::MR2I_0);
-                    w.set_mr2r(Mr2r::MR2R_0);
-                    w.set_mr2s(Mr2s::MR2S_0);
+                    w.set_mr2i(Mri::MRI0);
+                    w.set_mr2r(Mrr::MRR0);
+                    w.set_mr2s(Mrs::MRS0);
                 }
                 Channel::Three => {
-                    w.set_mr3i(Mr3i::MR3I_0);
-                    w.set_mr3r(Mr3r::MR3R_0);
-                    w.set_mr3s(Mr3s::MR3S_0);
+                    w.set_mr3i(Mri::MRI0);
+                    w.set_mr3r(Mrr::MRR0);
+                    w.set_mr3s(Mrs::MRS0);
                 }
             }
 
             match self.duty_ch.number() {
                 Channel::Zero => {
-                    w.set_mr0rl(Mr0rl::MR0RL_1);
+                    w.set_mr0rl(Mrrl::MRRL1);
                 }
                 Channel::One => {
-                    w.set_mr1rl(Mr1rl::MR1RL_1);
+                    w.set_mr1rl(Mrrl::MRRL1);
                 }
                 Channel::Two => {
-                    w.set_mr2rl(Mr2rl::MR2RL_1);
+                    w.set_mr2rl(Mrrl::MRRL1);
                 }
                 Channel::Three => {
-                    w.set_mr3rl(Mr3rl::MR3RL_1);
+                    w.set_mr3rl(Mrrl::MRRL1);
                 }
             }
         });
@@ -205,16 +202,16 @@ impl<'d> SinglePwm<'d> {
 
         self.pwm.info.regs().mcr().modify(|w| match self.period_ch.number() {
             Channel::Zero => {
-                w.set_mr0r(Mr0r::MR0R_1);
+                w.set_mr0r(Mrr::MRR1);
             }
             Channel::One => {
-                w.set_mr1r(Mr1r::MR1R_1);
+                w.set_mr1r(Mrr::MRR1);
             }
             Channel::Two => {
-                w.set_mr2r(Mr2r::MR2R_1);
+                w.set_mr2r(Mrr::MRR1);
             }
             Channel::Three => {
-                w.set_mr3r(Mr3r::MR3R_1);
+                w.set_mr3r(Mrr::MRR1);
             }
         });
 
@@ -314,16 +311,16 @@ impl<'d> DualPwm<'d> {
 
         self.pwm0.info.regs().mcr().modify(|w| match self.period_ch.number() {
             Channel::Zero => {
-                w.set_mr0r(Mr0r::MR0R_1);
+                w.set_mr0r(Mrr::MRR1);
             }
             Channel::One => {
-                w.set_mr1r(Mr1r::MR1R_1);
+                w.set_mr1r(Mrr::MRR1);
             }
             Channel::Two => {
-                w.set_mr2r(Mr2r::MR2R_1);
+                w.set_mr2r(Mrr::MRR1);
             }
             Channel::Three => {
-                w.set_mr3r(Mr3r::MR3R_1);
+                w.set_mr3r(Mrr::MRR1);
             }
         });
 
@@ -450,16 +447,16 @@ impl<'d> TriplePwm<'d> {
 
         self.pwm0.info.regs().mcr().modify(|w| match self.period_ch.number() {
             Channel::Zero => {
-                w.set_mr0r(Mr0r::MR0R_1);
+                w.set_mr0r(Mrr::MRR1);
             }
             Channel::One => {
-                w.set_mr1r(Mr1r::MR1R_1);
+                w.set_mr1r(Mrr::MRR1);
             }
             Channel::Two => {
-                w.set_mr2r(Mr2r::MR2R_1);
+                w.set_mr2r(Mrr::MRR1);
             }
             Channel::Three => {
-                w.set_mr3r(Mr3r::MR3R_1);
+                w.set_mr3r(Mrr::MRR1);
             }
         });
 


### PR DESCRIPTION
Latest nxp-pac merged some CTimer enums. Update ctimer drivers accordingly.

Closes https://github.com/OpenDevicePartnership/embassy-mcxa/issues/135