### PR TITLE
Fix grtc syscounter reset on init

### DIFF
--- a/embassy-nrf/src/time_driver.rs
+++ b/embassy-nrf/src/time_driver.rs
@@ -218,8 +218,10 @@ impl RtcDriver {
             r.events_compare(n).write_value(0);
             r.intenclr(DOMAIN_IDX).write(|w| w.0 = compare_n(n));
 
-            // 3. Clear and start the counter.
+            // 3. Clear and start the counter when lftimer is ready
+            while !r.status().lftimer().read().ready() {}
             r.tasks_clear().write_value(1);
+            while !r.status().lftimer().read().ready() {}
             r.tasks_start().write_value(1);
 
             // 4. Configure the sleep/wake mechanism and enable the SYSCOUNTER.


### PR DESCRIPTION
PR #5830 introduced a regression where the syscounter would not be reset to 0 during init. This is because it stopped ensuring GRTC TASKS_CLEAR was being run to completion. So when TASKS_CLEAR did finally complete later on and reset the counter, any alarms set in the meantime would stall for as long as it took for syscounter to get back to the value it was at boot.

According to the datasheet: "The STATUS.LFTIMER.READY indicates busy while handling the tasks TASKS_START, TASKS_STOP and TASKS_CLEAR. These tasks must be triggered only when the STATUS.LFTIMER.READY status indicates ready."

Before #5830 there was a wait on lftimer readiness, but it occurred after triggering TASKS_CLEAR. It may be sufficient to just do that, but that doesn't seem to be what the documentation instructs.

Fixes: #6074