### PR TITLE
stm32/timer: add get_frequency for complementary pwm

### DIFF
--- a/embassy-stm32/src/timer/complementary_pwm.rs
+++ b/embassy-stm32/src/timer/complementary_pwm.rs
@@ -480,6 +480,11 @@ impl<'d, T: AdvancedInstance4Channel> ComplementaryPwm<'d, T> {
         self.inner.set_frequency(freq, RoundTo::Slower);
     }
 
+    /// Get the PWM driver frequency.
+    pub fn get_frequency(&self) -> Hertz {
+        self.inner.get_frequency()
+    }
+
     /// Set the PWM period in milliseconds.
     ///
     /// In the edge-aligned mode, the timer will wrap-around in given period.


### PR DESCRIPTION
Adds `get_frequency` function to complementary pwm like the one in simple pwm, because currently, the only way to get frequency of complementary pwm is using `get_period` from `embedded_hal_02::Pwm`. 

While testing this I found #6503.