### PR TITLE
embassy-rp: Add runtime baud rate reconfiguration for PIO UART

### DIFF
--- a/embassy-rp/src/pio_programs/uart.rs
+++ b/embassy-rp/src/pio_programs/uart.rs
@@ -77,6 +77,18 @@ impl<'d, PIO: Instance, const SM: usize> PioUartTx<'d, PIO, SM> {
     pub async fn write_u8(&mut self, data: u8) {
         self.sm_tx.tx().wait_push(data as u32).await;
     }
+
+
+    /// Change Baud Rate 
+    pub async fn change_baud_rate(&mut self, baud:u32){
+        self.sm_tx.set_enable(false);
+        self.sm_tx.clear_fifos();
+        self.sm_tx.restart();
+
+        let clock_divider = (clk_sys_freq() / (8 * baud)).to_fixed();
+        self.sm_tx.set_clock_divider(clock_divider);
+        self.sm_tx.set_enable(true);
+    }
 }
 
 impl<PIO: Instance, const SM: usize> ErrorType for PioUartTx<'_, PIO, SM> {
@@ -172,6 +184,18 @@ impl<'d, PIO: Instance, const SM: usize> PioUartRx<'d, PIO, SM> {
     pub async fn read_u8(&mut self) -> u8 {
         self.sm_rx.rx().wait_pull().await as u8
     }
+    
+    /// Change Baud Rate 
+    pub async fn change_baud_rate(&mut self, baud:u32){
+        self.sm_rx.set_enable(false);
+        self.sm_rx.clear_fifos();
+        self.sm_rx.restart();
+
+        let clock_divider = (clk_sys_freq() / (8 * baud)).to_fixed();
+        self.sm_rx.set_clock_divider(clock_divider);
+        self.sm_rx.set_enable(true);
+    }
+
 }
 
 impl<PIO: Instance, const SM: usize> ErrorType for PioUartRx<'_, PIO, SM> {

--- a/embassy-rp/src/pio_programs/uart.rs
+++ b/embassy-rp/src/pio_programs/uart.rs
@@ -80,9 +80,8 @@ impl<'d, PIO: Instance, const SM: usize> PioUartTx<'d, PIO, SM> {
         self.sm_tx.tx().wait_push(data as u32).await;
     }
 
-    /// Change Baud Rate, make sure the communication stopped before changingthe baud rate in run time
-    /// if not data can be lost  
-    pub fn change_baud_rate(&mut self, baud: u32) {
+    /// Change baud rate on run time  
+    pub fn set_baudrate(&mut self, baud: u32) {
         let clock_divider: FixedU32<U8> = (clk_sys_freq() / (8 * baud)).to_fixed();
         self.sm_tx.set_enable(false);
         self.sm_tx.clear_fifos();
@@ -186,9 +185,8 @@ impl<'d, PIO: Instance, const SM: usize> PioUartRx<'d, PIO, SM> {
         self.sm_rx.rx().wait_pull().await as u8
     }
 
-    /// Change Baud Rate, make sure the communication stopped before changing it in run time
-    /// if not data can be lost  
-    pub fn change_baud_rate(&mut self, baud: u32) {
+    /// Change Baud rate on runtime
+    pub fn set_baudrate(&mut self, baud: u32) {
         let clock_divider: FixedU32<U8> = (clk_sys_freq() / (8 * baud)).to_fixed();
         self.sm_rx.set_enable(false);
         self.sm_rx.clear_fifos();

--- a/embassy-rp/src/pio_programs/uart.rs
+++ b/embassy-rp/src/pio_programs/uart.rs
@@ -82,7 +82,7 @@ impl<'d, PIO: Instance, const SM: usize> PioUartTx<'d, PIO, SM> {
     /// Change Baud Rate, make sure the communication stopped before changingthe baud rate in run time 
     /// if not data can be lost  
     pub async fn change_baud_rate(&mut self, baud:u32){
-        let clock_divider = (clk_sys_freq() as f32 / (8 * baud as f32)).to_fixed();
+        let clock_divider = (clk_sys_freq() / (8 * baud)).to_fixed();
         self.sm_tx.set_enable(false);
         self.sm_tx.clear_fifos();
         self.sm_tx.restart();
@@ -189,7 +189,7 @@ impl<'d, PIO: Instance, const SM: usize> PioUartRx<'d, PIO, SM> {
     /// Change Baud Rate, make sure the communication stopped before changing it in run time 
     /// if not data can be lost  
     pub async fn change_baud_rate(&mut self, baud:u32){
-        let clock_divider = (clk_sys_freq() as f32 / (8 * baud as f32)).to_fixed();
+        let clock_divider = (clk_sys_freq() / (8.0 * baud)).to_fixed();
         self.sm_rx.set_enable(false);
         self.sm_rx.clear_fifos();
         self.sm_rx.restart();

--- a/embassy-rp/src/pio_programs/uart.rs
+++ b/embassy-rp/src/pio_programs/uart.rs
@@ -2,16 +2,17 @@
 
 use core::convert::Infallible;
 
+use embedded_io_async::{ErrorType, Read, Write};
+use fixed::FixedU32;
+use fixed::traits::ToFixed;
+use fixed::types::extra::U8;
+
 use crate::Peri;
 use crate::clocks::clk_sys_freq;
 use crate::gpio::Level;
 use crate::pio::{
     Common, Config, Direction as PioDirection, FifoJoin, Instance, LoadedProgram, PioPin, ShiftDirection, StateMachine,
 };
-use embedded_io_async::{ErrorType, Read, Write};
-use fixed::FixedU32;
-use fixed::traits::ToFixed;
-use fixed::types::extra::U8;
 
 /// This struct represents a uart tx program loaded into pio instruction memory.
 pub struct PioUartTxProgram<'d, PIO: Instance> {

--- a/embassy-rp/src/pio_programs/uart.rs
+++ b/embassy-rp/src/pio_programs/uart.rs
@@ -82,7 +82,7 @@ impl<'d, PIO: Instance, const SM: usize> PioUartTx<'d, PIO, SM> {
 
     /// Change Baud Rate, make sure the communication stopped before changingthe baud rate in run time
     /// if not data can be lost  
-    pub async fn change_baud_rate(&mut self, baud: u32) {
+    pub fn change_baud_rate(&mut self, baud: u32) {
         let clock_divider: FixedU32<U8> = (clk_sys_freq() / (8 * baud)).to_fixed();
         self.sm_tx.set_enable(false);
         self.sm_tx.clear_fifos();
@@ -188,7 +188,7 @@ impl<'d, PIO: Instance, const SM: usize> PioUartRx<'d, PIO, SM> {
 
     /// Change Baud Rate, make sure the communication stopped before changing it in run time
     /// if not data can be lost  
-    pub async fn change_baud_rate(&mut self, baud: u32) {
+    pub fn change_baud_rate(&mut self, baud: u32) {
         let clock_divider: FixedU32<U8> = (clk_sys_freq() / (8 * baud)).to_fixed();
         self.sm_rx.set_enable(false);
         self.sm_rx.clear_fifos();

--- a/embassy-rp/src/pio_programs/uart.rs
+++ b/embassy-rp/src/pio_programs/uart.rs
@@ -2,15 +2,16 @@
 
 use core::convert::Infallible;
 
-use embedded_io_async::{ErrorType, Read, Write};
-use fixed::traits::ToFixed;
-
 use crate::Peri;
 use crate::clocks::clk_sys_freq;
 use crate::gpio::Level;
 use crate::pio::{
     Common, Config, Direction as PioDirection, FifoJoin, Instance, LoadedProgram, PioPin, ShiftDirection, StateMachine,
 };
+use embedded_io_async::{ErrorType, Read, Write};
+use fixed::FixedU32;
+use fixed::traits::ToFixed;
+use fixed::types::extra::U8;
 
 /// This struct represents a uart tx program loaded into pio instruction memory.
 pub struct PioUartTxProgram<'d, PIO: Instance> {
@@ -78,11 +79,10 @@ impl<'d, PIO: Instance, const SM: usize> PioUartTx<'d, PIO, SM> {
         self.sm_tx.tx().wait_push(data as u32).await;
     }
 
-
-    /// Change Baud Rate, make sure the communication stopped before changingthe baud rate in run time 
+    /// Change Baud Rate, make sure the communication stopped before changingthe baud rate in run time
     /// if not data can be lost  
-    pub async fn change_baud_rate(&mut self, baud:u32){
-        let clock_divider = (clk_sys_freq() / (8 * baud)).to_fixed();
+    pub async fn change_baud_rate(&mut self, baud: u32) {
+        let clock_divider: FixedU32<U8> = (clk_sys_freq() / (8 * baud)).to_fixed();
         self.sm_tx.set_enable(false);
         self.sm_tx.clear_fifos();
         self.sm_tx.restart();
@@ -185,18 +185,16 @@ impl<'d, PIO: Instance, const SM: usize> PioUartRx<'d, PIO, SM> {
         self.sm_rx.rx().wait_pull().await as u8
     }
 
-
-    /// Change Baud Rate, make sure the communication stopped before changing it in run time 
+    /// Change Baud Rate, make sure the communication stopped before changing it in run time
     /// if not data can be lost  
-    pub async fn change_baud_rate(&mut self, baud:u32){
-        let clock_divider = (clk_sys_freq() / (8.0 * baud)).to_fixed();
+    pub async fn change_baud_rate(&mut self, baud: u32) {
+        let clock_divider: FixedU32<U8> = (clk_sys_freq() / (8 * baud)).to_fixed();
         self.sm_rx.set_enable(false);
         self.sm_rx.clear_fifos();
         self.sm_rx.restart();
         self.sm_rx.set_clock_divider(clock_divider);
         self.sm_rx.set_enable(true);
     }
-
 }
 
 impl<PIO: Instance, const SM: usize> ErrorType for PioUartRx<'_, PIO, SM> {

--- a/embassy-rp/src/pio_programs/uart.rs
+++ b/embassy-rp/src/pio_programs/uart.rs
@@ -82,11 +82,10 @@ impl<'d, PIO: Instance, const SM: usize> PioUartTx<'d, PIO, SM> {
     /// Change Baud Rate, make sure the communication stopped before changingthe baud rate in run time 
     /// if not data can be lost  
     pub async fn change_baud_rate(&mut self, baud:u32){
+        let clock_divider = (clk_sys_freq() as f32 / (8 * baud as f32)).to_fixed();
         self.sm_tx.set_enable(false);
         self.sm_tx.clear_fifos();
         self.sm_tx.restart();
-
-        let clock_divider = (clk_sys_freq() as f32 / (8 * baud as f32)).to_fixed();
         self.sm_tx.set_clock_divider(clock_divider);
         self.sm_tx.set_enable(true);
     }
@@ -190,11 +189,10 @@ impl<'d, PIO: Instance, const SM: usize> PioUartRx<'d, PIO, SM> {
     /// Change Baud Rate, make sure the communication stopped before changing it in run time 
     /// if not data can be lost  
     pub async fn change_baud_rate(&mut self, baud:u32){
+        let clock_divider = (clk_sys_freq() as f32 / (8 * baud as f32)).to_fixed();
         self.sm_rx.set_enable(false);
         self.sm_rx.clear_fifos();
         self.sm_rx.restart();
-
-        let clock_divider = (clk_sys_freq() as f32 / (8 * baud as f32)).to_fixed();
         self.sm_rx.set_clock_divider(clock_divider);
         self.sm_rx.set_enable(true);
     }

--- a/embassy-rp/src/pio_programs/uart.rs
+++ b/embassy-rp/src/pio_programs/uart.rs
@@ -79,13 +79,14 @@ impl<'d, PIO: Instance, const SM: usize> PioUartTx<'d, PIO, SM> {
     }
 
 
-    /// Change Baud Rate 
+    /// Change Baud Rate, make sure the communication stopped before changingthe baud rate in run time 
+    /// if not data can be lost  
     pub async fn change_baud_rate(&mut self, baud:u32){
         self.sm_tx.set_enable(false);
         self.sm_tx.clear_fifos();
         self.sm_tx.restart();
 
-        let clock_divider = (clk_sys_freq() / (8 * baud)).to_fixed();
+        let clock_divider = (clk_sys_freq() as f32 / (8 * baud as f32)).to_fixed();
         self.sm_tx.set_clock_divider(clock_divider);
         self.sm_tx.set_enable(true);
     }
@@ -184,14 +185,16 @@ impl<'d, PIO: Instance, const SM: usize> PioUartRx<'d, PIO, SM> {
     pub async fn read_u8(&mut self) -> u8 {
         self.sm_rx.rx().wait_pull().await as u8
     }
-    
-    /// Change Baud Rate 
+
+
+    /// Change Baud Rate, make sure the communication stopped before changing it in run time 
+    /// if not data can be lost  
     pub async fn change_baud_rate(&mut self, baud:u32){
         self.sm_rx.set_enable(false);
         self.sm_rx.clear_fifos();
         self.sm_rx.restart();
 
-        let clock_divider = (clk_sys_freq() / (8 * baud)).to_fixed();
+        let clock_divider = (clk_sys_freq() as f32 / (8 * baud as f32)).to_fixed();
         self.sm_rx.set_clock_divider(clock_divider);
         self.sm_rx.set_enable(true);
     }


### PR DESCRIPTION
Adding the possibility to change PioUartRx and PioUartTx RP2xxx baud rate in runtime, by changing the clock divisor on state machine..

It's my first PR so some support may be needed. 