### PR TITLE
stm32/i2c/v2: Prevent clobbering the end of async reads

### DIFF
--- a/embassy-stm32/src/i2c/v2.rs
+++ b/embassy-stm32/src/i2c/v2.rs
@@ -1126,6 +1126,14 @@ impl<'d, IM: MasterMode> I2c<'d, Async, IM> {
         .await?;
 
         dma_transfer.await;
+
+        if !restart {
+            // Wait for the bus to be free
+            while self.info.regs.isr().read().busy() {
+                timeout.check()?;
+            }
+        }
+
         drop(on_drop);
 
         Ok(())


### PR DESCRIPTION
It has been observed that when the stars align a transaction after a read may begin before the stop of the previous read has been sent. This results in a busy bus that will never be cleared as the driver doesn't realize that it is what is holding up the bus.

This can be prevented by delaying the end of the read until the stop bit has been sent and the bus is no longer busy. No delay is needed on restarts as the peripheral seems to handle these correctly.

Closes #2884