### PR TITLE
boot: fix build with log and ed25519-salty features

### DIFF
--- a/embassy-boot/src/firmware_updater/asynch.rs
+++ b/embassy-boot/src/firmware_updater/asynch.rs
@@ -115,6 +115,7 @@ impl<'d, DFU: NorFlash, STATE: NorFlash> FirmwareUpdater<'d, DFU, STATE> {
             use salty::{PublicKey, Signature};
 
             use crate::digest_adapters::salty::Sha512;
+            use crate::fmt::Bytes;
 
             fn into_signature_error<E>(_: E) -> FirmwareUpdaterError {
                 FirmwareUpdaterError::Signature(signature::Error::default())
@@ -130,9 +131,9 @@ impl<'d, DFU: NorFlash, STATE: NorFlash> FirmwareUpdater<'d, DFU, STATE> {
             let r = public_key.verify(&message, &signature);
             trace!(
                 "Verifying with public key {}, signature {} and message {} yields ok: {}",
-                public_key.to_bytes(),
-                signature.to_bytes(),
-                message,
+                Bytes(&public_key.to_bytes()),
+                Bytes(&signature.to_bytes()),
+                Bytes(&message),
                 r.is_ok()
             );
             r.map_err(into_signature_error)?;

--- a/embassy-boot/src/firmware_updater/blocking.rs
+++ b/embassy-boot/src/firmware_updater/blocking.rs
@@ -150,6 +150,7 @@ impl<'d, DFU: NorFlash, STATE: NorFlash> BlockingFirmwareUpdater<'d, DFU, STATE>
             use salty::{PublicKey, Signature};
 
             use crate::digest_adapters::salty::Sha512;
+            use crate::fmt::Bytes;
 
             fn into_signature_error<E>(_: E) -> FirmwareUpdaterError {
                 FirmwareUpdaterError::Signature(signature::Error::default())
@@ -165,9 +166,9 @@ impl<'d, DFU: NorFlash, STATE: NorFlash> BlockingFirmwareUpdater<'d, DFU, STATE>
             let r = public_key.verify(&message, &signature);
             trace!(
                 "Verifying with public key {}, signature {} and message {} yields ok: {}",
-                public_key.to_bytes(),
-                signature.to_bytes(),
-                message,
+                Bytes(&public_key.to_bytes()),
+                Bytes(&signature.to_bytes()),
+                Bytes(&message),
                 r.is_ok()
             );
             r.map_err(into_signature_error)?;


### PR DESCRIPTION
embassy-boot doesn't build with the log and ed25519-salty features together. The trace! call in verify_and_mark_updated passes the public key, signature and message as [u8; 32] and [u8; 64] arrays. defmt formats arrays, but log goes through format_args!, which wants Display, and arrays only implement Debug.

Wrapped the three arguments in the Bytes helper that already sits in fmt.rs, the same one cyw43 and esp-hosted use for buffers. Under defmt the bytes now print as hex rather than the raw array encoding.

CI builds embassy-boot with ed25519-salty and with ed25519-dalek, but never with log on top, so that pair isn't covered today.

Closes #4632
