### PR TITLE
docs: add Docker-based PDF build target

### DIFF
--- a/docs/.gitignore
+++ b/docs/.gitignore
@@ -1,0 +1,3 @@
+book/
+build/
+texput.log

--- a/docs/Dockerfile.pandoc
+++ b/docs/Dockerfile.pandoc
@@ -1,0 +1,24 @@
+# pandoc/latex with extra fonts for xelatex Unicode coverage and nice
+# typography. Used by `make pdf` to build the Embassy Book PDF.
+#
+# Bundled font families (all usable via MAIN_FONT / SANS_FONT / MONO_FONT):
+#   - DejaVu Serif / DejaVu Sans / DejaVu Sans Mono   (broad Unicode coverage)
+#   - IBM Plex Serif / IBM Plex Sans / IBM Plex Mono  (nice prose + code look)
+FROM pandoc/latex:latest
+
+RUN apk add --no-cache font-dejavu fontconfig
+
+# IBM Plex (OTFs ship inside the texlive `plex` package, ~32MB) and the
+# LaTeX packages our pandoc-header.tex uses (titlesec for sans-family
+# section heads; mdframed + needspace + zref for the framed code blocks).
+RUN tlmgr install plex titlesec mdframed needspace zref
+
+# Expose TeX Live's IBM Plex OTF directory to fontconfig so fontspec can
+# resolve "IBM Plex Mono" etc. by family name.
+RUN printf '%s\n' \
+    '<?xml version="1.0"?>' \
+    '<!DOCTYPE fontconfig SYSTEM "fonts.dtd">' \
+    '<fontconfig>' \
+    '  <dir>/opt/texlive/texdir/texmf-dist/fonts/opentype/ibm/plex</dir>' \
+    '</fontconfig>' > /etc/fonts/conf.d/99-texlive-plex.conf \
+    && fc-cache -f

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -3,6 +3,93 @@ all:
 	cp -r images book
 
 clean:
-	rm -rf book
+	rm -rf book build
 
-.PHONY: all clean
+# --- PDF build (Docker) -----------------------------------------------------
+# Two-stage pipeline:
+#   1. asciidoctor (Docker)              : AsciiDoc -> DocBook XML (expands include::)
+#   2. local pandoc/latex+fonts (Docker) : DocBook XML -> PDF via xelatex
+#
+# The PDF builder is a thin Dockerfile on top of pandoc/latex:latest that adds
+# DejaVu fonts (Dockerfile.pandoc) — needed for Unicode glyphs used in code
+# listings (box-drawing chars, check marks, etc.) that aren't in TeX's
+# default Latin Modern.
+#
+# Usage:   make pdf
+# Output:  build/embassy-book.pdf
+
+PDF_OUT      ?= /tmp/embassy-book.pdf
+PANDOC_IMG   ?= embassy-pandoc:latest
+ASCIIDOC_IMG ?= asciidoctor/docker-asciidoctor:latest
+DOCKER       ?= docker
+UID          := $(shell id -u)
+GID          := $(shell id -g)
+
+# Fonts. Both families below are pre-installed in embassy-pandoc:latest:
+#   DejaVu Serif / DejaVu Sans / DejaVu Sans Mono
+#   IBM Plex Serif / IBM Plex Sans / IBM Plex Mono
+# Override on the command line, e.g.:
+#   make pdf MONO_FONT="IBM Plex Mono"
+#   make pdf MAIN_FONT="IBM Plex Serif" SANS_FONT="IBM Plex Sans" MONO_FONT="IBM Plex Mono"
+MAIN_FONT ?= DejaVu Serif
+SANS_FONT ?= DejaVu Sans
+MONO_FONT ?= DejaVu Sans Mono
+
+ADOC_SOURCES := index.adoc $(wildcard pages/*.adoc)
+
+# Mount the repo root (not just docs/) so the docs/examples/examples symlink
+# (-> ../../examples) resolves to a path inside the bind mount.
+REPO_ROOT := $(realpath $(CURDIR)/..)
+DOCS_REL  := $(notdir $(CURDIR))
+
+build/embassy-book.xml: $(ADOC_SOURCES)
+	mkdir -p build
+	$(DOCKER) run --rm -u $(UID):$(GID) \
+		-v "$(REPO_ROOT):/workspace" -w "/workspace/$(DOCS_REL)" \
+		$(ASCIIDOC_IMG) \
+		asciidoctor -b docbook5 -d book -o build/embassy-book.xml index.adoc
+	# Substitute a couple of Unicode chars that aren't in every monospace
+	# font (e.g. IBM Plex Mono lacks U+2714 check / U+2717 cross), so the
+	# output stays clean regardless of MONO_FONT.
+	@perl -i -CSD -pe 's/\x{2714}/[x]/g; s/\x{2717}/[ ]/g' build/embassy-book.xml
+
+build/.pandoc-image-id: Dockerfile.pandoc
+	mkdir -p build
+	$(DOCKER) build --platform=linux/amd64 -f Dockerfile.pandoc -t $(PANDOC_IMG) .
+	$(DOCKER) image inspect --format '{{.Id}}' $(PANDOC_IMG) > $@
+
+# pandoc/latex publishes amd64-only; force the platform so it runs under
+# Rosetta on Apple Silicon.
+# Build into the workspace mount (Docker Desktop on macOS exposes /tmp as
+# root-owned and not writable by the host UID inside the container), then
+# copy to PDF_OUT on the host.
+pdf: build/embassy-book.xml build/.pandoc-image-id pandoc-header.tex
+	@mkdir -p "$(dir $(PDF_OUT))"
+	$(DOCKER) run --rm --platform=linux/amd64 -u $(UID):$(GID) \
+		-e HOME=/tmp -e XDG_CACHE_HOME=/tmp/.cache \
+		-v "$(REPO_ROOT):/workspace" -w "/workspace/$(DOCS_REL)" \
+		$(PANDOC_IMG) \
+		--from=docbook --to=latex \
+		--pdf-engine=xelatex \
+		--toc --toc-depth=2 \
+		--number-sections \
+		--syntax-highlighting=tango \
+		--include-in-header=pandoc-header.tex \
+		-V documentclass=book \
+		-V geometry:margin=1in \
+		-V colorlinks=true \
+		-V linkcolor=NavyBlue \
+		-V urlcolor=NavyBlue \
+		-V toccolor=black \
+		-V mainfont="$(MAIN_FONT)" \
+		-V sansfont="$(SANS_FONT)" \
+		-V monofont="$(MONO_FONT)" \
+		-V title="The Embassy Book" \
+		-V subtitle="A Rust framework for async embedded development" \
+		-V author="The Embassy Project" \
+		-V date="$(shell date +%Y-%m-%d)" \
+		-o build/embassy-book.pdf build/embassy-book.xml
+	cp build/embassy-book.pdf "$(PDF_OUT)"
+	@echo "Wrote $(PDF_OUT)"
+
+.PHONY: all clean pdf

--- a/docs/pandoc-header.tex
+++ b/docs/pandoc-header.tex
@@ -1,0 +1,72 @@
+%% --- Typography polish -----------------------------------------------------
+% Better justification, character protrusion, and font expansion.
+\usepackage{microtype}
+
+% Better line-breaking for URLs and long identifiers; avoid full-page vertical
+% stretching when a page can't be filled (common when a tall code block is
+% bumped to the next page).
+\setlength{\emergencystretch}{3em}
+\raggedbottom
+
+%% --- Sans-serif section headings -------------------------------------------
+% Headings render in the configured sans font, body stays in the serif font.
+\usepackage{titlesec}
+\titleformat{\chapter}[hang]
+  {\normalfont\sffamily\Huge\bfseries}{\thechapter}{1em}{}
+\titlespacing*{\chapter}{0pt}{-20pt}{18pt}
+\titleformat{\section}
+  {\normalfont\sffamily\Large\bfseries}{\thesection}{1em}{}
+\titleformat{\subsection}
+  {\normalfont\sffamily\large\bfseries}{\thesubsection}{1em}{}
+\titleformat{\subsubsection}
+  {\normalfont\sffamily\normalsize\bfseries}{\thesubsubsection}{1em}{}
+
+%% --- Title page -----------------------------------------------------------
+% Override pandoc's default \maketitle for a cleaner cover. Uses whatever
+% title/author/date pandoc has already stashed in \@title etc.
+\makeatletter
+\renewcommand{\maketitle}{%
+  \begin{titlepage}
+    \centering
+    \vspace*{0.18\textheight}
+    {\sffamily\bfseries\fontsize{34pt}{40pt}\selectfont \@title \par}
+    \vfill
+    {\sffamily\Large \@author \par}
+    \vspace{0.6cm}
+    {\sffamily \@date \par}
+    \vspace{2cm}
+  \end{titlepage}
+}
+\makeatother
+
+%% --- Code-block frame ------------------------------------------------------
+% Replace pandoc's default gray-bg `Shaded` and bare `verbatim` with an
+% mdframed box: subtle left bar, light tint, and (nobreak=true) keep the
+% whole block on one page so listings don't split.
+\usepackage{xcolor}
+\usepackage{mdframed}
+\definecolor{codebg}{HTML}{F7F7F9}
+\definecolor{codebar}{HTML}{3F6FB5}
+
+\mdfdefinestyle{codeframe}{%
+  backgroundcolor=codebg,
+  linecolor=codebar,
+  linewidth=2.5pt,
+  topline=false, rightline=false, bottomline=false, leftline=true,
+  innerleftmargin=8pt, innerrightmargin=8pt,
+  innertopmargin=6pt, innerbottommargin=6pt,
+  skipabove=6pt, skipbelow=6pt,
+  nobreak=true,
+}
+
+% Replace pandoc's `Shaded` (highlighted code) with our frame. The default
+% `Shaded` wraps content in a gray `snugshade` box; we want only ours.
+\let\OldShaded\Shaded
+\let\endOldShaded\endShaded
+\renewenvironment{Shaded}
+  {\begin{mdframed}[style=codeframe]\small}
+  {\end{mdframed}}
+
+% Pandoc emits plain `verbatim` for unhighlighted code; wrap it too.
+\BeforeBeginEnvironment{verbatim}{\begin{mdframed}[style=codeframe]\small}
+\AfterEndEnvironment{verbatim}{\end{mdframed}}


### PR DESCRIPTION
Adds `make pdf` that produces a book-style PDF from the same AsciiDoc sources as `make all`. Pipeline runs entirely in Docker:

  1. asciidoctor/docker-asciidoctor : AsciiDoc -> DocBook XML (expands include:: across the docs/examples symlink)
  2. embassy-pandoc (Dockerfile.pandoc, FROM pandoc/latex:latest) : DocBook -> PDF via xelatex

Output defaults to /tmp/embassy-book.pdf; override with PDF_OUT. MAIN_FONT / SANS_FONT / MONO_FONT swap fonts on the command line — DejaVu (default) and IBM Plex are both pre-installed in the image.

Polish via pandoc-header.tex: microtype, sans-family chapter heads (titlesec), code blocks rendered as mdframed boxes with a left bar and no page-split, and a cleaner title page.

attached an example:
[embassy-book.pdf](https://github.com/user-attachments/files/28201176/embassy-book.pdf)
