### PR TITLE
nxp/lpc55: blocking spi

### DIFF
--- a/embassy-nxp/CHANGELOG.md
+++ b/embassy-nxp/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 <!-- next-header -->
 ## Unreleased - ReleaseDate
+- LPC55: blocking version of SPI
 - Codegen using `nxp-pac` metadata
 - LPC55: PWM simple
 - LPC55: Move ALT definitions for USART to TX/RX pin impls. 

--- a/embassy-nxp/Cargo.toml
+++ b/embassy-nxp/Cargo.toml
@@ -83,7 +83,7 @@ _lpc55 = []
 _time_driver = ["dep:embassy-time-driver", "dep:embassy-time-queue-utils"]
 
 #! ### Chip selection features
-lpc55-core0 = ["nxp-pac/lpc55s69_cm33_core0"]
+lpc55-core0 = ["nxp-pac/lpc55s69_cm33_core0", "_lpc55"]
 lpc55s16 = ["nxp-pac/lpc55s16", "_lpc55"]
 mimxrt1011 = ["nxp-pac/mimxrt1011", "_rt1xxx", "dep:imxrt-rt"]
 mimxrt1062 = ["nxp-pac/mimxrt1062", "_rt1xxx", "dep:imxrt-rt"]

--- a/embassy-nxp/Cargo.toml
+++ b/embassy-nxp/Cargo.toml
@@ -40,13 +40,13 @@ embassy-time-queue-utils = { version = "0.3.2", path = "../embassy-time-queue-ut
 embedded-io = { version = "0.7.1" }
 embedded-hal-02 = { package = "embedded-hal", version = "0.2.6", features = ["unproven"] }
 ## Chip dependencies
-nxp-pac = { version = "0.1.0", optional = true, git = "https://github.com/embassy-rs/nxp-pac", rev = "e93605d8e8686f1853726921d5349ef3ecdea693" }
+nxp-pac = { version = "0.1.0", optional = true, git = "https://github.com/embassy-rs/nxp-pac", rev = "c54814bbb514495a7a5aebad7d17b987b7b70c0f" }
 
 imxrt-rt = { version = "0.1.7", optional = true, features = ["device"] }
 
 [build-dependencies]
 cfg_aliases = "0.2.1"
-nxp-pac = { version = "0.1.0", git = "https://github.com/embassy-rs/nxp-pac", rev = "e93605d8e8686f1853726921d5349ef3ecdea693", default-features = false, features = ["metadata"] }
+nxp-pac = { version = "0.1.0", git = "https://github.com/embassy-rs/nxp-pac", rev = "c54814bbb514495a7a5aebad7d17b987b7b70c0f", default-features = false, features = ["metadata"] }
 proc-macro2 = "1.0.95"
 quote = "1.0.15"
 

--- a/embassy-nxp/build.rs
+++ b/embassy-nxp/build.rs
@@ -399,6 +399,48 @@ fn impl_sct(impls: &mut Vec<TokenStream>, peripheral: &Peripheral) {
     }
 }
 
+fn impl_spi(cfgs: &mut common::CfgSet, impls: &mut Vec<TokenStream>, peripheral: &Peripheral) {
+    cfgs.declare_all(&["has_spi_sck_pins", "has_spi_mosi_pins", "has_spi_miso_pins"]);
+
+    let instance = Ident::new(peripheral.name, Span::call_site());
+    let flexcomm = Ident::new(
+        peripheral.flexcomm.expect("LPC55 must specify FLEXCOMM instance"),
+        Span::call_site(),
+    );
+    let number = Literal::u8_unsuffixed(peripheral.name.strip_prefix("SPI").unwrap().parse::<u8>().unwrap());
+
+    impls.push(quote! {
+        impl_spi_instance!(#instance, #flexcomm, #number);
+    });
+
+    for signal in peripheral.signals {
+        let r#macro = match signal.name {
+            "SCK" => {
+                cfgs.enable("has_spi_sck_pins");
+                format_ident!("impl_spi_sck_pin")
+            }
+            "MOSI" => {
+                cfgs.enable("has_spi_mosi_pins");
+                format_ident!("impl_spi_mosi_pin")
+            }
+            "MISO" => {
+                cfgs.enable("has_spi_miso_pins");
+                format_ident!("impl_spi_miso_pin")
+            }
+            _ => unreachable!(),
+        };
+
+        for pin in signal.pins {
+            let alt = format_ident!("ALT{}", pin.alt);
+            let pin = format_ident!("{}", pin.pin);
+
+            impls.push(quote! {
+                #r#macro!(#pin, #instance, #alt);
+            });
+        }
+    }
+}
+
 fn impl_peripherals(cfgs: &mut common::CfgSet, _singletons: &[Singleton]) -> TokenStream {
     let mut impls = Vec::new();
 
@@ -413,6 +455,10 @@ fn impl_peripherals(cfgs: &mut common::CfgSet, _singletons: &[Singleton]) -> Tok
 
         if peripheral.name.starts_with("USART") {
             impl_usart(cfgs, &mut impls, peripheral);
+        }
+
+        if peripheral.name.starts_with("SPI") {
+            impl_spi(cfgs, &mut impls, peripheral);
         }
 
         if peripheral.name.starts_with("SCT") {

--- a/embassy-nxp/build.rs
+++ b/embassy-nxp/build.rs
@@ -431,7 +431,7 @@ fn impl_spi(cfgs: &mut common::CfgSet, impls: &mut Vec<TokenStream>, peripheral:
         };
 
         for pin in signal.pins {
-            let alt = format_ident!("ALT{}", pin.alt);
+            let alt = format_ident!("Alt{}", pin.alt);
             let pin = format_ident!("{}", pin.pin);
 
             impls.push(quote! {

--- a/embassy-nxp/src/dma/lpc55.rs
+++ b/embassy-nxp/src/dma/lpc55.rs
@@ -63,7 +63,7 @@ pub(crate) fn init() {
     DMA0.ctrl().modify(|w| w.set_enable(true));
 
     unsafe {
-        crate::pac::interrupt::DMA0.enable();
+        crate::dma::inner::Interrupt::DMA0.enable();
     }
     info!("DMA initialized");
 }

--- a/embassy-nxp/src/lib.rs
+++ b/embassy-nxp/src/lib.rs
@@ -16,6 +16,8 @@ pub mod pwm;
 #[cfg(lpc55)]
 pub mod sct;
 #[cfg(lpc55)]
+pub mod spi;
+#[cfg(lpc55)]
 pub mod usart;
 
 #[cfg(rt1xxx)]

--- a/embassy-nxp/src/pint.rs
+++ b/embassy-nxp/src/pint.rs
@@ -10,7 +10,7 @@ use embassy_sync::waitqueue::AtomicWaker;
 
 use crate::Peri;
 use crate::gpio::{self, AnyPin, Level, SealedPin};
-use crate::pac::{INPUTMUX, PINT, SYSCON, interrupt};
+use crate::pac::{INPUTMUX, Interrupt, PINT, SYSCON, interrupt};
 
 struct PinInterrupt {
     assigned: bool,
@@ -93,14 +93,14 @@ pub(crate) fn init() {
 
     // Enable interrupts
     unsafe {
-        interrupt::PIN_INT0.enable();
-        interrupt::PIN_INT1.enable();
-        interrupt::PIN_INT2.enable();
-        interrupt::PIN_INT3.enable();
-        interrupt::PIN_INT4.enable();
-        interrupt::PIN_INT5.enable();
-        interrupt::PIN_INT6.enable();
-        interrupt::PIN_INT7.enable();
+        Interrupt::PIN_INT0.enable();
+        Interrupt::PIN_INT1.enable();
+        Interrupt::PIN_INT2.enable();
+        Interrupt::PIN_INT3.enable();
+        Interrupt::PIN_INT4.enable();
+        Interrupt::PIN_INT5.enable();
+        Interrupt::PIN_INT6.enable();
+        Interrupt::PIN_INT7.enable();
     };
 
     info!("Pin interrupts initialized");

--- a/embassy-nxp/src/spi.rs
+++ b/embassy-nxp/src/spi.rs
@@ -1,0 +1,6 @@
+//! Serial Peripheral Interface (SPI) driver.
+#![macro_use]
+
+#[cfg_attr(lpc55, path = "./spi/lpc55.rs")]
+mod inner;
+pub use inner::*;

--- a/embassy-nxp/src/spi/lpc55.rs
+++ b/embassy-nxp/src/spi/lpc55.rs
@@ -1,0 +1,539 @@
+#![macro_use]
+
+use core::marker::PhantomData;
+
+use embassy_hal_internal::{Peri, PeripheralType};
+pub use embedded_hal_02::spi::{Phase, Polarity};
+
+use crate::gpio::{AnyPin, SealedPin};
+use crate::pac::flexcomm::Flexcomm as FlexcommReg;
+use crate::pac::iocon::vals::PioFunc;
+use crate::pac::spi::Spi as SpiReg;
+use crate::pac::*;
+use crate::{Blocking, Mode};
+
+/// SPI errors.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+#[non_exhaustive]
+pub enum Error {
+    /// Triggered when the FIFO (or shift-register) is overflowed.
+    Overrun,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+#[non_exhaustive]
+pub enum ConstructorError {
+    /// Neither MOSI nor MISO pin is provided.
+    NoTransferringPinsError,
+    /// Frequency is too low or too high.
+    IncompatibleFrequencyError,
+}
+
+/// SPI configuration.
+#[non_exhaustive]
+#[derive(Clone)]
+pub struct Config {
+    /// Frequency.
+    pub frequency: u32,
+    /// Phase.
+    pub phase: Phase,
+    /// Polarity.
+    pub polarity: Polarity,
+    /// Binary representaion of sent data.
+    pub data_format: DataFormat,
+}
+
+impl Default for Config {
+    fn default() -> Self {
+        Self {
+            frequency: 1_000_000,
+            phase: Phase::CaptureOnFirstTransition,
+            polarity: Polarity::IdleLow,
+            data_format: DataFormat::MsbFirst,
+        }
+    }
+}
+
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+pub enum DataFormat {
+    LsbFirst,
+    MsbFirst,
+}
+
+/// SPI driver.
+pub struct Spi<'d, M: Mode> {
+    info: &'static Info,
+    phantom: PhantomData<(&'d (), M)>,
+}
+
+impl<'d, M: Mode> Spi<'d, M> {
+    fn new_inner<T: Instance>(
+        mosi: Option<Peri<'d, AnyPin>>,
+        mosi_func: Option<PioFunc>,
+        miso: Option<Peri<'d, AnyPin>>,
+        miso_func: Option<PioFunc>,
+        sck: Peri<'d, AnyPin>,
+        sck_func: PioFunc,
+        config: Config,
+    ) -> Result<Self, ConstructorError> {
+        let mut is_transfer_pin_present = false;
+        let mut mosi_tuple = None;
+        let mut miso_tuple = None;
+        if let (Some(mosi), Some(mosi_func)) = (mosi, mosi_func) {
+            is_transfer_pin_present = true;
+            mosi_tuple = Some((mosi, mosi_func));
+        }
+        if let (Some(miso), Some(miso_func)) = (miso, miso_func) {
+            is_transfer_pin_present = true;
+            miso_tuple = Some((miso, miso_func));
+        }
+        if !is_transfer_pin_present {
+            return Err(ConstructorError::NoTransferringPinsError);
+        }
+        Self::init::<T>(mosi_tuple, miso_tuple, (sck, sck_func), config);
+        Ok(Self {
+            info: T::info(),
+            phantom: PhantomData,
+        })
+    }
+
+    fn init<T: Instance>(
+        mosi: Option<(Peri<'_, AnyPin>, PioFunc)>,
+        miso: Option<(Peri<'_, AnyPin>, PioFunc)>,
+        sck: (Peri<'_, AnyPin>, PioFunc),
+        config: Config,
+    ) {
+        Self::configure_flexcomm(T::info().fc_reg, T::instance_number());
+        Self::configure_clock(T::info(), T::instance_number(), &config);
+        Self::configure_pins(mosi, miso, sck);
+        Self::configure_spi(T::info(), &config);
+        T::info().spi_reg.cfg().modify(|w| w.set_enable(true));
+    }
+
+    fn configure_flexcomm(flexcomm_register: crate::pac::flexcomm::Flexcomm, instance_number: usize) {
+        critical_section::with(|_cs| {
+            if !(SYSCON.ahbclkctrl0().read().iocon()) {
+                SYSCON.ahbclkctrl0().modify(|w| w.set_iocon(true));
+            }
+        });
+        critical_section::with(|_cs| {
+            if !(SYSCON.ahbclkctrl1().read().fc(instance_number)) {
+                SYSCON.ahbclkctrl1().modify(|w| w.set_fc(instance_number, true));
+            }
+        });
+        SYSCON
+            .presetctrl1()
+            .modify(|w| w.set_fc_rst(instance_number, syscon::vals::FcRst::ASSERTED));
+        SYSCON
+            .presetctrl1()
+            .modify(|w| w.set_fc_rst(instance_number, syscon::vals::FcRst::RELEASED));
+        flexcomm_register.pselid().modify(|w| {
+            w.set_persel(flexcomm::vals::Persel::SPI);
+            // This will lock the peripheral PERSEL and will not allow any changes until the board is reset.
+            w.set_lock(true);
+        });
+    }
+
+    fn configure_clock(registers: &'static Info, instance_number: usize, config: &Config) {
+        // Adaptive clock choice based on desired frequency
+        // To get the desired frequency, it is necessary to choose the clock bigger than the desired value so that it can be 'chiseled'
+        // There are two types of dividers: integer divider (rate divider value)
+        // and fractional divider (fractional rate divider).
+
+        // Minimum and maximum values were computed taking these formulas into account:
+        // For minimum value, MULT = 255, DIVVAL = 65536
+        // For maximum value, MULT = 0, DIVVAL = 0
+        // Flexcomm Interface function clock = (clock selected via FCCLKSEL) / (1 + MULT / DIV)
+        // Final frequency = FCLK / (DIVVAL + 1)
+
+        // 96 MHz is chosen because the frequency range used by SPI can be obtained using simple divisions.
+        // Minimum value is around 732 Hz (96 MHz / ((1 + 256/256) * 65536) = 96 MHz / 131_072 = 732.42 Hz)
+
+        SYSCON
+            .fcclksel(instance_number)
+            .modify(|w| w.set_sel(syscon::vals::FcclkselSel::ENUM_0X3));
+        let source_clock = 96_000_000;
+
+        // Parameter calculation for clock division
+        let div_val = (source_clock / config.frequency).min(0xFFFF);
+        let raw_clock = 96_000_000 / div_val;
+        let mult_val = ((raw_clock * 256 / config.frequency) - 256).min(255);
+
+        // FCLK =  (clock selected via FCCLKSEL) / (1+ MULT / DIV)
+        // Remark: To use the fractional baud rate generator, 0xFF must be written to the DIV value
+        // to yield a denominator value of 256. All other values are not supported
+        SYSCON.flexfrgctrl(instance_number).modify(|w| {
+            w.set_div(0xFF);
+            w.set_mult(mult_val as u8);
+        });
+
+        // Final frequency = FCLK / (DIVVAL + 1)
+        registers.spi_reg.div().modify(|w| w.set_divval(div_val as u16));
+    }
+
+    fn configure_pins(
+        mosi: Option<(Peri<'_, AnyPin>, PioFunc)>,
+        miso: Option<(Peri<'_, AnyPin>, PioFunc)>,
+        sck: (Peri<'_, AnyPin>, PioFunc),
+    ) {
+        if let Some((mosi_pin, func)) = mosi {
+            mosi_pin.pio().modify(|w| {
+                w.set_func(func);
+                w.set_mode(iocon::vals::PioMode::INACTIVE);
+                w.set_slew(iocon::vals::PioSlew::STANDARD);
+                w.set_invert(false);
+                w.set_digimode(iocon::vals::PioDigimode::DIGITAL);
+                w.set_od(iocon::vals::PioOd::NORMAL);
+            });
+        }
+
+        if let Some((miso_pin, func)) = miso {
+            miso_pin.pio().modify(|w| {
+                w.set_func(func);
+                w.set_mode(iocon::vals::PioMode::INACTIVE);
+                w.set_slew(iocon::vals::PioSlew::STANDARD);
+                w.set_invert(false);
+                w.set_digimode(iocon::vals::PioDigimode::DIGITAL);
+                w.set_od(iocon::vals::PioOd::NORMAL);
+            });
+        };
+
+        sck.0.pio().modify(|w| {
+            w.set_func(sck.1);
+            w.set_mode(iocon::vals::PioMode::INACTIVE);
+            w.set_slew(iocon::vals::PioSlew::STANDARD);
+            w.set_invert(false);
+            w.set_digimode(iocon::vals::PioDigimode::DIGITAL);
+            w.set_od(iocon::vals::PioOd::NORMAL);
+        });
+    }
+
+    fn configure_spi(info: &'static Info, config: &Config) {
+        let registers = info.spi_reg;
+
+        registers.fifocfg().modify(|w| {
+            w.set_enablerx(false);
+            w.set_enabletx(false);
+        });
+
+        registers.cfg().modify(|w| {
+            w.set_enable(false);
+            w.set_master(spi::vals::Master::MASTER_MODE);
+            w.set_loop_(false);
+        });
+
+        // Configurations based on the config written by a user.
+        registers.cfg().modify(|w| {
+            w.set_cpha(match config.phase {
+                Phase::CaptureOnFirstTransition => spi::vals::Cpha::CAPTURE,
+                Phase::CaptureOnSecondTransition => spi::vals::Cpha::CHANGE,
+            });
+            w.set_cpol(match config.polarity {
+                Polarity::IdleLow => spi::vals::Cpol::LOW,
+                Polarity::IdleHigh => spi::vals::Cpol::HIGH,
+            });
+            w.set_lsbf(match config.data_format {
+                DataFormat::LsbFirst => spi::vals::Lsbf::REVERSE,
+                DataFormat::MsbFirst => spi::vals::Lsbf::STANDARD,
+            });
+        });
+
+        registers.fifocfg().modify(|w| {
+            // DMA is going to be disabled until the async version is implemented.
+            w.set_dmatx(false);
+            w.set_dmarx(false);
+            w.set_enabletx(true);
+            w.set_enablerx(true);
+            w.set_emptytx(true);
+            w.set_emptyrx(true);
+        });
+    }
+
+    /// Private function to apply SPI configuration (phase, polarity, frequency) settings.
+    ///
+    /// Driver should be disabled before making changes and re-enabled after the modifications
+    /// are applied.
+
+    /// Write data to SPI blocking execution until done.
+    pub fn blocking_write(&mut self, data: &[u8]) -> Result<(), Error> {
+        let spi_reg = self.info.spi_reg;
+        for d in data {
+            while !spi_reg.fifostat().read().txnotfull() {}
+            if spi_reg.fifostat().read().txerr() {
+                return Err(Error::Overrun);
+            }
+            spi_reg.fifowr().write(|w| {
+                w.set_rxignore(spi::vals::Rxignore::IGNORE);
+                w.set_txdata(*d as u16); // Data to be transferred
+                w.set_len(7);
+            });
+        }
+        self.flush()?;
+
+        Ok(())
+    }
+
+    /// Transfer data in place to SPI blocking execution until done.
+    pub fn blocking_transfer_in_place(&mut self, data: &mut [u8]) -> Result<(), Error> {
+        let spi_reg = self.info.spi_reg;
+        for d in data {
+            while !spi_reg.fifostat().read().txnotfull() {}
+            if spi_reg.fifostat().read().txerr() {
+                return Err(Error::Overrun);
+            }
+            spi_reg.fifowr().write(|w| {
+                w.set_rxignore(spi::vals::Rxignore::READ);
+                w.set_txdata(*d as u16); // Data to be transferred
+                w.set_len(7);
+            });
+            while !spi_reg.fifostat().read().rxnotempty() {}
+            if spi_reg.fifostat().read().rxerr() {
+                return Err(Error::Overrun);
+            }
+            *d = spi_reg.fiford().read().rxdata() as u8;
+        }
+        self.flush()?;
+        Ok(())
+    }
+
+    /// Read data from SPI blocking execution until done.
+    pub fn blocking_read(&mut self, data: &mut [u8]) -> Result<(), Error> {
+        let spi_reg = self.info.spi_reg;
+        for d in data {
+            while !spi_reg.fifostat().read().txnotfull() {}
+            spi_reg.fifowr().write(|w| {
+                w.set_rxignore(spi::vals::Rxignore::READ);
+                w.set_txdata(0u16); // Data to be transferred
+                w.set_len(7);
+            });
+            while !spi_reg.fifostat().read().rxnotempty() {}
+            if spi_reg.fifostat().read().rxerr() {
+                return Err(Error::Overrun);
+            }
+            *d = spi_reg.fiford().read().rxdata() as u8;
+        }
+        Ok(())
+    }
+
+    /// Transfer data to SPI blocking execution until done.
+    pub fn blocking_transfer(&mut self, read: &mut [u8], write: &[u8]) -> Result<(), Error> {
+        let spi_reg = self.info.spi_reg;
+        let len = read.len().max(write.len());
+        for i in 0..len {
+            let wb = write.get(i).copied().unwrap_or(0);
+            while !spi_reg.fifostat().read().txnotfull() {}
+            if spi_reg.fifostat().read().txerr() {
+                return Err(Error::Overrun);
+            }
+            spi_reg.fifowr().write(|w| {
+                w.set_rxignore(spi::vals::Rxignore::READ);
+                w.set_txdata(wb as u16); // Data to be transferred
+                w.set_len(7);
+            });
+            while !spi_reg.fifostat().read().rxnotempty() {}
+            if spi_reg.fifostat().read().rxerr() {
+                return Err(Error::Overrun);
+            }
+            let rb = spi_reg.fiford().read().rxdata() as u8;
+            if let Some(r) = read.get_mut(i) {
+                *r = rb;
+            }
+        }
+        self.flush()?;
+        Ok(())
+    }
+
+    /// Block execution until SPI is done.
+    pub fn flush(&mut self) -> Result<(), Error> {
+        while !self.info.spi_reg.fifostat().read().txempty() {}
+        Ok(())
+    }
+
+    // TODO: write a function that updates SPI configuration (phase, polarity, frequency) settings
+}
+
+impl<'d> Spi<'d, Blocking> {
+    /// Create an SPI driver in blocking mode.
+    pub fn new_blocking<T: Instance>(
+        _inner: Peri<'d, T>,
+        sck: Peri<'d, impl SckPin<T> + 'd>,
+        mosi: Peri<'d, impl MosiPin<T> + 'd>,
+        miso: Peri<'d, impl MisoPin<T> + 'd>,
+        config: Config,
+    ) -> Result<Self, ConstructorError> {
+        let mosi_func = mosi.pin_func();
+        let miso_func = miso.pin_func();
+        let sck_func = sck.pin_func();
+        Self::new_inner::<T>(
+            Some(mosi.into()),
+            Some(mosi_func),
+            Some(miso.into()),
+            Some(miso_func),
+            sck.into(),
+            sck_func,
+            config,
+        )
+    }
+
+    /// Create an SPI driver in blocking mode supporting writes only.
+    pub fn new_blocking_txonly<T: Instance>(
+        _inner: Peri<'d, T>,
+        sck: Peri<'d, impl SckPin<T> + 'd>,
+        mosi: Peri<'d, impl MosiPin<T> + 'd>,
+        config: Config,
+    ) -> Result<Self, ConstructorError> {
+        let mosi_func = mosi.pin_func();
+        let sck_func = sck.pin_func();
+        Self::new_inner::<T>(
+            Some(mosi.into()),
+            Some(mosi_func),
+            None,
+            None,
+            sck.into(),
+            sck_func,
+            config,
+        )
+    }
+
+    /// Create an SPI driver in blocking mode supporting reads only.
+    pub fn new_blocking_rxonly<T: Instance>(
+        _inner: Peri<'d, T>,
+        sck: Peri<'d, impl SckPin<T> + 'd>,
+        miso: Peri<'d, impl MisoPin<T> + 'd>,
+        config: Config,
+    ) -> Result<Self, ConstructorError> {
+        let miso_func = miso.pin_func();
+        let sck_func = sck.pin_func();
+        Self::new_inner::<T>(
+            None,
+            None,
+            Some(miso.into()),
+            Some(miso_func),
+            sck.into(),
+            sck_func,
+            config,
+        )
+    }
+}
+
+impl<'d> embedded_hal_02::blocking::spi::Transfer<u8> for Spi<'d, Blocking> {
+    type Error = Error;
+    fn transfer<'w>(&mut self, words: &'w mut [u8]) -> Result<&'w [u8], Self::Error> {
+        self.blocking_transfer_in_place(words)?;
+        Ok(words)
+    }
+}
+
+impl<'d> embedded_hal_02::blocking::spi::Write<u8> for Spi<'d, Blocking> {
+    type Error = Error;
+
+    fn write(&mut self, words: &[u8]) -> Result<(), Self::Error> {
+        self.blocking_write(words)
+    }
+}
+
+pub(crate) struct Info {
+    pub(crate) spi_reg: SpiReg,
+    pub(crate) fc_reg: FlexcommReg,
+}
+
+pub(crate) trait SealedInstance {
+    fn info() -> &'static Info;
+    fn instance_number() -> usize;
+}
+
+/// SPI instance trait.
+#[allow(private_bounds)]
+pub trait Instance: SealedInstance + PeripheralType {}
+
+macro_rules! impl_spi_instance {
+    ($inst:ident, $fc:ident, $fc_num:expr) => {
+        impl $crate::spi::SealedInstance for $crate::peripherals::$inst {
+            fn info() -> &'static crate::spi::Info {
+                static INFO: $crate::spi::Info = $crate::spi::Info {
+                    spi_reg: $crate::pac::$inst,
+                    fc_reg: $crate::pac::$fc,
+                };
+                &INFO
+            }
+
+            #[inline]
+            fn instance_number() -> usize {
+                $fc_num
+            }
+        }
+        impl $crate::spi::Instance for $crate::peripherals::$inst {}
+    };
+}
+
+#[cfg(has_spi_sck_pins)]
+pub(crate) trait SealedSckPin<T: Instance>: crate::gpio::Pin {
+    fn pin_func(&self) -> PioFunc;
+}
+
+#[cfg(has_spi_mosi_pins)]
+pub(crate) trait SealedMosiPin<T: Instance>: crate::gpio::Pin {
+    fn pin_func(&self) -> PioFunc;
+}
+
+#[cfg(has_spi_miso_pins)]
+pub(crate) trait SealedMisoPin<T: Instance>: crate::gpio::Pin {
+    fn pin_func(&self) -> PioFunc;
+}
+
+/// Trait for clock pins.
+#[cfg(has_spi_sck_pins)]
+#[allow(private_bounds)]
+pub trait SckPin<T: Instance>: SealedSckPin<T> + crate::gpio::Pin {}
+/// Trait for MOSI pins.
+#[cfg(has_spi_mosi_pins)]
+#[allow(private_bounds)]
+pub trait MosiPin<T: Instance>: SealedMosiPin<T> + crate::gpio::Pin {}
+/// Trait for MISO pins.
+#[cfg(has_spi_miso_pins)]
+#[allow(private_bounds)]
+pub trait MisoPin<T: Instance>: SealedMisoPin<T> + crate::gpio::Pin {}
+
+#[cfg(has_spi_miso_pins)]
+macro_rules! impl_spi_miso_pin {
+    ($pin:ident, $instance:ident, $func: ident) => {
+        impl crate::spi::SealedMisoPin<crate::peripherals::$instance> for crate::peripherals::$pin {
+            fn pin_func(&self) -> crate::pac::iocon::vals::PioFunc {
+                use crate::pac::iocon::vals::PioFunc;
+                PioFunc::$func
+            }
+        }
+
+        impl crate::spi::MisoPin<crate::peripherals::$instance> for crate::peripherals::$pin {}
+    };
+}
+
+#[cfg(has_spi_mosi_pins)]
+macro_rules! impl_spi_mosi_pin {
+    ($pin:ident, $instance:ident, $func: ident) => {
+        impl crate::spi::SealedMosiPin<crate::peripherals::$instance> for crate::peripherals::$pin {
+            fn pin_func(&self) -> crate::pac::iocon::vals::PioFunc {
+                use crate::pac::iocon::vals::PioFunc;
+                PioFunc::$func
+            }
+        }
+
+        impl crate::spi::MosiPin<crate::peripherals::$instance> for crate::peripherals::$pin {}
+    };
+}
+
+#[cfg(has_spi_sck_pins)]
+macro_rules! impl_spi_sck_pin {
+    ($pin:ident, $instance:ident, $func: ident) => {
+        impl crate::spi::SealedSckPin<crate::peripherals::$instance> for crate::peripherals::$pin {
+            fn pin_func(&self) -> crate::pac::iocon::vals::PioFunc {
+                use crate::pac::iocon::vals::PioFunc;
+                PioFunc::$func
+            }
+        }
+
+        impl crate::spi::SckPin<crate::peripherals::$instance> for crate::peripherals::$pin {}
+    };
+}

--- a/embassy-nxp/src/spi/lpc55.rs
+++ b/embassy-nxp/src/spi/lpc55.rs
@@ -125,12 +125,12 @@ impl<'d, M: Mode> Spi<'d, M> {
         });
         SYSCON
             .presetctrl1()
-            .modify(|w| w.set_fc_rst(instance_number, syscon::vals::FcRst::ASSERTED));
+            .modify(|w| w.set_fc_rst(instance_number, syscon::vals::FcRst::Asserted));
         SYSCON
             .presetctrl1()
-            .modify(|w| w.set_fc_rst(instance_number, syscon::vals::FcRst::RELEASED));
+            .modify(|w| w.set_fc_rst(instance_number, syscon::vals::FcRst::Released));
         flexcomm_register.pselid().modify(|w| {
-            w.set_persel(flexcomm::vals::Persel::SPI);
+            w.set_persel(flexcomm::vals::Persel::Spi);
             // This will lock the peripheral PERSEL and will not allow any changes until the board is reset.
             w.set_lock(true);
         });
@@ -153,7 +153,7 @@ impl<'d, M: Mode> Spi<'d, M> {
 
         SYSCON
             .fcclksel(instance_number)
-            .modify(|w| w.set_sel(syscon::vals::FcclkselSel::ENUM_0X3));
+            .modify(|w| w.set_sel(syscon::vals::FcclkselSel::Enum0x3));
         let source_clock = 96_000_000;
 
         // Parameter calculation for clock division
@@ -181,32 +181,32 @@ impl<'d, M: Mode> Spi<'d, M> {
         if let Some((mosi_pin, func)) = mosi {
             mosi_pin.pio().modify(|w| {
                 w.set_func(func);
-                w.set_mode(iocon::vals::PioMode::INACTIVE);
-                w.set_slew(iocon::vals::PioSlew::STANDARD);
+                w.set_mode(iocon::vals::PioMode::Inactive);
+                w.set_slew(iocon::vals::PioSlew::Standard);
                 w.set_invert(false);
-                w.set_digimode(iocon::vals::PioDigimode::DIGITAL);
-                w.set_od(iocon::vals::PioOd::NORMAL);
+                w.set_digimode(iocon::vals::PioDigimode::Digital);
+                w.set_od(iocon::vals::PioOd::Normal);
             });
         }
 
         if let Some((miso_pin, func)) = miso {
             miso_pin.pio().modify(|w| {
                 w.set_func(func);
-                w.set_mode(iocon::vals::PioMode::INACTIVE);
-                w.set_slew(iocon::vals::PioSlew::STANDARD);
+                w.set_mode(iocon::vals::PioMode::Inactive);
+                w.set_slew(iocon::vals::PioSlew::Standard);
                 w.set_invert(false);
-                w.set_digimode(iocon::vals::PioDigimode::DIGITAL);
-                w.set_od(iocon::vals::PioOd::NORMAL);
+                w.set_digimode(iocon::vals::PioDigimode::Digital);
+                w.set_od(iocon::vals::PioOd::Normal);
             });
         };
 
         sck.0.pio().modify(|w| {
             w.set_func(sck.1);
-            w.set_mode(iocon::vals::PioMode::INACTIVE);
-            w.set_slew(iocon::vals::PioSlew::STANDARD);
+            w.set_mode(iocon::vals::PioMode::Inactive);
+            w.set_slew(iocon::vals::PioSlew::Standard);
             w.set_invert(false);
-            w.set_digimode(iocon::vals::PioDigimode::DIGITAL);
-            w.set_od(iocon::vals::PioOd::NORMAL);
+            w.set_digimode(iocon::vals::PioDigimode::Digital);
+            w.set_od(iocon::vals::PioOd::Normal);
         });
     }
 
@@ -220,23 +220,23 @@ impl<'d, M: Mode> Spi<'d, M> {
 
         registers.cfg().modify(|w| {
             w.set_enable(false);
-            w.set_master(spi::vals::Master::MASTER_MODE);
+            w.set_master(spi::vals::Master::MasterMode);
             w.set_loop_(false);
         });
 
         // Configurations based on the config written by a user.
         registers.cfg().modify(|w| {
             w.set_cpha(match config.phase {
-                Phase::CaptureOnFirstTransition => spi::vals::Cpha::CAPTURE,
-                Phase::CaptureOnSecondTransition => spi::vals::Cpha::CHANGE,
+                Phase::CaptureOnFirstTransition => spi::vals::Cpha::Capture,
+                Phase::CaptureOnSecondTransition => spi::vals::Cpha::Change,
             });
             w.set_cpol(match config.polarity {
-                Polarity::IdleLow => spi::vals::Cpol::LOW,
-                Polarity::IdleHigh => spi::vals::Cpol::HIGH,
+                Polarity::IdleLow => spi::vals::Cpol::Low,
+                Polarity::IdleHigh => spi::vals::Cpol::High,
             });
             w.set_lsbf(match config.data_format {
-                DataFormat::LsbFirst => spi::vals::Lsbf::REVERSE,
-                DataFormat::MsbFirst => spi::vals::Lsbf::STANDARD,
+                DataFormat::LsbFirst => spi::vals::Lsbf::Reverse,
+                DataFormat::MsbFirst => spi::vals::Lsbf::Standard,
             });
         });
 
@@ -265,7 +265,7 @@ impl<'d, M: Mode> Spi<'d, M> {
                 return Err(Error::Overrun);
             }
             spi_reg.fifowr().write(|w| {
-                w.set_rxignore(spi::vals::Rxignore::IGNORE);
+                w.set_rxignore(spi::vals::Rxignore::Ignore);
                 w.set_txdata(*d as u16); // Data to be transferred
                 w.set_len(7);
             });
@@ -284,7 +284,7 @@ impl<'d, M: Mode> Spi<'d, M> {
                 return Err(Error::Overrun);
             }
             spi_reg.fifowr().write(|w| {
-                w.set_rxignore(spi::vals::Rxignore::READ);
+                w.set_rxignore(spi::vals::Rxignore::Read);
                 w.set_txdata(*d as u16); // Data to be transferred
                 w.set_len(7);
             });
@@ -304,7 +304,7 @@ impl<'d, M: Mode> Spi<'d, M> {
         for d in data {
             while !spi_reg.fifostat().read().txnotfull() {}
             spi_reg.fifowr().write(|w| {
-                w.set_rxignore(spi::vals::Rxignore::READ);
+                w.set_rxignore(spi::vals::Rxignore::Read);
                 w.set_txdata(0u16); // Data to be transferred
                 w.set_len(7);
             });
@@ -328,7 +328,7 @@ impl<'d, M: Mode> Spi<'d, M> {
                 return Err(Error::Overrun);
             }
             spi_reg.fifowr().write(|w| {
-                w.set_rxignore(spi::vals::Rxignore::READ);
+                w.set_rxignore(spi::vals::Rxignore::Read);
                 w.set_txdata(wb as u16); // Data to be transferred
                 w.set_len(7);
             });

--- a/examples/lpc55s69/src/bin/spi_blocking.rs
+++ b/examples/lpc55s69/src/bin/spi_blocking.rs
@@ -1,0 +1,41 @@
+#![no_std]
+#![no_main]
+
+use core::str::from_utf8_mut;
+
+use defmt::*;
+use defmt_rtt as _;
+use embassy_executor::Spawner;
+use embassy_nxp::spi::{Config, Spi};
+use embassy_time::Timer;
+use panic_halt as _;
+
+#[embassy_executor::main]
+async fn main(_spawner: Spawner) {
+    let p = embassy_nxp::init(Default::default());
+    let mut spi = Spi::new_blocking(p.SPI2, p.PIO1_23, p.PIO1_24, p.PIO1_25, Config::default()).unwrap();
+    let tx_buf = b"Hello, Ferris!";
+    let mut rx_buf = [0u8; 14];
+
+    loop {
+        info!("Write a message");
+
+        spi.blocking_transfer(&mut rx_buf, tx_buf).unwrap();
+        spi.flush().unwrap();
+
+        Timer::after_millis(500).await;
+
+        info!("Read a message");
+
+        match from_utf8_mut(&mut rx_buf) {
+            Ok(str) => {
+                info!("The message is: {}", str);
+            }
+            Err(_) => {
+                error!("Error in converting to UTF8");
+            }
+        }
+
+        Timer::after_millis(500).await;
+    }
+}


### PR DESCRIPTION
Hello!

This PR adds a blocking driver for SPI on the board NXP LPC55S69. I kindly ask you for the review.

UPD: I updated the `nxp-pac` version, apparently, the enums are handled by `chiptools` differently nowadays. Anyway, it didn't help with the tests. It still says that it cannot find some traits because some cfgs are not declared. Could someone help with it?