### PR TITLE
print warning if building embassy-stm32 for bare-metal arm but withou…

### DIFF
--- a/embassy-stm32/build.rs
+++ b/embassy-stm32/build.rs
@@ -42,6 +42,13 @@ fn main() {
     let mut cfgs = common::CfgSet::new();
     common::set_target_cfgs(&mut cfgs);
 
+    if std::env::var("CARGO_FEATURE_RT").is_err()
+        && std::env::var("CARGO_CFG_TARGET_OS") == Ok("none".to_string())
+        && std::env::var("CARGO_CFG_TARGET_ARCH") == Ok("arm".to_string())
+    {
+        println!("cargo::warning=Building for bare-metal ARM without `rt` feature: interrupts will loop forever.");
+    }
+
     let chip_name = match env::vars()
         .map(|(a, _)| a)
         .filter(|x| x.starts_with("CARGO_FEATURE_STM32") && x != "CARGO_FEATURE_STM32_HRTIM")


### PR DESCRIPTION
…t rt

Not activating the `rt` feature will cause all interrupt handlers to be omitted, making anything that relies on interrupts hang/fail/do nothing.

I only applied this to `embassy-stm32` for now, because I'm not sure if this holds for other HAL crates too. 

Additionally, I'm not sure whether this should be a warning or just an error: are there use-cases where one wants to do this?

One solution/helpful hand towards resolving #6526 