### PR TITLE
stm32/timer: fix 32-bit capture register truncation in input capture futures

### DIFF
--- a/embassy-stm32/src/timer/input_capture.rs
+++ b/embassy-stm32/src/timer/input_capture.rs
@@ -483,12 +483,20 @@ impl<T: GeneralInstance4Channel> Future for InputCaptureFuture<T> {
     type Output = T::Word;
 
     fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+        #[cfg(stm32l0)]
+        use crate::pac::timer::TimGp16 as timer;
+        #[cfg(not(stm32l0))]
+        use crate::pac::timer::TimGp32 as timer;
+
         T::state().cc_waker[self.channel.index()].register(cx.waker());
 
-        let regs = unsafe { crate::pac::timer::TimGp16::from_ptr(T::regs()) };
+        let regs = unsafe { timer::from_ptr(T::regs()) };
 
         let dier = regs.dier().read();
         if !dier.ccie(self.channel.index()) {
+            #[cfg(not(stm32l0))]
+            let val = unwrap!(regs.ccr(self.channel.index()).read().try_into());
+            #[cfg(stm32l0)]
             let val = unwrap!(regs.ccr(self.channel.index()).read().ccr().try_into());
             Poll::Ready(val)
         } else {

--- a/embassy-stm32/src/timer/pwm_input.rs
+++ b/embassy-stm32/src/timer/pwm_input.rs
@@ -175,13 +175,21 @@ impl<T: GeneralInstance4Channel> Future for PwmInputFuture<T> {
     type Output = u32;
 
     fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+        #[cfg(stm32l0)]
+        use crate::pac::timer::TimGp16 as timer;
+        #[cfg(not(stm32l0))]
+        use crate::pac::timer::TimGp32 as timer;
+
         T::state().cc_waker[self.channel.index()].register(cx.waker());
 
-        let regs = unsafe { crate::pac::timer::TimGp16::from_ptr(T::regs()) };
+        let regs = unsafe { timer::from_ptr(T::regs()) };
 
         let dier = regs.dier().read();
         if !dier.ccie(self.channel.index()) {
-            let val = regs.ccr(self.channel.index()).read().0;
+            #[cfg(not(stm32l0))]
+            let val = regs.ccr(self.channel.index()).read();
+            #[cfg(stm32l0)]
+            let val = regs.ccr(self.channel.index()).read().ccr() as u32;
             Poll::Ready(val)
         } else {
             Poll::Pending


### PR DESCRIPTION
The input capture and PWM input futures read the capture register through a 16-bit register view, silently truncating values on 32-bit timers. Use the 32-bit register view on non-stm32l0 targets to preserve the full register width.

From an application perspective, this makes it seem like the timer is wrapping because the lower 16 bits get reset after crossing 0xFFFF