### PR TITLE
embassy-nrf: clear events_lfclkstarted after init spin-wait

### DIFF
--- a/embassy-nrf/src/lib.rs
+++ b/embassy-nrf/src/lib.rs
@@ -1208,6 +1208,11 @@ pub fn init(config: config::Config) -> Peripherals {
     r.events_lfclkstarted().write_value(0);
     r.tasks_lfclkstart().write_value(1);
     while r.events_lfclkstarted().read() == 0 {}
+    // Clear the event after consuming it so downstream peripherals (e.g. MPSL)
+    // that also wait on LFCLKSTARTED see a fresh event rather than the stale one
+    // left by this init path. The anomaly-140 workaround path above already does
+    // this correctly; align the main path to match.
+    r.events_lfclkstarted().write_value(0);
 
     #[cfg(not(any(feature = "_nrf5340", feature = "_nrf91", feature = "_nrf54l")))]
     {


### PR DESCRIPTION
## Problem

In `embassy_nrf::init()`, the main LFCLK start path clears the `events_lfclkstarted` event before issuing `tasks_lfclkstart`, waits for the event to fire, but **never clears it afterward**:

```rust
// Start LFCLK.
r.events_lfclkstarted().write_value(0);
r.tasks_lfclkstart().write_value(1);
while r.events_lfclkstarted().read() == 0 {}
// ← event left SET here
```

Any downstream peripheral that also spin-waits on `LFCLKSTARTED` will see the stale event and return immediately — or, if it is configured for a *different* LF source, it will switch sources, never see the fresh event fire, and hang indefinitely.

## Discovery

We were building a BLE peripheral on nRF54L15-DK using `embassy-nrf` + `nrf-sdc`/MPSL. The firmware hung silently on every boot — no panic, no LED activity, no RTT output. No error was returned from any init call.

Initial suspicion was the onboard J-Link OB debugger or probe-rs interaction. The actual root cause turned out to be this stale event: `embassy_nrf::init()` consumed `LFCLKSTARTED` and left it set, so when MPSL called `TASKS_LFCLKSTART` and waited for `LFCLKSTARTED`, it either saw the stale event and proceeded before its oscillator was stable, or — in the same-source configuration — waited forever for an event that would never fire again.

The hang is invisible without a custom panic handler using raw register writes (the embassy runtime and heap are both uninitialised at the point of failure). We diagnosed it by adding LED blink checkpoints before and after each init call.

This will silently break any `embassy-nrf` user who initialises a second peripheral that waits on `LFCLKSTARTED` — most likely MPSL/nrf-sdc users on nRF54L15, but potentially others.

## Observed failure modes

**Different-source (e.g. `LfclkSource::Synthesized` + `MPSL_CLOCK_LF_SRC_RC`):**

MPSL switches to RC and waits for `LFCLKSTARTED`. The hardware fires a fresh event on the source switch — but the register is already SET from embassy init. MPSL sees it immediately and proceeds before the RC oscillator is stable, causing `mpsl_init()` to hang or fault.

**Same-source (e.g. `LfclkSource::ExternalXtal` + `MPSL_CLOCK_LF_SRC_XTAL`):**

MPSL waits for an event on a source that embassy already started. The event already fired and was consumed. MPSL waits forever — hard hang at `mpsl_init()`.

## Fix

Add one line after the spin-wait to clear the event before returning:

```rust
r.events_lfclkstarted().write_value(0);
r.tasks_lfclkstart().write_value(1);
while r.events_lfclkstarted().read() == 0 {}
r.events_lfclkstarted().write_value(0); // clear after consuming
```

## Precedent in this file

The anomaly-140 workaround path a few lines above **already does this correctly** — it clears the event after its own spin-wait. This patch aligns the main path to match.

## Testing

Verified on nRF54L15-DK: firmware with this patch applied passes through `embassy_nrf::init()` and `MultiprotocolServiceLayer::new()` without hanging. BLE advertising starts successfully.

Without the patch, the firmware hangs silently at MPSL init — the only diagnostic is an SOS blink pattern from a panic handler using raw register writes to bypass the uninitialised runtime.
