### PR TITLE
esp-hosted: Implement scanning

### DIFF
--- a/embassy-net-esp-hosted/CHANGELOG.md
+++ b/embassy-net-esp-hosted/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 <!-- next-header -->
 ## Unreleased - ReleaseDate
 
+- Added `Control::scan` to retrieve visible networks. Note that `esp-hosted-fg` can only retrieve up to 8 entries.
 - `embassy_net_esp_hosted::new` now returns an `HostedResources` struct with named fields.
 - Added Bluetooth (BLE) support via the new `bluetooth` feature. `new` returns a `bluetooth::BtDriver` implementing `bt_hci::transport::Transport`, exposing the ESP coprocessor's HCI controller over the ESP-Hosted HCI interface.
 - Added `FwVersion` struct and `Control::get_fw_version`.

--- a/embassy-net-esp-hosted/src/control.rs
+++ b/embassy-net-esp-hosted/src/control.rs
@@ -1,8 +1,9 @@
 use embassy_net_driver_channel as ch;
 use embassy_net_driver_channel::driver::{HardwareAddress, LinkState};
-use heapless::String;
+use heapless::{String, Vec};
 
 use crate::ioctl::Shared;
+use crate::rpc::ioctl_ctx::IoctlMessage;
 use crate::rpc::{IoctlCtx, RpcBackend};
 use crate::{Backend, MAX_IOCTL_SIZE};
 
@@ -85,6 +86,18 @@ pub struct Status {
     pub security: Security,
 }
 
+/// WiFi network information.
+#[derive(Clone, Debug)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+pub struct Network {
+    /// Service Set Identifier.
+    pub ssid: String<32>,
+    /// Basic Service Set Identifier.
+    pub bssid: [u8; 6],
+    /// Security mode.
+    pub security: Security,
+}
+
 /// Firmware version.
 #[derive(Clone, Copy, PartialEq, Eq, Debug)]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
@@ -129,10 +142,11 @@ impl<'a> Control<'a> {
         state_ch: ch::StateRunner<'a>,
         shared: &'a Shared,
         ioctl_buffer: &'a mut [u8; MAX_IOCTL_SIZE],
+        msg_buffer: &'a mut IoctlMessage,
     ) -> Self {
         Self {
             state_ch,
-            ioctl: IoctlCtx::new(shared, ioctl_buffer),
+            ioctl: IoctlCtx::new(shared, ioctl_buffer, msg_buffer),
             backend: Backend::default(),
         }
     }
@@ -171,6 +185,11 @@ impl<'a> Control<'a> {
     /// Get the current status.
     pub async fn get_status(&mut self) -> Result<Status, Error> {
         self.backend.get_status(&mut self.ioctl).await
+    }
+
+    /// Scan for available networks.
+    pub async fn scan<const N: usize>(&mut self, result: &mut Vec<Network, N>) -> Result<(), Error> {
+        self.backend.scan(&mut self.ioctl, result).await
     }
 
     /// Connect to the network identified by ssid using the provided password.

--- a/embassy-net-esp-hosted/src/lib.rs
+++ b/embassy-net-esp-hosted/src/lib.rs
@@ -16,9 +16,10 @@ use embassy_time::{Duration, Instant, Timer};
 use embedded_hal::digital::OutputPin;
 
 use crate::ioctl::{PendingIoctl, Shared};
+use crate::rpc::ioctl_ctx::IoctlMessage;
 use crate::rpc::{Backend, HostedEvent, RpcBackend};
 
-mod proto;
+pub(crate) mod proto;
 
 // must be first
 mod fmt;
@@ -119,14 +120,21 @@ enum InterfaceType {
 }
 
 const MAX_BUFFER_SIZE: usize = 1600;
-// Theoretical max overhead is 29 bytes. Biggest message currently is OTA write with 256 bytes.
-const MAX_IOCTL_SIZE: usize = 256 + 29;
+// Maximum payload size
+const MAX_IOCTL_SIZE: usize = if cfg!(feature = "esp-hosted-fg") {
+    // Scan results are unlimited
+    MAX_BUFFER_SIZE - 12
+} else {
+    // Theoretical max overhead is 29 bytes. Biggest message currently is OTA write with 256 bytes.
+    256 + 29
+};
 const HEARTBEAT_MAX_GAP: Duration = Duration::from_secs(20);
 
 /// State for the esp-hosted driver.
 pub struct State {
     shared: Shared,
     ioctl_buffer: [u8; MAX_IOCTL_SIZE],
+    msg_buffer: IoctlMessage,
     ch: ch::State<MTU, 4, 4>,
     #[cfg(feature = "bluetooth")]
     bt: bluetooth::BtState,
@@ -138,6 +146,7 @@ impl State {
         Self {
             shared: Shared::new(),
             ch: ch::State::new(),
+            msg_buffer: IoctlMessage::default(),
             ioctl_buffer: [0u8; MAX_IOCTL_SIZE],
             #[cfg(feature = "bluetooth")]
             bt: bluetooth::BtState::new(),
@@ -196,7 +205,7 @@ where
         net_device: device,
         #[cfg(feature = "bluetooth")]
         bluetooth: bt_driver,
-        control: Control::new(state_ch, &state.shared, &mut state.ioctl_buffer),
+        control: Control::new(state_ch, &state.shared, &mut state.ioctl_buffer, &mut state.msg_buffer),
         runner,
     }
 }

--- a/embassy-net-esp-hosted/src/proto/fg/esp_hosted_config.proto
+++ b/embassy-net-esp-hosted/src/proto/fg/esp_hosted_config.proto
@@ -78,7 +78,7 @@ enum CtrlMsgId {
     //Req_GetWifiMode = 103;
     Req_SetWifiMode = 104;
 
-    //Req_GetAPScanList = 105;
+    Req_GetAPScanList = 105;
     Req_GetAPConfig = 106;
     Req_ConnectAP = 107;
     Req_DisconnectAP = 108;
@@ -119,7 +119,7 @@ enum CtrlMsgId {
     //Resp_GetWifiMode = 203;
     Resp_SetWifiMode = 204;
 
-    //Resp_GetAPScanList = 205;
+    Resp_GetAPScanList = 205;
     Resp_GetAPConfig = 206;
     Resp_ConnectAP = 207;
     Resp_DisconnectAP = 208;
@@ -551,7 +551,7 @@ message CtrlMsg {
         //CtrlMsg_Req_GetMode req_get_wifi_mode = 103;
         CtrlMsg_Req_SetMode req_set_wifi_mode = 104;
 
-        //CtrlMsg_Req_ScanResult req_scan_ap_list = 105;
+        CtrlMsg_Req_ScanResult req_scan_ap_list = 105;
         CtrlMsg_Req_GetAPConfig req_get_ap_config = 106;
         CtrlMsg_Req_ConnectAP req_connect_ap = 107;
         CtrlMsg_Req_GetStatus req_disconnect_ap = 108;
@@ -586,7 +586,7 @@ message CtrlMsg {
         //CtrlMsg_Resp_GetMode resp_get_wifi_mode = 203;
         CtrlMsg_Resp_SetMode resp_set_wifi_mode = 204;
 
-        //CtrlMsg_Resp_ScanResult resp_scan_ap_list = 205;
+        CtrlMsg_Resp_ScanResult resp_scan_ap_list = 205;
         CtrlMsg_Resp_GetAPConfig resp_get_ap_config = 206;
         CtrlMsg_Resp_ConnectAP resp_connect_ap = 207;
         CtrlMsg_Resp_GetStatus resp_disconnect_ap = 208;

--- a/embassy-net-esp-hosted/src/proto/fg/mod.rs
+++ b/embassy-net-esp-hosted/src/proto/fg/mod.rs
@@ -3778,7 +3778,7 @@ impl ::micropb::MessageEncode for CtrlMsg_Req_ScanResult {
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub struct CtrlMsg_Resp_ScanResult {
     pub r#count: u32,
-    pub r#entries: ::heapless::Vec<ScanResult, 16>,
+    pub r#entries: ::heapless::Vec<ScanResult, 8>,
     pub r#resp: i32,
 }
 impl CtrlMsg_Resp_ScanResult {
@@ -3892,7 +3892,7 @@ impl ::micropb::MessageEncode for CtrlMsg_Resp_ScanResult {
             ::micropb::const_map!(<ScanResult as ::micropb::MessageEncode>::MAX_SIZE, |size| {
                 ::micropb::size::sizeof_len_record(size)
             }),
-            |size| (size + 1usize) * 16usize
+            |size| (size + 1usize) * 8usize
         ) {
             ::core::result::Result::Ok(size) => {
                 max_size += size;
@@ -11244,6 +11244,19 @@ impl ::micropb::MessageDecode for CtrlMsg {
                     };
                     mut_ref.decode_len_delimited(decoder)?;
                 }
+                105u32 => {
+                    let mut_ref = loop {
+                        if let ::core::option::Option::Some(variant) = &mut self.r#payload {
+                            if let CtrlMsg_::Payload::ReqScanApList(variant) = &mut *variant {
+                                break &mut *variant;
+                            }
+                        }
+                        self.r#payload = ::core::option::Option::Some(CtrlMsg_::Payload::ReqScanApList(
+                            ::core::default::Default::default(),
+                        ));
+                    };
+                    mut_ref.decode_len_delimited(decoder)?;
+                }
                 106u32 => {
                     let mut_ref = loop {
                         if let ::core::option::Option::Some(variant) = &mut self.r#payload {
@@ -11369,6 +11382,19 @@ impl ::micropb::MessageDecode for CtrlMsg {
                             }
                         }
                         self.r#payload = ::core::option::Option::Some(CtrlMsg_::Payload::RespSetWifiMode(
+                            ::core::default::Default::default(),
+                        ));
+                    };
+                    mut_ref.decode_len_delimited(decoder)?;
+                }
+                205u32 => {
+                    let mut_ref = loop {
+                        if let ::core::option::Option::Some(variant) = &mut self.r#payload {
+                            if let CtrlMsg_::Payload::RespScanApList(variant) = &mut *variant {
+                                break &mut *variant;
+                            }
+                        }
+                        self.r#payload = ::core::option::Option::Some(CtrlMsg_::Payload::RespScanApList(
                             ::core::default::Default::default(),
                         ));
                     };
@@ -11607,6 +11633,21 @@ impl ::micropb::MessageEncode for CtrlMsg {
                 }
             }
             match ::micropb::const_map!(
+                ::micropb::const_map!(<CtrlMsg_Req_ScanResult as ::micropb::MessageEncode>::MAX_SIZE, |size| {
+                    ::micropb::size::sizeof_len_record(size)
+                }),
+                |size| size + 2usize
+            ) {
+                ::core::result::Result::Ok(size) => {
+                    if size > max_size {
+                        max_size = size;
+                    }
+                }
+                ::core::result::Result::Err(err) => {
+                    break 'oneof (::core::result::Result::<usize, _>::Err(err));
+                }
+            }
+            match ::micropb::const_map!(
                 ::micropb::const_map!(
                     <CtrlMsg_Req_GetAPConfig as ::micropb::MessageEncode>::MAX_SIZE,
                     |size| ::micropb::size::sizeof_len_record(size)
@@ -11749,6 +11790,22 @@ impl ::micropb::MessageEncode for CtrlMsg {
                 ::micropb::const_map!(<CtrlMsg_Resp_SetMode as ::micropb::MessageEncode>::MAX_SIZE, |size| {
                     ::micropb::size::sizeof_len_record(size)
                 }),
+                |size| size + 2usize
+            ) {
+                ::core::result::Result::Ok(size) => {
+                    if size > max_size {
+                        max_size = size;
+                    }
+                }
+                ::core::result::Result::Err(err) => {
+                    break 'oneof (::core::result::Result::<usize, _>::Err(err));
+                }
+            }
+            match ::micropb::const_map!(
+                ::micropb::const_map!(
+                    <CtrlMsg_Resp_ScanResult as ::micropb::MessageEncode>::MAX_SIZE,
+                    |size| ::micropb::size::sizeof_len_record(size)
+                ),
                 |size| size + 2usize
             ) {
                 ::core::result::Result::Ok(size) => {
@@ -12002,6 +12059,11 @@ impl ::micropb::MessageEncode for CtrlMsg {
                     encoder.encode_varint32(834u32)?;
                     val_ref.encode_len_delimited(encoder)?;
                 }
+                CtrlMsg_::Payload::ReqScanApList(val_ref) => {
+                    let val_ref = &*val_ref;
+                    encoder.encode_varint32(842u32)?;
+                    val_ref.encode_len_delimited(encoder)?;
+                }
                 CtrlMsg_::Payload::ReqGetApConfig(val_ref) => {
                     let val_ref = &*val_ref;
                     encoder.encode_varint32(850u32)?;
@@ -12050,6 +12112,11 @@ impl ::micropb::MessageEncode for CtrlMsg {
                 CtrlMsg_::Payload::RespSetWifiMode(val_ref) => {
                     let val_ref = &*val_ref;
                     encoder.encode_varint32(1634u32)?;
+                    val_ref.encode_len_delimited(encoder)?;
+                }
+                CtrlMsg_::Payload::RespScanApList(val_ref) => {
+                    let val_ref = &*val_ref;
+                    encoder.encode_varint32(1642u32)?;
                     val_ref.encode_len_delimited(encoder)?;
                 }
                 CtrlMsg_::Payload::RespGetApConfig(val_ref) => {
@@ -12153,6 +12220,10 @@ impl ::micropb::MessageEncode for CtrlMsg {
                     let val_ref = &*val_ref;
                     size += 2usize + ::micropb::size::sizeof_len_record(val_ref.compute_size());
                 }
+                CtrlMsg_::Payload::ReqScanApList(val_ref) => {
+                    let val_ref = &*val_ref;
+                    size += 2usize + ::micropb::size::sizeof_len_record(val_ref.compute_size());
+                }
                 CtrlMsg_::Payload::ReqGetApConfig(val_ref) => {
                     let val_ref = &*val_ref;
                     size += 2usize + ::micropb::size::sizeof_len_record(val_ref.compute_size());
@@ -12190,6 +12261,10 @@ impl ::micropb::MessageEncode for CtrlMsg {
                     size += 2usize + ::micropb::size::sizeof_len_record(val_ref.compute_size());
                 }
                 CtrlMsg_::Payload::RespSetWifiMode(val_ref) => {
+                    let val_ref = &*val_ref;
+                    size += 2usize + ::micropb::size::sizeof_len_record(val_ref.compute_size());
+                }
+                CtrlMsg_::Payload::RespScanApList(val_ref) => {
                     let val_ref = &*val_ref;
                     size += 2usize + ::micropb::size::sizeof_len_record(val_ref.compute_size());
                 }
@@ -12257,7 +12332,7 @@ pub mod CtrlMsg_ {
         ///CtrlMsg_Req_SetMacAddress req_set_mac_address = 102;
         ///CtrlMsg_Req_GetMode req_get_wifi_mode = 103;
         ReqSetWifiMode(super::CtrlMsg_Req_SetMode),
-        ///CtrlMsg_Req_ScanResult req_scan_ap_list = 105;
+        ReqScanApList(super::CtrlMsg_Req_ScanResult),
         ReqGetApConfig(super::CtrlMsg_Req_GetAPConfig),
         ReqConnectAp(super::CtrlMsg_Req_ConnectAP),
         ReqDisconnectAp(super::CtrlMsg_Req_GetStatus),
@@ -12280,7 +12355,7 @@ pub mod CtrlMsg_ {
         ///CtrlMsg_Resp_SetMacAddress resp_set_mac_address = 202;
         ///CtrlMsg_Resp_GetMode resp_get_wifi_mode = 203;
         RespSetWifiMode(super::CtrlMsg_Resp_SetMode),
-        ///CtrlMsg_Resp_ScanResult resp_scan_ap_list = 205;
+        RespScanApList(super::CtrlMsg_Resp_ScanResult),
         RespGetApConfig(super::CtrlMsg_Resp_GetAPConfig),
         RespConnectAp(super::CtrlMsg_Resp_ConnectAP),
         RespDisconnectAp(super::CtrlMsg_Resp_GetStatus),
@@ -12505,7 +12580,7 @@ impl CtrlMsgId {
     ///Req_SetMacAddress = 102;
     ///Req_GetWifiMode = 103;
     pub const ReqSetWifiMode: Self = Self(104);
-    ///Req_GetAPScanList = 105;
+    pub const ReqGetApScanList: Self = Self(105);
     pub const ReqGetApConfig: Self = Self(106);
     pub const ReqConnectAp: Self = Self(107);
     pub const ReqDisconnectAp: Self = Self(108);
@@ -12525,7 +12600,7 @@ impl CtrlMsgId {
     ///Resp_SetMacAddress = 202;
     ///Resp_GetWifiMode = 203;
     pub const RespSetWifiMode: Self = Self(204);
-    ///Resp_GetAPScanList = 205;
+    pub const RespGetApScanList: Self = Self(205);
     pub const RespGetApConfig: Self = Self(206);
     pub const RespConnectAp: Self = Self(207);
     pub const RespDisconnectAp: Self = Self(208);

--- a/embassy-net-esp-hosted/src/proto/mcu/esp_hosted_rpc.proto
+++ b/embassy-net-esp-hosted/src/proto/mcu/esp_hosted_rpc.proto
@@ -134,11 +134,11 @@ enum RpcId {
 	Req_WifiSetConfig                 = 284; //0x11c
 	//Req_WifiGetConfig                 = 285; //0x11d
 
-	//Req_WifiScanStart                 = 286; //0x11e
+	Req_WifiScanStart                 = 286; //0x11e
 	//Req_WifiScanStop                  = 287; //0x11f
-	//Req_WifiScanGetApNum              = 288; //0x120
+	Req_WifiScanGetApNum              = 288; //0x120
 	//Req_WifiScanGetApRecords          = 289; //0x121
-	//Req_WifiClearApList               = 290; //0x122
+	Req_WifiClearApList               = 290; //0x122
 
 	//Req_WifiRestore                   = 291; //0x123
 	//Req_WifiClearFastConnect          = 292; //0x124
@@ -214,7 +214,7 @@ enum RpcId {
 
 	Req_GetCoprocessorFwVersion       = 350; //0x15e
 
-	//Req_WifiScanGetApRecord           = 351; //0x15f
+	Req_WifiScanGetApRecord           = 351; //0x15f
 
 	//Req_SetDhcpDnsStatus              = 352; //0x160
 	//Req_GetDhcpDnsStatus              = 353; //0x161
@@ -323,11 +323,11 @@ enum RpcId {
 	Resp_WifiSetConfig                = 540;
 	//Resp_WifiGetConfig                = 541;
 
-	//Resp_WifiScanStart                = 542;
+	Resp_WifiScanStart                = 542;
 	//Resp_WifiScanStop                 = 543;
-	//Resp_WifiScanGetApNum             = 544;
+	Resp_WifiScanGetApNum             = 544;
 	//Resp_WifiScanGetApRecords         = 545;
-	//Resp_WifiClearApList              = 546;
+	Resp_WifiClearApList              = 546;
 
 	//Resp_WifiRestore                  = 547;
 	//Resp_WifiClearFastConnect         = 548;
@@ -403,7 +403,7 @@ enum RpcId {
 
 	Resp_GetCoprocessorFwVersion      = 606;
 
-	//Resp_WifiScanGetApRecord          = 607;
+	Resp_WifiScanGetApRecord          = 607;
 
 	//Resp_SetDhcpDnsStatus             = 608;
 	//Resp_GetDhcpDnsStatus             = 609;
@@ -2201,11 +2201,11 @@ message Rpc {
 		Rpc_Req_WifiSetConfig               req_wifi_set_config               = 284;
 		//Rpc_Req_WifiGetConfig               req_wifi_get_config               = 285;
 
-		//Rpc_Req_WifiScanStart               req_wifi_scan_start               = 286;
+		Rpc_Req_WifiScanStart               req_wifi_scan_start               = 286;
 		//Rpc_Req_WifiScanStop                req_wifi_scan_stop                = 287;
-		//Rpc_Req_WifiScanGetApNum            req_wifi_scan_get_ap_num          = 288;
+		Rpc_Req_WifiScanGetApNum            req_wifi_scan_get_ap_num          = 288;
 		//Rpc_Req_WifiScanGetApRecords        req_wifi_scan_get_ap_records      = 289;
-		//Rpc_Req_WifiClearApList             req_wifi_clear_ap_list            = 290;
+		Rpc_Req_WifiClearApList             req_wifi_clear_ap_list            = 290;
 
 		//Rpc_Req_WifiRestore                 req_wifi_restore                  = 291;
 		//Rpc_Req_WifiClearFastConnect        req_wifi_clear_fast_connect       = 292;
@@ -2247,7 +2247,7 @@ message Rpc {
 
 		Rpc_Req_GetCoprocessorFwVersion     req_get_coprocessor_fwversion     = 350;
 
-		//Rpc_Req_WifiScanGetApRecord         req_wifi_scan_get_ap_record       = 351;
+		Rpc_Req_WifiScanGetApRecord         req_wifi_scan_get_ap_record       = 351;
 
 		//Rpc_Req_SetDhcpDnsStatus            req_set_dhcp_dns                  = 352;
 		//Rpc_Req_GetDhcpDnsStatus            req_get_dhcp_dns                  = 353;
@@ -2340,11 +2340,11 @@ message Rpc {
 		Rpc_Resp_WifiSetConfig              resp_wifi_set_config               = 540;
 		//Rpc_Resp_WifiGetConfig              resp_wifi_get_config               = 541;
 
-		//Rpc_Resp_WifiScanStart              resp_wifi_scan_start               = 542;
+		Rpc_Resp_WifiScanStart              resp_wifi_scan_start               = 542;
 		//Rpc_Resp_WifiScanStop               resp_wifi_scan_stop                = 543;
-		//Rpc_Resp_WifiScanGetApNum           resp_wifi_scan_get_ap_num          = 544;
+		Rpc_Resp_WifiScanGetApNum           resp_wifi_scan_get_ap_num          = 544;
 		//Rpc_Resp_WifiScanGetApRecords       resp_wifi_scan_get_ap_records      = 545;
-		//Rpc_Resp_WifiClearApList            resp_wifi_clear_ap_list            = 546;
+		Rpc_Resp_WifiClearApList            resp_wifi_clear_ap_list            = 546;
 
 		//Rpc_Resp_WifiRestore                resp_wifi_restore                  = 547;
 		//Rpc_Resp_WifiClearFastConnect       resp_wifi_clear_fast_connect       = 548;
@@ -2386,7 +2386,7 @@ message Rpc {
 
 		Rpc_Resp_GetCoprocessorFwVersion    resp_get_coprocessor_fwversion     = 606;
 
-		//Rpc_Resp_WifiScanGetApRecord        resp_wifi_scan_get_ap_record       = 607;
+		Rpc_Resp_WifiScanGetApRecord        resp_wifi_scan_get_ap_record       = 607;
 
 		//Rpc_Resp_SetDhcpDnsStatus           resp_set_dhcp_dns                  = 608;
 		//Rpc_Resp_GetDhcpDnsStatus           resp_get_dhcp_dns                  = 609;

--- a/embassy-net-esp-hosted/src/proto/mcu/mod.rs
+++ b/embassy-net-esp-hosted/src/proto/mcu/mod.rs
@@ -3185,7 +3185,7 @@ impl ::micropb::MessageEncode for r#wifi_he_ap_info {
         size
     }
 }
-#[derive(Debug, Default, Clone)]
+#[derive(Debug, Default, PartialEq, Clone)]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub struct r#wifi_ap_record {
     ///*< MAC address of AP 6char
@@ -3194,69 +3194,10 @@ pub struct r#wifi_ap_record {
     pub r#ssid: ::heapless::Vec<u8, 32>,
     ///*< channel of AP
     pub r#primary: u32,
-    ///*< secondary channel of AP
-    pub r#second: i32,
     ///*< signal strength of AP
     pub r#rssi: i32,
     ///*< authmode of AP
     pub r#authmode: i32,
-    ///*< pairwise cipher of AP
-    pub r#pairwise_cipher: i32,
-    ///*< group cipher of AP
-    pub r#group_cipher: i32,
-    ///*< antenna used to receive beacon from AP
-    pub r#ant: i32,
-    ///uint32_t phy_11b:1;                       /**< bit: 0 flag to identify if 11b mode is enabled or not */
-    ///uint32_t phy_11g:1;                       /**< bit: 1 flag to identify if 11g mode is enabled or not */
-    ///uint32_t phy_11n:1;                       /**< bit: 2 flag to identify if 11n mode is enabled or not */
-    ///uint32_t phy_lr:1;                        /**< bit: 3 flag to identify if low rate is enabled or not */
-    ///uint32_t wps:1;                           /**< bit: 4 flag to identify if WPS is supported or not */
-    ///uint32_t ftm_responder:1;                 /**< bit: 5 flag to identify if FTM is supported in responder mode */
-    ///uint32_t ftm_initiator:1;                 /**< bit: 6 flag to identify if FTM is supported in initiator mode */
-    ///uint32_t reserved:25;                     /**< bit: 7..31 reserved */
-    ///
-    /// Manually have to parse for above bits
-    pub r#bitmask: u32,
-    ///*< country information of AP
-    ///
-    /// *Note:* The presence of this field is tracked separately in the `_has` field. It's recommended to access this field via the accessor rather than directly.
-    pub r#country: r#wifi_country,
-    /// *Note:* The presence of this field is tracked separately in the `_has` field. It's recommended to access this field via the accessor rather than directly.
-    pub r#he_ap: r#wifi_he_ap_info,
-    ///*< For AP 20 MHz this value is set to 1. For AP 40 MHz this value is set to 2.
-    ///For AP 80 MHz this value is set to 3. For AP 160MHz this value is set to 4.
-    ///For AP 80+80MHz this value is set to 5
-    pub r#bandwidth: u32,
-    ///*< This fields are used only AP bandwidth is 80 and 160 MHz, to transmit the center channel
-    ///frequency of the BSS. For AP bandwidth is 80 + 80 MHz, it is the center channel frequency
-    ///of the lower frequency segment.
-    pub r#vht_ch_freq1: u32,
-    ///*< This fields are used only AP bandwidth is 80 + 80 MHz, and is used to transmit the center
-    ///channel frequency of the second segment.
-    pub r#vht_ch_freq2: u32,
-    /// Tracks presence of optional and message fields
-    pub _has: wifi_ap_record_::_Hazzer,
-}
-impl ::core::cmp::PartialEq for r#wifi_ap_record {
-    fn eq(&self, other: &Self) -> bool {
-        let mut ret = true;
-        ret &= (self.r#bssid == other.r#bssid);
-        ret &= (self.r#ssid == other.r#ssid);
-        ret &= (self.r#primary == other.r#primary);
-        ret &= (self.r#second == other.r#second);
-        ret &= (self.r#rssi == other.r#rssi);
-        ret &= (self.r#authmode == other.r#authmode);
-        ret &= (self.r#pairwise_cipher == other.r#pairwise_cipher);
-        ret &= (self.r#group_cipher == other.r#group_cipher);
-        ret &= (self.r#ant == other.r#ant);
-        ret &= (self.r#bitmask == other.r#bitmask);
-        ret &= (self.r#country() == other.r#country());
-        ret &= (self.r#he_ap() == other.r#he_ap());
-        ret &= (self.r#bandwidth == other.r#bandwidth);
-        ret &= (self.r#vht_ch_freq1 == other.r#vht_ch_freq1);
-        ret &= (self.r#vht_ch_freq2 == other.r#vht_ch_freq2);
-        ret
-    }
 }
 impl r#wifi_ap_record {
     /// Return a reference to `bssid`
@@ -3325,28 +3266,6 @@ impl r#wifi_ap_record {
         self.r#primary = value.into();
         self
     }
-    /// Return a reference to `second`
-    #[inline]
-    pub fn r#second(&self) -> &i32 {
-        &self.r#second
-    }
-    /// Return a mutable reference to `second`
-    #[inline]
-    pub fn mut_second(&mut self) -> &mut i32 {
-        &mut self.r#second
-    }
-    /// Set the value of `second`
-    #[inline]
-    pub fn set_second(&mut self, value: i32) -> &mut Self {
-        self.r#second = value.into();
-        self
-    }
-    /// Builder method that sets the value of `second`. Useful for initializing the message.
-    #[inline]
-    pub fn init_second(mut self, value: i32) -> Self {
-        self.r#second = value.into();
-        self
-    }
     /// Return a reference to `rssi`
     #[inline]
     pub fn r#rssi(&self) -> &i32 {
@@ -3391,232 +3310,6 @@ impl r#wifi_ap_record {
         self.r#authmode = value.into();
         self
     }
-    /// Return a reference to `pairwise_cipher`
-    #[inline]
-    pub fn r#pairwise_cipher(&self) -> &i32 {
-        &self.r#pairwise_cipher
-    }
-    /// Return a mutable reference to `pairwise_cipher`
-    #[inline]
-    pub fn mut_pairwise_cipher(&mut self) -> &mut i32 {
-        &mut self.r#pairwise_cipher
-    }
-    /// Set the value of `pairwise_cipher`
-    #[inline]
-    pub fn set_pairwise_cipher(&mut self, value: i32) -> &mut Self {
-        self.r#pairwise_cipher = value.into();
-        self
-    }
-    /// Builder method that sets the value of `pairwise_cipher`. Useful for initializing the message.
-    #[inline]
-    pub fn init_pairwise_cipher(mut self, value: i32) -> Self {
-        self.r#pairwise_cipher = value.into();
-        self
-    }
-    /// Return a reference to `group_cipher`
-    #[inline]
-    pub fn r#group_cipher(&self) -> &i32 {
-        &self.r#group_cipher
-    }
-    /// Return a mutable reference to `group_cipher`
-    #[inline]
-    pub fn mut_group_cipher(&mut self) -> &mut i32 {
-        &mut self.r#group_cipher
-    }
-    /// Set the value of `group_cipher`
-    #[inline]
-    pub fn set_group_cipher(&mut self, value: i32) -> &mut Self {
-        self.r#group_cipher = value.into();
-        self
-    }
-    /// Builder method that sets the value of `group_cipher`. Useful for initializing the message.
-    #[inline]
-    pub fn init_group_cipher(mut self, value: i32) -> Self {
-        self.r#group_cipher = value.into();
-        self
-    }
-    /// Return a reference to `ant`
-    #[inline]
-    pub fn r#ant(&self) -> &i32 {
-        &self.r#ant
-    }
-    /// Return a mutable reference to `ant`
-    #[inline]
-    pub fn mut_ant(&mut self) -> &mut i32 {
-        &mut self.r#ant
-    }
-    /// Set the value of `ant`
-    #[inline]
-    pub fn set_ant(&mut self, value: i32) -> &mut Self {
-        self.r#ant = value.into();
-        self
-    }
-    /// Builder method that sets the value of `ant`. Useful for initializing the message.
-    #[inline]
-    pub fn init_ant(mut self, value: i32) -> Self {
-        self.r#ant = value.into();
-        self
-    }
-    /// Return a reference to `bitmask`
-    #[inline]
-    pub fn r#bitmask(&self) -> &u32 {
-        &self.r#bitmask
-    }
-    /// Return a mutable reference to `bitmask`
-    #[inline]
-    pub fn mut_bitmask(&mut self) -> &mut u32 {
-        &mut self.r#bitmask
-    }
-    /// Set the value of `bitmask`
-    #[inline]
-    pub fn set_bitmask(&mut self, value: u32) -> &mut Self {
-        self.r#bitmask = value.into();
-        self
-    }
-    /// Builder method that sets the value of `bitmask`. Useful for initializing the message.
-    #[inline]
-    pub fn init_bitmask(mut self, value: u32) -> Self {
-        self.r#bitmask = value.into();
-        self
-    }
-    /// Return a reference to `country` as an `Option`
-    #[inline]
-    pub fn r#country(&self) -> ::core::option::Option<&r#wifi_country> {
-        self._has.r#country().then_some(&self.r#country)
-    }
-    /// Set the value and presence of `country`
-    #[inline]
-    pub fn set_country(&mut self, value: r#wifi_country) -> &mut Self {
-        self._has.set_country();
-        self.r#country = value.into();
-        self
-    }
-    /// Return a mutable reference to `country` as an `Option`
-    #[inline]
-    pub fn mut_country(&mut self) -> ::core::option::Option<&mut r#wifi_country> {
-        self._has.r#country().then_some(&mut self.r#country)
-    }
-    /// Clear the presence of `country`
-    #[inline]
-    pub fn clear_country(&mut self) -> &mut Self {
-        self._has.clear_country();
-        self
-    }
-    /// Take the value of `country` and clear its presence
-    #[inline]
-    pub fn take_country(&mut self) -> ::core::option::Option<r#wifi_country> {
-        let val = self._has.r#country().then(|| ::core::mem::take(&mut self.r#country));
-        self._has.clear_country();
-        val
-    }
-    /// Builder method that sets the value of `country`. Useful for initializing the message.
-    #[inline]
-    pub fn init_country(mut self, value: r#wifi_country) -> Self {
-        self.set_country(value);
-        self
-    }
-    /// Return a reference to `he_ap` as an `Option`
-    #[inline]
-    pub fn r#he_ap(&self) -> ::core::option::Option<&r#wifi_he_ap_info> {
-        self._has.r#he_ap().then_some(&self.r#he_ap)
-    }
-    /// Set the value and presence of `he_ap`
-    #[inline]
-    pub fn set_he_ap(&mut self, value: r#wifi_he_ap_info) -> &mut Self {
-        self._has.set_he_ap();
-        self.r#he_ap = value.into();
-        self
-    }
-    /// Return a mutable reference to `he_ap` as an `Option`
-    #[inline]
-    pub fn mut_he_ap(&mut self) -> ::core::option::Option<&mut r#wifi_he_ap_info> {
-        self._has.r#he_ap().then_some(&mut self.r#he_ap)
-    }
-    /// Clear the presence of `he_ap`
-    #[inline]
-    pub fn clear_he_ap(&mut self) -> &mut Self {
-        self._has.clear_he_ap();
-        self
-    }
-    /// Take the value of `he_ap` and clear its presence
-    #[inline]
-    pub fn take_he_ap(&mut self) -> ::core::option::Option<r#wifi_he_ap_info> {
-        let val = self._has.r#he_ap().then(|| ::core::mem::take(&mut self.r#he_ap));
-        self._has.clear_he_ap();
-        val
-    }
-    /// Builder method that sets the value of `he_ap`. Useful for initializing the message.
-    #[inline]
-    pub fn init_he_ap(mut self, value: r#wifi_he_ap_info) -> Self {
-        self.set_he_ap(value);
-        self
-    }
-    /// Return a reference to `bandwidth`
-    #[inline]
-    pub fn r#bandwidth(&self) -> &u32 {
-        &self.r#bandwidth
-    }
-    /// Return a mutable reference to `bandwidth`
-    #[inline]
-    pub fn mut_bandwidth(&mut self) -> &mut u32 {
-        &mut self.r#bandwidth
-    }
-    /// Set the value of `bandwidth`
-    #[inline]
-    pub fn set_bandwidth(&mut self, value: u32) -> &mut Self {
-        self.r#bandwidth = value.into();
-        self
-    }
-    /// Builder method that sets the value of `bandwidth`. Useful for initializing the message.
-    #[inline]
-    pub fn init_bandwidth(mut self, value: u32) -> Self {
-        self.r#bandwidth = value.into();
-        self
-    }
-    /// Return a reference to `vht_ch_freq1`
-    #[inline]
-    pub fn r#vht_ch_freq1(&self) -> &u32 {
-        &self.r#vht_ch_freq1
-    }
-    /// Return a mutable reference to `vht_ch_freq1`
-    #[inline]
-    pub fn mut_vht_ch_freq1(&mut self) -> &mut u32 {
-        &mut self.r#vht_ch_freq1
-    }
-    /// Set the value of `vht_ch_freq1`
-    #[inline]
-    pub fn set_vht_ch_freq1(&mut self, value: u32) -> &mut Self {
-        self.r#vht_ch_freq1 = value.into();
-        self
-    }
-    /// Builder method that sets the value of `vht_ch_freq1`. Useful for initializing the message.
-    #[inline]
-    pub fn init_vht_ch_freq1(mut self, value: u32) -> Self {
-        self.r#vht_ch_freq1 = value.into();
-        self
-    }
-    /// Return a reference to `vht_ch_freq2`
-    #[inline]
-    pub fn r#vht_ch_freq2(&self) -> &u32 {
-        &self.r#vht_ch_freq2
-    }
-    /// Return a mutable reference to `vht_ch_freq2`
-    #[inline]
-    pub fn mut_vht_ch_freq2(&mut self) -> &mut u32 {
-        &mut self.r#vht_ch_freq2
-    }
-    /// Set the value of `vht_ch_freq2`
-    #[inline]
-    pub fn set_vht_ch_freq2(&mut self, value: u32) -> &mut Self {
-        self.r#vht_ch_freq2 = value.into();
-        self
-    }
-    /// Builder method that sets the value of `vht_ch_freq2`. Useful for initializing the message.
-    #[inline]
-    pub fn init_vht_ch_freq2(mut self, value: u32) -> Self {
-        self.r#vht_ch_freq2 = value.into();
-        self
-    }
 }
 impl ::micropb::MessageDecode for r#wifi_ap_record {
     fn decode<IMPL_MICROPB_READ: ::micropb::PbRead>(
@@ -3652,16 +3345,6 @@ impl ::micropb::MessageDecode for r#wifi_ap_record {
                         }
                     };
                 }
-                4u32 => {
-                    let mut_ref = &mut self.r#second;
-                    {
-                        let val = decoder.decode_int32()?;
-                        let val_ref = &val;
-                        if *val_ref != 0 {
-                            *mut_ref = val as _;
-                        }
-                    };
-                }
                 5u32 => {
                     let mut_ref = &mut self.r#rssi;
                     {
@@ -3676,90 +3359,6 @@ impl ::micropb::MessageDecode for r#wifi_ap_record {
                     let mut_ref = &mut self.r#authmode;
                     {
                         let val = decoder.decode_int32()?;
-                        let val_ref = &val;
-                        if *val_ref != 0 {
-                            *mut_ref = val as _;
-                        }
-                    };
-                }
-                7u32 => {
-                    let mut_ref = &mut self.r#pairwise_cipher;
-                    {
-                        let val = decoder.decode_int32()?;
-                        let val_ref = &val;
-                        if *val_ref != 0 {
-                            *mut_ref = val as _;
-                        }
-                    };
-                }
-                8u32 => {
-                    let mut_ref = &mut self.r#group_cipher;
-                    {
-                        let val = decoder.decode_int32()?;
-                        let val_ref = &val;
-                        if *val_ref != 0 {
-                            *mut_ref = val as _;
-                        }
-                    };
-                }
-                9u32 => {
-                    let mut_ref = &mut self.r#ant;
-                    {
-                        let val = decoder.decode_int32()?;
-                        let val_ref = &val;
-                        if *val_ref != 0 {
-                            *mut_ref = val as _;
-                        }
-                    };
-                }
-                10u32 => {
-                    let mut_ref = &mut self.r#bitmask;
-                    {
-                        let val = decoder.decode_varint32()?;
-                        let val_ref = &val;
-                        if *val_ref != 0 {
-                            *mut_ref = val as _;
-                        }
-                    };
-                }
-                11u32 => {
-                    let mut_ref = &mut self.r#country;
-                    {
-                        mut_ref.decode_len_delimited(decoder)?;
-                    };
-                    self._has.set_country();
-                }
-                12u32 => {
-                    let mut_ref = &mut self.r#he_ap;
-                    {
-                        mut_ref.decode_len_delimited(decoder)?;
-                    };
-                    self._has.set_he_ap();
-                }
-                13u32 => {
-                    let mut_ref = &mut self.r#bandwidth;
-                    {
-                        let val = decoder.decode_varint32()?;
-                        let val_ref = &val;
-                        if *val_ref != 0 {
-                            *mut_ref = val as _;
-                        }
-                    };
-                }
-                14u32 => {
-                    let mut_ref = &mut self.r#vht_ch_freq1;
-                    {
-                        let val = decoder.decode_varint32()?;
-                        let val_ref = &val;
-                        if *val_ref != 0 {
-                            *mut_ref = val as _;
-                        }
-                    };
-                }
-                15u32 => {
-                    let mut_ref = &mut self.r#vht_ch_freq2;
-                    {
-                        let val = decoder.decode_varint32()?;
                         let val_ref = &val;
                         if *val_ref != 0 {
                             *mut_ref = val as _;
@@ -3817,96 +3416,6 @@ impl ::micropb::MessageEncode for r#wifi_ap_record {
                 break 'msg (::core::result::Result::<usize, _>::Err(err));
             }
         }
-        match ::micropb::const_map!(::core::result::Result::Ok(10usize), |size| size + 1usize) {
-            ::core::result::Result::Ok(size) => {
-                max_size += size;
-            }
-            ::core::result::Result::Err(err) => {
-                break 'msg (::core::result::Result::<usize, _>::Err(err));
-            }
-        }
-        match ::micropb::const_map!(::core::result::Result::Ok(10usize), |size| size + 1usize) {
-            ::core::result::Result::Ok(size) => {
-                max_size += size;
-            }
-            ::core::result::Result::Err(err) => {
-                break 'msg (::core::result::Result::<usize, _>::Err(err));
-            }
-        }
-        match ::micropb::const_map!(::core::result::Result::Ok(10usize), |size| size + 1usize) {
-            ::core::result::Result::Ok(size) => {
-                max_size += size;
-            }
-            ::core::result::Result::Err(err) => {
-                break 'msg (::core::result::Result::<usize, _>::Err(err));
-            }
-        }
-        match ::micropb::const_map!(::core::result::Result::Ok(10usize), |size| size + 1usize) {
-            ::core::result::Result::Ok(size) => {
-                max_size += size;
-            }
-            ::core::result::Result::Err(err) => {
-                break 'msg (::core::result::Result::<usize, _>::Err(err));
-            }
-        }
-        match ::micropb::const_map!(::core::result::Result::Ok(5usize), |size| size + 1usize) {
-            ::core::result::Result::Ok(size) => {
-                max_size += size;
-            }
-            ::core::result::Result::Err(err) => {
-                break 'msg (::core::result::Result::<usize, _>::Err(err));
-            }
-        }
-        match ::micropb::const_map!(
-            ::micropb::const_map!(<r#wifi_country as ::micropb::MessageEncode>::MAX_SIZE, |size| {
-                ::micropb::size::sizeof_len_record(size)
-            }),
-            |size| size + 1usize
-        ) {
-            ::core::result::Result::Ok(size) => {
-                max_size += size;
-            }
-            ::core::result::Result::Err(err) => {
-                break 'msg (::core::result::Result::<usize, _>::Err(err));
-            }
-        }
-        match ::micropb::const_map!(
-            ::micropb::const_map!(<r#wifi_he_ap_info as ::micropb::MessageEncode>::MAX_SIZE, |size| {
-                ::micropb::size::sizeof_len_record(size)
-            }),
-            |size| size + 1usize
-        ) {
-            ::core::result::Result::Ok(size) => {
-                max_size += size;
-            }
-            ::core::result::Result::Err(err) => {
-                break 'msg (::core::result::Result::<usize, _>::Err(err));
-            }
-        }
-        match ::micropb::const_map!(::core::result::Result::Ok(5usize), |size| size + 1usize) {
-            ::core::result::Result::Ok(size) => {
-                max_size += size;
-            }
-            ::core::result::Result::Err(err) => {
-                break 'msg (::core::result::Result::<usize, _>::Err(err));
-            }
-        }
-        match ::micropb::const_map!(::core::result::Result::Ok(5usize), |size| size + 1usize) {
-            ::core::result::Result::Ok(size) => {
-                max_size += size;
-            }
-            ::core::result::Result::Err(err) => {
-                break 'msg (::core::result::Result::<usize, _>::Err(err));
-            }
-        }
-        match ::micropb::const_map!(::core::result::Result::Ok(5usize), |size| size + 1usize) {
-            ::core::result::Result::Ok(size) => {
-                max_size += size;
-            }
-            ::core::result::Result::Err(err) => {
-                break 'msg (::core::result::Result::<usize, _>::Err(err));
-            }
-        }
         ::core::result::Result::Ok(max_size)
     };
     fn encode<IMPL_MICROPB_WRITE: ::micropb::PbWrite>(
@@ -3936,13 +3445,6 @@ impl ::micropb::MessageEncode for r#wifi_ap_record {
             }
         }
         {
-            let val_ref = &self.r#second;
-            if *val_ref != 0 {
-                encoder.encode_varint32(32u32)?;
-                encoder.encode_int32(*val_ref as _)?;
-            }
-        }
-        {
             let val_ref = &self.r#rssi;
             if *val_ref != 0 {
                 encoder.encode_varint32(40u32)?;
@@ -3954,67 +3456,6 @@ impl ::micropb::MessageEncode for r#wifi_ap_record {
             if *val_ref != 0 {
                 encoder.encode_varint32(48u32)?;
                 encoder.encode_int32(*val_ref as _)?;
-            }
-        }
-        {
-            let val_ref = &self.r#pairwise_cipher;
-            if *val_ref != 0 {
-                encoder.encode_varint32(56u32)?;
-                encoder.encode_int32(*val_ref as _)?;
-            }
-        }
-        {
-            let val_ref = &self.r#group_cipher;
-            if *val_ref != 0 {
-                encoder.encode_varint32(64u32)?;
-                encoder.encode_int32(*val_ref as _)?;
-            }
-        }
-        {
-            let val_ref = &self.r#ant;
-            if *val_ref != 0 {
-                encoder.encode_varint32(72u32)?;
-                encoder.encode_int32(*val_ref as _)?;
-            }
-        }
-        {
-            let val_ref = &self.r#bitmask;
-            if *val_ref != 0 {
-                encoder.encode_varint32(80u32)?;
-                encoder.encode_varint32(*val_ref as _)?;
-            }
-        }
-        {
-            if let ::core::option::Option::Some(val_ref) = self.r#country() {
-                encoder.encode_varint32(90u32)?;
-                val_ref.encode_len_delimited(encoder)?;
-            }
-        }
-        {
-            if let ::core::option::Option::Some(val_ref) = self.r#he_ap() {
-                encoder.encode_varint32(98u32)?;
-                val_ref.encode_len_delimited(encoder)?;
-            }
-        }
-        {
-            let val_ref = &self.r#bandwidth;
-            if *val_ref != 0 {
-                encoder.encode_varint32(104u32)?;
-                encoder.encode_varint32(*val_ref as _)?;
-            }
-        }
-        {
-            let val_ref = &self.r#vht_ch_freq1;
-            if *val_ref != 0 {
-                encoder.encode_varint32(112u32)?;
-                encoder.encode_varint32(*val_ref as _)?;
-            }
-        }
-        {
-            let val_ref = &self.r#vht_ch_freq2;
-            if *val_ref != 0 {
-                encoder.encode_varint32(120u32)?;
-                encoder.encode_varint32(*val_ref as _)?;
             }
         }
         Ok(())
@@ -4041,12 +3482,6 @@ impl ::micropb::MessageEncode for r#wifi_ap_record {
             }
         }
         {
-            let val_ref = &self.r#second;
-            if *val_ref != 0 {
-                size += 1usize + ::micropb::size::sizeof_int32(*val_ref as _);
-            }
-        }
-        {
             let val_ref = &self.r#rssi;
             if *val_ref != 0 {
                 size += 1usize + ::micropb::size::sizeof_int32(*val_ref as _);
@@ -4058,123 +3493,7 @@ impl ::micropb::MessageEncode for r#wifi_ap_record {
                 size += 1usize + ::micropb::size::sizeof_int32(*val_ref as _);
             }
         }
-        {
-            let val_ref = &self.r#pairwise_cipher;
-            if *val_ref != 0 {
-                size += 1usize + ::micropb::size::sizeof_int32(*val_ref as _);
-            }
-        }
-        {
-            let val_ref = &self.r#group_cipher;
-            if *val_ref != 0 {
-                size += 1usize + ::micropb::size::sizeof_int32(*val_ref as _);
-            }
-        }
-        {
-            let val_ref = &self.r#ant;
-            if *val_ref != 0 {
-                size += 1usize + ::micropb::size::sizeof_int32(*val_ref as _);
-            }
-        }
-        {
-            let val_ref = &self.r#bitmask;
-            if *val_ref != 0 {
-                size += 1usize + ::micropb::size::sizeof_varint32(*val_ref as _);
-            }
-        }
-        {
-            if let ::core::option::Option::Some(val_ref) = self.r#country() {
-                size += 1usize + ::micropb::size::sizeof_len_record(val_ref.compute_size());
-            }
-        }
-        {
-            if let ::core::option::Option::Some(val_ref) = self.r#he_ap() {
-                size += 1usize + ::micropb::size::sizeof_len_record(val_ref.compute_size());
-            }
-        }
-        {
-            let val_ref = &self.r#bandwidth;
-            if *val_ref != 0 {
-                size += 1usize + ::micropb::size::sizeof_varint32(*val_ref as _);
-            }
-        }
-        {
-            let val_ref = &self.r#vht_ch_freq1;
-            if *val_ref != 0 {
-                size += 1usize + ::micropb::size::sizeof_varint32(*val_ref as _);
-            }
-        }
-        {
-            let val_ref = &self.r#vht_ch_freq2;
-            if *val_ref != 0 {
-                size += 1usize + ::micropb::size::sizeof_varint32(*val_ref as _);
-            }
-        }
         size
-    }
-}
-/// Inner types for `wifi_ap_record`
-pub mod wifi_ap_record_ {
-    /// Compact bitfield for tracking presence of optional and message fields
-    #[derive(Debug, Default, PartialEq, Clone, Copy)]
-    #[cfg_attr(feature = "defmt", derive(defmt::Format))]
-    pub struct _Hazzer([u8; 1]);
-    impl _Hazzer {
-        /// New hazzer with all fields set to off
-        #[inline]
-        pub const fn _new() -> Self {
-            Self([0; 1])
-        }
-        /// Query presence of `country`
-        #[inline]
-        pub const fn r#country(&self) -> bool {
-            (self.0[0] & 1) != 0
-        }
-        /// Set presence of `country`
-        #[inline]
-        pub const fn set_country(&mut self) -> &mut Self {
-            let elem = &mut self.0[0];
-            *elem |= 1;
-            self
-        }
-        /// Clear presence of `country`
-        #[inline]
-        pub const fn clear_country(&mut self) -> &mut Self {
-            let elem = &mut self.0[0];
-            *elem &= !1;
-            self
-        }
-        /// Builder method that sets the presence of `country`. Useful for initializing the Hazzer.
-        #[inline]
-        pub const fn init_country(mut self) -> Self {
-            self.set_country();
-            self
-        }
-        /// Query presence of `he_ap`
-        #[inline]
-        pub const fn r#he_ap(&self) -> bool {
-            (self.0[0] & 2) != 0
-        }
-        /// Set presence of `he_ap`
-        #[inline]
-        pub const fn set_he_ap(&mut self) -> &mut Self {
-            let elem = &mut self.0[0];
-            *elem |= 2;
-            self
-        }
-        /// Clear presence of `he_ap`
-        #[inline]
-        pub const fn clear_he_ap(&mut self) -> &mut Self {
-            let elem = &mut self.0[0];
-            *elem &= !2;
-            self
-        }
-        /// Builder method that sets the presence of `he_ap`. Useful for initializing the Hazzer.
-        #[inline]
-        pub const fn init_he_ap(mut self) -> Self {
-            self.set_he_ap();
-            self
-        }
     }
 }
 #[derive(Debug, Default, PartialEq, Clone, Copy)]
@@ -49733,6 +49052,45 @@ impl ::micropb::MessageDecode for Rpc {
                     };
                     mut_ref.decode_len_delimited(decoder)?;
                 }
+                286u32 => {
+                    let mut_ref = loop {
+                        if let ::core::option::Option::Some(variant) = &mut self.r#payload {
+                            if let Rpc_::Payload::ReqWifiScanStart(variant) = &mut *variant {
+                                break &mut *variant;
+                            }
+                        }
+                        self.r#payload = ::core::option::Option::Some(Rpc_::Payload::ReqWifiScanStart(
+                            ::core::default::Default::default(),
+                        ));
+                    };
+                    mut_ref.decode_len_delimited(decoder)?;
+                }
+                288u32 => {
+                    let mut_ref = loop {
+                        if let ::core::option::Option::Some(variant) = &mut self.r#payload {
+                            if let Rpc_::Payload::ReqWifiScanGetApNum(variant) = &mut *variant {
+                                break &mut *variant;
+                            }
+                        }
+                        self.r#payload = ::core::option::Option::Some(Rpc_::Payload::ReqWifiScanGetApNum(
+                            ::core::default::Default::default(),
+                        ));
+                    };
+                    mut_ref.decode_len_delimited(decoder)?;
+                }
+                290u32 => {
+                    let mut_ref = loop {
+                        if let ::core::option::Option::Some(variant) = &mut self.r#payload {
+                            if let Rpc_::Payload::ReqWifiClearApList(variant) = &mut *variant {
+                                break &mut *variant;
+                            }
+                        }
+                        self.r#payload = ::core::option::Option::Some(Rpc_::Payload::ReqWifiClearApList(
+                            ::core::default::Default::default(),
+                        ));
+                    };
+                    mut_ref.decode_len_delimited(decoder)?;
+                }
                 294u32 => {
                     let mut_ref = loop {
                         if let ::core::option::Option::Some(variant) = &mut self.r#payload {
@@ -49754,6 +49112,19 @@ impl ::micropb::MessageDecode for Rpc {
                             }
                         }
                         self.r#payload = ::core::option::Option::Some(Rpc_::Payload::ReqGetCoprocessorFwversion(
+                            ::core::default::Default::default(),
+                        ));
+                    };
+                    mut_ref.decode_len_delimited(decoder)?;
+                }
+                351u32 => {
+                    let mut_ref = loop {
+                        if let ::core::option::Option::Some(variant) = &mut self.r#payload {
+                            if let Rpc_::Payload::ReqWifiScanGetApRecord(variant) = &mut *variant {
+                                break &mut *variant;
+                            }
+                        }
+                        self.r#payload = ::core::option::Option::Some(Rpc_::Payload::ReqWifiScanGetApRecord(
                             ::core::default::Default::default(),
                         ));
                     };
@@ -49928,6 +49299,45 @@ impl ::micropb::MessageDecode for Rpc {
                     };
                     mut_ref.decode_len_delimited(decoder)?;
                 }
+                542u32 => {
+                    let mut_ref = loop {
+                        if let ::core::option::Option::Some(variant) = &mut self.r#payload {
+                            if let Rpc_::Payload::RespWifiScanStart(variant) = &mut *variant {
+                                break &mut *variant;
+                            }
+                        }
+                        self.r#payload = ::core::option::Option::Some(Rpc_::Payload::RespWifiScanStart(
+                            ::core::default::Default::default(),
+                        ));
+                    };
+                    mut_ref.decode_len_delimited(decoder)?;
+                }
+                544u32 => {
+                    let mut_ref = loop {
+                        if let ::core::option::Option::Some(variant) = &mut self.r#payload {
+                            if let Rpc_::Payload::RespWifiScanGetApNum(variant) = &mut *variant {
+                                break &mut *variant;
+                            }
+                        }
+                        self.r#payload = ::core::option::Option::Some(Rpc_::Payload::RespWifiScanGetApNum(
+                            ::core::default::Default::default(),
+                        ));
+                    };
+                    mut_ref.decode_len_delimited(decoder)?;
+                }
+                546u32 => {
+                    let mut_ref = loop {
+                        if let ::core::option::Option::Some(variant) = &mut self.r#payload {
+                            if let Rpc_::Payload::RespWifiClearApList(variant) = &mut *variant {
+                                break &mut *variant;
+                            }
+                        }
+                        self.r#payload = ::core::option::Option::Some(Rpc_::Payload::RespWifiClearApList(
+                            ::core::default::Default::default(),
+                        ));
+                    };
+                    mut_ref.decode_len_delimited(decoder)?;
+                }
                 550u32 => {
                     let mut_ref = loop {
                         if let ::core::option::Option::Some(variant) = &mut self.r#payload {
@@ -49949,6 +49359,19 @@ impl ::micropb::MessageDecode for Rpc {
                             }
                         }
                         self.r#payload = ::core::option::Option::Some(Rpc_::Payload::RespGetCoprocessorFwversion(
+                            ::core::default::Default::default(),
+                        ));
+                    };
+                    mut_ref.decode_len_delimited(decoder)?;
+                }
+                607u32 => {
+                    let mut_ref = loop {
+                        if let ::core::option::Option::Some(variant) = &mut self.r#payload {
+                            if let Rpc_::Payload::RespWifiScanGetApRecord(variant) = &mut *variant {
+                                break &mut *variant;
+                            }
+                        }
+                        self.r#payload = ::core::option::Option::Some(Rpc_::Payload::RespWifiScanGetApRecord(
                             ::core::default::Default::default(),
                         ));
                     };
@@ -50238,6 +49661,53 @@ impl ::micropb::MessageEncode for Rpc {
                 }
             }
             match ::micropb::const_map!(
+                ::micropb::const_map!(<Rpc_Req_WifiScanStart as ::micropb::MessageEncode>::MAX_SIZE, |size| {
+                    ::micropb::size::sizeof_len_record(size)
+                }),
+                |size| size + 2usize
+            ) {
+                ::core::result::Result::Ok(size) => {
+                    if size > max_size {
+                        max_size = size;
+                    }
+                }
+                ::core::result::Result::Err(err) => {
+                    break 'oneof (::core::result::Result::<usize, _>::Err(err));
+                }
+            }
+            match ::micropb::const_map!(
+                ::micropb::const_map!(
+                    <Rpc_Req_WifiScanGetApNum as ::micropb::MessageEncode>::MAX_SIZE,
+                    |size| ::micropb::size::sizeof_len_record(size)
+                ),
+                |size| size + 2usize
+            ) {
+                ::core::result::Result::Ok(size) => {
+                    if size > max_size {
+                        max_size = size;
+                    }
+                }
+                ::core::result::Result::Err(err) => {
+                    break 'oneof (::core::result::Result::<usize, _>::Err(err));
+                }
+            }
+            match ::micropb::const_map!(
+                ::micropb::const_map!(
+                    <Rpc_Req_WifiClearApList as ::micropb::MessageEncode>::MAX_SIZE,
+                    |size| ::micropb::size::sizeof_len_record(size)
+                ),
+                |size| size + 2usize
+            ) {
+                ::core::result::Result::Ok(size) => {
+                    if size > max_size {
+                        max_size = size;
+                    }
+                }
+                ::core::result::Result::Err(err) => {
+                    break 'oneof (::core::result::Result::<usize, _>::Err(err));
+                }
+            }
+            match ::micropb::const_map!(
                 ::micropb::const_map!(
                     <Rpc_Req_WifiStaGetApInfo as ::micropb::MessageEncode>::MAX_SIZE,
                     |size| ::micropb::size::sizeof_len_record(size)
@@ -50256,6 +49726,22 @@ impl ::micropb::MessageEncode for Rpc {
             match ::micropb::const_map!(
                 ::micropb::const_map!(
                     <Rpc_Req_GetCoprocessorFwVersion as ::micropb::MessageEncode>::MAX_SIZE,
+                    |size| ::micropb::size::sizeof_len_record(size)
+                ),
+                |size| size + 2usize
+            ) {
+                ::core::result::Result::Ok(size) => {
+                    if size > max_size {
+                        max_size = size;
+                    }
+                }
+                ::core::result::Result::Err(err) => {
+                    break 'oneof (::core::result::Result::<usize, _>::Err(err));
+                }
+            }
+            match ::micropb::const_map!(
+                ::micropb::const_map!(
+                    <Rpc_Req_WifiScanGetApRecord as ::micropb::MessageEncode>::MAX_SIZE,
                     |size| ::micropb::size::sizeof_len_record(size)
                 ),
                 |size| size + 2usize
@@ -50467,6 +49953,53 @@ impl ::micropb::MessageEncode for Rpc {
                 }
             }
             match ::micropb::const_map!(
+                ::micropb::const_map!(<Rpc_Resp_WifiScanStart as ::micropb::MessageEncode>::MAX_SIZE, |size| {
+                    ::micropb::size::sizeof_len_record(size)
+                }),
+                |size| size + 2usize
+            ) {
+                ::core::result::Result::Ok(size) => {
+                    if size > max_size {
+                        max_size = size;
+                    }
+                }
+                ::core::result::Result::Err(err) => {
+                    break 'oneof (::core::result::Result::<usize, _>::Err(err));
+                }
+            }
+            match ::micropb::const_map!(
+                ::micropb::const_map!(
+                    <Rpc_Resp_WifiScanGetApNum as ::micropb::MessageEncode>::MAX_SIZE,
+                    |size| ::micropb::size::sizeof_len_record(size)
+                ),
+                |size| size + 2usize
+            ) {
+                ::core::result::Result::Ok(size) => {
+                    if size > max_size {
+                        max_size = size;
+                    }
+                }
+                ::core::result::Result::Err(err) => {
+                    break 'oneof (::core::result::Result::<usize, _>::Err(err));
+                }
+            }
+            match ::micropb::const_map!(
+                ::micropb::const_map!(
+                    <Rpc_Resp_WifiClearApList as ::micropb::MessageEncode>::MAX_SIZE,
+                    |size| ::micropb::size::sizeof_len_record(size)
+                ),
+                |size| size + 2usize
+            ) {
+                ::core::result::Result::Ok(size) => {
+                    if size > max_size {
+                        max_size = size;
+                    }
+                }
+                ::core::result::Result::Err(err) => {
+                    break 'oneof (::core::result::Result::<usize, _>::Err(err));
+                }
+            }
+            match ::micropb::const_map!(
                 ::micropb::const_map!(
                     <Rpc_Resp_WifiStaGetApInfo as ::micropb::MessageEncode>::MAX_SIZE,
                     |size| ::micropb::size::sizeof_len_record(size)
@@ -50485,6 +50018,22 @@ impl ::micropb::MessageEncode for Rpc {
             match ::micropb::const_map!(
                 ::micropb::const_map!(
                     <Rpc_Resp_GetCoprocessorFwVersion as ::micropb::MessageEncode>::MAX_SIZE,
+                    |size| ::micropb::size::sizeof_len_record(size)
+                ),
+                |size| size + 2usize
+            ) {
+                ::core::result::Result::Ok(size) => {
+                    if size > max_size {
+                        max_size = size;
+                    }
+                }
+                ::core::result::Result::Err(err) => {
+                    break 'oneof (::core::result::Result::<usize, _>::Err(err));
+                }
+            }
+            match ::micropb::const_map!(
+                ::micropb::const_map!(
+                    <Rpc_Resp_WifiScanGetApRecord as ::micropb::MessageEncode>::MAX_SIZE,
                     |size| ::micropb::size::sizeof_len_record(size)
                 ),
                 |size| size + 2usize
@@ -50674,6 +50223,21 @@ impl ::micropb::MessageEncode for Rpc {
                     encoder.encode_varint32(2274u32)?;
                     val_ref.encode_len_delimited(encoder)?;
                 }
+                Rpc_::Payload::ReqWifiScanStart(val_ref) => {
+                    let val_ref = &*val_ref;
+                    encoder.encode_varint32(2290u32)?;
+                    val_ref.encode_len_delimited(encoder)?;
+                }
+                Rpc_::Payload::ReqWifiScanGetApNum(val_ref) => {
+                    let val_ref = &*val_ref;
+                    encoder.encode_varint32(2306u32)?;
+                    val_ref.encode_len_delimited(encoder)?;
+                }
+                Rpc_::Payload::ReqWifiClearApList(val_ref) => {
+                    let val_ref = &*val_ref;
+                    encoder.encode_varint32(2322u32)?;
+                    val_ref.encode_len_delimited(encoder)?;
+                }
                 Rpc_::Payload::ReqWifiStaGetApInfo(val_ref) => {
                     let val_ref = &*val_ref;
                     encoder.encode_varint32(2354u32)?;
@@ -50682,6 +50246,11 @@ impl ::micropb::MessageEncode for Rpc {
                 Rpc_::Payload::ReqGetCoprocessorFwversion(val_ref) => {
                     let val_ref = &*val_ref;
                     encoder.encode_varint32(2802u32)?;
+                    val_ref.encode_len_delimited(encoder)?;
+                }
+                Rpc_::Payload::ReqWifiScanGetApRecord(val_ref) => {
+                    let val_ref = &*val_ref;
+                    encoder.encode_varint32(2810u32)?;
                     val_ref.encode_len_delimited(encoder)?;
                 }
                 Rpc_::Payload::ReqFeatureControl(val_ref) => {
@@ -50749,6 +50318,21 @@ impl ::micropb::MessageEncode for Rpc {
                     encoder.encode_varint32(4322u32)?;
                     val_ref.encode_len_delimited(encoder)?;
                 }
+                Rpc_::Payload::RespWifiScanStart(val_ref) => {
+                    let val_ref = &*val_ref;
+                    encoder.encode_varint32(4338u32)?;
+                    val_ref.encode_len_delimited(encoder)?;
+                }
+                Rpc_::Payload::RespWifiScanGetApNum(val_ref) => {
+                    let val_ref = &*val_ref;
+                    encoder.encode_varint32(4354u32)?;
+                    val_ref.encode_len_delimited(encoder)?;
+                }
+                Rpc_::Payload::RespWifiClearApList(val_ref) => {
+                    let val_ref = &*val_ref;
+                    encoder.encode_varint32(4370u32)?;
+                    val_ref.encode_len_delimited(encoder)?;
+                }
                 Rpc_::Payload::RespWifiStaGetApInfo(val_ref) => {
                     let val_ref = &*val_ref;
                     encoder.encode_varint32(4402u32)?;
@@ -50757,6 +50341,11 @@ impl ::micropb::MessageEncode for Rpc {
                 Rpc_::Payload::RespGetCoprocessorFwversion(val_ref) => {
                     let val_ref = &*val_ref;
                     encoder.encode_varint32(4850u32)?;
+                    val_ref.encode_len_delimited(encoder)?;
+                }
+                Rpc_::Payload::RespWifiScanGetApRecord(val_ref) => {
+                    let val_ref = &*val_ref;
+                    encoder.encode_varint32(4858u32)?;
                     val_ref.encode_len_delimited(encoder)?;
                 }
                 Rpc_::Payload::RespFeatureControl(val_ref) => {
@@ -50859,11 +50448,27 @@ impl ::micropb::MessageEncode for Rpc {
                     let val_ref = &*val_ref;
                     size += 2usize + ::micropb::size::sizeof_len_record(val_ref.compute_size());
                 }
+                Rpc_::Payload::ReqWifiScanStart(val_ref) => {
+                    let val_ref = &*val_ref;
+                    size += 2usize + ::micropb::size::sizeof_len_record(val_ref.compute_size());
+                }
+                Rpc_::Payload::ReqWifiScanGetApNum(val_ref) => {
+                    let val_ref = &*val_ref;
+                    size += 2usize + ::micropb::size::sizeof_len_record(val_ref.compute_size());
+                }
+                Rpc_::Payload::ReqWifiClearApList(val_ref) => {
+                    let val_ref = &*val_ref;
+                    size += 2usize + ::micropb::size::sizeof_len_record(val_ref.compute_size());
+                }
                 Rpc_::Payload::ReqWifiStaGetApInfo(val_ref) => {
                     let val_ref = &*val_ref;
                     size += 2usize + ::micropb::size::sizeof_len_record(val_ref.compute_size());
                 }
                 Rpc_::Payload::ReqGetCoprocessorFwversion(val_ref) => {
+                    let val_ref = &*val_ref;
+                    size += 2usize + ::micropb::size::sizeof_len_record(val_ref.compute_size());
+                }
+                Rpc_::Payload::ReqWifiScanGetApRecord(val_ref) => {
                     let val_ref = &*val_ref;
                     size += 2usize + ::micropb::size::sizeof_len_record(val_ref.compute_size());
                 }
@@ -50919,11 +50524,27 @@ impl ::micropb::MessageEncode for Rpc {
                     let val_ref = &*val_ref;
                     size += 2usize + ::micropb::size::sizeof_len_record(val_ref.compute_size());
                 }
+                Rpc_::Payload::RespWifiScanStart(val_ref) => {
+                    let val_ref = &*val_ref;
+                    size += 2usize + ::micropb::size::sizeof_len_record(val_ref.compute_size());
+                }
+                Rpc_::Payload::RespWifiScanGetApNum(val_ref) => {
+                    let val_ref = &*val_ref;
+                    size += 2usize + ::micropb::size::sizeof_len_record(val_ref.compute_size());
+                }
+                Rpc_::Payload::RespWifiClearApList(val_ref) => {
+                    let val_ref = &*val_ref;
+                    size += 2usize + ::micropb::size::sizeof_len_record(val_ref.compute_size());
+                }
                 Rpc_::Payload::RespWifiStaGetApInfo(val_ref) => {
                     let val_ref = &*val_ref;
                     size += 2usize + ::micropb::size::sizeof_len_record(val_ref.compute_size());
                 }
                 Rpc_::Payload::RespGetCoprocessorFwversion(val_ref) => {
+                    let val_ref = &*val_ref;
+                    size += 2usize + ::micropb::size::sizeof_len_record(val_ref.compute_size());
+                }
+                Rpc_::Payload::RespWifiScanGetApRecord(val_ref) => {
                     let val_ref = &*val_ref;
                     size += 2usize + ::micropb::size::sizeof_len_record(val_ref.compute_size());
                 }
@@ -50978,11 +50599,17 @@ pub mod Rpc_ {
         ReqWifiDisconnect(super::Rpc_Req_WifiDisconnect),
         ///Rpc_Req_WifiGetConfig               req_wifi_get_config               = 285;
         ReqWifiSetConfig(super::Rpc_Req_WifiSetConfig),
+        ReqWifiScanStart(super::Rpc_Req_WifiScanStart),
+        ///Rpc_Req_WifiScanStop                req_wifi_scan_stop                = 287;
+        ReqWifiScanGetApNum(super::Rpc_Req_WifiScanGetApNum),
+        ///Rpc_Req_WifiScanGetApRecords        req_wifi_scan_get_ap_records      = 289;
+        ReqWifiClearApList(super::Rpc_Req_WifiClearApList),
         ///Rpc_Req_WifiRestore                 req_wifi_restore                  = 291;
         ///Rpc_Req_WifiClearFastConnect        req_wifi_clear_fast_connect       = 292;
         ///Rpc_Req_WifiDeauthSta               req_wifi_deauth_sta               = 293;
         ReqWifiStaGetApInfo(super::Rpc_Req_WifiStaGetApInfo),
         ReqGetCoprocessorFwversion(super::Rpc_Req_GetCoprocessorFwVersion),
+        ReqWifiScanGetApRecord(super::Rpc_Req_WifiScanGetApRecord),
         ReqFeatureControl(super::Rpc_Req_FeatureControl),
         ///* Responses *
         RespGetMacAddress(super::Rpc_Resp_GetMacAddress),
@@ -51004,11 +50631,17 @@ pub mod Rpc_ {
         RespWifiDisconnect(super::Rpc_Resp_WifiDisconnect),
         ///Rpc_Resp_WifiGetConfig              resp_wifi_get_config               = 541;
         RespWifiSetConfig(super::Rpc_Resp_WifiSetConfig),
+        RespWifiScanStart(super::Rpc_Resp_WifiScanStart),
+        ///Rpc_Resp_WifiScanStop               resp_wifi_scan_stop                = 543;
+        RespWifiScanGetApNum(super::Rpc_Resp_WifiScanGetApNum),
+        ///Rpc_Resp_WifiScanGetApRecords       resp_wifi_scan_get_ap_records      = 545;
+        RespWifiClearApList(super::Rpc_Resp_WifiClearApList),
         ///Rpc_Resp_WifiRestore                resp_wifi_restore                  = 547;
         ///Rpc_Resp_WifiClearFastConnect       resp_wifi_clear_fast_connect       = 548;
         ///Rpc_Resp_WifiDeauthSta              resp_wifi_deauth_sta               = 549;
         RespWifiStaGetApInfo(super::Rpc_Resp_WifiStaGetApInfo),
         RespGetCoprocessorFwversion(super::Rpc_Resp_GetCoprocessorFwVersion),
+        RespWifiScanGetApRecord(super::Rpc_Resp_WifiScanGetApRecord),
         RespFeatureControl(super::Rpc_Resp_FeatureControl),
         ///* Notifications *
         EventEspInit(super::Rpc_Event_ESPInit),
@@ -51299,6 +50932,16 @@ impl RpcId {
     pub const ReqWifiDisconnect: Self = Self(283);
     ///0x11c
     pub const ReqWifiSetConfig: Self = Self(284);
+    ///0x11e
+    pub const ReqWifiScanStart: Self = Self(286);
+    ///Req_WifiScanStop                  = 287; //0x11f
+    ///
+    ///0x120
+    pub const ReqWifiScanGetApNum: Self = Self(288);
+    ///Req_WifiScanGetApRecords          = 289; //0x121
+    ///
+    ///0x122
+    pub const ReqWifiClearApList: Self = Self(290);
     ///Req_WifiRestore                   = 291; //0x123
     ///Req_WifiClearFastConnect          = 292; //0x124
     ///Req_WifiDeauthSta                 = 293; //0x125
@@ -51307,6 +50950,8 @@ impl RpcId {
     pub const ReqWifiStaGetApInfo: Self = Self(294);
     ///0x15e
     pub const ReqGetCoprocessorFwVersion: Self = Self(350);
+    ///0x15f
+    pub const ReqWifiScanGetApRecord: Self = Self(351);
     /// Common RPC to handle simple feature control with one optional parameter
     /// Supported Features:
     /// - BT Init/Deinit/Enable/Disable
@@ -51334,6 +50979,11 @@ impl RpcId {
     pub const RespWifiDisconnect: Self = Self(539);
     ///Resp_WifiGetConfig                = 541;
     pub const RespWifiSetConfig: Self = Self(540);
+    pub const RespWifiScanStart: Self = Self(542);
+    ///Resp_WifiScanStop                 = 543;
+    pub const RespWifiScanGetApNum: Self = Self(544);
+    ///Resp_WifiScanGetApRecords         = 545;
+    pub const RespWifiClearApList: Self = Self(546);
     ///Resp_WifiRestore                  = 547;
     ///Resp_WifiClearFastConnect         = 548;
     ///Resp_WifiDeauthSta                = 549;
@@ -51350,6 +51000,7 @@ impl RpcId {
     ///Resp_WifiGetCountry               = 560;
     pub const RespWifiStaGetApInfo: Self = Self(550);
     pub const RespGetCoprocessorFwVersion: Self = Self(606);
+    pub const RespWifiScanGetApRecord: Self = Self(607);
     ///Resp_IfaceMacAddrSetGet                   = 641;
     ///Resp_IfaceMacAddrLenGet                   = 642;
     pub const RespFeatureControl: Self = Self(643);

--- a/embassy-net-esp-hosted/src/proto/mod.rs
+++ b/embassy-net-esp-hosted/src/proto/mod.rs
@@ -35,6 +35,11 @@ fn main() {
         ".CtrlMsg_Req_VendorIEData.payload",
         micropb_gen::Config::new().max_bytes(64),
     );
+    // Scan result is extremely big
+    g.configure(
+        ".CtrlMsg_Resp_ScanResult.entries",
+        micropb_gen::Config::new().max_len(8),
+    );
 
     g.compile_protos(
         &["src/proto/fg/esp_hosted_config.proto"],
@@ -56,6 +61,17 @@ fn main() {
     // Special config for things that need to be larger
     g.configure(".Rpc_Req_OTAWrite.ota_data", micropb_gen::Config::new().max_bytes(256));
     g.configure(".Rpc_Event_ESPInit.init_data", micropb_gen::Config::new().max_bytes(64));
+    // Scan result is extremely big, skip unused fields
+    g.configure(".wifi_ap_record.second", micropb_gen::Config::new().skip(true));
+    g.configure(".wifi_ap_record.pairwise_cipher", micropb_gen::Config::new().skip(true));
+    g.configure(".wifi_ap_record.group_cipher", micropb_gen::Config::new().skip(true));
+    g.configure(".wifi_ap_record.ant", micropb_gen::Config::new().skip(true));
+    g.configure(".wifi_ap_record.bitmask", micropb_gen::Config::new().skip(true));
+    g.configure(".wifi_ap_record.country", micropb_gen::Config::new().skip(true));
+    g.configure(".wifi_ap_record.he_ap", micropb_gen::Config::new().skip(true));
+    g.configure(".wifi_ap_record.bandwidth", micropb_gen::Config::new().skip(true));
+    g.configure(".wifi_ap_record.vht_ch_freq1", micropb_gen::Config::new().skip(true));
+    g.configure(".wifi_ap_record.vht_ch_freq2", micropb_gen::Config::new().skip(true));
 
     g.compile_protos(
         &["src/proto/mcu/esp_hosted_rpc.proto"],

--- a/embassy-net-esp-hosted/src/rpc/fg.rs
+++ b/embassy-net-esp-hosted/src/rpc/fg.rs
@@ -1,5 +1,5 @@
 use CtrlMsg_::Payload;
-use heapless::String;
+use heapless::{String, Vec};
 use micropb::MessageDecode;
 
 use super::{HostedEvent, IoctlCtx, RpcBackend, check_resp};
@@ -7,13 +7,16 @@ use crate::control::{Error, Security, Status};
 use crate::proto::fg::{
     CtrlMsg, CtrlMsg_, CtrlMsg_Req_ConfigHeartbeat, CtrlMsg_Req_ConnectAP, CtrlMsg_Req_GetAPConfig,
     CtrlMsg_Req_GetMacAddress, CtrlMsg_Req_GetStatus, CtrlMsg_Req_OTABegin, CtrlMsg_Req_OTAEnd, CtrlMsg_Req_OTAWrite,
-    CtrlMsg_Req_SetMode, CtrlMsgId, CtrlMsgType,
+    CtrlMsg_Req_ScanResult, CtrlMsg_Req_SetMode, CtrlMsgId, CtrlMsgType, ScanResult,
 };
-use crate::{FwVersion, InterfaceType, WifiMode};
+use crate::rpc::from_utf8_lossy;
+use crate::{FwVersion, InterfaceType, Network, WifiMode};
 
 macro_rules! exchange {
     ($ctx:ident, $req_variant:ident, $resp_variant:ident, $req:expr) => {{
-        let mut msg = CtrlMsg {
+        let (mut ioctl, msg) = $ctx.fg();
+
+        *msg = CtrlMsg {
             msg_id: CtrlMsgId::$req_variant,
             msg_type: CtrlMsgType::Req,
             payload: Some(Payload::$req_variant($req)),
@@ -22,10 +25,10 @@ macro_rules! exchange {
         };
 
         debug!("ioctl req: {:?}", msg);
-        $ctx.exchange(&mut msg).await?;
+        ioctl.exchange(msg).await?;
         debug!("ioctl resp: {:?}", msg);
 
-        let Some(Payload::$resp_variant(resp)) = msg.payload else {
+        let Some(Payload::$resp_variant(ref resp)) = msg.payload else {
             return Err(Error::Internal);
         };
         check_resp(resp.resp)?;
@@ -127,6 +130,38 @@ impl RpcBackend for FgBackend {
         let resp = exchange!(ctx, ReqGetMacAddress, RespGetMacAddress, req);
         let mac_str = core::str::from_utf8(&resp.mac).map_err(|_| Error::Internal)?;
         parse_mac(mac_str)
+    }
+
+    async fn scan<const N: usize>(&self, ctx: &mut IoctlCtx<'_>, result: &mut Vec<Network, N>) -> Result<(), Error> {
+        let req = CtrlMsg_Req_ScanResult {};
+
+        let (mut ioctl, msg) = ctx.fg();
+
+        // Different names :(
+        *msg = CtrlMsg {
+            msg_id: CtrlMsgId::ReqGetApScanList,
+            msg_type: CtrlMsgType::Req,
+            payload: Some(Payload::ReqScanApList(req)),
+            req_resp_type: 0,
+            uid: 0,
+        };
+
+        debug!("ioctl req: {:?}", msg);
+        ioctl.exchange(msg).await?;
+        debug!("ioctl resp: {:?}", msg);
+
+        let Some(Payload::RespScanApList(ref resp)) = msg.payload else {
+            return Err(Error::Internal);
+        };
+        check_resp(resp.resp)?;
+
+        result.clear();
+        for network in resp.entries.iter() {
+            if result.push(network.try_into()?).is_err() {
+                break;
+            }
+        }
+        Ok(())
     }
 
     async fn connect_ap(&self, ctx: &mut IoctlCtx<'_>, ssid: &str, pwd: &str) -> Result<(), Error> {
@@ -256,4 +291,18 @@ fn parse_mac(mac: &str) -> Result<[u8; 6], Error> {
         *b = (nibble_from_hex(mac[i * 3])? << 4) | nibble_from_hex(mac[i * 3 + 1])?
     }
     Ok(res)
+}
+
+impl TryFrom<&ScanResult> for Network {
+    type Error = Error;
+
+    fn try_from(value: &ScanResult) -> Result<Self, Error> {
+        Ok(Network {
+            ssid: from_utf8_lossy(&value.ssid),
+            bssid: str::from_utf8(&value.bssid)
+                .map_err(|_| Error::Internal)
+                .and_then(parse_mac)?,
+            security: map_fg_security(value.sec_prot.0),
+        })
+    }
 }

--- a/embassy-net-esp-hosted/src/rpc/ioctl_ctx.rs
+++ b/embassy-net-esp-hosted/src/rpc/ioctl_ctx.rs
@@ -1,20 +1,80 @@
-use micropb::{MessageDecode, MessageEncode, PbEncoder};
+use micropb::{MessageDecode, MessageEncode, PbDecoder, PbEncoder};
 
 use crate::MAX_IOCTL_SIZE;
 use crate::control::Error;
 use crate::ioctl::Shared;
 
+#[derive(Default)]
+pub(crate) enum IoctlMessage {
+    #[default]
+    None,
+
+    #[cfg(feature = "esp-hosted-fg")]
+    Fg(crate::proto::fg::CtrlMsg),
+
+    #[cfg(feature = "esp-hosted-mcu")]
+    Mcu(crate::proto::mcu::Rpc),
+}
+
 /// One encode → ioctl → decode round-trip through [`Shared`].
 pub struct IoctlCtx<'a> {
     pub(crate) shared: &'a Shared,
     ioctl_buffer: &'a mut [u8; MAX_IOCTL_SIZE],
+    msg_buffer: &'a mut IoctlMessage,
+}
+
+pub struct Ioctl<'a> {
+    shared: &'a Shared,
+    ioctl_buffer: &'a mut [u8; MAX_IOCTL_SIZE],
 }
 
 impl<'a> IoctlCtx<'a> {
-    pub fn new(shared: &'a Shared, ioctl_buffer: &'a mut [u8; MAX_IOCTL_SIZE]) -> IoctlCtx<'a> {
-        IoctlCtx { shared, ioctl_buffer }
+    pub fn new(
+        shared: &'a Shared,
+        ioctl_buffer: &'a mut [u8; MAX_IOCTL_SIZE],
+        msg_buffer: &'a mut IoctlMessage,
+    ) -> IoctlCtx<'a> {
+        IoctlCtx {
+            shared,
+            ioctl_buffer,
+            msg_buffer,
+        }
     }
 
+    #[cfg(feature = "esp-hosted-fg")]
+    pub(crate) fn fg(&mut self) -> (Ioctl<'_>, &mut crate::proto::fg::CtrlMsg) {
+        *self.msg_buffer = IoctlMessage::Fg(Default::default());
+
+        let ioctl = Ioctl {
+            shared: self.shared,
+            ioctl_buffer: self.ioctl_buffer,
+        };
+
+        if let IoctlMessage::Fg(msg) = self.msg_buffer {
+            (ioctl, msg)
+        } else {
+            unreachable!()
+        }
+    }
+
+    #[cfg(feature = "esp-hosted-mcu")]
+    pub(crate) fn mcu(&mut self) -> (Ioctl<'_>, &mut crate::proto::mcu::Rpc) {
+        *self.msg_buffer = IoctlMessage::Mcu(Default::default());
+
+        let ioctl = Ioctl {
+            shared: self.shared,
+            ioctl_buffer: self.ioctl_buffer,
+        };
+
+        if let IoctlMessage::Mcu(msg) = self.msg_buffer {
+            (ioctl, msg)
+        } else {
+            unreachable!()
+        }
+    }
+}
+
+impl Ioctl<'_> {
     pub async fn exchange(&mut self, msg: &mut (impl MessageDecode + MessageEncode)) -> Result<(), Error> {
         let buf_len = self.ioctl_buffer.len();
 
@@ -46,7 +106,10 @@ impl<'a> IoctlCtx<'a> {
 
         ioctl.defuse();
 
-        msg.decode_from_bytes(&self.ioctl_buffer[..resp_len]).map_err(|_| {
+        let mut decoder = PbDecoder::new(&self.ioctl_buffer[..]);
+        // Do not fail if we receive more data than what fits into the statically sized vecs.
+        decoder.ignore_repeated_cap_err = true;
+        msg.decode(&mut decoder, resp_len).map_err(|_| {
             warn!("failed to deserialize control response");
             Error::Internal
         })?;

--- a/embassy-net-esp-hosted/src/rpc/mcu.rs
+++ b/embassy-net-esp-hosted/src/rpc/mcu.rs
@@ -6,17 +6,20 @@ use crate::control::{Error, Security, Status};
 use crate::proto::mcu::Rpc_::Payload;
 use crate::proto::mcu::{
     Rpc, Rpc_Req_ConfigHeartbeat, Rpc_Req_GetCoprocessorFwVersion, Rpc_Req_GetMacAddress, Rpc_Req_OTAActivate,
-    Rpc_Req_OTABegin, Rpc_Req_OTAEnd, Rpc_Req_OTAWrite, Rpc_Req_SetMode, Rpc_Req_WifiConnect, Rpc_Req_WifiDisconnect,
-    Rpc_Req_WifiInit, Rpc_Req_WifiSetConfig, Rpc_Req_WifiStaGetApInfo, Rpc_Req_WifiStart, RpcId, RpcType, wifi_config,
-    wifi_config_, wifi_init_config, wifi_scan_threshold, wifi_sta_config,
+    Rpc_Req_OTABegin, Rpc_Req_OTAEnd, Rpc_Req_OTAWrite, Rpc_Req_SetMode, Rpc_Req_WifiClearApList, Rpc_Req_WifiConnect,
+    Rpc_Req_WifiDisconnect, Rpc_Req_WifiInit, Rpc_Req_WifiScanGetApNum, Rpc_Req_WifiScanGetApRecord,
+    Rpc_Req_WifiScanStart, Rpc_Req_WifiSetConfig, Rpc_Req_WifiStaGetApInfo, Rpc_Req_WifiStart, RpcId, RpcType,
+    wifi_ap_record, wifi_config, wifi_config_, wifi_init_config, wifi_scan_threshold, wifi_sta_config,
 };
 #[cfg(feature = "bluetooth")]
 use crate::proto::mcu::{Rpc_Req_FeatureControl, RpcFeature, RpcFeatureCommand, RpcFeatureOption};
-use crate::{FwVersion, InterfaceType, WifiMode};
+use crate::rpc::from_utf8_lossy;
+use crate::{FwVersion, InterfaceType, Network, WifiMode};
 
 macro_rules! exchange {
     ($ctx:ident, $req_variant:ident, $resp_variant:ident, $req:expr) => {{
-        let mut msg = Rpc {
+        let (mut ioctl, msg) = $ctx.mcu();
+        *msg = Rpc {
             msg_id: RpcId::$req_variant,
             msg_type: RpcType::Req,
             uid: 0,
@@ -24,10 +27,10 @@ macro_rules! exchange {
         };
 
         debug!("ioctl req: {:?}", msg);
-        $ctx.exchange(&mut msg).await?;
+        ioctl.exchange(msg).await?;
         debug!("ioctl resp: {:?}", msg);
 
-        let Some(Payload::$resp_variant(resp)) = msg.payload else {
+        let Some(Payload::$resp_variant(ref resp)) = msg.payload else {
             return Err(Error::Internal);
         };
         check_resp(resp.resp)?;
@@ -190,6 +193,47 @@ impl RpcBackend for McuBackend {
         Ok(resp.mac[..6].try_into().unwrap())
     }
 
+    async fn scan<const N: usize>(&self, ctx: &mut IoctlCtx<'_>, result: &mut Vec<Network, N>) -> Result<(), Error> {
+        async fn read_one<'a>(ctx: &mut IoctlCtx<'a>) -> Result<Network, Error> {
+            let req = Rpc_Req_WifiScanGetApRecord {};
+            let resp = exchange!(ctx, ReqWifiScanGetApRecord, RespWifiScanGetApRecord, req);
+            Network::try_from(&resp.ap_record)
+        }
+
+        let req = Rpc_Req_WifiScanStart {
+            block: true,
+            ..Default::default()
+        };
+        exchange!(ctx, ReqWifiScanStart, RespWifiScanStart, req);
+
+        let req = Rpc_Req_WifiScanGetApNum {};
+        let ap_num = exchange!(ctx, ReqWifiScanGetApNum, RespWifiScanGetApNum, req);
+
+        debug!("Visible APs: {}", ap_num.number);
+        let aps = (ap_num.number as usize).min(N);
+        result.clear();
+
+        let mut res = Ok(());
+        for _ in 0..aps {
+            let network = match read_one(ctx).await {
+                Ok(network) => network,
+                Err(e) => {
+                    res = Err(e);
+                    break;
+                }
+            };
+            if result.push(network).is_err() {
+                break;
+            }
+        }
+
+        // Avoid leaking memory on the device.
+        let req = Rpc_Req_WifiClearApList {};
+        exchange!(ctx, ReqWifiClearApList, RespWifiClearApList, req);
+
+        res
+    }
+
     async fn connect_ap(&self, ctx: &mut IoctlCtx<'_>, ssid: &str, pwd: &str) -> Result<(), Error> {
         let mut req = Rpc_Req_WifiSetConfig::default();
         req.set_iface(WifiInterface::Sta as _);
@@ -234,7 +278,9 @@ impl RpcBackend for McuBackend {
     async fn get_fw_version(&self, ctx: &mut IoctlCtx<'_>) -> Result<FwVersion, Error> {
         let req = Rpc_Req_GetCoprocessorFwVersion::default();
 
-        let mut msg = Rpc {
+        // Different names :(
+        let (mut ioctl, msg) = ctx.mcu();
+        *msg = Rpc {
             msg_id: RpcId::ReqGetCoprocessorFwVersion,
             msg_type: RpcType::Req,
             uid: 0,
@@ -242,10 +288,10 @@ impl RpcBackend for McuBackend {
         };
 
         debug!("ioctl req: {:?}", msg);
-        ctx.exchange(&mut msg).await?;
+        ioctl.exchange(msg).await?;
         debug!("ioctl resp: {:?}", msg);
 
-        let Some(Payload::RespGetCoprocessorFwversion(resp)) = msg.payload else {
+        let Some(Payload::RespGetCoprocessorFwversion(ref resp)) = msg.payload else {
             return Err(Error::Internal);
         };
         check_resp(resp.resp)?;
@@ -497,3 +543,15 @@ const NO_CHANNEL_PREFERENCE: u32 = 0;
 const DEFAULT_LISTEN_INTERVAL: u32 = 3;
 const DEFAULT_FAILURE_RETRY_CNT: u32 = 0;
 const DEFAULT_SAE_PWE_H2E: i32 = 3;
+
+impl TryFrom<&wifi_ap_record> for Network {
+    type Error = Error;
+
+    fn try_from(value: &wifi_ap_record) -> Result<Self, Error> {
+        Ok(Network {
+            ssid: from_utf8_lossy(&value.ssid),
+            bssid: (&value.bssid[..]).try_into().map_err(|_| Error::Internal)?,
+            security: map_mcu_security(value.authmode),
+        })
+    }
+}

--- a/embassy-net-esp-hosted/src/rpc/mod.rs
+++ b/embassy-net-esp-hosted/src/rpc/mod.rs
@@ -5,14 +5,15 @@ compile_error!("At least one esp-hosted-* feature is required");
 
 #[cfg(feature = "esp-hosted-fg")]
 mod fg;
-mod ioctl_ctx;
+pub(crate) mod ioctl_ctx;
 #[cfg(feature = "esp-hosted-mcu")]
 mod mcu;
 
+use heapless::Vec;
 pub use ioctl_ctx::IoctlCtx;
 
 use crate::control::{Error, Status};
-use crate::{FwVersion, InterfaceType, WifiMode};
+use crate::{FwVersion, InterfaceType, Network, WifiMode};
 
 /// Normalized control-path events from the coprocessor.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -47,6 +48,7 @@ pub trait RpcBackend {
     async fn config_heartbeat(&self, ctx: &mut IoctlCtx<'_>, secs: u32) -> Result<(), Error>;
     async fn set_mode(&self, ctx: &mut IoctlCtx<'_>, mode: WifiMode) -> Result<(), Error>;
     async fn get_mac_addr(&self, ctx: &mut IoctlCtx<'_>) -> Result<[u8; 6], Error>;
+    async fn scan<const N: usize>(&self, ctx: &mut IoctlCtx<'_>, result: &mut Vec<Network, N>) -> Result<(), Error>;
     async fn connect_ap(&self, ctx: &mut IoctlCtx<'_>, ssid: &str, pwd: &str) -> Result<(), Error>;
     async fn disconnect_ap(&self, ctx: &mut IoctlCtx<'_>) -> Result<(), Error>;
     async fn get_fw_version(&self, ctx: &mut IoctlCtx<'_>) -> Result<FwVersion, Error>;
@@ -96,6 +98,7 @@ impl RpcBackend for Backend {
             async fn init_radio(&self, ctx: &mut IoctlCtx<'_>) -> Result<(), Error>;
             async fn set_mode(&self, ctx: &mut IoctlCtx<'_>, mode: WifiMode) -> Result<(), Error>;
             async fn get_mac_addr(&self, ctx: &mut IoctlCtx<'_>) -> Result<[u8; 6], Error>;
+            async fn scan<const N: usize>(&self, ctx: &mut IoctlCtx<'_>, result: &mut Vec<Network, N>) -> Result<(), Error>;
             async fn connect_ap(&self, ctx: &mut IoctlCtx<'_>, ssid: &str, pwd: &str) -> Result<(), Error>;
             async fn disconnect_ap(&self, ctx: &mut IoctlCtx<'_>) -> Result<(), Error>;
             async fn get_status(&self, ctx: &mut IoctlCtx<'_>) -> Result<Status, Error>;
@@ -219,6 +222,9 @@ impl RpcBackend for NoBackend {
     async fn get_mac_addr(&self, _ctx: &mut IoctlCtx<'_>) -> Result<[u8; 6], Error> {
         Err(Error::Internal)
     }
+    async fn scan<const N: usize>(&self, _ctx: &mut IoctlCtx<'_>, _result: &mut Vec<Network, N>) -> Result<(), Error> {
+        Err(Error::Internal)
+    }
     async fn connect_ap(&self, _ctx: &mut IoctlCtx<'_>, _ssid: &str, _pwd: &str) -> Result<(), Error> {
         Err(Error::Internal)
     }
@@ -251,4 +257,26 @@ fn check_resp(resp: i32) -> Result<(), Error> {
     } else {
         Ok(())
     }
+}
+
+fn from_utf8_lossy<const N: usize>(bytes: &[u8]) -> heapless::String<N> {
+    const REPLACEMENT: &str = "\u{FFFD}";
+
+    let mut str = heapless::String::new();
+
+    let end = bytes.iter().position(|c| *c == b'\x00').unwrap_or(bytes.len());
+    let bytes = &bytes[..end];
+
+    for chunk in bytes.utf8_chunks() {
+        if str.push_str(chunk.valid()).is_err() {
+            break;
+        }
+        if !chunk.invalid().is_empty() {
+            if str.push_str(REPLACEMENT).is_err() {
+                break;
+            }
+        }
+    }
+
+    str
 }


### PR DESCRIPTION
- FG is limited to 8 APs to not bloat the message struct up too much
  - Should the scan API maybe be feature-gated? We could break this into logical features (wifi sta (optionally with scan), ota, wifi ap, bluetooth, etc.). Slightly annoying to keep the generated proto up-to-date, but code size and ram use could be tuned.
- MCU iterates one by one so that we don't limit the results there
- The big deserialized message is now stored in State