### PR TITLE
stm32: ETH PTP timestamps

### DIFF
--- a/embassy-net-driver/src/lib.rs
+++ b/embassy-net-driver/src/lib.rs
@@ -21,6 +21,14 @@ pub struct PacketMeta {
     pub id: u32,
 }
 
+impl PacketMeta {
+    /// Empty packet metadata.
+    pub const EMPTY: Self = Self {
+        #[cfg(feature = "packetmeta-id")]
+        id: 0,
+    };
+}
+
 /// Representation of an hardware address, such as an Ethernet address or an IEEE802.15.4 address.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]

--- a/embassy-stm32/Cargo.toml
+++ b/embassy-stm32/Cargo.toml
@@ -55,6 +55,7 @@ build = [
     {target = "thumbv7em-none-eabi", features = ["defmt", "exti", "stm32f730i8", "time", "time-driver-any"]},
     {target = "thumbv7em-none-eabi", features = ["defmt", "exti", "stm32h753zi", "time", "time-driver-any"]},
     {target = "thumbv7em-none-eabi", features = ["defmt", "exti", "ptp", "stm32h753zi"]},
+    {target = "thumbv7em-none-eabi", features = ["exti", "log", "ptp", "stm32h753zi"]},
     {target = "thumbv7em-none-eabi", features = ["defmt", "exti", "stm32h735zg", "time", "time-driver-any"]},
     {target = "thumbv7em-none-eabi", features = ["defmt", "exti", "split-pc2", "split-pc3", "stm32h755zi-cm7", "time", "time-driver-any"]},
     {target = "thumbv7em-none-eabi", features = ["defmt", "exti", "stm32h725re", "time", "time-driver-any"]},

--- a/embassy-stm32/Cargo.toml
+++ b/embassy-stm32/Cargo.toml
@@ -249,6 +249,8 @@ defmt = [
 ]
 ## Use log for logging
 log = ["dep:log"]
+## Enable Ethernet PTP hardware timestamping.
+ptp = ["embassy-net-driver/packetmeta-id"]
 ## Enable chrono support
 chrono = ["dep:chrono"]
 ## Enable cyw

--- a/embassy-stm32/Cargo.toml
+++ b/embassy-stm32/Cargo.toml
@@ -54,6 +54,7 @@ build = [
     {target = "thumbv7em-none-eabi", features = ["defmt", "exti", "stm32f479zi", "time", "time-driver-any"]},
     {target = "thumbv7em-none-eabi", features = ["defmt", "exti", "stm32f730i8", "time", "time-driver-any"]},
     {target = "thumbv7em-none-eabi", features = ["defmt", "exti", "stm32h753zi", "time", "time-driver-any"]},
+    {target = "thumbv7em-none-eabi", features = ["defmt", "exti", "ptp", "stm32h753zi"]},
     {target = "thumbv7em-none-eabi", features = ["defmt", "exti", "stm32h735zg", "time", "time-driver-any"]},
     {target = "thumbv7em-none-eabi", features = ["defmt", "exti", "split-pc2", "split-pc3", "stm32h755zi-cm7", "time", "time-driver-any"]},
     {target = "thumbv7em-none-eabi", features = ["defmt", "exti", "stm32h725re", "time", "time-driver-any"]},

--- a/embassy-stm32/src/eth/mod.rs
+++ b/embassy-stm32/src/eth/mod.rs
@@ -51,10 +51,50 @@ pub struct PacketQueue<const TX: usize, const RX: usize> {
     packet_state: PacketStateStorage<TX, RX>,
 }
 
+/// Ethernet packet queue configuration.
+///
+/// This carries optional packet-queue services that need storage owned outside
+/// the DMA descriptor rings.
+#[derive(Clone, Copy)]
+pub struct PacketQueueConfig {
+    ptp: PtpStorage,
+}
+
+impl PacketQueueConfig {
+    /// Create a packet queue configuration with no optional services enabled.
+    pub const fn new() -> Self {
+        Self { ptp: PtpStorage::new() }
+    }
+
+    /// Attach Ethernet PTP timestamp storage.
+    ///
+    /// The MAC PTP clock, snapshot control, and filters must be configured
+    /// separately before timestamps will be produced by hardware.
+    #[cfg(all(feature = "ptp", any(eth_v2, eth_v2a)))]
+    pub const fn ptp<const PTP_TX: usize, const PTP_RX: usize>(
+        mut self,
+        timestamps: &'static PtpTimestampStore<PTP_TX, PTP_RX>,
+    ) -> Self {
+        self.ptp = PtpStorage::new_with_store(timestamps);
+        self
+    }
+}
+
+impl Default for PacketQueueConfig {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl<const TX: usize, const RX: usize> PacketQueue<TX, RX> {
     /// Create a new packet queue.
     pub const fn new() -> Self {
-        Self::new_inner(PtpStorage::new())
+        Self::new_with_config(PacketQueueConfig::new())
+    }
+
+    /// Create a new packet queue with optional services.
+    pub const fn new_with_config(config: PacketQueueConfig) -> Self {
+        Self::new_inner(config)
     }
 
     /// Create a new packet queue with Ethernet PTP timestamp storage.
@@ -66,16 +106,16 @@ impl<const TX: usize, const RX: usize> PacketQueue<TX, RX> {
     pub const fn new_with_ptp<const PTP_TX: usize, const PTP_RX: usize>(
         timestamps: &'static PtpTimestampStore<PTP_TX, PTP_RX>,
     ) -> Self {
-        Self::new_inner(PtpStorage::new_with_store(timestamps))
+        Self::new_with_config(PacketQueueConfig::new().ptp(timestamps))
     }
 
-    const fn new_inner(timestamps: PtpStorage) -> Self {
+    const fn new_inner(config: PacketQueueConfig) -> Self {
         Self {
             tx_desc: [const { TDes::new() }; TX],
             rx_desc: [const { RDes::new() }; RX],
             tx_buf: [Packet([0; TX_BUFFER_SIZE]); TX],
             rx_buf: [Packet([0; RX_BUFFER_SIZE]); RX],
-            packet_state: PacketStateStorage::new(timestamps),
+            packet_state: PacketStateStorage::new(config.ptp),
         }
     }
 
@@ -92,9 +132,16 @@ impl<const TX: usize, const RX: usize> PacketQueue<TX, RX> {
     ///
     /// After calling this function, calling `assume_init` on the MaybeUninit is guaranteed safe.
     pub fn init(this: &mut MaybeUninit<Self>) {
+        Self::init_with_config(this, PacketQueueConfig::new());
+    }
+
+    /// Initialize a packet queue in-place with optional services.
+    ///
+    /// This is the configurable equivalent of [`PacketQueue::init`].
+    pub fn init_with_config(this: &mut MaybeUninit<Self>, config: PacketQueueConfig) {
         unsafe {
             this.as_mut_ptr().write_bytes(0u8, 1);
-            addr_of_mut!((*this.as_mut_ptr()).packet_state).write(PacketStateStorage::new(PtpStorage::new()));
+            addr_of_mut!((*this.as_mut_ptr()).packet_state).write(PacketStateStorage::new(config.ptp));
         }
     }
 
@@ -108,11 +155,7 @@ impl<const TX: usize, const RX: usize> PacketQueue<TX, RX> {
         this: &mut MaybeUninit<Self>,
         timestamps: &'static PtpTimestampStore<PTP_TX, PTP_RX>,
     ) {
-        unsafe {
-            this.as_mut_ptr().write_bytes(0u8, 1);
-            addr_of_mut!((*this.as_mut_ptr()).packet_state)
-                .write(PacketStateStorage::new(PtpStorage::new_with_store(timestamps)));
-        }
+        Self::init_with_config(this, PacketQueueConfig::new().ptp(timestamps));
     }
 }
 

--- a/embassy-stm32/src/eth/mod.rs
+++ b/embassy-stm32/src/eth/mod.rs
@@ -19,8 +19,8 @@ use embassy_sync::waitqueue::AtomicWaker;
 
 pub use self::_version::{InterruptHandler, *};
 pub use self::generic_phy::*;
-use self::packet_state::PacketStateStorage;
-use self::ptp::PtpStorage;
+use self::packet_state::PacketState;
+use self::ptp::PtpTimestampSink;
 #[cfg(feature = "ptp")]
 pub use self::ptp::{PtpTimestamp, PtpTimestampStore};
 pub use self::sma::{Instance as SmaInstance, Sma, StationManagement};
@@ -48,53 +48,13 @@ pub struct PacketQueue<const TX: usize, const RX: usize> {
     rx_desc: [RDes; RX],
     tx_buf: [Packet<TX_BUFFER_SIZE>; TX],
     rx_buf: [Packet<RX_BUFFER_SIZE>; RX],
-    packet_state: PacketStateStorage<TX, RX>,
-}
-
-/// Ethernet packet queue configuration.
-///
-/// This carries optional packet-queue services that need storage owned outside
-/// the DMA descriptor rings.
-#[derive(Clone, Copy)]
-pub struct PacketQueueConfig {
-    ptp: PtpStorage,
-}
-
-impl PacketQueueConfig {
-    /// Create a packet queue configuration with no optional services enabled.
-    pub const fn new() -> Self {
-        Self { ptp: PtpStorage::new() }
-    }
-
-    /// Attach Ethernet PTP timestamp storage.
-    ///
-    /// The MAC PTP clock, snapshot control, and filters must be configured
-    /// separately before timestamps will be produced by hardware.
-    #[cfg(feature = "ptp")]
-    pub const fn ptp<const PTP_TX: usize, const PTP_RX: usize>(
-        mut self,
-        timestamps: &'static PtpTimestampStore<PTP_TX, PTP_RX>,
-    ) -> Self {
-        self.ptp = PtpStorage::new_with_store(timestamps);
-        self
-    }
-}
-
-impl Default for PacketQueueConfig {
-    fn default() -> Self {
-        Self::new()
-    }
+    packet_state: PacketState<TX, RX>,
 }
 
 impl<const TX: usize, const RX: usize> PacketQueue<TX, RX> {
     /// Create a new packet queue.
     pub const fn new() -> Self {
-        Self::new_with_config(PacketQueueConfig::new())
-    }
-
-    /// Create a new packet queue with optional services.
-    pub const fn new_with_config(config: PacketQueueConfig) -> Self {
-        Self::new_inner(config)
+        Self::new_inner(PtpTimestampSink::new())
     }
 
     /// Create a new packet queue with Ethernet PTP timestamp storage.
@@ -106,16 +66,16 @@ impl<const TX: usize, const RX: usize> PacketQueue<TX, RX> {
     pub const fn new_with_ptp<const PTP_TX: usize, const PTP_RX: usize>(
         timestamps: &'static PtpTimestampStore<PTP_TX, PTP_RX>,
     ) -> Self {
-        Self::new_with_config(PacketQueueConfig::new().ptp(timestamps))
+        Self::new_inner(PtpTimestampSink::from_store(timestamps))
     }
 
-    const fn new_inner(config: PacketQueueConfig) -> Self {
+    const fn new_inner(ptp: PtpTimestampSink) -> Self {
         Self {
             tx_desc: [const { TDes::new() }; TX],
             rx_desc: [const { RDes::new() }; RX],
             tx_buf: [Packet([0; TX_BUFFER_SIZE]); TX],
             rx_buf: [Packet([0; RX_BUFFER_SIZE]); RX],
-            packet_state: PacketStateStorage::new(config.ptp),
+            packet_state: PacketState::new(ptp),
         }
     }
 
@@ -132,16 +92,9 @@ impl<const TX: usize, const RX: usize> PacketQueue<TX, RX> {
     ///
     /// After calling this function, calling `assume_init` on the MaybeUninit is guaranteed safe.
     pub fn init(this: &mut MaybeUninit<Self>) {
-        Self::init_with_config(this, PacketQueueConfig::new());
-    }
-
-    /// Initialize a packet queue in-place with optional services.
-    ///
-    /// This is the configurable equivalent of [`PacketQueue::init`].
-    pub fn init_with_config(this: &mut MaybeUninit<Self>, config: PacketQueueConfig) {
         unsafe {
             this.as_mut_ptr().write_bytes(0u8, 1);
-            addr_of_mut!((*this.as_mut_ptr()).packet_state).write(PacketStateStorage::new(config.ptp));
+            addr_of_mut!((*this.as_mut_ptr()).packet_state).write(PacketState::new(PtpTimestampSink::new()));
         }
     }
 
@@ -155,7 +108,11 @@ impl<const TX: usize, const RX: usize> PacketQueue<TX, RX> {
         this: &mut MaybeUninit<Self>,
         timestamps: &'static PtpTimestampStore<PTP_TX, PTP_RX>,
     ) {
-        Self::init_with_config(this, PacketQueueConfig::new().ptp(timestamps));
+        unsafe {
+            this.as_mut_ptr().write_bytes(0u8, 1);
+            addr_of_mut!((*this.as_mut_ptr()).packet_state)
+                .write(PacketState::new(PtpTimestampSink::from_store(timestamps)));
+        }
     }
 }
 

--- a/embassy-stm32/src/eth/mod.rs
+++ b/embassy-stm32/src/eth/mod.rs
@@ -57,11 +57,13 @@ impl<const TX: usize, const RX: usize> PacketQueue<TX, RX> {
         Self::new_inner(PtpTimestampSink::new())
     }
 
-    /// Create a new packet queue with Ethernet PTP timestamp storage.
+    /// Create a new packet queue with Ethernet PTP packet timestamps.
     ///
-    /// This attaches PTP timestamp storage to the descriptor rings. The MAC PTP
-    /// clock, snapshot control, and filters must be configured separately before
-    /// timestamps will be produced by hardware.
+    /// The queue records hardware RX/TX timestamps in `timestamps`. Use the
+    /// [`PacketMeta`] supplied by `embassy-net` to retrieve them from the store.
+    ///
+    /// The MAC PTP clock and timestamping registers must be configured
+    /// separately before the hardware will produce timestamps.
     #[cfg(feature = "ptp")]
     pub const fn new_with_ptp<const PTP_TX: usize, const PTP_RX: usize>(
         timestamps: &'static PtpTimestampStore<PTP_TX, PTP_RX>,
@@ -98,11 +100,11 @@ impl<const TX: usize, const RX: usize> PacketQueue<TX, RX> {
         }
     }
 
-    /// Initialize a packet queue in-place with Ethernet PTP timestamp storage.
+    /// Initialize a packet queue in-place with Ethernet PTP packet timestamps.
     ///
     /// This is the PTP equivalent of [`PacketQueue::init`]. It avoids a
     /// temporary stack allocation of the full packet queue while still attaching
-    /// the timestamp storage required for PTP packet timestamp lookup.
+    /// the timestamp store used for packet timestamp lookup.
     #[cfg(feature = "ptp")]
     pub fn init_with_ptp<const PTP_TX: usize, const PTP_RX: usize>(
         this: &mut MaybeUninit<Self>,

--- a/embassy-stm32/src/eth/mod.rs
+++ b/embassy-stm32/src/eth/mod.rs
@@ -130,6 +130,7 @@ impl<'d, T: Instance, P: Phy> embassy_net_driver::Driver for Ethernet<'d, T, P> 
 
     fn receive(&mut self, cx: &mut Context) -> Option<(Self::RxToken<'_>, Self::TxToken<'_>)> {
         WAKER.register(cx.waker());
+        self.tx.collect_completed();
         if self.rx.available().is_some() && self.tx.available().is_some() {
             Some((RxToken { rx: &mut self.rx }, TxToken { tx: &mut self.tx }))
         } else {

--- a/embassy-stm32/src/eth/mod.rs
+++ b/embassy-stm32/src/eth/mod.rs
@@ -21,7 +21,7 @@ pub use self::_version::{InterruptHandler, *};
 pub use self::generic_phy::*;
 use self::packet_state::PacketStateStorage;
 use self::ptp::PtpStorage;
-#[cfg(all(feature = "ptp", any(eth_v2, eth_v2a)))]
+#[cfg(feature = "ptp")]
 pub use self::ptp::{PtpTimestamp, PtpTimestampStore};
 pub use self::sma::{Instance as SmaInstance, Sma, StationManagement};
 use crate::rcc::RccPeripheral;
@@ -70,7 +70,7 @@ impl PacketQueueConfig {
     ///
     /// The MAC PTP clock, snapshot control, and filters must be configured
     /// separately before timestamps will be produced by hardware.
-    #[cfg(all(feature = "ptp", any(eth_v2, eth_v2a)))]
+    #[cfg(feature = "ptp")]
     pub const fn ptp<const PTP_TX: usize, const PTP_RX: usize>(
         mut self,
         timestamps: &'static PtpTimestampStore<PTP_TX, PTP_RX>,
@@ -102,7 +102,7 @@ impl<const TX: usize, const RX: usize> PacketQueue<TX, RX> {
     /// This attaches PTP timestamp storage to the descriptor rings. The MAC PTP
     /// clock, snapshot control, and filters must be configured separately before
     /// timestamps will be produced by hardware.
-    #[cfg(all(feature = "ptp", any(eth_v2, eth_v2a)))]
+    #[cfg(feature = "ptp")]
     pub const fn new_with_ptp<const PTP_TX: usize, const PTP_RX: usize>(
         timestamps: &'static PtpTimestampStore<PTP_TX, PTP_RX>,
     ) -> Self {
@@ -150,7 +150,7 @@ impl<const TX: usize, const RX: usize> PacketQueue<TX, RX> {
     /// This is the PTP equivalent of [`PacketQueue::init`]. It avoids a
     /// temporary stack allocation of the full packet queue while still attaching
     /// the timestamp storage required for PTP packet timestamp lookup.
-    #[cfg(all(feature = "ptp", any(eth_v2, eth_v2a)))]
+    #[cfg(feature = "ptp")]
     pub fn init_with_ptp<const PTP_TX: usize, const PTP_RX: usize>(
         this: &mut MaybeUninit<Self>,
         timestamps: &'static PtpTimestampStore<PTP_TX, PTP_RX>,

--- a/embassy-stm32/src/eth/mod.rs
+++ b/embassy-stm32/src/eth/mod.rs
@@ -5,17 +5,24 @@
 #[cfg_attr(any(eth_v2, eth_v2a), path = "v2/mod.rs")]
 mod _version;
 mod generic_phy;
+mod packet_state;
+mod ptp;
 mod sma;
 
 use core::mem::MaybeUninit;
+use core::ptr::addr_of_mut;
 use core::task::Context;
 
 use embassy_hal_internal::PeripheralType;
-use embassy_net_driver::{Capabilities, HardwareAddress, LinkState};
+use embassy_net_driver::{Capabilities, HardwareAddress, LinkState, PacketMeta};
 use embassy_sync::waitqueue::AtomicWaker;
 
 pub use self::_version::{InterruptHandler, *};
 pub use self::generic_phy::*;
+use self::packet_state::PacketStateStorage;
+use self::ptp::PtpStorage;
+#[cfg(all(feature = "ptp", any(eth_v2, eth_v2a)))]
+pub use self::ptp::{PtpTimestamp, PtpTimestampStore};
 pub use self::sma::{Instance as SmaInstance, Sma, StationManagement};
 use crate::rcc::RccPeripheral;
 
@@ -41,16 +48,34 @@ pub struct PacketQueue<const TX: usize, const RX: usize> {
     rx_desc: [RDes; RX],
     tx_buf: [Packet<TX_BUFFER_SIZE>; TX],
     rx_buf: [Packet<RX_BUFFER_SIZE>; RX],
+    packet_state: PacketStateStorage<TX, RX>,
 }
 
 impl<const TX: usize, const RX: usize> PacketQueue<TX, RX> {
     /// Create a new packet queue.
     pub const fn new() -> Self {
+        Self::new_inner(PtpStorage::new())
+    }
+
+    /// Create a new packet queue with Ethernet PTP timestamp storage.
+    ///
+    /// This attaches PTP timestamp storage to the descriptor rings. The MAC PTP
+    /// clock, snapshot control, and filters must be configured separately before
+    /// timestamps will be produced by hardware.
+    #[cfg(all(feature = "ptp", any(eth_v2, eth_v2a)))]
+    pub const fn new_with_ptp<const PTP_TX: usize, const PTP_RX: usize>(
+        timestamps: &'static PtpTimestampStore<PTP_TX, PTP_RX>,
+    ) -> Self {
+        Self::new_inner(PtpStorage::new_with_store(timestamps))
+    }
+
+    const fn new_inner(timestamps: PtpStorage) -> Self {
         Self {
             tx_desc: [const { TDes::new() }; TX],
             rx_desc: [const { RDes::new() }; RX],
             tx_buf: [Packet([0; TX_BUFFER_SIZE]); TX],
             rx_buf: [Packet([0; RX_BUFFER_SIZE]); RX],
+            packet_state: PacketStateStorage::new(timestamps),
         }
     }
 
@@ -69,6 +94,24 @@ impl<const TX: usize, const RX: usize> PacketQueue<TX, RX> {
     pub fn init(this: &mut MaybeUninit<Self>) {
         unsafe {
             this.as_mut_ptr().write_bytes(0u8, 1);
+            addr_of_mut!((*this.as_mut_ptr()).packet_state).write(PacketStateStorage::new(PtpStorage::new()));
+        }
+    }
+
+    /// Initialize a packet queue in-place with Ethernet PTP timestamp storage.
+    ///
+    /// This is the PTP equivalent of [`PacketQueue::init`]. It avoids a
+    /// temporary stack allocation of the full packet queue while still attaching
+    /// the timestamp storage required for PTP packet timestamp lookup.
+    #[cfg(all(feature = "ptp", any(eth_v2, eth_v2a)))]
+    pub fn init_with_ptp<const PTP_TX: usize, const PTP_RX: usize>(
+        this: &mut MaybeUninit<Self>,
+        timestamps: &'static PtpTimestampStore<PTP_TX, PTP_RX>,
+    ) {
+        unsafe {
+            this.as_mut_ptr().write_bytes(0u8, 1);
+            addr_of_mut!((*this.as_mut_ptr()).packet_state)
+                .write(PacketStateStorage::new(PtpStorage::new_with_store(timestamps)));
         }
     }
 }
@@ -139,6 +182,10 @@ pub struct RxToken<'a, 'd> {
 }
 
 impl<'a, 'd> embassy_net_driver::RxToken for RxToken<'a, 'd> {
+    fn meta(&self) -> PacketMeta {
+        self.rx.meta()
+    }
+
     fn consume<R, F>(self, f: F) -> R
     where
         F: FnOnce(&mut [u8]) -> R,
@@ -157,6 +204,10 @@ pub struct TxToken<'a, 'd> {
 }
 
 impl<'a, 'd> embassy_net_driver::TxToken for TxToken<'a, 'd> {
+    fn set_meta(&mut self, meta: PacketMeta) {
+        self.tx.set_meta(meta);
+    }
+
     fn consume<R, F>(self, len: usize, f: F) -> R
     where
         F: FnOnce(&mut [u8]) -> R,

--- a/embassy-stm32/src/eth/packet_state.rs
+++ b/embassy-stm32/src/eth/packet_state.rs
@@ -78,7 +78,6 @@ impl TxPacketStateRing<'_> {
         let _ = index;
     }
 
-    #[cfg(any(eth_v2, eth_v2a))]
     pub(crate) fn pending(&self, index: usize) -> bool {
         #[cfg(feature = "ptp")]
         {
@@ -91,12 +90,10 @@ impl TxPacketStateRing<'_> {
         }
     }
 
-    #[cfg(any(eth_v2, eth_v2a))]
     pub(crate) fn timestamp_enabled(&self) -> bool {
         self.ptp.enabled() && self.next_id() != 0
     }
 
-    #[cfg(any(eth_v2, eth_v2a))]
     pub(crate) fn next_id(&self) -> u32 {
         #[cfg(feature = "ptp")]
         {
@@ -113,7 +110,6 @@ impl TxPacketStateRing<'_> {
         self.clear(index);
     }
 
-    #[cfg(any(eth_v2, eth_v2a))]
     pub(crate) fn id(&self, index: usize) -> u32 {
         #[cfg(feature = "ptp")]
         {

--- a/embassy-stm32/src/eth/packet_state.rs
+++ b/embassy-stm32/src/eth/packet_state.rs
@@ -1,189 +1,166 @@
-use embassy_net_driver::PacketMeta;
+#[cfg(feature = "ptp")]
+mod imp {
+    use embassy_net_driver::PacketMeta;
 
-use super::ptp::{PtpTimestamp, PtpTimestampSink, RxPtpRing, TxPtpRing};
+    use super::super::ptp::{PtpTimestamp, PtpTimestampSink, RxPtpRing, TxPtpRing};
 
-pub(crate) struct PacketState<const TX: usize, const RX: usize> {
-    #[cfg(feature = "ptp")]
-    tx_meta: [PacketMeta; TX],
-    #[cfg(feature = "ptp")]
-    tx_in_flight: [bool; TX],
-    #[cfg(feature = "ptp")]
-    rx_meta: [PacketMeta; RX],
-    ptp: PtpTimestampSink,
-}
+    pub(crate) struct PacketState<const TX: usize, const RX: usize> {
+        tx_meta: [PacketMeta; TX],
+        tx_in_flight: [bool; TX],
+        rx_meta: [PacketMeta; RX],
+        ptp: PtpTimestampSink,
+    }
 
-impl<const TX: usize, const RX: usize> PacketState<TX, RX> {
-    pub(crate) const fn new(ptp: PtpTimestampSink) -> Self {
-        Self {
-            #[cfg(feature = "ptp")]
-            tx_meta: [const { PacketMeta::EMPTY }; TX],
-            #[cfg(feature = "ptp")]
-            tx_in_flight: [false; TX],
-            #[cfg(feature = "ptp")]
-            rx_meta: [const { PacketMeta::EMPTY }; RX],
-            ptp,
+    impl<const TX: usize, const RX: usize> PacketState<TX, RX> {
+        pub(crate) const fn new(ptp: PtpTimestampSink) -> Self {
+            Self {
+                tx_meta: [const { PacketMeta::EMPTY }; TX],
+                tx_in_flight: [false; TX],
+                rx_meta: [const { PacketMeta::EMPTY }; RX],
+                ptp,
+            }
+        }
+
+        pub(crate) fn split(&mut self) -> (TxPacketStateRing<'_>, RxPacketStateRing<'_>) {
+            (
+                TxPacketStateRing {
+                    ptp: self.ptp.tx(),
+                    meta: &mut self.tx_meta,
+                    next_tx: PacketMeta::EMPTY,
+                    in_flight: &mut self.tx_in_flight,
+                },
+                RxPacketStateRing {
+                    ptp: self.ptp.rx(),
+                    meta: &mut self.rx_meta,
+                    next_rx_id: 1,
+                },
+            )
         }
     }
 
-    pub(crate) fn split(&mut self) -> (TxPacketStateRing<'_>, RxPacketStateRing<'_>) {
-        (
-            TxPacketStateRing {
-                ptp: self.ptp.tx(),
-                #[cfg(feature = "ptp")]
-                meta: &mut self.tx_meta,
-                #[cfg(feature = "ptp")]
-                next_tx: PacketMeta::EMPTY,
-                #[cfg(feature = "ptp")]
-                in_flight: &mut self.tx_in_flight,
-            },
-            RxPacketStateRing {
-                ptp: self.ptp.rx(),
-                #[cfg(feature = "ptp")]
-                meta: &mut self.rx_meta,
-                #[cfg(feature = "ptp")]
-                next_rx_id: 1,
-            },
-        )
+    pub(crate) struct TxPacketStateRing<'a> {
+        ptp: TxPtpRing<'a>,
+        meta: &'a mut [PacketMeta],
+        next_tx: PacketMeta,
+        in_flight: &'a mut [bool],
     }
-}
 
-pub(crate) struct TxPacketStateRing<'a> {
-    ptp: TxPtpRing<'a>,
-    #[cfg(feature = "ptp")]
-    meta: &'a mut [PacketMeta],
-    #[cfg(feature = "ptp")]
-    next_tx: PacketMeta,
-    #[cfg(feature = "ptp")]
-    in_flight: &'a mut [bool],
-}
-
-impl TxPacketStateRing<'_> {
-    pub(crate) fn set_meta(&mut self, meta: PacketMeta) {
-        #[cfg(feature = "ptp")]
-        {
+    impl TxPacketStateRing<'_> {
+        pub(crate) fn set_meta(&mut self, meta: PacketMeta) {
             self.next_tx = meta;
         }
-        #[cfg(not(feature = "ptp"))]
-        let _ = meta;
-    }
 
-    pub(crate) fn commit(&mut self, index: usize) {
-        #[cfg(feature = "ptp")]
-        {
+        pub(crate) fn commit(&mut self, index: usize) {
             self.in_flight[index] = true;
             self.meta[index] = self.next_tx;
             self.next_tx = PacketMeta::EMPTY;
         }
-        #[cfg(not(feature = "ptp"))]
-        let _ = index;
-    }
 
-    #[cfg(any(eth_v2, eth_v2a))]
-    pub(crate) fn pending(&self, index: usize) -> bool {
-        #[cfg(feature = "ptp")]
-        {
+        pub(crate) fn pending(&self, index: usize) -> bool {
             self.in_flight[index]
         }
-        #[cfg(not(feature = "ptp"))]
-        {
-            let _ = index;
-            false
+
+        pub(crate) fn timestamp_enabled(&self) -> bool {
+            self.ptp.enabled() && self.next_tx.id != 0
         }
-    }
 
-    #[cfg(any(eth_v2, eth_v2a))]
-    pub(crate) fn timestamp_enabled(&self) -> bool {
-        self.ptp.enabled() && self.next_id() != 0
-    }
-
-    #[cfg(any(eth_v2, eth_v2a))]
-    pub(crate) fn next_id(&self) -> u32 {
-        #[cfg(feature = "ptp")]
-        {
+        pub(crate) fn next_id(&self) -> u32 {
             self.next_tx.id
         }
-        #[cfg(not(feature = "ptp"))]
-        {
-            0
+
+        pub(crate) fn complete(&mut self, index: usize, timestamp: Option<PtpTimestamp>) {
+            self.ptp.store(self.id(index), timestamp);
+            self.clear(index);
         }
-    }
 
-    pub(crate) fn complete(&mut self, index: usize, timestamp: Option<PtpTimestamp>) {
-        self.ptp.store(self.id(index), timestamp);
-        self.clear(index);
-    }
-
-    pub(crate) fn id(&self, index: usize) -> u32 {
-        #[cfg(feature = "ptp")]
-        {
+        pub(crate) fn id(&self, index: usize) -> u32 {
             self.meta[index].id
         }
-        #[cfg(not(feature = "ptp"))]
-        {
-            let _ = index;
-            0
-        }
-    }
 
-    fn clear(&mut self, index: usize) {
-        #[cfg(feature = "ptp")]
-        {
+        fn clear(&mut self, index: usize) {
             self.in_flight[index] = false;
             self.meta[index] = PacketMeta::EMPTY;
         }
-        #[cfg(not(feature = "ptp"))]
-        let _ = index;
-    }
-}
-
-pub(crate) struct RxPacketStateRing<'a> {
-    ptp: RxPtpRing<'a>,
-    #[cfg(feature = "ptp")]
-    meta: &'a mut [PacketMeta],
-    #[cfg(feature = "ptp")]
-    next_rx_id: u32,
-}
-
-impl RxPacketStateRing<'_> {
-    pub(crate) fn capture(&mut self, index: usize, timestamp: Option<PtpTimestamp>) {
-        let packet_id = self.ensure_rx(index);
-        self.ptp.store(packet_id, timestamp);
     }
 
-    pub(crate) fn meta(&self, index: usize) -> PacketMeta {
-        #[cfg(feature = "ptp")]
-        {
+    pub(crate) struct RxPacketStateRing<'a> {
+        ptp: RxPtpRing<'a>,
+        meta: &'a mut [PacketMeta],
+        next_rx_id: u32,
+    }
+
+    impl RxPacketStateRing<'_> {
+        pub(crate) fn capture(&mut self, index: usize, timestamp: Option<PtpTimestamp>) {
+            let packet_id = self.ensure_rx(index);
+            self.ptp.store(packet_id, timestamp);
+        }
+
+        pub(crate) fn meta(&self, index: usize) -> PacketMeta {
             self.meta[index]
         }
-        #[cfg(not(feature = "ptp"))]
-        {
-            let _ = index;
-            PacketMeta::EMPTY
-        }
-    }
 
-    pub(crate) fn clear(&mut self, index: usize) {
-        #[cfg(feature = "ptp")]
-        {
+        pub(crate) fn clear(&mut self, index: usize) {
             self.meta[index] = PacketMeta::EMPTY;
         }
-        #[cfg(not(feature = "ptp"))]
-        let _ = index;
-    }
 
-    fn ensure_rx(&mut self, index: usize) -> u32 {
-        #[cfg(feature = "ptp")]
-        {
+        fn ensure_rx(&mut self, index: usize) -> u32 {
             if self.meta[index].id == 0 {
                 self.meta[index].id = self.next_rx_id;
                 self.next_rx_id = self.next_rx_id.wrapping_add(1).max(1);
             }
             self.meta[index].id
         }
-        #[cfg(not(feature = "ptp"))]
-        {
+    }
+}
+
+#[cfg(not(feature = "ptp"))]
+mod imp {
+    use core::marker::PhantomData;
+
+    use embassy_net_driver::PacketMeta;
+
+    use super::super::ptp::{PtpTimestamp, PtpTimestampSink};
+
+    pub(crate) struct PacketState<const TX: usize, const RX: usize>;
+
+    impl<const TX: usize, const RX: usize> PacketState<TX, RX> {
+        pub(crate) const fn new(_ptp: PtpTimestampSink) -> Self {
+            Self
+        }
+
+        pub(crate) fn split(&mut self) -> (TxPacketStateRing<'_>, RxPacketStateRing<'_>) {
+            (TxPacketStateRing(PhantomData), RxPacketStateRing(PhantomData))
+        }
+    }
+
+    pub(crate) struct TxPacketStateRing<'a>(PhantomData<&'a mut ()>);
+
+    impl TxPacketStateRing<'_> {
+        pub(crate) fn set_meta(&mut self, meta: PacketMeta) {
+            let _ = meta;
+        }
+
+        pub(crate) fn commit(&mut self, index: usize) {
             let _ = index;
-            0
+        }
+    }
+
+    pub(crate) struct RxPacketStateRing<'a>(PhantomData<&'a mut ()>);
+
+    impl RxPacketStateRing<'_> {
+        pub(crate) fn capture(&mut self, index: usize, timestamp: Option<PtpTimestamp>) {
+            let _ = (index, timestamp);
+        }
+
+        pub(crate) fn meta(&self, index: usize) -> PacketMeta {
+            let _ = index;
+            PacketMeta::EMPTY
+        }
+
+        pub(crate) fn clear(&mut self, index: usize) {
+            let _ = index;
         }
     }
 }
+
+pub(crate) use imp::{PacketState, RxPacketStateRing, TxPacketStateRing};

--- a/embassy-stm32/src/eth/packet_state.rs
+++ b/embassy-stm32/src/eth/packet_state.rs
@@ -1,0 +1,190 @@
+use embassy_net_driver::PacketMeta;
+
+use super::ptp::{PtpStorage, PtpTimestamp, RxPtpRing, TxPtpRing};
+
+pub(crate) struct PacketStateStorage<const TX: usize, const RX: usize> {
+    #[cfg(feature = "ptp")]
+    tx_meta: [PacketMeta; TX],
+    #[cfg(feature = "ptp")]
+    tx_in_flight: [bool; TX],
+    #[cfg(feature = "ptp")]
+    rx_meta: [PacketMeta; RX],
+    ptp: PtpStorage,
+}
+
+impl<const TX: usize, const RX: usize> PacketStateStorage<TX, RX> {
+    pub(crate) const fn new(ptp: PtpStorage) -> Self {
+        Self {
+            #[cfg(feature = "ptp")]
+            tx_meta: [const { PacketMeta::EMPTY }; TX],
+            #[cfg(feature = "ptp")]
+            tx_in_flight: [false; TX],
+            #[cfg(feature = "ptp")]
+            rx_meta: [const { PacketMeta::EMPTY }; RX],
+            ptp,
+        }
+    }
+
+    pub(crate) fn rings(&mut self) -> (TxPacketStateRing<'_>, RxPacketStateRing<'_>) {
+        (
+            TxPacketStateRing {
+                ptp: self.ptp.tx(),
+                #[cfg(feature = "ptp")]
+                meta: &mut self.tx_meta,
+                #[cfg(feature = "ptp")]
+                next_tx: PacketMeta::EMPTY,
+                #[cfg(feature = "ptp")]
+                in_flight: &mut self.tx_in_flight,
+            },
+            RxPacketStateRing {
+                ptp: self.ptp.rx(),
+                #[cfg(feature = "ptp")]
+                meta: &mut self.rx_meta,
+                #[cfg(feature = "ptp")]
+                next_rx_id: 1,
+            },
+        )
+    }
+}
+
+pub(crate) struct TxPacketStateRing<'a> {
+    ptp: TxPtpRing<'a>,
+    #[cfg(feature = "ptp")]
+    meta: &'a mut [PacketMeta],
+    #[cfg(feature = "ptp")]
+    next_tx: PacketMeta,
+    #[cfg(feature = "ptp")]
+    in_flight: &'a mut [bool],
+}
+
+impl TxPacketStateRing<'_> {
+    pub(crate) fn set_meta(&mut self, meta: PacketMeta) {
+        #[cfg(feature = "ptp")]
+        {
+            self.next_tx = meta;
+        }
+        #[cfg(not(feature = "ptp"))]
+        let _ = meta;
+    }
+
+    pub(crate) fn commit(&mut self, index: usize) {
+        #[cfg(feature = "ptp")]
+        {
+            self.in_flight[index] = true;
+            self.meta[index] = self.next_tx;
+            self.next_tx = PacketMeta::EMPTY;
+        }
+        #[cfg(not(feature = "ptp"))]
+        let _ = index;
+    }
+
+    #[cfg(any(eth_v2, eth_v2a))]
+    pub(crate) fn pending(&self, index: usize) -> bool {
+        #[cfg(feature = "ptp")]
+        {
+            self.in_flight[index]
+        }
+        #[cfg(not(feature = "ptp"))]
+        {
+            let _ = index;
+            false
+        }
+    }
+
+    #[cfg(any(eth_v2, eth_v2a))]
+    pub(crate) fn timestamp_enabled(&self) -> bool {
+        self.ptp.enabled() && self.next_id() != 0
+    }
+
+    #[cfg(any(eth_v2, eth_v2a))]
+    pub(crate) fn next_id(&self) -> u32 {
+        #[cfg(feature = "ptp")]
+        {
+            self.next_tx.id
+        }
+        #[cfg(not(feature = "ptp"))]
+        {
+            0
+        }
+    }
+
+    pub(crate) fn complete(&mut self, index: usize, timestamp: Option<PtpTimestamp>) {
+        self.ptp.store(self.id(index), timestamp);
+        self.clear(index);
+    }
+
+    #[cfg(any(eth_v2, eth_v2a))]
+    pub(crate) fn id(&self, index: usize) -> u32 {
+        #[cfg(feature = "ptp")]
+        {
+            self.meta[index].id
+        }
+        #[cfg(not(feature = "ptp"))]
+        {
+            let _ = index;
+            0
+        }
+    }
+
+    fn clear(&mut self, index: usize) {
+        #[cfg(feature = "ptp")]
+        {
+            self.in_flight[index] = false;
+            self.meta[index] = PacketMeta::EMPTY;
+        }
+        #[cfg(not(feature = "ptp"))]
+        let _ = index;
+    }
+}
+
+pub(crate) struct RxPacketStateRing<'a> {
+    ptp: RxPtpRing<'a>,
+    #[cfg(feature = "ptp")]
+    meta: &'a mut [PacketMeta],
+    #[cfg(feature = "ptp")]
+    next_rx_id: u32,
+}
+
+impl RxPacketStateRing<'_> {
+    pub(crate) fn capture(&mut self, index: usize, timestamp: Option<PtpTimestamp>) {
+        let packet_id = self.ensure_rx(index);
+        self.ptp.store(packet_id, timestamp);
+    }
+
+    pub(crate) fn meta(&self, index: usize) -> PacketMeta {
+        #[cfg(feature = "ptp")]
+        {
+            self.meta[index]
+        }
+        #[cfg(not(feature = "ptp"))]
+        {
+            let _ = index;
+            PacketMeta::EMPTY
+        }
+    }
+
+    pub(crate) fn clear(&mut self, index: usize) {
+        #[cfg(feature = "ptp")]
+        {
+            self.meta[index] = PacketMeta::EMPTY;
+        }
+        #[cfg(not(feature = "ptp"))]
+        let _ = index;
+    }
+
+    fn ensure_rx(&mut self, index: usize) -> u32 {
+        #[cfg(feature = "ptp")]
+        {
+            if self.meta[index].id == 0 {
+                self.meta[index].id = self.next_rx_id;
+                self.next_rx_id = self.next_rx_id.wrapping_add(1).max(1);
+            }
+            self.meta[index].id
+        }
+        #[cfg(not(feature = "ptp"))]
+        {
+            let _ = index;
+            0
+        }
+    }
+}

--- a/embassy-stm32/src/eth/packet_state.rs
+++ b/embassy-stm32/src/eth/packet_state.rs
@@ -1,19 +1,19 @@
 use embassy_net_driver::PacketMeta;
 
-use super::ptp::{PtpStorage, PtpTimestamp, RxPtpRing, TxPtpRing};
+use super::ptp::{PtpTimestamp, PtpTimestampSink, RxPtpRing, TxPtpRing};
 
-pub(crate) struct PacketStateStorage<const TX: usize, const RX: usize> {
+pub(crate) struct PacketState<const TX: usize, const RX: usize> {
     #[cfg(feature = "ptp")]
     tx_meta: [PacketMeta; TX],
     #[cfg(feature = "ptp")]
     tx_in_flight: [bool; TX],
     #[cfg(feature = "ptp")]
     rx_meta: [PacketMeta; RX],
-    ptp: PtpStorage,
+    ptp: PtpTimestampSink,
 }
 
-impl<const TX: usize, const RX: usize> PacketStateStorage<TX, RX> {
-    pub(crate) const fn new(ptp: PtpStorage) -> Self {
+impl<const TX: usize, const RX: usize> PacketState<TX, RX> {
+    pub(crate) const fn new(ptp: PtpTimestampSink) -> Self {
         Self {
             #[cfg(feature = "ptp")]
             tx_meta: [const { PacketMeta::EMPTY }; TX],
@@ -25,7 +25,7 @@ impl<const TX: usize, const RX: usize> PacketStateStorage<TX, RX> {
         }
     }
 
-    pub(crate) fn rings(&mut self) -> (TxPacketStateRing<'_>, RxPacketStateRing<'_>) {
+    pub(crate) fn split(&mut self) -> (TxPacketStateRing<'_>, RxPacketStateRing<'_>) {
         (
             TxPacketStateRing {
                 ptp: self.ptp.tx(),
@@ -78,6 +78,7 @@ impl TxPacketStateRing<'_> {
         let _ = index;
     }
 
+    #[cfg(any(eth_v2, eth_v2a))]
     pub(crate) fn pending(&self, index: usize) -> bool {
         #[cfg(feature = "ptp")]
         {
@@ -90,10 +91,12 @@ impl TxPacketStateRing<'_> {
         }
     }
 
+    #[cfg(any(eth_v2, eth_v2a))]
     pub(crate) fn timestamp_enabled(&self) -> bool {
         self.ptp.enabled() && self.next_id() != 0
     }
 
+    #[cfg(any(eth_v2, eth_v2a))]
     pub(crate) fn next_id(&self) -> u32 {
         #[cfg(feature = "ptp")]
         {

--- a/embassy-stm32/src/eth/ptp.rs
+++ b/embassy-stm32/src/eth/ptp.rs
@@ -209,10 +209,6 @@ mod imp {
 
 #[cfg(not(feature = "ptp"))]
 mod imp {
-    use core::marker::PhantomData;
-
-    use super::PtpTimestamp;
-
     #[derive(Clone, Copy)]
     pub(crate) struct PtpTimestampSink {}
 
@@ -220,42 +216,11 @@ mod imp {
         pub(crate) const fn new() -> Self {
             Self {}
         }
-
-        pub(crate) fn tx(&self) -> TxPtpRing<'static> {
-            TxPtpRing { _lifetime: PhantomData }
-        }
-
-        pub(crate) fn rx(&self) -> RxPtpRing<'static> {
-            RxPtpRing { _lifetime: PhantomData }
-        }
-    }
-
-    pub(crate) struct TxPtpRing<'a> {
-        _lifetime: PhantomData<&'a ()>,
-    }
-
-    impl TxPtpRing<'_> {
-        #[cfg(any(eth_v2, eth_v2a))]
-        pub(crate) fn enabled(&self) -> bool {
-            false
-        }
-
-        pub(crate) fn store(&self, packet_id: u32, timestamp: Option<PtpTimestamp>) {
-            let _ = (packet_id, timestamp);
-        }
-    }
-
-    pub(crate) struct RxPtpRing<'a> {
-        _lifetime: PhantomData<&'a ()>,
-    }
-
-    impl RxPtpRing<'_> {
-        pub(crate) fn store(&self, packet_id: u32, timestamp: Option<PtpTimestamp>) {
-            let _ = (packet_id, timestamp);
-        }
     }
 }
 
+pub(crate) use imp::PtpTimestampSink;
 #[cfg(feature = "ptp")]
 pub use imp::PtpTimestampStore;
-pub(crate) use imp::{PtpTimestampSink, RxPtpRing, TxPtpRing};
+#[cfg(feature = "ptp")]
+pub(crate) use imp::{RxPtpRing, TxPtpRing};

--- a/embassy-stm32/src/eth/ptp.rs
+++ b/embassy-stm32/src/eth/ptp.rs
@@ -1,4 +1,4 @@
-/// Ethernet MAC packet timestamp.
+/// Ethernet MAC PTP timestamp.
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub struct PtpTimestamp {
@@ -20,10 +20,13 @@ mod imp {
 
     use super::PtpTimestamp;
 
-    /// Shared PTP packet timestamp history.
+    /// Shared Ethernet PTP packet timestamp store.
     ///
     /// The `TX` and `RX` const parameters are timestamp history depths. They do
-    /// not need to match the Ethernet descriptor ring lengths.
+    /// not need to match the Ethernet descriptor ring lengths. Pass this store
+    /// to [`PacketQueue::new_with_ptp`](super::super::PacketQueue::new_with_ptp) or
+    /// [`PacketQueue::init_with_ptp`](super::super::PacketQueue::init_with_ptp),
+    /// then query it with the [`PacketMeta`] attached to RX and TX packets.
     pub struct PtpTimestampStore<const TX: usize, const RX: usize> {
         tx: [TimestampSlot; TX],
         rx: [TimestampSlot; RX],
@@ -40,7 +43,7 @@ mod imp {
             }
         }
 
-        /// Get the transmit timestamp recorded for `meta`.
+        /// Get the transmit timestamp for a packet.
         ///
         /// Returns `None` if the timestamp has not been recorded, if the packet
         /// was not hardware timestamped, or if the history slot was overwritten.
@@ -67,7 +70,7 @@ mod imp {
             }
         }
 
-        /// Get the receive timestamp recorded for `meta`.
+        /// Get the receive timestamp for a packet.
         ///
         /// Returns `None` if the timestamp was not recorded or if the history
         /// slot was overwritten.

--- a/embassy-stm32/src/eth/ptp.rs
+++ b/embassy-stm32/src/eth/ptp.rs
@@ -83,13 +83,13 @@ mod imp {
     }
 
     #[derive(Clone, Copy)]
-    pub(crate) struct PtpStorage {
+    pub(crate) struct PtpTimestampSink {
         tx: Option<&'static [TimestampSlot]>,
         rx: Option<&'static [TimestampSlot]>,
         tx_waker: Option<&'static AtomicWaker>,
     }
 
-    impl PtpStorage {
+    impl PtpTimestampSink {
         pub(crate) const fn new() -> Self {
             Self {
                 tx: None,
@@ -98,7 +98,7 @@ mod imp {
             }
         }
 
-        pub(crate) const fn new_with_store<const TX: usize, const RX: usize>(
+        pub(crate) const fn from_store<const TX: usize, const RX: usize>(
             store: &'static PtpTimestampStore<TX, RX>,
         ) -> Self {
             Self {
@@ -214,9 +214,9 @@ mod imp {
     use super::PtpTimestamp;
 
     #[derive(Clone, Copy)]
-    pub(crate) struct PtpStorage {}
+    pub(crate) struct PtpTimestampSink {}
 
-    impl PtpStorage {
+    impl PtpTimestampSink {
         pub(crate) const fn new() -> Self {
             Self {}
         }
@@ -235,6 +235,7 @@ mod imp {
     }
 
     impl TxPtpRing<'_> {
+        #[cfg(any(eth_v2, eth_v2a))]
         pub(crate) fn enabled(&self) -> bool {
             false
         }
@@ -257,4 +258,4 @@ mod imp {
 
 #[cfg(feature = "ptp")]
 pub use imp::PtpTimestampStore;
-pub(crate) use imp::{PtpStorage, RxPtpRing, TxPtpRing};
+pub(crate) use imp::{PtpTimestampSink, RxPtpRing, TxPtpRing};

--- a/embassy-stm32/src/eth/ptp.rs
+++ b/embassy-stm32/src/eth/ptp.rs
@@ -1,0 +1,221 @@
+/// Ethernet MAC packet timestamp.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+pub struct PtpTimestamp {
+    /// Seconds portion of the MAC timestamp.
+    pub seconds: u32,
+    /// Nanoseconds portion of the MAC timestamp.
+    pub nanos: u32,
+}
+
+#[cfg(all(feature = "ptp", any(eth_v2, eth_v2a)))]
+mod imp {
+    use core::sync::atomic::{AtomicU32, Ordering};
+
+    use embassy_net_driver::PacketMeta;
+
+    use super::PtpTimestamp;
+
+    /// Shared PTP packet timestamp history.
+    ///
+    /// The `TX` and `RX` const parameters are timestamp history depths. They do
+    /// not need to match the Ethernet descriptor ring lengths.
+    pub struct PtpTimestampStore<const TX: usize, const RX: usize> {
+        tx: [TimestampSlot; TX],
+        rx: [TimestampSlot; RX],
+    }
+
+    impl<const TX: usize, const RX: usize> PtpTimestampStore<TX, RX> {
+        /// Create an empty timestamp store.
+        pub const fn new() -> Self {
+            Self {
+                tx: [const { TimestampSlot::new() }; TX],
+                rx: [const { TimestampSlot::new() }; RX],
+            }
+        }
+
+        /// Get the transmit timestamp recorded for `meta`.
+        ///
+        /// Returns `None` if the timestamp has not been recorded, if the packet
+        /// was not hardware timestamped, or if the history slot was overwritten.
+        pub fn tx_timestamp(&self, meta: PacketMeta) -> Option<PtpTimestamp> {
+            find_timestamp(&self.tx, meta.id)
+        }
+
+        /// Get the receive timestamp recorded for `meta`.
+        ///
+        /// Returns `None` if the timestamp was not recorded or if the history
+        /// slot was overwritten.
+        pub fn rx_timestamp(&self, meta: PacketMeta) -> Option<PtpTimestamp> {
+            find_timestamp(&self.rx, meta.id)
+        }
+    }
+
+    impl<const TX: usize, const RX: usize> Default for PtpTimestampStore<TX, RX> {
+        fn default() -> Self {
+            Self::new()
+        }
+    }
+
+    #[derive(Clone, Copy)]
+    pub(crate) struct PtpStorage {
+        tx: Option<&'static [TimestampSlot]>,
+        rx: Option<&'static [TimestampSlot]>,
+    }
+
+    impl PtpStorage {
+        pub(crate) const fn new() -> Self {
+            Self { tx: None, rx: None }
+        }
+
+        pub(crate) const fn new_with_store<const TX: usize, const RX: usize>(
+            store: &'static PtpTimestampStore<TX, RX>,
+        ) -> Self {
+            Self {
+                tx: Some(&store.tx),
+                rx: Some(&store.rx),
+            }
+        }
+
+        pub(crate) fn tx(&self) -> TxPtpRing<'static> {
+            TxPtpRing { slots: self.tx }
+        }
+
+        pub(crate) fn rx(&self) -> RxPtpRing<'static> {
+            RxPtpRing { slots: self.rx }
+        }
+    }
+
+    pub(crate) struct TxPtpRing<'a> {
+        slots: Option<&'a [TimestampSlot]>,
+    }
+
+    impl TxPtpRing<'_> {
+        pub(crate) fn enabled(&self) -> bool {
+            self.slots.is_some()
+        }
+
+        pub(crate) fn store(&self, packet_id: u32, timestamp: Option<PtpTimestamp>) {
+            if let (Some(slots), Some(timestamp)) = (self.slots, timestamp) {
+                if packet_id != 0 && !slots.is_empty() {
+                    slots[slot_index(slots, packet_id)].store(packet_id, timestamp);
+                }
+            }
+        }
+    }
+
+    pub(crate) struct RxPtpRing<'a> {
+        slots: Option<&'a [TimestampSlot]>,
+    }
+
+    impl RxPtpRing<'_> {
+        pub(crate) fn store(&self, packet_id: u32, timestamp: Option<PtpTimestamp>) {
+            if let (Some(slots), Some(timestamp)) = (self.slots, timestamp) {
+                if packet_id != 0 && !slots.is_empty() {
+                    slots[slot_index(slots, packet_id)].store(packet_id, timestamp);
+                }
+            }
+        }
+    }
+
+    struct TimestampSlot {
+        id: AtomicU32,
+        seconds: AtomicU32,
+        nanos: AtomicU32,
+    }
+
+    impl TimestampSlot {
+        const fn new() -> Self {
+            Self {
+                id: AtomicU32::new(0),
+                seconds: AtomicU32::new(0),
+                nanos: AtomicU32::new(0),
+            }
+        }
+
+        fn store(&self, packet_id: u32, timestamp: PtpTimestamp) {
+            self.id.store(0, Ordering::Release);
+            self.seconds.store(timestamp.seconds, Ordering::Relaxed);
+            self.nanos.store(timestamp.nanos, Ordering::Relaxed);
+            self.id.store(packet_id, Ordering::Release);
+        }
+
+        fn load(&self, packet_id: u32) -> Option<PtpTimestamp> {
+            if packet_id == 0 || self.id.load(Ordering::Acquire) != packet_id {
+                return None;
+            }
+
+            let timestamp = PtpTimestamp {
+                seconds: self.seconds.load(Ordering::Relaxed),
+                nanos: self.nanos.load(Ordering::Relaxed),
+            };
+
+            (self.id.load(Ordering::Acquire) == packet_id).then_some(timestamp)
+        }
+    }
+
+    fn find_timestamp(slots: &[TimestampSlot], packet_id: u32) -> Option<PtpTimestamp> {
+        if packet_id == 0 || slots.is_empty() {
+            return None;
+        }
+
+        slots[slot_index(slots, packet_id)].load(packet_id)
+    }
+
+    fn slot_index(slots: &[TimestampSlot], packet_id: u32) -> usize {
+        packet_id as usize % slots.len()
+    }
+}
+
+#[cfg(not(feature = "ptp"))]
+mod imp {
+    use core::marker::PhantomData;
+
+    use super::PtpTimestamp;
+
+    #[derive(Clone, Copy)]
+    pub(crate) struct PtpStorage {}
+
+    impl PtpStorage {
+        pub(crate) const fn new() -> Self {
+            Self {}
+        }
+
+        pub(crate) fn tx(&self) -> TxPtpRing<'static> {
+            TxPtpRing { _lifetime: PhantomData }
+        }
+
+        pub(crate) fn rx(&self) -> RxPtpRing<'static> {
+            RxPtpRing { _lifetime: PhantomData }
+        }
+    }
+
+    pub(crate) struct TxPtpRing<'a> {
+        _lifetime: PhantomData<&'a ()>,
+    }
+
+    impl TxPtpRing<'_> {
+        #[cfg(any(eth_v2, eth_v2a))]
+        pub(crate) fn enabled(&self) -> bool {
+            false
+        }
+
+        pub(crate) fn store(&self, packet_id: u32, timestamp: Option<PtpTimestamp>) {
+            let _ = (packet_id, timestamp);
+        }
+    }
+
+    pub(crate) struct RxPtpRing<'a> {
+        _lifetime: PhantomData<&'a ()>,
+    }
+
+    impl RxPtpRing<'_> {
+        pub(crate) fn store(&self, packet_id: u32, timestamp: Option<PtpTimestamp>) {
+            let _ = (packet_id, timestamp);
+        }
+    }
+}
+
+#[cfg(all(feature = "ptp", any(eth_v2, eth_v2a)))]
+pub use imp::PtpTimestampStore;
+pub(crate) use imp::{PtpStorage, RxPtpRing, TxPtpRing};

--- a/embassy-stm32/src/eth/ptp.rs
+++ b/embassy-stm32/src/eth/ptp.rs
@@ -10,10 +10,8 @@ pub struct PtpTimestamp {
 
 #[cfg(feature = "ptp")]
 mod imp {
-    use core::{
-        sync::atomic::{AtomicU32, Ordering},
-        task::{Context, Poll},
-    };
+    use core::sync::atomic::{AtomicU32, Ordering};
+    use core::task::{Context, Poll};
 
     use embassy_net_driver::PacketMeta;
     use embassy_sync::waitqueue::AtomicWaker;

--- a/embassy-stm32/src/eth/ptp.rs
+++ b/embassy-stm32/src/eth/ptp.rs
@@ -8,7 +8,7 @@ pub struct PtpTimestamp {
     pub nanos: u32,
 }
 
-#[cfg(all(feature = "ptp", any(eth_v2, eth_v2a)))]
+#[cfg(feature = "ptp")]
 mod imp {
     use core::{
         sync::atomic::{AtomicU32, Ordering},
@@ -235,7 +235,6 @@ mod imp {
     }
 
     impl TxPtpRing<'_> {
-        #[cfg(any(eth_v2, eth_v2a))]
         pub(crate) fn enabled(&self) -> bool {
             false
         }
@@ -256,6 +255,6 @@ mod imp {
     }
 }
 
-#[cfg(all(feature = "ptp", any(eth_v2, eth_v2a)))]
+#[cfg(feature = "ptp")]
 pub use imp::PtpTimestampStore;
 pub(crate) use imp::{PtpStorage, RxPtpRing, TxPtpRing};

--- a/embassy-stm32/src/eth/ptp.rs
+++ b/embassy-stm32/src/eth/ptp.rs
@@ -10,9 +10,13 @@ pub struct PtpTimestamp {
 
 #[cfg(all(feature = "ptp", any(eth_v2, eth_v2a)))]
 mod imp {
-    use core::sync::atomic::{AtomicU32, Ordering};
+    use core::{
+        sync::atomic::{AtomicU32, Ordering},
+        task::{Context, Poll},
+    };
 
     use embassy_net_driver::PacketMeta;
+    use embassy_sync::waitqueue::AtomicWaker;
 
     use super::PtpTimestamp;
 
@@ -23,6 +27,7 @@ mod imp {
     pub struct PtpTimestampStore<const TX: usize, const RX: usize> {
         tx: [TimestampSlot; TX],
         rx: [TimestampSlot; RX],
+        tx_waker: AtomicWaker,
     }
 
     impl<const TX: usize, const RX: usize> PtpTimestampStore<TX, RX> {
@@ -31,6 +36,7 @@ mod imp {
             Self {
                 tx: [const { TimestampSlot::new() }; TX],
                 rx: [const { TimestampSlot::new() }; RX],
+                tx_waker: AtomicWaker::new(),
             }
         }
 
@@ -40,6 +46,25 @@ mod imp {
         /// was not hardware timestamped, or if the history slot was overwritten.
         pub fn tx_timestamp(&self, meta: PacketMeta) -> Option<PtpTimestamp> {
             find_timestamp(&self.tx, meta.id)
+        }
+
+        /// Poll until the transmit timestamp for `meta` is available.
+        ///
+        /// This registers `cx` for future transmit completions. It can remain
+        /// pending forever if the packet is not hardware timestamped or if its
+        /// history slot is overwritten before it is read. Only one task should
+        /// poll transmit timestamps from a store at a time.
+        pub fn poll_tx_timestamp(&self, meta: PacketMeta, cx: &mut Context<'_>) -> Poll<PtpTimestamp> {
+            if let Some(timestamp) = self.tx_timestamp(meta) {
+                return Poll::Ready(timestamp);
+            }
+
+            self.tx_waker.register(cx.waker());
+
+            match self.tx_timestamp(meta) {
+                Some(timestamp) => Poll::Ready(timestamp),
+                None => Poll::Pending,
+            }
         }
 
         /// Get the receive timestamp recorded for `meta`.
@@ -61,11 +86,16 @@ mod imp {
     pub(crate) struct PtpStorage {
         tx: Option<&'static [TimestampSlot]>,
         rx: Option<&'static [TimestampSlot]>,
+        tx_waker: Option<&'static AtomicWaker>,
     }
 
     impl PtpStorage {
         pub(crate) const fn new() -> Self {
-            Self { tx: None, rx: None }
+            Self {
+                tx: None,
+                rx: None,
+                tx_waker: None,
+            }
         }
 
         pub(crate) const fn new_with_store<const TX: usize, const RX: usize>(
@@ -74,11 +104,15 @@ mod imp {
             Self {
                 tx: Some(&store.tx),
                 rx: Some(&store.rx),
+                tx_waker: Some(&store.tx_waker),
             }
         }
 
         pub(crate) fn tx(&self) -> TxPtpRing<'static> {
-            TxPtpRing { slots: self.tx }
+            TxPtpRing {
+                slots: self.tx,
+                waker: self.tx_waker,
+            }
         }
 
         pub(crate) fn rx(&self) -> RxPtpRing<'static> {
@@ -88,6 +122,7 @@ mod imp {
 
     pub(crate) struct TxPtpRing<'a> {
         slots: Option<&'a [TimestampSlot]>,
+        waker: Option<&'a AtomicWaker>,
     }
 
     impl TxPtpRing<'_> {
@@ -96,9 +131,14 @@ mod imp {
         }
 
         pub(crate) fn store(&self, packet_id: u32, timestamp: Option<PtpTimestamp>) {
-            if let (Some(slots), Some(timestamp)) = (self.slots, timestamp) {
-                if packet_id != 0 && !slots.is_empty() {
-                    slots[slot_index(slots, packet_id)].store(packet_id, timestamp);
+            if packet_id != 0 {
+                if let (Some(slots), Some(timestamp)) = (self.slots, timestamp) {
+                    if !slots.is_empty() {
+                        slots[slot_index(slots, packet_id)].store(packet_id, timestamp);
+                    }
+                }
+                if let Some(waker) = self.waker {
+                    waker.wake();
                 }
             }
         }

--- a/embassy-stm32/src/eth/v1/mod.rs
+++ b/embassy-stm32/src/eth/v1/mod.rs
@@ -295,7 +295,7 @@ impl<'d, T: Instance, P: Phy> Ethernet<'d, T, P> {
 
         // TODO MTU size setting not found for v1 ethernet, check if correct
 
-        let (tx_packets, rx_packets) = queue.packet_state.split();
+        let (tx_state, rx_state) = queue.packet_state.split();
 
         let mut this = Self {
             _peri: peri,
@@ -303,8 +303,8 @@ impl<'d, T: Instance, P: Phy> Ethernet<'d, T, P> {
             phy: phy,
             mac_addr,
             link_state: LinkState::Down,
-            tx: TDesRing::new(&mut queue.tx_desc, &mut queue.tx_buf, tx_packets),
-            rx: RDesRing::new(&mut queue.rx_desc, &mut queue.rx_buf, rx_packets),
+            tx: TDesRing::new(&mut queue.tx_desc, &mut queue.tx_buf, tx_state),
+            rx: RDesRing::new(&mut queue.rx_desc, &mut queue.rx_buf, rx_state),
         };
 
         fence(Ordering::SeqCst);

--- a/embassy-stm32/src/eth/v1/mod.rs
+++ b/embassy-stm32/src/eth/v1/mod.rs
@@ -295,7 +295,7 @@ impl<'d, T: Instance, P: Phy> Ethernet<'d, T, P> {
 
         // TODO MTU size setting not found for v1 ethernet, check if correct
 
-        let (tx_packets, rx_packets) = queue.packet_state.rings();
+        let (tx_packets, rx_packets) = queue.packet_state.split();
 
         let mut this = Self {
             _peri: peri,

--- a/embassy-stm32/src/eth/v1/mod.rs
+++ b/embassy-stm32/src/eth/v1/mod.rs
@@ -295,14 +295,16 @@ impl<'d, T: Instance, P: Phy> Ethernet<'d, T, P> {
 
         // TODO MTU size setting not found for v1 ethernet, check if correct
 
+        let (tx_packets, rx_packets) = queue.packet_state.rings();
+
         let mut this = Self {
             _peri: peri,
             _pins: pins,
             phy: phy,
             mac_addr,
             link_state: LinkState::Down,
-            tx: TDesRing::new(&mut queue.tx_desc, &mut queue.tx_buf),
-            rx: RDesRing::new(&mut queue.rx_desc, &mut queue.rx_buf),
+            tx: TDesRing::new(&mut queue.tx_desc, &mut queue.tx_buf, tx_packets),
+            rx: RDesRing::new(&mut queue.rx_desc, &mut queue.rx_buf, rx_packets),
         };
 
         fence(Ordering::SeqCst);

--- a/embassy-stm32/src/eth/v1/rx_desc.rs
+++ b/embassy-stm32/src/eth/v1/rx_desc.rs
@@ -1,9 +1,11 @@
 use core::sync::atomic::{Ordering, compiler_fence, fence};
 
+use embassy_net_driver::PacketMeta;
 use stm32_metapac::eth::vals::{Rpd, Rps};
 use vcell::VolatileCell;
 
 use crate::eth::RX_BUFFER_SIZE;
+use crate::eth::packet_state::RxPacketStateRing;
 use crate::pac::ETH;
 
 mod rx_consts {
@@ -133,11 +135,16 @@ pub enum RunningState {
 pub(crate) struct RDesRing<'a> {
     descriptors: &'a mut [RDes],
     buffers: &'a mut [Packet<RX_BUFFER_SIZE>],
+    packets: RxPacketStateRing<'a>,
     index: usize,
 }
 
 impl<'a> RDesRing<'a> {
-    pub(crate) fn new(descriptors: &'a mut [RDes], buffers: &'a mut [Packet<RX_BUFFER_SIZE>]) -> Self {
+    pub(crate) fn new(
+        descriptors: &'a mut [RDes],
+        buffers: &'a mut [Packet<RX_BUFFER_SIZE>],
+        packets: RxPacketStateRing<'a>,
+    ) -> Self {
         assert!(descriptors.len() > 1);
         assert!(descriptors.len() == buffers.len());
 
@@ -154,6 +161,7 @@ impl<'a> RDesRing<'a> {
         Self {
             descriptors,
             buffers,
+            packets,
             index: 0,
         }
     }
@@ -211,7 +219,12 @@ impl<'a> RDesRing<'a> {
 
         let descriptor = &mut self.descriptors[self.index];
         let len = descriptor.packet_len();
+        self.packets.capture(self.index, None);
         return Some(&mut self.buffers[self.index].0[..len]);
+    }
+
+    pub(crate) fn meta(&self) -> PacketMeta {
+        self.packets.meta(self.index)
     }
 
     /// Pop the packet previously returned by `available`.
@@ -219,6 +232,7 @@ impl<'a> RDesRing<'a> {
         let descriptor = &mut self.descriptors[self.index];
         assert!(descriptor.available());
 
+        self.packets.clear(self.index);
         self.descriptors[self.index].set_ready(self.buffers[self.index].0.as_mut_ptr());
 
         self.demand_poll();

--- a/embassy-stm32/src/eth/v1/rx_desc.rs
+++ b/embassy-stm32/src/eth/v1/rx_desc.rs
@@ -135,7 +135,7 @@ pub enum RunningState {
 pub(crate) struct RDesRing<'a> {
     descriptors: &'a mut [RDes],
     buffers: &'a mut [Packet<RX_BUFFER_SIZE>],
-    packets: RxPacketStateRing<'a>,
+    state: RxPacketStateRing<'a>,
     index: usize,
 }
 
@@ -143,7 +143,7 @@ impl<'a> RDesRing<'a> {
     pub(crate) fn new(
         descriptors: &'a mut [RDes],
         buffers: &'a mut [Packet<RX_BUFFER_SIZE>],
-        packets: RxPacketStateRing<'a>,
+        state: RxPacketStateRing<'a>,
     ) -> Self {
         assert!(descriptors.len() > 1);
         assert!(descriptors.len() == buffers.len());
@@ -161,7 +161,7 @@ impl<'a> RDesRing<'a> {
         Self {
             descriptors,
             buffers,
-            packets,
+            state,
             index: 0,
         }
     }
@@ -219,12 +219,12 @@ impl<'a> RDesRing<'a> {
 
         let descriptor = &mut self.descriptors[self.index];
         let len = descriptor.packet_len();
-        self.packets.capture(self.index, None);
+        self.state.capture(self.index, None);
         return Some(&mut self.buffers[self.index].0[..len]);
     }
 
     pub(crate) fn meta(&self) -> PacketMeta {
-        self.packets.meta(self.index)
+        self.state.meta(self.index)
     }
 
     /// Pop the packet previously returned by `available`.
@@ -232,7 +232,7 @@ impl<'a> RDesRing<'a> {
         let descriptor = &mut self.descriptors[self.index];
         assert!(descriptor.available());
 
-        self.packets.clear(self.index);
+        self.state.clear(self.index);
         self.descriptors[self.index].set_ready(self.buffers[self.index].0.as_mut_ptr());
 
         self.demand_poll();

--- a/embassy-stm32/src/eth/v1/tx_desc.rs
+++ b/embassy-stm32/src/eth/v1/tx_desc.rs
@@ -108,7 +108,7 @@ impl TDes {
 pub(crate) struct TDesRing<'a> {
     descriptors: &'a mut [TDes],
     buffers: &'a mut [Packet<TX_BUFFER_SIZE>],
-    packets: TxPacketStateRing<'a>,
+    state: TxPacketStateRing<'a>,
     index: usize,
 }
 
@@ -117,7 +117,7 @@ impl<'a> TDesRing<'a> {
     pub(crate) fn new(
         descriptors: &'a mut [TDes],
         buffers: &'a mut [Packet<TX_BUFFER_SIZE>],
-        packets: TxPacketStateRing<'a>,
+        state: TxPacketStateRing<'a>,
     ) -> Self {
         assert!(descriptors.len() > 0);
         assert!(descriptors.len() == buffers.len());
@@ -134,7 +134,7 @@ impl<'a> TDesRing<'a> {
         Self {
             descriptors,
             buffers,
-            packets,
+            state,
             index: 0,
         }
     }
@@ -149,8 +149,6 @@ impl<'a> TDesRing<'a> {
     pub(crate) fn available(&mut self) -> Option<&mut [u8]> {
         let descriptor = &mut self.descriptors[self.index];
         if descriptor.available() {
-            #[cfg(feature = "ptp")]
-            self.packets.complete(self.index, None);
             Some(&mut self.buffers[self.index].0)
         } else {
             None
@@ -158,7 +156,7 @@ impl<'a> TDesRing<'a> {
     }
 
     pub(crate) fn set_meta(&mut self, meta: PacketMeta) {
-        self.packets.set_meta(meta);
+        self.state.set_meta(meta);
     }
 
     /// Transmit the packet written in a buffer returned by `available`.
@@ -168,7 +166,7 @@ impl<'a> TDesRing<'a> {
 
         descriptor.set_buffer1(self.buffers[self.index].0.as_ptr());
         descriptor.set_buffer1_len(len);
-        self.packets.commit(self.index);
+        self.state.commit(self.index);
 
         descriptor.set_owned();
 

--- a/embassy-stm32/src/eth/v1/tx_desc.rs
+++ b/embassy-stm32/src/eth/v1/tx_desc.rs
@@ -1,8 +1,10 @@
 use core::sync::atomic::{Ordering, compiler_fence, fence};
 
+use embassy_net_driver::PacketMeta;
 use vcell::VolatileCell;
 
 use crate::eth::TX_BUFFER_SIZE;
+use crate::eth::packet_state::TxPacketStateRing;
 use crate::pac::ETH;
 
 /// Transmit and Receive Descriptor fields
@@ -106,12 +108,17 @@ impl TDes {
 pub(crate) struct TDesRing<'a> {
     descriptors: &'a mut [TDes],
     buffers: &'a mut [Packet<TX_BUFFER_SIZE>],
+    packets: TxPacketStateRing<'a>,
     index: usize,
 }
 
 impl<'a> TDesRing<'a> {
     /// Initialise this TDesRing. Assume TDesRing is corrupt
-    pub(crate) fn new(descriptors: &'a mut [TDes], buffers: &'a mut [Packet<TX_BUFFER_SIZE>]) -> Self {
+    pub(crate) fn new(
+        descriptors: &'a mut [TDes],
+        buffers: &'a mut [Packet<TX_BUFFER_SIZE>],
+        packets: TxPacketStateRing<'a>,
+    ) -> Self {
         assert!(descriptors.len() > 0);
         assert!(descriptors.len() == buffers.len());
 
@@ -127,6 +134,7 @@ impl<'a> TDesRing<'a> {
         Self {
             descriptors,
             buffers,
+            packets,
             index: 0,
         }
     }
@@ -139,10 +147,15 @@ impl<'a> TDesRing<'a> {
     pub(crate) fn available(&mut self) -> Option<&mut [u8]> {
         let descriptor = &mut self.descriptors[self.index];
         if descriptor.available() {
+            self.packets.complete(self.index, None);
             Some(&mut self.buffers[self.index].0)
         } else {
             None
         }
+    }
+
+    pub(crate) fn set_meta(&mut self, meta: PacketMeta) {
+        self.packets.set_meta(meta);
     }
 
     /// Transmit the packet written in a buffer returned by `available`.
@@ -152,6 +165,7 @@ impl<'a> TDesRing<'a> {
 
         descriptor.set_buffer1(self.buffers[self.index].0.as_ptr());
         descriptor.set_buffer1_len(len);
+        self.packets.commit(self.index);
 
         descriptor.set_owned();
 

--- a/embassy-stm32/src/eth/v1/tx_desc.rs
+++ b/embassy-stm32/src/eth/v1/tx_desc.rs
@@ -143,6 +143,8 @@ impl<'a> TDesRing<'a> {
         self.descriptors.len()
     }
 
+    pub(crate) fn collect_completed(&mut self) {}
+
     /// Return the next available packet buffer for transmitting, or None
     pub(crate) fn available(&mut self) -> Option<&mut [u8]> {
         let descriptor = &mut self.descriptors[self.index];

--- a/embassy-stm32/src/eth/v1/tx_desc.rs
+++ b/embassy-stm32/src/eth/v1/tx_desc.rs
@@ -149,6 +149,7 @@ impl<'a> TDesRing<'a> {
     pub(crate) fn available(&mut self) -> Option<&mut [u8]> {
         let descriptor = &mut self.descriptors[self.index];
         if descriptor.available() {
+            #[cfg(feature = "ptp")]
             self.packets.complete(self.index, None);
             Some(&mut self.buffers[self.index].0)
         } else {

--- a/embassy-stm32/src/eth/v2/descriptors.rs
+++ b/embassy-stm32/src/eth/v2/descriptors.rs
@@ -94,6 +94,7 @@ impl TDes {
         self.tdes3.get() & EMAC_DES3_OWN == 0
     }
 
+    #[cfg(feature = "ptp")]
     fn timestamp(&self) -> Option<PtpTimestamp> {
         (self.tdes3.get() & EMAC_TDES3_TTSS != 0).then(|| PtpTimestamp {
             seconds: self.tdes1.get(),
@@ -107,6 +108,7 @@ pub(crate) struct TDesRing<'a> {
     buffers: &'a mut [Packet<TX_BUFFER_SIZE>],
     packets: TxPacketStateRing<'a>,
     index: usize,
+    #[cfg(feature = "ptp")]
     completion_index: usize,
 }
 
@@ -136,6 +138,7 @@ impl<'a> TDesRing<'a> {
             buffers,
             packets,
             index: 0,
+            #[cfg(feature = "ptp")]
             completion_index: 0,
         }
     }
@@ -157,6 +160,7 @@ impl<'a> TDesRing<'a> {
     }
 
     pub(crate) fn collect_completed(&mut self) {
+        #[cfg(feature = "ptp")]
         while self.packets.pending(self.completion_index) {
             let descriptor = &self.descriptors[self.completion_index];
             if !descriptor.available() {
@@ -202,8 +206,12 @@ impl<'a> TDesRing<'a> {
 
         // Read format
         td.tdes0.set(self.buffers[self.index].0.as_ptr() as u32);
+        #[cfg(feature = "ptp")]
         let packet_id = self.packets.next_id();
+        #[cfg(feature = "ptp")]
         let timestamp_enabled = self.packets.timestamp_enabled();
+        #[cfg(not(feature = "ptp"))]
+        let timestamp_enabled = false;
         let mut tdes2 = len as u32 & EMAC_TDES2_B1L | EMAC_TDES2_IOC;
         if timestamp_enabled {
             tdes2 |= EMAC_TDES2_TTSE;
@@ -219,6 +227,7 @@ impl<'a> TDesRing<'a> {
         #[cfg(eth_v2a)]
         let tdes3 = tdes3 | EMAC_TDES3_CIC_FULL;
         td.tdes3.set(tdes3);
+        #[cfg(feature = "ptp")]
         if timestamp_enabled {
             trace!(
                 "eth ptp tx submit idx={} packet_id={} len={} tdes2={:#010x}",

--- a/embassy-stm32/src/eth/v2/descriptors.rs
+++ b/embassy-stm32/src/eth/v2/descriptors.rs
@@ -106,7 +106,7 @@ impl TDes {
 pub(crate) struct TDesRing<'a> {
     descriptors: &'a mut [TDes],
     buffers: &'a mut [Packet<TX_BUFFER_SIZE>],
-    packets: TxPacketStateRing<'a>,
+    state: TxPacketStateRing<'a>,
     index: usize,
     #[cfg(feature = "ptp")]
     completion_index: usize,
@@ -117,7 +117,7 @@ impl<'a> TDesRing<'a> {
     pub fn new(
         descriptors: &'a mut [TDes],
         buffers: &'a mut [Packet<TX_BUFFER_SIZE>],
-        packets: TxPacketStateRing<'a>,
+        state: TxPacketStateRing<'a>,
     ) -> Self {
         assert!(descriptors.len() > 0);
         assert!(descriptors.len() == buffers.len());
@@ -136,7 +136,7 @@ impl<'a> TDesRing<'a> {
         Self {
             descriptors,
             buffers,
-            packets,
+            state,
             index: 0,
             #[cfg(feature = "ptp")]
             completion_index: 0,
@@ -161,14 +161,14 @@ impl<'a> TDesRing<'a> {
 
     pub(crate) fn collect_completed(&mut self) {
         #[cfg(feature = "ptp")]
-        while self.packets.pending(self.completion_index) {
+        while self.state.pending(self.completion_index) {
             let descriptor = &self.descriptors[self.completion_index];
             if !descriptor.available() {
                 break;
             }
 
             let timestamp = descriptor.timestamp();
-            let packet_id = self.packets.id(self.completion_index);
+            let packet_id = self.state.id(self.completion_index);
             if packet_id != 0 {
                 if timestamp.is_some() {
                     trace!(
@@ -189,13 +189,13 @@ impl<'a> TDesRing<'a> {
                     );
                 }
             }
-            self.packets.complete(self.completion_index, timestamp);
+            self.state.complete(self.completion_index, timestamp);
             self.completion_index = (self.completion_index + 1) % self.descriptors.len();
         }
     }
 
     pub(crate) fn set_meta(&mut self, meta: PacketMeta) {
-        self.packets.set_meta(meta);
+        self.state.set_meta(meta);
     }
 
     /// Transmit the packet written in a buffer returned by `available`.
@@ -207,9 +207,9 @@ impl<'a> TDesRing<'a> {
         // Read format
         td.tdes0.set(self.buffers[self.index].0.as_ptr() as u32);
         #[cfg(feature = "ptp")]
-        let packet_id = self.packets.next_id();
+        let packet_id = self.state.next_id();
         #[cfg(feature = "ptp")]
-        let timestamp_enabled = self.packets.timestamp_enabled();
+        let timestamp_enabled = self.state.timestamp_enabled();
         #[cfg(not(feature = "ptp"))]
         let timestamp_enabled = false;
         let mut tdes2 = len as u32 & EMAC_TDES2_B1L | EMAC_TDES2_IOC;
@@ -217,7 +217,7 @@ impl<'a> TDesRing<'a> {
             tdes2 |= EMAC_TDES2_TTSE;
         }
         td.tdes2.set(tdes2);
-        self.packets.commit(self.index);
+        self.state.commit(self.index);
 
         // FD: Contains first buffer of packet
         // LD: Contains last buffer of packet
@@ -329,7 +329,7 @@ impl RDes {
 pub(crate) struct RDesRing<'a> {
     descriptors: &'a mut [RDes],
     buffers: &'a mut [Packet<RX_BUFFER_SIZE>],
-    packets: RxPacketStateRing<'a>,
+    state: RxPacketStateRing<'a>,
     index: usize,
     consume_context: bool,
 }
@@ -338,7 +338,7 @@ impl<'a> RDesRing<'a> {
     pub(crate) fn new(
         descriptors: &'a mut [RDes],
         buffers: &'a mut [Packet<RX_BUFFER_SIZE>],
-        packets: RxPacketStateRing<'a>,
+        state: RxPacketStateRing<'a>,
     ) -> Self {
         assert!(descriptors.len() > 1);
         assert!(descriptors.len() == buffers.len());
@@ -356,7 +356,7 @@ impl<'a> RDesRing<'a> {
         Self {
             descriptors,
             buffers,
-            packets,
+            state,
             index: 0,
             consume_context: false,
         }
@@ -396,7 +396,7 @@ impl<'a> RDesRing<'a> {
             return None;
         };
         self.consume_context = consume_context;
-        self.packets.capture(self.index, timestamp);
+        self.state.capture(self.index, timestamp);
         return Some(&mut self.buffers[self.index].0[..len]);
     }
 
@@ -427,7 +427,7 @@ impl<'a> RDesRing<'a> {
     }
 
     pub(crate) fn meta(&self) -> PacketMeta {
-        self.packets.meta(self.index)
+        self.state.meta(self.index)
     }
 
     /// Pop the packet previously returned by `available`.
@@ -446,7 +446,7 @@ impl<'a> RDesRing<'a> {
         assert!(rd.available());
 
         if packet {
-            self.packets.clear(self.index);
+            self.state.clear(self.index);
         }
         rd.set_ready(self.buffers[self.index].0.as_mut_ptr());
 

--- a/embassy-stm32/src/eth/v2/descriptors.rs
+++ b/embassy-stm32/src/eth/v2/descriptors.rs
@@ -168,7 +168,7 @@ impl<'a> TDesRing<'a> {
             if packet_id != 0 {
                 if timestamp.is_some() {
                     trace!(
-                        "eth ptp tx complete idx={=usize} packet_id={=u32} tdes3={=u32:#010x} tdes1={=u32} tdes0={=u32}",
+                        "eth ptp tx complete idx={} packet_id={} tdes3={:#010x} tdes1={} tdes0={}",
                         self.completion_index,
                         packet_id,
                         descriptor.tdes3.get(),
@@ -177,7 +177,7 @@ impl<'a> TDesRing<'a> {
                     );
                 } else {
                     trace!(
-                        "eth ptp tx complete no-ts idx={=usize} packet_id={=u32} tdes3={=u32:#010x} tdes2={=u32:#010x}",
+                        "eth ptp tx complete no-ts idx={} packet_id={} tdes3={:#010x} tdes2={:#010x}",
                         self.completion_index,
                         packet_id,
                         descriptor.tdes3.get(),
@@ -221,7 +221,7 @@ impl<'a> TDesRing<'a> {
         td.tdes3.set(tdes3);
         if timestamp_enabled {
             trace!(
-                "eth ptp tx submit idx={=usize} packet_id={=u32} len={=usize} tdes2={=u32:#010x}",
+                "eth ptp tx submit idx={} packet_id={} len={} tdes2={:#010x}",
                 self.index, packet_id, len, tdes2
             );
         }

--- a/embassy-stm32/src/eth/v2/descriptors.rs
+++ b/embassy-stm32/src/eth/v2/descriptors.rs
@@ -156,7 +156,7 @@ impl<'a> TDesRing<'a> {
         }
     }
 
-    fn collect_completed(&mut self) {
+    pub(crate) fn collect_completed(&mut self) {
         while self.packets.pending(self.completion_index) {
             let descriptor = &self.descriptors[self.completion_index];
             if !descriptor.available() {

--- a/embassy-stm32/src/eth/v2/descriptors.rs
+++ b/embassy-stm32/src/eth/v2/descriptors.rs
@@ -1,5 +1,6 @@
 use core::sync::atomic::{Ordering, fence};
 
+use embassy_net_driver::PacketMeta;
 use vcell::VolatileCell;
 
 use crate::eth::packet_state::{RxPacketStateRing, TxPacketStateRing};
@@ -9,7 +10,6 @@ use crate::eth::{Packet, RX_BUFFER_SIZE, TX_BUFFER_SIZE};
 use crate::pac::ETH;
 #[cfg(eth_v2a)]
 use crate::pac::ETH1 as ETH;
-use embassy_net_driver::PacketMeta;
 
 /// Access a per-channel DMA register at channel 0.
 ///

--- a/embassy-stm32/src/eth/v2/descriptors.rs
+++ b/embassy-stm32/src/eth/v2/descriptors.rs
@@ -2,11 +2,14 @@ use core::sync::atomic::{Ordering, fence};
 
 use vcell::VolatileCell;
 
+use crate::eth::packet_state::{RxPacketStateRing, TxPacketStateRing};
+use crate::eth::ptp::PtpTimestamp;
 use crate::eth::{Packet, RX_BUFFER_SIZE, TX_BUFFER_SIZE};
 #[cfg(eth_v2)]
 use crate::pac::ETH;
 #[cfg(eth_v2a)]
 use crate::pac::ETH1 as ETH;
+use embassy_net_driver::PacketMeta;
 
 /// Access a per-channel DMA register at channel 0.
 ///
@@ -36,17 +39,20 @@ mod emac_consts {
     pub const EMAC_DES0_BUF1AP: u32 = 0xFFFF_FFFF;
 
     pub const EMAC_TDES2_IOC: u32 = 0x8000_0000;
+    pub const EMAC_TDES2_TTSE: u32 = 0x4000_0000;
     pub const EMAC_TDES2_B1L: u32 = 0x0000_3FFF;
 
     // TX checksum insertion control (TDES3, read format), bits [17:16]. 0b11 =
     // insert IP header + payload checksums, with the pseudo-header computed by
     // hardware (full offload). eth_v2a only.
     pub const EMAC_TDES3_CIC_FULL: u32 = 0x0003_0000;
+    pub const EMAC_TDES3_TTSS: u32 = 0x0002_0000;
 
     pub const EMAC_RDES3_IOC: u32 = 0x4000_0000;
     pub const EMAC_RDES3_PL: u32 = 0x0000_7FFF;
     pub const EMAC_RDES3_BUF1V: u32 = 0x0100_0000;
     pub const EMAC_RDES3_PKTLEN: u32 = 0x0000_7FFF;
+    pub const EMAC_RDES3_RS1V: u32 = 0x0400_0000;
 
     // RX checksum status (RDES1, write-back format). These are NOT folded into
     // the RDES3 error summary, so they must be inspected separately. eth_v2a only.
@@ -55,6 +61,7 @@ mod emac_consts {
     pub const EMAC_RDES1_PT: u32 = 0x0000_0003; // payload type
     pub const EMAC_RDES1_PT_UDP: u32 = 1;
     pub const EMAC_RDES1_PT_TCP: u32 = 2;
+    pub const EMAC_RDES1_TSA: u32 = 0x0000_4000; // timestamp available
 }
 use emac_consts::*;
 
@@ -86,17 +93,30 @@ impl TDes {
     fn available(&self) -> bool {
         self.tdes3.get() & EMAC_DES3_OWN == 0
     }
+
+    fn timestamp(&self) -> Option<PtpTimestamp> {
+        (self.tdes3.get() & EMAC_TDES3_TTSS != 0).then(|| PtpTimestamp {
+            seconds: self.tdes1.get(),
+            nanos: self.tdes0.get(),
+        })
+    }
 }
 
 pub(crate) struct TDesRing<'a> {
     descriptors: &'a mut [TDes],
     buffers: &'a mut [Packet<TX_BUFFER_SIZE>],
+    packets: TxPacketStateRing<'a>,
     index: usize,
+    completion_index: usize,
 }
 
 impl<'a> TDesRing<'a> {
     /// Initialise this TDesRing. Assume TDesRing is corrupt.
-    pub fn new(descriptors: &'a mut [TDes], buffers: &'a mut [Packet<TX_BUFFER_SIZE>]) -> Self {
+    pub fn new(
+        descriptors: &'a mut [TDes],
+        buffers: &'a mut [Packet<TX_BUFFER_SIZE>],
+        packets: TxPacketStateRing<'a>,
+    ) -> Self {
         assert!(descriptors.len() > 0);
         assert!(descriptors.len() == buffers.len());
 
@@ -114,7 +134,9 @@ impl<'a> TDesRing<'a> {
         Self {
             descriptors,
             buffers,
+            packets,
             index: 0,
+            completion_index: 0,
         }
     }
 
@@ -124,12 +146,52 @@ impl<'a> TDesRing<'a> {
 
     /// Return the next available packet buffer for transmitting, or None
     pub(crate) fn available(&mut self) -> Option<&mut [u8]> {
+        self.collect_completed();
+
         let d = &mut self.descriptors[self.index];
         if d.available() {
             Some(&mut self.buffers[self.index].0)
         } else {
             None
         }
+    }
+
+    fn collect_completed(&mut self) {
+        while self.packets.pending(self.completion_index) {
+            let descriptor = &self.descriptors[self.completion_index];
+            if !descriptor.available() {
+                break;
+            }
+
+            let timestamp = descriptor.timestamp();
+            let packet_id = self.packets.id(self.completion_index);
+            if packet_id != 0 {
+                if timestamp.is_some() {
+                    trace!(
+                        "eth ptp tx complete idx={=usize} packet_id={=u32} tdes3={=u32:#010x} tdes1={=u32} tdes0={=u32}",
+                        self.completion_index,
+                        packet_id,
+                        descriptor.tdes3.get(),
+                        descriptor.tdes1.get(),
+                        descriptor.tdes0.get()
+                    );
+                } else {
+                    trace!(
+                        "eth ptp tx complete no-ts idx={=usize} packet_id={=u32} tdes3={=u32:#010x} tdes2={=u32:#010x}",
+                        self.completion_index,
+                        packet_id,
+                        descriptor.tdes3.get(),
+                        descriptor.tdes2.get()
+                    );
+                }
+            }
+            self.packets.complete(self.completion_index, timestamp);
+            self.completion_index = (self.completion_index + 1) % self.descriptors.len();
+        }
+    }
+
+    pub(crate) fn set_meta(&mut self, meta: PacketMeta) {
+        self.packets.set_meta(meta);
     }
 
     /// Transmit the packet written in a buffer returned by `available`.
@@ -140,7 +202,14 @@ impl<'a> TDesRing<'a> {
 
         // Read format
         td.tdes0.set(self.buffers[self.index].0.as_ptr() as u32);
-        td.tdes2.set(len as u32 & EMAC_TDES2_B1L | EMAC_TDES2_IOC);
+        let packet_id = self.packets.next_id();
+        let timestamp_enabled = self.packets.timestamp_enabled();
+        let mut tdes2 = len as u32 & EMAC_TDES2_B1L | EMAC_TDES2_IOC;
+        if timestamp_enabled {
+            tdes2 |= EMAC_TDES2_TTSE;
+        }
+        td.tdes2.set(tdes2);
+        self.packets.commit(self.index);
 
         // FD: Contains first buffer of packet
         // LD: Contains last buffer of packet
@@ -150,6 +219,12 @@ impl<'a> TDesRing<'a> {
         #[cfg(eth_v2a)]
         let tdes3 = tdes3 | EMAC_TDES3_CIC_FULL;
         td.tdes3.set(tdes3);
+        if timestamp_enabled {
+            trace!(
+                "eth ptp tx submit idx={=usize} packet_id={=u32} len={=usize} tdes2={=u32:#010x}",
+                self.index, packet_id, len, tdes2
+            );
+        }
 
         // Ensure changes to the descriptor are committed before DMA engine sees tail pointer store.
         // This will generate an DMB instruction.
@@ -227,17 +302,35 @@ impl RDes {
         self.rdes0.set(buf as u32);
         self.rdes3.set(EMAC_RDES3_BUF1V | EMAC_RDES3_IOC | EMAC_DES3_OWN);
     }
+
+    fn context_available(&self) -> bool {
+        self.rdes3.get() & (EMAC_DES3_OWN | EMAC_DES3_CTXT) == EMAC_DES3_CTXT
+    }
+
+    fn context_timestamp(&self) -> Option<PtpTimestamp> {
+        let corrupted = self.rdes0.get() == u32::MAX && self.rdes1.get() == u32::MAX;
+        (self.context_available() && !corrupted).then(|| PtpTimestamp {
+            seconds: self.rdes1.get(),
+            nanos: self.rdes0.get(),
+        })
+    }
 }
 
 /// Rx ring of descriptors and packets
 pub(crate) struct RDesRing<'a> {
     descriptors: &'a mut [RDes],
     buffers: &'a mut [Packet<RX_BUFFER_SIZE>],
+    packets: RxPacketStateRing<'a>,
     index: usize,
+    consume_context: bool,
 }
 
 impl<'a> RDesRing<'a> {
-    pub(crate) fn new(descriptors: &'a mut [RDes], buffers: &'a mut [Packet<RX_BUFFER_SIZE>]) -> Self {
+    pub(crate) fn new(
+        descriptors: &'a mut [RDes],
+        buffers: &'a mut [Packet<RX_BUFFER_SIZE>],
+        packets: RxPacketStateRing<'a>,
+    ) -> Self {
         assert!(descriptors.len() > 1);
         assert!(descriptors.len() == buffers.len());
 
@@ -254,7 +347,9 @@ impl<'a> RDesRing<'a> {
         Self {
             descriptors,
             buffers,
+            packets,
             index: 0,
+            consume_context: false,
         }
     }
 
@@ -272,26 +367,70 @@ impl<'a> RDesRing<'a> {
                 return None;
             }
 
+            if descriptor.context_available() {
+                self.pop_current(false);
+                continue;
+            }
+
             // If packet is invalid, pop it and try again.
             if !descriptor.valid() {
                 warn!("invalid packet: {:08x}", descriptor.rdes0.get());
-                self.pop_packet();
+                self.pop_current(false);
                 continue;
             }
 
             break;
         }
 
-        let descriptor = &mut self.descriptors[self.index];
-        let len = (descriptor.rdes3.get() & EMAC_RDES3_PKTLEN) as usize;
+        let len = (self.descriptors[self.index].rdes3.get() & EMAC_RDES3_PKTLEN) as usize;
+        let Some((timestamp, consume_context)) = self.timestamp(self.index) else {
+            return None;
+        };
+        self.consume_context = consume_context;
+        self.packets.capture(self.index, timestamp);
         return Some(&mut self.buffers[self.index].0[..len]);
+    }
+
+    fn timestamp(&self, index: usize) -> Option<(Option<PtpTimestamp>, bool)> {
+        let descriptor = &self.descriptors[index];
+        let has_timestamp = descriptor.rdes1.get() & EMAC_RDES1_TSA != 0;
+        if !has_timestamp {
+            return Some((None, false));
+        }
+
+        let next = (index + 1) % self.descriptors.len();
+        let context = &self.descriptors[next];
+        if context.context_available() {
+            Some((context.context_timestamp(), true))
+        } else {
+            // Do not stall unrelated RX traffic waiting for an optional
+            // timestamp context descriptor.
+            Some((None, false))
+        }
+    }
+
+    pub(crate) fn meta(&self) -> PacketMeta {
+        self.packets.meta(self.index)
     }
 
     /// Pop the packet previously returned by `available`.
     pub(crate) fn pop_packet(&mut self) {
+        let consume_context = self.consume_context;
+        self.consume_context = false;
+
+        self.pop_current(true);
+        if consume_context {
+            self.pop_current(false);
+        }
+    }
+
+    fn pop_current(&mut self, packet: bool) {
         let rd = &mut self.descriptors[self.index];
         assert!(rd.available());
 
+        if packet {
+            self.packets.clear(self.index);
+        }
         rd.set_ready(self.buffers[self.index].0.as_mut_ptr());
 
         // "Preceding reads and writes cannot be moved past subsequent writes."

--- a/embassy-stm32/src/eth/v2/descriptors.rs
+++ b/embassy-stm32/src/eth/v2/descriptors.rs
@@ -393,7 +393,11 @@ impl<'a> RDesRing<'a> {
 
     fn timestamp(&self, index: usize) -> Option<(Option<PtpTimestamp>, bool)> {
         let descriptor = &self.descriptors[index];
-        let has_timestamp = descriptor.rdes1.get() & EMAC_RDES1_TSA != 0;
+        // RDES1 status is valid only when RS1V is set in RDES3. Without this
+        // guard, stale buffer-address bits in RDES1 can be mistaken for TSA and
+        // wedge the RX ring waiting for a context descriptor that will not come.
+        let has_timestamp =
+            descriptor.rdes3.get() & EMAC_RDES3_RS1V != 0 && descriptor.rdes1.get() & EMAC_RDES1_TSA != 0;
         if !has_timestamp {
             return Some((None, false));
         }
@@ -402,10 +406,13 @@ impl<'a> RDesRing<'a> {
         let context = &self.descriptors[next];
         if context.context_available() {
             Some((context.context_timestamp(), true))
+        } else if context.available() {
+            Some((None, false))
         } else {
             // Keep the packet queued until the following timestamp context
-            // descriptor is available. Dropping through here would expose a
-            // timestamped packet to the stack without its hardware timestamp.
+            // descriptor has been written back. If it becomes a normal packet
+            // instead, do not block the RX ring waiting for a timestamp that
+            // the hardware did not provide.
             None
         }
     }

--- a/embassy-stm32/src/eth/v2/descriptors.rs
+++ b/embassy-stm32/src/eth/v2/descriptors.rs
@@ -393,9 +393,9 @@ impl<'a> RDesRing<'a> {
 
     fn timestamp(&self, index: usize) -> Option<(Option<PtpTimestamp>, bool)> {
         let descriptor = &self.descriptors[index];
-        // RDES1 status is valid only when RS1V is set in RDES3. Without this
-        // guard, stale buffer-address bits in RDES1 can be mistaken for TSA and
-        // wedge the RX ring waiting for a context descriptor that will not come.
+        // RDES1 write-back status is valid only when RS1V is set in RDES3.
+        // Descriptors returned to DMA are not required to clear RDES1, so do
+        // not interpret TSA unless the hardware says the status word is valid.
         let has_timestamp =
             descriptor.rdes3.get() & EMAC_RDES3_RS1V != 0 && descriptor.rdes1.get() & EMAC_RDES1_TSA != 0;
         if !has_timestamp {

--- a/embassy-stm32/src/eth/v2/descriptors.rs
+++ b/embassy-stm32/src/eth/v2/descriptors.rs
@@ -403,9 +403,10 @@ impl<'a> RDesRing<'a> {
         if context.context_available() {
             Some((context.context_timestamp(), true))
         } else {
-            // Do not stall unrelated RX traffic waiting for an optional
-            // timestamp context descriptor.
-            Some((None, false))
+            // Keep the packet queued until the following timestamp context
+            // descriptor is available. Dropping through here would expose a
+            // timestamped packet to the stack without its hardware timestamp.
+            None
         }
     }
 

--- a/embassy-stm32/src/eth/v2/mod.rs
+++ b/embassy-stm32/src/eth/v2/mod.rs
@@ -492,11 +492,13 @@ impl<'d, T: Instance, P: Phy> Ethernet<'d, T, P> {
             w.set_rbsz(RX_BUFFER_SIZE as u16);
         });
 
+        let (tx_packets, rx_packets) = queue.packet_state.rings();
+
         let mut this = Self {
             _peri: peri,
             _wake_guard: T::RCC_INFO.wake_guard(),
-            tx: TDesRing::new(&mut queue.tx_desc, &mut queue.tx_buf),
-            rx: RDesRing::new(&mut queue.rx_desc, &mut queue.rx_buf),
+            tx: TDesRing::new(&mut queue.tx_desc, &mut queue.tx_buf, tx_packets),
+            rx: RDesRing::new(&mut queue.rx_desc, &mut queue.rx_buf, rx_packets),
             _pins: pins,
             phy,
             mac_addr,

--- a/embassy-stm32/src/eth/v2/mod.rs
+++ b/embassy-stm32/src/eth/v2/mod.rs
@@ -492,13 +492,13 @@ impl<'d, T: Instance, P: Phy> Ethernet<'d, T, P> {
             w.set_rbsz(RX_BUFFER_SIZE as u16);
         });
 
-        let (tx_packets, rx_packets) = queue.packet_state.split();
+        let (tx_state, rx_state) = queue.packet_state.split();
 
         let mut this = Self {
             _peri: peri,
             _wake_guard: T::RCC_INFO.wake_guard(),
-            tx: TDesRing::new(&mut queue.tx_desc, &mut queue.tx_buf, tx_packets),
-            rx: RDesRing::new(&mut queue.rx_desc, &mut queue.rx_buf, rx_packets),
+            tx: TDesRing::new(&mut queue.tx_desc, &mut queue.tx_buf, tx_state),
+            rx: RDesRing::new(&mut queue.rx_desc, &mut queue.rx_buf, rx_state),
             _pins: pins,
             phy,
             mac_addr,

--- a/embassy-stm32/src/eth/v2/mod.rs
+++ b/embassy-stm32/src/eth/v2/mod.rs
@@ -492,7 +492,7 @@ impl<'d, T: Instance, P: Phy> Ethernet<'d, T, P> {
             w.set_rbsz(RX_BUFFER_SIZE as u16);
         });
 
-        let (tx_packets, rx_packets) = queue.packet_state.rings();
+        let (tx_packets, rx_packets) = queue.packet_state.split();
 
         let mut this = Self {
             _peri: peri,

--- a/embassy-stm32/src/lib.rs
+++ b/embassy-stm32/src/lib.rs
@@ -15,6 +15,9 @@
 mod fmt;
 include!(concat!(env!("OUT_DIR"), "/_macros.rs"));
 
+#[cfg(all(feature = "ptp", not(any(eth_v2, eth_v2a))))]
+compile_error!("The 'ptp' feature is only supported on STM32 Ethernet MAC v2/v2a peripherals.");
+
 // Utilities
 mod macros;
 mod reg;


### PR DESCRIPTION
This builds on the existing `embassy-net-driver::PacketMeta` packet-id plumbing and lets the STM32 Ethernet (v2/v2a) driver associate hardware RX/TX descriptor timestamps with packet metadata. Builds without `ptp` do not pay memory or code cost.

This PR focuses on the packet and timestamp handling and does not yet implement the higher layers of MAC PTP peripheral register setup (later PR) or protocol layer (statime shim).