### PR TITLE
embassy-rp: Fix presence detection in PioOneWire::reset()

### DIFF
--- a/embassy-rp/src/pio_programs/onewire.rs
+++ b/embassy-rp/src/pio_programs/onewire.rs
@@ -151,14 +151,18 @@ impl<'d, PIO: Instance, const SM: usize> PioOneWire<'d, PIO, SM> {
         }
 
         let rx = self.sm.rx();
-        let mut found = false;
-        for _ in 0..4 {
-            if rx.wait_pull().await != 0 {
-                found = true;
-            }
+        let mut bytes = [0_u8; 4];
+        for byte in &mut bytes {
+            let word = rx.wait_pull().await;
+            // Save only the 8 bits the pio actually sent
+            *byte = (word >> 24) as u8;
         }
 
-        found
+        let samples = u32::from_be_bytes(bytes);
+
+        // If `samples == 0xFFFFFFFF` then nobody responded
+        // If `samples == 0x00000000` then your pullup is broken
+        samples != 0xFFFFFFFF && samples != 0x00000000
     }
 
     /// Write bytes to the onewire bus


### PR DESCRIPTION
Fixes #5939.

The previous implementation of `PioOneWire::reset()` flagged a device as "found" if any of the sampled bits were non-zero. Since an idle 1-Wire bus is pulled high, sampling an empty bus resulted in all ones, incorrectly returning true.

Now it receives all 32 samples from the pio, then checks that `samples != 0xFFFFFFFF && samples != 0x00000000`. This means:  

* **No device connected (`0xFFFFFFFF`):** Returns false (correct).

* **Device pulls line low (e.g: `0xFF000FFF`):** Returns true (correct).

* **Bus shorted to GND (`0x00000000`):** Returns false (correct).