### PR TITLE
stm32/qei: Add auto reload and count reset

### DIFF
--- a/embassy-stm32/src/timer/qei.rs
+++ b/embassy-stm32/src/timer/qei.rs
@@ -143,4 +143,9 @@ impl<'d, T: GeneralInstance4Channel> Qei<'d, T> {
     pub fn count(&self) -> u16 {
         self.inner.regs_gp16().cnt().read().cnt()
     }
+
+    /// Reset count.
+    pub fn reset(&mut self) {
+        self.inner.regs_gp16().cnt().modify(|w| w.set_cnt(0));
+    }
 }


### PR DESCRIPTION
- Add an  `auto_reload` field to the config struct, which is useful for automatically wrapping the counter when used with a rotary encoder (resolves #5013).
- Add a method to reset the counter, allowing the encoder to be manually indexed (useful for #5413).

Tested with a NUCLEO-G431KB and a quadrature encoder.