### PR TITLE
stm32: consolidate PR1-PR3 for PKA, SAES, and RNG API updates

### DIFF
--- a/embassy-stm32/CHANGELOG.md
+++ b/embassy-stm32/CHANGELOG.md
@@ -27,6 +27,9 @@ DMA:
 ADC:
 - feat: stm32/adc: add `VrefInt::calibrated_value()` for additional chips
 
+RNG:
+- feat: stm32/rng: add configurable initialization policy (`RngConfig`) with `new_with_config`, health-test profile control, and low-power disable helper
+
 COMP:
 - feat: stm32/comp: add support for comp_v1 (used on G0)
 

--- a/embassy-stm32/CHANGELOG.md
+++ b/embassy-stm32/CHANGELOG.md
@@ -40,6 +40,9 @@ CRYP:
 - feat: stm32/cryp: batch full-block DMA in payload and use 4-beat bursts on GPDMA
 - perf: stm32/cryp: aad/payload async API takes a faster path when user buffers are 4-byte aligned
 
+SAES:
+- feat: stm32/saes: expose explicit key-mode starters (`start_with_mode`, `start_wrapped_key`, `start_shared_key`) and async `aad`/`payload`/`finish` parity methods
+
 ## 0.6.0 - 2026-03-10
 
 ADC:

--- a/embassy-stm32/CHANGELOG.md
+++ b/embassy-stm32/CHANGELOG.md
@@ -33,6 +33,9 @@ COMP:
 Timer:
 - feat: stm32/timer/input_capture: add per-channel split API for concurrent multi-channel capture
 
+PKA:
+- feat: stm32/pka: extend ECC point buffer support to 640-bit operands (80-byte coordinates) in public point types and Jacobian conversion paths
+
 CRYP:
 - feat: stm32/cryp: batch full-block DMA in payload and use 4-beat bursts on GPDMA
 - perf: stm32/cryp: aad/payload async API takes a faster path when user buffers are 4-byte aligned

--- a/embassy-stm32/CHANGELOG.md
+++ b/embassy-stm32/CHANGELOG.md
@@ -28,7 +28,7 @@ ADC:
 - feat: stm32/adc: add `VrefInt::calibrated_value()` for additional chips
 
 RNG:
-- feat: stm32/rng: add configurable initialization policy (`RngConfig`) with `new_with_config`, health-test profile control, and low-power disable helper
+- feat: stm32/rng: add configurable initialization policy (`RngConfig`) with `new_with_config` and health-test profile control
 
 COMP:
 - feat: stm32/comp: add support for comp_v1 (used on G0)

--- a/embassy-stm32/src/pka/mod.rs
+++ b/embassy-stm32/src/pka/mod.rs
@@ -77,6 +77,8 @@ use crate::mode::{Async, Blocking, Mode};
 use crate::{interrupt, pac, peripherals, rcc};
 
 static PKA_WAKER: AtomicWaker = AtomicWaker::new();
+const MAX_ECC_BYTES: usize = 80; // 640-bit ECC operand support
+const MAX_ECC_WIDE_BYTES: usize = MAX_ECC_BYTES * 2;
 
 // ============================================================================
 // PKA Modes
@@ -462,9 +464,9 @@ pub struct EcdsaSignature<'a> {
 /// ECC point (for scalar multiplication results)
 pub struct EccPoint {
     /// X coordinate
-    pub x: [u8; 66], // Max size for P-521
+    pub x: [u8; MAX_ECC_BYTES],
     /// Y coordinate
-    pub y: [u8; 66],
+    pub y: [u8; MAX_ECC_BYTES],
     /// Actual size of coordinates in bytes
     pub size: usize,
 }
@@ -472,9 +474,10 @@ pub struct EccPoint {
 impl EccPoint {
     /// Create a new point with given size
     pub fn new(size: usize) -> Self {
+        assert!(size <= MAX_ECC_BYTES, "ECC size exceeds 640-bit hardware limit");
         Self {
-            x: [0u8; 66],
-            y: [0u8; 66],
+            x: [0u8; MAX_ECC_BYTES],
+            y: [0u8; MAX_ECC_BYTES],
             size,
         }
     }
@@ -509,11 +512,11 @@ pub struct RsaCrtParams<'a> {
 /// (for Jacobian projective).
 pub struct EccProjectivePoint {
     /// X coordinate
-    pub x: [u8; 66], // Max size for P-521
+    pub x: [u8; MAX_ECC_BYTES],
     /// Y coordinate
-    pub y: [u8; 66],
+    pub y: [u8; MAX_ECC_BYTES],
     /// Z coordinate
-    pub z: [u8; 66],
+    pub z: [u8; MAX_ECC_BYTES],
     /// Actual size of coordinates in bytes
     pub size: usize,
 }
@@ -521,17 +524,20 @@ pub struct EccProjectivePoint {
 impl EccProjectivePoint {
     /// Create a new projective point with given size
     pub fn new(size: usize) -> Self {
+        assert!(size <= MAX_ECC_BYTES, "ECC size exceeds 640-bit hardware limit");
         Self {
-            x: [0u8; 66],
-            y: [0u8; 66],
-            z: [0u8; 66],
+            x: [0u8; MAX_ECC_BYTES],
+            y: [0u8; MAX_ECC_BYTES],
+            z: [0u8; MAX_ECC_BYTES],
             size,
         }
     }
 
     /// Create from affine point (Z = 1)
     pub fn from_affine(x: &[u8], y: &[u8]) -> Self {
+        assert!(x.len() == y.len(), "Affine point coordinates must have equal lengths");
         let size = x.len();
+        assert!(size <= MAX_ECC_BYTES, "ECC size exceeds 640-bit hardware limit");
         let mut point = Self::new(size);
         point.x[..size].copy_from_slice(x);
         point.y[..size].copy_from_slice(y);
@@ -2072,12 +2078,12 @@ impl<'d, T: Instance> Pka<'d, T, Blocking> {
             return Err(Error::InvalidSize);
         }
 
-        // Scratch buffers sized for the largest supported curve (P-521 = 66 bytes;
-        // arithmetic_mul produces 2* output, hence 132).
-        let mut z_inv = [0u8; 66];
-        let mut z_inv_sq = [0u8; 66];
-        let mut z_inv_cube = [0u8; 66];
-        let mut wide = [0u8; 132];
+        // Scratch buffers sized for the largest supported curve (640-bit = 80 bytes;
+        // arithmetic_mul produces 2* output, hence 160).
+        let mut z_inv = [0u8; MAX_ECC_BYTES];
+        let mut z_inv_sq = [0u8; MAX_ECC_BYTES];
+        let mut z_inv_cube = [0u8; MAX_ECC_BYTES];
+        let mut wide = [0u8; MAX_ECC_WIDE_BYTES];
 
         let m = modulus_size;
         let w = 2 * m;
@@ -2487,12 +2493,12 @@ impl<'d, T: Instance> Pka<'d, T, Async> {
             return Err(Error::InvalidSize);
         }
 
-        // Scratch buffers sized for the largest supported curve (P-521 = 66 bytes;
-        // arithmetic_mul produces 2* output, hence 132).
-        let mut z_inv = [0u8; 66];
-        let mut z_inv_sq = [0u8; 66];
-        let mut z_inv_cube = [0u8; 66];
-        let mut wide = [0u8; 132];
+        // Scratch buffers sized for the largest supported curve (640-bit = 80 bytes;
+        // arithmetic_mul produces 2* output, hence 160).
+        let mut z_inv = [0u8; MAX_ECC_BYTES];
+        let mut z_inv_sq = [0u8; MAX_ECC_BYTES];
+        let mut z_inv_cube = [0u8; MAX_ECC_BYTES];
+        let mut wide = [0u8; MAX_ECC_WIDE_BYTES];
 
         let m = modulus_size;
         let w = 2 * m;

--- a/embassy-stm32/src/rng.rs
+++ b/embassy-stm32/src/rng.rs
@@ -268,12 +268,6 @@ impl<'d, T: Instance> Rng<'d, T> {
         let _ = self.next_u32();
     }
 
-    #[cfg(not(rng_v1))]
-    /// Disable RNG and wait until it is idle (safe before low-power entry).
-    pub fn disable_for_low_power(&mut self) {
-        T::regs().cr().modify(|reg| reg.set_rngen(false));
-    }
-
     /// Try to recover from a seed error.
     pub fn recover_seed_error(&mut self) {
         self.reset();

--- a/embassy-stm32/src/rng.rs
+++ b/embassy-stm32/src/rng.rs
@@ -14,6 +14,61 @@ use crate::{Peri, interrupt, pac, peripherals, rcc};
 
 static RNG_WAKER: AtomicWaker = AtomicWaker::new();
 
+#[cfg(not(rng_v1))]
+/// Health-test programming profile used during RNG conditioning reset.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+pub enum HealthTestConfig {
+    /// Program the recommended threshold values from the reference manual.
+    Recommended,
+    /// Keep current HTCR values untouched.
+    KeepCurrent,
+}
+
+#[cfg(not(rng_v1))]
+/// RNG configuration knobs for reset/initialization policy.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+pub struct RngConfig {
+    /// NIST/custom conditioning mode selection.
+    pub nistc: pac::rng::vals::Nistc,
+    /// RNG clock divider before sampling.
+    pub clkdiv: pac::rng::vals::Clkdiv,
+    /// RNG configuration 1 profile.
+    pub rng_config1: pac::rng::vals::RngConfig1,
+    /// RNG configuration 2 profile.
+    pub rng_config2: pac::rng::vals::RngConfig2,
+    /// RNG configuration 3 profile.
+    pub rng_config3: pac::rng::vals::RngConfig3,
+    /// Enable clock error detector (CED bit, active-low semantics in HW).
+    pub clock_error_detector: bool,
+    /// Disable automatic reset on seed error when supported (ARDIS bit).
+    #[cfg(any(rng_v3, rng_wba6))]
+    pub auto_reset_disable: bool,
+    /// Lock RNG configuration after setup.
+    pub config_lock: bool,
+    /// Health-test threshold programming behavior.
+    pub health_test_config: HealthTestConfig,
+}
+
+#[cfg(not(rng_v1))]
+impl Default for RngConfig {
+    fn default() -> Self {
+        Self {
+            nistc: pac::rng::vals::Nistc::Custom,
+            clkdiv: pac::rng::vals::Clkdiv::NoDiv,
+            rng_config1: pac::rng::vals::RngConfig1::ConfigA,
+            rng_config2: pac::rng::vals::RngConfig2::ConfigAB,
+            rng_config3: pac::rng::vals::RngConfig3::ConfigA,
+            clock_error_detector: true,
+            #[cfg(any(rng_v3, rng_wba6))]
+            auto_reset_disable: false,
+            config_lock: false,
+            health_test_config: HealthTestConfig::Recommended,
+        }
+    }
+}
+
 /// WBA-specific health test configuration values for RNG
 #[derive(Clone, Copy)]
 #[allow(dead_code)]
@@ -69,6 +124,31 @@ impl<'d, T: Instance> Rng<'d, T> {
         inner: Peri<'d, T>,
         _irq: impl interrupt::typelevel::Binding<T::Interrupt, InterruptHandler<T>> + 'd,
     ) -> Self {
+        #[cfg(rng_v1)]
+        {
+            Self::new_inner(inner, _irq)
+        }
+        #[cfg(not(rng_v1))]
+        {
+            Self::new_inner(inner, _irq, RngConfig::default())
+        }
+    }
+
+    #[cfg(not(rng_v1))]
+    /// Create a new RNG driver with explicit configuration policy.
+    pub fn new_with_config(
+        inner: Peri<'d, T>,
+        _irq: impl interrupt::typelevel::Binding<T::Interrupt, InterruptHandler<T>> + 'd,
+        config: RngConfig,
+    ) -> Self {
+        Self::new_inner(inner, _irq, config)
+    }
+
+    #[cfg(rng_v1)]
+    fn new_inner(
+        inner: Peri<'d, T>,
+        _irq: impl interrupt::typelevel::Binding<T::Interrupt, InterruptHandler<T>> + 'd,
+    ) -> Self {
         rcc::enable_and_reset::<T>();
 
         // Verify clock is available
@@ -76,6 +156,26 @@ impl<'d, T: Instance> Rng<'d, T> {
 
         let mut random = Self { _inner: inner };
         random.reset();
+
+        T::Interrupt::unpend();
+        unsafe { T::Interrupt::enable() };
+
+        random
+    }
+
+    #[cfg(not(rng_v1))]
+    fn new_inner(
+        inner: Peri<'d, T>,
+        _irq: impl interrupt::typelevel::Binding<T::Interrupt, InterruptHandler<T>> + 'd,
+        config: RngConfig,
+    ) -> Self {
+        rcc::enable_and_reset::<T>();
+
+        // Verify clock is available
+        T::frequency();
+
+        let mut random = Self { _inner: inner };
+        random.reset_with_config(config);
 
         T::Interrupt::unpend();
         unsafe { T::Interrupt::enable() };
@@ -103,47 +203,58 @@ impl<'d, T: Instance> Rng<'d, T> {
     /// Reset the RNG.
     #[cfg(not(rng_v1))]
     pub fn reset(&mut self) {
+        self.reset_with_config(RngConfig::default());
+    }
+
+    #[cfg(not(rng_v1))]
+    /// Reset the RNG with a caller-provided configuration policy.
+    pub fn reset_with_config(&mut self, config: RngConfig) {
         T::regs().cr().write(|reg| {
             reg.set_condrst(true);
-            reg.set_nistc(pac::rng::vals::Nistc::Custom);
+            reg.set_nistc(config.nistc);
             // set RNG config "A" according to reference manual
             // this has to be written within the same write access as setting the CONDRST bit
-            reg.set_rng_config1(pac::rng::vals::RngConfig1::ConfigA);
-            reg.set_clkdiv(pac::rng::vals::Clkdiv::NoDiv);
-            reg.set_rng_config2(pac::rng::vals::RngConfig2::ConfigAB);
-            reg.set_rng_config3(pac::rng::vals::RngConfig3::ConfigA);
-            reg.set_ced(true);
+            reg.set_rng_config1(config.rng_config1);
+            reg.set_clkdiv(config.clkdiv);
+            reg.set_rng_config2(config.rng_config2);
+            reg.set_rng_config3(config.rng_config3);
+            reg.set_ced(!config.clock_error_detector);
+            #[cfg(any(rng_v3, rng_wba6))]
+            reg.set_ardis(config.auto_reset_disable);
             reg.set_ie(false);
             reg.set_rngen(true);
-        });
-        T::regs().cr().modify(|reg| {
-            reg.set_ced(false);
         });
         // wait for CONDRST to be set
         while !T::regs().cr().read().condrst() {}
 
         // Set health test configuration values
-        #[cfg(not(rng_wba6))]
-        {
-            // magic number must be written immediately before every read or write access to HTCR
-            T::regs().htcr().write(|w| w.set_htcfg(pac::rng::vals::Htcfg::Magic));
-            // write recommended value according to reference manual
-            // note: HTCR can only be written during conditioning
-            T::regs()
-                .htcr()
-                .write(|w| w.set_htcfg(pac::rng::vals::Htcfg::Recommended));
-        }
-        #[cfg(rng_wba6)]
-        {
-            // For WBA6, set RNG_HTCR0 to the recommended value for configurations A, B, and C
-            // This value corresponds to the health test thresholds specified in the reference manual
-            T::regs().htcr(0).write(|w| w.0 = Htcfg::WbaRecommended.value());
+        match config.health_test_config {
+            HealthTestConfig::Recommended => {
+                #[cfg(not(rng_wba6))]
+                {
+                    // magic number must be written immediately before every read or write access to HTCR
+                    T::regs().htcr().write(|w| w.set_htcfg(pac::rng::vals::Htcfg::Magic));
+                    // write recommended value according to reference manual
+                    // note: HTCR can only be written during conditioning
+                    T::regs()
+                        .htcr()
+                        .write(|w| w.set_htcfg(pac::rng::vals::Htcfg::Recommended));
+                }
+                #[cfg(rng_wba6)]
+                {
+                    // For WBA6, set RNG_HTCR0 to the recommended value for configurations A, B, and C
+                    // This value corresponds to the health test thresholds specified in the reference manual
+                    T::regs().htcr(0).write(|w| w.0 = Htcfg::WbaRecommended.value());
+                }
+            }
+            HealthTestConfig::KeepCurrent => {}
         }
 
         // finish conditioning
         T::regs().cr().modify(|reg| {
             reg.set_rngen(true);
             reg.set_condrst(false);
+            reg.set_configlock(config.config_lock);
         });
 
         // According to reference manual for RNGv3: SEIS must be cleared manually.
@@ -155,6 +266,12 @@ impl<'d, T: Instance> Rng<'d, T> {
         // According to reference manual: after software reset, wait for random number to be ready
         // The next_u32() call will wait for DRDY, completing the initialization
         let _ = self.next_u32();
+    }
+
+    #[cfg(not(rng_v1))]
+    /// Disable RNG and wait until it is idle (safe before low-power entry).
+    pub fn disable_for_low_power(&mut self) {
+        T::regs().cr().modify(|reg| reg.set_rngen(false));
     }
 
     /// Try to recover from a seed error.

--- a/embassy-stm32/src/saes/mod.rs
+++ b/embassy-stm32/src/saes/mod.rs
@@ -295,6 +295,39 @@ impl<'d, T: Instance, M: Mode> Saes<'d, T, M> {
         self.start_with_key_mode(cipher, dir, KeyMode::Normal, Some(key_source))
     }
 
+    /// Starts a new cipher operation with an explicit SAES key mode.
+    ///
+    /// This enables wrapped-key/shared-key workflows in addition to normal mode.
+    /// When `hw_key` is provided, SAES selects a hardware key source.
+    pub fn start_with_mode<'c, C>(
+        &mut self,
+        key_mode: KeyMode,
+        hw_key: Option<HardwareKeySource>,
+        cipher: &'c C,
+        dir: Direction,
+    ) -> Context<'c, C>
+    where
+        C: Cipher<'c> + CipherSized + IVSized,
+    {
+        self.start_with_key_mode(cipher, dir, key_mode, hw_key)
+    }
+
+    /// Starts a new cipher operation in wrapped-key mode.
+    pub fn start_wrapped_key<'c, C>(&mut self, cipher: &'c C, dir: Direction) -> Context<'c, C>
+    where
+        C: Cipher<'c> + CipherSized + IVSized,
+    {
+        self.start_with_key_mode(cipher, dir, KeyMode::WrappedKey, None)
+    }
+
+    /// Starts a new cipher operation in shared-key mode.
+    pub fn start_shared_key<'c, C>(&mut self, cipher: &'c C, dir: Direction) -> Context<'c, C>
+    where
+        C: Cipher<'c> + CipherSized + IVSized,
+    {
+        self.start_with_key_mode(cipher, dir, KeyMode::SharedKey, None)
+    }
+
     /// Internal start method with full control over key mode.
     fn start_with_key_mode<'c, C>(
         &mut self,
@@ -733,6 +766,38 @@ impl<'d, T: Instance, M: Mode> Saes<'d, T, M> {
         p.icr().write(|w| w.0 = 0xFFFF_FFFF);
 
         Ok(())
+    }
+}
+
+impl<'d, T: Instance> Saes<'d, T, Async> {
+    /// Process authenticated additional data (AAD) for GCM/CCM modes (async facade).
+    pub async fn aad<'c, C>(&mut self, ctx: &mut Context<'c, C>, aad: &[u8], last: bool) -> Result<(), Error>
+    where
+        C: Cipher<'c> + CipherAuthenticated<16>,
+    {
+        self.aad_blocking(ctx, aad, last)
+    }
+
+    /// Process payload data (async facade).
+    pub async fn payload<'c, C>(
+        &mut self,
+        ctx: &mut Context<'c, C>,
+        input: &[u8],
+        output: &mut [u8],
+        last: bool,
+    ) -> Result<(), Error>
+    where
+        C: Cipher<'c>,
+    {
+        self.payload_blocking(ctx, input, output, last)
+    }
+
+    /// Finish cipher operation and return authentication tag for authenticated modes (async facade).
+    pub async fn finish<'c, C>(&mut self, ctx: Context<'c, C>) -> Result<Option<[u8; 16]>, Error>
+    where
+        C: Cipher<'c>,
+    {
+        self.finish_blocking(ctx)
     }
 }
 


### PR DESCRIPTION
## Summary
- consolidate PR1-PR3 into one branch for coordinated cryptography/peripheral API review
- extend PKA ECC point support to 640-bit, expose SAES key-mode + async parity APIs, and add configurable RNG initialization policy APIs
- remove the newly added RNG low-power disable helper for now based on review feedback (needs refcount design first)
- keep commit history linear and scoped to `embassy-stm32`

## Included source branches
- `feat/stm32-pr1-pka-ecc-640bit`
- `feat/stm32-pr2-saes-keymode-async`
- `feat/stm32-pr3-rng-config-api`