### PR TITLE
STM32 HSEM improvements, use HSEM for dual core init sync

### DIFF
--- a/embassy-stm32/src/hsem/mod.rs
+++ b/embassy-stm32/src/hsem/mod.rs
@@ -26,6 +26,8 @@ pub enum HsemError {
     LockFailed,
 }
 
+const CHANNELS: usize = 6;
+
 #[cfg(all(not(all(stm32wb, feature = "low-power")), not(all(stm32wl5x, feature = "low-power"))))]
 const PUB_CHANNELS: usize = 6;
 
@@ -89,7 +91,7 @@ pub struct HardwareSemaphoreChannel<'a, T: Instance> {
 
 impl<'a, T: Instance> HardwareSemaphoreChannel<'a, T> {
     pub(crate) const fn new(number: u8) -> Self {
-        core::assert!(number > 0 && number <= PUB_CHANNELS as u8);
+        core::assert!(number > 0 && number <= CHANNELS as u8);
 
         Self {
             index: number - 1,
@@ -396,28 +398,22 @@ impl<T: Instance> HardwareSemaphore<T> {
 
 #[cfg(all(any(stm32wb, stm32wl5x), feature = "low-power"))]
 pub(crate) fn init_hsem(cs: CriticalSection) {
+    use crate::rcc;
     rcc::enable_and_reset_with_cs::<crate::peripherals::HSEM>(cs);
 }
 
-#[cfg(any(all(stm32wb, feature = "low-power"), stm32wl5x))]
 pub(crate) const fn get_hsem<'a>(index: usize) -> HardwareSemaphoreChannel<'a, crate::peripherals::HSEM> {
-    match index {
-        #[cfg(any(stm32wb, stm32wl5x))]
-        3 => HardwareSemaphoreChannel::new(3),
-        #[cfg(stm32wb)]
-        4 => HardwareSemaphoreChannel::new(4),
-        _ => core::unreachable!(),
-    }
+    HardwareSemaphoreChannel::new(index as u8)
 }
 
 struct State {
-    wakers: [AtomicWaker; PUB_CHANNELS],
+    wakers: [AtomicWaker; CHANNELS],
 }
 
 impl State {
     const fn new() -> Self {
         Self {
-            wakers: [const { AtomicWaker::new() }; PUB_CHANNELS],
+            wakers: [const { AtomicWaker::new() }; CHANNELS],
         }
     }
 

--- a/embassy-stm32/src/hsem/mod.rs
+++ b/embassy-stm32/src/hsem/mod.rs
@@ -402,6 +402,7 @@ pub(crate) fn init_hsem(cs: CriticalSection) {
     rcc::enable_and_reset_with_cs::<crate::peripherals::HSEM>(cs);
 }
 
+#[cfg(any(all(stm32wb, feature = "low-power"), feature = "_dual-core"))]
 pub(crate) const fn get_hsem<'a>(index: usize) -> HardwareSemaphoreChannel<'a, crate::peripherals::HSEM> {
     HardwareSemaphoreChannel::new(index as u8)
 }

--- a/embassy-stm32/src/hsem/mod.rs
+++ b/embassy-stm32/src/hsem/mod.rs
@@ -2,13 +2,13 @@
 
 use core::future::poll_fn;
 use core::marker::PhantomData;
-use core::sync::atomic::{Ordering, compiler_fence};
 use core::task::Poll;
 
 #[cfg(all(any(stm32wb, stm32wl5x), feature = "low-power"))]
 use critical_section::CriticalSection;
 use embassy_hal_internal::PeripheralType;
 use embassy_sync::waitqueue::AtomicWaker;
+use interrupt::typelevel::Interrupt;
 
 // TODO: This code works for all HSEM implemenations except for the STM32WBA52/4/5xx MCUs.
 // Those MCUs have a different HSEM implementation (Secure semaphore lock support,
@@ -16,7 +16,7 @@ use embassy_sync::waitqueue::AtomicWaker;
 // which is not yet supported by this code.
 use crate::Peri;
 use crate::cpu::CoreId;
-use crate::rcc::{self, RccPeripheral};
+use crate::rcc::RccPeripheral;
 use crate::{interrupt, pac};
 
 /// HSEM error.
@@ -42,22 +42,27 @@ pub struct HardwareSemaphoreInterruptHandler<T: Instance> {
 
 impl<T: Instance> interrupt::typelevel::Handler<T::Interrupt> for HardwareSemaphoreInterruptHandler<T> {
     unsafe fn on_interrupt() {
-        let core_id = CoreId::current();
-        let isr = T::regs().isr(core_id.to_index()).read();
+        // Disable interrupts to defer clear to poll_fn
+        // otherwise the handler is called again on return
+        T::Interrupt::disable();
 
-        for number in 0..5 {
-            if isr.isf(number as usize) {
-                T::regs()
-                    .icr(core_id.to_index())
-                    .write(|w| w.set_isc(number as usize, true));
+        // Get pending semaphore bits from masked ISR for the current core
+        let mut pending = T::regs().misr(CoreId::current().to_index()).read().0;
 
-                T::state().waker_for(number).wake();
-            }
+        while pending != 0 {
+            // Index of lowest set bit
+            let n = pending.trailing_zeros() as u8;
+
+            // Clear lowest set bit.
+            // Safe when pending != 0 enforced by while predicate
+            pending &= pending - 1;
+
+            T::state().waker_for(n).wake();
         }
     }
 }
 
-/// Hardware semaphore mutex
+/// Hardware semaphore mutex. The semaphore is unlocked when the guard is dropped
 pub struct HardwareSemaphoreMutex<'a, T: Instance> {
     index: u8,
     process_id: u8,
@@ -65,19 +70,8 @@ pub struct HardwareSemaphoreMutex<'a, T: Instance> {
 }
 
 impl<'a, T: Instance> Drop for HardwareSemaphoreMutex<'a, T> {
+    /// Unlock the semaphore when this guard is dropped
     fn drop(&mut self) {
-        let core_id = CoreId::current();
-
-        T::regs()
-            .icr(core_id.to_index())
-            .write(|w| w.set_isc(self.index as usize, true));
-
-        critical_section::with(|_| {
-            T::regs()
-                .ier(core_id.to_index())
-                .modify(|w| w.set_ise(self.index as usize, false));
-        });
-
         HardwareSemaphoreChannel::<'a, T> {
             index: self.index,
             _lifetime: PhantomData,
@@ -86,6 +80,7 @@ impl<'a, T: Instance> Drop for HardwareSemaphoreMutex<'a, T> {
     }
 }
 
+#[derive(Copy, Clone)]
 /// Hardware semaphore channel
 pub struct HardwareSemaphoreChannel<'a, T: Instance> {
     index: u8,
@@ -94,7 +89,7 @@ pub struct HardwareSemaphoreChannel<'a, T: Instance> {
 
 impl<'a, T: Instance> HardwareSemaphoreChannel<'a, T> {
     pub(crate) const fn new(number: u8) -> Self {
-        core::assert!(number > 0 && number <= 6);
+        core::assert!(number > 0 && number <= PUB_CHANNELS as u8);
 
         Self {
             index: number - 1,
@@ -102,35 +97,96 @@ impl<'a, T: Instance> HardwareSemaphoreChannel<'a, T> {
         }
     }
 
-    /// Locks the semaphore.
-    /// The 2-step lock procedure consists in a write to lock the semaphore, followed by a read to
-    /// check if the lock has been successful, carried out from the HSEM_Rx register.
-    pub async fn lock(&mut self, process_id: u8) -> HardwareSemaphoreMutex<'a, T> {
-        let _scoped_wake_guard = T::RCC_INFO.wake_guard();
-        let core_id = CoreId::current();
+    /// Asynchronously lock a hardware semaphore with 1-step lock procedure and interrupts
+    /// This lock does not use process ID, and should only be used to synchronize between cores.
+    /// Locking a 1 step lock from the same AHB bus master ID will read the semaphore as locked
+    pub async fn fast_lock(&mut self) -> HardwareSemaphoreMutex<'a, T> {
+        if let Some(lock) = self.try_fast_lock() {
+            return lock;
+        }
 
-        poll_fn(|cx| {
-            T::state().waker_for(self.index).register(cx.waker());
+        let core_index = CoreId::current().to_index();
 
-            compiler_fence(Ordering::SeqCst);
+        poll_fn(|cx| match self.try_fast_lock() {
+            Some(lock) => {
+                self.enable_interrupt(core_index, false);
+                self.clear_interrupt(core_index);
+                Poll::Ready(lock)
+            }
+            None => {
+                self.clear_interrupt(core_index);
 
-            critical_section::with(|_| {
-                T::regs()
-                    .ier(core_id.to_index())
-                    .modify(|w| w.set_ise(self.index as usize, true));
-            });
+                if let Some(lock) = self.try_fast_lock() {
+                    return Poll::Ready(lock);
+                }
 
-            match self.try_lock(process_id) {
-                Some(mutex) => Poll::Ready(mutex),
-                None => Poll::Pending,
+                T::state().waker_for(self.index).register(cx.waker());
+
+                T::Interrupt::unpend();
+                unsafe {
+                    T::Interrupt::enable();
+                }
+                self.enable_interrupt(core_index, true);
+
+                Poll::Pending
             }
         })
         .await
     }
 
-    /// Locks the semaphore in blocking mode
-    /// The 2-step lock procedure consists in a write to lock the semaphore, followed by a read to
-    /// check if the lock has been successful, carried out from the HSEM_Rx register.
+    /// Asynchronously lock a hardware semaphore with 2-step lock procedure and interrupts outlined in RM0399 11.3.7.
+    ///
+    /// - Try to lock the semaphore and return if it is obtained
+    /// - If the lock fails:
+    ///   - Clear pending interrupt status and retry the lock
+    ///   - If the lock is obtained, return
+    ///   - If the lock fails, register the waker and enable interrupt in IER
+    ///
+    pub async fn lock(&mut self, process_id: u8) -> HardwareSemaphoreMutex<'a, T> {
+        let _scoped_wake_guard = T::RCC_INFO.wake_guard();
+
+        // Try to acquire the lock and return if it succeeds
+        if let Some(lock) = self.try_lock(process_id) {
+            return lock;
+        }
+
+        let core_index = CoreId::current().to_index();
+
+        self.clear_interrupt(core_index);
+
+        // Try to lock again otherwise register the waker and enable interrupts
+        poll_fn(|cx| match self.try_lock(process_id) {
+            Some(mutex) => {
+                self.enable_interrupt(core_index, false);
+                self.clear_interrupt(core_index);
+                Poll::Ready(mutex)
+            }
+            None => {
+                // If we were woken by an interrupt and the lock failed to acquire, clear
+                // interrupt flags and attempt to lock again before re-registering the waker
+                // RM0399 Rev4 page 559
+                self.clear_interrupt(core_index);
+
+                if let Some(lock) = self.try_lock(process_id) {
+                    return Poll::Ready(lock);
+                }
+
+                T::state().waker_for(self.index).register(cx.waker());
+
+                self.enable_interrupt(core_index, true);
+
+                T::Interrupt::unpend();
+                unsafe {
+                    T::Interrupt::enable();
+                }
+
+                Poll::Pending
+            }
+        })
+        .await
+    }
+
+    /// Locks the semaphore in a blocking wait loop
     pub fn blocking_lock(&mut self, process_id: u8) -> HardwareSemaphoreMutex<'a, T> {
         loop {
             if let Some(lock) = self.try_lock(process_id) {
@@ -139,7 +195,61 @@ impl<'a, T: Instance> HardwareSemaphoreChannel<'a, T> {
         }
     }
 
-    /// Try to lock the semaphor
+    /// Lock and unlock the semaphore to notify a listening core
+    pub fn blocking_notify(&mut self) {
+        while self.one_step_lock().is_err() {}
+        cortex_m::asm::dsb();
+        self.unlock(0);
+    }
+
+    /// Blocking poll for semaphore interrupt flag
+    pub fn blocking_listen(&mut self) {
+        let core_index = CoreId::current().to_index();
+        self.clear_interrupt(core_index);
+        self.enable_interrupt(core_index, true);
+        // Wait for the semaphore interrupt flag
+        while !T::regs().misr(core_index).read().misf(self.index as usize) {}
+        self.enable_interrupt(core_index, false);
+        self.clear_interrupt(core_index);
+    }
+
+    /// Asynchronous listen for a notification interrupt when this semaphore channel is unlocked
+    pub async fn listen(&mut self) {
+        let core_index = CoreId::current().to_index();
+        poll_fn(|cx| {
+            if T::regs().isr(core_index).read().isf(self.index as usize) {
+                self.enable_interrupt(core_index, false);
+                self.clear_interrupt(core_index);
+                return Poll::Ready(());
+            }
+            T::state().waker_for(self.index).register(cx.waker());
+            self.enable_interrupt(core_index, true);
+            T::Interrupt::unpend();
+            unsafe {
+                T::Interrupt::enable();
+            }
+            Poll::Pending
+        })
+        .await
+    }
+
+    /// Enable interrupts for this semaphore
+    #[inline(always)]
+    fn enable_interrupt(&self, core_index: usize, enable: bool) {
+        T::regs()
+            .ier(core_index)
+            .modify(|w| w.set_ise(self.index as usize, enable));
+    }
+
+    /// Clear interrupt flag for this semaphore
+    #[inline(always)]
+    fn clear_interrupt(&self, core_index: usize) {
+        T::regs()
+            .icr(core_index)
+            .write(|w| w.set_isc(self.index as usize, true));
+    }
+
+    /// Try to lock the semaphore
     /// The 2-step lock procedure consists in a write to lock the semaphore, followed by a read to
     /// check if the lock has been successful, carried out from the HSEM_Rx register.
     pub fn try_lock(&mut self, process_id: u8) -> Option<HardwareSemaphoreMutex<'a, T>> {
@@ -147,6 +257,20 @@ impl<'a, T: Instance> HardwareSemaphoreChannel<'a, T> {
             Some(HardwareSemaphoreMutex {
                 index: self.index,
                 process_id: process_id,
+                _lifetime: PhantomData,
+            })
+        } else {
+            None
+        }
+    }
+
+    /// Try to a lock a single step semaphore.
+    /// This should only be used from different cores, as fast locks do not use process IDs
+    pub fn try_fast_lock(&mut self) -> Option<HardwareSemaphoreMutex<'a, T>> {
+        if self.one_step_lock().is_ok() {
+            Some(HardwareSemaphoreMutex {
+                index: self.index,
+                process_id: 0,
                 _lifetime: PhantomData,
             })
         } else {
@@ -177,10 +301,13 @@ impl<'a, T: Instance> HardwareSemaphoreChannel<'a, T> {
     /// Locks the semaphore.
     /// The 1-step procedure consists in a read to lock and check the semaphore in a single step,
     /// carried out from the HSEM_RLRx register.
+    ///
+    /// This is only safe to use when acquiring from different cores/AHB masters,
+    /// as a 1-step is only exclusive per core, AHB bus master ID
     pub fn one_step_lock(&mut self) -> Result<(), HsemError> {
         let reg = T::regs().rlr(self.index as usize).read();
         match (reg.lock(), reg.coreid() == CoreId::current() as u8, reg.procid()) {
-            (false, true, 0) => Ok(()),
+            (true, true, 0) => Ok(()),
             _ => Err(HsemError::LockFailed),
         }
     }
@@ -213,7 +340,8 @@ impl<T: Instance> HardwareSemaphore<T> {
         _peripheral: Peri<'d, T>,
         _irq: impl interrupt::typelevel::Binding<T::Interrupt, HardwareSemaphoreInterruptHandler<T>> + 'd,
     ) -> Self {
-        rcc::enable_and_reset_without_stop::<T>();
+        // Do not attempt to reset the HSEM, as a race condition and deadlock can occur between cores
+        // It is assumed the HSEM is already initialized during `init_primary()`
 
         HardwareSemaphore { _type: PhantomData }
     }
@@ -283,13 +411,13 @@ pub(crate) const fn get_hsem<'a>(index: usize) -> HardwareSemaphoreChannel<'a, c
 }
 
 struct State {
-    wakers: [AtomicWaker; 6],
+    wakers: [AtomicWaker; PUB_CHANNELS],
 }
 
 impl State {
     const fn new() -> Self {
         Self {
-            wakers: [const { AtomicWaker::new() }; 6],
+            wakers: [const { AtomicWaker::new() }; PUB_CHANNELS],
         }
     }
 

--- a/embassy-stm32/src/hsem/mod.rs
+++ b/embassy-stm32/src/hsem/mod.rs
@@ -396,6 +396,7 @@ impl<T: Instance> HardwareSemaphore<T> {
 
 #[cfg(all(any(stm32wb, stm32wl5x), feature = "low-power"))]
 pub(crate) fn init_hsem(cs: CriticalSection) {
+    use crate::rcc;
     rcc::enable_and_reset_with_cs::<crate::peripherals::HSEM>(cs);
 }
 

--- a/embassy-stm32/src/lib.rs
+++ b/embassy-stm32/src/lib.rs
@@ -396,8 +396,8 @@ pub fn init(config: Config) -> Peripherals {
 mod dual_core {
     use core::cell::UnsafeCell;
     use core::mem::MaybeUninit;
-    use core::sync::atomic::{AtomicUsize, Ordering};
 
+    use hsem::HardwareSemaphoreChannel;
     use rcc::Clocks;
 
     use super::*;
@@ -419,7 +419,6 @@ mod dual_core {
     /// This static must be placed in the same position for both cores. How and where this is done is left to the user.
     #[repr(C)]
     pub struct SharedData {
-        init_flag: AtomicUsize,
         clocks: UnsafeCell<MaybeUninit<Clocks>>,
         config: UnsafeCell<MaybeUninit<SharedConfig>>,
         #[cfg(feature = "low-power")]
@@ -427,8 +426,6 @@ mod dual_core {
     }
 
     unsafe impl Sync for SharedData {}
-
-    const INIT_DONE_FLAG: usize = 0xca11ab1e;
 
     /// Initialize the `embassy-stm32` HAL with the provided configuration.
     /// This function does the actual initialization of the hardware, in contrast to [init_secondary] or [try_init_secondary].
@@ -438,24 +435,36 @@ mod dual_core {
     ///
     /// This should only be called once at startup, otherwise it panics.
     ///
-    /// The `shared_data` is used to coordinate the init with the second core. Read the [SharedData] docs
-    /// for more information on its requirements.
+    /// A hardware semaphore is used to coordinate the init with the second core.
     pub fn init_primary(config: Config, shared_data: &'static MaybeUninit<SharedData>) -> Peripherals {
         let shared_data = unsafe { shared_data.assume_init_ref() };
 
-        // Write the flag as soon as possible. Reading this flag uninitialized in the `init_secondary`
-        // is maybe unsound? Unclear. If it is indeed unsound, writing it sooner doesn't fix it all,
-        // but improves the odds of it going right
-        shared_data.init_flag.store(0, Ordering::SeqCst);
+        // Enable hardware semaphore.
+        // Attempting to reset is a race condition, as the second core may be using HSEM and deadlock.
+        critical_section::with(|cs| {
+            rcc::enable_with_cs::<peripherals::HSEM>(cs);
+        });
+
+        #[cfg(stm32h7)]
+        {
+            use stm32_metapac::RCC;
+
+            use super::cpu::CoreId;
+
+            // Wait for secondary core clocks
+            match CoreId::current() {
+                CoreId::Core0 => while RCC.cr().read().d2ckrdy() == false {},
+                CoreId::Core1 => while RCC.cr().read().d1ckrdy() == false {},
+            }
+        }
 
         rcc::set_freqs_ptr(shared_data.clocks.get());
         #[cfg(feature = "low-power")]
         rcc::set_rcc_config_ptr(shared_data.rcc_config.get());
         let p = init_hw(config);
 
-        unsafe { *shared_data.config.get() }.write(config.into());
-
-        shared_data.init_flag.store(INIT_DONE_FLAG, Ordering::SeqCst);
+        let mut hsem = HardwareSemaphoreChannel::<'_, peripherals::HSEM>::new(1);
+        hsem.blocking_notify();
 
         p
     }
@@ -467,17 +476,17 @@ mod dual_core {
     ///
     /// This should only be called once at startup, otherwise it may panic.
     ///
-    /// The `shared_data` is used to coordinate the init with the second core. Read the [SharedData] docs
-    /// for more information on its requirements.
+    /// A hardware semaphore is used to coordinate the init with the second core.
     pub fn try_init_secondary(shared_data: &'static MaybeUninit<SharedData>) -> Option<Peripherals> {
+        critical_section::with(|cs| {
+            rcc::enable_with_cs::<peripherals::HSEM>(cs);
+        });
+
+        // Wait for the semaphore to be unlocked by the primary core
+        let mut hsem = HardwareSemaphoreChannel::<'_, peripherals::HSEM>::new(1);
+        hsem.blocking_listen();
+
         let shared_data = unsafe { shared_data.assume_init_ref() };
-
-        if shared_data.init_flag.load(Ordering::SeqCst) != INIT_DONE_FLAG {
-            return None;
-        }
-
-        // Separate load and store to support the CM0 of the STM32WL
-        shared_data.init_flag.store(0, Ordering::SeqCst);
 
         Some(init_secondary_hw(shared_data))
     }
@@ -519,7 +528,10 @@ mod dual_core {
                     config.gpdma_interrupt_priority,
                     #[cfg(mdma)]
                     config.mdma_interrupt_priority,
-                )
+                );
+
+                #[cfg(feature = "exti")]
+                exti::init(cs);
             }
 
             #[cfg(feature = "_time-driver")]

--- a/embassy-stm32/src/lib.rs
+++ b/embassy-stm32/src/lib.rs
@@ -397,7 +397,6 @@ mod dual_core {
     use core::cell::UnsafeCell;
     use core::mem::MaybeUninit;
 
-    use hsem::HardwareSemaphoreChannel;
     use rcc::Clocks;
 
     use super::*;
@@ -463,8 +462,7 @@ mod dual_core {
         rcc::set_rcc_config_ptr(shared_data.rcc_config.get());
         let p = init_hw(config);
 
-        let mut hsem = HardwareSemaphoreChannel::<'_, peripherals::HSEM>::new(1);
-        hsem.blocking_notify();
+        hsem::get_hsem(1).blocking_notify();
 
         p
     }
@@ -483,8 +481,7 @@ mod dual_core {
         });
 
         // Wait for the semaphore to be unlocked by the primary core
-        let mut hsem = HardwareSemaphoreChannel::<'_, peripherals::HSEM>::new(1);
-        hsem.blocking_listen();
+        hsem::get_hsem(1).blocking_listen();
 
         let shared_data = unsafe { shared_data.assume_init_ref() };
 


### PR DESCRIPTION
Adds HSEM functionality tested on H747 which was previously not functional due to interrupts never being enabled.

* Added async `fast_lock()` for 1-step fast locking between cores without using a process id
* Added `blocking_notify()` for simple 1-step inter core notification
* Added `blocking_listen()` to busy wait poll the interrupt flag for an HSEM channel
* Added async `listen()` to wait for a channel interrupt without taking the lock for inter core notifications
* Avoid resetting HSEM in RCC, as it results in race/deadlock when two cores are trying to initialize
* Use HSEM notifications in `init_primary()` and `init_secondary()` in place of `INIT_DONE_FLAG` which avoids d-cache coherency issues. H7 is not hardware cache coherent, and atomics don't behave well even in an MPU configured non-cacheable region (bus faults)