### PR TITLE
[MCXA] i3c: re-emit Stop after IBI in async_wait_for_ibi

### DIFF
--- a/embassy-mcxa/src/i3c/controller.rs
+++ b/embassy-mcxa/src/i3c/controller.rs
@@ -1385,19 +1385,12 @@ where
     /// The P3T1755 (and most sensors) set BCR\[2\]=0 so no payload bytes follow the address header;
     /// in that case this returns `(addr, 0)`.
     ///
-    /// **Bus state on return:** the controller is left in `NORMACT` (between
-    /// start and stop). The caller MUST issue a follow-on bus operation
-    /// promptly — typically [`Self::async_read`] (which produces a repeated
-    /// start, what the target's pre-loaded IBI response expects) or
-    /// [`Self::async_write`], or call `async_stop` explicitly.
-    ///
-    /// Emitting an explicit Stop here would force the target to traverse the
-    /// `Stop → Start` boundary before the directed-read address arrives,
-    /// which races with the target's slave-side state machine and rarely
-    /// (≈1/10⁶ iterations) latches `SERRWARN.INVSTART` on the target — which
-    /// in turn causes a hardware NACK on the controller's directed-read
-    /// address. Leaving the bus in `NORMACT` lets the next `async_start`
-    /// emit a true repeated start, matching the target's expectation.
+    /// **Bus state on return:** the controller has emitted a Stop, so the
+    /// bus is idle. This matches the NXP SDK master driver behavior on
+    /// `kStatus_I3C_IBIWon` (see `I3C_MasterTransferHandleIRQ` in
+    /// `fsl_i3c.c`) and is what spec-compliant targets expect before the
+    /// next directed transfer. The caller should follow up with
+    /// [`Self::async_read`] or [`Self::async_write`] as needed.
     pub async fn async_wait_for_ibi(&mut self, buf: &mut [u8]) -> Result<(u8, usize), IOError> {
         // Step 1: Wait for SLVSTART (a target is asserting SDA low to request the bus).
         //
@@ -1500,10 +1493,13 @@ where
             self.async_wait_for_complete().await?;
         }
 
-        // Step 7: Clear status flags. We deliberately do NOT emit a Stop
-        // here — see the function's doc comment for the rationale (avoids
-        // an INVSTART race on the target during IBI→directed-read).
+        // Step 7: Clear status flags and emit a STOP to terminate the IBI
+        // sequence on the bus before the caller issues their follow-on
+        // transfer. This matches the NXP SDK master driver
+        // (`fsl_i3c.c` I3C_MasterTransferHandleIRQ → I3C_MasterEmitStop on
+        // `kStatus_I3C_IBIWon`) and is what spec-compliant targets expect.
         self.clear_flags();
+        self.async_stop(BusType::I3cSdr).await?;
 
         Ok((ibi_addr, payload_len))
     }

--- a/examples/mcxa2xx/src/bin/i3c-controller-async.rs
+++ b/examples/mcxa2xx/src/bin/i3c-controller-async.rs
@@ -75,16 +75,13 @@ async fn main(_spawner: Spawner) {
 
     let mut iter: u32 = 0;
     loop {
-        info!("[ctrl] iter {} write", iter);
         i3c.async_write(TARGET_DYNAMIC_ADDR, &[0xaa; 64], BusType::I3cSdr)
             .await
             .unwrap();
 
-        info!("[ctrl] iter {} wait-ibi", iter);
         let mut ibi_buf = [0u8; 8];
         let (_ibi_addr, _ibi_len) = i3c.async_wait_for_ibi(&mut ibi_buf).await.unwrap();
 
-        info!("[ctrl] iter {} read", iter);
         let mut buf = [0u8; 64];
         i3c.async_read(TARGET_DYNAMIC_ADDR, &mut buf, BusType::I3cSdr)
             .await
@@ -93,6 +90,8 @@ async fn main(_spawner: Spawner) {
         assert_eq!(buf, [0x55; 64]);
         Timer::after_micros(100).await;
         iter = iter.wrapping_add(1);
-        info!("[ctrl] iter {} done", iter);
+        if iter % 1000 == 0 {
+            info!("[ctrl] iter {} OK", iter);
+        }
     }
 }


### PR DESCRIPTION
Commit 3fee3a6bd ("[MCXA] i3c: fix Rust ctrl <-> Rust target intermittent failures") removed the post-IBI `async_stop` from `async_wait_for_ibi`, leaving the bus in NORMACT so the caller's follow-on transfer would issue what looked like a repeated start.  That side-stepped a target-side INVSTART race, but it left the controller behaving differently from every other I3C master we interoperate with.

Stressing RC <-> CT at 64-byte payloads reproduces the regression on the very first directed read after an IBI: the target does not ACK the address within the expected window and the controller latches MERRWARN.OREAD | MERRWARN.TIMEOUT, surfaced to the caller as IOError::Overread. CC <-> CT and CC <-> RT have always worked because the NXP SDK master driver (`fsl_i3c.c`, I3C_MasterTransferHandleIRQ -> I3C_MasterEmitStop on kStatus_I3C_IBIWon) emits a Stop after every IBI win before the user's next transfer.

Re-emit the Stop at the end of `async_wait_for_ibi` so the bus is returned to Idle, matching the SDK and what spec-compliant targets expect. Update the docstring to drop the obsolete "deliberately no Stop" rationale. The original target-side INVSTART race that 3fee3a6bd worked around must be addressed on the target if it recurs; masking it from the controller side breaks interop with every non-Rust target.