### PR TITLE
stm32: derive opamp output ADC channels

### DIFF
--- a/embassy-stm32/build.rs
+++ b/embassy-stm32/build.rs
@@ -1634,20 +1634,8 @@ fn main() {
                         format_ident!("{}", pin.pin)
                     };
 
-                    // H7 has differential voltage measurements
-                    let ch: Option<(u8, bool)> = if pin.signal.starts_with("INP") {
-                        Some((pin.signal.strip_prefix("INP").unwrap().parse().unwrap(), false))
-                    } else if pin.signal.starts_with("INN") {
-                        Some((pin.signal.strip_prefix("INN").unwrap().parse().unwrap(), true))
-                    } else if pin.signal.starts_with("IN") && pin.signal.ends_with('b') {
-                        // we number STM32L1 ADC bank 1 as 0..=31, bank 2 as 32..=63
-                        let signal = pin.signal.strip_prefix("IN").unwrap().strip_suffix('b').unwrap();
-                        Some((32u8 + signal.parse::<u8>().unwrap(), false))
-                    } else if pin.signal.starts_with("IN") {
-                        Some((pin.signal.strip_prefix("IN").unwrap().parse().unwrap(), false))
-                    } else {
-                        None
-                    };
+                    // H7 has differential voltage measurements.
+                    let ch = parse_adc_pin_signal(pin.signal);
                     if let Some((ch, false)) = ch {
                         adc_pairs.entry(ch).or_insert((None, None)).0.replace(pin_name.clone());
 
@@ -1688,7 +1676,29 @@ fn main() {
                         // Impl OutputPin for the VOUT pin
                         g.extend(quote! {
                             impl_opamp_vout_pin!( #peri, #pin_name );
-                        })
+                        });
+
+                        for adc in METADATA.peripherals {
+                            let Some(adc_regs) = &adc.registers else {
+                                continue;
+                            };
+                            if adc_regs.kind != "adc" || adc.rcc.is_none() {
+                                continue;
+                            }
+
+                            let adc_peri = format_ident!("{}", adc.name);
+                            for adc_pin in adc.pins {
+                                if adc_pin.pin != pin.pin {
+                                    continue;
+                                }
+
+                                if let Some((ch, false)) = parse_adc_pin_signal(adc_pin.signal) {
+                                    g.extend(quote! {
+                                        impl_opamp_external_output!( #peri, #adc_peri, #ch );
+                                    });
+                                }
+                            }
+                        }
                     }
                 }
 
@@ -2692,6 +2702,22 @@ fn mem_filter(chip: &str, region: &str) -> bool {
     }
 
     true
+}
+
+fn parse_adc_pin_signal(signal: &str) -> Option<(u8, bool)> {
+    if signal.starts_with("INP") {
+        Some((signal.strip_prefix("INP").unwrap().parse().unwrap(), false))
+    } else if signal.starts_with("INN") {
+        Some((signal.strip_prefix("INN").unwrap().parse().unwrap(), true))
+    } else if signal.starts_with("IN") && signal.ends_with('b') {
+        // We number STM32L1 ADC bank 1 as 0..=31, bank 2 as 32..=63.
+        let signal = signal.strip_prefix("IN").unwrap().strip_suffix('b').unwrap();
+        Some((32u8 + signal.parse::<u8>().unwrap(), false))
+    } else if signal.starts_with("IN") {
+        Some((signal.strip_prefix("IN").unwrap().parse().unwrap(), false))
+    } else {
+        None
+    }
 }
 
 #[derive(Copy, Clone, Debug)]

--- a/embassy-stm32/src/opamp.rs
+++ b/embassy-stm32/src/opamp.rs
@@ -602,7 +602,7 @@ macro_rules! impl_opamp_external_output {
         foreach_adc!(
             ($adc, $common_inst:ident, $adc_clock:ident) => {
                 impl<'d> crate::adc::SealedAdcChannel<crate::peripherals::$adc>
-                    for OpAmpOutput<'d, crate::peripherals::$inst>
+                    for crate::opamp::OpAmpOutput<'d, crate::peripherals::$inst>
                 {
                     fn channel(&self) -> u8 {
                         $ch
@@ -610,40 +610,13 @@ macro_rules! impl_opamp_external_output {
                 }
 
                 impl<'d> crate::adc::AdcChannel<crate::peripherals::$adc>
-                    for OpAmpOutput<'d, crate::peripherals::$inst>
+                    for crate::opamp::OpAmpOutput<'d, crate::peripherals::$inst>
                 {
                 }
             };
         );
     };
 }
-
-foreach_peripheral!(
-    (opamp, OPAMP1) => {
-        impl_opamp_external_output!(OPAMP1, ADC1, 3);
-    };
-    (opamp, OPAMP2) => {
-        impl_opamp_external_output!(OPAMP2, ADC2, 3);
-    };
-    (opamp, OPAMP3) => {
-        impl_opamp_external_output!(OPAMP3, ADC1, 12);
-        impl_opamp_external_output!(OPAMP3, ADC3, 1);
-    };
-    // OPAMP4 only in STM32G4 Cat 3 devices
-    (opamp, OPAMP4) => {
-        impl_opamp_external_output!(OPAMP4, ADC1, 11);
-        impl_opamp_external_output!(OPAMP4, ADC4, 3);
-    };
-    // OPAMP5 only in STM32G4 Cat 3 devices
-    (opamp, OPAMP5) => {
-        impl_opamp_external_output!(OPAMP5, ADC5, 1);
-    };
-    // OPAMP6 only in STM32G4 Cat 3/4 devices
-    (opamp, OPAMP6) => {
-        impl_opamp_external_output!(OPAMP6, ADC1, 14);
-        impl_opamp_external_output!(OPAMP6, ADC2, 14);
-    };
-);
 
 #[cfg(opamp_v5)]
 macro_rules! impl_opamp_internal_output {


### PR DESCRIPTION
Previously, `embassy-stm32/src/opamp.rs` contained a hardcoded table for external OPAMP outputs, for example `OPAMP1 -> ADC1 channel 3`.  This is wrong for e.g. STM32L4 parts like STM32L431, where the chip metadata and datasheet say `OPAMP1_VOUT` is on `PA3`, and `PA3` is `ADC1_IN8`.

This removes the hardcoded table and extends `build.rs` to generate the the macro definitions instead. It uses the `VOUT` pin information present on the opamp and the existing translation to ADC channels.