### PR TITLE
embassy-usb: expose line_coding() on CdcAcmClass::ControlChanged

### DIFF
--- a/embassy-usb/src/class/cdc_acm.rs
+++ b/embassy-usb/src/class/cdc_acm.rs
@@ -400,6 +400,11 @@ impl<'d> ControlChanged<'d> {
     pub fn rts(&self) -> bool {
         self.control.rts.load(Ordering::Relaxed)
     }
+
+    /// Gets the current line coding (baud rate, data bits, parity, stop bits).
+    pub fn line_coding(&self) -> LineCoding {
+        self.control.line_coding.lock(Cell::get)
+    }
 }
 
 /// CDC ACM class packet sender.


### PR DESCRIPTION
## Summary

Add `line_coding()` accessor to `ControlChanged`, matching the existing
`dtr()` and `rts()` accessors.

## Motivation

When using `CdcAcmClass::split_with_control`, the control task owns
`ControlChanged` and may need to read the baud rate after
`control_changed()` fires — e.g. to detect a 1200-baud DTR drop for
bootloader entry. Currently `line_coding()` is only available on
`Sender`, `Receiver`, and `CdcAcmClass` directly.

## Test plan

- Implementation is identical to existing `line_coding()` on `Sender`,
  `Receiver`, and `CdcAcmClass` — same one-liner delegate
- Tested in downstream project for 1200-baud bootloader detection via
  `ControlChanged`