### PR TITLE
stm32/adc: cleanup enum variants

### DIFF
--- a/embassy-stm32/src/adc/adc4.rs
+++ b/embassy-stm32/src/adc/adc4.rs
@@ -227,7 +227,7 @@ impl AdcRegs for crate::pac::adc::Adc4 {
         });
     }
 
-    fn configure_dma(&self, conversion_mode: ConversionMode, dma: bool) {
+    fn configure_dma(&self, conversion_mode: ConversionMode) {
         // Clear overrun and conversion flags
         self.isr().modify(|reg| {
             reg.set_ovr(true);
@@ -236,11 +236,8 @@ impl AdcRegs for crate::pac::adc::Adc4 {
         });
 
         self.cfgr1().modify(|reg| {
-            reg.set_dmaen(dma);
-            reg.set_dmacfg(match conversion_mode {
-                ConversionMode::Singular => Dmacfg::ONE_SHOT,
-                _ => Dmacfg::CIRCULAR,
-            });
+            reg.set_dmaen(!matches!(conversion_mode, ConversionMode::NoDma));
+            reg.set_dmacfg(Dmacfg::CIRCULAR);
             reg.set_discen(false);
             reg.set_cont(false);
             reg.set_chselrmod(false);

--- a/embassy-stm32/src/adc/c0.rs
+++ b/embassy-stm32/src/adc/c0.rs
@@ -77,7 +77,7 @@ impl AdcRegs for crate::pac::adc::Adc {
         });
     }
 
-    fn configure_dma(&self, conversion_mode: ConversionMode, dma: bool) {
+    fn configure_dma(&self, conversion_mode: ConversionMode) {
         // Enable overrun control, so no new DMA requests will be generated until
         // previous DR values is read.
         self.isr().modify(|reg| {
@@ -85,22 +85,14 @@ impl AdcRegs for crate::pac::adc::Adc {
         });
 
         self.cfgr1().modify(|w| {
-            w.set_cont(!dma);
+            w.set_cont(matches!(conversion_mode, ConversionMode::Repeated(None)));
             w.set_discen(false);
-            w.set_dmacfg(match conversion_mode {
-                ConversionMode::Singular => Dmacfg::DMA_ONE_SHOT,
-                _ => Dmacfg::DMA_CIRCULAR,
-            });
-            w.set_dmaen(dma);
+            w.set_dmacfg(Dmacfg::DMA_CIRCULAR);
+            w.set_dmaen(!matches!(conversion_mode, ConversionMode::NoDma));
             w.set_ovrmod(match conversion_mode {
-                ConversionMode::Singular | ConversionMode::ConfiguredSequence => Ovrmod::PRESERVE,
+                ConversionMode::Singular => Ovrmod::PRESERVE,
                 _ => Ovrmod::OVERWRITE,
             });
-
-            w.set_cont(matches!(
-                conversion_mode,
-                ConversionMode::Singular | ConversionMode::Repeated(None)
-            ));
 
             if let ConversionMode::Repeated(Some((signal, edge))) = conversion_mode {
                 w.set_extsel(signal);
@@ -110,8 +102,7 @@ impl AdcRegs for crate::pac::adc::Adc {
     }
 
     fn configure_sequence(&self, sequence: impl ExactSizeIterator<Item = ((u8, bool), Self::SampleTime)>) {
-        // TODO: get sequencer working
-        let mut needs_hw = sequence.len() == 1 || sequence.len() > CHSELR_SQ_SIZE || true;
+        let mut needs_hw = sequence.len() == 1 || sequence.len() > CHSELR_SQ_SIZE;
         let mut is_ordered_up = true;
         let mut is_ordered_down = true;
 

--- a/embassy-stm32/src/adc/f1.rs
+++ b/embassy-stm32/src/adc/f1.rs
@@ -81,7 +81,7 @@ impl AdcRegs for crate::pac::adc::Adc {
         self.sr().read().eoc()
     }
 
-    fn configure_dma(&self, _conversion_mode: ConversionMode, dma: bool) {
+    fn configure_dma(&self, conversion_mode: ConversionMode) {
         // Clear all status flags before configuring DMA.
         self.sr().modify(|regs| {
             regs.set_eoc(false);
@@ -99,7 +99,7 @@ impl AdcRegs for crate::pac::adc::Adc {
 
         self.cr2().modify(|w| {
             // Enable DMA mode
-            w.set_dma(dma);
+            w.set_dma(!matches!(conversion_mode, ConversionMode::NoDma));
             // EOC flag is set at the end of each conversion.
             w.set_cont(false);
         });

--- a/embassy-stm32/src/adc/f3.rs
+++ b/embassy-stm32/src/adc/f3.rs
@@ -82,7 +82,7 @@ impl AdcRegs for crate::pac::adc::Adc {
         self.isr().read().eoc()
     }
 
-    fn configure_dma(&self, conversion_mode: ConversionMode, dma: bool) {
+    fn configure_dma(&self, conversion_mode: ConversionMode) {
         // Clear all status flags before configuring DMA.
         self.isr().modify(|w| {
             w.set_eoc(false);
@@ -96,11 +96,14 @@ impl AdcRegs for crate::pac::adc::Adc {
 
         self.cfgr().modify(|w| {
             w.set_discen(false);
-            w.set_dmaen(dma);
-            w.set_cont(false);
-            w.set_dmacfg(match conversion_mode {
-                ConversionMode::Singular => Dmacfg::ONE_SHOT,
-            });
+            w.set_dmaen(!matches!(conversion_mode, ConversionMode::NoDma));
+            w.set_cont(matches!(conversion_mode, ConversionMode::Repeated(None)));
+            w.set_dmacfg(Dmacfg::CIRCULAR);
+
+            if let ConversionMode::Repeated(Some((trigger, edge))) = conversion_mode {
+                w.set_extsel(trigger);
+                w.set_exten(edge);
+            }
         });
     }
 

--- a/embassy-stm32/src/adc/g4.rs
+++ b/embassy-stm32/src/adc/g4.rs
@@ -10,7 +10,7 @@ pub use pac::adccommon::vals::{Dual, Presc};
 
 use super::{Adc, AnyAdcChannel, ConversionMode, Resolution, SampleTime, blocking_delay_us};
 use crate::adc::{AdcRegs, DefaultInstance, InjectedRegs};
-use crate::pac::adc::regs::{Smpr, Smpr2, Sqr1, Sqr2, Sqr3, Sqr4};
+use crate::pac::adc::regs::{Jsqr, Smpr, Smpr2, Sqr1, Sqr2, Sqr3, Sqr4};
 use crate::time::Hertz;
 use crate::{Peri, pac, rcc};
 
@@ -110,20 +110,17 @@ impl super::AdcRegs for crate::pac::adc::Adc {
         self.isr().read().eos()
     }
 
-    fn configure_dma(&self, conversion_mode: ConversionMode, dma: bool) {
+    fn configure_dma(&self, conversion_mode: ConversionMode) {
         self.isr().modify(|reg| {
             reg.set_ovr(true);
         });
 
         self.cfgr().modify(|reg| {
             reg.set_discen(false); // Convert all channels for each trigger
-            reg.set_dmacfg(match conversion_mode {
-                ConversionMode::Singular => Dmacfg::ONE_SHOT,
-                _ => Dmacfg::CIRCULAR,
-            });
-            reg.set_dmaen(match dma {
-                true => Dmaen::ENABLE,
-                false => Dmaen::DISABLE,
+            reg.set_dmacfg(Dmacfg::CIRCULAR);
+            reg.set_dmaen(match conversion_mode {
+                ConversionMode::NoDma => Dmaen::DISABLE,
+                _ => Dmaen::ENABLE,
             });
             reg.set_cont(matches!(conversion_mode, ConversionMode::Repeated(None)));
 
@@ -202,15 +199,20 @@ impl super::AdcRegs for crate::pac::adc::Adc {
 
 impl InjectedRegs for crate::pac::adc::Adc {
     fn configure_injected_sequence(&self, sequence: impl ExactSizeIterator<Item = ((u8, bool), Self::SampleTime)>) {
+        let mut smpr1 = self.smpr().read();
+        let mut smpr2 = self.smpr2().read();
+
+        let mut jsqr = Jsqr::default();
+
         let len: u8 = sequence.len().try_into().unwrap();
-        self.jsqr().modify(|w| w.set_jl(len - 1));
+        jsqr.set_jl(len - 1);
 
         for (n, ((channel, _), sample_time)) in sequence.enumerate() {
             let sample_time = sample_time.clone().into();
             if channel <= 9 {
-                self.smpr().modify(|reg| reg.set_smp(channel as _, sample_time));
+                smpr1.set_smp(channel as _, sample_time);
             } else {
-                self.smpr2().modify(|reg| reg.set_smp((channel - 10) as _, sample_time));
+                smpr2.set_smp((channel - 10) as _, sample_time);
             }
 
             let idx = match n {
@@ -221,8 +223,13 @@ impl InjectedRegs for crate::pac::adc::Adc {
                 _ => unreachable!(),
             };
 
-            self.jsqr().modify(|w| w.set_jsq(idx, channel));
+            jsqr.set_jsq(idx, channel);
         }
+
+        self.smpr().write_value(smpr1);
+        self.smpr2().write_value(smpr2);
+
+        self.jsqr().write_value(jsqr);
     }
 
     fn configure_injected_trigger(&self, trigger: (u8, Exten), interrupt: bool) {

--- a/embassy-stm32/src/adc/l1.rs
+++ b/embassy-stm32/src/adc/l1.rs
@@ -133,7 +133,7 @@ impl AdcRegs for crate::pac::adc::Adc {
         self.sr().read().eoc()
     }
 
-    fn configure_dma(&self, _conversion_mode: ConversionMode, dma: bool) {
+    fn configure_dma(&self, conversion_mode: ConversionMode) {
         // Clear all status flags before configuring DMA.
         self.sr().modify(|w| {
             w.set_eoc(false);
@@ -146,7 +146,7 @@ impl AdcRegs for crate::pac::adc::Adc {
         });
 
         self.cr2().modify(|w| {
-            w.set_dma(dma);
+            w.set_dma(!matches!(conversion_mode, ConversionMode::NoDma));
             w.set_cont(false);
         });
     }

--- a/embassy-stm32/src/adc/mod.rs
+++ b/embassy-stm32/src/adc/mod.rs
@@ -17,7 +17,7 @@
 #[cfg_attr(adc_c0, path = "c0.rs")]
 mod _version;
 
-#[cfg(any(adc_v2, adc_g4, adc_v3, adc_g0, adc_u0, adc_wba, adc_c0))]
+#[cfg(any(adc_v2, adc_g4, adc_v3, adc_g0, adc_u0, adc_wba, adc_c0, adc_f3v1))]
 mod ringbuffered;
 
 #[cfg(any(
@@ -38,7 +38,7 @@ pub use configured_sequence::ConfiguredSequence;
 use embassy_hal_internal::PeripheralType;
 #[cfg(any(adc_f1, adc_f3v1, adc_v1, adc_l0, adc_f3v2))]
 use embassy_sync::waitqueue::AtomicWaker;
-#[cfg(any(adc_v2, adc_g4, adc_v3, adc_g0, adc_u0, adc_wba, adc_c0))]
+#[cfg(any(adc_v2, adc_g4, adc_v3, adc_g0, adc_u0, adc_wba, adc_c0, adc_f3v1))]
 pub use ringbuffered::RingBufferedAdc;
 
 #[cfg(adc_u5)]
@@ -53,7 +53,7 @@ pub mod adc4;
 #[allow(unused)]
 pub(self) use crate::block_for_us as blocking_delay_us;
 pub use crate::pac::adc::vals;
-#[cfg(any(adc_v2, adc_g4, adc_g0, adc_c0))]
+#[cfg(any(adc_v2, adc_g4, adc_g0, adc_c0, adc_f3v1))]
 pub use crate::pac::adc::vals::Exten;
 #[cfg(not(any(adc_f1, adc_f3v3)))]
 pub use crate::pac::adc::vals::Res as Resolution;
@@ -63,7 +63,7 @@ use crate::{peripherals, rcc};
 
 dma_trait!(RxDma, Instance);
 
-#[cfg(not(any(adc_v2, adc_g4, adc_g0, adc_c0)))]
+#[cfg(not(any(adc_v2, adc_g4, adc_g0, adc_c0, adc_f3v1)))]
 /// Trigger edge stub.
 pub struct Exten;
 
@@ -139,7 +139,7 @@ trait AdcRegs: BasicAdcRegs {
     fn start(&self);
     fn stop(&self, disable: bool);
     fn wait_done(&self) -> bool;
-    fn configure_dma(&self, conversion_mode: ConversionMode, dma: bool);
+    fn configure_dma(&self, conversion_mode: ConversionMode);
     fn configure_sequence(&self, sequence: impl ExactSizeIterator<Item = ((u8, bool), Self::SampleTime)>);
     fn data(&self) -> *mut u16;
 }
@@ -208,16 +208,12 @@ pub enum Averaging {
 }
 
 pub(crate) enum ConversionMode {
-    // Should match the cfg on "read" below
+    NoDma,
     Singular,
     // Should match the cfg on "into_ring_buffered" below
-    #[cfg(any(adc_v2, adc_g4, adc_v3, adc_g0, adc_u0, adc_wba, adc_c0))]
+    #[cfg(any(adc_v2, adc_g4, adc_v3, adc_g0, adc_u0, adc_wba, adc_c0, adc_f3v1))]
     Repeated(Option<(u8, Exten)>),
     // Should match the cfg on "configured_sequence" below
-    #[cfg(any(
-        adc_g4, adc_v3, adc_g0, adc_h5, adc_h7rs, adc_u0, adc_v4, adc_u5, adc_u3, adc_wba, adc_c0, adc_v2
-    ))]
-    ConfiguredSequence,
 }
 
 #[cfg(not(adc_f3v3))]
@@ -243,7 +239,7 @@ impl<'d, T: Instance> Adc<'d, T> {
         T::regs().configure_sequence([((channel.channel(), channel.is_differential()), sample_time)].into_iter());
 
         T::regs().enable();
-        T::regs().configure_dma(ConversionMode::Singular, false);
+        T::regs().configure_dma(ConversionMode::NoDma);
         T::regs().start();
 
         poll_fn(|cx| {
@@ -274,7 +270,7 @@ impl<'d, T: Instance> Adc<'d, T> {
         T::regs().configure_sequence([((channel.channel(), channel.is_differential()), sample_time)].into_iter());
 
         T::regs().enable();
-        T::regs().configure_dma(ConversionMode::Singular, false);
+        T::regs().configure_dma(ConversionMode::NoDma);
 
         let i = if <T::Regs as AdcRegs>::HAS_ERRATA { 2 } else { 1 };
         for _ in 0..i {
@@ -346,7 +342,7 @@ impl<'d, T: Instance> Adc<'d, T> {
         );
 
         T::regs().enable();
-        T::regs().configure_dma(ConversionMode::Singular, true);
+        T::regs().configure_dma(ConversionMode::Singular);
 
         let request = rx_dma.request();
         let mut dma_channel = crate::dma::Channel::new(rx_dma, irq);
@@ -404,12 +400,12 @@ impl<'d, T: Instance> Adc<'d, T> {
         T::regs().enable();
 
         // Configure DMA once, reused across all subsequent read() calls.
-        T::regs().configure_dma(ConversionMode::ConfiguredSequence, true);
+        T::regs().configure_dma(ConversionMode::Singular);
 
         ConfiguredSequence::new(self, rx_dma, len, irq)
     }
 
-    #[cfg(any(adc_v2, adc_g4, adc_v3, adc_g0, adc_u0, adc_wba, adc_c0))]
+    #[cfg(any(adc_v2, adc_g4, adc_v3, adc_g0, adc_u0, adc_wba, adc_c0, adc_f3v1))]
     /// Configures the ADC to use a DMA ring buffer for continuous data acquisition.
     ///
     /// Use the [`Self::read`] method to retrieve measurements from the DMA ring buffer. The read buffer
@@ -462,7 +458,7 @@ impl<'d, T: Instance> Adc<'d, T> {
         );
 
         T::regs().enable();
-        T::regs().configure_dma(ConversionMode::Repeated(trigger.map(|t| (t._trigger, t._edge))), true);
+        T::regs().configure_dma(ConversionMode::Repeated(trigger.map(|t| (t._trigger, t._edge))));
 
         core::mem::forget(self);
 

--- a/embassy-stm32/src/adc/v1.rs
+++ b/embassy-stm32/src/adc/v1.rs
@@ -128,7 +128,7 @@ impl AdcRegs for crate::pac::adc::Adc {
         self.isr().read().eoc()
     }
 
-    fn configure_dma(&self, conversion_mode: ConversionMode, dma: bool) {
+    fn configure_dma(&self, conversion_mode: ConversionMode) {
         // Clear all interrupts
         self.isr().modify(|regs| {
             regs.set_eoc(false);
@@ -147,11 +147,9 @@ impl AdcRegs for crate::pac::adc::Adc {
             // Disable discontinuous mode
             w.set_discen(false);
             // Enable DMA mode
-            w.set_dmaen(dma);
+            w.set_dmaen(!matches!(conversion_mode, ConversionMode::NoDma));
             // DMA requests are issues as long as DMA=1 and data are converted.
-            w.set_cont(match conversion_mode {
-                ConversionMode::Singular => false,
-            });
+            w.set_cont(false);
         });
     }
 

--- a/embassy-stm32/src/adc/v2.rs
+++ b/embassy-stm32/src/adc/v2.rs
@@ -11,6 +11,7 @@ mod injected;
 pub use injected::InjectedAdc;
 
 use crate::pac::adc::regs::{Sqr1, Sqr2, Sqr3};
+use crate::pac::adc::vals::Dds;
 
 fn clear_interrupt_flags(r: crate::pac::adc::Adc) {
     r.sr().modify(|regs| {
@@ -130,7 +131,7 @@ impl AdcRegs for crate::pac::adc::Adc {
         self.sr().read().eoc()
     }
 
-    fn configure_dma(&self, conversion_mode: ConversionMode, dma: bool) {
+    fn configure_dma(&self, conversion_mode: ConversionMode) {
         let r = self;
 
         // Clear all status flags before configuring DMA.
@@ -154,14 +155,8 @@ impl AdcRegs for crate::pac::adc::Adc {
 
         r.cr2().modify(|w| {
             // Enable DMA mode
-            w.set_dma(dma);
-            w.set_dds(match conversion_mode {
-                // SINGLE: DMA requests stop after the sequence completes (one-shot).
-                ConversionMode::Singular => vals::Dds::SINGLE,
-                // CONTINUOUS: DMA stays armed between reads; cont=false below limits the ADC to one sequence per SWSTART.
-                // CONTINUOUS: DMA requests keep being issued as long as DMA=1 and data are converted.
-                _ => vals::Dds::CONTINUOUS,
-            });
+            w.set_dma(!matches!(conversion_mode, ConversionMode::NoDma));
+            w.set_dds(Dds::CONTINUOUS);
             // EOC flag is set at the end of each conversion.
             w.set_eocs(vals::Eocs::EACH_CONVERSION);
             w.set_cont(matches!(conversion_mode, ConversionMode::Repeated(None)));

--- a/embassy-stm32/src/adc/v3.rs
+++ b/embassy-stm32/src/adc/v3.rs
@@ -225,7 +225,7 @@ impl super::AdcRegs for crate::pac::adc::Adc {
         self.isr().read().eos()
     }
 
-    fn configure_dma(&self, conversion_mode: ConversionMode, dma: bool) {
+    fn configure_dma(&self, conversion_mode: ConversionMode) {
         // Set continuous mode with oneshot dma.
         // Clear overrun flag before starting transfer.
         self.isr().modify(|reg| {
@@ -240,14 +240,11 @@ impl super::AdcRegs for crate::pac::adc::Adc {
 
         regs.modify(|w| {
             w.set_discen(false);
-            w.set_dmaen(dma);
+            w.set_dmaen(!matches!(conversion_mode, ConversionMode::NoDma));
             w.set_cont(false);
             #[cfg(any(adc_v3, adc_g0, adc_u0))]
             w.set_cont(matches!(conversion_mode, ConversionMode::Repeated(None)));
-            w.set_dmacfg(match conversion_mode {
-                ConversionMode::Singular => Dmacfg::ONE_SHOT,
-                _ => Dmacfg::CIRCULAR,
-            });
+            w.set_dmacfg(Dmacfg::CIRCULAR);
 
             #[cfg(any(adc_v2, adc_g4, adc_v3, adc_g0, adc_u0, adc_wba, adc_c0))]
             if let ConversionMode::Repeated(Some((signal, _edge))) = conversion_mode {

--- a/embassy-stm32/src/adc/v4.rs
+++ b/embassy-stm32/src/adc/v4.rs
@@ -139,17 +139,16 @@ impl AdcRegs for crate::pac::adc::Adc {
         self.isr().read().eos()
     }
 
-    fn configure_dma(&self, conversion_mode: ConversionMode, dma: bool) {
+    fn configure_dma(&self, conversion_mode: ConversionMode) {
         self.isr().modify(|reg| {
             reg.set_ovr(true);
         });
 
         self.cfgr().modify(|w| {
             w.set_cont(false);
-            w.set_dmngt(match (conversion_mode, dma) {
-                (ConversionMode::Singular, true) => Dmngt::DMA_ONE_SHOT,
-                (_, false) => Dmngt::from_bits(0),
-                (_, true) => Dmngt::DMA_CIRCULAR,
+            w.set_dmngt(match conversion_mode {
+                ConversionMode::NoDma => Dmngt::from_bits(0),
+                _ => Dmngt::DMA_CIRCULAR,
             });
         });
     }

--- a/examples/stm32c0/src/bin/adc.rs
+++ b/examples/stm32c0/src/bin/adc.rs
@@ -32,7 +32,7 @@ async fn main(_spawner: Spawner) {
     let mut dma = p.DMA1_CH1;
     let mut read_buffer: [u16; 3] = [0; 3];
 
-    loop {
+    for _ in 0..5 {
         info!("============================");
         let blocking_temp = adc.blocking_read(&mut temp, SampleTime::CYCLES12_5);
         let blocking_vref = adc.blocking_read(&mut vref, SampleTime::CYCLES12_5);
@@ -55,6 +55,8 @@ async fn main(_spawner: Spawner) {
             read_buffer[0], read_buffer[1], read_buffer[2]
         );
 
-        Timer::after_millis(2000).await;
+        Timer::after_millis(500).await;
     }
+
+    cortex_m::asm::bkpt();
 }


### PR DESCRIPTION
there's no reason for a separate variant,  given that `adc.read(..)` is just `adc.configured_sequence(..).read(..)`.
