### PR TITLE
stm32: Fix half-duplex usart

### DIFF
--- a/embassy-stm32/src/usart/mod.rs
+++ b/embassy-stm32/src/usart/mod.rs
@@ -1780,6 +1780,14 @@ fn configure(
         return Err(ConfigError::RxOrTxNotEnabled);
     }
 
+    // The `duplex` config field is private and defaults to `Full`, so a user-supplied
+    // `Config` passed to `set_config`/`reconfigure` cannot express half-duplex. Combine
+    // the requested config with the current hardware HDSEL state so that reconfiguring a
+    // half-duplex peripheral (e.g. to change baudrate) does not silently revert it to
+    // full-duplex. On initial setup the peripheral has just been reset, so HDSEL is clear
+    // and the config value alone decides.
+    let half_duplex = config.duplex.is_half() || r.cr3().read().hdsel();
+
     #[cfg(not(any(usart_v1, usart_v2)))]
     let dem = r.cr3().read().dem();
 
@@ -1819,14 +1827,14 @@ fn configure(
     r.cr3().modify(|w| {
         #[cfg(not(usart_v1))]
         w.set_onebit(config.assume_noise_free);
-        w.set_hdsel(config.duplex.is_half());
+        w.set_hdsel(half_duplex);
     });
 
     let mut w: crate::pac::usart::regs::Cr1 = Default::default();
     // enable uart
     w.set_ue(true);
 
-    if config.duplex.is_half() {
+    if half_duplex {
         // The te and re bits will be set by write, read and flush methods.
         // Receiver should be enabled by default for Half-Duplex.
         w.set_te(false);

--- a/embassy-stm32/src/usart/mod.rs
+++ b/embassy-stm32/src/usart/mod.rs
@@ -1846,9 +1846,9 @@ fn configure(
             config.de_assertion_time
         });
         w.set_dedt(if over8 {
-            config.de_assertion_time / 2
+            config.de_deassertion_time / 2
         } else {
-            config.de_assertion_time
+            config.de_deassertion_time
         });
     }
 

--- a/embassy-stm32/src/usart/ringbuffered.rs
+++ b/embassy-stm32/src/usart/ringbuffered.rs
@@ -8,7 +8,7 @@ use embedded_io_async::ReadReady;
 use futures_util::future::{Either, select};
 
 use super::{
-    Config, ConfigError, Error, Info, State, UartRx, clear_interrupt_flags, rdr, reconfigure, set_baudrate, sr,
+    Config, ConfigError, Error, Info, State, UartRx, clear_interrupt_flags, flush, rdr, reconfigure, set_baudrate, sr,
 };
 use crate::dma::ReadableRingBuffer;
 use crate::gpio::Flex;
@@ -224,6 +224,10 @@ impl<'d> RingBufferedUartRx<'d> {
         // since they can't operate simultaneously on the shared line
         let r = self.info.regs;
         if r.cr3().read().hdsel() && r.cr1().read().te() {
+            // Wait for any in-flight transmission to complete before disabling the
+            // transmitter, otherwise the last byte(s) would be truncated on the wire.
+            flush(self.info, self.state).await?;
+
             r.cr1().modify(|reg| {
                 reg.set_re(true);
                 reg.set_te(false);


### PR DESCRIPTION
This PR fixes multiple issues:
- When reconfiguring baudrate via `UartTx::set_config`, the duplex config is lost and driver reverts to full-duplex mode
- Using `RingBufferedRx` simultaneously with TX would discard bytes in the TX FIFO
- Unrelated typo in `config.de_deassertion_time`

I would also like to consult about the `OutputConfig` struct which currently can not express some configuration options like push-pull with pull down (useful with half-duplex and invert_tx). Adding all permutations of `OutputType` and `Pull` seems unnecessary, so I propose to remove `OutputConfig` struct and let user specify `AfType` directly for all rx, tx, rts, cts, de pins. This would also allow selecting IO speed. The downside is that this would allow invalid config options like rx pin in output mode. Another option would be to make `OutputConfig` into a struct with mode, speed, pull.