### PR TITLE
Do not flush the wrong fifo

### DIFF
--- a/embassy-usb-synopsys-otg/CHANGELOG.md
+++ b/embassy-usb-synopsys-otg/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 <!-- next-header -->
 ## Unreleased - ReleaseDate
 
+- Disabling an OUT endpoint no longer flushes the TX FIFO of the corresponding IN endpoint
+
 ## 0.3.1 - 2025-08-26
 
 - Improve receive performance, more efficient copy from FIFO


### PR DESCRIPTION
When disabling an OUT endpoint, the previous implementation flushed a TX FIFO, but TX FIFOs are assigned to IN endpoints.

I think this closes (maybe not, though?) #5521 as the PR fixes an identical-looking issue on the ESP32-S3, and the F405 uses a different version of the same IP.