### PR TITLE
embassy-imxrt: migrate from svd2rust PACs to nxp-pac

### DIFF
--- a/embassy-imxrt/Cargo.toml
+++ b/embassy-imxrt/Cargo.toml
@@ -33,12 +33,11 @@ default = ["rt"]
 
 ## Cortex-M runtime (enabled by default)
 rt = [
-    "mimxrt685s-pac?/rt",
-    "mimxrt633s-pac?/rt",
+    "nxp-pac?/rt",
 ]
 
 ## Enable defmt
-defmt = ["dep:defmt", "embassy-hal-internal/defmt", "embassy-sync/defmt", "mimxrt685s-pac?/defmt", "mimxrt633s-pac?/defmt"]
+defmt = ["dep:defmt", "embassy-hal-internal/defmt", "embassy-sync/defmt", "nxp-pac?/defmt"]
 
 ## Enable features requiring `embassy-time`
 time = ["dep:embassy-time", "embassy-embedded-hal/time"]
@@ -65,9 +64,9 @@ _espi = []
 
 #! ### Chip selection features
 ## MIMXRT685S
-mimxrt685s = ["mimxrt685s-pac", "_mimxrt685s"]
+mimxrt685s = ["nxp-pac/mimxrt685s_cm33", "_mimxrt685s"]
 ## MIMXRT633S
-mimxrt633s = ["mimxrt633s-pac", "_mimxrt633s"]
+mimxrt633s = ["nxp-pac/mimxrt685s_cm33", "_mimxrt633s"]
 
 [dependencies]
 embassy-sync = { version = "0.8.0", path = "../embassy-sync" }
@@ -104,5 +103,4 @@ document-features = "0.2.7"
 paste = "1.0"
 
 # PACs
-mimxrt685s-pac = { version = "0.5.0", optional = true, features = ["rt", "critical-section"] }
-mimxrt633s-pac = { version = "0.5.0", optional = true, features = ["rt", "critical-section"] }
+nxp-pac = { git = "https://github.com/embassy-rs/nxp-pac.git", rev = "e259e278b91e26198b179ff326fe14c467188dcb", optional = true, features = ["rt"] }

--- a/embassy-imxrt/src/chips/mimxrt633s.rs
+++ b/embassy-imxrt/src/chips/mimxrt633s.rs
@@ -1,10 +1,10 @@
-pub use mimxrt633s_pac as pac;
+pub use nxp_pac as pac;
 
 #[allow(clippy::missing_safety_doc)]
 pub mod interrupts {
     embassy_hal_internal::interrupt_mod!(
         ACMP,
-        ADC0,
+        ADC,
         CASPER,
         CTIMER0,
         CTIMER1,
@@ -13,7 +13,7 @@ pub mod interrupts {
         CTIMER4,
         DMA0,
         DMA1,
-        DMIC0,
+        DMIC,
         ESPI,
         FLEXCOMM0,
         FLEXCOMM1,
@@ -31,7 +31,7 @@ pub mod interrupts {
         HASHCRYPT,
         HWVAD0,
         HYPERVISOR,
-        I3C0,
+        I3C,
         MRT0,
         MU_A,
         OS_EVENT,
@@ -48,7 +48,7 @@ pub mod interrupts {
         PUF,
         RNG,
         RTC,
-        SCT0,
+        SCT,
         SECUREVIOLATION,
         SGPIO_INTA,
         SGPIO_INTB,

--- a/embassy-imxrt/src/chips/mimxrt685s.rs
+++ b/embassy-imxrt/src/chips/mimxrt685s.rs
@@ -1,10 +1,10 @@
-pub use mimxrt685s_pac as pac;
+pub use nxp_pac as pac;
 
 #[allow(clippy::missing_safety_doc)]
 pub mod interrupts {
     embassy_hal_internal::interrupt_mod!(
         ACMP,
-        ADC0,
+        ADC,
         CASPER,
         CTIMER0,
         CTIMER1,
@@ -13,7 +13,7 @@ pub mod interrupts {
         CTIMER4,
         DMA0,
         DMA1,
-        DMIC0,
+        DMIC,
         DSPWAKE,
         FLEXCOMM0,
         FLEXCOMM1,
@@ -31,7 +31,7 @@ pub mod interrupts {
         HASHCRYPT,
         HWVAD0,
         HYPERVISOR,
-        I3C0,
+        I3C,
         MRT0,
         MU_A,
         OS_EVENT,
@@ -48,7 +48,7 @@ pub mod interrupts {
         PUF,
         RNG,
         RTC,
-        SCT0,
+        SCT,
         SECUREVIOLATION,
         SGPIO_INTA,
         SGPIO_INTB,

--- a/embassy-imxrt/src/clocks.rs
+++ b/embassy-imxrt/src/clocks.rs
@@ -459,15 +459,15 @@ impl LposcConfig {
     /// Initializes low-power oscillator.
     fn init_lposc() {
         // Enable low power oscillator
-        // SAFETY: unsafe needed to take pointer to Sysctl0, only happens once during init
-        let sysctl0 = unsafe { crate::pac::Sysctl0::steal() };
-        sysctl0.pdruncfg0_clr().write(|w| w.lposc_pd().clr_pdruncfg0());
+        let sysctl0 = crate::pac::SYSCTL0;
+        sysctl0
+            .pdruncfg0_clr()
+            .write(|w| w.set_lposc_pd(pac::sysctl0::vals::Pdruncfg0ClrLposcPd::CLR_PDRUNCFG0));
 
         // Wait for low-power oscillator to be ready (typically 64 us)
         // Busy loop seems better here than trying to shoe-in an async delay
-        // SAFETY: unsafe needed to take pointer to Clkctl0, needed to validate HW is ready
-        let clkctl0 = unsafe { crate::pac::Clkctl0::steal() };
-        while clkctl0.lposcctl0().read().clkrdy().bit_is_clear() {}
+        let clkctl0 = crate::pac::CLKCTL0;
+        while !clkctl0.lposcctl0().read().clkrdy() {}
     }
 }
 impl ConfigurableClock for LposcConfig {
@@ -476,11 +476,12 @@ impl ConfigurableClock for LposcConfig {
         Ok(())
     }
     fn disable(&self) -> Result<(), ClockError> {
-        // SAFETY: unsafe needed to take pointer to Sysctl0, needed to power down the LPOSC HW
-        let sysctl0 = unsafe { crate::pac::Sysctl0::steal() };
-        sysctl0.pdruncfg0_set().write(|w| w.lposc_pd().set_pdruncfg0());
+        let sysctl0 = crate::pac::SYSCTL0;
+        sysctl0
+            .pdruncfg0_set()
+            .write(|w| w.set_lposc_pd(pac::sysctl0::vals::Pdruncfg0SetLposcPd::SET_PDRUNCFG0));
         // Wait until LPOSC disabled
-        while !sysctl0.pdruncfg0().read().lposc_pd().is_power_down() {}
+        while sysctl0.pdruncfg0().read().lposc_pd() != pac::sysctl0::vals::Pdruncfg0LposcPd::POWER_DOWN {}
         Ok(())
     }
     fn get_clock_rate(&self) -> Result<u32, ClockError> {
@@ -512,16 +513,18 @@ impl ConfigurableClock for LposcConfig {
 impl FfroConfig {
     /// Necessary register writes to initialize the FFRO clock
     pub fn init_ffro_clk() {
-        // SAFETY: unsafe needed to take pointer to Sysctl0, only to power up FFRO
-        let sysctl0 = unsafe { crate::pac::Sysctl0::steal() };
+        let sysctl0 = crate::pac::SYSCTL0;
 
         /* Power on FFRO (48/60MHz) */
-        sysctl0.pdruncfg0_clr().write(|w| w.ffro_pd().clr_pdruncfg0());
+        sysctl0
+            .pdruncfg0_clr()
+            .write(|w| w.set_ffro_pd(pac::sysctl0::vals::Pdruncfg0ClrFfroPd::CLR_PDRUNCFG0));
 
-        // SAFETY: unsafe needed to take pointer to Clkctl0, only to set proper ffro update mode
-        let clkctl0 = unsafe { crate::pac::Clkctl0::steal() };
+        let clkctl0 = crate::pac::CLKCTL0;
 
-        clkctl0.ffroctl1().write(|w| w.update().normal_mode());
+        clkctl0
+            .ffroctl1()
+            .write(|w| w.set_update(pac::clkctl0::vals::Update::NORMAL_MODE));
 
         // No FFRO enable/disable control in CLKCTL.
         // Delay enough for FFRO to be stable in case it was just powered on
@@ -531,18 +534,18 @@ impl FfroConfig {
 
 impl ConfigurableClock for FfroConfig {
     fn enable_and_reset(&self) -> Result<(), ClockError> {
-        // SAFETY: should be called once
         FfroConfig::init_ffro_clk();
         // default is 48 MHz
         Ok(())
     }
     fn disable(&self) -> Result<(), ClockError> {
-        // SAFETY: unsafe needed to take pointer to Sysctl0, only to power down FFRO
-        let sysctl0 = unsafe { crate::pac::Sysctl0::steal() };
-        sysctl0.pdruncfg0_set().write(|w| w.ffro_pd().set_pdruncfg0());
+        let sysctl0 = crate::pac::SYSCTL0;
+        sysctl0
+            .pdruncfg0_set()
+            .write(|w| w.set_ffro_pd(pac::sysctl0::vals::Pdruncfg0SetFfroPd::SET_PDRUNCFG0));
         delay_loop_clocks(30, 12_000_000);
         // Wait until FFRO disabled
-        while !sysctl0.pdruncfg0().read().ffro_pd().is_power_down() {}
+        while sysctl0.pdruncfg0().read().ffro_pd() != pac::sysctl0::vals::Pdruncfg0FfroPd::POWER_DOWN {}
         Ok(())
     }
     fn get_clock_rate(&self) -> Result<u32, ClockError> {
@@ -552,22 +555,32 @@ impl ConfigurableClock for FfroConfig {
         if let Ok(r) = <u32 as TryInto<FfroFreq>>::try_into(freq) {
             match r {
                 FfroFreq::Ffro48m => {
-                    // SAFETY: unsafe needed to take pointer to Clkctl0, needed to set the right HW frequency
-                    let clkctl0 = unsafe { crate::pac::Clkctl0::steal() };
-                    clkctl0.ffroctl1().write(|w| w.update().update_safe_mode());
-                    clkctl0.ffroctl0().write(|w| w.trim_range().ffro_48mhz());
-                    clkctl0.ffroctl1().write(|w| w.update().normal_mode());
+                    let clkctl0 = crate::pac::CLKCTL0;
+                    clkctl0
+                        .ffroctl1()
+                        .write(|w| w.set_update(pac::clkctl0::vals::Update::UPDATE_SAFE_MODE));
+                    clkctl0
+                        .ffroctl0()
+                        .write(|w| w.set_trim_range(pac::clkctl0::vals::TrimRange::FFRO_48MHZ));
+                    clkctl0
+                        .ffroctl1()
+                        .write(|w| w.set_update(pac::clkctl0::vals::Update::NORMAL_MODE));
 
                     self.freq
                         .store(FfroFreq::Ffro48m as u32, core::sync::atomic::Ordering::Relaxed);
                     Ok(())
                 }
                 FfroFreq::Ffro60m => {
-                    // SAFETY: unsafe needed to take pointer to Clkctl0, needed to set the right HW frequency
-                    let clkctl0 = unsafe { crate::pac::Clkctl0::steal() };
-                    clkctl0.ffroctl1().write(|w| w.update().update_safe_mode());
-                    clkctl0.ffroctl0().write(|w| w.trim_range().ffro_60mhz());
-                    clkctl0.ffroctl1().write(|w| w.update().normal_mode());
+                    let clkctl0 = crate::pac::CLKCTL0;
+                    clkctl0
+                        .ffroctl1()
+                        .write(|w| w.set_update(pac::clkctl0::vals::Update::UPDATE_SAFE_MODE));
+                    clkctl0
+                        .ffroctl0()
+                        .write(|w| w.set_trim_range(pac::clkctl0::vals::TrimRange::FFRO_60MHZ));
+                    clkctl0
+                        .ffroctl1()
+                        .write(|w| w.set_update(pac::clkctl0::vals::Update::NORMAL_MODE));
 
                     self.freq
                         .store(FfroFreq::Ffro60m as u32, core::sync::atomic::Ordering::Relaxed);
@@ -586,20 +599,22 @@ impl ConfigurableClock for FfroConfig {
 
 impl ConfigurableClock for SfroConfig {
     fn enable_and_reset(&self) -> Result<(), ClockError> {
-        // SAFETY: unsafe needed to take pointer to Sysctl0, only to power up SFRO
-        let sysctl0 = unsafe { crate::pac::Sysctl0::steal() };
-        sysctl0.pdruncfg0_clr().write(|w| w.sfro_pd().clr_pdruncfg0());
+        let sysctl0 = crate::pac::SYSCTL0;
+        sysctl0
+            .pdruncfg0_clr()
+            .write(|w| w.set_sfro_pd(pac::sysctl0::vals::Pdruncfg0ClrSfroPd::CLR_PDRUNCFG0));
         // wait until ready
-        while !sysctl0.pdruncfg0().read().sfro_pd().is_enabled() {}
+        while sysctl0.pdruncfg0().read().sfro_pd() != pac::sysctl0::vals::Pdruncfg0SfroPd::ENABLED {}
         Ok(())
     }
     fn disable(&self) -> Result<(), ClockError> {
-        // SAFETY: unsafe needed to take pointer to Sysctl0, only to power down SFRO
-        let sysctl0 = unsafe { crate::pac::Sysctl0::steal() };
-        sysctl0.pdruncfg0_set().write(|w| w.sfro_pd().set_pdruncfg0());
+        let sysctl0 = crate::pac::SYSCTL0;
+        sysctl0
+            .pdruncfg0_set()
+            .write(|w| w.set_sfro_pd(pac::sysctl0::vals::Pdruncfg0SetSfroPd::SET_PDRUNCFG0));
         delay_loop_clocks(30, 12_000_000);
         // Wait until SFRO disabled
-        while !sysctl0.pdruncfg0().read().sfro_pd().is_power_down() {}
+        while sysctl0.pdruncfg0().read().sfro_pd() != pac::sysctl0::vals::Pdruncfg0SfroPd::POWER_DOWN {}
         Ok(())
     }
     fn get_clock_rate(&self) -> Result<u32, ClockError> {
@@ -712,14 +727,14 @@ impl ConfigurableClock for MainPllClkConfig {
     }
     fn set_clock_rate(&mut self, div: u8, mult: u8, freq: u32) -> Result<(), ClockError> {
         if self.is_enabled() {
-            // SAFETY: unsafe needed to take pointers to Sysctl0 and Clkctl0
-            let clkctl0 = unsafe { crate::pac::Clkctl0::steal() };
-            let sysctl0 = unsafe { crate::pac::Sysctl0::steal() };
+            let clkctl0 = crate::pac::CLKCTL0;
+            let sysctl0 = crate::pac::SYSCTL0;
 
             // Power down pll before changes
-            sysctl0
-                .pdruncfg0_set()
-                .write(|w| w.syspllldo_pd().set_pdruncfg0().syspllana_pd().set_pdruncfg0());
+            sysctl0.pdruncfg0_set().write(|w| {
+                w.set_syspllldo_pd(pac::sysctl0::vals::Pdruncfg0SetSyspllldoPd::SET_PDRUNCFG0);
+                w.set_syspllana_pd(pac::sysctl0::vals::Pdruncfg0SetSyspllanaPd::SET_PDRUNCFG0);
+            });
 
             let desired_freq: u64 = self.freq.load(Ordering::Relaxed).into();
 
@@ -728,18 +743,22 @@ impl ConfigurableClock for MainPllClkConfig {
                     let mut base_rate;
                     match c {
                         MainPllClkSrc::ClkIn => {
-                            clkctl0.syspll0clksel().write(|w| w.sel().sysxtal_clk());
+                            clkctl0
+                                .syspll0clksel()
+                                .write(|w| w.set_sel(pac::clkctl0::vals::Syspll0clkselSel::SYSXTAL_CLK));
                             let r = self.get_clock_rate()?;
                             base_rate = r;
                         }
                         MainPllClkSrc::FFRO => {
                             delay_loop_clocks(1000, desired_freq);
-                            match clkctl0.ffroctl0().read().trim_range().is_ffro_48mhz() {
+                            match clkctl0.ffroctl0().read().trim_range() == pac::clkctl0::vals::TrimRange::FFRO_48MHZ {
                                 true => base_rate = Into::into(FfroFreq::Ffro48m),
                                 false => base_rate = Into::into(FfroFreq::Ffro60m),
                             }
                             if div == 2 {
-                                clkctl0.syspll0clksel().write(|w| w.sel().ffro_div_2());
+                                clkctl0
+                                    .syspll0clksel()
+                                    .write(|w| w.set_sel(pac::clkctl0::vals::Syspll0clkselSel::FFRO_DIV_2));
                                 delay_loop_clocks(150, desired_freq);
                                 base_rate /= 2;
                             } else {
@@ -748,77 +767,100 @@ impl ConfigurableClock for MainPllClkConfig {
                         }
                         MainPllClkSrc::SFRO => {
                             base_rate = SFRO_FREQ;
-                            clkctl0.syspll0clksel().write(|w| w.sel().sfro_clk());
+                            clkctl0
+                                .syspll0clksel()
+                                .write(|w| w.set_sel(pac::clkctl0::vals::Syspll0clkselSel::SFRO_CLK));
                         }
                     };
                     base_rate *= u32::from(mult);
                     if base_rate != freq {
                         // make sure to power syspll back up before returning the error
                         // Clear System PLL reset
-                        clkctl0.syspll0ctl0().write(|w| w.reset().normal());
+                        clkctl0
+                            .syspll0ctl0()
+                            .write(|w| w.set_reset(pac::clkctl0::vals::Reset::NORMAL));
                         // Power up SYSPLL
-                        sysctl0
-                            .pdruncfg0_clr()
-                            .write(|w| w.syspllana_pd().clr_pdruncfg0().syspllldo_pd().clr_pdruncfg0());
+                        sysctl0.pdruncfg0_clr().write(|w| {
+                            w.set_syspllana_pd(pac::sysctl0::vals::Pdruncfg0ClrSyspllanaPd::CLR_PDRUNCFG0);
+                            w.set_syspllldo_pd(pac::sysctl0::vals::Pdruncfg0ClrSyspllldoPd::CLR_PDRUNCFG0);
+                        });
                         return Err(ClockError::InvalidFrequency);
                     }
-                    // SAFETY: unsafe needed to write the bits for the num and demon fields
-                    clkctl0.syspll0num().write(|w| unsafe { w.num().bits(0b0) });
-                    clkctl0.syspll0denom().write(|w| unsafe { w.denom().bits(0b1) });
+                    clkctl0.syspll0num().write(|w| w.set_num(0b0));
+                    clkctl0.syspll0denom().write(|w| w.set_denom(0b1));
                     delay_loop_clocks(30, desired_freq);
                     self.mult.store(mult, Ordering::Relaxed);
                     match mult {
                         16 => {
-                            clkctl0.syspll0ctl0().modify(|_r, w| w.mult().div_16());
+                            clkctl0
+                                .syspll0ctl0()
+                                .modify(|w| w.set_mult(pac::clkctl0::vals::Mult::DIV_16));
                         }
                         17 => {
-                            clkctl0.syspll0ctl0().modify(|_r, w| w.mult().div_17());
+                            clkctl0
+                                .syspll0ctl0()
+                                .modify(|w| w.set_mult(pac::clkctl0::vals::Mult::DIV_17));
                         }
                         20 => {
-                            clkctl0.syspll0ctl0().modify(|_r, w| w.mult().div_20());
+                            clkctl0
+                                .syspll0ctl0()
+                                .modify(|w| w.set_mult(pac::clkctl0::vals::Mult::DIV_20));
                         }
                         22 => {
-                            clkctl0.syspll0ctl0().modify(|_r, w| w.mult().div_22());
+                            clkctl0
+                                .syspll0ctl0()
+                                .modify(|w| w.set_mult(pac::clkctl0::vals::Mult::DIV_22));
                         }
                         27 => {
-                            clkctl0.syspll0ctl0().modify(|_r, w| w.mult().div_27());
+                            clkctl0
+                                .syspll0ctl0()
+                                .modify(|w| w.set_mult(pac::clkctl0::vals::Mult::DIV_27));
                         }
                         33 => {
-                            clkctl0.syspll0ctl0().modify(|_r, w| w.mult().div_33());
+                            clkctl0
+                                .syspll0ctl0()
+                                .modify(|w| w.set_mult(pac::clkctl0::vals::Mult::DIV_33));
                         }
                         _ => return Err(ClockError::InvalidMult),
                     }
                     // Clear System PLL reset
-                    clkctl0.syspll0ctl0().modify(|_r, w| w.reset().normal());
+                    clkctl0
+                        .syspll0ctl0()
+                        .modify(|w| w.set_reset(pac::clkctl0::vals::Reset::NORMAL));
                     // Power up SYSPLL
-                    sysctl0
-                        .pdruncfg0_clr()
-                        .write(|w| w.syspllana_pd().clr_pdruncfg0().syspllldo_pd().clr_pdruncfg0());
+                    sysctl0.pdruncfg0_clr().write(|w| {
+                        w.set_syspllana_pd(pac::sysctl0::vals::Pdruncfg0ClrSyspllanaPd::CLR_PDRUNCFG0);
+                        w.set_syspllldo_pd(pac::sysctl0::vals::Pdruncfg0ClrSyspllldoPd::CLR_PDRUNCFG0);
+                    });
 
                     // Set System PLL HOLDRINGOFF_ENA
-                    clkctl0.syspll0ctl0().modify(|_, w| w.holdringoff_ena().enable());
+                    clkctl0
+                        .syspll0ctl0()
+                        .modify(|w| w.set_holdringoff_ena(pac::clkctl0::vals::HoldringoffEna::ENABLE));
                     delay_loop_clocks(75, desired_freq);
 
                     // Clear System PLL HOLDRINGOFF_ENA
-                    clkctl0.syspll0ctl0().modify(|_, w| w.holdringoff_ena().dsiable());
+                    clkctl0
+                        .syspll0ctl0()
+                        .modify(|w| w.set_holdringoff_ena(pac::clkctl0::vals::HoldringoffEna::DSIABLE));
                     delay_loop_clocks(15, desired_freq);
 
                     // gate the output and clear bits.
-                    // SAFETY: unsafe needed to write the bits for pfd0
-                    clkctl0
-                        .syspll0pfd()
-                        .modify(|_, w| unsafe { w.pfd0_clkgate().gated().pfd0().bits(0x0) });
+                    clkctl0.syspll0pfd().modify(|w| {
+                        w.set_pfd0_clkgate(true);
+                        w.set_pfd0(0x0);
+                    });
                     // set pfd bits and un-gate the clock output
                     // output is multiplied by syspll * 18/pfd0_bits
-                    // SAFETY: unsafe needed to write the bits for pfd0
-                    clkctl0
-                        .syspll0pfd()
-                        .modify(|_r, w| unsafe { w.pfd0_clkgate().not_gated().pfd0().bits(0x12) });
+                    clkctl0.syspll0pfd().modify(|w| {
+                        w.set_pfd0_clkgate(false);
+                        w.set_pfd0(0x12);
+                    });
                     // wait for ready bit to be set
                     delay_loop_clocks(50, desired_freq);
-                    while clkctl0.syspll0pfd().read().pfd0_clkrdy().bit_is_clear() {}
+                    while !clkctl0.syspll0pfd().read().pfd0_clkrdy() {}
                     // clear by writing a 1
-                    clkctl0.syspll0pfd().modify(|_, w| w.pfd0_clkrdy().set_bit());
+                    clkctl0.syspll0pfd().modify(|w| w.set_pfd0_clkrdy(true));
 
                     Ok(())
                 }
@@ -837,7 +879,7 @@ impl MainPllClkConfig {
     /// Calculate the mult value of a desired frequency, return error if invalid
     pub(self) fn calc_mult(rate: u32, base_freq: u32) -> Result<u8, ClockError> {
         const VALIDMULTS: [u8; 6] = [16, 17, 20, 22, 27, 33];
-        if rate > base_freq && rate % base_freq == 0 {
+        if rate > base_freq && rate.is_multiple_of(base_freq) {
             let mult = (rate / base_freq) as u8;
             if VALIDMULTS.into_iter().any(|i| i == mult) {
                 Ok(mult)
@@ -849,115 +891,120 @@ impl MainPllClkConfig {
         }
     }
     pub(self) fn init_syspll() {
-        // SAFETY: unsafe needed to take pointers to Sysctl0 and Clkctl0
-        let clkctl0 = unsafe { crate::pac::Clkctl0::steal() };
-        let sysctl0 = unsafe { crate::pac::Sysctl0::steal() };
+        let clkctl0 = crate::pac::CLKCTL0;
+        let sysctl0 = crate::pac::SYSCTL0;
 
         // Power down SYSPLL before change fractional settings
-        sysctl0
-            .pdruncfg0_set()
-            .write(|w| w.syspllldo_pd().set_pdruncfg0().syspllana_pd().set_pdruncfg0());
+        sysctl0.pdruncfg0_set().write(|w| {
+            w.set_syspllldo_pd(pac::sysctl0::vals::Pdruncfg0SetSyspllldoPd::SET_PDRUNCFG0);
+            w.set_syspllana_pd(pac::sysctl0::vals::Pdruncfg0SetSyspllanaPd::SET_PDRUNCFG0);
+        });
 
-        clkctl0.syspll0clksel().write(|w| w.sel().ffro_div_2());
-        // SAFETY: unsafe needed to write the bits for both num and denom
-        clkctl0.syspll0num().write(|w| unsafe { w.num().bits(0x0) });
-        clkctl0.syspll0denom().write(|w| unsafe { w.denom().bits(0x1) });
+        clkctl0
+            .syspll0clksel()
+            .write(|w| w.set_sel(pac::clkctl0::vals::Syspll0clkselSel::FFRO_DIV_2));
+        clkctl0.syspll0num().write(|w| w.set_num(0x0));
+        clkctl0.syspll0denom().write(|w| w.set_denom(0x1));
 
         // kCLOCK_SysPllMult22
-        clkctl0.syspll0ctl0().modify(|_, w| w.mult().div_22());
+        clkctl0
+            .syspll0ctl0()
+            .modify(|w| w.set_mult(pac::clkctl0::vals::Mult::DIV_22));
 
         // Clear System PLL reset
-        clkctl0.syspll0ctl0().modify(|_, w| w.reset().normal());
+        clkctl0
+            .syspll0ctl0()
+            .modify(|w| w.set_reset(pac::clkctl0::vals::Reset::NORMAL));
 
         // Power up SYSPLL
-        sysctl0
-            .pdruncfg0_clr()
-            .write(|w| w.syspllldo_pd().clr_pdruncfg0().syspllana_pd().clr_pdruncfg0());
+        sysctl0.pdruncfg0_clr().write(|w| {
+            w.set_syspllldo_pd(pac::sysctl0::vals::Pdruncfg0ClrSyspllldoPd::CLR_PDRUNCFG0);
+            w.set_syspllana_pd(pac::sysctl0::vals::Pdruncfg0ClrSyspllanaPd::CLR_PDRUNCFG0);
+        });
         delay_loop_clocks((150 & 0xFFFF) / 2, 12_000_000);
 
         // Set System PLL HOLDRINGOFF_ENA
-        clkctl0.syspll0ctl0().modify(|_, w| w.holdringoff_ena().enable());
+        clkctl0
+            .syspll0ctl0()
+            .modify(|w| w.set_holdringoff_ena(pac::clkctl0::vals::HoldringoffEna::ENABLE));
         delay_loop_clocks((150 & 0xFFFF) / 2, 12_000_000);
 
         // Clear System PLL HOLDRINGOFF_ENA
-        clkctl0.syspll0ctl0().modify(|_, w| w.holdringoff_ena().dsiable());
+        clkctl0
+            .syspll0ctl0()
+            .modify(|w| w.set_holdringoff_ena(pac::clkctl0::vals::HoldringoffEna::DSIABLE));
         delay_loop_clocks((15 & 0xFFFF) / 2, 12_000_000);
     }
     /// enables default settings for pfd2 bits
     pub(self) fn init_syspll_pfd2(config_bits: u8) {
-        // SAFETY: unsafe needed to take pointer to Clkctl0 and write specific bits
-        // needed to change the output of pfd0
-        unsafe {
-            let clkctl0 = crate::pac::Clkctl0::steal();
+        let clkctl0 = crate::pac::CLKCTL0;
 
-            // Disable the clock output first.
-            // SAFETY: unsafe needed to write the bits for pfd2
-            clkctl0
-                .syspll0pfd()
-                .modify(|_, w| w.pfd2_clkgate().gated().pfd2().bits(0x0));
+        // Disable the clock output first.
+        clkctl0.syspll0pfd().modify(|w| {
+            w.set_pfd2_clkgate(true);
+            w.set_pfd2(0x0);
+        });
 
-            // Set the new value and enable output.
-            // SAFETY: unsafe needed to write the bits for pfd2
-            clkctl0
-                .syspll0pfd()
-                .modify(|_, w| w.pfd2_clkgate().not_gated().pfd2().bits(config_bits));
+        // Set the new value and enable output.
+        clkctl0.syspll0pfd().modify(|w| {
+            w.set_pfd2_clkgate(false);
+            w.set_pfd2(config_bits);
+        });
 
-            // Wait for output becomes stable.
-            while clkctl0.syspll0pfd().read().pfd2_clkrdy().bit_is_clear() {}
+        // Wait for output becomes stable.
+        while !clkctl0.syspll0pfd().read().pfd2_clkrdy() {}
 
-            // Clear ready status flag.
-            clkctl0.syspll0pfd().modify(|_, w| w.pfd2_clkrdy().clear_bit());
-        }
+        // Clear ready status flag.
+        clkctl0.syspll0pfd().modify(|w| w.set_pfd2_clkrdy(false));
     }
     /// Enables default settings for pfd0
     pub(self) fn init_syspll_pfd0(config_bits: u8) {
-        // SAFETY: unsafe needed to take pointer to Clkctl0 and write specific bits
-        // needed to change the output of pfd0
-        unsafe {
-            let clkctl0 = crate::pac::Clkctl0::steal();
-            // Disable the clock output first
-            clkctl0
-                .syspll0pfd()
-                .modify(|_, w| w.pfd0_clkgate().gated().pfd0().bits(0x0));
+        let clkctl0 = crate::pac::CLKCTL0;
+        // Disable the clock output first
+        clkctl0.syspll0pfd().modify(|w| {
+            w.set_pfd0_clkgate(true);
+            w.set_pfd0(0x0);
+        });
 
-            // Set the new value and enable output
-            clkctl0
-                .syspll0pfd()
-                .modify(|_, w| w.pfd0_clkgate().not_gated().pfd0().bits(config_bits));
+        // Set the new value and enable output
+        clkctl0.syspll0pfd().modify(|w| {
+            w.set_pfd0_clkgate(false);
+            w.set_pfd0(config_bits);
+        });
 
-            // Wait for output becomes stable
-            while clkctl0.syspll0pfd().read().pfd0_clkrdy().bit_is_clear() {}
+        // Wait for output becomes stable
+        while !clkctl0.syspll0pfd().read().pfd0_clkrdy() {}
 
-            // Clear ready status flag
-            clkctl0.syspll0pfd().modify(|_, w| w.pfd0_clkrdy().clear_bit());
-        }
+        // Clear ready status flag
+        clkctl0.syspll0pfd().modify(|w| w.set_pfd0_clkrdy(false));
     }
 }
 
 impl MainClkConfig {
     fn init_main_clk() {
-        // SAFETY:: unsafe needed to take pointers to Clkctl0 and Clkctl1
         // used to set the right HW frequency
-        let clkctl0 = unsafe { crate::pac::Clkctl0::steal() };
-        let clkctl1 = unsafe { crate::pac::Clkctl1::steal() };
+        let clkctl0 = crate::pac::CLKCTL0;
+        let clkctl1 = crate::pac::CLKCTL1;
 
-        clkctl0.mainclkselb().write(|w| w.sel().main_pll_clk());
+        clkctl0
+            .mainclkselb()
+            .write(|w| w.set_sel(pac::clkctl0::vals::MainclkselbSel::MAIN_PLL_CLK));
 
         // Set PFC0DIV divider to value 2, Subtract 1 since 0-> 1, 1-> 2, etc...
-        clkctl0.pfcdiv(0).modify(|_, w| w.reset().set_bit());
-        // SAFETY: unsafe needed to write the bits for pfcdiv
-        clkctl0
-            .pfcdiv(0)
-            .write(|w| unsafe { w.div().bits(2 - 1).halt().clear_bit() });
-        while clkctl0.pfcdiv(0).read().reqflag().bit_is_set() {}
+        clkctl0.pfcdiv(0).modify(|w| w.set_reset(true));
+        clkctl0.pfcdiv(0).write(|w| {
+            w.set_div(2 - 1);
+            w.set_halt(false);
+        });
+        while clkctl0.pfcdiv(0).read().reqflag() {}
 
         // Set FRGPLLCLKDIV divider to value 12, Subtract 1 since 0-> 1, 1-> 2, etc...
-        clkctl1.frgpllclkdiv().modify(|_, w| w.reset().set_bit());
-        // SAFETY: unsafe needed to write the bits for frgpllclkdiv
-        clkctl1
-            .frgpllclkdiv()
-            .write(|w| unsafe { w.div().bits(12 - 1).halt().clear_bit() });
-        while clkctl1.frgpllclkdiv().read().reqflag().bit_is_set() {}
+        clkctl1.frgpllclkdiv().modify(|w| w.set_reset(true));
+        clkctl1.frgpllclkdiv().write(|w| {
+            w.set_div(12 - 1);
+            w.set_halt(false);
+        });
+        while clkctl1.frgpllclkdiv().read().reqflag() {}
     }
 }
 impl MultiSourceClock for MainClkConfig {
@@ -968,15 +1015,15 @@ impl MultiSourceClock for MainClkConfig {
                 let converted_clock = Clocks::from(self.src);
                 match ConfigurableClock::get_clock_rate(self) {
                     Ok(_rate) => {
-                        // SAFETY: unsafe needed to take pointer to Clkctl0
                         // needed to calculate the clock rate from the bits written in the registers
-                        let clkctl0 = unsafe { crate::pac::Clkctl0::steal() };
-                        if self.src == MainClkSrc::PllMain && clkctl0.syspll0ctl0().read().bypass().is_programmed_clk()
+                        let clkctl0 = crate::pac::CLKCTL0;
+                        if self.src == MainClkSrc::PllMain
+                            && clkctl0.syspll0ctl0().read().bypass() == pac::clkctl0::vals::Bypass::PROGRAMMED_CLK
                         {
                             let mut temp;
                             temp = self.freq.load(Ordering::Relaxed)
-                                * u32::from(clkctl0.syspll0ctl0().read().mult().bits());
-                            temp = (u64::from(temp) * 18 / u64::from(clkctl0.syspll0pfd().read().pfd0().bits())) as u32;
+                                * u32::from(clkctl0.syspll0ctl0().read().mult().to_bits());
+                            temp = (u64::from(temp) * 18 / u64::from(clkctl0.syspll0pfd().read().pfd0())) as u32;
                             return Ok((converted_clock, temp));
                         }
                         Ok((converted_clock, self.freq.load(Ordering::Relaxed) / div))
@@ -997,15 +1044,18 @@ impl MultiSourceClock for MainClkConfig {
             return Err(ClockError::ClockNotEnabled);
         }
         if let Ok(c) = <Clocks as TryInto<MainClkSrc>>::try_into(*clock_src) {
-            // SAFETY: unsafe needed to take pointer to Clkctl0
             // needed to change the clock source
-            let clkctl0 = unsafe { crate::pac::Clkctl0::steal() };
+            let clkctl0 = crate::pac::CLKCTL0;
             match c {
                 MainClkSrc::ClkIn => {
                     self.src = MainClkSrc::ClkIn;
 
-                    clkctl0.mainclksela().write(|w| w.sel().sysxtal_clk());
-                    clkctl0.mainclkselb().write(|w| w.sel().main_1st_clk());
+                    clkctl0
+                        .mainclksela()
+                        .write(|w| w.set_sel(pac::clkctl0::vals::MainclkselaSel::SYSXTAL_CLK));
+                    clkctl0
+                        .mainclkselb()
+                        .write(|w| w.set_sel(pac::clkctl0::vals::MainclkselbSel::MAIN_1ST_CLK));
                     Ok(())
                 }
                 // the following will yield the same result as if compared to FFROdiv4
@@ -1014,16 +1064,24 @@ impl MultiSourceClock for MainClkConfig {
                         self.src = MainClkSrc::FFROdiv4;
                         self.freq.store(div4, Ordering::Relaxed);
 
-                        clkctl0.mainclksela().write(|w| w.sel().ffro_div_4());
-                        clkctl0.mainclkselb().write(|w| w.sel().main_1st_clk());
+                        clkctl0
+                            .mainclksela()
+                            .write(|w| w.set_sel(pac::clkctl0::vals::MainclkselaSel::FFRO_DIV_4));
+                        clkctl0
+                            .mainclkselb()
+                            .write(|w| w.set_sel(pac::clkctl0::vals::MainclkselbSel::MAIN_1ST_CLK));
                         Ok(())
                     }
                     div1 if div1 == FfroFreq::Ffro60m as u32 || div1 == FfroFreq::Ffro48m as u32 => {
                         self.src = MainClkSrc::FFRO;
                         self.freq.store(div1, Ordering::Relaxed);
 
-                        clkctl0.mainclksela().write(|w| w.sel().ffro_clk());
-                        clkctl0.mainclkselb().write(|w| w.sel().main_1st_clk());
+                        clkctl0
+                            .mainclksela()
+                            .write(|w| w.set_sel(pac::clkctl0::vals::MainclkselaSel::FFRO_CLK));
+                        clkctl0
+                            .mainclkselb()
+                            .write(|w| w.set_sel(pac::clkctl0::vals::MainclkselbSel::MAIN_1ST_CLK));
                         Ok(())
                     }
                     _ => Err(ClockError::InvalidFrequency),
@@ -1035,8 +1093,12 @@ impl MultiSourceClock for MainClkConfig {
                                 self.src = MainClkSrc::Lposc;
                                 self.freq.store(rate, Ordering::Relaxed);
 
-                                clkctl0.mainclksela().write(|w| w.sel().lposc());
-                                clkctl0.mainclkselb().write(|w| w.sel().main_1st_clk());
+                                clkctl0
+                                    .mainclksela()
+                                    .write(|w| w.set_sel(pac::clkctl0::vals::MainclkselaSel::LPOSC));
+                                clkctl0
+                                    .mainclkselb()
+                                    .write(|w| w.set_sel(pac::clkctl0::vals::MainclkselbSel::MAIN_1ST_CLK));
                                 Ok(())
                             }
                             LposcFreq::Lp32k => Err(ClockError::InvalidFrequency),
@@ -1049,7 +1111,9 @@ impl MultiSourceClock for MainClkConfig {
                     if rate == SFRO_FREQ {
                         self.src = MainClkSrc::SFRO;
                         self.freq.store(rate, Ordering::Relaxed);
-                        clkctl0.mainclkselb().write(|w| w.sel().sfro_clk());
+                        clkctl0
+                            .mainclkselb()
+                            .write(|w| w.set_sel(pac::clkctl0::vals::MainclkselbSel::SFRO_CLK));
                         Ok(())
                     } else {
                         Err(ClockError::InvalidFrequency)
@@ -1061,7 +1125,9 @@ impl MultiSourceClock for MainClkConfig {
                     let pll_max = 572_000_000;
                     let pll_min = 80_000_000;
                     if pll_min <= r && r <= pll_max {
-                        clkctl0.mainclkselb().write(|w| w.sel().main_pll_clk());
+                        clkctl0
+                            .mainclkselb()
+                            .write(|w| w.set_sel(pac::clkctl0::vals::MainclkselbSel::MAIN_PLL_CLK));
                         self.src = MainClkSrc::PllMain;
                         self.freq.store(r, Ordering::Relaxed);
                         Ok(())
@@ -1073,7 +1139,9 @@ impl MultiSourceClock for MainClkConfig {
                     if rate == RtcFreq::SubSecond32kHz as u32 {
                         self.src = MainClkSrc::RTC32k;
                         self.freq.store(rate, Ordering::Relaxed);
-                        clkctl0.mainclkselb().write(|w| w.sel().rtc_32k_clk());
+                        clkctl0
+                            .mainclkselb()
+                            .write(|w| w.set_sel(pac::clkctl0::vals::MainclkselbSel::RTC_32K_CLK));
                         Ok(())
                     } else {
                         Err(ClockError::InvalidFrequency)
@@ -1134,27 +1202,29 @@ impl ConfigurableClock for ClkInConfig {
 impl RtcClkConfig {
     /// Register writes to initialize the RTC Clock
     fn init_rtc_clk() {
-        // SAFETY: unsafe needed to take pointer to Clkctl0, Clkctl1, and RTC
         // needed to enable the RTC HW
-        let cc0 = unsafe { pac::Clkctl0::steal() };
-        let cc1 = unsafe { pac::Clkctl1::steal() };
-        let r = unsafe { pac::Rtc::steal() };
+        let cc0 = pac::CLKCTL0;
+        let cc1 = pac::CLKCTL1;
+        let r = pac::RTC;
         // Enable the RTC peripheral clock
-        cc1.pscctl2_set().write(|w| w.rtc_lite_clk_set().set_clock());
+        cc1.pscctl2_set()
+            .write(|w| w.set_rtc_lite_clk_set(pac::clkctl1::vals::RtcLiteClkSet::SET_CLOCK));
         // Make sure the reset bit is cleared amd RTC OSC is powered up
-        r.ctrl().modify(|_, w| w.swreset().not_in_reset().rtc_osc_pd().enable());
+        r.ctrl().modify(|w| {
+            w.set_swreset(false);
+            w.set_rtc_osc_pd(pac::rtc::vals::RtcOscPd::ENABLE);
+        });
 
         // set initial match value, note that with a 15 bit count-down timer this would
         // typically be 0x8000, but we are "doing some clever things" in time-driver.rs,
         // read more about it in the comments there
-        // SAFETY: unsafe needed to write the bits
-        r.wake().write(|w| unsafe { w.bits(0xA) });
+        r.wake().write_value(pac::rtc::regs::Wake(0xA));
 
         // Enable 32K OSC
-        cc0.osc32khzctl0().write(|w| w.ena32khz().enabled());
+        cc0.osc32khzctl0().write(|w| w.set_ena32khz(true));
 
         // enable rtc clk
-        r.ctrl().modify(|_, w| w.rtc_en().enable());
+        r.ctrl().modify(|w| w.set_rtc_en(true));
     }
 }
 
@@ -1169,28 +1239,27 @@ impl ConfigurableClock for RtcClkConfig {
     }
     fn set_clock_rate(&mut self, _div: u8, _mult: u8, freq: u32) -> Result<(), ClockError> {
         if let Ok(r) = <u32 as TryInto<RtcFreq>>::try_into(freq) {
-            // SAFETY: unsafe needed to take pointer to RTC
             // needed to enable the HW for the different RTC frequencies, powered down by default
-            let rtc = unsafe { crate::pac::Rtc::steal() };
+            let rtc = crate::pac::RTC;
             match r {
                 RtcFreq::Default1Hz => {
-                    if rtc.ctrl().read().rtc_en().is_enable() {
+                    if rtc.ctrl().read().rtc_en() {
                     } else {
-                        rtc.ctrl().modify(|_r, w| w.rtc_en().enable());
+                        rtc.ctrl().modify(|w| w.set_rtc_en(true));
                     }
                     Ok(())
                 }
                 RtcFreq::HighResolution1khz => {
-                    if rtc.ctrl().read().rtc1khz_en().is_enable() {
+                    if rtc.ctrl().read().rtc1khz_en() {
                     } else {
-                        rtc.ctrl().modify(|_r, w| w.rtc1khz_en().enable());
+                        rtc.ctrl().modify(|w| w.set_rtc1khz_en(true));
                     }
                     Ok(())
                 }
                 RtcFreq::SubSecond32kHz => {
-                    if rtc.ctrl().read().rtc_subsec_ena().is_enable() {
+                    if rtc.ctrl().read().rtc_subsec_ena() {
                     } else {
-                        rtc.ctrl().modify(|_r, w| w.rtc_subsec_ena().enable());
+                        rtc.ctrl().modify(|w| w.set_rtc_subsec_ena(true));
                     }
                     Ok(())
                 }
@@ -1227,36 +1296,47 @@ impl ConfigurableClock for SysOscConfig {
             return Ok(());
         }
 
-        // SAFETY: unsafe needed to take pointers to Sysctl0 and Clkctl0, needed to modify clock HW
-        let clkctl0 = unsafe { crate::pac::Clkctl0::steal() };
-        let sysctl0 = unsafe { crate::pac::Sysctl0::steal() };
+        let clkctl0 = crate::pac::CLKCTL0;
+        let sysctl0 = crate::pac::SYSCTL0;
 
         // Let CPU run on ffro for safe switching
-        clkctl0.mainclksela().write(|w| w.sel().ffro_clk());
-        clkctl0.mainclksela().write(|w| w.sel().ffro_div_4());
+        clkctl0
+            .mainclksela()
+            .write(|w| w.set_sel(pac::clkctl0::vals::MainclkselaSel::FFRO_CLK));
+        clkctl0
+            .mainclksela()
+            .write(|w| w.set_sel(pac::clkctl0::vals::MainclkselaSel::FFRO_DIV_4));
 
         // Power on SYSXTAL
-        sysctl0.pdruncfg0_clr().write(|w| w.sysxtal_pd().clr_pdruncfg0());
+        sysctl0
+            .pdruncfg0_clr()
+            .write(|w| w.set_sysxtal_pd(pac::sysctl0::vals::Pdruncfg0ClrSysxtalPd::CLR_PDRUNCFG0));
 
         // Enable system OSC
-        clkctl0
-            .sysoscctl0()
-            .write(|w| w.lp_enable().lp().bypass_enable().normal_mode());
+        clkctl0.sysoscctl0().write(|w| {
+            w.set_lp_enable(pac::clkctl0::vals::LpEnable::LP);
+            w.set_bypass_enable(pac::clkctl0::vals::BypassEnable::NORMAL_MODE);
+        });
 
         delay_loop_clocks(260, SYS_OSC_DEFAULT_FREQ.into());
         Ok(())
     }
     fn disable(&self) -> Result<(), ClockError> {
-        // SAFETY: unsafe needed to take pointers to Sysctl0 and Clkctl0, needed to modify clock HW
-        let clkctl0 = unsafe { crate::pac::Clkctl0::steal() };
-        let sysctl0 = unsafe { crate::pac::Sysctl0::steal() };
+        let clkctl0 = crate::pac::CLKCTL0;
+        let sysctl0 = crate::pac::SYSCTL0;
 
         // Let CPU run on ffro for safe switching
-        clkctl0.mainclksela().write(|w| w.sel().ffro_clk());
-        clkctl0.mainclksela().write(|w| w.sel().ffro_div_4());
+        clkctl0
+            .mainclksela()
+            .write(|w| w.set_sel(pac::clkctl0::vals::MainclkselaSel::FFRO_CLK));
+        clkctl0
+            .mainclksela()
+            .write(|w| w.set_sel(pac::clkctl0::vals::MainclkselaSel::FFRO_DIV_4));
 
         // Power on SYSXTAL
-        sysctl0.pdruncfg0_set().write(|w| w.sysxtal_pd().set_pdruncfg0());
+        sysctl0
+            .pdruncfg0_set()
+            .write(|w| w.set_sysxtal_pd(pac::sysctl0::vals::Pdruncfg0SetSysxtalPd::SET_PDRUNCFG0));
         Ok(())
     }
     fn get_clock_rate(&self) -> Result<u32, ClockError> {
@@ -1286,31 +1366,23 @@ pub fn delay_loop_clocks(usec: u64, freq_mhz: u64) {
 
 /// Configure the pad voltage pmc registers for all 3 vddio ranges
 fn set_pad_voltage_range() {
-    // SAFETY: unsafe needed to take pointer to PNC as well as to write specific bits
-    unsafe {
-        let pmc = crate::pac::Pmc::steal();
-        // Set up IO voltages
-        // all 3 ranges need to be 1.71-1.98V which is 01
-        pmc.padvrange().write(|w| {
-            w.vddio_0range()
-                .bits(0b01)
-                .vddio_1range()
-                .bits(0b01)
-                .vddio_2range()
-                .bits(0b01)
-        });
-    }
+    let pmc = crate::pac::PMC;
+    // Set up IO voltages
+    // all 3 ranges need to be 1.71-1.98V which is 01
+    pmc.padvrange().write(|w| {
+        w.set_vddio_0range(pac::pmc::vals::Vddio0range::from_bits(0b01));
+        w.set_vddio_1range(pac::pmc::vals::Vddio1range::from_bits(0b01));
+        w.set_vddio_2range(pac::pmc::vals::Vddio2range::from_bits(0b01));
+    });
 }
 
 /// Initialize AHB clock
 fn init_syscpuahb_clk() {
-    // SAFETY: unsafe needed to take pointer to Clkctl0
-    let clkctl0 = unsafe { crate::pac::Clkctl0::steal() };
-    // SAFETY: unsafe needed to write the bits
+    let clkctl0 = crate::pac::CLKCTL0;
     // Set syscpuahbclkdiv to value 2, Subtract 1 since 0-> 1, 1-> 2, etc...
-    clkctl0.syscpuahbclkdiv().write(|w| unsafe { w.div().bits(2 - 1) });
+    clkctl0.syscpuahbclkdiv().write(|w| w.set_div(2 - 1));
 
-    while clkctl0.syscpuahbclkdiv().read().reqflag().bit_is_set() {}
+    while clkctl0.syscpuahbclkdiv().read().reqflag() {}
 }
 
 /// `ClockOut` config
@@ -1377,60 +1449,85 @@ impl ClockOutConfig {
 
     /// Set the source of the Clock Out pin
     fn set_clkout_source(&mut self, src: ClkOutSrc) -> Result<(), ClockError> {
-        // SAFETY: unsafe needed to take pointers to Clkctl1, needed to set source in HW
-        let cc1 = unsafe { pac::Clkctl1::steal() };
+        let cc1 = pac::CLKCTL1;
         match src {
             ClkOutSrc::None => {
-                cc1.clkoutsel0().write(|w| w.sel().none());
-                cc1.clkoutsel1().write(|w| w.sel().none());
+                cc1.clkoutsel0()
+                    .write(|w| w.set_sel(pac::clkctl1::vals::Clkoutsel0Sel::NONE));
+                cc1.clkoutsel1()
+                    .write(|w| w.set_sel(pac::clkctl1::vals::Clkoutsel1Sel::NONE));
             }
             ClkOutSrc::Sfro => {
-                cc1.clkoutsel0().write(|w| w.sel().sfro_clk());
-                cc1.clkoutsel1().write(|w| w.sel().clkoutsel0_output());
+                cc1.clkoutsel0()
+                    .write(|w| w.set_sel(pac::clkctl1::vals::Clkoutsel0Sel::SFRO_CLK));
+                cc1.clkoutsel1()
+                    .write(|w| w.set_sel(pac::clkctl1::vals::Clkoutsel1Sel::CLKOUTSEL0_OUTPUT));
             }
             ClkOutSrc::ClkIn => {
-                cc1.clkoutsel0().write(|w| w.sel().xtalin_clk());
-                cc1.clkoutsel1().write(|w| w.sel().clkoutsel0_output());
+                cc1.clkoutsel0()
+                    .write(|w| w.set_sel(pac::clkctl1::vals::Clkoutsel0Sel::XTALIN_CLK));
+                cc1.clkoutsel1()
+                    .write(|w| w.set_sel(pac::clkctl1::vals::Clkoutsel1Sel::CLKOUTSEL0_OUTPUT));
             }
             ClkOutSrc::Lposc => {
-                cc1.clkoutsel0().write(|w| w.sel().lposc());
-                cc1.clkoutsel1().write(|w| w.sel().clkoutsel0_output());
+                cc1.clkoutsel0()
+                    .write(|w| w.set_sel(pac::clkctl1::vals::Clkoutsel0Sel::LPOSC));
+                cc1.clkoutsel1()
+                    .write(|w| w.set_sel(pac::clkctl1::vals::Clkoutsel1Sel::CLKOUTSEL0_OUTPUT));
             }
             ClkOutSrc::Ffro => {
-                cc1.clkoutsel0().write(|w| w.sel().ffro_clk());
-                cc1.clkoutsel1().write(|w| w.sel().clkoutsel0_output());
+                cc1.clkoutsel0()
+                    .write(|w| w.set_sel(pac::clkctl1::vals::Clkoutsel0Sel::FFRO_CLK));
+                cc1.clkoutsel1()
+                    .write(|w| w.set_sel(pac::clkctl1::vals::Clkoutsel1Sel::CLKOUTSEL0_OUTPUT));
             }
             ClkOutSrc::MainClk => {
-                cc1.clkoutsel0().write(|w| w.sel().main_clk());
-                cc1.clkoutsel1().write(|w| w.sel().clkoutsel0_output());
+                cc1.clkoutsel0()
+                    .write(|w| w.set_sel(pac::clkctl1::vals::Clkoutsel0Sel::MAIN_CLK));
+                cc1.clkoutsel1()
+                    .write(|w| w.set_sel(pac::clkctl1::vals::Clkoutsel1Sel::CLKOUTSEL0_OUTPUT));
             }
             ClkOutSrc::DspMainClk => {
-                cc1.clkoutsel0().write(|w| w.sel().dsp_main_clk());
-                cc1.clkoutsel1().write(|w| w.sel().clkoutsel0_output());
+                cc1.clkoutsel0()
+                    .write(|w| w.set_sel(pac::clkctl1::vals::Clkoutsel0Sel::DSP_MAIN_CLK));
+                cc1.clkoutsel1()
+                    .write(|w| w.set_sel(pac::clkctl1::vals::Clkoutsel1Sel::CLKOUTSEL0_OUTPUT));
             }
             ClkOutSrc::MainPllClk => {
-                cc1.clkoutsel0().write(|w| w.sel().none());
-                cc1.clkoutsel1().write(|w| w.sel().main_pll_clk());
+                cc1.clkoutsel0()
+                    .write(|w| w.set_sel(pac::clkctl1::vals::Clkoutsel0Sel::NONE));
+                cc1.clkoutsel1()
+                    .write(|w| w.set_sel(pac::clkctl1::vals::Clkoutsel1Sel::MAIN_PLL_CLK));
             }
             ClkOutSrc::Aux0PllClk => {
-                cc1.clkoutsel0().write(|w| w.sel().none());
-                cc1.clkoutsel1().write(|w| w.sel().syspll0_aux0_pll_clk());
+                cc1.clkoutsel0()
+                    .write(|w| w.set_sel(pac::clkctl1::vals::Clkoutsel0Sel::NONE));
+                cc1.clkoutsel1()
+                    .write(|w| w.set_sel(pac::clkctl1::vals::Clkoutsel1Sel::SYSPLL0_AUX0_PLL_CLK));
             }
             ClkOutSrc::DspPllClk => {
-                cc1.clkoutsel0().write(|w| w.sel().none());
-                cc1.clkoutsel1().write(|w| w.sel().dsp_pll_clk());
+                cc1.clkoutsel0()
+                    .write(|w| w.set_sel(pac::clkctl1::vals::Clkoutsel0Sel::NONE));
+                cc1.clkoutsel1()
+                    .write(|w| w.set_sel(pac::clkctl1::vals::Clkoutsel1Sel::DSP_PLL_CLK));
             }
             ClkOutSrc::AudioPllClk => {
-                cc1.clkoutsel0().write(|w| w.sel().none());
-                cc1.clkoutsel1().write(|w| w.sel().audio_pll_clk());
+                cc1.clkoutsel0()
+                    .write(|w| w.set_sel(pac::clkctl1::vals::Clkoutsel0Sel::NONE));
+                cc1.clkoutsel1()
+                    .write(|w| w.set_sel(pac::clkctl1::vals::Clkoutsel1Sel::AUDIO_PLL_CLK));
             }
             ClkOutSrc::Aux1PllClk => {
-                cc1.clkoutsel0().write(|w| w.sel().none());
-                cc1.clkoutsel1().write(|w| w.sel().syspll0_aux1_pll_clk());
+                cc1.clkoutsel0()
+                    .write(|w| w.set_sel(pac::clkctl1::vals::Clkoutsel0Sel::NONE));
+                cc1.clkoutsel1()
+                    .write(|w| w.set_sel(pac::clkctl1::vals::Clkoutsel1Sel::SYSPLL0_AUX1_PLL_CLK));
             }
             ClkOutSrc::RTC32k => {
-                cc1.clkoutsel0().write(|w| w.sel().none());
-                cc1.clkoutsel1().write(|w| w.sel().rtc_clk_32khz());
+                cc1.clkoutsel0()
+                    .write(|w| w.set_sel(pac::clkctl1::vals::Clkoutsel0Sel::NONE));
+                cc1.clkoutsel1()
+                    .write(|w| w.set_sel(pac::clkctl1::vals::Clkoutsel1Sel::RTC_CLK_32KHZ));
             }
         }
         self.src = src;
@@ -1438,17 +1535,19 @@ impl ClockOutConfig {
     }
     /// set the clock out divider
     /// note that 1 will be added to div when mapping to the divider
-    /// so bits(0) -> divide by 1
+    /// so set_div(0) -> divide by 1
     /// ...
-    /// bits(255)-> divide by 256
+    /// set_div(255)-> divide by 256
     pub fn set_clkout_divider(&self, div: u8) -> Result<(), ClockError> {
         // don't wait for clock to be ready if there's no source
         if self.src != ClkOutSrc::None {
-            let cc1 = unsafe { pac::Clkctl1::steal() };
+            let cc1 = pac::CLKCTL1;
 
-            cc1.clkoutdiv()
-                .modify(|_, w| unsafe { w.div().bits(div).halt().clear_bit() });
-            while cc1.clkoutdiv().read().reqflag().bit_is_set() {}
+            cc1.clkoutdiv().modify(|w| {
+                w.set_div(div);
+                w.set_halt(false);
+            });
+            while cc1.clkoutdiv().read().reqflag() {}
         }
         Ok(())
     }
@@ -1464,47 +1563,29 @@ impl ClockOutConfig {
 
 /// Using the config, enables all desired clocks to desired clock rates
 fn init_clock_hw(config: ClockConfig) -> Result<(), ClockError> {
-    if let Err(e) = config.rtc.enable_and_reset() {
-        return Err(e);
-    }
-
-    if let Err(e) = config.lposc.enable_and_reset() {
-        return Err(e);
-    }
-
-    if let Err(e) = config.ffro.enable_and_reset() {
-        return Err(e);
-    }
-
-    if let Err(e) = config.sfro.enable_and_reset() {
-        return Err(e);
-    }
-
-    if let Err(e) = config.sys_osc.enable_and_reset() {
-        return Err(e);
-    }
-
-    if let Err(e) = config.main_pll_clk.enable_and_reset() {
-        return Err(e);
-    }
+    config.rtc.enable_and_reset()?;
+    config.lposc.enable_and_reset()?;
+    config.ffro.enable_and_reset()?;
+    config.sfro.enable_and_reset()?;
+    config.sys_osc.enable_and_reset()?;
+    config.main_pll_clk.enable_and_reset()?;
 
     // Move FLEXSPI clock source from main clock to FFRO to avoid instruction/data fetch issue in XIP when
     // updating PLL and main clock.
-    // SAFETY: unsafe needed to take pointers to Clkctl0
-    let cc0 = unsafe { pac::Clkctl0::steal() };
-    cc0.flexspifclksel().write(|w| w.sel().ffro_clk());
+    let cc0 = pac::CLKCTL0;
+    cc0.flexspifclksel()
+        .write(|w| w.set_sel(pac::clkctl0::vals::FlexspifclkselSel::FFRO_CLK));
 
     // Move ESPI clock source to FFRO
     #[cfg(feature = "_espi")]
     {
-        cc0.espiclksel().write(|w| w.sel().use_48_60m());
+        cc0.espifclksel0()
+            .write(|w| w.set_sel(pac::clkctl0::vals::Espifclksel0Sel::FFRO_CLK));
     }
 
     init_syscpuahb_clk();
 
-    if let Err(e) = config.main_clk.enable_and_reset() {
-        return Err(e);
-    }
+    config.main_clk.enable_and_reset()?;
 
     config.sys_clk.update_sys_core_clock();
     Ok(())
@@ -1561,32 +1642,26 @@ macro_rules! impl_perph_clk {
     ($peripheral:ident, $clkctl:ident, $clkreg:ident, $rstctl:ident, $rstreg:ident, $bit:expr) => {
         impl SealedSysconPeripheral for crate::peripherals::$peripheral {
             fn enable_perph_clock() {
-                // SAFETY: unsafe needed to take pointers to Rstctl1 and Clkctl1
-                let cc1 = unsafe { pac::$clkctl::steal() };
+                let cc1 = pac::$clkctl;
 
                 paste! {
-                    // SAFETY: unsafe due to the use of bits()
-                    cc1.[<$clkreg _set>]().write(|w| unsafe { w.bits(1 << $bit) });
+                    cc1.[<$clkreg _set>]().write(|w| w.0 = 1 << $bit);
                 }
             }
 
             fn reset_perph() {
-                // SAFETY: unsafe needed to take pointers to Rstctl1 and Clkctl1
-                let rc1 = unsafe { pac::$rstctl::steal() };
+                let rc1 = pac::$rstctl;
 
                 paste! {
-                    // SAFETY: unsafe due to the use of bits()
-                    rc1.[<$rstreg _clr>]().write(|w| unsafe { w.bits(1 << $bit) });
+                    rc1.[<$rstreg _clr>]().write(|w| w.0 = 1 << $bit);
                 }
             }
 
             fn disable_perph_clock() {
-                // SAFETY: unsafe needed to take pointers to Rstctl1 and Clkctl1
-                let cc1 = unsafe { pac::$clkctl::steal() };
+                let cc1 = pac::$clkctl;
 
                 paste! {
-                    // SAFETY: unsafe due to the use of bits()
-                    cc1.[<$clkreg _clr>]().write(|w| unsafe { w.bits(1 << $bit) });
+                    cc1.[<$clkreg _clr>]().write(|w| w.0 = 1 << $bit);
                 }
             }
         }
@@ -1596,66 +1671,66 @@ macro_rules! impl_perph_clk {
 }
 
 // These should enabled once the relevant peripherals are implemented.
-// impl_perph_clk!(GPIOINTCTL, Clkctl1, pscctl2, Rstctl1, prstctl2, 30);
-// impl_perph_clk!(OTP, Clkctl0, pscctl0, Rstctl0, prstctl0, 17);
+// impl_perph_clk!(GPIOINTCTL, CLKCTL1, pscctl2, RSTCTL1, prstctl2, 30);
+// impl_perph_clk!(OTP, CLKCTL0, pscctl0, RSTCTL0, prstctl0, 17);
 
-// impl_perph_clk!(ROM_CTL_128KB, Clkctl0, pscctl0, Rstctl0, prstctl0, 2);
-// impl_perph_clk!(USBHS_SRAM, Clkctl0, pscctl0, Rstctl0, prstctl0, 23);
+// impl_perph_clk!(ROM_CTL_128KB, CLKCTL0, pscctl0, RSTCTL0, prstctl0, 2);
+// impl_perph_clk!(USBHS_SRAM, CLKCTL0, pscctl0, RSTCTL0, prstctl0, 23);
 
-impl_perph_clk!(PIMCTL, Clkctl1, pscctl2, Rstctl1, prstctl2, 31);
-impl_perph_clk!(ACMP, Clkctl0, pscctl1, Rstctl0, prstctl1, 15);
-impl_perph_clk!(ADC0, Clkctl0, pscctl1, Rstctl0, prstctl1, 16);
-impl_perph_clk!(CASPER, Clkctl0, pscctl0, Rstctl0, prstctl0, 9);
-impl_perph_clk!(CRC, Clkctl1, pscctl1, Rstctl1, prstctl1, 16);
-impl_perph_clk!(CTIMER0_COUNT_CHANNEL0, Clkctl1, pscctl2, Rstctl1, prstctl2, 0);
-impl_perph_clk!(CTIMER1_COUNT_CHANNEL0, Clkctl1, pscctl2, Rstctl1, prstctl2, 1);
-impl_perph_clk!(CTIMER2_COUNT_CHANNEL0, Clkctl1, pscctl2, Rstctl1, prstctl2, 2);
-impl_perph_clk!(CTIMER3_COUNT_CHANNEL0, Clkctl1, pscctl2, Rstctl1, prstctl2, 3);
-impl_perph_clk!(CTIMER4_COUNT_CHANNEL0, Clkctl1, pscctl2, Rstctl1, prstctl2, 4);
-impl_perph_clk!(DMA0, Clkctl1, pscctl1, Rstctl1, prstctl1, 23);
-impl_perph_clk!(DMA1, Clkctl1, pscctl1, Rstctl1, prstctl1, 24);
-impl_perph_clk!(DMIC0, Clkctl1, pscctl0, Rstctl1, prstctl0, 24);
+impl_perph_clk!(PIMCTL, CLKCTL1, pscctl2, RSTCTL1, prstctl2, 31);
+impl_perph_clk!(ACMP, CLKCTL0, pscctl1, RSTCTL0, prstctl1, 15);
+impl_perph_clk!(ADC0, CLKCTL0, pscctl1, RSTCTL0, prstctl1, 16);
+impl_perph_clk!(CASPER, CLKCTL0, pscctl0, RSTCTL0, prstctl0, 9);
+impl_perph_clk!(CRC, CLKCTL1, pscctl1, RSTCTL1, prstctl1, 16);
+impl_perph_clk!(CTIMER0_COUNT_CHANNEL0, CLKCTL1, pscctl2, RSTCTL1, prstctl2, 0);
+impl_perph_clk!(CTIMER1_COUNT_CHANNEL0, CLKCTL1, pscctl2, RSTCTL1, prstctl2, 1);
+impl_perph_clk!(CTIMER2_COUNT_CHANNEL0, CLKCTL1, pscctl2, RSTCTL1, prstctl2, 2);
+impl_perph_clk!(CTIMER3_COUNT_CHANNEL0, CLKCTL1, pscctl2, RSTCTL1, prstctl2, 3);
+impl_perph_clk!(CTIMER4_COUNT_CHANNEL0, CLKCTL1, pscctl2, RSTCTL1, prstctl2, 4);
+impl_perph_clk!(DMA0, CLKCTL1, pscctl1, RSTCTL1, prstctl1, 23);
+impl_perph_clk!(DMA1, CLKCTL1, pscctl1, RSTCTL1, prstctl1, 24);
+impl_perph_clk!(DMIC0, CLKCTL1, pscctl0, RSTCTL1, prstctl0, 24);
 
 #[cfg(feature = "_espi")]
-impl_perph_clk!(ESPI, Clkctl0, pscctl1, Rstctl0, prstctl1, 7);
+impl_perph_clk!(ESPI, CLKCTL0, pscctl1, RSTCTL0, prstctl1, 7);
 
-impl_perph_clk!(FLEXCOMM0, Clkctl1, pscctl0, Rstctl1, prstctl0, 8);
-impl_perph_clk!(FLEXCOMM1, Clkctl1, pscctl0, Rstctl1, prstctl0, 9);
-impl_perph_clk!(FLEXCOMM14, Clkctl1, pscctl0, Rstctl1, prstctl0, 22);
-impl_perph_clk!(FLEXCOMM15, Clkctl1, pscctl0, Rstctl1, prstctl0, 23);
-impl_perph_clk!(FLEXCOMM2, Clkctl1, pscctl0, Rstctl1, prstctl0, 10);
-impl_perph_clk!(FLEXCOMM3, Clkctl1, pscctl0, Rstctl1, prstctl0, 11);
-impl_perph_clk!(FLEXCOMM4, Clkctl1, pscctl0, Rstctl1, prstctl0, 12);
-impl_perph_clk!(FLEXCOMM5, Clkctl1, pscctl0, Rstctl1, prstctl0, 13);
-impl_perph_clk!(FLEXCOMM6, Clkctl1, pscctl0, Rstctl1, prstctl0, 14);
-impl_perph_clk!(FLEXCOMM7, Clkctl1, pscctl0, Rstctl1, prstctl0, 15);
-impl_perph_clk!(FLEXSPI, Clkctl0, pscctl0, Rstctl0, prstctl0, 16);
-impl_perph_clk!(FREQME, Clkctl1, pscctl1, Rstctl1, prstctl1, 31);
-impl_perph_clk!(HASHCRYPT, Clkctl0, pscctl0, Rstctl0, prstctl0, 10);
-impl_perph_clk!(HSGPIO0, Clkctl1, pscctl1, Rstctl1, prstctl1, 0);
-impl_perph_clk!(HSGPIO1, Clkctl1, pscctl1, Rstctl1, prstctl1, 1);
-impl_perph_clk!(HSGPIO2, Clkctl1, pscctl1, Rstctl1, prstctl1, 2);
-impl_perph_clk!(HSGPIO3, Clkctl1, pscctl1, Rstctl1, prstctl1, 3);
-impl_perph_clk!(HSGPIO4, Clkctl1, pscctl1, Rstctl1, prstctl1, 4);
-impl_perph_clk!(HSGPIO5, Clkctl1, pscctl1, Rstctl1, prstctl1, 5);
-impl_perph_clk!(HSGPIO6, Clkctl1, pscctl1, Rstctl1, prstctl1, 6);
-impl_perph_clk!(HSGPIO7, Clkctl1, pscctl1, Rstctl1, prstctl1, 7);
-impl_perph_clk!(I3C0, Clkctl1, pscctl2, Rstctl1, prstctl2, 16);
-impl_perph_clk!(MRT0, Clkctl1, pscctl2, Rstctl1, prstctl2, 8);
-impl_perph_clk!(MU_A, Clkctl1, pscctl1, Rstctl1, prstctl1, 28);
-impl_perph_clk!(OS_EVENT, Clkctl1, pscctl0, Rstctl1, prstctl0, 27);
-impl_perph_clk!(POWERQUAD, Clkctl0, pscctl0, Rstctl0, prstctl0, 8);
-impl_perph_clk!(PUF, Clkctl0, pscctl0, Rstctl0, prstctl0, 11);
-impl_perph_clk!(RNG, Clkctl0, pscctl0, Rstctl0, prstctl0, 12);
-impl_perph_clk!(RTC, Clkctl1, pscctl2, Rstctl1, prstctl2, 7);
-impl_perph_clk!(SCT0, Clkctl0, pscctl0, Rstctl0, prstctl0, 24);
-impl_perph_clk!(SECGPIO, Clkctl0, pscctl1, Rstctl0, prstctl1, 24);
-impl_perph_clk!(SEMA42, Clkctl1, pscctl1, Rstctl1, prstctl1, 29);
-impl_perph_clk!(USBHSD, Clkctl0, pscctl0, Rstctl0, prstctl0, 21);
-impl_perph_clk!(USBHSH, Clkctl0, pscctl0, Rstctl0, prstctl0, 22);
-impl_perph_clk!(USBPHY, Clkctl0, pscctl0, Rstctl0, prstctl0, 20);
-impl_perph_clk!(USDHC0, Clkctl0, pscctl1, Rstctl0, prstctl1, 2);
-impl_perph_clk!(USDHC1, Clkctl0, pscctl1, Rstctl0, prstctl1, 3);
-impl_perph_clk!(UTICK0, Clkctl0, pscctl2, Rstctl0, prstctl2, 0);
-impl_perph_clk!(WDT0, Clkctl0, pscctl2, Rstctl0, prstctl2, 1);
-impl_perph_clk!(WDT1, Clkctl1, pscctl2, Rstctl1, prstctl2, 10);
+impl_perph_clk!(FLEXCOMM0, CLKCTL1, pscctl0, RSTCTL1, prstctl0, 8);
+impl_perph_clk!(FLEXCOMM1, CLKCTL1, pscctl0, RSTCTL1, prstctl0, 9);
+impl_perph_clk!(FLEXCOMM14, CLKCTL1, pscctl0, RSTCTL1, prstctl0, 22);
+impl_perph_clk!(FLEXCOMM15, CLKCTL1, pscctl0, RSTCTL1, prstctl0, 23);
+impl_perph_clk!(FLEXCOMM2, CLKCTL1, pscctl0, RSTCTL1, prstctl0, 10);
+impl_perph_clk!(FLEXCOMM3, CLKCTL1, pscctl0, RSTCTL1, prstctl0, 11);
+impl_perph_clk!(FLEXCOMM4, CLKCTL1, pscctl0, RSTCTL1, prstctl0, 12);
+impl_perph_clk!(FLEXCOMM5, CLKCTL1, pscctl0, RSTCTL1, prstctl0, 13);
+impl_perph_clk!(FLEXCOMM6, CLKCTL1, pscctl0, RSTCTL1, prstctl0, 14);
+impl_perph_clk!(FLEXCOMM7, CLKCTL1, pscctl0, RSTCTL1, prstctl0, 15);
+impl_perph_clk!(FLEXSPI, CLKCTL0, pscctl0, RSTCTL0, prstctl0, 16);
+impl_perph_clk!(FREQME, CLKCTL1, pscctl1, RSTCTL1, prstctl1, 31);
+impl_perph_clk!(HASHCRYPT, CLKCTL0, pscctl0, RSTCTL0, prstctl0, 10);
+impl_perph_clk!(HSGPIO0, CLKCTL1, pscctl1, RSTCTL1, prstctl1, 0);
+impl_perph_clk!(HSGPIO1, CLKCTL1, pscctl1, RSTCTL1, prstctl1, 1);
+impl_perph_clk!(HSGPIO2, CLKCTL1, pscctl1, RSTCTL1, prstctl1, 2);
+impl_perph_clk!(HSGPIO3, CLKCTL1, pscctl1, RSTCTL1, prstctl1, 3);
+impl_perph_clk!(HSGPIO4, CLKCTL1, pscctl1, RSTCTL1, prstctl1, 4);
+impl_perph_clk!(HSGPIO5, CLKCTL1, pscctl1, RSTCTL1, prstctl1, 5);
+impl_perph_clk!(HSGPIO6, CLKCTL1, pscctl1, RSTCTL1, prstctl1, 6);
+impl_perph_clk!(HSGPIO7, CLKCTL1, pscctl1, RSTCTL1, prstctl1, 7);
+impl_perph_clk!(I3C0, CLKCTL1, pscctl2, RSTCTL1, prstctl2, 16);
+impl_perph_clk!(MRT0, CLKCTL1, pscctl2, RSTCTL1, prstctl2, 8);
+impl_perph_clk!(MU_A, CLKCTL1, pscctl1, RSTCTL1, prstctl1, 28);
+impl_perph_clk!(OS_EVENT, CLKCTL1, pscctl0, RSTCTL1, prstctl0, 27);
+impl_perph_clk!(POWERQUAD, CLKCTL0, pscctl0, RSTCTL0, prstctl0, 8);
+impl_perph_clk!(PUF, CLKCTL0, pscctl0, RSTCTL0, prstctl0, 11);
+impl_perph_clk!(RNG, CLKCTL0, pscctl0, RSTCTL0, prstctl0, 12);
+impl_perph_clk!(RTC, CLKCTL1, pscctl2, RSTCTL1, prstctl2, 7);
+impl_perph_clk!(SCT0, CLKCTL0, pscctl0, RSTCTL0, prstctl0, 24);
+impl_perph_clk!(SECGPIO, CLKCTL0, pscctl1, RSTCTL0, prstctl1, 24);
+impl_perph_clk!(SEMA42, CLKCTL1, pscctl1, RSTCTL1, prstctl1, 29);
+impl_perph_clk!(USBHSD, CLKCTL0, pscctl0, RSTCTL0, prstctl0, 21);
+impl_perph_clk!(USBHSH, CLKCTL0, pscctl0, RSTCTL0, prstctl0, 22);
+impl_perph_clk!(USBPHY, CLKCTL0, pscctl0, RSTCTL0, prstctl0, 20);
+impl_perph_clk!(USDHC0, CLKCTL0, pscctl1, RSTCTL0, prstctl1, 2);
+impl_perph_clk!(USDHC1, CLKCTL0, pscctl1, RSTCTL0, prstctl1, 3);
+impl_perph_clk!(UTICK0, CLKCTL0, pscctl2, RSTCTL0, prstctl2, 0);
+impl_perph_clk!(WDT0, CLKCTL0, pscctl2, RSTCTL0, prstctl2, 1);
+impl_perph_clk!(WDT1, CLKCTL1, pscctl2, RSTCTL1, prstctl2, 10);

--- a/embassy-imxrt/src/crc.rs
+++ b/embassy-imxrt/src/crc.rs
@@ -3,8 +3,20 @@
 use core::marker::PhantomData;
 
 use crate::clocks::{SysconPeripheral, enable_and_reset};
-pub use crate::pac::crc_engine::mode::CrcPolynomial as Polynomial;
 use crate::{Peri, PeripheralType, peripherals};
+
+/// CRC polynomial selection.
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+#[repr(u8)]
+pub enum Polynomial {
+    /// CRC-CCITT polynomial
+    CrcCcitt = 0,
+    /// CRC-16 polynomial
+    Crc16 = 1,
+    /// CRC-32 polynomial
+    Crc32 = 2,
+}
 
 /// CRC driver.
 pub struct Crc<'d> {
@@ -88,30 +100,22 @@ impl<'d> Crc<'d> {
     /// Reconfigured the CRC peripheral.
     fn reconfigure(&mut self) {
         self.info.regs.mode().write(|w| {
-            w.crc_poly()
-                .variant(self._config.polynomial)
-                .bit_rvs_wr()
-                .variant(self._config.reverse_in)
-                .cmpl_wr()
-                .variant(self._config.complement_in)
-                .bit_rvs_sum()
-                .variant(self._config.reverse_out)
-                .cmpl_sum()
-                .variant(self._config.complement_out)
+            w.set_crc_poly(self._config.polynomial as u8);
+            w.set_bit_rvs_wr(self._config.reverse_in);
+            w.set_cmpl_wr(self._config.complement_in);
+            w.set_bit_rvs_sum(self._config.reverse_out);
+            w.set_cmpl_sum(self._config.complement_out);
         });
 
         // Init CRC value
-        self.info
-            .regs
-            .seed()
-            .write(|w| unsafe { w.crc_seed().bits(self._config.seed) });
+        self.info.regs.seed().write(|w| w.set_crc_seed(self._config.seed));
     }
 
     /// Feeds a byte into the CRC peripheral. Returns the computed checksum.
     pub fn feed_byte(&mut self, byte: u8) -> u32 {
-        self.info.regs.wr_data8().write(|w| unsafe { w.bits(byte) });
+        self.info.regs.wr_data8().write(|w| w.set_data(byte));
 
-        self.info.regs.sum().read().bits()
+        self.info.regs.sum().read().crc_sum()
     }
 
     /// Feeds an slice of bytes into the CRC peripheral. Returns the computed checksum.
@@ -119,55 +123,55 @@ impl<'d> Crc<'d> {
         let (prefix, data, suffix) = unsafe { bytes.align_to::<u32>() };
 
         for b in prefix {
-            self.info.regs.wr_data8().write(|w| unsafe { w.bits(*b) });
+            self.info.regs.wr_data8().write(|w| w.set_data(*b));
         }
 
         for d in data {
-            self.info.regs.wr_data32().write(|w| unsafe { w.bits(*d) });
+            self.info.regs.wr_data32().write(|w| w.set_data(*d));
         }
 
         for b in suffix {
-            self.info.regs.wr_data8().write(|w| unsafe { w.bits(*b) });
+            self.info.regs.wr_data8().write(|w| w.set_data(*b));
         }
 
-        self.info.regs.sum().read().bits()
+        self.info.regs.sum().read().crc_sum()
     }
 
     /// Feeds a halfword into the CRC peripheral. Returns the computed checksum.
     pub fn feed_halfword(&mut self, halfword: u16) -> u32 {
-        self.info.regs.wr_data16().write(|w| unsafe { w.bits(halfword) });
+        self.info.regs.wr_data16().write(|w| w.set_data(halfword));
 
-        self.info.regs.sum().read().bits()
+        self.info.regs.sum().read().crc_sum()
     }
 
     /// Feeds an slice of halfwords into the CRC peripheral. Returns the computed checksum.
     pub fn feed_halfwords(&mut self, halfwords: &[u16]) -> u32 {
         for halfword in halfwords {
-            self.info.regs.wr_data16().write(|w| unsafe { w.bits(*halfword) });
+            self.info.regs.wr_data16().write(|w| w.set_data(*halfword));
         }
 
-        self.info.regs.sum().read().bits()
+        self.info.regs.sum().read().crc_sum()
     }
 
     /// Feeds a words into the CRC peripheral. Returns the computed checksum.
     pub fn feed_word(&mut self, word: u32) -> u32 {
-        self.info.regs.wr_data32().write(|w| unsafe { w.bits(word) });
+        self.info.regs.wr_data32().write(|w| w.set_data(word));
 
-        self.info.regs.sum().read().bits()
+        self.info.regs.sum().read().crc_sum()
     }
 
     /// Feeds an slice of words into the CRC peripheral. Returns the computed checksum.
     pub fn feed_words(&mut self, words: &[u32]) -> u32 {
         for word in words {
-            self.info.regs.wr_data32().write(|w| unsafe { w.bits(*word) });
+            self.info.regs.wr_data32().write(|w| w.set_data(*word));
         }
 
-        self.info.regs.sum().read().bits()
+        self.info.regs.sum().read().crc_sum()
     }
 }
 
 struct Info {
-    regs: crate::pac::CrcEngine,
+    regs: crate::pac::crc::Crc,
 }
 
 trait SealedInstance {
@@ -182,9 +186,8 @@ impl Instance for peripherals::CRC {}
 
 impl SealedInstance for peripherals::CRC {
     fn info() -> Info {
-        // SAFETY: safe from single executor
         Info {
-            regs: unsafe { crate::pac::CrcEngine::steal() },
+            regs: crate::pac::CRC_ENGINE,
         }
     }
 }

--- a/embassy-imxrt/src/dma.rs
+++ b/embassy-imxrt/src/dma.rs
@@ -7,8 +7,7 @@ use core::task::{Context, Poll};
 
 use embassy_hal_internal::{Peri, PeripheralType, impl_peripheral};
 use embassy_sync::waitqueue::AtomicWaker;
-use pac::dma0::channel::cfg::Periphreqen;
-use pac::dma0::channel::xfercfg::{Dstinc, Srcinc, Width};
+use pac::dma::vals::{Dstinc, Srcinc, Width};
 
 use crate::clocks::enable_and_reset;
 use crate::interrupt::InterruptExt;
@@ -21,47 +20,51 @@ pub(crate) const MAX_CHUNK_SIZE: usize = 1024;
 #[cfg(feature = "rt")]
 #[interrupt]
 fn DMA0() {
-    let reg = unsafe { crate::pac::Dma0::steal() };
+    let reg = crate::pac::DMA0;
 
-    if reg.intstat().read().activeerrint().bit() {
-        let err = reg.errint0().read().bits();
+    if reg.intstat().read().activeerrint() {
+        let err = reg.errint0().read().0;
 
         for channel in BitIter(err) {
             error!("DMA error interrupt on channel {}!", channel);
-            reg.errint0().write(|w| unsafe { w.err().bits(1 << channel) });
+            reg.errint0().write(|w| w.set_channel(channel as usize, true));
             CHANNEL_WAKERS[channel as usize].wake();
         }
     }
 
-    if reg.intstat().read().activeint().bit() {
-        let ia = reg.inta0().read().bits();
+    if reg.intstat().read().activeint() {
+        let ia = reg.inta0().read().0;
 
         for channel in BitIter(ia) {
-            reg.inta0().write(|w| unsafe { w.ia().bits(1 << channel) });
+            reg.inta0().write(|w| w.set_channel(channel as usize, true));
             CHANNEL_WAKERS[channel as usize].wake();
         }
     }
 }
 
 /// Initialize DMA controllers (DMA0 only, for now)
+///
+/// # Safety
+///
+/// Must be called exactly once during system initialization.
 pub(crate) unsafe fn init() {
-    let sysctl0 = crate::pac::Sysctl0::steal();
-    let dmactl0 = crate::pac::Dma0::steal();
+    let sysctl0 = crate::pac::SYSCTL0;
+    let dmactl0 = crate::pac::DMA0;
 
     enable_and_reset::<DMA0>();
 
     interrupt::DMA0.disable();
     interrupt::DMA0.set_priority(interrupt::Priority::P3);
 
-    dmactl0.ctrl().modify(|_, w| w.enable().set_bit());
+    dmactl0.ctrl().modify(|w| w.set_enable(true));
 
     // Set channel descriptor SRAM base address
     // Descriptor base must be 1K aligned
     let descriptor_base = core::ptr::addr_of!(DESCRIPTORS.descs) as u32;
-    dmactl0.srambase().write(|w| w.bits(descriptor_base));
+    dmactl0.srambase().write(|w| w.set_offset(descriptor_base));
 
     // Ensure AHB priority it highest (M4 == DMAC0)
-    sysctl0.ahbmatrixprior().modify(|_, w| w.m4().bits(0));
+    sysctl0.ahbmatrixprior().modify(|w| w.set_m4(0));
 
     interrupt::DMA0.unpend();
     interrupt::DMA0.enable();
@@ -69,7 +72,9 @@ pub(crate) unsafe fn init() {
 
 /// DMA read.
 ///
-/// SAFETY: Slice must point to a valid location reachable by DMA.
+/// # Safety
+///
+/// Slice must point to a valid location reachable by DMA.
 pub unsafe fn read<'a, C: Channel, W: Word>(ch: Peri<'a, C>, from: *const W, to: *mut [W]) -> Transfer<'a, C> {
     let count = (to.len().div_ceil(W::size() as usize) - 1) as isize;
 
@@ -87,7 +92,9 @@ pub unsafe fn read<'a, C: Channel, W: Word>(ch: Peri<'a, C>, from: *const W, to:
 
 /// DMA write.
 ///
-/// SAFETY: Slice must point to a valid location reachable by DMA.
+/// # Safety
+///
+/// Slice must point to a valid location reachable by DMA.
 pub unsafe fn write<'a, C: Channel, W: Word>(ch: Peri<'a, C>, from: *const [W], to: *mut W) -> Transfer<'a, C> {
     let count = (from.len().div_ceil(W::size() as usize) - 1) as isize;
 
@@ -105,7 +112,9 @@ pub unsafe fn write<'a, C: Channel, W: Word>(ch: Peri<'a, C>, from: *const [W], 
 
 /// DMA copy between slices.
 ///
-/// SAFETY: Slices must point to locations reachable by DMA.
+/// # Safety
+///
+/// Slices must point to locations reachable by DMA.
 pub unsafe fn copy<'a, C: Channel, W: Word>(ch: Peri<'a, C>, from: &[W], to: &mut [W]) -> Transfer<'a, C> {
     let from_len = from.len();
     let to_len = to.len();
@@ -125,6 +134,7 @@ pub unsafe fn copy<'a, C: Channel, W: Word>(ch: Peri<'a, C>, from: &[W], to: &mu
     )
 }
 
+#[allow(clippy::too_many_arguments)]
 fn copy_inner<'a, C: Channel>(
     ch: Peri<'a, C>,
     from: *const u32,
@@ -144,53 +154,39 @@ fn copy_inner<'a, C: Channel>(
 
     compiler_fence(Ordering::SeqCst);
 
-    p.errint0().write(|w| unsafe { w.err().bits(1 << ch.number()) });
-    p.inta0().write(|w| unsafe { w.ia().bits(1 << ch.number()) });
+    p.errint0().write(|w| w.set_channel(ch.number() as usize, true));
+    p.inta0().write(|w| w.set_channel(ch.number() as usize, true));
 
-    p.channel(ch.number().into()).cfg().write(|w| {
-        unsafe { w.chpriority().bits(0) }
-            .periphreqen()
-            .variant(match periph {
-                false => Periphreqen::Disabled,
-                true => Periphreqen::Enabled,
-            })
-            .hwtrigen()
-            .clear_bit()
+    p.channel(ch.number() as usize).cfg().write(|w| {
+        w.set_chpriority(0);
+        w.set_periphreqen(periph);
+        w.set_hwtrigen(false);
     });
 
-    p.intenset0().write(|w| unsafe { w.inten().bits(1 << ch.number()) });
+    p.intenset0().write(|w| w.set_channel(ch.number() as usize, true));
 
-    p.channel(ch.number().into()).xfercfg().write(|w| {
-        unsafe { w.xfercount().bits(count as u16) }
-            .cfgvalid()
-            .set_bit()
-            .clrtrig()
-            .set_bit()
-            .reload()
-            .clear_bit()
-            .setinta()
-            .set_bit()
-            .width()
-            .variant(width)
-            .srcinc()
-            .variant(match incr_read {
-                false => Srcinc::NoIncrement,
-                true => Srcinc::WidthX1,
-                // REVISIT: what about WidthX2 and WidthX4?
-            })
-            .dstinc()
-            .variant(match incr_write {
-                false => Dstinc::NoIncrement,
-                true => Dstinc::WidthX1,
-                // REVISIT: what about WidthX2 and WidthX4?
-            })
+    p.channel(ch.number() as usize).xfercfg().write(|w| {
+        w.set_xfercount(count as u16);
+        w.set_cfgvalid(true);
+        w.set_clrtrig(true);
+        w.set_reload(false);
+        w.set_setinta(true);
+        w.set_width(width);
+        w.set_srcinc(match incr_read {
+            false => Srcinc::NO_INCREMENT,
+            true => Srcinc::WIDTH_X_1,
+            // REVISIT: what about WidthX2 and WidthX4?
+        });
+        w.set_dstinc(match incr_write {
+            false => Dstinc::NO_INCREMENT,
+            true => Dstinc::WIDTH_X_1,
+            // REVISIT: what about WidthX2 and WidthX4?
+        });
     });
 
-    p.enableset0().write(|w| unsafe { w.ena().bits(1 << ch.number()) });
+    p.enableset0().write(|w| w.set_channel(ch.number() as usize, true));
 
-    p.channel(ch.number().into())
-        .xfercfg()
-        .modify(|_, w| w.swtrig().set_bit());
+    p.channel(ch.number() as usize).xfercfg().modify(|w| w.set_swtrig(true));
 
     compiler_fence(Ordering::SeqCst);
 
@@ -211,28 +207,21 @@ impl<'a, C: Channel> Transfer<'a, C> {
     pub(crate) fn abort(&mut self) -> usize {
         let p = self.channel.regs();
 
-        p.abort0().write(|w| w.channel(self.channel.number()).set_bit());
-        while p.busy0().read().bsy().bits() & (1 << self.channel.number()) != 0 {}
+        p.abort0()
+            .write(|w| w.set_channel(self.channel.number() as usize, true));
+        while p.busy0().read().channel(self.channel.number() as usize) {}
 
         p.enableclr0()
-            .write(|w| unsafe { w.clr().bits(1 << self.channel.number()) });
+            .write(|w| w.set_channel(self.channel.number() as usize, true));
 
         let width: u8 = p
-            .channel(self.channel.number().into())
+            .channel(self.channel.number() as usize)
             .xfercfg()
             .read()
             .width()
-            .variant()
-            .unwrap()
             .into();
 
-        let count = p
-            .channel(self.channel.number().into())
-            .xfercfg()
-            .read()
-            .xfercount()
-            .bits()
-            + 1;
+        let count = p.channel(self.channel.number() as usize).xfercfg().read().xfercount() + 1;
 
         usize::from(count) * usize::from(width)
     }
@@ -253,7 +242,13 @@ impl<'a, C: Channel> Future for Transfer<'a, C> {
         // wake will deregister the waker.
         CHANNEL_WAKERS[self.channel.number() as usize].register(cx.waker());
 
-        if self.channel.regs().active0().read().act().bits() & (1 << self.channel.number()) == 0 {
+        if !self
+            .channel
+            .regs()
+            .active0()
+            .read()
+            .channel(self.channel.number() as usize)
+        {
             Poll::Ready(())
         } else {
             Poll::Pending
@@ -306,8 +301,8 @@ pub trait Channel: PeripheralType + Sealed + Into<AnyChannel> + Sized + 'static 
     fn number(&self) -> u8;
 
     /// Channel registry block.
-    fn regs(&self) -> &'static pac::dma0::RegisterBlock {
-        unsafe { &*crate::pac::Dma0::ptr() }
+    fn regs(&self) -> pac::dma::Dma {
+        crate::pac::DMA0
     }
 }
 
@@ -324,7 +319,7 @@ pub trait Word: Sealed {
 impl Sealed for u8 {}
 impl Word for u8 {
     fn width() -> Width {
-        Width::Bit8
+        Width::BIT_8
     }
 
     fn size() -> isize {
@@ -335,7 +330,7 @@ impl Word for u8 {
 impl Sealed for u16 {}
 impl Word for u16 {
     fn width() -> Width {
-        Width::Bit16
+        Width::BIT_16
     }
 
     fn size() -> isize {
@@ -346,7 +341,7 @@ impl Word for u16 {
 impl Sealed for u32 {}
 impl Word for u32 {
     fn width() -> Width {
-        Width::Bit32
+        Width::BIT_32
     }
 
     fn size() -> isize {

--- a/embassy-imxrt/src/flexcomm/mod.rs
+++ b/embassy-imxrt/src/flexcomm/mod.rs
@@ -51,7 +51,7 @@ mod sealed {
 /// primary low-level flexcomm interface
 pub(crate) trait FlexcommLowLevel: sealed::Sealed + PeripheralType + SysconPeripheral + 'static + Send {
     // fetch the flexcomm register block for direct manipulation
-    fn reg() -> &'static pac::flexcomm0::RegisterBlock;
+    fn reg() -> pac::flexcomm::Flexcomm;
 
     // set the clock select for this flexcomm instance and remove from reset
     fn enable(clk: Clock);
@@ -64,45 +64,40 @@ macro_rules! impl_flexcomm {
 		impl sealed::Sealed for crate::peripherals::[<FLEXCOMM $idx>] {}
 
 		impl FlexcommLowLevel for crate::peripherals::[<FLEXCOMM $idx>] {
-		    fn reg() -> &'static crate::pac::flexcomm0::RegisterBlock {
-			// SAFETY: safe from single executor, enforce
-			// via peripheral reference lifetime tracking
-			unsafe {
-			    &*crate::pac::[<Flexcomm $idx>]::ptr()
-			}
+		    fn reg() -> crate::pac::flexcomm::Flexcomm {
+			crate::pac::[<FLEXCOMM $idx>]
 		    }
 
 		    fn enable(clk: Clock) {
-			// SAFETY: safe from single executor
-			let clkctl1 = unsafe { crate::pac::Clkctl1::steal() };
+			use crate::pac::clkctl1::vals::{FcfclkselSel, FrgclkselSel};
 
-			clkctl1.flexcomm($idx).fcfclksel().write(|w| match clk {
-			    Clock::Sfro => w.sel().sfro_clk(),
-			    Clock::Ffro => w.sel().ffro_clk(),
-			    Clock::AudioPll => w.sel().audio_pll_clk(),
-			    Clock::Master => w.sel().master_clk(),
-			    Clock::FcnFrgMain => w.sel().fcn_frg_clk(),
-			    Clock::FcnFrgPll => w.sel().fcn_frg_clk(),
-			    Clock::FcnFrgSfro => w.sel().fcn_frg_clk(),
-			    Clock::FcnFrgFfro => w.sel().fcn_frg_clk(),
-			    Clock::None => w.sel().none(), // no clock? throw an error?
-			});
+			let clkctl1 = crate::pac::CLKCTL1;
 
-			clkctl1.flexcomm($idx).frgclksel().write(|w| match clk {
-			    Clock::FcnFrgMain => w.sel().main_clk(),
-			    Clock::FcnFrgPll => w.sel().frg_pll_clk(),
-			    Clock::FcnFrgSfro => w.sel().sfro_clk(),
-			    Clock::FcnFrgFfro => w.sel().ffro_clk(),
-			    _ => w.sel().none(),    // not using frg ...
-			});
+			clkctl1.flexcomm($idx).fcfclksel().write(|w| w.set_sel(match clk {
+			    Clock::Sfro => FcfclkselSel::SFRO_CLK,
+			    Clock::Ffro => FcfclkselSel::FFRO_CLK,
+			    Clock::AudioPll => FcfclkselSel::AUDIO_PLL_CLK,
+			    Clock::Master => FcfclkselSel::MASTER_CLK,
+			    Clock::FcnFrgMain => FcfclkselSel::FCN_FRG_CLK,
+			    Clock::FcnFrgPll => FcfclkselSel::FCN_FRG_CLK,
+			    Clock::FcnFrgSfro => FcfclkselSel::FCN_FRG_CLK,
+			    Clock::FcnFrgFfro => FcfclkselSel::FCN_FRG_CLK,
+			    Clock::None => FcfclkselSel::NONE, // no clock? throw an error?
+			}));
+
+			clkctl1.flexcomm($idx).frgclksel().write(|w| w.set_sel(match clk {
+			    Clock::FcnFrgMain => FrgclkselSel::MAIN_CLK,
+			    Clock::FcnFrgPll => FrgclkselSel::FRG_PLL_CLK,
+			    Clock::FcnFrgSfro => FrgclkselSel::SFRO_CLK,
+			    Clock::FcnFrgFfro => FrgclkselSel::FFRO_CLK,
+			    _ => FrgclkselSel::NONE,    // not using frg ...
+			}));
 
 			// todo: add support for frg div/mult
 			clkctl1
 			    .flexcomm($idx)
 			    .frgctl()
-			    .write(|w|
-				   // SAFETY: unsafe only used for .bits() call
-				   unsafe { w.mult().bits(0) });
+			    .write(|w| w.set_mult(0));
 
 			enable_and_reset::<[<FLEXCOMM $idx>]>();
 		    }
@@ -119,40 +114,41 @@ impl_flexcomm!(0, 1, 2, 3, 4, 5, 6, 7);
 impl sealed::Sealed for crate::peripherals::FLEXCOMM14 {}
 
 impl FlexcommLowLevel for crate::peripherals::FLEXCOMM14 {
-    fn reg() -> &'static crate::pac::flexcomm0::RegisterBlock {
-        // SAFETY: safe from single executor, enforce
-        // via peripheral reference lifetime tracking
-        unsafe { &*crate::pac::Flexcomm14::ptr() }
+    fn reg() -> crate::pac::flexcomm::Flexcomm {
+        crate::pac::FLEXCOMM14
     }
 
     fn enable(clk: Clock) {
-        // SAFETY: safe from single executor
-        let clkctl1 = unsafe { crate::pac::Clkctl1::steal() };
+        use crate::pac::clkctl1::vals::{Fc14fclkselSel, Frg14clkselSel};
 
-        clkctl1.fc14fclksel().write(|w| match clk {
-            Clock::Sfro => w.sel().sfro_clk(),
-            Clock::Ffro => w.sel().ffro_clk(),
-            Clock::AudioPll => w.sel().audio_pll_clk(),
-            Clock::Master => w.sel().master_clk(),
-            Clock::FcnFrgMain => w.sel().fcn_frg_clk(),
-            Clock::FcnFrgPll => w.sel().fcn_frg_clk(),
-            Clock::FcnFrgSfro => w.sel().fcn_frg_clk(),
-            Clock::FcnFrgFfro => w.sel().fcn_frg_clk(),
-            Clock::None => w.sel().none(), // no clock? throw an error?
+        let clkctl1 = crate::pac::CLKCTL1;
+
+        clkctl1.fc14fclksel().write(|w| {
+            w.set_sel(match clk {
+                Clock::Sfro => Fc14fclkselSel::SFRO_CLK,
+                Clock::Ffro => Fc14fclkselSel::FFRO_CLK,
+                Clock::AudioPll => Fc14fclkselSel::AUDIO_PLL_CLK,
+                Clock::Master => Fc14fclkselSel::MASTER_CLK,
+                Clock::FcnFrgMain => Fc14fclkselSel::FCN_FRG_CLK,
+                Clock::FcnFrgPll => Fc14fclkselSel::FCN_FRG_CLK,
+                Clock::FcnFrgSfro => Fc14fclkselSel::FCN_FRG_CLK,
+                Clock::FcnFrgFfro => Fc14fclkselSel::FCN_FRG_CLK,
+                Clock::None => Fc14fclkselSel::NONE, // no clock? throw an error?
+            })
         });
 
-        clkctl1.frg14clksel().write(|w| match clk {
-            Clock::FcnFrgMain => w.sel().main_clk(),
-            Clock::FcnFrgPll => w.sel().frg_pll_clk(),
-            Clock::FcnFrgSfro => w.sel().sfro_clk(),
-            Clock::FcnFrgFfro => w.sel().ffro_clk(),
-            _ => w.sel().none(), // not using frg ...
+        clkctl1.frg14clksel().write(|w| {
+            w.set_sel(match clk {
+                Clock::FcnFrgMain => Frg14clkselSel::MAIN_CLK,
+                Clock::FcnFrgPll => Frg14clkselSel::FRG_PLL_CLK,
+                Clock::FcnFrgSfro => Frg14clkselSel::SFRO_CLK,
+                Clock::FcnFrgFfro => Frg14clkselSel::FFRO_CLK,
+                _ => Frg14clkselSel::NONE, // not using frg ...
+            })
         });
 
         // todo: add support for frg div/mult
-        clkctl1.frg14ctl().write(|w|
-                // SAFETY: unsafe only used for .bits() call
-                unsafe { w.mult().bits(0) });
+        clkctl1.frg14ctl().write(|w| w.set_mult(0));
 
         enable_and_reset::<FLEXCOMM14>();
     }
@@ -162,38 +158,39 @@ impl FlexcommLowLevel for crate::peripherals::FLEXCOMM14 {
 impl sealed::Sealed for crate::peripherals::FLEXCOMM15 {}
 
 impl FlexcommLowLevel for crate::peripherals::FLEXCOMM15 {
-    fn reg() -> &'static crate::pac::flexcomm0::RegisterBlock {
-        // SAFETY: safe from single executor, enforce
-        // via peripheral reference lifetime tracking
-        unsafe { &*crate::pac::Flexcomm15::ptr() }
+    fn reg() -> crate::pac::flexcomm::Flexcomm {
+        crate::pac::FLEXCOMM15
     }
 
     fn enable(clk: Clock) {
-        // SAFETY: safe from single executor
-        let clkctl1 = unsafe { crate::pac::Clkctl1::steal() };
+        use crate::pac::clkctl1::vals::{Fc15fclkselSel, Frg15clkselSel};
 
-        clkctl1.fc15fclksel().write(|w| match clk {
-            Clock::Sfro => w.sel().sfro_clk(),
-            Clock::Ffro => w.sel().ffro_clk(),
-            Clock::AudioPll => w.sel().audio_pll_clk(),
-            Clock::Master => w.sel().master_clk(),
-            Clock::FcnFrgMain => w.sel().fcn_frg_clk(),
-            Clock::FcnFrgPll => w.sel().fcn_frg_clk(),
-            Clock::FcnFrgSfro => w.sel().fcn_frg_clk(),
-            Clock::FcnFrgFfro => w.sel().fcn_frg_clk(),
-            Clock::None => w.sel().none(), // no clock? throw an error?
+        let clkctl1 = crate::pac::CLKCTL1;
+
+        clkctl1.fc15fclksel().write(|w| {
+            w.set_sel(match clk {
+                Clock::Sfro => Fc15fclkselSel::SFRO_CLK,
+                Clock::Ffro => Fc15fclkselSel::FFRO_CLK,
+                Clock::AudioPll => Fc15fclkselSel::AUDIO_PLL_CLK,
+                Clock::Master => Fc15fclkselSel::MASTER_CLK,
+                Clock::FcnFrgMain => Fc15fclkselSel::FCN_FRG_CLK,
+                Clock::FcnFrgPll => Fc15fclkselSel::FCN_FRG_CLK,
+                Clock::FcnFrgSfro => Fc15fclkselSel::FCN_FRG_CLK,
+                Clock::FcnFrgFfro => Fc15fclkselSel::FCN_FRG_CLK,
+                Clock::None => Fc15fclkselSel::NONE, // no clock? throw an error?
+            })
         });
-        clkctl1.frg15clksel().write(|w| match clk {
-            Clock::FcnFrgMain => w.sel().main_clk(),
-            Clock::FcnFrgPll => w.sel().frg_pll_clk(),
-            Clock::FcnFrgSfro => w.sel().sfro_clk(),
-            Clock::FcnFrgFfro => w.sel().ffro_clk(),
-            _ => w.sel().none(), // not using frg ...
+        clkctl1.frg15clksel().write(|w| {
+            w.set_sel(match clk {
+                Clock::FcnFrgMain => Frg15clkselSel::MAIN_CLK,
+                Clock::FcnFrgPll => Frg15clkselSel::FRG_PLL_CLK,
+                Clock::FcnFrgSfro => Frg15clkselSel::SFRO_CLK,
+                Clock::FcnFrgFfro => Frg15clkselSel::FFRO_CLK,
+                _ => Frg15clkselSel::NONE, // not using frg ...
+            })
         });
         // todo: add support for frg div/mult
-        clkctl1.frg15ctl().write(|w|
-                // SAFETY: unsafe only used for .bits() call
-                unsafe { w.mult().bits(0) });
+        clkctl1.frg15ctl().write(|w| w.set_mult(0));
 
         enable_and_reset::<FLEXCOMM15>();
     }
@@ -210,7 +207,7 @@ macro_rules! into_mode {
             pub trait [<Into $mode:camel>]: [<SealedInto $mode:camel>] {
                 /// Set mode of operation
                 fn [<into_ $mode>]() {
-                    Self::reg().pselid().write(|w| w.persel().[<$mode>]());
+                    Self::reg().pselid().write(|w| w.set_persel(pac::flexcomm::vals::Persel::[<$mode:upper>]));
                 }
             }
         }

--- a/embassy-imxrt/src/flexcomm/spi.rs
+++ b/embassy-imxrt/src/flexcomm/spi.rs
@@ -15,7 +15,7 @@ use crate::gpio::{AnyPin, GpioPin as Pin};
 use crate::interrupt;
 use crate::interrupt::typelevel::Interrupt;
 use crate::iopctl::{DriveMode, DriveStrength, Inverter, IopctlPin, Pull, SlewRate};
-use crate::pac::spi0::cfg::{Cpha, Cpol};
+use crate::pac::spi::vals::{Cpha, Cpol, Master, Rxignore};
 
 /// Driver move trait.
 #[allow(private_bounds)]
@@ -100,21 +100,21 @@ impl<'a, M: IoMode> Spi<'a, M> {
     /// Read data from Spi blocking execution until done.
     pub fn blocking_read(&mut self, data: &mut [u8]) -> Result<(), Error> {
         critical_section::with(|_| {
-            self.info
-                .regs
-                .fifostat()
-                .modify(|_, w| w.txerr().set_bit().rxerr().set_bit());
+            self.info.regs.fifostat().modify(|w| {
+                w.set_txerr(true);
+                w.set_rxerr(true);
+            });
 
             for word in data.iter_mut() {
                 // wait until we have data in the RxFIFO.
-                while self.info.regs.fifostat().read().rxnotempty().bit_is_clear() {}
+                while !self.info.regs.fifostat().read().rxnotempty() {}
 
-                self.info
-                    .regs
-                    .fifowr()
-                    .write(|w| unsafe { w.txdata().bits(*word as u16).len().bits(7) });
+                self.info.regs.fifowr().write(|w| {
+                    w.set_txdata(*word as u16);
+                    w.set_len(7);
+                });
 
-                *word = self.info.regs.fiford().read().rxdata().bits() as u8;
+                *word = self.info.regs.fiford().read().rxdata() as u8;
             }
         });
 
@@ -124,25 +124,23 @@ impl<'a, M: IoMode> Spi<'a, M> {
     /// Write data to Spi blocking execution until done.
     pub fn blocking_write(&mut self, data: &[u8]) -> Result<(), Error> {
         critical_section::with(|_| {
-            self.info
-                .regs
-                .fifostat()
-                .modify(|_, w| w.txerr().set_bit().rxerr().set_bit());
+            self.info.regs.fifostat().modify(|w| {
+                w.set_txerr(true);
+                w.set_rxerr(true);
+            });
 
             for (i, word) in data.iter().enumerate() {
                 // wait until we have space in the TxFIFO.
-                while self.info.regs.fifostat().read().txnotfull().bit_is_clear() {}
+                while !self.info.regs.fifostat().read().txnotfull() {}
 
                 self.info.regs.fifowr().write(|w| {
-                    unsafe { w.txdata().bits(*word as u16).len().bits(7) }
-                        .rxignore()
-                        .set_bit();
+                    w.set_txdata(*word as u16);
+                    w.set_len(7);
+                    w.set_rxignore(Rxignore::IGNORE);
 
                     if i == data.len() - 1 {
-                        w.eot().set_bit();
+                        w.set_eot(true);
                     }
-
-                    w
                 });
             }
         });
@@ -155,31 +153,30 @@ impl<'a, M: IoMode> Spi<'a, M> {
         let len = read.len().max(write.len());
 
         critical_section::with(|_| {
-            self.info
-                .regs
-                .fifostat()
-                .modify(|_, w| w.txerr().set_bit().rxerr().set_bit());
+            self.info.regs.fifostat().modify(|w| {
+                w.set_txerr(true);
+                w.set_rxerr(true);
+            });
 
             for i in 0..len {
                 let wb = write.get(i).copied().unwrap_or(0);
 
                 // wait until we have space in the TxFIFO.
-                while self.info.regs.fifostat().read().txnotfull().bit_is_clear() {}
+                while !self.info.regs.fifostat().read().txnotfull() {}
 
                 self.info.regs.fifowr().write(|w| {
-                    unsafe { w.txdata().bits(wb as u16).len().bits(7) };
+                    w.set_txdata(wb as u16);
+                    w.set_len(7);
 
                     if i == len - 1 {
-                        w.eot().set_bit();
+                        w.set_eot(true);
                     }
-
-                    w
                 });
 
                 // wait until we have data in the RxFIFO.
-                while self.info.regs.fifostat().read().rxnotempty().bit_is_clear() {}
+                while !self.info.regs.fifostat().read().rxnotempty() {}
 
-                let rb = self.info.regs.fiford().read().rxdata().bits() as u8;
+                let rb = self.info.regs.fiford().read().rxdata() as u8;
 
                 if let Some(r) = read.get_mut(i) {
                     *r = rb;
@@ -193,22 +190,19 @@ impl<'a, M: IoMode> Spi<'a, M> {
     /// Transfer data in place to SPI blocking execution until done.
     pub fn blocking_transfer_in_place(&mut self, data: &mut [u8]) -> Result<(), Error> {
         critical_section::with(|_| {
-            self.info
-                .regs
-                .fifostat()
-                .modify(|_, w| w.txerr().set_bit().rxerr().set_bit());
+            self.info.regs.fifostat().modify(|w| {
+                w.set_txerr(true);
+                w.set_rxerr(true);
+            });
 
             for word in data {
                 // wait until we have space in the TxFIFO.
-                while self.info.regs.fifostat().read().txnotfull().bit_is_clear() {}
-                self.info
-                    .regs
-                    .fifowr()
-                    .write(|w| unsafe { w.txdata().bits(*word as u16) });
+                while !self.info.regs.fifostat().read().txnotfull() {}
+                self.info.regs.fifowr().write(|w| w.set_txdata(*word as u16));
 
                 // wait until we have data in the RxFIFO.
-                while self.info.regs.fifostat().read().rxnotempty().bit_is_clear() {}
-                *word = self.info.regs.fiford().read().rxdata().bits() as u8;
+                while !self.info.regs.fifostat().read().rxnotempty() {}
+                *word = self.info.regs.fiford().read().rxdata() as u8;
             }
         });
 
@@ -218,7 +212,7 @@ impl<'a, M: IoMode> Spi<'a, M> {
     /// Block execution until Spi is done.
     pub fn flush(&mut self) -> Result<(), Error> {
         let regs = self.info.regs;
-        while regs.stat().read().mstidle().bit_is_clear() {}
+        while !regs.stat().read().mstidle() {}
         Ok(())
     }
 }
@@ -295,37 +289,37 @@ impl<'a> Spi<'a, Async> {
     /// Read data from Spi async execution until done.
     pub async fn async_read(&mut self, data: &mut [u8]) -> Result<(), Error> {
         critical_section::with(|_| {
-            self.info
-                .regs
-                .fifostat()
-                .modify(|_, w| w.txerr().set_bit().rxerr().set_bit());
+            self.info.regs.fifostat().modify(|w| {
+                w.set_txerr(true);
+                w.set_rxerr(true);
+            });
         });
 
         for word in data.iter_mut() {
             // wait until we have data in the RxFIFO.
             self.wait_for(
                 |me| {
-                    if me.info.regs.fifostat().read().rxnotempty().bit_is_set() {
+                    if me.info.regs.fifostat().read().rxnotempty() {
                         Poll::Ready(())
                     } else {
                         Poll::Pending
                     }
                 },
                 |me| {
-                    me.info
-                        .regs
-                        .fifointenset()
-                        .write(|w| w.rxlvl().set_bit().rxerr().set_bit());
+                    me.info.regs.fifointenset().write(|w| {
+                        w.set_rxlvl(true);
+                        w.set_rxerr(true);
+                    });
                 },
             )
             .await;
 
-            self.info
-                .regs
-                .fifowr()
-                .write(|w| unsafe { w.txdata().bits(*word as u16).len().bits(7) });
+            self.info.regs.fifowr().write(|w| {
+                w.set_txdata(*word as u16);
+                w.set_len(7);
+            });
 
-            *word = self.info.regs.fiford().read().rxdata().bits() as u8;
+            *word = self.info.regs.fiford().read().rxdata() as u8;
         }
 
         self.async_flush().await;
@@ -336,41 +330,39 @@ impl<'a> Spi<'a, Async> {
     /// Write data to Spi async execution until done.
     pub async fn async_write(&mut self, data: &[u8]) -> Result<(), Error> {
         critical_section::with(|_| {
-            self.info
-                .regs
-                .fifostat()
-                .modify(|_, w| w.txerr().set_bit().rxerr().set_bit());
+            self.info.regs.fifostat().modify(|w| {
+                w.set_txerr(true);
+                w.set_rxerr(true);
+            });
         });
 
         for (i, word) in data.iter().enumerate() {
             // wait until we have space in the TxFIFO.
             self.wait_for(
                 |me| {
-                    if me.info.regs.fifostat().read().txnotfull().bit_is_set() {
+                    if me.info.regs.fifostat().read().txnotfull() {
                         Poll::Ready(())
                     } else {
                         Poll::Pending
                     }
                 },
                 |me| {
-                    me.info
-                        .regs
-                        .fifointenset()
-                        .write(|w| w.txlvl().set_bit().txerr().set_bit());
+                    me.info.regs.fifointenset().write(|w| {
+                        w.set_txlvl(true);
+                        w.set_txerr(true);
+                    });
                 },
             )
             .await;
 
             self.info.regs.fifowr().write(|w| {
-                unsafe { w.txdata().bits(*word as u16).len().bits(7) }
-                    .rxignore()
-                    .set_bit();
+                w.set_txdata(*word as u16);
+                w.set_len(7);
+                w.set_rxignore(Rxignore::IGNORE);
 
                 if i == data.len() - 1 {
-                    w.eot().set_bit();
+                    w.set_eot(true);
                 }
-
-                w
             });
         }
 
@@ -384,10 +376,10 @@ impl<'a> Spi<'a, Async> {
         let len = read.len().max(write.len());
 
         critical_section::with(|_| {
-            self.info
-                .regs
-                .fifostat()
-                .modify(|_, w| w.txerr().set_bit().rxerr().set_bit());
+            self.info.regs.fifostat().modify(|w| {
+                w.set_txerr(true);
+                w.set_rxerr(true);
+            });
         });
 
         for i in 0..len {
@@ -396,52 +388,51 @@ impl<'a> Spi<'a, Async> {
             // wait until we have space in the TxFIFO.
             self.wait_for(
                 |me| {
-                    if me.info.regs.fifostat().read().txnotfull().bit_is_set() {
+                    if me.info.regs.fifostat().read().txnotfull() {
                         Poll::Ready(())
                     } else {
                         Poll::Pending
                     }
                 },
                 |me| {
-                    me.info.regs.fifotrig().write(|w| w.txlvlena().set_bit());
-                    me.info
-                        .regs
-                        .fifointenset()
-                        .write(|w| w.txlvl().set_bit().txerr().set_bit());
+                    me.info.regs.fifotrig().write(|w| w.set_txlvlena(true));
+                    me.info.regs.fifointenset().write(|w| {
+                        w.set_txlvl(true);
+                        w.set_txerr(true);
+                    });
                 },
             )
             .await;
 
             self.info.regs.fifowr().write(|w| {
-                unsafe { w.txdata().bits(wb as u16).len().bits(7) };
+                w.set_txdata(wb as u16);
+                w.set_len(7);
 
                 if i == len - 1 {
-                    w.eot().set_bit();
+                    w.set_eot(true);
                 }
-
-                w
             });
 
             // wait until we have data in the RxFIFO.
             self.wait_for(
                 |me| {
-                    if me.info.regs.fifostat().read().rxnotempty().bit_is_set() {
+                    if me.info.regs.fifostat().read().rxnotempty() {
                         Poll::Ready(())
                     } else {
                         Poll::Pending
                     }
                 },
                 |me| {
-                    me.info.regs.fifotrig().write(|w| w.rxlvlena().set_bit());
-                    me.info
-                        .regs
-                        .fifointenset()
-                        .write(|w| w.rxlvl().set_bit().rxerr().set_bit());
+                    me.info.regs.fifotrig().write(|w| w.set_rxlvlena(true));
+                    me.info.regs.fifointenset().write(|w| {
+                        w.set_rxlvl(true);
+                        w.set_rxerr(true);
+                    });
                 },
             )
             .await;
 
-            let rb = self.info.regs.fiford().read().rxdata().bits() as u8;
+            let rb = self.info.regs.fiford().read().rxdata() as u8;
 
             if let Some(r) = read.get_mut(i) {
                 *r = rb;
@@ -456,55 +447,52 @@ impl<'a> Spi<'a, Async> {
     /// Transfer data in place to SPI async execution until done.
     pub async fn async_transfer_in_place(&mut self, data: &mut [u8]) -> Result<(), Error> {
         critical_section::with(|_| {
-            self.info
-                .regs
-                .fifostat()
-                .modify(|_, w| w.txerr().set_bit().rxerr().set_bit());
+            self.info.regs.fifostat().modify(|w| {
+                w.set_txerr(true);
+                w.set_rxerr(true);
+            });
         });
 
         for word in data {
             // wait until we have space in the TxFIFO.
             self.wait_for(
                 |me| {
-                    if me.info.regs.fifostat().read().txnotfull().bit_is_set() {
+                    if me.info.regs.fifostat().read().txnotfull() {
                         Poll::Ready(())
                     } else {
                         Poll::Pending
                     }
                 },
                 |me| {
-                    me.info
-                        .regs
-                        .fifointenset()
-                        .write(|w| w.txlvl().set_bit().txerr().set_bit());
+                    me.info.regs.fifointenset().write(|w| {
+                        w.set_txlvl(true);
+                        w.set_txerr(true);
+                    });
                 },
             )
             .await;
 
-            self.info
-                .regs
-                .fifowr()
-                .write(|w| unsafe { w.txdata().bits(*word as u16) });
+            self.info.regs.fifowr().write(|w| w.set_txdata(*word as u16));
 
             // wait until we have data in the RxFIFO.
             self.wait_for(
                 |me| {
-                    if me.info.regs.fifostat().read().rxnotempty().bit_is_set() {
+                    if me.info.regs.fifostat().read().rxnotempty() {
                         Poll::Ready(())
                     } else {
                         Poll::Pending
                     }
                 },
                 |me| {
-                    me.info
-                        .regs
-                        .fifointenset()
-                        .write(|w| w.rxlvl().set_bit().rxerr().set_bit());
+                    me.info.regs.fifointenset().write(|w| {
+                        w.set_rxlvl(true);
+                        w.set_rxerr(true);
+                    });
                 },
             )
             .await;
 
-            *word = self.info.regs.fiford().read().rxdata().bits() as u8;
+            *word = self.info.regs.fiford().read().rxdata() as u8;
         }
 
         self.async_flush().await;
@@ -516,14 +504,14 @@ impl<'a> Spi<'a, Async> {
     pub fn async_flush(&mut self) -> impl Future<Output = ()> + use<'_, 'a> {
         self.wait_for(
             |me| {
-                if me.info.regs.stat().read().mstidle().bit_is_set() {
+                if me.info.regs.stat().read().mstidle() {
                     Poll::Ready(())
                 } else {
                     Poll::Pending
                 }
             },
             |me| {
-                me.info.regs.intenset().write(|w| w.mstidleen().set_bit());
+                me.info.regs.intenset().write(|w| w.set_mstidleen(true));
             },
         )
     }
@@ -571,53 +559,37 @@ impl<'a, M: IoMode> Spi<'a, M> {
 
         critical_section::with(|_| match (sck.is_some(), mosi.is_some(), miso.is_some()) {
             (true, true, true) => {
-                regs.fifocfg().modify(|_, w| {
-                    w.enabletx()
-                        .set_bit()
-                        .emptytx()
-                        .set_bit()
-                        .enablerx()
-                        .set_bit()
-                        .emptyrx()
-                        .set_bit()
+                regs.fifocfg().modify(|w| {
+                    w.set_enabletx(true);
+                    w.set_emptytx(true);
+                    w.set_enablerx(true);
+                    w.set_emptyrx(true);
                 });
             }
             (true, false, true) => {
-                regs.fifocfg().modify(|_, w| {
-                    w.enabletx()
-                        .set_bit()
-                        .emptytx()
-                        .clear_bit()
-                        .enablerx()
-                        .set_bit()
-                        .emptyrx()
-                        .set_bit()
+                regs.fifocfg().modify(|w| {
+                    w.set_enabletx(true);
+                    w.set_emptytx(false);
+                    w.set_enablerx(true);
+                    w.set_emptyrx(true);
                 });
             }
             (true, true, false) => {
-                regs.fifocfg().modify(|_, w| {
-                    w.enabletx()
-                        .set_bit()
-                        .emptytx()
-                        .set_bit()
-                        .enablerx()
-                        .clear_bit()
-                        .emptyrx()
-                        .set_bit()
+                regs.fifocfg().modify(|w| {
+                    w.set_enabletx(true);
+                    w.set_emptytx(true);
+                    w.set_enablerx(false);
+                    w.set_emptyrx(true);
                 });
             }
             (false, _, _) => {
-                regs.fifocfg().modify(|_, w| {
-                    w.enabletx()
-                        .set_bit()
-                        .emptytx()
-                        .set_bit()
-                        .enablerx()
-                        .set_bit()
-                        .emptyrx()
-                        .set_bit()
+                regs.fifocfg().modify(|w| {
+                    w.set_enabletx(true);
+                    w.set_emptytx(true);
+                    w.set_enablerx(true);
+                    w.set_emptyrx(true);
                 });
-                regs.cfg().modify(|_, w| w.loop_().enabled());
+                regs.cfg().modify(|w| w.set_loop_(true));
             }
             _ => {}
         });
@@ -650,17 +622,17 @@ impl<'a, M: IoMode> Spi<'a, M> {
         }
     }
 
-    fn apply_config(regs: &'static crate::pac::spi0::RegisterBlock, config: &Config) {
+    fn apply_config(regs: crate::pac::spi::Spi, config: &Config) {
         let polarity = if config.mode.polarity == Polarity::IdleLow {
-            Cpol::Low
+            Cpol::LOW
         } else {
-            Cpol::High
+            Cpol::HIGH
         };
 
         let phase = if config.mode.phase == Phase::CaptureOnFirstTransition {
-            Cpha::Change
+            Cpha::CHANGE
         } else {
-            Cpha::Capture
+            Cpha::CAPTURE
         };
 
         let clk = Self::clock(config);
@@ -668,22 +640,18 @@ impl<'a, M: IoMode> Spi<'a, M> {
 
         critical_section::with(|_| {
             // disable SPI every time we need to modify configuration.
-            regs.cfg().modify(|_, w| w.enable().disabled());
+            regs.cfg().modify(|w| w.set_enable(false));
 
-            regs.cfg().modify(|_, w| {
-                w.cpha()
-                    .variant(phase)
-                    .cpol()
-                    .variant(polarity)
-                    .loop_()
-                    .disabled()
-                    .master()
-                    .master_mode()
+            regs.cfg().modify(|w| {
+                w.set_cpha(phase);
+                w.set_cpol(polarity);
+                w.set_loop_(false);
+                w.set_master(Master::MASTER_MODE);
             });
 
-            regs.div().write(|w| unsafe { w.divval().bits(div as u16) });
+            regs.div().write(|w| w.set_divval(div as u16));
 
-            regs.cfg().modify(|_, w| w.enable().enabled());
+            regs.cfg().modify(|w| w.set_enable(true));
         });
     }
 }
@@ -707,18 +675,9 @@ impl Default for Config {
 }
 
 struct Info {
-    regs: &'static crate::pac::spi0::RegisterBlock,
+    regs: crate::pac::spi::Spi,
     waker: &'static AtomicWaker,
 }
-
-// SAFETY: safety for Send here is the same as the other accessors to
-// unsafe blocks: it must be done from a single executor context.
-//
-// This is a temporary workaround -- a better solution might be to
-// refactor Info to no longer maintain a reference to regs, but
-// instead look up the correct register set and then perform
-// operations within an unsafe block as we do for other peripherals
-unsafe impl Send for Info {}
 
 trait SealedInstance {
     fn info() -> Info;
@@ -734,24 +693,24 @@ impl<T: Instance> interrupt::typelevel::Handler<T::Interrupt> for InterruptHandl
         let waker = T::info().waker;
         let stat = T::info().regs.fifointstat().read();
 
-        if stat.perint().bit_is_set() {
-            T::info().regs.intenclr().write(|w| w.mstidle().clear_bit_by_one());
+        if stat.perint() {
+            T::info().regs.intenclr().write(|w| w.set_mstidle(true));
         }
 
-        if stat.txlvl().bit_is_set() {
-            T::info().regs.fifointenclr().write(|w| w.txlvl().set_bit());
+        if stat.txlvl() {
+            T::info().regs.fifointenclr().write(|w| w.set_txlvl(true));
         }
 
-        if stat.txerr().bit_is_set() {
-            T::info().regs.fifointenclr().write(|w| w.txerr().set_bit());
+        if stat.txerr() {
+            T::info().regs.fifointenclr().write(|w| w.set_txerr(true));
         }
 
-        if stat.rxlvl().bit_is_set() {
-            T::info().regs.fifointenclr().write(|w| w.rxlvl().set_bit());
+        if stat.rxlvl() {
+            T::info().regs.fifointenclr().write(|w| w.set_rxlvl(true));
         }
 
-        if stat.rxerr().bit_is_set() {
-            T::info().regs.fifointenclr().write(|w| w.rxerr().set_bit());
+        if stat.rxerr() {
+            T::info().regs.fifointenclr().write(|w| w.set_rxerr(true));
         }
 
         waker.wake();
@@ -775,7 +734,7 @@ macro_rules! impl_instance {
                         static WAKER: AtomicWaker = AtomicWaker::new();
 
                         Info {
-                            regs: unsafe { &*crate::pac::[<Spi $n>]::ptr() },
+                            regs: crate::pac::[<SPI $n>],
                             waker: &WAKER,
                         }
                     }

--- a/embassy-imxrt/src/flexcomm/uart.rs
+++ b/embassy-imxrt/src/flexcomm/uart.rs
@@ -17,8 +17,7 @@ use crate::flexcomm::Clock;
 use crate::gpio::{AnyPin, GpioPin as Pin};
 use crate::interrupt::typelevel::Interrupt;
 use crate::iopctl::{DriveMode, DriveStrength, Inverter, IopctlPin, Pull, SlewRate};
-use crate::pac::usart0::cfg::{Clkpol, Datalen, Loop, Paritysel as Parity, Stoplen, Syncen, Syncmst};
-use crate::pac::usart0::ctl::Cc;
+use crate::pac::usart::vals::{Cc, Clkpol, Datalen, Loop, Paritysel as Parity, Stoplen, Syncen, Syncmst};
 use crate::sealed::Sealed;
 use crate::{dma, interrupt};
 
@@ -86,14 +85,14 @@ impl Default for Config {
     fn default() -> Self {
         Self {
             baudrate: 115_200,
-            data_bits: Datalen::Bit8,
-            parity: Parity::NoParity,
-            stop_bits: Stoplen::Bit1,
-            clock_polarity: Clkpol::FallingEdge,
-            operation: Syncen::AsynchronousMode,
-            sync_mode_master_select: Syncmst::Slave,
-            continuous_clock: Cc::ClockOnCharacter,
-            loopback_mode: Loop::Normal,
+            data_bits: Datalen::BIT_8,
+            parity: Parity::NO_PARITY,
+            stop_bits: Stoplen::BIT_1,
+            clock_polarity: Clkpol::FALLING_EDGE,
+            operation: Syncen::ASYNCHRONOUS_MODE,
+            sync_mode_master_select: Syncmst::SLAVE,
+            continuous_clock: Cc::CLOCK_ON_CHARACTER,
+            loopback_mode: Loop::NORMAL,
             clock: crate::flexcomm::Clock::Sfro,
         }
     }
@@ -154,25 +153,21 @@ impl<'a, M: Mode> UartTx<'a, M> {
 impl<'a, M: Mode> Drop for UartTx<'a, M> {
     fn drop(&mut self) {
         if self.info.refcnt.fetch_sub(1, Ordering::Relaxed) == 1 {
-            while self.info.regs.stat().read().txidle().bit_is_clear() {}
+            while !self.info.regs.stat().read().txidle() {}
 
-            self.info.regs.fifointenclr().modify(|_, w| {
-                w.txerr()
-                    .set_bit()
-                    .rxerr()
-                    .set_bit()
-                    .txlvl()
-                    .set_bit()
-                    .rxlvl()
-                    .set_bit()
+            self.info.regs.fifointenclr().modify(|w| {
+                w.set_txerr(true);
+                w.set_rxerr(true);
+                w.set_txlvl(true);
+                w.set_rxlvl(true);
             });
 
-            self.info
-                .regs
-                .fifocfg()
-                .modify(|_, w| w.dmatx().clear_bit().dmarx().clear_bit());
+            self.info.regs.fifocfg().modify(|w| {
+                w.set_dmatx(false);
+                w.set_dmarx(false);
+            });
 
-            self.info.regs.cfg().modify(|_, w| w.enable().disabled());
+            self.info.regs.cfg().modify(|w| w.set_enable(false));
         }
     }
 }
@@ -190,17 +185,13 @@ impl<'a> UartTx<'a, Blocking> {
     }
 
     fn write_byte_internal(&mut self, byte: u8) -> Result<()> {
-        // SAFETY: unsafe only used for .bits()
-        self.info
-            .regs
-            .fifowr()
-            .write(|w| unsafe { w.txdata().bits(u16::from(byte)) });
+        self.info.regs.fifowr().write(|w| w.set_txdata(u16::from(byte)));
 
         Ok(())
     }
 
     fn blocking_write_byte(&mut self, byte: u8) -> Result<()> {
-        while self.info.regs.fifostat().read().txnotfull().bit_is_clear() {}
+        while !self.info.regs.fifostat().read().txnotfull() {}
 
         // Prevent the compiler from reordering write_byte_internal()
         // before the loop above.
@@ -210,7 +201,7 @@ impl<'a> UartTx<'a, Blocking> {
     }
 
     fn write_byte(&mut self, byte: u8) -> Result<()> {
-        if self.info.regs.fifostat().read().txnotfull().bit_is_clear() {
+        if !self.info.regs.fifostat().read().txnotfull() {
             Err(Error::TxFifoFull)
         } else {
             self.write_byte_internal(byte)
@@ -238,13 +229,13 @@ impl<'a> UartTx<'a, Blocking> {
 
     /// Flush UART TX blocking execution until done.
     pub fn blocking_flush(&mut self) -> Result<()> {
-        while self.info.regs.stat().read().txidle().bit_is_clear() {}
+        while !self.info.regs.stat().read().txidle() {}
         Ok(())
     }
 
     /// Flush UART TX.
     pub fn flush(&mut self) -> Result<()> {
-        if self.info.regs.stat().read().txidle().bit_is_clear() {
+        if !self.info.regs.stat().read().txidle() {
             Err(Error::TxBusy)
         } else {
             Ok(())
@@ -267,25 +258,21 @@ impl<'a, M: Mode> UartRx<'a, M> {
 impl<'a, M: Mode> Drop for UartRx<'a, M> {
     fn drop(&mut self) {
         if self.info.refcnt.fetch_sub(1, Ordering::Relaxed) == 1 {
-            while self.info.regs.stat().read().rxidle().bit_is_clear() {}
+            while !self.info.regs.stat().read().rxidle() {}
 
-            self.info.regs.fifointenclr().modify(|_, w| {
-                w.txerr()
-                    .set_bit()
-                    .rxerr()
-                    .set_bit()
-                    .txlvl()
-                    .set_bit()
-                    .rxlvl()
-                    .set_bit()
+            self.info.regs.fifointenclr().modify(|w| {
+                w.set_txerr(true);
+                w.set_rxerr(true);
+                w.set_txlvl(true);
+                w.set_rxlvl(true);
             });
 
-            self.info
-                .regs
-                .fifocfg()
-                .modify(|_, w| w.dmatx().clear_bit().dmarx().clear_bit());
+            self.info.regs.fifocfg().modify(|w| {
+                w.set_dmatx(false);
+                w.set_dmarx(false);
+            });
 
-            self.info.regs.cfg().modify(|_, w| w.enable().disabled());
+            self.info.regs.cfg().modify(|w| w.set_enable(false));
         }
     }
 }
@@ -304,27 +291,27 @@ impl<'a> UartRx<'a, Blocking> {
 
 impl UartRx<'_, Blocking> {
     fn read_byte_internal(&mut self) -> Result<u8> {
-        if self.info.regs.fifostat().read().rxerr().bit_is_set() {
-            self.info.regs.fifocfg().modify(|_, w| w.emptyrx().set_bit());
-            self.info.regs.fifostat().modify(|_, w| w.rxerr().set_bit());
+        if self.info.regs.fifostat().read().rxerr() {
+            self.info.regs.fifocfg().modify(|w| w.set_emptyrx(true));
+            self.info.regs.fifostat().modify(|w| w.set_rxerr(true));
             Err(Error::Read)
-        } else if self.info.regs.stat().read().parityerrint().bit_is_set() {
-            self.info.regs.stat().modify(|_, w| w.parityerrint().clear_bit_by_one());
+        } else if self.info.regs.stat().read().parityerrint() {
+            self.info.regs.stat().modify(|w| w.set_parityerrint(true));
             Err(Error::Parity)
-        } else if self.info.regs.stat().read().framerrint().bit_is_set() {
-            self.info.regs.stat().modify(|_, w| w.framerrint().clear_bit_by_one());
+        } else if self.info.regs.stat().read().framerrint() {
+            self.info.regs.stat().modify(|w| w.set_framerrint(true));
             Err(Error::Framing)
-        } else if self.info.regs.stat().read().rxnoiseint().bit_is_set() {
-            self.info.regs.stat().modify(|_, w| w.rxnoiseint().clear_bit_by_one());
+        } else if self.info.regs.stat().read().rxnoiseint() {
+            self.info.regs.stat().modify(|w| w.set_rxnoiseint(true));
             Err(Error::Noise)
         } else {
-            let byte = self.info.regs.fiford().read().rxdata().bits() as u8;
+            let byte = self.info.regs.fiford().read().rxdata() as u8;
             Ok(byte)
         }
     }
 
     fn read_byte(&mut self) -> Result<u8> {
-        if self.info.regs.fifostat().read().rxnotempty().bit_is_clear() {
+        if !self.info.regs.fifostat().read().rxnotempty() {
             Err(Error::RxFifoEmpty)
         } else {
             self.read_byte_internal()
@@ -332,7 +319,7 @@ impl UartRx<'_, Blocking> {
     }
 
     fn blocking_read_byte(&mut self) -> Result<u8> {
-        while self.info.regs.fifostat().read().rxnotempty().bit_is_clear() {}
+        while !self.info.regs.fifostat().read().rxnotempty() {}
 
         // Prevent the compiler from reordering read_byte_internal()
         // before the loop above.
@@ -404,21 +391,27 @@ impl<'a, M: Mode> Uart<'a, M> {
         let regs = T::info().regs;
 
         if tx.is_some() {
-            regs.fifocfg().modify(|_, w| w.emptytx().set_bit().enabletx().enabled());
+            regs.fifocfg().modify(|w| {
+                w.set_emptytx(true);
+                w.set_enabletx(true);
+            });
 
             // clear FIFO error
-            regs.fifostat().write(|w| w.txerr().set_bit());
+            regs.fifostat().write(|w| w.set_txerr(true));
         }
 
         if rx.is_some() {
-            regs.fifocfg().modify(|_, w| w.emptyrx().set_bit().enablerx().enabled());
+            regs.fifocfg().modify(|w| {
+                w.set_emptyrx(true);
+                w.set_enablerx(true);
+            });
 
             // clear FIFO error
-            regs.fifostat().write(|w| w.rxerr().set_bit());
+            regs.fifostat().write(|w| w.set_rxerr(true));
         }
 
         if rts.is_some() && cts.is_some() {
-            regs.cfg().modify(|_, w| w.ctsen().enabled());
+            regs.cfg().modify(|w| w.set_ctsen(true));
         }
 
         Self::set_baudrate_inner::<T>(config.baudrate, config.clock)?;
@@ -447,23 +440,20 @@ impl<'a, M: Mode> Uart<'a, M> {
         let regs = T::info().regs;
 
         // If synchronous master mode is enabled, only configure the BRG value.
-        if regs.cfg().read().syncen().is_synchronous_mode() {
+        if regs.cfg().read().syncen() == Syncen::SYNCHRONOUS_MODE {
             // Master
-            if regs.cfg().read().syncmst().is_master() {
+            if regs.cfg().read().syncmst() == Syncmst::MASTER {
                 // Calculate the BRG value
                 let brgval = (source_clock_hz / baudrate) - 1;
 
-                // SAFETY: unsafe only used for .bits()
-                regs.brg().write(|w| unsafe { w.brgval().bits(brgval as u16) });
+                regs.brg().write(|w| w.set_brgval(brgval as u16));
             }
         } else {
             let (osr, brg) = calculate_baudrate(source_clock_hz, baudrate)?;
 
-            // SAFETY: unsafe only used for .bits()
-            regs.osr().write(|w| unsafe { w.osrval().bits(osr - 1) });
+            regs.osr().write(|w| w.set_osrval(osr - 1));
 
-            // SAFETY: unsafe only used for .bits()
-            regs.brg().write(|w| unsafe { w.brgval().bits(brg - 1) });
+            regs.brg().write(|w| w.set_brgval(brg - 1));
         }
 
         Ok(())
@@ -472,24 +462,18 @@ impl<'a, M: Mode> Uart<'a, M> {
     fn set_uart_config<T: Instance>(config: Config) {
         let regs = T::info().regs;
 
-        regs.cfg().modify(|_, w| w.enable().disabled());
+        regs.cfg().modify(|w| w.set_enable(false));
 
-        regs.cfg().modify(|_, w| {
-            w.datalen()
-                .variant(config.data_bits)
-                .stoplen()
-                .variant(config.stop_bits)
-                .paritysel()
-                .variant(config.parity)
-                .loop_()
-                .variant(config.loopback_mode)
-                .syncen()
-                .variant(config.operation)
-                .clkpol()
-                .variant(config.clock_polarity)
+        regs.cfg().modify(|w| {
+            w.set_datalen(config.data_bits);
+            w.set_stoplen(config.stop_bits);
+            w.set_paritysel(config.parity);
+            w.set_loop_(config.loopback_mode);
+            w.set_syncen(config.operation);
+            w.set_clkpol(config.clock_polarity);
         });
 
-        regs.cfg().modify(|_, w| w.enable().enabled());
+        regs.cfg().modify(|w| w.set_enable(true));
     }
 
     /// Split the Uart into a transmitter and receiver, which is particularly
@@ -587,11 +571,11 @@ impl<'a> UartTx<'a, Async> {
 
         // Disable DMA on completion/cancellation
         let _dma_guard = OnDrop::new(|| {
-            regs.fifocfg().modify(|_, w| w.dmatx().disabled());
+            regs.fifocfg().modify(|w| w.set_dmatx(false));
         });
 
         for chunk in buf.chunks(dma::MAX_CHUNK_SIZE) {
-            regs.fifocfg().modify(|_, w| w.dmatx().enabled());
+            regs.fifocfg().modify(|w| w.set_dmatx(true));
 
             let ch = self.tx_dma.as_mut().unwrap().reborrow();
             let transfer = unsafe { dma::write(ch, chunk, regs.fifowr().as_ptr() as *mut u8) };
@@ -602,36 +586,28 @@ impl<'a> UartTx<'a, Async> {
                     UART_WAKERS[self.info.index].register(cx.waker());
 
                     self.info.regs.intenset().write(|w| {
-                        w.framerren()
-                            .set_bit()
-                            .parityerren()
-                            .set_bit()
-                            .rxnoiseen()
-                            .set_bit()
-                            .aberren()
-                            .set_bit()
+                        w.set_framerren(true);
+                        w.set_parityerren(true);
+                        w.set_rxnoiseen(true);
+                        w.set_aberren(true);
                     });
 
                     let stat = self.info.regs.stat().read();
 
                     self.info.regs.stat().write(|w| {
-                        w.framerrint()
-                            .clear_bit_by_one()
-                            .parityerrint()
-                            .clear_bit_by_one()
-                            .rxnoiseint()
-                            .clear_bit_by_one()
-                            .aberr()
-                            .clear_bit_by_one()
+                        w.set_framerrint(true);
+                        w.set_parityerrint(true);
+                        w.set_rxnoiseint(true);
+                        w.set_aberr(true);
                     });
 
-                    if stat.framerrint().bit_is_set() {
+                    if stat.framerrint() {
                         Poll::Ready(Err(Error::Framing))
-                    } else if stat.parityerrint().bit_is_set() {
+                    } else if stat.parityerrint() {
                         Poll::Ready(Err(Error::Parity))
-                    } else if stat.rxnoiseint().bit_is_set() {
+                    } else if stat.rxnoiseint() {
                         Poll::Ready(Err(Error::Noise))
-                    } else if stat.aberr().bit_is_set() {
+                    } else if stat.aberr() {
                         Poll::Ready(Err(Error::Fail))
                     } else {
                         Poll::Pending
@@ -653,14 +629,14 @@ impl<'a> UartTx<'a, Async> {
     pub async fn flush(&mut self) -> Result<()> {
         self.wait_on(
             |me| {
-                if me.info.regs.stat().read().txidle().bit_is_set() {
+                if me.info.regs.stat().read().txidle() {
                     Poll::Ready(Ok(()))
                 } else {
                     Poll::Pending
                 }
             },
             |me| {
-                me.info.regs.intenset().write(|w| w.txidleen().set_bit());
+                me.info.regs.intenset().write(|w| w.set_txidleen(true));
             },
         )
         .await
@@ -715,11 +691,11 @@ impl<'a> UartRx<'a, Async> {
 
         // Disable DMA on completion/cancellation
         let _dma_guard = OnDrop::new(|| {
-            regs.fifocfg().modify(|_, w| w.dmarx().disabled());
+            regs.fifocfg().modify(|w| w.set_dmarx(false));
         });
 
         for chunk in buf.chunks_mut(dma::MAX_CHUNK_SIZE) {
-            regs.fifocfg().modify(|_, w| w.dmarx().enabled());
+            regs.fifocfg().modify(|w| w.set_dmarx(true));
 
             let ch = self.rx_dma.as_mut().unwrap().reborrow();
             let transfer = unsafe { dma::read(ch, regs.fiford().as_ptr() as *const u8, chunk) };
@@ -730,36 +706,28 @@ impl<'a> UartRx<'a, Async> {
                     UART_WAKERS[self.info.index].register(cx.waker());
 
                     self.info.regs.intenset().write(|w| {
-                        w.framerren()
-                            .set_bit()
-                            .parityerren()
-                            .set_bit()
-                            .rxnoiseen()
-                            .set_bit()
-                            .aberren()
-                            .set_bit()
+                        w.set_framerren(true);
+                        w.set_parityerren(true);
+                        w.set_rxnoiseen(true);
+                        w.set_aberren(true);
                     });
 
                     let stat = self.info.regs.stat().read();
 
                     self.info.regs.stat().write(|w| {
-                        w.framerrint()
-                            .clear_bit_by_one()
-                            .parityerrint()
-                            .clear_bit_by_one()
-                            .rxnoiseint()
-                            .clear_bit_by_one()
-                            .aberr()
-                            .clear_bit_by_one()
+                        w.set_framerrint(true);
+                        w.set_parityerrint(true);
+                        w.set_rxnoiseint(true);
+                        w.set_aberr(true);
                     });
 
-                    if stat.framerrint().bit_is_set() {
+                    if stat.framerrint() {
                         Poll::Ready(Err(Error::Framing))
-                    } else if stat.parityerrint().bit_is_set() {
+                    } else if stat.parityerrint() {
                         Poll::Ready(Err(Error::Parity))
-                    } else if stat.rxnoiseint().bit_is_set() {
+                    } else if stat.rxnoiseint() {
                         Poll::Ready(Err(Error::Noise))
-                    } else if stat.aberr().bit_is_set() {
+                    } else if stat.aberr() {
                         Poll::Ready(Err(Error::Fail))
                     } else {
                         Poll::Pending
@@ -807,6 +775,7 @@ impl<'a> Uart<'a, Async> {
     }
 
     /// Create a new DMA enabled UART with hardware flow control (RTS/CTS)
+    #[allow(clippy::too_many_arguments)]
     pub fn new_with_rtscts<T: Instance>(
         _inner: Peri<'a, T>,
         tx: Peri<'a, impl TxPin<T>>,
@@ -1001,7 +970,7 @@ impl embedded_hal_nb::serial::Write for Uart<'_, Blocking> {
 }
 
 struct Info {
-    regs: &'static crate::pac::usart0::RegisterBlock,
+    regs: crate::pac::usart::Usart,
     index: usize,
     refcnt: AtomicU8,
 }
@@ -1025,23 +994,13 @@ impl<T: Instance> interrupt::typelevel::Handler<T::Interrupt> for InterruptHandl
         let regs = T::info().regs;
         let stat = regs.intstat().read();
 
-        if stat.txidle().bit_is_set()
-            || stat.framerrint().bit_is_set()
-            || stat.parityerrint().bit_is_set()
-            || stat.rxnoiseint().bit_is_set()
-            || stat.aberrint().bit_is_set()
-        {
+        if stat.txidle() || stat.framerrint() || stat.parityerrint() || stat.rxnoiseint() || stat.aberrint() {
             regs.intenclr().write(|w| {
-                w.txidleclr()
-                    .set_bit()
-                    .framerrclr()
-                    .set_bit()
-                    .parityerrclr()
-                    .set_bit()
-                    .rxnoiseclr()
-                    .set_bit()
-                    .aberrclr()
-                    .set_bit()
+                w.set_txidleclr(true);
+                w.set_framerrclr(true);
+                w.set_parityerrclr(true);
+                w.set_rxnoiseclr(true);
+                w.set_aberrclr(true);
             });
         }
 
@@ -1063,7 +1022,7 @@ macro_rules! impl_instance {
                 impl SealedInstance for crate::peripherals::[<FLEXCOMM $n>] {
                     fn info() -> Info {
                         Info {
-                            regs: unsafe { &*crate::pac::[<Usart $n>]::ptr() },
+                            regs: crate::pac::[<USART $n>],
                             index: $n,
 			    refcnt: AtomicU8::new(0),
                         }

--- a/embassy-imxrt/src/gpio.rs
+++ b/embassy-imxrt/src/gpio.rs
@@ -65,20 +65,19 @@ fn GPIO_INTA() {
 
 #[cfg(feature = "rt")]
 fn irq_handler(port_wakers: &[Option<&PortWaker>]) {
-    let reg = unsafe { crate::pac::Gpio::steal() };
+    let reg = crate::pac::GPIO;
 
     for (port, port_waker) in port_wakers.iter().enumerate() {
         let Some(port_waker) = port_waker else {
             continue;
         };
 
-        let stat = reg.intstata(port).read().bits();
+        let stat = reg.intstata(port).read().0;
         for pin in BitIter(stat) {
             // Clear the interrupt from this pin
-            reg.intstata(port).write(|w| unsafe { w.status().bits(1 << pin) });
+            reg.intstata(port).write(|w| w.0 = 1 << pin);
             // Disable interrupt from this pin
-            reg.intena(port)
-                .modify(|r, w| unsafe { w.int_en().bits(r.int_en().bits() & !(1 << pin)) });
+            reg.intena(port).modify(|w| w.0 &= !(1 << pin));
 
             let Some(waker) = port_waker.get_waker(pin as usize) else {
                 continue;
@@ -156,29 +155,26 @@ impl<S: Sense> Flex<'_, S> {
             .set_drive_strength(strength)
             .set_slew_rate(slew_rate);
 
-        self.pin.block().dirset(self.pin.port()).write(|w|
-            // SAFETY: Writing a 0 to bits in this register has no effect,
-            // however PAC has it marked unsafe due to using the bits() method.
-            // There is not currently a "safe" method for setting a single-bit.
-            unsafe { w.dirsetp().bits(1 << self.pin.pin()) });
+        self.pin
+            .block()
+            .dirset(self.pin.port())
+            .write(|w| w.0 = 1 << self.pin.pin());
     }
 
     /// Set high
     pub fn set_high(&mut self) {
-        self.pin.block().set(self.pin.port()).write(|w|
-            // SAFETY: Writing a 0 to bits in this register has no effect,
-            // however PAC has it marked unsafe due to using the bits() method.
-            // There is not currently a "safe" method for setting a single-bit.
-            unsafe { w.setp().bits(1 << self.pin.pin()) });
+        self.pin
+            .block()
+            .set(self.pin.port())
+            .write(|w| w.0 = 1 << self.pin.pin());
     }
 
     /// Set low
     pub fn set_low(&mut self) {
-        self.pin.block().clr(self.pin.port()).write(|w|
-            // SAFETY: Writing a 0 to bits in this register has no effect,
-            // however PAC has it marked unsafe due to using the bits() method.
-            // There is not currently a "safe" method for setting a single-bit.
-            unsafe { w.clrp().bits(1 << self.pin.pin()) });
+        self.pin
+            .block()
+            .clr(self.pin.port())
+            .write(|w| w.0 = 1 << self.pin.pin());
     }
 
     /// Set level
@@ -198,16 +194,15 @@ impl<S: Sense> Flex<'_, S> {
     /// Is the output level low?
     #[must_use]
     pub fn is_set_low(&self) -> bool {
-        (self.pin.block().set(self.pin.port()).read().setp().bits() & (1 << self.pin.pin())) == 0
+        (self.pin.block().set(self.pin.port()).read().0 & (1 << self.pin.pin())) == 0
     }
 
     /// Toggle
     pub fn toggle(&mut self) {
-        self.pin.block().not(self.pin.port()).write(|w|
-            // SAFETY: Writing a 0 to bits in this register has no effect,
-            // however PAC has it marked unsafe due to using the bits() method.
-            // There is not currently a "safe" method for setting a single-bit.
-            unsafe { w.notp().bits(1 << self.pin.pin()) });
+        self.pin
+            .block()
+            .not(self.pin.port())
+            .write(|w| w.0 = 1 << self.pin.pin());
     }
 }
 
@@ -237,11 +232,10 @@ impl<'d> Flex<'d, SenseEnabled> {
     pub fn set_as_input(&mut self, pull: Pull, inverter: Inverter) {
         self.pin.set_pull(pull).set_input_inverter(inverter);
 
-        self.pin.block().dirclr(self.pin.port()).write(|w|
-                    // SAFETY: Writing a 0 to bits in this register has no effect,
-                    // however PAC has it marked unsafe due to using the bits() method.
-                    // There is not currently a "safe" method for setting a single-bit.
-                    unsafe { w.dirclrp().bits(1 << self.pin.pin()) });
+        self.pin
+            .block()
+            .dirclr(self.pin.port())
+            .write(|w| w.0 = 1 << self.pin.pin());
     }
 
     /// Converts pin to special function pin
@@ -261,7 +255,7 @@ impl<'d> Flex<'d, SenseEnabled> {
     /// Is low?
     #[must_use]
     pub fn is_low(&self) -> bool {
-        self.pin.block().b(self.pin.port()).b_(self.pin.pin()).read() == 0
+        self.pin.block().b(self.pin.port()).b_(self.pin.pin()).read().0 == 0
     }
 
     /// Current level
@@ -411,25 +405,21 @@ impl<'d> InputFuture<'d> {
     fn new(pin: Peri<'d, impl GpioPin>, int_type: InterruptType, level: Level) -> Self {
         critical_section::with(|_| {
             // Clear any existing pending interrupt on this pin
-            pin.block()
-                .intstata(pin.port())
-                .write(|w| unsafe { w.status().bits(1 << pin.pin()) });
+            pin.block().intstata(pin.port()).write(|w| w.0 = 1 << pin.pin());
 
             /* Pin interrupt configuration */
-            pin.block().intedg(pin.port()).modify(|r, w| match int_type {
-                InterruptType::Edge => unsafe { w.bits(r.bits() | (1 << pin.pin())) },
-                InterruptType::Level => unsafe { w.bits(r.bits() & !(1 << pin.pin())) },
+            pin.block().intedg(pin.port()).modify(|w| match int_type {
+                InterruptType::Edge => w.0 |= 1 << pin.pin(),
+                InterruptType::Level => w.0 &= !(1 << pin.pin()),
             });
 
-            pin.block().intpol(pin.port()).modify(|r, w| match level {
-                Level::High => unsafe { w.bits(r.bits() & !(1 << pin.pin())) },
-                Level::Low => unsafe { w.bits(r.bits() | (1 << pin.pin())) },
+            pin.block().intpol(pin.port()).modify(|w| match level {
+                Level::High => w.0 &= !(1 << pin.pin()),
+                Level::Low => w.0 |= 1 << pin.pin(),
             });
 
             // Enable pin interrupt on GPIO INT A
-            pin.block()
-                .intena(pin.port())
-                .modify(|r, w| unsafe { w.int_en().bits(r.int_en().bits() | (1 << pin.pin())) });
+            pin.block().intena(pin.port()).modify(|w| w.0 |= 1 << pin.pin());
         });
 
         Self { pin: pin.into() }
@@ -462,7 +452,7 @@ impl Future for InputFuture<'_> {
         waker.unwrap().register(cx.waker());
 
         // Double check that the pin interrut has been disabled by IRQ handler
-        if self.pin.block().intena(self.pin.port()).read().bits() & (1 << self.pin.pin()) == 0 {
+        if self.pin.block().intena(self.pin.port()).read().0 & (1 << self.pin.pin()) == 0 {
             Poll::Ready(())
         } else {
             Poll::Pending
@@ -538,11 +528,8 @@ trait SealedPin: IopctlPin {
         self.pin_port() % 32
     }
 
-    fn block(&self) -> crate::pac::Gpio {
-        // SAFETY: Assuming GPIO pin specific registers are only accessed through this HAL,
-        // this is safe because the HAL ensures ownership or exclusive mutable references
-        // to pins.
-        unsafe { crate::pac::Gpio::steal() }
+    fn block(&self) -> crate::pac::gpio::Gpio {
+        crate::pac::GPIO
     }
 }
 

--- a/embassy-imxrt/src/iopctl.rs
+++ b/embassy-imxrt/src/iopctl.rs
@@ -2,17 +2,7 @@
 //!
 //! Also known as IO Pin Configuration (IOCON)
 
-use crate::pac::{Iopctl, iopctl};
-
-// A generic pin of any type.
-//
-// The actual pin type used here is arbitrary,
-// as all PioM_N types provide the same methods.
-//
-// Merely need some pin type to cast a raw pointer
-// to in order to access the provided methods.
-#[allow(non_camel_case_types)]
-type PioM_N = iopctl::Pio0_0;
+use crate::pac;
 
 /// Pin function number.
 #[derive(Debug, Copy, Clone, Eq, PartialEq)]
@@ -187,7 +177,7 @@ pub trait IopctlPin: SealedPin {
 /// Represents a pin peripheral created at run-time from given port and pin numbers.
 pub struct AnyPin {
     pin_port: u8,
-    reg: &'static PioM_N,
+    reg: pac::common::Reg<pac::iopctl::regs::Pio, pac::common::RW>,
 }
 
 impl AnyPin {
@@ -210,17 +200,10 @@ impl AnyPin {
     /// pin and port number combinations.
     #[must_use]
     pub unsafe fn steal(port: u8, pin: u8) -> Self {
-        // Calculates the offset from the beginning of the IOPCTL register block
-        // address to the register address representing the pin.
-        //
-        // See Table 297 in reference manual for how this offset is calculated.
-        let offset = ((port as usize) << 7) + ((pin as usize) << 2);
-
-        // SAFETY: This is safe assuming the caller of this function satisfies the safety requirements above.
-        let reg = unsafe { &*Iopctl::ptr().byte_offset(offset as isize).cast() };
+        let offset = (port as usize * 32 + pin as usize) * 4;
         Self {
             pin_port: port * 32 + pin,
-            reg,
+            reg: unsafe { pac::common::Reg::from_ptr((pac::IOPCTL.as_ptr() as *mut u8).wrapping_add(offset) as _) },
         }
     }
 
@@ -233,7 +216,7 @@ impl AnyPin {
 
 /// Represents a FC15 pin peripheral created at run-time from given pin number.
 pub struct FC15Pin {
-    reg: &'static PioM_N,
+    reg: pac::common::Reg<pac::iopctl::regs::Pio, pac::common::RW>,
 }
 
 impl FC15Pin {
@@ -256,13 +239,14 @@ impl FC15Pin {
     /// pin and port number combinations.
     #[must_use]
     pub unsafe fn steal(pin: u8) -> Self {
-        // Table 297:  FC15_I2C_SCL offset = 0x400, FC15_I2C_SCL offset = 0x404
-        let iopctl = unsafe { crate::pac::Iopctl::steal() };
+        let iopctl = pac::IOPCTL;
 
-        let reg = if pin == 0 {
-            &*iopctl.fc15_i2c_scl().as_ptr().cast()
+        // FC15 registers share the same memory layout as regular PIO pins,
+        // so we can safely construct a Reg<Pio> from their address.
+        let reg: pac::common::Reg<pac::iopctl::regs::Pio, pac::common::RW> = if pin == 0 {
+            unsafe { pac::common::Reg::from_ptr(iopctl.fc15_i2c_scl().as_ptr() as _) }
         } else {
-            &*iopctl.fc15_i2c_sda().as_ptr().cast()
+            unsafe { pac::common::Reg::from_ptr(iopctl.fc15_i2c_sda().as_ptr() as _) }
         };
 
         Self { reg }
@@ -284,50 +268,43 @@ macro_rules! impl_iopctlpin {
     ($pintype:ident) => {
         impl IopctlPin for $pintype {
             fn set_function(&self, function: Function) -> &Self {
-                critical_section::with(|_| match function {
-                    Function::F0 => {
-                        self.reg.modify(|_, w| w.fsel().function_0());
-                    }
-                    Function::F1 => {
-                        self.reg.modify(|_, w| w.fsel().function_1());
-                    }
-                    Function::F2 => {
-                        self.reg.modify(|_, w| w.fsel().function_2());
-                    }
-                    Function::F3 => {
-                        self.reg.modify(|_, w| w.fsel().function_3());
-                    }
-                    Function::F4 => {
-                        self.reg.modify(|_, w| w.fsel().function_4());
-                    }
-                    Function::F5 => {
-                        self.reg.modify(|_, w| w.fsel().function_5());
-                    }
-                    Function::F6 => {
-                        self.reg.modify(|_, w| w.fsel().function_6());
-                    }
-                    Function::F7 => {
-                        self.reg.modify(|_, w| w.fsel().function_7());
-                    }
-                    Function::F8 => {
-                        self.reg.modify(|_, w| w.fsel().function_8());
-                    }
+                use pac::iopctl::vals::Fsel;
+                critical_section::with(|_| {
+                    self.reg.modify(|w| {
+                        w.set_fsel(match function {
+                            Function::F0 => Fsel::FUNCTION_0,
+                            Function::F1 => Fsel::FUNCTION_1,
+                            Function::F2 => Fsel::FUNCTION_2,
+                            Function::F3 => Fsel::FUNCTION_3,
+                            Function::F4 => Fsel::FUNCTION_4,
+                            Function::F5 => Fsel::FUNCTION_5,
+                            Function::F6 => Fsel::FUNCTION_6,
+                            Function::F7 => Fsel::FUNCTION_7,
+                            Function::F8 => Fsel::FUNCTION_8,
+                        })
+                    });
                 });
                 self
             }
 
             fn set_pull(&self, pull: Pull) -> &Self {
+                use pac::iopctl::vals::Pupdsel;
                 critical_section::with(|_| {
                     match pull {
                         Pull::None => {
-                            self.reg.modify(|_, w| w.pupdena().disabled());
+                            self.reg.modify(|w| w.set_pupdena(false));
                         }
                         Pull::Up => {
-                            self.reg.modify(|_, w| w.pupdena().enabled().pupdsel().pull_up());
+                            self.reg.modify(|w| {
+                                w.set_pupdena(true);
+                                w.set_pupdsel(Pupdsel::PULL_UP);
+                            });
                         }
                         Pull::Down => {
-                            self.reg
-                                .modify(|_, w| w.pupdena().enabled().pupdsel().pull_down());
+                            self.reg.modify(|w| {
+                                w.set_pupdena(true);
+                                w.set_pupdsel(Pupdsel::PULL_DOWN);
+                            });
                         }
                     }
                     self
@@ -335,75 +312,77 @@ macro_rules! impl_iopctlpin {
             }
 
             fn enable_input_buffer(&self) -> &Self {
-                critical_section::with(|_| self.reg.modify(|_, w| w.ibena().enabled()));
+                critical_section::with(|_| self.reg.modify(|w| w.set_ibena(true)));
                 self
             }
 
             fn disable_input_buffer(&self) -> &Self {
-                critical_section::with(|_| self.reg.modify(|_, w| w.ibena().disabled()));
+                critical_section::with(|_| self.reg.modify(|w| w.set_ibena(false)));
                 self
             }
 
             fn set_slew_rate(&self, slew_rate: SlewRate) -> &Self {
-                critical_section::with(|_| match slew_rate {
-                    SlewRate::Standard => {
-                        self.reg.modify(|_, w| w.slewrate().normal());
-                    }
-                    SlewRate::Slow => {
-                        self.reg.modify(|_, w| w.slewrate().slow());
-                    }
+                use pac::iopctl::vals::Slewrate as PacSlewrate;
+                critical_section::with(|_| {
+                    self.reg.modify(|w| {
+                        w.set_slewrate(match slew_rate {
+                            SlewRate::Standard => PacSlewrate::NORMAL,
+                            SlewRate::Slow => PacSlewrate::SLOW,
+                        })
+                    });
                 });
                 self
             }
 
             fn set_drive_strength(&self, strength: DriveStrength) -> &Self {
-                critical_section::with(|_| match strength {
-                    DriveStrength::Normal => {
-                        self.reg.modify(|_, w| w.fulldrive().normal_drive());
-                    }
-                    DriveStrength::Full => {
-                        self.reg.modify(|_, w| w.fulldrive().full_drive());
-                    }
+                use pac::iopctl::vals::Fulldrive;
+                critical_section::with(|_| {
+                    self.reg.modify(|w| {
+                        w.set_fulldrive(match strength {
+                            DriveStrength::Normal => Fulldrive::NORMAL_DRIVE,
+                            DriveStrength::Full => Fulldrive::FULL_DRIVE,
+                        })
+                    });
                 });
                 self
             }
 
             fn enable_analog_multiplex(&self) -> &Self {
-                critical_section::with(|_| self.reg.modify(|_, w| w.amena().enabled()));
+                critical_section::with(|_| self.reg.modify(|w| w.set_amena(true)));
                 self
             }
 
             fn disable_analog_multiplex(&self) -> &Self {
-                critical_section::with(|_| self.reg.modify(|_, w| w.amena().disabled()));
+                critical_section::with(|_| self.reg.modify(|w| w.set_amena(false)));
                 self
             }
 
             fn set_drive_mode(&self, mode: DriveMode) -> &Self {
-                critical_section::with(|_| match mode {
-                    DriveMode::PushPull => {
-                        self.reg.modify(|_, w| w.odena().disabled());
-                    }
-                    DriveMode::OpenDrain => {
-                        self.reg.modify(|_, w| w.odena().enabled());
-                    }
+                critical_section::with(|_| {
+                    self.reg.modify(|w| {
+                        w.set_odena(match mode {
+                            DriveMode::PushPull => false,
+                            DriveMode::OpenDrain => true,
+                        })
+                    });
                 });
                 self
             }
 
             fn set_input_inverter(&self, inverter: Inverter) -> &Self {
-                critical_section::with(|_| match inverter {
-                    Inverter::Disabled => {
-                        self.reg.modify(|_, w| w.iiena().disabled());
-                    }
-                    Inverter::Enabled => {
-                        self.reg.modify(|_, w| w.iiena().enabled());
-                    }
+                critical_section::with(|_| {
+                    self.reg.modify(|w| {
+                        w.set_iiena(match inverter {
+                            Inverter::Disabled => false,
+                            Inverter::Enabled => true,
+                        })
+                    });
                 });
                 self
             }
 
             fn reset(&self) -> &Self {
-                self.reg.reset();
+                self.reg.write_value(Default::default());
                 self
             }
         }

--- a/embassy-imxrt/src/rng.rs
+++ b/embassy-imxrt/src/rng.rs
@@ -9,6 +9,10 @@ use embassy_sync::waitqueue::AtomicWaker;
 
 use crate::clocks::{SysconPeripheral, enable_and_reset};
 use crate::interrupt::typelevel::Interrupt;
+use crate::pac::trng::vals::{
+    IntCtrlEntVal, IntCtrlFrqCtFail, IntCtrlHwErr, IntMaskEntVal, IntMaskFrqCtFail, IntMaskHwErr, IntStatusEntVal,
+    IntStatusFrqCtFail, IntStatusHwErr,
+};
 use crate::{Peri, PeripheralType, interrupt, peripherals};
 
 static RNG_WAKER: AtomicWaker = AtomicWaker::new();
@@ -37,17 +41,14 @@ impl<T: Instance> interrupt::typelevel::Handler<T::Interrupt> for InterruptHandl
         let regs = T::info().regs;
         let int_status = regs.int_status().read();
 
-        if int_status.ent_val().bit_is_set()
-            || int_status.hw_err().bit_is_set()
-            || int_status.frq_ct_fail().bit_is_set()
+        if int_status.ent_val() == IntStatusEntVal::ENT_VAL_1
+            || int_status.hw_err() == IntStatusHwErr::HW_ERR_1
+            || int_status.frq_ct_fail() == IntStatusFrqCtFail::FRQ_CT_FAIL_1
         {
-            regs.int_ctrl().modify(|_, w| {
-                w.ent_val()
-                    .ent_val_0()
-                    .hw_err()
-                    .hw_err_0()
-                    .frq_ct_fail()
-                    .frq_ct_fail_0()
+            regs.int_ctrl().modify(|w| {
+                w.set_ent_val(IntCtrlEntVal::ENT_VAL_0);
+                w.set_hw_err(IntCtrlHwErr::HW_ERR_0);
+                w.set_frq_ct_fail(IntCtrlFrqCtFail::FRQ_CT_FAIL_0);
             });
             RNG_WAKER.wake();
         }
@@ -82,7 +83,10 @@ impl<'d> Rng<'d> {
 
     /// Reset the RNG.
     pub fn reset(&mut self) {
-        self.info.regs.mctl().write(|w| w.rst_def().set_bit().prgm().set_bit());
+        self.info.regs.mctl().write(|w| {
+            w.set_rst_def(true);
+            w.set_prgm(true);
+        });
     }
 
     /// Fill the given slice with random values.
@@ -103,7 +107,7 @@ impl<'d> Rng<'d> {
             // Check if already ready.
             // TODO: Is this necessary? Could we just check once after
             // the waker has been registered?
-            if self.info.regs.int_status().read().ent_val().bit_is_set() {
+            if self.info.regs.int_status().read().ent_val() == IntStatusEntVal::ENT_VAL_1 {
                 return Poll::Ready(Ok(()));
             }
 
@@ -114,11 +118,11 @@ impl<'d> Rng<'d> {
             let mctl = self.info.regs.mctl().read();
 
             // Check again if interrupt fired
-            if mctl.ent_val().bit_is_set() {
+            if mctl.ent_val() {
                 Poll::Ready(Ok(()))
-            } else if mctl.err().bit_is_set() {
+            } else if mctl.err() {
                 Poll::Ready(Err(Error::HwError))
-            } else if mctl.fct_fail().bit_is_set() {
+            } else if mctl.fct_fail() {
                 Poll::Ready(Err(Error::FreqCountFail))
             } else {
                 Poll::Pending
@@ -128,17 +132,17 @@ impl<'d> Rng<'d> {
 
         let bits = self.info.regs.mctl().read();
 
-        if bits.ent_val().bit_is_set() {
+        if bits.ent_val() {
             let mut entropy = [0; 16];
 
             for (i, item) in entropy.iter_mut().enumerate() {
-                *item = self.info.regs.ent(i).read().bits();
+                *item = self.info.regs.ent(i).read().ent();
             }
 
             // Read MCTL after reading ENT15
             let _ = self.info.regs.mctl().read();
 
-            if entropy.iter().any(|e| *e == 0) {
+            if entropy.contains(&0) {
                 return Err(Error::SeedError);
             }
 
@@ -155,34 +159,25 @@ impl<'d> Rng<'d> {
 
     fn mask_interrupts(&mut self) {
         self.info.regs.int_mask().write(|w| {
-            w.ent_val()
-                .ent_val_0()
-                .hw_err()
-                .hw_err_0()
-                .frq_ct_fail()
-                .frq_ct_fail_0()
+            w.set_ent_val(IntMaskEntVal::ENT_VAL_0);
+            w.set_hw_err(IntMaskHwErr::HW_ERR_0);
+            w.set_frq_ct_fail(IntMaskFrqCtFail::FRQ_CT_FAIL_0);
         });
     }
 
     fn unmask_interrupts(&mut self) {
-        self.info.regs.int_mask().modify(|_, w| {
-            w.ent_val()
-                .ent_val_1()
-                .hw_err()
-                .hw_err_1()
-                .frq_ct_fail()
-                .frq_ct_fail_1()
+        self.info.regs.int_mask().modify(|w| {
+            w.set_ent_val(IntMaskEntVal::ENT_VAL_1);
+            w.set_hw_err(IntMaskHwErr::HW_ERR_1);
+            w.set_frq_ct_fail(IntMaskFrqCtFail::FRQ_CT_FAIL_1);
         });
     }
 
     fn enable_interrupts(&mut self) {
         self.info.regs.int_ctrl().write(|w| {
-            w.ent_val()
-                .ent_val_1()
-                .hw_err()
-                .hw_err_1()
-                .frq_ct_fail()
-                .frq_ct_fail_1()
+            w.set_ent_val(IntCtrlEntVal::ENT_VAL_1);
+            w.set_hw_err(IntCtrlHwErr::HW_ERR_1);
+            w.set_frq_ct_fail(IntCtrlFrqCtFail::FRQ_CT_FAIL_1);
         });
     }
 
@@ -190,15 +185,15 @@ impl<'d> Rng<'d> {
         self.mask_interrupts();
 
         // Switch TRNG to programming mode
-        self.info.regs.mctl().modify(|_, w| w.prgm().set_bit());
+        self.info.regs.mctl().modify(|w| w.set_prgm(true));
 
         self.enable_interrupts();
 
         // Switch TRNG to Run Mode
-        self.info
-            .regs
-            .mctl()
-            .modify(|_, w| w.trng_acc().set_bit().prgm().clear_bit());
+        self.info.regs.mctl().modify(|w| {
+            w.set_trng_acc(true);
+            w.set_prgm(false);
+        });
     }
 
     /// Generate a random u32
@@ -278,7 +273,7 @@ impl<'d> rand_core_10::TryRng for Rng<'d> {
 impl<'d> rand_core_10::TryCryptoRng for Rng<'d> {}
 
 struct Info {
-    regs: crate::pac::Trng,
+    regs: crate::pac::trng::Trng,
 }
 
 trait SealedInstance {
@@ -298,9 +293,6 @@ impl Instance for peripherals::RNG {
 
 impl SealedInstance for peripherals::RNG {
     fn info() -> Info {
-        // SAFETY: safe from single executor
-        Info {
-            regs: unsafe { crate::pac::Trng::steal() },
-        }
+        Info { regs: crate::pac::TRNG }
     }
 }

--- a/embassy-imxrt/src/time_driver.rs
+++ b/embassy-imxrt/src/time_driver.rs
@@ -29,8 +29,8 @@ impl AlarmState {
 }
 
 #[cfg(feature = "time-driver-rtc")]
-fn rtc() -> &'static pac::rtc::RegisterBlock {
-    unsafe { &*pac::Rtc::ptr() }
+fn rtc() -> pac::rtc::Rtc {
+    pac::RTC
 }
 
 /// Calculate the timestamp from the period count and the tick count.
@@ -66,44 +66,26 @@ struct Rtc {
 
 #[cfg(feature = "time-driver-rtc")]
 impl Rtc {
-    /// Access the GPREG0 register to use it as a 31-bit counter.
-    #[inline]
-    fn counter_reg(&self) -> &pac::rtc::Gpreg {
-        rtc().gpreg(0)
-    }
-
-    /// Access the GPREG1 register to use it as a compare register for triggering alarms.
-    #[inline]
-    fn compare_reg(&self) -> &pac::rtc::Gpreg {
-        rtc().gpreg(1)
-    }
-
-    /// Access the GPREG2 register to use it to enable or disable interrupts (int_en).
-    #[inline]
-    fn int_en_reg(&self) -> &pac::rtc::Gpreg {
-        rtc().gpreg(2)
-    }
-
     fn init(&'static self, irq_prio: crate::interrupt::Priority) {
         let r = rtc();
         // enable RTC int (1kHz since subsecond doesn't generate an int)
-        r.ctrl().modify(|_r, w| w.rtc1khz_en().set_bit());
-        // TODO: low power support. line above is leaving out write to .wakedpd_en().set_bit())
+        r.ctrl().modify(|w| w.set_rtc1khz_en(true));
+        // TODO: low power support. line above is leaving out write to .set_wakedpd_en(true)
         // which enables wake from deep power down
 
-        // safety: Writing to the gregs is always considered unsafe, gpreg1 is used
-        // as a compare register for triggering an alarm so to avoid unnecessary triggers
-        // after initialization, this is set to 0x:FFFF_FFFF
-        self.compare_reg().write(|w| unsafe { w.gpdata().bits(u32::MAX) });
-        // safety: writing a value to the 1kHz RTC wake counter is always considered unsafe.
+        // gpreg1 is used as a compare register for triggering an alarm so to avoid
+        // unnecessary triggers after initialization, this is set to 0x:FFFF_FFFF
+        rtc().gpreg(1).write(|w| w.set_gpdata(u32::MAX));
         // The following loads 10 into the count-down timer.
-        r.wake().write(|w| unsafe { w.bits(0xA) });
+        r.wake().write_value(pac::rtc::regs::Wake(0xA));
         interrupt::RTC.set_priority(irq_prio);
         unsafe { interrupt::RTC.enable() };
     }
 
     #[cfg(feature = "rt")]
     fn on_interrupt(&self) {
+        use crate::pac::rtc::vals::Wake1khz;
+
         let r = rtc();
         // This interrupt fires every 10 ticks of the 1kHz RTC high res clk and adds
         // 10 to the 31 bit counter gpreg0. The 32nd bit is used for parity detection
@@ -112,22 +94,20 @@ impl Rtc {
         //
         // TODO: this is admittedly not great for power that we're generating this
         // many interrupts, will probably get updated in future iterations.
-        if r.ctrl().read().wake1khz().bit_is_set() {
-            r.ctrl().modify(|_r, w| w.wake1khz().set_bit());
-            // safety: writing a value to the 1kHz RTC wake counter is always considered unsafe.
+        if r.ctrl().read().wake1khz() == Wake1khz::TIME_OUT {
+            r.ctrl().modify(|w| w.set_wake1khz(Wake1khz::TIME_OUT));
             // The following reloads 10 into the count-down timer after it triggers an int.
             // The countdown begins anew after the write so time can continue to be measured.
-            r.wake().write(|w| unsafe { w.bits(0xA) });
-            if (self.counter_reg().read().bits() + 0xA) > 0x8000_0000 {
+            r.wake().write_value(pac::rtc::regs::Wake(0xA));
+            if (rtc().gpreg(0).read().0 + 0xA) > 0x8000_0000 {
                 // if we're going to "overflow", increase the period
                 self.next_period();
-                let rollover_diff = 0x8000_0000 - (self.counter_reg().read().bits() + 0xA);
-                // safety: writing to gpregs is always considered unsafe. In order to
-                // not "lose" time when incrementing the period, gpreg0, the extended
-                // counter, is restarted at the # of ticks it would overflow by
-                self.counter_reg().write(|w| unsafe { w.bits(rollover_diff) });
+                let rollover_diff = 0x8000_0000 - (rtc().gpreg(0).read().0 + 0xA);
+                // In order to not "lose" time when incrementing the period, gpreg0,
+                // the extended counter, is restarted at the # of ticks it would overflow by
+                rtc().gpreg(0).write_value(pac::rtc::regs::Gpreg(rollover_diff));
             } else {
-                self.counter_reg().modify(|r, w| unsafe { w.bits(r.bits() + 0xA) });
+                rtc().gpreg(0).modify(|w| w.0 = w.0 + 0xA);
             }
         }
 
@@ -135,10 +115,10 @@ impl Rtc {
             // gpreg2 as an "int_en" set by next_period(). This is
             // 1 when the timestamp for the alarm deadline expires
             // before the counter register overflows again.
-            if self.int_en_reg().read().gpdata().bits() == 1 {
+            if rtc().gpreg(2).read().gpdata() == 1 {
                 // gpreg0 is our extended counter register, check if
                 // our counter is larger than the compare value
-                if self.counter_reg().read().bits() > self.compare_reg().read().bits() {
+                if rtc().gpreg(0).read().0 > rtc().gpreg(1).read().0 {
                     self.trigger_alarm(cs);
                 }
             }
@@ -162,10 +142,10 @@ impl Rtc {
             let alarm = &self.alarms.borrow(cs);
             let at = alarm.timestamp.get();
             if at < t + 0xc000_0000 {
-                // safety: writing to gpregs is always unsafe, gpreg2 is an alarm
-                // enable. If the alarm must trigger within the next period, then
-                // just enable it. `set_alarm` has already set the correct CC val.
-                self.int_en_reg().write(|w| unsafe { w.gpdata().bits(1) });
+                // gpreg2 is an alarm enable. If the alarm must trigger within the
+                // next period, then just enable it. `set_alarm` has already set the
+                // correct CC val.
+                rtc().gpreg(2).write(|w| w.set_gpdata(1));
             }
         })
     }
@@ -177,11 +157,10 @@ impl Rtc {
 
         let t = self.now();
         if timestamp <= t {
-            // safety: Writing to the gpregs is always unsafe, gpreg2 is
-            // always just used as the alarm enable for the timer driver.
+            // gpreg2 is always just used as the alarm enable for the timer driver.
             // If alarm timestamp has passed the alarm will not fire.
             // Disarm the alarm and return `false` to indicate that.
-            self.int_en_reg().write(|w| unsafe { w.gpdata().bits(0) });
+            rtc().gpreg(2).write(|w| w.set_gpdata(0));
 
             alarm.timestamp.set(u64::MAX);
 
@@ -193,26 +172,26 @@ impl Rtc {
         // What's not allowed is triggering alarms *before* their scheduled time,
         let safe_timestamp = timestamp.max(t + 10); //t+3 was done for nrf chip, choosing 10
 
-        // safety: writing to the gregs is always unsafe. When a new alarm is set,
-        // the compare register, gpreg1, is set to the last 31 bits of the timestamp
-        // as the 32nd and final bit is used for the parity check in `next_period`
-        // `period` will be used for the upper bits in a timestamp comparison.
-        self.compare_reg()
-            .modify(|_r, w| unsafe { w.bits(safe_timestamp as u32 & 0x7FFF_FFFF) });
+        // When a new alarm is set, the compare register, gpreg1, is set to the last
+        // 31 bits of the timestamp as the 32nd and final bit is used for the parity
+        // check in `next_period`. `period` will be used for the upper bits in a
+        // timestamp comparison.
+        rtc()
+            .gpreg(1)
+            .write_value(pac::rtc::regs::Gpreg(safe_timestamp as u32 & 0x7FFF_FFFF));
 
         // The following checks that the difference in timestamp is less than the overflow period
         let diff = timestamp - t;
         if diff < 0xc000_0000 {
             // this is 0b11 << (30). NRF chip used 23 bit periods and checked against 0b11<<22
 
-            // safety: writing to the gpregs is always unsafe. If the alarm
-            // must trigger within the next period, set the "int enable"
-            self.int_en_reg().write(|w| unsafe { w.gpdata().bits(1) });
+            // If the alarm must trigger within the next period, set the "int enable"
+            rtc().gpreg(2).write(|w| w.set_gpdata(1));
         } else {
-            // safety: writing to the gpregs is always unsafe. If alarm must trigger
-            // some time after the current period, too far in the future, don't setup
-            // the alarm enable, gpreg2, yet. It will be setup later by `next_period`.
-            self.int_en_reg().write(|w| unsafe { w.gpdata().bits(0) });
+            // If alarm must trigger some time after the current period, too far in the
+            // future, don't setup the alarm enable, gpreg2, yet. It will be setup
+            // later by `next_period`.
+            rtc().gpreg(2).write(|w| w.set_gpdata(0));
         }
 
         true
@@ -233,7 +212,7 @@ impl Driver for Rtc {
         // `period` MUST be read before `counter`, see comment at the top for details.
         let period = self.period.load(Ordering::Acquire);
         compiler_fence(Ordering::Acquire);
-        let counter = self.counter_reg().read().bits();
+        let counter = rtc().gpreg(0).read().0;
         calc_now(period, counter)
     }
 
@@ -259,8 +238,8 @@ fn RTC() {
 }
 
 #[cfg(feature = "time-driver-os-timer")]
-fn os() -> &'static pac::ostimer0::RegisterBlock {
-    unsafe { &*pac::Ostimer0::ptr() }
+fn os() -> pac::ostimer::Ostimer {
+    pac::OSTIMER0
 }
 
 /// Convert gray to decimal
@@ -321,11 +300,11 @@ impl OsTimer {
         interrupt::OS_EVENT.disable();
 
         // Make sure interrupt is masked
-        os().osevent_ctrl().modify(|_, w| w.ostimer_intena().clear_bit());
+        os().osevent_ctrl().modify(|w| w.set_ostimer_intena(false));
 
         // Default to the end of time
-        os().match_l().write(|w| unsafe { w.bits(0xffff_ffff) });
-        os().match_h().write(|w| unsafe { w.bits(0xffff_ffff) });
+        os().match_l().write_value(pac::ostimer::regs::MatchL(0xffff_ffff));
+        os().match_h().write_value(pac::ostimer::regs::MatchH(0xffff_ffff));
 
         interrupt::OS_EVENT.unpend();
         interrupt::OS_EVENT.set_priority(irq_prio);
@@ -338,11 +317,11 @@ impl OsTimer {
 
         // Wait until we're allowed to write to MATCH_L/MATCH_H
         // registers
-        while os().osevent_ctrl().read().match_wr_rdy().bit_is_set() {}
+        while os().osevent_ctrl().read().match_wr_rdy() {}
 
         let t = self.now();
         if timestamp <= t {
-            os().osevent_ctrl().modify(|_, w| w.ostimer_intena().clear_bit());
+            os().osevent_ctrl().modify(|w| w.set_ostimer_intena(false));
             alarm.timestamp.set(u64::MAX);
             return false;
         }
@@ -350,10 +329,10 @@ impl OsTimer {
         let gray_timestamp = dec_to_gray(timestamp);
 
         os().match_l()
-            .write(|w| unsafe { w.bits(gray_timestamp as u32 & 0xffff_ffff) });
+            .write_value(pac::ostimer::regs::MatchL(gray_timestamp as u32 & 0xffff_ffff));
         os().match_h()
-            .write(|w| unsafe { w.bits((gray_timestamp >> 32) as u32) });
-        os().osevent_ctrl().modify(|_, w| w.ostimer_intena().set_bit());
+            .write_value(pac::ostimer::regs::MatchH((gray_timestamp >> 32) as u32));
+        os().osevent_ctrl().modify(|w| w.set_ostimer_intena(true));
 
         true
     }
@@ -369,9 +348,11 @@ impl OsTimer {
     #[cfg(feature = "rt")]
     fn on_interrupt(&self) {
         critical_section::with(|cs| {
-            if os().osevent_ctrl().read().ostimer_intrflag().bit_is_set() {
-                os().osevent_ctrl()
-                    .modify(|_, w| w.ostimer_intena().clear_bit().ostimer_intrflag().set_bit());
+            if os().osevent_ctrl().read().ostimer_intrflag() {
+                os().osevent_ctrl().modify(|w| {
+                    w.set_ostimer_intena(false);
+                    w.set_ostimer_intrflag(true);
+                });
                 self.trigger_alarm(cs);
             }
         });
@@ -381,9 +362,9 @@ impl OsTimer {
 #[cfg(feature = "time-driver-os-timer")]
 impl Driver for OsTimer {
     fn now(&self) -> u64 {
-        let mut t = os().evtimerh().read().bits() as u64;
+        let mut t = os().evtimerh().read().0 as u64;
         t <<= 32;
-        t |= os().evtimerl().read().bits() as u64;
+        t |= os().evtimerl().read().0 as u64;
         gray_to_dec(t)
     }
 


### PR DESCRIPTION
Replace the svd2rust-generated mimxrt685s-pac and mimxrt633s-pac dependencies with the chiptool-generated nxp-pac crate. This is a pure PAC swap with no functional changes.