### PR TITLE
stm32/usb: implement remote_wakeup() for non-OTG peripheral

### DIFF
--- a/embassy-stm32/src/usb/usb.rs
+++ b/embassy-stm32/src/usb/usb.rs
@@ -739,7 +739,24 @@ impl<'d, T: Instance> driver::Bus for Bus<'d, T> {
     async fn disable(&mut self) {}
 
     async fn remote_wakeup(&mut self) -> Result<(), Unsupported> {
-        Err(Unsupported)
+        let regs = T::regs();
+        // Wake transceiver from low-power mode
+        regs.cntr().modify(|w| w.set_lpmode(false));
+        // Drive K-state while FSUSP is still set
+        regs.cntr().modify(|w| w.set_resume(true));
+        #[cfg(feature = "time")]
+        embassy_time::Timer::after_millis(10).await;
+        #[cfg(not(feature = "time"))]
+        {
+            let freq = unsafe { crate::rcc::get_freqs() }.sys.to_hertz().unwrap().0 as u64;
+            let cycles = freq * 10 / 1_000;
+            cortex_m::asm::delay(cycles as u32);
+        }
+        regs.cntr().modify(|w| w.set_resume(false));
+        // Exit forced-suspend so the peripheral can handle the
+        // host's resume response
+        regs.cntr().modify(|w| w.set_fsusp(false));
+        Ok(())
     }
 }
 


### PR DESCRIPTION
remote_wakeup() in the non-OTG USB driver (usb.rs, F1/F3/L1 family) is stubbed to return Err(Unsupported). A device on this peripheral can't wake a suspended host. The resume signal is never driven on the bus, regardless of descriptor flags or host configuration.

The fix follows the device-initiated resume sequence from RM0316 §32.5.5:

1. Clear LPMODE to wake the analog transceiver
2. Set RESUME to drive K-state while FSUSP stays set
3. Hold for 10 ms (spec allows 1-15 ms)
4. Clear RESUME, then clear FSUSP

Tested on a GD32F303 running https://github.com/HaoboGu/rmk keyboard firmware.