### PR TITLE
rp: Use more reliable rotary encoder PIO program

### DIFF
--- a/embassy-rp/src/pio_programs/rotary_encoder.rs
+++ b/embassy-rp/src/pio_programs/rotary_encoder.rs
@@ -21,20 +21,22 @@ impl<'a, PIO: Instance> PioEncoderProgram<'a, PIO> {
             "mov y, isr",
             "mov isr, null",
             "jmp !y, invalid",
-            "in x 1", "push noblock",
+            "in x 1",
+            "push noblock",
             "invalid:",
-
             // loop while pins are [11] (home state). outputs x
             "while_11:",
-            "mov osr, ~ pins", "out x, 2",
+            "mov osr, ~ pins",
+            "out x, 2",
             "jmp !x, while_11", // pins == [11]
-
             // then, count how many [01] and [10] states come after that one
             // (ignoring [00]) until we see [11] again
             ".wrap_target",
-            "mov osr, ~ x", "out x, 2", // decide next state to search for
+            "mov osr, ~ x",
+            "out x, 2", // decide next state to search for
             "until_x:",
-            "mov osr, ~ pins", "out y, 2",
+            "mov osr, ~ pins",
+            "out y, 2",
             "jmp !y, complete", // pins == [11]
             "jmp x!=y until_x",
             // if pins matched next state:

--- a/embassy-rp/src/pio_programs/rotary_encoder.rs
+++ b/embassy-rp/src/pio_programs/rotary_encoder.rs
@@ -15,7 +15,32 @@ pub struct PioEncoderProgram<'a, PIO: Instance> {
 impl<'a, PIO: Instance> PioEncoderProgram<'a, PIO> {
     /// Load the program into the given pio
     pub fn new(common: &mut Common<'a, PIO>) -> Self {
-        let prg = pio::pio_asm!("wait 1 pin 1", "wait 0 pin 1", "in pins, 2", "push",);
+        let prg = pio::pio_asm!(
+            // reset count. if it was odd, we report a step
+            "complete:",
+            "mov y, isr",
+            "mov isr, null",
+            "jmp !y, invalid",
+            "in x 1", "push noblock",
+            "invalid:",
+
+            // loop while pins are [11] (home state). outputs x
+            "while_11:",
+            "mov osr, ~ pins", "out x, 2",
+            "jmp !x, while_11", // pins == [11]
+
+            // then, count how many [01] and [10] states come after that one
+            // (ignoring [00]) until we see [11] again
+            ".wrap_target",
+            "mov osr, ~ x", "out x, 2", // decide next state to search for
+            "until_x:",
+            "mov osr, ~ pins", "out y, 2",
+            "jmp !y, complete", // pins == [11]
+            "jmp x!=y until_x",
+            // if pins matched next state:
+            "mov isr, ~ isr", // count even/odd flag
+            ".wrap",
+        );
 
         let prg = common.load_program(&prg.program);
 
@@ -48,8 +73,8 @@ impl<'d, T: Instance, const SM: usize> PioEncoder<'d, T, SM> {
         cfg.fifo_join = FifoJoin::RxOnly;
         cfg.shift_in.direction = ShiftDirection::Left;
 
-        // Target 12.5 KHz PIO clock
-        cfg.clock_divider = calculate_pio_clock_divider(12_500);
+        // Target 12 MHz PIO clock
+        cfg.clock_divider = calculate_pio_clock_divider(12_000_000);
 
         cfg.use_program(&program.prg, &[]);
         sm.set_config(&cfg);
@@ -61,8 +86,8 @@ impl<'d, T: Instance, const SM: usize> PioEncoder<'d, T, SM> {
     pub async fn read(&mut self) -> Direction {
         loop {
             match self.sm.rx().wait_pull().await {
-                0 => return Direction::CounterClockwise,
-                1 => return Direction::Clockwise,
+                0 => return Direction::Clockwise,
+                1 => return Direction::CounterClockwise,
                 _ => {}
             }
         }


### PR DESCRIPTION
fixes #6282
I've tested this with a rotary encoder that was barely usable with the old program.
This program will never report steps in the wrong direction, or report incomplete/aborted steps, and only rarely misses steps (I believe this only happens if the RX FIFO fills up)

The only potential issues this change could cause are:
1: The PIO program is larger (only 17 instructions left unused, vs 28)
2: It's harder to support non-adjacent input pins (the old program didn't handle this either, but would've been easier to add; now it would probably use ~5 extra instructions.)

I can write a more complete explanation of how the code works, if necessary.