### PR TITLE
esp-hosted: Separate responses and events

### DIFF
--- a/embassy-net-esp-hosted/src/proto/fg/esp_hosted_config.proto
+++ b/embassy-net-esp-hosted/src/proto/fg/esp_hosted_config.proto
@@ -613,7 +613,26 @@ message CtrlMsg {
         //CtrlMsg_Resp_SetDhcpDnsStatus resp_set_dhcp_dns_status = 226;
         //CtrlMsg_Resp_GetDhcpDnsStatus resp_get_dhcp_dns_status = 227;
         //CtrlMsg_Resp_CustomRpcUnserialisedMsg resp_custom_rpc_unserialised_msg = 228;
+// Start of manual change - separate Event message to improve code size
+    }
+}
 
+message CtrlEvent {
+    /* msg_type could be req, resp or Event */
+    CtrlMsgType msg_type = 1;
+
+    /* msg id */
+    CtrlMsgId msg_id = 2;
+
+    /* UID of message */
+    int32 uid = 3;
+
+    /* Request/response type: sync or async */
+    uint32 req_resp_type = 4;
+
+    /* union of all msg ids */
+    oneof payload {
+// End of manual change
         /** Notifications **/
         CtrlMsg_Event_ESPInit event_esp_init = 301;
         CtrlMsg_Event_Heartbeat event_heartbeat = 302;

--- a/embassy-net-esp-hosted/src/proto/fg/mod.rs
+++ b/embassy-net-esp-hosted/src/proto/fg/mod.rs
@@ -11504,58 +11504,6 @@ impl ::micropb::MessageDecode for CtrlMsg {
                     };
                     mut_ref.decode_len_delimited(decoder)?;
                 }
-                301u32 => {
-                    let mut_ref = loop {
-                        if let ::core::option::Option::Some(variant) = &mut self.r#payload {
-                            if let CtrlMsg_::Payload::EventEspInit(variant) = &mut *variant {
-                                break &mut *variant;
-                            }
-                        }
-                        self.r#payload = ::core::option::Option::Some(CtrlMsg_::Payload::EventEspInit(
-                            ::core::default::Default::default(),
-                        ));
-                    };
-                    mut_ref.decode_len_delimited(decoder)?;
-                }
-                302u32 => {
-                    let mut_ref = loop {
-                        if let ::core::option::Option::Some(variant) = &mut self.r#payload {
-                            if let CtrlMsg_::Payload::EventHeartbeat(variant) = &mut *variant {
-                                break &mut *variant;
-                            }
-                        }
-                        self.r#payload = ::core::option::Option::Some(CtrlMsg_::Payload::EventHeartbeat(
-                            ::core::default::Default::default(),
-                        ));
-                    };
-                    mut_ref.decode_len_delimited(decoder)?;
-                }
-                303u32 => {
-                    let mut_ref = loop {
-                        if let ::core::option::Option::Some(variant) = &mut self.r#payload {
-                            if let CtrlMsg_::Payload::EventStationDisconnectFromAp(variant) = &mut *variant {
-                                break &mut *variant;
-                            }
-                        }
-                        self.r#payload = ::core::option::Option::Some(CtrlMsg_::Payload::EventStationDisconnectFromAp(
-                            ::core::default::Default::default(),
-                        ));
-                    };
-                    mut_ref.decode_len_delimited(decoder)?;
-                }
-                305u32 => {
-                    let mut_ref = loop {
-                        if let ::core::option::Option::Some(variant) = &mut self.r#payload {
-                            if let CtrlMsg_::Payload::EventStationConnectedToAp(variant) = &mut *variant {
-                                break &mut *variant;
-                            }
-                        }
-                        self.r#payload = ::core::option::Option::Some(CtrlMsg_::Payload::EventStationConnectedToAp(
-                            ::core::default::Default::default(),
-                        ));
-                    };
-                    mut_ref.decode_len_delimited(decoder)?;
-                }
                 _ => {
                     decoder.skip_wire_value(tag.wire_type())?;
                 }
@@ -11940,69 +11888,6 @@ impl ::micropb::MessageEncode for CtrlMsg {
                     break 'oneof (::core::result::Result::<usize, _>::Err(err));
                 }
             }
-            match ::micropb::const_map!(
-                ::micropb::const_map!(<CtrlMsg_Event_ESPInit as ::micropb::MessageEncode>::MAX_SIZE, |size| {
-                    ::micropb::size::sizeof_len_record(size)
-                }),
-                |size| size + 2usize
-            ) {
-                ::core::result::Result::Ok(size) => {
-                    if size > max_size {
-                        max_size = size;
-                    }
-                }
-                ::core::result::Result::Err(err) => {
-                    break 'oneof (::core::result::Result::<usize, _>::Err(err));
-                }
-            }
-            match ::micropb::const_map!(
-                ::micropb::const_map!(
-                    <CtrlMsg_Event_Heartbeat as ::micropb::MessageEncode>::MAX_SIZE,
-                    |size| ::micropb::size::sizeof_len_record(size)
-                ),
-                |size| size + 2usize
-            ) {
-                ::core::result::Result::Ok(size) => {
-                    if size > max_size {
-                        max_size = size;
-                    }
-                }
-                ::core::result::Result::Err(err) => {
-                    break 'oneof (::core::result::Result::<usize, _>::Err(err));
-                }
-            }
-            match ::micropb::const_map!(
-                ::micropb::const_map!(
-                    <CtrlMsg_Event_StationDisconnectFromAP as ::micropb::MessageEncode>::MAX_SIZE,
-                    |size| ::micropb::size::sizeof_len_record(size)
-                ),
-                |size| size + 2usize
-            ) {
-                ::core::result::Result::Ok(size) => {
-                    if size > max_size {
-                        max_size = size;
-                    }
-                }
-                ::core::result::Result::Err(err) => {
-                    break 'oneof (::core::result::Result::<usize, _>::Err(err));
-                }
-            }
-            match ::micropb::const_map!(
-                ::micropb::const_map!(
-                    <CtrlMsg_Event_StationConnectedToAP as ::micropb::MessageEncode>::MAX_SIZE,
-                    |size| ::micropb::size::sizeof_len_record(size)
-                ),
-                |size| size + 2usize
-            ) {
-                ::core::result::Result::Ok(size) => {
-                    if size > max_size {
-                        max_size = size;
-                    }
-                }
-                ::core::result::Result::Err(err) => {
-                    break 'oneof (::core::result::Result::<usize, _>::Err(err));
-                }
-            }
             ::core::result::Result::Ok(max_size)
         } {
             ::core::result::Result::Ok(size) => {
@@ -12159,26 +12044,6 @@ impl ::micropb::MessageEncode for CtrlMsg {
                     encoder.encode_varint32(1786u32)?;
                     val_ref.encode_len_delimited(encoder)?;
                 }
-                CtrlMsg_::Payload::EventEspInit(val_ref) => {
-                    let val_ref = &*val_ref;
-                    encoder.encode_varint32(2410u32)?;
-                    val_ref.encode_len_delimited(encoder)?;
-                }
-                CtrlMsg_::Payload::EventHeartbeat(val_ref) => {
-                    let val_ref = &*val_ref;
-                    encoder.encode_varint32(2418u32)?;
-                    val_ref.encode_len_delimited(encoder)?;
-                }
-                CtrlMsg_::Payload::EventStationDisconnectFromAp(val_ref) => {
-                    let val_ref = &*val_ref;
-                    encoder.encode_varint32(2426u32)?;
-                    val_ref.encode_len_delimited(encoder)?;
-                }
-                CtrlMsg_::Payload::EventStationConnectedToAp(val_ref) => {
-                    let val_ref = &*val_ref;
-                    encoder.encode_varint32(2442u32)?;
-                    val_ref.encode_len_delimited(encoder)?;
-                }
             }
         }
         Ok(())
@@ -12300,22 +12165,6 @@ impl ::micropb::MessageEncode for CtrlMsg {
                     let val_ref = &*val_ref;
                     size += 2usize + ::micropb::size::sizeof_len_record(val_ref.compute_size());
                 }
-                CtrlMsg_::Payload::EventEspInit(val_ref) => {
-                    let val_ref = &*val_ref;
-                    size += 2usize + ::micropb::size::sizeof_len_record(val_ref.compute_size());
-                }
-                CtrlMsg_::Payload::EventHeartbeat(val_ref) => {
-                    let val_ref = &*val_ref;
-                    size += 2usize + ::micropb::size::sizeof_len_record(val_ref.compute_size());
-                }
-                CtrlMsg_::Payload::EventStationDisconnectFromAp(val_ref) => {
-                    let val_ref = &*val_ref;
-                    size += 2usize + ::micropb::size::sizeof_len_record(val_ref.compute_size());
-                }
-                CtrlMsg_::Payload::EventStationConnectedToAp(val_ref) => {
-                    let val_ref = &*val_ref;
-                    size += 2usize + ::micropb::size::sizeof_len_record(val_ref.compute_size());
-                }
             }
         }
         size
@@ -12372,7 +12221,456 @@ pub mod CtrlMsg_ {
         ///CtrlMsg_Resp_SetDhcpDnsStatus resp_set_dhcp_dns_status = 226;
         ///CtrlMsg_Resp_GetDhcpDnsStatus resp_get_dhcp_dns_status = 227;
         ///CtrlMsg_Resp_CustomRpcUnserialisedMsg resp_custom_rpc_unserialised_msg = 228;
+        /// Start of manual change - separate Event message to improve code size
         RespGetFwVersion(super::CtrlMsg_Resp_GetFwVersion),
+    }
+}
+#[derive(Debug, Default, PartialEq, Clone)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+pub struct CtrlEvent {
+    /// msg_type could be req, resp or Event
+    pub r#msg_type: CtrlMsgType,
+    /// msg id
+    pub r#msg_id: CtrlMsgId,
+    /// UID of message
+    pub r#uid: i32,
+    /// Request/response type: sync or async
+    pub r#req_resp_type: u32,
+    /// union of all msg ids
+    ///
+    /// End of manual change
+    pub r#payload: ::core::option::Option<CtrlEvent_::Payload>,
+}
+impl CtrlEvent {
+    /// Return a reference to `msg_type`
+    #[inline]
+    pub fn r#msg_type(&self) -> &CtrlMsgType {
+        &self.r#msg_type
+    }
+    /// Return a mutable reference to `msg_type`
+    #[inline]
+    pub fn mut_msg_type(&mut self) -> &mut CtrlMsgType {
+        &mut self.r#msg_type
+    }
+    /// Set the value of `msg_type`
+    #[inline]
+    pub fn set_msg_type(&mut self, value: CtrlMsgType) -> &mut Self {
+        self.r#msg_type = value.into();
+        self
+    }
+    /// Builder method that sets the value of `msg_type`. Useful for initializing the message.
+    #[inline]
+    pub fn init_msg_type(mut self, value: CtrlMsgType) -> Self {
+        self.r#msg_type = value.into();
+        self
+    }
+    /// Return a reference to `msg_id`
+    #[inline]
+    pub fn r#msg_id(&self) -> &CtrlMsgId {
+        &self.r#msg_id
+    }
+    /// Return a mutable reference to `msg_id`
+    #[inline]
+    pub fn mut_msg_id(&mut self) -> &mut CtrlMsgId {
+        &mut self.r#msg_id
+    }
+    /// Set the value of `msg_id`
+    #[inline]
+    pub fn set_msg_id(&mut self, value: CtrlMsgId) -> &mut Self {
+        self.r#msg_id = value.into();
+        self
+    }
+    /// Builder method that sets the value of `msg_id`. Useful for initializing the message.
+    #[inline]
+    pub fn init_msg_id(mut self, value: CtrlMsgId) -> Self {
+        self.r#msg_id = value.into();
+        self
+    }
+    /// Return a reference to `uid`
+    #[inline]
+    pub fn r#uid(&self) -> &i32 {
+        &self.r#uid
+    }
+    /// Return a mutable reference to `uid`
+    #[inline]
+    pub fn mut_uid(&mut self) -> &mut i32 {
+        &mut self.r#uid
+    }
+    /// Set the value of `uid`
+    #[inline]
+    pub fn set_uid(&mut self, value: i32) -> &mut Self {
+        self.r#uid = value.into();
+        self
+    }
+    /// Builder method that sets the value of `uid`. Useful for initializing the message.
+    #[inline]
+    pub fn init_uid(mut self, value: i32) -> Self {
+        self.r#uid = value.into();
+        self
+    }
+    /// Return a reference to `req_resp_type`
+    #[inline]
+    pub fn r#req_resp_type(&self) -> &u32 {
+        &self.r#req_resp_type
+    }
+    /// Return a mutable reference to `req_resp_type`
+    #[inline]
+    pub fn mut_req_resp_type(&mut self) -> &mut u32 {
+        &mut self.r#req_resp_type
+    }
+    /// Set the value of `req_resp_type`
+    #[inline]
+    pub fn set_req_resp_type(&mut self, value: u32) -> &mut Self {
+        self.r#req_resp_type = value.into();
+        self
+    }
+    /// Builder method that sets the value of `req_resp_type`. Useful for initializing the message.
+    #[inline]
+    pub fn init_req_resp_type(mut self, value: u32) -> Self {
+        self.r#req_resp_type = value.into();
+        self
+    }
+}
+impl ::micropb::MessageDecode for CtrlEvent {
+    fn decode<IMPL_MICROPB_READ: ::micropb::PbRead>(
+        &mut self,
+        decoder: &mut ::micropb::PbDecoder<IMPL_MICROPB_READ>,
+        len: usize,
+    ) -> Result<(), ::micropb::DecodeError<IMPL_MICROPB_READ::Error>> {
+        use ::micropb::{FieldDecode, PbBytes, PbMap, PbString, PbVec};
+        let before = decoder.bytes_read();
+        while decoder.bytes_read() - before < len {
+            let tag = decoder.decode_tag()?;
+            match tag.field_num() {
+                0 => return Err(::micropb::DecodeError::ZeroField),
+                1u32 => {
+                    let mut_ref = &mut self.r#msg_type;
+                    {
+                        let val = decoder.decode_int32().map(|n| CtrlMsgType(n as _))?;
+                        let val_ref = &val;
+                        if val_ref.0 != 0 {
+                            *mut_ref = val as _;
+                        }
+                    };
+                }
+                2u32 => {
+                    let mut_ref = &mut self.r#msg_id;
+                    {
+                        let val = decoder.decode_int32().map(|n| CtrlMsgId(n as _))?;
+                        let val_ref = &val;
+                        if val_ref.0 != 0 {
+                            *mut_ref = val as _;
+                        }
+                    };
+                }
+                3u32 => {
+                    let mut_ref = &mut self.r#uid;
+                    {
+                        let val = decoder.decode_int32()?;
+                        let val_ref = &val;
+                        if *val_ref != 0 {
+                            *mut_ref = val as _;
+                        }
+                    };
+                }
+                4u32 => {
+                    let mut_ref = &mut self.r#req_resp_type;
+                    {
+                        let val = decoder.decode_varint32()?;
+                        let val_ref = &val;
+                        if *val_ref != 0 {
+                            *mut_ref = val as _;
+                        }
+                    };
+                }
+                301u32 => {
+                    let mut_ref = loop {
+                        if let ::core::option::Option::Some(variant) = &mut self.r#payload {
+                            if let CtrlEvent_::Payload::EventEspInit(variant) = &mut *variant {
+                                break &mut *variant;
+                            }
+                        }
+                        self.r#payload = ::core::option::Option::Some(CtrlEvent_::Payload::EventEspInit(
+                            ::core::default::Default::default(),
+                        ));
+                    };
+                    mut_ref.decode_len_delimited(decoder)?;
+                }
+                302u32 => {
+                    let mut_ref = loop {
+                        if let ::core::option::Option::Some(variant) = &mut self.r#payload {
+                            if let CtrlEvent_::Payload::EventHeartbeat(variant) = &mut *variant {
+                                break &mut *variant;
+                            }
+                        }
+                        self.r#payload = ::core::option::Option::Some(CtrlEvent_::Payload::EventHeartbeat(
+                            ::core::default::Default::default(),
+                        ));
+                    };
+                    mut_ref.decode_len_delimited(decoder)?;
+                }
+                303u32 => {
+                    let mut_ref = loop {
+                        if let ::core::option::Option::Some(variant) = &mut self.r#payload {
+                            if let CtrlEvent_::Payload::EventStationDisconnectFromAp(variant) = &mut *variant {
+                                break &mut *variant;
+                            }
+                        }
+                        self.r#payload = ::core::option::Option::Some(
+                            CtrlEvent_::Payload::EventStationDisconnectFromAp(::core::default::Default::default()),
+                        );
+                    };
+                    mut_ref.decode_len_delimited(decoder)?;
+                }
+                305u32 => {
+                    let mut_ref = loop {
+                        if let ::core::option::Option::Some(variant) = &mut self.r#payload {
+                            if let CtrlEvent_::Payload::EventStationConnectedToAp(variant) = &mut *variant {
+                                break &mut *variant;
+                            }
+                        }
+                        self.r#payload = ::core::option::Option::Some(CtrlEvent_::Payload::EventStationConnectedToAp(
+                            ::core::default::Default::default(),
+                        ));
+                    };
+                    mut_ref.decode_len_delimited(decoder)?;
+                }
+                _ => {
+                    decoder.skip_wire_value(tag.wire_type())?;
+                }
+            }
+        }
+        Ok(())
+    }
+}
+impl ::micropb::MessageEncode for CtrlEvent {
+    const MAX_SIZE: ::core::result::Result<usize, &'static str> = 'msg: {
+        let mut max_size = 0;
+        match ::micropb::const_map!(::core::result::Result::Ok(CtrlMsgType::_MAX_SIZE), |size| size + 1usize) {
+            ::core::result::Result::Ok(size) => {
+                max_size += size;
+            }
+            ::core::result::Result::Err(err) => {
+                break 'msg (::core::result::Result::<usize, _>::Err(err));
+            }
+        }
+        match ::micropb::const_map!(::core::result::Result::Ok(CtrlMsgId::_MAX_SIZE), |size| size + 1usize) {
+            ::core::result::Result::Ok(size) => {
+                max_size += size;
+            }
+            ::core::result::Result::Err(err) => {
+                break 'msg (::core::result::Result::<usize, _>::Err(err));
+            }
+        }
+        match ::micropb::const_map!(::core::result::Result::Ok(10usize), |size| size + 1usize) {
+            ::core::result::Result::Ok(size) => {
+                max_size += size;
+            }
+            ::core::result::Result::Err(err) => {
+                break 'msg (::core::result::Result::<usize, _>::Err(err));
+            }
+        }
+        match ::micropb::const_map!(::core::result::Result::Ok(5usize), |size| size + 1usize) {
+            ::core::result::Result::Ok(size) => {
+                max_size += size;
+            }
+            ::core::result::Result::Err(err) => {
+                break 'msg (::core::result::Result::<usize, _>::Err(err));
+            }
+        }
+        match 'oneof: {
+            let mut max_size = 0;
+            match ::micropb::const_map!(
+                ::micropb::const_map!(<CtrlMsg_Event_ESPInit as ::micropb::MessageEncode>::MAX_SIZE, |size| {
+                    ::micropb::size::sizeof_len_record(size)
+                }),
+                |size| size + 2usize
+            ) {
+                ::core::result::Result::Ok(size) => {
+                    if size > max_size {
+                        max_size = size;
+                    }
+                }
+                ::core::result::Result::Err(err) => {
+                    break 'oneof (::core::result::Result::<usize, _>::Err(err));
+                }
+            }
+            match ::micropb::const_map!(
+                ::micropb::const_map!(
+                    <CtrlMsg_Event_Heartbeat as ::micropb::MessageEncode>::MAX_SIZE,
+                    |size| ::micropb::size::sizeof_len_record(size)
+                ),
+                |size| size + 2usize
+            ) {
+                ::core::result::Result::Ok(size) => {
+                    if size > max_size {
+                        max_size = size;
+                    }
+                }
+                ::core::result::Result::Err(err) => {
+                    break 'oneof (::core::result::Result::<usize, _>::Err(err));
+                }
+            }
+            match ::micropb::const_map!(
+                ::micropb::const_map!(
+                    <CtrlMsg_Event_StationDisconnectFromAP as ::micropb::MessageEncode>::MAX_SIZE,
+                    |size| ::micropb::size::sizeof_len_record(size)
+                ),
+                |size| size + 2usize
+            ) {
+                ::core::result::Result::Ok(size) => {
+                    if size > max_size {
+                        max_size = size;
+                    }
+                }
+                ::core::result::Result::Err(err) => {
+                    break 'oneof (::core::result::Result::<usize, _>::Err(err));
+                }
+            }
+            match ::micropb::const_map!(
+                ::micropb::const_map!(
+                    <CtrlMsg_Event_StationConnectedToAP as ::micropb::MessageEncode>::MAX_SIZE,
+                    |size| ::micropb::size::sizeof_len_record(size)
+                ),
+                |size| size + 2usize
+            ) {
+                ::core::result::Result::Ok(size) => {
+                    if size > max_size {
+                        max_size = size;
+                    }
+                }
+                ::core::result::Result::Err(err) => {
+                    break 'oneof (::core::result::Result::<usize, _>::Err(err));
+                }
+            }
+            ::core::result::Result::Ok(max_size)
+        } {
+            ::core::result::Result::Ok(size) => {
+                max_size += size;
+            }
+            ::core::result::Result::Err(err) => {
+                break 'msg (::core::result::Result::<usize, _>::Err(err));
+            }
+        }
+        ::core::result::Result::Ok(max_size)
+    };
+    fn encode<IMPL_MICROPB_WRITE: ::micropb::PbWrite>(
+        &self,
+        encoder: &mut ::micropb::PbEncoder<IMPL_MICROPB_WRITE>,
+    ) -> Result<(), IMPL_MICROPB_WRITE::Error> {
+        use ::micropb::{FieldEncode, PbMap};
+        {
+            let val_ref = &self.r#msg_type;
+            if val_ref.0 != 0 {
+                encoder.encode_varint32(8u32)?;
+                encoder.encode_int32(val_ref.0 as _)?;
+            }
+        }
+        {
+            let val_ref = &self.r#msg_id;
+            if val_ref.0 != 0 {
+                encoder.encode_varint32(16u32)?;
+                encoder.encode_int32(val_ref.0 as _)?;
+            }
+        }
+        {
+            let val_ref = &self.r#uid;
+            if *val_ref != 0 {
+                encoder.encode_varint32(24u32)?;
+                encoder.encode_int32(*val_ref as _)?;
+            }
+        }
+        {
+            let val_ref = &self.r#req_resp_type;
+            if *val_ref != 0 {
+                encoder.encode_varint32(32u32)?;
+                encoder.encode_varint32(*val_ref as _)?;
+            }
+        }
+        if let Some(oneof) = &self.r#payload {
+            match &*oneof {
+                CtrlEvent_::Payload::EventEspInit(val_ref) => {
+                    let val_ref = &*val_ref;
+                    encoder.encode_varint32(2410u32)?;
+                    val_ref.encode_len_delimited(encoder)?;
+                }
+                CtrlEvent_::Payload::EventHeartbeat(val_ref) => {
+                    let val_ref = &*val_ref;
+                    encoder.encode_varint32(2418u32)?;
+                    val_ref.encode_len_delimited(encoder)?;
+                }
+                CtrlEvent_::Payload::EventStationDisconnectFromAp(val_ref) => {
+                    let val_ref = &*val_ref;
+                    encoder.encode_varint32(2426u32)?;
+                    val_ref.encode_len_delimited(encoder)?;
+                }
+                CtrlEvent_::Payload::EventStationConnectedToAp(val_ref) => {
+                    let val_ref = &*val_ref;
+                    encoder.encode_varint32(2442u32)?;
+                    val_ref.encode_len_delimited(encoder)?;
+                }
+            }
+        }
+        Ok(())
+    }
+    fn compute_size(&self) -> usize {
+        use ::micropb::{FieldEncode, PbMap};
+        let mut size = 0;
+        {
+            let val_ref = &self.r#msg_type;
+            if val_ref.0 != 0 {
+                size += 1usize + ::micropb::size::sizeof_int32(val_ref.0 as _);
+            }
+        }
+        {
+            let val_ref = &self.r#msg_id;
+            if val_ref.0 != 0 {
+                size += 1usize + ::micropb::size::sizeof_int32(val_ref.0 as _);
+            }
+        }
+        {
+            let val_ref = &self.r#uid;
+            if *val_ref != 0 {
+                size += 1usize + ::micropb::size::sizeof_int32(*val_ref as _);
+            }
+        }
+        {
+            let val_ref = &self.r#req_resp_type;
+            if *val_ref != 0 {
+                size += 1usize + ::micropb::size::sizeof_varint32(*val_ref as _);
+            }
+        }
+        if let Some(oneof) = &self.r#payload {
+            match &*oneof {
+                CtrlEvent_::Payload::EventEspInit(val_ref) => {
+                    let val_ref = &*val_ref;
+                    size += 2usize + ::micropb::size::sizeof_len_record(val_ref.compute_size());
+                }
+                CtrlEvent_::Payload::EventHeartbeat(val_ref) => {
+                    let val_ref = &*val_ref;
+                    size += 2usize + ::micropb::size::sizeof_len_record(val_ref.compute_size());
+                }
+                CtrlEvent_::Payload::EventStationDisconnectFromAp(val_ref) => {
+                    let val_ref = &*val_ref;
+                    size += 2usize + ::micropb::size::sizeof_len_record(val_ref.compute_size());
+                }
+                CtrlEvent_::Payload::EventStationConnectedToAp(val_ref) => {
+                    let val_ref = &*val_ref;
+                    size += 2usize + ::micropb::size::sizeof_len_record(val_ref.compute_size());
+                }
+            }
+        }
+        size
+    }
+}
+/// Inner types for `CtrlEvent`
+pub mod CtrlEvent_ {
+    /// union of all msg ids
+    ///
+    /// End of manual change
+    #[derive(Debug, PartialEq, Clone)]
+    #[cfg_attr(feature = "defmt", derive(defmt::Format))]
+    pub enum Payload {
         ///* Notifications *
         EventEspInit(super::CtrlMsg_Event_ESPInit),
         EventHeartbeat(super::CtrlMsg_Event_Heartbeat),

--- a/embassy-net-esp-hosted/src/proto/mcu/esp_hosted_rpc.proto
+++ b/embassy-net-esp-hosted/src/proto/mcu/esp_hosted_rpc.proto
@@ -2440,7 +2440,23 @@ message Rpc {
 		//Rpc_Resp_GpioSetPullMode            resp_gpio_set_pull_mode            = 651;
 
 		//Rpc_Resp_ExtCoex                    resp_ext_coex                     = 652;
+// Start of manual change - separate Event message to improve code size
+	}
+}
 
+message RpcEvent {
+	/* msg_type could be req, resp or Event */
+	RpcType msg_type = 1;
+
+	/* msg id */
+	RpcId msg_id = 2;
+
+	/* UID of message */
+	uint32 uid = 3;
+
+	/* union of all msg ids */
+	oneof payload {
+// End of manual change
 		/** Notifications **/
 		Rpc_Event_ESPInit                   event_esp_init                     = 769;
 		Rpc_Event_Heartbeat                 event_heartbeat                    = 770;

--- a/embassy-net-esp-hosted/src/proto/mcu/mod.rs
+++ b/embassy-net-esp-hosted/src/proto/mcu/mod.rs
@@ -49390,58 +49390,6 @@ impl ::micropb::MessageDecode for Rpc {
                     };
                     mut_ref.decode_len_delimited(decoder)?;
                 }
-                769u32 => {
-                    let mut_ref = loop {
-                        if let ::core::option::Option::Some(variant) = &mut self.r#payload {
-                            if let Rpc_::Payload::EventEspInit(variant) = &mut *variant {
-                                break &mut *variant;
-                            }
-                        }
-                        self.r#payload = ::core::option::Option::Some(Rpc_::Payload::EventEspInit(
-                            ::core::default::Default::default(),
-                        ));
-                    };
-                    mut_ref.decode_len_delimited(decoder)?;
-                }
-                770u32 => {
-                    let mut_ref = loop {
-                        if let ::core::option::Option::Some(variant) = &mut self.r#payload {
-                            if let Rpc_::Payload::EventHeartbeat(variant) = &mut *variant {
-                                break &mut *variant;
-                            }
-                        }
-                        self.r#payload = ::core::option::Option::Some(Rpc_::Payload::EventHeartbeat(
-                            ::core::default::Default::default(),
-                        ));
-                    };
-                    mut_ref.decode_len_delimited(decoder)?;
-                }
-                775u32 => {
-                    let mut_ref = loop {
-                        if let ::core::option::Option::Some(variant) = &mut self.r#payload {
-                            if let Rpc_::Payload::EventStaConnected(variant) = &mut *variant {
-                                break &mut *variant;
-                            }
-                        }
-                        self.r#payload = ::core::option::Option::Some(Rpc_::Payload::EventStaConnected(
-                            ::core::default::Default::default(),
-                        ));
-                    };
-                    mut_ref.decode_len_delimited(decoder)?;
-                }
-                776u32 => {
-                    let mut_ref = loop {
-                        if let ::core::option::Option::Some(variant) = &mut self.r#payload {
-                            if let Rpc_::Payload::EventStaDisconnected(variant) = &mut *variant {
-                                break &mut *variant;
-                            }
-                        }
-                        self.r#payload = ::core::option::Option::Some(Rpc_::Payload::EventStaDisconnected(
-                            ::core::default::Default::default(),
-                        ));
-                    };
-                    mut_ref.decode_len_delimited(decoder)?;
-                }
                 _ => {
                     decoder.skip_wire_value(tag.wire_type())?;
                 }
@@ -50063,67 +50011,6 @@ impl ::micropb::MessageEncode for Rpc {
                     break 'oneof (::core::result::Result::<usize, _>::Err(err));
                 }
             }
-            match ::micropb::const_map!(
-                ::micropb::const_map!(<Rpc_Event_ESPInit as ::micropb::MessageEncode>::MAX_SIZE, |size| {
-                    ::micropb::size::sizeof_len_record(size)
-                }),
-                |size| size + 2usize
-            ) {
-                ::core::result::Result::Ok(size) => {
-                    if size > max_size {
-                        max_size = size;
-                    }
-                }
-                ::core::result::Result::Err(err) => {
-                    break 'oneof (::core::result::Result::<usize, _>::Err(err));
-                }
-            }
-            match ::micropb::const_map!(
-                ::micropb::const_map!(<Rpc_Event_Heartbeat as ::micropb::MessageEncode>::MAX_SIZE, |size| {
-                    ::micropb::size::sizeof_len_record(size)
-                }),
-                |size| size + 2usize
-            ) {
-                ::core::result::Result::Ok(size) => {
-                    if size > max_size {
-                        max_size = size;
-                    }
-                }
-                ::core::result::Result::Err(err) => {
-                    break 'oneof (::core::result::Result::<usize, _>::Err(err));
-                }
-            }
-            match ::micropb::const_map!(
-                ::micropb::const_map!(<Rpc_Event_StaConnected as ::micropb::MessageEncode>::MAX_SIZE, |size| {
-                    ::micropb::size::sizeof_len_record(size)
-                }),
-                |size| size + 2usize
-            ) {
-                ::core::result::Result::Ok(size) => {
-                    if size > max_size {
-                        max_size = size;
-                    }
-                }
-                ::core::result::Result::Err(err) => {
-                    break 'oneof (::core::result::Result::<usize, _>::Err(err));
-                }
-            }
-            match ::micropb::const_map!(
-                ::micropb::const_map!(
-                    <Rpc_Event_StaDisconnected as ::micropb::MessageEncode>::MAX_SIZE,
-                    |size| ::micropb::size::sizeof_len_record(size)
-                ),
-                |size| size + 2usize
-            ) {
-                ::core::result::Result::Ok(size) => {
-                    if size > max_size {
-                        max_size = size;
-                    }
-                }
-                ::core::result::Result::Err(err) => {
-                    break 'oneof (::core::result::Result::<usize, _>::Err(err));
-                }
-            }
             ::core::result::Result::Ok(max_size)
         } {
             ::core::result::Result::Ok(size) => {
@@ -50353,26 +50240,6 @@ impl ::micropb::MessageEncode for Rpc {
                     encoder.encode_varint32(5146u32)?;
                     val_ref.encode_len_delimited(encoder)?;
                 }
-                Rpc_::Payload::EventEspInit(val_ref) => {
-                    let val_ref = &*val_ref;
-                    encoder.encode_varint32(6154u32)?;
-                    val_ref.encode_len_delimited(encoder)?;
-                }
-                Rpc_::Payload::EventHeartbeat(val_ref) => {
-                    let val_ref = &*val_ref;
-                    encoder.encode_varint32(6162u32)?;
-                    val_ref.encode_len_delimited(encoder)?;
-                }
-                Rpc_::Payload::EventStaConnected(val_ref) => {
-                    let val_ref = &*val_ref;
-                    encoder.encode_varint32(6202u32)?;
-                    val_ref.encode_len_delimited(encoder)?;
-                }
-                Rpc_::Payload::EventStaDisconnected(val_ref) => {
-                    let val_ref = &*val_ref;
-                    encoder.encode_varint32(6210u32)?;
-                    val_ref.encode_len_delimited(encoder)?;
-                }
             }
         }
         Ok(())
@@ -50552,22 +50419,6 @@ impl ::micropb::MessageEncode for Rpc {
                     let val_ref = &*val_ref;
                     size += 2usize + ::micropb::size::sizeof_len_record(val_ref.compute_size());
                 }
-                Rpc_::Payload::EventEspInit(val_ref) => {
-                    let val_ref = &*val_ref;
-                    size += 2usize + ::micropb::size::sizeof_len_record(val_ref.compute_size());
-                }
-                Rpc_::Payload::EventHeartbeat(val_ref) => {
-                    let val_ref = &*val_ref;
-                    size += 2usize + ::micropb::size::sizeof_len_record(val_ref.compute_size());
-                }
-                Rpc_::Payload::EventStaConnected(val_ref) => {
-                    let val_ref = &*val_ref;
-                    size += 2usize + ::micropb::size::sizeof_len_record(val_ref.compute_size());
-                }
-                Rpc_::Payload::EventStaDisconnected(val_ref) => {
-                    let val_ref = &*val_ref;
-                    size += 2usize + ::micropb::size::sizeof_len_record(val_ref.compute_size());
-                }
             }
         }
         size
@@ -50643,6 +50494,397 @@ pub mod Rpc_ {
         RespGetCoprocessorFwversion(super::Rpc_Resp_GetCoprocessorFwVersion),
         RespWifiScanGetApRecord(super::Rpc_Resp_WifiScanGetApRecord),
         RespFeatureControl(super::Rpc_Resp_FeatureControl),
+    }
+}
+#[derive(Debug, Default, PartialEq, Clone)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+pub struct RpcEvent {
+    /// msg_type could be req, resp or Event
+    pub r#msg_type: RpcType,
+    /// msg id
+    pub r#msg_id: RpcId,
+    /// UID of message
+    pub r#uid: u32,
+    /// union of all msg ids
+    ///
+    /// End of manual change
+    pub r#payload: ::core::option::Option<RpcEvent_::Payload>,
+}
+impl RpcEvent {
+    /// Return a reference to `msg_type`
+    #[inline]
+    pub fn r#msg_type(&self) -> &RpcType {
+        &self.r#msg_type
+    }
+    /// Return a mutable reference to `msg_type`
+    #[inline]
+    pub fn mut_msg_type(&mut self) -> &mut RpcType {
+        &mut self.r#msg_type
+    }
+    /// Set the value of `msg_type`
+    #[inline]
+    pub fn set_msg_type(&mut self, value: RpcType) -> &mut Self {
+        self.r#msg_type = value.into();
+        self
+    }
+    /// Builder method that sets the value of `msg_type`. Useful for initializing the message.
+    #[inline]
+    pub fn init_msg_type(mut self, value: RpcType) -> Self {
+        self.r#msg_type = value.into();
+        self
+    }
+    /// Return a reference to `msg_id`
+    #[inline]
+    pub fn r#msg_id(&self) -> &RpcId {
+        &self.r#msg_id
+    }
+    /// Return a mutable reference to `msg_id`
+    #[inline]
+    pub fn mut_msg_id(&mut self) -> &mut RpcId {
+        &mut self.r#msg_id
+    }
+    /// Set the value of `msg_id`
+    #[inline]
+    pub fn set_msg_id(&mut self, value: RpcId) -> &mut Self {
+        self.r#msg_id = value.into();
+        self
+    }
+    /// Builder method that sets the value of `msg_id`. Useful for initializing the message.
+    #[inline]
+    pub fn init_msg_id(mut self, value: RpcId) -> Self {
+        self.r#msg_id = value.into();
+        self
+    }
+    /// Return a reference to `uid`
+    #[inline]
+    pub fn r#uid(&self) -> &u32 {
+        &self.r#uid
+    }
+    /// Return a mutable reference to `uid`
+    #[inline]
+    pub fn mut_uid(&mut self) -> &mut u32 {
+        &mut self.r#uid
+    }
+    /// Set the value of `uid`
+    #[inline]
+    pub fn set_uid(&mut self, value: u32) -> &mut Self {
+        self.r#uid = value.into();
+        self
+    }
+    /// Builder method that sets the value of `uid`. Useful for initializing the message.
+    #[inline]
+    pub fn init_uid(mut self, value: u32) -> Self {
+        self.r#uid = value.into();
+        self
+    }
+}
+impl ::micropb::MessageDecode for RpcEvent {
+    fn decode<IMPL_MICROPB_READ: ::micropb::PbRead>(
+        &mut self,
+        decoder: &mut ::micropb::PbDecoder<IMPL_MICROPB_READ>,
+        len: usize,
+    ) -> Result<(), ::micropb::DecodeError<IMPL_MICROPB_READ::Error>> {
+        use ::micropb::{FieldDecode, PbBytes, PbMap, PbString, PbVec};
+        let before = decoder.bytes_read();
+        while decoder.bytes_read() - before < len {
+            let tag = decoder.decode_tag()?;
+            match tag.field_num() {
+                0 => return Err(::micropb::DecodeError::ZeroField),
+                1u32 => {
+                    let mut_ref = &mut self.r#msg_type;
+                    {
+                        let val = decoder.decode_int32().map(|n| RpcType(n as _))?;
+                        let val_ref = &val;
+                        if val_ref.0 != 0 {
+                            *mut_ref = val as _;
+                        }
+                    };
+                }
+                2u32 => {
+                    let mut_ref = &mut self.r#msg_id;
+                    {
+                        let val = decoder.decode_int32().map(|n| RpcId(n as _))?;
+                        let val_ref = &val;
+                        if val_ref.0 != 0 {
+                            *mut_ref = val as _;
+                        }
+                    };
+                }
+                3u32 => {
+                    let mut_ref = &mut self.r#uid;
+                    {
+                        let val = decoder.decode_varint32()?;
+                        let val_ref = &val;
+                        if *val_ref != 0 {
+                            *mut_ref = val as _;
+                        }
+                    };
+                }
+                769u32 => {
+                    let mut_ref = loop {
+                        if let ::core::option::Option::Some(variant) = &mut self.r#payload {
+                            if let RpcEvent_::Payload::EventEspInit(variant) = &mut *variant {
+                                break &mut *variant;
+                            }
+                        }
+                        self.r#payload = ::core::option::Option::Some(RpcEvent_::Payload::EventEspInit(
+                            ::core::default::Default::default(),
+                        ));
+                    };
+                    mut_ref.decode_len_delimited(decoder)?;
+                }
+                770u32 => {
+                    let mut_ref = loop {
+                        if let ::core::option::Option::Some(variant) = &mut self.r#payload {
+                            if let RpcEvent_::Payload::EventHeartbeat(variant) = &mut *variant {
+                                break &mut *variant;
+                            }
+                        }
+                        self.r#payload = ::core::option::Option::Some(RpcEvent_::Payload::EventHeartbeat(
+                            ::core::default::Default::default(),
+                        ));
+                    };
+                    mut_ref.decode_len_delimited(decoder)?;
+                }
+                775u32 => {
+                    let mut_ref = loop {
+                        if let ::core::option::Option::Some(variant) = &mut self.r#payload {
+                            if let RpcEvent_::Payload::EventStaConnected(variant) = &mut *variant {
+                                break &mut *variant;
+                            }
+                        }
+                        self.r#payload = ::core::option::Option::Some(RpcEvent_::Payload::EventStaConnected(
+                            ::core::default::Default::default(),
+                        ));
+                    };
+                    mut_ref.decode_len_delimited(decoder)?;
+                }
+                776u32 => {
+                    let mut_ref = loop {
+                        if let ::core::option::Option::Some(variant) = &mut self.r#payload {
+                            if let RpcEvent_::Payload::EventStaDisconnected(variant) = &mut *variant {
+                                break &mut *variant;
+                            }
+                        }
+                        self.r#payload = ::core::option::Option::Some(RpcEvent_::Payload::EventStaDisconnected(
+                            ::core::default::Default::default(),
+                        ));
+                    };
+                    mut_ref.decode_len_delimited(decoder)?;
+                }
+                _ => {
+                    decoder.skip_wire_value(tag.wire_type())?;
+                }
+            }
+        }
+        Ok(())
+    }
+}
+impl ::micropb::MessageEncode for RpcEvent {
+    const MAX_SIZE: ::core::result::Result<usize, &'static str> = 'msg: {
+        let mut max_size = 0;
+        match ::micropb::const_map!(::core::result::Result::Ok(RpcType::_MAX_SIZE), |size| size + 1usize) {
+            ::core::result::Result::Ok(size) => {
+                max_size += size;
+            }
+            ::core::result::Result::Err(err) => {
+                break 'msg (::core::result::Result::<usize, _>::Err(err));
+            }
+        }
+        match ::micropb::const_map!(::core::result::Result::Ok(RpcId::_MAX_SIZE), |size| size + 1usize) {
+            ::core::result::Result::Ok(size) => {
+                max_size += size;
+            }
+            ::core::result::Result::Err(err) => {
+                break 'msg (::core::result::Result::<usize, _>::Err(err));
+            }
+        }
+        match ::micropb::const_map!(::core::result::Result::Ok(5usize), |size| size + 1usize) {
+            ::core::result::Result::Ok(size) => {
+                max_size += size;
+            }
+            ::core::result::Result::Err(err) => {
+                break 'msg (::core::result::Result::<usize, _>::Err(err));
+            }
+        }
+        match 'oneof: {
+            let mut max_size = 0;
+            match ::micropb::const_map!(
+                ::micropb::const_map!(<Rpc_Event_ESPInit as ::micropb::MessageEncode>::MAX_SIZE, |size| {
+                    ::micropb::size::sizeof_len_record(size)
+                }),
+                |size| size + 2usize
+            ) {
+                ::core::result::Result::Ok(size) => {
+                    if size > max_size {
+                        max_size = size;
+                    }
+                }
+                ::core::result::Result::Err(err) => {
+                    break 'oneof (::core::result::Result::<usize, _>::Err(err));
+                }
+            }
+            match ::micropb::const_map!(
+                ::micropb::const_map!(<Rpc_Event_Heartbeat as ::micropb::MessageEncode>::MAX_SIZE, |size| {
+                    ::micropb::size::sizeof_len_record(size)
+                }),
+                |size| size + 2usize
+            ) {
+                ::core::result::Result::Ok(size) => {
+                    if size > max_size {
+                        max_size = size;
+                    }
+                }
+                ::core::result::Result::Err(err) => {
+                    break 'oneof (::core::result::Result::<usize, _>::Err(err));
+                }
+            }
+            match ::micropb::const_map!(
+                ::micropb::const_map!(<Rpc_Event_StaConnected as ::micropb::MessageEncode>::MAX_SIZE, |size| {
+                    ::micropb::size::sizeof_len_record(size)
+                }),
+                |size| size + 2usize
+            ) {
+                ::core::result::Result::Ok(size) => {
+                    if size > max_size {
+                        max_size = size;
+                    }
+                }
+                ::core::result::Result::Err(err) => {
+                    break 'oneof (::core::result::Result::<usize, _>::Err(err));
+                }
+            }
+            match ::micropb::const_map!(
+                ::micropb::const_map!(
+                    <Rpc_Event_StaDisconnected as ::micropb::MessageEncode>::MAX_SIZE,
+                    |size| ::micropb::size::sizeof_len_record(size)
+                ),
+                |size| size + 2usize
+            ) {
+                ::core::result::Result::Ok(size) => {
+                    if size > max_size {
+                        max_size = size;
+                    }
+                }
+                ::core::result::Result::Err(err) => {
+                    break 'oneof (::core::result::Result::<usize, _>::Err(err));
+                }
+            }
+            ::core::result::Result::Ok(max_size)
+        } {
+            ::core::result::Result::Ok(size) => {
+                max_size += size;
+            }
+            ::core::result::Result::Err(err) => {
+                break 'msg (::core::result::Result::<usize, _>::Err(err));
+            }
+        }
+        ::core::result::Result::Ok(max_size)
+    };
+    fn encode<IMPL_MICROPB_WRITE: ::micropb::PbWrite>(
+        &self,
+        encoder: &mut ::micropb::PbEncoder<IMPL_MICROPB_WRITE>,
+    ) -> Result<(), IMPL_MICROPB_WRITE::Error> {
+        use ::micropb::{FieldEncode, PbMap};
+        {
+            let val_ref = &self.r#msg_type;
+            if val_ref.0 != 0 {
+                encoder.encode_varint32(8u32)?;
+                encoder.encode_int32(val_ref.0 as _)?;
+            }
+        }
+        {
+            let val_ref = &self.r#msg_id;
+            if val_ref.0 != 0 {
+                encoder.encode_varint32(16u32)?;
+                encoder.encode_int32(val_ref.0 as _)?;
+            }
+        }
+        {
+            let val_ref = &self.r#uid;
+            if *val_ref != 0 {
+                encoder.encode_varint32(24u32)?;
+                encoder.encode_varint32(*val_ref as _)?;
+            }
+        }
+        if let Some(oneof) = &self.r#payload {
+            match &*oneof {
+                RpcEvent_::Payload::EventEspInit(val_ref) => {
+                    let val_ref = &*val_ref;
+                    encoder.encode_varint32(6154u32)?;
+                    val_ref.encode_len_delimited(encoder)?;
+                }
+                RpcEvent_::Payload::EventHeartbeat(val_ref) => {
+                    let val_ref = &*val_ref;
+                    encoder.encode_varint32(6162u32)?;
+                    val_ref.encode_len_delimited(encoder)?;
+                }
+                RpcEvent_::Payload::EventStaConnected(val_ref) => {
+                    let val_ref = &*val_ref;
+                    encoder.encode_varint32(6202u32)?;
+                    val_ref.encode_len_delimited(encoder)?;
+                }
+                RpcEvent_::Payload::EventStaDisconnected(val_ref) => {
+                    let val_ref = &*val_ref;
+                    encoder.encode_varint32(6210u32)?;
+                    val_ref.encode_len_delimited(encoder)?;
+                }
+            }
+        }
+        Ok(())
+    }
+    fn compute_size(&self) -> usize {
+        use ::micropb::{FieldEncode, PbMap};
+        let mut size = 0;
+        {
+            let val_ref = &self.r#msg_type;
+            if val_ref.0 != 0 {
+                size += 1usize + ::micropb::size::sizeof_int32(val_ref.0 as _);
+            }
+        }
+        {
+            let val_ref = &self.r#msg_id;
+            if val_ref.0 != 0 {
+                size += 1usize + ::micropb::size::sizeof_int32(val_ref.0 as _);
+            }
+        }
+        {
+            let val_ref = &self.r#uid;
+            if *val_ref != 0 {
+                size += 1usize + ::micropb::size::sizeof_varint32(*val_ref as _);
+            }
+        }
+        if let Some(oneof) = &self.r#payload {
+            match &*oneof {
+                RpcEvent_::Payload::EventEspInit(val_ref) => {
+                    let val_ref = &*val_ref;
+                    size += 2usize + ::micropb::size::sizeof_len_record(val_ref.compute_size());
+                }
+                RpcEvent_::Payload::EventHeartbeat(val_ref) => {
+                    let val_ref = &*val_ref;
+                    size += 2usize + ::micropb::size::sizeof_len_record(val_ref.compute_size());
+                }
+                RpcEvent_::Payload::EventStaConnected(val_ref) => {
+                    let val_ref = &*val_ref;
+                    size += 2usize + ::micropb::size::sizeof_len_record(val_ref.compute_size());
+                }
+                RpcEvent_::Payload::EventStaDisconnected(val_ref) => {
+                    let val_ref = &*val_ref;
+                    size += 2usize + ::micropb::size::sizeof_len_record(val_ref.compute_size());
+                }
+            }
+        }
+        size
+    }
+}
+/// Inner types for `RpcEvent`
+pub mod RpcEvent_ {
+    /// union of all msg ids
+    ///
+    /// End of manual change
+    #[derive(Debug, PartialEq, Clone)]
+    #[cfg_attr(feature = "defmt", derive(defmt::Format))]
+    pub enum Payload {
         ///* Notifications *
         EventEspInit(super::Rpc_Event_ESPInit),
         EventHeartbeat(super::Rpc_Event_Heartbeat),

--- a/embassy-net-esp-hosted/src/rpc/fg.rs
+++ b/embassy-net-esp-hosted/src/rpc/fg.rs
@@ -1,11 +1,12 @@
-use CtrlMsg_::Payload;
 use heapless::{String, Vec};
 use micropb::MessageDecode;
 
 use super::{HostedEvent, IoctlCtx, RpcBackend, check_resp};
 use crate::control::{Error, Security, Status};
+use crate::proto::fg::CtrlEvent_::Payload as EventPayload;
+use crate::proto::fg::CtrlMsg_::Payload;
 use crate::proto::fg::{
-    CtrlMsg, CtrlMsg_, CtrlMsg_Req_ConfigHeartbeat, CtrlMsg_Req_ConnectAP, CtrlMsg_Req_GetAPConfig,
+    CtrlEvent, CtrlMsg, CtrlMsg_Req_ConfigHeartbeat, CtrlMsg_Req_ConnectAP, CtrlMsg_Req_GetAPConfig,
     CtrlMsg_Req_GetMacAddress, CtrlMsg_Req_GetStatus, CtrlMsg_Req_OTABegin, CtrlMsg_Req_OTAEnd, CtrlMsg_Req_OTAWrite,
     CtrlMsg_Req_ScanResult, CtrlMsg_Req_SetMode, CtrlMsgId, CtrlMsgType, ScanResult,
 };
@@ -235,7 +236,7 @@ impl RpcBackend for FgBackend {
 
     #[inline]
     fn normalize_event(&self, raw: &[u8]) -> Option<HostedEvent> {
-        let mut event = CtrlMsg::default();
+        let mut event = CtrlEvent::default();
         if event.decode_from_bytes(raw).is_err() {
             warn!("failed to parse event");
             return None;
@@ -245,11 +246,10 @@ impl RpcBackend for FgBackend {
 
         let payload = event.payload.as_ref()?;
         match payload {
-            Payload::EventEspInit(_) => Some(HostedEvent::Init),
-            Payload::EventHeartbeat(_) => Some(HostedEvent::Heartbeat),
-            Payload::EventStationConnectedToAp(e) => Some(HostedEvent::StaConnected { resp: e.resp }),
-            Payload::EventStationDisconnectFromAp(e) => Some(HostedEvent::StaDisconnected { reason: e.reason }),
-            _ => None,
+            EventPayload::EventEspInit(_) => Some(HostedEvent::Init),
+            EventPayload::EventHeartbeat(_) => Some(HostedEvent::Heartbeat),
+            EventPayload::EventStationConnectedToAp(e) => Some(HostedEvent::StaConnected { resp: e.resp }),
+            EventPayload::EventStationDisconnectFromAp(e) => Some(HostedEvent::StaDisconnected { reason: e.reason }),
         }
     }
 }

--- a/embassy-net-esp-hosted/src/rpc/mcu.rs
+++ b/embassy-net-esp-hosted/src/rpc/mcu.rs
@@ -4,12 +4,13 @@ use micropb::MessageDecode;
 use super::{HostedEvent, IoctlCtx, RpcBackend, check_resp};
 use crate::control::{Error, Security, Status};
 use crate::proto::mcu::Rpc_::Payload;
+use crate::proto::mcu::RpcEvent_::Payload as EventPayload;
 use crate::proto::mcu::{
     Rpc, Rpc_Req_ConfigHeartbeat, Rpc_Req_GetCoprocessorFwVersion, Rpc_Req_GetMacAddress, Rpc_Req_OTAActivate,
     Rpc_Req_OTABegin, Rpc_Req_OTAEnd, Rpc_Req_OTAWrite, Rpc_Req_SetMode, Rpc_Req_WifiClearApList, Rpc_Req_WifiConnect,
     Rpc_Req_WifiDisconnect, Rpc_Req_WifiInit, Rpc_Req_WifiScanGetApNum, Rpc_Req_WifiScanGetApRecord,
-    Rpc_Req_WifiScanStart, Rpc_Req_WifiSetConfig, Rpc_Req_WifiStaGetApInfo, Rpc_Req_WifiStart, RpcId, RpcType,
-    wifi_ap_record, wifi_config, wifi_config_, wifi_init_config, wifi_scan_threshold, wifi_sta_config,
+    Rpc_Req_WifiScanStart, Rpc_Req_WifiSetConfig, Rpc_Req_WifiStaGetApInfo, Rpc_Req_WifiStart, RpcEvent, RpcId,
+    RpcType, wifi_ap_record, wifi_config, wifi_config_, wifi_init_config, wifi_scan_threshold, wifi_sta_config,
 };
 #[cfg(feature = "bluetooth")]
 use crate::proto::mcu::{Rpc_Req_FeatureControl, RpcFeature, RpcFeatureCommand, RpcFeatureOption};
@@ -330,7 +331,7 @@ impl RpcBackend for McuBackend {
 
     #[inline]
     fn normalize_event(&self, raw: &[u8]) -> Option<HostedEvent> {
-        let mut event = Rpc::default();
+        let mut event = RpcEvent::default();
         if event.decode_from_bytes(raw).is_err() {
             warn!("failed to parse event");
             return None;
@@ -340,13 +341,12 @@ impl RpcBackend for McuBackend {
 
         let payload = event.payload.as_ref()?;
         match payload {
-            Payload::EventEspInit(_) => Some(HostedEvent::Init),
-            Payload::EventHeartbeat(_) => Some(HostedEvent::Heartbeat),
-            Payload::EventStaConnected(e) => Some(HostedEvent::StaConnected { resp: e.resp }),
-            Payload::EventStaDisconnected(e) => Some(HostedEvent::StaDisconnected {
+            EventPayload::EventEspInit(_) => Some(HostedEvent::Init),
+            EventPayload::EventHeartbeat(_) => Some(HostedEvent::Heartbeat),
+            EventPayload::EventStaConnected(e) => Some(HostedEvent::StaConnected { resp: e.resp }),
+            EventPayload::EventStaDisconnected(e) => Some(HostedEvent::StaDisconnected {
                 reason: e.sta_disconnected().map(|d| d.reason).unwrap_or(0),
             }),
-            _ => None,
         }
     }
 }


### PR DESCRIPTION
A small .proto edit to save a few kB on code size. Hopefully probably shrinks the runner's stack requirement as well (`normalize_event` no longer stack-allocates an entire message object (up to 800 bytes)), but I haven't checked it.
