### PR TITLE
stm32/adc4: add AUTOFF/LFTRIG; fix RingBufferedAdc stop/start as suspend/resume

### DIFF
--- a/embassy-stm32/src/adc/adc4.rs
+++ b/embassy-stm32/src/adc/adc4.rs
@@ -292,7 +292,12 @@ impl AdcRegs for crate::pac::adc::Adc4 {
         // subsequent `start()` call restarts conversion without the ADEN startup
         // sequence.  This is the correct mode for RingBufferedAdc::stop() /
         // start() used as a suspend/resume pair.
-        if disable && (cr.aden() || cr.adstart()) {
+        //
+        // TODO: align `disable` flag semantics with other ADC impls (c0, f1, l1,
+        // g4, v1-v4, f3 all handle this differently); ideally all impls expose a
+        // consistent enable/disable API so callers aren't surprised when porting.
+        if disable && cr.aden() {
+            // ADSTART=1 implies ADEN=1, so checking aden() alone is sufficient.
             self.cr().modify(|w| w.set_addis(true));
             while self.cr().read().aden() {}
         }

--- a/embassy-stm32/src/adc/adc4.rs
+++ b/embassy-stm32/src/adc/adc4.rs
@@ -275,19 +275,30 @@ impl AdcRegs for crate::pac::adc::Adc4 {
         });
     }
 
-    fn stop(&self, _disable: bool) {
+    fn stop(&self, disable: bool) {
         let cr = self.cr().read();
+
+        // Stop any ongoing regular conversion via ADSTP (self-clearing).
+        // Must be done before ADDIS per RM: software shall not set ADDIS while
+        // ADSTART=1 or JADSTART=1.
         if cr.adstart() {
             self.cr().modify(|w| w.set_adstp(true));
             while self.cr().read().adstart() {}
         }
 
-        if cr.aden() || cr.adstart() {
+        // Disable only when the caller requests it (disable=true).  Keeping the
+        // ADC enabled (disable=false) after ADSTP leaves it in a suspended state
+        // where CFGR1/CHSELR/AWD registers can be safely reconfigured, and a
+        // subsequent `start()` call restarts conversion without the ADEN startup
+        // sequence.  This is the correct mode for RingBufferedAdc::stop() /
+        // start() used as a suspend/resume pair.
+        if disable && (cr.aden() || cr.adstart()) {
             self.cr().modify(|w| w.set_addis(true));
             while self.cr().read().aden() {}
         }
 
-        // Reset configuration.
+        // Always clear DMAEN so a stale DMA request is not serviced if the ADC
+        // is left enabled (disable=false) and the DMA channel is reconfigured.
         self.cfgr1().modify(|reg| {
             reg.set_dmaen(false);
         });

--- a/embassy-stm32/src/adc/adc4.rs
+++ b/embassy-stm32/src/adc/adc4.rs
@@ -522,6 +522,39 @@ impl<'d, T: Instance<Regs = crate::pac::adc::Adc4>> super::Adc<'d, T> {
         })
     }
 
+    /// Enable auto-off mode.
+    ///
+    /// When enabled the ADC powers itself off at the end of every conversion and
+    /// powers back up automatically before the next one.  This eliminates static
+    /// bias current between conversions, which is especially useful when the ADC
+    /// is triggered at low duty-cycle rates (e.g. from LPTIM running on LSE).
+    ///
+    /// Auto-off operates transparently with external triggers: the ADC wakes,
+    /// converts, then powers off again without software intervention.  The
+    /// additional startup latency is accounted for by the hardware before the
+    /// conversion sample window begins.
+    ///
+    /// Should be cleared before switching back to continuous or high-rate
+    /// triggered operation where the startup overhead would reduce throughput.
+    #[cfg(stm32wba)]
+    pub fn set_autoff(&mut self, enable: bool) {
+        T::regs().pwr().modify(|w| w.set_autoff(enable));
+    }
+
+    /// Enable low-frequency trigger mode.
+    ///
+    /// Must be set when the ADC external trigger rate is below approximately
+    /// 1 kHz (e.g. LPTIM clocked from LSI or LSE at a multi-second period).
+    /// Without this bit the ADC sampling window may start before the analog
+    /// input has had sufficient time to settle after the trigger edge.
+    ///
+    /// Has no effect when the ADC is running in continuous or software-triggered
+    /// mode; only relevant when `EXTEN != DISABLED`.
+    #[cfg(stm32wba)]
+    pub fn set_lftrig(&mut self, enable: bool) {
+        T::regs().cfgr2().modify(|w| w.set_lftrig(enable));
+    }
+
     /// Enable an analog watchdog and return a guard.
     ///
     /// `watchdog` selects which of the three hardware watchdogs to use. `channels` controls which

--- a/embassy-stm32/src/adc/ringbuffered.rs
+++ b/embassy-stm32/src/adc/ringbuffered.rs
@@ -51,6 +51,9 @@ impl<'d, R: AdcRegs> RingBufferedAdc<'d, R> {
     }
 
     /// Turns on ADC if it is not already turned on and starts continuous DMA transfer.
+    ///
+    /// Can be called after [`stop`] to resume a suspended scan without repeating the
+    /// full channel/DMA configuration — the ring buffer and sequence are preserved.
     pub fn start(&mut self) {
         compiler_fence(Ordering::SeqCst);
         self.ring_buf.start();
@@ -58,7 +61,24 @@ impl<'d, R: AdcRegs> RingBufferedAdc<'d, R> {
         self.regs.start();
     }
 
+    /// Suspend the continuous DMA scan.
+    ///
+    /// Issues ADSTP on the ADC hardware (leaving the ADC *enabled* and fully
+    /// configured) and pauses the DMA ring buffer.  The channel sequence, DMA
+    /// buffer, and all ADC register settings are preserved; call [`start`] to
+    /// resume from where the scan left off.
+    ///
+    /// This is intended as a lightweight suspend/resume pair for cases such as
+    /// low-power sleep modes where the caller needs to temporarily halt the scan
+    /// and optionally reconfigure the ADC (e.g. change trigger source, enable an
+    /// analog watchdog) before resuming.  It does **not** disable the ADC, so
+    /// CFGR1 and other configuration registers can be written immediately after
+    /// this call without going through the enable sequence again.
     pub fn stop(&mut self) {
+        // Stop ADC hardware first (ADSTP, leave ADEN=1) so it stops issuing DMA
+        // requests before we pause the DMA channel.
+        self.regs.stop(false);
+
         self.ring_buf.request_pause();
 
         compiler_fence(Ordering::SeqCst);


### PR DESCRIPTION
## Summary

Three related improvements to the STM32 ADC4 driver (STM32WBA / STM32U5) motivated by a low-power VBUS detection use case: LPTIM1-triggered ADC4 sampling with an analog watchdog wakeup from Stop mode.

### 1. `set_autoff` and `set_lftrig` on `Adc<T>` (`#[cfg(stm32wba)]`)

`AUTOFF` (PWR.AUTOFF) powers the ADC down after each conversion and wakes it automatically on the next external trigger. `LFTRIG` (CFGR2.LFTRIG) adjusts the ADC sampling window for trigger rates below ~1 kHz (e.g. LPTIM from LSE). Both are needed for correct, power-efficient operation when the ADC is triggered at a very low duty cycle.

### 2. Fix `AdcRegs::stop(disable: bool)` for Adc4

`stop()` accepted a `disable: bool` parameter but ignored it (`_disable`), always issuing ADDIS and fully disabling the ADC. This made it impossible to use `RingBufferedAdc::stop()` / `start()` as a lightweight suspend/resume pair. Fixed to:
- `disable=false` → ADSTP only; ADC stays enabled, registers can be reconfigured, `start()` restarts without re-enabling
- `disable=true` → ADSTP then ADDIS; matches previous behaviour

### 3. Fix `RingBufferedAdc::stop()` to halt the ADC hardware

Previously `stop()` only paused the DMA ring buffer, leaving the ADC running and issuing DMA requests into a paused channel. Now it calls `self.regs.stop(false)` first. `start()` and `stop()` are documented as a suspend/resume pair.

## Test plan

- [x] Builds for `stm32wba65ri` (thumbv8m.main-none-eabihf)
- [x] Builds for `stm32f429zi` (thumbv7em-none-eabihf) — confirms no regression on non-WBA targets using `stop()`