### PR TITLE
embassy-net-wiznet: combine W5500 SPI header into single write

### DIFF
--- a/embassy-net-wiznet/src/chip/w5500.rs
+++ b/embassy-net-wiznet/src/chip/w5500.rs
@@ -53,25 +53,16 @@ impl super::SealedChip for W5500 {
         address: Self::Address,
         data: &mut [u8],
     ) -> Result<(), SPI::Error> {
-        let address_phase = address.1.to_be_bytes();
-        let control_phase = [(address.0 as u8) << 3];
-        let operations = &mut [
-            Operation::Write(&address_phase),
-            Operation::Write(&control_phase),
-            Operation::TransferInPlace(data),
-        ];
+        let addr = address.1.to_be_bytes();
+        let header = [addr[0], addr[1], (address.0 as u8) << 3];
+        let operations = &mut [Operation::Write(&header), Operation::TransferInPlace(data)];
         spi.transaction(operations).await
     }
 
     async fn bus_write<SPI: SpiDevice>(spi: &mut SPI, address: Self::Address, data: &[u8]) -> Result<(), SPI::Error> {
-        let address_phase = address.1.to_be_bytes();
-        let control_phase = [(address.0 as u8) << 3 | 0b0000_0100];
-        let data_phase = data;
-        let operations = &mut [
-            Operation::Write(&address_phase[..]),
-            Operation::Write(&control_phase),
-            Operation::Write(&data_phase),
-        ];
+        let addr = address.1.to_be_bytes();
+        let header = [addr[0], addr[1], (address.0 as u8) << 3 | 0b0000_0100];
+        let operations = &mut [Operation::Write(&header), Operation::Write(data)];
         spi.transaction(operations).await
     }
 }


### PR DESCRIPTION
## Summary

The W5500 SPI frame header is 3 bytes (2-byte address + 1-byte control), but was split across two separate `Operation::Write` calls inside `transaction()`. This PR combines them into a single `Operation::Write(&[addr_hi, addr_lo, control])`, reducing the operations per SPI transaction from 3 to 2.

## Motivation

On some SPI implementations (notably `embassy-stm32` on STM32L4), the SPI peripheral is disabled (`SPE=0`) between DMA operations within a `transaction()`. This causes CLK to float hi-Z between operations, and the W5500 loses frame sync.

Each operation boundary is another chance for corruption. Combining the 3-byte header eliminates one boundary, making W5500 communication more robust against this class of SPI driver bugs. It's also slightly more efficient (one fewer DMA setup/teardown cycle).

The W5500 SPI frame format (datasheet section 4) requires the 3 header bytes to be sent as a contiguous sequence while CS is asserted — splitting them into separate operations was unnecessary.

Related: #3509

## Test plan

- [x] Tested on STM32L432KC + W5500 hardware (DHCP + TCP working)
- [ ] `cargo check -p embassy-net-wiznet`