### PR TITLE
esp-hosted: add bluetooth

### DIFF
--- a/embassy-net-esp-hosted/CHANGELOG.md
+++ b/embassy-net-esp-hosted/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 <!-- next-header -->
 ## Unreleased - ReleaseDate
 
+- `embassy_net_esp_hosted::new` now returns an `HostedResources` struct with named fields.
+- Added Bluetooth (BLE) support via the new `bluetooth` feature. `new` returns a `bluetooth::BtDriver` implementing `bt_hci::transport::Transport`, exposing the ESP coprocessor's HCI controller over the ESP-Hosted HCI interface.
 - Added `FwVersion` struct and `Control::get_fw_version`.
 - Fixed compilation error with the `log` feature.
 - `Interface::transfer` now exchanges the buffer in place.

--- a/embassy-net-esp-hosted/Cargo.toml
+++ b/embassy-net-esp-hosted/Cargo.toml
@@ -56,4 +56,4 @@ target = "thumbv7em-none-eabi"
 features = ["defmt", "esp-hosted-fg", "esp-hosted-mcu"]
 
 [package.metadata.docs.rs]
-features = ["defmt"]
+features = ["defmt", "esp-hosted-fg", "esp-hosted-mcu"]

--- a/embassy-net-esp-hosted/Cargo.toml
+++ b/embassy-net-esp-hosted/Cargo.toml
@@ -14,13 +14,16 @@ build = [
     {target = "thumbv7em-none-eabi", features = ["esp-hosted-fg"]},
     {target = "thumbv7em-none-eabi", features = ["esp-hosted-mcu"]},
     {target = "thumbv7em-none-eabi", features = ["esp-hosted-fg", "esp-hosted-mcu"]},
-    {target = "thumbv7em-none-eabi", features = ["esp-hosted-fg", "esp-hosted-mcu", "log"]},
-    {target = "thumbv7em-none-eabi", features = ["esp-hosted-fg", "esp-hosted-mcu", "defmt"]},
+    {target = "thumbv7em-none-eabi", features = ["esp-hosted-fg", "esp-hosted-mcu", "bluetooth", "log"]},
+    {target = "thumbv7em-none-eabi", features = ["esp-hosted-fg", "esp-hosted-mcu", "bluetooth", "defmt"]},
 ]
 
 [features]
-defmt = ["dep:defmt", "heapless/defmt"]
+defmt = ["dep:defmt", "heapless/defmt", "bt-hci?/defmt", "embedded-io-async?/defmt"]
 log = ["dep:log"]
+
+## Enable Bluetooth (BLE) support using `bt-hci`.
+bluetooth = ["dep:bt-hci", "dep:embedded-io-async"]
 
 #! ### Hosted firmware support
 #! At least one of the following features must be enabled. When both are enabled,
@@ -49,11 +52,15 @@ micropb = { version = "0.6.0", default-features = false, features = ["container-
 heapless = "0.9"
 document-features = "0.2.7"
 
+# Bluetooth deps
+embedded-io-async = { version = "0.7.0", optional = true }
+bt-hci = { version = "0.9.0", optional = true }
+
 [package.metadata.embassy_docs]
 src_base = "https://github.com/embassy-rs/embassy/blob/embassy-net-esp-hosted-v$VERSION/embassy-net-esp-hosted/src/"
 src_base_git = "https://github.com/embassy-rs/embassy/blob/$COMMIT/embassy-net-esp-hosted/src/"
 target = "thumbv7em-none-eabi"
-features = ["defmt", "esp-hosted-fg", "esp-hosted-mcu"]
+features = ["defmt", "esp-hosted-fg", "esp-hosted-mcu", "bluetooth"]
 
 [package.metadata.docs.rs]
-features = ["defmt", "esp-hosted-fg", "esp-hosted-mcu"]
+features = ["defmt", "esp-hosted-fg", "esp-hosted-mcu", "bluetooth"]

--- a/embassy-net-esp-hosted/README.md
+++ b/embassy-net-esp-hosted/README.md
@@ -1,6 +1,6 @@
 # ESP-Hosted `embassy-net` integration
 
-[`embassy-net`](https://crates.io/crates/embassy-net) integration for Espressif SoCs running the [ESP-Hosted](https://github.com/espressif/esp-hosted) stack.
+[`embassy-net`](https://crates.io/crates/embassy-net) integration for Espressif SoCs running the [ESP-Hosted-Fg](https://github.com/espressif/esp-hosted) or [ESP-Hosted-Mcu](https://github.com/espressif/esp-hosted-mcu) stack.
 
 See [`examples`](https://github.com/embassy-rs/embassy/tree/main/examples/nrf52840) directory for usage examples with the nRF52840.
 

--- a/embassy-net-esp-hosted/src/bluetooth.rs
+++ b/embassy-net-esp-hosted/src/bluetooth.rs
@@ -1,0 +1,199 @@
+//! Bluetooth (BLE) HCI transport over the ESP-Hosted `HCI` interface.
+//!
+//! The ESP coprocessor exposes its Bluetooth controller as an HCI interface multiplexed
+//! over the same SPI/SDIO link used for WiFi. This module provides a [`BtDriver`] that
+//! implements [`bt_hci::transport::Transport`], so it can be plugged directly into a
+//! host stack such as `trouble-host`.
+
+use core::cell::RefCell;
+use core::future::Future;
+use core::mem::MaybeUninit;
+
+use bt_hci::transport::WithIndicator;
+use bt_hci::{ControllerToHostPacket, FromHciBytes, FromHciBytesError, HostToControllerPacket, PacketKind, WriteHci};
+use embassy_sync::blocking_mutex::raw::NoopRawMutex;
+use embassy_sync::zerocopy_channel;
+use embedded_io_async::ErrorKind;
+
+/// Maximum size of a single HCI packet (including the 1-byte H4 packet type indicator).
+const BT_HCI_MTU: usize = 1024;
+
+/// A buffer holding a single HCI packet.
+///
+/// `buf[0]` is the H4 packet type indicator (Command / ACL / Sync / Event), the rest is
+/// the packet payload. This mirrors how the controller exchanges packets with the host.
+pub(crate) struct BtPacketBuf {
+    pub(crate) len: usize,
+    pub(crate) buf: [u8; BT_HCI_MTU],
+}
+
+impl BtPacketBuf {
+    /// Create a new, empty packet buffer.
+    pub const fn new() -> Self {
+        Self {
+            len: 0,
+            buf: [0; BT_HCI_MTU],
+        }
+    }
+}
+
+/// State backing the Bluetooth driver. Must outlive the driver and runner.
+pub(crate) struct BtState {
+    rx: [BtPacketBuf; 4],
+    tx: [BtPacketBuf; 4],
+    inner: MaybeUninit<BtStateInner<'static>>,
+}
+
+impl BtState {
+    /// Create a new, empty Bluetooth state holder.
+    pub const fn new() -> Self {
+        Self {
+            rx: [const { BtPacketBuf::new() }; 4],
+            tx: [const { BtPacketBuf::new() }; 4],
+            inner: MaybeUninit::uninit(),
+        }
+    }
+}
+
+impl Default for BtState {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+struct BtStateInner<'d> {
+    rx: zerocopy_channel::Channel<'d, NoopRawMutex, BtPacketBuf>,
+    tx: zerocopy_channel::Channel<'d, NoopRawMutex, BtPacketBuf>,
+}
+
+/// Bluetooth HCI transport driver.
+///
+/// Implements [`bt_hci::transport::Transport`]; hand it to a host stack to send and
+/// receive HCI packets.
+pub struct BtDriver<'d> {
+    rx: RefCell<zerocopy_channel::Receiver<'d, NoopRawMutex, BtPacketBuf>>,
+    tx: RefCell<zerocopy_channel::Sender<'d, NoopRawMutex, BtPacketBuf>>,
+}
+
+/// The runner half of the Bluetooth driver. Driven by the esp-hosted [`Runner`](crate::Runner).
+pub(crate) struct BtRunner<'d> {
+    /// HCI packets queued by the host stack, to be transmitted to the controller.
+    pub(crate) tx_chan: zerocopy_channel::Receiver<'d, NoopRawMutex, BtPacketBuf>,
+    /// HCI packets received from the controller, to be delivered to the host stack.
+    rx_chan: zerocopy_channel::Sender<'d, NoopRawMutex, BtPacketBuf>,
+}
+
+/// Split a [`BtState`] into a runner and a driver.
+pub(crate) fn new<'d>(state: &'d mut BtState) -> (BtRunner<'d>, BtDriver<'d>) {
+    // safety: this is a self-referential struct, however:
+    // - it can't move while the `'d` borrow is active.
+    // - when the borrow ends, the dangling references inside the MaybeUninit will never be used again.
+    let state_uninit: *mut MaybeUninit<BtStateInner<'d>> =
+        (&mut state.inner as *mut MaybeUninit<BtStateInner<'static>>).cast();
+    let state = unsafe { &mut *state_uninit }.write(BtStateInner {
+        rx: zerocopy_channel::Channel::new(&mut state.rx[..]),
+        tx: zerocopy_channel::Channel::new(&mut state.tx[..]),
+    });
+
+    let (rx_sender, rx_receiver) = state.rx.split();
+    let (tx_sender, tx_receiver) = state.tx.split();
+
+    (
+        BtRunner {
+            tx_chan: tx_receiver,
+            rx_chan: rx_sender,
+        },
+        BtDriver {
+            rx: RefCell::new(rx_receiver),
+            tx: RefCell::new(tx_sender),
+        },
+    )
+}
+
+impl<'d> BtRunner<'d> {
+    /// Deliver an HCI packet received from the controller to the host stack.
+    ///
+    /// `payload` is a complete HCI packet whose first byte is the H4 packet type indicator,
+    /// exactly as the ESP-Hosted firmware delivers it over the HCI interface.
+    pub(crate) fn rx(&mut self, payload: &[u8]) {
+        match self.rx_chan.try_send() {
+            Some(mut buf) => {
+                let n = payload.len().min(BT_HCI_MTU);
+                buf.buf[..n].copy_from_slice(&payload[..n]);
+                buf.len = n;
+                buf.send_done();
+            }
+            None => warn!("bluetooth rx queue full, dropping packet"),
+        }
+    }
+}
+
+/// HCI transport error.
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+#[derive(Debug)]
+pub enum Error {
+    /// I/O error.
+    Io(ErrorKind),
+}
+
+impl From<FromHciBytesError> for Error {
+    fn from(e: FromHciBytesError) -> Self {
+        match e {
+            FromHciBytesError::InvalidSize => Error::Io(ErrorKind::InvalidInput),
+            FromHciBytesError::InvalidValue => Error::Io(ErrorKind::InvalidData),
+        }
+    }
+}
+
+impl core::fmt::Display for Error {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        core::fmt::Debug::fmt(self, f)
+    }
+}
+
+impl core::error::Error for Error {}
+
+impl<'d> embedded_io_async::ErrorType for BtDriver<'d> {
+    type Error = Error;
+}
+
+impl embedded_io_async::Error for Error {
+    fn kind(&self) -> ErrorKind {
+        match self {
+            Self::Io(e) => *e,
+        }
+    }
+}
+
+impl<'d> bt_hci::transport::Transport for BtDriver<'d> {
+    fn read<'a>(&self, rx: &'a mut [u8]) -> impl Future<Output = Result<ControllerToHostPacket<'a>, Self::Error>> {
+        async {
+            let ch = &mut *self.rx.borrow_mut();
+            let buf = ch.receive().await;
+            let n = buf.len;
+            assert!(n < rx.len());
+            rx[..n].copy_from_slice(&buf.buf[..n]);
+            buf.receive_done();
+
+            let kind = PacketKind::from_hci_bytes_complete(&rx[..1])?;
+            let (pkt, _) = ControllerToHostPacket::from_hci_bytes_with_kind(kind, &rx[1..n])?;
+            Ok(pkt)
+        }
+    }
+
+    /// Write a complete HCI packet from the tx buffer.
+    fn write<T: HostToControllerPacket>(&self, val: &T) -> impl Future<Output = Result<(), Self::Error>> {
+        async {
+            let ch = &mut *self.tx.borrow_mut();
+            let mut buf = ch.send().await;
+            let buf_len = buf.buf.len();
+            let mut slice = &mut buf.buf[..];
+            WithIndicator::new(val)
+                .write_hci(&mut slice)
+                .map_err(|_| Error::Io(ErrorKind::Other))?;
+            buf.len = buf_len - slice.len();
+            buf.send_done();
+            Ok(())
+        }
+    }
+}

--- a/embassy-net-esp-hosted/src/control.rs
+++ b/embassy-net-esp-hosted/src/control.rs
@@ -143,8 +143,8 @@ impl<'a> Control<'a> {
         debug!("set heartbeat");
         self.backend.config_heartbeat(&mut ctx, 10).await?;
 
-        debug!("wifi_init");
-        self.backend.wifi_init(&mut ctx).await?;
+        debug!("init_radio");
+        self.backend.init_radio(&mut ctx).await?;
 
         debug!("set wifi mode");
         self.backend.set_mode(&mut ctx, WifiMode::Sta).await?;

--- a/embassy-net-esp-hosted/src/lib.rs
+++ b/embassy-net-esp-hosted/src/lib.rs
@@ -6,7 +6,10 @@
 #![warn(missing_docs)]
 #![allow(async_fn_in_trait)]
 
-use embassy_futures::select::{Either4, select4};
+#[cfg(not(feature = "bluetooth"))]
+use embassy_futures::select::{Either4 as EitherMany, select4 as select_many};
+#[cfg(feature = "bluetooth")]
+use embassy_futures::select::{Either5 as EitherMany, select5 as select_many};
 use embassy_net_driver_channel as ch;
 use embassy_net_driver_channel::driver::LinkState;
 use embassy_time::{Duration, Instant, Timer};
@@ -20,6 +23,8 @@ mod proto;
 // must be first
 mod fmt;
 
+#[cfg(feature = "bluetooth")]
+pub mod bluetooth;
 mod control;
 mod iface;
 mod ioctl;
@@ -120,6 +125,8 @@ const HEARTBEAT_MAX_GAP: Duration = Duration::from_secs(20);
 pub struct State {
     shared: Shared,
     ch: ch::State<MTU, 4, 4>,
+    #[cfg(feature = "bluetooth")]
+    bt: bluetooth::BtState,
 }
 
 impl State {
@@ -128,6 +135,8 @@ impl State {
         Self {
             shared: Shared::new(),
             ch: ch::State::new(),
+            #[cfg(feature = "bluetooth")]
+            bt: bluetooth::BtState::new(),
         }
     }
 }
@@ -135,21 +144,36 @@ impl State {
 /// Type alias for network driver.
 pub type NetDriver<'a> = ch::Device<'a, MTU>;
 
-/// Create a new esp-hosted driver using the provided state, interface, and reset pin.
+/// Handles returned by [`new`] for interacting with the esp-hosted driver.
+pub struct HostedResources<'a, I, OUT> {
+    /// Network device for use with embassy-net.
+    pub net_device: NetDriver<'a>,
+
+    /// Bluetooth HCI transport, for use with a `bt-hci` host stack.
+    #[cfg(feature = "bluetooth")]
+    pub bluetooth: bluetooth::BtDriver<'a>,
+
+    /// Control handle for managing WiFi and driver state.
+    pub control: Control<'a>,
+
+    /// Runner driving communication with the coprocessor. Must be spawned.
+    pub runner: Runner<'a, I, OUT>,
+}
+
+/// Create a new esp-hosted driver.
 ///
 /// Returns a device handle for interfacing with embassy-net, a control handle for
 /// interacting with the driver, and a runner for communicating with the WiFi device.
-pub async fn new<'a, I, OUT>(
-    state: &'a mut State,
-    iface: I,
-    reset: OUT,
-) -> (NetDriver<'a>, Control<'a>, Runner<'a, I, OUT>)
+pub async fn new<'a, I, OUT>(state: &'a mut State, iface: I, reset: OUT) -> HostedResources<'a, I, OUT>
 where
     I: Interface,
     OUT: OutputPin,
 {
     let (ch_runner, device) = ch::new(&mut state.ch, ch::driver::HardwareAddress::Ethernet([0; 6]));
     let state_ch = ch_runner.state_runner();
+
+    #[cfg(feature = "bluetooth")]
+    let (bt_runner, bt_driver) = bluetooth::new(&mut state.bt);
 
     let runner = Runner {
         ch: ch_runner,
@@ -160,9 +184,17 @@ where
         reset,
         iface,
         heartbeat_deadline: Instant::now() + HEARTBEAT_MAX_GAP,
+        #[cfg(feature = "bluetooth")]
+        bt: bt_runner,
     };
 
-    (device, Control::new(state_ch, &state.shared), runner)
+    HostedResources {
+        net_device: device,
+        #[cfg(feature = "bluetooth")]
+        bluetooth: bt_driver,
+        control: Control::new(state_ch, &state.shared),
+        runner,
+    }
 }
 
 /// Runner for communicating with the WiFi device.
@@ -177,6 +209,9 @@ pub struct Runner<'a, I, OUT> {
 
     iface: I,
     reset: OUT,
+
+    #[cfg(feature = "bluetooth")]
+    bt: bluetooth::BtRunner<'a>,
 }
 
 impl<'a, I, OUT> Runner<'a, I, OUT>
@@ -206,8 +241,18 @@ where
             let ev = self.iface.wait_for_ready();
             let hb = Timer::at(self.heartbeat_deadline);
 
-            match select4(ioctl, tx, ev, hb).await {
-                Either4::First(PendingIoctl { buf, req_len }) => {
+            let event = select_many(
+                ioctl,
+                tx,
+                ev,
+                hb,
+                #[cfg(feature = "bluetooth")]
+                self.bt.tx_chan.receive(),
+            )
+            .await;
+
+            match event {
+                EitherMany::First(PendingIoctl { buf, req_len }) => {
                     let if_type_and_num = unwrap!(self.backend.encode_iface_type(InterfaceType::Serial));
 
                     let payload_len = self
@@ -224,7 +269,7 @@ where
                     self.next_seq = self.next_seq.wrapping_add(1);
                     header.copy(&mut buffer);
                 }
-                Either4::Second(packet) => {
+                EitherMany::Second(packet) => {
                     if let Some(if_type_and_num) = self.backend.encode_iface_type(InterfaceType::Sta) {
                         buffer[PayloadHeader::SIZE..][..packet.len()].copy_from_slice(&packet);
 
@@ -241,16 +286,45 @@ where
 
                     packet.tx_done();
                 }
-                Either4::Third(()) => {
+                EitherMany::Third(()) => {
                     buffer[..PayloadHeader::SIZE].fill(0);
                 }
-                Either4::Fourth(()) => {
+                EitherMany::Fourth(()) => {
                     // Extend the deadline if initializing
                     if let ioctl::ControlState::Reboot = self.shared.state() {
                         self.heartbeat_deadline = Instant::now() + HEARTBEAT_MAX_GAP;
                         continue;
                     }
                     panic!("heartbeat from esp32 stopped")
+                }
+
+                // Bluetooth HCI packet queued by the host stack.
+                #[cfg(feature = "bluetooth")]
+                EitherMany::Fifth(slot) => {
+                    if let Some(if_type_and_num) = self.backend.encode_iface_type(InterfaceType::Hci) {
+                        // `slot.buf[0]` is the H4 packet type indicator; it travels in the
+                        // payload header's `hci_priv_packet_type` field, and the remaining
+                        // bytes are the HCI packet body.
+                        let pkt_type = slot.buf[0];
+                        let body = &slot.buf[1..slot.len];
+                        buffer[PayloadHeader::SIZE..][..body.len()].copy_from_slice(body);
+
+                        let header = PayloadHeader {
+                            if_type_and_num,
+                            len: body.len() as _,
+                            offset: PayloadHeader::SIZE as _,
+                            seq_num: self.next_seq,
+                            hci_priv_packet_type: pkt_type,
+                            ..Default::default()
+                        };
+                        self.next_seq = self.next_seq.wrapping_add(1);
+                        header.copy(&mut buffer);
+                    } else {
+                        // Backend doesn't support HCI (e.g. not yet initialized). Drop the
+                        // packet and send nothing this iteration.
+                        buffer[..PayloadHeader::SIZE].fill(0);
+                    }
+                    slot.receive_done();
                 }
             }
 
@@ -317,6 +391,15 @@ where
                     Some((false, data)) => self.shared.ioctl_done(data),
                     _ => {}
                 }
+            }
+            #[cfg(feature = "bluetooth")]
+            Some(InterfaceType::Hci) => {
+                #[cfg(feature = "log")]
+                trace!("hci rx: {:02x?}", payload);
+                #[cfg(feature = "defmt")]
+                trace!("hci rx: {=[u8]:02x}", payload);
+
+                self.bt.rx(payload);
             }
             _ => warn!("unknown iftype {}", if_type_and_num),
         }

--- a/embassy-net-esp-hosted/src/proto/mcu/esp_hosted_rpc.proto
+++ b/embassy-net-esp-hosted/src/proto/mcu/esp_hosted_rpc.proto
@@ -259,7 +259,7 @@ enum RpcId {
 	 * Supported Features:
 	 * - BT Init/Deinit/Enable/Disable
 	 */
-	//Req_FeatureControl                = 387; //0x183
+	Req_FeatureControl                = 387; //0x183
 
 	/* Custom RPC for user-defined packed structures */
 	//Req_CustomRpc                     = 388; //0x184
@@ -443,7 +443,7 @@ enum RpcId {
 
 	//Resp_IfaceMacAddrSetGet                   = 641;
 	//Resp_IfaceMacAddrLenGet                   = 642;
-	//Resp_FeatureControl                       = 643;
+	Resp_FeatureControl                       = 643;
 
 	//Resp_CustomRpc                            = 644;
 
@@ -2288,7 +2288,7 @@ message Rpc {
 		//Rpc_Req_IfaceMacAddrSetGet          req_iface_mac_addr_set_get        = 385;
 		//Rpc_Req_IfaceMacAddrLenGet          req_iface_mac_addr_len_get        = 386;
 
-		//Rpc_Req_FeatureControl              req_feature_control               = 387;
+		Rpc_Req_FeatureControl              req_feature_control               = 387;
 
 		//Rpc_Req_CustomRpc                   req_custom_rpc                    = 388;
 
@@ -2427,7 +2427,7 @@ message Rpc {
 		//Rpc_Resp_IfaceMacAddrSetGet         resp_iface_mac_addr_set_get        = 641;
 		//Rpc_Resp_IfaceMacAddrLenGet         resp_iface_mac_addr_len_get        = 642;
 
-		//Rpc_Resp_FeatureControl             resp_feature_control               = 643;
+		Rpc_Resp_FeatureControl             resp_feature_control               = 643;
 
 		//Rpc_Resp_CustomRpc                  resp_custom_rpc                    = 644;
 

--- a/embassy-net-esp-hosted/src/proto/mcu/mod.rs
+++ b/embassy-net-esp-hosted/src/proto/mcu/mod.rs
@@ -49759,6 +49759,19 @@ impl ::micropb::MessageDecode for Rpc {
                     };
                     mut_ref.decode_len_delimited(decoder)?;
                 }
+                387u32 => {
+                    let mut_ref = loop {
+                        if let ::core::option::Option::Some(variant) = &mut self.r#payload {
+                            if let Rpc_::Payload::ReqFeatureControl(variant) = &mut *variant {
+                                break &mut *variant;
+                            }
+                        }
+                        self.r#payload = ::core::option::Option::Some(Rpc_::Payload::ReqFeatureControl(
+                            ::core::default::Default::default(),
+                        ));
+                    };
+                    mut_ref.decode_len_delimited(decoder)?;
+                }
                 513u32 => {
                     let mut_ref = loop {
                         if let ::core::option::Option::Some(variant) = &mut self.r#payload {
@@ -49936,6 +49949,19 @@ impl ::micropb::MessageDecode for Rpc {
                             }
                         }
                         self.r#payload = ::core::option::Option::Some(Rpc_::Payload::RespGetCoprocessorFwversion(
+                            ::core::default::Default::default(),
+                        ));
+                    };
+                    mut_ref.decode_len_delimited(decoder)?;
+                }
+                643u32 => {
+                    let mut_ref = loop {
+                        if let ::core::option::Option::Some(variant) = &mut self.r#payload {
+                            if let Rpc_::Payload::RespFeatureControl(variant) = &mut *variant {
+                                break &mut *variant;
+                            }
+                        }
+                        self.r#payload = ::core::option::Option::Some(Rpc_::Payload::RespFeatureControl(
                             ::core::default::Default::default(),
                         ));
                     };
@@ -50244,6 +50270,21 @@ impl ::micropb::MessageEncode for Rpc {
                 }
             }
             match ::micropb::const_map!(
+                ::micropb::const_map!(<Rpc_Req_FeatureControl as ::micropb::MessageEncode>::MAX_SIZE, |size| {
+                    ::micropb::size::sizeof_len_record(size)
+                }),
+                |size| size + 2usize
+            ) {
+                ::core::result::Result::Ok(size) => {
+                    if size > max_size {
+                        max_size = size;
+                    }
+                }
+                ::core::result::Result::Err(err) => {
+                    break 'oneof (::core::result::Result::<usize, _>::Err(err));
+                }
+            }
+            match ::micropb::const_map!(
                 ::micropb::const_map!(<Rpc_Resp_GetMacAddress as ::micropb::MessageEncode>::MAX_SIZE, |size| {
                     ::micropb::size::sizeof_len_record(size)
                 }),
@@ -50458,6 +50499,22 @@ impl ::micropb::MessageEncode for Rpc {
                 }
             }
             match ::micropb::const_map!(
+                ::micropb::const_map!(
+                    <Rpc_Resp_FeatureControl as ::micropb::MessageEncode>::MAX_SIZE,
+                    |size| ::micropb::size::sizeof_len_record(size)
+                ),
+                |size| size + 2usize
+            ) {
+                ::core::result::Result::Ok(size) => {
+                    if size > max_size {
+                        max_size = size;
+                    }
+                }
+                ::core::result::Result::Err(err) => {
+                    break 'oneof (::core::result::Result::<usize, _>::Err(err));
+                }
+            }
+            match ::micropb::const_map!(
                 ::micropb::const_map!(<Rpc_Event_ESPInit as ::micropb::MessageEncode>::MAX_SIZE, |size| {
                     ::micropb::size::sizeof_len_record(size)
                 }),
@@ -50627,6 +50684,11 @@ impl ::micropb::MessageEncode for Rpc {
                     encoder.encode_varint32(2802u32)?;
                     val_ref.encode_len_delimited(encoder)?;
                 }
+                Rpc_::Payload::ReqFeatureControl(val_ref) => {
+                    let val_ref = &*val_ref;
+                    encoder.encode_varint32(3098u32)?;
+                    val_ref.encode_len_delimited(encoder)?;
+                }
                 Rpc_::Payload::RespGetMacAddress(val_ref) => {
                     let val_ref = &*val_ref;
                     encoder.encode_varint32(4106u32)?;
@@ -50695,6 +50757,11 @@ impl ::micropb::MessageEncode for Rpc {
                 Rpc_::Payload::RespGetCoprocessorFwversion(val_ref) => {
                     let val_ref = &*val_ref;
                     encoder.encode_varint32(4850u32)?;
+                    val_ref.encode_len_delimited(encoder)?;
+                }
+                Rpc_::Payload::RespFeatureControl(val_ref) => {
+                    let val_ref = &*val_ref;
+                    encoder.encode_varint32(5146u32)?;
                     val_ref.encode_len_delimited(encoder)?;
                 }
                 Rpc_::Payload::EventEspInit(val_ref) => {
@@ -50800,6 +50867,10 @@ impl ::micropb::MessageEncode for Rpc {
                     let val_ref = &*val_ref;
                     size += 2usize + ::micropb::size::sizeof_len_record(val_ref.compute_size());
                 }
+                Rpc_::Payload::ReqFeatureControl(val_ref) => {
+                    let val_ref = &*val_ref;
+                    size += 2usize + ::micropb::size::sizeof_len_record(val_ref.compute_size());
+                }
                 Rpc_::Payload::RespGetMacAddress(val_ref) => {
                     let val_ref = &*val_ref;
                     size += 2usize + ::micropb::size::sizeof_len_record(val_ref.compute_size());
@@ -50856,6 +50927,10 @@ impl ::micropb::MessageEncode for Rpc {
                     let val_ref = &*val_ref;
                     size += 2usize + ::micropb::size::sizeof_len_record(val_ref.compute_size());
                 }
+                Rpc_::Payload::RespFeatureControl(val_ref) => {
+                    let val_ref = &*val_ref;
+                    size += 2usize + ::micropb::size::sizeof_len_record(val_ref.compute_size());
+                }
                 Rpc_::Payload::EventEspInit(val_ref) => {
                     let val_ref = &*val_ref;
                     size += 2usize + ::micropb::size::sizeof_len_record(val_ref.compute_size());
@@ -50908,6 +50983,7 @@ pub mod Rpc_ {
         ///Rpc_Req_WifiDeauthSta               req_wifi_deauth_sta               = 293;
         ReqWifiStaGetApInfo(super::Rpc_Req_WifiStaGetApInfo),
         ReqGetCoprocessorFwversion(super::Rpc_Req_GetCoprocessorFwVersion),
+        ReqFeatureControl(super::Rpc_Req_FeatureControl),
         ///* Responses *
         RespGetMacAddress(super::Rpc_Resp_GetMacAddress),
         ///Rpc_Resp_SetMacAddress              resp_set_mac_address               = 514;
@@ -50933,6 +51009,7 @@ pub mod Rpc_ {
         ///Rpc_Resp_WifiDeauthSta              resp_wifi_deauth_sta               = 549;
         RespWifiStaGetApInfo(super::Rpc_Resp_WifiStaGetApInfo),
         RespGetCoprocessorFwversion(super::Rpc_Resp_GetCoprocessorFwVersion),
+        RespFeatureControl(super::Rpc_Resp_FeatureControl),
         ///* Notifications *
         EventEspInit(super::Rpc_Event_ESPInit),
         EventHeartbeat(super::Rpc_Event_Heartbeat),
@@ -51230,6 +51307,12 @@ impl RpcId {
     pub const ReqWifiStaGetApInfo: Self = Self(294);
     ///0x15e
     pub const ReqGetCoprocessorFwVersion: Self = Self(350);
+    /// Common RPC to handle simple feature control with one optional parameter
+    /// Supported Features:
+    /// - BT Init/Deinit/Enable/Disable
+    ///
+    ///0x183
+    pub const ReqFeatureControl: Self = Self(387);
     pub const RespGetMacAddress: Self = Self(513);
     ///Resp_SetMacAddress                = 514;
     ///Resp_GetWifiMode                  = 515;
@@ -51267,6 +51350,9 @@ impl RpcId {
     ///Resp_WifiGetCountry               = 560;
     pub const RespWifiStaGetApInfo: Self = Self(550);
     pub const RespGetCoprocessorFwVersion: Self = Self(606);
+    ///Resp_IfaceMacAddrSetGet                   = 641;
+    ///Resp_IfaceMacAddrLenGet                   = 642;
+    pub const RespFeatureControl: Self = Self(643);
     ///Event_Base = 768;
     pub const EventEspInit: Self = Self(769);
     pub const EventHeartbeat: Self = Self(770);

--- a/embassy-net-esp-hosted/src/rpc/fg.rs
+++ b/embassy-net-esp-hosted/src/rpc/fg.rs
@@ -92,11 +92,12 @@ impl RpcBackend for FgBackend {
         match iface_type {
             0 => Some(InterfaceType::Sta),
             2 => Some(InterfaceType::Serial),
+            3 => Some(InterfaceType::Hci),
             _ => None,
         }
     }
 
-    async fn wifi_init(&self, _ctx: &mut IoctlCtx<'_>) -> Result<(), Error> {
+    async fn init_radio(&self, _ctx: &mut IoctlCtx<'_>) -> Result<(), Error> {
         Ok(())
     }
 

--- a/embassy-net-esp-hosted/src/rpc/mcu.rs
+++ b/embassy-net-esp-hosted/src/rpc/mcu.rs
@@ -10,6 +10,8 @@ use crate::proto::mcu::{
     Rpc_Req_WifiInit, Rpc_Req_WifiSetConfig, Rpc_Req_WifiStaGetApInfo, Rpc_Req_WifiStart, RpcId, RpcType, wifi_config,
     wifi_config_, wifi_init_config, wifi_scan_threshold, wifi_sta_config,
 };
+#[cfg(feature = "bluetooth")]
+use crate::proto::mcu::{Rpc_Req_FeatureControl, RpcFeature, RpcFeatureCommand, RpcFeatureOption};
 use crate::{FwVersion, InterfaceType, WifiMode};
 
 macro_rules! exchange {
@@ -100,11 +102,12 @@ impl RpcBackend for McuBackend {
         match iface_type {
             1 => Some(InterfaceType::Sta),
             3 => Some(InterfaceType::Serial),
+            4 => Some(InterfaceType::Hci),
             _ => None,
         }
     }
 
-    async fn wifi_init(&self, ctx: &mut IoctlCtx<'_>) -> Result<(), Error> {
+    async fn init_radio(&self, ctx: &mut IoctlCtx<'_>) -> Result<(), Error> {
         let mut req = Rpc_Req_WifiInit::default();
         req.set_cfg(
             // TODO: this should be user-configurable, either in build-time or runtime
@@ -121,6 +124,40 @@ impl RpcBackend for McuBackend {
         );
 
         exchange!(ctx, ReqWifiInit, RespWifiInit, req);
+
+        #[cfg(feature = "bluetooth")]
+        {
+            // Since esp-hosted-mcu v2.5.2 the BT controller is disabled by default and must be
+            // explicitly initialized and enabled via the FeatureControl RPC before the BT host
+            // stack can talk to it over the HCI interface.
+            match self.get_fw_version(ctx).await? {
+                #[cfg(feature = "esp-hosted-fg")]
+                FwVersion::Fg { .. } => return Err(Error::Internal),
+
+                FwVersion::Mcu { major, minor, patch } => {
+                    if major < 2 || (major == 2 && minor < 5) || (major == 2 && minor == 5 && patch < 2) {
+                        return Ok(());
+                    }
+                }
+            }
+
+            debug!("Enabling Bluetooth though FeatureControl");
+
+            let req = Rpc_Req_FeatureControl {
+                feature: RpcFeature::FeatureBluetooth,
+                command: RpcFeatureCommand::FeatureCommandBtInit,
+                option: RpcFeatureOption::FeatureOptionNone,
+            };
+            exchange!(ctx, ReqFeatureControl, RespFeatureControl, req);
+
+            let req = Rpc_Req_FeatureControl {
+                feature: RpcFeature::FeatureBluetooth,
+                command: RpcFeatureCommand::FeatureCommandBtEnable,
+                option: RpcFeatureOption::FeatureOptionNone,
+            };
+            exchange!(ctx, ReqFeatureControl, RespFeatureControl, req);
+        }
+
         Ok(())
     }
 

--- a/embassy-net-esp-hosted/src/rpc/mod.rs
+++ b/embassy-net-esp-hosted/src/rpc/mod.rs
@@ -189,18 +189,17 @@ impl RpcBackend for NoBackend {
         None
     }
     fn decode_iface_type(&self, iface_type: u8) -> Option<InterfaceType> {
-        let iface = None::<InterfaceType>;
-
         #[cfg(feature = "esp-hosted-fg")]
-        let iface = iface.or_else(|| fg::FgBackend.decode_iface_type(iface_type));
-        #[cfg(feature = "esp-hosted-mcu")]
-        let iface = iface.or_else(|| mcu::McuBackend.decode_iface_type(iface_type));
-
-        if iface == Some(InterfaceType::Serial) {
-            Some(InterfaceType::Serial)
-        } else {
-            None
+        if let Some(InterfaceType::Serial) = fg::FgBackend.decode_iface_type(iface_type) {
+            return Some(InterfaceType::Serial);
         }
+
+        #[cfg(feature = "esp-hosted-mcu")]
+        if let Some(InterfaceType::Serial) = mcu::McuBackend.decode_iface_type(iface_type) {
+            return Some(InterfaceType::Serial);
+        }
+
+        None
     }
 
     async fn wifi_init(&self, _ctx: &mut IoctlCtx<'_>) -> Result<(), Error> {

--- a/embassy-net-esp-hosted/src/rpc/mod.rs
+++ b/embassy-net-esp-hosted/src/rpc/mod.rs
@@ -42,7 +42,7 @@ pub trait RpcBackend {
     fn encode_iface_type(&self, iface_type: InterfaceType) -> Option<u8>;
     fn decode_iface_type(&self, iface_type: u8) -> Option<InterfaceType>;
 
-    async fn wifi_init(&self, ctx: &mut IoctlCtx<'_>) -> Result<(), Error>;
+    async fn init_radio(&self, ctx: &mut IoctlCtx<'_>) -> Result<(), Error>;
     async fn start_wifi(&self, ctx: &mut IoctlCtx<'_>) -> Result<(), Error>;
     async fn config_heartbeat(&self, ctx: &mut IoctlCtx<'_>, secs: u32) -> Result<(), Error>;
     async fn set_mode(&self, ctx: &mut IoctlCtx<'_>, mode: WifiMode) -> Result<(), Error>;
@@ -93,7 +93,7 @@ impl RpcBackend for Backend {
 
             async fn start_wifi(&self, _ctx: &mut IoctlCtx<'_>) -> Result<(), Error>;
             async fn config_heartbeat(&self, ctx: &mut IoctlCtx<'_>, secs: u32) -> Result<(), Error>;
-            async fn wifi_init(&self, ctx: &mut IoctlCtx<'_>) -> Result<(), Error>;
+            async fn init_radio(&self, ctx: &mut IoctlCtx<'_>) -> Result<(), Error>;
             async fn set_mode(&self, ctx: &mut IoctlCtx<'_>, mode: WifiMode) -> Result<(), Error>;
             async fn get_mac_addr(&self, ctx: &mut IoctlCtx<'_>) -> Result<[u8; 6], Error>;
             async fn connect_ap(&self, ctx: &mut IoctlCtx<'_>, ssid: &str, pwd: &str) -> Result<(), Error>;
@@ -202,7 +202,7 @@ impl RpcBackend for NoBackend {
         None
     }
 
-    async fn wifi_init(&self, _ctx: &mut IoctlCtx<'_>) -> Result<(), Error> {
+    async fn init_radio(&self, _ctx: &mut IoctlCtx<'_>) -> Result<(), Error> {
         Err(Error::Internal)
     }
 

--- a/examples/nrf52840/src/bin/wifi_esp_hosted.rs
+++ b/examples/nrf52840/src/bin/wifi_esp_hosted.rs
@@ -61,8 +61,11 @@ async fn main(spawner: Spawner) {
     let iface = hosted::SpiInterface::new(spi, handshake, ready);
 
     static ESP_STATE: StaticCell<embassy_net_esp_hosted::State> = StaticCell::new();
-    let (device, mut control, runner) =
-        embassy_net_esp_hosted::new(ESP_STATE.init(embassy_net_esp_hosted::State::new()), iface, reset).await;
+    let embassy_net_esp_hosted::HostedResources {
+        net_device,
+        mut control,
+        runner,
+    } = embassy_net_esp_hosted::new(ESP_STATE.init(embassy_net_esp_hosted::State::new()), iface, reset).await;
 
     spawner.spawn(unwrap!(wifi_task(runner)));
 
@@ -84,7 +87,7 @@ async fn main(spawner: Spawner) {
 
     // Init network stack
     static RESOURCES: StaticCell<StackResources<3>> = StaticCell::new();
-    let (stack, runner) = embassy_net::new(device, config, RESOURCES.init(StackResources::new()), seed);
+    let (stack, runner) = embassy_net::new(net_device, config, RESOURCES.init(StackResources::new()), seed);
 
     spawner.spawn(unwrap!(net_task(runner)));
 

--- a/tests/nrf/src/bin/wifi_esp_hosted_perf.rs
+++ b/tests/nrf/src/bin/wifi_esp_hosted_perf.rs
@@ -66,8 +66,11 @@ async fn main(spawner: Spawner) {
     let iface = hosted::SpiInterface::new(spi, handshake, ready);
 
     static STATE: StaticCell<embassy_net_esp_hosted::State> = StaticCell::new();
-    let (device, mut control, runner) =
-        embassy_net_esp_hosted::new(STATE.init(embassy_net_esp_hosted::State::new()), iface, reset).await;
+    let embassy_net_esp_hosted::HostedResources {
+        net_device,
+        mut control,
+        runner,
+    } = embassy_net_esp_hosted::new(STATE.init(embassy_net_esp_hosted::State::new()), iface, reset).await;
 
     spawner.spawn(unwrap!(wifi_task(runner)));
 
@@ -83,7 +86,7 @@ async fn main(spawner: Spawner) {
     // Init network stack
     static RESOURCES: StaticCell<StackResources<2>> = StaticCell::new();
     let (stack, runner) = embassy_net::new(
-        device,
+        net_device,
         Config::dhcpv4(Default::default()),
         RESOURCES.init(StackResources::new()),
         seed,


### PR DESCRIPTION
Written by Claude based on cyw43 code. Works with both -fg and -mcu over the main interface (not using a parallel UART).