### PR TITLE
esp-hosted: Add HD-SPI protocol

### DIFF
--- a/embassy-net-esp-hosted/CHANGELOG.md
+++ b/embassy-net-esp-hosted/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 <!-- next-header -->
 ## Unreleased - ReleaseDate
 
+- `Interface` and `SpiInterface` have been moved to `crate::iface` and `crate::iface::spi` respectively.
+- Added `iface::hd_spi` module containing a half-duplex SPI `Interface` implementation.
 - Added `Interface::init` to initialize or re-initialize the transport.
 - Changed: The `Interface::transfer` method now takes a packet length.
 - Added `Control::scan` to retrieve visible networks. Note that `esp-hosted-fg` can only retrieve up to 8 entries.

--- a/embassy-net-esp-hosted/src/iface.rs
+++ b/embassy-net-esp-hosted/src/iface.rs
@@ -1,7 +1,10 @@
-use embassy_futures::join::join;
-use embedded_hal::digital::InputPin;
-use embedded_hal_async::digital::Wait;
-use embedded_hal_async::spi::SpiDevice;
+//! Transport interface.
+//!
+//! The esp-hosted firmware supports multiple interfaces, selected at compile time.
+//! This module provides the [`Interface`] trait and implementations for SPI and HD-SPI.
+
+pub mod hd_spi;
+pub mod spi;
 
 /// Physical interface trait for communicating with the ESP chip.
 pub trait Interface {
@@ -20,60 +23,4 @@ pub trait Interface {
     ///
     /// The payload bytes contain the valid length of the received buffer.
     async fn transfer(&mut self, buffer: &mut [u8], tx_len: usize);
-}
-
-/// Standard SPI interface.
-///
-/// This interface is what's implemented in the upstream `esp-hosted-fg` firmware. It uses:
-/// - An `SpiDevice` for SPI communication (CS is handled by the device)
-/// - A handshake pin that signals when the ESP is ready for a new transaction
-/// - A ready pin that indicates when the ESP has data to send
-pub struct SpiInterface<SPI, IN> {
-    spi: SPI,
-    handshake: IN,
-    ready: IN,
-}
-
-impl<SPI, IN> SpiInterface<SPI, IN>
-where
-    SPI: SpiDevice,
-    IN: InputPin + Wait,
-{
-    /// Create a new SpiInterface.
-    pub fn new(spi: SPI, handshake: IN, ready: IN) -> Self {
-        Self { spi, handshake, ready }
-    }
-}
-
-impl<SPI, IN> Interface for SpiInterface<SPI, IN>
-where
-    SPI: SpiDevice,
-    IN: InputPin + Wait,
-{
-    async fn init(&mut self, _cold_boot: bool) {
-        // No-op
-    }
-
-    async fn wait_for_handshake(&mut self) {
-        self.handshake.wait_for_high().await.unwrap();
-    }
-
-    async fn wait_for_ready(&mut self) {
-        self.ready.wait_for_high().await.unwrap();
-    }
-
-    async fn transfer(&mut self, buffer: &mut [u8], _tx_len: usize) {
-        let (a, b) = join(
-            // The esp-hosted firmware deasserts the HANDSHAKE pin a few us AFTER ending the SPI transfer
-            // If we check it again too fast, we'll see it's high from the previous transfer, and if we send it
-            // data it will get lost.
-            self.handshake.wait_for_low(),
-            // Always transfer the full buffer.
-            self.spi.transfer_in_place(buffer),
-        )
-        .await;
-
-        a.unwrap();
-        b.unwrap();
-    }
 }

--- a/embassy-net-esp-hosted/src/iface/hd_spi.rs
+++ b/embassy-net-esp-hosted/src/iface/hd_spi.rs
@@ -1,0 +1,240 @@
+//! Half-duplex SPI interface.
+//!
+//! Only supported by `esp-hosted-mcu`.
+
+use embassy_time::Timer;
+use embedded_hal::digital::InputPin;
+use embedded_hal_async::digital::Wait;
+
+use crate::Interface;
+
+/// Represents a register on the half-duplex SPI interface.
+#[derive(Clone, Copy)]
+pub enum HdRegister {
+    /// Indicates if co-processor is ready
+    CoprocessorReady = 0x00,
+
+    /// The length of data the co-processor can transmit.
+    ///
+    /// Updated whenever co-processor wants to transmit data.
+    TxBufLen = 0x0C,
+
+    /// The length of data co-processor can receive.
+    ///
+    /// Updated whenever co-processor can receive data.
+    RxBufLen = 0x10,
+
+    /// Controls co-processor operation.
+    CoprocessorControl = 0x14,
+}
+
+/// Represents a command on the half-duplex SPI interface.
+#[derive(Clone, Copy)]
+pub enum HdCommand {
+    /// Write to a 32-bit buffer register on the co-processor.
+    WriteReg = 0x01,
+
+    /// Read from a 32-bit buffer register on the co-processor
+    ReadReg = 0x02,
+
+    /// Write data to the co-processor.
+    WriteDma = 0x03,
+
+    /// Read data from the co-processor.
+    ReadDma = 0x04,
+
+    /// End of write.
+    WriteDone = 0x07,
+
+    /// CMD8 - End of read.
+    ReadDone = 0x08,
+
+    /// CMD9 - The host is done with the register read. The co-processor can de-assert `Data_Ready`.
+    Int1 = 0x09,
+}
+
+impl HdCommand {
+    /// Returns the command opcode for Dual SPI mode.
+    pub fn dual_spi(self) -> u8 {
+        (self as u8) | 0x50
+    }
+
+    /// Returns the command opcode for Quad SPI mode.
+    pub fn quad_spi(self) -> u8 {
+        (self as u8) | 0xA0
+    }
+}
+
+/// Trait for a half-duplex SPI interface.
+///
+/// The device must be configured to use the same number of data lines as the hosted firmware.
+pub trait HdSpi {
+    /// Read data from the SPI device using the given command and address.
+    ///
+    /// esp-hosted requires 8 dummy bits to be inserted between the address and the data.
+    async fn read(&mut self, command: HdCommand, addr: u32, buf: &mut [u8]);
+
+    /// Write data to the SPI device using the given command and address.
+    ///
+    /// esp-hosted requires 8 dummy bits to be inserted between the address and the data.
+    async fn write(&mut self, command: HdCommand, addr: u32, buf: &[u8]);
+}
+
+/// Half-duplex SPI interface.
+///
+/// This interface is what's implemented in the upstream `esp-hosted` firmware. It uses:
+/// - An `HdSpi` implementation for SPI communication (CS is handled by the device)
+/// - A `Data_Ready` pin that indicates when the ESP has data to send
+pub struct HdSpiInterface<D, DR> {
+    spi: D,
+    data_ready: DR,
+    tx_buf_count: u32,
+    rx_byte_count: u32,
+}
+
+impl<D, DR> HdSpiInterface<D, DR>
+where
+    D: HdSpi,
+    DR: InputPin + Wait,
+{
+    const HEADER_LEN: usize = 12;
+    const MAX_SPI_HD_BUFFER_SIZE: usize = 1600;
+    const TX_BUF_LEN_MASK: u32 = 0x00FF_FFFF;
+    const MAX_WRITE_BUF_RETRIES: u8 = 25;
+    const POLLING_READ: u8 = 3;
+    const COPROC_READY_FLAG: u32 = 0xEE;
+    const CTRL_DATAPATH_ON: u32 = 1 << 0;
+
+    /// Creates a new half-duplex SPI interface with the given SPI DMA driver and `Data_Ready` pin.
+    pub fn new(spi: D, data_ready: DR) -> Self {
+        Self {
+            spi,
+            data_ready,
+            tx_buf_count: 0,
+            rx_byte_count: 0,
+        }
+    }
+
+    async fn read_reg_once(&mut self, reg: HdRegister) -> u32 {
+        let mut buf = [0u8; 4];
+        self.spi.read(HdCommand::ReadReg, reg as u32, &mut buf).await;
+        u32::from_le_bytes(buf)
+    }
+
+    async fn write_reg(&mut self, reg: HdRegister, value: u32) {
+        self.spi
+            .write(HdCommand::WriteReg, reg as u32, &value.to_le_bytes())
+            .await;
+    }
+
+    // WR_DONE / CMD8 / CMD9: command + address + dummy, no data.
+    fn command(&mut self, cmd: HdCommand) -> impl Future<Output = ()> {
+        self.spi.write(cmd, 0, &[])
+    }
+
+    // Re-read until two reads agree; the co-processor may update mid-read.
+    async fn read_reg(&mut self, reg: HdRegister) -> u32 {
+        let mut value = self.read_reg_once(reg).await;
+        for _ in 0..Self::POLLING_READ {
+            let next = self.read_reg_once(reg).await;
+            if next == value {
+                break;
+            }
+            value = next;
+        }
+        value
+    }
+
+    async fn write_frame(&mut self, frame: &[u8]) {
+        let buffers_needed = frame.len().div_ceil(Self::MAX_SPI_HD_BUFFER_SIZE) as u32;
+
+        let mut retries = Self::MAX_WRITE_BUF_RETRIES;
+        loop {
+            let available = self
+                .read_reg(HdRegister::RxBufLen)
+                .await
+                .wrapping_sub(self.tx_buf_count);
+            if available >= buffers_needed {
+                break;
+            }
+            retries -= 1;
+            if retries == 0 {
+                warn!("spi-hd: no write buffers on co-processor, dropping packet");
+                return;
+            }
+            Timer::after_millis(1).await;
+        }
+
+        self.spi.write(HdCommand::WriteDma, 0, frame).await;
+
+        self.command(HdCommand::WriteDone).await;
+        self.tx_buf_count = self.tx_buf_count.wrapping_add(buffers_needed);
+    }
+
+    async fn read_frame(&mut self, buffer: &mut [u8]) -> usize {
+        let tx_buf_len = self.read_reg(HdRegister::TxBufLen).await;
+        self.command(HdCommand::Int1).await;
+
+        let total = tx_buf_len & Self::TX_BUF_LEN_MASK;
+        let size = (total.wrapping_sub(self.rx_byte_count) & Self::TX_BUF_LEN_MASK) as usize;
+        if size == 0 {
+            return 0;
+        }
+        if size > buffer.len() {
+            warn!("spi-hd: rx size {} exceeds buffer, dropping", size);
+            return 0;
+        }
+
+        self.spi.read(HdCommand::ReadDma, 0, &mut buffer[..size]).await;
+
+        self.command(HdCommand::ReadDone).await;
+        self.rx_byte_count = self.rx_byte_count.wrapping_add(size as u32) & Self::TX_BUF_LEN_MASK;
+        size
+    }
+}
+
+impl<D, DR> Interface for HdSpiInterface<D, DR>
+where
+    D: HdSpi,
+    DR: InputPin + Wait,
+{
+    async fn init(&mut self, cold_boot: bool) {
+        if !cold_boot {
+            // Give the device time to reboot.
+            Timer::after_secs(2).await;
+        }
+
+        self.tx_buf_count = 0;
+        self.rx_byte_count = 0;
+
+        while self.read_reg_once(HdRegister::CoprocessorReady).await != Self::COPROC_READY_FLAG {
+            Timer::after_millis(100).await;
+        }
+        self.write_reg(HdRegister::CoprocessorControl, Self::CTRL_DATAPATH_ON)
+            .await;
+    }
+
+    async fn wait_for_handshake(&mut self) {
+        // Half-duplex has no per-transaction handshake line.
+    }
+
+    async fn wait_for_ready(&mut self) {
+        self.data_ready.wait_for_high().await.unwrap();
+    }
+
+    async fn transfer(&mut self, buffer: &mut [u8], tx_len: usize) {
+        if tx_len > 0 {
+            self.write_frame(&buffer[..tx_len]).await;
+        }
+
+        let received = if self.data_ready.is_high().unwrap_or(false) {
+            self.read_frame(buffer).await
+        } else {
+            0
+        };
+
+        if received == 0 {
+            buffer[..Self::HEADER_LEN].fill(0);
+        }
+    }
+}

--- a/embassy-net-esp-hosted/src/iface/spi.rs
+++ b/embassy-net-esp-hosted/src/iface/spi.rs
@@ -1,0 +1,64 @@
+//! Full-duplex SPI interface.
+
+use embassy_futures::join::join;
+use embedded_hal::digital::InputPin;
+use embedded_hal_async::digital::Wait;
+use embedded_hal_async::spi::SpiDevice;
+
+use crate::Interface;
+
+/// Standard SPI interface.
+///
+/// This interface is what's implemented in the upstream `esp-hosted` firmware. It uses:
+/// - An `SpiDevice` for SPI communication (CS is handled by the device)
+/// - A handshake pin that signals when the ESP is ready for a new transaction
+/// - A ready pin that indicates when the ESP has data to send
+pub struct SpiInterface<SPI, IN> {
+    spi: SPI,
+    handshake: IN,
+    ready: IN,
+}
+
+impl<SPI, IN> SpiInterface<SPI, IN>
+where
+    SPI: SpiDevice,
+    IN: InputPin + Wait,
+{
+    /// Create a new SpiInterface.
+    pub fn new(spi: SPI, handshake: IN, ready: IN) -> Self {
+        Self { spi, handshake, ready }
+    }
+}
+
+impl<SPI, IN> Interface for SpiInterface<SPI, IN>
+where
+    SPI: SpiDevice,
+    IN: InputPin + Wait,
+{
+    async fn init(&mut self, _cold_boot: bool) {
+        // No-op
+    }
+
+    async fn wait_for_handshake(&mut self) {
+        self.handshake.wait_for_high().await.unwrap();
+    }
+
+    async fn wait_for_ready(&mut self) {
+        self.ready.wait_for_high().await.unwrap();
+    }
+
+    async fn transfer(&mut self, buffer: &mut [u8], _tx_len: usize) {
+        let (a, b) = join(
+            // The esp-hosted firmware deasserts the HANDSHAKE pin a few us AFTER ending the SPI transfer
+            // If we check it again too fast, we'll see it's high from the previous transfer, and if we send it
+            // data it will get lost.
+            self.handshake.wait_for_low(),
+            // Always transfer the full buffer.
+            self.spi.transfer_in_place(buffer),
+        )
+        .await;
+
+        a.unwrap();
+        b.unwrap();
+    }
+}

--- a/embassy-net-esp-hosted/src/lib.rs
+++ b/embassy-net-esp-hosted/src/lib.rs
@@ -27,12 +27,12 @@ mod fmt;
 #[cfg(feature = "bluetooth")]
 pub mod bluetooth;
 mod control;
-mod iface;
+pub mod iface;
 mod ioctl;
 mod rpc;
 
 pub use control::*;
-pub use iface::*;
+use iface::Interface;
 
 const MTU: usize = 1514;
 

--- a/examples/nrf52840/src/bin/wifi_esp_hosted.rs
+++ b/examples/nrf52840/src/bin/wifi_esp_hosted.rs
@@ -12,6 +12,7 @@ use embassy_nrf::{bind_interrupts, peripherals};
 use embassy_time::Delay;
 use embedded_hal_bus::spi::ExclusiveDevice;
 use embedded_io_async::Write;
+use hosted::iface::spi::SpiInterface;
 use static_cell::StaticCell;
 use {defmt_rtt as _, embassy_net_esp_hosted as hosted, panic_probe as _};
 
@@ -27,7 +28,7 @@ bind_interrupts!(struct Irqs {
 async fn wifi_task(
     runner: hosted::Runner<
         'static,
-        hosted::SpiInterface<ExclusiveDevice<Spim<'static>, Output<'static>, Delay>, Input<'static>>,
+        SpiInterface<ExclusiveDevice<Spim<'static>, Output<'static>, Delay>, Input<'static>>,
         Output<'static>,
     >,
 ) -> ! {
@@ -58,7 +59,7 @@ async fn main(spawner: Spawner) {
     let spi = spim::Spim::new(p.SPI3, Irqs, sck, miso, mosi, config);
     let spi = ExclusiveDevice::new(spi, cs, Delay);
 
-    let iface = hosted::SpiInterface::new(spi, handshake, ready);
+    let iface = SpiInterface::new(spi, handshake, ready);
 
     static ESP_STATE: StaticCell<embassy_net_esp_hosted::State> = StaticCell::new();
     let embassy_net_esp_hosted::HostedResources {

--- a/tests/nrf/src/bin/wifi_esp_hosted_perf.rs
+++ b/tests/nrf/src/bin/wifi_esp_hosted_perf.rs
@@ -13,6 +13,7 @@ use embassy_nrf::spim::{self, Spim};
 use embassy_nrf::{bind_interrupts, peripherals};
 use embassy_time::Delay;
 use embedded_hal_bus::spi::ExclusiveDevice;
+use hosted::iface::spi::SpiInterface;
 use static_cell::StaticCell;
 use {defmt_rtt as _, embassy_net_esp_hosted as hosted, panic_probe as _};
 
@@ -29,7 +30,7 @@ const WIFI_PASSWORD: &str = "V8YxhKt5CdIAJFud";
 async fn wifi_task(
     runner: hosted::Runner<
         'static,
-        hosted::SpiInterface<ExclusiveDevice<Spim<'static>, Output<'static>, Delay>, Input<'static>>,
+        SpiInterface<ExclusiveDevice<Spim<'static>, Output<'static>, Delay>, Input<'static>>,
         Output<'static>,
     >,
 ) -> ! {
@@ -63,7 +64,7 @@ async fn main(spawner: Spawner) {
     let spi = spim::Spim::new(p.SPI3, Irqs, sck, miso, mosi, config);
     let spi = ExclusiveDevice::new(spi, cs, Delay);
 
-    let iface = hosted::SpiInterface::new(spi, handshake, ready);
+    let iface = SpiInterface::new(spi, handshake, ready);
 
     static STATE: StaticCell<embassy_net_esp_hosted::State> = StaticCell::new();
     let embassy_net_esp_hosted::HostedResources {


### PR DESCRIPTION
An example esp-hal implementation (when the relevant half-duplex-using-DMA changes are released) should look something like this:

```rust
use embassy_net_esp_hosted::iface::hd_spi::{HdCommand, HdSpi};
use embedded_hal::digital::OutputPin;
use esp_hal::Async;
use esp_hal::spi::master::{Address, Command, DataMode, SpiDma};

pub struct EspHalQspi<'d, CS> {
    spi: SpiDma<'d, Async>,
    cs: CS,
    data_mode: DataMode,
}

impl<'d, CS> EspHalQspi<'d, CS>
where
    CS: OutputPin,
{
    const DUMMY_BITS: u8 = 8;

    pub fn new(spi: SpiDma<'d, Async>, cs: CS, data_mode: DataMode) -> Self {
        Self { spi, cs, data_mode }
    }

    fn cmd(&self, command: HdCommand) -> Command {
        Command::_8Bit(
            match self.data_mode {
                DataMode::Dual => command.dual_spi() as u16,
                DataMode::Quad => command.quad_spi() as u16,
                _ => unreachable!(),
            },
            DataMode::Single,
        )
    }

    fn addr(&self, value: u32) -> Address {
        Address::_8Bit(value, self.data_mode)
    }
}

impl<'d, CS> HdSpi for EspHalQspi<'d, CS>
where
    CS: OutputPin,
{
    async fn read(&mut self, command: HdCommand, addr: u32, buf: &mut [u8]) {
        self.cs.set_low().unwrap();

        let cmd = self.cmd(command);
        let addr = self.addr(addr);
        self.spi
            .half_duplex_read_async(self.data_mode, cmd, addr, Self::DUMMY_BITS, buf)
            .await
            .unwrap();

        self.cs.set_high().unwrap();
    }

    async fn write(&mut self, command: HdCommand, addr: u32, buf: &[u8]) {
        self.cs.set_low().unwrap();

        let cmd = self.cmd(command);
        let addr = self.addr(addr);
        self.spi
            .half_duplex_write_async(self.data_mode, cmd, addr, Self::DUMMY_BITS, buf)
            .await
            .unwrap();

        self.cs.set_high().unwrap();
    }
}
```