### PR TITLE
embassy-sync: add ThreadModeRawMutex support for riscv32

### DIFF
--- a/embassy-sync/build_common.rs
+++ b/embassy-sync/build_common.rs
@@ -79,6 +79,8 @@ pub fn set_target_cfgs(cfgs: &mut CfgSet) {
         cfgs.enable_all(&["cortex_m", "armv8m", "armv8m_base"]);
     } else if target.starts_with("thumbv8m.main") {
         cfgs.enable_all(&["cortex_m", "armv8m", "armv8m_main"]);
+    } else if target.starts_with("riscv32") {
+        cfgs.enable("riscv32");
     }
     cfgs.declare_all(&[
         "cortex_m",
@@ -88,6 +90,7 @@ pub fn set_target_cfgs(cfgs: &mut CfgSet) {
         "armv8m",
         "armv8m_base",
         "armv8m_main",
+        "riscv32",
     ]);
 
     cfgs.set("has_fpu", target.ends_with("-eabihf"));

--- a/embassy-sync/src/blocking_mutex/mod.rs
+++ b/embassy-sync/src/blocking_mutex/mod.rs
@@ -135,9 +135,9 @@ impl<T> Mutex<raw::NoopRawMutex, T> {
 // There's still a ThreadModeRawMutex for use with the generic Mutex (handy with Channel, for example),
 // but that will require T: Send even though it shouldn't be needed.
 
-#[cfg(any(cortex_m, doc, feature = "std"))]
+#[cfg(any(cortex_m, riscv32, doc, feature = "std"))]
 pub use thread_mode_mutex::*;
-#[cfg(any(cortex_m, doc, feature = "std"))]
+#[cfg(any(cortex_m, riscv32, doc, feature = "std"))]
 mod thread_mode_mutex {
     use super::*;
 

--- a/embassy-sync/src/blocking_mutex/raw.rs
+++ b/embassy-sync/src/blocking_mutex/raw.rs
@@ -89,7 +89,7 @@ unsafe impl RawMutex for NoopRawMutex {
 
 // ================
 
-#[cfg(any(cortex_m, doc, feature = "std"))]
+#[cfg(any(cortex_m, riscv32, doc, feature = "std"))]
 mod thread_mode {
     use super::*;
 
@@ -142,10 +142,14 @@ mod thread_mode {
         #[cfg(feature = "std")]
         return Some("main") == std::thread::current().name();
 
-        #[cfg(not(feature = "std"))]
+        #[cfg(cortex_m)]
         // ICSR.VECTACTIVE == 0
         return unsafe { (0xE000ED04 as *const u32).read_volatile() } & 0x1FF == 0;
+
+        #[cfg(riscv32)]
+        // No interrupt executor on RISC-V yet, so always in thread mode.
+        return true;
     }
 }
-#[cfg(any(cortex_m, doc, feature = "std"))]
+#[cfg(any(cortex_m, riscv32, doc, feature = "std"))]
 pub use thread_mode::*;


### PR DESCRIPTION
#### Fix ThreadModeRawMutex behavior on RISC-V (#5133)

`ThreadModeRawMutex` only works on `cortex_m` right now, so it can’t be used on `riscv32` targets.  
The RISC-V executor is thread-only for now, so `in_thread_mode()` just returns `true`.

If we add an interrupt executor for RISC-V in the future, this will need proper tracking—but that’s a separate PR.

## Testing

- Builds cleanly on `riscv32imac-unknown-none-elf`
- All host tests pass