### PR TITLE
stm32: U5 time-driver-lptim improvements

### DIFF
--- a/embassy-stm32/src/rcc/mod.rs
+++ b/embassy-stm32/src/rcc/mod.rs
@@ -631,6 +631,9 @@ pub(crate) fn init_rcc(_cs: CriticalSection, config: Config) {
                 #[cfg(not(stm32wba))]
                 {
                     use crate::pac::rcc::vals::Lptimsel;
+                    #[cfg(any(stm32u5, stm32u3))]
+                    ensure_lptim_clk!(lptim1sel, Lptimsel, Lptimsel::Msik);
+                    #[cfg(not(any(stm32u5, stm32u3)))]
                     ensure_lptim_clk!(lptim1sel, Lptimsel, Lptimsel::Pclk1);
                 }
                 #[cfg(stm32wba)]

--- a/embassy-stm32/src/time_driver/lptim.rs
+++ b/embassy-stm32/src/time_driver/lptim.rs
@@ -32,17 +32,18 @@ fn regs_lptim() -> Lptim {
     T::regs()
 }
 
-// LPTIM v2a (STM32WBA) renames the interrupt enable register from IER to DIER
-// and uses IcrAdv/DierAdv register types instead of Icr/Ier.
-// The compare register also changes from a single `cmp()` to an indexed `ccr(n)`.
+// LPTIM v2a/v2b (STM32WBA, STM32U5, STM32U3, etc.) renames the interrupt
+// enable register from IER to DIER and uses IcrAdv/DierAdv register types
+// instead of Icr/Ier. The compare register also changes from a single `cmp()`
+// to an indexed `ccr(n)`.
 
 /// Read the interrupt enable register value as a raw u32.
 fn ier_read(r: Lptim) -> u32 {
-    #[cfg(not(stm32wba))]
+    #[cfg(not(any(stm32wba, stm32u5, stm32u3)))]
     {
         r.ier().read().0
     }
-    #[cfg(stm32wba)]
+    #[cfg(any(stm32wba, stm32u5, stm32u3))]
     {
         r.dier().read().0
     }
@@ -50,11 +51,11 @@ fn ier_read(r: Lptim) -> u32 {
 
 /// Check if the compare-capture interrupt is enabled for channel `n`.
 fn ier_ccie(r: Lptim, n: usize) -> bool {
-    #[cfg(not(stm32wba))]
+    #[cfg(not(any(stm32wba, stm32u5, stm32u3)))]
     {
         r.ier().read().ccie(n)
     }
-    #[cfg(stm32wba)]
+    #[cfg(any(stm32wba, stm32u5, stm32u3))]
     {
         r.dier().read().ccie(n)
     }
@@ -62,35 +63,35 @@ fn ier_ccie(r: Lptim, n: usize) -> bool {
 
 /// Modify the interrupt enable register.
 fn ier_set_ueie(r: Lptim, val: bool) {
-    #[cfg(not(stm32wba))]
+    #[cfg(not(any(stm32wba, stm32u5, stm32u3)))]
     r.ier().modify(|w| w.set_ueie(val));
-    #[cfg(stm32wba)]
+    #[cfg(any(stm32wba, stm32u5, stm32u3))]
     r.dier().modify(|w| w.set_ueie(val));
 }
 
 fn ier_set_ccie(r: Lptim, n: usize, val: bool) {
-    #[cfg(not(stm32wba))]
+    #[cfg(not(any(stm32wba, stm32u5, stm32u3)))]
     r.ier().modify(|w| w.set_ccie(n, val));
-    #[cfg(stm32wba)]
+    #[cfg(any(stm32wba, stm32u5, stm32u3))]
     r.dier().modify(|w| w.set_ccie(n, val));
 }
 
 /// Write a raw value to the ICR (interrupt clear register).
 fn icr_write_raw(r: Lptim, val: u32) {
-    #[cfg(not(stm32wba))]
+    #[cfg(not(any(stm32wba, stm32u5, stm32u3)))]
     r.icr().write_value(stm32_metapac::lptim::regs::Icr(val));
-    #[cfg(stm32wba)]
+    #[cfg(any(stm32wba, stm32u5, stm32u3))]
     r.icr().write_value(stm32_metapac::lptim::regs::IcrAdv(val));
 }
 
 /// Write the compare value and wait for the write to be acknowledged.
 fn write_compare(r: Lptim, val: u16) {
-    #[cfg(not(stm32wba))]
+    #[cfg(not(any(stm32wba, stm32u5, stm32u3)))]
     {
         r.cmp().write(|w| w.set_cmp(val));
         while !r.isr().read().cmpok(0) {}
     }
-    #[cfg(stm32wba)]
+    #[cfg(any(stm32wba, stm32u5, stm32u3))]
     {
         r.ccr(0).write(|w| w.set_ccr(val));
         while !r.isr().read().cmpok(0) {}

--- a/embassy-stm32/src/time_driver/lptim.rs
+++ b/embassy-stm32/src/time_driver/lptim.rs
@@ -205,6 +205,28 @@ impl RtcDriver {
                     crate::pac::EXTI.imr(0).modify(|w| w.set_line(EXTI_WAKEUP_LINE, true));
                 }
             }
+
+            // U5/U3: the LP timer used as time driver must remain functional in
+            // STOP mode so it can wake the CPU. Two RCC bits are required:
+            //  - SRDAMR.*amen: autonomous mode enable, so the peripheral can
+            //    request its kernel clock (LSE/LSI) while in STOP.
+            //  - APB3SMENR.*smen: keep the APB bus clock available in STOP so
+            //    the NVIC interrupt reaches the CPU.
+            // Without these, the LPTIM keeps its registers but its interrupt
+            // cannot wake the core from STOP, hanging the executor.
+            #[cfg(any(stm32u5, stm32u3))]
+            {
+                #[cfg(time_driver_lptim1)]
+                {
+                    crate::pac::RCC.srdamr().modify(|w| w.set_lptim1amen(true));
+                    crate::pac::RCC.apb3smenr().modify(|w| w.set_lptim1smen(true));
+                }
+                #[cfg(time_driver_lptim3)]
+                {
+                    crate::pac::RCC.srdamr().modify(|w| w.set_lptim3amen(true));
+                    crate::pac::RCC.apb3smenr().modify(|w| w.set_lptim3smen(true));
+                }
+            }
         }
     }
 


### PR DESCRIPTION
Hi folks,

I've tried to get time-driver-lptim working on stm32u5, and found a couple of small changes were needed. Effectively, this PR just expands https://github.com/embassy-rs/embassy/pull/5963 to the equivalently-operating u3/u5 chips. 


I'm reasonably new to the innards of embassy, so please advise if there are smarter ways to handle this. Also note, I've only tested this on u575, but during a review of my patch, AI suggested that this should also apply to u3, so I've included U3 too. [The stm32-data table](https://github.com/embassy-rs/stm32-data-generated#lptim) supports this, but I have no u3 to test on.

Best,
K