### PR TITLE
CRC: Don't automatically read after feeding (5335)

### DIFF
--- a/embassy-stm32/src/crc/v2v3.rs
+++ b/embassy-stm32/src/crc/v2v3.rs
@@ -134,45 +134,39 @@ impl<'d> Crc<'d> {
         PAC_CRC.dr32().read()
     }
 
-    /// Feeds a byte into the CRC peripheral. Returns the computed CRC.
-    pub fn feed_byte(&mut self, byte: u8) -> u32 {
+    /// Feeds a byte into the CRC peripheral.
+    pub fn feed_byte(&mut self, byte: u8) {
         PAC_CRC.dr8().write_value(byte);
-        self.read()
     }
 
-    /// Feeds a slice of bytes into the CRC peripheral. Returns the computed CRC.
-    pub fn feed_bytes(&mut self, bytes: &[u8]) -> u32 {
+    /// Feeds a slice of bytes into the CRC peripheral.
+    pub fn feed_bytes(&mut self, bytes: &[u8]) {
         for byte in bytes {
             PAC_CRC.dr8().write_value(*byte);
         }
-        self.read()
     }
 
-    /// Feeds a halfword into the CRC peripheral. Returns the computed CRC.
-    pub fn feed_halfword(&mut self, halfword: u16) -> u32 {
+    /// Feeds a halfword into the CRC peripheral.
+    pub fn feed_halfword(&mut self, halfword: u16) {
         PAC_CRC.dr16().write_value(halfword);
-        self.read()
     }
 
-    /// Feeds a slice of halfwords into the CRC peripheral. Returns the computed CRC.
-    pub fn feed_halfwords(&mut self, halfwords: &[u16]) -> u32 {
+    /// Feeds a slice of halfwords into the CRC peripheral.
+    pub fn feed_halfwords(&mut self, halfwords: &[u16]) {
         for halfword in halfwords {
             PAC_CRC.dr16().write_value(*halfword);
         }
-        self.read()
     }
 
-    /// Feeds a word into the CRC peripheral. Returns the computed CRC.
-    pub fn feed_word(&mut self, word: u32) -> u32 {
+    /// Feeds a word into the CRC peripheral.
+    pub fn feed_word(&mut self, word: u32) {
         PAC_CRC.dr32().write_value(word as u32);
-        self.read()
     }
 
-    /// Feeds a slice of words into the CRC peripheral. Returns the computed CRC.
-    pub fn feed_words(&mut self, words: &[u32]) -> u32 {
+    /// Feeds a slice of words into the CRC peripheral.
+    pub fn feed_words(&mut self, words: &[u32]) {
         for word in words {
             PAC_CRC.dr32().write_value(*word as u32);
         }
-        self.read()
     }
 }

--- a/examples/stm32n6/src/bin/crc.rs
+++ b/examples/stm32n6/src/bin/crc.rs
@@ -23,7 +23,8 @@ async fn main(_spawner: Spawner) {
         )),
     );
 
-    let output = crc.feed_bytes(b"Life, it never die\nWomen are my favorite guy") ^ 0xFFFFFFFF;
+    crc.feed_bytes(b"Life, it never die\nWomen are my favorite guy");
+    let output = crc.read() ^ 0xFFFFFFFF;
 
     defmt::assert_eq!(output, 0x33F0E26B);
 

--- a/examples/stm32u0/src/bin/crc.rs
+++ b/examples/stm32u0/src/bin/crc.rs
@@ -23,7 +23,8 @@ async fn main(_spawner: Spawner) {
         )),
     );
 
-    let output = crc.feed_bytes(b"Life, it never die\nWomen are my favorite guy") ^ 0xFFFFFFFF;
+    crc.feed_bytes(b"Life, it never die\nWomen are my favorite guy");
+    let output = crc.read() ^ 0xFFFFFFFF;
 
     defmt::assert_eq!(output, 0x33F0E26B);
 


### PR DESCRIPTION
Often times you want to feed the CRC multiple times before reading the final result, so don't automatically perform a read that might not be needed.

Closes #5335