### PR TITLE
cyw43: add WPA3 SoftAP security modes

### DIFF
--- a/cyw43/CHANGELOG.md
+++ b/cyw43/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 <!-- next-header -->
 ## Unreleased - ReleaseDate
 
+- Add WPA3 and WPA2/WPA3 transition-mode SoftAP support.
+
 ## 0.7.0 - 2026-03-10
 
 - Reset WPA security before creating secure AP

--- a/cyw43/README.md
+++ b/cyw43/README.md
@@ -16,7 +16,7 @@ Working:
 
 - WiFi support
     - Station mode (joining an AP).
-    - AP mode (creating an AP)
+    - AP mode with open, WPA2, WPA3, and WPA2/WPA3 transition-mode security. WPA3 requires compatible CYW43 firmware and client support.
     - Scanning
     - Sending and receiving Ethernet frames.
     - Using the default MAC address.

--- a/cyw43/src/consts.rs
+++ b/cyw43/src/consts.rs
@@ -164,6 +164,7 @@ pub(crate) const INC_ADDR: bool = true;
 pub(crate) const FIXED_ADDR: bool = false;
 
 pub(crate) const AES_ENABLED: u32 = 0x0004;
+pub(crate) const WPA3_SECURITY: u32 = 0x01000000;
 pub(crate) const WPA2_SECURITY: u32 = 0x00400000;
 
 pub(crate) const MIN_PSK_LEN: usize = 8;
@@ -243,6 +244,8 @@ pub(crate) const SFC_RF_TERM: u8 = 1 << 0;
 pub(crate) enum Security {
     OPEN = 0,
     WPA2_AES_PSK = WPA2_SECURITY | AES_ENABLED,
+    WPA3_SAE = WPA3_SECURITY | AES_ENABLED,
+    WPA3_WPA2_PSK = WPA3_SECURITY | WPA2_SECURITY | AES_ENABLED,
 }
 
 crate::util::enum_from_u8! {

--- a/cyw43/src/control.rs
+++ b/cyw43/src/control.rs
@@ -104,6 +104,20 @@ pub enum JoinAuth {
     Wpa2Wpa3,
 }
 
+/// Authentication type for an access point.
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+pub enum ApAuth {
+    /// Open network.
+    Open,
+    /// WPA2 only.
+    Wpa2,
+    /// WPA3 only. Requires compatible CYW43 firmware and client support.
+    Wpa3,
+    /// WPA2 + WPA3 transition mode. WPA3 requires compatible CYW43 firmware and client support.
+    Wpa2Wpa3,
+}
+
 /// Options for [`Control::join`].
 #[derive(Clone, Debug)]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
@@ -449,18 +463,46 @@ impl<'a> Control<'a> {
 
     /// Start open access point.
     pub async fn start_ap_open(&mut self, ssid: &str, channel: u8) {
-        self.start_ap(ssid, "", Security::OPEN, channel).await;
+        self.start_ap(ssid, "", ApAuth::Open, channel).await;
     }
 
     /// Start WPA2 protected access point.
     pub async fn start_ap_wpa2(&mut self, ssid: &str, passphrase: &str, channel: u8) {
-        self.start_ap(ssid, passphrase, Security::WPA2_AES_PSK, channel).await;
+        self.start_ap(ssid, passphrase, ApAuth::Wpa2, channel).await;
     }
 
-    async fn start_ap(&mut self, ssid: &str, passphrase: &str, security: Security, channel: u8) {
-        if security != Security::OPEN && (passphrase.len() < MIN_PSK_LEN || passphrase.len() > MAX_PSK_LEN) {
+    /// Start WPA3 protected access point.
+    ///
+    /// Requires compatible CYW43 firmware and client support.
+    pub async fn start_ap_wpa3(&mut self, ssid: &str, passphrase: &str, channel: u8) {
+        self.start_ap(ssid, passphrase, ApAuth::Wpa3, channel).await;
+    }
+
+    /// Start WPA2/WPA3 transition mode access point.
+    ///
+    /// WPA3 requires compatible CYW43 firmware and client support.
+    pub async fn start_ap_wpa2_wpa3(&mut self, ssid: &str, passphrase: &str, channel: u8) {
+        self.start_ap(ssid, passphrase, ApAuth::Wpa2Wpa3, channel).await;
+    }
+
+    /// Start an access point with the specified authentication type.
+    ///
+    /// WPA3 requires compatible CYW43 firmware and client support.
+    pub async fn start_ap(&mut self, ssid: &str, passphrase: &str, auth: ApAuth, channel: u8) {
+        if auth != ApAuth::Open && (passphrase.len() < MIN_PSK_LEN || passphrase.len() > MAX_PSK_LEN) {
             panic!("Passphrase is too short or too long");
         }
+
+        let (security, mfp, wpa_auth) = match auth {
+            ApAuth::Open => (Security::OPEN, MFP_NONE, WPA_AUTH_DISABLED),
+            ApAuth::Wpa2 => (Security::WPA2_AES_PSK, MFP_NONE, WPA_AUTH_WPA2_PSK | WPA_AUTH_WPA_PSK),
+            ApAuth::Wpa3 => (Security::WPA3_SAE, MFP_REQUIRED, WPA_AUTH_WPA3_SAE_PSK),
+            ApAuth::Wpa2Wpa3 => (
+                Security::WPA3_WPA2_PSK,
+                MFP_CAPABLE,
+                WPA_AUTH_WPA2_PSK | WPA_AUTH_WPA3_SAE_PSK,
+            ),
+        };
 
         // Temporarily set wifi down
         self.down().await;
@@ -494,20 +536,24 @@ impl<'a> Control<'a> {
         // Set security
         self.set_iovar_u32x2("bsscfg:wsec", 0, (security as u32) & 0xFF).await;
 
-        if security != Security::OPEN {
-            self.set_iovar_u32x2("bsscfg:wpa_auth", 0, 0x0084).await; // wpa_auth = WPA2_AUTH_PSK | WPA_AUTH_PSK
+        // Set management frame protection
+        self.set_iovar_u32("mfp", mfp).await;
 
+        // Set WPA authentication
+        self.set_iovar_u32x2("bsscfg:wpa_auth", 0, wpa_auth).await;
+
+        if auth != ApAuth::Open {
             Timer::after_millis(100).await;
 
-            // Set passphrase
-            let mut pfi = PassphraseInfo {
-                len: passphrase.len() as _,
-                flags: 1, // WSEC_PASSPHRASE
-                passphrase: [0; 64],
-            };
-            pfi.passphrase[..passphrase.len()].copy_from_slice(passphrase.as_bytes());
-            self.ioctl(IoctlType::Set, Ioctl::SetWsecPmk, 0, &mut pfi.to_bytes().clone())
-                .await;
+            match auth {
+                ApAuth::Open => unreachable!(),
+                ApAuth::Wpa2 => self.set_ap_wpa2_passphrase(passphrase).await,
+                ApAuth::Wpa3 => self.set_ap_sae_passphrase(passphrase).await,
+                ApAuth::Wpa2Wpa3 => {
+                    self.set_ap_sae_passphrase(passphrase).await;
+                    self.set_ap_wpa2_passphrase(passphrase).await;
+                }
+            }
         }
 
         // Change mutlicast rate from 1 Mbps to 11 Mbps
@@ -515,6 +561,26 @@ impl<'a> Control<'a> {
 
         // Start AP
         self.set_iovar_u32x2("bss", 0, 1).await; // bss = BSS_UP
+    }
+
+    async fn set_ap_wpa2_passphrase(&mut self, passphrase: &str) {
+        let mut pfi = PassphraseInfo {
+            len: passphrase.len() as _,
+            flags: 1, // WSEC_PASSPHRASE
+            passphrase: [0; 64],
+        };
+        pfi.passphrase[..passphrase.len()].copy_from_slice(passphrase.as_bytes());
+        self.ioctl(IoctlType::Set, Ioctl::SetWsecPmk, 0, &mut pfi.to_bytes().clone())
+            .await;
+    }
+
+    async fn set_ap_sae_passphrase(&mut self, passphrase: &str) {
+        let mut pfi = SaePassphraseInfo {
+            len: passphrase.len() as _,
+            passphrase: [0; 128],
+        };
+        pfi.passphrase[..passphrase.len()].copy_from_slice(passphrase.as_bytes());
+        self.set_iovar("sae_password", pfi.to_bytes()).await;
     }
 
     /// Closes access point.

--- a/cyw43/src/lib.rs
+++ b/cyw43/src/lib.rs
@@ -34,7 +34,7 @@ use events::Events;
 use ioctl::IoctlState;
 
 pub use crate::control::{
-    AddMulticastAddressError, Control, JoinAuth, JoinError, JoinOptions, ScanOptions, ScanType, Scanner,
+    AddMulticastAddressError, ApAuth, Control, JoinAuth, JoinError, JoinOptions, ScanOptions, ScanType, Scanner,
 };
 pub use crate::runner::Runner;
 pub use crate::sdio::SdioBus;

--- a/examples/rp/src/bin/wifi_ap_tcp_server.rs
+++ b/examples/rp/src/bin/wifi_ap_tcp_server.rs
@@ -7,7 +7,7 @@
 
 use core::str::from_utf8;
 
-use cyw43::aligned_bytes;
+use cyw43::{ApAuth, aligned_bytes};
 use cyw43_pio::{DEFAULT_CLOCK_DIVIDER, PioSpi};
 use defmt::*;
 use embassy_executor::Spawner;
@@ -99,8 +99,10 @@ async fn main(spawner: Spawner) {
 
     spawner.spawn(unwrap!(net_task(runner)));
 
-    //control.start_ap_open("cyw43", 5).await;
-    control.start_ap_wpa2("cyw43", "password", 5).await;
+    control.start_ap("cyw43", "password", ApAuth::Wpa2, 5).await;
+    // WPA3 requires compatible CYW43 firmware and client support.
+    // control.start_ap("cyw43", "password", ApAuth::Wpa3, 5).await;
+    // control.start_ap("cyw43", "password", ApAuth::Wpa2Wpa3, 5).await;
 
     // And now we can use it!
 


### PR DESCRIPTION
Closes https://github.com/embassy-rs/embassy/issues/6521.

## Summary

- Add the public `ApAuth::{Open, Wpa2, Wpa3, Wpa2Wpa3}` API and a generalized `Control::start_ap` method.
- Keep `start_ap_open` and `start_ap_wpa2` source-compatible, and add `start_ap_wpa3` and `start_ap_wpa2_wpa3` convenience wrappers.
- Preserve the existing open and WPA2 behavior, including the AP security reset that guards against #4709.
- Keep the implementation `no_std` and stack-bounded, without allocation.

## SoftAP security configuration

| Mode | `bsscfg:wsec` | `bsscfg:wpa_auth` | `mfp` | Password programming |
| --- | ---: | ---: | ---: | --- |
| Open | `0` | `0x00000000` | `0` (`MFP_NONE`) | None |
| WPA2 | `4` (AES) | `0x00000084` | `0` (`MFP_NONE`) | `SetWsecPmk` |
| WPA3 | `4` (AES) | `0x00040000` | `2` (`MFP_REQUIRED`) | `sae_password` |
| WPA2/WPA3 | `4` (AES) | `0x00040080` | `1` (`MFP_CAPABLE`) | `sae_password` and `SetWsecPmk` |

AP initialization continues to set `AUTH_OPEN`. As in Infineon's SoftAP path, SAE is selected through `bsscfg:wpa_auth`; this does not copy station mode's `SetAuth(AUTH_SAE)` behavior.

## Verification

Compilation passed:

- `cargo check --target thumbv6m-none-eabi`
- `cargo check --target thumbv6m-none-eabi --features defmt`
- `cargo check --target thumbv6m-none-eabi --features log`
- `cargo check --bin wifi_ap_tcp_server`
- The same relevant checks with `RUSTFLAGS=-Dwarnings`
- `git diff --check`

Hardware was a Raspberry Pi Pico 2 W, flashed through a Raspberry Pi Debug Probe using the `RP235x` probe-rs target. RTT/defmt logs were captured throughout. Clients were a Mac running macOS 26.5.2 (build 25F84) and an iPhone 16e running iOS 26.5.2.

| Test | Result |
| --- | --- |
| Existing WPA2 behavior before the security changes | Passed; macOS associated successfully |
| Open AP boot, advertisement, and association | Passed with macOS; advertised as open only |
| WPA2 AP boot, advertisement, and association | Passed with macOS; advertised as WPA2 only |
| WPA3-only AP boot and stability | Passed |
| WPA3-capable client joins as WPA3 Personal | Passed with iPhone; association RSN IE selected SAE AKM `00-0f-ac:08`, with MFPC and MFPR set |
| WPA2-only client rejected by WPA3-only mode | Not performed; no WPA2-only client was available |
| Incorrect WPA3 password rejected | Passed |
| WPA2/WPA3 transition AP boot and stability | Passed |
| WPA2-only client joins transition mode | Not performed; no WPA2-only client was available |
| WPA3-capable client joins transition mode | Passed with iPhone |
| WPA3-capable transition client negotiates WPA3 | Passed; association RSN IE selected SAE AKM `00-0f-ac:08` |
| Transition AP cannot be downgraded to open | Passed; advertisement contained WPA2/WPA3 security and was not open |
| `close_ap()` followed by AP restart | Passed; the BSS returned to link-up and the iPhone rejoined with SAE |
| AP -> station -> AP transition | Passed; the board closed its transition AP, joined the iPhone WPA2 hotspot, then restarted the transition AP and reached link-up |
| Reconnect after disconnect and AP restart | Passed after a manual reconnect; one immediate cached reconnect attempt was rejected by firmware with reason 53 (`unsupported request in WPA2 IE`) before the subsequent SAE reconnect succeeded |
| Multiple associated clients | Not performed; no additional suitable client was available |
| SAE, authentication, MFP, association, and deauthentication logging | Captured over RTT |

The committed `cyw43-firmware/43439A0.bin` was sufficient for both WPA3-only and transition mode. The tested firmware identified itself as `RTE (SDIO-CDC) 7.95.61 (abcd531 CY) on BCM43439 r5`; no firmware blob was changed. No SoftAP IOCTL or IOVAR rejected the new configuration.

Open and WPA2 configuration and compatibility wrappers remain compatible. The unavailable WPA2-only and multiple-client tests are intentionally not claimed as verified; WPA3 operation still depends on compatible CYW43 firmware and client support.
