### PR TITLE
usb-host: more completeness-related changes

### DIFF
--- a/embassy-rp/src/usb/host.rs
+++ b/embassy-rp/src/usb/host.rs
@@ -705,6 +705,10 @@ impl<'d, T: Instance, E: pipe::Type, D: pipe::Direction> UsbPipe<E, D> for Chann
     fn set_timeout(&mut self, _: TimeoutConfig) {
         // Not yet implemented for RP2040.
     }
+
+    fn reset_data_toggle(&mut self) {
+        self.pid = false;
+    }
 }
 
 // TODO: channel should have reference to `allocated_pipes`

--- a/embassy-rp/src/usb/host.rs
+++ b/embassy-rp/src/usb/host.rs
@@ -759,6 +759,15 @@ impl<'d, T: Instance> UsbHostDriver for Driver<'d, T> {
             }
         })
         .await;
+
+        // Per the `UsbHostDriver` contract, drive a bus reset before
+        // reporting the attach so the device transitions from the Powered
+        // into the Default state (USB 2.0 §9.1.2). RP2040 is full-speed
+        // only, so no chirp handshake occurs and the speed observed before
+        // reset is authoritative after reset — no re-read is needed.
+        if matches!(ev, DeviceEvent::Connected(_)) {
+            self.bus_reset().await;
+        }
         ev
     }
 

--- a/embassy-stm32/src/usb/usb_host.rs
+++ b/embassy-stm32/src/usb/usb_host.rs
@@ -654,6 +654,23 @@ impl<'d, I: Instance, T: pipe::Type, D: pipe::Direction> UsbPipe<T, D> for Chann
     fn set_timeout(&mut self, _: TimeoutConfig) {
         //TODO: Implement.
     }
+
+    fn reset_data_toggle(&mut self) {
+        // On STM32 PMA USB, DTOG_RX and DTOG_TX are toggle-on-write-1: writing
+        // a 1 flips the bit, writing a 0 leaves it unchanged. To clear both
+        // to 0 (DATA0), read the current values and write them back — a
+        // currently-1 bit will toggle to 0, a currently-0 bit will be left
+        // alone. `invariant()` preserves CTR_* and clears STAT_* toggle
+        // fields; we then set the DTOG fields explicitly.
+        let epr = self.reg();
+        let current = epr.read();
+        let dtog_rx = current.dtog_rx();
+        let dtog_tx = current.dtog_tx();
+        let mut new = invariant(current);
+        new.set_dtog_rx(dtog_rx);
+        new.set_dtog_tx(dtog_tx);
+        epr.write_value(new);
+    }
 }
 
 impl<'d, I: Instance, T: pipe::Type, D: pipe::Direction> Drop for Channel<'d, I, D, T> {

--- a/embassy-usb-driver/src/host.rs
+++ b/embassy-usb-driver/src/host.rs
@@ -62,6 +62,7 @@ impl SplitInfo {
 /// Errors returned by [`UsbPipe`] operations.
 #[derive(Copy, Clone, Eq, PartialEq, Debug)]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
+#[non_exhaustive]
 pub enum PipeError {
     /// The packet is too long to fit in the buffer.
     BufferOverflow,
@@ -91,6 +92,7 @@ pub enum PipeError {
 /// Device has been attached/detached
 #[derive(Copy, Clone, Eq, PartialEq, Debug)]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
+#[non_exhaustive]
 pub enum DeviceEvent {
     /// Indicates a root-device has become attached
     Connected(Speed),
@@ -105,6 +107,7 @@ pub enum DeviceEvent {
 /// Indicates type of error of Host interface
 #[derive(Copy, Clone, Eq, PartialEq, Debug)]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
+#[non_exhaustive]
 pub enum HostError {
     /// A pipe-level transfer error occurred.
     PipeError(PipeError),

--- a/embassy-usb-driver/src/host.rs
+++ b/embassy-usb-driver/src/host.rs
@@ -234,6 +234,12 @@ pub mod pipe {
     pub trait IsInterrupt: sealed::Sealed {}
     impl IsInterrupt for Interrupt {}
 
+    /// Trait bound satisfied only by [`Bulk`] or [`Interrupt`] pipes.
+    #[diagnostic::on_unimplemented(message = "This is not a BULK or INTERRUPT pipe")]
+    pub trait IsBulkOrInterrupt: sealed::Sealed {}
+    impl IsBulkOrInterrupt for Bulk {}
+    impl IsBulkOrInterrupt for Interrupt {}
+
     /// Marker trait for the transfer direction of a pipe.
     pub trait Direction: sealed::Sealed {
         /// Returns `true` if this direction supports IN (device-to-host) transfers.
@@ -381,9 +387,7 @@ pub trait UsbPipe<T: pipe::Type, D: pipe::Direction> {
     ///   affected interfaces must be reset).
     /// - `SET_INTERFACE` succeeds (all non-control endpoints on the
     ///   affected interface must be reset).
-    ///
-    /// This method has no effect on control pipes, where the toggle is
-    /// determined by each transfer's setup/data/status stage and is
-    /// therefore not caller-managed.
-    fn reset_data_toggle(&mut self);
+    fn reset_data_toggle(&mut self)
+    where
+        T: pipe::IsBulkOrInterrupt;
 }

--- a/embassy-usb-driver/src/host.rs
+++ b/embassy-usb-driver/src/host.rs
@@ -94,8 +94,12 @@ pub enum PipeError {
 pub enum DeviceEvent {
     /// Indicates a root-device has become attached
     Connected(Speed),
+
     /// Indicates that a device has been detached
     Disconnected,
+
+    /// Root port overcurrent protection tripped.
+    Overcurrent,
 }
 
 /// Indicates type of error of Host interface
@@ -132,12 +136,18 @@ pub trait UsbHostDriver: Sized {
     /// Pipe implementation of this UsbHostDriver
     type Pipe<T: pipe::Type, D: pipe::Direction>: UsbPipe<T, D>;
 
-    /// Wait for device connect or disconnect
+    /// Wait for a root-port attach/detach.
     ///
-    /// When connected, this function must issue a bus reset before the speed is reported
+    /// On attach, the implementation must drive a bus reset to completion
+    /// before returning and must report the speed that the device settled
+    /// on after reset.
     async fn wait_for_device_event(&self) -> DeviceEvent;
 
-    /// Issue a bus reset.
+    /// Force a bus reset on the root port.
+    ///
+    /// Invalidates every pipe currently allocated against addresses other
+    /// than 0. Used to recover from a misbehaving device or to force
+    /// re-enumeration without unplug.
     async fn bus_reset(&self);
 
     /// Allocate pipe for communication with device.

--- a/embassy-usb-driver/src/host.rs
+++ b/embassy-usb-driver/src/host.rs
@@ -370,4 +370,20 @@ pub trait UsbPipe<T: pipe::Type, D: pipe::Direction> {
     fn set_timeout(&mut self, timeout: TimeoutConfig)
     where
         T: pipe::IsControl;
+
+    /// Reset the host-side data toggle on this pipe to DATA0.
+    ///
+    /// The caller must invoke this method after:
+    ///
+    /// - `CLEAR_FEATURE(ENDPOINT_HALT)` successfully clears a functional
+    ///   stall on this endpoint.
+    /// - `SET_CONFIGURATION` succeeds (all non-control endpoints on the
+    ///   affected interfaces must be reset).
+    /// - `SET_INTERFACE` succeeds (all non-control endpoints on the
+    ///   affected interface must be reset).
+    ///
+    /// This method has no effect on control pipes, where the toggle is
+    /// determined by each transfer's setup/data/status stage and is
+    /// therefore not caller-managed.
+    fn reset_data_toggle(&mut self);
 }

--- a/embassy-usb-host/src/lib.rs
+++ b/embassy-usb-host/src/lib.rs
@@ -132,6 +132,12 @@ impl<D: UsbHostDriver> UsbHost<D> {
                     // Spurious disconnect before connect; try again.
                     continue;
                 }
+                _ => {
+                    // Overcurrent, remote-wakeup, or any future variant that
+                    // isn't a fresh connection: keep waiting for a real
+                    // Connected event.
+                    continue;
+                }
             }
         }
     }

--- a/embassy-usb-synopsys-otg/src/host.rs
+++ b/embassy-usb-synopsys-otg/src/host.rs
@@ -467,10 +467,13 @@ impl<'d, const CH_COUNT: usize> UsbHostDriver for OtgHost<'d, CH_COUNT> {
                 state.port_waker.register(cx.waker());
 
                 let ev = state.port_event.load(Ordering::Acquire);
-                if ev & (PORT_EVENT_DISCONNECTED | PORT_EVENT_OVERCURRENT) != 0 {
-                    state
-                        .port_event
-                        .fetch_and(!(PORT_EVENT_DISCONNECTED | PORT_EVENT_OVERCURRENT), Ordering::AcqRel);
+                if ev & PORT_EVENT_OVERCURRENT != 0 {
+                    state.port_event.fetch_and(!PORT_EVENT_OVERCURRENT, Ordering::AcqRel);
+                    return Poll::Ready(PORT_EVENT_OVERCURRENT);
+                }
+
+                if ev & PORT_EVENT_DISCONNECTED != 0 {
+                    state.port_event.fetch_and(!PORT_EVENT_DISCONNECTED, Ordering::AcqRel);
                     // Wake all channels to signal disconnection
                     for ch in &state.channels {
                         if ch.allocated.load(Ordering::Relaxed) {
@@ -478,6 +481,7 @@ impl<'d, const CH_COUNT: usize> UsbHostDriver for OtgHost<'d, CH_COUNT> {
                             ch.waker.wake();
                         }
                     }
+
                     return Poll::Ready(PORT_EVENT_DISCONNECTED);
                 }
                 if ev & PORT_EVENT_CONNECTED != 0 {
@@ -501,10 +505,12 @@ impl<'d, const CH_COUNT: usize> UsbHostDriver for OtgHost<'d, CH_COUNT> {
                 state.port_waker.register(cx.waker());
 
                 let ev = state.port_event.load(Ordering::Acquire);
-                if ev & (PORT_EVENT_DISCONNECTED | PORT_EVENT_OVERCURRENT) != 0 {
-                    state
-                        .port_event
-                        .fetch_and(!(PORT_EVENT_DISCONNECTED | PORT_EVENT_OVERCURRENT), Ordering::AcqRel);
+                if ev & PORT_EVENT_OVERCURRENT != 0 {
+                    state.port_event.fetch_and(!PORT_EVENT_OVERCURRENT, Ordering::AcqRel);
+                    return Poll::Ready(PORT_EVENT_OVERCURRENT);
+                }
+                if ev & PORT_EVENT_DISCONNECTED != 0 {
+                    state.port_event.fetch_and(!PORT_EVENT_DISCONNECTED, Ordering::AcqRel);
                     for ch in &state.channels {
                         if ch.allocated.load(Ordering::Relaxed) {
                             ch.result.store(CH_RESULT_HALTED, Ordering::Release);
@@ -549,6 +555,10 @@ impl<'d, const CH_COUNT: usize> UsbHostDriver for OtgHost<'d, CH_COUNT> {
 
                     return DeviceEvent::Connected(speed);
                 }
+                PORT_EVENT_OVERCURRENT => {
+                    return DeviceEvent::Overcurrent;
+                }
+
                 _ => {
                     // Disconnected while waiting for enable; loop and wait again.
                     return DeviceEvent::Disconnected;

--- a/embassy-usb-synopsys-otg/src/host.rs
+++ b/embassy-usb-synopsys-otg/src/host.rs
@@ -1118,6 +1118,10 @@ impl<T: pipe::Type, D: pipe::Direction, const CH_COUNT: usize> UsbPipe<T, D> for
     fn set_timeout(&mut self, _timeout: embassy_usb_driver::host::TimeoutConfig) {
         // Hardware timeouts; no-op
     }
+
+    fn reset_data_toggle(&mut self) {
+        self.data_toggle = false;
+    }
 }
 
 /// Dpid extension for SETUP token.


### PR DESCRIPTION
- enums are non_exhaustive where they are expected to grow
- added `reset_data_toggle`
- added DeviceEvent::Overcurrent, handled in synopsys-otg
- updated embassy-rp to respect documented behaviour in driver trait impl

Claude wants to implement supend/resume/remote wakeup but I think it can be a later non-breaking addition using a subtrait (`SuspendResume: UsbHostDriver`) in case not every host IP supports it. It is also more of a low-power concern than a strictly required feature. Other missing features can also be implemented this way, whether or not they really make sense as an optional capability.

Claude also has some problems around missing queue-based isochronous APIs but I don't know if any changes are needed here, considering we already have an UAC class driver. Claude is wrong in its reasoning claiming that adding iso-specific methods to the UsbPipe would be an additive change, but oh well, one can't expect everything to be correct.