### PR TITLE
hosted: Tweak `Interface` for half-duplex implementations

### DIFF
--- a/embassy-net-esp-hosted/CHANGELOG.md
+++ b/embassy-net-esp-hosted/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 <!-- next-header -->
 ## Unreleased - ReleaseDate
 
+- Added `Interface::init` to initialize or re-initialize the transport.
+- Changed: The `Interface::transfer` method now takes a packet length.
 - Added `Control::scan` to retrieve visible networks. Note that `esp-hosted-fg` can only retrieve up to 8 entries.
 - `embassy_net_esp_hosted::new` now returns an `HostedResources` struct with named fields.
 - Added Bluetooth (BLE) support via the new `bluetooth` feature. `new` returns a `bluetooth::BtDriver` implementing `bt_hci::transport::Transport`, exposing the ESP coprocessor's HCI controller over the ESP-Hosted HCI interface.

--- a/embassy-net-esp-hosted/src/iface.rs
+++ b/embassy-net-esp-hosted/src/iface.rs
@@ -5,14 +5,21 @@ use embedded_hal_async::spi::SpiDevice;
 
 /// Physical interface trait for communicating with the ESP chip.
 pub trait Interface {
-    /// Wait for the HANDSHAKE signal indicating the ESP is ready for a new transaction.
+    /// Initialize or re-initialize the transport.
+    async fn init(&mut self, cold_boot: bool);
+
+    /// Wait for the ESP to indicate readiness for a new transaction.
     async fn wait_for_handshake(&mut self);
 
-    /// Wait for the READY signal indicating the ESP has data to send.
+    /// Wait for the ESP to indicate that it has data to send.
     async fn wait_for_ready(&mut self);
 
     /// Perform a transfer, exchanging data with the ESP chip.
-    async fn transfer(&mut self, buffer: &mut [u8]);
+    ///
+    /// `tx_len` is the number of bytes in the payload.
+    ///
+    /// The payload bytes contain the valid length of the received buffer.
+    async fn transfer(&mut self, buffer: &mut [u8], tx_len: usize);
 }
 
 /// Standard SPI interface.
@@ -43,6 +50,10 @@ where
     SPI: SpiDevice,
     IN: InputPin + Wait,
 {
+    async fn init(&mut self, _cold_boot: bool) {
+        // No-op
+    }
+
     async fn wait_for_handshake(&mut self) {
         self.handshake.wait_for_high().await.unwrap();
     }
@@ -51,12 +62,13 @@ where
         self.ready.wait_for_high().await.unwrap();
     }
 
-    async fn transfer(&mut self, buffer: &mut [u8]) {
+    async fn transfer(&mut self, buffer: &mut [u8], _tx_len: usize) {
         let (a, b) = join(
             // The esp-hosted firmware deasserts the HANDSHAKE pin a few us AFTER ending the SPI transfer
             // If we check it again too fast, we'll see it's high from the previous transfer, and if we send it
             // data it will get lost.
             self.handshake.wait_for_low(),
+            // Always transfer the full buffer.
             self.spi.transfer_in_place(buffer),
         )
         .await;

--- a/embassy-net-esp-hosted/src/ioctl.rs
+++ b/embassy-net-esp-hosted/src/ioctl.rs
@@ -42,6 +42,7 @@ enum ConnectState {
 pub(crate) enum ControlState {
     Init,
     Reboot,
+    WaitingForInit,
     Ready(Backend),
 }
 
@@ -118,6 +119,11 @@ impl Shared {
     pub fn ota_done(&self) {
         let mut this = self.0.borrow_mut();
         this.state = ControlState::Reboot;
+    }
+
+    pub fn interface_ready(&self) {
+        let mut this = self.0.borrow_mut();
+        this.state = ControlState::WaitingForInit;
     }
 
     // // // // // // // // // // // // // // // // // // // //

--- a/embassy-net-esp-hosted/src/lib.rs
+++ b/embassy-net-esp-hosted/src/lib.rs
@@ -240,14 +240,19 @@ where
         self.reset.set_high().unwrap();
         Timer::after_millis(1000).await;
 
+        self.iface.init(true).await;
+        self.shared.interface_ready();
+
         let mut buffer = [0u8; MAX_BUFFER_SIZE];
 
         loop {
-            self.iface.wait_for_handshake().await;
-
             if let ioctl::ControlState::Reboot = self.shared.state() {
                 self.backend = Backend::default();
+                self.iface.init(false).await;
+                self.shared.interface_ready();
             }
+
+            self.iface.wait_for_handshake().await;
 
             let ioctl = self.shared.ioctl_wait_pending();
             let tx = self.ch.tx_buf();
@@ -264,6 +269,7 @@ where
             )
             .await;
 
+            let mut tx_len = 0;
             match event {
                 EitherMany::First(PendingIoctl { buf, req_len }) => {
                     let if_type_and_num = unwrap!(self.backend.encode_iface_type(InterfaceType::Serial));
@@ -281,30 +287,38 @@ where
                     };
                     self.next_seq = self.next_seq.wrapping_add(1);
                     header.copy(&mut buffer);
+                    tx_len = PayloadHeader::SIZE + payload_len;
                 }
                 EitherMany::Second(packet) => {
+                    let packet_len = packet.len();
                     if let Some(if_type_and_num) = self.backend.encode_iface_type(InterfaceType::Sta) {
-                        buffer[PayloadHeader::SIZE..][..packet.len()].copy_from_slice(&packet);
+                        buffer[PayloadHeader::SIZE..][..packet_len].copy_from_slice(&packet);
 
                         let header = PayloadHeader {
                             if_type_and_num,
-                            len: packet.len() as _,
+                            len: packet_len as _,
                             offset: PayloadHeader::SIZE as _,
                             seq_num: self.next_seq,
                             ..Default::default()
                         };
                         self.next_seq = self.next_seq.wrapping_add(1);
                         header.copy(&mut buffer);
+                        tx_len = PayloadHeader::SIZE + packet_len;
+                    } else {
+                        // Backend doesn't support the requested interface type. Drop the
+                        // packet and send nothing this iteration.
+                        buffer[..PayloadHeader::SIZE].fill(0);
                     }
 
                     packet.tx_done();
                 }
                 EitherMany::Third(()) => {
                     buffer[..PayloadHeader::SIZE].fill(0);
+                    tx_len = 0;
                 }
                 EitherMany::Fourth(()) => {
                     // Extend the deadline if initializing
-                    if let ioctl::ControlState::Reboot = self.shared.state() {
+                    if let ioctl::ControlState::Reboot | ioctl::ControlState::WaitingForInit = self.shared.state() {
                         self.heartbeat_deadline = Instant::now() + HEARTBEAT_MAX_GAP;
                         continue;
                     }
@@ -332,6 +346,7 @@ where
                         };
                         self.next_seq = self.next_seq.wrapping_add(1);
                         header.copy(&mut buffer);
+                        tx_len = PayloadHeader::SIZE + body.len() as usize;
                     } else {
                         // Backend doesn't support HCI (e.g. not yet initialized). Drop the
                         // packet and send nothing this iteration.
@@ -348,7 +363,7 @@ where
                 trace!("tx: {=[u8]:02x}", &buffer[..40]);
             }
 
-            self.iface.transfer(&mut buffer).await;
+            self.iface.transfer(&mut buffer, tx_len).await;
 
             self.handle_rx(&mut buffer);
         }


### PR DESCRIPTION
This PR makes QSPI (esp-hosted-mcu only) and possibly SDIO (both firmwares) implementable