### PR TITLE
Add SPI support for stm32c5

### DIFF
--- a/embassy-stm32/Cargo.toml
+++ b/embassy-stm32/Cargo.toml
@@ -213,11 +213,11 @@ heapless = "0.9.1"
 once_cell = { version = "1.21.4", default-features = false, features=["critical-section"] }
 
 # stm32-metapac = { version = "21" }
-stm32-metapac = { git = "https://github.com/embassy-rs/stm32-data-generated", tag = "stm32-data-43d482dc249c6755fe990b67e86be4fdc9092909" }
+stm32-metapac = { git = "https://ci.embassy.dev/jobs/7784512d0581/artifacts/generated.git" }
 
 [build-dependencies]
 # stm32-metapac = { version = "21", default-features = false, features = ["metadata"]}
-stm32-metapac = { git = "https://github.com/embassy-rs/stm32-data-generated", tag = "stm32-data-43d482dc249c6755fe990b67e86be4fdc9092909", default-features = false, features = ["metadata"] }
+stm32-metapac = { git = "https://ci.embassy.dev/jobs/7784512d0581/artifacts/generated.git" , default-features = false, features = ["metadata"] }
 
 proc-macro2 = "1.0.36"
 quote = "1.0.15"

--- a/embassy-stm32/Cargo.toml
+++ b/embassy-stm32/Cargo.toml
@@ -213,11 +213,11 @@ heapless = "0.9.1"
 once_cell = { version = "1.21.4", default-features = false, features=["critical-section"] }
 
 # stm32-metapac = { version = "21" }
-stm32-metapac = { git = "https://ci.embassy.dev/jobs/103f8dd854f1/artifacts/generated.git" }
+stm32-metapac = { git = "https://github.com/embassy-rs/stm32-data-generated", tag = "stm32-data-1912ac7d73c27f03863fb2d71fbfddf0d9fce062" }
 
 [build-dependencies]
 # stm32-metapac = { version = "21", default-features = false, features = ["metadata"]}
-stm32-metapac = { git = "https://ci.embassy.dev/jobs/103f8dd854f1/artifacts/generated.git" , default-features = false, features = ["metadata"] }
+stm32-metapac = { git = "https://github.com/embassy-rs/stm32-data-generated", tag = "stm32-data-1912ac7d73c27f03863fb2d71fbfddf0d9fce062" , default-features = false, features = ["metadata"] }
 
 proc-macro2 = "1.0.36"
 quote = "1.0.15"

--- a/embassy-stm32/Cargo.toml
+++ b/embassy-stm32/Cargo.toml
@@ -213,11 +213,11 @@ heapless = "0.9.1"
 once_cell = { version = "1.21.4", default-features = false, features=["critical-section"] }
 
 # stm32-metapac = { version = "21" }
-stm32-metapac = { git = "https://github.com/embassy-rs/stm32-data-generated", tag = "stm32-data-ffae283b17ba1da175ee2888115409bb55c2f6ad" }
+stm32-metapac = { git = "https://ci.embassy.dev/jobs/103f8dd854f1/artifacts/generated.git" }
 
 [build-dependencies]
 # stm32-metapac = { version = "21", default-features = false, features = ["metadata"]}
-stm32-metapac = { git = "https://github.com/embassy-rs/stm32-data-generated", tag = "stm32-data-ffae283b17ba1da175ee2888115409bb55c2f6ad" , default-features = false, features = ["metadata"] }
+stm32-metapac = { git = "https://ci.embassy.dev/jobs/103f8dd854f1/artifacts/generated.git" , default-features = false, features = ["metadata"] }
 
 proc-macro2 = "1.0.36"
 quote = "1.0.15"

--- a/embassy-stm32/Cargo.toml
+++ b/embassy-stm32/Cargo.toml
@@ -213,11 +213,11 @@ heapless = "0.9.1"
 once_cell = { version = "1.21.4", default-features = false, features=["critical-section"] }
 
 # stm32-metapac = { version = "21" }
-stm32-metapac = { git = "https://ci.embassy.dev/jobs/7784512d0581/artifacts/generated.git" }
+stm32-metapac = { git = "https://github.com/embassy-rs/stm32-data-generated", tag = "stm32-data-ffae283b17ba1da175ee2888115409bb55c2f6ad" }
 
 [build-dependencies]
 # stm32-metapac = { version = "21", default-features = false, features = ["metadata"]}
-stm32-metapac = { git = "https://ci.embassy.dev/jobs/7784512d0581/artifacts/generated.git" , default-features = false, features = ["metadata"] }
+stm32-metapac = { git = "https://github.com/embassy-rs/stm32-data-generated", tag = "stm32-data-ffae283b17ba1da175ee2888115409bb55c2f6ad" , default-features = false, features = ["metadata"] }
 
 proc-macro2 = "1.0.36"
 quote = "1.0.15"

--- a/embassy-stm32/src/dma/util.rs
+++ b/embassy-stm32/src/dma/util.rs
@@ -34,7 +34,6 @@ impl<'d> ChannelAndRequest<'d> {
         self.channel.read(self.request, peri_addr, buf, options)
     }
 
-    #[cfg(not(stm32c5))]
     /// Create a read DMA transfer (peripheral to memory), using raw pointers.
     pub unsafe fn read_raw<'a, MW: Word, PW: Word>(
         &'a mut self,
@@ -68,7 +67,6 @@ impl<'d> ChannelAndRequest<'d> {
         self.channel.write(self.request, buf, peri_addr, options)
     }
 
-    #[cfg(not(stm32c5))]
     /// Create a write DMA transfer (memory to peripheral), using raw pointers.
     pub unsafe fn write_raw<'a, MW: Word, PW: Word>(
         &'a mut self,

--- a/embassy-stm32/src/gpio.rs
+++ b/embassy-stm32/src/gpio.rs
@@ -701,7 +701,7 @@ fn set_as_af(pin_port: PinNumber, af_num: u8, af_type: AfType) {
 }
 
 #[inline(never)]
-#[cfg(all(gpio_v2, not(stm32c5)))]
+#[cfg(gpio_v2)]
 fn set_speed(pin_port: PinNumber, speed: Speed) {
     let pin = unsafe { AnyPin::steal(pin_port) };
     let r = pin.block();
@@ -731,7 +731,6 @@ pub(crate) fn set_as_analog(pin_port: PinNumber) {
 }
 
 #[inline(never)]
-#[cfg(not(stm32c5))]
 fn get_pull(pin_port: PinNumber) -> Pull {
     let pin = unsafe { AnyPin::steal(pin_port) };
     let r = pin.block();
@@ -813,7 +812,7 @@ pub(crate) trait SealedPin {
     }
 
     #[inline]
-    #[cfg(all(gpio_v2, not(stm32c5)))]
+    #[cfg(gpio_v2)]
     fn set_speed(&self, speed: Speed) {
         set_speed(self.pin_port(), speed)
     }
@@ -837,7 +836,6 @@ pub(crate) trait SealedPin {
 
     /// Get the pull-up configuration.
     #[inline]
-    #[cfg(not(stm32c5))]
     fn pull(&self) -> Pull {
         critical_section::with(|_| get_pull(self.pin_port()))
     }

--- a/embassy-stm32/src/macros.rs
+++ b/embassy-stm32/src/macros.rs
@@ -1,6 +1,5 @@
 #![macro_use]
 
-#[cfg(not(stm32c5))]
 macro_rules! peri_trait {
     (
         $(irqs: [$($irq:ident),*],)?

--- a/embassy-stm32/src/macros.rs
+++ b/embassy-stm32/src/macros.rs
@@ -23,7 +23,6 @@ macro_rules! peri_trait {
     };
 }
 
-#[cfg(not(stm32c5))]
 macro_rules! peri_trait_impl {
     ($instance:ident, $info:expr) => {
         #[allow(private_interfaces)]

--- a/embassy-stm32/src/rcc/c5.rs
+++ b/embassy-stm32/src/rcc/c5.rs
@@ -183,6 +183,8 @@ pub(crate) unsafe fn init(config: Config) {
         lse: None,
 
         rtc: None,
+
+        audioclk: None,
     );
 }
 

--- a/examples/stm32c5/src/bin/i2c.rs
+++ b/examples/stm32c5/src/bin/i2c.rs
@@ -1,0 +1,42 @@
+#![no_std]
+#![no_main]
+
+use defmt::*;
+use embassy_executor::Spawner;
+use embassy_stm32::i2c::{Error, I2c};
+use embassy_stm32::{bind_interrupts, dma, i2c, peripherals};
+use {defmt_rtt as _, panic_probe as _};
+
+const ADDRESS: u8 = 0x5F;
+const WHOAMI: u8 = 0x0F;
+
+bind_interrupts!(struct Irqs {
+    I2C2_EV => i2c::EventInterruptHandler<peripherals::I2C2>;
+    I2C2_ERR => i2c::ErrorInterruptHandler<peripherals::I2C2>;
+    LPDMA1_CH4 => dma::InterruptHandler<peripherals::LPDMA1_CH4>;
+    LPDMA1_CH5 => dma::InterruptHandler<peripherals::LPDMA1_CH5>;
+});
+
+#[embassy_executor::main]
+async fn main(_spawner: Spawner) {
+    info!("Hello world!");
+    let p = embassy_stm32::init(Default::default());
+
+    let mut i2c = I2c::new(
+        p.I2C2,
+        p.PA11,
+        p.PA12,
+        p.LPDMA1_CH4,
+        p.LPDMA1_CH5,
+        Irqs,
+        Default::default(),
+    );
+
+    let mut data = [0u8; 1];
+
+    match i2c.blocking_write_read(ADDRESS, &[WHOAMI], &mut data) {
+        Ok(()) => info!("Whoami: {}", data[0]),
+        Err(Error::Timeout) => error!("Operation timed out"),
+        Err(e) => error!("I2c Error: {:?}", e),
+    }
+}


### PR DESCRIPTION
Remove c5 not guard for SPI required methods and set audioclk to None in c5's set_clock! macro.

Tested with a stm32c562re nucleo board and a LPS27HHW sensor