### PR TITLE
N6 CAN Support

### DIFF
--- a/embassy-stm32/Cargo.toml
+++ b/embassy-stm32/Cargo.toml
@@ -209,11 +209,11 @@ aligned = "0.4.3"
 heapless = "0.9.1"
 
 # stm32-metapac = { version = "21" }
-stm32-metapac = { git = "https://github.com/embassy-rs/stm32-data-generated", tag = "stm32-data-76e535160fa487473949537dcf0eff7e43400cf6" }
+stm32-metapac = { git = "https://github.com/embassy-rs/stm32-data-generated", tag = "stm32-data-fe91bec726df47c6467dafce3fcf64075f662a3c" }
 
 [build-dependencies]
 # stm32-metapac = { version = "21", default-features = false, features = ["metadata"]}
-stm32-metapac = { git = "https://github.com/embassy-rs/stm32-data-generated", tag = "stm32-data-76e535160fa487473949537dcf0eff7e43400cf6", default-features = false, features = ["metadata"] }
+stm32-metapac = { git = "https://github.com/embassy-rs/stm32-data-generated", tag = "stm32-data-fe91bec726df47c6467dafce3fcf64075f662a3c", default-features = false, features = ["metadata"] }
 
 proc-macro2 = "1.0.36"
 quote = "1.0.15"

--- a/embassy-stm32/src/can/common.rs
+++ b/embassy-stm32/src/can/common.rs
@@ -10,13 +10,13 @@ pub(crate) struct ClassicBufferedTxInner {
     pub tx_receiver: SendDynamicReceiver<'static, Frame>,
 }
 
-#[cfg(any(can_fdcan_v1, can_fdcan_h7))]
+#[cfg(any(can_fdcan_v1, can_fdcan_v2))]
 
 pub(crate) struct FdBufferedRxInner {
     pub rx_sender: SendDynamicSender<'static, Result<FdEnvelope, BusError>>,
 }
 
-#[cfg(any(can_fdcan_v1, can_fdcan_h7))]
+#[cfg(any(can_fdcan_v1, can_fdcan_v2))]
 pub(crate) struct FdBufferedTxInner {
     pub tx_receiver: SendDynamicReceiver<'static, FdFrame>,
 }

--- a/embassy-stm32/src/can/fd/peripheral.rs
+++ b/embassy-stm32/src/can/fd/peripheral.rs
@@ -31,10 +31,10 @@ impl Registers {
         &mut self.msg_ram_mut().transmit.tbsa[bufidx]
     }
     pub fn msg_ram_mut(&self) -> &mut RegisterBlock {
-        #[cfg(can_fdcan_h7)]
+        #[cfg(can_fdcan_v2)]
         let ptr = self.msgram.ram(self.msg_ram_offset / 4).as_ptr() as *mut RegisterBlock;
 
-        #[cfg(not(can_fdcan_h7))]
+        #[cfg(not(can_fdcan_v2))]
         let ptr = self.msgram.as_ptr() as *mut RegisterBlock;
 
         unsafe { &mut (*ptr) }
@@ -115,7 +115,7 @@ impl Registers {
     pub fn curr_error(&self) -> Option<BusError> {
         let err = { self.regs.psr().read() };
         cfg_if! {
-            if #[cfg(can_fdcan_h7)] {
+            if #[cfg(can_fdcan_v2)] {
                 let lec = err.lec();
             } else {
                 let lec = err.lec().to_bits();
@@ -343,14 +343,14 @@ impl Registers {
         // set extended filters list size to 8
         // REQUIRED: we use the memory map as if these settings are set
         // instead of re-calculating them.
-        #[cfg(not(can_fdcan_h7))]
+        #[cfg(not(can_fdcan_v2))]
         {
             self.regs.rxgfc().modify(|w| {
                 w.set_lss(crate::can::fd::message_ram::STANDARD_FILTER_MAX);
                 w.set_lse(crate::can::fd::message_ram::EXTENDED_FILTER_MAX);
             });
         }
-        #[cfg(can_fdcan_h7)]
+        #[cfg(can_fdcan_v2)]
         {
             self.regs
                 .sidfc()
@@ -363,11 +363,11 @@ impl Registers {
         self.configure_msg_ram();
 
         // Enable timestamping
-        #[cfg(not(can_fdcan_h7))]
+        #[cfg(not(can_fdcan_v2))]
         self.regs
             .tscc()
             .write(|w| w.set_tss(stm32_metapac::can::vals::Tss::Increment));
-        #[cfg(can_fdcan_h7)]
+        #[cfg(can_fdcan_v2)]
         self.regs.tscc().write(|w| w.set_tss(0x01));
 
         // this isn't really documented in the reference manual
@@ -510,9 +510,9 @@ impl Registers {
 
         self.regs.cccr().modify(|w| {
             w.set_fdoe(fdoe);
-            #[cfg(can_fdcan_h7)]
+            #[cfg(can_fdcan_v2)]
             w.set_bse(brse);
-            #[cfg(not(can_fdcan_h7))]
+            #[cfg(not(can_fdcan_v2))]
             w.set_brse(brse);
         });
     }
@@ -527,14 +527,14 @@ impl Registers {
     #[inline]
     #[allow(unused)]
     pub fn set_timestamp_counter_source(&self, select: TimestampSource) {
-        #[cfg(can_fdcan_h7)]
+        #[cfg(can_fdcan_v2)]
         let (tcp, tss) = match select {
             TimestampSource::None => (0, 0),
             TimestampSource::Prescaler(p) => (p as u8, 1),
             TimestampSource::FromTIM3 => (0, 2),
         };
 
-        #[cfg(not(can_fdcan_h7))]
+        #[cfg(not(can_fdcan_v2))]
         let (tcp, tss) = match select {
             TimestampSource::None => (0, stm32_metapac::can::vals::Tss::Zero),
             TimestampSource::Prescaler(p) => (p as u8, stm32_metapac::can::vals::Tss::Increment),
@@ -547,7 +547,7 @@ impl Registers {
         });
     }
 
-    #[cfg(not(can_fdcan_h7))]
+    #[cfg(not(can_fdcan_v2))]
     /// Configures the global filter settings
     #[inline]
     pub fn set_global_filter(&self, filter: GlobalFilter) {
@@ -570,7 +570,7 @@ impl Registers {
         });
     }
 
-    #[cfg(can_fdcan_h7)]
+    #[cfg(can_fdcan_v2)]
     /// Configures the global filter settings
     #[inline]
     pub fn set_global_filter(&self, filter: GlobalFilter) {
@@ -594,10 +594,10 @@ impl Registers {
         });
     }
 
-    #[cfg(not(can_fdcan_h7))]
+    #[cfg(not(can_fdcan_v2))]
     fn configure_msg_ram(&self) {}
 
-    #[cfg(can_fdcan_h7)]
+    #[cfg(can_fdcan_v2)]
     fn configure_msg_ram(&self) {
         let r = self.regs;
 

--- a/embassy-stm32/src/can/fdcan.rs
+++ b/embassy-stm32/src/can/fdcan.rs
@@ -1065,7 +1065,7 @@ macro_rules! impl_fdcan {
     };
 }
 
-#[cfg(not(can_fdcan_h7))]
+#[cfg(not(can_fdcan_v2))]
 foreach_peripheral!(
     (can, FDCAN) => { impl_fdcan!(FDCAN, FDCANRAM); };
     (can, FDCAN1) => { impl_fdcan!(FDCAN1, FDCANRAM1); };
@@ -1073,11 +1073,18 @@ foreach_peripheral!(
     (can, FDCAN3) => { impl_fdcan!(FDCAN3, FDCANRAM3); };
 );
 
-#[cfg(can_fdcan_h7)]
+#[cfg(all(not(stm32n6), can_fdcan_v2)]
 foreach_peripheral!(
     (can, FDCAN1) => { impl_fdcan!(FDCAN1, FDCANRAM, 0x0000); };
     (can, FDCAN2) => { impl_fdcan!(FDCAN2, FDCANRAM, 0x0C00); };
     (can, FDCAN3) => { impl_fdcan!(FDCAN3, FDCANRAM, 0x1800); };
+);
+
+#[cfg(all(stm32n6, can_fdcan_v2)]
+foreach_peripheral!(
+    (can, FDCAN1) => { impl_fdcan!(FDCAN1, FDCANRAM1, 0x0000); };
+    (can, FDCAN2) => { impl_fdcan!(FDCAN2, FDCANRAM1, 0x0C00); };
+    (can, FDCAN3) => { impl_fdcan!(FDCAN3, FDCANRAM1, 0x1800); };
 );
 
 pin_trait!(RxPin, Instance);

--- a/embassy-stm32/src/can/fdcan.rs
+++ b/embassy-stm32/src/can/fdcan.rs
@@ -1073,18 +1073,11 @@ foreach_peripheral!(
     (can, FDCAN3) => { impl_fdcan!(FDCAN3, FDCANRAM3); };
 );
 
-#[cfg(all(not(stm32n6), can_fdcan_v2)]
+#[cfg(can_fdcan_v2)]
 foreach_peripheral!(
     (can, FDCAN1) => { impl_fdcan!(FDCAN1, FDCANRAM, 0x0000); };
     (can, FDCAN2) => { impl_fdcan!(FDCAN2, FDCANRAM, 0x0C00); };
     (can, FDCAN3) => { impl_fdcan!(FDCAN3, FDCANRAM, 0x1800); };
-);
-
-#[cfg(all(stm32n6, can_fdcan_v2)]
-foreach_peripheral!(
-    (can, FDCAN1) => { impl_fdcan!(FDCAN1, FDCANRAM1, 0x0000); };
-    (can, FDCAN2) => { impl_fdcan!(FDCAN2, FDCANRAM1, 0x0C00); };
-    (can, FDCAN3) => { impl_fdcan!(FDCAN3, FDCANRAM1, 0x1800); };
 );
 
 pin_trait!(RxPin, Instance);

--- a/embassy-stm32/src/can/mod.rs
+++ b/embassy-stm32/src/can/mod.rs
@@ -2,7 +2,7 @@
 #![macro_use]
 
 #[cfg_attr(can_bxcan, path = "bxcan/mod.rs")]
-#[cfg_attr(any(can_fdcan_v1, can_fdcan_h7), path = "fdcan.rs")]
+#[cfg_attr(any(can_fdcan_v1, can_fdcan_v2), path = "fdcan.rs")]
 mod _version;
 pub use _version::*;
 


### PR DESCRIPTION
Adds support for CAN on the N6. The N6 is almost identical to the H7 CAN, except for a new field in one of the registers (marked reserved on H7). Thus the naming has been made more generic: `v2`.

Twin ticket: https://github.com/embassy-rs/stm32-data/pull/785

# Question for Reviewer

In `embassy-stm32/src/can/fdcan.rs`, v1 CAN RAM is implemented like so, because it defines the addresses for each CAN RAM `FDCANRAM1` to `FDCANRAM3`.

```
foreach_peripheral!(
    (can, FDCAN) => { impl_fdcan!(FDCAN, FDCANRAM); };
    (can, FDCAN1) => { impl_fdcan!(FDCAN1, FDCANRAM1); };
    (can, FDCAN2) => { impl_fdcan!(FDCAN2, FDCANRAM2); };
    (can, FDCAN3) => { impl_fdcan!(FDCAN3, FDCANRAM3); };
);
```

H7 CAN RAM is implemented with 3072 byte offsets like so, because the H7 only defines the RAM base `FDCANRAM`:

```
foreach_peripheral!(
    (can, FDCAN1) => { impl_fdcan!(FDCAN1, FDCANRAM, 0x0000); };
    (can, FDCAN2) => { impl_fdcan!(FDCAN2, FDCANRAM, 0x0C00); };
    (can, FDCAN3) => { impl_fdcan!(FDCAN3, FDCANRAM, 0x1800); };
);
```

While the N6 (at least by default) defines `FDCANRAM1` to `FDCANRAM3`, the offsets are not correct (they are in 848 byte chunks, but we want 3072 bytes). The below is tested and working, but it doesn't feel right. Is there a way to adjust the FDCANRAM addresses from the N6 config?

```
foreach_peripheral!(
    (can, FDCAN1) => { impl_fdcan!(FDCAN1, FDCANRAM1, 0x0000); };
    (can, FDCAN2) => { impl_fdcan!(FDCAN2, FDCANRAM1, 0x0C00); };
    (can, FDCAN3) => { impl_fdcan!(FDCAN3, FDCANRAM1, 0x1800); };
);
```