### PR TITLE
Fix lint warning for direct cast of fn to integer, for #5514

### DIFF
--- a/embassy-rp/src/multicore.rs
+++ b/embassy-rp/src/multicore.rs
@@ -254,7 +254,7 @@ where
         1,
         vector_table as usize,
         stack_ptr as usize,
-        core1_startup::<F> as usize,
+        core1_startup::<F> as *const () as usize,
     ];
 
     let mut seq = 0;


### PR DESCRIPTION
embassy-rp/src/multicore.rs throws a lint warning for direct cast of fn to usize. This PR fixes it by following the compiler's suggestion, casting through a pointer first.

Github's Actions CI builds in a project of mine promoted this warning to an error and I had trouble turning this down.