### PR TITLE
Fix some more C5 related errors

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -20,11 +20,11 @@
   //"rust-analyzer.cargo.target": "thumbv8m.main-none-eabihf",
   "rust-analyzer.cargo.features": [
     // Comment out these features when working on the examples. Most example crates do not have any cargo features.
-    "stm32f107rb",
-    "time-driver-any",
-    "unstable-pac",
-    "exti",
-    "rt",
+    //"stm32f107rb",
+    //"time-driver-any",
+    //"unstable-pac",
+    //"exti",
+    //"rt",
   ],
   "rust-analyzer.linkedProjects": [
     "embassy-stm32/Cargo.toml",
@@ -45,6 +45,7 @@
     // "examples/rp/Cargo.toml",
     // "examples/std/Cargo.toml",
     // "examples/stm32c0/Cargo.toml",
+    "examples/stm32c5/Cargo.toml",
     // "examples/stm32f0/Cargo.toml",
     // "examples/stm32f1/Cargo.toml",
     // "examples/stm32f2/Cargo.toml",
@@ -53,7 +54,7 @@
     // "examples/stm32f4/Cargo.toml",
     // "examples/stm32f7/Cargo.toml",
     // "examples/stm32g0/Cargo.toml",
-    // "examples/stm32g4/Cargo.toml",
+    //"examples/stm32g474/Cargo.toml",
     // "examples/stm32h5/Cargo.toml",
     // "examples/stm32h7/Cargo.toml",
     // "examples/stm32l0/Cargo.toml",

--- a/embassy-stm32/Cargo.toml
+++ b/embassy-stm32/Cargo.toml
@@ -126,6 +126,7 @@ flavors = [
     { regex_feature = "stm32f7[67]..[ig]", target = "thumbv7em-none-eabi", features = ["dual-bank"] },
     { regex_feature = "stm32f7.*", target = "thumbv7em-none-eabi" },
     { regex_feature = "stm32c0.*", target = "thumbv6m-none-eabi" },
+    { regex_feature = "stm32c5.*", target = "thumbv8m.main-none-eabihf" },
     { regex_feature = "stm32g0...c", target = "thumbv6m-none-eabi", features = ["dual-bank"] },
     { regex_feature = "stm32g0.*", target = "thumbv6m-none-eabi" },
     { regex_feature = "stm32g4[78].*", target = "thumbv7em-none-eabi", features = ["low-power", "dual-bank"] },

--- a/embassy-stm32/build.rs
+++ b/embassy-stm32/build.rs
@@ -2262,6 +2262,9 @@ fn main() {
                         return Ok(f.simplify());
                     }
                 }
+                if n.contains("Disabled") {
+                    return Ok(Frac { num: 0, denom: 1 });
+                }
                 Err(())
             }
 

--- a/embassy-stm32/src/gpio.rs
+++ b/embassy-stm32/src/gpio.rs
@@ -839,7 +839,7 @@ pub(crate) trait SealedPin {
 pub type PinNumber = u8;
 
 /// Pin that can be used to configure an [ExtiInput](crate::exti::ExtiInput). This trait is lost when converting to [AnyPin].
-#[cfg(feature = "exti")]
+#[cfg(all(feature = "exti", not(stm32c5)))]
 #[allow(private_bounds)]
 pub trait ExtiPin: PeripheralType + SealedPin {
     /// EXTI channel assigned to this pin.

--- a/embassy-stm32/src/lib.rs
+++ b/embassy-stm32/src/lib.rs
@@ -45,11 +45,14 @@ pub mod mode {
 }
 
 // Always-present hardware
+#[cfg(not(stm32c5))]
 pub mod dma;
 pub mod gpio;
 pub mod rcc;
-#[cfg(feature = "_time-driver")]
+#[cfg(all(feature = "_time-driver", not(stm32c5)))]
 mod time_driver;
+
+#[cfg(not(stm32c5))]
 pub mod timer;
 
 // Sometimes-present hardware
@@ -64,7 +67,7 @@ pub mod backup_sram;
 pub mod can;
 #[cfg(any(comp_u5, comp_v1, comp_v2))]
 pub mod comp;
-#[cfg(cordic)]
+#[cfg(all(cordic, not(stm32c5)))]
 pub mod cordic;
 
 #[cfg(not(any(comp_u5, comp_v1, comp_v2)))]
@@ -116,9 +119,9 @@ pub mod dsihost;
 pub mod dts;
 #[cfg(eth)]
 pub mod eth;
-#[cfg(feature = "exti")]
+#[cfg(all(feature = "exti", not(stm32c5)))]
 pub mod exti;
-#[cfg(flash)]
+#[cfg(all(flash, not(stm32c5)))]
 pub mod flash;
 #[cfg(fmac)]
 pub mod fmac;
@@ -750,11 +753,14 @@ fn init_hw(config: Config) -> Peripherals {
         #[cfg(any(stm32h7rs))]
         // On the H7RS the SYSCFG should not be reset if it is already enabled. This is typically the case when running from external flash and the bootloader enables the SYSCFG.
         rcc::enable_with_cs::<peripherals::SYSCFG>(cs);
-        #[cfg(not(any(stm32f1, stm32wb, stm32wl, stm32h7rs)))]
+        #[cfg(not(any(stm32f1, stm32wb, stm32wl, stm32h7rs, stm32c5)))] // TODO: stm32C5
         rcc::enable_and_reset_with_cs::<peripherals::SYSCFG>(cs);
         #[cfg(not(any(stm32h5, stm32h7, stm32h7rs, stm32wb, stm32wl)))]
         rcc::enable_and_reset_with_cs::<peripherals::PWR>(cs);
-        #[cfg(all(flash, not(any(stm32f2, stm32f4, stm32f7, stm32l0, stm32h5, stm32h7, stm32h7rs))))]
+        #[cfg(all(
+            flash,
+            not(any(stm32f2, stm32f4, stm32f7, stm32l0, stm32h5, stm32h7, stm32h7rs, stm32c5))
+        ))]
         rcc::enable_and_reset_with_cs::<peripherals::FLASH>(cs);
 
         // Enable the VDDIO2 power supply on chips that have it.
@@ -908,6 +914,7 @@ fn init_hw(config: Config) -> Peripherals {
             #[cfg(stm32f1)]
             crate::pac::AFIO.mapr().modify(|w| w.set_swj_cfg(config.swj.into()));
 
+            #[cfg(not(stm32c5))]
             dma::init(
                 cs,
                 #[cfg(bdma)]
@@ -919,7 +926,7 @@ fn init_hw(config: Config) -> Peripherals {
                 #[cfg(mdma)]
                 config.mdma_interrupt_priority,
             );
-            #[cfg(feature = "exti")]
+            #[cfg(all(feature = "exti", not(stm32c5)))]
             exti::init(cs);
 
             rcc::init_rcc(cs, config.rcc);
@@ -929,7 +936,7 @@ fn init_hw(config: Config) -> Peripherals {
             hsem::init_hsem(cs);
 
             // must be after rcc init
-            #[cfg(feature = "_time-driver")]
+            #[cfg(all(feature = "_time-driver", not(stm32c5)))]
             crate::time_driver::init(cs);
 
             // must be after time-driver init

--- a/embassy-stm32/src/rcc/c5.rs
+++ b/embassy-stm32/src/rcc/c5.rs
@@ -1,0 +1,8 @@
+pub use crate::pac::rcc::vals::{Hpre as AHBPrescaler, Ppre as APBPrescaler, Sw as Sysclk};
+
+/// Configuration of the core clocks
+#[non_exhaustive]
+#[derive(Clone, Copy)]
+pub struct Config {}
+
+pub(crate) unsafe fn init(_config: Config) {}

--- a/embassy-stm32/src/rcc/mco.rs
+++ b/embassy-stm32/src/rcc/mco.rs
@@ -97,9 +97,9 @@ use self::{McoSource as Mco1Source, McoSource as Mco2Source};
 
 #[cfg(mco)]
 impl_peri!(MCO, McoSource, set_mcosel, set_mcopre);
-#[cfg(mco1)]
+#[cfg(all(mco1, not(stm32c5)))]
 impl_peri!(MCO1, Mco1Source, set_mco1sel, set_mco1pre);
-#[cfg(mco2)]
+#[cfg(all(mco2, not(stm32c5)))]
 impl_peri!(MCO2, Mco2Source, set_mco2sel, set_mco2pre);
 
 pub struct Mco<'d, T: McoInstance> {

--- a/embassy-stm32/src/rcc/mod.rs
+++ b/embassy-stm32/src/rcc/mod.rs
@@ -5,7 +5,9 @@
 
 use core::mem::MaybeUninit;
 
+#[cfg(not(stm32c5))]
 mod bd;
+#[cfg(not(stm32c5))]
 pub use bd::*;
 
 #[cfg(any(mco, mco1, mco2))]
@@ -25,6 +27,7 @@ pub use hsi48::*;
 #[cfg_attr(any(stm32f0, stm32f1, stm32f3), path = "f013.rs")]
 #[cfg_attr(any(stm32f2, stm32f4, stm32f7), path = "f247.rs")]
 #[cfg_attr(stm32c0, path = "c0.rs")]
+#[cfg_attr(stm32c5, path = "c5.rs")]
 #[cfg_attr(stm32g0, path = "g0.rs")]
 #[cfg_attr(stm32g4, path = "g4.rs")]
 #[cfg_attr(any(stm32h5, stm32h7, stm32h7rs), path = "h.rs")]
@@ -600,7 +603,7 @@ pub fn reinit(config: Config, _rcc: &'_ mut crate::Peri<'_, crate::peripherals::
         init_rcc(cs, config);
 
         // must be after rcc init
-        #[cfg(feature = "_time-driver")]
+        #[cfg(all(feature = "_time-driver", not(stm32c5)))]
         crate::time_driver::init(cs);
     })
 }


### PR DESCRIPTION
Right now we still have

```
error[E0084]: unsupported representation for zero-variant enum
    --> /home/albin/my_projects/embassy/embassy-stm32/target/debug/build/embassy-stm32-7d36e6cf713b62f8/out/_generated.rs:2372:8
     |
2372 | #[repr(u8)]
     |        ^^
2373 | #[allow(non_camel_case_types)]
2374 | pub(crate) enum DmaChannel {}
     | -------------------------- zero-variant enum
```