### PR TITLE
Prepare embassy-usb-synopsys-otg release

### DIFF
--- a/docs/examples/layer-by-layer/blinky-async/Cargo.toml
+++ b/docs/examples/layer-by-layer/blinky-async/Cargo.toml
@@ -8,7 +8,7 @@ publish = false
 [dependencies]
 cortex-m = { version = "0.7", features = ["critical-section-single-core"] }
 cortex-m-rt = "0.7"
-embassy-stm32 = { version = "0.5.0", path = "../../../../embassy-stm32", features = ["stm32l475vg", "memory-x", "exti"]  }
+embassy-stm32 = { version = "0.6.0", path = "../../../../embassy-stm32", features = ["stm32l475vg", "memory-x", "exti"]  }
 embassy-executor = { version = "0.9.0", path = "../../../../embassy-executor", features = ["arch-cortex-m", "executor-thread"] }
 
 defmt = "1.0.1"

--- a/docs/examples/layer-by-layer/blinky-hal/Cargo.toml
+++ b/docs/examples/layer-by-layer/blinky-hal/Cargo.toml
@@ -8,7 +8,7 @@ publish = false
 [dependencies]
 cortex-m-rt = "0.7"
 cortex-m = { version = "0.7", features = ["critical-section-single-core"] }
-embassy-stm32 = { version = "0.5.0", path = "../../../../embassy-stm32", features = ["stm32l475vg", "memory-x"] }
+embassy-stm32 = { version = "0.6.0", path = "../../../../embassy-stm32", features = ["stm32l475vg", "memory-x"] }
 
 defmt = "1.0.1"
 defmt-rtt = "1.0.0"

--- a/docs/examples/layer-by-layer/blinky-irq/Cargo.toml
+++ b/docs/examples/layer-by-layer/blinky-irq/Cargo.toml
@@ -10,7 +10,7 @@ publish = false
 [dependencies]
 cortex-m = { version = "0.7", features = ["critical-section-single-core"] }
 cortex-m-rt = { version = "0.7" }
-embassy-stm32 = { version = "0.5.0", path = "../../../../embassy-stm32", features = ["stm32l475vg", "memory-x", "unstable-pac"] }
+embassy-stm32 = { version = "0.6.0", path = "../../../../embassy-stm32", features = ["stm32l475vg", "memory-x", "unstable-pac"] }
 
 defmt = "1.0.1"
 defmt-rtt = "1.0.0"

--- a/embassy-boot-stm32/CHANGELOG.md
+++ b/embassy-boot-stm32/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 <!-- next-header -->
 ## Unreleased - ReleaseDate
 
+## 0.8.0 - 2026-03-11
+
 ## 0.7.0 - 2026-01-04
 
 - Update embassy-stm32 version

--- a/embassy-boot-stm32/Cargo.toml
+++ b/embassy-boot-stm32/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 edition = "2024"
 name = "embassy-boot-stm32"
-version = "0.7.0"
+version = "0.8.0"
 description = "Bootloader lib for STM32 chips"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/embassy-rs/embassy"
@@ -31,7 +31,7 @@ defmt = { version = "1.0.1", optional = true }
 log = { version = "0.4", optional = true }
 
 embassy-sync = { version = "0.7.2", path = "../embassy-sync" }
-embassy-stm32 = { version = "0.5.0", path = "../embassy-stm32", default-features = false }
+embassy-stm32 = { version = "0.6.0", path = "../embassy-stm32", default-features = false }
 embassy-boot = { version = "0.6.1", path = "../embassy-boot" }
 cortex-m = { version = "0.7.6" }
 cortex-m-rt = { version = "0.7" }

--- a/embassy-stm32-wpan/Cargo.toml
+++ b/embassy-stm32-wpan/Cargo.toml
@@ -26,7 +26,7 @@ features = ["stm32wb55rg", "wb55_ble", "wb55_mac"]
 features = ["stm32wb55rg", "wb55_ble", "wb55_mac"]
 
 [dependencies]
-embassy-stm32 = { version = "0.5.0", path = "../embassy-stm32" , features = ["unstable-pac"]}
+embassy-stm32 = { version = "0.6.0", path = "../embassy-stm32" , features = ["unstable-pac"]}
 embassy-sync = { version = "0.7.2", path = "../embassy-sync" }
 embassy-time = { version = "0.5.0", path = "../embassy-time", optional = true }
 embassy-futures = { version = "0.1.2", path = "../embassy-futures" }

--- a/embassy-stm32/CHANGELOG.md
+++ b/embassy-stm32/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 <!-- next-header -->
 ## Unreleased - ReleaseDate
+
+## 0.6.0 - 2026-03-11
 - fix: stm32/i2s: fix frame misalignment after DMA ring buffer overrun recovery by adding alignment support to `ReadableDmaRingBuffer`
 - fix: stm32/i2s: defer I2SE enable from constructor to `start()` for proper slave frame synchronization
 - fix: stm32/i2s: Use correct PLLI2S clock source for STM32F2 and STM32F7 instead of APB clock

--- a/embassy-stm32/Cargo.toml
+++ b/embassy-stm32/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "embassy-stm32"
-version = "0.5.0"
+version = "0.6.0"
 edition = "2024"
 license = "MIT OR Apache-2.0"
 description = "Embassy Hardware Abstraction Layer (HAL) for ST STM32 series microcontrollers"
@@ -158,7 +158,7 @@ embassy-hal-internal = { version = "0.4.0", path = "../embassy-hal-internal", fe
 embassy-embedded-hal = { version = "0.5.0", path = "../embassy-embedded-hal", default-features = false }
 embassy-net-driver = { version = "0.2.0", path = "../embassy-net-driver" }
 embassy-usb-driver = { version = "0.2.0", path = "../embassy-usb-driver" }
-embassy-usb-synopsys-otg = { version = "0.3.1", path = "../embassy-usb-synopsys-otg" }
+embassy-usb-synopsys-otg = { version = "0.3.2", path = "../embassy-usb-synopsys-otg" }
 embassy-executor = { version = "0.9.0", path = "../embassy-executor", optional = true }
 cyw43 = { version = "0.6.0", path = "../cyw43", optional = true }
 

--- a/embassy-usb-synopsys-otg/CHANGELOG.md
+++ b/embassy-usb-synopsys-otg/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 <!-- next-header -->
 ## Unreleased - ReleaseDate
 
+## 0.3.2 - 2026-03-11
+
 - Disabling an OUT endpoint no longer flushes the TX FIFO of the corresponding IN endpoint
 
 ## 0.3.1 - 2025-08-26

--- a/embassy-usb-synopsys-otg/Cargo.toml
+++ b/embassy-usb-synopsys-otg/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "embassy-usb-synopsys-otg"
-version = "0.3.1"
+version = "0.3.2"
 edition = "2024"
 license = "MIT OR Apache-2.0"
 description = "`embassy-usb-driver` implementation for Synopsys OTG USB controllers"

--- a/examples/boot/application/stm32f3/Cargo.toml
+++ b/examples/boot/application/stm32f3/Cargo.toml
@@ -9,8 +9,8 @@ publish = false
 embassy-sync = { version = "0.7.2", path = "../../../../embassy-sync" }
 embassy-executor = { version = "0.9.0", path = "../../../../embassy-executor", features = ["arch-cortex-m", "executor-thread"] }
 embassy-time = { version = "0.5.0", path = "../../../../embassy-time", features = [ "tick-hz-32_768"] }
-embassy-stm32 = { version = "0.5.0", path = "../../../../embassy-stm32", features = ["stm32f303re", "time-driver-any", "exti"]  }
-embassy-boot-stm32 = { version = "0.7.0", path = "../../../../embassy-boot-stm32" }
+embassy-stm32 = { version = "0.6.0", path = "../../../../embassy-stm32", features = ["stm32f303re", "time-driver-any", "exti"]  }
+embassy-boot-stm32 = { version = "0.8.0", path = "../../../../embassy-boot-stm32" }
 embassy-embedded-hal = { version = "0.5.0", path = "../../../../embassy-embedded-hal" }
 
 defmt = { version = "1.0.1", optional = true }

--- a/examples/boot/application/stm32f7/Cargo.toml
+++ b/examples/boot/application/stm32f7/Cargo.toml
@@ -9,8 +9,8 @@ publish = false
 embassy-sync = { version = "0.7.2", path = "../../../../embassy-sync" }
 embassy-executor = { version = "0.9.0", path = "../../../../embassy-executor", features = ["arch-cortex-m", "executor-thread"] }
 embassy-time = { version = "0.5.0", path = "../../../../embassy-time", features = [ "tick-hz-32_768"] }
-embassy-stm32 = { version = "0.5.0", path = "../../../../embassy-stm32", features = ["stm32f767zi", "time-driver-any", "exti", "single-bank"]  }
-embassy-boot-stm32 = { version = "0.7.0", path = "../../../../embassy-boot-stm32", features = [] }
+embassy-stm32 = { version = "0.6.0", path = "../../../../embassy-stm32", features = ["stm32f767zi", "time-driver-any", "exti", "single-bank"]  }
+embassy-boot-stm32 = { version = "0.8.0", path = "../../../../embassy-boot-stm32", features = [] }
 embassy-embedded-hal = { version = "0.5.0", path = "../../../../embassy-embedded-hal" }
 
 defmt = { version = "1.0.1", optional = true }

--- a/examples/boot/application/stm32h7/Cargo.toml
+++ b/examples/boot/application/stm32h7/Cargo.toml
@@ -9,8 +9,8 @@ publish = false
 embassy-sync = { version = "0.7.2", path = "../../../../embassy-sync" }
 embassy-executor = { version = "0.9.0", path = "../../../../embassy-executor", features = ["arch-cortex-m", "executor-thread"] }
 embassy-time = { version = "0.5.0", path = "../../../../embassy-time", features = [ "tick-hz-32_768"] }
-embassy-stm32 = { version = "0.5.0", path = "../../../../embassy-stm32", features = ["stm32h743zi", "time-driver-any", "exti"]  }
-embassy-boot-stm32 = { version = "0.7.0", path = "../../../../embassy-boot-stm32", features = [] }
+embassy-stm32 = { version = "0.6.0", path = "../../../../embassy-stm32", features = ["stm32h743zi", "time-driver-any", "exti"]  }
+embassy-boot-stm32 = { version = "0.8.0", path = "../../../../embassy-boot-stm32", features = [] }
 embassy-embedded-hal = { version = "0.5.0", path = "../../../../embassy-embedded-hal" }
 
 defmt = { version = "1.0.1", optional = true }

--- a/examples/boot/application/stm32l0/Cargo.toml
+++ b/examples/boot/application/stm32l0/Cargo.toml
@@ -9,8 +9,8 @@ publish = false
 embassy-sync = { version = "0.7.2", path = "../../../../embassy-sync" }
 embassy-executor = { version = "0.9.0", path = "../../../../embassy-executor", features = ["arch-cortex-m", "executor-thread"] }
 embassy-time = { version = "0.5.0", path = "../../../../embassy-time", features = [ "tick-hz-32_768"] }
-embassy-stm32 = { version = "0.5.0", path = "../../../../embassy-stm32", features = ["stm32l072cz", "time-driver-any", "exti", "memory-x"]  }
-embassy-boot-stm32 = { version = "0.7.0", path = "../../../../embassy-boot-stm32", features = [] }
+embassy-stm32 = { version = "0.6.0", path = "../../../../embassy-stm32", features = ["stm32l072cz", "time-driver-any", "exti", "memory-x"]  }
+embassy-boot-stm32 = { version = "0.8.0", path = "../../../../embassy-boot-stm32", features = [] }
 embassy-embedded-hal = { version = "0.5.0", path = "../../../../embassy-embedded-hal" }
 
 defmt = { version = "1.0.1", optional = true }

--- a/examples/boot/application/stm32l1/Cargo.toml
+++ b/examples/boot/application/stm32l1/Cargo.toml
@@ -9,8 +9,8 @@ publish = false
 embassy-sync = { version = "0.7.2", path = "../../../../embassy-sync" }
 embassy-executor = { version = "0.9.0", path = "../../../../embassy-executor", features = ["arch-cortex-m", "executor-thread"] }
 embassy-time = { version = "0.5.0", path = "../../../../embassy-time", features = [ "tick-hz-32_768"] }
-embassy-stm32 = { version = "0.5.0", path = "../../../../embassy-stm32", features = ["stm32l151cb-a", "time-driver-any", "exti"]  }
-embassy-boot-stm32 = { version = "0.7.0", path = "../../../../embassy-boot-stm32", features = [] }
+embassy-stm32 = { version = "0.6.0", path = "../../../../embassy-stm32", features = ["stm32l151cb-a", "time-driver-any", "exti"]  }
+embassy-boot-stm32 = { version = "0.8.0", path = "../../../../embassy-boot-stm32", features = [] }
 embassy-embedded-hal = { version = "0.5.0", path = "../../../../embassy-embedded-hal" }
 
 defmt = { version = "1.0.1", optional = true }

--- a/examples/boot/application/stm32l4/Cargo.toml
+++ b/examples/boot/application/stm32l4/Cargo.toml
@@ -9,8 +9,8 @@ publish = false
 embassy-sync = { version = "0.7.2", path = "../../../../embassy-sync" }
 embassy-executor = { version = "0.9.0", path = "../../../../embassy-executor", features = ["arch-cortex-m", "executor-thread"] }
 embassy-time = { version = "0.5.0", path = "../../../../embassy-time", features = [ "tick-hz-32_768"] }
-embassy-stm32 = { version = "0.5.0", path = "../../../../embassy-stm32", features = ["stm32l475vg", "time-driver-any", "exti"]  }
-embassy-boot-stm32 = { version = "0.7.0", path = "../../../../embassy-boot-stm32", features = [] }
+embassy-stm32 = { version = "0.6.0", path = "../../../../embassy-stm32", features = ["stm32l475vg", "time-driver-any", "exti"]  }
+embassy-boot-stm32 = { version = "0.8.0", path = "../../../../embassy-boot-stm32", features = [] }
 embassy-embedded-hal = { version = "0.5.0", path = "../../../../embassy-embedded-hal" }
 
 defmt = { version = "1.0.1", optional = true }

--- a/examples/boot/application/stm32wb-dfu/Cargo.toml
+++ b/examples/boot/application/stm32wb-dfu/Cargo.toml
@@ -9,8 +9,8 @@ publish = false
 embassy-sync = { version = "0.7.2", path = "../../../../embassy-sync" }
 embassy-executor = { version = "0.9.0", path = "../../../../embassy-executor", features = ["arch-cortex-m", "executor-thread"] }
 embassy-time = { version = "0.5.0", path = "../../../../embassy-time", features = [ "tick-hz-32_768"] }
-embassy-stm32 = { version = "0.5.0", path = "../../../../embassy-stm32", features = ["stm32wb55rg", "time-driver-any", "exti"]  }
-embassy-boot-stm32 = { version = "0.7.0", path = "../../../../embassy-boot-stm32", features = [] }
+embassy-stm32 = { version = "0.6.0", path = "../../../../embassy-stm32", features = ["stm32wb55rg", "time-driver-any", "exti"]  }
+embassy-boot-stm32 = { version = "0.8.0", path = "../../../../embassy-boot-stm32", features = [] }
 embassy-embedded-hal = { version = "0.5.0", path = "../../../../embassy-embedded-hal" }
 embassy-usb = { version = "0.5.1", path = "../../../../embassy-usb" }
 embassy-usb-dfu = { version = "0.2.0", path = "../../../../embassy-usb-dfu", features = ["application", "cortex-m"] }

--- a/examples/boot/application/stm32wba-dfu/Cargo.toml
+++ b/examples/boot/application/stm32wba-dfu/Cargo.toml
@@ -9,8 +9,8 @@ publish = false
 embassy-sync = { version = "0.7.2", path = "../../../../embassy-sync" }
 embassy-executor = { version = "0.9.0", path = "../../../../embassy-executor", features = ["arch-cortex-m", "executor-thread"] }
 embassy-time = { version = "0.5.0", path = "../../../../embassy-time", features = [ "tick-hz-32_768"] }
-embassy-stm32 = { version = "0.5.0", path = "../../../../embassy-stm32", features = ["stm32wba65ri", "time-driver-any", "exti"]  }
-embassy-boot-stm32 = { version = "0.7.0", path = "../../../../embassy-boot-stm32", features = [] }
+embassy-stm32 = { version = "0.6.0", path = "../../../../embassy-stm32", features = ["stm32wba65ri", "time-driver-any", "exti"]  }
+embassy-boot-stm32 = { version = "0.8.0", path = "../../../../embassy-boot-stm32", features = [] }
 embassy-embedded-hal = { version = "0.5.0", path = "../../../../embassy-embedded-hal" }
 embassy-usb = { version = "0.5.1", path = "../../../../embassy-usb" }
 embassy-usb-dfu = { version = "0.2.0", path = "../../../../embassy-usb-dfu", features = ["application", "cortex-m"] }

--- a/examples/boot/application/stm32wl/Cargo.toml
+++ b/examples/boot/application/stm32wl/Cargo.toml
@@ -9,8 +9,8 @@ publish = false
 embassy-sync = { version = "0.7.2", path = "../../../../embassy-sync" }
 embassy-executor = { version = "0.9.0", path = "../../../../embassy-executor", features = ["arch-cortex-m", "executor-thread"] }
 embassy-time = { version = "0.5.0", path = "../../../../embassy-time", features = [ "tick-hz-32_768"] }
-embassy-stm32 = { version = "0.5.0", path = "../../../../embassy-stm32", features = ["stm32wl55jc-cm4", "time-driver-any", "exti"]  }
-embassy-boot-stm32 = { version = "0.7.0", path = "../../../../embassy-boot-stm32", features = [] }
+embassy-stm32 = { version = "0.6.0", path = "../../../../embassy-stm32", features = ["stm32wl55jc-cm4", "time-driver-any", "exti"]  }
+embassy-boot-stm32 = { version = "0.8.0", path = "../../../../embassy-boot-stm32", features = [] }
 embassy-embedded-hal = { version = "0.5.0", path = "../../../../embassy-embedded-hal" }
 
 defmt = { version = "1.0.1", optional = true }

--- a/examples/stm32c0/Cargo.toml
+++ b/examples/stm32c0/Cargo.toml
@@ -7,7 +7,7 @@ publish = false
 
 [dependencies]
 # Change stm32c031c6 to your chip name, if necessary.
-embassy-stm32 = { version = "0.5.0", path = "../../embassy-stm32", features = [ "defmt", "time-driver-any", "stm32c031c6", "memory-x", "unstable-pac", "exti", "chrono"]  }
+embassy-stm32 = { version = "0.6.0", path = "../../embassy-stm32", features = [ "defmt", "time-driver-any", "stm32c031c6", "memory-x", "unstable-pac", "exti", "chrono"]  }
 embassy-sync = { version = "0.7.2", path = "../../embassy-sync", features = ["defmt"] }
 embassy-executor = { version = "0.9.0", path = "../../embassy-executor", features = ["arch-cortex-m", "executor-thread", "defmt"] }
 embassy-time = { version = "0.5.0", path = "../../embassy-time", features = ["defmt", "defmt-timestamp-uptime", "tick-hz-32_768"] }

--- a/examples/stm32f072/Cargo.toml
+++ b/examples/stm32f072/Cargo.toml
@@ -7,7 +7,7 @@ publish = false
 
 [dependencies]
 # Change stm32f091rc to your chip name, if necessary.
-embassy-stm32 = { version = "0.5.0", path = "../../embassy-stm32", features = [ "defmt", "memory-x", "stm32f072rb", "time-driver-tim2", "exti", "unstable-pac"] }
+embassy-stm32 = { version = "0.6.0", path = "../../embassy-stm32", features = [ "defmt", "memory-x", "stm32f072rb", "time-driver-tim2", "exti", "unstable-pac"] }
 cortex-m = { version = "0.7.6", features = ["inline-asm", "critical-section-single-core"] }
 cortex-m-rt = "0.7.0"
 defmt = "1.0.1"

--- a/examples/stm32f1/Cargo.toml
+++ b/examples/stm32f1/Cargo.toml
@@ -7,7 +7,7 @@ publish = false
 
 [dependencies]
 # Change stm32f103c8 to your chip name, if necessary.
-embassy-stm32 = { version = "0.5.0", path = "../../embassy-stm32", features = [ "defmt", "stm32f103c8", "unstable-pac", "memory-x", "time-driver-any" ]  }
+embassy-stm32 = { version = "0.6.0", path = "../../embassy-stm32", features = [ "defmt", "stm32f103c8", "unstable-pac", "memory-x", "time-driver-any" ]  }
 embassy-sync = { version = "0.7.2", path = "../../embassy-sync", features = ["defmt"] }
 embassy-executor = { version = "0.9.0", path = "../../embassy-executor", features = ["arch-cortex-m", "executor-thread", "defmt"] }
 embassy-time = { version = "0.5.0", path = "../../embassy-time", features = ["defmt", "defmt-timestamp-uptime", "tick-hz-32_768"] }

--- a/examples/stm32f105/Cargo.toml
+++ b/examples/stm32f105/Cargo.toml
@@ -7,7 +7,7 @@ publish = false
 
 [dependencies]
 # Change stm32f105vb to your chip name, if necessary.
-embassy-stm32 = { version = "0.5.0", path = "../../embassy-stm32", features = [ "defmt", "stm32f105vb", "unstable-pac", "memory-x", "time-driver-any" ]  }
+embassy-stm32 = { version = "0.6.0", path = "../../embassy-stm32", features = [ "defmt", "stm32f105vb", "unstable-pac", "memory-x", "time-driver-any" ]  }
 embassy-executor = { version = "0.9.0", path = "../../embassy-executor", features = ["arch-cortex-m", "executor-thread", "defmt"] }
 embassy-usb = { version = "0.5.1", path = "../../embassy-usb", features = ["defmt"] }
 embassy-futures = { version = "0.1.2", path = "../../embassy-futures" }

--- a/examples/stm32f107/Cargo.toml
+++ b/examples/stm32f107/Cargo.toml
@@ -7,7 +7,7 @@ publish = false
 
 [dependencies]
 # Change stm32f107rc to your chip name, if necessary.
-embassy-stm32 = { version = "0.5.0", path = "../../embassy-stm32", features = [ "defmt", "stm32f107rc", "unstable-pac", "memory-x", "time-driver-any" ]  }
+embassy-stm32 = { version = "0.6.0", path = "../../embassy-stm32", features = [ "defmt", "stm32f107rc", "unstable-pac", "memory-x", "time-driver-any" ]  }
 embassy-executor = { version = "0.9.0", path = "../../embassy-executor", features = ["arch-cortex-m", "executor-thread", "defmt"] }
 embassy-net = { version = "0.8.0", path = "../../embassy-net", features = ["defmt", "tcp", "dhcpv4"] }
 

--- a/examples/stm32f2/Cargo.toml
+++ b/examples/stm32f2/Cargo.toml
@@ -7,7 +7,7 @@ publish = false
 
 [dependencies]
 # Change stm32f207zg to your chip name, if necessary.
-embassy-stm32 = { version = "0.5.0", path = "../../embassy-stm32", features = [ "defmt", "stm32f207zg", "unstable-pac", "memory-x", "time-driver-any", "exti"]  }
+embassy-stm32 = { version = "0.6.0", path = "../../embassy-stm32", features = [ "defmt", "stm32f207zg", "unstable-pac", "memory-x", "time-driver-any", "exti"]  }
 embassy-sync = { version = "0.7.2", path = "../../embassy-sync", features = ["defmt"] }
 embassy-executor = { version = "0.9.0", path = "../../embassy-executor", features = ["arch-cortex-m", "executor-thread", "defmt"] }
 embassy-time = { version = "0.5.0", path = "../../embassy-time", features = ["defmt", "defmt-timestamp-uptime", "tick-hz-32_768"] }

--- a/examples/stm32f3/Cargo.toml
+++ b/examples/stm32f3/Cargo.toml
@@ -7,7 +7,7 @@ publish = false
 
 [dependencies]
 # Change stm32f303ze to your chip name, if necessary.
-embassy-stm32 = { version = "0.5.0", path = "../../embassy-stm32", features = [ "defmt", "stm32f303ze", "unstable-pac", "memory-x", "time-driver-tim2", "exti"]  }
+embassy-stm32 = { version = "0.6.0", path = "../../embassy-stm32", features = [ "defmt", "stm32f303ze", "unstable-pac", "memory-x", "time-driver-tim2", "exti"]  }
 embassy-sync = { version = "0.7.2", path = "../../embassy-sync", features = ["defmt"] }
 embassy-executor = { version = "0.9.0", path = "../../embassy-executor", features = ["arch-cortex-m", "executor-thread", "executor-interrupt", "defmt"] }
 embassy-time = { version = "0.5.0", path = "../../embassy-time", features = ["defmt", "defmt-timestamp-uptime", "tick-hz-32_768"] }

--- a/examples/stm32f334/Cargo.toml
+++ b/examples/stm32f334/Cargo.toml
@@ -9,7 +9,7 @@ publish = false
 embassy-sync = { version = "0.7.2", path = "../../embassy-sync", features = ["defmt"] }
 embassy-executor = { version = "0.9.0", path = "../../embassy-executor", features = ["arch-cortex-m", "executor-thread", "executor-interrupt", "defmt"] }
 embassy-time = { version = "0.5.0", path = "../../embassy-time", features = ["defmt", "defmt-timestamp-uptime", "tick-hz-32_768"] }
-embassy-stm32 = { version = "0.5.0", path = "../../embassy-stm32", features = [ "defmt", "stm32f334r8", "unstable-pac", "memory-x", "time-driver-any", "exti"]  }
+embassy-stm32 = { version = "0.6.0", path = "../../embassy-stm32", features = [ "defmt", "stm32f334r8", "unstable-pac", "memory-x", "time-driver-any", "exti"]  }
 embassy-usb = { version = "0.5.1", path = "../../embassy-usb", features = ["defmt"] }
 embassy-futures = { version = "0.1.2", path = "../../embassy-futures" }
 

--- a/examples/stm32f4/Cargo.toml
+++ b/examples/stm32f4/Cargo.toml
@@ -7,7 +7,7 @@ publish = false
 
 [dependencies]
 # Change stm32f429zi to your chip name, if necessary.
-embassy-stm32 = { version = "0.5.0", path = "../../embassy-stm32", features = ["defmt", "stm32f429zi", "unstable-pac", "memory-x", "time-driver-tim4", "exti", "chrono"] }
+embassy-stm32 = { version = "0.6.0", path = "../../embassy-stm32", features = ["defmt", "stm32f429zi", "unstable-pac", "memory-x", "time-driver-tim4", "exti", "chrono"] }
 embassy-sync = { version = "0.7.2", path = "../../embassy-sync", features = ["defmt"] }
 embassy-executor = { version = "0.9.0", path = "../../embassy-executor", features = ["arch-cortex-m", "executor-thread", "executor-interrupt", "defmt"] }
 embassy-time = { version = "0.5.0", path = "../../embassy-time", features = ["defmt", "defmt-timestamp-uptime", "tick-hz-32_768"] }

--- a/examples/stm32f401/Cargo.toml
+++ b/examples/stm32f401/Cargo.toml
@@ -6,7 +6,7 @@ license = "MIT OR Apache-2.0"
 publish = false
 
 [dependencies]
-embassy-stm32 = { version = "0.5.0", path = "../../embassy-stm32", features = ["defmt", "stm32f401re", "unstable-pac", "memory-x", "time-driver-tim4", "exti", "chrono"] }
+embassy-stm32 = { version = "0.6.0", path = "../../embassy-stm32", features = ["defmt", "stm32f401re", "unstable-pac", "memory-x", "time-driver-tim4", "exti", "chrono"] }
 embassy-sync = { version = "0.7.2", path = "../../embassy-sync", features = ["defmt"] }
 embassy-executor = { version = "0.9.0", path = "../../embassy-executor", features = ["arch-cortex-m", "executor-thread", "executor-interrupt", "defmt"] }
 embassy-time = { version = "0.5.0", path = "../../embassy-time", features = ["defmt", "defmt-timestamp-uptime", "tick-hz-32_768"] }

--- a/examples/stm32f469/Cargo.toml
+++ b/examples/stm32f469/Cargo.toml
@@ -7,7 +7,7 @@ publish = false
 
 [dependencies]
 # Specific examples only for stm32f469
-embassy-stm32 = { version = "0.5.0", path = "../../embassy-stm32", features = ["defmt", "stm32f469ni", "unstable-pac", "memory-x", "time-driver-any", "exti", "chrono"] }
+embassy-stm32 = { version = "0.6.0", path = "../../embassy-stm32", features = ["defmt", "stm32f469ni", "unstable-pac", "memory-x", "time-driver-any", "exti", "chrono"] }
 embassy-executor = { version = "0.9.0", path = "../../embassy-executor", features = ["arch-cortex-m", "executor-thread", "executor-interrupt", "defmt"] }
 embassy-time = { version = "0.5.0", path = "../../embassy-time", features = ["defmt", "defmt-timestamp-uptime", "tick-hz-32_768"] }
 

--- a/examples/stm32f7/Cargo.toml
+++ b/examples/stm32f7/Cargo.toml
@@ -7,7 +7,7 @@ publish = false
 
 [dependencies]
 # Change stm32f777zi to your chip name, if necessary.
-embassy-stm32 = { version = "0.5.0", path = "../../embassy-stm32", features = ["defmt", "stm32f777zi", "memory-x", "unstable-pac", "time-driver-any", "exti", "single-bank"]  }
+embassy-stm32 = { version = "0.6.0", path = "../../embassy-stm32", features = ["defmt", "stm32f777zi", "memory-x", "unstable-pac", "time-driver-any", "exti", "single-bank"]  }
 embassy-sync = { version = "0.7.2", path = "../../embassy-sync", features = ["defmt"] }
 embassy-executor = { version = "0.9.0", path = "../../embassy-executor", features = ["arch-cortex-m", "executor-thread", "defmt"] }
 embassy-time = { version = "0.5.0", path = "../../embassy-time", features = ["defmt", "defmt-timestamp-uptime", "tick-hz-32_768"] }

--- a/examples/stm32g0/Cargo.toml
+++ b/examples/stm32g0/Cargo.toml
@@ -7,7 +7,7 @@ publish = false
 
 [dependencies]
 # Change stm32g0b1re to your chip name, if necessary.
-embassy-stm32 = { version = "0.5.0", path = "../../embassy-stm32", features = [ "defmt", "time-driver-any", "stm32g0b1re", "memory-x", "unstable-pac", "exti"]  }
+embassy-stm32 = { version = "0.6.0", path = "../../embassy-stm32", features = [ "defmt", "time-driver-any", "stm32g0b1re", "memory-x", "unstable-pac", "exti"]  }
 embassy-sync = { version = "0.7.2", path = "../../embassy-sync", features = ["defmt"] }
 embassy-executor = { version = "0.9.0", path = "../../embassy-executor", features = ["arch-cortex-m", "executor-thread", "defmt"] }
 embassy-time = { version = "0.5.0", path = "../../embassy-time", features = ["defmt", "defmt-timestamp-uptime", "tick-hz-32_768"] }

--- a/examples/stm32h5/Cargo.toml
+++ b/examples/stm32h5/Cargo.toml
@@ -7,7 +7,7 @@ publish = false
 
 [dependencies]
 # Change stm32h563zi to your chip name, if necessary.
-embassy-stm32 = { version = "0.5.0", path = "../../embassy-stm32", features = ["defmt", "stm32h563zi", "memory-x", "time-driver-any", "exti", "unstable-pac", "low-power-disable-pender", "cyw43"] }
+embassy-stm32 = { version = "0.6.0", path = "../../embassy-stm32", features = ["defmt", "stm32h563zi", "memory-x", "time-driver-any", "exti", "unstable-pac", "low-power-disable-pender", "cyw43"] }
 embassy-sync = { version = "0.7.2", path = "../../embassy-sync", features = ["defmt"] }
 embassy-executor = { version = "0.9.0", path = "../../embassy-executor", features = ["arch-cortex-m", "executor-thread", "defmt"] }
 embassy-time = { version = "0.5.0", path = "../../embassy-time", features = ["defmt", "defmt-timestamp-uptime", "tick-hz-32_768"] }

--- a/examples/stm32h7/Cargo.toml
+++ b/examples/stm32h7/Cargo.toml
@@ -7,7 +7,7 @@ publish = false
 
 [dependencies]
 # Change stm32h743bi to your chip name, if necessary.
-embassy-stm32 = { version = "0.5.0", path = "../../embassy-stm32", features = ["defmt", "stm32h743bi", "time-driver-tim2", "exti", "memory-x", "unstable-pac", "chrono"] }
+embassy-stm32 = { version = "0.6.0", path = "../../embassy-stm32", features = ["defmt", "stm32h743bi", "time-driver-tim2", "exti", "memory-x", "unstable-pac", "chrono"] }
 embassy-sync = { version = "0.7.2", path = "../../embassy-sync", features = ["defmt"] }
 embassy-embedded-hal = { version = "0.5.0", path = "../../embassy-embedded-hal" }
 embassy-executor = { version = "0.9.0", path = "../../embassy-executor", features = ["arch-cortex-m", "executor-thread", "executor-interrupt", "defmt"] }

--- a/examples/stm32h723/Cargo.toml
+++ b/examples/stm32h723/Cargo.toml
@@ -7,7 +7,7 @@ publish = false
 
 [dependencies]
 # Change stm32h723zg to your chip name, if necessary.
-embassy-stm32 = { version = "0.5.0", path = "../../embassy-stm32", features = ["defmt", "stm32h723zg", "time-driver-tim2", "exti", "memory-x", "unstable-pac", "chrono"] }
+embassy-stm32 = { version = "0.6.0", path = "../../embassy-stm32", features = ["defmt", "stm32h723zg", "time-driver-tim2", "exti", "memory-x", "unstable-pac", "chrono"] }
 embassy-sync = { version = "0.7.2", path = "../../embassy-sync", features = ["defmt"] }
 embassy-executor = { version = "0.9.0", path = "../../embassy-executor", features = ["arch-cortex-m", "executor-thread", "executor-interrupt", "defmt"] }
 embassy-time = { version = "0.5.0", path = "../../embassy-time", features = ["defmt", "defmt-timestamp-uptime", "tick-hz-32_768"] }

--- a/examples/stm32h735/Cargo.toml
+++ b/examples/stm32h735/Cargo.toml
@@ -6,7 +6,7 @@ license = "MIT OR Apache-2.0"
 publish = false
 
 [dependencies]
-embassy-stm32 = { version = "0.5.0", path = "../../embassy-stm32", features = ["defmt", "stm32h735ig", "time-driver-tim2", "exti", "memory-x", "unstable-pac", "chrono"] }
+embassy-stm32 = { version = "0.6.0", path = "../../embassy-stm32", features = ["defmt", "stm32h735ig", "time-driver-tim2", "exti", "memory-x", "unstable-pac", "chrono"] }
 embassy-sync = { version = "0.7.2", path = "../../embassy-sync", features = ["defmt"] }
 embassy-embedded-hal = { version = "0.5.0", path = "../../embassy-embedded-hal" }
 embassy-executor = { version = "0.9.0", path = "../../embassy-executor", features = ["arch-cortex-m", "executor-thread", "executor-interrupt", "defmt"] }

--- a/examples/stm32h742/Cargo.toml
+++ b/examples/stm32h742/Cargo.toml
@@ -6,7 +6,7 @@ license = "MIT OR Apache-2.0"
 publish = false
 
 [dependencies]
-embassy-stm32 = { version = "0.5.0", path = "../../embassy-stm32", features = [
+embassy-stm32 = { version = "0.6.0", path = "../../embassy-stm32", features = [
     "defmt",
     "stm32h742vi",
     "memory-x",

--- a/examples/stm32h755cm7/Cargo.toml
+++ b/examples/stm32h755cm7/Cargo.toml
@@ -7,7 +7,7 @@ publish = false
 
 [dependencies]
 # Change stm32h743bi to your chip name, if necessary.
-embassy-stm32 = { version = "0.5.0", path = "../../embassy-stm32", features = ["defmt", "stm32h755zi-cm7", "time-driver-tim3", "exti", "memory-x", "unstable-pac", "chrono"] }
+embassy-stm32 = { version = "0.6.0", path = "../../embassy-stm32", features = ["defmt", "stm32h755zi-cm7", "time-driver-tim3", "exti", "memory-x", "unstable-pac", "chrono"] }
 embassy-sync = { version = "0.7.2", path = "../../embassy-sync", features = ["defmt"] }
 embassy-embedded-hal = { version = "0.5.0", path = "../../embassy-embedded-hal" }
 embassy-executor = { version = "0.9.0", path = "../../embassy-executor", features = ["arch-cortex-m", "executor-thread", "executor-interrupt", "defmt"] }

--- a/examples/stm32h7b0/Cargo.toml
+++ b/examples/stm32h7b0/Cargo.toml
@@ -6,7 +6,7 @@ license = "MIT OR Apache-2.0"
 publish = false
 
 [dependencies]
-embassy-stm32 = { version = "0.5.0", path = "../../embassy-stm32", features = ["defmt", "stm32h7b0vb", "time-driver-tim2", "exti", "memory-x", "unstable-pac", "chrono"] }
+embassy-stm32 = { version = "0.6.0", path = "../../embassy-stm32", features = ["defmt", "stm32h7b0vb", "time-driver-tim2", "exti", "memory-x", "unstable-pac", "chrono"] }
 embassy-sync = { version = "0.7.2", path = "../../embassy-sync", features = ["defmt"] }
 embassy-embedded-hal = { version = "0.5.0", path = "../../embassy-embedded-hal" }
 embassy-executor = { version = "0.9.0", path = "../../embassy-executor", features = ["arch-cortex-m", "executor-thread", "executor-interrupt", "defmt"] }

--- a/examples/stm32h7rs/Cargo.toml
+++ b/examples/stm32h7rs/Cargo.toml
@@ -7,7 +7,7 @@ publish = false
 
 [dependencies]
 # Change stm32h743bi to your chip name, if necessary.
-embassy-stm32 = { version = "0.5.0", path = "../../embassy-stm32", features = ["defmt", "stm32h7s3l8", "time-driver-tim2", "exti", "memory-x", "unstable-pac", "chrono"] }
+embassy-stm32 = { version = "0.6.0", path = "../../embassy-stm32", features = ["defmt", "stm32h7s3l8", "time-driver-tim2", "exti", "memory-x", "unstable-pac", "chrono"] }
 embassy-sync = { version = "0.7.2", path = "../../embassy-sync", features = ["defmt"] }
 embassy-executor = { version = "0.9.0", path = "../../embassy-executor", features = ["arch-cortex-m", "executor-thread", "executor-interrupt", "defmt"] }
 embassy-time = { version = "0.5.0", path = "../../embassy-time", features = ["defmt", "defmt-timestamp-uptime", "tick-hz-32_768"] }

--- a/examples/stm32l0/Cargo.toml
+++ b/examples/stm32l0/Cargo.toml
@@ -7,7 +7,7 @@ publish = false
 
 [dependencies]
 # Change stm32l072cz to your chip name, if necessary.
-embassy-stm32 = { version = "0.5.0", path = "../../embassy-stm32", features = ["defmt", "stm32l073rz", "unstable-pac", "time-driver-any", "exti", "memory-x", "low-power-disable-pender"]  }
+embassy-stm32 = { version = "0.6.0", path = "../../embassy-stm32", features = ["defmt", "stm32l073rz", "unstable-pac", "time-driver-any", "exti", "memory-x", "low-power-disable-pender"]  }
 embassy-sync = { version = "0.7.2", path = "../../embassy-sync", features = ["defmt"] }
 embassy-executor = { version = "0.9.0", path = "../../embassy-executor", features = ["arch-cortex-m", "executor-thread", "defmt"] }
 embassy-time = { version = "0.5.0", path = "../../embassy-time", features = ["defmt", "defmt-timestamp-uptime", "tick-hz-32_768"] }

--- a/examples/stm32l1/Cargo.toml
+++ b/examples/stm32l1/Cargo.toml
@@ -9,7 +9,7 @@ publish = false
 embassy-sync = { version = "0.7.2", path = "../../embassy-sync", features = ["defmt"] }
 embassy-executor = { version = "0.9.0", path = "../../embassy-executor", features = ["arch-cortex-m", "executor-thread", "defmt"] }
 embassy-time = { version = "0.5.0", path = "../../embassy-time", features = ["defmt", "defmt-timestamp-uptime", "tick-hz-32_768"] }
-embassy-stm32 = { version = "0.5.0", path = "../../embassy-stm32", features = [ "defmt", "stm32l151cb-a", "time-driver-any", "memory-x"]  }
+embassy-stm32 = { version = "0.6.0", path = "../../embassy-stm32", features = [ "defmt", "stm32l151cb-a", "time-driver-any", "memory-x"]  }
 embassy-usb = { version = "0.5.1", path = "../../embassy-usb", features = ["defmt"] }
 embassy-futures = { version = "0.1.2", path = "../../embassy-futures" }
 

--- a/examples/stm32l4-rtic/Cargo.toml
+++ b/examples/stm32l4-rtic/Cargo.toml
@@ -8,7 +8,7 @@ publish = false
 [dependencies]
 
 # Change stm32l4r5zi to your chip name, if necessary.
-embassy-stm32 = { version = "0.5.0", path = "../../embassy-stm32", features = [ "defmt", "unstable-pac", "stm32l4r5zi", "memory-x", "exti", "single-bank"]  }
+embassy-stm32 = { version = "0.6.0", path = "../../embassy-stm32", features = [ "defmt", "unstable-pac", "stm32l4r5zi", "memory-x", "exti", "single-bank"]  }
 
 # rtic = { version = "2.1.2", features = [ "thumbv7-backend" ] }
 rtic = { version = "2.2.0", features = [ "thumbv7-backend" ] }

--- a/examples/stm32l4/Cargo.toml
+++ b/examples/stm32l4/Cargo.toml
@@ -7,7 +7,7 @@ publish = false
 
 [dependencies]
 # Change stm32l4s5vi to your chip name, if necessary.
-embassy-stm32 = { version = "0.5.0", path = "../../embassy-stm32", features = [ "defmt", "unstable-pac", "stm32l4r5zi", "memory-x", "time-driver-any", "exti", "chrono", "dual-bank"]  }
+embassy-stm32 = { version = "0.6.0", path = "../../embassy-stm32", features = [ "defmt", "unstable-pac", "stm32l4r5zi", "memory-x", "time-driver-any", "exti", "chrono", "dual-bank"]  }
 embassy-sync = { version = "0.7.2", path = "../../embassy-sync", features = ["defmt"] }
 embassy-executor = { version = "0.9.0", path = "../../embassy-executor", features = ["arch-cortex-m", "executor-thread", "defmt"] }
 embassy-time = { version = "0.5.0", path = "../../embassy-time", features = ["defmt", "defmt-timestamp-uptime", "tick-hz-32_768", ] }

--- a/examples/stm32l432/Cargo.toml
+++ b/examples/stm32l432/Cargo.toml
@@ -7,7 +7,7 @@ publish = false
 
 [dependencies]
 # Change stm32l4s5vi to your chip name, if necessary.
-embassy-stm32 = { version = "0.5.0", path = "../../embassy-stm32", features = [ "defmt", "unstable-pac", "stm32l432kc", "memory-x", "time-driver-any", "exti", "chrono"] }
+embassy-stm32 = { version = "0.6.0", path = "../../embassy-stm32", features = [ "defmt", "unstable-pac", "stm32l432kc", "memory-x", "time-driver-any", "exti", "chrono"] }
 embassy-sync = { version = "0.7.2", path = "../../embassy-sync", features = [ "defmt" ] }
 embassy-executor = { version = "0.9.0", path = "../../embassy-executor", features = [ "arch-cortex-m", "executor-thread", "defmt" ] }
 embassy-time = { version = "0.5.0", path = "../../embassy-time", features = [ "defmt", "defmt-timestamp-uptime", "tick-hz-32_768" ] }

--- a/examples/stm32l5/Cargo.toml
+++ b/examples/stm32l5/Cargo.toml
@@ -7,7 +7,7 @@ publish = false
 
 [dependencies]
 # Change stm32l552ze to your chip name, if necessary.
-embassy-stm32 = { version = "0.5.0", path = "../../embassy-stm32", features = [ "defmt", "unstable-pac", "stm32l552ze", "time-driver-any", "exti", "memory-x", "low-power-disable-pender", "dual-bank"]  }
+embassy-stm32 = { version = "0.6.0", path = "../../embassy-stm32", features = [ "defmt", "unstable-pac", "stm32l552ze", "time-driver-any", "exti", "memory-x", "low-power-disable-pender", "dual-bank"]  }
 embassy-sync = { version = "0.7.2", path = "../../embassy-sync", features = ["defmt"] }
 embassy-executor = { version = "0.9.0", path = "../../embassy-executor", features = ["arch-cortex-m", "executor-thread", "defmt"] }
 embassy-time = { version = "0.5.0", path = "../../embassy-time", features = ["defmt", "defmt-timestamp-uptime", "tick-hz-32_768"] }

--- a/examples/stm32n6/Cargo.toml
+++ b/examples/stm32n6/Cargo.toml
@@ -7,7 +7,7 @@ publish = false
 
 [dependencies]
 # Change stm32h563zi to your chip name, if necessary.
-embassy-stm32 = { version = "0.5.0", path = "../../embassy-stm32", features = ["defmt", "stm32n657x0", "time-driver-any", "exti", "unstable-pac"] }
+embassy-stm32 = { version = "0.6.0", path = "../../embassy-stm32", features = ["defmt", "stm32n657x0", "time-driver-any", "exti", "unstable-pac"] }
 embassy-sync = { version = "0.7.2", path = "../../embassy-sync", features = ["defmt"] }
 embassy-executor = { version = "0.9.0", path = "../../embassy-executor", features = ["arch-cortex-m", "executor-thread", "defmt"] }
 embassy-time = { version = "0.5.0", path = "../../embassy-time", features = ["defmt", "defmt-timestamp-uptime", "tick-hz-32_768"] }

--- a/examples/stm32u0/Cargo.toml
+++ b/examples/stm32u0/Cargo.toml
@@ -7,7 +7,7 @@ publish = false
 
 [dependencies]
 # Change stm32u083mc to your chip name, if necessary.
-embassy-stm32 = { version = "0.5.0", path = "../../embassy-stm32", features = [ "defmt", "time-driver-any", "stm32u083mc", "memory-x", "unstable-pac", "exti", "chrono"]  }
+embassy-stm32 = { version = "0.6.0", path = "../../embassy-stm32", features = [ "defmt", "time-driver-any", "stm32u083mc", "memory-x", "unstable-pac", "exti", "chrono"]  }
 embassy-sync = { version = "0.7.2", path = "../../embassy-sync", features = ["defmt"] }
 embassy-executor = { version = "0.9.0", path = "../../embassy-executor", features = ["arch-cortex-m", "executor-thread", "defmt"] }
 embassy-time = { version = "0.5.0", path = "../../embassy-time", features = ["defmt", "defmt-timestamp-uptime", "tick-hz-32_768"] }

--- a/examples/stm32u3/Cargo.toml
+++ b/examples/stm32u3/Cargo.toml
@@ -6,7 +6,7 @@ license = "MIT OR Apache-2.0"
 publish = false
 
 [dependencies]
-embassy-stm32 = { version = "0.5.0", path = "../../embassy-stm32", features = ["defmt", "unstable-pac", "stm32u385rg", "time-driver-any", "memory-x", "exti", "chrono", "low-power-disable-pender"]  }
+embassy-stm32 = { version = "0.6.0", path = "../../embassy-stm32", features = ["defmt", "unstable-pac", "stm32u385rg", "time-driver-any", "memory-x", "exti", "chrono", "low-power-disable-pender"]  }
 embassy-sync = { version = "0.7.2", path = "../../embassy-sync", features = ["defmt"] }
 embassy-executor = { version = "0.9.0", path = "../../embassy-executor", features = ["arch-cortex-m", "executor-thread", "defmt"] }
 embassy-time = { version = "0.5.0", path = "../../embassy-time", features = ["defmt", "defmt-timestamp-uptime", "tick-hz-32_768"] }

--- a/examples/stm32u5/Cargo.toml
+++ b/examples/stm32u5/Cargo.toml
@@ -7,7 +7,7 @@ publish = false
 
 [dependencies]
 # Change stm32u5g9zj to your chip name, if necessary.
-embassy-stm32 = { version = "0.5.0", path = "../../embassy-stm32", features = ["defmt", "unstable-pac", "stm32u5g9zj", "time-driver-any", "memory-x" ]  }
+embassy-stm32 = { version = "0.6.0", path = "../../embassy-stm32", features = ["defmt", "unstable-pac", "stm32u5g9zj", "time-driver-any", "memory-x" ]  }
 embassy-sync = { version = "0.7.2", path = "../../embassy-sync", features = ["defmt"] }
 embassy-executor = { version = "0.9.0", path = "../../embassy-executor", features = ["arch-cortex-m", "executor-thread", "defmt"] }
 embassy-time = { version = "0.5.0", path = "../../embassy-time", features = ["defmt", "defmt-timestamp-uptime", "tick-hz-32_768"] }

--- a/examples/stm32wb/Cargo.toml
+++ b/examples/stm32wb/Cargo.toml
@@ -7,7 +7,7 @@ publish = false
 
 [dependencies]
 # Change stm32wb55rg to your chip name in both dependencies, if necessary.
-embassy-stm32 = { version = "0.5.0", path = "../../embassy-stm32", features = [ "defmt", "stm32wb55rg", "time-driver-any", "memory-x", "exti", "low-power"]  }
+embassy-stm32 = { version = "0.6.0", path = "../../embassy-stm32", features = [ "defmt", "stm32wb55rg", "time-driver-any", "memory-x", "exti", "low-power"]  }
 embassy-stm32-wpan = { version = "0.1.0", path = "../../embassy-stm32-wpan", features = ["defmt", "stm32wb55rg"] }
 embassy-sync = { version = "0.7.2", path = "../../embassy-sync", features = ["defmt"] }
 embassy-executor = { version = "0.9.0", path = "../../embassy-executor", features = ["defmt"] }

--- a/examples/stm32wba-lp/Cargo.toml
+++ b/examples/stm32wba-lp/Cargo.toml
@@ -6,7 +6,7 @@ license = "MIT OR Apache-2.0"
 publish = false
 
 [dependencies]
-embassy-stm32 = { version = "0.5.0", path = "../../embassy-stm32", features = ["defmt", "stm32wba52cg", "time-driver-any", "memory-x", "unstable-pac", "exti", "low-power"] }
+embassy-stm32 = { version = "0.6.0", path = "../../embassy-stm32", features = ["defmt", "stm32wba52cg", "time-driver-any", "memory-x", "unstable-pac", "exti", "low-power"] }
 embassy-sync = { version = "0.7.2", path = "../../embassy-sync", features = ["defmt"] }
 embassy-executor = { version = "0.9.0", path = "../../embassy-executor", features = ["defmt"] }
 embassy-time = { version = "0.5.0", path = "../../embassy-time", features = ["defmt", "defmt-timestamp-uptime", "tick-hz-32_768"] }

--- a/examples/stm32wba/Cargo.toml
+++ b/examples/stm32wba/Cargo.toml
@@ -6,7 +6,7 @@ license = "MIT OR Apache-2.0"
 publish = false
 
 [dependencies]
-embassy-stm32 = { version = "0.5.0", path = "../../embassy-stm32", features = [ "defmt", "stm32wba52cg", "time-driver-any", "memory-x", "exti"]  }
+embassy-stm32 = { version = "0.6.0", path = "../../embassy-stm32", features = [ "defmt", "stm32wba52cg", "time-driver-any", "memory-x", "exti"]  }
 stm32-metapac = { version = "19", features = ["stm32wba52cg"] }
 embassy-stm32-wpan = { version = "0.1.0", path = "../../embassy-stm32-wpan", features = ["defmt", "stm32wba52cg", "ble-stack-basic", "linklayer-ble-basic"] }
 embassy-sync = { version = "0.7.2", path = "../../embassy-sync", features = ["defmt"] }

--- a/examples/stm32wba6-lp/Cargo.toml
+++ b/examples/stm32wba6-lp/Cargo.toml
@@ -6,7 +6,7 @@ license = "MIT OR Apache-2.0"
 publish = false
 
 [dependencies]
-embassy-stm32 = { version = "0.5.0", path = "../../embassy-stm32", features = ["defmt", "stm32wba65ri", "time-driver-any", "memory-x", "unstable-pac", "exti", "low-power"] }
+embassy-stm32 = { version = "0.6.0", path = "../../embassy-stm32", features = ["defmt", "stm32wba65ri", "time-driver-any", "memory-x", "unstable-pac", "exti", "low-power"] }
 embassy-sync = { version = "0.7.2", path = "../../embassy-sync", features = ["defmt"] }
 embassy-executor = { version = "0.9.0", path = "../../embassy-executor", features = ["defmt"] }
 embassy-time = { version = "0.5.0", path = "../../embassy-time", features = ["defmt", "defmt-timestamp-uptime", "tick-hz-32_768"] }

--- a/examples/stm32wba6/Cargo.toml
+++ b/examples/stm32wba6/Cargo.toml
@@ -6,7 +6,7 @@ license = "MIT OR Apache-2.0"
 publish = false
 
 [dependencies]
-embassy-stm32 = { version = "0.5.0", path = "../../embassy-stm32", features = [ "defmt", "stm32wba65ri", "time-driver-any", "memory-x", "exti"]  }
+embassy-stm32 = { version = "0.6.0", path = "../../embassy-stm32", features = [ "defmt", "stm32wba65ri", "time-driver-any", "memory-x", "exti"]  }
 stm32-metapac = { version = "19", features = ["stm32wba65ri"] }
 embassy-stm32-wpan = { version = "0.1.0", path = "../../embassy-stm32-wpan", features = ["defmt", "stm32wba65ri"], optional = true }
 embassy-sync = { version = "0.7.2", path = "../../embassy-sync", features = ["defmt"] }

--- a/examples/stm32wl/Cargo.toml
+++ b/examples/stm32wl/Cargo.toml
@@ -7,7 +7,7 @@ publish = false
 
 [dependencies]
 # Change stm32wl55jc-cm4 to your chip name, if necessary.
-embassy-stm32 = { version = "0.5.0", path = "../../embassy-stm32", features = ["defmt", "stm32wl55jc-cm4", "time-driver-any", "memory-x", "unstable-pac", "exti", "chrono"] }
+embassy-stm32 = { version = "0.6.0", path = "../../embassy-stm32", features = ["defmt", "stm32wl55jc-cm4", "time-driver-any", "memory-x", "unstable-pac", "exti", "chrono"] }
 embassy-sync = { version = "0.7.2", path = "../../embassy-sync", features = ["defmt"] }
 embassy-executor = { version = "0.9.0", path = "../../embassy-executor", features = ["arch-cortex-m", "executor-thread", "defmt"] }
 embassy-time = { version = "0.5.0", path = "../../embassy-time", features = ["defmt", "defmt-timestamp-uptime", "tick-hz-32_768"] }

--- a/examples/stm32wl55cm0p-lp/Cargo.toml
+++ b/examples/stm32wl55cm0p-lp/Cargo.toml
@@ -7,7 +7,7 @@ publish = false
 
 [dependencies]
 # Change stm32wl55jc-cm0 to your chip name, if necessary.
-embassy-stm32 = { version = "0.5.0", path = "../../embassy-stm32", features = [
+embassy-stm32 = { version = "0.6.0", path = "../../embassy-stm32", features = [
   "stm32wl55jc-cm0p",
   "time-driver-lptim1",
   "exti",

--- a/examples/stm32wl55cm0p/Cargo.toml
+++ b/examples/stm32wl55cm0p/Cargo.toml
@@ -7,7 +7,7 @@ publish = false
 
 [dependencies]
 # Change stm32wl55jc-cm0 to your chip name, if necessary.
-embassy-stm32 = { version = "0.5.0", path = "../../embassy-stm32", features = [
+embassy-stm32 = { version = "0.6.0", path = "../../embassy-stm32", features = [
   "defmt",
   "stm32wl55jc-cm0p",
   "time-driver-tim1",

--- a/examples/stm32wl55cm4-lp/Cargo.toml
+++ b/examples/stm32wl55cm4-lp/Cargo.toml
@@ -7,7 +7,7 @@ publish = false
 
 [dependencies]
 # Change stm32h743bi to your chip name, if necessary.
-embassy-stm32 = { version = "0.5.0", path = "../../embassy-stm32", features = [
+embassy-stm32 = { version = "0.6.0", path = "../../embassy-stm32", features = [
   "defmt",
   "stm32wl55jc-cm4",
   "time-driver-tim2",

--- a/examples/stm32wl55cm4/Cargo.toml
+++ b/examples/stm32wl55cm4/Cargo.toml
@@ -7,7 +7,7 @@ publish = false
 
 [dependencies]
 # Change stm32h743bi to your chip name, if necessary.
-embassy-stm32 = { version = "0.5.0", path = "../../embassy-stm32", features = ["defmt", "stm32wl55jc-cm4", "time-driver-tim2", "exti", "memory-x", "unstable-pac", "chrono"] }
+embassy-stm32 = { version = "0.6.0", path = "../../embassy-stm32", features = ["defmt", "stm32wl55jc-cm4", "time-driver-tim2", "exti", "memory-x", "unstable-pac", "chrono"] }
 embassy-sync = { version = "0.7.2", path = "../../embassy-sync", features = ["defmt"] }
 embassy-embedded-hal = { version = "0.5.0", path = "../../embassy-embedded-hal" }
 embassy-executor = { version = "0.9.0", path = "../../embassy-executor", features = ["arch-cortex-m", "executor-thread", "executor-interrupt", "defmt"] }

--- a/examples/stm32wle5-lp/Cargo.toml
+++ b/examples/stm32wle5-lp/Cargo.toml
@@ -7,7 +7,7 @@ publish = false
 
 [dependencies]
 # Change stm32wle5jc to your chip name, if necessary.
-embassy-stm32 = { version = "0.5.0", path = "../../embassy-stm32", features = ["defmt", "stm32wle5jc", "time-driver-lptim1", "memory-x", "unstable-pac", "exti", "low-power"] }
+embassy-stm32 = { version = "0.6.0", path = "../../embassy-stm32", features = ["defmt", "stm32wle5jc", "time-driver-lptim1", "memory-x", "unstable-pac", "exti", "low-power"] }
 embassy-sync = { version = "0.7.2", path = "../../embassy-sync", features = ["defmt"] }
 embassy-executor = { version = "0.9.0", path = "../../embassy-executor", features = ["defmt"] }
 embassy-time = { version = "0.5.0", path = "../../embassy-time", features = ["defmt", "defmt-timestamp-uptime", "tick-hz-1_000"] }

--- a/tests/stm32/Cargo.toml
+++ b/tests/stm32/Cargo.toml
@@ -75,7 +75,7 @@ teleprobe-meta = "1"
 embassy-sync = { version = "0.7.2", path = "../../embassy-sync", features = ["defmt"] }
 embassy-executor = { version = "0.9.0", path = "../../embassy-executor", features = ["arch-cortex-m", "executor-thread", "defmt"] }
 embassy-time = { version = "0.5.0", path = "../../embassy-time", features = ["defmt", "tick-hz-131_072", "defmt-timestamp-uptime"] }
-embassy-stm32 = { version = "0.5.0", path = "../../embassy-stm32", features = [ "defmt", "unstable-pac", "memory-x", "time-driver-any", "_allow-disable-rtc"]  }
+embassy-stm32 = { version = "0.6.0", path = "../../embassy-stm32", features = [ "defmt", "unstable-pac", "memory-x", "time-driver-any", "_allow-disable-rtc"]  }
 embassy-futures = { version = "0.1.2", path = "../../embassy-futures" }
 embassy-stm32-wpan = { version = "0.1.0", path = "../../embassy-stm32-wpan", optional = true, features = ["defmt", "stm32wb55rg", "wb55_ble"] }
 embassy-net = { version = "0.8.0", path = "../../embassy-net", features = ["defmt",  "tcp", "udp", "dhcpv4", "medium-ethernet"] }


### PR DESCRIPTION
This PR is the result of me running `cargo embassy-devtool prepare-release embassy-usb-synopsys-otg`. I don't know why the devtool bumped embassy-stm32 and embassy-boot-stm32 for this.
