### PR TITLE
STM32 LTDC pitch

### DIFF
--- a/embassy-stm32/src/ltdc.rs
+++ b/embassy-stm32/src/ltdc.rs
@@ -617,9 +617,9 @@ impl<'d, T: Instance, I: Interface> Ltdc<'d, T, I> {
         // framebuffer pitch and line length
         layer.cfblr().modify(|w| {
             w.set_cfbp(width * bytes_per_pixel);
-            #[cfg(not(any(stm32u5, stm32f7)))]
+            #[cfg(ltdc_v1_3)]
             w.set_cfbll(width * bytes_per_pixel + 7);
-            #[cfg(any(stm32u5, stm32f7))]
+            #[cfg(ltdc_v1)]
             w.set_cfbll(width * bytes_per_pixel + 3);
         });
 


### PR DESCRIPTION
Observed diagonal skew of image with DMA2D on F4. Found that LTDC is using the wrong offset on CFBLL register. This changes the gating to use LTDC IP version to select between the two line pitch offsets.