### PR TITLE
Add WritableDescriptor.

### DIFF
--- a/embassy-usb-host/src/class/hub.rs
+++ b/embassy-usb-host/src/class/hub.rs
@@ -16,6 +16,7 @@ use embassy_usb_driver::{Direction, EndpointInfo, EndpointType, Speed};
 use crate::control::{ControlPipeExt, ControlType, Recipient, RequestType, SetupPacket};
 use crate::descriptor::{
     DEFAULT_MAX_DESCRIPTOR_SIZE, DescriptorError, InterfaceDescriptor, USBDescriptor, VariableSizeDescriptor,
+    WritableDescriptor,
 };
 use crate::handler::{BusRoute, EnumerationInfo, HandlerEvent, RegisterError};
 use crate::{BusHandle, EnumerationError};
@@ -412,7 +413,7 @@ impl VariableSizeDescriptor for HubDescriptor {
         }
         let len = bytes[0] as usize;
         let port_num = bytes[2] as usize;
-        len == 6 + 2 * Ord::max(1, port_num.div_ceil(u8::BITS as usize))
+        len == 7 + 2 * Ord::max(1, port_num.div_ceil(u8::BITS as usize))
     }
 }
 
@@ -447,6 +448,21 @@ impl USBDescriptor for HubDescriptor {
             device_removable,
             port_power_ctrl_mask,
         })
+    }
+}
+
+impl WritableDescriptor for HubDescriptor {
+    fn write_to_bytes(&self, bytes: &mut [u8]) -> Result<usize, Self::Error> {
+        let n = Ord::max(1, self.port_num.div_ceil(u8::BITS as u8));
+        Self::prepare_bytes(bytes, 7 + 2 * n)?;
+        bytes[2] = self.port_num;
+        [bytes[3], bytes[4]] = self.characteristics.to_le_bytes();
+        bytes[5] = self.power_on_delay;
+        bytes[6] = self.max_current;
+        let n = n as usize;
+        bytes[7..7 + n].copy_from_slice(&self.device_removable[..n]);
+        bytes[7 + n..7 + 2 * n].copy_from_slice(&self.port_power_ctrl_mask[..n]);
+        Ok(bytes[0] as usize)
     }
 }
 
@@ -568,7 +584,7 @@ impl From<PortStatus> for Speed {
 
 #[cfg(test)]
 pub mod tests {
-    use super::HubInterrupt;
+    use super::*;
 
     #[test]
     fn test_hub_interrupt_0() {
@@ -626,5 +642,35 @@ pub mod tests {
         // empty byte
         assert_eq!(changes.take_port_change(), Some(22));
         assert_eq!(changes.take_port_change(), None);
+    }
+
+    #[test]
+    fn roundtrip_hub_descriptor() {
+        let descriptor = HubDescriptor {
+            port_num: 0x11,
+            characteristics: 0x2233,
+            power_on_delay: 0x44,
+            max_current: 0x55,
+            device_removable: {
+                let mut device_removable = [0u8; _];
+                device_removable[0] = 0b1111_1110; // 0x1-0x7
+                device_removable[1] = 0b1111_1111; // 0x8-0xf
+                device_removable[2] = 0b0000_0011; // 0x10-0x11
+                device_removable
+            },
+            port_power_ctrl_mask: {
+                let mut port_power_ctrl_mask = [0u8; _];
+                port_power_ctrl_mask[0] = 0b1111_1111; // 0x0-0x7
+                port_power_ctrl_mask[1] = 0b1111_1111; // 0x8-0xf
+                port_power_ctrl_mask[2] = 0b0000_0011; // 0x10-0x11
+                port_power_ctrl_mask
+            },
+        };
+        let mut bytes = [0u8; HubDescriptor::BUF_SIZE];
+        assert_eq!(
+            descriptor.write_to_bytes(&mut bytes),
+            Ok(7 + 2 * 0x11usize.div_ceil(u8::BITS as usize))
+        );
+        assert_eq!(HubDescriptor::try_from_bytes(&bytes), Ok(descriptor));
     }
 }

--- a/embassy-usb-host/src/class/kbd.rs
+++ b/embassy-usb-host/src/class/kbd.rs
@@ -11,6 +11,7 @@ use embassy_usb_driver::{Direction, EndpointInfo, EndpointType};
 use crate::control::ControlPipeExt;
 use crate::descriptor::{
     DEFAULT_MAX_DESCRIPTOR_SIZE, DescriptorError, InterfaceDescriptor, USBDescriptor, VariableSizeDescriptor,
+    WritableDescriptor,
 };
 use crate::handler::{EnumerationInfo, HandlerEvent, RegisterError};
 
@@ -213,5 +214,39 @@ impl USBDescriptor for HIDDescriptor {
             descriptor_type0: bytes[6],
             descriptor_length0: u16::from_le_bytes([bytes[7], bytes[8]]),
         })
+    }
+}
+
+impl WritableDescriptor for HIDDescriptor {
+    fn write_to_bytes(&self, bytes: &mut [u8]) -> Result<usize, Self::Error> {
+        if self.num_descriptors > Self::SUPPORTED_DESCRIPTORS {
+            return Err(DescriptorError::NotImplemented);
+        }
+        Self::prepare_bytes(bytes, 6 + 3 * self.num_descriptors)?;
+        [bytes[2], bytes[3]] = self.bcd_hid.to_le_bytes();
+        bytes[4] = self.country_code;
+        bytes[5] = self.num_descriptors;
+        bytes[6] = self.descriptor_type0;
+        [bytes[7], bytes[8]] = self.descriptor_length0.to_le_bytes();
+        Ok(bytes[0] as usize)
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn roundtrip_hid_descriptor() {
+        let descriptor = HIDDescriptor {
+            bcd_hid: 0x1122,
+            country_code: 0x33,
+            num_descriptors: 1,
+            descriptor_type0: 0x55,
+            descriptor_length0: 0x6677,
+        };
+        let mut bytes = [0u8; HIDDescriptor::BUF_SIZE];
+        assert_eq!(descriptor.write_to_bytes(&mut bytes), Ok(6 + 3 * 1));
+        assert_eq!(HIDDescriptor::try_from_bytes(&bytes), Ok(descriptor));
     }
 }

--- a/embassy-usb-host/src/class/uac/descriptors.rs
+++ b/embassy-usb-host/src/class/uac/descriptors.rs
@@ -592,6 +592,22 @@ impl USBDescriptor for ClockSelectorDescriptor {
     }
 }
 
+impl WritableDescriptor for ClockSelectorDescriptor {
+    fn write_to_bytes(&self, bytes: &mut [u8]) -> Result<usize, Self::Error> {
+        let num_source_ids = u8::try_from(self.source_ids.len()).map_err(|_| AudioInterfaceError::InvalidDescriptor)?;
+        if num_source_ids > Self::SUPPORTED_SOURCE_IDS {
+            return Err(AudioInterfaceError::InvalidDescriptor);
+        }
+        Self::prepare_bytes(bytes, 7 + num_source_ids)?;
+        bytes[3] = self.clock_id;
+        bytes[4] = num_source_ids;
+        bytes[5..5 + num_source_ids as usize].copy_from_slice(self.source_ids.as_slice());
+        bytes[5 + num_source_ids as usize] = self.controls_bitmap;
+        bytes[6 + num_source_ids as usize] = self.clock_name;
+        Ok(bytes[0] as usize)
+    }
+}
+
 /// Clock multiplier descriptor for frequency multiplication. (USB Audio Devices 2.0 §4.7.2.3)
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
@@ -1646,5 +1662,24 @@ mod test {
             Ok(ClockSourceDescriptor::MIN_LEN as usize)
         );
         assert_eq!(ClockSourceDescriptor::try_from_bytes(&bytes), Ok(descriptor));
+    }
+
+    #[test]
+    fn roundtrip_clock_selector_descriptor() {
+        for n in 0..ClockSelectorDescriptor::SUPPORTED_SOURCE_IDS {
+            let mut source_ids = Vec::new();
+            for i in 0..n {
+                assert!(source_ids.push(0x22u8 + i).is_ok());
+            }
+            let descriptor = ClockSelectorDescriptor {
+                clock_id: 0x11,
+                source_ids,
+                controls_bitmap: 0x33,
+                clock_name: 0x44,
+            };
+            let mut bytes = [0u8; ClockSelectorDescriptor::BUF_SIZE];
+            assert_eq!(descriptor.write_to_bytes(&mut bytes), Ok(7 + n as usize));
+            assert_eq!(ClockSelectorDescriptor::try_from_bytes(&bytes), Ok(descriptor));
+        }
     }
 }

--- a/embassy-usb-host/src/class/uac/descriptors.rs
+++ b/embassy-usb-host/src/class/uac/descriptors.rs
@@ -1249,6 +1249,17 @@ impl USBDescriptor for AudioEndpointDescriptor {
     }
 }
 
+impl WritableDescriptor for AudioEndpointDescriptor {
+    fn write_to_bytes(&self, bytes: &mut [u8]) -> Result<usize, Self::Error> {
+        Self::prepare_bytes(bytes, Self::MIN_LEN)?;
+        bytes[3] = self.attributes_bitmap;
+        bytes[4] = self.controls_bitmap;
+        bytes[5] = self.lock_delay_units;
+        [bytes[6], bytes[7]] = self.lock_delay.to_le_bytes();
+        Ok(bytes[0] as usize)
+    }
+}
+
 /// Enumeration of format type descriptors for different audio formats.
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
@@ -1948,5 +1959,21 @@ mod test {
             Ok(OutputTerminalDescriptor::MIN_LEN as usize)
         );
         assert_eq!(TerminalDescriptor::try_from_bytes(&bytes), Ok(descriptor));
+    }
+
+    #[test]
+    fn roundtrip_audio_endpoint_descriptor() {
+        let descriptor = AudioEndpointDescriptor {
+            attributes_bitmap: 0x11,
+            controls_bitmap: 0x22,
+            lock_delay_units: 0x33,
+            lock_delay: 0x4455,
+        };
+        let mut bytes = [0u8; AudioEndpointDescriptor::BUF_SIZE];
+        assert_eq!(
+            descriptor.write_to_bytes(&mut bytes),
+            Ok(AudioEndpointDescriptor::MIN_LEN as usize)
+        );
+        assert_eq!(AudioEndpointDescriptor::try_from_bytes(&bytes), Ok(descriptor));
     }
 }

--- a/embassy-usb-host/src/class/uac/descriptors.rs
+++ b/embassy-usb-host/src/class/uac/descriptors.rs
@@ -695,6 +695,15 @@ impl USBDescriptor for TerminalDescriptor {
     }
 }
 
+impl WritableDescriptor for TerminalDescriptor {
+    fn write_to_bytes(&self, bytes: &mut [u8]) -> Result<usize, Self::Error> {
+        match self {
+            Self::Input(descriptor) => descriptor.write_to_bytes(bytes),
+            Self::Output(descriptor) => descriptor.write_to_bytes(bytes),
+        }
+    }
+}
+
 impl TerminalDescriptor {
     /// Returns the terminal ID for this descriptor.
     pub fn terminal_id(&self) -> u8 {
@@ -1900,5 +1909,44 @@ mod test {
             Ok(OutputTerminalDescriptor::MIN_LEN as usize)
         );
         assert_eq!(OutputTerminalDescriptor::try_from_bytes(&bytes), Ok(descriptor));
+    }
+
+    #[test]
+    fn roundtrip_terminal_descriptor_input() {
+        let descriptor = TerminalDescriptor::Input(InputTerminalDescriptor {
+            terminal_id: 0x11,
+            terminal_type: TerminalType::Microphone,
+            associated_terminal_id: 0x33,
+            clock_source_id: 0x44,
+            num_channels: 0x55,
+            channel_config_bitmap: 0x66778899,
+            channel_names: 0xaa,
+            controls_bitmap: 0xbbcc,
+            terminal_name: 0xdd,
+        });
+        let mut bytes = [0u8; TerminalDescriptor::BUF_SIZE];
+        assert_eq!(
+            descriptor.write_to_bytes(&mut bytes),
+            Ok(InputTerminalDescriptor::MIN_LEN as usize)
+        );
+        assert_eq!(TerminalDescriptor::try_from_bytes(&bytes), Ok(descriptor));
+    }
+    #[test]
+    fn roundtrip_terminal_descriptor_output() {
+        let descriptor = TerminalDescriptor::Output(OutputTerminalDescriptor {
+            terminal_id: 0x11,
+            terminal_type: TerminalType::Speaker,
+            associated_terminal_id: 0x33,
+            source_id: 0x44,
+            clock_source_id: 0x55,
+            controls_bitmap: 0x6677,
+            terminal_name: 0x88,
+        });
+        let mut bytes = [0u8; TerminalDescriptor::BUF_SIZE];
+        assert_eq!(
+            descriptor.write_to_bytes(&mut bytes),
+            Ok(OutputTerminalDescriptor::MIN_LEN as usize)
+        );
+        assert_eq!(TerminalDescriptor::try_from_bytes(&bytes), Ok(descriptor));
     }
 }

--- a/embassy-usb-host/src/class/uac/descriptors.rs
+++ b/embassy-usb-host/src/class/uac/descriptors.rs
@@ -983,6 +983,22 @@ impl USBDescriptor for InputTerminalDescriptor {
     }
 }
 
+impl WritableDescriptor for InputTerminalDescriptor {
+    fn write_to_bytes(&self, bytes: &mut [u8]) -> Result<usize, Self::Error> {
+        Self::prepare_bytes(bytes, Self::MIN_LEN)?;
+        bytes[3] = self.terminal_id;
+        [bytes[4], bytes[5]] = u16::from(self.terminal_type).to_le_bytes();
+        bytes[6] = self.associated_terminal_id;
+        bytes[7] = self.clock_source_id;
+        bytes[8] = self.num_channels;
+        [bytes[9], bytes[10], bytes[11], bytes[12]] = self.channel_config_bitmap.to_le_bytes();
+        bytes[13] = self.channel_names;
+        [bytes[14], bytes[15]] = self.controls_bitmap.to_le_bytes();
+        bytes[16] = self.terminal_name;
+        Ok(bytes[0] as usize)
+    }
+}
+
 /// Output terminal descriptor for audio output destinations. (USB Audio Devices 2.0 §4.7.2.5)
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
@@ -1830,5 +1846,26 @@ mod test {
             let terminal_type = TerminalType::from(value);
             assert_eq!(u16::from(terminal_type), value);
         }
+    }
+
+    #[test]
+    fn roundtrip_input_terminal_descriptor() {
+        let descriptor = InputTerminalDescriptor {
+            terminal_id: 0x11,
+            terminal_type: TerminalType::Microphone,
+            associated_terminal_id: 0x33,
+            clock_source_id: 0x44,
+            num_channels: 0x55,
+            channel_config_bitmap: 0x66778899,
+            channel_names: 0xaa,
+            controls_bitmap: 0xbbcc,
+            terminal_name: 0xdd,
+        };
+        let mut bytes = [0u8; InputTerminalDescriptor::BUF_SIZE];
+        assert_eq!(
+            descriptor.write_to_bytes(&mut bytes),
+            Ok(InputTerminalDescriptor::MIN_LEN as usize)
+        );
+        assert_eq!(InputTerminalDescriptor::try_from_bytes(&bytes), Ok(descriptor));
     }
 }

--- a/embassy-usb-host/src/class/uac/descriptors.rs
+++ b/embassy-usb-host/src/class/uac/descriptors.rs
@@ -823,56 +823,113 @@ pub enum TerminalType {
     AvcStream,
 }
 
-fn terminal_type_from_u16(terminal_type: u16) -> TerminalType {
-    use TerminalType::*;
+impl From<u16> for TerminalType {
+    fn from(terminal_type: u16) -> TerminalType {
+        use TerminalType::*;
 
-    use crate::class::uac::codes::terminal_type::*;
+        use crate::class::uac::codes::terminal_type::*;
 
-    match terminal_type {
-        usb::UNDEFINED => UsbUndefined,
-        usb::STREAMING => UsbStreaming,
-        usb::VENDOR_SPECIFIC => UsbVendorSpecific,
+        match terminal_type {
+            usb::UNDEFINED => UsbUndefined,
+            usb::STREAMING => UsbStreaming,
+            usb::VENDOR_SPECIFIC => UsbVendorSpecific,
 
-        input::UNDEFINED => InputUndefined,
-        input::MICROPHONE => Microphone,
-        input::DESKTOP_MICROPHONE => DesktopMicrophone,
-        input::PERSONAL_MICROPHONE => PersonalMicrophone,
-        input::OMNI_DIRECTIONAL_MICROPHONE => OmniMicrophone,
-        input::MICROPHONE_ARRAY => MicrophoneArray,
-        input::PROCESSING_MICROPHONE_ARRAY => ProcessingMicrophoneArray,
+            input::UNDEFINED => InputUndefined,
+            input::MICROPHONE => Microphone,
+            input::DESKTOP_MICROPHONE => DesktopMicrophone,
+            input::PERSONAL_MICROPHONE => PersonalMicrophone,
+            input::OMNI_DIRECTIONAL_MICROPHONE => OmniMicrophone,
+            input::MICROPHONE_ARRAY => MicrophoneArray,
+            input::PROCESSING_MICROPHONE_ARRAY => ProcessingMicrophoneArray,
 
-        output::UNDEFINED => OutputUndefined,
-        output::SPEAKER => Speaker,
-        output::HEADPHONES => Headphones,
-        output::HEAD_MOUNTED_DISPLAY_AUDIO => HeadMountedDisplay,
-        output::DESKTOP_SPEAKER => DesktopSpeaker,
-        output::ROOM_SPEAKER => RoomSpeaker,
-        output::COMMUNICATION_SPEAKER => CommunicationSpeaker,
-        output::LOW_FREQUENCY_EFFECTS_SPEAKER => LowFrequencyEffectsSpeaker,
+            output::UNDEFINED => OutputUndefined,
+            output::SPEAKER => Speaker,
+            output::HEADPHONES => Headphones,
+            output::HEAD_MOUNTED_DISPLAY_AUDIO => HeadMountedDisplay,
+            output::DESKTOP_SPEAKER => DesktopSpeaker,
+            output::ROOM_SPEAKER => RoomSpeaker,
+            output::COMMUNICATION_SPEAKER => CommunicationSpeaker,
+            output::LOW_FREQUENCY_EFFECTS_SPEAKER => LowFrequencyEffectsSpeaker,
 
-        bidirectional::UNDEFINED => BiDirectionalUndefined,
-        bidirectional::HANDSET => Handset,
-        bidirectional::HEADSET => Headset,
-        bidirectional::SPEAKERPHONE_NO_ECHO => SpeakerPhone,
-        bidirectional::ECHO_SUPPRESSING_SPEAKERPHONE => EchoSuppressing,
-        bidirectional::ECHO_CANCELING_SPEAKERPHONE => EchoCanceling,
+            bidirectional::UNDEFINED => BiDirectionalUndefined,
+            bidirectional::HANDSET => Handset,
+            bidirectional::HEADSET => Headset,
+            bidirectional::SPEAKERPHONE_NO_ECHO => SpeakerPhone,
+            bidirectional::ECHO_SUPPRESSING_SPEAKERPHONE => EchoSuppressing,
+            bidirectional::ECHO_CANCELING_SPEAKERPHONE => EchoCanceling,
 
-        telephony::UNDEFINED => TelephonyUndefined,
-        telephony::PHONE_LINE => PhoneLine,
-        telephony::TELEPHONE => Telephone,
-        telephony::DOWN_LINE_PHONE => DownLinePhone,
+            telephony::UNDEFINED => TelephonyUndefined,
+            telephony::PHONE_LINE => PhoneLine,
+            telephony::TELEPHONE => Telephone,
+            telephony::DOWN_LINE_PHONE => DownLinePhone,
 
-        external::UNDEFINED => ExternalUndefined,
-        external::ANALOG_CONNECTOR => AnalogConnector,
-        external::DIGITAL_AUDIO_INTERFACE => DigitalAudioInterface,
-        external::LINE_CONNECTOR => LineConnector,
-        external::LEGACY_AUDIO_CONNECTOR => LegacyAudioConnector,
-        external::SPDIF_INTERFACE => SpdifInterface,
-        external::DA_STREAM_1394 => Da1394Stream,
-        external::DV_STREAM_SOUNDTRACK_1394 => DvdAudioStream,
-        external::ADAT_LIGHTPIPE => AvcStream,
+            external::UNDEFINED => ExternalUndefined,
+            external::ANALOG_CONNECTOR => AnalogConnector,
+            external::DIGITAL_AUDIO_INTERFACE => DigitalAudioInterface,
+            external::LINE_CONNECTOR => LineConnector,
+            external::LEGACY_AUDIO_CONNECTOR => LegacyAudioConnector,
+            external::SPDIF_INTERFACE => SpdifInterface,
+            external::DA_STREAM_1394 => Da1394Stream,
+            external::DV_STREAM_SOUNDTRACK_1394 => DvdAudioStream,
+            external::ADAT_LIGHTPIPE => AvcStream,
 
-        _ => Unknown(terminal_type),
+            _ => Unknown(terminal_type),
+        }
+    }
+}
+
+impl From<TerminalType> for u16 {
+    fn from(terminal_type: TerminalType) -> u16 {
+        use TerminalType::*;
+
+        use crate::class::uac::codes::terminal_type::*;
+
+        match terminal_type {
+            UsbUndefined => usb::UNDEFINED,
+            UsbStreaming => usb::STREAMING,
+            UsbVendorSpecific => usb::VENDOR_SPECIFIC,
+
+            InputUndefined => input::UNDEFINED,
+            Microphone => input::MICROPHONE,
+            DesktopMicrophone => input::DESKTOP_MICROPHONE,
+            PersonalMicrophone => input::PERSONAL_MICROPHONE,
+            OmniMicrophone => input::OMNI_DIRECTIONAL_MICROPHONE,
+            MicrophoneArray => input::MICROPHONE_ARRAY,
+            ProcessingMicrophoneArray => input::PROCESSING_MICROPHONE_ARRAY,
+
+            OutputUndefined => output::UNDEFINED,
+            Speaker => output::SPEAKER,
+            Headphones => output::HEADPHONES,
+            HeadMountedDisplay => output::HEAD_MOUNTED_DISPLAY_AUDIO,
+            DesktopSpeaker => output::DESKTOP_SPEAKER,
+            RoomSpeaker => output::ROOM_SPEAKER,
+            CommunicationSpeaker => output::COMMUNICATION_SPEAKER,
+            LowFrequencyEffectsSpeaker => output::LOW_FREQUENCY_EFFECTS_SPEAKER,
+
+            BiDirectionalUndefined => bidirectional::UNDEFINED,
+            Handset => bidirectional::HANDSET,
+            Headset => bidirectional::HEADSET,
+            SpeakerPhone => bidirectional::SPEAKERPHONE_NO_ECHO,
+            EchoSuppressing => bidirectional::ECHO_SUPPRESSING_SPEAKERPHONE,
+            EchoCanceling => bidirectional::ECHO_CANCELING_SPEAKERPHONE,
+
+            TelephonyUndefined => telephony::UNDEFINED,
+            PhoneLine => telephony::PHONE_LINE,
+            Telephone => telephony::TELEPHONE,
+            DownLinePhone => telephony::DOWN_LINE_PHONE,
+
+            ExternalUndefined => external::UNDEFINED,
+            AnalogConnector => external::ANALOG_CONNECTOR,
+            DigitalAudioInterface => external::DIGITAL_AUDIO_INTERFACE,
+            LineConnector => external::LINE_CONNECTOR,
+            LegacyAudioConnector => external::LEGACY_AUDIO_CONNECTOR,
+            SpdifInterface => external::SPDIF_INTERFACE,
+            Da1394Stream => external::DA_STREAM_1394,
+            DvdAudioStream => external::DV_STREAM_SOUNDTRACK_1394,
+            AvcStream => external::ADAT_LIGHTPIPE,
+
+            Unknown(terminal_type) => terminal_type,
+        }
     }
 }
 
@@ -914,7 +971,7 @@ impl USBDescriptor for InputTerminalDescriptor {
         Self::match_bytes(bytes)?;
         Ok(Self {
             terminal_id: bytes[3],
-            terminal_type: terminal_type_from_u16(u16::from_le_bytes([bytes[4], bytes[5]])),
+            terminal_type: TerminalType::from(u16::from_le_bytes([bytes[4], bytes[5]])),
             associated_terminal_id: bytes[6],
             clock_source_id: bytes[7],
             num_channels: bytes[8],
@@ -960,7 +1017,7 @@ impl USBDescriptor for OutputTerminalDescriptor {
         Self::match_bytes(bytes)?;
         Ok(Self {
             terminal_id: bytes[3],
-            terminal_type: terminal_type_from_u16(u16::from_le_bytes([bytes[4], bytes[5]])),
+            terminal_type: TerminalType::from(u16::from_le_bytes([bytes[4], bytes[5]])),
             associated_terminal_id: bytes[6],
             source_id: bytes[7],
             clock_source_id: bytes[8],
@@ -1765,5 +1822,13 @@ mod test {
             Ok(ClockMultiplierDescriptor::MIN_LEN as usize)
         );
         assert_eq!(ClockDescriptor::try_from_bytes(&bytes), Ok(descriptor));
+    }
+
+    #[test]
+    fn rountrip_terminal_type() {
+        for value in 0..=u16::MAX {
+            let terminal_type = TerminalType::from(value);
+            assert_eq!(u16::from(terminal_type), value);
+        }
     }
 }

--- a/embassy-usb-host/src/class/uac/descriptors.rs
+++ b/embassy-usb-host/src/class/uac/descriptors.rs
@@ -8,6 +8,7 @@ use crate::descriptor::descriptor_type::{CS_ENDPOINT, CS_INTERFACE, INTERFACE_AS
 use crate::descriptor::{
     ConfigurationDescriptorChain, DescriptorError, DescriptorVisitor, EndpointDescriptor, ExtendableDescriptor,
     InterfaceDescriptor, InterfaceDescriptorChain, StringIndex, USBDescriptor, VariableSizeDescriptor, VisitError,
+    WritableDescriptor,
 };
 
 const MAX_AUDIO_STREAMING_INTERFACES: usize = 16;
@@ -297,6 +298,19 @@ impl USBDescriptor for InterfaceAssociationDescriptor {
             protocol: bytes[6],
             interface_name: bytes[7],
         })
+    }
+}
+
+impl WritableDescriptor for InterfaceAssociationDescriptor {
+    fn write_to_bytes(&self, bytes: &mut [u8]) -> Result<usize, Self::Error> {
+        Self::prepare_bytes(bytes, Self::MIN_LEN)?;
+        bytes[2] = self.first_interface;
+        bytes[3] = self.num_interfaces;
+        bytes[4] = self.class;
+        bytes[5] = self.subclass;
+        bytes[6] = self.protocol;
+        bytes[7] = self.interface_name;
+        Ok(bytes[0] as usize)
     }
 }
 
@@ -1585,5 +1599,23 @@ mod test {
         let audio_interface_collection = AudioInterfaceCollection::try_from_configuration(&descriptor).unwrap();
         // info!("{:#?}", audio_interface_collection);
         assert_eq!(audio_interface_collection, expected);
+    }
+
+    #[test]
+    fn roundtrip_interface_association_descriptor() {
+        let descriptor = InterfaceAssociationDescriptor {
+            first_interface: 0x11,
+            num_interfaces: 0x22,
+            class: 0x33,
+            subclass: 0x44,
+            protocol: 0x55,
+            interface_name: 0x66,
+        };
+        let mut bytes = [0u8; InterfaceAssociationDescriptor::BUF_SIZE];
+        assert_eq!(
+            descriptor.write_to_bytes(&mut bytes),
+            Ok(InterfaceAssociationDescriptor::MIN_LEN as usize)
+        );
+        assert_eq!(InterfaceAssociationDescriptor::try_from_bytes(&bytes), Ok(descriptor));
     }
 }

--- a/embassy-usb-host/src/class/uac/descriptors.rs
+++ b/embassy-usb-host/src/class/uac/descriptors.rs
@@ -1043,6 +1043,20 @@ impl USBDescriptor for OutputTerminalDescriptor {
     }
 }
 
+impl WritableDescriptor for OutputTerminalDescriptor {
+    fn write_to_bytes(&self, bytes: &mut [u8]) -> Result<usize, Self::Error> {
+        Self::prepare_bytes(bytes, Self::MIN_LEN)?;
+        bytes[3] = self.terminal_id;
+        [bytes[4], bytes[5]] = u16::from(self.terminal_type).to_le_bytes();
+        bytes[6] = self.associated_terminal_id;
+        bytes[7] = self.source_id;
+        bytes[8] = self.clock_source_id;
+        [bytes[9], bytes[10]] = self.controls_bitmap.to_le_bytes();
+        bytes[11] = self.terminal_name;
+        Ok(bytes[0] as usize)
+    }
+}
+
 /// Enumeration of unit descriptor types for audio processing units.
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
@@ -1867,5 +1881,24 @@ mod test {
             Ok(InputTerminalDescriptor::MIN_LEN as usize)
         );
         assert_eq!(InputTerminalDescriptor::try_from_bytes(&bytes), Ok(descriptor));
+    }
+
+    #[test]
+    fn roudtrip_output_terminal_descriptor() {
+        let descriptor = OutputTerminalDescriptor {
+            terminal_id: 0x11,
+            terminal_type: TerminalType::Speaker,
+            associated_terminal_id: 0x33,
+            source_id: 0x44,
+            clock_source_id: 0x55,
+            controls_bitmap: 0x6677,
+            terminal_name: 0x88,
+        };
+        let mut bytes = [0u8; OutputTerminalDescriptor::BUF_SIZE];
+        assert_eq!(
+            descriptor.write_to_bytes(&mut bytes),
+            Ok(OutputTerminalDescriptor::MIN_LEN as usize)
+        );
+        assert_eq!(OutputTerminalDescriptor::try_from_bytes(&bytes), Ok(descriptor));
     }
 }

--- a/embassy-usb-host/src/class/uac/descriptors.rs
+++ b/embassy-usb-host/src/class/uac/descriptors.rs
@@ -466,6 +466,17 @@ impl USBDescriptor for ClockDescriptor {
     }
 }
 
+impl WritableDescriptor for ClockDescriptor {
+    fn write_to_bytes(&self, bytes: &mut [u8]) -> Result<usize, Self::Error> {
+        let len = match self {
+            ClockDescriptor::Source(descriptor) => descriptor.write_to_bytes(bytes)?,
+            ClockDescriptor::Selector(descriptor) => descriptor.write_to_bytes(bytes)?,
+            ClockDescriptor::Multiplier(descriptor) => descriptor.write_to_bytes(bytes)?,
+        };
+        Ok(len)
+    }
+}
+
 impl ClockDescriptor {
     /// Returns the clock ID for this descriptor.
     pub fn clock_id(&self) -> u8 {
@@ -1708,5 +1719,51 @@ mod test {
             Ok(ClockMultiplierDescriptor::MIN_LEN as usize)
         );
         assert_eq!(ClockMultiplierDescriptor::try_from_bytes(&bytes), Ok(descriptor));
+    }
+
+    #[test]
+    fn roundtrip_clock_descriptor_source() {
+        let descriptor = ClockDescriptor::Source(ClockSourceDescriptor {
+            clock_id: 0x11,
+            attributes_bitmap: 0x22,
+            controls_bitmap: 0x33,
+            associated_terminal: 0x44,
+            clock_name: 0x55,
+        });
+        let mut bytes = [0u8; ClockDescriptor::BUF_SIZE];
+        assert_eq!(
+            descriptor.write_to_bytes(&mut bytes),
+            Ok(ClockSourceDescriptor::MIN_LEN as usize)
+        );
+        assert_eq!(ClockDescriptor::try_from_bytes(&bytes), Ok(descriptor));
+    }
+
+    #[test]
+    fn roundtrip_clock_descriptor_selector() {
+        let descriptor = ClockDescriptor::Selector(ClockSelectorDescriptor {
+            clock_id: 0x11,
+            source_ids: Vec::from_array([0x22]),
+            controls_bitmap: 0x33,
+            clock_name: 0x44,
+        });
+        let mut bytes = [0u8; ClockDescriptor::BUF_SIZE];
+        assert_eq!(descriptor.write_to_bytes(&mut bytes), Ok(7 + 1));
+        assert_eq!(ClockDescriptor::try_from_bytes(&bytes), Ok(descriptor));
+    }
+
+    #[test]
+    fn roundtrip_clock_descriptor_multiplier() {
+        let descriptor = ClockDescriptor::Multiplier(ClockMultiplierDescriptor {
+            clock_id: 0x11,
+            source_id: 0x22,
+            controls_bitmap: 0x33,
+            clock_name: 0x44,
+        });
+        let mut bytes = [0u8; ClockDescriptor::BUF_SIZE];
+        assert_eq!(
+            descriptor.write_to_bytes(&mut bytes),
+            Ok(ClockMultiplierDescriptor::MIN_LEN as usize)
+        );
+        assert_eq!(ClockDescriptor::try_from_bytes(&bytes), Ok(descriptor));
     }
 }

--- a/embassy-usb-host/src/class/uac/descriptors.rs
+++ b/embassy-usb-host/src/class/uac/descriptors.rs
@@ -1389,6 +1389,67 @@ impl USBDescriptor for FormatTypeDescriptor {
     }
 }
 
+impl WritableDescriptor for FormatTypeDescriptor {
+    fn write_to_bytes(&self, bytes: &mut [u8]) -> Result<usize, Self::Error> {
+        match self {
+            Self::I(data) => {
+                Self::prepare_bytes(bytes, Self::BUF_SIZE_I as u8)?;
+                bytes[3] = format_type::I;
+                bytes[4] = data.subslot_size;
+                bytes[5] = data.bit_resolution;
+                Ok(bytes[0] as usize)
+            }
+            Self::II(data) => {
+                Self::prepare_bytes(bytes, Self::BUF_SIZE_II as u8)?;
+                bytes[3] = format_type::II;
+                [bytes[4], bytes[5]] = data.max_bit_rate.to_le_bytes();
+                [bytes[6], bytes[7]] = data.slots_per_frame.to_le_bytes();
+                Ok(bytes[0] as usize)
+            }
+            Self::III(data) => {
+                Self::prepare_bytes(bytes, Self::BUF_SIZE_III as u8)?;
+                bytes[3] = format_type::III;
+                bytes[4] = data.subslot_size;
+                bytes[5] = data.bit_resolution;
+                Ok(bytes[0] as usize)
+            }
+            Self::IV => {
+                Self::prepare_bytes(bytes, Self::BUF_SIZE_IV as u8)?;
+                bytes[3] = format_type::IV;
+                Ok(bytes[0] as usize)
+            }
+            Self::ExtendedI(data) => {
+                Self::prepare_bytes(bytes, Self::BUF_SIZE_EXTENDED_I as u8)?;
+                bytes[3] = format_type::EXT_I;
+                bytes[4] = data.subslot_size;
+                bytes[5] = data.bit_resolution;
+                bytes[6] = data.header_length;
+                bytes[7] = data.control_size;
+                bytes[8] = data.sideband_protocol;
+                Ok(bytes[0] as usize)
+            }
+            Self::ExtendedII(data) => {
+                Self::prepare_bytes(bytes, Self::BUF_SIZE_EXTENDED_II as u8)?;
+                bytes[3] = format_type::EXT_II;
+                [bytes[4], bytes[5]] = data.max_bit_rate.to_le_bytes();
+                [bytes[6], bytes[7]] = data.samples_per_frame.to_le_bytes();
+                bytes[8] = data.header_length;
+                bytes[9] = data.sideband_protocol;
+                Ok(bytes[0] as usize)
+            }
+            Self::ExtendedIII(data) => {
+                Self::prepare_bytes(bytes, Self::BUF_SIZE_EXTENDED_III as u8)?;
+                bytes[3] = format_type::EXT_III;
+                bytes[4] = data.subslot_size;
+                bytes[5] = data.bit_resolution;
+                bytes[6] = data.header_length;
+                bytes[7] = data.sideband_protocol;
+                Ok(bytes[0] as usize)
+            }
+        }
+    }
+}
+
 /// Type I format descriptor for PCM-like formats.
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
@@ -1975,5 +2036,114 @@ mod test {
             Ok(AudioEndpointDescriptor::MIN_LEN as usize)
         );
         assert_eq!(AudioEndpointDescriptor::try_from_bytes(&bytes), Ok(descriptor));
+    }
+
+    #[test]
+    fn roundtrip_format_type_descriptor_i() {
+        let descriptor = FormatTypeDescriptor::I(FormatTypeI {
+            subslot_size: 0x11,
+            bit_resolution: 0x22,
+        });
+        let mut bytes = [0u8; FormatTypeDescriptor::BUF_SIZE_I];
+        assert!(FormatTypeDescriptor::BUF_SIZE_I <= FormatTypeDescriptor::BUF_SIZE);
+        assert_eq!(
+            descriptor.write_to_bytes(&mut bytes),
+            Ok(FormatTypeDescriptor::BUF_SIZE_I)
+        );
+        assert_eq!(FormatTypeDescriptor::try_from_bytes(&bytes), Ok(descriptor));
+    }
+
+    #[test]
+    fn roundtrip_format_type_descriptor_ii() {
+        let descriptor = FormatTypeDescriptor::II(FormatTypeII {
+            max_bit_rate: 0x1122,
+            slots_per_frame: 0x3344,
+        });
+        let mut bytes = [0u8; FormatTypeDescriptor::BUF_SIZE_II];
+        assert!(FormatTypeDescriptor::BUF_SIZE_II <= FormatTypeDescriptor::BUF_SIZE);
+        assert_eq!(
+            descriptor.write_to_bytes(&mut bytes),
+            Ok(FormatTypeDescriptor::BUF_SIZE_II)
+        );
+        assert_eq!(FormatTypeDescriptor::try_from_bytes(&bytes), Ok(descriptor));
+    }
+
+    #[test]
+    fn roundtrip_format_type_descriptor_iii() {
+        let descriptor = FormatTypeDescriptor::III(FormatTypeIII {
+            subslot_size: 0x11,
+            bit_resolution: 0x22,
+        });
+        let mut bytes = [0u8; FormatTypeDescriptor::BUF_SIZE_III];
+        assert!(FormatTypeDescriptor::BUF_SIZE_III <= FormatTypeDescriptor::BUF_SIZE);
+        assert_eq!(
+            descriptor.write_to_bytes(&mut bytes),
+            Ok(FormatTypeDescriptor::BUF_SIZE_III)
+        );
+        assert_eq!(FormatTypeDescriptor::try_from_bytes(&bytes), Ok(descriptor));
+    }
+
+    #[test]
+    fn roundtrip_format_type_descriptor_iv() {
+        let descriptor = FormatTypeDescriptor::IV;
+        let mut bytes = [0u8; FormatTypeDescriptor::BUF_SIZE_IV];
+        assert!(FormatTypeDescriptor::BUF_SIZE_IV <= FormatTypeDescriptor::BUF_SIZE);
+        assert_eq!(
+            descriptor.write_to_bytes(&mut bytes),
+            Ok(FormatTypeDescriptor::BUF_SIZE_IV)
+        );
+        assert_eq!(FormatTypeDescriptor::try_from_bytes(&bytes), Ok(descriptor));
+    }
+
+    #[test]
+    fn roundtrip_format_type_descriptor_extended_i() {
+        let descriptor = FormatTypeDescriptor::ExtendedI(FormatTypeExtendedI {
+            subslot_size: 0x11,
+            bit_resolution: 0x22,
+            header_length: 0x33,
+            control_size: 0x44,
+            sideband_protocol: 0x55,
+        });
+        let mut bytes = [0u8; FormatTypeDescriptor::BUF_SIZE_EXTENDED_I];
+        assert!(FormatTypeDescriptor::BUF_SIZE_EXTENDED_I <= FormatTypeDescriptor::BUF_SIZE);
+        assert_eq!(
+            descriptor.write_to_bytes(&mut bytes),
+            Ok(FormatTypeDescriptor::BUF_SIZE_EXTENDED_I)
+        );
+        assert_eq!(FormatTypeDescriptor::try_from_bytes(&bytes), Ok(descriptor));
+    }
+
+    #[test]
+    fn roundtrip_format_type_descriptor_extended_ii() {
+        let descriptor = FormatTypeDescriptor::ExtendedII(FormatTypeExtendedII {
+            max_bit_rate: 0x1122,
+            samples_per_frame: 0x3344,
+            header_length: 0x55,
+            sideband_protocol: 0x66,
+        });
+        let mut bytes = [0u8; FormatTypeDescriptor::BUF_SIZE_EXTENDED_II];
+        assert!(FormatTypeDescriptor::BUF_SIZE_EXTENDED_II <= FormatTypeDescriptor::BUF_SIZE);
+        assert_eq!(
+            descriptor.write_to_bytes(&mut bytes),
+            Ok(FormatTypeDescriptor::BUF_SIZE_EXTENDED_II)
+        );
+        assert_eq!(FormatTypeDescriptor::try_from_bytes(&bytes), Ok(descriptor));
+    }
+
+    #[test]
+    fn roundtrip_format_type_descriptor_extended_iii() {
+        let descriptor = FormatTypeDescriptor::ExtendedIII(FormatTypeExtendedIII {
+            subslot_size: 0x11,
+            bit_resolution: 0x22,
+            header_length: 0x33,
+            sideband_protocol: 0x44,
+        });
+        let mut bytes = [0u8; FormatTypeDescriptor::BUF_SIZE_EXTENDED_III];
+        assert!(FormatTypeDescriptor::BUF_SIZE_EXTENDED_III <= FormatTypeDescriptor::BUF_SIZE);
+        assert_eq!(
+            descriptor.write_to_bytes(&mut bytes),
+            Ok(FormatTypeDescriptor::BUF_SIZE_EXTENDED_III)
+        );
+        assert_eq!(FormatTypeDescriptor::try_from_bytes(&bytes), Ok(descriptor));
     }
 }

--- a/embassy-usb-host/src/class/uac/descriptors.rs
+++ b/embassy-usb-host/src/class/uac/descriptors.rs
@@ -515,6 +515,18 @@ impl USBDescriptor for ClockSourceDescriptor {
     }
 }
 
+impl WritableDescriptor for ClockSourceDescriptor {
+    fn write_to_bytes(&self, bytes: &mut [u8]) -> Result<usize, Self::Error> {
+        Self::prepare_bytes(bytes, Self::MIN_LEN)?;
+        bytes[3] = self.clock_id;
+        bytes[4] = self.attributes_bitmap;
+        bytes[5] = self.controls_bitmap;
+        bytes[6] = self.associated_terminal;
+        bytes[7] = self.clock_name;
+        Ok(bytes[0] as usize)
+    }
+}
+
 /// Clock selector descriptor for selecting between multiple clock sources. (USB Audio Devices 2.0 §4.7.2.2)
 #[derive(Clone, Debug, PartialEq, Eq)]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
@@ -1617,5 +1629,22 @@ mod test {
             Ok(InterfaceAssociationDescriptor::MIN_LEN as usize)
         );
         assert_eq!(InterfaceAssociationDescriptor::try_from_bytes(&bytes), Ok(descriptor));
+    }
+
+    #[test]
+    fn roundtrip_clock_source_descriptor() {
+        let descriptor = ClockSourceDescriptor {
+            clock_id: 0x11,
+            attributes_bitmap: 0x22,
+            controls_bitmap: 0x33,
+            associated_terminal: 0x44,
+            clock_name: 0x55,
+        };
+        let mut bytes = [0u8; ClockSourceDescriptor::BUF_SIZE];
+        assert_eq!(
+            descriptor.write_to_bytes(&mut bytes),
+            Ok(ClockSourceDescriptor::MIN_LEN as usize)
+        );
+        assert_eq!(ClockSourceDescriptor::try_from_bytes(&bytes), Ok(descriptor));
     }
 }

--- a/embassy-usb-host/src/class/uac/descriptors.rs
+++ b/embassy-usb-host/src/class/uac/descriptors.rs
@@ -643,6 +643,17 @@ impl USBDescriptor for ClockMultiplierDescriptor {
     }
 }
 
+impl WritableDescriptor for ClockMultiplierDescriptor {
+    fn write_to_bytes(&self, bytes: &mut [u8]) -> Result<usize, Self::Error> {
+        Self::prepare_bytes(bytes, Self::MIN_LEN)?;
+        bytes[3] = self.clock_id;
+        bytes[4] = self.source_id;
+        bytes[5] = self.controls_bitmap;
+        bytes[6] = self.clock_name;
+        Ok(bytes[0] as usize)
+    }
+}
+
 /// Enumeration of terminal descriptor types.
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
@@ -1681,5 +1692,21 @@ mod test {
             assert_eq!(descriptor.write_to_bytes(&mut bytes), Ok(7 + n as usize));
             assert_eq!(ClockSelectorDescriptor::try_from_bytes(&bytes), Ok(descriptor));
         }
+    }
+
+    #[test]
+    fn roudtrip_clock_multiplier_descriptor() {
+        let descriptor = ClockMultiplierDescriptor {
+            clock_id: 0x11,
+            source_id: 0x22,
+            controls_bitmap: 0x33,
+            clock_name: 0x44,
+        };
+        let mut bytes = [0u8; ClockMultiplierDescriptor::BUF_SIZE];
+        assert_eq!(
+            descriptor.write_to_bytes(&mut bytes),
+            Ok(ClockMultiplierDescriptor::MIN_LEN as usize)
+        );
+        assert_eq!(ClockMultiplierDescriptor::try_from_bytes(&bytes), Ok(descriptor));
     }
 }

--- a/embassy-usb-host/src/descriptor.rs
+++ b/embassy-usb-host/src/descriptor.rs
@@ -71,6 +71,17 @@ pub trait USBDescriptor {
         Self: Sized;
 }
 
+/// Writable descriptor.
+///
+/// Implementors of this trait can be written to a byte slice.
+pub trait WritableDescriptor: USBDescriptor {
+    /// Writes this descriptor to the start of the byte buffer `bytes`.
+    ///
+    /// On success, it returns the number of bytes written.
+    /// On failure, it returns a [Self::Error].
+    fn write_to_bytes(&self, bytes: &mut [u8]) -> Result<usize, Self::Error>;
+}
+
 /// Fixed size descriptor.
 ///
 /// Implementors of this trait only allow the correct size while reading or writing.

--- a/embassy-usb-host/src/descriptor.rs
+++ b/embassy-usb-host/src/descriptor.rs
@@ -449,6 +449,19 @@ impl USBDescriptor for ConfigurationDescriptor {
     }
 }
 
+impl WritableDescriptor for ConfigurationDescriptor {
+    fn write_to_bytes(&self, bytes: &mut [u8]) -> Result<usize, Self::Error> {
+        Self::prepare_bytes(bytes, Self::MIN_LEN)?;
+        [bytes[2], bytes[3]] = self.total_len.to_le_bytes();
+        bytes[4] = self.num_interfaces;
+        bytes[5] = self.configuration_value;
+        bytes[6] = self.configuration_name;
+        bytes[7] = self.attributes;
+        bytes[8] = self.max_power;
+        Ok(bytes[0] as usize)
+    }
+}
+
 /// A chain of descriptors.
 ///
 /// Holds the current descriptor and a reference to the bytes after the descriptor.
@@ -1074,5 +1087,23 @@ mod test {
             Ok(DeviceDescriptor::MIN_LEN as usize)
         );
         assert_eq!(DeviceDescriptor::try_from_bytes(&bytes), Ok(descriptor));
+    }
+
+    #[test]
+    fn roundtrip_configuration_descriptor() {
+        let descriptor = ConfigurationDescriptor {
+            total_len: 0x1122,
+            num_interfaces: 0x33,
+            configuration_value: 0x44,
+            configuration_name: 0x55,
+            attributes: 0x66,
+            max_power: 0x77,
+        };
+        let mut bytes = [0u8; ConfigurationDescriptor::BUF_SIZE];
+        assert_eq!(
+            descriptor.write_to_bytes(&mut bytes),
+            Ok(ConfigurationDescriptor::MIN_LEN as usize)
+        );
+        assert_eq!(ConfigurationDescriptor::try_from_bytes(&bytes), Ok(descriptor));
     }
 }

--- a/embassy-usb-host/src/descriptor.rs
+++ b/embassy-usb-host/src/descriptor.rs
@@ -250,6 +250,36 @@ pub trait VariableSizeDescriptor: USBDescriptor {
     fn match_bytes_len(_bytes: &[u8]) -> bool {
         true
     }
+
+    /// Prepares `bytes` to receive descriptor data.
+    ///
+    /// Fills in the descriptor length and type, and zeroes the rest.
+    ///
+    /// It assumes that `len` matches the additional restrictions of the length.
+    ///
+    /// On success, it returns `Ok(())`.
+    /// On error, it returns a [DescriptorError].
+    #[inline(always)]
+    fn prepare_bytes(bytes: &mut [u8], len: u8) -> Result<(), DescriptorError>
+    where
+        Self: WritableDescriptor,
+    {
+        if !(Self::MIN_LEN..=Self::MAX_LEN).contains(&len) {
+            Err(DescriptorError::BadDescriptorSize)
+        } else if bytes.len() < len as usize {
+            Err(DescriptorError::UnexpectedEndOfBuffer)
+        } else {
+            bytes[0] = len;
+            bytes[1] = Self::DESC_TYPE;
+            if let Some(subtype) = Self::DESC_SUBTYPE {
+                bytes[2] = subtype;
+                bytes[3..len as usize].fill(0);
+            } else {
+                bytes[2..len as usize].fill(0);
+            }
+            Ok(())
+        }
+    }
 }
 
 /// Partial version of [DeviceDescriptor].

--- a/embassy-usb-host/src/descriptor.rs
+++ b/embassy-usb-host/src/descriptor.rs
@@ -921,6 +921,17 @@ impl USBDescriptor for EndpointDescriptor {
     }
 }
 
+impl WritableDescriptor for EndpointDescriptor {
+    fn write_to_bytes(&self, bytes: &mut [u8]) -> Result<usize, Self::Error> {
+        Self::prepare_bytes(bytes, Self::MIN_LEN)?;
+        bytes[2] = self.endpoint_address;
+        bytes[3] = self.attributes;
+        [bytes[4], bytes[5]] = self.max_packet_size.to_le_bytes();
+        bytes[6] = self.interval;
+        Ok(bytes[0] as usize)
+    }
+}
+
 impl From<EndpointDescriptor> for EndpointInfo {
     fn from(value: EndpointDescriptor) -> Self {
         EndpointInfo {
@@ -1138,5 +1149,21 @@ mod test {
             Ok(InterfaceDescriptor::MIN_LEN as usize)
         );
         assert_eq!(InterfaceDescriptor::try_from_bytes(&bytes), Ok(descriptor));
+    }
+
+    #[test]
+    fn roundtrip_endpoint_descriptor() {
+        let descriptor = EndpointDescriptor {
+            endpoint_address: 0x11,
+            attributes: 0x22,
+            max_packet_size: 0x3344,
+            interval: 0x55,
+        };
+        let mut bytes = [0u8; EndpointDescriptor::BUF_SIZE];
+        assert_eq!(
+            descriptor.write_to_bytes(&mut bytes),
+            Ok(EndpointDescriptor::MIN_LEN as usize)
+        );
+        assert_eq!(EndpointDescriptor::try_from_bytes(&bytes), Ok(descriptor));
     }
 }

--- a/embassy-usb-host/src/descriptor.rs
+++ b/embassy-usb-host/src/descriptor.rs
@@ -175,6 +175,34 @@ pub trait ExtendableDescriptor: USBDescriptor {
             Ok(())
         }
     }
+
+    /// Prepares `bytes` to receive descriptor data.
+    ///
+    /// Fills in the descriptor length and type, and zeroes the rest.
+    ///
+    /// On success, it returns `Ok(())`.
+    /// On error, it returns a [DescriptorError].
+    #[inline(always)]
+    fn prepare_bytes(bytes: &mut [u8], len: u8) -> Result<(), DescriptorError>
+    where
+        Self: WritableDescriptor,
+    {
+        if len < Self::MIN_LEN {
+            Err(DescriptorError::BadDescriptorSize)
+        } else if bytes.len() < len as usize {
+            Err(DescriptorError::UnexpectedEndOfBuffer)
+        } else {
+            bytes[0] = len;
+            bytes[1] = Self::DESC_TYPE;
+            if let Some(subtype) = Self::DESC_SUBTYPE {
+                bytes[2] = subtype;
+                bytes[3..len as usize].fill(0);
+            } else {
+                bytes[2..len as usize].fill(0);
+            }
+            Ok(())
+        }
+    }
 }
 
 /// Variable size descriptor.

--- a/embassy-usb-host/src/descriptor.rs
+++ b/embassy-usb-host/src/descriptor.rs
@@ -706,6 +706,20 @@ impl USBDescriptor for InterfaceDescriptor {
     }
 }
 
+impl WritableDescriptor for InterfaceDescriptor {
+    fn write_to_bytes(&self, bytes: &mut [u8]) -> Result<usize, Self::Error> {
+        Self::prepare_bytes(bytes, Self::MIN_LEN)?;
+        bytes[2] = self.interface_number;
+        bytes[3] = self.alternate_setting;
+        bytes[4] = self.num_endpoints;
+        bytes[5] = self.interface_class;
+        bytes[6] = self.interface_subclass;
+        bytes[7] = self.interface_protocol;
+        bytes[8] = self.interface_name;
+        Ok(bytes[0] as usize)
+    }
+}
+
 /// The chain of descriptors of a [InterfaceDescriptor].
 ///
 /// A [ConfigurationDescriptorChain] provides one or more interface descriptors (USB 2.0 §9.6.5).
@@ -1105,5 +1119,24 @@ mod test {
             Ok(ConfigurationDescriptor::MIN_LEN as usize)
         );
         assert_eq!(ConfigurationDescriptor::try_from_bytes(&bytes), Ok(descriptor));
+    }
+
+    #[test]
+    fn roundtrip_interface_descriptor() {
+        let descriptor = InterfaceDescriptor {
+            interface_number: 0x11,
+            alternate_setting: 0x22,
+            num_endpoints: 0x33,
+            interface_class: 0x44,
+            interface_subclass: 0x55,
+            interface_protocol: 0x66,
+            interface_name: 0x77,
+        };
+        let mut bytes = [0u8; InterfaceDescriptor::BUF_SIZE];
+        assert_eq!(
+            descriptor.write_to_bytes(&mut bytes),
+            Ok(InterfaceDescriptor::MIN_LEN as usize)
+        );
+        assert_eq!(InterfaceDescriptor::try_from_bytes(&bytes), Ok(descriptor));
     }
 }

--- a/embassy-usb-host/src/descriptor.rs
+++ b/embassy-usb-host/src/descriptor.rs
@@ -291,12 +291,12 @@ pub struct DeviceDescriptorPartial {
 }
 
 impl ExtendableDescriptor for DeviceDescriptorPartial {
-    const MIN_LEN: u8 = DeviceDescriptor::MIN_LEN;
+    // `max_packet_size0` is at byte 7.
+    const MIN_LEN: u8 = 8;
 }
 
 impl USBDescriptor for DeviceDescriptorPartial {
-    // `max_packet_size0` is at byte 7.
-    const BUF_SIZE: usize = 8;
+    const BUF_SIZE: usize = Self::MIN_LEN as usize;
     const DESC_TYPE: u8 = DeviceDescriptor::DESC_TYPE;
     type Error = DescriptorError;
 
@@ -1088,6 +1088,33 @@ mod test {
 
         let mut sv = ShowDescriptors {};
         cfg.visit_descriptors(&mut sv).unwrap();
+    }
+
+    #[test]
+    fn read_device_descriptor_partial() {
+        let descriptor = DeviceDescriptor {
+            bcd_usb: 0x1122,
+            device_class: 0x33,
+            device_subclass: 0x44,
+            device_protocol: 0x55,
+            max_packet_size0: 0x66,
+            vendor_id: 0x7788,
+            product_id: 0x99aa,
+            bcd_device: 0xbbcc,
+            manufacturer: 0xdd,
+            product: 0xee,
+            serial_number: 0xff,
+            num_configurations: 0x00,
+        };
+        let mut bytes = [0u8; DeviceDescriptor::BUF_SIZE];
+        assert_eq!(
+            descriptor.write_to_bytes(&mut bytes),
+            Ok(DeviceDescriptor::MIN_LEN as usize)
+        );
+        assert_eq!(
+            DeviceDescriptorPartial::try_from_bytes(&bytes[..DeviceDescriptorPartial::BUF_SIZE]),
+            Ok(DeviceDescriptorPartial { max_packet_size0: 0x66 })
+        );
     }
 
     #[test]

--- a/embassy-usb-host/src/descriptor.rs
+++ b/embassy-usb-host/src/descriptor.rs
@@ -113,6 +113,34 @@ pub trait FixedSizeDescriptor: USBDescriptor {
             Ok(())
         }
     }
+
+    /// Prepares `bytes` to receive descriptor data.
+    ///
+    /// Fills in the descriptor length and type, and zeroes the rest.
+    ///
+    /// On success, it returns `Ok(())`.
+    /// On error, it returns a [DescriptorError].
+    #[inline(always)]
+    fn prepare_bytes(bytes: &mut [u8], len: u8) -> Result<(), DescriptorError>
+    where
+        Self: WritableDescriptor,
+    {
+        if len != Self::LEN {
+            Err(DescriptorError::BadDescriptorSize)
+        } else if bytes.len() < Self::LEN as usize {
+            Err(DescriptorError::UnexpectedEndOfBuffer)
+        } else {
+            bytes[0] = len;
+            bytes[1] = Self::DESC_TYPE;
+            if let Some(subtype) = Self::DESC_SUBTYPE {
+                bytes[2] = subtype;
+                bytes[3..len as usize].fill(0);
+            } else {
+                bytes[2..len as usize].fill(0);
+            }
+            Ok(())
+        }
+    }
 }
 
 /// Extendable fixed size descriptor.

--- a/embassy-usb-host/src/descriptor.rs
+++ b/embassy-usb-host/src/descriptor.rs
@@ -24,7 +24,7 @@ pub type StringIndex = u8;
 /// Maximum descriptor buffer size used during enumeration.
 pub(crate) const DEFAULT_MAX_DESCRIPTOR_SIZE: usize = 512;
 
-#[derive(Debug)]
+#[derive(Debug, PartialEq, Eq)]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub enum DescriptorError {
     BadDescriptorData,
@@ -382,6 +382,25 @@ impl USBDescriptor for DeviceDescriptor {
             serial_number: bytes[16],
             num_configurations: bytes[17],
         })
+    }
+}
+
+impl WritableDescriptor for DeviceDescriptor {
+    fn write_to_bytes(&self, bytes: &mut [u8]) -> Result<usize, Self::Error> {
+        Self::prepare_bytes(bytes, Self::MIN_LEN)?;
+        [bytes[2], bytes[3]] = self.bcd_usb.to_le_bytes();
+        bytes[4] = self.device_class;
+        bytes[5] = self.device_subclass;
+        bytes[6] = self.device_protocol;
+        bytes[7] = self.max_packet_size0;
+        [bytes[8], bytes[9]] = self.vendor_id.to_le_bytes();
+        [bytes[10], bytes[11]] = self.product_id.to_le_bytes();
+        [bytes[12], bytes[13]] = self.bcd_device.to_le_bytes();
+        bytes[14] = self.manufacturer;
+        bytes[15] = self.product;
+        bytes[16] = self.serial_number;
+        bytes[17] = self.num_configurations;
+        Ok(bytes[0] as usize)
     }
 }
 
@@ -1031,5 +1050,29 @@ mod test {
 
         let mut sv = ShowDescriptors {};
         cfg.visit_descriptors(&mut sv).unwrap();
+    }
+
+    #[test]
+    fn roundtrip_device_descriptor() {
+        let descriptor = DeviceDescriptor {
+            bcd_usb: 0x1122,
+            device_class: 0x33,
+            device_subclass: 0x44,
+            device_protocol: 0x55,
+            max_packet_size0: 0x66,
+            vendor_id: 0x7788,
+            product_id: 0x99aa,
+            bcd_device: 0xbbcc,
+            manufacturer: 0xdd,
+            product: 0xee,
+            serial_number: 0xff,
+            num_configurations: 0x00,
+        };
+        let mut bytes = [0u8; DeviceDescriptor::BUF_SIZE];
+        assert_eq!(
+            descriptor.write_to_bytes(&mut bytes),
+            Ok(DeviceDescriptor::MIN_LEN as usize)
+        );
+        assert_eq!(DeviceDescriptor::try_from_bytes(&bytes), Ok(descriptor));
     }
 }


### PR DESCRIPTION
Add WritableDescriptor.
Implement WritableDescriptor for complete descriptors.
(not implemented for partial descriptors DeviceDescriptorPartial, AudioControlHeaderDescriptor, and UnitDescriptor)

Implement TerminalType<->u16 conversion with the trait From.

Fix length check in HubDescriptor::match_bytes_len.
Fix length of DeviceDescriptorPartial.