### PR TITLE
stm32/adc: do not reset config on stop

### DIFF
--- a/embassy-stm32/src/adc/v3.rs
+++ b/embassy-stm32/src/adc/v3.rs
@@ -211,18 +211,6 @@ impl super::AdcRegs for crate::pac::adc::Adc {
             });
             while self.cr().read().adstart() {}
         }
-
-        // Reset configuration.
-        #[cfg(not(any(adc_g0, adc_u0)))]
-        self.cfgr().modify(|reg| {
-            reg.set_cont(false);
-            reg.set_dmaen(false);
-        });
-        #[cfg(any(adc_g0, adc_u0))]
-        self.cfgr1().modify(|reg| {
-            reg.set_cont(false);
-            reg.set_dmaen(false);
-        });
     }
 
     fn power_down(&self) {


### PR DESCRIPTION
Reseating configuration here breaks for example `RingBufferedAdc` after stopping it and starting again.

Tested on STM32H523CE.