### PR TITLE
embassy-mcxa: Enable ADRSTALL to avoid drop byte on i2c target.

### DIFF
--- a/embassy-mcxa/src/i2c/target.rs
+++ b/embassy-mcxa/src/i2c/target.rs
@@ -369,6 +369,7 @@ impl<'d, M: Mode> I2c<'d, M> {
             });
 
             self.info.regs().scfgr1().modify(|w| {
+                w.set_adrstall(true);
                 w.set_rxstall(true);
                 w.set_txdstall(true);
                 w.set_gcen(config.general_call.into());


### PR DESCRIPTION
MCXA platform intermittently fails to apply reports, and in the worst case the keyboard is dead.
Root cause: I²C target first-byte drop on the MCXA LPI2C block due to short SCL low span.
SCL stay low for 1.9 us after address match, data drops the first byte.
<img width="1966" height="1033" alt="image" src="https://github.com/user-attachments/assets/b6397722-104a-4c33-ac22-bee3993cee24" />

Enable ADRSTALL (SCFGR1 bit 0, "Address SCL Stall"), refer to MCXAP172M240F70RM_Rev1.pdf section47 LPI2C
This bit is equivalent to SLVPENDING for imxrt platform.
<img width="1753" height="351" alt="image" src="https://github.com/user-attachments/assets/540f8b0f-4227-486d-80e0-9c3c71a253a8" />

Target will hold SCL low after the address match until MCU reads SASR.
SCL low stretch to 708 us, ready to receive the first byte
<img width="2134" height="574" alt="image" src="https://github.com/user-attachments/assets/d176106d-fe1f-42da-837f-1be484b26879" />
