### PR TITLE
add `try_write_all` method to Pipe

### DIFF
--- a/embassy-sync/CHANGELOG.md
+++ b/embassy-sync/CHANGELOG.md
@@ -8,6 +8,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 <!-- next-header -->
 ## Unreleased - ReleaseDate
 
+- Added `Pipe::try_write_all` method which repeatedly calls `Pipe::try_write` until all
+  bytes were written.
+
 ## 0.8.0 - 2026-03-10
 - Fix wakers getting dropped by `Signal::reset`
 - Remove `Sized` trait bound from `MutexGuard::map`

--- a/embassy-sync/src/pipe.rs
+++ b/embassy-sync/src/pipe.rs
@@ -394,9 +394,24 @@ where
     ///
     /// This method will either write a nonzero amount of bytes to the pipe immediately,
     /// or return an error if the pipe is full. See [`write`](Self::write) for a variant
-    /// that waits instead of returning an error.
+    /// that waits instead of returning an error. This method might not write all the provided data
+    /// even if there is enough space in the pipe due to implementation details. See
+    /// [Self::try_write_all] for a method which ensures that all bytes are written unless
+    /// an overflow occurs.
     pub fn try_write(&self, buf: &[u8]) -> Result<usize, TryWriteError> {
         self.try_write_with_context(None, buf)
+    }
+
+    /// Attempt to immediately write all provided bytes into the pipe.
+    ///
+    /// This method will try to write all bytes of the buffer into the pipe immediately,
+    /// or return an error if the pipe is full.
+    pub fn try_write_all(&self, mut buf: &[u8]) -> Result<(), TryWriteError> {
+        while !buf.is_empty() {
+            let n = self.try_write(buf)?;
+            buf = &buf[n..];
+        }
+        Ok(())
     }
 
     /// Read some bytes from the pipe.
@@ -811,6 +826,48 @@ mod tests {
     }
 
     #[test]
+    fn write_read_across_rollover() {
+        let c = Pipe::<NoopRawMutex, 3>::new();
+        assert_eq!(c.try_write(&[1, 2]).unwrap(), 2);
+        assert_eq!(c.free_capacity(), 1);
+        let mut buf = [0; 1];
+        c.try_read(&mut buf).expect("trying to read pipe failed");
+        assert_eq!(buf, [1]);
+        assert_eq!(c.free_capacity(), 2);
+        // Write across rollover, only one byte is written.
+        assert_eq!(c.try_write(&[3, 4]).unwrap(), 1);
+        assert_eq!(c.free_capacity(), 1);
+        // Write remaining byte.
+        assert_eq!(c.try_write(&[4]).unwrap(), 1);
+        assert_eq!(c.free_capacity(), 0);
+        let mut buf = [0; 3];
+        // Read across rollover, only two bytes are read.
+        assert_eq!(c.try_read(&mut buf).expect("trying to read pipe failed"), 2);
+        assert_eq!(buf, [2, 3, 0]);
+        assert_eq!(c.free_capacity(), 2);
+        // Read remaining byte.
+        assert_eq!(c.try_read(&mut buf).expect("trying to read pipe failed"), 1);
+        assert_eq!(buf[0], 4);
+        assert_eq!(c.free_capacity(), 3);
+    }
+
+    #[test]
+    fn write_all_across_rollover() {
+        let c = Pipe::<NoopRawMutex, 6>::new();
+        assert_eq!(c.try_write(&[1, 2, 3, 4, 5]).unwrap(), 5);
+        assert_eq!(c.free_capacity(), 1);
+        let mut buf = [0; 3];
+        c.try_read(&mut buf).expect("trying to read pipe failed");
+        assert_eq!(buf, [1, 2, 3]);
+        assert_eq!(c.free_capacity(), 4);
+        assert!(c.try_write_all(&[6, 7, 8]).is_ok());
+        assert_eq!(c.free_capacity(), 1);
+        c.try_read(&mut buf).expect("trying to read pipe failed");
+        assert_eq!(buf, [4, 5, 6]);
+        assert_eq!(c.free_capacity(), 4);
+    }
+
+    #[test]
     fn receiving_once_with_one_send() {
         let c = Pipe::<NoopRawMutex, 3>::new();
         assert!(c.try_write(&[42]).is_ok());
@@ -868,6 +925,7 @@ mod tests {
     fn writer_is_cloneable() {
         let mut c = Pipe::<NoopRawMutex, 3>::new();
         let (_r, w) = c.split();
+        #[allow(clippy::clone_on_copy)]
         let _ = w.clone();
     }
 


### PR DESCRIPTION
My colleague stumbled upon this after I stumbled on this a few months ago and spent quite a few hours debugging this.
`try_write` might not write all the bytes due to implementation details, even if the pipe has more than enough space.

What do you think about adding some docs and an additional helper method?