### PR TITLE
fix: add hse wpan init, failing assert issue

### DIFF
--- a/embassy-stm32-wpan/src/wba/linklayer_plat.rs
+++ b/embassy-stm32-wpan/src/wba/linklayer_plat.rs
@@ -752,10 +752,21 @@ pub unsafe extern "C" fn LINKLAYER_PLAT_DelayUs(delay: u32) {
 //   * @param  condition: conditional statement to be checked.
 //   * @retval None
 //   */
+// Some of these sanity checks fire on production silicon — e.g. an IP-version
+// probe inside the PHY init path can return the silicon-default response on
+// early WBA5x cuts, which doesn't match the value the type-7 PHY code
+// expects. ST's reference HAL project templates define `assert_failed()` with
+// an empty body, so the link-layer archive is designed to continue past a
+// failed assert.
+//
+// We mirror that here: log the failed assert (with the return address so it
+// can be looked up in the archive's disassembly) but do not halt.
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn LINKLAYER_PLAT_Assert(condition: u8) {
     if condition == 0 {
-        panic!("LINKLAYER_PLAT assertion failed");
+        let lr: u32;
+        core::arch::asm!("mov {}, lr", out(reg) lr);
+        warn!("LINKLAYER_PLAT_Assert(0) at LR=0x{:08x}", lr);
     }
 }
 

--- a/embassy-stm32/src/rcc/wba.rs
+++ b/embassy-stm32/src/rcc/wba.rs
@@ -123,6 +123,30 @@ impl Config {
         rcc
     }
 
+    /// BLE radio config for boards that have HSE but no LSE crystal.
+    ///
+    /// Identical to [`new_wpan`](Self::new_wpan) except the BLE radio sleep timer
+    /// is sourced from `HSE / 1000` (≈32 kHz) instead of LSE, and the RTC peripheral
+    /// falls back to LSI (since no LSE is available).
+    ///
+    /// Prefer this over [`new_wpan_lsi`](Self::new_wpan_lsi) when HSE is available:
+    /// the HSE crystal is much more accurate than LSI (~50 ppm vs ~1–2 %), which
+    /// keeps BLE sleep-clock tolerance tight and reduces wake-up margin overhead.
+    ///
+    /// RADIOSTSEL is set to `Hse` (hardware bit value 0x03).
+    pub const fn new_wpan_hse() -> Self {
+        let mut rcc = Self::new_wpan();
+
+        rcc.ls = LsConfig {
+            rtc: RtcClockSource::Lsi,
+            lsi: true,
+            lse: None,
+        };
+        rcc.mux.radiostsel = mux::Radiostsel::Hse;
+
+        rcc
+    }
+
     pub const fn new_wpan() -> Self {
         let mut rcc = Self::new();
 


### PR DESCRIPTION
# PR Summary

Adds an HSE-sourced BLE sleep-timer clock config for STM32WBA boards that lack an LSE crystal, and demotes the closed-source link-layer assert handler from `panic!()` to a non-halting `warn!`.

## 1. `rcc::Config::new_wpan_hse()` — new helper for boards without LSE

Tested on a WBA52 board that has HSE wired up but no LSE crystal.

The existing `new_wpan` requires LSE. `new_wpan_lsi` works without LSE but drives the BLE sleep timer from the internal LSI RC, which has ~1–2% drift and forces large wake-up guard bands. On any board that has HSE but no LSE, routing the radio sleep timer through `HSE / 1000` (≈32 kHz, ~50 ppm) gives much tighter tolerance — at the cost of needing HSE running through Stop modes that touch the radio, which is already the case during BLE sessions.

The new function mirrors `new_wpan_lsi` exactly except it sets `mux.radiostsel = Radiostsel::Hse` (RADIOSTSEL field = `0x03`). The RTC peripheral still falls back to LSI since the board has no LSE.

## 2. `LINKLAYER_PLAT_Assert` — log instead of panic

The closed-source link-layer archive (`libble_basic*.a`) calls `LINKLAYER_PLAT_Assert(condition)` on several internal sanity checks. At least two of those fire on production silicon during BLE stack init, so the previous `panic!("LINKLAYER_PLAT assertion failed")` bricked otherwise-functional boards.

On our WBA52 silicon the archive asserts twice during init (LR values from our trace, looked up in the archive disassembly):

- **`LR=0x08030d07`** — inside `llhwc_phy_init`, type-7 PHY initialization path. The archive issues an IP-version probe via `write_cfg_fifo_batch` and asserts that the 4 response bytes equal a post-firmware-load expected value of `0x03 0x00 0x1a 0x00`. Our silicon returns `0x02 0x30 0x1a 0x00` (the silicon default before the radio firmware is loaded). The first two bytes never match.
- **`LR=0x0803296b`** — second post-PHY-init check that depends on the same response.

ST's own HAL project templates wire `LINKLAYER_PLAT_Assert` → `assert_param(condition)` → `assert_failed()`, where the body of `assert_failed()` in the generated `main.c` is an **empty stub**. So in ST's reference flow the assert is effectively a no-op, and the archive is designed to continue past it. A `panic!()` here is stricter than ST's own reference and prevents the archive from completing init.

The new handler logs a `warn!` with the link register so the firing site can be looked up in the archive, then returns — matching ST's reference behavior. Verified: BLE stack initializes, controller responds to HCI, GATT init succeeds, and the board advertises normally.