### PR TITLE
embassy-boot-rp: Allow splitting WatchdogFlash back into components

### DIFF
--- a/embassy-boot-rp/src/lib.rs
+++ b/embassy-boot-rp/src/lib.rs
@@ -81,6 +81,11 @@ impl<'d, const SIZE: usize> WatchdogFlash<'d, SIZE> {
             timeout,
         }
     }
+
+    /// Split back into separate flash and watchdog.
+    pub fn split(self) -> (Flash<'d, FLASH, Blocking, SIZE>, Watchdog) {
+        (self.flash, self.watchdog)
+    }
 }
 
 impl<'d, const SIZE: usize> ErrorType for WatchdogFlash<'d, SIZE> {


### PR DESCRIPTION
Previously it was awkward to eg, stop the watchdog after long running flash operations are done because you can not get it back out of a `WatchdogFlash`.