### PR TITLE
[MCXA] add missing GPIO impl_pin and I2C SclPin mappings

### DIFF
--- a/embassy-mcxa/src/chips/mcxa5xx.rs
+++ b/embassy-mcxa/src/chips/mcxa5xx.rs
@@ -567,6 +567,10 @@ mod gpio_impls {
     #[cfg(feature = "jtag-extras-as-gpio")]
     impl_pin!(P0_6, 0, 6, GPIO0);
     impl_pin!(P0_7, 0, 7, GPIO0);
+    impl_pin!(P0_8, 0, 8, GPIO0);
+    impl_pin!(P0_9, 0, 9, GPIO0);
+    impl_pin!(P0_10, 0, 10, GPIO0);
+    impl_pin!(P0_11, 0, 11, GPIO0);
     impl_pin!(P0_12, 0, 12, GPIO0);
     impl_pin!(P0_13, 0, 13, GPIO0);
     impl_pin!(P0_14, 0, 14, GPIO0);
@@ -638,6 +642,10 @@ mod gpio_impls {
     impl_pin!(P2_24, 2, 24, GPIO2);
     impl_pin!(P2_25, 2, 25, GPIO2);
     impl_pin!(P2_26, 2, 26, GPIO2);
+    impl_pin!(P2_28, 2, 28, GPIO2);
+    impl_pin!(P2_29, 2, 29, GPIO2);
+    impl_pin!(P2_30, 2, 30, GPIO2);
+    impl_pin!(P2_31, 2, 31, GPIO2);
 
     impl_pin!(P3_0, 3, 0, GPIO3);
     impl_pin!(P3_1, 3, 1, GPIO3);

--- a/embassy-mcxa/src/i2c/mod.rs
+++ b/embassy-mcxa/src/i2c/mod.rs
@@ -196,6 +196,7 @@ mod mcxa5xx {
     impl_pin!(P1_0, LPI2C1, MUX3, SdaPin);
     impl_pin!(P1_1, LPI2C1, MUX3, SclPin);
     impl_pin!(P1_12, LPI2C1, MUX2, SdaPin);
+    impl_pin!(P1_13, LPI2C1, MUX2, SclPin);
     impl_pin!(P1_14, LPI2C1, MUX2, SclPin);
     impl_pin!(P1_15, LPI2C1, MUX2, SdaPin);
 


### PR DESCRIPTION
Add impl_pin! for P0_8-P0_11 (GPIO0) and P2_28-P2_31 (GPIO2). Add P1_13 as LPI2C1 SCL MUX2 pin (matches mcxa2xx).