### PR TITLE
[MCXA] Bump nxp-pac and use PascalCase for all enum variants

### DIFF
--- a/embassy-mcxa/Cargo.toml
+++ b/embassy-mcxa/Cargo.toml
@@ -59,7 +59,7 @@ grounded = { version = "0.2.1", features = ["cas", "critical-section"] }
 heapless = "0.9"
 maitake-sync = { version = "0.3.0", default-features = false, features = ["critical-section", "no-cache-pad"] }
 nb = "1.1.0"
-nxp-pac = { git = "https://github.com/embassy-rs/nxp-pac.git", rev = "10e7c2432894ab6bd4ce9d0168d4184eebc61925", features = ["rt"] }
+nxp-pac = { git = "https://github.com/embassy-rs/nxp-pac.git", rev = "be247ebf87b698532313c685103607036e512291", features = ["rt"] }
 paste = "1.0.15"
 
 rand-core-06 = { package = "rand_core", version = "0.6" }
@@ -67,7 +67,7 @@ rand-core-09 = { package = "rand_core", version = "0.9" }
 rand-core-10 = { package = "rand_core", version = "0.10" }
 
 [build-dependencies]
-nxp-pac = { git = "https://github.com/embassy-rs/nxp-pac.git", rev = "10e7c2432894ab6bd4ce9d0168d4184eebc61925", default-features = false, features = ["metadata"] }
+nxp-pac = { git = "https://github.com/embassy-rs/nxp-pac.git", rev = "be247ebf87b698532313c685103607036e512291", default-features = false, features = ["metadata"] }
 proc-macro2 = "1.0.106"
 quote = "1.0.45"
 regex = "1.12.3"

--- a/embassy-mcxa/Cargo.toml
+++ b/embassy-mcxa/Cargo.toml
@@ -59,7 +59,7 @@ grounded = { version = "0.2.1", features = ["cas", "critical-section"] }
 heapless = "0.9"
 maitake-sync = { version = "0.3.0", default-features = false, features = ["critical-section", "no-cache-pad"] }
 nb = "1.1.0"
-nxp-pac = { git = "https://github.com/embassy-rs/nxp-pac.git", rev = "be247ebf87b698532313c685103607036e512291", features = ["rt"] }
+nxp-pac = { git = "https://github.com/embassy-rs/nxp-pac.git", rev = "e259e278b91e26198b179ff326fe14c467188dcb", features = ["rt"] }
 paste = "1.0.15"
 
 rand-core-06 = { package = "rand_core", version = "0.6" }
@@ -67,7 +67,7 @@ rand-core-09 = { package = "rand_core", version = "0.9" }
 rand-core-10 = { package = "rand_core", version = "0.10" }
 
 [build-dependencies]
-nxp-pac = { git = "https://github.com/embassy-rs/nxp-pac.git", rev = "be247ebf87b698532313c685103607036e512291", default-features = false, features = ["metadata"] }
+nxp-pac = { git = "https://github.com/embassy-rs/nxp-pac.git", rev = "e259e278b91e26198b179ff326fe14c467188dcb", default-features = false, features = ["metadata"] }
 proc-macro2 = "1.0.106"
 quote = "1.0.45"
 regex = "1.12.3"

--- a/embassy-mcxa/build.rs
+++ b/embassy-mcxa/build.rs
@@ -228,7 +228,7 @@ fn generate_clkout_impls() -> TokenStream {
         for signal in clkout.signals {
             for pin in signal.pins {
                 let pin_name = format_ident!("{}", pin.pin);
-                let mux = format_ident!("MUX{}", pin.alt);
+                let mux = format_ident!("Mux{}", pin.alt);
                 let feature_gate = pin_feature_gate(pin.pin);
 
                 generated.extend(quote! {
@@ -252,7 +252,7 @@ fn generate_lpi2c_pin_impls() -> TokenStream {
             let signal_pin = format_ident!("{}Pin", ccase!(pascal, signal.name));
             for pin in signal.pins {
                 let pin_name = format_ident!("{}", pin.pin);
-                let mux = format_ident!("MUX{}", pin.alt);
+                let mux = format_ident!("Mux{}", pin.alt);
                 let feature_gate = pin_feature_gate(pin.pin);
 
                 generated.extend(quote! {
@@ -276,7 +276,7 @@ fn generate_i3c_pin_impls() -> TokenStream {
             let signal_pin = format_ident!("{}Pin", ccase!(pascal, signal.name));
             for pin in signal.pins {
                 let pin_name = format_ident!("{}", pin.pin);
-                let mux = format_ident!("MUX{}", pin.alt);
+                let mux = format_ident!("Mux{}", pin.alt);
                 let feature_gate = pin_feature_gate(pin.pin);
 
                 generated.extend(quote! {
@@ -300,7 +300,7 @@ fn generate_spi_pin_impls() -> TokenStream {
             let signal_pin = format_ident!("{}Pin", ccase!(pascal, signal.name));
             for pin in signal.pins {
                 let pin_name = format_ident!("{}", pin.pin);
-                let mux = format_ident!("MUX{}", pin.alt);
+                let mux = format_ident!("Mux{}", pin.alt);
                 let feature_gate = pin_feature_gate(pin.pin);
 
                 generated.extend(quote! {
@@ -332,13 +332,13 @@ fn generate_ctimer_pin_impls() -> TokenStream {
             if signal.name.starts_with("INP") {
                 for pin in signal.pins {
                     let pin_name = format_ident!("{}", pin.pin);
-                    let mux = format_ident!("MUX{}", pin.alt);
+                    let mux = format_ident!("Mux{}", pin.alt);
                     inp_pins.insert(pin_name, mux);
                 }
             } else if let Some(match_index) = get_regex_num(signal.name, &match_channel_regex) {
                 for pin in signal.pins {
                     let pin_name = format_ident!("{}", pin.pin);
-                    let mux = format_ident!("MUX{}", pin.alt);
+                    let mux = format_ident!("Mux{}", pin.alt);
                     let feature_gate = pin_feature_gate(pin.pin);
 
                     mat_pins.insert(pin_name.clone(), mux);
@@ -383,7 +383,7 @@ fn generate_lpuart_pin_impls() -> TokenStream {
             let signal_name = format_ident!("{}", signal.name);
             for pin in signal.pins {
                 let pin_name = format_ident!("{}", pin.pin);
-                let mux = format_ident!("MUX{}", pin.alt);
+                let mux = format_ident!("Mux{}", pin.alt);
                 let feature_gate = pin_feature_gate(pin.pin);
 
                 generated.extend(quote! {

--- a/embassy-mcxa/src/adc.rs
+++ b/embassy-mcxa/src/adc.rs
@@ -12,7 +12,7 @@ use crate::clocks::{ClockError, Gate, PoweredClock, WakeGuard, enable_and_reset}
 use crate::gpio::{AnyPin, GpioPin, SealedPin};
 use crate::interrupt::typelevel::{Handler, Interrupt};
 use crate::pac::adc::{
-    Avgs, CalAvgs, CalRdy, CalReq, Calofs, Cmpen, Dozen, Gcc0rdy, HptExdi, Loop as HwLoop, Mode as ConvMode, Next,
+    Avgs, CalAvgs, CalRdy, CalReq, Calofs, Cmpen, Dozen, Gcc0Rdy, HptExdi, Loop as HwLoop, Mode as ConvMode, Next,
     Pwrsel, Refsel, Rst, Rstfifo0, Sts, Tcmd, Tpri, Tprictrl,
 };
 use crate::pac::port::Mux;
@@ -100,11 +100,11 @@ impl Default for Config {
     fn default() -> Self {
         Self {
             enable_in_doze_mode: true,
-            calibration_average_mode: CalAvgs::NO_AVERAGE,
+            calibration_average_mode: CalAvgs::NoAverage,
             power_pre_enabled: false,
             power_up_delay: 0x80,
             reference_voltage_source: Default::default(),
-            power_level_mode: Pwrsel::LOWEST,
+            power_level_mode: Pwrsel::Lowest,
             trigger_priority_policy: TriggerPriorityPolicy::ConvPreemptImmediatelyNotAutoResumed,
             conv_pause_delay: None,
             power: PoweredClock::NormalEnabledDeepSleepDisabled,
@@ -168,9 +168,9 @@ pub enum Compare {
 impl Compare {
     fn cmp_en(&self) -> Cmpen {
         match self {
-            Compare::Disabled => Cmpen::DISABLED_ALWAYS_STORE_RESULT,
-            Compare::StoreIf(_) => Cmpen::COMPARE_RESULT_STORE_IF_TRUE,
-            Compare::SkipUntil(_) => Cmpen::COMPARE_RESULT_KEEP_CONVERTING_UNTIL_TRUE_STORE_IF_TRUE,
+            Compare::Disabled => Cmpen::DisabledAlwaysStoreResult,
+            Compare::StoreIf(_) => Cmpen::CompareResultStoreIfTrue,
+            Compare::SkipUntil(_) => Cmpen::CompareResultKeepConvertingUntilTrueStoreIfTrue,
         }
     }
 
@@ -321,10 +321,10 @@ impl Default for CommandConfig {
     fn default() -> Self {
         Self {
             chained_command: None,
-            averaging: Avgs::NO_AVERAGE,
-            sample_time: Sts::SAMPLE_3P5,
+            averaging: Avgs::NoAverage,
+            sample_time: Sts::Sample3p5,
             compare: Compare::Disabled,
-            resolution: ConvMode::DATA_12_BITS,
+            resolution: ConvMode::Data12Bits,
             wait_for_trigger: false,
         }
     }
@@ -350,7 +350,7 @@ impl Default for Trigger {
         Trigger {
             target_command_id: CommandId::Cmd1,
             delay_power: 0,
-            priority: Tpri::HIGHEST_PRIORITY,
+            priority: Tpri::HighestPriority,
             enable_hardware_trigger: false,
             resync: false,
             synchronous: false,
@@ -470,7 +470,7 @@ impl<'a> Adc<'a, Async> {
                 // Enable the interrupts. They get disabled in the interrupt handler
                 self.info.regs().ie().write(|reg| {
                     reg.set_fwmie0(true);
-                    reg.set_tcomp_ie(TcompIe::ALL_TRIGGER_COMPLETES_ENABLED);
+                    reg.set_tcomp_ie(TcompIe::AllTriggerCompletesEnabled);
                 });
 
                 match self.try_get_conversion() {
@@ -494,7 +494,7 @@ impl<'a> Adc<'a, Async> {
                 // Enable the interrupts. They get disabled in the interrupt handler
                 self.info.regs().ie().write(|reg| {
                     reg.set_fwmie0(true);
-                    reg.set_tcomp_ie(TcompIe::ALL_TRIGGER_COMPLETES_ENABLED);
+                    reg.set_tcomp_ie(TcompIe::AllTriggerCompletesEnabled);
                 });
 
                 match self.try_get_conversion() {
@@ -536,7 +536,7 @@ impl<'a, M: Mode> Adc<'a, M> {
         self.info
             .regs()
             .ctrl()
-            .modify(|w| w.set_rstfifo0(Rstfifo0::TRIGGER_RESET));
+            .modify(|w| w.set_rstfifo0(Rstfifo0::TriggerReset));
     }
 
     /// Get conversion result from FIFO.
@@ -547,7 +547,7 @@ impl<'a, M: Mode> Adc<'a, M> {
     /// - [Error::FifoPending] if the FIFO is empty, but the adc is active
     pub fn try_get_conversion(&mut self) -> Result<Conversion, Error> {
         if self.info.regs().fctrl0().read().fcount() == 0 {
-            if self.info.regs().stat().read().adc_active() == AdcActive::BUSY {
+            if self.info.regs().stat().read().adc_active() == AdcActive::Busy {
                 return Err(Error::FifoPending);
             }
             return Err(Error::FifoEmpty);
@@ -597,10 +597,10 @@ impl<'a, M: Mode> Adc<'a, M> {
         let adc = info.regs();
 
         /* Reset the module. */
-        adc.ctrl().modify(|w| w.set_rst(Rst::HELD_IN_RESET));
-        adc.ctrl().modify(|w| w.set_rst(Rst::RELEASED_FROM_RESET));
+        adc.ctrl().modify(|w| w.set_rst(Rst::HeldInReset));
+        adc.ctrl().modify(|w| w.set_rst(Rst::ReleasedFromReset));
 
-        adc.ctrl().modify(|w| w.set_rstfifo0(Rstfifo0::TRIGGER_RESET));
+        adc.ctrl().modify(|w| w.set_rstfifo0(Rstfifo0::TriggerReset));
 
         /* Disable the module before setting configuration. */
         adc.ctrl().modify(|w| w.set_adcen(false));
@@ -608,9 +608,9 @@ impl<'a, M: Mode> Adc<'a, M> {
         /* Configure the module generally. */
         adc.ctrl().modify(|w| {
             w.set_dozen(if config.enable_in_doze_mode {
-                Dozen::ENABLED
+                Dozen::Enabled
             } else {
-                Dozen::DISABLED
+                Dozen::Disabled
             })
         });
 
@@ -626,11 +626,11 @@ impl<'a, M: Mode> Adc<'a, M> {
             w.set_tprictrl(match config.trigger_priority_policy {
                 TriggerPriorityPolicy::ConvPreemptSoftlyNotAutoResumed
                 | TriggerPriorityPolicy::ConvPreemptSoftlyAutoRestarted
-                | TriggerPriorityPolicy::ConvPreemptSoftlyAutoResumed => Tprictrl::FINISH_CURRENT_ON_PRIORITY,
+                | TriggerPriorityPolicy::ConvPreemptSoftlyAutoResumed => Tprictrl::FinishCurrentOnPriority,
                 TriggerPriorityPolicy::ConvPreemptSubsequentlyNotAutoResumed
                 | TriggerPriorityPolicy::ConvPreemptSubsequentlyAutoRestarted
-                | TriggerPriorityPolicy::ConvPreemptSubsequentlyAutoResumed => Tprictrl::FINISH_SEQUENCE_ON_PRIORITY,
-                _ => Tprictrl::ABORT_CURRENT_ON_PRIORITY,
+                | TriggerPriorityPolicy::ConvPreemptSubsequentlyAutoResumed => Tprictrl::FinishSequenceOnPriority,
+                _ => Tprictrl::AbortCurrentOnPriority,
             });
             w.set_tres(matches!(
                 config.trigger_priority_policy,
@@ -649,8 +649,8 @@ impl<'a, M: Mode> Adc<'a, M> {
                     | TriggerPriorityPolicy::TriggerPriorityExceptionDisabled
             ));
             w.set_hpt_exdi(match config.trigger_priority_policy {
-                TriggerPriorityPolicy::TriggerPriorityExceptionDisabled => HptExdi::DISABLED,
-                _ => HptExdi::ENABLED,
+                TriggerPriorityPolicy::TriggerPriorityExceptionDisabled => HptExdi::Disabled,
+                _ => HptExdi::Enabled,
             });
         });
 
@@ -730,10 +730,10 @@ impl<'a, M: Mode> Adc<'a, M> {
         self.info
             .regs()
             .ctrl()
-            .modify(|w| w.set_calofs(Calofs::OFFSET_CALIBRATION_REQUEST_PENDING));
+            .modify(|w| w.set_calofs(Calofs::OffsetCalibrationRequestPending));
 
         // Wait for calibration to complete (polling status register)
-        while self.info.regs().stat().read().cal_rdy() == CalRdy::NOT_SET {}
+        while self.info.regs().stat().read().cal_rdy() == CalRdy::NotSet {}
     }
 
     /// Calculate gain conversion result from gain adjustment factor.
@@ -766,9 +766,9 @@ impl<'a, M: Mode> Adc<'a, M> {
         self.info
             .regs()
             .ctrl()
-            .modify(|w| w.set_cal_req(CalReq::CALIBRATION_REQUEST_PENDING));
+            .modify(|w| w.set_cal_req(CalReq::CalibrationRequestPending));
 
-        while self.info.regs().gcc0().read().rdy() == Gcc0rdy::GAIN_CAL_NOT_VALID {}
+        while self.info.regs().gcc0().read().rdy() == Gcc0Rdy::GainCalNotValid {}
 
         let mut gcca = self.info.regs().gcc0().read().gain_cal() as u32;
         if gcca & 0x8000 != 0 {
@@ -783,7 +783,7 @@ impl<'a, M: Mode> Adc<'a, M> {
         self.info.regs().gcr0().modify(|w| w.set_rdy(true));
 
         // Wait for calibration to complete (polling status register)
-        while self.info.regs().stat().read().cal_rdy() == CalRdy::NOT_SET {}
+        while self.info.regs().stat().read().cal_rdy() == CalRdy::NotSet {}
     }
 }
 
@@ -816,7 +816,7 @@ impl<T: Instance> Handler<T::Interrupt> for InterruptHandler<T> {
         T::info()
             .regs()
             .stat()
-            .write(|reg| reg.set_tcomp_int(TcompInt::COMPLETION_DETECTED));
+            .write(|reg| reg.set_tcomp_int(TcompInt::CompletionDetected));
         T::info().wait_cell().wake();
     }
 }
@@ -920,7 +920,7 @@ impl<T> AnyAdcPin<T> {
             pin.set_pull(crate::gpio::Pull::Disabled);
             pin.set_slew_rate(crate::gpio::SlewRate::Fast.into());
             pin.set_drive_strength(crate::gpio::DriveStrength::Normal.into());
-            pin.set_function(Mux::MUX0);
+            pin.set_function(Mux::Mux0);
         }
     }
 

--- a/embassy-mcxa/src/cdog.rs
+++ b/embassy-mcxa/src/cdog.rs
@@ -45,9 +45,9 @@ pub enum FaultControl {
 impl From<FaultControl> for Ctrl {
     fn from(val: FaultControl) -> Self {
         match val {
-            FaultControl::EnableReset => Ctrl::ENABLE_RESET,
-            FaultControl::EnableInterrupt => Ctrl::ENABLE_INTERRUPT,
-            FaultControl::DisableBoth => Ctrl::DISABLE_BOTH,
+            FaultControl::EnableReset => Ctrl::EnableReset,
+            FaultControl::EnableInterrupt => Ctrl::EnableInterrupt,
+            FaultControl::DisableBoth => Ctrl::DisableBoth,
         }
     }
 }
@@ -131,7 +131,7 @@ impl<'d> Watchdog<'d> {
         // The clearing method depends on whether the module is locked:
         // - Unlocked (LOCK_CTRL = 10b): Write flag values directly
         // - Locked (LOCK_CTRL = 01b): Write '1' to clear individual flags
-        let b = info.control().read().lock_ctrl() == LockCtrl::LOCKED;
+        let b = info.control().read().lock_ctrl() == LockCtrl::Locked;
         // Locked mode: write '1' to clear each flag
         info.flags().write(|w| {
             w.set_to_flag(b);
@@ -153,20 +153,20 @@ impl<'d> Watchdog<'d> {
 
             // IRQ pause control
             match config.irq_pause {
-                PauseControl::RunTimer => w.set_irq_pause(IrqPause::RUN_TIMER),
-                PauseControl::PauseTimer => w.set_irq_pause(IrqPause::PAUSE_TIMER),
+                PauseControl::RunTimer => w.set_irq_pause(IrqPause::RunTimer),
+                PauseControl::PauseTimer => w.set_irq_pause(IrqPause::PauseTimer),
             };
 
             // Debug halt control
             match config.debug_halt {
-                PauseControl::RunTimer => w.set_debug_halt_ctrl(DebugHaltCtrl::RUN_TIMER),
-                PauseControl::PauseTimer => w.set_debug_halt_ctrl(DebugHaltCtrl::PAUSE_TIMER),
+                PauseControl::RunTimer => w.set_debug_halt_ctrl(DebugHaltCtrl::RunTimer),
+                PauseControl::PauseTimer => w.set_debug_halt_ctrl(DebugHaltCtrl::PauseTimer),
             };
 
             // Lock control
             match config.lock {
-                LockControl::Locked => w.set_lock_ctrl(LockCtrl::LOCKED),
-                LockControl::Unlocked => w.set_lock_ctrl(LockCtrl::UNLOCKED),
+                LockControl::Locked => w.set_lock_ctrl(LockCtrl::Locked),
+                LockControl::Unlocked => w.set_lock_ctrl(LockCtrl::Unlocked),
             }
         });
 

--- a/embassy-mcxa/src/clkout.rs
+++ b/embassy-mcxa/src/clkout.rs
@@ -140,13 +140,13 @@ fn check_sel(sel: ClockOutSel, level: PoweredClock, divisor: u32) -> Result<(u32
         #[cfg(feature = "mcxa2xx")]
         let (freq, mux, fmax, expected) = {
             let (freq, mux) = match sel {
-                ClockOutSel::Fro12M => (c.ensure_fro_hf_active(&level)?, Mux::CLKROOT_12M),
-                ClockOutSel::FroHfDiv => (c.ensure_fro_hf_div_active(&level)?, Mux::CLKROOT_FIRC_DIV),
+                ClockOutSel::Fro12M => (c.ensure_fro_hf_active(&level)?, Mux::Clkroot12m),
+                ClockOutSel::FroHfDiv => (c.ensure_fro_hf_div_active(&level)?, Mux::ClkrootFircDiv),
                 #[cfg(not(feature = "sosc-as-gpio"))]
-                ClockOutSel::ClkIn => (c.ensure_clk_in_active(&level)?, Mux::CLKROOT_SOSC),
-                ClockOutSel::Clk16K => (c.ensure_clk_16k_vdd_core_active(&level)?, Mux::CLKROOT_16K),
-                ClockOutSel::Pll1Clk => (c.ensure_pll1_clk_active(&level)?, Mux::CLKROOT_SPLL),
-                ClockOutSel::SlowClk => (c.ensure_slow_clk_active(&level)?, Mux::CLKROOT_SLOW),
+                ClockOutSel::ClkIn => (c.ensure_clk_in_active(&level)?, Mux::ClkrootSosc),
+                ClockOutSel::Clk16K => (c.ensure_clk_16k_vdd_core_active(&level)?, Mux::Clkroot16k),
+                ClockOutSel::Pll1Clk => (c.ensure_pll1_clk_active(&level)?, Mux::ClkrootSpll),
+                ClockOutSel::SlowClk => (c.ensure_slow_clk_active(&level)?, Mux::ClkrootSlow),
             };
             let expected = freq / divisor;
             let fmax = match c.active_power {
@@ -158,14 +158,14 @@ fn check_sel(sel: ClockOutSel, level: PoweredClock, divisor: u32) -> Result<(u32
         #[cfg(feature = "mcxa5xx")]
         let (freq, mux, fmax, expected) = {
             let (freq, mux) = match sel {
-                ClockOutSel::Fro12M => (c.ensure_fro_hf_active(&level)?, Mux::I0_CLKROOT_12M),
-                ClockOutSel::FroHfDiv => (c.ensure_fro_hf_div_active(&level)?, Mux::I1_CLKROOT_FIRC_DIV),
+                ClockOutSel::Fro12M => (c.ensure_fro_hf_active(&level)?, Mux::I0Clkroot12m),
+                ClockOutSel::FroHfDiv => (c.ensure_fro_hf_div_active(&level)?, Mux::I1ClkrootFircDiv),
                 #[cfg(not(feature = "sosc-as-gpio"))]
-                ClockOutSel::ClkIn => (c.ensure_clk_in_active(&level)?, Mux::I2_CLKROOT_SOSC),
+                ClockOutSel::ClkIn => (c.ensure_clk_in_active(&level)?, Mux::I2ClkrootSosc),
                 // TODO: we need this to be an lp_osc clock
-                ClockOutSel::LpOsc => (c.ensure_clk_32k_vdd_core_active(&level)?, Mux::I3_CLKROOT_LPOSC),
-                ClockOutSel::Pll1ClkDiv => (c.ensure_pll1_clk_div_active(&level)?, Mux::I5_CLKROOT_SPLL_DIV),
-                ClockOutSel::SlowClk => (c.ensure_slow_clk_active(&level)?, Mux::I6_CLKROOT_SLOW),
+                ClockOutSel::LpOsc => (c.ensure_clk_32k_vdd_core_active(&level)?, Mux::I3ClkrootLposc),
+                ClockOutSel::Pll1ClkDiv => (c.ensure_pll1_clk_div_active(&level)?, Mux::I5ClkrootSpllDiv),
+                ClockOutSel::SlowClk => (c.ensure_slow_clk_active(&level)?, Mux::I6ClkrootSlow),
             };
             let expected = freq / divisor;
             let fmax = match c.active_power {
@@ -200,17 +200,17 @@ fn setup_clkout(mux: Mux, div: Div4) {
 
     // Set up clkdiv
     mrcc.mrcc_clkout_clkdiv().write(|w| {
-        w.set_halt(ClkdivHalt::OFF);
-        w.set_reset(ClkdivReset::OFF);
+        w.set_halt(ClkdivHalt::Off);
+        w.set_reset(ClkdivReset::Off);
         w.set_div(div.into_bits());
     });
     mrcc.mrcc_clkout_clkdiv().write(|w| {
-        w.set_halt(ClkdivHalt::ON);
-        w.set_reset(ClkdivReset::ON);
+        w.set_halt(ClkdivHalt::On);
+        w.set_reset(ClkdivReset::On);
         w.set_div(div.into_bits());
     });
 
-    while mrcc.mrcc_clkout_clkdiv().read().unstab() == ClkdivUnstab::ON {}
+    while mrcc.mrcc_clkout_clkdiv().read().unstab() == ClkdivUnstab::On {}
 }
 
 /// Stop the
@@ -220,8 +220,8 @@ fn disable_clkout() {
     // TODO: restore the pin to hi-z or something?
     let mrcc = crate::pac::MRCC0;
     mrcc.mrcc_clkout_clkdiv().write(|w| {
-        w.set_reset(ClkdivReset::OFF);
-        w.set_halt(ClkdivHalt::OFF);
+        w.set_reset(ClkdivReset::Off);
+        w.set_halt(ClkdivHalt::Off);
         w.set_div(0);
     });
     mrcc.mrcc_clkout_clksel().write(|w| w.0 = 0b111);

--- a/embassy-mcxa/src/clocks/config.rs
+++ b/embassy-mcxa/src/clocks/config.rs
@@ -499,21 +499,14 @@ pub enum FircFreqSel {
 impl FircFreqSel {
     #[cfg(feature = "mcxa2xx")]
     pub(crate) fn to_freq_and_sel(&self) -> (u32, FreqSel) {
-        // NOTE: the SVD currently has the wrong(?) values for these:
-        // 45 -> 48
-        // 60 -> 64
-        // 90 -> 96
-        // 180 -> 192
-        //
-        // Probably correct-ish, but for a different trim value?
         match self {
             FircFreqSel::Mhz45 => {
                 // We are default, there's nothing to do here.
-                (45_000_000, FreqSel::FIRC_48MHZ_192S)
+                (45_000_000, FreqSel::Firc45_48mhz)
             }
-            FircFreqSel::Mhz60 => (60_000_000, FreqSel::FIRC_64MHZ),
-            FircFreqSel::Mhz90 => (90_000_000, FreqSel::FIRC_96MHZ),
-            FircFreqSel::Mhz180 => (180_000_000, FreqSel::FIRC_192MHZ),
+            FircFreqSel::Mhz60 => (60_000_000, FreqSel::Firc60_64mhz),
+            FircFreqSel::Mhz90 => (90_000_000, FreqSel::Firc90_96mhz),
+            FircFreqSel::Mhz180 => (180_000_000, FreqSel::Firc180_192mhz),
         }
     }
 
@@ -522,11 +515,11 @@ impl FircFreqSel {
         match self {
             FircFreqSel::Mhz48 => {
                 // We are default, there's nothing to do here.
-                (48_000_000, FreqSel::FIRC_48MHZ_192S)
+                (48_000_000, FreqSel::Firc45_48mhz)
             }
-            FircFreqSel::Mhz64 => (64_000_000, FreqSel::FIRC_64MHZ),
-            FircFreqSel::Mhz96 => (96_000_000, FreqSel::FIRC_96MHZ),
-            FircFreqSel::Mhz192 => (192_000_000, FreqSel::FIRC_192MHZ),
+            FircFreqSel::Mhz64 => (64_000_000, FreqSel::Firc60_64mhz),
+            FircFreqSel::Mhz96 => (96_000_000, FreqSel::Firc90_96mhz),
+            FircFreqSel::Mhz192 => (192_000_000, FreqSel::Firc180_192mhz),
         }
     }
 }

--- a/embassy-mcxa/src/clocks/operator.rs
+++ b/embassy-mcxa/src/clocks/operator.rs
@@ -13,7 +13,7 @@ use super::config;
 use super::types::{Clock, ClockError, Clocks, PoweredClock};
 use crate::chips::{ClockLimits, clock_limits};
 use crate::pac;
-use crate::pac::cmc::CkctrlCkmode;
+use crate::pac::cmc::Ckmode;
 use crate::pac::scg::{
     Erefs, Fircacc, FircaccIe, FirccsrLk, Fircerr, FircerrIe, Fircsten, Range, Scs, SirccsrLk, Sircerr, Sircvld,
     SosccsrLk, Soscerr, Source, SpllLock, SpllcsrLk, Spllerr, Spllsten, TrimUnlock,
@@ -58,7 +58,7 @@ impl ClockOperator<'_> {
         // On the MCXA5xx, this is default *locked*, preventing any writes to
         // MRCC registers re enable/div settings. For now, just leave it unlocked,
         // we might want to actively unlock/lock in periph helpers in the future.
-        self.syscon.clkunlock().modify(|w| w.set_unlock(Unlock::ENABLE));
+        self.syscon.clkunlock().modify(|w| w.set_unlock(Unlock::Enable));
     }
 
     fn active_limits(&self) -> &'static ClockLimits {
@@ -106,27 +106,27 @@ impl ClockOperator<'_> {
         // If we are not default, then we need to switch to SIRC
         if !is_default {
             // Set SIRC (fro_12m) as the source
-            self.scg0.rccr().modify(|w| w.set_scs(Scs::SIRC));
+            self.scg0.rccr().modify(|w| w.set_scs(Scs::Sirc));
 
             // Wait for the change to complete
-            while self.scg0.csr().read().scs() != Scs::SIRC {}
+            while self.scg0.csr().read().scs() != Scs::Sirc {}
         }
 
         // Enable CSR writes
-        self.scg0.firccsr().modify(|w| w.set_lk(FirccsrLk::WRITE_ENABLED));
+        self.scg0.firccsr().modify(|w| w.set_lk(FirccsrLk::WriteEnabled));
 
         // Did the user give us a FIRC config?
         let Some(firc) = self.config.firc.as_ref() else {
             // Nope, and we've already switched to fro_12m. Disable FIRC.
             self.scg0.firccsr().modify(|w| {
-                w.set_fircsten(Fircsten::DISABLED_IN_STOP_MODES);
-                w.set_fircerr_ie(FircerrIe::ERROR_NOT_DETECTED);
+                w.set_fircsten(Fircsten::DisabledInStopModes);
+                w.set_fircerr_ie(FircerrIe::ErrorNotDetected);
                 w.set_firc_fclk_periph_en(false);
                 w.set_firc_sclk_periph_en(false);
                 w.set_fircen(false);
             });
 
-            self.scg0.firccsr().modify(|w| w.set_lk(FirccsrLk::WRITE_DISABLED));
+            self.scg0.firccsr().modify(|w| w.set_lk(FirccsrLk::WriteDisabled));
             return Ok(());
         };
 
@@ -134,14 +134,14 @@ impl ClockOperator<'_> {
         // we mess with it. If we are !default, we have already switched to SIRC instead!
         if !is_default {
             // Unlock
-            self.scg0.firccsr().modify(|w| w.set_lk(FirccsrLk::WRITE_ENABLED));
+            self.scg0.firccsr().modify(|w| w.set_lk(FirccsrLk::WriteEnabled));
 
             // Disable FIRC
             self.scg0.firccsr().modify(|w| {
                 w.set_fircen(false);
-                w.set_fircsten(Fircsten::DISABLED_IN_STOP_MODES);
-                w.set_fircerr_ie(FircerrIe::ERROR_NOT_DETECTED);
-                w.set_fircacc_ie(FircaccIe::FIRCACCNOT);
+                w.set_fircsten(Fircsten::DisabledInStopModes);
+                w.set_fircerr_ie(FircerrIe::ErrorNotDetected);
+                w.set_fircacc_ie(FircaccIe::Fircaccnot);
                 w.set_firc_sclk_periph_en(false);
                 w.set_firc_fclk_periph_en(false);
             });
@@ -160,9 +160,8 @@ impl ClockOperator<'_> {
         while !firc_ok {
             let csr = self.scg0.firccsr().read();
 
-            firc_ok = csr.fircen()
-                && csr.fircacc() == Fircacc::ENABLED_AND_VALID
-                && csr.fircerr() == Fircerr::ERROR_NOT_DETECTED;
+            firc_ok =
+                csr.fircen() && csr.fircacc() == Fircacc::EnabledAndValid && csr.fircerr() == Fircerr::ErrorNotDetected;
         }
 
         // Note that the fro_hf_root is active
@@ -183,13 +182,13 @@ impl ClockOperator<'_> {
         // When is the FRO enabled?
         let (bg_good, pow_set) = match power {
             PoweredClock::NormalEnabledDeepSleepDisabled => {
-                // We only need bandgap enabled in active mode
-                (self.clocks.bandgap_active, Fircsten::DISABLED_IN_STOP_MODES)
+                // We only need bandgap enabled in active Mode
+                (self.clocks.bandgap_active, Fircsten::DisabledInStopModes)
             }
             PoweredClock::AlwaysEnabled => {
                 // We need bandgaps enabled in both active and deep sleep mode
                 let bg_good = self.clocks.bandgap_active && self.clocks.bandgap_lowpower;
-                (bg_good, Fircsten::ENABLED_IN_STOP_MODES)
+                (bg_good, Fircsten::EnabledInStopModes)
             }
         };
         if !bg_good {
@@ -235,7 +234,7 @@ impl ClockOperator<'_> {
         });
 
         // Last write to CSR, re-lock
-        self.scg0.firccsr().modify(|w| w.set_lk(FirccsrLk::WRITE_DISABLED));
+        self.scg0.firccsr().modify(|w| w.set_lk(FirccsrLk::WriteDisabled));
 
         // Do we enable the `fro_hf_div` output?
         if let Some(d) = fro_hf_div.as_ref() {
@@ -257,19 +256,19 @@ impl ClockOperator<'_> {
 
             // Halt and reset the div; then set our desired div.
             self.syscon.frohfdiv().write(|w| {
-                w.set_halt(FrohfdivHalt::HALT);
-                w.set_reset(FrohfdivReset::ASSERTED);
+                w.set_halt(FrohfdivHalt::Halt);
+                w.set_reset(FrohfdivReset::Asserted);
                 w.set_div(d.into_bits());
             });
             // Then unhalt it, and reset it
             self.syscon.frohfdiv().write(|w| {
-                w.set_halt(FrohfdivHalt::RUN);
-                w.set_reset(FrohfdivReset::RELEASED);
+                w.set_halt(FrohfdivHalt::Run);
+                w.set_reset(FrohfdivReset::Released);
                 w.set_div(d.into_bits());
             });
 
             // Wait for clock to stabilize
-            while self.syscon.frohfdiv().read().unstab() == FrohfdivUnstab::ONGOING {}
+            while self.syscon.frohfdiv().read().unstab() == FrohfdivUnstab::Ongoing {}
 
             // Store off the clock info
             self.clocks.fro_hf_div = Some(Clock {
@@ -291,7 +290,7 @@ impl ClockOperator<'_> {
         let base_freq = 12_000_000;
 
         // Allow writes
-        self.scg0.sirccsr().modify(|w| w.set_lk(SirccsrLk::WRITE_ENABLED));
+        self.scg0.sirccsr().modify(|w| w.set_lk(SirccsrLk::WriteEnabled));
         self.clocks.fro_12m_root = Some(Clock {
             frequency: base_freq,
             power: *power,
@@ -328,8 +327,8 @@ impl ClockOperator<'_> {
             w.set_sirc_clk_periph_en(true);
         });
 
-        while self.scg0.sirccsr().read().sircvld() == Sircvld::DISABLED_OR_NOT_VALID {}
-        if self.scg0.sirccsr().read().sircerr() == Sircerr::ERROR_DETECTED {
+        while self.scg0.sirccsr().read().sircvld() == Sircvld::DisabledOrNotValid {}
+        if self.scg0.sirccsr().read().sircerr() == Sircerr::ErrorDetected {
             return Err(ClockError::BadConfig {
                 clock: "sirc",
                 reason: "error set",
@@ -337,7 +336,7 @@ impl ClockOperator<'_> {
         }
 
         // reset lock
-        self.scg0.sirccsr().modify(|w| w.set_lk(SirccsrLk::WRITE_DISABLED));
+        self.scg0.sirccsr().modify(|w| w.set_lk(SirccsrLk::WriteDisabled));
 
         // Do we enable the `fro_lf_div` output?
         if let Some(d) = fro_lf_div.as_ref() {
@@ -351,19 +350,19 @@ impl ClockOperator<'_> {
 
             // Halt and reset the div; then set our desired div.
             self.syscon.frolfdiv().write(|w| {
-                w.set_halt(FrolfdivHalt::HALT);
-                w.set_reset(FrolfdivReset::ASSERTED);
+                w.set_halt(FrolfdivHalt::Halt);
+                w.set_reset(FrolfdivReset::Asserted);
                 w.set_div(d.into_bits());
             });
             // Then unhalt it, and reset it
             self.syscon.frolfdiv().modify(|w| {
-                w.set_halt(FrolfdivHalt::RUN);
-                w.set_reset(FrolfdivReset::RELEASED);
+                w.set_halt(FrolfdivHalt::Run);
+                w.set_reset(FrolfdivReset::Released);
                 w.set_div(d.into_bits());
             });
 
             // Wait for clock to stabilize
-            while self.syscon.frolfdiv().read().unstab() == FrolfdivUnstab::ONGOING {}
+            while self.syscon.frolfdiv().read().unstab() == FrolfdivUnstab::Ongoing {}
 
             // Store off the clock info
             self.clocks.fro_lf_div = Some(Clock {
@@ -379,13 +378,13 @@ impl ClockOperator<'_> {
         // If we forced SIRC's fro_12m to be enabled, disable it now.
         if self.sirc_forced {
             // Allow writes
-            self.scg0.sirccsr().modify(|w| w.set_lk(SirccsrLk::WRITE_ENABLED));
+            self.scg0.sirccsr().modify(|w| w.set_lk(SirccsrLk::WriteEnabled));
 
             // Disable clk_12m
             self.scg0.sirccsr().modify(|w| w.set_sirc_clk_periph_en(false));
 
             // reset lock
-            self.scg0.sirccsr().modify(|w| w.set_lk(SirccsrLk::WRITE_DISABLED));
+            self.scg0.sirccsr().modify(|w| w.set_lk(SirccsrLk::WriteDisabled));
         }
     }
 
@@ -715,8 +714,8 @@ impl ClockOperator<'_> {
         self.ensure_ldo_active("sosc", &parts.power)?;
 
         let eref = match parts.mode {
-            config::SoscMode::CrystalOscillator => Erefs::INTERNAL,
-            config::SoscMode::ActiveClock => Erefs::EXTERNAL,
+            config::SoscMode::CrystalOscillator => Erefs::Internal,
+            config::SoscMode::ActiveClock => Erefs::External,
         };
         let freq = parts.frequency;
 
@@ -737,10 +736,10 @@ impl ClockOperator<'_> {
                     reason: "freq too low",
                 });
             }
-            8_000_000..16_000_000 => Range::FREQ_16TO20MHZ,
-            16_000_000..25_000_000 => Range::LOW_FREQ,
-            25_000_000..40_000_000 => Range::MEDIUM_FREQ,
-            40_000_000..50_000_001 => Range::HIGH_FREQ,
+            8_000_000..16_000_000 => Range::Freq16to20mhz,
+            16_000_000..25_000_000 => Range::LowFreq,
+            25_000_000..40_000_000 => Range::MediumFreq,
+            40_000_000..50_000_001 => Range::HighFreq,
             50_000_001.. => {
                 return Err(ClockError::BadConfig {
                     clock: "clk_in",
@@ -756,7 +755,7 @@ impl ClockOperator<'_> {
         });
 
         // Disable lock
-        self.scg0.sosccsr().modify(|w| w.set_lk(SosccsrLk::WRITE_ENABLED));
+        self.scg0.sosccsr().modify(|w| w.set_lk(SosccsrLk::WriteEnabled));
 
         // TODO: We could enable the SOSC clock monitor. There are some things to
         // figure out first:
@@ -791,7 +790,7 @@ impl ClockOperator<'_> {
 
         // Wait for SOSC to be valid, check for errors
         while !self.scg0.sosccsr().read().soscvld() {}
-        if self.scg0.sosccsr().read().soscerr() == Soscerr::ENABLED_AND_ERROR {
+        if self.scg0.sosccsr().read().soscerr() == Soscerr::EnabledAndError {
             return Err(ClockError::BadConfig {
                 clock: "clk_in",
                 reason: "soscerr is set",
@@ -799,7 +798,7 @@ impl ClockOperator<'_> {
         }
 
         // Re-lock the sosc
-        self.scg0.sosccsr().modify(|w| w.set_lk(SosccsrLk::WRITE_DISABLED));
+        self.scg0.sosccsr().modify(|w| w.set_lk(SosccsrLk::WriteDisabled));
 
         self.clocks.clk_in = Some(Clock {
             frequency: freq,
@@ -840,19 +839,19 @@ impl ClockOperator<'_> {
                 .clocks
                 .clk_in
                 .as_ref()
-                .map(|c| (c, Source::SOSC))
+                .map(|c| (c, Source::Sosc))
                 .ok_or("sosc not active"),
             config::SpllSource::Firc => self
                 .clocks
                 .clk_hf_fundamental
                 .as_ref()
-                .map(|c| (c, Source::FIRC))
+                .map(|c| (c, Source::Firc))
                 .ok_or("firc not active"),
             config::SpllSource::Sirc => self
                 .clocks
                 .fro_12m
                 .as_ref()
-                .map(|c| (c, Source::SIRC))
+                .map(|c| (c, Source::Sirc))
                 .ok_or("sirc not active"),
         };
         // This checks if active
@@ -1085,14 +1084,14 @@ impl ClockOperator<'_> {
         });
 
         // Unlock
-        self.scg0.spllcsr().modify(|w| w.set_lk(SpllcsrLk::WRITE_ENABLED));
+        self.scg0.spllcsr().modify(|w| w.set_lk(SpllcsrLk::WriteEnabled));
 
         // TODO: Support clock monitors?
         // self.scg0.spllcsr().modify(|w| w.spllcm().?);
 
         self.scg0.trim_lock().write(|w| {
             w.set_trim_lock_key(0x5a5a);
-            w.set_trim_unlock(TrimUnlock::NOT_LOCKED)
+            w.set_trim_unlock(TrimUnlock::NotLocked)
         });
 
         // SPLLLOCK_CNFG: The lock time programmed in this register must be
@@ -1108,10 +1107,10 @@ impl ClockOperator<'_> {
         // TODO: Support Spread spectrum?
 
         let (bg_good, spllsten) = match cfg.power {
-            PoweredClock::NormalEnabledDeepSleepDisabled => (self.clocks.bandgap_active, Spllsten::DISABLED_IN_STOP),
+            PoweredClock::NormalEnabledDeepSleepDisabled => (self.clocks.bandgap_active, Spllsten::DisabledInStop),
             PoweredClock::AlwaysEnabled => (
                 self.clocks.bandgap_active && self.clocks.bandgap_lowpower,
-                Spllsten::ENABLED_IN_STOP,
+                Spllsten::EnabledInStop,
             ),
         };
         if !bg_good {
@@ -1130,8 +1129,8 @@ impl ClockOperator<'_> {
         // Wait for SPLL to set up
         loop {
             let csr = self.scg0.spllcsr().read();
-            if csr.spll_lock() == SpllLock::ENABLED_AND_VALID {
-                if csr.spllerr() == Spllerr::ENABLED_AND_ERROR {
+            if csr.spll_lock() == SpllLock::EnabledAndValid {
+                if csr.spllerr() == Spllerr::EnabledAndError {
                     return Err(ClockError::BadConfig {
                         clock: "spll",
                         reason: "spllerr is set",
@@ -1142,7 +1141,7 @@ impl ClockOperator<'_> {
         }
 
         // Re-lock SPLL CSR
-        self.scg0.spllcsr().modify(|w| w.set_lk(SpllcsrLk::WRITE_DISABLED));
+        self.scg0.spllcsr().modify(|w| w.set_lk(SpllcsrLk::WriteDisabled));
 
         // Store clock state
         self.clocks.pll1_clk = Some(Clock {
@@ -1162,18 +1161,18 @@ impl ClockOperator<'_> {
 
             // Halt and reset the div; then set our desired div.
             self.syscon.pll1clkdiv().write(|w| {
-                w.set_halt(Pll1clkdivHalt::HALT);
-                w.set_reset(Pll1clkdivReset::ASSERTED);
+                w.set_halt(Pll1clkdivHalt::Halt);
+                w.set_reset(Pll1clkdivReset::Asserted);
                 w.set_div(d.into_bits());
             });
             // Then unhalt it, and reset it
             self.syscon.pll1clkdiv().write(|w| {
-                w.set_halt(Pll1clkdivHalt::RUN);
-                w.set_reset(Pll1clkdivReset::RELEASED);
+                w.set_halt(Pll1clkdivHalt::Run);
+                w.set_reset(Pll1clkdivReset::Released);
             });
 
             // Wait for clock to stabilize
-            while self.syscon.pll1clkdiv().read().unstab() == Pll1clkdivUnstab::ONGOING {}
+            while self.syscon.pll1clkdiv().read().unstab() == Pll1clkdivUnstab::Ongoing {}
 
             // Store off the clock info
             self.clocks.pll1_clk_div = Some(Clock {
@@ -1188,14 +1187,14 @@ impl ClockOperator<'_> {
     pub(super) fn configure_main_clk(&mut self) -> Result<(), ClockError> {
         let (var, name, clk) = match self.config.main_clock.source {
             #[cfg(not(feature = "sosc-as-gpio"))]
-            MainClockSource::SoscClkIn => (Scs::SOSC, "clk_in", self.clocks.clk_in.as_ref()),
-            MainClockSource::SircFro12M => (Scs::SIRC, "fro_12m", self.clocks.fro_12m.as_ref()),
-            MainClockSource::FircHfRoot => (Scs::FIRC, "fro_hf_root", self.clocks.fro_hf_root.as_ref()),
+            MainClockSource::SoscClkIn => (Scs::Sosc, "clk_in", self.clocks.clk_in.as_ref()),
+            MainClockSource::SircFro12M => (Scs::Sirc, "fro_12m", self.clocks.fro_12m.as_ref()),
+            MainClockSource::FircHfRoot => (Scs::Firc, "fro_hf_root", self.clocks.fro_hf_root.as_ref()),
             #[cfg(feature = "mcxa2xx")]
-            MainClockSource::RoscFro16K => (Scs::ROSC, "fro16k", self.clocks.clk_16k_vdd_core.as_ref()),
+            MainClockSource::RoscFro16K => (Scs::Rosc, "fro16k", self.clocks.clk_16k_vdd_core.as_ref()),
             #[cfg(all(feature = "mcxa5xx", not(feature = "rosc-32k-as-gpio")))]
-            MainClockSource::RoscOsc32K => (Scs::ROSC, "osc32k", self.clocks.clk_32k_vdd_core.as_ref()),
-            MainClockSource::SPll1 => (Scs::SPLL, "pll1_clk", self.clocks.pll1_clk.as_ref()),
+            MainClockSource::RoscOsc32K => (Scs::Rosc, "osc32k", self.clocks.clk_32k_vdd_core.as_ref()),
+            MainClockSource::SPll1 => (Scs::Spll, "pll1_clk", self.clocks.pll1_clk.as_ref()),
         };
         let Some(main_clk_src) = clk else {
             return Err(ClockError::BadConfig {
@@ -1283,7 +1282,7 @@ impl ClockOperator<'_> {
             // AHB has no halt/reset fields - it's different to other DIV8s!
             self.syscon.ahbclkdiv().modify(|w| w.set_div(ahb_div.into_bits()));
             // Wait for clock to stabilize
-            while self.syscon.ahbclkdiv().read().unstab() == AhbclkdivUnstab::ONGOING {}
+            while self.syscon.ahbclkdiv().read().unstab() == AhbclkdivUnstab::Ongoing {}
         }
 
         // Store off the clock info
@@ -1306,11 +1305,8 @@ impl ClockOperator<'_> {
                 None
             }
             #[cfg(feature = "mcxa5xx")]
-            VddLevel::NormalMode => {
-                // TODO: fix PAC fields, this is SRAM1V1
-                Some((ActiveCfgCoreldoVddLvl::NORMAL, Vsm::_RESERVED_2))
-            }
-            VddLevel::OverDriveMode => Some((ActiveCfgCoreldoVddLvl::OVER, Vsm::SRAM1V2)),
+            VddLevel::NormalMode => Some((ActiveCfgCoreldoVddLvl::Normal, Vsm::Sram1v1)),
+            VddLevel::OverDriveMode => Some((ActiveCfgCoreldoVddLvl::Over, Vsm::Sram1v2)),
         };
 
         if let Some((vdd, vsm)) = to_change {
@@ -1324,7 +1320,7 @@ impl ClockOperator<'_> {
             // Ensure drive strength is normal (BEFORE shifting level)
             self.spc0
                 .active_cfg()
-                .modify(|w| w.set_coreldo_vdd_ds(ActiveCfgCoreldoVddDs::NORMAL));
+                .modify(|w| w.set_coreldo_vdd_ds(ActiveCfgCoreldoVddDs::Normal));
 
             // ## DS 26.3.2:
             //
@@ -1438,29 +1434,29 @@ impl ClockOperator<'_> {
                     w.set_core_lvde(enable_bandgap);
                 });
 
-                (pac::spc::LpCfgCoreldoVddDs::LOW, enable_bandgap)
+                (pac::spc::LpCfgCoreldoVddDs::Low, enable_bandgap)
             }
             VddDriveStrength::Normal => {
                 // "If you specify normal drive strength, you must write a value to LP[BGMODE] that enables the bandgap."
-                (pac::spc::LpCfgCoreldoVddDs::NORMAL, true)
+                (pac::spc::LpCfgCoreldoVddDs::Normal, true)
             }
         };
         let lvl = match self.config.vdd_power.low_power_mode.level {
-            VddLevel::MidDriveMode => LpCfgCoreldoVddLvl::MID,
+            VddLevel::MidDriveMode => LpCfgCoreldoVddLvl::Mid,
             #[cfg(feature = "mcxa5xx")]
-            VddLevel::NormalMode => LpCfgCoreldoVddLvl::NORMAL,
-            VddLevel::OverDriveMode => LpCfgCoreldoVddLvl::OVER,
+            VddLevel::NormalMode => LpCfgCoreldoVddLvl::Normal,
+            VddLevel::OverDriveMode => LpCfgCoreldoVddLvl::Over,
         };
         self.spc0.lp_cfg().modify(|w| w.set_coreldo_vdd_ds(ds));
 
         // If we're enabling the bandgap, ensure we do it BEFORE changing the VDD level
         // If we're disabling the bandgap, ensure we do it AFTER changing the VDD level
         if bgap {
-            self.spc0.lp_cfg().modify(|w| w.set_bgmode(LpCfgBgmode::BGMODE01));
+            self.spc0.lp_cfg().modify(|w| w.set_bgmode(LpCfgBgmode::Bgmode01));
             self.spc0.lp_cfg().modify(|w| w.set_coreldo_vdd_lvl(lvl));
         } else {
             self.spc0.lp_cfg().modify(|w| w.set_coreldo_vdd_lvl(lvl));
-            self.spc0.lp_cfg().modify(|w| w.set_bgmode(LpCfgBgmode::BGMODE0));
+            self.spc0.lp_cfg().modify(|w| w.set_bgmode(LpCfgBgmode::Bgmode0));
         }
         self.clocks.bandgap_lowpower = bgap;
 
@@ -1488,12 +1484,12 @@ impl ClockOperator<'_> {
                 // optionally disable bandgap AFTER setting vdd strength to low
                 self.spc0
                     .active_cfg()
-                    .modify(|w| w.set_coreldo_vdd_ds(ActiveCfgCoreldoVddDs::LOW));
+                    .modify(|w| w.set_coreldo_vdd_ds(ActiveCfgCoreldoVddDs::Low));
                 self.spc0.active_cfg().modify(|w| {
                     if enable_bandgap {
-                        w.set_bgmode(ActiveCfgBgmode::BGMODE01)
+                        w.set_bgmode(ActiveCfgBgmode::Bgmode01)
                     } else {
-                        w.set_bgmode(ActiveCfgBgmode::BGMODE0)
+                        w.set_bgmode(ActiveCfgBgmode::Bgmode0)
                     }
                 });
 
@@ -1514,7 +1510,7 @@ impl ClockOperator<'_> {
         match self.config.vdd_power.core_sleep {
             CoreSleep::WfeUngated => {
                 // Do not gate
-                self.cmc.ckctrl().modify(|w| w.set_ckmode(CkctrlCkmode::CKMODE0000));
+                self.cmc.ckctrl().modify(|w| w.set_ckmode(Ckmode::Ckmode0000));
 
                 // Debug is enabled when core sleeps
                 self.cmc.dbgctl().modify(|w| w.set_sod(false));
@@ -1524,7 +1520,7 @@ impl ClockOperator<'_> {
             }
             CoreSleep::WfeGated => {
                 // Allow automatic gating of the core when in LIGHT sleep
-                self.cmc.ckctrl().modify(|w| w.set_ckmode(CkctrlCkmode::CKMODE0001));
+                self.cmc.ckctrl().modify(|w| w.set_ckmode(Ckmode::Ckmode0001));
 
                 // Debug is disabled when core sleeps
                 self.cmc.dbgctl().modify(|w| w.set_sod(true));
@@ -1540,7 +1536,7 @@ impl ClockOperator<'_> {
 
                 // For now, just enable light sleep. The executor will set deep sleep when
                 // appropriate
-                self.cmc.ckctrl().modify(|w| w.set_ckmode(CkctrlCkmode::CKMODE0001));
+                self.cmc.ckctrl().modify(|w| w.set_ckmode(Ckmode::Ckmode0001));
 
                 // Debug is disabled when core sleeps
                 self.cmc.dbgctl().modify(|w| w.set_sod(true));

--- a/embassy-mcxa/src/clocks/periph_helpers.rs
+++ b/embassy-mcxa/src/clocks/periph_helpers.rs
@@ -95,15 +95,15 @@ macro_rules! apply_div4 {
         // Set up clkdiv
         $divreg.modify(|w| {
             w.set_div($conf.div.into_bits());
-            w.set_halt(ClkdivHalt::OFF);
-            w.set_reset(ClkdivReset::OFF);
+            w.set_halt(ClkdivHalt::Off);
+            w.set_reset(ClkdivReset::Off);
         });
         $divreg.modify(|w| {
-            w.set_halt(ClkdivHalt::ON);
-            w.set_reset(ClkdivReset::ON);
+            w.set_halt(ClkdivHalt::On);
+            w.set_reset(ClkdivReset::On);
         });
 
-        while $divreg.read().unstab() == ClkdivUnstab::OFF {}
+        while $divreg.read().unstab() == ClkdivUnstab::Off {}
 
         Ok(PreEnableParts {
             freq: $freq / $conf.div.into_divisor(),
@@ -248,35 +248,30 @@ impl SPConfHelper for AdcConfig {
         let (freq, variant) = match self.source {
             AdcClockSel::FroLfDiv => {
                 let freq = clocks.ensure_fro_lf_div_active(&self.power)?;
-
                 // TODO: fix PAC names for consistency
                 #[cfg(feature = "mcxa2xx")]
-                let mux = AdcClkselMux::CLKROOT_FUNC_0;
+                let mux = AdcClkselMux::ClkrootFunc0;
                 #[cfg(feature = "mcxa5xx")]
-                let mux = AdcClkselMux::I0_CLKROOT_SIRC_DIV;
+                let mux = AdcClkselMux::I0ClkrootSircDiv;
 
                 (freq, mux)
             }
             AdcClockSel::FroHf => {
                 let freq = clocks.ensure_fro_hf_active(&self.power)?;
-
-                // TODO: fix PAC names for consistency
                 #[cfg(feature = "mcxa2xx")]
-                let mux = AdcClkselMux::CLKROOT_FUNC_1;
+                let mux = AdcClkselMux::ClkrootFunc1;
                 #[cfg(feature = "mcxa5xx")]
-                let mux = AdcClkselMux::I1_CLKROOT_FIRC_GATED;
+                let mux = AdcClkselMux::I1ClkrootFircGated;
 
                 (freq, mux)
             }
             #[cfg(not(feature = "sosc-as-gpio"))]
             AdcClockSel::ClkIn => {
                 let freq = clocks.ensure_clk_in_active(&self.power)?;
-
-                // TODO: fix PAC names for consistency
                 #[cfg(feature = "mcxa2xx")]
-                let mux = AdcClkselMux::CLKROOT_FUNC_3;
+                let mux = AdcClkselMux::ClkrootFunc3;
                 #[cfg(feature = "mcxa5xx")]
-                let mux = AdcClkselMux::I3_CLKROOT_SOSC;
+                let mux = AdcClkselMux::I3ClkrootSosc;
 
                 (freq, mux)
             }
@@ -288,23 +283,19 @@ impl SPConfHelper for AdcConfig {
             // }
             AdcClockSel::Clk1M => {
                 let freq = clocks.ensure_clk_1m_active(&self.power)?;
-
-                // TODO: fix PAC names for consistency
                 #[cfg(feature = "mcxa2xx")]
-                let mux = AdcClkselMux::CLKROOT_FUNC_5;
+                let mux = AdcClkselMux::ClkrootFunc5;
                 #[cfg(feature = "mcxa5xx")]
-                let mux = AdcClkselMux::I5_CLKROOT_1M;
+                let mux = AdcClkselMux::I5Clkroot1m;
 
                 (freq, mux)
             }
             AdcClockSel::Pll1ClkDiv => {
                 let freq = clocks.ensure_pll1_clk_div_active(&self.power)?;
-
-                // TODO: fix PAC names for consistency
                 #[cfg(feature = "mcxa2xx")]
-                let mux = AdcClkselMux::CLKROOT_FUNC_6;
+                let mux = AdcClkselMux::ClkrootFunc6;
                 #[cfg(feature = "mcxa5xx")]
-                let mux = AdcClkselMux::I6_CLKROOT_SPLL_DIV;
+                let mux = AdcClkselMux::I6ClkrootSpllDiv;
 
                 (freq, mux)
             }
@@ -314,8 +305,8 @@ impl SPConfHelper for AdcConfig {
                     w.set_mux(AdcClkselMux::_RESERVED_7)
                 });
                 mrcc0.mrcc_adc_clkdiv().modify(|w| {
-                    w.set_reset(ClkdivReset::ON);
-                    w.set_halt(ClkdivHalt::ON);
+                    w.set_reset(ClkdivReset::On);
+                    w.set_halt(ClkdivHalt::On);
                 });
                 return Ok(PreEnableParts::empty());
             }
@@ -387,9 +378,9 @@ impl SPConfHelper for OsTimerConfig {
             OstimerClockSel::Clk16kVddCore => {
                 // TODO: fix PAC names for consistency
                 #[cfg(feature = "mcxa2xx")]
-                let mux = OstimerClkselMux::CLKROOT_16K;
+                let mux = OstimerClkselMux::Clkroot16k;
                 #[cfg(feature = "mcxa5xx")]
-                let mux = OstimerClkselMux::I0_CLKROOT_16K;
+                let mux = OstimerClkselMux::I0Clkroot16k;
 
                 let freq = clocks.ensure_clk_16k_vdd_core_active(&self.power)?;
                 mrcc0.mrcc_ostimer0_clksel().write(|w| w.set_mux(mux));
@@ -402,9 +393,9 @@ impl SPConfHelper for OsTimerConfig {
                 let freq = clocks.ensure_clk_1m_active(&self.power)?;
                 // TODO: fix PAC names for consistency
                 #[cfg(feature = "mcxa2xx")]
-                let mux = OstimerClkselMux::CLKROOT_1M;
+                let mux = OstimerClkselMux::Clkroot1m;
                 #[cfg(feature = "mcxa5xx")]
-                let mux = OstimerClkselMux::I2_CLKROOT_1M;
+                let mux = OstimerClkselMux::I2Clkroot1m;
 
                 mrcc0.mrcc_ostimer0_clksel().write(|w| w.set_mux(mux));
                 PreEnableParts {
@@ -507,9 +498,9 @@ impl SPConfHelper for LpspiConfig {
 
                 // TODO: fix PAC names for consistency
                 #[cfg(feature = "mcxa2xx")]
-                let mux = LpspiClkselMux::CLKROOT_FUNC_0;
+                let mux = LpspiClkselMux::ClkrootFunc0;
                 #[cfg(feature = "mcxa5xx")]
-                let mux = LpspiClkselMux::I0_CLKROOT_FUNC_0;
+                let mux = LpspiClkselMux::I0ClkrootFunc0;
 
                 (freq, mux)
             }
@@ -518,9 +509,9 @@ impl SPConfHelper for LpspiConfig {
 
                 // TODO: fix PAC names for consistency
                 #[cfg(feature = "mcxa2xx")]
-                let mux = LpspiClkselMux::CLKROOT_FUNC_2;
+                let mux = LpspiClkselMux::ClkrootFunc2;
                 #[cfg(feature = "mcxa5xx")]
-                let mux = LpspiClkselMux::I2_CLKROOT_FUNC_2;
+                let mux = LpspiClkselMux::I2ClkrootFunc2;
 
                 (freq, mux)
             }
@@ -530,9 +521,9 @@ impl SPConfHelper for LpspiConfig {
 
                 // TODO: fix PAC names for consistency
                 #[cfg(feature = "mcxa2xx")]
-                let mux = LpspiClkselMux::CLKROOT_FUNC_3;
+                let mux = LpspiClkselMux::ClkrootFunc3;
                 #[cfg(feature = "mcxa5xx")]
-                let mux = LpspiClkselMux::I3_CLKROOT_FUNC_3;
+                let mux = LpspiClkselMux::I3ClkrootFunc3;
 
                 (freq, mux)
             }
@@ -541,9 +532,9 @@ impl SPConfHelper for LpspiConfig {
 
                 // TODO: fix PAC names for consistency
                 #[cfg(feature = "mcxa2xx")]
-                let mux = LpspiClkselMux::CLKROOT_FUNC_5;
+                let mux = LpspiClkselMux::ClkrootFunc5;
                 #[cfg(feature = "mcxa5xx")]
-                let mux = LpspiClkselMux::I5_CLKROOT_FUNC_5;
+                let mux = LpspiClkselMux::I5ClkrootFunc5;
 
                 (freq, mux)
             }
@@ -552,9 +543,9 @@ impl SPConfHelper for LpspiConfig {
 
                 // TODO: fix PAC names for consistency
                 #[cfg(feature = "mcxa2xx")]
-                let mux = LpspiClkselMux::CLKROOT_FUNC_6;
+                let mux = LpspiClkselMux::ClkrootFunc6;
                 #[cfg(feature = "mcxa5xx")]
-                let mux = LpspiClkselMux::I6_CLKROOT_FUNC_6;
+                let mux = LpspiClkselMux::I6ClkrootFunc6;
 
                 (freq, mux)
             }
@@ -562,8 +553,8 @@ impl SPConfHelper for LpspiConfig {
                 // no ClkrootFunc7, just write manually for now
                 clksel.write(|w| w.0 = 0b111);
                 clkdiv.modify(|w| {
-                    w.set_reset(ClkdivReset::OFF);
-                    w.set_halt(ClkdivHalt::OFF);
+                    w.set_reset(ClkdivReset::Off);
+                    w.set_halt(ClkdivHalt::Off);
                 });
                 return Ok(PreEnableParts::empty());
             }
@@ -655,58 +646,45 @@ impl SPConfHelper for I3cConfig {
         let (freq, variant) = match self.source {
             I3cClockSel::FroLfDiv => {
                 let freq = clocks.ensure_fro_lf_div_active(&self.power)?;
-
-                // TODO: fix PAC names for consistency
                 #[cfg(feature = "mcxa2xx")]
-                let mux = FclkClkselMux::CLKROOT_FUNC_0;
+                let mux = FclkClkselMux::ClkrootFunc0;
                 #[cfg(feature = "mcxa5xx")]
-                let mux = FclkClkselMux::I0_CLKROOT_FUNC_0;
+                let mux = FclkClkselMux::I0ClkrootFunc0;
 
                 (freq, mux)
             }
             I3cClockSel::FroHfDiv => {
                 let freq = clocks.ensure_fro_hf_div_active(&self.power)?;
-
-                // TODO: fix PAC names for consistency
                 #[cfg(feature = "mcxa2xx")]
-                let mux = FclkClkselMux::CLKROOT_FUNC_2;
+                let mux = FclkClkselMux::ClkrootFunc2;
                 #[cfg(feature = "mcxa5xx")]
-                let mux = FclkClkselMux::I2_CLKROOT_FUNC_2;
+                let mux = FclkClkselMux::I2ClkrootFunc2;
 
                 (freq, mux)
             }
             #[cfg(not(feature = "sosc-as-gpio"))]
             I3cClockSel::ClkIn => {
                 let freq = clocks.ensure_clk_in_active(&self.power)?;
-
-                // TODO: fix PAC names for consistency
                 #[cfg(feature = "mcxa2xx")]
-                let mux = FclkClkselMux::CLKROOT_FUNC_3;
+                let mux = FclkClkselMux::ClkrootFunc3;
                 #[cfg(feature = "mcxa5xx")]
-                let mux = FclkClkselMux::I3_CLKROOT_FUNC_3;
+                let mux = FclkClkselMux::I3ClkrootFunc3;
 
                 (freq, mux)
             }
             I3cClockSel::Clk1M => {
                 let freq = clocks.ensure_clk_1m_active(&self.power)?;
-
-                // TODO: fix PAC names for consistency
                 #[cfg(feature = "mcxa2xx")]
-                let mux = FclkClkselMux::CLKROOT_FUNC_5;
+                let mux = FclkClkselMux::ClkrootFunc5;
                 #[cfg(feature = "mcxa5xx")]
-                let mux = FclkClkselMux::I5_CLKROOT_FUNC_5;
+                let mux = FclkClkselMux::I5ClkrootFunc5;
 
                 (freq, mux)
             }
             #[cfg(feature = "mcxa5xx")]
             I3cClockSel::Pll1ClkDiv => {
                 let freq = clocks.ensure_pll1_clk_div_active(&self.power)?;
-
-                // TODO: fix PAC names for consistency
-                #[cfg(feature = "mcxa2xx")]
-                let mux = FclkClkselMux::CLKROOT_FUNC_6;
-                #[cfg(feature = "mcxa5xx")]
-                let mux = FclkClkselMux::I6_CLKROOT_FUNC_6;
+                let mux = FclkClkselMux::I6ClkrootFunc6;
 
                 (freq, mux)
             }
@@ -714,8 +692,8 @@ impl SPConfHelper for I3cConfig {
                 // no ClkrootFunc7, just write manually for now
                 clksel.write(|w| w.0 = 0b111);
                 clkdiv.modify(|w| {
-                    w.set_reset(ClkdivReset::OFF);
-                    w.set_halt(ClkdivHalt::OFF);
+                    w.set_reset(ClkdivReset::Off);
+                    w.set_halt(ClkdivHalt::Off);
                 });
                 return Ok(PreEnableParts::empty());
             }
@@ -802,23 +780,19 @@ impl SPConfHelper for Lpi2cConfig {
         let (freq, variant) = match self.source {
             Lpi2cClockSel::FroLfDiv => {
                 let freq = clocks.ensure_fro_lf_div_active(&self.power)?;
-
-                // TODO: fix PAC names for consistency
                 #[cfg(feature = "mcxa2xx")]
-                let mux = Lpi2cClkselMux::CLKROOT_FUNC_0;
+                let mux = Lpi2cClkselMux::ClkrootFunc0;
                 #[cfg(feature = "mcxa5xx")]
-                let mux = Lpi2cClkselMux::I0_CLKROOT_FUNC_0;
+                let mux = Lpi2cClkselMux::I0ClkrootFunc0;
 
                 (freq, mux)
             }
             Lpi2cClockSel::FroHfDiv => {
                 let freq = clocks.ensure_fro_hf_div_active(&self.power)?;
-
-                // TODO: fix PAC names for consistency
                 #[cfg(feature = "mcxa2xx")]
-                let mux = Lpi2cClkselMux::CLKROOT_FUNC_2;
+                let mux = Lpi2cClkselMux::ClkrootFunc2;
                 #[cfg(feature = "mcxa5xx")]
-                let mux = Lpi2cClkselMux::I2_CLKROOT_FUNC_2;
+                let mux = Lpi2cClkselMux::I2ClkrootFunc2;
 
                 (freq, mux)
             }
@@ -826,30 +800,28 @@ impl SPConfHelper for Lpi2cConfig {
             #[cfg(not(feature = "sosc-as-gpio"))]
             Lpi2cClockSel::ClkIn => {
                 let freq = clocks.ensure_clk_in_active(&self.power)?;
-                (freq, Lpi2cClkselMux::CLKROOT_FUNC_3)
+                (freq, Lpi2cClkselMux::ClkrootFunc3)
             }
             Lpi2cClockSel::Clk1M => {
                 let freq = clocks.ensure_clk_1m_active(&self.power)?;
-
-                // TODO: fix PAC names for consistency
                 #[cfg(feature = "mcxa2xx")]
-                let mux = Lpi2cClkselMux::CLKROOT_FUNC_5;
+                let mux = Lpi2cClkselMux::ClkrootFunc5;
                 #[cfg(feature = "mcxa5xx")]
-                let mux = Lpi2cClkselMux::I5_CLKROOT_FUNC_5;
+                let mux = Lpi2cClkselMux::I5ClkrootFunc5;
 
                 (freq, mux)
             }
             #[cfg(feature = "mcxa2xx")]
             Lpi2cClockSel::Pll1ClkDiv => {
                 let freq = clocks.ensure_pll1_clk_div_active(&self.power)?;
-                (freq, Lpi2cClkselMux::CLKROOT_FUNC_6)
+                (freq, Lpi2cClkselMux::ClkrootFunc6)
             }
             Lpi2cClockSel::None => {
                 // no ClkrootFunc7, just write manually for now
                 clksel.write(|w| w.0 = 0b111);
                 clkdiv.modify(|w| {
-                    w.set_reset(ClkdivReset::OFF);
-                    w.set_halt(ClkdivHalt::OFF);
+                    w.set_reset(ClkdivReset::Off);
+                    w.set_halt(ClkdivHalt::Off);
                 });
                 return Ok(PreEnableParts::empty());
             }
@@ -962,35 +934,32 @@ impl SPConfHelper for LpuartConfig {
         let (freq, variant) = match self.source {
             LpuartClockSel::FroLfDiv => {
                 let freq = clocks.ensure_fro_lf_div_active(&self.power)?;
-
                 // TODO: fix PAC names for consistency
                 #[cfg(feature = "mcxa2xx")]
-                let mux = LpuartClkselMux::CLKROOT_FUNC_0;
+                let mux = LpuartClkselMux::ClkrootFunc0;
                 #[cfg(feature = "mcxa5xx")]
-                let mux = LpuartClkselMux::I0_CLKROOT_SIRC_DIV;
+                let mux = LpuartClkselMux::I0ClkrootSircDiv;
 
                 (freq, mux)
             }
             LpuartClockSel::FroHfDiv => {
                 let freq = clocks.ensure_fro_hf_div_active(&self.power)?;
-
                 // TODO: fix PAC names for consistency
                 #[cfg(feature = "mcxa2xx")]
-                let mux = LpuartClkselMux::CLKROOT_FUNC_2;
+                let mux = LpuartClkselMux::ClkrootFunc2;
                 #[cfg(feature = "mcxa5xx")]
-                let mux = LpuartClkselMux::I2_CLKROOT_FIRC_DIV;
+                let mux = LpuartClkselMux::I2ClkrootFircDiv;
 
                 (freq, mux)
             }
             #[cfg(not(feature = "sosc-as-gpio"))]
             LpuartClockSel::ClkIn => {
                 let freq = clocks.ensure_clk_in_active(&self.power)?;
-
                 // TODO: fix PAC names for consistency
                 #[cfg(feature = "mcxa2xx")]
-                let mux = LpuartClkselMux::CLKROOT_FUNC_3;
+                let mux = LpuartClkselMux::ClkrootFunc3;
                 #[cfg(feature = "mcxa5xx")]
-                let mux = LpuartClkselMux::I3_CLKROOT_SOSC;
+                let mux = LpuartClkselMux::I3ClkrootSosc;
 
                 (freq, mux)
             }
@@ -1000,7 +969,7 @@ impl SPConfHelper for LpuartConfig {
 
                 // TODO: fix PAC names for consistency
                 #[cfg(feature = "mcxa2xx")]
-                let mux = LpuartClkselMux::CLKROOT_FUNC_4;
+                let mux = LpuartClkselMux::ClkrootFunc4;
                 // #[cfg(feature = "mcxa5xx")]
                 // let mux = LpuartClkselMux::I4_CLKROOT_LPOSC;
 
@@ -1008,23 +977,21 @@ impl SPConfHelper for LpuartConfig {
             }
             LpuartClockSel::Clk1M => {
                 let freq = clocks.ensure_clk_1m_active(&self.power)?;
-
                 // TODO: fix PAC names for consistency
                 #[cfg(feature = "mcxa2xx")]
-                let mux = LpuartClkselMux::CLKROOT_FUNC_5;
+                let mux = LpuartClkselMux::ClkrootFunc5;
                 #[cfg(feature = "mcxa5xx")]
-                let mux = LpuartClkselMux::I5_CLKROOT_1M;
+                let mux = LpuartClkselMux::I5Clkroot1m;
 
                 (freq, mux)
             }
             LpuartClockSel::Pll1ClkDiv => {
                 let freq = clocks.ensure_pll1_clk_div_active(&self.power)?;
-
                 // TODO: fix PAC names for consistency
                 #[cfg(feature = "mcxa2xx")]
-                let mux = LpuartClkselMux::CLKROOT_FUNC_6;
+                let mux = LpuartClkselMux::ClkrootFunc6;
                 #[cfg(feature = "mcxa5xx")]
-                let mux = LpuartClkselMux::I6_CLKROOT_SPLL_DIV;
+                let mux = LpuartClkselMux::I6ClkrootSpllDiv;
 
                 (freq, mux)
             }
@@ -1032,8 +999,8 @@ impl SPConfHelper for LpuartConfig {
                 // no ClkrootFunc7, just write manually for now
                 clksel.write(|w| w.set_mux(LpuartClkselMux::_RESERVED_7));
                 clkdiv.modify(|w| {
-                    w.set_reset(ClkdivReset::ON);
-                    w.set_halt(ClkdivHalt::ON);
+                    w.set_reset(ClkdivReset::On);
+                    w.set_halt(ClkdivHalt::On);
                 });
                 return Ok(PreEnableParts::empty());
             }
@@ -1143,35 +1110,32 @@ impl SPConfHelper for CTimerConfig {
         let (freq, variant) = match self.source {
             CTimerClockSel::FroLfDiv => {
                 let freq = clocks.ensure_fro_lf_div_active(&self.power)?;
-
                 // TODO: fix PAC names for consistency
                 #[cfg(feature = "mcxa2xx")]
-                let mux = CtimerClkselMux::CLKROOT_FUNC_0;
+                let mux = CtimerClkselMux::ClkrootFunc0;
                 #[cfg(feature = "mcxa5xx")]
-                let mux = CtimerClkselMux::I0_CLKROOT_SIRC_DIV;
+                let mux = CtimerClkselMux::I0ClkrootSircDiv;
 
                 (freq, mux)
             }
             CTimerClockSel::FroHfDiv => {
                 let freq = clocks.ensure_fro_hf_div_active(&self.power)?;
-
                 // TODO: fix PAC names for consistency
                 #[cfg(feature = "mcxa2xx")]
-                let mux = CtimerClkselMux::CLKROOT_FUNC_1;
+                let mux = CtimerClkselMux::ClkrootFunc1;
                 #[cfg(feature = "mcxa5xx")]
-                let mux = CtimerClkselMux::I1_CLKROOT_FIRC_GATED;
+                let mux = CtimerClkselMux::I1ClkrootFircGated;
 
                 (freq, mux)
             }
             #[cfg(not(feature = "sosc-as-gpio"))]
             CTimerClockSel::ClkIn => {
                 let freq = clocks.ensure_clk_in_active(&self.power)?;
-
                 // TODO: fix PAC names for consistency
                 #[cfg(feature = "mcxa2xx")]
-                let mux = CtimerClkselMux::CLKROOT_FUNC_3;
+                let mux = CtimerClkselMux::ClkrootFunc3;
                 #[cfg(feature = "mcxa5xx")]
-                let mux = CtimerClkselMux::I3_CLKROOT_SOSC;
+                let mux = CtimerClkselMux::I3ClkrootSosc;
 
                 (freq, mux)
             }
@@ -1181,7 +1145,7 @@ impl SPConfHelper for CTimerConfig {
 
                 // TODO: fix PAC names for consistency
                 #[cfg(feature = "mcxa2xx")]
-                let mux = CtimerClkselMux::CLKROOT_FUNC_4;
+                let mux = CtimerClkselMux::ClkrootFunc4;
                 // TODO: MCXA5xx uses "LPOSC", which can either be clk_16k or clk_32k.
                 // We do not support this yet.
                 // #[cfg(feature = "mcxa5xx")]
@@ -1191,23 +1155,21 @@ impl SPConfHelper for CTimerConfig {
             }
             CTimerClockSel::Clk1M => {
                 let freq = clocks.ensure_clk_1m_active(&self.power)?;
-
                 // TODO: fix PAC names for consistency
                 #[cfg(feature = "mcxa2xx")]
-                let mux = CtimerClkselMux::CLKROOT_FUNC_5;
+                let mux = CtimerClkselMux::ClkrootFunc5;
                 #[cfg(feature = "mcxa5xx")]
-                let mux = CtimerClkselMux::I5_CLKROOT_1M;
+                let mux = CtimerClkselMux::I5Clkroot1m;
 
                 (freq, mux)
             }
             CTimerClockSel::Pll1ClkDiv => {
                 let freq = clocks.ensure_pll1_clk_div_active(&self.power)?;
-
                 // TODO: fix PAC names for consistency
                 #[cfg(feature = "mcxa2xx")]
-                let mux = CtimerClkselMux::CLKROOT_FUNC_6;
+                let mux = CtimerClkselMux::ClkrootFunc6;
                 #[cfg(feature = "mcxa5xx")]
-                let mux = CtimerClkselMux::I6_CLKROOT_SPLL_DIV;
+                let mux = CtimerClkselMux::I6ClkrootSpllDiv;
 
                 (freq, mux)
             }
@@ -1215,8 +1177,8 @@ impl SPConfHelper for CTimerConfig {
                 // no ClkrootFunc7, just write manually for now
                 clksel.write(|w| w.set_mux(CtimerClkselMux::_RESERVED_7));
                 clkdiv.modify(|w| {
-                    w.set_reset(ClkdivReset::ON);
-                    w.set_halt(ClkdivHalt::ON)
+                    w.set_reset(ClkdivReset::On);
+                    w.set_halt(ClkdivHalt::On)
                 });
                 return Ok(PreEnableParts::empty());
             }

--- a/embassy-mcxa/src/clocks/sleep.rs
+++ b/embassy-mcxa/src/clocks/sleep.rs
@@ -8,7 +8,7 @@ use critical_section::CriticalSection;
 use super::CLOCKS;
 use super::types::{Clocks, PoweredClock};
 use crate::pac;
-use crate::pac::cmc::CkctrlCkmode;
+use crate::pac::cmc::Ckmode;
 #[cfg(feature = "mcxa2xx")]
 use crate::pac::scg::Fircvld;
 use crate::pac::scg::{Sircvld, SpllLock};
@@ -65,7 +65,7 @@ unsafe fn setup_deep_sleep() {
     // To configure for Deep Sleep Low-Power mode entry:
     //
     // Write Fh to Clock Control (CKCTRL)
-    cmc.ckctrl().modify(|w| w.set_ckmode(CkctrlCkmode::CKMODE1111));
+    cmc.ckctrl().modify(|w| w.set_ckmode(Ckmode::Ckmode1111));
     // Write 1h to Power Mode Protection (PMPROT)
     cmc.pmprot().write(|w| w.0 = 1);
     // Write 1h to Global Power Mode Control (GPMCTRL)
@@ -99,7 +99,7 @@ unsafe fn recover_deep_sleep(cs: &CriticalSection) {
     // Re-raise the sleep level to WFE sleep in the off chance that the
     // user decides to call `wfe` on their own accord, and to avoid having
     // to re-set if we chill in WFE sleep mostly
-    cmc.ckctrl().modify(|w| w.set_ckmode(CkctrlCkmode::CKMODE0001));
+    cmc.ckctrl().modify(|w| w.set_ckmode(Ckmode::Ckmode0001));
 }
 
 /// Perform any actions necessary to re-initialize clocks after returning to active
@@ -127,7 +127,7 @@ unsafe fn restart_active_only_clocks(_cs: &CriticalSection) {
     if let Some(fro12m) = clocks.fro_12m_root.as_ref()
         && !matches!(fro12m.power, PoweredClock::AlwaysEnabled)
     {
-        while scg.sirccsr().read().sircvld() != Sircvld::ENABLED_AND_VALID {}
+        while scg.sirccsr().read().sircvld() != Sircvld::EnabledAndValid {}
     }
 
     // Ensure FRO45M is up and running
@@ -135,7 +135,7 @@ unsafe fn restart_active_only_clocks(_cs: &CriticalSection) {
     if let Some(frohf) = clocks.fro_hf_root.as_ref()
         && !matches!(frohf.power, PoweredClock::AlwaysEnabled)
     {
-        while scg.firccsr().read().fircvld() != Fircvld::ENABLED_AND_VALID {}
+        while scg.firccsr().read().fircvld() != Fircvld::EnabledAndValid {}
     }
 
     // Ensure SOSC is up and running
@@ -150,6 +150,6 @@ unsafe fn restart_active_only_clocks(_cs: &CriticalSection) {
     if let Some(spll) = clocks.pll1_clk.as_ref()
         && !matches!(spll.power, PoweredClock::AlwaysEnabled)
     {
-        while scg.spllcsr().read().spll_lock() != SpllLock::ENABLED_AND_VALID {}
+        while scg.spllcsr().read().spll_lock() != SpllLock::EnabledAndValid {}
     }
 }

--- a/embassy-mcxa/src/crc.rs
+++ b/embassy-mcxa/src/crc.rs
@@ -33,14 +33,14 @@ impl<'d, M: Mode> Crc<'d, M> {
             w.set_fxor(config.complement_out.into());
             w.set_totr(config.reflect_out.into());
             w.set_tot(config.reflect_in.into());
-            w.set_was(Was::DATA);
+            w.set_was(Was::Data);
             w.set_tcrc(width);
         });
 
         self.info.regs().gpoly32().write(|w| *w = config.polynomial);
-        self.info.regs().ctrl().modify(|w| w.set_was(Was::SEED));
+        self.info.regs().ctrl().modify(|w| w.set_was(Was::Seed));
         self.info.regs().data32().write(|w| *w = config.seed);
-        self.info.regs().ctrl().modify(|w| w.set_was(Was::DATA));
+        self.info.regs().ctrl().modify(|w| w.set_was(Was::Data));
     }
 
     /// Read the computed CRC value
@@ -361,7 +361,7 @@ fn read_u16(regs: crate::pac::crc::Crc) -> u16 {
     let ctrl = regs.ctrl().read();
 
     // if transposition is enabled, result sits in the upper 16 bits
-    if matches!(ctrl.totr(), Totr::BYTS_TRNPS | Totr::BYTS_BTS_TRNPS) {
+    if matches!(ctrl.totr(), Totr::BytsTrnps | Totr::BytsBtsTrnps) {
         (regs.data32().read() >> 16) as u16
     } else {
         regs.data16().read()
@@ -718,8 +718,8 @@ pub enum Reflect {
 impl From<Reflect> for Tot {
     fn from(value: Reflect) -> Tot {
         match value {
-            Reflect::No => Tot::BYTS_TRNPS,
-            Reflect::Yes => Tot::BYTS_BTS_TRNPS,
+            Reflect::No => Tot::BytsTrnps,
+            Reflect::Yes => Tot::BytsBtsTrnps,
         }
     }
 }
@@ -727,8 +727,8 @@ impl From<Reflect> for Tot {
 impl From<Reflect> for Totr {
     fn from(value: Reflect) -> Totr {
         match value {
-            Reflect::No => Totr::NOTRNPS,
-            Reflect::Yes => Totr::BYTS_BTS_TRNPS,
+            Reflect::No => Totr::Notrnps,
+            Reflect::Yes => Totr::BytsBtsTrnps,
         }
     }
 }
@@ -743,8 +743,8 @@ pub enum Complement {
 impl From<Complement> for Fxor {
     fn from(value: Complement) -> Fxor {
         match value {
-            Complement::No => Fxor::NOXOR,
-            Complement::Yes => Fxor::INVERT,
+            Complement::No => Fxor::Noxor,
+            Complement::Yes => Fxor::Invert,
         }
     }
 }

--- a/embassy-mcxa/src/ctimer/capture.rs
+++ b/embassy-mcxa/src/ctimer/capture.rs
@@ -6,7 +6,6 @@ use core::ops::{Add, Sub};
 use core::sync::atomic::Ordering;
 
 use embassy_hal_internal::Peri;
-use nxp_pac::ctimer::{Capfe, Capi, Capre};
 
 use super::{AnyChannel, CTimer, CTimerChannel, Channel, Info, InputPin, Instance};
 use crate::clocks::WakeGuard;
@@ -207,50 +206,50 @@ impl<'d> Capture<'d> {
             match self.ch.number() {
                 Channel::Zero => match config.edge {
                     Edge::Both => {
-                        w.set_cap0re(Capre::CAPRE1);
-                        w.set_cap0fe(Capfe::CAPFE1);
+                        w.set_cap0re(true);
+                        w.set_cap0fe(true);
                     }
                     Edge::RisingEdge => {
-                        w.set_cap0re(Capre::CAPRE1);
+                        w.set_cap0re(true);
                     }
                     Edge::FallingEdge => {
-                        w.set_cap0fe(Capfe::CAPFE1);
+                        w.set_cap0fe(true);
                     }
                 },
                 Channel::One => match config.edge {
                     Edge::Both => {
-                        w.set_cap1re(Capre::CAPRE1);
-                        w.set_cap1fe(Capfe::CAPFE1);
+                        w.set_cap1re(true);
+                        w.set_cap1fe(true);
                     }
                     Edge::RisingEdge => {
-                        w.set_cap1re(Capre::CAPRE1);
+                        w.set_cap1re(true);
                     }
                     Edge::FallingEdge => {
-                        w.set_cap1fe(Capfe::CAPFE1);
+                        w.set_cap1fe(true);
                     }
                 },
                 Channel::Two => match config.edge {
                     Edge::Both => {
-                        w.set_cap2re(Capre::CAPRE1);
-                        w.set_cap2fe(Capfe::CAPFE1);
+                        w.set_cap2re(true);
+                        w.set_cap2fe(true);
                     }
                     Edge::RisingEdge => {
-                        w.set_cap2re(Capre::CAPRE1);
+                        w.set_cap2re(true);
                     }
                     Edge::FallingEdge => {
-                        w.set_cap2fe(Capfe::CAPFE1);
+                        w.set_cap2fe(true);
                     }
                 },
                 Channel::Three => match config.edge {
                     Edge::Both => {
-                        w.set_cap3re(Capre::CAPRE1);
-                        w.set_cap3fe(Capfe::CAPFE1);
+                        w.set_cap3re(true);
+                        w.set_cap3fe(true);
                     }
                     Edge::RisingEdge => {
-                        w.set_cap3re(Capre::CAPRE1);
+                        w.set_cap3re(true);
                     }
                     Edge::FallingEdge => {
-                        w.set_cap3fe(Capfe::CAPFE1);
+                        w.set_cap3fe(true);
                     }
                 },
             };
@@ -269,16 +268,16 @@ impl<'d> Capture<'d> {
             .wait_for(|| {
                 self.info.regs().ccr().modify(|w| match self.ch.number() {
                     Channel::Zero => {
-                        w.set_cap0i(Capi::CAPI1);
+                        w.set_cap0i(true);
                     }
                     Channel::One => {
-                        w.set_cap1i(Capi::CAPI1);
+                        w.set_cap1i(true);
                     }
                     Channel::Two => {
-                        w.set_cap2i(Capi::CAPI1);
+                        w.set_cap2i(true);
                     }
                     Channel::Three => {
-                        w.set_cap3i(Capi::CAPI1);
+                        w.set_cap3i(true);
                     }
                 });
 
@@ -315,22 +314,22 @@ impl<T: Instance> interrupt::typelevel::Handler<T::Interrupt> for InterruptHandl
         let mut mask = 0;
         T::info().regs().ccr().modify(|w| {
             if ir.cr0int() {
-                w.set_cap0i(Capi::CAPI0);
+                w.set_cap0i(false);
                 mask |= 1 << 0;
             }
 
             if ir.cr1int() {
-                w.set_cap1i(Capi::CAPI0);
+                w.set_cap1i(false);
                 mask |= 1 << 1;
             }
 
             if ir.cr2int() {
-                w.set_cap2i(Capi::CAPI0);
+                w.set_cap2i(false);
                 mask |= 1 << 2;
             }
 
             if ir.cr3int() {
-                w.set_cap3i(Capi::CAPI0);
+                w.set_cap3i(false);
                 mask |= 1 << 3;
             }
         });

--- a/embassy-mcxa/src/ctimer/pwm.rs
+++ b/embassy-mcxa/src/ctimer/pwm.rs
@@ -6,7 +6,7 @@ use embedded_hal_1::pwm::{Error, ErrorKind, ErrorType};
 
 use super::{AnyChannel, CTimer, CTimerChannel, Channel, Info, Instance, OutputPin};
 use crate::gpio::{AnyPin, SealedPin};
-use crate::pac::ctimer::{Mri, Mrr, Mrrl, Mrs, Pwmen};
+use crate::pac::ctimer::Pwmen;
 
 /// PWM error.
 #[derive(Debug)]
@@ -76,16 +76,16 @@ impl<'d> Pwm<'d> {
     fn set_pwm_mode(&self) {
         self.info.regs().pwmc().modify(|w| match self.duty_ch.number() {
             Channel::Zero => {
-                w.set_pwmen0(Pwmen::PWM);
+                w.set_pwmen0(Pwmen::Pwm);
             }
             Channel::One => {
-                w.set_pwmen1(Pwmen::PWM);
+                w.set_pwmen1(Pwmen::Pwm);
             }
             Channel::Two => {
-                w.set_pwmen2(Pwmen::PWM);
+                w.set_pwmen2(Pwmen::Pwm);
             }
             Channel::Three => {
-                w.set_pwmen3(Pwmen::PWM);
+                w.set_pwmen3(Pwmen::Pwm);
             }
         });
     }
@@ -95,39 +95,39 @@ impl<'d> Pwm<'d> {
             // Clear stop, reset, and interrupt bits for the PWM channel
             match self.duty_ch.number() {
                 Channel::Zero => {
-                    w.set_mr0i(Mri::MRI0);
-                    w.set_mr0r(Mrr::MRR0);
-                    w.set_mr0s(Mrs::MRS0);
+                    w.set_mr0i(false);
+                    w.set_mr0r(false);
+                    w.set_mr0s(false);
                 }
                 Channel::One => {
-                    w.set_mr1i(Mri::MRI0);
-                    w.set_mr1r(Mrr::MRR0);
-                    w.set_mr1s(Mrs::MRS0);
+                    w.set_mr1i(false);
+                    w.set_mr1r(false);
+                    w.set_mr1s(false);
                 }
                 Channel::Two => {
-                    w.set_mr2i(Mri::MRI0);
-                    w.set_mr2r(Mrr::MRR0);
-                    w.set_mr2s(Mrs::MRS0);
+                    w.set_mr2i(false);
+                    w.set_mr2r(false);
+                    w.set_mr2s(false);
                 }
                 Channel::Three => {
-                    w.set_mr3i(Mri::MRI0);
-                    w.set_mr3r(Mrr::MRR0);
-                    w.set_mr3s(Mrs::MRS0);
+                    w.set_mr3i(false);
+                    w.set_mr3r(false);
+                    w.set_mr3s(false);
                 }
             }
 
             match self.duty_ch.number() {
                 Channel::Zero => {
-                    w.set_mr0rl(Mrrl::MRRL1);
+                    w.set_mr0rl(true);
                 }
                 Channel::One => {
-                    w.set_mr1rl(Mrrl::MRRL1);
+                    w.set_mr1rl(true);
                 }
                 Channel::Two => {
-                    w.set_mr2rl(Mrrl::MRRL1);
+                    w.set_mr2rl(true);
                 }
                 Channel::Three => {
-                    w.set_mr3rl(Mrrl::MRRL1);
+                    w.set_mr3rl(true);
                 }
             }
         });
@@ -202,16 +202,16 @@ impl<'d> SinglePwm<'d> {
 
         self.pwm.info.regs().mcr().modify(|w| match self.period_ch.number() {
             Channel::Zero => {
-                w.set_mr0r(Mrr::MRR1);
+                w.set_mr0r(true);
             }
             Channel::One => {
-                w.set_mr1r(Mrr::MRR1);
+                w.set_mr1r(true);
             }
             Channel::Two => {
-                w.set_mr2r(Mrr::MRR1);
+                w.set_mr2r(true);
             }
             Channel::Three => {
-                w.set_mr3r(Mrr::MRR1);
+                w.set_mr3r(true);
             }
         });
 
@@ -311,16 +311,16 @@ impl<'d> DualPwm<'d> {
 
         self.pwm0.info.regs().mcr().modify(|w| match self.period_ch.number() {
             Channel::Zero => {
-                w.set_mr0r(Mrr::MRR1);
+                w.set_mr0r(true);
             }
             Channel::One => {
-                w.set_mr1r(Mrr::MRR1);
+                w.set_mr1r(true);
             }
             Channel::Two => {
-                w.set_mr2r(Mrr::MRR1);
+                w.set_mr2r(true);
             }
             Channel::Three => {
-                w.set_mr3r(Mrr::MRR1);
+                w.set_mr3r(true);
             }
         });
 
@@ -447,16 +447,16 @@ impl<'d> TriplePwm<'d> {
 
         self.pwm0.info.regs().mcr().modify(|w| match self.period_ch.number() {
             Channel::Zero => {
-                w.set_mr0r(Mrr::MRR1);
+                w.set_mr0r(true);
             }
             Channel::One => {
-                w.set_mr1r(Mrr::MRR1);
+                w.set_mr1r(true);
             }
             Channel::Two => {
-                w.set_mr2r(Mrr::MRR1);
+                w.set_mr2r(true);
             }
             Channel::Three => {
-                w.set_mr3r(Mrr::MRR1);
+                w.set_mr3r(true);
             }
         });
 

--- a/embassy-mcxa/src/dma.rs
+++ b/embassy-mcxa/src/dma.rs
@@ -140,7 +140,7 @@ pub(crate) fn init() {
     pac::DMA0.mp_csr().modify(|w| {
         w.set_edbg(true);
         w.set_erca(true);
-        w.set_halt(Halt::NORMAL_OPERATION);
+        w.set_halt(Halt::NormalOperation);
         w.set_gclc(true);
         w.set_gmrc(true);
     });
@@ -204,9 +204,9 @@ impl WordSize {
     /// Convert to hardware SSIZE/DSIZE field value.
     pub const fn to_hw_size(self) -> Size {
         match self {
-            WordSize::OneByte => Size::EIGHT_BIT,
-            WordSize::TwoBytes => Size::SIXTEEN_BIT,
-            WordSize::FourBytes => Size::THIRTYTWO_BIT,
+            WordSize::OneByte => Size::EightBit,
+            WordSize::TwoBytes => Size::SixteenBit,
+            WordSize::FourBytes => Size::ThirtytwoBit,
         }
     }
 
@@ -513,8 +513,8 @@ impl DmaChannel<'_> {
     #[inline]
     fn set_major_loop_nbytes_without_minor(t: &pac::edma_tcd::Tcd, count: u32) {
         t.tcd_nbytes_mloffno().write(|w| {
-            w.set_smloe(TcdNbytesMloffnoSmloe::OFFSET_NOT_APPLIED);
-            w.set_dmloe(TcdNbytesMloffnoDmloe::OFFSET_NOT_APPLIED);
+            w.set_smloe(TcdNbytesMloffnoSmloe::OffsetNotApplied);
+            w.set_dmloe(TcdNbytesMloffnoDmloe::OffsetNotApplied);
             w.set_nbytes(count)
         });
     }
@@ -559,8 +559,8 @@ impl DmaChannel<'_> {
     #[inline]
     fn set_fixed_priority(t: &pac::edma_tcd::Tcd, p: Priority) {
         t.ch_pri().write(|w| {
-            w.set_dpa(Dpa::SUSPEND);
-            w.set_ecp(Ecp::SUSPEND);
+            w.set_dpa(Dpa::Suspend);
+            w.set_ecp(Ecp::Suspend);
             w.set_apl(p as u8);
         });
     }
@@ -681,20 +681,20 @@ impl DmaChannel<'_> {
             w.set_intmajor(params.options.complete_transfer_interrupt);
             w.set_inthalf(params.options.half_transfer_interrupt);
             w.set_start(if params.software {
-                Start::CHANNEL_STARTED
+                Start::ChannelStarted
             } else {
-                Start::CHANNEL_NOT_STARTED
+                Start::ChannelNotStarted
             });
-            w.set_esg(Esg::NORMAL_FORMAT);
+            w.set_esg(Esg::NormalFormat);
             w.set_majorelink(false);
             w.set_eeop(false);
             w.set_esda(false);
-            w.set_bwc(Bwc::NO_STALL);
+            w.set_bwc(Bwc::NoStall);
 
             w.set_dreq(if params.circular {
-                Dreq::CHANNEL_NOT_AFFECTED // Don't clear ERQ on complete (circular)
+                Dreq::ChannelNotAffected // Don't clear ERQ on complete (circular)
             } else {
-                Dreq::ERQ_FIELD_CLEAR // Auto-disable request after major loop
+                Dreq::ErqFieldClear // Auto-disable request after major loop
             });
         });
 
@@ -1134,7 +1134,7 @@ impl DmaChannel<'_> {
     #[allow(unused)]
     pub(crate) unsafe fn trigger_start(&self) {
         let t = self.tcd();
-        t.tcd_csr().modify(|w| w.set_start(Start::CHANNEL_STARTED));
+        t.tcd_csr().modify(|w| w.set_start(Start::ChannelStarted));
     }
 
     /// Get the wait cell for this channel
@@ -2102,7 +2102,7 @@ impl<'a, W: Word> ScatterGatherBuilder<'a, W> {
         cortex_m::asm::dsb();
 
         // Start the transfer
-        t.tcd_csr().modify(|w| w.set_start(Start::CHANNEL_STARTED));
+        t.tcd_csr().modify(|w| w.set_start(Start::ChannelStarted));
 
         Ok(Transfer::new(channel))
     }

--- a/embassy-mcxa/src/flash.rs
+++ b/embassy-mcxa/src/flash.rs
@@ -256,16 +256,16 @@ fn speculation_buffer_clear() {
     let val = nvm.read();
 
     // Only proceed if MBECC error reporting is enabled for both inst and data
-    if val.dis_mbecc_err_inst() == DisMbeccErrInst::ENABLE && val.dis_mbecc_err_data() == DisMbeccErrData::ENABLE {
+    if val.dis_mbecc_err_inst() == DisMbeccErrInst::Enable && val.dis_mbecc_err_data() == DisMbeccErrData::Enable {
         // Toggle flash speculation disable
-        if val.dis_flash_spec() == DisFlashSpec::ENABLE {
-            nvm.modify(|w| w.set_dis_flash_spec(DisFlashSpec::DISABLE));
-            nvm.modify(|w| w.set_dis_flash_spec(DisFlashSpec::ENABLE));
+        if val.dis_flash_spec() == DisFlashSpec::Enable {
+            nvm.modify(|w| w.set_dis_flash_spec(DisFlashSpec::Disable));
+            nvm.modify(|w| w.set_dis_flash_spec(DisFlashSpec::Enable));
         }
         // Toggle data speculation disable
-        if nvm.read().dis_data_spec() == DisDataSpec::ENABLE {
-            nvm.modify(|w| w.set_dis_data_spec(DisDataSpec::DISABLE));
-            nvm.modify(|w| w.set_dis_data_spec(DisDataSpec::ENABLE));
+        if nvm.read().dis_data_spec() == DisDataSpec::Enable {
+            nvm.modify(|w| w.set_dis_data_spec(DisDataSpec::Disable));
+            nvm.modify(|w| w.set_dis_data_spec(DisDataSpec::Enable));
         }
     }
 }
@@ -275,8 +275,8 @@ fn speculation_buffer_clear() {
 #[inline]
 fn lpcac_clear() {
     let lpcac = pac::SYSCON.lpcac_ctrl();
-    if lpcac.read().dis_lpcac() == DisLpcac::ENABLE {
-        lpcac.modify(|w| w.set_clr_lpcac(ClrLpcac::DISABLE));
+    if lpcac.read().dis_lpcac() == DisLpcac::Enable {
+        lpcac.modify(|w| w.set_clr_lpcac(ClrLpcac::Disable));
     }
 }
 

--- a/embassy-mcxa/src/gpio.rs
+++ b/embassy-mcxa/src/gpio.rs
@@ -133,7 +133,7 @@ impl<T: Instance> Handler<T::Interrupt> for InterruptHandler<T> {
         for pin in BitIter(isfr.read().0) {
             // Clear all pending interrupts
             isfr.write(|w| w.0 = 1 << pin);
-            info.gpio.icr(pin).modify(|w| w.set_irqc(Irqc::IRQC0)); // Disable interrupt
+            info.gpio.icr(pin).modify(|w| w.set_irqc(Irqc::Irqc0)); // Disable interrupt
 
             // Wake the corresponding port waker
             if let Some(w) = PORT_WAIT_MAPS.get(info.port_index) {
@@ -157,8 +157,8 @@ pub enum OpenDrain {
 impl From<OpenDrain> for Ode {
     fn from(open_drain: OpenDrain) -> Self {
         match open_drain {
-            OpenDrain::No => Ode::ODE0,
-            OpenDrain::Yes => Ode::ODE1,
+            OpenDrain::No => Ode::Ode0,
+            OpenDrain::Yes => Ode::Ode1,
         }
     }
 }
@@ -190,9 +190,9 @@ pub enum Pull {
 impl From<Pull> for (Pe, Ps) {
     fn from(pull: Pull) -> Self {
         match pull {
-            Pull::Disabled => (Pe::PE0, Ps::PS0),
-            Pull::Up => (Pe::PE1, Ps::PS1),
-            Pull::Down => (Pe::PE1, Ps::PS0),
+            Pull::Disabled => (Pe::Pe0, Ps::Ps0),
+            Pull::Up => (Pe::Pe1, Ps::Ps1),
+            Pull::Down => (Pe::Pe1, Ps::Ps0),
         }
     }
 }
@@ -206,8 +206,8 @@ pub enum SlewRate {
 impl From<SlewRate> for Sre {
     fn from(slew_rate: SlewRate) -> Self {
         match slew_rate {
-            SlewRate::Fast => Sre::SRE0,
-            SlewRate::Slow => Sre::SRE1,
+            SlewRate::Fast => Sre::Sre0,
+            SlewRate::Slow => Sre::Sre1,
         }
     }
 }
@@ -221,8 +221,8 @@ pub enum DriveStrength {
 impl From<DriveStrength> for Dse {
     fn from(strength: DriveStrength) -> Self {
         match strength {
-            DriveStrength::Normal => Dse::DSE0,
-            DriveStrength::Double => Dse::DSE1,
+            DriveStrength::Normal => Dse::Dse0,
+            DriveStrength::Double => Dse::Dse1,
         }
     }
 }
@@ -236,8 +236,8 @@ pub enum Inverter {
 impl From<Inverter> for Inv {
     fn from(strength: Inverter) -> Self {
         match strength {
-            Inverter::Disabled => Inv::INV0,
-            Inverter::Enabled => Inv::INV1,
+            Inverter::Disabled => Inv::Inv0,
+            Inverter::Enabled => Inv::Inv1,
         }
     }
 }
@@ -403,19 +403,19 @@ impl SealedPin for AnyPin {
     #[inline(always)]
     fn set_enable_input_buffer(&self, buffer_enabled: bool) {
         self.pcr_reg()
-            .modify(|w| w.set_ibe(if buffer_enabled { Ibe::IBE1 } else { Ibe::IBE0 }));
+            .modify(|w| w.set_ibe(if buffer_enabled { Ibe::Ibe1 } else { Ibe::Ibe0 }));
     }
 
     #[inline(always)]
     fn set_as_disabled(&self) {
         // Set GPIO direction as input
-        self.gpio().pddr().modify(|w| w.set_pdd(self.pin() as usize, Pdd::PDD0));
+        self.gpio().pddr().modify(|w| w.set_pdd(self.pin() as usize, Pdd::Pdd0));
         // Set input buffer as disabled
         self.set_enable_input_buffer(false);
         // Set mode as GPIO (vs other potential functions)
-        self.set_function(Mux::MUX0);
+        self.set_function(Mux::Mux0);
         // Set pin as disabled
-        self.gpio().pidr().modify(|w| w.set_pid(self.pin() as usize, Pid::PID1));
+        self.gpio().pidr().modify(|w| w.set_pid(self.pin() as usize, Pid::Pid1));
     }
 }
 
@@ -479,19 +479,19 @@ macro_rules! impl_gpio_pin {
                 #[inline(always)]
                 fn set_enable_input_buffer(&self, buffer_enabled: bool) {
                     use crate::pac::port::Ibe;
-                    self.pcr_reg().modify(|w| w.set_ibe(if buffer_enabled { Ibe::IBE1 } else { Ibe::IBE0 }));
+                    self.pcr_reg().modify(|w| w.set_ibe(if buffer_enabled { Ibe::Ibe1 } else { Ibe::Ibe0 }));
                 }
 
                 #[inline(always)]
                 fn set_as_disabled(&self) {
                     // Set GPIO direction as input
-                    self.gpio().pddr().modify(|w| w.set_pdd(self.pin() as usize, crate::pac::gpio::Pdd::PDD0));
+                    self.gpio().pddr().modify(|w| w.set_pdd(self.pin() as usize, crate::pac::gpio::Pdd::Pdd0));
                     // Set input buffer as disabled
                     self.set_enable_input_buffer(false);
                     // Set mode as GPIO (vs other potential functions)
-                    self.set_function(crate::pac::port::Mux::MUX0);
+                    self.set_function(crate::pac::port::Mux::Mux0);
                     // Set pin as disabled
-                    self.gpio().pidr().modify(|w| w.set_pid(self.pin() as usize, crate::pac::gpio::Pid::PID1));
+                    self.gpio().pidr().modify(|w| w.set_pid(self.pin() as usize, crate::pac::gpio::Pid::Pid1));
                 }
             }
 
@@ -574,7 +574,7 @@ impl<'d> Flex<'d> {
     /// The pin remains unmodified. The initial output level is unspecified, but
     /// can be changed before the pin is put into output mode.
     pub fn new(pin: Peri<'d, impl GpioPin>) -> Self {
-        pin.set_function(Mux::MUX0);
+        pin.set_function(Mux::Mux0);
         Self {
             pin: pin.into(),
             _phantom: PhantomData,
@@ -593,7 +593,7 @@ impl<'d, M: Mode> Flex<'d, M> {
         self.set_enable_input_buffer(true);
         self.gpio()
             .pddr()
-            .modify(|w| w.set_pdd(self.pin.pin_index() as usize, Pdd::PDD0));
+            .modify(|w| w.set_pdd(self.pin.pin_index() as usize, Pdd::Pdd0));
     }
 
     /// Put the pin into output mode.
@@ -601,7 +601,7 @@ impl<'d, M: Mode> Flex<'d, M> {
         self.set_pull(Pull::Disabled);
         self.gpio()
             .pddr()
-            .modify(|w| w.set_pdd(self.pin.pin_index() as usize, Pdd::PDD1));
+            .modify(|w| w.set_pdd(self.pin.pin_index() as usize, Pdd::Pdd1));
     }
 
     /// Set output level to High.
@@ -609,7 +609,7 @@ impl<'d, M: Mode> Flex<'d, M> {
     pub fn set_high(&mut self) {
         self.gpio()
             .psor()
-            .write(|w| w.set_ptso(self.pin.pin_index() as usize, Ptso::PTSO1));
+            .write(|w| w.set_ptso(self.pin.pin_index() as usize, Ptso::Ptso1));
     }
 
     /// Set output level to Low.
@@ -617,7 +617,7 @@ impl<'d, M: Mode> Flex<'d, M> {
     pub fn set_low(&mut self) {
         self.gpio()
             .pcor()
-            .write(|w| w.set_ptco(self.pin.pin_index() as usize, Ptco::PTCO1));
+            .write(|w| w.set_ptco(self.pin.pin_index() as usize, Ptco::Ptco1));
     }
 
     /// Set output level to the given `Level`.
@@ -718,7 +718,7 @@ impl<'d> Flex<'d, Async> {
     where
         P: GpioPin + HasGpioInstance,
     {
-        pin.set_function(Mux::MUX0);
+        pin.set_function(Mux::Mux0);
         unsafe {
             <P::Instance as Instance>::Interrupt::enable();
         }
@@ -736,7 +736,7 @@ impl<'d> Flex<'d, Async> {
     /// If an [`AnyPin`] is provided that was not constucted with [`PeriGpioExt::degrade_async`],
     /// it will return the error: [`NoIrqBound`].
     pub fn async_from_anypin(pin: Peri<'d, AnyPin>) -> Result<Self, NoIrqBound> {
-        pin.set_function(Mux::MUX0);
+        pin.set_function(Mux::Mux0);
         if pin.irq_bound() {
             Ok(Self {
                 pin: pin.into(),
@@ -770,7 +770,7 @@ impl<'d> Flex<'d, Async> {
         self.pin
             .gpio()
             .icr(self.pin.pin().into())
-            .write(|w| w.set_isf(Isf::ISF1));
+            .write(|w| w.set_isf(Isf::Isf1));
 
         // Pin interrupt configuration
         self.pin.gpio().icr(self.pin.pin().into()).modify(|w| w.set_irqc(level));
@@ -785,31 +785,31 @@ impl<'d> Flex<'d, Async> {
     /// Wait until the pin is high. If it is already high, return immediately.
     #[inline]
     pub fn wait_for_high(&mut self) -> impl Future<Output = ()> + use<'_, 'd> {
-        self.wait_for_inner(Irqc::IRQC12)
+        self.wait_for_inner(Irqc::Irqc12)
     }
 
     /// Wait until the pin is low. If it is already low, return immediately.
     #[inline]
     pub fn wait_for_low(&mut self) -> impl Future<Output = ()> + use<'_, 'd> {
-        self.wait_for_inner(Irqc::IRQC8)
+        self.wait_for_inner(Irqc::Irqc8)
     }
 
     /// Wait for the pin to undergo a transition from low to high.
     #[inline]
     pub fn wait_for_rising_edge(&mut self) -> impl Future<Output = ()> + use<'_, 'd> {
-        self.wait_for_inner(Irqc::IRQC9)
+        self.wait_for_inner(Irqc::Irqc9)
     }
 
     /// Wait for the pin to undergo a transition from high to low.
     #[inline]
     pub fn wait_for_falling_edge(&mut self) -> impl Future<Output = ()> + use<'_, 'd> {
-        self.wait_for_inner(Irqc::IRQC10)
+        self.wait_for_inner(Irqc::Irqc10)
     }
 
     /// Wait for the pin to undergo any transition, i.e low to high OR high to low.
     #[inline]
     pub fn wait_for_any_edge(&mut self) -> impl Future<Output = ()> + use<'_, 'd> {
-        self.wait_for_inner(Irqc::IRQC11)
+        self.wait_for_inner(Irqc::Irqc11)
     }
 }
 

--- a/embassy-mcxa/src/i2c/controller.rs
+++ b/embassy-mcxa/src/i2c/controller.rs
@@ -332,7 +332,7 @@ impl<'d, M: Mode> I2c<'d, M> {
             self.info.regs().mcr().modify(|w| w.set_rst(false));
 
             self.info.regs().mcr().modify(|w| {
-                w.set_dozen(Dozen::ENABLED);
+                w.set_dozen(Dozen::Enabled);
                 w.set_dbgen(false);
             });
         });
@@ -353,14 +353,14 @@ impl<'d, M: Mode> I2c<'d, M> {
 
         // Clear all flags
         self.info.regs().msr().write(|w| {
-            w.set_epf(Epf::INT_YES);
-            w.set_sdf(MsrSdf::INT_YES);
-            w.set_ndf(Ndf::INT_YES);
-            w.set_alf(Alf::INT_YES);
-            w.set_fef(MsrFef::INT_YES);
-            w.set_pltf(Pltf::INT_YES);
-            w.set_dmf(Dmf::INT_YES);
-            w.set_stf(Stf::INT_YES);
+            w.set_epf(Epf::IntYes);
+            w.set_sdf(MsrSdf::IntYes);
+            w.set_ndf(Ndf::IntYes);
+            w.set_alf(Alf::IntYes);
+            w.set_fef(MsrFef::IntYes);
+            w.set_pltf(Pltf::IntYes);
+            w.set_dmf(Dmf::IntYes);
+            w.set_stf(Stf::IntYes);
         });
     }
 
@@ -381,8 +381,8 @@ impl<'d, M: Mode> I2c<'d, M> {
     fn reset_fifos(&self) {
         critical_section::with(|_| {
             self.info.regs().mcr().modify(|w| {
-                w.set_rtf(McrRtf::RESET);
-                w.set_rrf(McrRrf::RESET);
+                w.set_rtf(McrRtf::Reset);
+                w.set_rrf(McrRrf::Reset);
             });
         });
     }
@@ -411,11 +411,11 @@ impl<'d, M: Mode> I2c<'d, M> {
     /// Parses the controller status producing an
     /// appropriate `Result<(), Error>` variant.
     fn parse_status(&self, msr: &Msr) -> Result<(), IOError> {
-        if msr.ndf() == Ndf::INT_YES {
+        if msr.ndf() == Ndf::IntYes {
             Err(IOError::AddressNack)
-        } else if msr.alf() == Alf::INT_YES {
+        } else if msr.alf() == Alf::IntYes {
             Err(IOError::ArbitrationLoss)
-        } else if msr.fef() == MsrFef::INT_YES {
+        } else if msr.fef() == MsrFef::IntYes {
             Err(IOError::FifoError)
         } else {
             Ok(())

--- a/embassy-mcxa/src/i2c/target.rs
+++ b/embassy-mcxa/src/i2c/target.rs
@@ -317,7 +317,7 @@ impl<'d, M: Mode> I2c<'d, M> {
             self.info.regs().scr().modify(|w| w.set_rst(false));
 
             self.info.regs().scr().modify(|w| {
-                w.set_filtdz(Filtdz::FILTER_DISABLED);
+                w.set_filtdz(Filtdz::FilterDisabled);
                 w.set_filten(false);
             });
 
@@ -332,9 +332,9 @@ impl<'d, M: Mode> I2c<'d, M> {
                     self.info.regs().samr().write(|w| w.set_addr0(addr));
                     self.info.regs().scfgr1().modify(|w| {
                         w.set_addrcfg(if (0x00..=0x7f).contains(&addr) {
-                            Addrcfg::ADDRESS_MATCH0_7_BIT
+                            Addrcfg::AddressMatch07Bit
                         } else {
-                            Addrcfg::ADDRESS_MATCH0_10_BIT
+                            Addrcfg::AddressMatch010Bit
                         })
                     });
                 }
@@ -353,9 +353,9 @@ impl<'d, M: Mode> I2c<'d, M> {
                     });
                     self.info.regs().scfgr1().modify(|w| {
                         w.set_addrcfg(if (0x00..=0x7f).contains(&addr0) {
-                            Addrcfg::ADDRESS_MATCH0_7_BIT_OR_ADDRESS_MATCH1_7_BIT
+                            Addrcfg::AddressMatch07BitOrAddressMatch17Bit
                         } else {
-                            Addrcfg::ADDRESS_MATCH0_10_BIT_OR_ADDRESS_MATCH1_10_BIT
+                            Addrcfg::AddressMatch010BitOrAddressMatch110Bit
                         })
                     });
                 }
@@ -373,9 +373,9 @@ impl<'d, M: Mode> I2c<'d, M> {
                     });
                     self.info.regs().scfgr1().modify(|w| {
                         w.set_addrcfg(if (0x00..=0x7f).contains(&start) {
-                            Addrcfg::FROM_ADDRESS_MATCH0_7_BIT_TO_ADDRESS_MATCH1_7_BIT
+                            Addrcfg::FromAddressMatch07BitToAddressMatch17Bit
                         } else {
-                            Addrcfg::FROM_ADDRESS_MATCH0_10_BIT_TO_ADDRESS_MATCH1_10_BIT
+                            Addrcfg::FromAddressMatch010BitToAddressMatch110Bit
                         })
                     });
                 }
@@ -403,8 +403,8 @@ impl<'d, M: Mode> I2c<'d, M> {
         // read-modify-write operation.
         critical_section::with(|_| {
             self.info.regs().scr().modify(|w| {
-                w.set_rtf(ScrRtf::NOW_EMPTY);
-                w.set_rrf(ScrRrf::NOW_EMPTY);
+                w.set_rtf(ScrRtf::NowEmpty);
+                w.set_rrf(ScrRrf::NowEmpty);
             });
         });
     }

--- a/embassy-mcxa/src/i3c/controller.rs
+++ b/embassy-mcxa/src/i3c/controller.rs
@@ -100,9 +100,9 @@ pub enum BusType {
 impl From<BusType> for Type {
     fn from(value: BusType) -> Self {
         match value {
-            BusType::I3cSdr => Self::I3C,
-            BusType::I2c => Self::I2C,
-            BusType::I3cDdr => Self::DDR,
+            BusType::I3cSdr => Self::I3c,
+            BusType::I2c => Self::I2c,
+            BusType::I3cDdr => Self::Ddr,
         }
     }
 }
@@ -118,8 +118,8 @@ enum Dir {
 impl From<Dir> for I3cDir {
     fn from(value: Dir) -> Self {
         match value {
-            Dir::Write => Self::DIRWRITE,
-            Dir::Read => Self::DIRREAD,
+            Dir::Write => Self::Dirwrite,
+            Dir::Read => Self::Dirread,
         }
     }
 }
@@ -263,8 +263,8 @@ impl<'d, M: Mode> I3c<'d, M> {
             w.set_flushtb(true);
             w.set_flushfb(true);
             w.set_unlock(true);
-            w.set_txtrig(MdatactrlTxtrig::FULL_OR_LESS);
-            w.set_rxtrig(MdatactrlRxtrig::NOT_EMPTY);
+            w.set_txtrig(MdatactrlTxtrig::FullOrLess);
+            w.set_rxtrig(MdatactrlRxtrig::NotEmpty);
         });
 
         let (ppbaud, odbaud, i2cbaud) = self.calculate_baud_rate_params(config)?;
@@ -273,9 +273,9 @@ impl<'d, M: Mode> I3c<'d, M> {
             w.set_ppbaud(ppbaud as u8);
             w.set_odbaud(odbaud as u8);
             w.set_i2cbaud(i2cbaud as u8);
-            w.set_mstena(Mstena::MASTER_ON);
-            w.set_disto(Disto::ENABLE);
-            w.set_hkeep(Hkeep::NONE);
+            w.set_mstena(Mstena::MasterOn);
+            w.set_disto(Disto::Enable);
+            w.set_hkeep(Hkeep::None);
             w.set_odstop(false);
             w.set_odhpp(true);
         });
@@ -473,9 +473,9 @@ impl<'d, M: Mode> I3c<'d, M> {
             w.set_addr(address);
             w.set_rdterm(len);
             w.set_type_(bus_type.into());
-            w.set_request(Request::EMITSTARTADDR);
+            w.set_request(Request::Emitstartaddr);
             w.set_dir(dir.into());
-            w.set_ibiresp(Ibiresp::ACK);
+            w.set_ibiresp(Ibiresp::Ack);
         });
 
         self.blocking_wait_for_ctrldone();
@@ -489,7 +489,7 @@ impl<'d, M: Mode> I3c<'d, M> {
     /// waiting for the FIFO to become empty ensuring the command was
     /// sent.
     fn blocking_stop(&self, bus_type: BusType) -> Result<(), IOError> {
-        if self.info.regs().mstatus().read().state() != State::NORMACT {
+        if self.info.regs().mstatus().read().state() != State::Normact {
             Err(IOError::InvalidRequest)
         } else {
             // NOTE: Section 41.3.2.1 states that "when sending STOP
@@ -500,7 +500,7 @@ impl<'d, M: Mode> I3c<'d, M> {
                 .mconfig()
                 .modify(|w| w.set_odstop(bus_type == BusType::I2c));
             self.info.regs().mctrl().write(|w| {
-                w.set_request(Request::EMITSTOP);
+                w.set_request(Request::Emitstop);
                 w.set_type_(bus_type.into())
             });
             self.blocking_wait_for_ctrldone();
@@ -606,7 +606,7 @@ impl<'d, M: Mode> I3c<'d, M> {
         }
 
         // Check if the bus is already in use.
-        if self.info.regs().mstatus().read().state() != State::IDLE {
+        if self.info.regs().mstatus().read().state() != State::Idle {
             return Err(IOError::Other);
         }
 
@@ -615,7 +615,7 @@ impl<'d, M: Mode> I3c<'d, M> {
 
         // Start DAA sequence
         self.info.regs().mctrl().write(|w| {
-            w.set_request(Request::PROCESSDAA);
+            w.set_request(Request::Processdaa);
         });
 
         // Here
@@ -632,7 +632,7 @@ impl<'d, M: Mode> I3c<'d, M> {
                     return Err(IOError::Other);
                 }
 
-                if s.mctrldone() && s.state() == State::DAA {
+                if s.mctrldone() && s.state() == State::Daa {
                     break;
                 }
             }
@@ -661,7 +661,7 @@ impl<'d, M: Mode> I3c<'d, M> {
             self.info.regs().mwdatab().write(|w| w.set_value(address));
 
             // Trigger DAA processing
-            self.info.regs().mctrl().write(|w| w.set_request(Request::PROCESSDAA));
+            self.info.regs().mctrl().write(|w| w.set_request(Request::Processdaa));
 
             address += 1;
         }
@@ -930,7 +930,7 @@ impl<'d> AsyncEngine for I3c<'d, Dma<'d>> {
             self.info
                 .regs()
                 .mdmactrl()
-                .modify(|w| w.set_dmafb(MdmactrlDmafb::NOT_USED));
+                .modify(|w| w.set_dmafb(MdmactrlDmafb::NotUsed));
         });
 
         for chunk in read.chunks_mut(MAX_CHUNK_SIZE) {
@@ -960,7 +960,7 @@ impl<'d> AsyncEngine for I3c<'d, Dma<'d>> {
                 self.info
                     .regs()
                     .mdmactrl()
-                    .modify(|w| w.set_dmafb(MdmactrlDmafb::ENABLE));
+                    .modify(|w| w.set_dmafb(MdmactrlDmafb::Enable));
 
                 // Enable DMA channel request
                 self.mode.rx_dma.enable_request();
@@ -983,7 +983,7 @@ impl<'d> AsyncEngine for I3c<'d, Dma<'d>> {
             self.info
                 .regs()
                 .mdmactrl()
-                .modify(|w| w.set_dmafb(MdmactrlDmafb::NOT_USED));
+                .modify(|w| w.set_dmafb(MdmactrlDmafb::NotUsed));
             unsafe {
                 self.mode.rx_dma.disable_request();
                 self.mode.rx_dma.clear_done();
@@ -1013,7 +1013,7 @@ impl<'d> AsyncEngine for I3c<'d, Dma<'d>> {
             self.info
                 .regs()
                 .mdmactrl()
-                .modify(|w| w.set_dmatb(MdmactrlDmatb::NOT_USED));
+                .modify(|w| w.set_dmatb(MdmactrlDmatb::NotUsed));
         });
 
         self.async_start(address, bus_type, Dir::Write, 0).await?;
@@ -1065,7 +1065,7 @@ impl<'d> AsyncEngine for I3c<'d, Dma<'d>> {
                 self.info
                     .regs()
                     .mdmactrl()
-                    .modify(|w| w.set_dmatb(MdmactrlDmatb::ENABLE));
+                    .modify(|w| w.set_dmatb(MdmactrlDmatb::Enable));
 
                 // Enable DMA channel request
                 self.mode.tx_dma.enable_request();
@@ -1088,7 +1088,7 @@ impl<'d> AsyncEngine for I3c<'d, Dma<'d>> {
             self.info
                 .regs()
                 .mdmactrl()
-                .modify(|w| w.set_dmatb(MdmactrlDmatb::NOT_USED));
+                .modify(|w| w.set_dmatb(MdmactrlDmatb::NotUsed));
             unsafe {
                 self.mode.tx_dma.disable_request();
                 self.mode.tx_dma.clear_done();
@@ -1193,9 +1193,9 @@ where
             w.set_addr(address);
             w.set_rdterm(len);
             w.set_type_(bus_type.into());
-            w.set_request(Request::EMITSTARTADDR);
+            w.set_request(Request::Emitstartaddr);
             w.set_dir(dir.into());
-            w.set_ibiresp(Ibiresp::ACK);
+            w.set_ibiresp(Ibiresp::Ack);
         });
 
         self.async_wait_for_ctrldone().await?;
@@ -1209,7 +1209,7 @@ where
     /// waiting for the FIFO to become empty ensuring the command was
     /// sent.
     async fn async_stop(&self, bus_type: BusType) -> Result<(), IOError> {
-        if self.info.regs().mstatus().read().state() != State::NORMACT {
+        if self.info.regs().mstatus().read().state() != State::Normact {
             Err(IOError::InvalidRequest)
         } else {
             // NOTE: Section 41.3.2.1 states that "when sending STOP
@@ -1221,7 +1221,7 @@ where
                 .modify(|w| w.set_odstop(bus_type == BusType::I2c));
 
             self.info.regs().mctrl().write(|w| {
-                w.set_request(Request::EMITSTOP);
+                w.set_request(Request::Emitstop);
                 w.set_type_(bus_type.into());
             });
             self.async_wait_for_ctrldone().await?;
@@ -1254,7 +1254,7 @@ where
         self.status()?;
 
         // Only proceed if the bus is in SLVREQ state.
-        if self.info.regs().mstatus().read().state() != State::SLVREQ {
+        if self.info.regs().mstatus().read().state() != State::Slvreq {
             return Err(IOError::Other);
         }
 
@@ -1263,8 +1263,8 @@ where
 
         // Step 3: Issue AUTO_IBI with ACK — hardware handles the IBI protocol handshake.
         self.info.regs().mctrl().write(|w| {
-            w.set_request(Request::AUTOIBI);
-            w.set_ibiresp(Ibiresp::ACK);
+            w.set_request(Request::Autoibi);
+            w.set_ibiresp(Ibiresp::Ack);
         });
 
         // Step 4: Wait for IBIWON — the IBI has been accepted and the address header received.
@@ -1289,7 +1289,7 @@ where
 
         // Step 5: For normal IBIs (not Hot-Join or Controller-Request), drain the RX FIFO payload.
         let mut payload_len = 0;
-        if ibi_type == Ibitype::IBI && !buf.is_empty() {
+        if ibi_type == Ibitype::Ibi && !buf.is_empty() {
             'read: for byte in buf.iter_mut() {
                 loop {
                     // Drain available RX FIFO bytes.

--- a/embassy-mcxa/src/lpuart/bbq.rs
+++ b/embassy-mcxa/src/lpuart/bbq.rs
@@ -121,10 +121,10 @@ impl Default for BbqConfig {
         Self {
             baudrate_bps: 115_200u32,
             parity_mode: None,
-            data_bits_count: DataBits::DATA8,
-            msb_first: MsbFirst::LSB_FIRST,
-            stop_bits_count: StopBits::ONE,
-            rx_idle_config: IdleConfig::IDLE_1,
+            data_bits_count: DataBits::Data8,
+            msb_first: MsbFirst::LsbFirst,
+            stop_bits_count: StopBits::One,
+            rx_idle_config: IdleConfig::Idle1,
             power: PoweredClock::AlwaysEnabled,
             source: LpuartClockSel::FroLfDiv,
             div: Div4::no_div(),
@@ -1318,7 +1318,7 @@ impl BbqState {
         // immediately retrigger an interrupt.
         //
         // TODO: I'm not sure this actually ever happens, this is a defensive check
-        while info.regs.stat().read().tc() == Tc::COMPLETE {}
+        while info.regs.stat().read().tc() == Tc::Complete {}
 
         true
     }
@@ -1515,7 +1515,7 @@ unsafe fn handler(info: &'static Info, state: &'static BbqState) {
         // try to do this a bit earlier if the DMA completes but we haven't yet
         // drained the TX fifo yet.
         let txie_set = ctrl.tcie();
-        let tc_complete = regs.stat().read().tc() == Tc::COMPLETE;
+        let tc_complete = regs.stat().read().tc() == Tc::Complete;
         let txgr_present = (tx_state & STATE_TXGR_ACTIVE) != 0;
 
         let tx_did_finish = txie_set && tc_complete && txgr_present;

--- a/embassy-mcxa/src/lpuart/blocking.rs
+++ b/embassy-mcxa/src/lpuart/blocking.rs
@@ -139,12 +139,12 @@ impl<'a> LpuartTx<'a, Blocking> {
     }
 
     fn blocking_write_byte(&mut self, byte: u8) -> Result<(), Error> {
-        while self.info.regs().stat().read().tdre() == Tdre::TXDATA {}
+        while self.info.regs().stat().read().tdre() == Tdre::Txdata {}
         self.write_byte_internal(byte)
     }
 
     fn write_byte(&mut self, byte: u8) -> Result<(), Error> {
-        if self.info.regs().stat().read().tdre() == Tdre::TXDATA {
+        if self.info.regs().stat().read().tdre() == Tdre::Txdata {
             Err(Error::TxFifoFull)
         } else {
             self.write_byte_internal(byte)
@@ -180,7 +180,7 @@ impl<'a> LpuartTx<'a, Blocking> {
         }
 
         // Wait for last character to shift out
-        while self.info.regs().stat().read().tc() == Tc::ACTIVE {
+        while self.info.regs().stat().read().tc() == Tc::Active {
             // Wait for transmission to complete
         }
 
@@ -195,7 +195,7 @@ impl<'a> LpuartTx<'a, Blocking> {
         }
 
         // Check if transmission is complete
-        if self.info.regs().stat().read().tc() == Tc::ACTIVE {
+        if self.info.regs().stat().read().tc() == Tc::Active {
             return Err(Error::TxBusy);
         }
 

--- a/embassy-mcxa/src/lpuart/buffered.rs
+++ b/embassy-mcxa/src/lpuart/buffered.rs
@@ -314,7 +314,7 @@ impl<'a> LpuartTx<'a, Buffered> {
             .wait_for(|| {
                 let tx_empty = self.state.tx_buf.is_empty();
                 let fifo_empty = self.info.regs().water().read().txcount() == 0;
-                let tc_complete = self.info.regs().stat().read().tc() == Tc::COMPLETE;
+                let tc_complete = self.info.regs().stat().read().tc() == Tc::Complete;
                 tx_empty && fifo_empty && tc_complete
             })
             .await?)
@@ -577,7 +577,7 @@ impl<T: Instance> crate::interrupt::typelevel::Handler<T::Interrupt> for Buffere
                 // tx fifo size is 2^param.txfifo, we want to pop enough to fill
                 // the fifo, minus whatever is in there now.
                 (1 << param.txfifo()) - regs.water().read().txcount()
-            } else if regs.stat().read().tdre() != Tdre::TXDATA {
+            } else if regs.stat().read().tdre() != Tdre::Txdata {
                 1
             } else {
                 0
@@ -611,7 +611,7 @@ impl<T: Instance> crate::interrupt::typelevel::Handler<T::Interrupt> for Buffere
         }
 
         // Handle transmission complete
-        if ctrl.tcie() && regs.stat().read().tc() == Tc::COMPLETE {
+        if ctrl.tcie() && regs.stat().read().tc() == Tc::Complete {
             T::PERF_INT_WAKE_INCR();
             state.tx_waker.wake();
 

--- a/embassy-mcxa/src/lpuart/dma.rs
+++ b/embassy-mcxa/src/lpuart/dma.rs
@@ -205,7 +205,7 @@ impl<'a> LpuartTx<'a, Dma<'a>> {
     /// Blocking write (fallback when DMA is not needed)
     pub fn blocking_write(&mut self, buf: &[u8]) -> Result<(), Error> {
         for &byte in buf {
-            while self.info.regs().stat().read().tdre() == Tdre::TXDATA {}
+            while self.info.regs().stat().read().tdre() == Tdre::Txdata {}
             self.info.regs().data().write(|w| w.0 = byte as u32);
         }
         Ok(())
@@ -214,7 +214,7 @@ impl<'a> LpuartTx<'a, Dma<'a>> {
     /// Flush TX blocking
     pub fn blocking_flush(&mut self) -> Result<(), Error> {
         while self.info.regs().water().read().txcount() != 0 {}
-        while self.info.regs().stat().read().tc() == Tc::ACTIVE {}
+        while self.info.regs().stat().read().tc() == Tc::Active {}
         Ok(())
     }
 }

--- a/embassy-mcxa/src/lpuart/mod.rs
+++ b/embassy-mcxa/src/lpuart/mod.rs
@@ -183,8 +183,8 @@ impl_instance!(0; 1; 2; 3; 4; 5);
 /// Perform software reset on the LPUART peripheral
 fn perform_software_reset(info: &'static Info) {
     // Software reset - set and clear RST bit (Global register)
-    info.regs().global().write(|w| w.set_rst(Rst::RESET));
-    info.regs().global().write(|w| w.set_rst(Rst::NO_EFFECT));
+    info.regs().global().write(|w| w.set_rst(Rst::Reset));
+    info.regs().global().write(|w| w.set_rst(Rst::NoEffect));
 }
 
 /// Disable both transmitter and receiver
@@ -240,18 +240,18 @@ fn configure_control_settings(info: &'static Info, config: &Config) {
         // gating is used, or if the device never goes to deep sleep at all (e.g.
         // in WfeUngated configuration). For now, let's not touch this unless we
         // actually need to, e.g. *forcing* the lpuart to sleep!
-        w.set_dozeen(Dozeen::ENABLED);
+        w.set_dozeen(Dozeen::Enabled);
 
         // Data bits configuration
         match config.data_bits_count {
-            DataBits::DATA8 => {
+            DataBits::Data8 => {
                 if config.parity_mode.is_some() {
-                    w.set_m(DataBits::DATA9); // 8 data + 1 parity = 9 bits
+                    w.set_m(DataBits::Data9); // 8 data + 1 parity = 9 bits
                 } else {
-                    w.set_m(DataBits::DATA8); // 8 data bits only
+                    w.set_m(DataBits::Data8); // 8 data bits only
                 }
             }
-            DataBits::DATA9 => w.set_m(DataBits::DATA9),
+            DataBits::Data9 => w.set_m(DataBits::Data9),
         };
 
         // Idle configuration
@@ -260,9 +260,9 @@ fn configure_control_settings(info: &'static Info, config: &Config) {
 
         // Swap TXD/RXD if configured
         if config.swap_txd_rxd {
-            w.set_swap(Swap::SWAP);
+            w.set_swap(Swap::Swap);
         } else {
-            w.set_swap(Swap::STANDARD);
+            w.set_swap(Swap::Standard);
         }
     });
 }
@@ -283,8 +283,8 @@ fn configure_fifo(info: &'static Info, config: &Config) {
 
     // Flush FIFOs
     info.regs().fifo().modify(|w| {
-        w.set_txflush(Txflush::TXFIFO_RST);
-        w.set_rxflush(Rxflush::RXFIFO_RST);
+        w.set_txflush(Txflush::TxfifoRst);
+        w.set_rxflush(Rxflush::RxfifoRst);
     });
 }
 
@@ -367,7 +367,7 @@ fn wait_for_tx_complete(info: &'static Info) {
     }
 
     // Wait for last character to shift out (TC = Transmission Complete)
-    while info.regs().stat().read().tc() == Tc::ACTIVE {
+    while info.regs().stat().read().tc() == Tc::Active {
         // Wait for transmission to complete
     }
 }
@@ -598,15 +598,15 @@ impl Default for Config {
         Self {
             baudrate_bps: 115_200u32,
             parity_mode: None,
-            data_bits_count: DataBits::DATA8,
-            msb_first: MsbFirst::LSB_FIRST,
-            stop_bits_count: StopBits::ONE,
+            data_bits_count: DataBits::Data8,
+            msb_first: MsbFirst::LsbFirst,
+            stop_bits_count: StopBits::One,
             tx_fifo_watermark: 0,
             rx_fifo_watermark: 1,
-            tx_cts_source: TxCtsSource::CTS,
-            tx_cts_config: TxCtsConfig::START,
-            rx_idle_type: IdleType::FROM_START,
-            rx_idle_config: IdleConfig::IDLE_1,
+            tx_cts_source: TxCtsSource::Cts,
+            tx_cts_config: TxCtsConfig::Start,
+            rx_idle_type: IdleType::FromStart,
+            rx_idle_config: IdleConfig::Idle1,
             swap_txd_rxd: false,
             power: PoweredClock::NormalEnabledDeepSleepDisabled,
             source: LpuartClockSel::FroLfDiv,

--- a/embassy-mcxa/src/rtc/mcxa2xx.rs
+++ b/embassy-mcxa/src/rtc/mcxa2xx.rs
@@ -7,7 +7,6 @@ use embassy_hal_internal::{Peri, PeripheralType};
 #[cfg(feature = "embedded-mcu-hal")]
 use embedded_mcu_hal::time::{Datetime, DatetimeClock, DatetimeClockError, DatetimeFields, Month};
 use maitake_sync::WaitCell;
-use nxp_pac::rtc2xx::TcrVal;
 
 use crate::clocks::{WakeGuard, with_clocks};
 use crate::interrupt::typelevel::{Handler, Interrupt};
@@ -99,17 +98,17 @@ pub struct Config {
     #[allow(dead_code)]
     supervisor_access: bool,
     compensation_interval: u8,
-    compensation_time: TcrVal,
+    compensation_time: u8,
 }
 
 impl Default for Config {
     fn default() -> Self {
         Self {
             wakeup_select: false,
-            update_mode: Um::UM_0,
+            update_mode: Um::Um0,
             supervisor_access: false,
             compensation_interval: 0,
-            compensation_time: TcrVal::TCR_0,
+            compensation_time: 0,
         }
     }
 }
@@ -280,8 +279,8 @@ impl<'a> Rtc<'a> {
     }
 
     fn set_configuration(&mut self, config: &Config) {
-        self.info.regs().cr().modify(|w| w.set_swr(Swr::SWR_1));
-        self.info.regs().cr().modify(|w| w.set_swr(Swr::SWR_0));
+        self.info.regs().cr().modify(|w| w.set_swr(Swr::Swr1));
+        self.info.regs().cr().modify(|w| w.set_swr(Swr::Swr0));
         self.info.regs().tsr().write(|w| w.0 = 1);
 
         self.info.regs().cr().modify(|w| w.set_um(config.update_mode));

--- a/embassy-mcxa/src/rtc/mcxa5xx.rs
+++ b/embassy-mcxa/src/rtc/mcxa5xx.rs
@@ -371,8 +371,8 @@ impl<'a> Rtc<'a> {
     fn set_configuration(&mut self, config: &Config) -> Result<(), SetupError> {
         self.disable_write_protect();
 
-        self.info.regs().ctrl().modify(|w| w.set_swr(Swr::ASSERTED));
-        self.info.regs().ctrl().modify(|w| w.set_swr(Swr::CLEARED));
+        self.info.regs().ctrl().modify(|w| w.set_swr(Swr::Asserted));
+        self.info.regs().ctrl().modify(|w| w.set_swr(Swr::Cleared));
 
         self.info.regs().ctrl().modify(|w| {
             w.set_clkout(config.clkout.into());

--- a/embassy-mcxa/src/spi/controller.rs
+++ b/embassy-mcxa/src/spi/controller.rs
@@ -1165,22 +1165,22 @@ impl<'d> AsyncEngine for Spi<'d, Dma<'d>> {
 /// Baud = src_hz / (prescaler.divisor() * (SCKDIV + 2))
 pub(super) fn compute_baud_params(src_hz: u32, baud_hz: u32) -> (Prescale, u8) {
     if baud_hz == 0 {
-        return (Prescale::Divideby1, 0);
+        return (Prescale::DivideBy1, 0);
     }
 
     let prescalers = [
-        Prescale::Divideby1,
-        Prescale::Divideby2,
-        Prescale::Divideby4,
-        Prescale::Divideby8,
-        Prescale::Divideby16,
-        Prescale::Divideby32,
-        Prescale::Divideby64,
-        Prescale::Divideby128,
+        Prescale::DivideBy1,
+        Prescale::DivideBy2,
+        Prescale::DivideBy4,
+        Prescale::DivideBy8,
+        Prescale::DivideBy16,
+        Prescale::DivideBy32,
+        Prescale::DivideBy64,
+        Prescale::DivideBy128,
     ];
 
     let (prescaler, div, _) = prescalers.iter().fold(
-        (Prescale::Divideby1, 0u8, u32::MAX),
+        (Prescale::DivideBy1, 0u8, u32::MAX),
         |(best_pre, best_div, best_err), &prescaler| {
             let divisor: u32 = 1 << (prescaler as u8);
             let denom = divisor.saturating_mul(baud_hz);

--- a/embassy-mcxa/src/spi/controller.rs
+++ b/embassy-mcxa/src/spi/controller.rs
@@ -183,16 +183,16 @@ impl<'d, M: IoMode> Spi<'d, M> {
         self.info.regs().cr().write(|w| {
             w.set_men(false);
             w.set_rst(true);
-            w.set_rtf(Rtf::TXFIFO_RST);
-            w.set_rrf(Rrf::RXFIFO_RST);
+            w.set_rtf(Rtf::TxfifoRst);
+            w.set_rrf(Rrf::RxfifoRst);
         });
 
         self.info.regs().cr().modify(|w| w.set_rst(false));
 
         self.info.regs().cfgr1().write(|w| {
-            w.set_master(Master::MASTER_MODE);
-            w.set_pincfg(Pincfg::SIN_IN_SOUT_OUT);
-            w.set_pcspol(Pcspol::DISCARDED);
+            w.set_master(Master::MasterMode);
+            w.set_pincfg(Pincfg::SinInSoutOut);
+            w.set_pcspol(Pcspol::Discarded);
         });
 
         self.info.regs().ccr().write(|w| {
@@ -212,18 +212,18 @@ impl<'d, M: IoMode> Spi<'d, M> {
             w.set_framesz(7);
 
             w.set_cpol(match config.mode.polarity {
-                Polarity::IdleLow => Cpol::INACTIVE_LOW,
-                Polarity::IdleHigh => Cpol::INACTIVE_HIGH,
+                Polarity::IdleLow => Cpol::InactiveLow,
+                Polarity::IdleHigh => Cpol::InactiveHigh,
             });
 
             w.set_cpha(match config.mode.phase {
-                Phase::CaptureOnFirstTransition => Cpha::CAPTURED,
-                Phase::CaptureOnSecondTransition => Cpha::CHANGED,
+                Phase::CaptureOnFirstTransition => Cpha::Captured,
+                Phase::CaptureOnSecondTransition => Cpha::Changed,
             });
 
             w.set_lsbf(match config.bit_order {
-                BitOrder::MsbFirst => Lsbf::MSB_FIRST,
-                BitOrder::LsbFirst => Lsbf::LSB_FIRST,
+                BitOrder::MsbFirst => Lsbf::MsbFirst,
+                BitOrder::LsbFirst => Lsbf::LsbFirst,
             });
 
             w.set_prescale(prescaler);
@@ -241,7 +241,7 @@ impl<'d, M: IoMode> Spi<'d, M> {
 
         if status.ref_() {
             // Empty the RX FIFO.
-            self.info.regs().cr().modify(|w| w.set_rrf(Rrf::RXFIFO_RST));
+            self.info.regs().cr().modify(|w| w.set_rrf(Rrf::RxfifoRst));
             self.info.regs().sr().write(|w| w.set_ref_(true));
             Err(IoError::ReceiveError)
         } else if status.tef() {
@@ -259,8 +259,8 @@ impl<'d, M: IoMode> Spi<'d, M> {
         }
 
         self.info.regs().tcr().modify(|w| {
-            w.set_txmsk(Txmsk::MASK);
-            w.set_rxmsk(Rxmsk::NORMAL);
+            w.set_txmsk(Txmsk::Mask);
+            w.set_rxmsk(Rxmsk::Normal);
         });
 
         for word in data {
@@ -280,8 +280,8 @@ impl<'d, M: IoMode> Spi<'d, M> {
         }
 
         self.info.regs().tcr().modify(|w| {
-            w.set_txmsk(Txmsk::NORMAL);
-            w.set_rxmsk(Rxmsk::MASK);
+            w.set_txmsk(Txmsk::Normal);
+            w.set_rxmsk(Rxmsk::Mask);
         });
 
         let fifo_size = LPSPI_FIFO_SIZE;
@@ -303,8 +303,8 @@ impl<'d, M: IoMode> Spi<'d, M> {
         }
 
         self.info.regs().tcr().modify(|w| {
-            w.set_txmsk(Txmsk::NORMAL);
-            w.set_rxmsk(Rxmsk::NORMAL);
+            w.set_txmsk(Txmsk::Normal);
+            w.set_rxmsk(Rxmsk::Normal);
         });
 
         let fifo_size = LPSPI_FIFO_SIZE;
@@ -331,8 +331,8 @@ impl<'d, M: IoMode> Spi<'d, M> {
         }
 
         self.info.regs().tcr().modify(|w| {
-            w.set_txmsk(Txmsk::NORMAL);
-            w.set_rxmsk(Rxmsk::NORMAL);
+            w.set_txmsk(Txmsk::Normal);
+            w.set_rxmsk(Rxmsk::Normal);
         });
 
         let fifo_size = LPSPI_FIFO_SIZE;
@@ -354,7 +354,7 @@ impl<'d, M: IoMode> Spi<'d, M> {
 
     /// Block execution until Spi is done.
     pub fn blocking_flush(&mut self) -> Result<(), IoError> {
-        while self.info.regs().sr().read().mbf() == Mbf::BUSY {}
+        while self.info.regs().sr().read().mbf() == Mbf::Busy {}
         self.check_status()
     }
 }
@@ -921,8 +921,8 @@ impl<'d> AsyncEngine for Spi<'d, Async> {
         }
 
         self.info.regs().tcr().modify(|w| {
-            w.set_txmsk(Txmsk::MASK);
-            w.set_rxmsk(Rxmsk::NORMAL);
+            w.set_txmsk(Txmsk::Mask);
+            w.set_rxmsk(Rxmsk::Normal);
         });
 
         for word in data {
@@ -955,8 +955,8 @@ impl<'d> AsyncEngine for Spi<'d, Async> {
         }
 
         self.info.regs().tcr().modify(|w| {
-            w.set_txmsk(Txmsk::NORMAL);
-            w.set_rxmsk(Rxmsk::MASK);
+            w.set_txmsk(Txmsk::Normal);
+            w.set_rxmsk(Rxmsk::Mask);
         });
 
         for word in data {
@@ -987,8 +987,8 @@ impl<'d> AsyncEngine for Spi<'d, Async> {
         }
 
         self.info.regs().tcr().modify(|w| {
-            w.set_txmsk(Txmsk::NORMAL);
-            w.set_rxmsk(Rxmsk::NORMAL);
+            w.set_txmsk(Txmsk::Normal);
+            w.set_rxmsk(Rxmsk::Normal);
         });
 
         // Zip will terminate whenever the first of write or read are exhausted
@@ -1033,8 +1033,8 @@ impl<'d> AsyncEngine for Spi<'d, Async> {
         }
 
         self.info.regs().tcr().modify(|w| {
-            w.set_txmsk(Txmsk::NORMAL);
-            w.set_rxmsk(Rxmsk::NORMAL);
+            w.set_txmsk(Txmsk::Normal);
+            w.set_rxmsk(Rxmsk::Normal);
         });
 
         for word in data {
@@ -1072,15 +1072,15 @@ impl<'d> AsyncEngine for Spi<'d, Dma<'d>> {
         }
 
         self.info.regs().tcr().modify(|w| {
-            w.set_txmsk(Txmsk::NORMAL);
-            w.set_rxmsk(Rxmsk::NORMAL);
+            w.set_txmsk(Txmsk::Normal);
+            w.set_rxmsk(Rxmsk::Normal);
         });
 
-        self.info.regs().cfgr1().modify(|w| w.set_outcfg(Outcfg::TRISTATED));
+        self.info.regs().cfgr1().modify(|w| w.set_outcfg(Outcfg::Tristated));
 
         let _on_drop = OnDrop::new(|| {
             self.info.regs().der().modify(|w| w.set_rdde(false));
-            self.info.regs().cfgr1().modify(|w| w.set_outcfg(Outcfg::TRISTATED));
+            self.info.regs().cfgr1().modify(|w| w.set_outcfg(Outcfg::Tristated));
         });
 
         for chunk in data.chunks_mut(DMA_MAX_TRANSFER_SIZE) {
@@ -1096,8 +1096,8 @@ impl<'d> AsyncEngine for Spi<'d, Dma<'d>> {
         }
 
         self.info.regs().tcr().modify(|w| {
-            w.set_txmsk(Txmsk::NORMAL);
-            w.set_rxmsk(Rxmsk::MASK);
+            w.set_txmsk(Txmsk::Normal);
+            w.set_rxmsk(Rxmsk::Mask);
         });
 
         let on_drop = OnDrop::new(|| {
@@ -1119,8 +1119,8 @@ impl<'d> AsyncEngine for Spi<'d, Dma<'d>> {
         }
 
         self.info.regs().tcr().modify(|w| {
-            w.set_txmsk(Txmsk::NORMAL);
-            w.set_rxmsk(Rxmsk::NORMAL);
+            w.set_txmsk(Txmsk::Normal);
+            w.set_rxmsk(Rxmsk::Normal);
         });
 
         let on_drop = OnDrop::new(|| {
@@ -1145,8 +1145,8 @@ impl<'d> AsyncEngine for Spi<'d, Dma<'d>> {
         }
 
         self.info.regs().tcr().modify(|w| {
-            w.set_txmsk(Txmsk::NORMAL);
-            w.set_rxmsk(Rxmsk::NORMAL);
+            w.set_txmsk(Txmsk::Normal);
+            w.set_rxmsk(Rxmsk::Normal);
         });
 
         for chunk in data.chunks_mut(DMA_MAX_TRANSFER_SIZE) {
@@ -1165,22 +1165,22 @@ impl<'d> AsyncEngine for Spi<'d, Dma<'d>> {
 /// Baud = src_hz / (prescaler.divisor() * (SCKDIV + 2))
 pub(super) fn compute_baud_params(src_hz: u32, baud_hz: u32) -> (Prescale, u8) {
     if baud_hz == 0 {
-        return (Prescale::DIVIDEBY1, 0);
+        return (Prescale::Divideby1, 0);
     }
 
     let prescalers = [
-        Prescale::DIVIDEBY1,
-        Prescale::DIVIDEBY2,
-        Prescale::DIVIDEBY4,
-        Prescale::DIVIDEBY8,
-        Prescale::DIVIDEBY16,
-        Prescale::DIVIDEBY32,
-        Prescale::DIVIDEBY64,
-        Prescale::DIVIDEBY128,
+        Prescale::Divideby1,
+        Prescale::Divideby2,
+        Prescale::Divideby4,
+        Prescale::Divideby8,
+        Prescale::Divideby16,
+        Prescale::Divideby32,
+        Prescale::Divideby64,
+        Prescale::Divideby128,
     ];
 
     let (prescaler, div, _) = prescalers.iter().fold(
-        (Prescale::DIVIDEBY1, 0u8, u32::MAX),
+        (Prescale::Divideby1, 0u8, u32::MAX),
         |(best_pre, best_div, best_err), &prescaler| {
             let divisor: u32 = 1 << (prescaler as u8);
             let denom = divisor.saturating_mul(baud_hz);

--- a/embassy-mcxa/src/trng.rs
+++ b/embassy-mcxa/src/trng.rs
@@ -12,7 +12,7 @@ use crate::clocks::{Gate, enable_and_reset};
 use crate::interrupt::typelevel;
 use crate::interrupt::typelevel::{Handler, Interrupt};
 use crate::pac;
-use crate::pac::trng::{IntStatus, IntStatusEntVal, TrngEntCtl};
+use crate::pac::trng::{IntStatus, TrngEntCtl};
 
 const BLOCK_SIZE: usize = 8;
 
@@ -266,7 +266,7 @@ impl<'d> Trng<'d, Async> {
 
                 let status = IntStatus(status);
 
-                if status.ent_val() == IntStatusEntVal::ENT_VAL_VALID {
+                if status.ent_val() {
                     Some(Ok(()))
                 } else if status.frq_ct_fail() {
                     Some(Err(Error::FrequencyCountFail))
@@ -551,9 +551,9 @@ pub enum OscMode {
 impl From<OscMode> for TrngEntCtl {
     fn from(value: OscMode) -> Self {
         match value {
-            OscMode::SingleOsc1 => Self::TRNG_ENT_CTL_SINGLE_OSC1,
-            OscMode::DualOscs => Self::TRNG_ENT_CTL_DUAL_OSCS,
-            OscMode::SingleOsc2 => Self::TRNG_ENT_CTL_SINGLE_OSC2,
+            OscMode::SingleOsc1 => Self::TrngEntCtlSingleOsc1,
+            OscMode::DualOscs => Self::TrngEntCtlDualOscs,
+            OscMode::SingleOsc2 => Self::TrngEntCtlSingleOsc2,
         }
     }
 }

--- a/embassy-mcxa/src/wwdt.rs
+++ b/embassy-mcxa/src/wwdt.rs
@@ -146,23 +146,23 @@ impl<'d> Watchdog<'d> {
     /// Enable the watchdog timer.
     /// Function is blocking until the watchdog is actually started.
     fn enable(&self) {
-        self.info.regs().mod_().modify(|w| w.set_wden(Wden::RUN));
+        self.info.regs().mod_().modify(|w| w.set_wden(Wden::Run));
         while self.info.regs().tc().read().count() == 0xFF {}
     }
 
     /// Set the watchdog protection mode to flexible.
     fn set_flexible_mode(&self) {
-        self.info.regs().mod_().modify(|w| w.set_wdprotect(Wdprotect::FLEXIBLE));
+        self.info.regs().mod_().modify(|w| w.set_wdprotect(Wdprotect::Flexible));
     }
 
     /// Enable interrupt mode.
     fn enable_interrupt(&self) {
-        self.info.regs().mod_().modify(|w| w.set_wdreset(Wdreset::INTERRUPT));
+        self.info.regs().mod_().modify(|w| w.set_wdreset(Wdreset::Interrupt));
     }
 
     /// Enable reset mode.
     fn enable_reset(&self) {
-        self.info.regs().mod_().modify(|w| w.set_wdreset(Wdreset::RESET));
+        self.info.regs().mod_().modify(|w| w.set_wdreset(Wdreset::Reset));
     }
 
     /// Set the timeout value in clock cycles.

--- a/examples/mcxa2xx/src/bin/adc-temperature.rs
+++ b/examples/mcxa2xx/src/bin/adc-temperature.rs
@@ -29,10 +29,10 @@ async fn main(_spawner: Spawner) {
         2,
         CommandConfig {
             chained_command: None,
-            averaging: Avgs::AVERAGE_1024,  // Max average
-            sample_time: Sts::SAMPLE_131P5, // Max sample time
+            averaging: Avgs::Average1024,  // Max average
+            sample_time: Sts::Sample131p5, // Max sample time
             compare: adc::Compare::Disabled,
-            resolution: Mode::DATA_16_BITS,
+            resolution: Mode::Data16Bits,
             wait_for_trigger: false,
         },
     )

--- a/examples/mcxa5xx/src/bin/adc-temperature.rs
+++ b/examples/mcxa5xx/src/bin/adc-temperature.rs
@@ -29,10 +29,10 @@ async fn main(_spawner: Spawner) {
         2,
         CommandConfig {
             chained_command: None,
-            averaging: Avgs::AVERAGE_1024,  // Max average
-            sample_time: Sts::SAMPLE_131P5, // Max sample time
+            averaging: Avgs::Average1024,  // Max average
+            sample_time: Sts::Sample131p5, // Max sample time
             compare: adc::Compare::Disabled,
-            resolution: Mode::DATA_16_BITS,
+            resolution: Mode::Data16Bits,
             wait_for_trigger: false,
         },
     )

--- a/tests/mcxa2xx/src/bin/adc.rs
+++ b/tests/mcxa2xx/src/bin/adc.rs
@@ -35,7 +35,7 @@ async fn main(_spawner: Spawner) {
     let commands = &[Command::new_single(
         p.P2_4,
         CommandConfig {
-            resolution: Mode::DATA_16_BITS,
+            resolution: Mode::Data16Bits,
             ..Default::default()
         },
     )];

--- a/tests/mcxa2xx/src/bin/adc_compare.rs
+++ b/tests/mcxa2xx/src/bin/adc_compare.rs
@@ -38,7 +38,7 @@ async fn main(_spawner: Spawner) {
         let commands = &[Command::new_single(
             p.P2_4.reborrow(),
             CommandConfig {
-                resolution: Mode::DATA_16_BITS,
+                resolution: Mode::Data16Bits,
                 compare: adc::Compare::StoreIf(adc::CompareFunction::GreaterThan(0x8000)),
                 ..Default::default()
             },
@@ -82,7 +82,7 @@ async fn main(_spawner: Spawner) {
         let commands = &[Command::new_single(
             p.P2_4.reborrow(),
             CommandConfig {
-                resolution: Mode::DATA_16_BITS,
+                resolution: Mode::Data16Bits,
                 compare: adc::Compare::SkipUntil(adc::CompareFunction::GreaterThan(0x8000)),
                 ..Default::default()
             },


### PR DESCRIPTION
We updated chiptool to use PascalCase for all enum variants. [nxp-pac has been updated](https://github.com/embassy-rs/nxp-pac/pull/77) to have a more clear pipeline from SVD to generated code, and uses this new chiptool version.

Hence we update the HAL to use these new PascalCase variants.