### PR TITLE
cyw43-pio: fix deterministic single-bit RX corruption on RP2350

### DIFF
--- a/cyw43-pio/CHANGELOG.md
+++ b/cyw43-pio/CHANGELOG.md
@@ -8,6 +8,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 <!-- next-header -->
 ## Unreleased - ReleaseDate
 
+- Fix deterministic single-bit corruption on RP2350 backplane reads by using two DMA channels (TX + RX). The single single-channel pattern raced with the PIO state machine in debug builds, causing the LSB of the last sampled word in `cmd_read` to be cleared.
+- Breaking: `PioSpi::new` now takes two `dma::Channel` arguments (TX and RX) instead of one.
+
 ## 0.10.0 - 2026-03-10
 
 - Updated to use new DMA `Channel` driver struct from embassy-rp

--- a/cyw43-pio/Cargo.toml
+++ b/cyw43-pio/Cargo.toml
@@ -12,6 +12,7 @@ documentation = "https://docs.embassy.dev/cyw43-pio"
 [dependencies]
 cyw43 = { version = "0.7.0", path = "../cyw43" }
 embassy-rp = { version = "0.10.0", path = "../embassy-rp" }
+embassy-futures = { version = "0.1.2", path = "../embassy-futures" }
 fixed = "1.23.1"
 defmt = { version = "1.0.1", optional = true }
 

--- a/cyw43-pio/src/lib.rs
+++ b/cyw43-pio/src/lib.rs
@@ -20,7 +20,8 @@ pub struct PioSpi<'d, PIO: Instance, const SM: usize> {
     cs: Output<'d>,
     sm: StateMachine<'d, PIO, SM>,
     irq: Irq<'d, PIO, 0>,
-    dma: Channel<'d>,
+    dma_tx: Channel<'d>,
+    dma_rx: Channel<'d>,
     wrap_target: u8,
 }
 
@@ -57,7 +58,8 @@ where
         cs: Output<'d>,
         dio: Peri<'d, impl PioPin>,
         clk: Peri<'d, impl PioPin>,
-        dma: Channel<'d>,
+        dma_tx: Channel<'d>,
+        dma_rx: Channel<'d>,
     ) -> Self {
         let effective_pio_frequency = (clk_sys_freq() as f32 / clock_divider.to_num::<f32>()) as u32;
 
@@ -215,7 +217,8 @@ where
             cs,
             sm,
             irq,
-            dma,
+            dma_tx,
+            dma_rx,
             wrap_target: loaded_program.wrap.target,
         }
     }
@@ -238,13 +241,11 @@ where
 
         self.sm.set_enable(true);
 
-        self.sm.tx().dma_push(&mut self.dma, write, false).await;
-
         let mut status = 0;
-        self.sm
-            .rx()
-            .dma_pull(&mut self.dma, slice::from_mut(&mut status), false)
-            .await;
+        let (rx, tx) = self.sm.rx_tx();
+        let rx_fut = rx.dma_pull(&mut self.dma_rx, slice::from_mut(&mut status), false);
+        let tx_fut = tx.dma_push(&mut self.dma_tx, write, false);
+        embassy_futures::join::join(tx_fut, rx_fut).await;
         status
     }
 
@@ -267,16 +268,18 @@ where
             self.sm.exec_jmp(self.wrap_target);
         }
 
-        // self.cs.set_low();
         self.sm.set_enable(true);
 
-        self.sm.tx().dma_push(&mut self.dma, slice::from_ref(&cmd), false).await;
-        self.sm.rx().dma_pull(&mut self.dma, read, false).await;
+        let cmd_arr = [cmd];
+        let (rx, tx) = self.sm.rx_tx();
+        let rx_fut = rx.dma_pull(&mut self.dma_rx, read, false);
+        let tx_fut = tx.dma_push(&mut self.dma_tx, &cmd_arr, false);
+        embassy_futures::join::join(tx_fut, rx_fut).await;
 
         let mut status = 0;
         self.sm
             .rx()
-            .dma_pull(&mut self.dma, slice::from_mut(&mut status), false)
+            .dma_pull(&mut self.dma_rx, slice::from_mut(&mut status), false)
             .await;
 
         #[cfg(feature = "defmt")]

--- a/cyw43-pio/src/lib.rs
+++ b/cyw43-pio/src/lib.rs
@@ -270,10 +270,9 @@ where
 
         self.sm.set_enable(true);
 
-        let cmd_arr = [cmd];
         let (rx, tx) = self.sm.rx_tx();
         let rx_fut = rx.dma_pull(&mut self.dma_rx, read, false);
-        let tx_fut = tx.dma_push(&mut self.dma_tx, &cmd_arr, false);
+        let tx_fut = tx.dma_push(&mut self.dma_tx, slice::from_ref(&cmd), false);
         embassy_futures::join::join(tx_fut, rx_fut).await;
 
         let mut status = 0;

--- a/examples/rp/src/bin/wifi_ap_tcp_server.rs
+++ b/examples/rp/src/bin/wifi_ap_tcp_server.rs
@@ -15,7 +15,7 @@ use embassy_net::tcp::TcpSocket;
 use embassy_net::{Config, StackResources};
 use embassy_rp::clocks::RoscRng;
 use embassy_rp::gpio::{Level, Output};
-use embassy_rp::peripherals::{DMA_CH0, PIO0};
+use embassy_rp::peripherals::{DMA_CH0, DMA_CH1, PIO0};
 use embassy_rp::pio::{InterruptHandler, Pio};
 use embassy_rp::{bind_interrupts, dma};
 use embassy_time::Duration;
@@ -25,7 +25,7 @@ use {defmt_rtt as _, panic_probe as _};
 
 bind_interrupts!(struct Irqs {
     PIO0_IRQ_0 => InterruptHandler<PIO0>;
-    DMA_IRQ_0 => dma::InterruptHandler<DMA_CH0>;
+    DMA_IRQ_0 => dma::InterruptHandler<DMA_CH0>, dma::InterruptHandler<DMA_CH1>;
 });
 
 #[embassy_executor::task]
@@ -70,6 +70,7 @@ async fn main(spawner: Spawner) {
         p.PIN_24,
         p.PIN_29,
         dma::Channel::new(p.DMA_CH0, Irqs),
+        dma::Channel::new(p.DMA_CH1, Irqs),
     );
 
     static STATE: StaticCell<cyw43::State> = StaticCell::new();

--- a/examples/rp/src/bin/wifi_blinky.rs
+++ b/examples/rp/src/bin/wifi_blinky.rs
@@ -10,7 +10,7 @@ use cyw43_pio::{DEFAULT_CLOCK_DIVIDER, PioSpi};
 use defmt::*;
 use embassy_executor::Spawner;
 use embassy_rp::gpio::{Level, Output};
-use embassy_rp::peripherals::{DMA_CH0, PIO0};
+use embassy_rp::peripherals::{DMA_CH0, DMA_CH1, PIO0};
 use embassy_rp::pio::{InterruptHandler, Pio};
 use embassy_rp::{bind_interrupts, dma};
 use embassy_time::{Duration, Timer};
@@ -19,7 +19,7 @@ use {defmt_rtt as _, panic_probe as _};
 
 bind_interrupts!(struct Irqs {
     PIO0_IRQ_0 => InterruptHandler<PIO0>;
-    DMA_IRQ_0 => dma::InterruptHandler<DMA_CH0>;
+    DMA_IRQ_0 => dma::InterruptHandler<DMA_CH0>, dma::InterruptHandler<DMA_CH1>;
 });
 
 #[embassy_executor::task]
@@ -55,6 +55,7 @@ async fn main(spawner: Spawner) {
         p.PIN_24,
         p.PIN_29,
         dma::Channel::new(p.DMA_CH0, Irqs),
+        dma::Channel::new(p.DMA_CH1, Irqs),
     );
 
     static STATE: StaticCell<cyw43::State> = StaticCell::new();

--- a/examples/rp/src/bin/wifi_scan.rs
+++ b/examples/rp/src/bin/wifi_scan.rs
@@ -12,7 +12,7 @@ use cyw43_pio::{DEFAULT_CLOCK_DIVIDER, PioSpi};
 use defmt::*;
 use embassy_executor::Spawner;
 use embassy_rp::gpio::{Level, Output};
-use embassy_rp::peripherals::{DMA_CH0, PIO0};
+use embassy_rp::peripherals::{DMA_CH0, DMA_CH1, PIO0};
 use embassy_rp::pio::{InterruptHandler, Pio};
 use embassy_rp::{bind_interrupts, dma};
 use static_cell::StaticCell;
@@ -20,7 +20,7 @@ use {defmt_rtt as _, panic_probe as _};
 
 bind_interrupts!(struct Irqs {
     PIO0_IRQ_0 => InterruptHandler<PIO0>;
-    DMA_IRQ_0 => dma::InterruptHandler<DMA_CH0>;
+    DMA_IRQ_0 => dma::InterruptHandler<DMA_CH0>, dma::InterruptHandler<DMA_CH1>;
 });
 
 #[embassy_executor::task]
@@ -59,6 +59,7 @@ async fn main(spawner: Spawner) {
         p.PIN_24,
         p.PIN_29,
         dma::Channel::new(p.DMA_CH0, Irqs),
+        dma::Channel::new(p.DMA_CH1, Irqs),
     );
 
     static STATE: StaticCell<cyw43::State> = StaticCell::new();

--- a/examples/rp/src/bin/wifi_tcp_server.rs
+++ b/examples/rp/src/bin/wifi_tcp_server.rs
@@ -15,7 +15,7 @@ use embassy_net::tcp::TcpSocket;
 use embassy_net::{Config, StackResources};
 use embassy_rp::clocks::RoscRng;
 use embassy_rp::gpio::{Level, Output};
-use embassy_rp::peripherals::{DMA_CH0, PIO0};
+use embassy_rp::peripherals::{DMA_CH0, DMA_CH1, PIO0};
 use embassy_rp::pio::{InterruptHandler, Pio};
 use embassy_rp::{bind_interrupts, dma};
 use embassy_time::Duration;
@@ -25,7 +25,7 @@ use {defmt_rtt as _, panic_probe as _};
 
 bind_interrupts!(struct Irqs {
     PIO0_IRQ_0 => InterruptHandler<PIO0>;
-    DMA_IRQ_0 => dma::InterruptHandler<DMA_CH0>;
+    DMA_IRQ_0 => dma::InterruptHandler<DMA_CH0>, dma::InterruptHandler<DMA_CH1>;
 });
 
 const WIFI_NETWORK: &str = "ssid"; // change to your network SSID
@@ -73,6 +73,7 @@ async fn main(spawner: Spawner) {
         p.PIN_24,
         p.PIN_29,
         dma::Channel::new(p.DMA_CH0, Irqs),
+        dma::Channel::new(p.DMA_CH1, Irqs),
     );
 
     static STATE: StaticCell<cyw43::State> = StaticCell::new();

--- a/examples/rp/src/bin/wifi_webrequest.rs
+++ b/examples/rp/src/bin/wifi_webrequest.rs
@@ -15,7 +15,7 @@ use embassy_net::tcp::client::{TcpClient, TcpClientState};
 use embassy_net::{Config, StackResources};
 use embassy_rp::clocks::RoscRng;
 use embassy_rp::gpio::{Level, Output};
-use embassy_rp::peripherals::{DMA_CH0, PIO0};
+use embassy_rp::peripherals::{DMA_CH0, DMA_CH1, PIO0};
 use embassy_rp::pio::{InterruptHandler, Pio};
 use embassy_rp::{bind_interrupts, dma};
 use embassy_time::{Duration, Timer};
@@ -30,7 +30,7 @@ use {defmt_rtt as _, panic_probe as _};
 
 bind_interrupts!(struct Irqs {
     PIO0_IRQ_0 => InterruptHandler<PIO0>;
-    DMA_IRQ_0 => dma::InterruptHandler<DMA_CH0>;
+    DMA_IRQ_0 => dma::InterruptHandler<DMA_CH0>, dma::InterruptHandler<DMA_CH1>;
 });
 
 const WIFI_NETWORK: &str = "ssid"; // change to your network SSID
@@ -77,6 +77,7 @@ async fn main(spawner: Spawner) {
         p.PIN_24,
         p.PIN_29,
         dma::Channel::new(p.DMA_CH0, Irqs),
+        dma::Channel::new(p.DMA_CH1, Irqs),
     );
 
     static STATE: StaticCell<cyw43::State> = StaticCell::new();

--- a/examples/rp235x/src/bin/blinky_wifi.rs
+++ b/examples/rp235x/src/bin/blinky_wifi.rs
@@ -10,7 +10,7 @@ use cyw43_pio::{PioSpi, RM2_CLOCK_DIVIDER};
 use defmt::*;
 use embassy_executor::Spawner;
 use embassy_rp::gpio::{Level, Output};
-use embassy_rp::peripherals::{DMA_CH0, PIO0};
+use embassy_rp::peripherals::{DMA_CH0, DMA_CH1, PIO0};
 use embassy_rp::pio::{InterruptHandler, Pio};
 use embassy_rp::{bind_interrupts, dma};
 use embassy_time::{Duration, Timer};
@@ -33,7 +33,7 @@ pub static PICOTOOL_ENTRIES: [embassy_rp::binary_info::EntryAddr; 4] = [
 
 bind_interrupts!(struct Irqs {
     PIO0_IRQ_0 => InterruptHandler<PIO0>;
-    DMA_IRQ_0 => dma::InterruptHandler<DMA_CH0>;
+    DMA_IRQ_0 => dma::InterruptHandler<DMA_CH0>, dma::InterruptHandler<DMA_CH1>;
 });
 
 #[embassy_executor::task]
@@ -71,6 +71,7 @@ async fn main(spawner: Spawner) {
         p.PIN_24,
         p.PIN_29,
         dma::Channel::new(p.DMA_CH0, Irqs),
+        dma::Channel::new(p.DMA_CH1, Irqs),
     );
 
     static STATE: StaticCell<cyw43::State> = StaticCell::new();

--- a/examples/rp235x/src/bin/blinky_wifi_pico_plus_2.rs
+++ b/examples/rp235x/src/bin/blinky_wifi_pico_plus_2.rs
@@ -9,7 +9,7 @@ use cyw43::aligned_bytes;
 use cyw43_pio::{PioSpi, RM2_CLOCK_DIVIDER};
 use defmt::*;
 use embassy_executor::Spawner;
-use embassy_rp::peripherals::{DMA_CH0, PIO0};
+use embassy_rp::peripherals::{DMA_CH0, DMA_CH1, PIO0};
 use embassy_rp::pio::{InterruptHandler, Pio};
 use embassy_rp::{bind_interrupts, gpio};
 use embassy_time::{Duration, Timer};
@@ -32,7 +32,7 @@ pub static PICOTOOL_ENTRIES: [embassy_rp::binary_info::EntryAddr; 4] = [
 
 bind_interrupts!(struct Irqs {
     PIO0_IRQ_0 => InterruptHandler<PIO0>;
-    DMA_IRQ_0 => embassy_rp::dma::InterruptHandler<DMA_CH0>;
+    DMA_IRQ_0 => embassy_rp::dma::InterruptHandler<DMA_CH0>, embassy_rp::dma::InterruptHandler<DMA_CH1>;
 });
 
 #[embassy_executor::task]
@@ -68,6 +68,7 @@ async fn main(spawner: Spawner) {
         p.PIN_24,
         p.PIN_29,
         embassy_rp::dma::Channel::new(p.DMA_CH0, Irqs),
+        embassy_rp::dma::Channel::new(p.DMA_CH1, Irqs),
     );
 
     static STATE: StaticCell<cyw43::State> = StaticCell::new();

--- a/tests/rp/src/bin/cyw43-perf.rs
+++ b/tests/rp/src/bin/cyw43-perf.rs
@@ -9,7 +9,7 @@ use embassy_executor::Spawner;
 use embassy_net::{Config, StackResources};
 use embassy_rp::dma::{self, Channel};
 use embassy_rp::gpio::{Level, Output};
-use embassy_rp::peripherals::{DMA_CH0, PIO0};
+use embassy_rp::peripherals::{DMA_CH0, DMA_CH1, PIO0};
 use embassy_rp::pio::{InterruptHandler, Pio};
 use embassy_rp::{bind_interrupts, rom_data};
 use static_cell::StaticCell;
@@ -17,7 +17,7 @@ use {defmt_rtt as _, panic_probe as _};
 
 bind_interrupts!(struct Irqs {
     PIO0_IRQ_0 => InterruptHandler<PIO0>;
-    DMA_IRQ_0 => dma::InterruptHandler<DMA_CH0>;
+    DMA_IRQ_0 => dma::InterruptHandler<DMA_CH0>, dma::InterruptHandler<DMA_CH1>;
 });
 
 teleprobe_meta::timeout!(120);
@@ -70,6 +70,7 @@ async fn main(spawner: Spawner) {
         p.PIN_24,
         p.PIN_29,
         Channel::new(p.DMA_CH0, Irqs),
+        Channel::new(p.DMA_CH1, Irqs),
     );
 
     static STATE: StaticCell<cyw43::State> = StaticCell::new();


### PR DESCRIPTION
## Summary

Fixes a deterministic single-bit corruption on `cyw43-pio` backplane reads on RP2350 (Pico 2 W).

## Root cause

`cmd_read` (and `cmd_read_status`) drove TX and RX over a single DMA channel, sequentially:

```rust
self.sm.set_enable(true);
self.sm.tx().dma_push(&mut self.dma, &cmd, false).await;  // TX first
self.sm.rx().dma_pull(&mut self.dma, read, false).await;  // RX armed only after TX completes
```

The PIO state machine is enabled before RX DMA is armed. Output produced in that gap fills the 4-deep RX FIFO. By the time the SM samples the final bit of the read, the FIFO is already saturated and the last bit
is dropped, manifesting as a cleared LSB on the last word.

## Fix

Use two DMA channels (TX + RX) and arm them concurrently with `embassy_futures::join`, so RX is ready before the SM produces any samples. This mirrors the pico-sdk pattern.

```rust
let (rx, tx) = self.sm.rx_tx();
let rx_fut = rx.dma_pull(&mut self.dma_rx, read, false);
let tx_fut = tx.dma_push(&mut self.dma_tx, &cmd_arr, false);
embassy_futures::join::join(tx_fut, rx_fut).await;
```

## Reproduction

Hardware: Raspberry Pi Pico 2 W.

```bash
cd examples/rp235x
cargo run --bin blinky_wifi
```

Any `cyw43`-using binary on RP2350 in debug mode should reproduce. Release builds are fast enough to sometimes avoid the race.

## Symptom

Init panics during firmware load with a checksum mismatch on a 16-byte sample read back from the chip:

```text
[DEBUG] loading fw
[DEBUG] FW sample @00000000 checksum exp=a1f2d985 got=a1f24d24 match=false
[ERROR] FW expected: [00, 00, 00, 00, 71, 14, 00, 00, 9d, 13, 00, 00, 9d, 13, 00, 00]
        actual:      [00, 00, 00, 00, 71, 14, 00, 00, 9d, 13, 00, 00, 9c, 13, 00, 00]
                                                                      ^^
panicked at cyw43/src/lib.rs:458: firmware checksum mismatch
```

The error is deterministic and always in the same position (LSB of the last word of every 16-byte read). This was verified in 2 different firmware blobs.
