### PR TITLE
[MCXA] Fix time driver for small durations

### DIFF
--- a/embassy-mcxa/src/ostimer.rs
+++ b/embassy-mcxa/src/ostimer.rs
@@ -101,6 +101,7 @@ impl OsTimer {
         unsafe { interrupt::OS_EVENT.enable() };
     }
 
+    /// Set an alarm for timestamp, returning false if the time has already expired.
     fn set_alarm(&self, cs: CriticalSection, timestamp: u64) -> bool {
         let alarm = self.alarms.borrow(cs);
         alarm.timestamp.set(timestamp);
@@ -108,6 +109,14 @@ impl OsTimer {
         // Wait until we're allowed to write to MATCH_L/MATCH_H registers
         while OSTIMER0.osevent_ctrl().read().match_wr_rdy() {}
 
+        let gray_timestamp = dec_to_gray(timestamp);
+
+        OSTIMER0.match_l().write(|w| w.set_match_value(gray_timestamp as u32));
+        OSTIMER0
+            .match_h()
+            .write(|w| w.set_match_value((gray_timestamp >> 32) as u16));
+
+        // Check if the timestamp has already expired, which could mean the just set match value would never match.
         let t = self.now();
         if timestamp <= t {
             OSTIMER0.osevent_ctrl().modify(|w| w.set_ostimer_intena(false));
@@ -115,14 +124,8 @@ impl OsTimer {
             return false;
         }
 
-        let gray_timestamp = dec_to_gray(timestamp);
-
-        OSTIMER0.match_l().write(|w| w.set_match_value(gray_timestamp as u32));
-        OSTIMER0
-            .match_h()
-            .write(|w| w.set_match_value((gray_timestamp >> 32) as u16));
+        // Enable interrupt. If the timestamp already matched, this would immediately pend the interrupt.
         OSTIMER0.osevent_ctrl().modify(|w| w.set_ostimer_intena(true));
-
         true
     }
 


### PR DESCRIPTION
When setting a Timer like `embassy_time::Timer::after_micros(1).await` the future would never complete typically. This is because it was possible to set a timer timestamp that would pass during that procedure.

Fixed by checking if the time passed after setting the match register, ensuring either an interrupt being pended, or the time-has-already-passed check to check against a timestamp larger or equal to what we just set.