### PR TITLE
[MCXA] gpio: Fix is_set_*() methods

### DIFF
--- a/embassy-mcxa/Cargo.toml
+++ b/embassy-mcxa/Cargo.toml
@@ -41,7 +41,7 @@ embedded-io = "0.7"
 embedded-io-async = { version = "0.7.0" }
 heapless = "0.9"
 maitake-sync = { version = "0.2.2", default-features = false, features = ["critical-section", "no-cache-pad"] }
-nxp-pac = { git = "https://github.com/embassy-rs/nxp-pac.git", rev = "746b2092c6fb92e3fe5810575bb826320a34191c", features = ["rt", "mcxa256"] }
+nxp-pac = { git = "https://github.com/embassy-rs/nxp-pac.git", rev = "c1f8992e225db5efca440873b4013e1ed9751020", features = ["rt", "mcxa256"] }
 nb = "1.1.0"
 paste = "1.0.15"
 

--- a/embassy-mcxa/src/gpio.rs
+++ b/embassy-mcxa/src/gpio.rs
@@ -702,7 +702,7 @@ impl<'d> Flex<'d> {
     /// Is the output pin set as high?
     #[inline]
     pub fn is_set_high(&self) -> bool {
-        self.is_high()
+        self.gpio().pdor().read().pdo(self.pin.pin_index() as usize)
     }
 
     /// Is the output pin set as low?
@@ -855,13 +855,13 @@ impl<'d> Output<'d> {
     /// Is the output pin set as high?
     #[inline]
     pub fn is_set_high(&self) -> bool {
-        self.flex.is_high()
+        self.flex.is_set_high()
     }
 
     /// Is the output pin set as low?
     #[inline]
     pub fn is_set_low(&self) -> bool {
-        !self.is_set_high()
+        self.flex.is_set_low()
     }
 
     /// Expose the inner `Flex` if callers need to reconfigure the pin.


### PR DESCRIPTION
These methods should use the output data register.

Closes https://github.com/OpenDevicePartnership/embassy-mcxa/issues/151
Closes https://github.com/OpenDevicePartnership/embassy-mcxa/issues/152