### PR TITLE
nrf_ppi: time_driver_grtc: Switch to CC[11] to keep CC[0] free

### DIFF
--- a/embassy-nrf/src/time_driver.rs
+++ b/embassy-nrf/src/time_driver.rs
@@ -23,6 +23,22 @@ fn rtc() -> pac::rtc::Rtc {
     pac::RTC1
 }
 
+// The nRF54 series (which has the GRTC) uses asymmetric channels
+// Namely, CC[0] is the only channel which supports "periodic interval" (page 298 in the datasheet),
+// which supports periodic alarms by adding the value in the INTERVAL register when EVENTS_COMPARE[0] triggers
+// Because the time driver does not make use of periodic alarms (but always reprograms it), it does not need to make use of this.
+// This selects the last CC channel (CC[11]) instead of CC[0] to keep CC[0] free for application use,
+// specifically for PPI-driven events that aim to avoid CPU intervention in periodic tasks.
+#[cfg(feature = "_grtc")]
+fn time_driver_cc_n() -> usize {
+    11
+}
+
+#[cfg(not(feature = "_grtc"))]
+fn time_driver_cc_n() -> usize {
+    0
+}
+
 // On nRF54L/LM GRTC, SYSCOUNTER[n], INTENSETn/INTENCLRn/INTENn, and the
 // GRTC_n interrupt all index by "domain":
 //   FLPR              = 0
@@ -209,7 +225,7 @@ impl RtcDriver {
         // GRTC initialization for nRF54L/LM series.
         #[cfg(feature = "_grtc")]
         {
-            let n = 0;
+            let n = time_driver_cc_n();
 
             // 1. Disable the SYSCOUNTER before reconfiguring
             r.mode().modify(|w| w.set_syscounteren(false));
@@ -282,7 +298,7 @@ impl RtcDriver {
             self.next_period();
         }
 
-        let n = 0;
+        let n = time_driver_cc_n();
         if r.events_compare(n).read() == 1 {
             r.events_compare(n).write_value(0);
             critical_section::with(|cs| {
@@ -311,7 +327,7 @@ impl RtcDriver {
     }
 
     fn trigger_alarm(&self, cs: CriticalSection) {
-        let n = 0;
+        let n = time_driver_cc_n();
         let r = rtc();
         #[cfg(not(feature = "_grtc"))]
         r.intenclr().write(|w| w.0 = compare_n(n));
@@ -329,7 +345,7 @@ impl RtcDriver {
     }
 
     fn set_alarm(&self, cs: CriticalSection, timestamp: u64) -> bool {
-        let n = 0;
+        let n = time_driver_cc_n();
         let alarm = &self.alarms.borrow(cs);
         alarm.timestamp.set(timestamp);
 

--- a/embassy-nrf/src/time_driver.rs
+++ b/embassy-nrf/src/time_driver.rs
@@ -29,15 +29,7 @@ fn rtc() -> pac::rtc::Rtc {
 // Because the time driver does not make use of periodic alarms (but always reprograms it), it does not need to make use of this.
 // This selects the last CC channel (CC[11]) instead of CC[0] to keep CC[0] free for application use,
 // specifically for PPI-driven events that aim to avoid CPU intervention in periodic tasks.
-#[cfg(feature = "_grtc")]
-fn time_driver_cc_n() -> usize {
-    11
-}
-
-#[cfg(not(feature = "_grtc"))]
-fn time_driver_cc_n() -> usize {
-    0
-}
+const TIME_DRIVER_CC_N: usize = if cfg!(feature = "_grtc") { 11 } else { 0 };
 
 // On nRF54L/LM GRTC, SYSCOUNTER[n], INTENSETn/INTENCLRn/INTENn, and the
 // GRTC_n interrupt all index by "domain":
@@ -225,7 +217,7 @@ impl RtcDriver {
         // GRTC initialization for nRF54L/LM series.
         #[cfg(feature = "_grtc")]
         {
-            let n = time_driver_cc_n();
+            let n = TIME_DRIVER_CC_N;
 
             // 1. Disable the SYSCOUNTER before reconfiguring
             r.mode().modify(|w| w.set_syscounteren(false));
@@ -298,7 +290,7 @@ impl RtcDriver {
             self.next_period();
         }
 
-        let n = time_driver_cc_n();
+        let n = TIME_DRIVER_CC_N;
         if r.events_compare(n).read() == 1 {
             r.events_compare(n).write_value(0);
             critical_section::with(|cs| {
@@ -315,7 +307,7 @@ impl RtcDriver {
             self.period.store(period, Ordering::Relaxed);
             let t = (period as u64) << 23;
 
-            let n = 0;
+            let n = TIME_DRIVER_CC_N;
             let alarm = &self.alarms.borrow(cs);
             let at = alarm.timestamp.get();
 
@@ -327,7 +319,7 @@ impl RtcDriver {
     }
 
     fn trigger_alarm(&self, cs: CriticalSection) {
-        let n = time_driver_cc_n();
+        let n = TIME_DRIVER_CC_N;
         let r = rtc();
         #[cfg(not(feature = "_grtc"))]
         r.intenclr().write(|w| w.0 = compare_n(n));
@@ -345,7 +337,7 @@ impl RtcDriver {
     }
 
     fn set_alarm(&self, cs: CriticalSection, timestamp: u64) -> bool {
-        let n = time_driver_cc_n();
+        let n = TIME_DRIVER_CC_N;
         let alarm = &self.alarms.borrow(cs);
         alarm.timestamp.set(timestamp);
 


### PR DESCRIPTION
A proposal to fix the issue outlined in #6126 .

I'm not sure about the implications onto other chips. From what I understand, the `_grtc` feature is currently available only on `nrf54*` ICs. However, this change could be a breaking change potentially, especially if existing applications already use CC[11] differently.

I'm not sure if adding a feature flag to switch to CC[11] makes more sense, but this could potentially clutter the feature flag namespace for a technically small change.

Also, I cannot test other chips, and I'm not sure about the implications on the nRF53. Any feedback is welcome