### PR TITLE
Add independent OISx/OISxN idle state setters to ComplementaryPwm

### DIFF
--- a/embassy-stm32/src/timer/complementary_pwm.rs
+++ b/embassy-stm32/src/timer/complementary_pwm.rs
@@ -167,6 +167,42 @@ impl<'d, T: AdvancedInstance4Channel> ComplementaryPwm<'d, T> {
         }
     }
 
+    /// Sets the idle state for the normal (OISx) channels only. OISxN is not modified.
+    ///
+    /// When OSSI is enabled (`set_off_state_selection_idle(Ossi::IdleLevel)`), the timer
+    /// drives outputs to the configured idle state whenever MOE=0, regardless of GPIO
+    /// push-pull configuration. This makes idle behavior deterministic across platforms.
+    ///
+    /// **Constraint**: OISx and OISxN must not both map to the active output state for the same
+    /// channel. After a break event the timer inserts a dead time before settling outputs to their
+    /// idle state, and the hardware prevents both complementary outputs from being active
+    /// simultaneously to avoid a shoot-through condition in half-bridge configurations.
+    ///
+    /// - `ois_active = true`:  normal outputs go active when idle (OISx=1)
+    /// - `ois_active = false`: normal outputs go inactive when idle (OISx=0)
+    pub fn set_normal_output_idle_state(&mut self, channels: &[Channel], ois_active: bool) {
+        for &channel in channels {
+            self.inner.set_ois(channel, ois_active);
+        }
+    }
+
+    /// Sets the idle state for the complementary (OISxN) channels only. OISx is not modified.
+    ///
+    /// When OSSI is enabled (`set_off_state_selection_idle(Ossi::IdleLevel)`), the timer
+    /// drives outputs to the configured idle state whenever MOE=0, regardless of GPIO
+    /// push-pull configuration. This makes idle behavior deterministic across platforms.
+    ///
+    /// **Constraint**: OISx and OISxN must not both map to the active output state for the same
+    /// channel. See [`set_normal_output_idle_state`] for details.
+    ///
+    /// - `oisn_active = true`:  complementary outputs go active when idle (OISxN=1)
+    /// - `oisn_active = false`: complementary outputs go inactive when idle (OISxN=0)
+    pub fn set_complementary_output_idle_state(&mut self, channels: &[Channel], oisn_active: bool) {
+        for &channel in channels {
+            self.inner.set_oisn(channel, oisn_active);
+        }
+    }
+
     /// Set state of OSSI-bit in BDTR register
     pub fn set_off_state_selection_idle(&mut self, val: Ossi) {
         self.inner.set_ossi(val);


### PR DESCRIPTION
Add set_normal_output_idle_state and set_complementary_output_idle_state to allow OISx and OISxN to be configured independently. The existing set_output_idle_state always sets them as complements, which does not cover the case where both should be inactive (Hi-Z)