### PR TITLE
Set SIOO to false by default.

### DIFF
--- a/embassy-stm32/src/ospi/mod.rs
+++ b/embassy-stm32/src/ospi/mod.rs
@@ -171,6 +171,9 @@ pub struct TransferConfig {
     /// Data strobe (DQS) management enable
     pub dqse: bool,
     /// Send instruction only once (SIOO) mode enable
+    /// Enable this to improve memory-mapped latency. Ensure your device supports this mode.
+    /// Some manufacturers call this 'Continuous Read' mode and require specific bits to be set
+    /// in alternate bytes (e.g. Winbound W25Q) and specific disable sequences.
     pub sioo: bool,
 }
 
@@ -198,7 +201,7 @@ impl Default for TransferConfig {
             dummy: DummyCycles::_0,
 
             dqse: false,
-            sioo: true,
+            sioo: false,
         }
     }
 }


### PR DESCRIPTION
SIOO requires explicit hardware support to work - aka 'Continuous Read' on Winbond NOR flashes.

The only example currently using `enable_memory_mapped_mode` (`examples/stm32h7b0/src/bin/ospi_memory_mapped.rs`) did not configure the required alternate bytes configuration for the W2Q64JV and did not read from two addresses that would require the OctoSPI FIFO to be filled twice from different non-consecutive addresses that are further apart from each other than the size of the OctoSPI FIFO length. 

The offending example code is:

```rust
    flash.enable_mm().await;
    info!("Enabled memory mapped mode");

    let first_u32 = unsafe { *(0x90000000 as *const u32) };
    assert_eq!(first_u32, 0x03020100);

    let second_u32 = unsafe { *(0x90000004 as *const u32) };
    assert_eq!(second_u32, 0x07060504);
    flash.disable_mm().await;
```

here the addresses `0x90000000` and `0x90000004` are used, but the OctoSPI FIFO is 0x20 bytes long, so on the first read to `0x90000000` the memory for the second read at `0x90000004` will already be in the FIFO, as there are no maxtransfer or other settings configured to prevent the FIFO from being filled completly, and thus the MCU will not actually request memory from a different address.  If it DID, then the current SIOO default would cause it to fail because the flash chip is not correctly configured.

The example could be improved so that two reads are performed at are further than 0x20 apart are performed.  I will leave this point to the discretion of the maintainers.