### PR TITLE
stm32/ipcc: remove clear flag

### DIFF
--- a/embassy-stm32-wpan/src/wb/sub/ble.rs
+++ b/embassy-stm32-wpan/src/wb/sub/ble.rs
@@ -121,18 +121,15 @@ impl<'a> Ble<'a> {
     /// `HW_IPCC_BLE_EvtNot`
     pub async fn tl_read(&mut self) -> EvtBox<Self> {
         self.ipcc_ble_event_channel
-            .receive(
-                || unsafe {
-                    if let Some(node_ptr) =
-                        critical_section::with(|cs| LinkedListNode::remove_head(cs, EVT_QUEUE.as_mut_ptr()))
-                    {
-                        Some(EvtBox::new(node_ptr.cast()))
-                    } else {
-                        None
-                    }
-                },
-                false,
-            )
+            .receive(|| unsafe {
+                if let Some(node_ptr) =
+                    critical_section::with(|cs| LinkedListNode::remove_head(cs, EVT_QUEUE.as_mut_ptr()))
+                {
+                    Some(EvtBox::new(node_ptr.cast()))
+                } else {
+                    None
+                }
+            })
             .await
     }
 
@@ -163,14 +160,11 @@ impl<'a> Ble<'a> {
     pub async fn acl_read(&mut self) -> EvtBox<Self> {
         ACL_EVT_OUT.wait_for_low().await;
         self.ipcc_hci_acl_rx_data_channel
-            .receive(
-                || unsafe {
-                    ACL_EVT_OUT.set_high();
+            .receive(|| unsafe {
+                ACL_EVT_OUT.set_high();
 
-                    Some(EvtBox::new(HCI_ACL_DATA_BUFFER.as_mut_ptr() as *mut _))
-                },
-                false,
-            )
+                Some(EvtBox::new(HCI_ACL_DATA_BUFFER.as_mut_ptr() as *mut _))
+            })
             .await
     }
 }
@@ -241,18 +235,15 @@ impl<'a> BleRx<'a> {
     /// `HW_IPCC_BLE_EvtNot`
     pub async fn tl_read(&mut self) -> EvtBox<Ble<'a>> {
         self.ipcc_ble_event_channel
-            .receive(
-                || unsafe {
-                    if let Some(node_ptr) =
-                        critical_section::with(|cs| LinkedListNode::remove_head(cs, EVT_QUEUE.as_mut_ptr()))
-                    {
-                        Some(EvtBox::new(node_ptr.cast()))
-                    } else {
-                        None
-                    }
-                },
-                false,
-            )
+            .receive(|| unsafe {
+                if let Some(node_ptr) =
+                    critical_section::with(|cs| LinkedListNode::remove_head(cs, EVT_QUEUE.as_mut_ptr()))
+                {
+                    Some(EvtBox::new(node_ptr.cast()))
+                } else {
+                    None
+                }
+            })
             .await
     }
 
@@ -260,14 +251,11 @@ impl<'a> BleRx<'a> {
     pub async fn acl_read(&mut self) -> EvtBox<Ble<'a>> {
         ACL_EVT_OUT.wait_for_low().await;
         self.ipcc_hci_acl_rx_data_channel
-            .receive(
-                || unsafe {
-                    ACL_EVT_OUT.set_high();
+            .receive(|| unsafe {
+                ACL_EVT_OUT.set_high();
 
-                    Some(EvtBox::new(HCI_ACL_DATA_BUFFER.as_mut_ptr() as *mut _))
-                },
-                false,
-            )
+                Some(EvtBox::new(HCI_ACL_DATA_BUFFER.as_mut_ptr() as *mut _))
+            })
             .await
     }
 }
@@ -455,18 +443,15 @@ impl<'d> bt_hci::controller::Controller for AtomicController<'d> {
                         .ipcc_ble_event_channel
                         .lock()
                         .await
-                        .receive(
-                            || unsafe {
-                                if let Some(node_ptr) =
-                                    critical_section::with(|cs| LinkedListNode::remove_head(cs, EVT_QUEUE.as_mut_ptr()))
-                                {
-                                    Some(EvtBox::new(node_ptr.cast()))
-                                } else {
-                                    None
-                                }
-                            },
-                            false,
-                        )
+                        .receive(|| unsafe {
+                            if let Some(node_ptr) =
+                                critical_section::with(|cs| LinkedListNode::remove_head(cs, EVT_QUEUE.as_mut_ptr()))
+                            {
+                                Some(EvtBox::new(node_ptr.cast()))
+                            } else {
+                                None
+                            }
+                        })
                         .await;
 
                     let (pkt, _) = ControllerToHostPacket::from_hci_bytes(&evt.serial()).map_err(to_err)?;
@@ -504,25 +489,22 @@ impl<'d> bt_hci::controller::Controller for AtomicController<'d> {
                 let mut channel = self.ipcc_hci_acl_rx_data_channel.lock().await;
 
                 channel
-                    .receive(
-                        || unsafe {
-                            // We must copy out the event immediately so that it is not trashed by a pending command.
+                    .receive(|| unsafe {
+                        // We must copy out the event immediately so that it is not trashed by a pending command.
 
-                            let buf = core::slice::from_raw_parts_mut(buf as *mut _ as *mut u8, buf.len());
-                            let evt: EvtBox<Ble<'d>> = EvtBox::new(HCI_ACL_DATA_BUFFER.as_mut_ptr() as *mut _);
-                            let serial = evt.serial();
-                            buf[..serial.len()].copy_from_slice(serial);
+                        let buf = core::slice::from_raw_parts_mut(buf as *mut _ as *mut u8, buf.len());
+                        let evt: EvtBox<Ble<'d>> = EvtBox::new(HCI_ACL_DATA_BUFFER.as_mut_ptr() as *mut _);
+                        let serial = evt.serial();
+                        buf[..serial.len()].copy_from_slice(serial);
 
-                            // rx will be cleared by evt box drop
+                        // rx will be cleared by evt box drop
 
-                            Some(
-                                ControllerToHostPacket::from_hci_bytes(buf)
-                                    .map(|(pkt, _)| pkt)
-                                    .map_err(to_err),
-                            )
-                        },
-                        false,
-                    )
+                        Some(
+                            ControllerToHostPacket::from_hci_bytes(buf)
+                                .map(|(pkt, _)| pkt)
+                                .map_err(to_err),
+                        )
+                    })
                     .await
             },
         )

--- a/embassy-stm32-wpan/src/wb/sub/mac.rs
+++ b/embassy-stm32-wpan/src/wb/sub/mac.rs
@@ -121,16 +121,13 @@ impl<'a> MacRx<'a> {
 
         // Return a new event box
         self.ipcc_mac_802_15_4_notification_ack_channel
-            .receive(
-                || unsafe {
-                    MAC_EVT_OUT.set_high();
+            .receive(|| unsafe {
+                MAC_EVT_OUT.set_high();
 
-                    Some(MacEvent::new(EvtBox::new(
-                        MAC_802_15_4_NOTIF_RSP_EVT_BUFFER.as_mut_ptr() as *mut _,
-                    )))
-                },
-                false,
-            )
+                Some(MacEvent::new(EvtBox::new(
+                    MAC_802_15_4_NOTIF_RSP_EVT_BUFFER.as_mut_ptr() as *mut _,
+                )))
+            })
             .await
     }
 }

--- a/embassy-stm32-wpan/src/wb/sub/sys.rs
+++ b/embassy-stm32-wpan/src/wb/sub/sys.rs
@@ -125,18 +125,15 @@ impl<'a> Sys<'a> {
     /// handles the event channels directly.
     pub async fn read(&mut self) -> EvtBox<mm::MemoryManager<'_>> {
         self.ipcc_system_event_channel
-            .receive(
-                || unsafe {
-                    if let Some(node_ptr) =
-                        critical_section::with(|cs| LinkedListNode::remove_head(cs, SYSTEM_EVT_QUEUE.as_mut_ptr()))
-                    {
-                        Some(EvtBox::new(node_ptr.cast()))
-                    } else {
-                        None
-                    }
-                },
-                false,
-            )
+            .receive(|| unsafe {
+                if let Some(node_ptr) =
+                    critical_section::with(|cs| LinkedListNode::remove_head(cs, SYSTEM_EVT_QUEUE.as_mut_ptr()))
+                {
+                    Some(EvtBox::new(node_ptr.cast()))
+                } else {
+                    None
+                }
+            })
             .await
     }
 }

--- a/embassy-stm32/src/ipcc.rs
+++ b/embassy-stm32/src/ipcc.rs
@@ -323,9 +323,7 @@ impl<'a> IpccRxChannel<'a> {
     }
 
     /// Receive data from an IPCC channel. The closure is called to read the data when appropriate.
-    ///
-    /// `clear` determines whether the channel will fetch more data, even if some is returned.
-    pub async fn receive<R>(&mut self, mut f: impl FnMut() -> Option<R>, clear: bool) -> R {
+    pub async fn receive<R>(&mut self, mut f: impl FnMut() -> Option<R>) -> R {
         let _scoped_wake_guard = IPCC::RCC_INFO.wake_guard();
         let regs = IPCC::regs();
         let core = CoreId::current();
@@ -365,7 +363,7 @@ impl<'a> IpccRxChannel<'a> {
             let ret = f();
 
             compiler_fence(Ordering::SeqCst);
-            if ret.is_none() || clear {
+            if ret.is_none() {
                 self.clear();
             }
 
@@ -473,10 +471,10 @@ impl Ipcc {
     }
 
     /// Receive from a channel number
-    pub async unsafe fn receive<R>(number: u8, f: impl FnMut() -> Option<R>, clear: bool) -> R {
+    pub async unsafe fn receive<R>(number: u8, f: impl FnMut() -> Option<R>) -> R {
         core::assert!(number > 0 && number <= 6);
 
-        IpccRxChannel::new(number - 1).receive(f, clear).await
+        IpccRxChannel::new(number - 1).receive(f).await
     }
 
     /// Receive from a channel number

--- a/examples/stm32wl55cm0p-lp/src/bin/intercore.rs
+++ b/examples/stm32wl55cm0p-lp/src/bin/intercore.rs
@@ -66,7 +66,7 @@ async fn main(_spawner: Spawner) -> ! {
     _spawner.spawn(blink_heartbeat(red_led).unwrap());
 
     loop {
-        let state = rx.receive(|| Some(LED_STATE.load(Ordering::SeqCst)), false).await;
+        let state = rx.receive(|| Some(LED_STATE.load(Ordering::SeqCst))).await;
         #[cfg(feature = "defmt")]
         info!("CM0+ Recieve: {}", state);
         green_led.set_level(if state { Level::High } else { Level::Low });

--- a/examples/stm32wl55cm0p/src/bin/intercore.rs
+++ b/examples/stm32wl55cm0p/src/bin/intercore.rs
@@ -60,7 +60,7 @@ async fn main(_spawner: Spawner) -> ! {
     _spawner.spawn(blink_heartbeat(red_led).unwrap());
 
     loop {
-        let state = rx.receive(|| Some(LED_STATE.load(Ordering::Relaxed)), false).await;
+        let state = rx.receive(|| Some(LED_STATE.load(Ordering::Relaxed))).await;
         info!("CM0+ Recieve: {}", state);
         blue_led.set_level(if state { Level::High } else { Level::Low });
     }


### PR DESCRIPTION
this flag was not necessary and a bad idea, now that there is a clear method.