### PR TITLE
can: gate TimingCalcError Debug behind !defmt

### DIFF
--- a/embassy-stm32/src/can/bxcan/mod.rs
+++ b/embassy-stm32/src/can/bxcan/mod.rs
@@ -127,8 +127,7 @@ impl CanConfig<'_> {
     ///
     /// This is a helper that internally calls `set_bit_timing()`[Self::set_bit_timing].
     pub fn set_bitrate(self, bitrate: u32) -> Self {
-        let bit_timing = util::calc_can_timings(self.periph_clock, bitrate)
-            .unwrap_or_else(|_| panic!("CAN timing calculation failed"));
+        let bit_timing = unwrap!(util::calc_can_timings(self.periph_clock, bitrate));
         self.set_bit_timing(bit_timing)
     }
 
@@ -244,8 +243,7 @@ impl<'d> Can<'d> {
 
     /// Set CAN bit rate.
     pub fn set_bitrate(&mut self, bitrate: u32) {
-        let bit_timing = util::calc_can_timings(self.periph_clock, bitrate)
-            .unwrap_or_else(|_| panic!("CAN timing calculation failed"));
+        let bit_timing = unwrap!(util::calc_can_timings(self.periph_clock, bitrate));
         self.modify_config().set_bit_timing(bit_timing);
     }
 

--- a/embassy-stm32/src/can/bxcan/mod.rs
+++ b/embassy-stm32/src/can/bxcan/mod.rs
@@ -127,7 +127,8 @@ impl CanConfig<'_> {
     ///
     /// This is a helper that internally calls `set_bit_timing()`[Self::set_bit_timing].
     pub fn set_bitrate(self, bitrate: u32) -> Self {
-        let bit_timing = util::calc_can_timings(self.periph_clock, bitrate).unwrap();
+        let bit_timing = util::calc_can_timings(self.periph_clock, bitrate)
+            .unwrap_or_else(|_| panic!("CAN timing calculation failed"));
         self.set_bit_timing(bit_timing)
     }
 
@@ -243,7 +244,8 @@ impl<'d> Can<'d> {
 
     /// Set CAN bit rate.
     pub fn set_bitrate(&mut self, bitrate: u32) {
-        let bit_timing = util::calc_can_timings(self.periph_clock, bitrate).unwrap();
+        let bit_timing = util::calc_can_timings(self.periph_clock, bitrate)
+            .unwrap_or_else(|_| panic!("CAN timing calculation failed"));
         self.modify_config().set_bit_timing(bit_timing);
     }
 

--- a/embassy-stm32/src/can/enums.rs
+++ b/embassy-stm32/src/can/enums.rs
@@ -78,7 +78,7 @@ pub enum RefCountOp {
 }
 
 /// Error returned when calculating the can timing fails
-#[cfg_attr(not(feature = "defmt"), derive(Debug))]
+#[derive(Debug)]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub enum TimingCalcError {
     /// Bitrate is lower than 1000

--- a/embassy-stm32/src/can/enums.rs
+++ b/embassy-stm32/src/can/enums.rs
@@ -78,7 +78,7 @@ pub enum RefCountOp {
 }
 
 /// Error returned when calculating the can timing fails
-#[derive(Debug)]
+#[cfg_attr(not(feature = "defmt"), derive(Debug))]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub enum TimingCalcError {
     /// Bitrate is lower than 1000

--- a/embassy-stm32/src/can/fdcan.rs
+++ b/embassy-stm32/src/can/fdcan.rs
@@ -235,8 +235,7 @@ impl<'d> CanConfigurator<'d> {
 
     /// Configures the bit timings calculated from supplied bitrate.
     pub fn set_bitrate(&mut self, bitrate: u32) {
-        let bit_timing = util::calc_can_timings(self.properties.kernel_input_clock(), bitrate)
-            .unwrap_or_else(|_| panic!("CAN timing calculation failed"));
+        let bit_timing = unwrap!(util::calc_can_timings(self.properties.kernel_input_clock(), bitrate));
 
         let nbtr = crate::can::fd::config::NominalBitTiming {
             sync_jump_width: bit_timing.sync_jump_width,
@@ -249,8 +248,7 @@ impl<'d> CanConfigurator<'d> {
 
     /// Configures the bit timings for VBR data calculated from supplied bitrate. This also sets config to allow can FD and VBR
     pub fn set_fd_data_bitrate(&mut self, bitrate: u32, transceiver_delay_compensation: bool) {
-        let bit_timing = util::calc_can_timings(self.properties.kernel_input_clock(), bitrate)
-            .unwrap_or_else(|_| panic!("CAN FD data timing calculation failed"));
+        let bit_timing = unwrap!(util::calc_can_timings(self.properties.kernel_input_clock(), bitrate));
         // Note, used existing calculation for normal(non-VBR) bitrate, appears to work for 250k/1M
         let tdc_offset = if transceiver_delay_compensation {
             // sets at the end of tseg1

--- a/embassy-stm32/src/can/fdcan.rs
+++ b/embassy-stm32/src/can/fdcan.rs
@@ -235,7 +235,8 @@ impl<'d> CanConfigurator<'d> {
 
     /// Configures the bit timings calculated from supplied bitrate.
     pub fn set_bitrate(&mut self, bitrate: u32) {
-        let bit_timing = util::calc_can_timings(self.properties.kernel_input_clock(), bitrate).unwrap();
+        let bit_timing = util::calc_can_timings(self.properties.kernel_input_clock(), bitrate)
+            .unwrap_or_else(|_| panic!("CAN timing calculation failed"));
 
         let nbtr = crate::can::fd::config::NominalBitTiming {
             sync_jump_width: bit_timing.sync_jump_width,
@@ -248,7 +249,8 @@ impl<'d> CanConfigurator<'d> {
 
     /// Configures the bit timings for VBR data calculated from supplied bitrate. This also sets config to allow can FD and VBR
     pub fn set_fd_data_bitrate(&mut self, bitrate: u32, transceiver_delay_compensation: bool) {
-        let bit_timing = util::calc_can_timings(self.properties.kernel_input_clock(), bitrate).unwrap();
+        let bit_timing = util::calc_can_timings(self.properties.kernel_input_clock(), bitrate)
+            .unwrap_or_else(|_| panic!("CAN FD data timing calculation failed"));
         // Note, used existing calculation for normal(non-VBR) bitrate, appears to work for 250k/1M
         let tdc_offset = if transceiver_delay_compensation {
             // sets at the end of tseg1


### PR DESCRIPTION
can: use unwrap!() macro in set_bitrate for bxcan and fdcan

When the defmt feature is enabled, Result::unwrap() requires E: Debug,
but defmt builds prefer defmt::unwrap!() which requires E: defmt::Format
instead, avoiding the core::fmt::Debug machinery in the binary.