### PR TITLE
stm32/fdcan: fix range filter bounds

### DIFF
--- a/embassy-stm32/CHANGELOG.md
+++ b/embassy-stm32/CHANGELOG.md
@@ -8,6 +8,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 <!-- next-header -->
 ## Unreleased - ReleaseDate
 
+CAN:
+- fix: stm32/can/fdcan: write `FilterType::Range` bounds in the correct order (`from`→SFID1/EFID1, `to`→SFID2/EFID2). The swapped order prevented normal multi-ID ranges from matching, breaking both accepting and rejecting range filters.
+
 DMA:
 - fix: stm32/dma: fix HTIF masking TCIF in on_irq when both flags fire simultaneously
 - fix: stm32/dma: defer read_index advance until after copy in read_raw to avoid partial-advance on overrun

--- a/embassy-stm32/src/can/fd/filter.rs
+++ b/embassy-stm32/src/can/fd/filter.rs
@@ -334,7 +334,7 @@ impl ActivateFilter<StandardId, u16> for message_ram::StandardFilter {
         let sft = f.filter.into();
 
         let (sfid1, sfid2) = match f.filter {
-            FilterType::Range { to, from } => (to.as_raw(), from.as_raw()),
+            FilterType::Range { from, to } => (from.as_raw(), to.as_raw()),
             FilterType::DedicatedSingle(id) => (id.as_raw(), id.as_raw()),
             FilterType::DedicatedDual(id1, id2) => (id1.as_raw(), id2.as_raw()),
             FilterType::BitMask { filter, mask } => (filter, mask),
@@ -358,7 +358,7 @@ impl ActivateFilter<ExtendedId, u32> for message_ram::ExtendedFilter {
         let eft = f.filter.into();
 
         let (efid1, efid2) = match f.filter {
-            FilterType::Range { to, from } => (to.as_raw(), from.as_raw()),
+            FilterType::Range { from, to } => (from.as_raw(), to.as_raw()),
             FilterType::DedicatedSingle(id) => (id.as_raw(), id.as_raw()),
             FilterType::DedicatedDual(id1, id2) => (id1.as_raw(), id2.as_raw()),
             FilterType::BitMask { filter, mask } => (filter, mask),


### PR DESCRIPTION
Fixes FDCAN range filter encoding for both standard and extended IDs.

`FilterType::Range` currently writes the bounds in reverse order: `to` goes to `SFID1/EFID1`, and `from` goes to `SFID2/EFID2`.

M_CAN defines range filters as ID1 through ID2, with ID2 >= ID1. With the bounds reversed, normal ranges where `from < to` do not match, so range filters do not work.

This changes range activation to write:

- `from` -> `SFID1/EFID1`
- `to` -> `SFID2/EFID2`

Confirmed in:
1. Bosch M_CAN User Manual, sections _2.4.5 Standard Message ID Filter Element_ and _2.4.6 Extended Message ID Filter Element_
2. ST AN5348, section _4.3.1 RAM filtering sections_, Table 5 _Standard filter element configuration_. ST's example uses `SFID1=0x16` and `SFID2=0x20` for the range `[0x16..0x20]`, and notes that standard filters are configured in the same way as extended filters.