### PR TITLE
Minor doc edits

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,5 +165,5 @@ Unless you explicitly state otherwise, any contribution intentionally submitted
 for inclusion in the work by you, as defined in the Apache-2.0 license, shall be
 dual licensed as above, without any additional terms or conditions.
 
-[1]: https://github.com/embassy-rs/embassy/wiki/Getting-Started
+[1]: https://embassy-rs.github.io/embassy-book/embassy/dev/getting_started.html
 [2]: https://github.com/embassy-rs/embassy/wiki/Running-the-Examples

--- a/docs/pages/getting_started.adoc
+++ b/docs/pages/getting_started.adoc
@@ -4,6 +4,7 @@ So you want to try Embassy, great! To get started, there are a few tools you nee
 
 * link:https://rustup.rs/[rustup] - the Rust toolchain is needed to compile Rust code.
 * link:https://probe.rs/[probe-rs] - to flash the firmware on your device. If you already have other tools like `OpenOCD` setup, you can use that as well.
+* link:https://https://github.com/knurling-rs/flip-link[flip-link] - to link certain example binaries with stack overflow protection.
 
 If you don't have any supported board, don't worry: you can also run embassy on your PC using the `std` examples.
 


### PR DESCRIPTION
* Fixes dead link in README
* Adds link to flip-link, which I needed to link the examples