### PR TITLE
stm32/adc: add analog watchdog (AWD) driver for ADC4 (WBA/U5)

### DIFF
--- a/embassy-stm32/src/adc/adc4.rs
+++ b/embassy-stm32/src/adc/adc4.rs
@@ -1,3 +1,5 @@
+use core::marker::PhantomData;
+
 #[cfg(stm32u5)]
 use pac::adc::vals::{Adc4Dmacfg as Dmacfg, Adc4Exten as Exten, Adc4OversamplingRatio as OversamplingRatio};
 #[cfg(stm32wba)]
@@ -14,9 +16,58 @@ pub use crate::pac::adc::vals::{Adc4Presc as Presc, Adc4Res as Resolution, Adc4S
 #[cfg(stm32wba)]
 pub use crate::pac::adc::vals::{Extsel, Presc, Res as Resolution, SampleTime};
 use crate::time::Hertz;
-use crate::{Peri, pac, rcc};
+use crate::{Peri, interrupt, pac, rcc};
+
+mod watchdog_adc4;
+pub use watchdog_adc4::{AnalogWatchdog, WatchdogChannels, WatchdogIndex};
 
 const MAX_ADC_CLK_FREQ: Hertz = Hertz::mhz(55);
+
+/// Interrupt handler.
+pub struct InterruptHandler<T: Instance<Regs = crate::pac::adc::Adc4>> {
+    _phantom: PhantomData<T>,
+}
+
+impl<T: Instance<Regs = crate::pac::adc::Adc4>> interrupt::typelevel::Handler<T::Interrupt> for InterruptHandler<T> {
+    unsafe fn on_interrupt() {
+        let isr = T::regs().isr().read();
+        let ier = T::regs().ier().read();
+
+        if ier.eocie() && isr.eoc() {
+            T::regs().ier().modify(|w| w.set_eocie(false));
+        } else if ier.eosie() && isr.eos() {
+            T::regs().ier().modify(|w| w.set_eosie(false));
+        } else if (0..3).any(|i| ier.awdie(i) && isr.awd(i)) {
+            // Disable AWDIE + clear ISR flag to deassert the interrupt line.
+            T::regs().ier().modify(|w| {
+                for i in 0..3 {
+                    if ier.awdie(i) && isr.awd(i) {
+                        w.set_awdie(i, false);
+                    }
+                }
+            });
+            T::regs().isr().write(|w| {
+                for i in 0..3 {
+                    if isr.awd(i) {
+                        w.set_awd(i, true);
+                    }
+                }
+            });
+            // Read-back flushes the write buffer (Cortex-M pattern).
+            let _ = T::regs().isr().read();
+            // Signal the driver via atomic flags (ISR flag is now cleared).
+            for i in 0..3 {
+                if ier.awdie(i) && isr.awd(i) {
+                    T::state().awd_triggered[i].store(true, core::sync::atomic::Ordering::Release);
+                }
+            }
+        } else {
+            return;
+        }
+
+        T::state().waker.wake();
+    }
+}
 
 /// Default VREF voltage used for sample conversion to millivolts.
 pub const VREF_DEFAULT_MV: u32 = 3300;
@@ -228,8 +279,10 @@ impl AdcRegs for crate::pac::adc::Adc4 {
     }
 
     fn configure_dma(&self, conversion_mode: ConversionMode) {
-        // Clear overrun and conversion flags
-        self.isr().modify(|reg| {
+        // Clear overrun and conversion flags.
+        // ISR is W1C (write-1-to-clear): use write(), not modify(), to avoid
+        // accidentally clearing other set flags (e.g. ADRDY) via read-modify-write.
+        self.isr().write(|reg| {
             reg.set_ovr(true);
             reg.set_eos(true);
             reg.set_eoc(true);
@@ -451,5 +504,35 @@ impl<'d, T: Instance<Regs = crate::pac::adc::Adc4>> super::Adc<'d, T> {
             w.set_ovss(right_shift);
             w.set_ovse(enable)
         })
+    }
+
+    /// Initialize an analog watchdog.
+    ///
+    /// `watchdog` selects which of the three hardware watchdogs to use. `channels` controls which
+    /// ADC channels are monitored; see [`WatchdogChannels`] for which variants are valid for each
+    /// watchdog. `low_threshold` and `high_threshold` are raw ADC counts in `[0, 2^N − 1]` for
+    /// the currently configured resolution. The watchdog fires when a sample falls **outside**
+    /// `[low_threshold, high_threshold]`.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `low_threshold > high_threshold`, or if a channel selection variant is used that
+    /// is not supported by the chosen watchdog (e.g., [`WatchdogChannels::All`] with AWD2/AWD3,
+    /// or [`WatchdogChannels::Channels`] with AWD1).
+    #[must_use]
+    pub fn init_watchdog(
+        &mut self,
+        watchdog: WatchdogIndex,
+        channels: WatchdogChannels,
+        low_threshold: u16,
+        high_threshold: u16,
+    ) -> AnalogWatchdog<'_, 'd, T> {
+        assert!(
+            low_threshold <= high_threshold,
+            "low_threshold must be <= high_threshold"
+        );
+        let index = watchdog.index();
+        AnalogWatchdog::<T>::setup_awd(watchdog, channels, low_threshold, high_threshold);
+        AnalogWatchdog::new(self, index)
     }
 }

--- a/embassy-stm32/src/adc/adc4.rs
+++ b/embassy-stm32/src/adc/adc4.rs
@@ -506,7 +506,7 @@ impl<'d, T: Instance<Regs = crate::pac::adc::Adc4>> super::Adc<'d, T> {
         })
     }
 
-    /// Initialize an analog watchdog.
+    /// Enable an analog watchdog and return a guard.
     ///
     /// `watchdog` selects which of the three hardware watchdogs to use. `channels` controls which
     /// ADC channels are monitored; see [`WatchdogChannels`] for which variants are valid for each
@@ -514,25 +514,32 @@ impl<'d, T: Instance<Regs = crate::pac::adc::Adc4>> super::Adc<'d, T> {
     /// the currently configured resolution. The watchdog fires when a sample falls **outside**
     /// `[low_threshold, high_threshold]`.
     ///
+    /// The returned [`AnalogWatchdog`] does **not** borrow the ADC, so you may use the ADC for
+    /// DMA or other operations while the watchdog is active.  Call [`AnalogWatchdog::wait`] to
+    /// detect threshold crossings concurrently, or [`AnalogWatchdog::monitor`] for self-contained
+    /// single-pin monitoring (which temporarily borrows the ADC).
+    ///
+    /// Dropping the guard disables the watchdog and its interrupt.
+    ///
     /// # Panics
     ///
     /// Panics if `low_threshold > high_threshold`, or if a channel selection variant is used that
     /// is not supported by the chosen watchdog (e.g., [`WatchdogChannels::All`] with AWD2/AWD3,
     /// or [`WatchdogChannels::Channels`] with AWD1).
     #[must_use]
-    pub fn init_watchdog(
+    pub fn enable_watchdog(
         &mut self,
         watchdog: WatchdogIndex,
         channels: WatchdogChannels,
         low_threshold: u16,
         high_threshold: u16,
-    ) -> AnalogWatchdog<'_, 'd, T> {
+    ) -> AnalogWatchdog<T> {
         assert!(
             low_threshold <= high_threshold,
             "low_threshold must be <= high_threshold"
         );
         let index = watchdog.index();
         AnalogWatchdog::<T>::setup_awd(watchdog, channels, low_threshold, high_threshold);
-        AnalogWatchdog::new(self, index)
+        AnalogWatchdog::new(index)
     }
 }

--- a/embassy-stm32/src/adc/mod.rs
+++ b/embassy-stm32/src/adc/mod.rs
@@ -26,7 +26,7 @@ use core::marker::PhantomData;
 #[cfg(not(any(adc_f3v3, adc_wba)))]
 pub use _version::*;
 pub use configured_sequence::ConfiguredSequence;
-#[cfg(any(adc_f1, adc_f3v1, adc_v1, adc_l0, adc_f3v2))]
+#[cfg(any(adc_f1, adc_f3v1, adc_v1, adc_l0, adc_f3v2, adc_u5, adc_wba))]
 use embassy_sync::waitqueue::AtomicWaker;
 pub use ringbuffered::RingBufferedAdc;
 
@@ -110,6 +110,27 @@ impl State {
     }
 }
 
+/// ADC state for U5/WBA with per-AWD trigger flags for the analog watchdog driver.
+#[cfg(any(adc_u5, adc_wba))]
+pub struct State {
+    pub waker: AtomicWaker,
+    pub awd_triggered: [core::sync::atomic::AtomicBool; 3],
+}
+
+#[cfg(any(adc_u5, adc_wba))]
+impl State {
+    pub const fn new() -> Self {
+        Self {
+            waker: AtomicWaker::new(),
+            awd_triggered: [
+                core::sync::atomic::AtomicBool::new(false),
+                core::sync::atomic::AtomicBool::new(false),
+                core::sync::atomic::AtomicBool::new(false),
+            ],
+        }
+    }
+}
+
 #[cfg(not(adc_wba))]
 trait_set::trait_set! {
     pub trait DefaultInstance = Instance<Regs = crate::pac::adc::Adc>;
@@ -161,7 +182,7 @@ trait SealedInstance: BasicInstance {
     #[cfg(not(any(adc_f1, adc_v1, adc_l0, adc_f3v3, adc_f3v2, adc_g0)))]
     #[allow(unused)]
     fn common_regs() -> crate::pac::adccommon::AdcCommon;
-    #[cfg(any(adc_f1, adc_f3v1, adc_v1, adc_l0, adc_f3v2))]
+    #[cfg(any(adc_f1, adc_f3v1, adc_v1, adc_l0, adc_f3v2, adc_u5, adc_wba))]
     fn state() -> &'static State;
 }
 
@@ -719,6 +740,11 @@ foreach_adc!(
             fn common_regs() -> crate::pac::adccommon::AdcCommon {
                 return crate::pac::$common_inst
             }
+
+            fn state() -> &'static State {
+                static STATE: State = State::new();
+                &STATE
+            }
         }
 
         impl crate::adc::Instance for peripherals::ADC4 {
@@ -758,6 +784,11 @@ foreach_adc!(
             fn common_regs() -> crate::pac::adccommon::AdcCommon {
                 return crate::pac::$common_inst
             }
+
+            fn state() -> &'static State {
+                static STATE: State = State::new();
+                &STATE
+            }
         }
 
         impl crate::adc::Instance for peripherals::ADC4 {
@@ -777,6 +808,11 @@ foreach_adc!(
 
             fn common_regs() -> crate::pac::adccommon::AdcCommon {
                 return crate::pac::$common_inst
+            }
+
+            fn state() -> &'static State {
+                static STATE: State = State::new();
+                &STATE
             }
         }
 

--- a/embassy-stm32/src/adc/watchdog_adc4.rs
+++ b/embassy-stm32/src/adc/watchdog_adc4.rs
@@ -5,6 +5,7 @@
 compile_error!("watchdog_adc4 is only valid for stm32wba and stm32u5 targets");
 
 use core::future::poll_fn;
+use core::marker::PhantomData;
 use core::sync::atomic::{Ordering, compiler_fence};
 use core::task::Poll;
 
@@ -45,7 +46,7 @@ impl WatchdogIndex {
     }
 }
 
-/// Channel selection passed into [`Adc::init_watchdog`].
+/// Channel selection passed into [`Adc::enable_watchdog`].
 #[derive(Copy, Clone, Debug)]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub enum WatchdogChannels {
@@ -65,36 +66,39 @@ pub enum WatchdogChannels {
 }
 
 /// A driver for an ADC analog watchdog.
-pub struct AnalogWatchdog<'adc, 'd, T: Instance<Regs = crate::pac::adc::Adc4>> {
-    _adc: &'adc mut Adc<'d, T>,
+///
+/// Created by [`Adc::enable_watchdog`].  Does **not** borrow the [`Adc`] — you may hold this
+/// guard while performing DMA or other ADC operations concurrently and call [`Self::wait`] to
+/// detect when a monitored channel leaves the threshold window.
+///
+/// For self-contained single-pin monitoring that drives its own continuous conversion, use
+/// [`Self::monitor`], which temporarily borrows the [`Adc`].
+///
+/// Dropping the guard disables the watchdog and its interrupt.
+pub struct AnalogWatchdog<T: Instance<Regs = crate::pac::adc::Adc4>> {
     index: usize,
     /// True when [`Self::monitor`] started a continuous conversion that must be stopped in Drop.
     stop_on_drop: bool,
+    _phantom: PhantomData<T>,
 }
 
-impl<'adc, 'd, T: Instance<Regs = crate::pac::adc::Adc4>> AnalogWatchdog<'adc, 'd, T> {
-    pub(crate) fn new(adc: &'adc mut Adc<'d, T>, index: usize) -> Self {
+impl<T: Instance<Regs = crate::pac::adc::Adc4>> AnalogWatchdog<T> {
+    pub(crate) fn new(index: usize) -> Self {
         Self {
-            _adc: adc,
             index,
             stop_on_drop: false,
+            _phantom: PhantomData,
         }
     }
 
     /// Wait for the watchdog to trigger.
     ///
-    /// The watchdog is configured in [`Adc::init_watchdog`].
+    /// The watchdog is configured in [`Adc::enable_watchdog`].
     ///
     /// This method assumes conversions are already being performed externally (for example by DMA
     /// or another task running concurrently).  For typical single-pin monitoring driven entirely
     /// by the watchdog driver, prefer [`Self::monitor`].
-    ///
-    /// # Warning
-    ///
-    /// Do **not** call [`Self::monitor`] while an external DMA or task has active conversions and
-    /// you are simultaneously using `wait_for_trigger`.  [`Self::monitor`] stops any in-progress
-    /// conversion when it starts, which would abort the DMA transfer.
-    pub async fn wait_for_trigger(&mut self) {
+    pub async fn wait(&mut self) {
         self.start_awd();
         let index = self.index;
 
@@ -112,23 +116,26 @@ impl<'adc, 'd, T: Instance<Regs = crate::pac::adc::Adc4>> AnalogWatchdog<'adc, '
 
     /// Continuously convert `channel` and return the first result that trips the analog watchdog.
     ///
-    /// Thresholds and watchdog channel selection are configured in [`Adc::init_watchdog`].  When
+    /// Thresholds and watchdog channel selection are configured in [`Adc::enable_watchdog`].  When
     /// using [`WatchdogChannels::Single`], pass the same physical channel here.
     ///
     /// For AWD2/AWD3 with a [`WatchdogChannels::Channels`] bitmask, pass any one of the monitored
     /// channels here; the watchdog will fire when **any** of them leaves the threshold window.
     ///
-    /// # Warning
-    ///
-    /// This method stops any in-progress ADC conversion before starting its own continuous
-    /// conversion.  Do **not** call it while DMA or another task has active conversions — use
-    /// [`Self::wait_for_trigger`] instead.
+    /// This method takes exclusive access to the [`Adc`] for the duration of the operation
+    /// because it stops any in-progress conversion and starts its own.  For concurrent use
+    /// with DMA, use [`Self::wait`] instead.
     ///
     /// # Cancel safety
     ///
     /// If this future is dropped before it resolves, the ongoing continuous conversion is stopped
-    /// and continuous mode is cleared in [`Drop`].
-    pub async fn monitor(&mut self, channel: &mut impl AdcChannel<T>, sample_time: super::SampleTime) -> u16 {
+    /// and continuous mode is cleared when the [`AnalogWatchdog`] guard is dropped.
+    pub async fn monitor(
+        &mut self,
+        _adc: &mut Adc<'_, T>,
+        channel: &mut impl AdcChannel<T>,
+        sample_time: super::SampleTime,
+    ) -> u16 {
         let _scoped_wake_guard = <T as crate::rcc::SealedRccPeripheral>::RCC_INFO.wake_guard();
 
         channel.setup();
@@ -361,7 +368,7 @@ impl<'adc, 'd, T: Instance<Regs = crate::pac::adc::Adc4>> AnalogWatchdog<'adc, '
     }
 }
 
-impl<'adc, 'd, T: Instance<Regs = crate::pac::adc::Adc4>> Drop for AnalogWatchdog<'adc, 'd, T> {
+impl<T: Instance<Regs = crate::pac::adc::Adc4>> Drop for AnalogWatchdog<T> {
     fn drop(&mut self) {
         // Always disable the interrupt and watchdog enable/channel bits.
         T::regs().ier().modify(|w| w.set_awdie(self.index, false));

--- a/embassy-stm32/src/adc/watchdog_adc4.rs
+++ b/embassy-stm32/src/adc/watchdog_adc4.rs
@@ -1,0 +1,383 @@
+// This module is only instantiated for targets that have an ADC4 peripheral (STM32WBA, STM32U5).
+// The threshold/channel register field names differ between the two families; see comments at each
+// site.  If you add support for a new family, ensure the cfg guards below cover it.
+#[cfg(not(any(stm32wba, stm32u5)))]
+compile_error!("watchdog_adc4 is only valid for stm32wba and stm32u5 targets");
+
+use core::future::poll_fn;
+use core::sync::atomic::{Ordering, compiler_fence};
+use core::task::Poll;
+
+use crate::adc::{Adc, AdcChannel, AdcRegs, ConversionMode, Instance};
+use crate::interrupt::typelevel::Interrupt;
+// Both families expose an `Exten` enum for the external-trigger-enable field, but under different
+// names in the PAC.  Import it here under a single alias so the rest of the file is cfg-free.
+#[cfg(stm32u5)]
+use crate::pac::adc::vals::Adc4Exten as Exten;
+#[cfg(stm32wba)]
+use crate::pac::adc::vals::Exten;
+
+/// Select which of the three hardware analog watchdogs to use.
+#[derive(Copy, Clone, Debug)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+pub enum WatchdogIndex {
+    /// First analog watchdog (AWD1).
+    ///
+    /// Supports [`WatchdogChannels::All`] and [`WatchdogChannels::Single`] via CFGR1.
+    Awd1,
+    /// Second analog watchdog (AWD2).
+    ///
+    /// Supports [`WatchdogChannels::Single`] and [`WatchdogChannels::Channels`] via AWD2CR.
+    Awd2,
+    /// Third analog watchdog (AWD3).
+    ///
+    /// Supports [`WatchdogChannels::Single`] and [`WatchdogChannels::Channels`] via AWD3CR.
+    Awd3,
+}
+
+impl WatchdogIndex {
+    pub(crate) fn index(self) -> usize {
+        match self {
+            WatchdogIndex::Awd1 => 0,
+            WatchdogIndex::Awd2 => 1,
+            WatchdogIndex::Awd3 => 2,
+        }
+    }
+}
+
+/// Channel selection passed into [`Adc::init_watchdog`].
+#[derive(Copy, Clone, Debug)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+pub enum WatchdogChannels {
+    /// Monitor all channels in the regular sequence.
+    ///
+    /// Only valid with [`WatchdogIndex::Awd1`].
+    All,
+    /// Monitor a single specific channel.
+    ///
+    /// Valid for all three watchdogs.
+    Single(u8),
+    /// Monitor a bitmask of channels (bit N = channel N).
+    ///
+    /// Only valid with [`WatchdogIndex::Awd2`] and [`WatchdogIndex::Awd3`].
+    /// On STM32WBA: bits 0–13 (14 channels). On STM32U5: bits 0–23 (24 channels).
+    Channels(u32),
+}
+
+/// A driver for an ADC analog watchdog.
+pub struct AnalogWatchdog<'adc, 'd, T: Instance<Regs = crate::pac::adc::Adc4>> {
+    _adc: &'adc mut Adc<'d, T>,
+    index: usize,
+    /// True when [`Self::monitor`] started a continuous conversion that must be stopped in Drop.
+    stop_on_drop: bool,
+}
+
+impl<'adc, 'd, T: Instance<Regs = crate::pac::adc::Adc4>> AnalogWatchdog<'adc, 'd, T> {
+    pub(crate) fn new(adc: &'adc mut Adc<'d, T>, index: usize) -> Self {
+        Self {
+            _adc: adc,
+            index,
+            stop_on_drop: false,
+        }
+    }
+
+    /// Wait for the watchdog to trigger.
+    ///
+    /// The watchdog is configured in [`Adc::init_watchdog`].
+    ///
+    /// This method assumes conversions are already being performed externally (for example by DMA
+    /// or another task running concurrently).  For typical single-pin monitoring driven entirely
+    /// by the watchdog driver, prefer [`Self::monitor`].
+    ///
+    /// # Warning
+    ///
+    /// Do **not** call [`Self::monitor`] while an external DMA or task has active conversions and
+    /// you are simultaneously using `wait_for_trigger`.  [`Self::monitor`] stops any in-progress
+    /// conversion when it starts, which would abort the DMA transfer.
+    pub async fn wait_for_trigger(&mut self) {
+        self.start_awd();
+        let index = self.index;
+
+        poll_fn(|cx| {
+            T::state().waker.register(cx.waker());
+
+            if T::state().awd_triggered[index].load(Ordering::Acquire) {
+                Poll::Ready(())
+            } else {
+                Poll::Pending
+            }
+        })
+        .await;
+    }
+
+    /// Continuously convert `channel` and return the first result that trips the analog watchdog.
+    ///
+    /// Thresholds and watchdog channel selection are configured in [`Adc::init_watchdog`].  When
+    /// using [`WatchdogChannels::Single`], pass the same physical channel here.
+    ///
+    /// For AWD2/AWD3 with a [`WatchdogChannels::Channels`] bitmask, pass any one of the monitored
+    /// channels here; the watchdog will fire when **any** of them leaves the threshold window.
+    ///
+    /// # Warning
+    ///
+    /// This method stops any in-progress ADC conversion before starting its own continuous
+    /// conversion.  Do **not** call it while DMA or another task has active conversions — use
+    /// [`Self::wait_for_trigger`] instead.
+    ///
+    /// # Cancel safety
+    ///
+    /// If this future is dropped before it resolves, the ongoing continuous conversion is stopped
+    /// and continuous mode is cleared in [`Drop`].
+    pub async fn monitor(&mut self, channel: &mut impl AdcChannel<T>, sample_time: super::SampleTime) -> u16 {
+        let _scoped_wake_guard = <T as crate::rcc::SealedRccPeripheral>::RCC_INFO.wake_guard();
+
+        channel.setup();
+
+        T::regs().stop(false);
+        T::regs().configure_sequence([((channel.channel(), channel.is_differential()), sample_time)].into_iter());
+        T::regs().enable();
+        T::regs().configure_dma(ConversionMode::NoDma);
+
+        T::regs().cfgr1().modify(|w| {
+            w.set_cont(true);
+            w.set_exten(Exten::Disabled);
+        });
+
+        // Record that Drop must stop the ADC if this future is cancelled.
+        self.stop_on_drop = true;
+
+        self.start_awd();
+        T::regs().start();
+
+        let index = self.index;
+        let sample = poll_fn(|cx| {
+            T::state().waker.register(cx.waker());
+            compiler_fence(Ordering::SeqCst);
+
+            if T::state().awd_triggered[index].load(Ordering::Acquire) {
+                Poll::Ready(unsafe { core::ptr::read_volatile(T::regs().data()) })
+            } else {
+                Poll::Pending
+            }
+        })
+        .await;
+
+        // Normal completion: stop here so Drop does not do a redundant stop.
+        T::regs().stop(false);
+        T::regs().cfgr1().modify(|w| w.set_cont(false));
+        self.stop_on_drop = false;
+        sample
+    }
+
+    pub(crate) fn setup_awd(
+        watchdog: WatchdogIndex,
+        channels: WatchdogChannels,
+        low_threshold: u16,
+        high_threshold: u16,
+    ) {
+        match watchdog {
+            WatchdogIndex::Awd1 => {
+                // AWD1 threshold register field names differ between families:
+                //   STM32WBA: lt1 / ht1 (named after the watchdog index)
+                //   STM32U5:  lt3 / ht3 (the Adc4Awdtr struct reuses suffix "3" for all three
+                //             watchdog threshold registers on that family — it is not the AWD3 field)
+                T::regs().awd1tr().modify(|w| {
+                    #[cfg(stm32wba)]
+                    {
+                        w.set_lt1(low_threshold);
+                        w.set_ht1(high_threshold);
+                    }
+                    #[cfg(stm32u5)]
+                    {
+                        w.set_lt3(low_threshold);
+                        w.set_ht3(high_threshold);
+                    }
+                });
+
+                T::regs().cfgr1().modify(|w| {
+                    w.set_awd1en(true);
+                    #[cfg(stm32wba)]
+                    {
+                        use crate::pac::adc::vals::Awd1sgl;
+                        match channels {
+                            WatchdogChannels::Single(ch) => {
+                                w.set_awd1sgl(Awd1sgl::SingleChannel);
+                                w.set_awd1ch(ch);
+                            }
+                            WatchdogChannels::All => {
+                                w.set_awd1sgl(Awd1sgl::AllChannels);
+                            }
+                            WatchdogChannels::Channels(_) => {
+                                panic!(
+                                    "WatchdogChannels::Channels bitmask is not supported for AWD1; use Single or All"
+                                );
+                            }
+                        }
+                    }
+                    #[cfg(stm32u5)]
+                    {
+                        match channels {
+                            WatchdogChannels::Single(ch) => {
+                                w.set_awd1sgl(true);
+                                w.set_awd1ch(ch);
+                            }
+                            WatchdogChannels::All => {
+                                w.set_awd1sgl(false);
+                            }
+                            WatchdogChannels::Channels(_) => {
+                                panic!(
+                                    "WatchdogChannels::Channels bitmask is not supported for AWD1; use Single or All"
+                                );
+                            }
+                        }
+                    }
+                });
+            }
+
+            WatchdogIndex::Awd2 => {
+                // AWD2 threshold register field names:
+                //   STM32WBA: lt2 / ht2  (Awd2tr struct, named after watchdog 2)
+                //   STM32U5:  lt3 / ht3  (same Adc4Awdtr struct used for all three watchdogs;
+                //             the suffix "3" is a PAC implementation detail, not the AWD index)
+                T::regs().awd2tr().modify(|w| {
+                    #[cfg(stm32wba)]
+                    {
+                        w.set_lt2(low_threshold);
+                        w.set_ht2(high_threshold);
+                    }
+                    #[cfg(stm32u5)]
+                    {
+                        w.set_lt3(low_threshold);
+                        w.set_ht3(high_threshold);
+                    }
+                });
+
+                // AWD2/AWD3 use a dedicated channel-bitmask register (AWD2CR/AWD3CR) rather than
+                // CFGR1 fields; setting any bit enables monitoring of that channel.
+                T::regs().awd2cr().modify(|w| {
+                    // Clear all channel bits first, then set the requested ones.
+                    #[cfg(stm32wba)]
+                    {
+                        for n in 0..14usize {
+                            w.set_awd2ch(n, false);
+                        }
+                        match channels {
+                            WatchdogChannels::Single(ch) => w.set_awd2ch(ch as usize, true),
+                            WatchdogChannels::Channels(mask) => {
+                                for n in 0..14usize {
+                                    if mask & (1 << n) != 0 {
+                                        w.set_awd2ch(n, true);
+                                    }
+                                }
+                            }
+                            WatchdogChannels::All => {
+                                panic!("WatchdogChannels::All is not supported for AWD2; use Channels(0x3FFF) to monitor all 14 channels");
+                            }
+                        }
+                    }
+                    #[cfg(stm32u5)]
+                    {
+                        for n in 0..24usize {
+                            w.set_awdch(n, false);
+                        }
+                        match channels {
+                            WatchdogChannels::Single(ch) => w.set_awdch(ch as usize, true),
+                            WatchdogChannels::Channels(mask) => {
+                                for n in 0..24usize {
+                                    if mask & (1 << n) != 0 {
+                                        w.set_awdch(n, true);
+                                    }
+                                }
+                            }
+                            WatchdogChannels::All => {
+                                panic!("WatchdogChannels::All is not supported for AWD2; use Channels(0xFFFFFF) to monitor all 24 channels");
+                            }
+                        }
+                    }
+                });
+            }
+
+            WatchdogIndex::Awd3 => {
+                // AWD3 threshold register: both WBA (Awd3tr) and U5 (Adc4Awdtr) happen to expose
+                // the fields as lt3/ht3, so no cfg split is needed here.
+                T::regs().awd3tr().modify(|w| {
+                    w.set_lt3(low_threshold);
+                    w.set_ht3(high_threshold);
+                });
+
+                T::regs().awd3cr().modify(|w| {
+                    #[cfg(stm32wba)]
+                    {
+                        for n in 0..14usize {
+                            w.set_awd3ch(n, false);
+                        }
+                        match channels {
+                            WatchdogChannels::Single(ch) => w.set_awd3ch(ch as usize, true),
+                            WatchdogChannels::Channels(mask) => {
+                                for n in 0..14usize {
+                                    if mask & (1 << n) != 0 {
+                                        w.set_awd3ch(n, true);
+                                    }
+                                }
+                            }
+                            WatchdogChannels::All => {
+                                panic!("WatchdogChannels::All is not supported for AWD3; use Channels(0x3FFF) to monitor all 14 channels");
+                            }
+                        }
+                    }
+                    #[cfg(stm32u5)]
+                    {
+                        for n in 0..24usize {
+                            w.set_awdch(n, false);
+                        }
+                        match channels {
+                            WatchdogChannels::Single(ch) => w.set_awdch(ch as usize, true),
+                            WatchdogChannels::Channels(mask) => {
+                                for n in 0..24usize {
+                                    if mask & (1 << n) != 0 {
+                                        w.set_awdch(n, true);
+                                    }
+                                }
+                            }
+                            WatchdogChannels::All => {
+                                panic!("WatchdogChannels::All is not supported for AWD3; use Channels(0xFFFFFF) to monitor all 24 channels");
+                            }
+                        }
+                    }
+                });
+            }
+        }
+    }
+
+    fn start_awd(&mut self) {
+        // Reset atomic flag, clear hardware ISR flag, enable NVIC + AWDIE.
+        T::state().awd_triggered[self.index].store(false, Ordering::Release);
+        T::regs().isr().write(|w| w.set_awd(self.index, true));
+        T::Interrupt::unpend();
+        unsafe {
+            T::Interrupt::enable();
+        }
+        T::regs().ier().modify(|w| w.set_awdie(self.index, true));
+    }
+}
+
+impl<'adc, 'd, T: Instance<Regs = crate::pac::adc::Adc4>> Drop for AnalogWatchdog<'adc, 'd, T> {
+    fn drop(&mut self) {
+        // Always disable the interrupt and watchdog enable/channel bits.
+        T::regs().ier().modify(|w| w.set_awdie(self.index, false));
+
+        match self.index {
+            0 => T::regs().cfgr1().modify(|w| w.set_awd1en(false)),
+            1 => T::regs().awd2cr().modify(|w| *w = Default::default()),
+            2 => T::regs().awd3cr().modify(|w| *w = Default::default()),
+            _ => {}
+        }
+
+        // If monitor() started a continuous conversion that was not stopped normally (i.e. the
+        // future was cancelled), stop the ADC and clear continuous mode now.
+        if self.stop_on_drop {
+            T::regs().stop(false);
+            T::regs().cfgr1().modify(|w| w.set_cont(false));
+        }
+    }
+}

--- a/examples/stm32wba/src/bin/adc-watchdog.rs
+++ b/examples/stm32wba/src/bin/adc-watchdog.rs
@@ -34,26 +34,26 @@ async fn main(_spawner: Spawner) {
     loop {
         {
             // Wait for PA0 to exceed ~0.6 V (raw > 0x07F at 12-bit / 3.3 V).
-            let mut wd = adc.init_watchdog(
+            let mut wd = adc.enable_watchdog(
                 adc4::WatchdogIndex::Awd1,
                 adc4::WatchdogChannels::Single(pin_ch),
                 0,
                 0x07F,
             );
-            let raw = wd.monitor(&mut pin, SampleTime::Cycles125).await;
+            let raw = wd.monitor(&mut adc, &mut pin, SampleTime::Cycles125).await;
             let v = 3.3 * raw as f32 / max as f32;
             info!("Above high threshold, raw={} ~{} V", raw, v);
         }
 
         {
             // Wait for PA0 to drop below ~0.2 V (raw < 0x01F at 12-bit / 3.3 V).
-            let mut wd = adc.init_watchdog(
+            let mut wd = adc.enable_watchdog(
                 adc4::WatchdogIndex::Awd1,
                 adc4::WatchdogChannels::Single(pin_ch),
                 0x01F,
                 0x0FFF,
             );
-            let raw = wd.monitor(&mut pin, SampleTime::Cycles125).await;
+            let raw = wd.monitor(&mut adc, &mut pin, SampleTime::Cycles125).await;
             let v = 3.3 * raw as f32 / max as f32;
             info!("Below low threshold, raw={} ~{} V", raw, v);
         }

--- a/examples/stm32wba/src/bin/adc-watchdog.rs
+++ b/examples/stm32wba/src/bin/adc-watchdog.rs
@@ -1,0 +1,61 @@
+//! ADC4 analog watchdog: wait for a pin voltage to leave a programmed window.
+//!
+//! Connect a voltage source or potentiometer to **PA0** (ADC4 channel 9). The example waits for the
+//! sample to go above ~0.6 V, then waits for it to fall below ~0.2 V, and repeats.
+
+#![no_std]
+#![no_main]
+
+use defmt::*;
+use embassy_executor::Spawner;
+use embassy_stm32::adc::{Adc, AdcChannel, SampleTime, adc4};
+use embassy_stm32::{bind_interrupts, peripherals};
+use {defmt_rtt as _, panic_probe as _};
+
+bind_interrupts!(struct Irqs {
+    ADC4 => adc4::InterruptHandler<peripherals::ADC4>;
+});
+
+#[embassy_executor::main]
+async fn main(_spawner: Spawner) {
+    let p = embassy_stm32::init(Default::default());
+
+    info!("ADC4 analog watchdog example (PA0)");
+
+    let mut adc = Adc::new_adc4(p.ADC4);
+    let mut pin = p.PA0;
+    adc.set_resolution_adc4(adc4::Resolution::Bits12);
+    adc.set_averaging_adc4(adc4::Averaging::Disabled);
+
+    let pin_ch = pin.degrade_adc().get_hw_channel();
+
+    let max = adc4::resolution_to_max_count(adc4::Resolution::Bits12);
+
+    loop {
+        {
+            // Wait for PA0 to exceed ~0.6 V (raw > 0x07F at 12-bit / 3.3 V).
+            let mut wd = adc.init_watchdog(
+                adc4::WatchdogIndex::Awd1,
+                adc4::WatchdogChannels::Single(pin_ch),
+                0,
+                0x07F,
+            );
+            let raw = wd.monitor(&mut pin, SampleTime::Cycles125).await;
+            let v = 3.3 * raw as f32 / max as f32;
+            info!("Above high threshold, raw={} ~{} V", raw, v);
+        }
+
+        {
+            // Wait for PA0 to drop below ~0.2 V (raw < 0x01F at 12-bit / 3.3 V).
+            let mut wd = adc.init_watchdog(
+                adc4::WatchdogIndex::Awd1,
+                adc4::WatchdogChannels::Single(pin_ch),
+                0x01F,
+                0x0FFF,
+            );
+            let raw = wd.monitor(&mut pin, SampleTime::Cycles125).await;
+            let v = 3.3 * raw as f32 / max as f32;
+            info!("Below low threshold, raw={} ~{} V", raw, v);
+        }
+    }
+}

--- a/examples/stm32wba6/src/bin/adc-watchdog.rs
+++ b/examples/stm32wba6/src/bin/adc-watchdog.rs
@@ -56,26 +56,26 @@ async fn main(_spawner: Spawner) {
     loop {
         {
             // Wait for PA0 to exceed ~0.6 V (raw > 0x07F at 12-bit / 3.3 V).
-            let mut wd = adc.init_watchdog(
+            let mut wd = adc.enable_watchdog(
                 adc4::WatchdogIndex::Awd1,
                 adc4::WatchdogChannels::Single(pin_ch),
                 0,
                 0x07F,
             );
-            let raw = wd.monitor(&mut pin, SampleTime::Cycles125).await;
+            let raw = wd.monitor(&mut adc, &mut pin, SampleTime::Cycles125).await;
             let v = 3.3 * raw as f32 / max as f32;
             info!("Above high threshold, raw={} ~{} V", raw, v);
         }
 
         {
             // Wait for PA0 to drop below ~0.2 V (raw < 0x01F at 12-bit / 3.3 V).
-            let mut wd = adc.init_watchdog(
+            let mut wd = adc.enable_watchdog(
                 adc4::WatchdogIndex::Awd1,
                 adc4::WatchdogChannels::Single(pin_ch),
                 0x01F,
                 0x0FFF,
             );
-            let raw = wd.monitor(&mut pin, SampleTime::Cycles125).await;
+            let raw = wd.monitor(&mut adc, &mut pin, SampleTime::Cycles125).await;
             let v = 3.3 * raw as f32 / max as f32;
             info!("Below low threshold, raw={} ~{} V", raw, v);
         }

--- a/examples/stm32wba6/src/bin/adc-watchdog.rs
+++ b/examples/stm32wba6/src/bin/adc-watchdog.rs
@@ -1,0 +1,83 @@
+//! ADC4 analog watchdog: wait for a pin voltage to leave a programmed window.
+//!
+//! Connect a voltage source or potentiometer to **PA0** (ADC4 channel 9). The example waits for the
+//! sample to go above ~0.6 V, then waits for it to fall below ~0.2 V, and repeats.
+
+#![no_std]
+#![no_main]
+
+use defmt::*;
+use embassy_executor::Spawner;
+use embassy_stm32::adc::{Adc, AdcChannel, SampleTime, adc4};
+use embassy_stm32::rcc::{
+    AHB5Prescaler, AHBPrescaler, APBPrescaler, PllDiv, PllMul, PllPreDiv, PllSource, Sysclk, VoltageScale,
+};
+use embassy_stm32::{Config, bind_interrupts, peripherals};
+use {defmt_rtt as _, panic_probe as _};
+
+bind_interrupts!(struct Irqs {
+    ADC4 => adc4::InterruptHandler<peripherals::ADC4>;
+});
+
+#[embassy_executor::main]
+async fn main(_spawner: Spawner) {
+    let mut config = Config::default();
+    config.rcc.pll1 = Some(embassy_stm32::rcc::Pll {
+        source: PllSource::Hsi,
+        prediv: PllPreDiv::Div1,
+        mul: PllMul::Mul30,
+        divr: Some(PllDiv::Div5),
+        divq: None,
+        divp: Some(PllDiv::Div30),
+        frac: Some(0),
+    });
+
+    config.rcc.ahb_pre = AHBPrescaler::Div1;
+    config.rcc.apb1_pre = APBPrescaler::Div1;
+    config.rcc.apb2_pre = APBPrescaler::Div1;
+    config.rcc.apb7_pre = APBPrescaler::Div1;
+    config.rcc.ahb5_pre = AHB5Prescaler::Div4;
+    config.rcc.voltage_scale = VoltageScale::Range1;
+    config.rcc.sys = Sysclk::Pll1R;
+
+    let p = embassy_stm32::init(config);
+
+    info!("ADC4 analog watchdog example (PA0)");
+
+    let mut adc = Adc::new_adc4(p.ADC4);
+    let mut pin = p.PA0;
+    adc.set_resolution_adc4(adc4::Resolution::Bits12);
+    adc.set_averaging_adc4(adc4::Averaging::Disabled);
+
+    let pin_ch = pin.degrade_adc().get_hw_channel();
+
+    let max = adc4::resolution_to_max_count(adc4::Resolution::Bits12);
+
+    loop {
+        {
+            // Wait for PA0 to exceed ~0.6 V (raw > 0x07F at 12-bit / 3.3 V).
+            let mut wd = adc.init_watchdog(
+                adc4::WatchdogIndex::Awd1,
+                adc4::WatchdogChannels::Single(pin_ch),
+                0,
+                0x07F,
+            );
+            let raw = wd.monitor(&mut pin, SampleTime::Cycles125).await;
+            let v = 3.3 * raw as f32 / max as f32;
+            info!("Above high threshold, raw={} ~{} V", raw, v);
+        }
+
+        {
+            // Wait for PA0 to drop below ~0.2 V (raw < 0x01F at 12-bit / 3.3 V).
+            let mut wd = adc.init_watchdog(
+                adc4::WatchdogIndex::Awd1,
+                adc4::WatchdogChannels::Single(pin_ch),
+                0x01F,
+                0x0FFF,
+            );
+            let raw = wd.monitor(&mut pin, SampleTime::Cycles125).await;
+            let v = 3.3 * raw as f32 / max as f32;
+            info!("Below low threshold, raw={} ~{} V", raw, v);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- Add async analog watchdog driver for STM32 ADC4 peripherals (WBA and U5 families)
- Supports all three hardware watchdogs (AWD1/AWD2/AWD3) with single-channel, all-channel, and bitmask modes
- `monitor()` runs continuous conversion and returns the sample that trips the threshold; `wait_for_trigger()` waits while external conversions (e.g. DMA) are running
- Adds `InterruptHandler` for ADC4 with proper AWD interrupt handling: clears ISR flag (W1C), read-back barrier to prevent NVIC re-entry, signals driver via per-AWD `AtomicBool`
- Fixes `configure_dma()` using `.modify()` on W1C ISR register — changed to `.write()` to avoid accidentally clearing unrelated flags (matches ST HAL `WRITE_REG` pattern)