### PR TITLE
USB host: Remove unnecessary abstractions

### DIFF
--- a/embassy-usb-host/src/class/hub.rs
+++ b/embassy-usb-host/src/class/hub.rs
@@ -14,7 +14,7 @@ use zerocopy::{FromBytes, Immutable, IntoBytes, KnownLayout};
 
 use crate::control::{CLEAR_FEATURE, ControlChannelExt, GET_STATUS, SET_FEATURE};
 use crate::descriptor::{DEFAULT_MAX_DESCRIPTOR_SIZE, InterfaceDescriptor, USBDescriptor};
-use crate::handler::{EnumerationInfo, HandlerEvent, RegisterError, UsbHostHandler};
+use crate::handler::{EnumerationInfo, HandlerEvent, RegisterError};
 
 pub struct HubHandler<H: UsbHostDriver, const MAX_PORTS: usize> {
     interrupt_channel: H::Channel<channel::Interrupt, channel::In>,
@@ -32,22 +32,9 @@ pub enum HubEvent {
     DeviceRemoved { address: Option<NonZeroU8>, port: u8 },
 }
 
-impl<H: UsbHostDriver, const MAX_PORTS: usize> UsbHostHandler for HubHandler<H, MAX_PORTS> {
-    type PollEvent = HubEvent;
-    type Driver = H;
-
-    fn static_spec() -> crate::handler::StaticHandlerSpec {
-        use crate::handler::{DeviceFilter, StaticHandlerSpec};
-        StaticHandlerSpec {
-            device_filter: Some(DeviceFilter {
-                base_class: Some(unsafe { NonZeroU8::new_unchecked(0x09) }), // Hub
-                sub_class: Some(0x00),
-                protocol: None,
-            }),
-        }
-    }
-
-    async fn try_register(bus: &H, enum_info: &EnumerationInfo) -> Result<Self, RegisterError> {
+impl<H: UsbHostDriver, const MAX_PORTS: usize> HubHandler<H, MAX_PORTS> {
+    /// Attempt to register a hub handler for the given device.
+    pub async fn try_register(bus: &H, enum_info: &EnumerationInfo) -> Result<Self, RegisterError> {
         let mut control_channel = bus.alloc_channel::<channel::Control, channel::InOut>(
             enum_info.device_address,
             &EndpointInfo {
@@ -112,7 +99,8 @@ impl<H: UsbHostDriver, const MAX_PORTS: usize> UsbHostHandler for HubHandler<H, 
         Ok(hub)
     }
 
-    async fn wait_for_event(&mut self) -> Result<HandlerEvent<HubEvent>, HostError> {
+    /// Wait for a hub port status change event.
+    pub async fn wait_for_event(&mut self) -> Result<HandlerEvent<HubEvent>, HostError> {
         loop {
             let mut buf = [0u8; 16];
             let slice = &mut buf[..(self.desc.port_num as usize / 8) + 1];
@@ -156,9 +144,7 @@ impl<H: UsbHostDriver, const MAX_PORTS: usize> UsbHostHandler for HubHandler<H, 
             }
         }
     }
-}
 
-impl<H: UsbHostDriver, const MAX_PORTS: usize> HubHandler<H, MAX_PORTS> {
     /// Reset a port and enumerate the device attached to it.
     pub async fn enumerate_port(
         &mut self,

--- a/embassy-usb-host/src/class/kbd.rs
+++ b/embassy-usb-host/src/class/kbd.rs
@@ -9,7 +9,7 @@ use embassy_usb_driver::{Direction, EndpointInfo, EndpointType};
 
 use crate::control::ControlChannelExt;
 use crate::descriptor::{DEFAULT_MAX_DESCRIPTOR_SIZE, InterfaceDescriptor, USBDescriptor};
-use crate::handler::{EnumerationInfo, HandlerEvent, RegisterError, UsbHostHandler};
+use crate::handler::{EnumerationInfo, HandlerEvent, RegisterError};
 
 #[repr(C)]
 #[derive(Debug)]
@@ -42,15 +42,9 @@ pub struct KbdHandler<H: UsbHostDriver> {
     control_channel: H::Channel<channel::Control, channel::InOut>,
 }
 
-impl<H: UsbHostDriver> UsbHostHandler for KbdHandler<H> {
-    type PollEvent = KbdEvent;
-    type Driver = H;
-
-    fn static_spec() -> crate::handler::StaticHandlerSpec {
-        crate::handler::StaticHandlerSpec { device_filter: None }
-    }
-
-    async fn try_register(bus: &H, enum_info: &EnumerationInfo) -> Result<Self, RegisterError> {
+impl<H: UsbHostDriver> KbdHandler<H> {
+    /// Attempt to register a keyboard handler for the given device.
+    pub async fn try_register(bus: &H, enum_info: &EnumerationInfo) -> Result<Self, RegisterError> {
         let mut control_channel = bus.alloc_channel::<channel::Control, channel::InOut>(
             enum_info.device_address,
             &EndpointInfo {
@@ -121,7 +115,8 @@ impl<H: UsbHostDriver> UsbHostHandler for KbdHandler<H> {
         })
     }
 
-    async fn wait_for_event(&mut self) -> Result<HandlerEvent<Self::PollEvent>, HostError> {
+    /// Wait for the next keyboard event.
+    pub async fn wait_for_event(&mut self) -> Result<HandlerEvent<KbdEvent>, HostError> {
         let mut buffer = [0u8; 8];
         debug!("[kbd]: Requesting interrupt IN");
         self.interrupt_channel.request_in(&mut buffer[..]).await?;
@@ -129,6 +124,15 @@ impl<H: UsbHostDriver> UsbHostHandler for KbdHandler<H> {
         Ok(HandlerEvent::HandlerEvent(KbdEvent::KeyStatusUpdate(
             KeyStatusUpdate::from_buffer_unchecked(buffer),
         )))
+    }
+
+    /// SET_REPORT — update keyboard LEDs.
+    pub async fn set_state(&mut self, state: &KeyboardState) -> Result<(), HostError> {
+        const SET_REPORT: u8 = 0x09;
+        const OUTPUT_REPORT: u16 = 2 << 8;
+        self.control_channel
+            .class_request_out(SET_REPORT, OUTPUT_REPORT, 0, &[state.bits()])
+            .await
     }
 }
 
@@ -140,17 +144,6 @@ bitflags! {
         const SCROLL_LOCK = 1 << 2;
         const COMPOSE     = 1 << 3;
         const KANA        = 1 << 4;
-    }
-}
-
-impl<H: UsbHostDriver> KbdHandler<H> {
-    /// SET_REPORT — update keyboard LEDs.
-    pub async fn set_state(&mut self, state: &KeyboardState) -> Result<(), HostError> {
-        const SET_REPORT: u8 = 0x09;
-        const OUTPUT_REPORT: u16 = 2 << 8;
-        self.control_channel
-            .class_request_out(SET_REPORT, OUTPUT_REPORT, 0, &[state.bits()])
-            .await
     }
 }
 

--- a/embassy-usb-host/src/handler.rs
+++ b/embassy-usb-host/src/handler.rs
@@ -1,34 +1,12 @@
-//! USB host handler trait and device enumeration helpers.
+//! USB host device enumeration helpers.
 #![allow(missing_docs)]
-
-use core::num::NonZeroU8;
 
 use embassy_usb_driver::Speed;
 use embassy_usb_driver::host::channel::{self, IsIn, IsOut};
-use embassy_usb_driver::host::{HostError, UsbChannel, UsbHostDriver};
+use embassy_usb_driver::host::{HostError, UsbChannel};
 
 use crate::control::ControlChannelExt;
 use crate::descriptor::{ConfigurationDescriptor, DeviceDescriptor, USBDescriptor};
-
-/// A non-exhaustive filter applied before calling [`UsbHostHandler::try_register`].
-pub struct DeviceFilter {
-    /// Device base-class; `None` or `0` means class is defined at the interface level.
-    pub base_class: Option<NonZeroU8>,
-    pub sub_class: Option<u8>,
-    pub protocol: Option<u8>,
-}
-
-/// Static specification returned by [`UsbHostHandler::static_spec`].
-pub struct StaticHandlerSpec {
-    /// Optional pre-filter — avoids calling `try_register` for clearly mismatched devices.
-    pub device_filter: Option<DeviceFilter>,
-}
-
-impl StaticHandlerSpec {
-    pub fn new(device_filter: Option<DeviceFilter>) -> Self {
-        StaticHandlerSpec { device_filter }
-    }
-}
 
 /// Information obtained through preliminary enumeration.
 #[derive(Debug)]
@@ -151,29 +129,4 @@ impl From<HostError> for RegisterError {
     fn from(value: HostError) -> Self {
         RegisterError::HostError(value)
     }
-}
-
-/// A USB host-side class driver.
-///
-/// Implemented by class drivers (HID, CDC-ACM, Hub, …). The host calls
-/// [`try_register`](UsbHostHandler::try_register) after enumeration; on success the driver owns
-/// the relevant channels and events are polled via [`wait_for_event`](UsbHostHandler::wait_for_event).
-pub trait UsbHostHandler: Sized {
-    type Driver: UsbHostDriver;
-    type PollEvent;
-
-    fn static_spec() -> StaticHandlerSpec;
-
-    async fn try_register(bus: &Self::Driver, enum_info: &EnumerationInfo) -> Result<Self, RegisterError>;
-
-    async fn wait_for_event(&mut self) -> Result<HandlerEvent<Self::PollEvent>, HostError>;
-}
-
-/// Extension of [`UsbHostHandler`] that supports suspension (dropping channels) and resumption.
-pub trait UsbResumableHandler: UsbHostHandler {
-    type UsbResumeInfo;
-
-    async fn try_resume(bus: &Self::Driver, resume_info: Self::UsbResumeInfo) -> Result<Self, ()>;
-
-    async fn try_suspend(self, bus: &mut Self::Driver) -> Self::UsbResumeInfo;
 }


### PR DESCRIPTION
I have asked Claude to reevaluate the need for `UsbHostHandler` and remove it if it can, because it looked to me like the trait and some of its satellites were leftovers of a previous implementation - although even in #3307 nothing really needed this trait to exist.

Claude's output:

Here's a summary of what was removed and why:

**Removed from `handler.rs`:**
- `UsbHostHandler` trait — never used as a generic bound or for dynamic dispatch; its methods were only called as concrete methods on `HubHandler` and `KbdHandler`
- `UsbResumableHandler` trait — had **zero** implementations anywhere
- `DeviceFilter` struct — only used inside `static_spec()`, which was dead code
- `StaticHandlerSpec` struct — same; never called anywhere

**Kept in `handler.rs`:**
- `EnumerationInfo` — actively used by hub, kbd, uac, and control modules
- `HandlerEvent` — used by hub and kbd
- `RegisterError` — used by hub, kbd, and uac

**Converted in `hub.rs` and `kbd.rs`:**
- `impl UsbHostHandler for X` blocks became inherent `impl X` blocks
- `static_spec()` methods were dropped entirely (dead code)
- `try_register` and `wait_for_event` are now `pub` inherent methods, matching the pattern already used by the newer class drivers (`GipHost`, `CdcAcmHost`, `HidHost`)