### PR TITLE
cyw: propagate aligned type

### DIFF
--- a/cyw43/Cargo.toml
+++ b/cyw43/Cargo.toml
@@ -18,6 +18,7 @@ bluetooth = ["dep:bt-hci", "dep:embedded-io-async"]
 firmware-logs = []
 
 [dependencies]
+embassy-hal-internal = { version = "0.5.0", path = "../embassy-hal-internal", features=["aligned"]}
 embassy-time = { version = "0.5.1", path = "../embassy-time"}
 embassy-sync = { version = "0.8.0", path = "../embassy-sync"}
 embassy-futures = { version = "0.1.2", path = "../embassy-futures"}

--- a/cyw43/src/runner.rs
+++ b/cyw43/src/runner.rs
@@ -979,7 +979,7 @@ impl<'a, BUS: Bus, CHIP: Chip> Runner<'a, BUS, CHIP> {
                     }
 
                     if len == SdpcmHeader::SIZE {
-                        let Some((sdpcm_header, _)) = SdpcmHeader::parse(&mut buf[..3]) else {
+                        let Some((sdpcm_header, _)) = SdpcmHeader::parse(&mut buf[..len]) else {
                             debug!("failed to parse sdpcm header");
                             break;
                         };

--- a/cyw43/src/runner.rs
+++ b/cyw43/src/runner.rs
@@ -3,6 +3,7 @@ use core::sync::atomic::Ordering::Relaxed;
 
 use aligned::{A4, Aligned};
 use embassy_futures::select::{Either4, select4};
+use embassy_hal_internal::aligned::{AsAlignedSlice, AsMutAlignedSlice};
 use embassy_net_driver_channel as ch;
 use embassy_net_driver_channel::driver::LinkState;
 use embassy_time::Duration;
@@ -16,7 +17,7 @@ use crate::fmt::Bytes;
 use crate::ioctl::{IoctlState, IoctlType, PendingIoctl};
 pub use crate::spi::SpiBusCyw43;
 use crate::structs::*;
-use crate::util::{aligned_mut, aligned_ref, slice8_mut, slice16_mut, try_until};
+use crate::util::try_until;
 use crate::{Chip, ChipId, Core, MTU, WithContext, events, sdio};
 
 #[cfg(feature = "firmware-logs")]
@@ -717,7 +718,7 @@ impl<'a, BUS: Bus, CHIP: Chip> Runner<'a, BUS, CHIP> {
 
     /// Run the CYW43 event handling loop.
     pub async fn run(mut self) -> ! {
-        let mut buf = [0; 512];
+        let mut buf: Aligned<A4, [u8; _]> = Aligned([0u8; 2048]);
         loop {
             #[cfg(feature = "firmware-logs")]
             self.log_read().await;
@@ -758,7 +759,7 @@ impl<'a, BUS: Bus, CHIP: Chip> Runner<'a, BUS, CHIP> {
                     Either4::Second(packet) => {
                         trace!("tx pkt {:02x}", Bytes(&packet[..packet.len().min(48)]));
 
-                        let buf8 = slice8_mut(&mut buf);
+                        let buf8 = &mut buf[..];
 
                         // There MUST be 2 bytes of padding between the SDPCM and BDC headers.
                         // And ONLY for data packets!
@@ -805,7 +806,7 @@ impl<'a, BUS: Bus, CHIP: Chip> Runner<'a, BUS, CHIP> {
 
                         trace!("    {:02x}", Bytes(&buf8[..total_len.min(48)]));
 
-                        let _ = wlan_write(&mut self.bus, &aligned_ref(&buf)[..total_len]).await;
+                        let _ = wlan_write(&mut self.bus, &buf.as_aligned_slice()[..total_len]).await;
                         packet.tx_done();
                         self.check_status(&mut buf).await;
                     }
@@ -840,7 +841,7 @@ impl<'a, BUS: Bus, CHIP: Chip> Runner<'a, BUS, CHIP> {
     }
 
     /// Wait for IRQ on F2 packet available
-    async fn handle_irq(&mut self, buf: &mut [u32; 512]) {
+    async fn handle_irq(&mut self, buf: &mut Aligned<A4, [u8; 2048]>) {
         match BUS::TYPE {
             BusType::Sdio => {
                 let irq = self
@@ -915,7 +916,7 @@ impl<'a, BUS: Bus, CHIP: Chip> Runner<'a, BUS, CHIP> {
     }
 
     /// Handle F2 events while status register is set
-    async fn check_status(&mut self, buf: &mut [u32; 512]) {
+    async fn check_status(&mut self, buf: &mut Aligned<A4, [u8; 2048]>) {
         loop {
             match self.bus.bus_type() {
                 BusType::Spi => {
@@ -924,26 +925,32 @@ impl<'a, BUS: Bus, CHIP: Chip> Runner<'a, BUS, CHIP> {
 
                     if status & STATUS_F2_PKT_AVAILABLE != 0 {
                         let len = (status & STATUS_F2_PKT_LEN_MASK) >> STATUS_F2_PKT_LEN_SHIFT;
-                        if wlan_read(&mut self.bus, &mut aligned_mut(buf)[..len as usize])
+                        if wlan_read(&mut self.bus, &mut buf.as_mut_aligned_slice()[..len as usize])
                             .await
                             .is_err()
                         {
                             debug!("spi wlan_read failed");
                             break;
                         }
-                        trace!("rx {:02x}", Bytes(&slice8_mut(buf)[..(len as usize).min(48)]));
-                        self.rx(&mut slice8_mut(buf)[..len as usize]);
+                        trace!("rx {:02x}", Bytes(&mut buf[..(len as usize).min(48)]));
+                        self.rx(&mut buf[..len as usize]);
                     } else {
                         break;
                     }
                 }
                 BusType::Sdio => {
-                    if wlan_read(&mut self.bus, &mut aligned_mut(&mut buf[..1])).await.is_err() {
+                    if wlan_read(&mut self.bus, &mut buf.as_mut_aligned_slice()[..4])
+                        .await
+                        .is_err()
+                    {
                         debug!("failed to read sdio hwtag");
                         break;
                     }
                     let (len, len_inv) = {
-                        let hwtag = slice16_mut(&mut buf[..1]);
+                        let hwtag = [
+                            u16::from_le_bytes(buf[..2].try_into().unwrap()),
+                            u16::from_le_bytes(buf[2..4].try_into().unwrap()),
+                        ];
 
                         (hwtag[0], hwtag[1])
                     };
@@ -958,7 +965,7 @@ impl<'a, BUS: Bus, CHIP: Chip> Runner<'a, BUS, CHIP> {
                     if len > INITIAL_READ as usize {
                         if self
                             .bus
-                            .wlan_read(&mut aligned_mut(&mut buf[1..])[..len - INITIAL_READ as usize])
+                            .wlan_read(&mut buf.as_mut_aligned_slice()[4..][..len - INITIAL_READ as usize])
                             .await
                             .is_err()
                         {
@@ -972,15 +979,15 @@ impl<'a, BUS: Bus, CHIP: Chip> Runner<'a, BUS, CHIP> {
                     }
 
                     if len == SdpcmHeader::SIZE {
-                        let Some((sdpcm_header, _)) = SdpcmHeader::parse(slice8_mut(&mut buf[..3])) else {
+                        let Some((sdpcm_header, _)) = SdpcmHeader::parse(&mut buf[..3]) else {
                             debug!("failed to parse sdpcm header");
                             break;
                         };
 
                         self.update_credit(&sdpcm_header);
                     } else if len > SdpcmHeader::SIZE {
-                        trace!("rx {:02x}", Bytes(&slice8_mut(buf)[..len.min(48)]));
-                        self.rx(&mut slice8_mut(buf)[..len]);
+                        trace!("rx {:02x}", Bytes(&buf[..len.min(48)]));
+                        self.rx(&mut buf[..len]);
                     }
                 }
             }
@@ -1194,8 +1201,15 @@ impl<'a, BUS: Bus, CHIP: Chip> Runner<'a, BUS, CHIP> {
         self.sdpcm_seq != self.sdpcm_seq_max && self.sdpcm_seq_max.wrapping_sub(self.sdpcm_seq) & 0x80 == 0
     }
 
-    async fn send_ioctl(&mut self, kind: IoctlType, cmd: Ioctl, iface: u32, data: &[u8], buf: &mut [u32; 512]) {
-        let buf8 = slice8_mut(buf);
+    async fn send_ioctl(
+        &mut self,
+        kind: IoctlType,
+        cmd: Ioctl,
+        iface: u32,
+        data: &[u8],
+        buf: &mut Aligned<A4, [u8; 2048]>,
+    ) {
+        let buf8 = &mut buf[..];
 
         let total_len = SdpcmHeader::SIZE + CdcHeader::SIZE + data.len();
 
@@ -1232,6 +1246,6 @@ impl<'a, BUS: Bus, CHIP: Chip> Runner<'a, BUS, CHIP> {
         let total_len = (total_len + 3) & !3; // round up to 4byte,
         trace!("    {:02x}", Bytes(&buf8[..total_len.min(48)]));
 
-        let _ = wlan_write(&mut self.bus, &aligned_ref(buf)[..total_len]).await;
+        let _ = wlan_write(&mut self.bus, &buf.as_aligned_slice()[..total_len]).await;
     }
 }

--- a/cyw43/src/sdio.rs
+++ b/cyw43/src/sdio.rs
@@ -1,12 +1,13 @@
-use core::slice;
+use core::{mem, slice};
 
 use aligned::{A4, Aligned};
+use embassy_hal_internal::aligned::{AsAlignedSlice, AsMutAlignedSlice};
 use embassy_time::{Duration, Timer};
 
 use crate::WithContext;
 use crate::consts::*;
 use crate::runner::{BusConfig, BusType, SealedBus};
-use crate::util::{aligned_mut, aligned_ref, slice32_mut, slice32_ref, try_until};
+use crate::util::try_until;
 
 // macro_rules! ALIGN_UINT {
 //     ($val:expr, $align:expr) => {
@@ -400,9 +401,9 @@ where
 
         // align buffer len
         // note: safe because align is checked above
-        let mut data = aligned_mut(slice32_mut(unsafe { core::mem::transmute(data) }));
+        let mut data: &mut Aligned<A4, [u8]> = unsafe { mem::transmute(data) };
 
-        while !data.is_empty() {
+        loop {
             // Ensure transfer doesn't cross a window boundary.
             let window_offs = addr & BACKPLANE_ADDRESS_MASK;
             let window_remaining = BACKPLANE_WINDOW_SIZE - window_offs as usize;
@@ -417,7 +418,11 @@ where
 
             // Advance ptr.
             addr += len as u32;
-            data = &mut data[len..];
+            if data.len() == len {
+                break;
+            } else {
+                data = &mut data[len..];
+            }
         }
 
         self.backplane_set_window(CHIPCOMMON_BASE_ADDRESS).await;
@@ -438,9 +443,9 @@ where
 
         // align buffer len
         // note: safe because align is checked above
-        let mut data = aligned_ref(slice32_ref(unsafe { core::mem::transmute(data) }));
+        let mut data: &Aligned<A4, [u8]> = unsafe { mem::transmute(data) };
 
-        while !data.is_empty() {
+        loop {
             // Ensure transfer doesn't cross a window boundary.
             let window_offs = addr & BACKPLANE_ADDRESS_MASK;
             let window_remaining = BACKPLANE_WINDOW_SIZE - window_offs as usize;
@@ -455,7 +460,11 @@ where
 
             // Advance ptr.
             addr += len as u32;
-            data = &data[len..];
+            if data.len() == len {
+                break;
+            } else {
+                data = &data[len..];
+            }
         }
 
         self.backplane_set_window(CHIPCOMMON_BASE_ADDRESS).await;
@@ -498,25 +507,27 @@ where
     }
 
     async fn read16(&mut self, func: u32, addr: u32) -> u16 {
-        let mut val = [0u32];
-        let _ = self.cmd53_read(func, addr, &mut aligned_mut(&mut val)[..2]).await;
+        let mut val: Aligned<A4, [u8; _]> = Aligned([0u8; 2]);
+        let _ = self.cmd53_read(func, addr, val.as_mut_aligned_slice()).await;
 
-        u16::from_be_bytes(val[0].to_be_bytes()[..2].try_into().unwrap())
+        u16::from_le_bytes(*val)
     }
 
     async fn write16(&mut self, func: u32, addr: u32, val: u16) {
-        let _ = self.cmd53_write(func, addr, &aligned_ref(&[val as u32])[..2]).await;
+        let val: Aligned<A4, [u8; 2]> = Aligned(val.to_le_bytes().into());
+        let _ = self.cmd53_write(func, addr, val.as_aligned_slice()).await;
     }
 
     async fn read32(&mut self, func: u32, addr: u32) -> u32 {
-        let mut val = [0u32];
-        let _ = self.cmd53_read(func, addr, &mut aligned_mut(&mut val)).await;
+        let mut val: Aligned<A4, [u8; _]> = Aligned([0u8; 4]);
+        let _ = self.cmd53_read(func, addr, val.as_mut_aligned_slice()).await;
 
-        val[0]
+        u32::from_le_bytes(*val)
     }
 
     async fn write32(&mut self, func: u32, addr: u32, val: u32) {
-        let _ = self.cmd53_write(func, addr, &aligned_ref(&[val])).await;
+        let val: Aligned<A4, [u8; 4]> = Aligned(val.to_le_bytes().into());
+        let _ = self.cmd53_write(func, addr, val.as_aligned_slice()).await;
     }
 
     async fn wait_for_event(&mut self) {

--- a/cyw43/src/spi.rs
+++ b/cyw43/src/spi.rs
@@ -1,3 +1,5 @@
+use core::slice;
+
 use aligned::{A4, Aligned};
 use embassy_futures::yield_now;
 use embassy_time::Timer;
@@ -6,7 +8,6 @@ use futures::FutureExt;
 
 use crate::consts::*;
 use crate::runner::{BusConfig, BusType, SealedBus};
-use crate::util::{slice8_mut, slice32_mut, slice32_ref};
 
 /// Custom Spi Trait that _only_ supports the bus operation of the cyw43
 /// Implementors are expected to hold the CS pin low during an operation.
@@ -27,6 +28,16 @@ pub trait SpiBusCyw43 {
     async fn wait_for_event(&mut self) {
         yield_now().await;
     }
+}
+
+const fn slice32_mut(x: &mut Aligned<A4, [u8]>) -> &mut [u32] {
+    let len = (size_of_val(x) + 3) / 4;
+    unsafe { slice::from_raw_parts_mut(x as *mut Aligned<A4, [u8]> as *mut u32, len) }
+}
+
+const fn slice32_ref(x: &Aligned<A4, [u8]>) -> &[u32] {
+    let len = (size_of_val(x) + 3) / 4;
+    unsafe { slice::from_raw_parts(x as *const Aligned<A4, [u8]> as *const u32, len) }
 }
 
 /// Doc
@@ -272,7 +283,6 @@ where
         Ok(())
     }
 
-    #[allow(unused)]
     async fn bp_read(&mut self, mut addr: u32, mut data: &mut [u8]) -> crate::Result<()> {
         trace!("bp_read addr = {:08x}", addr);
 
@@ -283,7 +293,7 @@ where
         assert!(addr % 4 == 0);
 
         // Backplane read buffer has one extra word for the response delay.
-        let mut buf = [0u32; BACKPLANE_MAX_TRANSFER_SIZE / 4 + 1];
+        let mut buf: Aligned<A4, [u8; _]> = Aligned([0u8; 4 + BACKPLANE_MAX_TRANSFER_SIZE]);
 
         while !data.is_empty() {
             // Ensure transfer doesn't cross a window boundary.
@@ -297,10 +307,13 @@ where
             let cmd = cmd_word(READ, INC_ADDR, FUNC_BACKPLANE, window_offs, len as u32);
 
             // round `buf` to word boundary, add one extra word for the response delay
-            self.status = self.spi.cmd_read(cmd, &mut buf[..(len + 3) / 4 + 1]).await;
+            self.status = self
+                .spi
+                .cmd_read(cmd, &mut slice32_mut(&mut buf)[..(len + 3) / 4 + 1])
+                .await;
 
             // when writing out the data, we skip the response-delay byte
-            data[..len].copy_from_slice(&slice8_mut(&mut buf[1..])[..len]);
+            data[..len].copy_from_slice(&mut buf[4..][..len]);
 
             // Advance ptr.
             addr += len as u32;
@@ -319,7 +332,7 @@ where
         // To simplify, enforce 4-align for now.
         assert!(addr % 4 == 0);
 
-        let mut buf = [0u32; BACKPLANE_MAX_TRANSFER_SIZE / 4 + 1];
+        let mut buf: Aligned<A4, [u8; _]> = Aligned([0u8; 4 + BACKPLANE_MAX_TRANSFER_SIZE]);
 
         while !data.is_empty() {
             // Ensure transfer doesn't cross a window boundary.
@@ -327,14 +340,14 @@ where
             let window_remaining = BACKPLANE_WINDOW_SIZE - window_offs as usize;
 
             let len = data.len().min(BACKPLANE_MAX_TRANSFER_SIZE).min(window_remaining);
-            slice8_mut(&mut buf[1..])[..len].copy_from_slice(&data[..len]);
+            buf[4..][..len].copy_from_slice(&data[..len]);
 
             self.backplane_set_window(addr).await;
 
             let cmd = cmd_word(WRITE, INC_ADDR, FUNC_BACKPLANE, window_offs, len as u32);
-            buf[0] = cmd;
+            slice32_mut(&mut buf)[0] = cmd;
 
-            self.status = self.spi.cmd_write(&buf[..(len + 3) / 4 + 1]).await;
+            self.status = self.spi.cmd_write(&slice32_ref(&buf)[..(len + 3) / 4 + 1]).await;
 
             // Advance ptr.
             addr += len as u32;

--- a/cyw43/src/util.rs
+++ b/cyw43/src/util.rs
@@ -1,6 +1,6 @@
 #![allow(unused)]
 
-use core::slice;
+use core::{mem, ptr, slice};
 
 use aligned::{A4, Aligned};
 use embassy_time::{Duration, Ticker};
@@ -49,36 +49,6 @@ macro_rules! enum_from_u8 {
     };
 }
 pub(crate) use enum_from_u8;
-
-pub(crate) const fn slice8_mut(x: &mut [u32]) -> &mut [u8] {
-    let len = size_of_val(x);
-    unsafe { slice::from_raw_parts_mut(x.as_mut_ptr() as _, len) }
-}
-
-pub(crate) const fn slice16_mut(x: &mut [u32]) -> &mut [u16] {
-    let len = size_of_val(x) / 2;
-    unsafe { slice::from_raw_parts_mut(x.as_mut_ptr() as _, len) }
-}
-
-pub(crate) const fn aligned_mut(x: &mut [u32]) -> &mut Aligned<A4, [u8]> {
-    let len = size_of_val(x);
-    unsafe { core::mem::transmute(slice::from_raw_parts_mut(x.as_mut_ptr() as *mut u8, len)) }
-}
-
-pub(crate) const fn aligned_ref(x: &[u32]) -> &Aligned<A4, [u8]> {
-    let len = size_of_val(x);
-    unsafe { core::mem::transmute(slice::from_raw_parts(x.as_ptr() as *const u8, len)) }
-}
-
-pub(crate) const fn slice32_mut(x: &mut Aligned<A4, [u8]>) -> &mut [u32] {
-    let len = (size_of_val(x) + 3) / 4;
-    unsafe { slice::from_raw_parts_mut(x as *mut Aligned<A4, [u8]> as *mut u32, len) }
-}
-
-pub(crate) const fn slice32_ref(x: &Aligned<A4, [u8]>) -> &[u32] {
-    let len = (size_of_val(x) + 3) / 4;
-    unsafe { slice::from_raw_parts(x as *const Aligned<A4, [u8]> as *const u32, len) }
-}
 
 pub(crate) fn is_aligned(a: u32, x: u32) -> bool {
     (a & (x - 1)) == 0

--- a/embassy-hal-internal/Cargo.toml
+++ b/embassy-hal-internal/Cargo.toml
@@ -13,7 +13,7 @@ categories = [
 ]
 
 [features]
-
+aligned = ["dep:aligned", "dep:as-slice"]
 defmt = ["dep:defmt"]
 log = ["dep:log"]
 
@@ -33,6 +33,8 @@ cortex-m = ["dep:cortex-m", "dep:critical-section"]
 [dependencies]
 defmt = { version = "1.0.1", optional = true }
 log = { version = "0.4.14", optional = true }
+aligned = { version = "0.4.3", optional = true }
+as-slice = { version = "0.2.1", optional = true }
 
 num-traits = { version = "0.2.14", default-features = false }
 

--- a/embassy-hal-internal/src/aligned.rs
+++ b/embassy-hal-internal/src/aligned.rs
@@ -1,0 +1,56 @@
+//! Extra traits for aligned
+
+use core::mem;
+
+use aligned::{Aligned, Alignment};
+use as_slice::{AsMutSlice, AsSlice};
+
+/// Create an aligned slice from an aligned array
+pub trait AsAlignedSlice {
+    /// Slice element
+    type Element;
+    /// Slice alignment
+    type Alignment: Alignment;
+
+    /// Create the slice
+    fn as_aligned_slice(&self) -> &Aligned<Self::Alignment, [Self::Element]>;
+}
+
+/// Create an aligned slice from an aligned array
+pub trait AsMutAlignedSlice {
+    /// Slice element
+    type Element;
+    /// Slice alignment
+    type Alignment: Alignment;
+
+    /// Create the slice
+    fn as_mut_aligned_slice(&mut self) -> &mut Aligned<Self::Alignment, [Self::Element]>;
+}
+
+impl<A, T> AsAlignedSlice for Aligned<A, T>
+where
+    A: Alignment,
+    T: AsSlice,
+{
+    type Element = T::Element;
+    type Alignment = A;
+
+    #[inline]
+    fn as_aligned_slice(&self) -> &Aligned<A, [T::Element]> {
+        unsafe { mem::transmute(T::as_slice(&**self)) }
+    }
+}
+
+impl<A, T> AsMutAlignedSlice for Aligned<A, T>
+where
+    A: Alignment,
+    T: AsMutSlice,
+{
+    type Element = T::Element;
+    type Alignment = A;
+
+    #[inline]
+    fn as_mut_aligned_slice(&mut self) -> &mut Aligned<A, [T::Element]> {
+        unsafe { mem::transmute(T::as_mut_slice(&mut **self)) }
+    }
+}

--- a/embassy-hal-internal/src/lib.rs
+++ b/embassy-hal-internal/src/lib.rs
@@ -7,6 +7,8 @@
 // This mod MUST go first, so that the others see its macros.
 pub(crate) mod fmt;
 
+#[cfg(feature = "aligned")]
+pub mod aligned;
 pub mod atomic_ring_buffer;
 pub mod drop;
 mod macros;


### PR DESCRIPTION
propagate the aligned type in the driver and remove the util functions to hal-internal where needed.