### PR TITLE
embassy-rp: fix DMA abort on RP2350 (errata RP2350-E5)

### DIFF
--- a/embassy-rp/CHANGELOG.md
+++ b/embassy-rp/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 <!-- next-header -->
 ## Unreleased - ReleaseDate
 
+- DMA: clear channel `EN` bit before `chan_abort` on RP2350, per errata RP2350-E5 (see pico-sdk `dma_channel_abort` docs). Prevents the aborted channel from re-triggering.
+
 ## 0.10.0 - 2026-03-10
 - Add AON Timer driver for RP2350 with configurable clock sources and alarm wake modes
 - Add output enable inversion API (gpio, pio)

--- a/embassy-rp/src/dma.rs
+++ b/embassy-rp/src/dma.rs
@@ -266,6 +266,11 @@ impl<'a> Transfer<'a> {
 impl<'a> Drop for Transfer<'a> {
     fn drop(&mut self) {
         let p = self.channel.regs();
+        // RP2350 errata RP2350-E5: clear the enable bit of the aborted channel
+        // before the abort to prevent re-triggering.
+        // See pico-sdk dma_channel_abort() docs.
+        #[cfg(feature = "_rp235x")]
+        p.ctrl_trig().modify(|w| w.set_en(false));
         pac::DMA
             .chan_abort()
             .modify(|m| m.set_chan_abort(1 << self.channel.number()));


### PR DESCRIPTION
## Summary

- On RP2350, aborting a DMA channel via CHAN_ABORT while the channel's EN bit is still set can cause the channel to re-trigger after the abort completes (errata RP2350-E5).
- Transfer::drop now clears CTRL_TRIG.EN before writing to CHAN_ABORT on RP2350.
- Mirrors the workaround documented in the pico-sdk's dma_channel_abort().