### PR TITLE
STM32 EXTI H7 dual core

### DIFF
--- a/embassy-stm32/Cargo.toml
+++ b/embassy-stm32/Cargo.toml
@@ -209,11 +209,11 @@ aligned = "0.4.3"
 heapless = "0.9.1"
 
 # stm32-metapac = { version = "21" }
-stm32-metapac = { git = "https://github.com/embassy-rs/stm32-data-generated", tag = "stm32-data-7bc624653af48a1e816b41fff096de816bf97da4" }
+stm32-metapac = { git = "https://github.com/embassy-rs/stm32-data-generated", tag = "stm32-data-81f374262851c8cd549df1fb1d47ac455e7e5e4b" }
 
 [build-dependencies]
 # stm32-metapac = { version = "21", default-features = false, features = ["metadata"]}
-stm32-metapac = { git = "https://github.com/embassy-rs/stm32-data-generated", tag = "stm32-data-7bc624653af48a1e816b41fff096de816bf97da4", default-features = false, features = ["metadata"] }
+stm32-metapac = { git = "https://github.com/embassy-rs/stm32-data-generated", tag = "stm32-data-81f374262851c8cd549df1fb1d47ac455e7e5e4b", default-features = false, features = ["metadata"] }
 
 proc-macro2 = "1.0.36"
 quote = "1.0.15"

--- a/embassy-stm32/src/exti/low_level.rs
+++ b/embassy-stm32/src/exti/low_level.rs
@@ -78,6 +78,7 @@ pub(super) fn configure_and_enable_exti(pin: &Input, trigger_edge: TriggerEdge) 
     });
 }
 
+#[cfg(not(all(stm32h7, feature = "_dual-core")))]
 /// Conditional compilation for STM32 variants with separate RPR/FPR registers.
 /// These variants use separate Rising/Falling Pending Registers instead of the unified PR register.
 macro_rules! cfg_has_rpr_fpr {
@@ -87,6 +88,7 @@ macro_rules! cfg_has_rpr_fpr {
     };
 }
 
+#[cfg(not(all(stm32h7, feature = "_dual-core")))]
 /// Conditional compilation for STM32 variants with unified PR register.
 /// Represents variants that use a single Pending Register for both rising and falling edges.
 macro_rules! cfg_no_rpr_fpr {
@@ -121,9 +123,6 @@ pub(super) fn clear_exti_pending_mask(mask: u32) {
     #[cfg(not(all(stm32h7, feature = "_dual-core")))]
     {
         cfg_no_rpr_fpr! {
-            #[cfg(all(stm32h7, feature = "_dual-core"))]
-            EXTI.pr(0).write_value(Lines(mask));
-            #[cfg(not(all(stm32h7, feature = "_dual-core")))]
             EXTI.pr(0).write_value(Lines(mask));
         }
 
@@ -150,14 +149,17 @@ pub(super) fn clear_exti_pending(pin: PinNumber) {
 pub(super) fn is_exti_pending(pin: PinNumber) -> bool {
     let pin = pin as usize;
 
-    cfg_no_rpr_fpr! {
-        #[cfg(all(stm32h7, feature = "_dual-core"))]
-        return cpu_regs().pr(0).read().line(pin);
-        #[cfg(not(all(stm32h7, feature = "_dual-core")))]
-        return EXTI.pr(0).read().line(pin);
-    }
+    #[cfg(all(stm32h7, feature = "_dual-core"))]
+    return cpu_regs().pr(0).read().line(pin);
 
-    cfg_has_rpr_fpr! {
-        return EXTI.rpr(0).read().line(pin) || EXTI.fpr(0).read().line(pin);
+    #[cfg(not(all(stm32h7, feature = "_dual-core")))]
+    {
+        cfg_no_rpr_fpr! {
+            return EXTI.pr(0).read().line(pin);
+        }
+
+        cfg_has_rpr_fpr! {
+            return EXTI.rpr(0).read().line(pin) || EXTI.fpr(0).read().line(pin);
+        }
     }
 }

--- a/embassy-stm32/src/exti/mod.rs
+++ b/embassy-stm32/src/exti/mod.rs
@@ -26,14 +26,14 @@ pub mod blocking;
 const EXTI_COUNT: usize = 16;
 static EXTI_WAKERS: [AtomicWaker; EXTI_COUNT] = [const { AtomicWaker::new() }; EXTI_COUNT];
 
-#[cfg(feature = "_dual-core")]
+#[cfg(any(feature = "_dual-core", exti_w))]
 #[inline(always)]
 fn cpu_regs() -> pac::exti::Cpu {
     use crate::cpu::CoreId;
     EXTI.cpu(CoreId::current().to_index())
 }
 
-#[cfg(not(feature = "_dual-core"))]
+#[cfg(not(any(feature = "_dual-core", exti_w)))]
 #[inline(always)]
 fn cpu_regs() -> pac::exti::Exti {
     EXTI


### PR DESCRIPTION
Adds support for per-core EXTI registers on dual core H7 targets

* Depends on metapac PR https://github.com/embassy-rs/stm32-data/pull/772
* Change `cpu_regs` feature gate from `exti_w` to `_dual_core` and use `CoreId::current().to_index()`
* Move reading of pending interrupt flags into low_level.rs `read_pending()` with gating
* Gating on `stm32h7` and `_dual_core` for PR register which is not in CPU regs on all `_dual_core` targets