### PR TITLE
embassy-mcxa: i2c/target: improve async target robustness

### DIFF
--- a/embassy-mcxa/src/i2c/target.rs
+++ b/embassy-mcxa/src/i2c/target.rs
@@ -414,21 +414,6 @@ impl<'d, M: Mode> I2c<'d, M> {
         });
     }
 
-    /// Pre-load the TX FIFO with default data so the hardware has
-    /// something to send if the controller starts a read before the
-    /// firmware is ready with a real response.
-    pub fn preload_tx(&mut self, data: &[u8]) {
-        // Clear the TX FIFO first
-        critical_section::with(|_| {
-            self.info.regs().scr().modify(|w| {
-                w.set_rtf(ScrRtf::NowEmpty);
-            });
-        });
-        for &byte in data {
-            self.info.regs().stdr().write(|w| w.set_data(byte));
-        }
-    }
-
     fn clear_status(&self) {
         self.info.regs().ssr().write(|w| {
             w.set_rsf(true);

--- a/embassy-mcxa/src/i2c/target.rs
+++ b/embassy-mcxa/src/i2c/target.rs
@@ -1033,6 +1033,29 @@ impl<'d> AsyncEngine for I2c<'d, Async> {
             }
         }
 
+        // The controller may read more bytes than the buffer contains.
+        // Keep feeding zeros until the controller NACKs or sends STOP,
+        // otherwise the hardware clock-stretches indefinitely.
+        loop {
+            self.info
+                .wait_cell()
+                .wait_for(|| {
+                    self.enable_tx_ints();
+                    let ssr = self.info.regs().ssr().read();
+                    ssr.tdf() || ssr.sdf() || ssr.rsf()
+                })
+                .await
+                .map_err(|_| IOError::Other)?;
+
+            let ssr = self.info.regs().ssr().read();
+            if ssr.sdf() || ssr.rsf() {
+                self.reset_fifos();
+                break;
+            } else {
+                self.info.regs().stdr().write(|w| w.set_data(0x00));
+            }
+        }
+
         Ok(count)
     }
 

--- a/embassy-mcxa/src/i2c/target.rs
+++ b/embassy-mcxa/src/i2c/target.rs
@@ -859,7 +859,8 @@ impl<'d, M: AsyncMode> I2c<'d, M>
 where
     Self: AsyncEngine,
 {
-    fn enable_ints(&self) {
+    /// Enable only the interrupts relevant to listening for a new address match.
+    fn enable_listen_ints(&self) {
         self.info.regs().sier().write(|w| {
             w.set_sarie(self.smbus_alert.clone().into());
             w.set_gcie(self.general_call.clone().into());
@@ -869,9 +870,28 @@ where
             w.set_beie(true);
             w.set_sdie(true);
             w.set_rsie(true);
-            w.set_taie(true);
             w.set_avie(true);
+        });
+    }
+
+    /// Enable only the interrupts relevant to receiving data (respond_to_write).
+    fn enable_rx_ints(&self) {
+        self.info.regs().sier().write(|w| {
+            w.set_feie(true);
+            w.set_beie(true);
+            w.set_sdie(true);
+            w.set_rsie(true);
             w.set_rdie(true);
+        });
+    }
+
+    /// Enable only the interrupts relevant to transmitting data (respond_to_read).
+    fn enable_tx_ints(&self) {
+        self.info.regs().sier().write(|w| {
+            w.set_feie(true);
+            w.set_beie(true);
+            w.set_sdie(true);
+            w.set_rsie(true);
             w.set_tdie(true);
         });
     }
@@ -893,7 +913,7 @@ where
         self.info
             .wait_cell()
             .wait_for(|| {
-                self.enable_ints();
+                self.enable_listen_ints();
                 let status = self.info.regs().ssr().read();
                 status.avf() || status.sarf() || status.gcf() || status.sdf()
             })
@@ -978,7 +998,7 @@ impl<'d> AsyncEngine for I2c<'d, Async> {
             self.info
                 .wait_cell()
                 .wait_for(|| {
-                    self.enable_ints();
+                    self.enable_tx_ints();
                     let ssr = self.info.regs().ssr().read();
                     ssr.tdf() || ssr.sdf() || ssr.rsf()
                 })
@@ -1010,7 +1030,7 @@ impl<'d> AsyncEngine for I2c<'d, Async> {
             self.info
                 .wait_cell()
                 .wait_for(|| {
-                    self.enable_ints();
+                    self.enable_rx_ints();
                     let ssr = self.info.regs().ssr().read();
                     ssr.rdf() || ssr.sdf() || ssr.rsf()
                 })

--- a/embassy-mcxa/src/i2c/target.rs
+++ b/embassy-mcxa/src/i2c/target.rs
@@ -957,6 +957,13 @@ where
     /// This function sends the contents of the provided buffer to the I2C controller
     /// asynchronously.
     ///
+    /// If the controller continues clocking out bytes after the buffer has been
+    /// fully transmitted (for example, an I2C-HID host that reads a fixed block
+    /// size larger than the prepared response), the async implementation pads
+    /// the remainder of the transaction with `0x00` bytes until the controller
+    /// issues STOP or repeated START. This avoids indefinite SCL clock
+    /// stretching when the firmware has nothing more to send.
+    ///
     /// # Parameters
     ///
     /// - `buf`: The buffer containing the data to transmit.

--- a/embassy-mcxa/src/i2c/target.rs
+++ b/embassy-mcxa/src/i2c/target.rs
@@ -414,6 +414,21 @@ impl<'d, M: Mode> I2c<'d, M> {
         });
     }
 
+    /// Pre-load the TX FIFO with default data so the hardware has
+    /// something to send if the controller starts a read before the
+    /// firmware is ready with a real response.
+    pub fn preload_tx(&mut self, data: &[u8]) {
+        // Clear the TX FIFO first
+        critical_section::with(|_| {
+            self.info.regs().scr().modify(|w| {
+                w.set_rtf(ScrRtf::NowEmpty);
+            });
+        });
+        for &byte in data {
+            self.info.regs().stdr().write(|w| w.set_data(byte));
+        }
+    }
+
     fn clear_status(&self) {
         self.info.regs().ssr().write(|w| {
             w.set_rsf(true);


### PR DESCRIPTION
Four small fixes for the async LPI2C target driver, each useful on its own:

1. **use per-operation interrupt enables in async mode** — the target was leaving a broad interrupt mask enabled, which caused spurious wakeups and races where stale events were serviced under the wrong waker. Each `await` now enables only the interrupts it needs and clears them on completion.
2. **drain unconsumed RX FIFO bytes after `respond_to_write`** — if the host writes more bytes than the caller's buffer holds, the leftovers used to sit in the FIFO and corrupt the next read. Drain them before returning.
3. **add `preload_tx()` helper** — factors the "fill TX before the host starts clocking" sequence (including the `SCR.RTF = NowEmpty` reset) used by both read paths.
4. **pad TX with zeros until controller ends read** — if the host reads past what's been prepared, the peripheral used to stall SCL until something fed TX. Now we pad with zeros until the controller issues STOP / repeated START, matching what most masters expect.

Each commit builds and is independently reviewable.
