### PR TITLE
stm32: add 'suspendable peripheral' api

### DIFF
--- a/embassy-stm32-wpan/Cargo.toml
+++ b/embassy-stm32-wpan/Cargo.toml
@@ -56,6 +56,7 @@ futures-intrusive = { version ="0.5.0", default-features = false }
 [features]
 defmt = ["dep:defmt", "embassy-sync/defmt", "embassy-embedded-hal/defmt", "embassy-hal-internal/defmt", "stm32wb-hci?/defmt", "bt-hci?/defmt"]
 log = ["dep:log"]
+low-power = ["embassy-stm32/low-power"]
 bt-hci = ["dep:bt-hci" ]
 wb-hci = ["bt-hci", "dep:stm32wb-hci"]
 

--- a/embassy-stm32-wpan/src/wba/platform.rs
+++ b/embassy-stm32-wpan/src/wba/platform.rs
@@ -77,19 +77,53 @@ use crate::ChannelPacket;
 use crate::util::Flag;
 use crate::wba::{BasicRuntime, FullRuntime, linklayer_plat, util_seq};
 
+#[cfg(feature = "low-power")]
+struct MaybeResumablePeripheral<T: embassy_stm32::low_power::SuspendablePeripheral> {
+    peripheral: embassy_stm32::low_power::ResumablePeripheral<T>,
+}
+
+#[cfg(feature = "low-power")]
+impl<T: embassy_stm32::low_power::SuspendablePeripheral> MaybeResumablePeripheral<T> {
+    fn new(peripheral: T) -> Self {
+        Self {
+            peripheral: embassy_stm32::low_power::ResumablePeripheral::new(peripheral),
+        }
+    }
+
+    fn lock(&mut self) -> embassy_stm32::low_power::ResumablePeripheralGuard<'_, T> {
+        self.peripheral.lock()
+    }
+}
+
+#[cfg(not(feature = "low-power"))]
+struct MaybeResumablePeripheral<T> {
+    peripheral: T,
+}
+
+#[cfg(not(feature = "low-power"))]
+impl<T> MaybeResumablePeripheral<T> {
+    fn new(peripheral: T) -> Self {
+        Self { peripheral }
+    }
+
+    fn lock(&mut self) -> &mut T {
+        &mut self.peripheral
+    }
+}
+
 pub struct Platform {
     channel: UnsafeCell<Channel<'static, CriticalSectionRawMutex, ChannelPacket>>,
     rng_pipe: Pipe<CriticalSectionRawMutex, 256>,
     p256_req: Signal<CriticalSectionRawMutex, ([u32; 8], [u32; 8], [u32; 8])>,
     p256_resp: Signal<CriticalSectionRawMutex, ([u32; 8], [u32; 8])>,
     ble_init: Flag,
-    rng: Mutex<CriticalSectionRawMutex, Rng<'static, RNG>>,
+    rng: Mutex<CriticalSectionRawMutex, MaybeResumablePeripheral<Rng<'static, RNG>>>,
     pka: Mutex<CriticalSectionRawMutex, Option<Pka<'static, PkaPeriph, Async>>>,
     aes: Option<CriticalSectionMutex<RefCell<Aes<'static, AesPeriph, Blocking>>>>,
 }
 
 impl Platform {
-    pub const fn new_basic<const N: usize>(
+    pub fn new_basic<const N: usize>(
         buf: &'static mut [ChannelPacket; N],
         rng: Rng<'static, RNG>,
     ) -> (Self, BasicRuntime) {
@@ -100,7 +134,7 @@ impl Platform {
                 p256_req: Signal::new(),
                 p256_resp: Signal::new(),
                 ble_init: Flag::new(false),
-                rng: Mutex::new(rng),
+                rng: Mutex::new(MaybeResumablePeripheral::new(rng)),
                 pka: Mutex::new(None),
                 aes: None,
             },
@@ -108,7 +142,7 @@ impl Platform {
         )
     }
 
-    pub const fn new_full<const N: usize>(
+    pub fn new_full<const N: usize>(
         buf: &'static mut [ChannelPacket; N],
         rng: Rng<'static, RNG>,
         pka: Pka<'static, PkaPeriph, Async>,
@@ -121,7 +155,7 @@ impl Platform {
                 p256_req: Signal::new(),
                 p256_resp: Signal::new(),
                 ble_init: Flag::new(false),
-                rng: Mutex::new(rng),
+                rng: Mutex::new(MaybeResumablePeripheral::new(rng)),
                 pka: Mutex::new(Some(pka)),
                 aes: Some(CriticalSectionMutex::new(RefCell::new(aes))),
             },
@@ -261,7 +295,7 @@ impl Platform {
 
                 loop {
                     let mut buf = [0u8; 64];
-                    if let Err(e) = rng.async_fill_bytes(&mut buf).await {
+                    if let Err(e) = rng.lock().async_fill_bytes(&mut buf).await {
                         warn!("rng: err during fill bytes: {}", e);
 
                         continue;

--- a/embassy-stm32-wpan/src/wba/platform.rs
+++ b/embassy-stm32-wpan/src/wba/platform.rs
@@ -60,6 +60,7 @@ use core::task::Poll;
 
 use embassy_futures::join::join3;
 use embassy_futures::select::select;
+use embassy_stm32::ResumablePeripheral;
 use embassy_stm32::aes::Aes;
 use embassy_stm32::mode::{Async, Blocking};
 use embassy_stm32::peripherals::{AES as AesPeriph, PKA as PkaPeriph, RNG};
@@ -77,47 +78,13 @@ use crate::ChannelPacket;
 use crate::util::Flag;
 use crate::wba::{BasicRuntime, FullRuntime, linklayer_plat, util_seq};
 
-#[cfg(feature = "low-power")]
-struct MaybeResumablePeripheral<T: embassy_stm32::low_power::SuspendablePeripheral> {
-    peripheral: embassy_stm32::low_power::ResumablePeripheral<T>,
-}
-
-#[cfg(feature = "low-power")]
-impl<T: embassy_stm32::low_power::SuspendablePeripheral> MaybeResumablePeripheral<T> {
-    fn new(peripheral: T) -> Self {
-        Self {
-            peripheral: embassy_stm32::low_power::ResumablePeripheral::new(peripheral),
-        }
-    }
-
-    fn lock(&mut self) -> embassy_stm32::low_power::ResumablePeripheralGuard<'_, T> {
-        self.peripheral.lock()
-    }
-}
-
-#[cfg(not(feature = "low-power"))]
-struct MaybeResumablePeripheral<T> {
-    peripheral: T,
-}
-
-#[cfg(not(feature = "low-power"))]
-impl<T> MaybeResumablePeripheral<T> {
-    fn new(peripheral: T) -> Self {
-        Self { peripheral }
-    }
-
-    fn lock(&mut self) -> &mut T {
-        &mut self.peripheral
-    }
-}
-
 pub struct Platform {
     channel: UnsafeCell<Channel<'static, CriticalSectionRawMutex, ChannelPacket>>,
     rng_pipe: Pipe<CriticalSectionRawMutex, 256>,
     p256_req: Signal<CriticalSectionRawMutex, ([u32; 8], [u32; 8], [u32; 8])>,
     p256_resp: Signal<CriticalSectionRawMutex, ([u32; 8], [u32; 8])>,
     ble_init: Flag,
-    rng: Mutex<CriticalSectionRawMutex, MaybeResumablePeripheral<Rng<'static, RNG>>>,
+    rng: Mutex<CriticalSectionRawMutex, ResumablePeripheral<Rng<'static, RNG>>>,
     pka: Mutex<CriticalSectionRawMutex, Option<Pka<'static, PkaPeriph, Async>>>,
     aes: Option<CriticalSectionMutex<RefCell<Aes<'static, AesPeriph, Blocking>>>>,
 }
@@ -134,7 +101,7 @@ impl Platform {
                 p256_req: Signal::new(),
                 p256_resp: Signal::new(),
                 ble_init: Flag::new(false),
-                rng: Mutex::new(MaybeResumablePeripheral::new(rng)),
+                rng: Mutex::new(ResumablePeripheral::new(rng)),
                 pka: Mutex::new(None),
                 aes: None,
             },
@@ -155,7 +122,7 @@ impl Platform {
                 p256_req: Signal::new(),
                 p256_resp: Signal::new(),
                 ble_init: Flag::new(false),
-                rng: Mutex::new(MaybeResumablePeripheral::new(rng)),
+                rng: Mutex::new(ResumablePeripheral::new(rng)),
                 pka: Mutex::new(Some(pka)),
                 aes: Some(CriticalSectionMutex::new(RefCell::new(aes))),
             },

--- a/embassy-stm32-wpan/src/wba/platform.rs
+++ b/embassy-stm32-wpan/src/wba/platform.rs
@@ -262,13 +262,29 @@ impl Platform {
 
                 loop {
                     let mut buf = [0u8; 64];
-                    if let Err(e) = rng.lock().async_fill_bytes(&mut buf).await {
-                        warn!("rng: err during fill bytes: {}", e);
+                    let mut n;
+                    {
+                        #[allow(unused_mut)]
+                        let mut guard = rng.lock();
+                        'outer: loop {
+                            n = 0;
+                            if let Err(e) = guard.async_fill_bytes(&mut buf).await {
+                                warn!("rng: err during fill bytes: {}", e);
 
-                        continue;
+                                continue;
+                            }
+
+                            while n < buf.len() {
+                                if let Ok(len) = self.rng_pipe.try_write(&buf) {
+                                    n += len;
+                                } else {
+                                    break 'outer;
+                                }
+                            }
+                        }
                     }
 
-                    self.rng_pipe.write_all(&buf).await;
+                    self.rng_pipe.write_all(&buf[n..]).await;
                 }
             },
         )

--- a/embassy-stm32/src/lib.rs
+++ b/embassy-stm32/src/lib.rs
@@ -282,10 +282,31 @@ macro_rules! bind_interrupts {
 // Reexports
 pub use _generated::{Peripherals, peripherals};
 pub use embassy_hal_internal::{Peri, PeripheralType};
+#[cfg(feature = "low-power")]
+pub use low_power::ResumablePeripheral;
 #[cfg(feature = "unstable-pac")]
 pub use stm32_metapac as pac;
 #[cfg(not(feature = "unstable-pac"))]
 pub(crate) use stm32_metapac as pac;
+
+#[cfg(not(feature = "low-power"))]
+/// A mutex-like object to resume a peripheral. Does nothing when `low-power` is not enabled.
+pub struct ResumablePeripheral<T> {
+    peripheral: T,
+}
+
+#[cfg(not(feature = "low-power"))]
+impl<T> ResumablePeripheral<T> {
+    /// Create the object. Will suspend the peripheral as soon as it is passed.
+    pub fn new(peripheral: T) -> Self {
+        Self { peripheral }
+    }
+
+    /// Get the resumable peripheral guard
+    pub fn lock(&mut self) -> &mut T {
+        &mut self.peripheral
+    }
+}
 
 use crate::interrupt::Priority;
 #[cfg(feature = "rt")]

--- a/embassy-stm32/src/low_power.rs
+++ b/embassy-stm32/src/low_power.rs
@@ -25,7 +25,7 @@
 //! executor is the preferred way to lower power consumption if you're using `async`, instead of calling `sleep()` directly.
 
 use core::mem;
-use core::mem::{ManuallyDrop, transmute_copy};
+use core::mem::ManuallyDrop;
 use core::ops::{Deref, DerefMut};
 use core::sync::atomic::{AtomicBool, Ordering, compiler_fence};
 

--- a/embassy-stm32/src/low_power.rs
+++ b/embassy-stm32/src/low_power.rs
@@ -25,6 +25,8 @@
 //! executor is the preferred way to lower power consumption if you're using `async`, instead of calling `sleep()` directly.
 
 use core::mem;
+use core::mem::transmute_copy;
+use core::ops::{Deref, DerefMut};
 use core::sync::atomic::{AtomicBool, Ordering, compiler_fence};
 
 use cortex_m::peripheral::SCB;
@@ -375,4 +377,105 @@ pub unsafe fn sleep(cs: CriticalSection) {
     cortex_m::asm::dsb();
 
     on_wakeup(cs);
+}
+
+/// Peripheral that can be suspended
+#[allow(private_bounds)]
+pub trait SuspendablePeripheral: SealedSuspendablePeripheral {}
+
+pub(crate) trait SealedSuspendablePeripheral {
+    type InternalState;
+
+    #[allow(dead_code)]
+    fn suspend(self) -> Self::InternalState;
+    #[allow(dead_code)]
+    fn resume(state: Self::InternalState) -> Self;
+}
+
+impl<T: SealedSuspendablePeripheral> SuspendablePeripheral for T {}
+
+/// A suspended peripheral
+pub struct SuspendedPeripheral<T: SuspendablePeripheral> {
+    state: T::InternalState,
+}
+
+impl<T: SuspendablePeripheral> SuspendedPeripheral<T> {
+    /// Suspend a peripheral
+    pub fn from(peripheral: T) -> Self {
+        Self {
+            state: T::suspend(peripheral),
+        }
+    }
+
+    /// Resume a peripheral
+    pub fn resume(self) -> T {
+        T::resume(self.state)
+    }
+}
+
+enum ResumableState<T: SuspendablePeripheral> {
+    Suspended(SuspendedPeripheral<T>),
+    Resumed(T),
+}
+
+/// A mutex-like object to resume a peripheral
+pub struct ResumablePeripheral<T: SuspendablePeripheral> {
+    state: ResumableState<T>,
+}
+
+impl<T: SuspendablePeripheral> ResumablePeripheral<T> {
+    /// Create the object. Will suspend the peripheral as soon as it is passed.
+    pub fn new(peripheral: T) -> Self {
+        Self {
+            state: ResumableState::Suspended(SuspendedPeripheral::from(peripheral)),
+        }
+    }
+
+    /// Get the resumable peripheral guard
+    pub fn lock(&mut self) -> ResumablePeripheralGuard<'_, T> {
+        unsafe {
+            if let ResumableState::Suspended(peripheral) = transmute_copy(&self.state) {
+                self.state = ResumableState::Resumed(peripheral.resume());
+            }
+        }
+
+        ResumablePeripheralGuard { state: &mut self.state }
+    }
+}
+
+/// A mutex-like object guard, that when held, activates the peripheral
+pub struct ResumablePeripheralGuard<'a, T: SuspendablePeripheral> {
+    state: &'a mut ResumableState<T>,
+}
+
+impl<'a, T: SuspendablePeripheral> Drop for ResumablePeripheralGuard<'a, T> {
+    fn drop(&mut self) {
+        unsafe {
+            if let ResumableState::Resumed(peripheral) = transmute_copy(&self.state) {
+                *self.state = ResumableState::Suspended(SuspendedPeripheral::from(peripheral));
+            }
+        }
+    }
+}
+
+impl<'a, T: SuspendablePeripheral> Deref for ResumablePeripheralGuard<'a, T> {
+    type Target = T;
+
+    fn deref(&self) -> &T {
+        if let ResumableState::Resumed(peripheral) = &self.state {
+            peripheral
+        } else {
+            unreachable!()
+        }
+    }
+}
+
+impl<'a, T: SuspendablePeripheral> DerefMut for ResumablePeripheralGuard<'a, T> {
+    fn deref_mut(&mut self) -> &mut T {
+        if let ResumableState::Resumed(peripheral) = &mut self.state {
+            peripheral
+        } else {
+            unreachable!()
+        }
+    }
 }

--- a/embassy-stm32/src/low_power.rs
+++ b/embassy-stm32/src/low_power.rs
@@ -25,7 +25,7 @@
 //! executor is the preferred way to lower power consumption if you're using `async`, instead of calling `sleep()` directly.
 
 use core::mem;
-use core::mem::transmute_copy;
+use core::mem::{ManuallyDrop, transmute_copy};
 use core::ops::{Deref, DerefMut};
 use core::sync::atomic::{AtomicBool, Ordering, compiler_fence};
 
@@ -413,6 +413,10 @@ impl<T: SuspendablePeripheral> SuspendedPeripheral<T> {
     }
 }
 
+unsafe fn transmute_ref<T>(src: &T) -> T {
+    unsafe { mem::transmute_copy(src) }
+}
+
 enum ResumableState<T: SuspendablePeripheral> {
     Suspended(SuspendedPeripheral<T>),
     Resumed(T),
@@ -420,26 +424,33 @@ enum ResumableState<T: SuspendablePeripheral> {
 
 /// A mutex-like object to resume a peripheral
 pub struct ResumablePeripheral<T: SuspendablePeripheral> {
-    state: ResumableState<T>,
+    state: ManuallyDrop<ResumableState<T>>,
 }
 
 impl<T: SuspendablePeripheral> ResumablePeripheral<T> {
     /// Create the object. Will suspend the peripheral as soon as it is passed.
     pub fn new(peripheral: T) -> Self {
         Self {
-            state: ResumableState::Suspended(SuspendedPeripheral::from(peripheral)),
+            state: ManuallyDrop::new(ResumableState::Suspended(SuspendedPeripheral::from(peripheral))),
         }
     }
 
     /// Get the resumable peripheral guard
     pub fn lock(&mut self) -> ResumablePeripheralGuard<'_, T> {
-        unsafe {
-            if let ResumableState::Suspended(peripheral) = transmute_copy(&self.state) {
-                self.state = ResumableState::Resumed(peripheral.resume());
+        if let ResumableState::Suspended(peripheral) = &*self.state {
+            unsafe {
+                // self.state is ManuallyDrop, so the transmute_ref is safe
+                *self.state = ResumableState::Resumed(transmute_ref(peripheral).resume());
             }
         }
 
         ResumablePeripheralGuard { state: &mut self.state }
+    }
+}
+
+impl<T: SuspendablePeripheral> Drop for ResumablePeripheral<T> {
+    fn drop(&mut self) {
+        unsafe { ManuallyDrop::drop(&mut self.state) };
     }
 }
 
@@ -450,9 +461,10 @@ pub struct ResumablePeripheralGuard<'a, T: SuspendablePeripheral> {
 
 impl<'a, T: SuspendablePeripheral> Drop for ResumablePeripheralGuard<'a, T> {
     fn drop(&mut self) {
-        unsafe {
-            if let ResumableState::Resumed(peripheral) = transmute_copy(&self.state) {
-                *self.state = ResumableState::Suspended(SuspendedPeripheral::from(peripheral));
+        if let ResumableState::Resumed(peripheral) = &self.state {
+            unsafe {
+                // self.state is ManuallyDrop, so the transmute_ref is safe
+                *self.state = ResumableState::Suspended(SuspendedPeripheral::from(transmute_ref(peripheral)));
             }
         }
     }

--- a/embassy-stm32/src/rng.rs
+++ b/embassy-stm32/src/rng.rs
@@ -69,6 +69,10 @@ impl<'d, T: Instance> Rng<'d, T> {
         inner: Peri<'d, T>,
         _irq: impl interrupt::typelevel::Binding<T::Interrupt, InterruptHandler<T>> + 'd,
     ) -> Self {
+        Self::new_inner(inner)
+    }
+
+    fn new_inner(inner: Peri<'d, T>) -> Self {
         rcc::enable_and_reset::<T>();
 
         // Verify clock is available
@@ -262,6 +266,19 @@ impl<'d, T: Instance> Drop for Rng<'d, T> {
             reg.set_rngen(false);
         });
         rcc::disable::<T>();
+    }
+}
+
+#[cfg(feature = "low-power")]
+impl<'d, T: Instance> crate::low_power::SealedSuspendablePeripheral for Rng<'d, T> {
+    type InternalState = Peri<'d, T>;
+
+    fn suspend(self) -> Self::InternalState {
+        unsafe { self._inner.clone_unchecked() }
+    }
+
+    fn resume(state: Self::InternalState) -> Self {
+        Self::new_inner(state)
     }
 }
 

--- a/embassy-stm32/src/rng.rs
+++ b/embassy-stm32/src/rng.rs
@@ -126,7 +126,7 @@ impl<'d, T: Instance> Rng<'d, T> {
     ) -> Self {
         #[cfg(rng_v1)]
         {
-            Self::new_inner(inner, _irq)
+            Self::new_inner(inner)
         }
         #[cfg(not(rng_v1))]
         {
@@ -378,7 +378,15 @@ impl<'d, T: Instance> crate::low_power::SealedSuspendablePeripheral for Rng<'d, 
     }
 
     fn resume(state: Self::InternalState) -> Self {
-        Self::new_inner(state, Default::default())
+        #[cfg(not(rng_v1))]
+        {
+            Self::new_inner(state, Default::default())
+        }
+
+        #[cfg(rng_v1)]
+        {
+            Self::new_inner(state)
+        }
     }
 }
 

--- a/embassy-stm32/src/rng.rs
+++ b/embassy-stm32/src/rng.rs
@@ -371,16 +371,42 @@ impl<'d, T: Instance> Drop for Rng<'d, T> {
 
 #[cfg(feature = "low-power")]
 impl<'d, T: Instance> crate::low_power::SealedSuspendablePeripheral for Rng<'d, T> {
+    #[cfg(rng_v1)]
     type InternalState = Peri<'d, T>;
 
+    #[cfg(not(rng_v1))]
+    type InternalState = (Peri<'d, T>, RngConfig);
+
     fn suspend(self) -> Self::InternalState {
-        unsafe { self._inner.clone_unchecked() }
+        #[cfg(not(rng_v1))]
+        {
+            let cr = T::regs().cr().read();
+
+            let config = RngConfig {
+                nistc: cr.nistc(),
+                clkdiv: cr.clkdiv(),
+                rng_config1: cr.rng_config1(),
+                rng_config2: cr.rng_config2(),
+                rng_config3: cr.rng_config3(),
+                clock_error_detector: !cr.ced(),
+                #[cfg(any(rng_v3, rng_wba6))]
+                auto_reset_disable: cr.ardis(),
+                ..Default::default()
+            };
+
+            unsafe { (self._inner.clone_unchecked(), config) }
+        }
+
+        #[cfg(rng_v1)]
+        {
+            unsafe { self._inner.clone_unchecked() }
+        }
     }
 
     fn resume(state: Self::InternalState) -> Self {
         #[cfg(not(rng_v1))]
         {
-            Self::new_inner(state, Default::default())
+            Self::new_inner(state.0, state.1)
         }
 
         #[cfg(rng_v1)]

--- a/examples/stm32wba6-lp/Cargo.toml
+++ b/examples/stm32wba6-lp/Cargo.toml
@@ -21,7 +21,8 @@ panic-probe = { version = "1.0.0", features = ["print-defmt"] }
 static_cell = "2"
 
 [features]
-ble = ["dep:embassy-stm32-wpan", "embassy-stm32-wpan/wba-ble", "embassy-stm32-wpan/ble-stack-basic", "embassy-stm32-wpan/linklayer6-ble-basic"]
+default = [ "ble" ]
+ble = ["dep:embassy-stm32-wpan", "embassy-stm32-wpan/low-power", "embassy-stm32-wpan/wba-ble", "embassy-stm32-wpan/ble-stack-basic", "embassy-stm32-wpan/linklayer6-ble-basic"]
 
 [[bin]]
 name = "ble_advertiser_lp"


### PR DESCRIPTION
This allows resuming and suspending peripherals to enter stop2 with a type-erased object.