### PR TITLE
rp/dma: Make DMA channel number public

### DIFF
--- a/embassy-rp/src/dma.rs
+++ b/embassy-rp/src/dma.rs
@@ -65,7 +65,7 @@ impl<'d> Channel<'d> {
     }
 
     /// Get the channel number.
-    fn number(&self) -> u8 {
+    pub fn number(&self) -> u8 {
         self.number
     }
 


### PR DESCRIPTION
Since the registers are public, it would make sense to also make the channel number public. It's needed to e.g. configure the `CHAIN_TO` channel register and to use the channel abort register.