### PR TITLE
[MCXA] i2c/target: report end-of-transfer via ReadStatus/WriteStatus

### DIFF
--- a/ci.sh
+++ b/ci.sh
@@ -54,9 +54,6 @@ rm out/tests/stm32f207zg/eth
 rm out/tests/stm32f207zg/usart_rx_ringbuffered
 rm out/tests/stm32l152re/usart_rx_ringbuffered
 
-# failing
-rm out/tests/frdm-mcx-a266/i2c
-
 # doesn't work, gives "noise error", no idea why. usart_dma does pass.
 rm out/tests/stm32u5a5zj/usart
 

--- a/embassy-mcxa/src/i2c/target.rs
+++ b/embassy-mcxa/src/i2c/target.rs
@@ -40,11 +40,11 @@
 //!             target::Request::Read(addr) => {
 //!                 // Controller wants to read from us at `addr`
 //!                 buf.fill(0x55);
-//!                 let _count = i2c.blocking_respond_to_read(&buf).unwrap();
+//!                 let _status = i2c.blocking_respond_to_read(&buf).unwrap();
 //!             }
 //!             target::Request::Write(_addr) => {
 //!                 // Controller wants to write to us at `addr`
-//!                 let _count = i2c.blocking_respond_to_write(&mut buf).unwrap();
+//!                 let _status = i2c.blocking_respond_to_write(&mut buf).unwrap();
 //!             }
 //!             target::Request::Stop(_addr) => {
 //!                 // Controller issued a STOP condition for `addr`
@@ -53,7 +53,7 @@
 //!                 // Controller issued a General Call (broadcast write
 //!                 // to address 0x00). Drain the payload via the
 //!                 // normal write-response path.
-//!                 let _count = i2c.blocking_respond_to_write(&mut buf).unwrap();
+//!                 let _status = i2c.blocking_respond_to_write(&mut buf).unwrap();
 //!             }
 //!             target::Request::SmbusAlert => {
 //!                 // Controller issued an SMBus Alert
@@ -64,9 +64,11 @@
 //! }
 //! ```
 
+use core::future::poll_fn;
 use core::marker::PhantomData;
 use core::ops::Range;
 use core::sync::atomic::{Ordering, fence};
+use core::task::Poll;
 
 use embassy_hal_internal::Peri;
 use embassy_hal_internal::drop::OnDrop;
@@ -115,6 +117,48 @@ impl From<crate::dma::InvalidParameters> for IOError {
     fn from(_value: crate::dma::InvalidParameters) -> Self {
         IOError::Other
     }
+}
+
+/// Outcome of a `respond_to_read` call.
+///
+/// The `usize` in every variant counts bytes consumed from the supplied
+/// buffer, i.e. bytes the controller actually clocked out and ACKed.
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+#[non_exhaustive]
+pub enum ReadStatus {
+    /// Controller terminated the read with NACK + STOP exactly when the
+    /// supplied buffer was exhausted.
+    Complete(usize),
+    /// Buffer was fully consumed but the controller is still asking for
+    /// more bytes (it ACKed the last byte). Caller should call
+    /// `respond_to_read` again with additional bytes, or accept that the
+    /// bus will clock-stretch (with TXDSTALL enabled) until something
+    /// else terminates the transfer.
+    NeedMore(usize),
+    /// Controller issued an early STOP or repeated START before the
+    /// buffer was exhausted.
+    EarlyStop(usize),
+}
+
+/// Outcome of a `respond_to_write` call.
+///
+/// The `usize` in every variant counts bytes written into the supplied
+/// buffer, i.e. bytes the target ACKed.
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+#[non_exhaustive]
+pub enum WriteStatus {
+    /// Controller issued STOP.
+    Stopped(usize),
+    /// Controller issued a repeated START. The next `listen` call will
+    /// report the direction/address of the new sub-transaction.
+    Restarted(usize),
+    /// The supplied buffer filled before the controller terminated the
+    /// transfer. Caller should call `respond_to_write` again with more
+    /// buffer space, or accept that the bus will clock-stretch (with
+    /// RXSTALL enabled) until something else terminates the transfer.
+    BufferFull(usize),
 }
 
 /// I2C interrupt handler.
@@ -510,8 +554,9 @@ impl<'d, M: Mode> I2c<'d, M> {
 
     /// Transmit data to the I2C controller.
     ///
-    /// This function sends the contents of the provided buffer to the I2C controller. It
-    /// blocks until the data is transmitted or an error occurs.
+    /// Sends the contents of the provided buffer to the I2C controller. The
+    /// call services the transfer to a clean termination point (STOP,
+    /// repeated START, or buffer exhausted) before returning.
     ///
     /// # Parameters
     ///
@@ -519,9 +564,10 @@ impl<'d, M: Mode> I2c<'d, M> {
     ///
     /// # Returns
     ///
-    /// - `Ok(usize)` with the number of bytes transmitted.
+    /// - `Ok(ReadStatus)` describing how the transfer ended and how many
+    ///   bytes the controller ACKed.
     /// - `Err(IOError)` if an error occurs.
-    pub fn blocking_respond_to_read(&mut self, buf: &[u8]) -> Result<usize, IOError> {
+    pub fn blocking_respond_to_read(&mut self, buf: &[u8]) -> Result<ReadStatus, IOError> {
         let mut count = 0;
 
         self.clear_status();
@@ -530,33 +576,44 @@ impl<'d, M: Mode> I2c<'d, M> {
             // Wait until we can send data
             let ssr = loop {
                 let ssr = self.info.regs().ssr().read();
-                let tdf = ssr.tdf();
-                let sdf = ssr.sdf();
-                let rsf = ssr.rsf();
-
-                if tdf || sdf || rsf {
+                if ssr.tdf() || ssr.sdf() || ssr.rsf() {
                     break ssr;
                 }
             };
 
-            // If we see a STOP or REPEATED START, break out
             if ssr.sdf() || ssr.rsf() {
                 #[cfg(feature = "defmt")]
                 defmt::trace!("Early stop of Target Send routine. STOP or Repeated-start received");
-                break;
-            } else {
-                self.info.regs().stdr().write(|w| w.set_data(*byte));
-                count += 1;
+                return Ok(ReadStatus::EarlyStop(count));
             }
+
+            self.info.regs().stdr().write(|w| w.set_data(*byte));
+            count += 1;
         }
 
-        Ok(count)
+        // All caller bytes pushed. Wait briefly to determine whether the
+        // controller is done (NACK + STOP/RSTART) or whether it wants more.
+        let ssr = loop {
+            let ssr = self.info.regs().ssr().read();
+            if ssr.tdf() || ssr.sdf() || ssr.rsf() {
+                break ssr;
+            }
+        };
+
+        if ssr.sdf() || ssr.rsf() {
+            Ok(ReadStatus::Complete(count))
+        } else {
+            // tdf set: TX FIFO empty during a transmit transfer means the
+            // controller is still clocking and wants another byte.
+            Ok(ReadStatus::NeedMore(count))
+        }
     }
 
     /// Receive data from the I2C controller.
     ///
-    /// This function receives data from the I2C controller into the provided buffer. It
-    /// blocks until the buffer is filled or an error occurs.
+    /// Reads bytes the controller writes into the provided buffer. The call
+    /// services the transfer to a clean termination point (STOP, repeated
+    /// START, or buffer filled) before returning.
     ///
     /// # Parameters
     ///
@@ -564,9 +621,10 @@ impl<'d, M: Mode> I2c<'d, M> {
     ///
     /// # Returns
     ///
-    /// - `Ok(usize)` with the number of bytes received.
+    /// - `Ok(WriteStatus)` describing how the transfer ended and how many
+    ///   bytes the target received.
     /// - `Err(IOError)` if an error occurs.
-    pub fn blocking_respond_to_write(&mut self, buf: &mut [u8]) -> Result<usize, IOError> {
+    pub fn blocking_respond_to_write(&mut self, buf: &mut [u8]) -> Result<WriteStatus, IOError> {
         let mut count = 0;
 
         self.clear_status();
@@ -575,27 +633,27 @@ impl<'d, M: Mode> I2c<'d, M> {
             // Wait until we have data to read
             let ssr = loop {
                 let ssr = self.info.regs().ssr().read();
-                let rdf = ssr.rdf();
-                let sdf = ssr.sdf();
-                let rsf = ssr.rsf();
-
-                if rdf || sdf || rsf {
+                if ssr.rdf() || ssr.sdf() || ssr.rsf() {
                     break ssr;
                 }
             };
 
-            // If we see a STOP or REPEATED START, break out
-            if ssr.sdf() || ssr.rsf() {
+            if ssr.sdf() {
                 #[cfg(feature = "defmt")]
-                defmt::trace!("Early stop of Target Receive routine. STOP or Repeated-start received");
-                break;
-            } else {
-                *byte = self.info.regs().srdr().read().data();
-                count += 1;
+                defmt::trace!("Early stop of Target Receive routine. STOP received");
+                return Ok(WriteStatus::Stopped(count));
             }
+            if ssr.rsf() {
+                #[cfg(feature = "defmt")]
+                defmt::trace!("Early stop of Target Receive routine. Repeated-start received");
+                return Ok(WriteStatus::Restarted(count));
+            }
+
+            *byte = self.info.regs().srdr().read().data();
+            count += 1;
         }
 
-        Ok(count)
+        Ok(WriteStatus::BufferFull(count))
     }
 }
 
@@ -662,6 +720,32 @@ impl<'d> I2c<'d, Async> {
     }
 }
 
+/// Internal outcome of a single DMA TX chunk transfer (target -> controller).
+#[derive(Copy, Clone)]
+enum TxChunkOutcome {
+    /// Controller issued STOP. `usize` is bytes transferred from this chunk.
+    Stopped(usize),
+    /// Controller issued repeated START. `usize` is bytes transferred from
+    /// this chunk.
+    Restarted(usize),
+    /// DMA exhausted the chunk and the controller is still asking for more
+    /// bytes. `usize` equals the chunk length.
+    NeedMore(usize),
+}
+
+/// Internal outcome of a single DMA RX chunk transfer (controller -> target).
+#[derive(Copy, Clone)]
+enum RxChunkOutcome {
+    /// Controller issued STOP. `usize` is bytes received into this chunk.
+    Stopped(usize),
+    /// Controller issued repeated START. `usize` is bytes received into
+    /// this chunk.
+    Restarted(usize),
+    /// DMA filled the chunk before the controller terminated the transfer.
+    /// `usize` equals the chunk length.
+    Filled(usize),
+}
+
 impl<'d> I2c<'d, Dma<'d>> {
     /// Create a new asynchronous instance of the I2C Target bus driver with DMA support.
     ///
@@ -719,8 +803,9 @@ impl<'d> I2c<'d, Dma<'d>> {
         )
     }
 
-    async fn read_dma_chunk(&mut self, data: &mut [u8]) -> Result<usize, IOError> {
+    async fn read_dma_chunk(&mut self, data: &mut [u8]) -> Result<RxChunkOutcome, IOError> {
         let peri_addr = self.info.regs().srdr().as_ptr() as *const u8;
+        let chunk_len = data.len();
 
         self.clear_status();
 
@@ -733,7 +818,7 @@ impl<'d> I2c<'d, Dma<'d>> {
             // Set DMA request source from instance type (type-safe)
             self.mode.rx_dma.set_request_source(self.mode.rx_request);
 
-            // Configure TCD for memory-to-peripheral transfer
+            // Configure TCD for peripheral-to-memory transfer
             self.mode
                 .rx_dma
                 .setup_read_from_peripheral(peri_addr, data, false, TransferOptions::COMPLETE_INTERRUPT)?;
@@ -745,21 +830,32 @@ impl<'d> I2c<'d, Dma<'d>> {
             self.mode.rx_dma.enable_request();
         }
 
-        // Wait until STOP or REPEATED START
-        self.info
-            .wait_cell()
-            .wait_for(|| {
-                self.info.regs().sier().write(|w| {
-                    w.set_feie(true);
-                    w.set_beie(true);
-                    w.set_sdie(true);
-                    w.set_rsie(true);
-                });
-                let ssr = self.info.regs().ssr().read();
-                ssr.fef() || ssr.bef() || ssr.sdf() || ssr.rsf()
-            })
-            .await
-            .map_err(|_| IOError::Other)?;
+        // Wait for any of:
+        //  - I2C end-of-transfer flag (sdf, rsf) -> controller terminated
+        //  - I2C error flag (fef, bef) -> bus problem
+        //  - DMA channel completion -> chunk filled before controller stopped
+        //
+        // The DMA done interrupt wakes the DMA's wait_cell; I2C status
+        // changes wake the I2C wait_cell. Register on both.
+        poll_fn(|cx| {
+            let _ = self.mode.rx_dma.wait_cell().poll_wait(cx);
+            let _ = self.info.wait_cell().poll_wait(cx);
+
+            self.info.regs().sier().write(|w| {
+                w.set_feie(true);
+                w.set_beie(true);
+                w.set_sdie(true);
+                w.set_rsie(true);
+            });
+
+            let ssr = self.info.regs().ssr().read();
+            if ssr.fef() || ssr.bef() || ssr.sdf() || ssr.rsf() || self.mode.rx_dma.is_done() {
+                Poll::Ready(())
+            } else {
+                Poll::Pending
+            }
+        })
+        .await;
 
         // Cleanup
         self.info.regs().sder().modify(|w| w.set_rdde(false));
@@ -769,8 +865,6 @@ impl<'d> I2c<'d, Dma<'d>> {
         }
 
         // Ensure all writes by DMA are visible to the CPU
-        // TODO: ensure this is done internal to the DMA methods so individual drivers
-        // don't need to handle this?
         fence(Ordering::Acquire);
 
         let ssr = self.info.regs().ssr().read();
@@ -779,15 +873,20 @@ impl<'d> I2c<'d, Dma<'d>> {
             Err(IOError::FifoError)
         } else if ssr.bef() {
             Err(IOError::BitError)
-        } else if ssr.sdf() || ssr.rsf() {
-            Ok(self.mode.rx_dma.transferred_bytes())
+        } else if ssr.sdf() {
+            Ok(RxChunkOutcome::Stopped(self.mode.rx_dma.transferred_bytes()))
+        } else if ssr.rsf() {
+            Ok(RxChunkOutcome::Restarted(self.mode.rx_dma.transferred_bytes()))
         } else {
-            Err(IOError::Other)
+            // DMA done with no end-of-transfer flag: chunk filled, controller
+            // may want to write more bytes.
+            Ok(RxChunkOutcome::Filled(chunk_len))
         }
     }
 
-    async fn write_dma_chunk(&mut self, data: &[u8]) -> Result<usize, IOError> {
+    async fn write_dma_chunk(&mut self, data: &[u8]) -> Result<TxChunkOutcome, IOError> {
         let peri_addr = self.info.regs().stdr().as_ptr() as *mut u8;
+        let chunk_len = data.len();
 
         self.clear_status();
 
@@ -800,14 +899,15 @@ impl<'d> I2c<'d, Dma<'d>> {
             // Set DMA request source from instance type (type-safe)
             self.mode.tx_dma.set_request_source(self.mode.tx_request);
 
-            // Configure TCD for memory-to-peripheral transfer
+            // Configure TCD for memory-to-peripheral transfer. Use
+            // COMPLETE_INTERRUPT so the channel wakes us on DMA exhaustion
+            // (which lets us return NeedMore when the controller wants more
+            // bytes than the chunk holds).
             self.mode
                 .tx_dma
-                .setup_write_to_peripheral(data, peri_addr, false, TransferOptions::NO_INTERRUPTS)?;
+                .setup_write_to_peripheral(data, peri_addr, false, TransferOptions::COMPLETE_INTERRUPT)?;
 
             // Ensure all writes by DMA are visible to the CPU
-            // TODO: ensure this is done internal to the DMA methods so individual drivers
-            // don't need to handle this?
             fence(Ordering::Release);
 
             // Enable I2C TX DMA request
@@ -817,21 +917,30 @@ impl<'d> I2c<'d, Dma<'d>> {
             self.mode.tx_dma.enable_request();
         }
 
-        // Wait until STOP or REPEATED START
-        self.info
-            .wait_cell()
-            .wait_for(|| {
-                self.info.regs().sier().write(|w| {
-                    w.set_feie(true);
-                    w.set_beie(true);
-                    w.set_sdie(true);
-                    w.set_rsie(true);
-                });
-                let ssr = self.info.regs().ssr().read();
-                ssr.fef() || ssr.bef() || ssr.sdf() || ssr.rsf()
-            })
-            .await
-            .map_err(|_| IOError::Other)?;
+        // Wait for any of:
+        //  - I2C end-of-transfer flag (sdf, rsf) -> controller terminated
+        //  - I2C error flag (fef, bef) -> bus problem
+        //  - DMA channel completion -> chunk exhausted; if controller still
+        //    clocking, caller may want to call again (NeedMore)
+        poll_fn(|cx| {
+            let _ = self.mode.tx_dma.wait_cell().poll_wait(cx);
+            let _ = self.info.wait_cell().poll_wait(cx);
+
+            self.info.regs().sier().write(|w| {
+                w.set_feie(true);
+                w.set_beie(true);
+                w.set_sdie(true);
+                w.set_rsie(true);
+            });
+
+            let ssr = self.info.regs().ssr().read();
+            if ssr.fef() || ssr.bef() || ssr.sdf() || ssr.rsf() || self.mode.tx_dma.is_done() {
+                Poll::Ready(())
+            } else {
+                Poll::Pending
+            }
+        })
+        .await;
 
         // Cleanup
         self.info.regs().sder().modify(|w| w.set_tdde(false));
@@ -846,10 +955,14 @@ impl<'d> I2c<'d, Dma<'d>> {
             Err(IOError::FifoError)
         } else if ssr.bef() {
             Err(IOError::BitError)
-        } else if ssr.sdf() || ssr.rsf() {
-            Ok(self.mode.tx_dma.transferred_bytes())
+        } else if ssr.sdf() {
+            Ok(TxChunkOutcome::Stopped(self.mode.tx_dma.transferred_bytes()))
+        } else if ssr.rsf() {
+            Ok(TxChunkOutcome::Restarted(self.mode.tx_dma.transferred_bytes()))
         } else {
-            Err(IOError::Other)
+            // DMA done with no end-of-transfer flag: chunk exhausted,
+            // controller still expects more bytes.
+            Ok(TxChunkOutcome::NeedMore(chunk_len))
         }
     }
 }
@@ -939,15 +1052,17 @@ where
 
     /// Asynchronously transmit data to the I2C controller.
     ///
-    /// This function sends the contents of the provided buffer to the I2C controller
-    /// asynchronously.
+    /// Sends the contents of the provided buffer to the I2C controller.
+    /// The future services the transfer to a clean termination point
+    /// (STOP, repeated START, or buffer exhausted) before resolving.
     ///
-    /// If the controller continues clocking out bytes after the buffer has been
-    /// fully transmitted (for example, an I2C-HID host that reads a fixed block
-    /// size larger than the prepared response), the async implementation pads
-    /// the remainder of the transaction with `0x00` bytes until the controller
-    /// issues STOP or repeated START. This avoids indefinite SCL clock
-    /// stretching when the firmware has nothing more to send.
+    /// If the controller continues clocking after the buffer has been
+    /// fully transmitted (for example, an I2C-HID host that reads a fixed
+    /// block size larger than the prepared response), this call resolves
+    /// with [`ReadStatus::NeedMore`] so the caller can decide what to do:
+    /// call `async_respond_to_read` again with more bytes (or fill data),
+    /// or let the bus clock-stretch (with TXDSTALL enabled) until the
+    /// controller eventually terminates the transfer.
     ///
     /// # Parameters
     ///
@@ -955,16 +1070,21 @@ where
     ///
     /// # Returns
     ///
-    /// - `Ok(usize)` with the number of bytes transmitted.
+    /// - `Ok(ReadStatus)` describing how the transfer ended and how many
+    ///   bytes the controller ACKed.
     /// - `Err(IOError)` if an error occurs.
-    pub fn async_respond_to_read<'a>(&'a mut self, buf: &'a [u8]) -> impl Future<Output = Result<usize, IOError>> + 'a {
+    pub fn async_respond_to_read<'a>(
+        &'a mut self,
+        buf: &'a [u8],
+    ) -> impl Future<Output = Result<ReadStatus, IOError>> + 'a {
         <Self as AsyncEngine>::async_respond_to_read_internal(self, buf)
     }
 
     /// Asynchronously receive data from the I2C controller.
     ///
-    /// This function receives data from the I2C controller into the provided buffer
-    /// asynchronously.
+    /// Reads bytes the controller writes into the provided buffer. The
+    /// future services the transfer to a clean termination point (STOP,
+    /// repeated START, or buffer filled) before resolving.
     ///
     /// # Parameters
     ///
@@ -972,12 +1092,13 @@ where
     ///
     /// # Returns
     ///
-    /// - `Ok(usize)` with the number of bytes received.
+    /// - `Ok(WriteStatus)` describing how the transfer ended and how many
+    ///   bytes the target received.
     /// - `Err(IOError)` if an error occurs.
     pub fn async_respond_to_write<'a>(
         &'a mut self,
         buf: &'a mut [u8],
-    ) -> impl Future<Output = Result<usize, IOError>> + 'a {
+    ) -> impl Future<Output = Result<WriteStatus, IOError>> + 'a {
         <Self as AsyncEngine>::async_respond_to_write_internal(self, buf)
     }
 }
@@ -986,16 +1107,16 @@ trait AsyncEngine {
     fn async_respond_to_read_internal<'a>(
         &'a mut self,
         buf: &'a [u8],
-    ) -> impl Future<Output = Result<usize, IOError>> + 'a;
+    ) -> impl Future<Output = Result<ReadStatus, IOError>> + 'a;
 
     fn async_respond_to_write_internal<'a>(
         &'a mut self,
         buf: &'a mut [u8],
-    ) -> impl Future<Output = Result<usize, IOError>> + 'a;
+    ) -> impl Future<Output = Result<WriteStatus, IOError>> + 'a;
 }
 
 impl<'d> AsyncEngine for I2c<'d, Async> {
-    async fn async_respond_to_read_internal(&mut self, buf: &[u8]) -> Result<usize, IOError> {
+    async fn async_respond_to_read_internal(&mut self, buf: &[u8]) -> Result<ReadStatus, IOError> {
         let mut count = 0;
 
         self.clear_status();
@@ -1012,46 +1133,46 @@ impl<'d> AsyncEngine for I2c<'d, Async> {
                 .await
                 .map_err(|_| IOError::Other)?;
 
-            // If we see a STOP or REPEATED START, break out
             let ssr = self.info.regs().ssr().read();
             if ssr.sdf() || ssr.rsf() {
                 #[cfg(feature = "defmt")]
                 defmt::trace!("Early stop of Target Send routine. STOP or Repeated-start received");
                 self.reset_fifos();
-                break;
-            } else {
-                self.info.regs().stdr().write(|w| w.set_data(*byte));
-                count += 1;
+                return Ok(ReadStatus::EarlyStop(count));
             }
+
+            self.info.regs().stdr().write(|w| w.set_data(*byte));
+            count += 1;
         }
 
-        // The controller may read more bytes than the buffer contains.
-        // Keep feeding zeros until the controller NACKs or sends STOP,
-        // otherwise the hardware clock-stretches indefinitely.
-        loop {
-            self.info
-                .wait_cell()
-                .wait_for(|| {
-                    self.enable_tx_ints();
-                    let ssr = self.info.regs().ssr().read();
-                    ssr.tdf() || ssr.sdf() || ssr.rsf()
-                })
-                .await
-                .map_err(|_| IOError::Other)?;
+        // All caller bytes pushed. Wait briefly to determine whether the
+        // controller is done (NACK + STOP/RSTART) or whether it wants more.
+        // We do NOT auto-pad here: doing so blocks the firmware for the
+        // duration of the controller's extra reads, which causes us to fall
+        // behind on subsequent back-to-back transactions. The caller
+        // receives ReadStatus::NeedMore and decides how to proceed.
+        self.info
+            .wait_cell()
+            .wait_for(|| {
+                self.enable_tx_ints();
+                let ssr = self.info.regs().ssr().read();
+                ssr.tdf() || ssr.sdf() || ssr.rsf()
+            })
+            .await
+            .map_err(|_| IOError::Other)?;
 
-            let ssr = self.info.regs().ssr().read();
-            if ssr.sdf() || ssr.rsf() {
-                self.reset_fifos();
-                break;
-            } else {
-                self.info.regs().stdr().write(|w| w.set_data(0x00));
-            }
+        let ssr = self.info.regs().ssr().read();
+        if ssr.sdf() || ssr.rsf() {
+            self.reset_fifos();
+            Ok(ReadStatus::Complete(count))
+        } else {
+            // tdf set: TX FIFO empty during a transmit transfer means the
+            // controller is still clocking and wants another byte.
+            Ok(ReadStatus::NeedMore(count))
         }
-
-        Ok(count)
     }
 
-    async fn async_respond_to_write_internal(&mut self, buf: &mut [u8]) -> Result<usize, IOError> {
+    async fn async_respond_to_write_internal(&mut self, buf: &mut [u8]) -> Result<WriteStatus, IOError> {
         let mut count = 0;
 
         self.clear_status();
@@ -1067,25 +1188,30 @@ impl<'d> AsyncEngine for I2c<'d, Async> {
                 .await
                 .map_err(|_| IOError::Other)?;
 
-            // If we see a STOP or REPEATED START, break out
             let ssr = self.info.regs().ssr().read();
-            if ssr.sdf() || ssr.rsf() {
+            if ssr.sdf() {
                 #[cfg(feature = "defmt")]
-                defmt::trace!("Early stop of Target Receive routine. STOP or Repeated-start received");
+                defmt::trace!("Early stop of Target Receive routine. STOP received");
                 self.reset_fifos();
-                break;
-            } else {
-                *byte = self.info.regs().srdr().read().data();
-                count += 1;
+                return Ok(WriteStatus::Stopped(count));
             }
+            if ssr.rsf() {
+                #[cfg(feature = "defmt")]
+                defmt::trace!("Early stop of Target Receive routine. Repeated-start received");
+                self.reset_fifos();
+                return Ok(WriteStatus::Restarted(count));
+            }
+
+            *byte = self.info.regs().srdr().read().data();
+            count += 1;
         }
 
-        Ok(count)
+        Ok(WriteStatus::BufferFull(count))
     }
 }
 
 impl<'d> AsyncEngine for I2c<'d, Dma<'d>> {
-    async fn async_respond_to_read_internal(&mut self, buf: &[u8]) -> Result<usize, IOError> {
+    async fn async_respond_to_read_internal(&mut self, buf: &[u8]) -> Result<ReadStatus, IOError> {
         let mut count = 0;
 
         self.clear_status();
@@ -1095,17 +1221,51 @@ impl<'d> AsyncEngine for I2c<'d, Dma<'d>> {
             self.info.regs().sder().modify(|w| w.set_tdde(false));
         });
 
-        for chunk in buf.chunks(DMA_MAX_TRANSFER_SIZE) {
-            count += self.write_dma_chunk(chunk).await?;
+        let total = buf.len();
+        let mut chunks = buf.chunks(DMA_MAX_TRANSFER_SIZE).peekable();
+        while let Some(chunk) = chunks.next() {
+            let is_last = chunks.peek().is_none();
+            match self.write_dma_chunk(chunk).await? {
+                TxChunkOutcome::Stopped(n) => {
+                    count += n;
+                    on_drop.defuse();
+                    return Ok(if is_last && count == total {
+                        ReadStatus::Complete(count)
+                    } else {
+                        ReadStatus::EarlyStop(count)
+                    });
+                }
+                TxChunkOutcome::Restarted(n) => {
+                    count += n;
+                    on_drop.defuse();
+                    return Ok(if is_last && count == total {
+                        ReadStatus::Complete(count)
+                    } else {
+                        ReadStatus::EarlyStop(count)
+                    });
+                }
+                TxChunkOutcome::NeedMore(n) => {
+                    count += n;
+                    if is_last {
+                        on_drop.defuse();
+                        return Ok(ReadStatus::NeedMore(count));
+                    }
+                    // Non-last chunk completed normally: proceed to next
+                    // chunk. The bus will clock-stretch briefly between
+                    // chunks while we reprogram the TCD.
+                }
+            }
         }
 
-        // defuse it if the future is not dropped
+        // Reached only when buf was empty.
         on_drop.defuse();
-
-        Ok(count)
+        Ok(ReadStatus::NeedMore(count))
     }
 
-    async fn async_respond_to_write_internal<'a>(&'a mut self, buf: &'a mut [u8]) -> Result<usize, IOError> {
+    async fn async_respond_to_write_internal<'a>(
+        &'a mut self,
+        buf: &'a mut [u8],
+    ) -> Result<WriteStatus, IOError> {
         let mut count = 0;
 
         self.clear_status();
@@ -1115,14 +1275,36 @@ impl<'d> AsyncEngine for I2c<'d, Dma<'d>> {
             self.info.regs().sder().modify(|w| w.set_rdde(false));
         });
 
-        for chunk in buf.chunks_mut(DMA_MAX_TRANSFER_SIZE) {
-            count += self.read_dma_chunk(chunk).await?;
+        let total = buf.len();
+        let mut chunks = buf.chunks_mut(DMA_MAX_TRANSFER_SIZE).peekable();
+        while let Some(chunk) = chunks.next() {
+            let is_last = chunks.peek().is_none();
+            match self.read_dma_chunk(chunk).await? {
+                RxChunkOutcome::Stopped(n) => {
+                    count += n;
+                    on_drop.defuse();
+                    return Ok(WriteStatus::Stopped(count));
+                }
+                RxChunkOutcome::Restarted(n) => {
+                    count += n;
+                    on_drop.defuse();
+                    return Ok(WriteStatus::Restarted(count));
+                }
+                RxChunkOutcome::Filled(n) => {
+                    count += n;
+                    if is_last {
+                        on_drop.defuse();
+                        return Ok(WriteStatus::BufferFull(count));
+                    }
+                    // Non-last chunk filled: proceed to next chunk.
+                }
+            }
         }
 
-        // defuse it if the future is not dropped
+        // Reached only when buf was empty.
         on_drop.defuse();
-
-        Ok(count)
+        let _ = total;
+        Ok(WriteStatus::BufferFull(count))
     }
 }
 

--- a/examples/mcxa2xx/src/bin/i2c-target-async.rs
+++ b/examples/mcxa2xx/src/bin/i2c-target-async.rs
@@ -40,11 +40,21 @@ async fn main(_spawner: Spawner) {
         match request {
             target::Request::Read(_addr) => {
                 buf.fill(0x55);
-                let count = target.async_respond_to_read(&buf).await.unwrap();
+                let count = match target.async_respond_to_read(&buf).await.unwrap() {
+                    target::ReadStatus::Complete(n)
+                    | target::ReadStatus::NeedMore(n)
+                    | target::ReadStatus::EarlyStop(n) => n,
+                    _ => 0,
+                };
                 defmt::info!("T [R]: {:02x} -> {:02x}", _addr, buf[..count]);
             }
             target::Request::Write(_addr) => {
-                let count = target.async_respond_to_write(&mut buf).await.unwrap();
+                let count = match target.async_respond_to_write(&mut buf).await.unwrap() {
+                    target::WriteStatus::Stopped(n)
+                    | target::WriteStatus::Restarted(n)
+                    | target::WriteStatus::BufferFull(n) => n,
+                    _ => 0,
+                };
                 defmt::info!("T [W]: {:02x} <- {:02x}", _addr, buf[..count]);
             }
             _ => {}

--- a/examples/mcxa2xx/src/bin/i2c-target-blocking.rs
+++ b/examples/mcxa2xx/src/bin/i2c-target-blocking.rs
@@ -32,11 +32,21 @@ async fn main(_spawner: Spawner) {
         match request {
             target::Request::Read(_addr) => {
                 buf.fill(0x55);
-                let count = target.blocking_respond_to_read(&buf).unwrap();
+                let count = match target.blocking_respond_to_read(&buf).unwrap() {
+                    target::ReadStatus::Complete(n)
+                    | target::ReadStatus::NeedMore(n)
+                    | target::ReadStatus::EarlyStop(n) => n,
+                    _ => 0,
+                };
                 defmt::info!("T [R]: {:02x} -> {:02x}", _addr, buf[..count]);
             }
             target::Request::Write(_addr) => {
-                let count = target.blocking_respond_to_write(&mut buf).unwrap();
+                let count = match target.blocking_respond_to_write(&mut buf).unwrap() {
+                    target::WriteStatus::Stopped(n)
+                    | target::WriteStatus::Restarted(n)
+                    | target::WriteStatus::BufferFull(n) => n,
+                    _ => 0,
+                };
                 defmt::info!("T [W]: {:02x} <- {:02x}", _addr, buf[..count]);
             }
             _ => {}

--- a/examples/mcxa2xx/src/bin/i2c-target-dma.rs
+++ b/examples/mcxa2xx/src/bin/i2c-target-dma.rs
@@ -42,11 +42,21 @@ async fn main(_spawner: Spawner) {
         match request {
             target::Request::Read(_addr) => {
                 buf.fill(0x55);
-                let count = target.async_respond_to_read(&buf).await.unwrap();
+                let count = match target.async_respond_to_read(&buf).await.unwrap() {
+                    target::ReadStatus::Complete(n)
+                    | target::ReadStatus::NeedMore(n)
+                    | target::ReadStatus::EarlyStop(n) => n,
+                    _ => 0,
+                };
                 defmt::info!("T [R]: {:02x} -> {:02x}", _addr, buf[..count]);
             }
             target::Request::Write(_addr) => {
-                let count = target.async_respond_to_write(&mut buf).await.unwrap();
+                let count = match target.async_respond_to_write(&mut buf).await.unwrap() {
+                    target::WriteStatus::Stopped(n)
+                    | target::WriteStatus::Restarted(n)
+                    | target::WriteStatus::BufferFull(n) => n,
+                    _ => 0,
+                };
                 defmt::info!("T [W]: {:02x} <- {:02x}", _addr, buf[..count]);
             }
             _ => {}

--- a/examples/mcxa5xx/src/bin/i2c-target-async.rs
+++ b/examples/mcxa5xx/src/bin/i2c-target-async.rs
@@ -40,11 +40,21 @@ async fn main(_spawner: Spawner) {
         match request {
             target::Request::Read(_addr) => {
                 buf.fill(0x55);
-                let count = target.async_respond_to_read(&buf).await.unwrap();
+                let count = match target.async_respond_to_read(&buf).await.unwrap() {
+                    target::ReadStatus::Complete(n)
+                    | target::ReadStatus::NeedMore(n)
+                    | target::ReadStatus::EarlyStop(n) => n,
+                    _ => 0,
+                };
                 defmt::info!("T [R]: {:02x} -> {:02x}", _addr, buf[..count]);
             }
             target::Request::Write(_addr) => {
-                let count = target.async_respond_to_write(&mut buf).await.unwrap();
+                let count = match target.async_respond_to_write(&mut buf).await.unwrap() {
+                    target::WriteStatus::Stopped(n)
+                    | target::WriteStatus::Restarted(n)
+                    | target::WriteStatus::BufferFull(n) => n,
+                    _ => 0,
+                };
                 defmt::info!("T [W]: {:02x} <- {:02x}", _addr, buf[..count]);
             }
             _ => {}

--- a/examples/mcxa5xx/src/bin/i2c-target-blocking.rs
+++ b/examples/mcxa5xx/src/bin/i2c-target-blocking.rs
@@ -32,11 +32,21 @@ async fn main(_spawner: Spawner) {
         match request {
             target::Request::Read(_addr) => {
                 buf.fill(0x55);
-                let count = target.blocking_respond_to_read(&buf).unwrap();
+                let count = match target.blocking_respond_to_read(&buf).unwrap() {
+                    target::ReadStatus::Complete(n)
+                    | target::ReadStatus::NeedMore(n)
+                    | target::ReadStatus::EarlyStop(n) => n,
+                    _ => 0,
+                };
                 defmt::info!("T [R]: {:02x} -> {:02x}", _addr, buf[..count]);
             }
             target::Request::Write(_addr) => {
-                let count = target.blocking_respond_to_write(&mut buf).unwrap();
+                let count = match target.blocking_respond_to_write(&mut buf).unwrap() {
+                    target::WriteStatus::Stopped(n)
+                    | target::WriteStatus::Restarted(n)
+                    | target::WriteStatus::BufferFull(n) => n,
+                    _ => 0,
+                };
                 defmt::info!("T [W]: {:02x} <- {:02x}", _addr, buf[..count]);
             }
             _ => {}

--- a/examples/mcxa5xx/src/bin/i2c-target-dma.rs
+++ b/examples/mcxa5xx/src/bin/i2c-target-dma.rs
@@ -42,11 +42,21 @@ async fn main(_spawner: Spawner) {
         match request {
             target::Request::Read(_addr) => {
                 buf.fill(0x55);
-                let count = target.async_respond_to_read(&buf).await.unwrap();
+                let count = match target.async_respond_to_read(&buf).await.unwrap() {
+                    target::ReadStatus::Complete(n)
+                    | target::ReadStatus::NeedMore(n)
+                    | target::ReadStatus::EarlyStop(n) => n,
+                    _ => 0,
+                };
                 defmt::info!("T [R]: {:02x} -> {:02x}", _addr, buf[..count]);
             }
             target::Request::Write(_addr) => {
-                let count = target.async_respond_to_write(&mut buf).await.unwrap();
+                let count = match target.async_respond_to_write(&mut buf).await.unwrap() {
+                    target::WriteStatus::Stopped(n)
+                    | target::WriteStatus::Restarted(n)
+                    | target::WriteStatus::BufferFull(n) => n,
+                    _ => 0,
+                };
                 defmt::info!("T [W]: {:02x} <- {:02x}", _addr, buf[..count]);
             }
             _ => {}

--- a/examples/mcxa5xx/src/bin/i2c-target-stress-async.rs
+++ b/examples/mcxa5xx/src/bin/i2c-target-stress-async.rs
@@ -92,7 +92,13 @@ async fn main(_spawner: Spawner) {
         match req {
             target::Request::Write(_) => {
                 match tgt.async_respond_to_write(&mut wbuf).await {
-                    Ok(n) => {
+                    Ok(status) => {
+                        let n = match status {
+                            target::WriteStatus::Stopped(n)
+                            | target::WriteStatus::Restarted(n)
+                            | target::WriteStatus::BufferFull(n) => n,
+                            _ => 0,
+                        };
                         n_w = n_w.wrapping_add(1);
                         bytes_w = bytes_w.wrapping_add(n as u64);
                         // First byte = new register pointer; subsequent
@@ -118,7 +124,13 @@ async fn main(_spawner: Spawner) {
                     rbuf[k] = regs[off];
                 }
                 match tgt.async_respond_to_read(&rbuf).await {
-                    Ok(n) => {
+                    Ok(status) => {
+                        let n = match status {
+                            target::ReadStatus::Complete(n)
+                            | target::ReadStatus::NeedMore(n)
+                            | target::ReadStatus::EarlyStop(n) => n,
+                            _ => 0,
+                        };
                         n_r = n_r.wrapping_add(1);
                         bytes_r = bytes_r.wrapping_add(n as u64);
                     }

--- a/examples/mcxa5xx/src/bin/i2c-target-stress-blocking.rs
+++ b/examples/mcxa5xx/src/bin/i2c-target-stress-blocking.rs
@@ -73,7 +73,13 @@ async fn main(_spawner: Spawner) {
 
         match req {
             target::Request::Write(_) => match tgt.blocking_respond_to_write(&mut wbuf) {
-                Ok(n) => {
+                Ok(status) => {
+                    let n = match status {
+                        target::WriteStatus::Stopped(n)
+                        | target::WriteStatus::Restarted(n)
+                        | target::WriteStatus::BufferFull(n) => n,
+                        _ => 0,
+                    };
                     n_w = n_w.wrapping_add(1);
                     bytes_w = bytes_w.wrapping_add(n as u64);
                     if n >= 1 {
@@ -95,7 +101,13 @@ async fn main(_spawner: Spawner) {
                     rbuf[k] = regs[off];
                 }
                 match tgt.blocking_respond_to_read(&rbuf) {
-                    Ok(n) => {
+                    Ok(status) => {
+                        let n = match status {
+                            target::ReadStatus::Complete(n)
+                            | target::ReadStatus::NeedMore(n)
+                            | target::ReadStatus::EarlyStop(n) => n,
+                            _ => 0,
+                        };
                         n_r = n_r.wrapping_add(1);
                         bytes_r = bytes_r.wrapping_add(n as u64);
                     }

--- a/examples/mcxa5xx/src/bin/i2c-target-stress-dma.rs
+++ b/examples/mcxa5xx/src/bin/i2c-target-stress-dma.rs
@@ -82,7 +82,13 @@ async fn main(_spawner: Spawner) {
 
         match req {
             target::Request::Write(_) => match tgt.async_respond_to_write(&mut wbuf).await {
-                Ok(n) => {
+                Ok(status) => {
+                    let n = match status {
+                        target::WriteStatus::Stopped(n)
+                        | target::WriteStatus::Restarted(n)
+                        | target::WriteStatus::BufferFull(n) => n,
+                        _ => 0,
+                    };
                     n_w = n_w.wrapping_add(1);
                     bytes_w = bytes_w.wrapping_add(n as u64);
                     if n >= 1 {
@@ -104,7 +110,13 @@ async fn main(_spawner: Spawner) {
                     rbuf[k] = regs[off];
                 }
                 match tgt.async_respond_to_read(&rbuf).await {
-                    Ok(n) => {
+                    Ok(status) => {
+                        let n = match status {
+                            target::ReadStatus::Complete(n)
+                            | target::ReadStatus::NeedMore(n)
+                            | target::ReadStatus::EarlyStop(n) => n,
+                            _ => 0,
+                        };
                         n_r = n_r.wrapping_add(1);
                         bytes_r = bytes_r.wrapping_add(n as u64);
                     }

--- a/examples/mcxa5xx/src/i2c_loopback.rs
+++ b/examples/mcxa5xx/src/i2c_loopback.rs
@@ -47,11 +47,21 @@ pub async fn target_task(
         match request {
             Request::Read(addr) => {
                 buf.fill(0x55);
-                let count = tgt.async_respond_to_read(&buf).await.unwrap();
+                let count = match tgt.async_respond_to_read(&buf).await.unwrap() {
+                    target::ReadStatus::Complete(n)
+                    | target::ReadStatus::NeedMore(n)
+                    | target::ReadStatus::EarlyStop(n) => n,
+                    _ => 0,
+                };
                 defmt::trace!("[T R {:02x}] -> {:02x}", addr, buf[..count]);
             }
             Request::Write(addr) => {
-                let count = tgt.async_respond_to_write(&mut buf).await.unwrap();
+                let count = match tgt.async_respond_to_write(&mut buf).await.unwrap() {
+                    target::WriteStatus::Stopped(n)
+                    | target::WriteStatus::Restarted(n)
+                    | target::WriteStatus::BufferFull(n) => n,
+                    _ => 0,
+                };
                 defmt::trace!("[T W {:02x}] <- {:02x}", addr, buf[..count]);
             }
             _ => {}

--- a/tests/mcxa2xx/Cargo.toml
+++ b/tests/mcxa2xx/Cargo.toml
@@ -17,6 +17,7 @@ defmt-rtt = "1.0"
 
 embassy-embedded-hal = { version = "0.6.0", path = "../../embassy-embedded-hal" }
 embassy-executor = { version = "0.10.0", path = "../../embassy-executor", features = ["platform-cortex-m", "executor-interrupt", "executor-thread"], default-features = false }
+embassy-futures = { version = "0.1.2", path = "../../embassy-futures" }
 embassy-mcxa = { version = "0.1.0", path = "../../embassy-mcxa", features = ["defmt", "unstable-pac", "mcxa2xx"] }
 embassy-sync = { version = "0.8.0", path = "../../embassy-sync" }
 embassy-time = { version = "0.5.1", path = "../../embassy-time", features = ["defmt", "defmt-timestamp-uptime"] }

--- a/tests/mcxa2xx/src/bin/i2c.rs
+++ b/tests/mcxa2xx/src/bin/i2c.rs
@@ -1,4 +1,9 @@
-//! I2c controller + target
+//! I2c controller + target (Async and DMA variants).
+//!
+//! Runs the same controller-side script twice against the same target
+//! LPI2C instance: first with an Async-mode target, then with a DMA-mode
+//! target. Reusing peripherals across phases via `reborrow()` keeps the
+//! board wiring constant.
 
 #![no_std]
 #![no_main]
@@ -6,7 +11,7 @@
 teleprobe_meta::target!(b"frdm-mcx-a266");
 
 use embassy_executor::Spawner;
-use embassy_mcxa::i2c::Async;
+use embassy_futures::select::{Either, select};
 use hal::bind_interrupts;
 use hal::clocks::config::Div8;
 use hal::config::Config;
@@ -22,28 +27,131 @@ bind_interrupts!(
 );
 
 #[embassy_executor::main]
-async fn main(spawner: Spawner) {
+async fn main(_spawner: Spawner) {
     let mut config = Config::default();
     config.clock_cfg.sirc.fro_lf_div = Div8::from_divisor(1);
 
-    let p = hal::init(config);
+    let mut p = hal::init(config);
 
     defmt::info!("I2C controller + target test");
 
-    let mut config = target::Config::default();
-    config.address = target::Address::Dual(0x13, 0x37);
+    // ---- Phase 1: Async target ----
+    defmt::info!("---- Phase 1: Async target ----");
+    {
+        let mut tcfg = target::Config::default();
+        tcfg.address = target::Address::Dual(0x13, 0x37);
+        let mut target =
+            target::I2c::new_async(p.LPI2C1.reborrow(), p.P1_1.reborrow(), p.P1_0.reborrow(), Irqs, tcfg).unwrap();
 
-    let target = target::I2c::new_async(p.LPI2C1, p.P1_1, p.P1_0, Irqs, config).unwrap();
+        let mut i2c = controller::I2c::new_async(
+            p.LPI2C2.reborrow(),
+            p.P1_9.reborrow(),
+            p.P1_8.reborrow(),
+            Irqs,
+            controller::Config::default(),
+        )
+        .unwrap();
 
-    spawner.spawn(target_task(target).unwrap());
+        let mut addr0_value = [0u8];
+        let mut addr1_value = [0u8];
+        let target_fut = async {
+            loop {
+                defmt::debug!("Target listen");
+                let request = target.async_listen().await.unwrap();
+                defmt::info!("Received event {}", request);
 
-    // Await for the target task to have started listening.
-    embassy_time::Timer::after_millis(10).await;
+                match request {
+                    target::Request::Read(0x13) => {
+                        defmt::dbg!(target.async_respond_to_read(&addr0_value).await.unwrap());
+                    }
+                    target::Request::Read(0x37) => {
+                        target.async_respond_to_read(&addr1_value).await.unwrap();
+                    }
+                    target::Request::Write(0x13) => {
+                        target.async_respond_to_write(&mut addr0_value).await.unwrap();
+                    }
+                    target::Request::Write(0x37) => {
+                        target.async_respond_to_write(&mut addr1_value).await.unwrap();
+                    }
+                    _ => {}
+                }
+            }
+        };
 
-    let config = controller::Config::default();
-    let mut i2c = controller::I2c::new_async(p.LPI2C2, p.P1_9, p.P1_8, Irqs, config).unwrap();
+        match select(target_fut, controller_script(&mut i2c)).await {
+            Either::First(_) => defmt::panic!("target loop exited unexpectedly"),
+            Either::Second(_) => {}
+        }
+    }
 
-    let mut buf = [0];
+    // ---- Phase 2: DMA target ----
+    defmt::info!("---- Phase 2: DMA target ----");
+    {
+        let mut tcfg = target::Config::default();
+        tcfg.address = target::Address::Dual(0x13, 0x37);
+        let mut target = target::I2c::new_async_with_dma(
+            p.LPI2C1.reborrow(),
+            p.P1_1.reborrow(),
+            p.P1_0.reborrow(),
+            p.DMA0_CH0.reborrow(),
+            p.DMA0_CH1.reborrow(),
+            Irqs,
+            tcfg,
+        )
+        .unwrap();
+
+        let mut i2c = controller::I2c::new_async(
+            p.LPI2C2.reborrow(),
+            p.P1_9.reborrow(),
+            p.P1_8.reborrow(),
+            Irqs,
+            controller::Config::default(),
+        )
+        .unwrap();
+
+        let mut addr0_value = [0u8];
+        let mut addr1_value = [0u8];
+        let target_fut = async {
+            loop {
+                defmt::debug!("Target listen");
+                let request = target.async_listen().await.unwrap();
+                defmt::info!("Received event {}", request);
+
+                match request {
+                    target::Request::Read(0x13) => {
+                        defmt::dbg!(target.async_respond_to_read(&addr0_value).await.unwrap());
+                    }
+                    target::Request::Read(0x37) => {
+                        target.async_respond_to_read(&addr1_value).await.unwrap();
+                    }
+                    target::Request::Write(0x13) => {
+                        target.async_respond_to_write(&mut addr0_value).await.unwrap();
+                    }
+                    target::Request::Write(0x37) => {
+                        target.async_respond_to_write(&mut addr1_value).await.unwrap();
+                    }
+                    _ => {}
+                }
+            }
+        };
+
+        match select(target_fut, controller_script(&mut i2c)).await {
+            Either::First(_) => defmt::panic!("target loop exited unexpectedly"),
+            Either::Second(_) => {}
+        }
+    }
+
+    defmt::info!("Test OK");
+    cortex_m::asm::bkpt();
+}
+
+async fn controller_script(i2c: &mut controller::I2c<'_, hal::i2c::Async>) {
+    // Give the target side time to enter `async_listen` and arm its
+    // interrupts before the first START. Without this the target can
+    // miss the very first address match of a phase.
+    embassy_time::Timer::after_millis(250).await;
+
+    let mut buf = [0u8];
 
     defmt::info!("Write read 0x13");
     i2c.async_write_read(0x13, &[13], &mut buf).await.unwrap();
@@ -62,35 +170,4 @@ async fn main(spawner: Spawner) {
     defmt::info!("Write 0x01");
     let error = i2c.async_write(0x01, &[0]).await.unwrap_err();
     assert_eq!(error, controller::IOError::AddressNack);
-
-    defmt::info!("Test OK");
-    cortex_m::asm::bkpt();
-}
-
-#[embassy_executor::task]
-async fn target_task(mut target: target::I2c<'static, Async>) {
-    let mut addr0_value = [0];
-    let mut addr1_value = [0];
-
-    loop {
-        defmt::debug!("Target listen");
-        let request = target.async_listen().await.unwrap();
-        defmt::info!("Received event {}", request);
-
-        match request {
-            target::Request::Read(0x13) => {
-                defmt::dbg!(target.async_respond_to_read(&addr0_value).await.unwrap());
-            }
-            target::Request::Read(0x37) => {
-                target.async_respond_to_read(&addr1_value).await.unwrap();
-            }
-            target::Request::Write(0x13) => {
-                target.async_respond_to_write(&mut addr0_value).await.unwrap();
-            }
-            target::Request::Write(0x37) => {
-                target.async_respond_to_write(&mut addr1_value).await.unwrap();
-            }
-            _ => {}
-        }
-    }
 }


### PR DESCRIPTION
The unconditional zero-padding loop added to async_respond_to_read in 26a8afb30 ("pad TX with zeros until controller ends read") waits for SDF/RSF before returning. In back-to-back transactions, the firmware falls behind: a subsequent async_listen returns the stale first address-match, and async_respond_to_write then waits for RDF that will never fire because the bus has already advanced to the READ phase, so the target deadlocks.

Replace the per-op usize return with richer status enums modelled on embedded-mcu-hal::i2c::target:

  ReadStatus  := Complete(n) | NeedMore(n) | EarlyStop(n)
  WriteStatus := Stopped(n)  | Restarted(n) | BufferFull(n)

Each respond_to_* call now services the transfer to a clean termination point and tells the caller why it ended. NeedMore signals "controller wants more bytes than the buffer holds" so the caller can decide what to send next (more real data, fill bytes, or accept the bus stretching until something else terminates the transfer). No automatic padding.

Applied consistently to blocking, async, and DMA modes:

  * Blocking: busy-loop on tdf|sdf|rsf; map exit cause to a variant.
  * Async: drop the padding loop; one post-buffer wait_for to map to Complete / NeedMore / EarlyStop.
  * DMA: rewrite read_dma_chunk / write_dma_chunk with a dual-wake poll_fn that registers on both the DMA channel's wait_cell and the I2C peripheral's wait_cell. Switch the TX-side TCD from NO_INTERRUPTS to COMPLETE_INTERRUPT so DMA exhaustion can wake the task and surface NeedMore / BufferFull when the controller wants past the chunk. Outer respond_to_* aggregates per-chunk outcomes.

Test:

  tests/mcxa2xx/src/bin/i2c.rs now runs the controller script twice
  back-to-back against the same target peripheral, reborrowed first for
  new_async then for new_async_with_dma, racing the target loop and the
  controller script via embassy_futures::select. A 250 ms warm-up at
  the top of the controller script ensures the target side has armed
  its interrupts before the first START.

  Before: timeout (hang) on the second transaction.
  After:  Test OK in ~511 ms on FRDM-MCX-A266.

All in-tree examples migrated to the new return types.