### PR TITLE
net: add DHCPv4 NTP server (option 42) support

### DIFF
--- a/embassy-net/Cargo.toml
+++ b/embassy-net/Cargo.toml
@@ -20,6 +20,7 @@ build = [
     {target = "thumbv7em-none-eabi", features = ["defmt", "dhcpv4", "dns", "medium-ethernet", "tcp", "udp"]},
     {target = "thumbv7em-none-eabi", features = ["defmt", "dhcpv4", "dhcpv4-hostname", "dns", "medium-ethernet", "tcp", "udp"]},
     {target = "thumbv7em-none-eabi", features = ["defmt", "dhcpv4", "dhcpv4-hostname", "dns", "medium-ethernet", "slaac", "tcp", "udp"]},
+    {target = "thumbv7em-none-eabi", features = ["defmt", "dhcpv4", "dhcpv4-ntp", "dns", "medium-ethernet", "tcp", "udp"]},
     {target = "thumbv7em-none-eabi", features = ["defmt", "dns", "medium-ethernet", "proto-ipv6", "tcp", "udp"]},
     {target = "thumbv7em-none-eabi", features = ["defmt", "dns", "medium-ethernet", "proto-ipv6", "slaac", "tcp", "udp"]},
     {target = "thumbv7em-none-eabi", features = ["defmt", "dns", "medium-ieee802154", "proto-ipv6", "tcp", "udp"]},
@@ -86,6 +87,8 @@ mdns = ["dns", "smoltcp/socket-mdns"]
 dhcpv4 = ["proto-ipv4", "medium-ethernet", "smoltcp/socket-dhcpv4"]
 ## Enable DHCPv4 support with hostname
 dhcpv4-hostname = ["dhcpv4"]
+## Enable parsing of the NTP servers (DHCP option 42) from the DHCP reply
+dhcpv4-ntp = ["dhcpv4"]
 ## Enable IPv4 support
 proto-ipv4 = ["smoltcp/proto-ipv4"]
 ## Enable IPv6 support

--- a/embassy-net/src/lib.rs
+++ b/embassy-net/src/lib.rs
@@ -68,6 +68,8 @@ const LOCAL_PORT_MIN: u16 = 1025;
 const LOCAL_PORT_MAX: u16 = 65535;
 #[cfg(feature = "dns")]
 const MAX_QUERIES: usize = 4;
+#[cfg(feature = "dhcpv4-ntp")]
+const DHCP_RX_BUFFER_SIZE: usize = 576;
 #[cfg(feature = "dhcpv4-hostname")]
 const MAX_HOSTNAME_LEN: usize = 32;
 
@@ -93,6 +95,11 @@ pub struct StackResources<const SOCK: usize> {
     queries: MaybeUninit<[Option<dns::DnsQuery>; MAX_QUERIES]>,
     #[cfg(feature = "dhcpv4-hostname")]
     hostname: HostnameResources,
+    // Retains the raw DHCP reply so options not parsed by smoltcp (NTP servers, option 42) can be
+    // read out. 576 is the minimum DHCP message size every server must respect (RFC 2131); an
+    // undersized buffer never corrupts the IP configuration, it only drops the extra options.
+    #[cfg(feature = "dhcpv4-ntp")]
+    dhcp_rx_buffer: MaybeUninit<[u8; DHCP_RX_BUFFER_SIZE]>,
 }
 
 #[cfg(feature = "dhcpv4-hostname")]
@@ -114,6 +121,8 @@ impl<const SOCK: usize> StackResources<SOCK> {
                 option: MaybeUninit::uninit(),
                 data: MaybeUninit::uninit(),
             },
+            #[cfg(feature = "dhcpv4-ntp")]
+            dhcp_rx_buffer: MaybeUninit::uninit(),
         }
     }
 }
@@ -129,6 +138,9 @@ pub struct StaticConfigV4 {
     pub gateway: Option<Ipv4Address>,
     /// DNS servers.
     pub dns_servers: Vec<Ipv4Address, 3>,
+    /// NTP servers (DHCP option 42).
+    #[cfg(feature = "dhcpv4-ntp")]
+    pub ntp_servers: Vec<Ipv4Address, 4>,
 }
 
 /// Static IPv6 address configuration
@@ -317,6 +329,8 @@ pub(crate) struct Inner {
     dns_waker: WakerRegistration,
     #[cfg(feature = "dhcpv4-hostname")]
     hostname: *mut HostnameResources,
+    #[cfg(feature = "dhcpv4-ntp")]
+    dhcp_rx_buffer: *mut [u8],
 }
 
 fn _assert_covariant<'a, 'b: 'a>(x: Stack<'b>) -> Stack<'a> {
@@ -390,6 +404,8 @@ pub fn new<'d, D: Driver, const SOCK: usize>(
         dns_waker: WakerRegistration::new(),
         #[cfg(feature = "dhcpv4-hostname")]
         hostname: &mut resources.hostname,
+        #[cfg(feature = "dhcpv4-ntp")]
+        dhcp_rx_buffer: resources.dhcp_rx_buffer.write([0; DHCP_RX_BUFFER_SIZE]) as *mut [u8],
     };
 
     #[cfg(feature = "proto-ipv4")]
@@ -401,6 +417,36 @@ pub fn new<'d, D: Driver, const SOCK: usize>(
     let inner = &*resources.inner.write(RefCell::new(inner));
     let stack = Stack { inner };
     (stack, Runner { driver, stack })
+}
+
+/// Parse the NTP servers (DHCP option 42) out of the raw DHCP reply retained by smoltcp.
+///
+/// smoltcp does not parse this option itself; it only exposes the raw packet (when a receive
+/// buffer is set), leaving it to consumers to read out the options they care about.
+#[cfg(feature = "dhcpv4-ntp")]
+fn parse_dhcp_ntp_servers(config: &dhcpv4::Config) -> Vec<Ipv4Address, 4> {
+    /// DHCP option code for NTP servers (RFC 2132 §8.3). Length is a multiple of 4, one address each.
+    const OPT_NTP_SERVERS: u8 = 42;
+
+    let mut servers = Vec::new();
+    let Some(packet) = config.packet.as_ref() else {
+        return servers;
+    };
+    for option in packet.options() {
+        if option.kind != OPT_NTP_SERVERS {
+            continue;
+        }
+        for chunk in option.data.chunks_exact(4) {
+            // Drop any servers past our capacity, like smoltcp does for DNS servers.
+            if servers
+                .push(Ipv4Address::from_octets(chunk.try_into().unwrap()))
+                .is_err()
+            {
+                break;
+            }
+        }
+    }
+    servers
 }
 
 fn to_smoltcp_hardware_address(addr: driver::HardwareAddress) -> (HardwareAddress, Medium) {
@@ -719,7 +765,18 @@ impl Inner {
             ConfigV4::Dhcp(c) => {
                 // Create the socket if it doesn't exist.
                 if self.dhcp_socket.is_none() {
-                    let socket = smoltcp::socket::dhcpv4::Socket::new();
+                    #[allow(unused_mut)]
+                    let mut socket = smoltcp::socket::dhcpv4::Socket::new();
+
+                    #[cfg(feature = "dhcpv4-ntp")]
+                    {
+                        // smoltcp doesn't parse options it doesn't know about (e.g. NTP), but it can
+                        // retain the raw reply so we can read them out. safety: this pointer lives as
+                        // long as the stack, since `new()` borrows the resources for `'d`.
+                        let buffer = unsafe { &mut *self.dhcp_rx_buffer };
+                        socket.set_receive_packet_buffer(buffer);
+                    }
+
                     let handle = self.sockets.add(socket);
                     self.dhcp_socket = Some(handle);
                 }
@@ -923,10 +980,14 @@ impl Inner {
                             true
                         }
                         Some(dhcpv4::Event::Configured(config)) => {
+                            #[cfg(feature = "dhcpv4-ntp")]
+                            let ntp_servers = parse_dhcp_ntp_servers(&config);
                             self.static_v4 = Some(StaticConfigV4 {
                                 address: config.address,
                                 gateway: config.router,
                                 dns_servers: config.dns_servers,
+                                #[cfg(feature = "dhcpv4-ntp")]
+                                ntp_servers,
                             });
                             true
                         }


### PR DESCRIPTION
## Summary

Adds support for reading the NTP servers DHCP option (option 42) in `embassy-net`, behind a new opt-in `dhcpv4-ntp` feature.

When enabled, the obtained `StaticConfigV4` gains an `ntp_servers: Vec<Ipv4Address, 4>` field, populated from the DHCP lease and surfaced through the existing `Stack::config_v4()`.

### Why a dedicated feature / receive buffer

smoltcp deliberately does not parse this option into its `dhcpv4::Config` — per [smoltcp-rs/smoltcp#972](https://github.com/smoltcp-rs/smoltcp/pull/972), the maintainers' position is that adding a field for every possible option does not scale, and the supported way to read additional options is the raw reply exposed via `set_receive_packet_buffer` / `Config::packet`.

This PR follows that intended mechanism:

- `StackResources` gains a fixed-size `dhcp_rx_buffer` (`DHCP_RX_BUFFER_SIZE = 576`, the minimum DHCP message size every server must respect per RFC 2131), only allocated when the feature is enabled — mirroring how `dhcpv4-hostname` allocates `HostnameResources`.
- The buffer is handed to the DHCP socket once at creation.
- Option 42 is decoded from the retained packet when a lease is configured.

An undersized buffer never corrupts the IP configuration (address/gateway/DNS come from smoltcp's parsed `Config`); it only causes the extra options to be dropped.

### Notes

- The NTP server list is capped at 4 (matching common NTP client practice); extra servers are dropped, as smoltcp does for DNS servers.
- Setting a receive packet buffer makes smoltcp report the config as changed on every received DHCP packet (including renewals), so `apply_static_config()` re-runs each renewal. This only affects stacks that opt into `dhcpv4-ntp`.
