### PR TITLE
wip: add ptp impl to embassy-net

### DIFF
--- a/embassy-net/Cargo.toml
+++ b/embassy-net/Cargo.toml
@@ -110,7 +110,7 @@ alloc = ["smoltcp/alloc"]
 ## Enable smoltcp packetmeta-id feature
 packetmeta-id = [ "smoltcp/packetmeta-id", "embassy-net-driver/packetmeta-id" ]
 ## Enable ptp support
-ptp = []
+ptp = ["packetmeta-id"]
 
 [dependencies]
 

--- a/embassy-net/Cargo.toml
+++ b/embassy-net/Cargo.toml
@@ -109,6 +109,8 @@ std = ["smoltcp/std"]
 alloc = ["smoltcp/alloc"]
 ## Enable smoltcp packetmeta-id feature
 packetmeta-id = [ "smoltcp/packetmeta-id", "embassy-net-driver/packetmeta-id" ]
+## Enable ptp support
+ptp = []
 
 [dependencies]
 

--- a/embassy-net/src/driver_util.rs
+++ b/embassy-net/src/driver_util.rs
@@ -13,6 +13,9 @@ where
     pub inner: &'d mut T,
     pub medium: Medium,
     pub tx_exhausted: bool,
+    #[cfg(feature = "ptp")]
+    #[allow(unused)]
+    pub times: &'d mut dyn crate::LinearMap<crate::SocketHandle, crate::TimeEntry>,
 }
 
 impl<'d, 'c, T> phy::Device for DriverAdapter<'d, 'c, T>

--- a/embassy-net/src/driver_util.rs
+++ b/embassy-net/src/driver_util.rs
@@ -123,6 +123,7 @@ where
     }
 
     fn set_meta(&mut self, meta: phy::PacketMeta) {
+        // TODO: when called with a nonzero ID, associate the inner ID of this token with the ID if set.
         self.0.set_meta(into_embassy_net_meta(meta));
     }
 }

--- a/embassy-net/src/lib.rs
+++ b/embassy-net/src/lib.rs
@@ -101,6 +101,10 @@ pub struct StackResources<const SOCK: usize> {
     // undersized buffer never corrupts the IP configuration, it only drops the extra options.
     #[cfg(feature = "dhcpv4-ntp")]
     dhcp_rx_buffer: MaybeUninit<[u8; DHCP_RX_BUFFER_SIZE]>,
+    #[cfg(feature = "ptp")]
+    ids: MaybeUninit<[Option<u8>; SOCK]>,
+    #[cfg(feature = "ptp")]
+    times: MaybeUninit<[Option<embassy_net_driver::Timestamp>; SOCK]>,
 }
 
 #[cfg(feature = "dhcpv4-hostname")]
@@ -124,6 +128,10 @@ impl<const SOCK: usize> StackResources<SOCK> {
             },
             #[cfg(feature = "dhcpv4-ntp")]
             dhcp_rx_buffer: MaybeUninit::uninit(),
+            #[cfg(feature = "ptp")]
+            ids: MaybeUninit::uninit(),
+            #[cfg(feature = "ptp")]
+            times: MaybeUninit::uninit(),
         }
     }
 }
@@ -332,6 +340,10 @@ pub(crate) struct Inner {
     hostname: *mut HostnameResources,
     #[cfg(feature = "dhcpv4-ntp")]
     dhcp_rx_buffer: *mut [u8],
+    #[cfg(feature = "ptp")]
+    ids: &'static mut [Option<u8>],
+    #[cfg(feature = "ptp")]
+    times: &'static mut [Option<embassy_net_driver::Timestamp>],
 }
 
 fn _assert_covariant<'a, 'b: 'a>(x: Stack<'b>) -> Stack<'a> {
@@ -407,6 +419,10 @@ pub fn new<'d, D: Driver, const SOCK: usize>(
         hostname: &mut resources.hostname,
         #[cfg(feature = "dhcpv4-ntp")]
         dhcp_rx_buffer: resources.dhcp_rx_buffer.write([0; DHCP_RX_BUFFER_SIZE]) as *mut [u8],
+        #[cfg(feature = "ptp")]
+        ids: unsafe { &mut transmute_slice(resources.ids.write([None; SOCK]))[..] },
+        #[cfg(feature = "ptp")]
+        times: unsafe { &mut transmute_slice(resources.times.write([None; SOCK]))[..] },
     };
 
     #[cfg(feature = "proto-ipv4")]
@@ -939,6 +955,21 @@ impl Inner {
             };
             if do_set {
                 self.iface.set_hardware_addr(_hardware_addr);
+            }
+        }
+
+        #[cfg(feature = "ptp")]
+        while let Some((id, timestamp)) = driver.poll_timestamp(cx) {
+            if let Some(index) = self
+                .ids
+                .iter()
+                .enumerate()
+                .find(|x| x.1.is_some_and(|x| x == id))
+                .map(|x| x.0)
+            {
+                self.times[index] = Some(timestamp);
+
+                // TODO: wake socket waker
             }
         }
 

--- a/embassy-net/src/lib.rs
+++ b/embassy-net/src/lib.rs
@@ -338,11 +338,15 @@ pub(crate) struct Inner {
     dhcp_rx_buffer: *mut [u8],
     #[cfg(feature = "ptp")]
     times: &'static mut dyn LinearMap<SocketHandle, TimeEntry>,
+    #[cfg(feature = "ptp")]
+    next_id: u16,
 }
 
 #[cfg(feature = "ptp")]
 struct TimeEntry {
-    id: u8,
+    #[allow(unused)]
+    id: u16,
+    did: Option<u8>,
     time: Option<embassy_net_driver::Timestamp>,
     waker: WakerRegistration,
 }
@@ -464,6 +468,8 @@ pub fn new<'d, D: Driver, const SOCK: usize>(
         dhcp_rx_buffer: resources.dhcp_rx_buffer.write([0; DHCP_RX_BUFFER_SIZE]) as *mut [u8],
         #[cfg(feature = "ptp")]
         times: unsafe { transmute_static(resources.times.write(heapless::LinearMap::new())) },
+        #[cfg(feature = "ptp")]
+        next_id: 0,
     };
 
     #[cfg(feature = "proto-ipv4")]
@@ -1002,7 +1008,7 @@ impl Inner {
         #[cfg(feature = "ptp")]
         while let Some((id, timestamp)) = driver.poll_timestamp(cx) {
             for (_handle, entry) in self.times.iter_mut() {
-                if id == entry.id && entry.time.is_none() {
+                if entry.did.is_some_and(|did| id == did) && entry.time.is_none() {
                     entry.time = Some(timestamp);
                     entry.waker.wake();
                 }

--- a/embassy-net/src/lib.rs
+++ b/embassy-net/src/lib.rs
@@ -102,9 +102,7 @@ pub struct StackResources<const SOCK: usize> {
     #[cfg(feature = "dhcpv4-ntp")]
     dhcp_rx_buffer: MaybeUninit<[u8; DHCP_RX_BUFFER_SIZE]>,
     #[cfg(feature = "ptp")]
-    ids: MaybeUninit<[Option<u8>; SOCK]>,
-    #[cfg(feature = "ptp")]
-    times: MaybeUninit<[Option<embassy_net_driver::Timestamp>; SOCK]>,
+    times: MaybeUninit<heapless::LinearMap<SocketHandle, TimeEntry, SOCK>>,
 }
 
 #[cfg(feature = "dhcpv4-hostname")]
@@ -128,8 +126,6 @@ impl<const SOCK: usize> StackResources<SOCK> {
             },
             #[cfg(feature = "dhcpv4-ntp")]
             dhcp_rx_buffer: MaybeUninit::uninit(),
-            #[cfg(feature = "ptp")]
-            ids: MaybeUninit::uninit(),
             #[cfg(feature = "ptp")]
             times: MaybeUninit::uninit(),
         }
@@ -341,9 +337,51 @@ pub(crate) struct Inner {
     #[cfg(feature = "dhcpv4-ntp")]
     dhcp_rx_buffer: *mut [u8],
     #[cfg(feature = "ptp")]
-    ids: &'static mut [Option<u8>],
-    #[cfg(feature = "ptp")]
-    times: &'static mut [Option<embassy_net_driver::Timestamp>],
+    times: &'static mut dyn LinearMap<SocketHandle, TimeEntry>,
+}
+
+#[cfg(feature = "ptp")]
+struct TimeEntry {
+    id: u8,
+    time: Option<embassy_net_driver::Timestamp>,
+    waker: WakerRegistration,
+}
+
+#[cfg(feature = "ptp")]
+trait LinearMap<K, V> {
+    #[allow(dead_code)]
+    fn insert(&mut self, key: K, val: V) -> Result<Option<V>, ()>;
+    #[allow(dead_code)]
+    fn get_mut(&mut self, key: &K) -> Option<&mut V>;
+    #[allow(dead_code)]
+    fn remove(&mut self, key: &K) -> Option<V>;
+    #[allow(dead_code)]
+    fn iter(&self) -> heapless::linear_map::Iter<'_, K, V>;
+    #[allow(dead_code)]
+    fn iter_mut(&mut self) -> heapless::linear_map::IterMut<'_, K, V>;
+}
+
+#[cfg(feature = "ptp")]
+impl<K: Eq + Copy, V, const N: usize> LinearMap<K, V> for heapless::LinearMap<K, V, N> {
+    fn insert(&mut self, key: K, val: V) -> Result<Option<V>, ()> {
+        self.insert(key, val).map_err(|_| ())
+    }
+
+    fn get_mut(&mut self, key: &K) -> Option<&mut V> {
+        self.get_mut(key)
+    }
+
+    fn remove(&mut self, key: &K) -> Option<V> {
+        self.remove(key)
+    }
+
+    fn iter(&self) -> heapless::linear_map::Iter<'_, K, V> {
+        self.iter()
+    }
+
+    fn iter_mut(&mut self) -> heapless::linear_map::IterMut<'_, K, V> {
+        self.iter_mut()
+    }
 }
 
 fn _assert_covariant<'a, 'b: 'a>(x: Stack<'b>) -> Stack<'a> {
@@ -378,6 +416,11 @@ pub fn new<'d, D: Driver, const SOCK: usize>(
     );
 
     unsafe fn transmute_slice<T>(x: &mut [T]) -> &'static mut [T] {
+        core::mem::transmute(x)
+    }
+
+    #[cfg(feature = "ptp")]
+    unsafe fn transmute_static<T: ?Sized>(x: &mut T) -> &'static mut T {
         core::mem::transmute(x)
     }
 
@@ -420,9 +463,7 @@ pub fn new<'d, D: Driver, const SOCK: usize>(
         #[cfg(feature = "dhcpv4-ntp")]
         dhcp_rx_buffer: resources.dhcp_rx_buffer.write([0; DHCP_RX_BUFFER_SIZE]) as *mut [u8],
         #[cfg(feature = "ptp")]
-        ids: unsafe { &mut transmute_slice(resources.ids.write([None; SOCK]))[..] },
-        #[cfg(feature = "ptp")]
-        times: unsafe { &mut transmute_slice(resources.times.write([None; SOCK]))[..] },
+        times: unsafe { transmute_static(resources.times.write(heapless::LinearMap::new())) },
     };
 
     #[cfg(feature = "proto-ipv4")]
@@ -960,16 +1001,11 @@ impl Inner {
 
         #[cfg(feature = "ptp")]
         while let Some((id, timestamp)) = driver.poll_timestamp(cx) {
-            if let Some(index) = self
-                .ids
-                .iter()
-                .enumerate()
-                .find(|x| x.1.is_some_and(|x| x == id))
-                .map(|x| x.0)
-            {
-                self.times[index] = Some(timestamp);
-
-                // TODO: wake socket waker
+            for (_handle, entry) in self.times.iter_mut() {
+                if id == entry.id && entry.time.is_none() {
+                    entry.time = Some(timestamp);
+                    entry.waker.wake();
+                }
             }
         }
 

--- a/embassy-net/src/lib.rs
+++ b/embassy-net/src/lib.rs
@@ -419,6 +419,9 @@ pub fn new<'d, D: Driver, const SOCK: usize>(
         iface_cfg.slaac = matches!(config.ipv6, ConfigV6::Slaac);
     }
 
+    #[cfg(feature = "ptp")]
+    let times = resources.times.write(heapless::LinearMap::new());
+
     #[allow(unused_mut)]
     let mut iface = Interface::new(
         iface_cfg,
@@ -427,6 +430,8 @@ pub fn new<'d, D: Driver, const SOCK: usize>(
             cx: None,
             medium,
             tx_exhausted: false,
+            #[cfg(feature = "ptp")]
+            times,
         },
         instant_to_smoltcp(Instant::now()),
     );
@@ -479,7 +484,7 @@ pub fn new<'d, D: Driver, const SOCK: usize>(
         #[cfg(feature = "dhcpv4-ntp")]
         dhcp_rx_buffer: resources.dhcp_rx_buffer.write([0; DHCP_RX_BUFFER_SIZE]) as *mut [u8],
         #[cfg(feature = "ptp")]
-        times: unsafe { transmute_static(resources.times.write(heapless::LinearMap::new())) },
+        times: unsafe { transmute_static(times) },
         #[cfg(feature = "ptp")]
         next_id: 0,
     };
@@ -1052,6 +1057,8 @@ impl Inner {
             inner: driver,
             medium,
             tx_exhausted: false,
+            #[cfg(feature = "ptp")]
+            times: self.times,
         };
         self.iface.poll(timestamp, &mut smoldev, &mut self.sockets);
         let tx_exhausted = smoldev.tx_exhausted;

--- a/embassy-net/src/lib.rs
+++ b/embassy-net/src/lib.rs
@@ -352,6 +352,18 @@ struct TimeEntry {
 }
 
 #[cfg(feature = "ptp")]
+impl TimeEntry {
+    pub const fn new(id: u16) -> Self {
+        Self {
+            id,
+            did: None,
+            time: None,
+            waker: WakerRegistration::new(),
+        }
+    }
+}
+
+#[cfg(feature = "ptp")]
 trait LinearMap<K, V> {
     #[allow(dead_code)]
     fn insert(&mut self, key: K, val: V) -> Result<Option<V>, ()>;

--- a/embassy-net/src/udp.rs
+++ b/embassy-net/src/udp.rs
@@ -311,6 +311,45 @@ impl<'a> UdpSocket<'a> {
         })
     }
 
+    #[cfg(feature = "ptp")]
+    /// Send a datagram to the specified remote endpoint and retreive the timestamp in which it has been sent.
+    ///
+    /// This method will wait until the datagram has been sent.
+    ///
+    /// If the socket's send buffer is too small to fit `buf`, this method will return `Err(SendError::PacketTooLarge)`
+    ///
+    /// When the remote endpoint is not reachable, this method will return `Err(SendError::NoRoute)`
+    pub async fn send_to_timed<T>(
+        &self,
+        buf: &[u8],
+        remote_endpoint: T,
+    ) -> Result<embassy_net_driver::Timestamp, SendError>
+    where
+        T: Into<UdpMetadata>,
+    {
+        let mut remote_endpoint: UdpMetadata = remote_endpoint.into();
+
+        self.stack.with_mut(|s| {
+            s.next_id = s.next_id.wrapping_add(1);
+            remote_endpoint.meta.id = s.next_id as u32;
+            s.times
+                .insert(
+                    self.handle,
+                    crate::TimeEntry {
+                        id: s.next_id,
+                        did: None,
+                        time: None,
+                        waker: embassy_sync::waitqueue::WakerRegistration::new(),
+                    },
+                )
+                .unwrap();
+        });
+
+        poll_fn(move |cx| self.poll_send_to(buf, remote_endpoint, cx)).await?;
+
+        todo!()
+    }
+
     /// Send a datagram to the specified remote endpoint.
     ///
     /// This method will wait until the datagram has been sent.

--- a/embassy-net/src/udp.rs
+++ b/embassy-net/src/udp.rs
@@ -161,6 +161,17 @@ impl<'a> UdpSocket<'a> {
         })
     }
 
+    #[cfg(feature = "ptp")]
+    fn with_id(&self, mut remote_endpoint: UdpMetadata) -> (UdpMetadata, u16) {
+        self.stack.with_mut(|i| {
+            i.next_id = i.next_id.wrapping_add(1);
+            remote_endpoint.meta.id = i.next_id as u32;
+            i.times.insert(self.handle, crate::TimeEntry::new(i.next_id)).unwrap();
+
+            (remote_endpoint, i.next_id)
+        })
+    }
+
     /// Wait until the socket becomes readable.
     ///
     /// A socket is readable when a packet has been received, or when there are queued packets in
@@ -327,25 +338,12 @@ impl<'a> UdpSocket<'a> {
     where
         T: Into<UdpMetadata>,
     {
-        let mut remote_endpoint: UdpMetadata = remote_endpoint.into();
-
-        self.stack.with_mut(|s| {
-            s.next_id = s.next_id.wrapping_add(1);
-            remote_endpoint.meta.id = s.next_id as u32;
-            s.times
-                .insert(
-                    self.handle,
-                    crate::TimeEntry {
-                        id: s.next_id,
-                        did: None,
-                        time: None,
-                        waker: embassy_sync::waitqueue::WakerRegistration::new(),
-                    },
-                )
-                .unwrap();
-        });
+        let remote_endpoint: UdpMetadata = remote_endpoint.into();
+        let (remote_endpoint, id) = self.with_id(remote_endpoint);
 
         poll_fn(move |cx| self.poll_send_to(buf, remote_endpoint, cx)).await?;
+
+        // TODO: wait for the timestamp to be entered
 
         todo!()
     }

--- a/embassy-net/src/udp.rs
+++ b/embassy-net/src/udp.rs
@@ -339,7 +339,7 @@ impl<'a> UdpSocket<'a> {
         T: Into<UdpMetadata>,
     {
         let remote_endpoint: UdpMetadata = remote_endpoint.into();
-        let (remote_endpoint, id) = self.with_id(remote_endpoint);
+        let (remote_endpoint, _id) = self.with_id(remote_endpoint);
 
         poll_fn(move |cx| self.poll_send_to(buf, remote_endpoint, cx)).await?;
 


### PR DESCRIPTION
TODO:

add LinearMap of this: 

```
enum TimeEntryStatus {
    None,
    Id(u8),
    Timestamp(embassy_net_driver::Timestamp),
}

#[cfg(feature = "ptp")]
struct TimeEntry {
    status: TimeEntryStatus,
    waker: WakerRegistration,
}
```

add wrapping counter to generate packetmetadata ids. add reference to DriverAdapter to associate these ids with the smoltcp ids.