### PR TITLE
stm32: add g4 input capture example from trigger

### DIFF
--- a/embassy-stm32/src/timer/input_capture.rs
+++ b/embassy-stm32/src/timer/input_capture.rs
@@ -34,7 +34,7 @@ impl CapturePin {
         pin: Peri<'d, if_afio!(impl TimerPin<T, C, A>)>,
         pull: Pull,
     ) -> if_afio!(CaptureInput<'d, T, C, A>) {
-        CaptureInput::from_pin(pin, pull)
+        CaptureInput::from_pin(pin, pull).unwrap()
     }
 }
 
@@ -47,20 +47,20 @@ pub struct CaptureInput<'d, T, C, #[cfg(afio)] A> {
 }
 impl<'d, T: GeneralInstance4Channel, C: TimerChannel, #[cfg(afio)] A> if_afio!(CaptureInput<'d, T, C, A>) {
     /// Create a new capture pin instance.
-    pub fn from_pin(pin: Peri<'d, if_afio!(impl TimerPin<T, C, A>)>, pull: Pull) -> Self {
+    pub fn from_pin(pin: Peri<'d, if_afio!(impl TimerPin<T, C, A>)>, pull: Pull) -> Option<Self> {
         set_as_af!(pin, AfType::input(pull));
-        Self {
+        Some(Self {
             input: InputType::Pin(Flex::new(pin)),
             _marker: PhantomData,
-        }
+        })
     }
 
     /// Create a new capture pin instance.
-    pub fn from_trigger(trigger: impl TimerInputTrigger<T, C>) -> Self {
-        Self {
+    pub fn from_trigger(trigger: impl TimerInputTrigger<T, C>) -> Option<Self> {
+        Some(Self {
             input: InputType::Trigger(trigger.signal()),
             _marker: PhantomData,
-        }
+        })
     }
 }
 

--- a/examples/stm32f1/src/bin/input_capture.rs
+++ b/examples/stm32f1/src/bin/input_capture.rs
@@ -40,8 +40,7 @@ async fn main(spawner: Spawner) {
     spawner.spawn(unwrap!(blinky(p.PC13)));
 
     let ch3 = CaptureInput::from_pin(p.PA2, Pull::None);
-    let mut ic =
-        InputCapture::new::<AfioRemap<0>>(p.TIM2, None, None, Some(ch3), None, Irqs, khz(1000), Default::default());
+    let mut ic = InputCapture::new::<AfioRemap<0>>(p.TIM2, None, None, ch3, None, Irqs, khz(1000), Default::default());
 
     loop {
         info!("wait for rising edge");

--- a/examples/stm32f4/src/bin/input_capture.rs
+++ b/examples/stm32f4/src/bin/input_capture.rs
@@ -40,7 +40,7 @@ async fn main(spawner: Spawner) {
     spawner.spawn(unwrap!(blinky(p.PB2)));
 
     let ch3 = CaptureInput::from_pin(p.PB10, Pull::None);
-    let mut ic = InputCapture::new(p.TIM2, None, None, Some(ch3), None, Irqs, khz(1000), Default::default());
+    let mut ic = InputCapture::new(p.TIM2, None, None, ch3, None, Irqs, khz(1000), Default::default());
 
     loop {
         info!("wait for risign edge");

--- a/examples/stm32f4/src/bin/input_capture_split.rs
+++ b/examples/stm32f4/src/bin/input_capture_split.rs
@@ -36,16 +36,7 @@ async fn main(spawner: Spawner) {
 
     let ch1 = CaptureInput::from_pin(p.PA0, Pull::None);
     let ch2 = CaptureInput::from_pin(p.PA1, Pull::None);
-    let ic = InputCapture::new(
-        p.TIM2,
-        Some(ch1),
-        Some(ch2),
-        None,
-        None,
-        Irqs,
-        khz(1000),
-        Default::default(),
-    );
+    let ic = InputCapture::new(p.TIM2, ch1, ch2, None, None, Irqs, khz(1000), Default::default());
 
     let chs = ic.split();
     spawner.spawn(unwrap!(capture_task_ch1(chs.ch1)));

--- a/examples/stm32g0/src/bin/input_capture.rs
+++ b/examples/stm32g0/src/bin/input_capture.rs
@@ -53,7 +53,7 @@ async fn main(spawner: Spawner) {
     pwm.ch1().set_duty_cycle(50);
 
     let ch1 = CaptureInput::from_pin(p.PA0, Pull::None);
-    let mut ic = InputCapture::new(p.TIM2, Some(ch1), None, None, None, Irqs, khz(1000), Default::default());
+    let mut ic = InputCapture::new(p.TIM2, ch1, None, None, None, Irqs, khz(1000), Default::default());
 
     let mut old_capture = 0;
 

--- a/examples/stm32g4/src/bin/input_capture.rs
+++ b/examples/stm32g4/src/bin/input_capture.rs
@@ -4,7 +4,7 @@
 use defmt::*;
 use embassy_executor::Spawner;
 use embassy_stm32::comp::{Comp, Config, Hysteresis, InvertingInput, OutputPolarity, PowerMode};
-use embassy_stm32::dac::{Ch1, DacChannel, Value};
+use embassy_stm32::dac::{Ch1, DacChannel, u12r};
 use embassy_stm32::gpio::{Level, Output, Speed};
 use embassy_stm32::time::khz;
 use embassy_stm32::timer::input_capture::{CaptureInput, InputCapture};
@@ -40,7 +40,7 @@ async fn main(spawner: Spawner) {
     // 1. setup dac as internal output and set dac output to constant value 3.3V/4
     let mut dac: DacChannel<'_, embassy_stm32::mode::Blocking> = DacChannel::new_internal_blocking::<_, Ch1>(p.DAC1);
     let constant_voltage: u16 = 1024;
-    dac.set(Value::Bit12Right(constant_voltage));
+    dac.set(u12r(constant_voltage));
 
     // 2. configure comparator and set its inverting input as DAC1 output
     let comp1_config = Config {

--- a/examples/stm32g4/src/bin/input_capture.rs
+++ b/examples/stm32g4/src/bin/input_capture.rs
@@ -3,27 +3,72 @@
 
 use defmt::*;
 use embassy_executor::Spawner;
+use embassy_stm32::comp::{Comp, Config, Hysteresis, InvertingInput, OutputPolarity, PowerMode};
+use embassy_stm32::dac::{Ch1, DacChannel, Value};
+use embassy_stm32::gpio::{Level, Output, Speed};
 use embassy_stm32::time::khz;
-use embassy_stm32::timer::CaptureCompareInterruptHandler;
 use embassy_stm32::timer::input_capture::{CaptureInput, InputCapture};
+use embassy_stm32::timer::{CaptureCompareInterruptHandler, Channel};
 use embassy_stm32::triggers::COMP1_OUT;
-use embassy_stm32::{bind_interrupts, peripherals};
+use embassy_stm32::{bind_interrupts, comp, peripherals};
+use embassy_time::{Duration, Timer, with_timeout};
 use {defmt_rtt as _, panic_probe as _};
 
 bind_interrupts!(struct Irqs {
     TIM1_CC => CaptureCompareInterruptHandler<peripherals::TIM1>;
+    COMP1_2_3 => comp::InterruptHandler<embassy_stm32::peripherals::COMP1>;
 });
 
+#[embassy_executor::task]
+async fn toggle_pin(mut pin: Output<'static>) {
+    loop {
+        Timer::after_millis(500).await;
+
+        pin.set_low();
+
+        Timer::after_millis(500).await;
+
+        pin.set_high();
+    }
+}
+
 #[embassy_executor::main]
-async fn main(_spawner: Spawner) {
+async fn main(spawner: Spawner) {
     let p = embassy_stm32::init(Default::default());
     info!("Hello World!");
 
-    let trigger = CaptureInput::from_trigger(COMP1_OUT);
+    // 1. setup dac as internal output and set dac output to constant value 3.3V/4
+    let mut dac: DacChannel<'_, embassy_stm32::mode::Blocking> = DacChannel::new_internal_blocking::<_, Ch1>(p.DAC1);
+    let constant_voltage: u16 = 1024;
+    dac.set(Value::Bit12Right(constant_voltage));
 
-    let _pwm = InputCapture::new(
+    // 2. configure comparator and set its inverting input as DAC1 output
+    let comp1_config = Config {
+        power_mode: PowerMode::UltraLowPower,
+        hysteresis: Hysteresis::None,
+        output_polarity: OutputPolarity::NotInverted,
+        inverting_input: InvertingInput::Dac1,
+        ..Default::default()
+    };
+
+    let mut comp1 = Comp::new(p.COMP1, unsafe { p.PA1.clone_unchecked() }, Irqs, comp1_config);
+    comp1.enable();
+
+    spawner.spawn(toggle_pin(Output::new(p.PA1, Level::High, Speed::Low)).unwrap());
+
+    //    loop {
+    //        comp1.wait_for_low().await;
+    //
+    //        info!("comp1 low");
+    //
+    //        comp1.wait_for_high().await;
+    //
+    //        info!("comp1 high");
+    //    }
+
+    let mut ic = InputCapture::new(
         p.TIM1,
-        Some(trigger),
+        CaptureInput::from_trigger(COMP1_OUT),
         None,
         None,
         None,
@@ -31,4 +76,12 @@ async fn main(_spawner: Spawner) {
         khz(10),
         Default::default(),
     );
+
+    loop {
+        // 5. capture falling edge and print out the return value from get_capture_value(Channel::Ch1) function
+        match with_timeout(Duration::from_secs(3), ic.wait_for_falling_edge(Channel::Ch1)).await {
+            Ok(val) => info!("Falling edge detected: {}", val), // Handle success }
+            Err(_) => warn!("Timeout waiting for falling edge!"), // Handle timeout
+        }
+    }
 }

--- a/tests/stm32/src/bin/afio.rs
+++ b/tests/stm32/src/bin/afio.rs
@@ -254,7 +254,7 @@ async fn main(_spawner: Spawner) {
         reset_afio_registers();
         InputCapture::new::<AfioRemap<1>>(
             p.TIM1.reborrow(),
-            Some(CaptureInput::from_pin(p.PA8.reborrow(), Pull::Down)),
+            CaptureInput::from_pin(p.PA8.reborrow(), Pull::Down),
             None,
             None,
             None,


### PR DESCRIPTION
output from the example:

```
 ERROR teleprobe::client > === nucleo-stm32g491re target\thumbv7em-none-eabi\release\input_capture: FAILED: HTTP request failed with status code: 400: Bad Request
 ERROR teleprobe::client > INFO - run_from_ram: false
INFO - flashing program...
INFO - flashing done!
TRACE - 0.000000 rcc: enabled 0x18:0
TRACE - 0.000000 rcc: enabled 0x16:28
TRACE - 0.000000 rcc: enabled 0x12:8
TRACE - 0.000000 BDCR ok: 00008200
DEBUG - 0.000000 rcc: Clocks { hclk1: MaybeHertz(16000000), hclk2: MaybeHertz(16000000), hclk3: MaybeHertz(16000000), hse: MaybeHertz(0), hsi: MaybeHertz(16000000), hsi48: MaybeHertz(48000000), i2s_ckin: MaybeHertz(0), lse: MaybeHertz(0), lsi: MaybeHertz(0), pclk1: MaybeHertz(16000000), pclk1_tim: MaybeHertz(16000000), pclk2: MaybeHertz(16000000), pclk2_tim: MaybeHertz(16000000), pll1_p: MaybeHertz(0), pll1_q: MaybeHertz(0), rtc: MaybeHertz(32000), sys: MaybeHertz(16000000) }
TRACE - 0.000000 rcc: enabled 0x18:16
INFO - 0.000000 Hello World!
TRACE - 0.000091 rcc: enabled 0x13:16
TRACE - 0.000335 rcc: enabled 0x18:11
INFO - 0.500762 Falling edge detected: 4998
INFO - 1.500854 Falling edge detected: 14993
INFO - 2.500946 Falling edge detected: 24988
INFO - 3.501037 Falling edge detected: 34983
INFO - 4.501129 Falling edge detected: 44978
INFO - 5.501281 Falling edge detected: 54974
INFO - 6.501342 Falling edge detected: 64969
INFO - 7.501495 Falling edge detected: 9429
INFO - 8.501586 Falling edge detected: 19424
WARN - Deadline exceeded!
```

closes #6239.