### PR TITLE
stm32/adc: clean up transfer opts

### DIFF
--- a/embassy-stm32/src/adc/ringbuffered.rs
+++ b/embassy-stm32/src/adc/ringbuffered.rs
@@ -30,21 +30,7 @@ impl<'d, R: AdcRegs> RingBufferedAdc<'d, R> {
         dma_buf: &'d mut [u16],
         sequence_len: usize,
     ) -> Self {
-        // DMA side setup - configuration differs between DMA/BDMA and GPDMA
-        // For DMA/BDMA: use circular mode via TransferOptions
-        // For GPDMA: circular mode is achieved via linked-list ping-pong
-        #[cfg(not(gpdma))]
-        let opts = TransferOptions {
-            half_transfer_ir: true,
-            circular: true,
-            ..Default::default()
-        };
-
-        #[cfg(gpdma)]
-        let opts = TransferOptions {
-            half_transfer_ir: true,
-            ..Default::default()
-        };
+        let opts = Default::default();
 
         // Safety: we forget the struct before this function returns.
         let request = dma.request();


### PR DESCRIPTION
These options are already set inside `ReadableRingBuffer::new` by all implementations.

DMA/BDMA:
https://github.com/embassy-rs/embassy/blob/ea4afe2550c20ac497e6290a48a319ee885c7454/embassy-stm32/src/dma/dma_bdma.rs#L1274-L1276

GPDMA:
https://github.com/embassy-rs/embassy/blob/ea4afe2550c20ac497e6290a48a319ee885c7454/embassy-stm32/src/dma/gpdma/ringbuffered.rs#L105-L106

Ring buffered UART also uses default options:
https://github.com/embassy-rs/embassy/blob/ea4afe2550c20ac497e6290a48a319ee885c7454/embassy-stm32/src/usart/ringbuffered.rs#L107