### PR TITLE
fix(hal-internal): reset ReaderIterator index in reset_buf() to prevent double pop_done

### DIFF
--- a/embassy-hal-internal/src/atomic_ring_buffer.rs
+++ b/embassy-hal-internal/src/atomic_ring_buffer.rs
@@ -482,6 +482,7 @@ pub struct ReaderIterator<'a, 'b> {
 impl<'a, 'b> ReaderIterator<'a, 'b> {
     fn reset_buf(&mut self) {
         self.reader.pop_done(self.i);
+        self.i = 0;
 
         let (data, len) = self.reader.pop_buf();
         self.buf = unsafe { slice::from_raw_parts_mut(data, len) };


### PR DESCRIPTION
## Summary

- `ReaderIterator::reset_buf()` calls `pop_done(self.i)` but never resets `self.i` to 0
- When the iterator is dropped, `Drop::drop()` calls `reset_buf()` again with the stale index, double-advancing the read pointer
- This wraps the read pointer past the write pointer, making the ring buffer appear full of zero-initialized data
- In the USART BufferedUart TX interrupt path, this causes continuous 0x00 byte transmission after every legitimate write

One-line fix: reset `self.i = 0` after `pop_done()` in `reset_buf()`.

Tested on STM32WBA65RI — verified via Saleae logic analyzer that TX line idles correctly after sending commands.