### PR TITLE
[MCXA] i2c/i3c: let application choose clock source

### DIFF
--- a/embassy-mcxa/src/i3c/controller.rs
+++ b/embassy-mcxa/src/i3c/controller.rs
@@ -127,6 +127,9 @@ pub struct Config {
 
     /// I2C bus speed
     pub i2c_speed: Speed,
+
+    /// Clock configuration
+    pub clock_config: ClockConfig,
 }
 
 impl Default for Config {
@@ -135,6 +138,29 @@ impl Default for Config {
             push_pull_freq: 1_500_000,
             open_drain_freq: 750_000,
             i2c_speed: Speed::Fast,
+            clock_config: ClockConfig::default(),
+        }
+    }
+}
+
+/// I3C controller clock configuration
+#[derive(Clone)]
+#[non_exhaustive]
+pub struct ClockConfig {
+    /// Powered clock configuration
+    pub power: PoweredClock,
+    /// I3C clock source
+    pub source: I3cClockSel,
+    /// I3C pre-divider
+    pub div: Div4,
+}
+
+impl Default for ClockConfig {
+    fn default() -> Self {
+        Self {
+            power: PoweredClock::NormalEnabledDeepSleepDisabled,
+            source: I3cClockSel::FroLfDiv,
+            div: const { Div4::no_div() },
         }
     }
 }
@@ -162,7 +188,7 @@ impl<'d, M: Mode> I3c<'d, M> {
         config: Config,
         mode: M,
     ) -> Result<Self, SetupError> {
-        let (power, source, div) = Self::clock_config();
+        let ClockConfig { power, source, div } = config.clock_config;
 
         // Enable clocks
         let conf = I3cConfig { power, source, div };
@@ -187,15 +213,6 @@ impl<'d, M: Mode> I3c<'d, M> {
         inst.set_configuration(&config)?;
 
         Ok(inst)
-    }
-
-    // REVISIT: turn this into a function of the speed parameter
-    fn clock_config() -> (PoweredClock, I3cClockSel, Div4) {
-        (
-            PoweredClock::NormalEnabledDeepSleepDisabled,
-            I3cClockSel::FroLfDiv,
-            const { Div4::no_div() },
-        )
     }
 
     fn set_configuration(&self, config: &Config) -> Result<(), SetupError> {


### PR DESCRIPTION
Instead of attemping to guess which clock source to use, let the application tell us which one to use, just like SPI and I2C Target drivers.