### PR TITLE
stm32: replace without_stop with wakeguard

### DIFF
--- a/embassy-stm32/src/adc/adc4.rs
+++ b/embassy-stm32/src/adc/adc4.rs
@@ -360,7 +360,7 @@ impl AdcRegs for crate::pac::adc::Adc4 {
 impl<'d, T: Instance<Regs = crate::pac::adc::Adc4>> super::Adc<'d, T> {
     /// Create a new ADC driver.
     pub fn new_adc4(adc: Peri<'d, T>) -> Self {
-        rcc::enable_and_reset_without_stop::<T>();
+        rcc::enable_and_reset::<T>();
         let prescaler = from_ker_ck(T::frequency());
 
         T::regs().ccr().modify(|w| w.set_presc(prescaler));

--- a/embassy-stm32/src/adc/c0.rs
+++ b/embassy-stm32/src/adc/c0.rs
@@ -192,7 +192,7 @@ impl AdcRegs for crate::pac::adc::Adc {
 impl<'d, T: Instance<Regs = crate::pac::adc::Adc>> Adc<'d, T> {
     /// Create a new ADC driver.
     pub fn new(adc: Peri<'d, T>, resolution: Resolution) -> Self {
-        rcc::enable_and_reset_without_stop::<T>();
+        rcc::enable_and_reset::<T>();
 
         T::regs().cfgr2().modify(|w| w.set_ckmode(Ckmode::SYSCLK));
 

--- a/embassy-stm32/src/adc/g4.rs
+++ b/embassy-stm32/src/adc/g4.rs
@@ -278,7 +278,7 @@ impl SealedInjectedAdcRegs for crate::pac::adc::Adc {
 impl<'d, T: DefaultInstance> Adc<'d, T> {
     /// Create a new ADC driver.
     pub fn new(adc: Peri<'d, T>, config: AdcConfig) -> Self {
-        rcc::enable_and_reset_without_stop::<T>();
+        rcc::enable_and_reset::<T>();
 
         let prescaler = from_ker_ck(T::frequency());
 

--- a/embassy-stm32/src/adc/ringbuffered.rs
+++ b/embassy-stm32/src/adc/ringbuffered.rs
@@ -10,7 +10,7 @@ use crate::adc::{Instance, RxDma};
 use crate::dma::Channel;
 #[allow(unused_imports)]
 use crate::dma::{ReadableRingBuffer, TransferOptions};
-use crate::rcc::WakeGuard;
+use crate::rcc::{self, WakeGuard};
 
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub struct OverrunError;
@@ -219,6 +219,6 @@ impl<T: Instance> Drop for RingBufferedAdc<'_, T> {
         compiler_fence(Ordering::SeqCst);
 
         self.ring_buf.request_pause();
-        T::RCC_INFO.disable_without_stop();
+        rcc::disable::<T>();
     }
 }

--- a/embassy-stm32/src/adc/v1.rs
+++ b/embassy-stm32/src/adc/v1.rs
@@ -66,7 +66,7 @@ impl<'d, T: Instance> Adc<'d, T> {
         adc: Peri<'d, T>,
         _irq: impl interrupt::typelevel::Binding<T::Interrupt, InterruptHandler<T>> + 'd,
     ) -> Self {
-        rcc::enable_and_reset_without_stop::<T>();
+        rcc::enable_and_reset::<T>();
 
         // Delay 1μs when using HSI14 as the ADC clock.
         //
@@ -264,6 +264,6 @@ impl<'d, T: Instance> Drop for Adc<'d, T> {
         Self::teardown_adc();
         Self::teardown_awd();
 
-        <T as crate::rcc::SealedRccPeripheral>::RCC_INFO.disable_without_stop();
+        <T as crate::rcc::SealedRccPeripheral>::RCC_INFO.disable();
     }
 }

--- a/embassy-stm32/src/adc/v2.rs
+++ b/embassy-stm32/src/adc/v2.rs
@@ -304,7 +304,7 @@ impl<'d, T: DefaultInstance> Adc<'d, T> {
     }
 
     pub fn new_with_config(adc: Peri<'d, T>, config: AdcConfig) -> Self {
-        rcc::enable_and_reset_without_stop::<T>();
+        rcc::enable_and_reset::<T>();
 
         let presc = from_pclk2(T::frequency());
         T::common_regs().ccr().modify(|w| w.set_adcpre(presc));

--- a/embassy-stm32/src/adc/v3.rs
+++ b/embassy-stm32/src/adc/v3.rs
@@ -423,7 +423,7 @@ impl super::AdcRegs for crate::pac::adc::Adc {
 impl<'d, T: Instance<Regs = crate::pac::adc::Adc>> Adc<'d, T> {
     /// Enable the voltage regulator
     fn init_regulator() {
-        rcc::enable_and_reset_without_stop::<T>();
+        rcc::enable_and_reset::<T>();
         T::regs().cr().modify(|reg| {
             #[cfg(not(any(adc_g0, adc_u0)))]
             reg.set_deeppwd(false);
@@ -693,6 +693,6 @@ impl<'d, T: Instance<Regs = crate::pac::adc::Adc>> Adc<'d, T> {
 impl<'d, T: Instance> Drop for Adc<'d, T> {
     fn drop(&mut self) {
         super::AdcRegs::stop(&T::regs());
-        <T as crate::rcc::SealedRccPeripheral>::RCC_INFO.disable_without_stop();
+        <T as crate::rcc::SealedRccPeripheral>::RCC_INFO.disable();
     }
 }

--- a/embassy-stm32/src/adc/v4.rs
+++ b/embassy-stm32/src/adc/v4.rs
@@ -257,7 +257,7 @@ impl<'d, T: Instance<Regs = crate::pac::adc::Adc>> Adc<'d, T> {
 
     /// Create a new ADC driver.
     pub fn new(adc: Peri<'d, T>) -> Self {
-        rcc::enable_and_reset_without_stop::<T>();
+        rcc::enable_and_reset::<T>();
 
         #[cfg(not(stm32u3))]
         let prescaler = from_ker_ck(T::frequency());

--- a/embassy-stm32/src/can/fdcan.rs
+++ b/embassy-stm32/src/can/fdcan.rs
@@ -12,7 +12,7 @@ use embassy_sync::waitqueue::AtomicWaker;
 use crate::can::fd::peripheral::Registers;
 use crate::gpio::{AfType, OutputType, Pull, SealedPin as _, Speed};
 use crate::interrupt::typelevel::Interrupt;
-use crate::rcc::{self, RccInfo, RccPeripheral, SealedRccPeripheral};
+use crate::rcc::{self, RccInfo, RccPeripheral, SealedRccPeripheral, WakeGuard};
 use crate::{Peri, interrupt, peripherals};
 
 pub(crate) mod fd;
@@ -278,6 +278,7 @@ impl<'d> CanConfigurator<'d> {
             _phantom: PhantomData,
             config: self.config,
             _mode: mode,
+            _wake_guard: self.info.rcc_info.wake_guard(),
             properties: Properties::new(&self.info),
             info: InfoRef::new(&self.info),
         }
@@ -304,6 +305,7 @@ pub struct Can<'d> {
     _phantom: PhantomData<&'d ()>,
     config: crate::can::fd::config::FdCanConfig,
     _mode: OperatingMode,
+    _wake_guard: WakeGuard,
     properties: Properties,
     info: InfoRef,
 }
@@ -367,11 +369,13 @@ impl<'d> Can<'d> {
                 _phantom: PhantomData,
                 config: self.config,
                 _mode: self._mode,
+                _wake_guard: self.info.rcc_info.wake_guard(),
                 info: TxInfoRef::new(&self.info),
             },
             CanRx {
                 _phantom: PhantomData,
                 _mode: self._mode,
+                _wake_guard: self.info.rcc_info.wake_guard(),
                 info: RxInfoRef::new(&self.info),
             },
             Properties {
@@ -385,6 +389,7 @@ impl<'d> Can<'d> {
             _phantom: PhantomData,
             config: tx.config,
             _mode: rx._mode,
+            _wake_guard: tx.info.rcc_info.wake_guard(),
             properties: Properties::new(&tx.info),
             info: InfoRef::new(&tx.info),
         }
@@ -430,6 +435,7 @@ pub type TxBuf<const BUF_SIZE: usize> = Channel<CriticalSectionRawMutex, Frame, 
 pub struct BufferedCan<'d, const TX_BUF_SIZE: usize, const RX_BUF_SIZE: usize> {
     _phantom: PhantomData<&'d ()>,
     _mode: OperatingMode,
+    _wake_guard: WakeGuard,
     tx_buf: &'static TxBuf<TX_BUF_SIZE>,
     rx_buf: &'static RxBuf<RX_BUF_SIZE>,
     properties: Properties,
@@ -446,6 +452,7 @@ impl<'c, 'd, const TX_BUF_SIZE: usize, const RX_BUF_SIZE: usize> BufferedCan<'d,
         BufferedCan {
             _phantom: PhantomData,
             _mode,
+            _wake_guard: info.rcc_info.wake_guard(),
             tx_buf,
             rx_buf,
             properties: Properties::new(info),
@@ -519,6 +526,7 @@ pub type BufferedFdCanReceiver = super::common::BufferedReceiver<'static, FdEnve
 pub struct BufferedCanFd<'d, const TX_BUF_SIZE: usize, const RX_BUF_SIZE: usize> {
     _phantom: PhantomData<&'d ()>,
     _mode: OperatingMode,
+    _wake_guard: WakeGuard,
     tx_buf: &'static TxFdBuf<TX_BUF_SIZE>,
     rx_buf: &'static RxFdBuf<RX_BUF_SIZE>,
     properties: Properties,
@@ -535,6 +543,7 @@ impl<'c, 'd, const TX_BUF_SIZE: usize, const RX_BUF_SIZE: usize> BufferedCanFd<'
         BufferedCanFd {
             _phantom: PhantomData,
             _mode,
+            _wake_guard: info.rcc_info.wake_guard(),
             tx_buf,
             rx_buf,
             properties: Properties::new(info),
@@ -596,6 +605,7 @@ impl<'c, 'd, const TX_BUF_SIZE: usize, const RX_BUF_SIZE: usize> BufferedCanFd<'
 pub struct CanRx<'d> {
     _phantom: PhantomData<&'d ()>,
     _mode: OperatingMode,
+    _wake_guard: WakeGuard,
     info: RxInfoRef,
 }
 
@@ -616,6 +626,7 @@ pub struct CanTx<'d> {
     _phantom: PhantomData<&'d ()>,
     config: crate::can::fd::config::FdCanConfig,
     _mode: OperatingMode,
+    _wake_guard: WakeGuard,
     info: TxInfoRef,
 }
 

--- a/embassy-stm32/src/eth/v2/mod.rs
+++ b/embassy-stm32/src/eth/v2/mod.rs
@@ -11,6 +11,7 @@ use crate::gpio::{AfType, Flex, OutputType, Speed};
 use crate::interrupt;
 use crate::interrupt::InterruptExt;
 use crate::pac::ETH;
+use crate::rcc::WakeGuard;
 
 /// Interrupt handler.
 pub struct InterruptHandler {}
@@ -36,6 +37,7 @@ impl interrupt::typelevel::Handler<interrupt::typelevel::ETH> for InterruptHandl
 /// Ethernet driver.
 pub struct Ethernet<'d, T: Instance, P: Phy> {
     _peri: Peri<'d, T>,
+    _wake_guard: WakeGuard,
     pub(crate) tx: TDesRing<'d>,
     pub(crate) rx: RDesRing<'d>,
     _pins: Pins<'d>,
@@ -288,6 +290,7 @@ impl<'d, T: Instance, P: Phy> Ethernet<'d, T, P> {
 
         let mut this = Self {
             _peri: peri,
+            _wake_guard: T::RCC_INFO.wake_guard(),
             tx: TDesRing::new(&mut queue.tx_desc, &mut queue.tx_buf),
             rx: RDesRing::new(&mut queue.rx_desc, &mut queue.rx_buf),
             _pins: pins,

--- a/embassy-stm32/src/i2c/mod.rs
+++ b/embassy-stm32/src/i2c/mod.rs
@@ -122,7 +122,7 @@ struct I2CDropGuard<'d> {
 }
 impl<'d> Drop for I2CDropGuard<'d> {
     fn drop(&mut self) {
-        self.info.rcc.disable_without_stop();
+        self.info.rcc.disable();
     }
 }
 
@@ -221,7 +221,7 @@ impl<'d, M: Mode> I2c<'d, M, Master> {
     }
 
     fn enable_and_init(&mut self, config: Config) {
-        self.info.rcc.enable_and_reset_without_stop();
+        self.info.rcc.enable_and_reset();
         self.init(config);
     }
 }

--- a/embassy-stm32/src/ipcc.rs
+++ b/embassy-stm32/src/ipcc.rs
@@ -303,7 +303,7 @@ impl Ipcc {
         + 'd,
         _config: Config,
     ) -> Self {
-        rcc::enable_and_reset_without_stop::<IPCC>();
+        rcc::enable_and_reset::<IPCC>();
         IPCC::set_cpu2(_config.c2_boot);
 
         Self::init(_config);
@@ -325,7 +325,7 @@ impl Ipcc {
         _irq: impl interrupt::typelevel::Binding<interrupt::typelevel::IPCC_C2_RX_C2_TX, InterruptHandler> + 'd,
         _config: Config,
     ) -> Self {
-        rcc::enable_and_reset_without_stop::<IPCC>();
+        rcc::enable_and_reset::<IPCC>();
 
         Self::init(_config);
 

--- a/embassy-stm32/src/qspi/mod.rs
+++ b/embassy-stm32/src/qspi/mod.rs
@@ -126,7 +126,7 @@ impl<'d, T: Instance, M: PeriMode> Qspi<'d, T, M> {
         config: Config,
         fsel: FlashSelection,
     ) -> Self {
-        rcc::enable_and_reset_without_stop::<T>();
+        rcc::enable_and_reset::<T>();
 
         while T::REGS.sr().read().busy() {}
 

--- a/embassy-stm32/src/rcc/mod.rs
+++ b/embassy-stm32/src/rcc/mod.rs
@@ -299,7 +299,7 @@ impl RccInfo {
     }
 
     // TODO: should this be `unsafe`?
-    pub(crate) fn enable_and_reset_with_cs(&self, cs: CriticalSection) {
+    pub(crate) fn enable_and_reset_with_cs(&self, cs: CriticalSection) -> Result<(), ()> {
         if self.refcount_idx_or_0xff != 0xff {
             let refcount_idx = self.refcount_idx_or_0xff as usize;
 
@@ -311,7 +311,7 @@ impl RccInfo {
             {
                 *refcount += 1;
                 if *refcount > 1 {
-                    return;
+                    return Err(());
                 }
             } else {
                 panic!("refcount_idx out of bounds: {}", refcount_idx)
@@ -344,6 +344,8 @@ impl RccInfo {
         }
 
         self.enable_with_cs(cs);
+
+        Ok(())
     }
 
     // TODO: should this be `unsafe`?
@@ -387,7 +389,7 @@ impl RccInfo {
     }
 
     // TODO: should this be `unsafe`?
-    pub(crate) fn disable_with_cs(&self, _cs: CriticalSection) {
+    pub(crate) fn disable_with_cs(&self, _cs: CriticalSection) -> Result<(), ()> {
         if self.refcount_idx_or_0xff != 0xff {
             let refcount_idx = self.refcount_idx_or_0xff as usize;
 
@@ -399,7 +401,7 @@ impl RccInfo {
             {
                 *refcount -= 1;
                 if *refcount > 0 {
-                    return;
+                    return Err(());
                 }
             } else {
                 panic!("refcount_idx out of bounds: {}", refcount_idx)
@@ -423,12 +425,8 @@ impl RccInfo {
             }
             trace!("rcc: disabled 0x{:x}:{}", self.enable_offset, self.enable_bit);
         }
-    }
 
-    #[allow(dead_code)]
-    pub(crate) fn increment_stop_refcount_with_cs(&self, _cs: CriticalSection) {
-        #[cfg(feature = "low-power")]
-        increment_stop_refcount(_cs, self.stop_mode);
+        Ok(())
     }
 
     #[allow(dead_code)]
@@ -441,18 +439,6 @@ impl RccInfo {
     }
 
     #[allow(dead_code)]
-    pub(crate) fn increment_stop_refcount(&self) {
-        #[cfg(feature = "low-power")]
-        critical_section::with(|cs| self.increment_stop_refcount_with_cs(cs))
-    }
-
-    #[allow(dead_code)]
-    pub(crate) fn decrement_stop_refcount_with_cs(&self, _cs: CriticalSection) {
-        #[cfg(feature = "low-power")]
-        decrement_stop_refcount(_cs, self.stop_mode);
-    }
-
-    #[allow(dead_code)]
     fn decrement_minimum_stop_refcount_with_cs(&self, _cs: CriticalSection) {
         #[cfg(all(any(stm32wl, stm32wb), feature = "low-power"))]
         match self.stop_mode {
@@ -461,43 +447,24 @@ impl RccInfo {
         }
     }
 
-    #[allow(dead_code)]
-    pub(crate) fn decrement_stop_refcount(&self) {
-        #[cfg(feature = "low-power")]
-        critical_section::with(|cs| self.decrement_stop_refcount_with_cs(cs))
-    }
-
     // TODO: should this be `unsafe`?
     pub(crate) fn enable_and_reset(&self) {
-        critical_section::with(|cs| {
-            self.enable_and_reset_with_cs(cs);
-            self.increment_stop_refcount_with_cs(cs);
-        })
-    }
-
-    #[allow(dead_code)]
-    pub(crate) fn enable_and_reset_without_stop(&self) {
-        critical_section::with(|cs| {
-            self.enable_and_reset_with_cs(cs);
+        let _: Result<(), ()> = critical_section::with(|cs| {
+            self.enable_and_reset_with_cs(cs)?;
             self.increment_minimum_stop_refcount_with_cs(cs);
-        })
+
+            Ok(())
+        });
     }
 
     // TODO: should this be `unsafe`?
     pub(crate) fn disable(&self) {
-        critical_section::with(|cs| {
-            self.disable_with_cs(cs);
-            self.decrement_stop_refcount_with_cs(cs);
-        })
-    }
-
-    // TODO: should this be `unsafe`?
-    #[allow(dead_code)]
-    pub(crate) fn disable_without_stop(&self) {
-        critical_section::with(|cs| {
-            self.disable_with_cs(cs);
+        let _: Result<(), ()> = critical_section::with(|cs| {
+            self.disable_with_cs(cs)?;
             self.decrement_minimum_stop_refcount_with_cs(cs);
-        })
+
+            Ok(())
+        });
     }
 
     #[allow(dead_code)]
@@ -600,7 +567,7 @@ pub fn frequency<T: RccPeripheral>() -> Hertz {
 /// Peripheral must not be in use.
 // TODO: should this be `unsafe`?
 pub fn enable_and_reset_with_cs<T: RccPeripheral>(cs: CriticalSection) {
-    T::RCC_INFO.enable_and_reset_with_cs(cs);
+    let _ = T::RCC_INFO.enable_and_reset_with_cs(cs);
 }
 
 /// Enables and clears the reset for peripheral `T`.
@@ -619,7 +586,7 @@ pub fn enable_with_cs<T: RccPeripheral>(cs: CriticalSection) {
 /// Peripheral must not be in use.
 // TODO: should this be `unsafe`?
 pub fn disable_with_cs<T: RccPeripheral>(cs: CriticalSection) {
-    T::RCC_INFO.disable_with_cs(cs);
+    let _ = T::RCC_INFO.disable_with_cs(cs);
 }
 
 /// Enables and resets peripheral `T`.
@@ -630,16 +597,6 @@ pub fn disable_with_cs<T: RccPeripheral>(cs: CriticalSection) {
 // TODO: should this be `unsafe`?
 pub fn enable_and_reset<T: RccPeripheral>() {
     T::RCC_INFO.enable_and_reset();
-}
-
-/// Enables and resets peripheral `T` without incrementing the stop refcount.
-///
-/// # Safety
-///
-/// Peripheral must not be in use.
-// TODO: should this be `unsafe`?
-pub fn enable_and_reset_without_stop<T: RccPeripheral>() {
-    T::RCC_INFO.enable_and_reset_without_stop();
 }
 
 /// Disables peripheral `T`.

--- a/embassy-stm32/src/sdmmc/mod.rs
+++ b/embassy-stm32/src/sdmmc/mod.rs
@@ -672,7 +672,7 @@ impl<'d> Sdmmc<'d> {
         d7: Option<Flex<'d>>,
         config: Config,
     ) -> Self {
-        rcc::enable_and_reset_without_stop::<T>();
+        rcc::enable_and_reset::<T>();
 
         T::Interrupt::unpend();
         unsafe { T::Interrupt::enable() };
@@ -1154,7 +1154,7 @@ impl<'d> Drop for Sdmmc<'d> {
     fn drop(&mut self) {
         // T::Interrupt::disable();
         self.on_drop();
-        self.info.rcc.disable_without_stop();
+        self.info.rcc.disable();
     }
 }
 

--- a/embassy-stm32/src/spi/mod.rs
+++ b/embassy-stm32/src/spi/mod.rs
@@ -253,7 +253,7 @@ impl<'d, M: PeriMode, CM: CommunicationMode> Spi<'d, M, CM> {
         let cpol = config.raw_polarity();
         let lsbfirst = config.raw_byte_order();
 
-        self.info.rcc.enable_and_reset_without_stop();
+        self.info.rcc.enable_and_reset();
 
         /*
         - Software NSS management (SSM = 1)
@@ -1192,7 +1192,7 @@ impl<'d, CM: CommunicationMode> Spi<'d, Async, CM> {
 
 impl<'d, M: PeriMode, CM: CommunicationMode> Drop for Spi<'d, M, CM> {
     fn drop(&mut self) {
-        self.info.rcc.disable_without_stop();
+        self.info.rcc.disable();
     }
 }
 

--- a/embassy-stm32/src/time_driver/lptim.rs
+++ b/embassy-stm32/src/time_driver/lptim.rs
@@ -61,7 +61,7 @@ impl RtcDriver {
         let r = regs_lptim();
 
         // we want this to increment the stop mode counter (some lp timer can't do STOP2)
-        rcc::enable_and_reset_without_stop::<T>();
+        rcc::enable_and_reset::<T>();
 
         let timer_freq = T::frequency();
 

--- a/embassy-stm32/src/usart/mod.rs
+++ b/embassy-stm32/src/usart/mod.rs
@@ -575,7 +575,7 @@ impl<'d, M: Mode> UartTx<'d, M> {
         let state = self.state;
         state.tx_rx_refcount.store(1, Ordering::Relaxed);
 
-        info.rcc.enable_and_reset_without_stop();
+        info.rcc.enable_and_reset();
 
         info.regs.cr3().modify(|w| {
             w.set_ctse(self.cts.is_some());
@@ -1018,7 +1018,7 @@ impl<'d, M: Mode> UartRx<'d, M> {
             .eager_reads
             .store(config.eager_reads.unwrap_or(0), Ordering::Relaxed);
 
-        info.rcc.enable_and_reset_without_stop();
+        info.rcc.enable_and_reset();
 
         info.regs.cr3().write(|w| {
             w.set_rtse(self.rts.is_some());
@@ -1152,7 +1152,7 @@ fn drop_tx_rx(info: &Info, state: &State) {
         refcount == 1
     });
     if is_last_drop {
-        info.rcc.disable_without_stop();
+        info.rcc.disable();
     }
 }
 
@@ -1530,7 +1530,7 @@ impl<'d, M: Mode> Uart<'d, M> {
             .eager_reads
             .store(config.eager_reads.unwrap_or(0), Ordering::Relaxed);
 
-        info.rcc.enable_and_reset_without_stop();
+        info.rcc.enable_and_reset();
 
         info.regs.cr3().write(|w| {
             w.set_rtse(self.rx.rts.is_some());

--- a/embassy-stm32/src/usart/ringbuffered.rs
+++ b/embassy-stm32/src/usart/ringbuffered.rs
@@ -13,6 +13,7 @@ use super::{
 use crate::dma::ReadableRingBuffer;
 use crate::gpio::Flex;
 use crate::mode::Async;
+use crate::rcc::WakeGuard;
 use crate::time::Hertz;
 use crate::usart::Regs;
 
@@ -81,6 +82,7 @@ pub struct RingBufferedUartRx<'d> {
     info: &'static Info,
     state: &'static State,
     kernel_clock: Hertz,
+    _wake_guard: WakeGuard,
     _rx: Option<Flex<'d>>,
     _rts: Option<Flex<'d>>,
     ring_buf: ReadableRingBuffer<'d, u8>,
@@ -116,7 +118,7 @@ impl<'d> UartRx<'d, Async> {
         let rx = unsafe { self.rx.as_ref().map(|x| x.clone_unchecked()) };
         let rts = unsafe { self.rts.as_ref().map(|x| x.clone_unchecked()) };
 
-        info.rcc.increment_stop_refcount();
+        let wake_guard = self.info.rcc.wake_guard();
 
         // Don't disable the clock
         mem::forget(self);
@@ -125,6 +127,7 @@ impl<'d> UartRx<'d, Async> {
             info,
             state,
             kernel_clock,
+            _wake_guard: wake_guard,
             _rx: rx,
             _rts: rts,
             ring_buf,
@@ -325,7 +328,6 @@ impl<'d> RingBufferedUartRx<'d> {
 
 impl Drop for RingBufferedUartRx<'_> {
     fn drop(&mut self) {
-        self.info.rcc.decrement_stop_refcount();
         self.stop_uart();
         super::drop_tx_rx(self.info, self.state);
     }


### PR DESCRIPTION
`WakeGuard` can be added to future peripherals to keep them out of stop and can be grabbed by user code in the mean time as a workaround.