### PR TITLE
Fix RCC Reinit

### DIFF
--- a/embassy-stm32/src/rcc/mod.rs
+++ b/embassy-stm32/src/rcc/mod.rs
@@ -659,7 +659,13 @@ pub fn disable<T: RccPeripheral>() {
 /// This should only be called after `init`.
 #[cfg(not(feature = "_dual-core"))]
 pub fn reinit(config: Config, _rcc: &'_ mut crate::Peri<'_, crate::peripherals::RCC>) {
-    critical_section::with(|cs| init_rcc(cs, config))
+    critical_section::with(|cs| {
+        init_rcc(cs, config);
+
+        // must be after rcc init
+        #[cfg(feature = "_time-driver")]
+        crate::time_driver::init(cs);
+    })
 }
 
 #[cfg(feature = "low-power")]


### PR DESCRIPTION
PR #5548 moved `time_driver::init` out of `init_rcc` and into `init_hw`. Normally this is fine, as `init_hw` calls both. However, `reinit` relied on `init_rcc` to initialize the time driver, which it now doesn't. This is a quick fix to resolve that.