### PR TITLE
Enable full-duplex I2S for spi_v2 devices using I2SEXT peripherals

### DIFF
--- a/embassy-stm32/src/i2s.rs
+++ b/embassy-stm32/src/i2s.rs
@@ -398,7 +398,7 @@ impl<'d, W: Word> I2S<'d, W> {
     /// On STM32F4 (spi_v2), true full-duplex I2S requires the I2SEXT peripheral.
     /// The main SPI transmits while the associated I2SEXT receives. The `rxsd`
     /// pin connects to I2SEXT and `rxdma` is routed to the I2SEXT peripheral.
-    #[cfg(spi_v2)]
+    #[cfg(any(spi_v1, spi_v2))]
     pub fn new_full_duplex<T: Instance + I2sExtRegs, D2: RxDmaExt<T>>(
         peri: Peri<'d, T>,
         ws: Peri<'d, impl WsPin<T>>,


### PR DESCRIPTION
Fixes https://github.com/embassy-rs/embassy/issues/4698

There are two classes of changes in this PR: Ones that will be permanent, and ones that are temporary until stm32-metapac gets updated to reflect information about I2SEXT peripherals.

Changes of the latter type are reflected in a few traits at the top of the file. I have mimicked traits such as WsPin and RxDma, which is nice because it preserves a bunch of the design patterns below. It seems like metapac just needs to add these traits and implement them as appropriate for a device, but I don't grok metapac well enough to make this change right now. The I2sRegs trait should probably be absorbed into spi::Instance.

The permanent changes are of the following character:

* We add a method I2S::new_full_duplex() which is feature-gated to spi_v2 (though TBH I'm not sure if this is the only version of SPI that should be covered, or if every spi_v2 platform has I2SEXT peripherals)
* We add a field to struct I2S to hold the register block for the I2SEXT peripheral, if used
* In new_inner, if an I2SEXT peripheral is being used, we initialize it to the same I2S settings as the main SPI peripheral, in the opposite direction, and always in slave mode.
* Instead of referring to a single register block self.spi.info.regs, we distinguish between register blocks used in the tx and rx directions. These are different when an I2SEXT peripheral is in use, and the same otherwise. This does result in some duplication when I2SEXT is not in use; it might be possible to refactor to avoid.

Marking this as draft because of the above-mentioned issues, and because of the unresolved dependency on metapac changes. I have tested this on a real device using `stm32f405rg` using SPI to talk to an `WM8960` and it works reliably, but I have not tested not more generally.

Replaces #4746 