### PR TITLE
esp-hosted: Transfer data in place

### DIFF
--- a/embassy-net-esp-hosted/CHANGELOG.md
+++ b/embassy-net-esp-hosted/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 <!-- next-header -->
 ## Unreleased - ReleaseDate
 
+- `Interface::transfer` now exchanges the buffer in place.
+
 ## 0.3.0 - 2026-03-10
 
 - Add an `Interface` trait to allow using other interface transports.

--- a/embassy-net-esp-hosted/src/control.rs
+++ b/embassy-net-esp-hosted/src/control.rs
@@ -155,7 +155,7 @@ impl<'a> Control<'a> {
 
     /// Write slice of firmware to a device.
     ///
-    /// [`ota_begin`] must be called first.
+    /// [`ota_begin`][Self::ota_begin] must be called first.
     ///
     /// The slice is split into chunks that can be sent across
     /// the ioctl protocol to the wifi adapter.
@@ -171,7 +171,7 @@ impl<'a> Control<'a> {
 
     /// End the OTA session.
     ///
-    /// [`ota_begin`] must be called first.
+    /// [`ota_begin`][Self::ota_begin] must be called first.
     ///
     /// NOTE: Will reset the wifi adapter after 5 seconds.
     pub async fn ota_end(&mut self) -> Result<(), Error> {

--- a/embassy-net-esp-hosted/src/iface.rs
+++ b/embassy-net-esp-hosted/src/iface.rs
@@ -11,8 +11,8 @@ pub trait Interface {
     /// Wait for the READY signal indicating the ESP has data to send.
     async fn wait_for_ready(&mut self);
 
-    /// Perform a SPI transfer, exchanging data with the ESP chip.
-    async fn transfer(&mut self, rx: &mut [u8], tx: &[u8]);
+    /// Perform a transfer, exchanging data with the ESP chip.
+    async fn transfer(&mut self, buffer: &mut [u8]);
 }
 
 /// Standard SPI interface.
@@ -51,8 +51,8 @@ where
         self.ready.wait_for_high().await.unwrap();
     }
 
-    async fn transfer(&mut self, rx: &mut [u8], tx: &[u8]) {
-        self.spi.transfer(rx, tx).await.unwrap();
+    async fn transfer(&mut self, buffer: &mut [u8]) {
+        self.spi.transfer_in_place(buffer).await.unwrap();
 
         // The esp-hosted firmware deasserts the HANDSHAKE pin a few us AFTER ending the SPI transfer
         // If we check it again too fast, we'll see it's high from the previous transfer, and if we send it

--- a/embassy-net-esp-hosted/src/ioctl.rs
+++ b/embassy-net-esp-hosted/src/ioctl.rs
@@ -57,27 +57,24 @@ impl Shared {
         })
     }
 
-    pub async fn ioctl_wait_pending(&self) -> PendingIoctl {
-        let pending = poll_fn(|cx| {
+    pub fn ioctl_wait_pending(&self) -> impl Future<Output = PendingIoctl> + '_ {
+        poll_fn(|cx| {
             let mut this = self.0.borrow_mut();
             if let IoctlState::Pending(pending) = this.ioctl {
+                this.ioctl = IoctlState::Sent { buf: pending.buf };
                 Poll::Ready(pending)
             } else {
                 this.runner_waker.register(cx.waker());
                 Poll::Pending
             }
         })
-        .await;
-
-        self.0.borrow_mut().ioctl = IoctlState::Sent { buf: pending.buf };
-        pending
     }
 
     pub fn ioctl_cancel(&self) {
         self.0.borrow_mut().ioctl = IoctlState::Done { resp_len: 0 };
     }
 
-    pub async fn ioctl(&self, buf: &mut [u8], req_len: usize) -> usize {
+    pub fn ioctl(&self, buf: &mut [u8], req_len: usize) -> impl Future<Output = usize> + '_ {
         trace!("ioctl req bytes: {:02x}", Bytes(&buf[..req_len]));
 
         {
@@ -86,7 +83,7 @@ impl Shared {
             this.runner_waker.wake();
         }
 
-        self.ioctl_wait_complete().await
+        self.ioctl_wait_complete()
     }
 
     pub fn ioctl_done(&self, response: &[u8]) {

--- a/embassy-net-esp-hosted/src/lib.rs
+++ b/embassy-net-esp-hosted/src/lib.rs
@@ -180,8 +180,7 @@ where
         self.reset.set_high().unwrap();
         Timer::after_millis(1000).await;
 
-        let mut tx_buf = [0u8; MAX_SPI_BUFFER_SIZE];
-        let mut rx_buf = [0u8; MAX_SPI_BUFFER_SIZE];
+        let mut buffer = [0u8; MAX_SPI_BUFFER_SIZE];
 
         loop {
             self.iface.wait_for_handshake().await;
@@ -193,9 +192,9 @@ where
 
             match select4(ioctl, tx, ev, hb).await {
                 Either4::First(PendingIoctl { buf, req_len }) => {
-                    tx_buf[12..24].copy_from_slice(b"\x01\x08\x00ctrlResp\x02");
-                    tx_buf[24..26].copy_from_slice(&(req_len as u16).to_le_bytes());
-                    tx_buf[26..][..req_len].copy_from_slice(&unsafe { &*buf }[..req_len]);
+                    buffer[12..24].copy_from_slice(b"\x01\x08\x00ctrlResp\x02");
+                    buffer[24..26].copy_from_slice(&(req_len as u16).to_le_bytes());
+                    buffer[26..][..req_len].copy_from_slice(&unsafe { &*buf }[..req_len]);
 
                     let mut header = PayloadHeader {
                         if_type_and_num: InterfaceType::Serial as _,
@@ -207,12 +206,12 @@ where
                     self.next_seq = self.next_seq.wrapping_add(1);
 
                     // Calculate checksum
-                    tx_buf[0..12].copy_from_slice(&header.to_bytes());
-                    header.checksum = checksum(&tx_buf[..26 + req_len]);
-                    tx_buf[0..12].copy_from_slice(&header.to_bytes());
+                    buffer[0..12].copy_from_slice(&header.to_bytes());
+                    header.checksum = checksum(&buffer[..26 + req_len]);
+                    buffer[0..12].copy_from_slice(&header.to_bytes());
                 }
                 Either4::Second(packet) => {
-                    tx_buf[12..][..packet.len()].copy_from_slice(&packet);
+                    buffer[12..][..packet.len()].copy_from_slice(&packet);
 
                     let mut header = PayloadHeader {
                         if_type_and_num: InterfaceType::Sta as _,
@@ -224,14 +223,14 @@ where
                     self.next_seq = self.next_seq.wrapping_add(1);
 
                     // Calculate checksum
-                    tx_buf[0..12].copy_from_slice(&header.to_bytes());
-                    header.checksum = checksum(&tx_buf[..12 + packet.len()]);
-                    tx_buf[0..12].copy_from_slice(&header.to_bytes());
+                    buffer[0..12].copy_from_slice(&header.to_bytes());
+                    header.checksum = checksum(&buffer[..12 + packet.len()]);
+                    buffer[0..12].copy_from_slice(&header.to_bytes());
 
                     packet.tx_done();
                 }
                 Either4::Third(()) => {
-                    tx_buf[..PayloadHeader::SIZE].fill(0);
+                    buffer[..PayloadHeader::SIZE].fill(0);
                 }
                 Either4::Fourth(()) => {
                     // Extend the deadline if initializing
@@ -243,13 +242,13 @@ where
                 }
             }
 
-            if tx_buf[0] != 0 {
-                trace!("tx: {:02x}", &tx_buf[..40]);
+            if buffer[0] != 0 {
+                trace!("tx: {:02x}", &buffer[..40]);
             }
 
-            self.iface.transfer(&mut rx_buf, &tx_buf).await;
+            self.iface.transfer(&mut buffer).await;
 
-            self.handle_rx(&mut rx_buf);
+            self.handle_rx(&mut buffer);
         }
     }
 

--- a/embassy-net-esp-hosted/src/lib.rs
+++ b/embassy-net-esp-hosted/src/lib.rs
@@ -187,7 +187,7 @@ where
 
             let ioctl = self.shared.ioctl_wait_pending();
             let tx = self.ch.tx_buf();
-            let ev = async { self.iface.wait_for_ready().await };
+            let ev = self.iface.wait_for_ready();
             let hb = Timer::at(self.heartbeat_deadline);
 
             match select4(ioctl, tx, ev, hb).await {
@@ -277,7 +277,7 @@ where
             return;
         }
 
-        let payload = &mut buf[PayloadHeader::SIZE..][..payload_len];
+        let payload = &buf[PayloadHeader::SIZE..][..payload_len];
 
         match if_type_and_num & 0x0f {
             // STA


### PR DESCRIPTION
We don't need two buffers, every interface can copy data into the transmit buffer after the host is done writing. Also includes a bit of cleanup to save on code size.