### PR TITLE
Re-add e-io-async 0.6

### DIFF
--- a/embassy-nrf/Cargo.toml
+++ b/embassy-nrf/Cargo.toml
@@ -218,7 +218,7 @@ embassy-time = { version = "0.5.1", path = "../embassy-time", optional = true }
 embassy-sync = { version = "0.8.0", path = "../embassy-sync" }
 embassy-hal-internal = { version = "0.5.0", path = "../embassy-hal-internal", features = ["cortex-m", "prio-bits-3"] }
 embassy-embedded-hal = { version = "0.6.0", path = "../embassy-embedded-hal", default-features = false }
-embassy-usb-driver = { version = "0.2.1", path = "../embassy-usb-driver" }
+embassy-usb-driver = { version = "0.2.2", path = "../embassy-usb-driver" }
 embassy-usb-synopsys-otg = { version = "0.4.0", path = "../embassy-usb-synopsys-otg", optional = true }
 embassy-net-driver-channel = { version = "0.4.0", path = "../embassy-net-driver-channel", optional = true}
 embassy-futures = { version = "0.1.2", path = "../embassy-futures" }

--- a/embassy-rp/Cargo.toml
+++ b/embassy-rp/Cargo.toml
@@ -168,7 +168,7 @@ embassy-time = { version = "0.5.1", path = "../embassy-time" }
 embassy-futures = { version = "0.1.2", path = "../embassy-futures" }
 embassy-hal-internal = { version = "0.5.0", path = "../embassy-hal-internal", features = ["cortex-m", "prio-bits-2"] }
 embassy-embedded-hal = { version = "0.6.0", path = "../embassy-embedded-hal" }
-embassy-usb-driver = { version = "0.2.1", path = "../embassy-usb-driver" }
+embassy-usb-driver = { version = "0.2.2", path = "../embassy-usb-driver" }
 embassy-executor = { version = "0.10.0", path = "../embassy-executor", optional = true }
 embassy-executor-macros = { version = "0.8.0", path = "../embassy-executor-macros", optional = true }
 defmt = { version = "1.0.1", optional = true }

--- a/embassy-stm32/Cargo.toml
+++ b/embassy-stm32/Cargo.toml
@@ -160,7 +160,7 @@ embassy-futures = { version = "0.1.2", path = "../embassy-futures" }
 embassy-hal-internal = { version = "0.5.0", path = "../embassy-hal-internal", features = ["cortex-m", "prio-bits-4", "aligned"] }
 embassy-embedded-hal = { version = "0.6.0", path = "../embassy-embedded-hal", default-features = false }
 embassy-net-driver = { version = "0.2.0", path = "../embassy-net-driver" }
-embassy-usb-driver = { version = "0.2.1", path = "../embassy-usb-driver" }
+embassy-usb-driver = { version = "0.2.2", path = "../embassy-usb-driver" }
 embassy-usb-synopsys-otg = { version = "0.4.0", path = "../embassy-usb-synopsys-otg" }
 embassy-executor = { version = "0.10.0", path = "../embassy-executor", optional = true }
 cyw43 = { version = "0.7.0", path = "../cyw43", optional = true }

--- a/embassy-usb-driver/CHANGELOG.md
+++ b/embassy-usb-driver/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 <!-- next-header -->
 ## Unreleased - ReleaseDate
 
+- **Un-breaking change**: Re-add embedded-io-async 0.6.1 support.
+
 ## 0.2.1 - 2026-05-04
 
 - Add `EndpointOut::read_transfer()` and `EndpointIn::write_transfer()` provided methods.

--- a/embassy-usb-driver/CHANGELOG.md
+++ b/embassy-usb-driver/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 <!-- next-header -->
 ## Unreleased - ReleaseDate
 
+## 0.2.2 - 2026-05-28
+
 - **Un-breaking change**: Re-add embedded-io-async 0.6.1 support.
 
 ## 0.2.1 - 2026-05-04

--- a/embassy-usb-driver/Cargo.toml
+++ b/embassy-usb-driver/Cargo.toml
@@ -20,7 +20,8 @@ features = ["defmt"]
 
 [dependencies]
 # TODO: remove before releasing embassy-usb-driver v0.3
-embedded-io-async = "0.7.0"
+embedded-io-async-06 = { package = "embedded-io-async", version = "0.6.1" }
+embedded-io-async-07 = { package = "embedded-io-async", version = "0.7.0" }
 defmt = { version = "1", optional = true }
 
 [features]

--- a/embassy-usb-driver/Cargo.toml
+++ b/embassy-usb-driver/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "embassy-usb-driver"
-version = "0.2.1"
+version = "0.2.2"
 edition = "2024"
 license = "MIT OR Apache-2.0"
 description = "Driver trait for `embassy-usb`, an async USB device stack for embedded devices."

--- a/embassy-usb-driver/src/lib.rs
+++ b/embassy-usb-driver/src/lib.rs
@@ -457,11 +457,19 @@ pub enum EndpointError {
 }
 
 // TODO: remove before releasing embassy-usb-driver v0.3
-impl embedded_io_async::Error for EndpointError {
-    fn kind(&self) -> embedded_io_async::ErrorKind {
+impl embedded_io_async_06::Error for EndpointError {
+    fn kind(&self) -> embedded_io_async_06::ErrorKind {
         match self {
-            Self::BufferOverflow => embedded_io_async::ErrorKind::OutOfMemory,
-            Self::Disabled => embedded_io_async::ErrorKind::NotConnected,
+            Self::BufferOverflow => embedded_io_async_06::ErrorKind::OutOfMemory,
+            Self::Disabled => embedded_io_async_06::ErrorKind::NotConnected,
+        }
+    }
+}
+impl embedded_io_async_07::Error for EndpointError {
+    fn kind(&self) -> embedded_io_async_07::ErrorKind {
+        match self {
+            Self::BufferOverflow => embedded_io_async_07::ErrorKind::OutOfMemory,
+            Self::Disabled => embedded_io_async_07::ErrorKind::NotConnected,
         }
     }
 }

--- a/embassy-usb-host/Cargo.toml
+++ b/embassy-usb-host/Cargo.toml
@@ -20,7 +20,7 @@ features = ["defmt"]
 
 [dependencies]
 embassy-usb = { version = "0.6.0", path = "../embassy-usb" }
-embassy-usb-driver = { version = "0.2.1", path = "../embassy-usb-driver" }
+embassy-usb-driver = { version = "0.2.2", path = "../embassy-usb-driver" }
 embassy-sync = { version = "0.8.0", path = "../embassy-sync" }
 embassy-time = { version = "0.5.1", path = "../embassy-time" }
 embedded-io-async = "0.7.0"

--- a/embassy-usb-synopsys-otg/CHANGELOG.md
+++ b/embassy-usb-synopsys-otg/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 <!-- next-header -->
 ## Unreleased - ReleaseDate
 
-## 0.4.0 - 2026-05-23
+## 0.4.0 - 2026-05-28
 
 - **Breaking:** type-erased `State`/`HostState`, non-generic `OtgInstance`/`OtgHostInstance`, endpoint allocation in `State`, const generics removed from device/host drivers. Static state now needs to be constructed as `StateStorage::new()`/`HostStateStorage::new()` and then `as_state()`/`as_host_state()` must be called to obtain the state reference.
 - **Breaking:** type-erased `OtgState`/`OtgHostState`, non-generic `OtgInstance`/`OtgHostInstance`, endpoint allocation in `State`, const generics removed from device/host drivers.

--- a/embassy-usb-synopsys-otg/Cargo.toml
+++ b/embassy-usb-synopsys-otg/Cargo.toml
@@ -21,7 +21,7 @@ portable-atomic = { version = "1" }
 
 embassy-sync = { version = "0.8.0", path = "../embassy-sync" }
 embassy-time = { version = "0.5.1", path = "../embassy-time" }
-embassy-usb-driver = { version = "0.2.1", path = "../embassy-usb-driver" }
+embassy-usb-driver = { version = "0.2.2", path = "../embassy-usb-driver" }
 
 defmt = { version = "1.0.1", optional = true }
 log = { version = "0.4.14", optional = true }

--- a/embassy-usb/Cargo.toml
+++ b/embassy-usb/Cargo.toml
@@ -59,7 +59,7 @@ max-handler-count-8 = []
 
 [dependencies]
 embassy-futures = { version = "0.1.2", path = "../embassy-futures" }
-embassy-usb-driver = { version = "0.2.1", path = "../embassy-usb-driver" }
+embassy-usb-driver = { version = "0.2.2", path = "../embassy-usb-driver" }
 embassy-sync = { version = "0.8.0", path = "../embassy-sync" }
 embassy-net-driver-channel = { version = "0.4.0", path = "../embassy-net-driver-channel" }
 embassy-time = { version = "0.5.1", path = "../embassy-time" }

--- a/examples/rp/Cargo.toml
+++ b/examples/rp/Cargo.toml
@@ -14,7 +14,7 @@ embassy-time = { version = "0.5.1", path = "../../embassy-time", features = ["de
 embassy-rp = { version = "0.10.0", path = "../../embassy-rp", features = ["defmt", "unstable-pac", "time-driver", "critical-section-impl", "rp2040"] }
 embassy-usb = { version = "0.6.0", path = "../../embassy-usb", features = ["defmt"] }
 embassy-usb-host = { version = "0.1.0", path = "../../embassy-usb-host", features = ["defmt"] }
-embassy-usb-driver = { version = "0.2.1", path = "../../embassy-usb-driver" }
+embassy-usb-driver = { version = "0.2.2", path = "../../embassy-usb-driver" }
 embassy-net = { version = "0.9.1", path = "../../embassy-net", features = ["defmt", "icmp", "tcp", "udp", "raw", "dhcpv4", "medium-ethernet", "dns", "proto-ipv4", "proto-ipv6", "multicast"] }
 embassy-net-wiznet = { version = "0.3.0", path = "../../embassy-net-wiznet", features = ["defmt"] }
 embassy-futures = { version = "0.1.2", path = "../../embassy-futures" }

--- a/examples/stm32f4/Cargo.toml
+++ b/examples/stm32f4/Cargo.toml
@@ -16,7 +16,7 @@ embassy-net = { version = "0.9.1", path = "../../embassy-net", features = ["defm
 embassy-net-wiznet = { version = "0.3.0", path = "../../embassy-net-wiznet", features = ["defmt"] }
 embassy-futures = { version = "0.1.2", path = "../../embassy-futures" }
 embassy-usb-host = { version = "0.1.0", path = "../../embassy-usb-host", features = ["defmt"] }
-embassy-usb-driver = { version = "0.2.1", path = "../../embassy-usb-driver", features = ["defmt"] }
+embassy-usb-driver = { version = "0.2.2", path = "../../embassy-usb-driver", features = ["defmt"] }
 
 defmt = "1.0.1"
 defmt-rtt = "1.0.0"

--- a/examples/stm32g0/Cargo.toml
+++ b/examples/stm32g0/Cargo.toml
@@ -14,7 +14,7 @@ embassy-time = { version = "0.5.1", path = "../../embassy-time", features = ["de
 embassy-usb = { version = "0.6.0", path = "../../embassy-usb", default-features = false, features = ["defmt"] }
 embassy-usb-host = { version = "0.1.0", path = "../../embassy-usb-host", features = ["defmt"] }
 embassy-futures = { version = "0.1.2", path = "../../embassy-futures" }
-embassy-usb-driver = { version = "0.2.1", path = "../../embassy-usb-driver" }
+embassy-usb-driver = { version = "0.2.2", path = "../../embassy-usb-driver" }
 
 defmt = "1.0.1"
 defmt-rtt = "1.0.0"

--- a/examples/stm32wba6/Cargo.toml
+++ b/examples/stm32wba6/Cargo.toml
@@ -16,7 +16,7 @@ embassy-net = { version = "0.9.1", path = "../../embassy-net", features = ["defm
 embassy-usb = { version = "0.6.0", path = "../../embassy-usb", features = ["defmt"] }
 embassy-futures = { version = "0.1.2", path = "../../embassy-futures" }
 embassy-usb-host = { version = "0.1.0", path = "../../embassy-usb-host", features = ["defmt"] }
-embassy-usb-driver = { version = "0.2.1", path = "../../embassy-usb-driver", features = ["defmt"] }
+embassy-usb-driver = { version = "0.2.2", path = "../../embassy-usb-driver", features = ["defmt"] }
 embedded-sdmmc = "0.9.0"
 embedded-hal-bus = "0.3.0"
 


### PR DESCRIPTION
https://github.com/embassy-rs/embassy/pull/5157 managed to sneak in a breaking change. This PR adds back 0.6 support while keeping 0.7 to avoid breaking use cases that rely on the breaking change. 0.2.1 should probably be yanked.

This is also a good time to trigger a new synopsys-usb release :)