### PR TITLE
Add panic-free time functions and document panics

### DIFF
--- a/embassy-time/src/delay.rs
+++ b/embassy-time/src/delay.rs
@@ -10,9 +10,21 @@ use crate::Timer;
 /// ## Panics
 ///
 /// Panics if the computed instant overflows.
+/// Avoid panics with [`try_block_for()`].
 pub fn block_for(duration: Duration) {
     let expires_at = Instant::now() + duration;
     while Instant::now() < expires_at {}
+}
+
+/// Tries to block for at least `duration`.
+///
+/// This function may require interrupts to be enabled to work correctly.
+///
+/// This is a panic-free [`block_for()`].
+pub fn try_block_for(duration: Duration) -> Option<()> {
+    let expires_at = Instant::now().checked_add(duration)?;
+    while Instant::now() < expires_at {}
+    Some(())
 }
 
 /// Type implementing async delays and blocking `embedded-hal` delays.
@@ -146,5 +158,24 @@ impl embedded_hal_02::blocking::delay::DelayUs<u32> for Delay {
     /// Panics if the computed instant overflows.
     fn delay_us(&mut self, us: u32) {
         block_for(Duration::from_micros(us as u64))
+    }
+}
+
+#[cfg(all(test, feature = "std"))]
+mod test {
+    use super::*;
+
+    #[test]
+    #[should_panic(expected = "overflow")]
+    #[cfg(panic = "unwind")]
+    fn block_for_panics() {
+        while Instant::now() == Instant::MIN {} // with non-0 tick
+        block_for(Duration::MAX); // PANIC
+    }
+
+    #[test]
+    fn try_block_for_none() {
+        while Instant::now() == Instant::MIN {} // with non-0 tick
+        assert!(try_block_for(Duration::MAX).is_none());
     }
 }

--- a/embassy-time/src/delay.rs
+++ b/embassy-time/src/delay.rs
@@ -26,64 +26,124 @@ pub fn block_for(duration: Duration) {
 pub struct Delay;
 
 impl embedded_hal_1::delay::DelayNs for Delay {
+    /// Pauses execution for at minimum `ns` nanoseconds.
+    ///
+    /// ## Panics
+    ///
+    /// Panics if the computed instant overflows.
     fn delay_ns(&mut self, ns: u32) {
         block_for(Duration::from_nanos(ns as u64))
     }
 
+    /// Pauses execution for at minimum `us` microseconds.
+    ///
+    /// ## Panics
+    ///
+    /// Panics if the computed instant overflows.
     fn delay_us(&mut self, us: u32) {
         block_for(Duration::from_micros(us as u64))
     }
 
+    /// Pauses execution for at minimum `ms` milliseconds.
+    ///
+    /// ## Panics
+    ///
+    /// Panics if the computed instant overflows.
     fn delay_ms(&mut self, ms: u32) {
         block_for(Duration::from_millis(ms as u64))
     }
 }
 
 impl embedded_hal_async::delay::DelayNs for Delay {
+    /// Pauses execution for at minimum `ns` nanoseconds.
+    ///
+    /// ## Panics
+    ///
+    /// Panics if the computed instant overflows.
     fn delay_ns(&mut self, ns: u32) -> impl Future<Output = ()> {
         Timer::after_nanos(ns as _)
     }
 
+    /// Pauses execution for at minimum `us` microseconds.
+    ///
+    /// ## Panics
+    ///
+    /// Panics if the computed instant overflows.
     fn delay_us(&mut self, us: u32) -> impl Future<Output = ()> {
         Timer::after_micros(us as _)
     }
 
+    /// Pauses execution for at minimum `ms` milliseconds.
+    ///
+    /// ## Panics
+    ///
+    /// Panics if the computed instant overflows.
     fn delay_ms(&mut self, ms: u32) -> impl Future<Output = ()> {
         Timer::after_millis(ms as _)
     }
 }
 
 impl embedded_hal_02::blocking::delay::DelayMs<u8> for Delay {
+    /// Pauses execution for at minimum `ms` milliseconds.
+    ///
+    /// ## Panics
+    ///
+    /// Panics if the computed instant overflows.
     fn delay_ms(&mut self, ms: u8) {
         block_for(Duration::from_millis(ms as u64))
     }
 }
 
 impl embedded_hal_02::blocking::delay::DelayMs<u16> for Delay {
+    /// Pauses execution for at minimum `ms` milliseconds.
+    ///
+    /// ## Panics
+    ///
+    /// Panics if the computed instant overflows.
     fn delay_ms(&mut self, ms: u16) {
         block_for(Duration::from_millis(ms as u64))
     }
 }
 
 impl embedded_hal_02::blocking::delay::DelayMs<u32> for Delay {
+    /// Pauses execution for at minimum `ms` milliseconds.
+    ///
+    /// ## Panics
+    ///
+    /// Panics if the computed instant overflows.
     fn delay_ms(&mut self, ms: u32) {
         block_for(Duration::from_millis(ms as u64))
     }
 }
 
 impl embedded_hal_02::blocking::delay::DelayUs<u8> for Delay {
+    /// Pauses execution for at minimum `us` microseconds.
+    ///
+    /// ## Panics
+    ///
+    /// Panics if the computed instant overflows.
     fn delay_us(&mut self, us: u8) {
         block_for(Duration::from_micros(us as u64))
     }
 }
 
 impl embedded_hal_02::blocking::delay::DelayUs<u16> for Delay {
+    /// Pauses execution for at minimum `us` microseconds.
+    ///
+    /// ## Panics
+    ///
+    /// Panics if the computed instant overflows.
     fn delay_us(&mut self, us: u16) {
         block_for(Duration::from_micros(us as u64))
     }
 }
 
 impl embedded_hal_02::blocking::delay::DelayUs<u32> for Delay {
+    /// Pauses execution for at minimum `us` microseconds.
+    ///
+    /// ## Panics
+    ///
+    /// Panics if the computed instant overflows.
     fn delay_us(&mut self, us: u32) {
         block_for(Duration::from_micros(us as u64))
     }

--- a/embassy-time/src/delay.rs
+++ b/embassy-time/src/delay.rs
@@ -6,6 +6,10 @@ use crate::Timer;
 /// Blocks for at least `duration`.
 ///
 /// This function may require interrupts to be enabled to work correctly.
+///
+/// ## Panics
+///
+/// Panics if the computed instant overflows.
 pub fn block_for(duration: Duration) {
     let expires_at = Instant::now() + duration;
     while Instant::now() < expires_at {}

--- a/embassy-time/src/duration.rs
+++ b/embassy-time/src/duration.rs
@@ -174,6 +174,10 @@ impl Duration {
     /// Creates a duration corresponding to the specified Hz.
     /// NOTE: Giving this function a hz >= the TICK_HZ of your platform will clamp the Duration to 1
     /// tick. Doing so will not deadlock, but will certainly not produce the desired output.
+    ///
+    /// ## Panics
+    ///
+    /// Panics if `hz` is zero.
     pub const fn from_hz(hz: u64) -> Duration {
         let ticks = { if hz >= TICK_HZ { 1 } else { (TICK_HZ + hz / 2) / hz } };
         Duration { ticks }
@@ -203,12 +207,22 @@ impl Duration {
 impl Add for Duration {
     type Output = Duration;
 
+    /// Computes `Duration + Duration`. [Read more](Add)
+    ///
+    /// ## Panics
+    ///
+    /// Panics if the computed duration overflows.
     fn add(self, rhs: Duration) -> Duration {
         self.checked_add(rhs).expect("overflow when adding durations")
     }
 }
 
 impl AddAssign for Duration {
+    /// Computes `Duration += Duration`. [Read more](AddAssign)
+    ///
+    /// ## Panics
+    ///
+    /// Panics if the computed duration overflows.
     fn add_assign(&mut self, rhs: Duration) {
         *self = *self + rhs;
     }
@@ -217,12 +231,22 @@ impl AddAssign for Duration {
 impl Sub for Duration {
     type Output = Duration;
 
+    /// Computes `Duration - Duration`. [Read more](Sub)
+    ///
+    /// ## Panics
+    ///
+    /// Panics if the computed duration overflows.
     fn sub(self, rhs: Duration) -> Duration {
         self.checked_sub(rhs).expect("overflow when subtracting durations")
     }
 }
 
 impl SubAssign for Duration {
+    /// Computes `Duration -= Duration`. [Read more](SubAssign)
+    ///
+    /// ## Panics
+    ///
+    /// Panics if the computed duration overflows.
     fn sub_assign(&mut self, rhs: Duration) {
         *self = *self - rhs;
     }
@@ -231,6 +255,11 @@ impl SubAssign for Duration {
 impl Mul<u32> for Duration {
     type Output = Duration;
 
+    /// Computes `Duration * u32`. [Read more](Mul)
+    ///
+    /// ## Panics
+    ///
+    /// Panics if the computed duration overflows.
     fn mul(self, rhs: u32) -> Duration {
         self.checked_mul(rhs)
             .expect("overflow when multiplying duration by scalar")
@@ -240,12 +269,22 @@ impl Mul<u32> for Duration {
 impl Mul<Duration> for u32 {
     type Output = Duration;
 
+    /// Computes `u32 * Duration`. [Read more](Mul)
+    ///
+    /// ## Panics
+    ///
+    /// Panics if the computed duration overflows.
     fn mul(self, rhs: Duration) -> Duration {
         rhs * self
     }
 }
 
 impl MulAssign<u32> for Duration {
+    /// Computes `Duration *= u32`. [Read more](MulAssign)
+    ///
+    /// ## Panics
+    ///
+    /// Panics if the computed duration overflows.
     fn mul_assign(&mut self, rhs: u32) {
         *self = *self * rhs;
     }
@@ -254,6 +293,11 @@ impl MulAssign<u32> for Duration {
 impl Div<u32> for Duration {
     type Output = Duration;
 
+    /// Computes `Duration / u32`. [Read more](Div)
+    ///
+    /// ## Panics
+    ///
+    /// Panics if dividing by zero.
     fn div(self, rhs: u32) -> Duration {
         self.checked_div(rhs)
             .expect("divide by zero error when dividing duration by scalar")
@@ -261,6 +305,11 @@ impl Div<u32> for Duration {
 }
 
 impl DivAssign<u32> for Duration {
+    /// Computes `Duration /= u32`. [Read more](DivAssign)
+    ///
+    /// ## Panics
+    ///
+    /// Panics if dividing by zero.
     fn div_assign(&mut self, rhs: u32) {
         *self = *self / rhs;
     }

--- a/embassy-time/src/instant.rs
+++ b/embassy-time/src/instant.rs
@@ -125,7 +125,11 @@ impl Instant {
     }
 
     /// Duration between this Instant and another Instant
-    /// Panics on over/underflow.
+    ///
+    /// ## Panics
+    ///
+    /// Panics if the computed duration overflows.
+    /// Avoid panics with [`Instant::checked_duration_since()`] or [`Instant::saturating_duration_since()`].
     pub fn duration_since(&self, earlier: Instant) -> Duration {
         Duration {
             ticks: unwrap!(self.ticks.checked_sub(earlier.ticks)),
@@ -133,6 +137,8 @@ impl Instant {
     }
 
     /// Duration between this Instant and another Instant
+    ///
+    /// This is a panic-free [`Instant::duration_since()`].
     pub fn checked_duration_since(&self, earlier: Instant) -> Option<Duration> {
         if self.ticks < earlier.ticks {
             None
@@ -145,6 +151,8 @@ impl Instant {
 
     /// Returns the duration since the "earlier" Instant.
     /// If the "earlier" instant is in the future, the duration is set to zero.
+    ///
+    /// This is a panic-free alternative to [`Instant::duration_since()`].
     pub fn saturating_duration_since(&self, earlier: Instant) -> Duration {
         Duration {
             ticks: if self.ticks < earlier.ticks {
@@ -156,6 +164,10 @@ impl Instant {
     }
 
     /// Duration elapsed since this Instant.
+    ///
+    /// ## Panics
+    ///
+    /// Panics if the computed duration overflows.
     pub fn elapsed(&self) -> Duration {
         Instant::now() - *self
     }
@@ -186,6 +198,11 @@ impl Instant {
 impl Add<Duration> for Instant {
     type Output = Instant;
 
+    /// Computes `Instant + Duration`. [Read more](Add)
+    ///
+    /// ## Panics
+    ///
+    /// Panics if the computed instant overflows.
     fn add(self, other: Duration) -> Instant {
         self.checked_add(other)
             .expect("overflow when adding duration to instant")
@@ -193,6 +210,11 @@ impl Add<Duration> for Instant {
 }
 
 impl AddAssign<Duration> for Instant {
+    /// Computes `Instant += Duration`. [Read more](AddAssign)
+    ///
+    /// ## Panics
+    ///
+    /// Panics if the computed instant overflows.
     fn add_assign(&mut self, other: Duration) {
         *self = *self + other;
     }
@@ -201,6 +223,11 @@ impl AddAssign<Duration> for Instant {
 impl Sub<Duration> for Instant {
     type Output = Instant;
 
+    /// Computes `Instant - Duration`. [Read more](Sub)
+    ///
+    /// ## Panics
+    ///
+    /// Panics if the computed instant overflows.
     fn sub(self, other: Duration) -> Instant {
         self.checked_sub(other)
             .expect("overflow when subtracting duration from instant")
@@ -208,6 +235,11 @@ impl Sub<Duration> for Instant {
 }
 
 impl SubAssign<Duration> for Instant {
+    /// Computes `Instant -= Duration`. [Read more](SubAssign)
+    ///
+    /// ## Panics
+    ///
+    /// Panics if the computed instant overflows.
     fn sub_assign(&mut self, other: Duration) {
         *self = *self - other;
     }
@@ -216,6 +248,11 @@ impl SubAssign<Duration> for Instant {
 impl Sub<Instant> for Instant {
     type Output = Duration;
 
+    /// Computes `Instant - Instant`. [Read more](Sub)
+    ///
+    /// ## Panics
+    ///
+    /// Panics if the computed duration overflows in [`Instant::duration_since`].
     fn sub(self, other: Instant) -> Duration {
         self.duration_since(other)
     }

--- a/embassy-time/src/lib.rs
+++ b/embassy-time/src/lib.rs
@@ -34,7 +34,7 @@ pub use delay::{Delay, block_for, try_block_for};
 pub use duration::Duration;
 pub use embassy_time_driver::TICK_HZ;
 pub use instant::Instant;
-pub use timer::{Ticker, TimeoutError, Timer, WithTimeout, with_deadline, with_timeout};
+pub use timer::{Ticker, TimeoutError, Timer, WithTimeout, try_with_timeout, with_deadline, with_timeout};
 
 const fn gcd(a: u64, b: u64) -> u64 {
     if b == 0 { a } else { gcd(b, a % b) }

--- a/embassy-time/src/lib.rs
+++ b/embassy-time/src/lib.rs
@@ -30,7 +30,7 @@ mod driver_std;
 #[cfg(feature = "wasm")]
 mod driver_wasm;
 
-pub use delay::{Delay, block_for};
+pub use delay::{Delay, block_for, try_block_for};
 pub use duration::Duration;
 pub use embassy_time_driver::TICK_HZ;
 pub use instant::Instant;

--- a/embassy-time/src/timer.rs
+++ b/embassy-time/src/timer.rs
@@ -198,9 +198,25 @@ impl Timer {
     ///
     /// This method is a convenience wrapper for calling `Timer::after(Duration::from_micros())`.
     /// For more details, refer to [`Timer::after()`] and [`Duration::from_micros()`].
+    ///
+    /// ## Panics
+    ///
+    /// Panics if the computed instant overflows.
+    /// Avoid panics with [`Timer::try_after_nanos()`].
     #[inline]
     pub fn after_micros(micros: u64) -> Self {
         Self::after(Duration::from_micros(micros))
+    }
+
+    /// Try to expire after the specified number of microseconds.
+    ///
+    /// This method is a convenience wrapper for calling `Timer::try_after(Duration::from_micros())`.
+    /// For more details, refer to [`Timer::try_after()`] and [`Duration::from_micros()`].
+    ///
+    /// This is a panic-free [`Timer::after_micros()`].
+    #[inline]
+    pub fn try_after_micros(micros: u64) -> Option<Self> {
+        Self::try_after(Duration::from_micros(micros))
     }
 
     /// Expire after the specified number of milliseconds.

--- a/embassy-time/src/timer.rs
+++ b/embassy-time/src/timer.rs
@@ -148,9 +148,25 @@ impl Timer {
     ///
     /// This method is a convenience wrapper for calling `Timer::after(Duration::from_ticks())`.
     /// For more details, refer to [`Timer::after()`] and [`Duration::from_ticks()`].
+    ///
+    /// ## Panics
+    ///
+    /// Panics if the computed instant overflows.
+    /// Avoid panics with [`Timer::try_after_ticks()`].
     #[inline]
     pub fn after_ticks(ticks: u64) -> Self {
         Self::after(Duration::from_ticks(ticks))
+    }
+
+    /// Try to expire after the specified number of ticks.
+    ///
+    /// This method is a convenience wrapper for calling `Timer::try_after(Duration::from_ticks())`.
+    /// For more details, refer to [`Timer::try_after()`] and [`Duration::from_ticks()`].
+    ///
+    /// This is a panic-free [`Timer::after_ticks()`].
+    #[inline]
+    pub fn try_after_ticks(ticks: u64) -> Option<Self> {
+        Self::try_after(Duration::from_ticks(ticks))
     }
 
     /// Expire after the specified number of nanoseconds.

--- a/embassy-time/src/timer.rs
+++ b/embassy-time/src/timer.rs
@@ -173,9 +173,25 @@ impl Timer {
     ///
     /// This method is a convenience wrapper for calling `Timer::after(Duration::from_nanos())`.
     /// For more details, refer to [`Timer::after()`] and [`Duration::from_nanos()`].
+    ///
+    /// ## Panics
+    ///
+    /// Panics if the computed instant overflows.
+    /// Avoid panics with [`Timer::try_after_nanos()`].
     #[inline]
     pub fn after_nanos(nanos: u64) -> Self {
         Self::after(Duration::from_nanos(nanos))
+    }
+
+    /// Try to expire after the specified number of nanoseconds.
+    ///
+    /// This method is a convenience wrapper for calling `Timer::try_after(Duration::from_ticks())`.
+    /// For more details, refer to [`Timer::try_after()`] and [`Duration::from_nanos()`].
+    ///
+    /// This is a panic-free [`Timer::after_nanos()`].
+    #[inline]
+    pub fn try_after_nanos(nanos: u64) -> Option<Self> {
+        Self::try_after(Duration::from_nanos(nanos))
     }
 
     /// Expire after the specified number of microseconds.

--- a/embassy-time/src/timer.rs
+++ b/embassy-time/src/timer.rs
@@ -396,8 +396,24 @@ impl Ticker {
 
     /// Resets the ticker, after the specified duration has passed.
     /// If the specified duration is zero, the next tick will be after the duration of the ticker.
+    ///
+    /// ## Panics
+    ///
+    /// Panics if the computed instant overflows.
+    /// Avoid panics with [`Ticker::checked_reset_after()`].
     pub fn reset_after(&mut self, after: impl Into<Duration>) {
-        self.expires_at = Instant::now() + after.into() + self.duration;
+        let after = after.into();
+        self.expires_at = Instant::now() + after + self.duration;
+    }
+
+    /// Checked resets the ticker, after the specified duration has passed.
+    /// If the specified duration is zero, the next tick will be after the duration of the ticker.
+    ///
+    /// This is a panic-free [`Ticker::reset_after()`].
+    pub fn checked_reset_after(&mut self, after: impl Into<Duration>) -> Option<()> {
+        let after = after.into();
+        self.expires_at = Instant::now().checked_add(after)?.checked_add(self.duration)?;
+        Some(())
     }
 
     /// Waits for the next tick.
@@ -520,5 +536,27 @@ mod test {
             duration: Duration::MAX,
         };
         assert!(ticker.checked_reset_at(Instant::MAX).is_none());
+    }
+
+    #[test]
+    #[should_panic(expected = "overflow")]
+    #[cfg(panic = "unwind")]
+    fn ticker_reset_after_panics() {
+        let mut ticker = Ticker {
+            expires_at: Instant::MAX,
+            duration: Duration::MAX,
+        };
+        while Instant::now() == Instant::MIN {} // with non-0 tick
+        ticker.reset_after(Duration::MAX); // PANIC
+    }
+
+    #[test]
+    fn ticker_checked_reset_after_none() {
+        let mut ticker = Ticker {
+            expires_at: Instant::MAX,
+            duration: Duration::MAX,
+        };
+        while Instant::now() == Instant::MIN {} // with non-0 tick
+        assert!(ticker.checked_reset_after(Duration::MAX).is_none());
     }
 }

--- a/embassy-time/src/timer.rs
+++ b/embassy-time/src/timer.rs
@@ -442,6 +442,14 @@ impl Unpin for Ticker {}
 
 impl Stream for Ticker {
     type Item = ();
+    /// Attempt to pull the next tick from this [`Stream`].
+    ///
+    /// * Returns `Poll::Pending` if the instant is in the future.
+    /// * Returns `Poll::Ready(Some(()))` if the instant has been reached, and computes the next instant.
+    ///
+    /// ## Panics
+    ///
+    /// Panics if the computed instant overflows.
     fn poll_next(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
         if self.expires_at <= Instant::now() {
             let dur = self.duration;

--- a/embassy-time/src/timer.rs
+++ b/embassy-time/src/timer.rs
@@ -114,16 +114,13 @@ impl Timer {
     /// Expire after specified [Duration](struct.Duration.html).
     /// This can be used as a `sleep` abstraction.
     ///
-    /// Note: You must ensure that Instant::now() when added to the intended
-    /// sleep duration does not overflow the u64 tick counter or a panic will occur.
+    /// ## Panics
     ///
-    /// For example Timer::after(Duration::MAX) will always panic
-    /// and must be avoided.
+    /// Panics if the computed instant overflows.
+    /// Avoid panics with [`Timer::try_after()`].
     ///
-    /// The same restriction applies to with_timeout() and the other
-    /// after_* functions.
+    /// ## Example
     ///
-    /// Example:
     /// ``` no_run
     /// use embassy_time::{Duration, Timer};
     ///
@@ -134,10 +131,17 @@ impl Timer {
     /// }
     /// ```
     pub fn after(duration: impl Into<Duration>) -> Self {
-        Self {
-            expires_at: Instant::now() + duration.into(),
-            yielded_once: false,
-        }
+        let expires_at = Instant::now() + duration.into();
+        Self::at(expires_at)
+    }
+
+    /// Try to expire after specified [Duration](struct.Duration.html).
+    /// This can be used as a `sleep` abstraction.
+    ///
+    /// This is a panic-free [`Timer::after()`].
+    pub fn try_after(duration: impl Into<Duration>) -> Option<Self> {
+        let expires_at = Instant::now().checked_add(duration.into())?;
+        Some(Self::at(expires_at))
     }
 
     /// Expire after the specified number of ticks.
@@ -321,3 +325,22 @@ impl core::fmt::Display for TimeoutError {
     }
 }
 impl core::error::Error for TimeoutError {}
+
+#[cfg(all(test, feature = "std"))]
+mod test {
+    use super::*;
+
+    #[test]
+    #[should_panic(expected = "overflow")]
+    #[cfg(panic = "unwind")]
+    fn timer_after_panics() {
+        while Instant::now() == Instant::MIN {} // with non-0 tick
+        let _ = Timer::after(Duration::MAX); // PANIC
+    }
+
+    #[test]
+    fn timer_try_after_none() {
+        while Instant::now() == Instant::MIN {} // with non-0 tick
+        assert!(Timer::try_after(Duration::MAX).is_none());
+    }
+}

--- a/embassy-time/src/timer.rs
+++ b/embassy-time/src/timer.rs
@@ -418,6 +418,10 @@ impl Ticker {
 
     /// Waits for the next tick.
     ///
+    /// ## Panics
+    ///
+    /// Panics if the next computed instant overflows.
+    ///
     /// ## Cancel safety
     /// The produced Future is cancel safe, meaning no tick is lost if the Future is dropped.
     pub fn next(&mut self) -> impl Future<Output = ()> + Send + Sync + '_ {

--- a/embassy-time/src/timer.rs
+++ b/embassy-time/src/timer.rs
@@ -376,8 +376,22 @@ impl Ticker {
 
     /// Reset the ticker at the deadline.
     /// If the deadline is in the past, the ticker will fire before the next scheduled tick.
+    ///
+    /// ## Panics
+    ///
+    /// Panics if the computed instant overflows.
+    /// Avoid panics with [`Ticker::checked_reset_at()`].
     pub fn reset_at(&mut self, deadline: Instant) {
         self.expires_at = deadline + self.duration;
+    }
+
+    /// Checked reset the ticker at the deadline.
+    /// If the deadline is in the past, the ticker will fire before the next scheduled tick.
+    ///
+    /// This is a panic-free [`Ticker::reset_at()`].
+    pub fn checked_reset_at(&mut self, deadline: Instant) -> Option<()> {
+        self.expires_at = deadline.checked_add(self.duration)?;
+        Some(())
     }
 
     /// Resets the ticker, after the specified duration has passed.
@@ -486,5 +500,25 @@ mod test {
         };
         while Instant::now() == Instant::MIN {} // with non-0 tick
         assert!(ticker.checked_reset().is_none());
+    }
+
+    #[test]
+    #[should_panic(expected = "overflow")]
+    #[cfg(panic = "unwind")]
+    fn ticker_reset_at_panics() {
+        let mut ticker = Ticker {
+            expires_at: Instant::MAX,
+            duration: Duration::MAX,
+        };
+        ticker.reset_at(Instant::MAX); // PANIC
+    }
+
+    #[test]
+    fn ticker_checked_reset_at_none() {
+        let mut ticker = Ticker {
+            expires_at: Instant::MAX,
+            duration: Duration::MAX,
+        };
+        assert!(ticker.checked_reset_at(Instant::MAX).is_none());
     }
 }

--- a/embassy-time/src/timer.rs
+++ b/embassy-time/src/timer.rs
@@ -334,10 +334,24 @@ pub struct Ticker {
 
 impl Ticker {
     /// Creates a new ticker that ticks at the specified duration interval.
+    ///
+    /// ## Panics
+    ///
+    /// Panics if the computed instant overflows.
+    /// Avoid panics with [`Ticker::try_every()`].
     pub fn every(duration: impl Into<Duration>) -> Self {
         let duration = duration.into();
         let expires_at = Instant::now() + duration;
         Self { expires_at, duration }
+    }
+
+    /// Tries to create a new ticker that ticks at the specified duration interval.
+    ///
+    /// This is a panic-free [`Ticker::every()`].
+    pub fn try_every(duration: impl Into<Duration>) -> Option<Self> {
+        let duration = duration.into();
+        let expires_at = Instant::now().checked_add(duration)?;
+        Some(Self { expires_at, duration })
     }
 
     /// Resets the ticker back to its original state.
@@ -422,5 +436,19 @@ mod test {
     fn timer_try_after_none() {
         while Instant::now() == Instant::MIN {} // with non-0 tick
         assert!(Timer::try_after(Duration::MAX).is_none());
+    }
+
+    #[test]
+    #[should_panic(expected = "overflow")]
+    #[cfg(panic = "unwind")]
+    fn ticker_every_panics() {
+        while Instant::now() == Instant::MIN {} // with non-0 tick
+        let _ = Ticker::every(Duration::MAX); // PANIC
+    }
+
+    #[test]
+    fn ticker_try_every_none() {
+        while Instant::now() == Instant::MIN {} // with non-0 tick
+        assert!(Ticker::try_every(Duration::MAX).is_none());
     }
 }

--- a/embassy-time/src/timer.rs
+++ b/embassy-time/src/timer.rs
@@ -248,9 +248,25 @@ impl Timer {
     ///
     /// This method is a convenience wrapper for calling `Timer::after(Duration::from_secs())`.
     /// For more details, refer to [`Timer::after`] and [`Duration::from_secs()`].
+    ///
+    /// ## Panics
+    ///
+    /// Panics if the computed instant overflows.
+    /// Avoid panics with [`Timer::try_after_secs()`].
     #[inline]
     pub fn after_secs(secs: u64) -> Self {
         Self::after(Duration::from_secs(secs))
+    }
+
+    /// Try to expire after the specified number of seconds.
+    ///
+    /// This method is a convenience wrapper for calling `Timer::try_after(Duration::from_secs())`.
+    /// For more details, refer to [`Timer::try_after`] and [`Duration::from_secs()`].
+    ///
+    /// This is a panic-free [`Timer::after_secs()`].
+    #[inline]
+    pub fn try_after_secs(secs: u64) -> Option<Self> {
+        Self::try_after(Duration::from_secs(secs))
     }
 }
 

--- a/embassy-time/src/timer.rs
+++ b/embassy-time/src/timer.rs
@@ -22,10 +22,8 @@ pub struct TimeoutError;
 /// Panics if the computed instant overflows.
 /// Avoid panics with [`try_with_timeout()`].
 pub fn with_timeout<F: Future>(timeout: impl Into<Duration>, fut: F) -> TimeoutFuture<F> {
-    TimeoutFuture {
-        timer: Timer::after(timeout),
-        fut,
-    }
+    let timeout = timeout.into();
+    with_deadline(Instant::now() + timeout, fut)
 }
 
 /// Tries to run a given future with a timeout.
@@ -35,10 +33,8 @@ pub fn with_timeout<F: Future>(timeout: impl Into<Duration>, fut: F) -> TimeoutF
 ///
 /// This is a panic-free version of [`with_timeout`].
 pub fn try_with_timeout<F: Future>(timeout: impl Into<Duration>, fut: F) -> Option<TimeoutFuture<F>> {
-    Some(TimeoutFuture {
-        timer: Timer::try_after(timeout)?,
-        fut,
-    })
+    let timeout = timeout.into();
+    Some(with_deadline(Instant::now().checked_add(timeout)?, fut))
 }
 
 /// Runs a given future with a deadline time.
@@ -66,7 +62,10 @@ pub trait WithTimeout: Sized {
     ///
     /// Panics if the computed instant overflows.
     /// Avoid panics with [`WithTimeout::try_with_timeout()`].
-    fn with_timeout(self, timeout: impl Into<Duration>) -> TimeoutFuture<Self>;
+    fn with_timeout(self, timeout: impl Into<Duration>) -> TimeoutFuture<Self> {
+        let timeout = timeout.into();
+        self.with_deadline(Instant::now() + timeout)
+    }
 
     /// Tries to run a given future with a timeout.
     ///
@@ -74,7 +73,10 @@ pub trait WithTimeout: Sized {
     /// work on the future is stopped (`poll` is no longer called), the future is dropped and `Err(TimeoutError)` is returned.
     ///
     /// This is a panic-free [`WithTimeout::with_timeout()`].
-    fn try_with_timeout(self, timeout: impl Into<Duration>) -> Option<TimeoutFuture<Self>>;
+    fn try_with_timeout(self, timeout: impl Into<Duration>) -> Option<TimeoutFuture<Self>> {
+        let timeout = timeout.into();
+        Some(self.with_deadline(Instant::now().checked_add(timeout)?))
+    }
 
     /// Runs a given future with a deadline time.
     ///
@@ -85,14 +87,6 @@ pub trait WithTimeout: Sized {
 
 impl<F: Future> WithTimeout for F {
     type Output = F::Output;
-
-    fn with_timeout(self, timeout: impl Into<Duration>) -> TimeoutFuture<Self> {
-        with_timeout(timeout.into(), self)
-    }
-
-    fn try_with_timeout(self, timeout: impl Into<Duration>) -> Option<TimeoutFuture<Self>> {
-        try_with_timeout(timeout, self)
-    }
 
     fn with_deadline(self, at: Instant) -> TimeoutFuture<Self> {
         with_deadline(at, self)

--- a/embassy-time/src/timer.rs
+++ b/embassy-time/src/timer.rs
@@ -16,11 +16,29 @@ pub struct TimeoutError;
 ///
 /// If the future completes before the timeout, its output is returned. Otherwise, on timeout,
 /// work on the future is stopped (`poll` is no longer called), the future is dropped and `Err(TimeoutError)` is returned.
+///
+/// ## Panics
+///
+/// Panics if the computed instant overflows.
+/// Avoid panics with [`try_with_timeout()`].
 pub fn with_timeout<F: Future>(timeout: impl Into<Duration>, fut: F) -> TimeoutFuture<F> {
     TimeoutFuture {
-        timer: Timer::after(timeout.into()),
+        timer: Timer::after(timeout),
         fut,
     }
+}
+
+/// Tries to run a given future with a timeout.
+///
+/// If the future completes before the timeout, its output is returned. Otherwise, on timeout,
+/// work on the future is stopped (`poll` is no longer called), the future is dropped and `Err(TimeoutError)` is returned.
+///
+/// This is a panic-free version of [`with_timeout`].
+pub fn try_with_timeout<F: Future>(timeout: impl Into<Duration>, fut: F) -> Option<TimeoutFuture<F>> {
+    Some(TimeoutFuture {
+        timer: Timer::try_after(timeout)?,
+        fut,
+    })
 }
 
 /// Runs a given future with a deadline time.
@@ -43,7 +61,20 @@ pub trait WithTimeout: Sized {
     ///
     /// If the future completes before the timeout, its output is returned. Otherwise, on timeout,
     /// work on the future is stopped (`poll` is no longer called), the future is dropped and `Err(TimeoutError)` is returned.
+    ///
+    /// ## Panics
+    ///
+    /// Panics if the computed instant overflows.
+    /// Avoid panics with [`WithTimeout::try_with_timeout()`].
     fn with_timeout(self, timeout: impl Into<Duration>) -> TimeoutFuture<Self>;
+
+    /// Tries to run a given future with a timeout.
+    ///
+    /// If the future completes before the timeout, its output is returned. Otherwise, on timeout,
+    /// work on the future is stopped (`poll` is no longer called), the future is dropped and `Err(TimeoutError)` is returned.
+    ///
+    /// This is a panic-free [`WithTimeout::with_timeout()`].
+    fn try_with_timeout(self, timeout: impl Into<Duration>) -> Option<TimeoutFuture<Self>>;
 
     /// Runs a given future with a deadline time.
     ///
@@ -57,6 +88,10 @@ impl<F: Future> WithTimeout for F {
 
     fn with_timeout(self, timeout: impl Into<Duration>) -> TimeoutFuture<Self> {
         with_timeout(timeout.into(), self)
+    }
+
+    fn try_with_timeout(self, timeout: impl Into<Duration>) -> Option<TimeoutFuture<Self>> {
+        try_with_timeout(timeout, self)
     }
 
     fn with_deadline(self, at: Instant) -> TimeoutFuture<Self> {
@@ -479,6 +514,20 @@ impl core::error::Error for TimeoutError {}
 #[cfg(all(test, feature = "std"))]
 mod test {
     use super::*;
+
+    #[test]
+    #[should_panic(expected = "overflow")]
+    #[cfg(panic = "unwind")]
+    fn with_timeout_panics() {
+        while Instant::now() == Instant::MIN {} // with non-0 tick
+        let _ = with_timeout(Duration::MAX, async {}); // PANIC
+    }
+
+    #[test]
+    fn try_with_timeout_none() {
+        while Instant::now() == Instant::MIN {} // with non-0 tick
+        assert!(try_with_timeout(Duration::MAX, async {}).is_none());
+    }
 
     #[test]
     #[should_panic(expected = "overflow")]

--- a/embassy-time/src/timer.rs
+++ b/embassy-time/src/timer.rs
@@ -356,8 +356,22 @@ impl Ticker {
 
     /// Resets the ticker back to its original state.
     /// This causes the ticker to go back to zero, even if the current tick isn't over yet.
+    ///
+    /// ## Panics
+    ///
+    /// Panics if the computed instant overflows.
+    /// Avoid panics with [`Ticker::checked_reset()`].
     pub fn reset(&mut self) {
         self.expires_at = Instant::now() + self.duration;
+    }
+
+    /// Checked resets the ticker back to its original state.
+    /// This causes the ticker to go back to zero, even if the current tick isn't over yet.
+    ///
+    /// This is a panic-free [`Ticker::reset()`].
+    pub fn checked_reset(&mut self) -> Option<()> {
+        self.expires_at = Instant::now().checked_add(self.duration)?;
+        Some(())
     }
 
     /// Reset the ticker at the deadline.
@@ -450,5 +464,27 @@ mod test {
     fn ticker_try_every_none() {
         while Instant::now() == Instant::MIN {} // with non-0 tick
         assert!(Ticker::try_every(Duration::MAX).is_none());
+    }
+
+    #[test]
+    #[should_panic(expected = "overflow")]
+    #[cfg(panic = "unwind")]
+    fn ticker_reset_panics() {
+        let mut ticker = Ticker {
+            expires_at: Instant::MAX,
+            duration: Duration::MAX,
+        };
+        while Instant::now() == Instant::MIN {} // with non-0 tick
+        ticker.reset(); // PANIC
+    }
+
+    #[test]
+    fn ticker_checked_reset_none() {
+        let mut ticker = Ticker {
+            expires_at: Instant::MAX,
+            duration: Duration::MAX,
+        };
+        while Instant::now() == Instant::MIN {} // with non-0 tick
+        assert!(ticker.checked_reset().is_none());
     }
 }

--- a/embassy-time/src/timer.rs
+++ b/embassy-time/src/timer.rs
@@ -223,9 +223,25 @@ impl Timer {
     ///
     /// This method is a convenience wrapper for calling `Timer::after(Duration::from_millis())`.
     /// For more details, refer to [`Timer::after`] and [`Duration::from_millis()`].
+    ///
+    /// ## Panics
+    ///
+    /// Panics if the computed instant overflows.
+    /// Avoid panics with [`Timer::try_after_millis()`].
     #[inline]
     pub fn after_millis(millis: u64) -> Self {
         Self::after(Duration::from_millis(millis))
+    }
+
+    /// Try to expire after the specified number of milliseconds.
+    ///
+    /// This method is a convenience wrapper for calling `Timer::try_after(Duration::from_millis())`.
+    /// For more details, refer to [`Timer::try_after`] and [`Duration::from_millis()`].
+    ///
+    /// This is a panic-free [`Timer::after_millis()`].
+    #[inline]
+    pub fn try_after_millis(millis: u64) -> Option<Self> {
+        Self::try_after(Duration::from_millis(millis))
     }
 
     /// Expire after the specified number of seconds.


### PR DESCRIPTION
I noticed the panic info in the `Timer::after` docs, but this is not enough for me, I need every individual panicky place documented.

`cargo asm` was used to inquire which places panic, and documentation added.

I also added `try_*` constructors and `checked_*` mutators, following the convention in Instant.
I also added `try_*` solo functions, 

I failed to compile the tests with feature "mock-driver", so instead I used the "std" driver.