### PR TITLE
Input capture fixes

### DIFF
--- a/embassy-stm32/src/timer/input_capture.rs
+++ b/embassy-stm32/src/timer/input_capture.rs
@@ -151,6 +151,7 @@ impl<'d, T: GeneralInstance4Channel> InputCapture<'d, T> {
         self.inner.set_input_ti_selection(channel, tisel);
         self.inner.set_input_capture_mode(channel, mode);
         self.inner.enable_channel(channel, true);
+        self.inner.clear_input_interrupt(channel);
         self.inner.enable_input_interrupt(channel, true);
 
         InputCaptureFuture {


### PR DESCRIPTION
This PR fixes a couple issues I found with the timer input capture driver

1. Filter and prescaler are hardcoded with no way to adjust without being overwritten on every capture. This moves them into separate setters, but maintains the default behavior in the constructor.
2. Clear a stale flag before re-enabling on every capture, preventing poisoning if the future is dropped.

Tested on an STM32U5