### PR TITLE
Add wake_at() methods to waker registrations

### DIFF
--- a/embassy-sync/Cargo.toml
+++ b/embassy-sync/Cargo.toml
@@ -27,14 +27,15 @@ src_base_git = "https://github.com/embassy-rs/embassy/blob/$COMMIT/embassy-sync/
 target = "thumbv7em-none-eabi"
 
 [features]
+schedule-wake = ["dep:embassy-time", "dep:embassy-time-driver"]
 defmt = ["dep:defmt"]
 log = ["dep:log"]
 std = []
 turbowakers = []
 
 [dependencies]
-embassy-time = {version = "0.5.1", path = "../embassy-time"}
-embassy-time-driver = { version = "0.2.2", path = "../embassy-time-driver" }
+embassy-time = {version = "0.5.1", path = "../embassy-time", optional = true}
+embassy-time-driver = { version = "0.2.2", path = "../embassy-time-driver", optional = true}
 
 defmt = { version = "1.0.1", optional = true }
 log = { version = "0.4.14", optional = true }

--- a/embassy-sync/Cargo.toml
+++ b/embassy-sync/Cargo.toml
@@ -33,6 +33,9 @@ std = []
 turbowakers = []
 
 [dependencies]
+embassy-time = {version = "0.5.1", path = "../embassy-time"}
+embassy-time-driver = { version = "0.2.2", path = "../embassy-time-driver" }
+
 defmt = { version = "1.0.1", optional = true }
 log = { version = "0.4.14", optional = true }
 

--- a/embassy-sync/src/waitqueue/atomic_waker.rs
+++ b/embassy-sync/src/waitqueue/atomic_waker.rs
@@ -41,6 +41,7 @@ impl<M: RawMutex> GenericAtomicWaker<M> {
     }
 
     /// Schedule the waking of a waker.
+    #[cfg(feature = "schedule-wake")]
     pub fn wake_at(&mut self, time: embassy_time::Instant) {
         self.waker.lock(|cell| {
             if let Some(w) = cell.replace(None) {
@@ -75,6 +76,7 @@ impl AtomicWaker {
     }
 
     /// Schedule the waking of a waker.
+    #[cfg(feature = "schedule-wake")]
     pub fn wake_at(&mut self, time: embassy_time::Instant) {
         self.waker.wake_at(time);
     }

--- a/embassy-sync/src/waitqueue/atomic_waker.rs
+++ b/embassy-sync/src/waitqueue/atomic_waker.rs
@@ -76,6 +76,6 @@ impl AtomicWaker {
 
     /// Schedule the waking of a waker.
     pub fn wake_at(&mut self, time: embassy_time::Instant) {
-            self.waker.wake_at(time);
+        self.waker.wake_at(time);
     }
 }

--- a/embassy-sync/src/waitqueue/atomic_waker.rs
+++ b/embassy-sync/src/waitqueue/atomic_waker.rs
@@ -39,6 +39,16 @@ impl<M: RawMutex> GenericAtomicWaker<M> {
             }
         })
     }
+
+    /// Schedule the waking of a waker.
+    pub fn wake_at(&mut self, time: embassy_time::Instant) {
+        self.waker.lock(|cell| {
+            if let Some(w) = cell.replace(None) {
+                embassy_time_driver::schedule_wake(time.as_ticks(), &w);
+                cell.set(Some(w));
+            }
+        })
+    }
 }
 
 /// Utility struct to register and wake a waker.
@@ -62,5 +72,10 @@ impl AtomicWaker {
     /// Wake the registered waker, if any.
     pub fn wake(&self) {
         self.waker.wake();
+    }
+
+    /// Schedule the waking of a waker.
+    pub fn wake_at(&mut self, time: embassy_time::Instant) {
+            self.waker.wake_at(time);
     }
 }

--- a/embassy-sync/src/waitqueue/atomic_waker_turbo.rs
+++ b/embassy-sync/src/waitqueue/atomic_waker_turbo.rs
@@ -31,4 +31,11 @@ impl AtomicWaker {
             unsafe { Waker::from_turbo_ptr(ptr) }.wake();
         }
     }
+
+    /// Schedule the waking of a waker.
+    pub fn wake_at(&mut self, time: embassy_time::Instant) {
+        if let Some(w) = self.waker.take() {
+            embassy_time_driver::schedule_wake(time.as_ticks(), &w);
+        }
+    }
 }

--- a/embassy-sync/src/waitqueue/atomic_waker_turbo.rs
+++ b/embassy-sync/src/waitqueue/atomic_waker_turbo.rs
@@ -33,6 +33,7 @@ impl AtomicWaker {
     }
 
     /// Schedule the waking of a waker.
+    #[cfg(feature = "schedule-wake")]
     pub fn wake_at(&mut self, time: embassy_time::Instant) {
         if let Some(w) = self.waker.take() {
             embassy_time_driver::schedule_wake(time.as_ticks(), &w);

--- a/embassy-sync/src/waitqueue/multi_waker.rs
+++ b/embassy-sync/src/waitqueue/multi_waker.rs
@@ -60,4 +60,23 @@ impl<const N: usize> MultiWakerRegistration<N> {
             waker.wake();
         }
     }
+
+    /// Schedule the waking of a waker.
+    pub fn wake_at(&mut self, time: embassy_time::Instant) {
+        // heapless::Vec has no `drain()`, do it unsafely ourselves...
+
+        // First set length to 0, without dropping the contents.
+        // This is necessary for soundness: if wake() panics and we're using panic=unwind.
+        // Setting len=0 upfront ensures other code can't observe the vec in an inconsistent state.
+        // (it'll leak wakers, but that's not UB)
+        let len = self.wakers.len();
+        unsafe { self.wakers.set_len(0) }
+
+        for i in 0..len {
+            // Move a waker out of the vec.
+            let waker = unsafe { self.wakers.as_mut_ptr().add(i).read() };
+            // Wake it by value, which consumes (drops) it.
+            embassy_time_driver::schedule_wake(time.as_ticks(), &waker);
+        }
+    }
 }

--- a/embassy-sync/src/waitqueue/multi_waker.rs
+++ b/embassy-sync/src/waitqueue/multi_waker.rs
@@ -62,6 +62,7 @@ impl<const N: usize> MultiWakerRegistration<N> {
     }
 
     /// Schedule the waking of a waker.
+    #[cfg(feature = "schedule-wake")]
     pub fn wake_at(&mut self, time: embassy_time::Instant) {
         // heapless::Vec has no `drain()`, do it unsafely ourselves...
 

--- a/embassy-sync/src/waitqueue/waker_registration.rs
+++ b/embassy-sync/src/waitqueue/waker_registration.rs
@@ -49,6 +49,13 @@ impl WakerRegistration {
         }
     }
 
+    /// Schedule the waking of a waker.
+    pub fn wake_at(&mut self, time: embassy_time::Instant) {
+        if let Some(w) = self.waker.take() {
+            embassy_time_driver::schedule_wake(time.as_ticks(), &w);
+        }
+    }
+
     /// Returns true if a waker is currently registered
     pub fn occupied(&self) -> bool {
         self.waker.is_some()

--- a/embassy-sync/src/waitqueue/waker_registration.rs
+++ b/embassy-sync/src/waitqueue/waker_registration.rs
@@ -50,6 +50,7 @@ impl WakerRegistration {
     }
 
     /// Schedule the waking of a waker.
+    #[cfg(feature = "schedule-wake")]
     pub fn wake_at(&mut self, time: embassy_time::Instant) {
         if let Some(w) = self.waker.take() {
             embassy_time_driver::schedule_wake(time.as_ticks(), &w);


### PR DESCRIPTION
I've been making a construct which is a little bit like a timer which we can await before we determined when it should return. Waker had to be registered upon the initial await. One caveat is that once registered it's private so the functionality of scheduling its waking has to be a method.

It might also be preferable just make the waker field public.