### PR TITLE
usb-host: Replace pre with SplitInfo

### DIFF
--- a/embassy-rp/src/usb/host.rs
+++ b/embassy-rp/src/usb/host.rs
@@ -5,9 +5,16 @@ use core::task::Poll;
 
 use embassy_sync::waitqueue::AtomicWaker;
 use embassy_usb_driver::host::{
-    ChannelError, DeviceEvent, HostError, TimeoutConfig, UsbChannel, UsbHostDriver, channel,
+    ChannelError, DeviceEvent, HostError, SplitInfo, TimeoutConfig, UsbChannel, UsbHostDriver, channel,
 };
 use embassy_usb_driver::{EndpointInfo, EndpointType, Speed};
+
+/// Reduce a [`SplitInfo`] to the legacy "emit PRE packet" bit used by this
+/// full-speed only controller. USB 1.1 §11.8.6: PRE is required when the
+/// target device is low-speed and reached through a (full-speed) hub.
+fn split_to_pre(split: Option<SplitInfo>) -> bool {
+    matches!(split, Some(s) if s.device_speed() == Speed::Low)
+}
 use rp_pac::usb_dpram::vals::EpControlEndpointType;
 
 use super::{BUS_WAKER, DPRAM_DATA_OFFSET, EP_IN_WAKERS, EP_MEMORY, EndpointBuffer, Instance};
@@ -600,8 +607,13 @@ impl<'d, T: Instance, E: channel::Type, D: channel::Direction> UsbChannel<E, D> 
         Ok(())
     }
 
-    fn retarget_channel(&mut self, addr: u8, endpoint: &EndpointInfo, pre: bool) -> Result<(), HostError> {
-        self.pre = pre;
+    fn retarget_channel(
+        &mut self,
+        addr: u8,
+        endpoint: &EndpointInfo,
+        split: Option<SplitInfo>,
+    ) -> Result<(), HostError> {
+        self.pre = split_to_pre(split);
         self.dev_addr = addr;
         self.max_packet_size = endpoint.max_packet_size;
         Ok(())
@@ -763,8 +775,9 @@ impl<'d, T: Instance> UsbHostDriver for Driver<'d, T> {
         &self,
         dev_addr: u8,
         endpoint: &EndpointInfo,
-        pre: bool,
+        split: Option<SplitInfo>,
     ) -> Result<Self::Channel<E, D>, HostError> {
+        let pre = split_to_pre(split);
         if E::ep_type() == EndpointType::Interrupt {
             let alloc = self.allocated_pipes.load(Ordering::Acquire);
             let free_index = (1..16)

--- a/embassy-rp/src/usb/host.rs
+++ b/embassy-rp/src/usb/host.rs
@@ -5,7 +5,7 @@ use core::task::Poll;
 
 use embassy_sync::waitqueue::AtomicWaker;
 use embassy_usb_driver::host::{
-    ChannelError, DeviceEvent, HostError, SplitInfo, TimeoutConfig, UsbChannel, UsbHostDriver, channel,
+    ChannelError, DeviceEvent, HostError, SplitInfo, SplitSpeed, TimeoutConfig, UsbChannel, UsbHostDriver, channel,
 };
 use embassy_usb_driver::{EndpointInfo, EndpointType, Speed};
 
@@ -13,7 +13,7 @@ use embassy_usb_driver::{EndpointInfo, EndpointType, Speed};
 /// full-speed only controller. USB 1.1 §11.8.6: PRE is required when the
 /// target device is low-speed and reached through a (full-speed) hub.
 fn split_to_pre(split: Option<SplitInfo>) -> bool {
-    matches!(split, Some(s) if s.device_speed() == Speed::Low)
+    matches!(split, Some(s) if s.device_speed() == SplitSpeed::Low)
 }
 use rp_pac::usb_dpram::vals::EpControlEndpointType;
 

--- a/embassy-stm32/src/usb/otg.rs
+++ b/embassy-stm32/src/usb/otg.rs
@@ -743,9 +743,9 @@ mod host_impl {
             &self,
             addr: u8,
             endpoint: &embassy_usb_driver::EndpointInfo,
-            pre: bool,
+            split: Option<embassy_usb_driver::host::SplitInfo>,
         ) -> Result<Self::Channel<Ty, D>, embassy_usb_driver::host::HostError> {
-            self.inner.alloc_channel(addr, endpoint, pre)
+            self.inner.alloc_channel(addr, endpoint, split)
         }
     }
 }

--- a/embassy-stm32/src/usb/usb_host.rs
+++ b/embassy-stm32/src/usb/usb_host.rs
@@ -619,7 +619,7 @@ impl<'d, I: Instance, T: channel::Type, D: channel::Direction> UsbChannel<T, D> 
         &mut self,
         addr: u8,
         endpoint: &embassy_usb_driver::EndpointInfo,
-        _pre: bool,
+        _split: Option<embassy_usb_driver::host::SplitInfo>,
     ) -> Result<(), embassy_usb_driver::host::HostError> {
         trace!(
             "retarget_channel: addr: {:?} ep_type: {:?} index: {}",
@@ -676,7 +676,7 @@ impl<'d, I: Instance> UsbHostDriver for UsbHost<'d, I> {
         &self,
         addr: u8,
         endpoint: &embassy_usb_driver::EndpointInfo,
-        pre: bool,
+        split: Option<embassy_usb_driver::host::SplitInfo>,
     ) -> Result<Self::Channel<T, D>, embassy_usb_driver::host::HostError> {
         let new_index = if T::ep_type() == EndpointType::Control {
             // Only a single control channel is available
@@ -733,7 +733,7 @@ impl<'d, I: Instance> UsbHostDriver for UsbHost<'d, I> {
             endpoint.max_packet_size,
         );
 
-        channel.retarget_channel(addr, endpoint, pre)?;
+        channel.retarget_channel(addr, endpoint, split)?;
         Ok(channel)
     }
 

--- a/embassy-usb-driver/src/host.rs
+++ b/embassy-usb-driver/src/host.rs
@@ -4,6 +4,47 @@ use core::time::Duration;
 
 use crate::{EndpointInfo, EndpointType, Speed};
 
+/// Per-channel information necessary to encode a split-transaction token
+/// (USB 2.0 §11.14) or a legacy full-speed `PRE` packet (USB 1.1 §11.8.6).
+#[derive(Copy, Clone, Eq, PartialEq, Debug)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+pub struct SplitInfo {
+    hub_addr: u8,
+    port: u8,
+    device_speed: Speed,
+}
+
+impl SplitInfo {
+    /// Create a new [`SplitInfo`].
+    ///
+    /// `hub_addr` is the USB address of the hub that owns the Transaction
+    /// Translator; `port` is the 1-based port number on that hub where the
+    /// target device is attached; `device_speed` is the speed of the target
+    /// device, which must be [`Speed::Low`] or [`Speed::Full`].
+    pub const fn new(hub_addr: u8, port: u8, device_speed: Speed) -> Self {
+        Self {
+            hub_addr,
+            port,
+            device_speed,
+        }
+    }
+
+    /// USB address of the hub that owns the Transaction Translator.
+    pub const fn hub_addr(self) -> u8 {
+        self.hub_addr
+    }
+
+    /// 1-based port number on the hub where the target device is attached.
+    pub const fn port(self) -> u8 {
+        self.port
+    }
+
+    /// Speed of the target device.
+    pub const fn device_speed(self) -> Speed {
+        self.device_speed
+    }
+}
+
 /// Errors returned by [`UsbChannel`] operations.
 #[derive(Copy, Clone, Eq, PartialEq, Debug)]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
@@ -79,16 +120,20 @@ pub trait UsbHostDriver: Sized {
     /// Issue a bus reset.
     async fn bus_reset(&self);
 
-    /// Allocate channel for communication with device
+    /// Allocate channel for communication with device.
     ///
-    /// This can be a scarce resource, for one-off requests please scope the channel so it's dropped after completion
+    /// This can be a scarce resource, for one-off requests please scope the channel so it's dropped after completion.
     ///
-    /// `pre` - device is low-speed and communication is going through hub, so send PRE packet
+    /// `split` - when `Some`, every transfer on this channel is routed as a
+    /// split transaction through the specified hub's TT (USB 2.0 §11.14), or
+    /// as a legacy PRE packet on full-speed controllers (USB 1.1 §11.8.6).
+    /// Pass `None` when the device is reached directly (host at the same
+    /// speed as the device, or the device is high-speed).
     fn alloc_channel<T: channel::Type, D: channel::Direction>(
         &self,
         addr: u8,
         endpoint: &EndpointInfo,
-        pre: bool,
+        split: Option<SplitInfo>,
     ) -> Result<Self::Channel<T, D>, HostError>;
 }
 
@@ -255,8 +300,15 @@ pub trait UsbChannel<T: channel::Type, D: channel::Direction> {
         T: channel::IsControl,
         D: channel::IsOut;
 
-    /// Retargets channel to a new endpoint, may error if the underlying driver runs out of resources
-    fn retarget_channel(&mut self, addr: u8, endpoint: &EndpointInfo, pre: bool) -> Result<(), HostError>;
+    /// Retargets channel to a new endpoint, may error if the underlying driver runs out of resources.
+    ///
+    /// See [`UsbHostDriver::alloc_channel`] for the meaning of `split`.
+    fn retarget_channel(
+        &mut self,
+        addr: u8,
+        endpoint: &EndpointInfo,
+        split: Option<SplitInfo>,
+    ) -> Result<(), HostError>;
 
     /// Send IN request of type other from control
     /// For interrupt channels this will return the result of the next successful interrupt poll

--- a/embassy-usb-driver/src/host.rs
+++ b/embassy-usb-driver/src/host.rs
@@ -4,6 +4,20 @@ use core::time::Duration;
 
 use crate::{EndpointInfo, EndpointType, Speed};
 
+/// Speed of a low- or full-speed device reached through split transactions
+/// (USB 2.0 §11.14) or a `PRE` prefix (USB 1.1 §11.8.6).
+///
+/// High-speed devices are not valid split targets; split metadata only applies
+/// to devices operating at low or full speed behind a hub.
+#[derive(Copy, Clone, Eq, PartialEq, Debug)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+pub enum SplitSpeed {
+    /// 1.5 Mbit/s
+    Low,
+    /// 12 Mbit/s
+    Full,
+}
+
 /// Per-channel information necessary to encode a split-transaction token
 /// (USB 2.0 §11.14) or a legacy full-speed `PRE` packet (USB 1.1 §11.8.6).
 #[derive(Copy, Clone, Eq, PartialEq, Debug)]
@@ -11,7 +25,7 @@ use crate::{EndpointInfo, EndpointType, Speed};
 pub struct SplitInfo {
     hub_addr: u8,
     port: u8,
-    device_speed: Speed,
+    device_speed: SplitSpeed,
 }
 
 impl SplitInfo {
@@ -19,9 +33,9 @@ impl SplitInfo {
     ///
     /// `hub_addr` is the USB address of the hub that owns the Transaction
     /// Translator; `port` is the 1-based port number on that hub where the
-    /// target device is attached; `device_speed` is the speed of the target
-    /// device, which must be [`Speed::Low`] or [`Speed::Full`].
-    pub const fn new(hub_addr: u8, port: u8, device_speed: Speed) -> Self {
+    /// target device is attached; `device_speed` is the speed of that target
+    /// device ([`SplitSpeed::Low`] or [`SplitSpeed::Full`] only).
+    pub const fn new(hub_addr: u8, port: u8, device_speed: SplitSpeed) -> Self {
         Self {
             hub_addr,
             port,
@@ -39,8 +53,8 @@ impl SplitInfo {
         self.port
     }
 
-    /// Speed of the target device.
-    pub const fn device_speed(self) -> Speed {
+    /// Speed of the split target device (low or full only).
+    pub const fn device_speed(self) -> SplitSpeed {
         self.device_speed
     }
 }

--- a/embassy-usb-host/src/class/cdc_acm.rs
+++ b/embassy-usb-host/src/class/cdc_acm.rs
@@ -2,7 +2,7 @@
 //!
 //! This driver can communicate with USB CDC ACM devices (virtual serial ports).
 
-use embassy_usb_driver::host::{ChannelError, UsbChannel, UsbHostDriver, channel};
+use embassy_usb_driver::host::{ChannelError, SplitInfo, UsbChannel, UsbHostDriver, channel};
 use embassy_usb_driver::{Direction as UsbDirection, EndpointAddress, EndpointInfo, EndpointType};
 
 use crate::control::SetupPacket;
@@ -184,6 +184,7 @@ impl<D: UsbHostDriver> CdcAcmHost<D> {
         driver: &D,
         config_desc: &[u8],
         device_address: u8,
+        split: Option<SplitInfo>,
         max_packet_size_0: u16,
     ) -> Result<Self, CdcAcmError> {
         let info = find_cdc_acm(config_desc).ok_or(CdcAcmError::NoInterface)?;
@@ -210,13 +211,13 @@ impl<D: UsbHostDriver> CdcAcmHost<D> {
         };
 
         let ctrl_ch = driver
-            .alloc_channel::<channel::Control, channel::InOut>(device_address, &ctrl_ep_info, false)
+            .alloc_channel::<channel::Control, channel::InOut>(device_address, &ctrl_ep_info, split)
             .map_err(|_| CdcAcmError::NoChannel)?;
         let in_ch = driver
-            .alloc_channel::<channel::Bulk, channel::In>(device_address, &in_ep_info, false)
+            .alloc_channel::<channel::Bulk, channel::In>(device_address, &in_ep_info, split)
             .map_err(|_| CdcAcmError::NoChannel)?;
         let out_ch = driver
-            .alloc_channel::<channel::Bulk, channel::Out>(device_address, &out_ep_info, false)
+            .alloc_channel::<channel::Bulk, channel::Out>(device_address, &out_ep_info, split)
             .map_err(|_| CdcAcmError::NoChannel)?;
 
         Ok(Self {

--- a/embassy-usb-host/src/class/cdc_acm.rs
+++ b/embassy-usb-host/src/class/cdc_acm.rs
@@ -2,11 +2,12 @@
 //!
 //! This driver can communicate with USB CDC ACM devices (virtual serial ports).
 
-use embassy_usb_driver::host::{ChannelError, SplitInfo, UsbChannel, UsbHostDriver, channel};
+use embassy_usb_driver::host::{ChannelError, UsbChannel, UsbHostDriver, channel};
 use embassy_usb_driver::{Direction as UsbDirection, EndpointAddress, EndpointInfo, EndpointType};
 
 use crate::control::SetupPacket;
 use crate::descriptor::ConfigurationDescriptor;
+use crate::handler::EnumerationInfo;
 
 /// CDC class code.
 const USB_CLASS_CDC: u8 = 0x02;
@@ -180,19 +181,13 @@ impl<D: UsbHostDriver> CdcAcmHost<D> {
     /// Create a new CDC ACM host driver.
     ///
     /// Parses the config descriptor to find CDC ACM endpoints and allocates channels.
-    pub fn new(
-        driver: &D,
-        config_desc: &[u8],
-        device_address: u8,
-        split: Option<SplitInfo>,
-        max_packet_size_0: u16,
-    ) -> Result<Self, CdcAcmError> {
+    pub fn new(driver: &D, config_desc: &[u8], enum_info: &EnumerationInfo) -> Result<Self, CdcAcmError> {
         let info = find_cdc_acm(config_desc).ok_or(CdcAcmError::NoInterface)?;
 
         let ctrl_ep_info = EndpointInfo {
             addr: EndpointAddress::from_parts(0, UsbDirection::In),
             ep_type: EndpointType::Control,
-            max_packet_size: max_packet_size_0,
+            max_packet_size: enum_info.device_desc.max_packet_size0 as u16,
             interval_ms: 0,
         };
 
@@ -209,6 +204,9 @@ impl<D: UsbHostDriver> CdcAcmHost<D> {
             max_packet_size: info.bulk_out_mps,
             interval_ms: 0,
         };
+
+        let device_address = enum_info.device_address;
+        let split = enum_info.split;
 
         let ctrl_ch = driver
             .alloc_channel::<channel::Control, channel::InOut>(device_address, &ctrl_ep_info, split)

--- a/embassy-usb-host/src/class/gip.rs
+++ b/embassy-usb-host/src/class/gip.rs
@@ -66,10 +66,11 @@
 //!
 //! [MS-GIPUSB]: https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-gipusb/
 
-use embassy_usb_driver::host::{ChannelError, SplitInfo, UsbChannel, UsbHostDriver, channel};
+use embassy_usb_driver::host::{ChannelError, UsbChannel, UsbHostDriver, channel};
 use embassy_usb_driver::{Direction as UsbDirection, EndpointAddress, EndpointInfo, EndpointType};
 
 use crate::descriptor::ConfigurationDescriptor;
+use crate::handler::EnumerationInfo;
 
 // ── GIP USB interface identifiers ────────────────────────────────────────────
 
@@ -497,14 +498,9 @@ impl<D: UsbHostDriver, DEV: GipDevice> GipHost<D, DEV> {
     /// - [`GipError::NoInterface`] if no GIP interface is found.
     /// - [`GipError::NoChannel`] if channels cannot be allocated.
     /// - [`GipError::Transfer`] if a handshake transfer fails.
-    pub async fn try_register(
-        driver: &D,
-        config_desc: &[u8],
-        device_address: u8,
-        split: Option<SplitInfo>,
-        vendor_id: u16,
-        product_id: u16,
-    ) -> Result<Self, GipError> {
+    pub async fn try_register(driver: &D, config_desc: &[u8], enum_info: &EnumerationInfo) -> Result<Self, GipError> {
+        let vendor_id = enum_info.device_desc.vendor_id;
+        let product_id = enum_info.device_desc.product_id;
         let device = DEV::try_new(vendor_id, product_id).ok_or(GipError::UnsupportedDevice)?;
 
         let info = find_gip(config_desc).ok_or(GipError::NoInterface)?;
@@ -522,6 +518,9 @@ impl<D: UsbHostDriver, DEV: GipDevice> GipHost<D, DEV> {
             max_packet_size: info.interrupt_out_mps,
             interval_ms: info.interrupt_out_interval,
         };
+
+        let device_address = enum_info.device_address;
+        let split = enum_info.split;
 
         let in_ch = driver
             .alloc_channel::<channel::Interrupt, channel::In>(device_address, &in_ep_info, split)

--- a/embassy-usb-host/src/class/gip.rs
+++ b/embassy-usb-host/src/class/gip.rs
@@ -66,7 +66,7 @@
 //!
 //! [MS-GIPUSB]: https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-gipusb/
 
-use embassy_usb_driver::host::{ChannelError, UsbChannel, UsbHostDriver, channel};
+use embassy_usb_driver::host::{ChannelError, SplitInfo, UsbChannel, UsbHostDriver, channel};
 use embassy_usb_driver::{Direction as UsbDirection, EndpointAddress, EndpointInfo, EndpointType};
 
 use crate::descriptor::ConfigurationDescriptor;
@@ -501,6 +501,7 @@ impl<D: UsbHostDriver, DEV: GipDevice> GipHost<D, DEV> {
         driver: &D,
         config_desc: &[u8],
         device_address: u8,
+        split: Option<SplitInfo>,
         vendor_id: u16,
         product_id: u16,
     ) -> Result<Self, GipError> {
@@ -523,10 +524,10 @@ impl<D: UsbHostDriver, DEV: GipDevice> GipHost<D, DEV> {
         };
 
         let in_ch = driver
-            .alloc_channel::<channel::Interrupt, channel::In>(device_address, &in_ep_info, false)
+            .alloc_channel::<channel::Interrupt, channel::In>(device_address, &in_ep_info, split)
             .map_err(|_| GipError::NoChannel)?;
         let out_ch = driver
-            .alloc_channel::<channel::Interrupt, channel::Out>(device_address, &out_ep_info, false)
+            .alloc_channel::<channel::Interrupt, channel::Out>(device_address, &out_ep_info, split)
             .map_err(|_| GipError::NoChannel)?;
 
         let mut host = Self {

--- a/embassy-usb-host/src/class/hid.rs
+++ b/embassy-usb-host/src/class/hid.rs
@@ -2,7 +2,7 @@
 //!
 //! This driver can communicate with USB HID devices (keyboards, mice, gamepads, etc.).
 
-use embassy_usb_driver::host::{ChannelError, UsbChannel, UsbHostDriver, channel};
+use embassy_usb_driver::host::{ChannelError, SplitInfo, UsbChannel, UsbHostDriver, channel};
 use embassy_usb_driver::{Direction as UsbDirection, EndpointAddress, EndpointInfo, EndpointType};
 
 pub use super::hid_report::{ReportDescriptor, ReportField};
@@ -240,7 +240,13 @@ impl<D: UsbHostDriver> HidHost<D> {
     ///
     /// Parses the config descriptor to find the HID interface and its interrupt IN endpoint,
     /// then allocates the necessary channels.
-    pub fn new(driver: &D, config_desc: &[u8], device_address: u8, max_packet_size_0: u16) -> Result<Self, HidError> {
+    pub fn new(
+        driver: &D,
+        config_desc: &[u8],
+        device_address: u8,
+        split: Option<SplitInfo>,
+        max_packet_size_0: u16,
+    ) -> Result<Self, HidError> {
         let info = find_hid(config_desc).ok_or(HidError::NoInterface)?;
 
         let ctrl_ep_info = EndpointInfo {
@@ -258,10 +264,10 @@ impl<D: UsbHostDriver> HidHost<D> {
         };
 
         let ctrl_ch = driver
-            .alloc_channel::<channel::Control, channel::InOut>(device_address, &ctrl_ep_info, false)
+            .alloc_channel::<channel::Control, channel::InOut>(device_address, &ctrl_ep_info, split)
             .map_err(|_| HidError::NoChannel)?;
         let in_ch = driver
-            .alloc_channel::<channel::Interrupt, channel::In>(device_address, &in_ep_info, false)
+            .alloc_channel::<channel::Interrupt, channel::In>(device_address, &in_ep_info, split)
             .map_err(|_| HidError::NoChannel)?;
 
         Ok(Self {

--- a/embassy-usb-host/src/class/hid.rs
+++ b/embassy-usb-host/src/class/hid.rs
@@ -2,12 +2,13 @@
 //!
 //! This driver can communicate with USB HID devices (keyboards, mice, gamepads, etc.).
 
-use embassy_usb_driver::host::{ChannelError, SplitInfo, UsbChannel, UsbHostDriver, channel};
+use embassy_usb_driver::host::{ChannelError, UsbChannel, UsbHostDriver, channel};
 use embassy_usb_driver::{Direction as UsbDirection, EndpointAddress, EndpointInfo, EndpointType};
 
 pub use super::hid_report::{ReportDescriptor, ReportField};
 use crate::control::SetupPacket;
 use crate::descriptor::ConfigurationDescriptor;
+use crate::handler::EnumerationInfo;
 
 /// HID class code.
 const USB_CLASS_HID: u8 = 0x03;
@@ -240,19 +241,13 @@ impl<D: UsbHostDriver> HidHost<D> {
     ///
     /// Parses the config descriptor to find the HID interface and its interrupt IN endpoint,
     /// then allocates the necessary channels.
-    pub fn new(
-        driver: &D,
-        config_desc: &[u8],
-        device_address: u8,
-        split: Option<SplitInfo>,
-        max_packet_size_0: u16,
-    ) -> Result<Self, HidError> {
+    pub fn new(driver: &D, config_desc: &[u8], enum_info: &EnumerationInfo) -> Result<Self, HidError> {
         let info = find_hid(config_desc).ok_or(HidError::NoInterface)?;
 
         let ctrl_ep_info = EndpointInfo {
             addr: EndpointAddress::from_parts(0, UsbDirection::In),
             ep_type: EndpointType::Control,
-            max_packet_size: max_packet_size_0,
+            max_packet_size: enum_info.device_desc.max_packet_size0 as u16,
             interval_ms: 0,
         };
 
@@ -262,6 +257,9 @@ impl<D: UsbHostDriver> HidHost<D> {
             max_packet_size: info.interrupt_in_mps,
             interval_ms: 0,
         };
+
+        let device_address = enum_info.device_address;
+        let split = enum_info.split;
 
         let ctrl_ch = driver
             .alloc_channel::<channel::Control, channel::InOut>(device_address, &ctrl_ep_info, split)

--- a/embassy-usb-host/src/class/hub.rs
+++ b/embassy-usb-host/src/class/hub.rs
@@ -9,7 +9,7 @@ use core::num::NonZeroU8;
 use bitflags::bitflags;
 use embassy_time::Timer;
 use embassy_usb::control::Request;
-use embassy_usb_driver::host::{HostError, SplitInfo, UsbChannel, UsbHostDriver, channel};
+use embassy_usb_driver::host::{HostError, SplitInfo, SplitSpeed, UsbChannel, UsbHostDriver, channel};
 use embassy_usb_driver::{Direction, EndpointInfo, EndpointType, Speed};
 use zerocopy::{FromBytes, Immutable, KnownLayout};
 
@@ -36,7 +36,10 @@ pub enum HubEvent {
 impl<H: UsbHostDriver, const MAX_PORTS: usize> HubHandler<H, MAX_PORTS> {
     /// Attempt to register a hub handler for the given device.
     pub async fn try_register(bus: &H, enum_info: &EnumerationInfo) -> Result<Self, RegisterError> {
-        let ls_over_fs = enum_info.split.map(|s| s.device_speed() == Speed::Low).unwrap_or(false);
+        let ls_over_fs = enum_info
+            .split
+            .map(|s| s.device_speed() == SplitSpeed::Low)
+            .unwrap_or(false);
         let mut control_channel = bus.alloc_channel::<channel::Control, channel::InOut>(
             enum_info.device_address,
             &EndpointInfo {
@@ -218,10 +221,12 @@ impl<H: UsbHostDriver, const MAX_PORTS: usize> HubHandler<H, MAX_PORTS> {
         Timer::after_millis(50).await;
         self.port_feature(false, PortFeature::ChangeReset, port, 0).await?;
 
-        // Legacy PRE / low-speed-through-a-hub: everything else is not yet
-        // supported by any of the HAL drivers.
-        let split = matches!((speed, self.speed), (Speed::Low, Speed::Full | Speed::High))
-            .then(|| SplitInfo::new(self.device_address, port + 1, speed));
+        let split_speed = match (speed, self.speed) {
+            (Speed::Low, Speed::Full | Speed::High) => Some(SplitSpeed::Low),
+            (Speed::Full, Speed::High) => Some(SplitSpeed::Full),
+            _ => None,
+        };
+        let split = split_speed.map(|ss| SplitInfo::new(self.device_address, port + 1, ss));
         self.control_channel
             .enumerate_device(speed, new_device_address, split)
             .await

--- a/embassy-usb-host/src/class/hub.rs
+++ b/embassy-usb-host/src/class/hub.rs
@@ -9,7 +9,7 @@ use core::num::NonZeroU8;
 use bitflags::bitflags;
 use embassy_time::Timer;
 use embassy_usb::control::Request;
-use embassy_usb_driver::host::{HostError, UsbChannel, UsbHostDriver, channel};
+use embassy_usb_driver::host::{HostError, SplitInfo, UsbChannel, UsbHostDriver, channel};
 use embassy_usb_driver::{Direction, EndpointInfo, EndpointType, Speed};
 use zerocopy::{FromBytes, Immutable, KnownLayout};
 
@@ -36,6 +36,7 @@ pub enum HubEvent {
 impl<H: UsbHostDriver, const MAX_PORTS: usize> HubHandler<H, MAX_PORTS> {
     /// Attempt to register a hub handler for the given device.
     pub async fn try_register(bus: &H, enum_info: &EnumerationInfo) -> Result<Self, RegisterError> {
+        let ls_over_fs = enum_info.split.map(|s| s.device_speed() == Speed::Low).unwrap_or(false);
         let mut control_channel = bus.alloc_channel::<channel::Control, channel::InOut>(
             enum_info.device_address,
             &EndpointInfo {
@@ -44,10 +45,10 @@ impl<H: UsbHostDriver, const MAX_PORTS: usize> HubHandler<H, MAX_PORTS> {
                 max_packet_size: enum_info
                     .device_desc
                     .max_packet_size0
-                    .min(if enum_info.ls_over_fs { 8 } else { 64 }) as u16,
+                    .min(if ls_over_fs { 8 } else { 64 }) as u16,
                 interval_ms: 0,
             },
-            enum_info.ls_over_fs,
+            enum_info.split,
         )?;
 
         let mut cfg_desc_buf = [0u8; DEFAULT_MAX_DESCRIPTOR_SIZE];
@@ -78,7 +79,7 @@ impl<H: UsbHostDriver, const MAX_PORTS: usize> HubHandler<H, MAX_PORTS> {
         let interrupt_channel = bus.alloc_channel::<channel::Interrupt, channel::In>(
             enum_info.device_address,
             &interrupt_ep.into(),
-            enum_info.ls_over_fs,
+            enum_info.split,
         )?;
 
         let desc = control_channel.request_descriptor::<HubDescriptor, 64>(0, true).await?;
@@ -217,9 +218,12 @@ impl<H: UsbHostDriver, const MAX_PORTS: usize> HubHandler<H, MAX_PORTS> {
         Timer::after_millis(50).await;
         self.port_feature(false, PortFeature::ChangeReset, port, 0).await?;
 
-        let ls_pre = matches!((speed, self.speed), (Speed::Low, Speed::Full | Speed::High));
+        // Legacy PRE / low-speed-through-a-hub: everything else is not yet
+        // supported by any of the HAL drivers.
+        let split = matches!((speed, self.speed), (Speed::Low, Speed::Full | Speed::High))
+            .then(|| SplitInfo::new(self.device_address, port + 1, speed));
         self.control_channel
-            .enumerate_device(speed, new_device_address, ls_pre)
+            .enumerate_device(speed, new_device_address, split)
             .await
     }
 

--- a/embassy-usb-host/src/class/kbd.rs
+++ b/embassy-usb-host/src/class/kbd.rs
@@ -53,7 +53,7 @@ impl<H: UsbHostDriver> KbdHandler<H> {
                 max_packet_size: (enum_info.device_desc.max_packet_size0 as u16).min(enum_info.speed.max_packet_size()),
                 interval_ms: 0,
             },
-            enum_info.ls_over_fs,
+            enum_info.split,
         )?;
 
         let mut cfg_desc_buf = [0u8; DEFAULT_MAX_DESCRIPTOR_SIZE];
@@ -88,7 +88,7 @@ impl<H: UsbHostDriver> KbdHandler<H> {
         let interrupt_channel = bus.alloc_channel::<channel::Interrupt, channel::In>(
             enum_info.device_address,
             &interrupt_ep.into(),
-            enum_info.ls_over_fs,
+            enum_info.split,
         )?;
 
         debug!("[kbd]: Setting PROTOCOL & idle");

--- a/embassy-usb-host/src/class/uac/mod.rs
+++ b/embassy-usb-host/src/class/uac/mod.rs
@@ -110,7 +110,7 @@ impl<H: UsbHostDriver> UacHandler<H> {
                 max_packet_size: (enum_info.device_desc.max_packet_size0 as u16).min(enum_info.speed.max_packet_size()),
                 interval_ms: 0,
             },
-            enum_info.ls_over_fs,
+            enum_info.split,
         )?;
 
         let mut cfg_desc_buf = [0u8; DEFAULT_MAX_DESCRIPTOR_SIZE];
@@ -194,7 +194,7 @@ impl<H: UsbHostDriver> UacHandler<H> {
             output_channel = Some(host.alloc_channel::<channel::Isochronous, channel::Out>(
                 enum_info.device_address,
                 &output_interface.endpoint_descriptor.unwrap().into(),
-                false,
+                enum_info.split,
             )?);
         }
         if streaming_interface.num_endpoints > 1 {
@@ -202,7 +202,7 @@ impl<H: UsbHostDriver> UacHandler<H> {
                 feedback_channel = Some(host.alloc_channel::<channel::Isochronous, channel::In>(
                     enum_info.device_address,
                     &feedback_endpoint.into(),
-                    false,
+                    enum_info.split,
                 )?);
             }
         }

--- a/embassy-usb-host/src/control.rs
+++ b/embassy-usb-host/src/control.rs
@@ -5,7 +5,7 @@ use core::num::NonZeroU8;
 use embassy_time::Timer;
 use embassy_usb::control::Request;
 pub use embassy_usb_driver::host::channel;
-use embassy_usb_driver::host::{ChannelError, HostError, UsbChannel};
+use embassy_usb_driver::host::{ChannelError, HostError, SplitInfo, UsbChannel};
 use embassy_usb_driver::{Direction, EndpointInfo, EndpointType, Speed};
 
 use crate::descriptor::{USBDescriptor, descriptor_type};
@@ -390,7 +390,7 @@ pub trait ControlChannelExt<D: channel::Direction>: UsbChannel<channel::Control,
         &mut self,
         speed: Speed,
         new_device_address: u8,
-        ls_over_fs: bool,
+        split: Option<SplitInfo>,
     ) -> Result<EnumerationInfo, HostError>
     where
         D: channel::IsIn + channel::IsOut,
@@ -405,7 +405,7 @@ pub trait ControlChannelExt<D: channel::Direction>: UsbChannel<channel::Control,
                 max_packet_size: speed.max_packet_size(),
                 interval_ms: 0,
             },
-            ls_over_fs,
+            split,
         )?;
 
         trace!("[enum] Getting max_packet_size for new device");
@@ -447,7 +447,7 @@ pub trait ControlChannelExt<D: channel::Direction>: UsbChannel<channel::Control,
                 max_packet_size: max_packet_size0 as u16,
                 interval_ms: 0,
             },
-            ls_over_fs,
+            split,
         )?;
 
         let retries = 5;
@@ -472,7 +472,7 @@ pub trait ControlChannelExt<D: channel::Direction>: UsbChannel<channel::Control,
 
         Ok(EnumerationInfo {
             device_address: new_device_address,
-            ls_over_fs,
+            split,
             speed,
             device_desc,
         })

--- a/embassy-usb-host/src/handler.rs
+++ b/embassy-usb-host/src/handler.rs
@@ -3,18 +3,21 @@
 
 use embassy_usb_driver::Speed;
 use embassy_usb_driver::host::channel::{self, IsIn, IsOut};
-use embassy_usb_driver::host::{HostError, UsbChannel};
+use embassy_usb_driver::host::{HostError, SplitInfo, UsbChannel};
 
 use crate::control::ControlChannelExt;
 use crate::descriptor::{ConfigurationDescriptor, DeviceDescriptor, USBDescriptor};
 
 /// Information obtained through preliminary enumeration.
-#[derive(Debug)]
+#[derive(Clone, Copy, Debug)]
 pub struct EnumerationInfo {
     /// Assigned device address.
     pub device_address: u8,
-    /// Low-speed device connected via a full-speed or higher hub.
-    pub ls_over_fs: bool,
+    /// Split-transaction routing, when this device is behind a hub that
+    /// requires splits (HS host reaching LS/FS device through a HS hub, or
+    /// FS host reaching LS device through a FS hub). `None` for a device
+    /// attached directly to the host at its native speed.
+    pub split: Option<SplitInfo>,
     /// Negotiated speed.
     pub speed: Speed,
     /// Parsed device descriptor.

--- a/embassy-usb-host/src/lib.rs
+++ b/embassy-usb-host/src/lib.rs
@@ -15,7 +15,8 @@ use embassy_usb_driver::host::{ChannelError, DeviceEvent, HostError, UsbChannel,
 use embassy_usb_driver::{Direction as UsbDirection, EndpointAddress, EndpointInfo, EndpointType, Speed};
 
 use crate::control::SetupPacket;
-use crate::descriptor::{ConfigurationDescriptor, DeviceDescriptor, USBDescriptor};
+use crate::descriptor::{ConfigurationDescriptor, USBDescriptor};
+use crate::handler::EnumerationInfo;
 
 /// USB host enumeration error.
 #[derive(Debug)]
@@ -144,12 +145,12 @@ impl<D: UsbHostDriver> UsbHost<D> {
     /// 4. Get configuration descriptor
     /// 5. SET_CONFIGURATION
     ///
-    /// Returns the device descriptor, assigned address, and bytes written to config_buf.
+    /// Returns the [`EnumerationInfo`] for the device and bytes written to `config_buf`.
     pub async fn enumerate(
         &mut self,
         speed: Speed,
         config_buf: &mut [u8],
-    ) -> Result<(DeviceDescriptor, u8, usize), EnumerationError> {
+    ) -> Result<(EnumerationInfo, usize), EnumerationError> {
         use crate::control::ControlChannelExt;
 
         let ep0_info = EndpointInfo {
@@ -167,7 +168,7 @@ impl<D: UsbHostDriver> UsbHost<D> {
         // Steps 1–3: GET_DESCRIPTOR (partial + full), SET_ADDRESS, retarget channel.
         let addr = self.alloc_address().ok_or(EnumerationError::NoChannel)?;
         let enum_info = ch.enumerate_device(speed, addr, None).await?;
-        let dev_desc = enum_info.device_desc;
+        let dev_desc = &enum_info.device_desc;
 
         info!(
             "Device: VID={:04x} PID={:04x} class={:02x}",
@@ -210,6 +211,6 @@ impl<D: UsbHostDriver> UsbHost<D> {
         // Channel is released on drop.
         drop(ch);
 
-        Ok((dev_desc, addr, n))
+        Ok((enum_info, n))
     }
 }

--- a/embassy-usb-host/src/lib.rs
+++ b/embassy-usb-host/src/lib.rs
@@ -161,12 +161,12 @@ impl<D: UsbHostDriver> UsbHost<D> {
 
         let mut ch = self
             .driver
-            .alloc_channel::<channel::Control, channel::InOut>(0, &ep0_info, false)
+            .alloc_channel::<channel::Control, channel::InOut>(0, &ep0_info, None)
             .map_err(|_| EnumerationError::NoChannel)?;
 
         // Steps 1–3: GET_DESCRIPTOR (partial + full), SET_ADDRESS, retarget channel.
         let addr = self.alloc_address().ok_or(EnumerationError::NoChannel)?;
-        let enum_info = ch.enumerate_device(speed, addr, false).await?;
+        let enum_info = ch.enumerate_device(speed, addr, None).await?;
         let dev_desc = enum_info.device_desc;
 
         info!(

--- a/embassy-usb-synopsys-otg/src/host.rs
+++ b/embassy-usb-synopsys-otg/src/host.rs
@@ -6,7 +6,7 @@ use core::marker::PhantomData;
 use core::task::Poll;
 
 use embassy_sync::waitqueue::AtomicWaker;
-use embassy_usb_driver::host::{ChannelError, DeviceEvent, HostError, UsbChannel, UsbHostDriver, channel};
+use embassy_usb_driver::host::{ChannelError, DeviceEvent, HostError, SplitInfo, UsbChannel, UsbHostDriver, channel};
 use embassy_usb_driver::{EndpointInfo, EndpointType, Speed};
 use portable_atomic::{AtomicBool, AtomicU8, Ordering};
 
@@ -622,7 +622,7 @@ impl<'d, const CH_COUNT: usize> UsbHostDriver for OtgHost<'d, CH_COUNT> {
         &self,
         addr: u8,
         endpoint: &EndpointInfo,
-        _pre: bool,
+        _split: Option<SplitInfo>,
     ) -> Result<Self::Channel<T, D>, HostError> {
         let ep_number = endpoint.addr.index() as u8;
         let max_packet_size = endpoint.max_packet_size;
@@ -1101,7 +1101,7 @@ impl<T: channel::Type, D: channel::Direction, const CH_COUNT: usize> UsbChannel<
         Ok(())
     }
 
-    fn retarget_channel(&mut self, addr: u8, endpoint: &EndpointInfo, _pre: bool) -> Result<(), HostError> {
+    fn retarget_channel(&mut self, addr: u8, endpoint: &EndpointInfo, _split: Option<SplitInfo>) -> Result<(), HostError> {
         self.device_address = addr;
         self.ep_number = endpoint.addr.index() as u8;
         self.max_packet_size = endpoint.max_packet_size;

--- a/embassy-usb-synopsys-otg/src/host.rs
+++ b/embassy-usb-synopsys-otg/src/host.rs
@@ -1101,7 +1101,12 @@ impl<T: channel::Type, D: channel::Direction, const CH_COUNT: usize> UsbChannel<
         Ok(())
     }
 
-    fn retarget_channel(&mut self, addr: u8, endpoint: &EndpointInfo, _split: Option<SplitInfo>) -> Result<(), HostError> {
+    fn retarget_channel(
+        &mut self,
+        addr: u8,
+        endpoint: &EndpointInfo,
+        _split: Option<SplitInfo>,
+    ) -> Result<(), HostError> {
         self.device_address = addr;
         self.ep_number = endpoint.addr.index() as u8;
         self.max_packet_size = endpoint.max_packet_size;

--- a/examples/rp/src/bin/usb_host_keyboard.rs
+++ b/examples/rp/src/bin/usb_host_keyboard.rs
@@ -29,7 +29,7 @@ async fn main(_spawner: Spawner) {
         let mut config_buf = [0u8; 256];
         let result = host.enumerate(speed, &mut config_buf).await;
 
-        let (dev_desc, addr, config_len) = match result {
+        let (enum_info, config_len) = match result {
             Ok(r) => r,
             Err(e) => {
                 error!("Enumeration failed: {:?}", e);
@@ -39,15 +39,10 @@ async fn main(_spawner: Spawner) {
 
         info!(
             "Enumerated: VID={:04x} PID={:04x} addr={}",
-            dev_desc.vendor_id, dev_desc.product_id, addr
+            enum_info.device_desc.vendor_id, enum_info.device_desc.product_id, enum_info.device_address
         );
 
-        let mut hid = match HidHost::new(
-            host.driver(),
-            &config_buf[..config_len],
-            addr,
-            dev_desc.max_packet_size0 as u16,
-        ) {
+        let mut hid = match HidHost::new(host.driver(), &config_buf[..config_len], &enum_info) {
             Ok(h) => h,
             Err(e) => {
                 error!("HID init failed: {:?}", e);

--- a/examples/stm32f4/src/bin/usb_host_serial.rs
+++ b/examples/stm32f4/src/bin/usb_host_serial.rs
@@ -58,7 +58,7 @@ async fn main(_spawner: Spawner) {
         let mut config_buf = [0u8; 256];
         let result = host.enumerate(speed, &mut config_buf).await;
 
-        let (dev_desc, addr, config_len) = match result {
+        let (enum_info, config_len) = match result {
             Ok(r) => r,
             Err(e) => {
                 error!("Enumeration failed: {:?}", e);
@@ -68,16 +68,11 @@ async fn main(_spawner: Spawner) {
 
         info!(
             "Enumerated: VID={:04x} PID={:04x} addr={}",
-            dev_desc.vendor_id, dev_desc.product_id, addr
+            enum_info.device_desc.vendor_id, enum_info.device_desc.product_id, enum_info.device_address
         );
 
         // Try to create a CDC ACM host driver
-        let mut cdc = match CdcAcmHost::new(
-            host.driver(),
-            &config_buf[..config_len],
-            addr,
-            dev_desc.max_packet_size0 as u16,
-        ) {
+        let mut cdc = match CdcAcmHost::new(host.driver(), &config_buf[..config_len], &enum_info) {
             Ok(c) => c,
             Err(e) => {
                 error!("CDC ACM init failed: {:?}", e);

--- a/examples/stm32g0/src/bin/usb_host_keyboard.rs
+++ b/examples/stm32g0/src/bin/usb_host_keyboard.rs
@@ -88,7 +88,7 @@ async fn main(_spawner: Spawner) {
         let mut config_buf = [0u8; 256];
         let result = host.enumerate(speed, &mut config_buf).await;
 
-        let (dev_desc, addr, config_len) = match result {
+        let (enum_info, config_len) = match result {
             Ok(r) => r,
             Err(e) => {
                 error!("Enumeration failed: {:?}", e);
@@ -98,15 +98,10 @@ async fn main(_spawner: Spawner) {
 
         info!(
             "Enumerated: VID={:04x} PID={:04x} addr={}",
-            dev_desc.vendor_id, dev_desc.product_id, addr
+            enum_info.device_desc.vendor_id, enum_info.device_desc.product_id, enum_info.device_address
         );
 
-        let mut hid = match HidHost::new(
-            host.driver(),
-            &config_buf[..config_len],
-            addr,
-            dev_desc.max_packet_size0 as u16,
-        ) {
+        let mut hid = match HidHost::new(host.driver(), &config_buf[..config_len], &enum_info) {
             Ok(h) => h,
             Err(e) => {
                 error!("HID init failed: {:?}", e);

--- a/examples/stm32wba6/src/bin/usb_host_hid.rs
+++ b/examples/stm32wba6/src/bin/usb_host_hid.rs
@@ -61,7 +61,7 @@ async fn main(_spawner: Spawner) {
         let mut config_buf = [0u8; 256];
         let result = host.enumerate(speed, &mut config_buf).await;
 
-        let (dev_desc, addr, config_len) = match result {
+        let (enum_info, config_len) = match result {
             Ok(r) => r,
             Err(e) => {
                 error!("Enumeration failed: {:?}", e);
@@ -71,16 +71,11 @@ async fn main(_spawner: Spawner) {
 
         info!(
             "Enumerated: VID={:04x} PID={:04x} addr={}",
-            dev_desc.vendor_id, dev_desc.product_id, addr
+            enum_info.device_desc.vendor_id, enum_info.device_desc.product_id, enum_info.device_address
         );
 
         // Try to create a HID host driver
-        let mut hid = match HidHost::new(
-            host.driver(),
-            &config_buf[..config_len],
-            addr,
-            dev_desc.max_packet_size0 as u16,
-        ) {
+        let mut hid = match HidHost::new(host.driver(), &config_buf[..config_len], &enum_info) {
             Ok(h) => h,
             Err(e) => {
                 error!("HID init failed: {:?}", e);

--- a/examples/stm32wba6/src/bin/usb_host_serial.rs
+++ b/examples/stm32wba6/src/bin/usb_host_serial.rs
@@ -62,7 +62,7 @@ async fn main(_spawner: Spawner) {
         let mut config_buf = [0u8; 256];
         let result = host.enumerate(speed, &mut config_buf).await;
 
-        let (dev_desc, addr, config_len) = match result {
+        let (enum_info, config_len) = match result {
             Ok(r) => r,
             Err(e) => {
                 error!("Enumeration failed: {:?}", e);
@@ -72,16 +72,11 @@ async fn main(_spawner: Spawner) {
 
         info!(
             "Enumerated: VID={:04x} PID={:04x} addr={}",
-            dev_desc.vendor_id, dev_desc.product_id, addr
+            enum_info.device_desc.vendor_id, enum_info.device_desc.product_id, enum_info.device_address
         );
 
         // Try to create a CDC ACM host driver
-        let mut cdc = match CdcAcmHost::new(
-            host.driver(),
-            &config_buf[..config_len],
-            addr,
-            dev_desc.max_packet_size0 as u16,
-        ) {
+        let mut cdc = match CdcAcmHost::new(host.driver(), &config_buf[..config_len], &enum_info) {
             Ok(c) => c,
             Err(e) => {
                 error!("CDC ACM init failed: {:?}", e);


### PR DESCRIPTION
This PR ensures future compatibility with high-speed USB hubs in the host driver. Additionally, enumeration now returns EnumerationInfo (duh) and class constructors consistently take EnumerationInfo to better support connecting through HUBs.