### PR TITLE
cyw43: set link down on AP-initiated DEAUTH_IND / DISASSOC_IND

### DIFF
--- a/cyw43/src/runner.rs
+++ b/cyw43/src/runner.rs
@@ -1077,8 +1077,12 @@ impl<'a, BUS: Bus, CHIP: Chip> Runner<'a, BUS, CHIP> {
                     // Events indicating that the link is down
                     // Event LINK with flag 0 indicates link down. reason = 1: loss of signal (e.g. out of range), reason = 2: controlled network shutdown
                     // Event AUTH with status FAIL, reason 16, and auth_type 3 is specific for WPA3 networks
+                    // Event DEAUTH_IND is an AP-initiated deauth (e.g. AP reset); any status/reason means the link is down
+                    // Event DISASSOC_IND is an AP-initiated disassoc (e.g. idle-station inactivity timeout); any status/reason means the link is down
                     (Event::LINK, EStatus::SUCCESS, 0, ..)
                     | (Event::DEAUTH, EStatus::SUCCESS, ..)
+                    | (Event::DEAUTH_IND, ..)
+                    | (Event::DISASSOC_IND, ..)
                     | (Event::AUTH, EStatus::FAIL, _, 16, 3) => {
                         self.auth_ok = false;
                         self.join_ok = false;


### PR DESCRIPTION
Previously the link was only brought down on a locally-initiated DEAUTH, a generic LINK-down, or a WPA3 auth failure. When an AP disassociates an idle station (for example on an inactivity timeout, sending an 802.11 disassoc) it sends DEAUTH_IND (6) or DISASSOC_IND (12) instead, which were ignored. The link state therefore stayed Up after the AP had already dropped the station: a silent stall with no link-down event for the application to reconnect on, with the IP retained but every packet black-holing because the AP no longer has the station's MAC.

This treats both indications as link-down so the application is notified and can reconnect. They mean the peer dropped us regardless of status or reason, so they always bring the link down.

Tested on RP2350 (CYW43439) hardware against an AP that reaps idle stations on an inactivity timeout: the station now sees a prompt link-down and reconnects, instead of stalling silently until the next outgoing packet.
