### PR TITLE
Add slot API to zerocopy channel

### DIFF
--- a/cyw43/src/bluetooth.rs
+++ b/cyw43/src/bluetooth.rs
@@ -164,6 +164,14 @@ pub(crate) fn read_firmware_patch_line(p_btfw_cb: &mut CybtFwCb, hfd: &mut HexFi
     0
 }
 
+async fn bt_toggle_intr(bus: &mut impl Bus) {
+    trace!("bt_toggle_intr");
+    let old_val = bus.bp_read32(HOST_CTRL_REG_ADDR).await;
+    // TODO: do we need to swap endianness on this read?
+    let new_val = old_val ^ BTSDIO_REG_DATA_VALID_BITMASK;
+    bus.bp_write32(HOST_CTRL_REG_ADDR, new_val).await;
+}
+
 impl<'a> BtRunner<'a> {
     pub(crate) async fn init_bluetooth(&mut self, bus: &mut impl Bus, firmware: &[u8]) {
         trace!("init_bluetooth");
@@ -307,11 +315,7 @@ impl<'a> BtRunner<'a> {
     }
 
     pub(crate) async fn bt_toggle_intr(&mut self, bus: &mut impl Bus) {
-        trace!("bt_toggle_intr");
-        let old_val = bus.bp_read32(HOST_CTRL_REG_ADDR).await;
-        // TODO: do we need to swap endianness on this read?
-        let new_val = old_val ^ BTSDIO_REG_DATA_VALID_BITMASK;
-        bus.bp_write32(HOST_CTRL_REG_ADDR, new_val).await;
+        bt_toggle_intr(bus).await;
     }
 
     // TODO: use this
@@ -394,9 +398,9 @@ impl<'a> BtRunner<'a> {
         bus.bp_write32(self.addr + BTSDIO_OFFSET_HOST2BT_IN, self.h2b_write_pointer)
             .await;
 
-        self.bt_toggle_intr(bus).await;
+        bt_toggle_intr(bus).await;
 
-        self.tx_chan.receive_done();
+        buf.receive_done();
     }
 
     async fn bt_has_work(&mut self, bus: &mut impl Bus) -> bool {
@@ -437,7 +441,7 @@ impl<'a> BtRunner<'a> {
                 self.b2h_read_pointer = (self.b2h_read_pointer + 4) % BTSDIO_FWBUF_SIZE;
 
                 // Obtain a buf from the channel.
-                let buf = self.rx_chan.send().await;
+                let mut buf = self.rx_chan.send().await;
 
                 buf.buf[0] = header[3]; // hci packet type
                 let payload = &mut buf.buf[1..][..rounded_len as usize];
@@ -460,7 +464,7 @@ impl<'a> BtRunner<'a> {
                 buf.len = 1 + len as usize;
                 debug!("HCI rx: {:02x}", crate::fmt::Bytes(&buf.buf[..buf.len]));
 
-                self.rx_chan.send_done();
+                buf.send_done();
 
                 self.bt_toggle_intr(bus).await;
             }
@@ -513,7 +517,7 @@ impl<'d> bt_hci::transport::Transport for BtDriver<'d> {
             let n = buf.len;
             assert!(n < rx.len());
             rx[..n].copy_from_slice(&buf.buf[..n]);
-            ch.receive_done();
+            buf.receive_done();
 
             let kind = PacketKind::from_hci_bytes_complete(&rx[..1])?;
             let (pkt, _) = ControllerToHostPacket::from_hci_bytes_with_kind(kind, &rx[1..n])?;
@@ -525,14 +529,14 @@ impl<'d> bt_hci::transport::Transport for BtDriver<'d> {
     fn write<T: HostToControllerPacket>(&self, val: &T) -> impl Future<Output = Result<(), Self::Error>> {
         async {
             let ch = &mut *self.tx.borrow_mut();
-            let buf = ch.send().await;
+            let mut buf = ch.send().await;
             let buf_len = buf.buf.len();
             let mut slice = &mut buf.buf[..];
             WithIndicator::new(val)
                 .write_hci(&mut slice)
                 .map_err(|_| Error::Io(ErrorKind::Other))?;
             buf.len = buf_len - slice.len();
-            ch.send_done();
+            buf.send_done();
             Ok(())
         }
     }

--- a/cyw43/src/runner.rs
+++ b/cyw43/src/runner.rs
@@ -464,7 +464,9 @@ where
                 #[cfg(feature = "bluetooth")]
                 let bt_tx = async {
                     match &mut self.bt {
-                        Some(bt) => bt.tx_chan.receive().await,
+                        Some(bt) => {
+                            let _ = bt.tx_chan.receive().await;
+                        }
                         None => core::future::pending().await,
                     }
                 };
@@ -533,14 +535,14 @@ where
                         buf8[SdpcmHeader::SIZE + PADDING_SIZE..][..BdcHeader::SIZE]
                             .copy_from_slice(&bdc_header.to_bytes());
                         buf8[SdpcmHeader::SIZE + PADDING_SIZE + BdcHeader::SIZE..][..packet.len()]
-                            .copy_from_slice(packet);
+                            .copy_from_slice(&*packet);
 
                         let total_len = (total_len + 3) & !3; // round up to 4byte
 
                         trace!("    {:02x}", Bytes(&buf8[..total_len.min(48)]));
 
                         self.bus.wlan_write(&aligned_ref(&buf)[..total_len]).await;
-                        self.ch.tx_done();
+                        packet.tx_done();
                         self.check_status(&mut buf).await;
                     }
                     Either4::Third(_) => {
@@ -874,9 +876,9 @@ where
                 trace!("rx pkt {:02x}", Bytes(&packet[..packet.len().min(48)]));
 
                 match self.ch.try_rx_buf() {
-                    Some(buf) => {
+                    Some(mut buf) => {
                         buf[..packet.len()].copy_from_slice(packet);
-                        self.ch.rx_done(packet.len())
+                        buf.rx_done(packet.len())
                     }
                     None => warn!("failed to push rxd packet to the channel."),
                 }

--- a/embassy-net-adin1110/src/lib.rs
+++ b/embassy-net-adin1110/src/lib.rs
@@ -468,9 +468,9 @@ impl<'d, SPI: SpiDevice, INT: Wait, RST: OutputPin> Runner<'d, SPI, INT, RST> {
                                 // Note: rx_chan.rx_buf() channel don´t accept new request
                                 //       when the tx_chan is full. So these will be handled
                                 //       automaticly.
-                                Either::First(frame) => match self.mac.read_fifo(frame).await {
+                                Either::First(mut frame) => match self.mac.read_fifo(&mut frame).await {
                                     Ok(n) => {
-                                        rx_chan.rx_done(n);
+                                        frame.rx_done(n);
                                     }
                                     Err(e) => match e {
                                         AdinError::PACKET_TOO_BIG => {
@@ -489,10 +489,10 @@ impl<'d, SPI: SpiDevice, INT: Wait, RST: OutputPin> Runner<'d, SPI, INT, RST> {
                                         }
                                     },
                                 },
-                                Either::Second(frame) => {
+                                Either::Second(mut frame) => {
                                     // Handle frames that needs to transmit to the wire.
-                                    self.mac.write_fifo(frame).await.unwrap();
-                                    tx_chan.tx_done();
+                                    self.mac.write_fifo(&mut frame).await.unwrap();
+                                    frame.tx_done();
                                 }
                             }
                             status1 = Status1(self.mac.read_reg(sr::STATUS1).await.unwrap());
@@ -583,10 +583,10 @@ impl<'d, SPI: SpiDevice, INT: Wait, RST: OutputPin> Runner<'d, SPI, INT, RST> {
                         self.mac.write_reg(sr::STATUS0, 0xFFF).await.unwrap();
                         self.mac.write_reg(sr::STATUS1, status1_clr.0).await.unwrap();
                     }
-                    Either::Second(packet) => {
+                    Either::Second(mut packet) => {
                         // Handle frames that needs to transmit to the wire.
-                        self.mac.write_fifo(packet).await.unwrap();
-                        tx_chan.tx_done();
+                        self.mac.write_fifo(&mut packet).await.unwrap();
+                        packet.tx_done();
                     }
                 }
             }

--- a/embassy-net-driver-channel/src/lib.rs
+++ b/embassy-net-driver-channel/src/lib.rs
@@ -7,6 +7,7 @@ mod fmt;
 
 use core::cell::RefCell;
 use core::mem::MaybeUninit;
+use core::ops::{Deref, DerefMut};
 use core::task::{Context, Poll};
 
 pub use embassy_net_driver as driver;
@@ -79,6 +80,69 @@ pub struct TxRunner<'d, const MTU: usize> {
     tx_chan: zerocopy_channel::Receiver<'d, NoopRawMutex, PacketBuf<MTU>>,
 }
 
+/// A slot for an inbound packet.
+pub struct RxSlot<'a, const MTU: usize>(zerocopy_channel::SendSlot<'a, NoopRawMutex, PacketBuf<MTU>>);
+
+impl<'a, const MTU: usize> From<zerocopy_channel::SendSlot<'a, NoopRawMutex, PacketBuf<MTU>>> for RxSlot<'a, MTU> {
+    fn from(value: zerocopy_channel::SendSlot<'a, NoopRawMutex, PacketBuf<MTU>>) -> Self {
+        Self(value)
+    }
+}
+
+impl<const MTU: usize> Deref for RxSlot<'_, MTU> {
+    type Target = [u8];
+
+    fn deref(&self) -> &Self::Target {
+        &self.0.buf
+    }
+}
+
+impl<const MTU: usize> DerefMut for RxSlot<'_, MTU> {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.0.buf
+    }
+}
+
+impl<const MTU: usize> RxSlot<'_, MTU> {
+    /// Mark packet of `len` bytes as pushed to the inbound channel.
+    pub fn rx_done(mut self, len: usize) {
+        self.0.len = len;
+        self.0.send_done();
+    }
+}
+
+/// A slot for an outbound packet.
+pub struct TxSlot<'a, const MTU: usize>(zerocopy_channel::ReceiveSlot<'a, NoopRawMutex, PacketBuf<MTU>>);
+
+impl<const MTU: usize> Deref for TxSlot<'_, MTU> {
+    type Target = [u8];
+
+    fn deref(&self) -> &Self::Target {
+        let len = self.0.len;
+        &self.0.buf[..len]
+    }
+}
+
+impl<const MTU: usize> DerefMut for TxSlot<'_, MTU> {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        let len = self.0.len;
+        &mut self.0.buf[..len]
+    }
+}
+
+impl<const MTU: usize> TxSlot<'_, MTU> {
+    /// Mark outbound packet as processed.
+    pub fn tx_done(self) {
+        self.0.receive_done();
+    }
+}
+
+impl<'a, const MTU: usize> From<zerocopy_channel::ReceiveSlot<'a, NoopRawMutex, PacketBuf<MTU>>> for TxSlot<'a, MTU> {
+    fn from(value: zerocopy_channel::ReceiveSlot<'a, NoopRawMutex, PacketBuf<MTU>>) -> Self {
+        Self(value)
+    }
+}
+
 impl<'d, const MTU: usize> Runner<'d, MTU> {
     /// Split the runner into separate runners for controlling state, rx and tx.
     pub fn split(self) -> (StateRunner<'d>, RxRunner<'d, MTU>, TxRunner<'d, MTU>) {
@@ -125,56 +189,40 @@ impl<'d, const MTU: usize> Runner<'d, MTU> {
         });
     }
 
-    /// Wait until there is space for more inbound packets and return a slice they can be copied into.
-    pub async fn rx_buf(&mut self) -> &mut [u8] {
-        let p = self.rx_chan.send().await;
-        &mut p.buf
+    /// Wait until there is space for more inbound packets and return a slot.
+    pub async fn rx_buf(&mut self) -> RxSlot<'_, MTU> {
+        self.rx_chan.send().await.into()
     }
 
     /// Check if there is space for more inbound packets right now.
-    pub fn try_rx_buf(&mut self) -> Option<&mut [u8]> {
-        let p = self.rx_chan.try_send()?;
-        Some(&mut p.buf)
+    pub fn try_rx_buf(&mut self) -> Option<RxSlot<'_, MTU>> {
+        self.rx_chan.try_send().map(Into::into)
     }
 
     /// Polling the inbound channel if there is space for packets.
-    pub fn poll_rx_buf(&mut self, cx: &mut Context) -> Poll<&mut [u8]> {
+    pub fn poll_rx_buf(&'_ mut self, cx: &mut Context) -> Poll<RxSlot<'_, MTU>> {
         match self.rx_chan.poll_send(cx) {
-            Poll::Ready(p) => Poll::Ready(&mut p.buf),
+            Poll::Ready(slot) => Poll::Ready(slot.into()),
             Poll::Pending => Poll::Pending,
         }
     }
 
-    /// Mark packet of len bytes as pushed to the inbound channel.
-    pub fn rx_done(&mut self, len: usize) {
-        let p = self.rx_chan.try_send().unwrap();
-        p.len = len;
-        self.rx_chan.send_done();
-    }
-
-    /// Wait until there is space for more outbound packets and return a slice they can be copied into.
-    pub async fn tx_buf(&mut self) -> &mut [u8] {
-        let p = self.tx_chan.receive().await;
-        &mut p.buf[..p.len]
+    /// Wait until there is space for more outbound packets and return a slot.
+    pub async fn tx_buf(&mut self) -> TxSlot<'_, MTU> {
+        self.tx_chan.receive().await.into()
     }
 
     /// Check if there is space for more outbound packets right now.
-    pub fn try_tx_buf(&mut self) -> Option<&mut [u8]> {
-        let p = self.tx_chan.try_receive()?;
-        Some(&mut p.buf[..p.len])
+    pub fn try_tx_buf(&mut self) -> Option<TxSlot<'_, MTU>> {
+        self.tx_chan.try_receive().map(Into::into)
     }
 
     /// Polling the outbound channel if there is space for packets.
-    pub fn poll_tx_buf(&mut self, cx: &mut Context) -> Poll<&mut [u8]> {
+    pub fn poll_tx_buf(&mut self, cx: &mut Context) -> Poll<TxSlot<'_, MTU>> {
         match self.tx_chan.poll_receive(cx) {
-            Poll::Ready(p) => Poll::Ready(&mut p.buf[..p.len]),
+            Poll::Ready(slot) => Poll::Ready(slot.into()),
             Poll::Pending => Poll::Pending,
         }
-    }
-
-    /// Mark outbound packet as copied.
-    pub fn tx_done(&mut self) {
-        self.tx_chan.receive_done();
     }
 }
 
@@ -199,58 +247,42 @@ impl<'d> StateRunner<'d> {
 }
 
 impl<'d, const MTU: usize> RxRunner<'d, MTU> {
-    /// Wait until there is space for more inbound packets and return a slice they can be copied into.
-    pub async fn rx_buf(&mut self) -> &mut [u8] {
-        let p = self.rx_chan.send().await;
-        &mut p.buf
+    /// Wait until there is space for more inbound packets and return a slot.
+    pub async fn rx_buf(&mut self) -> RxSlot<'_, MTU> {
+        self.rx_chan.send().await.into()
     }
 
     /// Check if there is space for more inbound packets right now.
-    pub fn try_rx_buf(&mut self) -> Option<&mut [u8]> {
-        let p = self.rx_chan.try_send()?;
-        Some(&mut p.buf)
+    pub fn try_rx_buf(&mut self) -> Option<RxSlot<'_, MTU>> {
+        self.rx_chan.try_send().map(Into::into)
     }
 
     /// Polling the inbound channel if there is space for packets.
-    pub fn poll_rx_buf(&mut self, cx: &mut Context) -> Poll<&mut [u8]> {
+    pub fn poll_rx_buf(&mut self, cx: &mut Context) -> Poll<RxSlot<'_, MTU>> {
         match self.rx_chan.poll_send(cx) {
-            Poll::Ready(p) => Poll::Ready(&mut p.buf),
+            Poll::Ready(slot) => Poll::Ready(slot.into()),
             Poll::Pending => Poll::Pending,
         }
-    }
-
-    /// Mark packet of len bytes as pushed to the inbound channel.
-    pub fn rx_done(&mut self, len: usize) {
-        let p = self.rx_chan.try_send().unwrap();
-        p.len = len;
-        self.rx_chan.send_done();
     }
 }
 
 impl<'d, const MTU: usize> TxRunner<'d, MTU> {
-    /// Wait until there is space for more outbound packets and return a slice they can be copied into.
-    pub async fn tx_buf(&mut self) -> &mut [u8] {
-        let p = self.tx_chan.receive().await;
-        &mut p.buf[..p.len]
+    /// Wait until there is space for more outbound packets and return a slot.
+    pub async fn tx_buf(&mut self) -> TxSlot<'_, MTU> {
+        self.tx_chan.receive().await.into()
     }
 
     /// Check if there is space for more outbound packets right now.
-    pub fn try_tx_buf(&mut self) -> Option<&mut [u8]> {
-        let p = self.tx_chan.try_receive()?;
-        Some(&mut p.buf[..p.len])
+    pub fn try_tx_buf(&mut self) -> Option<TxSlot<'_, MTU>> {
+        self.tx_chan.try_receive().map(Into::into)
     }
 
     /// Polling the outbound channel if there is space for packets.
-    pub fn poll_tx_buf(&mut self, cx: &mut Context) -> Poll<&mut [u8]> {
+    pub fn poll_tx_buf(&mut self, cx: &mut Context) -> Poll<TxSlot<'_, MTU>> {
         match self.tx_chan.poll_receive(cx) {
-            Poll::Ready(p) => Poll::Ready(&mut p.buf[..p.len]),
+            Poll::Ready(slot) => Poll::Ready(slot.into()),
             Poll::Pending => Poll::Pending,
         }
-    }
-
-    /// Mark outbound packet as copied.
-    pub fn tx_done(&mut self) {
-        self.tx_chan.receive_done();
     }
 }
 
@@ -381,9 +413,10 @@ impl<'a, const MTU: usize> embassy_net_driver::RxToken for RxToken<'a, MTU> {
         F: FnOnce(&mut [u8]) -> R,
     {
         // NOTE(unwrap): we checked the queue wasn't full when creating the token.
-        let pkt = unwrap!(self.rx.try_receive());
-        let r = f(&mut pkt.buf[..pkt.len]);
-        self.rx.receive_done();
+        let mut pkt = unwrap!(self.rx.try_receive());
+        let len = pkt.len;
+        let r = f(&mut pkt.buf[..len]);
+        pkt.receive_done();
         r
     }
 }
@@ -401,10 +434,10 @@ impl<'a, const MTU: usize> embassy_net_driver::TxToken for TxToken<'a, MTU> {
         F: FnOnce(&mut [u8]) -> R,
     {
         // NOTE(unwrap): we checked the queue wasn't full when creating the token.
-        let pkt = unwrap!(self.tx.try_send());
+        let mut pkt = unwrap!(self.tx.try_send());
         let r = f(&mut pkt.buf[..len]);
         pkt.len = len;
-        self.tx.send_done();
+        pkt.send_done();
         r
     }
 }

--- a/embassy-net-esp-hosted/src/lib.rs
+++ b/embassy-net-esp-hosted/src/lib.rs
@@ -212,7 +212,7 @@ where
                     tx_buf[0..12].copy_from_slice(&header.to_bytes());
                 }
                 Either4::Second(packet) => {
-                    tx_buf[12..][..packet.len()].copy_from_slice(packet);
+                    tx_buf[12..][..packet.len()].copy_from_slice(&packet);
 
                     let mut header = PayloadHeader {
                         if_type_and_num: InterfaceType::Sta as _,
@@ -228,7 +228,7 @@ where
                     header.checksum = checksum(&tx_buf[..12 + packet.len()]);
                     tx_buf[0..12].copy_from_slice(&header.to_bytes());
 
-                    self.ch.tx_done();
+                    packet.tx_done();
                 }
                 Either4::Third(()) => {
                     tx_buf[..PayloadHeader::SIZE].fill(0);
@@ -283,9 +283,9 @@ where
         match if_type_and_num & 0x0f {
             // STA
             0 => match self.ch.try_rx_buf() {
-                Some(buf) => {
+                Some(mut buf) => {
                     buf[..payload.len()].copy_from_slice(payload);
-                    self.ch.rx_done(payload.len())
+                    buf.rx_done(payload.len())
                 }
                 None => warn!("failed to push rxd packet to the channel."),
             },

--- a/embassy-net-nrf91/src/lib.rs
+++ b/embassy-net-nrf91/src/lib.rs
@@ -656,7 +656,7 @@ impl StateInner {
                     9 => match (msg.id >> 16) & 0xFFF {
                         // IP receive notification
                         1 => {
-                            if let Some(buf) = ch.try_rx_buf() {
+                            if let Some(mut buf) = ch.try_rx_buf() {
                                 let mut len = msg.data_len;
                                 if len > buf.len() {
                                     warn!("truncating rx'd packet from {} to {} bytes", len, buf.len());
@@ -665,7 +665,7 @@ impl StateInner {
                                 fence(Ordering::SeqCst); // synchronize volatile accesses with the nonvolatile copy_nonoverlapping.
                                 unsafe { ptr::copy_nonoverlapping(msg.data, buf.as_mut_ptr(), len) }
                                 fence(Ordering::SeqCst); // synchronize volatile accesses with the nonvolatile copy_nonoverlapping.
-                                ch.rx_done(len);
+                                buf.rx_done(len);
                             }
                             false
                         }
@@ -970,10 +970,10 @@ impl<'a> Runner<'a> {
                     msg.id = 0x7006_0004; // IP send
                     msg.param_len = 12;
                     msg.param[4..8].copy_from_slice(&fd.to_le_bytes());
-                    if let Err(e) = state.send_message(&mut msg, buf) {
+                    if let Err(e) = state.send_message(&mut msg, &buf) {
                         warn!("tx failed: {:?}", e);
                     }
-                    self.ch.tx_done();
+                    buf.tx_done();
                 }
             }
 

--- a/embassy-net-ppp/src/lib.rs
+++ b/embassy-net-ppp/src/lib.rs
@@ -103,7 +103,7 @@ impl<'d> Runner<'d> {
                 Either::First(r) => {
                     needs_poll = false;
 
-                    let (buf, rx_data) = r?;
+                    let (mut buf, rx_data) = r?;
                     let n = ppp.consume(rx_data, &mut rx_buf);
                     rw.consume(n);
 
@@ -112,7 +112,7 @@ impl<'d> Runner<'d> {
                         PPPoSAction::Received(rg) => {
                             let pkt = &rx_buf[rg];
                             buf[..pkt.len()].copy_from_slice(pkt);
-                            rx_chan.rx_done(pkt.len());
+                            buf.rx_done(pkt.len());
                         }
                         PPPoSAction::Transmit(n) => rw.write_all(&tx_buf[..n]).await.map_err(RunError::Write)?,
                     }
@@ -136,11 +136,11 @@ impl<'d> Runner<'d> {
                     }
                 }
                 Either::Second(pkt) => {
-                    match ppp.send(pkt, &mut tx_buf) {
+                    match ppp.send(&pkt, &mut tx_buf) {
                         Ok(n) => rw.write_all(&tx_buf[..n]).await.map_err(RunError::Write)?,
                         Err(BufferFullError) => unreachable!(),
                     }
-                    tx_chan.tx_done();
+                    pkt.tx_done();
                 }
             }
         }

--- a/embassy-net-wiznet/src/lib.rs
+++ b/embassy-net-wiznet/src/lib.rs
@@ -77,14 +77,14 @@ impl<'d, C: Chip, SPI: SpiDevice, INT: Wait, RST: OutputPin> Runner<'d, C, SPI, 
             )
             .await
             {
-                Either3::First(p) => {
-                    if let Ok(n) = self.mac.read_frame(p).await {
-                        rx_chan.rx_done(n);
+                Either3::First(mut p) => {
+                    if let Ok(n) = self.mac.read_frame(&mut p).await {
+                        p.rx_done(n);
                     }
                 }
-                Either3::Second(p) => {
-                    self.mac.write_frame(p).await.ok();
-                    tx_chan.tx_done();
+                Either3::Second(mut p) => {
+                    self.mac.write_frame(&mut p).await.ok();
+                    p.tx_done();
                 }
                 Either3::Third(()) => {
                     if self.mac.is_link_up().await {

--- a/embassy-nrf/src/embassy_net_802154_driver.rs
+++ b/embassy-nrf/src/embassy_net_802154_driver.rs
@@ -55,16 +55,16 @@ impl<'d> Runner<'d> {
             )
             .await
             {
-                Either3::First(Some(rx_buf)) => {
+                Either3::First(Some(mut rx_buf)) => {
                     let len = rx_buf.len().min(packet.len() as usize);
                     (&mut rx_buf[..len]).copy_from_slice(&*packet);
-                    rx_chan.rx_done(len);
+                    rx_buf.rx_done(len);
                 }
                 Either3::Second(tx_buf) => {
                     let len = tx_buf.len().min(Packet::CAPACITY as usize);
                     packet.copy_from_slice(&tx_buf[..len]);
                     self.radio.try_send(&mut packet).await.ok().unwrap();
-                    tx_chan.tx_done();
+                    tx_buf.tx_done();
                 }
                 _ => {}
             }

--- a/embassy-sync/src/zerocopy_channel.rs
+++ b/embassy-sync/src/zerocopy_channel.rs
@@ -15,8 +15,9 @@
 //! another message will result in an error being returned.
 
 use core::cell::RefCell;
-use core::future::{Future, poll_fn};
+use core::future::poll_fn;
 use core::marker::PhantomData;
+use core::ops::{Deref, DerefMut};
 use core::task::{Context, Poll};
 
 use crate::blocking_mutex::Mutex;
@@ -121,22 +122,28 @@ impl<'a, M: RawMutex, T> Sender<'a, M, T> {
     }
 
     /// Attempts to send a value over the channel.
-    pub fn try_send(&mut self) -> Option<&mut T> {
+    pub fn try_send(&mut self) -> Option<SendSlot<'_, M, T>> {
         self.channel.state.lock(|s| {
             let s = &mut *s.borrow_mut();
             match s.push_index() {
-                Some(i) => Some(unsafe { &mut *self.channel.buf.add(i) }),
+                Some(i) => Some(SendSlot {
+                    value: unsafe { &mut *self.channel.buf.add(i) },
+                    state: &self.channel.state,
+                }),
                 None => None,
             }
         })
     }
 
     /// Attempts to send a value over the channel.
-    pub fn poll_send(&mut self, cx: &mut Context) -> Poll<&mut T> {
-        self.channel.state.lock(|s| {
+    pub fn poll_send(&mut self, cx: &mut Context) -> Poll<SendSlot<'_, M, T>> {
+        self.channel.state.lock(move |s| {
             let s = &mut *s.borrow_mut();
             match s.push_index() {
-                Some(i) => Poll::Ready(unsafe { &mut *self.channel.buf.add(i) }),
+                Some(i) => Poll::Ready(SendSlot {
+                    value: unsafe { &mut *self.channel.buf.add(i) },
+                    state: &self.channel.state,
+                }),
                 None => {
                     s.receive_waker.register(cx.waker());
                     Poll::Pending
@@ -146,15 +153,15 @@ impl<'a, M: RawMutex, T> Sender<'a, M, T> {
     }
 
     /// Asynchronously send a value over the channel.
-    pub fn send(&mut self) -> impl Future<Output = &mut T> {
+    pub fn send(&mut self) -> impl Future<Output = SendSlot<'_, M, T>> {
         poll_fn(|cx| {
             self.channel.state.lock(|s| {
                 let s = &mut *s.borrow_mut();
                 match s.push_index() {
-                    Some(i) => {
-                        let r = unsafe { &mut *self.channel.buf.add(i) };
-                        Poll::Ready(r)
-                    }
+                    Some(i) => Poll::Ready(SendSlot {
+                        value: unsafe { &mut *self.channel.buf.add(i) },
+                        state: &self.channel.state,
+                    }),
                     None => {
                         s.receive_waker.register(cx.waker());
                         Poll::Pending
@@ -162,11 +169,6 @@ impl<'a, M: RawMutex, T> Sender<'a, M, T> {
                 }
             })
         })
-    }
-
-    /// Notify the channel that the sending of the value has been finalized.
-    pub fn send_done(&mut self) {
-        self.channel.state.lock(|s| s.borrow_mut().push_done())
     }
 
     /// Clears all elements in the channel.
@@ -189,6 +191,35 @@ impl<'a, M: RawMutex, T> Sender<'a, M, T> {
     /// Returns whether the channel is full.
     pub fn is_full(&self) -> bool {
         self.channel.state.lock(|s| s.borrow().is_full())
+    }
+}
+
+/// A slot for sending in the channel
+///
+/// The slot is only marked as sent when [`SendSlot::send_done`] is called.
+pub struct SendSlot<'a, M: RawMutex, T> {
+    state: &'a Mutex<M, RefCell<State>>,
+    value: &'a mut T,
+}
+
+impl<M: RawMutex, T> Deref for SendSlot<'_, M, T> {
+    type Target = T;
+
+    fn deref(&self) -> &Self::Target {
+        self.value
+    }
+}
+
+impl<M: RawMutex, T> DerefMut for SendSlot<'_, M, T> {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        self.value
+    }
+}
+
+impl<M: RawMutex, T> SendSlot<'_, M, T> {
+    /// Notify the channel that the sending of the value has been finalized.
+    pub fn send_done(self) {
+        self.state.lock(|s| s.borrow_mut().push_done());
     }
 }
 
@@ -205,22 +236,28 @@ impl<'a, M: RawMutex, T> Receiver<'a, M, T> {
     }
 
     /// Attempts to receive a value over the channel.
-    pub fn try_receive(&mut self) -> Option<&mut T> {
+    pub fn try_receive(&mut self) -> Option<ReceiveSlot<'_, M, T>> {
         self.channel.state.lock(|s| {
             let s = &mut *s.borrow_mut();
             match s.pop_index() {
-                Some(i) => Some(unsafe { &mut *self.channel.buf.add(i) }),
+                Some(i) => Some(ReceiveSlot {
+                    value: unsafe { &mut *self.channel.buf.add(i) },
+                    state: &self.channel.state,
+                }),
                 None => None,
             }
         })
     }
 
     /// Attempts to asynchronously receive a value over the channel.
-    pub fn poll_receive(&mut self, cx: &mut Context) -> Poll<&mut T> {
+    pub fn poll_receive(&mut self, cx: &mut Context) -> Poll<ReceiveSlot<'_, M, T>> {
         self.channel.state.lock(|s| {
             let s = &mut *s.borrow_mut();
             match s.pop_index() {
-                Some(i) => Poll::Ready(unsafe { &mut *self.channel.buf.add(i) }),
+                Some(i) => Poll::Ready(ReceiveSlot {
+                    value: unsafe { &mut *self.channel.buf.add(i) },
+                    state: &self.channel.state,
+                }),
                 None => {
                     s.send_waker.register(cx.waker());
                     Poll::Pending
@@ -230,15 +267,15 @@ impl<'a, M: RawMutex, T> Receiver<'a, M, T> {
     }
 
     /// Asynchronously receive a value over the channel.
-    pub fn receive(&mut self) -> impl Future<Output = &mut T> {
+    pub fn receive(&mut self) -> impl Future<Output = ReceiveSlot<'_, M, T>> {
         poll_fn(|cx| {
             self.channel.state.lock(|s| {
                 let s = &mut *s.borrow_mut();
                 match s.pop_index() {
-                    Some(i) => {
-                        let r = unsafe { &mut *self.channel.buf.add(i) };
-                        Poll::Ready(r)
-                    }
+                    Some(i) => Poll::Ready(ReceiveSlot {
+                        value: unsafe { &mut *self.channel.buf.add(i) },
+                        state: &self.channel.state,
+                    }),
                     None => {
                         s.send_waker.register(cx.waker());
                         Poll::Pending
@@ -246,11 +283,6 @@ impl<'a, M: RawMutex, T> Receiver<'a, M, T> {
                 }
             })
         })
-    }
-
-    /// Notify the channel that the receiving of the value has been finalized.
-    pub fn receive_done(&mut self) {
-        self.channel.state.lock(|s| s.borrow_mut().pop_done())
     }
 
     /// Clears all elements in the channel.
@@ -273,6 +305,35 @@ impl<'a, M: RawMutex, T> Receiver<'a, M, T> {
     /// Returns whether the channel is full.
     pub fn is_full(&self) -> bool {
         self.channel.state.lock(|s| s.borrow().is_full())
+    }
+}
+
+/// A slot for receiving in the channel.
+///
+/// The slot is only marked as received when [`ReceiveSlot::receive_done`] is called.
+pub struct ReceiveSlot<'a, M: RawMutex, T> {
+    state: &'a Mutex<M, RefCell<State>>,
+    value: &'a mut T,
+}
+
+impl<M: RawMutex, T> Deref for ReceiveSlot<'_, M, T> {
+    type Target = T;
+
+    fn deref(&self) -> &Self::Target {
+        self.value
+    }
+}
+
+impl<M: RawMutex, T> DerefMut for ReceiveSlot<'_, M, T> {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        self.value
+    }
+}
+
+impl<M: RawMutex, T> ReceiveSlot<'_, M, T> {
+    /// Notify the channel that the receiving of the value has been finalized.
+    pub fn receive_done(self) {
+        self.state.lock(|s| s.borrow_mut().pop_done());
     }
 }
 
@@ -336,7 +397,6 @@ impl State {
     }
 
     fn push_done(&mut self) {
-        assert!(!self.is_full());
         self.back = self.increment(self.back);
         if self.back == self.front {
             self.full = true;
@@ -352,7 +412,6 @@ impl State {
     }
 
     fn pop_done(&mut self) {
-        assert!(!self.is_empty());
         self.front = self.increment(self.front);
         self.full = false;
         self.receive_waker.wake();

--- a/embassy-usb/src/class/cdc_ncm/embassy_net.rs
+++ b/embassy-usb/src/class/cdc_ncm/embassy_net.rs
@@ -47,9 +47,9 @@ impl<'d, D: Driver<'d>, const MTU: usize> Runner<'d, D, MTU> {
                 state_chan.set_link_state(LinkState::Up);
 
                 loop {
-                    let p = rx_chan.rx_buf().await;
-                    match self.rx_usb.read_packet(p).await {
-                        Ok(n) => rx_chan.rx_done(n),
+                    let mut p = rx_chan.rx_buf().await;
+                    match self.rx_usb.read_packet(&mut p).await {
+                        Ok(n) => p.rx_done(n),
                         Err(e) => {
                             warn!("error reading packet: {:?}", e);
                             break;
@@ -61,10 +61,10 @@ impl<'d, D: Driver<'d>, const MTU: usize> Runner<'d, D, MTU> {
         let tx_fut = async move {
             loop {
                 let p = tx_chan.tx_buf().await;
-                if let Err(e) = self.tx_usb.write_packet(p).await {
+                if let Err(e) = self.tx_usb.write_packet(&p).await {
                     warn!("Failed to TX packet: {:?}", e);
                 }
-                tx_chan.tx_done();
+                p.tx_done();
             }
         };
         match select(rx_fut, tx_fut).await {

--- a/examples/rp/src/bin/zerocopy.rs
+++ b/examples/rp/src/bin/zerocopy.rs
@@ -68,13 +68,16 @@ async fn main(spawner: Spawner) {
 async fn producer(mut sender: Sender<'static, NoopRawMutex, SampleBuffer>, mut adc: AdcParts) {
     loop {
         // Obtain a free buffer from the channel
-        let buf = sender.send().await;
+        let mut buf = sender.send().await;
 
         // Fill it with data
-        adc.adc.read_many(&mut adc.pin, buf, 1, &mut adc.dma).await.unwrap();
+        adc.adc
+            .read_many(&mut adc.pin, &mut *buf, 1, &mut adc.dma)
+            .await
+            .unwrap();
 
         // Notify the channel that the buffer is now ready to be received
-        sender.send_done();
+        buf.send_done();
     }
 }
 
@@ -90,6 +93,6 @@ async fn consumer(mut receiver: Receiver<'static, NoopRawMutex, SampleBuffer>) {
         MAX.store(*max, Ordering::Relaxed);
 
         // Notify the channel that the buffer is now ready to be reused
-        receiver.receive_done();
+        buf.receive_done();
     }
 }

--- a/examples/rp235x/src/bin/zerocopy.rs
+++ b/examples/rp235x/src/bin/zerocopy.rs
@@ -68,13 +68,16 @@ async fn main(spawner: Spawner) {
 async fn producer(mut sender: Sender<'static, NoopRawMutex, SampleBuffer>, mut adc: AdcParts) {
     loop {
         // Obtain a free buffer from the channel
-        let buf = sender.send().await;
+        let mut buf = sender.send().await;
 
         // Fill it with data
-        adc.adc.read_many(&mut adc.pin, buf, 1, &mut adc.dma).await.unwrap();
+        adc.adc
+            .read_many(&mut adc.pin, &mut *buf, 1, &mut adc.dma)
+            .await
+            .unwrap();
 
         // Notify the channel that the buffer is now ready to be received
-        sender.send_done();
+        buf.send_done();
     }
 }
 
@@ -90,6 +93,6 @@ async fn consumer(mut receiver: Receiver<'static, NoopRawMutex, SampleBuffer>) {
         MAX.store(*max, Ordering::Relaxed);
 
         // Notify the channel that the buffer is now ready to be reused
-        receiver.receive_done();
+        buf.receive_done();
     }
 }

--- a/examples/stm32f4/src/bin/usb_uac_speaker.rs
+++ b/examples/stm32f4/src/bin/usb_uac_speaker.rs
@@ -116,7 +116,7 @@ async fn stream_handler<'d, T: usb::Instance + 'd>(
 
         if word_count * SAMPLE_SIZE == data_size {
             // Obtain a buffer from the channel
-            let samples = sender.send().await;
+            let mut samples = sender.send().await;
             samples.clear();
 
             for w in 0..word_count {
@@ -127,7 +127,7 @@ async fn stream_handler<'d, T: usb::Instance + 'd>(
                 samples.push(sample).unwrap();
             }
 
-            sender.send_done();
+            samples.send_done();
         } else {
             debug!("Invalid USB buffer size of {}, skipped.", data_size);
         }
@@ -138,11 +138,11 @@ async fn stream_handler<'d, T: usb::Instance + 'd>(
 #[embassy_executor::task]
 async fn audio_receiver_task(mut usb_audio_receiver: zerocopy_channel::Receiver<'static, NoopRawMutex, SampleBlock>) {
     loop {
-        let _samples = usb_audio_receiver.receive().await;
+        let samples = usb_audio_receiver.receive().await;
         // Use the samples, for example play back via the SAI peripheral.
 
         // Notify the channel that the buffer is now ready to be reused
-        usb_audio_receiver.receive_done();
+        samples.receive_done();
     }
 }
 

--- a/examples/stm32h5/src/bin/usb_uac_speaker.rs
+++ b/examples/stm32h5/src/bin/usb_uac_speaker.rs
@@ -117,7 +117,7 @@ async fn stream_handler<'d, T: usb::Instance + 'd>(
 
         if word_count * SAMPLE_SIZE == data_size {
             // Obtain a buffer from the channel
-            let samples = sender.send().await;
+            let mut samples = sender.send().await;
             samples.clear();
 
             for w in 0..word_count {
@@ -128,7 +128,7 @@ async fn stream_handler<'d, T: usb::Instance + 'd>(
                 samples.push(sample).unwrap();
             }
 
-            sender.send_done();
+            samples.send_done();
         } else {
             debug!("Invalid USB buffer size of {}, skipped.", data_size);
         }
@@ -139,11 +139,11 @@ async fn stream_handler<'d, T: usb::Instance + 'd>(
 #[embassy_executor::task]
 async fn audio_receiver_task(mut usb_audio_receiver: zerocopy_channel::Receiver<'static, NoopRawMutex, SampleBlock>) {
     loop {
-        let _samples = usb_audio_receiver.receive().await;
+        let samples = usb_audio_receiver.receive().await;
         // Use the samples, for example play back via the SAI peripheral.
 
         // Notify the channel that the buffer is now ready to be reused
-        usb_audio_receiver.receive_done();
+        samples.receive_done();
     }
 }
 


### PR DESCRIPTION
The current zerocopy channel API is suboptimal, because the only way
to enforce we had previously reserved a slot for sending or receiving
when calling (send/receive)_done, was to panic in such a case. With
the new API, this would be impossible.

The proposed new API makes the send/receive methods return a slot. The
sending slot has the send_done method on it instead of sending
automatically when dropped, to prevent sends of partial data.

The important changes are in
embassy-sync/src/zerocopy_channel.rs and
embassy-net-driver-channel/src/lib.rs, while the rest of the files
just had to be edited to use the new API.