### PR TITLE
executor: use compiler_fence + Relaxed in run_enqueue on cortex-m

### DIFF
--- a/embassy-executor/src/raw/mod.rs
+++ b/embassy-executor/src/raw/mod.rs
@@ -9,9 +9,18 @@
 
 mod run_queue;
 
-#[cfg_attr(all(cortex_m, target_has_atomic = "32"), path = "state_atomics_arm.rs")]
+// The ARM-specific state backend uses `compiler_fence`, which is only a synchronization primitive
+// for same-core concurrency such as interrupts. `platform-cortex-m` is documented as single-core-only;
+// custom Cortex-M platforms, including multicore ones, use the generic atomic backend instead.
 #[cfg_attr(
-    all(not(cortex_m), any(target_has_atomic = "8", target_has_atomic = "32")),
+    all(cortex_m, target_has_atomic = "32", feature = "platform-cortex-m"),
+    path = "state_atomics_arm.rs"
+)]
+#[cfg_attr(
+    all(
+        not(all(cortex_m, target_has_atomic = "32", feature = "platform-cortex-m")),
+        any(target_has_atomic = "8", target_has_atomic = "32")
+    ),
     path = "state_atomics.rs"
 )]
 #[cfg_attr(

--- a/embassy-executor/src/raw/state_atomics_arm.rs
+++ b/embassy-executor/src/raw/state_atomics_arm.rs
@@ -66,7 +66,9 @@ impl State {
     /// function if the task was successfully marked.
     #[inline(always)]
     pub fn run_enqueue(&self, f: impl FnOnce(Token)) {
-        let old = self.run_queued.swap(true, Ordering::AcqRel);
+        compiler_fence(Ordering::Release);
+        let old = self.run_queued.swap(true, Ordering::Relaxed);
+        compiler_fence(Ordering::Acquire);
 
         if !old {
             locked(f);


### PR DESCRIPTION
## Summary

`embassy-executor/src/raw/state_atomics_arm.rs` uses `compiler_fence(Release/Acquire)` paired with `Ordering::Relaxed` atomics everywhere — in `spawn`, `despawn`, and `run_dequeue` — to avoid emitting `DMB` barriers on single-core Cortex-M, where they aren't required.

`run_enqueue` is the one exception: it used `swap(true, Ordering::AcqRel)`, which compiles down to an `ldrexb`/`strexb` loop **plus a `DMB SY`** on every call. Since `run_enqueue` is the wake fast path — hit on essentially every interrupt that drives the executor — this is the place where the inconsistency costs the most.

This PR aligns `run_enqueue` with the surrounding pattern: `compiler_fence(Release)` → `swap(.., Relaxed)` → `compiler_fence(Acquire)`. Semantics are unchanged on the single-core Cortex-M targets this file is selected for (via `#[cfg_attr(all(cortex_m, target_has_atomic = "32"), …)]`), and the DMB on the wake path goes away.

```diff
 pub fn run_enqueue(&self, f: impl FnOnce(Token)) {
-    let old = self.run_queued.swap(true, Ordering::AcqRel);
+    compiler_fence(Ordering::Release);
+    let old = self.run_queued.swap(true, Ordering::Relaxed);
+    compiler_fence(Ordering::Acquire);

     if !old {
         locked(f);
     }
 }
```