### PR TITLE
examples-rp: actually send to logging interface

### DIFF
--- a/examples/rp/src/bin/usb_serial_with_logger.rs
+++ b/examples/rp/src/bin/usb_serial_with_logger.rs
@@ -102,7 +102,7 @@ async fn echo<'d, T: Instance + 'd>(class: &mut CdcAcmClass<'d, Driver<'d, T>>) 
     loop {
         let n = class.read_packet(&mut buf).await?;
         let data = &buf[..n];
-        info!("data: {:x}", data);
+        log::info!("data: {:x?}", data);
         class.write_packet(data).await?;
     }
 }


### PR DESCRIPTION
Use `log::info!` instead of `dfmt::info!` to log incoming CDC serial data to the logging interface.