### PR TITLE
stm32/timer: improve set_frequency

### DIFF
--- a/embassy-stm32/src/timer/complementary_pwm.rs
+++ b/embassy-stm32/src/timer/complementary_pwm.rs
@@ -467,8 +467,12 @@ impl<'d, T: AdvancedInstance4Channel> ComplementaryPwm<'d, T> {
 
     /// Set PWM frequency.
     ///
+    /// In the edge-aligned mode, the timer will wrap-around at the same frequency as is being set
+    /// In the center-aligned mode, its the frequency of the timer counting both up and down,
+    /// so wrap-around frequency is effectively halved.
+    ///
     /// The actual frequency may differ from the requested value due to hardware
-    /// limitations. The timer will round towards a slower (longer) period.
+    /// limitations. The timer will round towards a longer period (slower).
     ///
     /// Note: that the frequency will not be applied in the timer until an update event
     /// occurs.
@@ -478,8 +482,11 @@ impl<'d, T: AdvancedInstance4Channel> ComplementaryPwm<'d, T> {
 
     /// Set the PWM period in milliseconds.
     ///
+    /// In the edge-aligned mode, the timer will wrap-around in given period.
+    /// In the center-aligned mode, given period includes counting both up and down.
+    ///
     /// The actual period may differ from the requested value due to hardware
-    /// limitations. The timer will round towards a slower (longer) period.
+    /// limitations. The timer will round towards a longer period (slower).
     ///
     /// Note: that the period will not be applied in the timer until an update event
     /// occurs.
@@ -489,8 +496,11 @@ impl<'d, T: AdvancedInstance4Channel> ComplementaryPwm<'d, T> {
 
     /// Set the PWM period in microseconds.
     ///
+    /// In the edge-aligned mode, the timer will wrap-around in given period.
+    /// In the center-aligned mode, given period includes counting both up and down.
+    ///
     /// The actual period may differ from the requested value due to hardware
-    /// limitations. The timer will round towards a slower (longer) period.
+    /// limitations. The timer will round towards a longer period (slower).
     ///
     /// Note: that the period will not be applied in the timer until an update event
     /// occurs.
@@ -500,8 +510,11 @@ impl<'d, T: AdvancedInstance4Channel> ComplementaryPwm<'d, T> {
 
     /// Set the PWM period in seconds.
     ///
+    /// In the edge-aligned mode, the timer will wrap-around in given period.
+    /// In the center-aligned mode, given period includes counting both up and down.
+    ///
     /// The actual period may differ from the requested value due to hardware
-    /// limitations. The timer will round towards a slower (longer) period.
+    /// limitations. The timer will round towards a longer period (slower).
     ///
     /// Note: that the period will not be applied in the timer until an update event
     /// occurs.
@@ -511,8 +524,11 @@ impl<'d, T: AdvancedInstance4Channel> ComplementaryPwm<'d, T> {
 
     /// Set the PWM period using an `embassy_time::Duration`.
     ///
+    /// In the edge-aligned mode, the timer will wrap-around in given period.
+    /// In the center-aligned mode, given period includes counting both up and down.
+    ///
     /// The actual period may differ from the requested value due to hardware
-    /// limitations. The timer will round towards a slower (longer) period.
+    /// limitations. The timer will round towards a longer period (slower).
     ///
     /// Note: that the period will not be applied in the timer until an update event
     /// occurs.

--- a/embassy-stm32/src/timer/complementary_pwm.rs
+++ b/embassy-stm32/src/timer/complementary_pwm.rs
@@ -473,14 +473,7 @@ impl<'d, T: AdvancedInstance4Channel> ComplementaryPwm<'d, T> {
     /// Note: that the frequency will not be applied in the timer until an update event
     /// occurs.
     pub fn set_frequency(&mut self, freq: Hertz) {
-        let multiplier = if self.inner.get_counting_mode().is_center_aligned() {
-            2u64
-        } else {
-            1u64
-        };
-        let timer_f = T::frequency().0 as u64;
-        let clocks = timer_f / (freq.0 as u64 * multiplier);
-        self.inner.set_period_clocks_internal(clocks, RoundTo::Slower, 16);
+        self.inner.set_frequency(freq, RoundTo::Slower);
     }
 
     /// Set the PWM period in milliseconds.
@@ -491,12 +484,7 @@ impl<'d, T: AdvancedInstance4Channel> ComplementaryPwm<'d, T> {
     /// Note: that the period will not be applied in the timer until an update event
     /// occurs.
     pub fn set_period_ms(&mut self, ms: u32) {
-        let timer_f = T::frequency().0 as u64;
-        let mut clocks = timer_f * ms as u64 / 1_000;
-        if self.inner.get_counting_mode().is_center_aligned() {
-            clocks = clocks / 2;
-        }
-        self.inner.set_period_clocks(clocks, RoundTo::Slower);
+        self.inner.set_period_ms(ms, RoundTo::Slower);
     }
 
     /// Set the PWM period in microseconds.
@@ -507,12 +495,7 @@ impl<'d, T: AdvancedInstance4Channel> ComplementaryPwm<'d, T> {
     /// Note: that the period will not be applied in the timer until an update event
     /// occurs.
     pub fn set_period_us(&mut self, us: u32) {
-        let timer_f = T::frequency().0 as u64;
-        let mut clocks = timer_f * us as u64 / 1_000_000;
-        if self.inner.get_counting_mode().is_center_aligned() {
-            clocks = clocks / 2;
-        }
-        self.inner.set_period_clocks(clocks, RoundTo::Slower);
+        self.inner.set_period_us(us, RoundTo::Slower);
     }
 
     /// Set the PWM period in seconds.
@@ -523,12 +506,7 @@ impl<'d, T: AdvancedInstance4Channel> ComplementaryPwm<'d, T> {
     /// Note: that the period will not be applied in the timer until an update event
     /// occurs.
     pub fn set_period_secs(&mut self, secs: u32) {
-        let timer_f = T::frequency().0 as u64;
-        let mut clocks = timer_f * secs as u64;
-        if self.inner.get_counting_mode().is_center_aligned() {
-            clocks = clocks / 2;
-        }
-        self.inner.set_period_clocks(clocks, RoundTo::Slower);
+        self.inner.set_period_secs(secs, RoundTo::Slower);
     }
 
     /// Set the PWM period using an `embassy_time::Duration`.
@@ -540,12 +518,7 @@ impl<'d, T: AdvancedInstance4Channel> ComplementaryPwm<'d, T> {
     /// occurs.
     #[cfg(feature = "time")]
     pub fn set_period(&mut self, period: embassy_time::Duration) {
-        let timer_f = T::frequency().0 as u64;
-        let mut clocks = timer_f * period.as_ticks() / embassy_time::TICK_HZ;
-        if self.inner.get_counting_mode().is_center_aligned() {
-            clocks = clocks / 2;
-        }
-        self.inner.set_period_clocks(clocks, RoundTo::Slower);
+        self.inner.set_period(period, RoundTo::Slower);
     }
 
     /// Get max duty value.

--- a/embassy-stm32/src/timer/low_level.rs
+++ b/embassy-stm32/src/timer/low_level.rs
@@ -487,7 +487,10 @@ impl<'d, T: CoreInstance> Timer<'d, T> {
     /// The timer will count for `clocks` clock cycles before wrapping.
     /// The actual period may differ from the requested value due to hardware
     /// limitations; the `round` parameter controls how rounding is performed.
-    pub fn set_period_clocks(&self, clocks: u64, round: RoundTo) {
+    pub fn set_period_clocks(&self, mut clocks: u64, round: RoundTo) {
+        if T::is_center_aligned() {
+            clocks = clocks / 2;
+        }
         self.set_period_clocks_internal(clocks, round, T::Word::bits());
     }
 

--- a/embassy-stm32/src/timer/low_level.rs
+++ b/embassy-stm32/src/timer/low_level.rs
@@ -484,7 +484,9 @@ impl<'d, T: CoreInstance> Timer<'d, T> {
 
     /// Set the timer period in timer clock cycles.
     ///
-    /// The timer will count for `clocks` clock cycles before wrapping.
+    /// In the edge-aligned mode, the timer will wrap in given clock cycles.
+    /// In the center-aligned mode, the timer will count up and down in given clock cycles.
+    ///
     /// The actual period may differ from the requested value due to hardware
     /// limitations; the `round` parameter controls how rounding is performed.
     pub fn set_period_clocks(&self, mut clocks: u64, round: RoundTo) {
@@ -507,12 +509,11 @@ impl<'d, T: CoreInstance> Timer<'d, T> {
         regs.arr().write_value(arr.into());
     }
 
-    /// Set the frequency of how many times per second the timer counts up to the max value or down to 0.
+    /// Set the frequency - how many times per second.
     ///
-    /// This means that in the default edge-aligned mode,
-    /// the timer counter will wrap around at the same frequency as is being set.
-    /// In center-aligned mode (which not all timers support), the wrap-around frequency is effectively halved
-    /// because it needs to count up and down.
+    /// In the edge-aligned mode, the timer will wrap-around at the same frequency as is being set
+    /// In the center-aligned mode, its the frequency of the timer counting both up and down,
+    /// so wrap-around frequency is effectively halved.
     ///
     /// The actual frequency may differ from the requested value due to hardware
     /// limitations; the `round` parameter controls how rounding is performed.
@@ -526,6 +527,9 @@ impl<'d, T: CoreInstance> Timer<'d, T> {
 
     /// Set the timer period in milliseconds.
     ///
+    /// In the edge-aligned mode, the timer will wrap-around in given period.
+    /// In the center-aligned mode, given period includes counting both up and down.
+    ///
     /// The actual period may differ from the requested value due to hardware
     /// limitations; the `round` parameter controls how rounding is performed.
     pub fn set_period_ms(&self, ms: u32, round: RoundTo) {
@@ -535,6 +539,9 @@ impl<'d, T: CoreInstance> Timer<'d, T> {
     }
 
     /// Set the timer period in microseconds.
+    ///
+    /// In the edge-aligned mode, the timer will wrap-around in given period.
+    /// In the center-aligned mode, given period includes counting both up and down.
     ///
     /// The actual period may differ from the requested value due to hardware
     /// limitations; the `round` parameter controls how rounding is performed.
@@ -546,6 +553,9 @@ impl<'d, T: CoreInstance> Timer<'d, T> {
 
     /// Set the timer period in seconds.
     ///
+    /// In the edge-aligned mode, the timer will wrap-around in given period.
+    /// In the center-aligned mode, given period includes counting both up and down.
+    ///
     /// The actual period may differ from the requested value due to hardware
     /// limitations; the `round` parameter controls how rounding is performed.
     pub fn set_period_secs(&self, secs: u32, round: RoundTo) {
@@ -555,6 +565,9 @@ impl<'d, T: CoreInstance> Timer<'d, T> {
     }
 
     /// Set the timer period using an `embassy_time::Duration`.
+    ///
+    /// In the edge-aligned mode, the timer will wrap-around in given period.
+    /// In the center-aligned mode, given period includes counting both up and down.
     ///
     /// The actual period may differ from the requested value due to hardware
     /// limitations; the `round` parameter controls how rounding is performed.

--- a/embassy-stm32/src/timer/mod.rs
+++ b/embassy-stm32/src/timer/mod.rs
@@ -159,9 +159,13 @@ trait SealedInstance: RccPeripheral + PeripheralType {
     fn state() -> &'static State;
 }
 
+trait CenterAligned {
+    fn is_center_aligned() -> bool;
+}
+
 /// Core timer instance.
 #[allow(private_bounds)]
-pub trait CoreInstance: SealedInstance + 'static {
+pub trait CoreInstance: SealedInstance + CenterAligned + 'static {
     /// Update Interrupt for this timer.
     type UpdateInterrupt: interrupt::typelevel::Interrupt;
 
@@ -313,11 +317,35 @@ macro_rules! impl_general_4ch_blank_sealed {
     };
 }
 
+#[allow(unused)]
+macro_rules! impl_never_center_aligned {
+    ($inst:ident) => {
+        impl CenterAligned for crate::peripherals::$inst {
+            fn is_center_aligned() -> bool {
+                false
+            }
+        }
+    };
+}
+
+#[allow(unused)]
+macro_rules! impl_maybe_center_aligned {
+    ($inst:ident) => {
+        impl CenterAligned for crate::peripherals::$inst {
+            fn is_center_aligned() -> bool {
+                let cr1 = unsafe { crate::pac::timer::TimGp16::from_ptr(Self::regs()) }.cr1().read();
+                low_level::CountingMode::from((cr1.cms(), cr1.dir())).is_center_aligned()
+            }
+        }
+    };
+}
+
 foreach_interrupt! {
     ($inst:ident, timer, TIM_BASIC, UP, $irq:ident) => {
         impl_core_timer!($inst, u16);
         impl BasicNoCr2Instance for crate::peripherals::$inst {}
         impl BasicInstance for crate::peripherals::$inst {}
+        impl_never_center_aligned!($inst);
     };
 
     ($inst:ident, timer, TIM_1CH, UP, $irq:ident) => {
@@ -327,6 +355,7 @@ foreach_interrupt! {
         impl_general_1ch!($inst);
         impl_general_2ch!($inst);
         impl GeneralInstance4Channel for crate::peripherals::$inst {}
+        impl_maybe_center_aligned!($inst);
         impl General4ChBlankSealed for crate::peripherals::$inst {}
     };
 
@@ -337,6 +366,7 @@ foreach_interrupt! {
         impl_general_1ch!($inst);
         impl_general_2ch!($inst);
         impl GeneralInstance4Channel for crate::peripherals::$inst {}
+        impl_maybe_center_aligned!($inst);
         impl General4ChBlankSealed for crate::peripherals::$inst {}
     };
 
@@ -347,6 +377,7 @@ foreach_interrupt! {
         impl_general_1ch!($inst);
         impl_general_2ch!($inst);
         impl GeneralInstance4Channel for crate::peripherals::$inst {}
+        impl_maybe_center_aligned!($inst);
         impl General4ChBlankSealed for crate::peripherals::$inst {}
     };
 
@@ -357,6 +388,7 @@ foreach_interrupt! {
         impl_general_1ch!($inst);
         impl_general_2ch!($inst);
         impl GeneralInstance4Channel for crate::peripherals::$inst {}
+        impl_maybe_center_aligned!($inst);
         impl GeneralInstance32bit4Channel for crate::peripherals::$inst {}
         impl General4ChBlankSealed for crate::peripherals::$inst {}
     };
@@ -368,6 +400,7 @@ foreach_interrupt! {
         impl_general_1ch!($inst);
         impl_general_2ch!($inst);
         impl GeneralInstance4Channel for crate::peripherals::$inst {}
+        impl_maybe_center_aligned!($inst);
         impl_general_4ch_blank_sealed!($inst);
         impl_advanced_1ch!($inst);
         impl AdvancedInstance2Channel for crate::peripherals::$inst {}
@@ -381,6 +414,7 @@ foreach_interrupt! {
         impl_general_1ch!($inst);
         impl_general_2ch!($inst);
         impl GeneralInstance4Channel for crate::peripherals::$inst {}
+        impl_maybe_center_aligned!($inst);
         impl_general_4ch_blank_sealed!($inst);
         impl_advanced_1ch!($inst);
         impl AdvancedInstance2Channel for crate::peripherals::$inst {}
@@ -394,6 +428,7 @@ foreach_interrupt! {
         impl_general_1ch!($inst);
         impl_general_2ch!($inst);
         impl GeneralInstance4Channel for crate::peripherals::$inst {}
+        impl_maybe_center_aligned!($inst);
         impl_general_4ch_blank_sealed!($inst);
         impl_advanced_1ch!($inst);
         impl AdvancedInstance2Channel for crate::peripherals::$inst {}

--- a/embassy-stm32/src/timer/mod.rs
+++ b/embassy-stm32/src/timer/mod.rs
@@ -333,7 +333,9 @@ macro_rules! impl_maybe_center_aligned {
     ($inst:ident) => {
         impl CenterAligned for crate::peripherals::$inst {
             fn is_center_aligned() -> bool {
-                let cr1 = unsafe { crate::pac::timer::TimGp16::from_ptr(Self::regs()) }.cr1().read();
+                let cr1 = unsafe { crate::pac::timer::TimGp16::from_ptr(Self::regs()) }
+                    .cr1()
+                    .read();
                 low_level::CountingMode::from((cr1.cms(), cr1.dir())).is_center_aligned()
             }
         }

--- a/embassy-stm32/src/timer/simple_pwm.rs
+++ b/embassy-stm32/src/timer/simple_pwm.rs
@@ -366,15 +366,7 @@ impl<'d, T: GeneralInstance4Channel> SimplePwm<'d, T> {
     /// Note: that the frequency will not be applied in the timer until an update event
     /// occurs.
     pub fn set_frequency(&mut self, freq: Hertz) {
-        // TODO: prevent ARR = u16::MAX?
-        let multiplier = if self.inner.get_counting_mode().is_center_aligned() {
-            2u64
-        } else {
-            1u64
-        };
-        let timer_f = T::frequency().0 as u64;
-        let clocks = timer_f / (freq.0 as u64 * multiplier);
-        self.inner.set_period_clocks_internal(clocks, RoundTo::Slower, 16);
+        self.inner.set_frequency(freq, RoundTo::Slower);
     }
 
     /// Get the PWM driver frequency.
@@ -390,12 +382,7 @@ impl<'d, T: GeneralInstance4Channel> SimplePwm<'d, T> {
     /// Note: that the period will not be applied in the timer until an update event
     /// occurs.
     pub fn set_period_ms(&mut self, ms: u32) {
-        let timer_f = T::frequency().0 as u64;
-        let mut clocks = timer_f * ms as u64 / 1_000;
-        if self.inner.get_counting_mode().is_center_aligned() {
-            clocks = clocks / 2;
-        }
-        self.inner.set_period_clocks(clocks, RoundTo::Slower);
+        self.inner.set_period_ms(ms, RoundTo::Slower);
     }
 
     /// Set PWM period in microseconds.
@@ -406,12 +393,7 @@ impl<'d, T: GeneralInstance4Channel> SimplePwm<'d, T> {
     /// Note: that the period will not be applied in the timer until an update event
     /// occurs.
     pub fn set_period_us(&mut self, us: u32) {
-        let timer_f = T::frequency().0 as u64;
-        let mut clocks = timer_f * us as u64 / 1_000_000;
-        if self.inner.get_counting_mode().is_center_aligned() {
-            clocks = clocks / 2;
-        }
-        self.inner.set_period_clocks(clocks, RoundTo::Slower);
+        self.inner.set_period_us(us, RoundTo::Slower);
     }
 
     /// Set PWM period in seconds.
@@ -422,12 +404,7 @@ impl<'d, T: GeneralInstance4Channel> SimplePwm<'d, T> {
     /// Note: that the period will not be applied in the timer until an update event
     /// occurs.
     pub fn set_period_secs(&mut self, secs: u32) {
-        let timer_f = T::frequency().0 as u64;
-        let mut clocks = timer_f * secs as u64;
-        if self.inner.get_counting_mode().is_center_aligned() {
-            clocks = clocks / 2;
-        }
-        self.inner.set_period_clocks(clocks, RoundTo::Slower);
+        self.inner.set_period_secs(secs, RoundTo::Slower);
     }
 
     /// Set PWM period using an `embassy_time::Duration`.
@@ -439,12 +416,7 @@ impl<'d, T: GeneralInstance4Channel> SimplePwm<'d, T> {
     /// occurs.
     #[cfg(feature = "time")]
     pub fn set_period(&mut self, period: embassy_time::Duration) {
-        let timer_f = T::frequency().0 as u64;
-        let mut clocks = timer_f * period.as_ticks() / embassy_time::TICK_HZ;
-        if self.inner.get_counting_mode().is_center_aligned() {
-            clocks = clocks / 2;
-        }
-        self.inner.set_period_clocks(clocks, RoundTo::Slower);
+        self.inner.set_period(period, RoundTo::Slower);
     }
 
     /// Get max duty value.

--- a/embassy-stm32/src/timer/simple_pwm.rs
+++ b/embassy-stm32/src/timer/simple_pwm.rs
@@ -360,8 +360,12 @@ impl<'d, T: GeneralInstance4Channel> SimplePwm<'d, T> {
 
     /// Set PWM frequency.
     ///
+    /// In the edge-aligned mode, the timer will wrap-around at the same frequency as is being set
+    /// In the center-aligned mode, its the frequency of the timer counting both up and down,
+    /// so wrap-around frequency is effectively halved.
+    ///
     /// The actual frequency may differ from the requested value due to hardware
-    /// limitations. The timer will round towards a slower (longer) period.
+    /// limitations. The timer will round towards a longer period (slower).
     ///
     /// Note: that the frequency will not be applied in the timer until an update event
     /// occurs.
@@ -376,8 +380,11 @@ impl<'d, T: GeneralInstance4Channel> SimplePwm<'d, T> {
 
     /// Set PWM period in milliseconds.
     ///
+    /// In the edge-aligned mode, the timer will wrap-around in given period.
+    /// In the center-aligned mode, given period includes counting both up and down.
+    ///
     /// The actual period may differ from the requested value due to hardware
-    /// limitations. The timer will round towards a slower (longer) period.
+    /// limitations. The timer will round towards a longer period (slower).
     ///
     /// Note: that the period will not be applied in the timer until an update event
     /// occurs.
@@ -387,8 +394,11 @@ impl<'d, T: GeneralInstance4Channel> SimplePwm<'d, T> {
 
     /// Set PWM period in microseconds.
     ///
+    /// In the edge-aligned mode, the timer will wrap-around in given period.
+    /// In the center-aligned mode, given period includes counting both up and down.
+    ///
     /// The actual period may differ from the requested value due to hardware
-    /// limitations. The timer will round towards a slower (longer) period.
+    /// limitations. The timer will round towards a longer period (slower).
     ///
     /// Note: that the period will not be applied in the timer until an update event
     /// occurs.
@@ -398,8 +408,11 @@ impl<'d, T: GeneralInstance4Channel> SimplePwm<'d, T> {
 
     /// Set PWM period in seconds.
     ///
+    /// In the edge-aligned mode, the timer will wrap-around in given period.
+    /// In the center-aligned mode, given period includes counting both up and down.
+    ///
     /// The actual period may differ from the requested value due to hardware
-    /// limitations. The timer will round towards a slower (longer) period.
+    /// limitations. The timer will round towards a longer period (slower).
     ///
     /// Note: that the period will not be applied in the timer until an update event
     /// occurs.
@@ -409,8 +422,11 @@ impl<'d, T: GeneralInstance4Channel> SimplePwm<'d, T> {
 
     /// Set PWM period using an `embassy_time::Duration`.
     ///
+    /// In the edge-aligned mode, the timer will wrap-around in given period.
+    /// In the center-aligned mode, given period includes counting both up and down.
+    ///
     /// The actual period may differ from the requested value due to hardware
-    /// limitations. The timer will round towards a slower (longer) period.
+    /// limitations. The timer will round towards a longer period (slower).
     ///
     /// Note: that the period will not be applied in the timer until an update event
     /// occurs.


### PR DESCRIPTION
Makes `set_frequency` and other functions in low level timer respect counting mode. That way simple pwm and complementary pwm can also reuse the same implementation.

I'm only not sure if `CenterAligned` trait is a correct/preferred implementation approach.