### PR TITLE
stm32/wba: bundle low-power, HSEM layout

### DIFF
--- a/embassy-stm32-wpan/src/wba/ll_sys_if.rs
+++ b/embassy-stm32-wpan/src/wba/ll_sys_if.rs
@@ -415,9 +415,51 @@ pub unsafe extern "C" fn ll_sys_sleep_clock_source_selection() {
 }
 
 /// Determine the BLE sleep-clock accuracy used by the stack.
-/// Returns zero when board-specific calibration data is unavailable.
+///
+/// Values follow the BLE Sleep Clock Accuracy range encoding used by the
+/// link-layer/HCI (0 = 251-500 ppm ... 7 = 0-20 ppm).
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn ll_sys_BLE_sleep_clock_accuracy_selection() -> u8 {
-    // TODO: derive the board-specific sleep clock accuracy once calibration data is available.
-    0
+    use embassy_stm32::pac::RCC;
+    use embassy_stm32::pac::rcc::vals::Radiostsel;
+
+    // BLE SCA range encoding (Bluetooth Core, Vol 6, Part B).
+    const BLE_SCA_251_TO_500_PPM: u8 = 0;
+    const BLE_SCA_021_TO_030_PPM: u8 = 6;
+
+    // Optional build-time override for board-specific characterization.
+    //
+    // Example:
+    // EMBASSY_WBA_BLE_SCA_RANGE=7 cargo build ...
+    //
+    // Valid values: 0..=7 (BLE SCA encoding).
+    if let Some(override_sca) = parse_ble_sca_override() {
+        return override_sca;
+    }
+
+    match RCC.bdcr().read().radiostsel() {
+        // Typical 32.768 kHz crystal population on WBA boards targets this range.
+        // If your board's 32 kHz source is better, this can be tightened later.
+        Radiostsel::Lse => BLE_SCA_021_TO_030_PPM,
+        // LSI is RC-based and significantly less accurate.
+        Radiostsel::Lsi => BLE_SCA_251_TO_500_PPM,
+        // HSE/1000 sleep-timer source is usually crystal-derived and tight.
+        Radiostsel::Hse => BLE_SCA_021_TO_030_PPM,
+        Radiostsel::Disable => BLE_SCA_251_TO_500_PPM,
+    }
+}
+
+#[inline]
+fn parse_ble_sca_override() -> Option<u8> {
+    match option_env!("EMBASSY_WBA_BLE_SCA_RANGE") {
+        Some("0") => Some(0),
+        Some("1") => Some(1),
+        Some("2") => Some(2),
+        Some("3") => Some(3),
+        Some("4") => Some(4),
+        Some("5") => Some(5),
+        Some("6") => Some(6),
+        Some("7") => Some(7),
+        _ => None,
+    }
 }

--- a/embassy-stm32/src/hsem/mod.rs
+++ b/embassy-stm32/src/hsem/mod.rs
@@ -10,10 +10,9 @@ use embassy_hal_internal::PeripheralType;
 use embassy_sync::waitqueue::AtomicWaker;
 use interrupt::typelevel::Interrupt;
 
-// TODO: This code works for all HSEM implemenations except for the STM32WBA52/4/5xx MCUs.
-// Those MCUs have a different HSEM implementation (Secure semaphore lock support,
-// Privileged / unprivileged semaphore lock support, Semaphore lock protection via semaphore attribute),
-// which is not yet supported by this code.
+// NOTE: STM32WBA5/6 expose additional secure/privileged HSEM features.
+// The nonsecure lock/listen flow used here is compatible with the common
+// semaphore interface and remains usable across WBA52/54/55/65 families.
 use crate::Peri;
 use crate::cpu::CoreId;
 use crate::peripherals::HSEM;
@@ -27,9 +26,16 @@ pub enum HsemError {
     LockFailed,
 }
 
+#[cfg(stm32wba)]
+const CHANNELS: usize = 16;
+#[cfg(not(stm32wba))]
 const CHANNELS: usize = 6;
 
-#[cfg(all(not(all(stm32wb, feature = "low-power")), not(all(stm32wl5x, feature = "low-power"))))]
+#[cfg(all(stm32wba, not(feature = "low-power")))]
+const PUB_CHANNELS: usize = 16;
+#[cfg(all(stm32wba, feature = "low-power"))]
+const PUB_CHANNELS: usize = 16;
+#[cfg(all(not(stm32wba), not(all(stm32wb, feature = "low-power")), not(all(stm32wl5x, feature = "low-power"))))]
 const PUB_CHANNELS: usize = 6;
 
 #[cfg(all(stm32wl5x, feature = "low-power"))]
@@ -367,6 +373,28 @@ impl<T: Instance> HardwareSemaphore<T> {
     ///
     /// If using low-power mode, channels 3 and 4 will not be returned
     pub const fn split<'a>(self) -> [HardwareSemaphoreChannel<'a, T>; PUB_CHANNELS] {
+        #[cfg(stm32wba)]
+        {
+            [
+                HardwareSemaphoreChannel::new(1),
+                HardwareSemaphoreChannel::new(2),
+                HardwareSemaphoreChannel::new(3),
+                HardwareSemaphoreChannel::new(4),
+                HardwareSemaphoreChannel::new(5),
+                HardwareSemaphoreChannel::new(6),
+                HardwareSemaphoreChannel::new(7),
+                HardwareSemaphoreChannel::new(8),
+                HardwareSemaphoreChannel::new(9),
+                HardwareSemaphoreChannel::new(10),
+                HardwareSemaphoreChannel::new(11),
+                HardwareSemaphoreChannel::new(12),
+                HardwareSemaphoreChannel::new(13),
+                HardwareSemaphoreChannel::new(14),
+                HardwareSemaphoreChannel::new(15),
+                HardwareSemaphoreChannel::new(16),
+            ]
+        }
+        #[cfg(not(stm32wba))]
         [
             HardwareSemaphoreChannel::new(1),
             HardwareSemaphoreChannel::new(2),

--- a/embassy-stm32/src/hsem/mod.rs
+++ b/embassy-stm32/src/hsem/mod.rs
@@ -35,7 +35,11 @@ const CHANNELS: usize = 6;
 const PUB_CHANNELS: usize = 16;
 #[cfg(all(stm32wba, feature = "low-power"))]
 const PUB_CHANNELS: usize = 16;
-#[cfg(all(not(stm32wba), not(all(stm32wb, feature = "low-power")), not(all(stm32wl5x, feature = "low-power"))))]
+#[cfg(all(
+    not(stm32wba),
+    not(all(stm32wb, feature = "low-power")),
+    not(all(stm32wl5x, feature = "low-power"))
+))]
 const PUB_CHANNELS: usize = 6;
 
 #[cfg(all(stm32wl5x, feature = "low-power"))]

--- a/embassy-stm32/src/low_power.rs
+++ b/embassy-stm32/src/low_power.rs
@@ -196,6 +196,9 @@ mod platform {
         });
         #[cfg(stm32wba)]
         crate::pac::PWR.sr().modify(|w| w.set_cssf(true));
+        #[cfg(stm32wba)]
+        // Clear WKUP1..WKUP8 pending flags (CWUFx) before stop entry.
+        crate::pac::PWR.wuscr().write(|w| w.0 = 0xff);
 
         #[cfg(stm32l0)]
         crate::pac::PWR.cr().modify(|w| w.set_cwuf(true));
@@ -301,16 +304,6 @@ mod platform {
             }
         }
     }
-
-    /// WBA-specific pre-stop cleanup.
-    ///
-    /// The reference manual requires wakeup pending flags to be cleared before
-    /// entering Stop, otherwise Stop entry may be ignored.
-    #[cfg(stm32wba)]
-    pub fn clear_wakeup_flags() {
-        // Clear WKUP1..WKUP8 pending flags (CWUFx).
-        crate::pac::PWR.wuscr().write(|w| w.0 = 0xff);
-    }
 }
 
 static STOP_ENTERED: AtomicBool = AtomicBool::new(false);
@@ -333,8 +326,6 @@ fn configure_pwr(cs: CriticalSection) {
 
     get_scb().clear_sleepdeep();
     platform::clear_flags();
-    #[cfg(stm32wba)]
-    platform::clear_wakeup_flags();
 
     compiler_fence(Ordering::Acquire);
 

--- a/embassy-stm32/src/low_power.rs
+++ b/embassy-stm32/src/low_power.rs
@@ -301,6 +301,16 @@ mod platform {
             }
         }
     }
+
+    /// WBA-specific pre-stop cleanup.
+    ///
+    /// The reference manual requires wakeup pending flags to be cleared before
+    /// entering Stop, otherwise Stop entry may be ignored.
+    #[cfg(stm32wba)]
+    pub fn clear_wakeup_flags() {
+        // Clear WKUP1..WKUP8 pending flags (CWUFx).
+        crate::pac::PWR.wuscr().write(|w| w.0 = 0xff);
+    }
 }
 
 static STOP_ENTERED: AtomicBool = AtomicBool::new(false);
@@ -323,6 +333,8 @@ fn configure_pwr(cs: CriticalSection) {
 
     get_scb().clear_sleepdeep();
     platform::clear_flags();
+    #[cfg(stm32wba)]
+    platform::clear_wakeup_flags();
 
     compiler_fence(Ordering::Acquire);
 


### PR DESCRIPTION
## Summary
- improve WBA low-power sleep timing/stop-entry robustness in the core low-power path
- add WBA 16-channel HSEM layout support for correct semaphore addressing

## Included source branches/commits
- `feat/wba-main-lowpower-hsem` (low-power + HSEM commits)