### PR TITLE
stm32: timer: add break input configuration and comparator routing

### DIFF
--- a/embassy-stm32/src/timer/complementary_pwm.rs
+++ b/embassy-stm32/src/timer/complementary_pwm.rs
@@ -2,13 +2,16 @@
 
 use core::marker::PhantomData;
 
+pub use super::low_level::FilterValue;
 use super::low_level::{CountingMode, OutputPolarity, RoundTo, Timer};
 use super::simple_pwm::PwmPin;
 use super::{AdvancedInstance4Channel, Ch1, Ch2, Ch3, Ch4, Channel, TimerComplementaryPin};
 use crate::Peri;
 use crate::dma::word::Word;
 use crate::gpio::{AfType, Flex, OutputType};
-pub use crate::pac::timer::vals::{Ccds, Ckd, Mms2, Ossi, Ossr};
+pub use crate::pac::timer::vals::{
+    Bkinp as BreakComparatorPolarity, Bkp as BreakInputPolarity, Ccds, Ckd, Mms2, Ossi, Ossr,
+};
 use crate::time::Hertz;
 use crate::timer::TimerChannel;
 use crate::timer::low_level::OutputCompareMode;
@@ -197,6 +200,151 @@ impl<'d, T: AdvancedInstance4Channel> ComplementaryPwm<'d, T> {
     /// Get Master Output Enable
     pub fn get_master_output_enable(&self) -> bool {
         self.inner.get_moe()
+    }
+
+    /// Enable/disable break input 1.
+    ///
+    /// When enabled, an active level on the break input forces all timer
+    /// outputs to their safe state (configured by OSSI/OSSR and OIS/OISN).
+    /// This provides hardware-level overcurrent protection for motor drives.
+    pub fn set_break_enable(&mut self, enable: bool) {
+        self.inner.set_break_enable(enable);
+    }
+
+    /// Get break input 1 enable state.
+    pub fn get_break_enable(&self) -> bool {
+        self.inner.get_break_enable()
+    }
+
+    /// Set break input 1 polarity.
+    pub fn set_break_polarity(&mut self, polarity: BreakInputPolarity) {
+        self.inner.set_break_polarity(polarity);
+    }
+
+    /// Get break input 1 polarity.
+    pub fn get_break_polarity(&self) -> BreakInputPolarity {
+        self.inner.get_break_polarity()
+    }
+
+    /// Set break input 1 digital filter.
+    ///
+    /// The filter rejects glitches shorter than the configured number of
+    /// clock cycles, preventing false break events from noise on the pin.
+    pub fn set_break_filter(&mut self, filter: FilterValue) {
+        self.inner.set_break_filter(filter);
+    }
+
+    /// Get break input 1 digital filter.
+    pub fn get_break_filter(&self) -> FilterValue {
+        self.inner.get_break_filter()
+    }
+
+    /// Enable/disable break input 2.
+    pub fn set_break2_enable(&mut self, enable: bool) {
+        self.inner.set_break2_enable(enable);
+    }
+
+    /// Get break input 2 enable state.
+    pub fn get_break2_enable(&self) -> bool {
+        self.inner.get_break2_enable()
+    }
+
+    /// Set break input 2 polarity.
+    pub fn set_break2_polarity(&mut self, polarity: BreakInputPolarity) {
+        self.inner.set_break2_polarity(polarity);
+    }
+
+    /// Get break input 2 polarity.
+    pub fn get_break2_polarity(&self) -> BreakInputPolarity {
+        self.inner.get_break2_polarity()
+    }
+
+    /// Set break input 2 digital filter.
+    pub fn set_break2_filter(&mut self, filter: FilterValue) {
+        self.inner.set_break2_filter(filter);
+    }
+
+    /// Get break input 2 digital filter.
+    pub fn get_break2_filter(&self) -> FilterValue {
+        self.inner.get_break2_filter()
+    }
+
+    /// Enable/disable automatic output enable (AOE).
+    ///
+    /// When enabled, the MOE bit is automatically set at the next update
+    /// event after a break event, allowing the outputs to resume. When
+    /// disabled, MOE can only be re-enabled by software after a break.
+    pub fn set_automatic_output_enable(&mut self, enable: bool) {
+        self.inner.set_automatic_output_enable(enable);
+    }
+
+    /// Get automatic output enable (AOE) state.
+    pub fn get_automatic_output_enable(&self) -> bool {
+        self.inner.get_automatic_output_enable()
+    }
+
+    /// Enable/disable comparator output as break input 1 source.
+    ///
+    /// Routes the internal comparator output directly to the break input,
+    /// no GPIO pin needed. `comp_index` is 0-based (0=COMP1, 1=COMP2, etc.).
+    /// Multiple comparators can be enabled simultaneously (OR'd together).
+    pub fn set_break_comparator_enable(&mut self, comp_index: usize, enable: bool) {
+        self.inner.set_break_comparator_enable(comp_index, enable);
+    }
+
+    /// Get comparator break input 1 enable state.
+    pub fn get_break_comparator_enable(&self, comp_index: usize) -> bool {
+        self.inner.get_break_comparator_enable(comp_index)
+    }
+
+    /// Set comparator break input 1 polarity.
+    pub fn set_break_comparator_polarity(&mut self, comp_index: usize, polarity: BreakComparatorPolarity) {
+        self.inner.set_break_comparator_polarity(comp_index, polarity);
+    }
+
+    /// Get comparator break input 1 polarity.
+    pub fn get_break_comparator_polarity(&self, comp_index: usize) -> BreakComparatorPolarity {
+        self.inner.get_break_comparator_polarity(comp_index)
+    }
+
+    /// Enable/disable the external BKIN pin as break input 1 source.
+    pub fn set_break_input_pin_enable(&mut self, enable: bool) {
+        self.inner.set_break_input_pin_enable(enable);
+    }
+
+    /// Get external BKIN pin enable state.
+    pub fn get_break_input_pin_enable(&self) -> bool {
+        self.inner.get_break_input_pin_enable()
+    }
+
+    /// Enable/disable comparator output as break input 2 source.
+    pub fn set_break2_comparator_enable(&mut self, comp_index: usize, enable: bool) {
+        self.inner.set_break2_comparator_enable(comp_index, enable);
+    }
+
+    /// Get comparator break input 2 enable state.
+    pub fn get_break2_comparator_enable(&self, comp_index: usize) -> bool {
+        self.inner.get_break2_comparator_enable(comp_index)
+    }
+
+    /// Set comparator break input 2 polarity.
+    pub fn set_break2_comparator_polarity(&mut self, comp_index: usize, polarity: BreakComparatorPolarity) {
+        self.inner.set_break2_comparator_polarity(comp_index, polarity);
+    }
+
+    /// Get comparator break input 2 polarity.
+    pub fn get_break2_comparator_polarity(&self, comp_index: usize) -> BreakComparatorPolarity {
+        self.inner.get_break2_comparator_polarity(comp_index)
+    }
+
+    /// Enable/disable the external BK2IN pin as break input 2 source.
+    pub fn set_break2_input_pin_enable(&mut self, enable: bool) {
+        self.inner.set_break2_input_pin_enable(enable);
+    }
+
+    /// Get external BK2IN pin enable state.
+    pub fn get_break2_input_pin_enable(&self) -> bool {
+        self.inner.get_break2_input_pin_enable()
     }
 
     /// Set Master Slave Mode 2

--- a/embassy-stm32/src/timer/low_level.rs
+++ b/embassy-stm32/src/timer/low_level.rs
@@ -9,6 +9,8 @@
 use core::mem::ManuallyDrop;
 
 use embassy_hal_internal::Peri;
+#[cfg(not(stm32l0))]
+pub use stm32_metapac::timer::vals::{Bkinp as BreakComparatorPolarity, Bkp as BreakInputPolarity};
 // Re-export useful enums
 pub use stm32_metapac::timer::vals::{FilterValue, Mms as MasterMode, Sms as SlaveMode, Ts as TriggerSource};
 
@@ -1142,6 +1144,98 @@ impl<'d, T: AdvancedInstance1Channel> Timer<'d, T> {
     pub fn get_moe(&self) -> bool {
         self.regs_1ch_cmp().bdtr().read().moe()
     }
+
+    /// Enable/disable break input 1.
+    ///
+    /// When enabled, an active level on the break input puts the timer outputs
+    /// into a safe state (driven by OSSI/OSSR and OIS/OISN settings).
+    pub fn set_break_enable(&self, enable: bool) {
+        self.regs_1ch_cmp().bdtr().modify(|w| w.set_bke(0, enable));
+    }
+
+    /// Get break input 1 enable state.
+    pub fn get_break_enable(&self) -> bool {
+        self.regs_1ch_cmp().bdtr().read().bke(0)
+    }
+
+    /// Set break input 1 polarity.
+    pub fn set_break_polarity(&self, polarity: vals::Bkp) {
+        self.regs_1ch_cmp().bdtr().modify(|w| w.set_bkp(0, polarity));
+    }
+
+    /// Get break input 1 polarity.
+    pub fn get_break_polarity(&self) -> vals::Bkp {
+        self.regs_1ch_cmp().bdtr().read().bkp(0)
+    }
+
+    /// Set break input 1 digital filter.
+    ///
+    /// The filter rejects glitches shorter than the configured number of clock
+    /// cycles, preventing false break events from noise.
+    pub fn set_break_filter(&self, filter: FilterValue) {
+        self.regs_1ch_cmp().bdtr().modify(|w| w.set_bkf(0, filter));
+    }
+
+    /// Get break input 1 digital filter.
+    pub fn get_break_filter(&self) -> FilterValue {
+        self.regs_1ch_cmp().bdtr().read().bkf(0)
+    }
+
+    /// Enable/disable automatic output enable (AOE).
+    ///
+    /// When AOE is set, the MOE bit is automatically set at the next update
+    /// event after a break event (allowing automatic recovery). When cleared,
+    /// MOE can only be set by software.
+    pub fn set_automatic_output_enable(&self, enable: bool) {
+        self.regs_1ch_cmp().bdtr().modify(|w| w.set_aoe(enable));
+    }
+
+    /// Get automatic output enable (AOE) state.
+    pub fn get_automatic_output_enable(&self) -> bool {
+        self.regs_1ch_cmp().bdtr().read().aoe()
+    }
+
+    /// Enable/disable comparator output as break input 1 source.
+    ///
+    /// When enabled, the output of comparator `comp_index` (0-based: 0=COMP1, 1=COMP2, etc.)
+    /// is internally OR'd into the break input 1 signal. Multiple comparators can be
+    /// enabled simultaneously. This is configured via the TIMx_AF1 register BKCMPE bits.
+    ///
+    /// No GPIO pin is needed — the routing is fully internal.
+    pub fn set_break_comparator_enable(&self, comp_index: usize, enable: bool) {
+        self.regs_1ch_cmp().af1().modify(|w| w.set_bkcmpe(comp_index, enable));
+    }
+
+    /// Get comparator break input 1 enable state.
+    pub fn get_break_comparator_enable(&self, comp_index: usize) -> bool {
+        self.regs_1ch_cmp().af1().read().bkcmpe(comp_index)
+    }
+
+    /// Set comparator break input 1 polarity.
+    ///
+    /// Controls the polarity of comparator `comp_index` (0-based, max 3) output
+    /// when used as a break source. Only COMP1-COMP4 have individual polarity control.
+    pub fn set_break_comparator_polarity(&self, comp_index: usize, polarity: vals::Bkinp) {
+        self.regs_1ch_cmp().af1().modify(|w| w.set_bkcmpp(comp_index, polarity));
+    }
+
+    /// Get comparator break input 1 polarity.
+    pub fn get_break_comparator_polarity(&self, comp_index: usize) -> vals::Bkinp {
+        self.regs_1ch_cmp().af1().read().bkcmpp(comp_index)
+    }
+
+    /// Enable/disable the external BKIN pin as break input 1 source.
+    ///
+    /// This controls whether the TIMx_BKIN GPIO pin contributes to the break input.
+    /// When using only comparator-based break sources, this can be disabled.
+    pub fn set_break_input_pin_enable(&self, enable: bool) {
+        self.regs_1ch_cmp().af1().modify(|w| w.set_bkine(enable));
+    }
+
+    /// Get external BKIN pin enable state.
+    pub fn get_break_input_pin_enable(&self) -> bool {
+        self.regs_1ch_cmp().af1().read().bkine()
+    }
 }
 
 #[cfg(not(stm32l0))]
@@ -1197,10 +1291,78 @@ impl<'d, T: AdvancedInstance4Channel> Timer<'d, T> {
         self.regs_advanced().rcr().modify(|w| w.set_rep(val));
     }
 
+    /// Enable/disable break input 2.
+    ///
+    /// When enabled, an active level on break input 2 puts the timer outputs
+    /// into a safe state. Only available on advanced 4-channel timers.
+    pub fn set_break2_enable(&self, enable: bool) {
+        self.regs_advanced().bdtr().modify(|w| w.set_bke(1, enable));
+    }
+
+    /// Get break input 2 enable state.
+    pub fn get_break2_enable(&self) -> bool {
+        self.regs_advanced().bdtr().read().bke(1)
+    }
+
+    /// Set break input 2 polarity.
+    pub fn set_break2_polarity(&self, polarity: vals::Bkp) {
+        self.regs_advanced().bdtr().modify(|w| w.set_bkp(1, polarity));
+    }
+
+    /// Get break input 2 polarity.
+    pub fn get_break2_polarity(&self) -> vals::Bkp {
+        self.regs_advanced().bdtr().read().bkp(1)
+    }
+
+    /// Set break input 2 digital filter.
+    pub fn set_break2_filter(&self, filter: FilterValue) {
+        self.regs_advanced().bdtr().modify(|w| w.set_bkf(1, filter));
+    }
+
+    /// Get break input 2 digital filter.
+    pub fn get_break2_filter(&self) -> FilterValue {
+        self.regs_advanced().bdtr().read().bkf(1)
+    }
+
     /// Trigger software break 1 or 2
     /// Setting this bit generates a break event. This bit is automatically cleared by the hardware.
     pub fn trigger_software_break(&self, n: usize) {
         self.regs_advanced().egr().write(|r| r.set_bg(n, true));
+    }
+
+    /// Enable/disable comparator output as break input 2 source.
+    ///
+    /// When enabled, the output of comparator `comp_index` (0-based: 0=COMP1, 1=COMP2, etc.)
+    /// is internally OR'd into the break input 2 signal. Configured via TIMx_AF2 register.
+    pub fn set_break2_comparator_enable(&self, comp_index: usize, enable: bool) {
+        self.regs_advanced().af2().modify(|w| w.set_bk2cmpe(comp_index, enable));
+    }
+
+    /// Get comparator break input 2 enable state.
+    pub fn get_break2_comparator_enable(&self, comp_index: usize) -> bool {
+        self.regs_advanced().af2().read().bk2cmpe(comp_index)
+    }
+
+    /// Set comparator break input 2 polarity.
+    pub fn set_break2_comparator_polarity(&self, comp_index: usize, polarity: vals::Bkinp) {
+        self.regs_advanced()
+            .af2()
+            .modify(|w| w.set_bk2cmpp(comp_index, polarity));
+    }
+
+    /// Get comparator break input 2 polarity.
+    pub fn get_break2_comparator_polarity(&self, comp_index: usize) -> vals::Bkinp {
+        self.regs_advanced().af2().read().bk2cmpp(comp_index)
+    }
+
+    /// Enable/disable the external BK2IN pin as break input 2 source.
+    pub fn set_break2_input_pin_enable(&self, enable: bool) {
+        self.regs_advanced().af2().modify(|w| w.set_bk2ine(enable));
+    }
+
+    /// Get external BK2IN pin enable state.
+    pub fn get_break2_input_pin_enable(&self) -> bool {
+        self.regs_advanced().af2().read().bk2ine()
     }
 }
 


### PR DESCRIPTION
## Summary
- Add BDTR break input config (enable, polarity, filter, AOE) to `low_level::Timer` and `ComplementaryPwm`
- Add AF1/AF2 comparator-to-break routing (BKCMPxE, BKCMPxP, BKINE) for internal comparator → break input without GPIO
- BRK1 methods on `AdvancedInstance1Channel`, BRK2 methods on `AdvancedInstance4Channel`
- Re-export `Bkp` as `BreakInputPolarity`, `Bkinp` as `BreakComparatorPolarity`, `FilterValue`

## Use case
Hardware overcurrent protection for motor drives: STM32G4 comparators monitor shunt currents and route directly to TIM1 break inputs, shutting down PWM in hardware with no software latency.

## Test plan
- [x] Tested on STM32G431 and STM32G474 with COMP1/COMP4 routed to TIM1 BRK1
- [x] CI build across chip families validates PAC indexed register access