### PR TITLE
stm32: GPDMA: fix linked-list table ownership and expose descriptor API

### DIFF
--- a/embassy-stm32/CHANGELOG.md
+++ b/embassy-stm32/CHANGELOG.md
@@ -23,6 +23,7 @@ DMA:
 - feat: stm32/dma: ungate `TransferOptions::burst_length` on GPDMA (was stm32n6-only)
 - fix: stm32/dma: auto-set `TR1.PAM = Pack` on GPDMA when source and destination widths differ, instead of silently zero-extending one beat per destination beat
 - fix: stm32/dma: compute GPDMA `BR1.BNDT` from the memory-side width regardless of direction, fixing destination overrun on reads with peripheral width > memory width
+- feat: stm32/dma: GPDMA: allow access to construct custom LinkedList chains for scatter/gather DMA
 
 ADC:
 - feat: stm32/adc: add `VrefInt::calibrated_value()` for additional chips

--- a/embassy-stm32/src/dma/gpdma/linked_list.rs
+++ b/embassy-stm32/src/dma/gpdma/linked_list.rs
@@ -126,7 +126,7 @@ impl LinearItem {
     /// Link to the next linear item at the given address.
     ///
     /// Enables channel update bits.
-    fn link_to(&mut self, next: u16) {
+    pub fn link_to(&mut self, next: u16) {
         let mut llr = regs::ChLlr(0);
 
         llr.set_ut1(true);
@@ -145,12 +145,12 @@ impl LinearItem {
     /// Unlink the next linear item.
     ///
     /// Disables channel update bits.
-    fn unlink(&mut self) {
+    pub fn unlink(&mut self) {
         self.llr = regs::ChLlr(0);
     }
 
     /// The item's transfer count in number of words.
-    fn transfer_count(&self) -> usize {
+    pub fn transfer_count(&self) -> usize {
         let word_size: WordSize = self.tr1.ddw().into();
         self.br1.bndt() as usize / word_size.bytes()
     }

--- a/embassy-stm32/src/dma/gpdma/linked_list.rs
+++ b/embassy-stm32/src/dma/gpdma/linked_list.rs
@@ -97,6 +97,24 @@ impl LinearItem {
         tr1.set_sinc(dir == Dir::MemoryToPeripheral && incr_mem);
         tr1.set_dinc(dir == Dir::PeripheralToMemory && incr_mem);
 
+        // Set AHB port assignments for GPDMA (LPDMA does not have SAP/DAP).
+        // This matches the logic in Channel::configure() for non-linked-list
+        // transfers: memory is on Port0 (AXI), peripheral is on Port1 (AHB).
+        #[cfg(gpdma)]
+        {
+            use stm32_metapac::gpdma::vals::Ap;
+            tr1.set_sap(match dir {
+                Dir::MemoryToPeripheral => Ap::Port0, // Source is memory on AXI
+                Dir::PeripheralToMemory => Ap::Port1, // Source is peripheral on AHB
+                Dir::MemoryToMemory => panic!("memory-to-memory transfers are not valid for LinearItem"),
+            });
+            tr1.set_dap(match dir {
+                Dir::MemoryToPeripheral => Ap::Port1, // Destination is peripheral on AHB
+                Dir::PeripheralToMemory => Ap::Port0, // Destination is memory on AXI
+                Dir::MemoryToMemory => panic!("memory-to-memory transfers are not valid for LinearItem"),
+            });
+        }
+
         let mut tr2 = regs::ChTr2(0);
         tr2.set_dreq(match dir {
             Dir::MemoryToPeripheral => Dreq::DestinationPeripheral,
@@ -147,6 +165,16 @@ impl LinearItem {
     /// Disables channel update bits.
     pub fn unlink(&mut self) {
         self.llr = regs::ChLlr(0);
+    }
+
+    /// Set the transfer complete event mode (`TR2.TCEM`) for this item.
+    ///
+    /// In linked-list mode, the channel's TR2 register is overwritten by
+    /// each LLI when `UT2` is set, so TCEM must be configured per-item.
+    ///
+    /// See [`TransferCompleteMode`](super::TransferCompleteMode) for details.
+    pub fn set_transfer_complete_mode(&mut self, mode: super::TransferCompleteMode) {
+        self.tr2.set_tcem(mode.into());
     }
 
     /// The item's transfer count in number of words.

--- a/embassy-stm32/src/dma/gpdma/mod.rs
+++ b/embassy-stm32/src/dma/gpdma/mod.rs
@@ -117,6 +117,46 @@ impl From<RequestMode> for vals::Breq {
     }
 }
 
+/// Transfer complete event mode (`TR2.TCEM`).
+///
+/// Controls when the transfer-complete (and half-transfer) events are
+/// generated. For linked-list transfers, this is a per-item field loaded
+/// from each LLI when `UT2` is set.
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+pub enum TransferCompleteMode {
+    /// Generate TC/HT events at the end of each block transfer.
+    EachBlock,
+    /// Generate TC at the end of each LLI transfer (including loading the
+    /// next LLI). HT is generated at the half of the LLI data transfer.
+    EachLinkedListItem,
+    /// Generate TC only at the end of the last LLI transfer. HT is
+    /// generated at the half of the last LLI's data transfer.
+    LastLinkedListItem,
+}
+
+#[cfg(gpdma)]
+impl From<TransferCompleteMode> for pac::gpdma::vals::Tcem {
+    fn from(value: TransferCompleteMode) -> Self {
+        match value {
+            TransferCompleteMode::EachBlock => Self::EachBlock,
+            TransferCompleteMode::EachLinkedListItem => Self::EachLinkedListItem,
+            TransferCompleteMode::LastLinkedListItem => Self::LastLinkedListItem,
+        }
+    }
+}
+
+#[cfg(lpdma)]
+impl From<TransferCompleteMode> for pac::lpdma::vals::Tcem {
+    fn from(value: TransferCompleteMode) -> Self {
+        match value {
+            TransferCompleteMode::EachBlock => Self::EachBlock,
+            TransferCompleteMode::EachLinkedListItem => Self::EachLinkedListItem,
+            TransferCompleteMode::LastLinkedListItem => Self::LastLinkedListItem,
+        }
+    }
+}
+
 /// Input-trigger polarity for GPDMA triggered transfers.
 #[derive(Debug, Copy, Clone, PartialEq, Eq)]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
@@ -347,6 +387,12 @@ pub struct TransferOptions {
     pub burst_length: Burst,
     /// Select whether peripheral handshaking is done at burst or block level.
     pub request_mode: RequestMode,
+    /// Transfer complete event mode. Default `EachBlock`.
+    ///
+    /// For linked-list transfers, set this on each `LinearItem` via
+    /// [`LinearItem::set_transfer_complete_mode`](linked_list::LinearItem::set_transfer_complete_mode)
+    /// since the channel TR2 is overwritten by the first LLI when `UT2` is set.
+    pub transfer_complete_mode: TransferCompleteMode,
     /// Optional trigger-gated transfer configuration.
     pub trigger: Option<TriggerConfig>,
 }
@@ -364,6 +410,7 @@ impl Default for TransferOptions {
             #[cfg(not(stm32c5))]
             burst_length: Burst::_1Beats,
             request_mode: RequestMode::Burst,
+            transfer_complete_mode: TransferCompleteMode::EachBlock,
             trigger: None,
         }
     }
@@ -662,6 +709,7 @@ impl<'d> Channel<'d> {
             });
             w.set_breq(options.request_mode.into());
             w.set_reqsel(request);
+            w.set_tcem(options.transfer_complete_mode.into());
             if let Some(trigger) = options.trigger {
                 w.set_trigsel(trigger.signal);
                 w.set_trigpol(trigger.polarity.into());
@@ -699,11 +747,7 @@ impl<'d> Channel<'d> {
     }
 
     /// Configure a linked-list transfer.
-    unsafe fn configure_linked_list<const N: usize>(
-        &self,
-        table: &Table<N>,
-        options: TransferOptions,
-    ) {
+    unsafe fn configure_linked_list<const N: usize>(&self, table: &Table<N>, options: TransferOptions) {
         let info = self.info();
         let ch = info.dma.ch(info.num);
 
@@ -966,6 +1010,23 @@ impl<'d> Channel<'d> {
             _wake_guard: self.info().wake_guard(),
             channel: self.reborrow(),
         }
+    }
+
+    /// Reconfigure and restart a linked-list transfer from item[0].
+    ///
+    /// Resets the channel, clears all flags, reconfigures LBAR/BR1/LLR/CR
+    /// from the table and options, and re-enables the channel. This is
+    /// intended for use cases that need to restart the same linked-list
+    /// chain from the beginning.
+    ///
+    /// # Safety
+    ///
+    /// The caller must ensure that no other code is concurrently accessing
+    /// the channel registers, and that the `table` remains valid for the
+    /// duration of the transfer.
+    pub unsafe fn restart_linked_list<const N: usize>(&self, table: &Table<N>, options: TransferOptions) {
+        self.configure_linked_list(table, options);
+        self.start();
     }
 }
 

--- a/embassy-stm32/src/dma/gpdma/mod.rs
+++ b/embassy-stm32/src/dma/gpdma/mod.rs
@@ -699,9 +699,9 @@ impl<'d> Channel<'d> {
     }
 
     /// Configure a linked-list transfer.
-    unsafe fn configure_linked_list<const ITEM_COUNT: usize>(
+    unsafe fn configure_linked_list<const N: usize>(
         &self,
-        table: &Table<ITEM_COUNT>,
+        table: &Table<N>,
         options: TransferOptions,
     ) {
         let info = self.info();
@@ -752,7 +752,7 @@ impl<'d> Channel<'d> {
         });
 
         let state = &STATE[self.channel as usize];
-        state.lli_state.count.store(ITEM_COUNT, Ordering::Relaxed);
+        state.lli_state.count.store(N, Ordering::Relaxed);
         state.lli_state.index.store(0, Ordering::Relaxed);
         state
             .lli_state
@@ -954,12 +954,12 @@ impl<'d> Channel<'d> {
     }
 
     /// Create a linked-list DMA transfer.
-    pub unsafe fn linked_list<'a, const ITEM_COUNT: usize>(
+    pub unsafe fn linked_list<'a, const N: usize>(
         &'a mut self,
-        table: Table<ITEM_COUNT>,
+        table: &'a Table<N>,
         options: TransferOptions,
-    ) -> LinkedListTransfer<'a, ITEM_COUNT> {
-        self.configure_linked_list(&table, options);
+    ) -> LinkedListTransfer<'a> {
+        self.configure_linked_list(table, options);
         self.start();
 
         LinkedListTransfer {
@@ -971,12 +971,12 @@ impl<'d> Channel<'d> {
 
 /// Linked-list DMA transfer.
 #[must_use = "futures do nothing unless you `.await` or poll them"]
-pub struct LinkedListTransfer<'a, const ITEM_COUNT: usize> {
+pub struct LinkedListTransfer<'a> {
     channel: Channel<'a>,
     _wake_guard: WakeGuard,
 }
 
-impl<'a, const ITEM_COUNT: usize> LinkedListTransfer<'a, ITEM_COUNT> {
+impl<'a> LinkedListTransfer<'a> {
     /// Request the transfer to pause, keeping the existing configuration for this channel.
     ///
     /// To resume the transfer, call [`request_resume`](Self::request_resume) again.
@@ -1023,7 +1023,7 @@ impl<'a, const ITEM_COUNT: usize> LinkedListTransfer<'a, ITEM_COUNT> {
     }
 }
 
-impl<'a, const ITEM_COUNT: usize> Drop for LinkedListTransfer<'a, ITEM_COUNT> {
+impl<'a> Drop for LinkedListTransfer<'a> {
     fn drop(&mut self) {
         self.request_reset();
 
@@ -1032,8 +1032,8 @@ impl<'a, const ITEM_COUNT: usize> Drop for LinkedListTransfer<'a, ITEM_COUNT> {
     }
 }
 
-impl<'a, const ITEM_COUNT: usize> Unpin for LinkedListTransfer<'a, ITEM_COUNT> {}
-impl<'a, const ITEM_COUNT: usize> Future for LinkedListTransfer<'a, ITEM_COUNT> {
+impl<'a> Unpin for LinkedListTransfer<'a> {}
+impl<'a> Future for LinkedListTransfer<'a> {
     type Output = ();
     fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
         let state = &STATE[self.channel.channel as usize];

--- a/embassy-stm32/src/dma/mod.rs
+++ b/embassy-stm32/src/dma/mod.rs
@@ -10,6 +10,8 @@ pub use dma_bdma::*;
 #[cfg(any(gpdma, lpdma))]
 pub(crate) mod gpdma;
 #[cfg(any(gpdma, lpdma))]
+pub use gpdma::linked_list::{LinearItem, RunMode, Table};
+#[cfg(any(gpdma, lpdma))]
 pub use gpdma::ringbuffered::*;
 #[cfg(any(gpdma, lpdma))]
 pub use gpdma::*;


### PR DESCRIPTION
make more features of gpdma available:
- Fix soundness issue where Channel::linked_list() took Table by value, dropping the descriptor memory while DMA was still reading from it. It now borrows &'a Table<N> so the compiler ties the table's lifetime to the transfer.
- Remove the unused const ITEM_COUNT generic from LinkedListTransfer -- item count is tracked at runtime in lli_state, the generic just added noise to type signatures.
- Make LinearItem::link_to(), unlink(), and transfer_count() public so users can build custom descriptor topologies (not just sequential/circular).
- Add TransferCompleteMode enum (EachBlock, EachLinkedListItem, LastLinkedListItem) to control when TC/HT events fire, with per-item support via LinearItem::set_transfer_complete_mode().
- Set SAP/DAP port assignments in LinearItem for GPDMA, matching the existing non-linked-list Channel::configure() logic.
- Add Channel::restart_linked_list() for restarting a chain from item 0.
- Re-export Table, LinearItem, RunMode from embassy_stm32::dma for ergonomic imports.
