### PR TITLE
stm32/qspi: add checks for address size

### DIFF
--- a/embassy-stm32/src/qspi/enums.rs
+++ b/embassy-stm32/src/qspi/enums.rs
@@ -136,9 +136,21 @@ pub enum AddressSize {
     /// 16-bit address
     _16Bit,
     /// 24-bit address
-    _24bit,
+    _24Bit,
     /// 32-bit address
-    _32bit,
+    _32Bit,
+}
+
+impl AddressSize {
+    /// The number of address bits for this address size
+    pub fn bit_width(self) -> u8 {
+        match self {
+            AddressSize::_8Bit => 8,
+            AddressSize::_16Bit => 16,
+            AddressSize::_24Bit => 24,
+            AddressSize::_32Bit => 32,
+        }
+    }
 }
 
 impl From<AddressSize> for u8 {
@@ -146,8 +158,8 @@ impl From<AddressSize> for u8 {
         match val {
             AddressSize::_8Bit => 0b00,
             AddressSize::_16Bit => 0b01,
-            AddressSize::_24bit => 0b10,
-            AddressSize::_32bit => 0b11,
+            AddressSize::_24Bit => 0b10,
+            AddressSize::_32Bit => 0b11,
         }
     }
 }

--- a/embassy-stm32/src/qspi/mod.rs
+++ b/embassy-stm32/src/qspi/mod.rs
@@ -77,7 +77,7 @@ impl Default for Config {
     fn default() -> Self {
         Self {
             memory_size: MemorySize::Other(0),
-            address_size: AddressSize::_24bit,
+            address_size: AddressSize::_24Bit,
             prescaler: 128,
             fifo_threshold: FIFOThresholdLevel::_17Bytes,
             cs_high_time: ChipSelectHighTime::_5Cycle,
@@ -360,7 +360,13 @@ impl<'d, T: Instance, M: PeriMode> Qspi<'d, T, M> {
 
         match (transaction.address, transaction.awidth) {
             (Some(_), QspiWidth::NONE) => panic!("QSPI address can't be sent with an address width of NONE"),
-            (Some(_), _) => {}
+            (Some(address), _) => {
+                // u32::bit_width was only stabilized in 1.97
+                let address_bit_width = u32::BITS - address.leading_zeros();
+                if address_bit_width > self.config.address_size.bit_width() as u32 {
+                    panic!("QSPI address too large to be represented with the given address size");
+                }
+            }
             (None, QspiWidth::NONE) => {}
             (None, _) => panic!("QSPI address is not set, so the address width should be NONE"),
         }

--- a/examples/stm32f7/src/bin/qspi.rs
+++ b/examples/stm32f7/src/bin/qspi.rs
@@ -280,7 +280,7 @@ async fn main(_spawner: Spawner) -> ! {
 
     let mut config = QspiCfg::default();
     config.memory_size = MemorySize::_8MiB;
-    config.address_size = AddressSize::_24bit;
+    config.address_size = AddressSize::_24Bit;
     config.prescaler = 16;
     config.cs_high_time = ChipSelectHighTime::_1Cycle;
     config.fifo_threshold = FIFOThresholdLevel::_16Bytes;

--- a/examples/stm32h7/src/bin/qspi_mdma.rs
+++ b/examples/stm32h7/src/bin/qspi_mdma.rs
@@ -75,7 +75,7 @@ impl<MODE: Mode> Flash<'_, MODE> {
         let mut config = qspi::Config::default();
 
         config.memory_size = MemorySize::_8MiB;
-        config.address_size = AddressSize::_24bit;
+        config.address_size = AddressSize::_24Bit;
         config.prescaler = 1;
         config.cs_high_time = ChipSelectHighTime::_2Cycle;
         config.fifo_threshold = FIFOThresholdLevel::_1Bytes;

--- a/examples/stm32h742/src/bin/qspi.rs
+++ b/examples/stm32h742/src/bin/qspi.rs
@@ -268,7 +268,7 @@ async fn main(_spawner: Spawner) -> ! {
 
     let mut config = QspiCfg::default();
     config.memory_size = MemorySize::_8MiB;
-    config.address_size = AddressSize::_24bit;
+    config.address_size = AddressSize::_24Bit;
     config.prescaler = 16;
     config.cs_high_time = ChipSelectHighTime::_1Cycle;
     config.fifo_threshold = FIFOThresholdLevel::_16Bytes;

--- a/examples/stm32l432/src/bin/qspi_mmap.rs
+++ b/examples/stm32l432/src/bin/qspi_mmap.rs
@@ -253,7 +253,7 @@ async fn main(_spawner: Spawner) {
 
     let mut config = qspi::Config::default();
     config.memory_size = MemorySize::_16MiB;
-    config.address_size = AddressSize::_24bit;
+    config.address_size = AddressSize::_24Bit;
     config.prescaler = 200;
     config.cs_high_time = ChipSelectHighTime::_1Cycle;
     config.fifo_threshold = FIFOThresholdLevel::_16Bytes;


### PR DESCRIPTION
This catches errors where the address gets silently truncated because of a mismatch with the address size.

This also makes the capitalization of the 24- and 32-bit variants of the AddressSize enum consistent with itself. The other *SPIs are also inconsistent, though: hspi uses all caps, whereas xspi uses all lowercase, and ospi uses a mix of both. Since the enum is the same between all of them, perhaps they could be combined into a single definition?