### PR TITLE
Fix N6 HSI Trim

### DIFF
--- a/embassy-stm32/src/rcc/n6.rs
+++ b/embassy-stm32/src/rcc/n6.rs
@@ -177,7 +177,7 @@ impl Config {
         Self {
             hsi: Some(Hsi {
                 pre: HsiPrescaler::Div1,
-                trim: HsiCalibration::from_bits(32),
+                trim: HsiCalibration::Zero,
             }),
             hse: None,
             msi: None,


### PR DESCRIPTION
**Issue**

The N6 HSI is factory calibrated to 64 MHz. This internal oscillator can be further adjusted by the user using HSI trim. 

[This PR](https://github.com/embassy-rs/embassy/pull/4714) added support for the N6 clocks, but set HSI trim to a default of 32, which increased the frequency by 4 MHz, making HSI 68 MHz. This error propagates into the UART / CAN baud rates (and probably other peripherals), causing communication failures.

From briefly looking online, it seems like some STM32 boards do expect a default of 32 or 64 for trim, so perhaps it was based on that? For the N6 at least this is not the case, as can be seen in the reset value in the reference manual.

<img width="796" height="163" alt="image" src="https://github.com/user-attachments/assets/77eb12d6-dd88-4f4e-83af-2a28b94b2e72" />

This invalid trim was tested on the N6 Disco / Nucleo kits by @tarfu and on custom N6 boards by me.

**Solution**

Setting it to zero in the config would work, but I figure we should change the default too so folks don't accidentally run into this.