### PR TITLE
Synopsys-OTG: type-erase endpoint counts

### DIFF
--- a/embassy-nrf/Cargo.toml
+++ b/embassy-nrf/Cargo.toml
@@ -219,7 +219,7 @@ embassy-sync = { version = "0.8.0", path = "../embassy-sync" }
 embassy-hal-internal = { version = "0.5.0", path = "../embassy-hal-internal", features = ["cortex-m", "prio-bits-3"] }
 embassy-embedded-hal = { version = "0.6.0", path = "../embassy-embedded-hal", default-features = false }
 embassy-usb-driver = { version = "0.2.1", path = "../embassy-usb-driver" }
-embassy-usb-synopsys-otg = { version = "0.3.3", path = "../embassy-usb-synopsys-otg", optional = true }
+embassy-usb-synopsys-otg = { version = "0.4.0", path = "../embassy-usb-synopsys-otg", optional = true }
 embassy-net-driver-channel = { version = "0.4.0", path = "../embassy-net-driver-channel", optional = true}
 embassy-futures = { version = "0.1.2", path = "../embassy-futures" }
 

--- a/embassy-nrf/src/usb/usbhs.rs
+++ b/embassy-nrf/src/usb/usbhs.rs
@@ -35,13 +35,13 @@ pub struct InterruptHandler<T: Instance> {
 
 impl<T: Instance> interrupt::typelevel::Handler<T::Interrupt> for InterruptHandler<T> {
     unsafe fn on_interrupt() {
-        on_interrupt_impl(T::core_regs(), T::state(), MAX_EP_COUNT);
+        on_interrupt_impl(T::core_regs(), &T::state().as_otg_state(), MAX_EP_COUNT);
     }
 }
 
 /// USB driver.
 pub struct Driver<'d, V: VbusDetect> {
-    inner: OtgDriver<'d, MAX_EP_COUNT>,
+    inner: OtgDriver<'d>,
     usb_regs: pac::usbhs::Usbhs,
     vbus_detect: V,
     _phantom: PhantomData<&'d ()>,
@@ -61,7 +61,7 @@ impl<'d, V: VbusDetect> Driver<'d, V> {
 
         let instance = OtgInstance {
             regs: T::core_regs(),
-            state: T::state(),
+            state: T::state().as_otg_state(),
             fifo_depth_words: FIFO_DEPTH_WORDS,
             endpoint_count: MAX_EP_COUNT,
             phy_type: PhyType::InternalHighSpeed,
@@ -125,7 +125,7 @@ impl<'d, V: VbusDetect + 'd> embassy_usb_driver::Driver<'d> for Driver<'d, V> {
 
 /// USB bus.
 pub struct Bus<'d, V: VbusDetect> {
-    inner: OtgBus<'d, MAX_EP_COUNT>,
+    inner: OtgBus<'d>,
     usb_regs: pac::usbhs::Usbhs,
     vbus_detect: V,
     power_present: bool,

--- a/embassy-nrf/src/usb/usbhs.rs
+++ b/embassy-nrf/src/usb/usbhs.rs
@@ -14,7 +14,7 @@ pub use embassy_usb_synopsys_otg::Config;
 use embassy_usb_synopsys_otg::otg_v1::Otg;
 use embassy_usb_synopsys_otg::otg_v1::vals::Dspd;
 use embassy_usb_synopsys_otg::{
-    Bus as OtgBus, ControlPipe, Driver as OtgDriver, Endpoint, In, OtgInstance, OtgState, Out, PhyType, State,
+    Bus as OtgBus, ControlPipe, Driver as OtgDriver, Endpoint, In, OtgInstance, Out, PhyType, State, StateStorage,
     on_interrupt as on_interrupt_impl,
 };
 
@@ -302,7 +302,7 @@ impl<'d, V: VbusDetect> Drop for Bus<'d, V> {
 pub(crate) trait SealedInstance {
     fn usb_regs() -> pac::usbhs::Usbhs;
     fn core_regs() -> Otg;
-    fn state() -> OtgState<'static>;
+    fn state() -> State<'static>;
 }
 
 /// USB peripheral instance.
@@ -321,9 +321,9 @@ impl SealedInstance for crate::peripherals::USBHS {
         unsafe { Otg::from_ptr(pac::USBHSCORE.as_ptr()) }
     }
 
-    fn state() -> OtgState<'static> {
-        static STATE: State<MAX_EP_COUNT> = State::new();
-        STATE.as_otg_state()
+    fn state() -> State<'static> {
+        static STATE: StateStorage<MAX_EP_COUNT> = StateStorage::new();
+        STATE.as_state()
     }
 }
 

--- a/embassy-nrf/src/usb/usbhs.rs
+++ b/embassy-nrf/src/usb/usbhs.rs
@@ -14,7 +14,7 @@ pub use embassy_usb_synopsys_otg::Config;
 use embassy_usb_synopsys_otg::otg_v1::Otg;
 use embassy_usb_synopsys_otg::otg_v1::vals::Dspd;
 use embassy_usb_synopsys_otg::{
-    Bus as OtgBus, ControlPipe, Driver as OtgDriver, Endpoint, In, OtgInstance, Out, PhyType, State,
+    Bus as OtgBus, ControlPipe, Driver as OtgDriver, Endpoint, OtgState, In, OtgInstance, Out, PhyType, State,
     on_interrupt as on_interrupt_impl,
 };
 
@@ -35,7 +35,7 @@ pub struct InterruptHandler<T: Instance> {
 
 impl<T: Instance> interrupt::typelevel::Handler<T::Interrupt> for InterruptHandler<T> {
     unsafe fn on_interrupt() {
-        on_interrupt_impl(T::core_regs(), &T::state().as_otg_state(), MAX_EP_COUNT);
+        on_interrupt_impl(T::core_regs(), &T::state(), MAX_EP_COUNT);
     }
 }
 
@@ -61,7 +61,7 @@ impl<'d, V: VbusDetect> Driver<'d, V> {
 
         let instance = OtgInstance {
             regs: T::core_regs(),
-            state: T::state().as_otg_state(),
+            state: T::state(),
             fifo_depth_words: FIFO_DEPTH_WORDS,
             endpoint_count: MAX_EP_COUNT,
             phy_type: PhyType::InternalHighSpeed,
@@ -303,7 +303,7 @@ impl<'d, V: VbusDetect> Drop for Bus<'d, V> {
 pub(crate) trait SealedInstance {
     fn usb_regs() -> pac::usbhs::Usbhs;
     fn core_regs() -> Otg;
-    fn state() -> &'static State<MAX_EP_COUNT>;
+    fn state() -> OtgState<'static>;
 }
 
 /// USB peripheral instance.
@@ -322,9 +322,9 @@ impl SealedInstance for crate::peripherals::USBHS {
         unsafe { Otg::from_ptr(pac::USBHSCORE.as_ptr()) }
     }
 
-    fn state() -> &'static State<MAX_EP_COUNT> {
+    fn state() -> OtgState<'static> {
         static STATE: State<MAX_EP_COUNT> = State::new();
-        &STATE
+        STATE.as_otg_state()
     }
 }
 

--- a/embassy-nrf/src/usb/usbhs.rs
+++ b/embassy-nrf/src/usb/usbhs.rs
@@ -14,7 +14,7 @@ pub use embassy_usb_synopsys_otg::Config;
 use embassy_usb_synopsys_otg::otg_v1::Otg;
 use embassy_usb_synopsys_otg::otg_v1::vals::Dspd;
 use embassy_usb_synopsys_otg::{
-    Bus as OtgBus, ControlPipe, Driver as OtgDriver, Endpoint, OtgState, In, OtgInstance, Out, PhyType, State,
+    Bus as OtgBus, ControlPipe, Driver as OtgDriver, Endpoint, In, OtgInstance, OtgState, Out, PhyType, State,
     on_interrupt as on_interrupt_impl,
 };
 
@@ -35,7 +35,7 @@ pub struct InterruptHandler<T: Instance> {
 
 impl<T: Instance> interrupt::typelevel::Handler<T::Interrupt> for InterruptHandler<T> {
     unsafe fn on_interrupt() {
-        on_interrupt_impl(T::core_regs(), &T::state(), MAX_EP_COUNT);
+        on_interrupt_impl(T::core_regs(), &T::state());
     }
 }
 
@@ -63,7 +63,6 @@ impl<'d, V: VbusDetect> Driver<'d, V> {
             regs: T::core_regs(),
             state: T::state(),
             fifo_depth_words: FIFO_DEPTH_WORDS,
-            endpoint_count: MAX_EP_COUNT,
             phy_type: PhyType::InternalHighSpeed,
             extra_rx_fifo_words: RX_FIFO_EXTRA_SIZE_WORDS,
             calculate_trdt_fn: calculate_trdt,

--- a/embassy-stm32/Cargo.toml
+++ b/embassy-stm32/Cargo.toml
@@ -161,7 +161,7 @@ embassy-hal-internal = { version = "0.5.0", path = "../embassy-hal-internal", fe
 embassy-embedded-hal = { version = "0.6.0", path = "../embassy-embedded-hal", default-features = false }
 embassy-net-driver = { version = "0.2.0", path = "../embassy-net-driver" }
 embassy-usb-driver = { version = "0.2.1", path = "../embassy-usb-driver" }
-embassy-usb-synopsys-otg = { version = "0.3.3", path = "../embassy-usb-synopsys-otg" }
+embassy-usb-synopsys-otg = { version = "0.4.0", path = "../embassy-usb-synopsys-otg" }
 embassy-executor = { version = "0.10.0", path = "../embassy-executor", optional = true }
 cyw43 = { version = "0.7.0", path = "../cyw43", optional = true }
 

--- a/embassy-stm32/src/usb/otg.rs
+++ b/embassy-stm32/src/usb/otg.rs
@@ -6,7 +6,7 @@ pub use embassy_usb_synopsys_otg::Config;
 use embassy_usb_synopsys_otg::otg_v1::Otg;
 use embassy_usb_synopsys_otg::otg_v1::vals::Dspd;
 use embassy_usb_synopsys_otg::{
-    Bus as OtgBus, ControlPipe, Driver as OtgDriver, Endpoint, In, OtgInstance, Out, PhyType, State,
+    Bus as OtgBus, ControlPipe, Driver as OtgDriver, Endpoint, In, OtgInstance, Out, PhyType, State, OtgState,
     on_interrupt as on_interrupt_impl,
 };
 
@@ -25,7 +25,7 @@ pub struct InterruptHandler<T: Instance> {
 impl<T: Instance> interrupt::typelevel::Handler<T::Interrupt> for InterruptHandler<T> {
     unsafe fn on_interrupt() {
         let r = T::regs();
-        on_interrupt_impl(r, &T::state().as_otg_state(), T::ENDPOINT_COUNT);
+        on_interrupt_impl(r, &T::state(), T::ENDPOINT_COUNT);
     }
 }
 
@@ -79,7 +79,7 @@ impl<'d, T: Instance> Driver<'d, T> {
 
         let instance = OtgInstance {
             regs,
-            state: T::state().as_otg_state(),
+            state: T::state(),
             fifo_depth_words: T::FIFO_DEPTH_WORDS,
             extra_rx_fifo_words: RX_FIFO_EXTRA_SIZE_WORDS,
             endpoint_count: T::ENDPOINT_COUNT,
@@ -118,7 +118,7 @@ impl<'d, T: Instance> Driver<'d, T> {
 
         let instance = OtgInstance {
             regs: T::regs(),
-            state: T::state().as_otg_state(),
+            state: T::state(),
             fifo_depth_words: T::FIFO_DEPTH_WORDS,
             extra_rx_fifo_words: RX_FIFO_EXTRA_SIZE_WORDS,
             endpoint_count: T::ENDPOINT_COUNT,
@@ -164,7 +164,7 @@ impl<'d, T: Instance> Driver<'d, T> {
 
         let instance = OtgInstance {
             regs: T::regs(),
-            state: T::state().as_otg_state(),
+            state: T::state(),
             fifo_depth_words: T::FIFO_DEPTH_WORDS,
             extra_rx_fifo_words: RX_FIFO_EXTRA_SIZE_WORDS,
             endpoint_count: T::ENDPOINT_COUNT,
@@ -212,7 +212,7 @@ impl<'d, T: Instance> Driver<'d, T> {
 
         let instance = OtgInstance {
             regs: T::regs(),
-            state: T::state().as_otg_state(),
+            state: T::state(),
             fifo_depth_words: T::FIFO_DEPTH_WORDS,
             extra_rx_fifo_words: RX_FIFO_EXTRA_SIZE_WORDS,
             endpoint_count: T::ENDPOINT_COUNT,
@@ -430,7 +430,7 @@ trait SealedInstance {
     const ENDPOINT_COUNT: usize;
 
     fn regs() -> Otg;
-    fn state() -> &'static State<{ MAX_EP_COUNT }>;
+    fn state() -> OtgState<'static>;
 }
 
 /// USB instance trait.
@@ -514,9 +514,9 @@ foreach_interrupt!(
                 unsafe { Otg::from_ptr(crate::pac::USB_OTG_FS.as_ptr()) }
             }
 
-            fn state() -> &'static State<MAX_EP_COUNT> {
+            fn state() -> OtgState<'static> {
                 static STATE: State<MAX_EP_COUNT> = State::new();
-                &STATE
+                STATE.as_otg_state()
             }
         }
 
@@ -565,9 +565,9 @@ foreach_interrupt!(
                 unsafe { Otg::from_ptr(crate::pac::USB_OTG_HS.as_ptr()) }
             }
 
-            fn state() -> &'static State<MAX_EP_COUNT> {
+            fn state() -> OtgState<'static> {
                 static STATE: State<MAX_EP_COUNT> = State::new();
-                &STATE
+                STATE.as_otg_state()
             }
         }
 
@@ -585,7 +585,7 @@ mod host_impl {
 
     use embassy_usb_synopsys_otg::PhyType;
     use embassy_usb_synopsys_otg::host::{
-        HostState, OtgHost as OtgHostDriver, OtgHostInstance, on_host_interrupt as on_host_interrupt_impl,
+        HostState, OtgHost as OtgHostDriver, OtgHostState, OtgHostInstance, on_host_interrupt as on_host_interrupt_impl,
     };
 
     use super::*;
@@ -595,23 +595,23 @@ mod host_impl {
     /// Per-instance host state, analogous to `SealedInstance::state()` for device mode.
     #[allow(private_bounds)]
     pub(super) trait SealedHostInstance: Instance {
-        fn host_state() -> &'static HostState<MAX_HOST_CH_COUNT>;
+        fn host_state() -> OtgHostState<'static>;
     }
 
     foreach_interrupt!(
         (USB_OTG_FS, otg, $block:ident, GLOBAL, $irq:ident) => {
             impl SealedHostInstance for crate::peripherals::USB_OTG_FS {
-                fn host_state() -> &'static HostState<MAX_HOST_CH_COUNT> {
+                fn host_state() -> OtgHostState<'static> {
                     static STATE: HostState<MAX_HOST_CH_COUNT> = HostState::new();
-                    &STATE
+                    STATE.as_otg_host_state()
                 }
             }
         };
         (USB_OTG_HS, otg, $block:ident, GLOBAL, $irq:ident) => {
             impl SealedHostInstance for crate::peripherals::USB_OTG_HS {
-                fn host_state() -> &'static HostState<MAX_HOST_CH_COUNT> {
+                fn host_state() -> OtgHostState<'static> {
                     static STATE: HostState<MAX_HOST_CH_COUNT> = HostState::new();
-                    &STATE
+                    STATE.as_otg_host_state()
                 }
             }
         };
@@ -628,7 +628,7 @@ mod host_impl {
             let r = T::regs();
             on_host_interrupt_impl(
                 r,
-                &T::host_state().as_otg_host_state(),
+                &T::host_state(),
                 T::ENDPOINT_COUNT.min(MAX_HOST_CH_COUNT),
             );
         }
@@ -662,7 +662,7 @@ mod host_impl {
 
             let instance = OtgHostInstance {
                 regs: T::regs(),
-                state: T::host_state().as_otg_host_state(),
+                state: T::host_state(),
                 fifo_depth_words: T::FIFO_DEPTH_WORDS,
                 channel_count: T::ENDPOINT_COUNT.min(MAX_HOST_CH_COUNT),
                 phy_type: PhyType::InternalFullSpeed,
@@ -712,7 +712,7 @@ mod host_impl {
 
             let instance = OtgHostInstance {
                 regs: T::regs(),
-                state: T::host_state().as_otg_host_state(),
+                state: T::host_state(),
                 fifo_depth_words: T::FIFO_DEPTH_WORDS,
                 channel_count: T::ENDPOINT_COUNT.min(MAX_HOST_CH_COUNT),
                 phy_type: PhyType::InternalHighSpeed,

--- a/embassy-stm32/src/usb/otg.rs
+++ b/embassy-stm32/src/usb/otg.rs
@@ -626,8 +626,11 @@ mod host_impl {
     impl<T: SealedHostInstance> interrupt::typelevel::Handler<T::Interrupt> for HostInterruptHandler<T> {
         unsafe fn on_interrupt() {
             let r = T::regs();
-            let state = T::host_state();
-            on_host_interrupt_impl(r, state, T::ENDPOINT_COUNT.min(MAX_HOST_CH_COUNT));
+            on_host_interrupt_impl(
+                r,
+                &T::host_state().as_otg_host_state(),
+                T::ENDPOINT_COUNT.min(MAX_HOST_CH_COUNT),
+            );
         }
     }
 
@@ -635,7 +638,7 @@ mod host_impl {
     #[allow(private_interfaces, private_bounds)]
     pub struct HostDriver<'d, T: SealedHostInstance> {
         phantom: PhantomData<&'d mut T>,
-        inner: OtgHostDriver<'d, MAX_HOST_CH_COUNT>,
+        inner: OtgHostDriver<'d>,
     }
 
     #[allow(private_bounds)]
@@ -659,7 +662,7 @@ mod host_impl {
 
             let instance = OtgHostInstance {
                 regs: T::regs(),
-                state: T::host_state(),
+                state: T::host_state().as_otg_host_state(),
                 fifo_depth_words: T::FIFO_DEPTH_WORDS,
                 channel_count: T::ENDPOINT_COUNT.min(MAX_HOST_CH_COUNT),
                 phy_type: PhyType::InternalFullSpeed,
@@ -709,7 +712,7 @@ mod host_impl {
 
             let instance = OtgHostInstance {
                 regs: T::regs(),
-                state: T::host_state(),
+                state: T::host_state().as_otg_host_state(),
                 fifo_depth_words: T::FIFO_DEPTH_WORDS,
                 channel_count: T::ENDPOINT_COUNT.min(MAX_HOST_CH_COUNT),
                 phy_type: PhyType::InternalHighSpeed,
@@ -724,8 +727,7 @@ mod host_impl {
 
     #[allow(private_bounds)]
     impl<'d, T: SealedHostInstance> embassy_usb_driver::host::UsbHostController<'d> for HostDriver<'d, T> {
-        type Allocator =
-            <OtgHostDriver<'d, MAX_HOST_CH_COUNT> as embassy_usb_driver::host::UsbHostController<'d>>::Allocator;
+        type Allocator = <OtgHostDriver<'d> as embassy_usb_driver::host::UsbHostController<'d>>::Allocator;
 
         fn allocator(&self) -> Self::Allocator {
             self.inner.allocator()

--- a/embassy-stm32/src/usb/otg.rs
+++ b/embassy-stm32/src/usb/otg.rs
@@ -25,8 +25,7 @@ pub struct InterruptHandler<T: Instance> {
 impl<T: Instance> interrupt::typelevel::Handler<T::Interrupt> for InterruptHandler<T> {
     unsafe fn on_interrupt() {
         let r = T::regs();
-        let state = T::state();
-        on_interrupt_impl(r, state, T::ENDPOINT_COUNT);
+        on_interrupt_impl(r, &T::state().as_otg_state(), T::ENDPOINT_COUNT);
     }
 }
 
@@ -49,7 +48,7 @@ const RX_FIFO_EXTRA_SIZE_WORDS: u16 = 30;
 /// USB driver.
 pub struct Driver<'d, T: Instance> {
     phantom: PhantomData<&'d mut T>,
-    inner: OtgDriver<'d, MAX_EP_COUNT>,
+    inner: OtgDriver<'d>,
 }
 
 impl<'d, T: Instance> Driver<'d, T> {
@@ -80,7 +79,7 @@ impl<'d, T: Instance> Driver<'d, T> {
 
         let instance = OtgInstance {
             regs,
-            state: T::state(),
+            state: T::state().as_otg_state(),
             fifo_depth_words: T::FIFO_DEPTH_WORDS,
             extra_rx_fifo_words: RX_FIFO_EXTRA_SIZE_WORDS,
             endpoint_count: T::ENDPOINT_COUNT,
@@ -119,7 +118,7 @@ impl<'d, T: Instance> Driver<'d, T> {
 
         let instance = OtgInstance {
             regs: T::regs(),
-            state: T::state(),
+            state: T::state().as_otg_state(),
             fifo_depth_words: T::FIFO_DEPTH_WORDS,
             extra_rx_fifo_words: RX_FIFO_EXTRA_SIZE_WORDS,
             endpoint_count: T::ENDPOINT_COUNT,
@@ -165,7 +164,7 @@ impl<'d, T: Instance> Driver<'d, T> {
 
         let instance = OtgInstance {
             regs: T::regs(),
-            state: T::state(),
+            state: T::state().as_otg_state(),
             fifo_depth_words: T::FIFO_DEPTH_WORDS,
             extra_rx_fifo_words: RX_FIFO_EXTRA_SIZE_WORDS,
             endpoint_count: T::ENDPOINT_COUNT,
@@ -213,7 +212,7 @@ impl<'d, T: Instance> Driver<'d, T> {
 
         let instance = OtgInstance {
             regs: T::regs(),
-            state: T::state(),
+            state: T::state().as_otg_state(),
             fifo_depth_words: T::FIFO_DEPTH_WORDS,
             extra_rx_fifo_words: RX_FIFO_EXTRA_SIZE_WORDS,
             endpoint_count: T::ENDPOINT_COUNT,
@@ -273,7 +272,7 @@ impl<'d, T: Instance> embassy_usb_driver::Driver<'d> for Driver<'d, T> {
 /// USB bus.
 pub struct Bus<'d, T: Instance> {
     phantom: PhantomData<&'d mut T>,
-    inner: OtgBus<'d, MAX_EP_COUNT>,
+    inner: OtgBus<'d>,
     inited: bool,
 }
 

--- a/embassy-stm32/src/usb/otg.rs
+++ b/embassy-stm32/src/usb/otg.rs
@@ -6,7 +6,7 @@ pub use embassy_usb_synopsys_otg::Config;
 use embassy_usb_synopsys_otg::otg_v1::Otg;
 use embassy_usb_synopsys_otg::otg_v1::vals::Dspd;
 use embassy_usb_synopsys_otg::{
-    Bus as OtgBus, ControlPipe, Driver as OtgDriver, Endpoint, In, OtgInstance, OtgState, Out, PhyType,
+    Bus as OtgBus, ControlPipe, Driver as OtgDriver, Endpoint, In, OtgInstance, Out, PhyType, State,
     on_interrupt as on_interrupt_impl,
 };
 
@@ -423,7 +423,7 @@ trait SealedInstance {
     const FIFO_DEPTH_WORDS: u16;
 
     fn regs() -> Otg;
-    fn state() -> OtgState<'static>;
+    fn state() -> State<'static>;
 }
 
 /// USB instance trait.
@@ -544,12 +544,12 @@ foreach_interrupt!(
                 unsafe { Otg::from_ptr(crate::pac::USB_OTG_FS.as_ptr()) }
             }
 
-            fn state() -> OtgState<'static> {
-                use embassy_usb_synopsys_otg::State;
+            fn state() -> State<'static> {
+                use embassy_usb_synopsys_otg::StateStorage;
 
                 const EP_COUNT: usize = crate::peripherals::USB_OTG_FS::ENDPOINT_COUNT;
-                static STATE: State<EP_COUNT> = State::new();
-                STATE.as_otg_state()
+                static STATE: StateStorage<EP_COUNT> = StateStorage::new();
+                STATE.as_state()
             }
         }
 
@@ -625,12 +625,12 @@ foreach_interrupt!(
                 unsafe { Otg::from_ptr(crate::pac::USB_OTG_HS.as_ptr()) }
             }
 
-            fn state() -> OtgState<'static> {
-                use embassy_usb_synopsys_otg::State;
+            fn state() -> State<'static> {
+                use embassy_usb_synopsys_otg::StateStorage;
 
                 const EP_COUNT: usize = crate::peripherals::USB_OTG_HS::ENDPOINT_COUNT;
-                static STATE: State<EP_COUNT> = State::new();
-                STATE.as_otg_state()
+                static STATE: StateStorage<EP_COUNT> = StateStorage::new();
+                STATE.as_state()
             }
         }
 
@@ -648,7 +648,7 @@ mod host_impl {
 
     use embassy_usb_synopsys_otg::PhyType;
     use embassy_usb_synopsys_otg::host::{
-        OtgHost as OtgHostDriver, OtgHostInstance, OtgHostState, on_host_interrupt as on_host_interrupt_impl,
+        HostState, OtgHost as OtgHostDriver, OtgHostInstance, on_host_interrupt as on_host_interrupt_impl,
     };
 
     use super::*;
@@ -656,29 +656,29 @@ mod host_impl {
     /// Per-instance host state, analogous to `SealedInstance::state()` for device mode.
     #[allow(private_bounds)]
     pub(super) trait SealedHostInstance: Instance {
-        fn host_state() -> OtgHostState<'static>;
+        fn host_state() -> HostState<'static>;
     }
 
     foreach_interrupt!(
         (USB_OTG_FS, otg, $block:ident, GLOBAL, $irq:ident) => {
             impl SealedHostInstance for crate::peripherals::USB_OTG_FS {
-                fn host_state() -> OtgHostState<'static> {
-                    use embassy_usb_synopsys_otg::host::HostState;
+                fn host_state() -> HostState<'static> {
+                    use embassy_usb_synopsys_otg::host::HostStateStorage;
 
                     const CH_COUNT:usize = crate::peripherals::USB_OTG_FS::ENDPOINT_COUNT;
-                    static STATE: HostState<CH_COUNT> = HostState::new();
-                    STATE.as_otg_host_state()
+                    static STATE: HostStateStorage<CH_COUNT> = HostStateStorage::new();
+                    STATE.as_host_state()
                 }
             }
         };
         (USB_OTG_HS, otg, $block:ident, GLOBAL, $irq:ident) => {
             impl SealedHostInstance for crate::peripherals::USB_OTG_HS {
-                fn host_state() -> OtgHostState<'static> {
-                    use embassy_usb_synopsys_otg::host::HostState;
+                fn host_state() -> HostState<'static> {
+                    use embassy_usb_synopsys_otg::host::HostStateStorage;
 
                     const CH_COUNT:usize = crate::peripherals::USB_OTG_HS::ENDPOINT_COUNT;
-                    static STATE: HostState<CH_COUNT> = HostState::new();
-                    STATE.as_otg_host_state()
+                    static STATE: HostStateStorage<CH_COUNT> = HostStateStorage::new();
+                    STATE.as_host_state()
                 }
             }
         };

--- a/embassy-stm32/src/usb/otg.rs
+++ b/embassy-stm32/src/usb/otg.rs
@@ -6,7 +6,7 @@ pub use embassy_usb_synopsys_otg::Config;
 use embassy_usb_synopsys_otg::otg_v1::Otg;
 use embassy_usb_synopsys_otg::otg_v1::vals::Dspd;
 use embassy_usb_synopsys_otg::{
-    Bus as OtgBus, ControlPipe, Driver as OtgDriver, Endpoint, In, OtgInstance, Out, PhyType, State, OtgState,
+    Bus as OtgBus, ControlPipe, Driver as OtgDriver, Endpoint, In, OtgInstance, OtgState, Out, PhyType,
     on_interrupt as on_interrupt_impl,
 };
 
@@ -14,8 +14,6 @@ use crate::gpio::{AfType, OutputType, Speed};
 use crate::interrupt::typelevel::Interrupt;
 use crate::rcc::{self, RccPeripheral};
 use crate::{Peri, interrupt};
-
-const MAX_EP_COUNT: usize = 9;
 
 /// Interrupt handler.
 pub struct InterruptHandler<T: Instance> {
@@ -25,7 +23,7 @@ pub struct InterruptHandler<T: Instance> {
 impl<T: Instance> interrupt::typelevel::Handler<T::Interrupt> for InterruptHandler<T> {
     unsafe fn on_interrupt() {
         let r = T::regs();
-        on_interrupt_impl(r, &T::state(), T::ENDPOINT_COUNT);
+        on_interrupt_impl(r, &T::state());
     }
 }
 
@@ -82,7 +80,6 @@ impl<'d, T: Instance> Driver<'d, T> {
             state: T::state(),
             fifo_depth_words: T::FIFO_DEPTH_WORDS,
             extra_rx_fifo_words: RX_FIFO_EXTRA_SIZE_WORDS,
-            endpoint_count: T::ENDPOINT_COUNT,
             phy_type: PhyType::InternalFullSpeed,
             calculate_trdt_fn: calculate_trdt::<T>,
         };
@@ -121,7 +118,6 @@ impl<'d, T: Instance> Driver<'d, T> {
             state: T::state(),
             fifo_depth_words: T::FIFO_DEPTH_WORDS,
             extra_rx_fifo_words: RX_FIFO_EXTRA_SIZE_WORDS,
-            endpoint_count: T::ENDPOINT_COUNT,
             phy_type: PhyType::InternalHighSpeed,
             calculate_trdt_fn: calculate_trdt::<T>,
         };
@@ -167,7 +163,6 @@ impl<'d, T: Instance> Driver<'d, T> {
             state: T::state(),
             fifo_depth_words: T::FIFO_DEPTH_WORDS,
             extra_rx_fifo_words: RX_FIFO_EXTRA_SIZE_WORDS,
-            endpoint_count: T::ENDPOINT_COUNT,
             phy_type: PhyType::ExternalFullSpeed,
             calculate_trdt_fn: calculate_trdt::<T>,
         };
@@ -215,7 +210,6 @@ impl<'d, T: Instance> Driver<'d, T> {
             state: T::state(),
             fifo_depth_words: T::FIFO_DEPTH_WORDS,
             extra_rx_fifo_words: RX_FIFO_EXTRA_SIZE_WORDS,
-            endpoint_count: T::ENDPOINT_COUNT,
             phy_type: PhyType::ExternalHighSpeed,
             calculate_trdt_fn: calculate_trdt::<T>,
         };
@@ -427,7 +421,6 @@ impl<'d, T: Instance> Drop for Bus<'d, T> {
 trait SealedInstance {
     const HIGH_SPEED: bool;
     const FIFO_DEPTH_WORDS: u16;
-    const ENDPOINT_COUNT: usize;
 
     fn regs() -> Otg;
     fn state() -> OtgState<'static>;
@@ -460,12 +453,9 @@ pin_trait!(UlpiD7Pin, Instance);
 
 foreach_interrupt!(
     (USB_OTG_FS, otg, $block:ident, GLOBAL, $irq:ident) => {
-        impl SealedInstance for crate::peripherals::USB_OTG_FS {
-            const HIGH_SPEED: bool = false;
-
+        impl crate::peripherals::USB_OTG_FS {
             cfg_if::cfg_if! {
                 if #[cfg(stm32f1)] {
-                    const FIFO_DEPTH_WORDS: u16 = 128;
                     const ENDPOINT_COUNT: usize = 8;
                 } else if #[cfg(any(
                     stm32f2,
@@ -480,7 +470,6 @@ foreach_interrupt!(
                     stm32f437,
                     stm32f439,
                 ))] {
-                    const FIFO_DEPTH_WORDS: u16 = 320;
                     const ENDPOINT_COUNT: usize = 4;
                 } else if #[cfg(any(
                     stm32f412,
@@ -494,17 +483,58 @@ foreach_interrupt!(
                     stm32u5,
                     stm32wba,
                 ))] {
-                    const FIFO_DEPTH_WORDS: u16 = 320;
                     const ENDPOINT_COUNT: usize = 6;
                 } else if #[cfg(stm32g0x1)] {
-                    const FIFO_DEPTH_WORDS: u16 = 512;
                     const ENDPOINT_COUNT: usize = 8;
                 } else if #[cfg(any(stm32h7, stm32h7rs))] {
-                    const FIFO_DEPTH_WORDS: u16 = 1024;
                     const ENDPOINT_COUNT: usize = 9;
                 } else if #[cfg(any(stm32wba, stm32u5))] {
-                    const FIFO_DEPTH_WORDS: u16 = 320;
                     const ENDPOINT_COUNT: usize = 6;
+                } else {
+                    compile_error!("USB_OTG_FS peripheral is not supported by this chip.");
+                }
+            }
+        }
+
+        impl SealedInstance for crate::peripherals::USB_OTG_FS {
+            const HIGH_SPEED: bool = false;
+
+            cfg_if::cfg_if! {
+                if #[cfg(stm32f1)] {
+                    const FIFO_DEPTH_WORDS: u16 = 128;
+                } else if #[cfg(any(
+                    stm32f2,
+                    stm32f401,
+                    stm32f405,
+                    stm32f407,
+                    stm32f411,
+                    stm32f415,
+                    stm32f417,
+                    stm32f427,
+                    stm32f429,
+                    stm32f437,
+                    stm32f439,
+                ))] {
+                    const FIFO_DEPTH_WORDS: u16 = 320;
+                } else if #[cfg(any(
+                    stm32f412,
+                    stm32f413,
+                    stm32f423,
+                    stm32f446,
+                    stm32f469,
+                    stm32f479,
+                    stm32f7,
+                    stm32l4,
+                    stm32u5,
+                    stm32wba,
+                ))] {
+                    const FIFO_DEPTH_WORDS: u16 = 320;
+                } else if #[cfg(stm32g0x1)] {
+                    const FIFO_DEPTH_WORDS: u16 = 512;
+                } else if #[cfg(any(stm32h7, stm32h7rs))] {
+                    const FIFO_DEPTH_WORDS: u16 = 1024;
+                } else if #[cfg(any(stm32wba, stm32u5))] {
+                    const FIFO_DEPTH_WORDS: u16 = 320;
                 } else {
                     compile_error!("USB_OTG_FS peripheral is not supported by this chip.");
                 }
@@ -515,7 +545,10 @@ foreach_interrupt!(
             }
 
             fn state() -> OtgState<'static> {
-                static STATE: State<MAX_EP_COUNT> = State::new();
+                use embassy_usb_synopsys_otg::State;
+
+                const EP_COUNT: usize = crate::peripherals::USB_OTG_FS::ENDPOINT_COUNT;
+                static STATE: State<EP_COUNT> = State::new();
                 STATE.as_otg_state()
             }
         }
@@ -526,6 +559,36 @@ foreach_interrupt!(
     };
 
     (USB_OTG_HS, otg, $block:ident, GLOBAL, $irq:ident) => {
+        impl crate::peripherals::USB_OTG_HS {
+            cfg_if::cfg_if! {
+                if #[cfg(any(
+                    stm32f2,
+                    stm32f405,
+                    stm32f407,
+                    stm32f415,
+                    stm32f417,
+                    stm32f427,
+                    stm32f429,
+                    stm32f437,
+                    stm32f439,
+                ))] {
+                    const ENDPOINT_COUNT: usize = 6;
+                } else if #[cfg(any(
+                    stm32f446,
+                    stm32f469,
+                    stm32f479,
+                    stm32f7,
+                    stm32h7, stm32h7rs,
+                ))] {
+                    const ENDPOINT_COUNT: usize = 9;
+                } else if #[cfg(any(stm32u5, stm32wba))] {
+                    const ENDPOINT_COUNT: usize = 9;
+                } else {
+                    compile_error!("USB_OTG_HS peripheral is not supported by this chip.");
+                }
+            }
+        }
+
         impl SealedInstance for crate::peripherals::USB_OTG_HS {
             const HIGH_SPEED: bool = true;
 
@@ -542,7 +605,6 @@ foreach_interrupt!(
                     stm32f439,
                 ))] {
                     const FIFO_DEPTH_WORDS: u16 = 1024;
-                    const ENDPOINT_COUNT: usize = 6;
                 } else if #[cfg(any(
                     stm32f446,
                     stm32f469,
@@ -551,10 +613,8 @@ foreach_interrupt!(
                     stm32h7, stm32h7rs,
                 ))] {
                     const FIFO_DEPTH_WORDS: u16 = 1024;
-                    const ENDPOINT_COUNT: usize = 9;
                 } else if #[cfg(any(stm32u5, stm32wba))] {
                     const FIFO_DEPTH_WORDS: u16 = 1024;
-                    const ENDPOINT_COUNT: usize = 9;
                 } else {
                     compile_error!("USB_OTG_HS peripheral is not supported by this chip.");
                 }
@@ -566,7 +626,10 @@ foreach_interrupt!(
             }
 
             fn state() -> OtgState<'static> {
-                static STATE: State<MAX_EP_COUNT> = State::new();
+                use embassy_usb_synopsys_otg::State;
+
+                const EP_COUNT: usize = crate::peripherals::USB_OTG_HS::ENDPOINT_COUNT;
+                static STATE: State<EP_COUNT> = State::new();
                 STATE.as_otg_state()
             }
         }
@@ -585,12 +648,10 @@ mod host_impl {
 
     use embassy_usb_synopsys_otg::PhyType;
     use embassy_usb_synopsys_otg::host::{
-        HostState, OtgHost as OtgHostDriver, OtgHostState, OtgHostInstance, on_host_interrupt as on_host_interrupt_impl,
+        OtgHost as OtgHostDriver, OtgHostInstance, OtgHostState, on_host_interrupt as on_host_interrupt_impl,
     };
 
     use super::*;
-
-    const MAX_HOST_CH_COUNT: usize = 12;
 
     /// Per-instance host state, analogous to `SealedInstance::state()` for device mode.
     #[allow(private_bounds)]
@@ -602,7 +663,10 @@ mod host_impl {
         (USB_OTG_FS, otg, $block:ident, GLOBAL, $irq:ident) => {
             impl SealedHostInstance for crate::peripherals::USB_OTG_FS {
                 fn host_state() -> OtgHostState<'static> {
-                    static STATE: HostState<MAX_HOST_CH_COUNT> = HostState::new();
+                    use embassy_usb_synopsys_otg::host::HostState;
+
+                    const CH_COUNT:usize = crate::peripherals::USB_OTG_FS::ENDPOINT_COUNT;
+                    static STATE: HostState<CH_COUNT> = HostState::new();
                     STATE.as_otg_host_state()
                 }
             }
@@ -610,7 +674,10 @@ mod host_impl {
         (USB_OTG_HS, otg, $block:ident, GLOBAL, $irq:ident) => {
             impl SealedHostInstance for crate::peripherals::USB_OTG_HS {
                 fn host_state() -> OtgHostState<'static> {
-                    static STATE: HostState<MAX_HOST_CH_COUNT> = HostState::new();
+                    use embassy_usb_synopsys_otg::host::HostState;
+
+                    const CH_COUNT:usize = crate::peripherals::USB_OTG_HS::ENDPOINT_COUNT;
+                    static STATE: HostState<CH_COUNT> = HostState::new();
                     STATE.as_otg_host_state()
                 }
             }
@@ -626,11 +693,7 @@ mod host_impl {
     impl<T: SealedHostInstance> interrupt::typelevel::Handler<T::Interrupt> for HostInterruptHandler<T> {
         unsafe fn on_interrupt() {
             let r = T::regs();
-            on_host_interrupt_impl(
-                r,
-                &T::host_state(),
-                T::ENDPOINT_COUNT.min(MAX_HOST_CH_COUNT),
-            );
+            on_host_interrupt_impl(r, &T::host_state());
         }
     }
 
@@ -664,7 +727,6 @@ mod host_impl {
                 regs: T::regs(),
                 state: T::host_state(),
                 fifo_depth_words: T::FIFO_DEPTH_WORDS,
-                channel_count: T::ENDPOINT_COUNT.min(MAX_HOST_CH_COUNT),
                 phy_type: PhyType::InternalFullSpeed,
             };
 
@@ -714,7 +776,6 @@ mod host_impl {
                 regs: T::regs(),
                 state: T::host_state(),
                 fifo_depth_words: T::FIFO_DEPTH_WORDS,
-                channel_count: T::ENDPOINT_COUNT.min(MAX_HOST_CH_COUNT),
                 phy_type: PhyType::InternalHighSpeed,
             };
 

--- a/embassy-usb-synopsys-otg/CHANGELOG.md
+++ b/embassy-usb-synopsys-otg/CHANGELOG.md
@@ -8,6 +8,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 <!-- next-header -->
 ## Unreleased - ReleaseDate
 
+## 0.4.0 - 2026-05-15
+
+- **Breaking:** type-erased `State`/`HostState`, non-generic `OtgInstance`/`OtgHostInstance`, endpoint allocation in `State`, const generics removed from device/host drivers. Static state now needs to be constructed as `StateStorage::new()`/`HostStateStorage::new()` and then `as_state()`/`as_host_state()` must be called to obtain the state reference.
+- **Breaking:** `OtgInstance::endpoint_count`, `OtgHostInstance::channel_count` have been removed.
+- **Breaking:** `endpoint_count`, and `channel_count` parameters have been removed from the interrupt handler functions.
+- Allow using 16 host channels
+
 ## 0.3.3 - 2026-05-04
 
 - New feature: "host" for embassy-usb-host support

--- a/embassy-usb-synopsys-otg/CHANGELOG.md
+++ b/embassy-usb-synopsys-otg/CHANGELOG.md
@@ -8,9 +8,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 <!-- next-header -->
 ## Unreleased - ReleaseDate
 
-## 0.4.0 - 2026-05-15
+## 0.4.0 - 2026-05-23
 
 - **Breaking:** type-erased `State`/`HostState`, non-generic `OtgInstance`/`OtgHostInstance`, endpoint allocation in `State`, const generics removed from device/host drivers. Static state now needs to be constructed as `StateStorage::new()`/`HostStateStorage::new()` and then `as_state()`/`as_host_state()` must be called to obtain the state reference.
+- **Breaking:** type-erased `OtgState`/`OtgHostState`, non-generic `OtgInstance`/`OtgHostInstance`, endpoint allocation in `State`, const generics removed from device/host drivers.
 - **Breaking:** `OtgInstance::endpoint_count`, `OtgHostInstance::channel_count` have been removed.
 - **Breaking:** `endpoint_count`, and `channel_count` parameters have been removed from the interrupt handler functions.
 - Allow using 16 host channels

--- a/embassy-usb-synopsys-otg/Cargo.toml
+++ b/embassy-usb-synopsys-otg/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "embassy-usb-synopsys-otg"
-version = "0.3.3"
+version = "0.4.0"
 edition = "2024"
 license = "MIT OR Apache-2.0"
 description = "`embassy-usb-driver` implementation for Synopsys OTG USB controllers"

--- a/embassy-usb-synopsys-otg/src/host.rs
+++ b/embassy-usb-synopsys-otg/src/host.rs
@@ -85,14 +85,38 @@ impl<const CH_COUNT: usize> HostState<CH_COUNT> {
             inited: AtomicBool::new(false),
         }
     }
+
+    /// Borrow this [`HostState`] as an [`OtgHostState`] for [`OtgHostInstance`].
+    pub fn as_otg_host_state(&self) -> OtgHostState<'_> {
+        OtgHostState {
+            channels: self.channels.as_slice(),
+            port_waker: &self.port_waker,
+            port_event: &self.port_event,
+            port_speed: &self.port_speed,
+            inited: &self.inited,
+        }
+    }
+}
+
+/// Type-erased view of [`HostState`] for [`OtgHostInstance`], [`OtgHost`], [`on_host_interrupt`], and pipes.
+///
+/// Build from [`HostState::as_otg_host_state`].
+#[derive(Clone, Copy)]
+pub struct OtgHostState<'d> {
+    channels: &'d [ChannelState],
+    port_waker: &'d AtomicWaker,
+    port_event: &'d AtomicU8,
+    port_speed: &'d AtomicU8,
+    inited: &'d AtomicBool,
 }
 
 /// Hardware-dependent host configuration.
-pub struct OtgHostInstance<'d, const CH_COUNT: usize> {
+#[derive(Copy, Clone)]
+pub struct OtgHostInstance<'d> {
     /// The USB peripheral registers.
     pub regs: Otg,
-    /// The host state.
-    pub state: &'d HostState<CH_COUNT>,
+    /// Shared host driver state from [`HostState::as_otg_host_state`].
+    pub state: OtgHostState<'d>,
     /// FIFO depth in words.
     pub fifo_depth_words: u16,
     /// Number of host channels available.
@@ -105,7 +129,7 @@ pub struct OtgHostInstance<'d, const CH_COUNT: usize> {
 ///
 /// # Safety
 /// Must be called from the USB OTG interrupt handler when the controller is in host mode.
-pub unsafe fn on_host_interrupt<const CH_COUNT: usize>(r: Otg, state: &HostState<CH_COUNT>, ch_count: usize) {
+pub unsafe fn on_host_interrupt(r: Otg, state: &OtgHostState<'_>, ch_count: usize) {
     let gintsts = r.gintsts().read();
 
     // Clear SOF interrupt immediately to avoid flooding.
@@ -338,13 +362,13 @@ fn hprt_read_safe(r: Otg) -> u32 {
 }
 
 /// USB OTG Host Driver.
-pub struct OtgHost<'d, const CH_COUNT: usize> {
-    instance: OtgHostInstance<'d, CH_COUNT>,
+pub struct OtgHost<'d> {
+    instance: OtgHostInstance<'d>,
 }
 
-impl<'d, const CH_COUNT: usize> OtgHost<'d, CH_COUNT> {
+impl<'d> OtgHost<'d> {
     /// Create a new OTG host driver.
-    pub fn new(instance: OtgHostInstance<'d, CH_COUNT>) -> Self {
+    pub fn new(instance: OtgHostInstance<'d>) -> Self {
         Self { instance }
     }
 
@@ -486,22 +510,22 @@ impl<'d, const CH_COUNT: usize> OtgHost<'d, CH_COUNT> {
 /// Obtained from [`UsbHostController::allocator`]. Holds only `Copy` handles
 /// to the controller's `'d`-borrowed state, so it can be freely copied and
 /// retained by class drivers independently of the controller's `&mut` borrow.
-pub struct OtgHostAllocator<'d, const CH_COUNT: usize> {
+pub struct OtgHostAllocator<'d> {
     regs: Otg,
-    state: &'d HostState<CH_COUNT>,
+    state: OtgHostState<'d>,
     channel_count: usize,
 }
 
-impl<'d, const CH_COUNT: usize> Clone for OtgHostAllocator<'d, CH_COUNT> {
+impl<'d> Clone for OtgHostAllocator<'d> {
     fn clone(&self) -> Self {
         *self
     }
 }
 
-impl<'d, const CH_COUNT: usize> Copy for OtgHostAllocator<'d, CH_COUNT> {}
+impl<'d> Copy for OtgHostAllocator<'d> {}
 
-impl<'d, const CH_COUNT: usize> UsbHostAllocator<'d> for OtgHostAllocator<'d, CH_COUNT> {
-    type Pipe<T: pipe::Type, D: pipe::Direction> = Channel<'d, T, D, CH_COUNT>;
+impl<'d> UsbHostAllocator<'d> for OtgHostAllocator<'d> {
+    type Pipe<T: pipe::Type, D: pipe::Direction> = Channel<'d, T, D>;
 
     fn alloc_pipe<T: pipe::Type, D: pipe::Direction>(
         &self,
@@ -516,8 +540,9 @@ impl<'d, const CH_COUNT: usize> UsbHostAllocator<'d> for OtgHostAllocator<'d, CH
         let speed_code = self.state.port_speed.load(Ordering::Acquire);
         let is_low_speed = speed_code == 1;
 
+        let max_ch = self.channel_count.min(self.state.channels.len());
         // Find a free channel using atomic CAS
-        for i in 0..self.channel_count.min(CH_COUNT) {
+        for i in 0..max_ch {
             if self.state.channels[i]
                 .allocated
                 .compare_exchange(false, true, Ordering::AcqRel, Ordering::Relaxed)
@@ -543,8 +568,8 @@ impl<'d, const CH_COUNT: usize> UsbHostAllocator<'d> for OtgHostAllocator<'d, CH
     }
 }
 
-impl<'d, const CH_COUNT: usize> UsbHostController<'d> for OtgHost<'d, CH_COUNT> {
-    type Allocator = OtgHostAllocator<'d, CH_COUNT>;
+impl<'d> UsbHostController<'d> for OtgHost<'d> {
+    type Allocator = OtgHostAllocator<'d>;
 
     fn allocator(&self) -> Self::Allocator {
         OtgHostAllocator {
@@ -577,7 +602,7 @@ impl<'d, const CH_COUNT: usize> UsbHostController<'d> for OtgHost<'d, CH_COUNT> 
                 if ev & PORT_EVENT_DISCONNECTED != 0 {
                     state.port_event.fetch_and(!PORT_EVENT_DISCONNECTED, Ordering::AcqRel);
                     // Wake all channels to signal disconnection
-                    for ch in &state.channels {
+                    for ch in state.channels {
                         if ch.allocated.load(Ordering::Relaxed) {
                             ch.result.store(CH_RESULT_HALTED, Ordering::Release);
                             ch.waker.wake();
@@ -613,7 +638,7 @@ impl<'d, const CH_COUNT: usize> UsbHostController<'d> for OtgHost<'d, CH_COUNT> 
                 }
                 if ev & PORT_EVENT_DISCONNECTED != 0 {
                     state.port_event.fetch_and(!PORT_EVENT_DISCONNECTED, Ordering::AcqRel);
-                    for ch in &state.channels {
+                    for ch in state.channels {
                         if ch.allocated.load(Ordering::Relaxed) {
                             ch.result.store(CH_RESULT_HALTED, Ordering::Release);
                             ch.waker.wake();
@@ -671,7 +696,7 @@ impl<'d, const CH_COUNT: usize> UsbHostController<'d> for OtgHost<'d, CH_COUNT> 
 
     async fn bus_reset(&mut self) {
         let r = self.instance.regs;
-        let ch_count = self.instance.channel_count.min(CH_COUNT);
+        let ch_count = self.instance.channel_count.min(self.instance.state.channels.len());
 
         // Halt any still-active hardware channels left over from a
         // previous session (e.g. interrupt endpoints that were polling
@@ -734,9 +759,9 @@ impl<'d, const CH_COUNT: usize> UsbHostController<'d> for OtgHost<'d, CH_COUNT> 
 /// A USB host channel for performing transfers.
 ///
 /// The channel is automatically released when dropped.
-pub struct Channel<'d, T: pipe::Type, D: pipe::Direction, const CH_COUNT: usize> {
+pub struct Channel<'d, T: pipe::Type, D: pipe::Direction> {
     regs: Otg,
-    state: &'d HostState<CH_COUNT>,
+    state: OtgHostState<'d>,
     index: usize,
     device_address: u8,
     ep_number: u8,
@@ -747,9 +772,9 @@ pub struct Channel<'d, T: pipe::Type, D: pipe::Direction, const CH_COUNT: usize>
 }
 
 // SAFETY: Channel only accesses its own state in the shared HostState.
-unsafe impl<T: pipe::Type, D: pipe::Direction, const CH_COUNT: usize> Send for Channel<'_, T, D, CH_COUNT> {}
+unsafe impl<T: pipe::Type, D: pipe::Direction> Send for Channel<'_, T, D> {}
 
-impl<T: pipe::Type, D: pipe::Direction, const CH_COUNT: usize> Drop for Channel<'_, T, D, CH_COUNT> {
+impl<T: pipe::Type, D: pipe::Direction> Drop for Channel<'_, T, D> {
     fn drop(&mut self) {
         let r = self.regs;
         let ch = self.index;
@@ -782,7 +807,7 @@ impl<T: pipe::Type, D: pipe::Direction, const CH_COUNT: usize> Drop for Channel<
     }
 }
 
-impl<T: pipe::Type, D: pipe::Direction, const CH_COUNT: usize> Channel<'_, T, D, CH_COUNT> {
+impl<T: pipe::Type, D: pipe::Direction> Channel<'_, T, D> {
     fn configure_channel(&self, dir_in: bool, ep_type: EndpointType, pktcnt: u16, xfrsiz: u32, dpid: u8) {
         let r = self.regs;
         let ch = self.index;
@@ -1139,7 +1164,7 @@ impl<T: pipe::Type, D: pipe::Direction, const CH_COUNT: usize> Channel<'_, T, D,
     }
 }
 
-impl<T: pipe::Type, D: pipe::Direction, const CH_COUNT: usize> UsbPipe<T, D> for Channel<'_, T, D, CH_COUNT> {
+impl<T: pipe::Type, D: pipe::Direction> UsbPipe<T, D> for Channel<'_, T, D> {
     async fn control_in(&mut self, setup: &[u8; 8], buf: &mut [u8]) -> Result<usize, PipeError>
     where
         T: pipe::IsControl,

--- a/embassy-usb-synopsys-otg/src/host.rs
+++ b/embassy-usb-synopsys-otg/src/host.rs
@@ -126,8 +126,6 @@ pub struct OtgHostInstance<'d> {
     pub state: OtgHostState<'d>,
     /// FIFO depth in words.
     pub fifo_depth_words: u16,
-    /// Number of host channels available.
-    pub channel_count: usize,
     /// The PHY type.
     pub phy_type: PhyType,
 }
@@ -136,11 +134,9 @@ pub struct OtgHostInstance<'d> {
 ///
 /// # Safety
 /// Must be called from the USB OTG interrupt handler when the controller is in host mode.
-pub unsafe fn on_host_interrupt(r: Otg, state: &OtgHostState<'_>, ch_count: usize) {
+pub unsafe fn on_host_interrupt(r: Otg, state: &OtgHostState<'_>) {
     let gintsts = r.gintsts().read();
-
-    // defensively cap ch_count to the number of channel slots we actually have.
-    let ch_count = ch_count.min(state.channels.len());
+    let ch_count = state.channels.len();
 
     // Clear SOF interrupt immediately to avoid flooding.
     if gintsts.sof() {
@@ -535,7 +531,6 @@ impl<'d> OtgHost<'d> {
 pub struct OtgHostAllocator<'d> {
     regs: Otg,
     state: OtgHostState<'d>,
-    channel_count: usize,
 }
 
 impl<'d> Clone for OtgHostAllocator<'d> {
@@ -562,7 +557,7 @@ impl<'d> UsbHostAllocator<'d> for OtgHostAllocator<'d> {
         let speed_code = self.state.fields.port_speed.load(Ordering::Acquire);
         let is_low_speed = speed_code == 1;
 
-        let max_ch = self.channel_count.min(self.state.channels.len());
+        let max_ch = self.state.channels.len();
         // Find a free channel using atomic CAS
         for i in 0..max_ch {
             if self.state.channels[i]
@@ -597,7 +592,6 @@ impl<'d> UsbHostController<'d> for OtgHost<'d> {
         OtgHostAllocator {
             regs: self.instance.regs,
             state: self.instance.state,
-            channel_count: self.instance.channel_count,
         }
     }
 
@@ -733,7 +727,7 @@ impl<'d> UsbHostController<'d> for OtgHost<'d> {
 
     async fn bus_reset(&mut self) {
         let r = self.instance.regs;
-        let ch_count = self.instance.channel_count.min(self.instance.state.channels.len());
+        let ch_count = self.instance.state.channels.len();
 
         // Halt any still-active hardware channels left over from a
         // previous session (e.g. interrupt endpoints that were polling

--- a/embassy-usb-synopsys-otg/src/host.rs
+++ b/embassy-usb-synopsys-otg/src/host.rs
@@ -53,13 +53,17 @@ struct ChannelState {
 unsafe impl Send for ChannelState {}
 unsafe impl Sync for ChannelState {}
 
-/// USB host driver state. Create one per OTG instance.
-pub struct HostState<const CH_COUNT: usize> {
-    channels: [ChannelState; CH_COUNT],
+struct HostStateFields {
     port_waker: AtomicWaker,
     port_event: AtomicU8,
     port_speed: AtomicU8,
     inited: AtomicBool,
+}
+
+/// USB host driver state. Create one per OTG instance.
+pub struct HostState<const CH_COUNT: usize> {
+    channels: [ChannelState; CH_COUNT],
+    fields: HostStateFields,
 }
 
 unsafe impl<const CH_COUNT: usize> Send for HostState<CH_COUNT> {}
@@ -79,10 +83,12 @@ impl<const CH_COUNT: usize> HostState<CH_COUNT> {
                     allocated: AtomicBool::new(false),
                 }
             }; CH_COUNT],
-            port_waker: AtomicWaker::new(),
-            port_event: AtomicU8::new(0),
-            port_speed: AtomicU8::new(0),
-            inited: AtomicBool::new(false),
+            fields: HostStateFields {
+                port_waker: AtomicWaker::new(),
+                port_event: AtomicU8::new(0),
+                port_speed: AtomicU8::new(0),
+                inited: AtomicBool::new(false),
+            },
         }
     }
 
@@ -90,10 +96,7 @@ impl<const CH_COUNT: usize> HostState<CH_COUNT> {
     pub fn as_otg_host_state(&self) -> OtgHostState<'_> {
         OtgHostState {
             channels: self.channels.as_slice(),
-            port_waker: &self.port_waker,
-            port_event: &self.port_event,
-            port_speed: &self.port_speed,
-            inited: &self.inited,
+            fields: &self.fields,
         }
     }
 }
@@ -104,10 +107,7 @@ impl<const CH_COUNT: usize> HostState<CH_COUNT> {
 #[derive(Clone, Copy)]
 pub struct OtgHostState<'d> {
     channels: &'d [ChannelState],
-    port_waker: &'d AtomicWaker,
-    port_event: &'d AtomicU8,
-    port_speed: &'d AtomicU8,
-    inited: &'d AtomicBool,
+    fields: &'d HostStateFields,
 }
 
 impl OtgHostState<'_> {
@@ -153,8 +153,11 @@ pub unsafe fn on_host_interrupt(r: Otg, state: &OtgHostState<'_>, ch_count: usiz
 
         if hprt.pcdet() {
             // Port connect detected
-            state.port_event.fetch_or(PORT_EVENT_CONNECTED, Ordering::Release);
-            state.port_waker.wake();
+            state
+                .fields
+                .port_event
+                .fetch_or(PORT_EVENT_CONNECTED, Ordering::Release);
+            state.fields.port_waker.wake();
         }
 
         if hprt.penchng() {
@@ -166,19 +169,25 @@ pub unsafe fn on_host_interrupt(r: Otg, state: &OtgHostState<'_>, ch_count: usiz
                     0b10 => 1, // Low speed
                     _ => 0,    // Default to full speed
                 };
-                state.port_speed.store(speed, Ordering::Release);
-                state.port_event.fetch_or(PORT_EVENT_ENABLED, Ordering::Release);
+                state.fields.port_speed.store(speed, Ordering::Release);
+                state.fields.port_event.fetch_or(PORT_EVENT_ENABLED, Ordering::Release);
             } else {
                 // Port disabled
-                state.port_event.fetch_or(PORT_EVENT_DISCONNECTED, Ordering::Release);
+                state
+                    .fields
+                    .port_event
+                    .fetch_or(PORT_EVENT_DISCONNECTED, Ordering::Release);
             }
-            state.port_waker.wake();
+            state.fields.port_waker.wake();
         }
 
         if hprt.pocchng() {
             if hprt.poca() {
-                state.port_event.fetch_or(PORT_EVENT_OVERCURRENT, Ordering::Release);
-                state.port_waker.wake();
+                state
+                    .fields
+                    .port_event
+                    .fetch_or(PORT_EVENT_OVERCURRENT, Ordering::Release);
+                state.fields.port_waker.wake();
             }
         }
 
@@ -190,8 +199,11 @@ pub unsafe fn on_host_interrupt(r: Otg, state: &OtgHostState<'_>, ch_count: usiz
     // Disconnect interrupt
     if gintsts.discint() {
         r.gintsts().write(|w| w.set_discint(true)); // clear
-        state.port_event.fetch_or(PORT_EVENT_DISCONNECTED, Ordering::Release);
-        state.port_waker.wake();
+        state
+            .fields
+            .port_event
+            .fetch_or(PORT_EVENT_DISCONNECTED, Ordering::Release);
+        state.fields.port_waker.wake();
     }
 
     // RX FIFO non-empty (IN data received)
@@ -547,7 +559,7 @@ impl<'d> UsbHostAllocator<'d> for OtgHostAllocator<'d> {
         let max_packet_size = endpoint.max_packet_size;
 
         // Read device speed from port_speed atomic (stored by ISR)
-        let speed_code = self.state.port_speed.load(Ordering::Acquire);
+        let speed_code = self.state.fields.port_speed.load(Ordering::Acquire);
         let is_low_speed = speed_code == 1;
 
         let max_ch = self.channel_count.min(self.state.channels.len());
@@ -591,26 +603,32 @@ impl<'d> UsbHostController<'d> for OtgHost<'d> {
 
     async fn wait_for_device_event(&mut self) -> DeviceEvent {
         // Lazily initialize the host hardware on first call.
-        if !self.instance.state.inited.load(Ordering::Acquire) {
+        if !self.instance.state.fields.inited.load(Ordering::Acquire) {
             self.configure_as_host().await;
             self.init_host();
-            self.instance.state.inited.store(true, Ordering::Release);
+            self.instance.state.fields.inited.store(true, Ordering::Release);
         }
 
         loop {
             // Wait for CONNECTED or DISCONNECTED event.
             let event = poll_fn(|cx| {
                 let state = self.instance.state;
-                state.port_waker.register(cx.waker());
+                state.fields.port_waker.register(cx.waker());
 
-                let ev = state.port_event.load(Ordering::Acquire);
+                let ev = state.fields.port_event.load(Ordering::Acquire);
                 if ev & PORT_EVENT_OVERCURRENT != 0 {
-                    state.port_event.fetch_and(!PORT_EVENT_OVERCURRENT, Ordering::AcqRel);
+                    state
+                        .fields
+                        .port_event
+                        .fetch_and(!PORT_EVENT_OVERCURRENT, Ordering::AcqRel);
                     return Poll::Ready(PORT_EVENT_OVERCURRENT);
                 }
 
                 if ev & PORT_EVENT_DISCONNECTED != 0 {
-                    state.port_event.fetch_and(!PORT_EVENT_DISCONNECTED, Ordering::AcqRel);
+                    state
+                        .fields
+                        .port_event
+                        .fetch_and(!PORT_EVENT_DISCONNECTED, Ordering::AcqRel);
                     // Wake all channels to signal disconnection
                     for ch in state.channels {
                         if ch.allocated.load(Ordering::Relaxed) {
@@ -622,7 +640,10 @@ impl<'d> UsbHostController<'d> for OtgHost<'d> {
                     return Poll::Ready(PORT_EVENT_DISCONNECTED);
                 }
                 if ev & PORT_EVENT_CONNECTED != 0 {
-                    state.port_event.fetch_and(!PORT_EVENT_CONNECTED, Ordering::AcqRel);
+                    state
+                        .fields
+                        .port_event
+                        .fetch_and(!PORT_EVENT_CONNECTED, Ordering::AcqRel);
                     return Poll::Ready(PORT_EVENT_CONNECTED);
                 }
                 Poll::Pending
@@ -639,15 +660,21 @@ impl<'d> UsbHostController<'d> for OtgHost<'d> {
             // Now wait for ENABLED or DISCONNECTED.
             let enabled_event = poll_fn(|cx| {
                 let state = self.instance.state;
-                state.port_waker.register(cx.waker());
+                state.fields.port_waker.register(cx.waker());
 
-                let ev = state.port_event.load(Ordering::Acquire);
+                let ev = state.fields.port_event.load(Ordering::Acquire);
                 if ev & PORT_EVENT_OVERCURRENT != 0 {
-                    state.port_event.fetch_and(!PORT_EVENT_OVERCURRENT, Ordering::AcqRel);
+                    state
+                        .fields
+                        .port_event
+                        .fetch_and(!PORT_EVENT_OVERCURRENT, Ordering::AcqRel);
                     return Poll::Ready(PORT_EVENT_OVERCURRENT);
                 }
                 if ev & PORT_EVENT_DISCONNECTED != 0 {
-                    state.port_event.fetch_and(!PORT_EVENT_DISCONNECTED, Ordering::AcqRel);
+                    state
+                        .fields
+                        .port_event
+                        .fetch_and(!PORT_EVENT_DISCONNECTED, Ordering::AcqRel);
                     for ch in state.channels {
                         if ch.allocated.load(Ordering::Relaxed) {
                             ch.result.store(CH_RESULT_HALTED, Ordering::Release);
@@ -657,7 +684,7 @@ impl<'d> UsbHostController<'d> for OtgHost<'d> {
                     return Poll::Ready(PORT_EVENT_DISCONNECTED);
                 }
                 if ev & PORT_EVENT_ENABLED != 0 {
-                    state.port_event.fetch_and(!PORT_EVENT_ENABLED, Ordering::AcqRel);
+                    state.fields.port_event.fetch_and(!PORT_EVENT_ENABLED, Ordering::AcqRel);
                     return Poll::Ready(PORT_EVENT_ENABLED);
                 }
                 Poll::Pending
@@ -666,7 +693,7 @@ impl<'d> UsbHostController<'d> for OtgHost<'d> {
 
             match enabled_event {
                 PORT_EVENT_ENABLED => {
-                    let speed_code = self.instance.state.port_speed.load(Ordering::Acquire);
+                    let speed_code = self.instance.state.fields.port_speed.load(Ordering::Acquire);
                     let speed = match speed_code {
                         0 => Speed::Full,
                         1 => Speed::Low,

--- a/embassy-usb-synopsys-otg/src/host.rs
+++ b/embassy-usb-synopsys-otg/src/host.rs
@@ -110,6 +110,13 @@ pub struct OtgHostState<'d> {
     inited: &'d AtomicBool,
 }
 
+impl OtgHostState<'_> {
+    /// Returns the number of host channels supported by this state.
+    pub fn channel_count(&self) -> usize {
+        self.channels.len()
+    }
+}
+
 /// Hardware-dependent host configuration.
 #[derive(Copy, Clone)]
 pub struct OtgHostInstance<'d> {

--- a/embassy-usb-synopsys-otg/src/host.rs
+++ b/embassy-usb-synopsys-otg/src/host.rs
@@ -57,7 +57,6 @@ struct HostStateFields {
     port_waker: AtomicWaker,
     port_event: AtomicU8,
     port_speed: AtomicU8,
-    inited: AtomicBool,
 }
 
 /// Storage object for USB host driver state. Create one per OTG instance.
@@ -84,7 +83,6 @@ impl<const CH_COUNT: usize> HostStateStorage<CH_COUNT> {
                 port_waker: AtomicWaker::new(),
                 port_event: AtomicU8::new(0),
                 port_speed: AtomicU8::new(0),
-                inited: AtomicBool::new(false),
             },
         }
     }
@@ -379,12 +377,16 @@ fn hprt_read_safe(r: Otg) -> u32 {
 /// USB OTG Host Driver.
 pub struct OtgHost<'d> {
     instance: OtgHostInstance<'d>,
+    inited: bool,
 }
 
 impl<'d> OtgHost<'d> {
     /// Create a new OTG host driver.
     pub fn new(instance: OtgHostInstance<'d>) -> Self {
-        Self { instance }
+        Self {
+            instance,
+            inited: false,
+        }
     }
 
     async fn configure_as_host(&self) {
@@ -594,10 +596,10 @@ impl<'d> UsbHostController<'d> for OtgHost<'d> {
 
     async fn wait_for_device_event(&mut self) -> DeviceEvent {
         // Lazily initialize the host hardware on first call.
-        if !self.instance.state.fields.inited.load(Ordering::Acquire) {
+        if !self.inited {
             self.configure_as_host().await;
             self.init_host();
-            self.instance.state.fields.inited.store(true, Ordering::Release);
+            self.inited = true;
         }
 
         loop {

--- a/embassy-usb-synopsys-otg/src/host.rs
+++ b/embassy-usb-synopsys-otg/src/host.rs
@@ -60,16 +60,13 @@ struct HostStateFields {
     inited: AtomicBool,
 }
 
-/// USB host driver state. Create one per OTG instance.
-pub struct HostState<const CH_COUNT: usize> {
+/// Storage object for USB host driver state. Create one per OTG instance.
+pub struct HostStateStorage<const CH_COUNT: usize> {
     channels: [ChannelState; CH_COUNT],
     fields: HostStateFields,
 }
 
-unsafe impl<const CH_COUNT: usize> Send for HostState<CH_COUNT> {}
-unsafe impl<const CH_COUNT: usize> Sync for HostState<CH_COUNT> {}
-
-impl<const CH_COUNT: usize> HostState<CH_COUNT> {
+impl<const CH_COUNT: usize> HostStateStorage<CH_COUNT> {
     /// Create a new host state.
     pub const fn new() -> Self {
         Self {
@@ -92,9 +89,9 @@ impl<const CH_COUNT: usize> HostState<CH_COUNT> {
         }
     }
 
-    /// Borrow this [`HostState`] as an [`OtgHostState`] for [`OtgHostInstance`].
-    pub fn as_otg_host_state(&self) -> OtgHostState<'_> {
-        OtgHostState {
+    /// Borrow this [`HostStateStorage`] as a [`HostState`] for [`OtgHostInstance`].
+    pub fn as_host_state(&self) -> HostState<'_> {
+        HostState {
             channels: self.channels.as_slice(),
             fields: &self.fields,
         }
@@ -103,14 +100,14 @@ impl<const CH_COUNT: usize> HostState<CH_COUNT> {
 
 /// Type-erased view of [`HostState`] for [`OtgHostInstance`], [`OtgHost`], [`on_host_interrupt`], and pipes.
 ///
-/// Build from [`HostState::as_otg_host_state`].
+/// Build from [`HostState::as_host_state`].
 #[derive(Clone, Copy)]
-pub struct OtgHostState<'d> {
+pub struct HostState<'d> {
     channels: &'d [ChannelState],
     fields: &'d HostStateFields,
 }
 
-impl OtgHostState<'_> {
+impl HostState<'_> {
     /// Returns the number of host channels supported by this state.
     pub fn channel_count(&self) -> usize {
         self.channels.len()
@@ -122,8 +119,8 @@ impl OtgHostState<'_> {
 pub struct OtgHostInstance<'d> {
     /// The USB peripheral registers.
     pub regs: Otg,
-    /// Shared host driver state from [`HostState::as_otg_host_state`].
-    pub state: OtgHostState<'d>,
+    /// Shared host driver state from [`HostState::as_host_state`].
+    pub state: HostState<'d>,
     /// FIFO depth in words.
     pub fifo_depth_words: u16,
     /// The PHY type.
@@ -134,7 +131,7 @@ pub struct OtgHostInstance<'d> {
 ///
 /// # Safety
 /// Must be called from the USB OTG interrupt handler when the controller is in host mode.
-pub unsafe fn on_host_interrupt(r: Otg, state: &OtgHostState<'_>) {
+pub unsafe fn on_host_interrupt(r: Otg, state: &HostState<'_>) {
     let gintsts = r.gintsts().read();
     let ch_count = state.channels.len();
 
@@ -530,7 +527,7 @@ impl<'d> OtgHost<'d> {
 /// retained by class drivers independently of the controller's `&mut` borrow.
 pub struct OtgHostAllocator<'d> {
     regs: Otg,
-    state: OtgHostState<'d>,
+    state: HostState<'d>,
 }
 
 impl<'d> Clone for OtgHostAllocator<'d> {
@@ -792,7 +789,7 @@ impl<'d> UsbHostController<'d> for OtgHost<'d> {
 /// The channel is automatically released when dropped.
 pub struct Channel<'d, T: pipe::Type, D: pipe::Direction> {
     regs: Otg,
-    state: OtgHostState<'d>,
+    state: HostState<'d>,
     index: usize,
     device_address: u8,
     ep_number: u8,

--- a/embassy-usb-synopsys-otg/src/host.rs
+++ b/embassy-usb-synopsys-otg/src/host.rs
@@ -132,6 +132,9 @@ pub struct OtgHostInstance<'d> {
 pub unsafe fn on_host_interrupt(r: Otg, state: &OtgHostState<'_>, ch_count: usize) {
     let gintsts = r.gintsts().read();
 
+    // defensively cap ch_count to the number of channel slots we actually have.
+    let ch_count = ch_count.min(state.channels.len());
+
     // Clear SOF interrupt immediately to avoid flooding.
     if gintsts.sof() {
         r.gintsts().write(|w| w.set_sof(true));

--- a/embassy-usb-synopsys-otg/src/lib.rs
+++ b/embassy-usb-synopsys-otg/src/lib.rs
@@ -970,6 +970,13 @@ impl<'d> Bus<'d> {
                             w.set_pktcnt(1);
                         }
                     });
+
+                    if index == 0 {
+                        regs.doepctl(index).modify(|w| {
+                            w.set_epena(true);
+                            w.set_cnak(true);
+                        });
+                    }
                 });
             }
         }

--- a/embassy-usb-synopsys-otg/src/lib.rs
+++ b/embassy-usb-synopsys-otg/src/lib.rs
@@ -29,7 +29,7 @@ pub mod host;
 use otg_v1::{Otg, regs, vals};
 
 /// Handle interrupts.
-pub unsafe fn on_interrupt(r: Otg, state: &OtgState<'_>) {
+pub unsafe fn on_interrupt(r: Otg, state: &State<'_>) {
     trace!("irq");
     let ep_count = state.endpoint_count();
 
@@ -301,22 +301,22 @@ struct EndpointData {
 /// Type-erased borrow of [`State`] passed to [`OtgInstance`], [`Driver`](crate::Driver), [`Bus`](crate::Bus),
 /// and [`on_interrupt`].
 ///
-/// Build from [`State::as_otg_state`].
+/// Build from [`State::as_state`].
 #[derive(Clone, Copy)]
-pub struct OtgState<'d> {
+pub struct State<'d> {
     cp_state: &'d ControlPipeSetupState,
     ep_states: &'d [EpState],
     bus_waker: &'d AtomicWaker,
 }
 
-impl OtgState<'_> {
+impl State<'_> {
     /// Returns the number of device endpoints supported by this state.
     pub fn endpoint_count(&self) -> usize {
         self.ep_states.len()
     }
 }
 
-impl<'d> OtgState<'d> {
+impl<'d> State<'d> {
     pub(crate) fn ep_alloc_get(&self, dir: Direction, index: usize) -> Option<&EndpointData> {
         unsafe {
             match dir {
@@ -371,15 +371,15 @@ impl<'d> OtgState<'d> {
     }
 }
 
-/// USB OTG driver state.
-pub struct State<const EP_COUNT: usize> {
+/// Storage object for USB OTG driver state.
+pub struct StateStorage<const EP_COUNT: usize> {
     cp_state: ControlPipeSetupState,
     ep_states: [EpState; EP_COUNT],
     bus_waker: AtomicWaker,
 }
 
-impl<const EP_COUNT: usize> State<EP_COUNT> {
-    /// Create a new State.
+impl<const EP_COUNT: usize> StateStorage<EP_COUNT> {
+    /// Create a new StateStorage.
     pub const fn new() -> Self {
         Self {
             cp_state: ControlPipeSetupState {
@@ -400,9 +400,9 @@ impl<const EP_COUNT: usize> State<EP_COUNT> {
         }
     }
 
-    /// Borrow this [`State`] as an [`OtgState`] for [`OtgInstance`] and the Synopsys [`Driver`](crate::Driver).
-    pub fn as_otg_state(&self) -> OtgState<'_> {
-        OtgState {
+    /// Borrow this [`StateStorage`] as a [`State`] for [`OtgInstance`] and the Synopsys [`Driver`](crate::Driver).
+    pub fn as_state(&self) -> State<'_> {
+        State {
             cp_state: &self.cp_state,
             ep_states: self.ep_states.as_slice(),
             bus_waker: &self.bus_waker,
@@ -1632,8 +1632,8 @@ fn ep0_mpsiz(max_packet_size: u16) -> u16 {
 pub struct OtgInstance<'d> {
     /// The USB peripheral.
     pub regs: Otg,
-    /// Shared driver/interrupt state from [`State::as_otg_state`].
-    pub state: OtgState<'d>,
+    /// Shared driver/interrupt state from [`State::as_state`].
+    pub state: State<'d>,
     /// FIFO depth in words.
     pub fifo_depth_words: u16,
     /// The PHY type.

--- a/embassy-usb-synopsys-otg/src/lib.rs
+++ b/embassy-usb-synopsys-otg/src/lib.rs
@@ -910,20 +910,17 @@ impl<'d> Bus<'d> {
                 "FIFO allocations exceeded maximum capacity"
             );
 
-            // Flush fifos
+            // Flush fifos, separately
             regs.grstctl().write(|w| {
-                w.set_rxfflsh(true);
                 w.set_txfflsh(true);
                 w.set_txfnum(0x10);
             });
+            while regs.grstctl().read().txfflsh() {}
+            regs.grstctl().write(|w| {
+                w.set_rxfflsh(true);
+            });
+            while regs.grstctl().read().rxfflsh() {}
         });
-
-        loop {
-            let x = regs.grstctl().read();
-            if !x.rxfflsh() && !x.txfflsh() {
-                break;
-            }
-        }
     }
 
     fn configure_endpoints(&mut self) {

--- a/embassy-usb-synopsys-otg/src/lib.rs
+++ b/embassy-usb-synopsys-otg/src/lib.rs
@@ -32,6 +32,9 @@ use otg_v1::{Otg, regs, vals};
 pub unsafe fn on_interrupt(r: Otg, state: &OtgState<'_>, ep_count: usize) {
     trace!("irq");
 
+    // defensively cap ep_count to the number of endpoint slots we actually have.
+    let ep_count = ep_count.min(state.ep_states.len());
+
     let ints = r.gintsts().read();
     if ints.wkupint() || ints.usbsusp() || ints.usbrst() || ints.enumdne() || ints.otgint() || ints.srqint() {
         // Mask interrupts and notify `Bus` to process them

--- a/embassy-usb-synopsys-otg/src/lib.rs
+++ b/embassy-usb-synopsys-otg/src/lib.rs
@@ -293,8 +293,14 @@ pub struct State<const EP_COUNT: usize> {
     cp_state: ControlPipeSetupState,
     ep_states: [EpState; EP_COUNT],
     bus_waker: AtomicWaker,
+
+    // Endpoint allocation data, owned by Driver/Bus.
+    ep_in_alloc: [UnsafeCell<Option<EndpointData>>; EP_COUNT],
+    ep_out_alloc: [UnsafeCell<Option<EndpointData>>; EP_COUNT],
 }
 
+// SAFETY: `ep_in_alloc` / `ep_out_alloc` are written only during `Driver` endpoint allocation before the USB device
+// stack runs; afterward they are read-only. `EpState::out_buffer` invariants are documented on `EpState`.
 unsafe impl<const EP_COUNT: usize> Send for State<EP_COUNT> {}
 unsafe impl<const EP_COUNT: usize> Sync for State<EP_COUNT> {}
 
@@ -314,7 +320,62 @@ impl<const EP_COUNT: usize> State<EP_COUNT> {
                     out_size: AtomicU16::new(EP_OUT_BUFFER_EMPTY),
                 }
             }; EP_COUNT],
+            ep_in_alloc: [const { UnsafeCell::new(None) }; EP_COUNT],
+            ep_out_alloc: [const { UnsafeCell::new(None) }; EP_COUNT],
             bus_waker: AtomicWaker::new(),
+        }
+    }
+
+    fn ep_alloc_get(&self, dir: Direction, index: usize) -> Option<EndpointData> {
+        unsafe {
+            match dir {
+                Direction::In => *self.ep_in_alloc[index].get(),
+                Direction::Out => *self.ep_out_alloc[index].get(),
+            }
+        }
+    }
+
+    fn ep_fifo_size_in(&self, endpoint_count: usize) -> u16 {
+        (0..endpoint_count)
+            .filter_map(|i| self.ep_alloc_get(Direction::In, i))
+            .map(|ep| ep.fifo_size_words)
+            .sum()
+    }
+
+    fn ep_fifo_size_out(&self, endpoint_count: usize) -> u16 {
+        (0..endpoint_count)
+            .filter_map(|i| self.ep_alloc_get(Direction::Out, i))
+            .map(|ep| ep.fifo_size_words)
+            .sum()
+    }
+
+    fn ep_irq_mask_in(&self, endpoint_count: usize) -> u16 {
+        (0..endpoint_count).fold(0, |mask, i| {
+            if self.ep_alloc_get(Direction::In, i).is_some() {
+                mask | (1 << i)
+            } else {
+                mask
+            }
+        })
+    }
+
+    fn ep_irq_mask_out(&self, endpoint_count: usize) -> u16 {
+        (0..endpoint_count).fold(0, |mask, i| {
+            if self.ep_alloc_get(Direction::Out, i).is_some() {
+                mask | (1 << i)
+            } else {
+                mask
+            }
+        })
+    }
+
+    /// # Safety
+    ///
+    /// Call only from [`Driver::alloc_endpoint`](crate::Driver::alloc_endpoint) before [`embassy_usb_driver::Driver::start`].
+    unsafe fn alloc_slot_write(&self, dir: Direction, index: usize, data: EndpointData) {
+        match dir {
+            Direction::In => *self.ep_in_alloc[index].get() = Some(data),
+            Direction::Out => *self.ep_out_alloc[index].get() = Some(data),
         }
     }
 }
@@ -367,8 +428,6 @@ impl Default for Config {
 /// USB OTG driver.
 pub struct Driver<'d, const MAX_EP_COUNT: usize> {
     config: Config,
-    ep_in: [Option<EndpointData>; MAX_EP_COUNT],
-    ep_out: [Option<EndpointData>; MAX_EP_COUNT],
     ep_out_buffer: &'d mut [u8],
     ep_out_buffer_offset: usize,
     instance: OtgInstance<'d, MAX_EP_COUNT>,
@@ -387,8 +446,6 @@ impl<'d, const MAX_EP_COUNT: usize> Driver<'d, MAX_EP_COUNT> {
     pub fn new(ep_out_buffer: &'d mut [u8], instance: OtgInstance<'d, MAX_EP_COUNT>, config: Config) -> Self {
         Self {
             config,
-            ep_in: [None; MAX_EP_COUNT],
-            ep_out: [None; MAX_EP_COUNT],
             ep_out_buffer,
             ep_out_buffer_offset: 0,
             instance,
@@ -397,7 +454,9 @@ impl<'d, const MAX_EP_COUNT: usize> Driver<'d, MAX_EP_COUNT> {
 
     /// Returns the total amount of words (u32) allocated in dedicated FIFO.
     fn allocated_fifo_words(&self) -> u16 {
-        self.instance.extra_rx_fifo_words + ep_fifo_size(&self.ep_out) + ep_fifo_size(&self.ep_in)
+        let state = self.instance.state;
+        let n = self.instance.endpoint_count;
+        self.instance.extra_rx_fifo_words + state.ep_fifo_size_out(n) + state.ep_fifo_size_in(n)
     }
 
     /// Creates an [`Endpoint`] with the given parameters.
@@ -434,59 +493,62 @@ impl<'d, const MAX_EP_COUNT: usize> Driver<'d, MAX_EP_COUNT> {
             return Err(EndpointAllocError);
         }
 
-        let eps = match D::dir() {
-            Direction::Out => &mut self.ep_out[..self.instance.endpoint_count],
-            Direction::In => &mut self.ep_in[..self.instance.endpoint_count],
-        };
+        let dir = D::dir();
+        let state = self.instance.state;
+        let endpoint_count = self.instance.endpoint_count;
 
         // Find endpoint slot
-        let slot = if let Some(addr) = ep_addr {
+        let index = if let Some(addr) = ep_addr {
             // Use the specified endpoint address
             let requested_index = addr.index();
-            if requested_index >= self.instance.endpoint_count {
+            if requested_index >= endpoint_count {
                 return Err(EndpointAllocError);
             }
             if requested_index == 0 && ep_type != EndpointType::Control {
                 return Err(EndpointAllocError); // EP0 is reserved for control
             }
-            if eps[requested_index].is_some() {
+            if state.ep_alloc_get(dir, requested_index).is_some() {
                 return Err(EndpointAllocError); // Already allocated
             }
-            Some((requested_index, &mut eps[requested_index]))
+            requested_index
         } else {
             // Find any free endpoint slot
-            eps.iter_mut().enumerate().find(|(i, ep)| {
-                if *i == 0 && ep_type != EndpointType::Control {
+            let found = (0..endpoint_count).find(|&i| {
+                if i == 0 && ep_type != EndpointType::Control {
                     // reserved for control pipe
                     false
                 } else {
-                    ep.is_none()
+                    state.ep_alloc_get(dir, i).is_none()
                 }
-            })
+            });
+            match found {
+                Some(i) => i,
+                None => {
+                    error!("No free endpoints available");
+                    return Err(EndpointAllocError);
+                }
+            }
         };
 
-        let index = match slot {
-            Some((index, ep)) => {
-                *ep = Some(EndpointData {
+        unsafe {
+            state.alloc_slot_write(
+                dir,
+                index,
+                EndpointData {
                     ep_type,
                     max_packet_size,
                     fifo_size_words,
-                });
-                index
-            }
-            None => {
-                error!("No free endpoints available");
-                return Err(EndpointAllocError);
-            }
+                },
+            );
         };
 
         trace!("  index={}", index);
 
-        let state = &self.instance.state.ep_states[index];
+        let ep_state = &self.instance.state.ep_states[index];
         if D::dir() == Direction::Out {
             // Buffer capacity check was done above, now allocation cannot fail
             unsafe {
-                *state.out_buffer.get() = self.ep_out_buffer.as_mut_ptr().offset(self.ep_out_buffer_offset as _);
+                *ep_state.out_buffer.get() = self.ep_out_buffer.as_mut_ptr().offset(self.ep_out_buffer_offset as _);
             }
             self.ep_out_buffer_offset += max_packet_size as usize;
         }
@@ -494,7 +556,7 @@ impl<'d, const MAX_EP_COUNT: usize> Driver<'d, MAX_EP_COUNT> {
         Ok(Endpoint {
             _phantom: PhantomData,
             regs: self.instance.regs,
-            state,
+            state: ep_state,
             info: EndpointInfo {
                 addr: EndpointAddress::from_parts(index, D::dir()),
                 ep_type,
@@ -548,8 +610,6 @@ impl<'d, const MAX_EP_COUNT: usize> embassy_usb_driver::Driver<'d> for Driver<'d
         (
             Bus {
                 config: self.config,
-                ep_in: self.ep_in,
-                ep_out: self.ep_out,
                 inited: false,
                 instance: self.instance,
             },
@@ -567,8 +627,6 @@ impl<'d, const MAX_EP_COUNT: usize> embassy_usb_driver::Driver<'d> for Driver<'d
 /// USB bus.
 pub struct Bus<'d, const MAX_EP_COUNT: usize> {
     config: Config,
-    ep_in: [Option<EndpointData>; MAX_EP_COUNT],
-    ep_out: [Option<EndpointData>; MAX_EP_COUNT],
     instance: OtgInstance<'d, MAX_EP_COUNT>,
     inited: bool,
 }
@@ -784,15 +842,17 @@ impl<'d, const MAX_EP_COUNT: usize> Bus<'d, MAX_EP_COUNT> {
         // the interrupt does not occur.
         critical_section::with(|_| {
             // Configure RX fifo size. All endpoints share the same FIFO area.
-            let rx_fifo_size_words = self.instance.extra_rx_fifo_words + ep_fifo_size(&self.ep_out);
+            let state = self.instance.state;
+            let ep_count = self.instance.endpoint_count;
+            let rx_fifo_size_words = self.instance.extra_rx_fifo_words + state.ep_fifo_size_out(ep_count);
             trace!("configuring rx fifo size={}", rx_fifo_size_words);
 
             regs.grxfsiz().modify(|w| w.set_rxfd(rx_fifo_size_words));
 
             // Configure TX (USB in direction) fifo size for each endpoint
             let mut fifo_top = rx_fifo_size_words;
-            for i in 0..self.instance.endpoint_count {
-                if let Some(ep) = self.ep_in[i] {
+            for i in 0..ep_count {
+                if let Some(ep) = state.ep_alloc_get(Direction::In, i) {
                     trace!(
                         "configuring tx fifo ep={}, offset={}, size={}",
                         i, fifo_top, ep.fifo_size_words
@@ -834,10 +894,11 @@ impl<'d, const MAX_EP_COUNT: usize> Bus<'d, MAX_EP_COUNT> {
         trace!("configure_endpoints");
 
         let regs = self.instance.regs;
+        let state = self.instance.state;
 
         // Configure IN endpoints
-        for (index, ep) in self.ep_in.iter().enumerate() {
-            if let Some(ep) = ep {
+        for index in 0..self.instance.endpoint_count {
+            if let Some(ep) = state.ep_alloc_get(Direction::In, index) {
                 critical_section::with(|_| {
                     regs.diepctl(index).write(|w| {
                         if index == 0 {
@@ -855,8 +916,8 @@ impl<'d, const MAX_EP_COUNT: usize> Bus<'d, MAX_EP_COUNT> {
         }
 
         // Configure OUT endpoints
-        for (index, ep) in self.ep_out.iter().enumerate() {
-            if let Some(ep) = ep {
+        for index in 0..self.instance.endpoint_count {
+            if let Some(ep) = state.ep_alloc_get(Direction::Out, index) {
                 critical_section::with(|_| {
                     regs.doepctl(index).write(|w| {
                         if index == 0 {
@@ -881,9 +942,10 @@ impl<'d, const MAX_EP_COUNT: usize> Bus<'d, MAX_EP_COUNT> {
         }
 
         // Enable IRQs for allocated endpoints
+        let ep_count = self.instance.endpoint_count;
         regs.daintmsk().modify(|w| {
-            w.set_iepm(ep_irq_mask(&self.ep_in));
-            w.set_oepm(ep_irq_mask(&self.ep_out));
+            w.set_iepm(state.ep_irq_mask_in(ep_count));
+            w.set_oepm(state.ep_irq_mask_out(ep_count));
         });
     }
 
@@ -1077,7 +1139,7 @@ impl<'d, const MAX_EP_COUNT: usize> embassy_usb_driver::Bus for Bus<'d, MAX_EP_C
                     // When re-enabling a non-EP0 OUT endpoint, prime it to receive a packet.
                     // Without this, the endpoint stays idle after reconnect and silently drops data.
                     if enabled && ep_addr.index() != 0 {
-                        if let Some(ep) = &self.ep_out[ep_addr.index()] {
+                        if let Some(ep) = self.instance.state.ep_alloc_get(Direction::Out, ep_addr.index()) {
                             regs.doeptsiz(ep_addr.index()).modify(|w| {
                                 w.set_xfrsiz(ep.max_packet_size as _);
                                 w.set_pktcnt(1);
@@ -1526,21 +1588,6 @@ fn to_eptyp(ep_type: EndpointType) -> vals::Eptyp {
         EndpointType::Bulk => vals::Eptyp::BULK,
         EndpointType::Interrupt => vals::Eptyp::INTERRUPT,
     }
-}
-
-/// Calculates total allocated FIFO size in words
-fn ep_fifo_size(eps: &[Option<EndpointData>]) -> u16 {
-    eps.iter().map(|ep| ep.map(|ep| ep.fifo_size_words).unwrap_or(0)).sum()
-}
-
-/// Generates IRQ mask for enabled endpoints
-fn ep_irq_mask(eps: &[Option<EndpointData>]) -> u16 {
-    eps.iter().enumerate().fold(
-        0,
-        |mask, (index, ep)| {
-            if ep.is_some() { mask | (1 << index) } else { mask }
-        },
-    )
 }
 
 /// Calculates MPSIZ value for EP0, which uses special values.

--- a/embassy-usb-synopsys-otg/src/lib.rs
+++ b/embassy-usb-synopsys-otg/src/lib.rs
@@ -275,11 +275,13 @@ struct EpState {
     /// Buffers are ready when associated [State::ep_out_size] != [EP_OUT_BUFFER_EMPTY].
     out_buffer: UnsafeCell<*mut u8>,
     out_size: AtomicU16,
+    // Written once during endpoint allocation (before Driver::start), read-only afterward.
+    in_alloc: UnsafeCell<Option<EndpointData>>,
+    out_alloc: UnsafeCell<Option<EndpointData>>,
 }
 
-// SAFETY: The EndpointAllocator ensures that the buffer points to valid memory exclusive for each endpoint and is
-// large enough to hold the maximum packet size. Access to the buffer is synchronized between the USB interrupt and the
-// EndpointOut impl using the out_size atomic variable.
+// SAFETY: `out_buffer` access is synchronized via `out_size`. `in_alloc`/`out_alloc` are written
+// only during endpoint allocation before the USB stack starts; afterward they are read-only.
 unsafe impl Send for EpState {}
 unsafe impl Sync for EpState {}
 
@@ -304,8 +306,6 @@ struct EndpointData {
 pub struct OtgState<'d> {
     cp_state: &'d ControlPipeSetupState,
     ep_states: &'d [EpState],
-    ep_in_alloc: &'d [UnsafeCell<Option<EndpointData>>],
-    ep_out_alloc: &'d [UnsafeCell<Option<EndpointData>>],
     bus_waker: &'d AtomicWaker,
 }
 
@@ -320,8 +320,8 @@ impl<'d> OtgState<'d> {
     pub(crate) fn ep_alloc_get(&self, dir: Direction, index: usize) -> Option<&EndpointData> {
         unsafe {
             match dir {
-                Direction::In => (*self.ep_in_alloc[index].get()).as_ref(),
-                Direction::Out => (*self.ep_out_alloc[index].get()).as_ref(),
+                Direction::In => (*self.ep_states[index].in_alloc.get()).as_ref(),
+                Direction::Out => (*self.ep_states[index].out_alloc.get()).as_ref(),
             }
         }
     }
@@ -365,8 +365,8 @@ impl<'d> OtgState<'d> {
     /// Call only from [`Driver::alloc_endpoint`](crate::Driver::alloc_endpoint) before [`embassy_usb_driver::Driver::start`].
     pub(crate) unsafe fn alloc_slot_write(&self, dir: Direction, index: usize, data: EndpointData) {
         match dir {
-            Direction::In => *self.ep_in_alloc[index].get() = Some(data),
-            Direction::Out => *self.ep_out_alloc[index].get() = Some(data),
+            Direction::In => *self.ep_states[index].in_alloc.get() = Some(data),
+            Direction::Out => *self.ep_states[index].out_alloc.get() = Some(data),
         }
     }
 }
@@ -376,16 +376,7 @@ pub struct State<const EP_COUNT: usize> {
     cp_state: ControlPipeSetupState,
     ep_states: [EpState; EP_COUNT],
     bus_waker: AtomicWaker,
-
-    // Endpoint allocation data, owned by Driver/Bus.
-    ep_in_alloc: [UnsafeCell<Option<EndpointData>>; EP_COUNT],
-    ep_out_alloc: [UnsafeCell<Option<EndpointData>>; EP_COUNT],
 }
-
-// SAFETY: `ep_in_alloc` / `ep_out_alloc` are written only during `Driver` endpoint allocation before the USB device
-// stack runs; afterward they are read-only. `EpState::out_buffer` invariants are documented on `EpState`.
-unsafe impl<const EP_COUNT: usize> Send for State<EP_COUNT> {}
-unsafe impl<const EP_COUNT: usize> Sync for State<EP_COUNT> {}
 
 impl<const EP_COUNT: usize> State<EP_COUNT> {
     /// Create a new State.
@@ -401,10 +392,10 @@ impl<const EP_COUNT: usize> State<EP_COUNT> {
                     out_waker: AtomicWaker::new(),
                     out_buffer: UnsafeCell::new(0 as _),
                     out_size: AtomicU16::new(EP_OUT_BUFFER_EMPTY),
+                    in_alloc: UnsafeCell::new(None),
+                    out_alloc: UnsafeCell::new(None),
                 }
             }; EP_COUNT],
-            ep_in_alloc: [const { UnsafeCell::new(None) }; EP_COUNT],
-            ep_out_alloc: [const { UnsafeCell::new(None) }; EP_COUNT],
             bus_waker: AtomicWaker::new(),
         }
     }
@@ -414,8 +405,6 @@ impl<const EP_COUNT: usize> State<EP_COUNT> {
         OtgState {
             cp_state: &self.cp_state,
             ep_states: self.ep_states.as_slice(),
-            ep_in_alloc: self.ep_in_alloc.as_slice(),
-            ep_out_alloc: self.ep_out_alloc.as_slice(),
             bus_waker: &self.bus_waker,
         }
     }

--- a/embassy-usb-synopsys-otg/src/lib.rs
+++ b/embassy-usb-synopsys-otg/src/lib.rs
@@ -1352,7 +1352,7 @@ impl<'d> embassy_usb_driver::EndpointOut for Endpoint<'d, Out> {
                 return Poll::Ready(Err(EndpointError::Disabled));
             }
 
-            let len = self.state.out_size.load(Ordering::Relaxed);
+            let len = self.state.out_size.load(Ordering::Acquire);
             if len != EP_OUT_BUFFER_EMPTY {
                 trace!("read ep={:?} done len={}", self.info.addr, len);
 
@@ -1536,7 +1536,7 @@ impl<'d> embassy_usb_driver::ControlPipe for ControlPipe<'d> {
         poll_fn(|cx| {
             self.ep_out.state.out_waker.register(cx.waker());
 
-            if self.setup_state.setup_ready.load(Ordering::Relaxed) {
+            if self.setup_state.setup_ready.load(Ordering::Acquire) {
                 let mut data = [0; 8];
                 data[0..4].copy_from_slice(&self.setup_state.setup_data[0].load(Ordering::Relaxed).to_ne_bytes());
                 data[4..8].copy_from_slice(&self.setup_state.setup_data[1].load(Ordering::Relaxed).to_ne_bytes());

--- a/embassy-usb-synopsys-otg/src/lib.rs
+++ b/embassy-usb-synopsys-otg/src/lib.rs
@@ -29,11 +29,9 @@ pub mod host;
 use otg_v1::{Otg, regs, vals};
 
 /// Handle interrupts.
-pub unsafe fn on_interrupt(r: Otg, state: &OtgState<'_>, ep_count: usize) {
+pub unsafe fn on_interrupt(r: Otg, state: &OtgState<'_>) {
     trace!("irq");
-
-    // defensively cap ep_count to the number of endpoint slots we actually have.
-    let ep_count = ep_count.min(state.ep_states.len());
+    let ep_count = state.endpoint_count();
 
     let ints = r.gintsts().read();
     if ints.wkupint() || ints.usbsusp() || ints.usbrst() || ints.enumdne() || ints.otgint() || ints.srqint() {
@@ -328,22 +326,22 @@ impl<'d> OtgState<'d> {
         }
     }
 
-    pub(crate) fn ep_fifo_size_in(&self, endpoint_count: usize) -> u16 {
-        (0..endpoint_count)
+    pub(crate) fn ep_fifo_size_in(&self) -> u16 {
+        (0..self.endpoint_count())
             .filter_map(|i| self.ep_alloc_get(Direction::In, i))
             .map(|ep| ep.fifo_size_words)
             .sum()
     }
 
-    pub(crate) fn ep_fifo_size_out(&self, endpoint_count: usize) -> u16 {
-        (0..endpoint_count)
+    pub(crate) fn ep_fifo_size_out(&self) -> u16 {
+        (0..self.endpoint_count())
             .filter_map(|i| self.ep_alloc_get(Direction::Out, i))
             .map(|ep| ep.fifo_size_words)
             .sum()
     }
 
-    pub(crate) fn ep_irq_mask_in(&self, endpoint_count: usize) -> u16 {
-        (0..endpoint_count).fold(0, |mask, i| {
+    pub(crate) fn ep_irq_mask_in(&self) -> u16 {
+        (0..self.endpoint_count()).fold(0, |mask, i| {
             if self.ep_alloc_get(Direction::In, i).is_some() {
                 mask | (1 << i)
             } else {
@@ -352,8 +350,8 @@ impl<'d> OtgState<'d> {
         })
     }
 
-    pub(crate) fn ep_irq_mask_out(&self, endpoint_count: usize) -> u16 {
-        (0..endpoint_count).fold(0, |mask, i| {
+    pub(crate) fn ep_irq_mask_out(&self) -> u16 {
+        (0..self.endpoint_count()).fold(0, |mask, i| {
             if self.ep_alloc_get(Direction::Out, i).is_some() {
                 mask | (1 << i)
             } else {
@@ -491,8 +489,7 @@ impl<'d> Driver<'d> {
     /// Returns the total amount of words (u32) allocated in dedicated FIFO.
     fn allocated_fifo_words(&self) -> u16 {
         let st = self.instance.state;
-        let n = self.instance.endpoint_count;
-        self.instance.extra_rx_fifo_words + st.ep_fifo_size_out(n) + st.ep_fifo_size_in(n)
+        self.instance.extra_rx_fifo_words + st.ep_fifo_size_out() + st.ep_fifo_size_in()
     }
 
     /// Creates an [`Endpoint`] with the given parameters.
@@ -531,7 +528,7 @@ impl<'d> Driver<'d> {
 
         let dir = D::dir();
         let st = self.instance.state;
-        let endpoint_count = self.instance.endpoint_count;
+        let endpoint_count = st.endpoint_count();
 
         // Find endpoint slot
         let index = if let Some(addr) = ep_addr {
@@ -879,15 +876,14 @@ impl<'d> Bus<'d> {
         critical_section::with(|_| {
             // Configure RX fifo size. All endpoints share the same FIFO area.
             let st = self.instance.state;
-            let ep_count = self.instance.endpoint_count;
-            let rx_fifo_size_words = self.instance.extra_rx_fifo_words + st.ep_fifo_size_out(ep_count);
+            let rx_fifo_size_words = self.instance.extra_rx_fifo_words + st.ep_fifo_size_out();
             trace!("configuring rx fifo size={}", rx_fifo_size_words);
 
             regs.grxfsiz().modify(|w| w.set_rxfd(rx_fifo_size_words));
 
             // Configure TX (USB in direction) fifo size for each endpoint
             let mut fifo_top = rx_fifo_size_words;
-            for i in 0..ep_count {
+            for i in 0..st.endpoint_count() {
                 if let Some(ep) = st.ep_alloc_get(Direction::In, i) {
                     trace!(
                         "configuring tx fifo ep={}, offset={}, size={}",
@@ -930,7 +926,7 @@ impl<'d> Bus<'d> {
         let st = self.instance.state;
 
         // Configure IN endpoints
-        for index in 0..self.instance.endpoint_count {
+        for index in 0..st.endpoint_count() {
             if let Some(ep) = st.ep_alloc_get(Direction::In, index) {
                 critical_section::with(|_| {
                     regs.diepctl(index).write(|w| {
@@ -949,7 +945,7 @@ impl<'d> Bus<'d> {
         }
 
         // Configure OUT endpoints
-        for index in 0..self.instance.endpoint_count {
+        for index in 0..st.endpoint_count() {
             if let Some(ep) = st.ep_alloc_get(Direction::Out, index) {
                 critical_section::with(|_| {
                     regs.doepctl(index).write(|w| {
@@ -982,15 +978,15 @@ impl<'d> Bus<'d> {
         }
 
         // Enable IRQs for allocated endpoints
-        let ep_count = self.instance.endpoint_count;
         regs.daintmsk().modify(|w| {
-            w.set_iepm(st.ep_irq_mask_in(ep_count));
-            w.set_oepm(st.ep_irq_mask_out(ep_count));
+            w.set_iepm(st.ep_irq_mask_in());
+            w.set_oepm(st.ep_irq_mask_out());
         });
     }
 
     fn disable_all_endpoints(&mut self) {
-        for i in 0..self.instance.endpoint_count {
+        let st = self.instance.state;
+        for i in 0..st.endpoint_count() {
             self.endpoint_set_enabled(EndpointAddress::from_parts(i, Direction::In), false);
             self.endpoint_set_enabled(EndpointAddress::from_parts(i, Direction::Out), false);
         }
@@ -1106,14 +1102,15 @@ impl<'d> embassy_usb_driver::Bus for Bus<'d> {
     fn endpoint_set_stalled(&mut self, ep_addr: EndpointAddress, stalled: bool) {
         trace!("endpoint_set_stalled ep={:?} en={}", ep_addr, stalled);
 
+        let regs = self.instance.regs;
+        let st = &self.instance.state;
+
         assert!(
-            ep_addr.index() < self.instance.endpoint_count,
+            ep_addr.index() < st.endpoint_count(),
             "endpoint_set_stalled index {} out of range",
             ep_addr.index()
         );
 
-        let regs = self.instance.regs;
-        let ep_states = &self.instance.state.ep_states;
         match ep_addr.direction() {
             Direction::Out => {
                 critical_section::with(|_| {
@@ -1122,7 +1119,7 @@ impl<'d> embassy_usb_driver::Bus for Bus<'d> {
                     });
                 });
 
-                ep_states[ep_addr.index()].out_waker.wake();
+                st.ep_states[ep_addr.index()].out_waker.wake();
             }
             Direction::In => {
                 critical_section::with(|_| {
@@ -1131,14 +1128,14 @@ impl<'d> embassy_usb_driver::Bus for Bus<'d> {
                     });
                 });
 
-                ep_states[ep_addr.index()].in_waker.wake();
+                st.ep_states[ep_addr.index()].in_waker.wake();
             }
         }
     }
 
     fn endpoint_is_stalled(&mut self, ep_addr: EndpointAddress) -> bool {
         assert!(
-            ep_addr.index() < self.instance.endpoint_count,
+            ep_addr.index() < self.instance.state.endpoint_count(),
             "endpoint_is_stalled index {} out of range",
             ep_addr.index()
         );
@@ -1154,7 +1151,7 @@ impl<'d> embassy_usb_driver::Bus for Bus<'d> {
         trace!("endpoint_set_enabled ep={:?} en={}", ep_addr, enabled);
 
         assert!(
-            ep_addr.index() < self.instance.endpoint_count,
+            ep_addr.index() < self.instance.state.endpoint_count(),
             "endpoint_set_enabled index {} out of range",
             ep_addr.index()
         );
@@ -1650,8 +1647,6 @@ pub struct OtgInstance<'d> {
     pub state: OtgState<'d>,
     /// FIFO depth in words.
     pub fifo_depth_words: u16,
-    /// Number of used endpoints.
-    pub endpoint_count: usize,
     /// The PHY type.
     pub phy_type: PhyType,
     /// Extra RX FIFO words needed by some implementations.

--- a/embassy-usb-synopsys-otg/src/lib.rs
+++ b/embassy-usb-synopsys-otg/src/lib.rs
@@ -29,7 +29,7 @@ pub mod host;
 use otg_v1::{Otg, regs, vals};
 
 /// Handle interrupts.
-pub unsafe fn on_interrupt<const MAX_EP_COUNT: usize>(r: Otg, state: &State<MAX_EP_COUNT>, ep_count: usize) {
+pub unsafe fn on_interrupt(r: Otg, state: &OtgState<'_>, ep_count: usize) {
     trace!("irq");
 
     let ints = r.gintsts().read();
@@ -288,6 +288,81 @@ struct ControlPipeSetupState {
     setup_ready: AtomicBool,
 }
 
+#[derive(Debug, Clone, Copy)]
+struct EndpointData {
+    ep_type: EndpointType,
+    max_packet_size: u16,
+    fifo_size_words: u16,
+}
+
+/// Type-erased borrow of [`State`] passed to [`OtgInstance`], [`Driver`](crate::Driver), [`Bus`](crate::Bus),
+/// and [`on_interrupt`].
+///
+/// Build from [`State::as_otg_state`].
+#[derive(Clone, Copy)]
+pub struct OtgState<'d> {
+    pub(crate) cp_state: &'d ControlPipeSetupState,
+    pub(crate) ep_states: &'d [EpState],
+    pub(crate) ep_in_alloc: &'d [UnsafeCell<Option<EndpointData>>],
+    pub(crate) ep_out_alloc: &'d [UnsafeCell<Option<EndpointData>>],
+    pub(crate) bus_waker: &'d AtomicWaker,
+}
+
+impl<'d> OtgState<'d> {
+    pub(crate) fn ep_alloc_get(&self, dir: Direction, index: usize) -> Option<&EndpointData> {
+        unsafe {
+            match dir {
+                Direction::In => (*self.ep_in_alloc[index].get()).as_ref(),
+                Direction::Out => (*self.ep_out_alloc[index].get()).as_ref(),
+            }
+        }
+    }
+
+    pub(crate) fn ep_fifo_size_in(&self, endpoint_count: usize) -> u16 {
+        (0..endpoint_count)
+            .filter_map(|i| self.ep_alloc_get(Direction::In, i))
+            .map(|ep| ep.fifo_size_words)
+            .sum()
+    }
+
+    pub(crate) fn ep_fifo_size_out(&self, endpoint_count: usize) -> u16 {
+        (0..endpoint_count)
+            .filter_map(|i| self.ep_alloc_get(Direction::Out, i))
+            .map(|ep| ep.fifo_size_words)
+            .sum()
+    }
+
+    pub(crate) fn ep_irq_mask_in(&self, endpoint_count: usize) -> u16 {
+        (0..endpoint_count).fold(0, |mask, i| {
+            if self.ep_alloc_get(Direction::In, i).is_some() {
+                mask | (1 << i)
+            } else {
+                mask
+            }
+        })
+    }
+
+    pub(crate) fn ep_irq_mask_out(&self, endpoint_count: usize) -> u16 {
+        (0..endpoint_count).fold(0, |mask, i| {
+            if self.ep_alloc_get(Direction::Out, i).is_some() {
+                mask | (1 << i)
+            } else {
+                mask
+            }
+        })
+    }
+
+    /// # Safety
+    ///
+    /// Call only from [`Driver::alloc_endpoint`](crate::Driver::alloc_endpoint) before [`embassy_usb_driver::Driver::start`].
+    pub(crate) unsafe fn alloc_slot_write(&self, dir: Direction, index: usize, data: EndpointData) {
+        match dir {
+            Direction::In => *self.ep_in_alloc[index].get() = Some(data),
+            Direction::Out => *self.ep_out_alloc[index].get() = Some(data),
+        }
+    }
+}
+
 /// USB OTG driver state.
 pub struct State<const EP_COUNT: usize> {
     cp_state: ControlPipeSetupState,
@@ -326,65 +401,16 @@ impl<const EP_COUNT: usize> State<EP_COUNT> {
         }
     }
 
-    fn ep_alloc_get(&self, dir: Direction, index: usize) -> Option<EndpointData> {
-        unsafe {
-            match dir {
-                Direction::In => *self.ep_in_alloc[index].get(),
-                Direction::Out => *self.ep_out_alloc[index].get(),
-            }
+    /// Borrow this [`State`] as an [`OtgState`] for [`OtgInstance`] and the Synopsys [`Driver`](crate::Driver).
+    pub fn as_otg_state(&self) -> OtgState<'_> {
+        OtgState {
+            cp_state: &self.cp_state,
+            ep_states: self.ep_states.as_slice(),
+            ep_in_alloc: self.ep_in_alloc.as_slice(),
+            ep_out_alloc: self.ep_out_alloc.as_slice(),
+            bus_waker: &self.bus_waker,
         }
     }
-
-    fn ep_fifo_size_in(&self, endpoint_count: usize) -> u16 {
-        (0..endpoint_count)
-            .filter_map(|i| self.ep_alloc_get(Direction::In, i))
-            .map(|ep| ep.fifo_size_words)
-            .sum()
-    }
-
-    fn ep_fifo_size_out(&self, endpoint_count: usize) -> u16 {
-        (0..endpoint_count)
-            .filter_map(|i| self.ep_alloc_get(Direction::Out, i))
-            .map(|ep| ep.fifo_size_words)
-            .sum()
-    }
-
-    fn ep_irq_mask_in(&self, endpoint_count: usize) -> u16 {
-        (0..endpoint_count).fold(0, |mask, i| {
-            if self.ep_alloc_get(Direction::In, i).is_some() {
-                mask | (1 << i)
-            } else {
-                mask
-            }
-        })
-    }
-
-    fn ep_irq_mask_out(&self, endpoint_count: usize) -> u16 {
-        (0..endpoint_count).fold(0, |mask, i| {
-            if self.ep_alloc_get(Direction::Out, i).is_some() {
-                mask | (1 << i)
-            } else {
-                mask
-            }
-        })
-    }
-
-    /// # Safety
-    ///
-    /// Call only from [`Driver::alloc_endpoint`](crate::Driver::alloc_endpoint) before [`embassy_usb_driver::Driver::start`].
-    unsafe fn alloc_slot_write(&self, dir: Direction, index: usize, data: EndpointData) {
-        match dir {
-            Direction::In => *self.ep_in_alloc[index].get() = Some(data),
-            Direction::Out => *self.ep_out_alloc[index].get() = Some(data),
-        }
-    }
-}
-
-#[derive(Debug, Clone, Copy)]
-struct EndpointData {
-    ep_type: EndpointType,
-    max_packet_size: u16,
-    fifo_size_words: u16,
 }
 
 /// USB driver config.
@@ -426,14 +452,14 @@ impl Default for Config {
 }
 
 /// USB OTG driver.
-pub struct Driver<'d, const MAX_EP_COUNT: usize> {
+pub struct Driver<'d> {
     config: Config,
     ep_out_buffer: &'d mut [u8],
     ep_out_buffer_offset: usize,
-    instance: OtgInstance<'d, MAX_EP_COUNT>,
+    instance: OtgInstance<'d>,
 }
 
-impl<'d, const MAX_EP_COUNT: usize> Driver<'d, MAX_EP_COUNT> {
+impl<'d> Driver<'d> {
     /// Initializes the USB OTG peripheral.
     ///
     /// # Arguments
@@ -443,7 +469,7 @@ impl<'d, const MAX_EP_COUNT: usize> Driver<'d, MAX_EP_COUNT> {
     /// Endpoint allocation will fail if it is too small.
     /// * `instance` - The USB OTG peripheral instance and its configuration.
     /// * `config` - The USB driver configuration.
-    pub fn new(ep_out_buffer: &'d mut [u8], instance: OtgInstance<'d, MAX_EP_COUNT>, config: Config) -> Self {
+    pub fn new(ep_out_buffer: &'d mut [u8], instance: OtgInstance<'d>, config: Config) -> Self {
         Self {
             config,
             ep_out_buffer,
@@ -454,9 +480,9 @@ impl<'d, const MAX_EP_COUNT: usize> Driver<'d, MAX_EP_COUNT> {
 
     /// Returns the total amount of words (u32) allocated in dedicated FIFO.
     fn allocated_fifo_words(&self) -> u16 {
-        let state = self.instance.state;
+        let st = self.instance.state;
         let n = self.instance.endpoint_count;
-        self.instance.extra_rx_fifo_words + state.ep_fifo_size_out(n) + state.ep_fifo_size_in(n)
+        self.instance.extra_rx_fifo_words + st.ep_fifo_size_out(n) + st.ep_fifo_size_in(n)
     }
 
     /// Creates an [`Endpoint`] with the given parameters.
@@ -494,7 +520,7 @@ impl<'d, const MAX_EP_COUNT: usize> Driver<'d, MAX_EP_COUNT> {
         }
 
         let dir = D::dir();
-        let state = self.instance.state;
+        let st = self.instance.state;
         let endpoint_count = self.instance.endpoint_count;
 
         // Find endpoint slot
@@ -507,7 +533,7 @@ impl<'d, const MAX_EP_COUNT: usize> Driver<'d, MAX_EP_COUNT> {
             if requested_index == 0 && ep_type != EndpointType::Control {
                 return Err(EndpointAllocError); // EP0 is reserved for control
             }
-            if state.ep_alloc_get(dir, requested_index).is_some() {
+            if st.ep_alloc_get(dir, requested_index).is_some() {
                 return Err(EndpointAllocError); // Already allocated
             }
             requested_index
@@ -518,7 +544,7 @@ impl<'d, const MAX_EP_COUNT: usize> Driver<'d, MAX_EP_COUNT> {
                     // reserved for control pipe
                     false
                 } else {
-                    state.ep_alloc_get(dir, i).is_none()
+                    st.ep_alloc_get(dir, i).is_none()
                 }
             });
             match found {
@@ -531,7 +557,7 @@ impl<'d, const MAX_EP_COUNT: usize> Driver<'d, MAX_EP_COUNT> {
         };
 
         unsafe {
-            state.alloc_slot_write(
+            st.alloc_slot_write(
                 dir,
                 index,
                 EndpointData {
@@ -567,11 +593,11 @@ impl<'d, const MAX_EP_COUNT: usize> Driver<'d, MAX_EP_COUNT> {
     }
 }
 
-impl<'d, const MAX_EP_COUNT: usize> embassy_usb_driver::Driver<'d> for Driver<'d, MAX_EP_COUNT> {
+impl<'d> embassy_usb_driver::Driver<'d> for Driver<'d> {
     type EndpointOut = Endpoint<'d, Out>;
     type EndpointIn = Endpoint<'d, In>;
     type ControlPipe = ControlPipe<'d>;
-    type Bus = Bus<'d, MAX_EP_COUNT>;
+    type Bus = Bus<'d>;
 
     fn alloc_endpoint_in(
         &mut self,
@@ -606,7 +632,7 @@ impl<'d, const MAX_EP_COUNT: usize> embassy_usb_driver::Driver<'d> for Driver<'d
         trace!("start");
 
         let regs = self.instance.regs;
-        let cp_setup_state = &self.instance.state.cp_state;
+        let setup_state = self.instance.state.cp_state;
         (
             Bus {
                 config: self.config,
@@ -615,7 +641,7 @@ impl<'d, const MAX_EP_COUNT: usize> embassy_usb_driver::Driver<'d> for Driver<'d
             },
             ControlPipe {
                 max_packet_size: control_max_packet_size,
-                setup_state: cp_setup_state,
+                setup_state,
                 ep_out,
                 ep_in,
                 regs,
@@ -625,13 +651,13 @@ impl<'d, const MAX_EP_COUNT: usize> embassy_usb_driver::Driver<'d> for Driver<'d
 }
 
 /// USB bus.
-pub struct Bus<'d, const MAX_EP_COUNT: usize> {
+pub struct Bus<'d> {
     config: Config,
-    instance: OtgInstance<'d, MAX_EP_COUNT>,
+    instance: OtgInstance<'d>,
     inited: bool,
 }
 
-impl<'d, const MAX_EP_COUNT: usize> Bus<'d, MAX_EP_COUNT> {
+impl<'d> Bus<'d> {
     fn restore_irqs(&mut self) {
         self.instance.regs.gintmsk().write(|w| {
             w.set_usbrst(true);
@@ -842,9 +868,9 @@ impl<'d, const MAX_EP_COUNT: usize> Bus<'d, MAX_EP_COUNT> {
         // the interrupt does not occur.
         critical_section::with(|_| {
             // Configure RX fifo size. All endpoints share the same FIFO area.
-            let state = self.instance.state;
+            let st = self.instance.state;
             let ep_count = self.instance.endpoint_count;
-            let rx_fifo_size_words = self.instance.extra_rx_fifo_words + state.ep_fifo_size_out(ep_count);
+            let rx_fifo_size_words = self.instance.extra_rx_fifo_words + st.ep_fifo_size_out(ep_count);
             trace!("configuring rx fifo size={}", rx_fifo_size_words);
 
             regs.grxfsiz().modify(|w| w.set_rxfd(rx_fifo_size_words));
@@ -852,7 +878,7 @@ impl<'d, const MAX_EP_COUNT: usize> Bus<'d, MAX_EP_COUNT> {
             // Configure TX (USB in direction) fifo size for each endpoint
             let mut fifo_top = rx_fifo_size_words;
             for i in 0..ep_count {
-                if let Some(ep) = state.ep_alloc_get(Direction::In, i) {
+                if let Some(ep) = st.ep_alloc_get(Direction::In, i) {
                     trace!(
                         "configuring tx fifo ep={}, offset={}, size={}",
                         i, fifo_top, ep.fifo_size_words
@@ -894,11 +920,11 @@ impl<'d, const MAX_EP_COUNT: usize> Bus<'d, MAX_EP_COUNT> {
         trace!("configure_endpoints");
 
         let regs = self.instance.regs;
-        let state = self.instance.state;
+        let st = self.instance.state;
 
         // Configure IN endpoints
         for index in 0..self.instance.endpoint_count {
-            if let Some(ep) = state.ep_alloc_get(Direction::In, index) {
+            if let Some(ep) = st.ep_alloc_get(Direction::In, index) {
                 critical_section::with(|_| {
                     regs.diepctl(index).write(|w| {
                         if index == 0 {
@@ -917,7 +943,7 @@ impl<'d, const MAX_EP_COUNT: usize> Bus<'d, MAX_EP_COUNT> {
 
         // Configure OUT endpoints
         for index in 0..self.instance.endpoint_count {
-            if let Some(ep) = state.ep_alloc_get(Direction::Out, index) {
+            if let Some(ep) = st.ep_alloc_get(Direction::Out, index) {
                 critical_section::with(|_| {
                     regs.doepctl(index).write(|w| {
                         if index == 0 {
@@ -944,8 +970,8 @@ impl<'d, const MAX_EP_COUNT: usize> Bus<'d, MAX_EP_COUNT> {
         // Enable IRQs for allocated endpoints
         let ep_count = self.instance.endpoint_count;
         regs.daintmsk().modify(|w| {
-            w.set_iepm(state.ep_irq_mask_in(ep_count));
-            w.set_oepm(state.ep_irq_mask_out(ep_count));
+            w.set_iepm(st.ep_irq_mask_in(ep_count));
+            w.set_oepm(st.ep_irq_mask_out(ep_count));
         });
     }
 
@@ -972,7 +998,7 @@ impl<'d, const MAX_EP_COUNT: usize> Bus<'d, MAX_EP_COUNT> {
     }
 }
 
-impl<'d, const MAX_EP_COUNT: usize> embassy_usb_driver::Bus for Bus<'d, MAX_EP_COUNT> {
+impl<'d> embassy_usb_driver::Bus for Bus<'d> {
     async fn poll(&mut self) -> Event {
         poll_fn(move |cx| {
             if !self.inited {
@@ -1073,7 +1099,7 @@ impl<'d, const MAX_EP_COUNT: usize> embassy_usb_driver::Bus for Bus<'d, MAX_EP_C
         );
 
         let regs = self.instance.regs;
-        let state = self.instance.state;
+        let ep_states = &self.instance.state.ep_states;
         match ep_addr.direction() {
             Direction::Out => {
                 critical_section::with(|_| {
@@ -1082,7 +1108,7 @@ impl<'d, const MAX_EP_COUNT: usize> embassy_usb_driver::Bus for Bus<'d, MAX_EP_C
                     });
                 });
 
-                state.ep_states[ep_addr.index()].out_waker.wake();
+                ep_states[ep_addr.index()].out_waker.wake();
             }
             Direction::In => {
                 critical_section::with(|_| {
@@ -1091,7 +1117,7 @@ impl<'d, const MAX_EP_COUNT: usize> embassy_usb_driver::Bus for Bus<'d, MAX_EP_C
                     });
                 });
 
-                state.ep_states[ep_addr.index()].in_waker.wake();
+                ep_states[ep_addr.index()].in_waker.wake();
             }
         }
     }
@@ -1120,7 +1146,7 @@ impl<'d, const MAX_EP_COUNT: usize> embassy_usb_driver::Bus for Bus<'d, MAX_EP_C
         );
 
         let regs = self.instance.regs;
-        let state = self.instance.state;
+        let st = self.instance.state;
         match ep_addr.direction() {
             Direction::Out => {
                 critical_section::with(|_| {
@@ -1139,7 +1165,7 @@ impl<'d, const MAX_EP_COUNT: usize> embassy_usb_driver::Bus for Bus<'d, MAX_EP_C
                     // When re-enabling a non-EP0 OUT endpoint, prime it to receive a packet.
                     // Without this, the endpoint stays idle after reconnect and silently drops data.
                     if enabled && ep_addr.index() != 0 {
-                        if let Some(ep) = self.instance.state.ep_alloc_get(Direction::Out, ep_addr.index()) {
+                        if let Some(ep) = st.ep_alloc_get(Direction::Out, ep_addr.index()) {
                             regs.doeptsiz(ep_addr.index()).modify(|w| {
                                 w.set_xfrsiz(ep.max_packet_size as _);
                                 w.set_pktcnt(1);
@@ -1153,7 +1179,7 @@ impl<'d, const MAX_EP_COUNT: usize> embassy_usb_driver::Bus for Bus<'d, MAX_EP_C
                 });
 
                 // Wake `Endpoint::wait_enabled()`
-                state.ep_states[ep_addr.index()].out_waker.wake();
+                st.ep_states[ep_addr.index()].out_waker.wake();
             }
             Direction::In => {
                 critical_section::with(|_| {
@@ -1189,7 +1215,7 @@ impl<'d, const MAX_EP_COUNT: usize> embassy_usb_driver::Bus for Bus<'d, MAX_EP_C
                 });
 
                 // Wake `Endpoint::wait_enabled()`
-                state.ep_states[ep_addr.index()].in_waker.wake();
+                st.ep_states[ep_addr.index()].in_waker.wake();
             }
         }
     }
@@ -1602,11 +1628,12 @@ fn ep0_mpsiz(max_packet_size: u16) -> u16 {
 }
 
 /// Hardware-dependent USB IP configuration.
-pub struct OtgInstance<'d, const MAX_EP_COUNT: usize> {
+#[derive(Copy, Clone)]
+pub struct OtgInstance<'d> {
     /// The USB peripheral.
     pub regs: Otg,
-    /// The USB state.
-    pub state: &'d State<MAX_EP_COUNT>,
+    /// Shared driver/interrupt state from [`State::as_otg_state`].
+    pub state: OtgState<'d>,
     /// FIFO depth in words.
     pub fifo_depth_words: u16,
     /// Number of used endpoints.

--- a/embassy-usb-synopsys-otg/src/lib.rs
+++ b/embassy-usb-synopsys-otg/src/lib.rs
@@ -304,11 +304,18 @@ struct EndpointData {
 /// Build from [`State::as_otg_state`].
 #[derive(Clone, Copy)]
 pub struct OtgState<'d> {
-    pub(crate) cp_state: &'d ControlPipeSetupState,
-    pub(crate) ep_states: &'d [EpState],
-    pub(crate) ep_in_alloc: &'d [UnsafeCell<Option<EndpointData>>],
-    pub(crate) ep_out_alloc: &'d [UnsafeCell<Option<EndpointData>>],
-    pub(crate) bus_waker: &'d AtomicWaker,
+    cp_state: &'d ControlPipeSetupState,
+    ep_states: &'d [EpState],
+    ep_in_alloc: &'d [UnsafeCell<Option<EndpointData>>],
+    ep_out_alloc: &'d [UnsafeCell<Option<EndpointData>>],
+    bus_waker: &'d AtomicWaker,
+}
+
+impl OtgState<'_> {
+    /// Returns the number of device endpoints supported by this state.
+    pub fn endpoint_count(&self) -> usize {
+        self.ep_states.len()
+    }
 }
 
 impl<'d> OtgState<'d> {

--- a/embassy-usb-synopsys-otg/src/lib.rs
+++ b/embassy-usb-synopsys-otg/src/lib.rs
@@ -1000,7 +1000,7 @@ impl<'d> Bus<'d> {
         }
     }
 
-    /// Deinitialize tehe device
+    /// Deinitialize the device
     pub fn deinit_device(&mut self) {
         if self.inited {
             self.inited = false;

--- a/embassy-usb-synopsys-otg/src/otg_v1.rs
+++ b/embassy-usb-synopsys-otg/src/otg_v1.rs
@@ -298,43 +298,43 @@ impl Otg {
     #[doc = "Host channel characteristics register"]
     #[inline(always)]
     pub const fn hcchar(self, n: usize) -> Reg<regs::Hcchar, RW> {
-        core::assert!(n < 12usize);
+        core::assert!(n < 16usize);
         unsafe { Reg::from_ptr(self.ptr.add(0x0500usize + n * 32usize) as _) }
     }
     #[doc = "Host channel split control register"]
     #[inline(always)]
     pub const fn hcsplt(self, n: usize) -> Reg<u32, RW> {
-        core::assert!(n < 12usize);
+        core::assert!(n < 16usize);
         unsafe { Reg::from_ptr(self.ptr.add(0x0504usize + n * 32usize) as _) }
     }
     #[doc = "Host channel interrupt register"]
     #[inline(always)]
     pub const fn hcint(self, n: usize) -> Reg<regs::Hcint, RW> {
-        core::assert!(n < 12usize);
+        core::assert!(n < 16usize);
         unsafe { Reg::from_ptr(self.ptr.add(0x0508usize + n * 32usize) as _) }
     }
     #[doc = "Host channel mask register"]
     #[inline(always)]
     pub const fn hcintmsk(self, n: usize) -> Reg<regs::Hcintmsk, RW> {
-        core::assert!(n < 12usize);
+        core::assert!(n < 16usize);
         unsafe { Reg::from_ptr(self.ptr.add(0x050cusize + n * 32usize) as _) }
     }
     #[doc = "Host channel transfer size register"]
     #[inline(always)]
     pub const fn hctsiz(self, n: usize) -> Reg<regs::Hctsiz, RW> {
-        core::assert!(n < 12usize);
+        core::assert!(n < 16usize);
         unsafe { Reg::from_ptr(self.ptr.add(0x0510usize + n * 32usize) as _) }
     }
     #[doc = "Host channel DMA address register (config for scatter/gather, ptr for buffer-dma)"]
     #[inline(always)]
     pub const fn hcdma(self, n: usize) -> Reg<regs::Hcdma, RW> {
-        core::assert!(n < 12usize);
+        core::assert!(n < 16usize);
         unsafe { Reg::from_ptr(self.ptr.add(0x0514usize + n * 32usize) as _) }
     }
     #[doc = "Host channel DMA address register (addr buffer for current transfer; used to debug ddma)"]
     #[inline(always)]
     pub const fn hcdmab(self, n: usize) -> Reg<u32, RW> {
-        core::assert!(n < 12usize);
+        core::assert!(n < 16usize);
         unsafe { Reg::from_ptr(self.ptr.add(0x051cusize + n * 32usize) as _) }
     }
     #[doc = "Device configuration register"]


### PR DESCRIPTION
This PR allows type-erasing the USB instance in HAL drivers without forcing them to use the same capacity endpoint/channel state buffer (i.e. without wasting memory for the "smaller" peripheral). This is done by introducing a type-erased state struct that holds slices and references, and also by moving the endpoint allocation buffers to the global state. This is the foundation for https://github.com/esp-rs/esp-hal/pull/5560