### PR TITLE
usb: recognize debug extension requests

### DIFF
--- a/embassy-usb/src/control.rs
+++ b/embassy-usb/src/control.rs
@@ -99,6 +99,12 @@ impl Request {
     /// Standard USB feature Device Remote Wakeup for Set/Clear Feature
     pub const FEATURE_DEVICE_REMOTE_WAKEUP: u16 = 1;
 
+    /// Standard USB feature Device Test Mode for Set Feature
+    pub const FEATURE_DEVICE_TEST_MODE: u16 = 2;
+
+    /// Standard USB feature Device Debug Mode for Set Feature
+    pub const FEATURE_DEVICE_DEBUG_MODE: u16 = 6;
+
     /// Parses a USB control request from a byte array.
     pub fn parse(buf: &[u8; 8]) -> Request {
         let rt = buf[0];

--- a/embassy-usb/src/descriptor.rs
+++ b/embassy-usb/src/descriptor.rs
@@ -16,6 +16,9 @@ pub mod descriptor_type {
     pub const ENDPOINT: u8 = 5;
     pub const DEVICE_QUALIFIER: u8 = 6;
     pub const OTHER_SPEED_CONFIGURATION: u8 = 7;
+    pub const INTERFACE_POWER: u8 = 8;
+    pub const OTG: u8 = 9;
+    pub const DEBUG: u8 = 10;
     pub const IAD: u8 = 11;
     pub const BOS: u8 = 15;
     pub const CAPABILITY: u8 = 16;

--- a/embassy-usb/src/lib.rs
+++ b/embassy-usb/src/lib.rs
@@ -575,6 +575,11 @@ impl<'d, D: Driver<'d>> Inner<'d, D> {
                     }
                     OutResponse::Accepted
                 }
+                // USB 2.0 debug devices use a standard device feature selector,
+                // but the actual mode transition is device-specific.
+                (Request::SET_FEATURE, Request::FEATURE_DEVICE_DEBUG_MODE) => {
+                    self.handle_control_out_delegated(req, data)
+                }
                 _ => OutResponse::Rejected,
             },
             (RequestType::Standard, Recipient::Interface) => {
@@ -786,6 +791,9 @@ impl<'d, D: Driver<'d>> Inner<'d, D> {
             descriptor_type::DEVICE_QUALIFIER if self.config.max_speed > UsbDeviceSpeed::Full => {
                 InResponse::Accepted(&self.device_qualifier_descriptor)
             }
+            // USB_DT_DEBUG is a standard descriptor, but its endpoint contents
+            // are supplied by a special-purpose debug device implementation.
+            descriptor_type::DEBUG => self.handle_control_in_delegated(req, buf),
             _ => InResponse::Rejected,
         }
     }


### PR DESCRIPTION
USB debug devices use standard descriptor and feature selector values
that the generic stack does not otherwise handle: USB_DT_DEBUG and
DEBUG_MODE.

Add constants for those values and delegate only the debug descriptor
and SET_FEATURE(DEBUG_MODE) requests to handlers. Other unsupported
standard requests still reject normally.