### PR TITLE
stm32/qspi: move address size to TransferConfig

### DIFF
--- a/embassy-stm32/src/qspi/mod.rs
+++ b/embassy-stm32/src/qspi/mod.rs
@@ -32,6 +32,8 @@ pub struct TransferConfig {
     pub instruction: u8,
     /// Flash memory address
     pub address: Option<u32>,
+    /// Address size (8/16/24/32-bit)
+    pub address_size: AddressSize,
     /// Number of dummy cycles (DCYC)
     pub dummy: DummyCycles,
 }
@@ -44,6 +46,7 @@ impl Default for TransferConfig {
             dwidth: QspiWidth::NONE,
             instruction: 0,
             address: None,
+            address_size: AddressSize::_24Bit,
             dummy: DummyCycles::_0,
         }
     }
@@ -57,8 +60,6 @@ pub struct Config {
     /// Flash memory size representend as 2^[0-32], as reasonable minimum 1KiB(9) was chosen.
     /// If you need other value the whose predefined use `Other` variant.
     pub memory_size: MemorySize,
-    /// Address size (8/16/24/32-bit)
-    pub address_size: AddressSize,
     /// Scalar factor for generating CLK [0-255]
     pub prescaler: u8,
     /// Number of bytes to trigger FIFO threshold flag.
@@ -77,7 +78,6 @@ impl Default for Config {
     fn default() -> Self {
         Self {
             memory_size: MemorySize::Other(0),
-            address_size: AddressSize::_24Bit,
             prescaler: 128,
             fifo_threshold: FIFOThresholdLevel::_17Bytes,
             cs_high_time: ChipSelectHighTime::_5Cycle,
@@ -280,7 +280,7 @@ impl<'d, T: Instance, M: PeriMode> Qspi<'d, T, M> {
             v.set_imode(transaction.iwidth.into());
             v.set_instruction(transaction.instruction);
             v.set_admode(transaction.awidth.into());
-            v.set_adsize(self.config.address_size.into());
+            v.set_adsize(transaction.address_size.into());
             v.set_dmode(transaction.dwidth.into());
             v.set_abmode(QspiWidth::NONE.into());
             v.set_dcyc(transaction.dummy.into());
@@ -363,7 +363,7 @@ impl<'d, T: Instance, M: PeriMode> Qspi<'d, T, M> {
             (Some(address), _) => {
                 // u32::bit_width was only stabilized in 1.97
                 let address_bit_width = u32::BITS - address.leading_zeros();
-                if address_bit_width > self.config.address_size.bit_width() as u32 {
+                if address_bit_width > transaction.address_size.bit_width() as u32 {
                     panic!("QSPI address too large to be represented with the given address size");
                 }
             }
@@ -397,7 +397,7 @@ impl<'d, T: Instance, M: PeriMode> Qspi<'d, T, M> {
             v.set_imode(transaction.iwidth.into());
             v.set_instruction(transaction.instruction);
             v.set_admode(transaction.awidth.into());
-            v.set_adsize(self.config.address_size.into());
+            v.set_adsize(transaction.address_size.into());
             v.set_dmode(transaction.dwidth.into());
             v.set_abmode(QspiWidth::NONE.into());
             v.set_dcyc(transaction.dummy.into());

--- a/examples/stm32f7/src/bin/qspi.rs
+++ b/examples/stm32f7/src/bin/qspi.rs
@@ -70,6 +70,7 @@ impl<I: Instance> FlashMemory<I> {
             dwidth: QspiWidth::NONE,
             instruction: cmd,
             address: None,
+            address_size: AddressSize::_24Bit,
             dummy: DummyCycles::_0,
         };
         self.qspi.blocking_command(transaction);
@@ -93,6 +94,7 @@ impl<I: Instance> FlashMemory<I> {
             dwidth: QspiWidth::SING,
             instruction: CMD_READ_ID,
             address: None,
+            address_size: AddressSize::_24Bit,
             dummy: DummyCycles::_0,
         };
         self.qspi.blocking_read(&mut buffer, transaction);
@@ -107,6 +109,7 @@ impl<I: Instance> FlashMemory<I> {
             dwidth: QspiWidth::SING,
             instruction: CMD_READ_UUID,
             address: Some(0),
+            address_size: AddressSize::_24Bit,
             dummy: DummyCycles::_8,
         };
         self.qspi.blocking_read(&mut buffer, transaction);
@@ -120,6 +123,7 @@ impl<I: Instance> FlashMemory<I> {
             dwidth: QspiWidth::QUAD,
             instruction: CMD_QUAD_READ,
             address: Some(addr),
+            address_size: AddressSize::_24Bit,
             dummy: DummyCycles::_8,
         };
         if use_dma {
@@ -140,6 +144,7 @@ impl<I: Instance> FlashMemory<I> {
             dwidth: QspiWidth::NONE,
             instruction: cmd,
             address: Some(addr),
+            address_size: AddressSize::_24Bit,
             dummy: DummyCycles::_0,
         };
         self.enable_write();
@@ -177,6 +182,7 @@ impl<I: Instance> FlashMemory<I> {
             dwidth: QspiWidth::QUAD,
             instruction: CMD_QUAD_WRITE_PG,
             address: Some(addr),
+            address_size: AddressSize::_24Bit,
             dummy: DummyCycles::_0,
         };
         self.enable_write();
@@ -212,6 +218,7 @@ impl<I: Instance> FlashMemory<I> {
             dwidth: QspiWidth::SING,
             instruction: cmd,
             address: None,
+            address_size: AddressSize::_24Bit,
             dummy: DummyCycles::_0,
         };
         self.qspi.blocking_read(&mut buffer, transaction);
@@ -226,6 +233,7 @@ impl<I: Instance> FlashMemory<I> {
             dwidth: QspiWidth::SING,
             instruction: cmd,
             address: None,
+            address_size: AddressSize::_24Bit,
             dummy: DummyCycles::_0,
         };
         self.qspi.blocking_write(&buffer, transaction);
@@ -280,7 +288,6 @@ async fn main(_spawner: Spawner) -> ! {
 
     let mut config = QspiCfg::default();
     config.memory_size = MemorySize::_8MiB;
-    config.address_size = AddressSize::_24Bit;
     config.prescaler = 16;
     config.cs_high_time = ChipSelectHighTime::_1Cycle;
     config.fifo_threshold = FIFOThresholdLevel::_16Bytes;

--- a/examples/stm32h7/src/bin/qspi_mdma.rs
+++ b/examples/stm32h7/src/bin/qspi_mdma.rs
@@ -75,7 +75,6 @@ impl<MODE: Mode> Flash<'_, MODE> {
         let mut config = qspi::Config::default();
 
         config.memory_size = MemorySize::_8MiB;
-        config.address_size = AddressSize::_24Bit;
         config.prescaler = 1;
         config.cs_high_time = ChipSelectHighTime::_2Cycle;
         config.fifo_threshold = FIFOThresholdLevel::_1Bytes;
@@ -91,6 +90,7 @@ impl<MODE: Mode> Flash<'_, MODE> {
             dwidth: QspiWidth::QUAD,
             instruction: FAST_READ_QUAD_IO_CMD,
             address: Some(address),
+            address_size: AddressSize::_24Bit,
             dummy: DummyCycles::_8,
         };
         self.qspi.blocking_read(buffer, transaction);
@@ -104,6 +104,7 @@ impl<MODE: Mode> Flash<'_, MODE> {
             dwidth: QspiWidth::SING,
             instruction: 0x4B,
             address: Some(0x00),
+            address_size: AddressSize::_24Bit,
             dummy: DummyCycles::_8,
         };
         self.qspi.blocking_read(&mut buffer, transaction);
@@ -131,6 +132,7 @@ impl<MODE: Mode> Flash<'_, MODE> {
                 dwidth: QspiWidth::QUAD,
                 instruction: WRITE_CMD,
                 address: Some(address),
+                address_size: AddressSize::_24Bit,
                 dummy: DummyCycles::_0,
             };
 
@@ -164,6 +166,7 @@ impl<MODE: Mode> Flash<'_, MODE> {
                 dwidth: QspiWidth::NONE,
                 instruction: SECTOR_ERASE_CMD,
                 address: Some(address),
+                address_size: AddressSize::_24Bit,
                 dummy: DummyCycles::_0,
             };
 
@@ -192,6 +195,7 @@ impl<MODE: Mode> Flash<'_, MODE> {
             dwidth: QspiWidth::NONE,
             instruction: WRITE_ENABLE_CMD,
             address: None,
+            address_size: AddressSize::_24Bit,
             dummy: DummyCycles::_0,
         };
         self.qspi.blocking_command(transaction);
@@ -213,6 +217,7 @@ impl<MODE: Mode> Flash<'_, MODE> {
             dwidth: QspiWidth::SING,
             instruction: READ_STATUS_REGISTER_CMD,
             address: None,
+            address_size: AddressSize::_24Bit,
             dummy: DummyCycles::_0,
         };
         self.qspi.blocking_read(&mut status, transaction);
@@ -226,6 +231,7 @@ impl<MODE: Mode> Flash<'_, MODE> {
             dwidth: QspiWidth::NONE,
             instruction: RESET_ENABLE_CMD,
             address: None,
+            address_size: AddressSize::_24Bit,
             dummy: DummyCycles::_0,
         };
         self.qspi.blocking_command(transaction);
@@ -236,6 +242,7 @@ impl<MODE: Mode> Flash<'_, MODE> {
             dwidth: QspiWidth::NONE,
             instruction: RESET_MEMORY_CMD,
             address: None,
+            address_size: AddressSize::_24Bit,
             dummy: DummyCycles::_0,
         };
         self.qspi.blocking_command(transaction);
@@ -252,6 +259,7 @@ impl<MODE: Mode> Flash<'_, MODE> {
             dwidth: QspiWidth::SING,
             instruction: WRITE_STATUS_REGISTER_CMD,
             address: None,
+            address_size: AddressSize::_24Bit,
             dummy: DummyCycles::_0,
         };
         self.qspi.blocking_write(&[value], transaction);
@@ -268,6 +276,7 @@ impl<MODE: Mode> Flash<'_, MODE> {
             dwidth: QspiWidth::SING,
             instruction: SET_READ_PARAMETERS_CMD,
             address: None,
+            address_size: AddressSize::_24Bit,
             dummy: DummyCycles::_0,
         };
         self.qspi.blocking_write(&[value], transaction);
@@ -333,6 +342,7 @@ impl<'a> Flash<'a, Async> {
             dwidth: QspiWidth::QUAD,
             instruction: FAST_READ_QUAD_IO_CMD,
             address: Some(address),
+            address_size: AddressSize::_24Bit,
             dummy: DummyCycles::_8,
         };
         self.qspi.read_dma(buffer, transaction).await;
@@ -358,6 +368,7 @@ impl<'a> Flash<'a, Async> {
                 dwidth: QspiWidth::QUAD,
                 instruction: WRITE_CMD,
                 address: Some(address),
+                address_size: AddressSize::_24Bit,
                 dummy: DummyCycles::_0,
             };
 
@@ -392,6 +403,7 @@ impl<'a> Flash<'a, Async> {
                 dwidth: QspiWidth::NONE,
                 instruction: SECTOR_ERASE_CMD,
                 address: Some(address),
+                address_size: AddressSize::_24Bit,
                 dummy: DummyCycles::_0,
             };
             self.qspi.blocking_command(transaction);
@@ -420,6 +432,7 @@ impl<'a> Flash<'a, Async> {
             dwidth: QspiWidth::SING,
             instruction: READ_STATUS_REGISTER_CMD,
             address: None,
+            address_size: AddressSize::_24Bit,
             dummy: DummyCycles::_0,
         };
 

--- a/examples/stm32h742/src/bin/qspi.rs
+++ b/examples/stm32h742/src/bin/qspi.rs
@@ -69,6 +69,7 @@ impl<I: Instance> FlashMemory<I> {
             dwidth: QspiWidth::NONE,
             instruction: cmd,
             address: None,
+            address_size: AddressSize::_24Bit,
             dummy: DummyCycles::_0,
         };
         self.qspi.blocking_command(transaction);
@@ -92,6 +93,7 @@ impl<I: Instance> FlashMemory<I> {
             dwidth: QspiWidth::SING,
             instruction: CMD_READ_ID,
             address: None,
+            address_size: AddressSize::_24Bit,
             dummy: DummyCycles::_0,
         };
         self.qspi.blocking_read(&mut buffer, transaction);
@@ -106,6 +108,7 @@ impl<I: Instance> FlashMemory<I> {
             dwidth: QspiWidth::SING,
             instruction: CMD_READ_UUID,
             address: Some(0),
+            address_size: AddressSize::_24Bit,
             dummy: DummyCycles::_8,
         };
         self.qspi.blocking_read(&mut buffer, transaction);
@@ -119,6 +122,7 @@ impl<I: Instance> FlashMemory<I> {
             dwidth: QspiWidth::QUAD,
             instruction: CMD_QUAD_READ,
             address: Some(addr),
+            address_size: AddressSize::_24Bit,
             dummy: DummyCycles::_8,
         };
         self.qspi.blocking_read(buffer, transaction);
@@ -135,6 +139,7 @@ impl<I: Instance> FlashMemory<I> {
             dwidth: QspiWidth::NONE,
             instruction: cmd,
             address: Some(addr),
+            address_size: AddressSize::_24Bit,
             dummy: DummyCycles::_0,
         };
         self.enable_write();
@@ -172,6 +177,7 @@ impl<I: Instance> FlashMemory<I> {
             dwidth: QspiWidth::QUAD,
             instruction: CMD_QUAD_WRITE_PG,
             address: Some(addr),
+            address_size: AddressSize::_24Bit,
             dummy: DummyCycles::_0,
         };
         self.enable_write();
@@ -203,6 +209,7 @@ impl<I: Instance> FlashMemory<I> {
             dwidth: QspiWidth::SING,
             instruction: cmd,
             address: None,
+            address_size: AddressSize::_24Bit,
             dummy: DummyCycles::_0,
         };
         self.qspi.blocking_read(&mut buffer, transaction);
@@ -217,6 +224,7 @@ impl<I: Instance> FlashMemory<I> {
             dwidth: QspiWidth::SING,
             instruction: cmd,
             address: None,
+            address_size: AddressSize::_24Bit,
             dummy: DummyCycles::_0,
         };
         self.qspi.blocking_write(&buffer, transaction);
@@ -268,7 +276,6 @@ async fn main(_spawner: Spawner) -> ! {
 
     let mut config = QspiCfg::default();
     config.memory_size = MemorySize::_8MiB;
-    config.address_size = AddressSize::_24Bit;
     config.prescaler = 16;
     config.cs_high_time = ChipSelectHighTime::_1Cycle;
     config.fifo_threshold = FIFOThresholdLevel::_16Bytes;

--- a/examples/stm32l432/src/bin/qspi_mmap.rs
+++ b/examples/stm32l432/src/bin/qspi_mmap.rs
@@ -55,6 +55,7 @@ impl<I: Instance> FlashMemory<I> {
             dwidth: QspiWidth::SING,
             instruction: cmd,
             address: None,
+            address_size: AddressSize::_24Bit,
             dummy: DummyCycles::_0,
         };
         self.qspi.blocking_read(&mut buffer, transaction);
@@ -69,6 +70,7 @@ impl<I: Instance> FlashMemory<I> {
             dwidth: QspiWidth::SING,
             instruction: cmd,
             address: None,
+            address_size: AddressSize::_24Bit,
             dummy: DummyCycles::_0,
         };
         self.qspi.blocking_write(&buffer, transaction);
@@ -81,6 +83,7 @@ impl<I: Instance> FlashMemory<I> {
             dwidth: QspiWidth::SING,
             instruction: CMD_WRITE_SR,
             address: None,
+            address_size: AddressSize::_24Bit,
             dummy: DummyCycles::_0,
         };
         self.qspi.blocking_write(&buffer, transaction);
@@ -105,6 +108,7 @@ impl<I: Instance> FlashMemory<I> {
             dwidth: QspiWidth::NONE,
             instruction: cmd,
             address: None,
+            address_size: AddressSize::_24Bit,
             dummy: DummyCycles::_0,
         };
         self.qspi.blocking_command(transaction);
@@ -121,6 +125,7 @@ impl<I: Instance> FlashMemory<I> {
             dwidth: QspiWidth::SING,
             instruction: CMD_READ_MID,
             address: Some(0),
+            address_size: AddressSize::_24Bit,
             dummy: DummyCycles::_0,
         };
         self.qspi.blocking_read(&mut buffer, transaction);
@@ -134,6 +139,7 @@ impl<I: Instance> FlashMemory<I> {
             dwidth: QspiWidth::SING,
             instruction: CMD_READ_UUID,
             address: Some(0),
+            address_size: AddressSize::_24Bit,
             dummy: DummyCycles::_8,
         };
         self.qspi.blocking_read(&mut buffer, transaction);
@@ -147,6 +153,7 @@ impl<I: Instance> FlashMemory<I> {
             dwidth: QspiWidth::SING,
             instruction: CMD_READ_ID,
             address: None,
+            address_size: AddressSize::_24Bit,
             dummy: DummyCycles::_0,
         };
         self.qspi.blocking_read(&mut buffer, transaction);
@@ -160,6 +167,7 @@ impl<I: Instance> FlashMemory<I> {
             dwidth: QspiWidth::QUAD,
             instruction: CMD_QUAD_READ,
             address: Some(0),
+            address_size: AddressSize::_24Bit,
             dummy: DummyCycles::_8,
         };
         self.qspi.enable_memory_map(&transaction);
@@ -171,6 +179,7 @@ impl<I: Instance> FlashMemory<I> {
             dwidth: QspiWidth::NONE,
             instruction: cmd,
             address: Some(addr),
+            address_size: AddressSize::_24Bit,
             dummy: DummyCycles::_0,
         };
         self.enable_write();
@@ -197,6 +206,7 @@ impl<I: Instance> FlashMemory<I> {
             dwidth: QspiWidth::QUAD,
             instruction: CMD_QUAD_WRITE_PG,
             address: Some(addr),
+            address_size: AddressSize::_24Bit,
             dummy: DummyCycles::_0,
         };
         self.enable_write();
@@ -230,6 +240,7 @@ impl<I: Instance> FlashMemory<I> {
             dwidth: QspiWidth::QUAD,
             instruction: CMD_QUAD_READ,
             address: Some(addr),
+            address_size: AddressSize::_24Bit,
             dummy: DummyCycles::_8,
         };
         if use_dma {
@@ -253,7 +264,6 @@ async fn main(_spawner: Spawner) {
 
     let mut config = qspi::Config::default();
     config.memory_size = MemorySize::_16MiB;
-    config.address_size = AddressSize::_24Bit;
     config.prescaler = 200;
     config.cs_high_time = ChipSelectHighTime::_1Cycle;
     config.fifo_threshold = FIFOThresholdLevel::_16Bytes;


### PR DESCRIPTION
Closes #6498.

This now matches the behaviour of ospi/hspi/xspi, which store the address size in TransferConfig. I have tested the patch with the NAND flash driver that motivated the opening of the above issue, and it now works as expected.