### PR TITLE
fix: add `const` to eligible fns and `deny(clippy::missing_const_for_fn)`

### DIFF
--- a/cyw43-pio/src/lib.rs
+++ b/cyw43-pio/src/lib.rs
@@ -2,6 +2,7 @@
 #![allow(async_fn_in_trait)]
 #![doc = include_str!("../README.md")]
 #![warn(missing_docs)]
+#![deny(clippy::missing_const_for_fn)]
 
 use core::slice;
 

--- a/cyw43/src/lib.rs
+++ b/cyw43/src/lib.rs
@@ -5,6 +5,7 @@
 #![deny(unused_must_use)]
 #![doc = include_str!("../README.md")]
 #![warn(missing_docs)]
+#![deny(clippy::missing_const_for_fn)]
 
 // This mod MUST go first, so that the others see its macros.
 pub(crate) mod fmt;

--- a/embassy-boot-nrf/src/lib.rs
+++ b/embassy-boot-nrf/src/lib.rs
@@ -2,6 +2,7 @@
 #![allow(unsafe_op_in_unsafe_fn)]
 #![warn(missing_docs)]
 #![doc = include_str!("../README.md")]
+#![deny(clippy::missing_const_for_fn)]
 mod fmt;
 
 pub use embassy_boot::{

--- a/embassy-boot-rp/src/lib.rs
+++ b/embassy-boot-rp/src/lib.rs
@@ -2,6 +2,7 @@
 #![allow(unsafe_op_in_unsafe_fn)]
 #![warn(missing_docs)]
 #![doc = include_str!("../README.md")]
+#![deny(clippy::missing_const_for_fn)]
 mod fmt;
 
 pub use embassy_boot::{

--- a/embassy-boot-stm32/src/lib.rs
+++ b/embassy-boot-stm32/src/lib.rs
@@ -2,6 +2,7 @@
 #![allow(unsafe_op_in_unsafe_fn)]
 #![warn(missing_docs)]
 #![doc = include_str!("../README.md")]
+#![deny(clippy::missing_const_for_fn)]
 mod fmt;
 
 pub use embassy_boot::{

--- a/embassy-boot/src/lib.rs
+++ b/embassy-boot/src/lib.rs
@@ -6,6 +6,7 @@
 
 //! ## Feature flags
 #![doc = document_features::document_features!(feature_label = r#"<span class="stab portability"><code>{feature}</code></span>"#)]
+#![deny(clippy::missing_const_for_fn)]
 
 mod fmt;
 

--- a/embassy-embedded-hal/src/lib.rs
+++ b/embassy-embedded-hal/src/lib.rs
@@ -2,6 +2,7 @@
 #![allow(async_fn_in_trait)]
 #![warn(missing_docs)]
 #![doc = include_str!("../README.md")]
+#![deny(clippy::missing_const_for_fn)]
 
 pub mod adapter;
 pub mod flash;

--- a/embassy-executor-macros/src/lib.rs
+++ b/embassy-executor-macros/src/lib.rs
@@ -1,4 +1,5 @@
 #![doc = include_str!("../README.md")]
+#![deny(clippy::missing_const_for_fn)]
 extern crate proc_macro;
 
 use proc_macro::TokenStream;

--- a/embassy-executor-timer-queue/src/lib.rs
+++ b/embassy-executor-timer-queue/src/lib.rs
@@ -19,6 +19,7 @@
 //! method. You can then use the [`as_ref`](TimerQueueItem::as_ref) and [`as_mut`](TimerQueueItem::as_mut)
 //! methods to reinterpret the data stored in the item as your custom item type.
 #![no_std]
+#![deny(clippy::missing_const_for_fn)]
 
 use core::task::Waker;
 
@@ -73,7 +74,7 @@ impl TimerQueueItem {
     ///
     /// - The type must be valid when zero-initialized.
     /// - The timer queue should only be interpreted as a single type `T` during its lifetime.
-    pub unsafe fn as_ref<T>(&self) -> &T {
+    pub unsafe const fn as_ref<T>(&self) -> &T {
         const { validate::<T>() }
         unsafe { &*(self.data.as_ptr() as *const T) }
     }

--- a/embassy-executor/src/lib.rs
+++ b/embassy-executor/src/lib.rs
@@ -6,6 +6,7 @@
 
 //! ## Feature flags
 #![doc = document_features::document_features!(feature_label = r#"<span class="stab portability"><code>{feature}</code></span>"#)]
+#![deny(clippy::missing_const_for_fn)]
 
 // This mod MUST go first, so that the others see its macros.
 pub(crate) mod fmt;

--- a/embassy-executor/src/raw/mod.rs
+++ b/embassy-executor/src/raw/mod.rs
@@ -160,7 +160,7 @@ impl TaskRef {
     /// Safety
     ///
     /// This function must only be called in the context of the integrated timer queue.
-    pub unsafe fn timer_queue_item(mut self) -> &'static mut TimerQueueItem {
+    pub unsafe const fn timer_queue_item(mut self) -> &'static mut TimerQueueItem {
         unsafe { &mut self.ptr.as_mut().timer_queue_item }
     }
 
@@ -197,7 +197,7 @@ pub struct TaskStorage<F: Future + 'static> {
     future: UninitCell<F>, // Valid if STATE_SPAWNED
 }
 
-unsafe fn poll_exited(_p: TaskRef) {
+unsafe const fn poll_exited(_p: TaskRef) {
     // Nothing to do, the task is already !SPAWNED and dequeued.
 }
 

--- a/embassy-executor/src/raw/util.rs
+++ b/embassy-executor/src/raw/util.rs
@@ -8,7 +8,7 @@ impl<T> UninitCell<T> {
         Self(MaybeUninit::uninit())
     }
 
-    pub unsafe fn as_mut_ptr(&self) -> *mut T {
+    pub unsafe const fn as_mut_ptr(&self) -> *mut T {
         (*self.0.as_ptr()).get()
     }
 

--- a/embassy-executor/src/raw/waker.rs
+++ b/embassy-executor/src/raw/waker.rs
@@ -12,7 +12,7 @@ unsafe fn wake(p: *const ()) {
     wake_task(TaskRef::from_ptr(p as *const TaskHeader))
 }
 
-unsafe fn drop(_: *const ()) {
+unsafe const fn drop(_: *const ()) {
     // nop
 }
 

--- a/embassy-futures/src/join.rs
+++ b/embassy-futures/src/join.rs
@@ -76,7 +76,7 @@ macro_rules! generate {
 
         impl<$($Fut: Future),*> $Join<$($Fut),*> {
             #[allow(non_snake_case)]
-            fn new($($Fut: $Fut),*) -> Self {
+            const fn new($($Fut: $Fut),*) -> Self {
                 Self {
                     $($Fut: MaybeDone::Future($Fut)),*
                 }
@@ -139,7 +139,7 @@ generate! {
 /// assert_eq!(pair, (1, 2));
 /// # });
 /// ```
-pub fn join<Fut1, Fut2>(future1: Fut1, future2: Fut2) -> Join<Fut1, Fut2>
+pub const fn join<Fut1, Fut2>(future1: Fut1, future2: Fut2) -> Join<Fut1, Fut2>
 where
     Fut1: Future,
     Fut2: Future,
@@ -168,7 +168,7 @@ where
 /// assert_eq!(res, (1, 2, 3));
 /// # });
 /// ```
-pub fn join3<Fut1, Fut2, Fut3>(future1: Fut1, future2: Fut2, future3: Fut3) -> Join3<Fut1, Fut2, Fut3>
+pub const fn join3<Fut1, Fut2, Fut3>(future1: Fut1, future2: Fut2, future3: Fut3) -> Join3<Fut1, Fut2, Fut3>
 where
     Fut1: Future,
     Fut2: Future,
@@ -199,7 +199,7 @@ where
 /// assert_eq!(res, (1, 2, 3, 4));
 /// # });
 /// ```
-pub fn join4<Fut1, Fut2, Fut3, Fut4>(
+pub const fn join4<Fut1, Fut2, Fut3, Fut4>(
     future1: Fut1,
     future2: Fut2,
     future3: Fut3,
@@ -237,7 +237,7 @@ where
 /// assert_eq!(res, (1, 2, 3, 4, 5));
 /// # });
 /// ```
-pub fn join5<Fut1, Fut2, Fut3, Fut4, Fut5>(
+pub const fn join5<Fut1, Fut2, Fut3, Fut4, Fut5>(
     future1: Fut1,
     future2: Fut2,
     future3: Fut3,

--- a/embassy-futures/src/lib.rs
+++ b/embassy-futures/src/lib.rs
@@ -1,6 +1,7 @@
 #![no_std]
 #![doc = include_str!("../README.md")]
 #![warn(missing_docs)]
+#![deny(clippy::missing_const_for_fn)]
 
 // This mod MUST go first, so that the others see its macros.
 pub(crate) mod fmt;

--- a/embassy-futures/src/select.rs
+++ b/embassy-futures/src/select.rs
@@ -16,12 +16,12 @@ pub enum Either<A, B> {
 
 impl<A, B> Either<A, B> {
     /// Did the first future complete first?
-    pub fn is_first(&self) -> bool {
+    pub const fn is_first(&self) -> bool {
         matches!(self, Either::First(_))
     }
 
     /// Did the second future complete first?
-    pub fn is_second(&self) -> bool {
+    pub const fn is_second(&self) -> bool {
         matches!(self, Either::Second(_))
     }
 }
@@ -32,7 +32,7 @@ impl<A, B> Either<A, B> {
 /// When one of them completes, it will complete with its result value.
 ///
 /// The other future is dropped.
-pub fn select<A, B>(a: A, b: B) -> Select<A, B>
+pub const fn select<A, B>(a: A, b: B) -> Select<A, B>
 where
     A: Future,
     B: Future,
@@ -87,23 +87,23 @@ pub enum Either3<A, B, C> {
 
 impl<A, B, C> Either3<A, B, C> {
     /// Did the first future complete first?
-    pub fn is_first(&self) -> bool {
+    pub const fn is_first(&self) -> bool {
         matches!(self, Either3::First(_))
     }
 
     /// Did the second future complete first?
-    pub fn is_second(&self) -> bool {
+    pub const fn is_second(&self) -> bool {
         matches!(self, Either3::Second(_))
     }
 
     /// Did the third future complete first?
-    pub fn is_third(&self) -> bool {
+    pub const fn is_third(&self) -> bool {
         matches!(self, Either3::Third(_))
     }
 }
 
 /// Same as [`select`], but with more futures.
-pub fn select3<A, B, C>(a: A, b: B, c: C) -> Select3<A, B, C>
+pub const fn select3<A, B, C>(a: A, b: B, c: C) -> Select3<A, B, C>
 where
     A: Future,
     B: Future,
@@ -165,28 +165,28 @@ pub enum Either4<A, B, C, D> {
 
 impl<A, B, C, D> Either4<A, B, C, D> {
     /// Did the first future complete first?
-    pub fn is_first(&self) -> bool {
+    pub const fn is_first(&self) -> bool {
         matches!(self, Either4::First(_))
     }
 
     /// Did the second future complete first?
-    pub fn is_second(&self) -> bool {
+    pub const fn is_second(&self) -> bool {
         matches!(self, Either4::Second(_))
     }
 
     /// Did the third future complete first?
-    pub fn is_third(&self) -> bool {
+    pub const fn is_third(&self) -> bool {
         matches!(self, Either4::Third(_))
     }
 
     /// Did the fourth future complete first?
-    pub fn is_fourth(&self) -> bool {
+    pub const fn is_fourth(&self) -> bool {
         matches!(self, Either4::Fourth(_))
     }
 }
 
 /// Same as [`select`], but with more futures.
-pub fn select4<A, B, C, D>(a: A, b: B, c: C, d: D) -> Select4<A, B, C, D>
+pub const fn select4<A, B, C, D>(a: A, b: B, c: C, d: D) -> Select4<A, B, C, D>
 where
     A: Future,
     B: Future,
@@ -257,33 +257,33 @@ pub enum Either5<A, B, C, D, E> {
 
 impl<A, B, C, D, E> Either5<A, B, C, D, E> {
     /// Did the first future complete first?
-    pub fn is_first(&self) -> bool {
+    pub const fn is_first(&self) -> bool {
         matches!(self, Either5::First(_))
     }
 
     /// Did the second future complete first?
-    pub fn is_second(&self) -> bool {
+    pub const fn is_second(&self) -> bool {
         matches!(self, Either5::Second(_))
     }
 
     /// Did the third future complete first?
-    pub fn is_third(&self) -> bool {
+    pub const fn is_third(&self) -> bool {
         matches!(self, Either5::Third(_))
     }
 
     /// Did the fourth future complete first?
-    pub fn is_fourth(&self) -> bool {
+    pub const fn is_fourth(&self) -> bool {
         matches!(self, Either5::Fourth(_))
     }
 
     /// Did the fifth future complete first?
-    pub fn is_fifth(&self) -> bool {
+    pub const fn is_fifth(&self) -> bool {
         matches!(self, Either5::Fifth(_))
     }
 }
 
 /// Same as [`select`], but with more futures.
-pub fn select5<A, B, C, D, E>(a: A, b: B, c: C, d: D, e: E) -> Select5<A, B, C, D, E>
+pub const fn select5<A, B, C, D, E>(a: A, b: B, c: C, d: D, e: E) -> Select5<A, B, C, D, E>
 where
     A: Future,
     B: Future,
@@ -363,38 +363,38 @@ pub enum Either6<A, B, C, D, E, F> {
 
 impl<A, B, C, D, E, F> Either6<A, B, C, D, E, F> {
     /// Did the first future complete first?
-    pub fn is_first(&self) -> bool {
+    pub const fn is_first(&self) -> bool {
         matches!(self, Either6::First(_))
     }
 
     /// Did the second future complete first?
-    pub fn is_second(&self) -> bool {
+    pub const fn is_second(&self) -> bool {
         matches!(self, Either6::Second(_))
     }
 
     /// Did the third future complete first?
-    pub fn is_third(&self) -> bool {
+    pub const fn is_third(&self) -> bool {
         matches!(self, Either6::Third(_))
     }
 
     /// Did the fourth future complete first?
-    pub fn is_fourth(&self) -> bool {
+    pub const fn is_fourth(&self) -> bool {
         matches!(self, Either6::Fourth(_))
     }
 
     /// Did the fifth future complete first?
-    pub fn is_fifth(&self) -> bool {
+    pub const fn is_fifth(&self) -> bool {
         matches!(self, Either6::Fifth(_))
     }
 
     /// Did the sixth future complete first?
-    pub fn is_sixth(&self) -> bool {
+    pub const fn is_sixth(&self) -> bool {
         matches!(self, Either6::Sixth(_))
     }
 }
 
 /// Same as [`select`], but with more futures.
-pub fn select6<A, B, C, D, E, F>(a: A, b: B, c: C, d: D, e: E, f: F) -> Select6<A, B, C, D, E, F>
+pub const fn select6<A, B, C, D, E, F>(a: A, b: B, c: C, d: D, e: E, f: F) -> Select6<A, B, C, D, E, F>
 where
     A: Future,
     B: Future,
@@ -520,7 +520,7 @@ pub struct SelectSlice<'a, Fut> {
 /// future that was ready.
 ///
 /// If the slice is empty, the resulting future will be Pending forever.
-pub fn select_slice<'a, Fut: Future>(slice: Pin<&'a mut [Fut]>) -> SelectSlice<'a, Fut> {
+pub const fn select_slice<'a, Fut: Future>(slice: Pin<&'a mut [Fut]>) -> SelectSlice<'a, Fut> {
     SelectSlice { inner: slice }
 }
 

--- a/embassy-hal-internal/src/atomic_ring_buffer.rs
+++ b/embassy-hal-internal/src/atomic_ring_buffer.rs
@@ -86,7 +86,7 @@ impl RingBuffer {
     ///
     /// - Only one reader can exist at a time.
     /// - Ringbuffer must be initialized.
-    pub unsafe fn reader(&self) -> Reader<'_> {
+    pub unsafe const fn reader(&self) -> Reader<'_> {
         Reader(self)
     }
 
@@ -108,7 +108,7 @@ impl RingBuffer {
     ///
     /// - Only one writer can exist at a time.
     /// - Ringbuffer must be initialized.
-    pub unsafe fn writer(&self) -> Writer<'_> {
+    pub unsafe const fn writer(&self) -> Writer<'_> {
         Writer(self)
     }
 

--- a/embassy-hal-internal/src/drop.rs
+++ b/embassy-hal-internal/src/drop.rs
@@ -10,12 +10,12 @@ pub struct OnDrop<F: FnOnce()> {
 
 impl<F: FnOnce()> OnDrop<F> {
     /// Create a new instance.
-    pub fn new(f: F) -> Self {
+    pub const fn new(f: F) -> Self {
         Self { f: MaybeUninit::new(f) }
     }
 
     /// Prevent drop handler from running.
-    pub fn defuse(self) {
+    pub const fn defuse(self) {
         mem::forget(self)
     }
 }
@@ -39,12 +39,12 @@ pub struct DropBomb {
 
 impl DropBomb {
     /// Create a new instance.
-    pub fn new() -> Self {
+    pub const fn new() -> Self {
         Self { _private: () }
     }
 
     /// Defuses the bomb, rendering it safe to drop.
-    pub fn defuse(self) {
+    pub const fn defuse(self) {
         mem::forget(self)
     }
 }

--- a/embassy-hal-internal/src/lib.rs
+++ b/embassy-hal-internal/src/lib.rs
@@ -3,6 +3,7 @@
 #![allow(unsafe_op_in_unsafe_fn)]
 #![doc = include_str!("../README.md")]
 #![warn(missing_docs)]
+#![deny(clippy::missing_const_for_fn)]
 
 // This mod MUST go first, so that the others see its macros.
 pub(crate) mod fmt;

--- a/embassy-imxrt/src/lib.rs
+++ b/embassy-imxrt/src/lib.rs
@@ -6,6 +6,7 @@
 
 //! ## Feature flags
 #![doc = document_features::document_features!(feature_label = r#"<span class="stab portability"><code>{feature}</code></span>"#)]
+#![deny(clippy::missing_const_for_fn)]
 
 #[cfg(not(any(feature = "mimxrt633s", feature = "mimxrt685s",)))]
 compile_error!(

--- a/embassy-mcxa/src/lib.rs
+++ b/embassy-mcxa/src/lib.rs
@@ -5,6 +5,7 @@
 //
 // Allow functions with too many args - we have a lot of HAL constructors like this for now
 #![allow(clippy::too_many_arguments)]
+#![deny(clippy::missing_const_for_fn)]
 
 /// Module for MCXA2xx-specific HAL drivers
 ///

--- a/embassy-microchip/src/lib.rs
+++ b/embassy-microchip/src/lib.rs
@@ -4,6 +4,7 @@
 
 //! ## Feature flags
 #![doc = document_features::document_features!(feature_label = r#"<span class="stab portability"><code>{feature}</code></span>"#)]
+#![deny(clippy::missing_const_for_fn)]
 
 #[cfg(not(any(
     feature = "mec1721n_b0_lj",

--- a/embassy-mspm0/src/lib.rs
+++ b/embassy-mspm0/src/lib.rs
@@ -7,6 +7,7 @@
     doc = "<div style='padding:30px;background:#810;color:#fff;text-align:center;'><p>You might want to <a href='https://docs.embassy.dev/embassy-mspm0'>browse the `embassy-mspm0` documentation on the Embassy website</a> instead.</p><p>The documentation here on `docs.rs` is built for a single chip only, while on the Embassy website you can pick your exact chip from the top menu. Available peripherals and their APIs change depending on the chip.</p></div>\n\n"
 )]
 #![doc = include_str!("../README.md")]
+#![deny(clippy::missing_const_for_fn)]
 
 // These mods MUST go first, so that the others see the macros.
 pub(crate) mod fmt;

--- a/embassy-net-adin1110/src/lib.rs
+++ b/embassy-net-adin1110/src/lib.rs
@@ -6,6 +6,7 @@
 #![allow(clippy::missing_panics_doc)]
 #![doc = include_str!("../README.md")]
 #![warn(missing_docs)]
+#![deny(clippy::missing_const_for_fn)]
 
 // must go first!
 mod fmt;

--- a/embassy-net-driver-channel/src/lib.rs
+++ b/embassy-net-driver-channel/src/lib.rs
@@ -1,6 +1,7 @@
 #![no_std]
 #![doc = include_str!("../README.md")]
 #![warn(missing_docs)]
+#![deny(clippy::missing_const_for_fn)]
 
 // must go first!
 mod fmt;

--- a/embassy-net-driver/src/lib.rs
+++ b/embassy-net-driver/src/lib.rs
@@ -2,6 +2,7 @@
 #![allow(unsafe_op_in_unsafe_fn)]
 #![warn(missing_docs)]
 #![doc = include_str!("../README.md")]
+#![deny(clippy::missing_const_for_fn)]
 
 use core::task::Context;
 

--- a/embassy-net-enc28j60/src/bank0.rs
+++ b/embassy-net-enc28j60/src/bank0.rs
@@ -28,11 +28,11 @@ pub enum Register {
 }
 
 impl Register {
-    pub(crate) fn addr(&self) -> u8 {
+    pub(crate) const fn addr(&self) -> u8 {
         *self as u8
     }
 
-    pub(crate) fn is_eth_register(&self) -> bool {
+    pub(crate) const fn is_eth_register(&self) -> bool {
         match *self {
             Register::ERDPTL => true,
             Register::ERDPTH => true,

--- a/embassy-net-enc28j60/src/bank1.rs
+++ b/embassy-net-enc28j60/src/bank1.rs
@@ -26,11 +26,11 @@ pub enum Register {
 }
 
 impl Register {
-    pub(crate) fn addr(&self) -> u8 {
+    pub(crate) const fn addr(&self) -> u8 {
         *self as u8
     }
 
-    pub(crate) fn is_eth_register(&self) -> bool {
+    pub(crate) const fn is_eth_register(&self) -> bool {
         match *self {
             Register::EHT0 => true,
             Register::EHT1 => true,

--- a/embassy-net-enc28j60/src/bank2.rs
+++ b/embassy-net-enc28j60/src/bank2.rs
@@ -20,11 +20,11 @@ pub enum Register {
 }
 
 impl Register {
-    pub(crate) fn addr(&self) -> u8 {
+    pub(crate) const fn addr(&self) -> u8 {
         *self as u8
     }
 
-    pub(crate) fn is_eth_register(&self) -> bool {
+    pub(crate) const fn is_eth_register(&self) -> bool {
         match *self {
             Register::MACON1 => false,
             Register::MACON3 => false,

--- a/embassy-net-enc28j60/src/bank3.rs
+++ b/embassy-net-enc28j60/src/bank3.rs
@@ -20,11 +20,11 @@ pub enum Register {
 }
 
 impl Register {
-    pub(crate) fn addr(&self) -> u8 {
+    pub(crate) const fn addr(&self) -> u8 {
         *self as u8
     }
 
-    pub(crate) fn is_eth_register(&self) -> bool {
+    pub(crate) const fn is_eth_register(&self) -> bool {
         match *self {
             Register::MAADR5 => false,
             Register::MAADR6 => false,

--- a/embassy-net-enc28j60/src/common.rs
+++ b/embassy-net-enc28j60/src/common.rs
@@ -9,11 +9,11 @@ pub enum Register {
 }
 
 impl Register {
-    pub(crate) fn addr(&self) -> u8 {
+    pub(crate) const fn addr(&self) -> u8 {
         *self as u8
     }
 
-    pub(crate) fn is_eth_register(&self) -> bool {
+    pub(crate) const fn is_eth_register(&self) -> bool {
         match *self {
             Register::ECON1 => true,
             Register::ECON2 => true,

--- a/embassy-net-enc28j60/src/lib.rs
+++ b/embassy-net-enc28j60/src/lib.rs
@@ -1,6 +1,7 @@
 #![no_std]
 #![doc = include_str!("../README.md")]
 #![warn(missing_docs)]
+#![deny(clippy::missing_const_for_fn)]
 
 // must go first.
 mod fmt;
@@ -194,7 +195,7 @@ where
     }
 
     /// Returns the device's MAC address
-    pub fn address(&self) -> [u8; 6] {
+    pub const fn address(&self) -> [u8; 6] {
         self.mac_addr
     }
 
@@ -569,7 +570,7 @@ enum Instruction {
 }
 
 impl Instruction {
-    fn opcode(&self) -> u8 {
+    const fn opcode(&self) -> u8 {
         *self as u8
     }
 }
@@ -584,7 +585,7 @@ enum Register {
 }
 
 impl Register {
-    fn addr(&self) -> u8 {
+    const fn addr(&self) -> u8 {
         match *self {
             Register::Bank0(r) => r.addr(),
             Register::Bank1(r) => r.addr(),
@@ -594,7 +595,7 @@ impl Register {
         }
     }
 
-    fn bank(&self) -> Option<Bank> {
+    const fn bank(&self) -> Option<Bank> {
         Some(match *self {
             Register::Bank0(_) => Bank::Bank0,
             Register::Bank1(_) => Bank::Bank1,
@@ -604,7 +605,7 @@ impl Register {
         })
     }
 
-    fn is_eth_register(&self) -> bool {
+    const fn is_eth_register(&self) -> bool {
         match *self {
             Register::Bank0(r) => r.is_eth_register(),
             Register::Bank1(r) => r.is_eth_register(),

--- a/embassy-net-enc28j60/src/macros.rs
+++ b/embassy-net-enc28j60/src/macros.rs
@@ -10,7 +10,7 @@ macro_rules! register {
 
         impl $REGISTER<super::traits::Mask> {
             #[allow(dead_code)]
-            pub(crate) fn mask() -> $REGISTER<super::traits::Mask> {
+            pub(crate) const fn mask() -> $REGISTER<super::traits::Mask> {
                 $REGISTER { bits: 0, _mode: ::core::marker::PhantomData }
             }
 
@@ -34,13 +34,13 @@ macro_rules! register {
 
         #[allow(non_snake_case)]
         #[allow(dead_code)]
-        pub(crate) fn $REGISTER(bits: $uxx) -> $REGISTER<super::traits::R> {
+        pub(crate) const fn $REGISTER(bits: $uxx) -> $REGISTER<super::traits::R> {
             $REGISTER { bits, _mode: ::core::marker::PhantomData }
         }
 
         impl $REGISTER<super::traits::R> {
             #[allow(dead_code)]
-            pub(crate) fn modify(self) -> $REGISTER<super::traits::W> {
+            pub(crate) const fn modify(self) -> $REGISTER<super::traits::W> {
                 $REGISTER { bits: self.bits, _mode: ::core::marker::PhantomData }
             }
 
@@ -61,7 +61,7 @@ macro_rules! register {
 
         impl $REGISTER<super::traits::W> {
             #[allow(dead_code)]
-            pub(crate) fn bits(self) -> $uxx {
+            pub(crate) const fn bits(self) -> $uxx {
                 self.bits
             }
 

--- a/embassy-net-enc28j60/src/phy.rs
+++ b/embassy-net-enc28j60/src/phy.rs
@@ -13,7 +13,7 @@ pub enum Register {
 }
 
 impl Register {
-    pub(crate) fn addr(&self) -> u8 {
+    pub(crate) const fn addr(&self) -> u8 {
         *self as u8
     }
 }

--- a/embassy-net-esp-hosted/src/lib.rs
+++ b/embassy-net-esp-hosted/src/lib.rs
@@ -5,6 +5,7 @@
 #![doc = document_features::document_features!(feature_label = r#"<span class="stab portability"><code>{feature}</code></span>"#)]
 #![warn(missing_docs)]
 #![allow(async_fn_in_trait)]
+#![deny(clippy::missing_const_for_fn)]
 
 use aligned::Aligned;
 #[cfg(not(feature = "bluetooth"))]

--- a/embassy-net-nrf91/src/lib.rs
+++ b/embassy-net-nrf91/src/lib.rs
@@ -3,6 +3,7 @@
 #![doc = include_str!("../README.md")]
 #![warn(missing_docs)]
 #![deny(unused_must_use)]
+#![deny(clippy::missing_const_for_fn)]
 
 // must be first
 mod fmt;

--- a/embassy-net-ppp/src/lib.rs
+++ b/embassy-net-ppp/src/lib.rs
@@ -1,6 +1,7 @@
 #![no_std]
 #![warn(missing_docs)]
 #![doc = include_str!("../README.md")]
+#![deny(clippy::missing_const_for_fn)]
 
 // must be first
 mod fmt;

--- a/embassy-net-tuntap/src/lib.rs
+++ b/embassy-net-tuntap/src/lib.rs
@@ -1,5 +1,6 @@
 #![warn(missing_docs)]
 #![doc = include_str!("../README.md")]
+#![deny(clippy::missing_const_for_fn)]
 use std::io;
 use std::io::{Read, Write};
 use std::os::fd::{AsFd, OwnedFd};

--- a/embassy-net-wiznet/src/lib.rs
+++ b/embassy-net-wiznet/src/lib.rs
@@ -2,6 +2,7 @@
 #![allow(async_fn_in_trait)]
 #![doc = include_str!("../README.md")]
 #![warn(missing_docs)]
+#![deny(clippy::missing_const_for_fn)]
 
 // must go first!
 mod fmt;

--- a/embassy-net/src/lib.rs
+++ b/embassy-net/src/lib.rs
@@ -6,6 +6,7 @@
 
 //! ## Feature flags
 #![doc = document_features::document_features!(feature_label = r#"<span class="stab portability"><code>{feature}</code></span>"#)]
+#![deny(clippy::missing_const_for_fn)]
 
 #[cfg(not(any(feature = "proto-ipv4", feature = "proto-ipv6")))]
 compile_error!("You must enable at least one of the following features: proto-ipv4, proto-ipv6");

--- a/embassy-nrf/src/lib.rs
+++ b/embassy-nrf/src/lib.rs
@@ -10,6 +10,7 @@
 
 //! ## Feature flags
 #![doc = document_features::document_features!(feature_label = r#"<span class="stab portability"><code>{feature}</code></span>"#)]
+#![deny(clippy::missing_const_for_fn)]
 
 #[cfg(not(any(
     feature = "_nrf51",

--- a/embassy-nxp/src/lib.rs
+++ b/embassy-nxp/src/lib.rs
@@ -1,5 +1,6 @@
 #![no_std]
 #![allow(unsafe_op_in_unsafe_fn)]
+#![deny(clippy::missing_const_for_fn)]
 
 // This mod MUST go first, so that the others see its macros.
 pub(crate) mod fmt;

--- a/embassy-rp/src/lib.rs
+++ b/embassy-rp/src/lib.rs
@@ -7,6 +7,7 @@
 
 //! ## Feature flags
 #![doc = document_features::document_features!(feature_label = r#"<span class="stab portability"><code>{feature}</code></span>"#)]
+#![deny(clippy::missing_const_for_fn)]
 
 // This mod MUST go first, so that the others see its macros.
 pub(crate) mod fmt;

--- a/embassy-stm32-wpan/src/lib.rs
+++ b/embassy-stm32-wpan/src/lib.rs
@@ -17,6 +17,7 @@
 #![doc = include_str!("../README.md")]
 // #![warn(missing_docs)]
 #![allow(static_mut_refs)] // TODO: Fix
+#![deny(clippy::missing_const_for_fn)]
 
 // This mod MUST go first, so that the others see its macros.
 pub(crate) mod fmt;

--- a/embassy-stm32/src/lib.rs
+++ b/embassy-stm32/src/lib.rs
@@ -10,6 +10,7 @@
 
 //! ## Feature flags
 #![doc = document_features::document_features!(feature_label = r#"<span class="stab portability"><code>{feature}</code></span>"#)]
+#![deny(clippy::missing_const_for_fn)]
 
 // This must go FIRST so that all the other modules see its macros.
 mod fmt;

--- a/embassy-sync/src/blocking_mutex/mod.rs
+++ b/embassy-sync/src/blocking_mutex/mod.rs
@@ -114,7 +114,7 @@ pub type NoopMutex<T> = Mutex<raw::NoopRawMutex, T>;
 
 impl<T> Mutex<raw::CriticalSectionRawMutex, T> {
     /// Borrows the data for the duration of the critical section
-    pub fn borrow<'cs>(&'cs self, _cs: critical_section::CriticalSection<'cs>) -> &'cs T {
+    pub const fn borrow<'cs>(&'cs self, _cs: critical_section::CriticalSection<'cs>) -> &'cs T {
         let ptr = self.data.get() as *const T;
         unsafe { &*ptr }
     }
@@ -123,7 +123,7 @@ impl<T> Mutex<raw::CriticalSectionRawMutex, T> {
 impl<T> Mutex<raw::NoopRawMutex, T> {
     /// Borrows the data
     #[allow(clippy::should_implement_trait)]
-    pub fn borrow(&self) -> &T {
+    pub const fn borrow(&self) -> &T {
         let ptr = self.data.get() as *const T;
         unsafe { &*ptr }
     }

--- a/embassy-sync/src/channel.rs
+++ b/embassy-sync/src/channel.rs
@@ -793,7 +793,7 @@ impl<T, const N: usize> ChannelState<T, N> {
         self.queue.clear();
     }
 
-    fn len(&self) -> usize {
+    const fn len(&self) -> usize {
         self.queue.len()
     }
 
@@ -876,12 +876,12 @@ where
     }
 
     /// Get a sender for this channel.
-    pub fn sender(&self) -> Sender<'_, M, T, N> {
+    pub const fn sender(&self) -> Sender<'_, M, T, N> {
         Sender { channel: self }
     }
 
     /// Get a receiver for this channel.
-    pub fn receiver(&self) -> Receiver<'_, M, T, N> {
+    pub const fn receiver(&self) -> Receiver<'_, M, T, N> {
         Receiver { channel: self }
     }
 
@@ -899,7 +899,7 @@ where
     ///
     /// Sending completes when the value has been pushed to the channel's queue.
     /// This doesn't mean the value has been received yet.
-    pub fn send(&self, message: T) -> SendFuture<'_, M, T, N> {
+    pub const fn send(&self, message: T) -> SendFuture<'_, M, T, N> {
         SendFuture {
             channel: self,
             message: Some(message),
@@ -924,7 +924,7 @@ where
     ///
     /// If there are no messages in the channel's buffer, this method will
     /// wait until a message is sent.
-    pub fn receive(&self) -> ReceiveFuture<'_, M, T, N> {
+    pub const fn receive(&self) -> ReceiveFuture<'_, M, T, N> {
         ReceiveFuture { channel: self }
     }
 
@@ -932,7 +932,7 @@ where
     ///
     /// If there are no messages in the channel's buffer, this method will
     /// wait until there is at least one
-    pub fn ready_to_receive(&self) -> ReceiveReadyFuture<'_, M, T, N> {
+    pub const fn ready_to_receive(&self) -> ReceiveReadyFuture<'_, M, T, N> {
         ReceiveReadyFuture { channel: self }
     }
 

--- a/embassy-sync/src/lib.rs
+++ b/embassy-sync/src/lib.rs
@@ -4,6 +4,7 @@
 #![allow(unsafe_op_in_unsafe_fn)]
 #![doc = include_str!("../README.md")]
 #![warn(missing_docs)]
+#![deny(clippy::missing_const_for_fn)]
 
 // This mod MUST go first, so that the others see its macros.
 pub(crate) mod fmt;

--- a/embassy-sync/src/mutex.rs
+++ b/embassy-sync/src/mutex.rs
@@ -124,7 +124,7 @@ where
     ///
     /// Since this call borrows the Mutex mutably, no actual locking needs to
     /// take place -- the mutable borrow statically guarantees no locks exist.
-    pub fn get_mut(&mut self) -> &mut T {
+    pub const fn get_mut(&mut self) -> &mut T {
         self.inner.get_mut()
     }
 }

--- a/embassy-sync/src/pipe.rs
+++ b/embassy-sync/src/pipe.rs
@@ -117,7 +117,7 @@ where
     /// If no bytes are currently available to read, this function waits until at least one byte is available.
     ///
     /// If the reader is at end-of-file (EOF), an empty slice is returned.
-    pub fn fill_buf(&mut self) -> FillBufFuture<'_, M, N> {
+    pub const fn fill_buf(&mut self) -> FillBufFuture<'_, M, N> {
         FillBufFuture { pipe: Some(self.pipe) }
     }
 
@@ -223,12 +223,12 @@ struct PipeState<const N: usize> {
 struct Buffer<const N: usize>(UnsafeCell<[u8; N]>);
 
 impl<const N: usize> Buffer<N> {
-    unsafe fn get<'a>(&self, r: Range<usize>) -> &'a [u8] {
+    unsafe const fn get<'a>(&self, r: Range<usize>) -> &'a [u8] {
         let p = self.0.get() as *const u8;
         core::slice::from_raw_parts(p.add(r.start), r.end - r.start)
     }
 
-    unsafe fn get_mut<'a>(&self, r: Range<usize>) -> &'a mut [u8] {
+    unsafe const fn get_mut<'a>(&self, r: Range<usize>) -> &'a mut [u8] {
         let p = self.0.get() as *mut u8;
         core::slice::from_raw_parts_mut(p.add(r.start), r.end - r.start)
     }
@@ -370,7 +370,7 @@ where
     /// implementing `BufRead` requires there is a single reader.
     ///
     /// The writer is cloneable, the reader is not.
-    pub fn split(&mut self) -> (Reader<'_, M, N>, Writer<'_, M, N>) {
+    pub const fn split(&mut self) -> (Reader<'_, M, N>, Writer<'_, M, N>) {
         (Reader { pipe: self }, Writer { pipe: self })
     }
 
@@ -388,7 +388,7 @@ where
     /// without writing all of `buf` (returning a number less than `buf.len()`) and still leave
     /// free space in the pipe buffer. You should always `write` in a loop, or use helpers like
     /// `write_all` from the `embedded-io` crate.
-    pub fn write<'a>(&'a self, buf: &'a [u8]) -> WriteFuture<'a, M, N> {
+    pub const fn write<'a>(&'a self, buf: &'a [u8]) -> WriteFuture<'a, M, N> {
         WriteFuture { pipe: self, buf }
     }
 
@@ -440,7 +440,7 @@ where
     /// without filling `buf` (returning a number less than `buf.len()`) and still leave bytes
     /// in the pipe buffer. You should always `read` in a loop, or use helpers like
     /// `read_exact` from the `embedded-io` crate.
-    pub fn read<'a>(&'a self, buf: &'a mut [u8]) -> ReadFuture<'a, M, N> {
+    pub const fn read<'a>(&'a self, buf: &'a mut [u8]) -> ReadFuture<'a, M, N> {
         ReadFuture { pipe: self, buf }
     }
 
@@ -490,7 +490,7 @@ where
     /// Total byte capacity.
     ///
     /// This is the same as the `N` generic param.
-    pub fn capacity(&self) -> usize {
+    pub const fn capacity(&self) -> usize {
         N
     }
 

--- a/embassy-sync/src/priority_channel.rs
+++ b/embassy-sync/src/priority_channel.rs
@@ -540,12 +540,12 @@ where
     }
 
     /// Get a sender for this channel.
-    pub fn sender(&self) -> Sender<'_, M, T, K, N> {
+    pub const fn sender(&self) -> Sender<'_, M, T, K, N> {
         Sender { channel: self }
     }
 
     /// Get a receiver for this channel.
-    pub fn receiver(&self) -> Receiver<'_, M, T, K, N> {
+    pub const fn receiver(&self) -> Receiver<'_, M, T, K, N> {
         Receiver { channel: self }
     }
 
@@ -553,7 +553,7 @@ where
     ///
     /// Sending completes when the value has been pushed to the channel's queue.
     /// This doesn't mean the value has been received yet.
-    pub fn send(&self, message: T) -> SendFuture<'_, M, T, K, N> {
+    pub const fn send(&self, message: T) -> SendFuture<'_, M, T, K, N> {
         SendFuture {
             channel: self,
             message: Some(message),
@@ -578,7 +578,7 @@ where
     ///
     /// If there are no messages in the channel's buffer, this method will
     /// wait until a message is sent.
-    pub fn receive(&self) -> ReceiveFuture<'_, M, T, K, N> {
+    pub const fn receive(&self) -> ReceiveFuture<'_, M, T, K, N> {
         ReceiveFuture { channel: self }
     }
 

--- a/embassy-sync/src/pubsub/mod.rs
+++ b/embassy-sync/src/pubsub/mod.rs
@@ -420,7 +420,7 @@ impl<T: Clone, const CAP: usize, const SUBS: usize, const PUBS: usize> PubSubSta
         }
     }
 
-    fn unregister_publisher(&mut self) {
+    const fn unregister_publisher(&mut self) {
         self.publisher_count -= 1;
     }
 
@@ -431,7 +431,7 @@ impl<T: Clone, const CAP: usize, const SUBS: usize, const PUBS: usize> PubSubSta
         self.queue.clear();
     }
 
-    fn len(&self) -> usize {
+    const fn len(&self) -> usize {
         self.queue.len()
     }
 

--- a/embassy-sync/src/pubsub/publisher.rs
+++ b/embassy-sync/src/pubsub/publisher.rs
@@ -32,7 +32,7 @@ impl<'a, PSB: PubSubBehavior<T> + ?Sized, T: Clone> Pub<'a, PSB, T> {
     }
 
     /// Publish a message. But if the message queue is full, wait for all subscribers to have read the last message
-    pub fn publish<'s>(&'s self, message: T) -> PublisherWaitFuture<'s, 'a, PSB, T> {
+    pub const fn publish<'s>(&'s self, message: T) -> PublisherWaitFuture<'s, 'a, PSB, T> {
         PublisherWaitFuture {
             message: Some(message),
             publisher: self,

--- a/embassy-sync/src/pubsub/subscriber.rs
+++ b/embassy-sync/src/pubsub/subscriber.rs
@@ -29,7 +29,7 @@ impl<'a, PSB: PubSubBehavior<T> + ?Sized, T: Clone> Sub<'a, PSB, T> {
     }
 
     /// Wait for a published message
-    pub fn next_message<'s>(&'s mut self) -> SubscriberWaitFuture<'s, 'a, PSB, T> {
+    pub const fn next_message<'s>(&'s mut self) -> SubscriberWaitFuture<'s, 'a, PSB, T> {
         SubscriberWaitFuture { subscriber: self }
     }
 

--- a/embassy-sync/src/ring_buffer.rs
+++ b/embassy-sync/src/ring_buffer.rs
@@ -68,11 +68,11 @@ impl<const N: usize> RingBuffer<N> {
         self.full = false;
     }
 
-    pub fn is_full(&self) -> bool {
+    pub const fn is_full(&self) -> bool {
         self.full
     }
 
-    pub fn is_empty(&self) -> bool {
+    pub const fn is_empty(&self) -> bool {
         self.start == self.end && !self.full
     }
 
@@ -87,7 +87,7 @@ impl<const N: usize> RingBuffer<N> {
         }
     }
 
-    pub fn clear(&mut self) {
+    pub const fn clear(&mut self) {
         self.start = 0;
         self.end = 0;
         self.full = false;

--- a/embassy-sync/src/rpc_service.rs
+++ b/embassy-sync/src/rpc_service.rs
@@ -451,7 +451,7 @@ impl<M: RawMutex, T, const S: usize> RpcService<M, T, S> {
     /// completion by the runner (with the return value discarded).
     /// Execution requires that [`run()`](Self::run) is eventually polled
     /// and the service is not dropped.
-    pub fn call<R, F>(&self, f: F) -> CallFuture<'_, M, T, R, F, S>
+    pub const fn call<R, F>(&self, f: F) -> CallFuture<'_, M, T, R, F, S>
     where
         F: FnOnce(&mut T) -> R + Send + 'static,
         R: Send + 'static,

--- a/embassy-sync/src/rwlock.rs
+++ b/embassy-sync/src/rwlock.rs
@@ -168,7 +168,7 @@ where
     ///
     /// Since this call borrows the RwLock mutably, no actual locking needs to
     /// take place -- the mutable borrow statically guarantees no locks exist.
-    pub fn get_mut(&mut self) -> &mut T {
+    pub const fn get_mut(&mut self) -> &mut T {
         self.inner.get_mut()
     }
 }

--- a/embassy-sync/src/semaphore.rs
+++ b/embassy-sync/src/semaphore.rs
@@ -60,14 +60,14 @@ impl<'a, S: Semaphore> Drop for SemaphoreReleaser<'a, S> {
 
 impl<'a, S: Semaphore> SemaphoreReleaser<'a, S> {
     /// The number of acquired permits.
-    pub fn permits(&self) -> usize {
+    pub const fn permits(&self) -> usize {
         self.permits
     }
 
     /// Prevent the acquired permits from being released on drop.
     ///
     /// Returns the number of acquired permits.
-    pub fn disarm(self) -> usize {
+    pub const fn disarm(self) -> usize {
         let permits = self.permits;
         core::mem::forget(self);
         permits
@@ -198,7 +198,7 @@ impl SemaphoreState {
         self.waker.register(w);
     }
 
-    fn take(&mut self, mut permits: usize, acquire_all: bool) -> Option<usize> {
+    const fn take(&mut self, mut permits: usize, acquire_all: bool) -> Option<usize> {
         if self.permits < permits {
             None
         } else {

--- a/embassy-sync/src/waitqueue/waker_registration.rs
+++ b/embassy-sync/src/waitqueue/waker_registration.rs
@@ -50,7 +50,7 @@ impl WakerRegistration {
     }
 
     /// Returns true if a waker is currently registered
-    pub fn occupied(&self) -> bool {
+    pub const fn occupied(&self) -> bool {
         self.waker.is_some()
     }
 }

--- a/embassy-sync/src/watch.rs
+++ b/embassy-sync/src/watch.rs
@@ -411,7 +411,7 @@ impl<'a, T: Clone, W: WatchBehavior<T> + ?Sized> Clone for Snd<'a, T, W> {
 
 impl<'a, T: Clone, W: WatchBehavior<T> + ?Sized> Snd<'a, T, W> {
     /// Creates a new `Receiver` with a reference to the `Watch`.
-    fn new(watch: &'a W) -> Self {
+    const fn new(watch: &'a W) -> Self {
         Self {
             watch,
             _phantom: PhantomData,
@@ -540,7 +540,7 @@ pub struct Rcv<'a, T: Clone, W: WatchBehavior<T> + ?Sized> {
 
 impl<'a, T: Clone, W: WatchBehavior<T> + ?Sized> Rcv<'a, T, W> {
     /// Creates a new `Receiver` with a reference to the `Watch`.
-    fn new(watch: &'a W, at_id: u64) -> Self {
+    const fn new(watch: &'a W, at_id: u64) -> Self {
         Self {
             watch,
             at_id,
@@ -635,7 +635,7 @@ pub struct AnonRcv<'a, T: Clone, W: WatchBehavior<T> + ?Sized> {
 
 impl<'a, T: Clone, W: WatchBehavior<T> + ?Sized> AnonRcv<'a, T, W> {
     /// Creates a new `Receiver` with a reference to the `Watch`.
-    fn new(watch: &'a W, at_id: u64) -> Self {
+    const fn new(watch: &'a W, at_id: u64) -> Self {
         Self {
             watch,
             at_id,

--- a/embassy-sync/src/zerocopy_channel.rs
+++ b/embassy-sync/src/zerocopy_channel.rs
@@ -69,7 +69,7 @@ impl<'a, M: RawMutex, T> Channel<'a, M, T> {
     ///
     /// Further Senders and Receivers can be created through [`Sender::borrow`] and
     /// [`Receiver::borrow`] respectively.
-    pub fn split(&mut self) -> (Sender<'_, M, T>, Receiver<'_, M, T>) {
+    pub const fn split(&mut self) -> (Sender<'_, M, T>, Receiver<'_, M, T>) {
         (Sender { channel: self }, Receiver { channel: self })
     }
 
@@ -101,7 +101,7 @@ impl<'a, M: RawMutex, T> Channel<'a, M, T> {
 struct BufferPtr<T>(*mut T);
 
 impl<T> BufferPtr<T> {
-    unsafe fn add(&self, count: usize) -> *mut T {
+    unsafe const fn add(&self, count: usize) -> *mut T {
         self.0.add(count)
     }
 }
@@ -117,7 +117,7 @@ pub struct Sender<'a, M: RawMutex, T> {
 
 impl<'a, M: RawMutex, T> Sender<'a, M, T> {
     /// Creates one further [`Sender`] over the same channel.
-    pub fn borrow(&mut self) -> Sender<'_, M, T> {
+    pub const fn borrow(&mut self) -> Sender<'_, M, T> {
         Sender { channel: self.channel }
     }
 
@@ -224,7 +224,7 @@ pub struct Receiver<'a, M: RawMutex, T> {
 
 impl<'a, M: RawMutex, T> Receiver<'a, M, T> {
     /// Creates one further [`Receiver`] over the same channel.
-    pub fn borrow(&mut self) -> Receiver<'_, M, T> {
+    pub const fn borrow(&mut self) -> Receiver<'_, M, T> {
         Receiver { channel: self.channel }
     }
 
@@ -349,7 +349,7 @@ struct State {
 }
 
 impl State {
-    fn increment(&self, i: usize) -> usize {
+    const fn increment(&self, i: usize) -> usize {
         if i + 1 == self.capacity { 0 } else { i + 1 }
     }
 
@@ -362,7 +362,7 @@ impl State {
         self.full = false;
     }
 
-    fn len(&self) -> usize {
+    const fn len(&self) -> usize {
         if !self.full {
             if self.back >= self.front {
                 self.back - self.front
@@ -374,11 +374,11 @@ impl State {
         }
     }
 
-    fn is_full(&self) -> bool {
+    const fn is_full(&self) -> bool {
         self.full
     }
 
-    fn is_empty(&self) -> bool {
+    const fn is_empty(&self) -> bool {
         self.front == self.back && !self.full
     }
 

--- a/embassy-time-driver/src/lib.rs
+++ b/embassy-time-driver/src/lib.rs
@@ -104,6 +104,7 @@
 
 //! ## Feature flags
 #![doc = document_features::document_features!(feature_label = r#"<span class="stab portability"><code>{feature}</code></span>"#)]
+#![deny(clippy::missing_const_for_fn)]
 
 use core::task::Waker;
 

--- a/embassy-time-queue-utils/src/lib.rs
+++ b/embassy-time-queue-utils/src/lib.rs
@@ -1,6 +1,7 @@
 #![no_std]
 #![doc = include_str!("../README.md")]
 #![warn(missing_docs)]
+#![deny(clippy::missing_const_for_fn)]
 
 use core::task::Waker;
 

--- a/embassy-time/src/instant.rs
+++ b/embassy-time/src/instant.rs
@@ -139,7 +139,7 @@ impl Instant {
     /// Duration between this Instant and another Instant
     ///
     /// This is a panic-free [`Instant::duration_since()`].
-    pub fn checked_duration_since(&self, earlier: Instant) -> Option<Duration> {
+    pub const fn checked_duration_since(&self, earlier: Instant) -> Option<Duration> {
         if self.ticks < earlier.ticks {
             None
         } else {
@@ -153,7 +153,7 @@ impl Instant {
     /// If the "earlier" instant is in the future, the duration is set to zero.
     ///
     /// This is a panic-free alternative to [`Instant::duration_since()`].
-    pub fn saturating_duration_since(&self, earlier: Instant) -> Duration {
+    pub const fn saturating_duration_since(&self, earlier: Instant) -> Duration {
         Duration {
             ticks: if self.ticks < earlier.ticks {
                 0
@@ -183,13 +183,13 @@ impl Instant {
     }
 
     /// Adds a Duration to self. In case of overflow, the maximum value is returned.
-    pub fn saturating_add(mut self, duration: Duration) -> Self {
+    pub const fn saturating_add(mut self, duration: Duration) -> Self {
         self.ticks = self.ticks.saturating_add(duration.ticks);
         self
     }
 
     /// Subtracts a Duration from self. In case of overflow, the minimum value is returned.
-    pub fn saturating_sub(mut self, duration: Duration) -> Self {
+    pub const fn saturating_sub(mut self, duration: Duration) -> Self {
         self.ticks = self.ticks.saturating_sub(duration.ticks);
         self
     }

--- a/embassy-time/src/lib.rs
+++ b/embassy-time/src/lib.rs
@@ -8,6 +8,7 @@
 
 //! ## Feature flags
 #![doc = document_features::document_features!(feature_label = r#"<span class="stab portability"><code>{feature}</code></span>"#)]
+#![deny(clippy::missing_const_for_fn)]
 
 // This mod MUST go first, so that the others see its macros.
 pub(crate) mod fmt;

--- a/embassy-time/src/timer.rs
+++ b/embassy-time/src/timer.rs
@@ -41,7 +41,7 @@ pub fn try_with_timeout<F: Future>(timeout: impl Into<Duration>, fut: F) -> Opti
 ///
 /// If the future completes before the deadline, its output is returned. Otherwise, on timeout,
 /// work on the future is stopped (`poll` is no longer called), the future is dropped and `Err(TimeoutError)` is returned.
-pub fn with_deadline<F: Future>(at: Instant, fut: F) -> TimeoutFuture<F> {
+pub const fn with_deadline<F: Future>(at: Instant, fut: F) -> TimeoutFuture<F> {
     TimeoutFuture {
         timer: Timer::at(at),
         fut,
@@ -133,7 +133,7 @@ pub struct Timer {
 impl Timer {
     /// Expire at specified [Instant](struct.Instant.html)
     /// Will expire immediately if the Instant is in the past.
-    pub fn at(expires_at: Instant) -> Self {
+    pub const fn at(expires_at: Instant) -> Self {
         Self {
             expires_at,
             yielded_once: false,

--- a/embassy-usb-dfu/src/lib.rs
+++ b/embassy-usb-dfu/src/lib.rs
@@ -1,6 +1,7 @@
 #![no_std]
 #![doc = include_str!("../README.md")]
 #![warn(missing_docs)]
+#![deny(clippy::missing_const_for_fn)]
 mod fmt;
 
 /// Re-export DFU constants from embassy-usb.

--- a/embassy-usb-driver/src/lib.rs
+++ b/embassy-usb-driver/src/lib.rs
@@ -3,6 +3,7 @@
 #![allow(unsafe_op_in_unsafe_fn)]
 #![doc = include_str!("../README.md")]
 #![warn(missing_docs)]
+#![deny(clippy::missing_const_for_fn)]
 
 pub mod host;
 
@@ -85,7 +86,7 @@ impl EndpointAddress {
 
     /// Constructs a new EndpointAddress with the given index and direction.
     #[inline]
-    pub fn from_parts(index: usize, dir: Direction) -> Self {
+    pub const fn from_parts(index: usize, dir: Direction) -> Self {
         let dir_u8 = match dir {
             Direction::Out => 0x00,
             Direction::In => Self::INBITS,
@@ -95,7 +96,7 @@ impl EndpointAddress {
 
     /// Gets the direction part of the address.
     #[inline]
-    pub fn direction(&self) -> Direction {
+    pub const fn direction(&self) -> Direction {
         if (self.0 & Self::INBITS) != 0 {
             Direction::In
         } else {
@@ -105,19 +106,19 @@ impl EndpointAddress {
 
     /// Returns true if the direction is IN, otherwise false.
     #[inline]
-    pub fn is_in(&self) -> bool {
+    pub const fn is_in(&self) -> bool {
         (self.0 & Self::INBITS) != 0
     }
 
     /// Returns true if the direction is OUT, otherwise false.
     #[inline]
-    pub fn is_out(&self) -> bool {
+    pub const fn is_out(&self) -> bool {
         (self.0 & Self::INBITS) == 0
     }
 
     /// Gets the index part of the endpoint address.
     #[inline]
-    pub fn index(&self) -> usize {
+    pub const fn index(&self) -> usize {
         (self.0 & !Self::INBITS) as usize
     }
 }

--- a/embassy-usb-host/src/lib.rs
+++ b/embassy-usb-host/src/lib.rs
@@ -2,6 +2,7 @@
 #![allow(async_fn_in_trait)]
 #![doc = include_str!("../README.md")]
 #![warn(missing_docs)]
+#![deny(clippy::missing_const_for_fn)]
 
 /// Get max value in const context.
 macro_rules! const_max {

--- a/embassy-usb-logger/src/lib.rs
+++ b/embassy-usb-logger/src/lib.rs
@@ -1,6 +1,7 @@
 #![no_std]
 #![doc = include_str!("../README.md")]
 #![warn(missing_docs)]
+#![deny(clippy::missing_const_for_fn)]
 
 use core::fmt::Write as _;
 use core::future::Future;

--- a/embassy-usb-synopsys-otg/src/lib.rs
+++ b/embassy-usb-synopsys-otg/src/lib.rs
@@ -3,6 +3,7 @@
 #![allow(unsafe_op_in_unsafe_fn)]
 #![doc = include_str!("../README.md")]
 #![warn(missing_docs)]
+#![deny(clippy::missing_const_for_fn)]
 
 // This must go FIRST so that all the other modules see its macros.
 mod fmt;

--- a/embassy-usb/src/lib.rs
+++ b/embassy-usb/src/lib.rs
@@ -2,6 +2,7 @@
 #![allow(unsafe_op_in_unsafe_fn)]
 #![doc = include_str!("../README.md")]
 #![warn(missing_docs)]
+#![deny(clippy::missing_const_for_fn)]
 
 // This mod MUST go first, so that the others see its macros.
 pub(crate) mod fmt;


### PR DESCRIPTION
Found a few fns in `embassy-sync` who could become `const fn`s, figure I could check all crates.
Added `const` to all eligible functions and denied `missing_const_for_fn` across all crates. I believe more `const` is better in embedded and in general. 
Happy to split into per-crate PRs or drop the `#![deny()]` attr if preferred.
Hope this helps!