### PR TITLE
stm32: include STM32WBA in low-power stop refcount tracking

### DIFF
--- a/embassy-stm32/src/rcc/mod.rs
+++ b/embassy-stm32/src/rcc/mod.rs
@@ -408,7 +408,7 @@ impl RccInfo {
 
     #[allow(dead_code)]
     fn increment_minimum_stop_refcount_with_cs(&self, _cs: CriticalSection) {
-        #[cfg(all(any(stm32wl, stm32wb), feature = "low-power"))]
+        #[cfg(all(any(stm32wl, stm32wb, stm32wba), feature = "low-power"))]
         match self.stop_mode {
             StopMode::Stop1 | StopMode::Stop2 => increment_stop_refcount(_cs, StopMode::Stop2),
             _ => {}
@@ -417,7 +417,7 @@ impl RccInfo {
 
     #[allow(dead_code)]
     fn decrement_minimum_stop_refcount_with_cs(&self, _cs: CriticalSection) {
-        #[cfg(all(any(stm32wl, stm32wb), feature = "low-power"))]
+        #[cfg(all(any(stm32wl, stm32wb, stm32wba), feature = "low-power"))]
         match self.stop_mode {
             StopMode::Stop1 | StopMode::Stop2 => decrement_stop_refcount(_cs, StopMode::Stop2),
             _ => {}


### PR DESCRIPTION
## Summary
- Adds `stm32wba` to the cfg gate in `increment_minimum_stop_refcount_with_cs` and `decrement_minimum_stop_refcount_with_cs` so that enabling/disabling peripherals on STM32WBA properly increments/decrements the STOP mode refcounts.
- This was an oversight — WBA support predates the stop refcount mechanism (introduced for WL/WB in late 2025) and was never added to the cfg gate.
- Without this fix, peripheral enable/disable on WBA has no effect on stop refcounts, meaning the low-power executor cannot determine whether active peripherals should block STOP mode entry.