### PR TITLE
stm32: fix low-power regressions after executor/low_power split

### DIFF
--- a/embassy-stm32/src/executor.rs
+++ b/embassy-stm32/src/executor.rs
@@ -136,15 +136,12 @@ mod thread {
 
                     // we do not care about race conditions between the load and store operations, interrupts
                     // will only set this value to true.
-                    critical_section::with(|cs| {
-                        // if there is work to do, loop back to polling
-                        if SIGNAL_WORK_THREAD_MODE.load(core::sync::atomic::Ordering::SeqCst) {
-                            SIGNAL_WORK_THREAD_MODE.store(false, core::sync::atomic::Ordering::SeqCst);
-                        } else {
-                            // if not, sleep waiting for interrupt
-                            crate::low_power::sleep(cs);
-                        }
-                    });
+                    if SIGNAL_WORK_THREAD_MODE.load(core::sync::atomic::Ordering::SeqCst) {
+                        SIGNAL_WORK_THREAD_MODE.store(false, core::sync::atomic::Ordering::SeqCst);
+                    } else {
+                        // if not, sleep waiting for interrupt
+                        crate::low_power::sleep();
+                    }
                     // if an interrupt occurred while waiting, it will be serviced here
                 };
             }

--- a/embassy-stm32/src/low_power.rs
+++ b/embassy-stm32/src/low_power.rs
@@ -42,6 +42,7 @@ foreach_interrupt! {
         #[interrupt]
         #[allow(non_snake_case)]
         unsafe fn $irq() {
+            on_wakeup_irq_or_event();
         }
     };
 }
@@ -52,6 +53,7 @@ foreach_interrupt! {
         #[interrupt]
         #[allow(non_snake_case)]
         unsafe fn $irq() {
+            on_wakeup_irq_or_event();
         }
     };
 }
@@ -355,10 +357,12 @@ fn configure_pwr(cs: CriticalSection) {
 
     if get_driver().pause_time(cs).is_err() {
         warn!("low_power: failed to pause time, not entering stop");
+        return;
     }
 
     if platform::enter_stop(cs, stop_mode).is_err() {
         warn!("low_power: failed to enter stop");
+        return;
     }
 
     #[cfg(stm32l0)]
@@ -382,8 +386,8 @@ fn configure_pwr(cs: CriticalSection) {
 /// sleep, otherwise HAL peripherals may misbehave. HAL drivers automatically prevent
 /// sleep as needed, but you might have to do it manually if you're using some peripherals
 /// with the PAC directly.
-pub unsafe fn sleep(cs: CriticalSection) {
-    configure_pwr(cs);
+pub unsafe fn sleep() {
+    critical_section::with(|cs| configure_pwr(cs));
 
     #[cfg(feature = "low-power-defmt-flush")]
     defmt::flush();


### PR DESCRIPTION
This fixes STM32 low-power regressions introduced by #5671.

Before this patch, low-power sleep/wake could HardFault or fail to awake from deep sleep.

This restores the previous STM32 low-power behavior by:
- removing the outer executor `critical_section` from the STM32 sleep path, which fixes the HardFault around low-power sleep/wake
- restoring RTC interrupt-side `on_wakeup_irq_or_event()`, which fixes failure to awake from deep sleep
- returning early when `pause_time()` or `platform::enter_stop()` fails, which avoids continuing into an invalid low-power path after setup failure

Tested on:
- `stm32u073cc`
- `time-driver-any` (`TIM15`)
- `executor-thread`
