### PR TITLE
stm32: make dma packing options more consistent

### DIFF
--- a/embassy-stm32/src/adc/mod.rs
+++ b/embassy-stm32/src/adc/mod.rs
@@ -408,7 +408,7 @@ impl<'d, T: Instance> Adc<'d, T> {
                     // DMA will read 0 unless it is marked as secure along with RISUP 64 (ADC12)
                     secure: true,
                     #[cfg(stm32n6)]
-                    packing: crate::dma::no_packing(),
+                    packing: crate::dma::Packing::ZeroExtendOrLeftTruncate,
                     ..Default::default()
                 },
             )

--- a/embassy-stm32/src/dac/mod.rs
+++ b/embassy-stm32/src/dac/mod.rs
@@ -13,7 +13,7 @@ use embassy_hal_internal::drop::OnDrop;
 use embassy_sync::blocking_mutex::raw::CriticalSectionRawMutex;
 pub use ringbuffered::RingBufferedDacChannel;
 
-use crate::dma::{ChannelAndRequest, no_packing, word as dma};
+use crate::dma::{ChannelAndRequest, Packing, word as dma};
 use crate::mode::{Async, Blocking, Mode as PeriMode};
 #[cfg(any(dac_v3, dac_v4, dac_v5, dac_v6, dac_v7))]
 use crate::pac::dac;
@@ -299,7 +299,7 @@ impl<'d> DacChannel<'d, Async> {
                 W::dma_ptr(info.regs, idx),
                 W::dma_buf_mut(dma_buf),
                 crate::dma::TransferOptions {
-                    packing: no_packing(),
+                    packing: Packing::ZeroExtendOrLeftTruncate,
                     ..Default::default()
                 },
             )
@@ -327,7 +327,7 @@ impl<'d> DacChannel<'d, Async> {
         let tx_options = crate::dma::TransferOptions {
             half_transfer_ir: false,
             complete_transfer_ir: true,
-            packing: no_packing(),
+            packing: Packing::ZeroExtendOrLeftTruncate,
             ..Default::default()
         };
 
@@ -363,7 +363,7 @@ impl<'d> DacChannel<'d, Async> {
             circular: true,
             half_transfer_ir: false,
             complete_transfer_ir: false,
-            packing: no_packing(),
+            packing: Packing::ZeroExtendOrLeftTruncate,
             ..Default::default()
         };
 

--- a/embassy-stm32/src/dma/dma_bdma.rs
+++ b/embassy-stm32/src/dma/dma_bdma.rs
@@ -162,8 +162,8 @@ pub struct TransferOptions {
     pub complete_transfer_ir: bool,
     /// DMA packing configuration
     ///
-    /// If false, psize may be adjusted based on the platform to acheive no packing.
-    pub packing: bool,
+    /// If [`Packing::ZeroExtendOrLeftTruncate`], psize may be adjusted based on the platform to acheive no packing.
+    pub packing: Packing,
     #[cfg(mdma)]
     /// Max bytes to transfer at once, 1-64
     pub buffer_size: u8,
@@ -178,9 +178,16 @@ pub struct TransferOptions {
     pub word_swap: bool,
 }
 
-/// Return the no packing value
-pub const fn no_packing() -> bool {
-    false
+/// DMA Packing options
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+pub enum Packing {
+    /// If destination is wider: source data is transferred as right aligned, padded with 0s up to the destination data width
+    /// If source is wider: source data is transferred as right aligned, left-truncated down to the destination data width
+    ZeroExtendOrLeftTruncate,
+    /// source data is FIFO queued and packed/unpacked at the destination data width,
+    /// to be transferred in a left (LSB) to right (MSB) order (named little endian) to the destination
+    Pack,
 }
 
 impl Default for TransferOptions {
@@ -198,7 +205,7 @@ impl Default for TransferOptions {
             circular: false,
             half_transfer_ir: false,
             complete_transfer_ir: true,
-            packing: true,
+            packing: Packing::Pack,
             #[cfg(mdma)]
             buffer_size: MDMA_MAX_BUFFER,
             #[cfg(mdma)]
@@ -528,7 +535,10 @@ impl<'d> Channel<'d> {
                 self.clear_irqs();
 
                 #[cfg(any(stm32f2, stm32f4, stm32f7, stm32h7))]
-                let peri_size = if !options.packing { mem_size } else { peri_size };
+                let peri_size = match options.packing {
+                    Packing::Pack => peri_size,
+                    Packing::ZeroExtendOrLeftTruncate => mem_size,
+                };
 
                 // NDTR is the number of transfers in the *peripheral* word size.
                 // ex: if mem_size=1, peri_size=4 and ndtr=3 it'll do 12 mem transfers, 3 peri transfers.

--- a/embassy-stm32/src/dma/gpdma/mod.rs
+++ b/embassy-stm32/src/dma/gpdma/mod.rs
@@ -22,7 +22,7 @@ use crate::rcc::WakeGuard;
 pub mod linked_list;
 pub mod ringbuffered;
 
-pub use vals::Pam;
+pub use vals::Pam as Packing;
 
 pub(crate) enum DmaInfo {
     #[cfg(gpdma)]
@@ -337,7 +337,7 @@ pub struct TransferOptions {
     #[cfg(stm32n6)]
     pub secure: bool,
     /// DMA packing configuration
-    pub packing: Pam,
+    pub packing: Packing,
     /// Source/destination burst length, in beats. Default `_1Beats`. Some
     /// peripherals only assert their DMA request line for bursts above a
     /// threshold (notably the JPEG codec on N6), and some require multi-beat
@@ -349,11 +349,6 @@ pub struct TransferOptions {
     pub request_mode: RequestMode,
     /// Optional trigger-gated transfer configuration.
     pub trigger: Option<TriggerConfig>,
-}
-
-/// Return the no packing value
-pub const fn no_packing() -> Pam {
-    Pam::ZeroExtendOrLeftTruncate
 }
 
 impl Default for TransferOptions {

--- a/embassy-stm32/src/sdmmc/mod.rs
+++ b/embassy-stm32/src/sdmmc/mod.rs
@@ -414,7 +414,7 @@ const DMA_TRANSFER_OPTIONS: crate::dma::TransferOptions = crate::dma::TransferOp
     circular: false,
     half_transfer_ir: false,
     complete_transfer_ir: true,
-    packing: true,
+    packing: crate::dma::Packing::Pack,
 };
 
 #[cfg(all(sdmmc_v1, not(dma)))]
@@ -423,7 +423,7 @@ const DMA_TRANSFER_OPTIONS: crate::dma::TransferOptions = crate::dma::TransferOp
     circular: false,
     half_transfer_ir: false,
     complete_transfer_ir: true,
-    packing: true,
+    packing: crate::dma::Packing::Pack,
 };
 
 /// SDMMC configuration


### PR DESCRIPTION
copy the enum from the gpdma mod.