### PR TITLE
stm32/exti: make from_input and from_flex unsafe

### DIFF
--- a/embassy-stm32/src/exti/mod.rs
+++ b/embassy-stm32/src/exti/mod.rs
@@ -143,7 +143,7 @@ impl<'d> ExtiInput<'d, Async> {
     /// token. The pin retains its current pull configuration.
     ///
     /// The Binding must bind the Channel's IRQ to [InterruptHandler].
-    pub fn from_input<C: Channel>(
+    pub unsafe fn from_input<C: Channel>(
         pin: Input<'d>,
         _ch: Peri<'d, C>,
         _irq: impl Binding<C::IRQ, InterruptHandler<C::IRQ>>,
@@ -165,7 +165,7 @@ impl<'d> ExtiInput<'d, Async> {
     /// before calling this.
     ///
     /// The Binding must bind the Channel's IRQ to [InterruptHandler].
-    pub fn from_flex<C: Channel>(
+    pub unsafe fn from_flex<C: Channel>(
         pin: Flex<'d>,
         _ch: Peri<'d, C>,
         _irq: impl Binding<C::IRQ, InterruptHandler<C::IRQ>>,

--- a/examples/stm32n6-flashboot/app/src/main.rs
+++ b/examples/stm32n6-flashboot/app/src/main.rs
@@ -126,7 +126,7 @@ async fn main(spawner: Spawner) {
     let user_button = ExtiInput::new(p.PC13, p.EXTI13, Pull::Down, Irqs);
     spawner.spawn(user_button_task(user_button, green_led).unwrap());
 
-    let pe0_exti = ExtiInput::from_input(pe0, p.EXTI0, Irqs);
+    let pe0_exti = unsafe { ExtiInput::from_input(pe0, p.EXTI0, Irqs) };
     spawner.spawn(mark_booted_task(pe0_exti).unwrap());
 
     info!("Blinking red LED. Hold PE0 3s to confirm boot.");


### PR DESCRIPTION
closes #6368.