### PR TITLE
mcxa: enable DMA0 channels 8-11 on MCXA5xx

### DIFF
--- a/embassy-mcxa/Cargo.toml
+++ b/embassy-mcxa/Cargo.toml
@@ -59,7 +59,7 @@ grounded = { version = "0.2.1", features = ["cas", "critical-section"] }
 heapless = "0.9"
 maitake-sync = { version = "0.3.0", default-features = false, features = ["critical-section", "no-cache-pad"] }
 nb = "1.1.0"
-nxp-pac = { git = "https://github.com/embassy-rs/nxp-pac.git", rev = "a46946e7f5ba3b5d8136f2962400300d54a99d6c", features = ["rt"] }
+nxp-pac = { git = "https://github.com/embassy-rs/nxp-pac.git", rev = "8512ecedcd0fe9c2713d06f3bbd1b7f93805f306", features = ["rt"] }
 paste = "1.0.15"
 
 rand-core-06 = { package = "rand_core", version = "0.6" }
@@ -67,7 +67,7 @@ rand-core-09 = { package = "rand_core", version = "0.9" }
 rand-core-10 = { package = "rand_core", version = "0.10" }
 
 [build-dependencies]
-nxp-pac = { git = "https://github.com/embassy-rs/nxp-pac.git", rev = "a46946e7f5ba3b5d8136f2962400300d54a99d6c", default-features = false, features = ["metadata"] }
+nxp-pac = { git = "https://github.com/embassy-rs/nxp-pac.git", rev = "8512ecedcd0fe9c2713d06f3bbd1b7f93805f306", default-features = false, features = ["metadata"] }
 proc-macro2 = "1.0.106"
 quote = "1.0.45"
 regex = "1.12.3"

--- a/embassy-mcxa/build.rs
+++ b/embassy-mcxa/build.rs
@@ -169,7 +169,15 @@ fn generate_cc_gates() -> TokenStream {
             .config
             .map(|config| format_ident!("{config}"))
             .unwrap_or_else(|| format_ident!("NoConfig"));
-        let bit = format_ident!("{}", peripheral.name.to_lowercase());
+        // The FlexCAN peripherals are named `CANn` in the peripheral metadata, but
+        // their MRCC clock-gate/reset register fields are named `flexcann`. Map the
+        // gate bit name accordingly; all other peripherals use their lowercased name.
+        let bit_name = match peripheral.name {
+            "CAN0" => "flexcan0".to_string(),
+            "CAN1" => "flexcan1".to_string(),
+            other => other.to_lowercase(),
+        };
+        let bit = format_ident!("{}", bit_name);
 
         match reset {
             Some(reset) => generated.extend(quote! {

--- a/embassy-mcxa/src/clocks/periph_helpers.rs
+++ b/embassy-mcxa/src/clocks/periph_helpers.rs
@@ -219,6 +219,18 @@ impl SPConfHelper for DacConfig {
     }
 }
 
+/// Placeholder configuration for the FlexCAN peripheral.
+///
+/// The FlexCAN HAL driver is not yet implemented, but the PAC metadata
+/// declares the gate config type, so we provide a stub here. Replace
+/// with the real implementation when the CAN driver is added.
+pub struct CanConfig;
+impl SPConfHelper for CanConfig {
+    fn pre_enable_config(&self, _clocks: &Clocks) -> Result<PreEnableParts, ClockError> {
+        Ok(PreEnableParts::empty())
+    }
+}
+
 //
 // Adc
 //

--- a/embassy-mcxa/src/dma.rs
+++ b/embassy-mcxa/src/dma.rs
@@ -6,9 +6,9 @@
 //!
 //! # Architecture
 //!
-//! The MCXA276 has 8 DMA channels (0-7), each with its own interrupt vector.
-//! Each channel has a Transfer Control Descriptor (TCD) that defines the
-//! transfer parameters.
+//! DMA0 has 8 channels (0-7) on MCXA2xx and 12 channels (0-11) on MCXA5xx,
+//! each with its own interrupt vector. Each channel has a Transfer Control
+//! Descriptor (TCD) that defines the transfer parameters.
 //!
 //! # Choosing the Right API
 //!
@@ -397,6 +397,14 @@ impl_channel!(DMA0_CH4, 4, DMA0_CH4);
 impl_channel!(DMA0_CH5, 5, DMA0_CH5);
 impl_channel!(DMA0_CH6, 6, DMA0_CH6);
 impl_channel!(DMA0_CH7, 7, DMA0_CH7);
+#[cfg(feature = "mcxa5xx")]
+impl_channel!(DMA0_CH8, 8, DMA0_CH8);
+#[cfg(feature = "mcxa5xx")]
+impl_channel!(DMA0_CH9, 9, DMA0_CH9);
+#[cfg(feature = "mcxa5xx")]
+impl_channel!(DMA0_CH10, 10, DMA0_CH10);
+#[cfg(feature = "mcxa5xx")]
+impl_channel!(DMA0_CH11, 11, DMA0_CH11);
 
 /// Parameters used to configure a 'typical' DMA transfer in [DmaChannel::setup_typical].
 struct DmaTransferParameters<WSRC: Word, WDST: Word> {
@@ -1316,7 +1324,15 @@ impl State {
     }
 }
 
-static STATES: [State; 8] = [const { State::new() }; 8];
+/// Number of DMA0 channels backed by the `EDMA_0_TCD` array.
+///
+/// DMA0 exposes 8 channels on MCXA2xx and 12 channels on MCXA5xx.
+#[cfg(feature = "mcxa5xx")]
+pub(crate) const DMA0_CHANNELS: usize = 12;
+#[cfg(not(feature = "mcxa5xx"))]
+pub(crate) const DMA0_CHANNELS: usize = 8;
+
+static STATES: [State; DMA0_CHANNELS] = [const { State::new() }; DMA0_CHANNELS];
 
 pub(crate) fn waker(idx: usize) -> &'static WaitCell {
     &STATES[idx].waker
@@ -2249,8 +2265,16 @@ impl_dma_interrupt_handler!(DMA0_CH4, 4);
 impl_dma_interrupt_handler!(DMA0_CH5, 5);
 impl_dma_interrupt_handler!(DMA0_CH6, 6);
 impl_dma_interrupt_handler!(DMA0_CH7, 7);
+#[cfg(feature = "mcxa5xx")]
+impl_dma_interrupt_handler!(DMA0_CH8, 8);
+#[cfg(feature = "mcxa5xx")]
+impl_dma_interrupt_handler!(DMA0_CH9, 9);
+#[cfg(feature = "mcxa5xx")]
+impl_dma_interrupt_handler!(DMA0_CH10, 10);
+#[cfg(feature = "mcxa5xx")]
+impl_dma_interrupt_handler!(DMA0_CH11, 11);
 
 // TODO(AJM): This is a gross, gross hack. This implements optional callbacks
 // for DMA completion interrupts. This should go away once we switch to
 // "in-band" DMA interrupt binding with `bind_interrupts!`.
-static CALLBACKS: [AtomicPtr<()>; 8] = [const { AtomicPtr::new(core::ptr::null_mut()) }; 8];
+static CALLBACKS: [AtomicPtr<()>; DMA0_CHANNELS] = [const { AtomicPtr::new(core::ptr::null_mut()) }; DMA0_CHANNELS];


### PR DESCRIPTION
## Summary

The MCXA5xx (e.g. MCXA577) exposes **12 DMA0 channels (0-11)**, but the `embassy-mcxa` driver only implemented channels 0-7 — a leftover from the 8-channel MCXA2xx port. This PR enables DMA0 channels 8-11 on MCXA5xx.

## Changes

- **Bump `nxp-pac`** to pick up the `EDMA_0_TCD` `Tcd12` fix (embassy-rs/nxp-pac#112), so the TCD register array actually has 12 slots. Without it, channels 8-11 would index past the 8-slot array at runtime.
- **Add `impl_channel!` and `impl_dma_interrupt_handler!` for `DMA0_CH8`-`DMA0_CH11`** (`mcxa5xx` only). NVIC wiring is derived dynamically from each channel's interrupt, so no additional plumbing is needed.
- **Replace the hardcoded `[_; 8]` `STATES`/`CALLBACKS` array sizes** with a `DMA0_CHANNELS` const (12 on `mcxa5xx`, 8 otherwise).

### Incidental: FlexCAN clock-gate build fix

The `nxp-pac` bump also pulls in FlexCAN clock-gate metadata that `embassy-mcxa` did not yet handle (unrelated to DMA, but required for the crate to compile against current `nxp-pac` `main`). Minimal fix:
- Add a `CanConfig` gate-config placeholder mirroring the existing `DacConfig`.
- Map the `CANn` peripheral name to its `flexcann` MRCC register field in the gate codegen.

There is no CAN HAL driver yet; this only keeps the build green.

## Not included

**DMA1 (CH0-3)** remains unimplemented and is intentionally left for a follow-up, as it requires decoupling the flat channel index from the per-controller TCD/state indexing.

## Testing

Builds clean for both `--features mcxa5xx` and `--features mcxa2xx` on `thumbv8m.main-none-eabihf`.
