### PR TITLE
stm32/qspi: wait for BUSY to clear before entering memory-mapped mode

### DIFF
--- a/embassy-stm32/src/qspi/mod.rs
+++ b/embassy-stm32/src/qspi/mod.rs
@@ -272,6 +272,9 @@ impl<'d, T: Instance, M: PeriMode> Qspi<'d, T, M> {
             v.set_ctef(true);
             v.set_ctof(true);
         });
+
+        while T::REGS.sr().read().busy() {}
+
         T::REGS.ccr().write(|v| {
             v.set_fmode(QspiMode::MemoryMapped.into());
             v.set_imode(transaction.iwidth.into());


### PR DESCRIPTION
enable_memory_map writes CCR to switch fmode to MemoryMapped, but did not first wait for any in-flight indirect transaction to complete. Per RM0402 12.5.6, every field in QUADSPI_CCR (including FMODE[1:0]) "can be written only when BUSY = 0", so writing CCR mid-transaction is prohibited.

This commit brings enable_memory_map in line with the other setup paths (setup_transaction, setup_auto_poll, the blocking_command paths) which already wait on SR.BUSY before reconfiguring CCR.

Reproduced on STM32F412 with a W25Q128: a blocking_read of the flash status register followed immediately by enable_memory_map left the CCR write rejected (CCR retained the indirect-read configuration), so the next AHB read of the QSPI memory-mapped region produced a precise BusFault. Adding the wait fixes it.