### PR TITLE
embassy-mcxa: gpio: clear PIDR in set_as_output

### DIFF
--- a/embassy-mcxa/src/gpio.rs
+++ b/embassy-mcxa/src/gpio.rs
@@ -599,6 +599,10 @@ impl<'d, M: Mode> Flex<'d, M> {
     /// Put the pin into output mode.
     pub fn set_as_output(&mut self) {
         self.set_pull(Pull::Disabled);
+        // Clear PIDR in case this pin was previously disabled.
+        self.gpio()
+            .pidr()
+            .modify(|w| w.set_pid(self.pin.pin_index() as usize, Pid::Pid0));
         self.gpio()
             .pddr()
             .modify(|w| w.set_pdd(self.pin.pin_index() as usize, Pdd::Pdd1));


### PR DESCRIPTION
`set_as_output()` was leaving `PIDR` in whatever state the pin had previously been in. On pins that had been through `set_as_disabled()` or `set_as_analog()` first, the input buffer stayed off and readback of the output level returned stale data. Clear `PIDR` here too, mirroring what `set_as_input()` already does.
