### PR TITLE
[time] Add experimental embedded-hal-timer traits

### DIFF
--- a/embassy-time/CHANGELOG.md
+++ b/embassy-time/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## Unreleased - ReleaseDate
 
 - Implement `core::error::Error` for `TimeoutError`.
+- Implement experimental embedded-hal-timer `Timer` and `Alarm` traits
 
 ## 0.5.1 - 2026-03-11
 

--- a/embassy-time/Cargo.toml
+++ b/embassy-time/Cargo.toml
@@ -451,6 +451,7 @@ log = { version = "0.4.14", optional = true }
 embedded-hal-02 = { package = "embedded-hal", version = "0.2.6" }
 embedded-hal-1 = { package = "embedded-hal", version = "1.0" }
 embedded-hal-async = { version = "1.0" }
+embedded-hal-timer = "0.1.0"
 
 futures-core = { version = "0.3.31", default-features = false }
 critical-section = "1.1"

--- a/embassy-time/Cargo.toml
+++ b/embassy-time/Cargo.toml
@@ -451,7 +451,7 @@ log = { version = "0.4.14", optional = true }
 embedded-hal-02 = { package = "embedded-hal", version = "0.2.6" }
 embedded-hal-1 = { package = "embedded-hal", version = "1.0" }
 embedded-hal-async = { version = "1.0" }
-embedded-hal-timer = "0.1.0"
+embedded-hal-timer = "0.2.0"
 
 futures-core = { version = "0.3.31", default-features = false }
 critical-section = "1.1"

--- a/embassy-time/src/eh_timer.rs
+++ b/embassy-time/src/eh_timer.rs
@@ -1,0 +1,125 @@
+use core::cell::Cell;
+
+use critical_section::Mutex;
+use embassy_time_driver::TICK_HZ;
+use embedded_hal_timer::{Alarm, OverflowError, Timer};
+
+use crate::{Duration, Instant};
+
+/// Embedded-hal implementation on top of embassy-time
+#[derive(Debug)]
+pub struct HalTimer(Mutex<Cell<Option<Instant>>>);
+
+impl HalTimer {
+    /// Construct a new timer that's not running.
+    /// Make sure to call [Self::start].
+    pub fn new() -> Self {
+        Self(Mutex::new(Cell::new(None)))
+    }
+
+    fn get_instant(&self) -> Option<Instant> {
+        critical_section::with(|cs| self.0.borrow(cs).get())
+    }
+}
+
+impl Timer for HalTimer {
+    fn start(&mut self) {
+        critical_section::with(|cs| self.0.borrow(cs).set(Some(Instant::now())));
+    }
+
+    fn tickrate(&self) -> u64 {
+        TICK_HZ
+    }
+
+    fn elapsed_ticks(&self) -> Result<u64, OverflowError> {
+        Ok(self.get_instant().map(|i| i.elapsed().as_ticks()).unwrap_or(u64::MAX))
+    }
+
+    fn elapsed_nanos(&self) -> Result<u64, OverflowError> {
+        Ok(self.get_instant().map(|i| i.elapsed().as_nanos()).unwrap_or(u64::MAX))
+    }
+
+    fn elapsed_micros(&self) -> Result<u64, OverflowError> {
+        Ok(self.get_instant().map(|i| i.elapsed().as_micros()).unwrap_or(u64::MAX))
+    }
+
+    fn elapsed_millis(&self) -> Result<u64, OverflowError> {
+        Ok(self.get_instant().map(|i| i.elapsed().as_millis()).unwrap_or(u64::MAX))
+    }
+
+    fn elapsed_secs(&self) -> Result<u64, OverflowError> {
+        Ok(self.get_instant().map(|i| i.elapsed().as_secs()).unwrap_or(u64::MAX))
+    }
+
+    fn max_ticks(&self) -> u64 {
+        (Instant::MAX - Instant::now()).as_ticks()
+    }
+
+    fn max_nanos(&self) -> u64 {
+        (Instant::MAX - Instant::now()).as_nanos()
+    }
+
+    fn max_micros(&self) -> u64 {
+        (Instant::MAX - Instant::now()).as_micros()
+    }
+
+    fn max_millis(&self) -> u64 {
+        (Instant::MAX - Instant::now()).as_millis()
+    }
+
+    fn max_secs(&self) -> u64 {
+        (Instant::MAX - Instant::now()).as_secs()
+    }
+}
+
+impl Alarm for HalTimer {
+    async fn wait_until_ticks(&mut self, value: u64) -> Result<(), OverflowError> {
+        let end_time = self
+            .get_instant()
+            .ok_or(OverflowError)?
+            .checked_add(Duration::from_ticks(value))
+            .ok_or(OverflowError)?;
+        crate::Timer::at(end_time).await;
+        Ok(())
+    }
+
+    async fn wait_until_nanos(&mut self, value: u64) -> Result<(), OverflowError> {
+        let end_time = self
+            .get_instant()
+            .ok_or(OverflowError)?
+            .checked_add(Duration::from_nanos(value))
+            .ok_or(OverflowError)?;
+        crate::Timer::at(end_time).await;
+        Ok(())
+    }
+
+    async fn wait_until_micros(&mut self, value: u64) -> Result<(), OverflowError> {
+        let end_time = self
+            .get_instant()
+            .ok_or(OverflowError)?
+            .checked_add(Duration::from_micros(value))
+            .ok_or(OverflowError)?;
+        crate::Timer::at(end_time).await;
+        Ok(())
+    }
+
+    async fn wait_until_millis(&mut self, value: u64) -> Result<(), OverflowError> {
+        let end_time = self
+            .get_instant()
+            .ok_or(OverflowError)?
+            .checked_add(Duration::from_millis(value))
+            .ok_or(OverflowError)?;
+        crate::Timer::at(end_time).await;
+        Ok(())
+    }
+
+    async fn wait_until_secs(&mut self, value: u64) -> Result<(), OverflowError> {
+        let end_time = self
+            .get_instant()
+            .ok_or(OverflowError)?
+            .checked_add(Duration::from_secs(value))
+            .ok_or(OverflowError)?;
+        crate::Timer::at(end_time).await;
+        Ok(())
+    }
+}

--- a/embassy-time/src/eh_timer.rs
+++ b/embassy-time/src/eh_timer.rs
@@ -1,6 +1,3 @@
-use core::cell::Cell;
-
-use critical_section::Mutex;
 use embassy_time_driver::TICK_HZ;
 use embedded_hal_timer::{Alarm, OverflowError, Timer};
 
@@ -8,23 +5,19 @@ use crate::{Duration, Instant};
 
 /// Embedded-hal implementation on top of embassy-time
 #[derive(Debug)]
-pub struct HalTimer(Mutex<Cell<Option<Instant>>>);
+pub struct HalTimer(Option<Instant>);
 
 impl HalTimer {
     /// Construct a new timer that's not running.
     /// Make sure to call [Self::start].
     pub fn new() -> Self {
-        Self(Mutex::new(Cell::new(None)))
-    }
-
-    fn get_instant(&self) -> Option<Instant> {
-        critical_section::with(|cs| self.0.borrow(cs).get())
+        Self(None)
     }
 }
 
 impl Timer for HalTimer {
     fn start(&mut self) {
-        critical_section::with(|cs| self.0.borrow(cs).set(Some(Instant::now())));
+        self.0 = Some(Instant::now());
     }
 
     fn tickrate(&self) -> u64 {
@@ -32,50 +25,50 @@ impl Timer for HalTimer {
     }
 
     fn elapsed_ticks(&self) -> Result<u64, OverflowError> {
-        Ok(self.get_instant().map(|i| i.elapsed().as_ticks()).unwrap_or(u64::MAX))
+        Ok(self.0.map(|i| i.elapsed().as_ticks()).unwrap_or(u64::MAX))
     }
 
     fn elapsed_nanos(&self) -> Result<u64, OverflowError> {
-        Ok(self.get_instant().map(|i| i.elapsed().as_nanos()).unwrap_or(u64::MAX))
+        Ok(self.0.map(|i| i.elapsed().as_nanos()).unwrap_or(u64::MAX))
     }
 
     fn elapsed_micros(&self) -> Result<u64, OverflowError> {
-        Ok(self.get_instant().map(|i| i.elapsed().as_micros()).unwrap_or(u64::MAX))
+        Ok(self.0.map(|i| i.elapsed().as_micros()).unwrap_or(u64::MAX))
     }
 
     fn elapsed_millis(&self) -> Result<u64, OverflowError> {
-        Ok(self.get_instant().map(|i| i.elapsed().as_millis()).unwrap_or(u64::MAX))
+        Ok(self.0.map(|i| i.elapsed().as_millis()).unwrap_or(u64::MAX))
     }
 
     fn elapsed_secs(&self) -> Result<u64, OverflowError> {
-        Ok(self.get_instant().map(|i| i.elapsed().as_secs()).unwrap_or(u64::MAX))
+        Ok(self.0.map(|i| i.elapsed().as_secs()).unwrap_or(u64::MAX))
     }
 
     fn max_ticks(&self) -> u64 {
-        (Instant::MAX - Instant::now()).as_ticks()
+        u64::MAX
     }
 
     fn max_nanos(&self) -> u64 {
-        (Instant::MAX - Instant::now()).as_nanos()
+        u64::MAX
     }
 
     fn max_micros(&self) -> u64 {
-        (Instant::MAX - Instant::now()).as_micros()
+        u64::MAX
     }
 
     fn max_millis(&self) -> u64 {
-        (Instant::MAX - Instant::now()).as_millis()
+        u64::MAX
     }
 
     fn max_secs(&self) -> u64 {
-        (Instant::MAX - Instant::now()).as_secs()
+        u64::MAX
     }
 }
 
 impl Alarm for HalTimer {
     async fn wait_until_ticks(&mut self, value: u64) -> Result<(), OverflowError> {
         let end_time = self
-            .get_instant()
+            .0
             .ok_or(OverflowError)?
             .checked_add(Duration::from_ticks(value))
             .ok_or(OverflowError)?;
@@ -85,7 +78,7 @@ impl Alarm for HalTimer {
 
     async fn wait_until_nanos(&mut self, value: u64) -> Result<(), OverflowError> {
         let end_time = self
-            .get_instant()
+            .0
             .ok_or(OverflowError)?
             .checked_add(Duration::from_nanos(value))
             .ok_or(OverflowError)?;
@@ -95,7 +88,7 @@ impl Alarm for HalTimer {
 
     async fn wait_until_micros(&mut self, value: u64) -> Result<(), OverflowError> {
         let end_time = self
-            .get_instant()
+            .0
             .ok_or(OverflowError)?
             .checked_add(Duration::from_micros(value))
             .ok_or(OverflowError)?;
@@ -105,7 +98,7 @@ impl Alarm for HalTimer {
 
     async fn wait_until_millis(&mut self, value: u64) -> Result<(), OverflowError> {
         let end_time = self
-            .get_instant()
+            .0
             .ok_or(OverflowError)?
             .checked_add(Duration::from_millis(value))
             .ok_or(OverflowError)?;
@@ -115,7 +108,7 @@ impl Alarm for HalTimer {
 
     async fn wait_until_secs(&mut self, value: u64) -> Result<(), OverflowError> {
         let end_time = self
-            .get_instant()
+            .0
             .ok_or(OverflowError)?
             .checked_add(Duration::from_secs(value))
             .ok_or(OverflowError)?;

--- a/embassy-time/src/lib.rs
+++ b/embassy-time/src/lib.rs
@@ -14,6 +14,7 @@ pub(crate) mod fmt;
 
 mod delay;
 mod duration;
+mod eh_timer;
 mod instant;
 mod timer;
 
@@ -32,6 +33,7 @@ mod driver_wasm;
 
 pub use delay::{Delay, block_for};
 pub use duration::Duration;
+pub use eh_timer::HalTimer;
 pub use embassy_time_driver::TICK_HZ;
 pub use instant::Instant;
 pub use timer::{Ticker, TimeoutError, Timer, WithTimeout, with_deadline, with_timeout};


### PR DESCRIPTION
Hey, I'm trying to get some timer and alarm traits into embedded-hal.
This adds those to embassy-time.

I want to add more impls for the HAL hardware timers too, but will do that in different PRs.

To consider:
- Is `HalTimer` a good name? `Timer` is already taken for something else
- Should it be behind an 'unstable' feature flag?
  - The traits will likely get a breaking change at some point...
- Currently when the timer hasn't started any elapsed function will return `u64::MAX` and alarm invocations will return `Err(Overflow)`. Do we think that's good behavior?
  - We could drop requiring calling the start function, but I think that'd lead to bad drivers that don't call start