### PR TITLE
stm32/can: allow re-entering into configuration mode

### DIFF
--- a/embassy-stm32/src/can/fd/peripheral.rs
+++ b/embassy-stm32/src/can/fd/peripheral.rs
@@ -309,7 +309,7 @@ impl Registers {
 
     /// Moves out of PoweredDownMode and into ConfigMode
     #[inline]
-    pub fn into_config_mode(self, _config: FdCanConfig) {
+    pub fn into_config_mode(&self, _config: FdCanConfig) {
         self.set_power_down_mode(false);
         self.enter_init_mode();
         self.reset_msg_ram();

--- a/embassy-stm32/src/can/fdcan.rs
+++ b/embassy-stm32/src/can/fdcan.rs
@@ -174,7 +174,6 @@ pub struct CanConfigurator<'d> {
     config: crate::can::fd::config::FdCanConfig,
     /// Reference to internals.
     properties: Properties,
-    periph_clock: crate::time::Hertz,
     info: InfoRef,
 }
 
@@ -215,7 +214,6 @@ impl<'d> CanConfigurator<'d> {
             _phantom: PhantomData,
             config,
             properties: Properties::new(T::info()),
-            periph_clock: T::frequency(),
             info: InfoRef::new(info),
         }
     }
@@ -237,7 +235,7 @@ impl<'d> CanConfigurator<'d> {
 
     /// Configures the bit timings calculated from supplied bitrate.
     pub fn set_bitrate(&mut self, bitrate: u32) {
-        let bit_timing = util::calc_can_timings(self.periph_clock, bitrate).unwrap();
+        let bit_timing = util::calc_can_timings(self.properties.kernel_input_clock(), bitrate).unwrap();
 
         let nbtr = crate::can::fd::config::NominalBitTiming {
             sync_jump_width: bit_timing.sync_jump_width,
@@ -250,7 +248,7 @@ impl<'d> CanConfigurator<'d> {
 
     /// Configures the bit timings for VBR data calculated from supplied bitrate. This also sets confit to allow can FD and VBR
     pub fn set_fd_data_bitrate(&mut self, bitrate: u32, transceiver_delay_compensation: bool) {
-        let bit_timing = util::calc_can_timings(self.periph_clock, bitrate).unwrap();
+        let bit_timing = util::calc_can_timings(self.properties.kernel_input_clock(), bitrate).unwrap();
         // Note, used existing calcluation for normal(non-VBR) bitrate, appears to work for 250k/1M
         let nbtr = crate::can::fd::config::DataBitTiming {
             transceiver_delay_compensation,
@@ -265,7 +263,11 @@ impl<'d> CanConfigurator<'d> {
 
     /// Start in mode.
     pub fn start(self, mode: OperatingMode) -> Can<'d> {
-        let ns_per_timer_tick = calc_ns_per_timer_tick(&self.info, self.periph_clock, self.config.frame_transmit);
+        let ns_per_timer_tick = calc_ns_per_timer_tick(
+            &self.info,
+            self.properties.kernel_input_clock(),
+            self.config.frame_transmit,
+        );
         self.info.state.lock(|s| {
             let mut state = s.borrow_mut();
             state.ns_per_timer_tick = ns_per_timer_tick;
@@ -404,6 +406,17 @@ impl<'d> Can<'d> {
         rxb: &'static mut RxFdBuf<RX_BUF_SIZE>,
     ) -> BufferedCanFd<'d, TX_BUF_SIZE, RX_BUF_SIZE> {
         BufferedCanFd::new(&self.info, self._mode, tx_buf, rxb)
+    }
+
+    /// Switch into config mode for re-configuration
+    pub fn into_config_mode(self) -> CanConfigurator<'d> {
+        self.info.regs.into_config_mode(self.config);
+        CanConfigurator {
+            _phantom: PhantomData,
+            config: self.config,
+            properties: self.properties,
+            info: self.info,
+        }
     }
 }
 
@@ -831,6 +844,11 @@ impl Properties {
         }
     }
 
+    /// Get the CAN subsystem kernel clock input (fdcan_ck) used for bit timing
+    pub fn kernel_input_clock(&self) -> crate::time::Hertz {
+        (self.info.periph_clock)()
+    }
+
     /// Set a standard address CAN filter in the specified slot in FDCAN memory.
     #[inline]
     pub fn set_standard_filter(&self, slot: StandardFilterSlot, filter: StandardFilter) {
@@ -917,6 +935,7 @@ pub(crate) struct Info {
     interrupt0: crate::interrupt::Interrupt,
     _interrupt1: crate::interrupt::Interrupt,
     pub(crate) tx_waker: fn(),
+    periph_clock: fn() -> crate::time::Hertz,
     state: SharedState,
     rcc_info: RccInfo,
 }
@@ -992,6 +1011,7 @@ macro_rules! impl_fdcan {
                     interrupt0: crate::_generated::peripheral_interrupts::$inst::IT0::IRQ,
                     _interrupt1: crate::_generated::peripheral_interrupts::$inst::IT1::IRQ,
                     tx_waker: crate::_generated::peripheral_interrupts::$inst::IT0::pend,
+                    periph_clock: peripherals::$inst::frequency,
                     state: embassy_sync::blocking_mutex::Mutex::new(core::cell::RefCell::new(State::new())),
                     rcc_info: crate::peripherals::$inst::RCC_INFO,
                 };


### PR DESCRIPTION
Allow re-entering into configuration mode from normal mode to change the bitrate, for example.