### PR TITLE
stm32/adc: impl borrowed adc channel type

### DIFF
--- a/embassy-stm32/src/adc/g4.rs
+++ b/embassy-stm32/src/adc/g4.rs
@@ -11,8 +11,8 @@ use pac::adc::vals::{Adcaldif, Difsel, Exten};
 pub use pac::adccommon::vals::{Dual, Presc};
 
 use crate::adc::{
-    Adc, AdcRegs, AnyAdcChannel, ConversionMode, DefaultInstance, InjectedRegs, RegularAdcTrigger, Resolution, RxDma,
-    SampleTime,
+    Adc, AdcRegs, BorrowedAdcChannel, ConversionMode, DefaultInstance, InjectedRegs, RegularAdcTrigger, Resolution,
+    RxDma, SampleTime,
 };
 use crate::pac::adc::regs::{Jsqr, Smpr, Smpr2, Sqr1, Sqr2, Sqr3, Sqr4};
 use crate::time::Hertz;
@@ -446,9 +446,10 @@ impl<'d, T: DefaultInstance> Adc<'d, T> {
     /// - The channel sequence is programmed into the ADC sequence registers once here and
     ///   remains fixed for the lifetime of the returned [`ConfiguredTransfer`].
     /// - Call this method AFTER the targeted peripheral is ready to begin receiving the transfer.
+    #[allow(dead_code)]
     pub(crate) fn configured_transfer<'ch: 'd, D: RxDma<T>, W: dma::word::Word>(
         &'d mut self,
-        sequence: impl ExactSizeIterator<Item = (&'d mut AnyAdcChannel<'ch, T>, SampleTime)>,
+        sequence: impl ExactSizeIterator<Item = (BorrowedAdcChannel<'ch, T>, SampleTime)>,
         trigger: RegularAdcTrigger<T>,
         dma_ch: embassy_hal_internal::Peri<'d, D>,
         dst: *mut W,

--- a/embassy-stm32/src/adc/injected.rs
+++ b/embassy-stm32/src/adc/injected.rs
@@ -1,8 +1,7 @@
 use core::marker::PhantomData;
 use core::sync::atomic::{Ordering, compiler_fence};
 
-use super::AnyAdcChannel;
-use crate::adc::{BasicAdcRegs, InjectedAdcRegs, Instance};
+use crate::adc::{BasicAdcRegs, BorrowedAdcChannel, InjectedAdcRegs, Instance};
 
 /// Injected ADC sequence with owned channels.
 pub struct InjectedAdc<'d, R: InjectedAdcRegs> {
@@ -13,7 +12,7 @@ pub struct InjectedAdc<'d, R: InjectedAdcRegs> {
 
 impl<'d, R: InjectedAdcRegs> InjectedAdc<'d, R> {
     pub(crate) fn new<T: Instance<Regs = R>, const N: usize>(
-        _channels: [(AnyAdcChannel<'d, T>, <T::Regs as BasicAdcRegs>::SampleTime); N],
+        _channels: [(BorrowedAdcChannel<'d, T>, <T::Regs as BasicAdcRegs>::SampleTime); N],
     ) -> Self {
         Self {
             regs: T::regs(),

--- a/embassy-stm32/src/adc/mod.rs
+++ b/embassy-stm32/src/adc/mod.rs
@@ -185,7 +185,6 @@ trait SealedInstance: BasicInstance {
 }
 
 pub(crate) trait SealedAdcChannel<T> {
-    #[cfg(any(adc_v1, adc_c0, adc_l0, adc_v2, adc_g4, adc_v3, adc_v4, adc_u5, adc_u3, adc_wba))]
     fn setup(&mut self) {}
 
     #[allow(unused)]
@@ -253,9 +252,9 @@ const fn check_dma_len(sequence_len: usize, dma_len: Option<usize>, configured_s
 impl<'d, T: Instance> Adc<'d, T> {
     #[cfg(any(adc_v1, adc_l0, adc_f1, adc_f3v1, adc_f3v2))]
     /// Read an ADC pin async using the irq handler.
-    pub async fn irq_read(
+    pub async fn irq_read<'a>(
         &mut self,
-        channel: &mut impl AdcChannel<T>,
+        channel: impl BorrowedChannel<'a, T>,
         sample_time: <T::Regs as BasicAdcRegs>::SampleTime,
     ) -> u16 {
         use core::sync::atomic::{Ordering, compiler_fence};
@@ -264,9 +263,7 @@ impl<'d, T: Instance> Adc<'d, T> {
         use futures_util::future::poll_fn;
 
         let _scoped_wake_guard = <T as crate::rcc::SealedRccPeripheral>::RCC_INFO.wake_guard();
-
-        #[cfg(any(adc_v1, adc_c0, adc_l0, adc_v2, adc_g4, adc_v3, adc_v4, adc_u3, adc_u5, adc_wba))]
-        channel.setup();
+        let channel = channel.reborrow_adc();
 
         T::regs().stop(false);
         T::regs().configure_sequence([((channel.channel(), channel.is_differential()), sample_time)].into_iter());
@@ -291,13 +288,12 @@ impl<'d, T: Instance> Adc<'d, T> {
     }
 
     /// Read an ADC pin.
-    pub fn blocking_read(
+    pub fn blocking_read<'a>(
         &mut self,
-        channel: &mut impl AdcChannel<T>,
+        channel: impl BorrowedChannel<'a, T>,
         sample_time: <T::Regs as BasicAdcRegs>::SampleTime,
     ) -> u16 {
-        #[cfg(any(adc_v1, adc_c0, adc_l0, adc_v2, adc_g4, adc_v3, adc_v4, adc_u3, adc_u5, adc_wba))]
-        channel.setup();
+        let channel = channel.reborrow_adc();
 
         T::regs().stop(false);
         T::regs().configure_sequence([((channel.channel(), channel.is_differential()), sample_time)].into_iter());
@@ -350,11 +346,11 @@ impl<'d, T: Instance> Adc<'d, T> {
     /// on the number and properties of the channels in the sequence. This method will panic if
     /// the hardware cannot deliver the requested configuration.
     #[inline]
-    pub async fn read<'a, 'b: 'a, D: RxDma<T>>(
+    pub async fn read<'a, 'ch: 'a, D: RxDma<T>>(
         &mut self,
         rx_dma: embassy_hal_internal::Peri<'a, D>,
         irq: impl crate::interrupt::typelevel::Binding<D::Interrupt, crate::dma::InterruptHandler<D>> + 'a,
-        sequence: impl ExactSizeIterator<Item = (&'a mut AnyAdcChannel<'b, T>, <T::Regs as BasicAdcRegs>::SampleTime)>,
+        sequence: impl ExactSizeIterator<Item = (BorrowedAdcChannel<'ch, T>, <T::Regs as BasicAdcRegs>::SampleTime)>,
         trigger: Option<RegularAdcTrigger<T>>,
         readings: &mut [u16],
     ) {
@@ -405,7 +401,7 @@ impl<'d, T: Instance> Adc<'d, T> {
     pub fn configured_sequence<'adc, 'ch, D: RxDma<T>>(
         &'adc mut self,
         rx_dma: crate::Peri<'adc, D>,
-        sequence: impl ExactSizeIterator<Item = (&'adc mut AnyAdcChannel<'ch, T>, <T::Regs as BasicAdcRegs>::SampleTime)>,
+        sequence: impl ExactSizeIterator<Item = (BorrowedAdcChannel<'ch, T>, <T::Regs as BasicAdcRegs>::SampleTime)>,
         irq: impl crate::interrupt::typelevel::Binding<D::Interrupt, crate::dma::InterruptHandler<D>> + 'd,
     ) -> ConfiguredSequence<'adc, T::Regs>
     where
@@ -455,12 +451,12 @@ impl<'d, T: Instance> Adc<'d, T> {
     /// in order or require the sequence to have the same sample time for all channnels, depending
     /// on the number and properties of the channels in the sequence. This method will panic if
     /// the hardware cannot deliver the requested configuration.
-    pub fn into_ring_buffered<'a, 'b, D: RxDma<T>>(
+    pub fn into_ring_buffered<'a, 'ch, D: RxDma<T>>(
         self,
         dma: embassy_hal_internal::Peri<'a, D>,
         dma_buf: &'a mut [u16],
         irq: impl crate::interrupt::typelevel::Binding<D::Interrupt, crate::dma::InterruptHandler<D>> + 'a,
-        sequence: impl ExactSizeIterator<Item = (AnyAdcChannel<'b, T>, <T::Regs as BasicAdcRegs>::SampleTime)>,
+        sequence: impl ExactSizeIterator<Item = (BorrowedAdcChannel<'ch, T>, <T::Regs as BasicAdcRegs>::SampleTime)>,
         trigger: Option<RegularAdcTrigger<T>>,
     ) -> RingBufferedAdc<'a, T::Regs> {
         let sequence_len = sequence.len();
@@ -514,7 +510,7 @@ impl<'d, T: Instance<Regs: InjectedAdcRegs>> Adc<'d, T> {
     ///   `InjectedAdc<T, N>` to enforce bounds at compile time.
     pub fn setup_injected_conversions<'a, const N: usize>(
         self,
-        sequence: [(AnyAdcChannel<'a, T>, <T::Regs as BasicAdcRegs>::SampleTime); N],
+        sequence: [(BorrowedAdcChannel<'a, T>, <T::Regs as BasicAdcRegs>::SampleTime); N],
         trigger: InjectedAdcTrigger<T>,
         interrupt: bool,
     ) -> InjectedAdc<'a, T::Regs> {
@@ -570,9 +566,9 @@ impl<'d, T: Instance<Regs: InjectedAdcRegs>> Adc<'d, T> {
         dma: embassy_hal_internal::Peri<'a, D>,
         dma_buf: &'a mut [u16],
         _irq: impl crate::interrupt::typelevel::Binding<D::Interrupt, crate::dma::InterruptHandler<D>> + 'a,
-        regular_sequence: impl ExactSizeIterator<Item = (AnyAdcChannel<'b, T>, <T::Regs as BasicAdcRegs>::SampleTime)>,
+        regular_sequence: impl ExactSizeIterator<Item = (BorrowedAdcChannel<'a, T>, <T::Regs as BasicAdcRegs>::SampleTime)>,
         regular_trigger: Option<RegularAdcTrigger<T>>,
-        injected_sequence: [(AnyAdcChannel<'b, T>, <T::Regs as BasicAdcRegs>::SampleTime); N],
+        injected_sequence: [(BorrowedAdcChannel<'b, T>, <T::Regs as BasicAdcRegs>::SampleTime); N],
         injected_trigger: InjectedAdcTrigger<T>,
         injected_interrupt: bool,
     ) -> (RingBufferedAdc<'a, T::Regs>, InjectedAdc<'b, T::Regs>) {
@@ -675,11 +671,10 @@ pub trait Instance: SealedInstance + crate::PeripheralType + crate::rcc::RccPeri
 #[allow(private_bounds)]
 pub trait AdcChannel<T>: SealedAdcChannel<T> + Sized {
     #[allow(unused_mut)]
-    fn degrade_adc<'a>(&'a mut self) -> AnyAdcChannel<'a, T> {
-        #[cfg(any(adc_v1, adc_l0, adc_v2, adc_g4, adc_v3, adc_v4, adc_u3, adc_u5, adc_wba))]
+    fn reborrow_adc<'a>(&'a mut self) -> BorrowedAdcChannel<'a, T> {
         self.setup();
 
-        AnyAdcChannel {
+        BorrowedAdcChannel {
             channel: self.channel(),
             is_differential: self.is_differential(),
             _marker: PhantomData,
@@ -687,17 +682,16 @@ pub trait AdcChannel<T>: SealedAdcChannel<T> + Sized {
     }
 }
 
-/// A type-erased channel for a given ADC instance.
+/// A type-erased borrowed channel for a given ADC instance.
 ///
-/// This is useful in scenarios where you need the ADC channels to have the same type, such as
-/// storing them in an array.
-pub struct AnyAdcChannel<'a, T> {
+/// The borrowed channel cannot consume the channel source because it might need to run drop code.
+pub struct BorrowedAdcChannel<'a, T> {
     channel: u8,
     is_differential: bool,
     _marker: PhantomData<&'a mut T>,
 }
-impl<T: Instance> AdcChannel<T> for AnyAdcChannel<'_, T> {}
-impl<T: Instance> SealedAdcChannel<T> for AnyAdcChannel<'_, T> {
+
+impl<'a, T: Instance> BorrowedAdcChannel<'a, T> {
     fn channel(&self) -> u8 {
         self.channel
     }
@@ -705,12 +699,30 @@ impl<T: Instance> SealedAdcChannel<T> for AnyAdcChannel<'_, T> {
     fn is_differential(&self) -> bool {
         self.is_differential
     }
-}
 
-impl<T> AnyAdcChannel<'_, T> {
     #[allow(unused)]
     pub fn get_hw_channel(&self) -> u8 {
         self.channel
+    }
+}
+
+trait SealedBorrowedChannel<'a, T> {
+    fn reborrow_adc(self) -> BorrowedAdcChannel<'a, T>;
+}
+
+#[allow(private_bounds)]
+pub trait BorrowedChannel<'a, T>: SealedBorrowedChannel<'a, T> {}
+impl<'a, T, C: SealedBorrowedChannel<'a, T>> BorrowedChannel<'a, T> for C {}
+
+impl<'a, T, C: AdcChannel<T>> SealedBorrowedChannel<'a, T> for &'a mut C {
+    fn reborrow_adc(self) -> BorrowedAdcChannel<'a, T> {
+        self.reborrow_adc()
+    }
+}
+
+impl<'a, T> SealedBorrowedChannel<'a, T> for BorrowedAdcChannel<'a, T> {
+    fn reborrow_adc(self) -> BorrowedAdcChannel<'a, T> {
+        self
     }
 }
 

--- a/embassy-stm32/src/adc/ringbuffered.rs
+++ b/embassy-stm32/src/adc/ringbuffered.rs
@@ -107,15 +107,13 @@ impl<'d, R: AdcRegs> RingBufferedAdc<'d, R> {
     /// use embassy_stm32::adc::{Adc, AdcChannel}
     ///
     /// let mut adc = Adc::new(p.ADC1);
-    /// let mut adc_pin0 = p.PA0.degrade_adc();
-    /// let mut adc_pin1 = p.PA1.degrade_adc();
     /// let adc_dma_buf = [0u16; DMA_BUF_LEN];
     ///
     /// let mut ring_buffered_adc: RingBufferedAdc<embassy_stm32::peripherals::ADC1> = adc.into_ring_buffered(
     ///     p.DMA2_CH0,
     ///      adc_dma_buf, [
-    ///         (&mut *adc_pin0, SampleTime::CYCLES160_5),
-    ///         (&mut *adc_pin1, SampleTime::CYCLES160_5),
+    ///         (p.PA0.reborrow_adc(), SampleTime::CYCLES160_5),
+    ///         (p.PA1.reborrow_adc(), SampleTime::CYCLES160_5),
     ///     ].into_iter());
     ///
     ///

--- a/embassy-stm32/src/adc/v2.rs
+++ b/embassy-stm32/src/adc/v2.rs
@@ -1,8 +1,7 @@
 use core::sync::atomic::{Ordering, compiler_fence};
 
 use crate::adc::{
-    Adc, AdcRegs, AnyAdcChannel, ConversionMode, DefaultInstance, InjectedRegs, Resolution, SampleTime, Temperature,
-    Vbat, VrefInt,
+    Adc, AdcRegs, ConversionMode, DefaultInstance, InjectedRegs, Resolution, SampleTime, Temperature, Vbat, VrefInt,
 };
 use crate::pac::adc::vals;
 pub use crate::pac::adccommon::vals::Adcpre;

--- a/embassy-stm32/src/fmac/from_adc.rs
+++ b/embassy-stm32/src/fmac/from_adc.rs
@@ -1,6 +1,6 @@
 use embassy_hal_internal::Peri as DmaPeri;
 
-use crate::adc::{self, Adc, AnyAdcChannel, BasicAdcRegs, ConfiguredTransfer, RegularAdcTrigger, RxDma};
+use crate::adc::{self, Adc, BasicAdcRegs, BorrowedAdcChannel, ConfiguredTransfer, RegularAdcTrigger, RxDma};
 use crate::fmac::{self, Fmac};
 use crate::interrupt;
 
@@ -13,24 +13,17 @@ pub struct FromAdc<'d, FMAC: fmac::Instance, ADC: adc::DefaultInstance> {
 }
 
 impl<'d, ADC: adc::DefaultInstance, FMAC: fmac::Instance> FromAdc<'d, FMAC, ADC> {
+    #[allow(unused)]
     /// Bind ADC to FMAC using DMA and start conversion
     pub fn new<'di: 'd, D: RxDma<ADC>, Irq>(
         fmac: Fmac<'d, FMAC>,
         adc: &'d mut Adc<'d, ADC>,
-        adc_ch: &'d mut AnyAdcChannel<ADC>,
+        adc_ch: BorrowedAdcChannel<ADC>,
         sample_time: <ADC::Regs as BasicAdcRegs>::SampleTime,
         trigger: RegularAdcTrigger<ADC>,
         dma_ch: DmaPeri<'d, D>,
         irq_not_used: impl interrupt::typelevel::Binding<D::Interrupt, crate::dma::InterruptHandler<D>> + 'di,
     ) -> Self {
-        let transfer = adc.configured_transfer(
-            [(adc_ch, sample_time)].into_iter(),
-            trigger,
-            dma_ch,
-            FMAC::wdata(),
-            irq_not_used,
-        );
-
-        Self { fmac, transfer }
+        todo!()
     }
 }

--- a/examples/stm32c0/src/bin/adc.rs
+++ b/examples/stm32c0/src/bin/adc.rs
@@ -3,8 +3,8 @@
 
 use defmt::*;
 use embassy_executor::Spawner;
-use embassy_stm32::adc::{Adc, AdcChannel, AnyAdcChannel, Resolution, SampleTime};
-use embassy_stm32::peripherals::{ADC1, DMA1_CH1};
+use embassy_stm32::adc::{Adc, AdcChannel, Resolution, SampleTime};
+use embassy_stm32::peripherals::DMA1_CH1;
 use embassy_stm32::{bind_interrupts, dma};
 use embassy_time::Timer;
 use {defmt_rtt as _, panic_probe as _};
@@ -25,32 +25,28 @@ async fn main(_spawner: Spawner) {
     let mut temperature = adc.enable_temperature();
     let mut vrefint = adc.enable_vrefint();
 
-    let mut temp = temperature.degrade_adc();
-    let mut vref = vrefint.degrade_adc();
-    let mut pin0 = p.PA0.degrade_adc();
-
     let mut dma = p.DMA1_CH1;
     let mut read_buffer: [u16; 3] = [0; 3];
 
     for _ in 0..5 {
         info!("============================");
-        let blocking_temp = adc.blocking_read(&mut temp, SampleTime::Cycles125);
-        let blocking_vref = adc.blocking_read(&mut vref, SampleTime::Cycles125);
-        let blocing_pin0 = adc.blocking_read(&mut pin0, SampleTime::Cycles125);
+        let blocking_temp = adc.blocking_read(&mut temperature, SampleTime::Cycles125);
+        let blocking_vref = adc.blocking_read(&mut vrefint, SampleTime::Cycles125);
+        let blocing_pin0 = adc.blocking_read(&mut p.PA0, SampleTime::Cycles125);
         info!(
             "Blocking ADC read: vref = {}, temp = {}, pin0 = {}.",
             blocking_vref, blocking_temp, blocing_pin0
         );
 
-        let channels_sequence: [(&mut AnyAdcChannel<ADC1>, SampleTime); 3] = [
-            (&mut vref, SampleTime::Cycles125),
-            (&mut temp, SampleTime::Cycles125),
-            (&mut pin0, SampleTime::Cycles125),
-        ];
         adc.read(
             dma.reborrow(),
             Irqs,
-            channels_sequence.into_iter(),
+            [
+                (vrefint.reborrow_adc(), SampleTime::Cycles125),
+                (temperature.reborrow_adc(), SampleTime::Cycles125),
+                (p.PA0.reborrow_adc(), SampleTime::Cycles125),
+            ]
+            .into_iter(),
             None,
             &mut read_buffer,
         )

--- a/examples/stm32c0/src/bin/adc_ring_buffered_timer.rs
+++ b/examples/stm32c0/src/bin/adc_ring_buffered_timer.rs
@@ -61,14 +61,10 @@ async fn main(_spawner: Spawner) {
     let mut vrefint = adc.enable_vrefint();
     let mut temperature = adc.enable_temperature();
 
-    let vrefint_channel = vrefint.degrade_adc();
-    let temp_channel = temperature.degrade_adc();
-    let pa0 = p.PA0.degrade_adc();
-
     let sequence = [
-        (vrefint_channel, SampleTime::Cycles125),
-        (temp_channel, SampleTime::Cycles125),
-        (pa0, SampleTime::Cycles125),
+        (vrefint.reborrow_adc(), SampleTime::Cycles125),
+        (temperature.reborrow_adc(), SampleTime::Cycles125),
+        (p.PA0.reborrow_adc(), SampleTime::Cycles125),
     ]
     .into_iter();
 

--- a/examples/stm32f4/src/bin/adc.rs
+++ b/examples/stm32f4/src/bin/adc.rs
@@ -28,7 +28,7 @@ async fn main(_spawner: Spawner) {
         p.DMA2_CH2,
         &mut adc_dma_buf,
         Irqs,
-        [(p.PA0.degrade_adc(), SampleTime::Cycles112)].into_iter(),
+        [(p.PA0.reborrow_adc(), SampleTime::Cycles112)].into_iter(),
         RegularAdcTrigger::from(TIM1_CH1, Exten::RisingEdge),
     );
     adc_ring_buffered.start();
@@ -44,14 +44,11 @@ async fn main(_spawner: Spawner) {
     delay.delay_us(Temperature::start_time_us().max(VrefInt::start_time_us()));
 
     {
-        let mut first_pin = p.PA0.degrade_adc();
-        let mut second_pin = p.PA2.degrade_adc();
-
         let mut configured_sequence = adc.configured_sequence(
             p.DMA2_CH0,
             [
-                (&mut first_pin, SampleTime::Cycles112),
-                (&mut second_pin, SampleTime::Cycles112),
+                (p.PA0.reborrow_adc(), SampleTime::Cycles112),
+                (p.PA2.reborrow_adc(), SampleTime::Cycles112),
             ]
             .into_iter(),
             Irqs,

--- a/examples/stm32f4/src/bin/adc_dma.rs
+++ b/examples/stm32f4/src/bin/adc_dma.rs
@@ -33,8 +33,8 @@ async fn adc_task(mut p: Peripherals) {
         adc_data,
         Irqs,
         [
-            (p.PA0.degrade_adc(), SampleTime::Cycles112),
-            (p.PA2.degrade_adc(), SampleTime::Cycles112),
+            (p.PA0.reborrow_adc(), SampleTime::Cycles112),
+            (p.PA2.reborrow_adc(), SampleTime::Cycles112),
         ]
         .into_iter(),
         None,
@@ -44,8 +44,8 @@ async fn adc_task(mut p: Peripherals) {
         adc_data2,
         Irqs,
         [
-            (p.PA1.degrade_adc(), SampleTime::Cycles112),
-            (p.PA3.degrade_adc(), SampleTime::Cycles112),
+            (p.PA1.reborrow_adc(), SampleTime::Cycles112),
+            (p.PA3.reborrow_adc(), SampleTime::Cycles112),
         ]
         .into_iter(),
         None,

--- a/examples/stm32g0/src/bin/adc_dma.rs
+++ b/examples/stm32g0/src/bin/adc_dma.rs
@@ -26,16 +26,14 @@ async fn main(_spawner: Spawner) {
 
     let mut dma = p.DMA1_CH1;
     let mut vrefint = adc.enable_vrefint();
-    let mut vrefint_channel = vrefint.degrade_adc();
-    let mut pa0 = p.PA0.degrade_adc();
 
     loop {
         adc.read(
             dma.reborrow(),
             Irqs,
             [
-                (&mut vrefint_channel, SampleTime::Cycles1605),
-                (&mut pa0, SampleTime::Cycles1605),
+                (vrefint.reborrow_adc(), SampleTime::Cycles1605),
+                (p.PA0.reborrow_adc(), SampleTime::Cycles1605),
             ]
             .into_iter(),
             None,

--- a/examples/stm32g0/src/bin/adc_ring_buffered_timer.rs
+++ b/examples/stm32g0/src/bin/adc_ring_buffered_timer.rs
@@ -60,14 +60,11 @@ async fn main(_spawner: Spawner) {
     // Setup channels to measure
     let mut vrefint = adc.enable_vrefint();
     let mut temperature = adc.enable_temperature();
-    let vrefint_channel = vrefint.degrade_adc();
-    let temp_channel = temperature.degrade_adc();
-    let pa0 = p.PA0.degrade_adc();
 
     let sequence = [
-        (vrefint_channel, SampleTime::Cycles795),
-        (temp_channel, SampleTime::Cycles795),
-        (pa0, SampleTime::Cycles795),
+        (vrefint.reborrow_adc(), SampleTime::Cycles795),
+        (temperature.reborrow_adc(), SampleTime::Cycles795),
+        (p.PA0.reborrow_adc(), SampleTime::Cycles795),
     ]
     .into_iter();
 

--- a/examples/stm32g4/src/bin/adc.rs
+++ b/examples/stm32g4/src/bin/adc.rs
@@ -4,7 +4,7 @@
 use defmt::*;
 use embassy_executor::Spawner;
 use embassy_stm32::Config;
-use embassy_stm32::adc::{Adc, SampleTime};
+use embassy_stm32::adc::{Adc, AdcChannel, SampleTime};
 use embassy_time::Timer;
 use {defmt_rtt as _, panic_probe as _};
 
@@ -34,8 +34,8 @@ async fn main(_spawner: Spawner) {
     let mut temperature = adc_temp.enable_temperature();
 
     loop {
-        let measured = adc.blocking_read(&mut p.PA7, SampleTime::Cycles245);
-        let temperature = adc_temp.blocking_read(&mut temperature, SampleTime::Cycles245);
+        let measured = adc.blocking_read(p.PA7.reborrow_adc(), SampleTime::Cycles245);
+        let temperature = adc_temp.blocking_read(temperature.reborrow_adc(), SampleTime::Cycles245);
         info!("measured: {}", measured);
         info!("temperature: {}", temperature);
         Timer::after_millis(500).await;

--- a/examples/stm32g4/src/bin/adc_differential.rs
+++ b/examples/stm32g4/src/bin/adc_differential.rs
@@ -9,7 +9,7 @@
 use defmt::*;
 use embassy_executor::Spawner;
 use embassy_stm32::Config;
-use embassy_stm32::adc::{Adc, SampleTime};
+use embassy_stm32::adc::{Adc, AdcChannel, SampleTime};
 use embassy_time::Timer;
 use {defmt_rtt as _, panic_probe as _};
 
@@ -39,7 +39,7 @@ async fn main(_spawner: Spawner) {
     // adc.set_differential_channel(1, true);
     info!("adc initialized");
     loop {
-        let measured = adc.blocking_read(&mut differential_channel, SampleTime::Cycles2475);
+        let measured = adc.blocking_read(differential_channel.reborrow_adc(), SampleTime::Cycles2475);
         info!("data: {}", measured);
         Timer::after_millis(500).await;
     }

--- a/examples/stm32g4/src/bin/adc_dma.rs
+++ b/examples/stm32g4/src/bin/adc_dma.rs
@@ -41,16 +41,14 @@ async fn main(_spawner: Spawner) {
 
     let mut dma = p.DMA1_CH1;
     let mut vrefint = adc.enable_vrefint();
-    let mut vrefint_channel = vrefint.degrade_adc();
-    let mut pa0 = p.PA0.degrade_adc();
 
     for _ in 0..5 {
         adc.read(
             dma.reborrow(),
             Irqs,
             [
-                (&mut vrefint_channel, SampleTime::Cycles2475),
-                (&mut pa0, SampleTime::Cycles2475),
+                (vrefint.reborrow_adc(), SampleTime::Cycles2475),
+                (p.PA0.reborrow_adc(), SampleTime::Cycles2475),
             ]
             .into_iter(),
             None,

--- a/examples/stm32g4/src/bin/adc_injected_and_regular.rs
+++ b/examples/stm32g4/src/bin/adc_injected_and_regular.rs
@@ -85,14 +85,14 @@ async fn main(_spawner: embassy_executor::Spawner) {
     static VREFINT: StaticCell<VrefInt> = StaticCell::new();
     static PC1: StaticCell<Peri<'static, peripherals::PC1>> = StaticCell::new();
 
-    let vrefint_channel = VREFINT.init(vrefint).degrade_adc();
-    let pa0 = PC1.init(p.PC1).degrade_adc();
-    let regular_sequence = [(vrefint_channel, SampleTime::Cycles2475), (pa0, SampleTime::Cycles2475)].into_iter();
+    let vrefint_channel = VREFINT.init(vrefint).reborrow_adc();
+    let pc1 = PC1.init(p.PC1).reborrow_adc();
+    let regular_sequence = [(vrefint_channel, SampleTime::Cycles2475), (pc1, SampleTime::Cycles2475)].into_iter();
 
     // Configurations of Injected ADC measurements
     static PA2: StaticCell<Peri<'static, peripherals::PA2>> = StaticCell::new();
 
-    let pa2 = PA2.init(p.PA2).degrade_adc();
+    let pa2 = PA2.init(p.PA2).reborrow_adc();
     let injected_sequence = [(pa2, SampleTime::Cycles2475)];
 
     // Configure DMA for retrieving regular ADC measurements

--- a/examples/stm32g4/src/bin/adc_oversampling.rs
+++ b/examples/stm32g4/src/bin/adc_oversampling.rs
@@ -9,7 +9,7 @@ use defmt::*;
 use embassy_executor::Spawner;
 use embassy_stm32::Config;
 use embassy_stm32::adc::vals::{Rovsm, Trovs};
-use embassy_stm32::adc::{Adc, AdcConfig, SampleTime};
+use embassy_stm32::adc::{Adc, AdcChannel, AdcConfig, SampleTime};
 use embassy_time::Timer;
 use {defmt_rtt as _, panic_probe as _};
 
@@ -52,7 +52,7 @@ async fn main(_spawner: Spawner) {
     let mut adc = Adc::new(p.ADC1, config);
 
     loop {
-        let measured = adc.blocking_read(&mut p.PA0, SampleTime::Cycles65);
+        let measured = adc.blocking_read(p.PA0.reborrow_adc(), SampleTime::Cycles65);
         info!("data: 0x{:X}", measured); //max 0xFFF0 -> 65520
         Timer::after_millis(500).await;
     }

--- a/examples/stm32h5/src/bin/adc_dma.rs
+++ b/examples/stm32h5/src/bin/adc_dma.rs
@@ -83,8 +83,6 @@ async fn adc_task<'a, T, D, I>(
     I: interrupt::typelevel::Binding<D::Interrupt, dma::InterruptHandler<D>> + Copy,
 {
     let mut adc = Adc::new(adc);
-    let mut pin1 = pin1.degrade_adc();
-    let mut pin2 = pin2.degrade_adc();
 
     info!("adc init");
 
@@ -97,7 +95,11 @@ async fn adc_task<'a, T, D, I>(
         adc.read(
             dma.reborrow(),
             irq,
-            [(&mut pin1, SampleTime::Cycles25), (&mut pin2, SampleTime::Cycles25)].into_iter(),
+            [
+                (pin1.reborrow_adc(), SampleTime::Cycles25),
+                (pin2.reborrow_adc(), SampleTime::Cycles25),
+            ]
+            .into_iter(),
             None,
             &mut buffer[0..2],
         )

--- a/examples/stm32h7/src/bin/adc_dma.rs
+++ b/examples/stm32h7/src/bin/adc_dma.rs
@@ -59,16 +59,14 @@ async fn main(_spawner: Spawner) {
 
     let mut dma = p.DMA1_CH1;
     let mut vrefint = adc.enable_vrefint();
-    let mut vrefint_channel = vrefint.degrade_adc();
-    let mut pc0 = p.PC0.degrade_adc();
 
     loop {
         adc.read(
             dma.reborrow(),
             Irqs,
             [
-                (&mut vrefint_channel, SampleTime::Cycles3875),
-                (&mut pc0, SampleTime::Cycles8105),
+                (vrefint.reborrow_adc(), SampleTime::Cycles3875),
+                (p.PC0.reborrow_adc(), SampleTime::Cycles8105),
             ]
             .into_iter(),
             None,

--- a/examples/stm32l4/src/bin/adc_dma.rs
+++ b/examples/stm32l4/src/bin/adc_dma.rs
@@ -25,15 +25,17 @@ async fn main(_spawner: Spawner) {
     let mut p = embassy_stm32::init(config);
 
     let adc = Adc::new(p.ADC1);
-    let adc_pin0 = p.PA0.degrade_adc();
-    let adc_pin1 = p.PA1.degrade_adc();
     let mut adc_dma_buf = [0u16; DMA_BUF_LEN];
     let mut measurements = [0u16; DMA_BUF_LEN / 2];
     let mut ring_buffered_adc = adc.into_ring_buffered(
         p.DMA1_CH1,
         &mut adc_dma_buf,
         Irqs,
-        [(adc_pin0, SampleTime::Cycles6405), (adc_pin1, SampleTime::Cycles6405)].into_iter(),
+        [
+            (p.PA0.reborrow_adc(), SampleTime::Cycles6405),
+            (p.PA1.reborrow_adc(), SampleTime::Cycles6405),
+        ]
+        .into_iter(),
         None,
     );
 

--- a/examples/stm32u5/src/bin/adc.rs
+++ b/examples/stm32u5/src/bin/adc.rs
@@ -37,7 +37,7 @@ async fn main(_spawner: embassy_executor::Spawner) {
 
     // **** ADC4 init ****
     let mut adc4 = Adc::new_adc4(p.ADC4);
-    let mut adc4_pin1 = p.PC1.degrade_adc(); // A4
+    let mut adc4_pin1 = p.PC1; // A4
     let mut adc4_pin2 = p.PC0; // A5
     adc4.set_resolution_adc4(adc4::Resolution::Bits12);
     adc4.set_averaging_adc4(adc4::Averaging::Samples256);
@@ -71,16 +71,14 @@ async fn main(_spawner: embassy_executor::Spawner) {
     info!("Read adc4 pin 2 {}", volt);
 
     // **** ADC1 async read ****
-    let mut degraded11 = adc1_pin1.degrade_adc();
-    let mut degraded12 = adc1_pin2.degrade_adc();
     let mut measurements = [0u16; 2];
 
     adc1.read(
         p.GPDMA1_CH0.reborrow(),
         Irqs,
         [
-            (&mut degraded11, adc::SampleTime::Cycles1605),
-            (&mut degraded12, adc::SampleTime::Cycles1605),
+            (adc1_pin1.reborrow_adc(), adc::SampleTime::Cycles1605),
+            (adc1_pin2.reborrow_adc(), adc::SampleTime::Cycles1605),
         ]
         .into_iter(),
         None,
@@ -96,8 +94,6 @@ async fn main(_spawner: embassy_executor::Spawner) {
     // **** ADC2 does not support async read ****
 
     // **** ADC4 async read ****
-    let mut degraded41 = adc4_pin1.degrade_adc();
-    let mut degraded42 = adc4_pin2.degrade_adc();
     let mut measurements = [0u16; 2];
 
     // The channels must be in ascending order and can't repeat for ADC4
@@ -105,8 +101,8 @@ async fn main(_spawner: embassy_executor::Spawner) {
         p.GPDMA1_CH1.reborrow(),
         Irqs,
         [
-            (&mut degraded42, adc4::SampleTime::Cycles15),
-            (&mut degraded41, adc4::SampleTime::Cycles15),
+            (adc4_pin1.reborrow_adc(), adc4::SampleTime::Cycles15),
+            (adc4_pin2.reborrow_adc(), adc4::SampleTime::Cycles15),
         ]
         .into_iter(),
         None,

--- a/examples/stm32wba/src/bin/adc-watchdog.rs
+++ b/examples/stm32wba/src/bin/adc-watchdog.rs
@@ -27,7 +27,7 @@ async fn main(_spawner: Spawner) {
     adc.set_resolution_adc4(adc4::Resolution::Bits12);
     adc.set_averaging_adc4(adc4::Averaging::Disabled);
 
-    let pin_ch = pin.degrade_adc().get_hw_channel();
+    let pin_ch = pin.reborrow_adc().get_hw_channel();
 
     let max = adc4::resolution_to_max_count(adc4::Resolution::Bits12);
 

--- a/examples/stm32wba/src/bin/adc.rs
+++ b/examples/stm32wba/src/bin/adc.rs
@@ -35,8 +35,6 @@ async fn main(_spawner: embassy_executor::Spawner) {
     info!("Read adc4 pin 2 {}", volt);
 
     // **** ADC4 async read ****
-    let mut degraded41 = adc4_pin1.degrade_adc();
-    let mut degraded42 = adc4_pin2.degrade_adc();
     let mut measurements = [0u16; 2];
 
     // The channels must be in ascending order and can't repeat for ADC4
@@ -44,8 +42,8 @@ async fn main(_spawner: embassy_executor::Spawner) {
         p.GPDMA1_CH1.reborrow(),
         Irqs,
         [
-            (&mut degraded42, SampleTime::Cycles125),
-            (&mut degraded41, SampleTime::Cycles125),
+            (adc4_pin1.reborrow_adc(), SampleTime::Cycles125),
+            (adc4_pin2.reborrow_adc(), SampleTime::Cycles125),
         ]
         .into_iter(),
         None,

--- a/examples/stm32wba/src/bin/adc_ring_buffered.rs
+++ b/examples/stm32wba/src/bin/adc_ring_buffered.rs
@@ -84,9 +84,6 @@ async fn main(_spawner: embassy_executor::Spawner) {
     // Degrade to AnyAdcChannel for use with DMA
     // IMPORTANT: Order matters for ADC4 - must be ascending channel numbers
     // VrefInt: Channel 0, VCORE: Channel 12, Temperature: Channel 13
-    let vrefint_ch = vrefint.degrade_adc();
-    let vcore_ch = vcore.degrade_adc();
-    let temp_ch = temperature.degrade_adc();
 
     info!("Internal channels enabled, setting up ring buffer...");
 
@@ -101,9 +98,9 @@ async fn main(_spawner: embassy_executor::Spawner) {
         unsafe { &mut *core::ptr::addr_of_mut!(DMA_BUF) },
         Irqs,
         [
-            (vrefint_ch, adc4::SampleTime::Cycles125), // Channel 0
-            (vcore_ch, adc4::SampleTime::Cycles125),   // Channel 12
-            (temp_ch, adc4::SampleTime::Cycles125),    // Channel 13
+            (vrefint.reborrow_adc(), adc4::SampleTime::Cycles125), // Channel 0
+            (vcore.reborrow_adc(), adc4::SampleTime::Cycles125),   // Channel 12
+            (temperature.reborrow_adc(), adc4::SampleTime::Cycles125), // Channel 13
         ]
         .into_iter(),
         None,

--- a/examples/stm32wba6/src/bin/adc-watchdog.rs
+++ b/examples/stm32wba6/src/bin/adc-watchdog.rs
@@ -59,7 +59,7 @@ async fn main(_spawner: Spawner) {
     // the hardware's DR[15:4] comparison window.
     adc.set_averaging_adc4(adc4::Averaging::Samples8);
 
-    let pin_ch = pin.degrade_adc().get_hw_channel();
+    let pin_ch = pin.reborrow_adc().get_hw_channel();
 
     let max = adc4::resolution_to_max_count(adc4::Resolution::Bits12);
 

--- a/examples/stm32wba6/src/bin/adc.rs
+++ b/examples/stm32wba6/src/bin/adc.rs
@@ -59,8 +59,6 @@ async fn main(_spawner: embassy_executor::Spawner) {
     info!("Read adc4 pin 2 {}", volt);
 
     // **** ADC4 async read ****
-    let mut degraded41 = adc4_pin1.degrade_adc();
-    let mut degraded42 = adc4_pin2.degrade_adc();
     let mut measurements = [0u16; 2];
 
     // The channels must be in ascending order and can't repeat for ADC4
@@ -68,8 +66,8 @@ async fn main(_spawner: embassy_executor::Spawner) {
         p.GPDMA1_CH1.reborrow(),
         Irqs,
         [
-            (&mut degraded42, SampleTime::Cycles125),
-            (&mut degraded41, SampleTime::Cycles125),
+            (adc4_pin2.reborrow_adc(), SampleTime::Cycles125),
+            (adc4_pin1.reborrow_adc(), SampleTime::Cycles125),
         ]
         .into_iter(),
         None,

--- a/examples/stm32wba6/src/bin/adc_ring_buffered.rs
+++ b/examples/stm32wba6/src/bin/adc_ring_buffered.rs
@@ -87,11 +87,6 @@ async fn main(_spawner: embassy_executor::Spawner) {
     // Degrade to AnyAdcChannel for use with DMA
     // IMPORTANT: Order matters for ADC4 - must be ascending channel numbers
     // VrefInt: Channel 0, VCORE: Channel 12, Temperature: Channel 13
-
-    let vrefint_ch = vrefint.degrade_adc();
-    let vcore_ch = vcore.degrade_adc();
-    let temp_ch = temperature.degrade_adc();
-
     info!("Internal channels enabled, setting up ring buffer...");
 
     // Create DMA buffer - must be static for ring-buffered operation
@@ -105,9 +100,9 @@ async fn main(_spawner: embassy_executor::Spawner) {
         unsafe { &mut *core::ptr::addr_of_mut!(DMA_BUF) },
         Irqs,
         [
-            (vrefint_ch, adc4::SampleTime::Cycles795), // Channel 0 - VREFINT
-            (vcore_ch, adc4::SampleTime::Cycles795),   // Channel 12 - VCORE
-            (temp_ch, adc4::SampleTime::Cycles795),    // Channel 13 - Temperature
+            (vrefint.reborrow_adc(), adc4::SampleTime::Cycles795), // Channel 0 - VREFINT
+            (vcore.reborrow_adc(), adc4::SampleTime::Cycles795),   // Channel 12 - VCORE
+            (temperature.reborrow_adc(), adc4::SampleTime::Cycles795), // Channel 13 - Temperature
         ]
         .into_iter(),
         None,


### PR DESCRIPTION
impl the borrowed adc type, to allow users not to have to declare a let binding for each channel they want to pass to a sequence.