### PR TITLE
stm32/ipcc: add explicit clear methods

### DIFF
--- a/embassy-stm32-wpan/src/wb/sub/ble.rs
+++ b/embassy-stm32-wpan/src/wb/sub/ble.rs
@@ -4,15 +4,13 @@ use core::cell::RefCell;
 use core::future::poll_fn;
 use core::ptr;
 
-#[cfg(feature = "bt-hci")]
-use embassy_futures::poll_once;
-use embassy_stm32::ipcc::{IpccRxChannel, IpccTxChannel};
+use embassy_stm32::ipcc::{Ipcc, IpccRxChannel, IpccTxChannel};
 #[cfg(feature = "bt-hci")]
 use embassy_sync::blocking_mutex;
-use embassy_sync::blocking_mutex::raw::CriticalSectionRawMutex;
 #[cfg(feature = "bt-hci")]
 use embassy_sync::blocking_mutex::raw::NoopRawMutex;
-use embassy_sync::mutex::{Mutex, MutexGuard};
+#[cfg(feature = "bt-hci")]
+use embassy_sync::mutex::Mutex;
 #[cfg(feature = "bt-hci")]
 use embassy_sync::signal::Signal;
 #[cfg(feature = "bt-hci")]
@@ -21,6 +19,7 @@ use embassy_sync::waitqueue::AtomicWaker;
 use futures_intrusive::sync::LocalSemaphore;
 use hci::Opcode;
 
+use crate::channels::cpu1::IPCC_HCI_ACL_DATA_CHANNEL;
 use crate::cmd::CmdPacket;
 use crate::consts::{TL_BLEEVT_CC_OPCODE, TL_BLEEVT_CS_OPCODE, TlPacketType};
 use crate::evt;
@@ -31,12 +30,6 @@ use crate::unsafe_linked_list::LinkedListNode;
 use crate::wb::Flag;
 
 static ACL_EVT_OUT: Flag = Flag::new(false);
-static ACL_MUTEX: Mutex<CriticalSectionRawMutex, ()> = Mutex::new(());
-
-async fn lock_acl() -> MutexGuard<'static, CriticalSectionRawMutex, ()> {
-    ACL_EVT_OUT.wait_for_low().await;
-    ACL_MUTEX.lock().await
-}
 
 /// A guard that, once constructed, may be used to send BLE commands to CPU2.
 ///
@@ -154,10 +147,8 @@ impl<'a> Ble<'a> {
 
     /// `TL_BLE_SendAclData`
     pub async fn acl_write(&mut self, handle: u16, payload: &[u8]) {
-        let _guard = lock_acl().await;
-
         self.ipcc_hci_acl_tx_data_channel
-            .send(|| unsafe {
+            .send_exclusive(|| unsafe {
                 CmdPacket::write_into(
                     HCI_ACL_DATA_BUFFER.as_mut_ptr() as *mut _,
                     TlPacketType::AclData,
@@ -170,18 +161,15 @@ impl<'a> Ble<'a> {
 
     /// `TL_BLE_AclNot`
     pub async fn acl_read(&mut self) -> EvtBox<Self> {
-        let _guard = lock_acl().await;
-
+        ACL_EVT_OUT.wait_for_low().await;
         self.ipcc_hci_acl_rx_data_channel
             .receive(
                 || unsafe {
-                    // The closure is not async, therefore the closure must execute to completion (cannot be dropped)
-                    // Therefore, the event box is guaranteed to be cleaned up if it's not leaked
                     ACL_EVT_OUT.set_high();
 
                     Some(EvtBox::new(HCI_ACL_DATA_BUFFER.as_mut_ptr() as *mut _))
                 },
-                true,
+                false,
             )
             .await
     }
@@ -191,6 +179,7 @@ impl<'a> evt::MemoryManager for Ble<'a> {
     /// SAFETY: passing a pointer to something other than a managed event packet is UB
     unsafe fn drop_event_packet(evt: *mut EvtPacket) {
         if ptr::eq(evt, HCI_ACL_DATA_BUFFER.as_mut_ptr() as *mut _) {
+            Ipcc::clear(IPCC_HCI_ACL_DATA_CHANNEL as u8);
             ACL_EVT_OUT.set_low();
 
             return;
@@ -269,18 +258,15 @@ impl<'a> BleRx<'a> {
 
     /// `TL_BLE_AclNot`
     pub async fn acl_read(&mut self) -> EvtBox<Ble<'a>> {
-        let _guard = lock_acl().await;
-
+        ACL_EVT_OUT.wait_for_low().await;
         self.ipcc_hci_acl_rx_data_channel
             .receive(
                 || unsafe {
-                    // The closure is not async, therefore the closure must execute to completion (cannot be dropped)
-                    // Therefore, the event box is guaranteed to be cleaned up if it's not leaked
                     ACL_EVT_OUT.set_high();
 
                     Some(EvtBox::new(HCI_ACL_DATA_BUFFER.as_mut_ptr() as *mut _))
                 },
-                true,
+                false,
             )
             .await
     }
@@ -517,7 +503,7 @@ impl<'d> bt_hci::controller::Controller for AtomicController<'d> {
             async {
                 let mut channel = self.ipcc_hci_acl_rx_data_channel.lock().await;
 
-                let ret = channel
+                channel
                     .receive(
                         || unsafe {
                             // We must copy out the event immediately so that it is not trashed by a pending command.
@@ -527,6 +513,8 @@ impl<'d> bt_hci::controller::Controller for AtomicController<'d> {
                             let serial = evt.serial();
                             buf[..serial.len()].copy_from_slice(serial);
 
+                            // rx will be cleared by evt box drop
+
                             Some(
                                 ControllerToHostPacket::from_hci_bytes(buf)
                                     .map(|(pkt, _)| pkt)
@@ -535,11 +523,7 @@ impl<'d> bt_hci::controller::Controller for AtomicController<'d> {
                         },
                         false,
                     )
-                    .await;
-
-                let _ = poll_once(channel.receive::<()>(|| None, false));
-
-                ret
+                    .await
             },
         )
         .await

--- a/embassy-stm32-wpan/src/wb/sub/mac.rs
+++ b/embassy-stm32-wpan/src/wb/sub/mac.rs
@@ -1,8 +1,8 @@
 use core::ptr;
 
-use embassy_futures::poll_once;
 use embassy_stm32::ipcc::{Ipcc, IpccRxChannel, IpccTxChannel};
 
+use crate::channels::cpu1::IPCC_MAC_802_15_4_CMD_RSP_CHANNEL;
 use crate::cmd::CmdPacket;
 use crate::consts::TlPacketType;
 use crate::evt::{EvtBox, EvtPacket};
@@ -117,28 +117,24 @@ impl<'a> MacRx<'a> {
     ///
     /// This function will stall if the previous `EvtBox` has not been dropped
     pub async fn read(&mut self) -> Result<MacEvent<'a>, ()> {
-        // Wait for the last event box to be dropped
         MAC_EVT_OUT.wait_for_low().await;
 
         // Return a new event box
         self.ipcc_mac_802_15_4_notification_ack_channel
             .receive(
                 || unsafe {
-                    // The closure is not async, therefore the closure must execute to completion (cannot be dropped)
-                    // Therefore, the event box is guaranteed to be cleaned up if it's not leaked
                     MAC_EVT_OUT.set_high();
 
                     Some(MacEvent::new(EvtBox::new(
                         MAC_802_15_4_NOTIF_RSP_EVT_BUFFER.as_mut_ptr() as *mut _,
                     )))
                 },
-                true,
+                false,
             )
             .await
     }
 }
 
-/// SAFETY: passing a pointer to something other than a managed event packet is UB
 pub(crate) unsafe fn drop_mac_event() {
     trace!("mac drop event");
 
@@ -151,8 +147,6 @@ pub(crate) unsafe fn drop_mac_event() {
     );
 
     // Clear the rx flag
-    let _ = poll_once(Ipcc::receive::<()>(3, || None, false));
-
-    // Allow a new read call
+    Ipcc::clear(IPCC_MAC_802_15_4_CMD_RSP_CHANNEL as u8);
     MAC_EVT_OUT.set_low();
 }

--- a/embassy-stm32/src/ipcc.rs
+++ b/embassy-stm32/src/ipcc.rs
@@ -184,7 +184,7 @@ impl<'a> IpccTxChannel<'a> {
             .read()
             .chf(self.index as usize)
         {
-            trace!("ipcc: ch {}: wait for rx clear", self.index as u8);
+            trace!("ipcc: ch {}: wait for rx clear", self.index + 1);
 
             poll_fn(|cx| {
                 IPCC::state().rx_waker_for(self.index).register(cx.waker());
@@ -208,7 +208,7 @@ impl<'a> IpccTxChannel<'a> {
         let ret = f();
         fence(Ordering::Release);
 
-        trace!("ipcc: ch {}: send data", self.index as u8);
+        trace!("ipcc: ch {}: send data", self.index + 1);
         regs.cpu(core.to_index().into())
             .scr()
             .write(|w| w.set_chs(self.index as usize, true));
@@ -226,7 +226,7 @@ impl<'a> IpccTxChannel<'a> {
         let ret = f();
         fence(Ordering::Release);
 
-        trace!("ipcc: ch {}: send data", self.index as u8);
+        trace!("ipcc: ch {}: send data", self.index + 1);
         regs.cpu(core.to_index().into())
             .scr()
             .write(|w| w.set_chs(self.index as usize, true));
@@ -242,7 +242,7 @@ impl<'a> IpccTxChannel<'a> {
 
         // This is a race, but is nice for debugging
         if regs.cpu(core.to_index().into()).sr().read().chf(self.index as usize) {
-            trace!("ipcc: ch {}: wait for tx free", self.index as u8);
+            trace!("ipcc: ch {}: wait for tx free", self.index + 1);
         } else {
             return;
         }
@@ -307,10 +307,25 @@ impl<'a> IpccRxChannel<'a> {
         }
     }
 
+    /// Clear the channel to receive more data
+    pub fn clear(&mut self) {
+        let regs = IPCC::regs();
+        let core = CoreId::current();
+
+        trace!("ipcc: ch {}: clear rx", self.index + 1);
+
+        // If the channel is clear and the read function returns none, fetch more data
+        regs.cpu(core.to_index().into())
+            .scr()
+            .write(|w| w.set_chc(self.index as usize, true));
+
+        IPCC::state().rx_waker_for(self.index).wake();
+    }
+
     /// Receive data from an IPCC channel. The closure is called to read the data when appropriate.
     ///
-    /// `close` determines whether the channel will be open for receiving more data, or not after data is read.
-    pub async fn receive<R>(&mut self, mut f: impl FnMut() -> Option<R>, close: bool) -> R {
+    /// `clear` determines whether the channel will fetch more data, even if some is returned.
+    pub async fn receive<R>(&mut self, mut f: impl FnMut() -> Option<R>, clear: bool) -> R {
         let _scoped_wake_guard = IPCC::RCC_INFO.wake_guard();
         let regs = IPCC::regs();
         let core = CoreId::current();
@@ -322,7 +337,7 @@ impl<'a> IpccRxChannel<'a> {
                 .read()
                 .chf(self.index as usize)
             {
-                trace!("ipcc: ch {}: wait for rx occupied", self.index as u8);
+                trace!("ipcc: ch {}: wait for rx occupied", self.index + 1);
 
                 let _irq = ActiveRxInterrupt::new(core, self.index);
                 poll_fn(|cx| {
@@ -344,17 +359,16 @@ impl<'a> IpccRxChannel<'a> {
                 .await;
             }
 
-            trace!("ipcc: ch {}: read data", self.index as u8);
+            trace!("ipcc: ch {}: read data", self.index + 1);
 
             fence(Ordering::Acquire);
             let ret = f();
 
-            trace!("ipcc: ch {}: clear rx", self.index as u8);
             compiler_fence(Ordering::SeqCst);
-            // If the channel is clear and the read function returns none, fetch more data
-            regs.cpu(core.to_index().into())
-                .scr()
-                .write(|w| w.set_chc(self.index as usize, ret.is_none() || !close));
+            if ret.is_none() || clear {
+                self.clear();
+            }
+
             match ret {
                 Some(ret) => return ret,
                 None => {}
@@ -459,10 +473,17 @@ impl Ipcc {
     }
 
     /// Receive from a channel number
-    pub async unsafe fn receive<R>(number: u8, f: impl FnMut() -> Option<R>, close: bool) -> R {
+    pub async unsafe fn receive<R>(number: u8, f: impl FnMut() -> Option<R>, clear: bool) -> R {
         core::assert!(number > 0 && number <= 6);
 
-        IpccRxChannel::new(number - 1).receive(f, close).await
+        IpccRxChannel::new(number - 1).receive(f, clear).await
+    }
+
+    /// Receive from a channel number
+    pub unsafe fn clear(number: u8) {
+        core::assert!(number > 0 && number <= 6);
+
+        IpccRxChannel::new(number - 1).clear();
     }
 
     /// Send to a channel number


### PR DESCRIPTION
use clear and ipcc variables rather than software variables to track state.