### PR TITLE
Fix/i2cv2 zero length transfers

### DIFF
--- a/embassy-stm32/CHANGELOG.md
+++ b/embassy-stm32/CHANGELOG.md
@@ -27,6 +27,7 @@ DMA:
 - feat: stm32/dma: add `TwoDItem`, `TwoDConfig`, and `LinkedListItem` trait; `Table` is now generic over item type
 
 I2C:
+- feat: stm32/i2cv2: support zero-length transfers instead of returning `Error::ZeroLengthTransfer`, enabling bus scans via `transaction(addr, &mut [Operation::Write(&[])])`. On the slave side an empty `respond_to_write` accepts zero bytes and an empty `respond_to_read` sends `0xFF` filler, since I2C cannot encode "nothing to send"; both previously left ADDR set, holding SCL low and wedging the bus
 - fix: stm32/i2cv2: handle a master RESTART during async slave `respond_to_read` instead of stalling until the transaction times out
 - fix: stm32/i2cv2: re-enable TCIE after starting a DMA write group, so an async `transaction()` whose write group is not the first group completes instead of hanging until it times out
 

--- a/embassy-stm32/CHANGELOG.md
+++ b/embassy-stm32/CHANGELOG.md
@@ -26,6 +26,10 @@ DMA:
 - feat: stm32/dma: GPDMA: allow access to construct custom LinkedList chains for scatter/gather DMA
 - feat: stm32/dma: add `TwoDItem`, `TwoDConfig`, and `LinkedListItem` trait; `Table` is now generic over item type
 
+I2C:
+- fix: stm32/i2cv2: handle a master RESTART during async slave `respond_to_read` instead of stalling until the transaction times out
+- fix: stm32/i2cv2: re-enable TCIE after starting a DMA write group, so an async `transaction()` whose write group is not the first group completes instead of hanging until it times out
+
 ADC:
 - feat: stm32/adc: add `VrefInt::calibrated_value()` for additional chips
 

--- a/embassy-stm32/src/i2c/v2.rs
+++ b/embassy-stm32/src/i2c/v2.rs
@@ -12,6 +12,18 @@ use stm32_metapac::i2c::vals::{Addmode, Oamsk};
 use super::*;
 use crate::pac::i2c;
 
+/// Bytes a slave transmits when it is read but has nothing to send.
+///
+/// I2C has no encoding for "nothing to send": once a slave ACKs an address with R=1 it is the
+/// transmitter and must drive the MSB of a data byte at the next SCL low. `0xFF` leaves SDA
+/// released for every bit, which is both what an idle bus reads as and what lets the master
+/// generate its STOP or repeated START at any point — driving a `0` bit would hold SDA low and
+/// prevent the master from forming a STOP at all.
+///
+/// A master that reads past this length under-runs the slave, which also releases SDA, so the
+/// wire keeps reading `0xFF`. The length only bounds how much is queued, not what is seen.
+const SLAVE_READ_FILLER: [u8; 16] = [0xFF; 16];
+
 impl From<AddrMask> for Oamsk {
     fn from(value: AddrMask) -> Self {
         match value {
@@ -600,10 +612,6 @@ impl<'d, M: Mode, IM: MasterMode> I2c<'d, M, IM> {
         addr: impl Into<Address>,
         operations: &mut [Operation<'_>],
     ) -> Result<(), Error> {
-        if operations.is_empty() {
-            return Err(Error::ZeroLengthTransfer);
-        }
-
         let address = addr.into();
         let timeout = self.timeout();
 
@@ -661,11 +669,13 @@ impl<'d, M: Mode, IM: MasterMode> I2c<'d, M, IM> {
 
         if total_bytes == 0 {
             // Handle empty write group - just send address
-            if is_first_group {
-                Self::master_write(self.info, address, 0, Stop::Software, false, !is_first_group, timeout)?;
-            }
+            Self::master_write(self.info, address, 0, Stop::Software, false, !is_first_group, timeout)?;
             if is_last_group {
+                self.wait_tc(timeout)?;
                 self.master_stop();
+                self.wait_stop(timeout)?;
+            } else {
+                self.wait_tc(timeout)?;
             }
             return Ok(());
         }
@@ -735,17 +745,15 @@ impl<'d, M: Mode, IM: MasterMode> I2c<'d, M, IM> {
 
         if total_bytes == 0 {
             // Handle empty read group
-            if is_first_group {
-                Self::master_read(
-                    self.info,
-                    address,
-                    0,
-                    if is_last_group { Stop::Automatic } else { Stop::Software },
-                    false, // reload
-                    !is_first_group,
-                    timeout,
-                )?;
-            }
+            Self::master_read(
+                self.info,
+                address,
+                0,
+                if is_last_group { Stop::Automatic } else { Stop::Software },
+                false, // reload
+                !is_first_group,
+                timeout,
+            )?;
             if is_last_group {
                 self.wait_stop(timeout)?;
             } else {
@@ -818,7 +826,7 @@ impl<'d, M: Mode, IM: MasterMode> I2c<'d, M, IM> {
     /// The buffers are concatenated in a single write transaction.
     pub fn blocking_write_vectored(&mut self, address: u8, write: &[&[u8]]) -> Result<(), Error> {
         if write.is_empty() {
-            return Err(Error::ZeroLengthTransfer);
+            return self.write_internal(address.into(), &[], true, self.timeout());
         }
 
         let timeout = self.timeout();
@@ -1181,7 +1189,7 @@ impl<'d, IM: MasterMode> I2c<'d, Async, IM> {
         let timeout = self.timeout();
 
         if write.is_empty() {
-            return Err(Error::ZeroLengthTransfer);
+            return self.write_internal(address, &[], true, timeout);
         }
 
         let mut iter = write.iter();
@@ -1260,9 +1268,6 @@ impl<'d, IM: MasterMode> I2c<'d, Async, IM> {
         operations: &mut [Operation<'_>],
     ) -> Result<(), Error> {
         let _scoped_wake_guard = self.info.rcc.wake_guard();
-        if operations.is_empty() {
-            return Err(Error::ZeroLengthTransfer);
-        }
 
         let address = addr.into();
         let timeout = self.timeout();
@@ -1323,11 +1328,13 @@ impl<'d, IM: MasterMode> I2c<'d, Async, IM> {
 
         if total_bytes == 0 {
             // Handle empty write group using blocking call
-            if is_first_group {
-                Self::master_write(self.info, address, 0, Stop::Software, false, !is_first_group, timeout)?;
-            }
+            Self::master_write(self.info, address, 0, Stop::Software, false, !is_first_group, timeout)?;
             if is_last_group {
+                self.wait_tc(timeout)?;
                 self.master_stop();
+                self.wait_stop(timeout)?;
+            } else {
+                self.wait_tc(timeout)?;
             }
             return Ok(());
         }
@@ -1380,17 +1387,15 @@ impl<'d, IM: MasterMode> I2c<'d, Async, IM> {
 
         if total_bytes == 0 {
             // Handle empty read group using blocking call
-            if is_first_group {
-                Self::master_read(
-                    self.info,
-                    address,
-                    0,
-                    if is_last_group { Stop::Automatic } else { Stop::Software },
-                    false, // reload
-                    !is_first_group,
-                    timeout,
-                )?;
-            }
+            Self::master_read(
+                self.info,
+                address,
+                0,
+                if is_last_group { Stop::Automatic } else { Stop::Software },
+                false, // reload
+                !is_first_group,
+                timeout,
+            )?;
             if is_last_group {
                 self.wait_stop(timeout)?;
             } else {
@@ -1710,6 +1715,16 @@ impl<'d, M: Mode> I2c<'d, M, MultiMaster> {
     // Receives data into the provided buffer. If the master sends more data than the buffer
     // can hold, excess bytes are acknowledged but discarded.
     fn slave_read_internal(&self, read: &mut [u8], timeout: Timeout) -> Result<usize, Error> {
+        if read.is_empty() {
+            // No chunks means the loop below never runs, so slave_start would never be
+            // reached and ADDR would stay set — holding SCL low and wedging the bus for
+            // every device on it. Clear it here, then let the drain wait out the frame.
+            trace!("--- Slave RX zero-length, releasing clock stretch");
+            Self::slave_start(self.info, 0, false);
+            self.drain_rxdr_until_stop(timeout)?;
+            return Ok(0);
+        }
+
         let completed_chunks = read.len() / 255;
         let total_chunks = if completed_chunks * 255 == read.len() {
             completed_chunks
@@ -1910,6 +1925,10 @@ impl<'d, M: Mode> I2c<'d, M, MultiMaster> {
     /// If the master sends more data than the buffer can hold, excess bytes are
     /// acknowledged but discarded.
     ///
+    /// An empty `buffer` accepts zero bytes: the address phase is acknowledged and the
+    /// transfer ends at the master's STOP or repeated START. This is what a master's
+    /// zero-length write (a bus-scan address probe) looks like from the slave side.
+    ///
     /// Returns the number of bytes actually stored in `buffer`.
     pub fn blocking_respond_to_write(&self, buffer: &mut [u8]) -> Result<usize, Error> {
         let timeout = self.timeout();
@@ -1921,10 +1940,22 @@ impl<'d, M: Mode> I2c<'d, M, MultiMaster> {
     /// Transmits the provided data to the master. The master controls how many bytes
     /// it reads by sending a NACK after the last byte it wants.
     ///
+    /// An empty `write` means "nothing to send", which I2C cannot express: having ACKed an
+    /// address with R=1 the slave is the transmitter and must drive a byte. It therefore
+    /// sends [`SLAVE_READ_FILLER`] and reports [`SendStatus::Done`]. See that constant for
+    /// why the filler is `0xFF`.
+    ///
     /// Returns [`SendStatus::Done`] if all bytes were sent, or [`SendStatus::LeftoverBytes`]
     /// if the master ended the transfer early (sent NACK before all data was transmitted).
     pub fn blocking_respond_to_read(&mut self, write: &[u8]) -> Result<SendStatus, Error> {
         let timeout = self.timeout();
+        if write.is_empty() {
+            // Untransmitted filler is not something the caller can act on, so normalise
+            // whatever the master took to Done.
+            return self
+                .slave_write_internal(&SLAVE_READ_FILLER, timeout)
+                .map(|_| SendStatus::Done);
+        }
         self.slave_write_internal(write, timeout)
     }
 }
@@ -1962,6 +1993,10 @@ impl<'d> I2c<'d, Async, MultiMaster> {
     /// If the master sends more data than the buffer can hold, excess bytes are
     /// acknowledged but discarded.
     ///
+    /// An empty `buffer` accepts zero bytes: the address phase is acknowledged and the
+    /// transfer ends at the master's STOP or repeated START. This is what a master's
+    /// zero-length write (a bus-scan address probe) looks like from the slave side.
+    ///
     /// Returns the number of bytes actually stored in `buffer`.
     pub async fn respond_to_write(&mut self, buffer: &mut [u8]) -> Result<usize, Error> {
         let _scoped_wake_guard = self.info.rcc.wake_guard();
@@ -1970,9 +2005,22 @@ impl<'d> I2c<'d, Async, MultiMaster> {
     }
 
     /// Respond to a read request from an I2C master.
+    ///
+    /// An empty `write` means "nothing to send", which I2C cannot express: having ACKed an
+    /// address with R=1 the slave is the transmitter and must drive a byte. It therefore
+    /// sends [`SLAVE_READ_FILLER`] and reports [`SendStatus::Done`]. See that constant for
+    /// why the filler is `0xFF`.
     pub async fn respond_to_read(&mut self, write: &[u8]) -> Result<SendStatus, Error> {
         let _scoped_wake_guard = self.info.rcc.wake_guard();
         let timeout = self.timeout();
+        if write.is_empty() {
+            // Untransmitted filler is not something the caller can act on, so normalise
+            // whatever the master took to Done.
+            return timeout
+                .with(self.write_dma_internal_slave(&SLAVE_READ_FILLER, timeout))
+                .await
+                .map(|_| SendStatus::Done);
+        }
         timeout.with(self.write_dma_internal_slave(write, timeout)).await
     }
 
@@ -1985,6 +2033,59 @@ impl<'d> I2c<'d, Async, MultiMaster> {
         let mut remaining_len = total_len;
 
         let regs = self.info.regs;
+
+        if total_len == 0 {
+            // Nothing to receive, so no DMA — a zero-length transfer would trip
+            // `assert!(mem_len > 0)` in the DMA layer. Clear ADDR to release the clock
+            // stretch, then wait out the frame; leaving ADDR set would wedge the bus.
+            trace!("--- Slave RX zero-length, releasing clock stretch");
+            Self::slave_start(self.info, 0, false);
+
+            let state = self.state;
+            regs.cr1().modify(|w| {
+                w.set_stopie(true);
+                w.set_addrie(true);
+            });
+            let on_drop = OnDrop::new(|| {
+                regs.cr1().modify(|w| {
+                    w.set_stopie(false);
+                    w.set_addrie(false);
+                });
+            });
+
+            let result = poll_fn(|cx| {
+                state.waker.register(cx.waker());
+
+                let isr = regs.isr().read();
+                if isr.stopf() {
+                    regs.icr().write(|w| w.set_stopcf(true));
+                    return Poll::Ready(Ok(0));
+                }
+                if isr.addr() {
+                    // Repeated START — leave ADDR set for the next listen() to pick up.
+                    return Poll::Ready(Ok(0));
+                }
+                if isr.rxne() {
+                    // The caller asked for no data but the master sent some anyway. RXDR must
+                    // be drained: while a received byte sits unread the hardware stretches SCL
+                    // to avoid an overrun, so the master could never reach the STOP we are
+                    // waiting for. Same reason blocking uses drain_rxdr_until_stop.
+                    let _ = regs.rxdr().read().rxdata();
+                    cx.waker().wake_by_ref();
+                    return Poll::Pending;
+                }
+                // Re-enable in case the interrupt handler disabled them on a spurious wake.
+                regs.cr1().modify(|w| {
+                    w.set_stopie(true);
+                    w.set_addrie(true);
+                });
+                Poll::Pending
+            });
+
+            let out = timeout.with(result).await;
+            drop(on_drop);
+            return out;
+        }
 
         let mut dma_transfer = unsafe {
             regs.cr1().modify(|w| {

--- a/embassy-stm32/src/i2c/v2.rs
+++ b/embassy-stm32/src/i2c/v2.rs
@@ -748,6 +748,8 @@ impl<'d, M: Mode, IM: MasterMode> I2c<'d, M, IM> {
             }
             if is_last_group {
                 self.wait_stop(timeout)?;
+            } else {
+                self.wait_tc(timeout)?;
             }
             return Ok(());
         }
@@ -995,8 +997,15 @@ impl<'d, IM: MasterMode> I2c<'d, Async, IM> {
                         Stop::Software,
                         timeout,
                     )?;
-                    self.info.regs.cr1().modify(|w| w.set_tcie(true));
                 }
+                // Re-enable TCIE unconditionally, after START/NBYTES has cleared TC.
+                //
+                // When this is not the first group of a transaction the previous group
+                // leaves TC set, so enabling TCIE before this poll fires the event
+                // interrupt straight away — and the handler disables TCIE again. Without
+                // re-enabling it here the real completion never raises an interrupt and
+                // the future waits until the transaction times out.
+                self.info.regs.cr1().modify(|w| w.set_tcie(true));
             } else if !(isr.tcr() || isr.tc()) {
                 // poll_fn was woken without an interrupt present
                 return Poll::Pending;
@@ -1384,6 +1393,8 @@ impl<'d, IM: MasterMode> I2c<'d, Async, IM> {
             }
             if is_last_group {
                 self.wait_stop(timeout)?;
+            } else {
+                self.wait_tc(timeout)?;
             }
             return Ok(());
         }
@@ -2098,6 +2109,7 @@ impl<'d> I2c<'d, Async, MultiMaster> {
                 w.set_txdmaen(true);
                 w.set_stopie(true);
                 w.set_tcie(true);
+                w.set_addrie(true); // Enable to detect RESTART condition
             });
             let dst = regs.txdr().as_ptr() as *mut u8;
 
@@ -2110,6 +2122,7 @@ impl<'d> I2c<'d, Async, MultiMaster> {
                 w.set_txdmaen(false);
                 w.set_stopie(false);
                 w.set_tcie(false);
+                w.set_addrie(false);
             });
             regs.isr().write(|w| w.set_txe(true));
         });
@@ -2127,6 +2140,7 @@ impl<'d> I2c<'d, Async, MultiMaster> {
                 self.info.regs.cr1().modify(|w| {
                     w.set_tcie(true);
                     w.set_stopie(true);
+                    w.set_addrie(true);
                 });
                 Poll::Pending
             } else if isr.tcr() {
@@ -2144,8 +2158,45 @@ impl<'d> I2c<'d, Async, MultiMaster> {
                 self.info.regs.cr1().modify(|w| {
                     w.set_tcie(true);
                     w.set_stopie(true);
+                    w.set_addrie(true);
                 });
                 Poll::Pending
+            } else if isr.berr() {
+                // BERR: misplaced START — the master issued a RESTART while we were
+                // transmitting. ERRIE is not enabled on this path, so BERR does not wake us
+                // by itself; we are woken by ADDR (which the hardware sets at the same time)
+                // and clear BERR here so it does not leak into the next transaction.
+                // Do NOT clear ADDR — listen() polls that flag to pick up the new address
+                // that followed the RESTART.
+                self.info.regs.icr().modify(|w| w.set_berrcf(true));
+                let mut leftover = dma_transfer.get_remaining_transfers() as usize;
+                if !self.info.regs.isr().read().txe() {
+                    leftover = leftover.saturating_add(1);
+                }
+                remaining_len = remaining_len.saturating_add(leftover);
+                if remaining_len > 0 {
+                    dma_transfer.request_pause();
+                    Poll::Ready(Ok(SendStatus::LeftoverBytes(remaining_len)))
+                } else {
+                    Poll::Ready(Ok(SendStatus::Done))
+                }
+            } else if isr.addr() && remaining_len != total_len {
+                // ADDR while transmitting: RESTART with a new address, on chips where BERR was
+                // not also set. The remaining_len != total_len guard mirrors
+                // read_dma_internal_slave: ADDR is still set from the listen() that got us here
+                // until slave_start clears it, so this must not fire before the transfer starts.
+                // Do NOT clear ADDR — let listen() handle the new transaction.
+                let mut leftover = dma_transfer.get_remaining_transfers() as usize;
+                if !self.info.regs.isr().read().txe() {
+                    leftover = leftover.saturating_add(1);
+                }
+                remaining_len = remaining_len.saturating_add(leftover);
+                if remaining_len > 0 {
+                    dma_transfer.request_pause();
+                    Poll::Ready(Ok(SendStatus::LeftoverBytes(remaining_len)))
+                } else {
+                    Poll::Ready(Ok(SendStatus::Done))
+                }
             } else if isr.stopf() {
                 let mut leftover_bytes = dma_transfer.get_remaining_transfers();
                 if !self.info.regs.isr().read().txe() {
@@ -2168,6 +2219,7 @@ impl<'d> I2c<'d, Async, MultiMaster> {
                 self.info.regs.cr1().modify(|w| {
                     w.set_tcie(true);
                     w.set_stopie(true);
+                    w.set_addrie(true);
                 });
                 Poll::Pending
             }


### PR DESCRIPTION
Fixes #2298. Supersedes #6336, which was closed for not being hardware tested.

Zero-length transfers returned `Error::ZeroLengthTransfer` instead of sending
the address, check ACK/NACK, issue a STOP, so bus scanning was impossible.

## What changed

**Master.** An empty operations slice is a no-op returning `Ok(())`. A zero-length group always
emits the address phase, not only when it is the first group, and waits for TC so a following
group's RESTART cannot race it. `write_vectored` with an empty outer slice no longer errors.

**Slave.** An empty `respond_to_write` accepts zero bytes. An empty `respond_to_read` sends
`0xFF` filler: I2C cannot encode "nothing to send" once the slave has ACKed an address with R=1
and become the transmitter, and `0xFF` releases SDA on every bit so the master can still form
its STOP. Both previously returned without clearing ADDR — which occurs in exactly one place in
`v2.rs`, inside `slave_start` — leaving SCL held low and the bus unusable for every device on
it. `blocking_respond_to_write` reported `Ok(0)` while doing so. The async forms tripped
`assert!(mem_len > 0)` in the DMA layer first. embedded-hal's `transaction` contract does not
define zero-length behaviour, so the chosen semantics are documented on all four methods.

**The first commit is two unrelated pre-existing bugs**, kept separate so they survive a revert
of the zero-length work. `write_dma_internal` re-enabled TCIE only on its reload path: when the
write group is not the first group, the previous group leaves TC set, enabling TCIE fires the
interrupt immediately, `on_interrupt` disables it again, and the TC ending the data phase never
wakes the future. And `write_dma_internal_slave` did not enable ADDRIE, so a master RESTART
mid-DMA was ignored until the timeout expired.

Neither involves a zero-length transfer. Both reproduce on `main` with
`transaction(addr, [Read(&mut [0u8; 1]), Write(&[0xAB])])` — against a pristine bus the very
first attempt times out:

```
### A: async [Read(1), Write(1)] - no zero-length involved
### A0 begin
### A0: Timeout          <-- origin/main
### A0: Ok, read 0xff    <-- this branch
```

## Hardware test

NUCLEO-H503RB master ↔ NUCLEO-H533RE async DMA slave at `0x42`, I2C2 on PB10 (SCL) / PB3 (SDA),
50 kHz, internal pull-ups. 14 master-side cases per round covering zero-length reads, writes and
empty operation slices on both the blocking and async paths, plus ordinary
write / read / write_read as regression guards. Slave-side cases read SCL/SDA out of `GPIOB.IDR`
so a stretched bus is observed directly rather than inferred from a timeout.

## Notes for reviewers

- `Error::ZeroLengthTransfer` is now produced nowhere in `v2.rs` or `v1.rs`. I left the variant
  in place.
