### PR TITLE
stm32/rtc: fix stop_wakeup_alarm clearing unrelated EXTI pending bits

### DIFF
--- a/embassy-stm32/src/rtc/low_power.rs
+++ b/embassy-stm32/src/rtc/low_power.rs
@@ -94,7 +94,7 @@ impl Rtc {
                 #[cfg(any(exti_v1, stm32h7, stm32wb))]
                 crate::pac::EXTI
                     .pr(0)
-                    .modify(|w| w.set_line(RTC::EXTI_WAKEUP_LINE, true));
+                    .write(|w| w.set_line(RTC::EXTI_WAKEUP_LINE, true));
 
                 <RTC as crate::rtc::SealedInstance>::WakeupInterrupt::unpend();
             });


### PR DESCRIPTION
EXTI_PR is write-1-to-clear. Using `modify` reads back all currently-pending lines and writes them back, clearing every pending line instead of just the RTC wakeup line. This drops EXTI edges that wake the MCU from Stop concurrently with the RTC wakeup alarm. 

Switch to `write`, matching how comp.rs and exti/low_level.rs already clear PR.

Tested on `stm32l072`