### PR TITLE
stm32: refactor dac type api

### DIFF
--- a/embassy-stm32/src/dac/mod.rs
+++ b/embassy-stm32/src/dac/mod.rs
@@ -4,6 +4,7 @@
 pub mod ringbuffered;
 
 use core::marker::PhantomData;
+use core::slice;
 
 #[cfg(stm32g4)]
 use dac::vals;
@@ -11,7 +12,7 @@ use embassy_hal_internal::PeripheralType;
 use embassy_sync::blocking_mutex::raw::CriticalSectionRawMutex;
 pub use ringbuffered::RingBufferedDacChannel;
 
-use crate::dma::ChannelAndRequest;
+use crate::dma::{ChannelAndRequest, word as dma};
 use crate::mode::{Async, Blocking, Mode as PeriMode};
 #[cfg(any(dac_v3, dac_v4, dac_v5, dac_v6, dac_v7))]
 use crate::pac::dac;
@@ -116,46 +117,6 @@ impl Mode {
             Mode::SampleHoldInternalUnbuffered => dac::vals::Mode::SampholdIntBufdis,
         }
     }
-}
-
-#[derive(Debug, Copy, Clone, Eq, PartialEq)]
-#[cfg_attr(feature = "defmt", derive(defmt::Format))]
-/// Single 8 or 12 bit value that can be output by the DAC.
-///
-/// 12-bit values outside the permitted range are silently truncated.
-pub enum Value {
-    /// 8 bit value
-    Bit8(u8),
-    /// 12 bit value stored in a u16, left-aligned
-    Bit12Left(u16),
-    /// 12 bit value stored in a u16, right-aligned
-    Bit12Right(u16),
-}
-
-#[derive(Debug, Copy, Clone, Eq, PartialEq)]
-#[cfg_attr(feature = "defmt", derive(defmt::Format))]
-/// Dual 8 or 12 bit values that can be output by the DAC channels 1 and 2 simultaneously.
-///
-/// 12-bit values outside the permitted range are silently truncated.
-pub enum DualValue {
-    /// 8 bit value
-    Bit8(u8, u8),
-    /// 12 bit value stored in a u16, left-aligned
-    Bit12Left(u16, u16),
-    /// 12 bit value stored in a u16, right-aligned
-    Bit12Right(u16, u16),
-}
-
-#[derive(Debug, Copy, Clone, Eq, PartialEq)]
-#[cfg_attr(feature = "defmt", derive(defmt::Format))]
-/// Array variant of [`Value`].
-pub enum ValueArray<'a> {
-    /// 8 bit values
-    Bit8(&'a [u8]),
-    /// 12 bit value stored in a u16, left-aligned
-    Bit12Left(&'a [u16]),
-    /// 12 bit values stored in a u16, right-aligned
-    Bit12Right(&'a [u16]),
 }
 
 #[derive(Debug)]
@@ -312,12 +273,11 @@ impl<'d> DacChannel<'d, Async> {
 
     /// Convert this channel into a ring-buffered DAC channel using 8-bit output (DHR8Rx).
     ///
-    /// Each element of `dma_buf` holds one 8-bit sample in bits [7:0]. DMA transfers are
-    /// 32-bit wide as required by the DAC peripheral, so the upper bits are ignored by hardware.
+    /// Each element of `dma_buf` holds one 8-bit sample in bits [7:0].
     /// The DMA runs in circular mode so output is uninterrupted between writes.
     /// Use [`RingBufferedDacChannel::write_immediate`] to pre-fill the buffer before
     /// calling [`RingBufferedDacChannel::start`].
-    pub fn into_ring_buffered_8bit(self, dma_buf: &'d mut [u32]) -> RingBufferedDacChannel<'d, u32> {
+    pub fn into_ring_buffered<W: Word>(self, dma_buf: &'d mut [W]) -> RingBufferedDacChannel<'d, W> {
         let info = self.info;
         let state = self.state;
         let idx = self.idx;
@@ -330,45 +290,13 @@ impl<'d> DacChannel<'d, Async> {
             w.set_en(idx, true);
             w.set_dmaen(idx, true);
         });
+
         let ring_buf = unsafe {
             crate::dma::WritableRingBuffer::new(
                 channel,
                 request,
-                info.regs.dhr8r(idx).as_ptr() as *mut u32,
-                dma_buf,
-                Default::default(),
-            )
-        };
-        RingBufferedDacChannel::new(ring_buf, info, state, idx)
-    }
-
-    /// Convert this channel into a ring-buffered DAC channel using 12-bit right-aligned output
-    /// (DHR12Rx).
-    ///
-    /// Each element of `dma_buf` holds one 12-bit sample in bits [11:0]. DMA transfers are
-    /// 32-bit wide as required by the DAC peripheral, so bits [31:12] are ignored by hardware.
-    /// The DMA runs in circular mode so output is uninterrupted between writes.
-    /// Use [`RingBufferedDacChannel::write_immediate`] to pre-fill the buffer before
-    /// calling [`RingBufferedDacChannel::start`].
-    pub fn into_ring_buffered_12right(self, dma_buf: &'d mut [u32]) -> RingBufferedDacChannel<'d, u32> {
-        let info = self.info;
-        let state = self.state;
-        let idx = self.idx;
-        // Safety: self is forgotten below so the ChannelAndRequest won't be dropped twice.
-        let dma = unsafe { self.dma.as_ref().unwrap().clone_unchecked() };
-        core::mem::forget(self);
-
-        let crate::dma::ChannelAndRequest { channel, request } = dma;
-        info.regs.cr().modify(|w| {
-            w.set_en(idx, true);
-            w.set_dmaen(idx, true);
-        });
-        let ring_buf = unsafe {
-            crate::dma::WritableRingBuffer::new(
-                channel,
-                request,
-                info.regs.dhr12r(idx).as_ptr() as *mut u32,
-                dma_buf,
+                W::dma_ptr(info.regs, idx),
+                W::dma_buf_mut(dma_buf),
                 Default::default(),
             )
         };
@@ -382,7 +310,7 @@ impl<'d> DacChannel<'d, Async> {
     /// `data`. Note that for performance reasons in circular mode the transfer-complete
     /// interrupt is disabled.
     #[cfg(not(gpdma))]
-    pub async fn write(&mut self, data: ValueArray<'_>, circular: bool) {
+    pub async fn write<W: Word>(&mut self, data: &[W], circular: bool) {
         // Enable DAC and DMA
         self.info.regs.cr().modify(|w| {
             w.set_en(self.idx, true);
@@ -399,17 +327,7 @@ impl<'d> DacChannel<'d, Async> {
         };
 
         // Initiate the correct type of DMA transfer depending on what data is passed
-        let tx_f = match data {
-            ValueArray::Bit8(buf) => unsafe {
-                dma.write_raw(buf, self.info.regs.dhr8r(self.idx).as_ptr() as *mut u32, tx_options)
-            },
-            ValueArray::Bit12Left(buf) => unsafe {
-                dma.write_raw(buf, self.info.regs.dhr12l(self.idx).as_ptr() as *mut u32, tx_options)
-            },
-            ValueArray::Bit12Right(buf) => unsafe {
-                dma.write_raw(buf, self.info.regs.dhr12r(self.idx).as_ptr() as *mut u32, tx_options)
-            },
-        };
+        let tx_f = unsafe { dma.write_raw(W::dma_buf(data), W::dma_ptr(self.info.regs, self.idx), tx_options) };
 
         tx_f.await;
 
@@ -652,12 +570,8 @@ impl<'d, M: PeriMode> DacChannel<'d, M> {
     ///
     /// If triggering is not enabled, the new value is immediately output; otherwise,
     /// it will be output after the next trigger.
-    pub fn set(&mut self, value: Value) {
-        match value {
-            Value::Bit8(v) => self.info.regs.dhr8r(self.idx).write(|reg| reg.set_dhr(v)),
-            Value::Bit12Left(v) => self.info.regs.dhr12l(self.idx).write(|reg| reg.set_dhr(v)),
-            Value::Bit12Right(v) => self.info.regs.dhr12r(self.idx).write(|reg| reg.set_dhr(v)),
-        }
+    pub fn set<W: Word>(&mut self, value: W) {
+        W::set_value(self.info.regs, self.idx, value);
     }
 
     /// Read the current output value of the DAC.
@@ -1107,21 +1021,166 @@ impl<'d, M: PeriMode> Dac<'d, M> {
     ///
     /// If triggering is not enabled, the new values are immediately output;
     /// otherwise, they will be output after the next trigger.
-    pub fn set(&mut self, values: DualValue) {
-        match values {
-            DualValue::Bit8(v1, v2) => self.info.regs.dhr8rd().write(|reg| {
-                reg.set_dhr(0, v1);
-                reg.set_dhr(1, v2);
-            }),
-            DualValue::Bit12Left(v1, v2) => self.info.regs.dhr12ld().write(|reg| {
-                reg.set_dhr(0, v1);
-                reg.set_dhr(1, v2);
-            }),
-            DualValue::Bit12Right(v1, v2) => self.info.regs.dhr12rd().write(|reg| {
-                reg.set_dhr(0, v1);
-                reg.set_dhr(1, v2);
-            }),
+    pub fn set<W: Word>(&mut self, values: (W, W)) {
+        W::set_values(self.info.regs, values);
+    }
+}
+
+trait SealedIntoSlice<T> {}
+trait SealedIntoArray<T> {}
+
+/// Convert between slice types
+#[allow(private_bounds)]
+pub trait IntoSlice<T>: SealedIntoSlice<T> {
+    /// Convert the slice
+    fn into_slice(&self) -> &[T];
+
+    /// Convert the mut slice
+    fn into_mut_slice(&mut self) -> &mut [T];
+}
+
+/// Convert between slice types
+#[allow(private_bounds)]
+pub trait IntoArray<T, const N: usize>: SealedIntoArray<T> {
+    /// Convert the array
+    fn into_array(&self) -> &[T; N];
+
+    /// Convert the mut array
+    fn into_mut_array(&mut self) -> &mut [T; N];
+}
+
+macro_rules! impl_word_type {
+    ($a:ident, $b:ident) => {
+        #[allow(non_camel_case_types)]
+        #[repr(transparent)]
+        #[doc = concat!(stringify!($a), " integer type.")]
+        #[derive(Clone, Copy, Debug)]
+        pub struct $a(pub $b);
+
+        impl_word_type!($a, $b, INTO_SLICE);
+        impl_word_type!($b, $a, INTO_SLICE);
+    };
+    ($a:ident, $b:ident, INTO_SLICE) => {
+        impl SealedIntoSlice<$a> for [$b] {}
+        impl IntoSlice<$a> for [$b] {
+            fn into_slice(&self) -> &[$a] {
+                unsafe { slice::from_raw_parts(self.as_ptr() as *const $a, self.len()) }
+            }
+
+            fn into_mut_slice(&mut self) -> &mut [$a] {
+                unsafe { slice::from_raw_parts_mut(self.as_mut_ptr() as *mut $a, self.len()) }
+            }
         }
+
+        impl<const N: usize> SealedIntoArray<$a> for [$b; N] {}
+        impl<const N: usize> IntoArray<$a, N> for [$b; N] {
+            fn into_array(&self) -> &[$a; N] {
+                unsafe { &*(self.as_ptr() as *const u8 as *const [$a; N]) }
+            }
+
+            fn into_mut_array(&mut self) -> &mut [$a; N] {
+                unsafe { &mut *(self.as_mut_ptr() as *mut u8 as *mut [$a; N]) }
+            }
+        }
+    };
+}
+
+impl_word_type!(u12r, u16);
+impl_word_type!(u12l, u16);
+
+trait SealedWord: Sized {
+    type Word: dma::Word;
+
+    fn dma_buf_mut(buf: &mut [Self]) -> &mut [Self::Word];
+    fn dma_buf(buf: &[Self]) -> &[Self::Word];
+    fn dma_ptr(regs: Regs, idx: usize) -> *mut u32;
+    fn set_value(regs: Regs, idx: usize, value: Self);
+    fn set_values(regs: Regs, values: (Self, Self));
+}
+
+trait_set::trait_set! {
+    /// The dac word type
+    pub trait Word = SealedWord;
+}
+
+impl SealedWord for u8 {
+    type Word = u8;
+
+    fn dma_buf(buf: &[Self]) -> &[Self::Word] {
+        buf
+    }
+
+    fn dma_buf_mut(buf: &mut [Self]) -> &mut [Self::Word] {
+        buf
+    }
+
+    fn dma_ptr(regs: Regs, idx: usize) -> *mut u32 {
+        regs.dhr8r(idx).as_ptr() as *mut u32
+    }
+
+    fn set_value(regs: Regs, idx: usize, value: Self) {
+        regs.dhr8r(idx).write(|reg| reg.set_dhr(value))
+    }
+
+    fn set_values(regs: Regs, values: (Self, Self)) {
+        regs.dhr8rd().write(|reg| {
+            reg.set_dhr(0, values.0);
+            reg.set_dhr(1, values.1);
+        })
+    }
+}
+
+impl SealedWord for u12r {
+    type Word = u16;
+
+    fn dma_buf(buf: &[Self]) -> &[Self::Word] {
+        buf.into_slice()
+    }
+
+    fn dma_buf_mut(buf: &mut [Self]) -> &mut [Self::Word] {
+        buf.into_mut_slice()
+    }
+
+    fn dma_ptr(regs: Regs, idx: usize) -> *mut u32 {
+        regs.dhr12r(idx).as_ptr() as *mut u32
+    }
+
+    fn set_value(regs: Regs, idx: usize, value: Self) {
+        regs.dhr12r(idx).write(|reg| reg.set_dhr(value.0))
+    }
+
+    fn set_values(regs: Regs, values: (Self, Self)) {
+        regs.dhr12rd().write(|reg| {
+            reg.set_dhr(0, values.0.0);
+            reg.set_dhr(1, values.1.0);
+        })
+    }
+}
+
+impl SealedWord for u12l {
+    type Word = u16;
+
+    fn dma_buf(buf: &[Self]) -> &[Self::Word] {
+        buf.into_slice()
+    }
+
+    fn dma_buf_mut(buf: &mut [Self]) -> &mut [Self::Word] {
+        buf.into_mut_slice()
+    }
+
+    fn dma_ptr(regs: Regs, idx: usize) -> *mut u32 {
+        regs.dhr12l(idx).as_ptr() as *mut u32
+    }
+
+    fn set_value(regs: Regs, idx: usize, value: Self) {
+        regs.dhr12l(idx).write(|reg| reg.set_dhr(value.0))
+    }
+
+    fn set_values(regs: Regs, values: (Self, Self)) {
+        regs.dhr12ld().write(|reg| {
+            reg.set_dhr(0, values.0.0);
+            reg.set_dhr(1, values.1.0);
+        })
     }
 }
 

--- a/embassy-stm32/src/dac/ringbuffered.rs
+++ b/embassy-stm32/src/dac/ringbuffered.rs
@@ -3,10 +3,9 @@
 use core::mem::ManuallyDrop;
 use core::sync::atomic::{Ordering, compiler_fence};
 
-use crate::dac::{ChannelEvent, Info, State};
+use crate::dac::{ChannelEvent, Info, State, Word};
 use crate::dma::WritableRingBuffer;
 use crate::dma::ringbuffer::Error;
-use crate::dma::word::Word;
 
 /// A DAC channel backed by a DMA ring buffer.
 ///
@@ -17,7 +16,7 @@ use crate::dma::word::Word;
 /// Obtain this from [`DacChannel::into_ring_buffered_8bit`] or
 /// [`DacChannel::into_ring_buffered_12right`].
 pub struct RingBufferedDacChannel<'d, W: Word> {
-    ring_buf: ManuallyDrop<WritableRingBuffer<'d, W>>,
+    ring_buf: ManuallyDrop<WritableRingBuffer<'d, W::Word>>,
     info: &'static Info,
     state: &'static State,
     idx: usize,
@@ -25,7 +24,7 @@ pub struct RingBufferedDacChannel<'d, W: Word> {
 
 impl<'d, W: Word> RingBufferedDacChannel<'d, W> {
     pub(super) fn new(
-        ring_buf: WritableRingBuffer<'d, W>,
+        ring_buf: WritableRingBuffer<'d, W::Word>,
         info: &'static Info,
         state: &'static State,
         idx: usize,
@@ -51,7 +50,7 @@ impl<'d, W: Word> RingBufferedDacChannel<'d, W> {
     /// Useful for pre-filling the buffer before calling [`start`](Self::start). Writes
     /// at most `capacity` elements aligned to the end of the buffer.
     pub fn write_immediate(&mut self, buf: &[W]) -> Result<(usize, usize), Error> {
-        self.ring_buf.write_immediate(buf)
+        self.ring_buf.write_immediate(W::dma_buf(buf))
     }
 
     /// Write samples into the ring buffer.
@@ -60,12 +59,12 @@ impl<'d, W: Word> RingBufferedDacChannel<'d, W> {
     /// consumed data faster than the CPU supplied it; the ring buffer resets itself
     /// automatically in that case.
     pub fn write(&mut self, buf: &[W]) -> Result<(usize, usize), Error> {
-        self.ring_buf.write(buf)
+        self.ring_buf.write(W::dma_buf(buf))
     }
 
     /// Write an exact number of samples, waiting asynchronously until space is available.
     pub async fn write_exact(&mut self, buffer: &[W]) -> Result<usize, Error> {
-        self.ring_buf.write_exact(buffer).await
+        self.ring_buf.write_exact(W::dma_buf(buffer)).await
     }
 
     /// Wait for a ring buffer write error (underrun).

--- a/examples/stm32f4/src/bin/dac.rs
+++ b/examples/stm32f4/src/bin/dac.rs
@@ -3,7 +3,7 @@
 
 use defmt::*;
 use embassy_executor::Spawner;
-use embassy_stm32::dac::{DacChannel, Value};
+use embassy_stm32::dac::DacChannel;
 use {defmt_rtt as _, panic_probe as _};
 
 #[embassy_executor::main]
@@ -15,7 +15,7 @@ async fn main(_spawner: Spawner) -> ! {
 
     loop {
         for v in 0..=255 {
-            dac.set(Value::Bit8(to_sine_wave(v)));
+            dac.set(to_sine_wave(v));
         }
     }
 }

--- a/examples/stm32g4/src/bin/dac_dma_circular.rs
+++ b/examples/stm32g4/src/bin/dac_dma_circular.rs
@@ -16,7 +16,7 @@
 
 use defmt::info;
 use embassy_executor::Spawner;
-use embassy_stm32::dac::DacChannel;
+use embassy_stm32::dac::{DacChannel, IntoArray, u12r};
 use embassy_stm32::timer::Channel;
 use embassy_stm32::timer::low_level::{MasterMode, RoundTo, Timer};
 use embassy_stm32::triggers::TIM8_TRGO;
@@ -30,14 +30,14 @@ use {defmt_rtt as _, panic_probe as _};
 // u32 elements are required because the DAC DMA uses 32-bit peripheral transfers;
 // only bits [11:0] of each word are used by the DHR12R register.
 const N: usize = 64;
-const SINE: [u32; N] = [
+const SINE: [u16; N] = [
     2048, 2244, 2438, 2629, 2813, 2991, 3159, 3317, 3462, 3594, 3711, 3812, 3896, 3962, 4010, 4038, 4048, 4038, 4010,
     3962, 3896, 3812, 3711, 3594, 3462, 3317, 3159, 2991, 2813, 2629, 2438, 2244, 2048, 1852, 1658, 1467, 1283, 1105,
     937, 779, 634, 502, 385, 284, 200, 134, 86, 58, 48, 58, 86, 134, 200, 284, 385, 502, 634, 779, 937, 1105, 1283,
     1467, 1658, 1852,
 ];
 
-static DMA_BUF: StaticCell<[u32; N]> = StaticCell::new();
+static DMA_BUF: StaticCell<[u12r; N]> = StaticCell::new();
 
 bind_interrupts!(struct Irqs {
     DMA1_CHANNEL5 => dma::InterruptHandler<peripherals::DMA1_CH5>;
@@ -74,7 +74,7 @@ async fn main(_spawner: Spawner) {
 
     // Pre-populate the DMA buffer with the sine table before handing it to the ring buffer.
     // No write_immediate needed — DMA reads the pre-filled data from the first trigger.
-    let mut ring = dac_ch1.into_ring_buffered_12right(DMA_BUF.init(SINE));
+    let mut ring = dac_ch1.into_ring_buffered(DMA_BUF.init(*SINE.into_array()));
 
     ring.start();
 

--- a/examples/stm32h7/src/bin/dac.rs
+++ b/examples/stm32h7/src/bin/dac.rs
@@ -4,7 +4,7 @@
 use cortex_m_rt::entry;
 use defmt::*;
 use embassy_stm32::Config;
-use embassy_stm32::dac::{DacChannel, Value};
+use embassy_stm32::dac::DacChannel;
 use {defmt_rtt as _, panic_probe as _};
 
 #[entry]
@@ -49,7 +49,7 @@ fn main() -> ! {
 
     loop {
         for v in 0..=255 {
-            dac.set(Value::Bit8(to_sine_wave(v)));
+            dac.set(to_sine_wave(v));
         }
     }
 }

--- a/examples/stm32h7/src/bin/dac_dma.rs
+++ b/examples/stm32h7/src/bin/dac_dma.rs
@@ -3,7 +3,7 @@
 
 use defmt::*;
 use embassy_executor::Spawner;
-use embassy_stm32::dac::{DacChannel, ValueArray};
+use embassy_stm32::dac::DacChannel;
 use embassy_stm32::mode::Async;
 use embassy_stm32::pac::timer::vals::Mms;
 use embassy_stm32::peripherals::{DMA1_CH3, DMA1_CH4, TIM6, TIM7};
@@ -106,7 +106,7 @@ async fn dac_task1(tim: Peri<'static, TIM6>, mut dac: DacChannel<'static, Async>
     // Loop technically not necessary if DMA circular mode is enabled
     loop {
         info!("Loop DAC1");
-        dac.write(ValueArray::Bit8(data), true).await;
+        dac.write(data, true).await;
     }
 }
 
@@ -143,7 +143,7 @@ async fn dac_task2(tim: Peri<'static, TIM7>, mut dac: DacChannel<'static, Async>
         data.len()
     );
 
-    dac.write(ValueArray::Bit8(data), true).await;
+    dac.write(data, true).await;
 }
 
 fn to_sine_wave(v: u8) -> u8 {

--- a/examples/stm32l4/src/bin/dac.rs
+++ b/examples/stm32l4/src/bin/dac.rs
@@ -2,7 +2,7 @@
 #![no_main]
 
 use defmt::*;
-use embassy_stm32::dac::{DacChannel, Value};
+use embassy_stm32::dac::DacChannel;
 use {defmt_rtt as _, panic_probe as _};
 
 #[cortex_m_rt::entry]
@@ -14,7 +14,7 @@ fn main() -> ! {
 
     loop {
         for v in 0..=255 {
-            dac.set(Value::Bit8(to_sine_wave(v)));
+            dac.set(to_sine_wave(v));
         }
     }
 }

--- a/examples/stm32l4/src/bin/dac_dma.rs
+++ b/examples/stm32l4/src/bin/dac_dma.rs
@@ -3,7 +3,7 @@
 
 use defmt::*;
 use embassy_executor::Spawner;
-use embassy_stm32::dac::{DacChannel, ValueArray};
+use embassy_stm32::dac::DacChannel;
 use embassy_stm32::mode::Async;
 use embassy_stm32::pac::timer::vals::Mms;
 use embassy_stm32::peripherals::{DMA1_CH3, DMA1_CH4, TIM6, TIM7};
@@ -75,7 +75,7 @@ async fn dac_task1(tim: Peri<'static, TIM6>, mut dac: DacChannel<'static, Async>
     // Loop technically not necessary if DMA circular mode is enabled
     loop {
         info!("Loop DAC1");
-        dac.write(ValueArray::Bit8(data), true).await;
+        dac.write(data, true).await;
     }
 }
 
@@ -112,7 +112,7 @@ async fn dac_task2(tim: Peri<'static, TIM7>, mut dac: DacChannel<'static, Async>
         data.len()
     );
 
-    dac.write(ValueArray::Bit8(data), true).await;
+    dac.write(data, true).await;
 }
 
 fn to_sine_wave(v: u8) -> u8 {

--- a/examples/stm32u0/src/bin/dac.rs
+++ b/examples/stm32u0/src/bin/dac.rs
@@ -2,7 +2,7 @@
 #![no_main]
 
 use defmt::*;
-use embassy_stm32::dac::{DacChannel, Value};
+use embassy_stm32::dac::DacChannel;
 use {defmt_rtt as _, panic_probe as _};
 
 #[cortex_m_rt::entry]
@@ -14,7 +14,7 @@ fn main() -> ! {
 
     loop {
         for v in 0..=255 {
-            dac.set(Value::Bit8(to_sine_wave(v)));
+            dac.set(to_sine_wave(v));
         }
     }
 }

--- a/tests/stm32/src/bin/dac.rs
+++ b/tests/stm32/src/bin/dac.rs
@@ -11,7 +11,7 @@ use common::*;
 use defmt::assert;
 use embassy_executor::Spawner;
 use embassy_stm32::adc::{Adc, SampleTime};
-use embassy_stm32::dac::{DacChannel, Value};
+use embassy_stm32::dac::DacChannel;
 use embassy_time::Timer;
 use micromath::F32Ext;
 use {defmt_rtt as _, panic_probe as _};
@@ -48,7 +48,7 @@ async fn main(_spawner: Spawner) {
     ))]
     let normalization_factor: i32 = 16;
 
-    dac.set(Value::Bit8(0));
+    dac.set(0);
     // Now wait a little to obtain a stable value
     Timer::after_millis(30).await;
     let offset = adc.blocking_read(&mut adc_pin, SampleTime::from_bits(0));
@@ -56,7 +56,7 @@ async fn main(_spawner: Spawner) {
     for v in 0..=255 {
         // First set the DAC output value
         let dac_output_val = to_sine_wave(v);
-        dac.set(Value::Bit8(dac_output_val));
+        dac.set(dac_output_val);
 
         // Now wait a little to obtain a stable value
         Timer::after_millis(30).await;

--- a/tests/stm32/src/bin/dac_l1.rs
+++ b/tests/stm32/src/bin/dac_l1.rs
@@ -11,7 +11,7 @@ use common::*;
 use defmt::assert;
 use embassy_executor::Spawner;
 use embassy_stm32::adc::{Adc, SampleTime};
-use embassy_stm32::dac::{DacChannel, Value};
+use embassy_stm32::dac::DacChannel;
 use embassy_stm32::{bind_interrupts, peripherals};
 use embassy_time::Timer;
 use micromath::F32Ext;
@@ -48,7 +48,7 @@ async fn main(_spawner: Spawner) {
     ))]
     let normalization_factor: i32 = 16;
 
-    dac.set(Value::Bit8(0));
+    dac.set(0);
     // Now wait a little to obtain a stable value
     Timer::after_millis(30).await;
     let offset = adc.irq_read(&mut adc_pin, SampleTime::from_bits(0)).await;
@@ -56,7 +56,7 @@ async fn main(_spawner: Spawner) {
     for v in 0..=255 {
         // First set the DAC output value
         let dac_output_val = to_sine_wave(v);
-        dac.set(Value::Bit8(dac_output_val));
+        dac.set(dac_output_val);
 
         // Now wait a little to obtain a stable value
         Timer::after_millis(30).await;


### PR DESCRIPTION
Make dac use monomorphism like spi and other peripherals, and introduce 12-bit types to accommodate the 12-bit values. Add conversion methods for slices containing these values.

Make ringbuffer use the new differentially-sized values.