### PR TITLE
stm32/adc: fix continuous adc on h5

### DIFF
--- a/embassy-stm32/src/adc/v3.rs
+++ b/embassy-stm32/src/adc/v3.rs
@@ -254,7 +254,7 @@ impl super::AdcRegs for crate::pac::adc::Adc {
             w.set_discen(false);
             w.set_dmaen(!matches!(conversion_mode, ConversionMode::NoDma));
             w.set_cont(false);
-            #[cfg(any(adc_v3, adc_g0, adc_u0))]
+            #[cfg(any(adc_v3, adc_g0, adc_u0, adc_h5))]
             w.set_cont(matches!(conversion_mode, ConversionMode::Repeated(None)));
             w.set_dmacfg(Dmacfg::Circular);
 

--- a/embassy-stm32/src/adc/v3.rs
+++ b/embassy-stm32/src/adc/v3.rs
@@ -253,6 +253,7 @@ impl super::AdcRegs for crate::pac::adc::Adc {
         regs.modify(|w| {
             w.set_discen(false);
             w.set_dmaen(!matches!(conversion_mode, ConversionMode::NoDma));
+            #[cfg(not(any(adc_v3, adc_g0, adc_u0, adc_h5)))]
             w.set_cont(false);
             #[cfg(any(adc_v3, adc_g0, adc_u0, adc_h5))]
             w.set_cont(matches!(conversion_mode, ConversionMode::Repeated(None)));


### PR DESCRIPTION
Found and tested on STM32H523CE.

I also added `#[cfg(not(any(...)))]` to `w.set_cont(false);` to prevent setting conversion mode twice, but don't know on which ADCs `w.set_cont(false);` is actually correct. I think it should always be set based on `conversion_mode`.