### PR TITLE
i2c v2: reset peripheral state machine after BERR and ARLO

### DIFF
--- a/embassy-stm32/src/i2c/v2.rs
+++ b/embassy-stm32/src/i2c/v2.rs
@@ -947,6 +947,11 @@ impl<'d, IM: MasterMode> I2c<'d, Async, IM> {
                 w.set_arlocf(true);
                 w.set_ovrcf(true);
             });
+            if isr.berr() || isr.arlo() {
+                regs.cr1().modify(|w| w.set_pe(false));
+                while regs.cr1().read().pe() {}
+                regs.cr1().modify(|w| w.set_pe(true));
+            }
         });
 
         poll_fn(|cx| {
@@ -1051,6 +1056,7 @@ impl<'d, IM: MasterMode> I2c<'d, Async, IM> {
 
         let on_drop = OnDrop::new(|| {
             let regs = self.info.regs;
+            let isr = regs.isr().read();
             regs.cr1().modify(|w| {
                 w.set_rxdmaen(false);
                 w.set_tcie(false);
@@ -1063,6 +1069,11 @@ impl<'d, IM: MasterMode> I2c<'d, Async, IM> {
                 w.set_arlocf(true);
                 w.set_ovrcf(true);
             });
+            if isr.berr() || isr.arlo() {
+                regs.cr1().modify(|w| w.set_pe(false));
+                while regs.cr1().read().pe() {}
+                regs.cr1().modify(|w| w.set_pe(true));
+            }
         });
 
         poll_fn(|cx| {
@@ -1436,6 +1447,7 @@ impl<'d, IM: MasterMode> I2c<'d, Async, IM> {
 
         let on_drop = OnDrop::new(|| {
             let regs = self.info.regs;
+            let isr = regs.isr().read();
             regs.cr1().modify(|w| {
                 w.set_rxdmaen(false);
                 w.set_tcie(false);
@@ -1448,6 +1460,11 @@ impl<'d, IM: MasterMode> I2c<'d, Async, IM> {
                 w.set_arlocf(true);
                 w.set_ovrcf(true);
             });
+            if isr.berr() || isr.arlo() {
+                regs.cr1().modify(|w| w.set_pe(false));
+                while regs.cr1().read().pe() {}
+                regs.cr1().modify(|w| w.set_pe(true));
+            }
         });
 
         poll_fn(|cx| {


### PR DESCRIPTION
Fixes #5619

## The problem

When the I2C v2 peripheral detects a bus error (BERR) or arbitration loss (ARLO), the driver clears the error flag and returns the appropriate error, but never resets the peripheral's state machine. This leaves the I2C hardware in a broken state where every subsequent transaction also fails, and only a power cycle recovers it. A firmware-only reset doesn't help because the peripheral retains its stuck state.

## What was happening

The BERR handler in `error_occurred()` (blocking path) does this:

```rust
} else if isr.berr() {
    self.info.regs.icr().modify(|reg| reg.set_berrcf(true));
    self.flush_txdr();
    return Err(Error::Bus);
}
```

It clears the flag and flushes the TX buffer, but the I2C state machine is still wedged. Compare this with `init()` and `set_config()`, which both do a PE off/on cycle to reset the state machine whenever they reconfigure the peripheral. That same PE toggle is exactly what's needed after a bus error.

The ARLO handler had the same gap. The async DMA paths (`write_dma_internal`, `read_dma_internal`, `read_dma_group_internal`) also only cleared the flags in their `on_drop` closures without resetting the state machine.

## The fix

Added a `soft_reset()` helper that toggles CR1.PE off then on, with a spin-wait for PE to actually deassert (takes a few APB clock cycles). This is the same pattern already used in `init()` and `set_config()`. TIMINGR and other config registers are preserved across a PE toggle, so no reconfiguration is needed.

The fix is applied to all BERR and ARLO error paths:

- **Blocking master path** (`error_occurred()`): calls `soft_reset()` after clearing flags
- **Blocking slave path** (`wait_txis_or_nack()`): same
- **Async DMA paths** (three `on_drop` closures in `write_dma_internal`, `read_dma_internal`, `read_dma_group_internal`): inlined PE toggle after flag clearing, gated on `isr.berr() || isr.arlo()` so it only fires when there was actually an error

## What about OVR?

The OVR (overrun) handler has the same pattern of only clearing the flag, but I left it alone intentionally. OVR is primarily a slave-mode concern (in master mode the master controls SCL, so overrun shouldn't happen). The existing OVR handler also has some inconsistencies around TXDR flushing that suggest it deserves its own focused look rather than being lumped into this fix. Happy to do a follow-up if you want the same treatment for OVR.

## How I tested this

Hardware: STM32H745ZIT6 (Cortex-M7), BMI088 IMU (gyro at 0x68) on I2C1 at 100 kHz with DMA, using the async API. External 4.7k pull-ups on SDA/SCL.

I wrote a test binary that:
1. Reads the BMI088 gyro chip ID to confirm the bus is healthy
2. Tries to inject a BERR by bit-banging SDA via GPIO during a transaction (this mostly triggers ARLO in practice)
3. Falls back to a polling loop where you manually ground SDA to trigger the fault
4. Confirms the bus is stuck with 5 consecutive reads
5. Does a manual PE toggle via PAC registers to prove recovery is possible
6. Reads again to confirm


<details>
<summary>berr_test.rs (click to expand)</summary>

```rust
//! I2C BERR Reproduction Test
//!
//! Demonstrates embassy-rs/embassy#5619: after a bus error (BERR), the I2C
//! peripheral stays stuck because the driver only clears the flag without
//! resetting the state machine via a PE toggle.
//!
//! What this does:
//!   1. Reads BMI088 gyro chip ID to prove the bus works
//!   2. Enters a polling loop -- you manually ground SDA to trigger the fault
//!   3. Tries to read again -- with stock Embassy, the bus is stuck forever
//!   4. Manually does a PE toggle to show recovery IS possible at the
//!      hardware level, just not done by the driver
//!
//! Hardware: STM32H745ZIT6, BMI088 gyro at 0x68, I2C1 (PB6/PB7), 100 kHz
//! Run with:  cargo run --bin berr_test

#![no_std]
#![no_main]

#[cfg(not(feature = "defmt"))]
use panic_halt as _;
#[cfg(feature = "defmt")]
use {defmt_rtt as _, panic_probe as _};

use core::mem::MaybeUninit;
use embassy_executor::Spawner;
use embassy_stm32::{bind_interrupts, i2c, peripherals, SharedData};
use embassy_stm32::i2c::I2c;
use embassy_stm32::i2c::Master;
use embassy_stm32::rcc::{
    LsConfig, Hse, HseMode, Pll, PllSource, PllPreDiv, PllMul, PllDiv,
    Sysclk, AHBPrescaler, APBPrescaler,
};
use embassy_stm32::time::Hertz;
use embassy_stm32::pac;
use embassy_time::{Duration, Timer, with_timeout};

use defmt::info;

bind_interrupts!(struct Irqs {
    I2C1_EV => i2c::EventInterruptHandler<peripherals::I2C1>;
    I2C1_ER => i2c::ErrorInterruptHandler<peripherals::I2C1>;
});

#[link_section = ".ram_d3"]
static SHARED_DATA: MaybeUninit<SharedData> = MaybeUninit::uninit();

const GYRO_ADDR: u8 = 0x68;
const GYRO_CHIP_ID_REG: u8 = 0x00;
const EXPECTED_GYRO_ID: u8 = 0x0F;

async fn read_gyro_id(i2c: &mut I2c<'static, embassy_stm32::mode::Async, Master>) -> Result<u8, i2c::Error> {
    let mut buf = [0u8; 1];
    i2c.write_read(GYRO_ADDR, &[GYRO_CHIP_ID_REG], &mut buf).await?;
    Ok(buf[0])
}

async fn read_gyro_id_timed(i2c: &mut I2c<'static, embassy_stm32::mode::Async, Master>) -> Result<Result<u8, i2c::Error>, ()> {
    match with_timeout(Duration::from_millis(500), read_gyro_id(i2c)).await {
        Ok(inner) => Ok(inner),
        Err(_timeout) => Err(()),
    }
}

#[embassy_executor::main]
async fn main(_spawner: Spawner) {
    info!("=========================================");
    info!("  I2C BERR Reproduction Test");
    info!("  embassy-rs/embassy#5619");
    info!("=========================================");

    let mut config = embassy_stm32::Config::default();
    config.rcc.hse = Some(Hse {
        freq: Hertz(24_000_000),
        mode: HseMode::Oscillator,
    });
    config.rcc.pll1 = Some(Pll {
        source: PllSource::HSE,
        prediv: PllPreDiv::from_bits(4),
        mul: PllMul::from_bits(159),
        divp: Some(PllDiv::from_bits(1)),
        divq: Some(PllDiv::from_bits(3)),
        divr: None,
    });
    config.rcc.sys = Sysclk::PLL1_P;
    config.rcc.ahb_pre = AHBPrescaler::DIV2;
    config.rcc.apb1_pre = APBPrescaler::DIV2;
    config.rcc.apb2_pre = APBPrescaler::DIV2;
    config.rcc.apb3_pre = APBPrescaler::DIV2;
    config.rcc.apb4_pre = APBPrescaler::DIV2;
    config.rcc.ls = LsConfig::default_lse();

    let p = embassy_stm32::init_primary(config, &SHARED_DATA);

    let mut i2c_config = embassy_stm32::i2c::Config::default();
    i2c_config.frequency = Hertz(100_000);

    let mut i2c = I2c::new(
        p.I2C1, p.PB6, p.PB7, Irqs,
        p.DMA1_CH0, p.DMA1_CH1,
        i2c_config,
    );
    info!("I2C1 ready (PB6=SCL, PB7=SDA, 100 kHz)");
    Timer::after(Duration::from_millis(50)).await;

    // Step 1: prove the bus works
    info!("");
    info!("[Step 1] Reading BMI088 gyro chip ID...");
    match read_gyro_id(&mut i2c).await {
        Ok(id) => {
            info!("  Gyro chip ID = 0x{:02x} (expected 0x{:02x})", id, EXPECTED_GYRO_ID);
            if id == EXPECTED_GYRO_ID {
                info!("  Bus is healthy.");
            } else {
                info!("  WARNING: unexpected ID, but bus responded.");
            }
        }
        Err(e) => {
            info!("  FAILED: {:?}", e);
            info!("  Can't proceed -- check wiring.");
            halt().await;
        }
    }

    // Step 2: wait for manual glitch
    info!("");
    info!("[Step 2] Ground SDA (PB7) briefly to trigger the fault...");
    info!("  Entering continuous read loop -- trigger glitch now...");

    loop {
        match read_gyro_id_timed(&mut i2c).await {
            Ok(Ok(id)) => info!("  read OK (0x{:02x}) -- waiting for glitch...", id),
            Ok(Err(e)) => {
                info!("  read FAILED ({:?}) -- continuing test.", e);
                break;
            }
            Err(()) => {
                info!("  read HUNG (timeout) -- continuing test.");
                break;
            }
        }
        Timer::after(Duration::from_millis(100)).await;
    }

    // Step 3: confirm stuck
    info!("");
    info!("[Step 3] Confirming bus is stuck (5 reads)...");
    let mut stuck_count = 0u32;
    for attempt in 0..5u32 {
        Timer::after(Duration::from_millis(200)).await;
        match read_gyro_id_timed(&mut i2c).await {
            Ok(Ok(id)) => info!("  Attempt {}: OK (0x{:02x})", attempt + 1, id),
            Ok(Err(e)) => {
                info!("  Attempt {}: FAILED {:?}", attempt + 1, e);
                stuck_count += 1;
            }
            Err(()) => {
                info!("  Attempt {}: HUNG (timeout)", attempt + 1);
                stuck_count += 1;
            }
        }
    }
    if stuck_count == 5 {
        info!("  All 5 reads failed. Bus is stuck.");
    } else if stuck_count == 0 {
        info!("  Bus recovered on its own (fix is working).");
    }

    // Step 4: manual PE toggle
    info!("");
    info!("[Step 4] Manual PE toggle via PAC...");
    {
        let i2c1 = pac::I2C1;
        i2c1.cr1().modify(|w| w.set_pe(false));
        while i2c1.cr1().read().pe() {}
        i2c1.cr1().modify(|w| w.set_pe(true));
    }
    info!("  PE toggled.");
    Timer::after(Duration::from_millis(10)).await;

    // Step 5: read after recovery
    info!("");
    info!("[Step 5] Reading after PE recovery...");
    match read_gyro_id_timed(&mut i2c).await {
        Ok(Ok(id)) => {
            info!("  Gyro chip ID = 0x{:02x}", id);
            info!("  BUS RECOVERED.");
        }
        Ok(Err(e)) => info!("  Still failing: {:?}", e),
        Err(()) => info!("  Still hung."),
    }

    info!("");
    info!("=========================================");
    info!("  Test complete.");
    info!("=========================================");
    halt().await;
}

async fn halt() -> ! {
    loop { Timer::after(Duration::from_secs(5)).await; }
}
```

</details>


The software glitch injection wasn't reliable enough to trigger a true BERR on its own (it mostly hit ARLO), so I triggered the fault by briefly grounding the SDA line (PB7) during an active transaction. This puts the peripheral into a state where transactions hang or fail permanently.

### Before the fix (stock embassy-stm32)

```
[Step 1] Reading BMI088 gyro chip ID...
  Gyro chip ID = 0x0f (expected 0x0f)
  Bus is healthy.

[Step 2] Injecting SDA glitch to trigger BERR...
  Entering continuous read loop -- trigger glitch now...
  read OK (0x0f) -- waiting for glitch...
  read OK (0x0f) -- waiting for glitch...
  read HUNG (timeout) -- bus stuck! Continuing test.

[Step 3] Confirming bus is stuck (5 reads, all should fail)...
  Attempt 1: FAILED Timeout
  Attempt 2: FAILED Timeout
  Attempt 3: FAILED Timeout
  Attempt 4: FAILED Timeout
  Attempt 5: FAILED Timeout
  All 5 reads failed. Bus is stuck.

[Step 4] Manual PE toggle recovery via raw PAC registers...
  PE toggled off and back on.

[Step 5] Reading gyro chip ID after PE recovery...
  Gyro chip ID = 0x0f
  BUS RECOVERED! The PE toggle fixed the state machine.
```

After grounding SDA, the bus hangs permanently. All 5 verification reads fail with timeout. The manual PE toggle at step 4 is needed to recover.

### After the fix (this PR)

```
[Step 1] Reading BMI088 gyro chip ID...
  Gyro chip ID = 0x0f (expected 0x0f)
  Bus is healthy.

[Step 2] Injecting SDA glitch to trigger BERR...
  Entering continuous read loop -- trigger glitch now...
  read OK (0x0f) -- waiting for glitch...
  read FAILED (Nack) -- bus stuck! Continuing test.

[Step 3] Confirming bus is stuck (5 reads, all should fail)...
  Attempt 1: OK (0x0f)
  Attempt 2: OK (0x0f)
  Attempt 3: OK (0x0f)
  Attempt 4: OK (0x0f)
  Attempt 5: OK (0x0f)
  Bus seems OK? The glitch didn't stick.
```

Same test, same manual SDA ground. The glitch triggers a Nack (not a hang), and the bus immediately recovers on the next transaction. All 5 verification reads succeed. The manual PE toggle in step 4 is redundant because the driver already did it.

## Chips affected

This applies to all STM32 families using the I2C v2 peripheral (F7, H7, L4, G4, U5, WL, etc.), not just H7. The v2.rs driver is shared across all of them.