### PR TITLE
embassy-usb-synopsys flip iso IN message polarity at eof

### DIFF
--- a/embassy-usb-synopsys-otg/src/lib.rs
+++ b/embassy-usb-synopsys-otg/src/lib.rs
@@ -166,6 +166,55 @@ pub unsafe fn on_interrupt<const MAX_EP_COUNT: usize>(r: Otg, state: &State<MAX_
             ep_num += 1;
         }
     }
+
+    if ints.eopf() {
+        let frame_number = r.dsts().read().fnsof();
+        let frame_is_odd = frame_number & 0x01 == 1;
+
+        // If an isochronous endpoint has an IN message waiting in its FIFO, but the host didn't poll for it before eof,
+        // switch the packet polarity, in the hope that it will be polled for in the next frame.
+        for ep_num in (0..ep_count).into_iter().filter(|ep_num| {
+            let diepctl = r.diepctl(*ep_num).read();
+            // Find iso endpoints
+            diepctl.eptyp() == vals::Eptyp::ISOCHRONOUS
+                // That have and unsent IN message
+                && diepctl.epena()
+                // Where the frame polarity matches the current frame
+                && diepctl.eonum_dpid() == frame_is_odd
+        }) {
+            trace!("Unsent message at EOF for ep: {}, frame: {}", ep_num, frame_number);
+
+            let ep_diepctl = r.diepctl(ep_num);
+            let ep_diepint = r.diepint(ep_num);
+
+            // Set NAK
+            ep_diepctl.modify(|m| m.set_snak(true));
+            while !ep_diepint.read().inepne() {}
+
+            // Disable the endpoint
+            ep_diepctl.modify(|m| {
+                m.set_snak(true);
+                m.set_epdis(true);
+            });
+            while !ep_diepint.read().epdisd() {}
+            ep_diepint.modify(|m| m.set_epdisd(true));
+
+            // Switch the packet polarity
+            ep_diepctl.modify(|r| {
+                if frame_is_odd {
+                    r.set_sd0pid_sevnfrm(true);
+                } else {
+                    r.set_sd1pid_soddfrm(true);
+                }
+            });
+
+            // Enable the endpoint again
+            ep_diepctl.modify(|w| {
+                w.set_cnak(true);
+                w.set_epena(true);
+            });
+        }
+    }
 }
 
 /// USB PHY type

--- a/examples/stm32f4/src/bin/usb_uac_speaker.rs
+++ b/examples/stm32f4/src/bin/usb_uac_speaker.rs
@@ -1,8 +1,7 @@
 #![no_std]
 #![no_main]
 
-use core::cell::RefCell;
-use core::sync::atomic::{AtomicU32, Ordering};
+use core::cell::{Cell, RefCell};
 
 use defmt::{panic, *};
 use embassy_executor::Spawner;
@@ -12,7 +11,6 @@ use embassy_sync::blocking_mutex::Mutex;
 use embassy_sync::blocking_mutex::raw::{CriticalSectionRawMutex, NoopRawMutex};
 use embassy_sync::signal::Signal;
 use embassy_sync::zerocopy_channel;
-use embassy_time::{Duration, WithTimeout as _};
 use embassy_usb::class::uac1;
 use embassy_usb::class::uac1::speaker::{self, Speaker};
 use embassy_usb::driver::EndpointError;
@@ -86,8 +84,6 @@ async fn feedback_handler<'d, T: usb::Instance + 'd>(
     // Collects the fractional component of the feedback value that is lost by rounding.
     let mut rest = 0.0_f32;
 
-    // Make sure the signal is clear before we start
-    _ = FEEDBACK_SIGNAL.wait().await;
     loop {
         let counter = FEEDBACK_SIGNAL.wait().await;
 
@@ -102,18 +98,7 @@ async fn feedback_handler<'d, T: usb::Instance + 'd>(
         packet.push((value >> 8) as u8).unwrap();
         packet.push((value >> 16) as u8).unwrap();
 
-        let Ok(res) = feedback
-            .write_packet(&packet)
-            // Short timeout to prevent queueing
-            .with_timeout(Duration::from_micros(10))
-            .await
-        else {
-            // Ignore timeout. There was already an uncollected message in the FIFO.
-            // The previous message will be delivered next time the host polls for it
-            continue;
-        };
-
-        res?; // Return on error
+        feedback.write_packet(&packet).await?;
         debug!("feedback sent {}", value);
     }
 }
@@ -234,24 +219,27 @@ async fn usb_control_task(control_monitor: speaker::ControlMonitor<'static>) {
 /// This gives an (ideal) counter value of 336.000 for every update of the `FEEDBACK_SIGNAL`.
 #[interrupt]
 fn TIM2() {
-    static LAST_TICKS: AtomicU32 = AtomicU32::new(0);
+    static LAST_TICKS: Mutex<CriticalSectionRawMutex, Cell<u32>> = Mutex::new(Cell::new(0));
+    static FRAME_COUNT: Mutex<CriticalSectionRawMutex, Cell<usize>> = Mutex::new(Cell::new(0));
 
-    // Count up frames and emit a signal, when the refresh period is reached.
-    let regs = embassy_stm32::pac::USB_OTG_FS;
     critical_section::with(|cs| {
         let mut guard = TIMER.borrow(cs).borrow_mut();
         let timer = guard.as_mut().unwrap();
         if timer.get_input_interrupt(TIMER_CHANNEL) {
-            let frame_number = regs.dsts().read().fnsof() as usize;
-            // Send the signal one frame before the feedback will be requested
-            if (frame_number + 1) % FEEDBACK_REFRESH_PERIOD.frame_count() == 0 {
-                let ticks = timer.get_capture_value(TIMER_CHANNEL);
-                let last_ticks = LAST_TICKS.load(Ordering::Relaxed);
-                FEEDBACK_SIGNAL.signal(ticks.wrapping_sub(last_ticks));
-                LAST_TICKS.store(ticks, Ordering::Relaxed);
+            let ticks = timer.get_capture_value(TIMER_CHANNEL);
+
+            let frame_count = FRAME_COUNT.borrow(cs);
+            let last_ticks = LAST_TICKS.borrow(cs);
+
+            frame_count.set(frame_count.get() + 1);
+            if frame_count.get() >= FEEDBACK_REFRESH_PERIOD.frame_count() {
+                frame_count.set(0);
+                FEEDBACK_SIGNAL.signal(ticks.wrapping_sub(last_ticks.get()));
+                last_ticks.set(ticks);
             }
+            // Clear trigger interrupt flag.
             timer.clear_input_interrupt(TIMER_CHANNEL);
-        }
+        };
     });
 }
 


### PR DESCRIPTION
## Reference
https://github.com/embassy-rs/embassy/issues/5533

## What this fixes
Feedback messages used to pace data streaming in UAC1 Class connections can get stuck and never received by the host.  This causes buffer over/under runs because clock drift cannot be corrected for.

## Background
For isochronous endpoints, messages sent from device to host (IN messages) are given a single bit to indicate the polarity of the frame they are destined for (`eonum` 1=odd, 0=even).

Feedback messages are polled periodically, for example every 8 frames.  Usually but not always, they are polled for on even frames. Once a stream has started, the polarity won't change, it'll always be either odd or even.

If the device creates a message with the wrong polarity, it'll never be delivered, and no more messages can be sent behind it. The endpoint is clogged.

## Previous fix
In https://github.com/embassy-rs/embassy/pull/5530, I added two countermeasures to the example itself:
* Always queue up feedback one frame before the next multiple of the feedback period,  using `fnsof`.
* Prevent next message queuing behind previous stuck message

This mostly works, except for cases in which the host polls on odd frames, as I have observed Windows doing. It also requires direct register access and very careful timing.

## A better solution

I have added a handler for the End of Frame flag (`eopf`).  It checks for  ISO endpoints with IN messages waiting, which were not polled for in the current frame.  It flips their polarity in the hope they will be collected in the next frame.

With this in place, it doesn't matter which frame the feedback message is created in, it'll flip polarity until it is collected.

This brings the behaviour closer to other chips such as rp2040, which don't have a frame polarity bit at all.

I have also restored the example file to mostly how it was before #5530, with just a few minor updates.  The example has been tested on an STM32F427ZI board.