### PR TITLE
[MCXA5] Initialize DMA driver

### DIFF
--- a/embassy-mcxa/src/chips/mcxa5xx.rs
+++ b/embassy-mcxa/src/chips/mcxa5xx.rs
@@ -456,8 +456,8 @@ pub fn init(cfg: crate::config::Config) -> Peripherals {
         crate::gpio::interrupt_init();
     }
 
-    // // Initialize DMA controller (clock, reset, configuration)
-    // crate::dma::init();
+    // Initialize DMA controller (clock, reset, configuration)
+    crate::dma::init();
 
     // Enable GPIO clocks
     unsafe {


### PR DESCRIPTION
This seems to have been missed in previously re-enabling DMA

CC #5594