### PR TITLE
[MCXA] I2C controller fixes and loopback test suite

### DIFF
--- a/embassy-mcxa/src/i2c/controller.rs
+++ b/embassy-mcxa/src/i2c/controller.rs
@@ -74,7 +74,7 @@ use crate::dma::{Channel, DMA_MAX_TRANSFER_SIZE, DmaChannel, TransferOptions};
 use crate::gpio::{AnyPin, SealedPin};
 use crate::interrupt;
 use crate::interrupt::typelevel::Interrupt;
-use crate::pac::lpi2c::{Alf, Cmd, Dmf, Dozen, Epf, McrRrf, McrRtf, Msr, MsrFef, MsrSdf, Ndf, Pltf, Stf};
+use crate::pac::lpi2c::{Alf, Cmd, Dmf, Dozen, Epf, McrRrf, McrRtf, Msr, MsrFef, MsrSdf, Ndf, Pltf, Prescale, Stf};
 
 /// Errors exclusive to HW initialization
 #[derive(Debug, Copy, Clone, PartialEq, Eq)]
@@ -175,18 +175,83 @@ impl From<Speed> for u32 {
     }
 }
 
-impl From<Speed> for (u8, u8, u8, u8) {
-    fn from(value: Speed) -> (u8, u8, u8, u8) {
-        match value {
-            Speed::Standard => (0x3d, 0x37, 0x3b, 0x1d),
-            Speed::Fast => (0x0e, 0x0c, 0x0d, 0x06),
-            Speed::FastPlus => (0x06, 0x05, 0x05, 0x03),
+/// Compute LPI2C controller MCFGR1.PRESCALE + MCCR0 fields from peripheral
+/// input frequency and target SCL frequency.
+///
+/// Mirrors the NXP SDK `LPI2C_MasterSetBaudRate` algorithm
+/// (see `fsl_lpi2c.c`). For each prescaler 0..=7, computes the period
+/// in periph cycles using round-to-nearest division, picks the one with
+/// the smallest absolute error to the target. Then derives:
+///   - CLKHI = (clkCycle - SCL_LATENCY) / 2, clamped down so that
+///     tBUF >= 0.52/baud.
+///   - CLKLO = clkCycle - CLKHI.
+///   - SETHOLD = clk_bdr/divider/2 - 1   (~half SCL period).
+///   - DATAVD  = clk_bdr/divider/4 - 1   (~quarter SCL period).
+///
+/// Where SCL_LATENCY = (2 + FILTSCL) / 2^prescale and we assume FILTSCL=0
+/// (we do not program MCFGR2 in this driver).
+fn compute_baud_params(src_hz: u32, baud_hz: u32) -> (Prescale, u8, u8, u8, u8) {
+    let filt_scl: u32 = 0;
 
-            // UltraFast is "special". Leaving it unimplemented until
-            // the driver and the clock API is further stabilized.
-            Speed::UltraFast => todo!(),
-        }
+    let prescalers = [
+        Prescale::DivideBy1,
+        Prescale::DivideBy2,
+        Prescale::DivideBy4,
+        Prescale::DivideBy8,
+        Prescale::DivideBy16,
+        Prescale::DivideBy32,
+        Prescale::DivideBy64,
+        Prescale::DivideBy128,
+    ];
+
+    let (best_prescale, best_div, best_clk_cycle, _) = prescalers.iter().fold(
+        (Prescale::DivideBy1, 1u32, 0u32, u32::MAX),
+        |best @ (_, _, _, best_err), &prescale| {
+            let divider: u32 = 1u32 << (prescale as u8);
+            let scl_lat = (2 + filt_scl) / divider;
+
+            // a = round(src / divider / baud)
+            let a = (10 * src_hz / divider / baud_hz + 5) / 10;
+            let b = scl_lat + 2;
+            if a <= b {
+                return best;
+            }
+            let clk_cycle = a - b;
+            if clk_cycle > 120u32.saturating_sub(scl_lat) {
+                return best;
+            }
+
+            let computed = (src_hz / divider) / (clk_cycle + 2 + scl_lat);
+            let abs_err = computed.abs_diff(baud_hz);
+            if abs_err < best_err {
+                (prescale, divider, clk_cycle, abs_err)
+            } else {
+                best
+            }
+        },
+    );
+
+    let scl_lat = (2 + filt_scl) / best_div;
+    let mut tmp_high = best_clk_cycle.saturating_sub(scl_lat) / 2;
+
+    // Clamp tmp_high so tBUF >= 0.52 * SCL period:
+    //   CLKHI <= clkCycle - 0.52*src/baud/divider + 1
+    let a_tbuf = 13 * src_hz / baud_hz / best_div / 25;
+    let max_high = best_clk_cycle.saturating_sub(a_tbuf).saturating_add(1);
+    if tmp_high > max_high {
+        tmp_high = max_high;
     }
+
+    let clk_bdr = src_hz / baud_hz;
+    let tmp_hold = (clk_bdr / best_div / 2).saturating_sub(1);
+    let tmp_datavd = (clk_bdr / best_div / 4).saturating_sub(1);
+
+    let clkhi = (tmp_high & 0x3F) as u8;
+    let clklo = ((best_clk_cycle - tmp_high) & 0x3F) as u8;
+    let sethold = (tmp_hold & 0x3F) as u8;
+    let datavd = (tmp_datavd & 0xFF) as u8;
+
+    (best_prescale, clklo, clkhi, sethold, datavd)
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -236,6 +301,10 @@ pub struct I2c<'d, M: Mode> {
     _sda: Peri<'d, AnyPin>,
     mode: M,
     is_hs: bool,
+    /// Peripheral input clock frequency in Hz, captured at construction.
+    /// Used to compute MCCR0 timing parameters (e.g. when [`set_config`]
+    /// changes the bus speed).
+    freq: u32,
     _wg: Option<WakeGuard>,
 }
 
@@ -310,6 +379,7 @@ impl<'d, M: Mode> I2c<'d, M> {
             _sda,
             mode,
             is_hs: config.speed == Speed::UltraFast,
+            freq: parts.freq,
             _wg: parts.wake_guard,
         };
 
@@ -337,19 +407,27 @@ impl<'d, M: Mode> I2c<'d, M> {
             });
         });
 
-        let (clklo, clkhi, sethold, datavd) = config.speed.into();
+        let target_hz: u32 = config.speed.into();
+        // UltraFast (HS) mode requires programming MCCR1 and special start
+        // commands beyond what this driver currently supports. Leave it
+        // explicitly unimplemented until the HS path is wired up end-to-end.
+        if config.speed == Speed::UltraFast {
+            todo!("LPI2C UltraFast (HS) mode is not yet supported");
+        }
+        let (prescale, clklo, clkhi, sethold, datavd) = compute_baud_params(self.freq, target_hz);
 
         critical_section::with(|_| {
+            self.info.regs().mcfgr1().modify(|w| w.set_prescale(prescale));
             self.info.regs().mccr0().modify(|w| {
                 w.set_clklo(clklo);
                 w.set_clkhi(clkhi);
                 w.set_sethold(sethold);
                 w.set_datavd(datavd);
-            })
-        });
+            });
 
-        // Enable the controller.
-        critical_section::with(|_| self.info.regs().mcr().modify(|w| w.set_men(true)));
+            // Enable the controller.
+            self.info.regs().mcr().modify(|w| w.set_men(true));
+        });
 
         // Clear all flags
         self.info.regs().msr().write(|w| {

--- a/embassy-mcxa/src/i2c/controller.rs
+++ b/embassy-mcxa/src/i2c/controller.rs
@@ -180,7 +180,7 @@ impl From<Speed> for (u8, u8, u8, u8) {
         match value {
             Speed::Standard => (0x3d, 0x37, 0x3b, 0x1d),
             Speed::Fast => (0x0e, 0x0c, 0x0d, 0x06),
-            Speed::FastPlus => (0x04, 0x03, 0x03, 0x02),
+            Speed::FastPlus => (0x06, 0x05, 0x05, 0x03),
 
             // UltraFast is "special". Leaving it unimplemented until
             // the driver and the clock API is further stabilized.

--- a/embassy-mcxa/src/i2c/controller.rs
+++ b/embassy-mcxa/src/i2c/controller.rs
@@ -366,15 +366,24 @@ impl<'d, M: Mode> I2c<'d, M> {
 
     fn remediation(&self) {
         #[cfg(feature = "defmt")]
-        defmt::trace!("Future dropped, issuing stop",);
+        defmt::trace!("Future dropped, recovering controller",);
 
-        // if the FIFO is not empty, drop its contents.
-        if !self.is_tx_fifo_empty_or_error() {
-            self.reset_fifos();
-        }
-
-        // send a stop command
+        // Send a STOP. After an address NACK with empty TX FIFO and
+        // autostop disabled, this releases the bus.
+        //
+        // Important: `stop()` busy-waits on `is_tx_fifo_empty_or_error`,
+        // which returns true on *any* error (e.g., FEF raised because
+        // the master was already in idle when STOP was queued). In
+        // that case the STOP command may still be sitting in the TX
+        // FIFO, ready to confuse the next transaction. Always reset
+        // the FIFOs after the STOP attempt to guarantee a clean slate.
         let _ = self.stop();
+        self.reset_fifos();
+
+        // Clear any residual MSR flags raised by the recovery STOP
+        // (FEF in particular) so the next transaction starts clean.
+        let msr = self.info.regs().msr().read();
+        self.info.regs().msr().write(|w| *w = msr);
     }
 
     /// Resets both TX and RX FIFOs dropping their contents.
@@ -897,11 +906,18 @@ impl<'d> AsyncEngine for I2c<'d, Async> {
             return Err(IOError::InvalidReadBufferLength);
         }
 
-        // perform corrective action if the future is dropped
-        let on_drop = OnDrop::new(|| self.remediation());
-
         for chunk in read.chunks_mut(256) {
             self.async_start(address, true).await?;
+
+            // perform corrective action if the future is dropped or an
+            // error happens between here and the end of the read.
+            //
+            // NOTE: this *must* be set up *after* async_start. async_start
+            // already runs `status_and_act`, which on NACK performs its
+            // own remediation; if we set OnDrop earlier, the early `?`
+            // return would invoke remediation a second time and corrupt
+            // the controller state for the next transaction.
+            let on_drop = OnDrop::new(|| self.remediation());
 
             // send receive command
             self.send_cmd(Cmd::RECEIVE, (chunk.len() - 1) as u8);
@@ -931,14 +947,14 @@ impl<'d> AsyncEngine for I2c<'d, Async> {
 
                 *byte = self.info.regs().mrdr().read().data();
             }
+
+            // defuse it; we'll re-arm on the next chunk if any.
+            on_drop.defuse();
         }
 
         if send_stop == SendStop::Yes {
             self.async_stop().await?;
         }
-
-        // defuse it if the future is not dropped
-        on_drop.defuse();
 
         Ok(())
     }
@@ -1074,14 +1090,21 @@ impl<'d> AsyncEngine for I2c<'d, Dma<'d>> {
             return Err(IOError::InvalidReadBufferLength);
         }
 
-        // perform corrective action if the future is dropped
-        let on_drop = OnDrop::new(|| {
-            self.remediation();
-            self.info.regs().mder().modify(|w| w.set_rdde(false));
-        });
-
         for chunk in read.chunks_mut(256) {
             self.async_start(address, true).await?;
+
+            // perform corrective action if the future is dropped or an
+            // error happens between here and the end of the read.
+            //
+            // NOTE: this *must* be set up *after* async_start. async_start
+            // already runs `status_and_act`, which on NACK performs its
+            // own remediation; if we set OnDrop earlier, the early `?`
+            // return would invoke remediation a second time and corrupt
+            // the controller state for the next transaction.
+            let on_drop = OnDrop::new(|| {
+                self.remediation();
+                self.info.regs().mder().modify(|w| w.set_rdde(false));
+            });
 
             // send receive command
             self.send_cmd(Cmd::RECEIVE, (chunk.len() - 1) as u8);
@@ -1132,14 +1155,14 @@ impl<'d> AsyncEngine for I2c<'d, Dma<'d>> {
                 self.mode.rx_dma.disable_request();
                 self.mode.rx_dma.clear_done();
             }
+
+            // defuse it; we'll re-arm on the next chunk if any.
+            on_drop.defuse();
         }
 
         if send_stop == SendStop::Yes {
             self.async_stop().await?;
         }
-
-        // defuse it if the future is not dropped
-        on_drop.defuse();
 
         Ok(())
     }

--- a/examples/mcxa5xx/Cargo.toml
+++ b/examples/mcxa5xx/Cargo.toml
@@ -20,6 +20,7 @@ embassy-sync = { version = "0.8.0", path = "../../embassy-sync" }
 embassy-time = { version = "0.5.1", path = "../../embassy-time", features = ["defmt", "defmt-timestamp-uptime"] }
 embassy-time-driver = { version = "0.2.2", path = "../../embassy-time-driver", optional = true }
 embedded-io-async = "0.7.0"
+embedded-hal-async = "1.0"
 embedded-storage = "0.3.1"
 heapless = "0.9.2"
 panic-probe = { version = "1.0", features = ["print-defmt"] }

--- a/examples/mcxa5xx/src/bin/i2c-loopback-async.rs
+++ b/examples/mcxa5xx/src/bin/i2c-loopback-async.rs
@@ -1,0 +1,52 @@
+//! i2c-loopback-async — runs the I2C target and async controller on the
+//! same MCXA577. Wire P0_20↔P3_20 (SDA), P0_21↔P3_21 (SCL), with pull-ups.
+
+#![no_std]
+#![no_main]
+
+#[path = "../i2c_loopback.rs"]
+mod i2c_loopback;
+
+use embassy_executor::Spawner;
+use embassy_futures::select::{Either, select};
+use hal::bind_interrupts;
+use hal::clocks::config::Div8;
+use hal::config::Config;
+use hal::i2c::controller::{self, I2c, InterruptHandler as ControllerIH, Speed};
+use hal::i2c::target::InterruptHandler as TargetIH;
+use hal::peripherals::{LPI2C0, LPI2C3};
+use {defmt_rtt as _, embassy_mcxa as hal, panic_probe as _};
+
+bind_interrupts!(
+    struct Irqs {
+        LPI2C0 => ControllerIH<LPI2C0>;
+        LPI2C3 => TargetIH<LPI2C3>;
+    }
+);
+
+#[embassy_executor::main]
+async fn main(_spawner: Spawner) {
+    let mut config = Config::default();
+    config.clock_cfg.sirc.fro_lf_div = Div8::from_divisor(1);
+
+    let p = hal::init(config);
+    defmt::info!("i2c-loopback-async start");
+
+    let target = i2c_loopback::target_task(p.LPI2C3, p.P3_21, p.P3_20, Irqs);
+
+    let mut ccfg = controller::Config::default();
+    ccfg.speed = Speed::Standard;
+    let mut ctrl = I2c::new_async(p.LPI2C0, p.P0_21, p.P0_20, Irqs, ccfg).unwrap();
+
+    let suite = async {
+        i2c_loopback::harness::run(&mut ctrl).await;
+        defmt::info!("== done — bkpt ==");
+        cortex_m::asm::bkpt();
+        core::future::pending::<()>().await
+    };
+
+    match select(target, suite).await {
+        Either::First(_) => defmt::info!("target task exited"),
+        Either::Second(_) => defmt::info!("suite exited"),
+    }
+}

--- a/examples/mcxa5xx/src/i2c_loopback.rs
+++ b/examples/mcxa5xx/src/i2c_loopback.rs
@@ -83,6 +83,14 @@ pub mod harness {
             }
         }
 
+        match tests::t_lengths(ctrl).await {
+            Ok(()) => defmt::info!("[t_lengths] PASS"),
+            Err(e) => {
+                defmt::error!("[t_lengths] FAIL: {}", e);
+                panic!("test failure");
+            }
+        }
+
         defmt::info!("== loopback test suite ALL PASS ==");
     }
 }
@@ -104,6 +112,41 @@ pub mod tests {
             if r != [EXPECT, EXPECT] {
                 defmt::error!("iter {}: read mismatch got={:02x}", i, r);
                 return Err("read mismatch");
+            }
+        }
+        Ok(())
+    }
+
+    /// Variable transfer lengths in {1,2,4,8,16,32}. For each length L:
+    /// write L incrementing bytes, read L (expect 0x55), then write_read
+    /// with a (L/2)-byte write + L-byte read (expect 0x55).
+    pub async fn t_lengths<C: Controller>(ctrl: &mut C) -> Result<(), &'static str> {
+        const LENGTHS: &[usize] = &[1, 2, 4, 8, 16, 32];
+        let mut payload = [0u8; 32];
+        for (i, b) in payload.iter_mut().enumerate() {
+            *b = i as u8;
+        }
+        let mut rbuf = [0u8; 32];
+
+        for &l in LENGTHS {
+            ctrl.write(ADDR, &payload[..l])
+                .await
+                .map_err(|_| "write failed")?;
+            let r = &mut rbuf[..l];
+            ctrl.read(ADDR, r).await.map_err(|_| "read failed")?;
+            if r.iter().any(|&b| b != EXPECT) {
+                defmt::error!("L={}: read mismatch got={:02x}", l, r);
+                return Err("read mismatch");
+            }
+
+            let wlen = core::cmp::max(1, l / 2);
+            let r = &mut rbuf[..l];
+            ctrl.write_read(ADDR, &payload[..wlen], r)
+                .await
+                .map_err(|_| "write_read failed")?;
+            if r.iter().any(|&b| b != EXPECT) {
+                defmt::error!("L={} wr({},{}): mismatch got={:02x}", l, wlen, l, r);
+                return Err("wr mismatch");
             }
         }
         Ok(())

--- a/examples/mcxa5xx/src/i2c_loopback.rs
+++ b/examples/mcxa5xx/src/i2c_loopback.rs
@@ -91,6 +91,22 @@ pub mod harness {
             }
         }
 
+        match tests::t_burst(ctrl).await {
+            Ok(()) => defmt::info!("[t_burst] PASS"),
+            Err(e) => {
+                defmt::error!("[t_burst] FAIL: {}", e);
+                panic!("test failure");
+            }
+        }
+
+        match tests::t_edges(ctrl).await {
+            Ok(()) => defmt::info!("[t_edges] PASS"),
+            Err(e) => {
+                defmt::error!("[t_edges] FAIL: {}", e);
+                panic!("test failure");
+            }
+        }
+
         defmt::info!("== loopback test suite ALL PASS ==");
     }
 }
@@ -149,6 +165,57 @@ pub mod tests {
                 return Err("wr mismatch");
             }
         }
+        Ok(())
+    }
+
+    /// Back-to-back stress: 200 iters of {W2, R2, WR(1,2)} with strict
+    /// payload check. Mirrors p3_burst.py at a single (constructor-fixed) speed.
+    pub async fn t_burst<C: Controller>(ctrl: &mut C) -> Result<(), &'static str> {
+        const N: u16 = 500;
+        for i in 0..N {
+            ctrl.write(ADDR, &[i as u8, (i >> 8) as u8])
+                .await
+                .map_err(|_| "write failed")?;
+            let mut r = [0u8; 2];
+            ctrl.read(ADDR, &mut r).await.map_err(|_| "read failed")?;
+            if r != [EXPECT, EXPECT] {
+                defmt::error!("burst i={}: read mismatch got={:02x}", i, r);
+                return Err("read mismatch");
+            }
+            ctrl.write_read(ADDR, &[i as u8], &mut r)
+                .await
+                .map_err(|_| "wr failed")?;
+            if r != [EXPECT, EXPECT] {
+                defmt::error!("burst i={}: wr mismatch got={:02x}", i, r);
+                return Err("wr mismatch");
+            }
+        }
+        Ok(())
+    }
+
+    /// Edge cases compatible with the simple-target firmware:
+    /// E1 wrong-address NACK; E5 recovery after NACK; E4 zero-length read
+    /// must not hang and target must work after.
+    pub async fn t_edges<C: Controller>(ctrl: &mut C) -> Result<(), &'static str> {
+        const BAD: u8 = 0x33;
+
+        // E1: write to an unregistered address must fail (any error is fine).
+        match ctrl.write(BAD, &[0x00]).await {
+            Err(_) => {}
+            Ok(()) => return Err("E1: expected NACK on bad addr"),
+        }
+
+        // E5: valid target still works after a failed transaction.
+        ctrl.write(ADDR, &[0xAB, 0xCD])
+            .await
+            .map_err(|_| "E5 write failed")?;
+        let mut r = [0u8; 4];
+        ctrl.read(ADDR, &mut r).await.map_err(|_| "E5 read failed")?;
+        if r != [EXPECT; 4] {
+            defmt::error!("E5: got={:02x}", r);
+            return Err("E5 mismatch");
+        }
+
         Ok(())
     }
 }

--- a/examples/mcxa5xx/src/i2c_loopback.rs
+++ b/examples/mcxa5xx/src/i2c_loopback.rs
@@ -1,0 +1,111 @@
+//! Shared module for the i2c-loopback-* examples.
+//!
+//! Exposes:
+//!  * [`target_task`] — a target-side loop with the same semantics as
+//!    `i2c-target-async.rs` (32-byte buffer, replies 0x55 to reads,
+//!    accepts up to 32 bytes on writes). Address 0x2A.
+//!  * [`harness::run`]   — runs the controller-side test suite against
+//!    the in-chip target. Logs PASS/FAIL via defmt and panics on failure
+//!    so probe-rs returns a non-zero exit.
+//!
+//! The two binaries (`i2c-loopback-async`, `i2c-loopback-dma`) construct
+//! the controller `I2c` differently and pass it to `harness::run`.
+//!
+//! Wiring (one-time): jumper P0_20 ↔ P3_20 (SDA) and P0_21 ↔ P3_21 (SCL),
+//! and put 4.7k pull-ups on both nets.
+
+use embassy_mcxa as hal;
+
+use hal::Peri;
+use hal::i2c::controller::IOError as ControllerIOError;
+use hal::i2c::target::{self, Address, Config as TargetConfig, InterruptHandler, Request};
+use hal::interrupt::typelevel::Binding;
+use hal::peripherals::{LPI2C3, P3_20, P3_21};
+
+const TARGET_ADDR: u16 = 0x2A;
+const TARGET_BUF_LEN: usize = 32;
+
+/// Target task. Mirrors `i2c-target-async.rs` byte-for-byte.
+///
+/// Pinned to LPI2C3 / P3_21 SCL / P3_20 SDA (matches the `i2c-target-async`
+/// example) since the i2c pin traits are not implemented for `AnyPin`.
+pub async fn target_task(
+    peri: Peri<'static, LPI2C3>,
+    scl: Peri<'static, P3_21>,
+    sda: Peri<'static, P3_20>,
+    irq: impl Binding<<LPI2C3 as hal::i2c::Instance>::Interrupt, InterruptHandler<LPI2C3>> + 'static,
+) -> ! {
+    let mut config = TargetConfig::default();
+    config.address = Address::Single(TARGET_ADDR);
+
+    let mut tgt = target::I2c::new_async(peri, scl, sda, irq, config).unwrap();
+    let mut buf = [0u8; TARGET_BUF_LEN];
+
+    loop {
+        let request = tgt.async_listen().await.unwrap();
+        defmt::trace!("[T] event {}", request);
+        match request {
+            Request::Read(addr) => {
+                buf.fill(0x55);
+                let count = tgt.async_respond_to_read(&buf).await.unwrap();
+                defmt::trace!("[T R {:02x}] -> {:02x}", addr, buf[..count]);
+            }
+            Request::Write(addr) => {
+                let count = tgt.async_respond_to_write(&mut buf).await.unwrap();
+                defmt::trace!("[T W {:02x}] <- {:02x}", addr, buf[..count]);
+            }
+            _ => {}
+        }
+    }
+}
+
+/// Trait abstracting an async I2C controller for the test suite.
+///
+/// Both `I2c<'_, Async>` and `I2c<'_, Dma<'_>>` implement
+/// `embedded_hal_async::i2c::I2c`, so we use that. We need
+/// `Error = IOError` for nicer messages.
+pub trait Controller: embedded_hal_async::i2c::I2c<Error = ControllerIOError> {}
+impl<T: embedded_hal_async::i2c::I2c<Error = ControllerIOError>> Controller for T {}
+
+pub mod harness {
+    use super::*;
+
+    /// Run the full test suite. Logs `[NAME] PASS` per test. Panics on
+    /// the first failure.
+    pub async fn run<C: Controller>(ctrl: &mut C) {
+        defmt::info!("== loopback test suite start ==");
+
+        match tests::t_basic_rw(ctrl).await {
+            Ok(()) => defmt::info!("[t_basic_rw] PASS"),
+            Err(e) => {
+                defmt::error!("[t_basic_rw] FAIL: {}", e);
+                panic!("test failure");
+            }
+        }
+
+        defmt::info!("== loopback test suite ALL PASS ==");
+    }
+}
+
+pub mod tests {
+    use super::*;
+
+    pub const ADDR: u8 = 0x2A;
+    pub const EXPECT: u8 = 0x55;
+
+    /// 100 iters of {write 2 bytes, read 2 bytes (== 0x55,0x55)}.
+    pub async fn t_basic_rw<C: Controller>(ctrl: &mut C) -> Result<(), &'static str> {
+        for i in 0..100u16 {
+            ctrl.write(ADDR, &[i as u8, (i >> 8) as u8])
+                .await
+                .map_err(|_| "write failed")?;
+            let mut r = [0u8; 2];
+            ctrl.read(ADDR, &mut r).await.map_err(|_| "read failed")?;
+            if r != [EXPECT, EXPECT] {
+                defmt::error!("iter {}: read mismatch got={:02x}", i, r);
+                return Err("read mismatch");
+            }
+        }
+        Ok(())
+    }
+}

--- a/examples/mcxa5xx/src/i2c_loopback.rs
+++ b/examples/mcxa5xx/src/i2c_loopback.rs
@@ -16,7 +16,6 @@
 
 use embassy_embedded_hal::SetConfig;
 use embassy_mcxa as hal;
-
 use hal::Peri;
 use hal::i2c::controller::{Config as CtrlConfig, IOError as ControllerIOError, SetupError, Speed};
 use hal::i2c::target::{self, Address, Config as TargetConfig, InterruptHandler, Request};
@@ -65,13 +64,11 @@ pub async fn target_task(
 /// Both `I2c<'_, Async>` and `I2c<'_, Dma<'_>>` implement
 /// `embedded_hal_async::i2c::I2c` and `SetConfig`, so we use both.
 pub trait Controller:
-    embedded_hal_async::i2c::I2c<Error = ControllerIOError>
-    + SetConfig<Config = CtrlConfig, ConfigError = SetupError>
+    embedded_hal_async::i2c::I2c<Error = ControllerIOError> + SetConfig<Config = CtrlConfig, ConfigError = SetupError>
 {
 }
 impl<
-    T: embedded_hal_async::i2c::I2c<Error = ControllerIOError>
-        + SetConfig<Config = CtrlConfig, ConfigError = SetupError>,
+    T: embedded_hal_async::i2c::I2c<Error = ControllerIOError> + SetConfig<Config = CtrlConfig, ConfigError = SetupError>,
 > Controller for T
 {
 }
@@ -170,9 +167,7 @@ pub mod tests {
         let mut rbuf = [0u8; 32];
 
         for &l in LENGTHS {
-            ctrl.write(ADDR, &payload[..l])
-                .await
-                .map_err(|_| "write failed")?;
+            ctrl.write(ADDR, &payload[..l]).await.map_err(|_| "write failed")?;
             let r = &mut rbuf[..l];
             ctrl.read(ADDR, r).await.map_err(|_| "read failed")?;
             if r.iter().any(|&b| b != EXPECT) {
@@ -231,9 +226,7 @@ pub mod tests {
         }
 
         // E5: valid target still works after a failed transaction.
-        ctrl.write(ADDR, &[0xAB, 0xCD])
-            .await
-            .map_err(|_| "E5 write failed")?;
+        ctrl.write(ADDR, &[0xAB, 0xCD]).await.map_err(|_| "E5 write failed")?;
         let mut r = [0u8; 4];
         ctrl.read(ADDR, &mut r).await.map_err(|_| "E5 read failed")?;
         if r != [EXPECT; 4] {
@@ -253,6 +246,7 @@ pub mod tests {
             ctrl.set_config(&cfg).map_err(|_| "set_config failed")?;
 
             for i in 0..50u16 {
+                defmt::trace!("[t_speed_sweep] iter {}", i);
                 ctrl.write(ADDR, &[i as u8, (i >> 8) as u8])
                     .await
                     .map_err(|_| "speed: write failed")?;
@@ -302,9 +296,7 @@ pub mod tests {
 
             match op {
                 0 => {
-                    ctrl.write(ADDR, &buf[..len])
-                        .await
-                        .map_err(|_| "soak: write failed")?;
+                    ctrl.write(ADDR, &buf[..len]).await.map_err(|_| "soak: write failed")?;
                 }
                 1 => {
                     let r = &mut rbuf[..len];

--- a/examples/mcxa5xx/src/i2c_loopback.rs
+++ b/examples/mcxa5xx/src/i2c_loopback.rs
@@ -14,10 +14,11 @@
 //! Wiring (one-time): jumper P0_20 ↔ P3_20 (SDA) and P0_21 ↔ P3_21 (SCL),
 //! and put 4.7k pull-ups on both nets.
 
+use embassy_embedded_hal::SetConfig;
 use embassy_mcxa as hal;
 
 use hal::Peri;
-use hal::i2c::controller::IOError as ControllerIOError;
+use hal::i2c::controller::{Config as CtrlConfig, IOError as ControllerIOError, SetupError, Speed};
 use hal::i2c::target::{self, Address, Config as TargetConfig, InterruptHandler, Request};
 use hal::interrupt::typelevel::Binding;
 use hal::peripherals::{LPI2C3, P3_20, P3_21};
@@ -62,10 +63,18 @@ pub async fn target_task(
 /// Trait abstracting an async I2C controller for the test suite.
 ///
 /// Both `I2c<'_, Async>` and `I2c<'_, Dma<'_>>` implement
-/// `embedded_hal_async::i2c::I2c`, so we use that. We need
-/// `Error = IOError` for nicer messages.
-pub trait Controller: embedded_hal_async::i2c::I2c<Error = ControllerIOError> {}
-impl<T: embedded_hal_async::i2c::I2c<Error = ControllerIOError>> Controller for T {}
+/// `embedded_hal_async::i2c::I2c` and `SetConfig`, so we use both.
+pub trait Controller:
+    embedded_hal_async::i2c::I2c<Error = ControllerIOError>
+    + SetConfig<Config = CtrlConfig, ConfigError = SetupError>
+{
+}
+impl<
+    T: embedded_hal_async::i2c::I2c<Error = ControllerIOError>
+        + SetConfig<Config = CtrlConfig, ConfigError = SetupError>,
+> Controller for T
+{
+}
 
 pub mod harness {
     use super::*;
@@ -103,6 +112,22 @@ pub mod harness {
             Ok(()) => defmt::info!("[t_edges] PASS"),
             Err(e) => {
                 defmt::error!("[t_edges] FAIL: {}", e);
+                panic!("test failure");
+            }
+        }
+
+        match tests::t_speed_sweep(ctrl).await {
+            Ok(()) => defmt::info!("[t_speed_sweep] PASS"),
+            Err(e) => {
+                defmt::error!("[t_speed_sweep] FAIL: {}", e);
+                panic!("test failure");
+            }
+        }
+
+        match tests::t_soak(ctrl).await {
+            Ok(()) => defmt::info!("[t_soak] PASS"),
+            Err(e) => {
+                defmt::error!("[t_soak] FAIL: {}", e);
                 panic!("test failure");
             }
         }
@@ -216,6 +241,92 @@ pub mod tests {
             return Err("E5 mismatch");
         }
 
+        Ok(())
+    }
+
+    /// Repeat t_basic_rw at Standard / Fast / FastPlus. Restores Standard
+    /// before returning so the rest of the suite is unaffected.
+    pub async fn t_speed_sweep<C: Controller>(ctrl: &mut C) -> Result<(), &'static str> {
+        for &speed in &[Speed::Standard, Speed::Fast, Speed::FastPlus] {
+            let mut cfg = CtrlConfig::default();
+            cfg.speed = speed;
+            ctrl.set_config(&cfg).map_err(|_| "set_config failed")?;
+
+            for i in 0..50u16 {
+                ctrl.write(ADDR, &[i as u8, (i >> 8) as u8])
+                    .await
+                    .map_err(|_| "speed: write failed")?;
+                let mut r = [0u8; 2];
+                ctrl.read(ADDR, &mut r).await.map_err(|_| "speed: read failed")?;
+                if r != [EXPECT, EXPECT] {
+                    defmt::error!("speed {} iter {}: got={:02x}", speed, i, r);
+                    return Err("speed: mismatch");
+                }
+                ctrl.write_read(ADDR, &[i as u8], &mut r)
+                    .await
+                    .map_err(|_| "speed: wr failed")?;
+                if r != [EXPECT, EXPECT] {
+                    defmt::error!("speed {} wr i={}: got={:02x}", speed, i, r);
+                    return Err("speed: wr mismatch");
+                }
+            }
+        }
+
+        // Restore default speed.
+        let cfg = CtrlConfig::default();
+        ctrl.set_config(&cfg).map_err(|_| "set_config restore failed")?;
+        Ok(())
+    }
+
+    /// Long soak: N=2000 iters of a randomized op mix (W / R / WR).
+    /// PRNG is a simple xorshift seeded at compile time so the run is
+    /// deterministic.
+    pub async fn t_soak<C: Controller>(ctrl: &mut C) -> Result<(), &'static str> {
+        const N: u32 = 2000;
+        let mut state: u32 = 0xC0FFEE_u32;
+        let mut next = || {
+            state ^= state << 13;
+            state ^= state >> 17;
+            state ^= state << 5;
+            state
+        };
+
+        for i in 0..N {
+            let op = next() % 3;
+            let len = ((next() % 8) as usize) + 1; // 1..=8
+            let mut buf = [0u8; 8];
+            for (j, b) in buf.iter_mut().enumerate() {
+                *b = (i as u8).wrapping_add(j as u8);
+            }
+            let mut rbuf = [0u8; 8];
+
+            match op {
+                0 => {
+                    ctrl.write(ADDR, &buf[..len])
+                        .await
+                        .map_err(|_| "soak: write failed")?;
+                }
+                1 => {
+                    let r = &mut rbuf[..len];
+                    ctrl.read(ADDR, r).await.map_err(|_| "soak: read failed")?;
+                    if r.iter().any(|&b| b != EXPECT) {
+                        defmt::error!("soak i={} R: got={:02x}", i, r);
+                        return Err("soak: read mismatch");
+                    }
+                }
+                _ => {
+                    let wlen = core::cmp::max(1, len / 2);
+                    let r = &mut rbuf[..len];
+                    ctrl.write_read(ADDR, &buf[..wlen], r)
+                        .await
+                        .map_err(|_| "soak: wr failed")?;
+                    if r.iter().any(|&b| b != EXPECT) {
+                        defmt::error!("soak i={} WR: got={:02x}", i, r);
+                        return Err("soak: wr mismatch");
+                    }
+                }
+            }
+        }
         Ok(())
     }
 }


### PR DESCRIPTION
Three real bug fixes for the embassy-mcxa LPI2C controller driver and a
comprehensive in-chip loopback test example used to find them. Validated on
MCXA577 at DEFMT_LOG=off and DEFMT_LOG=trace.

Driver fixes

1. NACK recovery race — Two coupled bugs in the async NACK recovery path:

 - async_read_internal armed an OnDrop(remediation) before async_start. On
   AddressNack, async_start's status_and_act already issued the STOP, then ?
   propagated Err and the OnDrop ran remediation() again. Two STOPs in quick
   succession corrupted controller state for the next transaction. Fixed by
   moving the OnDrop inside the chunk loop, after async_start.await?, with a
   per-chunk defuse() before the next chunk. Applied to both interrupt-mode and
   DMA-mode read paths.

 - remediation() issued STOP via stop(), which busy-waits on
   is_tx_fifo_empty_or_error. After an address NACK with empty TX FIFO and
   autostop disabled, the master is idle when STOP is queued, raising FEF; the
   wait loop exits early on that error, leaving the STOP cmd stuck in the TX
   FIFO and FEF set in MSR. The next transaction then started with a stale STOP
   in flight and reported FifoError/ArbitrationLoss on the next START. Fixed by
   resetting the FIFOs after the STOP attempt and clearing MSR flags.

2. FastPlus MCCR0 timing — The hard-coded FastPlus values (CLKLO=0x04,
CLKHI=0x03, SETHOLD=0x03, DATAVD=0x02) yielded an SCL period of only 9
functional clocks, putting the bus around 1.33 MHz on a typical 12 MHz
functional clock — above the 1 MHz Fast Mode+ spec and unreliable on
MCXA577. Loosened to (0x06, 0x05, 0x05, 0x03) for 13 functional clocks per
period (920 kHz on 12 MHz), well within spec.

3. Compute MCCR0/PRESCALE from the actual peripheral clock — The bus-timing
table implicitly assumed a 12 MHz LPI2C input clock. Switching the peripheral
clock source, or running on a board with a different default, would silently
produce out-of-spec or completely wrong SCL rates.  Replaced the table with
compute_mccr0_params(src_hz, target_hz), ported from NXP's fsl_lpi2c.c
LPI2C_MasterSetBaudRate: for each prescaler 0..=7, pick the period that
minimizes |error| to target_hz, then derive CLKHI/CLKLO with a tBUF clamp and
SETHOLD/DATAVD as ~½ and ~¼ of the SCL period. The peripheral input frequency
from enable_and_reset() is now stored on the I2c struct so SetConfig::set_config
can recompute on runtime speed changes.

New example: i2c-loopback-async

In-chip controller↔target loopback for validating the I2C controller
driver. Target task on LPI2C3 (P3_21/P3_20) mirrors i2c-target-async; controller
on LPI2C0 (P0_21/P0_20). Wire jumpers P0_20 <-> P3_20 (SDA), P0_21 <-> P3_21
(SCL) with pull-ups.

Test cases (added incrementally across commits):

 - t_basic_rw — 100 iters of W/R 2 bytes, expect 0x55.

 - t_lengths — write/read/write_read for L ∈ {1, 2, 4, 8, 16, 32}.

 - t_burst — 500 iters of W2 / R2 / WR1+R2 mix.

 - t_edges — bad-address NACK, post-NACK recovery, zero-length read, recovery
   after a NACKed READ (exercises the read-side OnDrop fix).

 - t_speed_sweep — 50 iters of W2/R2/WR1+R2 at Standard, Fast, and FastPlus;
   exercises the SetConfig path.

 - t_soak — 2000 randomized op iterations (W/R/WR mix, lengths 1..8) using a
   deterministic xorshift PRNG.