### PR TITLE
executor: add platform-riscv64 support

### DIFF
--- a/embassy-executor/CHANGELOG.md
+++ b/embassy-executor/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 <!-- next-header -->
 ## Unreleased - ReleaseDate
 
+- Added `platform-riscv64` for RISC-V 64-bit targets (thread executor only, uses `WFI`; shares implementation with `platform-riscv32`).
+
 ## 0.10.0 - 2026-03-10
 
 - Added new metadata API for tasks.

--- a/embassy-executor/Cargo.toml
+++ b/embassy-executor/Cargo.toml
@@ -40,6 +40,12 @@ build = [
     {target = "riscv32imac-unknown-none-elf", features = ["platform-riscv32"]},
     {target = "riscv32imac-unknown-none-elf", features = ["platform-riscv32", "executor-thread"]},
     {target = "riscv32imac-unknown-none-elf", features = ["platform-riscv32", "executor-thread", "trace"]},
+    {target = "riscv64imac-unknown-none-elf", features = ["platform-riscv64"]},
+    {target = "riscv64imac-unknown-none-elf", features = ["platform-riscv64", "executor-thread"]},
+    {target = "riscv64imac-unknown-none-elf", features = ["platform-riscv64", "executor-thread", "trace"]},
+    {target = "riscv64gc-unknown-none-elf", features = ["platform-riscv64"]},
+    {target = "riscv64gc-unknown-none-elf", features = ["platform-riscv64", "executor-thread"]},
+    {target = "riscv64gc-unknown-none-elf", features = ["platform-riscv64", "executor-thread", "trace"]},
     # Nightly builds
     {group = "nightly", target = "thumbv7em-none-eabi", features = ["nightly"]},
     {group = "nightly", target = "thumbv7em-none-eabi", features = ["nightly", "log"]},
@@ -52,6 +58,10 @@ build = [
     {group = "nightly", target = "thumbv7em-none-eabi", features = ["nightly", "platform-cortex-m", "executor-thread", "executor-interrupt"]},
     {group = "nightly", target = "riscv32imac-unknown-none-elf", features = ["nightly", "platform-riscv32"]},
     {group = "nightly", target = "riscv32imac-unknown-none-elf", features = ["nightly", "platform-riscv32", "executor-thread"]},
+    {group = "nightly", target = "riscv64imac-unknown-none-elf", features = ["nightly", "platform-riscv64"]},
+    {group = "nightly", target = "riscv64imac-unknown-none-elf", features = ["nightly", "platform-riscv64", "executor-thread"]},
+    {group = "nightly", target = "riscv64gc-unknown-none-elf", features = ["nightly", "platform-riscv64"]},
+    {group = "nightly", target = "riscv64gc-unknown-none-elf", features = ["nightly", "platform-riscv64", "executor-thread"]},
     {group = "nightly", target = "armv7a-none-eabi", features = ["nightly", "platform-cortex-ar", "executor-thread"]},
     {group = "nightly", target = "avr-none", features = ["nightly", "platform-avr", "avr-device/atmega328p"], build-std = ["core", "alloc"], env = { RUSTFLAGS = "-Ctarget-cpu=atmega328p" }},
     # Xtensa builds
@@ -77,6 +87,7 @@ flavors = [
     { name = "wasm",            target = "wasm32-unknown-unknown",       features = ["platform-wasm", "executor-thread"] },
     { name = "cortex-m",        target = "thumbv7em-none-eabi",          features = ["platform-cortex-m", "executor-thread", "executor-interrupt"] },
     { name = "riscv32",         target = "riscv32imac-unknown-none-elf", features = ["platform-riscv32", "executor-thread"] },
+    { name = "riscv64",         target = "riscv64imac-unknown-none-elf", features = ["platform-riscv64", "executor-thread"] },
 ]
 
 [package.metadata.docs.rs]
@@ -156,11 +167,17 @@ platform-cortex-m = ["_platform", "dep:cortex-m"]
 ## - Only usable on **privileged mode**. 
 platform-cortex-ar = ["_platform", "dep:aarch32-cpu", "dep:arm-targets"]
 ## RISC-V 32-bit platform. Uses WFI for the thread executor. Interrupt executor is not supported.
-## 
+##
 ## - Only usable on **single-core chips**.
 ## - Only usable on **bare-metal**. Do not use this if you want to run the executor inside an RTOS thread, you must use RTOS primitives to sleep/notify the thread instead.
-## - Only usable on **privileged mode**. 
+## - Only usable on **privileged mode**.
 platform-riscv32 = ["_platform"]
+## RISC-V 64-bit platform. Uses WFI for the thread executor. Interrupt executor is not supported.
+##
+## - Only usable on **single-core chips**.
+## - Only usable on **bare-metal**. Do not use this if you want to run the executor inside an RTOS thread, you must use RTOS primitives to sleep/notify the thread instead.
+## - Only usable on **privileged mode**.
+platform-riscv64 = ["_platform"]
 ## WASM platform.
 platform-wasm = ["_platform", "dep:wasm-bindgen", "dep:js-sys"]
 ## AVR platform. Uses WFI for the thread executor. Interrupt executor is not supported.

--- a/embassy-executor/src/lib.rs
+++ b/embassy-executor/src/lib.rs
@@ -29,6 +29,7 @@ check_at_most_one!(
     "platform-cortex-m",
     "platform-cortex-ar",
     "platform-riscv32",
+    "platform-riscv64",
     "platform-std",
     "platform-wasm",
     "platform-spin",
@@ -38,7 +39,8 @@ check_at_most_one!(
 #[cfg_attr(feature = "platform-avr", path = "platform/avr.rs")]
 #[cfg_attr(feature = "platform-cortex-m", path = "platform/cortex_m.rs")]
 #[cfg_attr(feature = "platform-cortex-ar", path = "platform/cortex_ar.rs")]
-#[cfg_attr(feature = "platform-riscv32", path = "platform/riscv32.rs")]
+#[cfg_attr(feature = "platform-riscv32", path = "platform/riscv.rs")]
+#[cfg_attr(feature = "platform-riscv64", path = "platform/riscv.rs")]
 #[cfg_attr(feature = "platform-std", path = "platform/std.rs")]
 #[cfg_attr(feature = "platform-wasm", path = "platform/wasm.rs")]
 #[cfg_attr(feature = "platform-spin", path = "platform/spin.rs")]

--- a/embassy-executor/src/platform/riscv.rs
+++ b/embassy-executor/src/platform/riscv.rs
@@ -1,5 +1,5 @@
 #[cfg(feature = "executor-interrupt")]
-compile_error!("`executor-interrupt` is not supported with `arch-riscv32`.");
+compile_error!("`executor-interrupt` is not supported on RISC-V.");
 
 #[cfg(feature = "executor-thread")]
 pub use thread::*;
@@ -20,7 +20,7 @@ mod thread {
         SIGNAL_WORK_THREAD_MODE.store(true, Ordering::SeqCst);
     }
 
-    /// RISCV32 Executor
+    /// RISC-V Executor
     pub struct Executor {
         inner: raw::Executor,
         not_send: PhantomData<*mut ()>,

--- a/examples/qemu-virt-riscv64/.cargo/config.toml
+++ b/examples/qemu-virt-riscv64/.cargo/config.toml
@@ -1,0 +1,5 @@
+[target.riscv64imac-unknown-none-elf]
+runner = "qemu-system-riscv64 -machine virt -cpu rv64 -semihosting -nographic -bios none -kernel"
+
+[build]
+target = "riscv64imac-unknown-none-elf"

--- a/examples/qemu-virt-riscv64/Cargo.toml
+++ b/examples/qemu-virt-riscv64/Cargo.toml
@@ -1,0 +1,29 @@
+[package]
+edition = "2024"
+name = "embassy-qemu-virt-riscv64-examples"
+version = "0.1.0"
+license = "MIT OR Apache-2.0"
+publish = false
+
+[dependencies]
+critical-section = { version = "1.2.0", features = ["restore-state-bool"] }
+embassy-executor = { version = "0.10.0", path = "../../embassy-executor", features = ["platform-riscv64", "executor-thread"] }
+embassy-futures = { version = "0.1.2", path = "../../embassy-futures" }
+embassy-sync = { version = "0.8.0", path = "../../embassy-sync" }
+
+riscv-rt = "0.12.2"
+riscv = { version = "0.11.1", features = ["critical-section-single-hart"] }
+semihosting = { version = "0.1.25", features = ["stdio"] }
+
+[profile.dev]
+panic = "abort"
+
+[profile.release]
+debug = 2
+panic = "abort"
+
+[package.metadata.embassy]
+build = [
+  { target = "riscv64imac-unknown-none-elf", artifact-dir = "out/examples/qemu-virt-riscv64" },
+  { target = "riscv64gc-unknown-none-elf",   artifact-dir = "out/examples/qemu-virt-riscv64" },
+]

--- a/examples/qemu-virt-riscv64/README.md
+++ b/examples/qemu-virt-riscv64/README.md
@@ -1,0 +1,78 @@
+# Examples for RISC-V 64 (in QEMU `virt`)
+
+These examples target a generic RV64IMAC core running on QEMU's `virt`
+machine and exercise the `platform-riscv64` thread executor.
+
+Run individual examples with:
+
+```sh
+cargo run --bin <crate-name>
+```
+
+for example:
+
+```sh
+cargo run --bin hello
+```
+
+Expected output:
+
+```
+Hello from embassy-executor on RISC-V 64!
+Hello from a spawned task!
+Goodbye.
+```
+
+QEMU then exits with status 0 via the semihosting `SYS_EXIT` call.
+
+## Checklist before running examples
+
+Before running these examples, you will need:
+
+* `qemu-system-riscv64` on your `PATH` (typically packaged as `qemu-system-misc`
+  on Debian/Ubuntu, `qemu-system-riscv` on Fedora/Arch, or `qemu` from Homebrew).
+
+The runner is configured in `.cargo/config.toml`:
+
+```
+qemu-system-riscv64 -machine virt -cpu rv64 -semihosting -nographic -bios none -kernel <elf>
+```
+
+`-bios none` is important: it skips OpenSBI so the kernel ELF is loaded
+directly at `0x80000000` (the start of RAM on the `virt` machine), which
+matches `memory.x`.
+
+## Running manually
+
+If `cargo run` does not pick up the runner for some reason, you can invoke
+QEMU directly:
+
+```sh
+cargo build --bin hello --release
+qemu-system-riscv64 \
+    -machine virt -cpu rv64 \
+    -semihosting -nographic -bios none \
+    -kernel target/riscv64imac-unknown-none-elf/release/hello
+```
+
+Press `Ctrl-A X` to terminate QEMU if a program hangs.
+
+## Verified QEMU CPU profiles
+
+The example is verified end-to-end against the following `qemu-system-riscv64
+-cpu` profiles. Run `./test-cpus.sh` to reproduce — it builds the binary for
+both Rust toolchain targets and asserts that stdout matches exactly and QEMU
+exits with status 0 for every supported combination.
+
+| Toolchain target               | CPU profiles                                                      |
+|--------------------------------|-------------------------------------------------------------------|
+| `riscv64imac-unknown-none-elf` | `rv64`, `sifive-u54`, `sifive-e51`, `thead-c906`, `veyron-v1`, `max` |
+| `riscv64gc-unknown-none-elf`   | `rv64`, `sifive-u54`, `thead-c906`, `veyron-v1`, `max`            |
+
+`riscv64gc` requires F+D extensions, so it is not run against `sifive-e51`
+(which is RV64IMAC only). That binary will trap during `riscv-rt`'s
+floating-point initialisation on a core without F/D — it's an architectural
+mismatch, not an executor bug.
+
+The `thead-c906` profile prints a benign QEMU-side warning about disabling
+the Zfa extension; the program runs to completion regardless.

--- a/examples/qemu-virt-riscv64/build.rs
+++ b/examples/qemu-virt-riscv64/build.rs
@@ -1,0 +1,23 @@
+use std::env;
+use std::fs::File;
+use std::io::Write;
+use std::path::PathBuf;
+
+fn main() {
+    let out = PathBuf::from(env::var_os("OUT_DIR").unwrap());
+    for (name, bytes) in [
+        ("memory.x", include_bytes!("memory.x").as_slice()),
+        ("no-unwind.x", include_bytes!("no-unwind.x").as_slice()),
+    ] {
+        File::create(out.join(name)).unwrap().write_all(bytes).unwrap();
+        println!("cargo:rerun-if-changed={name}");
+    }
+    println!("cargo:rustc-link-search={}", out.display());
+
+    // Order matters: `no-unwind.x` runs `/DISCARD/` on `.eh_frame` before
+    // `riscv-rt`'s `link.x` can place those sections at the default VMA, which
+    // would cause `R_RISCV_32_PCREL` overflow against `.text` at 0x80000000.
+    println!("cargo:rustc-link-arg-bins=-Tmemory.x");
+    println!("cargo:rustc-link-arg-bins=-Tno-unwind.x");
+    println!("cargo:rustc-link-arg-bins=-Tlink.x");
+}

--- a/examples/qemu-virt-riscv64/memory.x
+++ b/examples/qemu-virt-riscv64/memory.x
@@ -1,0 +1,21 @@
+/* QEMU `virt` machine: 128 MB of RAM at 0x80000000.
+ * With `-bios none`, the kernel ELF is loaded directly at the start of RAM
+ * and execution begins at its entry point (provided by riscv-rt).
+ *
+ * Use only the first 16 MB for our binary. QEMU places the device tree blob
+ * near the top of the configured RAM, so claiming all 128 MB for `.stack`
+ * causes a ROM-region overlap with the FDT.
+ */
+MEMORY
+{
+  RAM : ORIGIN = 0x80000000, LENGTH = 16M
+}
+
+REGION_ALIAS("REGION_TEXT", RAM);
+REGION_ALIAS("REGION_RODATA", RAM);
+REGION_ALIAS("REGION_DATA", RAM);
+REGION_ALIAS("REGION_BSS", RAM);
+REGION_ALIAS("REGION_HEAP", RAM);
+REGION_ALIAS("REGION_STACK", RAM);
+
+_stack_start = ORIGIN(RAM) + LENGTH(RAM) - 8;

--- a/examples/qemu-virt-riscv64/no-unwind.x
+++ b/examples/qemu-virt-riscv64/no-unwind.x
@@ -1,0 +1,22 @@
+/* Discard `.eh_frame` and `.eh_frame_hdr`.
+ *
+ * These sections are emitted by the prebuilt `libcore` and `compiler_builtins`
+ * rlibs the toolchain ships, regardless of `panic = "abort"` or
+ * `-C force-unwind-tables=no`. In a `no_std`, `panic = "abort"` binary
+ * nothing walks them, so they're dead weight.
+ *
+ * Dropping them here also sidesteps a hard linker error on `riscv64` when
+ * `.text` lives at a high address: `riscv-rt`'s `link.x` places these
+ * sections at the default VMA (~0), so `R_RISCV_32_PCREL` fixups inside
+ * `.eh_frame` cannot reach `.text` at `0x80000000` (= 2 GiB, the edge of
+ * signed 32-bit) and the link fails.
+ *
+ * Passed to the linker via `-T` *before* `link.x` so `/DISCARD/` removes
+ * the input sections before `riscv-rt`'s script can place them.
+ */
+SECTIONS {
+  /DISCARD/ : {
+    *(.eh_frame .eh_frame.*)
+    *(.eh_frame_hdr)
+  }
+}

--- a/examples/qemu-virt-riscv64/src/bin/hello.rs
+++ b/examples/qemu-virt-riscv64/src/bin/hello.rs
@@ -1,0 +1,32 @@
+#![no_std]
+#![no_main]
+
+use embassy_executor::Spawner;
+use embassy_sync::blocking_mutex::raw::CriticalSectionRawMutex;
+use embassy_sync::signal::Signal;
+use semihosting::println;
+
+#[panic_handler]
+fn panic(info: &core::panic::PanicInfo) -> ! {
+    println!("PANIC: {}", info);
+    semihosting::process::exit(1);
+}
+
+static DONE: Signal<CriticalSectionRawMutex, ()> = Signal::new();
+
+#[embassy_executor::task]
+async fn say_hello_from_task() {
+    println!("Hello from a spawned task!");
+    DONE.signal(());
+}
+
+#[embassy_executor::main]
+async fn main(spawner: Spawner) {
+    println!("Hello from embassy-executor on RISC-V 64!");
+    spawner.spawn(say_hello_from_task().unwrap());
+    // Wait for the spawned task to actually run; this also exercises
+    // cross-task wakeups through the executor's pender.
+    DONE.wait().await;
+    println!("Goodbye.");
+    semihosting::process::exit(0);
+}

--- a/examples/qemu-virt-riscv64/test-cpus.sh
+++ b/examples/qemu-virt-riscv64/test-cpus.sh
@@ -1,0 +1,76 @@
+#!/usr/bin/env bash
+# Build the hello example for both RV64 toolchain targets and run each binary
+# under qemu-system-riscv64 against every compatible CPU profile QEMU exposes,
+# verifying that stdout exactly matches the expected semihosting output and
+# that QEMU exits cleanly via the program's `process::exit(0)`.
+#
+# Run from anywhere; the script cd's into its own directory.
+
+set -euo pipefail
+
+cd -- "$(dirname -- "$0")"
+
+if ! command -v qemu-system-riscv64 >/dev/null 2>&1; then
+    echo "qemu-system-riscv64 not found on PATH; install it (e.g. apt install qemu-system-misc) and re-run." >&2
+    exit 2
+fi
+
+EXPECTED=$'Hello from embassy-executor on RISC-V 64!\nHello from a spawned task!\nGoodbye.'
+
+# Targets and the CPUs each one is compatible with.
+#
+# `riscv64imac` is RV64IMAC and runs on every CPU QEMU emulates, including
+# embedded cores like sifive-e51 that have no F/D extensions.
+#
+# `riscv64gc` adds F+D, so it cannot run on cores without floating point;
+# sifive-e51 is RV64IMAC and is excluded for that reason.
+IMAC_CPUS=(rv64 sifive-u54 sifive-e51 thead-c906 veyron-v1 max)
+GC_CPUS=(rv64 sifive-u54              thead-c906 veyron-v1 max)
+
+build_target() {
+    local target="$1"
+    echo "== building hello for $target =="
+    cargo build --release --target "$target" --bin hello >/dev/null
+}
+
+run_one() {
+    local target="$1" cpu="$2" bin="$3"
+    local out code
+    set +e
+    # -display/-serial/-monitor none keeps semihosting independent of stdio;
+    # plain -nographic muxes serial+monitor onto stdio and hangs under a TTY.
+    out=$(timeout 10 qemu-system-riscv64 -machine virt -cpu "$cpu" \
+            -semihosting -display none -serial none -monitor none \
+            -bios none -kernel "$bin" 2>/dev/null)
+    code=$?
+    set -e
+    if [ "$code" = "0" ] && [ "$out" = "$EXPECTED" ]; then
+        printf '  %-12s  cpu=%-12s  PASS\n' "$target" "$cpu"
+        return 0
+    else
+        printf '  %-12s  cpu=%-12s  FAIL  (exit %s)\n' "$target" "$cpu" "$code"
+        printf '    --- got ---\n%s\n    -----------\n' "$out"
+        return 1
+    fi
+}
+
+build_target riscv64imac-unknown-none-elf
+build_target riscv64gc-unknown-none-elf
+
+IMAC_BIN=target/riscv64imac-unknown-none-elf/release/hello
+GC_BIN=target/riscv64gc-unknown-none-elf/release/hello
+
+echo
+echo "== running matrix =="
+
+pass=0; fail=0
+for cpu in "${IMAC_CPUS[@]}"; do
+    if run_one riscv64imac "$cpu" "$IMAC_BIN"; then pass=$((pass+1)); else fail=$((fail+1)); fi
+done
+for cpu in "${GC_CPUS[@]}"; do
+    if run_one riscv64gc   "$cpu" "$GC_BIN";   then pass=$((pass+1)); else fail=$((fail+1)); fi
+done
+
+echo
+echo "Total: $pass pass / $fail fail"
+[ "$fail" = "0" ]

--- a/rust-toolchain-nightly.toml
+++ b/rust-toolchain-nightly.toml
@@ -8,6 +8,8 @@ targets = [
     "thumbv7em-none-eabihf",
     "thumbv8m.main-none-eabihf",
     "riscv32imac-unknown-none-elf",
+    "riscv64imac-unknown-none-elf",
+    "riscv64gc-unknown-none-elf",
     "wasm32-unknown-unknown",
     "armv7a-none-eabi",
 ]

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -8,6 +8,8 @@ targets = [
     "thumbv7em-none-eabihf",
     "thumbv8m.main-none-eabihf",
     "riscv32imac-unknown-none-elf",
+    "riscv64imac-unknown-none-elf",
+    "riscv64gc-unknown-none-elf",
     "wasm32-unknown-unknown",
     "armv7a-none-eabi",
     "armv7r-none-eabi",


### PR DESCRIPTION
Adds a `platform-riscv64` Cargo feature to `embassy-executor` for RISC-V 64-bit targets, sharing implementation with `platform-riscv32` via a single `platform/riscv.rs` thread module (WFI-based; interrupt executor unsupported). Both feature gates point at the same source file; instruction-set selection is driven by `--target`, matching how the Cortex-M and Cortex-A/R platform modules already cover multiple sub-architectures from one file.