### PR TITLE
stm32/i2cv2: allow zero-length transfers

### DIFF
--- a/embassy-stm32/src/i2c/v2.rs
+++ b/embassy-stm32/src/i2c/v2.rs
@@ -602,7 +602,8 @@ impl<'d, M: Mode, IM: MasterMode> I2c<'d, M, IM> {
     /// Performing an I2C bus scan using zero-length writes to check device presence:
     ///
     /// ```rust,no_run
-    /// use embassy_stm32::i2c::{I2c, Operation};
+    /// use embassy_stm32::i2c::I2c;
+    /// use embedded_hal_1::i2c::Operation;
     ///
     /// # macro_rules! host_code { () => {
     /// let mut i2c: I2c<'_, _, _> = ...;
@@ -1261,7 +1262,8 @@ impl<'d, IM: MasterMode> I2c<'d, Async, IM> {
     /// Performing an I2C bus scan using zero-length writes to check device presence:
     ///
     /// ```rust,no_run
-    /// use embassy_stm32::i2c::{I2c, Operation};
+    /// use embassy_stm32::i2c::I2c;
+    /// use embedded_hal_1::i2c::Operation;
     ///
     /// # macro_rules! host_code { () => {
     /// let mut i2c: I2c<'_, _, _> = ...;

--- a/embassy-stm32/src/i2c/v2.rs
+++ b/embassy-stm32/src/i2c/v2.rs
@@ -596,15 +596,32 @@ impl<'d, M: Mode, IM: MasterMode> I2c<'d, M, IM> {
     /// Consecutive operations of same type are merged. See [transaction contract] for details.
     ///
     /// [transaction contract]: embedded_hal_1::i2c::I2c::transaction
+    ///
+    /// # Example
+    ///
+    /// Performing an I2C bus scan using zero-length writes to check device presence:
+    ///
+    /// ```rust,no_run
+    /// use embassy_stm32::i2c::{I2c, Operation};
+    ///
+    /// # macro_rules! host_code { () => {
+    /// let mut i2c: I2c<'_, _, _> = ...;
+    ///
+    /// for addr in 0x08..0x78 {
+    ///     // A zero-length write transaction will send the address and check for ACK/NACK
+    ///     // without transferring any data bytes.
+    ///     let mut ops = [Operation::Write(&[])];
+    ///     if i2c.blocking_transaction(addr, &mut ops).is_ok() {
+    ///         defmt::info!("Device found at address 0x{:02x}", addr);
+    ///     }
+    /// }
+    /// # } }
+    /// ```
     pub fn blocking_transaction(
         &mut self,
         addr: impl Into<Address>,
         operations: &mut [Operation<'_>],
     ) -> Result<(), Error> {
-        if operations.is_empty() {
-            return Err(Error::ZeroLengthTransfer);
-        }
-
         let address = addr.into();
         let timeout = self.timeout();
 
@@ -662,11 +679,13 @@ impl<'d, M: Mode, IM: MasterMode> I2c<'d, M, IM> {
 
         if total_bytes == 0 {
             // Handle empty write group - just send address
-            if is_first_group {
-                Self::master_write(self.info, address, 0, Stop::Software, false, !is_first_group, timeout)?;
-            }
+            Self::master_write(self.info, address, 0, Stop::Software, false, !is_first_group, timeout)?;
             if is_last_group {
+                self.wait_tc(timeout)?;
                 self.master_stop();
+                self.wait_stop(timeout)?;
+            } else {
+                self.wait_tc(timeout)?;
             }
             return Ok(());
         }
@@ -736,17 +755,15 @@ impl<'d, M: Mode, IM: MasterMode> I2c<'d, M, IM> {
 
         if total_bytes == 0 {
             // Handle empty read group
-            if is_first_group {
-                Self::master_read(
-                    self.info,
-                    address,
-                    0,
-                    if is_last_group { Stop::Automatic } else { Stop::Software },
-                    false, // reload
-                    !is_first_group,
-                    timeout,
-                )?;
-            }
+            Self::master_read(
+                self.info,
+                address,
+                0,
+                if is_last_group { Stop::Automatic } else { Stop::Software },
+                false, // reload
+                !is_first_group,
+                timeout,
+            )?;
             if is_last_group {
                 self.wait_stop(timeout)?;
             }
@@ -817,7 +834,7 @@ impl<'d, M: Mode, IM: MasterMode> I2c<'d, M, IM> {
     /// The buffers are concatenated in a single write transaction.
     pub fn blocking_write_vectored(&mut self, address: u8, write: &[&[u8]]) -> Result<(), Error> {
         if write.is_empty() {
-            return Err(Error::ZeroLengthTransfer);
+            return self.write_internal(address.into(), &[], true, self.timeout());
         }
 
         let timeout = self.timeout();
@@ -1165,7 +1182,7 @@ impl<'d, IM: MasterMode> I2c<'d, Async, IM> {
         let timeout = self.timeout();
 
         if write.is_empty() {
-            return Err(Error::ZeroLengthTransfer);
+            return self.write_internal(address, &[], true, timeout);
         }
 
         let mut iter = write.iter();
@@ -1238,15 +1255,33 @@ impl<'d, IM: MasterMode> I2c<'d, Async, IM> {
     /// Consecutive operations of same type are merged. See [transaction contract] for details.
     ///
     /// [transaction contract]: embedded_hal_1::i2c::I2c::transaction
+    ///
+    /// # Example
+    ///
+    /// Performing an I2C bus scan using zero-length writes to check device presence:
+    ///
+    /// ```rust,no_run
+    /// use embassy_stm32::i2c::{I2c, Operation};
+    ///
+    /// # macro_rules! host_code { () => {
+    /// let mut i2c: I2c<'_, _, _> = ...;
+    ///
+    /// for addr in 0x08..0x78 {
+    ///     // A zero-length write transaction will send the address and check for ACK/NACK
+    ///     // without transferring any data bytes.
+    ///     let mut ops = [Operation::Write(&[])];
+    ///     if i2c.transaction(addr, &mut ops).await.is_ok() {
+    ///         defmt::info!("Device found at address 0x{:02x}", addr);
+    ///     }
+    /// }
+    /// # } }
+    /// ```
     pub async fn transaction(
         &mut self,
         addr: impl Into<Address>,
         operations: &mut [Operation<'_>],
     ) -> Result<(), Error> {
         let _scoped_wake_guard = self.info.rcc.wake_guard();
-        if operations.is_empty() {
-            return Err(Error::ZeroLengthTransfer);
-        }
 
         let address = addr.into();
         let timeout = self.timeout();
@@ -1307,11 +1342,13 @@ impl<'d, IM: MasterMode> I2c<'d, Async, IM> {
 
         if total_bytes == 0 {
             // Handle empty write group using blocking call
-            if is_first_group {
-                Self::master_write(self.info, address, 0, Stop::Software, false, !is_first_group, timeout)?;
-            }
+            Self::master_write(self.info, address, 0, Stop::Software, false, !is_first_group, timeout)?;
             if is_last_group {
+                self.wait_tc(timeout)?;
                 self.master_stop();
+                self.wait_stop(timeout)?;
+            } else {
+                self.wait_tc(timeout)?;
             }
             return Ok(());
         }
@@ -1364,17 +1401,15 @@ impl<'d, IM: MasterMode> I2c<'d, Async, IM> {
 
         if total_bytes == 0 {
             // Handle empty read group using blocking call
-            if is_first_group {
-                Self::master_read(
-                    self.info,
-                    address,
-                    0,
-                    if is_last_group { Stop::Automatic } else { Stop::Software },
-                    false, // reload
-                    !is_first_group,
-                    timeout,
-                )?;
-            }
+            Self::master_read(
+                self.info,
+                address,
+                0,
+                if is_last_group { Stop::Automatic } else { Stop::Software },
+                false, // reload
+                !is_first_group,
+                timeout,
+            )?;
             if is_last_group {
                 self.wait_stop(timeout)?;
             }

--- a/examples/stm32l4/src/bin/i2c_scan.rs
+++ b/examples/stm32l4/src/bin/i2c_scan.rs
@@ -1,0 +1,34 @@
+#![no_std]
+#![no_main]
+
+use defmt::*;
+use embassy_executor::Spawner;
+use embassy_stm32::i2c::{Error, I2c};
+use embedded_hal_1::i2c::Operation;
+use {defmt_rtt as _, panic_probe as _};
+
+#[embassy_executor::main]
+async fn main(_spawner: Spawner) {
+    let p = embassy_stm32::init(Default::default());
+    info!("Initializing I2C bus scanner...");
+
+    // Configure SCL/SDA pins for I2C2 (PB10 and PB11 are typical for Nucleo-L476RG)
+    let mut i2c = I2c::new_blocking(p.I2C2, p.PB10, p.PB11, Default::default());
+
+    info!("Starting bus scan using blocking zero-length writes...");
+    for addr in 0x08u8..0x78u8 {
+        let mut ops = [Operation::Write(&[])];
+        match i2c.blocking_transaction(addr, &mut ops) {
+            Ok(_) => {
+                info!("Found device at address: 0x{:02x}", addr);
+            }
+            Err(Error::Nack) => {
+                // Address not acknowledged (no device present)
+            }
+            Err(e) => {
+                warn!("Address 0x{:02x} failed with error: {:?}", addr, e);
+            }
+        }
+    }
+    info!("Scan complete!");
+}


### PR DESCRIPTION
#### Description
This PR allows zero-length transfers in the STM32 I2C v2 driver (`stm32/i2cv2`). This supports sending the address, verifying the ACK/NACK status, and generating proper STOP/RESTART conditions without transferring any data bytes. This enables address-only "device probe" transactions (I2C bus scanning) which the I2C spec permits.

Fixes #2298 

**Key Design Decisions:**
1. **Always Initiate Address Phase**: Removed the `is_first_group` guard around `master_write` and `master_read` inside `execute_write_group`, `execute_read_group`, and their async variants. This ensures the master always programs the START/RESTART condition and sends the target address (SAD+W or SAD+R) even for zero-length groups that are not the first in a transaction.
2. **Deterministic Sequencing**: Bypasses the byte data transfer loops for zero-length groups, instead waiting for transfer completion (`wait_tc`) and cleanly transitioning to a STOP condition (on last group) or returning to allow a RESTART condition (on intermediate groups).
3. **Delegation**: Modified `write_vectored` and `blocking_write_vectored` to delegate empty buffers to `write_internal` to execute a zero-length address-only transaction.
4. **Documentation**: Added doc examples to `transaction` and `blocking_transaction` showing how to perform I2C bus scanning via zero-length writes.

#### Testing
The changes have been validated through local compilation, Clippy, and formatting checks:
- Compiled `embassy-stm32` cleanly for STM32L4 (`stm32l476vg`, blocking & async paths) and STM32H7 (`stm32h743zi`, async DMA-heavy paths).
- Verified zero clippy warnings/errors (`cargo clippy --features stm32l476vg,time-driver-any,exti -- -D warnings`).
- Formatting verified with `cargo fmt --all --check`.
- Verified the state machine sequencing for all cases by inspection:
  - Single zero-length write (only op): START + SAD+W → ACK/NACK → STOP
  - Zero-length write as last of N: RESTART + SAD+W → ACK/NACK → STOP
  - Zero-length write as intermediate: RESTART + SAD+W → ACK/NACK → wait for next group (matches non-empty intermediate group sequencing with data phase skipped)
  - Zero-length write as first of N: START + SAD+W → ACK/NACK → wait for next group
  - Equivalent read-side sequencing verified for `Stop::Automatic`/`Stop::Software`

> [!WARNING]
> **Physical Hardware Validation**:
> While compilation, formatting, and Clippy lints pass successfully, this feature has not been validated on real physical boards. I request community members with STM32 L4/H7/etc. boards to validate using the zero-length write probe scan.

---

# Changelog

## embassy-stm32

- Fixed: `stm32/i2cv2`: allow zero-length transfers (e.g. for checking device presence during I2C address scanning).