### PR TITLE
stm32: use exhaustive enum for refcounts

### DIFF
--- a/embassy-stm32/build.rs
+++ b/embassy-stm32/build.rs
@@ -774,7 +774,7 @@ fn main() {
         }
     }
 
-    let mut refcount_idxs = HashMap::new();
+    let mut refcount_idxs = BTreeSet::new();
 
     for p in METADATA.peripherals {
         if !singletons.contains(&p.name.to_string()) {
@@ -825,11 +825,10 @@ fn main() {
 
             let needs_refcount = *rcc_field_count.get(&(en_reg.register, en_reg.field)).unwrap() > 1;
             let refcount_idx = if needs_refcount {
-                let next_refcount_idx = refcount_idxs.len() as u8;
-                let refcount_idx = *refcount_idxs
-                    .entry((en_reg.register, en_reg.field))
-                    .or_insert(next_refcount_idx);
-                quote! { Some(#refcount_idx) }
+                let refcount_idx = format_ident!("{}_{}", en_reg.register, en_reg.field);
+                let quoted = quote! { Some(RefcountIndex::#refcount_idx) };
+                refcount_idxs.insert(refcount_idx);
+                quoted
             } else {
                 quote! { None }
             };
@@ -877,8 +876,17 @@ fn main() {
     g.extend({
         let refcounts_len = refcount_idxs.len();
         let refcount_zeros: TokenStream = refcount_idxs.iter().map(|_| quote! { 0u8, }).collect();
+        let repr = (!refcount_idxs.is_empty()).then(|| quote! { #[repr(u8)] });
+        let refcount_idxs = refcount_idxs.iter();
         quote! {
             pub(crate) static mut REFCOUNTS: [u8; #refcounts_len] = [#refcount_zeros];
+
+            #repr
+            #[allow(non_camel_case_types)]
+            #[derive(Clone, Copy)]
+            pub(crate) enum RefcountIndex {
+                #(#refcount_idxs),*
+            }
         }
     });
 

--- a/embassy-stm32/src/rcc/mod.rs
+++ b/embassy-stm32/src/rcc/mod.rs
@@ -38,6 +38,7 @@ mod _version;
 pub use _version::*;
 use stm32_metapac::RCC;
 
+use crate::_generated::RefcountIndex;
 pub use crate::_generated::{Clocks, mux};
 use crate::time::Hertz;
 
@@ -106,7 +107,7 @@ pub(crate) unsafe fn set_freqs(freqs: Clocks) {
 #[cfg(not(feature = "_dual-core"))]
 /// Safety: Reads a mutable global.
 pub(crate) unsafe fn get_freqs() -> &'static Clocks {
-    (*core::ptr::addr_of_mut!(CLOCK_FREQS)).assume_init_ref()
+    (*&raw const CLOCK_FREQS).assume_init_ref()
 }
 
 #[cfg(feature = "_dual-core")]
@@ -224,9 +225,8 @@ pub(crate) struct RccInfo {
     /// Position of the xxxEN bit within the xxxENR register (0..=31).
     enable_bit: u8,
     /// If this peripheral shares the same xxxRSTR bit and xxxEN bit with other peripherals, we
-    /// maintain a refcount in `crate::_generated::REFCOUNTS` at this index. If the bit is not
-    /// shared, this is 0xff (we don't use an `Option` to save one byte of storage).
-    refcount_idx_or_0xff: u8,
+    /// maintain a refcount in `crate::_generated::REFCOUNTS` at this index.
+    refcount_idx: Option<RefcountIndex>,
     /// Stop mode of the peripheral, used to maintain `REFCOUNT_STOP1` and `REFCOUNT_STOP2`.
     #[cfg(feature = "low-power")]
     stop_mode: StopMode,
@@ -270,12 +270,11 @@ impl RccInfo {
     /// Safety:
     /// - `reset_offset_and_bit`, if set, must correspond to valid xxxRST bit
     /// - `enable_offset_and_bit` must correspond to valid xxxEN bit
-    /// - `refcount_idx`, if set, must correspond to valid refcount in `_generated::REFCOUNTS`
     /// - `stop_mode` must be valid
     pub(crate) const unsafe fn new(
         reset_offset_and_bit: Option<(u8, u8)>,
         enable_offset_and_bit: (u8, u8),
-        refcount_idx: Option<u8>,
+        refcount_idx: Option<RefcountIndex>,
         #[cfg(feature = "low-power")] stop_mode: StopMode,
     ) -> Self {
         let (reset_offset_or_0xff, reset_bit) = match reset_offset_and_bit {
@@ -283,16 +282,12 @@ impl RccInfo {
             None => (0xff, 0xff),
         };
         let (enable_offset, enable_bit) = enable_offset_and_bit;
-        let refcount_idx_or_0xff = match refcount_idx {
-            Some(idx) => idx,
-            None => 0xff,
-        };
         Self {
             reset_offset_or_0xff,
             reset_bit,
             enable_offset,
             enable_bit,
-            refcount_idx_or_0xff,
+            refcount_idx,
             #[cfg(feature = "low-power")]
             stop_mode,
         }
@@ -300,21 +295,12 @@ impl RccInfo {
 
     // TODO: should this be `unsafe`?
     pub(crate) fn enable_and_reset_with_cs(&self, cs: CriticalSection) -> Result<(), ()> {
-        if self.refcount_idx_or_0xff != 0xff {
-            let refcount_idx = self.refcount_idx_or_0xff as usize;
-
-            // Use .get_mut instead of []-operator so that we control how bounds checks happen.
-            // Otherwise, core::fmt will be pulled in here in order to format the integer in the
-            // out-of-bounds error.
-            if let Some(refcount) =
-                unsafe { (*core::ptr::addr_of_mut!(crate::_generated::REFCOUNTS)).get_mut(refcount_idx) }
-            {
-                *refcount += 1;
-                if *refcount > 1 {
-                    return Err(());
-                }
-            } else {
-                panic!("refcount_idx out of bounds: {}", refcount_idx)
+        if let Some(refcount_idx) = self.refcount_idx {
+            let refcount_idx = refcount_idx as usize;
+            let refcount = unsafe { &mut (*&raw mut crate::_generated::REFCOUNTS)[refcount_idx] };
+            *refcount += 1;
+            if *refcount > 1 {
+                return Err(());
             }
         }
 
@@ -390,21 +376,12 @@ impl RccInfo {
 
     // TODO: should this be `unsafe`?
     pub(crate) fn disable_with_cs(&self, _cs: CriticalSection) -> Result<(), ()> {
-        if self.refcount_idx_or_0xff != 0xff {
-            let refcount_idx = self.refcount_idx_or_0xff as usize;
-
-            // Use .get_mut instead of []-operator so that we control how bounds checks happen.
-            // Otherwise, core::fmt will be pulled in here in order to format the integer in the
-            // out-of-bounds error.
-            if let Some(refcount) =
-                unsafe { (*core::ptr::addr_of_mut!(crate::_generated::REFCOUNTS)).get_mut(refcount_idx) }
-            {
-                *refcount -= 1;
-                if *refcount > 0 {
-                    return Err(());
-                }
-            } else {
-                panic!("refcount_idx out of bounds: {}", refcount_idx)
+        if let Some(refcount_idx) = self.refcount_idx {
+            let refcount_idx = refcount_idx as usize;
+            let refcount = unsafe { &mut (*&raw mut crate::_generated::REFCOUNTS)[refcount_idx] };
+            *refcount -= 1;
+            if *refcount > 0 {
+                return Err(());
             }
         }
 


### PR DESCRIPTION
This greatly simplifies the refcount-related code. Since
sizeof(Option<#[repr(u8)] enum>) == sizeof(u8), the code is
equivalent, but the compiler can optimize out bounds checks.