### PR TITLE
stm32/adc: align ring buffer reads to scan sequence length

### DIFF
--- a/embassy-stm32/src/adc/mod.rs
+++ b/embassy-stm32/src/adc/mod.rs
@@ -341,11 +341,16 @@ impl<'d, T: Instance> Adc<'d, T> {
         _trigger: impl RegularTrigger<T>,
         #[cfg(any(adc_v2, adc_g4))] edge: Exten,
     ) -> RingBufferedAdc<'a, T> {
+        let sequence_len = sequence.len();
         assert!(!dma_buf.is_empty() && dma_buf.len() <= 0xFFFF);
-        assert!(sequence.len() != 0, "Asynchronous read sequence cannot be empty");
+        assert!(sequence_len != 0, "Asynchronous read sequence cannot be empty");
         assert!(
-            sequence.len() <= 16,
+            sequence_len <= 16,
             "Asynchronous read sequence cannot be more than 16 in length"
+        );
+        assert!(
+            dma_buf.len() % sequence_len == 0,
+            "DMA buffer length must be a multiple of the scan sequence length"
         );
         // Ensure no conversions are ongoing
         T::regs().stop();
@@ -370,7 +375,7 @@ impl<'d, T: Instance> Adc<'d, T> {
 
         core::mem::forget(self);
 
-        RingBufferedAdc::new(dma, irq, dma_buf)
+        RingBufferedAdc::new(dma, irq, dma_buf, sequence_len)
     }
 }
 

--- a/embassy-stm32/src/adc/ringbuffered.rs
+++ b/embassy-stm32/src/adc/ringbuffered.rs
@@ -25,6 +25,7 @@ impl<'d, T: Instance> RingBufferedAdc<'d, T> {
         dma: Peri<'d, D>,
         irq: impl crate::interrupt::typelevel::Binding<D::Interrupt, crate::dma::InterruptHandler<D>> + 'd,
         dma_buf: &'d mut [u16],
+        sequence_len: usize,
     ) -> Self {
         // DMA side setup - configuration differs between DMA/BDMA and GPDMA
         // For DMA/BDMA: use circular mode via TransferOptions
@@ -45,8 +46,12 @@ impl<'d, T: Instance> RingBufferedAdc<'d, T> {
         // Safety: we forget the struct before this function returns.
         let request = dma.request();
 
-        let ring_buf =
+        let mut ring_buf =
             unsafe { ReadableRingBuffer::new(Channel::new(dma, irq), request, T::regs().data(), dma_buf, opts) };
+
+        // Align reads to the scan sequence boundary so that channel assignments
+        // never shift after an overrun recovery.
+        ring_buf.set_alignment(sequence_len);
 
         Self {
             _phantom: PhantomData,


### PR DESCRIPTION
When `into_ring_buffered` is called with multiple channels the DMA fills the buffer in repeating scan order `[ch0, ch1, ch2, ...]`. After an overrun the ring buffer recovery could land at a position that is not a multiple of the channel count, shifting all subsequent channel assignments so the wrong values map to the wrong channels.

Call `set_alignment(sequence_len)` on the ring buffer so that read pointers are always snapped to a scan-sequence boundary after recovery. Also assert that the DMA buffer length is a multiple of the sequence length, which the existing docs already required but the code did not enforce.

Fixes #5025