### PR TITLE
feat: add sync + send for pubsub

### DIFF
--- a/embassy-sync/src/pubsub/mod.rs
+++ b/embassy-sync/src/pubsub/mod.rs
@@ -17,8 +17,10 @@ use crate::waitqueue::MultiWakerRegistration;
 pub mod publisher;
 pub mod subscriber;
 
-pub use publisher::{DynImmediatePublisher, DynPublisher, ImmediatePublisher, Publisher};
-pub use subscriber::{DynSubscriber, Subscriber};
+pub use publisher::{
+    DynImmediatePublisher, DynPublisher, ImmediatePublisher, Publisher, SendDynImmediatePublisher, SendDynPublisher,
+};
+pub use subscriber::{DynSubscriber, SendDynSubscriber, Subscriber};
 
 /// A broadcast channel implementation where multiple publishers can send messages to multiple subscribers
 ///
@@ -518,7 +520,25 @@ pub enum WaitResult<T> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::blocking_mutex::raw::NoopRawMutex;
+    use crate::blocking_mutex::raw::{CriticalSectionRawMutex, NoopRawMutex};
+
+    #[test]
+    fn send_dyn_are_send_sync() {
+        fn assert_send<T: Send>() {}
+        fn assert_sync<T: Sync>() {}
+
+        assert_send::<SendDynSubscriber<'_, u32>>();
+        assert_sync::<SendDynSubscriber<'_, u32>>();
+        assert_send::<SendDynPublisher<'_, u32>>();
+        assert_sync::<SendDynPublisher<'_, u32>>();
+        assert_send::<SendDynImmediatePublisher<'_, u32>>();
+        assert_sync::<SendDynImmediatePublisher<'_, u32>>();
+
+        let channel = PubSubChannel::<CriticalSectionRawMutex, u32, 4, 4, 4>::new();
+        let _sub: SendDynSubscriber<'_, u32> = channel.subscriber().unwrap().into();
+        let _pubb: SendDynPublisher<'_, u32> = channel.publisher().unwrap().into();
+        let _imm: SendDynImmediatePublisher<'_, u32> = channel.immediate_publisher().into();
+    }
 
     #[futures_test::test]
     async fn dyn_pub_sub_works() {

--- a/embassy-sync/src/pubsub/publisher.rs
+++ b/embassy-sync/src/pubsub/publisher.rs
@@ -106,6 +106,39 @@ impl<'a, T: Clone> DerefMut for DynPublisher<'a, T> {
     }
 }
 
+/// A publisher that holds a dynamic reference to the channel.
+/// This version can be sent between threads but can only be created if the underlying mutex is Send + Sync.
+pub struct SendDynPublisher<'a, T: Clone>(pub(super) Pub<'a, dyn PubSubBehavior<T> + 'a, T>);
+
+unsafe impl<'a, T: Clone + Send> Send for SendDynPublisher<'a, T> {}
+unsafe impl<'a, T: Clone + Send> Sync for SendDynPublisher<'a, T> {}
+
+impl<'a, T: Clone> Deref for SendDynPublisher<'a, T> {
+    type Target = Pub<'a, dyn PubSubBehavior<T> + 'a, T>;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+impl<'a, T: Clone> DerefMut for SendDynPublisher<'a, T> {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.0
+    }
+}
+
+impl<'a, M, T, const CAP: usize, const SUBS: usize, const PUBS: usize> From<Publisher<'a, M, T, CAP, SUBS, PUBS>>
+    for SendDynPublisher<'a, T>
+where
+    M: RawMutex + Send + Sync,
+    T: Clone,
+{
+    fn from(p: Publisher<'a, M, T, CAP, SUBS, PUBS>) -> Self {
+        let p = core::mem::ManuallyDrop::new(p);
+        Self(Pub::new(p.0.channel))
+    }
+}
+
 /// A publisher that holds a generic reference to the channel
 #[derive(Debug)]
 pub struct Publisher<'a, M: RawMutex, T: Clone, const CAP: usize, const SUBS: usize, const PUBS: usize>(
@@ -204,6 +237,38 @@ impl<'a, T: Clone> Deref for DynImmediatePublisher<'a, T> {
 impl<'a, T: Clone> DerefMut for DynImmediatePublisher<'a, T> {
     fn deref_mut(&mut self) -> &mut Self::Target {
         &mut self.0
+    }
+}
+
+/// An immediate publisher that holds a dynamic reference to the channel.
+/// This version can be sent between threads but can only be created if the underlying mutex is Send + Sync.
+pub struct SendDynImmediatePublisher<'a, T: Clone>(pub(super) ImmediatePub<'a, dyn PubSubBehavior<T> + 'a, T>);
+
+unsafe impl<'a, T: Clone + Send> Send for SendDynImmediatePublisher<'a, T> {}
+unsafe impl<'a, T: Clone + Send> Sync for SendDynImmediatePublisher<'a, T> {}
+
+impl<'a, T: Clone> Deref for SendDynImmediatePublisher<'a, T> {
+    type Target = ImmediatePub<'a, dyn PubSubBehavior<T> + 'a, T>;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+impl<'a, T: Clone> DerefMut for SendDynImmediatePublisher<'a, T> {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.0
+    }
+}
+
+impl<'a, M, T, const CAP: usize, const SUBS: usize, const PUBS: usize>
+    From<ImmediatePublisher<'a, M, T, CAP, SUBS, PUBS>> for SendDynImmediatePublisher<'a, T>
+where
+    M: RawMutex + Send + Sync,
+    T: Clone,
+{
+    fn from(p: ImmediatePublisher<'a, M, T, CAP, SUBS, PUBS>) -> Self {
+        Self(ImmediatePub::new(p.0.channel))
     }
 }
 

--- a/embassy-sync/src/pubsub/subscriber.rs
+++ b/embassy-sync/src/pubsub/subscriber.rs
@@ -151,6 +151,39 @@ impl<'a, T: Clone> DerefMut for DynSubscriber<'a, T> {
     }
 }
 
+/// A subscriber that holds a dynamic reference to the channel.
+/// This version can be sent between threads but can only be created if the underlying mutex is Send + Sync.
+pub struct SendDynSubscriber<'a, T: Clone>(pub(super) Sub<'a, dyn PubSubBehavior<T> + 'a, T>);
+
+unsafe impl<'a, T: Clone + Send> Send for SendDynSubscriber<'a, T> {}
+unsafe impl<'a, T: Clone + Send> Sync for SendDynSubscriber<'a, T> {}
+
+impl<'a, T: Clone> Deref for SendDynSubscriber<'a, T> {
+    type Target = Sub<'a, dyn PubSubBehavior<T> + 'a, T>;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+impl<'a, T: Clone> DerefMut for SendDynSubscriber<'a, T> {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.0
+    }
+}
+
+impl<'a, M, T, const CAP: usize, const SUBS: usize, const PUBS: usize> From<Subscriber<'a, M, T, CAP, SUBS, PUBS>>
+    for SendDynSubscriber<'a, T>
+where
+    M: RawMutex + Send + Sync,
+    T: Clone,
+{
+    fn from(s: Subscriber<'a, M, T, CAP, SUBS, PUBS>) -> Self {
+        let s = core::mem::ManuallyDrop::new(s);
+        Self(Sub::new(s.0.next_message_id, s.0.channel))
+    }
+}
+
 /// A subscriber that holds a generic reference to the channel
 #[derive(Debug)]
 pub struct Subscriber<'a, M: RawMutex, T: Clone, const CAP: usize, const SUBS: usize, const PUBS: usize>(

--- a/embassy-sync/tests/ui.rs
+++ b/embassy-sync/tests/ui.rs
@@ -10,4 +10,10 @@ fn ui() {
     t.compile_fail("tests/ui/sync_impl/lazy_lock_function.rs");
     t.compile_fail("tests/ui/sync_impl/lazy_lock_type.rs");
     t.compile_fail("tests/ui/sync_impl/once_lock.rs");
+
+    // NoopRawMutex is not Sync, so the `From` impls that produce the `SendDyn*`
+    // wrappers must not be available for channels built on it.
+    t.compile_fail("tests/ui/pubsub_send/subscriber_noop_mutex.rs");
+    t.compile_fail("tests/ui/pubsub_send/publisher_noop_mutex.rs");
+    t.compile_fail("tests/ui/pubsub_send/immediate_publisher_noop_mutex.rs");
 }

--- a/embassy-sync/tests/ui/pubsub_send/immediate_publisher_noop_mutex.rs
+++ b/embassy-sync/tests/ui/pubsub_send/immediate_publisher_noop_mutex.rs
@@ -1,0 +1,9 @@
+use embassy_sync::blocking_mutex::raw::NoopRawMutex;
+use embassy_sync::pubsub::{PubSubChannel, SendDynImmediatePublisher};
+
+// NoopRawMutex is not Sync, so converting an ImmediatePublisher backed by it
+// into a SendDynImmediatePublisher must fail to compile.
+fn main() {
+    let channel = PubSubChannel::<NoopRawMutex, u32, 4, 4, 4>::new();
+    let _imm: SendDynImmediatePublisher<'_, u32> = channel.immediate_publisher().into();
+}

--- a/embassy-sync/tests/ui/pubsub_send/immediate_publisher_noop_mutex.stderr
+++ b/embassy-sync/tests/ui/pubsub_send/immediate_publisher_noop_mutex.stderr
@@ -1,0 +1,19 @@
+error[E0277]: `*mut ()` cannot be shared between threads safely
+ --> tests/ui/pubsub_send/immediate_publisher_noop_mutex.rs:8:82
+  |
+8 |     let _imm: SendDynImmediatePublisher<'_, u32> = channel.immediate_publisher().into();
+  |                                                                                  ^^^^ `*mut ()` cannot be shared between threads safely
+  |
+  = help: within `NoopRawMutex`, the trait `Sync` is not implemented for `*mut ()`
+note: required because it appears within the type `PhantomData<*mut ()>`
+ --> $RUST/core/src/marker.rs
+  |
+  | pub struct PhantomData<T: PointeeSized>;
+  |            ^^^^^^^^^^^
+note: required because it appears within the type `NoopRawMutex`
+ --> src/blocking_mutex/raw.rs
+  |
+  | pub struct NoopRawMutex {
+  |            ^^^^^^^^^^^^
+  = note: required for `SendDynImmediatePublisher<'_, u32>` to implement `From<ImmediatePublisher<'_, NoopRawMutex, u32, 4, 4, 4>>`
+  = note: required for `ImmediatePublisher<'_, NoopRawMutex, u32, 4, 4, 4>` to implement `Into<SendDynImmediatePublisher<'_, u32>>`

--- a/embassy-sync/tests/ui/pubsub_send/publisher_noop_mutex.rs
+++ b/embassy-sync/tests/ui/pubsub_send/publisher_noop_mutex.rs
@@ -1,0 +1,9 @@
+use embassy_sync::blocking_mutex::raw::NoopRawMutex;
+use embassy_sync::pubsub::{PubSubChannel, SendDynPublisher};
+
+// NoopRawMutex is not Sync, so converting a Publisher backed by it into a
+// SendDynPublisher must fail to compile.
+fn main() {
+    let channel = PubSubChannel::<NoopRawMutex, u32, 4, 4, 4>::new();
+    let _pubb: SendDynPublisher<'_, u32> = channel.publisher().unwrap().into();
+}

--- a/embassy-sync/tests/ui/pubsub_send/publisher_noop_mutex.stderr
+++ b/embassy-sync/tests/ui/pubsub_send/publisher_noop_mutex.stderr
@@ -1,0 +1,19 @@
+error[E0277]: `*mut ()` cannot be shared between threads safely
+ --> tests/ui/pubsub_send/publisher_noop_mutex.rs:8:73
+  |
+8 |     let _pubb: SendDynPublisher<'_, u32> = channel.publisher().unwrap().into();
+  |                                                                         ^^^^ `*mut ()` cannot be shared between threads safely
+  |
+  = help: within `NoopRawMutex`, the trait `Sync` is not implemented for `*mut ()`
+note: required because it appears within the type `PhantomData<*mut ()>`
+ --> $RUST/core/src/marker.rs
+  |
+  | pub struct PhantomData<T: PointeeSized>;
+  |            ^^^^^^^^^^^
+note: required because it appears within the type `NoopRawMutex`
+ --> src/blocking_mutex/raw.rs
+  |
+  | pub struct NoopRawMutex {
+  |            ^^^^^^^^^^^^
+  = note: required for `SendDynPublisher<'_, u32>` to implement `From<Publisher<'_, NoopRawMutex, u32, 4, 4, 4>>`
+  = note: required for `Publisher<'_, NoopRawMutex, u32, 4, 4, 4>` to implement `Into<SendDynPublisher<'_, u32>>`

--- a/embassy-sync/tests/ui/pubsub_send/subscriber_noop_mutex.rs
+++ b/embassy-sync/tests/ui/pubsub_send/subscriber_noop_mutex.rs
@@ -1,0 +1,9 @@
+use embassy_sync::blocking_mutex::raw::NoopRawMutex;
+use embassy_sync::pubsub::{PubSubChannel, SendDynSubscriber};
+
+// NoopRawMutex is not Sync, so converting a Subscriber backed by it into a
+// SendDynSubscriber must fail to compile.
+fn main() {
+    let channel = PubSubChannel::<NoopRawMutex, u32, 4, 4, 4>::new();
+    let _sub: SendDynSubscriber<'_, u32> = channel.subscriber().unwrap().into();
+}

--- a/embassy-sync/tests/ui/pubsub_send/subscriber_noop_mutex.stderr
+++ b/embassy-sync/tests/ui/pubsub_send/subscriber_noop_mutex.stderr
@@ -1,0 +1,19 @@
+error[E0277]: `*mut ()` cannot be shared between threads safely
+ --> tests/ui/pubsub_send/subscriber_noop_mutex.rs:8:74
+  |
+8 |     let _sub: SendDynSubscriber<'_, u32> = channel.subscriber().unwrap().into();
+  |                                                                          ^^^^ `*mut ()` cannot be shared between threads safely
+  |
+  = help: within `NoopRawMutex`, the trait `Sync` is not implemented for `*mut ()`
+note: required because it appears within the type `PhantomData<*mut ()>`
+ --> $RUST/core/src/marker.rs
+  |
+  | pub struct PhantomData<T: PointeeSized>;
+  |            ^^^^^^^^^^^
+note: required because it appears within the type `NoopRawMutex`
+ --> src/blocking_mutex/raw.rs
+  |
+  | pub struct NoopRawMutex {
+  |            ^^^^^^^^^^^^
+  = note: required for `SendDynSubscriber<'_, u32>` to implement `From<Subscriber<'_, NoopRawMutex, u32, 4, 4, 4>>`
+  = note: required for `Subscriber<'_, NoopRawMutex, u32, 4, 4, 4>` to implement `Into<SendDynSubscriber<'_, u32>>`


### PR DESCRIPTION
Adds SendDynPublisher, SendDynImmediatePublisher and SendDynSubscriber that implement Send + Sync, and can only be created if the underlying mutex is also Send + Sync.

Note: Made with assistance of Claude Code. This is the same approach taken in the existing SendDynamicSender for the Channel type.