### PR TITLE
stm32/timer: improve dead time

### DIFF
--- a/embassy-stm32/src/timer/complementary_pwm.rs
+++ b/embassy-stm32/src/timer/complementary_pwm.rs
@@ -798,19 +798,19 @@ fn compute_dead_time_value(value: u16) -> (Ckd, u8) {
         // then DT/tDTS = (64 + DTG[5:0]) * 2
         // so DT/tDTS = (64 + 0..63) * 2 = 128..254
         // also DTG[5:0] = DT/tDTS / 2 - 64
-        // and DTG[7:0] = (DT/tDTS / 2 - 64) | 128
+        // and DTG[7:0] = (DT/tDTS / 2 - 64) | 0b100_00000
 
         // 110 case DTG[7:5]=110 => DT=(32+DTG[4:0])xtdtg with Tdtg=8xtDTS
         // then DT/tDTS = (32 + DTG[4:0]) * 8
         // so DT/tDTS = (32 + 0..31) * 8 = 256..504
-        // also DTG[5:0] = DT/tDTS / 8 - 32
-        // and DTG[7:0] = (DT/tDTS / 8 - 32) | 192
+        // also DTG[4:0] = DT/tDTS / 8 - 32
+        // and DTG[7:0] = (DT/tDTS / 8 - 32) | 0b110_00000
 
         // 111 case DTG[7:5]=111 => DT=(32+DTG[4:0])xtdtg with Tdtg=16xtDTS
         // then DT/tDTS = (32 + DTG[4:0]) * 16
         // so DT/tDTS = (32 + 0..31) * 16 = 512..1008
-        // also DTG[5:0] = DT/tDTS / 16 - 32
-        // and DTG[7:0] = (DT/tDTS / 16 - 32) | 224
+        // also DTG[4:0] = DT/tDTS / 16 - 32
+        // and DTG[7:0] = (DT/tDTS / 16 - 32) | 0b111_00000
 
         // because ranges do not cover all values they were
         // extended such that values fall into nearest one

--- a/embassy-stm32/src/timer/complementary_pwm.rs
+++ b/embassy-stm32/src/timer/complementary_pwm.rs
@@ -789,24 +789,24 @@ fn compute_dead_time_value(value: u16) -> (Ckd, u8) {
             _ => unreachable!(),
         };
 
-        // since DTG[7:5]=0xx => DT=DTG[7:0]x tdtg with tdtg=tDTS
+        // 0xx case DTG[7:5]=0xx => DT=DTG[7:0]x tdtg with tdtg=tDTS
         // then DT/tDTS = DTG[7:0] (where DTG[7] is always 0)
         // so DT/tDTS = 0..127
         // also DTG[7:0] = DT/tDTS
 
-        // since DTG[7:5]=10x => DT=(64+DTG[5:0])xtdtg with Tdtg=2xtDTS
+        // 10x case DTG[7:5]=10x => DT=(64+DTG[5:0])xtdtg with Tdtg=2xtDTS
         // then DT/tDTS = (64 + DTG[5:0]) * 2
         // so DT/tDTS = (64 + 0..63) * 2 = 128..254
         // also DTG[5:0] = DT/tDTS / 2 - 64
         // and DTG[7:0] = (DT/tDTS / 2 - 64) | 128
 
-        // since DTG[7:5]=110 => DT=(32+DTG[4:0])xtdtg with Tdtg=8xtDTS
+        // 110 case DTG[7:5]=110 => DT=(32+DTG[4:0])xtdtg with Tdtg=8xtDTS
         // then DT/tDTS = (32 + DTG[4:0]) * 8
         // so DT/tDTS = (32 + 0..31) * 8 = 256..504
         // also DTG[5:0] = DT/tDTS / 8 - 32
         // and DTG[7:0] = (DT/tDTS / 8 - 32) | 192
 
-        // since DTG[7:5]=111 => DT=(32+DTG[4:0])xtdtg with Tdtg=16xtDTS
+        // 111 case DTG[7:5]=111 => DT=(32+DTG[4:0])xtdtg with Tdtg=16xtDTS
         // then DT/tDTS = (32 + DTG[4:0]) * 16
         // so DT/tDTS = (32 + 0..31) * 16 = 512..1008
         // also DTG[5:0] = DT/tDTS / 16 - 32
@@ -862,32 +862,32 @@ mod tests {
             TestRun {
                 value: 1,
                 ckd: Ckd::Div1,
-                bits: 1,
+                bits: 0b000_000001, // case 0xx: 1 * 1 = 1, error = 0
             },
             TestRun {
                 value: 125,
                 ckd: Ckd::Div1,
-                bits: 125,
+                bits: 0b011_11101, // case 0xx: 125 * 1 = 125, error = 0
             },
             TestRun {
                 value: 245,
                 ckd: Ckd::Div1,
-                bits: 64 + 245 / 2,
+                bits: 0b101_11011, // case 10x: (64 + 59) * 2 * 1 = 246, error = 1
             },
             TestRun {
                 value: 255,
-                ckd: Ckd::Div2,
-                bits: 127,
+                ckd: Ckd::Div1,
+                bits: 0b110_00000, // case 110: (32 + 0) * 8 * 1 = 256, error = 1
             },
             TestRun {
                 value: 400,
                 ckd: Ckd::Div1,
-                bits: 210,
+                bits: 0b110_10010, // case 110: (32 + 18) * 8 * 1 = 400, error = 0
             },
             TestRun {
                 value: 600,
                 ckd: Ckd::Div4,
-                bits: 64 + (600u16 / 8) as u8,
+                bits: 0b100_01011, // case 10x: (64 + 11) * 2 * 4 = 600, error = 0
             },
         ];
 

--- a/embassy-stm32/src/timer/complementary_pwm.rs
+++ b/embassy-stm32/src/timer/complementary_pwm.rs
@@ -816,19 +816,21 @@ fn compute_dead_time_value(value: u16) -> (Ckd, u8) {
         // extended such that values fall into nearest one
 
         let target = value / outdiv;
-        let (these_bits, result) = if target < 128 {
-            (target as u8, target)
-        } else if target < 255 {
-            let tmp = div_round(value, outdiv * 2);
-            ((tmp as u8 - 64) | 128, tmp * 2)
-        } else if target < 508 {
-            let tmp = div_round(value, outdiv * 8);
-            ((tmp as u8 - 32) | 192, tmp * 8)
-        } else if target < 1008 {
-            let tmp = div_round(value, outdiv * 16);
-            ((tmp as u8 - 32) | 224, tmp * 16)
-        } else {
-            (u8::MAX, 1008)
+        let (these_bits, result) = match target {
+            0..127 | 127 => (target as u8, target),
+            128..254 | 254..256 => {
+                let tmp = div_round(value, outdiv * 2);
+                ((tmp as u8 - 64) | 128, tmp * 2)
+            }
+            256..504 | 504..508 => {
+                let tmp = div_round(value, outdiv * 8);
+                ((tmp as u8 - 32) | 192, tmp * 8)
+            }
+            508..512 | 512..1008 => {
+                let tmp = div_round(value, outdiv * 16);
+                ((tmp as u8 - 32) | 224, tmp * 16)
+            }
+            1008.. => (u8::MAX, 1008),
         };
 
         let this_error = value.abs_diff(result * outdiv);

--- a/embassy-stm32/src/timer/complementary_pwm.rs
+++ b/embassy-stm32/src/timer/complementary_pwm.rs
@@ -892,19 +892,47 @@ mod tests {
         }
     }
 
+    fn reference_dtg_to_dt(dtg: u8) -> u16 {
+        match ((dtg >> 7) & 1, (dtg >> 6) & 1, (dtg >> 5) & 1) {
+            (0, _, _) => dtg as u16,
+            (1, 0, _) => (64 + (dtg & 0b111111)) as u16 * 2,
+            (1, 1, 0) => (32 + (dtg & 0b11111)) as u16 * 8,
+            (1, 1, 1) => (32 + (dtg & 0b11111)) as u16 * 16,
+            _ => unreachable!()
+        }
+    }
+
     #[test]
-    fn test_dtg_with_reference() {
+    fn test_div1_dtg_with_reference() {
         for dtg in 0u8..=255u8 {
-            let dt = match ((dtg >> 7) & 1, (dtg >> 6) & 1, (dtg >> 5) & 1) {
-                (0, _, _) => dtg as u16,
-                (1, 0, _) => (64 + (dtg & 0b111111)) as u16 * 2,
-                (1, 1, 0) => (32 + (dtg & 0b11111)) as u16 * 8,
-                (1, 1, 1) => (32 + (dtg & 0b11111)) as u16 * 16,
-                _ => unreachable!()
-            };
+            let dt = reference_dtg_to_dt(dtg);
             let (ckd, bits) = compute_dead_time_value(dt);
             assert_eq!(ckd, Ckd::Div1);
             assert_eq!(bits, dtg);
+        }
+    }
+
+    #[test]
+    fn test_div2_dtg_with_reference() {
+        for dtg in 0u8..=255u8 {
+            let dt = reference_dtg_to_dt(dtg);
+            if dt * 2 > 1008 {
+                let (ckd, bits) = compute_dead_time_value(dt * 2);
+                assert_eq!(ckd, Ckd::Div2);
+                assert_eq!(bits, dtg);
+            }
+        }
+    }
+
+    #[test]
+    fn test_div4_dtg_with_reference() {
+        for dtg in 0u8..=255u8 {
+            let dt = reference_dtg_to_dt(dtg);
+            if dt * 4 > 1008 * 2 {
+                let (ckd, bits) = compute_dead_time_value(dt * 4);
+                assert_eq!(ckd, Ckd::Div4);
+                assert_eq!(bits, dtg);
+            }
         }
     }
 }

--- a/embassy-stm32/src/timer/complementary_pwm.rs
+++ b/embassy-stm32/src/timer/complementary_pwm.rs
@@ -820,15 +820,15 @@ fn compute_dead_time_value(value: u16) -> (Ckd, u8) {
             0..127 | 127 => (target as u8, target),
             128..254 | 254..256 => {
                 let tmp = div_round(value, outdiv * 2);
-                ((tmp as u8 - 64) | 128, tmp * 2)
+                ((tmp as u8 - 64) | 0b100_00000, tmp * 2)
             }
             256..504 | 504..508 => {
                 let tmp = div_round(value, outdiv * 8);
-                ((tmp as u8 - 32) | 192, tmp * 8)
+                ((tmp as u8 - 32) | 0b110_00000, tmp * 8)
             }
             508..512 | 512..1008 => {
                 let tmp = div_round(value, outdiv * 16);
-                ((tmp as u8 - 32) | 224, tmp * 16)
+                ((tmp as u8 - 32) | 0b111_00000, tmp * 16)
             }
             1008.. => (u8::MAX, 1008),
         };

--- a/embassy-stm32/src/timer/complementary_pwm.rs
+++ b/embassy-stm32/src/timer/complementary_pwm.rs
@@ -876,4 +876,20 @@ mod tests {
             assert_eq!(bits, test_run.bits);
         }
     }
+
+    #[test]
+    fn test_dtg_with_reference() {
+        for dtg in 0u8..=255u8 {
+            let dt = match ((dtg >> 7) & 1, (dtg >> 6) & 1, (dtg >> 5) & 1) {
+                (0, _, _) => dtg as u16,
+                (1, 0, _) => (64 + (dtg & 0b111111)) as u16 * 2,
+                (1, 1, 0) => (32 + (dtg & 0b11111)) as u16 * 8,
+                (1, 1, 1) => (32 + (dtg & 0b11111)) as u16 * 16,
+                _ => unreachable!()
+            };
+            let (ckd, bits) = compute_dead_time_value(dt);
+            assert_eq!(ckd, Ckd::Div1);
+            assert_eq!(bits, dtg);
+        }
+    }
 }

--- a/embassy-stm32/src/timer/complementary_pwm.rs
+++ b/embassy-stm32/src/timer/complementary_pwm.rs
@@ -892,13 +892,23 @@ mod tests {
         }
     }
 
+    fn reference_ckd_dtg_to_dt(ckd: Ckd, dtg: u8) -> u16 {
+        let div = match ckd {
+            Ckd::Div1 => 1,
+            Ckd::Div2 => 2,
+            Ckd::Div4 => 4,
+            _ => unreachable!(),
+        };
+        reference_dtg_to_dt(dtg) * div
+    }
+
     fn reference_dtg_to_dt(dtg: u8) -> u16 {
         match ((dtg >> 7) & 1, (dtg >> 6) & 1, (dtg >> 5) & 1) {
             (0, _, _) => dtg as u16,
             (1, 0, _) => (64 + (dtg & 0b111111)) as u16 * 2,
             (1, 1, 0) => (32 + (dtg & 0b11111)) as u16 * 8,
             (1, 1, 1) => (32 + (dtg & 0b11111)) as u16 * 16,
-            _ => unreachable!()
+            _ => unreachable!(),
         }
     }
 
@@ -933,6 +943,42 @@ mod tests {
                 assert_eq!(ckd, Ckd::Div4);
                 assert_eq!(bits, dtg);
             }
+        }
+    }
+
+    #[test]
+    fn test_all_dead_time_cases_min_error() {
+        let mut lut = [None; 4032 + 1]; // max possible dt is 4032
+        // fill lut with all possible dt values that have exact ckd and dtg
+        for ckd in [Ckd::Div4, Ckd::Div2, Ckd::Div1] {
+            for dtg in 0u8..=255u8 {
+                let dt = reference_ckd_dtg_to_dt(ckd, dtg);
+                lut[dt as usize] = Some((ckd, dtg));
+            }
+        }
+        // for given dt return min error to nearest dt that has exact ckd and dtg
+        let min_error = |dt: u16| -> u16 {
+            // fast path
+            if dt >= 4032 {
+                return dt - 4032;
+            }
+            // slow path
+            let mut i = 0;
+            loop {
+                let less = lut.get(dt.saturating_sub(i) as usize).and_then(|x| *x);
+                let more = lut.get(dt.saturating_add(i) as usize).and_then(|x| *x);
+                if less.is_some() || more.is_some() {
+                    return i;
+                }
+                i += 1;
+            }
+        };
+        // test all dt values and check if dt represented by
+        // the returned ckd and dgt is within min error
+        for dt in 0..=65535 {
+            let (ckd, dgt) = compute_dead_time_value(dt);
+            let exact_dt = reference_ckd_dtg_to_dt(ckd, dgt);
+            assert!(dt.abs_diff(exact_dt) <= min_error(dt));
         }
     }
 }

--- a/embassy-stm32/src/timer/complementary_pwm.rs
+++ b/embassy-stm32/src/timer/complementary_pwm.rs
@@ -747,6 +747,10 @@ impl<'d, T: AdvancedInstance4Channel> embedded_hal_02::Pwm for ComplementaryPwm<
     }
 }
 
+fn div_round(a: u16, b: u16) -> u16 {
+    (a + b / 2) / b
+}
+
 fn compute_dead_time_value(value: u16) -> (Ckd, u8) {
     /*
         Dead-time = T_clk * T_dts * T_dtg
@@ -815,11 +819,14 @@ fn compute_dead_time_value(value: u16) -> (Ckd, u8) {
         let (these_bits, result) = if target < 128 {
             (target as u8, target)
         } else if target < 255 {
-            (((target / 2) as u8).saturating_sub(64) | 128, (target - target % 2))
+            let tmp = div_round(value, outdiv * 2);
+            ((tmp as u8 - 64) | 128, tmp * 2)
         } else if target < 508 {
-            (((target / 8) as u8).saturating_sub(32) | 192, (target - target % 8))
+            let tmp = div_round(value, outdiv * 8);
+            ((tmp as u8 - 32) | 192, tmp * 8)
         } else if target < 1008 {
-            (((target / 16) as u8).saturating_sub(32) | 224, (target - target % 16))
+            let tmp = div_round(value, outdiv * 16);
+            ((tmp as u8 - 32) | 224, tmp * 16)
         } else {
             (u8::MAX, 1008)
         };

--- a/embassy-stm32/src/timer/complementary_pwm.rs
+++ b/embassy-stm32/src/timer/complementary_pwm.rs
@@ -815,11 +815,11 @@ fn compute_dead_time_value(value: u16) -> (Ckd, u8) {
         let (these_bits, result) = if target < 128 {
             (target as u8, target)
         } else if target < 255 {
-            ((64 + (target / 2) as u8) | 128, (target - target % 2))
+            (((target / 2) as u8).saturating_sub(64) | 128, (target - target % 2))
         } else if target < 508 {
-            ((32 + (target / 8) as u8) | 192, (target - target % 8))
+            (((target / 8) as u8).saturating_sub(32) | 192, (target - target % 8))
         } else if target < 1008 {
-            ((32 + (target / 16) as u8) | 224, (target - target % 16))
+            (((target / 16) as u8).saturating_sub(32) | 224, (target - target % 16))
         } else {
             (u8::MAX, 1008)
         };

--- a/embassy-stm32/src/timer/complementary_pwm.rs
+++ b/embassy-stm32/src/timer/complementary_pwm.rs
@@ -785,16 +785,31 @@ fn compute_dead_time_value(value: u16) -> (Ckd, u8) {
             _ => unreachable!(),
         };
 
-        // 127
-        // 128
-        // ..
-        // 254
-        // 256
-        // ..
-        // 504
-        // 512
-        // ..
-        // 1008
+        // since DTG[7:5]=0xx => DT=DTG[7:0]x tdtg with tdtg=tDTS
+        // then DT/tDTS = DTG[7:0] (where DTG[7] is always 0)
+        // so DT/tDTS = 0..127
+        // also DTG[7:0] = DT/tDTS
+
+        // since DTG[7:5]=10x => DT=(64+DTG[5:0])xtdtg with Tdtg=2xtDTS
+        // then DT/tDTS = (64 + DTG[5:0]) * 2
+        // so DT/tDTS = (64 + 0..63) * 2 = 128..254
+        // also DTG[5:0] = DT/tDTS / 2 - 64
+        // and DTG[7:0] = (DT/tDTS / 2 - 64) | 128
+
+        // since DTG[7:5]=110 => DT=(32+DTG[4:0])xtdtg with Tdtg=8xtDTS
+        // then DT/tDTS = (32 + DTG[4:0]) * 8
+        // so DT/tDTS = (32 + 0..31) * 8 = 256..504
+        // also DTG[5:0] = DT/tDTS / 8 - 32
+        // and DTG[7:0] = (DT/tDTS / 8 - 32) | 192
+
+        // since DTG[7:5]=111 => DT=(32+DTG[4:0])xtdtg with Tdtg=16xtDTS
+        // then DT/tDTS = (32 + DTG[4:0]) * 16
+        // so DT/tDTS = (32 + 0..31) * 16 = 512..1008
+        // also DTG[5:0] = DT/tDTS / 16 - 32
+        // and DTG[7:0] = (DT/tDTS / 16 - 32) | 224
+
+        // because ranges do not cover all values they were
+        // extended such that values fall into nearest one
 
         let target = value / outdiv;
         let (these_bits, result) = if target < 128 {


### PR DESCRIPTION
Since I plan to use dead time, and it is quite important to be correct, I decided to verify it.

In the original implementation I noticed `64 + ...` and `32 + ...` which should be `... - 64` and `... - 32`:
https://github.com/embassy-rs/embassy/blob/fc06053c582f60218cc853475e2ac470ebd872e3/embassy-stm32/src/timer/complementary_pwm.rs#L803-L807
So I added some docs and more tests to find where it fails. However, I haven't found any failing values and after more analysis I discovered that in this specific case both `+` and `-` work fine. I could probably prove it, but it is not important here.

Later I added test to verify that all dead times that don't have exact representation are always the nearest approximation. 
After adding this test, the code was no longer passing it and required some changes which mainly was rounding when dividing. I also converted it to `match` for readability.

Old tests also required slight change, because in the new implementation, for dead times with no exact representation, a different result is now returned, but they still have the same error (e.g. for 255, was 254, now is 256).

While this PR is mostly theoretical, I also verified some arbitrary dead time values using logic analyzer generated from STM32F411CE.