### PR TITLE
esp-hosted: Wait for the handshake to actually get deasserted

### DIFF
--- a/embassy-net-esp-hosted/CHANGELOG.md
+++ b/embassy-net-esp-hosted/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## Unreleased - ReleaseDate
 
 - `Interface::transfer` now exchanges the buffer in place.
+- The SPI interface now waits for the handshake pin to be low before returning.
 
 ## 0.3.0 - 2026-03-10
 

--- a/embassy-net-esp-hosted/src/iface.rs
+++ b/embassy-net-esp-hosted/src/iface.rs
@@ -1,3 +1,4 @@
+use embassy_futures::join::join;
 use embedded_hal::digital::InputPin;
 use embedded_hal_async::digital::Wait;
 use embedded_hal_async::spi::SpiDevice;
@@ -51,11 +52,16 @@ where
     }
 
     async fn transfer(&mut self, buffer: &mut [u8]) {
-        self.spi.transfer_in_place(buffer).await.unwrap();
+        let (a, b) = join(
+            // The esp-hosted firmware deasserts the HANDSHAKE pin a few us AFTER ending the SPI transfer
+            // If we check it again too fast, we'll see it's high from the previous transfer, and if we send it
+            // data it will get lost.
+            self.handshake.wait_for_low(),
+            self.spi.transfer_in_place(buffer),
+        )
+        .await;
 
-        // The esp-hosted firmware deasserts the HANDSHAKE pin a few us AFTER ending the SPI transfer
-        // If we check it again too fast, we'll see it's high from the previous transfer, and if we send it
-        // data it will get lost.
-        self.handshake.wait_for_low().await.unwrap();
+        a.unwrap();
+        b.unwrap();
     }
 }

--- a/embassy-net-esp-hosted/src/iface.rs
+++ b/embassy-net-esp-hosted/src/iface.rs
@@ -1,4 +1,3 @@
-use embassy_time::Timer;
 use embedded_hal::digital::InputPin;
 use embedded_hal_async::digital::Wait;
 use embedded_hal_async::spi::SpiDevice;
@@ -57,6 +56,6 @@ where
         // The esp-hosted firmware deasserts the HANDSHAKE pin a few us AFTER ending the SPI transfer
         // If we check it again too fast, we'll see it's high from the previous transfer, and if we send it
         // data it will get lost.
-        Timer::after_micros(100).await;
+        self.handshake.wait_for_low().await.unwrap();
     }
 }


### PR DESCRIPTION
This is semantically more correct, will not let continue before handshake is _actually_ low, and is actually faster because current esp-hosted-fg seems to [pull handshake low shortly after chip select is pulled low](https://github.com/espressif/esp-hosted/blob/0b35a393ed0747f153fa95c13248b17a73e51af8/esp_hosted_fg/esp/esp_driver/network_adapter/main/spi_slave_api.c#L603-L605).