### PR TITLE
stm32/wba: default WBA6-style RCC init and dedupe example setup

### DIFF
--- a/embassy-stm32/src/rcc/wba.rs
+++ b/embassy-stm32/src/rcc/wba.rs
@@ -89,16 +89,26 @@ impl Config {
         Config {
             hsi: true,
             hse: None,
-            pll1: None,
-            sys: Sysclk::Hsi,
+            // Match the common WBA6 example baseline:
+            // HSI 16 MHz -> PLL1 (x30 /5) -> SYSCLK 96 MHz, PLL1P 16 MHz.
+            pll1: Some(Pll {
+                source: PllSource::Hsi,
+                prediv: PllPreDiv::Div1,
+                mul: PllMul::Mul30,
+                divp: Some(PllDiv::Div30),
+                divq: None,
+                divr: Some(PllDiv::Div5),
+                frac: Some(0),
+            }),
+            sys: Sysclk::Pll1R,
             ahb_pre: AHBPrescaler::Div1,
-            ahb5_pre: AHB5Prescaler::Div1,
+            ahb5_pre: AHB5Prescaler::Div4,
             apb1_pre: APBPrescaler::Div1,
             apb2_pre: APBPrescaler::Div1,
             apb7_pre: APBPrescaler::Div1,
             ls: crate::rcc::LsConfig::new(),
             // lsi2: crate::rcc::LsConfig::new(),
-            voltage_scale: VoltageScale::Range2,
+            voltage_scale: VoltageScale::Range1,
             mux: super::mux::ClockMux::default(),
         }
     }

--- a/examples/stm32wba-lp/src/bin/blinky.rs
+++ b/examples/stm32wba-lp/src/bin/blinky.rs
@@ -20,6 +20,7 @@ async fn main(_spawner: Spawner) {
 
     // HSI 16 MHz as sysclk — no PLL needed for a blinky demo.
     config.rcc.sys = Sysclk::Hsi;
+    config.rcc.ahb5_pre = AHB5Prescaler::Div1;
 
     // LSI 32 kHz for the RTC — the time driver uses the RTC wakeup
     // alarm to bring the core back from STOP mode.

--- a/examples/stm32wba-lp/src/bin/button_exti.rs
+++ b/examples/stm32wba-lp/src/bin/button_exti.rs
@@ -27,6 +27,7 @@ async fn main(_spawner: Spawner) {
 
     // HSI 16 MHz as sysclk.
     config.rcc.sys = Sysclk::Hsi;
+    config.rcc.ahb5_pre = AHB5Prescaler::Div1;
 
     // LSI 32 kHz for the RTC — the time driver uses the RTC wakeup
     // alarm to bring the core back from STOP mode.

--- a/examples/stm32wba6-lp/src/bin/blinky.rs
+++ b/examples/stm32wba6-lp/src/bin/blinky.rs
@@ -20,6 +20,7 @@ async fn main(_spawner: Spawner) {
 
     // HSI 16 MHz as sysclk — no PLL needed for a blinky demo.
     config.rcc.sys = Sysclk::Hsi;
+    config.rcc.ahb5_pre = AHB5Prescaler::Div1;
 
     // LSI 32 kHz for the RTC — the time driver uses the RTC wakeup
     // alarm to bring the core back from STOP mode.

--- a/examples/stm32wba6-lp/src/bin/button_exti.rs
+++ b/examples/stm32wba6-lp/src/bin/button_exti.rs
@@ -27,6 +27,7 @@ async fn main(_spawner: Spawner) {
 
     // HSI 16 MHz as sysclk.
     config.rcc.sys = Sysclk::Hsi;
+    config.rcc.ahb5_pre = AHB5Prescaler::Div1;
 
     // LSI 32 kHz for the RTC — the time driver uses the RTC wakeup
     // alarm to bring the core back from STOP mode.

--- a/examples/stm32wba6/src/bin/adc-watchdog.rs
+++ b/examples/stm32wba6/src/bin/adc-watchdog.rs
@@ -16,9 +16,6 @@
 use defmt::*;
 use embassy_executor::Spawner;
 use embassy_stm32::adc::{Adc, AdcChannel, SampleTime, adc4};
-use embassy_stm32::rcc::{
-    AHB5Prescaler, AHBPrescaler, APBPrescaler, PllDiv, PllMul, PllPreDiv, PllSource, Sysclk, VoltageScale,
-};
 use embassy_stm32::{Config, bind_interrupts, peripherals};
 use {defmt_rtt as _, panic_probe as _};
 
@@ -28,25 +25,7 @@ bind_interrupts!(struct Irqs {
 
 #[embassy_executor::main]
 async fn main(_spawner: Spawner) {
-    let mut config = Config::default();
-    config.rcc.pll1 = Some(embassy_stm32::rcc::Pll {
-        source: PllSource::Hsi,
-        prediv: PllPreDiv::Div1,
-        mul: PllMul::Mul30,
-        divr: Some(PllDiv::Div5),
-        divq: None,
-        divp: Some(PllDiv::Div30),
-        frac: Some(0),
-    });
-
-    config.rcc.ahb_pre = AHBPrescaler::Div1;
-    config.rcc.apb1_pre = APBPrescaler::Div1;
-    config.rcc.apb2_pre = APBPrescaler::Div1;
-    config.rcc.apb7_pre = APBPrescaler::Div1;
-    config.rcc.ahb5_pre = AHB5Prescaler::Div4;
-    config.rcc.voltage_scale = VoltageScale::Range1;
-    config.rcc.sys = Sysclk::Pll1R;
-
+    let config = Config::default();
     let p = embassy_stm32::init(config);
 
     info!("ADC4 analog watchdog example (PA0)");

--- a/examples/stm32wba6/src/bin/adc.rs
+++ b/examples/stm32wba6/src/bin/adc.rs
@@ -3,9 +3,6 @@
 
 use defmt::*;
 use embassy_stm32::adc::{Adc, AdcChannel, SampleTime, adc4};
-use embassy_stm32::rcc::{
-    AHB5Prescaler, AHBPrescaler, APBPrescaler, PllDiv, PllMul, PllPreDiv, PllSource, Sysclk, VoltageScale,
-};
 use embassy_stm32::{Config, bind_interrupts, dma, peripherals};
 use {defmt_rtt as _, panic_probe as _};
 
@@ -15,30 +12,10 @@ bind_interrupts!(struct Irqs {
 
 #[embassy_executor::main]
 async fn main(_spawner: embassy_executor::Spawner) {
-    let mut config = Config::default();
+    let config = Config::default();
     // Fine-tune PLL1 dividers/multipliers
-    config.rcc.pll1 = Some(embassy_stm32::rcc::Pll {
-        source: PllSource::Hsi,
-        prediv: PllPreDiv::Div1,  // PLLM = 1 → HSI / 1 = 16 MHz
-        mul: PllMul::Mul30,       // PLLN = 30 → 16 MHz * 30 = 480 MHz VCO
-        divr: Some(PllDiv::Div5), // PLLR = 5 → 96 MHz (Sysclk)
-        // divq: Some(PllDiv::DIV10), // PLLQ = 10 → 48 MHz (NOT USED)
-        divq: None,
-        divp: Some(PllDiv::Div30), // PLLP = 30 → 16 MHz (USBOTG)
-        frac: Some(0),             // Fractional part (enabled)
-    });
-
-    config.rcc.ahb_pre = AHBPrescaler::Div1;
-    config.rcc.apb1_pre = APBPrescaler::Div1;
-    config.rcc.apb2_pre = APBPrescaler::Div1;
-    config.rcc.apb7_pre = APBPrescaler::Div1;
-    config.rcc.ahb5_pre = AHB5Prescaler::Div4;
-
     // voltage scale for max performance
-    config.rcc.voltage_scale = VoltageScale::Range1;
     // route PLL1_P into the USB‐OTG‐HS block
-    config.rcc.sys = Sysclk::Pll1R;
-
     let mut p = embassy_stm32::init(config);
 
     // **** ADC4 init ****

--- a/examples/stm32wba6/src/bin/adc_ring_buffered.rs
+++ b/examples/stm32wba6/src/bin/adc_ring_buffered.rs
@@ -23,9 +23,6 @@ use defmt::*;
 use embassy_stm32::adc::adc4::Calibration;
 use embassy_stm32::adc::{Adc, AdcChannel, RingBufferedAdc, adc4};
 use embassy_stm32::peripherals::GPDMA1_CH1;
-use embassy_stm32::rcc::{
-    AHB5Prescaler, AHBPrescaler, APBPrescaler, PllDiv, PllMul, PllPreDiv, PllSource, Sysclk, VoltageScale,
-};
 use embassy_stm32::{Config, bind_interrupts, dma};
 use {defmt_rtt as _, panic_probe as _};
 
@@ -41,25 +38,7 @@ bind_interrupts!(struct Irqs {
 #[embassy_executor::main]
 async fn main(_spawner: embassy_executor::Spawner) {
     // Configure RCC with PLL1 - required for ADC4 clock
-    let mut config = Config::default();
-    config.rcc.pll1 = Some(embassy_stm32::rcc::Pll {
-        source: PllSource::Hsi,
-        prediv: PllPreDiv::Div1,  // PLLM = 1 → HSI / 1 = 16 MHz
-        mul: PllMul::Mul30,       // PLLN = 30 → 16 MHz * 30 = 480 MHz VCO
-        divr: Some(PllDiv::Div5), // PLLR = 5 → 96 MHz (Sysclk)
-        divq: None,
-        divp: Some(PllDiv::Div30), // PLLP = 30 → 16 MHz (ADC4 clock source)
-        frac: Some(0),
-    });
-
-    config.rcc.ahb_pre = AHBPrescaler::Div1;
-    config.rcc.apb1_pre = APBPrescaler::Div1;
-    config.rcc.apb2_pre = APBPrescaler::Div1;
-    config.rcc.apb7_pre = APBPrescaler::Div1;
-    config.rcc.ahb5_pre = AHB5Prescaler::Div4;
-    config.rcc.voltage_scale = VoltageScale::Range1;
-    config.rcc.sys = Sysclk::Pll1R;
-
+    let config = Config::default();
     let p = embassy_stm32::init(config);
 
     info!("STM32WBA6 ADC4 Ring Buffered Example - Circular DMA with Calibrated Temperature");

--- a/examples/stm32wba6/src/bin/aes_cbc.rs
+++ b/examples/stm32wba6/src/bin/aes_cbc.rs
@@ -27,9 +27,6 @@
 
 use defmt::*;
 use embassy_stm32::aes::{Aes, AesCbc, Direction};
-use embassy_stm32::rcc::{
-    AHB5Prescaler, AHBPrescaler, APBPrescaler, PllDiv, PllMul, PllPreDiv, PllSource, Sysclk, VoltageScale,
-};
 use embassy_stm32::{Config, bind_interrupts, peripherals};
 use {defmt_rtt as _, panic_probe as _};
 
@@ -39,24 +36,7 @@ bind_interrupts!(struct Irqs {
 
 #[embassy_executor::main]
 async fn main(_spawner: embassy_executor::Spawner) {
-    let mut config = Config::default();
-    config.rcc.pll1 = Some(embassy_stm32::rcc::Pll {
-        source: PllSource::Hsi,
-        prediv: PllPreDiv::Div1,
-        mul: PllMul::Mul30,
-        divr: Some(PllDiv::Div5),
-        divq: None,
-        divp: Some(PllDiv::Div30),
-        frac: Some(0),
-    });
-    config.rcc.ahb_pre = AHBPrescaler::Div1;
-    config.rcc.apb1_pre = APBPrescaler::Div1;
-    config.rcc.apb2_pre = APBPrescaler::Div1;
-    config.rcc.apb7_pre = APBPrescaler::Div1;
-    config.rcc.ahb5_pre = AHB5Prescaler::Div4;
-    config.rcc.voltage_scale = VoltageScale::Range1;
-    config.rcc.sys = Sysclk::Pll1R;
-
+    let config = Config::default();
     let p = embassy_stm32::init(config);
     info!("AES-CBC Example");
 

--- a/examples/stm32wba6/src/bin/aes_ccm.rs
+++ b/examples/stm32wba6/src/bin/aes_ccm.rs
@@ -35,9 +35,6 @@
 
 use defmt::*;
 use embassy_stm32::aes::{Aes, AesCcm, Direction};
-use embassy_stm32::rcc::{
-    AHB5Prescaler, AHBPrescaler, APBPrescaler, PllDiv, PllMul, PllPreDiv, PllSource, Sysclk, VoltageScale,
-};
 use embassy_stm32::{Config, bind_interrupts, peripherals};
 use {defmt_rtt as _, panic_probe as _};
 
@@ -47,24 +44,7 @@ bind_interrupts!(struct Irqs {
 
 #[embassy_executor::main]
 async fn main(_spawner: embassy_executor::Spawner) {
-    let mut config = Config::default();
-    config.rcc.pll1 = Some(embassy_stm32::rcc::Pll {
-        source: PllSource::Hsi,
-        prediv: PllPreDiv::Div1,
-        mul: PllMul::Mul30,
-        divr: Some(PllDiv::Div5),
-        divq: None,
-        divp: Some(PllDiv::Div30),
-        frac: Some(0),
-    });
-    config.rcc.ahb_pre = AHBPrescaler::Div1;
-    config.rcc.apb1_pre = APBPrescaler::Div1;
-    config.rcc.apb2_pre = APBPrescaler::Div1;
-    config.rcc.apb7_pre = APBPrescaler::Div1;
-    config.rcc.ahb5_pre = AHB5Prescaler::Div4;
-    config.rcc.voltage_scale = VoltageScale::Range1;
-    config.rcc.sys = Sysclk::Pll1R;
-
+    let config = Config::default();
     let p = embassy_stm32::init(config);
     info!("AES-CCM Authenticated Encryption Example");
 

--- a/examples/stm32wba6/src/bin/aes_ctr.rs
+++ b/examples/stm32wba6/src/bin/aes_ctr.rs
@@ -34,9 +34,6 @@
 
 use defmt::*;
 use embassy_stm32::aes::{Aes, AesCtr, Direction};
-use embassy_stm32::rcc::{
-    AHB5Prescaler, AHBPrescaler, APBPrescaler, PllDiv, PllMul, PllPreDiv, PllSource, Sysclk, VoltageScale,
-};
 use embassy_stm32::{Config, bind_interrupts, peripherals};
 use {defmt_rtt as _, panic_probe as _};
 
@@ -46,24 +43,7 @@ bind_interrupts!(struct Irqs {
 
 #[embassy_executor::main]
 async fn main(_spawner: embassy_executor::Spawner) {
-    let mut config = Config::default();
-    config.rcc.pll1 = Some(embassy_stm32::rcc::Pll {
-        source: PllSource::Hsi,
-        prediv: PllPreDiv::Div1,
-        mul: PllMul::Mul30,
-        divr: Some(PllDiv::Div5),
-        divq: None,
-        divp: Some(PllDiv::Div30),
-        frac: Some(0),
-    });
-    config.rcc.ahb_pre = AHBPrescaler::Div1;
-    config.rcc.apb1_pre = APBPrescaler::Div1;
-    config.rcc.apb2_pre = APBPrescaler::Div1;
-    config.rcc.apb7_pre = APBPrescaler::Div1;
-    config.rcc.ahb5_pre = AHB5Prescaler::Div4;
-    config.rcc.voltage_scale = VoltageScale::Range1;
-    config.rcc.sys = Sysclk::Pll1R;
-
+    let config = Config::default();
     let p = embassy_stm32::init(config);
     info!("AES-CTR Stream Cipher Example");
 

--- a/examples/stm32wba6/src/bin/aes_ecb.rs
+++ b/examples/stm32wba6/src/bin/aes_ecb.rs
@@ -23,9 +23,6 @@
 
 use defmt::*;
 use embassy_stm32::aes::{Aes, AesEcb, Direction};
-use embassy_stm32::rcc::{
-    AHB5Prescaler, AHBPrescaler, APBPrescaler, PllDiv, PllMul, PllPreDiv, PllSource, Sysclk, VoltageScale,
-};
 use embassy_stm32::{Config, bind_interrupts, peripherals};
 use {defmt_rtt as _, panic_probe as _};
 
@@ -35,24 +32,7 @@ bind_interrupts!(struct Irqs {
 
 #[embassy_executor::main]
 async fn main(_spawner: embassy_executor::Spawner) {
-    let mut config = Config::default();
-    config.rcc.pll1 = Some(embassy_stm32::rcc::Pll {
-        source: PllSource::Hsi,
-        prediv: PllPreDiv::Div1,
-        mul: PllMul::Mul30,
-        divr: Some(PllDiv::Div5),
-        divq: None,
-        divp: Some(PllDiv::Div30),
-        frac: Some(0),
-    });
-    config.rcc.ahb_pre = AHBPrescaler::Div1;
-    config.rcc.apb1_pre = APBPrescaler::Div1;
-    config.rcc.apb2_pre = APBPrescaler::Div1;
-    config.rcc.apb7_pre = APBPrescaler::Div1;
-    config.rcc.ahb5_pre = AHB5Prescaler::Div4;
-    config.rcc.voltage_scale = VoltageScale::Range1;
-    config.rcc.sys = Sysclk::Pll1R;
-
+    let config = Config::default();
     let p = embassy_stm32::init(config);
     info!("AES-ECB Example");
 

--- a/examples/stm32wba6/src/bin/aes_gcm.rs
+++ b/examples/stm32wba6/src/bin/aes_gcm.rs
@@ -40,9 +40,6 @@
 
 use defmt::*;
 use embassy_stm32::aes::{Aes, AesGcm, Direction};
-use embassy_stm32::rcc::{
-    AHB5Prescaler, AHBPrescaler, APBPrescaler, PllDiv, PllMul, PllPreDiv, PllSource, Sysclk, VoltageScale,
-};
 use embassy_stm32::{Config, bind_interrupts, peripherals};
 use {defmt_rtt as _, panic_probe as _};
 
@@ -52,24 +49,7 @@ bind_interrupts!(struct Irqs {
 
 #[embassy_executor::main]
 async fn main(_spawner: embassy_executor::Spawner) {
-    let mut config = Config::default();
-    config.rcc.pll1 = Some(embassy_stm32::rcc::Pll {
-        source: PllSource::Hsi,
-        prediv: PllPreDiv::Div1,
-        mul: PllMul::Mul30,
-        divr: Some(PllDiv::Div5),
-        divq: None,
-        divp: Some(PllDiv::Div30),
-        frac: Some(0),
-    });
-    config.rcc.ahb_pre = AHBPrescaler::Div1;
-    config.rcc.apb1_pre = APBPrescaler::Div1;
-    config.rcc.apb2_pre = APBPrescaler::Div1;
-    config.rcc.apb7_pre = APBPrescaler::Div1;
-    config.rcc.ahb5_pre = AHB5Prescaler::Div4;
-    config.rcc.voltage_scale = VoltageScale::Range1;
-    config.rcc.sys = Sysclk::Pll1R;
-
+    let config = Config::default();
     let p = embassy_stm32::init(config);
     info!("AES-GCM Authenticated Encryption Example");
 

--- a/examples/stm32wba6/src/bin/aes_gmac.rs
+++ b/examples/stm32wba6/src/bin/aes_gmac.rs
@@ -31,9 +31,6 @@
 
 use defmt::*;
 use embassy_stm32::aes::{Aes, AesGmac, Direction};
-use embassy_stm32::rcc::{
-    AHB5Prescaler, AHBPrescaler, APBPrescaler, PllDiv, PllMul, PllPreDiv, PllSource, Sysclk, VoltageScale,
-};
 use embassy_stm32::{Config, bind_interrupts, peripherals};
 use {defmt_rtt as _, panic_probe as _};
 
@@ -43,24 +40,7 @@ bind_interrupts!(struct Irqs {
 
 #[embassy_executor::main]
 async fn main(_spawner: embassy_executor::Spawner) {
-    let mut config = Config::default();
-    config.rcc.pll1 = Some(embassy_stm32::rcc::Pll {
-        source: PllSource::Hsi,
-        prediv: PllPreDiv::Div1,
-        mul: PllMul::Mul30,
-        divr: Some(PllDiv::Div5),
-        divq: None,
-        divp: Some(PllDiv::Div30),
-        frac: Some(0),
-    });
-    config.rcc.ahb_pre = AHBPrescaler::Div1;
-    config.rcc.apb1_pre = APBPrescaler::Div1;
-    config.rcc.apb2_pre = APBPrescaler::Div1;
-    config.rcc.apb7_pre = APBPrescaler::Div1;
-    config.rcc.ahb5_pre = AHB5Prescaler::Div4;
-    config.rcc.voltage_scale = VoltageScale::Range1;
-    config.rcc.sys = Sysclk::Pll1R;
-
+    let config = Config::default();
     let p = embassy_stm32::init(config);
     info!("AES-GMAC Message Authentication Example");
 

--- a/examples/stm32wba6/src/bin/blinky.rs
+++ b/examples/stm32wba6/src/bin/blinky.rs
@@ -5,38 +5,15 @@ use defmt::*;
 use embassy_executor::Spawner;
 use embassy_stm32::Config;
 use embassy_stm32::gpio::{Level, Output, Speed};
-use embassy_stm32::rcc::{
-    AHB5Prescaler, AHBPrescaler, APBPrescaler, PllDiv, PllMul, PllPreDiv, PllSource, Sysclk, VoltageScale,
-};
 use embassy_time::Timer;
 use {defmt_rtt as _, panic_probe as _};
 
 #[embassy_executor::main]
 async fn main(_spawner: Spawner) {
-    let mut config = Config::default();
+    let config = Config::default();
     // Fine-tune PLL1 dividers/multipliers
-    config.rcc.pll1 = Some(embassy_stm32::rcc::Pll {
-        source: PllSource::Hsi,
-        prediv: PllPreDiv::Div1,  // PLLM = 1 → HSI / 1 = 16 MHz
-        mul: PllMul::Mul30,       // PLLN = 30 → 16 MHz * 30 = 480 MHz VCO
-        divr: Some(PllDiv::Div5), // PLLR = 5 → 96 MHz (Sysclk)
-        // divq: Some(PllDiv::DIV10), // PLLQ = 10 → 48 MHz (NOT USED)
-        divq: None,
-        divp: Some(PllDiv::Div30), // PLLP = 30 → 16 MHz (USBOTG)
-        frac: Some(0),             // Fractional part (enabled)
-    });
-
-    config.rcc.ahb_pre = AHBPrescaler::Div1;
-    config.rcc.apb1_pre = APBPrescaler::Div1;
-    config.rcc.apb2_pre = APBPrescaler::Div1;
-    config.rcc.apb7_pre = APBPrescaler::Div1;
-    config.rcc.ahb5_pre = AHB5Prescaler::Div4;
-
     // voltage scale for max performance
-    config.rcc.voltage_scale = VoltageScale::Range1;
     // route PLL1_P into the USB‐OTG‐HS block
-    config.rcc.sys = Sysclk::Pll1R;
-
     let p = embassy_stm32::init(config);
     info!("Hello World!");
 

--- a/examples/stm32wba6/src/bin/comp.rs
+++ b/examples/stm32wba6/src/bin/comp.rs
@@ -17,9 +17,6 @@
 use defmt::*;
 use embassy_executor::Spawner;
 use embassy_stm32::comp::{Comp, Config, Hysteresis, InvertingInput, OutputPolarity, PowerMode};
-use embassy_stm32::rcc::{
-    AHB5Prescaler, AHBPrescaler, APBPrescaler, PllDiv, PllMul, PllPreDiv, PllSource, Sysclk, VoltageScale,
-};
 use embassy_stm32::{bind_interrupts, comp};
 use embassy_time::Timer;
 use {defmt_rtt as _, panic_probe as _};
@@ -30,27 +27,9 @@ bind_interrupts!(struct Irqs {
 
 #[embassy_executor::main]
 async fn main(_spawner: Spawner) {
-    let mut config = embassy_stm32::Config::default();
+    let config = embassy_stm32::Config::default();
 
     // Configure PLL for system clock
-    config.rcc.pll1 = Some(embassy_stm32::rcc::Pll {
-        source: PllSource::Hsi,
-        prediv: PllPreDiv::Div1,
-        mul: PllMul::Mul30,
-        divr: Some(PllDiv::Div5),
-        divq: None,
-        divp: Some(PllDiv::Div30),
-        frac: Some(0),
-    });
-
-    config.rcc.ahb_pre = AHBPrescaler::Div1;
-    config.rcc.apb1_pre = APBPrescaler::Div1;
-    config.rcc.apb2_pre = APBPrescaler::Div1;
-    config.rcc.apb7_pre = APBPrescaler::Div1;
-    config.rcc.ahb5_pre = AHB5Prescaler::Div4;
-    config.rcc.voltage_scale = VoltageScale::Range1;
-    config.rcc.sys = Sysclk::Pll1R;
-
     let p = embassy_stm32::init(config);
     info!("COMP example starting!");
 

--- a/examples/stm32wba6/src/bin/comp_window.rs
+++ b/examples/stm32wba6/src/bin/comp_window.rs
@@ -25,9 +25,6 @@ use embassy_executor::Spawner;
 use embassy_stm32::comp::{
     Comp, Config, Hysteresis, InvertingInput, OutputPolarity, PowerMode, WindowMode, WindowOutput,
 };
-use embassy_stm32::rcc::{
-    AHB5Prescaler, AHBPrescaler, APBPrescaler, PllDiv, PllMul, PllPreDiv, PllSource, Sysclk, VoltageScale,
-};
 use embassy_stm32::{bind_interrupts, comp};
 use embassy_time::Timer;
 use {defmt_rtt as _, panic_probe as _};
@@ -61,27 +58,9 @@ fn get_window_position(comp1_high: bool, comp2_high: bool) -> WindowPosition {
 
 #[embassy_executor::main]
 async fn main(_spawner: Spawner) {
-    let mut config = embassy_stm32::Config::default();
+    let config = embassy_stm32::Config::default();
 
     // Configure PLL for system clock
-    config.rcc.pll1 = Some(embassy_stm32::rcc::Pll {
-        source: PllSource::Hsi,
-        prediv: PllPreDiv::Div1,
-        mul: PllMul::Mul30,
-        divr: Some(PllDiv::Div5),
-        divq: None,
-        divp: Some(PllDiv::Div30),
-        frac: Some(0),
-    });
-
-    config.rcc.ahb_pre = AHBPrescaler::Div1;
-    config.rcc.apb1_pre = APBPrescaler::Div1;
-    config.rcc.apb2_pre = APBPrescaler::Div1;
-    config.rcc.apb7_pre = APBPrescaler::Div1;
-    config.rcc.ahb5_pre = AHB5Prescaler::Div4;
-    config.rcc.voltage_scale = VoltageScale::Range1;
-    config.rcc.sys = Sysclk::Pll1R;
-
     let p = embassy_stm32::init(config);
     info!("COMP Window Mode example starting!");
 

--- a/examples/stm32wba6/src/bin/device_info.rs
+++ b/examples/stm32wba6/src/bin/device_info.rs
@@ -3,34 +3,13 @@
 
 use defmt::*;
 use embassy_executor::Spawner;
-use embassy_stm32::rcc::{
-    AHB5Prescaler, AHBPrescaler, APBPrescaler, PllDiv, PllMul, PllPreDiv, PllSource, Sysclk, VoltageScale,
-};
 use embassy_stm32::{Config, uid};
 use stm32_metapac::DESIG;
 use {defmt_rtt as _, panic_probe as _};
 
 #[embassy_executor::main]
 async fn main(_spawner: Spawner) {
-    let mut config = Config::default();
-    config.rcc.pll1 = Some(embassy_stm32::rcc::Pll {
-        source: PllSource::Hsi,
-        prediv: PllPreDiv::Div1,
-        mul: PllMul::Mul30,
-        divr: Some(PllDiv::Div5),
-        divq: None,
-        divp: Some(PllDiv::Div30),
-        frac: Some(0),
-    });
-
-    config.rcc.ahb_pre = AHBPrescaler::Div1;
-    config.rcc.apb1_pre = APBPrescaler::Div1;
-    config.rcc.apb2_pre = APBPrescaler::Div1;
-    config.rcc.apb7_pre = APBPrescaler::Div1;
-    config.rcc.ahb5_pre = AHB5Prescaler::Div4;
-    config.rcc.voltage_scale = VoltageScale::Range1;
-    config.rcc.sys = Sysclk::Pll1R;
-
+    let config = Config::default();
     let _p = embassy_stm32::init(config);
     info!("Device info example");
 

--- a/examples/stm32wba6/src/bin/flash.rs
+++ b/examples/stm32wba6/src/bin/flash.rs
@@ -12,32 +12,13 @@ use defmt::{info, unwrap};
 use embassy_executor::Spawner;
 use embassy_stm32::Config;
 use embassy_stm32::flash::Flash;
-use embassy_stm32::rcc::{
-    AHB5Prescaler, AHBPrescaler, APBPrescaler, PllDiv, PllMul, PllPreDiv, PllSource, Sysclk, VoltageScale, mux,
-};
+use embassy_stm32::rcc::mux;
 use embassy_time::Timer;
 use {defmt_rtt as _, panic_probe as _};
 
 #[embassy_executor::main]
 async fn main(_spawner: Spawner) {
     let mut config = Config::default();
-    config.rcc.pll1 = Some(embassy_stm32::rcc::Pll {
-        source: PllSource::Hsi,
-        prediv: PllPreDiv::Div1,
-        mul: PllMul::Mul30,
-        divr: Some(PllDiv::Div5),
-        divq: None,
-        divp: Some(PllDiv::Div30),
-        frac: Some(0),
-    });
-    config.rcc.ahb_pre = AHBPrescaler::Div1;
-    config.rcc.apb1_pre = APBPrescaler::Div1;
-    config.rcc.apb2_pre = APBPrescaler::Div1;
-    config.rcc.apb7_pre = APBPrescaler::Div1;
-    config.rcc.ahb5_pre = AHB5Prescaler::Div4;
-    config.rcc.voltage_scale = VoltageScale::Range1;
-    config.rcc.sys = Sysclk::Pll1R;
-
     // SAI clock source: HSI (flash example does not use SAI; avoids requiring PLL1.P)
     config.rcc.mux.sai1sel = mux::Sai1sel::Hsi;
 

--- a/examples/stm32wba6/src/bin/iwdg.rs
+++ b/examples/stm32wba6/src/bin/iwdg.rs
@@ -4,35 +4,13 @@
 use defmt::*;
 use embassy_executor::Spawner;
 use embassy_stm32::Config;
-use embassy_stm32::rcc::{
-    AHB5Prescaler, AHBPrescaler, APBPrescaler, PllDiv, PllMul, PllPreDiv, PllSource, Sysclk, VoltageScale,
-};
 use embassy_stm32::wdg::IndependentWatchdog;
 use embassy_time::Timer;
 use {defmt_rtt as _, panic_probe as _};
 
 #[embassy_executor::main]
 async fn main(_spawner: Spawner) {
-    let mut config = Config::default();
-    config.rcc.pll1 = Some(embassy_stm32::rcc::Pll {
-        source: PllSource::Hsi,
-        prediv: PllPreDiv::Div1,
-        mul: PllMul::Mul30,
-        divr: Some(PllDiv::Div5),
-        divq: None,
-        divp: Some(PllDiv::Div30),
-        frac: Some(0),
-    });
-
-    config.rcc.ahb_pre = AHBPrescaler::Div1;
-    config.rcc.apb1_pre = APBPrescaler::Div1;
-    config.rcc.apb2_pre = APBPrescaler::Div1;
-    config.rcc.apb7_pre = APBPrescaler::Div1;
-    config.rcc.ahb5_pre = AHB5Prescaler::Div4;
-
-    config.rcc.voltage_scale = VoltageScale::Range1;
-    config.rcc.sys = Sysclk::Pll1R;
-
+    let config = Config::default();
     let p = embassy_stm32::init(config);
     info!("IWDG example");
 

--- a/examples/stm32wba6/src/bin/mac_ffd.rs
+++ b/examples/stm32wba6/src/bin/mac_ffd.rs
@@ -4,9 +4,7 @@
 use defmt::*;
 use embassy_executor::Spawner;
 use embassy_stm32::Config;
-use embassy_stm32::rcc::{
-    AHB5Prescaler, AHBPrescaler, APBPrescaler, PllDiv, PllMul, PllPreDiv, PllSource, Sysclk, VoltageScale, mux,
-};
+use embassy_stm32::rcc::mux;
 use embassy_stm32_wpan::bindings::mac::{ST_MAC_callbacks_t, ST_MAC_init};
 use {defmt_rtt as _, panic_probe as _};
 
@@ -39,35 +37,15 @@ static _MAC_CALLBACKS: ST_MAC_callbacks_t = ST_MAC_callbacks_t {
     mlmeBeaconReqIndCb: None,       // ST_MAC_MLMEBeaconReqIndCbPtr,
     mlmeBeaconCnfCb: None,          // ST_MAC_MLMEBeaconCnfCbPtr,
     mlmeGetPwrInfoTableCnfCb: None, // ST_MAC_MLMEGetPwrInfoTableCnfCbPtr,
-    mlmeSetPwrInfoTableCnfCb: None, // ST_MAC_MLMESetPwrInfoTableCnfCbPtr,
+    mlmeSetPwrInfoTableCnfCb: None, // ST_MAC_MLMESetPwrInfoTableCnfCbPtr
 };
 
 #[embassy_executor::main]
 async fn main(_spawner: Spawner) {
     let mut config = Config::default();
     // Fine-tune PLL1 dividers/multipliers
-    config.rcc.pll1 = Some(embassy_stm32::rcc::Pll {
-        source: PllSource::HSI,
-        prediv: PllPreDiv::DIV1,  // PLLM = 1 → HSI / 1 = 16 MHz
-        mul: PllMul::MUL30,       // PLLN = 30 → 16 MHz * 30 = 480 MHz VCO
-        divr: Some(PllDiv::DIV5), // PLLR = 5 → 96 MHz (Sysclk)
-        // divq: Some(PllDiv::DIV10), // PLLQ = 10 → 48 MHz (NOT USED)
-        divq: None,
-        divp: Some(PllDiv::DIV30), // PLLP = 30 → 16 MHz (USBOTG)
-        frac: Some(0),             // Fractional part (enabled)
-    });
-
-    config.rcc.ahb_pre = AHBPrescaler::DIV1;
-    config.rcc.apb1_pre = APBPrescaler::DIV1;
-    config.rcc.apb2_pre = APBPrescaler::DIV1;
-    config.rcc.apb7_pre = APBPrescaler::DIV1;
-    config.rcc.ahb5_pre = AHB5Prescaler::DIV4;
-
     // voltage scale for max performance
-    config.rcc.voltage_scale = VoltageScale::RANGE1;
     // route PLL1_P into the USB‐OTG‐HS block
-    config.rcc.sys = Sysclk::PLL1_R;
-
     // let p = embassy_stm32::init(config);
 
     // config.rcc.sys = Sysclk::HSI;

--- a/examples/stm32wba6/src/bin/pka_ecdh.rs
+++ b/examples/stm32wba6/src/bin/pka_ecdh.rs
@@ -27,9 +27,7 @@
 
 use defmt::*;
 use embassy_stm32::pka::{EccPoint, EcdsaCurveParams, Pka};
-use embassy_stm32::rcc::{
-    AHB5Prescaler, AHBPrescaler, APBPrescaler, PllDiv, PllMul, PllPreDiv, PllSource, Sysclk, VoltageScale, mux,
-};
+use embassy_stm32::rcc::mux;
 use embassy_stm32::rng::Rng;
 use embassy_stm32::{Config, bind_interrupts, peripherals};
 use {defmt_rtt as _, panic_probe as _};
@@ -42,22 +40,6 @@ bind_interrupts!(struct Irqs {
 #[embassy_executor::main]
 async fn main(_spawner: embassy_executor::Spawner) {
     let mut config = Config::default();
-    config.rcc.pll1 = Some(embassy_stm32::rcc::Pll {
-        source: PllSource::Hsi,
-        prediv: PllPreDiv::Div1,
-        mul: PllMul::Mul30,
-        divr: Some(PllDiv::Div5),
-        divq: None,
-        divp: Some(PllDiv::Div30),
-        frac: Some(0),
-    });
-    config.rcc.ahb_pre = AHBPrescaler::Div1;
-    config.rcc.apb1_pre = APBPrescaler::Div1;
-    config.rcc.apb2_pre = APBPrescaler::Div1;
-    config.rcc.apb7_pre = APBPrescaler::Div1;
-    config.rcc.ahb5_pre = AHB5Prescaler::Div4;
-    config.rcc.voltage_scale = VoltageScale::Range1;
-    config.rcc.sys = Sysclk::Pll1R;
     // RNG requires HSI clock source on WBA
     config.rcc.mux.rngsel = mux::Rngsel::Hsi;
 

--- a/examples/stm32wba6/src/bin/pka_ecdsa_sign.rs
+++ b/examples/stm32wba6/src/bin/pka_ecdsa_sign.rs
@@ -23,9 +23,7 @@
 
 use defmt::*;
 use embassy_stm32::pka::{EccPoint, EcdsaCurveParams, EcdsaPublicKey, EcdsaSignature, Pka};
-use embassy_stm32::rcc::{
-    AHB5Prescaler, AHBPrescaler, APBPrescaler, PllDiv, PllMul, PllPreDiv, PllSource, Sysclk, VoltageScale, mux,
-};
+use embassy_stm32::rcc::mux;
 use embassy_stm32::rng::Rng;
 use embassy_stm32::{Config, bind_interrupts, peripherals};
 use {defmt_rtt as _, panic_probe as _};
@@ -38,22 +36,6 @@ bind_interrupts!(struct Irqs {
 #[embassy_executor::main]
 async fn main(_spawner: embassy_executor::Spawner) {
     let mut config = Config::default();
-    config.rcc.pll1 = Some(embassy_stm32::rcc::Pll {
-        source: PllSource::Hsi,
-        prediv: PllPreDiv::Div1,
-        mul: PllMul::Mul30,
-        divr: Some(PllDiv::Div5),
-        divq: None,
-        divp: Some(PllDiv::Div30),
-        frac: Some(0),
-    });
-    config.rcc.ahb_pre = AHBPrescaler::Div1;
-    config.rcc.apb1_pre = APBPrescaler::Div1;
-    config.rcc.apb2_pre = APBPrescaler::Div1;
-    config.rcc.apb7_pre = APBPrescaler::Div1;
-    config.rcc.ahb5_pre = AHB5Prescaler::Div4;
-    config.rcc.voltage_scale = VoltageScale::Range1;
-    config.rcc.sys = Sysclk::Pll1R;
     // RNG requires HSI clock source on WBA
     config.rcc.mux.rngsel = mux::Rngsel::Hsi;
 

--- a/examples/stm32wba6/src/bin/pka_ecdsa_verify.rs
+++ b/examples/stm32wba6/src/bin/pka_ecdsa_verify.rs
@@ -21,9 +21,7 @@
 
 use defmt::*;
 use embassy_stm32::pka::{EcdsaCurveParams, EcdsaPublicKey, EcdsaSignature, Pka};
-use embassy_stm32::rcc::{
-    AHB5Prescaler, AHBPrescaler, APBPrescaler, PllDiv, PllMul, PllPreDiv, PllSource, Sysclk, VoltageScale, mux,
-};
+use embassy_stm32::rcc::mux;
 use embassy_stm32::rng::Rng;
 use embassy_stm32::{Config, bind_interrupts, peripherals};
 use {defmt_rtt as _, panic_probe as _};
@@ -36,22 +34,6 @@ bind_interrupts!(struct Irqs {
 #[embassy_executor::main]
 async fn main(_spawner: embassy_executor::Spawner) {
     let mut config = Config::default();
-    config.rcc.pll1 = Some(embassy_stm32::rcc::Pll {
-        source: PllSource::Hsi,
-        prediv: PllPreDiv::Div1,
-        mul: PllMul::Mul30,
-        divr: Some(PllDiv::Div5),
-        divq: None,
-        divp: Some(PllDiv::Div30),
-        frac: Some(0),
-    });
-    config.rcc.ahb_pre = AHBPrescaler::Div1;
-    config.rcc.apb1_pre = APBPrescaler::Div1;
-    config.rcc.apb2_pre = APBPrescaler::Div1;
-    config.rcc.apb7_pre = APBPrescaler::Div1;
-    config.rcc.ahb5_pre = AHB5Prescaler::Div4;
-    config.rcc.voltage_scale = VoltageScale::Range1;
-    config.rcc.sys = Sysclk::Pll1R;
     // RNG clock is required for PKA to initialize properly on WBA
     config.rcc.mux.rngsel = mux::Rngsel::Hsi;
 

--- a/examples/stm32wba6/src/bin/pka_rsa.rs
+++ b/examples/stm32wba6/src/bin/pka_rsa.rs
@@ -22,9 +22,6 @@
 
 use defmt::*;
 use embassy_stm32::pka::Pka;
-use embassy_stm32::rcc::{
-    AHB5Prescaler, AHBPrescaler, APBPrescaler, PllDiv, PllMul, PllPreDiv, PllSource, Sysclk, VoltageScale,
-};
 use embassy_stm32::{Config, bind_interrupts, peripherals};
 use {defmt_rtt as _, panic_probe as _};
 
@@ -75,24 +72,7 @@ const RSA_D: [u8; 256] = [
 
 #[embassy_executor::main]
 async fn main(_spawner: embassy_executor::Spawner) {
-    let mut config = Config::default();
-    config.rcc.pll1 = Some(embassy_stm32::rcc::Pll {
-        source: PllSource::Hsi,
-        prediv: PllPreDiv::Div1,
-        mul: PllMul::Mul30,
-        divr: Some(PllDiv::Div5),
-        divq: None,
-        divp: Some(PllDiv::Div30),
-        frac: Some(0),
-    });
-    config.rcc.ahb_pre = AHBPrescaler::Div1;
-    config.rcc.apb1_pre = APBPrescaler::Div1;
-    config.rcc.apb2_pre = APBPrescaler::Div1;
-    config.rcc.apb7_pre = APBPrescaler::Div1;
-    config.rcc.ahb5_pre = AHB5Prescaler::Div4;
-    config.rcc.voltage_scale = VoltageScale::Range1;
-    config.rcc.sys = Sysclk::Pll1R;
-
+    let config = Config::default();
     let p = embassy_stm32::init(config);
     info!("PKA RSA Encryption/Decryption Example");
 

--- a/examples/stm32wba6/src/bin/pka_rsa_crt.rs
+++ b/examples/stm32wba6/src/bin/pka_rsa_crt.rs
@@ -33,9 +33,6 @@
 
 use defmt::*;
 use embassy_stm32::pka::{Pka, RsaCrtParams};
-use embassy_stm32::rcc::{
-    AHB5Prescaler, AHBPrescaler, APBPrescaler, PllDiv, PllMul, PllPreDiv, PllSource, Sysclk, VoltageScale,
-};
 use embassy_stm32::{Config, bind_interrupts, peripherals};
 use {defmt_rtt as _, panic_probe as _};
 
@@ -143,24 +140,7 @@ const RSA_QINV: [u8; 128] = [
 
 #[embassy_executor::main]
 async fn main(_spawner: embassy_executor::Spawner) {
-    let mut config = Config::default();
-    config.rcc.pll1 = Some(embassy_stm32::rcc::Pll {
-        source: PllSource::Hsi,
-        prediv: PllPreDiv::Div1,
-        mul: PllMul::Mul30,
-        divr: Some(PllDiv::Div5),
-        divq: None,
-        divp: Some(PllDiv::Div30),
-        frac: Some(0),
-    });
-    config.rcc.ahb_pre = AHBPrescaler::Div1;
-    config.rcc.apb1_pre = APBPrescaler::Div1;
-    config.rcc.apb2_pre = APBPrescaler::Div1;
-    config.rcc.apb7_pre = APBPrescaler::Div1;
-    config.rcc.ahb5_pre = AHB5Prescaler::Div4;
-    config.rcc.voltage_scale = VoltageScale::Range1;
-    config.rcc.sys = Sysclk::Pll1R;
-
+    let config = Config::default();
     let p = embassy_stm32::init(config);
     info!("PKA RSA-CRT Decryption Example");
 

--- a/examples/stm32wba6/src/bin/pka_rsa_keygen.rs
+++ b/examples/stm32wba6/src/bin/pka_rsa_keygen.rs
@@ -27,9 +27,6 @@
 
 use defmt::*;
 use embassy_stm32::pka::{ComparisonResult, Pka};
-use embassy_stm32::rcc::{
-    AHB5Prescaler, AHBPrescaler, APBPrescaler, PllDiv, PllMul, PllPreDiv, PllSource, Sysclk, VoltageScale,
-};
 use embassy_stm32::{Config, bind_interrupts, peripherals};
 use {defmt_rtt as _, panic_probe as _};
 
@@ -101,24 +98,7 @@ const RSA_D: [u8; 256] = [
 
 #[embassy_executor::main]
 async fn main(_spawner: embassy_executor::Spawner) {
-    let mut config = Config::default();
-    config.rcc.pll1 = Some(embassy_stm32::rcc::Pll {
-        source: PllSource::Hsi,
-        prediv: PllPreDiv::Div1,
-        mul: PllMul::Mul30,
-        divr: Some(PllDiv::Div5),
-        divq: None,
-        divp: Some(PllDiv::Div30),
-        frac: Some(0),
-    });
-    config.rcc.ahb_pre = AHBPrescaler::Div1;
-    config.rcc.apb1_pre = APBPrescaler::Div1;
-    config.rcc.apb2_pre = APBPrescaler::Div1;
-    config.rcc.apb7_pre = APBPrescaler::Div1;
-    config.rcc.ahb5_pre = AHB5Prescaler::Div4;
-    config.rcc.voltage_scale = VoltageScale::Range1;
-    config.rcc.sys = Sysclk::Pll1R;
-
+    let config = Config::default();
     let p = embassy_stm32::init(config);
     info!("PKA RSA Key Finalization Example");
 

--- a/examples/stm32wba6/src/bin/pwm.rs
+++ b/examples/stm32wba6/src/bin/pwm.rs
@@ -6,9 +6,6 @@ use defmt_rtt as _; // global logger
 use embassy_executor::Spawner;
 use embassy_stm32::Config;
 use embassy_stm32::gpio::OutputType;
-use embassy_stm32::rcc::{
-    AHB5Prescaler, AHBPrescaler, APBPrescaler, PllDiv, PllMul, PllPreDiv, PllSource, Sysclk, VoltageScale,
-};
 use embassy_stm32::time::khz;
 use embassy_stm32::timer::simple_pwm::{PwmPin, SimplePwm};
 use embassy_time::Timer;
@@ -18,30 +15,10 @@ use panic_probe as _;
 async fn main(_spawner: Spawner) {
     info!("Hello World!");
 
-    let mut config = Config::default();
+    let config = Config::default();
     // Fine-tune PLL1 dividers/multipliers
-    config.rcc.pll1 = Some(embassy_stm32::rcc::Pll {
-        source: PllSource::Hsi,
-        prediv: PllPreDiv::Div1,  // PLLM = 1 → HSI / 1 = 16 MHz
-        mul: PllMul::Mul30,       // PLLN = 30 → 16 MHz * 30 = 480 MHz VCO
-        divr: Some(PllDiv::Div5), // PLLR = 5 → 96 MHz (Sysclk)
-        // divq: Some(PllDiv::DIV10), // PLLQ = 10 → 48 MHz (NOT USED)
-        divq: None,
-        divp: Some(PllDiv::Div30), // PLLP = 30 → 16 MHz (USBOTG)
-        frac: Some(0),             // Fractional part (enabled)
-    });
-
-    config.rcc.ahb_pre = AHBPrescaler::Div1;
-    config.rcc.apb1_pre = APBPrescaler::Div1;
-    config.rcc.apb2_pre = APBPrescaler::Div1;
-    config.rcc.apb7_pre = APBPrescaler::Div1;
-    config.rcc.ahb5_pre = AHB5Prescaler::Div4;
-
     // voltage scale for max performance
-    config.rcc.voltage_scale = VoltageScale::Range1;
     // route PLL1_P into the USB‐OTG‐HS block
-    config.rcc.sys = Sysclk::Pll1R;
-
     let p = embassy_stm32::init(config);
 
     let ch1_pin = PwmPin::new(p.PA2, OutputType::PushPull);

--- a/examples/stm32wba6/src/bin/rng.rs
+++ b/examples/stm32wba6/src/bin/rng.rs
@@ -3,9 +3,7 @@
 
 use defmt::*;
 use embassy_executor::Spawner;
-use embassy_stm32::rcc::{
-    AHB5Prescaler, AHBPrescaler, APBPrescaler, PllDiv, PllMul, PllPreDiv, PllSource, Sysclk, VoltageScale, mux,
-};
+use embassy_stm32::rcc::mux;
 use embassy_stm32::rng::Rng;
 use embassy_stm32::{Config, bind_interrupts, peripherals, rng};
 use embassy_time::Timer;
@@ -20,24 +18,6 @@ async fn main(_spawner: Spawner) {
     let mut config = Config::default();
 
     // Configure PLL1 (required on WBA)
-    config.rcc.pll1 = Some(embassy_stm32::rcc::Pll {
-        source: PllSource::Hsi,
-        prediv: PllPreDiv::Div1,  // PLLM = 1 → HSI / 1 = 16 MHz
-        mul: PllMul::Mul30,       // PLLN = 30 → 16 MHz * 30 = 480 MHz VCO
-        divr: Some(PllDiv::Div5), // PLLR = 5 → 96 MHz (Sysclk)
-        divq: None,
-        divp: Some(PllDiv::Div30), // PLLP = 30 → 16 MHz (required for SAI)
-        frac: Some(0),
-    });
-
-    config.rcc.ahb_pre = AHBPrescaler::Div1;
-    config.rcc.apb1_pre = APBPrescaler::Div1;
-    config.rcc.apb2_pre = APBPrescaler::Div1;
-    config.rcc.apb7_pre = APBPrescaler::Div1;
-    config.rcc.ahb5_pre = AHB5Prescaler::Div4;
-    config.rcc.voltage_scale = VoltageScale::Range1;
-    config.rcc.sys = Sysclk::Pll1R;
-
     // Configure RNG clock source to HSI (required for WBA)
     config.rcc.mux.rngsel = mux::Rngsel::Hsi;
 

--- a/examples/stm32wba6/src/bin/rtc.rs
+++ b/examples/stm32wba6/src/bin/rtc.rs
@@ -4,33 +4,13 @@
 use defmt::*;
 use embassy_executor::Spawner;
 use embassy_stm32::Config;
-use embassy_stm32::rcc::*;
 use embassy_stm32::rtc::{DateTime, DayOfWeek, Rtc, RtcConfig};
 use embassy_time::Timer;
 use {defmt_rtt as _, panic_probe as _};
 
-pub fn pll_init(config: &mut Config) {
-    config.rcc.pll1 = Some(embassy_stm32::rcc::Pll {
-        source: PllSource::Hsi,
-        prediv: PllPreDiv::Div1,  // PLLM = 1 → HSI / 1 = 16 MHz
-        mul: PllMul::Mul30,       // PLLN = 30 → 16 MHz * 30 = 480 MHz VCO
-        divr: Some(PllDiv::Div5), // PLLR = 5 → 96 MHz (Sysclk)
-        // divq: Some(PllDiv::DIV10), // PLLQ = 10 → 48 MHz (NOT USED)
-        divq: None,
-        divp: Some(PllDiv::Div30), // PLLP = 30 → 16 MHz (USBOTG)
-        frac: Some(0),             // Fractional part (enabled)
-    });
-
-    config.rcc.ahb_pre = AHBPrescaler::Div1;
-    config.rcc.apb1_pre = APBPrescaler::Div1;
-    config.rcc.apb2_pre = APBPrescaler::Div1;
-    config.rcc.apb7_pre = APBPrescaler::Div1;
-    config.rcc.ahb5_pre = AHB5Prescaler::Div4;
-
+pub fn pll_init(_config: &mut Config) {
     // voltage scale for max performance
-    config.rcc.voltage_scale = VoltageScale::Range1;
     // route PLL1_P into the USB‐OTG‐HS block
-    config.rcc.sys = Sysclk::Pll1R;
 }
 
 #[embassy_executor::main]

--- a/examples/stm32wba6/src/bin/saes_ecb.rs
+++ b/examples/stm32wba6/src/bin/saes_ecb.rs
@@ -28,9 +28,6 @@
 #![no_main]
 
 use defmt::*;
-use embassy_stm32::rcc::{
-    AHB5Prescaler, AHBPrescaler, APBPrescaler, PllDiv, PllMul, PllPreDiv, PllSource, Sysclk, VoltageScale,
-};
 use embassy_stm32::saes::{AesCbc, AesEcb, Direction, Saes};
 use embassy_stm32::{Config, bind_interrupts, peripherals};
 use {defmt_rtt as _, panic_probe as _};
@@ -41,24 +38,7 @@ bind_interrupts!(struct Irqs {
 
 #[embassy_executor::main]
 async fn main(_spawner: embassy_executor::Spawner) {
-    let mut config = Config::default();
-    config.rcc.pll1 = Some(embassy_stm32::rcc::Pll {
-        source: PllSource::Hsi,
-        prediv: PllPreDiv::Div1,
-        mul: PllMul::Mul30,
-        divr: Some(PllDiv::Div5),
-        divq: None,
-        divp: Some(PllDiv::Div30),
-        frac: Some(0),
-    });
-    config.rcc.ahb_pre = AHBPrescaler::Div1;
-    config.rcc.apb1_pre = APBPrescaler::Div1;
-    config.rcc.apb2_pre = APBPrescaler::Div1;
-    config.rcc.apb7_pre = APBPrescaler::Div1;
-    config.rcc.ahb5_pre = AHB5Prescaler::Div4;
-    config.rcc.voltage_scale = VoltageScale::Range1;
-    config.rcc.sys = Sysclk::Pll1R;
-
+    let config = Config::default();
     let p = embassy_stm32::init(config);
     info!("SAES-ECB Example");
 

--- a/examples/stm32wba6/src/bin/saes_gcm.rs
+++ b/examples/stm32wba6/src/bin/saes_gcm.rs
@@ -25,9 +25,6 @@
 #![no_main]
 
 use defmt::*;
-use embassy_stm32::rcc::{
-    AHB5Prescaler, AHBPrescaler, APBPrescaler, PllDiv, PllMul, PllPreDiv, PllSource, Sysclk, VoltageScale,
-};
 use embassy_stm32::saes::{AesGcm, Direction, Saes};
 use embassy_stm32::{Config, bind_interrupts, peripherals};
 use {defmt_rtt as _, panic_probe as _};
@@ -38,24 +35,7 @@ bind_interrupts!(struct Irqs {
 
 #[embassy_executor::main]
 async fn main(_spawner: embassy_executor::Spawner) {
-    let mut config = Config::default();
-    config.rcc.pll1 = Some(embassy_stm32::rcc::Pll {
-        source: PllSource::Hsi,
-        prediv: PllPreDiv::Div1,
-        mul: PllMul::Mul30,
-        divr: Some(PllDiv::Div5),
-        divq: None,
-        divp: Some(PllDiv::Div30),
-        frac: Some(0),
-    });
-    config.rcc.ahb_pre = AHBPrescaler::Div1;
-    config.rcc.apb1_pre = APBPrescaler::Div1;
-    config.rcc.apb2_pre = APBPrescaler::Div1;
-    config.rcc.apb7_pre = APBPrescaler::Div1;
-    config.rcc.ahb5_pre = AHB5Prescaler::Div4;
-    config.rcc.voltage_scale = VoltageScale::Range1;
-    config.rcc.sys = Sysclk::Pll1R;
-
+    let config = Config::default();
     let p = embassy_stm32::init(config);
     info!("SAES-GCM Example");
 

--- a/examples/stm32wba6/src/bin/sdmmc_sai.rs
+++ b/examples/stm32wba6/src/bin/sdmmc_sai.rs
@@ -275,14 +275,7 @@ async fn main(spawner: Spawner) {
             divp: Some(PllDiv::Div30),
             frac: Some(2363),
         });
-
-        config.rcc.ahb_pre = AHBPrescaler::Div1;
-        config.rcc.apb1_pre = APBPrescaler::Div1;
-        config.rcc.apb2_pre = APBPrescaler::Div1;
-        config.rcc.apb7_pre = APBPrescaler::Div1;
         config.rcc.ahb5_pre = AHB5Prescaler::Div2;
-        config.rcc.voltage_scale = VoltageScale::Range1;
-
         config.rcc.mux.sai1sel = mux::Sai1sel::Pll1Q;
     }
 

--- a/examples/stm32wba6/src/bin/usb_host_hid.rs
+++ b/examples/stm32wba6/src/bin/usb_host_hid.rs
@@ -32,16 +32,7 @@ async fn main(_spawner: Spawner) {
             divp: Some(PllDiv::Div30), // PLLP = 30 → 16 MHz (USB_OTG_HS)
             frac: Some(0),
         });
-
-        config.rcc.ahb_pre = AHBPrescaler::Div1;
-        config.rcc.apb1_pre = APBPrescaler::Div1;
-        config.rcc.apb2_pre = APBPrescaler::Div1;
-        config.rcc.apb7_pre = APBPrescaler::Div1;
-        config.rcc.ahb5_pre = AHB5Prescaler::Div4;
-
-        config.rcc.voltage_scale = VoltageScale::Range1;
         config.rcc.mux.otghssel = mux::Otghssel::Pll1P;
-        config.rcc.sys = Sysclk::Pll1R;
     }
     let p = embassy_stm32::init(config);
 

--- a/examples/stm32wba6/src/bin/usb_host_serial.rs
+++ b/examples/stm32wba6/src/bin/usb_host_serial.rs
@@ -32,16 +32,7 @@ async fn main(_spawner: Spawner) {
             divp: Some(PllDiv::Div30), // PLLP = 30 → 16 MHz (USB_OTG_HS)
             frac: Some(0),
         });
-
-        config.rcc.ahb_pre = AHBPrescaler::Div1;
-        config.rcc.apb1_pre = APBPrescaler::Div1;
-        config.rcc.apb2_pre = APBPrescaler::Div1;
-        config.rcc.apb7_pre = APBPrescaler::Div1;
-        config.rcc.ahb5_pre = AHB5Prescaler::Div4;
-
-        config.rcc.voltage_scale = VoltageScale::Range1;
         config.rcc.mux.otghssel = mux::Otghssel::Pll1P;
-        config.rcc.sys = Sysclk::Pll1R;
     }
     let p = embassy_stm32::init(config);
 

--- a/examples/stm32wba6/src/bin/usb_hs_serial.rs
+++ b/examples/stm32wba6/src/bin/usb_hs_serial.rs
@@ -32,16 +32,7 @@ async fn main(_spawner: Spawner) {
             divp: Some(PllDiv::Div30), // PLLP = 30 → 16 MHz (USB_OTG_HS)
             frac: Some(0),             // Fractional part (disabled)
         });
-
-        config.rcc.ahb_pre = AHBPrescaler::Div1;
-        config.rcc.apb1_pre = APBPrescaler::Div1;
-        config.rcc.apb2_pre = APBPrescaler::Div1;
-        config.rcc.apb7_pre = APBPrescaler::Div1;
-        config.rcc.ahb5_pre = AHB5Prescaler::Div4;
-
-        config.rcc.voltage_scale = VoltageScale::Range1;
         config.rcc.mux.otghssel = mux::Otghssel::Pll1P;
-        config.rcc.sys = Sysclk::Pll1R;
     }
 
     let p = embassy_stm32::init(config);

--- a/examples/stm32wba6/src/bin/wwdg.rs
+++ b/examples/stm32wba6/src/bin/wwdg.rs
@@ -4,39 +4,16 @@
 use defmt::*;
 use embassy_executor::Spawner;
 use embassy_stm32::Config;
-use embassy_stm32::rcc::{
-    AHB5Prescaler, AHBPrescaler, APBPrescaler, PllDiv, PllMul, PllPreDiv, PllSource, Sysclk, VoltageScale,
-};
 use embassy_stm32::wdg::WindowWatchdog;
 use embassy_time::Timer;
 use {defmt_rtt as _, panic_probe as _};
 
 #[embassy_executor::main]
 async fn main(_spawner: Spawner) {
-    let mut config = Config::default();
+    let config = Config::default();
     // Fine-tune PLL1 dividers/multipliers
-    config.rcc.pll1 = Some(embassy_stm32::rcc::Pll {
-        source: PllSource::Hsi,
-        prediv: PllPreDiv::Div1,  // PLLM = 1 → HSI / 1 = 16 MHz
-        mul: PllMul::Mul30,       // PLLN = 30 → 16 MHz * 30 = 480 MHz VCO
-        divr: Some(PllDiv::Div5), // PLLR = 5 → 96 MHz (Sysclk)
-        // divq: Some(PllDiv::DIV10), // PLLQ = 10 → 48 MHz (NOT USED)
-        divq: None,
-        divp: Some(PllDiv::Div30), // PLLP = 30 → 16 MHz (USBOTG)
-        frac: Some(0),             // Fractional part (enabled)
-    });
-
-    config.rcc.ahb_pre = AHBPrescaler::Div1;
-    config.rcc.apb1_pre = APBPrescaler::Div1;
-    config.rcc.apb2_pre = APBPrescaler::Div1;
-    config.rcc.apb7_pre = APBPrescaler::Div1;
-    config.rcc.ahb5_pre = AHB5Prescaler::Div4;
-
     // voltage scale for max performance
-    config.rcc.voltage_scale = VoltageScale::Range1;
     // route PLL1_R into Sysclk
-    config.rcc.sys = Sysclk::Pll1R;
-
     let p = embassy_stm32::init(config);
     info!("WWDG example");
 

--- a/tests/stm32/src/common.rs
+++ b/tests/stm32/src/common.rs
@@ -831,12 +831,14 @@ pub fn config() -> Config {
     #[cfg(feature = "stm32wba52cg")]
     {
         config.rcc.sys = Sysclk::Hsi;
+        config.rcc.ahb5_pre = AHB5Prescaler::Div1;
         config.rcc.mux.rngsel = mux::Rngsel::Hsi;
     }
 
     #[cfg(feature = "stm32wba65ri")]
     {
         config.rcc.sys = Sysclk::Hsi;
+        config.rcc.ahb5_pre = AHB5Prescaler::Div1;
         config.rcc.mux.rngsel = mux::Rngsel::Hsi;
         config.rcc.mux.sai1sel = mux::Sai1sel::Hsi;
     }


### PR DESCRIPTION
## Summary
- update WBA RCC defaults to the common WBA6 baseline (`PLL1`-based `SYSCLK=96MHz`, `AHB5=DIV4`, `Range1`) so `Config::default()` matches what many WBA6 examples configured manually
- remove duplicated baseline RCC setup across `examples/stm32wba6` bins and keep only per-example clock overrides (USB OTG source, custom SAI/SDMMC PLL/mux, RNG mux, etc.)
- simplify imports in touched examples after removing redundant RCC assignments