### PR TITLE
[MCXA] i3c: controller: add initial support for target IBIs

### DIFF
--- a/embassy-mcxa/src/i3c/controller.rs
+++ b/embassy-mcxa/src/i3c/controller.rs
@@ -15,7 +15,7 @@ pub use crate::i2c::controller::Speed;
 use crate::interrupt::typelevel;
 use crate::interrupt::typelevel::Interrupt;
 use crate::pac::i3c::{
-    Disto, Hkeep, Ibiresp, MctrlDir as I3cDir, MdatactrlRxtrig, MdatactrlTxtrig, Mstena, Request, State, Type,
+    Disto, Hkeep, Ibiresp, Ibitype, MctrlDir as I3cDir, MdatactrlRxtrig, MdatactrlTxtrig, Mstena, Request, State, Type,
 };
 
 const MAX_CHUNK_SIZE: usize = 255;
@@ -78,7 +78,7 @@ impl From<crate::dma::InvalidParameters> for IOError {
 
 #[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
-enum SendStop {
+pub enum SendStop {
     #[default]
     No,
     Yes,
@@ -1230,6 +1230,116 @@ where
     }
 
     // Public API: Async
+
+    /// Wait for a target IBI, ACK it, drain any payload bytes, and emit STOP.
+    ///
+    /// Returns the IBI target address and the number of payload bytes written into `buf`.
+    /// The P3T1755 (and most sensors) set BCR[2]=0 so no payload bytes follow the address header;
+    /// in that case this returns `(addr, 0)`.
+    pub async fn async_wait_for_ibi(&mut self, buf: &mut [u8]) -> Result<(u8, usize), IOError> {
+        // Step 1: Wait for SLVSTART (a target is asserting SDA low to request the bus).
+        self.info
+            .wait_cell()
+            .wait_for(|| {
+                self.info.regs().mintset().write(|w| {
+                    w.set_slvstart(true);
+                    w.set_errwarn(true);
+                });
+                let status = self.info.regs().mstatus().read();
+                status.slvstart() || status.errwarn()
+            })
+            .await
+            .map_err(|_| IOError::Other)?;
+
+        self.status()?;
+
+        // Only proceed if the bus is in SLVREQ state.
+        if self.info.regs().mstatus().read().state() != State::SLVREQ {
+            return Err(IOError::Other);
+        }
+
+        // Step 2: Pre-clear IBIWON in case it was already set, so AUTO_IBI doesn't return early.
+        self.info.regs().mstatus().write(|w| w.set_ibiwon(true));
+
+        // Step 3: Issue AUTO_IBI with ACK — hardware handles the IBI protocol handshake.
+        self.info.regs().mctrl().write(|w| {
+            w.set_request(Request::AUTOIBI);
+            w.set_ibiresp(Ibiresp::ACK);
+        });
+
+        // Step 4: Wait for IBIWON — the IBI has been accepted and the address header received.
+        self.info
+            .wait_cell()
+            .wait_for(|| {
+                self.info.regs().mintset().write(|w| {
+                    w.set_ibiwon(true);
+                    w.set_errwarn(true);
+                });
+                let status = self.info.regs().mstatus().read();
+                status.ibiwon() || status.errwarn()
+            })
+            .await
+            .map_err(|_| IOError::Other)?;
+
+        self.status()?;
+
+        let mstatus = self.info.regs().mstatus().read();
+        let ibi_addr = mstatus.ibiaddr();
+        let ibi_type = mstatus.ibitype();
+
+        // Step 5: For normal IBIs (not Hot-Join or Controller-Request), drain the RX FIFO payload.
+        let mut payload_len = 0;
+        if ibi_type == Ibitype::IBI && !buf.is_empty() {
+            'read: for byte in buf.iter_mut() {
+                loop {
+                    // Drain available RX FIFO bytes.
+                    if self.info.regs().mdatactrl().read().rxcount() != 0 {
+                        *byte = self.info.regs().mrdatab().read().value();
+                        payload_len += 1;
+                        break;
+                    }
+
+                    // COMPLETE means the target has sent all its payload bytes.
+                    if self.info.regs().mstatus().read().complete() {
+                        break 'read;
+                    }
+
+                    // Wait for more bytes (rxpend) or end of message (complete).
+                    self.info
+                        .wait_cell()
+                        .wait_for(|| {
+                            self.info.regs().mintset().write(|w| {
+                                w.set_rxpend(true);
+                                w.set_complete(true);
+                                w.set_errwarn(true);
+                            });
+                            let s = self.info.regs().mstatus().read();
+                            s.rxpend() || s.complete() || s.errwarn()
+                        })
+                        .await
+                        .map_err(|_| IOError::Other)?;
+
+                    self.status()?;
+                }
+            }
+
+            // Drain any remaining bytes the caller's buffer couldn't hold.
+            while self.info.regs().mdatactrl().read().rxcount() != 0 {
+                let _ = self.info.regs().mrdatab().read().value();
+            }
+        }
+
+        // Step 6: Wait for COMPLETE (marks end of IBI reception, state transitions to NORMACT).
+        if !self.info.regs().mstatus().read().complete() {
+            self.async_wait_for_complete().await?;
+        }
+
+        // Step 7: Clear status flags, then emit STOP.
+        self.clear_flags();
+        self.async_stop(BusType::I3cSdr).await?;
+
+        Ok((ibi_addr, payload_len))
+    }
 
     /// Read from address into buffer asynchronously.
     pub fn async_read<'a>(

--- a/examples/mcxa2xx/Cargo.toml
+++ b/examples/mcxa2xx/Cargo.toml
@@ -14,6 +14,7 @@ defmt = "1.0"
 defmt-rtt = "1.0"
 embassy-embedded-hal = { version = "0.6.0", path = "../../embassy-embedded-hal" }
 embassy-executor = { version = "0.10.0", path = "../../embassy-executor", default-features = false, features = ["platform-cortex-m", "executor-thread", "defmt"] }
+embassy-futures = { version = "0.1.2", path = "../../embassy-futures"}
 embassy-mcxa = { version = "0.1.0", path = "../../embassy-mcxa", features = ["defmt", "unstable-pac", "mcxa2xx", "embedded-mcu-hal"] }
 embassy-sync = { version = "0.8.0", path = "../../embassy-sync" }
 embassy-time = { version = "0.5.1", path = "../../embassy-time", features = ["defmt", "defmt-timestamp-uptime"] }

--- a/examples/mcxa2xx/src/bin/i3c-ibi.rs
+++ b/examples/mcxa2xx/src/bin/i3c-ibi.rs
@@ -1,0 +1,194 @@
+#![no_std]
+#![no_main]
+
+use embassy_executor::Spawner;
+use embassy_futures::select::{Either, select};
+use embassy_mcxa::bind_interrupts;
+use embassy_mcxa::clocks::PoweredClock;
+use embassy_mcxa::clocks::config::{
+    CoreSleep, Div8, FircConfig, FircFreqSel, FlashSleep, MainClockConfig, MainClockSource, VddDriveStrength, VddLevel,
+};
+use embassy_mcxa::clocks::periph_helpers::{Div4, I3cClockSel};
+use embassy_mcxa::gpio::{self, Input, Pull};
+use embassy_mcxa::i3c::controller::{self, BusType, I3c, Operation};
+use embassy_mcxa::peripherals::{GPIO1, I3C0};
+use {defmt_rtt as _, embassy_mcxa as hal, panic_probe as _};
+
+bind_interrupts!(
+    struct Irqs {
+        GPIO1 => gpio::InterruptHandler<GPIO1>;
+        I3C0 => controller::InterruptHandler<I3C0>;
+    }
+);
+
+#[embassy_executor::main]
+async fn main(_spawner: Spawner) {
+    let mut cfg = hal::config::Config::default();
+
+    // Enable 180MHz clock source
+    let mut fcfg = FircConfig::default();
+    fcfg.frequency = FircFreqSel::Mhz180;
+    fcfg.power = PoweredClock::NormalEnabledDeepSleepDisabled;
+    fcfg.fro_hf_enabled = true;
+    fcfg.clk_hf_fundamental_enabled = false;
+    fcfg.fro_hf_div = Some(const { Div8::from_divisor(8).unwrap() });
+    cfg.clock_cfg.firc = Some(fcfg);
+
+    // Enable 12M osc
+    cfg.clock_cfg.sirc.fro_12m_enabled = true;
+    cfg.clock_cfg.sirc.fro_lf_div = Some(Div8::no_div());
+    cfg.clock_cfg.sirc.power = PoweredClock::AlwaysEnabled;
+
+    // Disable 16K osc
+    cfg.clock_cfg.fro16k = None;
+
+    // Disable external osc
+    cfg.clock_cfg.sosc = None;
+
+    // Disable PLL
+    cfg.clock_cfg.spll = None;
+
+    // Feed core from 180M osc
+    cfg.clock_cfg.main_clock = MainClockConfig {
+        source: MainClockSource::FircHfRoot,
+        power: PoweredClock::NormalEnabledDeepSleepDisabled,
+        ahb_clk_div: Div8::no_div(),
+    };
+
+    // We don't sleep, set relatively high power
+    cfg.clock_cfg.vdd_power.active_mode.level = VddLevel::OverDriveMode;
+    cfg.clock_cfg.vdd_power.low_power_mode.level = VddLevel::MidDriveMode;
+    cfg.clock_cfg.vdd_power.active_mode.drive = VddDriveStrength::Normal;
+    cfg.clock_cfg.vdd_power.low_power_mode.drive = VddDriveStrength::Low { enable_bandgap: false };
+
+    // Set "never sleep" mode
+    cfg.clock_cfg.vdd_power.core_sleep = CoreSleep::WfeUngated;
+
+    // Set flash doze, allowing internal flash clocks to be gated on sleep
+    cfg.clock_cfg.vdd_power.flash_sleep = FlashSleep::FlashDoze;
+
+    let p = hal::init(cfg);
+
+    defmt::info!("I3C controller <-> target IBI example");
+
+    let mut button = Input::new_async(p.P1_7, Irqs, Pull::Disabled);
+
+    let mut i3c_cfg = controller::Config::default();
+    i3c_cfg.clock_config.source = I3cClockSel::FroHfDiv;
+    i3c_cfg.clock_config.div = Div4::no_div();
+    let mut i3c = I3c::new_async_with_dma(p.I3C0, p.P1_9, p.P1_8, p.DMA0_CH0, p.DMA0_CH1, Irqs, i3c_cfg).unwrap();
+
+    let mut buf = [0u8; 2];
+
+    /* ---------------------------
+     * Dynamic Address Assignment
+     * --------------------------- */
+    i3c.blocking_reset_daa().unwrap();
+
+    /* ---------------------------
+     * SETDASA
+     * --------------------------- */
+    i3c.async_transaction(
+        &mut [
+            Operation::Write {
+                address: 0x7e,
+                buf: &[0x87],
+            },
+            Operation::Write {
+                address: 0x48,
+                buf: &[0x08 << 1],
+            },
+        ],
+        BusType::I3cSdr,
+    )
+    .await
+    .unwrap();
+
+    /* ---------------------------
+     * ENEC
+     * --------------------------- */
+    i3c.async_transaction(
+        &mut [
+            Operation::Write {
+                address: 0x7e,
+                buf: &[0x81],
+            },
+            Operation::Write {
+                address: 0x08,
+                buf: &[0x08 << 1, 0x01],
+            },
+        ],
+        BusType::I3cSdr,
+    )
+    .await
+    .unwrap();
+
+    /* ---------------------------
+     * Normal bus operation
+     * --------------------------- */
+
+    let addr = 0x08;
+
+    i3c.async_write_read(addr, &[0x01], &mut buf[..1], BusType::I3cSdr)
+        .await
+        .unwrap();
+    buf[0] |= 1 << 1;
+    i3c.async_write(addr, &[0x01, buf[0]], BusType::I3cSdr).await.unwrap();
+
+    let low = celsius_to_raw(22.0);
+    let high = celsius_to_raw(35.0);
+    i3c.async_write(addr, &[0x02, low[0], low[1]], BusType::I3cSdr)
+        .await
+        .unwrap();
+    i3c.async_write(addr, &[0x03, high[0], high[1]], BusType::I3cSdr)
+        .await
+        .unwrap();
+
+    i3c.async_write_read(addr, &[0x02], &mut buf, BusType::I3cSdr)
+        .await
+        .unwrap();
+    let low = raw_to_celsius(buf);
+
+    i3c.async_write_read(addr, &[0x03], &mut buf, BusType::I3cSdr)
+        .await
+        .unwrap();
+    let high = raw_to_celsius(buf);
+
+    i3c.async_write_read(addr, &[0x00], &mut buf, BusType::I3cSdr)
+        .await
+        .unwrap();
+    let current = raw_to_celsius(buf);
+
+    defmt::info!("low {}C high {}C current {}C", low, high, current);
+
+    loop {
+        defmt::info!("Waiting for IBI or button press...");
+        let mut ibi_payload = [0u8; 8];
+
+        match select(button.wait_for_falling_edge(), i3c.async_wait_for_ibi(&mut ibi_payload)).await {
+            Either::First(_) => {
+                defmt::info!("Button pressed");
+            }
+            Either::Second(res) => {
+                let (addr, payload_len) = res.unwrap();
+                defmt::info!("IBI from 0x{:02x}, payload_len={}", addr, payload_len);
+            }
+        }
+
+        i3c.async_write_read(addr, &[0x00], &mut buf, BusType::I3cSdr)
+            .await
+            .unwrap();
+        let current = raw_to_celsius(buf);
+        defmt::info!("Temperature {}C", current);
+    }
+}
+
+fn raw_to_celsius(raw: [u8; 2]) -> f32 {
+    let raw = i16::from_be_bytes(raw) / 16;
+    f32::from(raw) * 0.0625
+}
+
+fn celsius_to_raw(temp: f32) -> [u8; 2] {
+    let raw = ((temp / 0.0625) as i16) * 16;
+    raw.to_be_bytes()
+}

--- a/examples/mcxa5xx/Cargo.toml
+++ b/examples/mcxa5xx/Cargo.toml
@@ -14,6 +14,7 @@ defmt = "1.0"
 defmt-rtt = "1.0"
 embassy-embedded-hal = { version = "0.6.0", path = "../../embassy-embedded-hal" }
 embassy-executor = { version = "0.10.0", path = "../../embassy-executor", default-features = false, features = ["platform-cortex-m", "executor-thread", "defmt"]  }
+embassy-futures = { version = "0.1.2", path = "../../embassy-futures"}
 embassy-mcxa = { version = "0.1.0", path = "../../embassy-mcxa", features = ["defmt", "unstable-pac", "mcxa5xx", "embedded-mcu-hal"] }
 embassy-sync = { version = "0.8.0", path = "../../embassy-sync" }
 embassy-time = { version = "0.5.1", path = "../../embassy-time", features = ["defmt", "defmt-timestamp-uptime"] }

--- a/examples/mcxa5xx/src/bin/i3c-ibi.rs
+++ b/examples/mcxa5xx/src/bin/i3c-ibi.rs
@@ -1,0 +1,194 @@
+#![no_std]
+#![no_main]
+
+use embassy_executor::Spawner;
+use embassy_futures::select::{Either, select};
+use embassy_mcxa::bind_interrupts;
+use embassy_mcxa::clocks::PoweredClock;
+use embassy_mcxa::clocks::config::{
+    CoreSleep, Div8, FircConfig, FircFreqSel, FlashSleep, MainClockConfig, MainClockSource, VddDriveStrength, VddLevel,
+};
+use embassy_mcxa::clocks::periph_helpers::{Div4, I3cClockSel};
+use embassy_mcxa::gpio::{self, Input, Pull};
+use embassy_mcxa::i3c::controller::{self, BusType, I3c, Operation};
+use embassy_mcxa::peripherals::{GPIO3, I3C0};
+use {defmt_rtt as _, embassy_mcxa as hal, panic_probe as _};
+
+bind_interrupts!(
+    struct Irqs {
+        GPIO3 => gpio::InterruptHandler<GPIO3>;
+        I3C0 => controller::InterruptHandler<I3C0>;
+    }
+);
+
+#[embassy_executor::main]
+async fn main(_spawner: Spawner) {
+    let mut cfg = hal::config::Config::default();
+
+    // Enable 190MHz clock source
+    let mut fcfg = FircConfig::default();
+    fcfg.frequency = FircFreqSel::Mhz192;
+    fcfg.power = PoweredClock::NormalEnabledDeepSleepDisabled;
+    fcfg.fro_hf_enabled = true;
+    fcfg.clk_hf_fundamental_enabled = false;
+    fcfg.fro_hf_div = Some(const { Div8::from_divisor(8).unwrap() });
+    cfg.clock_cfg.firc = Some(fcfg);
+
+    // Enable 12M osc
+    cfg.clock_cfg.sirc.fro_12m_enabled = true;
+    cfg.clock_cfg.sirc.fro_lf_div = Some(Div8::no_div());
+    cfg.clock_cfg.sirc.power = PoweredClock::AlwaysEnabled;
+
+    // Disable 16K osc
+    cfg.clock_cfg.fro16k = None;
+
+    // Disable external osc
+    cfg.clock_cfg.sosc = None;
+
+    // Disable PLL
+    cfg.clock_cfg.spll = None;
+
+    // Feed core from 192M osc
+    cfg.clock_cfg.main_clock = MainClockConfig {
+        source: MainClockSource::FircHfRoot,
+        power: PoweredClock::NormalEnabledDeepSleepDisabled,
+        ahb_clk_div: Div8::no_div(),
+    };
+
+    // We don't sleep, set relatively high power
+    cfg.clock_cfg.vdd_power.active_mode.level = VddLevel::OverDriveMode;
+    cfg.clock_cfg.vdd_power.low_power_mode.level = VddLevel::MidDriveMode;
+    cfg.clock_cfg.vdd_power.active_mode.drive = VddDriveStrength::Normal;
+    cfg.clock_cfg.vdd_power.low_power_mode.drive = VddDriveStrength::Low { enable_bandgap: false };
+
+    // Set "never sleep" mode
+    cfg.clock_cfg.vdd_power.core_sleep = CoreSleep::WfeUngated;
+
+    // Set flash doze, allowing internal flash clocks to be gated on sleep
+    cfg.clock_cfg.vdd_power.flash_sleep = FlashSleep::FlashDoze;
+
+    let p = hal::init(cfg);
+
+    defmt::info!("I3C controller <-> target IBI example");
+
+    let mut button = Input::new_async(p.P3_17, Irqs, Pull::Disabled);
+
+    let mut i3c_cfg = controller::Config::default();
+    i3c_cfg.clock_config.source = I3cClockSel::FroHfDiv;
+    i3c_cfg.clock_config.div = Div4::no_div();
+    let mut i3c = I3c::new_async_with_dma(p.I3C0, p.P0_21, p.P0_20, p.DMA0_CH0, p.DMA0_CH1, Irqs, i3c_cfg).unwrap();
+
+    let mut buf = [0u8; 2];
+
+    /* ---------------------------
+     * Dynamic Address Assignment
+     * --------------------------- */
+    i3c.blocking_reset_daa().unwrap();
+
+    /* ---------------------------
+     * SETDASA
+     * --------------------------- */
+    i3c.async_transaction(
+        &mut [
+            Operation::Write {
+                address: 0x7e,
+                buf: &[0x87],
+            },
+            Operation::Write {
+                address: 0x48,
+                buf: &[0x08 << 1],
+            },
+        ],
+        BusType::I3cSdr,
+    )
+    .await
+    .unwrap();
+
+    /* ---------------------------
+     * ENEC
+     * --------------------------- */
+    i3c.async_transaction(
+        &mut [
+            Operation::Write {
+                address: 0x7e,
+                buf: &[0x81],
+            },
+            Operation::Write {
+                address: 0x08,
+                buf: &[0x08 << 1, 0x01],
+            },
+        ],
+        BusType::I3cSdr,
+    )
+    .await
+    .unwrap();
+
+    /* ---------------------------
+     * Normal bus operation
+     * --------------------------- */
+
+    let addr = 0x08;
+
+    i3c.async_write_read(addr, &[0x01], &mut buf[..1], BusType::I3cSdr)
+        .await
+        .unwrap();
+    buf[0] |= 1 << 1;
+    i3c.async_write(addr, &[0x01, buf[0]], BusType::I3cSdr).await.unwrap();
+
+    let low = celsius_to_raw(22.0);
+    let high = celsius_to_raw(35.0);
+    i3c.async_write(addr, &[0x02, low[0], low[1]], BusType::I3cSdr)
+        .await
+        .unwrap();
+    i3c.async_write(addr, &[0x03, high[0], high[1]], BusType::I3cSdr)
+        .await
+        .unwrap();
+
+    i3c.async_write_read(addr, &[0x02], &mut buf, BusType::I3cSdr)
+        .await
+        .unwrap();
+    let low = raw_to_celsius(buf);
+
+    i3c.async_write_read(addr, &[0x03], &mut buf, BusType::I3cSdr)
+        .await
+        .unwrap();
+    let high = raw_to_celsius(buf);
+
+    i3c.async_write_read(addr, &[0x00], &mut buf, BusType::I3cSdr)
+        .await
+        .unwrap();
+    let current = raw_to_celsius(buf);
+
+    defmt::info!("low {}C high {}C current {}C", low, high, current);
+
+    loop {
+        defmt::info!("Waiting for IBI or button press...");
+        let mut ibi_payload = [0u8; 8];
+
+        match select(button.wait_for_falling_edge(), i3c.async_wait_for_ibi(&mut ibi_payload)).await {
+            Either::First(_) => {
+                defmt::info!("Button pressed");
+            }
+            Either::Second(res) => {
+                let (addr, payload_len) = res.unwrap();
+                defmt::info!("IBI from 0x{:02x}, payload_len={}", addr, payload_len);
+            }
+        }
+
+        i3c.async_write_read(addr, &[0x00], &mut buf, BusType::I3cSdr)
+            .await
+            .unwrap();
+        let current = raw_to_celsius(buf);
+        defmt::info!("Temperature {}C", current);
+    }
+}
+
+fn raw_to_celsius(raw: [u8; 2]) -> f32 {
+    let raw = i16::from_be_bytes(raw) / 16;
+    f32::from(raw) * 0.0625
+}
+
+fn celsius_to_raw(temp: f32) -> [u8; 2] {
+    let raw = ((temp / 0.0625) as i16) * 16;
+    raw.to_be_bytes()
+}


### PR DESCRIPTION
Demonstrated using the temperature sensor on both MCXA2 and MCXA5 boards.