### PR TITLE
[MCXA] trng: add Instance trait

### DIFF
--- a/embassy-mcxa/src/perf_counters.rs
+++ b/embassy-mcxa/src/perf_counters.rs
@@ -188,8 +188,8 @@ define_counters!(
     interrupt_spi0_wake,
     interrupt_spi1,
     interrupt_spi1_wake,
-    interrupt_trng,
-    interrupt_trng_wake,
+    interrupt_trng0,
+    interrupt_trng0_wake,
     interrupt_wwdt,
     wfe_sleeps
 );

--- a/examples/mcxa2xx/src/bin/trng.rs
+++ b/examples/mcxa2xx/src/bin/trng.rs
@@ -4,6 +4,7 @@
 use embassy_executor::Spawner;
 use hal::bind_interrupts;
 use hal::config::Config;
+use hal::peripherals::TRNG0;
 use hal::trng::{self, InterruptHandler, Trng};
 use rand_core::RngCore;
 use rand_core::block::BlockRngCore;
@@ -11,7 +12,7 @@ use {defmt_rtt as _, embassy_mcxa as hal, panic_probe as _};
 
 bind_interrupts!(
     struct Irqs {
-        TRNG0 => InterruptHandler;
+        TRNG0 => InterruptHandler<TRNG0>;
     }
 );
 

--- a/tests/mcxa2xx/src/bin/trng.rs
+++ b/tests/mcxa2xx/src/bin/trng.rs
@@ -6,13 +6,14 @@ teleprobe_meta::target!(b"frdm-mcx-a266");
 use embassy_executor::Spawner;
 use hal::bind_interrupts;
 use hal::config::Config;
+use hal::peripherals::TRNG0;
 use hal::trng::{self, InterruptHandler, Trng};
 use rand_core::RngCore;
 use {defmt_rtt as _, embassy_mcxa as hal, panic_probe as _};
 
 bind_interrupts!(
     struct Irqs {
-        TRNG0 => InterruptHandler;
+        TRNG0 => InterruptHandler<TRNG0>;
     }
 );
 


### PR DESCRIPTION
Instead of assuming the existence of a unique singleton named TRNG0, add an Instance trait and depend on that instead.