### PR TITLE
move dsi config after enable_and_reset

### DIFF
--- a/embassy-stm32/src/dsihost/mod.rs
+++ b/embassy-stm32/src/dsihost/mod.rs
@@ -11,6 +11,7 @@ use crate::dsihost::panel::DsiPanel;
 use crate::gpio::{AfType, Flex};
 use crate::interrupt::typelevel::Interrupt;
 use crate::peripherals::{self};
+use crate::rcc::dsi::DSI_CONFIG;
 use crate::rcc::{self, RccPeripheral};
 use crate::time::MaybeHertz;
 use crate::{Peri, block_for_us, interrupt};
@@ -111,7 +112,26 @@ impl<'d, T: Instance> DsiHost<'d, T> {
     }
 
     /// Enable the PLL and wait for the lock interrupt
-    async fn enable_wait_pll_lock(&self) {
+    async fn enable_pll(&self) {
+        let config = unsafe { DSI_CONFIG }.unwrap();
+
+        // Set the PLL configuration
+        T::regs().wrpcr().modify(|w| {
+            w.set_ndiv(config.ndiv);
+
+            #[cfg(dsihost_v1)]
+            {
+                w.set_idf(config.idf as u8);
+                w.set_odf(config.odf as u8);
+            }
+
+            #[cfg(dsihost_u5)]
+            {
+                w.set_idf(config.idf);
+                w.set_odf(config.odf);
+            }
+        });
+
         poll_fn(|cx| {
             let status = T::regs().wisr().read();
 
@@ -154,7 +174,7 @@ impl<'d, T: Instance> DsiHost<'d, T> {
         #[cfg(dsihost_v1)]
         self.enable_regulator().await;
 
-        self.enable_wait_pll_lock().await;
+        self.enable_pll().await;
 
         self.phy_init(phy_config);
 

--- a/embassy-stm32/src/rcc/dsi.rs
+++ b/embassy-stm32/src/rcc/dsi.rs
@@ -1,7 +1,8 @@
-use crate::pac::DSIHOST;
 use crate::time::Hertz;
 #[cfg(dsihost_v1)]
 use crate::time::Prescaler;
+
+pub static mut DSI_CONFIG: Option<DsiHostPllConfig> = None;
 
 /// DSI PLL Input Divisor of HSE clock
 #[cfg(dsihost_v1)]
@@ -84,11 +85,11 @@ pub type DsiPllNdiv = u16;
 #[derive(Clone, Copy)]
 pub struct DsiHostPllConfig {
     /// Loop division factor
-    ndiv: DsiPllNdiv,
+    pub(crate) ndiv: DsiPllNdiv,
     /// Input division factor
-    idf: DsiPllInput,
+    pub(crate) idf: DsiPllInput,
     /// Output division factor
-    odf: DsiPllOutput,
+    pub(crate) odf: DsiPllOutput,
 }
 
 impl DsiHostPllConfig {
@@ -142,22 +143,7 @@ pub fn configure_pll(hse: Option<Hertz>, config: DsiHostPllConfig) -> Hertz {
         "DSI PLL output must be >= 62.5MHz and <= 1GHz"
     );
 
-    // Set the PLL configuration
-    DSIHOST.wrpcr().modify(|w| {
-        w.set_ndiv(config.ndiv);
-
-        #[cfg(dsihost_v1)]
-        {
-            w.set_idf(config.idf as u8);
-            w.set_odf(config.odf as u8);
-        }
-
-        #[cfg(dsihost_u5)]
-        {
-            w.set_idf(config.idf);
-            w.set_odf(config.odf);
-        }
-    });
+    unsafe { DSI_CONFIG = Some(config) };
 
     pll_freq
 }

--- a/embassy-stm32/src/rcc/mod.rs
+++ b/embassy-stm32/src/rcc/mod.rs
@@ -15,7 +15,7 @@ use critical_section::CriticalSection;
 pub use mco::*;
 
 #[cfg(dsihost)]
-mod dsi;
+pub(crate) mod dsi;
 
 #[cfg(crs)]
 mod hsi48;


### PR DESCRIPTION
This might be required if enable_and_reset overwrites these variables. Not sure, though.

cc @boondocklabs