### PR TITLE
[RP] Fix framing/brake errors when using half-duplex uart

### DIFF
--- a/embassy-rp/src/uart/mod.rs
+++ b/embassy-rp/src/uart/mod.rs
@@ -932,6 +932,11 @@ impl<'d, M: Mode> Uart<'d, M> {
                 #[cfg(feature = "_rp235x")]
                 w.set_iso(false);
                 w.set_ie(true);
+                if config.invert_rx {
+                    w.set_pde(true);
+                } else {
+                    w.set_pue(true);
+                }
             });
         }
         if let Some(pin) = &cts {


### PR DESCRIPTION
Resolves https://github.com/embassy-rs/embassy/issues/5009

When using half-duplex lines (e.g. RS485 with txrx-enable) buffered uart, since buffered will keep reading even with rx line is floating, which will receive all noise from the line. This can be avoided by simply enabling the internal pull up to keep the default state if none is asserted externally. 