### PR TITLE
stm32: update stm32-metapac to stm32-data-c94b8266d45caab8c3be8d9e6bbf7db8911d99c0

### DIFF
--- a/embassy-stm32/Cargo.toml
+++ b/embassy-stm32/Cargo.toml
@@ -210,11 +210,11 @@ heapless = "0.9.1"
 once_cell = { version = "1.21.4", default-features = false, features=["critical-section"] }
 
 # stm32-metapac = { version = "21" }
-stm32-metapac = { git = "https://github.com/embassy-rs/stm32-data-generated", tag = "stm32-data-7deeeef3bafb319dee1b79d5ba03812220bf514f" }
+stm32-metapac = { git = "https://github.com/embassy-rs/stm32-data-generated", tag = "stm32-data-c94b8266d45caab8c3be8d9e6bbf7db8911d99c0" }
 
 [build-dependencies]
 # stm32-metapac = { version = "21", default-features = false, features = ["metadata"]}
-stm32-metapac = { git = "https://github.com/embassy-rs/stm32-data-generated", tag = "stm32-data-7deeeef3bafb319dee1b79d5ba03812220bf514f", default-features = false, features = ["metadata"] }
+stm32-metapac = { git = "https://github.com/embassy-rs/stm32-data-generated", tag = "stm32-data-c94b8266d45caab8c3be8d9e6bbf7db8911d99c0", default-features = false, features = ["metadata"] }
 
 proc-macro2 = "1.0.36"
 quote = "1.0.15"


### PR DESCRIPTION
## Summary
Update `stm32-metapac` (runtime + build-dep) in `embassy-stm32` to the latest generated data:

- Old: `stm32-data-7deeeef3bafb319dee1b79d5ba03812220bf514f`
- New: `stm32-data-c94b8266d45caab8c3be8d9e6bbf7db8911d99c0`

(from https://github.com/embassy-rs/stm32-data-generated)

## Motivation
Pick up the most recent chip support, register layouts, and fixes produced by the stm32-data pipeline.

## Verification (what CI would run for this change)
- `cargo embassy-devtool check-manifest` + `check-crlf`
- Multiple `cargo check` / `cargo batch` runs (with `RUSTFLAGS=-Dwarnings` + `CARGO_NET_GIT_FETCH_WITH_CLI=true`) exercising the `[package.metadata.embassy]` build matrix: many STM32 families (F0/F1/F3/F4, G0/G4, H5/H7 + dual-core + split pins, L0-L5, U0/U5, C0, WB/WBA, N6, ...) + feature combinations (time drivers, exti, low-power, banks, defmt, executors, chrono, usb-host, etc.).
- Exact unit test commands from `.github/ci/test.sh` for `embassy-stm32` (stm32f429vg / f732ze / f769ni variants with the `test` feature) → all pass.
- Path-dependent crates (`examples/stm32f4`, `examples/stm32wba`, `embassy-stm32-wpan`, ...) build with their documented targets and `-Dwarnings`.
- No other source changes; `Cargo.lock` files under `embassy-stm32/` (and examples) are gitignored and managed by CI caching.

All the compile + test surface that feeds the rest of CI (including HIL) is clean.