### PR TITLE
examples/stm32h735: fix ltdc example (framebuffer alignment + panel enable pins)

### DIFF
--- a/examples/stm32h735/src/bin/ltdc.rs
+++ b/examples/stm32h735/src/bin/ltdc.rs
@@ -32,8 +32,14 @@ const DISPLAY_HEIGHT: usize = 272;
 const MY_TASK_POOL_SIZE: usize = 2;
 
 // the following two display buffers consume 261120 bytes that just about fits into axis ram found on the mcu
-pub static mut FB1: [TargetPixelType; DISPLAY_WIDTH * DISPLAY_HEIGHT] = [0; DISPLAY_WIDTH * DISPLAY_HEIGHT];
-pub static mut FB2: [TargetPixelType; DISPLAY_WIDTH * DISPLAY_HEIGHT] = [0; DISPLAY_WIDTH * DISPLAY_HEIGHT];
+//
+// The LTDC frame-buffer address (CFBAR) must be bus-aligned: a plain `[u8; N]` array (align 1)
+// can land at an odd address, which starves the LTDC FIFO and reports FifoUnderrun on every
+// frame. Wrap the buffers so the linker aligns them to the AXI bus width.
+#[repr(C, align(32))]
+pub struct Framebuffer(pub [TargetPixelType; DISPLAY_WIDTH * DISPLAY_HEIGHT]);
+pub static mut FB1: Framebuffer = Framebuffer([0; DISPLAY_WIDTH * DISPLAY_HEIGHT]);
+pub static mut FB2: Framebuffer = Framebuffer([0; DISPLAY_WIDTH * DISPLAY_HEIGHT]);
 
 bind_interrupts!(struct Irqs {
     LTDC => ltdc::InterruptHandler<peripherals::LTDC>;
@@ -48,6 +54,13 @@ async fn main(spawner: Spawner) {
     // blink the led on another task
     let led = Output::new(p.PC3, Level::High, Speed::Low);
     spawner.spawn(unwrap!(led_task(led)));
+
+    // The panel control pins are not part of the LTDC signal interface and must be driven
+    // separately: LCD_DISP (PD10) takes the panel out of standby, LCD_BL_CTRL (PG15) enables
+    // the backlight. Leaving either floating shows a blank/white panel regardless of the
+    // video content.
+    let _lcd_disp = Output::new(p.PD10, Level::High, Speed::Low);
+    let _lcd_backlight = Output::new(p.PG15, Level::High, Speed::Low);
 
     // numbers from STMicroelectronics/STM32CubeH7 STM32H735G-DK C-based example
     const RK043FN48H_HSYNC: u16 = 41; // Horizontal synchronization
@@ -100,8 +113,8 @@ async fn main(spawner: Spawner) {
     // Safety: the DoubleBuffer controls access to the statically allocated frame buffers
     // and it is the only thing that mutates their content
     let mut double_buffer = DoubleBuffer::new(
-        unsafe { FB1.as_mut() },
-        unsafe { FB2.as_mut() },
+        unsafe { FB1.0.as_mut() },
+        unsafe { FB2.0.as_mut() },
         layer_config,
         color_map,
     );


### PR DESCRIPTION
## Summary

The `stm32h735` `ltdc` example bit-rotted as `embassy-stm32` evolved and no
longer displays anything on real STM32H735G-DK hardware. Two independent
regressions, both fixed here:

- **Framebuffer alignment.** `FB1`/`FB2` were plain `[u8; N]` statics
  (align 1), which can land the LTDC frame-buffer base at an unaligned
  address. `LTDC_LxCFBAR` must be bus-aligned; an unaligned address starves
  the LTDC FIFO, and since the driver's `FifoUnderrun` check was added
  (`8a4649a5b`) the example now panics on the first `swap()`. Fixed by
  wrapping the buffers in a `#[repr(C, align(32))]` struct.
- **Panel control pins never driven.** LCD_DISP (PD10) must be high to take
  the STM32H735G-DK panel out of standby, and LCD_BL_CTRL (PG15) enables the
  backlight. Neither is part of the LTDC signal interface, so
  `Ltdc::new_with_pins` cannot configure them, and the example never drove
  them itself — with both floating the panel showed a blank white screen
  regardless of valid video output.

Verified on real STM32H735G-DK hardware: the bouncing ferris now renders
correctly, with zero FIFO underruns over an extended run.

## Test plan

- [x] `cargo build --release --target thumbv7em-none-eabi` (the CI target)
      with `RUSTFLAGS=-Dwarnings` — clean, no warnings
- [x] `rustfmt --check --skip-children --unstable-features --edition 2024`
      on nightly-2025-12-11 — no diff
- [x] Flashed to a real STM32H735G-DK and confirmed the ferris bounces
      correctly on the panel with zero underruns