### PR TITLE
[MCXA] Add `Instance` for WWDT driver

### DIFF
--- a/embassy-mcxa/src/chips/mcxa5xx.rs
+++ b/embassy-mcxa/src/chips/mcxa5xx.rs
@@ -303,6 +303,7 @@ mod inner_periph {
         // WAKETIMER0,
         // WUU0,
         WWDT0,
+        WWDT1,
     );
 }
 
@@ -412,6 +413,7 @@ mod inner_interrupt {
         // WAKETIMER0,
         // WUU0,
         WWDT0,
+        WWDT1,
     );
 }
 

--- a/embassy-mcxa/src/wwdt.rs
+++ b/embassy-mcxa/src/wwdt.rs
@@ -6,15 +6,16 @@
 //!
 //! The FRO12M provides a 1 MHz clock (clk_1m) used as WWDT0 independant clock source. This clock is / 4 by an internal fixed divider.
 
-use embassy_hal_internal::Peri;
-use embassy_hal_internal::interrupt::InterruptExt;
+use core::marker::PhantomData;
+
+use embassy_hal_internal::{Peri, PeripheralType};
 use embassy_time::Duration;
+use paste::paste;
 
 use crate::interrupt::typelevel;
-use crate::interrupt::typelevel::Handler;
+use crate::interrupt::typelevel::{Handler, Interrupt};
 use crate::pac;
 use crate::pac::wwdt::vals::{Wden, Wdprotect, Wdreset};
-use crate::peripherals::WWDT0;
 
 /// WWDT0 Error types
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -44,28 +45,29 @@ impl Default for Config {
 
 /// Watchdog peripheral
 pub struct Watchdog<'d> {
-    _peri: Peri<'d, WWDT0>,
-    // The register block of the WWDT instance
-    info: pac::wwdt::Wwdt,
+    info: &'static Info,
+    _phantom: PhantomData<&'d mut ()>,
 }
 
 impl<'d> Watchdog<'d> {
     /// Create a new WWDT instance.
+    ///
     /// Configure the WWDT, enables the interrupt, set the timeout and or warning value.
     ///
     /// # Arguments
     ///
-    /// * `_peri` - The WWDT0 peripheral instance
+    /// * `_peri` - The WWDT peripheral instance
     /// * `_irq` - Interrupt binding for WWDT0
-    /// * `config - WWDT0 config with timeout and optional warning value
-    pub fn new(
-        _peri: Peri<'d, WWDT0>,
-        _irq: impl crate::interrupt::typelevel::Binding<typelevel::WWDT0, InterruptHandler> + 'd,
+    /// * `config - WWDT config with timeout and optional warning value
+    pub fn new<T: Instance>(
+        _peri: Peri<'d, T>,
+        _irq: impl crate::interrupt::typelevel::Binding<T::Interrupt, InterruptHandler<T>> + 'd,
         config: Config,
     ) -> Result<Self, Error> {
-        let info = pac::WWDT0;
-
-        let watchdog = Self { _peri, info };
+        let watchdog = Self {
+            info: T::info(),
+            _phantom: PhantomData,
+        };
 
         let base_frequency = crate::clocks::with_clocks(|clocks| {
             // Ensure clk_1m is active at the required power level
@@ -90,6 +92,7 @@ impl<'d> Watchdog<'d> {
         if timeout_cycles > 0xFFFFFF {
             return Err(Error::TimeoutTooLarge);
         }
+
         if timeout_cycles <= 0xFF {
             return Err(Error::TimeoutTooSmall);
         }
@@ -112,10 +115,12 @@ impl<'d> Watchdog<'d> {
 
         watchdog.lock_oscillator();
 
-        crate::pac::Interrupt::WWDT0.unpend();
+        T::Interrupt::unpend();
 
         // Safety: `_irq` ensures an Interrupt Handler exists.
-        unsafe { crate::pac::Interrupt::WWDT0.enable() };
+        unsafe {
+            T::Interrupt::enable();
+        }
 
         Ok(watchdog)
     }
@@ -135,31 +140,31 @@ impl<'d> Watchdog<'d> {
     /// the watchdog from triggering a reset or interrupt.
     pub fn feed(&self) {
         critical_section::with(|_cs| {
-            self.info.feed().write(|w| w.set_feed(0xAA));
-            self.info.feed().write(|w| w.set_feed(0x55));
+            self.info.regs().feed().write(|w| w.set_feed(0xAA));
+            self.info.regs().feed().write(|w| w.set_feed(0x55));
         });
     }
 
     /// Enable the watchdog timer.
     /// Function is blocking until the watchdog is actually started.
     fn enable(&self) {
-        self.info.mod_().modify(|w| w.set_wden(Wden::RUN));
-        while self.info.tc().read().count() == 0xFF {}
+        self.info.regs().mod_().modify(|w| w.set_wden(Wden::RUN));
+        while self.info.regs().tc().read().count() == 0xFF {}
     }
 
     /// Set the watchdog protection mode to flexible.
     fn set_flexible_mode(&self) {
-        self.info.mod_().modify(|w| w.set_wdprotect(Wdprotect::FLEXIBLE));
+        self.info.regs().mod_().modify(|w| w.set_wdprotect(Wdprotect::FLEXIBLE));
     }
 
     /// Enable interrupt mode.
     fn enable_interrupt(&self) {
-        self.info.mod_().modify(|w| w.set_wdreset(Wdreset::INTERRUPT));
+        self.info.regs().mod_().modify(|w| w.set_wdreset(Wdreset::INTERRUPT));
     }
 
     /// Enable reset mode.
     fn enable_reset(&self) {
-        self.info.mod_().modify(|w| w.set_wdreset(Wdreset::RESET));
+        self.info.regs().mod_().modify(|w| w.set_wdreset(Wdreset::RESET));
     }
 
     /// Set the timeout value in clock cycles.
@@ -168,7 +173,7 @@ impl<'d> Watchdog<'d> {
     ///
     /// * `timeout` - Number of clock cycles before timeout.
     fn set_timeout_value(&self, timeout: u32) {
-        self.info.tc().write(|w| w.set_count(timeout));
+        self.info.regs().tc().write(|w| w.set_count(timeout));
     }
 
     /// Set the warning interrupt value in clock cycles.
@@ -177,38 +182,88 @@ impl<'d> Watchdog<'d> {
     ///
     /// * `warning` - Number of clock cycles before warning interrupt.
     fn set_warning_value(&self, warning: u16) {
-        self.info.warnint().write(|w| w.set_warnint(warning));
+        self.info.regs().warnint().write(|w| w.set_warnint(warning));
     }
 
     /// Lock the oscillator to prevent disabling or powering down the watchdog oscillator.
     fn lock_oscillator(&self) {
-        self.info.mod_().modify(|w| w.set_lock(true));
+        self.info.regs().mod_().modify(|w| w.set_lock(true));
     }
 }
 
-/// WWDT0 interrupt handler.
+/// WWDT interrupt handler.
 ///
 /// This handler is called when the watchdog warning interrupt fires.
 /// When reset happens, the interrupt handler will never be reached.
-pub struct InterruptHandler;
+pub struct InterruptHandler<T: Instance> {
+    _phantom: PhantomData<T>,
+}
 
-impl Handler<typelevel::WWDT0> for InterruptHandler {
+impl<T: Instance> Handler<T::Interrupt> for InterruptHandler<T> {
     unsafe fn on_interrupt() {
         crate::perf_counters::incr_interrupt_wwdt();
-        let wwdt = pac::WWDT0;
-
-        if wwdt.mod_().read().wdtof() {
+        if T::info().regs().mod_().read().wdtof() {
             #[cfg(feature = "defmt")]
             defmt::trace!("WWDT0: Timeout occurred");
 
-            wwdt.mod_().modify(|w| w.set_wdtof(true));
+            T::info().regs().mod_().modify(|w| w.set_wdtof(true));
         }
 
-        if wwdt.mod_().read().wdint() {
+        if T::info().regs().mod_().read().wdint() {
             #[cfg(feature = "defmt")]
-            defmt::trace!("WWDT0: Warning interrupt");
+            defmt::trace!("T::INFO().REGS()0: Warning interrupt");
 
-            wwdt.mod_().modify(|w| w.set_wdint(true));
+            T::info().regs().mod_().modify(|w| w.set_wdint(true));
         }
     }
 }
+
+trait SealedInstance {
+    fn info() -> &'static Info;
+}
+
+/// WWDT Instance
+#[allow(private_bounds)]
+pub trait Instance: SealedInstance + PeripheralType + 'static + Send {
+    /// Interrupt for this WWDT instance.
+    type Interrupt: typelevel::Interrupt;
+}
+
+struct Info {
+    regs: pac::wwdt::Wwdt,
+}
+
+impl Info {
+    #[inline(always)]
+    fn regs(&self) -> pac::wwdt::Wwdt {
+        self.regs
+    }
+}
+
+unsafe impl Sync for Info {}
+
+macro_rules! impl_instance {
+    ($($n:literal);*) => {
+        $(
+            paste!{
+                impl SealedInstance for crate::peripherals::[<WWDT $n>] {
+                    fn info() -> &'static Info {
+                        static INFO: Info = Info {
+                            regs: pac::[<WWDT $n>],
+                        };
+                        &INFO
+                    }
+                }
+
+                impl Instance for crate::peripherals::[<WWDT $n>] {
+                    type Interrupt = crate::interrupt::typelevel::[<WWDT $n>];
+                }
+            }
+        )*
+    };
+}
+
+impl_instance!(0);
+
+#[cfg(feature = "mcxa5xx")]
+impl_instance!(1);

--- a/examples/mcxa2xx/src/bin/wwdt_interrupt.rs
+++ b/examples/mcxa2xx/src/bin/wwdt_interrupt.rs
@@ -6,12 +6,13 @@ use embassy_time::{Duration, Timer};
 use hal::bind_interrupts;
 use hal::config::Config;
 use hal::gpio::{DriveStrength, Level, Output, SlewRate};
+use hal::peripherals::WWDT0;
 use hal::wwdt::{InterruptHandler, Watchdog};
 use {defmt_rtt as _, embassy_mcxa as hal, panic_probe as _};
 
 bind_interrupts!(
     struct Irqs {
-        WWDT0 => InterruptHandler;
+        WWDT0 => InterruptHandler<WWDT0>;
     }
 );
 

--- a/examples/mcxa2xx/src/bin/wwdt_reset.rs
+++ b/examples/mcxa2xx/src/bin/wwdt_reset.rs
@@ -6,12 +6,13 @@ use embassy_time::{Duration, Timer};
 use hal::bind_interrupts;
 use hal::config::Config;
 use hal::gpio::{DriveStrength, Level, Output, SlewRate};
+use hal::peripherals::WWDT0;
 use hal::wwdt::{InterruptHandler, Watchdog};
 use {defmt_rtt as _, embassy_mcxa as hal, panic_probe as _};
 
 bind_interrupts!(
     struct Irqs {
-        WWDT0 => InterruptHandler;
+        WWDT0 => InterruptHandler<WWDT0>;
     }
 );
 

--- a/examples/mcxa5xx/src/bin/wwdt_interrupt.rs
+++ b/examples/mcxa5xx/src/bin/wwdt_interrupt.rs
@@ -6,12 +6,13 @@ use embassy_time::{Duration, Timer};
 use hal::bind_interrupts;
 use hal::config::Config;
 use hal::gpio::{DriveStrength, Level, Output, SlewRate};
+use hal::peripherals::WWDT0;
 use hal::wwdt::{InterruptHandler, Watchdog};
 use {defmt_rtt as _, embassy_mcxa as hal, panic_probe as _};
 
 bind_interrupts!(
     struct Irqs {
-        WWDT0 => InterruptHandler;
+        WWDT0 => InterruptHandler<WWDT0>;
     }
 );
 
@@ -28,7 +29,7 @@ async fn main(_spawner: Spawner) {
     };
 
     let mut watchdog = Watchdog::new(p.WWDT0, Irqs, wwdt_config).unwrap();
-    let mut led = Output::new(p.P3_18, Level::High, DriveStrength::Normal, SlewRate::Fast);
+    let mut led = Output::new(p.P2_14, Level::High, DriveStrength::Normal, SlewRate::Fast);
 
     // Set the LED high for 2 seconds so we know when we're about to start the watchdog
     led.toggle();

--- a/examples/mcxa5xx/src/bin/wwdt_reset.rs
+++ b/examples/mcxa5xx/src/bin/wwdt_reset.rs
@@ -6,12 +6,13 @@ use embassy_time::{Duration, Timer};
 use hal::bind_interrupts;
 use hal::config::Config;
 use hal::gpio::{DriveStrength, Level, Output, SlewRate};
+use hal::peripherals::WWDT0;
 use hal::wwdt::{InterruptHandler, Watchdog};
 use {defmt_rtt as _, embassy_mcxa as hal, panic_probe as _};
 
 bind_interrupts!(
     struct Irqs {
-        WWDT0 => InterruptHandler;
+        WWDT0 => InterruptHandler<WWDT0>;
     }
 );
 

--- a/tests/mcxa2xx/src/bin/wwdt_interrupt.rs
+++ b/tests/mcxa2xx/src/bin/wwdt_interrupt.rs
@@ -3,27 +3,31 @@
 
 teleprobe_meta::target!(b"frdm-mcx-a266");
 
+use core::marker::PhantomData;
 use core::sync::atomic::{AtomicBool, Ordering};
 
 use embassy_executor::Spawner;
 use embassy_time::{Duration, Timer};
 use hal::bind_interrupts;
 use hal::config::Config;
-use hal::interrupt::typelevel::{Handler, WWDT0};
-use hal::wwdt::{InterruptHandler, Watchdog};
+use hal::interrupt::typelevel::{self, Handler};
+use hal::peripherals::WWDT0;
+use hal::wwdt::{Instance, InterruptHandler, Watchdog};
 use {defmt_rtt as _, embassy_mcxa as hal, panic_probe as _};
 
 bind_interrupts!(
     struct Irqs {
-        WWDT0 => InterruptHandler, TestInterruptHandler;
+        WWDT0 => InterruptHandler<WWDT0>, TestInterruptHandler<WWDT0>;
     }
 );
 
 static INTERRUPT_TRIGGERED: AtomicBool = AtomicBool::new(false);
 
-pub struct TestInterruptHandler;
+pub struct TestInterruptHandler<T: Instance> {
+    _phantom: PhantomData<T>,
+}
 
-impl Handler<WWDT0> for TestInterruptHandler {
+impl<T: Instance> Handler<typelevel::WWDT0> for TestInterruptHandler<T> {
     unsafe fn on_interrupt() {
         INTERRUPT_TRIGGERED.store(true, Ordering::Relaxed);
     }


### PR DESCRIPTION
MCXA5 has two WWDT instances. Let's support both.

While at that, also correct the GPIO used for the red LED on the example.

Closes https://github.com/OpenDevicePartnership/embassy-mcxa/issues/173