### PR TITLE
[MCXA] i3c: fix transfer length mismatch cases

### DIFF
--- a/embassy-mcxa/src/i3c/controller.rs
+++ b/embassy-mcxa/src/i3c/controller.rs
@@ -18,7 +18,7 @@ use crate::pac::i3c::{
     Disto, Hkeep, Ibiresp, Ibitype, MctrlDir as I3cDir, MdatactrlRxtrig, MdatactrlTxtrig, Mstena, Request, State, Type,
 };
 
-const MAX_CHUNK_SIZE: usize = 255;
+const MAX_CHUNK_SIZE: usize = 256;
 
 /// Setup Errors
 #[derive(Debug, Copy, Clone, PartialEq, Eq)]
@@ -76,6 +76,22 @@ impl From<crate::dma::InvalidParameters> for IOError {
     fn from(_value: crate::dma::InvalidParameters) -> Self {
         Self::Other
     }
+}
+
+/// Outcome of [`async_wait_for_rx_fifo`].
+///
+/// Distinguishes a normal "data available" wake-up from a target-terminated
+/// end-of-transaction (slave drove the T-bit to 0 with fewer bytes than the
+/// controller requested). Callers use this to drain remaining FIFO data and
+/// then break the read loop cleanly without reading phantom zeros from an
+/// empty FIFO.
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
+enum RxFifoStatus {
+    /// `MSTATUS.RXPEND` is set: at least one byte is in the RX FIFO.
+    RxPending,
+    /// `MSTATUS.COMPLETE` is set without `RXPEND`: transaction ended (the
+    /// slave T-bit'd) and the FIFO is drained.
+    Complete,
 }
 
 /// Whether to send a STOP condition after the transfer.
@@ -832,7 +848,7 @@ trait AsyncEngine {
         read: &'a mut [u8],
         bus_type: BusType,
         send_stop: SendStop,
-    ) -> impl Future<Output = Result<(), IOError>> + 'a;
+    ) -> impl Future<Output = Result<usize, IOError>> + 'a;
 
     fn async_write_internal<'a>(
         &'a self,
@@ -872,7 +888,7 @@ impl<'d> AsyncEngine for I3c<'d, Async> {
         read: &mut [u8],
         bus_type: BusType,
         send_stop: SendStop,
-    ) -> Result<(), IOError> {
+    ) -> Result<usize, IOError> {
         if read.is_empty() {
             return Err(IOError::InvalidReadBufferLength);
         }
@@ -882,24 +898,65 @@ impl<'d> AsyncEngine for I3c<'d, Async> {
             self.blocking_remediation(bus_type);
         });
 
-        for chunk in read.chunks_mut(MAX_CHUNK_SIZE) {
-            self.async_start(address, bus_type, Dir::Read, chunk.len() as u8)
-                .await?;
+        let mut bytes_received: usize = 0;
+        // Track final result; we never early-`return` so a single Stop
+        // path at the bottom can run regardless of error.
+        let mut result: Result<usize, IOError> = Ok(0);
+
+        'outer: for chunk in read.chunks_mut(MAX_CHUNK_SIZE) {
+            // `chunk.len() as u8` gives RDTERM=N for 1..=255 and RDTERM=0
+            // for exactly 256 (matches SDK: "no controller-side termination;
+            // slave drives end via T-bit").
+            if let Err(e) = self.async_start(address, bus_type, Dir::Read, chunk.len() as u8).await {
+                result = Err(e);
+                break 'outer;
+            }
 
             for byte in chunk.iter_mut() {
-                self.async_wait_for_rx_fifo().await?;
-                *byte = self.info.regs().mrdatab().read().value();
+                match self.async_wait_for_rx_fifo().await {
+                    Ok(RxFifoStatus::RxPending) => {
+                        *byte = self.info.regs().mrdatab().read().value();
+                        bytes_received += 1;
+                    }
+                    Ok(RxFifoStatus::Complete) => {
+                        // Slave T-bit'd before our requested length: clean
+                        // target-terminated short read. Report what we got
+                        // and exit before reading phantom bytes out of an
+                        // empty FIFO.
+                        result = Ok(bytes_received);
+                        break 'outer;
+                    }
+                    Err(e) => {
+                        // Real bus error. Any bytes already received =>
+                        // spec-compliant short read; suppress and return Ok.
+                        // Zero bytes => propagate the error.
+                        if bytes_received > 0 {
+                            self.clear_errors();
+                            result = Ok(bytes_received);
+                        } else {
+                            result = Err(e);
+                        }
+                        break 'outer;
+                    }
+                }
             }
+            result = Ok(bytes_received);
         }
 
+        // Always emit Stop on the configured send_stop path, regardless of
+        // success or short-read. After a short read the slave already
+        // released the bus; Stop may report InvalidRequest (state != Normact)
+        // which is benign here. Matches SDK StopState semantics
+        // (fsl_i3c.c:2293). Without this, the target sees a dirty bus on
+        // its next listen and raises SdrParity.
         if send_stop == SendStop::Yes {
-            self.async_stop(bus_type).await?;
+            let _ = self.async_stop(bus_type).await;
         }
 
         // defuse it if the future is not dropped
         on_drop.defuse();
 
-        Ok(())
+        result
     }
 
     async fn async_write_internal(
@@ -1011,7 +1068,7 @@ impl<'d> AsyncEngine for I3c<'d, Dma<'d>> {
         read: &mut [u8],
         bus_type: BusType,
         send_stop: SendStop,
-    ) -> Result<(), IOError> {
+    ) -> Result<usize, IOError> {
         if read.is_empty() {
             return Err(IOError::InvalidReadBufferLength);
         }
@@ -1025,9 +1082,19 @@ impl<'d> AsyncEngine for I3c<'d, Dma<'d>> {
                 .modify(|w| w.set_dmafb(MdmactrlDmafb::NotUsed));
         });
 
-        for chunk in read.chunks_mut(MAX_CHUNK_SIZE) {
-            self.async_start(address, bus_type, Dir::Read, chunk.len() as u8)
-                .await?;
+        let mut bytes_received: usize = 0;
+        // Track final result; we never early-`return` so a single Stop
+        // path at the bottom can run regardless of error.
+        let mut result: Result<usize, IOError> = Ok(0);
+
+        'outer: for chunk in read.chunks_mut(MAX_CHUNK_SIZE) {
+            // `chunk.len() as u8` gives RDTERM=N for 1..=255 and RDTERM=0
+            // for exactly 256 (matches SDK: "no controller-side termination;
+            // slave drives end via T-bit").
+            if let Err(e) = self.async_start(address, bus_type, Dir::Read, chunk.len() as u8).await {
+                result = Err(e);
+                break 'outer;
+            }
 
             let peri_addr = self.info.regs().mrdatab().as_ptr() as *const u8;
 
@@ -1041,12 +1108,15 @@ impl<'d> AsyncEngine for I3c<'d, Dma<'d>> {
                 self.mode.rx_dma.set_request_source(self.mode.rx_request);
 
                 // Configure TCD for peripheral-to-memory transfer
-                self.mode.rx_dma.setup_read_from_peripheral(
+                if let Err(e) = self.mode.rx_dma.setup_read_from_peripheral(
                     peri_addr,
                     chunk,
                     false,
                     TransferOptions::COMPLETE_INTERRUPT,
-                )?;
+                ) {
+                    result = Err(e.into());
+                    break 'outer;
+                }
 
                 // Enable I3C RX DMA request
                 self.info
@@ -1058,10 +1128,23 @@ impl<'d> AsyncEngine for I3c<'d, Dma<'d>> {
                 self.mode.rx_dma.enable_request();
             }
 
-            // Wait for completion asynchronously
+            // Race DMA-done vs I3C COMPLETE/errwarn. The target may end
+            // the read early via T-bit; in that case the IP fires COMPLETE
+            // but DMA stalls. Without this race we'd hang until something
+            // else nudges us, then misreport the latched MERRWARN.
             core::future::poll_fn(|cx| {
                 let _ = self.mode.rx_dma.wait_cell().poll_wait(cx);
-                if self.mode.rx_dma.is_done() {
+                let _ = self.info.wait_cell().poll_wait(cx);
+
+                // Enable I3C complete + errwarn interrupts so the I3C IRQ
+                // can wake us if DMA never finishes.
+                self.info.regs().mintset().write(|w| {
+                    w.set_complete(true);
+                    w.set_errwarn(true);
+                });
+
+                let st = self.info.regs().mstatus().read();
+                if self.mode.rx_dma.is_done() || st.complete() || st.errwarn() {
                     core::task::Poll::Ready(())
                 } else {
                     core::task::Poll::Pending
@@ -1071,6 +1154,10 @@ impl<'d> AsyncEngine for I3c<'d, Dma<'d>> {
 
             // Ensure DMA writes are visible to CPU
             cortex_m::asm::dsb();
+
+            // How many bytes did DMA actually move into this chunk?
+            let chunk_done = self.mode.rx_dma.transferred_bytes().min(chunk.len());
+
             // Cleanup
             self.info
                 .regs()
@@ -1080,16 +1167,59 @@ impl<'d> AsyncEngine for I3c<'d, Dma<'d>> {
                 self.mode.rx_dma.disable_request();
                 self.mode.rx_dma.clear_done();
             }
+
+            let st_after = self.info.regs().mstatus().read();
+            bytes_received += chunk_done;
+
+            // Classify the outcome. Per spec, target-terminated SDR reads
+            // can end before RDTERM with no error — and that's what SDK
+            // sees (status=0). The MCXA IP may still latch MERRWARN bits
+            // (nack/term/etc.) on certain RDTERM mismatch patterns.
+            //
+            // Rule (mirrors SDK behavior):
+            //   - bytes_received > 0 with any errwarn → spec-compliant
+            //     short read; suppress, return Ok(bytes_received).
+            //   - bytes_received == 0 with errwarn → real bus error
+            //     (true address NACK, parity, etc.); propagate.
+            //   - errwarn at chunk boundary with full chunk: same rule
+            //     (we got the bytes we asked for, suppress).
+            if chunk_done < chunk.len() {
+                if st_after.errwarn() {
+                    if bytes_received > 0 {
+                        self.clear_errors();
+                        result = Ok(bytes_received);
+                    } else {
+                        result = Err(self.status().err().unwrap_or(IOError::Other));
+                    }
+                } else {
+                    result = Ok(bytes_received);
+                }
+                break 'outer;
+            } else {
+                if st_after.errwarn() {
+                    // Full chunk delivered + errwarn. Suppress as long as
+                    // we did get data.
+                    self.clear_errors();
+                }
+                result = Ok(bytes_received);
+            }
         }
 
+        // Always emit Stop on the configured send_stop path, regardless of
+        // success or short-read. After a short read the slave already
+        // released the bus; Stop may report InvalidRequest (state != Normact)
+        // which is benign here. Matches SDK StopState semantics
+        // (fsl_i3c.c:2293) which emits Stop unconditionally after COMPLETE.
+        // Without this, the target sees a dirty bus on its next listen and
+        // raises SdrParity.
         if send_stop == SendStop::Yes {
-            self.async_stop(bus_type).await?;
+            let _ = self.async_stop(bus_type).await;
         }
 
         // defuse it if the future is not dropped
         on_drop.defuse();
 
-        Ok(())
+        result
     }
 
     async fn async_write_internal(
@@ -1259,20 +1389,39 @@ where
             .map_err(|_| IOError::Overwrite)
     }
 
-    async fn async_wait_for_rx_fifo(&self) -> Result<(), IOError> {
+    async fn async_wait_for_rx_fifo(&self) -> Result<RxFifoStatus, IOError> {
         self.info
             .wait_cell()
             .wait_for(|| {
-                // enable RXPEND interrupt
+                // enable RXPEND, COMPLETE, and ERRWARN interrupts so any of
+                // them wakes us. A target-terminated SDR read fires COMPLETE
+                // with no further bytes in the FIFO; we must distinguish
+                // that from "more data is coming".
                 self.info.regs().mintset().write(|w| {
                     w.set_rxpend(true);
+                    w.set_complete(true);
                     w.set_errwarn(true);
                 });
-                // if the rx FIFO is pending, we need to read bytes
-                self.info.regs().mstatus().read().rxpend() || self.info.regs().mstatus().read().errwarn()
+                let status = self.info.regs().mstatus().read();
+                status.rxpend() || status.complete() || status.errwarn()
             })
             .await
-            .map_err(|_| IOError::Overread)
+            .map_err(|_| IOError::Overread)?;
+
+        let status = self.info.regs().mstatus().read();
+        // Order matters: drain any pending FIFO byte first; on the next call
+        // we'll observe Complete without RxPending and report the early end.
+        // ERRWARN takes precedence only when the FIFO is already empty,
+        // otherwise we'd lose the last byte of a transaction that ended with
+        // a benign warning latched alongside the final byte.
+        if status.rxpend() {
+            Ok(RxFifoStatus::RxPending)
+        } else if status.errwarn() {
+            Err(self.status().err().unwrap_or(IOError::Other))
+        } else {
+            // complete() must be set (predicate above).
+            Ok(RxFifoStatus::Complete)
+        }
     }
 
     /// Prepares an appropriate Start condition on bus by issuing a
@@ -1505,12 +1654,17 @@ where
     }
 
     /// Read from address into buffer asynchronously.
+    ///
+    /// Returns the number of bytes actually read. On a spec-compliant
+    /// target-terminated short read (slave T-bits before `buf.len()` is
+    /// reached), this returns `Ok(n)` where `n < buf.len()`. Callers that
+    /// require the exact length should check `n == buf.len()` themselves.
     pub fn async_read<'a>(
         &'a mut self,
         address: u8,
         read: &'a mut [u8],
         bus_type: BusType,
-    ) -> impl Future<Output = Result<(), IOError>> + 'a {
+    ) -> impl Future<Output = Result<usize, IOError>> + 'a {
         <Self as AsyncEngine>::async_read_internal(self, address, read, bus_type, SendStop::Yes)
     }
 
@@ -1525,13 +1679,15 @@ where
     }
 
     /// Write to address from bytes and then read from address into buffer asynchronously.
+    ///
+    /// Returns the number of bytes actually read (see [`Self::async_read`]).
     pub async fn async_write_read<'a>(
         &'a mut self,
         address: u8,
         write: &'a [u8],
         read: &'a mut [u8],
         bus_type: BusType,
-    ) -> Result<(), IOError> {
+    ) -> Result<usize, IOError> {
         <Self as AsyncEngine>::async_write_internal(self, address, write, bus_type, SendStop::No).await?;
         <Self as AsyncEngine>::async_read_internal(self, address, read, bus_type, SendStop::Yes).await
     }
@@ -1550,7 +1706,7 @@ where
         for op in rest {
             match op {
                 Operation::Read { address, buf } => {
-                    <Self as AsyncEngine>::async_read_internal(self, *address, buf, bus_type, SendStop::No).await?
+                    <Self as AsyncEngine>::async_read_internal(self, *address, buf, bus_type, SendStop::No).await?;
                 }
                 Operation::Write { address, buf } => {
                     <Self as AsyncEngine>::async_write_internal(self, *address, buf, bus_type, SendStop::No).await?
@@ -1560,7 +1716,9 @@ where
 
         match last {
             Operation::Read { address, buf } => {
-                <Self as AsyncEngine>::async_read_internal(self, *address, buf, bus_type, SendStop::Yes).await
+                <Self as AsyncEngine>::async_read_internal(self, *address, buf, bus_type, SendStop::Yes)
+                    .await
+                    .map(|_| ())
             }
             Operation::Write { address, buf } => {
                 <Self as AsyncEngine>::async_write_internal(self, *address, buf, bus_type, SendStop::Yes).await
@@ -1717,7 +1875,7 @@ where
         for op in rest {
             match op {
                 embedded_hal_async::i2c::Operation::Read(buf) => {
-                    <Self as AsyncEngine>::async_read_internal(self, address, buf, BusType::I2c, SendStop::No).await?
+                    <Self as AsyncEngine>::async_read_internal(self, address, buf, BusType::I2c, SendStop::No).await?;
                 }
                 embedded_hal_async::i2c::Operation::Write(buf) => {
                     <Self as AsyncEngine>::async_write_internal(self, address, buf, BusType::I2c, SendStop::No).await?
@@ -1727,7 +1885,9 @@ where
 
         match last {
             embedded_hal_async::i2c::Operation::Read(buf) => {
-                <Self as AsyncEngine>::async_read_internal(self, address, buf, BusType::I2c, SendStop::Yes).await
+                <Self as AsyncEngine>::async_read_internal(self, address, buf, BusType::I2c, SendStop::Yes)
+                    .await
+                    .map(|_| ())
             }
             embedded_hal_async::i2c::Operation::Write(buf) => {
                 <Self as AsyncEngine>::async_write_internal(self, address, buf, BusType::I2c, SendStop::Yes).await

--- a/embassy-mcxa/src/i3c/target.rs
+++ b/embassy-mcxa/src/i3c/target.rs
@@ -889,8 +889,24 @@ impl<'d> I3c<'d> {
 
         _ibi_drop.defuse();
 
-        self.check_status()?;
-        Ok(())
+        // Treat `Terminated` as success: the controller is free to chunk this
+        // logical response into multiple wire-level reads (each bounded by
+        // RDTERM and separated by Sr or Stop). Every chunk boundary that
+        // falls mid-T=1-stream latches SERRWARN.TERM on the target, even
+        // though the IP keeps draining the TX FIFO across the Sr. By the
+        // time we reach this check, DMA has streamed `rest` into the FIFO
+        // and SWDATABE has emitted the final T=0 byte — so the wire-level
+        // payload is fully delivered regardless of how many TERM warnings
+        // got latched along the way. Mirrors `dma_respond_to_read`, which
+        // exposes the same condition as `ReadStatus::EarlyStop`.
+        //
+        // Genuine controller-side aborts (mid-payload Stop with bytes still
+        // pending in DMA) surface earlier as Underrun/UnderrunNack on the
+        // `wait_tx_space` / SWDATABE path, not here.
+        match self.check_status() {
+            Ok(()) | Err(IOError::Terminated) => Ok(()),
+            Err(e) => Err(e),
+        }
     }
 
     /// Diagnostic: measure the TX FIFO depth by pushing bytes until full.

--- a/examples/mcxa2xx/src/bin/i3c-controller-dma.rs
+++ b/examples/mcxa2xx/src/bin/i3c-controller-dma.rs
@@ -60,8 +60,7 @@ async fn main(_spawner: Spawner) {
     cfg.clock_config.div = Div4::from_divisor(1).unwrap();
     cfg.open_drain_freq = 1_000_000;
     cfg.push_pull_freq = 2_000_000;
-    let mut i3c =
-        I3c::new_async_with_dma(p.I3C0, p.P1_9, p.P1_8, p.DMA0_CH0, p.DMA0_CH1, Irqs, cfg).unwrap();
+    let mut i3c = I3c::new_async_with_dma(p.I3C0, p.P1_9, p.P1_8, p.DMA0_CH0, p.DMA0_CH1, Irqs, cfg).unwrap();
 
     Timer::after_secs(2).await;
     info!("[ctrl] RSTDAA");

--- a/examples/mcxa2xx/src/bin/i3c-controller-dma.rs
+++ b/examples/mcxa2xx/src/bin/i3c-controller-dma.rs
@@ -1,6 +1,8 @@
-//! Two-board I3C **controller** half — tight loop, panic-on-failure.
+//! Two-board I3C **controller** half (DMA) — tight loop, panic-on-failure.
 //!
-//! Pairs with `examples/mcxa5xx/src/bin/i3c-target-dma.rs`.
+//! Pairs with `examples/mcxa5xx/src/bin/i3c-target-dma.rs` (or any matching
+//! target). Same protocol/cadence as `i3c-controller-async.rs` but uses the
+//! DMA-backed controller driver (`I3c::new_async_with_dma`).
 //!
 //! Wiring: SCL P1_9 ↔ partner SCL, SDA P1_8 ↔ partner SDA, common GND.
 
@@ -58,8 +60,8 @@ async fn main(_spawner: Spawner) {
     cfg.clock_config.div = Div4::from_divisor(1).unwrap();
     cfg.open_drain_freq = 1_000_000;
     cfg.push_pull_freq = 2_000_000;
-    // cfg.odhpp = false;
-    let mut i3c = I3c::new_async(p.I3C0, p.P1_9, p.P1_8, Irqs, cfg).unwrap();
+    let mut i3c =
+        I3c::new_async_with_dma(p.I3C0, p.P1_9, p.P1_8, p.DMA0_CH0, p.DMA0_CH1, Irqs, cfg).unwrap();
 
     Timer::after_secs(2).await;
     info!("[ctrl] RSTDAA");
@@ -130,7 +132,6 @@ async fn main(_spawner: Spawner) {
                 panic!("ctrl read err");
             }
         }
-        // Timer::after_micros(100).await;
         iter = iter.wrapping_add(1);
         if iter % 1000 == 0 {
             info!("[ctrl] iter {} OK", iter);

--- a/examples/mcxa2xx/src/bin/i3c-target-dma.rs
+++ b/examples/mcxa2xx/src/bin/i3c-target-dma.rs
@@ -18,6 +18,12 @@ use {defmt::info, defmt_rtt as _, embassy_mcxa as hal, panic_probe as _};
 
 const TARGET_ADDR: u8 = 0x0a;
 const RX_BUF_SIZE: usize = 128;
+
+// Per-iteration TX payload size for the read response. Set smaller than
+// the controller's CTRL_RD_LEN to exercise the over-read path (target
+// runs out before controller's RDTERM is satisfied).
+const TGT_TX_LEN: usize = 16;
+const TX_PATTERN_BYTE: u8 = 0x55;
 static RX_BUF: ConstStaticCell<[u8; RX_BUF_SIZE]> = ConstStaticCell::new([0u8; RX_BUF_SIZE]);
 
 bind_interrupts!(
@@ -47,8 +53,9 @@ async fn main(_spawner: Spawner) {
     .unwrap();
     let mut tgt = tgt;
 
-    info!("[tgt] up, listening");
+    info!("[tgt] up, listening (TGT_TX_LEN={})", TGT_TX_LEN);
     let mut sink = [0u8; 64];
+    let tx_payload = [TX_PATTERN_BYTE; TGT_TX_LEN];
     let mut iter: u32 = 0;
 
     loop {
@@ -57,7 +64,17 @@ async fn main(_spawner: Spawner) {
             tgt.dma_respond_to_write(&mut sink).await.unwrap();
             assert_eq!(sink, [0xaa; 64]);
 
-            tgt.dma_respond_to_read_with_ibi(&[0x55; 64]).await.unwrap();
+            match tgt.dma_respond_to_read_with_ibi(&tx_payload).await {
+                Ok(()) => {
+                    if iter < 3 {
+                        info!("[tgt] iter {} TX_LEN={} OK", iter, TGT_TX_LEN);
+                    }
+                }
+                Err(e) => {
+                    defmt::error!("[tgt] iter {} TX_LEN={} err {:?}", iter, TGT_TX_LEN, e);
+                    panic!("tgt read-with-ibi failed");
+                }
+            }
             iter = iter.wrapping_add(1);
             if iter % 1000 == 0 {
                 info!("[tgt] iter {} OK", iter);

--- a/examples/mcxa5xx/src/bin/i3c-controller-async.rs
+++ b/examples/mcxa5xx/src/bin/i3c-controller-async.rs
@@ -20,6 +20,18 @@ use {defmt_rtt as _, embassy_mcxa as hal, panic_probe as _};
 const TARGET_STATIC_ADDR: u8 = 0x0a;
 const TARGET_DYNAMIC_ADDR: u8 = 0x0b;
 
+// Per-iteration read length the controller demands. Set larger than the
+// target's TGT_TX_LEN to exercise the over-read path: controller's
+// RDTERM = CTRL_RD_LEN, target T-bits early at TGT_TX_LEN.
+const CTRL_RD_LEN: usize = 256;
+const TGT_TX_LEN: usize = 16;
+const EXPECTED_RD_LEN: usize = if CTRL_RD_LEN < TGT_TX_LEN {
+    CTRL_RD_LEN
+} else {
+    TGT_TX_LEN
+};
+const RX_PATTERN_BYTE: u8 = 0x55;
+
 bind_interrupts!(
     struct Irqs {
         I3C0 => InterruptHandler<I3C0>;
@@ -66,7 +78,10 @@ async fn main(_spawner: Spawner) {
 
     i3c.register_ibi(IbiSlot::Slot0, TARGET_DYNAMIC_ADDR, Payload::Yes)
         .unwrap();
-    info!("[ctrl] entering loop");
+    info!(
+        "[ctrl] entering loop (CTRL_RD_LEN={} TGT_TX_LEN={} EXPECTED={})",
+        CTRL_RD_LEN, TGT_TX_LEN, EXPECTED_RD_LEN
+    );
 
     let mut iter: u32 = 0;
     loop {
@@ -75,15 +90,38 @@ async fn main(_spawner: Spawner) {
             .unwrap();
 
         let mut ibi_buf = [0u8; 8];
-        i3c.async_wait_for_ibi(&mut ibi_buf).await.unwrap();
+        let (_ibi_addr, _ibi_len) = i3c.async_wait_for_ibi(&mut ibi_buf).await.unwrap();
 
-        let mut buf = [0u8; 64];
-        i3c.async_read(TARGET_DYNAMIC_ADDR, &mut buf, BusType::I3cSdr)
-            .await
-            .unwrap();
-
-        assert_eq!(buf, [0x55; 64]);
-        Timer::after_micros(100).await;
+        let mut buf = [0u8; CTRL_RD_LEN];
+        match i3c.async_read(TARGET_DYNAMIC_ADDR, &mut buf, BusType::I3cSdr).await {
+            Ok(n) => {
+                let matched = buf[..n].iter().take_while(|&&b| b == RX_PATTERN_BYTE).count();
+                if iter < 3 {
+                    info!(
+                        "[ctrl] iter {} OK n={} matched={} head={:?}",
+                        iter,
+                        n,
+                        matched,
+                        &buf[..core::cmp::min(8, n)]
+                    );
+                }
+                if n != EXPECTED_RD_LEN || matched != EXPECTED_RD_LEN {
+                    defmt::error!(
+                        "[ctrl] iter {} mismatch: n={} matched_55={} EXPECTED={} buf={:?}",
+                        iter,
+                        n,
+                        matched,
+                        EXPECTED_RD_LEN,
+                        &buf[..]
+                    );
+                    panic!("ctrl read short/mismatch");
+                }
+            }
+            Err(e) => {
+                defmt::error!("[ctrl] iter {} async_read err {:?} buf={:?}", iter, e, &buf[..]);
+                panic!("ctrl read err");
+            }
+        }
         iter = iter.wrapping_add(1);
         if iter % 1000 == 0 {
             info!("[ctrl] iter {} OK", iter);

--- a/examples/mcxa5xx/src/bin/i3c-controller-dma.rs
+++ b/examples/mcxa5xx/src/bin/i3c-controller-dma.rs
@@ -1,8 +1,10 @@
-//! Two-board I3C **controller** half — tight loop, panic-on-failure.
+//! Two-board I3C **controller** half (DMA) — tight loop, panic-on-failure.
 //!
-//! Pairs with `examples/mcxa5xx/src/bin/i3c-target-dma.rs`.
+//! Pairs with `examples/mcxa2xx/src/bin/i3c-target-dma.rs` (or any matching
+//! target). Same protocol/cadence as `i3c-controller-async.rs` but uses the
+//! DMA-backed controller driver (`I3c::new_async_with_dma`).
 //!
-//! Wiring: SCL P1_9 ↔ partner SCL, SDA P1_8 ↔ partner SDA, common GND.
+//! Wiring: SCL P0_21 ↔ MCXA2 P1_9, SDA P0_20 ↔ MCXA2 P1_8, common GND.
 
 #![no_std]
 #![no_main]
@@ -11,7 +13,6 @@ use defmt::info;
 use embassy_executor::Spawner;
 use embassy_mcxa::bind_interrupts;
 use embassy_mcxa::clocks::config::Div8;
-use embassy_mcxa::clocks::periph_helpers::{Div4, I3cClockSel};
 use embassy_mcxa::config::Config;
 use embassy_mcxa::i3c::controller::{self, BusType, I3c, IbiSlot, InterruptHandler, Operation, Payload};
 use embassy_mcxa::peripherals::I3C0;
@@ -42,9 +43,7 @@ bind_interrupts!(
 #[embassy_executor::main]
 async fn main(_spawner: Spawner) {
     let mut config = Config::default();
-    if let Some(firc) = config.clock_cfg.firc.as_mut() {
-        firc.fro_hf_div = Some(Div8::from_divisor(2).unwrap());
-    }
+    config.clock_cfg.sirc.fro_lf_div = Div8::from_divisor(1);
 
     let p = hal::init(config);
 
@@ -53,13 +52,9 @@ async fn main(_spawner: Spawner) {
         PurPin::<I3C0>::mux(&*p.P0_2);
     }
 
-    let mut cfg = controller::Config::default();
-    cfg.clock_config.source = I3cClockSel::FroHfDiv;
-    cfg.clock_config.div = Div4::from_divisor(1).unwrap();
-    cfg.open_drain_freq = 1_000_000;
-    cfg.push_pull_freq = 2_000_000;
-    // cfg.odhpp = false;
-    let mut i3c = I3c::new_async(p.I3C0, p.P1_9, p.P1_8, Irqs, cfg).unwrap();
+    let cfg = controller::Config::default();
+    let mut i3c =
+        I3c::new_async_with_dma(p.I3C0, p.P0_21, p.P0_20, p.DMA0_CH0, p.DMA0_CH1, Irqs, cfg).unwrap();
 
     Timer::after_secs(2).await;
     info!("[ctrl] RSTDAA");
@@ -130,7 +125,6 @@ async fn main(_spawner: Spawner) {
                 panic!("ctrl read err");
             }
         }
-        // Timer::after_micros(100).await;
         iter = iter.wrapping_add(1);
         if iter % 1000 == 0 {
             info!("[ctrl] iter {} OK", iter);

--- a/examples/mcxa5xx/src/bin/i3c-controller-dma.rs
+++ b/examples/mcxa5xx/src/bin/i3c-controller-dma.rs
@@ -53,8 +53,7 @@ async fn main(_spawner: Spawner) {
     }
 
     let cfg = controller::Config::default();
-    let mut i3c =
-        I3c::new_async_with_dma(p.I3C0, p.P0_21, p.P0_20, p.DMA0_CH0, p.DMA0_CH1, Irqs, cfg).unwrap();
+    let mut i3c = I3c::new_async_with_dma(p.I3C0, p.P0_21, p.P0_20, p.DMA0_CH0, p.DMA0_CH1, Irqs, cfg).unwrap();
 
     Timer::after_secs(2).await;
     info!("[ctrl] RSTDAA");

--- a/examples/mcxa5xx/src/bin/i3c-target-dma.rs
+++ b/examples/mcxa5xx/src/bin/i3c-target-dma.rs
@@ -18,6 +18,12 @@ use {defmt::info, defmt_rtt as _, embassy_mcxa as hal, panic_probe as _};
 
 const TARGET_ADDR: u8 = 0x0a;
 const RX_BUF_SIZE: usize = 128;
+
+// Per-iteration TX payload size for the read response. Set smaller than
+// the controller's CTRL_RD_LEN to exercise the over-read path (target
+// runs out before controller's RDTERM is satisfied).
+const TGT_TX_LEN: usize = 16;
+const TX_PATTERN_BYTE: u8 = 0x55;
 static RX_BUF: ConstStaticCell<[u8; RX_BUF_SIZE]> = ConstStaticCell::new([0u8; RX_BUF_SIZE]);
 
 bind_interrupts!(
@@ -41,11 +47,15 @@ async fn main(_spawner: Spawner) {
 
     let rx_buf: &'static mut [u8] = RX_BUF.take();
 
-    let tgt = target::I3c::new_dma(p.I3C0, p.P0_21, p.P0_20, p.DMA0_CH0, p.DMA0_CH1, Irqs, rx_buf, 64, tgt_cfg).unwrap();
+    let tgt = target::I3c::new_dma(
+        p.I3C0, p.P0_21, p.P0_20, p.DMA0_CH0, p.DMA0_CH1, Irqs, rx_buf, 64, tgt_cfg,
+    )
+    .unwrap();
     let mut tgt = tgt;
 
-    info!("[tgt] up, listening");
+    info!("[tgt] up, listening (TGT_TX_LEN={})", TGT_TX_LEN);
     let mut sink = [0u8; 64];
+    let tx_payload = [TX_PATTERN_BYTE; TGT_TX_LEN];
     let mut iter: u32 = 0;
 
     loop {
@@ -54,7 +64,17 @@ async fn main(_spawner: Spawner) {
             tgt.dma_respond_to_write(&mut sink).await.unwrap();
             assert_eq!(sink, [0xaa; 64]);
 
-            tgt.dma_respond_to_read_with_ibi(&[0x55; 64]).await.unwrap();
+            match tgt.dma_respond_to_read_with_ibi(&tx_payload).await {
+                Ok(()) => {
+                    if iter < 3 {
+                        info!("[tgt] iter {} TX_LEN={} OK", iter, TGT_TX_LEN);
+                    }
+                }
+                Err(e) => {
+                    defmt::error!("[tgt] iter {} TX_LEN={} err {:?}", iter, TGT_TX_LEN, e);
+                    panic!("tgt read-with-ibi failed");
+                }
+            }
             iter = iter.wrapping_add(1);
             if iter % 1000 == 0 {
                 info!("[tgt] iter {} OK", iter);


### PR DESCRIPTION
Two related fixes for I3C SDR transactions where the controller and target
disagree on transfer length. In SDR this is *allowed* — the T-bit and
RDTERM negotiate it — but our driver was treating the resulting status
warnings as fatal errors on both sides.

### Controller: target-terminated short reads

When the controller asks for N bytes and the target ends the read early
(T=0 on the last byte it has), the MCXA IP raises COMPLETE plus an
ERRWARN. The driver was reading the FIFO opportunistically and reporting
phantom zeros. Now `async_wait_for_rx_fifo` returns a tri-state
(`RxPending`/`Complete`/error) with rxpend -> errwarn -> complete priority,
and `async_read_internal` exits cleanly on Complete with the actual byte
count. DMA path uses `transferred_bytes()` for the same classification.

### Target: controller-chunked reads

When the target sends a single logical block (e.g. 64B) and the controller
drains it via several RDTERM-bounded reads chained by Sr, every chunk
boundary that lands mid-T=1-stream latches `SERRWARN.TERM`.
`dma_respond_to_read_with_ibi` was failing those transactions even though
DMA had streamed every byte and SWDATABE had emitted the final T=0.
Treat `Terminated` here as success (mirroring `dma_respond_to_read`'s
`EarlyStop`); genuine aborts still surface as Underrun/UnderrunNack from
the earlier `wait_tx_space`/SWDATABE path.