### PR TITLE
[Embassy-rp] more defmt derives

### DIFF
--- a/embassy-rp/src/adc.rs
+++ b/embassy-rp/src/adc.rs
@@ -19,6 +19,7 @@ static WAKER: AtomicWaker = AtomicWaker::new();
 /// ADC config.
 #[non_exhaustive]
 #[derive(Default)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub struct Config {}
 
 #[derive(Debug)]

--- a/embassy-rp/src/aon_timer/mod.rs
+++ b/embassy-rp/src/aon_timer/mod.rs
@@ -224,6 +224,7 @@ pub enum AlarmWakeMode {
 
 /// AON Timer configuration
 #[derive(Clone, Copy)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub struct Config {
     /// Clock source for the timer
     pub clock_source: ClockSource,
@@ -248,6 +249,7 @@ impl Default for Config {
 
 /// Clock source for the AON Timer
 #[derive(Clone, Copy, PartialEq, Eq, Debug)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub enum ClockSource {
     /// Crystal oscillator (more accurate, requires external crystal)
     Xosc,

--- a/embassy-rp/src/block.rs
+++ b/embassy-rp/src/block.rs
@@ -224,6 +224,7 @@ pub const PARTITION_TABLE_MAX_ITEMS: usize = 128;
 
 /// Describes a unpartitioned space
 #[derive(Debug, Clone, PartialEq, Eq, Default)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub struct UnpartitionedSpace {
     permissions_and_location: u32,
     permissions_and_flags: u32,
@@ -341,6 +342,7 @@ impl core::fmt::Display for UnpartitionedSpace {
 
 /// Describes a Partition
 #[derive(Debug, Clone, PartialEq, Eq)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub struct Partition {
     permissions_and_location: u32,
     permissions_and_flags: u32,
@@ -588,6 +590,7 @@ impl core::fmt::Display for Partition {
 ///
 /// Don't store this as a static - make sure you convert it to a block.
 #[derive(Clone)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub struct PartitionTableBlock {
     /// This must look like a block, including the 1 word header and the 3 word footer.
     contents: [u32; PARTITION_TABLE_MAX_ITEMS],
@@ -773,6 +776,7 @@ impl Default for PartitionTableBlock {
 
 /// Flags that a Partition can have
 #[derive(Debug, Copy, Clone, PartialEq, Eq)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 #[repr(u32)]
 #[allow(missing_docs)]
 pub enum PartitionFlag {
@@ -789,6 +793,7 @@ pub enum PartitionFlag {
 
 /// Flags that a Partition can have
 #[derive(Debug, Copy, Clone, PartialEq, Eq)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 #[repr(u32)]
 #[allow(missing_docs)]
 pub enum UnpartitionedFlag {
@@ -803,6 +808,7 @@ pub enum UnpartitionedFlag {
 
 /// Kinds of linked partition
 #[derive(Debug, Copy, Clone, PartialEq, Eq)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub enum Link {
     /// Not linked to anything
     Nothing,
@@ -820,6 +826,7 @@ pub enum Link {
 
 /// Permissions that a Partition can have
 #[derive(Debug, Copy, Clone, PartialEq, Eq)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 #[repr(u32)]
 pub enum Permission {
     /// Can be read in Secure Mode
@@ -857,6 +864,7 @@ impl Permission {
 
 /// The supported RP2350 CPU architectures
 #[derive(Debug, Copy, Clone, PartialEq, Eq)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub enum Architecture {
     /// Core is in Arm Cortex-M33 mode
     Arm,
@@ -866,6 +874,7 @@ pub enum Architecture {
 
 /// The kinds of Secure Boot we support
 #[derive(Debug, Copy, Clone)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub enum Security {
     /// Security mode not given
     Unspecified,

--- a/embassy-rp/src/clocks.rs
+++ b/embassy-rp/src/clocks.rs
@@ -134,6 +134,7 @@ static CLOCKS: Clocks = Clocks {
 #[repr(u8)]
 #[non_exhaustive]
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub enum PeriClkSrc {
     /// SYS.
     Sys = ClkPeriCtrlAuxsrc::ClkSys as _,
@@ -273,6 +274,7 @@ impl CoreVoltage {
 
 /// Clock configuration.
 #[non_exhaustive]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub struct ClockConfig {
     /// Ring oscillator configuration.
     pub rosc: Option<RoscConfig>,
@@ -633,6 +635,7 @@ pub enum RoscRange {
 }
 
 /// On-chip ring oscillator configuration.
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub struct RoscConfig {
     /// Final frequency of the oscillator, after the divider has been applied.
     /// The oscillator has a nominal frequency of 6.5MHz at medium range with
@@ -648,6 +651,7 @@ pub struct RoscConfig {
 }
 
 /// Crystal oscillator configuration.
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub struct XoscConfig {
     /// Final frequency of the oscillator.
     pub hz: u32,
@@ -661,6 +665,7 @@ pub struct XoscConfig {
 
 /// PLL configuration.
 #[derive(Clone, Copy, Debug)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub struct PllConfig {
     /// Reference divisor.
     pub refdiv: u8,
@@ -717,6 +722,7 @@ impl PllConfig {
 }
 
 /// Reference clock config.
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub struct RefClkConfig {
     /// Reference clock source.
     pub src: RefClkSrc,
@@ -761,6 +767,7 @@ pub enum SysClkSrc {
 }
 
 /// SYS clock config.
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub struct SysClkConfig {
     /// SYS clock source.
     pub src: SysClkSrc,
@@ -798,6 +805,7 @@ pub enum UsbClkSrc {
 }
 
 /// USB clock config.
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub struct UsbClkConfig {
     /// USB clock source.
     pub src: UsbClkSrc,
@@ -827,6 +835,7 @@ pub enum AdcClkSrc {
 }
 
 /// ADC clock config.
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub struct AdcClkConfig {
     /// ADC clock source.
     pub src: AdcClkSrc,
@@ -858,6 +867,7 @@ pub enum RtcClkSrc {
 
 /// RTC clock config.
 #[cfg(feature = "rp2040")]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub struct RtcClkConfig {
     /// RTC clock source.
     pub src: RtcClkSrc,
@@ -1657,6 +1667,7 @@ impl_gpoutpin!(PIN_25, 3);
 
 /// Gpout clock source.
 #[repr(u8)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub enum GpoutSrc {
     /// Sys PLL.
     PllSys = ClkGpoutCtrlAuxsrc::ClksrcPllSys as _,

--- a/embassy-rp/src/datetime/datetime_no_deps.rs
+++ b/embassy-rp/src/datetime/datetime_no_deps.rs
@@ -24,6 +24,7 @@ pub enum Error {
 
 /// Structure containing date and time information
 #[derive(Clone, Debug)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub struct DateTime {
     /// 0..4095
     pub year: u16,

--- a/embassy-rp/src/i2c.rs
+++ b/embassy-rp/src/i2c.rs
@@ -68,6 +68,7 @@ pub enum ConfigError {
 /// I2C config.
 #[non_exhaustive]
 #[derive(Copy, Clone)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub struct Config {
     /// Frequency.
     pub frequency: u32,

--- a/embassy-rp/src/lib.rs
+++ b/embassy-rp/src/lib.rs
@@ -597,6 +597,7 @@ pub mod config {
 
     /// HAL configuration passed when initializing.
     #[non_exhaustive]
+    #[cfg_attr(feature = "defmt", derive(defmt::Format))]
     pub struct Config {
         /// Clock configuration.
         pub clocks: ClockConfig,

--- a/embassy-rp/src/pio/mod.rs
+++ b/embassy-rp/src/pio/mod.rs
@@ -631,6 +631,7 @@ impl Into<crate::pac::pio::vals::ExecctrlStatusN> for StatusN {
 
 /// PIO config.
 #[derive(Clone, Copy, Debug)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub struct Config<'d, PIO: Instance> {
     /// Clock divisor register for state machines.
     pub clock_divider: FixedU32<U8>,

--- a/embassy-rp/src/pio_programs/rotary_encoder.rs
+++ b/embassy-rp/src/pio_programs/rotary_encoder.rs
@@ -97,6 +97,7 @@ impl<'d, T: Instance, const SM: usize> PioEncoder<'d, T, SM> {
 }
 
 /// Encoder Count Direction
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub enum Direction {
     /// Encoder turned clockwise
     Clockwise,

--- a/embassy-rp/src/psram.rs
+++ b/embassy-rp/src/psram.rs
@@ -30,6 +30,7 @@ pub enum Error {
 
 /// PSRAM device verification type.
 #[derive(Clone, Copy)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub enum VerificationType {
     /// Skip device verification
     None,
@@ -39,6 +40,7 @@ pub enum VerificationType {
 
 /// Memory configuration.
 #[derive(Clone)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub struct Config {
     /// System clock frequency in Hz
     pub clock_hz: u32,
@@ -76,6 +78,7 @@ pub struct Config {
 
 /// Page break configuration for memory window operations.
 #[derive(Clone, Copy)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub enum PageBreak {
     /// No page breaks
     None,
@@ -89,6 +92,7 @@ pub enum PageBreak {
 
 /// Format configuration for read/write operations.
 #[derive(Clone)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub struct FormatConfig {
     /// Width of command prefix phase
     pub prefix_width: Width,
@@ -108,6 +112,7 @@ pub struct FormatConfig {
 
 /// Interface width for different phases of SPI transfer.
 #[derive(Clone, Copy)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub enum Width {
     /// Single-bit (standard SPI)
     Single,

--- a/embassy-rp/src/pwm.rs
+++ b/embassy-rp/src/pwm.rs
@@ -16,6 +16,7 @@ use crate::{RegExt, pac, peripherals};
 /// `(top + 1) * (phase_correct ? 1 : 2) * divider`
 #[non_exhaustive]
 #[derive(Clone)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub struct Config {
     /// Inverts the PWM output signal on channel A.
     pub invert_a: bool,
@@ -63,6 +64,7 @@ impl Default for Config {
 }
 
 /// PWM input mode.
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub enum InputMode {
     /// Level mode.
     Level,
@@ -84,6 +86,7 @@ impl From<InputMode> for Divmode {
 
 /// PWM error.
 #[derive(Debug)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub enum PwmError {
     /// Invalid Duty Cycle.
     InvalidDutyCycle,

--- a/embassy-rp/src/rtc/mod.rs
+++ b/embassy-rp/src/rtc/mod.rs
@@ -288,6 +288,7 @@ impl crate::interrupt::typelevel::Handler<crate::interrupt::typelevel::RTC_IRQ> 
 
 /// Errors that can occur on methods on [Rtc]
 #[derive(Clone, Debug, PartialEq, Eq)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub enum RtcError {
     /// An invalid DateTime was given or stored on the hardware.
     InvalidDateTime(DateTimeError),

--- a/embassy-rp/src/spi.rs
+++ b/embassy-rp/src/spi.rs
@@ -44,17 +44,22 @@ impl Default for Config {
 impl defmt::Format for Config {
     fn format(&self, f: defmt::Formatter) {
         let phase = match self.phase {
-            Phase::CaptureOnFirstTransition => "CaptureOnFirstTransition",
-            Phase::CaptureOnSecondTransition => "CaptureOnSecondTransition",
+            Phase::CaptureOnFirstTransition => {
+                defmt::intern!("CaptureOnFirstTransition")
+            }
+            Phase::CaptureOnSecondTransition => {
+                defmt::intern!("CaptureOnSecondTransition")
+            }
         };
+
         let polarity = match self.polarity {
-            Polarity::IdleLow => "IdleLow",
-            Polarity::IdleHigh => "IdleHigh",
+            Polarity::IdleLow => defmt::intern!("IdleLow"),
+            Polarity::IdleHigh => defmt::intern!("IdleHigh"),
         };
 
         defmt::write!(
             f,
-            "Config {{ frequency: {=u32}, phase: {}, polarity: {} }}",
+            "Config {{ frequency: {=u32}, phase: {=istr}, polarity: {=istr} }}",
             self.frequency,
             phase,
             polarity,

--- a/embassy-rp/src/spi.rs
+++ b/embassy-rp/src/spi.rs
@@ -40,6 +40,28 @@ impl Default for Config {
     }
 }
 
+#[cfg(feature = "defmt")]
+impl defmt::Format for Config {
+    fn format(&self, f: defmt::Formatter) {
+        let phase = match self.phase {
+            Phase::CaptureOnFirstTransition => "CaptureOnFirstTransition",
+            Phase::CaptureOnSecondTransition => "CaptureOnSecondTransition",
+        };
+        let polarity = match self.polarity {
+            Polarity::IdleLow => "IdleLow",
+            Polarity::IdleHigh => "IdleHigh",
+        };
+
+        defmt::write!(
+            f,
+            "Config {{ frequency: {=u32}, phase: {}, polarity: {} }}",
+            self.frequency,
+            phase,
+            polarity,
+        );
+    }
+}
+
 /// SPI driver.
 pub struct Spi<'d, M: Mode> {
     info: &'static Info,

--- a/embassy-rp/src/trng.rs
+++ b/embassy-rp/src/trng.rs
@@ -40,6 +40,7 @@ impl Instance for TRNG {
 }
 
 #[derive(Copy, Clone, Debug)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 #[allow(missing_docs)]
 /// TRNG ROSC Inverter chain length options.
 pub enum InverterChainLength {
@@ -88,6 +89,7 @@ impl From<InverterChainLength> for u8 {
 /// either hardware accelerated SHA256 (Bootrom) or xoroshiro128** (version 1.0!).
 #[non_exhaustive]
 #[derive(Copy, Clone, Debug)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub struct Config {
     /// Bypass TRNG autocorrelation test
     pub disable_autocorrelation_test: bool,

--- a/embassy-rp/src/uart/mod.rs
+++ b/embassy-rp/src/uart/mod.rs
@@ -23,6 +23,7 @@ pub use buffered::{BufferedInterruptHandler, BufferedUart, BufferedUartRx, Buffe
 
 /// Word length.
 #[derive(Clone, Copy, PartialEq, Eq, Debug)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub enum DataBits {
     /// 5 bits.
     DataBits5,
@@ -47,6 +48,7 @@ impl DataBits {
 
 /// Parity bit.
 #[derive(Clone, Copy, PartialEq, Eq, Debug)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub enum Parity {
     /// No parity.
     ParityNone,
@@ -58,6 +60,7 @@ pub enum Parity {
 
 /// Stop bits.
 #[derive(Clone, Copy, PartialEq, Eq, Debug)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub enum StopBits {
     #[doc = "1 stop bit"]
     STOP1,
@@ -68,6 +71,7 @@ pub enum StopBits {
 /// UART config.
 #[non_exhaustive]
 #[derive(Clone, Copy, PartialEq, Eq, Debug)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub struct Config {
     /// Baud rate.
     pub baudrate: u32,

--- a/embassy-rp/src/watchdog.rs
+++ b/embassy-rp/src/watchdog.rs
@@ -15,6 +15,7 @@ use crate::{Peri, pac};
 
 /// The reason for a system reset from the watchdog.
 #[derive(Debug, Copy, Clone, PartialEq, Eq)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub enum ResetReason {
     /// The reset was forced.
     Forced,


### PR DESCRIPTION
Hi, quick PR with a few more `#[cfg_attr(feature = "defmt", derive(defmt::Format))]` in embassy-rp


Disclaimer: I originally only targeted the uart config structs/enums but had a few tokens laying around so asked an llm (gpt5.5) to try and find other cases where such derive could be useful. Hope that's ok