### PR TITLE
Fix endianness of HubStatus, HubStatusChange, PortStatus, PortStatushange

### DIFF
--- a/embassy-usb-host/src/class/hub.rs
+++ b/embassy-usb-host/src/class/hub.rs
@@ -10,7 +10,7 @@ use bitflags::bitflags;
 use embassy_time::Timer;
 use embassy_usb_driver::host::{HostError, RequestType, SetupPacket, UsbChannel, UsbHostDriver, channel};
 use embassy_usb_driver::{Direction, EndpointInfo, EndpointType, Speed};
-use zerocopy::{FromBytes, Immutable, IntoBytes, KnownLayout};
+use zerocopy::{FromBytes, Immutable, KnownLayout};
 
 use crate::control::{CLEAR_FEATURE, ControlChannelExt, GET_STATUS, SET_FEATURE};
 use crate::descriptor::{DEFAULT_MAX_DESCRIPTOR_SIZE, InterfaceDescriptor, USBDescriptor};
@@ -185,11 +185,11 @@ impl<H: UsbHostDriver, const MAX_PORTS: usize> HubHandler<H, MAX_PORTS> {
             index: 0,
             length: 4,
         };
-        let mut buf = [0u16; 2];
-        self.control_channel.control_in(&setup, buf.as_mut_bytes()).await?;
+        let mut buf = [0u8; 4];
+        self.control_channel.control_in(&setup, &mut buf).await?;
         Ok((
-            HubStatus::from_bits_truncate(u16::from_le(buf[0])),
-            HubStatusChange::from_bits_truncate(u16::from_le(buf[1])),
+            HubStatus::from_bits_truncate(u16::from_le_bytes(buf[..2].try_into().unwrap())),
+            HubStatusChange::from_bits_truncate(u16::from_le_bytes(buf[2..].try_into().unwrap())),
         ))
     }
 
@@ -230,11 +230,11 @@ impl<H: UsbHostDriver, const MAX_PORTS: usize> HubHandler<H, MAX_PORTS> {
             index: (port + 1) as u16,
             length: 4,
         };
-        let mut buf = [0u16; 2];
-        self.control_channel.control_in(&setup, buf.as_mut_bytes()).await?;
+        let mut buf = [0u8; 4];
+        self.control_channel.control_in(&setup, &mut buf).await?;
         Ok((
-            PortStatus::from_bits_truncate(u16::from_le(buf[0])),
-            PortStatusChange::from_bits_truncate(u16::from_le(buf[1])),
+            PortStatus::from_bits_truncate(u16::from_le_bytes(buf[..2].try_into().unwrap())),
+            PortStatusChange::from_bits_truncate(u16::from_le_bytes(buf[2..].try_into().unwrap())),
         ))
     }
 }

--- a/embassy-usb-host/src/class/hub.rs
+++ b/embassy-usb-host/src/class/hub.rs
@@ -188,8 +188,8 @@ impl<H: UsbHostDriver, const MAX_PORTS: usize> HubHandler<H, MAX_PORTS> {
         let mut buf = [0u16; 2];
         self.control_channel.control_in(&setup, buf.as_mut_bytes()).await?;
         Ok((
-            HubStatus::from_bits_truncate(buf[0]),
-            HubStatusChange::from_bits_truncate(buf[1]),
+            HubStatus::from_bits_truncate(u16::from_le(buf[0])),
+            HubStatusChange::from_bits_truncate(u16::from_le(buf[1])),
         ))
     }
 
@@ -233,8 +233,8 @@ impl<H: UsbHostDriver, const MAX_PORTS: usize> HubHandler<H, MAX_PORTS> {
         let mut buf = [0u16; 2];
         self.control_channel.control_in(&setup, buf.as_mut_bytes()).await?;
         Ok((
-            PortStatus::from_bits_truncate(buf[0]),
-            PortStatusChange::from_bits_truncate(buf[1]),
+            PortStatus::from_bits_truncate(u16::from_le(buf[0])),
+            PortStatusChange::from_bits_truncate(u16::from_le(buf[1])),
         ))
     }
 }


### PR DESCRIPTION
According to the USB spec, all the data is little endian.

In big endian systems, like mine, the wrong value was being interpreted.

There might be other places with endian issues, but I don't see code to test/check/handle endianness automatically so I'm only fixing what I detected.