### PR TITLE
fix name collision

### DIFF
--- a/examples/qemu-virt-riscv64/Cargo.toml
+++ b/examples/qemu-virt-riscv64/Cargo.toml
@@ -24,6 +24,6 @@ panic = "abort"
 
 [package.metadata.embassy]
 build = [
-  { target = "riscv64imac-unknown-none-elf", artifact-dir = "out/examples/qemu-virt-riscv64" },
-  { target = "riscv64gc-unknown-none-elf",   artifact-dir = "out/examples/qemu-virt-riscv64" },
+  { target = "riscv64imac-unknown-none-elf", artifact-dir = "out/examples/qemu-virt-riscv64imac" },
+  { target = "riscv64gc-unknown-none-elf",   artifact-dir = "out/examples/qemu-virt-riscv64gc" },
 ]


### PR DESCRIPTION
fix this

The bin target `hello` in package `embassy-qemu-virt-riscv64-examples v0.1.0 (/ci/code/examples/qemu-virt-riscv64)` has the same output filename as the bin target `hello` in package `embassy-qemu-virt-riscv64-examples v0.1.0 (/ci/code/examples/qemu-virt-riscv64)`.
Colliding filename is: /ci/code/out/examples/qemu-virt-riscv64/hello
The exported filenames should be unique.
Consider changing their names to be unique or compiling them separately.
This may become a hard error in the future; see <https://github.com/rust-lang/cargo/issues/6313>.
warning: `--artifact-dir` filename collision.
The bin target `hello` in package `embassy-qemu-virt-riscv64-examples v0.1.0 (/ci/code/examples/qemu-virt-riscv64)` has the same output filename as the bin target `hello` in package `embassy-qemu-virt-riscv64-examples v0.1.0 (/ci/code/examples/qemu-virt-riscv64)`.
Colliding filename is: /ci/code/out/examples/qemu-virt-riscv64/hello.dwp