### PR TITLE
WPAN - Controller state reinit fix

### DIFF
--- a/embassy-stm32-wpan/src/bluetooth/mod.rs
+++ b/embassy-stm32-wpan/src/bluetooth/mod.rs
@@ -704,20 +704,21 @@ impl HCI<Test> {
 }
 
 impl<M: Mode> HCI<M> {
-    /// Fully tear down the BLE stack so that `Ble::new()` can be safely called again.
+    /// Fully tear down the BLE stack and return the controller state.
     ///
     /// Terminates all connections, resets the HCI controller (which resets the radio
     /// hardware to its initial state), and zeroes the host stack memory buffers so
-    /// `init_ble_stack()` can reinitialize cleanly on the next `Ble::new()` call.
+    /// `init_ble_stack()` can reinitialize cleanly on the next `HCI::new()` call.
     ///
-    /// After this returns, drop `Ble` and call `Ble::new().await` to reinitialize, then
-    /// rebuild any GATT services and restart advertising.
+    /// The returned `&'static mut ControllerState` can be passed directly to the next
+    /// `HCI::new()` or `HCI::new_dtm()` call, enabling multiple DTM cycles per boot
+    /// without re-initializing the underlying static buffers.
     ///
     /// # Returns
     ///
-    /// - `Ok(())` on success
+    /// - `Ok(&'static mut ControllerState)` on success
     /// - `Err(BleError)` if the HCI reset failed
-    pub fn deinit(&mut self) -> Result<(), BleError> {
+    pub fn deinit(mut self) -> Result<&'static mut ControllerState, BleError> {
         // Terminate all active connections cleanly
         for conn in self.connections.iter() {
             // 0x16 = "local host terminated connection"
@@ -729,7 +730,7 @@ impl<M: Mode> HCI<M> {
         self.cmd_sender.reset()?;
 
         self.is_advertising = false;
-        Ok(())
+        Ok(self.controller.into_state())
     }
 
     /// Read the next BLE event

--- a/embassy-stm32-wpan/src/bluetooth/mod.rs
+++ b/embassy-stm32-wpan/src/bluetooth/mod.rs
@@ -730,7 +730,7 @@ impl<M: Mode> HCI<M> {
         self.cmd_sender.reset()?;
 
         self.is_advertising = false;
-        Ok(self.controller.into_state())
+        Ok(self.controller.release_state())
     }
 
     /// Read the next BLE event

--- a/embassy-stm32-wpan/src/wba/controller.rs
+++ b/embassy-stm32-wpan/src/wba/controller.rs
@@ -115,6 +115,7 @@ macro_rules! new_controller_state {
 }
 
 pub struct Controller {
+    state: &'static mut ControllerState,
     receiver: zerocopy_channel::Receiver<'static, CriticalSectionRawMutex, ChannelPacket>,
     cmd_buf: ([u8; 255], usize),
 }
@@ -183,9 +184,16 @@ impl Controller {
         BLE_INIT_WAKER.wake();
 
         Ok(Self {
+            state,
             receiver,
             cmd_buf: ([0u8; 255], 0),
         })
+    }
+
+    /// Consume the controller and return the controller state so it can be
+    /// passed to the next `HCI::new()` or `HCI::new_dtm()` call.
+    pub fn into_state(self) -> &'static mut ControllerState {
+        self.state
     }
 
     pub async fn read_event(&mut self) -> Result<Event, event::Error> {

--- a/embassy-stm32-wpan/src/wba/controller.rs
+++ b/embassy-stm32-wpan/src/wba/controller.rs
@@ -115,7 +115,7 @@ macro_rules! new_controller_state {
 }
 
 pub struct Controller {
-    state: &'static mut ControllerState,
+    state_ptr: *mut ControllerState,
     receiver: zerocopy_channel::Receiver<'static, CriticalSectionRawMutex, ChannelPacket>,
     cmd_buf: ([u8; 255], usize),
 }
@@ -133,6 +133,7 @@ impl Controller {
         _irq: impl interrupt::typelevel::Binding<interrupt::typelevel::RADIO, HighInterruptHandler>
         + interrupt::typelevel::Binding<interrupt::typelevel::HASH, LowInterruptHandler>,
     ) -> Result<Self, BleError> {
+        let state_ptr = state as *mut ControllerState;
         let (sender, receiver) = state.channel.split();
         unsafe {
             EVENT_CHANNEL.replace(sender);
@@ -184,7 +185,7 @@ impl Controller {
         BLE_INIT_WAKER.wake();
 
         Ok(Self {
-            state,
+            state_ptr,
             receiver,
             cmd_buf: ([0u8; 255], 0),
         })
@@ -192,8 +193,12 @@ impl Controller {
 
     /// Consume the controller and return the controller state so it can be
     /// passed to the next `HCI::new()` or `HCI::new_dtm()` call.
-    pub fn into_state(self) -> &'static mut ControllerState {
-        self.state
+    pub(crate) fn release_state(self) -> &'static mut ControllerState {
+        let ptr = self.state_ptr;
+        // Drop self first — runs Drop (reset_ble_stack) and drops receiver —
+        // so no references into *ptr exist before we reconstruct the &'static mut.
+        drop(self);
+        unsafe { &mut *ptr }
     }
 
     pub async fn read_event(&mut self) -> Result<Event, event::Error> {

--- a/examples/stm32wba/src/bin/ble_dtm_runtime.rs
+++ b/examples/stm32wba/src/bin/ble_dtm_runtime.rs
@@ -197,9 +197,7 @@ async fn main(spawner: Spawner) {
                 state = ble.deinit().expect("deinit failed");
 
                 // Initialize a minimal DTM-only instance (no GAP/GATT needed for DTM)
-                let mut dtm_ble = HCI::new_dtm(state, rng, Irqs)
-                    .await
-                    .expect("DTM initialization failed");
+                let mut dtm_ble = HCI::new_dtm(state, rng, Irqs).await.expect("DTM initialization failed");
 
                 run_dtm_test(&mut dtm_ble, expected).await;
 
@@ -209,9 +207,7 @@ async fn main(spawner: Spawner) {
                 state = dtm_ble.deinit().expect("deinit after DTM failed");
 
                 // Reinitialize full BLE stack with the same state
-                ble = HCI::new(state, rng, aes, pka, Irqs)
-                    .await
-                    .expect("BLE reinit failed");
+                ble = HCI::new(state, rng, aes, pka, Irqs).await.expect("BLE reinit failed");
 
                 // Rebuild GATT services (cleared by hci_reset inside deinit)
                 let mut gatt = ble.gatt_server();

--- a/examples/stm32wba/src/bin/ble_dtm_runtime.rs
+++ b/examples/stm32wba/src/bin/ble_dtm_runtime.rs
@@ -34,7 +34,7 @@ use embassy_stm32_wpan::bluetooth::gatt::{CharProperties, GattEventMask, Securit
 use embassy_stm32_wpan::bluetooth::hci::types::DtmPacketPayload;
 use embassy_stm32_wpan::bluetooth::{HCI, Normal, Test};
 use embassy_stm32_wpan::{
-    HighInterruptHandler, LowInterruptHandler, ble_runner, declare_controller_state, use_controller_state,
+    ControllerState, HighInterruptHandler, LowInterruptHandler, ble_runner, new_controller_state,
 };
 use embassy_sync::blocking_mutex::Mutex;
 use embassy_sync::blocking_mutex::raw::CriticalSectionRawMutex;
@@ -131,19 +131,11 @@ async fn main(spawner: Spawner) {
     // Spawn the BLE runner task (required for proper BLE operation)
     spawner.spawn(ble_runner_task().expect("Failed to spawn BLE runner"));
 
-    // Create controller state
-    declare_controller_state!(EVENT_BUFFER, EVENT_CHANNEL, 8);
-
-    // Initialize BLE stack
-    let mut ble = HCI::new(
-        use_controller_state!(EVENT_BUFFER, EVENT_CHANNEL, 8),
-        rng,
-        aes,
-        pka,
-        Irqs,
-    )
-    .await
-    .expect("BLE initialization failed");
+    // Initialize BLE stack — state is stored and passed through each reinit
+    let mut state: &'static mut ControllerState = new_controller_state!(8);
+    let mut ble = HCI::new(state, rng, aes, pka, Irqs)
+        .await
+        .expect("BLE initialization failed");
 
     info!("BLE stack initialized");
 
@@ -200,35 +192,26 @@ async fn main(spawner: Spawner) {
                 info!("Button pressed — entering DTM mode");
 
                 // deinit terminates connections and advertising via hci_reset(),
-                // leaving the LL in a clean idle state regardless of current BLE state.
-                ble.deinit().expect("deinit failed");
-
-                drop(ble);
+                // leaving the LL in a clean idle state. State is returned so it
+                // can be passed directly to the next HCI instance.
+                state = ble.deinit().expect("deinit failed");
 
                 // Initialize a minimal DTM-only instance (no GAP/GATT needed for DTM)
-                let mut dtm_ble = HCI::new_dtm(use_controller_state!(EVENT_BUFFER, EVENT_CHANNEL, 8), rng, Irqs)
+                let mut dtm_ble = HCI::new_dtm(state, rng, Irqs)
                     .await
-                    .expect("BLE initialization failed");
+                    .expect("DTM initialization failed");
 
                 run_dtm_test(&mut dtm_ble, expected).await;
 
                 // Deinit the DTM instance — resets radio hardware so PhyStartClbr
                 // succeeds when advertising is configured after full BLE reinit.
                 info!("DTM done — reinitializing BLE stack");
-                dtm_ble.deinit().expect("deinit after DTM failed");
+                state = dtm_ble.deinit().expect("deinit after DTM failed");
 
-                drop(dtm_ble);
-
-                // Initialize BLE stack
-                ble = HCI::new(
-                    use_controller_state!(EVENT_BUFFER, EVENT_CHANNEL, 8),
-                    rng,
-                    aes,
-                    pka,
-                    Irqs,
-                )
-                .await
-                .expect("BLE initialization failed");
+                // Reinitialize full BLE stack with the same state
+                ble = HCI::new(state, rng, aes, pka, Irqs)
+                    .await
+                    .expect("BLE reinit failed");
 
                 // Rebuild GATT services (cleared by hci_reset inside deinit)
                 let mut gatt = ble.gatt_server();


### PR DESCRIPTION
Previously, HCI::deinit() took &mut self and returned (), permanently consuming the &'static mut ControllerState that was passed to HCI::new(). On any    
  subsequent reinit, callers were forced to call use_controller_state!() again — which panics on the second call because StaticCell::init() can only run    
  once. This meant the ble_dtm_runtime example would hard-fault on a button press.                                                                   
                                                                                                                                                            
  Changes:                                                                                                                                                  
                                                                                                                                                            
  - Controller now stores a *mut ControllerState raw pointer alongside the receiver. A raw pointer is used instead of &'static mut to avoid aliasing with   
  the 'static references held by the zerocopy channel receiver.
  - Controller::release_state(self) (crate-private) drops self first - running Drop and releasing all channel references - then reconstructs the &'static   
  mut ControllerState from the stored pointer. This ensures no aliasing exists at the point the reference is created.                                       
  - HCI::deinit(self) now consumes the HCI and returns Result<&'static mut ControllerState, BleError>. The caller passes the returned state directly to the
  next HCI::new() or HCI::new_dtm() call, forming a clean ownership chain with no StaticCell re-initialization required.                                    
  - ble_dtm_runtime.rs updated to use the new pattern: state = ble.deinit()? → HCI::new_dtm(state, ...) → state = dtm.deinit()? → HCI::new(state, ...).