### PR TITLE
Expose `embassy_stm32::net::sma::Instance` publicly.

### DIFF
--- a/embassy-stm32/src/eth/mod.rs
+++ b/embassy-stm32/src/eth/mod.rs
@@ -16,7 +16,7 @@ use embassy_sync::waitqueue::AtomicWaker;
 
 pub use self::_version::{InterruptHandler, *};
 pub use self::generic_phy::*;
-pub use self::sma::{Sma, StationManagement};
+pub use self::sma::{Instance as SmaInstance, Sma, StationManagement};
 use crate::rcc::RccPeripheral;
 
 #[allow(unused)]


### PR DESCRIPTION
The trait itself is marked as `pub` but the `sma` sub-module it's part of is private, so re-expose the trait as `SmaInstance`.

This allows one to write application code that's generic in the eth::sma instance for MDIO and MDC pins.