### PR TITLE
stm32: misc adc dma cleanups

### DIFF
--- a/embassy-stm32/src/adc/mod.rs
+++ b/embassy-stm32/src/adc/mod.rs
@@ -251,6 +251,12 @@ const fn check_dma_len(sequence_len: usize, dma_len: Option<usize>, configured_s
     }
 }
 
+#[cfg(stm32n6)]
+type Word = u32;
+
+#[cfg(not(stm32n6))]
+type Word = u16;
+
 #[cfg(not(adc_f3v3))]
 /// An ADC with a pre-configured channel sequence for repeated DMA to peripheral reads.
 ///
@@ -391,19 +397,17 @@ impl<'d, T: Instance> Adc<'d, T> {
         // Use repeated mode and use the dma to stop the transfer
         T::regs().configure_dma(ConversionMode::Repeated(trigger.map(|t| (t._trigger, t._edge))));
 
-        let request = rx_dma.request();
-        let mut dma_channel = crate::dma::Channel::new(rx_dma, irq);
-        #[cfg(not(stm32n6))]
-        let transfer = unsafe { dma_channel.read(request, T::regs().data(), readings, Default::default()) };
-        #[cfg(stm32n6)]
+        let mut dma_channel = new_dma_nonopt!(rx_dma, irq);
+
         let transfer = unsafe {
             dma_channel.read_raw(
-                request,
-                T::regs().data() as *mut u32,
+                T::regs().data() as *mut Word,
                 readings,
                 crate::dma::TransferOptions {
+                    #[cfg(stm32n6)]
                     // DMA will read 0 unless it is marked as secure along with RISUP 64 (ADC12)
                     secure: true,
+                    #[cfg(stm32n6)]
                     // Don't pack readings into buffer
                     packing: crate::pac::gpdma::vals::Pam::ZeroExtendOrLeftTruncate,
                     ..Default::default()
@@ -472,12 +476,11 @@ impl<'d, T: Instance> Adc<'d, T> {
         // Configure DMA once, reused across all subsequent read() calls.
         T::regs().configure_dma(ConversionMode::Repeated(Some((trigger._trigger, trigger._edge))));
 
-        let dma_request = rx_dma.request();
-        let mut dma_channel = crate::dma::Channel::new(rx_dma, irq);
+        let mut dma_channel = new_dma_nonopt!(rx_dma, irq);
+
         let transfer = unsafe {
             dma_channel
                 .read_raw_repeated(
-                    dma_request,
                     dst,
                     1,
                     T::regs().data(),

--- a/embassy-stm32/src/dma/util.rs
+++ b/embassy-stm32/src/dma/util.rs
@@ -14,9 +14,9 @@ pub(crate) struct ChannelAndRequest<'d> {
 
 impl<'d> ChannelAndRequest<'d> {
     pub fn new<T: ChannelInstance>(
+        request: Request,
         ch: Peri<'d, T>,
         irqs: impl Binding<T::Interrupt, InterruptHandler<T>> + 'd,
-        request: Request,
     ) -> Self {
         Self {
             channel: Channel::new(ch, irqs),
@@ -24,6 +24,7 @@ impl<'d> ChannelAndRequest<'d> {
         }
     }
 
+    /// Create a read DMA transfer (peripheral to memory).
     pub unsafe fn read<'a, W: Word>(
         &'a mut self,
         peri_addr: *mut W,
@@ -34,6 +35,7 @@ impl<'d> ChannelAndRequest<'d> {
     }
 
     #[cfg(not(stm32c5))]
+    /// Create a read DMA transfer (peripheral to memory), using raw pointers.
     pub unsafe fn read_raw<'a, MW: Word, PW: Word>(
         &'a mut self,
         peri_addr: *mut PW,
@@ -43,6 +45,20 @@ impl<'d> ChannelAndRequest<'d> {
         self.channel.read_raw(self.request, peri_addr, buf, options)
     }
 
+    #[allow(dead_code)]
+    /// Create a read DMA transfer (peripheral to memory), writing the same value repeatedly.
+    pub unsafe fn read_raw_repeated<'a, MW: Word, PW: Word>(
+        &'a mut self,
+        repeated: *mut MW,
+        count: usize,
+        peri_addr: *mut PW,
+        options: TransferOptions,
+    ) -> Transfer<'a> {
+        self.channel
+            .read_raw_repeated(self.request, repeated, count, peri_addr, options)
+    }
+
+    /// Create a write DMA transfer (memory to peripheral).
     pub unsafe fn write<'a, W: Word>(
         &'a mut self,
         buf: &'a [W],
@@ -53,6 +69,7 @@ impl<'d> ChannelAndRequest<'d> {
     }
 
     #[cfg(not(stm32c5))]
+    /// Create a write DMA transfer (memory to peripheral), using raw pointers.
     pub unsafe fn write_raw<'a, MW: Word, PW: Word>(
         &'a mut self,
         buf: *const [MW],
@@ -63,6 +80,7 @@ impl<'d> ChannelAndRequest<'d> {
     }
 
     #[allow(dead_code)]
+    /// Create a write DMA transfer (memory to peripheral), writing the same value repeatedly.
     pub unsafe fn write_repeated<'a, W: Word>(
         &'a mut self,
         repeated: &'a W,
@@ -74,8 +92,8 @@ impl<'d> ChannelAndRequest<'d> {
             .write_repeated(self.request, repeated, count, peri_addr, options)
     }
 
-    /// Reborrow the channel and request, allowing it to be used in multiple places.
     #[allow(dead_code)]
+    /// Reborrow the channel and request, allowing it to be used in multiple places.
     pub fn reborrow(&mut self) -> ChannelAndRequest<'_> {
         ChannelAndRequest {
             channel: self.channel.reborrow(),

--- a/embassy-stm32/src/macros.rs
+++ b/embassy-stm32/src/macros.rs
@@ -209,8 +209,7 @@ macro_rules! new_dma_nonopt {
     ($name:ident, $irqs:expr) => {{
         let dma = $name;
         dma.remap();
-        let request = dma.request();
-        crate::dma::ChannelAndRequest::new(dma, $irqs, request)
+        crate::dma::ChannelAndRequest::new(dma.request(), dma, $irqs)
     }};
 }
 
@@ -218,8 +217,7 @@ macro_rules! new_dma {
     ($name:ident, $irqs:expr) => {{
         let dma = $name;
         dma.remap();
-        let request = dma.request();
-        Some(crate::dma::ChannelAndRequest::new(dma, $irqs, request))
+        Some(crate::dma::ChannelAndRequest::new(dma.request(), dma, $irqs))
     }};
 }
 


### PR DESCRIPTION
reorder args to allow removing let binding and use new_dma_nonopt macro in adc mod.