### PR TITLE
stm32/ipcc: optimize and cleanup

### DIFF
--- a/ci.sh
+++ b/ci.sh
@@ -43,8 +43,8 @@ rm -rf out/tests/nrf5340-dk
 # disabled because these boards are not on the shelf
 rm -rf out/tests/mspm0g3507
 
-rm out/tests/stm32wb55rg/wpan_mac
-rm out/tests/stm32wb55rg/wpan_ble
+# rm out/tests/stm32wb55rg/wpan_mac
+# rm out/tests/stm32wb55rg/wpan_ble
 
 # unstable, I think it's running out of RAM?
 rm out/tests/stm32f207zg/eth

--- a/embassy-stm32-wpan/src/wb/sub/ble.rs
+++ b/embassy-stm32-wpan/src/wb/sub/ble.rs
@@ -96,15 +96,18 @@ impl<'a> Ble<'a> {
     /// `HW_IPCC_BLE_EvtNot`
     pub async fn tl_read(&mut self) -> EvtBox<Self> {
         self.ipcc_ble_event_channel
-            .receive(|| unsafe {
-                if let Some(node_ptr) =
-                    critical_section::with(|cs| LinkedListNode::remove_head(cs, EVT_QUEUE.as_mut_ptr()))
-                {
-                    Some(EvtBox::new(node_ptr.cast()))
-                } else {
-                    None
-                }
-            })
+            .receive(
+                || unsafe {
+                    if let Some(node_ptr) =
+                        critical_section::with(|cs| LinkedListNode::remove_head(cs, EVT_QUEUE.as_mut_ptr()))
+                    {
+                        Some(EvtBox::new(node_ptr.cast()))
+                    } else {
+                        None
+                    }
+                },
+                false,
+            )
             .await
     }
 
@@ -191,15 +194,18 @@ impl<'a> BleRx<'a> {
     /// `HW_IPCC_BLE_EvtNot`
     pub async fn tl_read(&mut self) -> EvtBox<Self> {
         self.ipcc_ble_event_channel
-            .receive(|| unsafe {
-                if let Some(node_ptr) =
-                    critical_section::with(|cs| LinkedListNode::remove_head(cs, EVT_QUEUE.as_mut_ptr()))
-                {
-                    Some(EvtBox::new(node_ptr.cast()))
-                } else {
-                    None
-                }
-            })
+            .receive(
+                || unsafe {
+                    if let Some(node_ptr) =
+                        critical_section::with(|cs| LinkedListNode::remove_head(cs, EVT_QUEUE.as_mut_ptr()))
+                    {
+                        Some(EvtBox::new(node_ptr.cast()))
+                    } else {
+                        None
+                    }
+                },
+                false,
+            )
             .await
     }
 }

--- a/embassy-stm32-wpan/src/wb/sub/mac.rs
+++ b/embassy-stm32-wpan/src/wb/sub/mac.rs
@@ -135,13 +135,16 @@ impl<'a> MacRx<'a> {
 
         // Return a new event box
         self.ipcc_mac_802_15_4_notification_ack_channel
-            .receive(|| unsafe {
-                // The closure is not async, therefore the closure must execute to completion (cannot be dropped)
-                // Therefore, the event box is guaranteed to be cleaned up if it's not leaked
-                MAC_EVT_OUT.store(true, Ordering::SeqCst);
+            .receive(
+                || unsafe {
+                    // The closure is not async, therefore the closure must execute to completion (cannot be dropped)
+                    // Therefore, the event box is guaranteed to be cleaned up if it's not leaked
+                    MAC_EVT_OUT.store(true, Ordering::SeqCst);
 
-                Some(EvtBox::new(MAC_802_15_4_NOTIF_RSP_EVT_BUFFER.as_mut_ptr() as *mut _))
-            })
+                    Some(EvtBox::new(MAC_802_15_4_NOTIF_RSP_EVT_BUFFER.as_mut_ptr() as *mut _))
+                },
+                true,
+            )
             .await
     }
 
@@ -164,7 +167,7 @@ impl<'a> evt::MemoryManager for MacRx<'a> {
         );
 
         // Clear the rx flag
-        let _ = poll_once(Ipcc::receive::<()>(3, || None));
+        let _ = poll_once(Ipcc::receive::<()>(3, || None, false));
 
         // Allow a new read call
         MAC_EVT_OUT.store(false, Ordering::Release);

--- a/embassy-stm32-wpan/src/wb/sub/sys.rs
+++ b/embassy-stm32-wpan/src/wb/sub/sys.rs
@@ -125,15 +125,18 @@ impl<'a> Sys<'a> {
     /// handles the event channels directly.
     pub async fn read(&mut self) -> EvtBox<mm::MemoryManager<'_>> {
         self.ipcc_system_event_channel
-            .receive(|| unsafe {
-                if let Some(node_ptr) =
-                    critical_section::with(|cs| LinkedListNode::remove_head(cs, SYSTEM_EVT_QUEUE.as_mut_ptr()))
-                {
-                    Some(EvtBox::new(node_ptr.cast()))
-                } else {
-                    None
-                }
-            })
+            .receive(
+                || unsafe {
+                    if let Some(node_ptr) =
+                        critical_section::with(|cs| LinkedListNode::remove_head(cs, SYSTEM_EVT_QUEUE.as_mut_ptr()))
+                    {
+                        Some(EvtBox::new(node_ptr.cast()))
+                    } else {
+                        None
+                    }
+                },
+                false,
+            )
             .await
     }
 }

--- a/embassy-stm32/src/ipcc.rs
+++ b/embassy-stm32/src/ipcc.rs
@@ -122,6 +122,35 @@ impl Default for Config {
     }
 }
 
+struct ActiveTxInterrupt {
+    core: CoreId,
+    index: u8,
+}
+
+impl ActiveTxInterrupt {
+    fn configure_interrupt(&mut self, enabled: bool) {
+        critical_section::with(|_| {
+            IPCC::regs()
+                .cpu(self.core.to_index().into())
+                .mr()
+                .modify(|w| w.set_chfm(self.index as usize, !enabled))
+        });
+    }
+
+    fn new(core: CoreId, index: u8) -> Self {
+        let mut this = Self { core, index };
+
+        this.configure_interrupt(true);
+        this
+    }
+}
+
+impl Drop for ActiveTxInterrupt {
+    fn drop(&mut self) {
+        self.configure_interrupt(false);
+    }
+}
+
 /// IPCC TX Channel
 pub struct IpccTxChannel<'a> {
     index: u8,
@@ -163,33 +192,51 @@ impl<'a> IpccTxChannel<'a> {
         // This is a race, but is nice for debugging
         if regs.cpu(core.to_index().into()).sr().read().chf(self.index as usize) {
             trace!("ipcc: ch {}: wait for tx free", self.index as u8);
+        } else {
+            return;
         }
 
+        let _irq = ActiveTxInterrupt::new(core, self.index);
         poll_fn(|cx| {
             IPCC::state().tx_waker_for(self.index).register(cx.waker());
-            // If bit is set to 1 then interrupt is disabled; we want to enable the interrupt
-            critical_section::with(|_| {
-                regs.cpu(core.to_index().into())
-                    .mr()
-                    .modify(|w| w.set_chfm(self.index as usize, false))
-            });
-
             compiler_fence(Ordering::SeqCst);
 
             if !regs.cpu(core.to_index().into()).sr().read().chf(self.index as usize) {
-                // If bit is set to 1 then interrupt is disabled; we want to disable the interrupt
-                critical_section::with(|_| {
-                    regs.cpu(core.to_index().into())
-                        .mr()
-                        .modify(|w| w.set_chfm(self.index as usize, true))
-                });
-
                 Poll::Ready(())
             } else {
                 Poll::Pending
             }
         })
         .await;
+    }
+}
+
+struct ActiveRxInterrupt {
+    core: CoreId,
+    index: u8,
+}
+
+impl ActiveRxInterrupt {
+    fn configure_interrupt(&mut self, enabled: bool) {
+        critical_section::with(|_| {
+            IPCC::regs()
+                .cpu(self.core.to_index().into())
+                .mr()
+                .modify(|w| w.set_chom(self.index as usize, !enabled))
+        });
+    }
+
+    fn new(core: CoreId, index: u8) -> Self {
+        let mut this = Self { core, index };
+
+        this.configure_interrupt(true);
+        this
+    }
+}
+
+impl Drop for ActiveRxInterrupt {
+    fn drop(&mut self) {
+        self.configure_interrupt(false);
     }
 }
 
@@ -210,7 +257,9 @@ impl<'a> IpccRxChannel<'a> {
     }
 
     /// Receive data from an IPCC channel. The closure is called to read the data when appropriate.
-    pub async fn receive<R>(&mut self, mut f: impl FnMut() -> Option<R>) -> R {
+    ///
+    /// `close` determines whether the channel will be open for receiving more data, or not after data is read.
+    pub async fn receive<R>(&mut self, mut f: impl FnMut() -> Option<R>, close: bool) -> R {
         let _scoped_wake_guard = IPCC::RCC_INFO.wake_guard();
         let regs = IPCC::regs();
         let core = CoreId::current();
@@ -224,38 +273,26 @@ impl<'a> IpccRxChannel<'a> {
                 .chf(self.index as usize)
             {
                 trace!("ipcc: ch {}: wait for rx occupied", self.index as u8);
+
+                let _irq = ActiveRxInterrupt::new(core, self.index);
+                poll_fn(|cx| {
+                    IPCC::state().rx_waker_for(self.index).register(cx.waker());
+
+                    compiler_fence(Ordering::SeqCst);
+
+                    if regs
+                        .cpu(core.other().to_index().into())
+                        .sr()
+                        .read()
+                        .chf(self.index as usize)
+                    {
+                        Poll::Ready(())
+                    } else {
+                        Poll::Pending
+                    }
+                })
+                .await;
             }
-
-            poll_fn(|cx| {
-                IPCC::state().rx_waker_for(self.index).register(cx.waker());
-                // If bit is set to 1 then interrupt is disabled; we want to enable the interrupt
-                critical_section::with(|_| {
-                    regs.cpu(core.to_index().into())
-                        .mr()
-                        .modify(|w| w.set_chom(self.index as usize, false))
-                });
-
-                compiler_fence(Ordering::SeqCst);
-
-                if regs
-                    .cpu(core.other().to_index().into())
-                    .sr()
-                    .read()
-                    .chf(self.index as usize)
-                {
-                    // If bit is set to 1 then interrupt is disabled; we want to disable the interrupt
-                    critical_section::with(|_| {
-                        regs.cpu(core.to_index().into())
-                            .mr()
-                            .modify(|w| w.set_chom(self.index as usize, true))
-                    });
-
-                    Poll::Ready(())
-                } else {
-                    Poll::Pending
-                }
-            })
-            .await;
 
             trace!("ipcc: ch {}: read data", self.index as u8);
 
@@ -267,7 +304,7 @@ impl<'a> IpccRxChannel<'a> {
             // If the channel is clear and the read function returns none, fetch more data
             regs.cpu(core.to_index().into())
                 .scr()
-                .write(|w| w.set_chc(self.index as usize, true));
+                .write(|w| w.set_chc(self.index as usize, ret.is_none() || !close));
             match ret {
                 Some(ret) => return ret,
                 None => {}
@@ -372,10 +409,10 @@ impl Ipcc {
     }
 
     /// Receive from a channel number
-    pub async unsafe fn receive<R>(number: u8, f: impl FnMut() -> Option<R>) -> R {
+    pub async unsafe fn receive<R>(number: u8, f: impl FnMut() -> Option<R>, close: bool) -> R {
         core::assert!(number > 0 && number <= 6);
 
-        IpccRxChannel::new(number - 1).receive(f).await
+        IpccRxChannel::new(number - 1).receive(f, close).await
     }
 
     /// Send to a channel number

--- a/examples/stm32wb/src/bin/eddystone_beacon.rs
+++ b/examples/stm32wb/src/bin/eddystone_beacon.rs
@@ -166,7 +166,7 @@ async fn main(_spawner: Spawner) {
     let response = ble.read().await.unwrap();
     defmt::info!("{}", response);
 
-    cortex_m::asm::wfi();
+    cortex_m::asm::bkpt();
 }
 
 fn get_bd_addr() -> BdAddr {

--- a/examples/stm32wl55cm0p-lp/src/bin/intercore.rs
+++ b/examples/stm32wl55cm0p-lp/src/bin/intercore.rs
@@ -66,7 +66,7 @@ async fn main(_spawner: Spawner) -> ! {
     _spawner.spawn(blink_heartbeat(red_led).unwrap());
 
     loop {
-        let state = rx.receive(|| Some(LED_STATE.load(Ordering::SeqCst))).await;
+        let state = rx.receive(|| Some(LED_STATE.load(Ordering::SeqCst)), false).await;
         #[cfg(feature = "defmt")]
         info!("CM0+ Recieve: {}", state);
         green_led.set_level(if state { Level::High } else { Level::Low });

--- a/examples/stm32wl55cm0p/src/bin/intercore.rs
+++ b/examples/stm32wl55cm0p/src/bin/intercore.rs
@@ -60,7 +60,7 @@ async fn main(_spawner: Spawner) -> ! {
     _spawner.spawn(blink_heartbeat(red_led).unwrap());
 
     loop {
-        let state = rx.receive(|| Some(LED_STATE.load(Ordering::Relaxed))).await;
+        let state = rx.receive(|| Some(LED_STATE.load(Ordering::Relaxed)), false).await;
         info!("CM0+ Recieve: {}", state);
         blue_led.set_level(if state { Level::High } else { Level::Low });
     }

--- a/tests/stm32/src/bin/wpan_ble.rs
+++ b/tests/stm32/src/bin/wpan_ble.rs
@@ -49,13 +49,9 @@ async fn main(spawner: Spawner) {
     info!("Hello World!");
 
     let config = Config::default();
-    let mbox = TlMbox::init(p.IPCC, Irqs, config);
-    let mut sys = mbox.sys_subsystem;
-    let mut ble = mbox.ble_subsystem;
+    let mbox = TlMbox::wait_ready(p.IPCC, Irqs, config).await.unwrap();
 
-    spawner.spawn(run_mm_queue(mbox.mm_subsystem).unwrap());
-
-    let fw_info = sys.wireless_fw_info().unwrap();
+    let fw_info = mbox.sys_subsystem.wireless_fw_info().unwrap();
     let version_major = fw_info.version_major();
     let version_minor = fw_info.version_minor();
     let subversion = fw_info.subversion();
@@ -68,7 +64,9 @@ async fn main(spawner: Spawner) {
         version_major, version_minor, subversion, sram2a_size, sram2b_size
     );
 
-    let _ = sys.shci_c2_ble_init(Default::default()).await;
+    let (mut ble, mm) = mbox.init_ble(Default::default()).await.unwrap();
+
+    spawner.spawn(run_mm_queue(mm).unwrap());
 
     info!("resetting BLE...");
     ble.reset().await;

--- a/tests/stm32/src/bin/wpan_mac.rs
+++ b/tests/stm32/src/bin/wpan_mac.rs
@@ -42,14 +42,16 @@ async fn main(spawner: Spawner) {
     info!("Hello World!");
 
     let config = Config::default();
-    let mbox = TlMbox::init(p.IPCC, Irqs, config);
-    let mut sys = mbox.sys_subsystem;
-    let (mut mac_rx, mut mac_tx) = mbox.mac_subsystem.split();
+    let (mac, mm) = TlMbox::wait_ready(p.IPCC, Irqs, config)
+        .await
+        .unwrap()
+        .init_mac()
+        .await
+        .unwrap();
 
-    spawner.spawn(run_mm_queue(mbox.mm_subsystem).unwrap());
+    spawner.spawn(run_mm_queue(mm).unwrap());
 
-    let result = sys.shci_c2_mac_802_15_4_init().await;
-    info!("initialized mac: {}", result);
+    let (mut mac_rx, mut mac_tx) = mac.split();
 
     info!("resetting");
     mac_tx


### PR DESCRIPTION
The existing logic in wpan/wb/mac assumed that the channel was blocked until the macevent was read. Previously, this was changed so that in other applications, the other core would be free to send more data. However, this broke this use case so I added a `close` flag to allow the user to determine whether they want the channel closed.

I also optimized the logic so that if the IPCC channel has data present, the interrupt is bypassed and the data is read/written directly. 

confirmed on hardware.