### PR TITLE
stm32: PtpTimeProvider

### DIFF
--- a/embassy-stm32/src/eth/ptp.rs
+++ b/embassy-stm32/src/eth/ptp.rs
@@ -8,6 +8,7 @@ pub struct PtpTimestamp {
     pub nanos: u32,
 }
 
+#[cfg(feature = "ptp")]
 impl PtpTimestamp {
     /// Add a duration to this timestamp.
     ///
@@ -50,7 +51,6 @@ impl PtpTimestamp {
         Some(core::time::Duration::new(seconds as u64, nanos))
     }
 
-    #[cfg(feature = "ptp")]
     pub(crate) fn from_offset_nanos(offset_nanos: i64) -> (Self, bool) {
         let subtract = offset_nanos < 0;
         let nanos = if subtract {
@@ -285,7 +285,7 @@ pub(crate) use imp::PtpTimestampSink;
 #[cfg(feature = "ptp")]
 pub use imp::PtpTimestampStore;
 
-#[cfg(test)]
+#[cfg(all(test, feature = "ptp"))]
 mod tests {
     use core::time::Duration;
 

--- a/embassy-stm32/src/eth/ptp.rs
+++ b/embassy-stm32/src/eth/ptp.rs
@@ -9,6 +9,47 @@ pub struct PtpTimestamp {
 }
 
 impl PtpTimestamp {
+    /// Add a duration to this timestamp.
+    ///
+    /// Returns `None` if the resulting timestamp does not fit in the MAC PTP
+    /// seconds field.
+    pub const fn checked_add_duration(&self, duration: core::time::Duration) -> Option<Self> {
+        let duration_seconds = duration.as_secs();
+        if duration_seconds > u32::MAX as u64 {
+            return None;
+        }
+
+        let nanos = self.nanos as u64 + duration.subsec_nanos() as u64;
+        let seconds = self.seconds as u64 + duration_seconds + nanos / 1_000_000_000;
+        if seconds > u32::MAX as u64 {
+            return None;
+        }
+
+        Some(Self {
+            seconds: seconds as u32,
+            nanos: (nanos % 1_000_000_000) as u32,
+        })
+    }
+
+    /// Return the duration between this timestamp and an earlier timestamp.
+    ///
+    /// Returns `None` if `earlier` is after this timestamp.
+    pub const fn checked_duration_since(&self, earlier: Self) -> Option<core::time::Duration> {
+        if self.seconds < earlier.seconds || (self.seconds == earlier.seconds && self.nanos < earlier.nanos) {
+            return None;
+        }
+
+        let mut seconds = self.seconds - earlier.seconds;
+        let nanos = if self.nanos >= earlier.nanos {
+            self.nanos - earlier.nanos
+        } else {
+            seconds -= 1;
+            (self.nanos as u64 + 1_000_000_000 - earlier.nanos as u64) as u32
+        };
+
+        Some(core::time::Duration::new(seconds as u64, nanos))
+    }
+
     #[cfg(feature = "ptp")]
     pub(crate) fn from_offset_nanos(offset_nanos: i64) -> (Self, bool) {
         let subtract = offset_nanos < 0;
@@ -243,5 +284,69 @@ mod imp {
 pub(crate) use imp::PtpTimestampSink;
 #[cfg(feature = "ptp")]
 pub use imp::PtpTimestampStore;
+
+#[cfg(test)]
+mod tests {
+    use core::time::Duration;
+
+    use super::PtpTimestamp;
+
+    #[test]
+    fn timestamp_add_duration_carries_nanos() {
+        assert_eq!(
+            PtpTimestamp {
+                seconds: 10,
+                nanos: 900_000_000,
+            }
+            .checked_add_duration(Duration::from_millis(250)),
+            Some(PtpTimestamp {
+                seconds: 11,
+                nanos: 150_000_000,
+            })
+        );
+    }
+
+    #[test]
+    fn timestamp_add_duration_checks_overflow() {
+        assert_eq!(
+            PtpTimestamp {
+                seconds: u32::MAX,
+                nanos: 999_999_999,
+            }
+            .checked_add_duration(Duration::from_nanos(1)),
+            None
+        );
+    }
+
+    #[test]
+    fn timestamp_duration_since_borrows_nanos() {
+        assert_eq!(
+            PtpTimestamp {
+                seconds: 12,
+                nanos: 100_000_000,
+            }
+            .checked_duration_since(PtpTimestamp {
+                seconds: 10,
+                nanos: 900_000_000,
+            }),
+            Some(Duration::from_millis(1200))
+        );
+    }
+
+    #[test]
+    fn timestamp_duration_since_checks_order() {
+        assert_eq!(
+            PtpTimestamp {
+                seconds: 10,
+                nanos: 100,
+            }
+            .checked_duration_since(PtpTimestamp {
+                seconds: 10,
+                nanos: 101,
+            }),
+            None
+        );
+    }
+}
 #[cfg(feature = "ptp")]
 pub(crate) use imp::{RxPtpRing, TxPtpRing};

--- a/embassy-stm32/src/eth/v2/mod.rs
+++ b/embassy-stm32/src/eth/v2/mod.rs
@@ -7,7 +7,7 @@ use core::sync::atomic::{Ordering, fence};
 pub(crate) use descriptors::{RDes, RDesRing, TDes, TDesRing};
 use embassy_hal_internal::Peri;
 #[cfg(feature = "ptp")]
-pub use ptp::{PtpClock, PtpClockConfig, PtpSubsecondIncrement};
+pub use ptp::{PtpClock, PtpClockConfig, PtpSubsecondIncrement, PtpTimeProvider};
 #[cfg(eth_v2)]
 use stm32_metapac::syscfg::vals::EthSelPhy;
 

--- a/embassy-stm32/src/eth/v2/ptp.rs
+++ b/embassy-stm32/src/eth/v2/ptp.rs
@@ -1,4 +1,4 @@
-use core::marker::PhantomData;
+use core::{fmt, marker::PhantomData};
 
 use super::Instance;
 use crate::eth::ptp::PtpTimestamp;
@@ -91,6 +91,34 @@ pub struct PtpClock<T: Instance> {
     _peri: PhantomData<T>,
 }
 
+/// Read-only provider for the Ethernet MAC PTP time.
+pub struct PtpTimeProvider<T: Instance> {
+    _peri: PhantomData<T>,
+}
+
+impl<T: Instance> Clone for PtpTimeProvider<T> {
+    fn clone(&self) -> Self {
+        Self::new()
+    }
+}
+
+impl<T: Instance> fmt::Debug for PtpTimeProvider<T> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("PtpTimeProvider").finish()
+    }
+}
+
+impl<T: Instance> PtpTimeProvider<T> {
+    const fn new() -> Self {
+        Self { _peri: PhantomData }
+    }
+
+    /// Read the current MAC PTP time.
+    pub fn now(&self) -> PtpTimestamp {
+        read_timestamp::<T>()
+    }
+}
+
 impl<T: Instance> PtpClock<T> {
     pub(crate) fn start(config: PtpClockConfig) -> Self {
         let hclk = unwrap!(unsafe { crate::rcc::get_freqs() }.hclk1.to_hertz());
@@ -120,16 +148,14 @@ impl<T: Instance> PtpClock<T> {
         self.rate.nominal_addend
     }
 
+    /// Return a read-only provider for the MAC PTP time.
+    pub fn time_provider(&self) -> PtpTimeProvider<T> {
+        PtpTimeProvider::new()
+    }
+
     /// Read the current MAC PTP time.
     pub fn now(&self) -> PtpTimestamp {
-        let mac = T::regs().ethernet_mac();
-        loop {
-            let seconds = mac.macstsr().read().tss();
-            let nanos = mac.macstnr().read().tsss();
-            if seconds == mac.macstsr().read().tss() {
-                return PtpTimestamp { seconds, nanos };
-            }
-        }
+        read_timestamp::<T>()
     }
 
     /// Set the MAC PTP time.
@@ -175,6 +201,17 @@ impl<T: Instance> PtpClock<T> {
             w.set_snaptypsel(0b01);
             w.set_txtsstsm(true);
         });
+    }
+}
+
+fn read_timestamp<T: Instance>() -> PtpTimestamp {
+    let mac = T::regs().ethernet_mac();
+    loop {
+        let seconds = mac.macstsr().read().tss();
+        let nanos = mac.macstnr().read().tsss();
+        if seconds == mac.macstsr().read().tss() {
+            return PtpTimestamp { seconds, nanos };
+        }
     }
 }
 

--- a/embassy-stm32/src/eth/v2/ptp.rs
+++ b/embassy-stm32/src/eth/v2/ptp.rs
@@ -1,4 +1,5 @@
-use core::{fmt, marker::PhantomData};
+use core::fmt;
+use core::marker::PhantomData;
 
 use super::Instance;
 use crate::eth::ptp::PtpTimestamp;


### PR DESCRIPTION
This adds `PtpTimeProvider`, a ZST read only `Clone`-handle that safely dishes out `PtpTimestamp`. It's modelled after `RtcTimeProvider`.
The PR also adds two helper methods to provide basic interfacing with `core::time::Duration`. `Add`/`Sub` traits or converters from/into other Instant/Duration/Interval types do not appear well-defined or useful right now.