### PR TITLE
opamp: prevent degrade_adc() from disabling the OPAMP

### DIFF
--- a/embassy-stm32/src/adc/mod.rs
+++ b/embassy-stm32/src/adc/mod.rs
@@ -485,9 +485,9 @@ pub trait AdcChannel<T>: SealedAdcChannel<T> + Sized {
 /// This is useful in scenarios where you need the ADC channels to have the same type, such as
 /// storing them in an array.
 pub struct AnyAdcChannel<'a, T> {
-    channel: u8,
-    is_differential: bool,
-    _phantom: PhantomData<&'a mut T>,
+    pub(crate) channel: u8,
+    pub(crate) is_differential: bool,
+    pub(crate) _phantom: PhantomData<&'a mut T>,
 }
 impl<T: Instance> AdcChannel<T> for AnyAdcChannel<'_, T> {}
 impl<T: Instance> SealedAdcChannel<T> for AnyAdcChannel<'_, T> {

--- a/embassy-stm32/src/opamp.rs
+++ b/embassy-stm32/src/opamp.rs
@@ -612,6 +612,21 @@ macro_rules! impl_opamp_external_output {
                 impl<'d> crate::adc::AdcChannel<crate::peripherals::$adc>
                     for crate::opamp::OpAmpOutput<'d, crate::peripherals::$inst>
                 {
+                    fn degrade_adc<'a>(self) -> crate::adc::AnyAdcChannel<'a, crate::peripherals::$adc>
+                    where
+                        Self: 'a,
+                    {
+                        let ch = crate::adc::AnyAdcChannel {
+                            channel: $ch,
+                            is_differential: false,
+                            _phantom: core::marker::PhantomData,
+                        };
+                        // Prevent Drop from disabling the OPAMP — the caller
+                        // has obtained the ADC channel and expects the OPAMP
+                        // to remain enabled.
+                        core::mem::forget(self);
+                        ch
+                    }
                 }
             };
         );
@@ -634,6 +649,21 @@ macro_rules! impl_opamp_internal_output {
                 impl<'d> crate::adc::AdcChannel<crate::peripherals::$adc>
                     for OpAmpInternalOutput<'d, crate::peripherals::$inst>
                 {
+                    fn degrade_adc<'a>(self) -> crate::adc::AnyAdcChannel<'a, crate::peripherals::$adc>
+                    where
+                        Self: 'a,
+                    {
+                        let ch = crate::adc::AnyAdcChannel {
+                            channel: $ch,
+                            is_differential: false,
+                            _phantom: core::marker::PhantomData,
+                        };
+                        // Prevent Drop from disabling the OPAMP — the caller
+                        // has obtained the ADC channel and expects the OPAMP
+                        // to remain enabled.
+                        core::mem::forget(self);
+                        ch
+                    }
                 }
             };
         );


### PR DESCRIPTION
## Summary

Fixes #4269

`OpAmpOutput` and `OpAmpInternalOutput` implement `Drop` to clear `OPAEN`, disabling the OPAMP when the output handle is dropped. However, `degrade_adc()` (the default `AdcChannel` trait method) consumes `self` to produce an `AnyAdcChannel`, which triggers `Drop` at the end of the function — silently disabling the OPAMP immediately after the caller obtains the ADC channel.

This makes it impossible to use OPAMP outputs with APIs that require `AnyAdcChannel` (e.g. `setup_injected_conversions()`) without the OPAMP being disabled.

### Fix

Override `degrade_adc()` for both `OpAmpOutput` and `OpAmpInternalOutput` to use `mem::forget(self)`, preventing the destructive `Drop` while still extracting the correct ADC channel number.

`AnyAdcChannel` fields are changed to `pub(crate)` to allow construction from the opamp module.

### Impact

This is a silent, critical bug affecting any code that chains `.pga_biased_int(...).degrade_adc()` or similar — the OPAMP appears to be configured correctly but is actually disabled by the time ADC conversions run. The ADC reads floating internal nodes instead of the amplified signal.

Tested on STM32G431 (B-G431B-ESC1 board) with three OPAMPs in PGA mode feeding injected ADC conversions.

## Test plan

- [x] Verified on hardware: without fix, ADC reads ~40-490 counts (floating); with fix, reads ~2573 (correct zero-current bias point)
- [x] `cargo build --features stm32g431cb,time-driver-tim2` passes
- [x] No new clippy warnings in opamp module