### PR TITLE
usb-host: don't panic on hubs with more ports than MAX_PORTS

### DIFF
--- a/embassy-usb-host/src/class/hub.rs
+++ b/embassy-usb-host/src/class/hub.rs
@@ -280,7 +280,12 @@ impl<'d, A: UsbHostAllocator<'d>, const MAX_PORTS: usize> HubHandler<'d, A, MAX_
         let (info, config_len) = self.bus.enumerate(route, config_buffer).await?;
 
         // Store the device address in the LUT for later retrieval on disconnect.
-        self.device_lut[port as usize] = NonZeroU8::new(info.device_address);
+        // A hub may report more ports than MAX_PORTS; devices on the excess
+        // ports still enumerate, but their [`HubEvent::DeviceRemoved`] carries
+        // no address (the caller cannot free it).
+        if let Some(device_ref) = self.device_lut.get_mut(port as usize) {
+            *device_ref = NonZeroU8::new(info.device_address);
+        }
 
         Ok((info, config_len))
     }


### PR DESCRIPTION
HubHandler::enumerate_port stored the device address with an unchecked index into the MAX_PORTS-sized device_lut, so a hub reporting more ports than the handler was instantiated with (e.g. a 10-port hub with a HubHandler<_, 8>) panicked as soon as a device attached to one of the excess ports. wait_for_event already uses the checked get_mut for the same lookup.

Use checked access here too: devices on excess ports enumerate and work normally, they only lose disconnect address bookkeeping (their DeviceRemoved event reports no address to free). Callers that need exact address bookkeeping on such hubs can track it themselves from enumerate_port's returned EnumerationInfo, or size MAX_PORTS to the hub.

Tested on STM32G0B1