### PR TITLE
stm32: add atomic modify traits

### DIFF
--- a/embassy-stm32/src/ipcc.rs
+++ b/embassy-stm32/src/ipcc.rs
@@ -12,6 +12,7 @@ use crate::cpu::CoreId;
 use crate::interrupt::typelevel::Interrupt;
 use crate::peripherals::IPCC;
 use crate::rcc::SealedRccPeripheral;
+use crate::reg::AtomicModify;
 use crate::{interrupt, rcc};
 
 /// Interrupt handler.
@@ -129,12 +130,12 @@ struct ActiveTxInterrupt {
 
 impl ActiveTxInterrupt {
     fn configure_interrupt(&mut self, enabled: bool) {
-        critical_section::with(|_| {
-            IPCC::regs()
-                .cpu(self.core.to_index().into())
-                .mr()
-                .modify(|w| w.set_chfm(self.index as usize, !enabled))
-        });
+        let mr = IPCC::regs().cpu(self.core.to_index().into()).mr();
+
+        match enabled {
+            true => mr.clear_bits(|w| w.set_chfm(self.index as usize, false)),
+            false => mr.set_bits(|w| w.set_chfm(self.index as usize, true)),
+        };
     }
 
     fn new(core: CoreId, index: u8) -> Self {
@@ -269,12 +270,12 @@ struct ActiveRxInterrupt {
 
 impl ActiveRxInterrupt {
     fn configure_interrupt(&mut self, enabled: bool) {
-        critical_section::with(|_| {
-            IPCC::regs()
-                .cpu(self.core.to_index().into())
-                .mr()
-                .modify(|w| w.set_chom(self.index as usize, !enabled))
-        });
+        let mr = IPCC::regs().cpu(self.core.to_index().into()).mr();
+
+        match enabled {
+            true => mr.clear_bits(|w| w.set_chom(self.index as usize, false)),
+            false => mr.set_bits(|w| w.set_chom(self.index as usize, true)),
+        };
     }
 
     fn new(core: CoreId, index: u8) -> Self {

--- a/embassy-stm32/src/lib.rs
+++ b/embassy-stm32/src/lib.rs
@@ -17,6 +17,7 @@ include!(concat!(env!("OUT_DIR"), "/_macros.rs"));
 
 // Utilities
 mod macros;
+mod reg;
 pub mod time;
 mod wait;
 /// Operating modes for peripherals.

--- a/embassy-stm32/src/reg.rs
+++ b/embassy-stm32/src/reg.rs
@@ -15,51 +15,63 @@ pub trait AtomicModify<T: Sized> {
 impl<T: Copy, A: Read + Write> AtomicModify<T> for Reg<T, A> {
     fn set_bits(&self, f: impl FnOnce(&mut T)) {
         unsafe {
-            #[cfg(target_has_atomic = "ptr")]
-            use core::sync::atomic::{AtomicUsize, Ordering};
+            #[cfg(target_has_atomic = "32")]
+            use core::sync::atomic::{AtomicU32, Ordering, compiler_fence};
 
-            let mut v = usize::MIN;
+            let mut v = u32::MIN;
 
-            core::assert_eq!(size_of::<usize>(), size_of::<T>());
-            core::assert_eq!(align_of::<usize>(), align_of::<T>());
+            core::assert_eq!(size_of::<u32>(), size_of::<T>());
+            core::assert_eq!(align_of::<u32>(), align_of::<T>());
 
             f(&mut *(&raw mut v as *mut T));
 
-            let ptr = self.as_ptr() as *mut usize;
+            let ptr = self.as_ptr() as *mut u32;
 
-            #[cfg(not(target_has_atomic = "ptr"))]
+            #[cfg(not(target_has_atomic = "32"))]
             critical_section::with(|_| {
                 let val = ptr.read_volatile();
                 ptr.write_volatile(val | v);
             });
 
-            #[cfg(target_has_atomic = "ptr")]
-            AtomicUsize::from_ptr(ptr).fetch_or(v, Ordering::Relaxed);
+            #[cfg(target_has_atomic = "32")]
+            compiler_fence(Ordering::Release);
+
+            #[cfg(target_has_atomic = "32")]
+            AtomicU32::from_ptr(ptr).fetch_or(v, Ordering::Relaxed);
+
+            #[cfg(target_has_atomic = "32")]
+            compiler_fence(Ordering::Release);
         }
     }
 
     fn clear_bits(&self, f: impl FnOnce(&mut T)) {
         unsafe {
-            #[cfg(target_has_atomic = "ptr")]
-            use core::sync::atomic::{AtomicUsize, Ordering};
+            #[cfg(target_has_atomic = "32")]
+            use core::sync::atomic::{AtomicU32, Ordering, compiler_fence};
 
-            let mut v = usize::MAX;
+            let mut v = u32::MAX;
 
-            core::assert_eq!(size_of::<usize>(), size_of::<T>());
-            core::assert_eq!(align_of::<usize>(), align_of::<T>());
+            core::assert_eq!(size_of::<u32>(), size_of::<T>());
+            core::assert_eq!(align_of::<u32>(), align_of::<T>());
 
             f(&mut *(&raw mut v as *mut T));
 
-            let ptr = self.as_ptr() as *mut usize;
+            let ptr = self.as_ptr() as *mut u32;
 
-            #[cfg(not(target_has_atomic = "ptr"))]
+            #[cfg(not(target_has_atomic = "32"))]
             critical_section::with(|_| {
                 let val = ptr.read_volatile();
                 ptr.write_volatile(val & v);
             });
 
-            #[cfg(target_has_atomic = "ptr")]
-            AtomicUsize::from_ptr(ptr).fetch_and(v, Ordering::Relaxed);
+            #[cfg(target_has_atomic = "32")]
+            compiler_fence(Ordering::Release);
+
+            #[cfg(target_has_atomic = "32")]
+            AtomicU32::from_ptr(ptr).fetch_and(v, Ordering::Relaxed);
+
+            #[cfg(target_has_atomic = "32")]
+            compiler_fence(Ordering::Release);
         }
     }
 }

--- a/embassy-stm32/src/reg.rs
+++ b/embassy-stm32/src/reg.rs
@@ -1,0 +1,65 @@
+use crate::pac::common::{Read, Reg, Write};
+
+#[allow(dead_code)]
+pub trait AtomicModify<T: Sized> {
+    /// Atomically mask bits
+    ///
+    /// Call `set_xxx(true)` inside the closure
+    fn set_bits(&self, f: impl FnOnce(&mut T));
+    /// Atomically unmask bits
+    ///
+    /// Call `set_xxx(false)` inside the closure
+    fn clear_bits(&self, f: impl FnOnce(&mut T));
+}
+
+impl<T: Copy, A: Read + Write> AtomicModify<T> for Reg<T, A> {
+    fn set_bits(&self, f: impl FnOnce(&mut T)) {
+        unsafe {
+            #[cfg(target_has_atomic = "ptr")]
+            use core::sync::atomic::{AtomicUsize, Ordering};
+
+            let mut v = usize::MIN;
+
+            core::assert_eq!(size_of::<usize>(), size_of::<T>());
+            core::assert_eq!(align_of::<usize>(), align_of::<T>());
+
+            f(&mut *(&raw mut v as *mut T));
+
+            let ptr = self.as_ptr() as *mut usize;
+
+            #[cfg(not(target_has_atomic = "ptr"))]
+            critical_section::with(|_| {
+                let val = ptr.read_volatile();
+                ptr.write_volatile(val | v);
+            });
+
+            #[cfg(target_has_atomic = "ptr")]
+            AtomicUsize::from_ptr(ptr).fetch_or(v, Ordering::Relaxed);
+        }
+    }
+
+    fn clear_bits(&self, f: impl FnOnce(&mut T)) {
+        unsafe {
+            #[cfg(target_has_atomic = "ptr")]
+            use core::sync::atomic::{AtomicUsize, Ordering};
+
+            let mut v = usize::MAX;
+
+            core::assert_eq!(size_of::<usize>(), size_of::<T>());
+            core::assert_eq!(align_of::<usize>(), align_of::<T>());
+
+            f(&mut *(&raw mut v as *mut T));
+
+            let ptr = self.as_ptr() as *mut usize;
+
+            #[cfg(not(target_has_atomic = "ptr"))]
+            critical_section::with(|_| {
+                let val = ptr.read_volatile();
+                ptr.write_volatile(val & v);
+            });
+
+            #[cfg(target_has_atomic = "ptr")]
+            AtomicUsize::from_ptr(ptr).fetch_and(v, Ordering::Relaxed);
+        }
+    }
+}

--- a/embassy-stm32/src/usart/mod.rs
+++ b/embassy-stm32/src/usart/mod.rs
@@ -25,6 +25,7 @@ use crate::pac::usart::Lpuart as Regs;
 use crate::pac::usart::Usart as Regs;
 use crate::pac::usart::{regs, vals};
 use crate::rcc::{RccInfo, SealedRccPeripheral};
+use crate::reg::AtomicModify;
 use crate::time::Hertz;
 
 /// Interrupt handler.
@@ -512,7 +513,7 @@ impl<'d> UartTx<'d, Async> {
         half_duplex_set_rx_tx_before_write(&r, self.duplex == Duplex::Half(HalfDuplexReadback::Readback));
 
         let ch = self.tx_dma.as_mut().unwrap();
-        r.cr3().modify(|reg| {
+        r.cr3().set_bits(|reg| {
             reg.set_dmat(true);
         });
         // If we don't assign future to a variable, the data register pointer
@@ -649,7 +650,7 @@ impl<'d, M: Mode> UartTx<'d, M> {
 async fn flush(info: &Info, state: &State) -> Result<(), Error> {
     let r = info.regs;
     if r.cr1().read().te() && !sr(r).read().tc() {
-        r.cr1().modify(|w| {
+        r.cr1().set_bits(|w| {
             // enable Transmission Complete interrupt
             w.set_tcie(true);
         });
@@ -694,7 +695,7 @@ pub fn send_break(regs: &Regs) {
 
     // Send break right after completing the current character transmission
     #[cfg(any(usart_v1, usart_v2))]
-    regs.cr1().modify(|w| w.set_sbk(true));
+    regs.cr1().set_bits(|w| w.set_sbk(true));
     #[cfg(any(usart_v3, usart_v4))]
     regs.rqr().write(|w| w.set_sbkrq(true));
 }
@@ -775,8 +776,11 @@ impl<'d> UartRx<'d, Async> {
             flush(&self.info, &self.state).await?;
 
             // Disable Transmitter and enable Receiver after flush
-            r.cr1().modify(|reg| {
+            r.cr1().set_bits(|reg| {
                 reg.set_re(true);
+            });
+
+            r.cr1().clear_bits(|reg| {
                 reg.set_te(false);
             });
         }
@@ -784,7 +788,7 @@ impl<'d> UartRx<'d, Async> {
         // make sure USART state is restored to neutral state when this future is dropped
         let on_drop = OnDrop::new(move || {
             // clear all interrupts and DMA Rx Request
-            r.cr1().modify(|w| {
+            r.cr1().clear_bits(|w| {
                 // disable RXNE interrupt
                 w.set_rxneie(false);
                 // disable parity interrupt
@@ -792,7 +796,7 @@ impl<'d> UartRx<'d, Async> {
                 // disable idle line interrupt
                 w.set_idleie(false);
             });
-            r.cr3().modify(|w| {
+            r.cr3().clear_bits(|w| {
                 // disable Error Interrupt: (Frame error, Noise error, Overrun error)
                 w.set_eie(false);
                 // disable DMA Rx Request
@@ -817,14 +821,18 @@ impl<'d> UartRx<'d, Async> {
             clear_interrupt_flags(r, sr);
         }
 
-        r.cr1().modify(|w| {
+        r.cr1().clear_bits(|w| {
             // disable RXNE interrupt
             w.set_rxneie(false);
-            // enable parity interrupt if not ParityNone
-            w.set_peie(w.pce());
         });
 
-        r.cr3().modify(|w| {
+        let pce = r.cr1().read().pce();
+        r.cr1().set_bits(|w| {
+            // enable parity interrupt if not ParityNone
+            w.set_peie(pce);
+        });
+
+        r.cr3().set_bits(|w| {
             // enable Error Interrupt: (Frame error, Noise error, Overrun error)
             w.set_eie(true);
             // enable DMA Rx Request
@@ -874,7 +882,7 @@ impl<'d> UartRx<'d, Async> {
             clear_interrupt_flags(r, sr);
 
             // enable idle interrupt
-            r.cr1().modify(|w| {
+            r.cr1().set_bits(|w| {
                 w.set_idleie(true);
             });
         }
@@ -894,7 +902,7 @@ impl<'d> UartRx<'d, Async> {
 
             if enable_idle_line_detection {
                 // enable idle interrupt
-                r.cr1().modify(|w| {
+                r.cr1().set_bits(|w| {
                     w.set_idleie(true);
                 });
             }
@@ -1124,8 +1132,11 @@ impl<'d, M: Mode> UartRx<'d, M> {
             blocking_flush(self.info)?;
 
             // Disable Transmitter and enable Receiver after flush
-            r.cr1().modify(|reg| {
+            r.cr1().set_bits(|reg| {
                 reg.set_re(true);
+            });
+
+            r.cr1().clear_bits(|reg| {
                 reg.set_te(false);
             });
         }


### PR DESCRIPTION
Why write assembly, when the compiler can do it for us?