### PR TITLE
[MCXA5] Enable DMA

### DIFF
--- a/embassy-mcxa/Cargo.toml
+++ b/embassy-mcxa/Cargo.toml
@@ -43,7 +43,7 @@ embedded-io = "0.7"
 embedded-io-async = { version = "0.7.0" }
 heapless = "0.9"
 maitake-sync = { version = "0.2.2", default-features = false, features = ["critical-section", "no-cache-pad"] }
-nxp-pac = { git = "https://github.com/embassy-rs/nxp-pac.git", rev = "2463b35bd4b6b20992fb4717ed6b5ce2893cd014", features = ["rt"] }
+nxp-pac = { git = "https://github.com/embassy-rs/nxp-pac.git", rev = "d6e4d73831ef4a1b42f20b3c54f74230b595078d", features = ["rt"] }
 nb = "1.1.0"
 paste = "1.0.15"
 

--- a/embassy-mcxa/src/chips/mcxa5xx.rs
+++ b/embassy-mcxa/src/chips/mcxa5xx.rs
@@ -69,16 +69,25 @@ mod inner_periph {
         CTIMER4_CH3,
 
         // DBGMAILBOX,
-        // DMA0,
-        // DMA_CH0,
-        // DMA_CH1,
-        // DMA_CH2,
-        // DMA_CH3,
-        // DMA_CH4,
-        // DMA_CH5,
-        // DMA_CH6,
-        // DMA_CH7,
-        // EDMA0_TCD0,
+
+        DMA0,
+        DMA_CH0,
+        DMA_CH1,
+        DMA_CH2,
+        DMA_CH3,
+        DMA_CH4,
+        DMA_CH5,
+        DMA_CH6,
+        DMA_CH7,
+        // Need more work on the DMA driver before we can enable these
+        // DMA_CH8,
+        // DMA_CH9,
+        // DMA_CH10,
+        // DMA_CH11,
+        EDMA0_TCD0,
+        // Need more work on the DMA driver before we can enable this
+        // EDMA0_TCD1,
+
         // EIM0,
         // EQDC0,
         // EQDC1,
@@ -335,14 +344,18 @@ mod inner_interrupt {
 
         // DAC0,
 
-        // DMA_CH0,
-        // DMA_CH1,
-        // DMA_CH2,
-        // DMA_CH3,
-        // DMA_CH4,
-        // DMA_CH5,
-        // DMA_CH6,
-        // DMA_CH7,
+        DMA_CH0,
+        DMA_CH1,
+        DMA_CH2,
+        DMA_CH3,
+        DMA_CH4,
+        DMA_CH5,
+        DMA_CH6,
+        DMA_CH7,
+        DMA_CH8,
+        DMA_CH9,
+        DMA_CH10,
+        DMA_CH11,
 
         // EQDC0_COMPARE,
         // EQDC0_HOME,
@@ -707,8 +720,8 @@ pub(crate) mod peripheral_gating {
     // impl_cc_gate!(LPUART4, mrcc_glb_acc0, mrcc_glb_rst0, lpuart4, LpuartConfig);
     // impl_cc_gate!(LPUART5, mrcc_glb_acc1, mrcc_glb_rst1, lpuart5, LpuartConfig);
 
-    // // DMA0 peripheral - uses NoConfig since it has no selectable clock source
-    // impl_cc_gate!(DMA0, mrcc_glb_acc0, mrcc_glb_rst0, dma0, NoConfig);
+    // DMA0 peripheral - uses NoConfig since it has no selectable clock source
+    impl_cc_gate!(DMA0, mrcc_glb_acc0, mrcc_glb_rst0, dma0, NoConfig);
 
     impl_cc_gate!(GPIO0, mrcc_glb_acc3, mrcc_glb_rst3, gpio0, NoConfig);
     impl_cc_gate!(GPIO1, mrcc_glb_acc3, mrcc_glb_rst3, gpio1, NoConfig);

--- a/embassy-mcxa/src/dma.rs
+++ b/embassy-mcxa/src/dma.rs
@@ -67,6 +67,8 @@
 //! // Configure and trigger a transfer...
 //! ```
 
+#![allow(dead_code)]
+
 use core::future::Future;
 use core::marker::PhantomData;
 use core::pin::Pin;
@@ -77,7 +79,8 @@ use core::task::{Context, Poll};
 use embassy_hal_internal::{Peri, PeripheralType};
 use embassy_sync::waitqueue::AtomicWaker;
 
-use crate::clocks::Gate;
+use crate::clocks::enable_and_reset;
+use crate::clocks::periph_helpers::NoConfig;
 use crate::dma::sealed::SealedChannel;
 use crate::pac::dma::vals::Halt;
 use crate::pac::edma_0_tcd::regs::{TcdAttr, TcdBiterElinkno, TcdCiterElinkno, TcdCsr};
@@ -92,20 +95,17 @@ use crate::peripherals::DMA0;
 /// The function enables the DMA0 clock, releases reset, and configures the controller
 /// for normal operation with round-robin arbitration.
 pub(crate) fn init() {
-    unsafe {
-        // Enable DMA0 clock and release reset
-        DMA0::enable_clock();
-        DMA0::release_reset();
+    // Enable DMA0 clock and release reset
+    let _ = unsafe { enable_and_reset::<DMA0>(&NoConfig) };
 
-        // Configure DMA controller
-        pac::DMA0.mp_csr().modify(|w| {
-            w.set_edbg(true);
-            w.set_erca(true);
-            w.set_halt(Halt::NORMAL_OPERATION);
-            w.set_gclc(true);
-            w.set_gmrc(true);
-        });
-    }
+    // Configure DMA controller
+    pac::DMA0.mp_csr().modify(|w| {
+        w.set_edbg(true);
+        w.set_erca(true);
+        w.set_halt(Halt::NORMAL_OPERATION);
+        w.set_gclc(true);
+        w.set_gmrc(true);
+    });
 }
 
 // ============================================================================

--- a/embassy-mcxa/src/lib.rs
+++ b/embassy-mcxa/src/lib.rs
@@ -15,7 +15,6 @@
 mod mcxa2xx_exclusive {
     pub mod adc;
     pub mod clkout;
-    pub mod dma;
     pub mod flash;
     pub mod i2c;
     pub mod i3c;
@@ -41,6 +40,7 @@ mod all_chips {
     pub mod config;
     pub mod crc;
     pub mod ctimer;
+    pub mod dma;
     #[cfg(feature = "custom-executor")]
     pub mod executor;
     pub mod gpio;

--- a/examples/mcxa5xx/src/bin/dma_mem_to_mem.rs
+++ b/examples/mcxa5xx/src/bin/dma_mem_to_mem.rs
@@ -1,0 +1,118 @@
+//! DMA memory-to-memory transfer example for MCXA276.
+//!
+//! This example demonstrates using DMA to copy data between memory buffers
+//! using the Embassy-style async API with type-safe transfers.
+//!
+//! # Embassy-style features demonstrated:
+//! - `TransferOptions` for configuration
+//! - Type-safe `mem_to_mem<u32>()` method with async `.await`
+//! - `Transfer` Future that can be `.await`ed
+//! - `Word` trait for automatic transfer width detection
+//! - `memset()` method for filling memory with a pattern
+
+#![no_std]
+#![no_main]
+
+use embassy_executor::Spawner;
+use embassy_mcxa::clocks::config::Div8;
+use embassy_mcxa::dma::{DmaChannel, TransferOptions};
+use static_cell::ConstStaticCell;
+use {defmt_rtt as _, embassy_mcxa as hal, panic_probe as _};
+
+const BUFFER_LENGTH: usize = 4;
+
+// Buffers in RAM (static mut is automatically placed in .bss/.data)
+static SRC_BUFFER: ConstStaticCell<[u32; BUFFER_LENGTH]> = ConstStaticCell::new([1, 2, 3, 4]);
+static DEST_BUFFER: ConstStaticCell<[u32; BUFFER_LENGTH]> = ConstStaticCell::new([0; BUFFER_LENGTH]);
+static MEMSET_BUFFER: ConstStaticCell<[u32; BUFFER_LENGTH]> = ConstStaticCell::new([0; BUFFER_LENGTH]);
+
+#[embassy_executor::main]
+async fn main(_spawner: Spawner) {
+    // Small delay to allow probe-rs to attach after reset
+    for _ in 0..100_000 {
+        cortex_m::asm::nop();
+    }
+
+    let mut cfg = hal::config::Config::default();
+    cfg.clock_cfg.sirc.fro_12m_enabled = true;
+    cfg.clock_cfg.sirc.fro_lf_div = Some(Div8::no_div());
+    let p = hal::init(cfg);
+
+    defmt::info!("DMA memory-to-memory example starting...");
+
+    defmt::info!("EDMA memory to memory example begin.");
+
+    let src = SRC_BUFFER.take();
+    let dst = DEST_BUFFER.take();
+    let mst = MEMSET_BUFFER.take();
+
+    defmt::info!("Source Buffer: {=[?]}", src.as_slice());
+    defmt::info!("Destination Buffer (before): {=[?]}", dst.as_slice());
+    defmt::info!("Configuring DMA with Embassy-style API...");
+
+    // Create DMA channel
+    let mut dma_ch0 = DmaChannel::new(p.DMA_CH0);
+
+    // Configure transfer options (Embassy-style)
+    // TransferOptions defaults to: complete_transfer_interrupt = true
+    let options = TransferOptions::default();
+
+    // =========================================================================
+    // Part 1: Embassy-style async API demonstration (mem_to_mem)
+    // =========================================================================
+    //
+    // Use the new type-safe `mem_to_mem<u32>()` method:
+    // - Automatically determines transfer width from buffer element type (u32)
+    // - Returns a `Transfer` future that can be `.await`ed
+    // - Uses TransferOptions for consistent configuration
+    //
+    // Using async `.await` - the executor can run other tasks while waiting!
+
+    // Perform type-safe memory-to-memory transfer using Embassy-style async API
+    // Using async `.await` - the executor can run other tasks while waiting!
+    let transfer = dma_ch0.mem_to_mem(src, dst, options).unwrap();
+    transfer.await.unwrap();
+
+    defmt::info!("DMA mem-to-mem transfer complete!");
+    defmt::info!("Destination Buffer (after): {=[?]}", dst.as_slice());
+
+    // Verify data
+    if src != dst {
+        defmt::error!("FAIL: mem_to_mem mismatch!");
+    } else {
+        defmt::info!("PASS: mem_to_mem verified.");
+    }
+
+    // =========================================================================
+    // Part 2: memset() demonstration
+    // =========================================================================
+    //
+    // The `memset()` method fills a buffer with a pattern value:
+    // - Fixed source address (pattern is read repeatedly)
+    // - Incrementing destination address
+    // - Uses the same Transfer future pattern
+
+    defmt::info!("--- Demonstrating memset() feature ---");
+
+    defmt::info!("Memset Buffer (before): {=[?]}", mst.as_slice());
+
+    // Fill buffer with a pattern value using DMA memset
+    let pattern: u32 = 0xDEADBEEF;
+    defmt::info!("Filling with pattern 0xDEADBEEF...");
+
+    // Using blocking_wait() for demonstration - also shows non-async usage
+    let transfer = dma_ch0.memset(&pattern, mst, options);
+    transfer.blocking_wait();
+
+    defmt::info!("DMA memset complete!");
+    defmt::info!("Memset Buffer (after): {=[?]}", mst.as_slice());
+
+    // Verify memset result
+    if !mst.iter().all(|&v| v == pattern) {
+        defmt::error!("FAIL: memset mismatch!");
+    } else {
+        defmt::info!("PASS: memset verified.");
+    }
+
+    defmt::info!("=== All DMA tests complete ===");
+}

--- a/examples/mcxa5xx/src/bin/dma_scatter_gather_builder.rs
+++ b/examples/mcxa5xx/src/bin/dma_scatter_gather_builder.rs
@@ -1,0 +1,130 @@
+//! DMA Scatter-Gather Builder example for MCXA276.
+//!
+//! This example demonstrates using the new `ScatterGatherBuilder` API for
+//! chaining multiple DMA transfers with a type-safe builder pattern.
+//!
+//! # Features demonstrated:
+//! - `ScatterGatherBuilder::new()` for creating a builder
+//! - `add_transfer()` for adding memory-to-memory segments
+//! - `build()` to start the chained transfer
+//! - Automatic TCD linking and ESG bit management
+//!
+//! # Comparison with manual scatter-gather:
+//! The manual approach (see `dma_scatter_gather.rs`) requires:
+//! - Manual TCD pool allocation and alignment
+//! - Manual CSR/ESG/INTMAJOR bit manipulation
+//! - Manual dlast_sga address calculations
+//!
+//! The builder approach handles all of this automatically!
+
+#![no_std]
+#![no_main]
+
+use embassy_executor::Spawner;
+use embassy_mcxa::clocks::config::Div8;
+use embassy_mcxa::dma::{DmaChannel, ScatterGatherBuilder};
+use static_cell::ConstStaticCell;
+use {defmt_rtt as _, embassy_mcxa as hal, panic_probe as _};
+
+// Source buffers (multiple segments)
+static SRC1: ConstStaticCell<[u32; 4]> = ConstStaticCell::new([0x11111111, 0x22222222, 0x33333333, 0x44444444]);
+static SRC2: ConstStaticCell<[u32; 4]> = ConstStaticCell::new([0xAAAAAAAA, 0xBBBBBBBB, 0xCCCCCCCC, 0xDDDDDDDD]);
+static SRC3: ConstStaticCell<[u32; 4]> = ConstStaticCell::new([0x12345678, 0x9ABCDEF0, 0xFEDCBA98, 0x76543210]);
+
+// Destination buffers (one per segment)
+static DST1: ConstStaticCell<[u32; 4]> = ConstStaticCell::new([0; 4]);
+static DST2: ConstStaticCell<[u32; 4]> = ConstStaticCell::new([0; 4]);
+static DST3: ConstStaticCell<[u32; 4]> = ConstStaticCell::new([0; 4]);
+
+#[embassy_executor::main]
+async fn main(_spawner: Spawner) {
+    // Small delay to allow probe-rs to attach after reset
+    for _ in 0..100_000 {
+        cortex_m::asm::nop();
+    }
+
+    let mut cfg = hal::config::Config::default();
+    cfg.clock_cfg.sirc.fro_12m_enabled = true;
+    cfg.clock_cfg.sirc.fro_lf_div = Some(Div8::no_div());
+    let p = hal::init(cfg);
+
+    defmt::info!("DMA Scatter-Gather Builder example starting...");
+
+    defmt::info!("DMA Scatter-Gather Builder Example");
+    defmt::info!("===================================");
+    let src1 = SRC1.take();
+    let src2 = SRC2.take();
+    let src3 = SRC3.take();
+    let dst1 = DST1.take();
+    let dst2 = DST2.take();
+    let dst3 = DST3.take();
+
+    // Show source buffers
+    defmt::info!("Source buffers:");
+    defmt::info!("  SRC1: {=[?]}", src1.as_slice());
+    defmt::info!("  SRC2: {=[?]}", src2.as_slice());
+    defmt::info!("  SRC3: {=[?]}", src3.as_slice());
+
+    defmt::info!("Destination buffers (before):");
+    defmt::info!("  DST1: {=[?]}", dst1.as_slice());
+    defmt::info!("  DST2: {=[?]}", dst2.as_slice());
+    defmt::info!("  DST3: {=[?]}", dst3.as_slice());
+
+    // Create DMA channel
+    let dma_ch0 = DmaChannel::new(p.DMA_CH0);
+
+    defmt::info!("Building scatter-gather chain with builder API...");
+
+    // =========================================================================
+    // ScatterGatherBuilder API demonstration
+    // =========================================================================
+    //
+    // The builder pattern makes scatter-gather transfers much easier:
+    // 1. Create a builder
+    // 2. Add transfer segments with add_transfer()
+    // 3. Call build() to start the entire chain
+    // No manual TCD manipulation required!
+
+    let mut builder = ScatterGatherBuilder::<u32>::new();
+
+    // Add three transfer segments - the builder handles TCD linking automatically
+    builder.add_transfer(src1, dst1);
+    builder.add_transfer(src2, dst2);
+    builder.add_transfer(src3, dst3);
+
+    defmt::info!("Added 3 transfer segments to chain.");
+    defmt::info!("Starting scatter-gather transfer with .await...");
+
+    // Build and execute the scatter-gather chain
+    // The build() method:
+    // - Links all TCDs together with ESG bit
+    // - Sets INTMAJOR on all TCDs
+    // - Loads the first TCD into hardware
+    // - Returns a Transfer future
+    let transfer = builder.build(dma_ch0).expect("Failed to build scatter-gather");
+    transfer.blocking_wait();
+
+    defmt::info!("Scatter-gather transfer complete!");
+
+    // Show results
+    defmt::info!("Destination buffers (after):");
+    defmt::info!("  DST1: {=[?]}", dst1.as_slice());
+    defmt::info!("  DST2: {=[?]}", dst2.as_slice());
+    defmt::info!("  DST3: {=[?]}", dst3.as_slice());
+
+    let comps = [(src1, dst1), (src2, dst2), (src3, dst3)];
+
+    // Verify all three segments
+    let mut all_ok = true;
+    for (src, dst) in comps {
+        all_ok &= src == dst;
+    }
+
+    if all_ok {
+        defmt::info!("PASS: All segments verified!");
+    } else {
+        defmt::error!("FAIL: Mismatch detected!");
+    }
+
+    defmt::info!("=== Scatter-Gather Builder example complete ===");
+}


### PR DESCRIPTION
Had to add `#![allow(dead_code)]` to the dma driver until the drivers using DMA are enabled again, otherwise we would end up with a lot of build warnings on MCXA5. Subsequent PRs shall fix that.

Closes https://github.com/OpenDevicePartnership/embassy-mcxa/issues/174