### PR TITLE
stm32/cryp: zero npblb when starting a new op

### DIFF
--- a/embassy-stm32/src/cryp/mod.rs
+++ b/embassy-stm32/src/cryp/mod.rs
@@ -1092,6 +1092,9 @@ impl<'d, T: Instance, M: Mode> Cryp<'d, T, M> {
 
         ctx.cipher.init_phase_blocking(T::regs(), self);
 
+        #[cfg(any(cryp_v3, cryp_v4))]
+        T::regs().cr().modify(|w| w.set_npblb(0));
+
         self.store_context(&mut ctx);
 
         ctx
@@ -1560,6 +1563,9 @@ impl<'d, T: Instance> Cryp<'d, T, Async> {
         T::regs().cr().modify(|w| w.set_fflush(true));
 
         ctx.cipher.init_phase(T::regs(), self).await;
+
+        #[cfg(any(cryp_v3, cryp_v4))]
+        T::regs().cr().modify(|w| w.set_npblb(0));
 
         self.store_context(&mut ctx);
 


### PR DESCRIPTION
The NPBLB field is never zeroed by the driver and only written for operations with a partial final block.
When performing a block-aligned op preceded by a non-block-aligned op, this leads to an incorrect AES-GCM tag.
Zeroing NPBLB unconditionally fixes this issue.