### PR TITLE
embassy-net-ppp: drop received packets larger than the MTU instead of panicking

### DIFF
--- a/embassy-net-ppp/CHANGELOG.md
+++ b/embassy-net-ppp/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 <!-- next-header -->
 ## Unreleased - ReleaseDate
 
+- Fix panic in `Runner::run` when a received packet is larger than the MTU (1500). Such packets are now dropped with a warning.
+
 ## 0.3.0 - 2026-03-11
 
 - Update to embedded-io 0.7

--- a/embassy-net-ppp/src/lib.rs
+++ b/embassy-net-ppp/src/lib.rs
@@ -111,8 +111,12 @@ impl<'d> Runner<'d> {
                         PPPoSAction::None => {}
                         PPPoSAction::Received(rg) => {
                             let pkt = &rx_buf[rg];
-                            buf[..pkt.len()].copy_from_slice(pkt);
-                            buf.rx_done(pkt.len());
+                            if pkt.len() > buf.len() {
+                                warn!("received packet len {} exceeds MTU {}, dropping", pkt.len(), buf.len());
+                            } else {
+                                buf[..pkt.len()].copy_from_slice(pkt);
+                                buf.rx_done(pkt.len());
+                            }
                         }
                         PPPoSAction::Transmit(n) => rw.write_all(&tx_buf[..n]).await.map_err(RunError::Write)?,
                     }


### PR DESCRIPTION
Fixes #6145.

`Runner::run` de-frames PPP input via ppproto into a local 2048-byte buffer, but the packet slots handed to embassy-net are `MTU` (1500) bytes. A well-formed IPv4 frame between 1501 and 2048 bytes, from line noise that still passes the FCS check or a peer that ignores our MRU, panics the copy into the slot with `range end index 1588 out of range for slice of length 1500` (the panics reported in the issue). Any garbage received over the UART can crash the firmware this way.

As suggested in the issue, such frames are now logged with a warning and dropped, and the link keeps running, matching how the esp-hosted interface handles oversized rx. Larger-packet support (MTU cargo feature or MRU negotiation) is left out per the issue discussion.

Verified on host by driving `Runner::run` with a scripted serial: a ppproto-encoded 1600-byte IPv4 frame panics the runner before this change; after it, the frame is dropped with a warning and a following 100-byte packet is still delivered. Checked with no features, `log` and `defmt`, on host and thumbv7em-none-eabi.
