### PR TITLE
STM32N6 fix PLL output frequency calculation

### DIFF
--- a/embassy-stm32/src/rcc/n6.rs
+++ b/embassy-stm32/src/rcc/n6.rs
@@ -774,7 +774,7 @@ fn init_pll(pll_config: Option<Pll>, pll_index: usize, input: &PllInput) -> PllO
                 divn: Some(Hertz(n)),
                 divp1: Some(Hertz(p1)),
                 divp2: Some(Hertz(p2)),
-                output: Some(Hertz(in_clk.0 / m * n / p1)),
+                output: Some(Hertz(in_clk.0 / m * n / p1 / p2)),
             }
         }
         Some(Pll::Bypass { source }) => {


### PR DESCRIPTION
According to chapter 14.6.5 of RM0486, PLL post-dividers POSTDIV1 and POSTDIV2 both contribute to output frequency but the implemented formula only accounts for POSTDIV1.

<img width="1083" height="851" alt="image" src="https://github.com/user-attachments/assets/1f13e56f-756c-4977-86d8-be9c02b40f81" />

This PR proposes to include POSTDIV2 in the output frequency calculation