### PR TITLE
stm32/gpio,exti: add from_flex/from_input constructors for Input and ExtiInput

### DIFF
--- a/embassy-stm32/src/gpio.rs
+++ b/embassy-stm32/src/gpio.rs
@@ -336,6 +336,17 @@ impl<'d> Input<'d> {
         Self { pin }
     }
 
+    /// Create a GPIO input driver from an existing [`Flex`] pin.
+    ///
+    /// This is useful when a pin was previously used in bidirectional mode and
+    /// needs to be converted to a typed input driver without re-acquiring the
+    /// peripheral token. The pin should already be configured as an input via
+    /// [`Flex::set_as_input()`].
+    #[inline]
+    pub fn from_flex(pin: Flex<'d>) -> Self {
+        Self { pin }
+    }
+
     /// Get whether the pin input level is high.
     #[inline]
     pub fn is_high(&self) -> bool {


### PR DESCRIPTION
Add constructors to convert an existing `Flex` pin to `Input` or
`ExtiInput<Async>` without re-acquiring the peripheral token:

- `Input::from_flex(pin: Flex<'d>) -> Input<'d>`
- `ExtiInput::from_input<C: Channel>(pin, ch, irq) -> ExtiInput<'d, Async>`
- `ExtiInput::from_flex<C: Channel>(pin, ch, irq) -> ExtiInput<'d, Async>`

Useful when a pin is temporarily driven as an output before switching to
interrupt-driven input mode (e.g., hardware bootloader entry sequences).
The `_ch` and `_irq` parameters enforce the same ownership and
interrupt-binding proofs as `new()`.