### PR TITLE
rp/gpio: make Flex::is_set_as_output public

### DIFF
--- a/embassy-rp/src/gpio.rs
+++ b/embassy-rp/src/gpio.rs
@@ -698,9 +698,9 @@ impl<'d> Flex<'d> {
         self.pin.sio_oe().value_set().write_value(self.bit())
     }
 
-    /// Set as output pin.
+    /// Is the pin in output mode?
     #[inline]
-    fn is_set_as_output(&self) -> bool {
+    pub fn is_set_as_output(&self) -> bool {
         (self.pin.sio_oe().value().read() & self.bit()) != 0
     }
 


### PR DESCRIPTION
This status is useful for Flex pins, indirectly exposed by `toggle_set_as_output`, and the doc comment was wrong so it looks like this was unintentionally private.