### PR TITLE
stm32/qspi: add 2-IO bank constructors that don't claim IO2/IO3

### DIFF
--- a/embassy-stm32/src/qspi/enums.rs
+++ b/embassy-stm32/src/qspi/enums.rs
@@ -22,7 +22,7 @@ impl From<QspiMode> for u8 {
 
 /// QSPI lane width
 #[allow(dead_code)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq, Eq, PartialOrd, Ord)]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub enum QspiWidth {
     /// None

--- a/embassy-stm32/src/qspi/mod.rs
+++ b/embassy-stm32/src/qspi/mod.rs
@@ -177,6 +177,37 @@ impl<'d, T: Instance, M: PeriMode> Qspi<'d, T, M> {
         }
     }
 
+    /// Widest transfer width supported.
+    pub fn max_transfer_width(&self) -> QspiWidth {
+        let bank_max = |d0, d1, d2, d3| match (d0, d1, d2, d3) {
+            (Some(_), Some(_), Some(_), Some(_)) => QspiWidth::QUAD,
+            (Some(_), Some(_), _, _) => QspiWidth::DUAL,
+            (Some(_), _, _, _) => QspiWidth::SING,
+            _ => QspiWidth::NONE,
+        };
+        let bk1 = bank_max(
+            self.bk1d0.as_ref(),
+            self.bk1d1.as_ref(),
+            self.bk1d2.as_ref(),
+            self.bk1d3.as_ref(),
+        );
+        let bk2 = bank_max(
+            self.bk2d0.as_ref(),
+            self.bk2d1.as_ref(),
+            self.bk2d2.as_ref(),
+            self.bk2d3.as_ref(),
+        );
+        bk1.max(bk2)
+    }
+
+    /// Panic if any width in `transaction` exceeds the wired-up IO lanes.
+    fn assert_transfer_widths(&self, transaction: &TransferConfig) {
+        let max = self.max_transfer_width();
+        if transaction.iwidth > max || transaction.awidth > max || transaction.dwidth > max {
+            panic!("QSPI transfer width exceeds configured IO lanes");
+        }
+    }
+
     /// Do a QSPI command.
     pub fn blocking_command(&mut self, transaction: TransferConfig) {
         #[cfg(not(stm32h7))]
@@ -233,6 +264,8 @@ impl<'d, T: Instance, M: PeriMode> Qspi<'d, T, M> {
 
     /// Enable memory map mode
     pub fn enable_memory_map(&mut self, transaction: &TransferConfig) {
+        self.assert_transfer_widths(transaction);
+
         T::REGS.fcr().modify(|v| {
             v.set_csmf(true);
             v.set_ctcf(true);
@@ -320,6 +353,8 @@ impl<'d, T: Instance, M: PeriMode> Qspi<'d, T, M> {
     }
 
     fn setup_transaction(&mut self, fmode: QspiMode, transaction: &TransferConfig, data_len: Option<usize>) {
+        self.assert_transfer_widths(transaction);
+
         match (transaction.address, transaction.awidth) {
             (Some(_), QspiWidth::NONE) => panic!("QSPI address can't be sent with an address width of NONE"),
             (Some(_), _) => {}
@@ -401,6 +436,39 @@ impl<'d, T: Instance> Qspi<'d, T, Blocking> {
         )
     }
 
+    /// Create a new QSPI driver for bank 1 using only IO0/IO1, in blocking mode.
+    ///
+    /// d2/d3 are not claimed; transfers asking for `QspiWidth::QUAD` will panic.
+    pub fn new_blocking_bank1_2io(
+        peri: Peri<'d, T>,
+        d0: Peri<'d, impl BK1D0Pin<T>>,
+        d1: Peri<'d, impl BK1D1Pin<T>>,
+        sck: Peri<'d, impl SckPin<T>>,
+        nss: Peri<'d, impl BK1NSSPin<T>>,
+        config: Config,
+    ) -> Self {
+        Self::new_inner(
+            peri,
+            new_pin!(d0, AfType::output(OutputType::PushPull, config.gpio_speed)),
+            new_pin!(d1, AfType::output(OutputType::PushPull, config.gpio_speed)),
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            new_pin!(sck, AfType::output(OutputType::PushPull, config.gpio_speed)),
+            new_pin!(
+                nss,
+                AfType::output_pull(OutputType::PushPull, config.gpio_speed, Pull::Up)
+            ),
+            None,
+            None,
+            config,
+            FlashSelection::Flash1,
+        )
+    }
+
     /// Create a new QSPI driver for bank 2, in blocking mode.
     pub fn new_blocking_bank2(
         peri: Peri<'d, T>,
@@ -433,6 +501,40 @@ impl<'d, T: Instance> Qspi<'d, T, Blocking> {
             FlashSelection::Flash2,
         )
     }
+
+    /// Create a new QSPI driver for bank 2 using only IO0/IO1, in blocking mode.
+    ///
+    /// d2/d3 are not claimed; transfers asking for `QspiWidth::QUAD` will panic.
+    pub fn new_blocking_bank2_2io(
+        peri: Peri<'d, T>,
+        d0: Peri<'d, impl BK2D0Pin<T>>,
+        d1: Peri<'d, impl BK2D1Pin<T>>,
+        sck: Peri<'d, impl SckPin<T>>,
+        nss: Peri<'d, impl BK2NSSPin<T>>,
+        config: Config,
+    ) -> Self {
+        Self::new_inner(
+            peri,
+            None,
+            None,
+            None,
+            None,
+            new_pin!(d0, AfType::output(OutputType::PushPull, config.gpio_speed)),
+            new_pin!(d1, AfType::output(OutputType::PushPull, config.gpio_speed)),
+            None,
+            None,
+            new_pin!(sck, AfType::output(OutputType::PushPull, config.gpio_speed)),
+            None,
+            new_pin!(
+                nss,
+                AfType::output_pull(OutputType::PushPull, config.gpio_speed, Pull::Up)
+            ),
+            None,
+            config,
+            FlashSelection::Flash2,
+        )
+    }
+
     /// Create a new QSPI driver for a dual bank, in blocking mode.
     /// NOTE: Both nss pins are optional, there are 3 mods of operation: (1)boths flashes share nss 1, (2)boths flashes share nss 2,(3)each flash have its own nss pin.
     pub fn new_blocking_dual_bank(
@@ -513,6 +615,48 @@ impl<'d, T: Instance> Qspi<'d, T, Async> {
         )
     }
 
+    /// Create a new QSPI driver for bank 1 using only IO0/IO1.
+    ///
+    /// d2/d3 are not claimed; transfers asking for `QspiWidth::QUAD` will panic.
+    pub fn new_bank1_2io<D, I>(
+        peri: Peri<'d, T>,
+        d0: Peri<'d, impl BK1D0Pin<T>>,
+        d1: Peri<'d, impl BK1D1Pin<T>>,
+        sck: Peri<'d, impl SckPin<T>>,
+        nss: Peri<'d, impl BK1NSSPin<T>>,
+        dma: Peri<'d, D>,
+        _irq: I,
+        config: Config,
+    ) -> Self
+    where
+        D: QuadDma<T>,
+        I: Binding<D::Interrupt, crate::dma::InterruptHandler<D>> + Binding<T::Interrupt, InterruptHandler<T>> + 'd,
+    {
+        T::Interrupt::unpend();
+        unsafe { T::Interrupt::enable() };
+
+        Self::new_inner(
+            peri,
+            new_pin!(d0, AfType::output(OutputType::PushPull, config.gpio_speed)),
+            new_pin!(d1, AfType::output(OutputType::PushPull, config.gpio_speed)),
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            new_pin!(sck, AfType::output(OutputType::PushPull, config.gpio_speed)),
+            new_pin!(
+                nss,
+                AfType::output_pull(OutputType::PushPull, config.gpio_speed, Pull::Up)
+            ),
+            None,
+            new_dma!(dma, _irq),
+            config,
+            FlashSelection::Flash1,
+        )
+    }
+
     /// Create a new QSPI driver for bank 2.
     pub fn new_bank2<D, I>(
         peri: Peri<'d, T>,
@@ -543,6 +687,48 @@ impl<'d, T: Instance> Qspi<'d, T, Async> {
             new_pin!(d1, AfType::output(OutputType::PushPull, config.gpio_speed)),
             new_pin!(d2, AfType::output(OutputType::PushPull, config.gpio_speed)),
             new_pin!(d3, AfType::output(OutputType::PushPull, config.gpio_speed)),
+            new_pin!(sck, AfType::output(OutputType::PushPull, config.gpio_speed)),
+            None,
+            new_pin!(
+                nss,
+                AfType::output_pull(OutputType::PushPull, config.gpio_speed, Pull::Up)
+            ),
+            new_dma!(dma, _irq),
+            config,
+            FlashSelection::Flash2,
+        )
+    }
+
+    /// Create a new QSPI driver for bank 2 using only IO0/IO1.
+    ///
+    /// d2/d3 are not claimed; transfers asking for `QspiWidth::QUAD` will panic.
+    pub fn new_bank2_2io<D, I>(
+        peri: Peri<'d, T>,
+        d0: Peri<'d, impl BK2D0Pin<T>>,
+        d1: Peri<'d, impl BK2D1Pin<T>>,
+        sck: Peri<'d, impl SckPin<T>>,
+        nss: Peri<'d, impl BK2NSSPin<T>>,
+        dma: Peri<'d, D>,
+        _irq: I,
+        config: Config,
+    ) -> Self
+    where
+        D: QuadDma<T>,
+        I: Binding<D::Interrupt, crate::dma::InterruptHandler<D>> + Binding<T::Interrupt, InterruptHandler<T>> + 'd,
+    {
+        T::Interrupt::unpend();
+        unsafe { T::Interrupt::enable() };
+
+        Self::new_inner(
+            peri,
+            None,
+            None,
+            None,
+            None,
+            new_pin!(d0, AfType::output(OutputType::PushPull, config.gpio_speed)),
+            new_pin!(d1, AfType::output(OutputType::PushPull, config.gpio_speed)),
+            None,
+            None,
             new_pin!(sck, AfType::output(OutputType::PushPull, config.gpio_speed)),
             None,
             new_pin!(


### PR DESCRIPTION
Some boards wire only the lower two data lines of a QSPI flash to the MCU and tie /WP and /HOLD high externally, leaving the MCU pins that would otherwise be IO2/IO3 free for other peripherals. The existing new_bank{1,2} / new_blocking_bank{1,2} constructors require all four IO pins, so this configuration was unreachable through the public API.

Add new_bank{1,2}_2io and new_blocking_bank{1,2}_2io, which omit the d2/d3 arguments and pass None for those slots into new_inner. Transfers are limited to single- or dual-line widths; setting a QspiWidth in a transfer greater than configured by the constructor will cause a panic.