### PR TITLE
embassy-usb-driver: remove dependency on `embedded-io-async`

### DIFF
--- a/embassy-usb-driver/CHANGELOG.md
+++ b/embassy-usb-driver/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## Unreleased - ReleaseDate
 
 - Add `EndpointOut::read_data()` and `EndpointIn::write_data()` provided methods.
+- Remove dependency on `embedded_io_async`
 
 ## 0.2.0 - 2025-07-16
 

--- a/embassy-usb-driver/Cargo.toml
+++ b/embassy-usb-driver/Cargo.toml
@@ -19,8 +19,6 @@ target = "thumbv7em-none-eabi"
 features = ["defmt"]
 
 [dependencies]
-# TODO: remove before releasing embassy-usb-driver v0.3
-embedded-io-async = "0.7.0"
 defmt = { version = "1", optional = true }
 
 [features]

--- a/embassy-usb-driver/src/lib.rs
+++ b/embassy-usb-driver/src/lib.rs
@@ -429,16 +429,6 @@ pub enum EndpointError {
     Disabled,
 }
 
-// TODO: remove before releasing embassy-usb-driver v0.3
-impl embedded_io_async::Error for EndpointError {
-    fn kind(&self) -> embedded_io_async::ErrorKind {
-        match self {
-            Self::BufferOverflow => embedded_io_async::ErrorKind::OutOfMemory,
-            Self::Disabled => embedded_io_async::ErrorKind::NotConnected,
-        }
-    }
-}
-
 impl core::fmt::Display for EndpointError {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         match self {


### PR DESCRIPTION
`EndpointError` is no longer being used as the error type for any `embedded-io-async` impls in `embedded-usb` which was the original reason for the dependency. It has been previously expressed that we would like to remove this dependency so that `embassy-usb-driver` doesn't need to be released each time `embedded-io-async` updates.