### PR TITLE
feat(stm32 can): expose ns_per_timer_tick via Properties

### DIFF
--- a/embassy-stm32/src/can/fdcan.rs
+++ b/embassy-stm32/src/can/fdcan.rs
@@ -868,6 +868,17 @@ impl Properties {
         (self.info.periph_clock)()
     }
 
+    /// Get the CAN peripheral's timestamp counter period in nanoseconds per tick.
+    ///
+    /// Useful when the `time` feature is disabled and `Envelope.ts` / `FdEnvelope.ts`
+    /// are exposed as raw `u16` hardware counter values. Multiply the counter delta
+    /// by this value to obtain elapsed nanoseconds.
+    ///
+    /// Returns 0 before the peripheral is configured via [`CanConfigurator::start`].
+    pub fn ns_per_timer_tick(&self) -> u64 {
+        self.info.state.lock(|s| s.borrow().ns_per_timer_tick)
+    }
+
     /// Set a standard address CAN filter in the specified slot in FDCAN memory.
     #[inline]
     pub fn set_standard_filter(&self, slot: StandardFilterSlot, filter: StandardFilter) {


### PR DESCRIPTION
Closes #5840.

## Problem

When the `time` feature is disabled, `Envelope.ts` (and `FdEnvelope.ts`) are exposed as raw `u16` FDCAN hardware timer counter values. The peripheral's tick period in nanoseconds is computed at init time (see `calc_ns_per_timer_tick` in `embassy-stm32/src/can/fdcan.rs:152`) and stored in `State::ns_per_timer_tick`, but that field has no public accessor. Users cannot convert the raw u16 into a real time unit without reaching into internal state.

## Fix

Add `Properties::ns_per_timer_tick()` which returns the stored value from `State`. Reachable via `Can::properties()`, `BufferedCan::properties()`, `BufferedCanFd::properties()`, `CanConfigurator::properties()`, or the `Properties` returned from `Can::split()`. Non-breaking.

```rust
pub fn ns_per_timer_tick(&self) -> u64 {
    self.info.state.lock(|s| s.borrow().ns_per_timer_tick)
}
```

Users can then compute:

```rust
let delta = ts_current.wrapping_sub(ts_prior);
let ns = (delta as u64) * can.properties().ns_per_timer_tick();
```

## Alternatives considered

- New `timestamp_to_ns(u16) -> u64` method: duplicates logic already in `calc_timestamp`; couples API to a specific unit. Rejected.
- Changing `Timestamp` type under `not(feature = "time")` from `u16` to a wrapping struct with methods: breaking API change. Rejected.

Placed on `Properties` rather than directly on `Can`/`CanRx` to match the existing `kernel_input_clock()` getter pattern and keep a single site of truth.