### PR TITLE
USB: reject DEVICE_QUALIFIER req for non-HS device

### DIFF
--- a/embassy-usb/src/builder.rs
+++ b/embassy-usb/src/builder.rs
@@ -20,7 +20,7 @@ pub enum UsbVersion {
     TwoOne = 0x0210,
 }
 
-#[derive(Debug, Copy, Clone, Eq, PartialEq)]
+#[derive(Debug, Copy, Clone, Eq, PartialEq, PartialOrd)]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
 /// The fastest speed the device configuration supports.
 pub enum UsbDeviceSpeed {

--- a/embassy-usb/src/lib.rs
+++ b/embassy-usb/src/lib.rs
@@ -798,7 +798,9 @@ impl<'d, D: Driver<'d>> Inner<'d, D> {
                     }
                 }
             }
-            descriptor_type::DEVICE_QUALIFIER => InResponse::Accepted(&self.device_qualifier_descriptor),
+            descriptor_type::DEVICE_QUALIFIER if self.config.max_speed > UsbDeviceSpeed::Full => {
+                InResponse::Accepted(&self.device_qualifier_descriptor)
+            }
             _ => InResponse::Rejected,
         }
     }


### PR DESCRIPTION
As discussed in the chat recently: There is currently an issue in the stack that it will [respond ](https://github.com/embassy-rs/embassy/blob/ddbe69377fc1797bdf4ed0a4a0b7d312388e0a06/embassy-usb/src/lib.rs#L801) to a DEVICE_QUALIFIER descriptor request. 

The USB 2.0 spec (April 27, 2000) in 9.6.2, page 264 states:

> If a full-speed only device (with a device descriptor version number equal to 0200H) receives a GetDescriptor() request for a device_qualifier, it must respond with a request error.

In the current implementation this response is always sent.

# Thoughts on the actual implementation:

- In #4318 there was a proposal to add a `const` property to the `Driver` to state what the max speed of the hardware is.
- In the chat the point was that we should rather go for a function on the `Driver` so that drivers can be configured differently, depending on the hardware, even if the same driver can be used (Synopsys IP with same interface, different config).
- Some side-discussion in the chat later pointed me to the `max_speed` setting, and it seemed to make most most sense to me to use that property. Biggest reason to me would be that if a user states a `max_speed` of full-speed it shouldn't matter that the hardware is capable of doing high speed. So the actual hardware property seems less important compared to the user intent.

If a user really sets `max_speed` = high-speed, and the hardware only supports full-speed - is this something that really needs to be cought? If yes the problem here is that during the config generation there are no APIs that would allow for that to be fallible...

I'm happy to adapt this PR to any of the other options, etc - if you prefer that.