### PR TITLE
embassy-stm32/adc4: add IWDG example for stm32wba6; fix AWD threshold scaling with oversampling

### DIFF
--- a/embassy-stm32/src/adc/adc4.rs
+++ b/embassy-stm32/src/adc/adc4.rs
@@ -510,9 +510,21 @@ impl<'d, T: Instance<Regs = crate::pac::adc::Adc4>> super::Adc<'d, T> {
     ///
     /// `watchdog` selects which of the three hardware watchdogs to use. `channels` controls which
     /// ADC channels are monitored; see [`WatchdogChannels`] for which variants are valid for each
-    /// watchdog. `low_threshold` and `high_threshold` are raw ADC counts in `[0, 2^N − 1]` for
-    /// the currently configured resolution. The watchdog fires when a sample falls **outside**
-    /// `[low_threshold, high_threshold]`.
+    /// watchdog. `low_threshold` and `high_threshold` are raw ADC counts in the range
+    /// `[0, 2^N − 1]` for the currently configured resolution. The watchdog fires when a sample
+    /// falls **outside** `[low_threshold, high_threshold]`.
+    ///
+    /// ## Oversampling
+    ///
+    /// When oversampling is enabled via [`Adc::set_averaging_adc4`], the ADC hardware always
+    /// compares `ADC_DR[15:4]` (the 12 MSBs of the 16-bit data register) against the threshold,
+    /// per the reference manual.  With a typical averaging shift that yields a 12-bit result in
+    /// `DR[11:0]`, the effective comparison window is only 8 bits: `DR[11:4]` vs `HTx[7:0]` /
+    /// `LTx[7:0]`, and `HTx[11:8]` / `LTx[11:8]` must stay zero.
+    ///
+    /// This method automatically detects whether oversampling is active and scales the caller's
+    /// thresholds by `>> 4` before writing them to hardware, so you always pass thresholds in
+    /// the same 12-bit space as the sample values returned by [`AnalogWatchdog::monitor`].
     ///
     /// The returned [`AnalogWatchdog`] does **not** borrow the ADC, so you may use the ADC for
     /// DMA or other operations while the watchdog is active.  Call [`AnalogWatchdog::wait`] to
@@ -538,8 +550,20 @@ impl<'d, T: Instance<Regs = crate::pac::adc::Adc4>> super::Adc<'d, T> {
             low_threshold <= high_threshold,
             "low_threshold must be <= high_threshold"
         );
+
+        // When oversampling is active, AWD compares ADC_DR[15:4] against the threshold
+        // (RM: "comparison is performed on the most significant 12 bits of the 16-bit
+        // oversampled result ADC_DR[15:4]"). For the common case where OVSS equals the
+        // number of accumulation bits (averaging mode), DR holds a 12-bit result and the
+        // effective AWD window is DR[11:4] — only the upper 8 bits. Scale down by 4.
+        let (lt, ht) = if T::regs().cfgr2().read().ovse() {
+            (low_threshold >> 4, high_threshold >> 4)
+        } else {
+            (low_threshold, high_threshold)
+        };
+
         let index = watchdog.index();
-        AnalogWatchdog::<T>::setup_awd(watchdog, channels, low_threshold, high_threshold);
+        AnalogWatchdog::<T>::setup_awd(watchdog, channels, lt, ht);
         AnalogWatchdog::new(index)
     }
 }

--- a/examples/stm32wba6/src/bin/adc-watchdog.rs
+++ b/examples/stm32wba6/src/bin/adc-watchdog.rs
@@ -2,6 +2,13 @@
 //!
 //! Connect a voltage source or potentiometer to **PA0** (ADC4 channel 9). The example waits for the
 //! sample to go above ~0.6 V, then waits for it to fall below ~0.2 V, and repeats.
+//!
+//! Hardware oversampling (8×) is enabled. When oversampling is active the AWD hardware compares
+//! `ADC_DR[15:4]` against the threshold registers (RM: "most significant 12 bits of the 16-bit
+//! oversampled result"). With an averaging shift that yields a 12-bit result in DR[11:0], only
+//! the upper 8 bits (`DR[11:4]`) are compared, so thresholds must be right-shifted by 4.
+//! `enable_watchdog` does this automatically — pass thresholds in the same 12-bit space as the
+//! sample values and the driver scales them correctly.
 
 #![no_std]
 #![no_main]
@@ -47,7 +54,10 @@ async fn main(_spawner: Spawner) {
     let mut adc = Adc::new_adc4(p.ADC4);
     let mut pin = p.PA0;
     adc.set_resolution_adc4(adc4::Resolution::Bits12);
-    adc.set_averaging_adc4(adc4::Averaging::Disabled);
+    // 8× oversampling with matching right-shift → same 12-bit range, lower noise.
+    // enable_watchdog will automatically scale AWD thresholds by >> 4 to match
+    // the hardware's DR[15:4] comparison window.
+    adc.set_averaging_adc4(adc4::Averaging::Samples8);
 
     let pin_ch = pin.degrade_adc().get_hw_channel();
 

--- a/examples/stm32wba6/src/bin/iwdg.rs
+++ b/examples/stm32wba6/src/bin/iwdg.rs
@@ -1,0 +1,48 @@
+#![no_std]
+#![no_main]
+
+use defmt::*;
+use embassy_executor::Spawner;
+use embassy_stm32::Config;
+use embassy_stm32::rcc::{
+    AHB5Prescaler, AHBPrescaler, APBPrescaler, PllDiv, PllMul, PllPreDiv, PllSource, Sysclk, VoltageScale,
+};
+use embassy_stm32::wdg::IndependentWatchdog;
+use embassy_time::Timer;
+use {defmt_rtt as _, panic_probe as _};
+
+#[embassy_executor::main]
+async fn main(_spawner: Spawner) {
+    let mut config = Config::default();
+    config.rcc.pll1 = Some(embassy_stm32::rcc::Pll {
+        source: PllSource::Hsi,
+        prediv: PllPreDiv::Div1,
+        mul: PllMul::Mul30,
+        divr: Some(PllDiv::Div5),
+        divq: None,
+        divp: Some(PllDiv::Div30),
+        frac: Some(0),
+    });
+
+    config.rcc.ahb_pre = AHBPrescaler::Div1;
+    config.rcc.apb1_pre = APBPrescaler::Div1;
+    config.rcc.apb2_pre = APBPrescaler::Div1;
+    config.rcc.apb7_pre = APBPrescaler::Div1;
+    config.rcc.ahb5_pre = AHB5Prescaler::Div4;
+
+    config.rcc.voltage_scale = VoltageScale::Range1;
+    config.rcc.sys = Sysclk::Pll1R;
+
+    let p = embassy_stm32::init(config);
+    info!("IWDG example");
+
+    // 2 s timeout. IWDG is clocked from LSI (~32 kHz on WBA), independent of system clock.
+    let mut wdg = IndependentWatchdog::new(p.IWDG, 2_000_000);
+    wdg.unleash();
+
+    loop {
+        Timer::after_millis(500).await;
+        info!("pet");
+        wdg.pet();
+    }
+}


### PR DESCRIPTION
## Summary

- **`examples/stm32wba6: add iwdg example`** — demonstrates configuring and petting the Independent Watchdog (IWDG) on STM32WBA6, including RCC clock setup for 96 MHz sysclk. Fills the same gap as the existing WWDG example for that family.

- **`embassy-stm32/adc4: scale AWD thresholds when oversampling is active`** — fixes a silent misconfiguration in `Adc::enable_watchdog`. When `CFGR2.OVSE` is set, the ADC4 hardware always compares `ADC_DR[15:4]` (the 12 MSBs of the 16-bit data register) against the watchdog threshold, not the full shifted result. With a typical averaging shift that yields a 12-bit result in `DR[11:0]`, only `DR[11:4]` participates in the comparison and `HTx[11:8]`/`LTx[11:8]` must remain zero (per RM0515 §"Analog watchdog with oversampling"). The previous code wrote the caller's 12-bit threshold directly, producing a threshold ~16× too high whenever averaging was enabled.

  The fix reads `CFGR2.OVSE` inside `enable_watchdog` and right-shifts both thresholds by 4 when oversampling is active. Callers always pass thresholds in the same 12-bit space as the sample values — no manual scaling required.

  The `stm32wba6` `adc-watchdog` example is updated to use `Averaging::Samples8` and documents the `DR[15:4]` comparison rule.