### PR TITLE
stm32: fix HASH NBLW zeroed when triggering DCAL

### DIFF
--- a/embassy-stm32/src/hash/mod.rs
+++ b/embassy-stm32/src/hash/mod.rs
@@ -220,7 +220,7 @@ impl<'d, T: Instance, M: Mode> Hash<'d, T, M> {
         if !ctx.key_sent {
             if let Some(key) = ctx.key {
                 self.accumulate_blocking(key);
-                T::regs().str().write(|w| w.set_dcal(true));
+                T::regs().str().modify(|w| w.set_dcal(true));
                 // Block waiting for digest.
                 while !T::regs().sr().read().dinis() {}
             }
@@ -303,13 +303,13 @@ impl<'d, T: Instance, M: Mode> Hash<'d, T, M> {
         ctx.buflen = 0;
 
         //Start the digest calculation.
-        T::regs().str().write(|w| w.set_dcal(true));
+        T::regs().str().modify(|w| w.set_dcal(true));
 
         // Load the HMAC key if provided.
         if let Some(key) = ctx.key {
             while !T::regs().sr().read().dinis() {}
             self.accumulate_blocking(key);
-            T::regs().str().write(|w| w.set_dcal(true));
+            T::regs().str().modify(|w| w.set_dcal(true));
         }
 
         // Block until digest computation is complete.

--- a/tests/stm32/src/bin/hash.rs
+++ b/tests/stm32/src/bin/hash.rs
@@ -95,6 +95,47 @@ fn test_interrupt(hw_hasher: &mut Hash<'_, peripherals::HASH, Blocking>) {
     defmt::assert!(hw_hmac == sw_hmac[..]);
 }
 
+/// Test inputs whose length is not a multiple of 4 bytes.
+/// This exercises the NBLW (number of valid bits in last word) handling
+/// in finish_blocking — a previous bug zeroed NBLW when triggering DCAL.
+fn test_short_inputs(hw_hasher: &mut Hash<'_, peripherals::HASH, Blocking>) {
+    // 3 bytes — NBLW must be 24
+    let mut ctx = hw_hasher.start(Algorithm::SHA256, DataType::Width8, None);
+    hw_hasher.update_blocking(&mut ctx, b"abc");
+    let mut hw_digest = [0u8; 32];
+    hw_hasher.finish_blocking(ctx, &mut hw_digest);
+
+    let mut sw = Sha256::new();
+    sw.update(b"abc");
+    let sw_digest = sw.finalize();
+    info!("Hardware SHA-256(abc): {:?}", hw_digest);
+    info!("Software SHA-256(abc): {:?}", sw_digest[..]);
+    defmt::assert!(hw_digest == sw_digest[..], "SHA-256 of 3-byte input (NBLW=24) failed");
+
+    // 1 byte — NBLW must be 8
+    let mut ctx = hw_hasher.start(Algorithm::SHA256, DataType::Width8, None);
+    hw_hasher.update_blocking(&mut ctx, b"x");
+    let mut hw_digest = [0u8; 32];
+    hw_hasher.finish_blocking(ctx, &mut hw_digest);
+
+    let mut sw = Sha256::new();
+    sw.update(b"x");
+    let sw_digest = sw.finalize();
+    defmt::assert!(hw_digest == sw_digest[..], "SHA-256 of 1-byte input (NBLW=8) failed");
+
+    // 5 bytes — multi-update, total not aligned
+    let mut ctx = hw_hasher.start(Algorithm::SHA256, DataType::Width8, None);
+    hw_hasher.update_blocking(&mut ctx, b"He");
+    hw_hasher.update_blocking(&mut ctx, b"llo");
+    let mut hw_digest = [0u8; 32];
+    hw_hasher.finish_blocking(ctx, &mut hw_digest);
+
+    let mut sw = Sha256::new();
+    sw.update(b"Hello");
+    let sw_digest = sw.finalize();
+    defmt::assert!(hw_digest == sw_digest[..], "SHA-256 of 5-byte multi-update input failed");
+}
+
 // This uses sha512, so only supported on hash_v3 and up
 #[cfg(feature = "hash-v34")]
 fn test_sizes(hw_hasher: &mut Hash<'_, peripherals::HASH, Blocking>) {
@@ -132,6 +173,7 @@ async fn main(_spawner: Spawner) {
     let p: embassy_stm32::Peripherals = init();
     let mut hw_hasher = Hash::new_blocking(p.HASH, Irqs);
 
+    test_short_inputs(&mut hw_hasher);
     test_interrupt(&mut hw_hasher);
     // Run it a second time to check hash-after-hmac
     test_interrupt(&mut hw_hasher);


### PR DESCRIPTION
## Summary

- `finish_blocking` and `update_blocking` (HMAC path) use `str().write(|w| w.set_dcal(true))` to trigger digest calculation, which zeros the entire STR register — including NBLW (number of valid bits in the last word)
- When input length is not a multiple of 4 bytes, `accumulate_blocking` correctly sets NBLW via `str().modify()`, but the subsequent `str().write()` for DCAL resets it to 0
- NBLW=0 tells the hardware all 32 bits of the last word are valid, so it hashes extra zero-padding bytes
- Fix: change all three `str().write(|w| w.set_dcal(true))` to `str().modify(|w| w.set_dcal(true))`

The existing HIL tests did not catch this because all test inputs happened to have lengths that are multiples of 4 bytes. Added `test_short_inputs()` with 1-byte, 3-byte, and 5-byte inputs to cover the NBLW path.

## Test plan

- [x] Tested on NUCLEO-H755ZI-Q (hash_v2) with NIST FIPS 180-4 SHA-256 vectors
- [ ] HIL test: `test_short_inputs` added to `tests/stm32/src/bin/hash.rs` (runs on all hash-capable targets)

🤖 Generated with [Claude Code](https://claude.com/claude-code)