### PR TITLE
stm32: add WBA low-power config (ULPMEN, FLASHFWU, SRAM power-down) and fix SRAM wait states

### DIFF
--- a/embassy-stm32/src/lib.rs
+++ b/embassy-stm32/src/lib.rs
@@ -305,6 +305,40 @@ pub struct Config {
     #[cfg(any(stm32l4, stm32l5, stm32u5, stm32u3, stm32wba))]
     pub enable_independent_io_supply: bool,
 
+    /// Enable ultra-low-power BOR0 mode (discontinuous BOR monitoring) in
+    /// Stop 1 and Standby modes.
+    ///
+    /// This must be set to reach the lowest power consumption in low-power modes.
+    ///
+    /// **Constraints:**
+    /// - Must not be set when autonomous peripherals use HSI as kernel clock.
+    /// - Only effective when BOR levels 1-4 and PVD are disabled; when they
+    ///   are enabled, continuous mode applies regardless of this setting.
+    ///
+    /// Defaults to `false` (disabled).
+    #[cfg(stm32wba)]
+    pub enable_ulpmen: bool,
+
+    /// Enable flash fast wakeup from Stop 0/1 modes.
+    ///
+    /// When `true`, flash stays in normal mode during stop (faster wakeup,
+    /// higher power). When `false` (default), flash enters low-power mode
+    /// (slower wakeup, lower power).
+    ///
+    /// Defaults to `false`.
+    #[cfg(stm32wba)]
+    pub flash_fast_wakeup: bool,
+
+    /// SRAM power-down configuration for Stop modes.
+    ///
+    /// Controls which SRAM pages are powered down when entering Stop 0 or
+    /// Stop 1 modes. Powered-down pages lose their content but reduce
+    /// current draw.
+    ///
+    /// Defaults to all SRAM retained.
+    #[cfg(stm32wba)]
+    pub stop_mode_sram: rcc::StopModeSramConfig,
+
     /// On the U5 series all analog peripherals are powered by a separate supply.
     #[cfg(any(stm32u5, stm32u3))]
     pub enable_independent_analog_supply: bool,
@@ -362,6 +396,12 @@ impl Default for Config {
             enable_debug_during_sleep: true,
             #[cfg(any(stm32l4, stm32l5, stm32u5, stm32u3, stm32wba))]
             enable_independent_io_supply: true,
+            #[cfg(stm32wba)]
+            enable_ulpmen: false,
+            #[cfg(stm32wba)]
+            flash_fast_wakeup: false,
+            #[cfg(stm32wba)]
+            stop_mode_sram: rcc::StopModeSramConfig::default(),
             #[cfg(any(stm32u5, stm32u3))]
             enable_independent_analog_supply: true,
             #[cfg(bdma)]
@@ -657,6 +697,37 @@ fn init_hw(config: Config) -> Peripherals {
                 } else {
                     vals::Io2sv::B0x0
                 });
+            });
+
+            // Ultra-low-power BOR0 mode for lowest Stop 1 / Standby consumption.
+            crate::pac::PWR.cr1().modify(|w| w.set_ulpmen(config.enable_ulpmen));
+
+            // Flash fast wakeup and SRAM page power-down in Stop modes.
+            crate::pac::PWR.cr2().modify(|w| {
+                w.set_flashfwu(if config.flash_fast_wakeup {
+                    vals::Flashfwu::Normal
+                } else {
+                    vals::Flashfwu::LowPower
+                });
+
+                let sram = &config.stop_mode_sram;
+                w.set_sram1pds(0, if sram.sram1_page0 { vals::Srampds::PoweredOff } else { vals::Srampds::PoweredOn });
+                w.set_sram1pds(1, if sram.sram1_page1 { vals::Srampds::PoweredOff } else { vals::Srampds::PoweredOn });
+                w.set_sram1pds(2, if sram.sram1_page2 { vals::Srampds::PoweredOff } else { vals::Srampds::PoweredOn });
+                w.set_sram1pds(3, if sram.sram1_page3 { vals::Srampds::PoweredOff } else { vals::Srampds::PoweredOn });
+                w.set_sram2pds1(if sram.sram2 { vals::Srampds::PoweredOff } else { vals::Srampds::PoweredOn });
+                w.set_sram1pds567(if sram.sram1_pages567 {
+                    vals::Sram1pds567::PoweredOff
+                } else {
+                    vals::Sram1pds567::PoweredOn
+                });
+                w.set_icrampds(if sram.icache_sram {
+                    vals::Icrampds::NotRetained
+                } else {
+                    vals::Icrampds::Retained
+                });
+                w.set_prampds(if sram.otg_sram { vals::Prampds::B0x1 } else { vals::Prampds::B0x0 });
+                w.set_pkarampds(if sram.pka_sram { vals::Pkarampds::B0x1 } else { vals::Pkarampds::B0x0 });
             });
         }
         #[cfg(any(stm32u5, stm32u3))]

--- a/embassy-stm32/src/lib.rs
+++ b/embassy-stm32/src/lib.rs
@@ -711,11 +711,43 @@ fn init_hw(config: Config) -> Peripherals {
                 });
 
                 let sram = &config.stop_mode_sram;
-                w.set_sram1pds(0, if sram.sram1_page0 { vals::Srampds::PoweredOff } else { vals::Srampds::PoweredOn });
-                w.set_sram1pds(1, if sram.sram1_page1 { vals::Srampds::PoweredOff } else { vals::Srampds::PoweredOn });
-                w.set_sram1pds(2, if sram.sram1_page2 { vals::Srampds::PoweredOff } else { vals::Srampds::PoweredOn });
-                w.set_sram1pds(3, if sram.sram1_page3 { vals::Srampds::PoweredOff } else { vals::Srampds::PoweredOn });
-                w.set_sram2pds1(if sram.sram2 { vals::Srampds::PoweredOff } else { vals::Srampds::PoweredOn });
+                w.set_sram1pds(
+                    0,
+                    if sram.sram1_page0 {
+                        vals::Srampds::PoweredOff
+                    } else {
+                        vals::Srampds::PoweredOn
+                    },
+                );
+                w.set_sram1pds(
+                    1,
+                    if sram.sram1_page1 {
+                        vals::Srampds::PoweredOff
+                    } else {
+                        vals::Srampds::PoweredOn
+                    },
+                );
+                w.set_sram1pds(
+                    2,
+                    if sram.sram1_page2 {
+                        vals::Srampds::PoweredOff
+                    } else {
+                        vals::Srampds::PoweredOn
+                    },
+                );
+                w.set_sram1pds(
+                    3,
+                    if sram.sram1_page3 {
+                        vals::Srampds::PoweredOff
+                    } else {
+                        vals::Srampds::PoweredOn
+                    },
+                );
+                w.set_sram2pds1(if sram.sram2 {
+                    vals::Srampds::PoweredOff
+                } else {
+                    vals::Srampds::PoweredOn
+                });
                 w.set_sram1pds567(if sram.sram1_pages567 {
                     vals::Sram1pds567::PoweredOff
                 } else {
@@ -726,8 +758,16 @@ fn init_hw(config: Config) -> Peripherals {
                 } else {
                     vals::Icrampds::Retained
                 });
-                w.set_prampds(if sram.otg_sram { vals::Prampds::B0x1 } else { vals::Prampds::B0x0 });
-                w.set_pkarampds(if sram.pka_sram { vals::Pkarampds::B0x1 } else { vals::Pkarampds::B0x0 });
+                w.set_prampds(if sram.otg_sram {
+                    vals::Prampds::B0x1
+                } else {
+                    vals::Prampds::B0x0
+                });
+                w.set_pkarampds(if sram.pka_sram {
+                    vals::Pkarampds::B0x1
+                } else {
+                    vals::Pkarampds::B0x0
+                });
             });
         }
         #[cfg(any(stm32u5, stm32u3))]

--- a/embassy-stm32/src/rcc/wba.rs
+++ b/embassy-stm32/src/rcc/wba.rs
@@ -109,6 +109,52 @@ impl Default for Config {
     }
 }
 
+/// SRAM page power-down configuration for Stop modes (Stop 0, Stop 1).
+///
+/// Each field controls whether a particular SRAM region is powered down
+/// (content lost) or retained when the MCU enters a Stop mode. Powering
+/// down unused SRAM pages reduces Stop-mode current consumption.
+///
+/// All pages default to retained (`false`), preserving backward compatibility.
+#[derive(Clone, Copy)]
+pub struct StopModeSramConfig {
+    /// SRAM1 page 0 power-down in Stop modes.
+    pub sram1_page0: bool,
+    /// SRAM1 page 1 power-down in Stop modes.
+    pub sram1_page1: bool,
+    /// SRAM1 page 2 power-down in Stop modes.
+    pub sram1_page2: bool,
+    /// SRAM1 page 3 power-down in Stop modes.
+    pub sram1_page3: bool,
+    /// SRAM2 power-down in Stop modes.
+    pub sram2: bool,
+    /// SRAM1 pages 5-7 (192KB) power-down in Stop modes.
+    /// Only present on WBA6x variants with 256KB SRAM.
+    pub sram1_pages567: bool,
+    /// ICACHE SRAM power-down in Stop modes.
+    pub icache_sram: bool,
+    /// OTG (USB) SRAM power-down in Stop modes.
+    pub otg_sram: bool,
+    /// PKA SRAM power-down in Stop modes.
+    pub pka_sram: bool,
+}
+
+impl Default for StopModeSramConfig {
+    fn default() -> Self {
+        Self {
+            sram1_page0: false,
+            sram1_page1: false,
+            sram1_page2: false,
+            sram1_page3: false,
+            sram2: false,
+            sram1_pages567: false,
+            icache_sram: false,
+            otg_sram: false,
+            pka_sram: false,
+        }
+    }
+}
+
 fn hsi_enable() {
     RCC.cr().modify(|w| w.set_hsion(true));
     while !RCC.cr().read().hsirdy() {}
@@ -194,7 +240,7 @@ pub(crate) unsafe fn init(config: Config) {
     while FLASH.acr().read().latency() != flash_latency {}
 
     // Set sram wait states
-    let _sram_latency = match config.voltage_scale {
+    let sram_latency = match config.voltage_scale {
         VoltageScale::Range1 => 0,
         VoltageScale::Range2 => match sys_clk.0 {
             ..=12_000_000 => 0,
@@ -202,7 +248,10 @@ pub(crate) unsafe fn init(config: Config) {
             _ => 2,
         },
     };
-    // TODO: Set the SRAM wait states
+    crate::pac::RCC.ahb1enr().modify(|w| w.set_ramcfgen(true));
+    cortex_m::asm::dsb();
+    crate::pac::RAMCFG.m1cr().modify(|w| w.set_wsc(sram_latency));
+    crate::pac::RAMCFG.m2cr().modify(|w| w.set_wsc(sram_latency));
 
     RCC.cfgr1().modify(|w| {
         w.set_sw(config.sys);


### PR DESCRIPTION
## Summary
- **Fix SRAM wait states TODO** in `rcc/wba.rs`: the latency value was already calculated but never written. Now writes to `RAMCFG.m1cr()`/`m2cr()` WSC registers for both SRAM banks, correctly re-applied on wakeup from stop via `reinit_saved()`.
- **Add `enable_ulpmen`** config (PWR CR1 bit 7): enables ultra-low-power discontinuous BOR0 mode in Stop 1 / Standby — the reference manual notes this "must be set to reach the lowest power consumption."
- **Add `flash_fast_wakeup`** config (PWR CR2 FLASHFWU): controls whether flash enters low-power mode during Stop 0/1 (slower wakeup, lower power) or stays in normal mode (faster wakeup, higher power).
- **Add `StopModeSramConfig`** struct with per-page SRAM power-down control in Stop modes (PWR CR2): SRAM1 pages 0–3, SRAM2, SRAM1 pages 5–7, ICACHE SRAM, OTG SRAM, and PKA SRAM.
- All new fields default to hardware reset values — **no behavioral change for existing users**.