### PR TITLE
[MCXA] add DMA functions for un-aligned and SW start transfers (SGI use)

### DIFF
--- a/embassy-mcxa/src/dma.rs
+++ b/embassy-mcxa/src/dma.rs
@@ -1136,7 +1136,6 @@ impl DmaChannel<'_> {
         let ssize = S::size();
         let dsize = D::size();
         let sbytes = ssize.bytes();
-        let dbytes = dsize.bytes();
         let total_bytes = buf.len() * sbytes;
 
         let t = self.tcd();


### PR DESCRIPTION
Two new public functions are added. 
'write_to_peripheral_mixed' allows bytes/half words to full word (u32) writes (will be useful for future symmetric SGI operations)
'write_to_peripheral_mixed_software_start' allows all the bytes to be transferred in one loop (used for filling the SHA2 AUTO FIFO in DMA mode.
