### PR TITLE
Fix USB CDC NCM endpoint allocation ordering

### DIFF
--- a/embassy-usb/src/class/cdc_ncm/mod.rs
+++ b/embassy-usb/src/class/cdc_ncm/mod.rs
@@ -313,8 +313,6 @@ impl<'d, D: Driver<'d>> CdcNcmClass<'d, D> {
             ],
         );
 
-        let comm_ep = alt.endpoint_interrupt_in(None, 8, 255);
-
         // Data interface
         let mut iface = func.interface();
         let data_if = iface.interface_number();
@@ -322,6 +320,8 @@ impl<'d, D: Driver<'d>> CdcNcmClass<'d, D> {
         let mut alt = iface.alt_setting(USB_CLASS_CDC_DATA, 0x00, CDC_PROTOCOL_NTB, None);
         let read_ep = alt.endpoint_bulk_out(None, max_packet_size);
         let write_ep = alt.endpoint_bulk_in(None, max_packet_size);
+
+        let comm_ep = alt.endpoint_interrupt_in(None, 8, 255);
 
         drop(func);
 


### PR DESCRIPTION
The USB CDC NCM device enumerates correctly on my Ubuntu 24.04 machine, but the interface stays down. I use an STM32F405RGT7 chip.

Allocating a dummy `endpoint_interrupt_in(None, 8, 255);` after `comm_ep` also fixes the issue. Specifying the endpoint numbers as well.

I suspect that allowing the endpoint allocation to do its thing allocates 0x02 for the bulk in, and 0x81 for the bulk out, leading to a mismatch. They should be on 0x01/0x81, or 0x02/0x82.

Moving the `comm_ep` allocation after the bulk endpoint allocations therefore fixes the mismatch.