### PR TITLE
Disconnection reason enum

### DIFF
--- a/embassy-stm32-wpan/src/bluetooth/gap/connection.rs
+++ b/embassy-stm32-wpan/src/bluetooth/gap/connection.rs
@@ -38,26 +38,92 @@ impl LePhy {
 }
 
 /// Reason for disconnection
-#[repr(u8)]
+///
+/// Represents the HCI status code reported when a connection terminates, or the
+/// reason supplied by the local host when initiating a disconnection. Codes that
+/// are not explicitly mapped are preserved via [`DisconnectReason::Unknown`].
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub enum DisconnectReason {
-    /// Remote user terminated connection
-    RemoteUserTerminated = 0x13,
-    /// Remote device terminated due to low resources
-    RemoteLowResources = 0x14,
-    /// Remote device terminated due to power off
-    RemotePowerOff = 0x15,
-    /// Connection terminated by local host
-    LocalHostTerminated = 0x16,
-    /// Unacceptable connection parameters
-    UnacceptableParameters = 0x3B,
+    /// Connection timeout (0x08)
+    ConnectionTimeout,
+    /// Remote user terminated connection (0x13)
+    RemoteUserTerminated,
+    /// Remote device terminated due to low resources (0x14)
+    RemoteLowResources,
+    /// Remote device terminated due to power off (0x15)
+    RemotePowerOff,
+    /// Connection terminated by local host (0x16)
+    LocalHostTerminated,
+    /// Unsupported remote feature (0x1A)
+    UnsupportedRemoteFeature,
+    /// Unacceptable connection parameters (0x3B)
+    UnacceptableParameters,
+    /// MIC failure (0x3D)
+    MicFailure,
+    /// Connection failed to establish (0x3E)
+    ConnectionFailedToEstablish,
+    /// Unknown or unmapped HCI status code
+    Unknown(u8),
 }
 
 impl DisconnectReason {
-    /// Convert to raw u8 value for HCI command
     pub fn as_u8(self) -> u8 {
-        self as u8
+        match self {
+            DisconnectReason::ConnectionTimeout => 0x08,
+            DisconnectReason::RemoteUserTerminated => 0x13,
+            DisconnectReason::RemoteLowResources => 0x14,
+            DisconnectReason::RemotePowerOff => 0x15,
+            DisconnectReason::LocalHostTerminated => 0x16,
+            DisconnectReason::UnsupportedRemoteFeature => 0x1A,
+            DisconnectReason::UnacceptableParameters => 0x3B,
+            DisconnectReason::MicFailure => 0x3D,
+            DisconnectReason::ConnectionFailedToEstablish => 0x3E,
+            DisconnectReason::Unknown(code) => code,
+        }
+    }
+}
+
+impl From<u8> for DisconnectReason {
+    fn from(code: u8) -> Self {
+        match code {
+            0x08 => DisconnectReason::ConnectionTimeout,
+            0x13 => DisconnectReason::RemoteUserTerminated,
+            0x14 => DisconnectReason::RemoteLowResources,
+            0x15 => DisconnectReason::RemotePowerOff,
+            0x16 => DisconnectReason::LocalHostTerminated,
+            0x1A => DisconnectReason::UnsupportedRemoteFeature,
+            0x3B => DisconnectReason::UnacceptableParameters,
+            0x3D => DisconnectReason::MicFailure,
+            0x3E => DisconnectReason::ConnectionFailedToEstablish,
+            other => DisconnectReason::Unknown(other),
+        }
+    }
+}
+
+impl From<DisconnectReason> for &'static str {
+    fn from(reason: DisconnectReason) -> Self {
+        match reason {
+            DisconnectReason::ConnectionTimeout => "Connection Timeout",
+            DisconnectReason::RemoteUserTerminated => "Remote User Terminated",
+            DisconnectReason::RemoteLowResources => "Remote Low Resources",
+            DisconnectReason::RemotePowerOff => "Remote Power Off",
+            DisconnectReason::LocalHostTerminated => "Local Host Terminated",
+            DisconnectReason::UnsupportedRemoteFeature => "Unsupported Remote Feature",
+            DisconnectReason::UnacceptableParameters => "Unacceptable Connection Parameters",
+            DisconnectReason::MicFailure => "MIC Failure",
+            DisconnectReason::ConnectionFailedToEstablish => "Connection Failed to Establish",
+            DisconnectReason::Unknown(_) => "Unknown",
+        }
+    }
+}
+
+impl core::fmt::Display for DisconnectReason {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        match self {
+            DisconnectReason::Unknown(code) => write!(f, "Unknown (0x{code:02X})"),
+            _ => f.write_str((*self).into()),
+        }
     }
 }
 
@@ -339,7 +405,7 @@ pub enum GapEvent {
         /// Handle of the terminated connection
         handle: ConnectionHandle,
         /// Reason for disconnection
-        reason: u8,
+        reason: DisconnectReason,
     },
 
     /// Connection parameters have been updated

--- a/embassy-stm32-wpan/src/bluetooth/mod.rs
+++ b/embassy-stm32-wpan/src/bluetooth/mod.rs
@@ -677,7 +677,7 @@ impl<'d> HCI<'d, Normal> {
 
                     Some(GapEvent::Disconnected {
                         handle: *conn_handle,
-                        reason: (*reason).into(),
+                        reason: DisconnectReason::from(u8::from(*reason)),
                     })
                 } else {
                     None

--- a/examples/stm32wba/src/bin/ble_central.rs
+++ b/examples/stm32wba/src/bin/ble_central.rs
@@ -224,7 +224,12 @@ async fn main(spawner: Spawner) {
 
                         GapEvent::Disconnected { handle, reason } => {
                             error!("Connection failed or disconnected during setup");
-                            error!("  Handle: 0x{:04X}, Reason: 0x{:02X}", handle.0, reason);
+                            error!(
+                                "  Handle: 0x{:04X}, Reason: 0x{:02X} ({})",
+                                handle.0,
+                                reason.as_u8(),
+                                Display2Format(&reason)
+                            );
 
                             // Go back to scanning
                             ble.start_scan_observation(scan_params.clone())
@@ -245,7 +250,7 @@ async fn main(spawner: Spawner) {
                         GapEvent::Disconnected { handle, reason } => {
                             info!("=== DISCONNECTED ===");
                             info!("  Handle: 0x{:04X}", handle.0);
-                            info!("  Reason: 0x{:02X} ({})", reason, disconnect_reason_str(reason));
+                            info!("  Reason: 0x{:02X} ({})", reason.as_u8(), Display2Format(&reason));
 
                             // Go back to scanning
                             ble.start_scan_observation(scan_params.clone())
@@ -389,20 +394,4 @@ enum CentralState {
     Connecting,
     /// Connected to a peripheral
     Connected,
-}
-
-/// Convert disconnect reason code to human-readable string
-fn disconnect_reason_str(reason: u8) -> &'static str {
-    match reason {
-        0x08 => "Connection Timeout",
-        0x13 => "Remote User Terminated",
-        0x14 => "Remote Low Resources",
-        0x15 => "Remote Power Off",
-        0x16 => "Local Host Terminated",
-        0x1A => "Unsupported Remote Feature",
-        0x3B => "Unacceptable Connection Parameters",
-        0x3D => "MIC Failure",
-        0x3E => "Connection Failed to Establish",
-        _ => "Unknown",
-    }
 }

--- a/examples/stm32wba/src/bin/ble_dtm_runtime.rs
+++ b/examples/stm32wba/src/bin/ble_dtm_runtime.rs
@@ -237,7 +237,7 @@ async fn handle_ble_event(ble: &mut HCI<'_, Normal>, event: &Event, adv_params: 
             GapEvent::Disconnected { handle, reason } => {
                 info!("=== DISCONNECTION ===");
                 info!("  Handle: 0x{:04X}", handle.0);
-                info!("  Reason: 0x{:02X} ({})", reason, disconnect_reason_str(reason));
+                info!("  Reason: 0x{:02X} ({})", reason.as_u8(), Display2Format(&reason));
                 info!("  Active connections: {}", ble.connections().count());
 
                 info!("Restarting advertising...");
@@ -331,20 +331,5 @@ async fn run_dtm_test(ble: &mut HCI<'_, Test>, expected: u32) {
                 Err(e) => error!("dtm_end failed: {:?}", e),
             }
         }
-    }
-}
-
-fn disconnect_reason_str(reason: u8) -> &'static str {
-    match reason {
-        0x08 => "Connection Timeout",
-        0x13 => "Remote User Terminated",
-        0x14 => "Remote Low Resources",
-        0x15 => "Remote Power Off",
-        0x16 => "Local Host Terminated",
-        0x1A => "Unsupported Remote Feature",
-        0x3B => "Unacceptable Connection Parameters",
-        0x3D => "MIC Failure",
-        0x3E => "Connection Failed to Establish",
-        _ => "Unknown",
     }
 }

--- a/examples/stm32wba/src/bin/ble_gatt_server.rs
+++ b/examples/stm32wba/src/bin/ble_gatt_server.rs
@@ -190,7 +190,12 @@ async fn main(spawner: Spawner) {
                     state.notifications_enabled = false; // Reset on new connection
                 }
                 GapEvent::Disconnected { handle, reason } => {
-                    info!("Disconnected: handle 0x{:04X}, reason 0x{:02X}", handle.0, reason);
+                    info!(
+                        "Disconnected: handle 0x{:04X}, reason 0x{:02X} ({})",
+                        handle.0,
+                        reason.as_u8(),
+                        Display2Format(&reason)
+                    );
                     state.current_conn_handle = None;
                     state.notifications_enabled = false;
 

--- a/examples/stm32wba/src/bin/ble_peripheral_connect.rs
+++ b/examples/stm32wba/src/bin/ble_peripheral_connect.rs
@@ -174,7 +174,7 @@ async fn main(spawner: Spawner) {
                 GapEvent::Disconnected { handle, reason } => {
                     info!("=== DISCONNECTION ===");
                     info!("  Handle: 0x{:04X}", handle.0);
-                    info!("  Reason: 0x{:02X} ({})", reason, disconnect_reason_str(reason));
+                    info!("  Reason: 0x{:02X} ({})", reason.as_u8(), Display2Format(&reason));
                     info!("  Active connections: {}", ble.connections().count());
 
                     // Restart advertising after disconnection.
@@ -217,21 +217,5 @@ async fn main(spawner: Spawner) {
             // Log other events for debugging
             debug!("Other BLE Event: {:?}", event);
         }
-    }
-}
-
-/// Convert disconnect reason code to human-readable string
-fn disconnect_reason_str(reason: u8) -> &'static str {
-    match reason {
-        0x08 => "Connection Timeout",
-        0x13 => "Remote User Terminated",
-        0x14 => "Remote Low Resources",
-        0x15 => "Remote Power Off",
-        0x16 => "Local Host Terminated",
-        0x1A => "Unsupported Remote Feature",
-        0x3B => "Unacceptable Connection Parameters",
-        0x3D => "MIC Failure",
-        0x3E => "Connection Failed to Establish",
-        _ => "Unknown",
     }
 }

--- a/examples/stm32wba/src/bin/ble_secure.rs
+++ b/examples/stm32wba/src/bin/ble_secure.rs
@@ -204,7 +204,12 @@ async fn main(spawner: Spawner) {
 
                 GapEvent::Disconnected { handle, reason } => {
                     info!("=== DISCONNECTED ===");
-                    info!("  Handle: 0x{:04X}, Reason: 0x{:02X}", handle.0, reason);
+                    info!(
+                        "  Handle: 0x{:04X}, Reason: 0x{:02X} ({})",
+                        handle.0,
+                        reason.as_u8(),
+                        Display2Format(&reason)
+                    );
 
                     // Restart advertising
                     ble.start_advertising(adv_params.clone(), create_adv_data(), None)

--- a/examples/stm32wba/src/bin/ble_serial_com.rs
+++ b/examples/stm32wba/src/bin/ble_serial_com.rs
@@ -335,7 +335,12 @@ async fn main(spawner: Spawner) {
                     state.tx_notifications_enabled = false; // Reset on new connection
                 }
                 GapEvent::Disconnected { handle, reason } => {
-                    info!("Disconnected: handle 0x{:04X}, reason 0x{:02X}", handle.0, reason);
+                    info!(
+                        "Disconnected: handle 0x{:04X}, reason 0x{:02X} ({})",
+                        handle.0,
+                        reason.as_u8(),
+                        Display2Format(&reason)
+                    );
                     state.current_conn_handle = None;
                     state.tx_notifications_enabled = false;
 

--- a/examples/stm32wba6/src/bin/ble_bonding.rs
+++ b/examples/stm32wba6/src/bin/ble_bonding.rs
@@ -234,7 +234,12 @@ async fn main(spawner: Spawner) {
                 }
 
                 GapEvent::Disconnected { handle, reason } => {
-                    info!("Disconnected: handle=0x{:04X} reason=0x{:02X}", handle.0, reason);
+                    info!(
+                        "Disconnected: handle=0x{:04X} reason=0x{:02X} ({})",
+                        handle.0,
+                        reason.as_u8(),
+                        Display2Format(&reason)
+                    );
                     // Match ST BLE_Privacy_Peripheral: do nothing on disconnect. The boot-time
                     // configure_filter_and_resolving_list call already populated the controller
                     // resolving list, and the stack auto-resumes the previous advertising set

--- a/examples/stm32wba6/src/bin/ble_central.rs
+++ b/examples/stm32wba6/src/bin/ble_central.rs
@@ -225,7 +225,12 @@ async fn main(spawner: Spawner) {
 
                         GapEvent::Disconnected { handle, reason } => {
                             error!("Connection failed or disconnected during setup");
-                            error!("  Handle: 0x{:04X}, Reason: 0x{:02X}", handle.0, reason);
+                            error!(
+                                "  Handle: 0x{:04X}, Reason: 0x{:02X} ({})",
+                                handle.0,
+                                reason.as_u8(),
+                                Display2Format(&reason)
+                            );
 
                             // Go back to scanning
                             ble.start_scan_observation(scan_params.clone())
@@ -246,7 +251,7 @@ async fn main(spawner: Spawner) {
                         GapEvent::Disconnected { handle, reason } => {
                             info!("=== DISCONNECTED ===");
                             info!("  Handle: 0x{:04X}", handle.0);
-                            info!("  Reason: 0x{:02X} ({})", reason, disconnect_reason_str(reason));
+                            info!("  Reason: 0x{:02X} ({})", reason.as_u8(), Display2Format(&reason));
 
                             // Go back to scanning
                             ble.start_scan_observation(scan_params.clone())
@@ -390,20 +395,4 @@ enum CentralState {
     Connecting,
     /// Connected to a peripheral
     Connected,
-}
-
-/// Convert disconnect reason code to human-readable string
-fn disconnect_reason_str(reason: u8) -> &'static str {
-    match reason {
-        0x08 => "Connection Timeout",
-        0x13 => "Remote User Terminated",
-        0x14 => "Remote Low Resources",
-        0x15 => "Remote Power Off",
-        0x16 => "Local Host Terminated",
-        0x1A => "Unsupported Remote Feature",
-        0x3B => "Unacceptable Connection Parameters",
-        0x3D => "MIC Failure",
-        0x3E => "Connection Failed to Establish",
-        _ => "Unknown",
-    }
 }

--- a/examples/stm32wba6/src/bin/ble_data_throughput_server.rs
+++ b/examples/stm32wba6/src/bin/ble_data_throughput_server.rs
@@ -300,7 +300,12 @@ async fn main(spawner: Spawner) {
                     }
                 }
                 GapEvent::Disconnected { handle, reason } => {
-                    info!("Disconnected: 0x{:04X}, reason 0x{:02X}", handle.0, reason);
+                    info!(
+                        "Disconnected: 0x{:04X}, reason 0x{:02X} ({})",
+                        handle.0,
+                        reason.as_u8(),
+                        Display2Format(&reason)
+                    );
                     state.conn_handle = None;
                     state.tx_notifications_enabled = false;
                     state.through_notifications_enabled = false;

--- a/examples/stm32wba6/src/bin/ble_direction_finding_tag.rs
+++ b/examples/stm32wba6/src/bin/ble_direction_finding_tag.rs
@@ -242,7 +242,12 @@ async fn main(spawner: Spawner) {
                                 }
                             }
                             GapEvent::Disconnected { handle, reason } => {
-                                info!("Disconnected: 0x{:04X}, reason 0x{:02X}", handle.0, reason);
+                                info!(
+                                    "Disconnected: 0x{:04X}, reason 0x{:02X} ({})",
+                                    handle.0,
+                                    reason.as_u8(),
+                                    Display2Format(&reason)
+                                );
                                 state.conn_handle = None;
                                 state.switch_notifications_enabled = false;
                                 ble.start_advertising(adv_params.clone(), adv_data.clone(), Some(scan_rsp.clone()))

--- a/examples/stm32wba6/src/bin/ble_dtm_runtime.rs
+++ b/examples/stm32wba6/src/bin/ble_dtm_runtime.rs
@@ -237,7 +237,7 @@ async fn handle_ble_event(ble: &mut HCI<'_, Normal>, event: &Event, adv_params: 
             GapEvent::Disconnected { handle, reason } => {
                 info!("=== DISCONNECTION ===");
                 info!("  Handle: 0x{:04X}", handle.0);
-                info!("  Reason: 0x{:02X} ({})", reason, disconnect_reason_str(reason));
+                info!("  Reason: 0x{:02X} ({})", reason.as_u8(), Display2Format(&reason));
                 info!("  Active connections: {}", ble.connections().count());
 
                 info!("Restarting advertising...");
@@ -331,20 +331,5 @@ async fn run_dtm_test(ble: &mut HCI<'_, Test>, expected: u32) {
                 Err(e) => error!("dtm_end failed: {:?}", e),
             }
         }
-    }
-}
-
-fn disconnect_reason_str(reason: u8) -> &'static str {
-    match reason {
-        0x08 => "Connection Timeout",
-        0x13 => "Remote User Terminated",
-        0x14 => "Remote Low Resources",
-        0x15 => "Remote Power Off",
-        0x16 => "Local Host Terminated",
-        0x1A => "Unsupported Remote Feature",
-        0x3B => "Unacceptable Connection Parameters",
-        0x3D => "MIC Failure",
-        0x3E => "Connection Failed to Establish",
-        _ => "Unknown",
     }
 }

--- a/examples/stm32wba6/src/bin/ble_gatt_server.rs
+++ b/examples/stm32wba6/src/bin/ble_gatt_server.rs
@@ -189,7 +189,12 @@ async fn main(spawner: Spawner) {
                     state.notifications_enabled = false; // Reset on new connection
                 }
                 GapEvent::Disconnected { handle, reason } => {
-                    info!("Disconnected: handle 0x{:04X}, reason 0x{:02X}", handle.0, reason);
+                    info!(
+                        "Disconnected: handle 0x{:04X}, reason 0x{:02X} ({})",
+                        handle.0,
+                        reason.as_u8(),
+                        Display2Format(&reason)
+                    );
                     state.current_conn_handle = None;
                     state.notifications_enabled = false;
 

--- a/examples/stm32wba6/src/bin/ble_health_thermometer.rs
+++ b/examples/stm32wba6/src/bin/ble_health_thermometer.rs
@@ -252,7 +252,12 @@ async fn main(spawner: Spawner) {
                             state.indication_pending = false;
                         }
                         GapEvent::Disconnected { handle, reason } => {
-                            info!("Disconnected: 0x{:04X}, reason 0x{:02X}", handle.0, reason);
+                            info!(
+                                "Disconnected: 0x{:04X}, reason 0x{:02X} ({})",
+                                handle.0,
+                                reason.as_u8(),
+                                Display2Format(&reason)
+                            );
                             state.conn_handle = None;
                             state.indications_enabled = false;
                             state.interm_notifications_enabled = false;

--- a/examples/stm32wba6/src/bin/ble_heart_rate.rs
+++ b/examples/stm32wba6/src/bin/ble_heart_rate.rs
@@ -227,7 +227,12 @@ async fn main(spawner: Spawner) {
                             state.notifications_enabled = false;
                         }
                         GapEvent::Disconnected { handle, reason } => {
-                            info!("Disconnected: 0x{:04X}, reason 0x{:02X}", handle.0, reason);
+                            info!(
+                                "Disconnected: 0x{:04X}, reason 0x{:02X} ({})",
+                                handle.0,
+                                reason.as_u8(),
+                                Display2Format(&reason)
+                            );
                             state.conn_handle = None;
                             state.notifications_enabled = false;
                             ble.start_advertising(adv_params.clone(), adv_data.clone(), None)

--- a/examples/stm32wba6/src/bin/ble_peripheral_connect.rs
+++ b/examples/stm32wba6/src/bin/ble_peripheral_connect.rs
@@ -175,7 +175,7 @@ async fn main(spawner: Spawner) {
                 GapEvent::Disconnected { handle, reason } => {
                     info!("=== DISCONNECTION ===");
                     info!("  Handle: 0x{:04X}", handle.0);
-                    info!("  Reason: 0x{:02X} ({})", reason, disconnect_reason_str(reason));
+                    info!("  Reason: 0x{:02X} ({})", reason.as_u8(), Display2Format(&reason));
                     info!("  Active connections: {}", ble.connections().count());
 
                     // Restart advertising after disconnection.
@@ -218,21 +218,5 @@ async fn main(spawner: Spawner) {
             // Log other events for debugging
             debug!("Other BLE Event: {:?}", event);
         }
-    }
-}
-
-/// Convert disconnect reason code to human-readable string
-fn disconnect_reason_str(reason: u8) -> &'static str {
-    match reason {
-        0x08 => "Connection Timeout",
-        0x13 => "Remote User Terminated",
-        0x14 => "Remote Low Resources",
-        0x15 => "Remote Power Off",
-        0x16 => "Local Host Terminated",
-        0x1A => "Unsupported Remote Feature",
-        0x3B => "Unacceptable Connection Parameters",
-        0x3D => "MIC Failure",
-        0x3E => "Connection Failed to Establish",
-        _ => "Unknown",
     }
 }

--- a/examples/stm32wba6/src/bin/ble_secure.rs
+++ b/examples/stm32wba6/src/bin/ble_secure.rs
@@ -209,7 +209,12 @@ async fn main(spawner: Spawner) {
 
                 GapEvent::Disconnected { handle, reason } => {
                     info!("=== DISCONNECTED ===");
-                    info!("  Handle: 0x{:04X}, Reason: 0x{:02X}", handle.0, reason);
+                    info!(
+                        "  Handle: 0x{:04X}, Reason: 0x{:02X} ({})",
+                        handle.0,
+                        reason.as_u8(),
+                        Display2Format(&reason)
+                    );
 
                     // Restart advertising
                     ble.start_advertising(adv_params.clone(), create_adv_data(), None)

--- a/examples/stm32wba6/src/bin/ble_serial_com.rs
+++ b/examples/stm32wba6/src/bin/ble_serial_com.rs
@@ -247,7 +247,12 @@ async fn main(spawner: Spawner) {
                     state.tx_notifications_enabled = false;
                 }
                 GapEvent::Disconnected { handle, reason } => {
-                    info!("Disconnected: 0x{:04X}, reason 0x{:02X}", handle.0, reason);
+                    info!(
+                        "Disconnected: 0x{:04X}, reason 0x{:02X} ({})",
+                        handle.0,
+                        reason.as_u8(),
+                        Display2Format(&reason)
+                    );
                     state.current_conn_handle = None;
                     state.tx_notifications_enabled = false;
                     ble.start_advertising(adv_params.clone(), adv_data.clone(), Some(scan_rsp.clone()))


### PR DESCRIPTION
Replaces the ad-hoc disconnect_reason_str() helper that was copy-pasted across six WBA examples with a proper DisconnectReason enum in the BLE stack (embassy-stm32-wpan). The GapEvent::Disconnected event now carries a typed DisconnectReason instead of a raw u8, and disconnect logging across all WBA/WBA6 examples is unified to show both the raw code and a human-readable string