### PR TITLE
Bump usbd-hid to 0.10.0

### DIFF
--- a/embassy-usb/CHANGELOG.md
+++ b/embassy-usb/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 <!-- next-header -->
 ## Unreleased - ReleaseDate
 
+- Bump usbd-hid from 0.9.0 to 0.10.0
+
 ## 0.6.0 - 2026-03-10
 
 - Add support for USB HID Boot Protocol Mode

--- a/embassy-usb/Cargo.toml
+++ b/embassy-usb/Cargo.toml
@@ -71,5 +71,5 @@ embedded-io-async = { version = "0.7.0" }
 bitflags = "2.4.1"
 
 # for HID
-usbd-hid = { version = "0.9.0", optional = true }
+usbd-hid = { version = "0.10.0", optional = true }
 ssmarshal = { version = "1.0", default-features = false, optional = true }

--- a/embassy-usb/src/class/hid.rs
+++ b/embassy-usb/src/class/hid.rs
@@ -5,8 +5,6 @@ use core::ops::Range;
 use core::sync::atomic::{AtomicUsize, Ordering};
 
 #[cfg(feature = "usbd-hid")]
-use ssmarshal::serialize;
-#[cfg(feature = "usbd-hid")]
 use usbd_hid::descriptor::AsInputReport;
 
 use crate::control::{InResponse, OutResponse, Recipient, Request, RequestType};
@@ -320,7 +318,7 @@ impl<'d, D: Driver<'d>, const N: usize> HidWriter<'d, D, N> {
     #[cfg(feature = "usbd-hid")]
     pub async fn write_serialize<IR: AsInputReport>(&mut self, r: &IR) -> Result<(), EndpointError> {
         let mut buf: [u8; N] = [0; N];
-        let Ok(size) = serialize(&mut buf, r) else {
+        let Ok(size) = r.serialize(&mut buf) else {
             return Err(EndpointError::BufferOverflow);
         };
         self.write(&buf[0..size]).await

--- a/examples/nrf52840/Cargo.toml
+++ b/examples/nrf52840/Cargo.toml
@@ -28,7 +28,7 @@ cortex-m-rt = "0.7.0"
 panic-probe = { version = "1.0.0", features = ["print-defmt"] }
 rand = { version = "0.9.0", default-features = false }
 embedded-storage = "0.3.1"
-usbd-hid = "0.9.0"
+usbd-hid = "0.10.0"
 serde = { version = "1.0.136", default-features = false }
 embedded-hal = { version = "1.0" }
 embedded-hal-async = { version = "1.0" }

--- a/examples/nrf5340/Cargo.toml
+++ b/examples/nrf5340/Cargo.toml
@@ -23,7 +23,7 @@ cortex-m = { version = "0.7.6", features = ["inline-asm", "critical-section-sing
 cortex-m-rt = "0.7.0"
 panic-probe = { version = "1.0.0", features = ["print-defmt"] }
 embedded-storage = "0.3.1"
-usbd-hid = "0.9.0"
+usbd-hid = "0.10.0"
 serde = { version = "1.0.136", default-features = false }
 rand = { version = "0.9.0", default-features = false }
 

--- a/examples/rp/Cargo.toml
+++ b/examples/rp/Cargo.toml
@@ -45,7 +45,7 @@ display-interface = "0.5.0"
 byte-slice-cast = { version = "1.2.0", default-features = false }
 smart-leds = "0.4.0"
 heapless = "0.9"
-usbd-hid = "0.9.0"
+usbd-hid = "0.10.0"
 
 embedded-hal-1 = { package = "embedded-hal", version = "1.0" }
 embedded-hal-async = "1.0"

--- a/examples/rp235x/Cargo.toml
+++ b/examples/rp235x/Cargo.toml
@@ -46,7 +46,7 @@ display-interface = "0.5.0"
 byte-slice-cast = { version = "1.2.0", default-features = false }
 smart-leds = "0.3.0"
 heapless = "0.9"
-usbd-hid = "0.9.0"
+usbd-hid = "0.10.0"
 
 embedded-hal-1 = { package = "embedded-hal", version = "1.0" }
 embedded-hal-async = "1.0"

--- a/examples/stm32f4/Cargo.toml
+++ b/examples/stm32f4/Cargo.toml
@@ -32,7 +32,7 @@ critical-section = "1.1"
 nb = "1.0.0"
 embedded-storage = "0.3.1"
 micromath = "2.0.0"
-usbd-hid = "0.9.0"
+usbd-hid = "0.10.0"
 static_cell = "2"
 chrono = { version = "^0.4", default-features = false}
 

--- a/examples/stm32f401/Cargo.toml
+++ b/examples/stm32f401/Cargo.toml
@@ -31,7 +31,7 @@ critical-section = "1.1"
 nb = "1.0.0"
 embedded-storage = "0.3.1"
 micromath = "2.0.0"
-usbd-hid = "0.9.0"
+usbd-hid = "0.10.0"
 static_cell = "2"
 chrono = { version = "^0.4", default-features = false}
 

--- a/examples/stm32g4/Cargo.toml
+++ b/examples/stm32g4/Cargo.toml
@@ -13,7 +13,7 @@ embassy-executor = { path = "../../embassy-executor", features = ["platform-cort
 embassy-time = { path = "../../embassy-time", features = ["defmt", "defmt-timestamp-uptime", "tick-hz-32_768"] }
 embassy-usb = { path = "../../embassy-usb", features = ["defmt"] }
 embassy-futures = { path = "../../embassy-futures" }
-usbd-hid = "0.9.0"
+usbd-hid = "0.10.0"
 
 defmt = "1.0.1"
 defmt-rtt = "1.0.0"

--- a/examples/stm32l5/Cargo.toml
+++ b/examples/stm32l5/Cargo.toml
@@ -14,7 +14,7 @@ embassy-time = { version = "0.5.1", path = "../../embassy-time", features = ["de
 embassy-usb = { version = "0.6.0", path = "../../embassy-usb", features = ["defmt"] }
 embassy-net = { version = "0.9.0", path = "../../embassy-net", features = ["defmt",  "tcp", "dhcpv4", "medium-ethernet"] }
 embassy-futures = { version = "0.1.2", path = "../../embassy-futures" }
-usbd-hid = "0.9.0"
+usbd-hid = "0.10.0"
 
 defmt = "1.0.1"
 defmt-rtt = "1.0.0"


### PR DESCRIPTION
usbd-hid v0.10.0 removes unmaintained `ssmarshal` dep 