### PR TITLE
[MCXA] add irq trace option

### DIFF
--- a/embassy-mcxa/Cargo.toml
+++ b/embassy-mcxa/Cargo.toml
@@ -147,6 +147,9 @@ rt = []
 # Enable perf counters
 perf = []
 
+# Enable irq tracing
+trace = []
+
 # Enable the custom executor platform implementation, which allows for low-power modes.
 #
 # If this feature is enabled, users should NOT enable `embassy-executor/platform-cortex-m` or any other executor platform.

--- a/embassy-mcxa/src/i3c/target.rs
+++ b/embassy-mcxa/src/i3c/target.rs
@@ -22,10 +22,9 @@ use crate::dma::{Channel, DmaChannel, DmaRequest, TransferOptions};
 use crate::gpio::{AnyPin, SealedPin};
 use crate::interrupt::typelevel;
 use crate::interrupt::typelevel::Interrupt;
-use crate::pac::i3c::Sstatus;
 use crate::pac::i3c::{
-    Evdet, Ibidis, Mstena, SctrlEvent, SdatactrlTxtrig, SdmactrlDmafb, SdmactrlDmatb, SdmactrlDmawidth, SstatusStart,
-    SstatusTxnotfull, Stnotstop, Streqrd, Type,
+    Evdet, Ibidis, Mstena, SctrlEvent, SdatactrlTxtrig, SdmactrlDmafb, SdmactrlDmatb, SdmactrlDmawidth, Sstatus,
+    SstatusStart, SstatusTxnotfull, Stnotstop, Streqrd, Type,
 };
 
 /// Setup Errors
@@ -464,7 +463,6 @@ impl<'d> I3c<'d> {
 
         Ok(())
     }
-
 }
 
 impl<'d> I3c<'d> {
@@ -1245,9 +1243,7 @@ impl<T: Instance> typelevel::Handler<T::Interrupt> for InterruptHandler<T> {
         // so the next transaction-end fires us again. `wait_for_end_of_chain`
         // and friends rely on the level-triggered `STNOTSTOP` instead of
         // the latched STOP and remain correct.
-        let pre = bbq
-            .state
-            .fetch_and(!STATE_RXDMA_COMPLETE, Ordering::AcqRel);
+        let pre = bbq.state.fetch_and(!STATE_RXDMA_COMPLETE, Ordering::AcqRel);
         let rx_present = (pre & STATE_RXDMA_PRESENT) != 0;
         let dma_complete = (pre & STATE_RXDMA_COMPLETE) != 0;
         let stop_fired = s_status.stop();
@@ -1498,8 +1494,7 @@ impl BbqState {
 
         // Publish INITED + RXDMA_PRESENT *before* opening the first
         // grant so that start_read_transfer sees the right state.
-        self.state
-            .store(STATE_INITED | STATE_RXDMA_PRESENT, Ordering::Release);
+        self.state.store(STATE_INITED | STATE_RXDMA_PRESENT, Ordering::Release);
 
         // Open the first grant + program DMA + enable SDMACTRL.dmafb.
         // SAFETY: just published RXDMA_PRESENT and we hold exclusive

--- a/embassy-mcxa/src/lib.rs
+++ b/embassy-mcxa/src/lib.rs
@@ -135,7 +135,7 @@ macro_rules! bind_interrupts {
             $(#[cfg($cond_irq)])?
             unsafe extern "C" fn $irq() {
                 use embassy_mcxa::interrupt::typelevel::Interrupt;
-                
+
                 $crate::trace::irq_start($crate::interrupt::typelevel::$irq::IRQ);
                 unsafe {
                     $(

--- a/embassy-mcxa/src/lib.rs
+++ b/embassy-mcxa/src/lib.rs
@@ -25,6 +25,8 @@ mod mcxa5xx_exclusive {
     pub use crate::chips::mcxa5xx::init;
 }
 
+pub mod trace;
+
 #[cfg(mcxa_adc)]
 pub mod adc;
 #[cfg(mcxa_cdog)]
@@ -132,12 +134,16 @@ macro_rules! bind_interrupts {
             #[unsafe(no_mangle)]
             $(#[cfg($cond_irq)])?
             unsafe extern "C" fn $irq() {
+                use embassy_mcxa::interrupt::typelevel::Interrupt;
+                
+                $crate::trace::irq_start($crate::interrupt::typelevel::$irq::IRQ);
                 unsafe {
                     $(
                         $(#[cfg($cond_handler)])?
                         <$handler as $crate::interrupt::typelevel::Handler<$crate::interrupt::typelevel::$irq>>::on_interrupt();
                     )*
                 }
+                $crate::trace::irq_end($crate::interrupt::typelevel::$irq::IRQ);
             }
 
             $(#[cfg($cond_irq)])?

--- a/embassy-mcxa/src/trace.rs
+++ b/embassy-mcxa/src/trace.rs
@@ -1,0 +1,25 @@
+#[cfg(feature = "trace")]
+unsafe extern "Rust" {
+    /// An interrupt has started executing
+    safe fn _embassy_mcxa_trace_irq_start(irq: u16);
+    /// An interrupt is done executing
+    safe fn _embassy_mcxa_trace_irq_end(irq: u16);
+}
+
+#[doc(hidden)]
+pub fn irq_start(_irq: crate::interrupt::Interrupt) {
+    #[cfg(feature = "trace")]
+    {
+        use cortex_m::interrupt::InterruptNumber;
+        _embassy_mcxa_trace_irq_start(_irq.number());
+    }
+}
+
+#[doc(hidden)]
+pub fn irq_end(_irq: crate::interrupt::Interrupt) {
+    #[cfg(feature = "trace")]
+    {
+        use cortex_m::interrupt::InterruptNumber;
+        _embassy_mcxa_trace_irq_end(_irq.number());
+    }
+}


### PR DESCRIPTION
This allows us to trace interrupts that are made with `bind_interrupts` in a similar fashion as how we can trace the executor.