### PR TITLE
Fix read_transfer, use transfer methods in embassy-usb

### DIFF
--- a/embassy-usb-driver/CHANGELOG.md
+++ b/embassy-usb-driver/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 <!-- next-header -->
 ## Unreleased - ReleaseDate
 
+- Fixed: `EndpointOut::read_transfer()` now returns when the buffer is full.
+
 ## 0.2.2 - 2026-05-28
 
 - **Un-breaking change**: Re-add embedded-io-async 0.6.1 support.

--- a/embassy-usb-driver/src/lib.rs
+++ b/embassy-usb-driver/src/lib.rs
@@ -275,7 +275,7 @@ pub trait EndpointOut: Endpoint {
         loop {
             let i = self.read(&mut buf[n..]).await?;
             n += i;
-            if i < self.info().max_packet_size as usize {
+            if i < self.info().max_packet_size as usize || n == buf.len() {
                 return Ok(n);
             }
         }

--- a/embassy-usb/src/class/cdc_ncm/mod.rs
+++ b/embassy-usb/src/class/cdc_ncm/mod.rs
@@ -416,14 +416,7 @@ impl<'d, D: Driver<'d>> Sender<'d, D> {
             buf[OUT_HEADER_LEN..self.max_packet_size].copy_from_slice(d1);
             self.write_ep.write(&buf[..self.max_packet_size]).await?;
 
-            for chunk in d2.chunks(self.max_packet_size) {
-                self.write_ep.write(chunk).await?;
-            }
-
-            // Send ZLP if needed.
-            if d2.len() % self.max_packet_size == 0 {
-                self.write_ep.write(&[]).await?;
-            }
+            self.write_ep.write_transfer(d2, true).await?;
         }
 
         Ok(())
@@ -448,14 +441,7 @@ impl<'d, D: Driver<'d>> Receiver<'d, D> {
         loop {
             // read NTB
             let mut ntb = [0u8; NTB_MAX_SIZE];
-            let mut pos = 0;
-            loop {
-                let n = self.read_ep.read(&mut ntb[pos..]).await?;
-                pos += n;
-                if n < self.read_ep.info().max_packet_size as usize || pos == NTB_MAX_SIZE {
-                    break;
-                }
-            }
+            let pos = self.read_ep.read_transfer(&mut ntb).await?;
 
             let ntb = &ntb[..pos];
 

--- a/embassy-usb/src/class/cmsis_dap_v2.rs
+++ b/embassy-usb/src/class/cmsis_dap_v2.rs
@@ -40,7 +40,6 @@ pub struct CmsisDapV2Class<'d, D: Driver<'d>> {
     read_ep: D::EndpointOut,
     write_ep: D::EndpointIn,
     trace_ep: Option<D::EndpointIn>,
-    max_packet_size: u16,
 }
 
 impl<'d, D: Driver<'d>> CmsisDapV2Class<'d, D> {
@@ -76,7 +75,6 @@ impl<'d, D: Driver<'d>> CmsisDapV2Class<'d, D> {
             read_ep,
             write_ep,
             trace_ep,
-            max_packet_size,
         }
     }
 
@@ -87,13 +85,7 @@ impl<'d, D: Driver<'d>> CmsisDapV2Class<'d, D> {
 
     /// Write data to the host.
     pub async fn write_packet(&mut self, data: &[u8]) -> Result<(), EndpointError> {
-        for chunk in data.chunks(self.max_packet_size as usize) {
-            self.write_ep.write(chunk).await?;
-        }
-        if data.len() % self.max_packet_size as usize == 0 {
-            self.write_ep.write(&[]).await?;
-        }
-        Ok(())
+        self.write_ep.write_transfer(data, true).await
     }
 
     /// Write data to the host via the trace output endpoint.
@@ -103,26 +95,11 @@ impl<'d, D: Driver<'d>> CmsisDapV2Class<'d, D> {
         let Some(ep) = self.trace_ep.as_mut() else {
             return Err(EndpointError::Disabled);
         };
-
-        for chunk in data.chunks(self.max_packet_size as usize) {
-            ep.write(chunk).await?;
-        }
-        if data.len() % self.max_packet_size as usize == 0 {
-            ep.write(&[]).await?;
-        }
-        Ok(())
+        ep.write_transfer(data, true).await
     }
 
     /// Read data from the host.
     pub async fn read_packet(&mut self, data: &mut [u8]) -> Result<usize, EndpointError> {
-        let mut n = 0;
-
-        loop {
-            let i = self.read_ep.read(&mut data[n..]).await?;
-            n += i;
-            if i < self.max_packet_size as usize {
-                return Ok(n);
-            }
-        }
+        self.read_ep.read_transfer(data).await
     }
 }

--- a/embassy-usb/src/class/hid.rs
+++ b/embassy-usb/src/class/hid.rs
@@ -334,18 +334,7 @@ impl<'d, D: Driver<'d>, const N: usize> HidWriter<'d, D, N> {
     /// Writes `report` to its interrupt endpoint.
     pub async fn write(&mut self, report: &[u8]) -> Result<(), EndpointError> {
         assert!(report.len() <= N);
-
-        let max_packet_size = usize::from(self.ep_in.info().max_packet_size);
-        let zlp_needed = report.len() < N && (report.len() % max_packet_size == 0);
-        for chunk in report.chunks(max_packet_size) {
-            self.ep_in.write(chunk).await?;
-        }
-
-        if zlp_needed {
-            self.ep_in.write(&[]).await?;
-        }
-
-        Ok(())
+        self.ep_in.write_transfer(report, report.len() < N).await
     }
 }
 


### PR DESCRIPTION
This PR actually uses the new methods introduced in #4613 unless single-packet semantics are actually wanted, or something prevents a naive update (HidReader::read)