### PR TITLE
wpan/bluetooth: fix advertising name and use random static address on WBA

### DIFF
--- a/embassy-stm32-wpan/src/bluetooth/gap/aci_gap.rs
+++ b/embassy-stm32-wpan/src/bluetooth/gap/aci_gap.rs
@@ -57,6 +57,27 @@ unsafe extern "C" {
     /// Set device in non-discoverable mode (stop advertising)
     #[link_name = "ACI_GAP_SET_NON_DISCOVERABLE"]
     fn aci_gap_set_non_discoverable() -> tBleStatus;
+
+    /// Start the GAP observation procedure (scanning without connection intent).
+    ///
+    /// Unlike raw HCI_LE_SET_SCAN_ENABLE, this routes advertising reports
+    /// through the host layer so they arrive via BLECB_Indication as standard
+    /// HCI_LE_Advertising_Report events.
+    #[link_name = "ACI_GAP_START_OBSERVATION_PROC"]
+    fn aci_gap_start_observation_proc(
+        le_scan_interval: u16,
+        le_scan_window: u16,
+        le_scan_type: u8,
+        own_address_type: u8,
+        filter_duplicates: u8,
+        scanning_filter_policy: u8,
+    ) -> tBleStatus;
+
+    /// Terminate a running GAP procedure.
+    ///
+    /// Pass `procedure_code = 0x80` to stop `GAP_OBSERVATION_PROC`.
+    #[link_name = "ACI_GAP_TERMINATE_GAP_PROC"]
+    fn aci_gap_terminate_gap_proc(procedure_code: u8) -> tBleStatus;
 }
 
 /// Start advertising using aci_gap_set_discoverable
@@ -130,6 +151,47 @@ pub fn set_discoverable(
             defmt::error!("aci_gap_set_discoverable failed: 0x{:02X}", status);
             Err(BleError::CommandFailed(Status::from_u8(status)))
         }
+    }
+}
+
+/// Start the GAP observation procedure (passive or active scanning).
+///
+/// Advertising reports arrive as standard `HCI_LE_Advertising_Report` events
+/// via `BLECB_Indication`.  This is the correct way to scan on the WBA BLE
+/// stack — raw `HCI_LE_SET_SCAN_ENABLE` starts the radio but does not route
+/// reports through the host layer.
+pub fn start_observation(
+    scan_interval: u16,
+    scan_window: u16,
+    scan_type: u8,
+    own_address_type: u8,
+    filter_duplicates: bool,
+    filter_policy: u8,
+) -> Result<(), BleError> {
+    let status = unsafe {
+        aci_gap_start_observation_proc(
+            scan_interval,
+            scan_window,
+            scan_type,
+            own_address_type,
+            filter_duplicates as u8,
+            filter_policy,
+        )
+    };
+    if status == BLE_STATUS_SUCCESS {
+        Ok(())
+    } else {
+        Err(BleError::CommandFailed(Status::from_u8(status)))
+    }
+}
+
+/// Stop the running GAP observation procedure (`procedure_code = 0x80`).
+pub fn stop_observation() -> Result<(), BleError> {
+    let status = unsafe { aci_gap_terminate_gap_proc(0x80) };
+    if status == BLE_STATUS_SUCCESS {
+        Ok(())
+    } else {
+        Err(BleError::CommandFailed(Status::from_u8(status)))
     }
 }
 

--- a/embassy-stm32-wpan/src/bluetooth/gap/advertiser.rs
+++ b/embassy-stm32-wpan/src/bluetooth/gap/advertiser.rs
@@ -90,7 +90,11 @@ pub(crate) fn update_scan_rsp_data(cmd: &CommandSender, scan_rsp_data: &AdvData)
     cmd.le_set_scan_response_data(scan_rsp_data.build())
 }
 
-/// Extract local name from advertising data
+/// Extract local name AD field from advertising data.
+///
+/// Returns the slice `[ad_type, name_bytes...]` — the AD-type byte (0x08 or 0x09)
+/// is kept as the first byte because `aci_gap_set_discoverable` expects it that
+/// way and counts it in `local_name_length`.
 pub(crate) fn extract_local_name(adv_data: &[u8]) -> Option<&[u8]> {
     let mut offset = 0;
     while offset < adv_data.len() {
@@ -106,7 +110,7 @@ pub(crate) fn extract_local_name(adv_data: &[u8]) -> Option<&[u8]> {
         // AD_TYPE_COMPLETE_LOCAL_NAME = 0x09
         // AD_TYPE_SHORTENED_LOCAL_NAME = 0x08
         if ad_type == 0x09 || ad_type == 0x08 {
-            return Some(&adv_data[offset + 2..offset + 1 + len]);
+            return Some(&adv_data[offset + 1..offset + 1 + len]);
         }
 
         offset += 1 + len;
@@ -114,8 +118,11 @@ pub(crate) fn extract_local_name(adv_data: &[u8]) -> Option<&[u8]> {
     None
 }
 
-/// Extract 16-bit service UUID bytes from advertising data.
-/// Returns raw bytes in the format expected by aci_gap_set_discoverable.
+/// Extract 16-bit service UUID AD field from advertising data.
+///
+/// Returns the slice `[ad_type, uuid_bytes_le...]` — the AD-type byte (0x02 or 0x03)
+/// is kept as the first byte because `aci_gap_set_discoverable` expects it that way
+/// and counts it in `service_uuid_length`.
 pub(crate) fn extract_service_uuids_16(adv_data: &[u8]) -> Option<&[u8]> {
     let mut offset = 0;
     while offset < adv_data.len() {
@@ -131,7 +138,7 @@ pub(crate) fn extract_service_uuids_16(adv_data: &[u8]) -> Option<&[u8]> {
         // AD_TYPE_16_BIT_SERV_UUID = 0x02 (incomplete list)
         // AD_TYPE_16_BIT_SERV_UUID_CMPLT_LIST = 0x03 (complete list)
         if ad_type == 0x02 || ad_type == 0x03 {
-            return Some(&adv_data[offset + 2..offset + 1 + len]);
+            return Some(&adv_data[offset + 1..offset + 1 + len]);
         }
 
         offset += 1 + len;

--- a/embassy-stm32-wpan/src/bluetooth/gap/scanner.rs
+++ b/embassy-stm32-wpan/src/bluetooth/gap/scanner.rs
@@ -7,7 +7,6 @@ use stm32wb_hci::host::OwnAddressType;
 
 use crate::bluetooth::error::BleError;
 use crate::bluetooth::gap::aci_gap;
-use crate::bluetooth::hci::CommandSender;
 
 /// Scan type
 #[repr(u8)]
@@ -141,18 +140,14 @@ impl ScanParams {
 ///
 /// The Scanner provides methods for starting and stopping BLE scanning.
 /// Advertising reports are received through the main event loop.
-pub struct Scanner<'d> {
-    cmd: &'d CommandSender,
+pub struct Scanner {
     is_scanning: bool,
 }
 
-impl<'d> Scanner<'d> {
+impl Scanner {
     /// Create a new Scanner
-    pub(crate) fn new(cmd: &'d CommandSender) -> Self {
-        Self {
-            cmd,
-            is_scanning: false,
-        }
+    pub(crate) fn new() -> Self {
+        Self { is_scanning: false }
     }
 
     /// Start scanning with the given parameters

--- a/embassy-stm32-wpan/src/bluetooth/gap/scanner.rs
+++ b/embassy-stm32-wpan/src/bluetooth/gap/scanner.rs
@@ -6,6 +6,7 @@
 use stm32wb_hci::host::OwnAddressType;
 
 use crate::bluetooth::error::BleError;
+use crate::bluetooth::gap::aci_gap;
 use crate::bluetooth::hci::CommandSender;
 
 /// Scan type
@@ -180,17 +181,18 @@ impl<'d> Scanner<'d> {
     /// }
     /// ```
     pub fn start(&mut self, params: ScanParams) -> Result<(), BleError> {
-        // Set scan parameters
-        self.cmd.le_set_scan_parameters(
-            params.scan_type as u8,
+        // Use the GAP observation procedure instead of raw HCI scan commands.
+        // Raw HCI_LE_SET_SCAN_ENABLE starts the radio but the WBA host layer
+        // never routes the resulting reports through BLECB_Indication; only
+        // ACI_GAP_START_OBSERVATION_PROC does.
+        aci_gap::start_observation(
             params.scan_interval,
             params.scan_window,
-            params.own_address_type,
+            params.scan_type as u8,
+            params.own_address_type as u8,
+            params.filter_duplicates,
             params.filter_policy as u8,
         )?;
-
-        // Enable scanning
-        self.cmd.le_set_scan_enable(true, params.filter_duplicates)?;
 
         self.is_scanning = true;
         Ok(())
@@ -199,7 +201,7 @@ impl<'d> Scanner<'d> {
     /// Stop scanning
     pub fn stop(&mut self) -> Result<(), BleError> {
         if self.is_scanning {
-            self.cmd.le_set_scan_enable(false, false)?;
+            aci_gap::stop_observation()?;
             self.is_scanning = false;
         }
         Ok(())

--- a/embassy-stm32-wpan/src/bluetooth/gap/types.rs
+++ b/embassy-stm32-wpan/src/bluetooth/gap/types.rs
@@ -54,7 +54,8 @@ impl Default for AdvParams {
             interval_min: 0x0800, // 1.28 seconds
             interval_max: 0x0800, // 1.28 seconds
             adv_type: AdvType::ConnectableUndirected,
-            own_addr_type: OwnAddressType::Public,
+            // Matches the default address type configured in `GapInitParams`.
+            own_addr_type: OwnAddressType::Random,
             filter_policy: AdvFilterPolicy::All,
             channel_map: 0x07, // All channels
         }

--- a/embassy-stm32-wpan/src/bluetooth/gap_init.rs
+++ b/embassy-stm32-wpan/src/bluetooth/gap_init.rs
@@ -27,6 +27,8 @@ const CONFIG_DATA_GAP_ADD_REC_NBR_LEN: u8 = 1;
 const GAP_PERIPHERAL_ROLE: u8 = 0x01;
 #[allow(dead_code)]
 const GAP_CENTRAL_ROLE: u8 = 0x04;
+#[allow(dead_code)]
+const GAP_OBSERVER_ROLE: u8 = 0x08;
 
 #[link(name = "stm32wba_ble_stack_basic")]
 unsafe extern "C" {
@@ -128,6 +130,9 @@ pub enum GapRole {
     Peripheral,
     Central,
     Both,
+    /// Observer: scanning only, no advertising or connections.
+    /// Required for `ACI_GAP_START_OBSERVATION_PROC`.
+    Observer,
 }
 
 impl GapRole {
@@ -136,6 +141,7 @@ impl GapRole {
             GapRole::Peripheral => GAP_PERIPHERAL_ROLE,
             GapRole::Central => GAP_CENTRAL_ROLE,
             GapRole::Both => GAP_PERIPHERAL_ROLE | GAP_CENTRAL_ROLE,
+            GapRole::Observer => GAP_OBSERVER_ROLE,
         }
     }
 }

--- a/embassy-stm32-wpan/src/bluetooth/gap_init.rs
+++ b/embassy-stm32-wpan/src/bluetooth/gap_init.rs
@@ -82,6 +82,18 @@ unsafe extern "C" {
     ) -> tBleStatus;
 }
 
+/// Address type to use for the device.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum AddressType {
+    /// IEEE-registered public address. Written to PUBADDR (config offset 0x00).
+    /// Requires a real OUI; the WBA stack-basic library will reject the write
+    /// if the address violates expectations.
+    Public,
+    /// Random static address. The caller sets it via `hci_le_set_random_address`
+    /// after `init_gap_and_hal` returns; the PUBADDR config write is skipped.
+    RandomStatic,
+}
+
 /// GAP initialization parameters
 pub struct GapInitParams {
     /// Device role (peripheral, central, or both)
@@ -92,8 +104,10 @@ pub struct GapInitParams {
     pub device_name: &'static [u8],
     /// GAP appearance value
     pub appearance: u16,
-    /// BD address (6 bytes)
+    /// BD address (6 bytes). For `RandomStatic`, the top two bits of byte 5 must be `11`.
     pub bd_addr: [u8; 6],
+    /// Whether `bd_addr` is a public or random static address.
+    pub address_type: AddressType,
     /// Identity Root key (16 bytes) for IRK derivation
     pub ir_value: [u8; 16],
     /// Encryption Root key (16 bytes) for LTK derivation
@@ -203,8 +217,12 @@ impl Default for GapInitParams {
             role: GapRole::Peripheral,
             privacy_enabled: false,
             device_name: b"Embassy-BLE",
-            appearance: 0,                                 // Unknown
-            bd_addr: [0xE1, 0x80, 0xE1, 0x26, 0x1A, 0x00], // Default address
+            appearance: 0, // Unknown
+            // Random static address: top two bits of byte 5 are `11`.
+            // Callers that want a per-chip address should overwrite all 6 bytes
+            // (e.g. from the chip UID) and then `bd_addr[5] |= 0xC0`.
+            bd_addr: [0x00, 0x1A, 0x26, 0xE1, 0x80, 0xC1],
+            address_type: AddressType::RandomStatic,
             ir_value: [0x12; 16],
             er_value: [0x34; 16],
             tx_power: 25, // +6 dBm
@@ -248,26 +266,44 @@ pub fn init_gap_and_hal(params: &GapInitParams) -> Result<GapHandles, BleError> 
             warn!("aci_hal_write_config_data (GAP_ADD_REC_NBR) failed: 0x{:02X}", status);
         }
 
-        // 2. Write BD address
-        let status = aci_hal_write_config_data(
-            CONFIG_DATA_PUBADDR_OFFSET,
-            CONFIG_DATA_PUBADDR_LEN,
-            params.bd_addr.as_ptr(),
-        );
-        if status != BLE_STATUS_SUCCESS {
-            error!("aci_hal_write_config_data (PUBADDR) failed: 0x{:02X}", status);
-            return Err(BleError::CommandFailed(Status::from_u8(status)));
+        // 2. Write BD address (only for public addresses).
+        //
+        // For random static addresses, the WBA stack-basic library doesn't accept
+        // PUBADDR writes — the caller programs the random address via
+        // `hci_le_set_random_address` after this function returns.
+        match params.address_type {
+            AddressType::Public => {
+                let status = aci_hal_write_config_data(
+                    CONFIG_DATA_PUBADDR_OFFSET,
+                    CONFIG_DATA_PUBADDR_LEN,
+                    params.bd_addr.as_ptr(),
+                );
+                if status != BLE_STATUS_SUCCESS {
+                    error!("aci_hal_write_config_data (PUBADDR) failed: 0x{:02X}", status);
+                    return Err(BleError::CommandFailed(Status::from_u8(status)));
+                }
+                info!(
+                    "Public BD address configured: {:02X}:{:02X}:{:02X}:{:02X}:{:02X}:{:02X}",
+                    params.bd_addr[5],
+                    params.bd_addr[4],
+                    params.bd_addr[3],
+                    params.bd_addr[2],
+                    params.bd_addr[1],
+                    params.bd_addr[0]
+                );
+            }
+            AddressType::RandomStatic => {
+                info!(
+                    "Random static address (to be set via HCI): {:02X}:{:02X}:{:02X}:{:02X}:{:02X}:{:02X}",
+                    params.bd_addr[5],
+                    params.bd_addr[4],
+                    params.bd_addr[3],
+                    params.bd_addr[2],
+                    params.bd_addr[1],
+                    params.bd_addr[0]
+                );
+            }
         }
-
-        info!(
-            "BD Address configured: {:02X}:{:02X}:{:02X}:{:02X}:{:02X}:{:02X}",
-            params.bd_addr[5],
-            params.bd_addr[4],
-            params.bd_addr[3],
-            params.bd_addr[2],
-            params.bd_addr[1],
-            params.bd_addr[0]
-        );
 
         // 3. Write IR (Identity Root) value
         let status = aci_hal_write_config_data(CONFIG_DATA_IR_OFFSET, CONFIG_DATA_IR_LEN, params.ir_value.as_ptr());

--- a/embassy-stm32-wpan/src/bluetooth/hci/command.rs
+++ b/embassy-stm32-wpan/src/bluetooth/hci/command.rs
@@ -4,7 +4,6 @@
 //! These functions are synchronous and return a status code immediately, which simplifies
 //! the implementation compared to packet-based HCI.
 
-use stm32_bindings::ble;
 use stm32wb_hci::BdAddrType;
 use stm32wb_hci::host::OwnAddressType;
 
@@ -145,6 +144,12 @@ unsafe extern "C" {
 
     #[link_name = "ACI_HAL_LE_TX_TEST_PACKET_NUMBER"]
     fn aci_hal_le_tx_test_packet_number(num_packets: *mut u32) -> tBleStatus;
+
+    #[link_name = "HCI_LE_SET_RANDOM_ADDRESS"]
+    fn hci_le_set_random_address(random_address: *const u8) -> tBleStatus;
+
+    #[link_name = "HCI_LE_READ_ADVERTISING_PHYSICAL_CHANNEL_TX_POWER"]
+    fn hci_le_read_advertising_physical_channel_tx_power(transmit_power_level: *mut u8) -> tBleStatus;
 }
 
 /// BLE Success status code
@@ -273,7 +278,7 @@ impl CommandSender {
     /// Set random address
     pub fn le_set_random_address(&self, address: &[u8; 6]) -> Result<(), BleError> {
         unsafe {
-            let status = ble::hci_le_set_random_address(address.as_ptr());
+            let status = hci_le_set_random_address(address.as_ptr());
             Self::check_status(status)
         }
     }
@@ -309,7 +314,7 @@ impl CommandSender {
     pub fn le_read_advertising_channel_tx_power(&self) -> Result<i8, BleError> {
         unsafe {
             let mut tx_power = 0u8;
-            let status = ble::hci_le_read_advertising_physical_channel_tx_power(&mut tx_power);
+            let status = hci_le_read_advertising_physical_channel_tx_power(&mut tx_power);
             Self::check_status(status)?;
             Ok(tx_power as i8)
         }

--- a/embassy-stm32-wpan/src/bluetooth/mod.rs
+++ b/embassy-stm32-wpan/src/bluetooth/mod.rs
@@ -21,7 +21,7 @@ use crate::bluetooth::gap::connection::{
 };
 use crate::bluetooth::gap::scanner::Scanner;
 use crate::bluetooth::gap::types::{AdvData, AdvParams};
-use crate::bluetooth::gap_init::{GapInitParams, init_gap_and_hal};
+use crate::bluetooth::gap_init::{GapInitParams, GapRole, init_gap_and_hal};
 use crate::bluetooth::gatt::GattServer;
 use crate::bluetooth::gatt::server::init_gatt_layer;
 use crate::bluetooth::hci::command::CommandSender;
@@ -98,6 +98,20 @@ impl<'d> HCI<'d, Normal> {
         irq: impl interrupt::typelevel::Binding<interrupt::typelevel::RADIO, HighInterruptHandler>
         + interrupt::typelevel::Binding<interrupt::typelevel::HASH, LowInterruptHandler>,
     ) -> Result<Self, BleError> {
+        Self::new_with_role(platform, runtime, irq, GapRole::Peripheral).await
+    }
+
+    /// Like `new`, but lets you specify the GAP role.
+    ///
+    /// Use `GapRole::Observer` for a scanner-only device (required for
+    /// `ACI_GAP_START_OBSERVATION_PROC` to succeed).
+    pub async fn new_with_role(
+        platform: &'static Platform,
+        runtime: &'d mut FullRuntime,
+        irq: impl interrupt::typelevel::Binding<interrupt::typelevel::RADIO, HighInterruptHandler>
+        + interrupt::typelevel::Binding<interrupt::typelevel::HASH, LowInterruptHandler>,
+        role: GapRole,
+    ) -> Result<Self, BleError> {
         let controller = Controller::new(platform, runtime, irq)
             .await
             .map_err(|_| BleError::InitializationFailed)?;
@@ -110,38 +124,14 @@ impl<'d> HCI<'d, Normal> {
             _mode: Normal,
         };
 
-        this.init()?;
+        this.init_with_role(role)?;
 
         yield_now().await;
 
         Ok(this)
     }
 
-    /// Initialize the BLE stack
-    ///
-    /// This function performs the following initialization steps:
-    /// 1. Initializes BLE host stack (BleStack_Init)
-    /// 2. Resets the BLE controller
-    /// 3. Reads and logs the local version information
-    /// 4. Reads the BD address
-    /// 5. Sets the event mask
-    /// 6. Reads buffer sizes
-    /// 7. Reads supported features
-    /// 8. Initializes GATT layer (aci_gatt_init) - MUST be before GAP!
-    /// 9. Initializes GAP and HAL (aci_gap_init, aci_hal_write_config_data, etc.)
-    ///
-    /// Must be called before any other BLE operations.
-    ///
-    /// # Initialization Order
-    ///
-    /// The order is critical: GATT initialization MUST happen before GAP initialization.
-    /// This matches ST's BLE_HeartRate example sequence.
-    ///
-    /// # Returns
-    ///
-    /// - `Ok(())` if initialization succeeded
-    /// - `Err(BleError)` if any initialization step failed
-    fn init(&mut self) -> Result<(), BleError> {
+    fn init_with_role(&mut self, role: GapRole) -> Result<(), BleError> {
         info!("Ble::init: BLE stack initialized, sending HCI reset");
 
         // 1. Reset BLE controller
@@ -223,6 +213,7 @@ impl<'d> HCI<'d, Normal> {
         // address must be `11`.
         let uid = embassy_stm32::uid::uid();
         let mut gap_params = GapInitParams::default();
+        gap_params.role = role;
         gap_params.bd_addr.copy_from_slice(&uid[0..6]);
         gap_params.bd_addr[5] |= 0xC0;
 
@@ -757,8 +748,9 @@ impl<'d, M: Mode> HCI<'d, M> {
     /// raw events (e.g., for connection management).
     pub async fn read_event(&mut self) -> stm32wb_hci::Event {
         loop {
-            if let Ok(event) = self.controller.read_event().await {
-                return event;
+            match self.controller.read_event().await {
+                Ok(event) => return event,
+                Err(e) => warn!("read_event: parse error {:?}", e),
             }
         }
     }

--- a/embassy-stm32-wpan/src/bluetooth/mod.rs
+++ b/embassy-stm32-wpan/src/bluetooth/mod.rs
@@ -219,11 +219,18 @@ impl<'d> HCI<'d, Normal> {
         info!("Initializing GAP and HAL...");
 
         // Derive a stable random static address from the chip's unique ID.
+        // Per BT Core spec, the top two bits of the MSB of a random static
+        // address must be `11`.
         let uid = embassy_stm32::uid::uid();
         let mut gap_params = GapInitParams::default();
         gap_params.bd_addr.copy_from_slice(&uid[0..6]);
+        gap_params.bd_addr[5] |= 0xC0;
 
         let _gap_handles = init_gap_and_hal(&gap_params)?;
+
+        // Program the random static address into the controller. Must happen
+        // before any advertising/scanning that uses `own_addr_type = Random`.
+        self.cmd_sender.le_set_random_address(&gap_params.bd_addr)?;
 
         info!("GAP and HAL initialized");
 

--- a/embassy-stm32-wpan/src/bluetooth/mod.rs
+++ b/embassy-stm32-wpan/src/bluetooth/mod.rs
@@ -750,7 +750,7 @@ impl<'d, M: Mode> HCI<'d, M> {
         loop {
             match self.controller.read_event().await {
                 Ok(event) => return event,
-                Err(e) => warn!("read_event: parse error {:?}", e),
+                Err(e) => debug!("read_event: unhandled event {:?}", e),
             }
         }
     }

--- a/embassy-stm32-wpan/src/bluetooth/mod.rs
+++ b/embassy-stm32-wpan/src/bluetooth/mod.rs
@@ -344,8 +344,8 @@ impl<'d> HCI<'d, Normal> {
     /// The BLE stack must be initialized before creating a scanner.
     /// Advertising reports will be received through the main event loop
     /// as `LeAdvertisingReport` events.
-    pub fn scanner(&self) -> Scanner<'_> {
-        Scanner::new(&self.cmd_sender)
+    pub fn scanner(&self) -> Scanner {
+        Scanner::new()
     }
 
     // ===== Connection Management =====

--- a/embassy-stm32-wpan/src/bluetooth/security/mod.rs
+++ b/embassy-stm32-wpan/src/bluetooth/security/mod.rs
@@ -31,6 +31,9 @@ type tBleStatus = u8;
 
 #[link(name = "stm32wba_ble_stack_basic")]
 unsafe extern "C" {
+    #[link_name = "ACI_GAP_SET_IO_CAPABILITY"]
+    fn aci_gap_set_io_capability(io_capability: u8) -> tBleStatus;
+
     #[link_name = "ACI_GAP_SET_AUTHENTICATION_REQUIREMENT"]
     fn aci_gap_set_authentication_requirement(
         bonding_mode: u8,
@@ -149,6 +152,14 @@ pub struct SecurityParams {
     pub fixed_pin: u32,
     /// Identity address type
     pub identity_address_type: IdentityAddressType,
+    /// IO capability.
+    ///
+    /// Must match what the device can actually do. Determines which pairing
+    /// method the stack selects. If `mitm_protection` is `true`, this must be
+    /// something other than `NoInputNoOutput`; otherwise pairing always fails
+    /// with `AuthRequirements` because "Just Works" (the only method available
+    /// for NoInputNoOutput) provides no MITM protection.
+    pub io_capability: IoCapability,
 }
 
 impl Default for SecurityParams {
@@ -163,6 +174,7 @@ impl Default for SecurityParams {
             use_fixed_pin: false,
             fixed_pin: 0,
             identity_address_type: IdentityAddressType::Public,
+            io_capability: IoCapability::NoInputNoOutput,
         }
     }
 }
@@ -221,48 +233,43 @@ impl SecurityParams {
         self
     }
 
+    /// Set IO capability.
+    ///
+    /// Determines which pairing method the BLE stack selects. When
+    /// `mitm_protection` is enabled, use anything other than
+    /// `NoInputNoOutput`; otherwise the stack can only do "Just Works"
+    /// and pairing will fail with `AuthRequirements`.
+    pub fn with_io_capability(mut self, cap: IoCapability) -> Self {
+        self.io_capability = cap;
+        self
+    }
+
     /// Preset for "Just Works" pairing (no MITM protection)
     pub fn just_works() -> Self {
         Self {
-            bonding_mode: BondingMode::Bonding,
-            mitm_protection: false,
-            secure_connections: SecureConnectionsSupport::Optional,
-            keypress_notification: false,
-            min_encryption_key_size: 7,
-            max_encryption_key_size: 16,
-            use_fixed_pin: false,
-            fixed_pin: 0,
-            identity_address_type: IdentityAddressType::Public,
+            io_capability: IoCapability::NoInputNoOutput,
+            ..Self::default()
         }
     }
 
-    /// Preset for passkey entry pairing
+    /// Preset for passkey entry pairing (device displays passkey, peer enters it)
     pub fn passkey_entry() -> Self {
         Self {
-            bonding_mode: BondingMode::Bonding,
             mitm_protection: true,
-            secure_connections: SecureConnectionsSupport::Optional,
-            keypress_notification: false,
-            min_encryption_key_size: 7,
-            max_encryption_key_size: 16,
-            use_fixed_pin: false,
-            fixed_pin: 0,
-            identity_address_type: IdentityAddressType::Public,
+            io_capability: IoCapability::DisplayOnly,
+            ..Self::default()
         }
     }
 
     /// Preset for secure connections with numeric comparison
     pub fn secure_numeric_comparison() -> Self {
         Self {
-            bonding_mode: BondingMode::Bonding,
             mitm_protection: true,
             secure_connections: SecureConnectionsSupport::Required,
-            keypress_notification: false,
             min_encryption_key_size: 16,
             max_encryption_key_size: 16,
-            use_fixed_pin: false,
-            fixed_pin: 0,
-            identity_address_type: IdentityAddressType::Public,
+            io_capability: IoCapability::DisplayYesNo,
+            ..Self::default()
         }
     }
 }
@@ -396,6 +403,13 @@ impl SecurityManager {
     /// Must be called before connections are established.
     pub fn set_authentication_requirements(&mut self, params: SecurityParams) -> Result<(), BleError> {
         unsafe {
+            // IO capability determines the pairing method. Must be set before
+            // the authentication requirement so the stack uses the right method.
+            let io_status = aci_gap_set_io_capability(params.io_capability as u8);
+            if io_status != BLE_STATUS_SUCCESS {
+                return Err(BleError::CommandFailed(Status::from_u8(io_status)));
+            }
+
             let status = aci_gap_set_authentication_requirement(
                 params.bonding_mode as u8,
                 params.mitm_protection as u8,

--- a/embassy-stm32-wpan/src/bluetooth/security/mod.rs
+++ b/embassy-stm32-wpan/src/bluetooth/security/mod.rs
@@ -53,6 +53,9 @@ unsafe extern "C" {
     #[link_name = "ACI_GAP_NUMERIC_COMPARISON_VALUE_CONFIRM_YESNO"]
     fn aci_gap_numeric_comparison_value_confirm_yesno(connection_handle: u16, confirm_yes_no: u8) -> tBleStatus;
 
+    #[link_name = "ACI_GAP_PERIPHERAL_SECURITY_REQ"]
+    fn aci_gap_peripheral_security_req(connection_handle: u16) -> tBleStatus;
+
     #[link_name = "ACI_GAP_ALLOW_REBOND"]
     fn aci_gap_allow_rebond(connection_handle: u16) -> tBleStatus;
 
@@ -459,6 +462,24 @@ impl SecurityManager {
         unsafe {
             let status = aci_gap_numeric_comparison_value_confirm_yesno(conn_handle, confirm as u8);
 
+            if status == BLE_STATUS_SUCCESS {
+                Ok(())
+            } else {
+                Err(BleError::CommandFailed(Status::from_u8(status)))
+            }
+        }
+    }
+
+    /// Request pairing/encryption from the peripheral side.
+    ///
+    /// Sends an SMP Security Request to the central. Call this immediately
+    /// after connection when the device has security requirements, rather than
+    /// waiting for the central to trigger pairing via an insufficient-security
+    /// GATT error. Matches ST's recommended pattern (aci_gap_slave_security_req
+    /// in BLE_HeartRate).
+    pub fn request_pairing(&self, conn_handle: u16) -> Result<(), BleError> {
+        unsafe {
+            let status = aci_gap_peripheral_security_req(conn_handle);
             if status == BLE_STATUS_SUCCESS {
                 Ok(())
             } else {

--- a/embassy-stm32-wpan/src/wba/linklayer_plat.rs
+++ b/embassy-stm32-wpan/src/wba/linklayer_plat.rs
@@ -785,6 +785,38 @@ pub unsafe extern "C" fn LINKLAYER_PLAT_AclkCtrl(enable: u8) {
 //   * @param  len: number of byte of anthropy to get.
 //   * @retval None
 //   */
+/// Poll the hardware RNG directly to fill `buf`.
+///
+/// Used as a fallback when the async pipe is transiently empty — e.g. when the
+/// BLE link layer requests entropy inside `seq_resume()`, where we cannot yield
+/// to let `run_rng` replenish the pipe.  Reading DR is safe even while the
+/// embassy RNG driver holds the peripheral: the hardware immediately starts
+/// generating the next word after each DR read, so the async driver simply
+/// waits for the next DRDY interrupt.
+unsafe fn fill_from_hardware_rng(buf: &mut [u8]) {
+    use embassy_stm32::pac::RNG;
+    let mut i = 0;
+    while i < buf.len() {
+        loop {
+            let sr = RNG.sr().read();
+            if sr.seis() || sr.ceis() {
+                RNG.sr().modify(|w| {
+                    w.set_seis(false);
+                    w.set_ceis(false);
+                });
+            }
+            if sr.drdy() {
+                break;
+            }
+        }
+        let word = RNG.dr().read();
+        let bytes = word.to_le_bytes();
+        let to_copy = (buf.len() - i).min(4);
+        buf[i..i + to_copy].copy_from_slice(&bytes[..to_copy]);
+        i += to_copy;
+    }
+}
+
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn LINKLAYER_PLAT_GetRNG(ptr_rnd: *mut u8, len: u32) {
     trace!("LINKLAYER_PLAT_GetRNG: ptr_rnd={:?}, len={}", ptr_rnd, len);
@@ -792,9 +824,11 @@ pub unsafe extern "C" fn LINKLAYER_PLAT_GetRNG(ptr_rnd: *mut u8, len: u32) {
         return;
     }
 
-    get_platform()
-        .try_fill_all_bytes(core::slice::from_raw_parts_mut(ptr_rnd, len as usize))
-        .expect("LINKLAYER_PLAT_GetRNG: could not fill bytes");
+    let buf = core::slice::from_raw_parts_mut(ptr_rnd, len as usize);
+    let from_pipe = get_platform().try_fill_bytes(buf);
+    if from_pipe < buf.len() {
+        fill_from_hardware_rng(&mut buf[from_pipe..]);
+    }
 
     trace!("LINKLAYER_PLAT_GetRNG: generated {} random bytes", len);
 }
@@ -1250,9 +1284,11 @@ pub unsafe extern "C" fn BLEPLAT_RngGet(n: u8, val: *mut u32) {
         return;
     }
 
-    get_platform()
-        .try_fill_all_bytes(core::slice::from_raw_parts_mut(val as *mut u8, n as usize * 4))
-        .expect("BLEPLAT_RngGet: could not fill bytes");
+    let buf = core::slice::from_raw_parts_mut(val as *mut u8, n as usize * 4);
+    let from_pipe = get_platform().try_fill_bytes(buf);
+    if from_pipe < buf.len() {
+        fill_from_hardware_rng(&mut buf[from_pipe..]);
+    }
 }
 
 /// AES ECB encrypt function using hardware AES peripheral.

--- a/embassy-stm32-wpan/src/wba/linklayer_plat.rs
+++ b/embassy-stm32-wpan/src/wba/linklayer_plat.rs
@@ -1847,7 +1847,11 @@ pub unsafe extern "C" fn BLECB_Indication(data: *const u8, length: u16, ext_data
 
     // Convert to slice
     let event_data = core::slice::from_raw_parts(data, length as usize);
-    let ext_data = core::slice::from_raw_parts(ext_data, ext_length as usize);
+    let ext_data: &[u8] = if ext_data.is_null() || ext_length == 0 {
+        &[]
+    } else {
+        core::slice::from_raw_parts(ext_data, ext_length as usize)
+    };
 
     trace!(
         "BLECB_Indication: event_code=0x{:02X}, length={}",

--- a/embassy-stm32-wpan/src/wba/platform.rs
+++ b/embassy-stm32-wpan/src/wba/platform.rs
@@ -137,12 +137,10 @@ impl Platform {
         self.pipe.wait_full().await
     }
 
-    pub(crate) fn try_fill_all_bytes(&self, buf: &mut [u8]) -> Result<(), ()> {
-        if self.pipe.try_read(buf).map_err(|_| ())? < buf.len() {
-            Err(())
-        } else {
-            Ok(())
-        }
+    /// Fill `buf` from the pipe, returning how many bytes were actually written.
+    /// May return less than `buf.len()` if the pipe is transiently low.
+    pub(crate) fn try_fill_bytes(&self, buf: &mut [u8]) -> usize {
+        self.pipe.try_read(buf).unwrap_or(0)
     }
 
     /// Fill `buf` with random bytes from the BLE platform's RNG pipe.

--- a/examples/stm32wba/src/bin/ble_scanner.rs
+++ b/examples/stm32wba/src/bin/ble_scanner.rs
@@ -25,6 +25,7 @@ use embassy_stm32::rng::{self, Rng};
 use embassy_stm32::{Config, bind_interrupts};
 use embassy_stm32_wpan::bluetooth::HCI;
 use embassy_stm32_wpan::bluetooth::gap::{ParsedAdvData, ScanParams, ScanType};
+use embassy_stm32_wpan::bluetooth::gap_init::GapRole;
 use embassy_stm32_wpan::{HighInterruptHandler, LowInterruptHandler, Platform, new_platform};
 use stm32wb_hci::Event;
 use {defmt_rtt as _, panic_probe as _};
@@ -74,8 +75,8 @@ async fn main(spawner: Spawner) {
     // Spawn the BLE runner task (required for proper BLE operation)
     spawner.spawn(ble_runner_task(platform).expect("Failed to spawn BLE runner"));
 
-    // Initialize BLE stack
-    let mut ble = HCI::new(platform, runtime, Irqs)
+    // Initialize BLE stack in Observer role (required for ACI_GAP_START_OBSERVATION_PROC)
+    let mut ble = HCI::new_with_role(platform, runtime, Irqs, GapRole::Observer)
         .await
         .expect("BLE initialization failed");
 

--- a/examples/stm32wba/src/bin/ble_secure.rs
+++ b/examples/stm32wba/src/bin/ble_secure.rs
@@ -30,7 +30,7 @@ use embassy_stm32::{Config, bind_interrupts};
 use embassy_stm32_wpan::bluetooth::HCI;
 use embassy_stm32_wpan::bluetooth::gap::{AdvData, AdvParams, AdvType, GapEvent};
 use embassy_stm32_wpan::bluetooth::gatt::{CharProperties, GattEventMask, SecurityPermissions, ServiceType, Uuid};
-use embassy_stm32_wpan::bluetooth::security::{SecureConnectionsSupport, SecurityParams};
+use embassy_stm32_wpan::bluetooth::security::{IoCapability, SecureConnectionsSupport, SecurityParams};
 use embassy_stm32_wpan::{HighInterruptHandler, LowInterruptHandler, Platform, new_platform};
 use stm32wb_hci::Event;
 use stm32wb_hci::event::EncryptionChange;
@@ -103,7 +103,8 @@ async fn main(spawner: Spawner) {
         .with_bonding(true)
         .with_mitm_protection(true)
         .with_secure_connections(SecureConnectionsSupport::Optional)
-        .with_key_size_range(7, 16);
+        .with_key_size_range(7, 16)
+        .with_io_capability(IoCapability::DisplayYesNo);
 
     security
         .set_authentication_requirements(security_params)
@@ -188,8 +189,11 @@ async fn main(spawner: Spawner) {
                     info!("  Handle: 0x{:04X}", conn.handle.0);
                     info!("  Peer: {}", conn.peer_address);
 
-                    info!("Waiting for pairing request...");
-                    info!("(Try to read the secure characteristic to trigger pairing)");
+                    if let Err(e) = security.request_pairing(conn.handle.0) {
+                        warn!("request_pairing failed: {:?}", e);
+                    } else {
+                        info!("Pairing requested — waiting for central to respond...");
+                    }
                 }
 
                 GapEvent::Disconnected { handle, reason } => {

--- a/examples/stm32wba6/src/bin/ble_scanner.rs
+++ b/examples/stm32wba6/src/bin/ble_scanner.rs
@@ -16,7 +16,6 @@
 #![no_main]
 
 use defmt::*;
-use defmt_rtt as _;
 use embassy_executor::Spawner;
 use embassy_stm32::aes::{self, Aes};
 use embassy_stm32::peripherals::{AES, PKA, RNG};
@@ -27,8 +26,8 @@ use embassy_stm32_wpan::bluetooth::HCI;
 use embassy_stm32_wpan::bluetooth::gap::{ParsedAdvData, ScanParams, ScanType};
 use embassy_stm32_wpan::bluetooth::gap_init::GapRole;
 use embassy_stm32_wpan::{HighInterruptHandler, LowInterruptHandler, Platform, new_platform};
-use panic_probe as _;
 use stm32wb_hci::Event;
+use {defmt_rtt as _, panic_probe as _};
 
 bind_interrupts!(struct Irqs {
     RNG => rng::InterruptHandler<RNG>;

--- a/examples/stm32wba6/src/bin/ble_scanner.rs
+++ b/examples/stm32wba6/src/bin/ble_scanner.rs
@@ -22,8 +22,9 @@ use embassy_stm32::peripherals::{AES, PKA, RNG};
 use embassy_stm32::pka::{self, Pka};
 use embassy_stm32::rng::{self, Rng};
 use embassy_stm32::{Config, bind_interrupts, rcc};
-use embassy_stm32_wpan::bluetooth::HCI;
+use embassy_stm32_wpan::bluetooth::gap_init::GapRole;
 use embassy_stm32_wpan::bluetooth::gap::{ParsedAdvData, ScanParams, ScanType};
+use embassy_stm32_wpan::bluetooth::HCI;
 use embassy_stm32_wpan::{HighInterruptHandler, LowInterruptHandler, Platform, new_platform};
 use stm32wb_hci::Event;
 use {defmt_rtt as _, panic_probe as _};
@@ -73,8 +74,8 @@ async fn main(spawner: Spawner) {
     // Spawn the BLE runner task (required for proper BLE operation)
     spawner.spawn(ble_runner_task(platform).expect("Failed to spawn BLE runner"));
 
-    // Initialize BLE stack
-    let mut ble = HCI::new(platform, runtime, Irqs)
+    // Initialize BLE stack in Observer role (required for ACI_GAP_START_OBSERVATION_PROC)
+    let mut ble = HCI::new_with_role(platform, runtime, Irqs, GapRole::Observer)
         .await
         .expect("BLE initialization failed");
 

--- a/examples/stm32wba6/src/bin/ble_scanner.rs
+++ b/examples/stm32wba6/src/bin/ble_scanner.rs
@@ -16,18 +16,19 @@
 #![no_main]
 
 use defmt::*;
+use defmt_rtt as _;
 use embassy_executor::Spawner;
 use embassy_stm32::aes::{self, Aes};
 use embassy_stm32::peripherals::{AES, PKA, RNG};
 use embassy_stm32::pka::{self, Pka};
 use embassy_stm32::rng::{self, Rng};
 use embassy_stm32::{Config, bind_interrupts, rcc};
-use embassy_stm32_wpan::bluetooth::gap_init::GapRole;
-use embassy_stm32_wpan::bluetooth::gap::{ParsedAdvData, ScanParams, ScanType};
 use embassy_stm32_wpan::bluetooth::HCI;
+use embassy_stm32_wpan::bluetooth::gap::{ParsedAdvData, ScanParams, ScanType};
+use embassy_stm32_wpan::bluetooth::gap_init::GapRole;
 use embassy_stm32_wpan::{HighInterruptHandler, LowInterruptHandler, Platform, new_platform};
+use panic_probe as _;
 use stm32wb_hci::Event;
-use {defmt_rtt as _, panic_probe as _};
 
 bind_interrupts!(struct Irqs {
     RNG => rng::InterruptHandler<RNG>;

--- a/examples/stm32wba6/src/bin/ble_secure.rs
+++ b/examples/stm32wba6/src/bin/ble_secure.rs
@@ -29,7 +29,7 @@ use embassy_stm32::{Config, bind_interrupts, rcc};
 use embassy_stm32_wpan::bluetooth::HCI;
 use embassy_stm32_wpan::bluetooth::gap::{AdvData, AdvParams, AdvType, GapEvent};
 use embassy_stm32_wpan::bluetooth::gatt::{CharProperties, GattEventMask, SecurityPermissions, ServiceType, Uuid};
-use embassy_stm32_wpan::bluetooth::security::{SecureConnectionsSupport, SecurityParams};
+use embassy_stm32_wpan::bluetooth::security::{IoCapability, SecureConnectionsSupport, SecurityParams};
 use embassy_stm32_wpan::{HighInterruptHandler, LowInterruptHandler, Platform, new_platform};
 use stm32wb_hci::Event;
 use stm32wb_hci::event::EncryptionChange;
@@ -104,7 +104,11 @@ async fn main(spawner: Spawner) {
         .with_bonding(true)
         .with_mitm_protection(true)
         .with_secure_connections(SecureConnectionsSupport::Optional)
-        .with_key_size_range(7, 16);
+        .with_key_size_range(7, 16)
+        // DisplayYesNo: device can show a passkey or numeric comparison value.
+        // Required for MITM — NoInputNoOutput (the default) only allows "Just
+        // Works" pairing which provides no MITM protection.
+        .with_io_capability(IoCapability::DisplayYesNo);
 
     security
         .set_authentication_requirements(security_params)

--- a/examples/stm32wba6/src/bin/ble_secure.rs
+++ b/examples/stm32wba6/src/bin/ble_secure.rs
@@ -193,8 +193,14 @@ async fn main(spawner: Spawner) {
                     info!("  Handle: 0x{:04X}", conn.handle.0);
                     info!("  Peer: {}", conn.peer_address);
 
-                    info!("Waiting for pairing request...");
-                    info!("(Try to read the secure characteristic to trigger pairing)");
+                    // Immediately request pairing from the peripheral side so
+                    // the central doesn't have to trigger it via an
+                    // insufficient-security GATT error first.
+                    if let Err(e) = security.request_pairing(conn.handle.0) {
+                        warn!("request_pairing failed: {:?}", e);
+                    } else {
+                        info!("Pairing requested — waiting for central to respond...");
+                    }
                 }
 
                 GapEvent::Disconnected { handle, reason } => {


### PR DESCRIPTION
- gap/advertiser: extract_local_name and extract_service_uuids_16 now keep the AD-type byte in the returned slice. aci_gap_set_discoverable expects local_name / service_uuid_list to start with the AD-type byte (with the length including it); previously the name byte was stripped, so phones saw the device as "N/A".

- gap_init: add AddressType { Public, RandomStatic } on GapInitParams, default to RandomStatic, and skip the PUBADDR config write in that mode. PUBADDR (offset 0x00) is rejected by WBA stack-basic when the address isn't a real IEEE-registered public address.

- bluetooth/mod: mask the UID-derived BD address into a valid random static address (top two bits of byte 5 set to 0b11) and program it via hci_le_set_random_address after init_gap_and_hal.

- gap/types: default AdvParams.own_addr_type to Random to match.