### PR TITLE
embassy-rp: Fix race in dma irq handler

### DIFF
--- a/embassy-rp/src/dma.rs
+++ b/embassy-rp/src/dma.rs
@@ -29,9 +29,10 @@ impl<T: ChannelInstance> interrupt::typelevel::Handler<T::Interrupt> for Interru
 
         let ints0 = pac::DMA.ints(0).read();
         if ints0 & (1 << channel) != 0 {
+            pac::DMA.ints(0).write_value(1 << channel);
+
             CHANNEL_WAKERS[channel].wake();
         }
-        pac::DMA.ints(0).write_value(1 << channel);
     }
 }
 


### PR DESCRIPTION
This fixes a race that could arise in following situation: 
Two channels are active CH1 and CH2.
CH1 finishes and triggers an IRQ.
Handlers for CH1 and CH2 are ran.
Just after handler for CH2 fetched ints0 CH2 finishes and fires it's IRQ.
The currently running handler decides that there is no work to be done for CH2 and clears CH2 flag anyway.

This would result in CH2 IRQ being cleared without being handled.

Fix it by only clearing the flag if we did the work.