### PR TITLE
USB Host (STM32): Restore shared control channel state before each control transfer.

### DIFF
--- a/embassy-stm32/src/usb/usb_host.rs
+++ b/embassy-stm32/src/usb/usb_host.rs
@@ -390,6 +390,8 @@ pub struct Channel<'d, I: SealedHostInstance, D: pipe::Direction, T: pipe::Type>
     _marker: PhantomData<(&'d mut I, D, T)>,
     /// Register index (there are 8 in total)
     index: usize,
+    /// Device address this pipe targets (re-asserted before each control transfer).
+    addr: u8,
     max_packet_size_in: u16,
     #[allow(dead_code)]
     max_packet_size_out: u16,
@@ -400,6 +402,7 @@ pub struct Channel<'d, I: SealedHostInstance, D: pipe::Direction, T: pipe::Type>
 impl<'d, I: SealedHostInstance, D: pipe::Direction, T: pipe::Type> Channel<'d, I, D, T> {
     fn new(
         index: usize,
+        addr: u8,
         buf_in: Option<EndpointBuffer<I>>,
         buf_out: Option<EndpointBuffer<I>>,
         max_packet_size_in: u16,
@@ -408,10 +411,29 @@ impl<'d, I: SealedHostInstance, D: pipe::Direction, T: pipe::Type> Channel<'d, I
         Self {
             _marker: PhantomData,
             index,
+            addr,
             max_packet_size_in,
             max_packet_size_out,
             buf_in,
             buf_out,
+        }
+    }
+
+    /// Re-assert this pipe's device address and receive-buffer descriptor on the
+    /// shared control channel (slot 0). All control pipes reuse slot 0, but its
+    /// address and BTABLE receive descriptor are written only at allocation, so
+    /// opening another device's control pipe re-points slot 0 at that device;
+    /// restore both from this pipe's own state before each transfer. The
+    /// transmit descriptor is rewritten per packet in `write_data`.
+    fn restore_control_channel(&self) {
+        let epr_reg = self.reg();
+        let mut epr = invariant(epr_reg.read());
+        epr.set_devaddr(self.addr);
+        epr_reg.write_value(epr);
+
+        if let Some(buf_in) = self.buf_in.as_ref() {
+            let (_, len_bits) = calc_receive_len_bits(self.max_packet_size_in);
+            btable::write_receive_buffer_descriptor::<I>(self.index, buf_in.addr, len_bits);
         }
     }
 
@@ -589,6 +611,9 @@ impl<'d, I: SealedHostInstance, T: pipe::Type, D: pipe::Direction> UsbPipe<T, D>
         T: pipe::IsControl,
         D: pipe::IsIn,
     {
+        // Slot 0 is shared by all control pipes; re-point it at this device.
+        self.restore_control_channel();
+
         let epr0 = I::regs().epr(0);
 
         // setup stage
@@ -615,6 +640,9 @@ impl<'d, I: SealedHostInstance, T: pipe::Type, D: pipe::Direction> UsbPipe<T, D>
         T: pipe::IsControl,
         D: pipe::IsOut,
     {
+        // Slot 0 is shared by all control pipes; re-point it at this device.
+        self.restore_control_channel();
+
         let epr0 = I::regs().epr(0);
 
         // setup stage
@@ -768,6 +796,7 @@ impl<'d, I: SealedHostInstance> UsbHostAllocator<'d> for Allocator<'d, I> {
 
         let channel = Channel::<I, D, T>::new(
             new_index as usize,
+            addr,
             buffer_in,
             buffer_out,
             endpoint.max_packet_size,


### PR DESCRIPTION
All control pipes share host channel register slot 0, but its device address and BTABLE receive-buffer descriptor are written only at allocation, so allocating a second device's control pipe re-points slot 0 at that device.

For example first we enumerate a Hub, then the devices behind it. After that the control pipe is configured for the device. So if we want to read the Hub status we first need to reconfigure the correct address and buffer.

Therefore we re-assert the device address and receive descriptor from each pipe's own state at the start of every control transfer.

Tested on STM32G0B with Nedis USB-A hub (UHUBU2420BK)