### PR TITLE
embassy-stm32: Allow non-zero DLC on RTR CAN-FD frames

### DIFF
--- a/embassy-stm32/src/can/fd/peripheral.rs
+++ b/embassy-stm32/src/can/fd/peripheral.rs
@@ -687,7 +687,7 @@ fn put_tx_header(mailbox: &mut TxBufferElement, header: &Header) {
     mailbox.header.write(|w| {
         unsafe { w.id().bits(id) }
             .rtr()
-            .bit(header.len() == 0 && header.rtr())
+            .bit(header.rtr())
             .xtd()
             .set_id_type(id_type)
             .set_len(DataLength::new(header.len(), frame_format))


### PR DESCRIPTION
Remote transmission CAN frames only have their RTR bit set if the RTR bit is set in the header and the data length code is zero. According to the standard, remote frames can have non-zero DLCs, so this length check should be removed. Tested with external loopback and this change correctly asserts the RTR bit regardless of DLC.