### PR TITLE
feat(stm32/rcc): implement CPU reboot reason read

### DIFF
--- a/embassy-stm32/src/rcc/h.rs
+++ b/embassy-stm32/src/rcc/h.rs
@@ -1355,8 +1355,8 @@ pub enum ResetReason {
 impl ResetReason {
     /// Read and clear the reason the core thinks the reset occurred.
     pub fn read_clear() -> ResetReason {
-        let rsr = RCC.c1_rsr().read();
-        RCC.c1_rsr().modify(|w| w.set_rmvf(true));
+        let rsr = RCC.rcc_rsr().read();
+        RCC.rcc_rsr().modify(|w| w.set_rmvf(true));
 
         // Refer to Reference Manual (RM0433, Rev 8, Table 56).
         match (
@@ -1369,7 +1369,7 @@ impl ResetReason {
             rsr.borrstf(),
             rsr.d2rstf(),
             rsr.d1rstf(),
-            rsr.cpurstf()
+            rsr.cpurstf(),
         ) {
             (false, false, false, false, true, true, true, true, true, true) => ResetReason::PowerOnReset,
             (false, false, false, false, false, true, false, false, false, true) => ResetReason::PinReset,
@@ -1381,7 +1381,7 @@ impl ResetReason {
             (false, false, false, false, false, false, false, false, true, false) => ResetReason::D1ExitStandby,
             (false, false, false, false, false, false, false, true, false, false) => ResetReason::D2ExitStandby,
             (true, false, false, false, false, true, false, false, false, true) => ResetReason::D1ErroneousStandby,
-            _ => ResetReason::Unknown(rsr.0)
+            _ => ResetReason::Unknown(rsr.0),
         }
     }
 }

--- a/embassy-stm32/src/rcc/h.rs
+++ b/embassy-stm32/src/rcc/h.rs
@@ -1334,7 +1334,7 @@ pub fn set_and_enable_comp_vals(cv: &CompVals) {
 ///
 /// The STM32 RCC peripheral implements the ability for the CPU to detect why a reset
 /// occurred.
-#[cfg(all(stm32h7, not(stm32h7rs)))]
+#[cfg(rcc_h7rm0433)]
 #[derive(Debug, Copy, Clone)]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub enum ResetReason {
@@ -1351,12 +1351,12 @@ pub enum ResetReason {
     Unknown(u32),
 }
 
-#[cfg(all(stm32h7, not(stm32h7rs)))]
+#[cfg(rcc_h7rm0433)]
 impl ResetReason {
     /// Read and clear the reason the core thinks the reset occurred.
     pub fn read_clear() -> ResetReason {
-        let rsr = RCC.rcc_rsr().read();
-        RCC.rcc_rsr().modify(|w| w.set_rmvf(true));
+        let rsr = RCC.rsr().read();
+        RCC.rsr().modify(|w| w.set_rmvf(true));
 
         // Refer to Reference Manual (RM0433, Rev 8, Table 56).
         match (

--- a/embassy-stm32/src/rcc/h.rs
+++ b/embassy-stm32/src/rcc/h.rs
@@ -1329,3 +1329,59 @@ pub fn set_and_enable_comp_vals(cv: &CompVals) {
         w.set_comp_codesel(true);
     });
 }
+
+/// CPU Reset Sources
+///
+/// The STM32 RCC peripheral implements the ability for the CPU to detect why a reset
+/// occurred.
+#[cfg(all(stm32h7, not(stm32h7rs)))]
+#[derive(Debug, Copy, Clone)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+pub enum ResetReason {
+    PowerOnReset,
+    PinReset,
+    BrownoutReset,
+    SysReset,
+    CpuReset,
+    Wwdg1Reset,
+    Iwdg1Reset,
+    D1ExitStandby,
+    D2ExitStandby,
+    D1ErroneousStandby,
+    Unknown(u32),
+}
+
+#[cfg(all(stm32h7, not(stm32h7rs)))]
+impl ResetReason {
+    /// Read and clear the reason the core thinks the reset occurred.
+    pub fn read_clear() -> ResetReason {
+        let rsr = RCC.c1_rsr().read();
+        RCC.c1_rsr().modify(|w| w.set_rmvf(true));
+
+        // Refer to Reference Manual (RM0433, Rev 8, Table 56).
+        match (
+            rsr.lpwrrstf(),
+            rsr.wwdg1rstf(),
+            rsr.iwdg1rstf(),
+            rsr.sftrstf(),
+            rsr.porrstf(),
+            rsr.pinrstf(),
+            rsr.borrstf(),
+            rsr.d2rstf(),
+            rsr.d1rstf(),
+            rsr.cpurstf()
+        ) {
+            (false, false, false, false, true, true, true, true, true, true) => ResetReason::PowerOnReset,
+            (false, false, false, false, false, true, false, false, false, true) => ResetReason::PinReset,
+            (false, false, false, false, false, true, true, false, false, true) => ResetReason::BrownoutReset,
+            (false, false, false, true, false, true, false, false, false, true) => ResetReason::SysReset,
+            (false, false, false, false, false, false, false, false, false, true) => ResetReason::CpuReset,
+            (false, true, false, false, false, true, false, false, false, true) => ResetReason::Wwdg1Reset,
+            (false, false, true, false, false, true, false, false, false, true) => ResetReason::Iwdg1Reset,
+            (false, false, false, false, false, false, false, false, true, false) => ResetReason::D1ExitStandby,
+            (false, false, false, false, false, false, false, true, false, false) => ResetReason::D2ExitStandby,
+            (true, false, false, false, false, true, false, false, false, true) => ResetReason::D1ErroneousStandby,
+            _ => ResetReason::Unknown(rsr.0)
+        }
+    }
+}


### PR DESCRIPTION
This only works for STM32H74x/75x (chips covered under RM0433). Let me know if I am using the features incorrectly!

For testing, I am not sure the best way to make a HitL test because it involves resetting the CPU, which would cause the debug probe to complain... Open to other ideas as well!

Reference:
<img width="1328" height="1326" alt="Screenshot from Reference Manual 0433 covering the logic for determining reboot reason" src="https://github.com/user-attachments/assets/9441204d-9f23-4330-8785-2ab1bcb78978" />

Link to stm32h7xx-hal's implementation, which is similar: https://docs.rs/stm32h7xx-hal/latest/src/stm32h7xx_hal/rcc/reset_reason.rs.html
