### PR TITLE
stm32/adc: rework trigger traits again

### DIFF
--- a/embassy-stm32/src/adc/g4.rs
+++ b/embassy-stm32/src/adc/g4.rs
@@ -9,7 +9,7 @@ use pac::adc::vals::{Adcaldif, Difsel, Exten};
 pub use pac::adccommon::vals::{Dual, Presc};
 
 use super::{Adc, AnyAdcChannel, ConversionMode, Instance, Resolution, SampleTime, blocking_delay_us};
-use crate::adc::{AdcRegs, InjectedTrigger, SealedAdcChannel};
+use crate::adc::{AdcRegs, InjectedAdcTrigger, SealedAdcChannel};
 use crate::pac::adc::regs::{Smpr, Smpr2, Sqr1, Sqr2, Sqr3, Sqr4};
 use crate::time::Hertz;
 use crate::{Peri, pac, rcc};
@@ -396,7 +396,7 @@ impl<'d, T: Instance<Regs = crate::pac::adc::Adc>> Adc<'d, T> {
     pub fn setup_injected_conversions<'a, const N: usize>(
         self,
         sequence: [(AnyAdcChannel<'a, T>, SampleTime); N],
-        trigger: (impl InjectedTrigger<T>, Exten),
+        trigger: InjectedAdcTrigger<T>,
         interrupt: bool,
     ) -> InjectedAdc<'a, T, N> {
         assert!(N != 0, "Read sequence cannot be empty");
@@ -438,8 +438,8 @@ impl<'d, T: Instance<Regs = crate::pac::adc::Adc>> Adc<'d, T> {
         // Set external trigger for injected conversion sequence
         // Possible trigger values are seen in Table 167 in RM0440 Rev 9
         T::regs().jsqr().modify(|r| {
-            r.set_jextsel(trigger.0.signal());
-            r.set_jexten(trigger.1);
+            r.set_jextsel(trigger._trigger);
+            r.set_jexten(trigger._edge);
         });
 
         // Enable end of injected sequence interrupt

--- a/embassy-stm32/src/adc/mod.rs
+++ b/embassy-stm32/src/adc/mod.rs
@@ -50,7 +50,6 @@ pub use crate::pac::adc::vals::Exten;
 pub use crate::pac::adc::vals::Res as Resolution;
 pub use crate::pac::adc::vals::SampleTime;
 use crate::peripherals;
-use crate::triggers::NoTrigger;
 
 dma_trait!(RxDma, Instance);
 
@@ -58,9 +57,36 @@ dma_trait!(RxDma, Instance);
 /// Trigger edge stub.
 pub struct Exten;
 
-/// Type-checked representation of no trigger
-pub fn trigger_none<T>() -> Option<(NoTrigger, T)> {
-    None
+pub struct RegularAdcTrigger<T: Instance> {
+    _trigger: u8,
+    _edge: Exten,
+    _typ: PhantomData<T>,
+}
+
+impl<T: Instance> RegularAdcTrigger<T> {
+    pub fn from(trigger: impl RegularTrigger<T>, edge: Exten) -> Option<Self> {
+        Some(Self {
+            _trigger: trigger.signal(),
+            _edge: edge,
+            _typ: PhantomData,
+        })
+    }
+}
+
+pub struct InjectedAdcTrigger<T: Instance> {
+    _trigger: u8,
+    _edge: Exten,
+    _typ: PhantomData<T>,
+}
+
+impl<T: Instance> InjectedAdcTrigger<T> {
+    pub fn from(trigger: impl InjectedTrigger<T>, edge: Exten) -> Self {
+        Self {
+            _trigger: trigger.signal(),
+            _edge: edge,
+            _typ: PhantomData,
+        }
+    }
 }
 
 /// Analog to Digital driver.
@@ -319,7 +345,7 @@ impl<'d, T: Instance> Adc<'d, T> {
         dma_buf: &'a mut [u16],
         irq: impl crate::interrupt::typelevel::Binding<D::Interrupt, crate::dma::InterruptHandler<D>> + 'a,
         sequence: impl ExactSizeIterator<Item = (AnyAdcChannel<'b, T>, <T::Regs as BasicAdcRegs>::SampleTime)>,
-        trigger: Option<(impl RegularTrigger<T>, Exten)>,
+        trigger: Option<RegularAdcTrigger<T>>,
     ) -> RingBufferedAdc<'a, T> {
         let sequence_len = sequence.len();
         assert!(!dma_buf.is_empty() && dma_buf.len() <= 0xFFFF);
@@ -339,7 +365,7 @@ impl<'d, T: Instance> Adc<'d, T> {
         );
 
         T::regs().enable();
-        T::regs().configure_dma(ConversionMode::Repeated(trigger.map(|t| (t.0.signal(), t.1))));
+        T::regs().configure_dma(ConversionMode::Repeated(trigger.map(|t| (t._trigger, t._edge))));
 
         core::mem::forget(self);
 
@@ -381,9 +407,9 @@ impl<'d, T: DefaultInstance> Adc<'d, T> {
         dma_buf: &'a mut [u16],
         _irq: impl crate::interrupt::typelevel::Binding<D::Interrupt, crate::dma::InterruptHandler<D>> + 'a,
         regular_sequence: impl ExactSizeIterator<Item = (AnyAdcChannel<'b, T>, <T::Regs as BasicAdcRegs>::SampleTime)>,
-        regular_trigger: Option<(impl RegularTrigger<T>, Exten)>,
+        regular_trigger: Option<RegularAdcTrigger<T>>,
         injected_sequence: [(AnyAdcChannel<'b, T>, SampleTime); N],
-        injected_trigger: (impl InjectedTrigger<T>, Exten),
+        injected_trigger: InjectedAdcTrigger<T>,
         injected_interrupt: bool,
     ) -> (RingBufferedAdc<'a, T>, InjectedAdc<'b, T, N>) {
         unsafe {

--- a/embassy-stm32/src/adc/v2.rs
+++ b/embassy-stm32/src/adc/v2.rs
@@ -2,7 +2,7 @@ use core::mem;
 use core::sync::atomic::{Ordering, compiler_fence};
 
 use super::{AnyAdcChannel, ConversionMode, Temperature, Vbat, VrefInt, blocking_delay_us};
-use crate::adc::{Adc, AdcRegs, InjectedTrigger, Instance, Resolution, SampleTime, SealedAdcChannel};
+use crate::adc::{Adc, AdcRegs, InjectedAdcTrigger, Instance, Resolution, SampleTime, SealedAdcChannel};
 use crate::pac::adc::vals;
 pub use crate::pac::adccommon::vals::Adcpre;
 use crate::time::Hertz;
@@ -10,7 +10,6 @@ use crate::{Peri, rcc};
 
 mod injected;
 pub use injected::InjectedAdc;
-use stm32_metapac::adc::vals::Exten;
 
 fn clear_interrupt_flags(r: crate::pac::adc::Adc) {
     r.sr().modify(|regs| {
@@ -308,7 +307,7 @@ where
     pub fn setup_injected_conversions<'a, const N: usize>(
         self,
         sequence: [(AnyAdcChannel<'a, T>, SampleTime); N],
-        trigger: (impl InjectedTrigger<T>, Exten),
+        trigger: InjectedAdcTrigger<T>,
         interrupt: bool,
     ) -> InjectedAdc<'a, T, N> {
         assert!(N != 0, "Read sequence cannot be empty");
@@ -351,8 +350,8 @@ where
             w.set_jeocie(interrupt);
         });
         T::regs().cr2().modify(|w| {
-            w.set_jextsel(trigger.0.signal());
-            w.set_jexten(trigger.1);
+            w.set_jextsel(trigger._trigger);
+            w.set_jexten(trigger._edge);
         });
 
         Self::start_injected_conversions();

--- a/embassy-stm32/src/lib.rs
+++ b/embassy-stm32/src/lib.rs
@@ -182,9 +182,6 @@ pub use crate::_generated::interrupt;
 pub mod triggers {
     #[allow(unused_imports)]
     pub use crate::_generated::triggers::*;
-
-    /// Represents no trigger
-    pub struct NoTrigger;
 }
 
 /// Macro to bind interrupts to handlers.

--- a/embassy-stm32/src/macros.rs
+++ b/embassy-stm32/src/macros.rs
@@ -178,24 +178,6 @@ macro_rules! dma_trait_impl {
 
 // ====================
 
-#[allow(unused_macros)]
-macro_rules! trigger_trait_no_trigger_impl {
-    ($signal:ident, $instance:path, $mode:path) => {
-        impl<T: $instance, M: $mode> $signal<T, M> for crate::triggers::NoTrigger {
-            fn signal(&self) -> u8 {
-                unreachable!();
-            }
-        }
-    };
-    ($signal:ident, $instance:path) => {
-        impl<T: $instance> $signal<T> for crate::triggers::NoTrigger {
-            fn signal(&self) -> u8 {
-                unreachable!();
-            }
-        }
-    };
-}
-
 #[allow(unused)]
 macro_rules! trigger_trait {
     ($signal:ident, $instance:path$(, $mode:path)?) => {
@@ -206,8 +188,6 @@ macro_rules! trigger_trait {
             /// `embassy-stm32` always uses the "channel" and "request number" names.
             fn signal(&self) -> u8;
         }
-
-        trigger_trait_no_trigger_impl!($signal, $instance $(, $mode)?);
     };
 }
 

--- a/examples/stm32c0/src/bin/adc_ring_buffered_timer.rs
+++ b/examples/stm32c0/src/bin/adc_ring_buffered_timer.rs
@@ -13,7 +13,7 @@
 
 use defmt::*;
 use embassy_executor::Spawner;
-use embassy_stm32::adc::{Adc, AdcChannel as _, Resolution, SampleTime};
+use embassy_stm32::adc::{Adc, AdcChannel as _, RegularAdcTrigger, Resolution, SampleTime};
 use embassy_stm32::pac::adc::vals::Exten;
 use embassy_stm32::peripherals::DMA1_CH1;
 use embassy_stm32::time::Hertz;
@@ -82,7 +82,7 @@ async fn main(_spawner: Spawner) {
         &mut dma_buf,
         Irqs,
         sequence,
-        Some((TIM1_TRGO2, Exten::RISING_EDGE)), // Timer 1 TRGO2 as trigger source and trigger on rising edge (can also use FALLING_EDGE or BOTH_EDGES)
+        RegularAdcTrigger::from(TIM1_TRGO2, Exten::RISING_EDGE), // Timer 1 TRGO2 as trigger source and trigger on rising edge (can also use FALLING_EDGE or BOTH_EDGES)
     );
 
     // Start ADC conversions and DMA transfer

--- a/examples/stm32f4/src/bin/adc.rs
+++ b/examples/stm32f4/src/bin/adc.rs
@@ -5,7 +5,7 @@ use cortex_m::prelude::_embedded_hal_blocking_delay_DelayUs;
 use defmt::*;
 use embassy_executor::Spawner;
 use embassy_stm32::adc::vals::Exten;
-use embassy_stm32::adc::{Adc, AdcChannel, SampleTime, Temperature, VrefInt};
+use embassy_stm32::adc::{Adc, AdcChannel, RegularAdcTrigger, SampleTime, Temperature, VrefInt};
 use embassy_stm32::triggers::TIM1_CH1;
 use embassy_stm32::{bind_interrupts, dma, peripherals};
 use embassy_time::{Delay, Timer};
@@ -28,7 +28,7 @@ async fn main(_spawner: Spawner) {
         &mut adc_dma_buf,
         Irqs,
         [(p.PA0.degrade_adc(), SampleTime::CYCLES112)].into_iter(),
-        Some((TIM1_CH1, Exten::RISING_EDGE)),
+        RegularAdcTrigger::from(TIM1_CH1, Exten::RISING_EDGE),
     );
     adc_ring_buffered.start();
 

--- a/examples/stm32f4/src/bin/adc_dma.rs
+++ b/examples/stm32f4/src/bin/adc_dma.rs
@@ -3,7 +3,7 @@
 use cortex_m::singleton;
 use defmt::*;
 use embassy_executor::Spawner;
-use embassy_stm32::adc::{Adc, AdcChannel, RingBufferedAdc, SampleTime, trigger_none};
+use embassy_stm32::adc::{Adc, AdcChannel, RingBufferedAdc, SampleTime};
 use embassy_stm32::{Peripherals, bind_interrupts, dma, peripherals};
 use embassy_time::Instant;
 use {defmt_rtt as _, panic_probe as _};
@@ -37,7 +37,7 @@ async fn adc_task(mut p: Peripherals) {
             (p.PA2.degrade_adc(), SampleTime::CYCLES112),
         ]
         .into_iter(),
-        trigger_none(),
+        None,
     );
     let mut adc2: RingBufferedAdc<embassy_stm32::peripherals::ADC2> = adc2.into_ring_buffered(
         p.DMA2_CH2,
@@ -48,7 +48,7 @@ async fn adc_task(mut p: Peripherals) {
             (p.PA3.degrade_adc(), SampleTime::CYCLES112),
         ]
         .into_iter(),
-        trigger_none(),
+        None,
     );
 
     // Note that overrun is a big consideration in this implementation. Whatever task is running the adc.read() calls absolutely must circle back around

--- a/examples/stm32g0/src/bin/adc_ring_buffered_timer.rs
+++ b/examples/stm32g0/src/bin/adc_ring_buffered_timer.rs
@@ -13,7 +13,7 @@
 
 use defmt::*;
 use embassy_executor::Spawner;
-use embassy_stm32::adc::{Adc, AdcChannel as _, Clock, Presc, SampleTime};
+use embassy_stm32::adc::{Adc, AdcChannel as _, Clock, Presc, RegularAdcTrigger, SampleTime};
 use embassy_stm32::pac::adc::vals::Exten;
 use embassy_stm32::peripherals::DMA1_CH1;
 use embassy_stm32::time::Hertz;
@@ -81,7 +81,7 @@ async fn main(_spawner: Spawner) {
         &mut dma_buf,
         Irqs,
         sequence,
-        Some((TIM1_TRGO2, Exten::RISING_EDGE)), // Timer 1 TRGO2 as trigger source and Trigger on rising edge (can also use FALLING_EDGE or BOTH_EDGES)
+        RegularAdcTrigger::from(TIM1_TRGO2, Exten::RISING_EDGE), // Timer 1 TRGO2 as trigger source and Trigger on rising edge (can also use FALLING_EDGE or BOTH_EDGES)
     );
 
     // Start ADC conversions and DMA transfer

--- a/examples/stm32g4/src/bin/adc_injected_and_regular.rs
+++ b/examples/stm32g4/src/bin/adc_injected_and_regular.rs
@@ -9,7 +9,9 @@
 use core::cell::RefCell;
 
 use defmt::info;
-use embassy_stm32::adc::{Adc, AdcChannel as _, Exten, InjectedAdc, SampleTime, VrefInt};
+use embassy_stm32::adc::{
+    Adc, AdcChannel as _, Exten, InjectedAdc, InjectedAdcTrigger, RegularAdcTrigger, SampleTime, VrefInt,
+};
 use embassy_stm32::interrupt::typelevel::{ADC1_2, Interrupt};
 use embassy_stm32::peripherals::ADC1;
 use embassy_stm32::time::Hertz;
@@ -107,9 +109,9 @@ async fn main(_spawner: embassy_executor::Spawner) {
         &mut readings,
         Irqs,
         regular_sequence,
-        Some((TIM1_TRGO2, Exten::RISING_EDGE)),
+        RegularAdcTrigger::from(TIM1_TRGO2, Exten::RISING_EDGE),
         injected_sequence,
-        (TIM1_TRGO2, Exten::RISING_EDGE),
+        InjectedAdcTrigger::from(TIM1_TRGO2, Exten::RISING_EDGE),
         true,
     );
 

--- a/examples/stm32l4/src/bin/adc_dma.rs
+++ b/examples/stm32l4/src/bin/adc_dma.rs
@@ -3,7 +3,7 @@
 
 use defmt::*;
 use embassy_executor::Spawner;
-use embassy_stm32::adc::{Adc, AdcChannel, SampleTime, trigger_none};
+use embassy_stm32::adc::{Adc, AdcChannel, SampleTime};
 use embassy_stm32::{Config, bind_interrupts, dma, peripherals};
 use {defmt_rtt as _, panic_probe as _};
 
@@ -34,7 +34,7 @@ async fn main(_spawner: Spawner) {
         &mut adc_dma_buf,
         Irqs,
         [(adc_pin0, SampleTime::CYCLES640_5), (adc_pin1, SampleTime::CYCLES640_5)].into_iter(),
-        trigger_none(),
+        None,
     );
 
     info!("starting measurement loop");

--- a/examples/stm32wba/src/bin/adc_ring_buffered.rs
+++ b/examples/stm32wba/src/bin/adc_ring_buffered.rs
@@ -18,7 +18,7 @@
 
 use defmt::*;
 use embassy_stm32::adc::adc4::Calibration;
-use embassy_stm32::adc::{Adc, AdcChannel, RingBufferedAdc, adc4, trigger_none};
+use embassy_stm32::adc::{Adc, AdcChannel, RingBufferedAdc, adc4};
 use embassy_stm32::peripherals::{ADC4, GPDMA1_CH1};
 use embassy_stm32::rcc::{
     AHB5Prescaler, AHBPrescaler, APBPrescaler, PllDiv, PllMul, PllPreDiv, PllSource, Sysclk, VoltageScale,
@@ -106,7 +106,7 @@ async fn main(_spawner: embassy_executor::Spawner) {
             (temp_ch, adc4::SampleTime::CYCLES12_5),    // Channel 13
         ]
         .into_iter(),
-        trigger_none(),
+        None,
     );
 
     info!("Ring buffer configured, starting continuous sampling...");

--- a/examples/stm32wba6/src/bin/adc_ring_buffered.rs
+++ b/examples/stm32wba6/src/bin/adc_ring_buffered.rs
@@ -21,7 +21,7 @@
 
 use defmt::*;
 use embassy_stm32::adc::adc4::Calibration;
-use embassy_stm32::adc::{Adc, AdcChannel, RingBufferedAdc, adc4, trigger_none};
+use embassy_stm32::adc::{Adc, AdcChannel, RingBufferedAdc, adc4};
 use embassy_stm32::peripherals::{ADC4, GPDMA1_CH1};
 use embassy_stm32::rcc::{
     AHB5Prescaler, AHBPrescaler, APBPrescaler, PllDiv, PllMul, PllPreDiv, PllSource, Sysclk, VoltageScale,
@@ -110,7 +110,7 @@ async fn main(_spawner: embassy_executor::Spawner) {
             (temp_ch, adc4::SampleTime::CYCLES79_5),    // Channel 13 - Temperature
         ]
         .into_iter(),
-        trigger_none(),
+        None,
     );
 
     info!("Ring buffer configured, starting continuous sampling...");


### PR DESCRIPTION
remove the `NoTrigger` and `trigger_none()` functions.