### PR TITLE
stm32/adc: add optional trigger to read method

### DIFF
--- a/embassy-stm32/src/adc/configured_sequence.rs
+++ b/embassy-stm32/src/adc/configured_sequence.rs
@@ -4,7 +4,7 @@ use embassy_hal_internal::Peri;
 
 use super::AdcRegs;
 use crate::adc::{Instance, RxDma, check_dma_len};
-use crate::dma::Channel;
+use crate::dma::ChannelAndRequest;
 use crate::rcc::RccInfo;
 
 /// An ADC with a pre-configured channel sequence for repeated DMA reads.
@@ -20,8 +20,7 @@ pub struct ConfiguredSequence<'adc, R: AdcRegs> {
     regs: R,
     info: RccInfo,
     len: usize,
-    request: u8,
-    channel: Channel<'adc>,
+    dma: ChannelAndRequest<'adc>,
 }
 
 #[allow(private_bounds)]
@@ -36,8 +35,7 @@ impl<'adc, R: AdcRegs> ConfiguredSequence<'adc, R> {
             regs: T::regs(),
             info: T::RCC_INFO,
             len,
-            request: rx_dma.request(),
-            channel: Channel::new(rx_dma, irq),
+            dma: new_dma!(rx_dma, irq).unwrap(),
         }
     }
 
@@ -56,10 +54,7 @@ impl<'adc, R: AdcRegs> ConfiguredSequence<'adc, R> {
 
         check_dma_len(self.len, Some(buf.len()), true);
 
-        let transfer = unsafe {
-            self.channel
-                .read(self.request, self.regs.data(), buf, Default::default())
-        };
+        let transfer = unsafe { self.dma.read(self.regs.data(), buf, Default::default()) };
 
         self.regs.start();
         transfer.await;

--- a/embassy-stm32/src/adc/mod.rs
+++ b/embassy-stm32/src/adc/mod.rs
@@ -17,28 +17,17 @@
 #[cfg_attr(adc_c0, path = "c0.rs")]
 mod _version;
 
-#[cfg(any(adc_v2, adc_g4, adc_v3, adc_g0, adc_u0, adc_wba, adc_c0, adc_f3v1))]
-mod ringbuffered;
-
-#[cfg(any(
-    adc_g4, adc_v3, adc_g0, adc_h5, adc_h7rs, adc_u0, adc_v4, adc_u5, adc_u3, adc_wba, adc_c0, adc_v2
-))]
 mod configured_sequence;
+mod ringbuffered;
 
 use core::marker::PhantomData;
 
 #[allow(unused)]
 #[cfg(not(any(adc_f3v3, adc_wba)))]
 pub use _version::*;
-#[cfg(any(
-    adc_g4, adc_v3, adc_g0, adc_h5, adc_h7rs, adc_u0, adc_v4, adc_u5, adc_u3, adc_wba, adc_c0, adc_v2
-))]
 pub use configured_sequence::ConfiguredSequence;
-#[allow(unused)]
-use embassy_hal_internal::PeripheralType;
 #[cfg(any(adc_f1, adc_f3v1, adc_v1, adc_l0, adc_f3v2))]
 use embassy_sync::waitqueue::AtomicWaker;
-#[cfg(any(adc_v2, adc_g4, adc_v3, adc_g0, adc_u0, adc_wba, adc_c0, adc_f3v1))]
 pub use ringbuffered::RingBufferedAdc;
 
 #[cfg(adc_u5)]
@@ -49,6 +38,8 @@ use crate::pac::adc::vals::SampleTime as Adc4SampleTime;
 #[cfg(any(adc_u5, adc_wba))]
 #[path = "adc4.rs"]
 pub mod adc4;
+
+use embassy_hal_internal::drop::OnDrop;
 
 #[allow(unused)]
 pub(self) use crate::block_for_us as blocking_delay_us;
@@ -210,10 +201,8 @@ pub enum Averaging {
 pub(crate) enum ConversionMode {
     NoDma,
     Singular,
-    // Should match the cfg on "into_ring_buffered" below
-    #[cfg(any(adc_v2, adc_g4, adc_v3, adc_g0, adc_u0, adc_wba, adc_c0, adc_f3v1))]
+    #[allow(dead_code)]
     Repeated(Option<(u8, Exten)>),
-    // Should match the cfg on "configured_sequence" below
 }
 
 const fn check_dma_len(sequence_len: usize, dma_len: Option<usize>, configured_sequence: bool) {
@@ -347,6 +336,7 @@ impl<'d, T: Instance> Adc<'d, T> {
         rx_dma: embassy_hal_internal::Peri<'a, D>,
         irq: impl crate::interrupt::typelevel::Binding<D::Interrupt, crate::dma::InterruptHandler<D>> + 'a,
         sequence: impl ExactSizeIterator<Item = (&'a mut AnyAdcChannel<'b, T>, <T::Regs as BasicAdcRegs>::SampleTime)>,
+        trigger: Option<RegularAdcTrigger<T>>,
         readings: &mut [u16],
     ) {
         let _scoped_wake_guard = <T as crate::rcc::SealedRccPeripheral>::RCC_INFO.wake_guard();
@@ -361,28 +351,21 @@ impl<'d, T: Instance> Adc<'d, T> {
 
         T::regs().enable();
 
-        #[cfg(adc_g4)]
-        T::regs().configure_dma(ConversionMode::Repeated(None));
-
-        #[cfg(not(adc_g4))]
-        T::regs().configure_dma(ConversionMode::Singular);
+        // Use repeated mode and use the dma to stop the transfer
+        T::regs().configure_dma(ConversionMode::Repeated(trigger.map(|t| (t._trigger, t._edge))));
 
         let request = rx_dma.request();
         let mut dma_channel = crate::dma::Channel::new(rx_dma, irq);
         let transfer = unsafe { dma_channel.read(request, T::regs().data(), readings, Default::default()) };
 
+        // Ensure conversions are finished, even in the event of dropping the future
+        let _stop_adc = OnDrop::new(|| T::regs().stop(false));
         T::regs().start();
 
         // Wait for conversion sequence to finish.
         transfer.await;
-
-        // Ensure conversions are finished.
-        T::regs().stop(false);
     }
 
-    #[cfg(any(
-        adc_g4, adc_v3, adc_g0, adc_h5, adc_h7rs, adc_u0, adc_v4, adc_u5, adc_u3, adc_wba, adc_c0, adc_v2
-    ))]
     /// Configure an ADC channel sequence once and return a [`ConfiguredSequence`] for repeated
     /// DMA reads without reprogramming the sequence each time.
     ///
@@ -427,7 +410,6 @@ impl<'d, T: Instance> Adc<'d, T> {
         ConfiguredSequence::new(self, rx_dma, len, irq)
     }
 
-    #[cfg(any(adc_v2, adc_g4, adc_v3, adc_g0, adc_u0, adc_wba, adc_c0, adc_f3v1))]
     /// Configures the ADC to use a DMA ring buffer for continuous data acquisition.
     ///
     /// Use the [`Self::read`] method to retrieve measurements from the DMA ring buffer. The read buffer
@@ -661,19 +643,6 @@ pub struct Dac;
 impl SpecialChannel for Dac {}
 
 /// ADC instance.
-#[cfg(not(any(
-    adc_f1, adc_v1, adc_l0, adc_v2, adc_v3, adc_v4, adc_g4, adc_f3v1, adc_f3v2, adc_g0, adc_u0, adc_h5, adc_h7rs,
-    adc_u5, adc_u3, adc_c0, adc_wba,
-)))]
-#[allow(private_bounds)]
-pub trait Instance: SealedInstance + crate::PeripheralType {
-    type Interrupt: crate::interrupt::typelevel::Interrupt;
-}
-/// ADC instance.
-#[cfg(any(
-    adc_f1, adc_v1, adc_l0, adc_v2, adc_v3, adc_v4, adc_g4, adc_f3v1, adc_f3v2, adc_g0, adc_u0, adc_h5, adc_h7rs,
-    adc_u5, adc_u3, adc_c0, adc_wba,
-))]
 #[allow(private_bounds)]
 pub trait Instance: SealedInstance + crate::PeripheralType + crate::rcc::RccPeripheral {
     type Interrupt: crate::interrupt::typelevel::Interrupt;

--- a/examples/stm32c0/src/bin/adc.rs
+++ b/examples/stm32c0/src/bin/adc.rs
@@ -47,8 +47,14 @@ async fn main(_spawner: Spawner) {
             (&mut temp, SampleTime::CYCLES12_5),
             (&mut pin0, SampleTime::CYCLES12_5),
         ];
-        adc.read(dma.reborrow(), Irqs, channels_sequence.into_iter(), &mut read_buffer)
-            .await;
+        adc.read(
+            dma.reborrow(),
+            Irqs,
+            channels_sequence.into_iter(),
+            None,
+            &mut read_buffer,
+        )
+        .await;
         // Values are ordered according to hardware ADC channel number!
         info!(
             "DMA ADC read in set: vref = {}, temp = {}, pin0 = {}.",

--- a/examples/stm32g0/src/bin/adc_dma.rs
+++ b/examples/stm32g0/src/bin/adc_dma.rs
@@ -38,6 +38,7 @@ async fn main(_spawner: Spawner) {
                 (&mut pa0, SampleTime::CYCLES160_5),
             ]
             .into_iter(),
+            None,
             &mut read_buffer,
         )
         .await;

--- a/examples/stm32g4/src/bin/adc_dma.rs
+++ b/examples/stm32g4/src/bin/adc_dma.rs
@@ -53,6 +53,7 @@ async fn main(_spawner: Spawner) {
                 (&mut pa0, SampleTime::CYCLES247_5),
             ]
             .into_iter(),
+            None,
             read_buffer,
         )
         .await;

--- a/examples/stm32h5/src/bin/adc_dma.rs
+++ b/examples/stm32h5/src/bin/adc_dma.rs
@@ -98,6 +98,7 @@ async fn adc_task<'a, T, D, I>(
             dma.reborrow(),
             irq,
             [(&mut pin1, SampleTime::CYCLES2_5), (&mut pin2, SampleTime::CYCLES2_5)].into_iter(),
+            None,
             &mut buffer[0..2],
         )
         .await;

--- a/examples/stm32h7/src/bin/adc_dma.rs
+++ b/examples/stm32h7/src/bin/adc_dma.rs
@@ -71,6 +71,7 @@ async fn main(_spawner: Spawner) {
                 (&mut pc0, SampleTime::CYCLES810_5),
             ]
             .into_iter(),
+            None,
             &mut read_buffer,
         )
         .await;

--- a/examples/stm32u5/src/bin/adc.rs
+++ b/examples/stm32u5/src/bin/adc.rs
@@ -83,6 +83,7 @@ async fn main(_spawner: embassy_executor::Spawner) {
             (&mut degraded12, adc::SampleTime::CYCLES160_5),
         ]
         .into_iter(),
+        None,
         &mut measurements,
     )
     .await;
@@ -108,6 +109,7 @@ async fn main(_spawner: embassy_executor::Spawner) {
             (&mut degraded41, adc4::SampleTime::CYCLES1_5),
         ]
         .into_iter(),
+        None,
         &mut measurements,
     )
     .await;

--- a/examples/stm32wba/src/bin/adc.rs
+++ b/examples/stm32wba/src/bin/adc.rs
@@ -48,6 +48,7 @@ async fn main(_spawner: embassy_executor::Spawner) {
             (&mut degraded41, SampleTime::CYCLES12_5),
         ]
         .into_iter(),
+        None,
         &mut measurements,
     )
     .await;

--- a/examples/stm32wba6/src/bin/adc.rs
+++ b/examples/stm32wba6/src/bin/adc.rs
@@ -72,6 +72,7 @@ async fn main(_spawner: embassy_executor::Spawner) {
             (&mut degraded41, SampleTime::CYCLES12_5),
         ]
         .into_iter(),
+        None,
         &mut measurements,
     )
     .await;


### PR DESCRIPTION
following up from #5834, normalize functionality between chips where repeated is available.