### PR TITLE
stm32/lp: remove chrono dependency for calc

### DIFF
--- a/.github/ci/test.sh
+++ b/.github/ci/test.sh
@@ -29,7 +29,7 @@ cargo test --manifest-path ./embassy-nrf/Cargo.toml --no-default-features --feat
 cargo test --manifest-path ./embassy-rp/Cargo.toml --no-default-features --features time-driver,rp2040,_test
 cargo test --manifest-path ./embassy-rp/Cargo.toml --no-default-features --features time-driver,rp235xa,_test
 
-cargo test --manifest-path ./embassy-stm32/Cargo.toml --no-default-features --features stm32f429vg,time-driver-any,exti,single-bank
+cargo test --manifest-path ./embassy-stm32/Cargo.toml --no-default-features --features stm32f429vg,time-driver-any,exti,single-bank,low-power,chrono,test
 cargo test --manifest-path ./embassy-stm32/Cargo.toml --no-default-features --features stm32f429vg,time-driver-any,exti,dual-bank
 cargo test --manifest-path ./embassy-stm32/Cargo.toml --no-default-features --features stm32f732ze,time-driver-any,exti
 cargo test --manifest-path ./embassy-stm32/Cargo.toml --no-default-features --features stm32f769ni,time-driver-any,exti,single-bank

--- a/embassy-stm32/Cargo.toml
+++ b/embassy-stm32/Cargo.toml
@@ -249,11 +249,13 @@ log = ["dep:log"]
 chrono = ["dep:chrono"]
 ## Enable cyw
 cyw43 = ["dep:cyw43"]
+## Used for running hosted tests
+test = []
 
 stm32-hrtim = ["dep:stm32-hrtim"]
 
 exti = []
-low-power = [ "time", "chrono" ]
+low-power = [ "time" ]
 low-power-debug-with-sleep = [ "low-power" ]
 low-power-defmt-flush = [ "defmt" ]
 

--- a/embassy-stm32/src/lib.rs
+++ b/embassy-stm32/src/lib.rs
@@ -741,3 +741,7 @@ fn init_hw(config: Config) -> Peripherals {
 pub(crate) fn block_for_us(us: u64) {
     cortex_m::asm::delay(unsafe { rcc::get_freqs().sys.to_hertz().unwrap().0 as u64 * us / 1_000_000 } as u32);
 }
+
+#[cfg(feature = "test")]
+#[unsafe(no_mangle)]
+extern "Rust" fn __embassy_time_queue_item_from_waker() {}

--- a/embassy-stm32/src/low_power.rs
+++ b/embassy-stm32/src/low_power.rs
@@ -30,13 +30,13 @@ use core::sync::atomic::{Ordering, compiler_fence};
 use cortex_m::peripheral::SCB;
 use critical_section::CriticalSection;
 
-#[cfg(not(feature = "_lp-time-driver"))]
+#[cfg(not(any(feature = "_lp-time-driver", feature = "test")))]
 use crate::interrupt;
 pub use crate::rcc::StopMode;
 use crate::rcc::get_stop_mode;
 use crate::time_driver::{LPTimeDriver, get_driver};
 
-#[cfg(not(any(stm32u0, feature = "_lp-time-driver")))]
+#[cfg(not(any(stm32u0, feature = "_lp-time-driver", feature = "test")))]
 foreach_interrupt! {
     (RTC, rtc, $block:ident, WKUP, $irq:ident) => {
         #[interrupt]

--- a/embassy-stm32/src/rtc/datetime.rs
+++ b/embassy-stm32/src/rtc/datetime.rs
@@ -48,6 +48,34 @@ pub struct DateTime {
 }
 
 impl DateTime {
+    #[cfg(all(feature = "low-power", not(feature = "_lp-time-driver")))]
+    pub(crate) const fn millis_from_unix_epoch(&self) -> i64 {
+        // overflows 292_471_209 years from 1_970 with a precision less than 1 / 256 (an RTC tick)
+
+        const fn julian(year: i32, month: i32, day: i32) -> i32 {
+            let (mut y, mut m) = (year, month);
+
+            // Adjust months so that March is month 1
+            if m <= 2 {
+                y -= 1;
+                m += 12;
+            }
+
+            let a = y / 100;
+            let b = 2 - a + (a / 4);
+
+            (36525 * (y + 4716)) / 100 + (306001 * (m + 1)) / 10000 + day + b - 1524
+        }
+
+        let days = julian(self.year as i32, self.month as i32, self.day as i32) - julian(1970i32, 1i32, 1i32);
+        let hour = self.hour;
+        let minute = self.minute;
+        let second = self.second;
+        let seconds = days as i64 * 86_400 + ((hour as i32) * 3_600 + (minute as i32) * 60 + (second as i32)) as i64;
+
+        seconds * 1_000i64 + (self.usecond / 1_000u32) as i64
+    }
+
     /// Get the year (0..=4095)
     pub const fn year(&self) -> u16 {
         self.year
@@ -211,4 +239,24 @@ pub(super) const fn day_of_week_from_u8(v: u8) -> Result<DayOfWeek, Error> {
 
 pub(super) const fn day_of_week_to_u8(dotw: DayOfWeek) -> u8 {
     dotw as u8
+}
+
+#[cfg(all(feature = "low-power", feature = "chrono", not(feature = "_lp-time-driver")))]
+#[test]
+fn test_millis_from_unix_epoch() {
+    for d in 1..1_000_000 {
+        for (h, m, s) in [(1, 1, 1), (3, 4, 5), (13, 14, 15), (18, 19, 20)] {
+            let date_time = chrono::NaiveDate::from_epoch_days(d)
+                .unwrap()
+                .and_hms_opt(h, m, s)
+                .unwrap();
+
+            let chrono_millis = date_time.and_utc().timestamp_millis();
+
+            let date_time: DateTime = date_time.into();
+            let our_millis = date_time.millis_from_unix_epoch();
+
+            assert!(chrono_millis.abs_diff(our_millis) < 5);
+        }
+    }
 }

--- a/embassy-stm32/src/rtc/low_power.rs
+++ b/embassy-stm32/src/rtc/low_power.rs
@@ -1,4 +1,3 @@
-use chrono::{DateTime, NaiveDateTime, TimeDelta, Utc};
 use embassy_time::{Duration, Instant, TICK_HZ};
 
 use super::Rtc;
@@ -20,10 +19,16 @@ fn wucksel_compute_min(val: u32) -> (Wucksel, u32) {
 }
 
 impl Rtc {
-    pub(super) fn calc_epoch(&self) -> DateTime<Utc> {
-        let now: NaiveDateTime = RtcTimeProvider::new().now().unwrap().into();
+    pub(super) fn millis_from_unix_epoch(&self) -> i64 {
+        RtcTimeProvider::new().now().unwrap().millis_from_unix_epoch()
+    }
 
-        now.and_utc() - TimeDelta::microseconds(Instant::now().as_micros().try_into().unwrap())
+    pub(super) fn calc_epoch(&self) -> i64 {
+        self.millis_from_unix_epoch() - Instant::now().as_millis() as i64
+    }
+
+    pub(super) fn reset_epoch(&mut self) {
+        self.epoch = self.calc_epoch();
     }
 
     /// start the wakeup alarm and with a duration that is as close to but less than
@@ -99,10 +104,7 @@ impl Rtc {
             });
         }
 
-        let datetime: NaiveDateTime = RtcTimeProvider::new().now().expect("failed to read now").into();
-        let offset = datetime.and_utc() - self.epoch;
-
-        Instant::from_micros(offset.num_microseconds().unwrap().try_into().unwrap())
+        Instant::from_millis((self.millis_from_unix_epoch() - self.epoch).try_into().unwrap())
     }
 
     pub(super) fn enable_wakeup_line(&mut self) {

--- a/embassy-stm32/src/rtc/mod.rs
+++ b/embassy-stm32/src/rtc/mod.rs
@@ -164,7 +164,7 @@ impl<'a> ops::DerefMut for RtcBorrow<'a> {
 /// RTC driver.
 pub struct Rtc {
     #[cfg(all(feature = "low-power", not(feature = "_lp-time-driver")))]
-    epoch: chrono::DateTime<chrono::Utc>,
+    epoch: i64,
     _private: (),
 }
 
@@ -218,7 +218,7 @@ impl Rtc {
 
         let mut this = Self {
             #[cfg(all(feature = "low-power", not(feature = "_lp-time-driver")))]
-            epoch: chrono::DateTime::from_timestamp_secs(0).unwrap(),
+            epoch: 0i64,
             _private: (),
         };
 
@@ -238,7 +238,7 @@ impl Rtc {
         #[cfg(all(feature = "low-power", not(feature = "_lp-time-driver")))]
         {
             this.enable_wakeup_line();
-            this.epoch = this.calc_epoch();
+            this.reset_epoch();
         }
 
         this
@@ -290,9 +290,7 @@ impl Rtc {
         });
 
         #[cfg(all(feature = "low-power", not(feature = "_lp-time-driver")))]
-        {
-            self.epoch = self.calc_epoch();
-        }
+        self.reset_epoch();
 
         Ok(())
     }
@@ -307,7 +305,10 @@ impl Rtc {
     pub fn set_daylight_savings(&mut self, daylight_savings: bool) {
         self.write(true, |rtc| {
             rtc.cr().modify(|w| w.set_bkp(daylight_savings));
-        })
+        });
+
+        #[cfg(all(feature = "low-power", not(feature = "_lp-time-driver")))]
+        self.reset_epoch();
     }
 
     /// Number of backup registers of this instance.

--- a/embassy-stm32/src/time_driver/gp16.rs
+++ b/embassy-stm32/src/time_driver/gp16.rs
@@ -10,7 +10,9 @@ use embassy_sync::blocking_mutex::Mutex;
 use embassy_sync::blocking_mutex::raw::CriticalSectionRawMutex;
 use embassy_time_driver::{Driver, TICK_HZ};
 use embassy_time_queue_utils::Queue;
-use stm32_metapac::timer::{TimGp16, regs};
+use stm32_metapac::timer::TimGp16;
+#[cfg(not(feature = "test"))]
+use stm32_metapac::timer::regs;
 
 use super::AlarmState;
 use crate::interrupt::typelevel::Interrupt;
@@ -161,6 +163,7 @@ impl RtcDriver {
         regs_gp16().cr1().modify(|w| w.set_cen(true));
     }
 
+    #[cfg(not(feature = "test"))]
     pub(crate) fn on_interrupt(&self) {
         let r = regs_gp16();
 
@@ -190,6 +193,7 @@ impl RtcDriver {
         })
     }
 
+    #[cfg(not(feature = "test"))]
     fn next_period(&self) {
         let r = regs_gp16();
 


### PR DESCRIPTION
removes the chrono dependency, which should reduce binary size