### PR TITLE
embassy-stm32: Fix H7 RNG lockup

### DIFF
--- a/embassy-stm32/src/rng.rs
+++ b/embassy-stm32/src/rng.rs
@@ -144,6 +144,13 @@ impl<'d, T: Instance> Rng<'d, T> {
             reg.set_rngen(true);
             reg.set_condrst(false);
         });
+
+        // According to reference manual for RNGv3: SEIS must be cleared manually.
+        // RNGv2 does not say anything about SEIS clearing, but ST Cube HAL clears it.
+        T::regs().sr().modify(|reg| {
+            reg.set_seis(false);
+        });
+
         // According to reference manual: after software reset, wait for random number to be ready
         // The next_u32() call will wait for DRDY, completing the initialization
         let _ = self.next_u32();


### PR DESCRIPTION
This should fix #3047.

Quoting myself from the issue:

> I did some digging, and it seems that missing piece is clearing the SEIS bit from SR: https://github.com/chemicstry/embassy/commit/c50e2d849d47b76a6b362cf7cd8ba9871b5c5697
>
> RNGv2 (STM32H723) manual is ambiguous on this:
> <img width="276" height="103" alt="Image" src="https://github.com/user-attachments/assets/079031b8-f8a1-4ee2-bd5e-7cb234148dfc" />
>
> But RNGv3 (STM32H523) mentions that SEIS has to be cleared manually:
> <img width="278" height="135" alt="Image" src="https://github.com/user-attachments/assets/43a0805d-20e8-4122-9f40-e8881f13a154" />
>
> Also, ST Cube HAL clears SEIS bit regardless of RNG v2/v3 version: https://github.com/STMicroelectronics/stm32h7xx-hal-driver/blob/release/v1.11.2/Src/stm32h7xx_hal_rng.c#L1021