### PR TITLE
stm32: allow pinless pwm_advanced for hrtim

### DIFF
--- a/embassy-stm32/src/hrtim/stm32_hrtim.rs
+++ b/embassy-stm32/src/hrtim/stm32_hrtim.rs
@@ -1,7 +1,7 @@
 use core::mem::MaybeUninit;
 
 use ::stm32_hrtim::control::{HrPwmControl, HrTimOngoingCalibration};
-use ::stm32_hrtim::output::{Output1Pin, Output2Pin};
+use ::stm32_hrtim::output::{NoPin, Output1Pin, Output2Pin};
 #[cfg(hrtim_v2)]
 use ::stm32_hrtim::pac::HRTIM_TIMF;
 use ::stm32_hrtim::pac::{HRTIM_MASTER, HRTIM_TIMA, HRTIM_TIMB, HRTIM_TIMC, HRTIM_TIMD, HRTIM_TIME};
@@ -126,6 +126,14 @@ pub trait Out1Pin<TIM>: Output1Pin<TIM> {
 pub trait Out2Pin<TIM>: Output2Pin<TIM> {
     /// Connect pin to hrtim timer
     fn connect_to_hrtim(self);
+}
+
+impl<T> Out1Pin<T> for NoPin {
+    fn connect_to_hrtim(self) {}
+}
+
+impl<T> Out2Pin<T> for NoPin {
+    fn connect_to_hrtim(self) {}
 }
 
 macro_rules! pins_helper {


### PR DESCRIPTION
When I try to configure the HRTIM without pins, the finalize method call does not work, since finalize requires the Out1Pin trait, not Output1Pin, which is implemented for it.

```rust
let Parts {
    tima,
    ..
} = hrtim.hr_control();
let (calibrated, _, _) = control.wait_for_calibration();
let mut control = calibrated.constrain();

tima.pwm_advanced(NoPin, NoPin)
    .period(123)
    .finalize(&mut control);
// -^^^^^^^^ method cannot be called due to unsatisfied trait bounds
```

I suggest to implement Out1Pin for NoPin as well, so pwm_advanced can be used pinless (which is already possible for the master timer).