### PR TITLE
Add support for packetmeta to embassy-net

### DIFF
--- a/embassy-net-driver/Cargo.toml
+++ b/embassy-net-driver/Cargo.toml
@@ -26,3 +26,4 @@ defmt = { version = "1.0.1", optional = true }
 
 [features]
 defmt = ["dep:defmt"]
+packetmeta-id = []

--- a/embassy-net-driver/src/lib.rs
+++ b/embassy-net-driver/src/lib.rs
@@ -5,6 +5,20 @@
 
 use core::task::Context;
 
+/// Metadata associated with a packet.
+///
+/// The packet metadata is a set of attributes associated to network packets
+/// as they travel up or down the stack. The metadata is get/set by the
+/// [`Driver`] implementations or by the user when sending/receiving packets
+/// from a socket.
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+#[derive(Debug, PartialEq, Eq, Hash, Clone, Copy, Default)]
+#[non_exhaustive]
+pub struct PacketMeta {
+    #[cfg(feature = "packetmeta-id")]
+    pub id: u32,
+}
+
 /// Representation of an hardware address, such as an Ethernet address or an IEEE802.15.4 address.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
@@ -119,6 +133,11 @@ pub trait RxToken {
     fn consume<R, F>(self, f: F) -> R
     where
         F: FnOnce(&mut [u8]) -> R;
+
+    /// The Packet metadata associated with the frame received by this [`RxToken`]
+    fn meta(&self) -> PacketMeta {
+        PacketMeta::default()
+    }
 }
 
 /// A token to transmit a single network packet.
@@ -132,6 +151,11 @@ pub trait TxToken {
     fn consume<R, F>(self, len: usize, f: F) -> R
     where
         F: FnOnce(&mut [u8]) -> R;
+
+    /// The Packet metadata to be associated with the frame to be transmitted by
+    /// this [`TxToken`].
+    #[allow(unused_variables)]
+    fn set_meta(&mut self, meta: PacketMeta) {}
 }
 
 /// A description of device capabilities.

--- a/embassy-net/Cargo.toml
+++ b/embassy-net/Cargo.toml
@@ -101,6 +101,8 @@ slaac = ["proto-ipv6", "multicast", "smoltcp/proto-ipv6-slaac"]
 std = ["smoltcp/std"]
 ## Enable smoltcp alloc feature (necessary if using "managed" crate alloc feature)
 alloc = ["smoltcp/alloc"]
+## Enable smoltcp packetmeta-id feature
+packetmeta-id = [ "smoltcp/packetmeta-id", "embassy-net-driver/packetmeta-id" ]
 
 [dependencies]
 

--- a/embassy-net/src/driver_util.rs
+++ b/embassy-net/src/driver_util.rs
@@ -1,6 +1,6 @@
 use core::task::Context;
 
-use embassy_net_driver::{Capabilities, Checksum, Driver, RxToken, TxToken};
+use embassy_net_driver::{Capabilities, Checksum, Driver, PacketMeta, RxToken, TxToken};
 use smoltcp::phy::{self, Medium};
 use smoltcp::time::Instant;
 
@@ -93,6 +93,10 @@ where
             f(buf)
         })
     }
+
+    fn meta(&self) -> phy::PacketMeta {
+        into_smoltcp_meta(self.0.meta())
+    }
 }
 
 pub(crate) struct TxTokenAdapter<T>(T)
@@ -114,4 +118,28 @@ where
             r
         })
     }
+
+    fn set_meta(&mut self, meta: phy::PacketMeta) {
+        self.0.set_meta(into_embassy_net_meta(meta));
+    }
+}
+
+#[allow(unused, reason = "meta isn't used if no features are enabled")]
+fn into_smoltcp_meta(meta: PacketMeta) -> phy::PacketMeta {
+    let out_meta = phy::PacketMeta::default();
+    #[cfg(feature = "packetmeta-id")]
+    {
+        out_meta.id = meta.id;
+    }
+    out_meta
+}
+
+#[allow(unused, reason = "meta isn't used if no features are enabled")]
+fn into_embassy_net_meta(meta: phy::PacketMeta) -> PacketMeta {
+    let out_meta = PacketMeta::default();
+    #[cfg(feature = "packetmeta-id")]
+    {
+        out_meta.id = meta.id;
+    }
+    out_meta
 }


### PR DESCRIPTION
Currently, we can't do packetmeta stuff with `embassy-net` because the plumbing does not exist.

Add the plumbing and the wiring so that we can