### PR TITLE
feature: add support for GPDMA on the DAC peripheral on STM32U5

### DIFF
--- a/embassy-stm32/src/dac/mod.rs
+++ b/embassy-stm32/src/dac/mod.rs
@@ -336,6 +336,27 @@ impl<'d> DacChannel<'d, Async> {
             w.set_dmaen(self.idx, false);
         });
     }
+
+    #[cfg(gpdma)]
+    pub async fn write<W: Word>(&mut self, buffer: &[W]) {
+        let _scoped_wake_guard = self.info.rcc.wake_guard();
+
+        // tsel and ten needed to connect the timer to the GPDMA transfer
+        self.info.regs.cr().modify(|w| {
+            w.set_tsel(self.idx, 5);
+            w.set_ten(self.idx, true);
+            w.set_en(self.idx, true);
+            w.set_dmaen(self.idx, true);
+        });
+
+        let dma = self.dma.as_mut().unwrap();
+        let tx_options = crate::dma::TransferOptions { ..Default::default() };
+        let tx_dst = W::dma_ptr(self.info.regs, self.idx);
+
+        let tx_f = unsafe { dma.write_raw(W::dma_buf(buffer), tx_dst, tx_options) };
+
+        tx_f.await;
+    }
 }
 
 impl<'d> DacChannel<'d, Blocking> {

--- a/embassy-stm32/src/dac/mod.rs
+++ b/embassy-stm32/src/dac/mod.rs
@@ -337,13 +337,17 @@ impl<'d> DacChannel<'d, Async> {
         });
     }
 
+    /// Write "data" to this channel using GPDMA
+    ///
+    /// It uses TIMx's trigger output (TSEL = 5 for TIM6) to pace each conversion.
+    /// Without a running trigger, the DAC never requests new data and this future hangs forever.
     #[cfg(gpdma)]
-    pub async fn write<W: Word>(&mut self, buffer: &[W]) {
+    pub async fn write<W: Word>(&mut self, buffer: &[W], trgo_timer: u8) {
         let _scoped_wake_guard = self.info.rcc.wake_guard();
 
         // tsel and ten needed to connect the timer to the GPDMA transfer
         self.info.regs.cr().modify(|w| {
-            w.set_tsel(self.idx, 5);
+            w.set_tsel(self.idx, trgo_timer);
             w.set_ten(self.idx, true);
             w.set_en(self.idx, true);
             w.set_dmaen(self.idx, true);

--- a/embassy-stm32/src/dac/mod.rs
+++ b/embassy-stm32/src/dac/mod.rs
@@ -12,7 +12,7 @@ use embassy_hal_internal::PeripheralType;
 use embassy_sync::blocking_mutex::raw::CriticalSectionRawMutex;
 pub use ringbuffered::RingBufferedDacChannel;
 
-use crate::dma::{ChannelAndRequest, word as dma};
+use crate::dma::{ChannelAndRequest, no_packing, word as dma};
 use crate::mode::{Async, Blocking, Mode as PeriMode};
 #[cfg(any(dac_v3, dac_v4, dac_v5, dac_v6, dac_v7))]
 use crate::pac::dac;
@@ -342,19 +342,22 @@ impl<'d> DacChannel<'d, Async> {
     /// It uses TIMx's trigger output (TSEL = 5 for TIM6) to pace each conversion.
     /// Without a running trigger, the DAC never requests new data and this future hangs forever.
     #[cfg(gpdma)]
-    pub async fn write<W: Word>(&mut self, buffer: &[W], trgo_timer: u8) {
+    pub async fn write<W: Word>(&mut self, buffer: &[W]) {
         let _scoped_wake_guard = self.info.rcc.wake_guard();
 
         // tsel and ten needed to connect the timer to the GPDMA transfer
         self.info.regs.cr().modify(|w| {
-            w.set_tsel(self.idx, trgo_timer);
+            //w.set_tsel(self.idx, trgo_timer);
             w.set_ten(self.idx, true);
             w.set_en(self.idx, true);
             w.set_dmaen(self.idx, true);
         });
 
         let dma = self.dma.as_mut().unwrap();
-        let tx_options = crate::dma::TransferOptions { ..Default::default() };
+        let tx_options = crate::dma::TransferOptions {
+            packing: no_packing(),
+            ..Default::default()
+        };
         let tx_dst = W::dma_ptr(self.info.regs, self.idx);
 
         let tx_f = unsafe { dma.write_raw(W::dma_buf(buffer), tx_dst, tx_options) };

--- a/embassy-stm32/src/dma/dma_bdma.rs
+++ b/embassy-stm32/src/dma/dma_bdma.rs
@@ -174,6 +174,11 @@ pub struct TransferOptions {
     pub word_swap: bool,
 }
 
+/// Return the no packing value
+pub const fn no_packing() -> bool {
+    false
+}
+
 impl Default for TransferOptions {
     fn default() -> Self {
         Self {

--- a/embassy-stm32/src/dma/gpdma/mod.rs
+++ b/embassy-stm32/src/dma/gpdma/mod.rs
@@ -22,6 +22,8 @@ use crate::rcc::WakeGuard;
 pub mod linked_list;
 pub mod ringbuffered;
 
+pub use vals::Pam;
+
 pub(crate) enum DmaInfo {
     #[cfg(gpdma)]
     Gpdma(pac::gpdma::Gpdma),
@@ -335,8 +337,7 @@ pub struct TransferOptions {
     #[cfg(stm32n6)]
     pub secure: bool,
     /// DMA packing configuration
-    #[cfg(any(gpdma, lpdma))]
-    pub packing: vals::Pam,
+    pub packing: Pam,
     /// Source/destination burst length, in beats. Default `_1Beats`. Some
     /// peripherals only assert their DMA request line for bursts above a
     /// threshold (notably the JPEG codec on N6), and some require multi-beat
@@ -350,6 +351,11 @@ pub struct TransferOptions {
     pub trigger: Option<TriggerConfig>,
 }
 
+/// Return the no packing value
+pub const fn no_packing() -> Pam {
+    Pam::ZeroExtendOrLeftTruncate
+}
+
 impl Default for TransferOptions {
     fn default() -> Self {
         Self {
@@ -358,7 +364,6 @@ impl Default for TransferOptions {
             complete_transfer_ir: true,
             #[cfg(stm32n6)]
             secure: false,
-            #[cfg(any(gpdma, lpdma))]
             packing: vals::Pam::Pack,
 
             #[cfg(not(stm32c5))]
@@ -465,7 +470,7 @@ pub(crate) unsafe fn init(cs: critical_section::CriticalSection, irq_priority: c
         };
     }
     crate::_generated::init_gpdma();
-    crate::_generated::init_lpdma();
+    //crate::_generated::init_lpdma();
 }
 
 pub(crate) unsafe fn on_irq(channel: DmaChannel) {


### PR DESCRIPTION
Implemented GPDMA support, tested using a simple u8 transfer to a LED