### PR TITLE
stm32/adc: set smp in v1

### DIFF
--- a/embassy-stm32/src/adc/v1.rs
+++ b/embassy-stm32/src/adc/v1.rs
@@ -181,6 +181,8 @@ impl AdcRegs for crate::pac::adc::Adc {
             "F0/L0 channels must be passed in order.",
         );
 
+        self.smpr().modify(|reg| reg.set_smp(sample_time.into()));
+
         self.cfgr1().modify(|w| {
             w.set_scandir(if is_ordered_up {
                 Scandir::Upward


### PR DESCRIPTION
closes #6357.