### PR TITLE
mcxa/flexspi: fix AHBCR.AFLASHBASE memory-mapped bug + SDK register alignment

### DIFF
--- a/embassy-mcxa/src/flexspi.rs
+++ b/embassy-mcxa/src/flexspi.rs
@@ -627,7 +627,14 @@ impl<'d, M: Mode> InnerFlexSpi<'d, M> {
             r.set_readaddropt(pac::flexspi::Readaddropt::Val0);
             r.set_resumedisable(pac::flexspi::Resumedisable::Val0);
             r.set_readszalign(pac::flexspi::Readszalign::Val0);
-            r.set_aflashbase(0x8);
+            // AFLASHBASE (AHBCR[31:28], 256 MB-granular) must stay 0 on MCXA577.
+            // The SoC bus matrix strips the AHB window base (secure 0x9000_0000 /
+            // non-secure 0x8000_0000) and presents the controller a window-relative
+            // offset, so there is no base to subtract here. Any non-zero value folds
+            // high bits into the internal flash address that then exceed
+            // FLSHCR0.FLSHSZ, making every memory-mapped (AHB/XIP) access bus-fault.
+            // The NXP SDK likewise never programs this field on this part.
+            r.set_aflashbase(0);
         });
         self.info.regs.ahbrxbuf0cr0().write(|r: &mut Ahbrxbuf0cr0| {
             r.set_bufsz(0xff);

--- a/embassy-mcxa/src/flexspi.rs
+++ b/embassy-mcxa/src/flexspi.rs
@@ -28,8 +28,8 @@ use crate::gpio::{DriveStrength, GpioPin, Pull, SlewRate};
 use crate::interrupt::typelevel::{Handler, Interrupt};
 pub use crate::pac::flexspi::Flexspi as Regs;
 use crate::pac::flexspi::{
-    Ahbcr, Ahbrxbuf0cr0, Flshcr0, Flshcr1, Flshcr2, Flshcr4, Intr, Ipcmd, Ipcr0, Ipcr1, Iprxfcr, Iptxfcr, Lut, Lutcr,
-    Lutkey, Mcr0, Tfdr,
+    Ahbcr, Ahbrxbuf0cr0, Dllcr, Flshcr0, Flshcr1, Flshcr2, Flshcr4, Intr, Ipcmd, Ipcr0, Ipcr1, Iprxfcr, Iptxfcr, Lut,
+    Lutcr, Lutkey, Mcr0, Tfdr,
 };
 use crate::{interrupt, pac};
 
@@ -693,6 +693,17 @@ impl<'d, M: Mode> InnerFlexSpi<'d, M> {
         });
         self.info.regs.iptxfcr().modify(|r: &mut Iptxfcr| r.set_txwmrk(0));
         self.info.regs.iprxfcr().modify(|r: &mut Iprxfcr| r.set_rxwmrk(0));
+
+        // Read-strobe (sample clock) delay line. For the loopback RXCLKSRC modes
+        // this driver uses (RXCLKSRC = loopback-from-DQS-pad), the SDK programs
+        // DLLCR to FLEXSPI_DLLCR_DEFAULT == OVRDEN=1, OVRDVAL=0 -- a fixed,
+        // minimal delay -- regardless of the serial clock; only the
+        // external-DQS path uses the frequency-dependent DLL. The reset value 0
+        // leaves the override path disabled. DLLCR is per port (A = 0, B = 1).
+        self.info
+            .regs
+            .dllcr((self.chip_index >> 1) as usize)
+            .write(|r: &mut Dllcr| r.set_ovrden(pac::flexspi::Ovrden::Value1));
 
         self.load_lut(self.flash.lookup_table);
         self.software_reset();

--- a/embassy-mcxa/src/flexspi.rs
+++ b/embassy-mcxa/src/flexspi.rs
@@ -616,6 +616,15 @@ impl<'d, M: Mode> InnerFlexSpi<'d, M> {
         self.info.regs.mcr0().write(|r: &mut Mcr0| {
             r.set_mdis(pac::flexspi::Mdis::Val0);
             r.set_rxclksrc(pac::flexspi::Rxclksrc::Val1);
+            // Match the SDK's arbitration / low-power defaults. IPGRANTWAIT and
+            // AHBGRANTWAIT bound how many (1024-serial-clock) cycles an IP- or
+            // AHB-triggered command waits for the sequence-engine grant before a
+            // grant-timeout error; the reset value 0 is the shortest window.
+            // DOZEEN lets the controller halt when the SoC asserts doze (deep
+            // low power). A bare `write` would otherwise leave all three at 0.
+            r.set_ipgrantwait(0xff);
+            r.set_ahbgrantwait(0xff);
+            r.set_dozeen(pac::flexspi::Dozeen::Val1);
         });
         self.info.regs.ahbcr().write(|r: &mut Ahbcr| {
             r.set_aparen(pac::flexspi::Aparen::Individual);

--- a/embassy-mcxa/src/flexspi.rs
+++ b/embassy-mcxa/src/flexspi.rs
@@ -664,9 +664,14 @@ impl<'d, M: Mode> InnerFlexSpi<'d, M> {
             .flshcr2(self.chip_index as usize)
             .write(|r: &mut Flshcr2| {
                 r.set_ardseqid(self.flash.read_seq);
-                r.set_ardseqnum(1);
+                // ARDSEQNUM/AWRSEQNUM are encoded as (sequence count - 1): the
+                // controller runs `field + 1` LUT sequences for an AHB-triggered
+                // read/write. We define a single sequence per operation, so the
+                // field must be 0. The SDK writes `ARDSeqNumber - 1` with
+                // ARDSeqNumber == 1, i.e. 0; writing 1 requested two sequences.
+                r.set_ardseqnum(0);
                 r.set_awrseqid(self.flash.page_program_seq);
-                r.set_awrseqnum(1);
+                r.set_awrseqnum(0);
                 r.set_awrwait(0);
                 r.set_awrwaitunit(pac::flexspi::Awrwaitunit::Val0);
                 r.set_clrinstrptr(false);

--- a/examples/mcxa5xx/src/bin/flexspi-quad-memory-mapped.rs
+++ b/examples/mcxa5xx/src/bin/flexspi-quad-memory-mapped.rs
@@ -1,0 +1,98 @@
+#![no_std]
+#![no_main]
+
+//! FlexSPI memory-mapped (XIP-style) read example for MCXA577.
+//!
+//! Once [`Flexspi::new_blocking`] has configured `FLEXSPI0`, the external NOR
+//! flash is directly readable through the FlexSPI AHB memory-mapped window —
+//! no IP commands required. This example programs a sector with IP commands
+//! (the writable path the driver exposes) and then reads it back purely
+//! through the memory-mapped window, verifying the two agree.
+//!
+//! Notes for MCXA577:
+//! * The core boots in the secure state, so the secure window alias
+//!   `0x9000_0000` is used. The non-secure alias `0x8000_0000` would bus-fault
+//!   when accessed from secure code.
+//! * The shared `FLASH_CONFIG` read sequence uses a 3-byte (24-bit) address,
+//!   so only the low 16 MiB is reachable; the test offset stays under that.
+
+use defmt::{info, panic, unwrap};
+use embassy_executor::Spawner;
+use embassy_time::Timer;
+use hal::config::Config;
+use hal::flexspi::{ClockConfig as FlexspiClockConfig, Flexspi, NorFlash};
+use {defmt_rtt as _, embassy_mcxa as hal, panic_probe as _};
+
+#[path = "../flexspi_common.rs"]
+mod flexspi_common;
+
+use flexspi_common::{FLASH_CONFIG, FLASH_PAGE_SIZE, FLASH_SECTOR_SIZE, check_pattern, fill_pattern};
+
+/// FlexSPI AHB memory-mapped window base (secure alias; the core boots secure).
+const FLEXSPI_AMBA_BASE: u32 = 0x9000_0000;
+/// Flash offset to exercise (sector aligned, under the 16 MiB 3-byte reach).
+const FLASH_OFFSET: u32 = 0x0040_0000;
+
+/// Read `buf.len()` bytes from the memory-mapped flash window at `offset`.
+///
+/// Each access lands in the FlexSPI AHB window, where the controller services
+/// it by running the AHB read LUT sequence against the NOR flash — there is no
+/// driver call involved, just a load.
+fn memory_mapped_read(offset: u32, buf: &mut [u8]) {
+    for (i, b) in buf.iter_mut().enumerate() {
+        let addr = (FLEXSPI_AMBA_BASE + offset + i as u32) as *const u8;
+        // SAFETY: `addr` is inside the FlexSPI memory-mapped window configured
+        // by the driver; the region is valid for reads while the driver lives.
+        *b = unsafe { core::ptr::read_volatile(addr) };
+    }
+}
+
+#[embassy_executor::main]
+async fn main(_spawner: Spawner) {
+    let p = hal::init(Config::default());
+
+    info!("FlexSPI memory-mapped read example");
+
+    let flexspi = unwrap!(Flexspi::new_blocking(
+        p.FLEXSPI0,
+        p.P3_0,
+        p.P3_7,
+        p.P3_6,
+        p.P3_8,
+        p.P3_9,
+        p.P3_10,
+        p.P3_11,
+        FlexspiClockConfig::default(),
+        FLASH_CONFIG,
+    ));
+    let mut flash = NorFlash::new(flexspi);
+
+    // Program a known pattern into one sector using IP commands.
+    info!("Programming sector at flash offset 0x{=u32:08x} via IP commands", FLASH_OFFSET);
+    unwrap!(flash.blocking_erase_sector(FLASH_OFFSET));
+    let mut page = [0u8; FLASH_PAGE_SIZE];
+    for pg in 0..(FLASH_SECTOR_SIZE / FLASH_PAGE_SIZE) as u32 {
+        let addr = FLASH_OFFSET + pg * FLASH_PAGE_SIZE as u32;
+        fill_pattern(addr, &mut page);
+        unwrap!(flash.blocking_page_program(addr, &page));
+    }
+
+    // Read the whole sector back through the memory-mapped window only.
+    let window_addr = FLEXSPI_AMBA_BASE + FLASH_OFFSET;
+    info!("Reading it back through the memory-mapped window at 0x{=u32:08x}", window_addr);
+    let mut readback = [0u8; FLASH_SECTOR_SIZE];
+    memory_mapped_read(FLASH_OFFSET, &mut readback);
+
+    match check_pattern(FLASH_OFFSET, &readback) {
+        None => info!(
+            "Memory-mapped read PASSED: {=usize} bytes match the IP-programmed pattern",
+            readback.len()
+        ),
+        Some(bad) => panic!("memory-mapped read mismatch at flash offset 0x{=u32:08x}", bad),
+    }
+
+    loop {
+        Timer::after_secs(1).await;
+        info!("FlexSPI memory-mapped demo heartbeat");
+    }
+}

--- a/examples/mcxa5xx/src/bin/flexspi-quad-memory-mapped.rs
+++ b/examples/mcxa5xx/src/bin/flexspi-quad-memory-mapped.rs
@@ -68,7 +68,10 @@ async fn main(_spawner: Spawner) {
     let mut flash = NorFlash::new(flexspi);
 
     // Program a known pattern into one sector using IP commands.
-    info!("Programming sector at flash offset 0x{=u32:08x} via IP commands", FLASH_OFFSET);
+    info!(
+        "Programming sector at flash offset 0x{=u32:08x} via IP commands",
+        FLASH_OFFSET
+    );
     unwrap!(flash.blocking_erase_sector(FLASH_OFFSET));
     let mut page = [0u8; FLASH_PAGE_SIZE];
     for pg in 0..(FLASH_SECTOR_SIZE / FLASH_PAGE_SIZE) as u32 {
@@ -79,7 +82,10 @@ async fn main(_spawner: Spawner) {
 
     // Read the whole sector back through the memory-mapped window only.
     let window_addr = FLEXSPI_AMBA_BASE + FLASH_OFFSET;
-    info!("Reading it back through the memory-mapped window at 0x{=u32:08x}", window_addr);
+    info!(
+        "Reading it back through the memory-mapped window at 0x{=u32:08x}",
+        window_addr
+    );
     let mut readback = [0u8; FLASH_SECTOR_SIZE];
     memory_mapped_read(FLASH_OFFSET, &mut readback);
 

--- a/examples/mcxa5xx/src/flexspi_common.rs
+++ b/examples/mcxa5xx/src/flexspi_common.rs
@@ -59,8 +59,21 @@ pub fn check_erased(base: u32, buffer: &[u8]) -> Option<u32> {
 
 const ENTER_OPI_SEQ: u8 = Command::WriteStatus as u8;
 
+/// Flash configuration for the FRDM-MCXA577's on-board NOR flash.
+///
+/// The board carries a Winbond **W25Q64** (64 Mbit = 8 MiB), driven here in
+/// 1-4-4 quad mode. The read/erase/program LUT sequences below all use a 3-byte
+/// (24-bit) address, which reaches 16 MiB and so covers this part in full; a
+/// flash larger than 16 MiB would need 4-byte-address sequences instead.
+///
+/// The FlexSPI hardware is not the limiting factor: the AHB memory-mapped window
+/// spans 256 MiB (secure `0x9000_0000..=0x9FFF_FFFF`) and IP commands carry a
+/// full 32-bit address in `IPCR0.SFAR`.
 pub const FLASH_CONFIG: FlashConfig = FlashConfig {
-    flash_size_kbytes: 0x10000,
+    // W25Q64 == 8 MiB == 8192 KiB. `flash_size_kbytes` programs FLSHCR0.FLSHSZ,
+    // which bounds every IP and memory-mapped access; sizing it to the real chip
+    // makes the controller reject out-of-range accesses instead of wrapping.
+    flash_size_kbytes: 0x2000,
     page_size: FLASH_PAGE_SIZE,
     busy_status_polarity: true,
     busy_status_offset: 0,


### PR DESCRIPTION
## Summary

While reviewing the MCXA FlexSPI driver against the NXP MCUXpresso SDK
(`frdmmcxa577_flexspi_octal_dma3_transfer`), I found and fixed a real bug in
`AHBCR.AFLASHBASE` that breaks all memory-mapped (AHB/XIP) flash access, plus
one incorrect example config value and three register settings that diverged
from the SDK. Everything here was characterised and verified on hardware
(FRDM-MCXA577, on-board Winbond **W25Q64**, via `probe-rs`).

The driver's IP-command path (the only path it exposes today) was unaffected by
the AFLASHBASE bug, which is why it stayed latent.

## The headline bug — `AHBCR.AFLASHBASE`

`configure_controller()` programmed `AFLASHBASE` (`AHBCR[31:28]`, 256 MiB
granular) to `0x8`, on the assumption it encodes the `0x8000_0000` AHB window
base. On MCXA577 that is wrong: the SoC bus matrix strips the window base and
presents the controller a **window-relative offset**, so `AFLASHBASE` must be
`0`. Any non-zero value folds high bits into the controller's internal flash
address that then exceed `FLSHCR0.FLSHSZ`, so **every memory-mapped access bus-faults**.

Reproduced and root-caused on hardware:

- Read of the secure window `0x9040_0000` **bus-faults** with `AFLASHBASE=0x8`,
  and returns correct data with `0`. (Everything else held constant.)
- `AFLASHBASE=0x9` also faults — proving the controller sees a relative offset,
  not the absolute address (otherwise `0x9` would be the correct base for the
  `0x9000_0000` window).
- Enlarging `FLSHSZ` turns the `0x8` fault into a correct read of the *same*
  byte, confirming the field only affects the internal address's high bits
  (above the 24-bit serial address) and that the fault is the `FLSHSZ` range
  check.
- A "banked window" hypothesis (small `FLSHSZ` + `AFLASHBASE` to page across the
  flash) was tested and disproved: `AFLASHBASE` is 256 MiB-granular regardless
  of `FLSHSZ`, and the 256 MiB AHB window already maps the whole 8 MiB chip, so
  higher offsets are reached via the window address, not `AFLASHBASE`.

This matches the SDK, which gates the field off
(`FSL_FEATURE_FLEXSPI_HAS_AHBCR_AFLASHBASE_BIT` undefined for MCXA577) and never
writes it.

## Changes

**Fixes**
- `AHBCR.AFLASHBASE` `0x8 → 0`. Restores memory-mapped/XIP access (bus-faulted
  before).
- Example `flash_size_kbytes` `0x10000 (64 MiB) → 0x2000 (8 MiB)`. The board has
  a W25Q64 (8 MiB); `0x10000` is the size of the *other* part NXP's example
  supports (Micron MT35XU512), hardcoded for both. The wrong size left
  `FLSHSZ` at 64 MiB, so the controller accepted 8–64 MiB accesses that
  silently wrap in the 8 MiB device. Confirmed the address space wraps at 8 MiB
  with a hardware wrap test.
- `FLSHCR2.ARDSEQNUM/AWRSEQNUM` `1 → 0`. The field is N−1 encoded (controller
  runs `field + 1` LUT sequences for an AHB-triggered read/write); `1` requested
  two sequences. The SDK writes `ARDSeqNumber - 1 == 0`. Latent (AHB path only,
  and verified benign for reads on this hardware), but wrong per the encoding.

**SDK alignment**
- `MCR0`: program `IPGRANTWAIT=0xFF`, `AHBGRANTWAIT=0xFF`, `DOZEEN=1` (a bare
  `write` had left them 0). Grant-wait `0` is the shortest arbitration window;
  the driver's IRQ handler already surfaces `IPCMDGE` as a grant-timeout error,
  so `0xFF` avoids a spurious error if AHB and IP traffic are ever mixed.
- `DLLCR`: program the read-strobe delay line to `FLEXSPI_DLLCR_DEFAULT` (`0x100`
  = `OVRDEN=1, OVRDVAL=0`). The driver samples reads with
  `RXCLKSRC = loopback-from-DQS-pad` (matching the SDK W25Q64 example); for every
  loopback mode `FLEXSPI_CalculateDll` returns this fixed value regardless of
  clock. Driver left it at reset `0` (override disabled). At the default clock
  reads are reliable either way — this applies the SDK's defined read-strobe
  config and its margin rather than relying on the reset default.

**Example**
- New `flexspi-quad-memory-mapped` example: programs a sector via IP commands,
  then reads it back purely through the AHB window (`0x9000_0000 + offset`) and
  verifies. Doubles as a regression test for the AFLASHBASE fix.

## Hardware verification

All on an FRDM-MCXA577 (W25Q64), built `--release`, flashed with `probe-rs`:

- `flexspi-quad-polling-transfer` — full erase/program/pattern-verify across
  16 KiB plus odd-length and cross-sector reads: **PASS** with every change.
- `flexspi-quad-memory-mapped` — 4096-byte memory-mapped readback matches the
  IP-programmed data: **PASS** (this exact read bus-faulted before the AFLASHBASE
  fix).
