### PR TITLE
embassy-stm32/i2c: fix zero-length write hang on v1 devices

### DIFF
--- a/embassy-stm32/src/i2c/v1.rs
+++ b/embassy-stm32/src/i2c/v1.rs
@@ -163,6 +163,9 @@ impl<'d, M: PeriMode, IM: MasterMode> I2c<'d, M, IM> {
         // Return early if there are no bytes to transmit and no START to send.
         // If send_start is true the empty check is handled after the address phase.
         if write_buffer.is_empty() && !frame.send_start() {
+            if frame.send_stop() {
+                self.info.regs.cr1().modify(|reg| reg.set_stop(true));
+            }
             return Ok(());
         }
 
@@ -406,6 +409,9 @@ impl<'d, IM: MasterMode> I2c<'d, Async, IM> {
         // Return early if there are no bytes to transmit and no START to send.
         // If send_start is true the empty check is handled after the address phase.
         if write_buffer.is_empty() && !frame.send_start() {
+            if frame.send_stop() {
+                self.info.regs.cr1().modify(|reg| reg.set_stop(true));
+            }
             return Ok(());
         }
 

--- a/embassy-stm32/src/i2c/v1.rs
+++ b/embassy-stm32/src/i2c/v1.rs
@@ -160,6 +160,12 @@ impl<'d, M: PeriMode, IM: MasterMode> I2c<'d, M, IM> {
         timeout: Timeout,
         frame: FrameOptions,
     ) -> Result<(), Error> {
+        // Return early if there are no bytes to transmit and no START to send.
+        // If send_start is true the empty check is handled after the address phase.
+        if write_buffer.is_empty() && !frame.send_start() {
+            return Ok(());
+        }
+
         if frame.send_start() {
             // Send a START condition
 
@@ -189,6 +195,14 @@ impl<'d, M: PeriMode, IM: MasterMode> I2c<'d, M, IM> {
 
             // Clear condition by reading SR2
             let _ = self.info.regs.sr2().read();
+
+            // Return early if there are no bytes to transmit.
+            if write_buffer.is_empty() {
+                if frame.send_stop() {
+                    self.info.regs.cr1().modify(|w| w.set_stop(true));
+                }
+                return Ok(());
+            }
         }
 
         // Send bytes
@@ -389,6 +403,12 @@ impl<'d, M: PeriMode, IM: MasterMode> I2c<'d, M, IM> {
 
 impl<'d, IM: MasterMode> I2c<'d, Async, IM> {
     async fn write_frame(&mut self, address: u8, write_buffer: &[u8], frame: FrameOptions) -> Result<(), Error> {
+        // Return early if there are no bytes to transmit and no START to send.
+        // If send_start is true the empty check is handled after the address phase.
+        if write_buffer.is_empty() && !frame.send_start() {
+            return Ok(());
+        }
+
         self.info.regs.cr2().modify(|w| {
             // Note: Do not enable the ITBUFEN bit in the I2C_CR2 register if DMA is used for
             // reception.
@@ -470,6 +490,15 @@ impl<'d, IM: MasterMode> I2c<'d, Async, IM> {
 
             // Clear condition by reading SR2
             self.info.regs.sr2().read();
+
+            // Return early if there are no bytes to transmit.
+            if write_buffer.is_empty() {
+                if frame.send_stop() {
+                    self.info.regs.cr1().modify(|w| w.set_stop(true));
+                }
+                drop(on_drop);
+                return Ok(());
+            }
         }
 
         let dma_transfer = unsafe {


### PR DESCRIPTION
write_frame and write_bytes unconditionally waited for BTF after the address phase regardless of buffer length. With no bytes to transfer BTF never fires, causing an infinite hang.

Return early after the address ACK if there are no bytes to transmit.

Changes:
- embassy-stm32/src/i2c/v1.rs: return early in write_frame and write_bytes when write buffer is empty