### PR TITLE
usb-host: propagate BusState MAX generic through BusHandle and bus()

### DIFF
--- a/embassy-usb-host/src/class/hub.rs
+++ b/embassy-usb-host/src/class/hub.rs
@@ -18,8 +18,8 @@ use crate::descriptor::{DEFAULT_MAX_DESCRIPTOR_SIZE, InterfaceDescriptor, USBDes
 use crate::handler::{BusRoute, EnumerationInfo, HandlerEvent, RegisterError};
 use crate::{BusHandle, EnumerationError};
 
-pub struct HubHandler<'d, A: UsbHostAllocator<'d>, const MAX_PORTS: usize> {
-    bus: BusHandle<'d, A>,
+pub struct HubHandler<'d, A: UsbHostAllocator<'d>, const MAX_PORTS: usize, const MAX: u8 = 127> {
+    bus: BusHandle<'d, A, MAX>,
     interrupt_channel: A::Pipe<pipe::Interrupt, pipe::In>,
     control_channel: A::Pipe<pipe::Control, pipe::InOut>,
     desc: HubDescriptor,
@@ -35,9 +35,9 @@ pub enum HubEvent {
     DeviceRemoved { address: Option<NonZeroU8>, port: u8 },
 }
 
-impl<'d, A: UsbHostAllocator<'d>, const MAX_PORTS: usize> HubHandler<'d, A, MAX_PORTS> {
+impl<'d, A: UsbHostAllocator<'d>, const MAX_PORTS: usize, const MAX: u8> HubHandler<'d, A, MAX_PORTS, MAX> {
     /// Attempt to register a hub handler for the given device.
-    pub async fn try_register(bus: &BusHandle<'d, A>, enum_info: &EnumerationInfo) -> Result<Self, RegisterError> {
+    pub async fn try_register(bus: &BusHandle<'d, A, MAX>, enum_info: &EnumerationInfo) -> Result<Self, RegisterError> {
         let ls_over_fs = matches!(enum_info.split(), Some(s) if s.device_speed() == SplitSpeed::Low);
         let mut control_channel = bus.alloc_pipe::<pipe::Control, pipe::InOut>(
             enum_info.device_address,

--- a/embassy-usb-host/src/lib.rs
+++ b/embassy-usb-host/src/lib.rs
@@ -131,7 +131,7 @@ impl<const MAX: u8> BusState<MAX> {
     }
 }
 
-impl Default for BusState {
+impl<const MAX: u8> Default for BusState<MAX> {
     fn default() -> Self {
         Self::new()
     }
@@ -199,14 +199,14 @@ impl<'d, C: UsbHostController<'d>> BusController<'d, C> {
 /// its inner allocator, so it can be passed directly to class driver
 /// constructors.
 #[derive(Clone)]
-pub struct BusHandle<'d, A: UsbHostAllocator<'d>> {
+pub struct BusHandle<'d, A: UsbHostAllocator<'d>, const MAX: u8 = 127> {
     alloc: A,
-    state: &'d BusState,
+    state: &'d BusState<MAX>,
 }
 
-impl<'d, A: UsbHostAllocator<'d>> BusHandle<'d, A> {
+impl<'d, A: UsbHostAllocator<'d>, const MAX: u8> BusHandle<'d, A, MAX> {
     /// Borrow the shared bus state.
-    pub fn state(&self) -> &'d BusState {
+    pub fn state(&self) -> &'d BusState<MAX> {
         self.state
     }
 
@@ -406,7 +406,7 @@ impl<'d, A: UsbHostAllocator<'d>> BusHandle<'d, A> {
     }
 }
 
-impl<'d, A: UsbHostAllocator<'d>> UsbHostAllocator<'d> for BusHandle<'d, A> {
+impl<'d, A: UsbHostAllocator<'d>, const MAX: u8> UsbHostAllocator<'d> for BusHandle<'d, A, MAX> {
     type Pipe<T: pipe::Type, D: pipe::Direction> = A::Pipe<T, D>;
 
     fn alloc_pipe<T: pipe::Type, D: pipe::Direction>(
@@ -426,10 +426,10 @@ impl<'d, A: UsbHostAllocator<'d>> UsbHostAllocator<'d> for BusHandle<'d, A> {
 /// and can be freely shared, handed to class drivers, hub handlers, or
 /// other concurrent tasks while the controller task is blocked inside
 /// [`wait_for_device_event`](BusController::wait_for_device_event).
-pub fn bus<'d, C: UsbHostController<'d>>(
+pub fn bus<'d, C: UsbHostController<'d>, const MAX: u8>(
     driver: C,
-    state: &'d BusState,
-) -> (BusController<'d, C>, BusHandle<'d, C::Allocator>) {
+    state: &'d BusState<MAX>,
+) -> (BusController<'d, C>, BusHandle<'d, C::Allocator, MAX>) {
     let alloc = driver.allocator();
     (
         BusController {


### PR DESCRIPTION
## Summary

Follow-up to #5965. That PR added a `const MAX: u8 = 127` generic to `BusState`, but the consuming APIs (`BusHandle`, `bus()`, `HubHandler`, `Default for BusState`) still hardcoded the default `BusState` (= `BusState<127>`), so a `BusState::<200>::new()` couldn't actually be passed to `bus()` and the generic was effectively inert.

This PR threads `MAX` through:

- `BusHandle<'d, A, const MAX: u8 = 127>` — defaulted const generic, `state` field is now `&'d BusState<MAX>`.
- `bus<'d, C, const MAX: u8>(driver, state: &'d BusState<MAX>) -> (BusController<'d, C>, BusHandle<'d, C::Allocator, MAX>)` — `MAX` is inferred from the argument, no turbofish required at call sites.
- `impl<'d, A, const MAX: u8> UsbHostAllocator<'d> for BusHandle<'d, A, MAX>` — propagates `MAX`.
- `impl<const MAX: u8> Default for BusState<MAX>` — was previously only for the default type.
- `HubHandler<'d, A, const MAX_PORTS: usize, const MAX: u8 = 127>` — added so it can hold a `BusHandle<'d, A, MAX>`.

## Backwards compatibility

All existing call sites compile unchanged:

- `static BUS_STATE: BusState = BusState::new();` — uses the type-level default of 127.
- `bus(driver, &BUS_STATE)` — `MAX` is inferred from the `&BusState<MAX>` argument.
- Existing `BusHandle` / `HubHandler` uses without naming `MAX` get 127 via the type default.