### PR TITLE
embassy-nrf: fixes hang on multiple UART instantiations

### DIFF
--- a/embassy-nrf/src/buffered_uarte/v2.rs
+++ b/embassy-nrf/src/buffered_uarte/v2.rs
@@ -443,6 +443,9 @@ impl<'a, U: UarteInstance> Drop for BufferedUarteTx<'a, U> {
         let s = U::buffered_state();
         unsafe { s.tx_buf.deinit() }
 
+        // This is used during the interrupt to check if it is its first execution
+        s.rx_started.swap(false, Ordering::Relaxed);
+
         let s = U::state();
         drop_tx_rx(r, s);
     }

--- a/examples/nrf54l15-app/src/bin/buffered_uart_lowpower.rs
+++ b/examples/nrf54l15-app/src/bin/buffered_uart_lowpower.rs
@@ -1,0 +1,62 @@
+#![no_std]
+#![no_main]
+
+use defmt::*;
+use defmt_rtt as _;
+use embassy_executor::Spawner;
+use embassy_nrf::buffered_uarte::{self, BufferedUarte};
+use embassy_nrf::gpio::{Input, Pull};
+use embassy_nrf::{bind_interrupts, peripherals, uarte};
+use embedded_io_async::Write;
+use panic_probe as _;
+
+bind_interrupts!(struct Irqs {
+    SERIAL30 => buffered_uarte::InterruptHandler<peripherals::SERIAL30>;
+});
+
+/// Uses the pins of the VCOM0 and button 0 on the nRF54L15 devkit.
+/// Loops the following:
+///   - write Hello! to VCOM0
+///   - read some bytes from VCOM0
+///   - wait for button 0 to be pressed
+#[embassy_executor::main]
+async fn main(_spawner: Spawner) {
+    let mut p = embassy_nrf::init(Default::default());
+    let mut config = uarte::Config::default();
+    config.parity = uarte::Parity::Excluded;
+    config.baudrate = uarte::Baudrate::Baud115200;
+
+    let mut tx_buffer = [0u8; 12];
+    let mut rx_buffer = [0u8; 12];
+
+    loop {
+        let mut u = BufferedUarte::new(
+            p.SERIAL30.reborrow(),
+            p.P0_01.reborrow(),
+            p.P0_00.reborrow(),
+            Irqs,
+            config.clone(),
+            &mut rx_buffer,
+            &mut tx_buffer,
+        );
+
+        info!("uarte initialized!");
+
+        unwrap!(u.write_all(b"Hello!\r\n").await);
+        info!("wrote hello in uart!");
+
+        info!("reading...");
+        let buf = unwrap!(u.fill_buf().await);
+        info!("read done, got {}", buf);
+
+        // Read bytes have to be explicitly consumed, otherwise fill_buf() will return them again
+        let n = buf.len();
+        u.consume(n);
+
+        // Enter low power state of the UART
+        drop(u);
+
+        // Wait for button 0 to be pressed
+        Input::new(p.P1_13.reborrow(), Pull::Up).wait_for_low().await;
+    }
+}


### PR DESCRIPTION
This fixes #6439. I cannot oversee all consequences of this fix, but it "seems to work". I hope someone with more intricate knowledge of how v2.rs works can confirm this is a proper fix. I can imagine there might be a race condition between the interrupt and dropping of the UART, but that would be the case regardless of this change.

I included an example showing the functionality and I can confirm that it is indeed low power:
<img width="1469" height="802" alt="image" src="https://github.com/user-attachments/assets/3e6eb642-beb3-4040-95e2-9cbab84edde9" />

Let me know if you need something changed.

Cheers.