### PR TITLE
fix(stm32/adc4): enable continuous conversion for Repeated(None) mode

### DIFF
--- a/embassy-stm32/src/adc/adc4.rs
+++ b/embassy-stm32/src/adc/adc4.rs
@@ -292,7 +292,7 @@ impl AdcRegs for crate::pac::adc::Adc4 {
             reg.set_dmaen(!matches!(conversion_mode, ConversionMode::NoDma));
             reg.set_dmacfg(Dmacfg::Circular);
             reg.set_discen(false);
-            reg.set_cont(false);
+            reg.set_cont(matches!(conversion_mode, ConversionMode::Repeated(None)));
             reg.set_chselrmod(false);
 
             #[cfg(stm32wba)]


### PR DESCRIPTION
## Summary

- ADC4 `configure_dma()` unconditionally sets `CONT=0`, preventing continuous scanning when `into_ring_buffered()` is called with `trigger=None`
- Introduced in 2b5a59d35d ("stm32/adc: more cleanup") which flattened platform-specific cfg blocks and hardcoded `cont(false)`, losing the WBA continuous mode path
- Fix matches the pattern used in g4.rs, c0.rs, v3.rs, f3.rs, and v2.rs: `set_cont(matches!(conversion_mode, ConversionMode::Repeated(None)))`

Without this fix, the ADC fires one scan and stops. DMA reads stale data — some channels return stuck values (4095 or 0) while others appear correct depending on scan timing.

Tested on STM32WBA65RI with 11-channel ring-buffered ADC4.