### PR TITLE
stm32/i2c: Fix 10-bit slave address detection in determine_matched_address()

### DIFF
--- a/embassy-stm32/src/i2c/v2.rs
+++ b/embassy-stm32/src/i2c/v2.rs
@@ -1622,12 +1622,9 @@ impl<'d, M: Mode> I2c<'d, M, MultiMaster> {
     fn determine_matched_address(&self) -> Result<Address, Error> {
         let matched = self.info.regs.isr().read().addcode();
 
-        if matched >> 3 == 0b11110 {
-            // is 10-bit address and we need to get the other 8 bits from the rxdr
-            // we do this by doing a blocking read of 1 byte
-            let mut buffer = [0];
-            self.slave_read_internal(&mut buffer, self.timeout())?;
-            Ok(Address::TenBit((matched as u16) << 6 | buffer[0] as u16))
+        if matched >> 2 == 0b11110 {
+            let address = self.info.regs.oar1().read().oa1();
+            Ok(Address::TenBit(address))
         } else {
             Ok(Address::SevenBit(matched))
         }


### PR DESCRIPTION
Fixes https://github.com/embassy-rs/embassy/issues/5969
### Problem

When using I2C slave mode with a 10-bit address, `listen()` returns an incorrect 7-bit address. For example, configuring address `TenBit(391)` results in `SevenBit(121)`.

### Root Cause

Two issues in `determine_matched_address()`:

1. **Incorrect bit shift**: The `addcode()` field from ISR is 7 bits. For 10-bit address detection, comparing `matched >> 3 == 0b11110` is wrong - it should be `matched >> 2 == 0b11110` (since `0b11110XX >> 2 = 0x1E`).

2. **Wrong address retrieval**: The current code attempts to read the second address byte from RXDR via `slave_read_internal()`. According to RM0456, the hardware consumes both address bytes during address matching and does not store them in RXDR. The correct approach is to read the configured address from the OAR1 register.

### Solution

- Change the bit shift from 3 to 2 for 10-bit address detection
- Retrieve the address from `self.info.regs.oar1().read().oa1()` instead of reading from RXDR

### Testing
```rust
#[embassy_executor::task]
async fn task1_i2c(i2c: embassy_stm32::i2c::I2c<'static, embassy_stm32::mode::Async, i2c::Master>) {
    let mut i2c = i2c.into_slave_multimaster(SlaveAddrConfig { addr: i2c::OwnAddresses::OA1(Address::TenBit(391)), general_call: false });
    let mut buf = [0u8;10];
    loop {
        match i2c.listen().await {
            Ok(slave) => {
                defmt::info!("slave command: {:?}", slave);
                i2c.respond_to_write(&mut buf).await.unwrap();
                let s = str::from_utf8(&buf[0..4]).unwrap();
                defmt::info!("buf: {:?}", s);
            },
            Err(e) => {
                defmt::error!("failed to listen: {:?}", e);
                Timer::after_secs(1).await;
            },
        }
    }
}
```
With this fix, `listen()` correctly returns `TenBit(391)` instead of `SevenBit(121)`.

### Related

STM32 RM0456