### PR TITLE
ControlPipe: Add provided methods that handle chunking

### DIFF
--- a/embassy-usb-driver/CHANGELOG.md
+++ b/embassy-usb-driver/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 <!-- next-header -->
 ## Unreleased - ReleaseDate
 
+- Add `ControlPipe::data_out_transfer()` and `ControlPipe::data_in_transfer()` provided methods.
+
 ## 0.2.2 - 2026-05-28
 
 - **Un-breaking change**: Re-add embedded-io-async 0.6.1 support.

--- a/embassy-usb-driver/src/lib.rs
+++ b/embassy-usb-driver/src/lib.rs
@@ -367,10 +367,46 @@ pub trait ControlPipe {
     /// and `length` greater than zero.
     async fn data_out(&mut self, buf: &mut [u8], first: bool, last: bool) -> Result<usize, EndpointError>;
 
+    /// Read a DATA OUT packet into `buf` in response to a control write request.
+    ///
+    /// Must be called after `setup()` for requests with `direction` of `Out`
+    /// and request length greater than zero.
+    ///
+    /// `buf` must be **at most** as large as the request length.
+    async fn data_out_transfer(&mut self, buf: &mut [u8]) -> Result<usize, EndpointError> {
+        let mut total = 0;
+
+        let req_len = buf.len();
+
+        let chunks = buf.chunks_mut(self.max_packet_size());
+        for (first, last, chunk) in first_last(chunks) {
+            let size = self.data_out(chunk, first, last).await?;
+            total += size;
+            if size < self.max_packet_size() || total == req_len {
+                break;
+            }
+        }
+
+        Ok(total)
+    }
+
     /// Send a DATA IN packet with `data` in response to a control read request.
     ///
-    /// If `last_packet` is true, the STATUS packet will be ACKed following the transfer of `data`.
+    /// If `last` is true, the STATUS packet will be ACKed following the transfer of `data`.
     async fn data_in(&mut self, data: &[u8], first: bool, last: bool) -> Result<(), EndpointError>;
+
+    /// Send a number of DATA IN packets with `data` in response to a control read request.
+    async fn data_in_transfer(&mut self, data: &[u8], needs_zlp: bool) -> Result<(), EndpointError> {
+        let chunks = data
+            .chunks(self.max_packet_size())
+            .chain(needs_zlp.then(|| -> &[u8] { &[] }));
+
+        for (first, last, chunk) in first_last(chunks) {
+            self.data_in(chunk, first, last).await?;
+        }
+
+        Ok(())
+    }
 
     /// Accept a control request.
     ///
@@ -387,6 +423,18 @@ pub trait ControlPipe {
     /// For most drivers this function should firstly call `accept()` and then change the bus address.
     /// However, there are peripherals (Synopsys USB OTG) that have reverse order.
     async fn accept_set_address(&mut self, addr: u8);
+}
+
+fn first_last<T: Iterator>(iter: T) -> impl Iterator<Item = (bool, bool, T::Item)> {
+    let mut iter = iter.peekable();
+    let mut first = true;
+    core::iter::from_fn(move || {
+        let val = iter.next()?;
+        let is_first = first;
+        first = false;
+        let is_last = iter.peek().is_none();
+        Some((is_first, is_last, val))
+    })
 }
 
 /// IN Endpoint trait.

--- a/embassy-usb/src/lib.rs
+++ b/embassy-usb/src/lib.rs
@@ -397,20 +397,10 @@ impl<'d, D: Driver<'d>> UsbDevice<'d, D> {
         match self.inner.handle_control_in(req, self.control_buf) {
             InResponse::Accepted(data) => {
                 let len = data.len().min(resp_length);
-                let need_zlp = len != resp_length && (len % max_packet_size) == 0;
+                let needs_zlp = len != resp_length && (len % max_packet_size) == 0;
 
-                let chunks = data[0..len]
-                    .chunks(max_packet_size)
-                    .chain(need_zlp.then(|| -> &[u8] { &[] }));
-
-                for (first, last, chunk) in first_last(chunks) {
-                    match self.control.data_in(chunk, first, last).await {
-                        Ok(()) => {}
-                        Err(e) => {
-                            warn!("control accept_in failed: {:?}", e);
-                            return;
-                        }
-                    }
+                if let Err(e) = self.control.data_in_transfer(&data[0..len], needs_zlp).await {
+                    warn!("control accept_in failed: {:?}", e);
                 }
             }
             InResponse::Rejected => self.control.reject().await,
@@ -419,8 +409,6 @@ impl<'d, D: Driver<'d>> UsbDevice<'d, D> {
 
     async fn handle_control_out(&mut self, req: Request) {
         let req_length = req.length as usize;
-        let max_packet_size = self.control.max_packet_size();
-        let mut total = 0;
 
         if req_length > self.control_buf.len() {
             warn!(
@@ -432,20 +420,17 @@ impl<'d, D: Driver<'d>> UsbDevice<'d, D> {
             return;
         }
 
-        let chunks = self.control_buf[..req_length].chunks_mut(max_packet_size);
-        for (first, last, chunk) in first_last(chunks) {
-            let size = match self.control.data_out(chunk, first, last).await {
-                Ok(x) => x,
-                Err(e) => {
-                    warn!("usb: failed to read CONTROL OUT data stage: {:?}", e);
-                    return;
-                }
-            };
-            total += size;
-            if size < max_packet_size || total == req_length {
-                break;
+        let total = match self
+            .control
+            .data_out_transfer(&mut self.control_buf[..req_length])
+            .await
+        {
+            Ok(total) => total,
+            Err(e) => {
+                warn!("usb: failed to receive CONTROL OUT data stage: {:?}", e);
+                return;
             }
-        }
+        };
 
         let data = &self.control_buf[0..total];
         #[cfg(feature = "defmt")]
@@ -804,16 +789,4 @@ impl<'d, D: Driver<'d>> Inner<'d, D> {
             _ => InResponse::Rejected,
         }
     }
-}
-
-fn first_last<T: Iterator>(iter: T) -> impl Iterator<Item = (bool, bool, T::Item)> {
-    let mut iter = iter.peekable();
-    let mut first = true;
-    core::iter::from_fn(move || {
-        let val = iter.next()?;
-        let is_first = first;
-        first = false;
-        let is_last = iter.peek().is_none();
-        Some((is_first, is_last, val))
-    })
 }


### PR DESCRIPTION
Similar in spirit to #4613, we can let the driver do the chunking fo control requests, too, if the driver can do better.

I think this closes #2753