### PR TITLE
rp/pio: fix infinite loop when loading program that wont't fit

### DIFF
--- a/embassy-rp/src/pio/mod.rs
+++ b/embassy-rp/src/pio/mod.rs
@@ -1105,10 +1105,17 @@ impl<'d, PIO: Instance> Common<'d, PIO> {
                 // PIO does support that. with only 32 instruction slots it
                 // doesn't make much sense to do anything more fancy.
                 let mut origin = 0;
-                while origin < 32 {
+                loop {
                     match self.try_load_program_at(prog, origin as _) {
                         Ok(r) => return Ok(r),
-                        Err(a) => origin = a + 1,
+                        Err(addr_in_use) => {
+                            if addr_in_use < origin {
+                                // wrapped around, theres no more space
+                                break;
+                            }
+
+                            origin = addr_in_use + 1;
+                        }
                     }
                 }
                 Err(LoadError::InsufficientSpace)

--- a/tests/rp/src/bin/pio_multi_load.rs
+++ b/tests/rp/src/bin/pio_multi_load.rs
@@ -124,6 +124,15 @@ async fn main(_spawner: Spawner) {
         };
     }
 
+    // program won't fit
+    {
+        let prg = pio_asm!("nop", "nop", "nop", "nop", "nop", "nop", "nop", "nop", "nop");
+        match common.try_load_program(&prg.program) {
+            Err(LoadError::InsufficientSpace) => (),
+            _ => panic!("program loaded when it shouldn't"),
+        };
+    }
+
     info!("Test OK");
     cortex_m::asm::bkpt();
 }


### PR DESCRIPTION
When the returned address wraps around, the search was retried infinitely as the condition `origin < 32` is always satisfied.

The loop condition now checks for wrap around. If it occurs, the loop exits since the entire address space has already been searched from zero address.

Fixes #5657 