### PR TITLE
Add MAX generic to BusState.

### DIFF
--- a/embassy-usb-host/src/lib.rs
+++ b/embassy-usb-host/src/lib.rs
@@ -77,35 +77,38 @@ impl core::error::Error for EnumerationError {}
 
 /// Shared bus-wide state used by a [`BusHandle`].
 ///
-/// Holds the in-use USB device addresses (1–127) and an async mutex used to
+/// Holds the in-use USB device addresses (1–MAX) and an async mutex used to
 /// serialise enumerations on a single bus.
-pub struct BusState {
-    addr_bitmap: BlockingMutex<CriticalSectionRawMutex, RefCell<[u64; 2]>>,
+///
+/// MAX is 127 by default.
+pub struct BusState<const MAX: u8 = 127> {
+    addr_bitmap:
+        BlockingMutex<CriticalSectionRawMutex, RefCell<[usize; (u8::MAX as usize).div_ceil(usize::BITS as usize)]>>,
     enum_lock: AsyncMutex<CriticalSectionRawMutex, ()>,
 }
 
-impl BusState {
+impl<const MAX: u8> BusState<MAX> {
     /// Create new, empty bus state.
     pub const fn new() -> Self {
         Self {
-            addr_bitmap: BlockingMutex::new(RefCell::new([0u64; 2])),
+            addr_bitmap: BlockingMutex::new(RefCell::new([0usize; _])),
             enum_lock: AsyncMutex::new(()),
         }
     }
 
-    /// Allocate the next free device address (1–127),
+    /// Allocate the next free device address (1–MAX),
     /// marking it as in use.
     ///
-    /// Returns `None` when every address in the 1–127 range is already
+    /// Returns `None` when every address in the 1–MAX range is already
     /// taken.
     fn alloc_address(&self) -> Option<u8> {
         self.addr_bitmap.lock(|b| {
             let mut b = b.borrow_mut();
-            for addr in 1u8..=127 {
-                let word = (addr / 64) as usize;
-                let bit = addr % 64;
-                if b[word] & (1u64 << bit) == 0 {
-                    b[word] |= 1u64 << bit;
+            for addr in 1u8..=MAX {
+                let word = (addr / usize::BITS as u8) as usize;
+                let bit = addr % usize::BITS as u8;
+                if b[word] & (1usize << bit) == 0 {
+                    b[word] |= 1usize << bit;
                     return Some(addr);
                 }
             }
@@ -117,12 +120,12 @@ impl BusState {
     ///
     /// No-op if the address is out of range or was not marked as in use.
     pub fn free_address(&self, addr: u8) {
-        if addr >= 1 && addr <= 127 {
+        if addr >= 1 && addr <= MAX {
             self.addr_bitmap.lock(|b| {
                 let mut b = b.borrow_mut();
-                let word = (addr / 64) as usize;
-                let bit = addr % 64;
-                b[word] &= !(1u64 << bit);
+                let word = (addr / usize::BITS as u8) as usize;
+                let bit = addr % usize::BITS as u8;
+                b[word] &= !(1usize << bit);
             });
         }
     }


### PR DESCRIPTION
MAX is 127 by default.
It allows you to specify the maximum address that the bus supports.

--

No idea why it was 127, for OHCI the restrictions are that it fits a u8 and is not 0.
I want to support the full range of addresses in my driver and not be limited to 127.

I changed the array type from `u64` to `usize` to avoid unnecessary u64 operations in my 32-bit system.

Currently rust does not support generic parameters in const operations.
Since i could not size the array based on MAX, I increase the array size to fit the whole u8 range.