### PR TITLE
Address GPDMA race condition in ringbuffered mode

### DIFF
--- a/embassy-stm32/src/dma/gpdma/linked_list.rs
+++ b/embassy-stm32/src/dma/gpdma/linked_list.rs
@@ -165,6 +165,26 @@ impl<const ITEM_COUNT: usize> Table<ITEM_COUNT> {
         Self { items }
     }
 
+    /// Create a single-LLI circular linked-list table.
+    ///
+    /// Uses one linked-list item covering the entire buffer, linked to itself.
+    /// This avoids multi-LLI race conditions in position tracking while still
+    /// providing half-transfer and transfer-complete interrupts for wakeups.
+    pub unsafe fn new_circular<W: Word>(
+        request: Request,
+        peri_addr: *mut W,
+        buffer: &mut [W],
+        direction: Dir,
+    ) -> Table<1> {
+        let item = match direction {
+            Dir::MemoryToPeripheral => LinearItem::new_write(request, &buffer[..], peri_addr),
+            Dir::PeripheralToMemory => LinearItem::new_read(request, peri_addr, &mut buffer[..]),
+            Dir::MemoryToMemory => panic!("memory-to-memory transfers are not valid for LinearItem"),
+        };
+
+        Table::new([item])
+    }
+
     /// Create a ping-pong linked-list table.
     ///
     /// This uses two linked-list items, one for each half of the buffer.

--- a/embassy-stm32/src/dma/gpdma/ringbuffered.rs
+++ b/embassy-stm32/src/dma/gpdma/ringbuffered.rs
@@ -35,8 +35,7 @@ impl<'a> DmaCtrlImpl<'a> {
     }
 
     /// Compute remaining transfers from hardware and LLI state.
-    /// Must be called with interrupts disabled (inside a critical section).
-    fn compute_remaining(&self) -> usize {
+    fn compute_remaining(&self, _cs: critical_section::CriticalSection) -> usize {
         let state = &STATE[self.channel.channel as usize];
         let lli_count = state.lli_state.count.load(Ordering::Relaxed);
 
@@ -69,9 +68,9 @@ impl<'a> DmaCtrl for DmaCtrlImpl<'a> {
         // Snapshot complete_count and BNDT atomically by disabling interrupts.
         // This prevents the DMA ISR from modifying complete_count or lli_index
         // between the two reads, eliminating the race that causes DmaUnsynced.
-        critical_section::with(|_| {
+        critical_section::with(|cs| {
             let count = state.complete_count.swap(0, Ordering::AcqRel);
-            self.cached_remaining = self.compute_remaining();
+            self.cached_remaining = self.compute_remaining(cs);
             count
         })
     }

--- a/embassy-stm32/src/dma/gpdma/ringbuffered.rs
+++ b/embassy-stm32/src/dma/gpdma/ringbuffered.rs
@@ -13,36 +13,71 @@ use crate::dma::word::Word;
 use crate::dma::{Dir, Request};
 use crate::rcc::WakeGuard;
 
-struct DmaCtrlImpl<'a>(Channel<'a>);
+/// DmaCtrl implementation for GPDMA linked-list ring buffers.
+///
+/// Uses a critical section in `reset_complete_count` to atomically snapshot both
+/// `complete_count` and the hardware BNDT register. This prevents the DMA ISR from
+/// updating `complete_count` or `lli_index` between the two reads, which would cause
+/// `dma_sync` (which calls `reset_complete_count` then `get_remaining_transfers`) to
+/// see an inconsistent position.
+struct DmaCtrlImpl<'a> {
+    channel: Channel<'a>,
+    /// Remaining transfers cached by the last `reset_complete_count` call.
+    cached_remaining: usize,
+}
 
-impl<'a> DmaCtrl for DmaCtrlImpl<'a> {
-    fn get_remaining_transfers(&self) -> usize {
-        let state = &STATE[self.0.channel as usize];
-        let current_remaining = self.0.get_remaining_transfers() as usize;
-
-        let lli_count = state.lli_state.count.load(Ordering::Acquire);
-
-        if lli_count > 0 {
-            // In linked-list mode, the remaining transfers are the sum of the full lengths of LLIs that follow,
-            // and the remaining transfers for the current LLI.
-            let lli_index = state.lli_state.index.load(Ordering::Acquire);
-            let single_transfer_count = state.lli_state.transfer_count.load(Ordering::Acquire) / lli_count;
-
-            (lli_count - lli_index - 1) * single_transfer_count + current_remaining
-        } else {
-            // No linked-list mode.
-            current_remaining
+impl<'a> DmaCtrlImpl<'a> {
+    fn new(channel: Channel<'a>) -> Self {
+        Self {
+            channel,
+            cached_remaining: 0,
         }
     }
 
-    fn reset_complete_count(&mut self) -> usize {
-        let state = &STATE[self.0.channel as usize];
+    /// Compute remaining transfers from hardware and LLI state.
+    /// Must be called with interrupts disabled (inside a critical section).
+    fn compute_remaining(&self) -> usize {
+        let state = &STATE[self.channel.channel as usize];
+        let lli_count = state.lli_state.count.load(Ordering::Relaxed);
 
-        state.complete_count.swap(0, Ordering::AcqRel)
+        if lli_count > 0 {
+            let lli_index = state.lli_state.index.load(Ordering::Relaxed);
+            let single_transfer_count = state.lli_state.transfer_count.load(Ordering::Relaxed) / lli_count;
+            let current_remaining = self.channel.get_remaining_transfers() as usize;
+
+            // During LLI reload, BNDT can momentarily read as 0. In a critical section
+            // the ISR can't run, so lli_index is consistent with BNDT. If BNDT is 0,
+            // the LLI just completed. Treat it as 1 to avoid pos = cap which would
+            // double-count with the pending complete_count increment.
+            let current_remaining = current_remaining.max(1);
+
+            (lli_count - lli_index - 1) * single_transfer_count + current_remaining
+        } else {
+            self.channel.get_remaining_transfers() as usize
+        }
+    }
+}
+
+impl<'a> DmaCtrl for DmaCtrlImpl<'a> {
+    fn get_remaining_transfers(&self) -> usize {
+        self.cached_remaining
+    }
+
+    fn reset_complete_count(&mut self) -> usize {
+        let state = &STATE[self.channel.channel as usize];
+
+        // Snapshot complete_count and BNDT atomically by disabling interrupts.
+        // This prevents the DMA ISR from modifying complete_count or lli_index
+        // between the two reads, eliminating the race that causes DmaUnsynced.
+        critical_section::with(|_| {
+            let count = state.complete_count.swap(0, Ordering::AcqRel);
+            self.cached_remaining = self.compute_remaining();
+            count
+        })
     }
 
     fn set_waker(&mut self, waker: &Waker) {
-        STATE[self.0.channel as usize].waker.register(waker);
+        STATE[self.channel.channel as usize].waker.register(waker);
     }
 }
 
@@ -51,7 +86,7 @@ pub struct ReadableRingBuffer<'a, W: Word> {
     channel: Channel<'a>,
     _wake_guard: WakeGuard,
     ringbuf: ReadableDmaRingBuffer<'a, W>,
-    table: Table<2>,
+    table: Table<1>,
     options: TransferOptions,
 }
 
@@ -66,7 +101,7 @@ impl<'a, W: Word> ReadableRingBuffer<'a, W> {
         buffer: &'a mut [W],
         options: TransferOptions,
     ) -> Self {
-        let table = Table::<2>::new_ping_pong::<W>(request, peri_addr, buffer, Dir::PeripheralToMemory);
+        let table = Table::<1>::new_circular::<W>(request, peri_addr, buffer, Dir::PeripheralToMemory);
 
         Self {
             _wake_guard: channel.info().wake_guard(),
@@ -94,7 +129,7 @@ impl<'a, W: Word> ReadableRingBuffer<'a, W> {
 
     /// Clear all data in the ring buffer.
     pub fn clear(&mut self) {
-        self.ringbuf.reset(&mut DmaCtrlImpl(self.channel.reborrow()));
+        self.ringbuf.reset(&mut DmaCtrlImpl::new(self.channel.reborrow()));
     }
 
     /// Read elements from the ring buffer
@@ -103,7 +138,7 @@ impl<'a, W: Word> ReadableRingBuffer<'a, W> {
     /// The length remaining is the capacity, ring_buf.sync_len(), less the elements remaining after the read
     /// Error is returned if the portion to be read was overwritten by the DMA controller.
     pub fn read(&mut self, buf: &mut [W]) -> Result<(usize, usize), Error> {
-        self.ringbuf.read(&mut DmaCtrlImpl(self.channel.reborrow()), buf)
+        self.ringbuf.read(&mut DmaCtrlImpl::new(self.channel.reborrow()), buf)
     }
 
     /// Read an exact number of elements from the ringbuffer.
@@ -119,13 +154,13 @@ impl<'a, W: Word> ReadableRingBuffer<'a, W> {
     /// - Otherwise, this function may need up to N/2 extra elements to arrive before returning.
     pub async fn read_exact(&mut self, buffer: &mut [W]) -> Result<usize, Error> {
         self.ringbuf
-            .read_exact(&mut DmaCtrlImpl(self.channel.reborrow()), buffer)
+            .read_exact(&mut DmaCtrlImpl::new(self.channel.reborrow()), buffer)
             .await
     }
 
     /// The current length of the ringbuffer
     pub fn len(&mut self) -> Result<usize, Error> {
-        Ok(self.ringbuf.sync_len(&mut DmaCtrlImpl(self.channel.reborrow()))?)
+        Ok(self.ringbuf.sync_len(&mut DmaCtrlImpl::new(self.channel.reborrow()))?)
     }
 
     /// Read the most recent elements from the ring buffer, discarding any older data.
@@ -137,7 +172,8 @@ impl<'a, W: Word> ReadableRingBuffer<'a, W> {
     /// This is ideal for use cases like ADC sampling where the consumer only cares about
     /// the latest values.
     pub fn read_latest(&mut self, buf: &mut [W]) -> usize {
-        self.ringbuf.read_latest(&mut DmaCtrlImpl(self.channel.reborrow()), buf)
+        self.ringbuf
+            .read_latest(&mut DmaCtrlImpl::new(self.channel.reborrow()), buf)
     }
 
     /// The capacity of the ringbuffer
@@ -147,7 +183,7 @@ impl<'a, W: Word> ReadableRingBuffer<'a, W> {
 
     /// Set a waker to be woken when at least one byte is received.
     pub fn set_waker(&mut self, waker: &Waker) {
-        DmaCtrlImpl(self.channel.reborrow()).set_waker(waker);
+        DmaCtrlImpl::new(self.channel.reborrow()).set_waker(waker);
     }
 
     /// Request the transfer to pause, keeping the existing configuration for this channel.
@@ -211,7 +247,7 @@ pub struct WritableRingBuffer<'a, W: Word> {
     channel: Channel<'a>,
     _wake_guard: WakeGuard,
     ringbuf: WritableDmaRingBuffer<'a, W>,
-    table: Table<2>,
+    table: Table<1>,
     options: TransferOptions,
 }
 
@@ -226,7 +262,7 @@ impl<'a, W: Word> WritableRingBuffer<'a, W> {
         buffer: &'a mut [W],
         options: TransferOptions,
     ) -> Self {
-        let table = Table::<2>::new_ping_pong::<W>(request, peri_addr, buffer, Dir::MemoryToPeripheral);
+        let table = Table::<1>::new_circular::<W>(request, peri_addr, buffer, Dir::MemoryToPeripheral);
 
         Self {
             _wake_guard: channel.info().wake_guard(),
@@ -248,7 +284,7 @@ impl<'a, W: Word> WritableRingBuffer<'a, W> {
 
     /// Clear all data in the ring buffer.
     pub fn clear(&mut self) {
-        self.ringbuf.reset(&mut DmaCtrlImpl(self.channel.reborrow()));
+        self.ringbuf.reset(&mut DmaCtrlImpl::new(self.channel.reborrow()));
     }
 
     /// Write elements directly to the raw buffer.
@@ -260,26 +296,26 @@ impl<'a, W: Word> WritableRingBuffer<'a, W> {
     /// Write elements from the ring buffer
     /// Return a tuple of the length written and the length remaining in the buffer
     pub fn write(&mut self, buf: &[W]) -> Result<(usize, usize), Error> {
-        self.ringbuf.write(&mut DmaCtrlImpl(self.channel.reborrow()), buf)
+        self.ringbuf.write(&mut DmaCtrlImpl::new(self.channel.reborrow()), buf)
     }
 
     /// Write an exact number of elements to the ringbuffer.
     pub async fn write_exact(&mut self, buffer: &[W]) -> Result<usize, Error> {
         self.ringbuf
-            .write_exact(&mut DmaCtrlImpl(self.channel.reborrow()), buffer)
+            .write_exact(&mut DmaCtrlImpl::new(self.channel.reborrow()), buffer)
             .await
     }
 
     /// Wait for any ring buffer write error.
     pub async fn wait_write_error(&mut self) -> Result<usize, Error> {
         self.ringbuf
-            .wait_write_error(&mut DmaCtrlImpl(self.channel.reborrow()))
+            .wait_write_error(&mut DmaCtrlImpl::new(self.channel.reborrow()))
             .await
     }
 
     /// The current length of the ringbuffer
     pub fn len(&mut self) -> Result<usize, Error> {
-        Ok(self.ringbuf.sync_len(&mut DmaCtrlImpl(self.channel.reborrow()))?)
+        Ok(self.ringbuf.sync_len(&mut DmaCtrlImpl::new(self.channel.reborrow()))?)
     }
 
     /// The capacity of the ringbuffer
@@ -296,7 +332,7 @@ impl<'a, W: Word> WritableRingBuffer<'a, W> {
 
     /// Set a waker to be woken when at least one byte is received.
     pub fn set_waker(&mut self, waker: &Waker) {
-        DmaCtrlImpl(self.channel.reborrow()).set_waker(waker);
+        DmaCtrlImpl::new(self.channel.reborrow()).set_waker(waker);
     }
 
     /// Request the DMA to suspend.


### PR DESCRIPTION
`dma_sync` called `reset_complete_count` and `get_remaining_transfers` as two separate steps and the DMA ISR could fire between them. This would cause `DmaUnsynced` errors to be triggered.

This PR switches from ping-pong (2-LLI) to single LLI circular mode (in `linked_list.rs`).
`ReadableRingBuffer` and `WritableRingBuffer` now use `Table<1>` instead of `Table<2> + new_ping_pong`.
