### PR TITLE
[MCXA] Normalize RAW ADC

### DIFF
--- a/embassy-mcxa/src/adc.rs
+++ b/embassy-mcxa/src/adc.rs
@@ -389,7 +389,7 @@ pub struct Conversion {
     pub loop_channel_index: u8,
     /// The trigger that triggered the command to run
     pub trigger_id_source: u8,
-    /// The raw value from the ADC
+    /// The converted value, normalized to the configured resolution (0–4095 for 12-bit, 0–65535 for 16-bit)
     pub conv_value: u16,
 }
 
@@ -563,8 +563,8 @@ impl<'a, M: Mode> Adc<'a, M> {
         // In 16-bit mode, the full 16-bit range is used and no shift is needed.
         let conv_value = if cmd_index > 0 && cmd_index <= self.commands.len() {
             match self.commands[cmd_index - 1].config.resolution {
-                ConvMode::DATA_12_BITS => raw_value >> 3,
-                ConvMode::DATA_16_BITS => raw_value,
+                ConvMode::Data12Bits => raw_value >> 3,
+                ConvMode::Data16Bits => raw_value,
             }
         } else {
             raw_value

--- a/embassy-mcxa/src/adc.rs
+++ b/embassy-mcxa/src/adc.rs
@@ -553,12 +553,28 @@ impl<'a, M: Mode> Adc<'a, M> {
         }
 
         let fifo = self.info.regs().resfifo0().read();
+        let cmd_index = fifo.cmdsrc() as usize;
+        let raw_value = fifo.d();
+
+        // Normalize the raw ADC result based on the configured resolution.
+        // In 12-bit mode, the LPADC stores results left-justified in the
+        // 16-bit RESFIFO D field (bits [15:3]), so right-shift by 3 to
+        // produce the actual 12-bit value (0–4095).
+        // In 16-bit mode, the full 16-bit range is used and no shift is needed.
+        let conv_value = if cmd_index > 0 && cmd_index <= self.commands.len() {
+            match self.commands[cmd_index - 1].config.resolution {
+                ConvMode::DATA_12_BITS => raw_value >> 3,
+                ConvMode::DATA_16_BITS => raw_value,
+            }
+        } else {
+            raw_value
+        };
 
         Ok(Conversion {
             command: (fifo.cmdsrc() as u8).into(),
             loop_channel_index: fifo.loopcnt() as u8,
             trigger_id_source: fifo.tsrc() as u8,
-            conv_value: fifo.d(),
+            conv_value,
         })
     }
 


### PR DESCRIPTION
Normalize the raw ADC result based on the configured resolution. In 12-bit mode, the LPADC stores results left-justified in the 16-bit RESFIFO D field (bits [15:3]), so right-shift by 3 to produce the actual 12-bit value (0–4095). In 16-bit mode, the full 16-bit range is used and no shift is needed.