### PR TITLE
STM32: Add config option to v3 ADC to set the ADC clock prescaler and

### DIFF
--- a/embassy-stm32/src/adc/v3.rs
+++ b/embassy-stm32/src/adc/v3.rs
@@ -8,6 +8,8 @@ use pac::adc::vals::Dmacfg;
 use pac::adc::vals::{OversamplingRatio, OversamplingShift, Rovsm, Trovs};
 #[cfg(adc_g0)]
 pub use pac::adc::vals::{Ovsr, Ovss, Presc};
+#[cfg(any(adc_h5, adc_h7rs))]
+use pac::adccommon::vals::Presc;
 
 #[allow(unused_imports)]
 use crate::adc::SealedAdcChannel;
@@ -146,6 +148,9 @@ pub struct AdcConfig {
     pub oversampling_mode: Option<(Rovsm, Trovs, bool)>,
     #[cfg(adc_g0)]
     pub clock: Option<Clock>,
+    #[cfg(any(adc_h5, adc_h7rs))]
+    /// Clock prescaler for the ker_ck_input clock
+    pub prescaler: Option<Presc>,
     pub resolution: Option<Resolution>,
     pub averaging: Option<Averaging>,
 }
@@ -460,14 +465,27 @@ impl<'d, T: Instance<Regs = crate::pac::adc::Adc>> Adc<'d, T> {
     }
 
     pub fn new_with_config(adc: Peri<'d, T>, config: AdcConfig) -> Self {
-        #[cfg(not(adc_g0))]
-        let s = Self::new(adc);
+        #[cfg(any(adc_h5, adc_h7rs))]
+        let s = {
+            Self::init_regulator();
+            // Configure the prescaler before running the calibration
+            if let Some(prescaler) = config.prescaler {
+                T::common_regs().ccr().modify(|w| w.set_presc(prescaler));
+            }
+
+            Self::init_calibrate();
+
+            Self { adc }
+        };
 
         #[cfg(adc_g0)]
         let s = match config.clock {
             Some(clock) => Self::new_with_clock(adc, clock),
             None => Self::new(adc),
         };
+
+        #[cfg(not(any(adc_g0, adc_h5, adc_h7rs)))]
+        let s = Self::new(adc);
 
         #[cfg(any(adc_g0, adc_u0, adc_v3))]
         if let Some(shift) = config.oversampling_shift {

--- a/examples/stm32h5/src/bin/adc.rs
+++ b/examples/stm32h5/src/bin/adc.rs
@@ -4,7 +4,8 @@
 use defmt::*;
 use embassy_executor::Spawner;
 use embassy_stm32::Config;
-use embassy_stm32::adc::{Adc, SampleTime};
+use embassy_stm32::adc::{Adc, AdcConfig, SampleTime};
+use embassy_stm32::pac::adccommon::vals::Presc;
 use embassy_time::Timer;
 use {defmt_rtt as _, panic_probe as _};
 
@@ -43,7 +44,9 @@ async fn main(_spawner: Spawner) {
 
     info!("Hello World!");
 
-    let mut adc = Adc::new(p.ADC1);
+    let mut adc_config = AdcConfig::default();
+    adc_config.prescaler = Some(Presc::Div256);
+    let mut adc = Adc::new_with_config(p.ADC1, adc_config);
 
     let mut vrefint_channel = adc.enable_vrefint();
 


### PR DESCRIPTION
Adds a config option for the ADC prescaler to scale down the internal ADC clock on H5 and H7RS.

Configures the prescaler before calibrating

Also updates the H5 example to use the prescaler to test