### PR TITLE
embassy-stm32/ospi: add missing implementations of OctoDma

### DIFF
--- a/embassy-stm32/build.rs
+++ b/embassy-stm32/build.rs
@@ -2045,6 +2045,8 @@ fn main() {
         (("quadspi", "QUADSPI"), quote!(crate::qspi::QuadDma)),
         (("quadspi", "FIFO"), quote!(crate::qspi::QuadDma)),
         (("octospi", "OCTOSPI1"), quote!(crate::ospi::OctoDma)),
+        (("octospi", "OCTOSPI2"), quote!(crate::ospi::OctoDma)),
+        (("octospi", "FIFO"), quote!(crate::ospi::OctoDma)),
         (("hspi", "HSPI1"), quote!(crate::hspi::HspiDma)),
         (("dac", "CH1"), quote!(crate::dac::Dma<Ch1>)),
         (("dac", "CH2"), quote!(crate::dac::Dma<Ch2>)),


### PR DESCRIPTION
The `OctoDma` trait impls were never generated for `OCTOSPI` on MDMA chips, nor for `OCTOSPI2` on GPDMA chips (L4+/U5). This PR adds the two missing mappings in the embassy-stm32 `build.rs`.

I was able to test that async OSPI now compiles and works fine on the H7.