### PR TITLE
stm32/time_driver: call irq handler in now() if irqs disabled

### DIFF
--- a/embassy-stm32/src/time_driver/gp16.rs
+++ b/embassy-stm32/src/time_driver/gp16.rs
@@ -343,6 +343,13 @@ impl Driver for RtcDriver {
     fn now(&self) -> u64 {
         let r = regs_gp16();
 
+        // trigger the interrupt handler if irqs have been disabled
+        let sr = r.sr().read();
+        if sr.uif() || sr.ccif(0) {
+            #[cfg(feature = "rt")]
+            self.on_interrupt();
+        }
+
         let period = self.period.load(Ordering::Relaxed);
         compiler_fence(Ordering::Acquire);
         let counter = r.cnt().read().cnt();


### PR DESCRIPTION
@hydra does block_for work with this?