### PR TITLE
nrf: nrf54 timer channel fix

### DIFF
--- a/embassy-nrf/src/chips/nrf54l05_app.rs
+++ b/embassy-nrf/src/chips/nrf54l05_app.rs
@@ -623,13 +623,13 @@ impl_ppi_group!(PPI20_GROUP5, DPPIC20, 5);
 impl_ppi_group!(PPI30_GROUP0, DPPIC30, 0);
 impl_ppi_group!(PPI30_GROUP1, DPPIC30, 1);
 
-impl_timer!(TIMER00, TIMER00, TIMER00);
-impl_timer!(TIMER10, TIMER10, TIMER10);
-impl_timer!(TIMER20, TIMER20, TIMER20);
-impl_timer!(TIMER21, TIMER21, TIMER21);
-impl_timer!(TIMER22, TIMER22, TIMER22);
-impl_timer!(TIMER23, TIMER23, TIMER23);
-impl_timer!(TIMER24, TIMER24, TIMER24);
+impl_timer!(TIMER00, TIMER00, TIMER00, 6);
+impl_timer!(TIMER10, TIMER10, TIMER10, 8);
+impl_timer!(TIMER20, TIMER20, TIMER20, 6);
+impl_timer!(TIMER21, TIMER21, TIMER21, 6);
+impl_timer!(TIMER22, TIMER22, TIMER22, 6);
+impl_timer!(TIMER23, TIMER23, TIMER23, 6);
+impl_timer!(TIMER24, TIMER24, TIMER24, 6);
 
 impl_twim!(SERIAL20, TWIM20, SERIAL20);
 impl_twim!(SERIAL21, TWIM21, SERIAL21);

--- a/embassy-nrf/src/chips/nrf54l10_app.rs
+++ b/embassy-nrf/src/chips/nrf54l10_app.rs
@@ -623,13 +623,13 @@ impl_ppi_group!(PPI20_GROUP5, DPPIC20, 5);
 impl_ppi_group!(PPI30_GROUP0, DPPIC30, 0);
 impl_ppi_group!(PPI30_GROUP1, DPPIC30, 1);
 
-impl_timer!(TIMER00, TIMER00, TIMER00);
-impl_timer!(TIMER10, TIMER10, TIMER10);
-impl_timer!(TIMER20, TIMER20, TIMER20);
-impl_timer!(TIMER21, TIMER21, TIMER21);
-impl_timer!(TIMER22, TIMER22, TIMER22);
-impl_timer!(TIMER23, TIMER23, TIMER23);
-impl_timer!(TIMER24, TIMER24, TIMER24);
+impl_timer!(TIMER00, TIMER00, TIMER00, 6);
+impl_timer!(TIMER10, TIMER10, TIMER10, 8);
+impl_timer!(TIMER20, TIMER20, TIMER20, 6);
+impl_timer!(TIMER21, TIMER21, TIMER21, 6);
+impl_timer!(TIMER22, TIMER22, TIMER22, 6);
+impl_timer!(TIMER23, TIMER23, TIMER23, 6);
+impl_timer!(TIMER24, TIMER24, TIMER24, 6);
 
 impl_twim!(SERIAL20, TWIM20, SERIAL20);
 impl_twim!(SERIAL21, TWIM21, SERIAL21);

--- a/embassy-nrf/src/chips/nrf54l15_app.rs
+++ b/embassy-nrf/src/chips/nrf54l15_app.rs
@@ -623,13 +623,13 @@ impl_ppi_group!(PPI20_GROUP5, DPPIC20, 5);
 impl_ppi_group!(PPI30_GROUP0, DPPIC30, 0);
 impl_ppi_group!(PPI30_GROUP1, DPPIC30, 1);
 
-impl_timer!(TIMER00, TIMER00, TIMER00);
-impl_timer!(TIMER10, TIMER10, TIMER10);
-impl_timer!(TIMER20, TIMER20, TIMER20);
-impl_timer!(TIMER21, TIMER21, TIMER21);
-impl_timer!(TIMER22, TIMER22, TIMER22);
-impl_timer!(TIMER23, TIMER23, TIMER23);
-impl_timer!(TIMER24, TIMER24, TIMER24);
+impl_timer!(TIMER00, TIMER00, TIMER00, 6);
+impl_timer!(TIMER10, TIMER10, TIMER10, 8);
+impl_timer!(TIMER20, TIMER20, TIMER20, 6);
+impl_timer!(TIMER21, TIMER21, TIMER21, 6);
+impl_timer!(TIMER22, TIMER22, TIMER22, 6);
+impl_timer!(TIMER23, TIMER23, TIMER23, 6);
+impl_timer!(TIMER24, TIMER24, TIMER24, 6);
 
 impl_twim!(SERIAL20, TWIM20, SERIAL20);
 impl_twim!(SERIAL21, TWIM21, SERIAL21);

--- a/embassy-nrf/src/chips/nrf54lm20_app.rs
+++ b/embassy-nrf/src/chips/nrf54lm20_app.rs
@@ -728,13 +728,13 @@ impl_ppi_group!(PPI20_GROUP5, DPPIC20, 5);
 impl_ppi_group!(PPI30_GROUP0, DPPIC30, 0);
 impl_ppi_group!(PPI30_GROUP1, DPPIC30, 1);
 
-impl_timer!(TIMER00, TIMER00, TIMER00);
-impl_timer!(TIMER10, TIMER10, TIMER10);
-impl_timer!(TIMER20, TIMER20, TIMER20);
-impl_timer!(TIMER21, TIMER21, TIMER21);
-impl_timer!(TIMER22, TIMER22, TIMER22);
-impl_timer!(TIMER23, TIMER23, TIMER23);
-impl_timer!(TIMER24, TIMER24, TIMER24);
+impl_timer!(TIMER00, TIMER00, TIMER00, 6);
+impl_timer!(TIMER10, TIMER10, TIMER10, 8);
+impl_timer!(TIMER20, TIMER20, TIMER20, 6);
+impl_timer!(TIMER21, TIMER21, TIMER21, 6);
+impl_timer!(TIMER22, TIMER22, TIMER22, 6);
+impl_timer!(TIMER23, TIMER23, TIMER23, 6);
+impl_timer!(TIMER24, TIMER24, TIMER24, 6);
 
 impl_twim!(SERIAL20, TWIM20, SERIAL20);
 impl_twim!(SERIAL21, TWIM21, SERIAL21);


### PR DESCRIPTION
Propses fix for #5843 by explicitly specifying the channel numbers.

### Summary ###
The patch assigns a channel number of 6 for all `timer_impl!` in the chip definition of nrf54-type chips, except for TIMER10, which has 8 channels (see the [online documentation](https://docs.nordicsemi.com/bundle/ps_nrf54L15/page/timer.html))

I've kept the patch as minimal as possible intentionally. Specifically, I did not touch the timer_impl! extended case, even though I'm not sure using a boolean flag makes sense compared to simply specifying the explicit number of channels in other nrf-chips as well.
