### PR TITLE
stm32/can: add loopback examples for classic CAN, FD, and split TX/RX

### DIFF
--- a/examples/stm32u5/src/bin/can.rs
+++ b/examples/stm32u5/src/bin/can.rs
@@ -5,12 +5,11 @@
 // Tested on a NUCLEO-U545RE-Q; builds under this directory's stm32u5g9zj feature.
 
 use defmt::{error, info};
-use defmt_rtt as _;
 use embassy_executor::Spawner;
 use embassy_stm32::can::{CanConfigurator, Frame, IT0InterruptHandler, IT1InterruptHandler, filter};
 use embassy_stm32::{Config, bind_interrupts, peripherals};
 use embassy_time::Timer;
-use panic_probe as _;
+use {defmt_rtt as _, panic_probe as _};
 
 // FDCAN1 has 2 interrupt lines which must be bound
 

--- a/examples/stm32u5/src/bin/can.rs
+++ b/examples/stm32u5/src/bin/can.rs
@@ -1,0 +1,96 @@
+#![no_std]
+#![no_main]
+
+// CAN example for the STM32U5, in internal loopback mode.
+// Tested on a NUCLEO-U545RE-Q; builds under this directory's stm32u5g9zj feature.
+
+use defmt::{error, info};
+use defmt_rtt as _;
+use embassy_executor::Spawner;
+use embassy_stm32::can::{CanConfigurator, Frame, IT0InterruptHandler, IT1InterruptHandler, filter};
+use embassy_stm32::{Config, bind_interrupts, peripherals};
+use embassy_time::Timer;
+use panic_probe as _;
+
+// FDCAN1 has 2 interrupt lines which must be bound
+
+// Manual: rm0456, pg 3023/3651
+bind_interrupts!(struct Irqs {
+    FDCAN1_IT0 => IT0InterruptHandler<peripherals::FDCAN1>;
+    FDCAN1_IT1 => IT1InterruptHandler<peripherals::FDCAN1>;
+});
+
+#[embassy_executor::main]
+async fn main(_spawner: Spawner) {
+    let mut config = Config::default();
+    {
+        use embassy_stm32::rcc::*;
+        // The HSE crystal is not populated on the MB1841 board (see UM3062), so the system
+        // and FDCAN are clocked from the internal 16 MHz HSI via PLL1
+        config.rcc.hsi = true;
+        config.rcc.pll1 = Some(Pll {
+            source: PllSource::Hsi,
+            prediv: PllPreDiv::Div1,  // 16 MHz
+            mul: PllMul::Mul10,       // VCO = 16 × 10 = 160 MHz
+            divp: None,               // unused
+            divq: Some(PllDiv::Div4), // 40 MHz FDCAN kernel clock
+            divr: Some(PllDiv::Div1), // 160 MHz for the CPU
+        });
+
+        config.rcc.sys = Sysclk::Pll1R;
+        config.rcc.mux.fdcan1sel = mux::Fdcansel::Pll1Q;
+    }
+
+    let p = embassy_stm32::init(config);
+    info!("Device started");
+
+    let mut can = CanConfigurator::new(p.FDCAN1, p.PA11, p.PA12, Irqs);
+
+    // Standard CAN bit rate. Every node on a bus must use the same one —
+    // 125k / 250k / 500k / 1M are the common choices.
+    can.set_bitrate(250_000);
+
+    can.properties().set_extended_filter(
+        filter::ExtendedFilterSlot::_0,
+        filter::ExtendedFilter::accept_all_into_fifo1(),
+    );
+
+    // Internal loopback: TX is looped to RX inside the chip.
+    // External loopback: TX is driven on the pin and looped back through a transceiver
+    // Normal mode: needs a transceiver AND a second node to ACK.
+    let mut can = can.into_internal_loopback_mode();
+    info!("CAN configured !");
+
+    let mut i = 0;
+    let mut last_read_ts = embassy_time::Instant::now();
+
+    loop {
+        info!("Writing frame...");
+        // Arbitrary 29-bit extended ID. On a real bus the ID also sets priority (lower = higher).
+        let frame = Frame::new_extended(0x123456F, &[i; 8]).unwrap();
+        can.write(&frame).await;
+
+        match can.read().await {
+            Ok(envelope) => {
+                let (ts, rx_frame) = (envelope.ts, envelope.frame);
+                let delta = (ts - last_read_ts).as_millis();
+                last_read_ts = ts;
+
+                info!(
+                    "Rx: {} {:02x} --- {}ms",
+                    rx_frame.header().len(),                              // Number of data bytes
+                    rx_frame.data()[0..rx_frame.header().len() as usize], // Slice of the valid payload
+                    delta,
+                )
+            }
+            Err(err) => error!("Error in frame: {}", err),
+        }
+
+        Timer::after_millis(250).await;
+
+        i += 1;
+        if i > 2 {
+            break;
+        }
+    }
+}

--- a/examples/stm32u5/src/bin/can_split.rs
+++ b/examples/stm32u5/src/bin/can_split.rs
@@ -1,0 +1,110 @@
+#![no_std]
+#![no_main]
+
+// CAN example for the STM32U5 using split() to drive TX and RX from separate tasks.
+// Tested on a NUCLEO-U545RE-Q; builds under this directory's stm32u5g9zj feature.
+use defmt::{error, info};
+use defmt_rtt as _;
+use embassy_executor::Spawner;
+use embassy_stm32::can::{CanConfigurator, CanRx, CanTx, Frame, IT0InterruptHandler, IT1InterruptHandler, filter};
+use embassy_stm32::{Config, bind_interrupts, peripherals};
+use embassy_time::{Instant, Timer};
+use panic_probe as _;
+
+// FDCAN1 has 2 interrupt lines which must be bound
+// Manual: rm0456, pg 3023/3651
+bind_interrupts!(struct Irqs {
+    FDCAN1_IT0 => IT0InterruptHandler<peripherals::FDCAN1>;
+    FDCAN1_IT1 => IT1InterruptHandler<peripherals::FDCAN1>;
+});
+
+#[embassy_executor::task]
+async fn writer(mut tx: CanTx<'static>) {
+    let mut i = 0;
+    let start = Instant::now();
+    loop {
+        info!("Writing frame...");
+        // Arbitrary 29-bit extended ID. On a real bus the ID also sets priority (lower = higher).
+        let frame = Frame::new_extended(0x123456F, &[i; 8]).unwrap();
+        tx.write(&frame).await;
+        let elapsed_ms = start.elapsed().as_millis(); // Time since the task has started
+        info!("tx: Sent frame {} at: {} ms", i, elapsed_ms);
+
+        i += 1;
+        if i > 3 {
+            break;
+        }
+        // Keep the task from blocking the MCU
+        Timer::after_millis(250).await;
+    }
+}
+
+#[embassy_executor::task]
+async fn reader(mut rx: CanRx<'static>) {
+    loop {
+        match rx.read().await {
+            Ok(envelope) => info!("Rx: Received {:02x}", envelope.frame.data()), // Slice of the valid payload
+            Err(_err) => error!("rx error"),
+        }
+
+        // Keep the task from blocking the MCU
+        Timer::after_millis(250).await;
+    }
+}
+
+#[embassy_executor::main]
+async fn main(spawner: Spawner) {
+    let mut config = Config::default();
+    {
+        use embassy_stm32::rcc::*;
+        // The HSE crystal is not populated on the MB1841 board (see UM3062), so the system
+        // and FDCAN are clocked from the internal 16 MHz HSI via PLL1
+        config.rcc.hsi = true;
+        config.rcc.pll1 = Some(Pll {
+            source: PllSource::Hsi,
+            prediv: PllPreDiv::Div1,  // 16 MHz
+            mul: PllMul::Mul10,       // VCO = 16 × 10 = 160 MHz
+            divp: None,               // unused
+            divq: Some(PllDiv::Div4), // 40 MHz FDCAN kernel clock
+            divr: Some(PllDiv::Div1), // 160 MHz for the CPU
+        });
+
+        config.rcc.sys = Sysclk::Pll1R;
+        config.rcc.mux.fdcan1sel = mux::Fdcansel::Pll1Q;
+    }
+
+    let p = embassy_stm32::init(config);
+    info!("Device started");
+
+    let mut can = CanConfigurator::new(p.FDCAN1, p.PA11, p.PA12, Irqs);
+
+    // Standard CAN bit rate. Every node on a bus must use the same one —
+    // 125k / 250k / 500k / 1M are the common choices.
+    can.set_bitrate(250_000);
+
+    // Accept every frame into the RX FIFO. Without a filter, the peripheral discards
+    // all incoming frames, so read() would block forever.
+    can.properties().set_extended_filter(
+        filter::ExtendedFilterSlot::_0,
+        filter::ExtendedFilter::accept_all_into_fifo1(),
+    );
+
+    // Internal loopback: TX is looped to RX inside the chip.
+    // External loopback: TX is driven on the pin and looped back through a transceiver
+    // Normal mode: needs a transceiver AND a second node to ACK.
+    let can = can.into_internal_loopback_mode();
+    info!("CAN configured !");
+
+    // if read and write capabilities need to be divided across tasks, use .split() to get owned values that can be passed to tasks
+    // split() hands ownership of TX and RX to separate tasks, so neither needs a Mutex to share one Can — the point of the function.
+
+    let (tx, rx, _properties) = can.split();
+
+    spawner.spawn(writer(tx).unwrap());
+    spawner.spawn(reader(rx).unwrap());
+
+    // Keep main alive while tasks are polled
+    loop {
+        Timer::after_millis(100).await;
+    }
+}

--- a/examples/stm32u5/src/bin/can_split.rs
+++ b/examples/stm32u5/src/bin/can_split.rs
@@ -4,12 +4,11 @@
 // CAN example for the STM32U5 using split() to drive TX and RX from separate tasks.
 // Tested on a NUCLEO-U545RE-Q; builds under this directory's stm32u5g9zj feature.
 use defmt::{error, info};
-use defmt_rtt as _;
 use embassy_executor::Spawner;
 use embassy_stm32::can::{CanConfigurator, CanRx, CanTx, Frame, IT0InterruptHandler, IT1InterruptHandler, filter};
 use embassy_stm32::{Config, bind_interrupts, peripherals};
 use embassy_time::{Instant, Timer};
-use panic_probe as _;
+use {defmt_rtt as _, panic_probe as _};
 
 // FDCAN1 has 2 interrupt lines which must be bound
 // Manual: rm0456, pg 3023/3651

--- a/examples/stm32u5/src/bin/fd_can.rs
+++ b/examples/stm32u5/src/bin/fd_can.rs
@@ -5,12 +5,11 @@
 // Tested on a NUCLEO-U545RE-Q; builds under this directory's stm32u5g9zj feature.
 
 use defmt::{error, info};
-use defmt_rtt as _;
 use embassy_executor::Spawner;
 use embassy_stm32::can::{CanConfigurator, IT0InterruptHandler, IT1InterruptHandler, filter, frame};
 use embassy_stm32::{Config, bind_interrupts, peripherals};
 use embassy_time::Timer;
-use panic_probe as _;
+use {defmt_rtt as _, panic_probe as _};
 
 // FDCAN1 has 2 interrupt lines which must be bound
 // Manual: rm0456, pg 3023/3651

--- a/examples/stm32u5/src/bin/fd_can.rs
+++ b/examples/stm32u5/src/bin/fd_can.rs
@@ -1,0 +1,97 @@
+#![no_std]
+#![no_main]
+
+// FDCAN example for the STM32U5, in internal loopback mode.
+// Tested on a NUCLEO-U545RE-Q; builds under this directory's stm32u5g9zj feature.
+
+use defmt::{error, info};
+use defmt_rtt as _;
+use embassy_executor::Spawner;
+use embassy_stm32::can::{CanConfigurator, IT0InterruptHandler, IT1InterruptHandler, filter, frame};
+use embassy_stm32::{Config, bind_interrupts, peripherals};
+use embassy_time::Timer;
+use panic_probe as _;
+
+// FDCAN1 has 2 interrupt lines which must be bound
+// Manual: rm0456, pg 3023/3651
+bind_interrupts!(struct Irqs {
+    FDCAN1_IT0 => IT0InterruptHandler<peripherals::FDCAN1>;
+    FDCAN1_IT1 => IT1InterruptHandler<peripherals::FDCAN1>;
+});
+
+#[embassy_executor::main]
+async fn main(_spawner: Spawner) {
+    let mut config = Config::default();
+    {
+        use embassy_stm32::rcc::*;
+        // The HSE crystal is not populated on the MB1841 board (see UM3062), so the system
+        // and FDCAN are clocked from the internal 16 MHz HSI via PLL1
+        config.rcc.hsi = true;
+        config.rcc.pll1 = Some(Pll {
+            source: PllSource::Hsi,
+            prediv: PllPreDiv::Div1,  // 16 MHz
+            mul: PllMul::Mul10,       // VCO = 16 × 10 = 160 MHz
+            divp: None,               // unused
+            divq: Some(PllDiv::Div4), // 40 MHz FDCAN kernel clock
+            divr: Some(PllDiv::Div1), // 160 MHz for the CPU
+        });
+
+        config.rcc.sys = Sysclk::Pll1R;
+        config.rcc.mux.fdcan1sel = mux::Fdcansel::Pll1Q;
+    }
+
+    let p = embassy_stm32::init(config);
+    info!("Device started");
+
+    let mut can = CanConfigurator::new(p.FDCAN1, p.PA11, p.PA12, Irqs);
+
+    // Standard CAN bit rate. Every node on a bus must use the same one —
+    // 125k / 250k / 500k / 1M are the common choices.
+    can.set_bitrate(250_000);
+    // false disables bit-rate switching (BRS), so frames use the nominal rate throughout
+    can.set_fd_data_bitrate(1_000_000, false);
+
+    can.properties().set_extended_filter(
+        filter::ExtendedFilterSlot::_0,
+        filter::ExtendedFilter::accept_all_into_fifo1(),
+    );
+
+    // Internal loopback: TX is looped to RX inside the chip.
+    // External loopback: TX is driven on the pin and looped back through a transceiver
+    // Normal mode: needs a transceiver AND a second node to ACK.
+    let mut can = can.into_internal_loopback_mode();
+    info!("CAN configured !");
+
+    let mut i = 0;
+    let mut last_read_ts = embassy_time::Instant::now();
+
+    loop {
+        info!("Writing frame using FD Api");
+        // Arbitrary 29-bit extended ID. On a real bus the ID also sets priority (lower = higher).
+        // FD frames carry up to 64 data bytes, vs. 8 for classic CAN.
+        let frame = frame::FdFrame::new_extended(0x123456F, &[i; 64]).unwrap();
+        can.write_fd(&frame).await;
+
+        match can.read_fd().await {
+            Ok(envelope) => {
+                let (ts, rx_frame) = (envelope.ts, envelope.frame);
+                let delta = (ts - last_read_ts).as_millis();
+                last_read_ts = ts;
+                info!(
+                    "Rx: {} {:02x} --- using FD API {}ms",
+                    rx_frame.header().len(),                              // Number of data bytes
+                    rx_frame.data()[0..rx_frame.header().len() as usize], // Slice of the valid payload
+                    delta,
+                )
+            }
+            Err(err) => error!("Error in frame: {}", err),
+        }
+
+        i += 1;
+        if i > 4 {
+            break;
+        }
+
+        Timer::after_millis(250).await;
+    }
+}


### PR DESCRIPTION
Adds three CAN bus examples for the STM32U5: one using classic CAN frames, one using CAN-FD frames, and one driving RX and TX from separate tasks via split().

All three were hardware-tested on a NUCLEO-U545RE-Q development board (stm32u545re feature, STM32U545REIx chip) and successfully compile against this directory's pinned stm32u5g9zj feature (STM32U5G9ZJTxQ chip).