### PR TITLE
fix(dfu): transition to `State::ManifestWaitReset` when WILL_DETACH bit is disabled

### DIFF
--- a/embassy-usb/src/class/dfu/dfu_mode.rs
+++ b/embassy-usb/src/class/dfu/dfu_mode.rs
@@ -181,6 +181,9 @@ impl<H: Handler> crate::Handler for DfuState<H> {
                             self.reset();
                         }
                     }
+                    State::Manifest if !self.attrs.contains(DfuAttributes::WILL_DETACH) => {
+                        self.state = State::ManifestWaitReset;
+                    }
                     _ => {}
                 }
                 //TODO: Configurable poll timeout, ability to add string for Vendor error


### PR DESCRIPTION
After github.com/embassy-rs/embassy/pull/5555/ it is no longer possible for the DFU implementation to enter the `State::ManifestWaitReset` which is necessary so the host triggers the USB reset in the case the device is not using the DfuAttributes::WILL_DETACH nor the DfuAttributes::MANIFESTATION_TOLERANT.

This change should ensure that devices that want to be reset by the host can do so, by exposing the MANIFEST_WAIT_RESET state after a GET_STATUS command is issued while the device is in MANIFEST state.

Tested with:
* dfu-util 0.11 
* dfu-nusb 

