### PR TITLE
STM32H7RS: Add internal flash config option for SYSCFG control

### DIFF
--- a/embassy-stm32/src/lib.rs
+++ b/embassy-stm32/src/lib.rs
@@ -339,14 +339,6 @@ pub struct Config {
     /// Allows JTAG pins to be used for GPIO
     #[cfg(stm32f1)]
     pub swj: gpio::SwjCfg,
-
-    /// Sets if SYSCFG should be enabled and reset or not.
-    /// 
-    /// If running from external flash, the bootloader should handle initializing the SYSCFG peripheral.
-    /// 
-    /// Defaults to true (bootloader or single internal flash applications)
-    #[cfg(stm32h7rs)]
-    pub internal_flash: bool,
 }
 
 impl Default for Config {
@@ -377,8 +369,6 @@ impl Default for Config {
             enable_ucpd2_dead_battery: false,
             #[cfg(stm32f1)]
             swj: Default::default(),
-            #[cfg(stm32h7rs)]
-            internal_flash: true,
         }
     }
 }
@@ -623,13 +613,9 @@ fn init_hw(config: Config) -> Peripherals {
         });
 
         #[cfg(any(stm32h7rs))]
-        {
-            if config.internal_flash {
-                rcc::enable_and_reset_with_cs::<peripherals::SYSCFG>(cs);
-            }
-        }
-
-        #[cfg(not(any(stm32f1, stm32wb, stm32wl)))]
+        // On the H7RS the SYSCFG should not be reset if it is already enabled. This is typically the case when running from external flash and the bootloader enables the SYSCFG.
+        rcc::enable_with_cs::<peripherals::SYSCFG>(cs);
+        #[cfg(not(any(stm32f1, stm32wb, stm32wl, stm32h7rs)))]
         rcc::enable_and_reset_with_cs::<peripherals::SYSCFG>(cs);
         #[cfg(not(any(stm32h5, stm32h7, stm32h7rs, stm32wb, stm32wl)))]
         rcc::enable_and_reset_with_cs::<peripherals::PWR>(cs);


### PR DESCRIPTION
This allows controlling whether or not the application is responsible for enabling and setting up the SYSCFG peripheral. For programs running from internal flash such as bootloader, this needs to be setup. Programs running from external flash don't need to enable SYSCFG since it should have already been setup by the bootloader