### PR TITLE
STM32N6: default external supply and SDMMC SDR104 fixes

### DIFF
--- a/embassy-stm32/src/sdmmc/mod.rs
+++ b/embassy-stm32/src/sdmmc/mod.rs
@@ -1828,9 +1828,16 @@ impl<'d> Sdmmc<'d> {
             return Err(MmcError::Crc);
         }
 
+        // The `sdio` crate's `Response::from_words` expects little-endian words
+        // (buf[0] = least-significant word). The STM32 RESPx registers are big-endian:
+        // for a long (R2/R136) response respr(0) = RESP1 = most-significant [127:96].
+        // Reverse the word order so multi-word responses (CID/CSD) assemble correctly —
+        // otherwise CSD_STRUCTURE/C_SIZE are mis-parsed and the reported card size is wrong.
+        // (Single-word R48 responses are unaffected: n = 1 → buf[0] = respr(0).)
         let mut buf = [0u32; 4];
-        for i in 0..R::LEN.words() {
-            buf[i] = self.info.regs.respr(i).read().cardstatus();
+        let n = R::LEN.words();
+        for i in 0..n {
+            buf[i] = self.info.regs.respr(n - 1 - i).read().cardstatus();
         }
 
         Ok(::sdio::Response::from_words(&buf))
@@ -1961,9 +1968,13 @@ impl<'d> MmcBus for Sdmmc<'d> {
     }
 
     fn supports_frequency(&self) -> u32 {
-        if self.uhs_active() && self.has_dlyb() {
+        // Report the bus *capability* (from the tuning hardware wired up at construction),
+        // not the runtime UHS state. The sdio layer clamps the requested frequency against
+        // this value BEFORE the 1.8 V UHS switch, so gating on `uhs_active()` (still false at
+        // that point) capped every request to 50 MHz and made SDR50/SDR104 unreachable.
+        if self.has_dlyb() {
             208_000_000
-        } else if self.uhs_active() && (self.has_ckin() || self.has_dlyb()) {
+        } else if self.has_ckin() {
             100_000_000
         } else {
             50_000_000

--- a/examples/stm32n6-flashboot/app/src/main.rs
+++ b/examples/stm32n6-flashboot/app/src/main.rs
@@ -9,7 +9,7 @@ use embassy_executor::Spawner;
 use embassy_stm32::exti::{self, ExtiInput};
 use embassy_stm32::gpio::{Input, Level, Output, Pull, Speed};
 use embassy_stm32::mode::Async;
-use embassy_stm32::rcc::XspiClkSrc;
+use embassy_stm32::rcc::{SupplyConfig, XspiClkSrc};
 use embassy_stm32::{bind_interrupts, interrupt, usart};
 use embassy_time::{Duration, Timer, with_timeout};
 use {defmt_rtt as _, panic_probe as _};
@@ -67,6 +67,8 @@ async fn main(spawner: Spawner) {
     info!("App starting");
 
     let mut config = embassy_stm32::Config::default();
+    // DK uses external SMPS (UM3300 Tab.6); embassy default = internal SMPS hangs init() at VOSRDY.
+    config.rcc.supply_config = SupplyConfig::External;
     config.rcc.mux.xspi2sel = XspiClkSrc::Per;
     config.rcc.vddio3_1v8 = true;
     let p = embassy_stm32::init(config);

--- a/examples/stm32n6-flashboot/fsbl/src/main.rs
+++ b/examples/stm32n6-flashboot/fsbl/src/main.rs
@@ -10,7 +10,7 @@ use defmt::{error, info};
 use defmt_rtt as _;
 use embassy_boot_stm32::*;
 use embassy_stm32::pac::{BSEC, RCC, XSPI1, XSPI2, XSPIM};
-use embassy_stm32::rcc::XspiClkSrc;
+use embassy_stm32::rcc::{SupplyConfig, XspiClkSrc};
 use embassy_stm32::xspi::{ChipSelectHighTime, FIFOThresholdLevel, MemorySize, MemoryType, WrapSize, Xspi};
 use embassy_sync::blocking_mutex::Mutex;
 use embassy_sync::blocking_mutex::raw::NoopRawMutex;
@@ -88,6 +88,8 @@ fn main() -> ! {
     //    Using PER avoids IC4/PLL routing, so the app's reinit() can use the
     //    same config without touching IC divider registers mid-execution.
     let mut config = embassy_stm32::Config::default();
+    // DK uses external SMPS (UM3300 Tab.6); embassy default = internal SMPS hangs init() at VOSRDY.
+    config.rcc.supply_config = SupplyConfig::External;
     config.rcc.mux.xspi2sel = XspiClkSrc::Per;
     config.rcc.vddio3_1v8 = true;
     let p = embassy_stm32::init(config);

--- a/examples/stm32n6/src/bin/blinky.rs
+++ b/examples/stm32n6/src/bin/blinky.rs
@@ -25,7 +25,10 @@ async fn button_task(mut button: ExtiInput<'static, Async>) {
 
 #[embassy_executor::main]
 async fn main(spawner: Spawner) {
-    let p = embassy_stm32::init(Default::default());
+    // DK uses external SMPS (UM3300 Tab.6); embassy default = internal SMPS hangs init() at VOSRDY.
+    let mut config = embassy_stm32::Config::default();
+    config.rcc.supply_config = embassy_stm32::rcc::SupplyConfig::External;
+    let p = embassy_stm32::init(config);
     info!("Hello World!");
 
     let mut led = Output::new(p.PG10, Level::High, Speed::Low);

--- a/examples/stm32n6/src/bin/camera_to_sd.rs
+++ b/examples/stm32n6/src/bin/camera_to_sd.rs
@@ -29,7 +29,7 @@ use embassy_stm32::i2c::I2c;
 use embassy_stm32::ltdc::{self, Ltdc, LtdcLayer, LtdcLayerConfig, PixelFormat};
 use embassy_stm32::peripherals::DCMIPP;
 use embassy_stm32::rcc::mux::{Dcmippsel, Ltdcsel};
-use embassy_stm32::rcc::{CpuClk, IcConfig, Icint, Icsel, Pll, Plldivm, Pllpdiv, Pllsel, SysClk};
+use embassy_stm32::rcc::{CpuClk, IcConfig, Icint, Icsel, Pll, Plldivm, Pllpdiv, Pllsel, SupplyConfig, SysClk};
 use embassy_stm32::rif::{RifMaster, RifMasterAttributes, RifPeripheral, RifPeripheralAttributes};
 use embassy_stm32::sdmmc::Sdmmc;
 use embassy_stm32::sdmmc::sd::{Addressable, Card, CmdBlock, DataBlock, StorageDevice};
@@ -553,6 +553,11 @@ impl TimeSource for FixedTime {
 
 fn rcc_config() -> Config {
     let mut config = Config::default();
+    // The STM32N6570-DK supplies VCORE from an external SMPS (board default, UM3300
+    // Table 6). The embassy default (SupplyConfig::Smps) enables the *internal* SMPS,
+    // so VOSRDY never reaches the selected VOS level and init() hangs in the voltage-
+    // scaling wait. Selecting External clears SDEN → VOSRDY/ACTVOSRDY read ready.
+    config.rcc.supply_config = SupplyConfig::External;
     config.rcc.pll1 = Some(Pll::Oscillator {
         source: Pllsel::Hsi,
         divm: Plldivm::Div4,

--- a/examples/stm32n6/src/bin/crc.rs
+++ b/examples/stm32n6/src/bin/crc.rs
@@ -8,7 +8,10 @@ use {defmt_rtt as _, panic_probe as _};
 
 #[embassy_executor::main]
 async fn main(_spawner: Spawner) {
-    let p = embassy_stm32::init(Default::default());
+    // DK uses external SMPS (UM3300 Tab.6); embassy default = internal SMPS hangs init() at VOSRDY.
+    let mut config = embassy_stm32::Config::default();
+    config.rcc.supply_config = embassy_stm32::rcc::SupplyConfig::External;
+    let p = embassy_stm32::init(config);
     info!("Hello World!");
 
     // Setup for: https://crccalc.com/?crc=Life, it never dieWomen are my favorite guy&method=crc32&datatype=ascii&outtype=0

--- a/examples/stm32n6/src/bin/eth_speedtest.rs
+++ b/examples/stm32n6/src/bin/eth_speedtest.rs
@@ -27,7 +27,7 @@ use embassy_net::tcp::TcpSocket;
 use embassy_net::{Ipv4Address, Ipv4Cidr, StackResources, StaticConfigV4};
 use embassy_stm32::eth::{Ethernet, GenericPhy, PacketQueue, Sma};
 use embassy_stm32::peripherals::{ETH_SMA, ETH1};
-use embassy_stm32::rcc::{CpuClk, IcConfig, Icint, Icsel, Pll, Plldivm, Pllpdiv, Pllsel, SysClk};
+use embassy_stm32::rcc::{CpuClk, IcConfig, Icint, Icsel, Pll, Plldivm, Pllpdiv, Pllsel, SupplyConfig, SysClk};
 use embassy_stm32::{Config, bind_interrupts, eth};
 use embassy_time::{Duration, Instant};
 use embedded_io_async::{Read, Write};
@@ -53,6 +53,8 @@ const GATEWAY: Ipv4Address = Ipv4Address::new(192, 168, 137, 1);
 
 fn rcc_config() -> Config {
     let mut config = Config::default();
+    // DK uses external SMPS (UM3300 Tab.6); embassy default = internal SMPS hangs init() at VOSRDY.
+    config.rcc.supply_config = SupplyConfig::External;
     // PLL1 = HSI(64 MHz) / 4 * 50 = 800 MHz.
     config.rcc.pll1 = Some(Pll::Oscillator {
         source: Pllsel::Hsi,

--- a/examples/stm32n6/src/bin/hash.rs
+++ b/examples/stm32n6/src/bin/hash.rs
@@ -18,7 +18,9 @@ bind_interrupts!(struct Irqs {
 
 #[embassy_executor::main]
 async fn main(_spawner: Spawner) -> ! {
-    let config = Config::default();
+    // DK uses external SMPS (UM3300 Tab.6); embassy default = internal SMPS hangs init() at VOSRDY.
+    let mut config = Config::default();
+    config.rcc.supply_config = embassy_stm32::rcc::SupplyConfig::External;
     let p = embassy_stm32::init(config);
 
     let test_1: &[u8] = b"as;dfhaslfhas;oifvnasd;nifvnhasd;nifvhndlkfghsd;nvfnahssdfgsdafgsasdfasdfasdfasdfasdfghjklmnbvcalskdjghalskdjgfbaslkdjfgbalskdjgbalskdjbdfhsdfhsfghsfghfgh";

--- a/examples/stm32n6/src/bin/jpeg_decode.rs
+++ b/examples/stm32n6/src/bin/jpeg_decode.rs
@@ -27,7 +27,10 @@ struct Aligned<const N: usize>([u8; N]);
 
 #[embassy_executor::main]
 async fn main(_spawner: Spawner) -> ! {
-    let p = embassy_stm32::init(Config::default());
+    // DK uses external SMPS (UM3300 Tab.6); embassy default = internal SMPS hangs init() at VOSRDY.
+    let mut config = Config::default();
+    config.rcc.supply_config = embassy_stm32::rcc::SupplyConfig::External;
+    let p = embassy_stm32::init(config);
 
     let mut codec = Jpeg::new(p.JPEG, p.GPDMA1_CH0, p.GPDMA1_CH1, Irqs);
 

--- a/examples/stm32n6/src/bin/jpeg_decode_blocking.rs
+++ b/examples/stm32n6/src/bin/jpeg_decode_blocking.rs
@@ -19,7 +19,10 @@ struct Aligned<const N: usize>([u8; N]);
 
 #[embassy_executor::main]
 async fn main(_spawner: Spawner) -> ! {
-    let p = embassy_stm32::init(Config::default());
+    // DK uses external SMPS (UM3300 Tab.6); embassy default = internal SMPS hangs init() at VOSRDY.
+    let mut config = Config::default();
+    config.rcc.supply_config = embassy_stm32::rcc::SupplyConfig::External;
+    let p = embassy_stm32::init(config);
 
     let mut codec = Jpeg::new_blocking(p.JPEG);
 

--- a/examples/stm32n6/src/bin/jpeg_encode.rs
+++ b/examples/stm32n6/src/bin/jpeg_encode.rs
@@ -24,7 +24,10 @@ struct Aligned<const N: usize>([u8; N]);
 
 #[embassy_executor::main]
 async fn main(_spawner: Spawner) -> ! {
-    let p = embassy_stm32::init(Config::default());
+    // DK uses external SMPS (UM3300 Tab.6); embassy default = internal SMPS hangs init() at VOSRDY.
+    let mut config = Config::default();
+    config.rcc.supply_config = embassy_stm32::rcc::SupplyConfig::External;
+    let p = embassy_stm32::init(config);
 
     // Build an MCU-ordered grayscale source: 64×64 image is 8×8 = 64 MCUs of
     // 8×8 pixels each. For grayscale the buffer layout is identical to a

--- a/examples/stm32n6/src/bin/jpeg_encode_blocking.rs
+++ b/examples/stm32n6/src/bin/jpeg_encode_blocking.rs
@@ -19,7 +19,10 @@ struct Aligned<const N: usize>([u8; N]);
 
 #[embassy_executor::main]
 async fn main(_spawner: Spawner) -> ! {
-    let p = embassy_stm32::init(Config::default());
+    // DK uses external SMPS (UM3300 Tab.6); embassy default = internal SMPS hangs init() at VOSRDY.
+    let mut config = Config::default();
+    config.rcc.supply_config = embassy_stm32::rcc::SupplyConfig::External;
+    let p = embassy_stm32::init(config);
 
     let mut src_buf = Aligned::<{ (W as usize) * (H as usize) }>([0u8; (W as usize) * (H as usize)]);
     let src = &mut src_buf.0;

--- a/examples/stm32n6/src/bin/lcd.rs
+++ b/examples/stm32n6/src/bin/lcd.rs
@@ -28,7 +28,7 @@ use embassy_executor::Spawner;
 use embassy_stm32::dma2d::{self, Dma2d};
 use embassy_stm32::ltdc::{self, Ltdc, LtdcLayer, LtdcLayerConfig, PixelFormat};
 use embassy_stm32::rcc::mux::Ltdcsel;
-use embassy_stm32::rcc::{CpuClk, IcConfig, Icint, Icsel, Pll, Plldivm, Pllpdiv, Pllsel, SysClk};
+use embassy_stm32::rcc::{CpuClk, IcConfig, Icint, Icsel, Pll, Plldivm, Pllpdiv, Pllsel, SupplyConfig, SysClk};
 use embassy_stm32::rif::{RifMaster, RifMasterAttributes, RifPeripheral, RifPeripheralAttributes};
 use embassy_stm32::{Config, bind_interrupts, pac, peripherals};
 use embassy_time::Instant;
@@ -178,6 +178,11 @@ fn dma2d_r2m_fill_rgb565(fb_ptr: *mut u16, stride: u16, x: u16, y: u16, width: u
 #[embassy_executor::main]
 async fn main(_spawner: Spawner) {
     let mut config = Config::default();
+    // The STM32N6570-DK supplies VCORE from an external SMPS (board default, UM3300
+    // Table 6). The embassy default (SupplyConfig::Smps) enables the *internal* SMPS,
+    // so VOSRDY never reaches the selected VOS level and init() hangs in the voltage-
+    // scaling wait. Selecting External clears SDEN → VOSRDY/ACTVOSRDY read ready.
+    config.rcc.supply_config = SupplyConfig::External;
     // PLL1 oscillator: HSI 64 MHz / DIVM=4 = 16 MHz ref, × DIVN=50 → 800 MHz VCO.
     //   IC1 div1 → 800 MHz CPU (M55 max).
     //   IC2/6/11 div4 → 200 MHz system bus. The embassy N6 defaults of AHB=Div2 and

--- a/examples/stm32n6/src/bin/rng.rs
+++ b/examples/stm32n6/src/bin/rng.rs
@@ -19,7 +19,9 @@ async fn main(_spawner: Spawner) {
 
     // On STM32N6, the RNG kernel clock (rng_ker_ck) is hardwired to hsis_osc_ck (48 MHz internal RC
     // oscillator) with no mux - RM0486 Table 73. No explicit kernel clock selection is needed.
-    let config = Config::default();
+    // DK uses external SMPS (UM3300 Tab.6); embassy default = internal SMPS hangs init() at VOSRDY.
+    let mut config = Config::default();
+    config.rcc.supply_config = embassy_stm32::rcc::SupplyConfig::External;
 
     let p = embassy_stm32::init(config);
     info!("Hello World!");

--- a/examples/stm32n6/src/bin/sdmmc_throughput.rs
+++ b/examples/stm32n6/src/bin/sdmmc_throughput.rs
@@ -16,7 +16,7 @@ use block_device_driver::BlockDevice as _;
 use defmt::{error, info};
 use embassy_executor::Spawner;
 use embassy_stm32::gpio::{Level, Output, Speed};
-use embassy_stm32::rcc::{CpuClk, IcConfig, Icint, Icsel, Pll, Plldivm, Pllpdiv, Pllsel, SysClk};
+use embassy_stm32::rcc::{CpuClk, IcConfig, Icint, Icsel, Pll, Plldivm, Pllpdiv, Pllsel, SupplyConfig, SysClk};
 use embassy_stm32::sdmmc::Sdmmc;
 use embassy_stm32::{Config, bind_interrupts, peripherals};
 use embassy_time::{Delay, Instant};
@@ -153,6 +153,8 @@ async fn main(_spawner: Spawner) {
 
 fn rcc_config() -> Config {
     let mut config = Config::default();
+    // DK uses external SMPS (UM3300 Tab.6); embassy default = internal SMPS hangs init() at VOSRDY.
+    config.rcc.supply_config = SupplyConfig::External;
     config.rcc.pll1 = Some(Pll::Oscillator {
         source: Pllsel::Hsi,
         divm: Plldivm::Div4,

--- a/examples/stm32n6/src/bin/sdmmc_throughput.rs
+++ b/examples/stm32n6/src/bin/sdmmc_throughput.rs
@@ -15,8 +15,10 @@ mod sd_save;
 use block_device_driver::BlockDevice as _;
 use defmt::{error, info};
 use embassy_executor::Spawner;
-use embassy_stm32::gpio::{Level, Output, Speed};
-use embassy_stm32::rcc::{CpuClk, IcConfig, Icint, Icsel, Pll, Plldivm, Pllpdiv, Pllsel, SupplyConfig, SysClk};
+use embassy_stm32::gpio::{Input, Level, Output, Pull, Speed};
+use embassy_stm32::rcc::{
+    CpuClk, IcConfig, Icint, Icsel, Pll, Plldivm, Pllpdiv, Pllsel, SupplyConfig, SysClk, VoltageScale,
+};
 use embassy_stm32::sdmmc::Sdmmc;
 use embassy_stm32::{Config, bind_interrupts, peripherals};
 use embassy_time::{Delay, Instant};
@@ -36,6 +38,13 @@ const CHUNK_BYTES: usize = 32 * 1024;
 #[embassy_executor::main]
 async fn main(_spawner: Spawner) {
     let p = embassy_stm32::init(rcc_config());
+
+    // The DK gates the microSD power rail (VDD_SD) via PWR_SD_EN (PQ7), active-high — UM3300 §8.9.
+    // Drive it high so the card is definitely powered, then report card-detect (PN12, low=present).
+    let _pwr_sd = Output::new(p.PQ7, Level::High, Speed::Low);
+    let card_detect = Input::new(p.PN12, Pull::Up);
+    embassy_time::Timer::after_millis(10).await;
+    info!("uSD_Detect (PN12) low=present: {}", card_detect.is_low());
 
     let vswitch = Output::new(p.PO5, Level::Low, Speed::Low);
 
@@ -58,8 +67,8 @@ async fn main(_spawner: Spawner) {
         sd_cfg,
     );
 
-    // 110 MHz triggers SDR104 negotiation (>100 MHz). With the default
-    // 100 MHz kernel + CLKDIV bypass the wire stays at 100 MHz.
+    // 110 MHz negotiates UHS-I SDR104 (1.8 V switch + DLYB RX tuning). Needs the patched
+    // sdio crate with the correct 4-bit tuning pattern (see [patch.crates-io] in Cargo.toml).
     let mut storage = match DefaultBlockDevice::new_sd_card(&mut sd, 110_000_000, Delay).await {
         Ok(s) => s,
         Err(e) => {
@@ -155,6 +164,8 @@ fn rcc_config() -> Config {
     let mut config = Config::default();
     // DK uses external SMPS (UM3300 Tab.6); embassy default = internal SMPS hangs init() at VOSRDY.
     config.rcc.supply_config = SupplyConfig::External;
+    // Test: force VOS low. Under External supply the VOS bit has no effect on VCORE per RM0486.
+    config.rcc.voltage_scale = VoltageScale::Scale0;
     config.rcc.pll1 = Some(Pll::Oscillator {
         source: Pllsel::Hsi,
         divm: Plldivm::Div4,

--- a/examples/stm32n6/src/bin/xspi_flash.rs
+++ b/examples/stm32n6/src/bin/xspi_flash.rs
@@ -23,7 +23,7 @@ use defmt::{error, info, warn};
 use embassy_executor::Spawner;
 use embassy_stm32::gpio::{Level, Output, Speed};
 use embassy_stm32::mode::Blocking;
-use embassy_stm32::rcc::{IcConfig, Icint, Icsel, XspiClkSrc};
+use embassy_stm32::rcc::{IcConfig, Icint, Icsel, SupplyConfig, XspiClkSrc};
 use embassy_stm32::xspi::{
     AddressSize, ChipSelectHighTime, DummyCycles, FIFOThresholdLevel, Instance, MemorySize, MemoryType, TransferConfig,
     WrapSize, Xspi, XspiWidth,
@@ -37,6 +37,8 @@ const MEMORY_PAGE_SIZE: usize = 256;
 async fn main(_spawner: Spawner) {
     // Configure RCC with IC4 for XSPI2 kernel clock
     let mut config = embassy_stm32::Config::default();
+    // DK uses external SMPS (UM3300 Tab.6); embassy default = internal SMPS hangs init() at VOSRDY.
+    config.rcc.supply_config = SupplyConfig::External;
     config.rcc.ic4 = Some(IcConfig {
         source: Icsel::Pll2,          // PLL2 in bypass mode = HSI 64 MHz
         divider: Icint::from_bits(0), // DIV1 = no division

--- a/examples/stm32n6/src/bin/xspi_psram.rs
+++ b/examples/stm32n6/src/bin/xspi_psram.rs
@@ -34,7 +34,9 @@ use defmt::{error, info};
 use embassy_executor::Spawner;
 use embassy_stm32::gpio::{Level, Output, Speed};
 use embassy_stm32::mode::Blocking;
-use embassy_stm32::rcc::{CpuClk, IcConfig, Icint, Icsel, Pll, Plldivm, Pllpdiv, Pllsel, SysClk, XspiClkSrc};
+use embassy_stm32::rcc::{
+    CpuClk, IcConfig, Icint, Icsel, Pll, Plldivm, Pllpdiv, Pllsel, SupplyConfig, SysClk, XspiClkSrc,
+};
 use embassy_stm32::xspi::{
     AddressSize, ChipSelectHighTime, DummyCycles, FIFOThresholdLevel, Instance, MemorySize, MemoryType, TransferConfig,
     WrapSize, Xspi, XspiWidth,
@@ -90,6 +92,8 @@ unsafe fn psram_write_byte(addr: *mut u8, val: u8) {
 async fn main(_spawner: Spawner) {
     // Configure RCC with full clock tree for 200MHz XSPI operation
     let mut config = embassy_stm32::Config::default();
+    // DK uses external SMPS (UM3300 Tab.6); embassy default = internal SMPS hangs init() at VOSRDY.
+    config.rcc.supply_config = SupplyConfig::External;
 
     // Configure PLL1: HSI 64MHz / 4 * 75 = 1200MHz
     config.rcc.pll1 = Some(Pll::Oscillator {


### PR DESCRIPTION
This fixes the power config for STM32N6-DK for the examples, and fix the possible frequencies possible for the sdmmc.
Also fixes the calculation for sdcard size.