### PR TITLE
wpan/platform: expose borrow_aes, borrow_pka, fill_random_bytes

### DIFF
--- a/embassy-stm32-wpan/src/wba/platform.rs
+++ b/embassy-stm32-wpan/src/wba/platform.rs
@@ -141,7 +141,24 @@ impl Platform {
         }
     }
 
-    pub(crate) fn borrow_aes<R>(&self, f: impl FnOnce(&mut Aes<'static, AesPeriph, Blocking>) -> R) -> R {
+    /// Fill `buf` with random bytes from the BLE platform's RNG pipe.
+    ///
+    /// The pipe is fed by [`Self::run_rng`] using the same hardware RNG that
+    /// backs the BLE controller, so applications sharing this `Platform` for
+    /// crypto don't need a second `Rng` instance.
+    pub async fn fill_random_bytes(&self, buf: &mut [u8]) {
+        let mut filled = 0;
+        while filled < buf.len() {
+            let n = self.pipe.read(&mut buf[filled..]).await;
+            filled += n;
+        }
+    }
+
+    /// Borrow the shared AES peripheral for the duration of `f`.
+    ///
+    /// Panics if the platform was built with [`Self::new_basic`] (no AES).
+    /// Held under a critical section, so `f` should be short.
+    pub fn borrow_aes<R>(&self, f: impl FnOnce(&mut Aes<'static, AesPeriph, Blocking>) -> R) -> R {
         critical_section::with(|cs| {
             let mut aes = self
                 .aes
@@ -154,7 +171,12 @@ impl Platform {
         })
     }
 
-    pub(crate) fn borrow_pka<R>(&self, f: impl FnOnce(&mut Pka<'static, PkaPeriph>) -> R) -> R {
+    /// Borrow the shared PKA peripheral for the duration of `f`.
+    ///
+    /// Panics if the platform was built with [`Self::new_basic`] (no PKA).
+    /// Held under a critical section; long operations (e.g. P-256 ECDH) will
+    /// delay BLE LL interrupts until `f` returns.
+    pub fn borrow_pka<R>(&self, f: impl FnOnce(&mut Pka<'static, PkaPeriph>) -> R) -> R {
         critical_section::with(|cs| {
             let mut pka = self
                 .pka


### PR DESCRIPTION
## Summary

Promotes `Platform::borrow_aes` and `Platform::borrow_pka` from `pub(crate)` to `pub`, and adds a new `pub async fn fill_random_bytes` that reads from the RNG pipe fed by `run_rng`.

## Motivation

STM32WBA chips have a single AES, single PKA, and single RNG peripheral. When BLE is initialized with `Platform::new_full`, the platform takes ownership of all three. Applications that want to do their own crypto (e.g. AES-GCM for a secure transport, P-256 ECDSA for signing, etc.) currently have no way to access those peripherals — they would need a second instance, which the hardware doesn't have.

The accessors already exist internally (called from the C link-layer callbacks for AES-128 CMAC and P-256 LE Secure Connections). They guard access with a critical-section mutex, which is exactly the synchronization an application needs to share the peripheral with the BLE stack. Making them `pub` lets applications reuse this machinery instead of re-implementing it externally.

`fill_random_bytes` complements this for the RNG case: `run_rng` already holds the RNG mutex permanently and pumps bytes into a pipe for the BLE stack to consume; exposing a pipe reader lets applications draw from the same well.