### PR TITLE
stm32u5: ADF/MDF, graphics drivers, FSMC, and JPEG

### DIFF
--- a/embassy-stm32/build.rs
+++ b/embassy-stm32/build.rs
@@ -1712,8 +1712,31 @@ fn main() {
         (("lcd", "VLCD"), quote!(crate::lcd::VlcdPin)),
         (("dac", "OUT1"), quote!(crate::dac::DacPin<Ch1>)),
         (("dac", "OUT2"), quote!(crate::dac::DacPin<Ch2>)),
+        (("adf", "CCK0"), quote!(crate::adf::CckPin)),
+        (("adf", "CCK1"), quote!(crate::adf::CckPin)),
+        (("adf", "SDI0"), quote!(crate::adf::SdiPin)),
+        (("mdf", "CCK0"), quote!(crate::mdf::CckPin)),
+        (("mdf", "CCK1"), quote!(crate::mdf::CckPin)),
+        (("mdf", "CKI0"), quote!(crate::mdf::CkiPin)),
+        (("mdf", "CKI1"), quote!(crate::mdf::CkiPin)),
+        (("mdf", "CKI2"), quote!(crate::mdf::CkiPin)),
+        (("mdf", "CKI3"), quote!(crate::mdf::CkiPin)),
+        (("mdf", "CKI4"), quote!(crate::mdf::CkiPin)),
+        (("mdf", "CKI5"), quote!(crate::mdf::CkiPin)),
+        (("mdf", "SDI0"), quote!(crate::mdf::SdiPin)),
+        (("mdf", "SDI1"), quote!(crate::mdf::SdiPin)),
+        (("mdf", "SDI2"), quote!(crate::mdf::SdiPin)),
+        (("mdf", "SDI3"), quote!(crate::mdf::SdiPin)),
+        (("mdf", "SDI4"), quote!(crate::mdf::SdiPin)),
+        (("mdf", "SDI5"), quote!(crate::mdf::SdiPin)),
     ] {
         signals.entry(key).or_default().push(value);
+    }
+
+    // STM32U5 maps the external memory controller as kind "fsmc" (v5x1) but uses
+    // the same pin signals as FMC on other families.
+    for ((_, signal), traits) in signals.clone().into_iter().filter(|((kind, _), _)| *kind == "fmc") {
+        signals.entry(("fsmc", signal)).or_default().extend(traits);
     }
 
     // On some families the USB DM/DP signals are present as alternate functions,
@@ -2077,6 +2100,13 @@ fn main() {
         (("timer", "CH4"), quote!(crate::timer::Dma<Ch4>)),
         (("cordic", "WRITE"), quote!(crate::cordic::WriteDma)),
         (("cordic", "READ"), quote!(crate::cordic::ReadDma)),
+        (("adf", "FLT0"), quote!(crate::adf::RxDma<Flt0>)),
+        (("mdf", "FLT0"), quote!(crate::mdf::RxDma<Flt0>)),
+        (("mdf", "FLT1"), quote!(crate::mdf::RxDma<Flt1>)),
+        (("mdf", "FLT2"), quote!(crate::mdf::RxDma<Flt2>)),
+        (("mdf", "FLT3"), quote!(crate::mdf::RxDma<Flt3>)),
+        (("mdf", "FLT4"), quote!(crate::mdf::RxDma<Flt4>)),
+        (("mdf", "FLT5"), quote!(crate::mdf::RxDma<Flt5>)),
         (("xspi", "RX"), quote!(crate::xspi::XDma)),
         (("xspi", "RX"), quote!(crate::xspi::XDma)),
     ]
@@ -2112,9 +2142,9 @@ fn main() {
         signals.insert(("adc", "ADC4"), quote!(crate::adc::RxDma));
     }
 
-    // JPEG HAL is currently N6-only; only emit dma_trait impls there.
+    // JPEG HAL: emit dma_trait impls on chips that use RX/TX DMA signal names.
     // ST naming: jpeg_rx_dma = mem→peri (input), jpeg_tx_dma = peri→mem (output).
-    if chip_name.starts_with("stm32n6") {
+    if chip_name.starts_with("stm32n6") || chip_name.starts_with("stm32u5f9") || chip_name.starts_with("stm32u5g9") {
         signals.insert(("jpeg", "RX"), quote!(crate::jpeg::DmaIn));
         signals.insert(("jpeg", "TX"), quote!(crate::jpeg::DmaOut));
     }

--- a/embassy-stm32/src/adf.rs
+++ b/embassy-stm32/src/adf.rs
@@ -1,0 +1,265 @@
+//! Audio Digital Filter (ADF)
+
+use core::marker::PhantomData;
+
+use embassy_hal_internal::PeripheralType;
+
+use crate::dflt::{Acqmod, Cckdir, Ccken, Cicmod, Ckgmod, Datsrc, Rxfifo};
+pub use crate::dflt::{ClockConfig, FilterConfig, SitfConfig, sample_from_dma_word, samples_from_dma_words};
+use crate::dma::ringbuffer::Error as RingbufferError;
+use crate::dma::{Channel, ReadableRingBuffer, TransferOptions};
+use crate::gpio::{AfType, OutputType, Pull, Speed};
+use crate::interrupt::typelevel::Interrupt;
+use crate::pac::adf::Adf as Regs;
+use crate::{Peri, interrupt, rcc};
+
+/// Marker type for digital filter 0 (the only filter on ADF).
+pub struct Flt0;
+
+trait SealedFilter {}
+
+impl SealedFilter for Flt0 {}
+
+/// Identifies the ADF digital filter (filter 0 only).
+#[allow(private_bounds)]
+pub trait Filter: SealedFilter {}
+
+impl Filter for Flt0 {}
+
+/// ADF driver error.
+#[derive(Debug)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+pub enum Error {
+    /// DMA ring buffer error.
+    Ringbuffer(RingbufferError),
+}
+
+impl From<RingbufferError> for Error {
+    fn from(err: RingbufferError) -> Self {
+        Self::Ringbuffer(err)
+    }
+}
+
+/// Ring-buffered ADF driver.
+pub struct Adf<'d, T: Instance> {
+    _peri: Peri<'d, T>,
+    ring_buffer: ReadableRingBuffer<'d, u32>,
+}
+
+/// Combined configuration for a typical PDM microphone capture on filter 0.
+#[derive(Clone, Copy, Debug)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+pub struct Config {
+    /// Clock generator settings.
+    pub clock: ClockConfig,
+    /// Serial interface 0 settings.
+    pub sitf: SitfConfig,
+    /// Digital filter 0 settings.
+    pub filter: FilterConfig,
+}
+
+impl Default for Config {
+    fn default() -> Self {
+        Self {
+            clock: ClockConfig::default(),
+            sitf: SitfConfig::default(),
+            filter: pdm_filter_config(),
+        }
+    }
+}
+
+impl<'d, T: Instance> Adf<'d, T> {
+    fn dma_opts() -> TransferOptions {
+        TransferOptions {
+            half_transfer_ir: true,
+            ..Default::default()
+        }
+    }
+
+    /// Create a new ADF instance configured for PDM capture on filter 0.
+    ///
+    /// `cck` drives the PDM bit clock and `sdi` receives the PDM data stream.
+    pub fn new<D>(
+        peri: Peri<'d, T>,
+        irq: impl interrupt::typelevel::Binding<T::Interrupt, InterruptHandler<T>>
+        + interrupt::typelevel::Binding<D::Interrupt, crate::dma::InterruptHandler<D>>
+        + 'd,
+        config: Config,
+        cck: Peri<'d, impl CckPin<T>>,
+        sdi: Peri<'d, impl SdiPin<T>>,
+        dma: Peri<'d, D>,
+        dma_buf: &'d mut [u32],
+    ) -> Self
+    where
+        D: RxDma<T, Flt0>,
+    {
+        set_as_af!(cck, AfType::output(OutputType::PushPull, Speed::VeryHigh));
+        set_as_af!(sdi, AfType::input(Pull::None));
+
+        rcc::enable_and_reset::<T>();
+        T::Interrupt::unpend();
+        unsafe { T::Interrupt::enable() };
+
+        let regs = T::regs();
+        Self::apply_config(regs, &config);
+
+        let request = dma.request();
+        let ring_buffer = unsafe {
+            ReadableRingBuffer::new(
+                Channel::new(dma, irq),
+                request,
+                regs.dfltdr().as_ptr() as *mut u32,
+                dma_buf,
+                Self::dma_opts(),
+            )
+        };
+
+        Self {
+            _peri: peri,
+            ring_buffer,
+        }
+    }
+
+    fn apply_config(regs: Regs, config: &Config) {
+        regs.ckgcr().modify(|w| {
+            w.set_ckgmod(Ckgmod::Immediate);
+            w.set_procdiv(config.clock.procdiv);
+            w.set_cckdiv(config.clock.cckdiv);
+            w.set_cck0dir(if config.clock.cck0_output {
+                Cckdir::Output
+            } else {
+                Cckdir::Input
+            });
+            w.set_cck1dir(if config.clock.cck1_output {
+                Cckdir::Output
+            } else {
+                Cckdir::Input
+            });
+            w.set_cck0en(if config.clock.cck0_output {
+                Ccken::Generated
+            } else {
+                Ccken::NotGenerated
+            });
+            w.set_cck1en(if config.clock.cck1_output {
+                Ccken::Generated
+            } else {
+                Ccken::NotGenerated
+            });
+            w.set_ckgden(true);
+        });
+
+        regs.sitfcr().modify(|w| {
+            w.set_sitfmod(config.sitf.mode);
+            w.set_scksrc(config.sitf.clock_source);
+            w.set_sth(config.sitf.threshold);
+            w.set_sitfen(true);
+        });
+
+        regs.bsmxcr().modify(|w| w.set_bssel(config.filter.bitstream));
+        regs.dfltcicr().modify(|w| {
+            w.set_datsrc(Datsrc::Bsmx);
+            w.set_cicmod(Cicmod::Sinc5);
+            w.set_mcicd(config.filter.cic_decimation);
+            w.set_scale(config.filter.scale);
+        });
+        regs.dfltrsfr().modify(|w| {
+            w.set_rsfltbyp(true);
+            w.set_hpfbyp(true);
+        });
+        regs.dfltcr().modify(|w| {
+            w.set_acqmod(config.filter.acquisition_mode);
+            w.set_fth(config.filter.fifo_threshold);
+            w.set_dmaen(true);
+        });
+    }
+
+    /// Start filter acquisition and DMA.
+    pub fn start(&mut self) {
+        self.ring_buffer.start();
+        T::regs().dfltcr().modify(|w| {
+            w.set_dflten(true);
+            w.set_dfltrun(true);
+        });
+    }
+
+    /// Read raw 32-bit DMA words from the filter output ring buffer.
+    pub async fn read_raw(&mut self, words: &mut [u32]) -> Result<(), Error> {
+        self.ring_buffer.read_exact(words).await?;
+        Ok(())
+    }
+
+    /// Return the kernel clock frequency in Hz.
+    pub fn kernel_clock_hz(&self) -> u32 {
+        <T as crate::rcc::SealedRccPeripheral>::frequency().0
+    }
+}
+
+impl<'d, T: Instance> Drop for Adf<'d, T> {
+    fn drop(&mut self) {
+        let regs = T::regs();
+        regs.dfltcr().modify(|w| {
+            w.set_dfltrun(false);
+            w.set_dflten(false);
+            w.set_dmaen(false);
+        });
+        regs.sitfcr().modify(|w| w.set_sitfen(false));
+        regs.ckgcr().modify(|w| w.set_ckgden(false));
+    }
+}
+
+trait SealedInstance: crate::rcc::RccPeripheral {
+    fn regs() -> Regs;
+}
+
+/// ADF instance trait.
+#[allow(private_bounds)]
+pub trait Instance: SealedInstance + PeripheralType + 'static {
+    /// Filter 0 interrupt.
+    type Interrupt: interrupt::typelevel::Interrupt;
+}
+
+/// ADF interrupt handler.
+pub struct InterruptHandler<T: Instance> {
+    _marker: PhantomData<T>,
+}
+
+impl<T: Instance> interrupt::typelevel::Handler<T::Interrupt> for InterruptHandler<T> {
+    unsafe fn on_interrupt() {
+        let isr = T::regs().dfltisr().read();
+        if isr.dovrf() || isr.rfovrf() {
+            T::regs().dfltisr().modify(|w| {
+                w.set_dovrf(true);
+                w.set_rfovrf(true);
+            });
+        }
+    }
+}
+
+pin_trait!(CckPin, Instance);
+pin_trait!(SdiPin, Instance);
+
+dma_trait!(RxDma, Instance, Filter);
+
+foreach_peripheral!(
+    (adf, $inst:ident) => {
+        impl crate::adf::SealedInstance for crate::peripherals::$inst {
+            fn regs() -> crate::pac::adf::Adf {
+                crate::pac::$inst
+            }
+        }
+        impl crate::adf::Instance for crate::peripherals::$inst {
+            type Interrupt = crate::_generated::peripheral_interrupts::$inst::FLT0;
+        }
+    };
+);
+
+/// Default continuous-capture filter configuration for PDM use on filter 0 / SITF 0.
+pub const fn pdm_filter_config() -> FilterConfig {
+    FilterConfig {
+        bitstream: crate::dflt::Bssel::Bs0R,
+        cic_decimation: 31,
+        scale: 0b100000,
+        acquisition_mode: Acqmod::AsynchronousContinuous,
+        fifo_threshold: Rxfifo::HalfFull,
+    }
+}

--- a/embassy-stm32/src/dflt.rs
+++ b/embassy-stm32/src/dflt.rs
@@ -1,0 +1,101 @@
+//! Shared configuration types for ADF and MDF digital filter peripherals.
+
+pub use crate::pac::adf::vals::{
+    Acqmod, Bssel, Cckdir, Cckdiv, Ccken, Cicmod, Ckgmod, Datsrc, Rxfifo, Scksrc, Sitfmod,
+};
+
+/// Clock generator configuration shared by ADF and MDF.
+#[derive(Clone, Copy, Debug)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+pub struct ClockConfig {
+    /// Divider applied to the kernel clock to produce the processing clock.
+    ///
+    /// Output frequency is `kernel_clock / (procdiv + 1)`.
+    pub procdiv: u8,
+    /// Divider applied to the CCK output clock.
+    pub cckdiv: Cckdiv,
+    /// Drive CCK0 as output (typically the PDM bit clock).
+    pub cck0_output: bool,
+    /// Drive CCK1 as output.
+    pub cck1_output: bool,
+}
+
+impl Default for ClockConfig {
+    fn default() -> Self {
+        Self {
+            procdiv: 0,
+            cckdiv: Cckdiv::Div1,
+            cck0_output: true,
+            cck1_output: false,
+        }
+    }
+}
+
+/// Serial interface (SITF) configuration.
+#[derive(Clone, Copy, Debug)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+pub struct SitfConfig {
+    /// Serial interface mode.
+    pub mode: Sitfmod,
+    /// Serial clock source.
+    pub clock_source: Scksrc,
+    /// Manchester/SPI threshold (must be >= 4 in SPI mode).
+    pub threshold: u8,
+}
+
+impl Default for SitfConfig {
+    fn default() -> Self {
+        Self {
+            mode: Sitfmod::NormalSpi,
+            clock_source: Scksrc::Cck0,
+            threshold: 4,
+        }
+    }
+}
+
+/// Digital filter configuration.
+#[derive(Clone, Copy, Debug)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+pub struct FilterConfig {
+    /// Bitstream routed into the filter.
+    pub bitstream: Bssel,
+    /// CIC decimation ratio: actual ratio is `cic_decimation + 1`, minimum 2.
+    pub cic_decimation: u16,
+    /// CIC output gain / shift (see RM Table "Possible gain values").
+    pub scale: u8,
+    /// Acquisition mode.
+    pub acquisition_mode: Acqmod,
+    /// RX FIFO threshold for DMA requests.
+    pub fifo_threshold: Rxfifo,
+}
+
+impl Default for FilterConfig {
+    fn default() -> Self {
+        Self {
+            bitstream: Bssel::Bs0R,
+            cic_decimation: 31,
+            scale: 0b100000,
+            acquisition_mode: Acqmod::AsynchronousContinuous,
+            fifo_threshold: Rxfifo::HalfFull,
+        }
+    }
+}
+
+/// Extract a signed 24-bit sample from a DMA word read from DFLTDR.
+#[inline]
+pub fn sample_from_dma_word(word: u32) -> i32 {
+    let raw = (word >> 8) & 0x00FF_FFFF;
+    if raw & 0x0080_0000 != 0 {
+        (raw | 0xFF00_0000) as i32
+    } else {
+        raw as i32
+    }
+}
+
+/// Convert raw DMA words into signed PCM samples.
+#[inline]
+pub fn samples_from_dma_words(raw: &[u32], out: &mut [i32]) {
+    for (sample, word) in out.iter_mut().zip(raw.iter()) {
+        *sample = sample_from_dma_word(*word);
+    }
+}

--- a/embassy-stm32/src/fmc.rs
+++ b/embassy-stm32/src/fmc.rs
@@ -120,6 +120,8 @@ macro_rules! fmc_sdram_constructor {
     };
 }
 
+// fsmc_v5x1 (STM32U5) has no SDRAM register block; only NOR/PSRAM async banks.
+#[cfg(not(fsmc_v5x1))]
 impl<'d, T: Instance> Fmc<'d, T> {
     fmc_sdram_constructor!(sdram_a12bits_d16bits_4banks_bank1: (
         bank: stm32_fmc::SdramTargetBank::Bank1,
@@ -275,8 +277,14 @@ impl<'d, T: Instance> Fmc<'d, T> {
 }
 
 trait SealedInstance: crate::rcc::RccPeripheral {
-    const REGS: crate::pac::fmc::Fmc;
+    const REGS: Regs;
 }
+
+/// Register block type for the external memory controller.
+#[cfg(fmc)]
+pub type Regs = crate::pac::fmc::Fmc;
+#[cfg(all(fsmc, not(fmc)))]
+pub type Regs = crate::pac::fsmc::Fsmc;
 
 /// FMC instance trait.
 #[allow(private_bounds)]
@@ -285,7 +293,13 @@ pub trait Instance: SealedInstance + PeripheralType + 'static {}
 foreach_peripheral!(
     (fmc, $inst:ident) => {
         impl crate::fmc::SealedInstance for crate::peripherals::$inst {
-            const REGS: crate::pac::fmc::Fmc = crate::pac::$inst;
+            const REGS: crate::fmc::Regs = crate::pac::$inst;
+        }
+        impl crate::fmc::Instance for crate::peripherals::$inst {}
+    };
+    (fsmc, $inst:ident) => {
+        impl crate::fmc::SealedInstance for crate::peripherals::$inst {
+            const REGS: crate::fmc::Regs = crate::pac::$inst;
         }
         impl crate::fmc::Instance for crate::peripherals::$inst {}
     };

--- a/embassy-stm32/src/fmc.rs
+++ b/embassy-stm32/src/fmc.rs
@@ -3,8 +3,9 @@ use core::marker::PhantomData;
 
 use embassy_hal_internal::PeripheralType;
 
+#[cfg(not(fsmc_v5x1))]
 use crate::gpio::{AfType, OutputType, Pull, Speed};
-use crate::{Peri, rcc};
+use crate::{rcc, Peri};
 
 /// FMC driver
 pub struct Fmc<'d, T: Instance> {
@@ -72,6 +73,7 @@ where
     }
 }
 
+#[cfg(not(fsmc_v5x1))]
 macro_rules! config_pins {
     ($($pin:ident),*) => {
                 $(
@@ -80,6 +82,7 @@ macro_rules! config_pins {
     };
 }
 
+#[cfg(not(fsmc_v5x1))]
 macro_rules! fmc_sdram_constructor {
     ($name:ident: (
         bank: $bank:expr,
@@ -280,10 +283,11 @@ trait SealedInstance: crate::rcc::RccPeripheral {
     const REGS: Regs;
 }
 
-/// Register block type for the external memory controller.
 #[cfg(fmc)]
+/// Register block type for the external memory controller.
 pub type Regs = crate::pac::fmc::Fmc;
 #[cfg(all(fsmc, not(fmc)))]
+/// Register block type for the external memory controller.
 pub type Regs = crate::pac::fsmc::Fsmc;
 
 /// FMC instance trait.

--- a/embassy-stm32/src/fmc.rs
+++ b/embassy-stm32/src/fmc.rs
@@ -5,7 +5,7 @@ use embassy_hal_internal::PeripheralType;
 
 #[cfg(not(fsmc_v5x1))]
 use crate::gpio::{AfType, OutputType, Pull, Speed};
-use crate::{rcc, Peri};
+use crate::{Peri, rcc};
 
 /// FMC driver
 pub struct Fmc<'d, T: Instance> {

--- a/embassy-stm32/src/gfxmmu.rs
+++ b/embassy-stm32/src/gfxmmu.rs
@@ -1,0 +1,239 @@
+//! GFXMMU — graphics MMU for LTDC framebuffers.
+//!
+//! Maps a virtual framebuffer address space (used by LTDC) onto up to four physical
+//! memory buffers using a line LUT. Typical use is a contiguous RGB framebuffer in
+//! one physical buffer while LTDC reads through the GFXMMU aperture.
+
+use core::marker::PhantomData;
+
+use embassy_hal_internal::PeripheralType;
+
+use crate::interrupt::typelevel::Interrupt;
+use crate::pac::gfxmmu::Gfxmmu as Regs;
+use crate::pac::gfxmmu::vals::Bm192;
+use crate::{Peri, interrupt, rcc};
+
+/// GFXMMU block size in bytes.
+pub const BLOCK_SIZE: u32 = 16;
+
+/// GFXMMU driver error.
+#[derive(Debug, PartialEq, Eq, Clone, Copy)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+pub enum Error {
+    /// AHB master error reported in status.
+    MasterError,
+    /// Buffer overflow reported in status.
+    BufferOverflow,
+}
+
+/// Physical buffer description for one GFXMMU buffer slot (0..3).
+#[derive(Clone, Copy, Debug)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+pub struct BufferConfig {
+    /// CPU address of the physical buffer (must be 16-byte aligned).
+    pub base_addr: u32,
+}
+
+impl BufferConfig {
+    /// Encode `base_addr` into BCR register fields.
+    fn encode(self) -> (u32, u16) {
+        let pbo = (self.base_addr >> 4) & 0x0007_ffff;
+        let pbba = ((self.base_addr >> 22) & 0x01ff) as u16;
+        (pbo, pbba)
+    }
+}
+
+/// Driver configuration applied at init.
+#[derive(Clone, Copy, Debug)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+pub struct Config {
+    /// Use 192 blocks per line instead of 256.
+    pub block_mode_192: bool,
+    /// Enable the cache unit.
+    pub cache_enable: bool,
+    /// Default 32-bit fill value for unmapped blocks.
+    pub default_value: u32,
+}
+
+impl Default for Config {
+    fn default() -> Self {
+        Self {
+            block_mode_192: true,
+            cache_enable: true,
+            default_value: 0,
+        }
+    }
+}
+
+/// One LUT line entry.
+#[derive(Clone, Copy, Debug)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+pub struct LutLine {
+    /// Line is mapped through the LUT.
+    pub enabled: bool,
+    /// First valid block index within the line.
+    pub first_block: u8,
+    /// Last valid block index within the line.
+    pub last_block: u8,
+    /// Line offset in blocks from the physical buffer base (block 0 of this line).
+    pub line_offset_blocks: u32,
+}
+
+/// GFXMMU driver.
+pub struct Gfxmmu<'d, T: Instance> {
+    _peri: Peri<'d, T>,
+}
+
+impl<'d, T: Instance> Gfxmmu<'d, T> {
+    /// Create and configure GFXMMU.
+    pub fn new(
+        peri: Peri<'d, T>,
+        _irq: impl interrupt::typelevel::Binding<T::Interrupt, InterruptHandler<T>> + 'd,
+        config: Config,
+    ) -> Self {
+        rcc::enable_and_reset::<T>();
+        T::Interrupt::unpend();
+        unsafe { T::Interrupt::enable() };
+
+        let regs = T::regs();
+        regs.dvr().write(|w| w.set_dv(config.default_value));
+        regs.cr().modify(|w| {
+            w.set_bm(
+                0,
+                if config.block_mode_192 {
+                    Bm192::_192blocksPerLine
+                } else {
+                    Bm192::_256blocksPerLine
+                },
+            );
+            w.set_ce(config.cache_enable);
+        });
+
+        Self { _peri: peri }
+    }
+
+    /// Configure one of the four physical buffer slots.
+    pub fn set_buffer(&mut self, index: usize, config: BufferConfig) {
+        assert!(index < 4);
+        let (pbo, pbba) = config.encode();
+        T::regs().bcr(index).modify(|w| {
+            w.set_pbo(pbo);
+            w.set_pbba(pbba);
+        });
+    }
+
+    /// Program one LUT line.
+    pub fn set_lut_line(&mut self, line: usize, entry: LutLine) {
+        assert!(line < 1024);
+        T::regs().lutl(line).write(|w| {
+            w.set_en(entry.enabled);
+            w.set_fvb(entry.first_block);
+            w.set_lvb(entry.last_block);
+        });
+        T::regs().luth(line).write(|w| w.set_lo(entry.line_offset_blocks));
+    }
+
+    /// Configure a contiguous linear framebuffer in buffer slot 0.
+    ///
+    /// `width_px` and `bytes_per_pixel` define the active line width. Lines `0..height`
+    /// are mapped sequentially in the physical buffer.
+    pub fn configure_linear_framebuffer(
+        &mut self,
+        buffer: BufferConfig,
+        width_px: u16,
+        height: u16,
+        bytes_per_pixel: u8,
+        block_mode_192: bool,
+    ) {
+        self.set_buffer(0, buffer);
+
+        let bytes_per_line = width_px as u32 * bytes_per_pixel as u32;
+        let blocks_per_line =
+            ((bytes_per_line + BLOCK_SIZE - 1) / BLOCK_SIZE).min(if block_mode_192 { 192 } else { 256 }) as u8;
+
+        for line in 0..height as usize {
+            self.set_lut_line(
+                line,
+                LutLine {
+                    enabled: true,
+                    first_block: 0,
+                    last_block: blocks_per_line.saturating_sub(1),
+                    line_offset_blocks: (line as u32) * blocks_per_line as u32,
+                },
+            );
+        }
+    }
+
+    /// Flush the cache (blocks until complete).
+    pub fn flush_cache(&mut self) {
+        let regs = T::regs();
+        regs.ccr().modify(|w| w.set_ff(true));
+        while regs.ccr().read().ff() {}
+    }
+
+    /// Invalidate the cache (blocks until complete).
+    pub fn invalidate_cache(&mut self) {
+        let regs = T::regs();
+        regs.ccr().modify(|w| w.set_fi(true));
+        while regs.ccr().read().fi() {}
+    }
+
+    /// Read and clear sticky error flags.
+    pub fn take_status(&mut self) -> Result<(), Error> {
+        let regs = T::regs();
+        let sr = regs.sr().read();
+        let mut err = Ok(());
+
+        regs.fcr().write(|w| {
+            for i in 0..4 {
+                if sr.bof(i) {
+                    w.set_cbof(i, true);
+                    err = Err(Error::BufferOverflow);
+                }
+            }
+            if sr.amef() {
+                w.set_camef(true);
+                err = Err(Error::MasterError);
+            }
+        });
+
+        err
+    }
+}
+
+/// GFXMMU interrupt handler.
+pub struct InterruptHandler<T: Instance> {
+    _marker: PhantomData<T>,
+}
+
+impl<T: Instance> interrupt::typelevel::Handler<T::Interrupt> for InterruptHandler<T> {
+    unsafe fn on_interrupt() {
+        let _ = T::regs();
+        // Errors are cleared via [`Gfxmmu::take_status`].
+    }
+}
+
+trait SealedInstance: crate::rcc::RccPeripheral {
+    fn regs() -> Regs;
+}
+
+/// GFXMMU instance trait.
+#[allow(private_bounds)]
+pub trait Instance: SealedInstance + PeripheralType + 'static {
+    /// GFXMMU interrupt.
+    type Interrupt: Interrupt;
+}
+
+foreach_interrupt!(
+    ($inst:ident, gfxmmu, GFXMMU, GLOBAL, $irq:ident) => {
+        impl Instance for crate::peripherals::$inst {
+            type Interrupt = crate::interrupt::typelevel::$irq;
+        }
+
+        impl SealedInstance for crate::peripherals::$inst {
+            fn regs() -> Regs {
+                crate::pac::$inst
+            }
+        }
+    };
+);

--- a/embassy-stm32/src/gfxtim.rs
+++ b/embassy-stm32/src/gfxtim.rs
@@ -1,0 +1,98 @@
+//! GFXTIM — graphics timer for display pipeline synchronization.
+
+use core::marker::PhantomData;
+
+use embassy_hal_internal::PeripheralType;
+
+use crate::interrupt::typelevel::Interrupt;
+use crate::pac::gfxtim::Gfxtim as Regs;
+use crate::{Peri, interrupt, rcc};
+
+/// GFXTIM driver.
+pub struct Gfxtim<'d, T: Instance> {
+    _peri: Peri<'d, T>,
+}
+
+impl<'d, T: Instance> Gfxtim<'d, T> {
+    /// Create a GFXTIM instance.
+    pub fn new(
+        peri: Peri<'d, T>,
+        _irq: impl interrupt::typelevel::Binding<T::Interrupt, InterruptHandler<T>> + 'd,
+    ) -> Self {
+        rcc::enable_and_reset::<T>();
+        T::Interrupt::unpend();
+        unsafe { T::Interrupt::enable() };
+        Self { _peri: peri }
+    }
+
+    /// Set line and frame counter reload values.
+    pub fn set_counter_reload(&mut self, lines_per_frame: u16, pixels_per_line: u32) {
+        let regs = T::regs();
+        regs.lccrr().write(|w| w.set_reload(pixels_per_line));
+        regs.fccrr().write(|w| w.set_reload(lines_per_frame));
+    }
+
+    /// Enable the absolute line and frame counters.
+    pub fn start_counters(&mut self) {
+        T::regs().tcr().modify(|w| {
+            w.set_alcen(true);
+            w.set_afcen(true);
+        });
+    }
+
+    /// Disable the absolute line and frame counters.
+    pub fn stop_counters(&mut self) {
+        T::regs().tcr().modify(|w| {
+            w.set_alcen(false);
+            w.set_afcen(false);
+        });
+    }
+
+    /// Read absolute line counter.
+    pub fn line_counter(&self) -> u16 {
+        T::regs().alcr().read().line()
+    }
+
+    /// Read absolute frame counter.
+    pub fn frame_counter(&self) -> u32 {
+        T::regs().afcr().read().frame()
+    }
+}
+
+/// GFXTIM interrupt handler.
+pub struct InterruptHandler<T: Instance> {
+    _marker: PhantomData<T>,
+}
+
+impl<T: Instance> interrupt::typelevel::Handler<T::Interrupt> for InterruptHandler<T> {
+    unsafe fn on_interrupt() {
+        let regs = T::regs();
+        let pending = regs.isr().read().0;
+        regs.icr().write(|w| w.0 = pending);
+    }
+}
+
+trait SealedInstance: crate::rcc::RccPeripheral {
+    fn regs() -> Regs;
+}
+
+/// GFXTIM instance trait.
+#[allow(private_bounds)]
+pub trait Instance: SealedInstance + PeripheralType + 'static {
+    /// GFXTIM interrupt.
+    type Interrupt: Interrupt;
+}
+
+foreach_interrupt!(
+    ($inst:ident, gfxtim, GFXTIM, GLOBAL, $irq:ident) => {
+        impl Instance for crate::peripherals::$inst {
+            type Interrupt = crate::interrupt::typelevel::$irq;
+        }
+
+        impl SealedInstance for crate::peripherals::$inst {
+            fn regs() -> Regs {
+                crate::pac::$inst
+            }
+        }
+    };
+);

--- a/embassy-stm32/src/gpu2d.rs
+++ b/embassy-stm32/src/gpu2d.rs
@@ -1,0 +1,100 @@
+//! GPU2D (NeoChrom) 2D graphics accelerator.
+//!
+//! The GPU2D is primarily programmed via command lists in memory; the peripheral
+//! registers expose status and interrupt control only.
+
+use core::marker::PhantomData;
+
+use embassy_hal_internal::PeripheralType;
+
+use crate::interrupt::typelevel::Interrupt;
+use crate::pac::gpu2d::Gpu2d as Regs;
+use crate::{Peri, interrupt, rcc};
+
+/// GPU2D driver error flag.
+#[derive(Debug, PartialEq, Eq, Clone, Copy)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+pub enum Error {
+    /// System error flag set.
+    SystemError,
+}
+
+/// GPU2D driver.
+pub struct Gpu2d<'d, T: Instance> {
+    _peri: Peri<'d, T>,
+}
+
+impl<'d, T: Instance> Gpu2d<'d, T> {
+    /// Create a GPU2D instance.
+    pub fn new(
+        peri: Peri<'d, T>,
+        _irq: impl interrupt::typelevel::Binding<T::Interrupt, InterruptHandler<T>> + 'd,
+    ) -> Self {
+        rcc::enable_and_reset::<T>();
+        T::Interrupt::unpend();
+        unsafe { T::Interrupt::enable() };
+        Self { _peri: peri }
+    }
+
+    /// Last completed command list identifier.
+    pub fn last_command_list_id(&self) -> u32 {
+        T::regs().clid().read().id()
+    }
+
+    /// Returns true when the command-list-complete flag is set.
+    pub fn command_list_complete(&self) -> bool {
+        T::regs().itctrl().read().clc()
+    }
+
+    /// Clear the command-list-complete flag.
+    pub fn clear_command_list_complete(&mut self) {
+        T::regs().itctrl().modify(|w| w.set_clc(true));
+    }
+
+    /// Read and clear error status.
+    pub fn take_error(&mut self) -> Result<(), Error> {
+        let regs = T::regs();
+        if regs.sys_interrupt().read().er() {
+            regs.sys_interrupt().modify(|w| w.set_er(true));
+            Err(Error::SystemError)
+        } else {
+            Ok(())
+        }
+    }
+}
+
+/// GPU2D error interrupt handler.
+pub struct InterruptHandler<T: Instance> {
+    _marker: PhantomData<T>,
+}
+
+impl<T: Instance> interrupt::typelevel::Handler<T::Interrupt> for InterruptHandler<T> {
+    unsafe fn on_interrupt() {
+        let _ = T::regs();
+    }
+}
+
+trait SealedInstance: crate::rcc::RccPeripheral {
+    fn regs() -> Regs;
+}
+
+/// GPU2D instance trait.
+#[allow(private_bounds)]
+pub trait Instance: SealedInstance + PeripheralType + 'static {
+    /// GPU2D error interrupt.
+    type Interrupt: Interrupt;
+}
+
+foreach_interrupt!(
+    ($inst:ident, gpu2d, GPU2D, ER, $irq:ident) => {
+        impl Instance for crate::peripherals::$inst {
+            type Interrupt = crate::interrupt::typelevel::$irq;
+        }
+
+        impl SealedInstance for crate::peripherals::$inst {
+            fn regs() -> Regs {
+                crate::pac::$inst
+            }
+        }
+    };
+);

--- a/embassy-stm32/src/lib.rs
+++ b/embassy-stm32/src/lib.rs
@@ -52,6 +52,7 @@ pub mod rcc;
 mod time_driver;
 pub mod timer;
 
+#[cfg(any(adf, mdf))]
 pub(crate) mod dflt;
 
 // Sometimes-present hardware
@@ -132,7 +133,7 @@ pub mod fmc;
 pub mod gfxmmu;
 #[cfg(gfxtim)]
 pub mod gfxtim;
-#[cfg(gpu2d)]
+#[cfg(all(gpu2d, stm32u5))]
 pub mod gpu2d;
 #[cfg(hash)]
 pub mod hash;
@@ -149,7 +150,7 @@ pub mod i2s;
 #[cfg(any(stm32wb, stm32wl5x))]
 pub mod ipcc;
 // JPEG is unavailable on some families (e.g. H7 uses different DMA signal names).
-#[cfg(jpeg)]
+#[cfg(all(jpeg, any(stm32n6, stm32u5f9, stm32u5g9)))]
 pub mod jpeg;
 #[cfg(lcd)]
 pub mod lcd;

--- a/embassy-stm32/src/lib.rs
+++ b/embassy-stm32/src/lib.rs
@@ -129,7 +129,7 @@ pub mod flash;
 pub mod fmac;
 #[cfg(any(fmc, fsmc))]
 pub mod fmc;
-#[cfg(gfxmmu)]
+#[cfg(gfxmmu_v2)]
 pub mod gfxmmu;
 #[cfg(gfxtim)]
 pub mod gfxtim;

--- a/embassy-stm32/src/lib.rs
+++ b/embassy-stm32/src/lib.rs
@@ -52,10 +52,14 @@ pub mod rcc;
 mod time_driver;
 pub mod timer;
 
+pub(crate) mod dflt;
+
 // Sometimes-present hardware
 
 #[cfg(adc)]
 pub mod adc;
+#[cfg(adf)]
+pub mod adf;
 #[cfg(aes_v3b)]
 pub mod aes;
 #[cfg(backup_sram)]
@@ -122,8 +126,14 @@ pub mod exti;
 pub mod flash;
 #[cfg(fmac)]
 pub mod fmac;
-#[cfg(fmc)]
+#[cfg(any(fmc, fsmc))]
 pub mod fmc;
+#[cfg(gfxmmu)]
+pub mod gfxmmu;
+#[cfg(gfxtim)]
+pub mod gfxtim;
+#[cfg(gpu2d)]
+pub mod gpu2d;
 #[cfg(hash)]
 pub mod hash;
 #[cfg(hrtim)]
@@ -138,19 +148,21 @@ pub mod i2c;
 pub mod i2s;
 #[cfg(any(stm32wb, stm32wl5x))]
 pub mod ipcc;
-// Limited to N6 for now — on H7 the metapac entry for JPEG has `rcc: None`
-// (no RccPeripheral impl is generated), and the DMA signal names differ
-// (INFIFO/OUTFIFO vs N6's RX/TX). Broaden once stm32-data is updated.
-#[cfg(all(jpeg, stm32n6))]
+// JPEG is unavailable on some families (e.g. H7 uses different DMA signal names).
+#[cfg(jpeg)]
 pub mod jpeg;
 #[cfg(lcd)]
 pub mod lcd;
 #[cfg(feature = "low-power")]
 pub mod low_power;
+#[cfg(lpgpio)]
+pub mod lpgpio;
 #[cfg(lptim)]
 pub mod lptim;
 #[cfg(ltdc)]
 pub mod ltdc;
+#[cfg(mdf)]
+pub mod mdf;
 #[cfg(opamp)]
 pub mod opamp;
 #[cfg(octospi)]

--- a/embassy-stm32/src/lpgpio.rs
+++ b/embassy-stm32/src/lpgpio.rs
@@ -1,0 +1,82 @@
+//! LPGPIO — low-power GPIO port (Stop 2/3 capable on supported U5 lines).
+
+use embassy_hal_internal::PeripheralType;
+
+use crate::pac::lpgpio::Lpgpio as Regs;
+use crate::{Peri, rcc};
+
+/// Number of pins on LPGPIO1.
+pub const PIN_COUNT: u8 = 16;
+
+/// Pin mode.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+pub enum Mode {
+    /// Input.
+    Input,
+    /// Push-pull output.
+    Output,
+}
+
+/// LPGPIO driver.
+pub struct Lpgpio<'d, T: Instance> {
+    _peri: Peri<'d, T>,
+}
+
+impl<'d, T: Instance> Lpgpio<'d, T> {
+    /// Create a new LPGPIO instance.
+    pub fn new(peri: Peri<'d, T>) -> Self {
+        rcc::enable_and_reset::<T>();
+        Self { _peri: peri }
+    }
+
+    /// Set pin mode (`false` = input, `true` = output in hardware).
+    pub fn set_mode(&mut self, pin: u8, mode: Mode) {
+        assert!(pin < PIN_COUNT);
+        let mask = 1u32 << pin;
+        T::regs().moder().modify(|w| match mode {
+            Mode::Input => w.0 &= !mask,
+            Mode::Output => w.0 |= mask,
+        });
+    }
+
+    /// Drive an output pin high or low. Pin must be configured as output.
+    pub fn set_level(&mut self, pin: u8, high: bool) {
+        assert!(pin < PIN_COUNT);
+        if high {
+            T::regs().bsrr().write(|w| w.0 = 1 << pin);
+        } else {
+            T::regs().brr().write(|w| w.0 = 1 << pin);
+        }
+    }
+
+    /// Read the input level of a pin.
+    pub fn get_level(&self, pin: u8) -> bool {
+        assert!(pin < PIN_COUNT);
+        (T::regs().idr().read().0 & (1 << pin)) != 0
+    }
+
+    /// Toggle an output pin.
+    pub fn toggle(&mut self, pin: u8) {
+        self.set_level(pin, !self.get_level(pin));
+    }
+}
+
+trait SealedInstance: crate::rcc::RccPeripheral {
+    fn regs() -> Regs;
+}
+
+/// LPGPIO instance trait.
+#[allow(private_bounds)]
+pub trait Instance: SealedInstance + PeripheralType + 'static {}
+
+foreach_peripheral!(
+    (lpgpio, $inst:ident) => {
+        impl crate::lpgpio::SealedInstance for crate::peripherals::$inst {
+            fn regs() -> Regs {
+                crate::pac::$inst
+            }
+        }
+        impl crate::lpgpio::Instance for crate::peripherals::$inst {}
+    };
+);

--- a/embassy-stm32/src/mdf.rs
+++ b/embassy-stm32/src/mdf.rs
@@ -1,0 +1,312 @@
+//! Multi-function Digital Filter (MDF)
+
+use core::marker::PhantomData;
+
+use embassy_hal_internal::PeripheralType;
+
+use crate::dflt::{Acqmod, Bssel, Cckdir, Cicmod, Ckgmod, Datsrc, Rxfifo};
+pub use crate::dflt::{ClockConfig, FilterConfig, SitfConfig, sample_from_dma_word, samples_from_dma_words};
+use crate::dma::ringbuffer::Error as RingbufferError;
+use crate::dma::{Channel, ReadableRingBuffer, TransferOptions};
+use crate::gpio::{AfType, OutputType, Pull, Speed};
+use crate::interrupt::typelevel::Interrupt;
+use crate::pac::mdf::Mdf as Regs;
+use crate::{Peri, interrupt, rcc};
+
+/// Marker types for MDF digital filters 0..5.
+pub struct Flt0;
+/// Marker type for filter 1.
+pub struct Flt1;
+/// Marker type for filter 2.
+pub struct Flt2;
+/// Marker type for filter 3.
+pub struct Flt3;
+/// Marker type for filter 4.
+pub struct Flt4;
+/// Marker type for filter 5.
+pub struct Flt5;
+
+/// Identifies one of the six MDF filter channels.
+#[allow(private_bounds)]
+pub trait Filter: SealedFilter {
+    /// Filter index (0..5).
+    const INDEX: u8;
+    /// Interrupt for this filter.
+    type Interrupt: Interrupt;
+}
+
+trait SealedFilter {}
+
+macro_rules! impl_filter {
+    ($flt:ident, $idx:literal, $int:ident) => {
+        impl SealedFilter for $flt {}
+        impl Filter for $flt {
+            const INDEX: u8 = $idx;
+            type Interrupt = crate::_generated::peripheral_interrupts::MDF1::$int;
+        }
+    };
+}
+
+impl_filter!(Flt0, 0, FLT0);
+impl_filter!(Flt1, 1, FLT1);
+impl_filter!(Flt2, 2, FLT2);
+impl_filter!(Flt3, 3, FLT3);
+impl_filter!(Flt4, 4, FLT4);
+impl_filter!(Flt5, 5, FLT5);
+
+/// MDF driver error.
+#[derive(Debug)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+pub enum Error {
+    /// DMA ring buffer error.
+    Ringbuffer(RingbufferError),
+}
+
+impl From<RingbufferError> for Error {
+    fn from(err: RingbufferError) -> Self {
+        Self::Ringbuffer(err)
+    }
+}
+
+/// Ring-buffered MDF driver for one digital filter.
+pub struct Mdf<'d, T: Instance, F: Filter> {
+    _peri: Peri<'d, T>,
+    _filter: PhantomData<F>,
+    ring_buffer: ReadableRingBuffer<'d, u32>,
+}
+
+/// Combined configuration for PDM capture on a filter/SITF pair.
+#[derive(Clone, Copy, Debug)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+pub struct Config {
+    /// Clock generator settings.
+    pub clock: ClockConfig,
+    /// Serial interface settings.
+    pub sitf: SitfConfig,
+    /// Digital filter settings.
+    pub filter: FilterConfig,
+}
+
+impl Config {
+    /// Default configuration for the given filter / serial interface index.
+    pub const fn for_filter(index: u8) -> Self {
+        Self {
+            clock: ClockConfig {
+                procdiv: 0,
+                cckdiv: crate::dflt::Cckdiv::Div1,
+                cck0_output: true,
+                cck1_output: false,
+            },
+            sitf: SitfConfig {
+                mode: crate::dflt::Sitfmod::NormalSpi,
+                clock_source: crate::dflt::Scksrc::Cck0,
+                threshold: 4,
+            },
+            filter: FilterConfig {
+                bitstream: bitstream_for_sitf(index),
+                cic_decimation: 31,
+                scale: 0b100000,
+                acquisition_mode: Acqmod::AsynchronousContinuous,
+                fifo_threshold: Rxfifo::HalfFull,
+            },
+        }
+    }
+}
+
+impl<'d, T: Instance, F: Filter> Mdf<'d, T, F> {
+    fn dma_opts() -> TransferOptions {
+        TransferOptions {
+            half_transfer_ir: true,
+            ..Default::default()
+        }
+    }
+
+    /// Create a new MDF instance for filter `F`.
+    ///
+    /// `cck` drives the PDM bit clock and `sdi` receives the PDM data stream for the
+    /// serial interface with the same index as the filter.
+    pub fn new<D>(
+        peri: Peri<'d, T>,
+        irq: impl interrupt::typelevel::Binding<F::Interrupt, FilterInterruptHandler<T, F>>
+        + interrupt::typelevel::Binding<D::Interrupt, crate::dma::InterruptHandler<D>>
+        + 'd,
+        config: Config,
+        cck: Peri<'d, impl CckPin<T>>,
+        sdi: Peri<'d, impl SdiPin<T>>,
+        dma: Peri<'d, D>,
+        dma_buf: &'d mut [u32],
+    ) -> Self
+    where
+        D: RxDma<T, F>,
+    {
+        set_as_af!(cck, AfType::output(OutputType::PushPull, Speed::VeryHigh));
+        set_as_af!(sdi, AfType::input(Pull::None));
+
+        rcc::enable_and_reset::<T>();
+        F::Interrupt::unpend();
+        unsafe { F::Interrupt::enable() };
+
+        let regs = T::regs();
+        let index = F::INDEX as usize;
+        Self::apply_config(regs, index, &config);
+
+        let request = dma.request();
+        let ring_buffer = unsafe {
+            ReadableRingBuffer::new(
+                Channel::new(dma, irq),
+                request,
+                regs.dfltdr(index).as_ptr() as *mut u32,
+                dma_buf,
+                Self::dma_opts(),
+            )
+        };
+
+        Self {
+            _peri: peri,
+            _filter: PhantomData,
+            ring_buffer,
+        }
+    }
+
+    fn apply_config(regs: Regs, index: usize, config: &Config) {
+        use crate::pac::mdf::vals as v;
+
+        regs.ckgcr().modify(|w| {
+            w.set_ckgmod(v::Ckgmod::from_bits(Ckgmod::Immediate.to_bits()));
+            w.set_procdiv(config.clock.procdiv);
+            w.set_cckdiv(v::Cckdiv::from_bits(config.clock.cckdiv.to_bits()));
+            w.set_cck0dir(v::Cckdir::from_bits(if config.clock.cck0_output {
+                Cckdir::Output.to_bits()
+            } else {
+                Cckdir::Input.to_bits()
+            }));
+            w.set_cck1dir(v::Cckdir::from_bits(if config.clock.cck1_output {
+                Cckdir::Output.to_bits()
+            } else {
+                Cckdir::Input.to_bits()
+            }));
+            w.set_cck0en(config.clock.cck0_output);
+            w.set_cck1en(config.clock.cck1_output);
+            w.set_ckgden(true);
+        });
+
+        regs.sitfcr(index).modify(|w| {
+            w.set_sitfmod(v::Sitfmod::from_bits(config.sitf.mode.to_bits()));
+            w.set_scksrc(v::Scksrc::from_bits(config.sitf.clock_source.to_bits()));
+            w.set_sth(config.sitf.threshold);
+            w.set_sitfen(true);
+        });
+
+        regs.bsmxcr(index).modify(|w| {
+            w.set_bssel(v::Bssel::from_bits(config.filter.bitstream.to_bits()));
+        });
+        regs.dfltcicr(index).modify(|w| {
+            w.set_datsrc(v::Datsrc::from_bits(Datsrc::Bsmx.to_bits()));
+            w.set_cicmod(v::Cicmod::from_bits(Cicmod::Sinc5.to_bits()));
+            w.set_mcicd(config.filter.cic_decimation);
+            w.set_scale(config.filter.scale);
+        });
+        regs.dfltrsfr(index).modify(|w| {
+            w.set_rsfltbyp(true);
+            w.set_hpfbyp(true);
+        });
+        regs.dfltcr(index).modify(|w| {
+            w.set_acqmod(v::Acqmod::from_bits(config.filter.acquisition_mode.to_bits()));
+            w.set_fth(v::Rxfifo::from_bits(config.filter.fifo_threshold.to_bits()));
+            w.set_dmaen(true);
+        });
+    }
+
+    /// Start filter acquisition and DMA.
+    pub fn start(&mut self) {
+        self.ring_buffer.start();
+        let index = F::INDEX as usize;
+        T::regs().dfltcr(index).modify(|w| {
+            w.set_dflten(true);
+            w.set_dfltrun(true);
+        });
+    }
+
+    /// Read raw 32-bit DMA words from the filter output ring buffer.
+    pub async fn read_raw(&mut self, words: &mut [u32]) -> Result<(), Error> {
+        self.ring_buffer.read_exact(words).await?;
+        Ok(())
+    }
+
+    /// Return the kernel clock frequency in Hz.
+    pub fn kernel_clock_hz(&self) -> u32 {
+        <T as crate::rcc::SealedRccPeripheral>::frequency().0
+    }
+}
+
+impl<'d, T: Instance, F: Filter> Drop for Mdf<'d, T, F> {
+    fn drop(&mut self) {
+        let index = F::INDEX as usize;
+        let regs = T::regs();
+        regs.dfltcr(index).modify(|w| {
+            w.set_dfltrun(false);
+            w.set_dflten(false);
+            w.set_dmaen(false);
+        });
+        regs.sitfcr(index).modify(|w| w.set_sitfen(false));
+        if index == 0 {
+            regs.ckgcr().modify(|w| w.set_ckgden(false));
+        }
+    }
+}
+
+trait SealedInstance: crate::rcc::RccPeripheral {
+    fn regs() -> Regs;
+}
+
+/// MDF instance trait.
+#[allow(private_bounds)]
+pub trait Instance: SealedInstance + PeripheralType + 'static {}
+
+/// MDF filter interrupt handler.
+pub struct FilterInterruptHandler<T: Instance, F: Filter> {
+    _marker: PhantomData<(T, F)>,
+}
+
+impl<T: Instance, F: Filter> interrupt::typelevel::Handler<F::Interrupt> for FilterInterruptHandler<T, F> {
+    unsafe fn on_interrupt() {
+        let index = F::INDEX as usize;
+        let isr = T::regs().dfltisr(index).read();
+        if isr.dovrf() || isr.rfovrf() {
+            T::regs().dfltisr(index).modify(|w| {
+                w.set_dovrf(true);
+                w.set_rfovrf(true);
+            });
+        }
+    }
+}
+
+pin_trait!(CckPin, Instance);
+pin_trait!(CkiPin, Instance);
+pin_trait!(SdiPin, Instance);
+
+dma_trait!(RxDma, Instance, Filter);
+
+foreach_peripheral!(
+    (mdf, $inst:ident) => {
+        impl crate::mdf::SealedInstance for crate::peripherals::$inst {
+            fn regs() -> crate::pac::mdf::Mdf {
+                crate::pac::$inst
+            }
+        }
+        impl crate::mdf::Instance for crate::peripherals::$inst {}
+    };
+);
+
+/// Return the BSMX bitstream selection for a given serial interface index.
+pub const fn bitstream_for_sitf(index: u8) -> Bssel {
+    match index {
+        0 => Bssel::Bs0R,
+        1 => Bssel::Bs1R,
+        2 => Bssel::Bs2R,
+        3 => Bssel::Bs3R,
+        4 => Bssel::Bs4R,
+        5 => Bssel::Bs5R,
+        _ => Bssel::Bs0R,
+    }
+}

--- a/examples/stm32u5/src/bin/pdm.rs
+++ b/examples/stm32u5/src/bin/pdm.rs
@@ -1,0 +1,103 @@
+//! PDM microphone capture on STM32U5 using MDF filter 0.
+//!
+//! Tested on NUCLEO-U545RE-Q / NUCLEO-U575ZI-Q class boards (see `Cargo.toml` chip feature).
+//!
+//! # Hardware
+//!
+//! Connect a PDM microphone (e.g. MP34DT05) to:
+//! - **CLK** → `PE9` (MDF1 CCK0)
+//! - **DATA** → `PE10` (MDF1 SDI0)
+//! - **3V3** and **GND** as usual
+//!
+//! The MDF kernel clock must be configured in RCC before use — same as other U5 peripherals
+//! with a dedicated clock mux (DAC, FDCAN, SAI, etc.). This example routes MDF1 from HCLK1.
+//!
+//! # Output
+//!
+//! Decimated PCM samples are read via DMA. The example prints an approximate RMS level over
+//! defmt once per second. With no microphone attached the level stays near zero.
+
+#![no_std]
+#![no_main]
+
+use defmt::*;
+use embassy_executor::Spawner;
+use embassy_stm32::mdf::{self, Config, Flt0, Mdf, samples_from_dma_words};
+use embassy_stm32::rcc::{self, mux};
+use embassy_stm32::{Config as StmConfig, bind_interrupts, dma, peripherals};
+use embassy_time::Timer;
+use micromath::F32Ext;
+use {defmt_rtt as _, panic_probe as _};
+
+/// Target PDM bit clock. Common for many MEMS PDM mics (1–3.2 MHz).
+const PDM_CCK_HZ: u32 = 2_000_000;
+
+const RAW_BUF_LEN: usize = 256;
+
+bind_interrupts!(struct Irqs {
+    MDF1_FLT0 => mdf::FilterInterruptHandler<peripherals::MDF1, Flt0>;
+    GPDMA1_CHANNEL0 => dma::InterruptHandler<peripherals::GPDMA1_CH0>;
+});
+
+/// Build MDF config for filter 0 / SITF 0 at the given kernel clock.
+fn mdf_config(kernel_hz: u32) -> Config {
+    let mut config = Config::for_filter(0);
+    // Processing clock = kernel / (procdiv + 1); CCK0 uses that clock with cckdiv = 1.
+    config.clock.procdiv = kernel_hz.div_ceil(PDM_CCK_HZ).saturating_sub(1).min(255) as u8;
+    config
+}
+
+#[embassy_executor::main]
+async fn main(_spawner: Spawner) {
+    let mut stm_config = StmConfig::default();
+    // Peripherals with kernel-clock muxes are configured in application RCC setup, not in the driver.
+    stm_config.rcc.mux.mdf1sel = mux::Mdfsel::Hclk1;
+
+    let p = embassy_stm32::init(stm_config);
+    info!("PDM example started");
+
+    let kernel_hz = rcc::frequency::<peripherals::MDF1>().0;
+    let config = mdf_config(kernel_hz);
+
+    let mut dma_buf = [0u32; RAW_BUF_LEN];
+    let mut raw = [0u32; RAW_BUF_LEN];
+    let mut samples = [0i32; RAW_BUF_LEN];
+
+    let mut mdf = Mdf::new(
+        p.MDF1,
+        Irqs,
+        config,
+        p.PE9,  // CCK0
+        p.PE10, // SDI0
+        p.GPDMA1_CH0,
+        &mut dma_buf,
+    );
+
+    info!(
+        "MDF kernel clock: {} Hz, procdiv: {}, target PDM clock: {} Hz",
+        kernel_hz, config.clock.procdiv, PDM_CCK_HZ
+    );
+
+    mdf.start();
+
+    loop {
+        match mdf.read_raw(&mut raw).await {
+            Ok(()) => {
+                samples_from_dma_words(&raw, &mut samples);
+                let rms = rms(&samples);
+                info!("PCM RMS (approx): {}", rms as u32);
+            }
+            Err(e) => error!("MDF read error: {:?}", e),
+        }
+
+        Timer::after_secs(1).await;
+    }
+}
+
+fn rms(samples: &[i32]) -> f32 {
+    if samples.is_empty() {
+        return 0.0;
+    }
+    let sum_sq: f32 = samples.iter().map(|s| (*s as f32) * (*s as f32)).sum();
+    (sum_sq / samples.len() as f32).sqrt()
+}


### PR DESCRIPTION
## Summary

- Add **ADF** and **MDF** drivers for PDM microphone capture with DMA ring buffers, shared config types in `dflt`, and pin/DMA build.rs wiring.
- Wire **FMC** for STM32U5 `fsmc_v5x1` (pin traits, instance impls; SDRAM constructors gated where unsupported).
- Add premium-line drivers: **GFXMMU** (framebuffer LUT), **GPU2D** (status/interrupt skeleton), **GFXTIM** (display counters), and **LPGPIO** (Stop-mode GPIO).
- Enable **JPEG** driver on U5F9/U5G9 (DMA trait impls; module no longer N6-only).
- Add **`examples/stm32u5/src/bin/pdm.rs`** demonstrating MDF filter 0 capture on PE9/PE10.

## Test plan

- [x] `cargo build --target thumbv8m.main-none-eabihf --features stm32u575zi`
- [x] `cargo build --target thumbv8m.main-none-eabihf --features stm32u599zj`
- [x] `cargo build --target thumbv8m.main-none-eabihf --features stm32u5f9zj`
- [x] `cargo build --bin pdm --target thumbv8m.main-none-eabihf` in `examples/stm32u5`