### PR TITLE
stm32/adc: expose configure_transfer  and add some deprecations

### DIFF
--- a/embassy-stm32/src/adc/configured_sequence.rs
+++ b/embassy-stm32/src/adc/configured_sequence.rs
@@ -14,7 +14,7 @@ use crate::rcc::RccInfo;
 /// reuses the existing hardware sequence configuration, avoiding the per-call
 /// overhead of reprogramming the sequence registers.
 ///
-/// Obtain via [`Adc::configured_sequence`].
+/// Obtain via [`Adc::configure_sequence`].
 #[allow(private_bounds)]
 pub struct ConfiguredSequence<'adc, R: AdcRegs> {
     regs: R,
@@ -43,10 +43,10 @@ impl<'adc, R: AdcRegs> ConfiguredSequence<'adc, R> {
     /// wait for it to complete.
     ///
     /// Returns a slice over the results in the same channel order as the
-    /// sequence passed to [`Adc::configured_sequence`].
+    /// sequence passed to [`Adc::configure_sequence`].
     ///
     /// The ADC and DMA are configured once at construction by
-    /// [`Adc::configured_sequence`]. The hardware is configured so that
+    /// [`Adc::configure_sequence`]. The hardware is configured so that
     /// DMA stays armed between calls while the ADC runs only one sequence per
     /// [`start`](AdcRegs::start) call.
     pub async fn read(&mut self, buf: &mut [u16]) {

--- a/embassy-stm32/src/adc/g4.rs
+++ b/embassy-stm32/src/adc/g4.rs
@@ -1,5 +1,3 @@
-use core::marker::PhantomData;
-
 #[cfg(stm32g4)]
 use pac::adc::regs::Difsel as DifselReg;
 #[allow(unused)]
@@ -10,14 +8,11 @@ pub use pac::adc::vals::{Adcaldif, Adstp, Difsel, Dmacfg, Dmaen, Exten, Rovsm, T
 use pac::adc::vals::{Adcaldif, Difsel, Exten};
 pub use pac::adccommon::vals::{Dual, Presc};
 
-use crate::adc::{
-    Adc, AdcRegs, BorrowedAdcChannel, ConversionMode, DefaultInstance, InjectedRegs, RegularAdcTrigger, Resolution,
-    RxDma, SampleTime,
-};
+use crate::adc::{Adc, AdcRegs, ConversionMode, DefaultInstance, InjectedRegs, Resolution, SampleTime};
 use crate::pac::adc::regs::{Jsqr, Smpr, Smpr2, Sqr1, Sqr2, Sqr3, Sqr4};
 use crate::time::Hertz;
 use crate::wait::block_for_us;
-use crate::{Peri, dma, pac, rcc};
+use crate::{Peri, pac, rcc};
 
 mod injected;
 pub use injected::InjectedAdc;
@@ -60,19 +55,6 @@ pub struct AdcConfig {
     pub oversampling_ratio: Option<u8>,
     #[cfg(stm32g4)]
     pub oversampling_mode: Option<(Rovsm, Trovs, bool)>,
-}
-
-/// An ADC with a pre-configured channel sequence for repeated DMA to peripheral reads.
-///
-/// Just like [`Adc::configured_sequence`], this type programs the ADC channel sequence
-/// registers. However, while `ConfiguredSequence` is targeted at ADC to mem transfers,
-/// `ConfiguredTransfer` is designed for ADC to peripheral transfers such as to FMAC or CORDIC
-///
-/// Obtain via [`Adc::configured_transfer`].
-#[allow(private_bounds)]
-pub struct ConfiguredTransfer<'adc, R: super::AdcRegs> {
-    _transfer: dma::Transfer<'adc>,
-    _marker: PhantomData<R>,
 }
 
 impl super::AdcRegs for crate::pac::adc::Adc {
@@ -429,71 +411,6 @@ impl<'d, T: DefaultInstance> Adc<'d, T> {
     //     T::regs().cfgr2().modify(|reg| reg.set_rovse(enable));
     //     T::regs().cfgr2().modify(|reg| reg.set_jovse(enable));
     // }
-
-    /// Configure an ADC channel sequence once and return a [`ConfiguredTransfer`] for repeated
-    /// DMA reads to peripherals such as FMAC or CORDIC.
-    ///
-    /// Use [`Adc::configured_sequence`] instead if you don't want to pipe the results directly
-    /// to a peripheral.
-    ///
-    /// # Parameters
-    /// - `sequence`: Iterator of channels and sample times. Maximum 16 entries.
-    ///
-    /// # Returns
-    /// A [`ConfiguredTransfer`] which is can be passed to [`fmac::FromAdc::new`]
-    ///
-    /// # Notes
-    /// - The channel sequence is programmed into the ADC sequence registers once here and
-    ///   remains fixed for the lifetime of the returned [`ConfiguredTransfer`].
-    /// - Call this method AFTER the targeted peripheral is ready to begin receiving the transfer.
-    pub(crate) fn configured_transfer<'adc, 'ch, D: RxDma<T>, W: dma::word::Word>(
-        &'adc mut self,
-        rx_dma: embassy_hal_internal::Peri<'adc, D>,
-        irq: impl crate::interrupt::typelevel::Binding<D::Interrupt, crate::dma::InterruptHandler<D>> + 'd,
-        sequence: impl ExactSizeIterator<Item = (BorrowedAdcChannel<'ch, T>, SampleTime)>,
-        trigger: RegularAdcTrigger<T>,
-        dst: *mut W,
-    ) -> ConfiguredTransfer<'adc, T::Regs>
-    where
-        'ch: 'adc,
-    {
-        // Ensure no conversions are ongoing
-        T::regs().stop(false);
-        T::regs().configure_sequence(
-            sequence.map(|(channel, sample_time)| ((channel.channel, channel.is_differential), sample_time)),
-        );
-
-        T::regs().enable();
-
-        // Configure DMA once, reused across all subsequent read() calls.
-        T::regs().configure_dma(ConversionMode::Repeated(Some((trigger._trigger, trigger._edge))));
-
-        let dma_request = rx_dma.request();
-        let mut dma_channel = dma::Channel::new(rx_dma, irq);
-        let transfer = unsafe {
-            dma_channel
-                .read_raw_repeated(
-                    dma_request,
-                    dst,
-                    1,
-                    T::regs().data(),
-                    dma::TransferOptions {
-                        priority: dma::Priority::VeryHigh,
-                        circular: true,
-                        half_transfer_ir: false,
-                        complete_transfer_ir: false,
-                    },
-                )
-                .unchecked_extend_lifetime()
-        };
-
-        T::regs().start();
-
-        ConfiguredTransfer {
-            _transfer: transfer,
-            _marker: PhantomData,
-        }
-    }
 }
 
 #[cfg(stm32g4)]

--- a/embassy-stm32/src/adc/mod.rs
+++ b/embassy-stm32/src/adc/mod.rs
@@ -249,6 +249,20 @@ const fn check_dma_len(sequence_len: usize, dma_len: Option<usize>, configured_s
 }
 
 #[cfg(not(adc_f3v3))]
+/// An ADC with a pre-configured channel sequence for repeated DMA to peripheral reads.
+///
+/// Just like [`Adc::configure_sequence`], this type programs the ADC channel sequence
+/// registers. However, while `ConfiguredSequence` is targeted at ADC to mem transfers,
+/// `ConfiguredTransfer` is designed for ADC to peripheral transfers such as to FMAC or CORDIC
+///
+/// Obtain via [`Adc::configure_transfer`].
+#[allow(private_bounds)]
+pub struct ConfiguredTransfer<'adc, R: AdcRegs> {
+    _transfer: crate::dma::Transfer<'adc>,
+    _marker: PhantomData<R>,
+}
+
+#[cfg(not(adc_f3v3))]
 impl<'d, T: Instance> Adc<'d, T> {
     #[cfg(any(adc_v1, adc_l0, adc_f1, adc_f3v1, adc_f3v2))]
     /// Read an ADC pin async using the irq handler.
@@ -381,6 +395,98 @@ impl<'d, T: Instance> Adc<'d, T> {
         transfer.await;
     }
 
+    #[deprecated = "use `configure_transfer`"]
+    pub unsafe fn configured_transfer<'adc, 'ch, D: RxDma<T>, W: crate::dma::word::Word>(
+        &'adc mut self,
+        rx_dma: embassy_hal_internal::Peri<'adc, D>,
+        irq: impl crate::interrupt::typelevel::Binding<D::Interrupt, crate::dma::InterruptHandler<D>> + 'd,
+        sequence: impl ExactSizeIterator<Item = (BorrowedAdcChannel<'ch, T>, <T::Regs as BasicAdcRegs>::SampleTime)>,
+        trigger: RegularAdcTrigger<T>,
+        dst: *mut W,
+    ) -> ConfiguredTransfer<'adc, T::Regs>
+    where
+        'ch: 'adc,
+    {
+        self.configure_transfer(rx_dma, irq, sequence, trigger, dst)
+    }
+
+    /// Configure an ADC channel sequence once and return a [`ConfiguredTransfer`] for repeated
+    /// DMA reads to peripherals such as FMAC or CORDIC.
+    ///
+    /// Use [`Adc::configure_sequence`] instead if you don't want to pipe the results directly
+    /// to a peripheral.
+    ///
+    /// # Parameters
+    /// - `sequence`: Iterator of channels and sample times. Maximum 16 entries.
+    ///
+    /// # Returns
+    /// A [`ConfiguredTransfer`] which is can be passed to [`fmac::FromAdc::new`]
+    ///
+    /// # Notes
+    /// - The channel sequence is programmed into the ADC sequence registers once here and
+    ///   remains fixed for the lifetime of the returned [`ConfiguredTransfer`].
+    /// - Call this method AFTER the targeted peripheral is ready to begin receiving the transfer.
+    pub unsafe fn configure_transfer<'adc, 'ch, D: RxDma<T>, W: crate::dma::word::Word>(
+        &'adc mut self,
+        rx_dma: embassy_hal_internal::Peri<'adc, D>,
+        irq: impl crate::interrupt::typelevel::Binding<D::Interrupt, crate::dma::InterruptHandler<D>> + 'd,
+        sequence: impl ExactSizeIterator<Item = (BorrowedAdcChannel<'ch, T>, <T::Regs as BasicAdcRegs>::SampleTime)>,
+        trigger: RegularAdcTrigger<T>,
+        dst: *mut W,
+    ) -> ConfiguredTransfer<'adc, T::Regs>
+    where
+        'ch: 'adc,
+    {
+        // Ensure no conversions are ongoing
+        T::regs().stop(false);
+        T::regs().configure_sequence(
+            sequence.map(|(channel, sample_time)| ((channel.channel, channel.is_differential), sample_time)),
+        );
+
+        T::regs().enable();
+
+        // Configure DMA once, reused across all subsequent read() calls.
+        T::regs().configure_dma(ConversionMode::Repeated(Some((trigger._trigger, trigger._edge))));
+
+        let dma_request = rx_dma.request();
+        let mut dma_channel = crate::dma::Channel::new(rx_dma, irq);
+        let transfer = unsafe {
+            dma_channel
+                .read_raw_repeated(
+                    dma_request,
+                    dst,
+                    1,
+                    T::regs().data(),
+                    crate::dma::TransferOptions {
+                        #[cfg(any(bdma, dma, mdma))]
+                        circular: true,
+                        ..Default::default()
+                    },
+                )
+                .unchecked_extend_lifetime()
+        };
+
+        T::regs().start();
+
+        ConfiguredTransfer {
+            _transfer: transfer,
+            _marker: PhantomData,
+        }
+    }
+
+    #[deprecated = "use `configure_sequence`"]
+    pub fn configured_sequence<'adc, 'ch, D: RxDma<T>>(
+        &'adc mut self,
+        rx_dma: crate::Peri<'adc, D>,
+        sequence: impl ExactSizeIterator<Item = (BorrowedAdcChannel<'ch, T>, <T::Regs as BasicAdcRegs>::SampleTime)>,
+        irq: impl crate::interrupt::typelevel::Binding<D::Interrupt, crate::dma::InterruptHandler<D>> + 'd,
+    ) -> ConfiguredSequence<'adc, T::Regs>
+    where
+        'ch: 'adc,
+    {
+        self.configure_sequence(rx_dma, sequence, irq)
+    }
+
     /// Configure an ADC channel sequence once and return a [`ConfiguredSequence`] for repeated
     /// DMA reads without reprogramming the sequence each time.
     ///
@@ -398,7 +504,7 @@ impl<'d, T: Instance> Adc<'d, T> {
     /// # Notes
     /// - The channel sequence is programmed into the ADC sequence registers once here and
     ///   remains fixed for the lifetime of the returned [`ConfiguredSequence`].
-    pub fn configured_sequence<'adc, 'ch, D: RxDma<T>>(
+    pub fn configure_sequence<'adc, 'ch, D: RxDma<T>>(
         &'adc mut self,
         rx_dma: crate::Peri<'adc, D>,
         sequence: impl ExactSizeIterator<Item = (BorrowedAdcChannel<'ch, T>, <T::Regs as BasicAdcRegs>::SampleTime)>,
@@ -670,6 +776,11 @@ pub trait Instance: SealedInstance + crate::PeripheralType + crate::rcc::RccPeri
 /// ADC channel.
 #[allow(private_bounds)]
 pub trait AdcChannel<T>: SealedAdcChannel<T> + Sized {
+    #[deprecated = "use `reborrow_adc`"]
+    fn degrade_adc<'a>(&'a mut self) -> BorrowedAdcChannel<'a, T> {
+        self.reborrow_adc()
+    }
+
     #[allow(unused_mut)]
     fn reborrow_adc<'a>(&'a mut self) -> BorrowedAdcChannel<'a, T> {
         self.setup();

--- a/embassy-stm32/src/dma/gpdma/mod.rs
+++ b/embassy-stm32/src/dma/gpdma/mod.rs
@@ -660,6 +660,35 @@ impl<'d> Channel<'d> {
         }
     }
 
+    /// Create a read DMA transfer (peripheral to memory), writing the same value repeatedly.
+    pub unsafe fn read_raw_repeated<'a, MW: Word, PW: Word>(
+        &'a mut self,
+        request: Request,
+        repeated: *mut MW,
+        count: usize,
+        peri_addr: *mut PW,
+        options: TransferOptions,
+    ) -> Transfer<'a> {
+        assert!(count > 0 && count <= 0xFFFF);
+
+        self.configure(
+            request,
+            Dir::PeripheralToMemory,
+            peri_addr as *const u32,
+            repeated as *const MW as *mut u32,
+            count,
+            false,
+            MW::size(),
+            PW::size(),
+            options,
+        );
+        self.start();
+        Transfer {
+            _wake_guard: self.info().wake_guard(),
+            channel: self.reborrow(),
+        }
+    }
+
     /// Create a write DMA transfer (memory to peripheral).
     pub unsafe fn write<'a, MW: Word, PW: Word>(
         &'a mut self,

--- a/embassy-stm32/src/fmac/from_adc.rs
+++ b/embassy-stm32/src/fmac/from_adc.rs
@@ -9,14 +9,14 @@ pub struct FromAdc<'d, FMAC: fmac::Instance, ADC: adc::DefaultInstance> {
     #[allow(unused)]
     transfer: ConfiguredTransfer<'d, ADC::Regs>,
     #[allow(unused)]
-    fmac: Fmac<'d, FMAC>,
+    fmac: &'d mut Fmac<'d, FMAC>,
 }
 
 impl<'d, ADC: adc::DefaultInstance, FMAC: fmac::Instance> FromAdc<'d, FMAC, ADC> {
     #[allow(unused)]
     /// Bind ADC to FMAC using DMA and start conversion
     pub fn new<'ch, 'a, D: RxDma<ADC>>(
-        fmac: Fmac<'d, FMAC>,
+        fmac: &'d mut Fmac<'d, FMAC>,
         adc: &'d mut Adc<'a, ADC>,
         sequence: impl ExactSizeIterator<Item = (BorrowedAdcChannel<'ch, ADC>, SampleTime)>,
         trigger: RegularAdcTrigger<ADC>,
@@ -28,7 +28,7 @@ impl<'d, ADC: adc::DefaultInstance, FMAC: fmac::Instance> FromAdc<'d, FMAC, ADC>
     {
         Self {
             fmac,
-            transfer: adc.configured_transfer(dma_ch, irq, sequence, trigger, FMAC::wdata()),
+            transfer: unsafe { adc.configure_transfer(dma_ch, irq, sequence, trigger, FMAC::wdata()) },
         }
     }
 

--- a/embassy-stm32/src/fmac/mod.rs
+++ b/embassy-stm32/src/fmac/mod.rs
@@ -1,11 +1,9 @@
 //! Filter Math Accelerator
 
-#[cfg(adc_g4)]
 mod from_adc;
 
 pub use dsp_fixedpoint::Q16;
 use embassy_hal_internal::{Peri, PeripheralType};
-#[cfg(adc_g4)]
 pub use from_adc::FromAdc;
 
 use crate::{peripherals, rcc};

--- a/examples/stm32f4/src/bin/adc.rs
+++ b/examples/stm32f4/src/bin/adc.rs
@@ -44,7 +44,7 @@ async fn main(_spawner: Spawner) {
     delay.delay_us(Temperature::start_time_us().max(VrefInt::start_time_us()));
 
     {
-        let mut configured_sequence = adc.configured_sequence(
+        let mut configured_sequence = adc.configure_sequence(
             p.DMA2_CH0,
             [
                 (p.PA0.reborrow_adc(), SampleTime::Cycles112),

--- a/examples/stm32g474/src/bin/fmac_w_adc.rs
+++ b/examples/stm32g474/src/bin/fmac_w_adc.rs
@@ -54,7 +54,7 @@ async fn main(_spawner: Spawner) {
     // result = input_history[0] * latest_input +
     //     input_history[1] * older_input +
     //     input_history[2] * oldest_input
-    let fmac = fmac::Fmac::fir(
+    let mut fmac = fmac::Fmac::fir(
         p.FMAC.reborrow(),
         fmac::Config {
             output_mode: fmac::OutputMode::Saturating,
@@ -67,8 +67,8 @@ async fn main(_spawner: Spawner) {
     );
     let trigger = RegularAdcTrigger::from(triggers::HRTIM_ADC_TRG1, Exten::RisingEdge).unwrap();
 
-    let mut fmac = fmac::FromAdc::new(
-        fmac,
+    let mut from_adc = fmac::FromAdc::new(
+        &mut fmac,
         &mut adc,
         [(temperature.reborrow_adc(), SampleTime::Cycles6405)].into_iter(),
         trigger,
@@ -98,10 +98,10 @@ async fn main(_spawner: Spawner) {
     control.adc_trigger1.enable_source(&tim.cr3);
     tim.timer.start(&mut control.control);
 
-    defmt::assert!(fmac.read().is_none()); // <-- Not enough data yet
+    defmt::assert!(from_adc.read().is_none()); // <-- Not enough data yet
     defmt::println!("Running!");
     loop {
-        if let Some(raw) = fmac.read() {
+        if let Some(raw) = from_adc.read() {
             // raw is in Q1.15 format, convert back to u16
             let filtered_value = raw.inner;
             defmt::println!("reading: {}", filtered_value);


### PR DESCRIPTION
- expose configure_transfer for all adc versions. can be patched later if there are specific cases of not working
- rename some methods and add deprecated methods as hints for refactoring