### PR TITLE
mcxa/flexspi: write-size contract, bounds validation, async cancel-safety, and soak tests

### DIFF
--- a/embassy-mcxa/src/flexspi.rs
+++ b/embassy-mcxa/src/flexspi.rs
@@ -889,6 +889,25 @@ impl<'d, M: Mode> InnerFlexSpi<'d, M> {
     }
 
     fn prepare_ip_transfer(&mut self) {
+        // Recover from a previous async operation that was cancelled (its future
+        // dropped) mid-command -- e.g. the caller wrapped it in `with_timeout`
+        // and it elapsed. That can leave the sequence engine non-idle (CS
+        // asserted, TX-FIFO underrun), after which a plain `wait_idle()` would
+        // spin forever. A software reset forces idle, de-asserts CS, resets the
+        // instruction pointer, and flushes the FIFOs; the LUT and controller
+        // config survive it (the init path relies on exactly this). A single
+        // SEQIDLE sample is authoritative: SEQIDLE only deasserts on a fresh
+        // IPCMD trigger and none is pending here, so a still-draining command
+        // holds it low rather than reading idle mid-sequence.
+        //
+        // This is cancel-safety (correctness), not a timeout: *how long* to wait
+        // for an operation, and whether to give up, is policy left to the caller
+        // (wrap the async op in `with_timeout` with an application-specific
+        // budget). The driver only guarantees that a cancelled op does not wedge
+        // the next one.
+        if self.info.regs.sts0().read().seqidle() != pac::flexspi::Seqidle::Value1 {
+            self.software_reset();
+        }
         self.wait_idle();
         self.info.pending_events().store(0, Ordering::Release);
 

--- a/embassy-mcxa/src/flexspi.rs
+++ b/embassy-mcxa/src/flexspi.rs
@@ -38,6 +38,10 @@ const MAX_PAGE_WORDS: usize = MAX_PAGE_SIZE / 4;
 const LUT_KEY_VALUE: u32 = 0x5AF0_5AF0;
 const LUT_WORD_COUNT: usize = 64;
 const DMA_FIFO_WINDOW_BYTES: usize = 8;
+/// FlexSPI IP write granularity. The IP write path corrupts the byte before a
+/// non-aligned start address, so page programs must be aligned to this many
+/// bytes; it is the same granularity the DMA FIFO window requires.
+const WRITE_GRANULARITY: usize = DMA_FIFO_WINDOW_BYTES;
 const TEMP_SEQUENCE_INDEX: u8 = 15;
 const IP_FIFO_DEPTH_WORDS: usize = 32;
 const IP_FIFO_CAPACITY_BYTES: usize = IP_FIFO_DEPTH_WORDS * 4;
@@ -831,7 +835,7 @@ impl<'d, M: Mode> InnerFlexSpi<'d, M> {
         if len == 0 || len > self.flash.page_size {
             return Err(IoError::InvalidTransferLength);
         }
-        if address % 8 != 0 || len % 8 != 0 {
+        if address as usize % WRITE_GRANULARITY != 0 || len % WRITE_GRANULARITY != 0 {
             return Err(IoError::Misaligned);
         }
         if (address as usize % self.flash.page_size) + len > self.flash.page_size {

--- a/embassy-mcxa/src/flexspi.rs
+++ b/embassy-mcxa/src/flexspi.rs
@@ -494,12 +494,22 @@ impl From<IoError> for SetupError {
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
 #[non_exhaustive]
 pub enum IoError {
-    Command { error_code: pac::flexspi::Ipcmderrcode },
+    Command {
+        error_code: pac::flexspi::Ipcmderrcode,
+    },
     CommandGrantTimeout,
     Dma(crate::dma::TransferErrors),
     InterruptWait,
     InvalidDmaParameters,
     InvalidTransferLength,
+    /// A `page_program` address or length is not 8-byte aligned, or the write
+    /// would cross a page boundary. The FlexSPI IP write path corrupts the byte
+    /// before a non-8-aligned start address, so writes must be 8-byte aligned
+    /// (the same granularity the DMA path requires); and a program that crosses
+    /// a page wraps the column address within that page.
+    Misaligned,
+    /// The requested access extends past the configured flash size.
+    OutOfBounds,
 }
 
 impl From<crate::dma::InvalidParameters> for IoError {
@@ -762,6 +772,7 @@ impl<'d, M: Mode> InnerFlexSpi<'d, M> {
     }
 
     pub fn erase_sector(&mut self, address: u32) -> Result<(), IoError> {
+        self.check_in_bounds(address, 1)?;
         self.write_enable()?;
         self.issue_ip_command(address, self.flash.erase_sector_seq as usize, 0, None)?;
         self.wait_bus_busy()?;
@@ -769,6 +780,7 @@ impl<'d, M: Mode> InnerFlexSpi<'d, M> {
     }
 
     pub fn read(&mut self, address: u32, buffer: &mut [u8]) -> Result<(), IoError> {
+        self.check_in_bounds(address, buffer.len())?;
         let mut offset = 0;
 
         while offset < buffer.len() {
@@ -788,9 +800,7 @@ impl<'d, M: Mode> InnerFlexSpi<'d, M> {
     }
 
     pub fn page_program(&mut self, address: u32, data: &[u8]) -> Result<(), IoError> {
-        if data.is_empty() || data.len() > self.flash.page_size {
-            return Err(IoError::InvalidTransferLength);
-        }
+        self.check_program(address, data.len())?;
 
         self.write_enable()?;
 
@@ -798,6 +808,36 @@ impl<'d, M: Mode> InnerFlexSpi<'d, M> {
 
         self.wait_bus_busy()?;
         Ok(())
+    }
+
+    /// Total addressable flash size in bytes.
+    fn flash_size_bytes(&self) -> u64 {
+        self.flash.flash_size_kbytes as u64 * 1024
+    }
+
+    /// Reject a read/erase access that runs past the end of the device.
+    fn check_in_bounds(&self, address: u32, len: usize) -> Result<(), IoError> {
+        if address as u64 + len as u64 > self.flash_size_bytes() {
+            return Err(IoError::OutOfBounds);
+        }
+        Ok(())
+    }
+
+    /// Validate a page-program request: non-empty and no larger than a page,
+    /// 8-byte aligned (the FlexSPI IP-write granularity; a non-aligned start
+    /// corrupts the preceding byte), not crossing a page boundary, and within
+    /// the device.
+    fn check_program(&self, address: u32, len: usize) -> Result<(), IoError> {
+        if len == 0 || len > self.flash.page_size {
+            return Err(IoError::InvalidTransferLength);
+        }
+        if address % 8 != 0 || len % 8 != 0 {
+            return Err(IoError::Misaligned);
+        }
+        if (address as usize % self.flash.page_size) + len > self.flash.page_size {
+            return Err(IoError::Misaligned);
+        }
+        self.check_in_bounds(address, len)
     }
 
     fn write_enable(&mut self) -> Result<(), IoError> {
@@ -1013,6 +1053,7 @@ impl<'d> InnerFlexSpi<'d, Async> {
     }
 
     pub async fn erase_sector_async(&mut self, address: u32) -> Result<(), IoError> {
+        self.check_in_bounds(address, 1)?;
         self.write_enable_async().await?;
         self.issue_ip_command_async(address, self.flash.erase_sector_seq as usize, 0, None)
             .await?;
@@ -1022,6 +1063,7 @@ impl<'d> InnerFlexSpi<'d, Async> {
     }
 
     pub async fn read_async(&mut self, address: u32, buffer: &mut [u8]) -> Result<(), IoError> {
+        self.check_in_bounds(address, buffer.len())?;
         let mut offset = 0;
 
         while offset < buffer.len() {
@@ -1057,9 +1099,7 @@ impl<'d> InnerFlexSpi<'d, Async> {
     }
 
     pub async fn page_program_async(&mut self, address: u32, data: &[u8]) -> Result<(), IoError> {
-        if data.is_empty() || data.len() > self.flash.page_size {
-            return Err(IoError::InvalidTransferLength);
-        }
+        self.check_program(address, data.len())?;
 
         self.write_enable_async().await?;
 

--- a/examples/mcxa5xx/src/bin/flexspi-cancel-soak.rs
+++ b/examples/mcxa5xx/src/bin/flexspi-cancel-soak.rs
@@ -1,0 +1,442 @@
+#![no_std]
+#![no_main]
+
+//! FlexSPI NOR **async / DMA cancellation soak** for the FRDM-MCXA577
+//! (Winbond W25Q64, 8 MiB).
+//!
+//! Companion to `flexspi-soak` (which torture-tests the *blocking* + AHB paths).
+//! This one drives the **async + DMA** path and, crucially, validates that the
+//! driver is **cancel-safe**: a dropped in-flight future must not wedge the
+//! controller for the next operation. It is the hardware proof for the
+//! self-healing `prepare_ip_transfer` recovery -- which is what makes the
+//! application-level `with_timeout` pattern (the intended way to bound an
+//! operation) usable: when the caller's timeout cancels an op mid-flight, the
+//! driver un-wedges itself before the next one.
+//!
+//! ## DESTRUCTIVE
+//! Erases and reprograms a rotating window of the external flash, repeatedly.
+//! Do not keep anything you care about on the W25Q64 before running it.
+//!
+//! ## What it does every round (wear-spread rotating 2-sector window)
+//! - **Phase A - async/DMA integrity:** erase the window, verify erased, program
+//!   s0 with random 8-byte-aligned sub-page writes and s1 with full pages (the
+//!   DMA write path), verify both via async read (the DMA read path), and
+//!   cross-check s0 against the memory-mapped (AHB) window. Fatal on mismatch.
+//! - **Phase B - cancellation torture:** repeatedly start an async op and drop
+//!   it in flight at a sweep of `with_timeout` delays (from ~1 us, which lands
+//!   mid command-shift, up to ~2 ms, mid write-in-progress), then immediately
+//!   run a *fresh* op and assert it succeeds with correct data. Cancelling
+//!   **reads** exercises pure controller recovery (a read leaves the device
+//!   idle); cancelling **program/erase** adds the device-busy path, reconverged
+//!   with an erase-until-clean settle. A regression (no cancel-safety) would
+//!   **hang** the next op forever, so the test simply finishing -- across
+//!   thousands of cancellations -- is itself the pass signal.
+//! - a never-erased **canary** sector is verified every round (wild-write net).
+//!
+//! ## Repro
+//! Seeded xorshift PRNG; the seed and per-round state are logged. Data-integrity
+//! failures `panic!` (panic-probe halts) with full context. The run is bounded
+//! by a wall-clock limit and then halts (`bkpt`).
+//!
+//! Run: `cargo run --release --bin flexspi-cancel-soak`
+
+use defmt::{info, unwrap, warn};
+use embassy_executor::Spawner;
+use embassy_mcxa::{bind_interrupts, peripherals};
+use embassy_time::{Duration, Instant, with_timeout};
+use hal::config::Config;
+use hal::flexspi::{self, Async, ClockConfig as FlexspiClockConfig, Flexspi, NorFlash};
+use {defmt_rtt as _, embassy_mcxa as hal, panic_probe as _};
+
+#[path = "../flexspi_common.rs"]
+mod flexspi_common;
+
+use flexspi_common::{FLASH_CONFIG, check_erased, check_pattern, fill_pattern, pattern_byte};
+
+// ----- geometry -----
+const PAGE: u32 = 256;
+const SECTOR: u32 = 4096;
+const NUM_SECTORS: u32 = 2048; // W25Q64 = 8 MiB
+const PAGES_PER_SECTOR: u32 = SECTOR / PAGE; // 16
+
+/// FlexSPI AHB memory-mapped window, secure alias (the core boots secure).
+const AMBA_BASE_S: u32 = 0x9000_0000;
+
+// ----- wear management (mirrors flexspi-soak) -----
+const WINDOW_SECTORS: u32 = 2;
+const CANARY_SECTOR: u32 = NUM_SECTORS - 1; // 2047, never erased after init
+const ROT_MOD: u32 = NUM_SECTORS - WINDOW_SECTORS; // 2046
+const ROT_STRIDE: u32 = 1021; // prime, coprime with 2046 -> even wear
+const ERASE_BUDGET: u16 = 50_000;
+
+// ----- cancellation sweep -----
+/// `with_timeout` delays (microseconds) used to drop an in-flight op at varied
+/// points: ~1-20 us lands mid command-shift (SEQIDLE low -> exercises the
+/// software-reset recovery in `prepare_ip_transfer`); ~0.1-2 ms lands mid
+/// write-in-progress poll (device busy, engine idle).
+const CANCEL_DELAYS_US: &[u64] = &[1, 3, 8, 20, 60, 200, 800, 2000];
+
+// ----- reporting -----
+const SEED: u32 = 0x0bad_c0de;
+const HEARTBEAT_ROUNDS: u64 = 8;
+/// Wall-clock limit; the soak stops and halts (bkpt) when reached.
+const SOAK_DURATION_SECS: u64 = 120;
+
+bind_interrupts!(struct Irqs {
+    FLEXSPI0 => flexspi::InterruptHandler<peripherals::FLEXSPI0>;
+});
+
+#[inline]
+fn xorshift32(s: &mut u32) -> u32 {
+    let mut x = *s;
+    x ^= x << 13;
+    x ^= x >> 17;
+    x ^= x << 5;
+    *s = x;
+    x
+}
+
+/// Uniform-ish `lo..hi` (hi exclusive). Caller guarantees `hi > lo`.
+#[inline]
+fn gen_range(s: &mut u32, lo: u32, hi: u32) -> u32 {
+    lo + xorshift32(s) % (hi - lo)
+}
+
+/// One memory-mapped (AHB/XIP) byte at flash `offset`.
+#[inline]
+fn mmap_byte(offset: u32) -> u8 {
+    // SAFETY: inside the FlexSPI secure memory-mapped window, valid for reads
+    // while the driver is initialised.
+    unsafe { core::ptr::read_volatile((AMBA_BASE_S + offset) as *const u8) }
+}
+
+/// Async IP-read `[addr, addr+len)` and assert it matches `pattern_byte`. Fatal.
+async fn expect_pattern(
+    flash: &mut NorFlash<'_, Async>,
+    addr: u32,
+    len: usize,
+    buf: &mut [u8],
+    round: u64,
+    phase: &str,
+) {
+    unwrap!(flash.read_async(addr, &mut buf[..len]).await);
+    if let Some(bad) = check_pattern(addr, &buf[..len]) {
+        let got = buf[(bad - addr) as usize];
+        defmt::panic!(
+            "CANCEL-SOAK FAIL [{=str}] round={=u64} pattern mismatch @0x{=u32:08x} exp=0x{=u8:02x} got=0x{=u8:02x} (read start=0x{=u32:08x} len={=usize})",
+            phase,
+            round,
+            bad,
+            pattern_byte(bad),
+            got,
+            addr,
+            len
+        );
+    }
+}
+
+/// Async IP-read `[addr, addr+len)` and assert it is fully erased (0xFF). Fatal.
+async fn expect_erased(
+    flash: &mut NorFlash<'_, Async>,
+    addr: u32,
+    len: usize,
+    buf: &mut [u8],
+    round: u64,
+    phase: &str,
+) {
+    unwrap!(flash.read_async(addr, &mut buf[..len]).await);
+    if let Some(bad) = check_erased(addr, &buf[..len]) {
+        let got = buf[(bad - addr) as usize];
+        defmt::panic!(
+            "CANCEL-SOAK FAIL [{=str}] round={=u64} not erased @0x{=u32:08x} got=0x{=u8:02x} (read start=0x{=u32:08x} len={=usize})",
+            phase,
+            round,
+            bad,
+            got,
+            addr,
+            len
+        );
+    }
+}
+
+/// Program a whole sector with the address-derived pattern using random
+/// **8-byte-aligned** sub-page writes (the driver's write-size contract).
+async fn program_sector_split(flash: &mut NorFlash<'_, Async>, sector_addr: u32, page: &mut [u8; 256], prng: &mut u32) {
+    for p in 0..PAGES_PER_SECTOR {
+        let page_addr = sector_addr + p * PAGE;
+        fill_pattern(page_addr, page);
+        let mut start = 0u32;
+        while start < PAGE {
+            let units_left = (PAGE - start) / 8; // PAGE and start are multiples of 8
+            let units = if units_left <= 1 {
+                1
+            } else {
+                gen_range(prng, 1, units_left + 1)
+            };
+            let end = start + units * 8;
+            unwrap!(
+                flash
+                    .page_program_async(page_addr + start, &page[start as usize..end as usize])
+                    .await
+            );
+            start = end;
+        }
+    }
+}
+
+/// Program a whole sector with the pattern, one full page at a time (the DMA
+/// write path: 256-byte, 8-aligned writes).
+async fn program_sector_simple(flash: &mut NorFlash<'_, Async>, sector_addr: u32, page: &mut [u8; 256]) {
+    for p in 0..PAGES_PER_SECTOR {
+        let page_addr = sector_addr + p * PAGE;
+        fill_pattern(page_addr, page);
+        unwrap!(flash.page_program_async(page_addr, &page[..]).await);
+    }
+}
+
+/// Erase `sector` and confirm it (via async read) until it reads all-0xFF, with
+/// a bounded number of retries. After a cancelled erase/program the device may
+/// still be mid-write; the first `erase_sector_async` recovers the controller
+/// and its trailing WIP wait drains the in-flight op, and a second pass then
+/// actually erases. Fatal if it never converges.
+async fn settle_erase(flash: &mut NorFlash<'_, Async>, sector: u32, buf: &mut [u8], round: u64) {
+    for _ in 0..6 {
+        unwrap!(flash.erase_sector_async(sector).await);
+        unwrap!(flash.read_async(sector, &mut buf[..SECTOR as usize]).await);
+        if check_erased(sector, &buf[..SECTOR as usize]).is_none() {
+            return;
+        }
+    }
+    defmt::panic!(
+        "CANCEL-SOAK FAIL [settle] round={=u64} sector 0x{=u32:08x} not erased after retries",
+        round,
+        sector
+    );
+}
+
+/// `(offset within window, length)` async reads forced every round so the
+/// FIFO/page/sector seams (and the DMA multi-chunk path) are always exercised.
+const BOUNDARY: &[(u32, usize)] = &[
+    (0, 1),
+    (7, 13),
+    (100, 100),   // crosses the 128 B IP-FIFO seam
+    (200, 120),   // crosses the 256 B page seam
+    (255, 257),   // crosses 256, multi-chunk
+    (2048, 4096), // spans the 4096 B sector seam into the second sector
+    (4095, 2),    // straddles the sector boundary
+];
+
+#[embassy_executor::main]
+async fn main(_spawner: Spawner) {
+    let p = hal::init(Config::default());
+
+    info!("FlexSPI NOR async/DMA CANCELLATION soak (DESTRUCTIVE to a rotating window of the external flash)");
+    info!(
+        "seed=0x{=u32:08x}  window={=u32} sectors  rotation: base += {=u32} mod {=u32}  canary sector={=u32}  limit={=u64}s",
+        SEED, WINDOW_SECTORS, ROT_STRIDE, ROT_MOD, CANARY_SECTOR, SOAK_DURATION_SECS
+    );
+
+    let flexspi = unwrap!(Flexspi::new_with_dma(
+        p.FLEXSPI0,
+        p.P3_0,
+        p.P3_7,
+        p.P3_6,
+        p.P3_8,
+        p.P3_9,
+        p.P3_10,
+        p.P3_11,
+        p.DMA0_CH0,
+        p.DMA0_CH1,
+        Irqs,
+        FlexspiClockConfig::default(),
+        FLASH_CONFIG,
+    ));
+    let mut flash = NorFlash::new(flexspi);
+
+    // Vendor-id sanity (W25Q64 == 0xEF). 0x00/0x7F would mean a dead/floating bus.
+    let id = unwrap!(flash.read_vendor_id_async().await);
+    if id != 0xEF {
+        defmt::panic!("unexpected vendor id 0x{=u8:02x} (expected 0xEF Winbond)", id);
+    }
+    info!("vendor id 0x{=u8:02x} OK", id);
+
+    let mut buf = [0u8; 4096];
+    let mut page = [0u8; 256];
+    let mut erase_count = [0u16; NUM_SECTORS as usize];
+
+    // ---- one-time: program the canary sector (never erased afterwards) ----
+    let canary_addr = CANARY_SECTOR * SECTOR;
+    unwrap!(flash.erase_sector_async(canary_addr).await);
+    erase_count[CANARY_SECTOR as usize] += 1;
+    program_sector_simple(&mut flash, canary_addr, &mut page).await;
+    expect_pattern(&mut flash, canary_addr, SECTOR as usize, &mut buf, 0, "canary-init").await;
+    info!("canary programmed at 0x{=u32:08x}", canary_addr);
+
+    info!("starting cancellation soak loop");
+
+    // ---- soak loop ----
+    let mut prng = SEED;
+    let mut base: u32 = 0;
+    let mut round: u64 = 0;
+    let mut total_erases: u64 = 0;
+    let mut cancels: u64 = 0;
+    let mut cancel_inflight: u64 = 0; // dropped while the op was still pending
+    let mut cancel_completed: u64 = 0; // op finished before the cancel point
+    let mut recoveries: u64 = 0; // fresh ops that succeeded right after a cancel
+    let start = Instant::now();
+
+    loop {
+        let prng_at_round = prng;
+        let s0 = base * SECTOR;
+        let s1 = (base + 1) * SECTOR;
+
+        if start.elapsed() >= Duration::from_secs(SOAK_DURATION_SECS) {
+            warn!("cancel-soak time limit ({=u64}s) reached", SOAK_DURATION_SECS);
+            break;
+        }
+        let max_in_window = erase_count[base as usize].max(erase_count[(base + 1) as usize]);
+        if max_in_window >= ERASE_BUDGET {
+            warn!(
+                "erase budget reached on sector {=u32} ({=u16} erases) -- stopping to protect the flash",
+                base, max_in_window
+            );
+            break;
+        }
+
+        // ===== Phase A: async/DMA data integrity =====
+        unwrap!(flash.erase_sector_async(s0).await);
+        unwrap!(flash.erase_sector_async(s1).await);
+        erase_count[base as usize] += 1;
+        erase_count[(base + 1) as usize] += 1;
+        total_erases += 2;
+        expect_erased(&mut flash, s0, SECTOR as usize, &mut buf, round, "A-erase-s0").await;
+        expect_erased(&mut flash, s1, SECTOR as usize, &mut buf, round, "A-erase-s1").await;
+
+        program_sector_split(&mut flash, s0, &mut page, &mut prng).await;
+        program_sector_simple(&mut flash, s1, &mut page).await;
+
+        expect_pattern(&mut flash, s0, SECTOR as usize, &mut buf, round, "A-verify-s0").await;
+        expect_pattern(&mut flash, s1, SECTOR as usize, &mut buf, round, "A-verify-s1").await;
+
+        // mmap (AHB) cross-check of s0 against the async-read ground truth.
+        unwrap!(flash.read_async(s0, &mut buf[..SECTOR as usize]).await);
+        for i in 0..SECTOR {
+            let m = mmap_byte(s0 + i);
+            let ip = buf[i as usize];
+            let exp = pattern_byte(s0 + i);
+            if m != ip || m != exp {
+                defmt::panic!(
+                    "CANCEL-SOAK FAIL [A-mmap-xcheck] round={=u64} @0x{=u32:08x} mmap=0x{=u8:02x} ip=0x{=u8:02x} exp=0x{=u8:02x} (prng=0x{=u32:08x})",
+                    round,
+                    s0 + i,
+                    m,
+                    ip,
+                    exp,
+                    prng_at_round
+                );
+            }
+        }
+        for &(off, len) in BOUNDARY {
+            expect_pattern(&mut flash, s0 + off, len, &mut buf, round, "A-boundary").await;
+        }
+
+        // ===== Phase B1: cancel READS, then prove a clean read recovers =====
+        // A read leaves the device idle, so any wedge here is purely the
+        // controller -> this isolates the cancel-safety recovery. `with_timeout`
+        // is the application-level way to bound an op: when it elapses it drops
+        // the in-flight future, which is exactly the cancellation we recover from.
+
+        // A cancelled vendor-id read (smallest command) then a clean one.
+        let _ = with_timeout(Duration::from_micros(1), flash.read_vendor_id_async()).await;
+        cancels += 1;
+        let id = unwrap!(flash.read_vendor_id_async().await);
+        if id != 0xEF {
+            defmt::panic!(
+                "CANCEL-SOAK FAIL [B1-vendor-recover] round={=u64} vendor id 0x{=u8:02x} after cancelled read",
+                round,
+                id
+            );
+        }
+        recoveries += 1;
+
+        // Timed cancels across the delay sweep.
+        for &d_us in CANCEL_DELAYS_US {
+            match with_timeout(
+                Duration::from_micros(d_us),
+                flash.read_async(s0, &mut buf[..SECTOR as usize]),
+            )
+            .await
+            {
+                Ok(inner) => {
+                    unwrap!(inner); // a completed read must not error
+                    cancel_completed += 1;
+                }
+                Err(_) => cancel_inflight += 1,
+            }
+            cancels += 1;
+            // Fresh read must return correct data -> controller recovered.
+            expect_pattern(&mut flash, s0, SECTOR as usize, &mut buf, round, "B1-timed-recover").await;
+            recoveries += 1;
+        }
+
+        // ===== Phase B2: cancel PROGRAM/ERASE, settle, reverify =====
+        // These can leave the device mid-write; settle_erase reconverges it.
+        // 1-2 us lands mid command-shift; 30 us / 1 ms lands mid write-in-progress.
+        fill_pattern(s0, &mut page);
+        let _ = with_timeout(Duration::from_micros(2), flash.page_program_async(s0, &page[..])).await;
+        cancels += 1;
+        let _ = with_timeout(Duration::from_micros(30), flash.page_program_async(s0, &page[..])).await;
+        cancels += 1;
+        let _ = with_timeout(Duration::from_micros(2), flash.erase_sector_async(s0)).await;
+        cancels += 1;
+        let _ = with_timeout(Duration::from_millis(1), flash.erase_sector_async(s0)).await;
+        cancels += 1;
+
+        // Recovery + device reconvergence: erase-until-clean, then a fresh
+        // program/read round-trips correctly.
+        settle_erase(&mut flash, s0, &mut buf, round).await;
+        erase_count[base as usize] += 2; // settle does at least one extra erase
+        total_erases += 2;
+        program_sector_simple(&mut flash, s0, &mut page).await;
+        expect_pattern(&mut flash, s0, SECTOR as usize, &mut buf, round, "B2-recover").await;
+        recoveries += 1;
+
+        // ===== canary integrity (wild-write detector), every round =====
+        expect_pattern(&mut flash, canary_addr, SECTOR as usize, &mut buf, round, "canary").await;
+        unwrap!(flash.read_async(canary_addr, &mut buf[..PAGE as usize]).await);
+        for i in 0..PAGE {
+            if mmap_byte(canary_addr + i) != buf[i as usize] {
+                defmt::panic!(
+                    "CANCEL-SOAK FAIL [canary-xcheck] round={=u64} @0x{=u32:08x} mmap != ip",
+                    round,
+                    canary_addr + i
+                );
+            }
+        }
+
+        // advance
+        round += 1;
+        base = (base + ROT_STRIDE) % ROT_MOD;
+
+        if round % HEARTBEAT_ROUNDS == 0 {
+            let mut max_erase = 0u16;
+            for &c in erase_count.iter() {
+                if c > max_erase {
+                    max_erase = c;
+                }
+            }
+            info!(
+                "[hb] round={=u64} erases={=u64} cancels={=u64} (inflight={=u64} completed={=u64}) recoveries={=u64} max_sector_erases={=u16} next_base={=u32}",
+                round, total_erases, cancels, cancel_inflight, cancel_completed, recoveries, max_erase, base
+            );
+        }
+    }
+
+    info!(
+        "cancel-soak finished: rounds={=u64} erases={=u64} cancels={=u64} (inflight={=u64} completed={=u64}) recoveries={=u64}",
+        round, total_erases, cancels, cancel_inflight, cancel_completed, recoveries
+    );
+    loop {
+        cortex_m::asm::bkpt();
+    }
+}

--- a/examples/mcxa5xx/src/bin/flexspi-quad-dma3-transfer.rs
+++ b/examples/mcxa5xx/src/bin/flexspi-quad-dma3-transfer.rs
@@ -140,7 +140,7 @@ async fn main(_spawner: Spawner) {
     // 6) Partial-page program.
     let last_sector = FLASH_BASE + (SELF_TEST_SECTORS - 1) * FLASH_SECTOR_SIZE as u32;
     unwrap!(flash.erase_sector_async(last_sector).await);
-    let partial_len = 100usize;
+    let partial_len = 96usize; // 8-byte aligned (driver write-size contract)
     let mut partial = [0u8; FLASH_PAGE_SIZE];
     fill_pattern(last_sector, &mut partial);
     unwrap!(flash.page_program_async(last_sector, &partial[..partial_len]).await);

--- a/examples/mcxa5xx/src/bin/flexspi-quad-interrupt-transfer.rs
+++ b/examples/mcxa5xx/src/bin/flexspi-quad-interrupt-transfer.rs
@@ -137,7 +137,7 @@ async fn main(_spawner: Spawner) {
     // 6) Partial-page write.
     let last_sector = FLASH_BASE + (SELF_TEST_SECTORS - 1) * FLASH_SECTOR_SIZE as u32;
     unwrap!(flash.erase_sector_async(last_sector).await);
-    let partial_len = 100usize;
+    let partial_len = 96usize; // 8-byte aligned (driver write-size contract)
     let mut partial = [0u8; FLASH_PAGE_SIZE];
     fill_pattern(last_sector, &mut partial);
     unwrap!(flash.page_program_async(last_sector, &partial[..partial_len]).await);

--- a/examples/mcxa5xx/src/bin/flexspi-quad-polling-transfer.rs
+++ b/examples/mcxa5xx/src/bin/flexspi-quad-polling-transfer.rs
@@ -136,7 +136,7 @@ async fn main(_spawner: Spawner) {
     //    the page (and rest of the sector) stays at 0xFF.
     let last_sector = FLASH_BASE + (SELF_TEST_SECTORS - 1) * FLASH_SECTOR_SIZE as u32;
     unwrap!(flash.blocking_erase_sector(last_sector));
-    let partial_len = 100usize;
+    let partial_len = 96usize; // 8-byte aligned (driver write-size contract)
     let mut partial = [0u8; FLASH_PAGE_SIZE];
     fill_pattern(last_sector, &mut partial);
     unwrap!(flash.blocking_page_program(last_sector, &partial[..partial_len]));

--- a/examples/mcxa5xx/src/bin/flexspi-soak.rs
+++ b/examples/mcxa5xx/src/bin/flexspi-soak.rs
@@ -1,0 +1,533 @@
+#![no_std]
+#![no_main]
+
+//! FlexSPI NOR **soak test** for the FRDM-MCXA577 (Winbond W25Q64, 8 MiB).
+//!
+//! A long-running, self-checking torture loop that tries hard to break the
+//! blocking + memory-mapped paths of `embassy_mcxa::flexspi`. Designed by the
+//! reliability/tester/reviewer agents; v1 covers the highest-value, safe-to-run
+//! scope (blocking IP + AHB/XIP reads). Async/DMA and future-cancellation
+//! abuse are deliberately out of scope for v1 (the driver has no cancel-safe
+//! `Drop`, so a dropped future can wedge the controller).
+//!
+//! ## DESTRUCTIVE
+//! This erases and reprograms the **entire** external flash, repeatedly. Do not
+//! store anything you care about on the W25Q64 before running it.
+//!
+//! ## What it checks every round (on a wear-spread rotating 2-sector window)
+//! - erase -> all 0xFF; program (fuzzed sub-page splits) -> exact `pattern_byte`
+//! - **memory-mapped read == IP read == pattern** (the AFLASHBASE/DLLCR/ARDSEQNUM
+//!   regression net) -- fatal on mismatch
+//! - boundary/length matrix crossing the 128 B IP-FIFO, 256 B page and 4096 B
+//!   sector seams, plus a read spanning two sectors
+//! - partial-page program leaves the page tail erased (0xFF)
+//! - erase isolates its sector (neighbour intact)
+//! - **stale AHB buffer probe**: mmap a page, reprogram it via IP, mmap again --
+//!   must reflect the new contents (counted, *not* fatal: suspected driver gap)
+//! - negative paths: over-length / empty program -> `Err`, no side effects;
+//!   zero-length read -> `Ok` no-op
+//! - out-of-range read characterisation (read-only, logged)
+//! - a never-erased **canary** sector verified every round (wild-write detector)
+//!
+//! ## Repro
+//! Everything is driven by a seeded xorshift PRNG; the seed and the per-round
+//! PRNG state are logged, so any failing round can be replayed in isolation.
+//! On a data-integrity failure it `panic!`s (panic-probe halts) with the full
+//! context (round, phase, address, expected vs got).
+//!
+//! Run: `cargo run --release --bin flexspi-soak` (then Ctrl-C when satisfied).
+
+use defmt::{info, unwrap, warn};
+use embassy_executor::Spawner;
+use embassy_time::{Duration, Instant};
+use hal::config::Config;
+use hal::flexspi::{Blocking, ClockConfig as FlexspiClockConfig, Flexspi, IoError, NorFlash};
+use {defmt_rtt as _, embassy_mcxa as hal, panic_probe as _};
+
+#[path = "../flexspi_common.rs"]
+mod flexspi_common;
+
+use flexspi_common::{FLASH_CONFIG, check_erased, check_pattern, fill_pattern, pattern_byte};
+
+// ----- geometry -----
+const PAGE: u32 = 256;
+const SECTOR: u32 = 4096;
+const NUM_SECTORS: u32 = 2048; // W25Q64 = 8 MiB
+const PAGES_PER_SECTOR: u32 = SECTOR / PAGE; // 16
+
+/// FlexSPI AHB memory-mapped window, secure alias (the core boots secure).
+const AMBA_BASE_S: u32 = 0x9000_0000;
+
+// ----- wear management -----
+/// Window walked across the device each round (2 sectors -> cross-sector reads
+/// and neighbour-isolation).
+const WINDOW_SECTORS: u32 = 2;
+/// Top sector is a never-erased integrity canary; the window never reaches it.
+const CANARY_SECTOR: u32 = NUM_SECTORS - 1; // 2047
+/// Rotation modulus so the window stays in `0..=2045` (below the canary).
+const ROT_MOD: u32 = NUM_SECTORS - WINDOW_SECTORS; // 2046
+/// Prime, coprime with ROT_MOD (2046 = 2*3*11*31) -> visits every base once
+/// per sweep, spreading wear uniformly.
+const ROT_STRIDE: u32 = 1021;
+/// Hard backstop: stop before any sector approaches its ~100k erase rating.
+const ERASE_BUDGET: u16 = 50_000;
+
+// ----- reporting -----
+const SEED: u32 = 0x1234_5678;
+const HEARTBEAT_ROUNDS: u64 = 64;
+/// Wall-clock time limit; the soak stops and halts (bkpt) when reached.
+const SOAK_DURATION_SECS: u64 = 300;
+
+#[inline]
+fn xorshift32(s: &mut u32) -> u32 {
+    let mut x = *s;
+    x ^= x << 13;
+    x ^= x >> 17;
+    x ^= x << 5;
+    *s = x;
+    x
+}
+
+/// Uniform-ish `lo..hi` (hi exclusive). Caller guarantees `hi > lo`.
+#[inline]
+fn gen_range(s: &mut u32, lo: u32, hi: u32) -> u32 {
+    lo + xorshift32(s) % (hi - lo)
+}
+
+/// One memory-mapped (AHB/XIP) byte at flash `offset`.
+#[inline]
+fn mmap_byte(offset: u32) -> u8 {
+    // SAFETY: inside the FlexSPI secure memory-mapped window, valid for reads
+    // while the driver is initialised.
+    unsafe { core::ptr::read_volatile((AMBA_BASE_S + offset) as *const u8) }
+}
+
+/// IP-read `[addr, addr+len)` and assert it matches `pattern_byte`. Fatal.
+fn expect_pattern(flash: &mut NorFlash<'_, Blocking>, addr: u32, len: usize, buf: &mut [u8], round: u64, phase: &str) {
+    unwrap!(flash.blocking_read(addr, &mut buf[..len]));
+    if let Some(bad) = check_pattern(addr, &buf[..len]) {
+        let got = buf[(bad - addr) as usize];
+        defmt::panic!(
+            "SOAK FAIL [{=str}] round={=u64} pattern mismatch @0x{=u32:08x} exp=0x{=u8:02x} got=0x{=u8:02x} (read start=0x{=u32:08x} len={=usize})",
+            phase,
+            round,
+            bad,
+            pattern_byte(bad),
+            got,
+            addr,
+            len
+        );
+    }
+}
+
+/// IP-read `[addr, addr+len)` and assert it is fully erased (0xFF). Fatal.
+fn expect_erased(flash: &mut NorFlash<'_, Blocking>, addr: u32, len: usize, buf: &mut [u8], round: u64, phase: &str) {
+    unwrap!(flash.blocking_read(addr, &mut buf[..len]));
+    if let Some(bad) = check_erased(addr, &buf[..len]) {
+        let got = buf[(bad - addr) as usize];
+        defmt::panic!(
+            "SOAK FAIL [{=str}] round={=u64} not erased @0x{=u32:08x} got=0x{=u8:02x} (read start=0x{=u32:08x} len={=usize})",
+            phase,
+            round,
+            bad,
+            got,
+            addr,
+            len
+        );
+    }
+}
+
+/// Program a whole sector with the address-derived pattern, split into
+/// random-sized in-page sub-writes (never crossing a page boundary).
+/// Program a whole sector with the pattern using random **8-byte-aligned**
+/// sub-page writes (the driver's write-size contract: multiple writes per page,
+/// each at an 8-aligned offset with a multiple-of-8 length).
+fn program_sector_split(flash: &mut NorFlash<'_, Blocking>, sector_addr: u32, page: &mut [u8; 256], prng: &mut u32) {
+    for p in 0..PAGES_PER_SECTOR {
+        let page_addr = sector_addr + p * PAGE;
+        fill_pattern(page_addr, page);
+        let mut start = 0u32;
+        while start < PAGE {
+            let units_left = (PAGE - start) / 8; // PAGE and start are multiples of 8
+            let units = if units_left <= 1 {
+                1
+            } else {
+                gen_range(prng, 1, units_left + 1)
+            };
+            let end = start + units * 8;
+            unwrap!(flash.blocking_page_program(page_addr + start, &page[start as usize..end as usize]));
+            start = end;
+        }
+    }
+}
+
+/// Program a whole sector with the pattern, one full page at a time.
+fn program_sector_simple(flash: &mut NorFlash<'_, Blocking>, sector_addr: u32, page: &mut [u8; 256]) {
+    for p in 0..PAGES_PER_SECTOR {
+        let page_addr = sector_addr + p * PAGE;
+        fill_pattern(page_addr, page);
+        unwrap!(flash.blocking_page_program(page_addr, &page[..]));
+    }
+}
+
+/// Which contract-violation error a negative test expects.
+#[derive(Clone, Copy)]
+enum Expect {
+    InvalidLen,
+    Misaligned,
+    OutOfBounds,
+}
+
+/// Assert a write/read returned the expected contract-violation error. Fatal.
+fn expect_err(r: Result<(), IoError>, expect: Expect, round: u64, what: &str) {
+    let ok = matches!(
+        (&r, expect),
+        (Err(IoError::InvalidTransferLength), Expect::InvalidLen)
+            | (Err(IoError::Misaligned), Expect::Misaligned)
+            | (Err(IoError::OutOfBounds), Expect::OutOfBounds)
+    );
+    if !ok {
+        defmt::panic!(
+            "SOAK FAIL [{=str}] round={=u64}: contract not enforced (wrong/absent Err)",
+            what,
+            round
+        );
+    }
+}
+
+/// `(offset within window, length)` reads forced every round so the FIFO/page/
+/// sector seams are always exercised, not merely sometimes.
+const BOUNDARY: &[(u32, usize)] = &[
+    (0, 1),
+    (0, 4096),
+    (1, 127),
+    (3, 33),
+    (7, 13),
+    (100, 100),   // crosses the 128 B IP-FIFO seam
+    (120, 16),    // crosses 128
+    (127, 4),     // crosses 128
+    (200, 120),   // crosses the 256 B page seam
+    (255, 2),     // crosses 256
+    (255, 257),   // crosses 256, multi-chunk
+    (256, 256),   // page-aligned
+    (257, 255),   // unaligned tail
+    (2048, 4096), // spans the 4096 B sector seam into the second sector
+    (4095, 2),    // straddles the sector boundary
+    (4096, 1),
+    (4096, 256),
+];
+
+#[embassy_executor::main]
+async fn main(_spawner: Spawner) {
+    let p = hal::init(Config::default());
+
+    info!("FlexSPI NOR soak test (DESTRUCTIVE to the whole external flash)");
+    info!(
+        "seed=0x{=u32:08x}  window={=u32} sectors  rotation: base += {=u32} mod {=u32}  canary sector={=u32}  erase budget={=u16}",
+        SEED, WINDOW_SECTORS, ROT_STRIDE, ROT_MOD, CANARY_SECTOR, ERASE_BUDGET
+    );
+
+    let flexspi = unwrap!(Flexspi::new_blocking(
+        p.FLEXSPI0,
+        p.P3_0,
+        p.P3_7,
+        p.P3_6,
+        p.P3_8,
+        p.P3_9,
+        p.P3_10,
+        p.P3_11,
+        FlexspiClockConfig::default(),
+        FLASH_CONFIG,
+    ));
+    let mut flash = NorFlash::new(flexspi);
+
+    // Vendor-id sanity (W25Q64 == 0xEF). 0x00/0x7F would mean a dead/floating bus.
+    let id = unwrap!(flash.blocking_vendor_id());
+    if id != 0xEF {
+        defmt::panic!("unexpected vendor id 0x{=u8:02x} (expected 0xEF Winbond)", id);
+    }
+    info!("vendor id 0x{=u8:02x} OK", id);
+
+    let mut buf = [0u8; 4096];
+    let mut page = [0u8; 256];
+    let mut erase_count = [0u16; NUM_SECTORS as usize];
+
+    // ---- one-time: program the canary sector (never erased afterwards) ----
+    let canary_addr = CANARY_SECTOR * SECTOR;
+    unwrap!(flash.blocking_erase_sector(canary_addr));
+    erase_count[CANARY_SECTOR as usize] += 1;
+    program_sector_simple(&mut flash, canary_addr, &mut page);
+    expect_pattern(&mut flash, canary_addr, SECTOR as usize, &mut buf, 0, "canary-init");
+    info!("canary programmed at 0x{=u32:08x}", canary_addr);
+
+    // ---- one-time: cold memory-mapped vs IP validation (fatal) ----
+    // Fresh program with no prior mmap access -> no staleness confound, so this
+    // is a clean check that the AFLASHBASE=0 / DLLCR / ARDSEQNUM fixes hold.
+    {
+        let a = 0u32; // sector 0
+        unwrap!(flash.blocking_erase_sector(a));
+        erase_count[0] += 1;
+        program_sector_simple(&mut flash, a, &mut page);
+        unwrap!(flash.blocking_read(a, &mut buf[..SECTOR as usize]));
+        for i in 0..SECTOR {
+            let m = mmap_byte(a + i);
+            let ip = buf[i as usize];
+            let exp = pattern_byte(a + i);
+            if m != ip || m != exp {
+                defmt::panic!(
+                    "COLD mmap/IP mismatch @0x{=u32:08x} mmap=0x{=u8:02x} ip=0x{=u8:02x} exp=0x{=u8:02x}",
+                    a + i,
+                    m,
+                    ip,
+                    exp
+                );
+            }
+        }
+        info!("cold memory-mapped vs IP validation OK ({=u32} bytes)", SECTOR);
+    }
+
+    info!("starting soak loop");
+
+    // ---- soak loop ----
+    let mut prng = SEED;
+    let mut base: u32 = 0;
+    let mut round: u64 = 0u64;
+    let mut total_erases: u64 = 0;
+    let mut bytes_written: u64 = 0;
+    let mut bytes_read: u64 = 0;
+    let mut mmap_mismatch: u64 = 0;
+    let mut stale_mmap: u64 = 0;
+    let mut neg_ok: u64 = 0;
+    let start = Instant::now();
+
+    loop {
+        let prng_at_round = prng;
+        let s0 = base * SECTOR;
+        let s1 = (base + 1) * SECTOR;
+        let win = s0; // window base address
+
+        // Stop cleanly at the wall-clock limit.
+        if start.elapsed() >= Duration::from_secs(SOAK_DURATION_SECS) {
+            warn!("soak time limit ({=u64}s) reached", SOAK_DURATION_SECS);
+            break;
+        }
+
+        // Wear backstop: stop cleanly if any window sector nears its rating.
+        let max_in_window = erase_count[base as usize].max(erase_count[(base + 1) as usize]);
+        if max_in_window >= ERASE_BUDGET {
+            warn!(
+                "erase budget reached on sector {=u32} ({=u16} erases) -- stopping to protect the flash",
+                base, max_in_window
+            );
+            break;
+        }
+
+        // 1) erase the window, verify erased (IP only -- avoid mmap here so the
+        //    step-3 mmap cross-check has no staleness confound).
+        unwrap!(flash.blocking_erase_sector(s0));
+        unwrap!(flash.blocking_erase_sector(s1));
+        erase_count[base as usize] += 1;
+        erase_count[(base + 1) as usize] += 1;
+        total_erases += 2;
+        expect_erased(&mut flash, s0, SECTOR as usize, &mut buf, round, "erase-verify-s0");
+        expect_erased(&mut flash, s1, SECTOR as usize, &mut buf, round, "erase-verify-s1");
+
+        // 2) program: s0 with random 8-byte-aligned sub-page writes (the valid
+        //    multi-write path), s1 with full pages.
+        program_sector_split(&mut flash, s0, &mut page, &mut prng);
+        program_sector_simple(&mut flash, s1, &mut page);
+        bytes_written += 2 * SECTOR as u64;
+
+        // 3) verify both sectors via IP (fatal), then a full mmap cross-check of
+        //    s0 against IP and pattern (fatal: read-path integrity).
+        expect_pattern(&mut flash, s0, SECTOR as usize, &mut buf, round, "verify-s0");
+        expect_pattern(&mut flash, s1, SECTOR as usize, &mut buf, round, "verify-s1");
+        unwrap!(flash.blocking_read(s0, &mut buf[..SECTOR as usize]));
+        for i in 0..SECTOR {
+            let m = mmap_byte(s0 + i);
+            let ip = buf[i as usize];
+            let exp = pattern_byte(s0 + i);
+            if m != ip || m != exp {
+                defmt::panic!(
+                    "SOAK FAIL [mmap-xcheck] round={=u64} @0x{=u32:08x} mmap=0x{=u8:02x} ip=0x{=u8:02x} exp=0x{=u8:02x} (prng=0x{=u32:08x})",
+                    round,
+                    s0 + i,
+                    m,
+                    ip,
+                    exp,
+                    prng_at_round
+                );
+            }
+        }
+        bytes_read += 2 * SECTOR as u64;
+
+        // 4) boundary/length matrix (both sectors are fully patterned now).
+        for &(off, len) in BOUNDARY {
+            expect_pattern(&mut flash, win + off, len, &mut buf, round, "boundary");
+            bytes_read += len as u64;
+        }
+
+        // 5) neighbour isolation: erase s0, s1 must be untouched.
+        unwrap!(flash.blocking_erase_sector(s0));
+        erase_count[base as usize] += 1;
+        total_erases += 1;
+        expect_pattern(&mut flash, s1, SECTOR as usize, &mut buf, round, "neighbour-s1");
+        expect_erased(&mut flash, s0, SECTOR as usize, &mut buf, round, "neighbour-s0-erased");
+
+        // 6) stale AHB-buffer probe (counted, not fatal): mmap a patterned page
+        //    of s1, erase s1 via IP, then mmap again -- must read 0xFF.
+        {
+            let pp = gen_range(&mut prng, 0, PAGES_PER_SECTOR) * PAGE;
+            let page_addr = s1 + pp;
+            // populate the AHB prefetch buffer with the current (patterned) data
+            let mut warmed_ok = true;
+            for i in 0..PAGE {
+                if mmap_byte(page_addr + i) != pattern_byte(page_addr + i) {
+                    warmed_ok = false;
+                }
+            }
+            unwrap!(flash.blocking_erase_sector(s1));
+            erase_count[(base + 1) as usize] += 1;
+            total_erases += 1;
+            core::sync::atomic::compiler_fence(core::sync::atomic::Ordering::SeqCst);
+            cortex_m::asm::dsb();
+            let mut stale = false;
+            for i in 0..PAGE {
+                if mmap_byte(page_addr + i) != 0xFF {
+                    stale = true;
+                }
+            }
+            if stale {
+                stale_mmap += 1;
+                warn!(
+                    "stale AHB read after erase @0x{=u32:08x} round={=u64} (mmap returned pre-erase data; IP path is ground truth)",
+                    page_addr, round
+                );
+            } else if !warmed_ok {
+                // mmap disagreed with the pattern *before* the erase -> a plain
+                // read-path issue, count it.
+                mmap_mismatch += 1;
+                warn!(
+                    "mmap disagreed with pattern pre-erase @0x{=u32:08x} round={=u64}",
+                    page_addr, round
+                );
+            }
+        }
+
+        // 7) contract enforcement (s1 is erased; scratch = page 0 of s1). Every
+        //    out-of-contract call must return the right Err and not touch flash.
+        {
+            let scratch = s1;
+            for (i, b) in buf[..257].iter_mut().enumerate() {
+                *b = i as u8;
+            }
+            expect_err(
+                flash.blocking_page_program(scratch, &buf[..257]),
+                Expect::InvalidLen,
+                round,
+                "over-length",
+            );
+            expect_err(
+                flash.blocking_page_program(scratch, &[]),
+                Expect::InvalidLen,
+                round,
+                "empty",
+            );
+            expect_err(
+                flash.blocking_page_program(scratch + 4, &buf[..8]),
+                Expect::Misaligned,
+                round,
+                "addr-misalign",
+            );
+            expect_err(
+                flash.blocking_page_program(scratch, &buf[..12]),
+                Expect::Misaligned,
+                round,
+                "len-misalign",
+            );
+            expect_err(
+                flash.blocking_page_program(scratch + (PAGE - 8), &buf[..16]),
+                Expect::Misaligned,
+                round,
+                "page-cross",
+            );
+            expect_err(
+                flash.blocking_page_program(NUM_SECTORS * SECTOR, &buf[..8]),
+                Expect::OutOfBounds,
+                round,
+                "oob-prog",
+            );
+            expect_err(
+                flash.blocking_read(NUM_SECTORS * SECTOR, &mut buf[..16]),
+                Expect::OutOfBounds,
+                round,
+                "oob-read",
+            );
+            neg_ok += 7;
+            // none of the rejected calls touched the flash
+            expect_erased(
+                &mut flash,
+                scratch,
+                PAGE as usize,
+                &mut buf,
+                round,
+                "neg-no-side-effect",
+            );
+            // zero-length read is a defined no-op
+            if flash.blocking_read(scratch, &mut []).is_err() {
+                defmt::panic!(
+                    "SOAK FAIL [neg-zero-read] round={=u64} zero-length read returned Err",
+                    round
+                );
+            }
+            neg_ok += 1;
+        }
+
+        // 9) canary integrity (wild-write detector), every round.
+        expect_pattern(&mut flash, canary_addr, SECTOR as usize, &mut buf, round, "canary");
+        // and the two read engines must agree on the canary
+        unwrap!(flash.blocking_read(canary_addr, &mut buf[..PAGE as usize]));
+        for i in 0..PAGE {
+            if mmap_byte(canary_addr + i) != buf[i as usize] {
+                defmt::panic!(
+                    "SOAK FAIL [canary-xcheck] round={=u64} @0x{=u32:08x} mmap != ip",
+                    round,
+                    canary_addr + i
+                );
+            }
+        }
+
+        // advance
+        round += 1;
+        base = (base + ROT_STRIDE) % ROT_MOD;
+
+        if round % HEARTBEAT_ROUNDS == 0 {
+            let mut max_erase = 0u16;
+            for &c in erase_count.iter() {
+                if c > max_erase {
+                    max_erase = c;
+                }
+            }
+            info!(
+                "[hb] round={=u64} erases={=u64} wrote={=u64}KiB read={=u64}KiB mmap_mismatch={=u64} stale_mmap={=u64} neg_ok={=u64} max_sector_erases={=u16} next_base={=u32}",
+                round,
+                total_erases,
+                bytes_written / 1024,
+                bytes_read / 1024,
+                mmap_mismatch,
+                stale_mmap,
+                neg_ok,
+                max_erase,
+                base
+            );
+        }
+    }
+
+    info!(
+        "soak finished: rounds={=u64} erases={=u64} mmap_mismatch={=u64} stale_mmap={=u64} neg_ok={=u64}",
+        round, total_erases, mmap_mismatch, stale_mmap, neg_ok
+    );
+    loop {
+        cortex_m::asm::bkpt();
+    }
+}

--- a/examples/mcxa5xx/src/bin/flexspi-stress.rs
+++ b/examples/mcxa5xx/src/bin/flexspi-stress.rs
@@ -129,11 +129,10 @@ const READ_OFFSETS: &[u32] = &[
     0, 1, 2, 3, 4, 5, 7, 16, 17, 64, 100, 127, 128, 129, 200, 255, 256, 257, 4095, 4096, 4097,
 ];
 
-/// Program sizes covering the DMA fast path (`>= 8 && % 8 == 0`) and the
-/// FIFO fallback (everything else).
-const PROGRAM_SIZES: &[usize] = &[
-    1, 2, 3, 4, 7, 8, 9, 15, 16, 17, 24, 31, 32, 33, 63, 64, 65, 100, 128, 200, 248, 255, 256,
-];
+/// Program sizes. The driver requires 8-byte-aligned writes (its write-size
+/// contract), so every entry is a multiple of 8; this still exercises both the
+/// DMA fast path (DMA mode) and the IP/FIFO path (blocking/interrupt mode).
+const PROGRAM_SIZES: &[usize] = &[8, 16, 24, 32, 40, 64, 96, 128, 192, 200, 248, 256];
 
 bind_interrupts!(struct Irqs {
     FLEXSPI0 => flexspi::InterruptHandler<peripherals::FLEXSPI0>;
@@ -530,7 +529,7 @@ async fn run_stress<F: FlashOps>(mode: &'static str, flash: &mut F, fails: &mut 
     //     tail.  Distinct from the program-size matrix in that it lives
     //     in its own dedicated sector so we don't perturb earlier results.
     unwrap!(flash.erase_sector(overlay_sector).await);
-    let partial_len = 100usize;
+    let partial_len = 96usize; // 8-byte aligned (driver write-size contract)
     let mut partial = [0u8; FLASH_PAGE_SIZE];
     fill_pattern(overlay_sector, &mut partial);
     unwrap!(flash.page_program(overlay_sector, &partial[..partial_len]).await);


### PR DESCRIPTION
Hardens the MCXA5xx FlexSPI NOR driver and adds two long-running, self-checking soak tests, all validated on FRDM-MCXA577 hardware (on-board Winbond W25Q64, 8 MiB). Builds on the AHBCR/DLLCR/FLSHCR2 register fixes in #6386.

Four commits:

- require 8-byte-aligned writes; validate program/read/erase bounds — API hardening
- add NOR soak test — blocking + memory-mapped torture test
- make the async path cancel-safe — correctness fix for dropped async futures
- add async/DMA cancellation soak — hardware proof of (3)

## Write-size contract + bounds validation

The FlexSPI IP write path corrupts the byte before a non-8-byte-aligned start address when a consecutive write follows in the same page (a controller alignment quirk — the FIFO-fill loop is byte-identical to the NXP SDK's FLEXSPI_WriteBlocking; single writes of any length are fine). Rather than silently corrupt data, page_program now enforces a write-size contract and all entry points bounds-check against the configured flash size:

- page_program (blocking and async): requires addr % 8 == 0, len % 8 == 0, within a single page, in-bounds — else returns Err before touching the flash.
- read / erase_sector (blocking + async): bounds-checked instead of wrapping.
- New IoError variants: Misaligned, OutOfBounds (IoError is #[non_exhaustive], so this is non-breaking).

Partial-page writes remain fully supported — just at 8-byte granularity, the standard WRITE_SIZE model, and the same granularity the DMA path already required.

The bundled examples are updated to comply (partial_len 100 → 96; flexspi-stress PROGRAM_SIZES made 8-aligned).

## Async cancel-safety

A dropped in-flight async future (the idiomatic result of with_timeout, select!, or task cancellation) could leave the FlexSPI sequence engine non-idle (CS asserted, TX-FIFO underrun), after which the next operation spun forever in prepare_ip_transfer's wait_idle(). The driver had no recovery, so any async cancellation wedged the controller.

prepare_ip_transfer is now self-healing: if the engine isn't idle on entry (the fingerprint of a cancelled op), it issues a software_reset to force idle / de-assert CS / flush FIFOs before proceeding. A single SEQIDLE sample is authoritative because SEQIDLE only deasserts on a fresh IPCMD trigger and none is pending there; the LUT and controller config survive a software reset (the init path already relies on this).

Design note: timeout policy (how long to wait, whether to give up) is deliberately left to the application via the with_timeout combinator — the driver imposes no timeout of its own and keeps embassy-time out of its hot path. The recovery above is what makes that combinator safe: when the caller's timeout cancels an op mid-flight, the driver un-wedges itself for the next one.

## Soak tests

Two destructive, self-checking torture loops over a wear-spread rotating window with a never-erased canary sector, a per-sector erase budget, a wall-clock limit, and bkpt on completion; every round is driven by a logged xorshift seed so any failure is reproducible.

- flexspi-soak — blocking IP + memory-mapped (AHB) paths: erase/verify, fuzzed 8-aligned sub-page programs, IP-vs-mmap cross-check, boundary/length read matrix, neighbour isolation, stale-AHB probe, and the write-size/bounds contract (negative tests).
- flexspi-cancel-soak — async + DMA paths: DMA program/read integrity plus cancellation torture (an op is bounded with with_timeout across a delay sweep so it's dropped in flight; a fresh op must then recover with correct data).

Testing (FRDM-MCXA577 / W25Q64)

- Blocking self-test: PASSED
- flexspi-soak (blocking + mmap): 384 rounds clean, mmap_mismatch=0, contract negatives all enforced
- flexspi-cancel-soak (async + DMA): 388 rounds, 5044 in-flight cancellations, 3880 clean recoveries, zero wedges, zero data corruption

Compatibility / risk

- Public API: additive only (two new #[non_exhaustive] IoError variants). Callers doing sub-page writes must align to 8 bytes; previously such writes silently corrupted an adjacent byte.
- No embedded-storage trait impl yet, but the contract maps cleanly to a future WRITE_SIZE = 8 / ERASE_SIZE = 4096.