### PR TITLE
stm32/eth: cache link state

### DIFF
--- a/embassy-stm32/src/eth/generic_phy.rs
+++ b/embassy-stm32/src/eth/generic_phy.rs
@@ -1,6 +1,8 @@
 //! Generic SMI Ethernet PHY
 
 use core::task::Context;
+#[cfg(feature = "time")]
+use core::task::Poll;
 
 #[cfg(feature = "time")]
 use embassy_time::{Duration, Timer};
@@ -49,6 +51,8 @@ pub struct GenericPhy<SM: StationManagement> {
     sm: SM,
     #[cfg(feature = "time")]
     poll_interval: Duration,
+    #[cfg(feature = "time")]
+    timer: Timer,
 }
 
 impl<SM: StationManagement> GenericPhy<SM> {
@@ -63,6 +67,8 @@ impl<SM: StationManagement> GenericPhy<SM> {
             sm,
             #[cfg(feature = "time")]
             poll_interval: Duration::from_millis(500),
+            #[cfg(feature = "time")]
+            timer: Timer::after_ticks(0),
         }
     }
 
@@ -76,6 +82,8 @@ impl<SM: StationManagement> GenericPhy<SM> {
             phy_addr: 0xFF,
             #[cfg(feature = "time")]
             poll_interval: Duration::from_millis(500),
+            #[cfg(feature = "time")]
+            timer: Timer::after_ticks(0),
         }
     }
 }
@@ -115,26 +123,33 @@ impl<SM: StationManagement> Phy for GenericPhy<SM> {
         );
     }
 
-    fn poll_link(&mut self, cx: &mut Context) -> bool {
+    fn poll_link(&mut self, cx: &mut Context) -> Option<bool> {
         #[cfg(not(feature = "time"))]
         cx.waker().wake_by_ref();
 
         #[cfg(feature = "time")]
-        let _ = Timer::after(self.poll_interval).poll_unpin(cx);
+        {
+            if matches!(self.timer.poll_unpin(cx), Poll::Ready(())) {
+                self.timer = Timer::after(self.poll_interval);
+                let _ = self.timer.poll_unpin(cx);
+            } else {
+                return None;
+            }
+        }
 
         let bsr = self.sm.smi_read(self.phy_addr, PHY_REG_BSR);
 
         // No link without autonegotiate
         if bsr & PHY_REG_BSR_ANDONE == 0 {
-            return false;
+            return Some(false);
         }
         // No link if link is down
         if bsr & PHY_REG_BSR_UP == 0 {
-            return false;
+            return Some(false);
         }
 
         // Got link
-        true
+        Some(true)
     }
 }
 

--- a/embassy-stm32/src/eth/mod.rs
+++ b/embassy-stm32/src/eth/mod.rs
@@ -111,11 +111,11 @@ impl<'d, T: Instance, P: Phy> embassy_net_driver::Driver for Ethernet<'d, T, P> 
     }
 
     fn link_state(&mut self, cx: &mut Context) -> LinkState {
-        if self.phy.poll_link(cx) {
-            LinkState::Up
-        } else {
-            LinkState::Down
+        if let Some(link_state) = self.phy.poll_link(cx) {
+            self.link_state = if link_state { LinkState::Up } else { LinkState::Down };
         }
+
+        self.link_state
     }
 
     fn hardware_address(&self) -> HardwareAddress {
@@ -166,7 +166,7 @@ pub trait Phy {
     /// PHY initialisation.
     fn phy_init(&mut self);
     /// Poll link to see if it is up and FD with 100Mbps
-    fn poll_link(&mut self, cx: &mut Context) -> bool;
+    fn poll_link(&mut self, cx: &mut Context) -> Option<bool>;
 }
 
 impl<'d, T: Instance, P: Phy> Ethernet<'d, T, P> {

--- a/embassy-stm32/src/eth/v1/mod.rs
+++ b/embassy-stm32/src/eth/v1/mod.rs
@@ -46,6 +46,7 @@ impl interrupt::typelevel::Handler<interrupt::typelevel::ETH> for InterruptHandl
 /// Ethernet driver.
 pub struct Ethernet<'d, T: Instance, P: Phy> {
     _peri: Peri<'d, T>,
+    pub(crate) link_state: LinkState,
     pub(crate) tx: TDesRing<'d>,
     pub(crate) rx: RDesRing<'d>,
 
@@ -299,6 +300,7 @@ impl<'d, T: Instance, P: Phy> Ethernet<'d, T, P> {
             _pins: pins,
             phy: phy,
             mac_addr,
+            link_state: LinkState::Down,
             tx: TDesRing::new(&mut queue.tx_desc, &mut queue.tx_buf),
             rx: RDesRing::new(&mut queue.rx_desc, &mut queue.rx_buf),
         };

--- a/embassy-stm32/src/eth/v2/mod.rs
+++ b/embassy-stm32/src/eth/v2/mod.rs
@@ -38,6 +38,7 @@ impl interrupt::typelevel::Handler<interrupt::typelevel::ETH> for InterruptHandl
 pub struct Ethernet<'d, T: Instance, P: Phy> {
     _peri: Peri<'d, T>,
     _wake_guard: WakeGuard,
+    pub(crate) link_state: LinkState,
     pub(crate) tx: TDesRing<'d>,
     pub(crate) rx: RDesRing<'d>,
     _pins: Pins<'d>,
@@ -296,6 +297,7 @@ impl<'d, T: Instance, P: Phy> Ethernet<'d, T, P> {
             _pins: pins,
             phy,
             mac_addr,
+            link_state: LinkState::Down,
         };
 
         fence(Ordering::SeqCst);


### PR DESCRIPTION
this avoid requerying the smi on every packet tx/rx.