### PR TITLE
stm32/timer: consolidate QEI, OCREF clear, Hall, break, dithering, and status APIs

### DIFF
--- a/embassy-stm32/CHANGELOG.md
+++ b/embassy-stm32/CHANGELOG.md
@@ -33,6 +33,7 @@ COMP:
 Timer:
 - feat: stm32/timer/input_capture: add per-channel split API for concurrent multi-channel capture
 - feat: stm32/timer: add timer_v2 dithering APIs (`DitheringConfig`, ARR/CCR fractional nibble setters) in low-level, simple PWM, and complementary PWM drivers
+- feat: stm32/timer: add low-level timer status helpers for UIF remap control and counting direction (`is_counting_up`/`is_counting_down`)
 
 CRYP:
 - feat: stm32/cryp: batch full-block DMA in payload and use 4-beat bursts on GPDMA

--- a/embassy-stm32/CHANGELOG.md
+++ b/embassy-stm32/CHANGELOG.md
@@ -32,6 +32,7 @@ COMP:
 
 Timer:
 - feat: stm32/timer/input_capture: add per-channel split API for concurrent multi-channel capture
+- feat: stm32/timer: add timer_v2 dithering APIs (`DitheringConfig`, ARR/CCR fractional nibble setters) in low-level, simple PWM, and complementary PWM drivers
 
 CRYP:
 - feat: stm32/cryp: batch full-block DMA in payload and use 4-beat bursts on GPDMA

--- a/embassy-stm32/src/timer/complementary_pwm.rs
+++ b/embassy-stm32/src/timer/complementary_pwm.rs
@@ -3,20 +3,23 @@
 use core::marker::PhantomData;
 
 pub use super::low_level::FilterValue;
-use super::low_level::{CountingMode, OcrefClearSource, OutputPolarity, RoundTo, Timer};
 #[cfg(timer_v2)]
-use crate::timer::low_level::DitheringConfig;
+use super::low_level::OcrefClearSource;
+use super::low_level::{CountingMode, OutputPolarity, RoundTo, Timer};
 use super::simple_pwm::PwmPin;
 use super::{AdvancedInstance4Channel, Ch1, Ch2, Ch3, Ch4, Channel, TimerComplementaryPin};
 use crate::Peri;
 use crate::dma::word::Word;
 use crate::gpio::{AfType, Flex, OutputType};
+#[cfg(timer_v2)]
+pub use crate::pac::timer::vals::{Bkbid as BreakBidirectionalMode, Bkdsrm as BreakDisarmMode};
 pub use crate::pac::timer::vals::{
-    Bkbid as BreakBidirectionalMode, Bkdsrm as BreakDisarmMode, Bkinp as BreakComparatorPolarity, Bkp as BreakInputPolarity,
-    Ccds, Ckd, Mms2, Ossi, Ossr,
+    Bkinp as BreakComparatorPolarity, Bkp as BreakInputPolarity, Ccds, Ckd, Mms2, Ossi, Ossr,
 };
 use crate::time::Hertz;
 use crate::timer::TimerChannel;
+#[cfg(timer_v2)]
+use crate::timer::low_level::DitheringConfig;
 use crate::timer::low_level::OutputCompareMode;
 use crate::timer::simple_pwm::PwmPinConfig;
 
@@ -236,6 +239,7 @@ impl<'d, T: AdvancedInstance4Channel> ComplementaryPwm<'d, T> {
         self.inner.set_moe(enable);
     }
 
+    #[cfg(timer_v2)]
     /// Select OCREF clear source.
     pub fn set_ocref_clear_source(&mut self, source: OcrefClearSource) {
         self.inner.set_ocref_clear_source(source);

--- a/embassy-stm32/src/timer/complementary_pwm.rs
+++ b/embassy-stm32/src/timer/complementary_pwm.rs
@@ -4,6 +4,8 @@ use core::marker::PhantomData;
 
 pub use super::low_level::FilterValue;
 use super::low_level::{CountingMode, OcrefClearSource, OutputPolarity, RoundTo, Timer};
+#[cfg(timer_v2)]
+use crate::timer::low_level::DitheringConfig;
 use super::simple_pwm::PwmPin;
 use super::{AdvancedInstance4Channel, Ch1, Ch2, Ch3, Ch4, Channel, TimerComplementaryPin};
 use crate::Peri;
@@ -551,6 +553,18 @@ impl<'d, T: AdvancedInstance4Channel> ComplementaryPwm<'d, T> {
         } else {
             self.inner.get_max_compare_value().into() + 1
         }
+    }
+
+    #[cfg(timer_v2)]
+    /// Configure timer dithering mode and ARR fractional nibble.
+    pub fn set_dithering(&mut self, config: DitheringConfig) {
+        self.inner.set_dithering(config);
+    }
+
+    #[cfg(timer_v2)]
+    /// Set CCR fractional nibble for one channel.
+    pub fn set_channel_dither(&mut self, channel: Channel, dither: u8) {
+        self.inner.set_compare_dither_value(channel, dither);
     }
 
     /// Set the duty for a given channel.

--- a/embassy-stm32/src/timer/complementary_pwm.rs
+++ b/embassy-stm32/src/timer/complementary_pwm.rs
@@ -10,7 +10,8 @@ use crate::Peri;
 use crate::dma::word::Word;
 use crate::gpio::{AfType, Flex, OutputType};
 pub use crate::pac::timer::vals::{
-    Bkinp as BreakComparatorPolarity, Bkp as BreakInputPolarity, Ccds, Ckd, Mms2, Ossi, Ossr,
+    Bkbid as BreakBidirectionalMode, Bkdsrm as BreakDisarmMode, Bkinp as BreakComparatorPolarity, Bkp as BreakInputPolarity,
+    Ccds, Ckd, Mms2, Ossi, Ossr,
 };
 use crate::time::Hertz;
 use crate::timer::TimerChannel;
@@ -280,6 +281,30 @@ impl<'d, T: AdvancedInstance4Channel> ComplementaryPwm<'d, T> {
         self.inner.get_break_filter()
     }
 
+    #[cfg(timer_v2)]
+    /// Set break input 1 disarm mode.
+    pub fn set_break_disarm_mode(&mut self, mode: BreakDisarmMode) {
+        self.inner.set_break_disarm_mode(mode);
+    }
+
+    #[cfg(timer_v2)]
+    /// Get break input 1 disarm mode.
+    pub fn get_break_disarm_mode(&self) -> BreakDisarmMode {
+        self.inner.get_break_disarm_mode()
+    }
+
+    #[cfg(timer_v2)]
+    /// Set break input 1 bidirectional mode.
+    pub fn set_break_bidirectional_mode(&mut self, mode: BreakBidirectionalMode) {
+        self.inner.set_break_bidirectional_mode(mode);
+    }
+
+    #[cfg(timer_v2)]
+    /// Get break input 1 bidirectional mode.
+    pub fn get_break_bidirectional_mode(&self) -> BreakBidirectionalMode {
+        self.inner.get_break_bidirectional_mode()
+    }
+
     /// Enable/disable break input 2.
     pub fn set_break2_enable(&mut self, enable: bool) {
         self.inner.set_break2_enable(enable);
@@ -308,6 +333,30 @@ impl<'d, T: AdvancedInstance4Channel> ComplementaryPwm<'d, T> {
     /// Get break input 2 digital filter.
     pub fn get_break2_filter(&self) -> FilterValue {
         self.inner.get_break2_filter()
+    }
+
+    #[cfg(timer_v2)]
+    /// Set break input 2 disarm mode.
+    pub fn set_break2_disarm_mode(&mut self, mode: BreakDisarmMode) {
+        self.inner.set_break2_disarm_mode(mode);
+    }
+
+    #[cfg(timer_v2)]
+    /// Get break input 2 disarm mode.
+    pub fn get_break2_disarm_mode(&self) -> BreakDisarmMode {
+        self.inner.get_break2_disarm_mode()
+    }
+
+    #[cfg(timer_v2)]
+    /// Set break input 2 bidirectional mode.
+    pub fn set_break2_bidirectional_mode(&mut self, mode: BreakBidirectionalMode) {
+        self.inner.set_break2_bidirectional_mode(mode);
+    }
+
+    #[cfg(timer_v2)]
+    /// Get break input 2 bidirectional mode.
+    pub fn get_break2_bidirectional_mode(&self) -> BreakBidirectionalMode {
+        self.inner.get_break2_bidirectional_mode()
     }
 
     /// Enable/disable automatic output enable (AOE).

--- a/embassy-stm32/src/timer/complementary_pwm.rs
+++ b/embassy-stm32/src/timer/complementary_pwm.rs
@@ -3,7 +3,7 @@
 use core::marker::PhantomData;
 
 pub use super::low_level::FilterValue;
-use super::low_level::{CountingMode, OutputPolarity, RoundTo, Timer};
+use super::low_level::{CountingMode, OcrefClearSource, OutputPolarity, RoundTo, Timer};
 use super::simple_pwm::PwmPin;
 use super::{AdvancedInstance4Channel, Ch1, Ch2, Ch3, Ch4, Channel, TimerComplementaryPin};
 use crate::Peri;
@@ -231,6 +231,11 @@ impl<'d, T: AdvancedInstance4Channel> ComplementaryPwm<'d, T> {
     /// Set Master Output Enable
     pub fn set_master_output_enable(&mut self, enable: bool) {
         self.inner.set_moe(enable);
+    }
+
+    /// Select OCREF clear source.
+    pub fn set_ocref_clear_source(&mut self, source: OcrefClearSource) {
+        self.inner.set_ocref_clear_source(source);
     }
 
     /// Get Master Output Enable
@@ -505,6 +510,11 @@ impl<'d, T: AdvancedInstance4Channel> ComplementaryPwm<'d, T> {
     pub fn set_duty(&mut self, channel: Channel, duty: u32) {
         assert!(duty <= self.get_max_duty());
         self.inner.set_compare_value(channel, unwrap!(duty.try_into()))
+    }
+
+    /// Enable/disable OCREF clear for a given channel.
+    pub fn set_output_compare_clear_enable(&mut self, channel: Channel, enable: bool) {
+        self.inner.set_output_compare_clear_enable(channel, enable);
     }
 
     /// Set the output polarity for a given channel.

--- a/embassy-stm32/src/timer/hall.rs
+++ b/embassy-stm32/src/timer/hall.rs
@@ -1,0 +1,114 @@
+//! Hall sensor interface helper using timer XOR input.
+//!
+//! This helper targets 3-phase BLDC Hall setups where CH1/CH2/CH3 are routed
+//! into the timer input stage and optionally XOR-combined (TI1S).
+
+use stm32_metapac::timer::vals::{self, FilterValue};
+
+use super::low_level::{InputCaptureMode, InputCaptureSelection, Timer};
+use super::{Ch1, Ch2, Ch3, Channel, GeneralInstance4Channel, TimerPin};
+use crate::Peri;
+use crate::gpio::{AfType, Flex, Pull};
+
+/// Hall interface configuration.
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+#[derive(Clone, Copy)]
+pub struct HallConfig {
+    /// Pull configuration for Hall input pins.
+    pub pull: Pull,
+    /// Input filter applied on capture channel 1.
+    pub filter: FilterValue,
+    /// Input capture prescaler factor for channel 1 (1,2,4,8).
+    pub prescaler: u8,
+    /// Enable CH1/CH2/CH3 XOR function (TI1S).
+    pub enable_xor: bool,
+    /// Trigger source for Hall/reset sequencing.
+    pub trigger_source: vals::Ts,
+    /// If set, configure slave reset mode to restart the counter on trigger.
+    pub reset_on_trigger: bool,
+}
+
+impl Default for HallConfig {
+    fn default() -> Self {
+        Self {
+            pull: Pull::None,
+            filter: FilterValue::NoFilter,
+            prescaler: 1,
+            enable_xor: true,
+            trigger_source: vals::Ts::Ti1fEd,
+            reset_on_trigger: true,
+        }
+    }
+}
+
+/// Hall sensor timer interface.
+pub struct HallInterface<'d, T: GeneralInstance4Channel> {
+    inner: Timer<'d, T>,
+    _ch1: Flex<'d>,
+    _ch2: Flex<'d>,
+    _ch3: Flex<'d>,
+}
+
+impl<'d, T: GeneralInstance4Channel> HallInterface<'d, T> {
+    /// Create and configure a Hall sensor interface on timer CH1/CH2/CH3.
+    #[allow(unused)]
+    pub fn new<#[cfg(afio)] A>(
+        tim: Peri<'d, T>,
+        ch1: Peri<'d, if_afio!(impl TimerPin<T, Ch1, A>)>,
+        ch2: Peri<'d, if_afio!(impl TimerPin<T, Ch2, A>)>,
+        ch3: Peri<'d, if_afio!(impl TimerPin<T, Ch3, A>)>,
+        config: HallConfig,
+    ) -> Self {
+        critical_section::with(|_| {
+            ch1.set_low();
+            ch2.set_low();
+            ch3.set_low();
+        });
+
+        let inner = Timer::new(tim);
+        let regs = inner.regs_gp16();
+
+        regs.cr2().modify(|w| {
+            w.set_ti1s(if config.enable_xor {
+                vals::Ti1s::Xor
+            } else {
+                vals::Ti1s::Normal
+            })
+        });
+
+        inner.set_input_capture_selection(Channel::Ch1, InputCaptureSelection::TRC);
+        inner.set_input_capture_mode(Channel::Ch1, InputCaptureMode::Rising);
+        inner.set_input_capture_filter(Channel::Ch1, config.filter);
+        inner.set_input_capture_prescaler(Channel::Ch1, config.prescaler);
+        inner.enable_channel(Channel::Ch1, true);
+
+        if config.reset_on_trigger {
+            inner.set_trigger_source(config.trigger_source);
+            inner.set_slave_mode(vals::Sms::ResetMode);
+        }
+
+        inner.start();
+
+        Self {
+            inner,
+            _ch1: new_pin!(ch1, AfType::input(config.pull)).unwrap(),
+            _ch2: new_pin!(ch2, AfType::input(config.pull)).unwrap(),
+            _ch3: new_pin!(ch3, AfType::input(config.pull)).unwrap(),
+        }
+    }
+
+    /// Read the latest captured Hall event timestamp (CCR1).
+    pub fn capture_ticks(&self) -> T::Word {
+        self.inner.get_capture_value(Channel::Ch1)
+    }
+
+    /// Check capture interrupt flag for Hall event channel.
+    pub fn event_pending(&self) -> bool {
+        self.inner.get_input_interrupt(Channel::Ch1)
+    }
+
+    /// Clear capture interrupt flag for Hall event channel.
+    pub fn clear_event(&self) {
+        self.inner.clear_input_interrupt(Channel::Ch1);
+    }
+}

--- a/embassy-stm32/src/timer/low_level.rs
+++ b/embassy-stm32/src/timer/low_level.rs
@@ -280,6 +280,27 @@ pub enum RoundTo {
     Faster,
 }
 
+/// Dithering configuration for timer_v2-capable timers.
+#[cfg(timer_v2)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+pub struct DitheringConfig {
+    /// Enable/disable hardware dithering mode.
+    pub enabled: bool,
+    /// Fractional ARR nibble (`ARR_DITHER.DITHER`).
+    pub arr_dither: u8,
+}
+
+#[cfg(timer_v2)]
+impl Default for DitheringConfig {
+    fn default() -> Self {
+        Self {
+            enabled: false,
+            arr_dither: 0,
+        }
+    }
+}
+
 /// Result of PSC/ARR calculation for timer configuration.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
@@ -884,6 +905,23 @@ impl<'d, T: GeneralInstance4Channel> Timer<'d, T> {
         self.regs_gp16()
             .ccr(channel.index())
             .modify(|w| w.set_ccr(unwrap!(value.try_into())));
+    }
+
+    #[cfg(timer_v2)]
+    /// Configure timer dithering mode and ARR fractional nibble.
+    pub fn set_dithering(&self, config: DitheringConfig) {
+        self.regs_gp16().cr1().modify(|w| w.set_dithen(config.enabled));
+        self.regs_gp16()
+            .arr_dither()
+            .modify(|w| w.set_dither(config.arr_dither & 0x0f));
+    }
+
+    #[cfg(timer_v2)]
+    /// Set CCR fractional nibble (`CCRx_DITHER.DITHER`) for a channel.
+    pub fn set_compare_dither_value(&self, channel: Channel, dither: u8) {
+        self.regs_gp16()
+            .ccr_dither(channel.index())
+            .modify(|w| w.set_dither(dither & 0x0f));
     }
 
     /// Get compare value for a channel.

--- a/embassy-stm32/src/timer/low_level.rs
+++ b/embassy-stm32/src/timer/low_level.rs
@@ -1409,6 +1409,54 @@ impl<'d, T: AdvancedInstance4Channel> Timer<'d, T> {
         self.regs_advanced().bdtr().read().bkf(1)
     }
 
+    #[cfg(timer_v2)]
+    /// Set break input 1 disarm mode.
+    pub fn set_break_disarm_mode(&self, mode: vals::Bkdsrm) {
+        self.regs_advanced().bdtr().modify(|w| w.set_bkdsrm(0, mode));
+    }
+
+    #[cfg(timer_v2)]
+    /// Get break input 1 disarm mode.
+    pub fn get_break_disarm_mode(&self) -> vals::Bkdsrm {
+        self.regs_advanced().bdtr().read().bkdsrm(0)
+    }
+
+    #[cfg(timer_v2)]
+    /// Set break input 1 bidirectional mode.
+    pub fn set_break_bidirectional_mode(&self, mode: vals::Bkbid) {
+        self.regs_advanced().bdtr().modify(|w| w.set_bkbid(0, mode));
+    }
+
+    #[cfg(timer_v2)]
+    /// Get break input 1 bidirectional mode.
+    pub fn get_break_bidirectional_mode(&self) -> vals::Bkbid {
+        self.regs_advanced().bdtr().read().bkbid(0)
+    }
+
+    #[cfg(timer_v2)]
+    /// Set break input 2 disarm mode.
+    pub fn set_break2_disarm_mode(&self, mode: vals::Bkdsrm) {
+        self.regs_advanced().bdtr().modify(|w| w.set_bkdsrm(1, mode));
+    }
+
+    #[cfg(timer_v2)]
+    /// Get break input 2 disarm mode.
+    pub fn get_break2_disarm_mode(&self) -> vals::Bkdsrm {
+        self.regs_advanced().bdtr().read().bkdsrm(1)
+    }
+
+    #[cfg(timer_v2)]
+    /// Set break input 2 bidirectional mode.
+    pub fn set_break2_bidirectional_mode(&self, mode: vals::Bkbid) {
+        self.regs_advanced().bdtr().modify(|w| w.set_bkbid(1, mode));
+    }
+
+    #[cfg(timer_v2)]
+    /// Get break input 2 bidirectional mode.
+    pub fn get_break2_bidirectional_mode(&self) -> vals::Bkbid {
+        self.regs_advanced().bdtr().read().bkbid(1)
+    }
+
     /// Trigger software break 1 or 2
     /// Setting this bit generates a break event. This bit is automatically cleared by the hardware.
     pub fn trigger_software_break(&self, n: usize) {

--- a/embassy-stm32/src/timer/low_level.rs
+++ b/embassy-stm32/src/timer/low_level.rs
@@ -1395,6 +1395,7 @@ impl<'d, T: AdvancedInstance4Channel> Timer<'d, T> {
         unsafe { crate::pac::timer::TimAdv::from_ptr(T::regs()) }
     }
 
+    #[cfg(timer_v2)]
     /// Select OCREF clear source.
     pub fn set_ocref_clear_source(&self, source: OcrefClearSource) {
         self.regs_advanced().smcr().modify(|w| {

--- a/embassy-stm32/src/timer/low_level.rs
+++ b/embassy-stm32/src/timer/low_level.rs
@@ -190,6 +190,16 @@ pub enum OutputCompareMode {
     AsymmetricPwmMode2,
 }
 
+/// OCREF clear trigger source.
+#[derive(Clone, Copy)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+pub enum OcrefClearSource {
+    /// Use the timer's dedicated OCREF clear input.
+    Internal,
+    /// Use filtered external trigger (ETRF) as OCREF clear source.
+    Etrf,
+}
+
 #[cfg(timer_v3)]
 impl From<OutputCompareMode> for crate::pac::timer::vals::OcmGp {
     fn from(mode: OutputCompareMode) -> Self {
@@ -837,6 +847,16 @@ impl<'d, T: GeneralInstance4Channel> Timer<'d, T> {
             .modify(|w| w.set_ocm(raw_channel % 2, mode.into()));
     }
 
+    /// Enable/disable OCREF clear on a channel.
+    ///
+    /// When enabled, a configured clear input can force OCxREF inactive.
+    pub fn set_output_compare_clear_enable(&self, channel: Channel, enable: bool) {
+        let raw_channel = channel.index();
+        self.regs_gp16()
+            .ccmr_output(raw_channel / 2)
+            .modify(|w| w.set_occe(raw_channel % 2, enable));
+    }
+
     /// Set output polarity.
     pub fn set_output_polarity(&self, channel: Channel, polarity: OutputPolarity) {
         self.regs_gp16()
@@ -1311,6 +1331,16 @@ impl<'d, T: AdvancedInstance4Channel> Timer<'d, T> {
     /// Get access to the advanced timer registers.
     pub fn regs_advanced(&self) -> crate::pac::timer::TimAdv {
         unsafe { crate::pac::timer::TimAdv::from_ptr(T::regs()) }
+    }
+
+    /// Select OCREF clear source.
+    pub fn set_ocref_clear_source(&self, source: OcrefClearSource) {
+        self.regs_advanced().smcr().modify(|w| {
+            w.set_occs(match source {
+                OcrefClearSource::Internal => vals::Occs::Input,
+                OcrefClearSource::Etrf => vals::Occs::Etrf,
+            });
+        });
     }
 
     /// Set complementary output polarity.

--- a/embassy-stm32/src/timer/low_level.rs
+++ b/embassy-stm32/src/timer/low_level.rs
@@ -604,6 +604,20 @@ impl<'d, T: CoreInstance> Timer<'d, T> {
         self.regs_core().cr1().modify(|r| r.set_arpe(enable));
     }
 
+    /// Enable/disable UIF status remapping.
+    ///
+    /// When enabled, the update interrupt flag (UIF) is copied into the counter
+    /// register's MSB, allowing atomic reads of counter+overflow status on
+    /// supported timer variants.
+    pub fn set_uif_remap(&self, enable: bool) {
+        self.regs_core().cr1().modify(|r| r.set_uifremap(enable));
+    }
+
+    /// Get UIF status remapping state.
+    pub fn get_uif_remap(&self) -> bool {
+        self.regs_core().cr1().read().uifremap()
+    }
+
     /// Get the timer frequency.
     pub fn get_frequency(&self) -> Hertz {
         let timer_f = T::frequency();
@@ -746,6 +760,16 @@ impl<'d, T: GeneralInstance4Channel> Timer<'d, T> {
     pub fn get_counting_mode(&self) -> CountingMode {
         let cr1 = self.regs_gp16().cr1().read();
         (cr1.cms(), cr1.dir()).into()
+    }
+
+    /// Return whether the timer direction bit indicates up-counting.
+    pub fn is_counting_up(&self) -> bool {
+        self.regs_gp16().cr1().read().dir() == vals::Dir::Up
+    }
+
+    /// Return whether the timer direction bit indicates down-counting.
+    pub fn is_counting_down(&self) -> bool {
+        self.regs_gp16().cr1().read().dir() == vals::Dir::Down
     }
 
     /// Set input capture filter.

--- a/embassy-stm32/src/timer/low_level.rs
+++ b/embassy-stm32/src/timer/low_level.rs
@@ -755,6 +755,54 @@ impl<'d, T: GeneralInstance4Channel> Timer<'d, T> {
         self.regs_gp16().tisel().modify(|w| w.set_tisel(raw_channel, tisel));
     }
 
+    #[cfg(timer_v2)]
+    /// Configure encoder index direction behavior (TIMx_ECR.IDIR).
+    pub fn set_encoder_index_direction(&self, direction: vals::Idir) {
+        self.regs_gp16().ecr().modify(|w| w.set_idir(direction));
+    }
+
+    #[cfg(timer_v2)]
+    /// Configure encoder index position behavior (TIMx_ECR.FIDX).
+    pub fn set_encoder_index_position(&self, position: vals::Fidx) {
+        self.regs_gp16().ecr().modify(|w| w.set_fidx(position));
+    }
+
+    #[cfg(timer_v2)]
+    /// Enable/disable index event interrupts (TIMx_DIER.IDXIE).
+    pub fn enable_encoder_index_interrupt(&self, enable: bool) {
+        self.regs_gp16().dier().modify(|w| w.set_idxie(enable));
+    }
+
+    #[cfg(timer_v2)]
+    /// Enable/disable direction-change interrupts (TIMx_DIER.DIRIE).
+    pub fn enable_encoder_direction_change_interrupt(&self, enable: bool) {
+        self.regs_gp16().dier().modify(|w| w.set_dirie(enable));
+    }
+
+    #[cfg(timer_v2)]
+    /// Get index event interrupt pending state (TIMx_SR.IDXIF).
+    pub fn get_encoder_index_interrupt(&self) -> bool {
+        self.regs_gp16().sr().read().idxif()
+    }
+
+    #[cfg(timer_v2)]
+    /// Get direction-change interrupt pending state (TIMx_SR.DIRIF).
+    pub fn get_encoder_direction_change_interrupt(&self) -> bool {
+        self.regs_gp16().sr().read().dirif()
+    }
+
+    #[cfg(timer_v2)]
+    /// Clear index event interrupt pending state (TIMx_SR.IDXIF).
+    pub fn clear_encoder_index_interrupt(&self) {
+        self.regs_gp16().sr().modify(|w| w.set_idxif(false));
+    }
+
+    #[cfg(timer_v2)]
+    /// Clear direction-change interrupt pending state (TIMx_SR.DIRIF).
+    pub fn clear_encoder_direction_change_interrupt(&self) {
+        self.regs_gp16().sr().modify(|w| w.set_dirif(false));
+    }
+
     /// Set input capture selection.
     pub fn set_input_capture_selection(&self, channel: Channel, icsel: InputCaptureSelection) {
         let raw_channel = channel.index();

--- a/embassy-stm32/src/timer/mod.rs
+++ b/embassy-stm32/src/timer/mod.rs
@@ -7,8 +7,8 @@ use embassy_sync::waitqueue::AtomicWaker;
 
 #[cfg(not(stm32l0))]
 pub mod complementary_pwm;
-pub mod input_capture;
 pub mod hall;
+pub mod input_capture;
 pub mod low_level;
 pub mod one_pulse;
 pub mod pwm_input;

--- a/embassy-stm32/src/timer/mod.rs
+++ b/embassy-stm32/src/timer/mod.rs
@@ -8,6 +8,7 @@ use embassy_sync::waitqueue::AtomicWaker;
 #[cfg(not(stm32l0))]
 pub mod complementary_pwm;
 pub mod input_capture;
+pub mod hall;
 pub mod low_level;
 pub mod one_pulse;
 pub mod pwm_input;

--- a/embassy-stm32/src/timer/qei.rs
+++ b/embassy-stm32/src/timer/qei.rs
@@ -35,6 +35,40 @@ impl Default for Config {
     }
 }
 
+/// Advanced QEI configuration.
+///
+/// This extends [`Config`] with optional encoder-index controls on timer variants
+/// that expose TIMx_ECR/TIMx_SR index fields.
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+#[derive(Clone, Copy, Default)]
+pub struct AdvancedConfig {
+    /// Base QEI configuration.
+    pub base: Config,
+    /// Optional index behavior configuration.
+    #[cfg(timer_v2)]
+    pub index: Option<IndexConfig>,
+    /// Enable index event interrupt.
+    #[cfg(timer_v2)]
+    pub enable_index_interrupt: bool,
+    /// Enable direction-change interrupt.
+    #[cfg(timer_v2)]
+    pub enable_direction_change_interrupt: bool,
+}
+
+impl From<Config> for AdvancedConfig {
+    fn from(base: Config) -> Self {
+        Self {
+            base,
+            #[cfg(timer_v2)]
+            index: None,
+            #[cfg(timer_v2)]
+            enable_index_interrupt: false,
+            #[cfg(timer_v2)]
+            enable_direction_change_interrupt: false,
+        }
+    }
+}
+
 /// See STMicro AN4013 for §2.3 for more information
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
 #[derive(Clone, Copy)]
@@ -55,6 +89,17 @@ impl From<QeiMode> for Sms {
             QeiMode::Mode3 => Sms::EncoderMode3,
         }
     }
+}
+
+#[cfg(timer_v2)]
+/// Encoder index configuration (TIMx_ECR fields).
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+#[derive(Clone, Copy)]
+pub struct IndexConfig {
+    /// Index-direction selection.
+    pub direction: vals::Idir,
+    /// Index position selection.
+    pub position: vals::Fidx,
 }
 
 /// Counting direction
@@ -93,6 +138,17 @@ impl<'d, T: GeneralInstance4Channel> Qei<'d, T> {
         ch2: Peri<'d, if_afio!(impl TimerPin<T, CH2, A>)>,
         config: Config,
     ) -> Self {
+        Self::new_advanced(tim, ch1, ch2, config.into())
+    }
+
+    /// Create a new quadrature decoder driver with extended encoder options.
+    #[allow(unused)]
+    pub fn new_advanced<CH1: QeiChannel, CH2: QeiChannel, #[cfg(afio)] A>(
+        tim: Peri<'d, T>,
+        ch1: Peri<'d, if_afio!(impl TimerPin<T, CH1, A>)>,
+        ch2: Peri<'d, if_afio!(impl TimerPin<T, CH2, A>)>,
+        config: AdvancedConfig,
+    ) -> Self {
         // Configure the pins to be used for the QEI peripheral.
         critical_section::with(|_| {
             ch1.set_low();
@@ -118,16 +174,28 @@ impl<'d, T: GeneralInstance4Channel> Qei<'d, T> {
         });
 
         r.smcr().modify(|w| {
-            w.set_sms(config.mode.into());
+            w.set_sms(config.base.mode.into());
         });
 
-        r.arr().modify(|w| w.set_arr(config.auto_reload));
+        r.arr().modify(|w| w.set_arr(config.base.auto_reload));
         r.cr1().modify(|w| w.set_cen(true));
+
+        #[cfg(timer_v2)]
+        if let Some(index) = config.index {
+            inner.set_encoder_index_direction(index.direction);
+            inner.set_encoder_index_position(index.position);
+        }
+
+        #[cfg(timer_v2)]
+        {
+            inner.enable_encoder_index_interrupt(config.enable_index_interrupt);
+            inner.enable_encoder_direction_change_interrupt(config.enable_direction_change_interrupt);
+        }
 
         Self {
             inner,
-            _ch1: new_pin!(ch1, AfType::input(config.ch1_pull)).unwrap(),
-            _ch2: new_pin!(ch2, AfType::input(config.ch2_pull)).unwrap(),
+            _ch1: new_pin!(ch1, AfType::input(config.base.ch1_pull)).unwrap(),
+            _ch2: new_pin!(ch2, AfType::input(config.base.ch2_pull)).unwrap(),
         }
     }
 
@@ -147,5 +215,29 @@ impl<'d, T: GeneralInstance4Channel> Qei<'d, T> {
     /// Reset count.
     pub fn reset(&mut self) {
         self.inner.regs_gp16().cnt().modify(|w| w.set_cnt(0));
+    }
+
+    #[cfg(timer_v2)]
+    /// Check whether an encoder index event interrupt is pending.
+    pub fn index_event_pending(&self) -> bool {
+        self.inner.get_encoder_index_interrupt()
+    }
+
+    #[cfg(timer_v2)]
+    /// Clear encoder index event interrupt pending state.
+    pub fn clear_index_event(&self) {
+        self.inner.clear_encoder_index_interrupt();
+    }
+
+    #[cfg(timer_v2)]
+    /// Check whether a direction-change interrupt is pending.
+    pub fn direction_change_pending(&self) -> bool {
+        self.inner.get_encoder_direction_change_interrupt()
+    }
+
+    #[cfg(timer_v2)]
+    /// Clear direction-change interrupt pending state.
+    pub fn clear_direction_change(&self) {
+        self.inner.clear_encoder_direction_change_interrupt();
     }
 }

--- a/embassy-stm32/src/timer/ringbuffered.rs
+++ b/embassy-stm32/src/timer/ringbuffered.rs
@@ -155,4 +155,9 @@ impl<'d, T: GeneralInstance4Channel, W: Word + Into<T::Word>> RingBufferedPwmCha
     pub fn set_output_compare_mode(&mut self, mode: super::low_level::OutputCompareMode) {
         self.timer.set_output_compare_mode(self.channel, mode);
     }
+
+    /// Enable/disable OCREF clear for this channel.
+    pub fn set_output_compare_clear_enable(&mut self, enable: bool) {
+        self.timer.set_output_compare_clear_enable(self.channel, enable);
+    }
 }

--- a/embassy-stm32/src/timer/simple_pwm.rs
+++ b/embassy-stm32/src/timer/simple_pwm.rs
@@ -4,8 +4,6 @@ use core::marker::PhantomData;
 use core::mem::ManuallyDrop;
 
 use super::low_level::{CountingMode, OutputCompareMode, OutputPolarity, RoundTo, Timer};
-#[cfg(timer_v2)]
-use crate::timer::low_level::DitheringConfig;
 use super::ringbuffered::RingBufferedPwmChannel;
 use super::{Ch1, Ch2, Ch3, Ch4, Channel, GeneralInstance4Channel, TimerChannel, TimerPin};
 use crate::Peri;
@@ -15,6 +13,8 @@ use crate::gpio::Pull;
 use crate::gpio::{AfType, Flex, OutputType, Speed};
 use crate::pac::timer::vals::Ccds;
 use crate::time::Hertz;
+#[cfg(timer_v2)]
+use crate::timer::low_level::DitheringConfig;
 
 /// PWM pin wrapper.
 ///

--- a/embassy-stm32/src/timer/simple_pwm.rs
+++ b/embassy-stm32/src/timer/simple_pwm.rs
@@ -166,6 +166,11 @@ impl<'d, T: GeneralInstance4Channel> SimplePwmChannel<'d, T> {
         self.timer.set_output_compare_mode(self.channel, mode);
     }
 
+    /// Enable/disable OCREF clear for this channel.
+    pub fn set_output_compare_clear_enable(&mut self, enable: bool) {
+        self.timer.set_output_compare_clear_enable(self.channel, enable);
+    }
+
     /// Convert this PWM channel into a ring-buffered PWM channel.
     ///
     /// This allows continuous PWM waveform generation using a DMA ring buffer.

--- a/embassy-stm32/src/timer/simple_pwm.rs
+++ b/embassy-stm32/src/timer/simple_pwm.rs
@@ -4,6 +4,8 @@ use core::marker::PhantomData;
 use core::mem::ManuallyDrop;
 
 use super::low_level::{CountingMode, OutputCompareMode, OutputPolarity, RoundTo, Timer};
+#[cfg(timer_v2)]
+use crate::timer::low_level::DitheringConfig;
 use super::ringbuffered::RingBufferedPwmChannel;
 use super::{Ch1, Ch2, Ch3, Ch4, Channel, GeneralInstance4Channel, TimerChannel, TimerPin};
 use crate::Peri;
@@ -450,6 +452,18 @@ impl<'d, T: GeneralInstance4Channel> SimplePwm<'d, T> {
     /// This value depends on the configured frequency and the timer's clock rate from RCC.
     pub fn max_duty_cycle(&self) -> u32 {
         self.inner.get_max_compare_value().into() + 1
+    }
+
+    #[cfg(timer_v2)]
+    /// Configure timer dithering mode and ARR fractional nibble.
+    pub fn set_dithering(&mut self, config: DitheringConfig) {
+        self.inner.set_dithering(config);
+    }
+
+    #[cfg(timer_v2)]
+    /// Set CCR fractional nibble for one channel.
+    pub fn set_channel_dither(&mut self, channel: Channel, dither: u8) {
+        self.inner.set_compare_dither_value(channel, dither);
     }
 
     /// Generate a sequence of PWM waveform


### PR DESCRIPTION
## Summary
- consolidate timer enhancements from branches pr-a through pr-f into one reviewable change set
- add advanced QEI index APIs, OCREF clear configuration, Hall sensor interface helpers, and break disarm/bidirectional controls
- add timer_v2 dithering APIs and status utility helpers

## Included source branches
- `feat/stm32-pr-a-qei-advanced`
- `feat/stm32-pr-b-ocref-clear`
- `feat/stm32-pr-c-hall-interface`
- `feat/stm32-pr-d-break-rearm`
- `feat/stm32-pr-e-dithering`
- `feat/stm32-pr-f-timer-status-utils`