### PR TITLE
embassy_rp: WS2812 pio program improvements

### DIFF
--- a/embassy-rp/Cargo.toml
+++ b/embassy-rp/Cargo.toml
@@ -201,7 +201,7 @@ rp2040-boot2 = "0.3"
 document-features = "0.2.10"
 sha2-const-stable = "0.1"
 rp-binary-info = { version = "0.1.0", optional = true }
-smart-leds = "0.4.0"
+smart-leds-trait = "0.3.2"
 
 [dev-dependencies]
 embassy-executor = { version = "0.10.0", path = "../embassy-executor", features = ["platform-std", "executor-thread"] }

--- a/embassy-rp/src/pio_programs/ws2812.rs
+++ b/embassy-rp/src/pio_programs/ws2812.rs
@@ -1,8 +1,8 @@
 //! [ws2812](https://www.sparkfun.com/categories/tags/ws2812)
 
-use embassy_time::Timer;
+use embassy_time::{Duration, Timer};
 use fixed::types::U24F8;
-use smart_leds::{RGB8, RGBW};
+use smart_leds_trait::{RGB8, RGBW, SmartLedsWriteAsync};
 
 use crate::clocks::clk_sys_freq;
 use crate::pio::{
@@ -14,6 +14,7 @@ const T1: u8 = 2; // start bit
 const T2: u8 = 5; // data bit
 const T3: u8 = 3; // stop bit
 const CYCLES_PER_BIT: u32 = (T1 + T2 + T3) as u32;
+const RESET_DELAY: Duration = Duration::from_micros(55);
 
 /// Color orders for WS2812B, type RGB8
 pub trait RgbColorOrder {
@@ -99,7 +100,7 @@ impl<'a, PIO: Instance> PioWs2812Program<'a, PIO> {
 
 /// Pio backed RGB ws2812 driver
 /// Const N is the number of ws2812 leds attached to this pin
-pub struct PioWs2812<'d, P: Instance, const S: usize, const N: usize, ORDER>
+pub struct PioWs2812<'d, P: Instance, const S: usize, ORDER>
 where
     ORDER: RgbColorOrder,
 {
@@ -108,7 +109,7 @@ where
     _order: core::marker::PhantomData<ORDER>,
 }
 
-impl<'d, P: Instance, const S: usize, const N: usize> PioWs2812<'d, P, S, N, Grb> {
+impl<'d, P: Instance, const S: usize> PioWs2812<'d, P, S, Grb> {
     /// Configure a pio state machine to use the loaded ws2812 program.
     /// Uses the default GRB order.
     pub fn new<D: dma::ChannelInstance>(
@@ -123,7 +124,7 @@ impl<'d, P: Instance, const S: usize, const N: usize> PioWs2812<'d, P, S, N, Grb
     }
 }
 
-impl<'d, P: Instance, const S: usize, const N: usize, ORDER> PioWs2812<'d, P, S, N, ORDER>
+impl<'d, P: Instance, const S: usize, ORDER> PioWs2812<'d, P, S, ORDER>
 where
     ORDER: RgbColorOrder,
 {
@@ -172,7 +173,7 @@ where
     }
 
     /// Write a buffer of [smart_leds::RGB8] to the ws2812 string
-    pub async fn write(&mut self, colors: &[RGB8; N]) {
+    pub async fn write_slice<const N: usize>(&mut self, colors: &[RGB8; N]) {
         // Precompute the word bytes from the colors
         let mut words = [0u32; N];
         for i in 0..N {
@@ -182,14 +183,33 @@ where
         // DMA transfer
         self.sm.tx().dma_push(&mut self.dma, &words, false).await;
 
-        Timer::after_micros(55).await;
+        Timer::after(RESET_DELAY).await;
+    }
+}
+
+impl<'d, P: Instance, const S: usize, ORDER: RgbColorOrder> SmartLedsWriteAsync for PioWs2812<'d, P, S, ORDER> {
+    type Error = core::convert::Infallible;
+
+    type Color = RGB8;
+
+    async fn write<T, I>(&mut self, iterator: T) -> Result<(), Self::Error>
+    where
+        T: IntoIterator<Item = I>,
+        I: Into<Self::Color>,
+    {
+        for color in iterator.into_iter() {
+            let word = ORDER::pack(color.into());
+            self.sm.tx().dma_push(&mut self.dma, &[word], false).await;
+        }
+        Timer::after(RESET_DELAY).await;
+        Ok(())
     }
 }
 
 /// Pio backed RGBW ws2812 driver
 /// This version is intended for ws2812 leds with 4 addressable lights
 /// Const N is the number of ws2812 leds attached to this pin
-pub struct RgbwPioWs2812<'d, P: Instance, const S: usize, const N: usize, ORDER>
+pub struct RgbwPioWs2812<'d, P: Instance, const S: usize, ORDER>
 where
     ORDER: RgbwColorOrder,
 {
@@ -198,7 +218,7 @@ where
     _order: core::marker::PhantomData<ORDER>,
 }
 
-impl<'d, P: Instance, const S: usize, const N: usize> RgbwPioWs2812<'d, P, S, N, Grbw> {
+impl<'d, P: Instance, const S: usize> RgbwPioWs2812<'d, P, S, Grbw> {
     /// Configure a pio state machine to use the loaded ws2812 program.
     /// Uses the default GRBW color order
     pub fn new<D: dma::ChannelInstance>(
@@ -213,7 +233,7 @@ impl<'d, P: Instance, const S: usize, const N: usize> RgbwPioWs2812<'d, P, S, N,
     }
 }
 
-impl<'d, P: Instance, const S: usize, const N: usize, ORDER> RgbwPioWs2812<'d, P, S, N, ORDER>
+impl<'d, P: Instance, const S: usize, ORDER> RgbwPioWs2812<'d, P, S, ORDER>
 where
     ORDER: RgbwColorOrder,
 {
@@ -262,7 +282,7 @@ where
     }
 
     /// Write a buffer of [smart_leds::RGBW] to the ws2812 string
-    pub async fn write(&mut self, colors: &[RGBW<u8>; N]) {
+    pub async fn write_slice<const N: usize>(&mut self, colors: &[RGBW<u8>; N]) {
         // Precompute the word bytes from the colors
         let mut words = [0u32; N];
         for i in 0..N {
@@ -272,6 +292,25 @@ where
         // DMA transfer
         self.sm.tx().dma_push(&mut self.dma, &words, false).await;
 
-        Timer::after_micros(55).await;
+        Timer::after(RESET_DELAY).await;
+    }
+}
+
+impl<'d, P: Instance, const S: usize, ORDER: RgbwColorOrder> SmartLedsWriteAsync for RgbwPioWs2812<'d, P, S, ORDER> {
+    type Error = core::convert::Infallible;
+
+    type Color = RGBW<u8>;
+
+    async fn write<T, I>(&mut self, iterator: T) -> Result<(), Self::Error>
+    where
+        T: IntoIterator<Item = I>,
+        I: Into<Self::Color>,
+    {
+        for color in iterator.into_iter() {
+            let word = ORDER::pack(color.into());
+            self.sm.tx().dma_push(&mut self.dma, &[word], false).await;
+        }
+        Timer::after(RESET_DELAY).await;
+        Ok(())
     }
 }

--- a/examples/rp/src/bin/pio_ws2812.rs
+++ b/examples/rp/src/bin/pio_ws2812.rs
@@ -61,7 +61,7 @@ async fn main(_spawner: Spawner) {
                 data[i] = wheel((((i * 256) as u16 / NUM_LEDS as u16 + j as u16) & 255) as u8);
                 debug!("R: {} G: {} B: {}", data[i].r, data[i].g, data[i].b);
             }
-            ws2812.write(&data).await;
+            ws2812.write_slice(&data).await;
 
             ticker.next().await;
         }

--- a/examples/rp235x/src/bin/pio_ws2812.rs
+++ b/examples/rp235x/src/bin/pio_ws2812.rs
@@ -61,7 +61,7 @@ async fn main(_spawner: Spawner) {
                 data[i] = wheel((((i * 256) as u16 / NUM_LEDS as u16 + j as u16) & 255) as u8);
                 debug!("R: {} G: {} B: {}", data[i].r, data[i].g, data[i].b);
             }
-            ws2812.write(&data).await;
+            ws2812.write_slice(&data).await;
 
             ticker.next().await;
         }


### PR DESCRIPTION
- Use `smart-leds-trait` crate instead of `smart-leds` (as advised in the smart-leds crate README)
- Implement `SmartLedsWriteAsync` trait
- Refactor to remove the const generic N from the struct, moving it directly to the `write_slice` method
- Rename `write` -> `write_slice` (to distinguish from the write method of `SmartLedsWriteAsync`)

Please let me know if these changes are reasonable. If so, should I also write something in the CHANGELOG?