### PR TITLE
embassy-net: change IP address info to `info` log level

### DIFF
--- a/embassy-net/src/lib.rs
+++ b/embassy-net/src/lib.rs
@@ -787,15 +787,15 @@ impl Inner {
 
         #[cfg(feature = "proto-ipv4")]
         if let Some(config) = &self.static_v4 {
-            debug!("IPv4: UP");
-            debug!("   IP address:      {:?}", config.address);
-            debug!("   Default gateway: {:?}", config.gateway);
+            info!("IPv4: UP");
+            info!("   IP address:      {:?}", config.address);
+            info!("   Default gateway: {:?}", config.gateway);
 
             unwrap!(addrs.push(IpCidr::Ipv4(config.address)).ok());
             gateway_v4 = config.gateway;
             #[cfg(feature = "dns")]
             for s in &config.dns_servers {
-                debug!("   DNS server:      {:?}", s);
+                info!("   DNS server:      {:?}", s);
                 unwrap!(dns_servers.push(s.clone().into()).ok());
             }
         } else {
@@ -804,15 +804,15 @@ impl Inner {
 
         #[cfg(feature = "proto-ipv6")]
         if let Some(config) = &self.static_v6 {
-            debug!("IPv6: UP");
-            debug!("   IP address:      {:?}", config.address);
-            debug!("   Default gateway: {:?}", config.gateway);
+            info!("IPv6: UP");
+            info!("   IP address:      {:?}", config.address);
+            info!("   Default gateway: {:?}", config.gateway);
 
             unwrap!(addrs.push(IpCidr::Ipv6(config.address)).ok());
             gateway_v6 = config.gateway;
             #[cfg(feature = "dns")]
             for s in &config.dns_servers {
-                debug!("   DNS server:      {:?}", s);
+                info!("   DNS server:      {:?}", s);
                 unwrap!(dns_servers.push(s.clone().into()).ok());
             }
         } else {


### PR DESCRIPTION
The log levels used when new IP configuration is applied are inconsistent: The "DOWN" messages come at `info!`, whereas the "UP" and their details come in `debug!`.

This PR changes them all to info, for I think that's useful: Especially in testing and prototyping, the full infrastructure one would need to find their devices properly (multicast / registering / fixed-addresses) is often not set up, and users would just look at the debug output for the addresses -- even when they're not so deep in "why is it doing what it is doing" mode that they'd enable `debug` log level.

We've had this as a custom patch in Ariel OS for some time (it's the only patch left on embassy-net), but I think it's useful to have also directly in embassy, plus there's the consistency aspect.