### PR TITLE
Add RNG peripheral test for N6

### DIFF
--- a/embassy-stm32/Cargo.toml
+++ b/embassy-stm32/Cargo.toml
@@ -210,11 +210,11 @@ heapless = "0.9.1"
 once_cell = { version = "1.21.4", default-features = false, features=["critical-section"] }
 
 # stm32-metapac = { version = "21" }
-stm32-metapac = { git = "https://github.com/embassy-rs/stm32-data-generated", tag = "stm32-data-6d108b6d3695cafd30923b033bc82291da5859a7" }
+stm32-metapac = { git = "https://github.com/embassy-rs/stm32-data-generated", tag = "stm32-data-a1906cf83a69ba308d630c2cf1c1ba545c9ff101" }
 
 [build-dependencies]
 # stm32-metapac = { version = "21", default-features = false, features = ["metadata"]}
-stm32-metapac = { git = "https://github.com/embassy-rs/stm32-data-generated", tag = "stm32-data-6d108b6d3695cafd30923b033bc82291da5859a7", default-features = false, features = ["metadata"] }
+stm32-metapac = { git = "https://github.com/embassy-rs/stm32-data-generated", tag = "stm32-data-a1906cf83a69ba308d630c2cf1c1ba545c9ff101", default-features = false, features = ["metadata"] }
 
 proc-macro2 = "1.0.36"
 quote = "1.0.15"

--- a/examples/stm32n6/src/bin/rng.rs
+++ b/examples/stm32n6/src/bin/rng.rs
@@ -1,0 +1,32 @@
+#![no_std]
+#![no_main]
+
+use defmt::*;
+use embassy_executor::Spawner;
+use embassy_stm32::rng::Rng;
+use embassy_stm32::{Config, bind_interrupts, peripherals, rng};
+use {defmt_rtt as _, panic_probe as _};
+
+bind_interrupts!(struct Irqs {
+    RNG => rng::InterruptHandler<peripherals::RNG>;
+});
+
+#[embassy_executor::main]
+async fn main(_spawner: Spawner) {
+    let mut core_peri = unsafe { cortex_m::Peripherals::steal() };
+    core_peri.SCB.invalidate_icache();
+    core_peri.SCB.enable_icache();
+
+    // On STM32N6, the RNG kernel clock (rng_ker_ck) is hardwired to hsis_osc_ck (48 MHz internal RC
+    // oscillator) with no mux - RM0486 Table 73. No explicit kernel clock selection is needed.
+    let config = Config::default();
+
+    let p = embassy_stm32::init(config);
+    info!("Hello World!");
+
+    let mut rng = Rng::new(p.RNG, Irqs);
+
+    let mut buf = [0u8; 16];
+    unwrap!(rng.async_fill_bytes(&mut buf).await);
+    info!("random bytes: {:02x}", buf);
+}


### PR DESCRIPTION
Add test program for RNG peripheral on N6

Bump stm32-metapac to stm32-data-a1906cf83a69ba308d630c2cf1c1ba545c9ff101 which adds RNG v3 to perimap for N6