### PR TITLE
embassy-net: Add auto-icmp-echo-reply to default features

### DIFF
--- a/embassy-net/Cargo.toml
+++ b/embassy-net/Cargo.toml
@@ -54,6 +54,8 @@ target = "thumbv7em-none-eabi"
 features = ["defmt", "tcp", "udp", "raw", "dns", "icmp", "dhcpv4", "proto-ipv6", "medium-ethernet", "medium-ip", "medium-ieee802154", "multicast", "dhcpv4-hostname", "packetmeta-id"]
 
 [features]
+default = ["auto-icmp-echo-reply"]
+
 ## Enable defmt
 defmt = ["dep:defmt", "smoltcp/defmt", "embassy-net-driver/defmt", "embassy-time/defmt", "heapless/defmt", "defmt?/ip_in_core"]
 ## Enable log


### PR DESCRIPTION
The feature [was added to smoltcp](https://github.com/smoltcp-rs/smoltcp/pull/1106) in the recent 0.13.0 release, and embassy-net was updated to use 0.13.0 in f0ff2ac131d2979f0bae0caa5ad7d28e228ff269. Support for the feature was earlier added to embassy-net in 3540e528f2490569bf6cb3cb134a0c69b0ca5adb.

In smoltcp the feature is enabled by default to preserve the previous behaviour of replying to ICMP echo requests, but possible to disable using `default-features=false`. When the equivalent feature was added to embassy-net it wasn't enabled by default, so the behaviour changed to default not reply to pings. I think that was probably unintentional and we should match the smoltcp behaviour of replying by default.