### PR TITLE
Usb HID host fixes

### DIFF
--- a/embassy-usb-host/src/class/hid.rs
+++ b/embassy-usb-host/src/class/hid.rs
@@ -153,6 +153,8 @@ pub struct HidInfo {
     pub interrupt_in_ep: u8,
     /// Interrupt IN max packet size.
     pub interrupt_in_mps: u16,
+    /// Interrupt IN polling interval (from endpoint descriptor).
+    pub interrupt_in_interval: u8,
     /// Length of the HID Report Descriptor in bytes (from the HID class descriptor).
     /// Pass this to [`HidHost::fetch_report_descriptor`] as the buffer size.
     pub report_descriptor_len: u16,
@@ -189,6 +191,7 @@ pub fn find_hid(config_desc: &[u8]) -> Option<HidInfo> {
             interface_number: iface.interface_number,
             interrupt_in_ep: ep.endpoint_address,
             interrupt_in_mps: ep.max_packet_size,
+            interrupt_in_interval: ep.interval,
             report_descriptor_len: report_desc_len,
         });
     }
@@ -256,7 +259,7 @@ impl<'d, A: UsbHostAllocator<'d>> HidHost<'d, A> {
             addr: EndpointAddress::from_parts((info.interrupt_in_ep & 0x0F) as usize, UsbDirection::In),
             ep_type: EndpointType::Interrupt,
             max_packet_size: info.interrupt_in_mps,
-            interval_ms: 0,
+            interval_ms: info.interrupt_in_interval,
         };
 
         let device_address = enum_info.device_address;

--- a/embassy-usb-host/src/lib.rs
+++ b/embassy-usb-host/src/lib.rs
@@ -277,7 +277,7 @@ impl<'d, A: UsbHostAllocator<'d>> BusHandle<'d, A> {
         let ep0_info = EndpointInfo {
             addr: EndpointAddress::from_parts(0, UsbDirection::In),
             ep_type: EndpointType::Control,
-            max_packet_size: route.device_speed().max_packet_size(),
+            max_packet_size: 8,
             interval_ms: 0,
         };
 

--- a/embassy-usb-host/src/lib.rs
+++ b/embassy-usb-host/src/lib.rs
@@ -274,10 +274,13 @@ impl<'d, A: UsbHostAllocator<'d>> BusHandle<'d, A> {
 
         let addr = self.state.alloc_address().ok_or(EnumerationError::NoPipe)?;
 
+        // use smallest size "8", since some devices use lower than default for given speed.
+        const DEFAULT_MAX_PACKET_SIZE: u16 = 8;
+
         let ep0_info = EndpointInfo {
             addr: EndpointAddress::from_parts(0, UsbDirection::In),
             ep_type: EndpointType::Control,
-            max_packet_size: 8,
+            max_packet_size: DEFAULT_MAX_PACKET_SIZE,
             interval_ms: 0,
         };
 


### PR DESCRIPTION
## Changes
1. During enumeration it is possible to get a `InvalidDescriptor` error due to the device minimum packet size being 8 bytes. This PR changes the default to the minimum (8 bytes) until the actual device min is known.
2. binterval is not used for HID interrupt leading to integer overflow error.