### PR TITLE
nrf52840/nvmc: Remove obsolete delay from example

### DIFF
--- a/examples/nrf52840/src/bin/nvmc.rs
+++ b/examples/nrf52840/src/bin/nvmc.rs
@@ -4,7 +4,6 @@
 use defmt::{info, unwrap};
 use embassy_executor::Spawner;
 use embassy_nrf::nvmc::Nvmc;
-use embassy_time::Timer;
 use embedded_storage::nor_flash::{NorFlash, ReadNorFlash};
 use {defmt_rtt as _, panic_probe as _};
 
@@ -12,9 +11,6 @@ use {defmt_rtt as _, panic_probe as _};
 async fn main(_spawner: Spawner) {
     let p = embassy_nrf::init(Default::default());
     info!("Hello NVMC!");
-
-    // probe-rs run breaks without this, I'm not sure why.
-    Timer::after_secs(1).await;
 
     let mut f = Nvmc::new(p.NVMC);
     const ADDR: u32 = 0x80000;


### PR DESCRIPTION
Delay has been part of the example since 2021 ([e78d226](https://github.com/embassy-rs/embassy/commit/e78d226acd5e2dc5f2eecfc98269747daf7e0633#diff-680032c1f913f5df07dd8571b135c276df1cf82351352b7f7afe54eed0c6dee1R18-R19)) but is no longer needed.

```shell
$ cargo run --release --bin nvmc
    Finished `release` profile [optimized + debuginfo] target(s) in 0.04s
     Running `probe-rs run --chip nRF52840_xxAA target/thumbv7em-none-eabi/release/nvmc`
      Erasing ✔ 100% [####################]  12.00 KiB @  22.93 KiB/s (took 1s)
     Finished in 1.36s
0.000000 [INFO ] Hello NVMC! (nvmc src/bin/nvmc.rs:13)
0.000000 [INFO ] Reading... (nvmc src/bin/nvmc.rs:18)
0.000000 [INFO ] Read: [1, 2, 3, 4] (nvmc src/bin/nvmc.rs:21)
0.000000 [INFO ] Erasing... (nvmc src/bin/nvmc.rs:23)
0.083587 [INFO ] Reading... (nvmc src/bin/nvmc.rs:26)
0.083618 [INFO ] Read: [ff, ff, ff, ff] (nvmc src/bin/nvmc.rs:29)
0.083679 [INFO ] Writing... (nvmc src/bin/nvmc.rs:31)
0.083740 [INFO ] Reading... (nvmc src/bin/nvmc.rs:34)
0.083770 [INFO ] Read: [1, 2, 3, 4] (nvmc src/bin/nvmc.rs:37)
```