### PR TITLE
embassy-sync: make `Signal::poll_wait` public

### DIFF
--- a/embassy-sync/CHANGELOG.md
+++ b/embassy-sync/CHANGELOG.md
@@ -25,6 +25,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added `Pipe::try_write_all` method which repeatedly calls `Pipe::try_write` until all
   bytes were written.
 - Implement `core::error::Error` for `channel::TryReceiveError` and `channel::TrySendError`.
+- Made `Signal::poll_wait` public.
 
 ## 0.8.0 - 2026-03-10
 - Fix wakers getting dropped by `Signal::reset`

--- a/embassy-sync/src/signal.rs
+++ b/embassy-sync/src/signal.rs
@@ -86,7 +86,8 @@ where
         self.try_take();
     }
 
-    fn poll_wait(&self, cx: &mut Context<'_>) -> Poll<T> {
+    /// Poll for state changes of this Signal.
+    pub fn poll_wait(&self, cx: &mut Context<'_>) -> Poll<T> {
         self.state.lock(|cell| {
             let state = cell.replace(State::None);
             match state {


### PR DESCRIPTION
Similar functions are exposed for other primitives, so it makes sense to do this here to, as `Signal::wait` is just a poll_fn calling said function.