### PR TITLE
Add StringDescriptorLossy.

### DIFF
--- a/embassy-usb-host/src/descriptor.rs
+++ b/embassy-usb-host/src/descriptor.rs
@@ -1117,6 +1117,29 @@ impl StringDescriptor {
         }
         Self { string }
     }
+
+    /// Alternate to [USBDescriptor::try_from_bytes] that allows invalid UNICODE data.
+    ///
+    /// Invalid data will be replaced with [`U+FFFD` REPLACEMENT CHARACTER](char::REPLACEMENT_CHARACTER) (�).
+    fn try_from_bytes_lossy(bytes: &[u8]) -> Result<Self, DescriptorError> {
+        Self::match_bytes(bytes)?;
+        let len = bytes[0];
+        let mut utf16: Vec<u16, { Self::MAX_UTF16 }> = Vec::new();
+        for i in (2..len as usize).step_by(2) {
+            if let Some(data) = bytes.get(i..i + 2) {
+                let value = u16::from_le_bytes([data[0], data[1]]);
+                let result = utf16.push(value);
+                debug_assert!(result.is_ok(), "must fit");
+            }
+        }
+        let mut string = String::new();
+        for c_result in char::decode_utf16(utf16.into_iter()) {
+            let c = c_result.unwrap_or(char::REPLACEMENT_CHARACTER);
+            let result = string.push(c);
+            debug_assert!(result.is_ok(), "must fit");
+        }
+        Ok(Self { string })
+    }
 }
 
 impl TryFrom<&str> for StringDescriptor {
@@ -1191,6 +1214,23 @@ impl WritableDescriptor for StringDescriptor {
             }
         }
         Ok(bytes[0] as usize)
+    }
+}
+
+/// A [StringDescriptor] wrapper that allows invalid UNICODE data.
+///
+/// Invalid data will be replaced with [`U+FFFD` REPLACEMENT CHARACTER](char::REPLACEMENT_CHARACTER) (�).
+#[derive(Clone, Debug, PartialEq, Eq)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+pub struct StringDescriptorLossy(pub StringDescriptor);
+
+impl USBDescriptor for StringDescriptorLossy {
+    const BUF_SIZE: usize = StringDescriptor::BUF_SIZE;
+    const DESC_TYPE: u8 = descriptor_type::STRING;
+    type Error = DescriptorError;
+
+    fn try_from_bytes(bytes: &[u8]) -> Result<Self, Self::Error> {
+        Ok(Self(StringDescriptor::try_from_bytes_lossy(bytes)?))
     }
 }
 
@@ -1500,6 +1540,20 @@ mod test {
         assert_eq!(<&str>::from(&descriptor), truncated);
         assert_eq!(descriptor.deref(), truncated);
         assert_eq!(StringDescriptor::from_str_truncate(too_big), descriptor.clone());
+    }
+
+    #[test]
+    fn string_descriptor_lossy() {
+        let bytes = [4, descriptor_type::STRING, 0xDC, 0xDC]; // unpaired trailing surrogate
+        assert_eq!(
+            StringDescriptor::try_from_bytes(&bytes),
+            Err(DescriptorError::BadDescriptorData)
+        );
+        let lossy = StringDescriptorLossy(StringDescriptor {
+            string: String::try_from("\u{FFFD}").expect("must fit"),
+        });
+        assert_eq!(StringDescriptor::try_from_bytes_lossy(&bytes), Ok(lossy.0.clone()));
+        assert_eq!(StringDescriptorLossy::try_from_bytes(&bytes), Ok(lossy.clone()));
     }
 
     #[test]


### PR DESCRIPTION
This descriptor wrapper allows reading invalid data just like [String::from_ut1f16_lossy](https://doc.rust-lang.org/std/string/struct.String.html#method.from_utf16_lossy).
USB mandates valid UNICODE, but you never know what vendors will do in practice.
