### PR TITLE
embassy-usb: add get_descriptor_requested handler callback

### DIFF
--- a/embassy-usb/src/lib.rs
+++ b/embassy-usb/src/lib.rs
@@ -158,6 +158,30 @@ pub trait Handler {
         let _ = (index, lang_id);
         None
     }
+
+    /// Called when a GET_DESCRIPTOR control request is received, before the
+    /// descriptor is sent.
+    ///
+    /// This is an observer callback: it cannot influence the response.
+    /// The default implementation does nothing.
+    ///
+    /// `descriptor_type` and `index` are the high/low bytes of wValue.
+    /// `wlength` is the maximum number of bytes the host is willing to
+    /// receive.
+    ///
+    /// # Example
+    ///
+    /// ```rust,ignore
+    /// impl Handler for MyHandler {
+    ///     fn get_descriptor_requested(&mut self, descriptor_type: u8, _index: u8, wlength: u16) {
+    ///         // Log or collect per-request wLength for diagnostics
+    ///         if descriptor_type == 3 {
+    ///             self.string_wlengths.push(wlength);
+    ///         }
+    ///     }
+    /// }
+    /// ```
+    fn get_descriptor_requested(&mut self, _descriptor_type: u8, _index: u8, _wlength: u16) {}
 }
 
 struct Interface {
@@ -718,6 +742,10 @@ impl<'d, D: Driver<'d>> Inner<'d, D> {
 
     fn handle_get_descriptor<'a>(&'a mut self, req: Request, buf: &'a mut [u8]) -> InResponse<'a> {
         let (dtype, index) = req.descriptor_type_index();
+
+        for handler in &mut self.handlers {
+            handler.get_descriptor_requested(dtype, index, req.length);
+        }
 
         match dtype {
             descriptor_type::BOS => InResponse::Accepted(self.bos_descriptor),


### PR DESCRIPTION
## Summary

Add an observer callback `get_descriptor_requested` to the `Handler` trait that fires on every GET_DESCRIPTOR control request, exposing `descriptor_type`, `index`, and `wLength` from the SETUP packet.

## Motivation

Currently there is no way for a `Handler` to observe the raw GET_DESCRIPTOR request parameters. The existing `get_string` callback only fires for STRING descriptors and does not expose `wLength`. The `control_in` callback is not called for standard GET_DESCRIPTOR requests since they are handled internally.

This makes it impossible to implement behaviors that depend on the host's descriptor request patterns — for example, keyboard firmware uses per-request `wLength` values on STRING descriptors to distinguish host operating systems (see QMK [`FingerprintUSBHost`](https://github.com/qmk/qmk_firmware/blob/master/tmk_core/protocol/usb_descriptor.c)).

## Changes

- `Handler` trait: add `get_descriptor_requested(&mut self, descriptor_type: u8, index: u8, wlength: u16)` with a default no-op implementation
- `Inner::handle_get_descriptor()`: call the new method for all registered handlers before dispatching the descriptor response

## Usage example

```rust
impl Handler for MyHandler {
    fn get_descriptor_requested(&mut self, descriptor_type: u8, _index: u8, wlength: u16) {
        // Log or collect per-request wLength for diagnostics
        if descriptor_type == 3 {
            self.string_wlengths.push(wlength);
        }
    }
}
```

## Design notes

- Observer only: the callback cannot influence the descriptor response
- Zero cost when unused: the default empty implementation is optimized away entirely
- No performance concern when used: GET_DESCRIPTOR is a control transfer that occurs during enumeration, not on the data path
- Non-breaking: the new method has a default implementation, so existing `Handler` impls are unaffected