### PR TITLE
Map I2S_SDI and I2S_SDO to I2sSdPin

### DIFF
--- a/embassy-stm32/build.rs
+++ b/embassy-stm32/build.rs
@@ -1071,6 +1071,8 @@ fn main() {
         (("spi", "I2S_CK"), quote!(crate::spi::CkPin)),
         (("spi", "I2S_WS"), quote!(crate::spi::WsPin)),
         (("spi", "I2S_SD"), quote!(crate::spi::I2sSdPin)),
+        (("spi", "I2S_SDI"), quote!(crate::spi::I2sSdPin)),
+        (("spi", "I2S_SDO"), quote!(crate::spi::I2sSdPin)),
         (("i2c", "SDA"), quote!(crate::i2c::SdaPin)),
         (("i2c", "SCL"), quote!(crate::i2c::SclPin)),
         (("rcc", "MCO_1"), quote!(crate::rcc::McoPin)),


### PR DESCRIPTION
`I2sSdPin` should be implemented for `I2S_SDI` and `I2S_SDO` to use the interface in txonly or rxonly mode