### PR TITLE
feat!: cryptocell power management

### DIFF
--- a/embassy-nrf/src/cryptocell/mod.rs
+++ b/embassy-nrf/src/cryptocell/mod.rs
@@ -1,0 +1,56 @@
+//! CryptoCell drivers
+//!
+//! If you want to interact with the CryptoCell, you can activate it using [`activate()`].
+//! This function will return a handle that will keep the CryptoCell active until it is dropped.
+
+#![macro_use]
+
+use core::sync::atomic::{AtomicU16, Ordering};
+
+use crate::pac;
+
+pub mod rng;
+
+static ACTIVE_USERS: AtomicU16 = AtomicU16::new(0);
+
+/// Use this function to activate the CryptoCell subsystem.
+///
+/// CryptoCell is active until the handle is dropped.
+#[must_use]
+pub fn activate() -> CryptoCellActivationHandle {
+    ACTIVE_USERS.fetch_add(1, Ordering::Relaxed);
+
+    // Make sure the CryptoCell is enabled.
+    pac::CRYPTOCELL.enable().write(|w| w.set_enable(true));
+
+    CryptoCellActivationHandle::new()
+}
+
+fn release() {
+    // We need to make sure an activation doesn't happen between us checking the value and disabling
+    // the CryptoCell.
+    critical_section::with(|_cs| {
+        // If we released the last one, turn off CRYPTOCELL.
+        // We can use the Relaxed ordering as this happens in a critical section.
+        if ACTIVE_USERS.fetch_sub(1, Ordering::Relaxed) == 1 {
+            pac::CRYPTOCELL.enable().write(|w| w.set_enable(false));
+        }
+    })
+}
+
+/// Cryptocell is active until this is dropped.
+pub struct CryptoCellActivationHandle {
+    _private: (),
+}
+
+impl CryptoCellActivationHandle {
+    fn new() -> Self {
+        Self { _private: () }
+    }
+}
+
+impl Drop for CryptoCellActivationHandle {
+    fn drop(&mut self) {
+        release()
+    }
+}

--- a/embassy-nrf/src/cryptocell/rng.rs
+++ b/embassy-nrf/src/cryptocell/rng.rs
@@ -158,7 +158,7 @@ impl<'d> CcRng<'d, Async> {
 
         // In self.start() there are calls to set_enable() that resets the interrupt mask,
         // self.enable_irq() needs to be called after self.start().
-        self.start();
+        let _handle = self.start();
 
         self.enable_irq();
 
@@ -204,11 +204,8 @@ impl<'d> CcRng<'d, Async> {
 }
 
 impl<'d, M: Mode> CcRng<'d, M> {
-    fn start(&self) {
-        // FIXME: CRYPTOCELL is never disabled.
-        if !pac::CRYPTOCELL.enable().read().enable() {
-            pac::CRYPTOCELL.enable().write(|w| w.set_enable(true));
-        }
+    fn start(&self) -> super::CryptoCellActivationHandle {
+        let handle = super::activate();
 
         self.r.rng_clk().write(|w| w.set_enable(true));
         self.r.rng_sw_reset().write(|w| w.set_reset(true));
@@ -226,6 +223,7 @@ impl<'d, M: Mode> CcRng<'d, M> {
             .trng_config()
             .modify(|w| w.set_rosc_len(pac::cc_rng::vals::TrngConfigRoscLen::Rosc1));
         self.r.noise_source().modify(|w| w.set_enable(true));
+        handle
     }
 
     fn stop(&self) {
@@ -236,7 +234,7 @@ impl<'d, M: Mode> CcRng<'d, M> {
 
     /// Fill the buffer with random bytes, blocking version.
     pub fn blocking_fill_bytes(&mut self, dest: &mut [u8]) {
-        self.start();
+        let _handle = self.start();
         self.inner_fill_bytes(dest);
         self.stop();
     }
@@ -389,16 +387,16 @@ pub trait Instance: SealedInstance + PeripheralType + 'static + Send {
 
 macro_rules! impl_ccrng {
     ($type:ident, $pac_type:ident, $irq:ident) => {
-        impl crate::cryptocell_rng::SealedInstance for peripherals::$type {
+        impl crate::cryptocell::rng::SealedInstance for peripherals::$type {
             fn regs() -> pac::cc_rng::CcRng {
                 pac::$pac_type
             }
-            fn state() -> &'static crate::cryptocell_rng::State {
-                static STATE: crate::cryptocell_rng::State = crate::cryptocell_rng::State::new();
+            fn state() -> &'static crate::cryptocell::rng::State {
+                static STATE: crate::cryptocell::rng::State = crate::cryptocell::rng::State::new();
                 &STATE
             }
         }
-        impl crate::cryptocell_rng::Instance for peripherals::$type {
+        impl crate::cryptocell::rng::Instance for peripherals::$type {
             type Interrupt = crate::interrupt::typelevel::$irq;
         }
     };

--- a/embassy-nrf/src/lib.rs
+++ b/embassy-nrf/src/lib.rs
@@ -179,7 +179,7 @@ pub mod rng;
     feature = "nrf52840",
     all(any(feature = "_nrf91", feature = "_nrf5340-app"), feature = "_s"),
 ))]
-pub mod cryptocell_rng;
+pub mod cryptocell;
 
 #[cfg(not(feature = "_nrf54l"))]
 pub mod rtc;

--- a/examples/nrf5340/src/bin/cryptocell_rng.rs
+++ b/examples/nrf5340/src/bin/cryptocell_rng.rs
@@ -2,13 +2,13 @@
 #![no_main]
 
 use embassy_executor::Spawner;
-use embassy_nrf::cryptocell_rng::{self, CcRng};
+use embassy_nrf::cryptocell::rng::{self, CcRng};
 use embassy_nrf::{bind_interrupts, peripherals};
 use rand::Rng as _;
 use {defmt_rtt as _, panic_probe as _};
 
 bind_interrupts!(struct Irqs {
-    CRYPTOCELL => cryptocell_rng::InterruptHandler<peripherals::CC_RNG>;
+    CRYPTOCELL => rng::InterruptHandler<peripherals::CC_RNG>;
 });
 
 #[embassy_executor::main]

--- a/examples/nrf9151/s/src/bin/cryptocell_rng.rs
+++ b/examples/nrf9151/s/src/bin/cryptocell_rng.rs
@@ -2,13 +2,13 @@
 #![no_main]
 
 use embassy_executor::Spawner;
-use embassy_nrf::cryptocell_rng::{self, CcRng};
+use embassy_nrf::cryptocell::rng::{self, CcRng};
 use embassy_nrf::{bind_interrupts, peripherals};
 use rand::Rng as _;
 use {defmt_rtt as _, panic_probe as _};
 
 bind_interrupts!(struct Irqs {
-    CRYPTOCELL => cryptocell_rng::InterruptHandler<peripherals::CC_RNG>;
+    CRYPTOCELL => rng::InterruptHandler<peripherals::CC_RNG>;
 });
 
 #[embassy_executor::main]

--- a/examples/nrf9160/src/bin/modem_tcp_client.rs
+++ b/examples/nrf9160/src/bin/modem_tcp_client.rs
@@ -13,7 +13,7 @@ use embassy_net::{Ipv4Cidr, Stack, StackResources};
 use embassy_net_nrf91::context::Status;
 use embassy_net_nrf91::{Runner, State, TraceBuffer, TraceReader, context};
 use embassy_nrf::buffered_uarte::{self, BufferedUarteTx};
-use embassy_nrf::cryptocell_rng::CcRng;
+use embassy_nrf::cryptocell::rng::CcRng;
 use embassy_nrf::gpio::{AnyPin, Level, Output, OutputDrive};
 use embassy_nrf::uarte::Baudrate;
 use embassy_nrf::{Peri, bind_interrupts, interrupt, peripherals, uarte};


### PR DESCRIPTION
This refactors how the CryptoCell is handled in `embassy-nrf` to allow powering down the CryptoCell when none of its components are used, improving power consumption. 

This has a breaking change as `cryptocell_rng` is moved into a `cryptocell` module.

This allows the chip to go on System ON IDLE, for the nrf9151 that makes it idle at less than 10 μA after using CcRng instead of ~500μA before this change.