### PR TITLE
stm32: use exhaustive enum for DMA channel ID

### DIFF
--- a/embassy-stm32/build.rs
+++ b/embassy-stm32/build.rs
@@ -2239,7 +2239,7 @@ fn main() {
         }
     }
 
-    for (ch_idx, ch) in METADATA.dma_channels.iter().enumerate() {
+    for ch in METADATA.dma_channels.iter() {
         let (dma_peri, _) = peripheral_map.get(ch.dma).unwrap();
         let stop_mode = dma_peri
             .rcc
@@ -2254,7 +2254,6 @@ fn main() {
         };
 
         let name = format_ident!("{}", ch.name);
-        let idx = ch_idx as u8;
 
         // Get the interrupt type for this DMA channel
         let irq_name = dma_ch_to_irq
@@ -2267,7 +2266,7 @@ fn main() {
         #[cfg(feature = "_dual-core")]
         let irq_pac = quote!(crate::pac::Interrupt::#irq_ident);
 
-        g.extend(quote!(dma_channel_impl!(#name, #idx, #irq_type);));
+        g.extend(quote!(dma_channel_impl!(#name, #irq_type);));
 
         let dma = format_ident!("{}", ch.dma);
         let ch_num = ch.channel as usize;
@@ -2327,6 +2326,16 @@ fn main() {
 
     g.extend(quote! {
         pub(crate) const DMA_CHANNELS: &[crate::dma::ChannelInfo] = &[#dmas];
+    });
+
+    let ch_names = METADATA.dma_channels.iter().map(|ch| format_ident!("{}", ch.name));
+    g.extend(quote! {
+        #[derive(Copy, Clone)]
+        #[repr(u8)]
+        #[allow(non_camel_case_types)]
+        pub(crate) enum DmaChannel {
+            #(#ch_names),*
+        }
     });
 
     // ========

--- a/embassy-stm32/src/dma/dma_bdma.rs
+++ b/embassy-stm32/src/dma/dma_bdma.rs
@@ -8,13 +8,14 @@ use embassy_sync::waitqueue::AtomicWaker;
 use super::ringbuffer::{DmaCtrl, Error, ReadableDmaRingBuffer, WritableDmaRingBuffer};
 use super::word::{Word, WordSize};
 use super::{Channel, Dir, Increment, Request, STATE, info};
+use crate::_generated::DmaChannel;
 use crate::interrupt::typelevel::Interrupt;
 use crate::rcc::WakeGuard;
 use crate::{interrupt, pac};
 
-pub(crate) unsafe fn on_irq(id: u8) {
-    let info = info(id);
-    let state = &STATE[id as usize];
+pub(crate) unsafe fn on_irq(channel: DmaChannel) {
+    let info = info(channel);
+    let state = &STATE[channel as usize];
     match info.dma {
         #[cfg(dma)]
         DmaInfo::Dma(r) => {
@@ -476,7 +477,7 @@ pub(crate) unsafe fn init(
 
 impl<'d> Channel<'d> {
     fn info(&self) -> &'static super::ChannelInfo {
-        super::info(self.id)
+        super::info(self.channel)
     }
 
     unsafe fn configure(
@@ -510,7 +511,7 @@ impl<'d> Channel<'d> {
             #[cfg(dma)]
             DmaInfo::Dma(r) => {
                 assert!(mem_len > 0 && mem_len <= 0xFFFF);
-                let state: &ChannelState = &STATE[self.id as usize];
+                let state: &ChannelState = &STATE[self.channel as usize];
                 let ch = r.st(info.num);
 
                 state.complete_count.store(0, Ordering::Release);
@@ -599,7 +600,7 @@ impl<'d> Channel<'d> {
                 #[cfg(bdma_v2)]
                 critical_section::with(|_| r.cselr().modify(|w| w.set_cs(info.num, _request)));
 
-                let state: &ChannelState = &STATE[self.id as usize];
+                let state: &ChannelState = &STATE[self.channel as usize];
                 let ch = r.ch(info.num);
 
                 state.complete_count.store(0, Ordering::Release);
@@ -649,7 +650,7 @@ impl<'d> Channel<'d> {
                 // Circular mode is not supported
                 assert!(!options.circular);
 
-                let state: &ChannelState = &STATE[self.id as usize];
+                let state: &ChannelState = &STATE[self.channel as usize];
                 let ch = r.ch(info.num);
 
                 state.complete_count.store(0, Ordering::Release);
@@ -908,7 +909,7 @@ impl<'d> Channel<'d> {
             DmaInfo::Dma(r) => r.st(info.num).cr().read().en(),
             #[cfg(bdma)]
             DmaInfo::Bdma(r) => {
-                let state: &ChannelState = &STATE[self.id as usize];
+                let state: &ChannelState = &STATE[self.channel as usize];
                 let ch = r.ch(info.num);
                 let en = ch.cr().read().en();
                 let circular = ch.cr().read().circ();
@@ -1178,7 +1179,7 @@ impl<'a> Unpin for Transfer<'a> {}
 impl<'a> Future for Transfer<'a> {
     type Output = ();
     fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
-        let state: &ChannelState = &STATE[self.channel.id as usize];
+        let state: &ChannelState = &STATE[self.channel.channel as usize];
 
         state.waker.register(cx.waker());
 
@@ -1203,7 +1204,7 @@ impl<'a> DmaCtrl for DmaCtrlImpl<'a> {
     }
 
     fn reset_complete_count(&mut self) -> usize {
-        let state = &STATE[self.0.id as usize];
+        let state = &STATE[self.0.channel as usize];
         #[cfg(not(armv6m))]
         return state.complete_count.swap(0, Ordering::AcqRel);
         #[cfg(armv6m)]
@@ -1215,7 +1216,7 @@ impl<'a> DmaCtrl for DmaCtrlImpl<'a> {
     }
 
     fn set_waker(&mut self, waker: &Waker) {
-        STATE[self.0.id as usize].waker.register(waker);
+        STATE[self.0.channel as usize].waker.register(waker);
     }
 }
 

--- a/embassy-stm32/src/dma/gpdma/mod.rs
+++ b/embassy-stm32/src/dma/gpdma/mod.rs
@@ -10,6 +10,7 @@ use linked_list::Table;
 
 use super::word::{Word, WordSize};
 use super::{Channel, Dir, Request, STATE};
+use crate::_generated::DmaChannel;
 use crate::interrupt::typelevel::Interrupt;
 use crate::pac;
 use crate::pac::gpdma::vals;
@@ -146,15 +147,15 @@ pub(crate) unsafe fn init(cs: critical_section::CriticalSection, irq_priority: c
     crate::_generated::init_gpdma();
 }
 
-pub(crate) unsafe fn on_irq(id: u8) {
-    let info = super::info(id);
+pub(crate) unsafe fn on_irq(channel: DmaChannel) {
+    let info = super::info(channel);
     #[cfg(feature = "_dual-core")]
     {
         use embassy_hal_internal::interrupt::InterruptExt as _;
         info.irq.enable();
     }
 
-    let state = &STATE[id as usize];
+    let state = &STATE[channel as usize];
 
     let ch = info.dma.ch(info.num);
     let sr = ch.sr().read();
@@ -217,7 +218,7 @@ pub(crate) unsafe fn on_irq(id: u8) {
 
 impl<'d> Channel<'d> {
     fn info(&self) -> &'static super::ChannelInfo {
-        super::info(self.id)
+        super::info(self.channel)
     }
 
     fn get_remaining_transfers(&self) -> u16 {
@@ -316,7 +317,7 @@ impl<'d> Channel<'d> {
             w.set_suspie(true);
         });
 
-        let state = &STATE[self.id as usize];
+        let state = &STATE[self.channel as usize];
         state.lli_state.count.store(0, Ordering::Relaxed);
         state.lli_state.index.store(0, Ordering::Relaxed);
         state.lli_state.transfer_count.store(0, Ordering::Relaxed)
@@ -375,7 +376,7 @@ impl<'d> Channel<'d> {
             w.set_suspie(true);
         });
 
-        let state = &STATE[self.id as usize];
+        let state = &STATE[self.channel as usize];
         state.lli_state.count.store(ITEM_COUNT, Ordering::Relaxed);
         state.lli_state.index.store(0, Ordering::Relaxed);
         state
@@ -631,7 +632,7 @@ impl<'a, const ITEM_COUNT: usize> Unpin for LinkedListTransfer<'a, ITEM_COUNT> {
 impl<'a, const ITEM_COUNT: usize> Future for LinkedListTransfer<'a, ITEM_COUNT> {
     type Output = ();
     fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
-        let state = &STATE[self.channel.id as usize];
+        let state = &STATE[self.channel.channel as usize];
         state.waker.register(cx.waker());
 
         if self.is_running() {
@@ -716,7 +717,7 @@ impl<'a> Unpin for Transfer<'a> {}
 impl<'a> Future for Transfer<'a> {
     type Output = ();
     fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
-        let state = &STATE[self.channel.id as usize];
+        let state = &STATE[self.channel.channel as usize];
         state.waker.register(cx.waker());
 
         compiler_fence(Ordering::SeqCst);

--- a/embassy-stm32/src/dma/gpdma/ringbuffered.rs
+++ b/embassy-stm32/src/dma/gpdma/ringbuffered.rs
@@ -17,7 +17,7 @@ struct DmaCtrlImpl<'a>(Channel<'a>);
 
 impl<'a> DmaCtrl for DmaCtrlImpl<'a> {
     fn get_remaining_transfers(&self) -> usize {
-        let state = &STATE[self.0.id as usize];
+        let state = &STATE[self.0.channel as usize];
         let current_remaining = self.0.get_remaining_transfers() as usize;
 
         let lli_count = state.lli_state.count.load(Ordering::Acquire);
@@ -36,13 +36,13 @@ impl<'a> DmaCtrl for DmaCtrlImpl<'a> {
     }
 
     fn reset_complete_count(&mut self) -> usize {
-        let state = &STATE[self.0.id as usize];
+        let state = &STATE[self.0.channel as usize];
 
         state.complete_count.swap(0, Ordering::AcqRel)
     }
 
     fn set_waker(&mut self, waker: &Waker) {
-        STATE[self.0.id as usize].waker.register(waker);
+        STATE[self.0.channel as usize].waker.register(waker);
     }
 }
 

--- a/embassy-stm32/src/dma/mod.rs
+++ b/embassy-stm32/src/dma/mod.rs
@@ -29,6 +29,7 @@ use core::marker::PhantomData;
 
 use embassy_hal_internal::{Peri, PeripheralType};
 
+use crate::_generated::DmaChannel;
 use crate::interrupt;
 
 /// The direction of a DMA transfer.
@@ -66,7 +67,7 @@ pub type Request = ();
 
 /// DMA channel driver
 pub struct Channel<'d> {
-    pub(crate) id: u8,
+    pub(crate) channel: DmaChannel,
     phantom: PhantomData<&'d ()>,
 }
 
@@ -77,7 +78,7 @@ impl<'d> Channel<'d> {
         _irq: impl interrupt::typelevel::Binding<T::Interrupt, crate::dma::InterruptHandler<T>> + 'd,
     ) -> Self {
         Self {
-            id: T::ID,
+            channel: T::CHANNEL,
             phantom: PhantomData,
         }
     }
@@ -85,21 +86,21 @@ impl<'d> Channel<'d> {
     /// Reborrow the channel, allowing it to be used in multiple places.
     pub fn reborrow(&mut self) -> Channel<'_> {
         Channel {
-            id: self.id,
+            channel: self.channel,
             phantom: PhantomData,
         }
     }
 
     pub(crate) unsafe fn clone_unchecked(&self) -> Channel<'d> {
         Channel {
-            id: self.id,
+            channel: self.channel,
             phantom: PhantomData,
         }
     }
 }
 
 pub(crate) trait SealedChannelInstance {
-    const ID: u8;
+    const CHANNEL: DmaChannel;
 }
 
 /// DMA channel.
@@ -117,14 +118,14 @@ pub struct InterruptHandler<T: ChannelInstance> {
 
 impl<T: ChannelInstance> interrupt::typelevel::Handler<T::Interrupt> for InterruptHandler<T> {
     unsafe fn on_interrupt() {
-        on_irq(T::ID)
+        on_irq(T::CHANNEL)
     }
 }
 
 macro_rules! dma_channel_impl {
-    ($channel_peri:ident, $index:expr, $irq:ty) => {
+    ($channel_peri:ident, $irq:ty) => {
         impl crate::dma::SealedChannelInstance for crate::peripherals::$channel_peri {
-            const ID: u8 = $index;
+            const CHANNEL: crate::_generated::DmaChannel = crate::_generated::DmaChannel::$channel_peri;
         }
 
         impl crate::dma::ChannelInstance for crate::peripherals::$channel_peri {
@@ -136,8 +137,8 @@ macro_rules! dma_channel_impl {
 const CHANNEL_COUNT: usize = crate::_generated::DMA_CHANNELS.len();
 static STATE: [ChannelState; CHANNEL_COUNT] = [ChannelState::NEW; CHANNEL_COUNT];
 
-pub(crate) fn info(id: u8) -> &'static ChannelInfo {
-    &crate::_generated::DMA_CHANNELS[id as usize]
+pub(crate) fn info(channel: DmaChannel) -> &'static ChannelInfo {
+    &crate::_generated::DMA_CHANNELS[channel as usize]
 }
 
 // safety: must be called only once at startup

--- a/embassy-stm32/src/dma/ringbuffer/mod.rs
+++ b/embassy-stm32/src/dma/ringbuffer/mod.rs
@@ -190,7 +190,7 @@ impl<'a, W: Word> ReadableDmaRingBuffer<'a, W> {
         poll_fn(|cx| {
             dma.set_waker(cx.waker());
 
-            match self.read(dma, &mut buffer[read_data..buffer_len]) {
+            match self.read(dma, &mut buffer[read_data..]) {
                 Ok((len, remaining)) => {
                     read_data += len;
                     if read_data == buffer_len {


### PR DESCRIPTION
The DMA channel IDs used to stored as u8, but this prevented the compiler from being able to optimize out some bounds checks in operations like STATE[id as usize].

We now generate an enum (that is repr(u8), meaning that nothing functionally changes) and use it instead of a plain u8.