### PR TITLE
fix: use correct pins in nRF54L15 SPIM example

### DIFF
--- a/examples/nrf54l15/src/bin/spim.rs
+++ b/examples/nrf54l15/src/bin/spim.rs
@@ -14,7 +14,7 @@ async fn main(_spawner: Spawner) {
     let p = embassy_nrf::init(Default::default());
     let mut config = spim::Config::default();
     config.frequency = spim::Frequency::M32;
-    let mut spim = spim::Spim::new(p.SERIAL00, Irqs, p.P2_05, p.P2_09, p.P2_08, config.clone());
+    let mut spim = spim::Spim::new(p.SERIAL00, Irqs, p.P2_01, p.P2_04, p.P2_02, config.clone());
     let data = [
         0x42, 0x43, 0x44, 0x45, 0x66, 0x12, 0x23, 0x34, 0x45, 0x19, 0x91, 0xaa, 0xff, 0xa5, 0x5a, 0x77,
     ];


### PR DESCRIPTION
Pins in the P2 peripheral region have dedicated purposes. Currently, the nRF54L15 example uses P2.05 as the clock pin which is not capable of that. I also adjusted the other pins to use the lowest pin number that supports the given function to ensure the example works on the QFN40 variant which has less pins (it lacks P2.09 for example)
