### PR TITLE
N6 ADC Support

### DIFF
--- a/embassy-stm32/src/adc/mod.rs
+++ b/embassy-stm32/src/adc/mod.rs
@@ -12,7 +12,7 @@
 #[cfg_attr(adc_l0, path = "v1.rs")]
 #[cfg_attr(adc_v2, path = "v2.rs")]
 #[cfg_attr(any(adc_v3, adc_g0, adc_h5, adc_h7rs, adc_u0), path = "v3.rs")]
-#[cfg_attr(any(adc_v4, adc_u5, adc_u3), path = "v4.rs")]
+#[cfg_attr(any(adc_v4, adc_u5, adc_u3, adc_n6), path = "v4.rs")]
 #[cfg_attr(adc_g4, path = "g4.rs")]
 #[cfg_attr(adc_c0, path = "c0.rs")]
 mod _version;
@@ -199,7 +199,7 @@ pub(crate) trait SealedAdcChannel<T> {
     }
 }
 
-#[cfg(any(adc_c0, adc_v3, adc_g0, adc_h5, adc_h7rs, adc_u0, adc_v4, adc_u5, adc_u3))]
+#[cfg(any(adc_c0, adc_v3, adc_g0, adc_h5, adc_h7rs, adc_u0, adc_v4, adc_u5, adc_u3, adc_n6))]
 /// Number of samples used for averaging.
 #[derive(Copy, Clone, Debug)]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
@@ -213,9 +213,9 @@ pub enum Averaging {
     Samples64,
     Samples128,
     Samples256,
-    #[cfg(any(adc_c0, adc_v4, adc_u5, adc_u3))]
+    #[cfg(any(adc_c0, adc_v4, adc_u5, adc_u3, adc_n6))]
     Samples512,
-    #[cfg(any(adc_c0, adc_v4, adc_u5, adc_u3))]
+    #[cfg(any(adc_c0, adc_v4, adc_u5, adc_u3, adc_n6))]
     Samples1024,
 }
 
@@ -325,7 +325,12 @@ impl<'d, T: Instance> Adc<'d, T> {
             while !T::regs().wait_done() {}
         }
 
-        unsafe { core::ptr::read_volatile(T::regs().data()) }
+        #[cfg(not(stm32n6))]
+        return unsafe { core::ptr::read_volatile(T::regs().data()) };
+        #[cfg(stm32n6)]
+        unsafe {
+            core::ptr::read_volatile(T::regs().data() as *mut u32) as u16
+        }
     }
 
     /// Read one or multiple ADC regular channels using DMA.
@@ -388,7 +393,23 @@ impl<'d, T: Instance> Adc<'d, T> {
 
         let request = rx_dma.request();
         let mut dma_channel = crate::dma::Channel::new(rx_dma, irq);
+        #[cfg(not(stm32n6))]
         let transfer = unsafe { dma_channel.read(request, T::regs().data(), readings, Default::default()) };
+        #[cfg(stm32n6)]
+        let transfer = unsafe {
+            dma_channel.read_raw(
+                request,
+                T::regs().data() as *mut u32,
+                readings,
+                crate::dma::TransferOptions {
+                    // DMA will read 0 unless it is marked as secure along with RISUP 64 (ADC12)
+                    secure: true,
+                    // Don't pack readings into buffer
+                    packing: crate::pac::gpdma::vals::Pam::ZeroExtendOrLeftTruncate,
+                    ..Default::default()
+                },
+            )
+        };
 
         // Ensure conversions are finished, even in the event of dropping the future
         let _stop_adc = OnDrop::new(|| T::regs().stop());
@@ -744,7 +765,6 @@ impl VrefInt {
         stm32l4,
         stm32l4_plus,
         stm32l5,
-        stm32n6,
         stm32l5,
         stm32wb,
         stm32wl
@@ -987,7 +1007,9 @@ pub(crate) trait AnalogPin {
 
 impl<T: crate::gpio::SealedPin> AnalogPin for T {
     fn set_as_analog(&self) {
-        #[cfg(any(adc_v1, adc_c0, adc_l0, adc_v2, adc_g4, adc_v3, adc_v4, adc_u3, adc_u5, adc_wba))]
+        #[cfg(any(
+            adc_v1, adc_c0, adc_l0, adc_v2, adc_g4, adc_v3, adc_v4, adc_u3, adc_u5, adc_wba, stm32n6
+        ))]
         T::set_as_analog(self);
     }
 }

--- a/embassy-stm32/src/adc/v4.rs
+++ b/embassy-stm32/src/adc/v4.rs
@@ -1,13 +1,15 @@
+#[cfg(stm32n6)]
+use pac::adc::vals::Adcaldif;
 #[cfg(not(stm32u3))]
 use pac::adc::vals::Difsel;
-#[cfg(not(any(stm32u5, stm32u3)))]
+#[cfg(not(any(stm32u5, stm32u3, stm32n6)))]
 use pac::adc::vals::{Adcaldif, Boost};
 #[allow(unused)]
 use pac::adc::vals::{Adstp, Dmngt, Exten, Pcsel};
-#[cfg(not(stm32u3))]
+#[cfg(not(any(stm32u3, stm32n6)))]
 use pac::adccommon::vals::Presc;
 
-#[cfg(any(stm32u5, stm32u3))]
+#[cfg(any(stm32u5, stm32u3, stm32n6))]
 use crate::adc::DefaultInstance;
 use crate::adc::{
     Adc, AdcRegs, Averaging, ConversionMode, Instance, Resolution, SampleTime, Temperature, Vbat, VrefInt,
@@ -31,6 +33,8 @@ const MAX_ADC_CLK_FREQ: Hertz = Hertz::mhz(50);
 const MAX_ADC_CLK_FREQ: Hertz = Hertz::mhz(55);
 #[cfg(stm32u3)]
 const MAX_ADC_CLK_FREQ: Hertz = Hertz::mhz(48);
+#[cfg(stm32n6)]
+const MAX_ADC_CLK_FREQ: Hertz = Hertz::mhz(70);
 
 #[cfg(stm32g4)]
 impl<T: Instance> super::ConverterFor<super::VrefInt> for T {
@@ -51,7 +55,7 @@ impl<T: Instance> super::ConverterFor<super::Temperature> for T {
 }
 
 // TODO this should be 14 for H7a/b/35
-#[cfg(not(any(stm32u5, stm32u3)))]
+#[cfg(not(any(stm32u5, stm32u3, stm32n6)))]
 impl<T: Instance> super::ConverterFor<super::Vbat> for T {
     const CHANNEL: u8 = 17;
 }
@@ -69,7 +73,7 @@ impl<T: DefaultInstance> super::ConverterFor<super::Vbat> for T {
     const CHANNEL: u8 = 18;
 }
 
-#[cfg(stm32u3)]
+#[cfg(any(stm32u3, stm32n6))]
 impl<T: DefaultInstance> super::ConverterFor<super::Vbat> for T {
     const CHANNEL: u8 = 16;
 }
@@ -79,7 +83,12 @@ impl<T: DefaultInstance> super::ConverterFor<super::Temperature> for T {
     const CHANNEL: u8 = 17;
 }
 
-#[cfg(not(stm32u3))]
+#[cfg(stm32n6)]
+impl<T: DefaultInstance> super::ConverterFor<super::VrefInt> for T {
+    const CHANNEL: u8 = 17;
+}
+
+#[cfg(not(any(stm32u3, stm32n6)))]
 fn from_ker_ck(frequency: Hertz) -> Presc {
     let raw_prescaler = rcc::raw_prescaler(frequency.0, MAX_ADC_CLK_FREQ.0);
     match raw_prescaler {
@@ -183,7 +192,7 @@ impl AdcRegs for crate::pac::adc::Adc {
                 smpr2.set_smp((channel - 10) as _, sample_time);
             }
 
-            #[cfg(any(stm32h7, stm32u5, stm32u3))]
+            #[cfg(any(stm32h7, stm32u5, stm32u3, stm32n6))]
             {
                 self.cfgr2().modify(|w| w.set_lshift(0));
                 self.pcsel().modify(|w| w.set_pcsel(channel as _, Pcsel::Preselected));
@@ -254,14 +263,14 @@ impl<'d, T: Instance<Regs = crate::pac::adc::Adc>> Adc<'d, T> {
     pub fn new(adc: Peri<'d, T>) -> Self {
         rcc::enable_and_reset::<T>();
 
-        #[cfg(not(stm32u3))]
+        #[cfg(not(any(stm32u3, stm32n6)))]
         let prescaler = from_ker_ck(T::frequency());
-        #[cfg(not(stm32u3))]
+        #[cfg(not(any(stm32u3, stm32n6)))]
         T::common_regs().ccr().modify(|w| w.set_presc(prescaler));
-        #[cfg(not(stm32u3))]
+        #[cfg(not(any(stm32u3, stm32n6)))]
         let frequency = T::frequency() / prescaler;
 
-        #[cfg(stm32u3)]
+        #[cfg(any(stm32u3, stm32n6))]
         let frequency = T::frequency();
 
         info!("ADC frequency set to {}", frequency);
@@ -289,6 +298,7 @@ impl<'d, T: Instance<Regs = crate::pac::adc::Adc>> Adc<'d, T> {
 
         T::regs().cr().modify(|reg| {
             reg.set_deeppwd(false);
+            #[cfg(not(stm32n6))]
             reg.set_advregen(true);
         });
 
@@ -301,20 +311,88 @@ impl<'d, T: Instance<Regs = crate::pac::adc::Adc>> Adc<'d, T> {
             }
         });
 
-        #[cfg(not(stm32u3))]
-        T::regs().cr().modify(|w| {
-            #[cfg(not(adc_u5))]
-            w.set_adcaldif(Adcaldif::SingleEnded);
-            w.set_adcallin(true);
-        });
+        #[cfg(not(stm32n6))]
+        {
+            #[cfg(not(stm32u3))]
+            T::regs().cr().modify(|w| {
+                #[cfg(not(adc_u5))]
+                w.set_adcaldif(Adcaldif::SingleEnded);
+                w.set_adcallin(true);
+            });
 
-        T::regs().cr().modify(|w| w.set_adcal(true));
+            T::regs().cr().modify(|w| w.set_adcal(true));
 
-        while T::regs().cr().read().adcal() {}
+            while T::regs().cr().read().adcal() {}
 
-        block_for_us(1);
+            block_for_us(1);
 
-        T::regs().enable();
+            T::regs().enable();
+        }
+
+        #[cfg(stm32n6)]
+        {
+            // See STM32N6 reference manual 32.4.8: Software procedure to calibrate the ADC
+            const ADC_MIDPOINT: u64 = 0x7ff;
+            // Steps 4 to 8
+            let mut sample_and_average = || -> u64 {
+                let mut data = [0u64; 8];
+                for reading in &mut data {
+                    // 4. Set the ADSTART bit in the ADC_CR register.
+                    T::regs().cr().modify(|w| w.set_adstart(true));
+                    // 5. Wait until the ADSTART bit is cleared or the EOC flag is set.
+                    while T::regs().cr().read().adstart() && !T::regs().isr().read().eoc() {}
+                    // 6. Read the ADC_DR register, then copy the converted data to the memory.
+                    *reading = T::regs().dr().read().rdata() as u64;
+                    // 7. Repeat from step 4 several times (for example eight times).
+                }
+                // 8. Average the data stored in memory by dividing the accumulated data by the
+                // number of the conversions
+                data.iter().sum::<u64>() / data.len() as u64
+            };
+            // 1. Ensure DEEPPWD = 0, ADEN = 1 and wait until the ADRDY bit is set.
+            T::regs().cr().modify(|reg| reg.set_deeppwd(false));
+            block_for_us(1);
+            T::regs().enable();
+            // 2. Set ADCAL and ensure CALADDOS = 0.
+            T::regs().cr().modify(|w| w.set_adcal(true));
+            T::regs().calfact().modify(|w| w.set_caladdos(false));
+            // 3. Select the calibration input mode by clearing ADCALDIF (single-ended input).
+            T::regs().cr().modify(|w| w.set_adcaldif(Adcaldif::SingleEnded));
+            // Steps 4 to 8
+            let mut average = sample_and_average();
+            // 9. If the averaged data is zero, set CALADDOS. Repeat all steps from step 4.
+            if average == 0 {
+                T::regs().calfact().modify(|w| w.set_caladdos(true));
+                average = sample_and_average();
+            }
+            // 10. Store the averaged data to CALFACT_S[8:0].
+            T::regs().calfact().modify(|w| w.set_calfact_s(average as u16));
+            // 11. Select the calibration input mode by setting ADCALDIF (differential input).
+            T::regs().cr().modify(|w| w.set_adcaldif(Adcaldif::Differential));
+            // 12. Keep the same CALADDOS setting as the one obtained during the single-end
+            // calibration.
+            // 13. Repeat steps 4 to 8.
+            average = sample_and_average();
+            // 14. Subtract 0x7FF from the averaged data. If the result is positive, store it in the
+            // CALFACT_D[8:0] bitfield. If it is negative, set CALADDOS, then repeat steps from 4 to
+            // 8.
+            if average < ADC_MIDPOINT {
+                T::regs().calfact().modify(|w| w.set_caladdos(true));
+                average = sample_and_average();
+            }
+            // 15. Subtract again 0x7FF from the new averaged data. The resulting value is positive.
+            // Store it in CALFACT_D[8:0].
+            let result = average.saturating_sub(ADC_MIDPOINT) as u16;
+            T::regs().calfact().modify(|w| w.set_calfact_d(result));
+            // 16. CALADDOS is now set, so clear ADCALDIF, and repeat steps 4 to 8..
+            T::regs().cr().modify(|w| w.set_adcaldif(Adcaldif::SingleEnded));
+            average = sample_and_average();
+            // 17. Store the averaged data in CALFACT_S[8:0].
+            T::regs().calfact().modify(|w| w.set_calfact_s(average as u16));
+            // 18. Clear ADCAL bit.
+            T::regs().cr().modify(|w| w.set_adcal(false));
+            block_for_us(1);
+        }
 
         // single conversion mode, software trigger
         T::regs().cfgr().modify(|w| {
@@ -336,6 +414,7 @@ impl<'d, T: Instance<Regs = crate::pac::adc::Adc>> Adc<'d, T> {
 
     /// Enable reading the temperature internal channel.
     pub fn enable_temperature(&mut self) -> Temperature {
+        #[cfg(not(stm32n6))]
         T::common_regs().ccr().modify(|reg| {
             reg.set_vsenseen(true);
         });

--- a/embassy-stm32/src/dma/gpdma/mod.rs
+++ b/embassy-stm32/src/dma/gpdma/mod.rs
@@ -334,6 +334,9 @@ pub struct TransferOptions {
     /// after partial progress. Default `false`.
     #[cfg(stm32n6)]
     pub secure: bool,
+    /// DMA packing configuration
+    #[cfg(any(gpdma, lpdma))]
+    pub packing: vals::Pam,
     /// Source/destination burst length, in beats. Default `_1Beats`. Some
     /// peripherals only assert their DMA request line for bursts above a
     /// threshold (notably the JPEG codec on N6), and some require multi-beat
@@ -355,6 +358,8 @@ impl Default for TransferOptions {
             complete_transfer_ir: true,
             #[cfg(stm32n6)]
             secure: false,
+            #[cfg(any(gpdma, lpdma))]
+            packing: vals::Pam::Pack,
 
             #[cfg(not(stm32c5))]
             burst_length: Burst::_1Beats,
@@ -606,7 +611,7 @@ impl<'d> Channel<'d> {
                     // one source beat per destination beat, which silently corrupts
                     // mixed-width transfers.
                     if data_size != dst_size {
-                        w.set_pam(vals::Pam::Pack);
+                        w.set_pam(options.packing);
                     }
                     w.set_dap(match dir {
                         Dir::MemoryToPeripheral => vals::Ap::Port1, // Destination is peripheral on AHB for HPDMA
@@ -644,7 +649,7 @@ impl<'d> Channel<'d> {
                     // one source beat per destination beat, which silently corrupts
                     // mixed-width transfers.
                     if data_size != dst_size {
-                        w.set_pam(vals::Pam::Pack);
+                        w.set_pam(options.packing);
                     }
                 });
             }

--- a/embassy-stm32/src/rcc/n6.rs
+++ b/embassy-stm32/src/rcc/n6.rs
@@ -1401,6 +1401,7 @@ pub(crate) unsafe fn init(config: Config) {
         pclk2: Some(clocks.apb2),
         pclk1_tim: Some(clocks.pclk_tim),
         pclk2_tim: Some(clocks.pclk_tim),
+        timg: Some(clocks.pclk_tim),
         pclk4: Some(clocks.apb4),
         pclk5: Some(clocks.apb5),
         per: Some(clocks.perclk),


### PR DESCRIPTION
Adds support for ADC on the N6. The N6 is mostly follows the U3, but has a 32-bit data register and different calibration steps. This has been tested on the disco N6 and a custom N6 board with blocking reads.

Twin ticket: https://github.com/embassy-rs/stm32-data/pull/868

> [!NOTE]  
> It's still a work in progress, as I need to refactor and clean it up

## ~~REFSC Fun~~

```Rust
RIFSC.risc_seccfgr(2).modify(|w| w.set_cfg(0, true));
```

~~Without the above line blocking and DMA reads return 2000. With the above line blocking reads return the correct value for the voltage, but DMA reads just return 0. I'm not sure if it's a driver issue or a security setting preventing DMA from working. I think it's security related though, since DMA could read the ADC data register fine when seccfgr wasn't set?~~

Fixed: DMA had to be marked secure

## Todo

- [x] Squash commits
- [x] Formatting
- [x] Update blocking reads to use a 32-bit pointer and convert it to 16-bit data
- [x] Update DMA reads to use blanking unless FIFO packing is requested
- [x] Is MAX_ADC_CLK_FREQ correct?
- [x] Clean up calibration (better comments, refactor, remove unnecessary delays)


Let me know if there's anything else that looks off.