### PR TITLE
Update fixed for embassy-rp

### DIFF
--- a/embassy-rp/CHANGELOG.md
+++ b/embassy-rp/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## Unreleased - ReleaseDate
 - Fix i2c_slave respond_to_read for buffers larger than one chunk
 
+- Update `fixed` dependency
 - DMA: clear channel `EN` bit before `chan_abort` on RP2350, per errata RP2350-E5 (see pico-sdk `dma_channel_abort` docs). Prevents the aborted channel from re-triggering.
 - PIO: add `Config::set_input_sync_bypass` to declare input synchronizer bypass pins; the bypass is applied inside `StateMachine::set_config` once `GPIOBASE` is established, fixing bypass for pins >= 32 on RP2350B.
 - breaking: Remove `<T: Instance>` from `Spi`, `I2c` and `I2cSlave` ([#4900](https://github.com/embassy-rs/embassy/pull/4900))

--- a/embassy-rp/Cargo.toml
+++ b/embassy-rp/Cargo.toml
@@ -48,7 +48,7 @@ default = [ "rt" ]
 rt = [ "rp-pac/rt" ]
 
 ## Enable [defmt support](https://docs.rs/defmt) and enables `defmt` debug-log messages and formatting in embassy drivers.
-defmt = ["dep:defmt", "embassy-usb-driver/defmt", "embassy-hal-internal/defmt", "chrono?/defmt"]
+defmt = ["dep:defmt", "embassy-usb-driver/defmt", "embassy-hal-internal/defmt", "chrono?/defmt", "fixed/defmt"]
 ## Enable log support
 log = ["dep:log"]
 ## Enable chrono support
@@ -183,7 +183,7 @@ embedded-io = { version = "0.7.1" }
 embedded-io-async = { version = "0.7.0" }
 embedded-storage = { version = "0.3" }
 embedded-storage-async = { version = "0.4.1" }
-fixed = "1.28.0"
+fixed = "1.31.0"
 
 rp-pac = { git = "https://github.com/embassy-rs/rp-pac", rev = "c2e27609b021c444f634673155318977d7f0bdf6" }
 


### PR DESCRIPTION
Blocks: #6373
See #6373 for further details (TL/DR: newer versions of `fixed` adds support for `defmt` but requires a bump in msrv)

Question: I have no idea what to do about msrv itself, version bump to every crate? patch? minor? major? technically this is breaking change right?