### PR TITLE
stm32: make min stop universal

### DIFF
--- a/embassy-stm32/src/rcc/mod.rs
+++ b/embassy-stm32/src/rcc/mod.rs
@@ -408,7 +408,7 @@ impl RccInfo {
 
     #[allow(dead_code)]
     fn increment_minimum_stop_refcount_with_cs(&self, _cs: CriticalSection) {
-        #[cfg(all(any(stm32wl, stm32wb, stm32wba), feature = "low-power"))]
+        #[cfg(feature = "low-power")]
         match self.stop_mode {
             StopMode::Stop1 | StopMode::Stop2 => increment_stop_refcount(_cs, StopMode::Stop2),
             _ => {}
@@ -417,7 +417,7 @@ impl RccInfo {
 
     #[allow(dead_code)]
     fn decrement_minimum_stop_refcount_with_cs(&self, _cs: CriticalSection) {
-        #[cfg(all(any(stm32wl, stm32wb, stm32wba), feature = "low-power"))]
+        #[cfg(feature = "low-power")]
         match self.stop_mode {
             StopMode::Stop1 | StopMode::Stop2 => decrement_stop_refcount(_cs, StopMode::Stop2),
             _ => {}


### PR DESCRIPTION
This seems to apply to most chips, and can be disabled on a case-by-case basis rather than the inverse.