### PR TITLE
stm32/rtc:  conditionally re-init rtc

### DIFF
--- a/embassy-stm32/src/rtc/v3.rs
+++ b/embassy-stm32/src/rtc/v3.rs
@@ -10,10 +10,10 @@ impl super::Rtc {
     /// It this changes the RTC clock source the time will be reset
     pub(super) fn configure(&mut self, async_psc: u8, sync_psc: u16) {
         let prer = RTC::regs().prer().read();
-        if (prer.prediv_s() == sync_psc
+        if prer.prediv_s() == sync_psc
             && prer.prediv_a() == async_psc
             && RTC::regs().cr().read().fmt() == Fmt::TwentyFourHour
-            && RTC::regs().icsr().read().inits())
+            && RTC::regs().icsr().read().inits()
         {
             return;
         }

--- a/embassy-stm32/src/rtc/v3.rs
+++ b/embassy-stm32/src/rtc/v3.rs
@@ -10,23 +10,24 @@ impl super::Rtc {
     /// It this changes the RTC clock source the time will be reset
     pub(super) fn configure(&mut self, async_psc: u8, sync_psc: u16) {
         let prer = RTC::regs().prer().read();
-        let needs_init = prer.prediv_s() != sync_psc
-            || prer.prediv_a() != async_psc
-            || RTC::regs().cr().read().fmt() != Fmt::TwentyFourHour;
-
-        self.write(needs_init, |rtc| {
-            if needs_init {
-                rtc.cr().modify(|w| w.set_fmt(Fmt::TwentyFourHour));
-                rtc.prer().modify(|w| {
-                    w.set_prediv_s(sync_psc);
-                    w.set_prediv_a(async_psc);
-                });
-            }
-
+        if (prer.prediv_s() == sync_psc
+            && prer.prediv_a() == async_psc
+            && RTC::regs().cr().read().fmt() == Fmt::TwentyFourHour
+            && RTC::regs().icsr().read().inits())
+        {
+            return;
+        }
+        self.write(true, |rtc| {
             rtc.cr().modify(|w| {
                 w.set_bypshad(true);
+                w.set_fmt(Fmt::TwentyFourHour);
                 w.set_osel(Osel::Disabled);
                 w.set_pol(Pol::High);
+            });
+
+            rtc.prer().modify(|w| {
+                w.set_prediv_s(sync_psc);
+                w.set_prediv_a(async_psc);
             });
 
             // TODO: configuration for output pins

--- a/embassy-stm32/src/rtc/v3.rs
+++ b/embassy-stm32/src/rtc/v3.rs
@@ -13,16 +13,16 @@ impl super::Rtc {
         let needs_init = prer.prediv_s() != sync_psc
             || prer.prediv_a() != async_psc
             || RTC::regs().cr().read().fmt() != Fmt::TwentyFourHour;
-        
+
         self.write(needs_init, |rtc| {
             if needs_init {
                 rtc.cr().modify(|w| w.set_fmt(Fmt::TwentyFourHour));
                 rtc.prer().modify(|w| {
                     w.set_prediv_s(sync_psc);
                     w.set_prediv_a(async_psc);
-                }); 
+                });
             }
-            
+
             rtc.cr().modify(|w| {
                 w.set_bypshad(true);
                 w.set_osel(Osel::Disabled);

--- a/embassy-stm32/src/rtc/v3.rs
+++ b/embassy-stm32/src/rtc/v3.rs
@@ -9,17 +9,24 @@ impl super::Rtc {
     /// Applies the RTC config
     /// It this changes the RTC clock source the time will be reset
     pub(super) fn configure(&mut self, async_psc: u8, sync_psc: u16) {
-        self.write(true, |rtc| {
+        let prer = RTC::regs().prer().read();
+        let needs_init = prer.prediv_s() != sync_psc
+            || prer.prediv_a() != async_psc
+            || RTC::regs().cr().read().fmt() != Fmt::TwentyFourHour;
+        
+        self.write(needs_init, |rtc| {
+            if needs_init {
+                rtc.cr().modify(|w| w.set_fmt(Fmt::TwentyFourHour));
+                rtc.prer().modify(|w| {
+                    w.set_prediv_s(sync_psc);
+                    w.set_prediv_a(async_psc);
+                }); 
+            }
+            
             rtc.cr().modify(|w| {
                 w.set_bypshad(true);
-                w.set_fmt(Fmt::TwentyFourHour);
                 w.set_osel(Osel::Disabled);
                 w.set_pol(Pol::High);
-            });
-
-            rtc.prer().modify(|w| {
-                w.set_prediv_s(sync_psc);
-                w.set_prediv_a(async_psc);
             });
 
             // TODO: configuration for output pins


### PR DESCRIPTION
entering init mode causes the subseconds to be loss and the clock is frozen for the duration. I used claude to research and double check the work but the code itself was hand written. I confirmed from the stm32l5 reference manual that only the initial time and date calendar values, including the time format and the prescaler configuration need init mode.

RTC initialization and configuration is on page 1407 https://www.st.com/resource/en/reference_manual/rm0438-stm32l5-series-advanced-armbased-32bit-mcus-stmicroelectronics.pdf