### PR TITLE
[MCXA] Put MCXA5xx DMA IPD-REQ unmasking behind feature gate; update nxp-pac

### DIFF
--- a/embassy-mcxa/Cargo.toml
+++ b/embassy-mcxa/Cargo.toml
@@ -45,7 +45,7 @@ embedded-io = "0.7"
 embedded-io-async = { version = "0.7.0" }
 heapless = "0.9"
 maitake-sync = { version = "0.3.0", default-features = false, features = ["critical-section", "no-cache-pad"] }
-nxp-pac = { git = "https://github.com/embassy-rs/nxp-pac.git", rev = "cda54d1fbdfb8ebb94caca00470b6f754ac49426", features = ["rt"] }
+nxp-pac = { git = "https://github.com/embassy-rs/nxp-pac.git", rev = "366d44d45f080d6aba0fd27597f17044c028d813", features = ["rt"] }
 nb = "1.1.0"
 paste = "1.0.15"
 
@@ -65,7 +65,7 @@ bbqueue = { version = "0.7.0", features = ["disable-cache-padding"] }
 grounded = { version = "0.2.1", features = ["cas", "critical-section"] }
 
 [features]
-default = ["rt", "swd-swo-as-gpio"]
+default = ["rt", "swd-swo-as-gpio", "dma-ipd-req"]
 
 # Base defmt feature enables core + panic handler
 # Use with one logger feature: defmt-rtt (preferred) or defmt-uart (fallback)
@@ -117,6 +117,13 @@ jtag-extras-as-gpio = []
 # possible to reset the device and reflash using probe-rs after enabling this
 # feature. Use at your own risk!
 dangerous-reset-as-gpio = []
+
+# Unmasks DMA IPD_REQ hardware lines in AHBSC during init. (only on MCXA5xx)
+#
+# If this feature is not set, something else is responsible for unmasking them
+# when driving DMA transfers from hardware peripheral requests.
+# This can either be another (trustzone secure) binary or from IFR0 CFPA Trustzone presets.
+dma-ipd-req = []
 
 # dummy feature to silence embassy-hal-internal lint
 #

--- a/embassy-mcxa/src/dma.rs
+++ b/embassy-mcxa/src/dma.rs
@@ -144,22 +144,10 @@ pub(crate) fn init() {
         w.set_gmrc(true);
     });
 
-    // REVISIT: This needs to be improved.
-    //
     // Enable all DMA request lines for non-secure access.
-    #[cfg(feature = "mcxa5xx")]
-    {
-        let ahbsc = crate::pac::AHBSC;
-        ahbsc.sec_gp_reg0().write(|w| w.0 = 0xffff_ffff);
-        ahbsc.sec_gp_reg1().write(|w| w.0 = 0xffff_ffff);
-        ahbsc.sec_gp_reg2().write(|w| w.0 = 0xffff_ffff);
-        ahbsc.sec_gp_reg3().write(|w| w.0 = 0xffff_ffff);
-        ahbsc.sec_gp_reg4().write(|w| w.0 = 0xffff_ffff);
-        ahbsc.sec_gp_reg5().write(|w| w.0 = 0xffff_ffff);
-        ahbsc.sec_gp_reg6().write(|w| w.0 = 0xffff_ffff);
-        ahbsc.sec_gp_reg7().write(|w| w.0 = 0xffff_ffff);
-        ahbsc.sec_gp_reg8().write(|w| w.0 = 0xffff_ffff);
-        ahbsc.sec_gp_reg9().write(|w| w.0 = 0xffff_ffff);
+    #[cfg(all(feature = "mcxa5xx", feature = "dma-ipd-req"))]
+    for sec_gp_i in 0..=9 {
+        crate::pac::AHBSC.sec_gp_reg(sec_gp_i).write(|w| w.0 = 0xffff_ffff);
     }
 }
 


### PR DESCRIPTION
Working on a trustzone example for the MCXA5xx right now, and currently we unmask the DMA IPD-REQ fields in the HAL init code. This however touches AHBSC registers, which are typically not allowed from a trustzone binary in nonsecure mode.

This PR adds a feature flag to unmask these bits, which is enabled by default. Also updates nxp-pac with a more tidied up AHBSC.