### PR TITLE
examples: remove delay in rp flash examples

### DIFF
--- a/examples/rp/src/bin/flash.rs
+++ b/examples/rp/src/bin/flash.rs
@@ -8,7 +8,6 @@ use embassy_executor::Spawner;
 use embassy_rp::bind_interrupts;
 use embassy_rp::flash::{Async, ERASE_SIZE, FLASH_BASE};
 use embassy_rp::peripherals::{DMA_CH0, FLASH};
-use embassy_time::Timer;
 use {defmt_rtt as _, panic_probe as _};
 
 bind_interrupts!(struct Irqs {
@@ -22,12 +21,6 @@ const FLASH_SIZE: usize = 2 * 1024 * 1024;
 async fn main(_spawner: Spawner) {
     let p = embassy_rp::init(Default::default());
     info!("Hello World!");
-
-    // add some delay to give an attached debug probe time to parse the
-    // defmt RTT header. Reading that header might touch flash memory, which
-    // interferes with flash write operations.
-    // https://github.com/knurling-rs/defmt/pull/683
-    Timer::after_millis(10).await;
 
     let mut flash = embassy_rp::flash::Flash::<_, Async, FLASH_SIZE>::new(p.FLASH, p.DMA_CH0, Irqs);
 

--- a/examples/rp235x/src/bin/flash.rs
+++ b/examples/rp235x/src/bin/flash.rs
@@ -8,7 +8,6 @@ use embassy_executor::Spawner;
 use embassy_rp::bind_interrupts;
 use embassy_rp::flash::{Async, ERASE_SIZE, FLASH_BASE};
 use embassy_rp::peripherals::{DMA_CH0, FLASH};
-use embassy_time::Timer;
 use {defmt_rtt as _, panic_probe as _};
 
 bind_interrupts!(struct Irqs {
@@ -22,12 +21,6 @@ const FLASH_SIZE: usize = 2 * 1024 * 1024;
 async fn main(_spawner: Spawner) {
     let p = embassy_rp::init(Default::default());
     info!("Hello World!");
-
-    // add some delay to give an attached debug probe time to parse the
-    // defmt RTT header. Reading that header might touch flash memory, which
-    // interferes with flash write operations.
-    // https://github.com/knurling-rs/defmt/pull/683
-    Timer::after_millis(10).await;
 
     let mut flash = embassy_rp::flash::Flash::<_, Async, FLASH_SIZE>::new(p.FLASH, p.DMA_CH0, Irqs);
 

--- a/tests/rp/src/bin/flash.rs
+++ b/tests/rp/src/bin/flash.rs
@@ -10,7 +10,6 @@ use embassy_executor::Spawner;
 use embassy_rp::flash::{Async, ERASE_SIZE, FLASH_BASE};
 use embassy_rp::peripherals::DMA_CH0;
 use embassy_rp::{bind_interrupts, dma};
-use embassy_time::Timer;
 use {defmt_rtt as _, panic_probe as _};
 
 bind_interrupts!(struct Irqs {
@@ -23,12 +22,6 @@ const ADDR_OFFSET: u32 = 0x8000;
 async fn main(_spawner: Spawner) {
     let p = embassy_rp::init(Default::default());
     info!("Hello World!");
-
-    // add some delay to give an attached debug probe time to parse the
-    // defmt RTT header. Reading that header might touch flash memory, which
-    // interferes with flash write operations.
-    // https://github.com/knurling-rs/defmt/pull/683
-    Timer::after_millis(10).await;
 
     let mut flash = embassy_rp::flash::Flash::<_, Async, { 2 * 1024 * 1024 }>::new(p.FLASH, p.DMA_CH0, Irqs);
 


### PR DESCRIPTION
The rp2040/235x flash examples included a brief delay prior to reading from flash with a reference to https://github.com/knurling-rs/defmt/pull/683, which had been merged but not yet released (it went into defmt 0.4.0 I believe). Digging uncovers an Embassy dev first encountered the issue here: https://github.com/embassy-rs/embassy/pull/951#issuecomment-1293006985.

From what I can see since we're now on defmt 1.0.1 the RTT header is in RAM and the delay should now be unnecessary. 

I have tested locally on rp2040.