### PR TITLE
fix: allow the `stm32h730` to use `fracn`

### DIFF
--- a/embassy-stm32/src/rcc/h.rs
+++ b/embassy-stm32/src/rcc/h.rs
@@ -80,7 +80,7 @@ pub struct Pll {
     /// PLL multiplication factor.
     pub mul: PllMul,
 
-    #[cfg(any(stm32h743))]
+    #[cfg(any(stm32h743, stm32h730))]
     /// PLL Fractional multiplier.
     pub fracn: Option<u16>,
 
@@ -997,14 +997,14 @@ fn init_pll(num: usize, config: Option<Pll>, input: &PllInput) -> PllOutput {
     // be chosen when the reference clock frequency is lower than 2 MHz.
     let wide_allowed = ref_range != Pllrge::Range1;
 
-    #[cfg(stm32h743)]
+    #[cfg(any(stm32h743, stm32h730))]
     let vco_clk = match config.fracn {
         Some(fracn) => {
             Hertz::hz((ref_clk.0 as f32 * ((config.mul.to_bits() + 1) as f32 + (fracn as f32 / 8192.0))) as u32)
         }
         None => ref_clk * config.mul,
     };
-    #[cfg(not(stm32h743))]
+    #[cfg(not(any(stm32h743, stm32h730)))]
     let vco_clk = ref_clk * config.mul;
 
     let vco_range = if VCO_RANGE.contains(&vco_clk) {
@@ -1053,7 +1053,7 @@ fn init_pll(num: usize, config: Option<Pll>, input: &PllInput) -> PllOutput {
             w.set_pllsrc(config.source);
         });
 
-        #[cfg(stm32h743)]
+        #[cfg(any(stm32h743, stm32h730))]
         if let Some(fracn) = config.fracn {
             RCC.pllfracr(num).modify(|w| w.set_fracn(fracn))
         }
@@ -1062,14 +1062,14 @@ fn init_pll(num: usize, config: Option<Pll>, input: &PllInput) -> PllOutput {
             w.set_pllvcosel(num, vco_range);
             w.set_pllrge(num, ref_range);
 
-            #[cfg(stm32h743)]
+            #[cfg(any(stm32h743, stm32h730))]
             if config.fracn.is_some() {
                 w.set_pllfracen(num, true);
             } else {
                 w.set_pllfracen(num, false);
             }
 
-            #[cfg(not(stm32h743))]
+            #[cfg(not(any(stm32h743, stm32h730)))]
             w.set_pllfracen(num, false);
 
             w.set_divpen(num, p.is_some());


### PR DESCRIPTION
Re-targets `rcc::Pll::fracn` to support the `stm32h730`.

Might be better to make a separate config along the lines of "pll_fracn_support", or a feature (since it's based on the specific chip).

fixes #6021 