### PR TITLE
[MCXA] Use PhantomData<&mut _> to encode exclusive peripheral ownership

### DIFF
--- a/embassy-mcxa/src/lpuart/mod.rs
+++ b/embassy-mcxa/src/lpuart/mod.rs
@@ -838,7 +838,7 @@ pub struct LpuartTx<'a, M: Mode> {
     mode: M,
     _tx_pins: TxPins<'a>,
     _wg: Option<WakeGuard>,
-    _phantom: PhantomData<&'a ()>,
+    _phantom: PhantomData<&'a mut ()>,
 }
 
 /// Lpuart Rx driver.
@@ -848,7 +848,7 @@ pub struct LpuartRx<'a, M: Mode> {
     mode: M,
     _rx_pins: RxPins<'a>,
     _wg: Option<WakeGuard>,
-    _phantom: PhantomData<&'a ()>,
+    _phantom: PhantomData<&'a mut ()>,
 }
 
 fn disable_peripheral(info: &'static Info) {

--- a/embassy-mcxa/src/spi/controller.rs
+++ b/embassy-mcxa/src/spi/controller.rs
@@ -137,7 +137,7 @@ pub struct Spi<'d, M: IoMode> {
     _freq: u32,
     mode: M,
     _wg: Option<WakeGuard>,
-    _phantom: PhantomData<&'d M>,
+    _phantom: PhantomData<&'d mut M>,
 }
 
 impl<'d, M: IoMode> Spi<'d, M> {


### PR DESCRIPTION
These drivers conceptually hold exclusive access to the peripheral/pins for the duration of the name lifetimes ('a and 'd), but previously used PhantomData<&'a ()> / PhantomData<&'d M>, which only encodes shared borrowing.

That can let Rust conclude the mutable borrow ends at new(), enabling a second mutable borrow of the same underlying peripheral while the driver still exists.

Changing the marker to include `mut` keyword, models an exclusive borrow, making the lifetime invariant and ensuring the borrow checker enforces “only one mutable owner” for as long as the driver lives.