### PR TITLE
STM32: ADD10 I2C support

### DIFF
--- a/embassy-stm32/src/i2c/config.rs
+++ b/embassy-stm32/src/i2c/config.rs
@@ -58,7 +58,12 @@ impl Address {
             Address::TenBit(addr) => *addr,
         }
     }
+}
 
+// These methods are only used by the v1 software address sequencing (v2 handles
+// 10-bit addressing in hardware). Gated so v2-only builds don't trigger dead_code.
+#[cfg(any(i2c_v1, test))]
+impl Address {
     /// Wire byte for the write address phase (first byte after START).
     ///
     /// - 7-bit: `addr << 1` (R/W = 0)

--- a/embassy-stm32/src/i2c/config.rs
+++ b/embassy-stm32/src/i2c/config.rs
@@ -58,6 +58,36 @@ impl Address {
             Address::TenBit(addr) => *addr,
         }
     }
+
+    /// Wire byte for the write address phase (first byte after START).
+    ///
+    /// - 7-bit: `addr << 1` (R/W = 0)
+    /// - 10-bit: header byte `11110_XX_0` where XX = addr\[9:8\]
+    pub(super) fn write_header(&self) -> u8 {
+        match self {
+            Address::SevenBit(addr) => addr << 1,
+            Address::TenBit(addr) => 0xF0 | ((*addr >> 7) as u8 & 0x06),
+        }
+    }
+
+    /// Wire byte for the read address phase (first byte after START).
+    ///
+    /// - 7-bit: `(addr << 1) | 1` (R/W = 1)
+    /// - 10-bit: header byte `11110_XX_1` where XX = addr\[9:8\]
+    pub(super) fn read_header(&self) -> u8 {
+        match self {
+            Address::SevenBit(addr) => (addr << 1) | 1,
+            Address::TenBit(addr) => 0xF0 | ((*addr >> 7) as u8 & 0x06) | 1,
+        }
+    }
+
+    /// Whether this is a 7-bit address in the reserved 10-bit header range (0x78–0x7B).
+    ///
+    /// Write bytes for these addresses match the 10-bit header pattern `11110_XX_0`,
+    /// causing the v1 I2C peripheral to set ADD10 instead of ADDR.
+    pub(super) fn is_reserved_range(&self) -> bool {
+        matches!(self, Address::SevenBit(0x78..=0x7B))
+    }
 }
 
 #[derive(Debug, Copy, Clone)]
@@ -173,5 +203,209 @@ impl Config {
                 false => Pull::None,
             },
         );
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // ---- From conversions ----
+
+    #[test]
+    fn from_u8_gives_seven_bit() {
+        let addr: Address = 0x50u8.into();
+        assert_eq!(addr, Address::SevenBit(0x50));
+    }
+
+    #[test]
+    fn from_u16_gives_ten_bit() {
+        let addr: Address = 0x123u16.into();
+        assert_eq!(addr, Address::TenBit(0x123));
+    }
+
+    #[test]
+    #[should_panic(expected = "Ten bit address must be less than 0x400")]
+    fn from_u16_rejects_out_of_range() {
+        let _addr: Address = 0x400u16.into();
+    }
+
+    #[test]
+    fn addr_method_returns_raw_value() {
+        assert_eq!(Address::SevenBit(0x50).addr(), 0x50);
+        assert_eq!(Address::TenBit(0x3FF).addr(), 0x3FF);
+    }
+
+    // ---- write_header ----
+
+    #[test]
+    fn write_header_seven_bit_standard() {
+        // 0x50 << 1 = 0xA0
+        assert_eq!(Address::SevenBit(0x50).write_header(), 0xA0);
+    }
+
+    #[test]
+    fn write_header_seven_bit_zero() {
+        assert_eq!(Address::SevenBit(0x00).write_header(), 0x00);
+    }
+
+    #[test]
+    fn write_header_seven_bit_max() {
+        // 0x7F << 1 = 0xFE
+        assert_eq!(Address::SevenBit(0x7F).write_header(), 0xFE);
+    }
+
+    #[test]
+    fn write_header_seven_bit_reserved_range() {
+        // 0x78 << 1 = 0xF0 (matches 10-bit header pattern)
+        assert_eq!(Address::SevenBit(0x78).write_header(), 0xF0);
+        assert_eq!(Address::SevenBit(0x79).write_header(), 0xF2);
+        assert_eq!(Address::SevenBit(0x7A).write_header(), 0xF4);
+        assert_eq!(Address::SevenBit(0x7B).write_header(), 0xF6);
+    }
+
+    #[test]
+    fn write_header_ten_bit_zero() {
+        // addr=0x000: header = 11110_00_0 = 0xF0
+        assert_eq!(Address::TenBit(0x000).write_header(), 0xF0);
+    }
+
+    #[test]
+    fn write_header_ten_bit_max() {
+        // addr=0x3FF: bits[9:8]=11 → header = 11110_11_0 = 0xF6
+        assert_eq!(Address::TenBit(0x3FF).write_header(), 0xF6);
+    }
+
+    #[test]
+    fn write_header_ten_bit_all_upper_bit_combos() {
+        // XX=00 → 0xF0
+        assert_eq!(Address::TenBit(0x000).write_header(), 0xF0);
+        // XX=01 → 0xF2
+        assert_eq!(Address::TenBit(0x100).write_header(), 0xF2);
+        // XX=10 → 0xF4
+        assert_eq!(Address::TenBit(0x200).write_header(), 0xF4);
+        // XX=11 → 0xF6
+        assert_eq!(Address::TenBit(0x300).write_header(), 0xF6);
+    }
+
+    // ---- read_header ----
+
+    #[test]
+    fn read_header_seven_bit_standard() {
+        // (0x50 << 1) | 1 = 0xA1
+        assert_eq!(Address::SevenBit(0x50).read_header(), 0xA1);
+    }
+
+    #[test]
+    fn read_header_seven_bit_zero() {
+        assert_eq!(Address::SevenBit(0x00).read_header(), 0x01);
+    }
+
+    #[test]
+    fn read_header_seven_bit_max() {
+        // (0x7F << 1) | 1 = 0xFF
+        assert_eq!(Address::SevenBit(0x7F).read_header(), 0xFF);
+    }
+
+    #[test]
+    fn read_header_seven_bit_reserved_range() {
+        // 0x78: (0x78 << 1) | 1 = 0xF1 (R/W=1, does NOT trigger ADD10)
+        assert_eq!(Address::SevenBit(0x78).read_header(), 0xF1);
+        assert_eq!(Address::SevenBit(0x7B).read_header(), 0xF7);
+    }
+
+    #[test]
+    fn read_header_ten_bit_zero() {
+        // addr=0x000: header = 11110_00_1 = 0xF1
+        assert_eq!(Address::TenBit(0x000).read_header(), 0xF1);
+    }
+
+    #[test]
+    fn read_header_ten_bit_max() {
+        // addr=0x3FF: header = 11110_11_1 = 0xF7
+        assert_eq!(Address::TenBit(0x3FF).read_header(), 0xF7);
+    }
+
+    #[test]
+    fn read_header_ten_bit_all_upper_bit_combos() {
+        assert_eq!(Address::TenBit(0x000).read_header(), 0xF1);
+        assert_eq!(Address::TenBit(0x100).read_header(), 0xF3);
+        assert_eq!(Address::TenBit(0x200).read_header(), 0xF5);
+        assert_eq!(Address::TenBit(0x300).read_header(), 0xF7);
+    }
+
+    // ---- read_header is write_header | 1 ----
+
+    #[test]
+    fn read_header_equals_write_header_or_one() {
+        for addr in [0x000u16, 0x055, 0x100, 0x1FF, 0x200, 0x2AB, 0x300, 0x3FF] {
+            let a = Address::TenBit(addr);
+            assert_eq!(
+                a.read_header(),
+                a.write_header() | 1,
+                "mismatch at 10-bit addr {:#05x}",
+                addr
+            );
+        }
+        for addr in [0x00u8, 0x27, 0x50, 0x77, 0x78, 0x7B, 0x7F] {
+            let a = Address::SevenBit(addr);
+            assert_eq!(
+                a.read_header(),
+                a.write_header() | 1,
+                "mismatch at 7-bit addr {:#04x}",
+                addr
+            );
+        }
+    }
+
+    // ---- is_reserved_range ----
+
+    #[test]
+    fn reserved_range_boundaries() {
+        assert!(!Address::SevenBit(0x77).is_reserved_range());
+        assert!(Address::SevenBit(0x78).is_reserved_range());
+        assert!(Address::SevenBit(0x79).is_reserved_range());
+        assert!(Address::SevenBit(0x7A).is_reserved_range());
+        assert!(Address::SevenBit(0x7B).is_reserved_range());
+        assert!(!Address::SevenBit(0x7C).is_reserved_range());
+    }
+
+    #[test]
+    fn reserved_range_common_addresses() {
+        assert!(!Address::SevenBit(0x00).is_reserved_range());
+        assert!(!Address::SevenBit(0x50).is_reserved_range());
+        assert!(!Address::SevenBit(0x68).is_reserved_range());
+    }
+
+    #[test]
+    fn reserved_range_ten_bit_is_never_reserved() {
+        // TenBit addresses are true 10-bit, not "reserved-range 7-bit"
+        assert!(!Address::TenBit(0x078).is_reserved_range());
+        assert!(!Address::TenBit(0x0F0).is_reserved_range());
+        assert!(!Address::TenBit(0x3FF).is_reserved_range());
+    }
+
+    // ---- 10-bit second address byte ----
+
+    #[test]
+    fn ten_bit_second_byte_is_low_byte() {
+        assert_eq!(Address::TenBit(0x3FF).addr() as u8, 0xFF);
+        assert_eq!(Address::TenBit(0x100).addr() as u8, 0x00);
+        assert_eq!(Address::TenBit(0x0AB).addr() as u8, 0xAB);
+    }
+
+    // ---- impl Into<Address> accepts both u8 and Address ----
+
+    fn takes_address(_addr: impl Into<Address>) {}
+
+    #[test]
+    fn into_address_accepts_u8() {
+        takes_address(0x50u8);
+    }
+
+    #[test]
+    fn into_address_accepts_address() {
+        takes_address(Address::SevenBit(0x50));
+        takes_address(Address::TenBit(0x123));
     }
 }

--- a/embassy-stm32/src/i2c/v1.rs
+++ b/embassy-stm32/src/i2c/v1.rs
@@ -155,7 +155,7 @@ impl<'d, M: PeriMode, IM: MasterMode> I2c<'d, M, IM> {
 
     fn write_bytes(
         &mut self,
-        address: u8,
+        address: Address,
         write_buffer: &[u8],
         timeout: Timeout,
         frame: FrameOptions,
@@ -168,6 +168,8 @@ impl<'d, M: PeriMode, IM: MasterMode> I2c<'d, M, IM> {
             }
             return Ok(());
         }
+
+        let mut data_offset = 0usize;
 
         if frame.send_start() {
             // Send a START condition
@@ -186,21 +188,42 @@ impl<'d, M: PeriMode, IM: MasterMode> I2c<'d, M, IM> {
                 return Err(Error::Arbitration);
             }
 
-            // Set up current address we're trying to talk to
-            self.info.regs.dr().write(|reg| reg.set_dr(address << 1));
+            // Send address, handling ADD10 for 10-bit and reserved-range 7-bit addresses.
+            // data_offset tracks bytes consumed from write_buffer during the address phase
+            // (reserved-range 7-bit addresses use the first data byte as the "second address
+            // byte" to satisfy the ADD10 hardware sequence).
+            self.info.regs.dr().write(|reg| reg.set_dr(address.write_header()));
 
-            // Wait until address was sent
-            // Wait for the address to be acknowledged
-            // Check for any I2C errors. If a NACK occurs, the ADDR bit will never be set.
+            data_offset = if matches!(address, Address::TenBit(_)) || address.is_reserved_range() {
+                // Wait for ADD10 (peripheral detected 10-bit header pattern on wire)
+                while !Self::check_and_clear_error_flags(self.info)?.add10() {
+                    timeout.check()?;
+                }
+                match address {
+                    Address::TenBit(addr) => {
+                        self.info.regs.dr().write(|reg| reg.set_dr(addr as u8));
+                        0
+                    }
+                    _ => {
+                        // Reserved-range 7-bit: feed first data byte to complete ADD10 sequence.
+                        // The device already ACK'd the address and expects data next.
+                        let byte = write_buffer.first().copied().unwrap_or(0);
+                        self.info.regs.dr().write(|reg| reg.set_dr(byte));
+                        usize::from(!write_buffer.is_empty())
+                    }
+                }
+            } else {
+                0
+            };
+
+            // Wait for ADDR (set after address ACK for 7-bit, or second byte ACK for 10-bit)
             while !Self::check_and_clear_error_flags(self.info)?.addr() {
                 timeout.check()?;
             }
-
-            // Clear condition by reading SR2
             let _ = self.info.regs.sr2().read();
 
-            // Return early if there are no bytes to transmit.
-            if write_buffer.is_empty() {
+            // Return early if there are no bytes left to transmit.
+            if write_buffer.len() <= data_offset {
                 if frame.send_stop() {
                     self.info.regs.cr1().modify(|w| w.set_stop(true));
                 }
@@ -209,7 +232,7 @@ impl<'d, M: PeriMode, IM: MasterMode> I2c<'d, M, IM> {
         }
 
         // Send bytes
-        for c in write_buffer {
+        for c in &write_buffer[data_offset..] {
             self.send_byte(*c, timeout)?;
         }
 
@@ -269,7 +292,7 @@ impl<'d, M: PeriMode, IM: MasterMode> I2c<'d, M, IM> {
 
     fn blocking_read_timeout(
         &mut self,
-        address: u8,
+        address: Address,
         read_buffer: &mut [u8],
         timeout: Timeout,
         frame: FrameOptions,
@@ -295,17 +318,54 @@ impl<'d, M: PeriMode, IM: MasterMode> I2c<'d, M, IM> {
                 return Err(Error::Arbitration);
             }
 
-            // Set up current address we're trying to talk to
-            self.info.regs.dr().write(|reg| reg.set_dr((address << 1) + 1));
+            match address {
+                Address::TenBit(addr) => {
+                    // 10-bit read: write phase (header + second byte), then repeated START with read header.
+                    self.info.regs.dr().write(|reg| reg.set_dr(address.write_header()));
 
-            // Wait until address was sent
-            // Wait for the address to be acknowledged
-            while !Self::check_and_clear_error_flags(self.info)?.addr() {
-                timeout.check()?;
+                    while !Self::check_and_clear_error_flags(self.info)?.add10() {
+                        timeout.check()?;
+                    }
+
+                    self.info.regs.dr().write(|reg| reg.set_dr(addr as u8));
+
+                    while !Self::check_and_clear_error_flags(self.info)?.addr() {
+                        timeout.check()?;
+                    }
+                    let _ = self.info.regs.sr2().read();
+
+                    // Repeated START for read phase
+                    self.info.regs.cr1().modify(|reg| {
+                        reg.set_start(true);
+                        reg.set_ack(true);
+                    });
+
+                    while !Self::check_and_clear_error_flags(self.info)?.start() {
+                        timeout.check()?;
+                    }
+
+                    if self.info.regs.cr1().read().start() || !self.info.regs.sr2().read().msl() {
+                        return Err(Error::Arbitration);
+                    }
+
+                    // Read header (R/W=1) — ADDR set directly, no ADD10
+                    self.info.regs.dr().write(|reg| reg.set_dr(address.read_header()));
+
+                    while !Self::check_and_clear_error_flags(self.info)?.addr() {
+                        timeout.check()?;
+                    }
+                    let _ = self.info.regs.sr2().read();
+                }
+                _ => {
+                    // 7-bit read: R/W=1 never triggers ADD10, even for reserved-range addresses.
+                    self.info.regs.dr().write(|reg| reg.set_dr(address.read_header()));
+
+                    while !Self::check_and_clear_error_flags(self.info)?.addr() {
+                        timeout.check()?;
+                    }
+                    let _ = self.info.regs.sr2().read();
+                }
             }
-
-            // Clear condition by reading SR2
-            let _ = self.info.regs.sr2().read();
         }
 
         // Receive bytes into buffer
@@ -331,13 +391,23 @@ impl<'d, M: PeriMode, IM: MasterMode> I2c<'d, M, IM> {
     }
 
     /// Blocking read.
-    pub fn blocking_read(&mut self, address: u8, read_buffer: &mut [u8]) -> Result<(), Error> {
-        self.blocking_read_timeout(address, read_buffer, self.timeout(), FrameOptions::FirstAndLastFrame)
+    pub fn blocking_read(&mut self, address: impl Into<Address>, read_buffer: &mut [u8]) -> Result<(), Error> {
+        self.blocking_read_timeout(
+            address.into(),
+            read_buffer,
+            self.timeout(),
+            FrameOptions::FirstAndLastFrame,
+        )
     }
 
     /// Blocking write.
-    pub fn blocking_write(&mut self, address: u8, write_buffer: &[u8]) -> Result<(), Error> {
-        self.write_bytes(address, write_buffer, self.timeout(), FrameOptions::FirstAndLastFrame)?;
+    pub fn blocking_write(&mut self, address: impl Into<Address>, write_buffer: &[u8]) -> Result<(), Error> {
+        self.write_bytes(
+            address.into(),
+            write_buffer,
+            self.timeout(),
+            FrameOptions::FirstAndLastFrame,
+        )?;
 
         // Fallthrough is success
         Ok(())
@@ -346,21 +416,17 @@ impl<'d, M: PeriMode, IM: MasterMode> I2c<'d, M, IM> {
     /// Blocking write, restart, read.
     pub fn blocking_write_read(
         &mut self,
-        address: u8,
+        address: impl Into<Address>,
         write_buffer: &[u8],
         read_buffer: &mut [u8],
     ) -> Result<(), Error> {
-        // Check empty read buffer before starting transaction. Otherwise, we would not generate the
-        // stop condition below.
         if read_buffer.is_empty() {
             return Err(Error::Overrun);
         }
-
         let timeout = self.timeout();
-
+        let address: Address = address.into();
         self.write_bytes(address, write_buffer, timeout, FrameOptions::FirstFrame)?;
         self.blocking_read_timeout(address, read_buffer, timeout, FrameOptions::FirstAndLastFrame)?;
-
         Ok(())
     }
 
@@ -369,8 +435,13 @@ impl<'d, M: PeriMode, IM: MasterMode> I2c<'d, M, IM> {
     /// Consecutive operations of same type are merged. See [transaction contract] for details.
     ///
     /// [transaction contract]: embedded_hal_1::i2c::I2c::transaction
-    pub fn blocking_transaction(&mut self, address: u8, operations: &mut [Operation<'_>]) -> Result<(), Error> {
+    pub fn blocking_transaction(
+        &mut self,
+        address: impl Into<Address>,
+        operations: &mut [Operation<'_>],
+    ) -> Result<(), Error> {
         let timeout = self.timeout();
+        let address: Address = address.into();
 
         for (op, frame) in operation_frames(operations)? {
             match op {
@@ -382,7 +453,7 @@ impl<'d, M: PeriMode, IM: MasterMode> I2c<'d, M, IM> {
         Ok(())
     }
 
-    /// Can be used by both blocking and async implementations  
+    /// Can be used by both blocking and async implementations
     #[inline] // pretty sure this should always be inlined
     fn enable_interrupts(info: &'static Info) {
         // The interrupt handler disables interrupts globally, so we need to re-enable them
@@ -405,7 +476,7 @@ impl<'d, M: PeriMode, IM: MasterMode> I2c<'d, M, IM> {
 }
 
 impl<'d, IM: MasterMode> I2c<'d, Async, IM> {
-    async fn write_frame(&mut self, address: u8, write_buffer: &[u8], frame: FrameOptions) -> Result<(), Error> {
+    async fn write_frame(&mut self, address: Address, write_buffer: &[u8], frame: FrameOptions) -> Result<(), Error> {
         // Return early if there are no bytes to transmit and no START to send.
         // If send_start is true the empty check is handled after the address phase.
         if write_buffer.is_empty() && !frame.send_start() {
@@ -414,6 +485,8 @@ impl<'d, IM: MasterMode> I2c<'d, Async, IM> {
             }
             return Ok(());
         }
+
+        let mut data_offset = 0usize;
 
         self.info.regs.cr2().modify(|w| {
             // Note: Do not enable the ITBUFEN bit in the I2C_CR2 register if DMA is used for
@@ -466,26 +539,60 @@ impl<'d, IM: MasterMode> I2c<'d, Async, IM> {
                 return Err(Error::Arbitration);
             }
 
-            // Set up current address we're trying to talk to
-            self.info.regs.dr().write(|reg| reg.set_dr(address << 1));
+            // Send address, handling ADD10 for 10-bit and reserved-range 7-bit addresses.
+            self.info.regs.dr().write(|reg| reg.set_dr(address.write_header()));
 
-            // Wait for the address to be acknowledged
+            if matches!(address, Address::TenBit(_)) || address.is_reserved_range() {
+                // Wait for ADD10
+                poll_fn(|cx| {
+                    self.state.waker.register(cx.waker());
+
+                    match Self::check_and_clear_error_flags(self.info) {
+                        Err(e) => {
+                            self.info.regs.cr1().modify(|reg| reg.set_stop(true));
+                            Poll::Ready(Err(e))
+                        }
+                        Ok(sr1) => {
+                            if sr1.add10() {
+                                Poll::Ready(Ok(()))
+                            } else {
+                                Self::enable_interrupts(self.info);
+                                Poll::Pending
+                            }
+                        }
+                    }
+                })
+                .await?;
+
+                // Write second byte: addr[7:0] for 10-bit, first data byte for reserved-range 7-bit
+                match address {
+                    Address::TenBit(addr) => {
+                        self.info.regs.dr().write(|reg| reg.set_dr(addr as u8));
+                    }
+                    _ => {
+                        let byte = write_buffer.first().copied().unwrap_or(0);
+                        self.info.regs.dr().write(|reg| reg.set_dr(byte));
+                        if !write_buffer.is_empty() {
+                            data_offset = 1;
+                        }
+                    }
+                }
+            }
+
+            // Wait for ADDR
             poll_fn(|cx| {
                 self.state.waker.register(cx.waker());
 
                 match Self::check_and_clear_error_flags(self.info) {
                     Err(e) => {
-                        // Send STOP condition, otherwise SCL will remain low forever.
                         trace!("I2C master: address not acknowledged, send stop");
                         self.info.regs.cr1().modify(|reg| reg.set_stop(true));
-
                         Poll::Ready(Err(e))
                     }
                     Ok(sr1) => {
                         if sr1.addr() {
                             Poll::Ready(Ok(()))
                         } else {
-                            // When pending, (re-)enable interrupts to wake us up.
                             Self::enable_interrupts(self.info);
                             Poll::Pending
                         }
@@ -497,8 +604,8 @@ impl<'d, IM: MasterMode> I2c<'d, Async, IM> {
             // Clear condition by reading SR2
             self.info.regs.sr2().read();
 
-            // Return early if there are no bytes to transmit.
-            if write_buffer.is_empty() {
+            // Return early if there are no bytes left to transmit.
+            if write_buffer.len() <= data_offset {
                 if frame.send_stop() {
                     self.info.regs.cr1().modify(|w| w.set_stop(true));
                 }
@@ -515,7 +622,7 @@ impl<'d, IM: MasterMode> I2c<'d, Async, IM> {
             self.tx_dma
                 .as_mut()
                 .unwrap()
-                .write(write_buffer, dst, Default::default())
+                .write(&write_buffer[data_offset..], dst, Default::default())
         };
 
         // Wait for bytes to be sent, or an error to occur.
@@ -580,24 +687,24 @@ impl<'d, IM: MasterMode> I2c<'d, Async, IM> {
     }
 
     /// Write.
-    pub async fn write(&mut self, address: u8, write_buffer: &[u8]) -> Result<(), Error> {
+    pub async fn write(&mut self, address: impl Into<Address>, write_buffer: &[u8]) -> Result<(), Error> {
         let _scoped_wake_guard = self.info.rcc.wake_guard();
-        self.write_frame(address, write_buffer, FrameOptions::FirstAndLastFrame)
+        self.write_frame(address.into(), write_buffer, FrameOptions::FirstAndLastFrame)
             .await?;
 
         Ok(())
     }
 
     /// Read.
-    pub async fn read(&mut self, address: u8, read_buffer: &mut [u8]) -> Result<(), Error> {
+    pub async fn read(&mut self, address: impl Into<Address>, read_buffer: &mut [u8]) -> Result<(), Error> {
         let _scoped_wake_guard = self.info.rcc.wake_guard();
-        self.read_frame(address, read_buffer, FrameOptions::FirstAndLastFrame)
+        self.read_frame(address.into(), read_buffer, FrameOptions::FirstAndLastFrame)
             .await?;
 
         Ok(())
     }
 
-    async fn read_frame(&mut self, address: u8, read_buffer: &mut [u8], frame: FrameOptions) -> Result<(), Error> {
+    async fn read_frame(&mut self, address: Address, read_buffer: &mut [u8], frame: FrameOptions) -> Result<(), Error> {
         if read_buffer.is_empty() {
             return Err(Error::Overrun);
         }
@@ -659,26 +766,107 @@ impl<'d, IM: MasterMode> I2c<'d, Async, IM> {
                 return Err(Error::Arbitration);
             }
 
-            // Set up current address we're trying to talk to
-            self.info.regs.dr().write(|reg| reg.set_dr((address << 1) + 1));
+            if let Address::TenBit(addr) = address {
+                // 10-bit read: write phase (header + second byte), then repeated START with read header.
+                self.info.regs.dr().write(|reg| reg.set_dr(address.write_header()));
 
-            // Wait for the address to be acknowledged
+                // Wait for ADD10
+                poll_fn(|cx| {
+                    self.state.waker.register(cx.waker());
+
+                    match Self::check_and_clear_error_flags(self.info) {
+                        Err(e) => {
+                            self.info.regs.cr1().modify(|reg| reg.set_stop(true));
+                            Poll::Ready(Err(e))
+                        }
+                        Ok(sr1) => {
+                            if sr1.add10() {
+                                Poll::Ready(Ok(()))
+                            } else {
+                                Self::enable_interrupts(self.info);
+                                Poll::Pending
+                            }
+                        }
+                    }
+                })
+                .await?;
+
+                // Write second address byte
+                self.info.regs.dr().write(|reg| reg.set_dr(addr as u8));
+
+                // Wait for ADDR
+                poll_fn(|cx| {
+                    self.state.waker.register(cx.waker());
+
+                    match Self::check_and_clear_error_flags(self.info) {
+                        Err(e) => {
+                            self.info.regs.cr1().modify(|reg| reg.set_stop(true));
+                            Poll::Ready(Err(e))
+                        }
+                        Ok(sr1) => {
+                            if sr1.addr() {
+                                Poll::Ready(Ok(()))
+                            } else {
+                                Self::enable_interrupts(self.info);
+                                Poll::Pending
+                            }
+                        }
+                    }
+                })
+                .await?;
+
+                // Clear ADDR
+                self.info.regs.sr2().read();
+
+                // Repeated START for read phase
+                self.info.regs.cr1().modify(|reg| {
+                    reg.set_start(true);
+                    reg.set_ack(true);
+                });
+
+                // Wait for SB
+                poll_fn(|cx| {
+                    self.state.waker.register(cx.waker());
+
+                    match Self::check_and_clear_error_flags(self.info) {
+                        Err(e) => Poll::Ready(Err(e)),
+                        Ok(sr1) => {
+                            if sr1.start() {
+                                Poll::Ready(Ok(()))
+                            } else {
+                                Self::enable_interrupts(self.info);
+                                Poll::Pending
+                            }
+                        }
+                    }
+                })
+                .await?;
+
+                if self.info.regs.cr1().read().start() || !self.info.regs.sr2().read().msl() {
+                    return Err(Error::Arbitration);
+                }
+
+                // Read header (R/W=1) — ADDR set directly, no ADD10
+                self.info.regs.dr().write(|reg| reg.set_dr(address.read_header()));
+            } else {
+                // 7-bit read: R/W=1 never triggers ADD10, even for reserved-range addresses.
+                self.info.regs.dr().write(|reg| reg.set_dr(address.read_header()));
+            }
+
+            // Wait for ADDR
             poll_fn(|cx| {
                 self.state.waker.register(cx.waker());
 
                 match Self::check_and_clear_error_flags(self.info) {
                     Err(e) => {
-                        // Send STOP condition, otherwise SCL will remain low forever.
                         trace!("I2C master: address not acknowledged, send stop");
                         self.info.regs.cr1().modify(|reg| reg.set_stop(true));
-
                         Poll::Ready(Err(e))
                     }
                     Ok(sr1) => {
                         if sr1.addr() {
                             Poll::Ready(Ok(()))
                         } else {
-                            // When pending, (re-)enable interrupts to wake us up.
                             Self::enable_interrupts(self.info);
                             Poll::Pending
                         }
@@ -760,14 +948,17 @@ impl<'d, IM: MasterMode> I2c<'d, Async, IM> {
     }
 
     /// Write, restart, read.
-    pub async fn write_read(&mut self, address: u8, write_buffer: &[u8], read_buffer: &mut [u8]) -> Result<(), Error> {
+    pub async fn write_read(
+        &mut self,
+        address: impl Into<Address>,
+        write_buffer: &[u8],
+        read_buffer: &mut [u8],
+    ) -> Result<(), Error> {
         let _scoped_wake_guard = self.info.rcc.wake_guard();
-        // Check empty read buffer before starting transaction. Otherwise, we would not generate the
-        // stop condition below.
         if read_buffer.is_empty() {
             return Err(Error::Overrun);
         }
-
+        let address: Address = address.into();
         self.write_frame(address, write_buffer, FrameOptions::FirstFrame)
             .await?;
         self.read_frame(address, read_buffer, FrameOptions::FirstAndLastFrame)
@@ -779,8 +970,13 @@ impl<'d, IM: MasterMode> I2c<'d, Async, IM> {
     /// Consecutive operations of same type are merged. See [transaction contract] for details.
     ///
     /// [transaction contract]: embedded_hal_1::i2c::I2c::transaction
-    pub async fn transaction(&mut self, address: u8, operations: &mut [Operation<'_>]) -> Result<(), Error> {
+    pub async fn transaction(
+        &mut self,
+        address: impl Into<Address>,
+        operations: &mut [Operation<'_>],
+    ) -> Result<(), Error> {
         let _scoped_wake_guard = self.info.rcc.wake_guard();
+        let address: Address = address.into();
         for (op, frame) in operation_frames(operations)? {
             match op {
                 Operation::Read(read_buffer) => self.read_frame(address, read_buffer, frame).await?,
@@ -850,7 +1046,7 @@ enum ReceiveResult {
 enum SlaveTermination {
     /// STOP condition received - normal end of transaction
     Stop,
-    /// RESTART condition received - master starting new transaction  
+    /// RESTART condition received - master starting new transaction
     Restart,
     /// NACK received - normal end of read transaction
     Nack,
@@ -943,7 +1139,7 @@ impl<'d, M: PeriMode, IM: MasterMode> I2c<'d, M, IM> {
         self.info.regs.oar1().modify(|reg| reg.0 |= 1 << 14);
     }
 
-    /// Configure the secondary address (OA2) register  
+    /// Configure the secondary address (OA2) register
     fn configure_secondary_address(&mut self, addr: u8) {
         self.info.regs.oar2().write(|reg| {
             reg.set_add2(addr);

--- a/embassy-stm32/src/i2c/v2.rs
+++ b/embassy-stm32/src/i2c/v2.rs
@@ -567,21 +567,27 @@ impl<'d, M: Mode, IM: MasterMode> I2c<'d, M, IM> {
     //  Blocking public API
 
     /// Blocking read.
-    pub fn blocking_read(&mut self, address: u8, read: &mut [u8]) -> Result<(), Error> {
+    pub fn blocking_read(&mut self, address: impl Into<Address>, read: &mut [u8]) -> Result<(), Error> {
         self.read_internal(address.into(), read, false, self.timeout())
         // Automatic Stop
     }
 
     /// Blocking write.
-    pub fn blocking_write(&mut self, address: u8, write: &[u8]) -> Result<(), Error> {
+    pub fn blocking_write(&mut self, address: impl Into<Address>, write: &[u8]) -> Result<(), Error> {
         self.write_internal(address.into(), write, true, self.timeout())
     }
 
     /// Blocking write, restart, read.
-    pub fn blocking_write_read(&mut self, address: u8, write: &[u8], read: &mut [u8]) -> Result<(), Error> {
+    pub fn blocking_write_read(
+        &mut self,
+        address: impl Into<Address>,
+        write: &[u8],
+        read: &mut [u8],
+    ) -> Result<(), Error> {
+        let address = address.into();
         let timeout = self.timeout();
-        self.write_internal(address.into(), write, false, timeout)?;
-        self.read_internal(address.into(), read, true, timeout)
+        self.write_internal(address, write, false, timeout)?;
+        self.read_internal(address, read, true, timeout)
         // Automatic Stop
     }
 
@@ -590,7 +596,11 @@ impl<'d, M: Mode, IM: MasterMode> I2c<'d, M, IM> {
     /// Consecutive operations of same type are merged. See [transaction contract] for details.
     ///
     /// [transaction contract]: embedded_hal_1::i2c::I2c::transaction
-    pub fn blocking_transaction(&mut self, addr: u8, operations: &mut [Operation<'_>]) -> Result<(), Error> {
+    pub fn blocking_transaction(
+        &mut self,
+        addr: impl Into<Address>,
+        operations: &mut [Operation<'_>],
+    ) -> Result<(), Error> {
         if operations.is_empty() {
             return Err(Error::ZeroLengthTransfer);
         }
@@ -1134,14 +1144,15 @@ impl<'d, IM: MasterMode> I2c<'d, Async, IM> {
     //  Async public API
 
     /// Write.
-    pub async fn write(&mut self, address: u8, write: &[u8]) -> Result<(), Error> {
+    pub async fn write(&mut self, address: impl Into<Address>, write: &[u8]) -> Result<(), Error> {
         let _scoped_wake_guard = self.info.rcc.wake_guard();
+        let address = address.into();
         let timeout = self.timeout();
         if write.is_empty() {
-            self.write_internal(address.into(), write, true, timeout)
+            self.write_internal(address, write, true, timeout)
         } else {
             timeout
-                .with(self.write_dma_internal(address.into(), write, true, true, true, false, timeout))
+                .with(self.write_dma_internal(address, write, true, true, true, false, timeout))
                 .await
         }
     }
@@ -1181,34 +1192,41 @@ impl<'d, IM: MasterMode> I2c<'d, Async, IM> {
     }
 
     /// Read.
-    pub async fn read(&mut self, address: u8, buffer: &mut [u8]) -> Result<(), Error> {
+    pub async fn read(&mut self, address: impl Into<Address>, buffer: &mut [u8]) -> Result<(), Error> {
         let _scoped_wake_guard = self.info.rcc.wake_guard();
+        let address = address.into();
         let timeout = self.timeout();
 
         if buffer.is_empty() {
-            self.read_internal(address.into(), buffer, false, timeout)
+            self.read_internal(address, buffer, false, timeout)
         } else {
-            let fut = self.read_dma_internal(address.into(), buffer, false, timeout);
+            let fut = self.read_dma_internal(address, buffer, false, timeout);
             timeout.with(fut).await
         }
     }
 
     /// Write, restart, read.
-    pub async fn write_read(&mut self, address: u8, write: &[u8], read: &mut [u8]) -> Result<(), Error> {
+    pub async fn write_read(
+        &mut self,
+        address: impl Into<Address>,
+        write: &[u8],
+        read: &mut [u8],
+    ) -> Result<(), Error> {
         let _scoped_wake_guard = self.info.rcc.wake_guard();
+        let address = address.into();
         let timeout = self.timeout();
 
         if write.is_empty() {
-            self.write_internal(address.into(), write, false, timeout)?;
+            self.write_internal(address, write, false, timeout)?;
         } else {
-            let fut = self.write_dma_internal(address.into(), write, true, true, false, false, timeout);
+            let fut = self.write_dma_internal(address, write, true, true, false, false, timeout);
             timeout.with(fut).await?;
         }
 
         if read.is_empty() {
-            self.read_internal(address.into(), read, true, timeout)?;
+            self.read_internal(address, read, true, timeout)?;
         } else {
-            let fut = self.read_dma_internal(address.into(), read, true, timeout);
+            let fut = self.read_dma_internal(address, read, true, timeout);
             timeout.with(fut).await?;
         }
 
@@ -1220,7 +1238,11 @@ impl<'d, IM: MasterMode> I2c<'d, Async, IM> {
     /// Consecutive operations of same type are merged. See [transaction contract] for details.
     ///
     /// [transaction contract]: embedded_hal_1::i2c::I2c::transaction
-    pub async fn transaction(&mut self, addr: u8, operations: &mut [Operation<'_>]) -> Result<(), Error> {
+    pub async fn transaction(
+        &mut self,
+        addr: impl Into<Address>,
+        operations: &mut [Operation<'_>],
+    ) -> Result<(), Error> {
         let _scoped_wake_guard = self.info.rcc.wake_guard();
         if operations.is_empty() {
             return Err(Error::ZeroLengthTransfer);

--- a/examples/stm32wle5-lp/src/bin/i2c.rs
+++ b/examples/stm32wle5-lp/src/bin/i2c.rs
@@ -70,7 +70,7 @@ async fn async_main(_spawner: Spawner) {
     loop {
         let mut buffer = [0; 2];
         // read the temperature register of the onboard lm75
-        match i2c.read(0x48, &mut buffer).await {
+        match i2c.read(0x48u8, &mut buffer).await {
             Ok(_) => info!("--> {:?}", buffer),
             Err(e) => info!("--> Error: {:?}", e),
         }


### PR DESCRIPTION
# STM32: I2C v1: ADD10 support for master mode + `impl Into<Address>` public API for v1 and v2

## The problem

I have the unfortunate task of interacting with an I2C device, [The Bartels mp-Highdriver4](https://bartels-mikrotechnik.de/product/pump-driver/), a piezo pump controller. It uses I2C address `0x78`. This address falls in the [I2C specification's](https://www.nxp.com/docs/en/user-guide/UM10204.pdf) reserved range for 10-bit addressing (0x78–0x7B). When shifted and placed on the wire as a write, `0x78` becomes `0xF0` (bit pattern `11110_00_0`), which is exactly the 10-bit address header format defined in 3.1.11 of the I2C spec.

The Highdriver4 is a normal 7-bit device. It ACKs the single address byte and immediately expects data. It does not speak the 10-bit protocol. It simply uses a reserved address.

On my STM32F405 (and all other v1 I2C parts: F1, F2, F4, L1), every `blocking_write` to this device hangs until timeout. Reads work fine. Writes send `0xF0` (R/W=0, matches the 10-bit header pattern), while reads send `0xF1` (R/W=1, which does not match).

The fix requires handling the `ADD10` flag that the peripheral raises when it sees the 10-bit header pattern. Once you're handling `ADD10` for the reserved-range workaround, proper 10-bit address support falls out naturally — the same flag and the same state machine are involved, just with a real second address byte instead of a data byte standing in for one.

## What the peripheral is doing

The STM32 v1 I2C peripheral pattern-matches every byte sent after START. When it sees `11110_XX_0`, it assumes a 10-bit address transaction is in progress and enters the 10-bit state machine described in [RM0090](https://www.st.com/resource/en/reference_manual/dm00031020-stm32f405-415-stm32f407-417-stm32f427-437-and-stm32f429-439-advanced-arm-based-32-bit-mcus-stmicroelectronics.pdf) 27.3.3:

1. It clocks the byte onto the bus and receives ACK from the slave.
2. It sets `SR1.ADD10` (not `SR1.ADDR`) and stretches SCL, waiting for software to write a second address byte to `DR`.
3. Only after the second byte is ACKed does it set `SR1.ADDR`.

The embassy v1 driver never checks `ADD10`. After writing the address byte, it polls `SR1.ADDR` in a tight loop. For addresses 0x78–0x7B on writes, `ADDR` was never set, so the loop runs until timeout.

The v2 I2C peripheral (L4, G0, G4, H5, H7, U5, WB, WL, etc.) does not have this problem. It has a `CR2.ADD10` hardware bit that lets software explicitly select 7-bit or 10-bit mode, and the peripheral handles the multi-byte address sequence automatically. The v2 driver already uses the `Address` type internally.

Neither driver, however, exposes 10-bit addressing: all public methods accept `u8`, which converts to `Address::SevenBit` unconditionally.

## What changed

### `config.rs` - `Address` encoding methods

Three methods added to the existing `Address` enum:

- `write_header() -> u8` the wire byte for a write (7-bit: `addr << 1`, 10-bit: `0xF0 | XX` header).
- `read_header() -> u8` the wire byte for a read (same, with R/W=1).
- `is_reserved_range() -> bool` true for `SevenBit(0x78..=0x7B)`.

These are `pub(super)` and shared by both v1 and v2.

### `v1.rs` blocking and async master-mode paths

All four internal transaction functions (`write_bytes`, `blocking_read_timeout`, `write_frame`, `read_frame`) now accept `Address` and handle three cases:

**Normal 7-bit** (addr < 0x78 or addr > 0x7B) - unchanged: Write header to `DR`, wait for `ADDR`.

**Reserved-range 7-bit** (0x78–0x7B) -  the peripheral will set `ADD10` on writes. The driver now detects this, waits for `ADD10`, and feeds the first data byte as the "second address byte" to satisfy the hardware. The device already ACKed the address and treats this byte as data, so the transfer is correct from the bus perspective. The remaining data bytes are sent normally (or via DMA in the async path). Reads are unaffected since R/W=1 does not trigger ADD10.

**True 10-bit** (`Address::TenBit`) - full RM0090 27.3.3 protocol:
- *Writes*: header byte → ADD10 → second address byte → ADDR → data.
- *Reads*: header byte (W) → ADD10 → second address byte → ADDR → repeated START → header byte (R) → ADDR → receive data.

The async paths use `poll_fn` for each flag wait, matching the existing pattern. ADD10 shares the event interrupt channel with SB, ADDR, and BTF (enabled by `ITEVFEN`), so no additional interrupt configuration is needed.

### `v1.rs` and `v2.rs` - Public API

All public methods on both drivers changed from `address: u8` to `address: impl Into<Address>`. This is backward-compatible: existing code passing `u8` compiles without changes via the existing `From<u8> for Address` impl. But it also accepts `Address::TenBit(0x123)` directly for true 10-bit devices, or `Address::SevenBit(0x78)` explicitly.

The `embedded-hal` and `embedded-hal-async` trait implementations are unaffected - their signatures are fixed at `u8` by the trait, and `u8: Into<Address>`.

## Backward compatibility

- All public method signatures accept `impl Into<Address>`, so any call site passing `u8` continues to work without modification.
- The `From<u8>` conversion produces `SevenBit`, preserving existing behavior for all 7-bit addresses.
- For addresses outside the reserved range, the internal code paths are identical to before.
- For addresses in the reserved range (0x78–0x7B), writes now succeed instead of timing out - a bugfix, not a behavior change for working code.

Refs: #5174 