### PR TITLE
Add embassy-boot example for RP2350

### DIFF
--- a/examples/boot/application/rp235x/.cargo/config.toml
+++ b/examples/boot/application/rp235x/.cargo/config.toml
@@ -1,0 +1,13 @@
+[unstable]
+#build-std = ["core"]
+#build-std-features = ["panic_immediate_abort"]
+
+[target.'cfg(all(target_arch = "arm", target_os = "none"))']
+runner = "probe-rs run --chip RP235x"
+# runner = "picotool load -u -v -t elf"
+
+[build]
+target = "thumbv8m.main-none-eabihf"
+
+[env]
+DEFMT_LOG = "trace"

--- a/examples/boot/application/rp235x/Cargo.toml
+++ b/examples/boot/application/rp235x/Cargo.toml
@@ -1,0 +1,42 @@
+[package]
+edition = "2024"
+name = "embassy-boot-rp235x-examples"
+version = "0.1.0"
+license = "MIT OR Apache-2.0"
+publish = false
+
+[dependencies]
+embassy-sync = { version = "0.8.0", path = "../../../../embassy-sync" }
+embassy-executor = { version = "0.10.0", path = "../../../../embassy-executor", features = ["platform-cortex-m", "executor-thread"] }
+embassy-time = { version = "0.5.1", path = "../../../../embassy-time", features = [] }
+embassy-rp = { version = "0.10.0", path = "../../../../embassy-rp", features = ["time-driver", "rp235xa"] }
+embassy-boot-rp = { version = "0.10.0", path = "../../../../embassy-boot-rp", features = [] }
+embassy-embedded-hal = { version = "0.6.0", path = "../../../../embassy-embedded-hal" }
+
+defmt = "1.0.1"
+defmt-rtt = "1.0.0"
+panic-probe = { version = "1.0.0", features = ["print-defmt"], optional = true }
+panic-reset = { version = "0.1.1", optional = true }
+embedded-hal = { version = "0.2.6" }
+
+cortex-m = { version = "0.7.6", features = ["inline-asm", "critical-section-single-core"] }
+cortex-m-rt = "0.7.0"
+embedded-storage = "0.3.1"
+
+[features]
+default = ["panic-reset"]
+debug = [
+    "embassy-rp/defmt",
+    "embassy-boot-rp/defmt",
+    "embassy-sync/defmt",
+    "panic-probe"
+]
+skip-include = []
+
+[profile.release]
+debug = true
+
+[package.metadata.embassy]
+build = [
+  { target = "thumbv8m.main-none-eabihf", features = ["skip-include"], artifact-dir = "out/examples/boot/rp235x" }
+]

--- a/examples/boot/application/rp235x/README.md
+++ b/examples/boot/application/rp235x/README.md
@@ -1,0 +1,29 @@
+# Examples using bootloader
+
+Example for Raspberry Pi Pico 2 demonstrating the bootloader. The example consists of application binaries, 'a'
+which waits for 5 seconds before flashing the 'b' binary, which blinks the LED.
+
+The 'b' binary marks the new binary (itself) as active, so the device will run the blinking program on every subsequent reset.
+When 'b' boots the first time the blinking is fast, and every reset after that it wil be slower.
+
+## Prerequisites
+
+* `cargo-binutils`
+* `cargo-flash`
+
+## Usage
+
+```
+# Flash bootloader
+cargo flash --manifest-path ../../bootloader/rp235x/Cargo.toml --release --chip RP235x
+
+# Generate binary for 'b'
+cargo objcopy --release --bin b -- -O binary b.bin
+
+# Flash `a` (which includes b.bin)
+cargo flash --release --bin a --chip RP235x
+```
+
+Depending on how you flash you might have to reset the device after, then wait as the updating process does take a couple of seconds.
+
+By default, `Cargo.toml` specifies the `rp235xa` variant, you may need to change that.

--- a/examples/boot/application/rp235x/build.rs
+++ b/examples/boot/application/rp235x/build.rs
@@ -1,0 +1,35 @@
+//! This build script copies the `memory.x` file from the crate root into
+//! a directory where the linker can always find it at build time.
+//! For many projects this is optional, as the linker always searches the
+//! project root directory -- wherever `Cargo.toml` is. However, if you
+//! are using a workspace or have a more complicated build setup, this
+//! build script becomes required. Additionally, by requesting that
+//! Cargo re-run the build script whenever `memory.x` is changed,
+//! updating `memory.x` ensures a rebuild of the application with the
+//! new memory settings.
+
+use std::env;
+use std::fs::File;
+use std::io::Write;
+use std::path::PathBuf;
+
+fn main() {
+    // Put `memory.x` in our output directory and ensure it's
+    // on the linker search path.
+    let out = &PathBuf::from(env::var_os("OUT_DIR").unwrap());
+    File::create(out.join("memory.x"))
+        .unwrap()
+        .write_all(include_bytes!("memory.x"))
+        .unwrap();
+    println!("cargo:rustc-link-search={}", out.display());
+
+    // By default, Cargo will re-run a build script whenever
+    // any file in the project changes. By specifying `memory.x`
+    // here, we ensure the build script is only re-run when
+    // `memory.x` is changed.
+    println!("cargo:rerun-if-changed=memory.x");
+
+    println!("cargo:rustc-link-arg-bins=--nmagic");
+    println!("cargo:rustc-link-arg-bins=-Tlink.x");
+    println!("cargo:rustc-link-arg-bins=-Tdefmt.x");
+}

--- a/examples/boot/application/rp235x/memory.x
+++ b/examples/boot/application/rp235x/memory.x
@@ -1,0 +1,56 @@
+MEMORY
+{
+  FLASH_ZERO       : ORIGIN = 0x10000000 , LENGTH = 0
+  /* Bootloader code that will have jumped to the start of FLASH  */
+  BOOTLOADER       : ORIGIN = 0x10000000, LENGTH = 128K
+  BOOTLOADER_STATE : ORIGIN = 0x10020000, LENGTH = 4K
+  /* The binary that will actually run */
+  FLASH            : ORIGIN = 0x10021000, LENGTH = 512K
+  /* New binary to swap in, or the previous binary to revert to if it failed.
+     Needs to be at least one page larger than FLASH  */
+  DFU              : ORIGIN = ORIGIN(FLASH) + LENGTH(FLASH), LENGTH = LENGTH(FLASH) + 4K
+  RAM   : ORIGIN = 0x20000000, LENGTH = 512K
+}
+
+SECTIONS {
+    /* ### Boot ROM info
+     *
+     * Goes after .vector_table, to keep it in the first 4K of flash
+     * where the Boot ROM (and picotool) can find it
+     */
+    .start_block : ALIGN(4)
+    {
+        __start_block_addr = .;
+        KEEP(*(.start_block));
+        KEEP(*(.boot_info));
+    } > FLASH
+
+} INSERT AFTER .vector_table;
+
+/* move .text to start /after/ the boot info */
+_stext = ADDR(.start_block) + SIZEOF(.start_block);
+
+SECTIONS {
+    /* ### Boot ROM extra info
+     *
+     * Goes after everything in our program, so it can contain a signature.
+     */
+    .end_block : ALIGN(4)
+    {
+        __end_block_addr = .;
+        KEEP(*(.end_block));
+    } > FLASH
+
+} INSERT AFTER .uninit;
+
+PROVIDE(start_to_end = __end_block_addr - __start_block_addr);
+PROVIDE(end_to_start = __start_block_addr - __end_block_addr);
+
+/* These will be read by `FirmwareUpdaterConfig::from_linkerfile_blocking`.
+   Mind the subtracted FLASH_ZERO: they are offsets in flash, not absolute addresses. */
+
+__bootloader_state_start = ORIGIN(BOOTLOADER_STATE) - ORIGIN(FLASH_ZERO);
+__bootloader_state_end = ORIGIN(BOOTLOADER_STATE) + LENGTH(BOOTLOADER_STATE) - ORIGIN(FLASH_ZERO);
+
+__bootloader_dfu_start = ORIGIN(DFU) - ORIGIN(FLASH_ZERO);
+__bootloader_dfu_end = ORIGIN(DFU) + LENGTH(DFU) - ORIGIN(FLASH_ZERO);

--- a/examples/boot/application/rp235x/src/bin/a.rs
+++ b/examples/boot/application/rp235x/src/bin/a.rs
@@ -1,0 +1,74 @@
+#![no_std]
+#![no_main]
+
+use core::cell::RefCell;
+
+use defmt_rtt as _;
+use embassy_boot_rp::*;
+use embassy_executor::Spawner;
+use embassy_rp::flash::Flash;
+use embassy_rp::gpio::{Level, Output};
+use embassy_rp::watchdog::Watchdog;
+use embassy_sync::blocking_mutex::Mutex;
+use embassy_time::{Duration, Timer};
+use embedded_storage::nor_flash::NorFlash;
+#[cfg(feature = "panic-probe")]
+use panic_probe as _;
+#[cfg(feature = "panic-reset")]
+use panic_reset as _;
+
+#[cfg(feature = "skip-include")]
+static APP_B: &[u8] = &[0, 1, 2, 3];
+#[cfg(not(feature = "skip-include"))]
+static APP_B: &[u8] = include_bytes!("../../b.bin");
+
+const FLASH_SIZE: usize = 2 * 1024 * 1024;
+const WATCHDOG_TIMEOUT: Duration = Duration::from_secs(8);
+
+#[embassy_executor::main]
+async fn main(_s: Spawner) {
+    let p = embassy_rp::init(Default::default());
+    let mut led = Output::new(p.PIN_25, Level::Low);
+
+    // The bootloader set up a watchdog, so take it over
+    let mut watchdog = Watchdog::new(p.WATCHDOG);
+    watchdog.start(WATCHDOG_TIMEOUT);
+
+    let flash = Flash::<_, _, FLASH_SIZE>::new_blocking(p.FLASH);
+    let flash = Mutex::new(RefCell::new(flash));
+
+    let config = FirmwareUpdaterConfig::from_linkerfile_blocking(&flash, &flash);
+    let mut aligned = AlignedBuffer([0; 1]);
+    let mut updater = BlockingFirmwareUpdater::new(config, &mut aligned.0);
+
+    Timer::after_secs(5).await;
+    watchdog.feed(WATCHDOG_TIMEOUT);
+    led.set_high();
+    let mut offset = 0;
+    let mut buf: AlignedBuffer<4096> = AlignedBuffer([0; 4096]);
+    defmt::info!("preparing update");
+
+    // This call can take a while for large flash areas.
+    // If the watchdog triggers before it's done (boot loop), increase the timeout or use WatchdogFlash.
+    let writer = updater
+        .prepare_update()
+        .map_err(|e| defmt::warn!("E: {:?}", defmt::Debug2Format(&e)))
+        .unwrap();
+    defmt::info!("writer created, starting write");
+    watchdog.feed(WATCHDOG_TIMEOUT);
+    for chunk in APP_B.chunks(4096) {
+        buf.0[..chunk.len()].copy_from_slice(chunk);
+        defmt::info!("writing block at offset {}", offset);
+        writer.write(offset, &buf.0[..chunk.len()]).unwrap();
+        offset += chunk.len() as u32;
+    }
+    watchdog.feed(WATCHDOG_TIMEOUT);
+    defmt::info!("firmware written, marking update");
+
+    // Set flag for the bootloader, then reboot
+    updater.mark_updated().unwrap();
+    Timer::after_secs(2).await;
+    led.set_low();
+    defmt::info!("update marked, resetting");
+    cortex_m::peripheral::SCB::sys_reset();
+}

--- a/examples/boot/application/rp235x/src/bin/b.rs
+++ b/examples/boot/application/rp235x/src/bin/b.rs
@@ -1,0 +1,49 @@
+#![no_std]
+#![no_main]
+
+use core::cell::RefCell;
+
+use embassy_boot_rp::{AlignedBuffer, BlockingFirmwareUpdater, FirmwareUpdaterConfig, State};
+use embassy_executor::Spawner;
+use embassy_rp::flash::{self, Flash};
+use embassy_rp::gpio;
+use embassy_rp::watchdog::Watchdog;
+use embassy_sync::blocking_mutex::Mutex;
+use embassy_time::Timer;
+use gpio::{Level, Output};
+use {defmt_rtt as _, panic_reset as _};
+
+const FLASH_SIZE: usize = 2 * 1024 * 1024;
+
+#[embassy_executor::main]
+async fn main(_s: Spawner) {
+    let p = embassy_rp::init(Default::default());
+
+    let mut watchdog = Watchdog::new(p.WATCHDOG);
+    watchdog.stop();
+
+    let flash = Flash::<_, _, FLASH_SIZE>::new_blocking(p.FLASH);
+    let flash = Mutex::new(RefCell::new(flash));
+
+    let config = FirmwareUpdaterConfig::from_linkerfile_blocking(&flash, &flash);
+    let mut aligned = AlignedBuffer([0; flash::WRITE_SIZE]);
+    let mut updater = BlockingFirmwareUpdater::new(config, &mut aligned.0);
+    let blink = if let Ok(State::Boot) = updater.get_state() {
+        // Not the first time booting this binary
+        500
+    } else {
+        // Binary was just updated
+        100
+    };
+    updater.mark_booted().unwrap();
+
+    let mut led = Output::new(p.PIN_25, Level::Low);
+
+    loop {
+        led.set_high();
+        Timer::after_millis(blink).await;
+
+        led.set_low();
+        Timer::after_millis(100).await;
+    }
+}

--- a/examples/boot/bootloader/rp235x/.cargo/config.toml
+++ b/examples/boot/bootloader/rp235x/.cargo/config.toml
@@ -1,0 +1,9 @@
+[target.'cfg(all(target_arch = "arm", target_os = "none"))']
+# runner = "picotool load -u -v -t elf"
+runner = "probe-rs run --chip RP235x"
+
+[build]
+target = "thumbv8m.main-none-eabihf"
+
+[env]
+DEFMT_LOG = "trace"

--- a/examples/boot/bootloader/rp235x/Cargo.toml
+++ b/examples/boot/bootloader/rp235x/Cargo.toml
@@ -1,0 +1,39 @@
+[package]
+edition = "2024"
+name = "rp235x-bootloader-example"
+version = "0.1.0"
+description = "Example bootloader for RP235x chips"
+license = "MIT OR Apache-2.0"
+publish = false
+
+[dependencies]
+defmt = { version = "1.0.1", optional = true }
+defmt-rtt = { version = "1.0.0", optional = true }
+
+embassy-rp = { path = "../../../../embassy-rp", features = ["rp235xa"] }
+embassy-boot-rp = { path = "../../../../embassy-boot-rp" }
+embassy-sync = { version = "0.8.0", path = "../../../../embassy-sync" }
+embassy-time = { path = "../../../../embassy-time", features = [] }
+
+cortex-m = { version = "0.7.6", features = ["inline-asm", "critical-section-single-core"] }
+cortex-m-rt = { version = "0.7" }
+embedded-storage = "0.3.1"
+embedded-storage-async = "0.4.0"
+cfg-if = "1.0.0"
+
+[features]
+defmt = [
+    "dep:defmt",
+    "dep:defmt-rtt",
+    "embassy-boot-rp/defmt",
+    "embassy-rp/defmt",
+]
+
+[profile.release]
+debug = true
+opt-level = 's'
+
+[package.metadata.embassy]
+build = [
+  { target = "thumbv8m.main-none-eabihf" }
+]

--- a/examples/boot/bootloader/rp235x/README.md
+++ b/examples/boot/bootloader/rp235x/README.md
@@ -1,0 +1,13 @@
+# Bootloader for RP235x
+
+The bootloader uses `embassy-boot` to interact with the flash.
+
+# Usage
+
+Flashing the bootloader either with `cargo run -r` (see "runner" `.cargo/config.toml`), or:
+
+```
+cargo flash --release --chip RP235x
+```
+
+By default, `Cargo.toml` specifies the `rp235xa` variant, you may need to change that.

--- a/examples/boot/bootloader/rp235x/build.rs
+++ b/examples/boot/bootloader/rp235x/build.rs
@@ -1,0 +1,27 @@
+use std::env;
+use std::fs::File;
+use std::io::Write;
+use std::path::PathBuf;
+
+fn main() {
+    // Put `memory.x` in our output directory and ensure it's
+    // on the linker search path.
+    let out = &PathBuf::from(env::var_os("OUT_DIR").unwrap());
+    File::create(out.join("memory.x"))
+        .unwrap()
+        .write_all(include_bytes!("memory.x"))
+        .unwrap();
+    println!("cargo:rustc-link-search={}", out.display());
+
+    // By default, Cargo will re-run a build script whenever
+    // any file in the project changes. By specifying `memory.x`
+    // here, we ensure the build script is only re-run when
+    // `memory.x` is changed.
+    println!("cargo:rerun-if-changed=memory.x");
+
+    println!("cargo:rustc-link-arg-bins=--nmagic");
+    println!("cargo:rustc-link-arg-bins=-Tlink.x");
+    if env::var("CARGO_FEATURE_DEFMT").is_ok() {
+        println!("cargo:rustc-link-arg-bins=-Tdefmt.x");
+    }
+}

--- a/examples/boot/bootloader/rp235x/memory.x
+++ b/examples/boot/bootloader/rp235x/memory.x
@@ -1,0 +1,57 @@
+MEMORY {
+  /* Bootloader code */
+  FLASH            : ORIGIN = 0x10000000, LENGTH = 128K
+  BOOTLOADER_STATE : ORIGIN = 0x10020000, LENGTH = 4K
+  /* The binary that will be booted to  */
+  ACTIVE           : ORIGIN = 0x10021000, LENGTH = 512K
+  /* New binary to swap in, or the previous binary to revert to if it failed.
+     Needs to be at least one page larger than ACTIVE  */
+  DFU              : ORIGIN = ORIGIN(ACTIVE) + LENGTH(ACTIVE), LENGTH = LENGTH(ACTIVE) + 4K
+  RAM : ORIGIN = 0x20000000, LENGTH = 512K
+}
+
+SECTIONS {
+    /* ### Boot ROM info
+     *
+     * Goes after .vector_table, to keep it in the first 4K of flash
+     * where the Boot ROM (and picotool) can find it
+     */
+    .start_block : ALIGN(4)
+    {
+        __start_block_addr = .;
+        KEEP(*(.start_block));
+        KEEP(*(.boot_info));
+    } > FLASH
+
+} INSERT AFTER .vector_table;
+
+_stext = ADDR(.start_block) + SIZEOF(.start_block);
+
+SECTIONS {
+    /* ### Boot ROM extra info
+     *
+     * Goes after everything in our program, so it can contain a signature.
+     */
+    .end_block : ALIGN(4)
+    {
+        __end_block_addr = .;
+        KEEP(*(.end_block));
+    } > FLASH
+
+} INSERT AFTER .uninit;
+
+
+PROVIDE(start_to_end = __end_block_addr - __start_block_addr);
+PROVIDE(end_to_start = __start_block_addr - __end_block_addr);
+
+/* These will be read by `FirmwareUpdaterConfig::from_linkerfile_blocking`.
+   Mind the subtracted FLASH base: they are offsets in flash, not absolute addresses. */
+
+__bootloader_state_start = ORIGIN(BOOTLOADER_STATE) - ORIGIN(FLASH);
+__bootloader_state_end = ORIGIN(BOOTLOADER_STATE) + LENGTH(BOOTLOADER_STATE) - ORIGIN(FLASH);
+
+__bootloader_active_start = ORIGIN(ACTIVE) - ORIGIN(FLASH);
+__bootloader_active_end = ORIGIN(ACTIVE) + LENGTH(ACTIVE) - ORIGIN(FLASH);
+
+__bootloader_dfu_start = ORIGIN(DFU) - ORIGIN(FLASH);
+__bootloader_dfu_end = ORIGIN(DFU) + LENGTH(DFU) - ORIGIN(FLASH);

--- a/examples/boot/bootloader/rp235x/src/main.rs
+++ b/examples/boot/bootloader/rp235x/src/main.rs
@@ -1,0 +1,54 @@
+#![no_std]
+#![no_main]
+
+use core::cell::RefCell;
+
+use cortex_m_rt::{entry, exception};
+#[cfg(feature = "defmt")]
+use defmt_rtt as _;
+use embassy_boot_rp::*;
+use embassy_sync::blocking_mutex::Mutex;
+use embassy_time::Duration;
+
+const FLASH_SIZE: usize = 2 * 1024 * 1024;
+
+#[entry]
+fn main() -> ! {
+    let p = embassy_rp::init(Default::default());
+
+    // Uncomment this if you are debugging the bootloader with debugger/RTT attached,
+    // as it prevents a hard fault when accessing flash 'too early' after boot.
+    /*
+    for i in 0..10000000 {
+        cortex_m::asm::nop();
+    }
+    */
+
+    let flash = WatchdogFlash::<FLASH_SIZE>::start(p.FLASH, p.WATCHDOG, Duration::from_secs(8));
+    let flash = Mutex::new(RefCell::new(flash));
+
+    let config = BootLoaderConfig::from_linkerfile_blocking(&flash, &flash, &flash);
+    let active_offset = config.active.offset();
+    let bl: BootLoader = BootLoader::prepare(config);
+
+    unsafe { bl.load(embassy_rp::flash::FLASH_BASE as u32 + active_offset) }
+}
+
+#[unsafe(no_mangle)]
+#[cfg_attr(target_os = "none", unsafe(link_section = ".HardFault.user"))]
+unsafe extern "C" fn HardFault() {
+    cortex_m::peripheral::SCB::sys_reset();
+}
+
+#[exception]
+unsafe fn DefaultHandler(_: i16) -> ! {
+    const SCB_ICSR: *const u32 = 0xE000_ED04 as *const u32;
+    let irqn = unsafe { core::ptr::read_volatile(SCB_ICSR) } as u8 as i16 - 16;
+
+    panic!("DefaultHandler #{:?}", irqn);
+}
+
+#[panic_handler]
+fn panic(_info: &core::panic::PanicInfo) -> ! {
+    cortex_m::asm::udf();
+}


### PR DESCRIPTION
What it says on the tin basically^^

The linker scripts are the main difference from the 2040 version since there's not boot2, the rest is similar.