### PR TITLE
stm32/i2c: new_no_dma

### DIFF
--- a/embassy-stm32/src/i2c/mod.rs
+++ b/embassy-stm32/src/i2c/mod.rs
@@ -164,6 +164,26 @@ impl<'d> I2c<'d, Async, Master> {
             config,
         )
     }
+
+    /// Create a new I2C driver.
+    pub fn new_no_dma<T: Instance, #[cfg(afio)] A>(
+        peri: Peri<'d, T>,
+        scl: Peri<'d, if_afio!(impl SclPin<T, A>)>,
+        sda: Peri<'d, if_afio!(impl SdaPin<T, A>)>,
+        _irq: impl interrupt::typelevel::Binding<T::EventInterrupt, EventInterruptHandler<T>>
+        + interrupt::typelevel::Binding<T::ErrorInterrupt, ErrorInterruptHandler<T>>
+        + 'd,
+        config: Config,
+    ) -> Self {
+        Self::new_inner(
+            peri,
+            new_pin!(scl, config.scl_af()),
+            new_pin!(sda, config.sda_af()),
+            None,
+            None,
+            config,
+        )
+    }
 }
 
 impl<'d> I2c<'d, Blocking, Master> {


### PR DESCRIPTION
Closes #5974

> The method [listen](https://docs.embassy.dev/embassy-stm32/0.6.0/stm32f303k8/i2c/struct.I2c.html#method.listen) on I2c claims to not require DMA, which is correct for the listen method itself. But still requires DMA since the listen method is only defined for the async variant of the peripheral which can only be constructed with rx and tx DMA channels.


Tested on a stm32f030

```rust
    let slave_config = SlaveAddrConfig::basic(SLAVE_ADDR);
    let mut slave = I2c::new_no_dma(p, sda, sck, Irqs, config).into_slave_multimaster(slave_config);
    info!("i2c slave listening for address: {:#x}", SLAVE_ADDR);
    loop {
        let cmd = unwrap!(slave.listen().await);
        debug!("read requested: {}", cmd);
        if let SlaveCommand {
            kind: i2c::SlaveCommandKind::Read,
            address: _,
        } = cmd
        {
            let data = data();
            let res = slave.blocking_respond_to_read(&data[..]);
            if let Err(e) = res {
                error!("i2c respond error: {}", e);
            }
        } else {
            warn!("unsupported slave command: {}", cmd);
        }
    }

```