### PR TITLE
stm32/hsem: fix duplicate Instance impl after GTZC NVIC merging

### DIFF
--- a/embassy-stm32/Cargo.toml
+++ b/embassy-stm32/Cargo.toml
@@ -209,11 +209,11 @@ aligned = "0.4.3"
 heapless = "0.9.1"
 
 # stm32-metapac = { version = "21" }
-stm32-metapac = { git = "https://github.com/embassy-rs/stm32-data-generated", tag = "stm32-data-5f15bbfaf37bd6a6330fec66a3a39de0042d64ac" }
+stm32-metapac = { git = "https://github.com/embassy-rs/stm32-data-generated", tag = "stm32-data-10af491da4af2cf36f885e8a244139ddb97296c4" }
 
 [build-dependencies]
 # stm32-metapac = { version = "21", default-features = false, features = ["metadata"]}
-stm32-metapac = { git = "https://github.com/embassy-rs/stm32-data-generated", tag = "stm32-data-5f15bbfaf37bd6a6330fec66a3a39de0042d64ac", default-features = false, features = ["metadata"] }
+stm32-metapac = { git = "https://github.com/embassy-rs/stm32-data-generated", tag = "stm32-data-10af491da4af2cf36f885e8a244139ddb97296c4", default-features = false, features = ["metadata"] }
 
 proc-macro2 = "1.0.36"
 quote = "1.0.15"

--- a/embassy-stm32/src/hsem/mod.rs
+++ b/embassy-stm32/src/hsem/mod.rs
@@ -463,7 +463,7 @@ impl SealedInstance for crate::peripherals::HSEM {
 }
 
 foreach_interrupt!(
-    ($inst:ident, hsem, $block:ident, $signal_name:ident, $irq:ident) => {
+    ($inst:ident, hsem, $block:ident, GLOBAL, $irq:ident) => {
         impl Instance for crate::peripherals::$inst {
             type Interrupt = crate::interrupt::typelevel::$irq;
         }


### PR DESCRIPTION
## Summary
- Fixes CI build failure introduced by stm32-data#775 (GTZC sub-block decomposition with NVIC merging)
- The NVIC merge exposes both `HSEM` (GLOBAL) and `HSEM_S` interrupt entries for WBA chips, causing `foreach_interrupt!` to generate conflicting `impl Instance` blocks (E0119)
- Filters the macro by `GLOBAL` signal, matching the pattern used by other drivers (rng, cryp, hash, tsc, etc.)
- Includes the PAC update from #5900
