### PR TITLE
[MCXA] Add support for reset-less peripherals

### DIFF
--- a/embassy-mcxa/src/chips/mcxa2xx.rs
+++ b/embassy-mcxa/src/chips/mcxa2xx.rs
@@ -716,7 +716,8 @@ pub(crate) mod peripheral_gating {
 
     use crate::clocks::Gate;
     use crate::clocks::periph_helpers::{
-        AdcConfig, CTimerConfig, I3cConfig, Lpi2cConfig, LpspiConfig, LpuartConfig, NoConfig, OsTimerConfig,
+        AdcConfig, CTimerConfig, Clk1MConfig, I3cConfig, Lpi2cConfig, LpspiConfig, LpuartConfig, NoConfig,
+        OsTimerConfig,
     };
     use crate::{impl_cc_gate, pac};
 
@@ -772,6 +773,8 @@ pub(crate) mod peripheral_gating {
 
     impl_cc_gate!(LPSPI0, mrcc_glb_acc0, mrcc_glb_rst0, lpspi0, LpspiConfig);
     impl_cc_gate!(LPSPI1, mrcc_glb_acc0, mrcc_glb_rst0, lpspi1, LpspiConfig);
+
+    impl_cc_gate!(WWDT0, mrcc_glb_acc0, wwdt0, Clk1MConfig);
 }
 
 pub(crate) mod clock_limits {

--- a/embassy-mcxa/src/chips/mcxa5xx.rs
+++ b/embassy-mcxa/src/chips/mcxa5xx.rs
@@ -662,7 +662,7 @@ pub(crate) mod peripheral_gating {
     use paste::paste;
 
     use crate::clocks::Gate;
-    use crate::clocks::periph_helpers::{NoConfig, OsTimerConfig};
+    use crate::clocks::periph_helpers::{Clk1MConfig, NoConfig, OsTimerConfig};
     // use crate::clocks::periph_helpers::{
     //     AdcConfig, CTimerConfig, I3cConfig, Lpi2cConfig, LpspiConfig, LpuartConfig, NoConfig,
     // };
@@ -725,6 +725,9 @@ pub(crate) mod peripheral_gating {
 
     // impl_cc_gate!(LPSPI0, mrcc_glb_acc0, mrcc_glb_rst0, lpspi0, LpspiConfig);
     // impl_cc_gate!(LPSPI1, mrcc_glb_acc0, mrcc_glb_rst0, lpspi1, LpspiConfig);
+
+    impl_cc_gate!(WWDT0, mrcc_glb_acc0, wwdt0, Clk1MConfig);
+    impl_cc_gate!(WWDT1, mrcc_glb_acc0, wwdt1, Clk1MConfig);
 }
 
 pub(crate) mod clock_limits {

--- a/embassy-mcxa/src/clocks/mod.rs
+++ b/embassy-mcxa/src/clocks/mod.rs
@@ -2199,6 +2199,40 @@ impl ClockOperator<'_> {
 #[doc(hidden)]
 #[macro_export]
 macro_rules! impl_cc_gate {
+    ($name:ident, $clk_reg:ident, $field:ident, $config:ty) => {
+        impl Gate for $crate::peripherals::$name {
+            type MrccPeriphConfig = $config;
+
+            paste! {
+                #[inline]
+                unsafe fn enable_clock() {
+                    pac::MRCC0.$clk_reg().modify(|w| w.[<set_ $field>](true));
+                }
+
+                #[inline]
+                unsafe fn disable_clock() {
+                    pac::MRCC0.$clk_reg().modify(|w| w.[<set_ $field>](false));
+                }
+
+                #[inline]
+                unsafe fn release_reset() {}
+
+                #[inline]
+                unsafe fn assert_reset() {}
+            }
+
+            #[inline]
+            fn is_clock_enabled() -> bool {
+                pac::MRCC0.$clk_reg().read().$field()
+            }
+
+            #[inline]
+            fn is_reset_released() -> bool {
+                false
+            }
+        }
+    };
+
     ($name:ident, $clk_reg:ident, $rst_reg:ident, $field:ident, $config:ty) => {
         impl Gate for $crate::peripherals::$name {
             type MrccPeriphConfig = $config;

--- a/embassy-mcxa/src/clocks/periph_helpers/mod.rs
+++ b/embassy-mcxa/src/clocks/periph_helpers/mod.rs
@@ -199,6 +199,21 @@ impl SPConfHelper for NoConfig {
     }
 }
 
+/// A basic type that always returns `Ok` when `PreEnableParts` is called.
+///
+/// This should only be used for peripherals that are clocked only by
+/// the CLK1M clock and have no other selectable/configurable source
+/// clock.
+pub struct Clk1MConfig;
+impl SPConfHelper for Clk1MConfig {
+    fn pre_enable_config(&self, _clocks: &Clocks) -> Result<PreEnableParts, ClockError> {
+        Ok(PreEnableParts {
+            freq: 1_000_000,
+            wake_guard: None,
+        })
+    }
+}
+
 //
 // OSTimer
 //

--- a/embassy-mcxa/src/wwdt.rs
+++ b/embassy-mcxa/src/wwdt.rs
@@ -12,6 +12,8 @@ use embassy_hal_internal::{Peri, PeripheralType};
 use embassy_time::Duration;
 use paste::paste;
 
+use crate::clocks::periph_helpers::Clk1MConfig;
+use crate::clocks::{ClockError, Gate, WakeGuard, enable_and_reset};
 use crate::interrupt::typelevel;
 use crate::interrupt::typelevel::{Handler, Interrupt};
 use crate::pac;
@@ -21,6 +23,8 @@ use crate::pac::wwdt::vals::{Wden, Wdprotect, Wdreset};
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub enum Error {
+    /// Clock configuration error.
+    ClockSetup(ClockError),
     TimeoutTooSmall,
     TimeoutTooLarge,
     WarningTooLarge,
@@ -47,6 +51,7 @@ impl Default for Config {
 pub struct Watchdog<'d> {
     info: &'static Info,
     _phantom: PhantomData<&'d mut ()>,
+    _wg: Option<WakeGuard>,
 }
 
 impl<'d> Watchdog<'d> {
@@ -64,24 +69,15 @@ impl<'d> Watchdog<'d> {
         _irq: impl crate::interrupt::typelevel::Binding<T::Interrupt, InterruptHandler<T>> + 'd,
         config: Config,
     ) -> Result<Self, Error> {
+        let parts = unsafe { enable_and_reset::<T>(&Clk1MConfig).map_err(Error::ClockSetup)? };
+
         let watchdog = Self {
             info: T::info(),
             _phantom: PhantomData,
+            _wg: parts.wake_guard,
         };
 
-        let base_frequency = crate::clocks::with_clocks(|clocks| {
-            // Ensure clk_1m is active at the required power level
-            clocks.ensure_clk_1m_active(&crate::clocks::PoweredClock::NormalEnabledDeepSleepDisabled)
-        })
-        .expect("Clocks not initialized")
-        .expect("clk_1m not enabled or not at required power level");
-
-        let frequency = base_frequency / 4;
-
-        // Enable WATCHDOG clock by writing to mrcc register
-        // Can't use enable_and_reset API here because WWDT doesn't have a reset signal.
-        pac::MRCC0.mrcc_glb_cc0().modify(|w| w.set_wwdt0(true));
-
+        let frequency = parts.freq / 4;
         let timeout_cycles = (frequency as u64 * config.timeout.as_micros()) / 1_000_000;
 
         // Ensure the value fits in u32 and is within valid range
@@ -218,7 +214,7 @@ impl<T: Instance> Handler<T::Interrupt> for InterruptHandler<T> {
     }
 }
 
-trait SealedInstance {
+trait SealedInstance: Gate<MrccPeriphConfig = Clk1MConfig> {
     fn info() -> &'static Info;
 }
 


### PR DESCRIPTION
Some peripherals don't have a reset bit. We can modify impl_cc_gate to accept such peripherals and stub out the reset-related methods. With this change, drivers for those peripherals can still use enable_and_reset().

Closes https://github.com/OpenDevicePartnership/embassy-mcxa/issues/175