### PR TITLE
embassy-sync: fix `PriorityChannel::poll_ready_to_send` always returns Pending

### DIFF
--- a/embassy-sync/src/priority_channel.rs
+++ b/embassy-sync/src/priority_channel.rs
@@ -438,7 +438,7 @@ where
     fn poll_ready_to_send(&mut self, cx: &mut Context<'_>) -> Poll<()> {
         self.senders_waker.register(cx.waker());
 
-        if !self.queue.len() == self.queue.capacity() {
+        if self.queue.len() != self.queue.capacity() {
             Poll::Ready(())
         } else {
             Poll::Pending


### PR DESCRIPTION
Due to what looks like a typo, the poll condition is false in (essentially) every reachable state and thus returns `Poll::Pending` when it shouldn't.

`PriorityChannel::poll_ready_to_send` doesn't seem to be used anywhere across embassy, so its effect has likely remained invisible – but it is reachable from the public API.