### PR TITLE
STM32 OctoSPI fixes #1

### DIFF
--- a/embassy-stm32/src/ospi/mod.rs
+++ b/embassy-stm32/src/ospi/mod.rs
@@ -286,6 +286,11 @@ impl<'d, T: Instance, M: PeriMode> Ospi<'d, T, M> {
 
     /// Quit from memory mapped mode
     pub fn disable_memory_mapped_mode(&mut self) {
+        // Ensure memory transactions have completed.
+        // If this is called immediately after writing to memory mapped memory a BusFault of type
+        // 'Imprecise data access error' could occur.
+        cortex_m::asm::dsb();
+
         let reg = T::REGS;
 
         reg.cr().modify(|r| {

--- a/embassy-stm32/src/ospi/mod.rs
+++ b/embassy-stm32/src/ospi/mod.rs
@@ -269,7 +269,9 @@ impl<'d, T: Instance, M: PeriMode> Ospi<'d, T, M> {
             w.set_ddtr(write_config.ddtr);
 
             w.set_abmode(PhaseMode::from_bits(write_config.abwidth.into()));
-            w.set_dqse(write_config.dqse);
+            // Always Enable DQS bit - without this bit set every write request returns an error
+            // See "ES0491 - Rev 9 - 2.8.6 - Memory-mapped write error response when DQS output is disabled"
+            w.set_dqse(true);
         });
 
         reg.wtcr().modify(|w| w.set_dcyc(write_config.dummy.into()));


### PR DESCRIPTION
As per matrix chat:

> Today I was finally getting round to making the register access work using memory mapped mode. I got it working, but ran into three issues:
> 1)    embassy defauts SIOO (Send Instruction Only Once) to TRUE by default, this is not good, as it requires explicit hardware support, and thus as this should be explicitly set. Due to this default the second read was returning garbage.
> 2)    there's an errata on the H7 (and other MCUs using the same OctoSPI peripheral version) regarding DQSE and memory mapped writes that needs a simple workaround.
> 3)    disabling memory mapped mode immediately after a write was the cause of the bus error because a write transaction was still in progress. adding a DSB instruction fixed that.

This PR addresses points 2 and 3, via separate commits.

I have only tested this on the STM32H735 that I am currently working with, however the dqse errata seems to apply to other STM32 MCUs with the OctoSPI peripheral.

e.g.

STM32L4Rxxx/STM32L4Sxxx - ES0393 - Rev 10 2.8.17 "Memory-mapped write error response when DQS output is disabled"

I'm not sure if some gating on ospi peripheral versions is needed or not.