### PR TITLE
[STM32] fix bxcan auto-retransmission inverted logic

### DIFF
--- a/embassy-stm32/src/can/bxcan/registers.rs
+++ b/embassy-stm32/src/can/bxcan/registers.rs
@@ -67,7 +67,7 @@ impl Registers {
     ///
     /// Automatic retransmission is enabled by default.
     pub fn set_automatic_retransmit(&self, enabled: bool) {
-        self.0.mcr().modify(|reg| reg.set_nart(enabled));
+        self.0.mcr().modify(|reg| reg.set_nart(!enabled));
     }
 
     /// Enables or disables loopback mode: Internally connects the TX and RX


### PR DESCRIPTION
Auto-retransmission is disabled by setting the `NART` register (no-autoretransmission) to `true`.

closes #5944.