### PR TITLE
embassy-sync: fix OnceLock init memory ordering

### DIFF
--- a/embassy-sync/src/once_lock.rs
+++ b/embassy-sync/src/once_lock.rs
@@ -77,7 +77,7 @@ impl<T> OnceLock<T> {
 
     /// Try to get a reference to the underlying value if it exists.
     pub fn try_get(&self) -> Option<&T> {
-        if self.init.load(Ordering::Relaxed) {
+        if self.init.load(Ordering::Acquire) {
             Some(unsafe { self.get_ref_unchecked() })
         } else {
             None
@@ -92,7 +92,7 @@ impl<T> OnceLock<T> {
             // If the value is not set, set it and return Ok.
             if !self.init.load(Ordering::Relaxed) {
                 self.data.set(MaybeUninit::new(value));
-                self.init.store(true, Ordering::Relaxed);
+                self.init.store(true, Ordering::Release);
                 Ok(())
 
             // Otherwise return an error with the given value.
@@ -113,7 +113,7 @@ impl<T> OnceLock<T> {
             // If the value is not set, set it.
             if !self.init.load(Ordering::Relaxed) {
                 self.data.set(MaybeUninit::new(f()));
-                self.init.store(true, Ordering::Relaxed);
+                self.init.store(true, Ordering::Release);
             }
         });
 


### PR DESCRIPTION
OnceLock is missing ordering guarantees on the atomic `init` flag

The relaxed store to `init` in `init()`/`get_or_init()` and relaxed load from `init` in `try_get()` does not enforce a happens-before relation

Seeing `init == true` then does not guarantee that the initialized value in `data` is already visible to a concurrent reader so `try_get()` could create a reference to memory that is still uninitialized from the readers pov.

`LazyLock` already uses Acquire/Release for the same pattern.

Miri detects the bug when testing:

```rust
fn main() {
    let lock = Arc::new(OnceLock::<u64>::new());
    let l = lock.clone();
    let r = thread::spawn(move || while l.try_get().is_none() {});
    lock.init(42).unwrap();
    r.join().unwrap();
}
```

```
error: Undefined Behavior: Data race detected between (1) non-atomic write on thread `main` and (2) retag read of type `std::mem::MaybeUninit<u64>` on thread `unnamed-1` at alloc308+0x10
--> embassy-sync/src/once_lock.rs:158:9
    |
158 |         (*self.data.as_ptr()).assume_init_ref()
    |         ^^^^^^^^^^^^^^^^^^^^^ (2) just happened here
    |
help: and (1) occurred earlier here
   --> src/main.rs:10:5
    |
 10 |     lock.init(42).unwrap();
    |     ^^^^^^^^^^^^^
...
```