### PR TITLE
USB Host (STM32): fixes for multi device support via hub

### DIFF
--- a/embassy-stm32/src/usb/usb_host.rs
+++ b/embassy-stm32/src/usb/usb_host.rs
@@ -151,8 +151,8 @@ fn align_len_up(len: u16) -> u16 {
 /// `len_bits` should be placed on the upper 16 bits of the register value
 fn calc_receive_len_bits(len: u16) -> (u16, u16) {
     match len {
-        // NOTE: this could be 2..=62 with 16bit USBRAM, but not with 32bit. Limit it to 60 for simplicity.
-        2..=60 => (align_len_up(len), align_len_up(len) / 2 << 10),
+        // NOTE: this could be 1..=62 with 16bit USBRAM, but not with 32bit. Limit it to 60 for simplicity.
+        1..=60 => (align_len_up(len), align_len_up(len) / 2 << 10),
         61..=1024 => ((len + 31) / 32 * 32, (((len + 31) / 32 - 1) << 10) | 0x8000),
         _ => panic!("invalid OUT length {}", len),
     }

--- a/embassy-stm32/src/usb/usb_host.rs
+++ b/embassy-stm32/src/usb/usb_host.rs
@@ -779,7 +779,9 @@ impl<'d, I: SealedHostInstance> UsbHostAllocator<'d> for Allocator<'d, I> {
         let mut epr = invariant(epr_reg.read());
         epr.set_devaddr(addr);
         epr.set_ep_type(convert_type(endpoint.ep_type));
-        epr.set_ea(new_index as _);
+        // EA is the device endpoint number, not the host channel slot
+        // (`new_index`); these differ once more than one device is attached.
+        epr.set_ea(endpoint.addr.index() as _);
         epr_reg.write_value(epr);
 
         Ok(channel)


### PR DESCRIPTION
Two small fixes for using USB Host with an USB Hub

- USB Hubs with 7 or fewer ports report `wMaxPacketLength 1` for their status-change interrupt endpoint. This caused a panic in `calc_receive_len_bits`.
- Host channel allocation index does not necessarily coincide with the device endpoint address when having multiple devices attached via HUB.

Tested on STM32G0B with Nedis USB-A hub (UHUBU2420BK)