### PR TITLE
Add FDCAN missing Transceiver Delay Compensation setup

### DIFF
--- a/embassy-stm32/src/can/fd/config.rs
+++ b/embassy-stm32/src/can/fd/config.rs
@@ -62,10 +62,9 @@ impl Default for NominalBitTiming {
 
 /// Configures the data bit timings for the FdCan Variable Bitrates.
 /// This is not used when frame_transmit is set to anything other than AllowFdCanAndBRS.
+#[non_exhaustive]
 #[derive(Clone, Copy, Debug)]
 pub struct DataBitTiming {
-    /// Tranceiver Delay Compensation
-    pub transceiver_delay_compensation: bool,
     ///  The value by which the oscillator frequency is divided to generate the bit time quanta. The bit
     ///  time is built up from a multiple of this quanta. Valid values for the Baud Rate Prescaler are 1
     ///  to 31.
@@ -76,14 +75,14 @@ pub struct DataBitTiming {
     pub seg2: NonZeroU8,
     /// Must always be smaller than DTSEG2, valid values are 1 to 15.
     pub sync_jump_width: NonZeroU8,
+    /// Transceiver Delay Compensation enabled
+    pub transceiver_delay_compensation: bool,
+    /// Transmitter delay compensation offset, valid values are 0 to 63.
+    pub tdc_offset: u8,
+    /// Transmitter delay compensation filter window length, valid values are 0 to 63.
+    pub tdc_filter_window_length: u8,
 }
 impl DataBitTiming {
-    // #[inline]
-    // fn tdc(&self) -> u8 {
-    //     let tsd = self.transceiver_delay_compensation as u8;
-    //     //TODO: stm32g4 does not export the TDC field
-    //     todo!()
-    // }
     #[inline]
     pub(crate) fn dbrp(&self) -> u8 {
         (u16::from(self.prescaler) & 0x001F) as u8
@@ -100,6 +99,14 @@ impl DataBitTiming {
     pub(crate) fn dsjw(&self) -> u8 {
         u8::from(self.sync_jump_width) & 0x0F
     }
+    #[inline]
+    pub(crate) fn tdco(&self) -> u8 {
+        self.tdc_offset.min(0x3F)
+    }
+    #[inline]
+    pub(crate) fn tdcf(&self) -> u8 {
+        self.tdc_filter_window_length.min(0x3F)
+    }
 }
 
 impl Default for DataBitTiming {
@@ -108,11 +115,13 @@ impl Default for DataBitTiming {
         // Kernel Clock 8MHz, Bit rate: 500kbit/s. Corresponds to a DBTP
         // register value of 0x0000_0A33
         Self {
-            transceiver_delay_compensation: false,
             prescaler: NonZeroU16::new(1).unwrap(),
             seg1: NonZeroU8::new(11).unwrap(),
             seg2: NonZeroU8::new(4).unwrap(),
             sync_jump_width: NonZeroU8::new(4).unwrap(),
+            transceiver_delay_compensation: false,
+            tdc_offset: 0,
+            tdc_filter_window_length: 0,
         }
     }
 }

--- a/embassy-stm32/src/can/fd/peripheral.rs
+++ b/embassy-stm32/src/can/fd/peripheral.rs
@@ -385,7 +385,7 @@ impl Registers {
         });
 
         self.set_data_bit_timing(config.dbtr);
-        self.set_transmitter_delay_compensation(config.dbtr);
+        self.set_transceiver_delay_compensation(config.dbtr);
         self.set_nominal_bit_timing(config.nbtr);
         self.set_automatic_retransmit(config.automatic_retransmit);
         self.set_transmit_pause(config.transmit_pause);
@@ -455,7 +455,7 @@ impl Registers {
     }
 
     #[inline]
-    pub fn set_transmitter_delay_compensation(&self, btr: DataBitTiming) {
+    pub fn set_transceiver_delay_compensation(&self, btr: DataBitTiming) {
         self.regs.tdcr().write(|w| {
             w.set_tdco(btr.tdco());
             w.set_tdcf(btr.tdcf());

--- a/embassy-stm32/src/can/fd/peripheral.rs
+++ b/embassy-stm32/src/can/fd/peripheral.rs
@@ -385,6 +385,7 @@ impl Registers {
         });
 
         self.set_data_bit_timing(config.dbtr);
+        self.set_transmitter_delay_compensation(config.dbtr);
         self.set_nominal_bit_timing(config.nbtr);
         self.set_automatic_retransmit(config.automatic_retransmit);
         self.set_transmit_pause(config.transmit_pause);
@@ -449,6 +450,15 @@ impl Registers {
             w.set_dtseg1(btr.dtseg1() - 1);
             w.set_dtseg2(btr.dtseg2() - 1);
             w.set_dsjw(btr.dsjw() - 1);
+            w.set_tdc(btr.transceiver_delay_compensation);
+        });
+    }
+
+    #[inline]
+    pub fn set_transmitter_delay_compensation(&self, btr: DataBitTiming) {
+        self.regs.tdcr().write(|w| {
+            w.set_tdco(btr.tdco());
+            w.set_tdcf(btr.tdcf());
         });
     }
 

--- a/embassy-stm32/src/can/fdcan.rs
+++ b/embassy-stm32/src/can/fdcan.rs
@@ -246,19 +246,27 @@ impl<'d> CanConfigurator<'d> {
         self.config = self.config.set_nominal_bit_timing(nbtr);
     }
 
-    /// Configures the bit timings for VBR data calculated from supplied bitrate. This also sets confit to allow can FD and VBR
+    /// Configures the bit timings for VBR data calculated from supplied bitrate. This also sets config to allow can FD and VBR
     pub fn set_fd_data_bitrate(&mut self, bitrate: u32, transceiver_delay_compensation: bool) {
         let bit_timing = util::calc_can_timings(self.properties.kernel_input_clock(), bitrate).unwrap();
-        // Note, used existing calcluation for normal(non-VBR) bitrate, appears to work for 250k/1M
-        let nbtr = crate::can::fd::config::DataBitTiming {
-            transceiver_delay_compensation,
+        // Note, used existing calculation for normal(non-VBR) bitrate, appears to work for 250k/1M
+        let tdc_offset = if transceiver_delay_compensation {
+            // sets at the end of tseg1
+            (1 + u8::from(bit_timing.seg1)) * u16::from(bit_timing.prescaler) as u8
+        } else {
+            0
+        };
+        let dbtr = crate::can::fd::config::DataBitTiming {
             sync_jump_width: bit_timing.sync_jump_width,
             prescaler: bit_timing.prescaler,
             seg1: bit_timing.seg1,
             seg2: bit_timing.seg2,
+            transceiver_delay_compensation,
+            tdc_offset,
+            tdc_filter_window_length: 0,
         };
         self.config.frame_transmit = FrameTransmissionConfig::AllowFdCanAndBRS;
-        self.config = self.config.set_data_bit_timing(nbtr);
+        self.config = self.config.set_data_bit_timing(dbtr);
     }
 
     /// Start in mode.


### PR DESCRIPTION
closes #5273.

The fix was tested using STM32C092KCT and STM32G0B1CET.