### PR TITLE
stm32/usb: disable ULPI clock for OTG_HS FS host

### DIFF
--- a/embassy-stm32/src/usb/otg.rs
+++ b/embassy-stm32/src/usb/otg.rs
@@ -723,6 +723,21 @@ mod host_impl {
 
             super::super::common_init::<T>();
 
+            // The ULPI clock has to be disabled for an internal PHY.
+            // Left enabled, the OTG_HS core waits on an absent external ULPI PHY
+            // and never enters host mode, so no downstream device is ever detected.
+            #[cfg(stm32h7)]
+            critical_section::with(|_| {
+                let rcc = crate::pac::RCC;
+                if T::HIGH_SPEED {
+                    rcc.ahb1enr().modify(|w| w.set_usb_otg_hs_ulpien(false));
+                    rcc.ahb1lpenr().modify(|w| w.set_usb_otg_hs_ulpilpen(false));
+                } else {
+                    rcc.ahb1enr().modify(|w| w.set_usb_otg_fs_ulpien(false));
+                    rcc.ahb1lpenr().modify(|w| w.set_usb_otg_fs_ulpilpen(false));
+                }
+            });
+
             let instance = OtgHostInstance {
                 regs: T::regs(),
                 state: T::host_state(),


### PR DESCRIPTION
I couldn't get OTG_HS using to work in order to receive keyboard events on an STM32H7.

Upon inspection, I found that `Bus::init` disables the ULPI clock when using the internal FS PHY, but `new_fs_host` only calls `common_init` and thus leaves the clock enabled.

On OTG_HS, the enabled ULPI clock makes the core wait for an external ULPI PHY that is not there. The core then never switches to host mode (`GINTSTS.CMOD` stays 0), `HPRT.PCSTS` never gets set, and the host never sees the downstream device.

This PR disables the ULPI clock bits in `new_fs_host` as well, matching `Bus::init`. This lets OTG_HS with the internal FS PHY switch to host mode and enumerate devices correctly.