### PR TITLE
stm32: add comparator support for STM32G4

### DIFF
--- a/embassy-stm32/Cargo.toml
+++ b/embassy-stm32/Cargo.toml
@@ -203,12 +203,12 @@ block-device-driver = { version = "0.2" }
 aligned = "0.4.3"
 heapless = "0.9.1"
 
-stm32-metapac = { version = "20" }
-# stm32-metapac = { git = "https://github.com/embassy-rs/stm32-data-generated", tag = "stm32-data-0f4c948b5c81ebe421fe902857ccdb39029651f6" }
+# stm32-metapac = { version = "20" }
+stm32-metapac = { git = "https://github.com/embassy-rs/stm32-data-generated", tag = "stm32-data-21b543f6cab91a2966c0a4247e418d73a87a4ae7" }
 
 [build-dependencies]
-stm32-metapac = { version = "20", default-features = false, features = ["metadata"]}
-# stm32-metapac = { git = "https://github.com/embassy-rs/stm32-data-generated", tag = "stm32-data-0f4c948b5c81ebe421fe902857ccdb39029651f6", default-features = false, features = ["metadata"] }
+# stm32-metapac = { version = "20", default-features = false, features = ["metadata"]}
+stm32-metapac = { git = "https://github.com/embassy-rs/stm32-data-generated", tag = "stm32-data-21b543f6cab91a2966c0a4247e418d73a87a4ae7", default-features = false, features = ["metadata"] }
 
 proc-macro2 = "1.0.36"
 quote = "1.0.15"

--- a/embassy-stm32/build.rs
+++ b/embassy-stm32/build.rs
@@ -1705,15 +1705,24 @@ fn main() {
                 if regs.kind == "comp" {
                     let peri = format_ident!("{}", p.name);
                     let pin_name = format_ident!("{}", pin.pin);
-                    if pin.signal.starts_with("INP") {
-                        // Impl InputPlusPin for INP or INP0, INP1 etc.
-                        let ch: u8 = pin.signal.strip_prefix("INP").unwrap().parse().unwrap_or(0);
+                    // Check if this peripheral has numbered signals (e.g. INP0/INP1 from extra YAML).
+                    // If so, skip bare INP/INM to avoid duplicate trait impls.
+                    let has_numbered = p.pins.iter().any(|s| s.signal.starts_with("INP") && s.signal.len() > 3);
+                    if let Some(ch_str) = pin.signal.strip_prefix("INP") {
+                        let ch: u8 = match ch_str.parse() {
+                            Ok(ch) => ch,
+                            Err(_) if !has_numbered => 0, // bare "INP" on chips without numbered signals
+                            Err(_) => continue,           // skip bare "INP" when numbered signals exist
+                        };
                         g.extend(quote! {
                             impl_comp_inp_pin!( #peri, #pin_name, #ch );
                         });
-                    } else if pin.signal.starts_with("INM") {
-                        // Impl InputMinusPin for INM or INM0, INM1 etc.
-                        let ch: u8 = pin.signal.strip_prefix("INM").unwrap().parse().unwrap_or(0);
+                    } else if let Some(ch_str) = pin.signal.strip_prefix("INM") {
+                        let ch: u8 = match ch_str.parse() {
+                            Ok(ch) => ch,
+                            Err(_) if !has_numbered => 0,
+                            Err(_) => continue,
+                        };
                         g.extend(quote! {
                             impl_comp_inm_pin!( #peri, #pin_name, #ch );
                         });

--- a/embassy-stm32/src/comp.rs
+++ b/embassy-stm32/src/comp.rs
@@ -1,7 +1,7 @@
 //! Analog Comparator (COMP)
 //!
-//! This driver currently supports chips with the comp_u5 peripheral version
-//! (STM32WBA and STM32U5 series).
+//! This driver supports chips with the comp_u5 peripheral version
+//! (STM32WBA and STM32U5 series) and comp_v2 (STM32G4 series).
 #![macro_use]
 
 use core::future::poll_fn;
@@ -10,6 +10,7 @@ use core::task::Poll;
 
 use embassy_hal_internal::PeripheralType;
 use embassy_sync::waitqueue::AtomicWaker;
+use stm32_metapac::comp::vals;
 
 use crate::interrupt::typelevel::{Binding, Interrupt};
 use crate::rcc::RccInfo;
@@ -30,6 +31,7 @@ pub enum PowerMode {
 /// Hysteresis level.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
+#[cfg(comp_u5)]
 pub enum Hysteresis {
     /// No hysteresis.
     None,
@@ -39,6 +41,29 @@ pub enum Hysteresis {
     Medium,
     /// High hysteresis.
     High,
+}
+
+/// Hysteresis level.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+#[cfg(comp_v2)]
+pub enum Hysteresis {
+    /// No hysteresis.
+    None,
+    /// 10mV hysteresis.
+    Hyst10M,
+    /// 20mV hysteresis.
+    Hyst20M,
+    /// 30mV hysteresis.
+    Hyst30M,
+    /// 40mV hysteresis.
+    Hyst40M,
+    /// 50mV hysteresis.
+    Hyst50M,
+    /// 60mV hysteresis.
+    Hyst60M,
+    /// 70mV hysteresis.
+    Hyst70M,
 }
 
 /// Output polarity.
@@ -69,6 +94,9 @@ pub enum InvertingInput {
     Dac2,
     /// External IO pin (INM1).
     InputPin,
+    /// External IO pin (INM2).
+    #[cfg(comp_v2)]
+    InputPin2,
 }
 
 /// Blanking source selection.
@@ -233,16 +261,27 @@ impl<'d, T: Instance> Comp<'d, T> {
         Self { _peri: peri }
     }
 
-    #[cfg(comp_u5)]
-    fn configure(inp_channel: u8, config: Config) {
-        use crate::pac::comp::vals;
-
+    fn configure_raw(inp_channel: u8, inmsel: vals::Inm, config: Config) {
+        #[cfg(comp_u5)]
         let pwrmode = match config.power_mode {
             PowerMode::HighSpeed => vals::PowerMode::HIGH_SPEED,
             PowerMode::MediumSpeed => vals::PowerMode::MEDIUM_SPEED,
             PowerMode::UltraLowPower => vals::PowerMode::ULTRA_LOW,
         };
 
+        #[cfg(comp_v2)]
+        let hyst = match config.hysteresis {
+            Hysteresis::None => vals::Hysteresis::NONE,
+            Hysteresis::Hyst10M => vals::Hysteresis::HYST10M,
+            Hysteresis::Hyst20M => vals::Hysteresis::HYST20M,
+            Hysteresis::Hyst30M => vals::Hysteresis::HYST30M,
+            Hysteresis::Hyst40M => vals::Hysteresis::HYST40M,
+            Hysteresis::Hyst50M => vals::Hysteresis::HYST50M,
+            Hysteresis::Hyst60M => vals::Hysteresis::HYST60M,
+            Hysteresis::Hyst70M => vals::Hysteresis::HYST70M,
+        };
+
+        #[cfg(comp_u5)]
         let hyst = match config.hysteresis {
             Hysteresis::None => vals::Hysteresis::NONE,
             Hysteresis::Low => vals::Hysteresis::LOW,
@@ -255,98 +294,88 @@ impl<'d, T: Instance> Comp<'d, T> {
             OutputPolarity::Inverted => vals::Polarity::INVERTED,
         };
 
+        let blanksel = match config.blanking_source {
+            BlankingSource::None => vals::Blanking::NO_BLANKING,
+            BlankingSource::Blank1 => vals::Blanking::BLANK1,
+            BlankingSource::Blank2 => vals::Blanking::BLANK2,
+            BlankingSource::Blank3 => vals::Blanking::BLANK3,
+        };
+
+        #[cfg(comp_u5)]
+        let winmode = match config.window_mode {
+            WindowMode::Disabled => vals::WindowMode::THIS_INPSEL,
+            WindowMode::Enabled => vals::WindowMode::OTHER_INPSEL,
+        };
+
+        #[cfg(comp_u5)]
+        let winout = match config.window_output {
+            WindowOutput::OwnValue => vals::WindowOut::COMP1_VALUE,
+            WindowOutput::XorValue => vals::WindowOut::COMP1_VALUE_XOR_COMP2_VALUE,
+        };
+
+        #[cfg(comp_v2)]
+        let inp_channel = inp_channel != 0;
+
+        T::regs().csr().modify(|w| {
+            w.set_inpsel(inp_channel);
+            w.set_inmsel(inmsel);
+            w.set_hyst(hyst);
+            w.set_polarity(polarity);
+            w.set_blanksel(blanksel);
+
+            // G4 COMP needs SCALEN/BRGEN bits to enable internal voltage references.
+            // SCALEN enables the Vrefint scaler, BRGEN enables the bridge resistor divider.
+            #[cfg(comp_v2)]
+            {
+                w.set_scalen(matches!(
+                    inmsel,
+                    vals::Inm::QUARTER_VREF | vals::Inm::HALF_VREF | vals::Inm::THREE_QUARTER_VREF | vals::Inm::VREF
+                ));
+                w.set_brgen(matches!(
+                    inmsel,
+                    vals::Inm::QUARTER_VREF | vals::Inm::HALF_VREF | vals::Inm::THREE_QUARTER_VREF
+                ));
+            }
+
+            w.set_en(true);
+            #[cfg(comp_u5)]
+            {
+                w.set_pwrmode(pwrmode);
+                w.set_winmode(winmode);
+                w.set_winout(winout);
+            }
+        });
+    }
+
+    fn configure(inp_channel: u8, config: Config) {
         let inmsel = match config.inverting_input {
             InvertingInput::OneQuarterVref => vals::Inm::QUARTER_VREF,
             InvertingInput::HalfVref => vals::Inm::HALF_VREF,
             InvertingInput::ThreeQuarterVref => vals::Inm::THREE_QUARTER_VREF,
             InvertingInput::Vref => vals::Inm::VREF,
+            #[cfg(comp_u5)]
             InvertingInput::Dac1 => vals::Inm::DAC1,
+            #[cfg(comp_u5)]
             InvertingInput::Dac2 => vals::Inm::DAC2,
+            #[cfg(comp_v2)]
+            InvertingInput::Dac1 => vals::Inm::DACA,
+            #[cfg(comp_v2)]
+            InvertingInput::Dac2 => vals::Inm::DACB,
+
             InvertingInput::InputPin => vals::Inm::INM1,
+            #[cfg(comp_v2)]
+            InvertingInput::InputPin2 => vals::Inm::INM2,
         };
 
-        let blanksel = match config.blanking_source {
-            BlankingSource::None => vals::Blanking::NO_BLANKING,
-            BlankingSource::Blank1 => vals::Blanking::BLANK1,
-            BlankingSource::Blank2 => vals::Blanking::BLANK2,
-            BlankingSource::Blank3 => vals::Blanking::BLANK3,
-        };
-
-        let winmode = match config.window_mode {
-            WindowMode::Disabled => vals::WindowMode::THIS_INPSEL,
-            WindowMode::Enabled => vals::WindowMode::OTHER_INPSEL,
-        };
-
-        let winout = match config.window_output {
-            WindowOutput::OwnValue => vals::WindowOut::COMP1_VALUE,
-            WindowOutput::XorValue => vals::WindowOut::COMP1_VALUE_XOR_COMP2_VALUE,
-        };
-
-        T::regs().csr().modify(|w| {
-            w.set_inpsel(inp_channel);
-            w.set_inmsel(inmsel);
-            w.set_pwrmode(pwrmode);
-            w.set_hyst(hyst);
-            w.set_polarity(polarity);
-            w.set_blanksel(blanksel);
-            w.set_winmode(winmode);
-            w.set_winout(winout);
-        });
+        Self::configure_raw(inp_channel, inmsel, config);
     }
 
-    #[cfg(comp_u5)]
     fn configure_with_input_minus_pin(inp_channel: u8, inm_channel: u8, config: Config) {
-        use crate::pac::comp::vals;
-
-        let pwrmode = match config.power_mode {
-            PowerMode::HighSpeed => vals::PowerMode::HIGH_SPEED,
-            PowerMode::MediumSpeed => vals::PowerMode::MEDIUM_SPEED,
-            PowerMode::UltraLowPower => vals::PowerMode::ULTRA_LOW,
-        };
-
-        let hyst = match config.hysteresis {
-            Hysteresis::None => vals::Hysteresis::NONE,
-            Hysteresis::Low => vals::Hysteresis::LOW,
-            Hysteresis::Medium => vals::Hysteresis::MEDIUM,
-            Hysteresis::High => vals::Hysteresis::HIGH,
-        };
-
-        let polarity = match config.output_polarity {
-            OutputPolarity::NotInverted => vals::Polarity::NOT_INVERTED,
-            OutputPolarity::Inverted => vals::Polarity::INVERTED,
-        };
-
         // Map the channel to the INM enum value
         // INM1 = 0x06, INM2 = 0x07
         let inmsel = vals::Inm::from_bits(0x06 + inm_channel);
 
-        let blanksel = match config.blanking_source {
-            BlankingSource::None => vals::Blanking::NO_BLANKING,
-            BlankingSource::Blank1 => vals::Blanking::BLANK1,
-            BlankingSource::Blank2 => vals::Blanking::BLANK2,
-            BlankingSource::Blank3 => vals::Blanking::BLANK3,
-        };
-
-        let winmode = match config.window_mode {
-            WindowMode::Disabled => vals::WindowMode::THIS_INPSEL,
-            WindowMode::Enabled => vals::WindowMode::OTHER_INPSEL,
-        };
-
-        let winout = match config.window_output {
-            WindowOutput::OwnValue => vals::WindowOut::COMP1_VALUE,
-            WindowOutput::XorValue => vals::WindowOut::COMP1_VALUE_XOR_COMP2_VALUE,
-        };
-
-        T::regs().csr().modify(|w| {
-            w.set_inpsel(inp_channel);
-            w.set_inmsel(inmsel);
-            w.set_pwrmode(pwrmode);
-            w.set_hyst(hyst);
-            w.set_polarity(polarity);
-            w.set_blanksel(blanksel);
-            w.set_winmode(winmode);
-            w.set_winout(winout);
-        });
+        Self::configure_raw(inp_channel, inmsel, config)
     }
 
     /// Enable the comparator.
@@ -372,16 +401,12 @@ impl<'d, T: Instance> Comp<'d, T> {
     ///
     /// Returns `true` if the non-inverting input is higher than the inverting input
     /// (or the opposite if polarity is inverted).
-    #[cfg(comp_u5)]
     pub fn output_level(&self) -> bool {
         T::regs().csr().read().value()
     }
 
     /// Set the blanking source.
-    #[cfg(comp_u5)]
     pub fn set_blanking_source(&mut self, source: BlankingSource) {
-        use crate::pac::comp::vals;
-
         let blanksel = match source {
             BlankingSource::None => vals::Blanking::NO_BLANKING,
             BlankingSource::Blank1 => vals::Blanking::BLANK1,
@@ -634,13 +659,38 @@ macro_rules! impl_comp {
     };
 }
 
-// COMP1 uses EXTI line 17, COMP2 uses EXTI line 18
+#[cfg(comp_u5)]
 foreach_peripheral! {
     (comp, COMP1) => {
         impl_comp!(COMP1, 17);
     };
     (comp, COMP2) => {
         impl_comp!(COMP2, 18);
+    };
+}
+
+#[cfg(comp_v2)]
+foreach_peripheral! {
+    (comp, COMP1) => {
+        impl_comp!(COMP1, 21);
+    };
+    (comp, COMP2) => {
+        impl_comp!(COMP2, 22);
+    };
+    (comp, COMP3) => {
+        impl_comp!(COMP3, 29);
+    };
+    (comp, COMP4) => {
+        impl_comp!(COMP4, 30);
+    };
+    (comp, COMP5) => {
+        impl_comp!(COMP5, 31);
+    };
+    (comp, COMP6) => {
+        impl_comp!(COMP6, 32);
+    };
+    (comp, COMP7) => {
+        impl_comp!(COMP7, 33);
     };
 }
 
@@ -667,3 +717,7 @@ macro_rules! impl_comp_inm_pin {
         }
     };
 }
+
+// COMP pin implementations are generated by build.rs from stm32-data.
+// Channel numbers (INP0/INP1, INM0/INM1) come from data/extra/STM32G4.yaml
+// in the stm32-data repository.

--- a/embassy-stm32/src/lib.rs
+++ b/embassy-stm32/src/lib.rs
@@ -61,19 +61,21 @@ pub mod can;
 // FIXME: Cordic driver cause stm32u5a5zj crash
 #[cfg(aes_v3b)]
 pub mod aes;
-#[cfg(comp_u5)]
+#[cfg(any(comp_u5, comp_v2))]
 pub mod comp;
 #[cfg(all(cordic, not(any(stm32u5a5, stm32u5a9))))]
 pub mod cordic;
 
 // Stub macros for COMP pin implementations when comp module is not compiled.
 // These are needed because build.rs generates macro calls for all chips with COMP,
-// but the actual macros are only defined in the comp module which is only compiled for comp_u5.
-#[cfg(all(comp, not(comp_u5)))]
+// but the actual macros are only defined in the comp module.
+#[cfg(all(comp, not(any(comp_u5, comp_v2))))]
+#[allow(unused_macros)]
 macro_rules! impl_comp_inp_pin {
     ($inst:ident, $pin:ident, $ch:expr) => {};
 }
-#[cfg(all(comp, not(comp_u5)))]
+#[cfg(all(comp, not(any(comp_u5, comp_v2))))]
+#[allow(unused_macros)]
 macro_rules! impl_comp_inm_pin {
     ($inst:ident, $pin:ident, $ch:expr) => {};
 }

--- a/examples/stm32g474/src/bin/comp.rs
+++ b/examples/stm32g474/src/bin/comp.rs
@@ -1,0 +1,55 @@
+//! Comparator (COMP) example for STM32G474.
+//!
+//! Demonstrates using the comparator peripheral to compare an analog input
+//! against an internal reference (Vref ~ 1.2V).
+//!
+//! Hardware setup:
+//! - Connect a variable voltage (0-3.3V) to PA7 (COMP2 INP0)
+//!
+//! The comparator will read HIGH when PA7 > Vref, LOW otherwise.
+
+#![no_std]
+#![no_main]
+
+use defmt::*;
+use embassy_executor::Spawner;
+use embassy_stm32::comp::{self, Comp, Config, InvertingInput};
+use embassy_stm32::{Config as SysConfig, bind_interrupts};
+use embassy_time::Timer;
+use {defmt_rtt as _, panic_probe as _};
+
+bind_interrupts!(struct Irqs {
+    COMP1_2_3 => comp::InterruptHandler<embassy_stm32::peripherals::COMP2>;
+});
+
+#[embassy_executor::main]
+async fn main(_spawner: Spawner) {
+    let p = embassy_stm32::init(SysConfig::default());
+    info!("COMP example starting!");
+
+    let mut cfg = Config::default();
+    cfg.inverting_input = InvertingInput::Vref;
+
+    let mut comp2 = Comp::new(p.COMP2, p.PA7, Irqs, cfg);
+    comp2.enable();
+
+    info!("Comparator configured. Comparing PA7 against Vref (~1.2V)");
+
+    // Polling
+    for _ in 0..5 {
+        info!("output: {}", comp2.output_level());
+        Timer::after_millis(500).await;
+    }
+
+    // Async edge detection
+    info!("Waiting for edges...");
+    loop {
+        comp2.wait_for_rising_edge().await;
+        info!("Rising edge!");
+        Timer::after_millis(100).await;
+
+        comp2.wait_for_falling_edge().await;
+        info!("Falling edge!");
+        Timer::after_millis(100).await;
+    }
+}


### PR DESCRIPTION
Closes #5550.

## Changes

**comp.rs:**
- Add G4-specific hysteresis enum (10-70mV in 10mV steps)
- Add `InputPin2` variant for the second inverting GPIO input
- Add `configure_raw()` helper to deduplicate `configure()` and `configure_with_input_minus_pin()`
- Gate SCALEN/BRGEN register bits behind `#[cfg(comp_v2)]` (G4-only, not present on U5)
- Map DAC names per peripheral version (DAC1/DAC2 on U5, DACA/DACB on G4)
- EXTI line assignments for COMP1-7 per RM0440

**build.rs:**
- Fix COMP pin codegen to skip bare `INP`/`INM` signals (from MCU XML) and only generate impls from numbered `INP0`/`INP1`/`INM0`/`INM1` (from stm32-data extra YAML), matching the existing OPAMP pattern

**lib.rs:**
- Gate comp module on `any(comp_u5, comp_v2)`
- Fix stub macro condition to exclude `comp_v2`

**Cargo.toml:**
- Update stm32-metapac to git tag that includes COMP pin channel data

**example:**
- Add `examples/stm32g474/src/bin/comp.rs` demonstrating polling and async edge detection

## Tested

- `cargo build --features stm32g474re,time-driver-any,exti,dual-bank`
- `cargo build --features stm32g431cb,time-driver-any,exti`
- `cargo build --features stm32u575zi,time-driver-any,exti` (U5 regression check)
- G474 example builds