### PR TITLE
feat(sync): public poll_next_message / poll_changed for Subscriber and watch Receiver

### DIFF
--- a/embassy-sync/CHANGELOG.md
+++ b/embassy-sync/CHANGELOG.md
@@ -26,6 +26,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   bytes were written.
 - Implement `core::error::Error` for `channel::TryReceiveError` and `channel::TrySendError`.
 - Made `Signal::poll_wait` public.
+- Made `Subscriber::poll_next_message` public.
+- Made `watch::Receiver::poll_changed` public.
 
 ## 0.8.0 - 2026-03-10
 - Fix wakers getting dropped by `Signal::reset`

--- a/embassy-sync/src/pubsub/subscriber.rs
+++ b/embassy-sync/src/pubsub/subscriber.rs
@@ -33,6 +33,11 @@ impl<'a, PSB: PubSubBehavior<T> + ?Sized, T: Clone> Sub<'a, PSB, T> {
         SubscriberWaitFuture { subscriber: self }
     }
 
+    /// Poll for the next published message, preserving lag results.
+    pub fn poll_next_message(&mut self, cx: &mut Context<'_>) -> Poll<WaitResult<T>> {
+        self.channel.get_message_with_context(&mut self.next_message_id, Some(cx))
+    }
+
     /// Wait for a published message (ignoring lag results)
     pub async fn next_message_pure(&mut self) -> T {
         loop {

--- a/embassy-sync/src/pubsub/subscriber.rs
+++ b/embassy-sync/src/pubsub/subscriber.rs
@@ -35,7 +35,8 @@ impl<'a, PSB: PubSubBehavior<T> + ?Sized, T: Clone> Sub<'a, PSB, T> {
 
     /// Poll for the next published message, preserving lag results.
     pub fn poll_next_message(&mut self, cx: &mut Context<'_>) -> Poll<WaitResult<T>> {
-        self.channel.get_message_with_context(&mut self.next_message_id, Some(cx))
+        self.channel
+            .get_message_with_context(&mut self.next_message_id, Some(cx))
     }
 
     /// Wait for a published message (ignoring lag results)

--- a/embassy-sync/src/watch.rs
+++ b/embassy-sync/src/watch.rs
@@ -587,6 +587,11 @@ impl<'a, T: Clone, W: WatchBehavior<T> + ?Sized> Rcv<'a, T, W> {
         poll_fn(|cx| self.watch.poll_changed(&mut self.at_id, cx)).await
     }
 
+    /// Poll the `Watch` for a changed value, marking it as seen.
+    pub fn poll_changed(&mut self, cx: &mut Context<'_>) -> Poll<T> {
+        self.watch.poll_changed(&mut self.at_id, cx)
+    }
+
     /// Tries to get the new value of the watch without waiting, marking it as seen.
     pub fn try_changed(&mut self) -> Option<T> {
         self.watch.try_changed(&mut self.at_id)


### PR DESCRIPTION
`Channel` already exposes a public `poll_receive`, but the pubsub `Subscriber`
and watch `Receiver` only offer the async (`next_message` / `changed`) and
`try_*` forms, plus a `Stream` impl that drops `WaitResult::Lagged`. This adds
the matching public poll methods so the primitives can be driven from a
manually-written `poll` (e.g. bridging them behind another poll-based trait)
while preserving lag:

- `Subscriber::poll_next_message(&mut self, cx) -> Poll<WaitResult<T>>`
- `watch::Receiver::poll_changed(&mut self, cx) -> Poll<T>`

Both are thin, additive wrappers over the existing sealed methods the async
versions already use (`get_message_with_context` / `poll_changed`); no behavior
change to existing APIs.