### PR TITLE
[MCXA] Add DMA1 support

### DIFF
--- a/embassy-mcxa/Cargo.toml
+++ b/embassy-mcxa/Cargo.toml
@@ -59,7 +59,7 @@ grounded = { version = "0.2.1", features = ["cas", "critical-section"] }
 heapless = "0.9"
 maitake-sync = { version = "0.3.0", default-features = false, features = ["critical-section", "no-cache-pad"] }
 nb = "1.1.0"
-nxp-pac = { git = "https://github.com/embassy-rs/nxp-pac.git", rev = "a46946e7f5ba3b5d8136f2962400300d54a99d6c", features = ["rt"] }
+nxp-pac = { git = "https://github.com/embassy-rs/nxp-pac.git", rev = "8512ecedcd0fe9c2713d06f3bbd1b7f93805f306", features = ["rt"] }
 paste = "1.0.15"
 
 rand-core-06 = { package = "rand_core", version = "0.6" }
@@ -67,7 +67,7 @@ rand-core-09 = { package = "rand_core", version = "0.9" }
 rand-core-10 = { package = "rand_core", version = "0.10" }
 
 [build-dependencies]
-nxp-pac = { git = "https://github.com/embassy-rs/nxp-pac.git", rev = "a46946e7f5ba3b5d8136f2962400300d54a99d6c", default-features = false, features = ["metadata"] }
+nxp-pac = { git = "https://github.com/embassy-rs/nxp-pac.git", rev = "8512ecedcd0fe9c2713d06f3bbd1b7f93805f306", default-features = false, features = ["metadata"] }
 proc-macro2 = "1.0.106"
 quote = "1.0.45"
 regex = "1.12.3"

--- a/embassy-mcxa/build.rs
+++ b/embassy-mcxa/build.rs
@@ -39,11 +39,6 @@ fn main() {
         }
 
         cfgs.enable(&driver_to_cfg_name(peripheral.driver_name));
-
-        // Also enable cfgs for each peripheral
-        let peripheral_gate = format!("peripheral_{}", peripheral.name);
-        cfgs.declare(&peripheral_gate);
-        cfgs.enable(&peripheral_gate);
     }
 
     let generated = [

--- a/embassy-mcxa/build.rs
+++ b/embassy-mcxa/build.rs
@@ -39,6 +39,11 @@ fn main() {
         }
 
         cfgs.enable(&driver_to_cfg_name(peripheral.driver_name));
+
+        // Also enable cfgs for each peripheral
+        let peripheral_gate = format!("peripheral_{}", peripheral.name);
+        cfgs.declare(&peripheral_gate);
+        cfgs.enable(&peripheral_gate);
     }
 
     let generated = [
@@ -56,6 +61,7 @@ fn main() {
         generate_ctimer_pin_impls(),
         generate_lpuart_pin_impls(),
         generate_flexspi_pin_impls(),
+        generate_dma_impls(),
     ];
 
     let out_dir = &PathBuf::from(env::var_os("OUT_DIR").unwrap());
@@ -158,6 +164,10 @@ fn generate_cc_gates() -> TokenStream {
     let mut generated = TokenStream::new();
 
     for peripheral in METADATA.peripherals {
+        if peripheral.name.to_ascii_lowercase().starts_with("can") {
+            continue;
+        }
+
         let Some(gate) = peripheral.gate.as_ref() else {
             continue;
         };
@@ -498,6 +508,35 @@ fn generate_lpuart_pin_impls() -> TokenStream {
 }
 
 fn generate_dma_requests_enum() -> TokenStream {
+    let mut generated = TokenStream::new();
+
+    let dma_regex = Regex::new(r"(?:^DMA)(\d+)").unwrap();
+    let dma_driver_regex = Regex::new(r"(?:DMA)(\d+)").unwrap();
+
+    for (dma, dma_num) in METADATA
+        .peripherals
+        .iter()
+        .filter_map(|p| get_regex_num(p.name, &dma_regex).map(|num| (p, num)))
+    {
+        let num_channels = get_regex_num(dma.driver_name, &dma_driver_regex).unwrap();
+
+        for channel_num in 0..num_channels {
+            let dma_num = proc_macro2::Literal::u32_unsuffixed(dma_num);
+            let channel_num = proc_macro2::Literal::u32_unsuffixed(channel_num);
+
+            let channel_ident = format_ident!("DMA{dma_num}_CH{channel_num}");
+
+            generated.extend(quote! {
+                crate::impl_dma_channel!(#channel_ident, #dma_num, #channel_num, #channel_ident);
+                crate::impl_dma_interrupt_handler!(#channel_ident, #dma_num, #channel_num);
+            });
+        }
+    }
+
+    generated
+}
+
+fn generate_dma_impls() -> TokenStream {
     let mut dma_requests = HashMap::new();
     for dma_mux in METADATA.peripherals.iter().flat_map(|p| p.dma_muxing) {
         dma_requests.insert(dma_mux.signal, dma_mux.request);

--- a/embassy-mcxa/src/dma.rs
+++ b/embassy-mcxa/src/dma.rs
@@ -473,9 +473,8 @@ impl DmaChannel<'_> {
     #[inline]
     pub(crate) fn tcd(&self) -> pac::edma_tcd::Tcd {
         match self.dma() {
-            #[cfg(peripheral_EDMA_0_TCD)]
             0 => pac::EDMA_0_TCD.tcd(self.channel.channel()),
-            #[cfg(peripheral_EDMA_1_TCD)]
+            #[cfg(feature = "mcxa5xx")]
             1 => pac::EDMA_1_TCD.tcd(self.channel.channel()),
             _ => unreachable!(),
         }
@@ -2206,9 +2205,8 @@ pub(crate) unsafe fn on_interrupt(dma: usize, channel: usize) {
     crate::perf_counters::incr_interrupt_edma0();
 
     let t = match dma {
-        #[cfg(peripheral_EDMA_0_TCD)]
         0 => pac::EDMA_0_TCD.tcd(channel),
-        #[cfg(peripheral_EDMA_1_TCD)]
+        #[cfg(feature = "mcxa5xx")]
         1 => pac::EDMA_1_TCD.tcd(channel),
         _ => unreachable!(),
     };

--- a/embassy-mcxa/src/dma.rs
+++ b/embassy-mcxa/src/dma.rs
@@ -124,6 +124,8 @@ use crate::pac::edma_tcd::{
     TcdNbytesMloffnoSmloe,
 };
 use crate::pac::{self, Interrupt};
+#[cfg(feature = "mcxa5xx")]
+use crate::peripherals::DMA1;
 use crate::peripherals::DMA0;
 
 /// Initialize DMA controller (clock enabled, reset released, controller configured).
@@ -144,6 +146,22 @@ pub(crate) fn init() {
         w.set_gclc(true);
         w.set_gmrc(true);
     });
+
+    // Enable DMA1 clock, release reset, and configure its management page.
+    // Without this, any access to the DMA1 TCD registers faults because the
+    // peripheral is unclocked and held in reset.
+    #[cfg(feature = "mcxa5xx")]
+    {
+        let _ = unsafe { enable_and_reset::<DMA1>(&NoConfig) };
+
+        pac::DMA1.mp_csr().modify(|w| {
+            w.set_edbg(true);
+            w.set_erca(true);
+            w.set_halt(Halt::NormalOperation);
+            w.set_gclc(true);
+            w.set_gmrc(true);
+        });
+    }
 
     // Enable all DMA request lines for non-secure access.
     #[cfg(all(feature = "mcxa5xx", feature = "dma-ipd-req"))]

--- a/embassy-mcxa/src/dma.rs
+++ b/embassy-mcxa/src/dma.rs
@@ -299,11 +299,14 @@ pub struct InvalidParameters;
 /// than this must be split into multiple DMA operations.
 pub const DMA_MAX_TRANSFER_SIZE: usize = 0x7FFF;
 
-mod sealed {
+pub(crate) mod sealed {
     /// Sealed trait for DMA channels.
     pub trait SealedChannel {
+        /// The dma instance number
+        fn dma(&self) -> usize;
+
         /// Zero-based channel index into the TCD array.
-        fn index(&self) -> usize;
+        fn channel(&self) -> usize;
 
         /// Interrupt vector for this channel.
         fn interrupt(&self) -> crate::interrupt::Interrupt;
@@ -347,14 +350,19 @@ pub trait Channel: sealed::SealedChannel + PeripheralType + Into<AnyChannel> + '
 /// ```
 #[derive(Debug, Clone, Copy)]
 pub struct AnyChannel {
-    index: usize,
-    interrupt: Interrupt,
+    pub(crate) dma: u8,
+    pub(crate) channel: u8,
+    pub(crate) interrupt: Interrupt,
 }
 
 impl PeripheralType for AnyChannel {}
 impl sealed::SealedChannel for AnyChannel {
-    fn index(&self) -> usize {
-        self.index
+    fn dma(&self) -> usize {
+        self.dma as usize
+    }
+
+    fn channel(&self) -> usize {
+        self.channel as usize
     }
 
     fn interrupt(&self) -> Interrupt {
@@ -364,39 +372,37 @@ impl sealed::SealedChannel for AnyChannel {
 
 impl Channel for AnyChannel {}
 
+#[doc(hidden)]
+#[macro_export]
 /// Macro to implement Channel trait for a peripheral.
-macro_rules! impl_channel {
-    ($peri:ident, $index:expr, $irq:ident) => {
-        impl sealed::SealedChannel for crate::peripherals::$peri {
-            fn index(&self) -> usize {
-                $index
+macro_rules! impl_dma_channel {
+    ($peri:ident, $dma:expr, $channel:expr, $irq:ident) => {
+        impl crate::dma::sealed::SealedChannel for crate::peripherals::$peri {
+            fn dma(&self) -> usize {
+                $dma
             }
 
-            fn interrupt(&self) -> Interrupt {
-                Interrupt::$irq
+            fn channel(&self) -> usize {
+                $channel
+            }
+
+            fn interrupt(&self) -> nxp_pac::Interrupt {
+                nxp_pac::Interrupt::$irq
             }
         }
-        impl Channel for crate::peripherals::$peri {}
+        impl crate::dma::Channel for crate::peripherals::$peri {}
 
-        impl From<crate::peripherals::$peri> for AnyChannel {
+        impl From<crate::peripherals::$peri> for crate::dma::AnyChannel {
             fn from(_: crate::peripherals::$peri) -> Self {
-                AnyChannel {
-                    index: $index,
-                    interrupt: Interrupt::$irq,
+                crate::dma::AnyChannel {
+                    dma: $dma,
+                    channel: $channel,
+                    interrupt: nxp_pac::Interrupt::$irq,
                 }
             }
         }
     };
 }
-
-impl_channel!(DMA0_CH0, 0, DMA0_CH0);
-impl_channel!(DMA0_CH1, 1, DMA0_CH1);
-impl_channel!(DMA0_CH2, 2, DMA0_CH2);
-impl_channel!(DMA0_CH3, 3, DMA0_CH3);
-impl_channel!(DMA0_CH4, 4, DMA0_CH4);
-impl_channel!(DMA0_CH5, 5, DMA0_CH5);
-impl_channel!(DMA0_CH6, 6, DMA0_CH6);
-impl_channel!(DMA0_CH7, 7, DMA0_CH7);
 
 /// Parameters used to configure a 'typical' DMA transfer in [DmaChannel::setup_typical].
 struct DmaTransferParameters<WSRC: Word, WDST: Word> {
@@ -453,15 +459,26 @@ impl DmaChannel<'_> {
 
     /// Channel index in the EDMA_0_TCD0 array.
     #[inline]
-    pub(crate) fn index(&self) -> usize {
-        self.channel.index()
+    pub(crate) fn channel(&self) -> usize {
+        self.channel.channel()
+    }
+
+    /// Dma index
+    #[inline]
+    pub(crate) fn dma(&self) -> usize {
+        self.channel.dma()
     }
 
     /// Return a reference to the underlying TCD register block.
     #[inline]
     pub(crate) fn tcd(&self) -> pac::edma_tcd::Tcd {
-        // Safety: MCXA276 has a single eDMA instance
-        pac::EDMA_0_TCD.tcd(self.channel.index())
+        match self.dma() {
+            #[cfg(peripheral_EDMA_0_TCD)]
+            0 => pac::EDMA_0_TCD.tcd(self.channel.channel()),
+            #[cfg(peripheral_EDMA_1_TCD)]
+            1 => pac::EDMA_1_TCD.tcd(self.channel.channel()),
+            _ => unreachable!(),
+        }
     }
 
     /// set a manual callback to be called AFTER the DMA interrupt is processed. Will be called in the DMA interrupt
@@ -472,7 +489,7 @@ impl DmaChannel<'_> {
     pub(crate) unsafe fn set_callback(&mut self, f: fn()) {
         // See https://doc.rust-lang.org/std/primitive.fn.html#casting-to-and-from-integers
         let cb = f as *mut ();
-        CALLBACKS[self.index()].store(cb, Ordering::Release);
+        CALLBACKS[self.dma()][self.channel()].store(cb, Ordering::Release);
     }
 
     /// Unset the callback, causing no method to be called after DMA completion.
@@ -480,7 +497,7 @@ impl DmaChannel<'_> {
     /// SAFETY: This must only be called on an owned DmaChannel, as there is only a single
     /// callback slot, and calling this will invalidate any previously set callbacks.
     pub(crate) unsafe fn clear_callback(&mut self) {
-        CALLBACKS[self.index()].store(core::ptr::null_mut(), Ordering::Release);
+        CALLBACKS[self.dma()][self.channel()].store(core::ptr::null_mut(), Ordering::Release);
     }
 
     /// Access TCD DADDR field
@@ -1139,7 +1156,7 @@ impl DmaChannel<'_> {
 
     /// Get the wait cell for this channel
     pub(crate) fn wait_cell(&self) -> &'static WaitCell {
-        &STATES[self.channel.index()].waker
+        &STATES[self.channel.dma()][self.channel.channel()].waker
     }
 
     /// Enable the interrupt for this channel in the NVIC.
@@ -1316,14 +1333,14 @@ impl State {
     }
 }
 
-static STATES: [State; 8] = [const { State::new() }; 8];
+static STATES: [[State; 12]; 2] = [const { [const { State::new() }; 12] }; 2];
 
-pub(crate) fn waker(idx: usize) -> &'static WaitCell {
-    &STATES[idx].waker
+pub(crate) fn waker(dma: usize, channel: usize) -> &'static WaitCell {
+    &STATES[dma][channel].waker
 }
 
-pub(crate) fn half_waker(idx: usize) -> &'static WaitCell {
-    &STATES[idx].half_waker
+pub(crate) fn half_waker(dma: usize, channel: usize) -> &'static WaitCell {
+    &STATES[dma][channel].half_waker
 }
 
 // ============================================================================
@@ -1387,7 +1404,7 @@ impl<'a> Transfer<'a> {
         use core::future::poll_fn;
 
         poll_fn(|cx| {
-            let state = &STATES[self.channel.index()];
+            let state = &STATES[self.channel.dma()][self.channel.channel()];
 
             // Register the half-transfer waker
             let _ = state.half_waker.poll_wait(cx);
@@ -1648,7 +1665,7 @@ impl<'a> Future for Transfer<'a> {
                 };
             }
 
-            match STATES[self.channel.index()].waker.poll_wait(cx) {
+            match STATES[self.channel.dma()][self.channel.channel()].waker.poll_wait(cx) {
                 Poll::Pending => return Poll::Pending,
                 // Consumed a stale wake; loop and re-check is_done, then
                 // try registering the waker again on the next iteration.
@@ -1832,7 +1849,7 @@ impl<'channel, 'buf, W: Word> RingBuffer<'channel, 'buf, W> {
             }
 
             // Register wakers for both half and complete interrupts
-            let state = &STATES[self.channel.index()];
+            let state = &STATES[self.channel.dma()][self.channel.channel()];
             let _ = state.waker.poll_wait(cx);
             let _ = state.half_waker.poll_wait(cx);
 
@@ -2185,10 +2202,16 @@ pub struct ScatterGatherResult {
 ///
 /// # Safety
 /// Must be called from the correct DMA channel interrupt context.
-unsafe fn on_interrupt(ch_index: usize) {
+pub(crate) unsafe fn on_interrupt(dma: usize, channel: usize) {
     crate::perf_counters::incr_interrupt_edma0();
-    let edma = &pac::EDMA_0_TCD;
-    let t = edma.tcd(ch_index);
+
+    let t = match dma {
+        #[cfg(peripheral_EDMA_0_TCD)]
+        0 => pac::EDMA_0_TCD.tcd(channel),
+        #[cfg(peripheral_EDMA_1_TCD)]
+        1 => pac::EDMA_1_TCD.tcd(channel),
+        _ => unreachable!(),
+    };
 
     // Read TCD CSR to determine interrupt source
     let csr = t.tcd_csr().read();
@@ -2203,7 +2226,7 @@ unsafe fn on_interrupt(ch_index: usize) {
         if citer <= half_point && citer > 0 {
             // Half-transfer interrupt - wake half_waker
             crate::perf_counters::incr_interrupt_edma0_wake();
-            half_waker(ch_index).wake();
+            half_waker(dma, channel).wake();
         }
     }
 
@@ -2214,22 +2237,24 @@ unsafe fn on_interrupt(ch_index: usize) {
     // Only wake the full-transfer waker when the transfer is actually complete
     if t.ch_csr().read().done() {
         crate::perf_counters::incr_interrupt_edma0_wake();
-        waker(ch_index).wake();
+        waker(dma, channel).wake();
     }
 }
 
+#[doc(hidden)]
+#[macro_export]
 /// Macro to generate DMA channel interrupt handlers.
 macro_rules! impl_dma_interrupt_handler {
-    ($irq:ident, $ch:expr) => {
-        #[interrupt]
+    ($irq:ident, $dma:expr, $ch:expr) => {
+        #[cortex_m_rt::interrupt]
         fn $irq() {
             // SAFETY: The correct $ch is called as generated, We check that
             // the given callback is non-null before calling.
             unsafe {
-                on_interrupt($ch);
+                crate::dma::on_interrupt($dma, $ch);
 
                 // See https://doc.rust-lang.org/std/primitive.fn.html#casting-to-and-from-integers
-                let cb: *mut () = CALLBACKS[$ch].load(Ordering::Acquire);
+                let cb: *mut () = crate::dma::CALLBACKS[$dma][$ch].load(core::sync::atomic::Ordering::Acquire);
                 if !cb.is_null() {
                     let cb: fn() = core::mem::transmute(cb);
                     (cb)();
@@ -2239,18 +2264,8 @@ macro_rules! impl_dma_interrupt_handler {
     };
 }
 
-use crate::pac::interrupt;
-
-impl_dma_interrupt_handler!(DMA0_CH0, 0);
-impl_dma_interrupt_handler!(DMA0_CH1, 1);
-impl_dma_interrupt_handler!(DMA0_CH2, 2);
-impl_dma_interrupt_handler!(DMA0_CH3, 3);
-impl_dma_interrupt_handler!(DMA0_CH4, 4);
-impl_dma_interrupt_handler!(DMA0_CH5, 5);
-impl_dma_interrupt_handler!(DMA0_CH6, 6);
-impl_dma_interrupt_handler!(DMA0_CH7, 7);
-
 // TODO(AJM): This is a gross, gross hack. This implements optional callbacks
 // for DMA completion interrupts. This should go away once we switch to
 // "in-band" DMA interrupt binding with `bind_interrupts!`.
-static CALLBACKS: [AtomicPtr<()>; 8] = [const { AtomicPtr::new(core::ptr::null_mut()) }; 8];
+pub(crate) static CALLBACKS: [[AtomicPtr<()>; 12]; 2] =
+    [const { [const { AtomicPtr::new(core::ptr::null_mut()) }; 12] }; 2];

--- a/embassy-mcxa/src/dma.rs
+++ b/embassy-mcxa/src/dma.rs
@@ -124,9 +124,9 @@ use crate::pac::edma_tcd::{
     TcdNbytesMloffnoSmloe,
 };
 use crate::pac::{self, Interrupt};
+use crate::peripherals::DMA0;
 #[cfg(feature = "mcxa5xx")]
 use crate::peripherals::DMA1;
-use crate::peripherals::DMA0;
 
 /// Initialize DMA controller (clock enabled, reset released, controller configured).
 ///


### PR DESCRIPTION
Adds DMA0_8..=11 and DMA1_0..=3 support. This is now generated from the build.rs.

@bramsdell-ms I've tried adding DMA1 to the HAL. Implementation should work, but it doesn't... But I don't really have time to debug.

To reproduce, go to the mcxa5xx examples, dma_mem_to_mem and then change dma0_ch0 to dma1_ch0. Run the example and you'll see a hardfault because of some pointer write.