### PR TITLE
stm32: support flash base address remapping

### DIFF
--- a/embassy-stm32/build.rs
+++ b/embassy-stm32/build.rs
@@ -76,9 +76,9 @@ fn main() {
 
     // ========
     // Select the memory variant to use
+    let dual_bank_selected = env::var("CARGO_FEATURE_DUAL_BANK").is_ok();
     let memory = {
         let single_bank_selected = env::var("CARGO_FEATURE_SINGLE_BANK").is_ok();
-        let dual_bank_selected = env::var("CARGO_FEATURE_DUAL_BANK").is_ok();
 
         let single_bank_memory = METADATA.memory.iter().find(|mem| {
             mem.iter().any(|region| region.name.contains("BANK_1"))
@@ -418,21 +418,76 @@ fn main() {
             .iter()
             .filter(|x| x.kind == MemoryRegionKind::Flash && x.settings.is_some())
             .collect();
+
+        let check_fb_mode = dual_bank_selected
+            && METADATA.peripherals.iter().any(|p| {
+                p.name == "SYSCFG"
+                    && p.registers.as_ref().is_some_and(|r| {
+                        r.ir.fieldsets
+                            .iter()
+                            .any(|f| f.name == "Memrmp" && f.fields.iter().any(|f| f.name == "fb_mode"))
+                    })
+            });
+
+        let mut bank_1_base = None;
+        let mut bank_2_base = None;
+        let mut otp_base = None;
+        for region in flash_memory_regions.iter() {
+            if region.name == "BANK_1" || region.name == "BANK_1_REGION_1" {
+                bank_1_base = Some(region.address);
+            } else if region.name == "BANK_2" || region.name == "BANK_2_REGION_1" {
+                bank_2_base = Some(region.address);
+            } else if region.name == "OTP" {
+                otp_base = Some(region.address);
+            }
+        }
+        let bank_1 = bank_1_base
+            .map(|a| quote!(#a))
+            .unwrap_or_else(|| quote!(panic!("Bank 1 not present")));
+        let bank_2 = bank_2_base
+            .map(|a| quote!(#a))
+            .unwrap_or_else(|| quote!(panic!("Bank 2 not present")));
+        let otp = otp_base
+            .map(|a| quote!(#a))
+            .unwrap_or_else(|| quote!(panic!("OTP not present")));
+
+        let (swap_check, bank1, bank2) = if check_fb_mode {
+            (
+                quote! { let is_swapped = crate::pac::SYSCFG.memrmp().read().fb_mode(); },
+                quote! { if is_swapped { #bank_2 } else { #bank_1 } },
+                quote! { if is_swapped { #bank_1 } else { #bank_2 } },
+            )
+        } else {
+            (quote! {}, quote! { #bank_1 }, quote! { #bank_2 })
+        };
+
+        flash_regions.extend(quote! {
+            impl crate::flash::FlashBank {
+                /// Absolute base address.
+                pub fn base(&self) -> u32 {
+                    #swap_check
+                    match self {
+                        crate::flash::FlashBank::Bank1 => #bank1,
+                        crate::flash::FlashBank::Bank2 => #bank2,
+                        crate::flash::FlashBank::Otp => #otp,
+                    }
+                }
+            }
+        });
+
         for region in flash_memory_regions.iter() {
             let region_name = format_ident!("{}", get_flash_region_name(region.name));
-            let bank_variant = format_ident!(
-                "{}",
-                if region.name.starts_with("BANK_1") {
-                    "Bank1"
-                } else if region.name.starts_with("BANK_2") {
-                    "Bank2"
-                } else if region.name == "OTP" {
-                    "Otp"
-                } else {
-                    continue;
-                }
-            );
-            let base = region.address;
+            let (bank_variant, base) = if region.name.starts_with("BANK_1") {
+                ("Bank1", bank_1_base.unwrap())
+            } else if region.name.starts_with("BANK_2") {
+                ("Bank2", bank_2_base.unwrap())
+            } else if region.name == "OTP" {
+                ("Otp", otp_base.unwrap())
+            } else {
+                continue;
+            };
+            let bank_variant = format_ident!("{bank_variant}");
+            let offset = region.address - base;
             let size = region.size;
             let settings = region.settings.as_ref().unwrap();
             let erase_size = settings.erase_size;
@@ -442,7 +497,7 @@ fn main() {
             flash_regions.extend(quote! {
                 pub const #region_name: crate::flash::FlashRegion = crate::flash::FlashRegion {
                     bank: crate::flash::FlashBank::#bank_variant,
-                    base: #base,
+                    offset: #offset,
                     size: #size,
                     erase_size: #erase_size,
                     write_size: #write_size,
@@ -2245,7 +2300,7 @@ fn main() {
             .iter()
             .filter(|x| x.kind == MemoryRegionKind::Flash && x.name.starts_with("BANK_"))
             .collect();
-        let first_flash = flash_regions.first().unwrap();
+        let first_flash = flash_regions.iter().min_by_key(|region| region.address).unwrap();
         let total_flash_size = flash_regions
             .iter()
             .map(|x| x.size)

--- a/embassy-stm32/src/flash/asynch.rs
+++ b/embassy-stm32/src/flash/asynch.rs
@@ -153,19 +153,19 @@ foreach_flash_region! {
             ///
             /// Note: reading from flash can't actually block, so this is the same as `blocking_read`.
             pub async fn read(&mut self, offset: u32, bytes: &mut [u8]) -> Result<(), Error> {
-                blocking_read(self.0.base, self.0.size, offset, bytes)
+                blocking_read(self.0.base(), self.0.size, offset, bytes)
             }
 
             /// Async write.
             pub async fn write(&mut self, offset: u32, bytes: &[u8]) -> Result<(), Error> {
                 let _guard = REGION_ACCESS.lock().await;
-                unsafe { write_chunked(self.0.base, self.0.size, offset, bytes).await }
+                unsafe { write_chunked(self.0.base(), self.0.size, offset, bytes).await }
             }
 
             /// Async erase.
             pub async fn erase(&mut self, from: u32, to: u32) -> Result<(), Error> {
                 let _guard = REGION_ACCESS.lock().await;
-                unsafe { erase_sectored(self.0.base, from, to).await }
+                unsafe { erase_sectored(self.0.base(), from, to).await }
             }
         }
 

--- a/embassy-stm32/src/flash/common.rs
+++ b/embassy-stm32/src/flash/common.rs
@@ -186,12 +186,12 @@ pub(super) fn get_sector(address: u32, regions: &[&FlashRegion]) -> FlashSector 
             bank_offset = 0;
         }
 
-        if address >= region.base && address < region.end() {
-            let index_in_region = (address - region.base) / region.erase_size;
+        if address >= region.base() && address < region.end() {
+            let index_in_region = (address - region.base()) / region.erase_size;
             return FlashSector {
                 bank: region.bank,
                 index_in_bank: bank_offset + index_in_region as u8,
-                start: region.base + index_in_region * region.erase_size,
+                start: region.base() + index_in_region * region.erase_size,
                 size: region.erase_size,
             };
         }
@@ -258,7 +258,7 @@ foreach_flash_region! {
             /// NOTE: `offset` is an offset from the flash start, NOT an absolute address.
             /// For example, to read address `0x0800_1234` you have to use offset `0x1234`.
             pub fn blocking_read(&mut self, offset: u32, bytes: &mut [u8]) -> Result<(), Error> {
-                blocking_read(self.0.base, self.0.size, offset, bytes)
+                blocking_read(self.0.base(), self.0.size, offset, bytes)
             }
         }
 
@@ -268,7 +268,7 @@ foreach_flash_region! {
             /// NOTE: `offset` is an offset from the flash start, NOT an absolute address.
             /// For example, to write address `0x0800_1234` you have to use offset `0x1234`.
             pub fn blocking_write(&mut self, offset: u32, bytes: &[u8]) -> Result<(), Error> {
-                unsafe { blocking_write(self.0.base, self.0.size, offset, bytes, write_chunk_with_critical_section) }
+                unsafe { blocking_write(self.0.base(), self.0.size, offset, bytes, write_chunk_with_critical_section) }
             }
 
             /// Blocking erase.
@@ -276,7 +276,7 @@ foreach_flash_region! {
             /// NOTE: `from` and `to` are offsets from the flash start, NOT an absolute address.
             /// For example, to erase address `0x0801_0000` you have to use offset `0x1_0000`.
             pub fn blocking_erase(&mut self, from: u32, to: u32) -> Result<(), Error> {
-                unsafe { blocking_erase(self.0.base, from, to, erase_sector_with_critical_section) }
+                unsafe { blocking_erase(self.0.base(), from, to, erase_sector_with_critical_section) }
             }
         }
 

--- a/embassy-stm32/src/flash/f7.rs
+++ b/embassy-stm32/src/flash/f7.rs
@@ -166,53 +166,6 @@ mod tests {
         assert_sector(7, 0x080C_0000, LARGE_SECTOR_SIZE, 0x080C_0000);
         assert_sector(7, 0x080C_0000, LARGE_SECTOR_SIZE, 0x080F_FFFF);
     }
-
-    #[test]
-    #[cfg(all(stm32f769, feature = "dual-bank"))]
-    fn can_get_sector() {
-        const SMALL_SECTOR_SIZE: u32 = 16 * 1024;
-        const MEDIUM_SECTOR_SIZE: u32 = 64 * 1024;
-        const LARGE_SECTOR_SIZE: u32 = 128 * 1024;
-
-        let assert_sector = |index_in_bank: u8, start: u32, size: u32, address: u32, snb: u8, bank: FlashBank| {
-            assert_eq!(
-                FlashSector {
-                    bank: bank,
-                    index_in_bank,
-                    start,
-                    size
-                },
-                get_sector(address, crate::flash::get_flash_regions())
-            );
-            assert_eq!(get_sector(address, crate::flash::get_flash_regions()).snb(), snb);
-        };
-
-        assert_sector(0, 0x0800_0000, SMALL_SECTOR_SIZE, 0x0800_0000, 0x00, FlashBank::Bank1);
-        assert_sector(0, 0x0800_0000, SMALL_SECTOR_SIZE, 0x0800_3FFF, 0x00, FlashBank::Bank1);
-        assert_sector(3, 0x0800_C000, SMALL_SECTOR_SIZE, 0x0800_C000, 0x03, FlashBank::Bank1);
-        assert_sector(3, 0x0800_C000, SMALL_SECTOR_SIZE, 0x0800_FFFF, 0x03, FlashBank::Bank1);
-
-        assert_sector(4, 0x0801_0000, MEDIUM_SECTOR_SIZE, 0x0801_0000, 0x04, FlashBank::Bank1);
-        assert_sector(4, 0x0801_0000, MEDIUM_SECTOR_SIZE, 0x0801_FFFF, 0x04, FlashBank::Bank1);
-
-        assert_sector(5, 0x0802_0000, LARGE_SECTOR_SIZE, 0x0802_0000, 0x05, FlashBank::Bank1);
-        assert_sector(5, 0x0802_0000, LARGE_SECTOR_SIZE, 0x0803_FFFF, 0x05, FlashBank::Bank1);
-        assert_sector(10, 0x080C_0000, LARGE_SECTOR_SIZE, 0x080C_0000, 0x0A, FlashBank::Bank1);
-        assert_sector(10, 0x080C_0000, LARGE_SECTOR_SIZE, 0x080D_FFFF, 0x0A, FlashBank::Bank1);
-
-        assert_sector(0, 0x0810_0000, SMALL_SECTOR_SIZE, 0x0810_0000, 0x10, FlashBank::Bank2);
-        assert_sector(0, 0x0810_0000, SMALL_SECTOR_SIZE, 0x0810_3FFF, 0x10, FlashBank::Bank2);
-        assert_sector(3, 0x0810_C000, SMALL_SECTOR_SIZE, 0x0810_C000, 0x13, FlashBank::Bank2);
-        assert_sector(3, 0x0810_C000, SMALL_SECTOR_SIZE, 0x0810_FFFF, 0x13, FlashBank::Bank2);
-
-        assert_sector(4, 0x0811_0000, MEDIUM_SECTOR_SIZE, 0x0811_0000, 0x14, FlashBank::Bank2);
-        assert_sector(4, 0x0811_0000, MEDIUM_SECTOR_SIZE, 0x0811_FFFF, 0x14, FlashBank::Bank2);
-
-        assert_sector(5, 0x0812_0000, LARGE_SECTOR_SIZE, 0x0812_0000, 0x15, FlashBank::Bank2);
-        assert_sector(5, 0x0812_0000, LARGE_SECTOR_SIZE, 0x0813_FFFF, 0x15, FlashBank::Bank2);
-        assert_sector(10, 0x081C_0000, LARGE_SECTOR_SIZE, 0x081C_0000, 0x1A, FlashBank::Bank2);
-        assert_sector(10, 0x081C_0000, LARGE_SECTOR_SIZE, 0x081D_FFFF, 0x1A, FlashBank::Bank2);
-    }
 }
 
 #[cfg(all(bank_setup_configurable))]

--- a/embassy-stm32/src/flash/h7.rs
+++ b/embassy-stm32/src/flash/h7.rs
@@ -66,7 +66,7 @@ pub(crate) unsafe fn disable_blocking_write() {}
 
 pub(crate) async unsafe fn write(start_address: u32, buf: &[u8; WRITE_SIZE]) -> Result<(), Error> {
     // We cannot have the write setup sequence in begin_write as it depends on the address
-    let bank = if start_address < BANK1_REGION.end() {
+    let bank = if start_address >= BANK1_REGION.base() && start_address < BANK1_REGION.end() {
         pac::FLASH.bank(0)
     } else {
         pac::FLASH.bank(1)
@@ -114,7 +114,7 @@ pub(crate) async unsafe fn write(start_address: u32, buf: &[u8; WRITE_SIZE]) -> 
 
 pub(crate) unsafe fn blocking_write(start_address: u32, buf: &[u8; WRITE_SIZE]) -> Result<(), Error> {
     // We cannot have the write setup sequence in begin_write as it depends on the address
-    let bank = if start_address < BANK1_REGION.end() {
+    let bank = if start_address >= BANK1_REGION.base() && start_address < BANK1_REGION.end() {
         pac::FLASH.bank(0)
     } else {
         pac::FLASH.bank(1)

--- a/embassy-stm32/src/flash/mod.rs
+++ b/embassy-stm32/src/flash/mod.rs
@@ -44,8 +44,8 @@ pub enum Async {}
 pub struct FlashRegion {
     /// Bank number.
     pub bank: FlashBank,
-    /// Absolute base address.
-    pub base: u32,
+    /// Offset from bank base.
+    pub offset: u32,
     /// Size in bytes.
     pub size: u32,
     /// Erase size (sector size).
@@ -58,9 +58,14 @@ pub struct FlashRegion {
 }
 
 impl FlashRegion {
+    /// Absolute base address.
+    pub fn base(&self) -> u32 {
+        self.bank.base() + self.offset
+    }
+
     /// Absolute end address.
-    pub const fn end(&self) -> u32 {
-        self.base + self.size
+    pub fn end(&self) -> u32 {
+        self.base() + self.size
     }
 
     /// Number of sectors in the region.

--- a/examples/boot/bootloader/stm32-dual-bank/src/main.rs
+++ b/examples/boot/bootloader/stm32-dual-bank/src/main.rs
@@ -30,7 +30,7 @@ fn main() -> ! {
     let active_offset = config.active.offset();
     let bl = BootLoader::prepare::<_, _, _, 2048>(config);
 
-    unsafe { bl.load(BANK1_REGION.base + active_offset) }
+    unsafe { bl.load(BANK1_REGION.base() + active_offset) }
 }
 
 #[unsafe(no_mangle)]

--- a/examples/boot/bootloader/stm32/src/main.rs
+++ b/examples/boot/bootloader/stm32/src/main.rs
@@ -29,7 +29,7 @@ fn main() -> ! {
     let active_offset = config.active.offset();
     let bl = BootLoader::prepare::<_, _, _, 2048>(config);
 
-    unsafe { bl.load(BANK1_REGION.base + active_offset) }
+    unsafe { bl.load(BANK1_REGION.base() + active_offset) }
 }
 
 #[unsafe(no_mangle)]

--- a/examples/boot/bootloader/stm32wb-dfu/src/main.rs
+++ b/examples/boot/bootloader/stm32wb-dfu/src/main.rs
@@ -106,7 +106,7 @@ fn main() -> ! {
         embassy_futures::block_on(dev.run());
     }
 
-    unsafe { bl.load(BANK1_REGION.base + active_offset) }
+    unsafe { bl.load(BANK1_REGION.base() + active_offset) }
 }
 
 #[unsafe(no_mangle)]

--- a/examples/boot/bootloader/stm32wba-dfu/src/main.rs
+++ b/examples/boot/bootloader/stm32wba-dfu/src/main.rs
@@ -135,7 +135,7 @@ fn main() -> ! {
         embassy_futures::block_on(dev.run());
     }
 
-    unsafe { bl.load(BANK1_REGION.base + active_offset) }
+    unsafe { bl.load(BANK1_REGION.base() + active_offset) }
 }
 
 #[unsafe(no_mangle)]


### PR DESCRIPTION
Select STM32 devices allow for BANK1 and BANK2 to have their addresses swapped with the FB_MODE flag. This is required if we wish to use flash when booting from bank 2 (BFB2 flag), to allow for OTA updates.

The FB_MODE flag cannot change during runtime, meaning that we could only perform this check once, but the performance impact of checking each time should be minimal, and this avoids the need for additional synchronization.

As far as I can tell no other logic needs to be changed for this feature.

I had to delete a test because it would now have to be run on real hardware, since it reads a register.