### PR TITLE
chore: Make most blinky examples a bit more uniform

### DIFF
--- a/examples/mcxa2xx/src/bin/blinky.rs
+++ b/examples/mcxa2xx/src/bin/blinky.rs
@@ -20,17 +20,17 @@ async fn main(_spawner: Spawner) {
         defmt::info!("Toggle LEDs");
 
         red.toggle();
-        Timer::after_millis(250).await;
+        Timer::after_millis(500).await;
 
         red.toggle();
         green.toggle();
-        Timer::after_millis(250).await;
+        Timer::after_millis(500).await;
 
         green.toggle();
         blue.toggle();
-        Timer::after_millis(250).await;
+        Timer::after_millis(500).await;
         blue.toggle();
 
-        Timer::after_millis(250).await;
+        Timer::after_millis(500).await;
     }
 }

--- a/examples/mcxa5xx/src/bin/blinky.rs
+++ b/examples/mcxa5xx/src/bin/blinky.rs
@@ -20,17 +20,17 @@ async fn main(_spawner: Spawner) {
         defmt::info!("Toggle LEDs");
 
         red.toggle();
-        Timer::after_millis(250).await;
+        Timer::after_millis(500).await;
 
         red.toggle();
         green.toggle();
-        Timer::after_millis(250).await;
+        Timer::after_millis(500).await;
 
         green.toggle();
         blue.toggle();
-        Timer::after_millis(250).await;
+        Timer::after_millis(500).await;
         blue.toggle();
 
-        Timer::after_millis(250).await;
+        Timer::after_millis(500).await;
     }
 }

--- a/examples/microchip/src/bin/blinky.rs
+++ b/examples/microchip/src/bin/blinky.rs
@@ -20,6 +20,6 @@ async fn main(_spawner: Spawner) {
         info!("toggle leds");
         led1.toggle();
         led2.toggle();
-        Timer::after_secs(1).await;
+        Timer::after_millis(500).await;
     }
 }

--- a/examples/mimxrt6/src/bin/blinky.rs
+++ b/examples/mimxrt6/src/bin/blinky.rs
@@ -25,6 +25,6 @@ async fn main(_spawner: Spawner) {
     loop {
         info!("Toggling LED");
         led.toggle();
-        Timer::after_secs(1).await;
+        Timer::after_millis(500).await;
     }
 }

--- a/examples/mspm0c1104/src/bin/blinky.rs
+++ b/examples/mspm0c1104/src/bin/blinky.rs
@@ -17,7 +17,7 @@ async fn main(_spawner: Spawner) -> ! {
     led1.set_inversion(true);
 
     loop {
-        Timer::after_millis(400).await;
+        Timer::after_millis(500).await;
 
         info!("Toggle");
         led1.toggle();

--- a/examples/mspm0g3507/src/bin/blinky.rs
+++ b/examples/mspm0g3507/src/bin/blinky.rs
@@ -17,7 +17,7 @@ async fn main(_spawner: Spawner) -> ! {
     led1.set_inversion(true);
 
     loop {
-        Timer::after_millis(400).await;
+        Timer::after_millis(500).await;
 
         info!("Toggle");
         led1.toggle();

--- a/examples/mspm0g3519/src/bin/blinky.rs
+++ b/examples/mspm0g3519/src/bin/blinky.rs
@@ -17,7 +17,7 @@ async fn main(_spawner: Spawner) -> ! {
     led1.set_inversion(true);
 
     loop {
-        Timer::after_millis(400).await;
+        Timer::after_millis(500).await;
 
         info!("Toggle");
         led1.toggle();

--- a/examples/mspm0g5187/src/bin/blinky.rs
+++ b/examples/mspm0g5187/src/bin/blinky.rs
@@ -17,7 +17,7 @@ async fn main(_spawner: Spawner) -> ! {
     led1.set_inversion(true);
 
     loop {
-        Timer::after_millis(400).await;
+        Timer::after_millis(500).await;
 
         info!("Toggle");
         led1.toggle();

--- a/examples/mspm0l1306/src/bin/blinky.rs
+++ b/examples/mspm0l1306/src/bin/blinky.rs
@@ -17,7 +17,7 @@ async fn main(_spawner: Spawner) -> ! {
     led1.set_inversion(true);
 
     loop {
-        Timer::after_millis(400).await;
+        Timer::after_millis(500).await;
 
         info!("Toggle");
         led1.toggle();

--- a/examples/mspm0l2228/src/bin/blinky.rs
+++ b/examples/mspm0l2228/src/bin/blinky.rs
@@ -17,7 +17,7 @@ async fn main(_spawner: Spawner) -> ! {
     led1.set_inversion(true);
 
     loop {
-        Timer::after_millis(400).await;
+        Timer::after_millis(500).await;
 
         info!("Toggle");
         led1.toggle();

--- a/examples/nrf51/src/bin/blinky.rs
+++ b/examples/nrf51/src/bin/blinky.rs
@@ -1,6 +1,7 @@
 #![no_std]
 #![no_main]
 
+use defmt::*;
 use embassy_executor::Spawner;
 use embassy_nrf::gpio::{Level, Output, OutputDrive};
 use embassy_time::Timer;
@@ -12,9 +13,12 @@ async fn main(_spawner: Spawner) {
     let mut led = Output::new(p.P0_21, Level::Low, OutputDrive::Standard);
 
     loop {
+        info!("led on!");
         led.set_high();
-        Timer::after_millis(300).await;
+        Timer::after_millis(500).await;
+
+        info!("led off!");
         led.set_low();
-        Timer::after_millis(300).await;
+        Timer::after_millis(500).await;
     }
 }

--- a/examples/nrf52810/src/bin/blinky.rs
+++ b/examples/nrf52810/src/bin/blinky.rs
@@ -1,6 +1,7 @@
 #![no_std]
 #![no_main]
 
+use defmt::*;
 use embassy_executor::Spawner;
 use embassy_nrf::gpio::{Level, Output, OutputDrive};
 use embassy_time::Timer;
@@ -12,9 +13,12 @@ async fn main(_spawner: Spawner) {
     let mut led = Output::new(p.P0_18, Level::Low, OutputDrive::Standard);
 
     loop {
+        info!("led on!");
         led.set_high();
-        Timer::after_millis(300).await;
+        Timer::after_millis(500).await;
+
+        info!("led off!");
         led.set_low();
-        Timer::after_millis(300).await;
+        Timer::after_millis(500).await;
     }
 }

--- a/examples/nrf52840-rtic/src/bin/blinky.rs
+++ b/examples/nrf52840-rtic/src/bin/blinky.rs
@@ -31,12 +31,13 @@ mod app {
         let mut led = Output::new(pin, Level::Low, OutputDrive::Standard);
 
         loop {
-            info!("off!");
+            info!("led on!");
             led.set_high();
-            Timer::after_millis(300).await;
-            info!("on!");
+            Timer::after_millis(500).await;
+
+            info!("led off!");
             led.set_low();
-            Timer::after_millis(300).await;
+            Timer::after_millis(500).await;
         }
     }
 }

--- a/examples/nrf52840/src/bin/blinky.rs
+++ b/examples/nrf52840/src/bin/blinky.rs
@@ -1,6 +1,7 @@
 #![no_std]
 #![no_main]
 
+use defmt::*;
 use embassy_executor::Spawner;
 use embassy_nrf::gpio::{Level, Output, OutputDrive};
 use embassy_time::Timer;
@@ -12,9 +13,12 @@ async fn main(_spawner: Spawner) {
     let mut led = Output::new(p.P0_13, Level::Low, OutputDrive::Standard);
 
     loop {
+        info!("led on!");
         led.set_high();
-        Timer::after_millis(300).await;
+        Timer::after_millis(500).await;
+
+        info!("led off!");
         led.set_low();
-        Timer::after_millis(300).await;
+        Timer::after_millis(500).await;
     }
 }

--- a/examples/nrf5340/src/bin/blinky.rs
+++ b/examples/nrf5340/src/bin/blinky.rs
@@ -1,6 +1,7 @@
 #![no_std]
 #![no_main]
 
+use defmt::*;
 use embassy_executor::Spawner;
 use embassy_nrf::gpio::{Level, Output, OutputDrive};
 use embassy_time::Timer;
@@ -12,9 +13,12 @@ async fn main(_spawner: Spawner) {
     let mut led = Output::new(p.P0_28, Level::Low, OutputDrive::Standard);
 
     loop {
+        info!("led on!");
         led.set_high();
-        Timer::after_millis(300).await;
+        Timer::after_millis(500).await;
+
+        info!("led off!");
         led.set_low();
-        Timer::after_millis(300).await;
+        Timer::after_millis(500).await;
     }
 }

--- a/examples/nrf54l15-app/src/bin/blinky.rs
+++ b/examples/nrf54l15-app/src/bin/blinky.rs
@@ -13,11 +13,12 @@ async fn main(_spawner: Spawner) {
     let mut led = Output::new(p.P2_09, Level::Low, OutputDrive::Standard);
 
     loop {
-        info!("high!");
+        info!("led on!");
         led.set_high();
-        Timer::after_millis(300).await;
-        info!("low!");
+        Timer::after_millis(500).await;
+
+        info!("led off!");
         led.set_low();
-        Timer::after_millis(300).await;
+        Timer::after_millis(500).await;
     }
 }

--- a/examples/nrf54lm20/src/bin/blinky.rs
+++ b/examples/nrf54lm20/src/bin/blinky.rs
@@ -13,11 +13,12 @@ async fn main(_spawner: Spawner) {
     let mut led = Output::new(p.P1_22, Level::Low, OutputDrive::HighDrive);
 
     loop {
-        info!("high!");
+        info!("led on!");
         led.set_high();
-        Timer::after_millis(300).await;
-        info!("low!");
+        Timer::after_millis(500).await;
+
+        info!("led off!");
         led.set_low();
-        Timer::after_millis(300).await;
+        Timer::after_millis(500).await;
     }
 }

--- a/examples/nrf9151/ns/src/bin/blinky.rs
+++ b/examples/nrf9151/ns/src/bin/blinky.rs
@@ -1,6 +1,7 @@
 #![no_std]
 #![no_main]
 
+use defmt::*;
 use embassy_executor::Spawner;
 use embassy_nrf::gpio::{Level, Output, OutputDrive};
 use embassy_time::Timer;
@@ -12,11 +13,12 @@ async fn main(_spawner: Spawner) {
     let mut led = Output::new(p.P0_00, Level::Low, OutputDrive::Standard);
 
     loop {
+        info!("led on!");
         led.set_high();
-        defmt::info!("high");
         Timer::after_millis(500).await;
+
+        info!("led off!");
         led.set_low();
-        defmt::info!("low");
-        Timer::after_millis(1000).await;
+        Timer::after_millis(500).await;
     }
 }

--- a/examples/nrf9151/s/src/bin/blinky.rs
+++ b/examples/nrf9151/s/src/bin/blinky.rs
@@ -1,6 +1,7 @@
 #![no_std]
 #![no_main]
 
+use defmt::*;
 use embassy_executor::Spawner;
 use embassy_nrf::gpio::{Level, Output, OutputDrive};
 use embassy_time::Timer;
@@ -12,11 +13,12 @@ async fn main(_spawner: Spawner) {
     let mut led = Output::new(p.P0_00, Level::Low, OutputDrive::Standard);
 
     loop {
+        info!("led on!");
         led.set_high();
-        defmt::info!("high");
         Timer::after_millis(500).await;
+
+        info!("led off!");
         led.set_low();
-        defmt::info!("low");
-        Timer::after_millis(1000).await;
+        Timer::after_millis(500).await;
     }
 }

--- a/examples/nrf9160/src/bin/blinky.rs
+++ b/examples/nrf9160/src/bin/blinky.rs
@@ -1,6 +1,7 @@
 #![no_std]
 #![no_main]
 
+use defmt::*;
 use embassy_executor::Spawner;
 use embassy_nrf::gpio::{Level, Output, OutputDrive};
 use embassy_time::Timer;
@@ -12,9 +13,12 @@ async fn main(_spawner: Spawner) {
     let mut led = Output::new(p.P0_02, Level::Low, OutputDrive::Standard);
 
     loop {
+        info!("led on!");
         led.set_high();
-        Timer::after_millis(300).await;
+        Timer::after_millis(500).await;
+
+        info!("led off!");
         led.set_low();
-        Timer::after_millis(300).await;
+        Timer::after_millis(500).await;
     }
 }

--- a/examples/rp/src/bin/blinky.rs
+++ b/examples/rp/src/bin/blinky.rs
@@ -20,10 +20,10 @@ async fn main(_spawner: Spawner) {
     loop {
         info!("led on!");
         led.set_high();
-        Timer::after_secs(1).await;
+        Timer::after_millis(500).await;
 
         info!("led off!");
         led.set_low();
-        Timer::after_secs(1).await;
+        Timer::after_millis(500).await;
     }
 }

--- a/examples/rp235x/src/bin/blinky.rs
+++ b/examples/rp235x/src/bin/blinky.rs
@@ -33,10 +33,10 @@ async fn main(_spawner: Spawner) {
     loop {
         info!("led on!");
         led.set_high();
-        Timer::after_millis(250).await;
+        Timer::after_millis(500).await;
 
         info!("led off!");
         led.set_low();
-        Timer::after_millis(250).await;
+        Timer::after_millis(500).await;
     }
 }

--- a/examples/stm32c5/src/bin/blinky.rs
+++ b/examples/stm32c5/src/bin/blinky.rs
@@ -15,11 +15,11 @@ async fn main(_spawner: Spawner) {
     let mut led = Output::new(p.PA5, Level::High, Speed::Low);
 
     loop {
-        info!("high");
+        info!("led on!");
         led.set_high();
         Timer::after_millis(500).await;
 
-        info!("low");
+        info!("led off!");
         led.set_low();
         Timer::after_millis(500).await;
     }

--- a/examples/stm32f0/src/bin/blinky.rs
+++ b/examples/stm32f0/src/bin/blinky.rs
@@ -16,12 +16,12 @@ async fn main(_spawner: Spawner) {
     let mut led = Output::new(p.PA5, Level::High, Speed::Low);
 
     loop {
-        info!("high");
+        info!("led on!");
         led.set_high();
-        Timer::after_millis(300).await;
+        Timer::after_millis(500).await;
 
-        info!("low");
+        info!("led off!");
         led.set_low();
-        Timer::after_millis(300).await;
+        Timer::after_millis(500).await;
     }
 }

--- a/examples/stm32f1/src/bin/blinky.rs
+++ b/examples/stm32f1/src/bin/blinky.rs
@@ -15,12 +15,12 @@ async fn main(_spawner: Spawner) {
     let mut led = Output::new(p.PC13, Level::High, Speed::Low);
 
     loop {
-        info!("high");
+        info!("led on!");
         led.set_high();
-        Timer::after_millis(300).await;
+        Timer::after_millis(500).await;
 
-        info!("low");
+        info!("led off!");
         led.set_low();
-        Timer::after_millis(300).await;
+        Timer::after_millis(500).await;
     }
 }

--- a/examples/stm32f2/src/bin/blinky.rs
+++ b/examples/stm32f2/src/bin/blinky.rs
@@ -15,12 +15,12 @@ async fn main(_spawner: Spawner) {
     let mut led = Output::new(p.PB14, Level::High, Speed::Low);
 
     loop {
-        info!("high");
+        info!("led on!");
         led.set_high();
-        Timer::after_millis(1000).await;
+        Timer::after_millis(500).await;
 
-        info!("low");
+        info!("led off!");
         led.set_low();
-        Timer::after_millis(1000).await;
+        Timer::after_millis(500).await;
     }
 }

--- a/examples/stm32f3/src/bin/blinky.rs
+++ b/examples/stm32f3/src/bin/blinky.rs
@@ -15,12 +15,12 @@ async fn main(_spawner: Spawner) {
     let mut led = Output::new(p.PA5, Level::High, Speed::Low);
 
     loop {
-        info!("high");
+        info!("led on!");
         led.set_high();
-        Timer::after_millis(1000).await;
+        Timer::after_millis(500).await;
 
-        info!("low");
+        info!("led off!");
         led.set_low();
-        Timer::after_millis(1000).await;
+        Timer::after_millis(500).await;
     }
 }

--- a/examples/stm32f4/src/bin/blinky.rs
+++ b/examples/stm32f4/src/bin/blinky.rs
@@ -15,12 +15,12 @@ async fn main(_spawner: Spawner) {
     let mut led = Output::new(p.PB7, Level::High, Speed::Low);
 
     loop {
-        info!("high");
+        info!("led on!");
         led.set_high();
-        Timer::after_millis(300).await;
+        Timer::after_millis(500).await;
 
-        info!("low");
+        info!("led off!");
         led.set_low();
-        Timer::after_millis(300).await;
+        Timer::after_millis(500).await;
     }
 }

--- a/examples/stm32f7/src/bin/blinky.rs
+++ b/examples/stm32f7/src/bin/blinky.rs
@@ -15,12 +15,12 @@ async fn main(_spawner: Spawner) {
     let mut led = Output::new(p.PB7, Level::High, Speed::Low);
 
     loop {
-        info!("high");
+        info!("led on!");
         led.set_high();
-        Timer::after_millis(300).await;
+        Timer::after_millis(500).await;
 
-        info!("low");
+        info!("led off!");
         led.set_low();
-        Timer::after_millis(300).await;
+        Timer::after_millis(500).await;
     }
 }

--- a/examples/stm32g0/src/bin/blinky.rs
+++ b/examples/stm32g0/src/bin/blinky.rs
@@ -15,12 +15,12 @@ async fn main(_spawner: Spawner) {
     let mut led = Output::new(p.PB7, Level::High, Speed::Low);
 
     loop {
-        info!("high");
+        info!("led on!");
         led.set_high();
-        Timer::after_millis(300).await;
+        Timer::after_millis(500).await;
 
-        info!("low");
+        info!("led off!");
         led.set_low();
-        Timer::after_millis(300).await;
+        Timer::after_millis(500).await;
     }
 }

--- a/examples/stm32g4/src/bin/blinky.rs
+++ b/examples/stm32g4/src/bin/blinky.rs
@@ -15,12 +15,12 @@ async fn main(_spawner: Spawner) {
     let mut led = Output::new(p.PA5, Level::High, Speed::Low);
 
     loop {
-        info!("high");
+        info!("led on!");
         led.set_high();
-        Timer::after_millis(300).await;
+        Timer::after_millis(500).await;
 
-        info!("low");
+        info!("led off!");
         led.set_low();
-        Timer::after_millis(300).await;
+        Timer::after_millis(500).await;
     }
 }

--- a/examples/stm32h5/src/bin/blinky.rs
+++ b/examples/stm32h5/src/bin/blinky.rs
@@ -15,11 +15,11 @@ async fn main(_spawner: Spawner) {
     let mut led = Output::new(p.PB0, Level::High, Speed::Low);
 
     loop {
-        info!("high");
+        info!("led on!");
         led.set_high();
         Timer::after_millis(500).await;
 
-        info!("low");
+        info!("led off!");
         led.set_low();
         Timer::after_millis(500).await;
     }

--- a/examples/stm32h7/src/bin/blinky.rs
+++ b/examples/stm32h7/src/bin/blinky.rs
@@ -15,11 +15,11 @@ async fn main(_spawner: Spawner) {
     let mut led = Output::new(p.PB14, Level::High, Speed::Low);
 
     loop {
-        info!("high");
+        info!("led on!");
         led.set_high();
         Timer::after_millis(500).await;
 
-        info!("low");
+        info!("led off!");
         led.set_low();
         Timer::after_millis(500).await;
     }

--- a/examples/stm32h755cm4/src/bin/blinky.rs
+++ b/examples/stm32h755cm4/src/bin/blinky.rs
@@ -21,12 +21,12 @@ async fn main(_spawner: Spawner) {
     let mut led = Output::new(p.PE1, Level::High, Speed::Low);
 
     loop {
-        info!("high");
+        info!("led on!");
         led.set_high();
-        Timer::after_millis(250).await;
+        Timer::after_millis(500).await;
 
-        info!("low");
+        info!("led off!");
         led.set_low();
-        Timer::after_millis(250).await;
+        Timer::after_millis(500).await;
     }
 }

--- a/examples/stm32h755cm7/src/bin/blinky.rs
+++ b/examples/stm32h755cm7/src/bin/blinky.rs
@@ -43,11 +43,11 @@ async fn main(_spawner: Spawner) {
     let mut led = Output::new(p.PB14, Level::High, Speed::Low);
 
     loop {
-        info!("high");
+        info!("led on!");
         led.set_high();
         Timer::after_millis(500).await;
 
-        info!("low");
+        info!("led off!");
         led.set_low();
         Timer::after_millis(500).await;
     }

--- a/examples/stm32h7rs/src/bin/blinky.rs
+++ b/examples/stm32h7rs/src/bin/blinky.rs
@@ -42,11 +42,11 @@ async fn main(_spawner: Spawner) {
     let mut led = Output::new(p.PD10, Level::High, Speed::Low);
 
     loop {
-        info!("high");
+        info!("led on!");
         led.set_high();
         Timer::after_millis(500).await;
 
-        info!("low");
+        info!("led off!");
         led.set_low();
         Timer::after_millis(500).await;
     }

--- a/examples/stm32l0/src/bin/blinky.rs
+++ b/examples/stm32l0/src/bin/blinky.rs
@@ -16,13 +16,13 @@ async fn main(_spawner: Spawner) {
     let mut led = Output::new(p.PB5, Level::High, Speed::Low);
 
     for _ in 0..5 {
-        info!("high");
+        info!("led on!");
         led.set_high();
-        Timer::after_millis(300).await;
+        Timer::after_millis(500).await;
 
-        info!("low");
+        info!("led off!");
         led.set_low();
-        Timer::after_millis(300).await;
+        Timer::after_millis(500).await;
     }
 
     asm::bkpt();

--- a/examples/stm32l1/src/bin/blinky.rs
+++ b/examples/stm32l1/src/bin/blinky.rs
@@ -15,12 +15,12 @@ async fn main(_spawner: Spawner) {
     let mut led = Output::new(p.PA12, Level::High, Speed::Low);
 
     loop {
-        info!("high");
+        info!("led on!");
         led.set_high();
-        Timer::after_millis(1000).await;
+        Timer::after_millis(500).await;
 
-        info!("low");
+        info!("led off!");
         led.set_low();
-        Timer::after_millis(1000).await;
+        Timer::after_millis(500).await;
     }
 }

--- a/examples/stm32l4/src/bin/blinky.rs
+++ b/examples/stm32l4/src/bin/blinky.rs
@@ -15,9 +15,12 @@ async fn main(_spawner: Spawner) {
     let mut led = Output::new(p.PB14, Level::High, Speed::Low);
 
     loop {
+        info!("led on!");
         led.set_high();
-        Timer::after_millis(300).await;
+        Timer::after_millis(500).await;
+
+        info!("led off!");
         led.set_low();
-        Timer::after_millis(300).await;
+        Timer::after_millis(500).await;
     }
 }

--- a/examples/stm32n6/src/bin/blinky.rs
+++ b/examples/stm32n6/src/bin/blinky.rs
@@ -39,9 +39,11 @@ async fn main(spawner: Spawner) {
     spawner.spawn(button_task(button).unwrap());
 
     loop {
+        info!("led on!");
         led.set_high();
         Timer::after_millis(500).await;
 
+        info!("led off!");
         led.set_low();
         Timer::after_millis(500).await;
     }

--- a/examples/stm32u0/src/bin/blinky.rs
+++ b/examples/stm32u0/src/bin/blinky.rs
@@ -15,12 +15,12 @@ async fn main(_spawner: Spawner) {
     let mut led = Output::new(p.PA5, Level::High, Speed::Low);
 
     loop {
-        info!("high");
+        info!("led on!");
         led.set_high();
-        Timer::after_millis(300).await;
+        Timer::after_millis(500).await;
 
-        info!("low");
+        info!("led off!");
         led.set_low();
-        Timer::after_millis(300).await;
+        Timer::after_millis(500).await;
     }
 }

--- a/examples/stm32u3/src/bin/blinky.rs
+++ b/examples/stm32u3/src/bin/blinky.rs
@@ -1,6 +1,7 @@
 #![no_std]
 #![no_main]
 
+use defmt::*;
 use embassy_executor::Spawner;
 use embassy_stm32::gpio::{Level, Output, Speed};
 use embassy_time::Timer;
@@ -15,12 +16,12 @@ async fn main(_spawner: Spawner) -> ! {
     let mut led = Output::new(p.PA5, Level::High, Speed::Medium);
 
     loop {
-        defmt::info!("on!");
-        led.set_low();
-        Timer::after_millis(1000).await;
-
-        defmt::info!("off!");
+        info!("led on!");
         led.set_high();
-        Timer::after_millis(1000).await;
+        Timer::after_millis(500).await;
+
+        info!("led off!");
+        led.set_low();
+        Timer::after_millis(500).await;
     }
 }

--- a/examples/stm32u5/src/bin/blinky.rs
+++ b/examples/stm32u5/src/bin/blinky.rs
@@ -16,12 +16,12 @@ async fn main(_spawner: Spawner) -> ! {
     let mut led = Output::new(p.PC13, Level::Low, Speed::Medium);
 
     loop {
-        defmt::info!("on!");
-        led.set_low();
-        Timer::after_millis(200).await;
-
-        defmt::info!("off!");
+        info!("led on!");
         led.set_high();
-        Timer::after_millis(200).await;
+        Timer::after_millis(500).await;
+
+        info!("led off!");
+        led.set_low();
+        Timer::after_millis(500).await;
     }
 }

--- a/examples/stm32wb/src/bin/blinky.rs
+++ b/examples/stm32wb/src/bin/blinky.rs
@@ -15,11 +15,11 @@ async fn main(_spawner: Spawner) {
     let mut led = Output::new(p.PB0, Level::High, Speed::Low);
 
     loop {
-        info!("high");
+        info!("led on!");
         led.set_high();
         Timer::after_millis(500).await;
 
-        info!("low");
+        info!("led off!");
         led.set_low();
         Timer::after_millis(500).await;
     }

--- a/examples/stm32wba/src/bin/blinky.rs
+++ b/examples/stm32wba/src/bin/blinky.rs
@@ -15,11 +15,11 @@ async fn main(_spawner: Spawner) {
     let mut led = Output::new(p.PB4, Level::High, Speed::Low);
 
     loop {
-        info!("high");
+        info!("led on!");
         led.set_high();
         Timer::after_millis(500).await;
 
-        info!("low");
+        info!("led off!");
         led.set_low();
         Timer::after_millis(500).await;
     }

--- a/examples/stm32wba6/src/bin/blinky.rs
+++ b/examples/stm32wba6/src/bin/blinky.rs
@@ -21,11 +21,11 @@ async fn main(_spawner: Spawner) {
     let mut led = Output::new(p.PC4, Level::High, Speed::Low);
 
     loop {
-        info!("high");
+        info!("led on!");
         led.set_high();
         Timer::after_millis(500).await;
 
-        info!("low");
+        info!("led off!");
         led.set_low();
         Timer::after_millis(500).await;
     }

--- a/examples/stm32wl/src/bin/blinky.rs
+++ b/examples/stm32wl/src/bin/blinky.rs
@@ -21,11 +21,11 @@ async fn main(_spawner: Spawner) {
     let mut led = Output::new(p.PB15, Level::High, Speed::Low);
 
     loop {
-        info!("high");
+        info!("led on!");
         led.set_high();
         Timer::after_millis(500).await;
 
-        info!("low");
+        info!("led off!");
         led.set_low();
         Timer::after_millis(500).await;
     }


### PR DESCRIPTION
I was running the `blinky` example on a Raspberry Pi Pico (RP2040) and a Pico 2 (RP2350). I realized that the blinking frequency was really different. At first, I thought about a difference in CPU clocks but I thought it would be embarrassing for embassy to be this off regarding timing. Looking at the code, I saw that it was just that the examples were different regarding timing.
This PR makes most examples use the same interval (500ms off, 500ms on). I didn't touch the examples using `.toggle` (those could be changed to `on` and `off` to make the examples even more unified) and I also didn't touch the "low power" examples since it would defeat their purpose, demonstrating the CPU going to sleep.
I didn't test all the examples on real boards since I do not own all of them, I compile-tested most of them, though. Hoping for CI / GH actions to catch any problems I caused.