### PR TITLE
ETQU: Make generic-queues replace integrated timers by default

### DIFF
--- a/embassy-time-queue-utils/CHANGELOG.md
+++ b/embassy-time-queue-utils/CHANGELOG.md
@@ -8,6 +8,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 <!-- next-header -->
 ## Unreleased - ReleaseDate
 
+- By default, enabling a `generic-queue-*` feature disables the integrated timers. Integrated timers
+  can be enabled alongside the generic queue by using the `integrated-timers` feature.
+
 ## 0.3.1 - 2026-04-16
 
 - Fixed an issue where never-ending timers were not correctly removed from the timer queue

--- a/embassy-time-queue-utils/Cargo.toml
+++ b/embassy-time-queue-utils/Cargo.toml
@@ -28,16 +28,23 @@ embassy-executor-timer-queue = { version = "0.1", path = "../embassy-executor-ti
 #! ### Generic Queue
 
 #! By default this crate uses a timer queue implementation that is faster but depends on `embassy-executor`.
-#! It will panic if you try to await any timer when using another executor.
-#! 
+#! It will fail to build if you try to use it without an embassy executor in the project.
+#!
 #! Alternatively, you can choose to use a "generic" timer queue implementation that works on any executor.
-#! To enable it, enable any of the features below.
-#! 
+#! To enable it, enable any of the `generic-queue-*` features below. Note that these features by themselves
+#! replace the integrated queue implementation.
+#!
 #! The features also set how many timers are used for the generic queue. At most one
 #! `generic-queue-*` feature can be enabled. If none is enabled, a default of 64 timers is used.
 #!
-#! When using embassy-time-queue-driver from libraries, you should *not* enable any `generic-queue-*` feature, to allow the
-#! end user to pick.
+#! If both options are enabled, the integrated queue implementation will be used by default as the
+#! `Queue` implementation. Both implementations will be separately available under their own modules.
+#!
+#! When using embassy-time-queue-utils from libraries, you should *not* enable any `generic-queue-*`
+#! feature, to allow the end user to pick.
+
+## Enable the integrated queue implementation _even when generic queues are also enabled_.
+integrated-timers = []
 
 ## Generic Queue with 8 timers
 generic-queue-8 = ["_generic-queue"]

--- a/embassy-time-queue-utils/src/lib.rs
+++ b/embassy-time-queue-utils/src/lib.rs
@@ -5,11 +5,16 @@
 use core::task::Waker;
 
 pub mod queue_generic;
+
+// Not explicitly enabled - acts as default, but cannot be relied upon as an implementation detail.
+#[cfg(all(not(feature = "integrated-timers"), not(feature = "_generic-queue")))]
+mod queue_integrated;
+#[cfg(feature = "integrated-timers")]
 pub mod queue_integrated;
 
-#[cfg(feature = "_generic-queue")]
+#[cfg(all(not(feature = "integrated-timers"), feature = "_generic-queue"))]
 type QueueImpl = queue_generic::Queue;
-#[cfg(not(feature = "_generic-queue"))]
+#[cfg(any(feature = "integrated-timers", not(feature = "_generic-queue")))]
 type QueueImpl = queue_integrated::Queue;
 
 /// The default timer queue, configured by the crate's features.


### PR DESCRIPTION
This turns a non-additive set of cargo features into even more of a mess, but I don't have a better idea short of dropping this crate altogether. Fixes #5924 and 0.3.1 should be yanked.