### PR TITLE
Implement core::error::Error for more error types

### DIFF
--- a/embassy-net/CHANGELOG.md
+++ b/embassy-net/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 <!-- next-header -->
 ## Unreleased - ReleaseDate
 
+- Implement `core::error::Error` for `dns::Error`, `tcp::AcceptError`, `udp::SendError` and `udp::RecvError`.
+
 ## 0.9.1 - 2026-04-16
 
 - Avoid busy looping if network driver's TX buffer is exhausted

--- a/embassy-net/src/dns.rs
+++ b/embassy-net/src/dns.rs
@@ -118,3 +118,14 @@ impl<'a> embedded_nal_async::Dns for DnsSocket<'a> {
 fn _assert_covariant<'a, 'b: 'a>(x: DnsSocket<'b>) -> DnsSocket<'a> {
     x
 }
+
+impl core::fmt::Display for Error {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        match self {
+            Self::InvalidName => f.write_str("InvalidName"),
+            Self::NameTooLong => f.write_str("NameTooLong"),
+            Self::Failed => f.write_str("Failed"),
+        }
+    }
+}
+impl core::error::Error for Error {}

--- a/embassy-net/src/tcp.rs
+++ b/embassy-net/src/tcp.rs
@@ -1022,6 +1022,17 @@ mod embedded_io_impls {
     }
 }
 
+impl core::fmt::Display for AcceptError {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        match self {
+            Self::InvalidState => f.write_str("InvalidState"),
+            Self::InvalidPort => f.write_str("InvalidPort"),
+            Self::ConnectionReset => f.write_str("ConnectionReset"),
+        }
+    }
+}
+impl core::error::Error for AcceptError {}
+
 /// TCP client compatible with `embedded-nal-async` traits.
 pub mod client {
     use core::cell::{Cell, UnsafeCell};

--- a/embassy-net/src/udp.rs
+++ b/embassy-net/src/udp.rs
@@ -512,3 +512,23 @@ impl Drop for UdpSocket<'_> {
 fn _assert_covariant<'a, 'b: 'a>(x: UdpSocket<'b>) -> UdpSocket<'a> {
     x
 }
+
+impl core::fmt::Display for SendError {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        match self {
+            Self::NoRoute => f.write_str("NoRoute"),
+            Self::SocketNotBound => f.write_str("SocketNotBound"),
+            Self::PacketTooLarge => f.write_str("PacketTooLarge"),
+        }
+    }
+}
+impl core::error::Error for SendError {}
+
+impl core::fmt::Display for RecvError {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        match self {
+            Self::Truncated => f.write_str("Truncated"),
+        }
+    }
+}
+impl core::error::Error for RecvError {}

--- a/embassy-sync/CHANGELOG.md
+++ b/embassy-sync/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Added `Pipe::try_write_all` method which repeatedly calls `Pipe::try_write` until all
   bytes were written.
+- Implement `core::error::Error` for `channel::TryReceiveError` and `channel::TrySendError`.
 
 ## 0.8.0 - 2026-03-10
 - Fix wakers getting dropped by `Signal::reset`

--- a/embassy-sync/src/channel.rs
+++ b/embassy-sync/src/channel.rs
@@ -1056,6 +1056,24 @@ where
     }
 }
 
+impl core::fmt::Display for TryReceiveError {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        match self {
+            Self::Empty => f.write_str("Empty"),
+        }
+    }
+}
+impl core::error::Error for TryReceiveError {}
+
+impl<T> core::fmt::Display for TrySendError<T> {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        match self {
+            Self::Full(_) => f.write_str("Full"),
+        }
+    }
+}
+impl<T: core::fmt::Debug> core::error::Error for TrySendError<T> {}
+
 #[cfg(test)]
 mod tests {
     use core::time::Duration;

--- a/embassy-time/CHANGELOG.md
+++ b/embassy-time/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 <!-- next-header -->
 ## Unreleased - ReleaseDate
 
+- Implement `core::error::Error` for `TimeoutError`.
+
 ## 0.5.1 - 2026-03-11
 
 - Add `as_nanos` and `from_nanos` where missing

--- a/embassy-time/src/timer.rs
+++ b/embassy-time/src/timer.rs
@@ -304,3 +304,10 @@ impl FusedStream for Ticker {
         false
     }
 }
+
+impl core::fmt::Display for TimeoutError {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.write_str("TimeoutError")
+    }
+}
+impl core::error::Error for TimeoutError {}


### PR DESCRIPTION
Closes #5917.

Add `core::fmt::Display` and `core::error::Error` impls for `dns::Error`, `tcp::AcceptError`, `udp::SendError`, `udp::RecvError`, `time::TimeoutError`, `channel::TryReceiveError` and `channel::TrySendError`. Mirrors the existing pattern for `tcp::ConnectError` and `tcp::Error` in `embassy-net/src/tcp.rs`.

`core::error::Error` is stable since Rust 1.81; `rust-toolchain.toml` is pinned to 1.92. The README still claims MSRV 1.75, but `tcp::ConnectError` already needs 1.81, so no new MSRV constraint is introduced here. Happy to bump the README claim or feature-gate the impls if you prefer.

CHANGELOG bumped in all three crates.
