### PR TITLE
Disable the RCC for FDCAN when the Info reference counter for an instance reaches 0

### DIFF
--- a/embassy-stm32/src/can/fdcan.rs
+++ b/embassy-stm32/src/can/fdcan.rs
@@ -12,7 +12,7 @@ use embassy_sync::waitqueue::AtomicWaker;
 use crate::can::fd::peripheral::Registers;
 use crate::gpio::{AfType, OutputType, Pull, SealedPin as _, Speed};
 use crate::interrupt::typelevel::Interrupt;
-use crate::rcc::{self, RccPeripheral};
+use crate::rcc::{self, RccInfo, RccPeripheral, SealedRccPeripheral};
 use crate::{Peri, interrupt, peripherals};
 
 pub(crate) mod fd;
@@ -918,6 +918,7 @@ pub(crate) struct Info {
     _interrupt1: crate::interrupt::Interrupt,
     pub(crate) tx_waker: fn(),
     state: SharedState,
+    rcc_info: RccInfo,
 }
 
 impl Info {
@@ -951,6 +952,7 @@ impl Info {
                     let rx_pin = crate::gpio::AnyPin::steal(mut_state.rx_pin_port.unwrap());
                     rx_pin.set_as_disconnected();
                     self.interrupt0.disable();
+                    self.rcc_info.disable();
                 }
             }
         });
@@ -991,6 +993,7 @@ macro_rules! impl_fdcan {
                     _interrupt1: crate::_generated::peripheral_interrupts::$inst::IT1::IRQ,
                     tx_waker: crate::_generated::peripheral_interrupts::$inst::IT0::pend,
                     state: embassy_sync::blocking_mutex::Mutex::new(core::cell::RefCell::new(State::new())),
+                    rcc_info: crate::peripherals::$inst::RCC_INFO,
                 };
                 &INFO
             }


### PR DESCRIPTION
Without this, the RCC is never disabled for the CAN and if the can is re-initialized later the RCC reference counter eventually overflows the uint8 that stores it

In our application we drop and re-initialize the CAN peripherals often to change modes (listen only, transmit). After 255 mode changes, the RCC enable was panicking when the u8 reference counter overflowed. 