### PR TITLE
Add most cargo configs to gitignore.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,6 @@ out/
 *.vim
 **/.idea
 **/.nvim.lua
+**/.cargo
+!**/tests/**/.cargo
+!**/examples/**/.cargo


### PR DESCRIPTION
Cargo configs that are not in the tests and examples directory should probably not exist. This config will stop those files from being accidentally checked in.

FTR, I know that I am making a pretty sweeping assumption here. I would like to discuss this change if there are any concerns.

Also, I would like to note that I am using a local .cargo/config.toml to override some deps until the changes get checked into upstream repos. I am trying to make sure that it's not possible to check in these kinds of local configs.

Also, I looked through the repo, and there do appear to be legitimate uses in the examples and tests, so I did want to exclude those from this rule.

Thanks!