### PR TITLE
Add embassy-ambiq HAL: groundwork and examples

### DIFF
--- a/embassy-ambiq/Cargo.toml
+++ b/embassy-ambiq/Cargo.toml
@@ -1,0 +1,79 @@
+[package]
+name = "embassy-ambiq"
+version = "0.1.0"
+edition = "2024"
+description = "Embassy Hardware Abstraction Layer for Ambiq microcontrollers"
+license = "MIT OR Apache-2.0"
+repository = "https://github.com/embassy-rs/embassy"
+documentation = "https://docs.embassy.dev/embassy-ambiq"
+
+[package.metadata.embassy]
+build = [
+    { target = "thumbv7em-none-eabihf", features = ["apollo3", "time-driver-stimer-xtal-32768"] }
+]
+
+[package.metadata.docs.rs]
+features = ["apollo3", "time-driver-stimer-xtal-32768"]
+rustdoc-args = ["--cfg", "docsrs"]
+[dependencies]
+# Embassy Core
+embassy-hal-internal = { version = "0.5.0", path = "../embassy-hal-internal", features = ["cortex-m", "prio-bits-3"] }
+embassy-sync = { version = "0.8.0", path = "../embassy-sync" }
+embassy-time-driver = { version = "0.2.2", path = "../embassy-time-driver", optional = true }
+embassy-time-queue-utils = { version = "0.3.2", path = "../embassy-time-queue-utils", optional = true }
+
+# HAL Traits
+embedded-hal = "1.0"
+embedded-hal-async = "1.0"
+
+# ARM Cortex-M basics
+cortex-m = "0.7"
+cortex-m-rt = "0.7"
+critical-section = "1.1"
+
+# Logging
+defmt = { version = "0.3", optional = true }
+
+# Macro helpers
+paste = "1.0"
+
+# Device PACs 
+[dependencies.apollo3-pac]
+version = "0.2.0"
+optional = true
+features = ["rt"]
+
+[features]
+default = ["apollo3", "time-driver-stimer-xtal-32768"]
+
+# --- Time driver ---
+# Enable AT MOST ONE `time-driver-*` backend. Each one bundles the hardware timer, its
+# clock source, AND the matching embassy-time tick rate, so there is no separate knob to
+# get wrong.
+_time-driver = ["dep:embassy-time-driver", "dep:embassy-time-queue-utils"]
+
+## STIMER from the 32.768 kHz crystal — the divider sets the tick rate:
+time-driver-stimer-xtal-32768 = ["_time-driver", "_stimer", "_xtal-div1",  "embassy-time-driver?/tick-hz-32_768"] # XTAL/1  = 32768 Hz
+time-driver-stimer-xtal-16384 = ["_time-driver", "_stimer", "_xtal-div2",  "embassy-time-driver?/tick-hz-16_384"] # XTAL/2  = 16384 Hz
+time-driver-stimer-xtal-1024  = ["_time-driver", "_stimer", "_xtal-div32", "embassy-time-driver?/tick-hz-1_024"]  # XTAL/32 = 1024 Hz
+## STIMER from the LFRC (~1 kHz, uncalibrated, lowest power).
+time-driver-stimer-lfrc       = ["_time-driver", "_stimer", "_lfrc",       "embassy-time-driver?/tick-hz-1_024"]
+## CTIMER0 @ 1 MHz, HFRC/16. EXPERIMENTAL: the continuous-mode compare is one-shot, so
+## alarms do not re-arm (blinks once). Kept for reference only.
+time-driver-ctimer0           = ["_time-driver", "embassy-time-driver?/tick-hz-1_000_000"]
+
+# Internal markers — do not enable directly.
+_stimer = []
+_xtal-div1 = []
+_xtal-div2 = []
+_xtal-div32 = []
+_lfrc = []
+
+# Chip features
+apollo3 = ["dep:apollo3-pac"]
+
+# Bootloader features
+svl-vtor = []
+
+# Other features
+defmt = ["dep:defmt", "embassy-hal-internal/defmt", "embassy-sync/defmt", "apollo3-pac?/defmt"]

--- a/embassy-ambiq/README.md
+++ b/embassy-ambiq/README.md
@@ -1,0 +1,20 @@
+# embassy-ambiq
+
+Support for Ambiq Apollo3 microcontrollers.
+
+## Status
+- **Supported:** GPIO, Time Driver (STIMER/CTIMER0)
+- **Primary Target:** Apollo3 Blue / SparkFun Artemis
+
+## Quirks
+
+### Time Drivers
+Timer features (`time-driver-stimer-*` or `time-driver-ctimer0`) bundle the hardware timer, clock source, and `embassy-time` tick rate together. Enable exactly one. 
+- `time-driver-stimer-xtal-32768`: Standard continuous timekeeping.
+- `time-driver-ctimer0`: Experimental one-shot mode (alarms do not re-arm).
+
+### SVL Bootloader (SparkFun Artemis)
+The Artemis SVL bootloader hands off execution at `0x10000`. If you are flashing via UART/SVL, you can enable the `svl-vtor` feature. This repoints the vector table to `0x10000` during `embassy_ambiq::init()`. Do not enable this if you are using a raw SWD probe at `0x0`.
+
+### PAC
+The `apollo3-pac` is currently at [apollo3-pac-rs](https://github.com/Fo-Zi/apollo3-pac-rs).

--- a/embassy-ambiq/src/gpio.rs
+++ b/embassy-ambiq/src/gpio.rs
@@ -1,0 +1,457 @@
+//! General Purpose Input / Output (GPIO)
+use core::convert::Infallible;
+use core::sync::atomic::{AtomicBool, Ordering};
+use core::task::Poll;
+
+use apollo3_pac as pac;
+use apollo3_pac::interrupt;
+use embassy_hal_internal::{Peri, PeripheralType, impl_peripheral};
+use embassy_sync::waitqueue::AtomicWaker;
+use embedded_hal::digital::{ErrorType, InputPin, OutputPin, StatefulOutputPin};
+
+const NEW_WAKER: AtomicWaker = AtomicWaker::new();
+static WAKERS: [AtomicWaker; 50] = [NEW_WAKER; 50];
+
+const NEW_FIRED: AtomicBool = AtomicBool::new(false);
+static FIRED: [AtomicBool; 50] = [NEW_FIRED; 50];
+
+pub enum Pull {
+    None,
+    Up,
+}
+
+/// Sealed trait carrying a pad's identity.
+pub(crate) trait SealedPin {
+    /// Physical pad number (0-49).
+    fn number(&self) -> u8;
+}
+
+#[allow(private_bounds)]
+pub trait Pin: SealedPin + PeripheralType + Into<AnyPin> + 'static {
+    /// Returns the physical pad number (0-49).
+    #[inline(always)]
+    fn pin_number(&self) -> u8 {
+        self.number()
+    }
+}
+
+/// Sealed trait that performs a pad's function-select (FNCSEL) configuration.
+pub(crate) trait SealedConfigure {
+    /// Write the 3-bit function-select field for this pad.
+    fn set_fncsel_bits(&self, sel: u8);
+
+    /// Configure the pad as an input with the given pull configuration.
+    fn configure_as_input(&self, pull: Pull);
+
+    /// Every Apollo3 pad exposes plain GPIO at function-select `0x03`.
+    const GPIO_FNCSEL: u8 = 0x03;
+
+    /// Route the pad to plain GPIO mode.
+    #[inline(always)]
+    fn set_as_gpio(&self) {
+        self.set_fncsel_bits(Self::GPIO_FNCSEL);
+    }
+}
+
+// Internal Helpers
+
+#[inline(always)]
+fn with_padkey<F: FnOnce()>(f: F) {
+    let gpio = pac::GPIO;
+    critical_section::with(|_| {
+        gpio.padkey().write_value(pac::gpio::regs::Padkey(0x73));
+        f();
+        gpio.padkey().write_value(pac::gpio::regs::Padkey(0));
+    });
+}
+
+#[inline(always)]
+fn modify_cfg<F: FnOnce(u32) -> u32>(n: usize, f: F) {
+    let gpio = pac::GPIO;
+    match n / 8 {
+        0 => gpio.cfga().modify(|w| w.0 = f(w.0)),
+        1 => gpio.cfgb().modify(|w| w.0 = f(w.0)),
+        2 => gpio.cfgc().modify(|w| w.0 = f(w.0)),
+        3 => gpio.cfgd().modify(|w| w.0 = f(w.0)),
+        4 => gpio.cfge().modify(|w| w.0 = f(w.0)),
+        5 => gpio.cfgf().modify(|w| w.0 = f(w.0)),
+        6 => gpio.cfgg().modify(|w| w.0 = f(w.0)),
+        _ => unreachable!(),
+    }
+}
+
+// Macro implementing all pin traits for a whole PADREG bank at once.
+//
+// Each pad supplies only its number; the struct name (`P{n}`), the typed setter
+// (`set_pad{n}fncsel`) and the enum (`Pad{n}fncsel`) are all derived from it. The
+// bank register (`padreg{a..m}`) is the one thing that can't be computed, so it is
+// stated once per group. `From<P{n}> for AnyPin` is generated here too.
+
+macro_rules! pins {
+    ($($padreg:ident: [$($n:literal),* $(,)?]),* $(,)?) => {
+        $($(
+            paste::paste! {
+                impl SealedPin for crate::peripherals::[<P $n>] {
+                    #[inline(always)]
+                    fn number(&self) -> u8 { $n }
+                }
+
+                impl Pin for crate::peripherals::[<P $n>] {}
+
+                impl SealedConfigure for crate::peripherals::[<P $n>] {
+                    #[inline(always)]
+                    fn set_fncsel_bits(&self, sel: u8) {
+                        let gpio = pac::GPIO;
+                        with_padkey(|| {
+                            gpio.$padreg().modify(|w| {
+                                w.[<set_pad $n fncsel>](pac::gpio::vals::[<Pad $n fncsel>]::from_bits(sel))
+                            });
+                        });
+                    }
+
+                    #[inline(always)]
+                    fn configure_as_input(&self, pull: Pull) {
+                        let gpio = pac::GPIO;
+                        with_padkey(|| {
+                            gpio.$padreg().modify(|w| {
+                                w.[<set_pad $n fncsel>](pac::gpio::vals::[<Pad $n fncsel>]::from_bits(Self::GPIO_FNCSEL));
+                                w.[<set_pad $n inpen>](true);
+                                w.[<set_pad $n pull>](match pull {
+                                    Pull::Up => true,
+                                    Pull::None => false,
+                                });
+                            });
+                        });
+                    }
+                }
+
+                impl From<crate::peripherals::[<P $n>]> for AnyPin {
+                    #[inline(always)]
+                    fn from(_val: crate::peripherals::[<P $n>]) -> Self {
+                        Self { number: $n }
+                    }
+                }
+            }
+        )*)*
+    };
+}
+
+// Pin Definitions — grouped by PADREG bank (pad numbers only)
+
+pins! {
+    padrega: [0, 1, 2, 3],
+    padregb: [4, 5, 6, 7],
+    padregc: [8, 9, 10, 11],
+    padregd: [12, 13, 14, 15],
+    padrege: [16, 17, 18, 19],
+    padregf: [20, 21, 22, 23],
+    padregg: [24, 25, 26, 27],
+    padregh: [28, 29, 30, 31],
+    padregi: [32, 33, 34, 35],
+    padregj: [36, 37, 38, 39],
+    padregk: [40, 41, 42, 43],
+    padregl: [44, 45, 46, 47],
+    padregm: [48, 49],
+}
+
+/// Type Erasure and Flex Wrapper
+
+/// Type-erased GPIO pin
+pub struct AnyPin {
+    number: u8,
+}
+
+impl_peripheral!(AnyPin);
+
+impl SealedPin for AnyPin {
+    #[inline(always)]
+    fn number(&self) -> u8 {
+        self.number
+    }
+}
+
+impl Pin for AnyPin {}
+
+// `From<P{n}> for AnyPin` is generated per pad by the `pins!` macro above.
+
+/// GPIO flexible pin, handling raw register writes for state manipulation.
+pub struct Flex<'d> {
+    pub(crate) pin: Peri<'d, AnyPin>,
+}
+
+impl<'d> Flex<'d> {
+    #[inline(always)]
+    pub fn new(pin: Peri<'d, impl Pin>) -> Self {
+        Self { pin: pin.into() }
+    }
+
+    #[inline(always)]
+    pub fn set_as_output(&mut self) {
+        let gpio = pac::GPIO;
+        let n = self.pin.pin_number() as usize;
+
+        if n < 32 {
+            gpio.enca().write_value(1 << n);
+        } else {
+            gpio.encb().write_value(pac::gpio::regs::Encb(1 << (n - 32)));
+        }
+    }
+
+    #[inline(always)]
+    pub fn set_high(&mut self) {
+        let n = self.pin.pin_number() as usize;
+        let gpio = pac::GPIO;
+        if n < 32 {
+            gpio.wtsa().write_value(1 << n);
+        } else {
+            gpio.wtsb().write_value(pac::gpio::regs::Wtsb(1 << (n - 32)));
+        }
+    }
+
+    #[inline(always)]
+    pub fn set_low(&mut self) {
+        let n = self.pin.pin_number() as usize;
+        let gpio = pac::GPIO;
+        if n < 32 {
+            gpio.wtca().write_value(1 << n);
+        } else {
+            gpio.wtcb().write_value(pac::gpio::regs::Wtcb(1 << (n - 32)));
+        }
+    }
+
+    /// Read the pin state (true = high, false = low)
+    #[inline(always)]
+    pub fn is_high(&self) -> bool {
+        let n = self.pin.pin_number() as usize;
+        let gpio = pac::GPIO;
+        if n < 32 {
+            (gpio.rda().read() & (1 << n)) != 0
+        } else {
+            (gpio.rdb().read().0 & (1 << (n - 32))) != 0
+        }
+    }
+
+    /// Internal method to wait for an edge
+    async fn wait_for_edge(&mut self, incfg: u32, intd: u32) {
+        let n = self.pin.pin_number() as usize;
+        let gpio = pac::GPIO;
+        let k = n % 8;
+        let shift = k * 4;
+
+        with_padkey(|| {
+            modify_cfg(n, |val| {
+                let mut v = val;
+                // clear INCFG (bit 0) and INTD (bit 3)
+                v &= !(0x09 << shift);
+                // set INCFG and INTD
+                v |= (incfg << shift) | ((intd << 3) << shift);
+                v
+            });
+
+            // Clear stale interrupts and enable BEFORE entering the poll_fn
+            // (INT0EN requires PADKEY)
+            if n < 32 {
+                gpio.int0clr().write(|w| {
+                    w.0 = 1 << n;
+                });
+                gpio.int0en().modify(|w| {
+                    w.0 |= 1 << n;
+                });
+            } else {
+                gpio.int1clr().write(|w| {
+                    w.0 = 1 << (n - 32);
+                });
+                gpio.int1en().modify(|w| {
+                    w.0 |= 1 << (n - 32);
+                });
+            }
+        });
+
+        // Reset the fired flag
+        FIRED[n].store(false, Ordering::Relaxed);
+
+        core::future::poll_fn(move |cx| {
+            // Register waker
+            WAKERS[n].register(cx.waker());
+
+            // Check if the ISR has flagged that the interrupt fired
+            if FIRED[n].load(Ordering::Relaxed) {
+                // We leave the interrupt enabled. It will fire again next time.
+                // The task might wait_for_edge again.
+                Poll::Ready(())
+            } else {
+                Poll::Pending
+            }
+        })
+        .await
+    }
+}
+
+/// Output Driver
+
+/// Digital output pin driver
+pub struct Output<'d> {
+    pin: Flex<'d>,
+}
+
+impl<'d> Output<'d> {
+    #[inline(always)]
+    #[allow(private_bounds)]
+    pub fn new(pin: Peri<'d, impl Pin + SealedConfigure>) -> Self {
+        // Route the pad to plain GPIO (fncsel = 0x03) through the PAC.
+        pin.set_as_gpio();
+
+        let n = pin.pin_number() as usize;
+        let k = n % 8;
+        let shift = k * 4 + 1; // gpioNoutcfg is at bit 1 and 2
+
+        with_padkey(|| {
+            modify_cfg(n, |val| {
+                let mut v = val;
+                v &= !(0x03 << shift);
+                v |= 0x01 << shift; // 1 = Pushpull
+                v
+            });
+        });
+
+        let mut flex = Flex { pin: pin.into() };
+        flex.set_as_output();
+        flex.set_low(); // Default to low
+
+        Self { pin: flex }
+    }
+
+    #[inline(always)]
+    pub fn set_high(&mut self) {
+        self.pin.set_high();
+    }
+
+    #[inline(always)]
+    pub fn set_low(&mut self) {
+        self.pin.set_low();
+    }
+}
+
+impl<'d> ErrorType for Output<'d> {
+    type Error = Infallible;
+}
+
+impl<'d> OutputPin for Output<'d> {
+    #[inline(always)]
+    fn set_high(&mut self) -> Result<(), Self::Error> {
+        self.set_high();
+        Ok(())
+    }
+
+    #[inline(always)]
+    fn set_low(&mut self) -> Result<(), Self::Error> {
+        self.set_low();
+        Ok(())
+    }
+}
+
+impl<'d> StatefulOutputPin for Output<'d> {
+    #[inline(always)]
+    fn is_set_high(&mut self) -> Result<bool, Self::Error> {
+        Ok(self.pin.is_high())
+    }
+
+    #[inline(always)]
+    fn is_set_low(&mut self) -> Result<bool, Self::Error> {
+        Ok(!self.pin.is_high())
+    }
+}
+
+/// Input Driver
+
+/// Digital input pin driver
+pub struct Input<'d> {
+    pin: Flex<'d>,
+}
+
+impl<'d> Input<'d> {
+    #[inline(always)]
+    #[allow(private_bounds)]
+    pub fn new(pin: Peri<'d, impl Pin + SealedConfigure>, pull: Pull) -> Self {
+        pin.configure_as_input(pull);
+        Self {
+            pin: Flex { pin: pin.into() },
+        }
+    }
+
+    pub async fn wait_for_rising_edge(&mut self) {
+        // L2H: INCFG=0, INTD=0
+        self.pin.wait_for_edge(0, 0).await;
+    }
+
+    pub async fn wait_for_falling_edge(&mut self) {
+        // H2L: INCFG=0, INTD=1
+        self.pin.wait_for_edge(0, 1).await;
+    }
+
+    pub async fn wait_for_any_edge(&mut self) {
+        // BOTH: INCFG=1, INTD=1
+        self.pin.wait_for_edge(1, 1).await;
+    }
+}
+
+impl<'d> ErrorType for Input<'d> {
+    type Error = Infallible;
+}
+
+impl<'d> InputPin for Input<'d> {
+    #[inline(always)]
+    fn is_high(&mut self) -> Result<bool, Self::Error> {
+        Ok(self.pin.is_high())
+    }
+
+    #[inline(always)]
+    fn is_low(&mut self) -> Result<bool, Self::Error> {
+        Ok(!self.pin.is_high())
+    }
+}
+
+/// Interrupt Handler
+
+#[interrupt]
+fn GPIO() {
+    let gpio = pac::GPIO;
+    let stat0 = gpio.int0stat().read().0;
+    let stat1 = gpio.int1stat().read().0;
+
+    // Clear the interrupts
+    gpio.int0clr().write(|w| {
+        w.0 = stat0;
+    });
+    gpio.int1clr().write(|w| {
+        w.0 = stat1;
+    });
+
+    // Wake tasks and set fired flag
+    // We DO NOT disable int0en here to avoid needing padkey in the ISR
+    for i in 0..32 {
+        if (stat0 & (1 << i)) != 0 {
+            FIRED[i].store(true, Ordering::Relaxed);
+            WAKERS[i].wake();
+        }
+    }
+
+    for i in 0..18 {
+        if (stat1 & (1 << i)) != 0 {
+            FIRED[32 + i].store(true, Ordering::Relaxed);
+            WAKERS[32 + i].wake();
+        }
+    }
+}
+
+// Force the linker to keep the GPIO interrupt handler from being stripped.
+// The `#[interrupt]` macro exports the handler under the symbol name `GPIO`
+// (via `#[no_mangle]`), but does not leave a Rust-visible value by that name,
+// so we reference the exported symbol through an `extern "C"` declaration.
+#[used]
+static KEEP_GPIO: unsafe extern "C" fn() = {
+    unsafe extern "C" {
+        fn GPIO();
+    }
+    GPIO
+};

--- a/embassy-ambiq/src/lib.rs
+++ b/embassy-ambiq/src/lib.rs
@@ -1,0 +1,42 @@
+#![no_std]
+
+#[cfg(feature = "apollo3")]
+pub use apollo3_pac as pac;
+
+pub mod gpio;
+#[cfg(any(feature = "_stimer", feature = "time-driver-ctimer0"))]
+pub mod time_driver;
+
+embassy_hal_internal::peripherals! {
+    P0, P1, P2, P3, P4, P5, P6, P7, P8, P9,
+    P10, P11, P12, P13, P14, P15, P16, P17, P18, P19,
+    P20, P21, P22, P23, P24, P25, P26, P27, P28, P29,
+    P30, P31, P32, P33, P34, P35, P36, P37, P38, P39,
+    P40, P41, P42, P43, P44, P45, P46, P47, P48, P49,
+}
+
+pub fn init() -> Peripherals {
+    let p = Peripherals::take();
+    #[cfg(any(feature = "_stimer", feature = "time-driver-ctimer0"))]
+    crate::time_driver::Apollo3TimeDriver::init();
+
+    unsafe {
+        cortex_m::interrupt::enable();
+
+        let mut scb = cortex_m::peripheral::Peripherals::steal().SCB;
+        scb.clear_sleepdeep();
+
+        #[cfg(feature = "svl-vtor")]
+        {
+            // The SparkFun SVL bootloader leaves VTOR at 0x0 pointing at its own vector table.
+            // Repoint to our app vectors at 0x10000 (matches memory.x FLASH ORIGIN).
+            // We do this before setting up any interrupts.
+            scb.vtor.write(0x0001_0000);
+        }
+
+        // Enable the global GPIO interrupt. Individual pins configure their own routing.
+        cortex_m::peripheral::NVIC::unmask(pac::Interrupt::GPIO);
+    }
+
+    p
+}

--- a/embassy-ambiq/src/time_driver.rs
+++ b/embassy-ambiq/src/time_driver.rs
@@ -1,0 +1,331 @@
+//! High-resolution and low-power time drivers for Embassy.
+#![allow(clippy::new_without_default)]
+
+use core::cell::{Cell, RefCell};
+use core::sync::atomic::{AtomicU32, Ordering};
+use core::task::Waker;
+
+use apollo3_pac as pac;
+use cortex_m::peripheral::NVIC;
+use critical_section::{CriticalSection, Mutex};
+use embassy_time_driver::Driver;
+use embassy_time_queue_utils::Queue;
+use pac::{Interrupt, interrupt};
+
+#[cfg(all(feature = "_stimer", feature = "time-driver-ctimer0"))]
+compile_error!(
+    "embassy-ambiq: enable at most one time-driver backend — \
+     `time-driver-stimer-lfrc` / `time-driver-stimer-xtal` OR `time-driver-ctimer0`."
+);
+
+struct AlarmState {
+    /// Timestamp at which to fire the alarm. `u64::MAX` if no alarm is scheduled.
+    timestamp: Cell<u64>,
+}
+
+unsafe impl Send for AlarmState {}
+
+impl AlarmState {
+    const fn new() -> Self {
+        Self {
+            timestamp: Cell::new(u64::MAX),
+        }
+    }
+}
+
+pub(crate) struct Apollo3TimeDriver {
+    /// 32-bit overflow counter. Appended to the 32-bit hardware counter to form a 64-bit tick count.
+    overflows: AtomicU32,
+    /// Next hardware compare deadline.
+    alarm: Mutex<AlarmState>,
+    /// Pending timer wakers, owned by the executor's time queue.
+    queue: Mutex<RefCell<Queue>>,
+}
+
+embassy_time_driver::time_driver_impl!(static DRIVER: Apollo3TimeDriver = Apollo3TimeDriver {
+    overflows: AtomicU32::new(0),
+    alarm: Mutex::new(AlarmState::new()),
+    queue: Mutex::new(RefCell::new(Queue::new())),
+});
+
+/// STIMER BACKEND
+
+#[cfg(feature = "_stimer")]
+impl Apollo3TimeDriver {
+    pub(crate) fn init() {
+        let ctimer = pac::CTIMER;
+
+        // Clear and freeze the counter while (re)configuring.
+        ctimer.stcfg().write(|w| {
+            w.set_clear(pac::ctimer::vals::Clear::Clear);
+            w.set_freeze(pac::ctimer::vals::Freeze::Freeze);
+        });
+
+        // Clock source (and thus tick rate) is fixed by the selected feature.
+        ctimer.stcfg().write(|w| {
+            #[cfg(feature = "_xtal-div1")]
+            w.set_clksel(pac::ctimer::vals::Clksel::XtalDiv1); // 32768 Hz
+            #[cfg(feature = "_xtal-div2")]
+            w.set_clksel(pac::ctimer::vals::Clksel::XtalDiv2); // 16384 Hz
+            #[cfg(feature = "_xtal-div32")]
+            w.set_clksel(pac::ctimer::vals::Clksel::XtalDiv32); // 1024 Hz
+            #[cfg(feature = "_lfrc")]
+            w.set_clksel(pac::ctimer::vals::Clksel::LfrcDiv1); // ~1024 Hz (uncalibrated)
+
+            w.set_compare_a_en(true);
+            w.set_clear(pac::ctimer::vals::Clear::Run);
+            w.set_freeze(pac::ctimer::vals::Freeze::Thaw);
+        });
+
+        // Enable the Compare-A interrupt once, leaving it enabled. The ISR only clears the
+        // status and re-arms by writing a new absolute compare. Overflow feeds the 64-bit now().
+        ctimer.stmintclr().write(|w| w.set_comparea(true));
+        ctimer.stminten().modify(|w| {
+            w.set_comparea(true);
+            w.set_overflow(true);
+        });
+
+        // Enable NVIC interrupts
+        unsafe {
+            NVIC::unmask(Interrupt::STIMER);
+            NVIC::unmask(Interrupt::STIMER_CMPR0);
+        }
+    }
+
+    fn on_overflow(&self) {
+        self.overflows.fetch_add(1, Ordering::Relaxed);
+        pac::CTIMER.stmintclr().write(|w| w.set_overflow(true));
+    }
+
+    fn on_compare0(&self) {
+        // Clear the status only; Compare-A stays enabled (see init).
+        pac::CTIMER.stmintclr().write(|w| w.set_comparea(true));
+
+        critical_section::with(|cs| {
+            self.alarm.borrow(cs).timestamp.set(u64::MAX);
+            self.trigger_alarm(cs);
+        });
+    }
+
+    fn trigger_alarm(&self, cs: CriticalSection) {
+        let mut next = self.queue.borrow(cs).borrow_mut().next_expiration(self.now());
+        while !self.set_alarm(cs, next) {
+            next = self.queue.borrow(cs).borrow_mut().next_expiration(self.now());
+        }
+    }
+
+    fn set_alarm(&self, cs: CriticalSection, timestamp: u64) -> bool {
+        let alarm = self.alarm.borrow(cs);
+        alarm.timestamp.set(timestamp);
+
+        let now = self.now();
+        if timestamp <= now {
+            alarm.timestamp.set(u64::MAX);
+            return false;
+        }
+
+        let diff = timestamp - now;
+        let diff_u32 = if diff > 0x7FFF_FFFF { 0x7FFF_FFFF } else { diff as u32 };
+
+        // SCMPR0 takes a DELTA ("offset from NOW"): the hardware adds it to the COUNTER in the
+        // STIMER clock domain. Write the raw diff
+        pac::CTIMER.scmpr0().write_value(diff_u32);
+        pac::CTIMER.stmintclr().write(|w| w.set_comparea(true));
+
+        true
+    }
+}
+
+#[cfg(feature = "_stimer")]
+impl Driver for Apollo3TimeDriver {
+    fn now(&self) -> u64 {
+        critical_section::with(|_| {
+            let high = self.overflows.load(Ordering::Relaxed);
+            let low = pac::CTIMER.sttmr().read();
+
+            if pac::CTIMER.stmintstat().read().overflow() {
+                let low = pac::CTIMER.sttmr().read();
+                (((high + 1) as u64) << 32) | (low as u64)
+            } else {
+                ((high as u64) << 32) | (low as u64)
+            }
+        })
+    }
+
+    fn schedule_wake(&self, at: u64, waker: &Waker) {
+        critical_section::with(|cs| {
+            let mut queue = self.queue.borrow(cs).borrow_mut();
+            if queue.schedule_wake(at, waker) {
+                let mut next = queue.next_expiration(self.now());
+                while !self.set_alarm(cs, next) {
+                    next = queue.next_expiration(self.now());
+                }
+            }
+        })
+    }
+}
+
+#[cfg(feature = "_stimer")]
+#[interrupt]
+fn STIMER() {
+    DRIVER.on_overflow();
+}
+
+#[cfg(feature = "_stimer")]
+#[interrupt]
+fn STIMER_CMPR0() {
+    DRIVER.on_compare0();
+}
+
+/// CTIMER0 BACKEND (High Speed)
+
+#[cfg(feature = "time-driver-ctimer0")]
+impl Apollo3TimeDriver {
+    pub(crate) fn init() {
+        let ctimer = pac::CTIMER;
+
+        const _ASSERT_TICK: () = assert!(
+            embassy_time_driver::TICK_HZ == 1_000_000,
+            "embassy-time tick-hz must be 1_000_000 for ctimer0 (HFRC/16 scaled to 1MHz)"
+        );
+
+        // Stop the timer
+        ctimer.ctrl0().write(|w| {
+            w.set_tmra0en(false);
+            w.set_tmrb0en(false);
+            w.set_tmra0clr(pac::ctimer::vals::Clear::Clear);
+            w.set_tmrb0clr(pac::ctimer::vals::Clear::Clear);
+        });
+
+        // Configure CTIMER0 as a single 32-bit timer, clocked by HFRC/16 (3 MHz)
+        ctimer.ctrl0().modify(|w| {
+            w.set_ctlink0(pac::ctimer::vals::Ctlink::_32bitTimer);
+            w.set_tmra0clk(pac::ctimer::vals::Tmra0clk::HfrcDiv16); // 3 MHz
+            w.set_tmra0fn(pac::ctimer::vals::Tmrfn::Continuous);
+            w.set_tmra0ie0(true); // REQUIRED to generate the compare 0 interrupt
+        });
+
+        // Initialize compare registers far into the future to prevent an immediate interrupt on boot
+        ctimer.cmpra0().write_value(pac::ctimer::regs::Cmpra0(0xFFFF));
+        ctimer.cmprb0().write_value(pac::ctimer::regs::Cmprb0(0xFFFF));
+
+        // Enable interrupt on Compare A0
+        ctimer.inten().modify(|w| w.set_ctmra0c0int(true));
+
+        // Start the timer
+        ctimer.ctrl0().modify(|w| {
+            w.set_tmra0en(true);
+            w.set_tmrb0en(true); // 32-bit mode requires B side to run too
+            w.set_tmra0clr(pac::ctimer::vals::Clear::Run);
+            w.set_tmrb0clr(pac::ctimer::vals::Clear::Run);
+        });
+
+        // Globally enable CTIMER0 (A and B sides)
+        ctimer.globen().modify(|w| {
+            w.set_ena0(pac::ctimer::vals::En::Lco);
+            w.set_enb0(pac::ctimer::vals::En::Lco);
+        });
+
+        // Enable NVIC interrupts
+        unsafe {
+            NVIC::unmask(Interrupt::CTIMER);
+        }
+    }
+
+    fn on_interrupt(&self) {
+        let ctimer = pac::CTIMER;
+        let stat = ctimer.intstat().read();
+
+        if stat.ctmra0c0int() || stat.ctmrb0c0int() {
+            // Clear ALL CTIMER interrupts just in case
+            ctimer.intclr().write(|w| {
+                w.set_ctmra0c0int(true);
+                w.set_ctmrb0c0int(true);
+                w.set_ctmra0c1int(true);
+                w.set_ctmrb0c1int(true);
+            });
+            ctimer.inten().modify(|w| w.set_ctmra0c0int(false)); // Disable compare int
+
+            critical_section::with(|cs| {
+                self.alarm.borrow(cs).timestamp.set(u64::MAX);
+                self.trigger_alarm(cs);
+            });
+        }
+    }
+
+    fn trigger_alarm(&self, cs: CriticalSection) {
+        let mut next = self.queue.borrow(cs).borrow_mut().next_expiration(self.now());
+        while !self.set_alarm(cs, next) {
+            next = self.queue.borrow(cs).borrow_mut().next_expiration(self.now());
+        }
+    }
+
+    fn set_alarm(&self, cs: CriticalSection, timestamp: u64) -> bool {
+        let alarm = self.alarm.borrow(cs);
+        alarm.timestamp.set(timestamp);
+
+        let now = self.now();
+        if timestamp <= now {
+            pac::CTIMER.inten().modify(|w| w.set_ctmra0c0int(false));
+            alarm.timestamp.set(u64::MAX);
+            return false;
+        }
+
+        // Calculate diff in 1MHz ticks, then scale to 3MHz hardware ticks
+        let diff = timestamp.saturating_sub(now);
+        let diff_hw = diff.saturating_mul(3);
+        let diff_u32 = if diff_hw > 0x7FFF_FFFF {
+            0x7FFF_FFFF
+        } else {
+            diff_hw as u32
+        };
+
+        let current = pac::CTIMER.tmr0().read().0;
+        let target = current.wrapping_add(diff_u32);
+
+        // 32-bit timer mode requires the target to be split across A and B registers
+        pac::CTIMER
+            .cmpra0()
+            .write_value(pac::ctimer::regs::Cmpra0(target & 0xFFFF));
+        pac::CTIMER
+            .cmprb0()
+            .write_value(pac::ctimer::regs::Cmprb0(target >> 16));
+
+        pac::CTIMER.intclr().write(|w| w.set_ctmra0c0int(true));
+        pac::CTIMER.inten().modify(|w| w.set_ctmra0c0int(true));
+
+        true
+    }
+}
+
+#[cfg(feature = "time-driver-ctimer0")]
+impl Driver for Apollo3TimeDriver {
+    fn now(&self) -> u64 {
+        critical_section::with(|_| {
+            let low = pac::CTIMER.tmr0().read();
+            let high = self.overflows.load(Ordering::Relaxed);
+
+            // hardware ticks at 3MHz. Convert to 1MHz ticks (divide by 3).
+            let hw_ticks = ((high as u64) << 32) | (low.0 as u64);
+            hw_ticks / 3
+        })
+    }
+
+    fn schedule_wake(&self, at: u64, waker: &Waker) {
+        critical_section::with(|cs| {
+            let mut queue = self.queue.borrow(cs).borrow_mut();
+            if queue.schedule_wake(at, waker) {
+                let mut next = queue.next_expiration(self.now());
+                while !self.set_alarm(cs, next) {
+                    next = queue.next_expiration(self.now());
+                }
+            }
+        })
+    }
+}
+
+#[cfg(feature = "time-driver-ctimer0")]
+#[interrupt]
+fn CTIMER() {
+    DRIVER.on_interrupt();
+}

--- a/examples/ambiq/sparkfun-artemis/.cargo/config.toml
+++ b/examples/ambiq/sparkfun-artemis/.cargo/config.toml
@@ -1,0 +1,9 @@
+[target.'cfg(all(target_arch = "arm", target_os = "none"))']
+runner = "tools/flash.sh"
+
+rustflags = [
+  "-C", "link-arg=-Tlink.x",
+]
+
+[build]
+target = "thumbv7em-none-eabihf"

--- a/examples/ambiq/sparkfun-artemis/Cargo.toml
+++ b/examples/ambiq/sparkfun-artemis/Cargo.toml
@@ -1,0 +1,21 @@
+[package]
+name = "apollo-embassy-examples"
+version = "0.1.0"
+edition = "2024"
+license = "MIT OR Apache-2.0"
+publish = false
+
+[package.metadata.embassy]
+build = [
+  { target = "thumbv7em-none-eabihf", artifact-dir = "out/examples/ambiq" }
+]
+
+[dependencies]
+cortex-m = { version = "0.7.7", features = ["critical-section-single-core"] }
+cortex-m-rt = "0.7.3"
+panic-halt = "0.2.0"
+
+embassy-executor = { version = "0.10.0", path = "../../../embassy-executor", features = ["platform-cortex-m", "executor-thread", "executor-interrupt"] }
+embassy-time = { version = "0.5.1", path = "../../../embassy-time" }
+embassy-ambiq = { path = "../../../embassy-ambiq", default-features = false, features = ["apollo3", "time-driver-stimer-xtal-32768", "svl-vtor"] }
+apollo3-pac = "0.2.0"

--- a/examples/ambiq/sparkfun-artemis/README.md
+++ b/examples/ambiq/sparkfun-artemis/README.md
@@ -1,0 +1,15 @@
+# SparkFun Artemis (Apollo3) Examples
+
+Examples for the Ambiq Apollo3, configured specifically for SparkFun Artemis boards.
+
+## Flashing & Bootloader
+Artemis boards use the SparkFun SVL bootloader, which requires the application to boot from `0x10000`. 
+- **Flashing:** Simply run `cargo run --release --bin <example_name>`.
+- **How it works:** The `.cargo/config.toml` intercepts the runner and passes the binary to `tools/flash.sh`, which uses the SVL python script to flash over UART.
+
+*(Note: If you want to flash a bare chip at `0x0` using a standard SWD debugger and `probe-rs`, you must change `memory.x`'s flash origin to `0x0` and remove the `svl-vtor` feature from `Cargo.toml`)*.
+
+## Examples
+- `sync_blinky`: Blocking blinky (no executor).
+- `async_blinky`: Demonstrates the Embassy executor and STIMER backend.
+- `async_button`: Using the `Input` driver's async `.wait_for_falling_edge()` to toggle an LED.

--- a/examples/ambiq/sparkfun-artemis/build.rs
+++ b/examples/ambiq/sparkfun-artemis/build.rs
@@ -1,0 +1,15 @@
+use std::path::PathBuf;
+use std::{env, fs};
+
+fn main() {
+    let out = PathBuf::from(env::var("OUT_DIR").unwrap());
+
+    // memory.x: Apollo3 FLASH/RAM map. Only consumed when an example/binary
+    // is linked (cortex-m-rt's link.x includes it); harmless for downstream
+    // PAC consumers that ship their own memory.x.
+    fs::write(out.join("memory.x"), include_bytes!("memory.x")).unwrap();
+
+    println!("cargo:rustc-link-search={}", out.display());
+    println!("cargo:rerun-if-changed=memory.x");
+    println!("cargo:rerun-if-changed=build.rs");
+}

--- a/examples/ambiq/sparkfun-artemis/memory.x
+++ b/examples/ambiq/sparkfun-artemis/memory.x
@@ -1,0 +1,8 @@
+MEMORY
+{
+  /* Apollo3 typically has 1MB Flash and 384KB RAM. 
+     Note: If you are using a bootloader (like SparkFun Artemis), 
+     you may need to offset the FLASH origin to 0x0000C000 or 0x00010000. */
+  FLASH (rx) : ORIGIN = 0x00010000, LENGTH = 960K
+  RAM (rwx)  : ORIGIN = 0x10000000, LENGTH = 384K
+}

--- a/examples/ambiq/sparkfun-artemis/src/bin/async_blinky.rs
+++ b/examples/ambiq/sparkfun-artemis/src/bin/async_blinky.rs
@@ -1,0 +1,21 @@
+#![no_std]
+#![no_main]
+
+use embassy_ambiq::gpio::Output;
+use embassy_executor::Spawner;
+use embassy_time::Timer;
+use panic_halt as _;
+
+// SparkFun RedBoard Artemis STAT LED is on GPIO5 (D5).
+#[embassy_executor::main]
+async fn main(_spawner: Spawner) {
+    let p = embassy_ambiq::init();
+    let mut led = Output::new(p.P5);
+
+    loop {
+        led.set_high();
+        Timer::after_millis(500).await;
+        led.set_low();
+        Timer::after_millis(500).await;
+    }
+}

--- a/examples/ambiq/sparkfun-artemis/src/bin/async_button.rs
+++ b/examples/ambiq/sparkfun-artemis/src/bin/async_button.rs
@@ -1,0 +1,36 @@
+#![no_std]
+#![no_main]
+
+use embassy_ambiq::gpio::{Input, Output, Pull};
+use embassy_executor::Spawner;
+use embassy_time::Timer;
+use panic_halt as _;
+
+// SparkFun RedBoard Artemis
+// STAT LED is on Pad5
+// A0 is on Pad29
+#[embassy_executor::main]
+async fn main(_spawner: Spawner) {
+    let p = embassy_ambiq::init();
+
+    let mut led = Output::new(p.P5);
+    let mut button = Input::new(p.P29, Pull::Up);
+
+    let mut state = false;
+
+    loop {
+        // Asynchronously wait for the falling edge (button pressed)
+        button.wait_for_falling_edge().await;
+
+        // Toggle the LED
+        state = !state;
+        if state {
+            led.set_high();
+        } else {
+            led.set_low();
+        }
+
+        // 50ms debounce so it doesn't flicker multiple times on a single press
+        Timer::after_millis(50).await;
+    }
+}

--- a/examples/ambiq/sparkfun-artemis/src/bin/sync_blinky.rs
+++ b/examples/ambiq/sparkfun-artemis/src/bin/sync_blinky.rs
@@ -1,0 +1,23 @@
+#![no_std]
+#![no_main]
+
+use cortex_m_rt::entry;
+use embassy_ambiq::gpio::Output;
+use embassy_time::{Duration, block_for};
+use panic_halt as _;
+
+#[entry]
+fn main() -> ! {
+    let p = embassy_ambiq::init();
+
+    // Blue STAT LED is on PAD5 on the SparkFun RedBoard Artemis ->
+    let mut led = Output::new(p.P5);
+
+    loop {
+        led.set_high();
+        block_for(Duration::from_millis(500));
+
+        led.set_low();
+        block_for(Duration::from_millis(500));
+    }
+}

--- a/examples/ambiq/sparkfun-artemis/tools/flash.sh
+++ b/examples/ambiq/sparkfun-artemis/tools/flash.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+set -e
+
+ELF_PATH="$1"
+BIN_PATH="${ELF_PATH}.bin"
+
+# 1. Convert the ELF binary to .bin format
+arm-none-eabi-objcopy -O binary "$ELF_PATH" "$BIN_PATH"
+
+# 2. Flash the .bin file using svl.py
+python3 tools/svl.py /dev/ttyUSB0 -f "$BIN_PATH"

--- a/examples/ambiq/sparkfun-artemis/tools/svl.py
+++ b/examples/ambiq/sparkfun-artemis/tools/svl.py
@@ -1,0 +1,421 @@
+#!/usr/bin/env python
+# SparkFun Variable Loader
+# Variable baud rate bootloader for Artemis Apollo3 modules
+
+# Immediately upon reset the Artemis module will search for the timing character
+#   to auto-detect the baud rate. If a valid baud rate is found the Artemis will
+#   respond with the bootloader version packet
+# If the computer receives a well-formatted version number packet at the desired
+#   baud rate it will send a command to begin bootloading. The Artemis shall then
+#   respond with the a command asking for the next frame.
+# The host will then send a frame packet. If the CRC is OK the Artemis will write
+#   that to memory and request the next frame. If the CRC fails the Artemis will
+#   discard that data and send a request to re-send the previous frame.
+# This cycle repeats until the Artemis receives a done command in place of the
+#   requested frame data command.
+# The initial baud rate determination must occur within some small timeout. Once
+#   baud rate detection has completed all additional communication will have a
+#   universal timeout value. Once the Artemis has begun requesting data it may no
+#   no longer exit the bootloader. If the host detects a timeout at any point it
+#   will stop bootloading.
+
+# Notes about PySerial timeout:
+# The timeout operates on whole functions - that is to say that a call to
+#   ser.read(10) will return after ser.timeout, just as will ser.read(1) (assuming
+#   that the necessary bytes were not found)
+# If there are no incoming bytes (on the line or in the buffer) then two calls to
+#   ser.read(n) will time out after 2*ser.timeout
+# Incoming UART data is buffered behind the scenes, probably by the OS.
+
+# ***********************************************************************************
+#
+# Imports
+#
+# ***********************************************************************************
+
+import argparse
+import serial
+import serial.tools.list_ports as list_ports
+import sys
+import time
+import math
+import os.path
+from sys import exit
+
+SCRIPT_VERSION_MAJOR = "1"
+SCRIPT_VERSION_MINOR = "7"
+
+# ***********************************************************************************
+#
+# Commands
+#
+# ***********************************************************************************
+SVL_CMD_VER = 0x01  # version
+SVL_CMD_BL = 0x02  # enter bootload mode
+SVL_CMD_NEXT = 0x03  # request next chunk
+SVL_CMD_FRAME = 0x04  # indicate app data frame
+SVL_CMD_RETRY = 0x05  # request re-send frame
+SVL_CMD_DONE = 0x06  # finished - all data sent
+
+barWidthInCharacters = 50  # Width of progress bar, ie [###### % complete
+
+crcTable = (
+    0x0000, 0x8005, 0x800F, 0x000A, 0x801B, 0x001E, 0x0014, 0x8011,
+    0x8033, 0x0036, 0x003C, 0x8039, 0x0028, 0x802D, 0x8027, 0x0022,
+    0x8063, 0x0066, 0x006C, 0x8069, 0x0078, 0x807D, 0x8077, 0x0072,
+    0x0050, 0x8055, 0x805F, 0x005A, 0x804B, 0x004E, 0x0044, 0x8041,
+    0x80C3, 0x00C6, 0x00CC, 0x80C9, 0x00D8, 0x80DD, 0x80D7, 0x00D2,
+    0x00F0, 0x80F5, 0x80FF, 0x00FA, 0x80EB, 0x00EE, 0x00E4, 0x80E1,
+    0x00A0, 0x80A5, 0x80AF, 0x00AA, 0x80BB, 0x00BE, 0x00B4, 0x80B1,
+    0x8093, 0x0096, 0x009C, 0x8099, 0x0088, 0x808D, 0x8087, 0x0082,
+    0x8183, 0x0186, 0x018C, 0x8189, 0x0198, 0x819D, 0x8197, 0x0192,
+    0x01B0, 0x81B5, 0x81BF, 0x01BA, 0x81AB, 0x01AE, 0x01A4, 0x81A1,
+    0x01E0, 0x81E5, 0x81EF, 0x01EA, 0x81FB, 0x01FE, 0x01F4, 0x81F1,
+    0x81D3, 0x01D6, 0x01DC, 0x81D9, 0x01C8, 0x81CD, 0x81C7, 0x01C2,
+    0x0140, 0x8145, 0x814F, 0x014A, 0x815B, 0x015E, 0x0154, 0x8151,
+    0x8173, 0x0176, 0x017C, 0x8179, 0x0168, 0x816D, 0x8167, 0x0162,
+    0x8123, 0x0126, 0x012C, 0x8129, 0x0138, 0x813D, 0x8137, 0x0132,
+    0x0110, 0x8115, 0x811F, 0x011A, 0x810B, 0x010E, 0x0104, 0x8101,
+    0x8303, 0x0306, 0x030C, 0x8309, 0x0318, 0x831D, 0x8317, 0x0312,
+    0x0330, 0x8335, 0x833F, 0x033A, 0x832B, 0x032E, 0x0324, 0x8321,
+    0x0360, 0x8365, 0x836F, 0x036A, 0x837B, 0x037E, 0x0374, 0x8371,
+    0x8353, 0x0356, 0x035C, 0x8359, 0x0348, 0x834D, 0x8347, 0x0342,
+    0x03C0, 0x83C5, 0x83CF, 0x03CA, 0x83DB, 0x03DE, 0x03D4, 0x83D1,
+    0x83F3, 0x03F6, 0x03FC, 0x83F9, 0x03E8, 0x83ED, 0x83E7, 0x03E2,
+    0x83A3, 0x03A6, 0x03AC, 0x83A9, 0x03B8, 0x83BD, 0x83B7, 0x03B2,
+    0x0390, 0x8395, 0x839F, 0x039A, 0x838B, 0x038E, 0x0384, 0x8381,
+    0x0280, 0x8285, 0x828F, 0x028A, 0x829B, 0x029E, 0x0294, 0x8291,
+    0x82B3, 0x02B6, 0x02BC, 0x82B9, 0x02A8, 0x82AD, 0x82A7, 0x02A2,
+    0x82E3, 0x02E6, 0x02EC, 0x82E9, 0x02F8, 0x82FD, 0x82F7, 0x02F2,
+    0x02D0, 0x82D5, 0x82DF, 0x02DA, 0x82CB, 0x02CE, 0x02C4, 0x82C1,
+    0x8243, 0x0246, 0x024C, 0x8249, 0x0258, 0x825D, 0x8257, 0x0252,
+    0x0270, 0x8275, 0x827F, 0x027A, 0x826B, 0x026E, 0x0264, 0x8261,
+    0x0220, 0x8225, 0x822F, 0x022A, 0x823B, 0x023E, 0x0234, 0x8231,
+    0x8213, 0x0216, 0x021C, 0x8219, 0x0208, 0x820D, 0x8207, 0x0202)
+# ***********************************************************************************
+#
+# Compute CRC on a byte array
+#
+# ***********************************************************************************
+
+
+def get_crc16(data):
+
+    # Table and code ported from Artemis SVL bootloader
+    crc = 0x0000
+    data = bytearray(data)
+    for ch in data:
+        tableAddr = ch ^ (crc >> 8)
+        CRCH = (crcTable[tableAddr] >> 8) ^ (crc & 0xFF)
+        CRCL = crcTable[tableAddr] & 0x00FF
+        crc = CRCH << 8 | CRCL
+    return crc
+
+
+# ***********************************************************************************
+#
+# Wait for a packet
+#
+# ***********************************************************************************
+def wait_for_packet(ser):
+
+    packet = {'len': 0, 'cmd': 0, 'data': 0, 'crc': 1, 'timeout': 1}
+
+    n = ser.read(2)  # get the number of bytes
+    if(len(n) < 2):
+        return packet
+
+    packet['len'] = int.from_bytes(n, byteorder='big', signed=False)    #
+    payload = ser.read(packet['len'])
+
+    if(len(payload) != packet['len']):
+        return packet
+
+    # all bytes received, so timeout is not true
+    packet['timeout'] = 0
+    # cmd is the first byte of the payload
+    packet['cmd'] = payload[0]
+    # the data is the part of the payload that is not cmd or crc
+    packet['data'] = payload[1:packet['len']-2]
+    # performing the crc on the whole payload should return 0
+    packet['crc'] = get_crc16(payload)
+
+    return packet
+
+# ***********************************************************************************
+#
+# Send a packet
+#
+# ***********************************************************************************
+
+
+def send_packet(ser, cmd, data):
+    data = bytearray(data)
+    num_bytes = 3 + len(data)
+    payload = bytearray(cmd.to_bytes(1, 'big'))
+    payload.extend(data)
+    crc = get_crc16(payload)
+    payload.extend(bytearray(crc.to_bytes(2, 'big')))
+
+    ser.write(num_bytes.to_bytes(2, 'big'))
+    ser.write(bytes(payload))
+
+
+# ***********************************************************************************
+#
+# Setup: signal baud rate, get version, and command BL enter
+#
+# ***********************************************************************************
+def phase_setup(ser):
+
+    baud_detect_byte = b'U'
+
+    verboseprint('\nPhase:\tSetup')
+
+    # Handle the serial startup blip
+    ser.reset_input_buffer()
+    verboseprint('\tCleared startup blip')
+
+    ser.write(baud_detect_byte)             # send the baud detection character
+
+    packet = wait_for_packet(ser)
+    if(packet['timeout'] or packet['crc']):
+        return False  # failed to enter bootloader
+
+    twopartprint('\t', 'Got SVL Bootloader Version: ' +
+                 str(int.from_bytes(packet['data'], 'big')))
+    verboseprint('\tSending \'enter bootloader\' command')
+
+    send_packet(ser, SVL_CMD_BL, b'')
+
+    return True
+
+    # Now enter the bootload phase
+
+
+# ***********************************************************************************
+#
+# Bootloader phase (Artemis is locked in)
+#
+# ***********************************************************************************
+def phase_bootload(ser):
+
+    startTime = time.time()
+    frame_size = 512*4
+
+    resend_max = 4
+    resend_count = 0
+
+    verboseprint('\nPhase:\tBootload')
+
+    with open(args.binfile, mode='rb') as binfile:
+        application = binfile.read()
+        total_len = len(application)
+
+        total_frames = math.ceil(total_len/frame_size)
+        curr_frame = 0
+        progressChars = 0
+
+        if (not args.verbose):
+            print("[", end='')
+
+        verboseprint('\thave ' + str(total_len) +
+                     ' bytes to send in ' + str(total_frames) + ' frames')
+
+        bl_done = False
+        bl_succeeded = True
+        while((bl_done == False) and (bl_succeeded == True)):
+
+            # wait for indication by Artemis
+            packet = wait_for_packet(ser)
+            if(packet['timeout'] or packet['crc']):
+                verboseprint('\n\tError receiving packet')
+                verboseprint(packet)
+                verboseprint('\n')
+                bl_succeeded = False
+                bl_done = True
+
+            if(packet['cmd'] == SVL_CMD_NEXT):
+                # verboseprint('\tgot frame request')
+                curr_frame += 1
+                resend_count = 0
+            elif(packet['cmd'] == SVL_CMD_RETRY):
+                verboseprint('\t\tRetrying...')
+                resend_count += 1
+                if(resend_count >= resend_max):
+                    bl_succeeded = False
+                    bl_done = True
+            else:
+                print('Timeout or unknown error')
+                bl_succeeded = False
+                bl_done = True
+
+            if(curr_frame <= total_frames):
+                frame_data = application[(
+                    (curr_frame-1)*frame_size):((curr_frame-1+1)*frame_size)]
+                if(args.verbose):
+                    verboseprint('\tSending frame #'+str(curr_frame) +
+                                 ', length: '+str(len(frame_data)))
+                else:
+                    percentComplete = curr_frame * 100 / total_frames
+                    percentCompleteInChars = math.ceil(
+                        percentComplete / 100 * barWidthInCharacters)
+                    while(progressChars < percentCompleteInChars):
+                        progressChars = progressChars + 1
+                        print('#', end='', flush=True)
+                    if (percentComplete == 100):
+                        print("]", end='')
+
+                send_packet(ser, SVL_CMD_FRAME, frame_data)
+
+            else:
+                send_packet(ser, SVL_CMD_DONE, b'')
+                bl_done = True
+
+        if(bl_succeeded == True):
+            twopartprint('\n\t', 'Upload complete')
+            endTime = time.time()
+            bps = total_len / (endTime - startTime)
+            verboseprint('\n\tNominal bootload bps: ' + str(round(bps, 2)))
+        else:
+            twopartprint('\n\t', 'Upload failed')
+
+        return bl_succeeded
+
+
+# ***********************************************************************************
+#
+# Help if serial port could not be opened
+#
+# ***********************************************************************************
+def phase_serial_port_help():
+    devices = list_ports.comports()
+
+    # First check to see if user has the given port open
+    for dev in devices:
+        if(dev.device.upper() == args.port.upper()):
+            print(dev.device + " is currently open. Please close any other terminal programs that may be using " +
+                  dev.device + " and try again.")
+            exit()
+
+    # otherwise, give user a list of possible com ports
+    print(args.port.upper() +
+          " not found but we detected the following serial ports:")
+    for dev in devices:
+        if 'CH340' in dev.description:
+            print(
+                dev.description + ": Likely an Arduino or derivative. Try " + dev.device + ".")
+        elif 'FTDI' in dev.description:
+            print(
+                dev.description + ": Likely an Arduino or derivative. Try " + dev.device + ".")
+        elif 'USB Serial Device' in dev.description:
+            print(
+                dev.description + ": Possibly an Arduino or derivative.")
+        else:
+            print(dev.description)
+
+
+# ***********************************************************************************
+#
+# Main function
+#
+# ***********************************************************************************
+def main():
+    try:
+        num_tries = 3
+
+        print('\n\nArtemis SVL Bootloader')
+
+        verboseprint("Script version " + SCRIPT_VERSION_MAJOR +
+                     "." + SCRIPT_VERSION_MINOR)
+
+        if not os.path.exists(args.binfile):
+            print("Bin file {} does not exist.".format(args.binfile))
+            exit()
+
+        bl_success = False
+        entered_bootloader = False
+
+        for _ in range(num_tries):
+
+            with serial.Serial(args.port, args.baud, timeout=args.timeout) as ser:
+
+                # startup time for Artemis bootloader   (experimentally determined - 0.095 sec min delay)
+                t_su = 0.15
+
+                time.sleep(t_su)        # Allow Artemis to come out of reset
+
+                # Perform baud rate negotiation
+                entered_bootloader = phase_setup(ser)
+
+                if(entered_bootloader == True):
+                    bl_success = phase_bootload(ser)
+                    if(bl_success == True):     # Bootload
+                        #print("Bootload complete!")
+                        break
+                else:
+                    verboseprint("Failed to enter bootload phase")
+
+            if(bl_success == True):
+                break
+
+        if(entered_bootloader == False):
+            print(
+                "Target failed to enter bootload mode. Verify the right COM port is selected and that your board has the SVL bootloader.")
+
+    except serial.SerialException:
+        phase_serial_port_help()
+
+    exit()
+
+
+# ******************************************************************************
+#
+# Main program flow
+#
+# ******************************************************************************
+if __name__ == '__main__':
+
+    parser = argparse.ArgumentParser(
+        description='SparkFun Serial Bootloader for Artemis')
+
+    parser.add_argument('port', help='Serial COMx Port')
+
+    parser.add_argument('-b', dest='baud', default=115200, type=int,
+                        help='Baud Rate (default is 115200)')
+
+    parser.add_argument('-f', dest='binfile', default='',
+                        help='Binary file to program into the target device')
+
+    parser.add_argument("-v", "--verbose", default=0, help="Enable verbose output",
+                        action="store_true")
+
+    parser.add_argument("-t", "--timeout", default=0.50, help="Communication timeout in seconds (default 0.5)",
+                        type=float)
+
+    if len(sys.argv) < 2:
+        print("No port selected. Detected Serial Ports:")
+        devices = list_ports.comports()
+        for dev in devices:
+            print(dev.description)
+
+    args = parser.parse_args()
+
+    # Create print function for verbose output if caller deems it: https://stackoverflow.com/questions/5980042/how-to-implement-the-verbose-or-v-option-into-a-script
+    if args.verbose:
+        def verboseprint(*args):
+            # Print each argument separately so caller doesn't need to
+            # stuff everything to be printed into a single string
+            for arg in args:
+                print(arg, end='', flush=True),
+            print()
+    else:
+        verboseprint = lambda *a: None      # do-nothing function
+
+    def twopartprint(verbosestr, printstr):
+        if args.verbose:
+            print(verbosestr, end='')
+
+        print(printstr)
+
+    main()


### PR DESCRIPTION
## What
Follows this [issue](https://github.com/embassy-rs/embassy/issues/3660#issue-2746236173).
Adds groundwork for "embassy-ambiq", a new HAL for the Ambiq Apollo 3, and some examples validated with Sparkfun RedBoard Artemis.

Implemented on this PR:
- GPIO: sync, async input/output, edge-triggered wait via GPIO IRQ
- Time driver
- Examples: async_blinky, async_button, sync_blinky

## Notes
- This is my first PR and I wanted to get feedback before continuing adding support for this MCU, I want to make sure that the implementation is "somewhat embassy-idiomatic" before investing more effort on it.
- The PAC I used was generated by me as well, since the ones I could find were unmaintained and their authors unresponsive. This might need a review as well. For now it's sitting on my personal repo and published as `apollo3-pac 0.2.0` on crates.io, I don't mind moving it somewhere else at your guidance.

## Questions
- VTOR relocation: `init()` optionally repoints VTOR to the app vector
  table (behind the `svl-vtor` feature) because the SparkFun SVL bootloader
  loads the app at a fixed offset and leaves VTOR pointing at its own table.
  Unsure about: (1) Does this belongs in the HAL at all? (2) Is a cargo feature is the right mechanism
  for a vendor bootloader specific?
- GPIO interrupt handler uses a `#[used]` keep-hack (see the comment in
  `gpio.rs`) to overcome the weak `DefaultHandler` fallbacks in the PAC's
  `device.x`. I intend to rework interrupt handling, open to
  guidance on the idiomatic pattern.