### PR TITLE
embassy-net: fix compilation with packetmeta-id feature

### DIFF
--- a/embassy-net-driver/Cargo.toml
+++ b/embassy-net-driver/Cargo.toml
@@ -21,6 +21,11 @@ target = "thumbv7em-none-eabi"
 [package.metadata.docs.rs]
 features = ["defmt"]
 
+[package.metadata.embassy]
+build = [
+    {target = "thumbv7em-none-eabi", features = ["defmt", "packetmeta-id"]},
+]
+
 [dependencies]
 defmt = { version = "1.0.1", optional = true }
 

--- a/embassy-net-driver/src/lib.rs
+++ b/embassy-net-driver/src/lib.rs
@@ -15,6 +15,8 @@ use core::task::Context;
 #[derive(Debug, PartialEq, Eq, Hash, Clone, Copy, Default)]
 #[non_exhaustive]
 pub struct PacketMeta {
+    /// An identifier associated with a transmitted or received
+    /// packet.
     #[cfg(feature = "packetmeta-id")]
     pub id: u32,
 }

--- a/embassy-net/Cargo.toml
+++ b/embassy-net/Cargo.toml
@@ -28,6 +28,7 @@ build = [
     {target = "thumbv7em-none-eabi", features = ["defmt", "dns", "medium-ip", "proto-ipv4", "proto-ipv6", "tcp", "udp"]},
     {target = "thumbv7em-none-eabi", features = ["defmt", "dns", "medium-ethernet", "medium-ip", "proto-ipv4", "proto-ipv6", "tcp", "udp"]},
     {target = "thumbv7em-none-eabi", features = ["defmt", "dns", "medium-ethernet", "medium-ieee802154", "medium-ip", "proto-ipv4", "proto-ipv6", "tcp", "udp"]},
+    {target = "thumbv7em-none-eabi", features = ["defmt", "dns", "medium-ethernet", "medium-ieee802154", "medium-ip", "proto-ipv4", "proto-ipv6", "tcp", "udp", "packetmeta-id"]},
     # Xtensa builds
     {group = "xtensa", build-std = ["core", "alloc"],  target = "xtensa-esp32-none-elf", features = ["defmt", "tcp", "udp", "dns", "proto-ipv4", "medium-ethernet", "packet-trace"]},
     {group = "xtensa", build-std = ["core", "alloc"],  target = "xtensa-esp32-none-elf", features = ["defmt", "tcp", "udp", "dns", "proto-ipv4", "multicast", "medium-ethernet"]},
@@ -46,11 +47,11 @@ build = [
 [package.metadata.embassy_docs]
 src_base = "https://github.com/embassy-rs/embassy/blob/embassy-net-v$VERSION/embassy-net/src/"
 src_base_git = "https://github.com/embassy-rs/embassy/blob/$COMMIT/embassy-net/src/"
-features = ["defmt", "tcp", "udp", "raw", "dns", "icmp", "dhcpv4", "proto-ipv6", "medium-ethernet", "medium-ip", "medium-ieee802154", "multicast", "dhcpv4-hostname"]
+features = ["defmt", "tcp", "udp", "raw", "dns", "icmp", "dhcpv4", "proto-ipv6", "medium-ethernet", "medium-ip", "medium-ieee802154", "multicast", "dhcpv4-hostname", "packetmeta-id"]
 target = "thumbv7em-none-eabi"
 
 [package.metadata.docs.rs]
-features = ["defmt", "tcp", "udp", "raw", "dns", "icmp", "dhcpv4", "proto-ipv6", "medium-ethernet", "medium-ip", "medium-ieee802154", "multicast", "dhcpv4-hostname"]
+features = ["defmt", "tcp", "udp", "raw", "dns", "icmp", "dhcpv4", "proto-ipv6", "medium-ethernet", "medium-ip", "medium-ieee802154", "multicast", "dhcpv4-hostname", "packetmeta-id"]
 
 [features]
 ## Enable defmt

--- a/embassy-net/src/driver_util.rs
+++ b/embassy-net/src/driver_util.rs
@@ -126,7 +126,7 @@ where
 
 #[allow(unused, reason = "meta isn't used if no features are enabled")]
 pub(crate) fn into_smoltcp_meta(meta: PacketMeta) -> phy::PacketMeta {
-    let out_meta = phy::PacketMeta::default();
+    let mut out_meta = phy::PacketMeta::default();
     #[cfg(feature = "packetmeta-id")]
     {
         out_meta.id = meta.id;
@@ -136,7 +136,7 @@ pub(crate) fn into_smoltcp_meta(meta: PacketMeta) -> phy::PacketMeta {
 
 #[allow(unused, reason = "meta isn't used if no features are enabled")]
 pub(crate) fn into_embassy_net_meta(meta: phy::PacketMeta) -> PacketMeta {
-    let out_meta = PacketMeta::default();
+    let mut out_meta = PacketMeta::default();
     #[cfg(feature = "packetmeta-id")]
     {
         out_meta.id = meta.id;


### PR DESCRIPTION
Apparently I didn't do my due-dilligence and this just didn't compile at all.

Is there an easy way to add features to the stuff that is checked by CI? I don't understand the embassy-dev-tool, and can't figure out where (if anywhere) to add features that should be included in the CI run.
