### PR TITLE
embassy-stm32: Prevent InputCapture from dropping CapturePin

### DIFF
--- a/embassy-stm32/src/timer/input_capture.rs
+++ b/embassy-stm32/src/timer/input_capture.rs
@@ -36,6 +36,10 @@ impl<'d, T: GeneralInstance4Channel, C: TimerChannel, #[cfg(afio)] A> if_afio!(C
 /// Input capture driver.
 pub struct InputCapture<'d, T: GeneralInstance4Channel> {
     inner: Timer<'d, T>,
+    _ch1: Option<Flex<'d>>,
+    _ch2: Option<Flex<'d>>,
+    _ch3: Option<Flex<'d>>,
+    _ch4: Option<Flex<'d>>,
 }
 
 impl<'d, T: GeneralInstance4Channel> InputCapture<'d, T> {
@@ -51,11 +55,33 @@ impl<'d, T: GeneralInstance4Channel> InputCapture<'d, T> {
         freq: Hertz,
         counting_mode: CountingMode,
     ) -> Self {
-        Self::new_inner(tim, freq, counting_mode)
+        Self::new_inner(
+            tim,
+            ch1.map(|pin| pin.pin),
+            ch2.map(|pin| pin.pin),
+            ch3.map(|pin| pin.pin),
+            ch4.map(|pin| pin.pin),
+            freq,
+            counting_mode,
+        )
     }
 
-    fn new_inner(tim: Peri<'d, T>, freq: Hertz, counting_mode: CountingMode) -> Self {
-        let mut this = Self { inner: Timer::new(tim) };
+    fn new_inner(
+        tim: Peri<'d, T>,
+        _ch1: Option<Flex<'d>>,
+        _ch2: Option<Flex<'d>>,
+        _ch3: Option<Flex<'d>>,
+        _ch4: Option<Flex<'d>>,
+        freq: Hertz,
+        counting_mode: CountingMode,
+    ) -> Self {
+        let mut this = Self {
+            inner: Timer::new(tim),
+            _ch1,
+            _ch2,
+            _ch3,
+            _ch4,
+        };
 
         this.inner.set_counting_mode(counting_mode);
         this.inner.set_tick_freq(freq);


### PR DESCRIPTION
`CapturePin` switched from using `Peri<'d, AnyPin>` to `Flex<'d>` in [`3e4b65a`](https://github.com/embassy-rs/embassy/commit/3e4b65a803ec989d060b6825ba25f854fb8f6cfc). However, unlike `Peri`, `Flex` implements `Drop`, which disconnects the pin when `CapturePin` is dropped and prevents the pin from triggering the interrupt required by `InputCapture`.

`ComplementaryPwm`, `OnePulse`, and `SimplePwm` had the same issue, which was fixed in [2fba48f](https://github.com/embassy-rs/embassy/commit/2fba48fdbf90fd596a26d9a4b296e8d45f2977bb), and this PR implements the same fix for `InputCapture`.