### PR TITLE
stm32/adc: more cleanup

### DIFF
--- a/embassy-stm32/src/adc/adc4.rs
+++ b/embassy-stm32/src/adc/adc4.rs
@@ -123,23 +123,23 @@ impl Calibration {
     }
 }
 
-impl super::SealedSpecialConverter<super::VrefInt> for crate::peripherals::ADC4 {
+impl super::ConverterFor<super::VrefInt> for crate::peripherals::ADC4 {
     const CHANNEL: u8 = 0;
 }
 
-impl super::SealedSpecialConverter<super::Temperature> for crate::peripherals::ADC4 {
+impl super::ConverterFor<super::Temperature> for crate::peripherals::ADC4 {
     const CHANNEL: u8 = 13;
 }
 
-impl super::SealedSpecialConverter<super::Vcore> for crate::peripherals::ADC4 {
+impl super::ConverterFor<super::Vcore> for crate::peripherals::ADC4 {
     const CHANNEL: u8 = 12;
 }
 
-impl super::SealedSpecialConverter<super::Vbat> for crate::peripherals::ADC4 {
+impl super::ConverterFor<super::Vbat> for crate::peripherals::ADC4 {
     const CHANNEL: u8 = 14;
 }
 
-impl super::SealedSpecialConverter<super::Dac> for crate::peripherals::ADC4 {
+impl super::ConverterFor<super::Dac> for crate::peripherals::ADC4 {
     const CHANNEL: u8 = 21;
 }
 

--- a/embassy-stm32/src/adc/c0.rs
+++ b/embassy-stm32/src/adc/c0.rs
@@ -18,11 +18,11 @@ const CHSELR_SQ_SIZE: usize = 8;
 const CHSELR_SQ_MAX_CHANNEL: u8 = 14;
 const CHSELR_SQ_SEQUENCE_END_MARKER: u8 = 0b1111;
 
-impl<T: Instance> super::SealedSpecialConverter<super::VrefInt> for T {
+impl<T: Instance> super::ConverterFor<super::VrefInt> for T {
     const CHANNEL: u8 = 10;
 }
 
-impl<T: Instance> super::SealedSpecialConverter<super::Temperature> for T {
+impl<T: Instance> super::ConverterFor<super::Temperature> for T {
     const CHANNEL: u8 = 9;
 }
 

--- a/embassy-stm32/src/adc/configured_sequence.rs
+++ b/embassy-stm32/src/adc/configured_sequence.rs
@@ -4,6 +4,8 @@ use embassy_hal_internal::Peri;
 
 use super::AdcRegs;
 use crate::adc::{Instance, RxDma};
+use crate::dma::Channel;
+use crate::rcc::RccInfo;
 
 /// An ADC with a pre-configured channel sequence for repeated DMA reads.
 ///
@@ -13,15 +15,30 @@ use crate::adc::{Instance, RxDma};
 /// overhead of reprogramming the sequence registers.
 ///
 /// Obtain via [`Adc::configured_sequence`].
-pub struct ConfiguredSequence<'adc, 'd, T: Instance, D: RxDma<T>> {
-    _adc: &'adc mut super::Adc<'d, T>,
-    rx_dma: Peri<'adc, D>,
-    buf: &'adc mut [u16],
+#[allow(private_bounds)]
+pub struct ConfiguredSequence<'adc, R: AdcRegs> {
+    regs: R,
+    info: RccInfo,
+    len: usize,
+    request: u8,
+    channel: Channel<'adc>,
 }
 
-impl<'adc, 'd, T: Instance, D: RxDma<T>> ConfiguredSequence<'adc, 'd, T, D> {
-    pub(crate) fn new(adc: &'adc mut super::Adc<'d, T>, rx_dma: Peri<'adc, D>, buf: &'adc mut [u16]) -> Self {
-        Self { _adc: adc, rx_dma, buf }
+#[allow(private_bounds)]
+impl<'adc, R: AdcRegs> ConfiguredSequence<'adc, R> {
+    pub(crate) fn new<'d, T: Instance<Regs = R>, D: RxDma<T>>(
+        _adc: &'adc mut super::Adc<'d, T>,
+        rx_dma: Peri<'adc, D>,
+        len: usize,
+        irq: impl crate::interrupt::typelevel::Binding<D::Interrupt, crate::dma::InterruptHandler<D>> + 'adc,
+    ) -> Self {
+        Self {
+            regs: T::regs(),
+            info: T::RCC_INFO,
+            len,
+            request: rx_dma.request(),
+            channel: Channel::new(rx_dma, irq),
+        }
     }
 
     /// Trigger one DMA conversion of the pre-configured channel sequence and
@@ -34,26 +51,27 @@ impl<'adc, 'd, T: Instance, D: RxDma<T>> ConfiguredSequence<'adc, 'd, T, D> {
     /// [`Adc::configured_sequence`]. The hardware is configured so that
     /// DMA stays armed between calls while the ADC runs only one sequence per
     /// [`start`](AdcRegs::start) call.
-    pub async fn read(
-        &mut self,
-        irq: impl crate::interrupt::typelevel::Binding<D::Interrupt, crate::dma::InterruptHandler<D>>,
-    ) -> &[u16] {
-        let _scoped_wake_guard = <T as crate::rcc::SealedRccPeripheral>::RCC_INFO.wake_guard();
+    pub async fn read(&mut self, buf: &mut [u16]) {
+        let _scoped_wake_guard = self.info.wake_guard();
 
-        let request = self.rx_dma.request();
-        let mut dma_channel = crate::dma::Channel::new(self.rx_dma.reborrow(), irq);
-        let transfer = unsafe { dma_channel.read(request, T::regs().data(), self.buf, Default::default()) };
+        assert!(
+            buf.len() >= self.len,
+            "Buffer must have at least as many entries as the sequence"
+        );
 
-        T::regs().start();
+        let transfer = unsafe {
+            self.channel
+                .read(self.request, self.regs.data(), buf, Default::default())
+        };
+
+        self.regs.start();
         transfer.await;
-
-        &self.buf[..]
     }
 }
 
-impl<T: Instance, D: RxDma<T>> Drop for ConfiguredSequence<'_, '_, T, D> {
+impl<R: AdcRegs> Drop for ConfiguredSequence<'_, R> {
     fn drop(&mut self) {
-        T::regs().stop(false);
+        self.regs.stop(false);
         compiler_fence(Ordering::SeqCst);
     }
 }

--- a/embassy-stm32/src/adc/f1.rs
+++ b/embassy-stm32/src/adc/f1.rs
@@ -1,6 +1,6 @@
 use core::marker::PhantomData;
 
-use stm32_metapac::adc::regs::{Sqr1, Sqr2, Sqr3};
+use stm32_metapac::adc::regs::{Smpr1, Smpr2, Sqr1, Sqr2, Sqr3};
 
 use super::blocking_delay_us;
 use crate::adc::{Adc, AdcRegs, ConversionMode, DefaultInstance, Instance, SampleTime, VrefInt};
@@ -28,11 +28,11 @@ impl<T: DefaultInstance> interrupt::typelevel::Handler<T::Interrupt> for Interru
     }
 }
 
-impl<T: Instance> super::SealedSpecialConverter<VrefInt> for T {
+impl<T: Instance> super::ConverterFor<VrefInt> for T {
     const CHANNEL: u8 = 17;
 }
 
-impl<T: Instance> super::SealedSpecialConverter<super::Temperature> for T {
+impl<T: Instance> super::ConverterFor<super::Temperature> for T {
     const CHANNEL: u8 = 16;
 }
 
@@ -110,8 +110,8 @@ impl AdcRegs for crate::pac::adc::Adc {
         let mut sqr2 = Sqr2::default();
         let mut sqr3 = Sqr3::default();
 
-        let mut smpr1 = self.smpr1().read();
-        let mut smpr2 = self.smpr2().read();
+        let mut smpr1 = Smpr1::default();
+        let mut smpr2 = Smpr2::default();
 
         // Check the sequence is long enough
         sqr1.set_l((sequence.len() - 1).try_into().unwrap());

--- a/embassy-stm32/src/adc/f3.rs
+++ b/embassy-stm32/src/adc/f3.rs
@@ -1,6 +1,6 @@
 use core::marker::PhantomData;
 
-use stm32_metapac::adc::regs::{Sqr1, Sqr2, Sqr3};
+use stm32_metapac::adc::regs::{Smpr1, Smpr2, Sqr1, Sqr2, Sqr3};
 use stm32_metapac::adc::vals::{Advregen, Dmacfg};
 
 use super::blocking_delay_us;
@@ -30,11 +30,11 @@ impl<T: DefaultInstance> interrupt::typelevel::Handler<T::Interrupt> for Interru
     }
 }
 
-impl<T: Instance> super::SealedSpecialConverter<VrefInt> for T {
+impl<T: Instance> super::ConverterFor<VrefInt> for T {
     const CHANNEL: u8 = 18;
 }
 
-impl<T: Instance> super::SealedSpecialConverter<super::Temperature> for T {
+impl<T: Instance> super::ConverterFor<super::Temperature> for T {
     const CHANNEL: u8 = 16;
 }
 
@@ -109,8 +109,8 @@ impl AdcRegs for crate::pac::adc::Adc {
         let mut sqr2 = Sqr2::default();
         let mut sqr3 = Sqr3::default();
 
-        let mut smpr1 = self.smpr1().read();
-        let mut smpr2 = self.smpr2().read();
+        let mut smpr1 = Smpr1::default();
+        let mut smpr2 = Smpr2::default();
 
         // Check the sequence is long enough
         sqr1.set_l((sequence.len() - 1).try_into().unwrap());

--- a/embassy-stm32/src/adc/g4.rs
+++ b/embassy-stm32/src/adc/g4.rs
@@ -408,47 +408,47 @@ impl<'d, T: DefaultInstance> Adc<'d, T> {
 
 #[cfg(stm32g4)]
 mod g4 {
-    use crate::adc::{SealedSpecialConverter, Temperature, Vbat, VrefInt};
+    use crate::adc::{ConverterFor, Temperature, Vbat, VrefInt};
 
-    impl SealedSpecialConverter<Temperature> for crate::peripherals::ADC1 {
+    impl ConverterFor<Temperature> for crate::peripherals::ADC1 {
         const CHANNEL: u8 = 16;
     }
 
-    impl SealedSpecialConverter<VrefInt> for crate::peripherals::ADC1 {
+    impl ConverterFor<VrefInt> for crate::peripherals::ADC1 {
         const CHANNEL: u8 = 18;
     }
 
-    impl SealedSpecialConverter<Vbat> for crate::peripherals::ADC1 {
+    impl ConverterFor<Vbat> for crate::peripherals::ADC1 {
         const CHANNEL: u8 = 17;
     }
 
     #[cfg(peri_adc3_common)]
-    impl SealedSpecialConverter<VrefInt> for crate::peripherals::ADC3 {
+    impl ConverterFor<VrefInt> for crate::peripherals::ADC3 {
         const CHANNEL: u8 = 18;
     }
 
     #[cfg(peri_adc3_common)]
-    impl SealedSpecialConverter<Vbat> for crate::peripherals::ADC3 {
+    impl ConverterFor<Vbat> for crate::peripherals::ADC3 {
         const CHANNEL: u8 = 17;
     }
 
     #[cfg(not(stm32g4x1))]
-    impl SealedSpecialConverter<VrefInt> for crate::peripherals::ADC4 {
+    impl ConverterFor<VrefInt> for crate::peripherals::ADC4 {
         const CHANNEL: u8 = 18;
     }
 
     #[cfg(not(stm32g4x1))]
-    impl SealedSpecialConverter<Temperature> for crate::peripherals::ADC5 {
+    impl ConverterFor<Temperature> for crate::peripherals::ADC5 {
         const CHANNEL: u8 = 4;
     }
 
     #[cfg(not(stm32g4x1))]
-    impl SealedSpecialConverter<VrefInt> for crate::peripherals::ADC5 {
+    impl ConverterFor<VrefInt> for crate::peripherals::ADC5 {
         const CHANNEL: u8 = 18;
     }
 
     #[cfg(not(stm32g4x1))]
-    impl SealedSpecialConverter<Vbat> for crate::peripherals::ADC5 {
+    impl ConverterFor<Vbat> for crate::peripherals::ADC5 {
         const CHANNEL: u8 = 17;
     }
 }
@@ -456,13 +456,13 @@ mod g4 {
 // TODO this should look at each ADC individually and impl the correct channels
 #[cfg(stm32h7)]
 mod h7 {
-    impl<T: Instance> SealedSpecialConverter<Temperature> for T {
+    impl<T: Instance> ConverterFor<Temperature> for T {
         const CHANNEL: u8 = 18;
     }
-    impl<T: Instance> SealedSpecialConverter<VrefInt> for T {
+    impl<T: Instance> ConverterFor<VrefInt> for T {
         const CHANNEL: u8 = 19;
     }
-    impl<T: Instance> SealedSpecialConverter<Vbat> for T {
+    impl<T: Instance> ConverterFor<Vbat> for T {
         // TODO this should be 14 for H7a/b/35
         const CHANNEL: u8 = 17;
     }

--- a/embassy-stm32/src/adc/l1.rs
+++ b/embassy-stm32/src/adc/l1.rs
@@ -1,6 +1,6 @@
 use core::marker::PhantomData;
 
-use stm32_metapac::adc::regs::{Sqr1, Sqr2, Sqr3, Sqr4, Sqr5};
+use stm32_metapac::adc::regs::{Smpr0, Smpr1, Smpr2, Smpr3, Sqr1, Sqr2, Sqr3, Sqr4, Sqr5};
 
 use super::Resolution;
 use crate::adc::{Adc, AdcRegs, ConversionMode, DefaultInstance, Instance, SampleTime, Temperature, VrefInt};
@@ -47,11 +47,11 @@ impl<T: DefaultInstance> interrupt::typelevel::Handler<T::Interrupt> for Interru
     }
 }
 
-impl<T: Instance> super::SealedSpecialConverter<VrefInt> for T {
+impl<T: Instance> super::ConverterFor<VrefInt> for T {
     const CHANNEL: u8 = 17;
 }
 
-impl<T: Instance> super::SealedSpecialConverter<Temperature> for T {
+impl<T: Instance> super::ConverterFor<Temperature> for T {
     const CHANNEL: u8 = 16;
 }
 
@@ -158,10 +158,10 @@ impl AdcRegs for crate::pac::adc::Adc {
         let mut sqr4 = Sqr4::default();
         let mut sqr5 = Sqr5::default();
 
-        let mut smpr0 = self.smpr0().read();
-        let mut smpr1 = self.smpr1().read();
-        let mut smpr2 = self.smpr2().read();
-        let mut smpr3 = self.smpr3().read();
+        let mut smpr0 = Smpr0::default();
+        let mut smpr1 = Smpr1::default();
+        let mut smpr2 = Smpr2::default();
+        let mut smpr3 = Smpr3::default();
 
         // Check the sequence is long enough
         sqr1.set_l((sequence.len() - 1).try_into().unwrap());

--- a/embassy-stm32/src/adc/mod.rs
+++ b/embassy-stm32/src/adc/mod.rs
@@ -7,7 +7,7 @@
 #[cfg(not(any(adc_f3v3, adc_wba)))]
 #[cfg_attr(adc_f1, path = "f1.rs")]
 #[cfg_attr(adc_f3v1, path = "f3.rs")]
-#[cfg_attr(adc_f3v2, path = "f3_v1_1.rs")]
+#[cfg_attr(adc_f3v2, path = "l1.rs")]
 #[cfg_attr(adc_v1, path = "v1.rs")]
 #[cfg_attr(adc_l0, path = "v1.rs")]
 #[cfg_attr(adc_v2, path = "v2.rs")]
@@ -385,17 +385,15 @@ impl<'d, T: Instance> Adc<'d, T> {
         &'adc mut self,
         rx_dma: crate::Peri<'adc, D>,
         sequence: impl ExactSizeIterator<Item = (&'adc mut AnyAdcChannel<'ch, T>, <T::Regs as BasicAdcRegs>::SampleTime)>,
-        buf: &'adc mut [u16],
-    ) -> ConfiguredSequence<'adc, 'd, T, D>
+        irq: impl crate::interrupt::typelevel::Binding<D::Interrupt, crate::dma::InterruptHandler<D>> + 'd,
+    ) -> ConfiguredSequence<'adc, T::Regs>
     where
         'ch: 'adc,
     {
         assert!(sequence.len() != 0, "Sequence cannot be empty");
         assert!(sequence.len() <= 16, "Sequence cannot be more than 16 in length");
-        assert!(
-            buf.len() >= sequence.len(),
-            "Buffer must have at least as many entries as the sequence"
-        );
+
+        let len = sequence.len();
 
         // Ensure no conversions are ongoing
         T::regs().stop(false);
@@ -408,7 +406,7 @@ impl<'d, T: Instance> Adc<'d, T> {
         // Configure DMA once, reused across all subsequent read() calls.
         T::regs().configure_dma(ConversionMode::ConfiguredSequence, true);
 
-        ConfiguredSequence::new(self, rx_dma, buf)
+        ConfiguredSequence::new(self, rx_dma, len, irq)
     }
 
     #[cfg(any(adc_v2, adc_g4, adc_v3, adc_g0, adc_u0, adc_wba, adc_c0))]
@@ -445,7 +443,7 @@ impl<'d, T: Instance> Adc<'d, T> {
         irq: impl crate::interrupt::typelevel::Binding<D::Interrupt, crate::dma::InterruptHandler<D>> + 'a,
         sequence: impl ExactSizeIterator<Item = (AnyAdcChannel<'b, T>, <T::Regs as BasicAdcRegs>::SampleTime)>,
         trigger: Option<RegularAdcTrigger<T>>,
-    ) -> RingBufferedAdc<'a, T> {
+    ) -> RingBufferedAdc<'a, T::Regs> {
         let sequence_len = sequence.len();
         assert!(!dma_buf.is_empty() && dma_buf.len() <= 0xFFFF);
         assert!(sequence_len != 0, "Asynchronous read sequence cannot be empty");
@@ -565,7 +563,7 @@ impl<'d, T: Instance<Regs: InjectedAdcRegs>> Adc<'d, T> {
         injected_sequence: [(AnyAdcChannel<'b, T>, <T::Regs as BasicAdcRegs>::SampleTime); N],
         injected_trigger: InjectedAdcTrigger<T>,
         injected_interrupt: bool,
-    ) -> (RingBufferedAdc<'a, T>, InjectedAdc<'b, T, N>) {
+    ) -> (RingBufferedAdc<'a, T::Regs>, InjectedAdc<'b, T, N>) {
         unsafe {
             (
                 Self {
@@ -593,17 +591,17 @@ impl<'d, T: Instance> Drop for Adc<'d, T> {
 pub(self) trait SpecialChannel {}
 
 /// Implemented for ADCs that have a special channel
-trait SealedSpecialConverter<T: SpecialChannel + Sized> {
+trait ConverterFor<T: SpecialChannel + Sized> {
     const CHANNEL: u8;
 }
 
 #[allow(private_bounds)]
-pub trait SpecialConverter<T: SpecialChannel + Sized>: SealedSpecialConverter<T> {}
+pub trait SpecialConverter<T: SpecialChannel + Sized>: ConverterFor<T> {}
 
-impl<C: SpecialChannel + Sized, T: SealedSpecialConverter<C>> SpecialConverter<C> for T {}
+impl<C: SpecialChannel + Sized, T: ConverterFor<C>> SpecialConverter<C> for T {}
 
-impl<C: SpecialChannel, T: Instance + SealedSpecialConverter<C>> AdcChannel<T> for C {}
-impl<C: SpecialChannel, T: Instance + SealedSpecialConverter<C>> SealedAdcChannel<T> for C {
+impl<C: SpecialChannel, T: Instance + ConverterFor<C>> AdcChannel<T> for C {}
+impl<C: SpecialChannel, T: Instance + ConverterFor<C>> SealedAdcChannel<T> for C {
     fn channel(&self) -> u8 {
         T::CHANNEL
     }

--- a/embassy-stm32/src/adc/ringbuffered.rs
+++ b/embassy-stm32/src/adc/ringbuffered.rs
@@ -1,4 +1,3 @@
-use core::marker::PhantomData;
 use core::sync::atomic::{Ordering, compiler_fence};
 
 #[allow(unused_imports)]
@@ -10,19 +9,22 @@ use crate::adc::{Instance, RxDma};
 use crate::dma::Channel;
 #[allow(unused_imports)]
 use crate::dma::{ReadableRingBuffer, TransferOptions};
-use crate::rcc::{self, WakeGuard};
+use crate::rcc::{RccInfo, WakeGuard};
 
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub struct OverrunError;
 
-pub struct RingBufferedAdc<'d, T: Instance> {
-    _phantom: PhantomData<T>,
-    _wake_guard: WakeGuard,
+#[allow(private_bounds)]
+pub struct RingBufferedAdc<'d, R: AdcRegs> {
+    regs: R,
+    info: RccInfo,
     ring_buf: ReadableRingBuffer<'d, u16>,
+    _wake_guard: WakeGuard,
 }
 
-impl<'d, T: Instance> RingBufferedAdc<'d, T> {
-    pub(crate) fn new<D: RxDma<T>>(
+#[allow(private_bounds)]
+impl<'d, R: AdcRegs> RingBufferedAdc<'d, R> {
+    pub(crate) fn new<T: Instance<Regs = R>, D: RxDma<T>>(
         dma: Peri<'d, D>,
         irq: impl crate::interrupt::typelevel::Binding<D::Interrupt, crate::dma::InterruptHandler<D>> + 'd,
         dma_buf: &'d mut [u16],
@@ -55,7 +57,8 @@ impl<'d, T: Instance> RingBufferedAdc<'d, T> {
         ring_buf.set_alignment(sequence_len);
 
         Self {
-            _phantom: PhantomData,
+            regs: T::regs(),
+            info: T::RCC_INFO,
             _wake_guard: T::RCC_INFO.wake_guard(),
             ring_buf,
         }
@@ -66,7 +69,7 @@ impl<'d, T: Instance> RingBufferedAdc<'d, T> {
         compiler_fence(Ordering::SeqCst);
         self.ring_buf.start();
 
-        T::regs().start();
+        self.regs.start();
     }
 
     pub fn stop(&mut self) {
@@ -212,13 +215,13 @@ impl<'d, T: Instance> RingBufferedAdc<'d, T> {
     }
 }
 
-impl<T: Instance> Drop for RingBufferedAdc<'_, T> {
+impl<R: AdcRegs> Drop for RingBufferedAdc<'_, R> {
     fn drop(&mut self) {
-        T::regs().stop(true);
+        self.regs.stop(true);
 
         compiler_fence(Ordering::SeqCst);
 
         self.ring_buf.request_pause();
-        rcc::disable::<T>();
+        self.info.disable();
     }
 }

--- a/embassy-stm32/src/adc/v1.rs
+++ b/embassy-stm32/src/adc/v1.rs
@@ -42,21 +42,21 @@ impl<T: DefaultInstance> interrupt::typelevel::Handler<T::Interrupt> for Interru
 }
 
 #[cfg(not(adc_l0))]
-impl super::SealedSpecialConverter<super::Vbat> for crate::peripherals::ADC1 {
+impl super::ConverterFor<super::Vbat> for crate::peripherals::ADC1 {
     const CHANNEL: u8 = 18;
 }
 
-impl super::SealedSpecialConverter<super::VrefInt> for crate::peripherals::ADC1 {
+impl super::ConverterFor<super::VrefInt> for crate::peripherals::ADC1 {
     const CHANNEL: u8 = 17;
 }
 
 #[cfg(adc_l0)]
-impl super::SealedSpecialConverter<super::Temperature> for crate::peripherals::ADC1 {
+impl super::ConverterFor<super::Temperature> for crate::peripherals::ADC1 {
     const CHANNEL: u8 = 18;
 }
 
 #[cfg(not(adc_l0))]
-impl super::SealedSpecialConverter<super::Temperature> for crate::peripherals::ADC1 {
+impl super::ConverterFor<super::Temperature> for crate::peripherals::ADC1 {
     const CHANNEL: u8 = 16;
 }
 

--- a/embassy-stm32/src/adc/v2.rs
+++ b/embassy-stm32/src/adc/v2.rs
@@ -26,21 +26,21 @@ pub const VREF_CALIB_MV: u32 = 3300;
 
 pub const NR_INJECTED_RANKS: usize = 4;
 
-impl super::SealedSpecialConverter<super::VrefInt> for crate::peripherals::ADC1 {
+impl super::ConverterFor<super::VrefInt> for crate::peripherals::ADC1 {
     const CHANNEL: u8 = 17;
 }
 
 #[cfg(any(stm32f2, stm32f40x, stm32f41x))]
-impl super::SealedSpecialConverter<super::Temperature> for crate::peripherals::ADC1 {
+impl super::ConverterFor<super::Temperature> for crate::peripherals::ADC1 {
     const CHANNEL: u8 = 16;
 }
 
 #[cfg(not(any(stm32f2, stm32f40x, stm32f41x)))]
-impl super::SealedSpecialConverter<super::Temperature> for crate::peripherals::ADC1 {
+impl super::ConverterFor<super::Temperature> for crate::peripherals::ADC1 {
     const CHANNEL: u8 = 18;
 }
 
-impl super::SealedSpecialConverter<super::Vbat> for crate::peripherals::ADC1 {
+impl super::ConverterFor<super::Vbat> for crate::peripherals::ADC1 {
     const CHANNEL: u8 = 18;
 }
 

--- a/embassy-stm32/src/adc/v3.rs
+++ b/embassy-stm32/src/adc/v3.rs
@@ -30,53 +30,53 @@ pub const VREF_CALIB_MV: u32 = 3300;
 const SAMPLE_TIMES_CAPACITY: usize = 2;
 
 #[cfg(adc_g0)]
-impl<T: Instance> super::SealedSpecialConverter<super::VrefInt> for T {
+impl<T: Instance> super::ConverterFor<super::VrefInt> for T {
     const CHANNEL: u8 = 13;
 }
 #[cfg(any(adc_h5, adc_h7rs))]
-impl<T: Instance> super::SealedSpecialConverter<super::VrefInt> for T {
+impl<T: Instance> super::ConverterFor<super::VrefInt> for T {
     const CHANNEL: u8 = 17;
 }
 #[cfg(adc_u0)]
-impl<T: Instance> super::SealedSpecialConverter<super::VrefInt> for T {
+impl<T: Instance> super::ConverterFor<super::VrefInt> for T {
     const CHANNEL: u8 = 12;
 }
 #[cfg(not(any(adc_g0, adc_h5, adc_h7rs, adc_u0)))]
-impl<T: Instance> super::SealedSpecialConverter<super::VrefInt> for T {
+impl<T: Instance> super::ConverterFor<super::VrefInt> for T {
     const CHANNEL: u8 = 0;
 }
 
 #[cfg(adc_g0)]
-impl<T: Instance> super::SealedSpecialConverter<super::Temperature> for T {
+impl<T: Instance> super::ConverterFor<super::Temperature> for T {
     const CHANNEL: u8 = 12;
 }
 #[cfg(any(adc_h5, adc_h7rs))]
-impl<T: Instance> super::SealedSpecialConverter<super::Temperature> for T {
+impl<T: Instance> super::ConverterFor<super::Temperature> for T {
     const CHANNEL: u8 = 16;
 }
 #[cfg(adc_u0)]
-impl<T: Instance> super::SealedSpecialConverter<super::Temperature> for T {
+impl<T: Instance> super::ConverterFor<super::Temperature> for T {
     const CHANNEL: u8 = 11;
 }
 #[cfg(not(any(adc_g0, adc_h5, adc_h7rs, adc_u0)))]
-impl<T: Instance> super::SealedSpecialConverter<super::Temperature> for T {
+impl<T: Instance> super::ConverterFor<super::Temperature> for T {
     const CHANNEL: u8 = 17;
 }
 
 #[cfg(adc_g0)]
-impl<T: Instance> super::SealedSpecialConverter<super::Vbat> for T {
+impl<T: Instance> super::ConverterFor<super::Vbat> for T {
     const CHANNEL: u8 = 14;
 }
 #[cfg(any(adc_h5, adc_h7rs))]
-impl<T: Instance> super::SealedSpecialConverter<super::Vbat> for T {
+impl<T: Instance> super::ConverterFor<super::Vbat> for T {
     const CHANNEL: u8 = 16;
 }
 #[cfg(adc_u0)]
-impl<T: Instance> super::SealedSpecialConverter<super::Vbat> for T {
+impl<T: Instance> super::ConverterFor<super::Vbat> for T {
     const CHANNEL: u8 = 13;
 }
 #[cfg(not(any(adc_g0, adc_h5, adc_h7rs, adc_u0)))]
-impl<T: Instance> super::SealedSpecialConverter<super::Vbat> for T {
+impl<T: Instance> super::ConverterFor<super::Vbat> for T {
     const CHANNEL: u8 = 18;
 }
 

--- a/embassy-stm32/src/adc/v4.rs
+++ b/embassy-stm32/src/adc/v4.rs
@@ -31,49 +31,49 @@ const MAX_ADC_CLK_FREQ: Hertz = Hertz::mhz(55);
 const MAX_ADC_CLK_FREQ: Hertz = Hertz::mhz(48);
 
 #[cfg(stm32g4)]
-impl<T: Instance> super::SealedSpecialConverter<super::VrefInt> for T {
+impl<T: Instance> super::ConverterFor<super::VrefInt> for T {
     const CHANNEL: u8 = 18;
 }
 #[cfg(stm32g4)]
-impl<T: Instance> super::SealedSpecialConverter<super::Temperature> for T {
+impl<T: Instance> super::ConverterFor<super::Temperature> for T {
     const CHANNEL: u8 = 16;
 }
 
 #[cfg(stm32h7)]
-impl<T: Instance> super::SealedSpecialConverter<super::VrefInt> for T {
+impl<T: Instance> super::ConverterFor<super::VrefInt> for T {
     const CHANNEL: u8 = 19;
 }
 #[cfg(stm32h7)]
-impl<T: Instance> super::SealedSpecialConverter<super::Temperature> for T {
+impl<T: Instance> super::ConverterFor<super::Temperature> for T {
     const CHANNEL: u8 = 18;
 }
 
 // TODO this should be 14 for H7a/b/35
 #[cfg(not(any(stm32u5, stm32u3)))]
-impl<T: Instance> super::SealedSpecialConverter<super::Vbat> for T {
+impl<T: Instance> super::ConverterFor<super::Vbat> for T {
     const CHANNEL: u8 = 17;
 }
 
 #[cfg(any(stm32u5, stm32u3))]
-impl<T: DefaultInstance> super::SealedSpecialConverter<super::VrefInt> for T {
+impl<T: DefaultInstance> super::ConverterFor<super::VrefInt> for T {
     const CHANNEL: u8 = 0;
 }
 #[cfg(stm32u5)]
-impl<T: DefaultInstance> super::SealedSpecialConverter<super::Temperature> for T {
+impl<T: DefaultInstance> super::ConverterFor<super::Temperature> for T {
     const CHANNEL: u8 = 19;
 }
 #[cfg(stm32u5)]
-impl<T: DefaultInstance> super::SealedSpecialConverter<super::Vbat> for T {
+impl<T: DefaultInstance> super::ConverterFor<super::Vbat> for T {
     const CHANNEL: u8 = 18;
 }
 
 #[cfg(stm32u3)]
-impl<T: DefaultInstance> super::SealedSpecialConverter<super::Vbat> for T {
+impl<T: DefaultInstance> super::ConverterFor<super::Vbat> for T {
     const CHANNEL: u8 = 16;
 }
 
 #[cfg(stm32u3)]
-impl<T: DefaultInstance> super::SealedSpecialConverter<super::Temperature> for T {
+impl<T: DefaultInstance> super::ConverterFor<super::Temperature> for T {
     const CHANNEL: u8 = 17;
 }
 

--- a/examples/stm32f4/src/bin/adc.rs
+++ b/examples/stm32f4/src/bin/adc.rs
@@ -13,6 +13,7 @@ use {defmt_rtt as _, panic_probe as _};
 
 bind_interrupts!(struct Irqs {
     DMA2_STREAM2 => dma::InterruptHandler<peripherals::DMA2_CH2>;
+    DMA2_STREAM0 => dma::InterruptHandler<peripherals::DMA2_CH0>;
 });
 
 #[embassy_executor::main]
@@ -41,6 +42,26 @@ async fn main(_spawner: Spawner) {
 
     // Startup delay can be combined to the maximum of either
     delay.delay_us(Temperature::start_time_us().max(VrefInt::start_time_us()));
+
+    {
+        let mut first_pin = p.PA0.degrade_adc();
+        let mut second_pin = p.PA2.degrade_adc();
+
+        let mut configured_sequence = adc.configured_sequence(
+            p.DMA2_CH0,
+            [
+                (&mut first_pin, SampleTime::CYCLES112),
+                (&mut second_pin, SampleTime::CYCLES112),
+            ]
+            .into_iter(),
+            Irqs,
+        );
+
+        let mut buf = [0u16; 4];
+
+        configured_sequence.read(&mut buf[..2]).await;
+        configured_sequence.read(&mut buf[2..]).await;
+    }
 
     let vrefint_sample = adc.blocking_read(&mut vrefint, SampleTime::CYCLES112);
 

--- a/examples/stm32f4/src/bin/adc_dma.rs
+++ b/examples/stm32f4/src/bin/adc_dma.rs
@@ -28,7 +28,7 @@ async fn adc_task(mut p: Peripherals) {
     let adc = Adc::new_with_config(p.ADC1, Default::default());
     let adc2 = Adc::new_with_config(p.ADC2, Default::default());
 
-    let mut adc: RingBufferedAdc<embassy_stm32::peripherals::ADC1> = adc.into_ring_buffered(
+    let mut adc: RingBufferedAdc<_> = adc.into_ring_buffered(
         p.DMA2_CH0,
         adc_data,
         Irqs,
@@ -39,7 +39,7 @@ async fn adc_task(mut p: Peripherals) {
         .into_iter(),
         None,
     );
-    let mut adc2: RingBufferedAdc<embassy_stm32::peripherals::ADC2> = adc2.into_ring_buffered(
+    let mut adc2: RingBufferedAdc<_> = adc2.into_ring_buffered(
         p.DMA2_CH2,
         adc_data2,
         Irqs,

--- a/examples/stm32wb/.cargo/config.toml
+++ b/examples/stm32wb/.cargo/config.toml
@@ -1,7 +1,8 @@
 [target.'cfg(all(target_arch = "arm", target_os = "none"))']
 # replace STM32WB55CCUx with your chip as listed in `probe-rs chip list`
 # runner = "probe-rs run --chip STM32WB55RGVx --speed 1000 --connect-under-reset"
-runner = "teleprobe local run --chip STM32WB55RG --elf"
+# runner = "probe-rs run --chip STM32WB55RG"
+runner = "teleprobe local run --chip STM32WB55RG"
 
 [build]
 target = "thumbv7em-none-eabihf"

--- a/examples/stm32wba/src/bin/adc_ring_buffered.rs
+++ b/examples/stm32wba/src/bin/adc_ring_buffered.rs
@@ -19,7 +19,7 @@
 use defmt::*;
 use embassy_stm32::adc::adc4::Calibration;
 use embassy_stm32::adc::{Adc, AdcChannel, RingBufferedAdc, adc4};
-use embassy_stm32::peripherals::{ADC4, GPDMA1_CH1};
+use embassy_stm32::peripherals::GPDMA1_CH1;
 use embassy_stm32::rcc::{
     AHB5Prescaler, AHBPrescaler, APBPrescaler, PllDiv, PllMul, PllPreDiv, PllSource, Sysclk, VoltageScale,
 };
@@ -96,7 +96,7 @@ async fn main(_spawner: embassy_executor::Spawner) {
     // Create the ring-buffered ADC with continuous mode
     // Channels must be in ascending order for ADC4
     // CYCLES12_5 + Samples128 averaging = 5000 samples/sec per channel
-    let mut ring_adc: RingBufferedAdc<ADC4> = adc.into_ring_buffered(
+    let mut ring_adc: RingBufferedAdc<_> = adc.into_ring_buffered(
         p.GPDMA1_CH1,
         unsafe { &mut *core::ptr::addr_of_mut!(DMA_BUF) },
         Irqs,

--- a/examples/stm32wba6/src/bin/adc_ring_buffered.rs
+++ b/examples/stm32wba6/src/bin/adc_ring_buffered.rs
@@ -22,7 +22,7 @@
 use defmt::*;
 use embassy_stm32::adc::adc4::Calibration;
 use embassy_stm32::adc::{Adc, AdcChannel, RingBufferedAdc, adc4};
-use embassy_stm32::peripherals::{ADC4, GPDMA1_CH1};
+use embassy_stm32::peripherals::GPDMA1_CH1;
 use embassy_stm32::rcc::{
     AHB5Prescaler, AHBPrescaler, APBPrescaler, PllDiv, PllMul, PllPreDiv, PllSource, Sysclk, VoltageScale,
 };
@@ -100,7 +100,7 @@ async fn main(_spawner: embassy_executor::Spawner) {
     // Create the ring-buffered ADC with continuous mode
     // Channels must be in ascending order for ADC4
     // CYCLES79_5 (1.66 µs) - longest available sample time for internal channels
-    let mut ring_adc: RingBufferedAdc<ADC4> = adc.into_ring_buffered(
+    let mut ring_adc: RingBufferedAdc<_> = adc.into_ring_buffered(
         p.GPDMA1_CH1,
         unsafe { &mut *core::ptr::addr_of_mut!(DMA_BUF) },
         Irqs,


### PR DESCRIPTION
1. rename some things
2. optimize configure_sequence for some impls.
3. rewrite and type-erase configured_sequence and ringbuf.