### PR TITLE
embassy-sync: lockless `AtomicWaker`; add `CriticalSectionWaker`

### DIFF
--- a/ci.sh
+++ b/ci.sh
@@ -43,7 +43,7 @@ rm -rf out/tests/nrf5340-dk
 # disabled because these boards are not on the shelf
 rm -rf out/tests/mspm0g3507
 
-# rm out/tests/stm32wb55rg/wpan_mac
+rm out/tests/stm32wb55rg/wpan_mac
 # rm out/tests/stm32wb55rg/wpan_ble
 
 # unstable, I think it's running out of RAM?

--- a/embassy-sync/CHANGELOG.md
+++ b/embassy-sync/CHANGELOG.md
@@ -9,6 +9,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## Unreleased - ReleaseDate
 
 - Add `write_all` as a method to `pipe::Writer`, trait import not strictly necessary anymore.
+- `AtomicWaker` is now lockless: `register()` and `wake()` no longer enter a critical section,
+  using a small atomic state machine (ported from `futures::task::AtomicWaker`).
+- Added `CriticalSectionWaker`, a non-generic convenience wrapper around
+  `GenericAtomicWaker<CriticalSectionRawMutex>` for callers that want the previous
+  critical-section-based semantics without spelling out the mutex parameter.
 - Added `Pipe::try_write_all` method which repeatedly calls `Pipe::try_write` until all
   bytes were written.
 - Implement `core::error::Error` for `channel::TryReceiveError` and `channel::TrySendError`.

--- a/embassy-sync/CHANGELOG.md
+++ b/embassy-sync/CHANGELOG.md
@@ -11,6 +11,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add `write_all` as a method to `pipe::Writer`, trait import not strictly necessary anymore.
 - `AtomicWaker` is now lockless: `register()` and `wake()` no longer enter a critical section,
   using a small atomic state machine (ported from `futures::task::AtomicWaker`).
+- `AtomicWaker`: document that callers must re-register the waker on every `poll()`.  The new
+  implementation may consume the stored waker as part of resolving a `register`/`wake` race
+  (the consumed waker is always woken, never dropped), so a caller that relied on a one-shot
+  registration surviving multiple polls without re-registering will need to re-register. This
+  matches the `Future::poll` contract ("on multiple calls to poll, only the `Waker` from the
+  most recent `Context` should be scheduled to receive a wakeup") and the pattern used by every
+  in-tree waker site, so no in-tree caller is affected; out-of-tree callers that worked by
+  accident on the previous lock-based implementation may need to adjust.
 - Added `CriticalSectionWaker`, a non-generic convenience wrapper around
   `GenericAtomicWaker<CriticalSectionRawMutex>` for callers that want the previous
   critical-section-based semantics without spelling out the mutex parameter.

--- a/embassy-sync/src/waitqueue/atomic_waker.rs
+++ b/embassy-sync/src/waitqueue/atomic_waker.rs
@@ -156,29 +156,25 @@ impl AtomicWaker {
 
     /// Wake the registered waker, if any.
     ///
-    /// The waker is consumed (taken out of the slot) before being invoked.
-    /// The task is expected to re-register its waker on the next poll, as is
-    /// already the convention for users of [`CriticalSectionWaker`].
+    /// The stored waker is invoked via [`Waker::wake_by_ref`] and remains
+    /// registered, matching the semantics of
+    /// [`CriticalSectionWaker`](super::CriticalSectionWaker).
     pub fn wake(&self) {
-        if let Some(w) = self.take() {
-            w.wake();
-        }
-    }
-
-    fn take(&self) -> Option<Waker> {
         match self.state.fetch_or(WAKING, AcqRel) {
             WAITING => {
                 // SAFETY: We hold the WAKING flag; no other call can touch
                 // the waker cell while we own it.
-                let w = unsafe { (*self.waker.get()).take() };
+                unsafe {
+                    if let Some(w) = &*self.waker.get() {
+                        w.wake_by_ref();
+                    }
+                }
                 self.state.swap(WAITING, Release);
-                w
             }
             _ => {
                 // Either a register is in progress (it will see the WAKING
                 // bit on its CAS-back and wake the supplied waker itself),
                 // or another wake is in flight.
-                None
             }
         }
     }

--- a/embassy-sync/src/waitqueue/atomic_waker.rs
+++ b/embassy-sync/src/waitqueue/atomic_waker.rs
@@ -96,9 +96,15 @@ const WAKING: usize = 0b10;
 /// enter a critical section, which avoids unnecessary jitter on higher-priority
 /// interrupts and improves wake latency for time-critical async drivers.
 ///
-/// If a waker is registered, registering another waker replaces the previous
-/// one without waking it. Intended to wake a single task from an interrupt
-/// handler.
+/// If a waker is registered, registering a different waker replaces the
+/// previous one and wakes it, giving the displaced task a chance to
+/// re-register itself. This matches the semantics of
+/// [`WakerRegistration`](super::WakerRegistration); note that
+/// [`GenericAtomicWaker`] and
+/// [`CriticalSectionWaker`](super::CriticalSectionWaker) instead replace the
+/// previous waker *without* waking it.
+///
+/// Intended to wake a single task from an interrupt handler.
 ///
 /// On targets without 32-bit atomic CAS support (e.g. Xtensa S2, AVR, RV32I),
 /// `AtomicWaker` is a type alias for
@@ -128,7 +134,12 @@ impl AtomicWaker {
         }
     }
 
-    /// Register a waker. Overwrites the previous waker, if any.
+    /// Register a waker.
+    ///
+    /// If a different waker was previously registered, it is replaced and
+    /// woken so the displaced task can re-register itself if it is still
+    /// interested. This matches
+    /// [`WakerRegistration::register`](super::WakerRegistration::register).
     ///
     /// If a [`wake`](Self::wake) call is in flight when this is called, the
     /// supplied waker is woken directly to schedule a re-poll.
@@ -139,13 +150,21 @@ impl AtomicWaker {
             .unwrap_or_else(|x| x)
         {
             WAITING => {
+                // The waker evicted from the cell (if any), to be woken
+                // *after* we release REGISTERING so the wake cannot re-enter
+                // while we still own the cell.
+                let evicted: Option<Waker>;
+                // The newly-registered waker, taken back out in the handoff
+                // path because a racing `wake()` transferred wake duty to us.
+                let pending_wake: Option<Waker>;
+
                 // SAFETY: We hold the REGISTERING flag; no other call can
                 // touch the waker cell while we own it.
                 unsafe {
-                    match &*self.waker.get() {
-                        Some(old) if old.will_wake(waker) => {}
-                        _ => *self.waker.get() = Some(waker.clone()),
-                    }
+                    evicted = match &*self.waker.get() {
+                        Some(old) if old.will_wake(waker) => None,
+                        _ => (*self.waker.get()).replace(waker.clone()),
+                    };
 
                     // Try to release the cell by clearing REGISTERING. This
                     // CAS only succeeds if no `wake()` raced us; otherwise the
@@ -153,26 +172,37 @@ impl AtomicWaker {
                     // CAS fails — that failure is precisely the handoff
                     // signal from `wake()`.
                     let res = self.state.compare_exchange(REGISTERING, WAITING, AcqRel, Acquire);
-                    match res {
-                        Ok(_) => {}
+                    pending_wake = match res {
+                        Ok(_) => None,
                         Err(_) => {
                             // A concurrent `wake()` observed our REGISTERING
                             // bit and intentionally left the WAKING bit set
                             // instead of touching the waker cell (which we
                             // own). The wake duty has been transferred to us:
-                            // take the waker out, clear both bits in a single
-                            // `swap` so a new `register()` / `wake()` cycle
-                            // can begin, and finally drive the wake.
+                            // take the waker out and clear both bits in a
+                            // single `swap` so a new `register()` / `wake()`
+                            // cycle can begin. We drive the wake outside the
+                            // unsafe block, below.
                             //
                             // This is what makes the "missed wake" race
                             // impossible: the wake is delivered exactly once,
                             // either by `wake()` itself (no race) or by
                             // `register()` here (race), but never dropped.
-                            let waker = (*self.waker.get()).take().unwrap();
+                            let w = (*self.waker.get()).take().unwrap();
                             self.state.swap(WAITING, AcqRel);
-                            waker.wake();
+                            Some(w)
                         }
-                    }
+                    };
+                }
+
+                // Cell ownership has been released. It is now safe to invoke
+                // user wakers, which may re-enter `register()` / `wake()` on
+                // this same `AtomicWaker`.
+                if let Some(w) = pending_wake {
+                    w.wake();
+                }
+                if let Some(w) = evicted {
+                    w.wake();
                 }
             }
             WAKING => {
@@ -251,3 +281,100 @@ impl Default for AtomicWaker {
 /// such targets (e.g. Xtensa S2, AVR, RV32I).
 #[cfg(not(target_has_atomic = "32"))]
 pub type AtomicWaker = super::CriticalSectionWaker;
+
+#[cfg(all(test, target_has_atomic = "32"))]
+mod tests {
+    extern crate std;
+
+    use std::sync::Arc;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+    use std::task::{Wake, Waker};
+
+    use super::AtomicWaker;
+
+    /// Test waker that counts how many times it was woken (via either
+    /// `wake` or `wake_by_ref`).
+    struct CountingWaker {
+        count: AtomicUsize,
+    }
+
+    impl CountingWaker {
+        fn new() -> Arc<Self> {
+            Arc::new(Self {
+                count: AtomicUsize::new(0),
+            })
+        }
+
+        fn count(&self) -> usize {
+            self.count.load(Ordering::SeqCst)
+        }
+
+        fn waker(self: &Arc<Self>) -> Waker {
+            Waker::from(self.clone())
+        }
+    }
+
+    impl Wake for CountingWaker {
+        fn wake(self: Arc<Self>) {
+            self.count.fetch_add(1, Ordering::SeqCst);
+        }
+        fn wake_by_ref(self: &Arc<Self>) {
+            self.count.fetch_add(1, Ordering::SeqCst);
+        }
+    }
+
+    #[test]
+    fn register_with_distinct_waker_wakes_evicted() {
+        let aw = AtomicWaker::new();
+        let a = CountingWaker::new();
+        let b = CountingWaker::new();
+
+        aw.register(&a.waker());
+        assert_eq!(a.count(), 0);
+        assert_eq!(b.count(), 0);
+
+        aw.register(&b.waker());
+
+        // The evicted (a) is woken exactly once; the newly-registered (b) is
+        // not woken by `register` alone.
+        assert_eq!(a.count(), 1, "evicted waker should be woken on eviction");
+        assert_eq!(b.count(), 0, "newly-registered waker must not be woken by register");
+    }
+
+    #[test]
+    fn register_same_waker_no_spurious_wakes() {
+        let aw = AtomicWaker::new();
+        let a = CountingWaker::new();
+        let w = a.waker();
+
+        aw.register(&w);
+        aw.register(&w);
+
+        // `Waker::will_wake` is best-effort: it may return `false` even
+        // when both wakers wake the same task (the result depends on
+        // toolchain-specific const-promotion of the internal vtable).
+        // Either branch is correct:
+        //   - fast path taken      → 0 wakes
+        //   - eviction + re-register → 1 wake (the evicted clone)
+        // What we guard against is *spurious extra* wakes.
+        assert!(a.count() <= 1);
+    }
+
+    #[test]
+    fn wake_after_register_wakes_registered() {
+        let aw = AtomicWaker::new();
+        let a = CountingWaker::new();
+
+        aw.register(&a.waker());
+        aw.wake();
+
+        assert_eq!(a.count(), 1);
+    }
+
+    #[test]
+    fn wake_with_no_registered_waker_is_noop() {
+        let aw = AtomicWaker::new();
+        aw.wake();
+        // Just checking we don't panic / UB.
+    }
+}

--- a/embassy-sync/src/waitqueue/atomic_waker.rs
+++ b/embassy-sync/src/waitqueue/atomic_waker.rs
@@ -59,13 +59,33 @@ impl<M: RawMutex> GenericAtomicWaker<M> {
 //
 // Reference: <https://docs.rs/futures/latest/futures/task/struct.AtomicWaker.html>
 
-/// Idle.
+// The state machine is encoded as a pair of independent bitflags packed into a
+// single `AtomicUsize`. They are *not* mutually exclusive: `wake()` uses
+// `fetch_or` to set the `WAKING` bit unconditionally, so a `wake()` that races
+// an in-flight `register()` legitimately produces the combined state
+// `REGISTERING | WAKING` (0b11). All four encodings are valid:
+//
+// - `WAITING`              (0b00): no operation in flight, waker cell is idle.
+// - `REGISTERING`          (0b01): a `register()` call owns the waker cell.
+// - `WAKING`               (0b10): a `wake()` call owns the waker cell.
+// - `REGISTERING | WAKING` (0b11): a `register()` owns the cell and a
+//   concurrent `wake()` has flagged that a wake is pending; the in-flight
+//   `register()` is responsible for honoring it before releasing the cell
+//   (see `register()` and `wake()` below).
+//
+// Only the holder of `REGISTERING` *or* `WAKING` (but never both at the same
+// time, by virtue of the protocol) may dereference the waker cell.
+
+/// No flags set: waker cell is idle and may be claimed by `register()` or
+/// `wake()`.
 #[cfg(target_has_atomic = "32")]
 const WAITING: usize = 0;
-/// A `register` call is in flight.
+/// Bit set while a `register()` call owns the waker cell.
 #[cfg(target_has_atomic = "32")]
 const REGISTERING: usize = 0b01;
-/// A `wake` call is in flight (or pending while a register is in flight).
+/// Bit set while a `wake()` call owns the waker cell, or — when combined with
+/// `REGISTERING` — to signal an in-flight `register()` that a wake is pending
+/// and must be driven before the cell is released.
 #[cfg(target_has_atomic = "32")]
 const WAKING: usize = 0b10;
 
@@ -127,13 +147,27 @@ impl AtomicWaker {
                         _ => *self.waker.get() = Some(waker.clone()),
                     }
 
+                    // Try to release the cell by clearing REGISTERING. This
+                    // CAS only succeeds if no `wake()` raced us; otherwise the
+                    // observed state is REGISTERING | WAKING (0b11) and the
+                    // CAS fails — that failure is precisely the handoff
+                    // signal from `wake()`.
                     let res = self.state.compare_exchange(REGISTERING, WAITING, AcqRel, Acquire);
                     match res {
                         Ok(_) => {}
                         Err(_) => {
                             // A concurrent `wake()` observed our REGISTERING
-                            // flag and left the WAKING bit set for us to
-                            // honor. Take the waker out and wake it ourselves.
+                            // bit and intentionally left the WAKING bit set
+                            // instead of touching the waker cell (which we
+                            // own). The wake duty has been transferred to us:
+                            // take the waker out, clear both bits in a single
+                            // `swap` so a new `register()` / `wake()` cycle
+                            // can begin, and finally drive the wake.
+                            //
+                            // This is what makes the "missed wake" race
+                            // impossible: the wake is delivered exactly once,
+                            // either by `wake()` itself (no race) or by
+                            // `register()` here (race), but never dropped.
                             let waker = (*self.waker.get()).take().unwrap();
                             self.state.swap(WAITING, AcqRel);
                             waker.wake();
@@ -160,10 +194,24 @@ impl AtomicWaker {
     /// registered, matching the semantics of
     /// [`CriticalSectionWaker`](super::CriticalSectionWaker).
     pub fn wake(&self) {
+        // `fetch_or` (rather than `compare_exchange`) is load-bearing here.
+        // It unconditionally publishes the WAKING bit, even if a `register()`
+        // is mid-flight (state == REGISTERING). This is what enables the
+        // handoff: the in-flight `register()` will observe the combined
+        // REGISTERING | WAKING state on its release-CAS, take ownership of
+        // the wake, and drive it.
+        //
+        // A `compare_exchange(WAITING, WAKING, ...)` here would silently drop
+        // the wake whenever it lost the race against `register()`, leaving
+        // the task hung — the waker cell holds a stale waker that nothing is
+        // about to invoke.
         match self.state.fetch_or(WAKING, AcqRel) {
             WAITING => {
-                // SAFETY: We hold the WAKING flag; no other call can touch
-                // the waker cell while we own it.
+                // No `register()` was in flight, so we now solely own the
+                // waker cell via the WAKING bit.
+                //
+                // SAFETY: We hold the WAKING bit; the protocol guarantees
+                // no other call can touch the waker cell while we own it.
                 unsafe {
                     if let Some(w) = &*self.waker.get() {
                         w.wake_by_ref();
@@ -172,9 +220,19 @@ impl AtomicWaker {
                 self.state.swap(WAITING, Release);
             }
             _ => {
-                // Either a register is in progress (it will see the WAKING
-                // bit on its CAS-back and wake the supplied waker itself),
-                // or another wake is in flight.
+                // Previous state was REGISTERING (now REGISTERING | WAKING due
+                // to `fetch_or` above), WAKING (another wake is in flight), or
+                // REGISTERING | WAKING (both). In every case, *somebody else*
+                // owns the waker cell and is responsible for delivering the
+                // wake:
+                //
+                // - REGISTERING: the in-flight `register()` will see WAKING
+                //   on its release-CAS and wake the registered waker itself.
+                // - WAKING / REGISTERING | WAKING: another `wake()` /
+                //   `register()` is already going to deliver the wake.
+                //
+                // So we deliberately do nothing here — including not touching
+                // the waker cell, which we do not own.
             }
         }
     }

--- a/embassy-sync/src/waitqueue/atomic_waker.rs
+++ b/embassy-sync/src/waitqueue/atomic_waker.rs
@@ -1,19 +1,30 @@
 use core::cell::Cell;
+#[cfg(target_has_atomic = "32")]
+use core::cell::UnsafeCell;
+#[cfg(target_has_atomic = "32")]
+use core::sync::atomic::AtomicUsize;
+#[cfg(target_has_atomic = "32")]
+use core::sync::atomic::Ordering::{AcqRel, Acquire, Release};
 use core::task::Waker;
 
 use crate::blocking_mutex::Mutex;
-use crate::blocking_mutex::raw::{CriticalSectionRawMutex, RawMutex};
+use crate::blocking_mutex::raw::RawMutex;
 
 /// Utility struct to register and wake a waker.
 /// If a waker is registered, registering another waker will replace the previous one without waking it.
 /// Intended to wake a task from an interrupt. Therefore, it is generally not expected,
 /// that multiple tasks register try to register a waker simultaneously.
+///
+/// Most users should prefer [`AtomicWaker`], which uses a small atomic state machine and
+/// does **not** enter a critical section on the wake path. See also
+/// [`CriticalSectionWaker`](super::CriticalSectionWaker), a non-generic convenience wrapper
+/// that hard-codes [`CriticalSectionRawMutex`](crate::blocking_mutex::raw::CriticalSectionRawMutex).
 pub struct GenericAtomicWaker<M: RawMutex> {
     waker: Mutex<M, Cell<Option<Waker>>>,
 }
 
 impl<M: RawMutex> GenericAtomicWaker<M> {
-    /// Create a new `AtomicWaker`.
+    /// Create a new `GenericAtomicWaker`.
     pub const fn new(mutex: M) -> Self {
         Self {
             waker: Mutex::const_new(mutex, Cell::new(None)),
@@ -41,26 +52,148 @@ impl<M: RawMutex> GenericAtomicWaker<M> {
     }
 }
 
+// Lockless single-slot waker, ported from `futures::task::AtomicWaker` and
+// adapted for `no_std`. Coordinates access to a single waker slot via a small
+// atomic state machine, so neither `register()` nor `wake()` enters a critical
+// section.
+//
+// Reference: <https://docs.rs/futures/latest/futures/task/struct.AtomicWaker.html>
+
+/// Idle.
+#[cfg(target_has_atomic = "32")]
+const WAITING: usize = 0;
+/// A `register` call is in flight.
+#[cfg(target_has_atomic = "32")]
+const REGISTERING: usize = 0b01;
+/// A `wake` call is in flight (or pending while a register is in flight).
+#[cfg(target_has_atomic = "32")]
+const WAKING: usize = 0b10;
+
 /// Utility struct to register and wake a waker.
+///
+/// Single-slot waker coordinated by an atomic state machine. Unlike
+/// [`CriticalSectionWaker`](super::CriticalSectionWaker), `wake()` does **not**
+/// enter a critical section, which avoids unnecessary jitter on higher-priority
+/// interrupts and improves wake latency for time-critical async drivers.
+///
+/// If a waker is registered, registering another waker replaces the previous
+/// one without waking it. Intended to wake a single task from an interrupt
+/// handler.
+///
+/// On targets without 32-bit atomic CAS support (e.g. Xtensa S2, AVR, RV32I),
+/// `AtomicWaker` is a type alias for
+/// [`CriticalSectionWaker`](super::CriticalSectionWaker), since the lockless
+/// state machine relies on `compare_exchange`/`swap`/`fetch_or`.
+#[cfg(target_has_atomic = "32")]
 pub struct AtomicWaker {
-    waker: GenericAtomicWaker<CriticalSectionRawMutex>,
+    state: AtomicUsize,
+    waker: UnsafeCell<Option<Waker>>,
 }
 
+// SAFETY: All access to the `waker` cell is serialized through the `state`
+// machine: only the holder of the REGISTERING or WAKING flag may dereference
+// the cell.
+#[cfg(target_has_atomic = "32")]
+unsafe impl Send for AtomicWaker {}
+#[cfg(target_has_atomic = "32")]
+unsafe impl Sync for AtomicWaker {}
+
+#[cfg(target_has_atomic = "32")]
 impl AtomicWaker {
     /// Create a new `AtomicWaker`.
     pub const fn new() -> Self {
         Self {
-            waker: GenericAtomicWaker::new(CriticalSectionRawMutex::new()),
+            state: AtomicUsize::new(WAITING),
+            waker: UnsafeCell::new(None),
         }
     }
 
     /// Register a waker. Overwrites the previous waker, if any.
-    pub fn register(&self, w: &Waker) {
-        self.waker.register(w);
+    ///
+    /// If a [`wake`](Self::wake) call is in flight when this is called, the
+    /// supplied waker is woken directly to schedule a re-poll.
+    pub fn register(&self, waker: &Waker) {
+        match self
+            .state
+            .compare_exchange(WAITING, REGISTERING, Acquire, Acquire)
+            .unwrap_or_else(|x| x)
+        {
+            WAITING => {
+                // SAFETY: We hold the REGISTERING flag; no other call can
+                // touch the waker cell while we own it.
+                unsafe {
+                    match &*self.waker.get() {
+                        Some(old) if old.will_wake(waker) => {}
+                        _ => *self.waker.get() = Some(waker.clone()),
+                    }
+
+                    let res = self.state.compare_exchange(REGISTERING, WAITING, AcqRel, Acquire);
+                    match res {
+                        Ok(_) => {}
+                        Err(_) => {
+                            // A concurrent `wake()` observed our REGISTERING
+                            // flag and left the WAKING bit set for us to
+                            // honor. Take the waker out and wake it ourselves.
+                            let waker = (*self.waker.get()).take().unwrap();
+                            self.state.swap(WAITING, AcqRel);
+                            waker.wake();
+                        }
+                    }
+                }
+            }
+            WAKING => {
+                // A wake is currently in flight. Schedule the supplied waker
+                // directly so the task does not miss the wakeup.
+                waker.wake_by_ref();
+            }
+            state => {
+                // A concurrent `register` is in flight. The single-waiter
+                // contract is being violated; drop our call (memory-safe).
+                debug_assert!(state == REGISTERING || state == REGISTERING | WAKING);
+            }
+        }
     }
 
     /// Wake the registered waker, if any.
+    ///
+    /// The waker is consumed (taken out of the slot) before being invoked.
+    /// The task is expected to re-register its waker on the next poll, as is
+    /// already the convention for users of [`CriticalSectionWaker`].
     pub fn wake(&self) {
-        self.waker.wake();
+        if let Some(w) = self.take() {
+            w.wake();
+        }
+    }
+
+    fn take(&self) -> Option<Waker> {
+        match self.state.fetch_or(WAKING, AcqRel) {
+            WAITING => {
+                // SAFETY: We hold the WAKING flag; no other call can touch
+                // the waker cell while we own it.
+                let w = unsafe { (*self.waker.get()).take() };
+                self.state.swap(WAITING, Release);
+                w
+            }
+            _ => {
+                // Either a register is in progress (it will see the WAKING
+                // bit on its CAS-back and wake the supplied waker itself),
+                // or another wake is in flight.
+                None
+            }
+        }
     }
 }
+
+#[cfg(target_has_atomic = "32")]
+impl Default for AtomicWaker {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+/// On targets without 32-bit atomic CAS, fall back to the critical-section
+/// based waker. The lockless state machine requires
+/// `AtomicUsize::{compare_exchange, swap, fetch_or}`, which are unavailable on
+/// such targets (e.g. Xtensa S2, AVR, RV32I).
+#[cfg(not(target_has_atomic = "32"))]
+pub type AtomicWaker = super::CriticalSectionWaker;

--- a/embassy-sync/src/waitqueue/critical_section_waker.rs
+++ b/embassy-sync/src/waitqueue/critical_section_waker.rs
@@ -1,0 +1,28 @@
+use core::task::Waker;
+
+use super::GenericAtomicWaker;
+use crate::blocking_mutex::raw::CriticalSectionRawMutex;
+
+/// Utility struct to register and wake a waker.
+pub struct CriticalSectionWaker {
+    waker: GenericAtomicWaker<CriticalSectionRawMutex>,
+}
+
+impl CriticalSectionWaker {
+    /// Create a new `CriticalSectionWaker`.
+    pub const fn new() -> Self {
+        Self {
+            waker: GenericAtomicWaker::new(CriticalSectionRawMutex::new()),
+        }
+    }
+
+    /// Register a waker. Overwrites the previous waker, if any.
+    pub fn register(&self, w: &Waker) {
+        self.waker.register(w);
+    }
+
+    /// Wake the registered waker, if any.
+    pub fn wake(&self) {
+        self.waker.wake();
+    }
+}

--- a/embassy-sync/src/waitqueue/mod.rs
+++ b/embassy-sync/src/waitqueue/mod.rs
@@ -4,6 +4,9 @@
 mod atomic_waker;
 pub use atomic_waker::*;
 
+mod critical_section_waker;
+pub use critical_section_waker::*;
+
 mod waker_registration;
 pub use waker_registration::*;
 


### PR DESCRIPTION
Replace the previous `AtomicWaker` (a typedef-style alias for `GenericAtomicWaker<CriticalSectionRawMutex>`) with a lockless single-slot waker, ported from `futures::task::AtomicWaker` and adapted for `no_std`.

Coordination uses a small atomic state machine (WAITING / REGISTERING / WAKING) so that neither `register()` nor `wake()` enters a critical section. On Cortex-M this means `wake()` does not disable interrupts, which avoids unnecessary jitter.

The previous typedef-style wrapper around
`GenericAtomicWaker<CriticalSectionRawMutex>` is preserved verbatim under a new name, `CriticalSectionWaker`, and lives in its own `critical_section_waker.rs` module. Callers that want the old critical-section semantics (`wake_by_ref` + restore, no atomic state machine) can switch to it without changes to their call sites beyond the type name. `GenericAtomicWaker<M>` itself is unchanged.

Behavioral note for `AtomicWaker`: the new `wake()` consumes the waker (takes it out of the slot before invoking it) instead of waking by reference and restoring it. Tasks always re-register their waker on each poll, so this is observably equivalent for the single-waiter contract that this type is designed for.

Measured on FRDM-MCXA266 (MCXA266, Cortex-M33 @ 180 MHz, FIRC HF, WfeUngated), GPIO IRQ wake path with a scope:

| edge               | mutex   | lockless | delta   |
|--------------------|---------|----------|---------|
| wake() body (mean) | 1920 ns | 1630 ns  | -290 ns |