### PR TITLE
Add i2c support for stm32c5

### DIFF
--- a/embassy-stm32/Cargo.toml
+++ b/embassy-stm32/Cargo.toml
@@ -213,11 +213,11 @@ heapless = "0.9.1"
 once_cell = { version = "1.21.4", default-features = false, features=["critical-section"] }
 
 # stm32-metapac = { version = "21" }
-stm32-metapac = { git = "https://github.com/embassy-rs/stm32-data-generated", tag = "stm32-data-43d482dc249c6755fe990b67e86be4fdc9092909" }
+stm32-metapac = { git = "https://ci.embassy.dev/jobs/7784512d0581/artifacts/generated.git" }
 
 [build-dependencies]
 # stm32-metapac = { version = "21", default-features = false, features = ["metadata"]}
-stm32-metapac = { git = "https://github.com/embassy-rs/stm32-data-generated", tag = "stm32-data-43d482dc249c6755fe990b67e86be4fdc9092909", default-features = false, features = ["metadata"] }
+stm32-metapac = { git = "https://ci.embassy.dev/jobs/7784512d0581/artifacts/generated.git" , default-features = false, features = ["metadata"] }
 
 proc-macro2 = "1.0.36"
 quote = "1.0.15"

--- a/embassy-stm32/Cargo.toml
+++ b/embassy-stm32/Cargo.toml
@@ -213,11 +213,11 @@ heapless = "0.9.1"
 once_cell = { version = "1.21.4", default-features = false, features=["critical-section"] }
 
 # stm32-metapac = { version = "21" }
-stm32-metapac = { git = "https://ci.embassy.dev/jobs/7784512d0581/artifacts/generated.git" }
+stm32-metapac = { git = "https://github.com/embassy-rs/stm32-data-generated", tag = "stm32-data-ffae283b17ba1da175ee2888115409bb55c2f6ad" }
 
 [build-dependencies]
 # stm32-metapac = { version = "21", default-features = false, features = ["metadata"]}
-stm32-metapac = { git = "https://ci.embassy.dev/jobs/7784512d0581/artifacts/generated.git" , default-features = false, features = ["metadata"] }
+stm32-metapac = { git = "https://github.com/embassy-rs/stm32-data-generated", tag = "stm32-data-ffae283b17ba1da175ee2888115409bb55c2f6ad" , default-features = false, features = ["metadata"] }
 
 proc-macro2 = "1.0.36"
 quote = "1.0.15"

--- a/embassy-stm32/src/macros.rs
+++ b/embassy-stm32/src/macros.rs
@@ -1,6 +1,5 @@
 #![macro_use]
 
-#[cfg(not(stm32c5))]
 macro_rules! peri_trait {
     (
         $(irqs: [$($irq:ident),*],)?

--- a/examples/stm32c5/src/bin/i2c.rs
+++ b/examples/stm32c5/src/bin/i2c.rs
@@ -1,0 +1,42 @@
+#![no_std]
+#![no_main]
+
+use defmt::*;
+use embassy_executor::Spawner;
+use embassy_stm32::i2c::{Error, I2c};
+use embassy_stm32::{bind_interrupts, dma, i2c, peripherals};
+use {defmt_rtt as _, panic_probe as _};
+
+const ADDRESS: u8 = 0x5F;
+const WHOAMI: u8 = 0x0F;
+
+bind_interrupts!(struct Irqs {
+    I2C2_EV => i2c::EventInterruptHandler<peripherals::I2C2>;
+    I2C2_ERR => i2c::ErrorInterruptHandler<peripherals::I2C2>;
+    LPDMA1_CH4 => dma::InterruptHandler<peripherals::LPDMA1_CH4>;
+    LPDMA1_CH5 => dma::InterruptHandler<peripherals::LPDMA1_CH5>;
+});
+
+#[embassy_executor::main]
+async fn main(_spawner: Spawner) {
+    info!("Hello world!");
+    let p = embassy_stm32::init(Default::default());
+
+    let mut i2c = I2c::new(
+        p.I2C2,
+        p.PA11,
+        p.PA12,
+        p.LPDMA1_CH4,
+        p.LPDMA1_CH5,
+        Irqs,
+        Default::default(),
+    );
+
+    let mut data = [0u8; 1];
+
+    match i2c.blocking_write_read(ADDRESS, &[WHOAMI], &mut data) {
+        Ok(()) => info!("Whoami: {}", data[0]),
+        Err(Error::Timeout) => error!("Operation timed out"),
+        Err(e) => error!("I2c Error: {:?}", e),
+    }
+}


### PR DESCRIPTION
Remove peri_trait not gate to allow i2c support for stm32c5.

Tested using stm32c562re nucleo board and a LPS27HHW sensor