### PR TITLE
embassy-sync: remove unsound zerocopy_channel `Sender::clear`

### DIFF
--- a/embassy-sync/src/zerocopy_channel.rs
+++ b/embassy-sync/src/zerocopy_channel.rs
@@ -24,12 +24,6 @@ use crate::blocking_mutex::Mutex;
 use crate::blocking_mutex::raw::RawMutex;
 use crate::waitqueue::WakerRegistration;
 
-/// Error returned by [`Sender::try_clear`] when the [`Receiver`]
-/// still holds an outstanding [`ReceiveSlot`].
-#[derive(PartialEq, Eq, Clone, Copy, Debug)]
-#[cfg_attr(feature = "defmt", derive(defmt::Format))]
-pub struct TryClearError;
-
 /// A bounded zero-copy channel for communicating between asynchronous tasks
 /// with backpressure.
 ///
@@ -65,7 +59,6 @@ impl<'a, M: RawMutex, T> Channel<'a, M, T> {
                 front: 0,
                 back: 0,
                 full: false,
-                outstanding_receive: false,
                 send_waker: WakerRegistration::new(),
                 receive_waker: WakerRegistration::new(),
             })),
@@ -179,17 +172,10 @@ impl<'a, M: RawMutex, T> Sender<'a, M, T> {
     }
 
     /// Clears all elements in the channel.
-    ///
-    /// Fails if the peer [`Receiver`] still holds a [`ReceiveSlot`].
-    pub fn try_clear(&mut self) -> Result<(), TryClearError> {
+    pub fn clear(&mut self) {
         self.channel.state.lock(|s| {
-            let s = &mut *s.borrow_mut();
-            if s.outstanding_receive {
-                return Err(TryClearError);
-            }
-            s.clear();
-            Ok(())
-        })
+            s.borrow_mut().clear();
+        });
     }
 
     /// Returns the number of elements currently in the channel.
@@ -351,12 +337,6 @@ impl<M: RawMutex, T> ReceiveSlot<'_, M, T> {
     }
 }
 
-impl<M: RawMutex, T> Drop for ReceiveSlot<'_, M, T> {
-    fn drop(&mut self) {
-        self.state.lock(|s| s.borrow_mut().outstanding_receive = false);
-    }
-}
-
 #[derive(Debug)]
 struct State {
     /// Maximum number of elements the channel can hold.
@@ -370,9 +350,6 @@ struct State {
     /// Used to distinguish "empty" and "full" cases when `front == back`.
     /// May only be `true` if `front == back`, always `false` otherwise.
     full: bool,
-
-    /// True while a [`ReceiveSlot`] is alive. Used by [`Sender::try_clear`].
-    outstanding_receive: bool,
 
     send_waker: WakerRegistration,
     receive_waker: WakerRegistration,
@@ -430,10 +407,7 @@ impl State {
     fn pop_index(&mut self) -> Option<usize> {
         match self.is_empty() {
             true => None,
-            false => {
-                self.outstanding_receive = true;
-                Some(self.front)
-            }
+            false => Some(self.front),
         }
     }
 
@@ -441,26 +415,5 @@ impl State {
         self.front = self.increment(self.front);
         self.full = false;
         self.receive_waker.wake();
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-    use crate::blocking_mutex::raw::NoopRawMutex;
-
-    #[test]
-    fn try_clear_refuses_while_receive_slot_alive() {
-        let mut buf = [0u32; 2];
-        let mut ch = Channel::<NoopRawMutex, u32>::new(&mut buf);
-        let (mut tx, mut rx) = ch.split();
-
-        tx.try_send().unwrap().send_done();
-        let recv_slot = rx.try_receive().unwrap();
-        assert_eq!(tx.try_clear(), Err(TryClearError));
-        drop(recv_slot);
-        tx.try_clear().unwrap();
-
-        assert!(tx.is_empty());
     }
 }

--- a/embassy-sync/src/zerocopy_channel.rs
+++ b/embassy-sync/src/zerocopy_channel.rs
@@ -171,13 +171,6 @@ impl<'a, M: RawMutex, T> Sender<'a, M, T> {
         })
     }
 
-    /// Clears all elements in the channel.
-    pub fn clear(&mut self) {
-        self.channel.state.lock(|s| {
-            s.borrow_mut().clear();
-        });
-    }
-
     /// Returns the number of elements currently in the channel.
     pub fn len(&self) -> usize {
         self.channel.state.lock(|s| s.borrow().len())

--- a/embassy-sync/src/zerocopy_channel.rs
+++ b/embassy-sync/src/zerocopy_channel.rs
@@ -24,6 +24,12 @@ use crate::blocking_mutex::Mutex;
 use crate::blocking_mutex::raw::RawMutex;
 use crate::waitqueue::WakerRegistration;
 
+/// Error returned by [`Sender::try_clear`] when the [`Receiver`]
+/// still holds an outstanding [`ReceiveSlot`].
+#[derive(PartialEq, Eq, Clone, Copy, Debug)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+pub struct TryClearError;
+
 /// A bounded zero-copy channel for communicating between asynchronous tasks
 /// with backpressure.
 ///
@@ -59,6 +65,7 @@ impl<'a, M: RawMutex, T> Channel<'a, M, T> {
                 front: 0,
                 back: 0,
                 full: false,
+                outstanding_receive: false,
                 send_waker: WakerRegistration::new(),
                 receive_waker: WakerRegistration::new(),
             })),
@@ -172,10 +179,17 @@ impl<'a, M: RawMutex, T> Sender<'a, M, T> {
     }
 
     /// Clears all elements in the channel.
-    pub fn clear(&mut self) {
+    ///
+    /// Fails if the peer [`Receiver`] still holds a [`ReceiveSlot`].
+    pub fn try_clear(&mut self) -> Result<(), TryClearError> {
         self.channel.state.lock(|s| {
-            s.borrow_mut().clear();
-        });
+            let s = &mut *s.borrow_mut();
+            if s.outstanding_receive {
+                return Err(TryClearError);
+            }
+            s.clear();
+            Ok(())
+        })
     }
 
     /// Returns the number of elements currently in the channel.
@@ -337,6 +351,12 @@ impl<M: RawMutex, T> ReceiveSlot<'_, M, T> {
     }
 }
 
+impl<M: RawMutex, T> Drop for ReceiveSlot<'_, M, T> {
+    fn drop(&mut self) {
+        self.state.lock(|s| s.borrow_mut().outstanding_receive = false);
+    }
+}
+
 #[derive(Debug)]
 struct State {
     /// Maximum number of elements the channel can hold.
@@ -350,6 +370,9 @@ struct State {
     /// Used to distinguish "empty" and "full" cases when `front == back`.
     /// May only be `true` if `front == back`, always `false` otherwise.
     full: bool,
+
+    /// True while a [`ReceiveSlot`] is alive. Used by [`Sender::try_clear`].
+    outstanding_receive: bool,
 
     send_waker: WakerRegistration,
     receive_waker: WakerRegistration,
@@ -407,7 +430,10 @@ impl State {
     fn pop_index(&mut self) -> Option<usize> {
         match self.is_empty() {
             true => None,
-            false => Some(self.front),
+            false => {
+                self.outstanding_receive = true;
+                Some(self.front)
+            }
         }
     }
 
@@ -415,5 +441,26 @@ impl State {
         self.front = self.increment(self.front);
         self.full = false;
         self.receive_waker.wake();
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::blocking_mutex::raw::NoopRawMutex;
+
+    #[test]
+    fn try_clear_refuses_while_receive_slot_alive() {
+        let mut buf = [0u32; 2];
+        let mut ch = Channel::<NoopRawMutex, u32>::new(&mut buf);
+        let (mut tx, mut rx) = ch.split();
+
+        tx.try_send().unwrap().send_done();
+        let recv_slot = rx.try_receive().unwrap();
+        assert_eq!(tx.try_clear(), Err(TryClearError));
+        drop(recv_slot);
+        tx.try_clear().unwrap();
+
+        assert!(tx.is_empty());
     }
 }


### PR DESCRIPTION
`Sender::clear` resets the channel front/back/full indices without checking whether the peer endpoint still holds an outstanding slot.  

We can use this in safe code to obtain two aliasing &mut T to the same buffer element

```rust
fn main() {
    let mut buf = [0u32; 2];
    let mut channel = Channel::<CriticalSectionRawMutex, u32>::new(&mut buf);
    let (mut sender, mut receiver) = channel.split();
    let mut slot = sender.try_send().unwrap();
    *slot = 42;
    slot.send_done();

    // receiver holds &mut u32 to buf[0]
    let r = receiver.try_receive().unwrap();

    // clear channel state while r is still alive
    sender.clear();
    // channel now believes it's empty, but r still points to buf[0]

    // sender takes what it thinks is a "fresh" &mut but now aliases buf[0]
    let s = sender.try_send().unwrap();

    // r and s alias
    assert_ne!(*r as *const u32, *s as *const u32);
}
```

This PR simply removes `Sender::clear`. In previous commits, I tried implementing a `try_clear()` instead, but this modified the Drop impl, and caused problems in other crates.

Note: `Receiver::clear` does not seem to be directly exploitable the same way, since `try_receive()` retruns None on an empty channel. `Channel::clear(&mut self)`needs exclusive access and is thus also not affected.
