### PR TITLE
nrf: Fix hang during `BufferedUarte::drop`.

### DIFF
--- a/embassy-nrf/src/buffered_uarte/v1.rs
+++ b/embassy-nrf/src/buffered_uarte/v1.rs
@@ -861,6 +861,7 @@ impl<'a> Drop for BufferedUarteRx<'a> {
             w.set_rxdrdy(true);
             w.set_dmarxready(true);
             w.set_rxto(true);
+            w.set_error(true);
         });
         r.events_rxto().write_value(0);
         r.tasks_dma().rx().stop().write_value(1);

--- a/embassy-nrf/src/ppi/dppi.rs
+++ b/embassy-nrf/src/ppi/dppi.rs
@@ -1,4 +1,4 @@
-use super::{Channel, ConfigurableChannel, Event, Ppi, Task};
+use super::{Channel, ConfigurableChannel, Event, Group, Ppi, PpiGroup, Task};
 use crate::Peri;
 
 const DPPI_ENABLE_BIT: u32 = 0x8000_0000;
@@ -79,5 +79,51 @@ impl<'d, C: Channel, const EVENT_COUNT: usize, const TASK_COUNT: usize> Drop for
         for event in self.events {
             unsafe { event.publish_reg().write_volatile(0) }
         }
+    }
+}
+
+impl<'d, G: Group> PpiGroup<'d, G> {
+    /// Add a PPI channel to this group.
+    ///
+    /// If the channel is already in the group, this is a no-op.
+    pub fn add_channel<C: Channel, const EVENT_COUNT: usize, const TASK_COUNT: usize>(
+        &mut self,
+        ch: &Ppi<'_, C, EVENT_COUNT, TASK_COUNT>,
+    ) {
+        let r = self.g.regs();
+        let ng = self.g.number();
+        let nc = ch.ch.number();
+
+        let en = r.subscribe_chg(ng).en().read();
+        let dis = r.subscribe_chg(ng).dis().read();
+        r.subscribe_chg(ng).en().write_value(Default::default());
+        r.subscribe_chg(ng).dis().write_value(Default::default());
+
+        r.chg(ng).modify(|w| w.set_ch(nc, true));
+
+        r.subscribe_chg(ng).en().write_value(en);
+        r.subscribe_chg(ng).dis().write_value(dis);
+    }
+
+    /// Remove a PPI channel from this group.
+    ///
+    /// If the channel is already not in the group, this is a no-op.
+    pub fn remove_channel<C: Channel, const EVENT_COUNT: usize, const TASK_COUNT: usize>(
+        &mut self,
+        ch: &Ppi<'_, C, EVENT_COUNT, TASK_COUNT>,
+    ) {
+        let r = self.g.regs();
+        let ng = self.g.number();
+        let nc = ch.ch.number();
+
+        let en = r.subscribe_chg(ng).en().read();
+        let dis = r.subscribe_chg(ng).dis().read();
+        r.subscribe_chg(ng).en().write_value(Default::default());
+        r.subscribe_chg(ng).dis().write_value(Default::default());
+
+        r.chg(ng).modify(|w| w.set_ch(nc, false));
+
+        r.subscribe_chg(ng).en().write_value(en);
+        r.subscribe_chg(ng).dis().write_value(dis);
     }
 }

--- a/embassy-nrf/src/ppi/mod.rs
+++ b/embassy-nrf/src/ppi/mod.rs
@@ -56,32 +56,6 @@ impl<'d, G: Group> PpiGroup<'d, G> {
         Self { g }
     }
 
-    /// Add a PPI channel to this group.
-    ///
-    /// If the channel is already in the group, this is a no-op.
-    pub fn add_channel<C: Channel, const EVENT_COUNT: usize, const TASK_COUNT: usize>(
-        &mut self,
-        ch: &Ppi<'_, C, EVENT_COUNT, TASK_COUNT>,
-    ) {
-        let r = self.g.regs();
-        let ng = self.g.number();
-        let nc = ch.ch.number();
-        r.chg(ng).modify(|w| w.set_ch(nc, true));
-    }
-
-    /// Remove a PPI channel from this group.
-    ///
-    /// If the channel is already not in the group, this is a no-op.
-    pub fn remove_channel<C: Channel, const EVENT_COUNT: usize, const TASK_COUNT: usize>(
-        &mut self,
-        ch: &Ppi<'_, C, EVENT_COUNT, TASK_COUNT>,
-    ) {
-        let r = self.g.regs();
-        let ng = self.g.number();
-        let nc = ch.ch.number();
-        r.chg(ng).modify(|w| w.set_ch(nc, false));
-    }
-
     /// Enable all the channels in this group.
     pub fn enable_all(&mut self) {
         let n = self.g.number();

--- a/embassy-nrf/src/ppi/ppi.rs
+++ b/embassy-nrf/src/ppi/ppi.rs
@@ -1,4 +1,4 @@
-use super::{Channel, ConfigurableChannel, Event, Ppi, Task};
+use super::{Channel, ConfigurableChannel, Event, Group, Ppi, PpiGroup, Task};
 use crate::{Peri, pac};
 
 impl<'d> Task<'d> {
@@ -87,5 +87,33 @@ impl<'d, C: Channel, const EVENT_COUNT: usize, const TASK_COUNT: usize> Drop for
         r.ch(n).tep().write_value(0);
         #[cfg(not(feature = "_nrf51"))]
         r.fork(n).tep().write_value(0);
+    }
+}
+
+impl<'d, G: Group> PpiGroup<'d, G> {
+    /// Add a PPI channel to this group.
+    ///
+    /// If the channel is already in the group, this is a no-op.
+    pub fn add_channel<C: Channel, const EVENT_COUNT: usize, const TASK_COUNT: usize>(
+        &mut self,
+        ch: &Ppi<'_, C, EVENT_COUNT, TASK_COUNT>,
+    ) {
+        let r = self.g.regs();
+        let ng = self.g.number();
+        let nc = ch.ch.number();
+        r.chg(ng).modify(|w| w.set_ch(nc, true));
+    }
+
+    /// Remove a PPI channel from this group.
+    ///
+    /// If the channel is already not in the group, this is a no-op.
+    pub fn remove_channel<C: Channel, const EVENT_COUNT: usize, const TASK_COUNT: usize>(
+        &mut self,
+        ch: &Ppi<'_, C, EVENT_COUNT, TASK_COUNT>,
+    ) {
+        let r = self.g.regs();
+        let ng = self.g.number();
+        let nc = ch.ch.number();
+        r.chg(ng).modify(|w| w.set_ch(nc, false));
     }
 }


### PR DESCRIPTION
This PR fixes two race conditions that can cause a hang during `BufferedUarte::drop()`.

The first race condition was first observed causing devices in the field to hang sporadically. Once reproduced, I found that the device was hanging in the following loop in `BufferedUarteRx::drop()`:
```rust
        r.events_rxto().write_value(0);
        r.tasks_dma().rx().stop().write_value(1);
        while r.events_rxto().read() == 0 {}
```

Further investigation revealed that in the cases it hangs, the RXTO event never arrives because the stop action gets interrupted by PPI reacting to ENDRX triggering STARTRX. This shouldn't be possible, because the PPI channel should have been disabled by the preceding call to `self._ppi_group.disable_all();`, but this call is ineffective because the channel never got added to the group.

Per the [documentation for the CHG register](https://docs.nordicsemi.com/r/bundle/ps_nrf9151/page/dppi.html?section=register.CHG):
> Note: Writes to this register are ignored if either SUBSCRIBE_CHG[n].EN or SUBSCRIBE_CHG[n].DIS is enabled

In other words, on devices with DPPI a channel can't be added to a group after any of the group tasks are added to a channel. The `Ppi` API also only allows assigning tasks to the channel at construction time, making it effectively impossible to make a group that triggers one of its own tasks.

This PR solves the issue by disabling group tasks when editing channel membership. With this fix, the ENDRX -> STARTTX connection gets disabled like intended, and the hang waiting for RXTO can no longer be reproduced.

While trying to reproduce the above hang, a second race condition that also results in a hang in the drop handler were observed.

In the ISR, the ERROR event is only handled if the RX buffer is available. An ERROR event occurring during drop after the RX buffer have been deinitialized will go unhandled and retrigger the ISR infinitely.

This PR solves the issue by disabling ERROR along with the other RX interrupts.