### PR TITLE
embassy-net: Avoid looping if the link is down

### DIFF
--- a/embassy-net/CHANGELOG.md
+++ b/embassy-net/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 <!-- next-header -->
 ## Unreleased - ReleaseDate
 
+- Avoid looping forever if the network interface is down.
+
 ## 0.9.0 - 2026-03-10
 
 - raw: Removed unnecessary Driver type parameter from `RawSocket::new`

--- a/embassy-net/src/lib.rs
+++ b/embassy-net/src/lib.rs
@@ -961,10 +961,12 @@ impl Inner {
             self.apply_static_config()
         }
 
-        if let Some(poll_at) = self.iface.poll_at(timestamp, &mut self.sockets) {
-            let t = pin!(Timer::at(instant_from_smoltcp(poll_at)));
-            if t.poll(cx).is_ready() {
-                cx.waker().wake_by_ref();
+        if self.link_up {
+            if let Some(poll_at) = self.iface.poll_at(timestamp, &mut self.sockets) {
+                let t = pin!(Timer::at(instant_from_smoltcp(poll_at)));
+                if t.poll(cx).is_ready() {
+                    cx.waker().wake_by_ref();
+                }
             }
         }
     }


### PR DESCRIPTION
When the network device is down, smoltcp may return a request for immediate re-polling (see https://github.com/esp-rs/esp-hal/issues/4973) which, because the link is down, will not do anything useful. This PR only queries for a re-poll request when the link is up, which can prevent the runner task from consuming all CPU time in this case.

