### PR TITLE
[MCXA5] Add missing pins

### DIFF
--- a/embassy-mcxa/src/chips/mcxa5xx.rs
+++ b/embassy-mcxa/src/chips/mcxa5xx.rs
@@ -155,6 +155,10 @@ mod inner_periph {
         #[cfg(feature = "jtag-extras-as-gpio")]
         P0_6,
         P0_7,
+        P0_8,
+        P0_9,
+        P0_10,
+        P0_11,
         P0_12,
         P0_13,
         P0_14,


### PR DESCRIPTION
P0_8, P0_9, P0_10, and P0_11.