### PR TITLE
usb-host: Make bus-related operations take `&mut self`

### DIFF
--- a/embassy-rp/src/usb/host.rs
+++ b/embassy-rp/src/usb/host.rs
@@ -725,7 +725,7 @@ impl<'d, T: Instance, E: pipe::Type, D: pipe::Direction> UsbPipe<E, D> for Chann
 impl<'d, T: Instance> UsbHostDriver for Driver<'d, T> {
     type Pipe<E: pipe::Type, D: pipe::Direction> = Channel<'d, T, E, D>;
 
-    async fn wait_for_device_event(&self) -> DeviceEvent {
+    async fn wait_for_device_event(&mut self) -> DeviceEvent {
         let is_connected = |status: u8| match status {
             0b01 | 0b10 => true,
             _ => false,
@@ -771,7 +771,7 @@ impl<'d, T: Instance> UsbHostDriver for Driver<'d, T> {
         ev
     }
 
-    async fn bus_reset(&self) {
+    async fn bus_reset(&mut self) {
         T::regs().sie_ctrl().modify(|w| {
             w.set_reset_bus(true);
         });

--- a/embassy-stm32/src/usb/otg.rs
+++ b/embassy-stm32/src/usb/otg.rs
@@ -728,11 +728,11 @@ mod host_impl {
         type Pipe<Ty: embassy_usb_driver::host::pipe::Type, D: embassy_usb_driver::host::pipe::Direction> =
             <OtgHostDriver<'d, MAX_HOST_CH_COUNT> as embassy_usb_driver::host::UsbHostDriver>::Pipe<Ty, D>;
 
-        async fn wait_for_device_event(&self) -> embassy_usb_driver::host::DeviceEvent {
+        async fn wait_for_device_event(&mut self) -> embassy_usb_driver::host::DeviceEvent {
             self.inner.wait_for_device_event().await
         }
 
-        async fn bus_reset(&self) {
+        async fn bus_reset(&mut self) {
             self.inner.bus_reset().await
         }
 

--- a/embassy-stm32/src/usb/usb_host.rs
+++ b/embassy-stm32/src/usb/usb_host.rs
@@ -752,7 +752,7 @@ impl<'d, I: Instance> UsbHostDriver for UsbHost<'d, I> {
         Ok(channel)
     }
 
-    async fn bus_reset(&self) {
+    async fn bus_reset(&mut self) {
         let regs = I::regs();
 
         trace!("Bus reset");
@@ -770,7 +770,7 @@ impl<'d, I: Instance> UsbHostDriver for UsbHost<'d, I> {
         });
     }
 
-    async fn wait_for_device_event(&self) -> embassy_usb_driver::host::DeviceEvent {
+    async fn wait_for_device_event(&mut self) -> embassy_usb_driver::host::DeviceEvent {
         // TODO: which event do we expect?
         self.wait_for_device_connect().await
     }

--- a/embassy-usb-driver/src/host.rs
+++ b/embassy-usb-driver/src/host.rs
@@ -144,14 +144,14 @@ pub trait UsbHostDriver: Sized {
     /// On attach, the implementation must drive a bus reset to completion
     /// before returning and must report the speed that the device settled
     /// on after reset.
-    async fn wait_for_device_event(&self) -> DeviceEvent;
+    async fn wait_for_device_event(&mut self) -> DeviceEvent;
 
     /// Force a bus reset on the root port.
     ///
     /// Invalidates every pipe currently allocated against addresses other
     /// than 0. Used to recover from a misbehaving device or to force
     /// re-enumeration without unplug.
-    async fn bus_reset(&self);
+    async fn bus_reset(&mut self);
 
     /// Allocate pipe for communication with device.
     ///

--- a/embassy-usb-synopsys-otg/src/host.rs
+++ b/embassy-usb-synopsys-otg/src/host.rs
@@ -452,7 +452,7 @@ impl<'d, const CH_COUNT: usize> OtgHost<'d, CH_COUNT> {
 impl<'d, const CH_COUNT: usize> UsbHostDriver for OtgHost<'d, CH_COUNT> {
     type Pipe<T: pipe::Type, D: pipe::Direction> = Channel<T, D, CH_COUNT>;
 
-    async fn wait_for_device_event(&self) -> DeviceEvent {
+    async fn wait_for_device_event(&mut self) -> DeviceEvent {
         // Lazily initialize the host hardware on first call.
         if !self.instance.state.inited.load(Ordering::Acquire) {
             self.configure_as_host().await;
@@ -567,7 +567,7 @@ impl<'d, const CH_COUNT: usize> UsbHostDriver for OtgHost<'d, CH_COUNT> {
         }
     }
 
-    async fn bus_reset(&self) {
+    async fn bus_reset(&mut self) {
         let r = self.instance.regs;
         let ch_count = self.instance.channel_count.min(CH_COUNT);
 


### PR DESCRIPTION
These really shouldn't be possible to be called concurrently.