### PR TITLE
USBHost (STM32): Reset the bus on device attach in the host driver.

### DIFF
--- a/embassy-stm32/src/usb/usb_host.rs
+++ b/embassy-stm32/src/usb/usb_host.rs
@@ -812,7 +812,14 @@ impl<'d, I: SealedHostInstance> UsbHostController<'d> for UsbHost<'d, I> {
     }
 
     async fn wait_for_device_event(&mut self) -> embassy_usb_driver::host::DeviceEvent {
-        // TODO: which event do we expect?
-        self.wait_for_device_connect().await
+        let event = self.wait_for_device_connect().await;
+        if matches!(event, DeviceEvent::Connected(_)) {
+            // The UsbHostController contract requires driving a bus reset to
+            // completion on attach before returning.
+            self.bus_reset().await;
+            // USB 2.0 §7.1.7.5: reset recovery time before the device must respond.
+            Timer::after_millis(10).await;
+        }
+        event
     }
 }


### PR DESCRIPTION
The UsbHostController contract requires wait_for_device_event to drive a bus reset to completion on attach before reporting the connected event, but the driver returned immediately without resetting, so the device stayed in the Attached state and every following transfer timed out. This belongs in the driver rather than application code: embassy-usb-host calls enumerate() directly after wait_for_connection() returns, leaving no higher layer in which to reset, and devices behind a hub are likewise reset by the hub driver, not the application. After detecting a connection we now reset the bus and wait the USB reset-recovery time before reporting the event.