### PR TITLE
Implement SetConfig for YieldingAsync and BlockingAsync adapters.

### DIFF
--- a/embassy-embedded-hal/src/adapter/blocking_async.rs
+++ b/embassy-embedded-hal/src/adapter/blocking_async.rs
@@ -1,3 +1,5 @@
+use crate::SetConfig;
+
 /// Wrapper that implements async traits using blocking implementations.
 ///
 /// This allows driver writers to depend on the async traits while still supporting embedded-hal peripheral implementations.
@@ -92,6 +94,18 @@ where
     async fn transfer_in_place(&mut self, data: &mut [u8]) -> Result<(), Self::Error> {
         self.wrapped.transfer_in_place(data)?;
         Ok(())
+    }
+}
+
+///
+/// Implementations relating to both I2C and SPI
+///
+
+impl<T: SetConfig> SetConfig for BlockingAsync<T> {
+    type Config = T::Config;
+    type ConfigError = T::ConfigError;
+    fn set_config(&mut self, config: &Self::Config) -> Result<(), Self::ConfigError> {
+        self.wrapped.set_config(config)
     }
 }
 

--- a/embassy-embedded-hal/src/adapter/yielding_async.rs
+++ b/embassy-embedded-hal/src/adapter/yielding_async.rs
@@ -1,5 +1,7 @@
 use embassy_futures::yield_now;
 
+use crate::SetConfig;
+
 /// Wrapper that yields for each operation to the wrapped instance
 ///
 /// This can be used in combination with [super::BlockingAsync] to enforce yields
@@ -101,6 +103,18 @@ where
         self.wrapped.transfer_in_place(words).await?;
         yield_now().await;
         Ok(())
+    }
+}
+
+///
+/// Implementations relating to both I2C and SPI
+///
+
+impl<T: SetConfig> SetConfig for YieldingAsync<T> {
+    type Config = T::Config;
+    type ConfigError = T::ConfigError;
+    fn set_config(&mut self, config: &Self::Config) -> Result<(), Self::ConfigError> {
+        self.wrapped.set_config(config)
     }
 }
 


### PR DESCRIPTION
This implements `SetConfig` for `YieldingAsync` and `BlockingAsync` adapters.

The `YieldingAsync` implementation in particular is to support a workaround for #1061 because prior to this change, I could not use the `YieldingAsync` adapter to enforce `yield_now().await` alongside SPI read/write/transaction operations when also using `embassy_embedded_hal::shared_bus::asynch::spi::SpiDeviceWithConfig`.