### PR TITLE
`embassy-sync`: add `ResourcePool`

### DIFF
--- a/embassy-sync/src/lib.rs
+++ b/embassy-sync/src/lib.rs
@@ -19,6 +19,7 @@ pub mod once_lock;
 pub mod pipe;
 pub mod priority_channel;
 pub mod pubsub;
+pub mod resource_pool;
 pub mod rwlock;
 pub mod semaphore;
 pub mod signal;

--- a/embassy-sync/src/lib.rs
+++ b/embassy-sync/src/lib.rs
@@ -19,6 +19,7 @@ pub mod once_lock;
 pub mod pipe;
 pub mod priority_channel;
 pub mod pubsub;
+pub mod resource_pool;
 pub mod rpc_service;
 pub mod rwlock;
 pub mod semaphore;

--- a/embassy-sync/src/resource_pool.rs
+++ b/embassy-sync/src/resource_pool.rs
@@ -66,10 +66,10 @@ impl<'a, M: RawMutex, T, const N: usize> ResourcePool<'a, M, T, N> {
 
 #[repr(transparent)]
 #[derive(Debug)]
-struct BufferPtr<T>(*mut T);
+struct BufferPtr<T: ?Sized>(*mut T);
 
-unsafe impl<T> Send for BufferPtr<T> {}
-unsafe impl<T> Sync for BufferPtr<T> {}
+unsafe impl<T: ?Sized> Send for BufferPtr<T> {}
+unsafe impl<T: ?Sized> Sync for BufferPtr<T> {}
 
 struct State<const N: usize> {
     available: Vec<usize, N>,
@@ -101,12 +101,92 @@ impl<'guard, 'buffer, M: RawMutex, T, const N: usize> Deref for ResourceGuard<'g
 
     fn deref(&self) -> &Self::Target {
         unsafe { &*self.store.buf.0.add(self.index) }
-        // unsafe { &*self.element.0 }
     }
 }
 
 impl<'guard, 'buffer, M: RawMutex, T, const N: usize> DerefMut for ResourceGuard<'guard, 'buffer, M, T, N> {
     fn deref_mut(&mut self) -> &mut Self::Target {
         unsafe { &mut *self.store.buf.0.add(self.index) }
+    }
+}
+
+impl<'guard, 'buffer, M: RawMutex, T, const N: usize> ResourceGuard<'guard, 'buffer, M, T, N> {
+    /// maps the value contained to another, referencing the original value. Does not take "self" to avoid shadowing any functions of the wrapped type.
+    pub fn map<U: ?Sized>(
+        orig: Self,
+        fun: impl FnOnce(&mut T) -> &mut U,
+    ) -> MappedResourceGuard<'guard, 'buffer, M, T, U, N> {
+        let store = orig.store;
+        let index = orig.index;
+        let value = fun(unsafe { &mut *store.buf.0.add(index) });
+        // Don't run the `drop` method for MutexGuard. The ownership of the underlying
+        // locked state is being moved to the returned MappedMutexGuard.
+        core::mem::forget(orig);
+        MappedResourceGuard {
+            store,
+            value: BufferPtr(value),
+            index,
+        }
+    }
+}
+
+/// Resource guard
+///
+/// Owning this guard provides mutable access to the underlying resource.
+///
+/// Dropping the guard returns the resource back to the pool.
+pub struct MappedResourceGuard<'guard, 'buffer, M: RawMutex, T, U: ?Sized, const N: usize> {
+    store: &'guard ResourcePool<'buffer, M, T, N>,
+    index: usize,
+    value: BufferPtr<U>,
+}
+
+impl<'guard, 'buffer, M: RawMutex, T, U: ?Sized, const N: usize> Drop
+    for MappedResourceGuard<'guard, 'buffer, M, T, U, N>
+{
+    fn drop(&mut self) {
+        self.store.state.lock(|state| {
+            let state = &mut *state.borrow_mut();
+            state.available.push(self.index).unwrap();
+            state.waker.wake();
+        });
+    }
+}
+
+impl<'guard, 'buffer, M: RawMutex, T, U: ?Sized, const N: usize> Deref
+    for MappedResourceGuard<'guard, 'buffer, M, T, U, N>
+{
+    type Target = U;
+
+    fn deref(&self) -> &Self::Target {
+        unsafe { &*self.value.0 }
+    }
+}
+
+impl<'guard, 'buffer, M: RawMutex, T, U: ?Sized, const N: usize> DerefMut
+    for MappedResourceGuard<'guard, 'buffer, M, T, U, N>
+{
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        unsafe { &mut *self.value.0 }
+    }
+}
+
+impl<'guard, 'buffer, M: RawMutex, T, U: ?Sized, const N: usize> MappedResourceGuard<'guard, 'buffer, M, T, U, N> {
+    /// maps the value contained to another, referencing the original value. Does not take "self" to avoid shadowing any functions of the wrapped type.
+    pub fn map<V: ?Sized>(
+        orig: Self,
+        fun: impl FnOnce(&mut U) -> &mut V,
+    ) -> MappedResourceGuard<'guard, 'buffer, M, T, V, N> {
+        let store = orig.store;
+        let index = orig.index;
+        let value = fun(unsafe { &mut *orig.value.0 });
+        // Don't run the `drop` method for MutexGuard. The ownership of the underlying
+        // locked state is being moved to the returned MappedMutexGuard.
+        core::mem::forget(orig);
+        MappedResourceGuard {
+            store,
+            value: BufferPtr(value),
+            index,
+        }
     }
 }

--- a/embassy-sync/src/resource_pool.rs
+++ b/embassy-sync/src/resource_pool.rs
@@ -1,0 +1,112 @@
+//! A collection of objects that may be shared between tasks.
+//!
+//! Multiple tasks may share a reference to the pool and acquire resources when required.
+//! Acquired resources may be kept or moved between tasks before they are released.
+use core::cell::RefCell;
+use core::future::poll_fn;
+use core::marker::PhantomData;
+use core::ops::{Deref, DerefMut};
+use core::task::Poll;
+
+use heapless::Vec;
+
+use crate::blocking_mutex::Mutex;
+use crate::blocking_mutex::raw::RawMutex;
+use crate::waitqueue::WakerRegistration;
+
+/// Resource pool
+pub struct ResourcePool<'a, M: RawMutex, T, const N: usize> {
+    buf: BufferPtr<T>,
+    phantom: PhantomData<&'a mut T>,
+    state: Mutex<M, RefCell<State<N>>>,
+}
+
+impl<'a, M: RawMutex, T, const N: usize> ResourcePool<'a, M, T, N> {
+    /// Crate a new resource pool, taking an array of resources which will be managed.
+    pub fn new(buf: &'a mut [T]) -> Self {
+        let mut available = Vec::new();
+        available.extend(0..buf.len());
+        Self {
+            buf: BufferPtr(buf.as_mut_ptr()),
+            phantom: PhantomData,
+            state: Mutex::new(RefCell::new(State {
+                available,
+                waker: WakerRegistration::new(),
+            })),
+        }
+    }
+
+    /// Attempt to acquire one instance of the resource.
+    ///
+    /// If no instance is available, return None immediately.
+    pub fn try_take<'guard>(&'guard self) -> Option<ResourceGuard<'guard, 'a, M, T, N>> {
+        self.state.lock(|state| {
+            let state = &mut *state.borrow_mut();
+            let index = state.available.pop()?;
+            Some(ResourceGuard { store: self, index })
+        })
+    }
+
+    /// Acquire one instance of the resource.
+    ///
+    /// If no instance is available, wait for an instance to be returned to the pool.
+    pub fn take<'guard>(&'guard self) -> impl Future<Output = ResourceGuard<'guard, 'a, M, T, N>> {
+        poll_fn(|cx| {
+            self.state.lock(|state| {
+                let state = &mut *state.borrow_mut();
+                let Some(index) = state.available.pop() else {
+                    state.waker.register(cx.waker());
+                    return Poll::Pending;
+                };
+                Poll::Ready(ResourceGuard { store: self, index })
+            })
+        })
+    }
+}
+
+#[repr(transparent)]
+#[derive(Debug)]
+struct BufferPtr<T>(*mut T);
+
+unsafe impl<T> Send for BufferPtr<T> {}
+unsafe impl<T> Sync for BufferPtr<T> {}
+
+struct State<const N: usize> {
+    available: Vec<usize, N>,
+    waker: WakerRegistration,
+}
+
+/// Resource guard
+///
+/// Owning this guard provides mutable access to the underlying resource.
+///
+/// Dropping the guard returns the resource back to the pool.
+pub struct ResourceGuard<'guard, 'buffer, M: RawMutex, T, const N: usize> {
+    store: &'guard ResourcePool<'buffer, M, T, N>,
+    index: usize,
+}
+
+impl<'guard, 'buffer, M: RawMutex, T, const N: usize> Drop for ResourceGuard<'guard, 'buffer, M, T, N> {
+    fn drop(&mut self) {
+        self.store.state.lock(|state| {
+            let state = &mut *state.borrow_mut();
+            state.available.push(self.index).unwrap();
+            state.waker.wake();
+        });
+    }
+}
+
+impl<'guard, 'buffer, M: RawMutex, T, const N: usize> Deref for ResourceGuard<'guard, 'buffer, M, T, N> {
+    type Target = T;
+
+    fn deref(&self) -> &Self::Target {
+        unsafe { &*self.store.buf.0.add(self.index) }
+        // unsafe { &*self.element.0 }
+    }
+}
+
+impl<'guard, 'buffer, M: RawMutex, T, const N: usize> DerefMut for ResourceGuard<'guard, 'buffer, M, T, N> {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        unsafe { &mut *self.store.buf.0.add(self.index) }
+    }
+}

--- a/embassy-sync/src/resource_pool.rs
+++ b/embassy-sync/src/resource_pool.rs
@@ -1,7 +1,9 @@
-//! A collection of objects that may be shared between tasks.
+//! A collection of objects that can be shared between tasks.
 //!
 //! Multiple tasks may share a reference to the pool and acquire resources when required.
 //! Acquired resources may be kept or moved between tasks before they are released.
+//!
+//! Since only references are shared, this can be used to implement a zero-copy message passing system.
 use core::cell::RefCell;
 use core::future::poll_fn;
 use core::marker::PhantomData;
@@ -14,7 +16,12 @@ use crate::blocking_mutex::Mutex;
 use crate::blocking_mutex::raw::RawMutex;
 use crate::waitqueue::WakerRegistration;
 
-/// Resource pool
+/// A collection of objects that can be shared between tasks.
+///
+/// Multiple tasks may share a reference to the pool and acquire resources when required.
+/// Acquired resources may be kept or moved between tasks before they are released.
+///
+/// When the reference to a resource is dropped, the resource is returned to the pool and may be acquired by another task.
 pub struct ResourcePool<'a, M: RawMutex, T, const N: usize> {
     buf: BufferPtr<T>,
     phantom: PhantomData<&'a mut T>,
@@ -22,7 +29,9 @@ pub struct ResourcePool<'a, M: RawMutex, T, const N: usize> {
 }
 
 impl<'a, M: RawMutex, T, const N: usize> ResourcePool<'a, M, T, N> {
-    /// Crate a new resource pool, taking an array of resources which will be managed.
+    /// Crate a new [`ResourcePool`], taking an array of resources which will be managed.
+    ///
+    /// The function will panic if the length of the array is larger than `N`.
     pub fn new(buf: &'a mut [T]) -> Self {
         let mut available = Vec::new();
         available.extend(0..buf.len());
@@ -78,9 +87,9 @@ struct State<const N: usize> {
 
 /// Resource guard
 ///
-/// Owning this guard provides mutable access to the underlying resource.
-///
-/// Dropping the guard returns the resource back to the pool.
+/// Owning this guard provides mutable access to an instance of the underlying resource.
+/// Dropping the guard returns the resource back to the [`ResourcePool`].
+/// The guard can be mapped to a different type, referencing the original resource, using [`ResourceGuard::map`].
 pub struct ResourceGuard<'guard, 'buffer, M: RawMutex, T, const N: usize> {
     store: &'guard ResourcePool<'buffer, M, T, N>,
     index: usize,
@@ -111,7 +120,7 @@ impl<'guard, 'buffer, M: RawMutex, T, const N: usize> DerefMut for ResourceGuard
 }
 
 impl<'guard, 'buffer, M: RawMutex, T, const N: usize> ResourceGuard<'guard, 'buffer, M, T, N> {
-    /// maps the value contained to another, referencing the original value. Does not take "self" to avoid shadowing any functions of the wrapped type.
+    /// Maps the managed resource to another type, referencing the original value. Does not take "self" to avoid shadowing any functions of the wrapped type.
     pub fn map<U: ?Sized>(
         orig: Self,
         fun: impl FnOnce(&mut T) -> &mut U,
@@ -130,11 +139,11 @@ impl<'guard, 'buffer, M: RawMutex, T, const N: usize> ResourceGuard<'guard, 'buf
     }
 }
 
-/// Resource guard
+/// Mapped resource guard
 ///
 /// Owning this guard provides mutable access to the underlying resource.
-///
-/// Dropping the guard returns the resource back to the pool.
+/// This guard is created by mapping a [`ResourceGuard`] to a different type, referencing the original resource.
+/// Dropping the guard returns the resource back to the [`ResourcePool`].
 pub struct MappedResourceGuard<'guard, 'buffer, M: RawMutex, T, U: ?Sized, const N: usize> {
     store: &'guard ResourcePool<'buffer, M, T, N>,
     index: usize,
@@ -172,7 +181,7 @@ impl<'guard, 'buffer, M: RawMutex, T, U: ?Sized, const N: usize> DerefMut
 }
 
 impl<'guard, 'buffer, M: RawMutex, T, U: ?Sized, const N: usize> MappedResourceGuard<'guard, 'buffer, M, T, U, N> {
-    /// maps the value contained to another, referencing the original value. Does not take "self" to avoid shadowing any functions of the wrapped type.
+    /// Maps the managed resource to another type, referencing the original value. Does not take "self" to avoid shadowing any functions of the wrapped type.
     pub fn map<V: ?Sized>(
         orig: Self,
         fun: impl FnOnce(&mut U) -> &mut V,
@@ -188,5 +197,42 @@ impl<'guard, 'buffer, M: RawMutex, T, U: ?Sized, const N: usize> MappedResourceG
             value: BufferPtr(value),
             index,
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::blocking_mutex::raw::NoopRawMutex;
+
+    #[test]
+    fn resources_returned_to_pool_when_dropped() {
+        let mut resources = [0, 1];
+        let pool = ResourcePool::<NoopRawMutex, _, 2>::new(&mut resources);
+
+        {
+            let a = pool.try_take().expect("Failed to take resource");
+            let b = pool.try_take().expect("Failed to take resource");
+            let c = pool.try_take();
+            assert!(c.is_none(), "Expected no more resources to be available");
+        }
+
+        let d = pool.try_take().expect("Resource should have been returned to the pool");
+    }
+
+    #[test]
+    fn mapped_resources_not_returned_to_pool() {
+        let mut resources = [[0]];
+        let pool = ResourcePool::<NoopRawMutex, _, 1>::new(&mut resources);
+
+        {
+            let a = pool.try_take().expect("Failed to take resource");
+            let mapped = ResourceGuard::map(a, |r| &mut r[0]);
+
+            let b = pool.try_take();
+            assert!(b.is_none(), "Expected no more resources to be available");
+        }
+
+        let c = pool.try_take().expect("Resource should have been returned to the pool");
     }
 }

--- a/examples/stm32g4/src/bin/resource_pool.rs
+++ b/examples/stm32g4/src/bin/resource_pool.rs
@@ -4,15 +4,14 @@
 use core::fmt::Write;
 
 use defmt::info;
-use defmt_rtt as _;
 use embassy_executor::Spawner;
 use embassy_sync::blocking_mutex::raw::ThreadModeRawMutex;
 use embassy_sync::channel::Channel;
-use embassy_sync::resource_pool::{ResourceGuard, ResourcePool};
+use embassy_sync::resource_pool::{MappedResourceGuard, ResourceGuard, ResourcePool};
 use embassy_time::Timer;
 use heapless::String;
-use panic_probe as _;
 use static_cell::{ConstStaticCell, StaticCell};
+use {defmt_rtt as _, panic_probe as _};
 
 const N_BUFFERS: usize = 3;
 const N_BYTES: usize = 256;
@@ -22,7 +21,7 @@ static BUFFERS: ConstStaticCell<[String<N_BYTES>; N_BUFFERS]> =
 
 static SHARED_CHANNEL: Channel<
     ThreadModeRawMutex,
-    ResourceGuard<'static, 'static, ThreadModeRawMutex, String<N_BYTES>, N_BUFFERS>,
+    MappedResourceGuard<'static, 'static, ThreadModeRawMutex, String<N_BYTES>, str, N_BUFFERS>,
     8,
 > = Channel::new();
 
@@ -48,11 +47,7 @@ async fn main(spawner: Spawner) {
     loop {
         let guard = receiver.receive().await;
 
-        defmt::info!(
-            "received: {} at addr {}",
-            guard.as_str(),
-            guard.as_str().as_ptr() as usize
-        );
+        defmt::info!("received: {} at addr {}", &*guard, guard.as_ptr() as usize);
 
         // keep buffer for a while so it is not immediately returned to the pool
         Timer::after_millis(1500).await;
@@ -70,11 +65,6 @@ async fn produce_data(pool: &'static ResourcePool<'static, ThreadModeRawMutex, S
     loop {
         Timer::after_secs(3).await;
 
-        // let Some(mut guard) = pool.try_take() else {
-        //     info!("task {} could not acquire buffer", num);
-        //     continue;
-        // };
-
         // acquire one buffer
         let mut guard = pool.take().await;
 
@@ -82,7 +72,10 @@ async fn produce_data(pool: &'static ResourcePool<'static, ThreadModeRawMutex, S
         guard.clear();
         write!(&mut *guard, "hello {} from task {}", n, num).unwrap();
 
-        let addr = guard.as_str().as_ptr() as usize;
+        // map
+        let guard = ResourceGuard::map(guard, |g| g.as_mut_str());
+
+        let addr = guard.as_ptr() as usize;
 
         // send buffer to main loop
         sender.try_send(guard).ok().unwrap();

--- a/examples/stm32g4/src/bin/resource_pool.rs
+++ b/examples/stm32g4/src/bin/resource_pool.rs
@@ -1,0 +1,94 @@
+#![no_std]
+#![no_main]
+
+use core::fmt::Write;
+
+use defmt::info;
+use defmt_rtt as _;
+use embassy_executor::Spawner;
+use embassy_sync::blocking_mutex::raw::ThreadModeRawMutex;
+use embassy_sync::channel::Channel;
+use embassy_sync::resource_pool::{ResourceGuard, ResourcePool};
+use embassy_time::Timer;
+use heapless::String;
+use panic_probe as _;
+use static_cell::{ConstStaticCell, StaticCell};
+
+const N_BUFFERS: usize = 3;
+const N_BYTES: usize = 256;
+
+static BUFFERS: ConstStaticCell<[String<N_BYTES>; N_BUFFERS]> =
+    ConstStaticCell::new([String::new(), String::new(), String::new()]);
+
+static SHARED_CHANNEL: Channel<
+    ThreadModeRawMutex,
+    ResourceGuard<'static, 'static, ThreadModeRawMutex, String<N_BYTES>, N_BUFFERS>,
+    8,
+> = Channel::new();
+
+#[embassy_executor::main]
+async fn main(spawner: Spawner) {
+    let _p = embassy_stm32::init(Default::default());
+
+    static POOL: StaticCell<ResourcePool<'static, ThreadModeRawMutex, String<N_BYTES>, N_BUFFERS>> = StaticCell::new();
+    let pool = POOL.init(ResourcePool::new(BUFFERS.take()));
+
+    spawner.spawn(produce_data(pool, 0).unwrap());
+    Timer::after_millis(100).await;
+    spawner.spawn(produce_data(pool, 1).unwrap());
+    Timer::after_millis(100).await;
+    spawner.spawn(produce_data(pool, 2).unwrap());
+    Timer::after_millis(100).await;
+    spawner.spawn(produce_data(pool, 3).unwrap());
+
+    info!("started producers");
+
+    let receiver = SHARED_CHANNEL.receiver();
+
+    loop {
+        let guard = receiver.receive().await;
+
+        defmt::info!(
+            "received: {} at addr {}",
+            guard.as_str(),
+            guard.as_str().as_ptr() as usize
+        );
+
+        // keep buffer for a while so it is not immediately returned to the pool
+        Timer::after_millis(1500).await;
+
+        // extra verbose, this happens automatically
+        // core::mem::drop(guard);
+    }
+}
+
+#[embassy_executor::task(pool_size = 4)]
+async fn produce_data(pool: &'static ResourcePool<'static, ThreadModeRawMutex, String<N_BYTES>, N_BUFFERS>, num: u32) {
+    let sender = SHARED_CHANNEL.sender();
+
+    let mut n = 0;
+    loop {
+        Timer::after_secs(3).await;
+
+        // let Some(mut guard) = pool.try_take() else {
+        //     info!("task {} could not acquire buffer", num);
+        //     continue;
+        // };
+
+        // acquire one buffer
+        let mut guard = pool.take().await;
+
+        // write to buffer
+        guard.clear();
+        write!(&mut *guard, "hello {} from task {}", n, num).unwrap();
+
+        let addr = guard.as_str().as_ptr() as usize;
+
+        // send buffer to main loop
+        sender.try_send(guard).ok().unwrap();
+
+        info!("task {} sent buffer with addr {}", num, addr);
+
+        n += 1;
+    }
+}

--- a/examples/stm32g4/src/bin/resource_pool.rs
+++ b/examples/stm32g4/src/bin/resource_pool.rs
@@ -4,14 +4,15 @@
 use core::fmt::Write;
 
 use defmt::info;
+use defmt_rtt as _;
 use embassy_executor::Spawner;
 use embassy_sync::blocking_mutex::raw::ThreadModeRawMutex;
 use embassy_sync::channel::Channel;
 use embassy_sync::resource_pool::{MappedResourceGuard, ResourceGuard, ResourcePool};
 use embassy_time::Timer;
 use heapless::String;
+use panic_probe as _;
 use static_cell::{ConstStaticCell, StaticCell};
-use {defmt_rtt as _, panic_probe as _};
 
 const N_BUFFERS: usize = 3;
 const N_BYTES: usize = 256;


### PR DESCRIPTION
I think this would be a good addition to embassy-sync. I see two main uses:
- Managing similar peripherals (although in most cases it probably does matter which specific one you end up with)
- Managing larger buffers, similar to `zerocopy_channel`

I've mostly created it for the second case, because I needed to get around the limitations of `zerocopy_channel`.

The idea is that you can dynamically acquire a smart pointer to a shared resource, similar to `MutexGuard`, which you can then pass around between tasks.

Right now, the documentation is still incomplete because I want to ask for feedback first. Is this something you'd consider merging into embassy?

For a code example, see examples/stm32g4/src/bin/resource_pool.rs

Some TODOs:
- double-check the soundness of the implementation and lifetimes
- add proper documentation
- ~add `map()` function like `Mutex`?~
- add dynamic versions of everything like `DynamicChannel`
- make `new()` const?
- reduce the size of the state by replacing the `available` Vec with an array of u32 and bit-masking (the reason I have not implemented that are that `generic_const_exprs` for calculating the number of u32s (ie. ceil(N/32)) are still unstable.