### PR TITLE
Feat/dtm ble

### DIFF
--- a/embassy-stm32-wpan/src/wba/ble.rs
+++ b/embassy-stm32-wpan/src/wba/ble.rs
@@ -15,6 +15,7 @@ use embassy_sync::blocking_mutex::Mutex;
 use embassy_sync::blocking_mutex::raw::CriticalSectionRawMutex;
 
 use crate::linklayer_plat::{HARDWARE_AES, HARDWARE_PKA, HARDWARE_RNG};
+use crate::runner::register_ble_tasks;
 use crate::wba::error::BleError;
 use crate::wba::gap::Advertiser;
 use crate::wba::gap::connection::{
@@ -276,6 +277,47 @@ impl Ble {
     /// Check if the BLE stack is initialized
     pub fn is_initialized(&self) -> bool {
         self.initialized.load(Ordering::Acquire)
+    }
+
+    /// Initialize the BLE stack for Direct Test Mode (DTM) only.
+    ///
+    /// Performs the minimum initialization required before issuing DTM commands
+    /// (HCI_LE_Transmitter_Test, HCI_LE_Receiver_Test, HCI_LE_Test_End).
+    /// Does not initialize GATT or GAP — those layers are not used in DTM.
+    ///
+    /// Must be used with `Ble::new_dtm()`.
+    pub fn dtm_init(&mut self) -> Result<(), BleError> {
+        if self.is_initialized() {
+            return Ok(());
+        }
+
+        init_ble_stack().map_err(|_| BleError::InitializationFailed)?;
+        register_ble_tasks();
+
+        self.cmd_sender.reset()?;
+
+        let version = self.cmd_sender.read_local_version()?;
+        #[cfg(feature = "defmt")]
+        defmt::info!(
+            "BLE Controller: HCI Version {}.{}, Manufacturer: 0x{:04X}",
+            version.hci_version >> 4,
+            version.hci_version & 0x0F,
+            version.manufacturer_name
+        );
+
+        if let Err(e) = self.cmd_sender.set_event_mask(0xFFFF_FFFF_FFFF_FFFF) {
+            #[cfg(feature = "defmt")]
+            defmt::warn!("set_event_mask failed: {:?}", e);
+        }
+        if let Err(e) = self.cmd_sender.le_set_event_mask(0xFFFF_FFFF_FFFF_FFFF) {
+            #[cfg(feature = "defmt")]
+            defmt::warn!("le_set_event_mask failed: {:?}", e);
+        }
+
+        self.initialized.store(true, Ordering::Release);
+        #[cfg(feature = "defmt")]
+        defmt::info!("BLE stack initialized for DTM");
+        Ok(())
     }
 
     /// Set a random address for the device

--- a/embassy-stm32-wpan/src/wba/hci/command.rs
+++ b/embassy-stm32-wpan/src/wba/hci/command.rs
@@ -123,6 +123,25 @@ unsafe extern "C" {
 
     #[link_name = "HCI_LE_SET_DATA_LENGTH"]
     fn hci_le_set_data_length(connection_handle: u16, tx_octets: u16, tx_time: u16) -> tBleStatus;
+
+    // DTM — Direct Test Mode commands
+    #[link_name = "HCI_LE_RECEIVER_TEST"]
+    fn hci_le_receiver_test(rx_channel: u8) -> tBleStatus;
+
+    #[link_name = "HCI_LE_RECEIVER_TEST_V2"]
+    fn hci_le_receiver_test_v2(rx_channel: u8, phy: u8, modulation_index: u8) -> tBleStatus;
+
+    #[link_name = "HCI_LE_TRANSMITTER_TEST"]
+    fn hci_le_transmitter_test(tx_channel: u8, test_data_length: u8, packet_payload: u8) -> tBleStatus;
+
+    #[link_name = "HCI_LE_TRANSMITTER_TEST_V2"]
+    fn hci_le_transmitter_test_v2(tx_channel: u8, test_data_length: u8, packet_payload: u8, phy: u8) -> tBleStatus;
+
+    #[link_name = "HCI_LE_TEST_END"]
+    fn hci_le_test_end(num_packets: *mut u16) -> tBleStatus;
+
+    #[link_name = "ACI_HAL_LE_TX_TEST_PACKET_NUMBER"]
+    fn aci_hal_le_tx_test_packet_number(num_packets: *mut u32) -> tBleStatus;
 }
 
 /// BLE Success status code
@@ -556,5 +575,90 @@ impl CommandSender {
 impl Default for CommandSender {
     fn default() -> Self {
         Self::new()
+    }
+}
+
+/// Start a DTM receiver test on the given channel (v1, 1M PHY).
+///
+/// `rx_channel`: 0–39. Frequency = 2402 + (2 × N) MHz.
+/// Call `le_test_end()` to stop and read the received packet count.
+pub fn le_receiver_test(rx_channel: u8) -> Result<(), BleError> {
+    let status = unsafe { hci_le_receiver_test(rx_channel) };
+    if status == BLE_STATUS_SUCCESS {
+        Ok(())
+    } else {
+        Err(BleError::CommandFailed(super::types::Status::from_u8(status)))
+    }
+}
+
+/// Start a DTM receiver test with PHY selection (v2).
+///
+/// `modulation_index`: 0x00 = standard, 0x01 = stable.
+pub fn le_receiver_test_v2(rx_channel: u8, phy: super::types::DtmRxPhy, modulation_index: u8) -> Result<(), BleError> {
+    let status = unsafe { hci_le_receiver_test_v2(rx_channel, phy as u8, modulation_index) };
+    if status == BLE_STATUS_SUCCESS {
+        Ok(())
+    } else {
+        Err(BleError::CommandFailed(super::types::Status::from_u8(status)))
+    }
+}
+
+/// Start a DTM transmitter test (v1, 1M PHY).
+///
+/// `tx_channel`: 0–39. Frequency = 2402 + (2 × N) MHz.
+/// `test_data_length`: payload bytes per packet, 0–255.
+pub fn le_transmitter_test(
+    tx_channel: u8,
+    test_data_length: u8,
+    packet_payload: super::types::DtmPacketPayload,
+) -> Result<(), BleError> {
+    let status = unsafe { hci_le_transmitter_test(tx_channel, test_data_length, packet_payload as u8) };
+    if status == BLE_STATUS_SUCCESS {
+        Ok(())
+    } else {
+        Err(BleError::CommandFailed(super::types::Status::from_u8(status)))
+    }
+}
+
+/// Start a DTM transmitter test with PHY selection (v2).
+pub fn le_transmitter_test_v2(
+    tx_channel: u8,
+    test_data_length: u8,
+    packet_payload: super::types::DtmPacketPayload,
+    phy: super::types::DtmTxPhy,
+) -> Result<(), BleError> {
+    let status = unsafe { hci_le_transmitter_test_v2(tx_channel, test_data_length, packet_payload as u8, phy as u8) };
+    if status == BLE_STATUS_SUCCESS {
+        Ok(())
+    } else {
+        Err(BleError::CommandFailed(super::types::Status::from_u8(status)))
+    }
+}
+
+/// End a DTM test and return the received packet count.
+///
+/// For a **receiver** test: returns the number of packets received.
+/// For a **transmitter** test: always returns 0 (per BLE spec Vol 4 Part E §7.8.30).
+pub fn le_test_end() -> Result<u16, BleError> {
+    let mut num_packets: u16 = 0;
+    let status = unsafe { hci_le_test_end(&mut num_packets) };
+    if status == BLE_STATUS_SUCCESS {
+        Ok(num_packets)
+    } else {
+        Err(BleError::CommandFailed(super::types::Status::from_u8(status)))
+    }
+}
+
+/// Read the number of TX packets sent during an active transmitter test.
+///
+/// ST proprietary command. Call this while the test is running to monitor
+/// progress without ending the test.
+pub fn aci_hal_tx_test_packet_number() -> Result<u32, BleError> {
+    let mut num_packets: u32 = 0;
+    let status = unsafe { aci_hal_le_tx_test_packet_number(&mut num_packets) };
+    if status == BLE_STATUS_SUCCESS {
+        Ok(num_packets)
+    } else {
+        Err(BleError::CommandFailed(super::types::Status::from_u8(status)))
     }
 }

--- a/embassy-stm32-wpan/src/wba/hci/types.rs
+++ b/embassy-stm32-wpan/src/wba/hci/types.rs
@@ -230,3 +230,57 @@ pub enum AdvFilterPolicy {
     /// Process scan and connection requests only from white list
     WhiteListOnly = 0x03,
 }
+
+/// DTM packet payload pattern.                                                                                    
+/// BLE Core Spec v6.0, Vol 4, Part E, Section 7.8.29, page 2547.                                                  
+#[repr(u8)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+pub enum DtmPacketPayload {
+    /// PRBS9 sequence as described in [Vol 6] Part F, Section 4.1.5                                               
+    Prbs9 = 0x00,
+    /// Repeated '11110000' sequence as described in [Vol 6] Part F, Section 4.1.5
+    Repeated11110000 = 0x01,
+    /// Repeated '10101010' sequence as described in [Vol 6] Part F, Section 4.1.5
+    Repeated10101010 = 0x02,
+    /// PRBS15 sequence as described in [Vol 6] Part F, Section 4.1.5
+    Prbs15 = 0x03,
+    /// Repeated '11111111' sequence
+    AllOnes = 0x04,
+    /// Repeated '00000000' sequence
+    AllZeros = 0x05,
+    /// Repeated '00001111' sequence
+    Repeated00001111 = 0x06,
+    /// Repeated '01010101' sequence                                                                               
+    Repeated01010101 = 0x07,
+}
+
+/// PHY for DTM transmitter test.                                                                                  
+/// BLE Core Spec v6.0, Vol 4, Part E, Section 7.8.29, page 2548.                                                  
+#[repr(u8)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+pub enum DtmTxPhy {
+    /// LE 1M PHY                                                                                                  
+    Le1M = 0x01,
+    /// LE 2M PHY                                                                                                  
+    Le2M = 0x02,
+    /// LE Coded PHY with S=8 data coding (125 kbps)                                                               
+    LeCodedS8 = 0x03,
+    /// LE Coded PHY with S=2 data coding (500 kbps)
+    LeCodedS2 = 0x04,
+}
+
+/// PHY for DTM receiver test.                                                                                     
+/// BLE Core Spec v6.0, Vol 4, Part E, Section 7.8.28, page 2542.
+#[repr(u8)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+pub enum DtmRxPhy {
+    /// LE 1M PHY
+    Le1M = 0x01,
+    /// LE 2M PHY
+    Le2M = 0x02,
+    /// LE Coded PHY
+    LeCoded = 0x03,
+}

--- a/examples/stm32wba/Cargo.toml
+++ b/examples/stm32wba/Cargo.toml
@@ -47,6 +47,11 @@ required-features = ["ble"]
 name = "ble_gatt_server"
 required-features = ["ble"]
 
+[[bin]]
+name = "ble_dtm"
+required-features = ["ble"]
+
+
 [profile.release]
 debug = 2
 

--- a/examples/stm32wba/src/bin/ble_dtm.rs
+++ b/examples/stm32wba/src/bin/ble_dtm.rs
@@ -1,0 +1,182 @@
+//! BLE Direct Test Mode (DTM) example for STM32WBA55CG
+//!
+//! Demonstrates RF testing using BLE DTM HCI commands.
+//!
+//! To use with two Nucleo-WBA55CG boards:
+//!  - Change DTM_MODE to DtmMode::Tx on one board, DtmMode::Rx on the other
+//!  - Both boards must use the same DTM_CHANNEL
+//!  - Flash both, observe defmt logs
+//!  - TX board logs packet count while running
+//!  - RX board reports received packet count after DTM_TEST_DURATION_SECS
+//!
+//! Hardware: STM32WBA55CG (Nucleo-WBA55CG)
+
+#![no_std]
+#![no_main]
+
+use core::cell::RefCell;
+
+use defmt::*;
+use embassy_executor::Spawner;
+use embassy_stm32::peripherals::RNG;
+use embassy_stm32::rng::{self, Rng};
+use embassy_stm32::time::Hertz;
+use embassy_stm32::{Config, bind_interrupts, interrupt};
+use embassy_stm32_wpan::hci::command::{
+    aci_hal_tx_test_packet_number, le_receiver_test, le_test_end, le_transmitter_test,
+};
+use embassy_stm32_wpan::hci::types::DtmPacketPayload;
+use embassy_stm32_wpan::{Ble, ble_runner, run_radio_high_isr, run_radio_sw_low_isr};
+use embassy_sync::blocking_mutex::Mutex;
+use embassy_sync::blocking_mutex::raw::CriticalSectionRawMutex;
+use embassy_time::Timer;
+use static_cell::StaticCell;
+use {defmt_rtt as _, panic_probe as _};
+
+// ---- Test configuration ----
+// Change these to configure the test
+#[allow(dead_code)]
+enum DtmMode {
+    Tx,
+    Rx,
+}
+const DTM_MODE: DtmMode = DtmMode::Tx; // change to Rx on the other board
+const DTM_CHANNEL: u8 = 19; // 2440 MHz — same on both boards
+const DTM_DATA_LENGTH: u8 = 37; // bytes per packet
+const DTM_TEST_DURATION_SECS: u64 = 10;
+// ----------------------------
+
+bind_interrupts!(struct Irqs {
+    RNG => rng::InterruptHandler<RNG>;
+});
+
+// RADIO interrupt handler - required for BLE stack operation
+#[interrupt]
+unsafe fn RADIO() {
+    unsafe { run_radio_high_isr() };
+}
+
+// HASH interrupt handler - used as software low-priority interrupt for BLE
+#[interrupt]
+unsafe fn HASH() {
+    unsafe { run_radio_sw_low_isr() };
+}
+
+/// BLE runner task - drives the BLE stack sequencer
+#[embassy_executor::task]
+async fn ble_runner_task() {
+    ble_runner().await
+}
+
+#[embassy_executor::main]
+async fn main(spawner: Spawner) {
+    let mut config = Config::default();
+    {
+        use embassy_stm32::rcc::*;
+        // Enable HSE (32 MHz external crystal) - REQUIRED for BLE radio
+        config.rcc.hse = Some(Hse {
+            prescaler: HsePrescaler::Div1,
+        });
+
+        // Enable LSE (32.768 kHz external crystal) - REQUIRED for BLE radio sleep timer
+        config.rcc.ls = LsConfig {
+            rtc: RtcClockSource::Lse,
+            lsi: false,
+            lse: Some(LseConfig {
+                frequency: Hertz(32_768),
+                mode: LseMode::Oscillator(LseDrive::MediumLow),
+                peripherals_clocked: true,
+            }),
+        };
+        // Configure PLL1 (required on WBA)
+        config.rcc.pll1 = Some(Pll {
+            source: PllSource::Hsi,
+            prediv: PllPreDiv::Div1,
+            mul: PllMul::Mul30,
+            divr: Some(PllDiv::Div5),
+            divq: None,
+            divp: Some(PllDiv::Div30),
+            frac: Some(0),
+        });
+        config.rcc.ahb_pre = AHBPrescaler::Div1;
+        config.rcc.apb1_pre = APBPrescaler::Div1;
+        config.rcc.apb2_pre = APBPrescaler::Div1;
+        config.rcc.apb7_pre = APBPrescaler::Div1;
+        config.rcc.ahb5_pre = AHB5Prescaler::Div4;
+        config.rcc.voltage_scale = VoltageScale::Range1;
+        config.rcc.sys = Sysclk::Pll1R;
+        config.rcc.mux.rngsel = mux::Rngsel::Hsi;
+    }
+
+    let p = embassy_stm32::init(config);
+    // Configure radio sleep timer to use LSE
+    {
+        use embassy_stm32::pac::RCC;
+        use embassy_stm32::pac::rcc::vals::Radiostsel;
+        RCC.bdcr().modify(|w| w.set_radiostsel(Radiostsel::Lse));
+    }
+
+    info!("Embassy STM32WBA BLE DTM (Direct Test Mode) Example");
+
+    // Initialize hardware peripherals required
+    static RNG_INST: StaticCell<Mutex<CriticalSectionRawMutex, RefCell<Rng<'static, RNG>>>> = StaticCell::new();
+    let rng = RNG_INST.init(Mutex::new(RefCell::new(Rng::new(p.RNG, Irqs))));
+
+    info!("Hardware peripherals initialized (RNG)");
+
+    // Initialize BLE-DTM stack
+    let mut ble = Ble::new_dtm(rng);
+    ble.dtm_init().expect("DTM init failed");
+
+    // Spawn the BLE runner task (required for proper BLE operation)
+    spawner.spawn(ble_runner_task().expect("Failed to spawn BLE runner"));
+    embassy_futures::yield_now().await;
+
+    match DTM_MODE {
+        DtmMode::Tx => {
+            info!(
+                "Starting DTM TX on channel {} ({}MHz), {} byte payload, PRBS9",
+                DTM_CHANNEL,
+                2402 + 2 * DTM_CHANNEL as u32,
+                DTM_DATA_LENGTH
+            );
+
+            le_transmitter_test(DTM_CHANNEL, DTM_DATA_LENGTH, DtmPacketPayload::Prbs9).expect("DTM TX start failed");
+
+            for elapsed in 1..=DTM_TEST_DURATION_SECS {
+                Timer::after_secs(1).await;
+                match aci_hal_tx_test_packet_number() {
+                    Ok(n) => info!("  {}s: {} TX packets sent", elapsed, n),
+                    Err(e) => warn!("  packet count unavailable: {:?}", e),
+                }
+            }
+
+            match le_test_end() {
+                Ok(_) => info!("DTM TX test ended"),
+                Err(e) => error!("le_test_end failed: {:?}", e),
+            }
+        }
+
+        DtmMode::Rx => {
+            info!(
+                "Starting DTM RX on channel {} ({}MHz)",
+                DTM_CHANNEL,
+                2402 + 2 * DTM_CHANNEL as u32
+            );
+
+            le_receiver_test(DTM_CHANNEL).expect("DTM RX start failed");
+
+            Timer::after_secs(DTM_TEST_DURATION_SECS).await;
+
+            match le_test_end() {
+                Ok(n) => info!("DTM RX test ended: {} packets received", n),
+                Err(e) => error!("le_test_end failed: {:?}", e),
+            }
+        }
+    }
+
+    info!("Done.");
+    loop {
+        Timer::after_secs(86400).await;
+    }
+}

--- a/examples/stm32wba/src/bin/ble_dtm.rs
+++ b/examples/stm32wba/src/bin/ble_dtm.rs
@@ -6,10 +6,14 @@
 //!  - Change DTM_MODE to DtmMode::Tx on one board, DtmMode::Rx on the other
 //!  - Both boards must use the same DTM_CHANNEL
 //!  - Flash both, observe defmt logs
-//!  - TX board logs packet count while running
-//!  - RX board reports received packet count after DTM_TEST_DURATION_SECS
+//!  - Press USER button (B1) on each board when ready to start
+//!  - RX board reports received packet count and PER after DTM_TEST_DURATION_SECS
 //!
 //! Hardware: STM32WBA55CG (Nucleo-WBA55CG)
+//!
+//! Note: The BLE runner task is not needed for DTM. DTM commands are synchronous
+//! HCI calls handled directly by the controller. The RADIO and HASH interrupt
+//! handlers are sufficient to drive the link layer.
 
 #![no_std]
 #![no_main]
@@ -18,15 +22,15 @@ use core::cell::RefCell;
 
 use defmt::*;
 use embassy_executor::Spawner;
+use embassy_stm32::exti::ExtiInput;
+use embassy_stm32::gpio::Pull;
 use embassy_stm32::peripherals::RNG;
 use embassy_stm32::rng::{self, Rng};
 use embassy_stm32::time::Hertz;
-use embassy_stm32::{Config, bind_interrupts, interrupt};
-use embassy_stm32_wpan::hci::command::{
-    aci_hal_tx_test_packet_number, le_receiver_test, le_test_end, le_transmitter_test,
-};
+use embassy_stm32::{Config, bind_interrupts, exti, interrupt};
+use embassy_stm32_wpan::hci::command::{le_receiver_test, le_test_end, le_transmitter_test};
 use embassy_stm32_wpan::hci::types::DtmPacketPayload;
-use embassy_stm32_wpan::{Ble, ble_runner, run_radio_high_isr, run_radio_sw_low_isr};
+use embassy_stm32_wpan::{Ble, run_radio_high_isr, run_radio_sw_low_isr};
 use embassy_sync::blocking_mutex::Mutex;
 use embassy_sync::blocking_mutex::raw::CriticalSectionRawMutex;
 use embassy_time::Timer;
@@ -34,7 +38,6 @@ use static_cell::StaticCell;
 use {defmt_rtt as _, panic_probe as _};
 
 // ---- Test configuration ----
-// Change these to configure the test
 #[allow(dead_code)]
 enum DtmMode {
     Tx,
@@ -48,6 +51,7 @@ const DTM_TEST_DURATION_SECS: u64 = 10;
 
 bind_interrupts!(struct Irqs {
     RNG => rng::InterruptHandler<RNG>;
+    EXTI13 => exti::InterruptHandler<interrupt::typelevel::EXTI13>;
 });
 
 // RADIO interrupt handler - required for BLE stack operation
@@ -62,14 +66,8 @@ unsafe fn HASH() {
     unsafe { run_radio_sw_low_isr() };
 }
 
-/// BLE runner task - drives the BLE stack sequencer
-#[embassy_executor::task]
-async fn ble_runner_task() {
-    ble_runner().await
-}
-
 #[embassy_executor::main]
-async fn main(spawner: Spawner) {
+async fn main(_spawner: Spawner) {
     let mut config = Config::default();
     {
         use embassy_stm32::rcc::*;
@@ -116,9 +114,18 @@ async fn main(spawner: Spawner) {
         RCC.bdcr().modify(|w| w.set_radiostsel(Radiostsel::Lse));
     }
 
-    info!("Embassy STM32WBA BLE DTM (Direct Test Mode) Example");
+    let mut button = ExtiInput::new(p.PC13, p.EXTI13, Pull::Up, Irqs);
 
-    // Initialize hardware peripherals required
+    info!("Embassy STM32WBA BLE DTM Example");
+    match DTM_MODE {
+        DtmMode::Tx => info!("Mode: TX"),
+        DtmMode::Rx => info!("Mode: RX"),
+    }
+
+    info!("Press USER button (B1) to start...");
+    button.wait_for_falling_edge().await;
+    info!("Button pressed — initialising BLE");
+
     static RNG_INST: StaticCell<Mutex<CriticalSectionRawMutex, RefCell<Rng<'static, RNG>>>> = StaticCell::new();
     let rng = RNG_INST.init(Mutex::new(RefCell::new(Rng::new(p.RNG, Irqs))));
 
@@ -128,40 +135,43 @@ async fn main(spawner: Spawner) {
     let mut ble = Ble::new_dtm(rng);
     ble.dtm_init().expect("DTM init failed");
 
-    // Spawn the BLE runner task (required for proper BLE operation)
-    spawner.spawn(ble_runner_task().expect("Failed to spawn BLE runner"));
-    embassy_futures::yield_now().await;
+    // DTM packet interval is 625 µs (1 BLE slot) per Vol 6, Part F, Section 4.1.6.
+    // Expected packets = duration_s × (1_000_000 µs/s ÷ 625 µs/packet) = duration_s × 1600.
+    let expected: u32 = DTM_TEST_DURATION_SECS as u32 * 1_000_000 / 625;
 
     match DTM_MODE {
         DtmMode::Tx => {
+            let freq_mhz = 2402 + 2 * DTM_CHANNEL as u32;
             info!(
-                "Starting DTM TX on channel {} ({}MHz), {} byte payload, PRBS9",
-                DTM_CHANNEL,
-                2402 + 2 * DTM_CHANNEL as u32,
-                DTM_DATA_LENGTH
+                "DTM TX: channel {} ({}MHz), {} byte payload, PRBS9, {}s",
+                DTM_CHANNEL, freq_mhz, DTM_DATA_LENGTH, DTM_TEST_DURATION_SECS
+            );
+            // BLE spec Vol 6 Part F §3.4.2: TX packet count is always 0 by spec.
+            // Expected rate: ~1600 packets/s (625 µs interval).
+            info!(
+                "Expected ~{} packets over {}s (~1600 packets/s at 625us interval)",
+                expected, DTM_TEST_DURATION_SECS
             );
 
             le_transmitter_test(DTM_CHANNEL, DTM_DATA_LENGTH, DtmPacketPayload::Prbs9).expect("DTM TX start failed");
 
-            for elapsed in 1..=DTM_TEST_DURATION_SECS {
-                Timer::after_secs(1).await;
-                match aci_hal_tx_test_packet_number() {
-                    Ok(n) => info!("  {}s: {} TX packets sent", elapsed, n),
-                    Err(e) => warn!("  packet count unavailable: {:?}", e),
-                }
-            }
+            Timer::after_secs(DTM_TEST_DURATION_SECS).await;
 
             match le_test_end() {
-                Ok(_) => info!("DTM TX test ended"),
+                Ok(_) => info!("DTM TX test ended after {}s", DTM_TEST_DURATION_SECS),
                 Err(e) => error!("le_test_end failed: {:?}", e),
             }
         }
 
         DtmMode::Rx => {
+            let freq_mhz = 2402 + 2 * DTM_CHANNEL as u32;
             info!(
-                "Starting DTM RX on channel {} ({}MHz)",
-                DTM_CHANNEL,
-                2402 + 2 * DTM_CHANNEL as u32
+                "DTM RX: channel {} ({}MHz), {}s",
+                DTM_CHANNEL, freq_mhz, DTM_TEST_DURATION_SECS
+            );
+            info!(
+                "Expected ~{} packets over {}s (~1600 packets/s at 625us interval)",
+                expected, DTM_TEST_DURATION_SECS
             );
 
             le_receiver_test(DTM_CHANNEL).expect("DTM RX start failed");
@@ -169,7 +179,23 @@ async fn main(spawner: Spawner) {
             Timer::after_secs(DTM_TEST_DURATION_SECS).await;
 
             match le_test_end() {
-                Ok(n) => info!("DTM RX test ended: {} packets received", n),
+                Ok(received) => {
+                    let received = received as u32;
+                    // Packet Error Rate = lost / expected × 100
+                    // lost = expected − received (clamped to 0 if received > expected)
+                    let lost = expected.saturating_sub(received);
+                    let per_pct = lost * 100 / expected;
+                    let per_frac = (lost * 10000 / expected) % 100;
+                    info!("--- DTM RX Results ---");
+                    info!("  Expected : {} packets", expected);
+                    info!("  Received : {} packets", received);
+                    info!("  Lost     : {} packets", lost);
+                    info!("  PER      : {}.{:02}%  (lost/expected × 100)", per_pct, per_frac);
+                    info!(
+                        "  Math     : {} / {} × 100 = {}.{:02}%",
+                        lost, expected, per_pct, per_frac
+                    );
+                }
                 Err(e) => error!("le_test_end failed: {:?}", e),
             }
         }


### PR DESCRIPTION
Adds DTM support to embassy-stm32-wpan for the STM32WBA family, enabling RF testing required for FCC/CE            
  certification. Includes a two-board example demonstrating TX/RX operation on the Nucleo-WBA55CG.                   
                                                                                                                     
  ---                                                                                                                
  Changes                                                                                                            
         
  embassy-stm32-wpan/src/wba/hci/types.rs
                                                                                                                     
  Added three enums derived directly from BLE Core Spec v6.0, Vol 4, Part E:                                         
  - DtmPacketPayload — 8 payload patterns (PRBS9, repeated sequences) from Section 7.8.29 page 2547                  
  - DtmTxPhy — 4 TX PHY options including Coded S=8 and S=2 from Section 7.8.29 page 2548                            
  - DtmRxPhy — 3 RX PHY options (no S= distinction on receive) from Section 7.8.28 page 2542
                                                                                                                     
  embassy-stm32-wpan/src/wba/hci/command.rs                                                                          
                                                                                                                     
  Added C bindings and safe Rust wrappers for 6 symbols confirmed present in libstm32wba_ble_stack_basic.a:          
  - le_receiver_test / le_receiver_test_v2
  - le_transmitter_test / le_transmitter_test_v2                                                                     
  - le_test_end — returns received packet count; per spec §7.8.30 always returns 0 for TX tests
  - aci_hal_tx_test_packet_number — ST proprietary live TX counter                                                   
                                                                                                                     
  embassy-stm32-wpan/src/wba/ble.rs                                                                                  
                                                                                                                     
  Added Ble::dtm_init(): a minimal initialization path for DTM that skips GATT and GAP setup. DTM is a               
  controller-only mode (BLE spec Vol 6, Part F) and does not use the host stack layers.

  examples/stm32wba/src/bin/ble_dtm.rs (new)                                                                         
   
  Two-board example for Nucleo-WBA55CG demonstrating a complete DTM test cycle:                                      
  - Button-triggered start (USER button B1, PC13)
  - TX mode: transmits PRBS9 packets on channel 19 (2440 MHz) for 10 seconds                                         
  - RX mode: receives and reports packet count with Packet Error Rate calculation
  - Expected packet count derived from the 625 µs DTM packet interval (Vol 6, Part F, Section 4.1.6): duration_s ×   
  1_000_000 / 625                                                                                                  
  - The BLE runner task is not spawned — DTM HCI commands are synchronous and the link layer runs entirely from the  
  RADIO and HASH interrupt handlers
                                                                                                                     
  examples/stm32wba/Cargo.toml
                                                                                                                     
  Added [[bin]] entry for ble_dtm with required-features = ["ble"].                                                  
   
  ---                                                                                                                
  Testing         
         
  Tested on two Nucleo-WBA55CG boards simultaneously:
  - TX board transmitted for 10 seconds on channel 19                                                                
  - RX board received 15,992 / 16,000 expected packets → PER: 0.05%
                                                                                                                     
  ---                                                                                                                
  Notes
                                                                                                                     
  The BLE spec (Vol 6, Part F, Section 3.4.2) explicitly defines that the TX test always reports Num_Packets = 0.
  aci_hal_tx_test_packet_number is an ST proprietary extension to fill this gap; it is included as a standalone      
  function but not used in the example as it requires the runner to be active and returns unreliable values when
  polled.