### PR TITLE
Fix cargo all-features test

### DIFF
--- a/embassy-usb-host/Cargo.toml
+++ b/embassy-usb-host/Cargo.toml
@@ -37,3 +37,9 @@ env_logger = "0.9"
 [features]
 defmt = ["dep:defmt", "embassy-usb-driver/defmt", "heapless/defmt"]
 log = ["dep:log"]
+
+[package.metadata.cargo-all-features]
+skip_feature_sets = [
+    # these features are mutually exclusive
+    ["log", "defmt"],
+]

--- a/embassy-usb-host/src/lib.rs
+++ b/embassy-usb-host/src/lib.rs
@@ -324,3 +324,40 @@ impl<'d, D: UsbHostDriver<'d>> UsbHost<'d, D> {
         ))
     }
 }
+
+#[cfg(all(test, feature = "defmt"))]
+mod tests {
+    //! Provide defmt stuff for tests.
+
+    extern crate std;
+
+    #[unsafe(no_mangle)]
+    fn _defmt_acquire() {}
+
+    #[unsafe(no_mangle)]
+    fn _defmt_flush() {}
+
+    #[unsafe(no_mangle)]
+    fn _defmt_release() {}
+
+    /// Writes bytes as a simple hex line: "xx xx xx xx  xx xx xx xx  xx..."
+    #[unsafe(no_mangle)]
+    fn _defmt_write(bytes: &[u8]) {
+        for (i, b) in bytes.into_iter().enumerate() {
+            if i > 0 {
+                if i.is_multiple_of(4) {
+                    std::print!("  ");
+                } else {
+                    std::print!(" ");
+                }
+            }
+            std::print!("{:02x}", b);
+        }
+        std::println!("");
+    }
+
+    #[unsafe(no_mangle)]
+    fn _defmt_timestamp(_fmt: defmt::Formatter<'_>) {
+        std::println!("{:?}", std::time::Instant::now());
+    }
+}


### PR DESCRIPTION
Fixes #5930.

Only merge this if you want to support testing with the defmt feature enabled.

I did not bother checking other crates, maybe this could be turned into a reusable file that is `include!`ed or something?