### PR TITLE
Fix enabling DMA on FIFO for USART configuration

### DIFF
--- a/embassy-nxp/src/usart/lpc55.rs
+++ b/embassy-nxp/src/usart/lpc55.rs
@@ -696,7 +696,7 @@ impl<'d, M: Mode> Usart<'d, M> {
         // DMA-related settings
         registers.fifocfg().modify(|w| {
             w.set_dmatx(false);
-            w.set_dmatx(false);
+            w.set_dmarx(false);
         });
 
         // Enabling USART


### PR DESCRIPTION
This is an untested change as I do not have a S69, but the duplication looks like a typo. I'm assuming that DMA was supposed to be enable on the RX direction also.