### PR TITLE
examples/stm32wba{,6}-lp: add MEASURE_POWER flag and power-measurement improvements

### DIFF
--- a/examples/stm32wba-lp/src/bin/blinky.rs
+++ b/examples/stm32wba-lp/src/bin/blinky.rs
@@ -14,6 +14,8 @@ use embassy_stm32::rcc::*;
 use embassy_time::Timer;
 use {defmt_rtt as _, panic_probe as _};
 
+const MEASURE_POWER: bool = true;
+
 #[embassy_executor::main(executor = "embassy_stm32::executor::Executor", entry = "cortex_m_rt::entry")]
 async fn main(_spawner: Spawner) {
     let mut config = embassy_stm32::Config::default();
@@ -30,12 +32,22 @@ async fn main(_spawner: Spawner) {
         lse: None,
     };
 
-    // Disable debug peripherals during STOP to minimise leakage.
-    // Set to `true` when debugging with probe-rs / RTT.
-    config.enable_debug_during_sleep = false;
+    if MEASURE_POWER {
+        // Lowest leakage profile for current measurements.
+        config.enable_debug_during_sleep = false;
+        config.min_stop_pause = embassy_time::Duration::from_millis(100);
+    } else {
+        // Easier debug/reflash profile, but with higher STOP current.
+        config.enable_debug_during_sleep = true;
+        config.min_stop_pause = embassy_time::Duration::from_millis(20);
+    }
 
     let p = embassy_stm32::init(config);
     info!("Hello from STM32WBA low-power blinky!");
+    info!(
+        "Power profile: {}",
+        if MEASURE_POWER { "measurement" } else { "debug-friendly" }
+    );
 
     let mut led = Output::new(p.PB4, Level::High, Speed::Low);
 

--- a/examples/stm32wba-lp/src/bin/button_exti.rs
+++ b/examples/stm32wba-lp/src/bin/button_exti.rs
@@ -15,6 +15,8 @@ use embassy_stm32::rcc::*;
 use embassy_stm32::{bind_interrupts, interrupt};
 use {defmt_rtt as _, panic_probe as _};
 
+const MEASURE_POWER: bool = true;
+
 bind_interrupts!(
     pub struct Irqs {
         EXTI13 => exti::InterruptHandler<interrupt::typelevel::EXTI13>;
@@ -37,12 +39,22 @@ async fn main(_spawner: Spawner) {
         lse: None,
     };
 
-    // Disable debug peripherals during STOP to minimise leakage.
-    // Set to `true` when debugging with probe-rs / RTT.
-    config.enable_debug_during_sleep = false;
+    if MEASURE_POWER {
+        // Lowest leakage profile for current measurements.
+        config.enable_debug_during_sleep = false;
+        config.min_stop_pause = embassy_time::Duration::from_millis(100);
+    } else {
+        // Easier debug/reflash profile, but with higher STOP current.
+        config.enable_debug_during_sleep = true;
+        config.min_stop_pause = embassy_time::Duration::from_millis(20);
+    }
 
     let p = embassy_stm32::init(config);
     info!("Hello from STM32WBA low-power button example!");
+    info!(
+        "Power profile: {}",
+        if MEASURE_POWER { "measurement" } else { "debug-friendly" }
+    );
     info!("Press the USER button (PC13)...");
 
     let mut button = ExtiInput::new(p.PC13, p.EXTI13, Pull::Up, Irqs);

--- a/examples/stm32wba6-lp/src/bin/ble_advertiser_lp.rs
+++ b/examples/stm32wba6-lp/src/bin/ble_advertiser_lp.rs
@@ -24,7 +24,7 @@ use embassy_executor::Spawner;
 use embassy_stm32::aes::{self, Aes};
 use embassy_stm32::peripherals::{AES, PKA, RNG};
 use embassy_stm32::pka::{self, Pka};
-use embassy_stm32::rcc::Config as RccConfig;
+use embassy_stm32::rcc::{Config as RccConfig, LseDrive, LseMode};
 use embassy_stm32::rng::{self, Rng};
 use embassy_stm32::{Config, bind_interrupts};
 use embassy_stm32_wpan::bluetooth::HCI;
@@ -33,10 +33,31 @@ use embassy_stm32_wpan::bluetooth::gap::{AdvData, AdvParams, AdvType};
 use embassy_stm32_wpan::bluetooth::gap_init::{AddressType, GapInitParams};
 use embassy_stm32_wpan::bluetooth::gatt::{CharProperties, GattEventMask, SecurityPermissions, ServiceType, Uuid};
 use embassy_stm32_wpan::{HighInterruptHandler, LowInterruptHandler, Platform, new_platform};
+use embassy_time::Duration;
 use {defmt_rtt as _, panic_probe as _};
 
 // ---- Test configuration ----
 const ADDR_TYPE: OwnAddressType = OwnAddressType::Random;
+const MEASURE_POWER: bool = true;
+const ULTRA_LOW_POWER_PRESET: bool = false;
+const AGGRESSIVE_SRAM_POWERDOWN: bool = false;
+const TUNE_LSE_DRIVE: bool = false;
+const LSE_DRIVE_SETTING: LseDrive = LseDrive::Low;
+
+// Conservative defaults for low-power measurements.
+const ADV_INTERVAL_UNITS: u16 = 0x0800; // 1.28 s (0.625 ms units)
+const MIN_STOP_PAUSE_MS: u64 = 100;
+
+// Suggested measurement matrix (run each for ~30-60s average current):
+// A) Baseline:
+//    ULTRA_LOW_POWER_PRESET=false, TUNE_LSE_DRIVE=false, AGGRESSIVE_SRAM_POWERDOWN=false
+// B) BOR ultra-low-power:
+//    ULTRA_LOW_POWER_PRESET=true,  TUNE_LSE_DRIVE=false, AGGRESSIVE_SRAM_POWERDOWN=false
+// C) LSE drive sweep:
+//    ULTRA_LOW_POWER_PRESET=true,  TUNE_LSE_DRIVE=true,  LSE_DRIVE_SETTING=MediumLow/Low
+// D) SRAM power-down:
+//    ULTRA_LOW_POWER_PRESET=true,  TUNE_LSE_DRIVE=true,  AGGRESSIVE_SRAM_POWERDOWN=true
+// Keep ADV interval and RF conditions fixed while comparing.
 
 bind_interrupts!(struct Irqs {
     RNG => rng::InterruptHandler<RNG>;
@@ -59,9 +80,47 @@ async fn main(spawner: Spawner) {
     // Enable HSE/LSE clocks and configure system at 96 MHz via PLL1
     config.rcc = RccConfig::new_wpan();
 
-    // Disable debug peripherals during STOP to achieve lowest current draw
-    // If you need active RTT/probe-rs debugging during STOP, set this to true
-    config.enable_debug_during_sleep = false;
+    // Optional board-specific LSE drive tuning.
+    // RM guidance: lower drive can reduce current after startup, but may hurt startup margin.
+    if TUNE_LSE_DRIVE {
+        if let Some(lse) = &mut config.rcc.ls.lse {
+            lse.mode = LseMode::Oscillator(LSE_DRIVE_SETTING);
+        }
+    }
+
+    // Two practical profiles:
+    // - MEASURE_POWER=true: best current draw, limited STOP-time debug visibility.
+    // - MEASURE_POWER=false: easier bring-up/logging, higher sleep current.
+    if MEASURE_POWER {
+        config.enable_debug_during_sleep = false;
+        // Keep this comfortably below the advertising period to maximize STOP residency.
+        config.min_stop_pause = Duration::from_millis(MIN_STOP_PAUSE_MS);
+
+        // Optional preset aligned with RM0515 guidance for lowest Stop/Standby current.
+        // Keep disabled by default: this can be board/application sensitive.
+        if ULTRA_LOW_POWER_PRESET {
+            // Enable BOR0 ultra-low-power monitoring mode in Stop1/Standby.
+            // RM constraints: avoid when autonomous peripherals rely on HSI kernels.
+            config.enable_ulpmen = true;
+
+            // Keep flash in low-power mode during stop (lowest current, slower wake).
+            config.flash_fast_wakeup = false;
+
+            // Optional aggressive SRAM power-down in Stop modes.
+            // WARNING: Any powered-down SRAM content is lost across STOP entry.
+            if AGGRESSIVE_SRAM_POWERDOWN {
+                config.stop_mode_sram.sram1_page2 = true;
+                config.stop_mode_sram.sram1_page3 = true;
+                config.stop_mode_sram.sram1_pages567 = true;
+                config.stop_mode_sram.sram2 = true;
+                config.stop_mode_sram.icache_sram = true;
+                config.stop_mode_sram.otg_sram = true;
+            }
+        }
+    } else {
+        config.enable_debug_during_sleep = true;
+        config.min_stop_pause = Duration::from_millis(20);
+    }
 
     let p = embassy_stm32::init(config);
 
@@ -144,11 +203,10 @@ async fn main(spawner: Spawner) {
     info!("Advertising data created ({} bytes)", adv_data.len());
 
     // Configure advertising parameters
-    // Using a 100 ms advertising interval. The device will wake up, transmit an ad packet,
-    // and immediately return to STOP mode within less than 5 milliseconds.
+    // Slower advertising intervals significantly reduce average radio duty cycle.
     let adv_params = AdvParams {
-        interval_min: 0x00A0, // 100 ms
-        interval_max: 0x00A0, // 100 ms
+        interval_min: ADV_INTERVAL_UNITS,
+        interval_max: ADV_INTERVAL_UNITS,
         adv_type: AdvType::ConnectableUndirected,
         own_addr_type: ADDR_TYPE,
         ..AdvParams::default()
@@ -161,11 +219,38 @@ async fn main(spawner: Spawner) {
 
     info!("BLE advertising started!");
     info!("Device is visible as 'Embassy-LP-WBA6'");
-    info!("Waking up only for BLE events, then automatically returning to STOP mode...");
+    if MEASURE_POWER {
+        info!("Power profile: measurement (debug-in-sleep OFF)");
+        info!(
+            "Ultra-low-power preset: {}",
+            if ULTRA_LOW_POWER_PRESET { "enabled" } else { "disabled" }
+        );
+        info!(
+            "Aggressive SRAM power-down: {}",
+            if ULTRA_LOW_POWER_PRESET && AGGRESSIVE_SRAM_POWERDOWN {
+                "enabled"
+            } else {
+                "disabled"
+            }
+        );
+        info!(
+            "LSE drive tuning: {}",
+            if TUNE_LSE_DRIVE { "enabled" } else { "disabled" }
+        );
+    } else {
+        info!("Power profile: debug-friendly (debug-in-sleep ON)");
+    }
+    info!("Waking for BLE events/timers, then returning to STOP when possible...");
 
-    // Main loop - handle BLE events in a power-efficient manner
+    // Main loop - handle BLE events in a power-efficient manner.
+    // Keep draining BLE events; pending events/interrupts can otherwise reduce STOP residency.
     loop {
         let event = ble.read_event().await;
-        info!("BLE Event received: {:?}", event);
+        // Keep host/log overhead low: avoid formatting every event unless debugging.
+        if !MEASURE_POWER {
+            info!("BLE Event received: {:?}", event);
+        } else {
+            let _ = event;
+        }
     }
 }

--- a/examples/stm32wba6-lp/src/bin/blinky.rs
+++ b/examples/stm32wba6-lp/src/bin/blinky.rs
@@ -14,6 +14,8 @@ use embassy_stm32::rcc::*;
 use embassy_time::Timer;
 use {defmt_rtt as _, panic_probe as _};
 
+const MEASURE_POWER: bool = true;
+
 #[embassy_executor::main(executor = "embassy_stm32::executor::Executor", entry = "cortex_m_rt::entry")]
 async fn main(_spawner: Spawner) {
     let mut config = embassy_stm32::Config::default();
@@ -34,12 +36,22 @@ async fn main(_spawner: Spawner) {
     // PLL1 is not configured in this demo.
     config.rcc.mux.sai1sel = Sai1sel::Hsi;
 
-    // Disable debug peripherals during STOP to minimise leakage.
-    // Set to `true` when debugging with probe-rs / RTT.
-    config.enable_debug_during_sleep = false;
+    if MEASURE_POWER {
+        // Lowest leakage profile for current measurements.
+        config.enable_debug_during_sleep = false;
+        config.min_stop_pause = embassy_time::Duration::from_millis(100);
+    } else {
+        // Easier debug/reflash profile, but with higher STOP current.
+        config.enable_debug_during_sleep = true;
+        config.min_stop_pause = embassy_time::Duration::from_millis(20);
+    }
 
     let p = embassy_stm32::init(config);
     info!("Hello from STM32WBA6 low-power blinky!");
+    info!(
+        "Power profile: {}",
+        if MEASURE_POWER { "measurement" } else { "debug-friendly" }
+    );
 
     let mut led = Output::new(p.PB4, Level::High, Speed::Low);
 

--- a/examples/stm32wba6-lp/src/bin/button_exti.rs
+++ b/examples/stm32wba6-lp/src/bin/button_exti.rs
@@ -15,6 +15,8 @@ use embassy_stm32::rcc::*;
 use embassy_stm32::{bind_interrupts, interrupt};
 use {defmt_rtt as _, panic_probe as _};
 
+const MEASURE_POWER: bool = true;
+
 bind_interrupts!(
     pub struct Irqs {
         EXTI13 => exti::InterruptHandler<interrupt::typelevel::EXTI13>;
@@ -41,12 +43,22 @@ async fn main(_spawner: Spawner) {
     // PLL1 is not configured in this demo.
     config.rcc.mux.sai1sel = Sai1sel::Hsi;
 
-    // Disable debug peripherals during STOP to minimise leakage.
-    // Set to `true` when debugging with probe-rs / RTT.
-    config.enable_debug_during_sleep = false;
+    if MEASURE_POWER {
+        // Lowest leakage profile for current measurements.
+        config.enable_debug_during_sleep = false;
+        config.min_stop_pause = embassy_time::Duration::from_millis(100);
+    } else {
+        // Easier debug/reflash profile, but with higher STOP current.
+        config.enable_debug_during_sleep = true;
+        config.min_stop_pause = embassy_time::Duration::from_millis(20);
+    }
 
     let p = embassy_stm32::init(config);
     info!("Hello from STM32WBA6 low-power button example!");
+    info!(
+        "Power profile: {}",
+        if MEASURE_POWER { "measurement" } else { "debug-friendly" }
+    );
     info!("Press the USER button (PC13)...");
 
     let mut button = ExtiInput::new(p.PC13, p.EXTI13, Pull::Up, Irqs);


### PR DESCRIPTION
## Summary

- Adds a `MEASURE_POWER` compile-time flag (default: `true`) to `blinky`, `button_exti`, and `ble_advertiser_lp` examples for both `stm32wba-lp` and `stm32wba6-lp`
- When `true`: debug interface disabled during STOP, `min_stop_pause = 100 ms` — lowest current draw for measurements
- When `false`: debug interface stays enabled, RTT accessible — easier bring-up and logging
- `ble_advertiser_lp` also gains a configurable advertising interval (default 1.28 s to reduce radio duty cycle), optional ultra-low-power preset (ULPMEN, flash LP mode, SRAM power-down per RM0515), optional LSE drive tuning, and a measurement matrix comment

## Test plan

- [x] `blinky` flashed and verified on NUCLEO-WBA65RI: enters Stop2, RTC wakeup fires at 5 s intervals, clocks restored correctly
- [x] `ble_advertiser_lp` flashed and verified on NUCLEO-WBA65RI: BLE advertising started as `Embassy-LP-WBA6`, chip enters STOP between advertising events at ~1.28 s intervals
- [x] `button_exti` flashed and verified on NUCLEO-WBA65RI: EXTI13 wakes chip from STOP on every press and release of the USER button (PC13)
- [ ] `stm32wba-lp` examples not hardware-tested (no WBA5x board available) — changes are structurally identical to the verified WBA6 versions