### PR TITLE
stm32/spi: delay receive until corresponding tx

### DIFF
--- a/embassy-stm32/src/spi/mod.rs
+++ b/embassy-stm32/src/spi/mod.rs
@@ -1478,7 +1478,7 @@ fn transfer_words<W: Word>(regs: Regs, read: *mut [W], write: *const [W]) -> Res
                 w += 1;
             }
 
-            if r < ndt && check_rx_ready(regs)? {
+            if r < ndt && r < w && check_rx_ready(regs)? {
                 if let Some(word_in) = read.next() {
                     *word_in = ptr::read_volatile(regs.rx_ptr());
                 } else {


### PR DESCRIPTION
the read must be delayed, because if it isn't, it could overwrite outgoing data. when this function was written it was assumed that the hardware would impose this condition, but this is not true for slave mode.

closes #6294

