### PR TITLE
stm32/dma: Fix `read_latest` in ring buffer

### DIFF
--- a/embassy-stm32/src/dma/ringbuffer/mod.rs
+++ b/embassy-stm32/src/dma/ringbuffer/mod.rs
@@ -167,13 +167,9 @@ impl<'a, W: Word> ReadableDmaRingBuffer<'a, W> {
     /// Error is returned if the portion to be read was overwritten by the DMA controller,
     /// in which case the rinbuffer will automatically reset itself.
     pub fn read(&mut self, dma: &mut impl DmaCtrl, buf: &mut [W]) -> Result<(usize, usize), Error> {
-        fence(Ordering::Acquire);
-
-        let available = self.sync_len(dma).inspect_err(|_e| {
+        self.read_raw(dma, buf).inspect_err(|_e| {
             self.reset(dma);
-        })?;
-
-        Ok(self.read_raw(available, buf))
+        })
     }
 
     /// Read an exact number of elements from the ringbuffer.
@@ -209,7 +205,11 @@ impl<'a, W: Word> ReadableDmaRingBuffer<'a, W> {
         .await
     }
 
-    fn read_raw(&mut self, mut available: usize, buf: &mut [W]) -> (usize, usize) {
+    fn read_raw(&mut self, dma: &mut impl DmaCtrl, buf: &mut [W]) -> Result<(usize, usize), Error> {
+        fence(Ordering::Acquire);
+
+        let mut available = self.sync_len(dma)?;
+
         // Compute alignment skip without advancing read_index yet.
         // DMA always starts at buffer position 0 (frame-aligned) and advances
         // sequentially, so position N is frame-aligned when N % alignment == 0.
@@ -221,7 +221,7 @@ impl<'a, W: Word> ReadableDmaRingBuffer<'a, W> {
                     available -= skip;
                     skip
                 } else {
-                    return (0, available);
+                    return Ok((0, available));
                 }
             } else {
                 0
@@ -250,7 +250,7 @@ impl<'a, W: Word> ReadableDmaRingBuffer<'a, W> {
         self.read_index.advance(self.cap(), skip + readable);
 
         let remaining = write_snapshot.diff(self.cap(), &self.read_index).max(0) as usize;
-        (readable, remaining)
+        Ok((readable, remaining))
     }
 
     /// Read the most recent elements from the ring buffer, discarding any older data.

--- a/embassy-stm32/src/dma/ringbuffer/mod.rs
+++ b/embassy-stm32/src/dma/ringbuffer/mod.rs
@@ -167,9 +167,13 @@ impl<'a, W: Word> ReadableDmaRingBuffer<'a, W> {
     /// Error is returned if the portion to be read was overwritten by the DMA controller,
     /// in which case the rinbuffer will automatically reset itself.
     pub fn read(&mut self, dma: &mut impl DmaCtrl, buf: &mut [W]) -> Result<(usize, usize), Error> {
-        self.read_raw(dma, buf).inspect_err(|_e| {
+        fence(Ordering::Acquire);
+
+        let available = self.sync_len(dma).inspect_err(|_e| {
             self.reset(dma);
-        })
+        })?;
+
+        Ok(self.read_raw(available, buf))
     }
 
     /// Read an exact number of elements from the ringbuffer.
@@ -205,11 +209,7 @@ impl<'a, W: Word> ReadableDmaRingBuffer<'a, W> {
         .await
     }
 
-    fn read_raw(&mut self, dma: &mut impl DmaCtrl, buf: &mut [W]) -> Result<(usize, usize), Error> {
-        fence(Ordering::Acquire);
-
-        let mut available = self.sync_len(dma)?;
-
+    fn read_raw(&mut self, mut available: usize, buf: &mut [W]) -> (usize, usize) {
         // Compute alignment skip without advancing read_index yet.
         // DMA always starts at buffer position 0 (frame-aligned) and advances
         // sequentially, so position N is frame-aligned when N % alignment == 0.
@@ -221,7 +221,7 @@ impl<'a, W: Word> ReadableDmaRingBuffer<'a, W> {
                     available -= skip;
                     skip
                 } else {
-                    return Ok((0, available));
+                    return (0, available);
                 }
             } else {
                 0
@@ -250,7 +250,7 @@ impl<'a, W: Word> ReadableDmaRingBuffer<'a, W> {
         self.read_index.advance(self.cap(), skip + readable);
 
         let remaining = write_snapshot.diff(self.cap(), &self.read_index).max(0) as usize;
-        Ok((readable, remaining))
+        (readable, remaining)
     }
 
     /// Read the most recent elements from the ring buffer, discarding any older data.
@@ -270,54 +270,24 @@ impl<'a, W: Word> ReadableDmaRingBuffer<'a, W> {
     pub fn read_latest(&mut self, dma: &mut impl DmaCtrl, buf: &mut [W]) -> usize {
         fence(Ordering::Acquire);
 
-        self.write_index.dma_sync(self.cap(), dma);
-        DmaIndex::normalize(&mut self.write_index, &mut self.read_index);
-
-        let diff = self.write_index.diff(self.cap(), &self.read_index);
-
-        // On overrun or desync, reset the read pointer to the current write position.
-        // This means zero samples are available right now, but the next call will
-        // return fresh data without any error.
-        if diff < 0 || diff > self.cap() as isize {
+        let available = self.sync_len(dma).unwrap_or_else(|err| {
             self.read_index = self.write_index;
-            return 0;
-        }
+            match err {
+                Error::Overrun => {
+                    // the entire buffer contains the latest data
+                    self.write_index.complete_count += 1;
+                    self.cap()
+                },
+                Error::DmaUnsynced => {
+                    #[cfg(feature = "defmt")]
+                    defmt::error!("Ring buffer broken invariants detected!");
+                    0
+                },
+            }
+        });
 
-        let available = diff as usize;
-        if available == 0 {
-            return 0;
-        }
-
-        // Respect frame alignment. Because read_latest reads the NEWEST data
-        // (skip at the front, read at the tail), reducing to_read moves the
-        // start forward. We must compute front_skip explicitly so the read
-        // window starts at an aligned buffer position.
-        let (to_read, front_skip) = if self.alignment > 1 {
-            // Discard any partial frame at the tail of available data, then
-            // round down to_read so it fits in buf and lands on a frame boundary.
-            let end_pos = self.read_index.as_index(self.cap(), available);
-            let aligned_available = available.saturating_sub(end_pos % self.alignment);
-            let to_read = aligned_available.min(buf.len());
-            let to_read = to_read - to_read % self.alignment;
-            (to_read, aligned_available - to_read)
-        } else {
-            let to_read = available.min(buf.len());
-            (to_read, available - to_read)
-        };
-
-        // Advance past old data to the aligned start position.
-        if front_skip > 0 {
-            self.read_index.advance(self.cap(), front_skip);
-        }
-
-        for i in 0..to_read {
-            buf[i] = self.read_buf(i);
-        }
-
-        // Advance past what we read plus any trailing partial frame.
-        self.read_index.advance(self.cap(), available - front_skip);
-
-        to_read
+        let (read, _) = self.read_raw(available, buf);
+        read
     }
 
     fn read_buf(&self, offset: usize) -> W {

--- a/embassy-stm32/src/dma/ringbuffer/mod.rs
+++ b/embassy-stm32/src/dma/ringbuffer/mod.rs
@@ -277,17 +277,45 @@ impl<'a, W: Word> ReadableDmaRingBuffer<'a, W> {
                     // the entire buffer contains the latest data
                     self.write_index.complete_count += 1;
                     self.cap()
-                },
+                }
                 Error::DmaUnsynced => {
                     #[cfg(feature = "defmt")]
                     defmt::error!("Ring buffer broken invariants detected!");
-                    0
-                },
+                    return 0;
+                }
             }
         });
 
-        let (read, _) = self.read_raw(available, buf);
-        read
+        // Respect frame alignment. Because read_latest reads the NEWEST data
+        // (skip at the front, read at the tail), reducing to_read moves the
+        // start forward. We must compute front_skip explicitly so the read
+        // window starts at an aligned buffer position.
+        let (to_read, front_skip) = if self.alignment > 1 {
+            // Discard any partial frame at the tail of available data, then
+            // round down to_read so it fits in buf and lands on a frame boundary.
+            let end_pos = self.read_index.as_index(self.cap(), available);
+            let aligned_available = available.saturating_sub(end_pos % self.alignment);
+            let to_read = aligned_available.min(buf.len());
+            let to_read = to_read - to_read % self.alignment;
+            (to_read, aligned_available - to_read)
+        } else {
+            let to_read = available.min(buf.len());
+            (to_read, available - to_read)
+        };
+
+        // Advance past old data to the aligned start position.
+        if front_skip > 0 {
+            self.read_index.advance(self.cap(), front_skip);
+        }
+
+        for i in 0..to_read {
+            buf[i] = self.read_buf(i);
+        }
+
+        // Advance past what we read plus any trailing partial frame.
+        self.read_index.advance(self.cap(), available - front_skip);
+
+        to_read
     }
 
     fn read_buf(&self, offset: usize) -> W {

--- a/embassy-stm32/src/dma/ringbuffer/tests/mod.rs
+++ b/embassy-stm32/src/dma/ringbuffer/tests/mod.rs
@@ -273,9 +273,10 @@ fn read_latest_recovers_from_overrun() {
         TestCircularTransferRequest::PositionRequest(5),
     ]);
 
-    // Should not panic or error — just returns 0 (reset to catch up).
+    // Should not panic or error — catches up and returns latest data.
     let n = ringbuf.read_latest(&mut dma, &mut read_buf);
-    assert_eq!(n, 0);
+    assert_eq!(n, 8);
+    assert_eq!(&read_buf[..n], &[13, 14, 15, 0, 1, 2, 3, 4]);
 
     // Next call after overrun recovery should return fresh data normally.
     dma.setup(vec![

--- a/embassy-stm32/src/dma/ringbuffer/tests/mod.rs
+++ b/embassy-stm32/src/dma/ringbuffer/tests/mod.rs
@@ -247,7 +247,53 @@ fn read_latest_returns_most_recent_data() {
     assert_eq!(&read_buf[..n], &[8, 9, 10, 11]);
 }
 
-/// read_latest never errors on overrun — it just resets and returns 0.
+/// read_latest never errors on overrun and respects alignment.
+#[test]
+fn read_latest_recovers_from_overrun_respecting_alignment() {
+    let mut dma_buf = [0u8; CAP];
+    for i in 0..CAP {
+        dma_buf[i] = i as u8;
+    }
+    let mut ringbuf = ReadableDmaRingBuffer::new(&mut dma_buf);
+    ringbuf.set_alignment(4);
+    let mut dma = TestCircularTransfer::new(CAP);
+
+    // Reset at position 0 (aligned).
+    dma.setup(vec![
+        TestCircularTransferRequest::ResetCompleteCount(0),
+        TestCircularTransferRequest::ResetCompleteCount(0),
+        TestCircularTransferRequest::PositionRequest(0),
+    ]);
+    ringbuf.reset(&mut dma);
+
+    // Simulate overrun: DMA has wrapped more than once (complete_count=2, pos=6).
+    // after overrun 16 samples are available and read_index = 6
+    // 6 (end_pos) % 4 = 2 (partial frame discarded), aligned_available = 14.
+    // to_read = min(14, 6) = 6, rounded down to 4.
+    // front_skip = 14 - 4 = 10. Read starts at position:
+    // (6 + 10) % 16 = 0 (aligned): [0, 1, 2, 3].
+    let mut read_buf = [0u8; 6];
+    dma.setup(vec![
+        TestCircularTransferRequest::ResetCompleteCount(2),
+        TestCircularTransferRequest::PositionRequest(6),
+    ]);
+
+    let n = ringbuf.read_latest(&mut dma, &mut read_buf);
+    assert_eq!(n, 4);
+    assert_eq!(&read_buf[..n], &[0, 1, 2, 3]);
+
+    // Next call after overrun recovery should return fresh data normally.
+    dma.setup(vec![
+        TestCircularTransferRequest::ResetCompleteCount(0),
+        TestCircularTransferRequest::PositionRequest(12),
+    ]);
+
+    let n = ringbuf.read_latest(&mut dma, &mut read_buf);
+    assert_eq!(n, 4);
+    assert_eq!(&read_buf[..n], &[8, 9, 10, 11]);
+}
+
+/// read_latest never errors on overrun.
 #[test]
 fn read_latest_recovers_from_overrun() {
     let mut dma_buf = [0u8; CAP];


### PR DESCRIPTION
This is my proposed fix for issue #6254. 

When an overrun is detected it sets read and write indexes such that the entire buffer can be read.

~~Since `read_latest` and `read_raw` were doing nearly the same thing, to deduplicate code, I modified `read_raw` so that it can be reused by `read_latest` function. I chose `read_raw` implementation over original `read_latest` because in my opinion it was cleaner and easier to reason about.~~ Their difference is actually important here.

Tested on STM32F411CE.