### PR TITLE
stm32: add ETH v2/v2a PTP clock support

### DIFF
--- a/embassy-stm32/src/eth/mod.rs
+++ b/embassy-stm32/src/eth/mod.rs
@@ -1,6 +1,9 @@
 //! Ethernet (ETH)
 #![macro_use]
 
+#[cfg(all(feature = "ptp", not(eth_v2), not(eth_v2a)))]
+compile_error!("The 'ptp' feature is only supported on STM32 Ethernet MAC v2/v2a peripherals.");
+
 #[cfg_attr(any(eth_v1a, eth_v1b, eth_v1c), path = "v1/mod.rs")]
 #[cfg_attr(any(eth_v2, eth_v2a), path = "v2/mod.rs")]
 mod _version;

--- a/embassy-stm32/src/eth/mod.rs
+++ b/embassy-stm32/src/eth/mod.rs
@@ -25,7 +25,7 @@ pub use self::generic_phy::*;
 use self::packet_state::PacketState;
 use self::ptp::PtpTimestampSink;
 #[cfg(feature = "ptp")]
-pub use self::ptp::{PtpTimestamp, PtpTimestampStore};
+pub use self::ptp::{PtpClock, PtpClockConfig, PtpSubsecondIncrement, PtpTimestamp, PtpTimestampStore};
 pub use self::sma::{Instance as SmaInstance, Sma, StationManagement};
 use crate::rcc::RccPeripheral;
 

--- a/embassy-stm32/src/eth/mod.rs
+++ b/embassy-stm32/src/eth/mod.rs
@@ -25,7 +25,7 @@ pub use self::generic_phy::*;
 use self::packet_state::PacketState;
 use self::ptp::PtpTimestampSink;
 #[cfg(feature = "ptp")]
-pub use self::ptp::{PtpClock, PtpClockConfig, PtpSubsecondIncrement, PtpTimestamp, PtpTimestampStore};
+pub use self::ptp::{PtpTimestamp, PtpTimestampStore};
 pub use self::sma::{Instance as SmaInstance, Sma, StationManagement};
 use crate::rcc::RccPeripheral;
 

--- a/embassy-stm32/src/eth/ptp.rs
+++ b/embassy-stm32/src/eth/ptp.rs
@@ -8,195 +8,15 @@ pub struct PtpTimestamp {
     pub nanos: u32,
 }
 
-/// Ethernet MAC PTP subsecond increment.
-///
-/// The Ethernet clock API configures nanosecond rollover mode, where the
-/// `MACSSIR.SSINC` field is the timestamp increment in nanoseconds.
-#[cfg(feature = "ptp")]
-#[non_exhaustive]
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
-#[cfg_attr(feature = "defmt", derive(defmt::Format))]
-pub struct PtpSubsecondIncrement {
-    nanos: u8,
-}
-
-#[cfg(feature = "ptp")]
-impl PtpSubsecondIncrement {
-    /// 8 ns timestamp increment.
-    pub const NANOS_8: Self = Self { nanos: 8 };
-
-    /// Create a subsecond increment from integer nanoseconds.
-    pub const fn from_nanos(nanos: u8) -> Option<Self> {
-        if nanos == 0 { None } else { Some(Self { nanos }) }
-    }
-
-    /// Return the integer nanosecond increment.
-    pub const fn nanos(self) -> u8 {
-        self.nanos
-    }
-}
-
-/// Ethernet MAC PTP clock configuration.
-///
-/// The clock is configured in fine-update, nanosecond rollover mode.
-#[cfg(feature = "ptp")]
-#[non_exhaustive]
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
-#[cfg_attr(feature = "defmt", derive(defmt::Format))]
-pub struct PtpClockConfig {
-    /// Timestamp increment programmed into `MACSSIR.SSINC`.
-    pub subsecond_increment: PtpSubsecondIncrement,
-}
-
-#[cfg(feature = "ptp")]
-impl PtpClockConfig {
-    /// Create a PTP clock configuration with a custom subsecond increment.
-    pub const fn new(subsecond_increment: PtpSubsecondIncrement) -> Self {
-        Self { subsecond_increment }
-    }
-}
-
-#[cfg(feature = "ptp")]
-impl Default for PtpClockConfig {
-    fn default() -> Self {
-        Self::new(PtpSubsecondIncrement::NANOS_8)
-    }
-}
-
 #[cfg(feature = "ptp")]
 mod imp {
-    use core::marker::PhantomData;
     use core::sync::atomic::{AtomicU32, Ordering};
     use core::task::{Context, Poll};
 
     use embassy_net_driver::PacketMeta;
     use embassy_sync::waitqueue::AtomicWaker;
 
-    use super::{PtpClockConfig, PtpSubsecondIncrement, PtpTimestamp};
-    use crate::eth::Instance;
-
-    #[derive(Clone, Copy, Debug)]
-    #[cfg_attr(feature = "defmt", derive(defmt::Format))]
-    pub(super) struct ClockRate {
-        pub(super) increment: PtpSubsecondIncrement,
-        pub(super) nominal_addend: u32,
-    }
-
-    impl ClockRate {
-        pub(super) fn from_hclk(hclk_hz: u32, increment: PtpSubsecondIncrement) -> Self {
-            let denominator = u64::from(hclk_hz) * u64::from(increment.nanos());
-            assert!(denominator != 0);
-
-            let numerator = (1u64 << 32) * 1_000_000_000;
-            let addend = (numerator + denominator / 2) / denominator;
-            assert!(addend != 0 && addend <= u64::from(u32::MAX));
-
-            Self {
-                increment,
-                nominal_addend: addend as u32,
-            }
-        }
-    }
-
-    #[derive(Clone, Copy)]
-    enum TimeUpdate {
-        Init,
-        Offset,
-    }
-
-    /// Handle for the Ethernet MAC PTP clock.
-    #[derive(Debug)]
-    pub struct PtpClock<T: Instance> {
-        rate: ClockRate,
-        _peri: PhantomData<T>,
-    }
-
-    impl<T: Instance> PtpClock<T> {
-        pub(crate) fn start(config: PtpClockConfig) -> Self {
-            let hclk = unwrap!(unsafe { crate::rcc::get_freqs() }.hclk1.to_hertz());
-            let rate = ClockRate::from_hclk(hclk.0, config.subsecond_increment);
-            let clock = Self {
-                rate,
-                _peri: PhantomData,
-            };
-            clock.configure();
-            clock.set_time(PtpTimestamp { seconds: 0, nanos: 0 });
-            debug!(
-                "eth ptp clock hclk={} increment={}ns addend={:#010x}",
-                hclk.0,
-                rate.increment.nanos(),
-                rate.nominal_addend
-            );
-            clock
-        }
-
-        /// Return the configured subsecond increment.
-        pub fn subsecond_increment(&self) -> PtpSubsecondIncrement {
-            self.rate.increment
-        }
-
-        /// Return the nominal timestamp addend for the configured HCLK.
-        pub fn nominal_addend(&self) -> u32 {
-            self.rate.nominal_addend
-        }
-
-        /// Read the current MAC PTP time.
-        pub fn now(&self) -> PtpTimestamp {
-            let mac = T::regs().ethernet_mac();
-            loop {
-                let seconds = mac.macstsr().read().tss();
-                let nanos = mac.macstnr().read().tsss();
-                if seconds == mac.macstsr().read().tss() {
-                    return PtpTimestamp { seconds, nanos };
-                }
-            }
-        }
-
-        /// Set the MAC PTP time.
-        pub fn set_time(&self, timestamp: PtpTimestamp) {
-            apply_time_update::<T>(timestamp, false, TimeUpdate::Init);
-        }
-
-        /// Step the MAC PTP time by `offset_nanos`.
-        pub fn offset_time(&self, offset_nanos: i64) {
-            let (timestamp, subtract) = timestamp_from_offset(offset_nanos);
-            apply_time_update::<T>(timestamp, subtract, TimeUpdate::Offset);
-        }
-
-        /// Set the live MAC PTP addend register.
-        ///
-        /// This adjusts the running clock frequency without changing
-        /// [`PtpClock::nominal_addend`].
-        pub fn set_addend(&self, addend: u32) {
-            let mac = T::regs().ethernet_mac();
-            mac.mactsar().write(|w| w.set_tsar(addend));
-            while mac.mactscr().read().tsaddreg() {}
-            mac.mactscr().modify(|w| w.set_tsaddreg(true));
-            while mac.mactscr().read().tsaddreg() {}
-        }
-
-        fn configure(&self) {
-            let mac = T::regs().ethernet_mac();
-            mac.macier().modify(|w| w.set_tsie(false));
-            mac.mactscr().modify(|w| w.set_tsena(false));
-            mac.macssir().write(|w| {
-                w.set_snsinc(0);
-                w.set_ssinc(self.rate.increment.nanos());
-            });
-            self.set_addend(self.rate.nominal_addend);
-            mac.mactscr().write(|w| {
-                w.set_tsena(true);
-                w.set_tscfupdt(true);
-                w.set_tsctrlssr(true);
-                w.set_tsver2ena(true);
-                w.set_tsipv4ena(true);
-                w.set_tsipv6ena(true);
-                w.set_tsevntena(true);
-                w.set_snaptypsel(0b01);
-                w.set_txtsstsm(true);
-            });
-        }
-    }
+    use super::PtpTimestamp;
 
     /// Shared Ethernet PTP packet timestamp store.
     ///
@@ -386,50 +206,6 @@ mod imp {
     fn slot_index(slots: &[TimestampSlot], packet_id: u32) -> usize {
         packet_id as usize % slots.len()
     }
-
-    fn apply_time_update<T: Instance>(timestamp: PtpTimestamp, subtract: bool, update: TimeUpdate) {
-        write_time_update::<T>(timestamp, subtract);
-        wait_timestamp_init_or_update_clear::<T>();
-        T::regs().ethernet_mac().mactscr().modify(|w| match update {
-            TimeUpdate::Init => w.set_tsinit(true),
-            TimeUpdate::Offset => w.set_tsupdt(true),
-        });
-        wait_timestamp_init_or_update_clear::<T>();
-    }
-
-    fn write_time_update<T: Instance>(timestamp: PtpTimestamp, subtract: bool) {
-        let mac = T::regs().ethernet_mac();
-        mac.macstsur().write(|w| w.set_tss(timestamp.seconds));
-        mac.macstnur().write(|w| {
-            w.set_tsss(timestamp.nanos);
-            w.set_addsub(subtract);
-        });
-    }
-
-    fn wait_timestamp_init_or_update_clear<T: Instance>() {
-        let mac = T::regs().ethernet_mac();
-        while {
-            let control = mac.mactscr().read();
-            control.tsinit() || control.tsupdt()
-        } {}
-    }
-
-    fn timestamp_from_offset(offset_nanos: i64) -> (PtpTimestamp, bool) {
-        let subtract = offset_nanos < 0;
-        let nanos = if subtract {
-            offset_nanos.unsigned_abs()
-        } else {
-            offset_nanos as u64
-        };
-        let seconds = nanos / 1_000_000_000;
-        let (seconds, nanos) = if seconds > u64::from(u32::MAX) {
-            (u32::MAX, 999_999_999)
-        } else {
-            (seconds as u32, (nanos % 1_000_000_000) as u32)
-        };
-
-        (PtpTimestamp { seconds, nanos }, subtract)
-    }
 }
 
 #[cfg(not(feature = "ptp"))]
@@ -444,33 +220,8 @@ mod imp {
     }
 }
 
-#[cfg(feature = "ptp")]
-pub use imp::PtpClock;
 pub(crate) use imp::PtpTimestampSink;
 #[cfg(feature = "ptp")]
 pub use imp::PtpTimestampStore;
 #[cfg(feature = "ptp")]
 pub(crate) use imp::{RxPtpRing, TxPtpRing};
-
-#[cfg(all(test, feature = "ptp"))]
-mod tests {
-    use super::{PtpSubsecondIncrement, imp::ClockRate};
-
-    #[test]
-    fn addend_for_200mhz_8ns() {
-        let rate = ClockRate::from_hclk(200_000_000, PtpSubsecondIncrement::NANOS_8);
-        assert_eq!(rate.nominal_addend, 0xa000_0000);
-    }
-
-    #[test]
-    fn addend_for_200mhz_6ns() {
-        let rate = ClockRate::from_hclk(200_000_000, PtpSubsecondIncrement::from_nanos(6).unwrap());
-        assert_eq!(rate.nominal_addend, 0xd555_5555);
-    }
-
-    #[test]
-    #[should_panic]
-    fn addend_rejects_impossible_rate() {
-        ClockRate::from_hclk(200_000_000, PtpSubsecondIncrement::from_nanos(5).unwrap());
-    }
-}

--- a/embassy-stm32/src/eth/ptp.rs
+++ b/embassy-stm32/src/eth/ptp.rs
@@ -8,6 +8,25 @@ pub struct PtpTimestamp {
     pub nanos: u32,
 }
 
+impl PtpTimestamp {
+    pub(crate) fn from_offset_nanos(offset_nanos: i64) -> (Self, bool) {
+        let subtract = offset_nanos < 0;
+        let nanos = if subtract {
+            offset_nanos.unsigned_abs()
+        } else {
+            offset_nanos as u64
+        };
+        let seconds = nanos / 1_000_000_000;
+        let (seconds, nanos) = if seconds > u64::from(u32::MAX) {
+            (u32::MAX, 999_999_999)
+        } else {
+            (seconds as u32, (nanos % 1_000_000_000) as u32)
+        };
+
+        (Self { seconds, nanos }, subtract)
+    }
+}
+
 #[cfg(feature = "ptp")]
 mod imp {
     use core::sync::atomic::{AtomicU32, Ordering};

--- a/embassy-stm32/src/eth/ptp.rs
+++ b/embassy-stm32/src/eth/ptp.rs
@@ -9,6 +9,7 @@ pub struct PtpTimestamp {
 }
 
 impl PtpTimestamp {
+    #[cfg(feature = "ptp")]
     pub(crate) fn from_offset_nanos(offset_nanos: i64) -> (Self, bool) {
         let subtract = offset_nanos < 0;
         let nanos = if subtract {

--- a/embassy-stm32/src/eth/ptp.rs
+++ b/embassy-stm32/src/eth/ptp.rs
@@ -8,15 +8,195 @@ pub struct PtpTimestamp {
     pub nanos: u32,
 }
 
+/// Ethernet MAC PTP subsecond increment.
+///
+/// The Ethernet clock API configures nanosecond rollover mode, where the
+/// `MACSSIR.SSINC` field is the timestamp increment in nanoseconds.
+#[cfg(feature = "ptp")]
+#[non_exhaustive]
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+pub struct PtpSubsecondIncrement {
+    nanos: u8,
+}
+
+#[cfg(feature = "ptp")]
+impl PtpSubsecondIncrement {
+    /// 8 ns timestamp increment.
+    pub const NANOS_8: Self = Self { nanos: 8 };
+
+    /// Create a subsecond increment from integer nanoseconds.
+    pub const fn from_nanos(nanos: u8) -> Option<Self> {
+        if nanos == 0 { None } else { Some(Self { nanos }) }
+    }
+
+    /// Return the integer nanosecond increment.
+    pub const fn nanos(self) -> u8 {
+        self.nanos
+    }
+}
+
+/// Ethernet MAC PTP clock configuration.
+///
+/// The clock is configured in fine-update, nanosecond rollover mode.
+#[cfg(feature = "ptp")]
+#[non_exhaustive]
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+pub struct PtpClockConfig {
+    /// Timestamp increment programmed into `MACSSIR.SSINC`.
+    pub subsecond_increment: PtpSubsecondIncrement,
+}
+
+#[cfg(feature = "ptp")]
+impl PtpClockConfig {
+    /// Create a PTP clock configuration with a custom subsecond increment.
+    pub const fn new(subsecond_increment: PtpSubsecondIncrement) -> Self {
+        Self { subsecond_increment }
+    }
+}
+
+#[cfg(feature = "ptp")]
+impl Default for PtpClockConfig {
+    fn default() -> Self {
+        Self::new(PtpSubsecondIncrement::NANOS_8)
+    }
+}
+
 #[cfg(feature = "ptp")]
 mod imp {
+    use core::marker::PhantomData;
     use core::sync::atomic::{AtomicU32, Ordering};
     use core::task::{Context, Poll};
 
     use embassy_net_driver::PacketMeta;
     use embassy_sync::waitqueue::AtomicWaker;
 
-    use super::PtpTimestamp;
+    use super::{PtpClockConfig, PtpSubsecondIncrement, PtpTimestamp};
+    use crate::eth::Instance;
+
+    #[derive(Clone, Copy, Debug)]
+    #[cfg_attr(feature = "defmt", derive(defmt::Format))]
+    pub(super) struct ClockRate {
+        pub(super) increment: PtpSubsecondIncrement,
+        pub(super) nominal_addend: u32,
+    }
+
+    impl ClockRate {
+        pub(super) fn from_hclk(hclk_hz: u32, increment: PtpSubsecondIncrement) -> Self {
+            let denominator = u64::from(hclk_hz) * u64::from(increment.nanos());
+            assert!(denominator != 0);
+
+            let numerator = (1u64 << 32) * 1_000_000_000;
+            let addend = (numerator + denominator / 2) / denominator;
+            assert!(addend != 0 && addend <= u64::from(u32::MAX));
+
+            Self {
+                increment,
+                nominal_addend: addend as u32,
+            }
+        }
+    }
+
+    #[derive(Clone, Copy)]
+    enum TimeUpdate {
+        Init,
+        Offset,
+    }
+
+    /// Handle for the Ethernet MAC PTP clock.
+    #[derive(Debug)]
+    pub struct PtpClock<T: Instance> {
+        rate: ClockRate,
+        _peri: PhantomData<T>,
+    }
+
+    impl<T: Instance> PtpClock<T> {
+        pub(crate) fn start(config: PtpClockConfig) -> Self {
+            let hclk = unwrap!(unsafe { crate::rcc::get_freqs() }.hclk1.to_hertz());
+            let rate = ClockRate::from_hclk(hclk.0, config.subsecond_increment);
+            let clock = Self {
+                rate,
+                _peri: PhantomData,
+            };
+            clock.configure();
+            clock.set_time(PtpTimestamp { seconds: 0, nanos: 0 });
+            debug!(
+                "eth ptp clock hclk={} increment={}ns addend={:#010x}",
+                hclk.0,
+                rate.increment.nanos(),
+                rate.nominal_addend
+            );
+            clock
+        }
+
+        /// Return the configured subsecond increment.
+        pub fn subsecond_increment(&self) -> PtpSubsecondIncrement {
+            self.rate.increment
+        }
+
+        /// Return the nominal timestamp addend for the configured HCLK.
+        pub fn nominal_addend(&self) -> u32 {
+            self.rate.nominal_addend
+        }
+
+        /// Read the current MAC PTP time.
+        pub fn now(&self) -> PtpTimestamp {
+            let mac = T::regs().ethernet_mac();
+            loop {
+                let seconds = mac.macstsr().read().tss();
+                let nanos = mac.macstnr().read().tsss();
+                if seconds == mac.macstsr().read().tss() {
+                    return PtpTimestamp { seconds, nanos };
+                }
+            }
+        }
+
+        /// Set the MAC PTP time.
+        pub fn set_time(&self, timestamp: PtpTimestamp) {
+            apply_time_update::<T>(timestamp, false, TimeUpdate::Init);
+        }
+
+        /// Step the MAC PTP time by `offset_nanos`.
+        pub fn offset_time(&self, offset_nanos: i64) {
+            let (timestamp, subtract) = timestamp_from_offset(offset_nanos);
+            apply_time_update::<T>(timestamp, subtract, TimeUpdate::Offset);
+        }
+
+        /// Set the live MAC PTP addend register.
+        ///
+        /// This adjusts the running clock frequency without changing
+        /// [`PtpClock::nominal_addend`].
+        pub fn set_addend(&self, addend: u32) {
+            let mac = T::regs().ethernet_mac();
+            mac.mactsar().write(|w| w.set_tsar(addend));
+            while mac.mactscr().read().tsaddreg() {}
+            mac.mactscr().modify(|w| w.set_tsaddreg(true));
+            while mac.mactscr().read().tsaddreg() {}
+        }
+
+        fn configure(&self) {
+            let mac = T::regs().ethernet_mac();
+            mac.macier().modify(|w| w.set_tsie(false));
+            mac.mactscr().modify(|w| w.set_tsena(false));
+            mac.macssir().write(|w| {
+                w.set_snsinc(0);
+                w.set_ssinc(self.rate.increment.nanos());
+            });
+            self.set_addend(self.rate.nominal_addend);
+            mac.mactscr().write(|w| {
+                w.set_tsena(true);
+                w.set_tscfupdt(true);
+                w.set_tsctrlssr(true);
+                w.set_tsver2ena(true);
+                w.set_tsipv4ena(true);
+                w.set_tsipv6ena(true);
+                w.set_tsevntena(true);
+                w.set_snaptypsel(0b01);
+                w.set_txtsstsm(true);
+            });
+        }
+    }
 
     /// Shared Ethernet PTP packet timestamp store.
     ///
@@ -206,6 +386,50 @@ mod imp {
     fn slot_index(slots: &[TimestampSlot], packet_id: u32) -> usize {
         packet_id as usize % slots.len()
     }
+
+    fn apply_time_update<T: Instance>(timestamp: PtpTimestamp, subtract: bool, update: TimeUpdate) {
+        write_time_update::<T>(timestamp, subtract);
+        wait_timestamp_init_or_update_clear::<T>();
+        T::regs().ethernet_mac().mactscr().modify(|w| match update {
+            TimeUpdate::Init => w.set_tsinit(true),
+            TimeUpdate::Offset => w.set_tsupdt(true),
+        });
+        wait_timestamp_init_or_update_clear::<T>();
+    }
+
+    fn write_time_update<T: Instance>(timestamp: PtpTimestamp, subtract: bool) {
+        let mac = T::regs().ethernet_mac();
+        mac.macstsur().write(|w| w.set_tss(timestamp.seconds));
+        mac.macstnur().write(|w| {
+            w.set_tsss(timestamp.nanos);
+            w.set_addsub(subtract);
+        });
+    }
+
+    fn wait_timestamp_init_or_update_clear<T: Instance>() {
+        let mac = T::regs().ethernet_mac();
+        while {
+            let control = mac.mactscr().read();
+            control.tsinit() || control.tsupdt()
+        } {}
+    }
+
+    fn timestamp_from_offset(offset_nanos: i64) -> (PtpTimestamp, bool) {
+        let subtract = offset_nanos < 0;
+        let nanos = if subtract {
+            offset_nanos.unsigned_abs()
+        } else {
+            offset_nanos as u64
+        };
+        let seconds = nanos / 1_000_000_000;
+        let (seconds, nanos) = if seconds > u64::from(u32::MAX) {
+            (u32::MAX, 999_999_999)
+        } else {
+            (seconds as u32, (nanos % 1_000_000_000) as u32)
+        };
+
+        (PtpTimestamp { seconds, nanos }, subtract)
+    }
 }
 
 #[cfg(not(feature = "ptp"))]
@@ -220,8 +444,33 @@ mod imp {
     }
 }
 
+#[cfg(feature = "ptp")]
+pub use imp::PtpClock;
 pub(crate) use imp::PtpTimestampSink;
 #[cfg(feature = "ptp")]
 pub use imp::PtpTimestampStore;
 #[cfg(feature = "ptp")]
 pub(crate) use imp::{RxPtpRing, TxPtpRing};
+
+#[cfg(all(test, feature = "ptp"))]
+mod tests {
+    use super::{PtpSubsecondIncrement, imp::ClockRate};
+
+    #[test]
+    fn addend_for_200mhz_8ns() {
+        let rate = ClockRate::from_hclk(200_000_000, PtpSubsecondIncrement::NANOS_8);
+        assert_eq!(rate.nominal_addend, 0xa000_0000);
+    }
+
+    #[test]
+    fn addend_for_200mhz_6ns() {
+        let rate = ClockRate::from_hclk(200_000_000, PtpSubsecondIncrement::from_nanos(6).unwrap());
+        assert_eq!(rate.nominal_addend, 0xd555_5555);
+    }
+
+    #[test]
+    #[should_panic]
+    fn addend_rejects_impossible_rate() {
+        ClockRate::from_hclk(200_000_000, PtpSubsecondIncrement::from_nanos(5).unwrap());
+    }
+}

--- a/embassy-stm32/src/eth/v2/descriptors.rs
+++ b/embassy-stm32/src/eth/v2/descriptors.rs
@@ -206,7 +206,8 @@ impl<'a> TDesRing<'a> {
 
         // Read format
         td.tdes0.set(self.buffers[self.index].0.as_ptr() as u32);
-        let mut tdes2 = len as u32 & EMAC_TDES2_B1L | EMAC_TDES2_IOC;
+        let mut tdes2 = len as u32 & EMAC_TDES2_B1L;
+        tdes2 |= EMAC_TDES2_IOC;
         #[cfg(feature = "ptp")]
         if self.state.timestamp_enabled() {
             tdes2 |= EMAC_TDES2_TTSE;

--- a/embassy-stm32/src/eth/v2/descriptors.rs
+++ b/embassy-stm32/src/eth/v2/descriptors.rs
@@ -206,15 +206,17 @@ impl<'a> TDesRing<'a> {
 
         // Read format
         td.tdes0.set(self.buffers[self.index].0.as_ptr() as u32);
-        #[cfg(feature = "ptp")]
-        let packet_id = self.state.next_id();
-        #[cfg(feature = "ptp")]
-        let timestamp_enabled = self.state.timestamp_enabled();
-        #[cfg(not(feature = "ptp"))]
-        let timestamp_enabled = false;
         let mut tdes2 = len as u32 & EMAC_TDES2_B1L | EMAC_TDES2_IOC;
-        if timestamp_enabled {
+        #[cfg(feature = "ptp")]
+        if self.state.timestamp_enabled() {
             tdes2 |= EMAC_TDES2_TTSE;
+            trace!(
+                "eth ptp tx submit idx={} packet_id={} len={} tdes2={:#010x}",
+                self.index,
+                self.state.next_id(),
+                len,
+                tdes2
+            );
         }
         td.tdes2.set(tdes2);
         self.state.commit(self.index);
@@ -227,13 +229,6 @@ impl<'a> TDesRing<'a> {
         #[cfg(eth_v2a)]
         let tdes3 = tdes3 | EMAC_TDES3_CIC_FULL;
         td.tdes3.set(tdes3);
-        #[cfg(feature = "ptp")]
-        if timestamp_enabled {
-            trace!(
-                "eth ptp tx submit idx={} packet_id={} len={} tdes2={:#010x}",
-                self.index, packet_id, len, tdes2
-            );
-        }
 
         // Ensure changes to the descriptor are committed before DMA engine sees tail pointer store.
         // This will generate an DMB instruction.
@@ -441,11 +436,11 @@ impl<'a> RDesRing<'a> {
         }
     }
 
-    fn pop_current(&mut self, packet: bool) {
+    fn pop_current(&mut self, state: bool) {
         let rd = &mut self.descriptors[self.index];
         assert!(rd.available());
 
-        if packet {
+        if state {
             self.state.clear(self.index);
         }
         rd.set_ready(self.buffers[self.index].0.as_mut_ptr());

--- a/embassy-stm32/src/eth/v2/mod.rs
+++ b/embassy-stm32/src/eth/v2/mod.rs
@@ -6,6 +6,8 @@ use core::sync::atomic::{Ordering, fence};
 
 pub(crate) use descriptors::{RDes, RDesRing, TDes, TDesRing};
 use embassy_hal_internal::Peri;
+#[cfg(feature = "ptp")]
+pub use ptp::{PtpClock, PtpClockConfig, PtpSubsecondIncrement};
 #[cfg(eth_v2)]
 use stm32_metapac::syscfg::vals::EthSelPhy;
 
@@ -18,8 +20,6 @@ use crate::pac::ETH;
 #[cfg(eth_v2a)]
 use crate::pac::ETH1 as ETH;
 use crate::rcc::WakeGuard;
-#[cfg(feature = "ptp")]
-pub use ptp::{PtpClock, PtpClockConfig, PtpSubsecondIncrement};
 
 // The two MACs sit behind different interrupt lines.
 #[cfg(eth_v2)]

--- a/embassy-stm32/src/eth/v2/mod.rs
+++ b/embassy-stm32/src/eth/v2/mod.rs
@@ -1,4 +1,6 @@
 mod descriptors;
+#[cfg(feature = "ptp")]
+mod ptp;
 
 use core::sync::atomic::{Ordering, fence};
 
@@ -8,8 +10,6 @@ use embassy_hal_internal::Peri;
 use stm32_metapac::syscfg::vals::EthSelPhy;
 
 use super::*;
-#[cfg(feature = "ptp")]
-use super::{PtpClock, PtpClockConfig};
 use crate::gpio::{AfType, Flex, OutputType, Speed};
 use crate::interrupt;
 use crate::interrupt::InterruptExt;
@@ -18,6 +18,8 @@ use crate::pac::ETH;
 #[cfg(eth_v2a)]
 use crate::pac::ETH1 as ETH;
 use crate::rcc::WakeGuard;
+#[cfg(feature = "ptp")]
+pub use ptp::{PtpClock, PtpClockConfig, PtpSubsecondIncrement};
 
 // The two MACs sit behind different interrupt lines.
 #[cfg(eth_v2)]

--- a/embassy-stm32/src/eth/v2/mod.rs
+++ b/embassy-stm32/src/eth/v2/mod.rs
@@ -8,6 +8,8 @@ use embassy_hal_internal::Peri;
 use stm32_metapac::syscfg::vals::EthSelPhy;
 
 use super::*;
+#[cfg(feature = "ptp")]
+use super::{PtpClock, PtpClockConfig};
 use crate::gpio::{AfType, Flex, OutputType, Speed};
 use crate::interrupt;
 use crate::interrupt::InterruptExt;
@@ -71,6 +73,8 @@ pub struct Ethernet<'d, T: Instance, P: Phy> {
     _pins: Pins<'d>,
     pub(crate) phy: P,
     pub(crate) mac_addr: [u8; 6],
+    #[cfg(feature = "ptp")]
+    ptp_clock_taken: bool,
 }
 
 /// Pins of ethernet driver.
@@ -503,6 +507,8 @@ impl<'d, T: Instance, P: Phy> Ethernet<'d, T, P> {
             phy,
             mac_addr,
             link_state: LinkState::Down,
+            #[cfg(feature = "ptp")]
+            ptp_clock_taken: false,
         };
 
         fence(Ordering::SeqCst);
@@ -542,6 +548,18 @@ impl<'d, T: Instance, P: Phy> Ethernet<'d, T, P> {
         }
 
         this
+    }
+
+    /// Start the Ethernet MAC PTP clock.
+    #[cfg(feature = "ptp")]
+    pub fn start_ptp(&mut self, config: PtpClockConfig) -> PtpClock<T> {
+        if self.ptp_clock_taken {
+            panic!("Ethernet PTP clock already started");
+        }
+
+        let clock = PtpClock::start(config);
+        self.ptp_clock_taken = true;
+        clock
     }
 }
 

--- a/embassy-stm32/src/eth/v2/ptp.rs
+++ b/embassy-stm32/src/eth/v2/ptp.rs
@@ -1,0 +1,246 @@
+use core::marker::PhantomData;
+
+use super::Instance;
+use crate::eth::ptp::PtpTimestamp;
+
+/// Ethernet MAC PTP subsecond increment.
+///
+/// The v2/v2a Ethernet MAC PTP clock is configured in nanosecond rollover
+/// mode, where the subsecond increment field is an integer number of
+/// nanoseconds.
+#[non_exhaustive]
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+pub struct PtpSubsecondIncrement {
+    nanos: u8,
+}
+
+impl PtpSubsecondIncrement {
+    /// 8 ns timestamp increment.
+    pub const NANOS_8: Self = Self { nanos: 8 };
+
+    /// Create a subsecond increment from integer nanoseconds.
+    pub const fn from_nanos(nanos: u8) -> Option<Self> {
+        if nanos == 0 { None } else { Some(Self { nanos }) }
+    }
+
+    /// Return the integer nanosecond increment.
+    pub const fn nanos(self) -> u8 {
+        self.nanos
+    }
+}
+
+/// Ethernet MAC PTP clock configuration.
+///
+/// The v2/v2a Ethernet MAC PTP clock is configured in fine-update,
+/// nanosecond rollover mode.
+#[non_exhaustive]
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+pub struct PtpClockConfig {
+    /// Timestamp subsecond increment.
+    pub subsecond_increment: PtpSubsecondIncrement,
+}
+
+impl PtpClockConfig {
+    /// Create a PTP clock configuration with a custom subsecond increment.
+    pub const fn new(subsecond_increment: PtpSubsecondIncrement) -> Self {
+        Self { subsecond_increment }
+    }
+}
+
+impl Default for PtpClockConfig {
+    fn default() -> Self {
+        Self::new(PtpSubsecondIncrement::NANOS_8)
+    }
+}
+
+#[derive(Clone, Copy, Debug)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+pub(super) struct ClockRate {
+    pub(super) increment: PtpSubsecondIncrement,
+    pub(super) nominal_addend: u32,
+}
+
+impl ClockRate {
+    pub(super) fn from_hclk(hclk_hz: u32, increment: PtpSubsecondIncrement) -> Self {
+        let denominator = u64::from(hclk_hz) * u64::from(increment.nanos());
+        assert!(denominator != 0);
+
+        let numerator = (1u64 << 32) * 1_000_000_000;
+        let addend = (numerator + denominator / 2) / denominator;
+        assert!(addend != 0 && addend <= u64::from(u32::MAX));
+
+        Self {
+            increment,
+            nominal_addend: addend as u32,
+        }
+    }
+}
+
+#[derive(Clone, Copy)]
+enum TimeUpdate {
+    Init,
+    Offset,
+}
+
+/// Handle for the Ethernet MAC PTP clock.
+#[derive(Debug)]
+pub struct PtpClock<T: Instance> {
+    rate: ClockRate,
+    _peri: PhantomData<T>,
+}
+
+impl<T: Instance> PtpClock<T> {
+    pub(crate) fn start(config: PtpClockConfig) -> Self {
+        let hclk = unwrap!(unsafe { crate::rcc::get_freqs() }.hclk1.to_hertz());
+        let rate = ClockRate::from_hclk(hclk.0, config.subsecond_increment);
+        let clock = Self {
+            rate,
+            _peri: PhantomData,
+        };
+        clock.configure();
+        clock.set_time(PtpTimestamp { seconds: 0, nanos: 0 });
+        debug!(
+            "eth ptp clock hclk={} increment={}ns addend={:#010x}",
+            hclk.0,
+            rate.increment.nanos(),
+            rate.nominal_addend
+        );
+        clock
+    }
+
+    /// Return the configured subsecond increment.
+    pub fn subsecond_increment(&self) -> PtpSubsecondIncrement {
+        self.rate.increment
+    }
+
+    /// Return the nominal timestamp addend for the configured HCLK.
+    pub fn nominal_addend(&self) -> u32 {
+        self.rate.nominal_addend
+    }
+
+    /// Read the current MAC PTP time.
+    pub fn now(&self) -> PtpTimestamp {
+        let mac = T::regs().ethernet_mac();
+        loop {
+            let seconds = mac.macstsr().read().tss();
+            let nanos = mac.macstnr().read().tsss();
+            if seconds == mac.macstsr().read().tss() {
+                return PtpTimestamp { seconds, nanos };
+            }
+        }
+    }
+
+    /// Set the MAC PTP time.
+    pub fn set_time(&self, timestamp: PtpTimestamp) {
+        apply_time_update::<T>(timestamp, false, TimeUpdate::Init);
+    }
+
+    /// Step the MAC PTP time by `offset_nanos`.
+    pub fn offset_time(&self, offset_nanos: i64) {
+        let (timestamp, subtract) = timestamp_from_offset(offset_nanos);
+        apply_time_update::<T>(timestamp, subtract, TimeUpdate::Offset);
+    }
+
+    /// Set the live MAC PTP addend register.
+    ///
+    /// This adjusts the running clock frequency without changing
+    /// [`PtpClock::nominal_addend`].
+    pub fn set_addend(&self, addend: u32) {
+        let mac = T::regs().ethernet_mac();
+        mac.mactsar().write(|w| w.set_tsar(addend));
+        while mac.mactscr().read().tsaddreg() {}
+        mac.mactscr().modify(|w| w.set_tsaddreg(true));
+        while mac.mactscr().read().tsaddreg() {}
+    }
+
+    fn configure(&self) {
+        let mac = T::regs().ethernet_mac();
+        mac.macier().modify(|w| w.set_tsie(false));
+        mac.mactscr().modify(|w| w.set_tsena(false));
+        mac.macssir().write(|w| {
+            w.set_snsinc(0);
+            w.set_ssinc(self.rate.increment.nanos());
+        });
+        self.set_addend(self.rate.nominal_addend);
+        mac.mactscr().write(|w| {
+            w.set_tsena(true);
+            w.set_tscfupdt(true);
+            w.set_tsctrlssr(true);
+            w.set_tsver2ena(true);
+            w.set_tsipv4ena(true);
+            w.set_tsipv6ena(true);
+            w.set_tsevntena(true);
+            w.set_snaptypsel(0b01);
+            w.set_txtsstsm(true);
+        });
+    }
+}
+
+fn apply_time_update<T: Instance>(timestamp: PtpTimestamp, subtract: bool, update: TimeUpdate) {
+    write_time_update::<T>(timestamp, subtract);
+    wait_timestamp_init_or_update_clear::<T>();
+    T::regs().ethernet_mac().mactscr().modify(|w| match update {
+        TimeUpdate::Init => w.set_tsinit(true),
+        TimeUpdate::Offset => w.set_tsupdt(true),
+    });
+    wait_timestamp_init_or_update_clear::<T>();
+}
+
+fn write_time_update<T: Instance>(timestamp: PtpTimestamp, subtract: bool) {
+    let mac = T::regs().ethernet_mac();
+    mac.macstsur().write(|w| w.set_tss(timestamp.seconds));
+    mac.macstnur().write(|w| {
+        w.set_tsss(timestamp.nanos);
+        w.set_addsub(subtract);
+    });
+}
+
+fn wait_timestamp_init_or_update_clear<T: Instance>() {
+    let mac = T::regs().ethernet_mac();
+    while {
+        let control = mac.mactscr().read();
+        control.tsinit() || control.tsupdt()
+    } {}
+}
+
+fn timestamp_from_offset(offset_nanos: i64) -> (PtpTimestamp, bool) {
+    let subtract = offset_nanos < 0;
+    let nanos = if subtract {
+        offset_nanos.unsigned_abs()
+    } else {
+        offset_nanos as u64
+    };
+    let seconds = nanos / 1_000_000_000;
+    let (seconds, nanos) = if seconds > u64::from(u32::MAX) {
+        (u32::MAX, 999_999_999)
+    } else {
+        (seconds as u32, (nanos % 1_000_000_000) as u32)
+    };
+
+    (PtpTimestamp { seconds, nanos }, subtract)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{ClockRate, PtpSubsecondIncrement};
+
+    #[test]
+    fn addend_for_200mhz_8ns() {
+        let rate = ClockRate::from_hclk(200_000_000, PtpSubsecondIncrement::NANOS_8);
+        assert_eq!(rate.nominal_addend, 0xa000_0000);
+    }
+
+    #[test]
+    fn addend_for_200mhz_6ns() {
+        let rate = ClockRate::from_hclk(200_000_000, PtpSubsecondIncrement::from_nanos(6).unwrap());
+        assert_eq!(rate.nominal_addend, 0xd555_5555);
+    }
+
+    #[test]
+    #[should_panic]
+    fn addend_rejects_impossible_rate() {
+        ClockRate::from_hclk(200_000_000, PtpSubsecondIncrement::from_nanos(5).unwrap());
+    }
+}

--- a/embassy-stm32/src/eth/v2/ptp.rs
+++ b/embassy-stm32/src/eth/v2/ptp.rs
@@ -139,7 +139,7 @@ impl<T: Instance> PtpClock<T> {
 
     /// Step the MAC PTP time by `offset_nanos`.
     pub fn offset_time(&self, offset_nanos: i64) {
-        let (timestamp, subtract) = timestamp_from_offset(offset_nanos);
+        let (timestamp, subtract) = PtpTimestamp::from_offset_nanos(offset_nanos);
         apply_time_update::<T>(timestamp, subtract, TimeUpdate::Offset);
     }
 
@@ -203,23 +203,6 @@ fn wait_timestamp_init_or_update_clear<T: Instance>() {
         let control = mac.mactscr().read();
         control.tsinit() || control.tsupdt()
     } {}
-}
-
-fn timestamp_from_offset(offset_nanos: i64) -> (PtpTimestamp, bool) {
-    let subtract = offset_nanos < 0;
-    let nanos = if subtract {
-        offset_nanos.unsigned_abs()
-    } else {
-        offset_nanos as u64
-    };
-    let seconds = nanos / 1_000_000_000;
-    let (seconds, nanos) = if seconds > u64::from(u32::MAX) {
-        (u32::MAX, 999_999_999)
-    } else {
-        (seconds as u32, (nanos % 1_000_000_000) as u32)
-    };
-
-    (PtpTimestamp { seconds, nanos }, subtract)
 }
 
 #[cfg(test)]

--- a/embassy-stm32/src/lib.rs
+++ b/embassy-stm32/src/lib.rs
@@ -15,9 +15,6 @@
 mod fmt;
 include!(concat!(env!("OUT_DIR"), "/_macros.rs"));
 
-#[cfg(all(feature = "ptp", not(any(eth_v2, eth_v2a))))]
-compile_error!("The 'ptp' feature is only supported on STM32 Ethernet MAC v2/v2a peripherals.");
-
 // Utilities
 mod macros;
 mod reg;


### PR DESCRIPTION
On top of #6325:

This adds ETH PTP configuration and clock getting/setting/offsetting/tuning support for the STM32 v2/v2a MAC.

It is slightly opinionated in the configuration with an eye towards an actual PTP implementation. With this, a `impl statime::Clock` is small. `MyClock(PtpClock)` is a desirable app-side newtype since people may want custom logging/statistics or a custom clock handling layer. But if direct statime support is desired the bare impl could also go here or into statime.

Includes one NFC stylistic tweak commit after #6325.