### PR TITLE
mspm0: update DMA to use Channel driver

### DIFF
--- a/embassy-mspm0/src/dma.rs
+++ b/embassy-mspm0/src/dma.rs
@@ -3,20 +3,33 @@
 #![macro_use]
 
 use core::future::Future;
-use core::mem;
+use core::marker::PhantomData;
 use core::pin::Pin;
 use core::sync::atomic::{Ordering, compiler_fence};
 use core::task::{Context, Poll};
+use core::{fmt, mem};
 
 use critical_section::CriticalSection;
+use embassy_hal_internal::PeripheralType;
 use embassy_hal_internal::interrupt::InterruptExt;
-use embassy_hal_internal::{PeripheralType, impl_peripheral};
 use embassy_sync::waitqueue::AtomicWaker;
 use mspm0_metapac::common::{RW, Reg};
 use mspm0_metapac::dma::regs;
 use mspm0_metapac::dma::vals::{self, Autoen, Em, Incr, Preirq, Wdth};
 
+use crate::interrupt::typelevel::{Handler, Interrupt};
 use crate::{Peri, interrupt, pac};
+
+/// DMA interrupt handler.
+pub struct InterruptHandler<T: ChannelInstance> {
+    _marker: PhantomData<T>,
+}
+
+impl<T: ChannelInstance> Handler<<T as ChannelInstance>::Interrupt> for InterruptHandler<T> {
+    unsafe fn on_interrupt() {
+        on_irq(pac::DMA);
+    }
+}
 
 /// The burst size of a DMA transfer.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -37,49 +50,152 @@ pub enum BurstSize {
     _32,
 }
 
-/// DMA channel.
-#[allow(private_bounds)]
-pub trait Channel: Into<AnyChannel> + PeripheralType {}
-
-/// Full DMA channel.
-#[allow(private_bounds)]
-pub trait FullChannel: Channel + Into<AnyFullChannel> {}
-
-/// Type-erased DMA channel.
-pub struct AnyChannel {
-    pub(crate) id: u8,
+/// Basic DMA channel driver.
+pub struct Channel<'d> {
+    id: u8,
+    _marker: PhantomData<&'d ()>,
 }
-impl_peripheral!(AnyChannel);
 
-impl SealedChannel for AnyChannel {
-    fn id(&self) -> u8 {
-        self.id
+impl<'d> Channel<'d> {
+    /// Create a new basic DMA channel driver.
+    pub fn new<T: ChannelInstance>(
+        _ch: Peri<'d, T>,
+        _irq: impl interrupt::typelevel::Binding<T::Interrupt, InterruptHandler<T>> + 'd,
+    ) -> Self {
+        Self {
+            id: T::ID,
+            _marker: PhantomData,
+        }
+    }
+
+    /// Reborrow the channel, allowing it to be used in multiple places.
+    pub fn reborrow(&mut self) -> Channel<'_> {
+        Channel {
+            id: self.id,
+            _marker: PhantomData,
+        }
+    }
+
+    /// Create a new read DMA transfer.
+    pub unsafe fn read<'a, SW: Word, DW: Word>(
+        &'a mut self,
+        trigger_source: u8,
+        src: *mut SW,
+        dst: &'a mut [DW],
+        options: TransferOptions,
+    ) -> Result<Transfer<'a>, Error> {
+        self.read_raw(trigger_source, src, dst, options)
+    }
+
+    /// Create a new read DMA transfer, using raw pointers.
+    pub unsafe fn read_raw<'a, SW: Word, DW: Word>(
+        &'a mut self,
+        trigger_source: u8,
+        src: *mut SW,
+        dst: *mut [DW],
+        options: TransferOptions,
+    ) -> Result<Transfer<'a>, Error> {
+        verify_transfer::<DW>(dst)?;
+
+        let transfer = Transfer {
+            channel: self.reborrow(),
+        };
+        transfer.channel.configure(
+            trigger_source,
+            src.cast(),
+            SW::width(),
+            dst.cast(),
+            DW::width(),
+            dst.len() as u16,
+            false,
+            true,
+            options,
+        );
+        transfer.channel.start();
+
+        Ok(transfer)
+    }
+
+    /// Create a new write DMA transfer.
+    pub unsafe fn write<'a, SW: Word, DW: Word>(
+        &'a mut self,
+        trigger_source: u8,
+        src: &'a [SW],
+        dst: *mut DW,
+        options: TransferOptions,
+    ) -> Result<Transfer<'a>, Error> {
+        self.write_raw(trigger_source, src, dst, options)
+    }
+
+    /// Create a new write DMA transfer, using raw pointers.
+    pub unsafe fn write_raw<'a, SW: Word, DW: Word>(
+        &'a mut self,
+        trigger_source: u8,
+        src: *const [SW],
+        dst: *mut DW,
+        options: TransferOptions,
+    ) -> Result<Transfer<'a>, Error> {
+        verify_transfer::<SW>(src)?;
+
+        let transfer = Transfer {
+            channel: self.reborrow(),
+        };
+        transfer.channel.configure(
+            trigger_source,
+            src.cast(),
+            SW::width(),
+            dst.cast(),
+            DW::width(),
+            src.len() as u16,
+            true,
+            false,
+            options,
+        );
+        transfer.channel.start();
+
+        Ok(transfer)
     }
 }
-impl Channel for AnyChannel {}
 
-/// Type-erased full DMA channel.
-pub struct AnyFullChannel {
-    pub(crate) id: u8,
-}
-impl_peripheral!(AnyFullChannel);
+/// Full DMA channel driver.
+///
+/// This is an extended [`Channel`] driver and can be [reborrowed](Self::reborrow) to be used as a basic
+/// channel driver.
+pub struct FullChannel<'d>(Channel<'d>);
 
-impl SealedChannel for AnyFullChannel {
-    fn id(&self) -> u8 {
-        self.id
+impl<'d> FullChannel<'d> {
+    /// Create a new full DMA channel driver.
+    pub fn new<T: FullChannelInstance>(
+        ch: Peri<'d, T>,
+        irq: impl interrupt::typelevel::Binding<T::Interrupt, InterruptHandler<T>> + 'd,
+    ) -> Self {
+        Self(Channel::new(ch, irq))
+    }
+
+    /// Reborrow the full channel, allowing it to be used in multiple places.
+    pub fn reborrow_full(&mut self) -> FullChannel<'_> {
+        FullChannel(self.0.reborrow())
+    }
+
+    /// Reborrow the channel as a basic [`Channel`], allowing it to be used in multiple places.
+    pub fn reborrow(&mut self) -> Channel<'_> {
+        self.0.reborrow()
     }
 }
-impl Channel for AnyFullChannel {}
-impl FullChannel for AnyFullChannel {}
 
-impl From<AnyFullChannel> for AnyChannel {
-    fn from(value: AnyFullChannel) -> Self {
-        Self { id: value.id }
-    }
+/// DMA channel instance.
+#[allow(private_bounds)]
+pub trait ChannelInstance: SealedChannel + PeripheralType {
+    /// Interrupt type for this DMA channel.
+    type Interrupt: Interrupt;
 }
+
+/// Full DMA channel instance.
+#[allow(private_bounds)]
+pub trait FullChannelInstance: ChannelInstance {}
 
 #[allow(private_bounds)]
-pub trait Word: SealedWord {
+pub trait Word: SealedWord + 'static {
     /// Size in bytes for the width.
     fn size() -> isize;
 }
@@ -151,6 +267,16 @@ pub enum Error {
     TooManyTransfers,
 }
 
+impl fmt::Display for Error {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Error::TooManyTransfers => write!(f, "too many transfers"),
+        }
+    }
+}
+
+impl core::error::Error for Error {}
+
 /// DMA transfer mode for basic channels.
 #[derive(Debug, Copy, Clone, PartialEq, Eq)]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
@@ -183,7 +309,7 @@ impl Default for TransferOptions {
 /// DMA transfer.
 #[must_use = "futures do nothing unless you `.await` or poll them"]
 pub struct Transfer<'a> {
-    channel: Peri<'a, AnyChannel>,
+    channel: Channel<'a>,
 }
 
 impl<'a> Transfer<'a> {
@@ -192,84 +318,6 @@ impl<'a> Transfer<'a> {
     /// Using this trigger source means that a transfer will start immediately rather than waiting for
     /// a hardware event. This can be useful if you want to do a DMA accelerated memcpy.
     pub const SOFTWARE_TRIGGER: u8 = 0;
-
-    /// Create a new read DMA transfer.
-    pub unsafe fn new_read<SW: Word, DW: Word>(
-        channel: Peri<'a, impl Channel>,
-        trigger_source: u8,
-        src: *mut SW,
-        dst: &'a mut [DW],
-        options: TransferOptions,
-    ) -> Result<Self, Error> {
-        Self::new_read_raw(channel, trigger_source, src, dst, options)
-    }
-
-    /// Create a new read DMA transfer, using raw pointers.
-    pub unsafe fn new_read_raw<SW: Word, DW: Word>(
-        channel: Peri<'a, impl Channel>,
-        trigger_source: u8,
-        src: *mut SW,
-        dst: *mut [DW],
-        options: TransferOptions,
-    ) -> Result<Self, Error> {
-        verify_transfer::<DW>(dst)?;
-
-        let channel = channel.into();
-        channel.configure(
-            trigger_source,
-            src.cast(),
-            SW::width(),
-            dst.cast(),
-            DW::width(),
-            dst.len() as u16,
-            false,
-            true,
-            options,
-        );
-        channel.start();
-
-        Ok(Self { channel })
-    }
-
-    /// Create a new write DMA transfer.
-    pub unsafe fn new_write<SW: Word, DW: Word>(
-        channel: Peri<'a, impl Channel>,
-        trigger_source: u8,
-        src: &'a [SW],
-        dst: *mut DW,
-        options: TransferOptions,
-    ) -> Result<Self, Error> {
-        Self::new_write_raw(channel, trigger_source, src, dst, options)
-    }
-
-    /// Create a new write DMA transfer, using raw pointers.
-    pub unsafe fn new_write_raw<SW: Word, DW: Word>(
-        channel: Peri<'a, impl Channel>,
-        trigger_source: u8,
-        src: *const [SW],
-        dst: *mut DW,
-        options: TransferOptions,
-    ) -> Result<Self, Error> {
-        verify_transfer::<SW>(src)?;
-
-        let channel = channel.into();
-        channel.configure(
-            trigger_source,
-            src.cast(),
-            SW::width(),
-            dst.cast(),
-            DW::width(),
-            src.len() as u16,
-            true,
-            false,
-            options,
-        );
-        channel.start();
-
-        Ok(Self { channel })
-    }
-
-    // TODO: Copy between slices.
 
     /// Request the transfer to resume.
     pub fn resume(&mut self) {
@@ -401,31 +449,33 @@ pub(crate) trait SealedWord {
 }
 
 pub(crate) trait SealedChannel {
-    fn id(&self) -> u8;
+    const ID: u8;
+}
 
+impl<'d> Channel<'d> {
     #[inline]
     fn tctl(&self) -> Reg<regs::Tctl, RW> {
-        pac::DMA.trig(self.id() as usize).tctl()
+        pac::DMA.trig(self.id as usize).tctl()
     }
 
     #[inline]
     fn ctl(&self) -> Reg<regs::Ctl, RW> {
-        pac::DMA.chan(self.id() as usize).ctl()
+        pac::DMA.chan(self.id as usize).ctl()
     }
 
     #[inline]
     fn sa(&self) -> Reg<u32, RW> {
-        pac::DMA.chan(self.id() as usize).sa()
+        pac::DMA.chan(self.id as usize).sa()
     }
 
     #[inline]
     fn da(&self) -> Reg<u32, RW> {
-        pac::DMA.chan(self.id() as usize).da()
+        pac::DMA.chan(self.id as usize).da()
     }
 
     #[inline]
     fn sz(&self) -> Reg<regs::Sz, RW> {
-        pac::DMA.chan(self.id() as usize).sz()
+        pac::DMA.chan(self.id as usize).sz()
     }
 
     #[inline]
@@ -433,7 +483,7 @@ pub(crate) trait SealedChannel {
         // Enabling interrupts is an RMW operation.
         critical_section::with(|_cs| {
             pac::DMA.int_event(0).imask().modify(|w| {
-                w.set_ch(self.id() as usize, enable);
+                w.set_ch(self.id as usize, enable);
             });
         })
     }
@@ -559,23 +609,18 @@ pub(crate) trait SealedChannel {
     }
 }
 
+// Some future parts will have no DMA.
+#[allow(unused_macros)]
 macro_rules! impl_dma_channel {
     ($instance: ident, $num: expr) => {
         impl crate::dma::SealedChannel for crate::peripherals::$instance {
-            fn id(&self) -> u8 {
-                $num
-            }
+            const ID: u8 = $num;
         }
 
-        impl From<crate::peripherals::$instance> for crate::dma::AnyChannel {
-            fn from(value: crate::peripherals::$instance) -> Self {
-                use crate::dma::SealedChannel;
-
-                Self { id: value.id() }
-            }
+        impl crate::dma::ChannelInstance for crate::peripherals::$instance {
+            // TODO: For chips with multiple DMAs, pick correct instance
+            type Interrupt = crate::interrupt::typelevel::DMA;
         }
-
-        impl crate::dma::Channel for crate::peripherals::$instance {}
     };
 }
 
@@ -585,24 +630,14 @@ macro_rules! impl_full_dma_channel {
     ($instance: ident, $num: expr) => {
         impl_dma_channel!($instance, $num);
 
-        impl From<crate::peripherals::$instance> for crate::dma::AnyFullChannel {
-            fn from(value: crate::peripherals::$instance) -> Self {
-                use crate::dma::SealedChannel;
-
-                Self { id: value.id() }
-            }
-        }
-
-        impl crate::dma::FullChannel for crate::peripherals::$instance {}
+        impl crate::dma::FullChannelInstance for crate::peripherals::$instance {}
     };
 }
 
-#[cfg(feature = "rt")]
-#[interrupt]
-fn DMA() {
+fn on_irq(dma: pac::dma::Dma) {
     use crate::BitIter;
 
-    let events = pac::DMA.int_event(0);
+    let events = dma.int_event(0);
     let mis = events.mis().read();
 
     // TODO: Handle DATAERR and ADDRERR? However we do not know which channel causes an error.

--- a/tests/mspm0/src/bin/dma.rs
+++ b/tests/mspm0/src/bin/dma.rs
@@ -11,111 +11,118 @@ use core::slice;
 
 use defmt::{assert, assert_eq, *};
 use embassy_executor::Spawner;
-use embassy_mspm0::Peri;
 use embassy_mspm0::dma::{Channel, Transfer, TransferMode, TransferOptions, Word};
+use embassy_mspm0::{bind_interrupts, dma, peripherals};
 use {defmt_rtt as _, panic_probe as _};
+
+bind_interrupts!(
+    struct Irqs {
+        DMA => dma::InterruptHandler<peripherals::DMA_CH0>;
+    }
+);
 
 #[embassy_executor::main]
 async fn main(_spawner: Spawner) {
-    let mut p = embassy_mspm0::init(Default::default());
     info!("Hello World!");
+    let p = embassy_mspm0::init(Default::default());
+    let mut channel = dma::Channel::new(p.DMA_CH0, Irqs);
 
     {
         info!("Single u8 read (blocking)");
-        single_read(p.DMA_CH0.reborrow(), 0x41_u8);
+        single_read(channel.reborrow(), 0x41_u8);
 
         info!("Single u16 read (blocking)");
-        single_read(p.DMA_CH0.reborrow(), 0xFF41_u16);
+        single_read(channel.reborrow(), 0xFF41_u16);
 
         info!("Single u32 read (blocking)");
-        single_read(p.DMA_CH0.reborrow(), 0xFFEE_FF41_u32);
+        single_read(channel.reborrow(), 0xFFEE_FF41_u32);
 
         info!("Single u64 read (blocking)");
-        single_read(p.DMA_CH0.reborrow(), 0x0011_2233_FFEE_FF41_u64);
+        single_read(channel.reborrow(), 0x0011_2233_FFEE_FF41_u64);
     }
 
     // Widening transfers
     {
         info!("Single u8 read to u16");
-        widening_single_read::<u8, u16>(p.DMA_CH0.reborrow(), 0x41);
+        widening_single_read::<u8, u16>(channel.reborrow(), 0x41);
 
         info!("Single u8 read to u32");
-        widening_single_read::<u8, u32>(p.DMA_CH0.reborrow(), 0x43);
+        widening_single_read::<u8, u32>(channel.reborrow(), 0x43);
 
         info!("Single u8 read to u64");
-        widening_single_read::<u8, u64>(p.DMA_CH0.reborrow(), 0x47);
+        widening_single_read::<u8, u64>(channel.reborrow(), 0x47);
 
         info!("Single u16 read to u32");
-        widening_single_read::<u16, u32>(p.DMA_CH0.reborrow(), 0xAE43);
+        widening_single_read::<u16, u32>(channel.reborrow(), 0xAE43);
 
         info!("Single u16 read to u64");
-        widening_single_read::<u16, u64>(p.DMA_CH0.reborrow(), 0xAF47);
+        widening_single_read::<u16, u64>(channel.reborrow(), 0xAF47);
 
         info!("Single u32 read to u64");
-        widening_single_read::<u32, u64>(p.DMA_CH0.reborrow(), 0xDEAD_AF47);
+        widening_single_read::<u32, u64>(channel.reborrow(), 0xDEAD_AF47);
     }
 
     // Narrowing transfers.
     {
         info!("Single u16 read to u8");
-        narrowing_single_read::<u16, u8>(p.DMA_CH0.reborrow(), 0x4142);
+        narrowing_single_read::<u16, u8>(channel.reborrow(), 0x4142);
 
         info!("Single u32 read to u8");
-        narrowing_single_read::<u32, u8>(p.DMA_CH0.reborrow(), 0x4142_2414);
+        narrowing_single_read::<u32, u8>(channel.reborrow(), 0x4142_2414);
 
         info!("Single u64 read to u8");
-        narrowing_single_read::<u64, u8>(p.DMA_CH0.reborrow(), 0x4142_2414_5153_7776);
+        narrowing_single_read::<u64, u8>(channel.reborrow(), 0x4142_2414_5153_7776);
 
         info!("Single u32 read to u16");
-        narrowing_single_read::<u32, u16>(p.DMA_CH0.reborrow(), 0x4142_2414);
+        narrowing_single_read::<u32, u16>(channel.reborrow(), 0x4142_2414);
 
         info!("Single u64 read to u16");
-        narrowing_single_read::<u64, u16>(p.DMA_CH0.reborrow(), 0x4142_2414_5153_7776);
+        narrowing_single_read::<u64, u16>(channel.reborrow(), 0x4142_2414_5153_7776);
 
         info!("Single u64 read to u32");
-        narrowing_single_read::<u64, u32>(p.DMA_CH0.reborrow(), 0x4142_2414_5153_7776);
+        narrowing_single_read::<u64, u32>(channel.reborrow(), 0x4142_2414_5153_7776);
     }
 
     {
         info!("Single u8 read (async)");
-        async_single_read(p.DMA_CH0.reborrow(), 0x42_u8).await;
+        async_single_read(channel.reborrow(), 0x42_u8).await;
 
         info!("Single u16 read (async)");
-        async_single_read(p.DMA_CH0.reborrow(), 0xAE42_u16).await;
+        async_single_read(channel.reborrow(), 0xAE42_u16).await;
 
         info!("Single u32 read (async)");
-        async_single_read(p.DMA_CH0.reborrow(), 0xFE44_1500_u32).await;
+        async_single_read(channel.reborrow(), 0xFE44_1500_u32).await;
 
         info!("Single u64 read (async)");
-        async_single_read(p.DMA_CH0.reborrow(), 0x8F7F_6F5F_4F3F_2F1F_u64).await;
+        async_single_read(channel.reborrow(), 0x8F7F_6F5F_4F3F_2F1F_u64).await;
     }
 
     {
         info!("Multiple u8 reads (blocking)");
-        block_read::<_, 16>(p.DMA_CH0.reborrow(), 0x98_u8);
+        block_read::<_, 16>(channel.reborrow(), 0x98_u8);
 
         info!("Multiple u16 reads (blocking)");
-        block_read::<_, 2>(p.DMA_CH0.reborrow(), 0x9801_u16);
+        block_read::<_, 2>(channel.reborrow(), 0x9801_u16);
 
         info!("Multiple u32 reads (blocking)");
-        block_read::<_, 4>(p.DMA_CH0.reborrow(), 0x9821_9801_u32);
+        block_read::<_, 4>(channel.reborrow(), 0x9821_9801_u32);
 
         info!("Multiple u64 reads (blocking)");
-        block_read::<_, 4>(p.DMA_CH0.reborrow(), 0xABCD_EF01_2345_6789_u64);
+        block_read::<_, 4>(channel.reborrow(), 0xABCD_EF01_2345_6789_u64);
     }
 
     {
         info!("Multiple u8 reads (async)");
-        async_block_read::<_, 8>(p.DMA_CH0.reborrow(), 0x86_u8).await;
+        async_block_read::<_, 8>(channel.reborrow(), 0x86_u8).await;
 
         info!("Multiple u16 reads (async)");
-        async_block_read::<_, 6>(p.DMA_CH0.reborrow(), 0x7777_u16).await;
+        async_block_read::<_, 6>(channel.reborrow(), 0x7777_u16).await;
 
         info!("Multiple u32 reads (async)");
-        async_block_read::<_, 3>(p.DMA_CH0.reborrow(), 0xA5A5_A5A5_u32).await;
+        async_block_read::<_, 3>(channel.reborrow(), 0xA5A5_A5A5_u32).await;
 
         info!("Multiple u64 reads (async)");
-        async_block_read::<_, 14>(p.DMA_CH0.reborrow(), 0x5A5A_5A5A_A5A5_A5A5_u64).await;
+        async_block_read::<_, 14>(channel.reborrow(), 0x5A5A_5A5A_A5A5_A5A5_u64).await;
     }
 
     // Intentionally skip testing multiple reads in single transfer mode.
@@ -130,48 +137,48 @@ async fn main(_spawner: Spawner) {
 
     {
         info!("Single u8 write (blocking)");
-        single_write(p.DMA_CH0.reborrow(), 0x41_u8);
+        single_write(channel.reborrow(), 0x41_u8);
 
         info!("Single u16 write (blocking)");
-        single_write(p.DMA_CH0.reborrow(), 0x4142_u16);
+        single_write(channel.reborrow(), 0x4142_u16);
 
         info!("Single u32 write (blocking)");
-        single_write(p.DMA_CH0.reborrow(), 0x4142_4344_u32);
+        single_write(channel.reborrow(), 0x4142_4344_u32);
 
         info!("Single u64 write (blocking)");
-        single_write(p.DMA_CH0.reborrow(), 0x4142_4344_4546_4748_u64);
+        single_write(channel.reborrow(), 0x4142_4344_4546_4748_u64);
     }
 
     {
         info!("Single u8 write (async)");
-        async_single_write(p.DMA_CH0.reborrow(), 0xAA_u8).await;
+        async_single_write(channel.reborrow(), 0xAA_u8).await;
 
         info!("Single u16 write (async)");
-        async_single_write(p.DMA_CH0.reborrow(), 0xBBBB_u16).await;
+        async_single_write(channel.reborrow(), 0xBBBB_u16).await;
 
         info!("Single u32 write (async)");
-        async_single_write(p.DMA_CH0.reborrow(), 0xCCCC_CCCC_u32).await;
+        async_single_write(channel.reborrow(), 0xCCCC_CCCC_u32).await;
 
         info!("Single u64 write (async)");
-        async_single_write(p.DMA_CH0.reborrow(), 0xDDDD_DDDD_DDDD_DDDD_u64).await;
+        async_single_write(channel.reborrow(), 0xDDDD_DDDD_DDDD_DDDD_u64).await;
     }
 
     {
         info!("Multiple u8 writes (blocking)");
-        block_write(p.DMA_CH0.reborrow(), &[0xFF_u8, 0x7F, 0x3F, 0x1F]);
+        block_write(channel.reborrow(), &[0xFF_u8, 0x7F, 0x3F, 0x1F]);
 
         info!("Multiple u16 writes (blocking)");
-        block_write(p.DMA_CH0.reborrow(), &[0xFFFF_u16, 0xFF7F, 0xFF3F, 0xFF1F]);
+        block_write(channel.reborrow(), &[0xFFFF_u16, 0xFF7F, 0xFF3F, 0xFF1F]);
 
         info!("Multiple u32 writes (blocking)");
         block_write(
-            p.DMA_CH0.reborrow(),
+            channel.reborrow(),
             &[0xFF00_00FF_u32, 0xFF00_007F, 0x0000_FF3F, 0xFF1F_0000],
         );
 
         info!("Multiple u64 writes (blocking)");
         block_write(
-            p.DMA_CH0.reborrow(),
+            channel.reborrow(),
             &[
                 0xFF00_0000_0000_00FF_u64,
                 0x0000_FF00_007F_0000,
@@ -183,17 +190,17 @@ async fn main(_spawner: Spawner) {
 
     {
         info!("Multiple u8 writes (async)");
-        async_block_write(p.DMA_CH0.reborrow(), &[0u8, 1, 2, 3]).await;
+        async_block_write(channel.reborrow(), &[0u8, 1, 2, 3]).await;
 
         info!("Multiple u16 writes (async)");
-        async_block_write(p.DMA_CH0.reborrow(), &[0x9801u16, 0x9802, 0x9803, 0x9800, 0x9000]).await;
+        async_block_write(channel.reborrow(), &[0x9801u16, 0x9802, 0x9803, 0x9800, 0x9000]).await;
 
         info!("Multiple u32 writes (async)");
-        async_block_write(p.DMA_CH0.reborrow(), &[0x9801_ABCDu32, 0xFFAC_9802, 0xDEAD_9803]).await;
+        async_block_write(channel.reborrow(), &[0x9801_ABCDu32, 0xFFAC_9802, 0xDEAD_9803]).await;
 
         info!("Multiple u64 writes (async)");
         async_block_write(
-            p.DMA_CH0.reborrow(),
+            channel.reborrow(),
             &[
                 0xA55A_1111_3333_5555_u64,
                 0x1111_A55A_3333_5555,
@@ -210,51 +217,31 @@ async fn main(_spawner: Spawner) {
     cortex_m::asm::bkpt();
 }
 
-fn single_read<W: Word + Copy + Default + Eq + defmt::Format>(mut channel: Peri<'_, impl Channel>, mut src: W) {
+fn single_read<W: Word + Copy + Default + Eq + defmt::Format>(mut channel: Channel<'_>, mut src: W) {
     let options = TransferOptions::default();
     let mut dst = W::default();
 
     // SAFETY: src and dst outlive the transfer.
-    let transfer = unsafe {
-        unwrap!(Transfer::new_read(
-            channel.reborrow(),
-            Transfer::SOFTWARE_TRIGGER,
-            &mut src,
-            slice::from_mut(&mut dst),
-            options,
-        ))
-    };
+    let transfer =
+        unsafe { unwrap!(channel.read(Transfer::SOFTWARE_TRIGGER, &mut src, slice::from_mut(&mut dst), options,)) };
     transfer.blocking_wait();
 
     assert_eq!(src, dst);
 }
 
-async fn async_single_read<W: Word + Copy + Default + Eq + defmt::Format>(
-    mut channel: Peri<'_, impl Channel>,
-    mut src: W,
-) {
+async fn async_single_read<W: Word + Copy + Default + Eq + defmt::Format>(mut channel: Channel<'_>, mut src: W) {
     let options = TransferOptions::default();
     let mut dst = W::default();
 
     // SAFETY: src and dst outlive the transfer.
-    let transfer = unsafe {
-        unwrap!(Transfer::new_read(
-            channel.reborrow(),
-            Transfer::SOFTWARE_TRIGGER,
-            &mut src,
-            slice::from_mut(&mut dst),
-            options,
-        ))
-    };
+    let transfer =
+        unsafe { unwrap!(channel.read(Transfer::SOFTWARE_TRIGGER, &mut src, slice::from_mut(&mut dst), options,)) };
     transfer.await;
 
     assert_eq!(src, dst);
 }
 
-fn block_read<W: Word + Copy + Default + Eq + defmt::Format, const N: usize>(
-    mut channel: Peri<'_, impl Channel>,
-    mut src: W,
-) {
+fn block_read<W: Word + Copy + Default + Eq + defmt::Format, const N: usize>(mut channel: Channel<'_>, mut src: W) {
     let mut options = TransferOptions::default();
     // Complete the entire transfer.
     options.mode = TransferMode::Block;
@@ -262,22 +249,14 @@ fn block_read<W: Word + Copy + Default + Eq + defmt::Format, const N: usize>(
     let mut dst = [W::default(); N];
 
     // SAFETY: src and dst outlive the transfer.
-    let transfer = unsafe {
-        unwrap!(Transfer::new_read(
-            channel.reborrow(),
-            Transfer::SOFTWARE_TRIGGER,
-            &mut src,
-            &mut dst[..],
-            options,
-        ))
-    };
+    let transfer = unsafe { unwrap!(channel.read(Transfer::SOFTWARE_TRIGGER, &mut src, &mut dst[..], options,)) };
     transfer.blocking_wait();
 
     assert_eq!(dst, [src; N]);
 }
 
 async fn async_block_read<W: Word + Copy + Default + Eq + defmt::Format, const N: usize>(
-    mut channel: Peri<'_, impl Channel>,
+    mut channel: Channel<'_>,
     mut src: W,
 ) {
     let mut options = TransferOptions::default();
@@ -287,59 +266,37 @@ async fn async_block_read<W: Word + Copy + Default + Eq + defmt::Format, const N
     let mut dst = [W::default(); N];
 
     // SAFETY: src and dst outlive the transfer.
-    let transfer = unsafe {
-        unwrap!(Transfer::new_read(
-            channel.reborrow(),
-            Transfer::SOFTWARE_TRIGGER,
-            &mut src,
-            &mut dst[..],
-            options,
-        ))
-    };
+    let transfer = unsafe { unwrap!(channel.read(Transfer::SOFTWARE_TRIGGER, &mut src, &mut dst[..], options,)) };
     transfer.await;
 
     assert_eq!(dst, [src; N]);
 }
 
-fn single_write<W: Word + Default + Eq + defmt::Format>(mut channel: Peri<'_, impl Channel>, src: W) {
+fn single_write<W: Word + Default + Eq + defmt::Format>(mut channel: Channel<'_>, src: W) {
     let options = TransferOptions::default();
     let mut dst = W::default();
 
     // SAFETY: src and dst outlive the transfer.
-    let transfer = unsafe {
-        unwrap!(Transfer::new_write(
-            channel.reborrow(),
-            Transfer::SOFTWARE_TRIGGER,
-            slice::from_ref(&src),
-            &mut dst,
-            options,
-        ))
-    };
+    let transfer =
+        unsafe { unwrap!(channel.write(Transfer::SOFTWARE_TRIGGER, slice::from_ref(&src), &mut dst, options,)) };
     transfer.blocking_wait();
 
     assert_eq!(src, dst);
 }
 
-async fn async_single_write<W: Word + Default + Eq + defmt::Format>(mut channel: Peri<'_, impl Channel>, src: W) {
+async fn async_single_write<W: Word + Default + Eq + defmt::Format>(mut channel: Channel<'_>, src: W) {
     let options = TransferOptions::default();
     let mut dst = W::default();
 
     // SAFETY: src and dst outlive the transfer.
-    let transfer = unsafe {
-        unwrap!(Transfer::new_write(
-            channel.reborrow(),
-            Transfer::SOFTWARE_TRIGGER,
-            slice::from_ref(&src),
-            &mut dst,
-            options,
-        ))
-    };
+    let transfer =
+        unsafe { unwrap!(channel.write(Transfer::SOFTWARE_TRIGGER, slice::from_ref(&src), &mut dst, options,)) };
     transfer.await;
 
     assert_eq!(src, dst);
 }
 
-fn block_write<W: Word + Default + Eq + defmt::Format>(mut channel: Peri<'_, impl Channel>, src: &[W]) {
+fn block_write<W: Word + Default + Eq + defmt::Format>(mut channel: Channel<'_>, src: &[W]) {
     let mut options = TransferOptions::default();
     // Complete the entire transfer.
     options.mode = TransferMode::Block;
@@ -351,15 +308,7 @@ fn block_write<W: Word + Default + Eq + defmt::Format>(mut channel: Peri<'_, imp
         info!("-> {} write(s)", i);
 
         // SAFETY: src and dst outlive the transfer.
-        let transfer = unsafe {
-            unwrap!(Transfer::new_write(
-                channel.reborrow(),
-                Transfer::SOFTWARE_TRIGGER,
-                &src[..i],
-                &mut dst,
-                options,
-            ))
-        };
+        let transfer = unsafe { unwrap!(channel.write(Transfer::SOFTWARE_TRIGGER, &src[..i], &mut dst, options,)) };
         transfer.blocking_wait();
 
         // The result will be the last value written.
@@ -367,7 +316,7 @@ fn block_write<W: Word + Default + Eq + defmt::Format>(mut channel: Peri<'_, imp
     }
 }
 
-async fn async_block_write<W: Word + Default + Eq + defmt::Format>(mut channel: Peri<'_, impl Channel>, src: &[W]) {
+async fn async_block_write<W: Word + Default + Eq + defmt::Format>(mut channel: Channel<'_>, src: &[W]) {
     let mut options = TransferOptions::default();
     // Complete the entire transfer.
     options.mode = TransferMode::Block;
@@ -378,15 +327,7 @@ async fn async_block_write<W: Word + Default + Eq + defmt::Format>(mut channel: 
     for i in 1..src.len() {
         info!("-> {} write(s)", i);
         // SAFETY: src and dst outlive the transfer.
-        let transfer = unsafe {
-            unwrap!(Transfer::new_write(
-                channel.reborrow(),
-                Transfer::SOFTWARE_TRIGGER,
-                &src[..i],
-                &mut dst,
-                options,
-            ))
-        };
+        let transfer = unsafe { unwrap!(channel.write(Transfer::SOFTWARE_TRIGGER, &src[..i], &mut dst, options,)) };
         transfer.await;
 
         // The result will be the last value written.
@@ -398,7 +339,7 @@ async fn async_block_write<W: Word + Default + Eq + defmt::Format>(mut channel: 
 ///
 /// The MSPM0 DMA states that the upper bytes when the destination is longer than the source are zeroed.
 /// This matches the behavior in Rust for all unsigned integer types.
-fn widening_single_read<SW, DW>(mut channel: Peri<'_, impl Channel>, mut src: SW)
+fn widening_single_read<SW, DW>(mut channel: Channel<'_>, mut src: SW)
 where
     SW: Word + Copy + Default + Eq + defmt::Format,
     DW: Word + Copy + Default + Eq + defmt::Format + From<SW>,
@@ -412,15 +353,8 @@ where
     let mut dst = DW::default();
 
     // SAFETY: src and dst outlive the transfer.
-    let transfer = unsafe {
-        unwrap!(Transfer::new_read(
-            channel.reborrow(),
-            Transfer::SOFTWARE_TRIGGER,
-            &mut src,
-            slice::from_mut(&mut dst),
-            options,
-        ))
-    };
+    let transfer =
+        unsafe { unwrap!(channel.read(Transfer::SOFTWARE_TRIGGER, &mut src, slice::from_mut(&mut dst), options,)) };
     transfer.blocking_wait();
 
     assert_eq!(DW::from(src), dst);
@@ -430,7 +364,7 @@ where
 ///
 /// The MSPM0 DMA states that the upper bytes when the source is longer than the destination are dropped.
 /// This matches the behavior in Rust for all unsigned integer types.
-fn narrowing_single_read<SW, DW>(mut channel: Peri<'_, impl Channel>, mut src: SW)
+fn narrowing_single_read<SW, DW>(mut channel: Channel<'_>, mut src: SW)
 where
     SW: Word + Copy + Default + Eq + defmt::Format + From<DW>,
     DW: Word + Copy + Default + Eq + defmt::Format + Narrow<SW>,
@@ -444,15 +378,8 @@ where
     let mut dst = DW::default();
 
     // SAFETY: src and dst outlive the transfer.
-    let transfer = unsafe {
-        unwrap!(Transfer::new_read(
-            channel.reborrow(),
-            Transfer::SOFTWARE_TRIGGER,
-            &mut src,
-            slice::from_mut(&mut dst),
-            options,
-        ))
-    };
+    let transfer =
+        unsafe { unwrap!(channel.read(Transfer::SOFTWARE_TRIGGER, &mut src, slice::from_mut(&mut dst), options,)) };
     transfer.blocking_wait();
 
     // The expected value is the source value masked by the maximum destination value.


### PR DESCRIPTION
To both match other hals and to reclaim space on C1104

On the C1104 UART example (which does not use DMA):
Before:
```
  text    data     bss     dec     hex filename
   5964      80     396    6440    1928 uart
```

After:
```
   text    data     bss     dec     hex filename
   5844      80     388    6312    18a8 uart
```

Approximately 120B of flash and 8B of RAM. C1104 only has 1 DMA channel so the RAM savings are quite minimal.

The existing tests also pass on G3507.