### PR TITLE
Fix PIO Common lifetime issue with cyw43::PioSpi

### DIFF
--- a/cyw43-pio/src/lib.rs
+++ b/cyw43-pio/src/lib.rs
@@ -15,12 +15,13 @@ use fixed::FixedU32;
 use fixed::types::extra::U8;
 
 /// SPI comms driven by PIO.
-pub struct PioSpi<'d, PIO: Instance, const SM: usize, DMA: Channel> {
+pub struct PioSpi<'a, 'd, PIO: Instance, const SM: usize, DMA: Channel> {
     cs: Output<'d>,
     sm: StateMachine<'d, PIO, SM>,
     irq: Irq<'d, PIO, 0>,
     dma: Peri<'d, DMA>,
     wrap_target: u8,
+    common: core::marker::PhantomData<&'a mut Common<'d, PIO>>,
 }
 
 /// The default clock divider that works for Pico 1 and 2 W. As well as the RM2 on rp2040 devices.
@@ -42,14 +43,15 @@ pub const OVERCLOCK_CLOCK_DIVIDER: FixedU32<U8> = FixedU32::from_bits(0x0100);
 /// Pico Plus 2 Non w with the RM2 breakout module, and the Pico 2 with the RM2 breakout module.
 pub const RM2_CLOCK_DIVIDER: FixedU32<U8> = FixedU32::from_bits(0x0300);
 
-impl<'d, PIO, const SM: usize, DMA> PioSpi<'d, PIO, SM, DMA>
+impl<'a, 'd, PIO, const SM: usize, DMA> PioSpi<'a, 'd, PIO, SM, DMA>
 where
+    'd: 'a,
     DMA: Channel,
     PIO: Instance,
 {
     /// Create a new instance of PioSpi.
     pub fn new(
-        common: &mut Common<'d, PIO>,
+        common: &'a mut Common<'d, PIO>,
         mut sm: StateMachine<'d, PIO, SM>,
         clock_divider: FixedU32<U8>,
         irq: Irq<'d, PIO, 0>,
@@ -144,6 +146,7 @@ where
             irq,
             dma: dma,
             wrap_target: loaded_program.wrap.target,
+            common: core::marker::PhantomData,
         }
     }
 
@@ -216,7 +219,7 @@ where
     }
 }
 
-impl<'d, PIO, const SM: usize, DMA> SpiBusCyw43 for PioSpi<'d, PIO, SM, DMA>
+impl<'a, 'd, PIO, const SM: usize, DMA> SpiBusCyw43 for PioSpi<'a, 'd, PIO, SM, DMA>
 where
     PIO: Instance,
     DMA: Channel,


### PR DESCRIPTION
Currently, `cyw43::PioSpi::new()` borrows a `&mut Common<'d, PIO>` and logically requires that the `Common` and the underlying `PIO` outlive it, but it doesn't currently enforce that - the lifetime of the new `PioSpi` only depends on `'d` - the lifetime of the internal borrows of `PIO`.

This patch is a bit of a conservative approach - It holds a `&mut Common` the entire time it's alive. This fixes the issue, although a more permissive patch could be imagined that programs it with a `&mut Common` but then only holds a `&Common` afterwards. But expressing that might be awkward, and I don't know how common it might be to do something like that.

Fixes #6251