### PR TITLE
enforce that embassy-executor-timer-queue is only once in the dependency tree

### DIFF
--- a/embassy-executor-timer-queue/src/lib.rs
+++ b/embassy-executor-timer-queue/src/lib.rs
@@ -22,6 +22,9 @@
 
 use core::task::Waker;
 
+#[unsafe(no_mangle)]
+static __EMBASSY_EXECUTOR_TIME_QUEUE_ONLY_ONCE_IN_DEPENDENCY_TREE: () = ();
+
 const ITEM_WORDS: usize = if cfg!(feature = "timer-item-size-8-words") {
     8
 } else if cfg!(feature = "timer-item-size-6-words") {


### PR DESCRIPTION
Does it ever make sense to have two different versions, possibly with different ITEM_SIZES, in the dependency tree? I had that issue when mixing git and crates-io dependencies of embassy-executor/embassy-time.

this led to a silent failure because embassy-executor used crate-io v0.1 with item size 0, while the item size 6 was only activated for the git version of embassy-executor-timer-queue