### PR TITLE
wpan: remove direct mode and impl. controller trait

### DIFF
--- a/embassy-stm32-wpan/Cargo.toml
+++ b/embassy-stm32-wpan/Cargo.toml
@@ -46,7 +46,7 @@ critical-section = "1.2"
 
 bit_field = "0.10.2"
 stm32-device-signature = { version = "0.3.3", features = ["stm32wb5x"] }
-stm32wb-hci = { version = "0.17.3", optional = true }
+stm32wb-hci = { version = "0.17.4", optional = true, git="https://github.com/embassy-rs/stm32wb-hci.git", rev="0ea312" }
 futures-util = { version = "0.3.30", default-features = false }
 bitflags = { version = "2.3.3", optional = true }
 bt-hci = { version = "0.9.0", optional = true }
@@ -57,14 +57,14 @@ futures-intrusive = { version ="0.5.0", default-features = false }
 defmt = ["dep:defmt", "embassy-sync/defmt", "embassy-embedded-hal/defmt", "embassy-hal-internal/defmt", "stm32wb-hci?/defmt", "bt-hci?/defmt"]
 log = ["dep:log"]
 bt-hci = ["dep:bt-hci", "dep:embedded-io"]
-wb-hci = ["dep:stm32wb-hci"]
+wb-hci = ["bt-hci", "dep:stm32wb-hci"]
 
 wb = []
 wb-ble = []
 wb-mac = ["dep:bitflags", "dep:embassy-net-driver", "dep:smoltcp", "smoltcp/medium-ieee802154"]
 
 wba = [ "dep:stm32-bindings" ]
-wba-ble = [  "stm32-bindings/wba_wpan_ble" , "stm32-bindings/wba_wpan", "stm32-bindings/wba_wpan_mac" ]
+wba-ble = [ "stm32-bindings/wba_wpan_ble" , "stm32-bindings/wba_wpan", "stm32-bindings/wba_wpan_mac" ]
 wba-mac = [ "stm32-bindings/wba_wpan_mac", "stm32-bindings/wba_wpan_ble" , "stm32-bindings/lib_wba5_linklayer15_4", "stm32-bindings/lib_wba_mac_lib" , "stm32-bindings/wba_wpan" ]
 
 # BLE stack library variants (choose one)

--- a/embassy-stm32-wpan/src/bluetooth/error.rs
+++ b/embassy-stm32-wpan/src/bluetooth/error.rs
@@ -1,9 +1,14 @@
 //! BLE Error types
 
+use stm32wb_hci::host::Error as HostError;
+use stm32wb_hci::vendor::command::gap::Error as GapError;
+use stm32wb_hci::vendor::command::gatt::Error as GattError;
+use stm32wb_hci::vendor::command::hal::Error as HalError;
+
 use super::hci::types::Status;
 
 /// BLE Stack Errors
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq)]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub enum BleError {
     /// BLE stack not initialized or runner not initialized
@@ -30,8 +35,44 @@ pub enum BleError {
     /// Connection error
     ConnectionError,
 
+    // Controller Host Error
+    HostError(HostError),
+
+    // Controller Gatt Error
+    GattError(GattError),
+
+    // Controller Gap Error
+    GapError(GapError),
+
+    // Controller Hal Error
+    HalError(HalError),
+
     /// Unknown or unspecified error
     Unknown,
+}
+
+impl From<HostError> for BleError {
+    fn from(err: HostError) -> Self {
+        Self::HostError(err)
+    }
+}
+
+impl From<GattError> for BleError {
+    fn from(err: GattError) -> Self {
+        Self::GattError(err)
+    }
+}
+
+impl From<GapError> for BleError {
+    fn from(err: GapError) -> Self {
+        Self::GapError(err)
+    }
+}
+
+impl From<HalError> for BleError {
+    fn from(err: HalError) -> Self {
+        Self::HalError(err)
+    }
 }
 
 impl From<Status> for BleError {

--- a/embassy-stm32-wpan/src/bluetooth/mod.rs
+++ b/embassy-stm32-wpan/src/bluetooth/mod.rs
@@ -13,6 +13,8 @@ use stm32wb_hci::event::{
     DisconnectionComplete, LeConnectionComplete, LeConnectionUpdateComplete, LeDataLengthChangeEvent,
     LeEnhancedConnectionComplete, LePhyUpdateComplete,
 };
+use stm32wb_hci::host::uart::Packet;
+use stm32wb_hci::host::{EventFlags, HostHci, LeEventFlags};
 use stm32wb_hci::{BdAddr, ConnectionHandle, Event, Status};
 
 use crate::bluetooth::error::BleError;
@@ -28,7 +30,7 @@ use crate::bluetooth::hci::command::CommandSender;
 use crate::bluetooth::hci::types::DtmPacketPayload;
 use crate::bluetooth::hci::{DtmRxPhy, DtmTxPhy};
 use crate::bluetooth::security::SecurityManager;
-use crate::controller::Controller;
+use crate::controller::{Controller, ControllerAdapter};
 use crate::{BasicRuntime, FullRuntime, HighInterruptHandler, LowInterruptHandler, Platform, Runtime};
 
 trait SealedMode {}
@@ -80,7 +82,7 @@ impl Mode for Test {
 /// }
 /// ```
 pub struct HCI<'d, M: Mode> {
-    controller: Controller<'d, M::Runtime>,
+    controller: ControllerAdapter<'d, M::Runtime>,
     cmd_sender: CommandSender,
     connections: ConnectionManager<MAX_CONNECTIONS>,
     is_advertising: bool,
@@ -138,25 +140,25 @@ impl<'d> HCI<'d, Normal> {
             cmd_sender: CommandSender::new(),
             connections: ConnectionManager::new(),
             is_advertising: false,
-            controller,
+            controller: ControllerAdapter::new(controller),
             _mode: Normal,
         };
 
-        this.init_with_gap_params(gap_params)?;
+        this.init_with_gap_params(gap_params).await?;
 
         yield_now().await;
 
         Ok(this)
     }
 
-    fn init_with_gap_params(&mut self, mut gap_params: GapInitParams) -> Result<(), BleError> {
+    async fn init_with_gap_params(&mut self, mut gap_params: GapInitParams) -> Result<(), BleError> {
         info!("Ble::init: BLE stack initialized, sending HCI reset");
 
         // 1. Reset BLE controller
-        self.cmd_sender.reset()?;
+        self.controller.reset().await?;
 
         // 2. Read local version information
-        let version = self.cmd_sender.read_local_version()?;
+        let version = self.controller.read_local_version_information().await?;
 
         info!(
             "BLE Controller: HCI Version {}.{}, Revision: 0x{:04X}, LMP Version: {}.{}, Manufacturer: 0x{:04X}",
@@ -173,14 +175,14 @@ impl<'d> HCI<'d, Normal> {
         // may not be needed. Skip if they fail with UnknownCommand.
 
         info!("Calling set_event_mask...");
-        if let Err(e) = self.cmd_sender.set_event_mask(0xFFFF_FFFF_FFFF_FFFF) {
+        if let Err(e) = self.controller.set_event_mask(EventFlags::all()).await {
             warn!("set_event_mask failed: {:?} (may be handled internally)", e);
         } else {
             info!("set_event_mask OK");
         }
 
         info!("Calling le_set_event_mask...");
-        if let Err(e) = self.cmd_sender.le_set_event_mask(0xFFFF_FFFF_FFFF_FFFF) {
+        if let Err(e) = self.controller.le_set_event_mask(LeEventFlags::all()).await {
             warn!("le_set_event_mask failed: {:?} (may be handled internally)", e);
         } else {
             info!("le_set_event_mask OK");
@@ -611,7 +613,7 @@ impl<'d> HCI<'d, Test> {
             cmd_sender: CommandSender::new(),
             connections: ConnectionManager::new(),
             is_advertising: false,
-            controller,
+            controller: ControllerAdapter::new(controller),
             _mode: Test,
         };
 
@@ -744,10 +746,11 @@ impl<'d, M: Mode> HCI<'d, M> {
     /// and scanning. This is provided for applications that need to handle
     /// raw events (e.g., for connection management).
     pub async fn read_event(&mut self) -> stm32wb_hci::Event {
+        use stm32wb_hci::host::uart::UartHci;
+
         loop {
-            match self.controller.read_event().await {
-                Ok(event) => return event,
-                Err(e) => debug!("read_event: unhandled event {:?}", e),
+            if let Ok(Packet::Event(event)) = self.controller.read_packet().await {
+                return event;
             }
         }
     }

--- a/embassy-stm32-wpan/src/wb/evt.rs
+++ b/embassy-stm32-wpan/src/wb/evt.rs
@@ -141,7 +141,7 @@ impl<T: MemoryManager> EvtBox<T> {
         }
     }
 
-    pub fn serial<'a>(&'a self) -> &'a [u8] {
+    pub const fn serial<'a>(&'a self) -> &'a [u8] {
         unsafe {
             let evt_serial: *const EvtSerial = &(*self.ptr).evt_serial;
             let evt_serial_buf: *const u8 = evt_serial.cast();

--- a/embassy-stm32-wpan/src/wb/sub/ble.rs
+++ b/embassy-stm32-wpan/src/wb/sub/ble.rs
@@ -277,15 +277,13 @@ impl<'d> ControllerAdapter<'d> {
         ))
     }
 
-    async fn exec_cmd<C: bt_hci::WriteHci + bt_hci::cmd::Cmd>(
+    async fn exec_cmd<C: bt_hci::WriteHci + bt_hci::cmd::Cmd, R>(
         &self,
         cmd: &C,
-    ) -> Result<
-        (bt_hci::event::CommandCompleteWithStatus<'_>, SlotGuard<'d, '_>),
-        bt_hci::cmd::Error<embedded_io::ErrorKind>,
-    > {
-        use core::slice;
-
+        f: impl FnOnce(
+            &bt_hci::event::CommandCompleteWithStatus<'_>,
+        ) -> Result<R, bt_hci::cmd::Error<embedded_io::ErrorKind>>,
+    ) -> Result<R, bt_hci::cmd::Error<embedded_io::ErrorKind>> {
         use bt_hci::WriteHci;
         use bt_hci::cmd::Error as CmdError;
         use bt_hci::param::Error as ParamError;
@@ -293,7 +291,7 @@ impl<'d> ControllerAdapter<'d> {
 
         use crate::util::make_cc_with_cs;
 
-        let guard = self.grab_slot(C::OPCODE).await;
+        let _guard = self.grab_slot(C::OPCODE).await;
 
         self.hw_ipcc_ble_cmd_channel
             .lock()
@@ -311,10 +309,11 @@ impl<'d> ControllerAdapter<'d> {
             .await
             .ok_or(CmdError::Hci(ParamError::OPERATION_CANCELLED_BY_HOST))?;
 
-        // Packets with CC or CS opcode are not managed by the memory manager
-        let evt_serial = unsafe { slice::from_raw_parts(evt.serial() as *const _ as *const u8, evt.serial().len()) };
+        let ccws = make_cc_with_cs(evt.serial())?;
 
-        Ok((make_cc_with_cs(evt_serial)?, guard))
+        trace!("returned ccws: {:?}", ccws.status);
+
+        Ok(f(&ccws)?)
     }
 }
 
@@ -436,11 +435,10 @@ where
         use bt_hci::cmd;
         debug!("Executing sync command with opcode {:x}", C::OPCODE.0);
 
-        let (e, _guard) = self.exec_cmd(cmd).await?;
+        let r = self
+            .exec_cmd(cmd, |e| e.to_result::<C>().map_err(cmd::Error::Hci))
+            .await?;
 
-        trace!("returned ccws: {:?}", e.status);
-
-        let r = e.to_result::<C>().map_err(cmd::Error::Hci)?;
         debug!("Done executing command with opcode {:x}", C::OPCODE.0);
         Ok(r)
     }
@@ -452,13 +450,11 @@ where
     C: bt_hci::cmd::AsyncCmd,
 {
     async fn exec(&self, cmd: &C) -> Result<(), bt_hci::cmd::Error<Self::Error>> {
+        use bt_hci::cmd;
         debug!("Executing async command with opcode {:x}", C::OPCODE.0);
 
-        let (e, _guard) = self.exec_cmd(cmd).await?;
-
-        trace!("returned ccws: {:?}", e.status);
-
-        e.status.to_result()?;
+        self.exec_cmd(cmd, |e| e.status.to_result().map_err(cmd::Error::Hci))
+            .await?;
 
         debug!("Done executing command with opcode {:x}", C::OPCODE.0);
         Ok(())

--- a/embassy-stm32-wpan/src/wb/sub/ble.rs
+++ b/embassy-stm32-wpan/src/wb/sub/ble.rs
@@ -62,18 +62,6 @@ pub struct Ble<'a> {
     ipcc_hci_acl_rx_data_channel: IpccRxChannel<'a>,
 }
 
-/// BLE for only sending commands to CPU2
-pub struct BleTx<'a> {
-    hw_ipcc_ble_cmd_channel: IpccTxChannel<'a>,
-    ipcc_hci_acl_tx_data_channel: IpccTxChannel<'a>,
-}
-
-/// BLE for only receive commands from CPU2
-pub struct BleRx<'a> {
-    ipcc_ble_event_channel: IpccRxChannel<'a>,
-    ipcc_hci_acl_rx_data_channel: IpccRxChannel<'a>,
-}
-
 impl<'a> Ble<'a> {
     /// Constructs a guard that allows for BLE commands to be sent to CPU2.
     ///
@@ -101,20 +89,6 @@ impl<'a> Ble<'a> {
             ipcc_hci_acl_tx_data_channel,
             ipcc_hci_acl_rx_data_channel,
         }
-    }
-
-    /// Split current BLE into BleTx and BleRx
-    pub fn split(self) -> (BleTx<'a>, BleRx<'a>) {
-        (
-            BleTx {
-                hw_ipcc_ble_cmd_channel: self.hw_ipcc_ble_cmd_channel,
-                ipcc_hci_acl_tx_data_channel: self.ipcc_hci_acl_tx_data_channel,
-            },
-            BleRx {
-                ipcc_ble_event_channel: self.ipcc_ble_event_channel,
-                ipcc_hci_acl_rx_data_channel: self.ipcc_hci_acl_rx_data_channel,
-            },
-        )
     }
 
     /// `HW_IPCC_BLE_EvtNot`
@@ -184,96 +158,6 @@ impl<'a> evt::MemoryManager for Ble<'a> {
         if !(stub.evt_code == TL_BLEEVT_CS_OPCODE || stub.evt_code == TL_BLEEVT_CC_OPCODE) {
             mm::MemoryManager::drop_event_packet(evt);
         }
-    }
-}
-
-#[cfg(feature = "wb-hci")]
-impl<'a> stm32wb_hci::Controller for Ble<'a> {
-    async fn controller_write(&mut self, opcode: stm32wb_hci::Opcode, payload: &[u8]) {
-        self.tl_write(opcode.0, payload).await;
-    }
-
-    async fn controller_read_into(&mut self, buf: &mut [u8]) {
-        let evt_box = self.tl_read().await;
-        let evt_serial = evt_box.serial();
-
-        buf[..evt_serial.len()].copy_from_slice(evt_serial);
-    }
-}
-
-impl<'a> BleTx<'a> {
-    /// `TL_BLE_SendCmd`
-    pub async fn tl_write(&mut self, opcode: u16, payload: &[u8]) {
-        self.hw_ipcc_ble_cmd_channel
-            .send(|| unsafe {
-                CmdPacket::write_into(BLE_CMD_BUFFER.as_mut_ptr(), TlPacketType::BleCmd, opcode, payload);
-            })
-            .await;
-    }
-
-    /// `TL_BLE_SendAclData`
-    pub async fn acl_write(&mut self, handle: u16, payload: &[u8]) {
-        self.ipcc_hci_acl_tx_data_channel
-            .send(|| unsafe {
-                CmdPacket::write_into(
-                    HCI_ACL_DATA_BUFFER.as_mut_ptr() as *mut _,
-                    TlPacketType::AclData,
-                    handle,
-                    payload,
-                );
-            })
-            .await;
-    }
-}
-
-impl<'a> BleRx<'a> {
-    /// `HW_IPCC_BLE_EvtNot`
-    pub async fn tl_read(&mut self) -> EvtBox<Ble<'a>> {
-        self.ipcc_ble_event_channel
-            .receive(|| unsafe {
-                if let Some(node_ptr) =
-                    critical_section::with(|cs| LinkedListNode::remove_head(cs, EVT_QUEUE.as_mut_ptr()))
-                {
-                    Some(EvtBox::new(node_ptr.cast()))
-                } else {
-                    None
-                }
-            })
-            .await
-    }
-
-    /// `TL_BLE_AclNot`
-    pub async fn acl_read(&mut self) -> EvtBox<Ble<'a>> {
-        ACL_EVT_OUT.wait_for_low().await;
-        self.ipcc_hci_acl_rx_data_channel
-            .receive(|| unsafe { Some(EvtBox::new(HCI_ACL_DATA_BUFFER.as_mut_ptr() as *mut _)) })
-            .await
-    }
-}
-
-#[cfg(feature = "wb-hci")]
-/// Implement Controller for TX (Write only)
-impl<'a> stm32wb_hci::Controller for BleTx<'a> {
-    async fn controller_write(&mut self, opcode: stm32wb_hci::Opcode, payload: &[u8]) {
-        self.tl_write(opcode.0, payload).await;
-    }
-
-    async fn controller_read_into(&mut self, _buf: &mut [u8]) {
-        panic!("BleTx cannot read!");
-    }
-}
-
-#[cfg(feature = "wb-hci")]
-/// Implement Controller for RX (Read only)
-impl<'a> stm32wb_hci::Controller for BleRx<'a> {
-    async fn controller_write(&mut self, _opcode: stm32wb_hci::Opcode, _payload: &[u8]) {
-        panic!("BleRx cannot write!");
-    }
-
-    async fn controller_read_into(&mut self, buf: &mut [u8]) {
-        let evt_box = self.tl_read().await;
-        let evt_serial = evt_box.serial();
-        buf[..evt_serial.len()].copy_from_slice(evt_serial);
     }
 }
 
@@ -362,6 +246,8 @@ impl<'d> ControllerAdapter<'d> {
     async fn read_pkt(
         &self,
     ) -> Result<(EvtBox<Ble<'d>>, bt_hci::ControllerToHostPacket<'static>), embedded_io::ErrorKind> {
+        use core::slice;
+
         use bt_hci::{ControllerToHostPacket, FromHciBytes};
 
         use crate::util::to_err;
@@ -381,25 +267,43 @@ impl<'d> ControllerAdapter<'d> {
             })
             .await;
 
-        let serial = evt.serial();
-        let buf = unsafe { core::slice::from_raw_parts(serial as *const _ as *const u8, serial.len()) };
+        let evt_serial = unsafe { slice::from_raw_parts(evt.serial() as *const _ as *const u8, evt.serial().len()) };
 
         Ok((
             evt,
-            ControllerToHostPacket::from_hci_bytes(buf)
+            ControllerToHostPacket::from_hci_bytes(evt_serial)
                 .map_err(to_err)
                 .map(|(pkt, _)| pkt)?,
         ))
     }
 
-    async fn read_status(
+    async fn exec_cmd<C: bt_hci::WriteHci + bt_hci::cmd::Cmd>(
         &self,
-        _guard: &SlotGuard<'d, '_>,
-    ) -> Result<bt_hci::event::CommandCompleteWithStatus<'_>, bt_hci::cmd::Error<embedded_io::ErrorKind>> {
+        cmd: &C,
+    ) -> Result<
+        (bt_hci::event::CommandCompleteWithStatus<'_>, SlotGuard<'d, '_>),
+        bt_hci::cmd::Error<embedded_io::ErrorKind>,
+    > {
+        use core::slice;
+
+        use bt_hci::WriteHci;
         use bt_hci::cmd::Error as CmdError;
         use bt_hci::param::Error as ParamError;
+        use bt_hci::transport::WithIndicator;
 
         use crate::util::make_cc_with_cs;
+
+        let guard = self.grab_slot(C::OPCODE).await;
+
+        self.hw_ipcc_ble_cmd_channel
+            .lock()
+            .await
+            .send(|| unsafe {
+                WithIndicator::new(cmd)
+                    .write_hci(CmdPacket::writer(BLE_CMD_BUFFER.as_mut_ptr()))
+                    .map_err(CmdError::Io)
+            })
+            .await?;
 
         let evt = self
             .signal
@@ -408,10 +312,9 @@ impl<'d> ControllerAdapter<'d> {
             .ok_or(CmdError::Hci(ParamError::OPERATION_CANCELLED_BY_HOST))?;
 
         // Packets with CC or CS opcode are not managed by the memory manager
-        let evt_serial = evt.serial();
-        let evt_serial = unsafe { core::slice::from_raw_parts(evt_serial as *const _ as *const u8, evt_serial.len()) };
+        let evt_serial = unsafe { slice::from_raw_parts(evt.serial() as *const _ as *const u8, evt.serial().len()) };
 
-        make_cc_with_cs(evt_serial)
+        Ok((make_cc_with_cs(evt_serial)?, guard))
     }
 }
 
@@ -530,25 +433,10 @@ where
     C: bt_hci::cmd::SyncCmd,
 {
     async fn exec(&self, cmd: &C) -> Result<C::Return, bt_hci::cmd::Error<Self::Error>> {
-        use bt_hci::cmd::Error as CmdError;
-        use bt_hci::transport::WithIndicator;
-        use bt_hci::{WriteHci, cmd};
-
+        use bt_hci::cmd;
         debug!("Executing sync command with opcode {:x}", C::OPCODE.0);
 
-        let guard = self.grab_slot(C::OPCODE).await;
-
-        self.hw_ipcc_ble_cmd_channel
-            .lock()
-            .await
-            .send(|| unsafe {
-                WithIndicator::new(cmd)
-                    .write_hci(CmdPacket::writer(BLE_CMD_BUFFER.as_mut_ptr()))
-                    .map_err(CmdError::Io)
-            })
-            .await?;
-
-        let e = self.read_status(&guard).await?;
+        let (e, _guard) = self.exec_cmd(cmd).await?;
 
         trace!("returned ccws: {:?}", e.status);
 
@@ -564,25 +452,9 @@ where
     C: bt_hci::cmd::AsyncCmd,
 {
     async fn exec(&self, cmd: &C) -> Result<(), bt_hci::cmd::Error<Self::Error>> {
-        use bt_hci::WriteHci;
-        use bt_hci::cmd::Error as CmdError;
-        use bt_hci::transport::WithIndicator;
-
         debug!("Executing async command with opcode {:x}", C::OPCODE.0);
 
-        let guard = self.grab_slot(C::OPCODE).await;
-
-        self.hw_ipcc_ble_cmd_channel
-            .lock()
-            .await
-            .send(|| unsafe {
-                WithIndicator::new(cmd)
-                    .write_hci(CmdPacket::writer(BLE_CMD_BUFFER.as_mut_ptr()))
-                    .map_err(CmdError::Io)
-            })
-            .await?;
-
-        let e = self.read_status(&guard).await?;
+        let (e, _guard) = self.exec_cmd(cmd).await?;
 
         trace!("returned ccws: {:?}", e.status);
 

--- a/embassy-stm32-wpan/src/wba/controller.rs
+++ b/embassy-stm32-wpan/src/wba/controller.rs
@@ -182,51 +182,6 @@ impl<'d, T: Runtime> Controller<'d, T> {
             }
         }
     }
-
-    #[cfg(feature = "wb-hci")]
-    pub async fn read_event(&mut self) -> Result<stm32wb_hci::Event, stm32wb_hci::event::Error> {
-        use stm32wb_hci::Event;
-        use stm32wb_hci::event::Packet;
-
-        if let Some(buf) = self.pop_buf() {
-            Event::new(Packet(&buf[1..]))
-        } else {
-            let slot = self.receiver.receive().await;
-            // Parse and queue the event for processing.
-            // Skip byte 0 (0x04 HCI Event packet indicator) — the parser expects
-            // data starting at the event code byte.
-            let parse_data = if *&slot.len() >= 2 && *&slot[0] == 0x04 {
-                &slot[1..]
-            } else {
-                &slot
-            };
-
-            let event = Event::new(Packet(parse_data));
-
-            slot.receive_done();
-
-            event
-        }
-    }
-}
-
-#[cfg(feature = "wb-hci")]
-impl<'d, T: Runtime> stm32wb_hci::Controller for Controller<'d, T> {
-    async fn controller_read_into(&mut self, _buf: &mut [u8]) {
-        panic!("use `read_event` to read events")
-    }
-
-    async fn controller_write(&mut self, opcode: stm32wb_hci::Opcode, payload: &[u8]) {
-        use stm32wb_hci::host::HciHeader;
-        use stm32wb_hci::vendor::CommandHeader;
-
-        self.exec(|buf| {
-            let (header, pkt) = buf.split_at_mut(CommandHeader::HEADER_LENGTH);
-
-            CommandHeader::new(opcode, payload.len()).copy_into_slice(header);
-            pkt[..payload.len()].copy_from_slice(payload);
-        });
-    }
 }
 
 #[cfg(feature = "bt-hci")]
@@ -371,15 +326,4 @@ impl<'d, T: Runtime> Drop for Controller<'d, T> {
         // init_ble_stack() → BleStack_Init() can run cleanly on next Ble::new().
         crate::wba::ll_sys::reset_ble_stack();
     }
-}
-
-/// Version information from the BLE controller
-#[derive(Debug, Clone, Copy)]
-#[cfg_attr(feature = "defmt", derive(defmt::Format))]
-pub struct VersionInfo {
-    pub hci_version: u8,
-    pub hci_revision: u16,
-    pub lmp_version: u8,
-    pub manufacturer_name: u16,
-    pub lmp_subversion: u16,
 }

--- a/examples/stm32wb/Cargo.toml
+++ b/examples/stm32wb/Cargo.toml
@@ -23,7 +23,8 @@ embedded-hal = "1.0.0"
 panic-probe = { version = "1.0.0", features = ["print-defmt"] }
 heapless = { version = "0.9", default-features = false }
 static_cell = "2"
-stm32wb-hci = "0.17.4"
+stm32wb-hci = { version = "0.17.4", git="https://github.com/embassy-rs/stm32wb-hci.git", rev="0ea312" }
+embassy-futures = "0.1.2"
 
 [features]
 default = ["ble", "mac"]

--- a/examples/stm32wb/src/bin/eddystone_beacon.rs
+++ b/examples/stm32wb/src/bin/eddystone_beacon.rs
@@ -5,11 +5,14 @@ use core::time::Duration;
 
 use defmt::*;
 use embassy_executor::Spawner;
+use embassy_futures::join::join;
 use embassy_stm32::bind_interrupts;
 use embassy_stm32::ipcc::{Config, ReceiveInterruptHandler, TransmitInterruptHandler};
 use embassy_stm32::rcc::Config as RccConfig;
 use embassy_stm32_wpan::TlMbox;
 use embassy_stm32_wpan::lhci::LhciC1DeviceInformationCcrp;
+use embassy_stm32_wpan::sub::ble::ControllerAdapter;
+use embassy_stm32_wpan::sub::mm;
 use stm32wb_hci::BdAddr;
 use stm32wb_hci::host::uart::UartHci;
 use stm32wb_hci::host::{AdvertisingFilterPolicy, EncryptionKey, HostHci, OwnAddressType};
@@ -27,7 +30,7 @@ bind_interrupts!(struct Irqs{
 const BLE_GAP_DEVICE_NAME_LENGTH: u8 = 7;
 
 #[embassy_executor::main(executor = "embassy_stm32::executor::Executor", entry = "cortex_m_rt::entry")]
-async fn main(_spawner: Spawner) {
+async fn main(spawner: Spawner) {
     /*
         How to make this work:
 
@@ -57,116 +60,127 @@ async fn main(_spawner: Spawner) {
     info!("Hello World!");
 
     let config = Config::default();
-    let (mut ble, _) = TlMbox::wait_ready(p.IPCC, Irqs, config)
+    let (ble, mm) = TlMbox::wait_ready(p.IPCC, Irqs, config)
         .await
         .unwrap()
         .init_ble(Default::default())
         .await
         .unwrap();
 
-    info!("resetting BLE...");
-    ble.reset().await;
-    let response = ble.read().await.unwrap();
-    defmt::info!("{}", response);
+    spawner.spawn(run_mm_queue(mm).unwrap());
 
-    info!("config public address...");
-    ble.write_config_data(&ConfigData::public_address(get_bd_addr()).build())
-        .await;
-    let response = ble.read().await.unwrap();
-    defmt::info!("{}", response);
+    let ble = ControllerAdapter::new(ble);
 
-    info!("config random address...");
-    ble.write_config_data(&ConfigData::random_address(get_random_addr()).build())
-        .await;
-    let response = ble.read().await.unwrap();
-    defmt::info!("{}", response);
+    join(
+        async {
+            loop {
+                let pkt = ble.read_packet().await;
 
-    info!("config identity root...");
-    ble.write_config_data(&ConfigData::identity_root(&get_irk()).build())
-        .await;
-    let response = ble.read().await.unwrap();
-    defmt::info!("{}", response);
+                defmt::info!("pkt: {}", pkt);
+            }
+        },
+        async {
+            info!("resetting BLE...");
+            let response = ble.reset().await;
+            defmt::info!("{}", response);
 
-    info!("config encryption root...");
-    ble.write_config_data(&ConfigData::encryption_root(&get_erk()).build())
-        .await;
-    let response = ble.read().await.unwrap();
-    defmt::info!("{}", response);
+            info!("config public address...");
 
-    info!("config tx power level...");
-    ble.set_tx_power_level(PowerLevel::ZerodBm).await;
-    let response = ble.read().await.unwrap();
-    defmt::info!("{}", response);
+            let response = ble
+                .write_config_data(&ConfigData::public_address(get_bd_addr()).build())
+                .await;
+            defmt::info!("{}", response);
 
-    info!("GATT init...");
-    ble.init_gatt().await;
-    let response = ble.read().await.unwrap();
-    defmt::info!("{}", response);
+            info!("config random address...");
+            let response = ble
+                .write_config_data(&ConfigData::random_address(get_random_addr()).build())
+                .await;
+            defmt::info!("{}", response);
 
-    info!("GAP init...");
-    ble.init_gap(Role::PERIPHERAL, false, BLE_GAP_DEVICE_NAME_LENGTH).await;
-    let response = ble.read().await.unwrap();
-    defmt::info!("{}", response);
+            info!("config identity root...");
+            let response = ble
+                .write_config_data(&ConfigData::identity_root(&get_irk()).build())
+                .await;
+            defmt::info!("{}", response);
 
-    // info!("set scan response...");
-    // ble.le_set_scan_response_data(&[]).await.unwrap();
-    // let response = ble.read().await.unwrap();
-    // defmt::info!("{}", response);
+            info!("config encryption root...");
+            let response = ble
+                .write_config_data(&ConfigData::encryption_root(&get_erk()).build())
+                .await;
+            defmt::info!("{}", response);
 
-    info!("set discoverable...");
-    ble.set_discoverable(&DiscoverableParameters {
-        advertising_type: AdvertisingType::NonConnectableUndirected,
-        advertising_interval: Some((Duration::from_millis(250), Duration::from_millis(250))),
-        address_type: OwnAddressType::Public,
-        filter_policy: AdvertisingFilterPolicy::AllowConnectionAndScan,
-        local_name: None,
-        advertising_data: &[],
-        conn_interval: (None, None),
-    })
-    .await
-    .unwrap();
+            info!("config tx power level...");
+            let response = ble.set_tx_power_level(PowerLevel::ZerodBm).await;
+            defmt::info!("{}", response);
 
-    let response = ble.read().await;
-    defmt::info!("{}", response);
+            info!("GATT init...");
+            let response = ble.init_gatt().await;
+            defmt::info!("{}", response);
 
-    // remove some advertisement to decrease the packet size
-    info!("delete tx power ad type...");
-    ble.delete_ad_type(AdvertisingDataType::TxPowerLevel).await;
-    let response = ble.read().await.unwrap();
-    defmt::info!("{}", response);
+            info!("GAP init...");
+            let response = ble.init_gap(Role::PERIPHERAL, false, BLE_GAP_DEVICE_NAME_LENGTH).await;
+            defmt::info!("{}", response);
 
-    info!("delete conn interval ad type...");
-    ble.delete_ad_type(AdvertisingDataType::PeripheralConnectionInterval)
-        .await;
-    let response = ble.read().await.unwrap();
-    defmt::info!("{}", response);
+            // info!("set scan response...");
+            // ble.le_set_scan_response_data(&[]).await.unwrap();
+            // let response = ble.read().await.unwrap();
+            // defmt::info!("{}", response);
 
-    info!("update advertising data...");
-    ble.update_advertising_data(&eddystone_advertising_data())
-        .await
-        .unwrap();
-    let response = ble.read().await.unwrap();
-    defmt::info!("{}", response);
+            info!("set discoverable...");
+            let response = ble
+                .set_discoverable(&DiscoverableParameters {
+                    advertising_type: AdvertisingType::NonConnectableUndirected,
+                    advertising_interval: Some((Duration::from_millis(250), Duration::from_millis(250))),
+                    address_type: OwnAddressType::Public,
+                    filter_policy: AdvertisingFilterPolicy::AllowConnectionAndScan,
+                    local_name: None,
+                    advertising_data: &[],
+                    conn_interval: (None, None),
+                })
+                .await
+                .unwrap();
+            defmt::info!("{}", response);
 
-    info!("update advertising data type...");
-    ble.update_advertising_data(&[3, AdvertisingDataType::UuidCompleteList16 as u8, 0xaa, 0xfe])
-        .await
-        .unwrap();
-    let response = ble.read().await.unwrap();
-    defmt::info!("{}", response);
+            // remove some advertisement to decrease the packet size
+            info!("delete tx power ad type...");
+            let response = ble.delete_ad_type(AdvertisingDataType::TxPowerLevel).await;
+            defmt::info!("{}", response);
 
-    info!("update advertising data flags...");
-    ble.update_advertising_data(&[
-        2,
-        AdvertisingDataType::Flags as u8,
-        (0x02 | 0x04) as u8, // BLE general discoverable, without BR/EDR support
-    ])
-    .await
-    .unwrap();
-    let response = ble.read().await.unwrap();
-    defmt::info!("{}", response);
+            info!("delete conn interval ad type...");
+            let response = ble
+                .delete_ad_type(AdvertisingDataType::PeripheralConnectionInterval)
+                .await;
+            defmt::info!("{}", response);
 
-    cortex_m::asm::bkpt();
+            info!("update advertising data...");
+            let response = ble.update_advertising_data(&eddystone_advertising_data()).await;
+            defmt::info!("{}", response);
+
+            info!("update advertising data type...");
+            let response = ble
+                .update_advertising_data(&[3, AdvertisingDataType::UuidCompleteList16 as u8, 0xaa, 0xfe])
+                .await;
+            defmt::info!("{}", response);
+
+            info!("update advertising data flags...");
+            let response = ble
+                .update_advertising_data(&[
+                    2,
+                    AdvertisingDataType::Flags as u8,
+                    (0x02 | 0x04) as u8, // BLE general discoverable, without BR/EDR support
+                ])
+                .await;
+            defmt::info!("{}", response);
+
+            // cortex_m::asm::bkpt();
+        },
+    )
+    .await;
+}
+
+#[embassy_executor::task]
+async fn run_mm_queue(mut memory_manager: mm::MemoryManager<'static>) {
+    memory_manager.run_queue().await;
 }
 
 fn get_bd_addr() -> BdAddr {

--- a/examples/stm32wb/src/bin/gatt_server.rs
+++ b/examples/stm32wb/src/bin/gatt_server.rs
@@ -10,9 +10,11 @@ use embassy_stm32::ipcc::{Config, ReceiveInterruptHandler, TransmitInterruptHand
 use embassy_stm32::rcc::Config as RccConfig;
 use embassy_stm32_wpan::TlMbox;
 use embassy_stm32_wpan::lhci::LhciC1DeviceInformationCcrp;
-use embassy_stm32_wpan::sub::ble::Ble;
+use embassy_stm32_wpan::sub::ble::ControllerAdapter;
 use embassy_stm32_wpan::sub::mm;
-use stm32wb_hci::event::command::{CommandComplete, ReturnParameters};
+use embassy_sync::blocking_mutex::raw::CriticalSectionRawMutex;
+use embassy_sync::channel::{Channel, Sender};
+use static_cell::StaticCell;
 use stm32wb_hci::host::uart::{Packet, UartHci};
 use stm32wb_hci::host::{AdvertisingFilterPolicy, EncryptionKey, HostHci, OwnAddressType};
 use stm32wb_hci::types::AdvertisingType;
@@ -26,7 +28,6 @@ use stm32wb_hci::vendor::command::gatt::{
     WriteResponseParameters,
 };
 use stm32wb_hci::vendor::command::hal::{ConfigData, HalCommands, PowerLevel};
-use stm32wb_hci::vendor::event::command::VendorReturnParameters;
 use stm32wb_hci::vendor::event::{self, AttributeHandle, VendorEvent};
 use stm32wb_hci::{BdAddr, Event};
 use {defmt_rtt as _, panic_probe as _};
@@ -63,93 +64,97 @@ async fn main(spawner: Spawner) {
         Note: extended stack versions are not supported at this time. Do not attempt to install a stack with "extended" in the name.
     */
 
+    static PACKET_CHANNEL: static_cell::StaticCell<Channel<CriticalSectionRawMutex, Packet, 3>> = StaticCell::new();
+    static CONTROLLER: static_cell::StaticCell<ControllerAdapter<'static>> = StaticCell::new();
+
     let mut config = embassy_stm32::Config::default();
     config.rcc = RccConfig::new_wpan();
     let p = embassy_stm32::init(config);
     info!("Hello World!");
 
     let config = Config::default();
-    let (mut ble, mm) = TlMbox::wait_ready(p.IPCC, Irqs, config)
+    let (ble, mm) = TlMbox::wait_ready(p.IPCC, Irqs, config)
         .await
         .unwrap()
         .init_ble(Default::default())
         .await
         .unwrap();
 
+    let pkt_channel = PACKET_CHANNEL.init(Channel::new());
+    let ble = CONTROLLER.init(ControllerAdapter::new(ble));
+    let pkt_sender = pkt_channel.sender();
+    let pkt_receiver = pkt_channel.receiver();
+
     spawner.spawn(run_mm_queue(mm).unwrap());
+    spawner.spawn(receive_packets(ble, pkt_sender).unwrap());
 
     info!("resetting BLE...");
-    ble.reset().await;
-    let response = ble.read().await;
+    let response = ble.reset().await;
     defmt::debug!("{}", response);
 
     info!("config public address...");
-    ble.write_config_data(&ConfigData::public_address(get_bd_addr()).build())
+    let response = ble
+        .write_config_data(&ConfigData::public_address(get_bd_addr()).build())
         .await;
-    let response = ble.read().await;
     defmt::debug!("{}", response);
 
     info!("config random address...");
-    ble.write_config_data(&ConfigData::random_address(get_random_addr()).build())
+    let response = ble
+        .write_config_data(&ConfigData::random_address(get_random_addr()).build())
         .await;
-    let response = ble.read().await;
     defmt::debug!("{}", response);
 
     info!("config identity root...");
-    ble.write_config_data(&ConfigData::identity_root(&get_irk()).build())
+    let response = ble
+        .write_config_data(&ConfigData::identity_root(&get_irk()).build())
         .await;
-    let response = ble.read().await;
     defmt::debug!("{}", response);
 
     info!("config encryption root...");
-    ble.write_config_data(&ConfigData::encryption_root(&get_erk()).build())
+    let response = ble
+        .write_config_data(&ConfigData::encryption_root(&get_erk()).build())
         .await;
-    let response = ble.read().await;
     defmt::debug!("{}", response);
 
     info!("config tx power level...");
-    ble.set_tx_power_level(PowerLevel::ZerodBm).await;
-    let response = ble.read().await;
+    let response = ble.set_tx_power_level(PowerLevel::ZerodBm).await;
     defmt::debug!("{}", response);
 
     info!("GATT init...");
-    ble.init_gatt().await;
-    let response = ble.read().await;
+    let response = ble.init_gatt().await;
     defmt::debug!("{}", response);
 
     info!("GAP init...");
-    ble.init_gap(Role::PERIPHERAL, false, BLE_GAP_DEVICE_NAME_LENGTH).await;
-    let response = ble.read().await;
+    let response = ble.init_gap(Role::PERIPHERAL, false, BLE_GAP_DEVICE_NAME_LENGTH).await;
     defmt::debug!("{}", response);
 
     info!("set IO capabilities...");
-    ble.set_io_capability(IoCapability::DisplayConfirm).await;
-    let response = ble.read().await;
+    let response = ble.set_io_capability(IoCapability::DisplayConfirm).await;
     defmt::debug!("{}", response);
 
     info!("set authentication requirements...");
-    ble.set_authentication_requirement(&AuthenticationRequirements {
-        bonding_required: false,
-        keypress_notification_support: false,
-        mitm_protection_required: false,
-        encryption_key_size_range: (8, 16),
-        fixed_pin: Pin::Requested,
-        identity_address_type: AddressType::Public,
-        secure_connection_support: SecureConnectionSupport::Optional,
-    })
-    .await
-    .unwrap();
-    let response = ble.read().await;
+    let response = ble
+        .set_authentication_requirement(&AuthenticationRequirements {
+            bonding_required: false,
+            keypress_notification_support: false,
+            mitm_protection_required: false,
+            encryption_key_size_range: (8, 16),
+            fixed_pin: Pin::Requested,
+            identity_address_type: AddressType::Public,
+            secure_connection_support: SecureConnectionSupport::Optional,
+        })
+        .await;
     defmt::debug!("{}", response);
 
     info!("set scan response data...");
-    ble.le_set_scan_response_data(b"TXTX").await.unwrap();
-    let response = ble.read().await;
+    let response = ble.le_set_scan_response_data(b"TXTX").await;
     defmt::debug!("{}", response);
 
     defmt::info!("initializing services and characteristics...");
-    let mut ble_context = init_gatt_services(&mut ble).await.unwrap();
+    let ble_context = init_gatt_services(&ble).await;
     defmt::info!("{}", ble_context);
+
+    let mut ble_context = ble_context.unwrap();
 
     let discovery_params = DiscoverableParameters {
         advertising_type: AdvertisingType::ConnectableUndirected,
@@ -162,15 +167,15 @@ async fn main(spawner: Spawner) {
     };
 
     info!("set discoverable...");
-    ble.set_discoverable(&discovery_params).await.unwrap();
-    let response = ble.read().await;
+    let response = ble.set_discoverable(&discovery_params).await;
     defmt::debug!("{}", response);
 
     loop {
-        let response = ble.read().await;
+        let response = pkt_receiver.receive().await;
         defmt::debug!("{}", response);
 
-        if let Ok(Packet::Event(event)) = response {
+        #[allow(irrefutable_let_patterns)]
+        if let Packet::Event(event) = response {
             match event {
                 Event::LeConnectionComplete(_) => {
                     defmt::info!("connected");
@@ -183,7 +188,7 @@ async fn main(spawner: Spawner) {
                 Event::Vendor(vendor_event) => match vendor_event {
                     VendorEvent::AttReadPermitRequest(read_req) => {
                         defmt::info!("read request received {}, allowing", read_req);
-                        ble.allow_read(read_req.conn_handle).await
+                        ble.allow_read(read_req.conn_handle).await.unwrap();
                     }
                     VendorEvent::AttWritePermitRequest(write_req) => {
                         defmt::info!("write request received {}, allowing", write_req);
@@ -212,6 +217,21 @@ async fn main(spawner: Spawner) {
                 },
                 _ => {}
             }
+        }
+    }
+}
+
+#[embassy_executor::task]
+async fn receive_packets(
+    controller: &'static ControllerAdapter<'static>,
+    pkt_sender: Sender<'static, CriticalSectionRawMutex, Packet, 3>,
+) {
+    loop {
+        let response = controller.read_packet().await;
+        defmt::debug!("{}", response);
+
+        if let Ok(packet) = response {
+            pkt_sender.send(packet).await;
         }
     }
 }
@@ -278,11 +298,11 @@ pub struct CharHandles {
     pub notify: AttributeHandle,
 }
 
-pub async fn init_gatt_services<'a>(ble_subsystem: &mut Ble<'a>) -> Result<BleContext, ()> {
-    let service_handle = gatt_add_service(ble_subsystem, Uuid::Uuid16(0x500)).await?;
+pub async fn init_gatt_services<'a>(controller: &ControllerAdapter<'a>) -> Result<BleContext, ()> {
+    let service_handle = gatt_add_service(controller, Uuid::Uuid16(0x500)).await?;
 
     let read = gatt_add_char(
-        ble_subsystem,
+        controller,
         service_handle,
         Uuid::Uuid16(0x501),
         CharacteristicProperty::READ,
@@ -291,7 +311,7 @@ pub async fn init_gatt_services<'a>(ble_subsystem: &mut Ble<'a>) -> Result<BleCo
     .await?;
 
     let write = gatt_add_char(
-        ble_subsystem,
+        controller,
         service_handle,
         Uuid::Uuid16(0x502),
         CharacteristicProperty::WRITE_WITHOUT_RESPONSE | CharacteristicProperty::WRITE | CharacteristicProperty::READ,
@@ -300,7 +320,7 @@ pub async fn init_gatt_services<'a>(ble_subsystem: &mut Ble<'a>) -> Result<BleCo
     .await?;
 
     let notify = gatt_add_char(
-        ble_subsystem,
+        controller,
         service_handle,
         Uuid::Uuid16(0x503),
         CharacteristicProperty::NOTIFY | CharacteristicProperty::READ,
@@ -315,26 +335,17 @@ pub async fn init_gatt_services<'a>(ble_subsystem: &mut Ble<'a>) -> Result<BleCo
     })
 }
 
-async fn gatt_add_service<'a>(ble_subsystem: &mut Ble<'a>, uuid: Uuid) -> Result<AttributeHandle, ()> {
-    ble_subsystem
+async fn gatt_add_service<'a>(controller: &ControllerAdapter<'a>, uuid: Uuid) -> Result<AttributeHandle, ()> {
+    let response = controller
         .add_service(&AddServiceParameters {
             uuid,
             service_type: ServiceType::Primary,
             max_attribute_records: 8,
         })
         .await;
-    let response = ble_subsystem.read().await;
     defmt::debug!("{}", response);
 
-    if let Ok(Packet::Event(Event::CommandComplete(CommandComplete {
-        return_params:
-            ReturnParameters::Vendor(VendorReturnParameters::GattAddService(event::command::GattService {
-                service_handle,
-                ..
-            })),
-        ..
-    }))) = response
-    {
+    if let Ok(event::command::GattService { service_handle }) = response {
         Ok(service_handle)
     } else {
         Err(())
@@ -342,13 +353,13 @@ async fn gatt_add_service<'a>(ble_subsystem: &mut Ble<'a>, uuid: Uuid) -> Result
 }
 
 async fn gatt_add_char<'a>(
-    ble_subsystem: &mut Ble<'a>,
+    controller: &ControllerAdapter<'a>,
     service_handle: AttributeHandle,
     characteristic_uuid: Uuid,
     characteristic_properties: CharacteristicProperty,
     default_value: Option<&[u8]>,
 ) -> Result<AttributeHandle, ()> {
-    ble_subsystem
+    let response = controller
         .add_characteristic(&AddCharacteristicParameters {
             service_handle,
             characteristic_uuid,
@@ -360,30 +371,19 @@ async fn gatt_add_char<'a>(
             is_variable: true,
         })
         .await;
-    let response = ble_subsystem.read().await;
     defmt::debug!("{}", response);
 
-    if let Ok(Packet::Event(Event::CommandComplete(CommandComplete {
-        return_params:
-            ReturnParameters::Vendor(VendorReturnParameters::GattAddCharacteristic(event::command::GattCharacteristic {
-                characteristic_handle,
-                ..
-            })),
-        ..
-    }))) = response
-    {
+    if let Ok(event::command::GattCharacteristic { characteristic_handle }) = response {
         if let Some(value) = default_value {
-            ble_subsystem
+            let response = controller
                 .update_characteristic_value(&UpdateCharacteristicValueParameters {
                     service_handle,
                     characteristic_handle,
                     offset: 0,
                     value,
                 })
-                .await
-                .unwrap();
+                .await;
 
-            let response = ble_subsystem.read().await;
             defmt::debug!("{}", response);
         }
         Ok(characteristic_handle)

--- a/examples/stm32wba/Cargo.toml
+++ b/examples/stm32wba/Cargo.toml
@@ -24,7 +24,7 @@ panic-probe = { version = "1.0.0", features = ["print-defmt"] }
 heapless = { version = "0.9", default-features = false }
 static_cell = "2"
 embedded-io-async = "0.7.0"
-stm32wb-hci = "0.17.4"
+stm32wb-hci = { version = "0.17.4", git="https://github.com/embassy-rs/stm32wb-hci.git", rev="0ea312" }
 
 [features]
 default = ["ble"]

--- a/examples/stm32wba6/Cargo.toml
+++ b/examples/stm32wba6/Cargo.toml
@@ -29,7 +29,7 @@ embedded-hal = "1.0.0"
 panic-probe = { version = "1.0.0", features = ["print-defmt"] }
 heapless = { version = "0.9", default-features = false }
 static_cell = "2"
-stm32wb-hci = "0.17.4"
+stm32wb-hci = { version = "0.17.4", git="https://github.com/embassy-rs/stm32wb-hci.git", rev="0ea312" }
 
 [features]
 default = ["ble"]

--- a/tests/stm32/Cargo.toml
+++ b/tests/stm32/Cargo.toml
@@ -102,7 +102,7 @@ rand_chacha = { version = "0.9.0", default-features = false }
 static_cell = "2"
 portable-atomic = { version = "1.5", features = [] }
 critical-section = "1.1"
-stm32wb-hci = { version = "0.17.4", optional = true }
+stm32wb-hci = { version = "0.17.4", optional = true, git="https://github.com/embassy-rs/stm32wb-hci.git", rev="0ea312"  }
 
 chrono = { version = "^0.4", default-features = false, optional = true}
 sha2 = { version = "0.10.8", default-features = false }

--- a/tests/stm32/src/bin/wpan_ble.rs
+++ b/tests/stm32/src/bin/wpan_ble.rs
@@ -9,11 +9,13 @@ use core::time::Duration;
 
 use common::*;
 use embassy_executor::Spawner;
+use embassy_futures::join::join;
 use embassy_stm32::bind_interrupts;
 use embassy_stm32::ipcc::{Config, ReceiveInterruptHandler, TransmitInterruptHandler};
 use embassy_stm32::rcc::Config as RccConfig;
 use embassy_stm32_wpan::TlMbox;
 use embassy_stm32_wpan::lhci::LhciC1DeviceInformationCcrp;
+use embassy_stm32_wpan::sub::ble::ControllerAdapter;
 use embassy_stm32_wpan::sub::mm;
 use stm32wb_hci::BdAddr;
 use stm32wb_hci::host::uart::UartHci;
@@ -64,114 +66,118 @@ async fn main(spawner: Spawner) {
         version_major, version_minor, subversion, sram2a_size, sram2b_size
     );
 
-    let (mut ble, mm) = mbox.init_ble(Default::default()).await.unwrap();
+    let (ble, mm) = mbox.init_ble(Default::default()).await.unwrap();
 
     spawner.spawn(run_mm_queue(mm).unwrap());
 
-    info!("resetting BLE...");
-    ble.reset().await;
-    let response = ble.read().await.unwrap();
-    info!("{}", response);
+    let ble = ControllerAdapter::new(ble);
 
-    info!("config public address...");
-    ble.write_config_data(&ConfigData::public_address(get_bd_addr()).build())
-        .await;
-    let response = ble.read().await.unwrap();
-    info!("{}", response);
+    join(
+        async {
+            loop {
+                let pkt = ble.read_packet().await;
 
-    info!("config random address...");
-    ble.write_config_data(&ConfigData::random_address(get_random_addr()).build())
-        .await;
-    let response = ble.read().await.unwrap();
-    info!("{}", response);
+                info!("pkt: {}", pkt);
+            }
+        },
+        async {
+            info!("resetting BLE...");
+            let response = ble.reset().await;
+            info!("{}", response);
 
-    info!("config identity root...");
-    ble.write_config_data(&ConfigData::identity_root(&get_irk()).build())
-        .await;
-    let response = ble.read().await.unwrap();
-    info!("{}", response);
+            info!("config public address...");
 
-    info!("config encryption root...");
-    ble.write_config_data(&ConfigData::encryption_root(&get_erk()).build())
-        .await;
-    let response = ble.read().await.unwrap();
-    info!("{}", response);
+            let response = ble
+                .write_config_data(&ConfigData::public_address(get_bd_addr()).build())
+                .await;
+            info!("{}", response);
 
-    info!("config tx power level...");
-    ble.set_tx_power_level(PowerLevel::ZerodBm).await;
-    let response = ble.read().await.unwrap();
-    info!("{}", response);
+            info!("config random address...");
+            let response = ble
+                .write_config_data(&ConfigData::random_address(get_random_addr()).build())
+                .await;
+            info!("{}", response);
 
-    info!("GATT init...");
-    ble.init_gatt().await;
-    let response = ble.read().await.unwrap();
-    info!("{}", response);
+            info!("config identity root...");
+            let response = ble
+                .write_config_data(&ConfigData::identity_root(&get_irk()).build())
+                .await;
+            info!("{}", response);
 
-    info!("GAP init...");
-    ble.init_gap(Role::PERIPHERAL, false, BLE_GAP_DEVICE_NAME_LENGTH).await;
-    let response = ble.read().await.unwrap();
-    info!("{}", response);
+            info!("config encryption root...");
+            let response = ble
+                .write_config_data(&ConfigData::encryption_root(&get_erk()).build())
+                .await;
+            info!("{}", response);
 
-    // info!("set scan response...");
-    // ble.le_set_scan_response_data(&[]).await.unwrap();
-    // let response = ble.read().await.unwrap();
-    // info!("{}", response);
+            info!("config tx power level...");
+            let response = ble.set_tx_power_level(PowerLevel::ZerodBm).await;
+            info!("{}", response);
 
-    info!("set discoverable...");
-    ble.set_discoverable(&DiscoverableParameters {
-        advertising_type: AdvertisingType::NonConnectableUndirected,
-        advertising_interval: Some((Duration::from_millis(250), Duration::from_millis(250))),
-        address_type: OwnAddressType::Public,
-        filter_policy: AdvertisingFilterPolicy::AllowConnectionAndScan,
-        local_name: None,
-        advertising_data: &[],
-        conn_interval: (None, None),
-    })
-    .await
-    .unwrap();
+            info!("GATT init...");
+            let response = ble.init_gatt().await;
+            info!("{}", response);
 
-    let response = ble.read().await;
-    info!("{}", response);
+            info!("GAP init...");
+            let response = ble.init_gap(Role::PERIPHERAL, false, BLE_GAP_DEVICE_NAME_LENGTH).await;
+            info!("{}", response);
 
-    // remove some advertisement to decrease the packet size
-    info!("delete tx power ad type...");
-    ble.delete_ad_type(AdvertisingDataType::TxPowerLevel).await;
-    let response = ble.read().await.unwrap();
-    info!("{}", response);
+            // info!("set scan response...");
+            // ble.le_set_scan_response_data(&[]).await.unwrap();
+            // let response = ble.read().await.unwrap();
+            // info!("{}", response);
 
-    info!("delete conn interval ad type...");
-    ble.delete_ad_type(AdvertisingDataType::PeripheralConnectionInterval)
-        .await;
-    let response = ble.read().await.unwrap();
-    info!("{}", response);
+            info!("set discoverable...");
+            let response = ble
+                .set_discoverable(&DiscoverableParameters {
+                    advertising_type: AdvertisingType::NonConnectableUndirected,
+                    advertising_interval: Some((Duration::from_millis(250), Duration::from_millis(250))),
+                    address_type: OwnAddressType::Public,
+                    filter_policy: AdvertisingFilterPolicy::AllowConnectionAndScan,
+                    local_name: None,
+                    advertising_data: &[],
+                    conn_interval: (None, None),
+                })
+                .await
+                .unwrap();
+            info!("{}", response);
 
-    info!("update advertising data...");
-    ble.update_advertising_data(&eddystone_advertising_data())
-        .await
-        .unwrap();
-    let response = ble.read().await.unwrap();
-    info!("{}", response);
+            // remove some advertisement to decrease the packet size
+            info!("delete tx power ad type...");
+            let response = ble.delete_ad_type(AdvertisingDataType::TxPowerLevel).await;
+            info!("{}", response);
 
-    info!("update advertising data type...");
-    ble.update_advertising_data(&[3, AdvertisingDataType::UuidCompleteList16 as u8, 0xaa, 0xfe])
-        .await
-        .unwrap();
-    let response = ble.read().await.unwrap();
-    info!("{}", response);
+            info!("delete conn interval ad type...");
+            let response = ble
+                .delete_ad_type(AdvertisingDataType::PeripheralConnectionInterval)
+                .await;
+            info!("{}", response);
 
-    info!("update advertising data flags...");
-    ble.update_advertising_data(&[
-        2,
-        AdvertisingDataType::Flags as u8,
-        (0x02 | 0x04) as u8, // BLE general discoverable, without BR/EDR support
-    ])
-    .await
-    .unwrap();
-    let response = ble.read().await.unwrap();
-    info!("{}", response);
+            info!("update advertising data...");
+            let response = ble.update_advertising_data(&eddystone_advertising_data()).await;
+            info!("{}", response);
 
-    info!("Test OK");
-    cortex_m::asm::bkpt();
+            info!("update advertising data type...");
+            let response = ble
+                .update_advertising_data(&[3, AdvertisingDataType::UuidCompleteList16 as u8, 0xaa, 0xfe])
+                .await;
+            info!("{}", response);
+
+            info!("update advertising data flags...");
+            let response = ble
+                .update_advertising_data(&[
+                    2,
+                    AdvertisingDataType::Flags as u8,
+                    (0x02 | 0x04) as u8, // BLE general discoverable, without BR/EDR support
+                ])
+                .await;
+            info!("{}", response);
+
+            info!("Tesk OK");
+            cortex_m::asm::bkpt();
+        },
+    )
+    .await;
 }
 
 fn get_bd_addr() -> BdAddr {


### PR DESCRIPTION
Based on refactoring stm32wb-hci to use bt-hci

- [x] merge embassy-rs/bt-hci#81
- [x] update and verify stm32wb examples
- [ ] merge OueslatiGhaith/stm32wb-hci#21
- [x] release bt-hci
- [ ] release stm32wb-hci
 