### PR TITLE
nrf: add System OFF support for nRF54L series

### DIFF
--- a/embassy-nrf/CHANGELOG.md
+++ b/embassy-nrf/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 <!-- next-header -->
 ## Unreleased - ReleaseDate
 
+- added: System OFF support for the nRF54L series.
+
 ## 0.11.0 - 2026-06-16
 
 - added: support for the SQSPI peripheral for nRF54.

--- a/embassy-nrf/src/lib.rs
+++ b/embassy-nrf/src/lib.rs
@@ -134,8 +134,12 @@ pub use rramc as nvmc;
     feature = "_nrf91",
 ))]
 pub mod pdm;
-#[cfg(not(feature = "_nrf54l"))] // TODO
-#[cfg(any(feature = "nrf52840", feature = "nrf9160-s", feature = "nrf9160-ns"))]
+#[cfg(any(
+    feature = "nrf52840",
+    feature = "nrf9160-s",
+    feature = "nrf9160-ns",
+    feature = "_nrf54l"
+))]
 pub mod power;
 pub mod ppi;
 #[cfg(feature = "_nrf54l")]

--- a/embassy-nrf/src/power.rs
+++ b/embassy-nrf/src/power.rs
@@ -2,13 +2,13 @@
 
 #[cfg(feature = "nrf52840")]
 use crate::chip::pac::POWER;
-#[cfg(any(feature = "nrf9160-s", feature = "nrf9160-ns"))]
+#[cfg(any(feature = "nrf9160-s", feature = "nrf9160-ns", feature = "_nrf54l"))]
 use crate::chip::pac::REGULATORS;
 
 /// Puts the MCU into "System Off" mode with minimal power usage
 pub fn set_system_off() {
     #[cfg(feature = "nrf52840")]
     POWER.systemoff().write(|w| w.set_systemoff(true));
-    #[cfg(any(feature = "nrf9160-s", feature = "nrf9160-ns"))]
+    #[cfg(any(feature = "nrf9160-s", feature = "nrf9160-ns", feature = "_nrf54l"))]
     REGULATORS.systemoff().write(|w| w.set_systemoff(true));
 }

--- a/examples/nrf54l15-app/src/bin/system_off.rs
+++ b/examples/nrf54l15-app/src/bin/system_off.rs
@@ -1,0 +1,33 @@
+#![no_std]
+#![no_main]
+
+use defmt::info;
+use embassy_executor::Spawner;
+use embassy_nrf::gpio::{Input, Level, Output, OutputDrive, Pull};
+use embassy_nrf::pac::gpio::vals::Sense;
+use embassy_nrf::{pac, power};
+use embassy_time::Timer;
+use {defmt_rtt as _, panic_probe as _};
+
+#[embassy_executor::main]
+async fn main(_spawner: Spawner) {
+    let p = embassy_nrf::init(Default::default());
+
+    // LED 0 on the nRF54L15-DK. Lit while awake, so wakeup is visible.
+    let mut led = Output::new(p.P2_09, Level::High, OutputDrive::Standard);
+
+    info!("Entering System OFF in 5 seconds. Press Button 0 to wake up.");
+    Timer::after_secs(5).await;
+    led.set_low();
+
+    // Button 0 on the nRF54L15-DK is on P1.13, active low.
+    let _button = Input::new(p.P1_13, Pull::Up);
+    // Enable SENSE on the button pin so it wakes the chip from System OFF.
+    pac::P1.pin_cnf(13).modify(|w| w.set_sense(Sense::Low));
+
+    info!("Entering System OFF now.");
+    power::set_system_off();
+
+    // The chip is now in System OFF. Wakeup causes a reset.
+    loop {}
+}


### PR DESCRIPTION
Adds System OFF support for the nRF54L series to `embassy-nrf`.

- `power::set_system_off()` now covers nRF54L by writing
  `REGULATORS.SYSTEMOFF`, same as the existing nRF91 path (the nRF54L has
  no dedicated POWER.SYSTEMOFF register). This matches Zephyr's
  implementation in `soc/nordic/common/poweroff.c`

Note: on nRF54L all RAM is retained in System OFF by reset default
(https://docs.nordicsemi.com/r/bundle/ps_nrf54l15/page/memconf.html), so power consumption stays above the datasheet floor. RAM retention control is intentionally left out of this PR.  I'll open a
separate issue to discuss the API for it.

Tested on hardware (nRF54L15-DK): flashed the example with probe-rs.

Steps to test on hardware:
- Navigate into `embassy/examples/nrf54l15-app`
- Build and flash the application `cargo run --release --bin system_off`
- Terminate the probe-rs connection as it is keeping the debug port active and prevents the uC going into `system off` state
- Unplug/plug the power cable
- `led0` is on and after 5 seconds `led0` turns off as nRF54L15 goes into `system off` mode
- Press `button0` to wake-up, it will be cold boot.
