### PR TITLE
stm32wba: fix HSE init clobbering HSION; add Config::new_wpan_lsi()

### DIFF
--- a/embassy-stm32-wpan/src/wba/ll_sys_if.rs
+++ b/embassy-stm32-wpan/src/wba/ll_sys_if.rs
@@ -405,7 +405,7 @@ pub unsafe extern "C" fn ll_sys_sleep_clock_source_selection() {
     let radiostsel = RCC.bdcr().read().radiostsel();
     let slp_clk_src = match radiostsel {
         Radiostsel::Lse => link_layer::_SLPTMR_SRC_TYPE_E_RTC_SLPTMR as u8,
-        Radiostsel::_RESERVED_2 => link_layer::_SLPTMR_SRC_TYPE_E_RCO_SLPTMR as u8, // LSI
+        Radiostsel::Lsi => link_layer::_SLPTMR_SRC_TYPE_E_RCO_SLPTMR as u8,
         Radiostsel::Hse => link_layer::_SLPTMR_SRC_TYPE_E_CRYSTAL_OSCILLATOR_SLPTMR as u8,
         Radiostsel::Disable => panic!("Radio sleep timer clock not configured (RADIOSTSEL=DISABLE)"),
     };

--- a/embassy-stm32/Cargo.toml
+++ b/embassy-stm32/Cargo.toml
@@ -209,11 +209,11 @@ aligned = "0.4.3"
 heapless = "0.9.1"
 
 # stm32-metapac = { version = "21" }
-stm32-metapac = { git = "https://github.com/embassy-rs/stm32-data-generated", tag = "stm32-data-32bfde734486c6898c8457c464f45eb5cedbf2f1" }
+stm32-metapac = { git = "https://github.com/embassy-rs/stm32-data-generated", tag = "stm32-data-6d108b6d3695cafd30923b033bc82291da5859a7" }
 
 [build-dependencies]
 # stm32-metapac = { version = "21", default-features = false, features = ["metadata"]}
-stm32-metapac = { git = "https://github.com/embassy-rs/stm32-data-generated", tag = "stm32-data-32bfde734486c6898c8457c464f45eb5cedbf2f1", default-features = false, features = ["metadata"] }
+stm32-metapac = { git = "https://github.com/embassy-rs/stm32-data-generated", tag = "stm32-data-6d108b6d3695cafd30923b033bc82291da5859a7", default-features = false, features = ["metadata"] }
 
 proc-macro2 = "1.0.36"
 quote = "1.0.15"

--- a/embassy-stm32/src/rcc/wba.rs
+++ b/embassy-stm32/src/rcc/wba.rs
@@ -103,6 +103,27 @@ impl Config {
         }
     }
 
+    /// BLE radio config for boards without an LSE crystal.
+    ///
+    /// Identical to [`new_wpan`](Self::new_wpan) except the 32 kHz sleep-timer clock comes from
+    /// LSI1 (internal RC) instead of LSE.  LSI is less accurate (~1-2% vs <20 ppm for LSE), which
+    /// increases BLE sleep-clock tolerance and slightly degrades power consumption in deep sleep.
+    ///
+    /// RADIOSTSEL is set to `_RESERVED_2` (hardware bit value 0x02 = LSI), the only PAC-visible
+    /// way to select LSI until the metapac gains a named `Lsi` variant.
+    pub const fn new_wpan_lsi() -> Self {
+        let mut rcc = Self::new_wpan();
+
+        rcc.ls = LsConfig {
+            rtc: RtcClockSource::Lsi,
+            lsi: true,
+            lse: None,
+        };
+        rcc.mux.radiostsel = mux::Radiostsel::_RESERVED_2; // LSI (hardware bit 0x02)
+
+        rcc
+    }
+
     pub const fn new_wpan() -> Self {
         let mut rcc = Self::new();
 
@@ -232,7 +253,7 @@ pub(crate) unsafe fn init(config: Config) {
     });
 
     let hse = config.hse.map(|hse| {
-        RCC.cr().write(|w| {
+        RCC.cr().modify(|w| {
             w.set_hseon(true);
             w.set_hsepre(hse.prescaler);
         });
@@ -378,6 +399,10 @@ pub(crate) unsafe fn init(config: Config) {
 
     // Disable HSI if not used
     if !config.hsi {
+        assert!(
+            config.mux.rngsel != mux::Rngsel::Hsi,
+            "RNG is configured to use HSI but HSI is disabled"
+        );
         RCC.cr().modify(|w| w.set_hsion(false));
     }
 

--- a/embassy-stm32/src/rcc/wba.rs
+++ b/embassy-stm32/src/rcc/wba.rs
@@ -109,8 +109,7 @@ impl Config {
     /// LSI1 (internal RC) instead of LSE.  LSI is less accurate (~1-2% vs <20 ppm for LSE), which
     /// increases BLE sleep-clock tolerance and slightly degrades power consumption in deep sleep.
     ///
-    /// RADIOSTSEL is set to `_RESERVED_2` (hardware bit value 0x02 = LSI), the only PAC-visible
-    /// way to select LSI until the metapac gains a named `Lsi` variant.
+    /// RADIOSTSEL is set to `Lsi` (hardware bit value 0x02).
     pub const fn new_wpan_lsi() -> Self {
         let mut rcc = Self::new_wpan();
 
@@ -119,7 +118,7 @@ impl Config {
             lsi: true,
             lse: None,
         };
-        rcc.mux.radiostsel = mux::Radiostsel::_RESERVED_2; // LSI (hardware bit 0x02)
+        rcc.mux.radiostsel = mux::Radiostsel::Lsi;
 
         rcc
     }


### PR DESCRIPTION
## Summary

- **Bug fix**: `RCC.cr().write()` when enabling HSE zeroed the entire CR register, clearing HSION immediately after `hsi_enable()` set it. Any config with both HSI and HSE enabled (including `new_wpan()`) silently disabled HSI, breaking RNG and any other HSI-clocked peripheral. Fixed by using `modify()` instead of `write()`.
- **Defensive assert**: added a check before the HSI disable that catches the misconfiguration `rngsel=Hsi` + `hsi=false` at init time with a clear message instead of a silent runtime failure.
- **New constructor**: `Config::new_wpan_lsi()` for STM32WBA boards without an LSE crystal. Mirrors `new_wpan()` but uses LSI1 as the RTC and 2.4 GHz radio sleep timer clock source. `RADIOSTSEL` is set to `_RESERVED_2` (hardware value `0x02` = LSI) pending a named `Lsi` variant in the metapac — see stm32-data PR [#795](https://github.com/embassy-rs/stm32-data/pull/795).