### PR TITLE
stm32/sdmmc: yield between CMD13 polls in write_block

### DIFF
--- a/embassy-stm32/src/sdmmc/sd.rs
+++ b/embassy-stm32/src/sdmmc/sd.rs
@@ -673,6 +673,7 @@ impl<'a, 'b, A: Addressable> StorageDevice<'a, 'b, A> {
             if status.ready_for_data() {
                 return Ok(());
             }
+            yield_now().await;
             timeout -= 1;
         }
 
@@ -750,6 +751,7 @@ impl<'a, 'b, A: Addressable> StorageDevice<'a, 'b, A> {
             if status.ready_for_data() {
                 return Ok(());
             }
+            yield_now().await;
             timeout -= 1;
         }
         Err(Error::SoftwareTimeout)

--- a/embassy-stm32/src/sdmmc/sd.rs
+++ b/embassy-stm32/src/sdmmc/sd.rs
@@ -1,6 +1,6 @@
 use core::default::Default;
 use core::ops::{Deref, DerefMut};
-
+use embassy_futures::yield_now;
 use sdio_host::common_cmd::R3;
 use sdio_host::emmc::{EMMC, ExtCSD};
 use sdio_host::sd::{BusWidth, CIC, CID, CSD, CardCapacity, CardStatus, CurrentState, OCR, RCA, SCR, SD, SDStatus};


### PR DESCRIPTION
stm32/sdmmc: yield between CMD13 polls in write_block

The post-write `ready_for_data()` polling loop in `write_block()` spun synchronously on CMD13 responses, blocking the executor for the full card programming window — typically 5–50 ms per single-block write.

Added `yield_now().await` between each CMD13 poll so other tasks can run during this window. The DMA transfer phase already yields correctly via `complete_datapath_transfer()`.