### PR TITLE
ubs-host: Separate pipe/address allocation from the main bus controller

### DIFF
--- a/embassy-rp/src/usb/host.rs
+++ b/embassy-rp/src/usb/host.rs
@@ -772,19 +772,24 @@ impl<'d, T: SealedHostInstance> UsbHostAllocator<'d> for Allocator<'d, T> {
         let state = T::host_state();
         let pre = split_to_pre(split);
         if E::ep_type() == EndpointType::Interrupt {
-            let alloc = state.allocated_pipes.load(Ordering::Acquire);
-            let free_index = (1..16).find(|i| alloc & (1 << i) == 0).ok_or(HostError::OutOfPipes)? as u8;
-
-            state.allocated_pipes.store(alloc | 1 << free_index, Ordering::Release);
+            let free_index = critical_section::with(|_| {
+                let alloc = state.allocated_pipes.load(Ordering::Relaxed);
+                if let Some(idx) = (1..16).find(|i| alloc & (1 << i) == 0) {
+                    state.allocated_pipes.store(alloc | (1 << idx), Ordering::Relaxed);
+                    Ok(idx as u8)
+                } else {
+                    Err(HostError::OutOfPipes)
+                }
+            })?;
             // Use fixed layout
             let addr = DPRAM_DATA_OFFSET + MAIN_BUFFER_SIZE as u16 + free_index as u16 * 64;
 
             Ok(Channel::new(free_index as _, addr, 64, endpoint, dev_addr, pre))
         } else {
             let index = critical_section::with(|_| {
-                let old_val = state.channel_index.load(Ordering::Relaxed);
-                state.channel_index.store(old_val + 1, Ordering::Relaxed);
-                old_val
+                let old = state.channel_index.load(Ordering::Relaxed);
+                state.channel_index.store(old + 1, Ordering::Relaxed);
+                old
             });
             Ok(Channel::new(
                 index,

--- a/embassy-rp/src/usb/host.rs
+++ b/embassy-rp/src/usb/host.rs
@@ -5,7 +5,8 @@ use core::task::Poll;
 
 use embassy_sync::waitqueue::AtomicWaker;
 use embassy_usb_driver::host::{
-    DeviceEvent, HostError, PipeError, SplitInfo, SplitSpeed, TimeoutConfig, UsbHostDriver, UsbPipe, pipe,
+    DeviceEvent, HostError, PipeError, SplitInfo, SplitSpeed, TimeoutConfig, UsbHostAllocator, UsbHostController,
+    UsbPipe, pipe,
 };
 use embassy_usb_driver::{EndpointInfo, EndpointType, Speed};
 
@@ -31,13 +32,17 @@ const MAIN_BUFFER_SIZE: usize = 1024;
 /// 0 means None
 static CURRENT_CHANNEL: AtomicUsize = AtomicUsize::new(0);
 
+/// Bitset of allocated interrupt pipes (shared between driver and allocator).
+static ALLOCATED_PIPES: AtomicU16 = AtomicU16::new(0);
+
+/// Next 'allocated' non-interrupt channel index (shared between driver and allocator).
+///
+/// Seeded in [`Driver::new`]; indexes 1-15 are reserved for interrupt endpoints.
+static CHANNEL_INDEX: AtomicUsize = AtomicUsize::new(16);
+
 /// RP2040 USB host driver handle.
 pub struct Driver<'d, T: Instance> {
     phantom: PhantomData<&'d mut T>,
-    /// Bitset of allocated interrupt pipes
-    allocated_pipes: AtomicU16,
-    /// Index for next 'allocated' channel
-    channel_index: AtomicUsize,
 }
 
 impl<'d, T: Instance> Driver<'d, T> {
@@ -91,12 +96,11 @@ impl<'d, T: Instance> Driver<'d, T> {
         // Initialize the bus so that it signals that power is available
         BUS_WAKER.wake();
 
-        Self {
-            phantom: PhantomData,
-            allocated_pipes: AtomicU16::new(0),
-            // 1-15 are reserved for interrupt EPs
-            channel_index: AtomicUsize::new(16),
-        }
+        // Reset allocator state. Indices 1-15 are reserved for interrupt EPs.
+        ALLOCATED_PIPES.store(0, Ordering::Relaxed);
+        CHANNEL_INDEX.store(16, Ordering::Relaxed);
+
+        Self { phantom: PhantomData }
     }
 }
 
@@ -715,8 +719,67 @@ impl<'d, T: Instance, E: pipe::Type, D: pipe::Direction> UsbPipe<E, D> for Chann
 //     }
 // }
 
-impl<'d, T: Instance> UsbHostDriver<'d> for Driver<'d, T> {
+/// Pipe allocator handle for [`Driver`].
+///
+/// Obtained from [`UsbHostController::allocator`]. All state is stored in
+/// module-level `static`s, so this handle is a zero-sized marker and can
+/// be freely copied and held by class drivers independently of the
+/// controller's `&mut` borrow.
+pub struct Allocator<'d, T: Instance> {
+    phantom: PhantomData<&'d T>,
+}
+
+impl<'d, T: Instance> Clone for Allocator<'d, T> {
+    fn clone(&self) -> Self {
+        *self
+    }
+}
+
+impl<'d, T: Instance> Copy for Allocator<'d, T> {}
+
+impl<'d, T: Instance> UsbHostAllocator<'d> for Allocator<'d, T> {
     type Pipe<E: pipe::Type, D: pipe::Direction> = Channel<'d, T, E, D>;
+
+    fn alloc_pipe<E: pipe::Type, D: pipe::Direction>(
+        &self,
+        dev_addr: u8,
+        endpoint: &EndpointInfo,
+        split: Option<SplitInfo>,
+    ) -> Result<Self::Pipe<E, D>, HostError> {
+        let pre = split_to_pre(split);
+        if E::ep_type() == EndpointType::Interrupt {
+            let alloc = ALLOCATED_PIPES.load(Ordering::Acquire);
+            let free_index = (1..16).find(|i| alloc & (1 << i) == 0).ok_or(HostError::OutOfPipes)? as u8;
+
+            ALLOCATED_PIPES.store(alloc | 1 << free_index, Ordering::Release);
+            // Use fixed layout
+            let addr = DPRAM_DATA_OFFSET + MAIN_BUFFER_SIZE as u16 + free_index as u16 * 64;
+
+            Ok(Channel::new(free_index as _, addr, 64, endpoint, dev_addr, pre))
+        } else {
+            let index = critical_section::with(|_| {
+                let old_val = CHANNEL_INDEX.load(Ordering::Relaxed);
+                CHANNEL_INDEX.store(old_val + 1, Ordering::Relaxed);
+                old_val
+            });
+            Ok(Channel::new(
+                index,
+                DPRAM_DATA_OFFSET,
+                MAIN_BUFFER_SIZE as u16,
+                endpoint,
+                dev_addr,
+                pre,
+            ))
+        }
+    }
+}
+
+impl<'d, T: Instance> UsbHostController<'d> for Driver<'d, T> {
+    type Allocator = Allocator<'d, T>;
+
+    fn allocator(&self) -> Self::Allocator {
+        Allocator { phantom: PhantomData }
+    }
 
     async fn wait_for_device_event(&mut self) -> DeviceEvent {
         let is_connected = |status: u8| match status {
@@ -753,7 +816,7 @@ impl<'d, T: Instance> UsbHostDriver<'d> for Driver<'d, T> {
         })
         .await;
 
-        // Per the `UsbHostDriver` contract, drive a bus reset before
+        // Per the `UsbHostController` contract, drive a bus reset before
         // reporting the attach so the device transitions from the Powered
         // into the Default state (USB 2.0 §9.1.2). RP2040 is full-speed
         // only, so no chirp handshake occurs and the speed observed before
@@ -770,39 +833,6 @@ impl<'d, T: Instance> UsbHostDriver<'d> for Driver<'d, T> {
         });
 
         embassy_time::Timer::after_millis(50).await;
-    }
-
-    fn alloc_pipe<E: pipe::Type, D: pipe::Direction>(
-        &self,
-        dev_addr: u8,
-        endpoint: &EndpointInfo,
-        split: Option<SplitInfo>,
-    ) -> Result<Self::Pipe<E, D>, HostError> {
-        let pre = split_to_pre(split);
-        if E::ep_type() == EndpointType::Interrupt {
-            let alloc = self.allocated_pipes.load(Ordering::Acquire);
-            let free_index = (1..16).find(|i| alloc & (1 << i) == 0).ok_or(HostError::OutOfPipes)? as u8;
-
-            self.allocated_pipes.store(alloc | 1 << free_index, Ordering::Release);
-            // Use fixed layout
-            let addr = DPRAM_DATA_OFFSET + MAIN_BUFFER_SIZE as u16 + free_index as u16 * 64;
-
-            Ok(Channel::new(free_index as _, addr, 64, endpoint, dev_addr, pre))
-        } else {
-            let index = critical_section::with(|_| {
-                let old_val = self.channel_index.load(Ordering::Relaxed);
-                self.channel_index.store(old_val + 1, Ordering::Relaxed);
-                old_val
-            });
-            Ok(Channel::new(
-                index,
-                DPRAM_DATA_OFFSET,
-                MAIN_BUFFER_SIZE as u16,
-                endpoint,
-                dev_addr,
-                pre,
-            ))
-        }
     }
 }
 

--- a/embassy-rp/src/usb/host.rs
+++ b/embassy-rp/src/usb/host.rs
@@ -27,25 +27,54 @@ use crate::{Peri, RegExt};
 
 const MAIN_BUFFER_SIZE: usize = 1024;
 
-/// Current channel with ongoing transfer
-///
-/// 0 means None
-static CURRENT_CHANNEL: AtomicUsize = AtomicUsize::new(0);
+/// Per-instance state shared between [`Driver`], [`Allocator`] and [`Channel`].
+pub struct HostState {
+    /// Current channel with ongoing non-interrupt transfer. `0` means None.
+    current_channel: AtomicUsize,
+    /// Bitset of allocated interrupt pipes.
+    allocated_pipes: AtomicU16,
+    /// Next 'allocated' non-interrupt channel index. Indexes 1-15 are reserved for
+    /// interrupt endpoints, so allocation starts at 16.
+    channel_index: AtomicUsize,
+}
 
-/// Bitset of allocated interrupt pipes (shared between driver and allocator).
-static ALLOCATED_PIPES: AtomicU16 = AtomicU16::new(0);
+impl HostState {
+    /// Create a new, reset host state.
+    pub const fn new() -> Self {
+        Self {
+            current_channel: AtomicUsize::new(0),
+            allocated_pipes: AtomicU16::new(0),
+            channel_index: AtomicUsize::new(16),
+        }
+    }
 
-/// Next 'allocated' non-interrupt channel index (shared between driver and allocator).
-///
-/// Seeded in [`Driver::new`]; indexes 1-15 are reserved for interrupt endpoints.
-static CHANNEL_INDEX: AtomicUsize = AtomicUsize::new(16);
+    fn reset(&self) {
+        self.current_channel.store(0, Ordering::Relaxed);
+        self.allocated_pipes.store(0, Ordering::Relaxed);
+        self.channel_index.store(16, Ordering::Relaxed);
+    }
+}
+
+/// Sealed extension of [`Instance`] exposing the per-peripheral [`HostState`].
+#[allow(private_bounds)]
+pub trait SealedHostInstance: Instance {
+    #[doc(hidden)]
+    fn host_state() -> &'static HostState;
+}
+
+impl SealedHostInstance for crate::peripherals::USB {
+    fn host_state() -> &'static HostState {
+        static STATE: HostState = HostState::new();
+        &STATE
+    }
+}
 
 /// RP2040 USB host driver handle.
 pub struct Driver<'d, T: Instance> {
     phantom: PhantomData<&'d mut T>,
 }
 
-impl<'d, T: Instance> Driver<'d, T> {
+impl<'d, T: SealedHostInstance> Driver<'d, T> {
     /// Create a new USB driver.
     pub fn new(_usb: Peri<'d, USB>, _irq: impl Binding<T::Interrupt, InterruptHandler<T>>) -> Self {
         let regs = T::regs();
@@ -96,9 +125,8 @@ impl<'d, T: Instance> Driver<'d, T> {
         // Initialize the bus so that it signals that power is available
         BUS_WAKER.wake();
 
-        // Reset allocator state. Indices 1-15 are reserved for interrupt EPs.
-        ALLOCATED_PIPES.store(0, Ordering::Relaxed);
-        CHANNEL_INDEX.store(16, Ordering::Relaxed);
+        // Reset per-instance allocator state.
+        T::host_state().reset();
 
         Self { phantom: PhantomData }
     }
@@ -165,7 +193,7 @@ impl<'d, T: Instance, E: pipe::Type, D: pipe::Direction> Channel<'d, T, E, D> {
 type BufferControlReg = rp_pac::common::Reg<rp_pac::usb_dpram::regs::EpBufferControl, rp_pac::common::RW>;
 type EpControlReg = rp_pac::common::Reg<rp_pac::usb_dpram::regs::EpControl, rp_pac::common::RW>;
 type AddrControlReg = rp_pac::common::Reg<rp_pac::usb::regs::AddrEndpX, rp_pac::common::RW>;
-impl<'d, T: Instance, E: pipe::Type, D: pipe::Direction> Channel<'d, T, E, D> {
+impl<'d, T: SealedHostInstance, E: pipe::Type, D: pipe::Direction> Channel<'d, T, E, D> {
     /// Get channel waker
     fn waker(&self) -> &AtomicWaker {
         if Self::is_interrupt_in() {
@@ -235,7 +263,7 @@ impl<'d, T: Instance, E: pipe::Type, D: pipe::Direction> Channel<'d, T, E, D> {
         if Self::is_interrupt_in() {
             true
         } else {
-            let sel = CURRENT_CHANNEL.load(Ordering::Relaxed);
+            let sel = T::host_state().current_channel.load(Ordering::Relaxed);
             sel == self.index || sel == 0
         }
     }
@@ -347,7 +375,7 @@ impl<'d, T: Instance, E: pipe::Type, D: pipe::Direction> Channel<'d, T, E, D> {
                 w.set_intep_preamble(self.pre)
             });
         } else {
-            CURRENT_CHANNEL.store(self.index, Ordering::Relaxed);
+            T::host_state().current_channel.store(self.index, Ordering::Relaxed);
 
             T::regs().addr_endp().write(|w| {
                 w.set_address(self.dev_addr);
@@ -380,7 +408,7 @@ impl<'d, T: Instance, E: pipe::Type, D: pipe::Direction> Channel<'d, T, E, D> {
         // If this channel is selected
         if self.is_ready_for_transaction() {
             if !Self::is_interrupt_in() {
-                CURRENT_CHANNEL.store(0, Ordering::Relaxed);
+                T::host_state().current_channel.store(0, Ordering::Relaxed);
             }
 
             self.ep_control().modify(|w| {
@@ -562,7 +590,7 @@ impl<'d, T: Instance, E: pipe::Type, D: pipe::Direction> Channel<'d, T, E, D> {
     }
 }
 
-impl<'d, T: Instance, E: pipe::Type, D: pipe::Direction> UsbPipe<E, D> for Channel<'d, T, E, D> {
+impl<'d, T: SealedHostInstance, E: pipe::Type, D: pipe::Direction> UsbPipe<E, D> for Channel<'d, T, E, D> {
     async fn control_in(&mut self, setup: &[u8; 8], buf: &mut [u8]) -> Result<usize, PipeError>
     where
         E: pipe::IsControl,
@@ -720,11 +748,6 @@ impl<'d, T: Instance, E: pipe::Type, D: pipe::Direction> UsbPipe<E, D> for Chann
 // }
 
 /// Pipe allocator handle for [`Driver`].
-///
-/// Obtained from [`UsbHostController::allocator`]. All state is stored in
-/// module-level `static`s, so this handle is a zero-sized marker and can
-/// be freely copied and held by class drivers independently of the
-/// controller's `&mut` borrow.
 pub struct Allocator<'d, T: Instance> {
     phantom: PhantomData<&'d T>,
 }
@@ -737,7 +760,7 @@ impl<'d, T: Instance> Clone for Allocator<'d, T> {
 
 impl<'d, T: Instance> Copy for Allocator<'d, T> {}
 
-impl<'d, T: Instance> UsbHostAllocator<'d> for Allocator<'d, T> {
+impl<'d, T: SealedHostInstance> UsbHostAllocator<'d> for Allocator<'d, T> {
     type Pipe<E: pipe::Type, D: pipe::Direction> = Channel<'d, T, E, D>;
 
     fn alloc_pipe<E: pipe::Type, D: pipe::Direction>(
@@ -746,20 +769,21 @@ impl<'d, T: Instance> UsbHostAllocator<'d> for Allocator<'d, T> {
         endpoint: &EndpointInfo,
         split: Option<SplitInfo>,
     ) -> Result<Self::Pipe<E, D>, HostError> {
+        let state = T::host_state();
         let pre = split_to_pre(split);
         if E::ep_type() == EndpointType::Interrupt {
-            let alloc = ALLOCATED_PIPES.load(Ordering::Acquire);
+            let alloc = state.allocated_pipes.load(Ordering::Acquire);
             let free_index = (1..16).find(|i| alloc & (1 << i) == 0).ok_or(HostError::OutOfPipes)? as u8;
 
-            ALLOCATED_PIPES.store(alloc | 1 << free_index, Ordering::Release);
+            state.allocated_pipes.store(alloc | 1 << free_index, Ordering::Release);
             // Use fixed layout
             let addr = DPRAM_DATA_OFFSET + MAIN_BUFFER_SIZE as u16 + free_index as u16 * 64;
 
             Ok(Channel::new(free_index as _, addr, 64, endpoint, dev_addr, pre))
         } else {
             let index = critical_section::with(|_| {
-                let old_val = CHANNEL_INDEX.load(Ordering::Relaxed);
-                CHANNEL_INDEX.store(old_val + 1, Ordering::Relaxed);
+                let old_val = state.channel_index.load(Ordering::Relaxed);
+                state.channel_index.store(old_val + 1, Ordering::Relaxed);
                 old_val
             });
             Ok(Channel::new(
@@ -774,7 +798,7 @@ impl<'d, T: Instance> UsbHostAllocator<'d> for Allocator<'d, T> {
     }
 }
 
-impl<'d, T: Instance> UsbHostController<'d> for Driver<'d, T> {
+impl<'d, T: SealedHostInstance> UsbHostController<'d> for Driver<'d, T> {
     type Allocator = Allocator<'d, T>;
 
     fn allocator(&self) -> Self::Allocator {

--- a/embassy-stm32/src/usb/otg.rs
+++ b/embassy-stm32/src/usb/otg.rs
@@ -724,9 +724,13 @@ mod host_impl {
     }
 
     #[allow(private_bounds)]
-    impl<'d, T: SealedHostInstance> embassy_usb_driver::host::UsbHostDriver<'d> for HostDriver<'d, T> {
-        type Pipe<Ty: embassy_usb_driver::host::pipe::Type, D: embassy_usb_driver::host::pipe::Direction> =
-            <OtgHostDriver<'d, MAX_HOST_CH_COUNT> as embassy_usb_driver::host::UsbHostDriver<'d>>::Pipe<Ty, D>;
+    impl<'d, T: SealedHostInstance> embassy_usb_driver::host::UsbHostController<'d> for HostDriver<'d, T> {
+        type Allocator =
+            <OtgHostDriver<'d, MAX_HOST_CH_COUNT> as embassy_usb_driver::host::UsbHostController<'d>>::Allocator;
+
+        fn allocator(&self) -> Self::Allocator {
+            self.inner.allocator()
+        }
 
         async fn wait_for_device_event(&mut self) -> embassy_usb_driver::host::DeviceEvent {
             self.inner.wait_for_device_event().await
@@ -734,15 +738,6 @@ mod host_impl {
 
         async fn bus_reset(&mut self) {
             self.inner.bus_reset().await
-        }
-
-        fn alloc_pipe<Ty: embassy_usb_driver::host::pipe::Type, D: embassy_usb_driver::host::pipe::Direction>(
-            &self,
-            addr: u8,
-            endpoint: &embassy_usb_driver::EndpointInfo,
-            split: Option<embassy_usb_driver::host::SplitInfo>,
-        ) -> Result<Self::Pipe<Ty, D>, embassy_usb_driver::host::HostError> {
-            self.inner.alloc_pipe(addr, endpoint, split)
         }
     }
 }

--- a/embassy-stm32/src/usb/usb_host.rs
+++ b/embassy-stm32/src/usb/usb_host.rs
@@ -696,13 +696,17 @@ impl<'d, I: Instance> Copy for Allocator<'d, I> {}
 
 fn alloc_channel_mem(state: &HostState, len: u16) -> Result<u16, ()> {
     assert!(len as usize % USBRAM_ALIGN == 0);
-    let addr = state.ep_mem_free.load(Ordering::Relaxed);
-    if addr + len > USBRAM_SIZE as _ {
-        error!("Endpoint memory full");
-        return Err(());
-    }
-    state.ep_mem_free.store(addr + len, Ordering::Relaxed);
-    Ok(addr)
+    // Bump-allocate a contiguous range under a critical section so concurrent
+    // allocations from copies of the allocator can't clobber each other.
+    critical_section::with(|_| {
+        let addr = state.ep_mem_free.load(Ordering::Relaxed);
+        if addr + len > USBRAM_SIZE as _ {
+            error!("Endpoint memory full");
+            return Err(());
+        }
+        state.ep_mem_free.store(addr + len, Ordering::Relaxed);
+        Ok(addr)
+    })
 }
 
 impl<'d, I: SealedHostInstance> UsbHostAllocator<'d> for Allocator<'d, I> {

--- a/embassy-stm32/src/usb/usb_host.rs
+++ b/embassy-stm32/src/usb/usb_host.rs
@@ -7,7 +7,9 @@ use core::task::Poll;
 
 use embassy_sync::waitqueue::AtomicWaker;
 use embassy_time::{Duration, Instant, Timer};
-use embassy_usb_driver::host::{DeviceEvent, HostError, PipeError, TimeoutConfig, UsbHostDriver, UsbPipe, pipe};
+use embassy_usb_driver::host::{
+    DeviceEvent, HostError, PipeError, TimeoutConfig, UsbHostAllocator, UsbHostController, UsbPipe, pipe,
+};
 use embassy_usb_driver::{EndpointType, Speed};
 use stm32_metapac::common::{RW, Reg};
 use stm32_metapac::usb::regs::Epr;
@@ -313,18 +315,6 @@ impl<'d, I: Instance> UsbHost<'d, I> {
         let istr = regs.istr().read();
 
         istr.0
-    }
-
-    fn alloc_channel_mem(&self, len: u16) -> Result<u16, ()> {
-        assert!(len as usize % USBRAM_ALIGN == 0);
-        let addr = EP_MEM_FREE.load(Ordering::Relaxed);
-        if addr + len > USBRAM_SIZE as _ {
-            // panic!("Endpoint memory full");
-            error!("Endpoint memory full");
-            return Err(());
-        }
-        EP_MEM_FREE.store(addr + len, Ordering::Relaxed);
-        Ok(addr)
     }
 
     async fn wait_for_device_connect(&self) -> DeviceEvent {
@@ -660,7 +650,36 @@ impl<'d, I: Instance, T: pipe::Type, D: pipe::Direction> Drop for Channel<'d, I,
     }
 }
 
-impl<'d, I: Instance> UsbHostDriver<'d> for UsbHost<'d, I> {
+/// Pipe allocator handle for [`UsbHost`].
+///
+/// Obtained from [`UsbHostController::allocator`]. All state is stored in
+/// module-level `static`s, so this handle is a zero-sized marker and can
+/// be freely copied and held by class drivers independently of the
+/// controller's `&mut` borrow.
+pub struct Allocator<'d, I: Instance> {
+    _phantom: PhantomData<&'d I>,
+}
+
+impl<'d, I: Instance> Clone for Allocator<'d, I> {
+    fn clone(&self) -> Self {
+        *self
+    }
+}
+
+impl<'d, I: Instance> Copy for Allocator<'d, I> {}
+
+fn alloc_channel_mem(len: u16) -> Result<u16, ()> {
+    assert!(len as usize % USBRAM_ALIGN == 0);
+    let addr = EP_MEM_FREE.load(Ordering::Relaxed);
+    if addr + len > USBRAM_SIZE as _ {
+        error!("Endpoint memory full");
+        return Err(());
+    }
+    EP_MEM_FREE.store(addr + len, Ordering::Relaxed);
+    Ok(addr)
+}
+
+impl<'d, I: Instance> UsbHostAllocator<'d> for Allocator<'d, I> {
     type Pipe<T: pipe::Type, D: pipe::Direction> = Channel<'d, I, D, T>;
 
     fn alloc_pipe<T: pipe::Type, D: pipe::Direction>(
@@ -691,7 +710,7 @@ impl<'d, I: Instance> UsbHostDriver<'d> for UsbHost<'d, I> {
 
         let buffer_in = if D::is_in() {
             let (len, len_bits) = calc_receive_len_bits(max_packet_size);
-            let Ok(buffer_addr) = self.alloc_channel_mem(len) else {
+            let Ok(buffer_addr) = alloc_channel_mem(len) else {
                 return Err(HostError::OutOfSlots);
             };
 
@@ -704,7 +723,7 @@ impl<'d, I: Instance> UsbHostDriver<'d> for UsbHost<'d, I> {
 
         let buffer_out = if D::is_out() {
             let len = align_len_up(max_packet_size);
-            let Ok(buffer_addr) = self.alloc_channel_mem(len) else {
+            let Ok(buffer_addr) = alloc_channel_mem(len) else {
                 return Err(HostError::OutOfSlots);
             };
 
@@ -733,6 +752,14 @@ impl<'d, I: Instance> UsbHostDriver<'d> for UsbHost<'d, I> {
         epr_reg.write_value(epr);
 
         Ok(channel)
+    }
+}
+
+impl<'d, I: Instance> UsbHostController<'d> for UsbHost<'d, I> {
+    type Allocator = Allocator<'d, I>;
+
+    fn allocator(&self) -> Self::Allocator {
+        Allocator { _phantom: PhantomData }
     }
 
     async fn bus_reset(&mut self) {

--- a/embassy-stm32/src/usb/usb_host.rs
+++ b/embassy-stm32/src/usb/usb_host.rs
@@ -226,10 +226,41 @@ impl<I: Instance> EndpointBuffer<I> {
     }
 }
 
-/// First bit is used to indicate control pipes
-/// bitfield for keeping track of used channels
-static ALLOCATED_PIPES: AtomicU32 = AtomicU32::new(0);
-static EP_MEM_FREE: AtomicU16 = AtomicU16::new(0);
+/// Per-instance state shared between [`UsbHost`], [`Allocator`] and [`Channel`].
+pub struct HostState {
+    /// Bitmap of allocated channels. Bit 0 is reserved for the control pipe.
+    allocated_pipes: AtomicU32,
+    /// First free address in the endpoint buffer memory, in bytes.
+    ep_mem_free: AtomicU16,
+}
+
+impl HostState {
+    /// Create a new, reset host state.
+    pub const fn new() -> Self {
+        Self {
+            allocated_pipes: AtomicU32::new(0),
+            ep_mem_free: AtomicU16::new(0),
+        }
+    }
+}
+
+/// Sealed extension of [`Instance`] exposing the per-peripheral [`HostState`].
+#[allow(private_bounds)]
+pub trait SealedHostInstance: Instance {
+    #[doc(hidden)]
+    fn host_state() -> &'static HostState;
+}
+
+foreach_interrupt!(
+    ($inst:ident, usb, $block:ident, LP, $irq:ident) => {
+        impl SealedHostInstance for crate::peripherals::$inst {
+            fn host_state() -> &'static HostState {
+                static STATE: HostState = HostState::new();
+                &STATE
+            }
+        }
+    };
+);
 
 /// USB host driver.
 pub struct UsbHost<'d, I: Instance> {
@@ -238,7 +269,7 @@ pub struct UsbHost<'d, I: Instance> {
     // ep_mem_free: u16,
 }
 
-impl<'d, I: Instance> UsbHost<'d, I> {
+impl<'d, I: SealedHostInstance> UsbHost<'d, I> {
     /// Create a new USB driver.
     pub fn new(
         _usb: Peri<'d, USB>,
@@ -274,7 +305,9 @@ impl<'d, I: Instance> UsbHost<'d, I> {
         #[cfg(stm32l1)]
         let _ = (dp, dm); // suppress "unused" warnings.
 
-        EP_MEM_FREE.store(EP_COUNT as u16 * 8, Ordering::Relaxed);
+        I::host_state()
+            .ep_mem_free
+            .store(EP_COUNT as u16 * 8, Ordering::Relaxed);
         Self {
             phantom: PhantomData,
             // ep_mem_free: EP_COUNT as u16 * 8, // for each EP, 4 regs, so 8 bytes
@@ -353,7 +386,7 @@ impl<'d, I: Instance> UsbHost<'d, I> {
 }
 
 /// USB endpoint. Only implements single buffer mode.
-pub struct Channel<'d, I: Instance, D: pipe::Direction, T: pipe::Type> {
+pub struct Channel<'d, I: SealedHostInstance, D: pipe::Direction, T: pipe::Type> {
     _phantom: PhantomData<(&'d mut I, D, T)>,
     /// Register index (there are 8 in total)
     index: usize,
@@ -364,7 +397,7 @@ pub struct Channel<'d, I: Instance, D: pipe::Direction, T: pipe::Type> {
     buf_out: Option<EndpointBuffer<I>>,
 }
 
-impl<'d, I: Instance, D: pipe::Direction, T: pipe::Type> Channel<'d, I, D, T> {
+impl<'d, I: SealedHostInstance, D: pipe::Direction, T: pipe::Type> Channel<'d, I, D, T> {
     fn new(
         index: usize,
         buf_in: Option<EndpointBuffer<I>>,
@@ -550,7 +583,7 @@ impl<'d, I: Instance, D: pipe::Direction, T: pipe::Type> Channel<'d, I, D, T> {
     }
 }
 
-impl<'d, I: Instance, T: pipe::Type, D: pipe::Direction> UsbPipe<T, D> for Channel<'d, I, D, T> {
+impl<'d, I: SealedHostInstance, T: pipe::Type, D: pipe::Direction> UsbPipe<T, D> for Channel<'d, I, D, T> {
     async fn control_in(&mut self, setup: &[u8; 8], buf: &mut [u8]) -> Result<usize, PipeError>
     where
         T: pipe::IsControl,
@@ -639,23 +672,16 @@ impl<'d, I: Instance, T: pipe::Type, D: pipe::Direction> UsbPipe<T, D> for Chann
     }
 }
 
-impl<'d, I: Instance, T: pipe::Type, D: pipe::Direction> Drop for Channel<'d, I, D, T> {
+impl<'d, I: SealedHostInstance, T: pipe::Type, D: pipe::Direction> Drop for Channel<'d, I, D, T> {
     fn drop(&mut self) {
         critical_section::with(|_| {
-            ALLOCATED_PIPES.store(
-                ALLOCATED_PIPES.load(Ordering::Relaxed) & !(1 << self.index),
-                Ordering::Relaxed,
-            );
+            let pipes = &I::host_state().allocated_pipes;
+            pipes.store(pipes.load(Ordering::Relaxed) & !(1 << self.index), Ordering::Relaxed);
         });
     }
 }
 
 /// Pipe allocator handle for [`UsbHost`].
-///
-/// Obtained from [`UsbHostController::allocator`]. All state is stored in
-/// module-level `static`s, so this handle is a zero-sized marker and can
-/// be freely copied and held by class drivers independently of the
-/// controller's `&mut` borrow.
 pub struct Allocator<'d, I: Instance> {
     _phantom: PhantomData<&'d I>,
 }
@@ -668,18 +694,18 @@ impl<'d, I: Instance> Clone for Allocator<'d, I> {
 
 impl<'d, I: Instance> Copy for Allocator<'d, I> {}
 
-fn alloc_channel_mem(len: u16) -> Result<u16, ()> {
+fn alloc_channel_mem(state: &HostState, len: u16) -> Result<u16, ()> {
     assert!(len as usize % USBRAM_ALIGN == 0);
-    let addr = EP_MEM_FREE.load(Ordering::Relaxed);
+    let addr = state.ep_mem_free.load(Ordering::Relaxed);
     if addr + len > USBRAM_SIZE as _ {
         error!("Endpoint memory full");
         return Err(());
     }
-    EP_MEM_FREE.store(addr + len, Ordering::Relaxed);
+    state.ep_mem_free.store(addr + len, Ordering::Relaxed);
     Ok(addr)
 }
 
-impl<'d, I: Instance> UsbHostAllocator<'d> for Allocator<'d, I> {
+impl<'d, I: SealedHostInstance> UsbHostAllocator<'d> for Allocator<'d, I> {
     type Pipe<T: pipe::Type, D: pipe::Direction> = Channel<'d, I, D, T>;
 
     fn alloc_pipe<T: pipe::Type, D: pipe::Direction>(
@@ -688,19 +714,20 @@ impl<'d, I: Instance> UsbHostAllocator<'d> for Allocator<'d, I> {
         endpoint: &embassy_usb_driver::EndpointInfo,
         _split: Option<embassy_usb_driver::host::SplitInfo>,
     ) -> Result<Self::Pipe<T, D>, embassy_usb_driver::host::HostError> {
+        let state = I::host_state();
         let new_index = if T::ep_type() == EndpointType::Control {
             // Only a single control channel is available
             0
         } else {
             critical_section::with(|_| {
-                let pipes = ALLOCATED_PIPES.load(Ordering::Relaxed);
+                let pipes = state.allocated_pipes.load(Ordering::Relaxed);
 
                 // Ignore index 0
                 let new_index = (pipes | 1).trailing_ones();
                 if new_index as usize >= USB_MAX_PIPES {
                     Err(HostError::OutOfPipes)
                 } else {
-                    ALLOCATED_PIPES.store(pipes | 1 << new_index, Ordering::Relaxed);
+                    state.allocated_pipes.store(pipes | 1 << new_index, Ordering::Relaxed);
                     Ok(new_index)
                 }
             })?
@@ -710,7 +737,7 @@ impl<'d, I: Instance> UsbHostAllocator<'d> for Allocator<'d, I> {
 
         let buffer_in = if D::is_in() {
             let (len, len_bits) = calc_receive_len_bits(max_packet_size);
-            let Ok(buffer_addr) = alloc_channel_mem(len) else {
+            let Ok(buffer_addr) = alloc_channel_mem(state, len) else {
                 return Err(HostError::OutOfSlots);
             };
 
@@ -723,7 +750,7 @@ impl<'d, I: Instance> UsbHostAllocator<'d> for Allocator<'d, I> {
 
         let buffer_out = if D::is_out() {
             let len = align_len_up(max_packet_size);
-            let Ok(buffer_addr) = alloc_channel_mem(len) else {
+            let Ok(buffer_addr) = alloc_channel_mem(state, len) else {
                 return Err(HostError::OutOfSlots);
             };
 
@@ -755,7 +782,7 @@ impl<'d, I: Instance> UsbHostAllocator<'d> for Allocator<'d, I> {
     }
 }
 
-impl<'d, I: Instance> UsbHostController<'d> for UsbHost<'d, I> {
+impl<'d, I: SealedHostInstance> UsbHostController<'d> for UsbHost<'d, I> {
     type Allocator = Allocator<'d, I>;
 
     fn allocator(&self) -> Self::Allocator {

--- a/embassy-usb-driver/src/host.rs
+++ b/embassy-usb-driver/src/host.rs
@@ -133,12 +133,51 @@ impl From<PipeError> for HostError {
     }
 }
 
-/// Async USB Host Driver trait.
+/// Pipe allocator trait for USB host drivers.
 ///
-/// To be implemented by the HAL.
-pub trait UsbHostDriver<'d>: Sized {
-    /// Pipe implementation of this UsbHostDriver
+/// Implementations are expected to back allocator state with `'d`-lifetime
+/// storage (typically statics or user-provided `&'d` buffers), not with
+/// fields on the controller struct. This lets [`UsbHostController::allocator`]
+/// hand out lightweight handles that do not re-borrow the controller.
+pub trait UsbHostAllocator<'d>: Sized {
+    /// Pipe implementation produced by this allocator.
     type Pipe<T: pipe::Type, D: pipe::Direction>: UsbPipe<T, D> + 'd;
+
+    /// Allocate a pipe for communication with a device endpoint.
+    ///
+    /// This can be a scarce resource; for one-off requests please scope the
+    /// pipe so that it is dropped after completion.
+    ///
+    /// `split` — when `Some`, every transfer on this pipe is routed as a
+    /// split transaction through the specified hub's TT (USB 2.0 §11.14), or
+    /// as a legacy `PRE` packet on full-speed controllers (USB 1.1 §11.8.6).
+    /// Pass `None` when the device is reached directly (host at the same
+    /// speed as the device, or the device is high-speed).
+    fn alloc_pipe<T: pipe::Type, D: pipe::Direction>(
+        &self,
+        addr: u8,
+        endpoint: &EndpointInfo,
+        split: Option<SplitInfo>,
+    ) -> Result<Self::Pipe<T, D>, HostError>;
+}
+
+/// Main USB host controller trait.
+///
+/// Covers the bus-level operations that must be serialised on a single
+/// controller instance (root-port event waiting, bus reset). Pipe allocation
+/// lives on the companion [`UsbHostAllocator`] trait.
+///
+/// Implemented by the HAL.
+pub trait UsbHostController<'d>: Sized {
+    /// Pipe allocator associated with this controller.
+    type Allocator: UsbHostAllocator<'d>;
+
+    /// Return an allocator handle.
+    ///
+    /// Callers may keep the handle and use it to allocate pipes concurrently
+    /// with [`wait_for_device_event`](Self::wait_for_device_event)
+    /// or [`bus_reset`](Self::bus_reset).
+    fn allocator(&self) -> Self::Allocator;
 
     /// Wait for a root-port attach/detach.
     ///
@@ -153,22 +192,6 @@ pub trait UsbHostDriver<'d>: Sized {
     /// than 0. Used to recover from a misbehaving device or to force
     /// re-enumeration without unplug.
     async fn bus_reset(&mut self);
-
-    /// Allocate pipe for communication with device.
-    ///
-    /// This can be a scarce resource, for one-off requests please scope the pipe so it's dropped after completion.
-    ///
-    /// `split` - when `Some`, every transfer on this pipe is routed as a
-    /// split transaction through the specified hub's TT (USB 2.0 §11.14), or
-    /// as a legacy PRE packet on full-speed controllers (USB 1.1 §11.8.6).
-    /// Pass `None` when the device is reached directly (host at the same
-    /// speed as the device, or the device is high-speed).
-    fn alloc_pipe<T: pipe::Type, D: pipe::Direction>(
-        &self,
-        addr: u8,
-        endpoint: &EndpointInfo,
-        split: Option<SplitInfo>,
-    ) -> Result<Self::Pipe<T, D>, HostError>;
 }
 
 /// Type-level pipe markers for endpoint type and direction.
@@ -321,7 +344,7 @@ impl Default for TimeoutConfig {
 
 /// ## USB Pipes
 /// These contain the required information to send a packet correctly to a device endpoint.
-/// The information is carried with the pipe on creation (see [`UsbHostDriver::alloc_pipe`]).
+/// The information is carried with the pipe on creation (see [`UsbHostAllocator::alloc_pipe`]).
 ///
 /// It is up to the HAL's driver how to implement concurrent requests, some hardware IP may allow for multiple hardware channels
 ///  while others may only have a single channel which needs to be multiplexed in software, while others still use DMA request linked-lists.

--- a/embassy-usb-driver/src/host.rs
+++ b/embassy-usb-driver/src/host.rs
@@ -137,9 +137,8 @@ impl From<PipeError> for HostError {
 ///
 /// Implementations are expected to back allocator state with `'d`-lifetime
 /// storage (typically statics or user-provided `&'d` buffers), not with
-/// fields on the controller struct. This lets [`UsbHostController::allocator`]
-/// hand out lightweight handles that do not re-borrow the controller.
-pub trait UsbHostAllocator<'d>: Sized {
+/// fields on the controller struct.
+pub trait UsbHostAllocator<'d>: Sized + Clone {
     /// Pipe implementation produced by this allocator.
     type Pipe<T: pipe::Type, D: pipe::Direction>: UsbPipe<T, D> + 'd;
 

--- a/embassy-usb-driver/src/lib.rs
+++ b/embassy-usb-driver/src/lib.rs
@@ -136,7 +136,7 @@ pub struct EndpointInfo {
     pub interval_ms: u8,
 }
 
-/// Main USB driver trait.
+/// Main USB device driver trait.
 ///
 /// Implement this to add support for a new hardware platform.
 pub trait Driver<'a> {

--- a/embassy-usb-host/Cargo.toml
+++ b/embassy-usb-host/Cargo.toml
@@ -21,6 +21,7 @@ features = ["defmt"]
 [dependencies]
 embassy-usb = { version = "0.6.0", path = "../embassy-usb" }
 embassy-usb-driver = { version = "0.2.0", path = "../embassy-usb-driver" }
+embassy-sync = { version = "0.8.0", path = "../embassy-sync" }
 embassy-time = { version = "0.5.1", path = "../embassy-time" }
 embedded-io-async = "0.7.0"
 aligned = "0.4"

--- a/embassy-usb-host/src/class/cdc_acm.rs
+++ b/embassy-usb-host/src/class/cdc_acm.rs
@@ -2,7 +2,7 @@
 //!
 //! This driver can communicate with USB CDC ACM devices (virtual serial ports).
 
-use embassy_usb_driver::host::{PipeError, UsbHostDriver, UsbPipe, pipe};
+use embassy_usb_driver::host::{PipeError, UsbHostAllocator, UsbPipe, pipe};
 use embassy_usb_driver::{Direction as UsbDirection, EndpointAddress, EndpointInfo, EndpointType};
 
 use crate::control::SetupPacket;
@@ -170,19 +170,19 @@ pub fn find_cdc_acm(config_desc: &[u8]) -> Option<CdcAcmInfo> {
 /// CDC ACM host driver.
 ///
 /// Provides read/write access to a CDC ACM (virtual serial port) USB device.
-pub struct CdcAcmHost<'d, D: UsbHostDriver<'d>> {
-    ctrl_ch: D::Pipe<pipe::Control, pipe::InOut>,
-    in_ch: D::Pipe<pipe::Bulk, pipe::In>,
-    out_ch: D::Pipe<pipe::Bulk, pipe::Out>,
+pub struct CdcAcmHost<'d, A: UsbHostAllocator<'d>> {
+    ctrl_ch: A::Pipe<pipe::Control, pipe::InOut>,
+    in_ch: A::Pipe<pipe::Bulk, pipe::In>,
+    out_ch: A::Pipe<pipe::Bulk, pipe::Out>,
     comm_interface: u8,
     _phantom: core::marker::PhantomData<&'d ()>,
 }
 
-impl<'d, D: UsbHostDriver<'d>> CdcAcmHost<'d, D> {
+impl<'d, A: UsbHostAllocator<'d>> CdcAcmHost<'d, A> {
     /// Create a new CDC ACM host driver.
     ///
     /// Parses the config descriptor to find CDC ACM endpoints and allocates channels.
-    pub fn new(driver: &D, config_desc: &[u8], enum_info: &EnumerationInfo) -> Result<Self, CdcAcmError> {
+    pub fn new(alloc: A, config_desc: &[u8], enum_info: &EnumerationInfo) -> Result<Self, CdcAcmError> {
         let info = find_cdc_acm(config_desc).ok_or(CdcAcmError::NoInterface)?;
 
         let ctrl_ep_info = EndpointInfo {
@@ -209,13 +209,13 @@ impl<'d, D: UsbHostDriver<'d>> CdcAcmHost<'d, D> {
         let device_address = enum_info.device_address;
         let split = enum_info.split();
 
-        let ctrl_ch = driver
+        let ctrl_ch = alloc
             .alloc_pipe::<pipe::Control, pipe::InOut>(device_address, &ctrl_ep_info, split)
             .map_err(|_| CdcAcmError::NoPipe)?;
-        let in_ch = driver
+        let in_ch = alloc
             .alloc_pipe::<pipe::Bulk, pipe::In>(device_address, &in_ep_info, split)
             .map_err(|_| CdcAcmError::NoPipe)?;
-        let out_ch = driver
+        let out_ch = alloc
             .alloc_pipe::<pipe::Bulk, pipe::Out>(device_address, &out_ep_info, split)
             .map_err(|_| CdcAcmError::NoPipe)?;
 
@@ -258,17 +258,17 @@ impl<'d, D: UsbHostDriver<'d>> CdcAcmHost<'d, D> {
     }
 }
 
-impl<'d, D: UsbHostDriver<'d>> embedded_io_async::ErrorType for CdcAcmHost<'d, D> {
+impl<'d, A: UsbHostAllocator<'d>> embedded_io_async::ErrorType for CdcAcmHost<'d, A> {
     type Error = CdcAcmError;
 }
 
-impl<'d, D: UsbHostDriver<'d>> embedded_io_async::Read for CdcAcmHost<'d, D> {
+impl<'d, A: UsbHostAllocator<'d>> embedded_io_async::Read for CdcAcmHost<'d, A> {
     async fn read(&mut self, buf: &mut [u8]) -> Result<usize, Self::Error> {
         CdcAcmHost::read(self, buf).await
     }
 }
 
-impl<'d, D: UsbHostDriver<'d>> embedded_io_async::Write for CdcAcmHost<'d, D> {
+impl<'d, A: UsbHostAllocator<'d>> embedded_io_async::Write for CdcAcmHost<'d, A> {
     async fn write(&mut self, buf: &[u8]) -> Result<usize, Self::Error> {
         CdcAcmHost::write(self, buf).await
     }

--- a/embassy-usb-host/src/class/cdc_acm.rs
+++ b/embassy-usb-host/src/class/cdc_acm.rs
@@ -182,7 +182,7 @@ impl<'d, A: UsbHostAllocator<'d>> CdcAcmHost<'d, A> {
     /// Create a new CDC ACM host driver.
     ///
     /// Parses the config descriptor to find CDC ACM endpoints and allocates channels.
-    pub fn new(alloc: A, config_desc: &[u8], enum_info: &EnumerationInfo) -> Result<Self, CdcAcmError> {
+    pub fn new(alloc: &A, config_desc: &[u8], enum_info: &EnumerationInfo) -> Result<Self, CdcAcmError> {
         let info = find_cdc_acm(config_desc).ok_or(CdcAcmError::NoInterface)?;
 
         let ctrl_ep_info = EndpointInfo {

--- a/embassy-usb-host/src/class/gip.rs
+++ b/embassy-usb-host/src/class/gip.rs
@@ -36,7 +36,7 @@
 //! use embassy_usb_host::class::gip::{GipHost, XboxOneSGamepad, GipEvent, RumbleCommand};
 //!
 //! let mut gip = GipHost::<_, XboxOneSGamepad>::try_register(
-//!     host.driver(),
+//!     bus,
 //!     &config_buf[..config_len],
 //!     addr,
 //!     dev_desc.vendor_id,
@@ -66,7 +66,7 @@
 //!
 //! [MS-GIPUSB]: https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-gipusb/
 
-use embassy_usb_driver::host::{PipeError, UsbHostDriver, UsbPipe, pipe};
+use embassy_usb_driver::host::{PipeError, UsbHostAllocator, UsbPipe, pipe};
 use embassy_usb_driver::{Direction as UsbDirection, EndpointAddress, EndpointInfo, EndpointType};
 
 use crate::descriptor::ConfigurationDescriptor;
@@ -472,15 +472,15 @@ impl GipDevice for XboxOneSGamepad {
 /// 1. Register with [`GipHost::try_register`] after USB enumeration.
 /// 2. Poll for events with [`GipHost::poll`].
 /// 3. Optionally send rumble with [`GipHost::set_rumble`].
-pub struct GipHost<'d, D: UsbHostDriver<'d>, DEV: GipDevice> {
-    in_ch: D::Pipe<pipe::Interrupt, pipe::In>,
-    out_ch: D::Pipe<pipe::Interrupt, pipe::Out>,
+pub struct GipHost<'d, A: UsbHostAllocator<'d>, DEV: GipDevice> {
+    in_ch: A::Pipe<pipe::Interrupt, pipe::In>,
+    out_ch: A::Pipe<pipe::Interrupt, pipe::Out>,
     seq: u8,
     device: DEV,
     _phantom: core::marker::PhantomData<&'d ()>,
 }
 
-impl<'d, D: UsbHostDriver<'d>, DEV: GipDevice> GipHost<'d, D, DEV> {
+impl<'d, A: UsbHostAllocator<'d>, DEV: GipDevice> GipHost<'d, A, DEV> {
     /// Create and initialize a GIP host driver.
     ///
     /// Performs the full setup sequence:
@@ -499,7 +499,7 @@ impl<'d, D: UsbHostDriver<'d>, DEV: GipDevice> GipHost<'d, D, DEV> {
     /// - [`GipError::NoInterface`] if no GIP interface is found.
     /// - [`GipError::NoPipe`] if pipes cannot be allocated.
     /// - [`GipError::Transfer`] if a handshake transfer fails.
-    pub async fn try_register(driver: &D, config_desc: &[u8], enum_info: &EnumerationInfo) -> Result<Self, GipError> {
+    pub async fn try_register(alloc: A, config_desc: &[u8], enum_info: &EnumerationInfo) -> Result<Self, GipError> {
         let vendor_id = enum_info.device_desc.vendor_id;
         let product_id = enum_info.device_desc.product_id;
         let device = DEV::try_new(vendor_id, product_id).ok_or(GipError::UnsupportedDevice)?;
@@ -523,10 +523,10 @@ impl<'d, D: UsbHostDriver<'d>, DEV: GipDevice> GipHost<'d, D, DEV> {
         let device_address = enum_info.device_address;
         let split = enum_info.split();
 
-        let in_ch = driver
+        let in_ch = alloc
             .alloc_pipe::<pipe::Interrupt, pipe::In>(device_address, &in_ep_info, split)
             .map_err(|_| GipError::NoPipe)?;
-        let out_ch = driver
+        let out_ch = alloc
             .alloc_pipe::<pipe::Interrupt, pipe::Out>(device_address, &out_ep_info, split)
             .map_err(|_| GipError::NoPipe)?;
 

--- a/embassy-usb-host/src/class/gip.rs
+++ b/embassy-usb-host/src/class/gip.rs
@@ -36,7 +36,7 @@
 //! use embassy_usb_host::class::gip::{GipHost, XboxOneSGamepad, GipEvent, RumbleCommand};
 //!
 //! let mut gip = GipHost::<_, XboxOneSGamepad>::try_register(
-//!     bus,
+//!     &bus,
 //!     &config_buf[..config_len],
 //!     addr,
 //!     dev_desc.vendor_id,
@@ -499,7 +499,7 @@ impl<'d, A: UsbHostAllocator<'d>, DEV: GipDevice> GipHost<'d, A, DEV> {
     /// - [`GipError::NoInterface`] if no GIP interface is found.
     /// - [`GipError::NoPipe`] if pipes cannot be allocated.
     /// - [`GipError::Transfer`] if a handshake transfer fails.
-    pub async fn try_register(alloc: A, config_desc: &[u8], enum_info: &EnumerationInfo) -> Result<Self, GipError> {
+    pub async fn try_register(alloc: &A, config_desc: &[u8], enum_info: &EnumerationInfo) -> Result<Self, GipError> {
         let vendor_id = enum_info.device_desc.vendor_id;
         let product_id = enum_info.device_desc.product_id;
         let device = DEV::try_new(vendor_id, product_id).ok_or(GipError::UnsupportedDevice)?;

--- a/embassy-usb-host/src/class/hid.rs
+++ b/embassy-usb-host/src/class/hid.rs
@@ -2,7 +2,7 @@
 //!
 //! This driver can communicate with USB HID devices (keyboards, mice, gamepads, etc.).
 
-use embassy_usb_driver::host::{PipeError, UsbHostDriver, UsbPipe, pipe};
+use embassy_usb_driver::host::{PipeError, UsbHostAllocator, UsbPipe, pipe};
 use embassy_usb_driver::{Direction as UsbDirection, EndpointAddress, EndpointInfo, EndpointType};
 
 pub use super::hid_report::{ReportDescriptor, ReportField};
@@ -229,20 +229,20 @@ impl core::error::Error for HidError {}
 /// HID host driver.
 ///
 /// Provides report reading and optional class request access to a USB HID device.
-pub struct HidHost<'d, D: UsbHostDriver<'d>> {
-    ctrl_ch: D::Pipe<pipe::Control, pipe::InOut>,
-    in_ch: D::Pipe<pipe::Interrupt, pipe::In>,
+pub struct HidHost<'d, A: UsbHostAllocator<'d>> {
+    ctrl_ch: A::Pipe<pipe::Control, pipe::InOut>,
+    in_ch: A::Pipe<pipe::Interrupt, pipe::In>,
     interface: u8,
     report_descriptor_len: u16,
     _phantom: core::marker::PhantomData<&'d ()>,
 }
 
-impl<'d, D: UsbHostDriver<'d>> HidHost<'d, D> {
+impl<'d, A: UsbHostAllocator<'d>> HidHost<'d, A> {
     /// Create a new HID host driver.
     ///
     /// Parses the config descriptor to find the HID interface and its interrupt IN endpoint,
     /// then allocates the necessary channels.
-    pub fn new(driver: &D, config_desc: &[u8], enum_info: &EnumerationInfo) -> Result<Self, HidError> {
+    pub fn new(alloc: A, config_desc: &[u8], enum_info: &EnumerationInfo) -> Result<Self, HidError> {
         let info = find_hid(config_desc).ok_or(HidError::NoInterface)?;
 
         let ctrl_ep_info = EndpointInfo {
@@ -262,10 +262,10 @@ impl<'d, D: UsbHostDriver<'d>> HidHost<'d, D> {
         let device_address = enum_info.device_address;
         let split = enum_info.split();
 
-        let ctrl_ch = driver
+        let ctrl_ch = alloc
             .alloc_pipe::<pipe::Control, pipe::InOut>(device_address, &ctrl_ep_info, split)
             .map_err(|_| HidError::NoPipe)?;
-        let in_ch = driver
+        let in_ch = alloc
             .alloc_pipe::<pipe::Interrupt, pipe::In>(device_address, &in_ep_info, split)
             .map_err(|_| HidError::NoPipe)?;
 

--- a/embassy-usb-host/src/class/hid.rs
+++ b/embassy-usb-host/src/class/hid.rs
@@ -242,7 +242,7 @@ impl<'d, A: UsbHostAllocator<'d>> HidHost<'d, A> {
     ///
     /// Parses the config descriptor to find the HID interface and its interrupt IN endpoint,
     /// then allocates the necessary channels.
-    pub fn new(alloc: A, config_desc: &[u8], enum_info: &EnumerationInfo) -> Result<Self, HidError> {
+    pub fn new(alloc: &A, config_desc: &[u8], enum_info: &EnumerationInfo) -> Result<Self, HidError> {
         let info = find_hid(config_desc).ok_or(HidError::NoInterface)?;
 
         let ctrl_ep_info = EndpointInfo {

--- a/embassy-usb-host/src/class/hub.rs
+++ b/embassy-usb-host/src/class/hub.rs
@@ -7,20 +7,21 @@
 use core::num::NonZeroU8;
 
 use bitflags::bitflags;
+use embassy_sync::blocking_mutex::raw::RawMutex;
 use embassy_time::Timer;
 use embassy_usb::control::Request;
-use embassy_usb_driver::host::{HostError, SplitInfo, SplitSpeed, UsbHostDriver, UsbPipe, pipe};
+use embassy_usb_driver::host::{HostError, SplitInfo, SplitSpeed, UsbHostAllocator, UsbPipe, pipe};
 use embassy_usb_driver::{Direction, EndpointInfo, EndpointType, Speed};
 use zerocopy::{FromBytes, Immutable, KnownLayout};
 
 use crate::control::{ControlPipeExt, ControlType, Recipient, RequestType, SetupPacket};
 use crate::descriptor::{DEFAULT_MAX_DESCRIPTOR_SIZE, InterfaceDescriptor, USBDescriptor};
 use crate::handler::{BusRoute, EnumerationInfo, HandlerEvent, RegisterError};
-use crate::{EnumerationError, UsbHost};
+use crate::{BusHandle, EnumerationError};
 
-pub struct HubHandler<'d, H: UsbHostDriver<'d>, const MAX_PORTS: usize> {
-    interrupt_channel: H::Pipe<pipe::Interrupt, pipe::In>,
-    control_channel: H::Pipe<pipe::Control, pipe::InOut>,
+pub struct HubHandler<'d, A: UsbHostAllocator<'d>, const MAX_PORTS: usize> {
+    interrupt_channel: A::Pipe<pipe::Interrupt, pipe::In>,
+    control_channel: A::Pipe<pipe::Control, pipe::InOut>,
     desc: HubDescriptor,
     device_address: u8,
     device_lut: [Option<NonZeroU8>; MAX_PORTS],
@@ -35,11 +36,11 @@ pub enum HubEvent {
     DeviceRemoved { address: Option<NonZeroU8>, port: u8 },
 }
 
-impl<'d, H: UsbHostDriver<'d>, const MAX_PORTS: usize> HubHandler<'d, H, MAX_PORTS> {
+impl<'d, A: UsbHostAllocator<'d>, const MAX_PORTS: usize> HubHandler<'d, A, MAX_PORTS> {
     /// Attempt to register a hub handler for the given device.
-    pub async fn try_register(bus: &H, enum_info: &EnumerationInfo) -> Result<Self, RegisterError> {
+    pub async fn try_register(alloc: A, enum_info: &EnumerationInfo) -> Result<Self, RegisterError> {
         let ls_over_fs = matches!(enum_info.split(), Some(s) if s.device_speed() == SplitSpeed::Low);
-        let mut control_channel = bus.alloc_pipe::<pipe::Control, pipe::InOut>(
+        let mut control_channel = alloc.alloc_pipe::<pipe::Control, pipe::InOut>(
             enum_info.device_address,
             &EndpointInfo {
                 addr: 0.into(),
@@ -78,7 +79,7 @@ impl<'d, H: UsbHostDriver<'d>, const MAX_PORTS: usize> HubHandler<'d, H, MAX_POR
             .find(|v| v.ep_type() == EndpointType::Interrupt && v.ep_dir() == Direction::In)
             .ok_or(RegisterError::NoSupportedInterface)?;
 
-        let interrupt_channel = bus.alloc_pipe::<pipe::Interrupt, pipe::In>(
+        let interrupt_channel = alloc.alloc_pipe::<pipe::Interrupt, pipe::In>(
             enum_info.device_address,
             &interrupt_ep.into(),
             enum_info.split(),
@@ -214,9 +215,9 @@ impl<'d, H: UsbHostDriver<'d>, const MAX_PORTS: usize> HubHandler<'d, H, MAX_POR
     /// Reset a port and enumerate the device attached to it.
     ///
     /// `port` and `speed` are the 0-based port index and device speed as
-    /// reported by [`HubEvent::DeviceDetected`]. `bus` is the USB host to
-    /// use for enumeration, and it must be the same bus that this hub is
-    /// registered on.
+    /// reported by [`HubEvent::DeviceDetected`]. `bus` is the [`BusHandle`]
+    /// to use for enumeration, and it must be the same bus that this hub
+    /// is registered on.
     ///
     /// Returns the [`EnumerationInfo`] for the device and bytes written
     /// to `config_buffer`.
@@ -235,9 +236,9 @@ impl<'d, H: UsbHostDriver<'d>, const MAX_PORTS: usize> HubHandler<'d, H, MAX_POR
     ///   latter uses the legacy `PRE` prefix on full-speed buses), a new
     ///   [`SplitInfo`] is constructed pointing at this hub.
     /// - Otherwise the child is reached directly at its native speed.
-    pub async fn enumerate_port(
+    pub async fn enumerate_port<M: RawMutex>(
         &mut self,
-        bus: &mut UsbHost<'d, H>,
+        bus: &BusHandle<'d, A, M>,
         config_buffer: &mut [u8],
         port: u8,
         speed: Speed,

--- a/embassy-usb-host/src/class/hub.rs
+++ b/embassy-usb-host/src/class/hub.rs
@@ -7,7 +7,6 @@
 use core::num::NonZeroU8;
 
 use bitflags::bitflags;
-use embassy_sync::blocking_mutex::raw::RawMutex;
 use embassy_time::Timer;
 use embassy_usb::control::Request;
 use embassy_usb_driver::host::{HostError, SplitInfo, SplitSpeed, UsbHostAllocator, UsbPipe, pipe};
@@ -20,13 +19,13 @@ use crate::handler::{BusRoute, EnumerationInfo, HandlerEvent, RegisterError};
 use crate::{BusHandle, EnumerationError};
 
 pub struct HubHandler<'d, A: UsbHostAllocator<'d>, const MAX_PORTS: usize> {
+    bus: BusHandle<'d, A>,
     interrupt_channel: A::Pipe<pipe::Interrupt, pipe::In>,
     control_channel: A::Pipe<pipe::Control, pipe::InOut>,
     desc: HubDescriptor,
     device_address: u8,
     device_lut: [Option<NonZeroU8>; MAX_PORTS],
     route: BusRoute,
-    _phantom: core::marker::PhantomData<&'d ()>,
 }
 
 #[derive(Debug)]
@@ -38,9 +37,9 @@ pub enum HubEvent {
 
 impl<'d, A: UsbHostAllocator<'d>, const MAX_PORTS: usize> HubHandler<'d, A, MAX_PORTS> {
     /// Attempt to register a hub handler for the given device.
-    pub async fn try_register(alloc: A, enum_info: &EnumerationInfo) -> Result<Self, RegisterError> {
+    pub async fn try_register(bus: &BusHandle<'d, A>, enum_info: &EnumerationInfo) -> Result<Self, RegisterError> {
         let ls_over_fs = matches!(enum_info.split(), Some(s) if s.device_speed() == SplitSpeed::Low);
-        let mut control_channel = alloc.alloc_pipe::<pipe::Control, pipe::InOut>(
+        let mut control_channel = bus.alloc_pipe::<pipe::Control, pipe::InOut>(
             enum_info.device_address,
             &EndpointInfo {
                 addr: 0.into(),
@@ -79,7 +78,7 @@ impl<'d, A: UsbHostAllocator<'d>, const MAX_PORTS: usize> HubHandler<'d, A, MAX_
             .find(|v| v.ep_type() == EndpointType::Interrupt && v.ep_dir() == Direction::In)
             .ok_or(RegisterError::NoSupportedInterface)?;
 
-        let interrupt_channel = alloc.alloc_pipe::<pipe::Interrupt, pipe::In>(
+        let interrupt_channel = bus.alloc_pipe::<pipe::Interrupt, pipe::In>(
             enum_info.device_address,
             &interrupt_ep.into(),
             enum_info.split(),
@@ -88,13 +87,13 @@ impl<'d, A: UsbHostAllocator<'d>, const MAX_PORTS: usize> HubHandler<'d, A, MAX_
         let desc = control_channel.request_descriptor::<HubDescriptor, 64>(0, true).await?;
 
         let mut hub = HubHandler {
+            bus: bus.clone(),
             interrupt_channel,
             control_channel,
             desc,
             device_address: enum_info.device_address,
             device_lut: [None; MAX_PORTS],
             route: enum_info.route,
-            _phantom: core::marker::PhantomData,
         };
 
         for port in 0..hub.desc.port_num {
@@ -215,9 +214,8 @@ impl<'d, A: UsbHostAllocator<'d>, const MAX_PORTS: usize> HubHandler<'d, A, MAX_
     /// Reset a port and enumerate the device attached to it.
     ///
     /// `port` and `speed` are the 0-based port index and device speed as
-    /// reported by [`HubEvent::DeviceDetected`]. `bus` is the [`BusHandle`]
-    /// to use for enumeration, and it must be the same bus that this hub
-    /// is registered on.
+    /// reported by [`HubEvent::DeviceDetected`]. Enumeration uses the
+    /// [`BusHandle`] the hub was registered with.
     ///
     /// Returns the [`EnumerationInfo`] for the device and bytes written
     /// to `config_buffer`.
@@ -236,9 +234,8 @@ impl<'d, A: UsbHostAllocator<'d>, const MAX_PORTS: usize> HubHandler<'d, A, MAX_
     ///   latter uses the legacy `PRE` prefix on full-speed buses), a new
     ///   [`SplitInfo`] is constructed pointing at this hub.
     /// - Otherwise the child is reached directly at its native speed.
-    pub async fn enumerate_port<M: RawMutex>(
+    pub async fn enumerate_port(
         &mut self,
-        bus: &BusHandle<'d, A, M>,
         config_buffer: &mut [u8],
         port: u8,
         speed: Speed,
@@ -275,7 +272,7 @@ impl<'d, A: UsbHostAllocator<'d>, const MAX_PORTS: usize> HubHandler<'d, A, MAX_
             }
         };
 
-        let (info, config_len) = bus.enumerate(route, config_buffer).await?;
+        let (info, config_len) = self.bus.enumerate(route, config_buffer).await?;
 
         // Store the device address in the LUT for later retrieval on disconnect.
         self.device_lut[port as usize] = NonZeroU8::new(info.device_address);

--- a/embassy-usb-host/src/class/kbd.rs
+++ b/embassy-usb-host/src/class/kbd.rs
@@ -45,7 +45,7 @@ pub struct KbdHandler<'d, A: UsbHostAllocator<'d>> {
 
 impl<'d, A: UsbHostAllocator<'d>> KbdHandler<'d, A> {
     /// Attempt to register a keyboard handler for the given device.
-    pub async fn try_register(alloc: A, enum_info: &EnumerationInfo) -> Result<Self, RegisterError> {
+    pub async fn try_register(alloc: &A, enum_info: &EnumerationInfo) -> Result<Self, RegisterError> {
         let mut control_channel = alloc.alloc_pipe::<pipe::Control, pipe::InOut>(
             enum_info.device_address,
             &EndpointInfo {

--- a/embassy-usb-host/src/class/kbd.rs
+++ b/embassy-usb-host/src/class/kbd.rs
@@ -4,7 +4,7 @@
 use core::num::NonZeroU8;
 
 use bitflags::bitflags;
-use embassy_usb_driver::host::{HostError, UsbHostDriver, UsbPipe, pipe};
+use embassy_usb_driver::host::{HostError, UsbHostAllocator, UsbPipe, pipe};
 use embassy_usb_driver::{Direction, EndpointInfo, EndpointType};
 
 use crate::control::ControlPipeExt;
@@ -37,16 +37,16 @@ pub enum KbdEvent {
 }
 
 /// Host-side HID boot-keyboard driver.
-pub struct KbdHandler<'d, H: UsbHostDriver<'d>> {
-    interrupt_channel: H::Pipe<pipe::Interrupt, pipe::In>,
-    control_channel: H::Pipe<pipe::Control, pipe::InOut>,
+pub struct KbdHandler<'d, A: UsbHostAllocator<'d>> {
+    interrupt_channel: A::Pipe<pipe::Interrupt, pipe::In>,
+    control_channel: A::Pipe<pipe::Control, pipe::InOut>,
     _phantom: core::marker::PhantomData<&'d ()>,
 }
 
-impl<'d, H: UsbHostDriver<'d>> KbdHandler<'d, H> {
+impl<'d, A: UsbHostAllocator<'d>> KbdHandler<'d, A> {
     /// Attempt to register a keyboard handler for the given device.
-    pub async fn try_register(bus: &H, enum_info: &EnumerationInfo) -> Result<Self, RegisterError> {
-        let mut control_channel = bus.alloc_pipe::<pipe::Control, pipe::InOut>(
+    pub async fn try_register(alloc: A, enum_info: &EnumerationInfo) -> Result<Self, RegisterError> {
+        let mut control_channel = alloc.alloc_pipe::<pipe::Control, pipe::InOut>(
             enum_info.device_address,
             &EndpointInfo {
                 addr: 0.into(),
@@ -87,7 +87,7 @@ impl<'d, H: UsbHostDriver<'d>> KbdHandler<'d, H> {
             .set_configuration(configuration.configuration_value)
             .await?;
 
-        let interrupt_channel = bus.alloc_pipe::<pipe::Interrupt, pipe::In>(
+        let interrupt_channel = alloc.alloc_pipe::<pipe::Interrupt, pipe::In>(
             enum_info.device_address,
             &interrupt_ep.into(),
             enum_info.split(),

--- a/embassy-usb-host/src/class/uac/mod.rs
+++ b/embassy-usb-host/src/class/uac/mod.rs
@@ -41,7 +41,7 @@ use core::task::Poll;
 use aligned::{A4, Aligned};
 use embassy_time::{Duration, Instant, Timer};
 use embassy_usb::control::Request;
-use embassy_usb_driver::host::{HostError, PipeError, UsbHostDriver, UsbPipe, pipe};
+use embassy_usb_driver::host::{HostError, PipeError, UsbHostAllocator, UsbPipe, pipe};
 use embassy_usb_driver::{Direction, EndpointInfo, EndpointType, Speed};
 use heapless::{String, Vec};
 
@@ -59,15 +59,15 @@ const MAX_STRING_LENGTH: usize = 127;
 ///
 /// This struct manages the USB pipes and interface descriptors required to interact with
 /// a UAC device, including control, output, and feedback pipes.
-pub struct UacHandler<'d, H: UsbHostDriver<'d>> {
+pub struct UacHandler<'d, A: UsbHostAllocator<'d>> {
     /// Collection of audio interface descriptors parsed from the device configuration.
     pub interface_collection: descriptors::AudioInterfaceCollection,
     /// Control pipe for sending standard and class-specific requests.
-    pub control_channel: H::Pipe<pipe::Control, pipe::InOut>,
+    pub control_channel: A::Pipe<pipe::Control, pipe::InOut>,
     /// Output pipe for isochronous audio streaming (if available).
-    pub output_channel: Option<H::Pipe<pipe::Isochronous, pipe::Out>>,
+    pub output_channel: Option<A::Pipe<pipe::Isochronous, pipe::Out>>,
     /// Feedback pipe for isochronous feedback endpoint (if available).
-    pub feedback_channel: Option<H::Pipe<pipe::Isochronous, pipe::In>>,
+    pub feedback_channel: Option<A::Pipe<pipe::Isochronous, pipe::In>>,
     input_terminal_id: u8,
     output_interface_idx: usize,
     speed: Speed,
@@ -88,14 +88,14 @@ pub enum RequestError {
     NoSupportedInterface,
 }
 
-impl<'d, H: UsbHostDriver<'d>> UacHandler<'d, H> {
+impl<'d, A: UsbHostAllocator<'d>> UacHandler<'d, A> {
     /// Attempts to register a UAC device and allocate necessary pipes.
     ///
     /// This method parses the device's configuration, finds a suitable streaming interface,
     /// and allocates output and feedback pipes as needed.
     ///
     /// Returns a new [`UacHandler`] on success, or a [`RegisterError`] if registration fails.
-    pub async fn try_register(host: &H, enum_info: EnumerationInfo) -> Result<Self, RegisterError> {
+    pub async fn try_register(alloc: A, enum_info: EnumerationInfo) -> Result<Self, RegisterError> {
         // Steps taken:
         // 1. Find the first streaming interface with an output endpoint
         // 2. Connect it to its terminal to find the sampling frequency
@@ -103,7 +103,7 @@ impl<'d, H: UsbHostDriver<'d>> UacHandler<'d, H> {
         // 4. Select the right alternate setting for the interface with a SET_INTERFACE request
         // 5. Allocate up the output pipe and the corresponding feedback pipe, store on Self
 
-        let mut control_channel = host.alloc_pipe::<pipe::Control, pipe::InOut>(
+        let mut control_channel = alloc.alloc_pipe::<pipe::Control, pipe::InOut>(
             enum_info.device_address,
             &EndpointInfo {
                 addr: 0.into(),
@@ -193,7 +193,7 @@ impl<'d, H: UsbHostDriver<'d>> UacHandler<'d, H> {
         );
 
         if streaming_interface.num_endpoints > 0 {
-            output_channel = Some(host.alloc_pipe::<pipe::Isochronous, pipe::Out>(
+            output_channel = Some(alloc.alloc_pipe::<pipe::Isochronous, pipe::Out>(
                 enum_info.device_address,
                 &output_interface.endpoint_descriptor.unwrap().into(),
                 enum_info.split(),
@@ -201,7 +201,7 @@ impl<'d, H: UsbHostDriver<'d>> UacHandler<'d, H> {
         }
         if streaming_interface.num_endpoints > 1 {
             if let Some(feedback_endpoint) = output_interface.feedback_endpoint_descriptor {
-                feedback_channel = Some(host.alloc_pipe::<pipe::Isochronous, pipe::In>(
+                feedback_channel = Some(alloc.alloc_pipe::<pipe::Isochronous, pipe::In>(
                     enum_info.device_address,
                     &feedback_endpoint.into(),
                     enum_info.split(),
@@ -224,7 +224,7 @@ impl<'d, H: UsbHostDriver<'d>> UacHandler<'d, H> {
     /// Returns a [`UacOut`] object for audio output streaming.
     ///
     /// Returns an error if the output or feedback pipe is not allocated or if the interface is unsupported.
-    pub async fn output(&mut self) -> Result<UacOut<'d, H>, RequestError> {
+    pub async fn output(&mut self) -> Result<UacOut<'d, A>, RequestError> {
         if self.output_channel.is_none() {
             error!("[UAC] Output pipe not allocated");
             return Err(RequestError::DeviceDisconnected);
@@ -271,7 +271,7 @@ impl<'d, H: UsbHostDriver<'d>> UacHandler<'d, H> {
                 _ => 1000.0,
             };
 
-        Ok(UacOut::<'d, H> {
+        Ok(UacOut::<'d, A> {
             output_channel: self.output_channel.take().unwrap(),
             feedback_channel: self.feedback_channel.take(),
             speed: self.speed,
@@ -661,11 +661,11 @@ impl<'d, H: UsbHostDriver<'d>> UacHandler<'d, H> {
 ///
 /// This struct manages the output and feedback pipes for isochronous audio streaming,
 /// as well as timing and format information required for correct streaming.
-pub struct UacOut<'d, H: UsbHostDriver<'d>> {
+pub struct UacOut<'d, A: UsbHostAllocator<'d>> {
     /// Output pipe for isochronous audio streaming.
-    pub output_channel: H::Pipe<pipe::Isochronous, pipe::Out>,
+    pub output_channel: A::Pipe<pipe::Isochronous, pipe::Out>,
     /// Feedback pipe for isochronous feedback endpoint.
-    pub feedback_channel: Option<H::Pipe<pipe::Isochronous, pipe::In>>,
+    pub feedback_channel: Option<A::Pipe<pipe::Isochronous, pipe::In>>,
     speed: Speed,
     samples_per_microframe: f32,
     microframes_per_microsecond: f32,
@@ -684,7 +684,7 @@ enum LockDelay {
     Samples(u16),
 }
 
-impl<'d, H: UsbHostDriver<'d>> UacOut<'d, H> {
+impl<'d, A: UsbHostAllocator<'d>> UacOut<'d, A> {
     /// Starts the output audio stream, invoking the provided callback to fill each packet.
     ///
     /// The callback is called repeatedly with a mutable buffer for each packet to be sent.

--- a/embassy-usb-host/src/class/uac/mod.rs
+++ b/embassy-usb-host/src/class/uac/mod.rs
@@ -18,7 +18,7 @@
 //!
 //! ```rust,ignore
 //! // Register a UAC device
-//! let handler = UacHandler::try_register(host, enum_info).await?;
+//! let handler = UacHandler::try_register(&host, enum_info).await?;
 //!
 //! // Get current sampling frequency
 //! let freq = handler.get_sampling_freq(terminal_id).await?;
@@ -95,7 +95,7 @@ impl<'d, A: UsbHostAllocator<'d>> UacHandler<'d, A> {
     /// and allocates output and feedback pipes as needed.
     ///
     /// Returns a new [`UacHandler`] on success, or a [`RegisterError`] if registration fails.
-    pub async fn try_register(alloc: A, enum_info: EnumerationInfo) -> Result<Self, RegisterError> {
+    pub async fn try_register(alloc: &A, enum_info: EnumerationInfo) -> Result<Self, RegisterError> {
         // Steps taken:
         // 1. Find the first streaming interface with an output endpoint
         // 2. Connect it to its terminal to find the sampling frequency

--- a/embassy-usb-host/src/class/uac/mod.rs
+++ b/embassy-usb-host/src/class/uac/mod.rs
@@ -18,7 +18,7 @@
 //!
 //! ```rust,ignore
 //! // Register a UAC device
-//! let handler = UacHandler::try_register(&host, enum_info).await?;
+//! let handler = UacHandler::try_register(&bus, enum_info).await?;
 //!
 //! // Get current sampling frequency
 //! let freq = handler.get_sampling_freq(terminal_id).await?;

--- a/embassy-usb-host/src/lib.rs
+++ b/embassy-usb-host/src/lib.rs
@@ -11,7 +11,13 @@ pub mod control;
 pub mod descriptor;
 pub mod handler;
 
-use embassy_usb_driver::host::{DeviceEvent, HostError, PipeError, UsbHostDriver, UsbPipe, pipe};
+use core::cell::RefCell;
+use core::marker::PhantomData;
+
+use embassy_sync::blocking_mutex::Mutex as BlockingMutex;
+use embassy_sync::blocking_mutex::raw::RawMutex;
+use embassy_sync::mutex::Mutex as AsyncMutex;
+use embassy_usb_driver::host::{DeviceEvent, HostError, PipeError, UsbHostAllocator, UsbHostController, UsbPipe, pipe};
 pub use embassy_usb_driver::host::{SplitInfo, SplitSpeed};
 use embassy_usb_driver::{Direction as UsbDirection, EndpointAddress, EndpointInfo, EndpointType, Speed};
 
@@ -69,62 +75,103 @@ impl core::fmt::Display for EnumerationError {
 
 impl core::error::Error for EnumerationError {}
 
-/// USB host controller.
+/// Shared bus-wide state used by a [`BusHandle`].
 ///
-/// Manages device connection, enumeration, and class driver binding.
-pub struct UsbHost<'d, D: UsbHostDriver<'d>> {
-    driver: D,
-    /// Bitmask of in-use USB device addresses (1–127).
-    /// Bit `n` of `addr_bitmap[n / 64]` is set when address `n` is assigned.
-    addr_bitmap: [u64; 2],
-    _phantom: core::marker::PhantomData<&'d ()>,
+/// Holds the in-use USB device addresses (1–127) and an async mutex used to
+/// serialise enumerations on a single bus.
+pub struct BusState<M: RawMutex> {
+    addr_bitmap: BlockingMutex<M, RefCell<[u64; 2]>>,
+    enum_lock: AsyncMutex<M, ()>,
 }
 
-impl<'d, D: UsbHostDriver<'d>> UsbHost<'d, D> {
-    /// Create a new USB host from a driver.
-    pub fn new(driver: D) -> Self {
+impl<M: RawMutex> BusState<M> {
+    /// Create new, empty bus state.
+    pub const fn new() -> Self {
         Self {
-            driver,
-            addr_bitmap: [0u64; 2],
-            _phantom: core::marker::PhantomData,
+            addr_bitmap: BlockingMutex::new(RefCell::new([0u64; 2])),
+            enum_lock: AsyncMutex::new(()),
         }
     }
 
-    /// Allocate the next free device address (1–127), marking it as in use.
-    fn alloc_address(&mut self) -> Option<u8> {
-        for addr in 1u8..=127 {
-            let word = (addr / 64) as usize;
-            let bit = addr % 64;
-            if self.addr_bitmap[word] & (1u64 << bit) == 0 {
-                self.addr_bitmap[word] |= 1u64 << bit;
-                return Some(addr);
+    /// Allocate the next free device address (1–127),
+    /// marking it as in use.
+    ///
+    /// Returns `None` when every address in the 1–127 range is already
+    /// taken.
+    fn alloc_address(&self) -> Option<u8> {
+        self.addr_bitmap.lock(|b| {
+            let mut b = b.borrow_mut();
+            for addr in 1u8..=127 {
+                let word = (addr / 64) as usize;
+                let bit = addr % 64;
+                if b[word] & (1u64 << bit) == 0 {
+                    b[word] |= 1u64 << bit;
+                    return Some(addr);
+                }
             }
-        }
-        None
+            None
+        })
     }
 
     /// Release a previously allocated device address.
-    pub fn free_address(&mut self, addr: u8) {
+    ///
+    /// No-op if the address is out of range or was not marked as in use.
+    pub fn free_address(&self, addr: u8) {
         if addr >= 1 && addr <= 127 {
-            let word = (addr / 64) as usize;
-            let bit = addr % 64;
-            self.addr_bitmap[word] &= !(1u64 << bit);
+            self.addr_bitmap.lock(|b| {
+                let mut b = b.borrow_mut();
+                let word = (addr / 64) as usize;
+                let bit = addr % 64;
+                b[word] &= !(1u64 << bit);
+            });
         }
     }
+}
 
-    /// Get a reference to the underlying driver.
-    pub fn driver(&self) -> &D {
+impl<M: RawMutex> Default for BusState<M> {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+/// Bus-level controller for a single root USB controller.
+///
+/// Owns the [`UsbHostController`] implementation and exposes the
+/// bus-wide operations that must be serialised against each other
+/// (root-port event waiting, bus reset).
+///
+/// Pipe allocation and device enumeration live on the companion
+/// [`BusHandle`] returned alongside a `BusController` by the [`bus`]
+/// constructor.
+pub struct BusController<'d, C: UsbHostController<'d>> {
+    driver: C,
+    _phantom: PhantomData<&'d ()>,
+}
+
+impl<'d, C: UsbHostController<'d>> BusController<'d, C> {
+    /// Get a reference to the underlying controller.
+    pub fn controller(&self) -> &C {
         &self.driver
     }
 
-    /// Get a mutable reference to the underlying driver.
-    pub fn driver_mut(&mut self) -> &mut D {
+    /// Get a mutable reference to the underlying controller.
+    pub fn controller_mut(&mut self) -> &mut C {
         &mut self.driver
     }
 
-    /// Wait for a device to connect.
+    /// Wait for a root-port attach/detach.
+    ///
+    /// On attach, the implementation drives a bus reset to completion
+    /// before returning and reports the speed the device settled on.
+    pub async fn wait_for_device_event(&mut self) -> DeviceEvent {
+        self.driver.wait_for_device_event().await
+    }
+
+    /// Wait for a device to connect on the root port.
     ///
     /// Issues a bus reset internally and returns the detected speed.
+    /// Spurious disconnects, overcurrent events, and other non-attach
+    /// events are silently absorbed.
     pub async fn wait_for_connection(&mut self) -> Speed {
         loop {
             match self.driver.wait_for_device_event().await {
@@ -132,18 +179,53 @@ impl<'d, D: UsbHostDriver<'d>> UsbHost<'d, D> {
                     info!("USB device connected, speed: {:?}", speed);
                     return speed;
                 }
-                DeviceEvent::Disconnected => {
-                    // Spurious disconnect before connect; try again.
-                    continue;
-                }
-                _ => {
-                    // Overcurrent, remote-wakeup, or any future variant that
-                    // isn't a fresh connection: keep waiting for a real
-                    // Connected event.
-                    continue;
-                }
+                DeviceEvent::Disconnected => continue,
+                _ => continue,
             }
         }
+    }
+}
+
+/// Shareable handle for pipe allocation and device enumeration.
+///
+/// A `BusHandle` bundles a [`UsbHostAllocator`] produced by a
+/// [`UsbHostController`] with a reference to the bus-wide
+/// [`BusState`].
+///
+/// `BusHandle` itself implements [`UsbHostAllocator`] by forwarding to
+/// its inner allocator, so it can be passed directly to class driver
+/// constructors.
+pub struct BusHandle<'d, A: UsbHostAllocator<'d>, M: RawMutex> {
+    alloc: A,
+    state: &'d BusState<M>,
+    _phantom: core::marker::PhantomData<&'d ()>,
+}
+
+impl<'d, A: UsbHostAllocator<'d> + Copy, M: RawMutex> Clone for BusHandle<'d, A, M> {
+    fn clone(&self) -> Self {
+        *self
+    }
+}
+
+impl<'d, A: UsbHostAllocator<'d> + Copy, M: RawMutex> Copy for BusHandle<'d, A, M> {}
+
+impl<'d, A: UsbHostAllocator<'d>, M: RawMutex> BusHandle<'d, A, M> {
+    /// Borrow the inner pipe allocator.
+    pub fn allocator(&self) -> &A {
+        &self.alloc
+    }
+
+    /// Borrow the shared bus state.
+    pub fn state(&self) -> &'d BusState<M> {
+        self.state
+    }
+
+    /// Release a previously allocated device address.
+    ///
+    /// Equivalent to `self.state().free_address(addr)`. Must be called
+    /// by application code when a device is removed.
+    pub fn free_address(&self, addr: u8) {
+        self.state.free_address(addr);
     }
 
     /// Enumerate a connected device.
@@ -155,23 +237,28 @@ impl<'d, D: UsbHostDriver<'d>> UsbHost<'d, D> {
     /// 4. Get configuration descriptor
     /// 5. SET_CONFIGURATION
     ///
-    /// `route` describes how the device is reached on the bus (directly at
-    /// its native speed, or via split transactions / legacy `PRE` through a
-    /// hub's transaction translator).
+    /// `route` describes how the device is reached on the bus (directly
+    /// at its native speed, or via split transactions / legacy `PRE`
+    /// through a hub's transaction translator).
+    ///
+    /// Enumerations are serialised bus-wide through the
+    /// [`BusState`]'s enumeration mutex.
     ///
     /// # Preconditions
     ///
-    /// The caller must have placed the device into the default (address 0)
-    /// state *before* calling this method. For a root-port device that
-    /// means an upstream bus reset has completed; for a hub-attached
-    /// device, the parent hub's port reset must have completed and
-    /// [`BusRoute::Translated`] must carry the appropriate [`SplitInfo`].
+    /// The caller must have placed the device into the default
+    /// (address 0) state *before* calling this method. For a root-port
+    /// device that means an upstream bus reset has completed; for a
+    /// hub-attached device, the parent hub's port reset must have
+    /// completed and [`BusRoute::Translated`] must carry the
+    /// appropriate [`SplitInfo`].
     ///
-    /// Returns the [`EnumerationInfo`] for the device and bytes written to `config_buf`.
+    /// Returns the [`EnumerationInfo`] for the device and the number of
+    /// bytes written to `config_buf`.
     ///
     /// [`SplitInfo`]: embassy_usb_driver::host::SplitInfo
     pub async fn enumerate(
-        &mut self,
+        &self,
         route: BusRoute,
         config_buf: &mut [u8],
     ) -> Result<(EnumerationInfo, usize), EnumerationError> {
@@ -179,7 +266,11 @@ impl<'d, D: UsbHostDriver<'d>> UsbHost<'d, D> {
 
         use crate::descriptor::DeviceDescriptorPartial;
 
-        let addr = self.alloc_address().ok_or(EnumerationError::NoPipe)?;
+        // Serialise enumerations against other concurrent callers on
+        // the same bus: the default (address 0) state is bus-global.
+        let _enum_guard = self.state.enum_lock.lock().await;
+
+        let addr = self.state.alloc_address().ok_or(EnumerationError::NoPipe)?;
 
         let ep0_info = EndpointInfo {
             addr: EndpointAddress::from_parts(0, UsbDirection::In),
@@ -189,10 +280,10 @@ impl<'d, D: UsbHostDriver<'d>> UsbHost<'d, D> {
         };
 
         let mut ch = self
-            .driver
+            .alloc
             .alloc_pipe::<pipe::Control, pipe::InOut>(0, &ep0_info, route.split())
             .map_err(|_| {
-                self.free_address(addr);
+                self.state.free_address(addr);
                 EnumerationError::NoPipe
             })?;
 
@@ -212,7 +303,7 @@ impl<'d, D: UsbHostDriver<'d>> UsbHost<'d, D> {
                             Timer::after_millis(1).await;
                             continue;
                         } else {
-                            self.free_address(addr);
+                            self.state.free_address(addr);
                             return Err(e.into());
                         }
                     }
@@ -221,7 +312,7 @@ impl<'d, D: UsbHostDriver<'d>> UsbHost<'d, D> {
         };
         // USB 2.0 §9.6.1: legal EP0 max packet sizes are 8, 16, 32, 64.
         if !matches!(max_packet_size0, 8 | 16 | 32 | 64) {
-            self.free_address(addr);
+            self.state.free_address(addr);
             return Err(EnumerationError::InvalidDescriptor);
         }
 
@@ -240,10 +331,10 @@ impl<'d, D: UsbHostDriver<'d>> UsbHost<'d, D> {
         };
 
         let mut ch = self
-            .driver
+            .alloc
             .alloc_pipe::<pipe::Control, pipe::InOut>(addr, &ep0_info, route.split())
             .map_err(|_| {
-                self.free_address(addr);
+                self.state.free_address(addr);
                 EnumerationError::NoPipe
             })?;
 
@@ -275,10 +366,10 @@ impl<'d, D: UsbHostDriver<'d>> UsbHost<'d, D> {
         let n = ch
             .control_in(&setup.to_bytes(), &mut config_buf[..9])
             .await
-            .inspect_err(|_| self.free_address(addr))?;
+            .inspect_err(|_| self.state.free_address(addr))?;
 
         if n < 9 {
-            self.free_address(addr);
+            self.state.free_address(addr);
             return Err(EnumerationError::InvalidDescriptor);
         }
 
@@ -287,7 +378,7 @@ impl<'d, D: UsbHostDriver<'d>> UsbHost<'d, D> {
         let total_len = config_header.total_len as usize;
 
         if total_len > config_buf.len() {
-            self.free_address(addr);
+            self.state.free_address(addr);
             return Err(EnumerationError::ConfigBufferTooSmall(total_len));
         }
 
@@ -297,7 +388,7 @@ impl<'d, D: UsbHostDriver<'d>> UsbHost<'d, D> {
 
         // USB 2.0 §9.4.3: the device must return exactly total_len bytes for a full config descriptor.
         if n != total_len {
-            self.free_address(addr);
+            self.state.free_address(addr);
             return Err(EnumerationError::InvalidDescriptor);
         }
 
@@ -307,7 +398,7 @@ impl<'d, D: UsbHostDriver<'d>> UsbHost<'d, D> {
         let setup = SetupPacket::set_configuration(config_header.configuration_value);
         ch.control_out(&setup.to_bytes(), &[])
             .await
-            .inspect_err(|_| self.free_address(addr))?;
+            .inspect_err(|_| self.state.free_address(addr))?;
 
         info!("Device configured (config={})", config_header.configuration_value);
 
@@ -323,4 +414,42 @@ impl<'d, D: UsbHostDriver<'d>> UsbHost<'d, D> {
             n,
         ))
     }
+}
+
+impl<'d, A: UsbHostAllocator<'d>, M: RawMutex> UsbHostAllocator<'d> for BusHandle<'d, A, M> {
+    type Pipe<T: pipe::Type, D: pipe::Direction> = A::Pipe<T, D>;
+
+    fn alloc_pipe<T: pipe::Type, D: pipe::Direction>(
+        &self,
+        addr: u8,
+        endpoint: &EndpointInfo,
+        split: Option<SplitInfo>,
+    ) -> Result<Self::Pipe<T, D>, HostError> {
+        self.alloc.alloc_pipe::<T, D>(addr, endpoint, split)
+    }
+}
+
+/// Split a [`UsbHostController`] into a bus controller / bus handle pair.
+///
+/// The returned [`BusController`] drives root-port events and bus
+/// resets. The [`BusHandle`] owns pipe allocation and device enumeration
+/// and can be freely shared, handed to class drivers, hub handlers, or
+/// other concurrent tasks while the controller task is blocked inside
+/// [`wait_for_device_event`](BusController::wait_for_device_event).
+pub fn bus<'d, C: UsbHostController<'d>, M: RawMutex>(
+    driver: C,
+    state: &'d BusState<M>,
+) -> (BusController<'d, C>, BusHandle<'d, C::Allocator, M>) {
+    let alloc = driver.allocator();
+    (
+        BusController {
+            driver,
+            _phantom: PhantomData,
+        },
+        BusHandle {
+            alloc,
+            state,
+            _phantom: core::marker::PhantomData,
+        },
+    )
 }

--- a/embassy-usb-host/src/lib.rs
+++ b/embassy-usb-host/src/lib.rs
@@ -15,7 +15,7 @@ use core::cell::RefCell;
 use core::marker::PhantomData;
 
 use embassy_sync::blocking_mutex::Mutex as BlockingMutex;
-use embassy_sync::blocking_mutex::raw::RawMutex;
+use embassy_sync::blocking_mutex::raw::CriticalSectionRawMutex;
 use embassy_sync::mutex::Mutex as AsyncMutex;
 use embassy_usb_driver::host::{DeviceEvent, HostError, PipeError, UsbHostAllocator, UsbHostController, UsbPipe, pipe};
 pub use embassy_usb_driver::host::{SplitInfo, SplitSpeed};
@@ -79,12 +79,12 @@ impl core::error::Error for EnumerationError {}
 ///
 /// Holds the in-use USB device addresses (1–127) and an async mutex used to
 /// serialise enumerations on a single bus.
-pub struct BusState<M: RawMutex> {
-    addr_bitmap: BlockingMutex<M, RefCell<[u64; 2]>>,
-    enum_lock: AsyncMutex<M, ()>,
+pub struct BusState {
+    addr_bitmap: BlockingMutex<CriticalSectionRawMutex, RefCell<[u64; 2]>>,
+    enum_lock: AsyncMutex<CriticalSectionRawMutex, ()>,
 }
 
-impl<M: RawMutex> BusState<M> {
+impl BusState {
     /// Create new, empty bus state.
     pub const fn new() -> Self {
         Self {
@@ -128,7 +128,7 @@ impl<M: RawMutex> BusState<M> {
     }
 }
 
-impl<M: RawMutex> Default for BusState<M> {
+impl Default for BusState {
     fn default() -> Self {
         Self::new()
     }
@@ -195,28 +195,15 @@ impl<'d, C: UsbHostController<'d>> BusController<'d, C> {
 /// `BusHandle` itself implements [`UsbHostAllocator`] by forwarding to
 /// its inner allocator, so it can be passed directly to class driver
 /// constructors.
-pub struct BusHandle<'d, A: UsbHostAllocator<'d>, M: RawMutex> {
+#[derive(Clone)]
+pub struct BusHandle<'d, A: UsbHostAllocator<'d>> {
     alloc: A,
-    state: &'d BusState<M>,
-    _phantom: core::marker::PhantomData<&'d ()>,
+    state: &'d BusState,
 }
 
-impl<'d, A: UsbHostAllocator<'d> + Copy, M: RawMutex> Clone for BusHandle<'d, A, M> {
-    fn clone(&self) -> Self {
-        *self
-    }
-}
-
-impl<'d, A: UsbHostAllocator<'d> + Copy, M: RawMutex> Copy for BusHandle<'d, A, M> {}
-
-impl<'d, A: UsbHostAllocator<'d>, M: RawMutex> BusHandle<'d, A, M> {
-    /// Borrow the inner pipe allocator.
-    pub fn allocator(&self) -> &A {
-        &self.alloc
-    }
-
+impl<'d, A: UsbHostAllocator<'d>> BusHandle<'d, A> {
     /// Borrow the shared bus state.
-    pub fn state(&self) -> &'d BusState<M> {
+    pub fn state(&self) -> &'d BusState {
         self.state
     }
 
@@ -416,7 +403,7 @@ impl<'d, A: UsbHostAllocator<'d>, M: RawMutex> BusHandle<'d, A, M> {
     }
 }
 
-impl<'d, A: UsbHostAllocator<'d>, M: RawMutex> UsbHostAllocator<'d> for BusHandle<'d, A, M> {
+impl<'d, A: UsbHostAllocator<'d>> UsbHostAllocator<'d> for BusHandle<'d, A> {
     type Pipe<T: pipe::Type, D: pipe::Direction> = A::Pipe<T, D>;
 
     fn alloc_pipe<T: pipe::Type, D: pipe::Direction>(
@@ -436,20 +423,16 @@ impl<'d, A: UsbHostAllocator<'d>, M: RawMutex> UsbHostAllocator<'d> for BusHandl
 /// and can be freely shared, handed to class drivers, hub handlers, or
 /// other concurrent tasks while the controller task is blocked inside
 /// [`wait_for_device_event`](BusController::wait_for_device_event).
-pub fn bus<'d, C: UsbHostController<'d>, M: RawMutex>(
+pub fn bus<'d, C: UsbHostController<'d>>(
     driver: C,
-    state: &'d BusState<M>,
-) -> (BusController<'d, C>, BusHandle<'d, C::Allocator, M>) {
+    state: &'d BusState,
+) -> (BusController<'d, C>, BusHandle<'d, C::Allocator>) {
     let alloc = driver.allocator();
     (
         BusController {
             driver,
             _phantom: PhantomData,
         },
-        BusHandle {
-            alloc,
-            state,
-            _phantom: core::marker::PhantomData,
-        },
+        BusHandle { alloc, state },
     )
 }

--- a/embassy-usb-synopsys-otg/src/host.rs
+++ b/embassy-usb-synopsys-otg/src/host.rs
@@ -893,9 +893,8 @@ impl<T: pipe::Type, D: pipe::Direction, const CH_COUNT: usize> Channel<'_, T, D,
             let ch_state = &self.state.channels[self.index];
             ch_state.waker.register(cx.waker());
 
-            let result = ch_state.result.load(Ordering::Acquire);
+            let result = ch_state.result.swap(CH_RESULT_NONE, Ordering::AcqRel);
             if result != CH_RESULT_NONE {
-                ch_state.result.store(CH_RESULT_NONE, Ordering::Release);
                 Poll::Ready(result)
             } else {
                 Poll::Pending

--- a/embassy-usb-synopsys-otg/src/host.rs
+++ b/embassy-usb-synopsys-otg/src/host.rs
@@ -6,7 +6,9 @@ use core::marker::PhantomData;
 use core::task::Poll;
 
 use embassy_sync::waitqueue::AtomicWaker;
-use embassy_usb_driver::host::{DeviceEvent, HostError, PipeError, SplitInfo, UsbHostDriver, UsbPipe, pipe};
+use embassy_usb_driver::host::{
+    DeviceEvent, HostError, PipeError, SplitInfo, UsbHostAllocator, UsbHostController, UsbPipe, pipe,
+};
 use embassy_usb_driver::{EndpointInfo, EndpointType, Speed};
 use portable_atomic::{AtomicBool, AtomicU8, Ordering};
 
@@ -449,8 +451,78 @@ impl<'d, const CH_COUNT: usize> OtgHost<'d, CH_COUNT> {
     }
 }
 
-impl<'d, const CH_COUNT: usize> UsbHostDriver<'d> for OtgHost<'d, CH_COUNT> {
+/// Pipe allocator handle for [`OtgHost`].
+///
+/// Obtained from [`UsbHostController::allocator`]. Holds only `Copy` handles
+/// to the controller's `'d`-borrowed state, so it can be freely copied and
+/// retained by class drivers independently of the controller's `&mut` borrow.
+pub struct OtgHostAllocator<'d, const CH_COUNT: usize> {
+    regs: Otg,
+    state: &'d HostState<CH_COUNT>,
+    channel_count: usize,
+}
+
+impl<'d, const CH_COUNT: usize> Clone for OtgHostAllocator<'d, CH_COUNT> {
+    fn clone(&self) -> Self {
+        *self
+    }
+}
+
+impl<'d, const CH_COUNT: usize> Copy for OtgHostAllocator<'d, CH_COUNT> {}
+
+impl<'d, const CH_COUNT: usize> UsbHostAllocator<'d> for OtgHostAllocator<'d, CH_COUNT> {
     type Pipe<T: pipe::Type, D: pipe::Direction> = Channel<'d, T, D, CH_COUNT>;
+
+    fn alloc_pipe<T: pipe::Type, D: pipe::Direction>(
+        &self,
+        addr: u8,
+        endpoint: &EndpointInfo,
+        _split: Option<SplitInfo>,
+    ) -> Result<Self::Pipe<T, D>, HostError> {
+        let ep_number = endpoint.addr.index() as u8;
+        let max_packet_size = endpoint.max_packet_size;
+
+        // Read device speed from port_speed atomic (stored by ISR)
+        let speed_code = self.state.port_speed.load(Ordering::Acquire);
+        let is_low_speed = speed_code == 1;
+
+        // Find a free channel using atomic CAS
+        for i in 0..self.channel_count.min(CH_COUNT) {
+            if self.state.channels[i]
+                .allocated
+                .compare_exchange(false, true, Ordering::AcqRel, Ordering::Relaxed)
+                .is_ok()
+            {
+                self.state.channels[i].result.store(CH_RESULT_NONE, Ordering::Release);
+
+                return Ok(Channel {
+                    regs: self.regs,
+                    state: self.state,
+                    index: i,
+                    device_address: addr,
+                    ep_number,
+                    max_packet_size,
+                    is_low_speed,
+                    data_toggle: false,
+                    phantom: PhantomData,
+                });
+            }
+        }
+
+        Err(HostError::OutOfPipes)
+    }
+}
+
+impl<'d, const CH_COUNT: usize> UsbHostController<'d> for OtgHost<'d, CH_COUNT> {
+    type Allocator = OtgHostAllocator<'d, CH_COUNT>;
+
+    fn allocator(&self) -> Self::Allocator {
+        OtgHostAllocator {
+            regs: self.instance.regs,
+            state: self.instance.state,
+            channel_count: self.instance.channel_count,
+        }
+    }
 
     async fn wait_for_device_event(&mut self) -> DeviceEvent {
         // Lazily initialize the host hardware on first call.
@@ -626,47 +698,6 @@ impl<'d, const CH_COUNT: usize> UsbHostDriver<'d> for OtgHost<'d, CH_COUNT> {
 
         // Wait for the device to recover after reset de-assertion.
         embassy_time::Timer::after_millis(20).await;
-    }
-
-    fn alloc_pipe<T: pipe::Type, D: pipe::Direction>(
-        &self,
-        addr: u8,
-        endpoint: &EndpointInfo,
-        _split: Option<SplitInfo>,
-    ) -> Result<Self::Pipe<T, D>, HostError> {
-        let ep_number = endpoint.addr.index() as u8;
-        let max_packet_size = endpoint.max_packet_size;
-
-        // Read device speed from port_speed atomic (stored by ISR)
-        let speed_code = self.instance.state.port_speed.load(Ordering::Acquire);
-        let is_low_speed = speed_code == 1;
-
-        // Find a free channel using atomic CAS
-        for i in 0..self.instance.channel_count.min(CH_COUNT) {
-            if self.instance.state.channels[i]
-                .allocated
-                .compare_exchange(false, true, Ordering::AcqRel, Ordering::Relaxed)
-                .is_ok()
-            {
-                self.instance.state.channels[i]
-                    .result
-                    .store(CH_RESULT_NONE, Ordering::Release);
-
-                return Ok(Channel {
-                    regs: self.instance.regs,
-                    state: self.instance.state,
-                    index: i,
-                    device_address: addr,
-                    ep_number,
-                    max_packet_size,
-                    is_low_speed,
-                    data_toggle: false,
-                    phantom: PhantomData,
-                });
-            }
-        }
-
-        Err(HostError::OutOfPipes)
     }
 }
 

--- a/examples/rp/src/bin/usb_host_keyboard.rs
+++ b/examples/rp/src/bin/usb_host_keyboard.rs
@@ -5,8 +5,9 @@ use defmt::*;
 use embassy_executor::Spawner;
 use embassy_rp::bind_interrupts;
 use embassy_rp::peripherals::USB;
+use embassy_sync::blocking_mutex::raw::CriticalSectionRawMutex;
 use embassy_usb_host::class::hid::HidHost;
-use embassy_usb_host::{BusRoute, UsbHost};
+use embassy_usb_host::{BusRoute, BusState};
 use {defmt_rtt as _, panic_probe as _};
 
 bind_interrupts!(struct Irqs {
@@ -18,16 +19,18 @@ async fn main(_spawner: Spawner) {
     let p = embassy_rp::init(Default::default());
 
     let driver = embassy_rp::usb::host::Driver::new(p.USB, Irqs);
-    let mut host = UsbHost::new(driver);
+
+    static BUS_STATE: BusState<CriticalSectionRawMutex> = BusState::new();
+    let (mut bus_ctrl, bus) = embassy_usb_host::bus(driver, &BUS_STATE);
 
     info!("USB host initialized, waiting for device...");
 
     loop {
-        let speed = host.wait_for_connection().await;
+        let speed = bus_ctrl.wait_for_connection().await;
         info!("Device connected at speed {:?}", speed);
 
         let mut config_buf = [0u8; 256];
-        let result = host.enumerate(BusRoute::Direct(speed), &mut config_buf).await;
+        let result = bus.enumerate(BusRoute::Direct(speed), &mut config_buf).await;
 
         let (enum_info, config_len) = match result {
             Ok(r) => r,
@@ -42,7 +45,7 @@ async fn main(_spawner: Spawner) {
             enum_info.device_desc.vendor_id, enum_info.device_desc.product_id, enum_info.device_address
         );
 
-        let mut hid = match HidHost::new(host.driver(), &config_buf[..config_len], &enum_info) {
+        let mut hid = match HidHost::new(bus, &config_buf[..config_len], &enum_info) {
             Ok(h) => h,
             Err(e) => {
                 error!("HID init failed: {:?}", e);

--- a/examples/rp/src/bin/usb_host_keyboard.rs
+++ b/examples/rp/src/bin/usb_host_keyboard.rs
@@ -5,7 +5,6 @@ use defmt::*;
 use embassy_executor::Spawner;
 use embassy_rp::bind_interrupts;
 use embassy_rp::peripherals::USB;
-use embassy_sync::blocking_mutex::raw::CriticalSectionRawMutex;
 use embassy_usb_host::class::hid::HidHost;
 use embassy_usb_host::{BusRoute, BusState};
 use {defmt_rtt as _, panic_probe as _};
@@ -20,7 +19,7 @@ async fn main(_spawner: Spawner) {
 
     let driver = embassy_rp::usb::host::Driver::new(p.USB, Irqs);
 
-    static BUS_STATE: BusState<CriticalSectionRawMutex> = BusState::new();
+    static BUS_STATE: BusState = BusState::new();
     let (mut bus_ctrl, bus) = embassy_usb_host::bus(driver, &BUS_STATE);
 
     info!("USB host initialized, waiting for device...");
@@ -45,7 +44,7 @@ async fn main(_spawner: Spawner) {
             enum_info.device_desc.vendor_id, enum_info.device_desc.product_id, enum_info.device_address
         );
 
-        let mut hid = match HidHost::new(bus, &config_buf[..config_len], &enum_info) {
+        let mut hid = match HidHost::new(&bus, &config_buf[..config_len], &enum_info) {
             Ok(h) => h,
             Err(e) => {
                 error!("HID init failed: {:?}", e);

--- a/examples/stm32f4/src/bin/usb_host_serial.rs
+++ b/examples/stm32f4/src/bin/usb_host_serial.rs
@@ -6,8 +6,9 @@ use embassy_executor::Spawner;
 use embassy_stm32::time::Hertz;
 use embassy_stm32::usb::HostDriver;
 use embassy_stm32::{Config, bind_interrupts, peripherals, usb};
+use embassy_sync::blocking_mutex::raw::CriticalSectionRawMutex;
 use embassy_usb_host::class::cdc_acm::{CdcAcmHost, LineCoding};
-use embassy_usb_host::{BusRoute, UsbHost};
+use embassy_usb_host::{BusRoute, BusState};
 use {defmt_rtt as _, panic_probe as _};
 
 bind_interrupts!(struct Irqs {
@@ -46,17 +47,18 @@ async fn main(_spawner: Spawner) {
     // Create the host driver (FS mode)
     let driver = HostDriver::new_fs_host(p.USB_OTG_FS, Irqs, p.PA12, p.PA11);
 
-    let mut host = UsbHost::new(driver);
+    static BUS_STATE: BusState<CriticalSectionRawMutex> = BusState::new();
+    let (mut bus_ctrl, bus) = embassy_usb_host::bus(driver, &BUS_STATE);
     info!("USB host initialized, waiting for device...");
 
     loop {
         // Wait for a device to connect
-        let speed = host.wait_for_connection().await;
+        let speed = bus_ctrl.wait_for_connection().await;
         info!("Device connected at speed {:?}", speed);
 
         // Enumerate the device
         let mut config_buf = [0u8; 256];
-        let result = host.enumerate(BusRoute::Direct(speed), &mut config_buf).await;
+        let result = bus.enumerate(BusRoute::Direct(speed), &mut config_buf).await;
 
         let (enum_info, config_len) = match result {
             Ok(r) => r,
@@ -72,7 +74,7 @@ async fn main(_spawner: Spawner) {
         );
 
         // Try to create a CDC ACM host driver
-        let mut cdc = match CdcAcmHost::new(host.driver(), &config_buf[..config_len], &enum_info) {
+        let mut cdc = match CdcAcmHost::new(bus, &config_buf[..config_len], &enum_info) {
             Ok(c) => c,
             Err(e) => {
                 error!("CDC ACM init failed: {:?}", e);

--- a/examples/stm32f4/src/bin/usb_host_serial.rs
+++ b/examples/stm32f4/src/bin/usb_host_serial.rs
@@ -6,7 +6,6 @@ use embassy_executor::Spawner;
 use embassy_stm32::time::Hertz;
 use embassy_stm32::usb::HostDriver;
 use embassy_stm32::{Config, bind_interrupts, peripherals, usb};
-use embassy_sync::blocking_mutex::raw::CriticalSectionRawMutex;
 use embassy_usb_host::class::cdc_acm::{CdcAcmHost, LineCoding};
 use embassy_usb_host::{BusRoute, BusState};
 use {defmt_rtt as _, panic_probe as _};
@@ -47,7 +46,7 @@ async fn main(_spawner: Spawner) {
     // Create the host driver (FS mode)
     let driver = HostDriver::new_fs_host(p.USB_OTG_FS, Irqs, p.PA12, p.PA11);
 
-    static BUS_STATE: BusState<CriticalSectionRawMutex> = BusState::new();
+    static BUS_STATE: BusState = BusState::new();
     let (mut bus_ctrl, bus) = embassy_usb_host::bus(driver, &BUS_STATE);
     info!("USB host initialized, waiting for device...");
 
@@ -74,7 +73,7 @@ async fn main(_spawner: Spawner) {
         );
 
         // Try to create a CDC ACM host driver
-        let mut cdc = match CdcAcmHost::new(bus, &config_buf[..config_len], &enum_info) {
+        let mut cdc = match CdcAcmHost::new(&bus, &config_buf[..config_len], &enum_info) {
             Ok(c) => c,
             Err(e) => {
                 error!("CDC ACM init failed: {:?}", e);

--- a/examples/stm32g0/src/bin/usb_host_keyboard.rs
+++ b/examples/stm32g0/src/bin/usb_host_keyboard.rs
@@ -7,9 +7,10 @@ use embassy_stm32::gpio::{AfType, Level, Output, OutputType, Speed};
 use embassy_stm32::i2c::{self, I2c};
 use embassy_stm32::time::mhz;
 use embassy_stm32::{Config, bind_interrupts, dma, pac, peripherals, usb};
+use embassy_sync::blocking_mutex::raw::CriticalSectionRawMutex;
 use embassy_time::Timer;
 use embassy_usb_host::class::hid::HidHost;
-use embassy_usb_host::{BusRoute, UsbHost};
+use embassy_usb_host::{BusRoute, BusState};
 use {defmt_rtt as _, panic_probe as _};
 
 pub use crate::pac::rcc::vals::Mcosel;
@@ -78,15 +79,16 @@ async fn main(_spawner: Spawner) {
     let mut usbhost = usb::UsbHost::new(p.USB, Irqs, p.PA12, p.PA11);
     usbhost.start();
 
-    let mut host = UsbHost::new(usbhost);
+    static BUS_STATE: BusState<CriticalSectionRawMutex> = BusState::new();
+    let (mut bus_ctrl, bus) = embassy_usb_host::bus(usbhost, &BUS_STATE);
     info!("USB host initialized, waiting for device...");
 
     loop {
-        let speed = host.wait_for_connection().await;
+        let speed = bus_ctrl.wait_for_connection().await;
         info!("Device connected at speed {:?}", speed);
 
         let mut config_buf = [0u8; 256];
-        let result = host.enumerate(BusRoute::Direct(speed), &mut config_buf).await;
+        let result = bus.enumerate(BusRoute::Direct(speed), &mut config_buf).await;
 
         let (enum_info, config_len) = match result {
             Ok(r) => r,
@@ -101,7 +103,7 @@ async fn main(_spawner: Spawner) {
             enum_info.device_desc.vendor_id, enum_info.device_desc.product_id, enum_info.device_address
         );
 
-        let mut hid = match HidHost::new(host.driver(), &config_buf[..config_len], &enum_info) {
+        let mut hid = match HidHost::new(bus, &config_buf[..config_len], &enum_info) {
             Ok(h) => h,
             Err(e) => {
                 error!("HID init failed: {:?}", e);

--- a/examples/stm32g0/src/bin/usb_host_keyboard.rs
+++ b/examples/stm32g0/src/bin/usb_host_keyboard.rs
@@ -7,7 +7,6 @@ use embassy_stm32::gpio::{AfType, Level, Output, OutputType, Speed};
 use embassy_stm32::i2c::{self, I2c};
 use embassy_stm32::time::mhz;
 use embassy_stm32::{Config, bind_interrupts, dma, pac, peripherals, usb};
-use embassy_sync::blocking_mutex::raw::CriticalSectionRawMutex;
 use embassy_time::Timer;
 use embassy_usb_host::class::hid::HidHost;
 use embassy_usb_host::{BusRoute, BusState};
@@ -79,7 +78,7 @@ async fn main(_spawner: Spawner) {
     let mut usbhost = usb::UsbHost::new(p.USB, Irqs, p.PA12, p.PA11);
     usbhost.start();
 
-    static BUS_STATE: BusState<CriticalSectionRawMutex> = BusState::new();
+    static BUS_STATE: BusState = BusState::new();
     let (mut bus_ctrl, bus) = embassy_usb_host::bus(usbhost, &BUS_STATE);
     info!("USB host initialized, waiting for device...");
 
@@ -103,7 +102,7 @@ async fn main(_spawner: Spawner) {
             enum_info.device_desc.vendor_id, enum_info.device_desc.product_id, enum_info.device_address
         );
 
-        let mut hid = match HidHost::new(bus, &config_buf[..config_len], &enum_info) {
+        let mut hid = match HidHost::new(&bus, &config_buf[..config_len], &enum_info) {
             Ok(h) => h,
             Err(e) => {
                 error!("HID init failed: {:?}", e);

--- a/examples/stm32wba6/src/bin/usb_host_hid.rs
+++ b/examples/stm32wba6/src/bin/usb_host_hid.rs
@@ -8,8 +8,9 @@ use defmt::*;
 use embassy_executor::Spawner;
 use embassy_stm32::usb::HostDriver;
 use embassy_stm32::{Config, bind_interrupts, peripherals, usb};
+use embassy_sync::blocking_mutex::raw::CriticalSectionRawMutex;
 use embassy_usb_host::class::hid::HidHost;
-use embassy_usb_host::{BusRoute, UsbHost};
+use embassy_usb_host::{BusRoute, BusState};
 use {defmt_rtt as _, panic_probe as _};
 
 bind_interrupts!(struct Irqs {
@@ -49,17 +50,18 @@ async fn main(_spawner: Spawner) {
 
     // Create the host driver (HS mode, internal PHY)
     let driver = HostDriver::new_hs_host(p.USB_OTG_HS, Irqs, p.PD6, p.PD7);
-    let mut host = UsbHost::new(driver);
+    static BUS_STATE: BusState<CriticalSectionRawMutex> = BusState::new();
+    let (mut bus_ctrl, bus) = embassy_usb_host::bus(driver, &BUS_STATE);
     info!("USB host initialized, waiting for device...");
 
     loop {
         // Wait for a device to connect
-        let speed = host.wait_for_connection().await;
+        let speed = bus_ctrl.wait_for_connection().await;
         info!("Device connected at speed {:?}", speed);
 
         // Enumerate the device
         let mut config_buf = [0u8; 256];
-        let result = host.enumerate(BusRoute::Direct(speed), &mut config_buf).await;
+        let result = bus.enumerate(BusRoute::Direct(speed), &mut config_buf).await;
 
         let (enum_info, config_len) = match result {
             Ok(r) => r,
@@ -75,7 +77,7 @@ async fn main(_spawner: Spawner) {
         );
 
         // Try to create a HID host driver
-        let mut hid = match HidHost::new(host.driver(), &config_buf[..config_len], &enum_info) {
+        let mut hid = match HidHost::new(bus, &config_buf[..config_len], &enum_info) {
             Ok(h) => h,
             Err(e) => {
                 error!("HID init failed: {:?}", e);

--- a/examples/stm32wba6/src/bin/usb_host_hid.rs
+++ b/examples/stm32wba6/src/bin/usb_host_hid.rs
@@ -8,7 +8,6 @@ use defmt::*;
 use embassy_executor::Spawner;
 use embassy_stm32::usb::HostDriver;
 use embassy_stm32::{Config, bind_interrupts, peripherals, usb};
-use embassy_sync::blocking_mutex::raw::CriticalSectionRawMutex;
 use embassy_usb_host::class::hid::HidHost;
 use embassy_usb_host::{BusRoute, BusState};
 use {defmt_rtt as _, panic_probe as _};
@@ -50,7 +49,7 @@ async fn main(_spawner: Spawner) {
 
     // Create the host driver (HS mode, internal PHY)
     let driver = HostDriver::new_hs_host(p.USB_OTG_HS, Irqs, p.PD6, p.PD7);
-    static BUS_STATE: BusState<CriticalSectionRawMutex> = BusState::new();
+    static BUS_STATE: BusState = BusState::new();
     let (mut bus_ctrl, bus) = embassy_usb_host::bus(driver, &BUS_STATE);
     info!("USB host initialized, waiting for device...");
 
@@ -77,7 +76,7 @@ async fn main(_spawner: Spawner) {
         );
 
         // Try to create a HID host driver
-        let mut hid = match HidHost::new(bus, &config_buf[..config_len], &enum_info) {
+        let mut hid = match HidHost::new(&bus, &config_buf[..config_len], &enum_info) {
             Ok(h) => h,
             Err(e) => {
                 error!("HID init failed: {:?}", e);

--- a/examples/stm32wba6/src/bin/usb_host_serial.rs
+++ b/examples/stm32wba6/src/bin/usb_host_serial.rs
@@ -8,7 +8,6 @@ use defmt::*;
 use embassy_executor::Spawner;
 use embassy_stm32::usb::HostDriver;
 use embassy_stm32::{Config, bind_interrupts, peripherals, usb};
-use embassy_sync::blocking_mutex::raw::CriticalSectionRawMutex;
 use embassy_usb_host::class::cdc_acm::{CdcAcmHost, LineCoding};
 use embassy_usb_host::{BusRoute, BusState};
 use {defmt_rtt as _, panic_probe as _};
@@ -51,7 +50,7 @@ async fn main(_spawner: Spawner) {
     // Create the host driver (HS mode, internal PHY)
     let driver = HostDriver::new_hs_host(p.USB_OTG_HS, Irqs, p.PD6, p.PD7);
 
-    static BUS_STATE: BusState<CriticalSectionRawMutex> = BusState::new();
+    static BUS_STATE: BusState = BusState::new();
     let (mut bus_ctrl, bus) = embassy_usb_host::bus(driver, &BUS_STATE);
     info!("USB host initialized, waiting for device...");
 
@@ -78,7 +77,7 @@ async fn main(_spawner: Spawner) {
         );
 
         // Try to create a CDC ACM host driver
-        let mut cdc = match CdcAcmHost::new(bus, &config_buf[..config_len], &enum_info) {
+        let mut cdc = match CdcAcmHost::new(&bus, &config_buf[..config_len], &enum_info) {
             Ok(c) => c,
             Err(e) => {
                 error!("CDC ACM init failed: {:?}", e);

--- a/examples/stm32wba6/src/bin/usb_host_serial.rs
+++ b/examples/stm32wba6/src/bin/usb_host_serial.rs
@@ -8,8 +8,9 @@ use defmt::*;
 use embassy_executor::Spawner;
 use embassy_stm32::usb::HostDriver;
 use embassy_stm32::{Config, bind_interrupts, peripherals, usb};
+use embassy_sync::blocking_mutex::raw::CriticalSectionRawMutex;
 use embassy_usb_host::class::cdc_acm::{CdcAcmHost, LineCoding};
-use embassy_usb_host::{BusRoute, UsbHost};
+use embassy_usb_host::{BusRoute, BusState};
 use {defmt_rtt as _, panic_probe as _};
 
 bind_interrupts!(struct Irqs {
@@ -50,17 +51,18 @@ async fn main(_spawner: Spawner) {
     // Create the host driver (HS mode, internal PHY)
     let driver = HostDriver::new_hs_host(p.USB_OTG_HS, Irqs, p.PD6, p.PD7);
 
-    let mut host = UsbHost::new(driver);
+    static BUS_STATE: BusState<CriticalSectionRawMutex> = BusState::new();
+    let (mut bus_ctrl, bus) = embassy_usb_host::bus(driver, &BUS_STATE);
     info!("USB host initialized, waiting for device...");
 
     loop {
         // Wait for a device to connect
-        let speed = host.wait_for_connection().await;
+        let speed = bus_ctrl.wait_for_connection().await;
         info!("Device connected at speed {:?}", speed);
 
         // Enumerate the device
         let mut config_buf = [0u8; 256];
-        let result = host.enumerate(BusRoute::Direct(speed), &mut config_buf).await;
+        let result = bus.enumerate(BusRoute::Direct(speed), &mut config_buf).await;
 
         let (enum_info, config_len) = match result {
             Ok(r) => r,
@@ -76,7 +78,7 @@ async fn main(_spawner: Spawner) {
         );
 
         // Try to create a CDC ACM host driver
-        let mut cdc = match CdcAcmHost::new(host.driver(), &config_buf[..config_len], &enum_info) {
+        let mut cdc = match CdcAcmHost::new(bus, &config_buf[..config_len], &enum_info) {
             Ok(c) => c,
             Err(e) => {
                 error!("CDC ACM init failed: {:?}", e);


### PR DESCRIPTION
This PR separates out resource (pipe, device address) allocation from the original driver trait and UsbHost struct. The root port's event handler is now separate from a shared resource allocator (BusHandle) that can enumerate devices, so it's no longer necessary to stop listening for events in order to enumerate a device. This used to prevent reconfiguring interfaces (UAC, UVC) - now the classes can hold on to BusHandle and allocate pipes as they need.

To allow this split, the host driver now requires a user-allocated, shared BusState object. This object uses CriticalSectionRawMutex internally due to it not being performance critical. The mutex type is not generic because that would be a viral change (at least HubHandler, but potentially other classes would need a mutex generic if they hold on to the BusHandle).

Since the allocator can now be moved more freely, this PR contains some corrections to the drivers, where load-modify-store operations looked like they could cause thread safety issues.

addresses https://github.com/embassy-rs/embassy/issues/5881#issuecomment-4286658815