### PR TITLE
feat: add support for ppi bridges for nrf54l

### DIFF
--- a/embassy-nrf/src/chips/nrf54l05_app.rs
+++ b/embassy-nrf/src/chips/nrf54l05_app.rs
@@ -759,3 +759,86 @@ embassy_hal_internal::interrupt_mod!(
     GPIOTE30_1,
     CLOCK_POWER,
 );
+
+// PPI bridge (PPIB) channels
+use crate::ppib::impl_ppib_channel;
+
+impl_ppib_channel!(PPIB00_CH0, PPIB00, 0, PPIB10_CH0);
+impl_ppib_channel!(PPIB00_CH1, PPIB00, 1, PPIB10_CH1);
+impl_ppib_channel!(PPIB00_CH2, PPIB00, 2, PPIB10_CH2);
+impl_ppib_channel!(PPIB00_CH3, PPIB00, 3, PPIB10_CH3);
+impl_ppib_channel!(PPIB00_CH4, PPIB00, 4, PPIB10_CH4);
+impl_ppib_channel!(PPIB00_CH5, PPIB00, 5, PPIB10_CH5);
+impl_ppib_channel!(PPIB00_CH6, PPIB00, 6, PPIB10_CH6);
+impl_ppib_channel!(PPIB00_CH7, PPIB00, 7, PPIB10_CH7);
+
+impl_ppib_channel!(PPIB01_CH0, PPIB01, 0, PPIB20_CH0);
+impl_ppib_channel!(PPIB01_CH1, PPIB01, 1, PPIB20_CH1);
+impl_ppib_channel!(PPIB01_CH2, PPIB01, 2, PPIB20_CH2);
+impl_ppib_channel!(PPIB01_CH3, PPIB01, 3, PPIB20_CH3);
+impl_ppib_channel!(PPIB01_CH4, PPIB01, 4, PPIB20_CH4);
+impl_ppib_channel!(PPIB01_CH5, PPIB01, 5, PPIB20_CH5);
+impl_ppib_channel!(PPIB01_CH6, PPIB01, 6, PPIB20_CH6);
+impl_ppib_channel!(PPIB01_CH7, PPIB01, 7, PPIB20_CH7);
+
+impl_ppib_channel!(PPIB10_CH0, PPIB10, 0, PPIB00_CH0);
+impl_ppib_channel!(PPIB10_CH1, PPIB10, 1, PPIB00_CH1);
+impl_ppib_channel!(PPIB10_CH2, PPIB10, 2, PPIB00_CH2);
+impl_ppib_channel!(PPIB10_CH3, PPIB10, 3, PPIB00_CH3);
+impl_ppib_channel!(PPIB10_CH4, PPIB10, 4, PPIB00_CH4);
+impl_ppib_channel!(PPIB10_CH5, PPIB10, 5, PPIB00_CH5);
+impl_ppib_channel!(PPIB10_CH6, PPIB10, 6, PPIB00_CH6);
+impl_ppib_channel!(PPIB10_CH7, PPIB10, 7, PPIB00_CH7);
+
+impl_ppib_channel!(PPIB11_CH0, PPIB11, 0, PPIB21_CH0);
+impl_ppib_channel!(PPIB11_CH1, PPIB11, 1, PPIB21_CH1);
+impl_ppib_channel!(PPIB11_CH2, PPIB11, 2, PPIB21_CH2);
+impl_ppib_channel!(PPIB11_CH3, PPIB11, 3, PPIB21_CH3);
+impl_ppib_channel!(PPIB11_CH4, PPIB11, 4, PPIB21_CH4);
+impl_ppib_channel!(PPIB11_CH5, PPIB11, 5, PPIB21_CH5);
+impl_ppib_channel!(PPIB11_CH6, PPIB11, 6, PPIB21_CH6);
+impl_ppib_channel!(PPIB11_CH7, PPIB11, 7, PPIB21_CH7);
+impl_ppib_channel!(PPIB11_CH8, PPIB11, 8, PPIB21_CH8);
+impl_ppib_channel!(PPIB11_CH9, PPIB11, 9, PPIB21_CH9);
+impl_ppib_channel!(PPIB11_CH10, PPIB11, 10, PPIB21_CH10);
+impl_ppib_channel!(PPIB11_CH11, PPIB11, 11, PPIB21_CH11);
+impl_ppib_channel!(PPIB11_CH12, PPIB11, 12, PPIB21_CH12);
+impl_ppib_channel!(PPIB11_CH13, PPIB11, 13, PPIB21_CH13);
+impl_ppib_channel!(PPIB11_CH14, PPIB11, 14, PPIB21_CH14);
+impl_ppib_channel!(PPIB11_CH15, PPIB11, 15, PPIB21_CH15);
+
+impl_ppib_channel!(PPIB20_CH0, PPIB20, 0, PPIB01_CH0);
+impl_ppib_channel!(PPIB20_CH1, PPIB20, 1, PPIB01_CH1);
+impl_ppib_channel!(PPIB20_CH2, PPIB20, 2, PPIB01_CH2);
+impl_ppib_channel!(PPIB20_CH3, PPIB20, 3, PPIB01_CH3);
+impl_ppib_channel!(PPIB20_CH4, PPIB20, 4, PPIB01_CH4);
+impl_ppib_channel!(PPIB20_CH5, PPIB20, 5, PPIB01_CH5);
+impl_ppib_channel!(PPIB20_CH6, PPIB20, 6, PPIB01_CH6);
+impl_ppib_channel!(PPIB20_CH7, PPIB20, 7, PPIB01_CH7);
+
+impl_ppib_channel!(PPIB21_CH0, PPIB21, 0, PPIB11_CH0);
+impl_ppib_channel!(PPIB21_CH1, PPIB21, 1, PPIB11_CH1);
+impl_ppib_channel!(PPIB21_CH2, PPIB21, 2, PPIB11_CH2);
+impl_ppib_channel!(PPIB21_CH3, PPIB21, 3, PPIB11_CH3);
+impl_ppib_channel!(PPIB21_CH4, PPIB21, 4, PPIB11_CH4);
+impl_ppib_channel!(PPIB21_CH5, PPIB21, 5, PPIB11_CH5);
+impl_ppib_channel!(PPIB21_CH6, PPIB21, 6, PPIB11_CH6);
+impl_ppib_channel!(PPIB21_CH7, PPIB21, 7, PPIB11_CH7);
+impl_ppib_channel!(PPIB21_CH8, PPIB21, 8, PPIB11_CH8);
+impl_ppib_channel!(PPIB21_CH9, PPIB21, 9, PPIB11_CH9);
+impl_ppib_channel!(PPIB21_CH10, PPIB21, 10, PPIB11_CH10);
+impl_ppib_channel!(PPIB21_CH11, PPIB21, 11, PPIB11_CH11);
+impl_ppib_channel!(PPIB21_CH12, PPIB21, 12, PPIB11_CH12);
+impl_ppib_channel!(PPIB21_CH13, PPIB21, 13, PPIB11_CH13);
+impl_ppib_channel!(PPIB21_CH14, PPIB21, 14, PPIB11_CH14);
+impl_ppib_channel!(PPIB21_CH15, PPIB21, 15, PPIB11_CH15);
+
+impl_ppib_channel!(PPIB22_CH0, PPIB22, 0, PPIB30_CH0);
+impl_ppib_channel!(PPIB22_CH1, PPIB22, 1, PPIB30_CH1);
+impl_ppib_channel!(PPIB22_CH2, PPIB22, 2, PPIB30_CH2);
+impl_ppib_channel!(PPIB22_CH3, PPIB22, 3, PPIB30_CH3);
+
+impl_ppib_channel!(PPIB30_CH0, PPIB30, 0, PPIB22_CH0);
+impl_ppib_channel!(PPIB30_CH1, PPIB30, 1, PPIB22_CH1);
+impl_ppib_channel!(PPIB30_CH2, PPIB30, 2, PPIB22_CH2);
+impl_ppib_channel!(PPIB30_CH3, PPIB30, 3, PPIB22_CH3);

--- a/embassy-nrf/src/chips/nrf54l10_app.rs
+++ b/embassy-nrf/src/chips/nrf54l10_app.rs
@@ -759,3 +759,86 @@ embassy_hal_internal::interrupt_mod!(
     GPIOTE30_1,
     CLOCK_POWER,
 );
+
+// PPI bridge (PPIB) channels
+use crate::ppib::impl_ppib_channel;
+
+impl_ppib_channel!(PPIB00_CH0, PPIB00, 0, PPIB10_CH0);
+impl_ppib_channel!(PPIB00_CH1, PPIB00, 1, PPIB10_CH1);
+impl_ppib_channel!(PPIB00_CH2, PPIB00, 2, PPIB10_CH2);
+impl_ppib_channel!(PPIB00_CH3, PPIB00, 3, PPIB10_CH3);
+impl_ppib_channel!(PPIB00_CH4, PPIB00, 4, PPIB10_CH4);
+impl_ppib_channel!(PPIB00_CH5, PPIB00, 5, PPIB10_CH5);
+impl_ppib_channel!(PPIB00_CH6, PPIB00, 6, PPIB10_CH6);
+impl_ppib_channel!(PPIB00_CH7, PPIB00, 7, PPIB10_CH7);
+
+impl_ppib_channel!(PPIB01_CH0, PPIB01, 0, PPIB20_CH0);
+impl_ppib_channel!(PPIB01_CH1, PPIB01, 1, PPIB20_CH1);
+impl_ppib_channel!(PPIB01_CH2, PPIB01, 2, PPIB20_CH2);
+impl_ppib_channel!(PPIB01_CH3, PPIB01, 3, PPIB20_CH3);
+impl_ppib_channel!(PPIB01_CH4, PPIB01, 4, PPIB20_CH4);
+impl_ppib_channel!(PPIB01_CH5, PPIB01, 5, PPIB20_CH5);
+impl_ppib_channel!(PPIB01_CH6, PPIB01, 6, PPIB20_CH6);
+impl_ppib_channel!(PPIB01_CH7, PPIB01, 7, PPIB20_CH7);
+
+impl_ppib_channel!(PPIB10_CH0, PPIB10, 0, PPIB00_CH0);
+impl_ppib_channel!(PPIB10_CH1, PPIB10, 1, PPIB00_CH1);
+impl_ppib_channel!(PPIB10_CH2, PPIB10, 2, PPIB00_CH2);
+impl_ppib_channel!(PPIB10_CH3, PPIB10, 3, PPIB00_CH3);
+impl_ppib_channel!(PPIB10_CH4, PPIB10, 4, PPIB00_CH4);
+impl_ppib_channel!(PPIB10_CH5, PPIB10, 5, PPIB00_CH5);
+impl_ppib_channel!(PPIB10_CH6, PPIB10, 6, PPIB00_CH6);
+impl_ppib_channel!(PPIB10_CH7, PPIB10, 7, PPIB00_CH7);
+
+impl_ppib_channel!(PPIB11_CH0, PPIB11, 0, PPIB21_CH0);
+impl_ppib_channel!(PPIB11_CH1, PPIB11, 1, PPIB21_CH1);
+impl_ppib_channel!(PPIB11_CH2, PPIB11, 2, PPIB21_CH2);
+impl_ppib_channel!(PPIB11_CH3, PPIB11, 3, PPIB21_CH3);
+impl_ppib_channel!(PPIB11_CH4, PPIB11, 4, PPIB21_CH4);
+impl_ppib_channel!(PPIB11_CH5, PPIB11, 5, PPIB21_CH5);
+impl_ppib_channel!(PPIB11_CH6, PPIB11, 6, PPIB21_CH6);
+impl_ppib_channel!(PPIB11_CH7, PPIB11, 7, PPIB21_CH7);
+impl_ppib_channel!(PPIB11_CH8, PPIB11, 8, PPIB21_CH8);
+impl_ppib_channel!(PPIB11_CH9, PPIB11, 9, PPIB21_CH9);
+impl_ppib_channel!(PPIB11_CH10, PPIB11, 10, PPIB21_CH10);
+impl_ppib_channel!(PPIB11_CH11, PPIB11, 11, PPIB21_CH11);
+impl_ppib_channel!(PPIB11_CH12, PPIB11, 12, PPIB21_CH12);
+impl_ppib_channel!(PPIB11_CH13, PPIB11, 13, PPIB21_CH13);
+impl_ppib_channel!(PPIB11_CH14, PPIB11, 14, PPIB21_CH14);
+impl_ppib_channel!(PPIB11_CH15, PPIB11, 15, PPIB21_CH15);
+
+impl_ppib_channel!(PPIB20_CH0, PPIB20, 0, PPIB01_CH0);
+impl_ppib_channel!(PPIB20_CH1, PPIB20, 1, PPIB01_CH1);
+impl_ppib_channel!(PPIB20_CH2, PPIB20, 2, PPIB01_CH2);
+impl_ppib_channel!(PPIB20_CH3, PPIB20, 3, PPIB01_CH3);
+impl_ppib_channel!(PPIB20_CH4, PPIB20, 4, PPIB01_CH4);
+impl_ppib_channel!(PPIB20_CH5, PPIB20, 5, PPIB01_CH5);
+impl_ppib_channel!(PPIB20_CH6, PPIB20, 6, PPIB01_CH6);
+impl_ppib_channel!(PPIB20_CH7, PPIB20, 7, PPIB01_CH7);
+
+impl_ppib_channel!(PPIB21_CH0, PPIB21, 0, PPIB11_CH0);
+impl_ppib_channel!(PPIB21_CH1, PPIB21, 1, PPIB11_CH1);
+impl_ppib_channel!(PPIB21_CH2, PPIB21, 2, PPIB11_CH2);
+impl_ppib_channel!(PPIB21_CH3, PPIB21, 3, PPIB11_CH3);
+impl_ppib_channel!(PPIB21_CH4, PPIB21, 4, PPIB11_CH4);
+impl_ppib_channel!(PPIB21_CH5, PPIB21, 5, PPIB11_CH5);
+impl_ppib_channel!(PPIB21_CH6, PPIB21, 6, PPIB11_CH6);
+impl_ppib_channel!(PPIB21_CH7, PPIB21, 7, PPIB11_CH7);
+impl_ppib_channel!(PPIB21_CH8, PPIB21, 8, PPIB11_CH8);
+impl_ppib_channel!(PPIB21_CH9, PPIB21, 9, PPIB11_CH9);
+impl_ppib_channel!(PPIB21_CH10, PPIB21, 10, PPIB11_CH10);
+impl_ppib_channel!(PPIB21_CH11, PPIB21, 11, PPIB11_CH11);
+impl_ppib_channel!(PPIB21_CH12, PPIB21, 12, PPIB11_CH12);
+impl_ppib_channel!(PPIB21_CH13, PPIB21, 13, PPIB11_CH13);
+impl_ppib_channel!(PPIB21_CH14, PPIB21, 14, PPIB11_CH14);
+impl_ppib_channel!(PPIB21_CH15, PPIB21, 15, PPIB11_CH15);
+
+impl_ppib_channel!(PPIB22_CH0, PPIB22, 0, PPIB30_CH0);
+impl_ppib_channel!(PPIB22_CH1, PPIB22, 1, PPIB30_CH1);
+impl_ppib_channel!(PPIB22_CH2, PPIB22, 2, PPIB30_CH2);
+impl_ppib_channel!(PPIB22_CH3, PPIB22, 3, PPIB30_CH3);
+
+impl_ppib_channel!(PPIB30_CH0, PPIB30, 0, PPIB22_CH0);
+impl_ppib_channel!(PPIB30_CH1, PPIB30, 1, PPIB22_CH1);
+impl_ppib_channel!(PPIB30_CH2, PPIB30, 2, PPIB22_CH2);
+impl_ppib_channel!(PPIB30_CH3, PPIB30, 3, PPIB22_CH3);

--- a/embassy-nrf/src/chips/nrf54l15_app.rs
+++ b/embassy-nrf/src/chips/nrf54l15_app.rs
@@ -759,3 +759,86 @@ embassy_hal_internal::interrupt_mod!(
     GPIOTE30_1,
     CLOCK_POWER,
 );
+
+// PPI bridge (PPIB) channels
+use crate::ppib::impl_ppib_channel;
+
+impl_ppib_channel!(PPIB00_CH0, PPIB00, 0, PPIB10_CH0);
+impl_ppib_channel!(PPIB00_CH1, PPIB00, 1, PPIB10_CH1);
+impl_ppib_channel!(PPIB00_CH2, PPIB00, 2, PPIB10_CH2);
+impl_ppib_channel!(PPIB00_CH3, PPIB00, 3, PPIB10_CH3);
+impl_ppib_channel!(PPIB00_CH4, PPIB00, 4, PPIB10_CH4);
+impl_ppib_channel!(PPIB00_CH5, PPIB00, 5, PPIB10_CH5);
+impl_ppib_channel!(PPIB00_CH6, PPIB00, 6, PPIB10_CH6);
+impl_ppib_channel!(PPIB00_CH7, PPIB00, 7, PPIB10_CH7);
+
+impl_ppib_channel!(PPIB01_CH0, PPIB01, 0, PPIB20_CH0);
+impl_ppib_channel!(PPIB01_CH1, PPIB01, 1, PPIB20_CH1);
+impl_ppib_channel!(PPIB01_CH2, PPIB01, 2, PPIB20_CH2);
+impl_ppib_channel!(PPIB01_CH3, PPIB01, 3, PPIB20_CH3);
+impl_ppib_channel!(PPIB01_CH4, PPIB01, 4, PPIB20_CH4);
+impl_ppib_channel!(PPIB01_CH5, PPIB01, 5, PPIB20_CH5);
+impl_ppib_channel!(PPIB01_CH6, PPIB01, 6, PPIB20_CH6);
+impl_ppib_channel!(PPIB01_CH7, PPIB01, 7, PPIB20_CH7);
+
+impl_ppib_channel!(PPIB10_CH0, PPIB10, 0, PPIB00_CH0);
+impl_ppib_channel!(PPIB10_CH1, PPIB10, 1, PPIB00_CH1);
+impl_ppib_channel!(PPIB10_CH2, PPIB10, 2, PPIB00_CH2);
+impl_ppib_channel!(PPIB10_CH3, PPIB10, 3, PPIB00_CH3);
+impl_ppib_channel!(PPIB10_CH4, PPIB10, 4, PPIB00_CH4);
+impl_ppib_channel!(PPIB10_CH5, PPIB10, 5, PPIB00_CH5);
+impl_ppib_channel!(PPIB10_CH6, PPIB10, 6, PPIB00_CH6);
+impl_ppib_channel!(PPIB10_CH7, PPIB10, 7, PPIB00_CH7);
+
+impl_ppib_channel!(PPIB11_CH0, PPIB11, 0, PPIB21_CH0);
+impl_ppib_channel!(PPIB11_CH1, PPIB11, 1, PPIB21_CH1);
+impl_ppib_channel!(PPIB11_CH2, PPIB11, 2, PPIB21_CH2);
+impl_ppib_channel!(PPIB11_CH3, PPIB11, 3, PPIB21_CH3);
+impl_ppib_channel!(PPIB11_CH4, PPIB11, 4, PPIB21_CH4);
+impl_ppib_channel!(PPIB11_CH5, PPIB11, 5, PPIB21_CH5);
+impl_ppib_channel!(PPIB11_CH6, PPIB11, 6, PPIB21_CH6);
+impl_ppib_channel!(PPIB11_CH7, PPIB11, 7, PPIB21_CH7);
+impl_ppib_channel!(PPIB11_CH8, PPIB11, 8, PPIB21_CH8);
+impl_ppib_channel!(PPIB11_CH9, PPIB11, 9, PPIB21_CH9);
+impl_ppib_channel!(PPIB11_CH10, PPIB11, 10, PPIB21_CH10);
+impl_ppib_channel!(PPIB11_CH11, PPIB11, 11, PPIB21_CH11);
+impl_ppib_channel!(PPIB11_CH12, PPIB11, 12, PPIB21_CH12);
+impl_ppib_channel!(PPIB11_CH13, PPIB11, 13, PPIB21_CH13);
+impl_ppib_channel!(PPIB11_CH14, PPIB11, 14, PPIB21_CH14);
+impl_ppib_channel!(PPIB11_CH15, PPIB11, 15, PPIB21_CH15);
+
+impl_ppib_channel!(PPIB20_CH0, PPIB20, 0, PPIB01_CH0);
+impl_ppib_channel!(PPIB20_CH1, PPIB20, 1, PPIB01_CH1);
+impl_ppib_channel!(PPIB20_CH2, PPIB20, 2, PPIB01_CH2);
+impl_ppib_channel!(PPIB20_CH3, PPIB20, 3, PPIB01_CH3);
+impl_ppib_channel!(PPIB20_CH4, PPIB20, 4, PPIB01_CH4);
+impl_ppib_channel!(PPIB20_CH5, PPIB20, 5, PPIB01_CH5);
+impl_ppib_channel!(PPIB20_CH6, PPIB20, 6, PPIB01_CH6);
+impl_ppib_channel!(PPIB20_CH7, PPIB20, 7, PPIB01_CH7);
+
+impl_ppib_channel!(PPIB21_CH0, PPIB21, 0, PPIB11_CH0);
+impl_ppib_channel!(PPIB21_CH1, PPIB21, 1, PPIB11_CH1);
+impl_ppib_channel!(PPIB21_CH2, PPIB21, 2, PPIB11_CH2);
+impl_ppib_channel!(PPIB21_CH3, PPIB21, 3, PPIB11_CH3);
+impl_ppib_channel!(PPIB21_CH4, PPIB21, 4, PPIB11_CH4);
+impl_ppib_channel!(PPIB21_CH5, PPIB21, 5, PPIB11_CH5);
+impl_ppib_channel!(PPIB21_CH6, PPIB21, 6, PPIB11_CH6);
+impl_ppib_channel!(PPIB21_CH7, PPIB21, 7, PPIB11_CH7);
+impl_ppib_channel!(PPIB21_CH8, PPIB21, 8, PPIB11_CH8);
+impl_ppib_channel!(PPIB21_CH9, PPIB21, 9, PPIB11_CH9);
+impl_ppib_channel!(PPIB21_CH10, PPIB21, 10, PPIB11_CH10);
+impl_ppib_channel!(PPIB21_CH11, PPIB21, 11, PPIB11_CH11);
+impl_ppib_channel!(PPIB21_CH12, PPIB21, 12, PPIB11_CH12);
+impl_ppib_channel!(PPIB21_CH13, PPIB21, 13, PPIB11_CH13);
+impl_ppib_channel!(PPIB21_CH14, PPIB21, 14, PPIB11_CH14);
+impl_ppib_channel!(PPIB21_CH15, PPIB21, 15, PPIB11_CH15);
+
+impl_ppib_channel!(PPIB22_CH0, PPIB22, 0, PPIB30_CH0);
+impl_ppib_channel!(PPIB22_CH1, PPIB22, 1, PPIB30_CH1);
+impl_ppib_channel!(PPIB22_CH2, PPIB22, 2, PPIB30_CH2);
+impl_ppib_channel!(PPIB22_CH3, PPIB22, 3, PPIB30_CH3);
+
+impl_ppib_channel!(PPIB30_CH0, PPIB30, 0, PPIB22_CH0);
+impl_ppib_channel!(PPIB30_CH1, PPIB30, 1, PPIB22_CH1);
+impl_ppib_channel!(PPIB30_CH2, PPIB30, 2, PPIB22_CH2);
+impl_ppib_channel!(PPIB30_CH3, PPIB30, 3, PPIB22_CH3);

--- a/embassy-nrf/src/chips/nrf54lm20_app.rs
+++ b/embassy-nrf/src/chips/nrf54lm20_app.rs
@@ -865,3 +865,86 @@ embassy_hal_internal::interrupt_mod!(
     CLOCK_POWER,
     VREGUSB,
 );
+
+// PPI bridge (PPIB) channels
+use crate::ppib::impl_ppib_channel;
+
+impl_ppib_channel!(PPIB00_CH0, PPIB00, 0, PPIB10_CH0);
+impl_ppib_channel!(PPIB00_CH1, PPIB00, 1, PPIB10_CH1);
+impl_ppib_channel!(PPIB00_CH2, PPIB00, 2, PPIB10_CH2);
+impl_ppib_channel!(PPIB00_CH3, PPIB00, 3, PPIB10_CH3);
+impl_ppib_channel!(PPIB00_CH4, PPIB00, 4, PPIB10_CH4);
+impl_ppib_channel!(PPIB00_CH5, PPIB00, 5, PPIB10_CH5);
+impl_ppib_channel!(PPIB00_CH6, PPIB00, 6, PPIB10_CH6);
+impl_ppib_channel!(PPIB00_CH7, PPIB00, 7, PPIB10_CH7);
+
+impl_ppib_channel!(PPIB01_CH0, PPIB01, 0, PPIB20_CH0);
+impl_ppib_channel!(PPIB01_CH1, PPIB01, 1, PPIB20_CH1);
+impl_ppib_channel!(PPIB01_CH2, PPIB01, 2, PPIB20_CH2);
+impl_ppib_channel!(PPIB01_CH3, PPIB01, 3, PPIB20_CH3);
+impl_ppib_channel!(PPIB01_CH4, PPIB01, 4, PPIB20_CH4);
+impl_ppib_channel!(PPIB01_CH5, PPIB01, 5, PPIB20_CH5);
+impl_ppib_channel!(PPIB01_CH6, PPIB01, 6, PPIB20_CH6);
+impl_ppib_channel!(PPIB01_CH7, PPIB01, 7, PPIB20_CH7);
+
+impl_ppib_channel!(PPIB10_CH0, PPIB10, 0, PPIB00_CH0);
+impl_ppib_channel!(PPIB10_CH1, PPIB10, 1, PPIB00_CH1);
+impl_ppib_channel!(PPIB10_CH2, PPIB10, 2, PPIB00_CH2);
+impl_ppib_channel!(PPIB10_CH3, PPIB10, 3, PPIB00_CH3);
+impl_ppib_channel!(PPIB10_CH4, PPIB10, 4, PPIB00_CH4);
+impl_ppib_channel!(PPIB10_CH5, PPIB10, 5, PPIB00_CH5);
+impl_ppib_channel!(PPIB10_CH6, PPIB10, 6, PPIB00_CH6);
+impl_ppib_channel!(PPIB10_CH7, PPIB10, 7, PPIB00_CH7);
+
+impl_ppib_channel!(PPIB11_CH0, PPIB11, 0, PPIB21_CH0);
+impl_ppib_channel!(PPIB11_CH1, PPIB11, 1, PPIB21_CH1);
+impl_ppib_channel!(PPIB11_CH2, PPIB11, 2, PPIB21_CH2);
+impl_ppib_channel!(PPIB11_CH3, PPIB11, 3, PPIB21_CH3);
+impl_ppib_channel!(PPIB11_CH4, PPIB11, 4, PPIB21_CH4);
+impl_ppib_channel!(PPIB11_CH5, PPIB11, 5, PPIB21_CH5);
+impl_ppib_channel!(PPIB11_CH6, PPIB11, 6, PPIB21_CH6);
+impl_ppib_channel!(PPIB11_CH7, PPIB11, 7, PPIB21_CH7);
+impl_ppib_channel!(PPIB11_CH8, PPIB11, 8, PPIB21_CH8);
+impl_ppib_channel!(PPIB11_CH9, PPIB11, 9, PPIB21_CH9);
+impl_ppib_channel!(PPIB11_CH10, PPIB11, 10, PPIB21_CH10);
+impl_ppib_channel!(PPIB11_CH11, PPIB11, 11, PPIB21_CH11);
+impl_ppib_channel!(PPIB11_CH12, PPIB11, 12, PPIB21_CH12);
+impl_ppib_channel!(PPIB11_CH13, PPIB11, 13, PPIB21_CH13);
+impl_ppib_channel!(PPIB11_CH14, PPIB11, 14, PPIB21_CH14);
+impl_ppib_channel!(PPIB11_CH15, PPIB11, 15, PPIB21_CH15);
+
+impl_ppib_channel!(PPIB20_CH0, PPIB20, 0, PPIB01_CH0);
+impl_ppib_channel!(PPIB20_CH1, PPIB20, 1, PPIB01_CH1);
+impl_ppib_channel!(PPIB20_CH2, PPIB20, 2, PPIB01_CH2);
+impl_ppib_channel!(PPIB20_CH3, PPIB20, 3, PPIB01_CH3);
+impl_ppib_channel!(PPIB20_CH4, PPIB20, 4, PPIB01_CH4);
+impl_ppib_channel!(PPIB20_CH5, PPIB20, 5, PPIB01_CH5);
+impl_ppib_channel!(PPIB20_CH6, PPIB20, 6, PPIB01_CH6);
+impl_ppib_channel!(PPIB20_CH7, PPIB20, 7, PPIB01_CH7);
+
+impl_ppib_channel!(PPIB21_CH0, PPIB21, 0, PPIB11_CH0);
+impl_ppib_channel!(PPIB21_CH1, PPIB21, 1, PPIB11_CH1);
+impl_ppib_channel!(PPIB21_CH2, PPIB21, 2, PPIB11_CH2);
+impl_ppib_channel!(PPIB21_CH3, PPIB21, 3, PPIB11_CH3);
+impl_ppib_channel!(PPIB21_CH4, PPIB21, 4, PPIB11_CH4);
+impl_ppib_channel!(PPIB21_CH5, PPIB21, 5, PPIB11_CH5);
+impl_ppib_channel!(PPIB21_CH6, PPIB21, 6, PPIB11_CH6);
+impl_ppib_channel!(PPIB21_CH7, PPIB21, 7, PPIB11_CH7);
+impl_ppib_channel!(PPIB21_CH8, PPIB21, 8, PPIB11_CH8);
+impl_ppib_channel!(PPIB21_CH9, PPIB21, 9, PPIB11_CH9);
+impl_ppib_channel!(PPIB21_CH10, PPIB21, 10, PPIB11_CH10);
+impl_ppib_channel!(PPIB21_CH11, PPIB21, 11, PPIB11_CH11);
+impl_ppib_channel!(PPIB21_CH12, PPIB21, 12, PPIB11_CH12);
+impl_ppib_channel!(PPIB21_CH13, PPIB21, 13, PPIB11_CH13);
+impl_ppib_channel!(PPIB21_CH14, PPIB21, 14, PPIB11_CH14);
+impl_ppib_channel!(PPIB21_CH15, PPIB21, 15, PPIB11_CH15);
+
+impl_ppib_channel!(PPIB22_CH0, PPIB22, 0, PPIB30_CH0);
+impl_ppib_channel!(PPIB22_CH1, PPIB22, 1, PPIB30_CH1);
+impl_ppib_channel!(PPIB22_CH2, PPIB22, 2, PPIB30_CH2);
+impl_ppib_channel!(PPIB22_CH3, PPIB22, 3, PPIB30_CH3);
+
+impl_ppib_channel!(PPIB30_CH0, PPIB30, 0, PPIB22_CH0);
+impl_ppib_channel!(PPIB30_CH1, PPIB30, 1, PPIB22_CH1);
+impl_ppib_channel!(PPIB30_CH2, PPIB30, 2, PPIB22_CH2);
+impl_ppib_channel!(PPIB30_CH3, PPIB30, 3, PPIB22_CH3);

--- a/embassy-nrf/src/lib.rs
+++ b/embassy-nrf/src/lib.rs
@@ -138,6 +138,8 @@ pub mod pdm;
 #[cfg(any(feature = "nrf52840", feature = "nrf9160-s", feature = "nrf9160-ns"))]
 pub mod power;
 pub mod ppi;
+#[cfg(feature = "_nrf54l")]
+pub mod ppib;
 #[cfg(not(any(
     feature = "_nrf51",
     feature = "nrf52805",

--- a/embassy-nrf/src/ppib.rs
+++ b/embassy-nrf/src/ppib.rs
@@ -1,0 +1,78 @@
+//! PPIB (PPI bridge).
+//!
+//! On parts with multiple power domains (e.g. nRF54L) DPPI channels are local to
+//! a domain; a PPIB forwards a signal across domains through a fixed pair of PPIB
+//! instances. A cross-domain link is two ordinary [`Ppi`](crate::ppi::Ppi) hops
+//! (one per domain) joined by a [`Ppib`]: connect the source event to the
+//! bridge's [`task`](Ppib::task), and the bridge's [`event`](Ppib::event) to the
+//! destination task.
+//!
+//! Hardwired pairs (nRF54L): PPIB00<->PPIB10, PPIB01<->PPIB20, PPIB11<->PPIB21,
+//! PPIB22<->PPIB30.
+
+use core::ptr::NonNull;
+
+use embassy_hal_internal::{Peri, PeripheralType};
+
+use crate::pac;
+use crate::ppi::{Event, Task};
+
+pub(crate) trait SealedBridgeChannel {
+    fn regs(&self) -> pac::ppib::Ppib;
+    fn number(&self) -> usize;
+}
+
+/// One half of a hardwired bridge. [`Paired`](Self::Paired) is the channel it is
+/// physically connected to in the other domain (same index, paired instance).
+#[allow(private_bounds)]
+pub trait BridgeChannel: SealedBridgeChannel + PeripheralType + Sized + 'static {
+    /// The hardwired counterpart in the other domain. Symmetric:
+    /// `<Self::Paired as BridgeChannel>::Paired` is `Self`.
+    type Paired: BridgeChannel;
+}
+
+/// A cross-domain PPI bridge: a source channel and its hardwired sink channel in
+/// the other domain.
+pub struct Ppib<'d> {
+    task: Task<'d>,
+    event: Event<'d>,
+}
+
+impl<'d> Ppib<'d> {
+    /// Bridge from the `source` channel to the `sink` channel.
+    pub fn new<S: BridgeChannel>(source: Peri<'d, S>, sink: Peri<'d, S::Paired>) -> Self {
+        let task = source.regs().tasks_send(source.number()).as_ptr();
+        let event = sink.regs().events_receive(sink.number()).as_ptr();
+        Self {
+            task: unsafe { Task::new_unchecked(NonNull::new_unchecked(task)) },
+            event: unsafe { Event::new_unchecked(NonNull::new_unchecked(event)) },
+        }
+    }
+
+    /// The source-domain SEND task.
+    pub fn task(&self) -> Task<'d> {
+        self.task
+    }
+
+    /// The destination-domain RECEIVE event.
+    pub fn event(&self) -> Event<'d> {
+        self.event
+    }
+}
+
+macro_rules! impl_ppib_channel {
+    ($type:ident, $inst:ident, $number:expr, $paired:ident) => {
+        impl crate::ppib::SealedBridgeChannel for crate::peripherals::$type {
+            fn regs(&self) -> crate::pac::ppib::Ppib {
+                crate::pac::$inst
+            }
+            fn number(&self) -> usize {
+                $number
+            }
+        }
+        impl crate::ppib::BridgeChannel for crate::peripherals::$type {
+            type Paired = crate::peripherals::$paired;
+        }
+    };
+}
+pub(crate) use impl_ppib_channel;

--- a/examples/nrf54l15-app/src/bin/ppi.rs
+++ b/examples/nrf54l15-app/src/bin/ppi.rs
@@ -1,0 +1,61 @@
+//! PPI and PPIB (PPI bridge) demo:
+//! - PPI: a TIMER compare event toggles LED1 (both in the PERI domain).
+//! - PPIB: a button in the MCU domain toggles LED2 in the PERI domain, forwarded
+//!   across the PPIB30 <-> PPIB22 bridge as one DPPI hop per domain.
+
+#![no_std]
+#![no_main]
+
+use core::future::pending;
+
+use defmt::info;
+use embassy_executor::Spawner;
+use embassy_nrf::gpio::{Level, OutputDrive, Pull};
+use embassy_nrf::gpiote::{InputChannel, InputChannelPolarity, OutputChannel, OutputChannelPolarity};
+use embassy_nrf::ppi::Ppi;
+use embassy_nrf::ppib::Ppib;
+use embassy_nrf::timer::Timer;
+use {defmt_rtt as _, panic_probe as _};
+
+#[embassy_executor::main]
+async fn main(_spawner: Spawner) {
+    let p = embassy_nrf::init(Default::default());
+    info!("Starting!");
+
+    // GPIOTE20 drives P1 pins (PERI domain), GPIOTE30 drives P0 pins (MCU domain).
+    let led1 = OutputChannel::new(
+        p.GPIOTE20_CH0,
+        p.P1_10,
+        Level::Low,
+        OutputDrive::Standard,
+        OutputChannelPolarity::Toggle,
+    );
+    let led3 = OutputChannel::new(
+        p.GPIOTE20_CH1,
+        p.P1_14,
+        Level::Low,
+        OutputDrive::Standard,
+        OutputChannelPolarity::Toggle,
+    );
+    let button = InputChannel::new(p.GPIOTE30_CH0, p.P0_04, Pull::Up, InputChannelPolarity::HiToLo);
+
+    // Periodic CC[0] compare event, every 0.5 s at the default 1 MHz.
+    let timer = Timer::new(p.TIMER20);
+    timer.cc(0).write(500_000);
+    timer.cc(0).short_compare_clear();
+    timer.start();
+
+    let mut blink = Ppi::new_one_to_one(p.PPI20_CH0, timer.cc(0).event_compare(), led1.task_out());
+    blink.enable();
+
+    let bridge = Ppib::new(p.PPIB30_CH0, p.PPIB22_CH0);
+    let mut src = Ppi::new_one_to_one(p.PPI30_CH0, button.event_in(), bridge.task());
+    src.enable();
+    let mut dst = Ppi::new_one_to_one(p.PPI20_CH1, bridge.event(), led3.task_out());
+    dst.enable();
+
+    info!("LED1 blinks off the timer; press the button to toggle LED2.");
+
+    // Keep the drivers alive — dropping them tears the wiring down.
+    pending::<()>().await;
+}


### PR DESCRIPTION
The PPIB peripheral allows bridging PPI channels between different power domains on the nRF54L. These are models similarily to regulare PPI channels, but the PPIB channel in one power domain has a fixed mapping to a PPIB channel in another power domain.

Add an example for the nRF54L15 devkit showing PPI and PPIB usage.