### PR TITLE
stm32/gpdma: enable HT/TC IRQs for ring buffers

### DIFF
--- a/embassy-stm32/src/dma/gpdma/ringbuffered.rs
+++ b/embassy-stm32/src/dma/gpdma/ringbuffered.rs
@@ -93,13 +93,18 @@ impl<'a, W: Word> ReadableRingBuffer<'a, W> {
     /// Create a new ring buffer.
     ///
     /// Transfer options are applied to the individual linked list items.
+    /// Half-transfer and transfer-complete IRQs are always enabled (same as BDMA ring
+    /// buffers) so async `read_exact` / `write_exact` can wake at half-buffer boundaries.
     pub unsafe fn new(
         channel: Channel<'a>,
         request: Request,
         peri_addr: *mut W,
         buffer: &'a mut [W],
-        options: TransferOptions,
+        mut options: TransferOptions,
     ) -> Self {
+        options.half_transfer_ir = true;
+        options.complete_transfer_ir = true;
+
         let table = Table::<1>::new_circular::<W>(request, peri_addr, buffer, Dir::PeripheralToMemory);
 
         Self {
@@ -254,13 +259,18 @@ impl<'a, W: Word> WritableRingBuffer<'a, W> {
     /// Create a new ring buffer.
     ///
     /// Transfer options are applied to the individual linked list items.
+    /// Half-transfer and transfer-complete IRQs are always enabled (same as BDMA ring
+    /// buffers) so async `read_exact` / `write_exact` can wake at half-buffer boundaries.
     pub unsafe fn new(
         channel: Channel<'a>,
         request: Request,
         peri_addr: *mut W,
         buffer: &'a mut [W],
-        options: TransferOptions,
+        mut options: TransferOptions,
     ) -> Self {
+        options.half_transfer_ir = true;
+        options.complete_transfer_ir = true;
+
         let table = Table::<1>::new_circular::<W>(request, peri_addr, buffer, Dir::MemoryToPeripheral);
 
         Self {


### PR DESCRIPTION
## Summary

- Force `half_transfer_ir` and `complete_transfer_ir` in GPDMA `ReadableRingBuffer::new` and `WritableRingBuffer::new`, matching existing BDMA ring buffer behavior.
- Enables half-buffer wakeups for async `read_exact` / `write_exact` on STM32 GPDMA circular linked-list channels (TIM update DMA, ADC, etc.).

## Motivation

RM0515 §17.4.13 recommends HTIE + TCIE for circular buffering. BDMA rings already set these in `new()`; GPDMA rings passed `TransferOptions` through unchanged (default `half_transfer_ir: false`), which made producer/consumer pacing harder on STM32WBA