### PR TITLE
STM32N6 calculate PLL outputs even when previously initialized

### DIFF
--- a/embassy-stm32/src/rcc/n6.rs
+++ b/embassy-stm32/src/rcc/n6.rs
@@ -695,10 +695,60 @@ fn disable_pll(pll_index: usize) {
     cfgr1.modify(|w| w.set_pllbyp(false));
 }
 
-fn init_pll(pll_config: Option<Pll>, pll_index: usize, input: &PllInput) -> PllOutput {
+fn init_pll(pll_config: Option<Pll>, pll_index: usize, input: &PllInput, skip_initialization: bool) -> PllOutput {
     let cfgr1 = RCC.pllcfgr1(pll_index);
     let cfgr2 = RCC.pllcfgr2(pll_index);
     let cfgr3 = RCC.pllcfgr3(pll_index);
+
+    if skip_initialization {
+        // Caller guarantees registers already match `pll_config` (verified via
+        // `is_new_pll_config`), so just compute the PllOutput.
+        return match pll_config {
+            Some(Pll::Oscillator {
+                source,
+                divm,
+                fractional: _,
+                divn,
+                divp1,
+                divp2,
+            }) => {
+                let in_clk = match source {
+                    Pllsel::Hsi => unwrap!(input.hsi),
+                    Pllsel::Msi => unwrap!(input.msi),
+                    Pllsel::Hse => unwrap!(input.hse),
+                    Pllsel::I2sCkin => unwrap!(input.i2s_ckin),
+                    _ => panic!("reserved PLL source not allowed"),
+                };
+                let m = divm.to_bits() as u32;
+                let n = divn as u32;
+                let p1 = divp1.to_bits() as u32;
+                let p2 = divp2.to_bits() as u32;
+
+                PllOutput {
+                    divm: Some(Hertz(m)),
+                    divn: Some(Hertz(n)),
+                    divp1: Some(Hertz(p1)),
+                    divp2: Some(Hertz(p2)),
+                    output: Some(Hertz(in_clk.0 / m * n / p1)),
+                }
+            }
+            Some(Pll::Bypass { source }) => {
+                let in_clk = match source {
+                    Pllsel::Hsi => unwrap!(input.hsi),
+                    Pllsel::Msi => unwrap!(input.msi),
+                    Pllsel::Hse => unwrap!(input.hse),
+                    Pllsel::I2sCkin => unwrap!(input.i2s_ckin),
+                    _ => panic!("reserved PLL source not allowed"),
+                };
+
+                PllOutput {
+                    output: Some(in_clk),
+                    ..Default::default()
+                }
+            }
+            None => PllOutput::default(),
+        };
+    }
 
     match pll_config {
         Some(Pll::Oscillator {
@@ -1060,11 +1110,16 @@ fn init_osc(config: Config) -> OscOutput {
                     disable_pll(n);
                     PllOutput::default()
                 },
-                |c| init_pll(Some(c), n, &pll_input),
+                |c| init_pll(Some(c), n, &pll_input, false),
             );
-        } else if pll.is_some() && !pll_ready {
-            RCC.csr().write(|w| w.set_pllons(n, true));
-            while !RCC.sr().read().pllrdy(n) {}
+        } else if pll.is_some() {
+            // Config matches current register state. Run init_pll
+            // in skip mode and compute PllOutput.
+            *out = init_pll(pll, n, &pll_input, true);
+            if !pll_ready {
+                RCC.csr().write(|w| w.set_pllons(n, true));
+                while !RCC.sr().read().pllrdy(n) {}
+            }
         }
     }
 

--- a/embassy-stm32/src/rcc/n6.rs
+++ b/embassy-stm32/src/rcc/n6.rs
@@ -695,6 +695,54 @@ fn disable_pll(pll_index: usize) {
     cfgr1.modify(|w| w.set_pllbyp(false));
 }
 
+fn pll_output(pll_config: Option<Pll>, input: &PllInput) -> PllOutput {
+    match pll_config {
+        Some(Pll::Oscillator {
+            source,
+            divm,
+            fractional: _,
+            divn,
+            divp1,
+            divp2,
+        }) => {
+            let in_clk = match source {
+                Pllsel::Hsi => unwrap!(input.hsi),
+                Pllsel::Msi => unwrap!(input.msi),
+                Pllsel::Hse => unwrap!(input.hse),
+                Pllsel::I2sCkin => unwrap!(input.i2s_ckin),
+                _ => panic!("reserved PLL source not allowed"),
+            };
+            let m = divm.to_bits() as u32;
+            let n = divn as u32;
+            let p1 = divp1.to_bits() as u32;
+            let p2 = divp2.to_bits() as u32;
+
+            PllOutput {
+                divm: Some(Hertz(m)),
+                divn: Some(Hertz(n)),
+                divp1: Some(Hertz(p1)),
+                divp2: Some(Hertz(p2)),
+                output: Some(Hertz(in_clk.0 / m * n / p1 / p2)),
+            }
+        }
+        Some(Pll::Bypass { source }) => {
+            let in_clk = match source {
+                Pllsel::Hsi => unwrap!(input.hsi),
+                Pllsel::Msi => unwrap!(input.msi),
+                Pllsel::Hse => unwrap!(input.hse),
+                Pllsel::I2sCkin => unwrap!(input.i2s_ckin),
+                _ => panic!("reserved PLL source not allowed"),
+            };
+
+            PllOutput {
+                output: Some(in_clk),
+                ..Default::default()
+            }
+        }
+        None => PllOutput::default(),
+    }
+}
+
 fn init_pll(pll_config: Option<Pll>, pll_index: usize, input: &PllInput, skip_initialization: bool) -> PllOutput {
     let cfgr1 = RCC.pllcfgr1(pll_index);
     let cfgr2 = RCC.pllcfgr2(pll_index);
@@ -703,51 +751,7 @@ fn init_pll(pll_config: Option<Pll>, pll_index: usize, input: &PllInput, skip_in
     if skip_initialization {
         // Caller guarantees registers already match `pll_config` (verified via
         // `is_new_pll_config`), so just compute the PllOutput.
-        return match pll_config {
-            Some(Pll::Oscillator {
-                source,
-                divm,
-                fractional: _,
-                divn,
-                divp1,
-                divp2,
-            }) => {
-                let in_clk = match source {
-                    Pllsel::Hsi => unwrap!(input.hsi),
-                    Pllsel::Msi => unwrap!(input.msi),
-                    Pllsel::Hse => unwrap!(input.hse),
-                    Pllsel::I2sCkin => unwrap!(input.i2s_ckin),
-                    _ => panic!("reserved PLL source not allowed"),
-                };
-                let m = divm.to_bits() as u32;
-                let n = divn as u32;
-                let p1 = divp1.to_bits() as u32;
-                let p2 = divp2.to_bits() as u32;
-
-                PllOutput {
-                    divm: Some(Hertz(m)),
-                    divn: Some(Hertz(n)),
-                    divp1: Some(Hertz(p1)),
-                    divp2: Some(Hertz(p2)),
-                    output: Some(Hertz(in_clk.0 / m * n / p1)),
-                }
-            }
-            Some(Pll::Bypass { source }) => {
-                let in_clk = match source {
-                    Pllsel::Hsi => unwrap!(input.hsi),
-                    Pllsel::Msi => unwrap!(input.msi),
-                    Pllsel::Hse => unwrap!(input.hse),
-                    Pllsel::I2sCkin => unwrap!(input.i2s_ckin),
-                    _ => panic!("reserved PLL source not allowed"),
-                };
-
-                PllOutput {
-                    output: Some(in_clk),
-                    ..Default::default()
-                }
-            }
-            None => PllOutput::default(),
-        };
+        return pll_output(pll_config, input);
     }
 
     match pll_config {
@@ -776,24 +780,10 @@ fn init_pll(pll_config: Option<Pll>, pll_index: usize, input: &PllInput, skip_in
                 w.set_plldivn(divn);
             });
 
-            let in_clk = match source {
-                Pllsel::Hsi => unwrap!(input.hsi),
-                Pllsel::Msi => unwrap!(input.msi),
-                Pllsel::Hse => unwrap!(input.hse),
-                Pllsel::I2sCkin => unwrap!(input.i2s_ckin),
-                _ => panic!("reserved PLL source not allowed"),
-            };
-
-            let m = divm.to_bits() as u32;
-            let n = divn as u32;
-
             cfgr3.modify(|w| {
                 w.set_pllpdiv1(divp1);
                 w.set_pllpdiv2(divp2);
             });
-
-            let p1 = divp1.to_bits() as u32;
-            let p2 = divp2.to_bits() as u32;
 
             // configure pll divnfrac
             cfgr2.modify(|w| w.set_plldivnfrac(fractional));
@@ -819,13 +809,7 @@ fn init_pll(pll_config: Option<Pll>, pll_index: usize, input: &PllInput, skip_in
             while !RCC.sr().read().pllrdy(pll_index) {}
             debug!("PLL{}: ready", pll_index + 1);
 
-            PllOutput {
-                divm: Some(Hertz(m)),
-                divn: Some(Hertz(n)),
-                divp1: Some(Hertz(p1)),
-                divp2: Some(Hertz(p2)),
-                output: Some(Hertz(in_clk.0 / m * n / p1 / p2)),
-            }
+            pll_output(pll_config, input)
         }
         Some(Pll::Bypass { source }) => {
             // check if source is ready
@@ -842,18 +826,7 @@ fn init_pll(pll_config: Option<Pll>, pll_index: usize, input: &PllInput, skip_in
                 w.set_pllsel(source);
             });
 
-            let in_clk = match source {
-                Pllsel::Hsi => unwrap!(input.hsi),
-                Pllsel::Msi => unwrap!(input.msi),
-                Pllsel::Hse => unwrap!(input.hse),
-                Pllsel::I2sCkin => unwrap!(input.i2s_ckin),
-                _ => panic!("reserved PLL source not allowed"),
-            };
-
-            PllOutput {
-                output: Some(in_clk),
-                ..Default::default()
-            }
+            pll_output(pll_config, input)
         }
         None => {
             disable_pll(pll_index);

--- a/embassy-stm32/src/rcc/n6.rs
+++ b/embassy-stm32/src/rcc/n6.rs
@@ -743,16 +743,10 @@ fn pll_output(pll_config: Option<Pll>, input: &PllInput) -> PllOutput {
     }
 }
 
-fn init_pll(pll_config: Option<Pll>, pll_index: usize, input: &PllInput, skip_initialization: bool) -> PllOutput {
+fn init_pll(pll_config: Option<Pll>, pll_index: usize, input: &PllInput) -> PllOutput {
     let cfgr1 = RCC.pllcfgr1(pll_index);
     let cfgr2 = RCC.pllcfgr2(pll_index);
     let cfgr3 = RCC.pllcfgr3(pll_index);
-
-    if skip_initialization {
-        // Caller guarantees registers already match `pll_config` (verified via
-        // `is_new_pll_config`), so just compute the PllOutput.
-        return pll_output(pll_config, input);
-    }
 
     match pll_config {
         Some(Pll::Oscillator {
@@ -1083,12 +1077,11 @@ fn init_osc(config: Config) -> OscOutput {
                     disable_pll(n);
                     PllOutput::default()
                 },
-                |c| init_pll(Some(c), n, &pll_input, false),
+                |c| init_pll(Some(c), n, &pll_input),
             );
         } else if pll.is_some() {
-            // Config matches current register state. Run init_pll
-            // in skip mode and compute PllOutput.
-            *out = init_pll(pll, n, &pll_input, true);
+            // Config matches current register state.
+            *out = pll_output(pll, &pll_input);
             if !pll_ready {
                 RCC.csr().write(|w| w.set_pllons(n, true));
                 while !RCC.sr().read().pllrdy(n) {}


### PR DESCRIPTION
Currently, if PLLs are already initialized (e.g. by FSBL) and embassy configuration matches the hardware one, initialization is skipped and PLL output frequencies are not calculated.

However, this causes ICs depending on that PLL to not have their frequency set and a panic if a mux tries to use those ICs.

This PR proposes to calculate the PLL output frequencies based on the values provided by the configuration since it already matches with the registers