### PR TITLE
stm32/low-power: add STM32WBA wake-up handler and fix STOP mode mapping

### DIFF
--- a/examples/stm32wba-lp/.cargo/config.toml
+++ b/examples/stm32wba-lp/.cargo/config.toml
@@ -1,0 +1,8 @@
+[target.'cfg(all(target_arch = "arm", target_os = "none"))']
+runner = "probe-rs run --chip STM32WBA55CGUx"
+
+[build]
+target = "thumbv8m.main-none-eabihf"
+
+[env]
+DEFMT_LOG = "trace"

--- a/examples/stm32wba-lp/Cargo.toml
+++ b/examples/stm32wba-lp/Cargo.toml
@@ -1,0 +1,27 @@
+[package]
+edition = "2024"
+name = "embassy-stm32wba-lp-examples"
+version = "0.1.0"
+license = "MIT OR Apache-2.0"
+publish = false
+
+[dependencies]
+embassy-stm32 = { version = "0.5.0", path = "../../embassy-stm32", features = ["defmt", "stm32wba52cg", "time-driver-any", "memory-x", "unstable-pac", "exti", "low-power-pender"] }
+embassy-sync = { version = "0.7.2", path = "../../embassy-sync", features = ["defmt"] }
+embassy-executor = { version = "0.9.0", path = "../../embassy-executor", features = ["defmt"] }
+embassy-time = { version = "0.5.0", path = "../../embassy-time", features = ["defmt", "defmt-timestamp-uptime", "tick-hz-32_768"] }
+
+defmt = "1.0.1"
+defmt-rtt = "1.1.0"
+
+cortex-m = { version = "0.7.6", features = ["inline-asm", "critical-section-single-core"] }
+cortex-m-rt = "0.7.0"
+panic-probe = { version = "1.0.0", features = ["print-defmt"] }
+
+[profile.release]
+debug = 2
+
+[package.metadata.embassy]
+build = [
+  { target = "thumbv8m.main-none-eabihf", artifact-dir = "out/examples/stm32wba-lp" }
+]

--- a/examples/stm32wba-lp/build.rs
+++ b/examples/stm32wba-lp/build.rs
@@ -1,0 +1,10 @@
+use std::error::Error;
+
+fn main() -> Result<(), Box<dyn Error>> {
+    println!("cargo:rerun-if-changed=link.x");
+    println!("cargo:rustc-link-arg-bins=--nmagic");
+    println!("cargo:rustc-link-arg-bins=-Tlink.x");
+    println!("cargo:rustc-link-arg-bins=-Tdefmt.x");
+
+    Ok(())
+}

--- a/examples/stm32wba-lp/src/bin/blinky.rs
+++ b/examples/stm32wba-lp/src/bin/blinky.rs
@@ -1,0 +1,50 @@
+//! Blinky example with STOP mode.
+//!
+//! The MCU enters STOP mode between LED toggles (5 s intervals).
+//! Current draw drops to ~1 µA while sleeping; the RTC wakeup alarm
+//! brings the core back to run mode for the next toggle.
+
+#![no_std]
+#![no_main]
+
+use defmt::*;
+use embassy_executor::Spawner;
+use embassy_stm32::gpio::{Level, Output, Speed};
+use embassy_stm32::rcc::*;
+use embassy_time::Timer;
+use {defmt_rtt as _, panic_probe as _};
+
+#[embassy_executor::main(executor = "embassy_stm32::Executor", entry = "cortex_m_rt::entry")]
+async fn main(_spawner: Spawner) {
+    let mut config = embassy_stm32::Config::default();
+
+    // HSI 16 MHz as sysclk — no PLL needed for a blinky demo.
+    config.rcc.sys = Sysclk::HSI;
+
+    // LSI 32 kHz for the RTC — the time driver uses the RTC wakeup
+    // alarm to bring the core back from STOP mode.
+    config.rcc.ls = LsConfig {
+        rtc: RtcClockSource::LSI,
+        lsi: true,
+        lse: None,
+    };
+
+    // Disable debug peripherals during STOP to minimise leakage.
+    // Set to `true` when debugging with probe-rs / RTT.
+    config.enable_debug_during_sleep = false;
+
+    let p = embassy_stm32::init(config);
+    info!("Hello from STM32WBA low-power blinky!");
+
+    let mut led = Output::new(p.PB4, Level::High, Speed::Low);
+
+    loop {
+        info!("led on — sleeping 5 s");
+        led.set_high();
+        Timer::after_millis(5000).await; // MCU enters STOP here
+
+        info!("led off — sleeping 5 s");
+        led.set_low();
+        Timer::after_millis(5000).await; // MCU enters STOP here
+    }
+}

--- a/examples/stm32wba-lp/src/bin/button_exti.rs
+++ b/examples/stm32wba-lp/src/bin/button_exti.rs
@@ -1,0 +1,57 @@
+//! EXTI button example with STOP mode.
+//!
+//! The MCU enters STOP mode while waiting for a button press on PC13.
+//! The EXTI line wakes the core from STOP — no polling required.
+//! Current draw drops to ~1 µA between presses.
+
+#![no_std]
+#![no_main]
+
+use defmt::*;
+use embassy_executor::Spawner;
+use embassy_stm32::exti::{self, ExtiInput};
+use embassy_stm32::gpio::Pull;
+use embassy_stm32::rcc::*;
+use embassy_stm32::{bind_interrupts, interrupt};
+use {defmt_rtt as _, panic_probe as _};
+
+bind_interrupts!(
+    pub struct Irqs {
+        EXTI13 => exti::InterruptHandler<interrupt::typelevel::EXTI13>;
+    }
+);
+
+#[embassy_executor::main(executor = "embassy_stm32::Executor", entry = "cortex_m_rt::entry")]
+async fn main(_spawner: Spawner) {
+    let mut config = embassy_stm32::Config::default();
+
+    // HSI 16 MHz as sysclk.
+    config.rcc.sys = Sysclk::HSI;
+
+    // LSI 32 kHz for the RTC — the time driver uses the RTC wakeup
+    // alarm to bring the core back from STOP mode.
+    config.rcc.ls = LsConfig {
+        rtc: RtcClockSource::LSI,
+        lsi: true,
+        lse: None,
+    };
+
+    // Disable debug peripherals during STOP to minimise leakage.
+    // Set to `true` when debugging with probe-rs / RTT.
+    config.enable_debug_during_sleep = false;
+
+    let p = embassy_stm32::init(config);
+    info!("Hello from STM32WBA low-power button example!");
+    info!("Press the USER button (PC13)...");
+
+    let mut button = ExtiInput::new(p.PC13, p.EXTI13, Pull::Up, Irqs);
+
+    loop {
+        // MCU enters STOP while waiting for the falling edge.
+        button.wait_for_falling_edge().await;
+        info!("Pressed!");
+
+        button.wait_for_rising_edge().await;
+        info!("Released!");
+    }
+}

--- a/examples/stm32wba6-lp/.cargo/config.toml
+++ b/examples/stm32wba6-lp/.cargo/config.toml
@@ -1,0 +1,8 @@
+[target.'cfg(all(target_arch = "arm", target_os = "none"))']
+runner = "probe-rs run --chip STM32WBA65RI"
+
+[build]
+target = "thumbv8m.main-none-eabihf"
+
+[env]
+DEFMT_LOG = "trace"

--- a/examples/stm32wba6-lp/Cargo.toml
+++ b/examples/stm32wba6-lp/Cargo.toml
@@ -1,0 +1,27 @@
+[package]
+edition = "2024"
+name = "embassy-stm32wba6-lp-examples"
+version = "0.1.0"
+license = "MIT OR Apache-2.0"
+publish = false
+
+[dependencies]
+embassy-stm32 = { version = "0.5.0", path = "../../embassy-stm32", features = ["defmt", "stm32wba65ri", "time-driver-any", "memory-x", "unstable-pac", "exti", "low-power-pender"] }
+embassy-sync = { version = "0.7.2", path = "../../embassy-sync", features = ["defmt"] }
+embassy-executor = { version = "0.9.0", path = "../../embassy-executor", features = ["defmt"] }
+embassy-time = { version = "0.5.0", path = "../../embassy-time", features = ["defmt", "defmt-timestamp-uptime", "tick-hz-32_768"] }
+
+defmt = "1.0.1"
+defmt-rtt = "1.1.0"
+
+cortex-m = { version = "0.7.6", features = ["inline-asm", "critical-section-single-core"] }
+cortex-m-rt = "0.7.0"
+panic-probe = { version = "1.0.0", features = ["print-defmt"] }
+
+[profile.release]
+debug = 2
+
+[package.metadata.embassy]
+build = [
+  { target = "thumbv8m.main-none-eabihf", artifact-dir = "out/examples/stm32wba6-lp" }
+]

--- a/examples/stm32wba6-lp/build.rs
+++ b/examples/stm32wba6-lp/build.rs
@@ -1,0 +1,10 @@
+use std::error::Error;
+
+fn main() -> Result<(), Box<dyn Error>> {
+    println!("cargo:rerun-if-changed=link.x");
+    println!("cargo:rustc-link-arg-bins=--nmagic");
+    println!("cargo:rustc-link-arg-bins=-Tlink.x");
+    println!("cargo:rustc-link-arg-bins=-Tdefmt.x");
+
+    Ok(())
+}

--- a/examples/stm32wba6-lp/src/bin/blinky.rs
+++ b/examples/stm32wba6-lp/src/bin/blinky.rs
@@ -1,0 +1,54 @@
+//! Blinky example with STOP mode.
+//!
+//! The MCU enters STOP mode between LED toggles (5 s intervals).
+//! Current draw drops to ~1 µA while sleeping; the RTC wakeup alarm
+//! brings the core back to run mode for the next toggle.
+
+#![no_std]
+#![no_main]
+
+use defmt::*;
+use embassy_executor::Spawner;
+use embassy_stm32::gpio::{Level, Output, Speed};
+use embassy_stm32::rcc::*;
+use embassy_time::Timer;
+use {defmt_rtt as _, panic_probe as _};
+
+#[embassy_executor::main(executor = "embassy_stm32::Executor", entry = "cortex_m_rt::entry")]
+async fn main(_spawner: Spawner) {
+    let mut config = embassy_stm32::Config::default();
+
+    // HSI 16 MHz as sysclk — no PLL needed for a blinky demo.
+    config.rcc.sys = Sysclk::HSI;
+
+    // LSI 32 kHz for the RTC — the time driver uses the RTC wakeup
+    // alarm to bring the core back from STOP mode.
+    config.rcc.ls = LsConfig {
+        rtc: RtcClockSource::LSI,
+        lsi: true,
+        lse: None,
+    };
+
+    // SAI1 clock mux defaults to PLL1_P — override to HSI since
+    // PLL1 is not configured in this demo.
+    config.rcc.mux.sai1sel = Sai1sel::HSI;
+
+    // Disable debug peripherals during STOP to minimise leakage.
+    // Set to `true` when debugging with probe-rs / RTT.
+    config.enable_debug_during_sleep = false;
+
+    let p = embassy_stm32::init(config);
+    info!("Hello from STM32WBA6 low-power blinky!");
+
+    let mut led = Output::new(p.PB4, Level::High, Speed::Low);
+
+    loop {
+        info!("led on — sleeping 5 s");
+        led.set_high();
+        Timer::after_millis(5000).await; // MCU enters STOP here
+
+        info!("led off — sleeping 5 s");
+        led.set_low();
+        Timer::after_millis(5000).await; // MCU enters STOP here
+    }
+}

--- a/examples/stm32wba6-lp/src/bin/button_exti.rs
+++ b/examples/stm32wba6-lp/src/bin/button_exti.rs
@@ -1,0 +1,61 @@
+//! EXTI button example with STOP mode.
+//!
+//! The MCU enters STOP mode while waiting for a button press on PC13.
+//! The EXTI line wakes the core from STOP — no polling required.
+//! Current draw drops to ~1 µA between presses.
+
+#![no_std]
+#![no_main]
+
+use defmt::*;
+use embassy_executor::Spawner;
+use embassy_stm32::exti::{self, ExtiInput};
+use embassy_stm32::gpio::Pull;
+use embassy_stm32::rcc::*;
+use embassy_stm32::{bind_interrupts, interrupt};
+use {defmt_rtt as _, panic_probe as _};
+
+bind_interrupts!(
+    pub struct Irqs {
+        EXTI13 => exti::InterruptHandler<interrupt::typelevel::EXTI13>;
+    }
+);
+
+#[embassy_executor::main(executor = "embassy_stm32::Executor", entry = "cortex_m_rt::entry")]
+async fn main(_spawner: Spawner) {
+    let mut config = embassy_stm32::Config::default();
+
+    // HSI 16 MHz as sysclk.
+    config.rcc.sys = Sysclk::HSI;
+
+    // LSI 32 kHz for the RTC — the time driver uses the RTC wakeup
+    // alarm to bring the core back from STOP mode.
+    config.rcc.ls = LsConfig {
+        rtc: RtcClockSource::LSI,
+        lsi: true,
+        lse: None,
+    };
+
+    // SAI1 clock mux defaults to PLL1_P — override to HSI since
+    // PLL1 is not configured in this demo.
+    config.rcc.mux.sai1sel = Sai1sel::HSI;
+
+    // Disable debug peripherals during STOP to minimise leakage.
+    // Set to `true` when debugging with probe-rs / RTT.
+    config.enable_debug_during_sleep = false;
+
+    let p = embassy_stm32::init(config);
+    info!("Hello from STM32WBA6 low-power button example!");
+    info!("Press the USER button (PC13)...");
+
+    let mut button = ExtiInput::new(p.PC13, p.EXTI13, Pull::Up, Irqs);
+
+    loop {
+        // MCU enters STOP while waiting for the falling edge.
+        button.wait_for_falling_edge().await;
+        info!("Pressed!");
+
+        button.wait_for_rising_edge().await;
+        info!("Released!");
+    }
+}


### PR DESCRIPTION
The STM32WBA series was missing from the on_wakeup_irq_or_event() handler, causing the clock tree and time driver to not be re-initialized after waking from STOP modes. This resulted in the system hanging on wake.

Changes:
- Fix STOP mode mapping: WBA STOP2 is auto-entered by hardware when LPMS=STOP0 and the 2.4 GHz radio is in deep sleep. Map Stop2/Standby to STOP0 instead of STOP1.
- Add WBA-specific wakeup handler that reads PWR.SR().stopf()/stop2f(), re-initializes RCC, clears stop flags via CSSF, and re-initializes the time driver.
- Clear WBA stop flags in configure_pwr() before entering STOP to prevent stale flags from triggering false wakeup detection.