### PR TITLE
mcxa/i3c: treat DAA COMPLETE as normal termination, not an error

### DIFF
--- a/embassy-mcxa/src/i3c/controller.rs
+++ b/embassy-mcxa/src/i3c/controller.rs
@@ -726,8 +726,10 @@ impl<'d, M: Mode> I3c<'d, M> {
             w.set_request(Request::Processdaa);
         });
 
-        // Here
-        for device in devices {
+        // Enumerate responding targets. The loop is bounded by the caller's
+        // `devices` slice; DAA itself ends when no further target arbitrates,
+        // which the hardware signals via `mstatus.complete()` (see below).
+        'daa: for device in devices {
             // Wait for controller event
             loop {
                 let s = self.info.regs().mstatus().read();
@@ -737,7 +739,11 @@ impl<'d, M: Mode> I3c<'d, M> {
                 }
 
                 if s.complete() {
-                    return Err(IOError::Other);
+                    // DAA finished: no further target arbitrated. Every target
+                    // that responded has already been decoded and assigned in a
+                    // previous iteration, so this is the normal end of the
+                    // sequence, not an error. Fall through to the cleanup below.
+                    break 'daa;
                 }
 
                 if s.mctrldone() && s.state() == State::Daa {


### PR DESCRIPTION
## Description

### Symptom

`Controller::daa()` fails any Dynamic Address Assignment where the caller's
`devices` slice is larger than the number of targets physically on the bus —
which is the normal, defensive way to size that buffer. With a single target and
a slice of length > 1, DAA completes correctly on the wire (the target's
PID/BCR/DCR are read and its dynamic address is assigned), but the function
returns `Err(IOError::Other)` instead of `Ok(())`. Callers that size the slice to
exactly the device count avoid it by luck; anyone who leaves headroom cannot
enumerate a target at all.

### Root cause

The enumeration loop is bounded by the caller's slice, not by the DAA state
machine:

```rust
for device in devices {
    loop {
        let s = self.info.regs().mstatus().read();
        if s.errwarn() { return self.status(); }
        if s.complete() { return Err(IOError::Other); }   // <-- here
        if s.mctrldone() && s.state() == State::Daa { break; }
    }
    // ... decode PID/BCR/DCR, write DA, retrigger ProcessDAA ...
}
```

`mstatus.complete()` is the **normal** terminal condition of a DAA round: the
controller asserts it once no further target arbitrates for an address. By the
time the loop observes it, every target that responded has already been decoded
and assigned in a previous iteration. Treating that signal as `Err(IOError::Other)`
turns a fully successful assignment into a failure whenever there is at least one
spare slot left in `devices`.

### Fix

Treat `complete()` as the normal end of the sequence. Label the enumeration loop
and `break` out of it, falling through to the existing flag/error cleanup and the
`Ok(())` return, with the already-populated `devices` entries intact:

```rust
'daa: for device in devices {
    loop {
        let s = self.info.regs().mstatus().read();
        if s.errwarn() { return self.status(); }
        if s.complete() { break 'daa; }   // normal termination
        if s.mctrldone() && s.state() == State::Daa { break; }
    }
    // ...
}
self.clear_flags();
self.clear_errors();
Ok(())
```

Genuine failures are unaffected: the bus-not-idle and address-range checks return
`Err` before the loop, and `errwarn` inside the loop still returns
`self.status()`.

### Evidence

- `cargo build -p embassy-mcxa --target thumbv8m.main-none-eabihf --features mcxa5xx,unstable-pac,defmt` — clean.
- `cargo fmt -- --check` on `embassy-mcxa` — clean.
- Verified on NXP **MCXA-family** hardware with a **P3T1755** temperature sensor as
  the I3C target, flashed with `probe-rs` and logging over `defmt` RTT. Before the
  fix, `Controller::daa()` returned `Err(IOError::Other)` even though the target's
  PID/BCR/DCR were correctly decoded and its dynamic address was assigned on the bus;
  after the fix it returns `Ok(())` with the populated `devices` entries intact.
  Resetting and re-running DAA re-enumerates the target reproducibly.
- Independently confirmed with a **logic-analyzer capture** of the ENTDAA exchange:
  dynamic address **0x08** (valid parity), **BCR = 0x03**, **DCR = 0x63**, and
  **PID = MIPI manufacturer 0x011B (NXP) / part 0x152A0090** — matching the driver's
  decode. (Maintainer note: decode the 64-bit ENTDAA data phase as one continuous
  PID+BCR+DCR field, not as a sequence of 9-bit SDR bytes; mis-framing it shifts the
  grouping and yields bogus values such as `BCR=0xD8 DCR=0x88`.)

> NOTE: a follow-on addressed SDR write to the freshly-assigned target was not
> exercised as a data round-trip here — the P3T1755 is a temperature sensor, not a
> loopback device — so read/write payload validation awaits a dedicated I3C target.
> This is unrelated to DAA; the address assignment itself is confirmed.
