### PR TITLE
fix(stm32/rcc): hclk is derived from d1cpre_clk

### DIFF
--- a/embassy-stm32/src/rcc/h.rs
+++ b/embassy-stm32/src/rcc/h.rs
@@ -622,7 +622,7 @@ pub(crate) unsafe fn init(config: Config) {
     let hclk = {
         let d1cpre_clk = sys / config.d1c_pre;
         assert!(d1cpre_clk <= d1cpre_clk_max);
-        sys / config.ahb_pre
+        d1cpre_clk / config.ahb_pre
     };
     #[cfg(stm32h5)]
     let hclk = sys / config.ahb_pre;


### PR DESCRIPTION
According to RM0433, Rev 8, Figure 49, the HCLK is derived from the output of the sys_d1cpre_clk, not the sys_clk.

<img width="1313" height="1226" alt="image" src="https://github.com/user-attachments/assets/387f5cda-fb0c-4b02-8bf0-3328921becd8" />

The primary impact of this change is to allow slightly faster clock speeds on the STM32H7 because the code would previously panic given valid inputs (well, valid according to the STM32 CubeMX application).