### PR TITLE
usb-synopsys-otg: allow 8th IN endpoint TX FIFO register

### DIFF
--- a/embassy-usb-synopsys-otg/src/otg_v1.rs
+++ b/embassy-usb-synopsys-otg/src/otg_v1.rs
@@ -252,7 +252,7 @@ impl Otg {
     #[doc = "Device IN endpoint transmit FIFO size register"]
     #[inline(always)]
     pub const fn dieptxf(self, n: usize) -> Reg<regs::Fsiz, RW> {
-        core::assert!(n < 7usize);
+        core::assert!(n < 8usize);
         unsafe { Reg::from_ptr(self.ptr.add(0x0104usize + n * 4usize) as _) }
     }
     #[doc = "Host configuration register"]


### PR DESCRIPTION
This allows using all 8 (plus special ep0) endpoints on devices like STM32H729. I'm not sure if this assert is necessary, because endpoint count is limited by `ENDPOINT_COUNT` const in `embassy-stm32` so if there is a new device in the future with even more endpoints, this assert will have to be adjusted again.