### PR TITLE
nrf: nvmc: remove unsound usage of `core::slice::from_raw_parts`

### DIFF
--- a/embassy-nrf/src/nvmc.rs
+++ b/embassy-nrf/src/nvmc.rs
@@ -1,6 +1,6 @@
 //! Non-Volatile Memory Controller (NVMC, AKA internal flash) driver.
 
-use core::{ptr, slice};
+use core::ptr;
 
 use embedded_storage::nor_flash::{
     ErrorType, MultiwriteNorFlash, NorFlash, NorFlashError, NorFlashErrorKind, ReadNorFlash,
@@ -119,8 +119,8 @@ impl<'d> ReadNorFlash for Nvmc<'d> {
             return Err(Error::OutOfBounds);
         }
 
-        let flash_data = unsafe { slice::from_raw_parts(offset as *const u8, bytes.len()) };
-        bytes.copy_from_slice(flash_data);
+        unsafe { ptr::copy_nonoverlapping(offset as _, bytes.as_mut_ptr(), bytes.len()) };
+
         Ok(())
     }
 

--- a/examples/nrf9151/s/Cargo.toml
+++ b/examples/nrf9151/s/Cargo.toml
@@ -10,6 +10,8 @@ embassy-executor = { version = "0.10.0", path = "../../../embassy-executor", fea
 embassy-time = { version = "0.5.1", path = "../../../embassy-time", features = ["defmt", "defmt-timestamp-uptime"] }
 embassy-nrf = { version = "0.11.0", path = "../../../embassy-nrf", features = ["defmt", "nrf9151-s", "time-driver-rtc1", "gpiote", "unstable-pac", "time"] }
 
+embedded-storage = "0.3"
+
 defmt = "1.0.1"
 defmt-rtt = "1.0.0"
 

--- a/examples/nrf9151/s/src/bin/nvmc.rs
+++ b/examples/nrf9151/s/src/bin/nvmc.rs
@@ -1,0 +1,20 @@
+#![no_std]
+#![no_main]
+
+use embassy_executor::Spawner;
+use embassy_nrf::nvmc::Nvmc;
+use embedded_storage::nor_flash::ReadNorFlash;
+use {defmt_rtt as _, panic_probe as _};
+
+#[embassy_executor::main]
+async fn main(_spawner: Spawner) {
+    let p = embassy_nrf::init(Default::default());
+    let mut nvmc = Nvmc::new(p.NVMC);
+
+    defmt::println!("Reading data from flash...");
+
+    let mut data = [0u8; 32];
+    nvmc.read(0, &mut data).unwrap();
+
+    defmt::println!("Read data: {:X}", data);
+}


### PR DESCRIPTION
The docs for `raw_from_slice` explicitly state that the starting address must be non-0 ([ref](https://doc.rust-lang.org/beta/core/slice/fn.from_raw_parts.html#safety)).

In a bit of code I ran I just got a `HardFault` when trying to execute this `read` function. The example code seemed to Just Work even without the fix, but this is obviously unsound.

Replaced with `ptr::copy_nonoverlapping`, which doesn't have the non-0 requirement.