### PR TITLE
fix: stm32/adc/g4: correct VREF_CALIB_MV

### DIFF
--- a/embassy-stm32/CHANGELOG.md
+++ b/embassy-stm32/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - fix: don't put USB pins into alternate mode on chips where USB is an additional function
 - feat: add i2s to STM32G4 except G414
 - fix: stm32/rcc: allow linker to optimize out expensive PLL init functions in binaries where the PLL is not used (e.g. most bootloaders)
+- fix: stm32/adc/g4: correct VREF_CALIB_MV
 
 ## 0.5.0 - 2026-01-04
 - Add `receive_waveform` method in `InputCapture`, allowing asynchronous input capture with DMA.

--- a/embassy-stm32/src/adc/g4.rs
+++ b/embassy-stm32/src/adc/g4.rs
@@ -20,7 +20,7 @@ pub use injected::InjectedAdc;
 /// Default VREF voltage used for sample conversion to millivolts.
 pub const VREF_DEFAULT_MV: u32 = 3300;
 /// VREF voltage used for factory calibration of VREFINTCAL register.
-pub const VREF_CALIB_MV: u32 = 3300;
+pub const VREF_CALIB_MV: u32 = 3000;
 
 const NR_INJECTED_RANKS: usize = 4;
 


### PR DESCRIPTION
Based on the STM32G491CC datasheet (DS13122 rev 4) section 3.18.2, the VREFINT was calibrated at 3.0 V.