### PR TITLE
embassy-nxp: add LPC55 USB device driver

### DIFF
--- a/embassy-nxp/CHANGELOG.md
+++ b/embassy-nxp/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 <!-- next-header -->
 ## Unreleased - ReleaseDate
 - LPC55: Main clock selection via `config::MainClock` (FRO-HF 96 MHz)
+- LPC55: USB1 high-speed device driver
 - Codegen using `nxp-pac` metadata
 - LPC55: PWM simple
 - LPC55: Move ALT definitions for USART to TX/RX pin impls. 

--- a/embassy-nxp/CHANGELOG.md
+++ b/embassy-nxp/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 <!-- next-header -->
 ## Unreleased - ReleaseDate
+- LPC55: Main clock selection via `config::MainClock` (FRO-HF 96 MHz)
 - Codegen using `nxp-pac` metadata
 - LPC55: PWM simple
 - LPC55: Move ALT definitions for USART to TX/RX pin impls. 

--- a/embassy-nxp/CHANGELOG.md
+++ b/embassy-nxp/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## Unreleased - ReleaseDate
 - LPC55: Main clock selection via `config::MainClock` (FRO-HF 96 MHz, PLL0 150 MHz)
 - LPC55: USB1 high-speed device driver
+- LPC55: USB0 full-speed device driver
 - Codegen using `nxp-pac` metadata
 - LPC55: PWM simple
 - LPC55: Move ALT definitions for USART to TX/RX pin impls. 

--- a/embassy-nxp/CHANGELOG.md
+++ b/embassy-nxp/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 <!-- next-header -->
 ## Unreleased - ReleaseDate
-- LPC55: Main clock selection via `config::MainClock` (FRO-HF 96 MHz)
+- LPC55: Main clock selection via `config::MainClock` (FRO-HF 96 MHz, PLL0 150 MHz)
 - LPC55: USB1 high-speed device driver
 - Codegen using `nxp-pac` metadata
 - LPC55: PWM simple

--- a/embassy-nxp/Cargo.toml
+++ b/embassy-nxp/Cargo.toml
@@ -38,15 +38,16 @@ embassy-time = { version = "0.5.1", path = "../embassy-time", optional = true }
 embassy-time-driver = { version = "0.2.2", path = "../embassy-time-driver", optional = true }
 embassy-time-queue-utils = { version = "0.3.2", path = "../embassy-time-queue-utils", optional = true }
 embedded-io = { version = "0.7.1" }
+embassy-usb-driver = { version = "0.2.2", path = "../embassy-usb-driver" }
 embedded-hal-02 = { package = "embedded-hal", version = "0.2.6", features = ["unproven"] }
 ## Chip dependencies
-nxp-pac = { version = "0.1.0", optional = true, git = "https://github.com/embassy-rs/nxp-pac", rev = "e93605d8e8686f1853726921d5349ef3ecdea693" }
+nxp-pac = { version = "0.1.0", optional = true, git = "https://github.com/embassy-rs/nxp-pac", rev = "c54814bbb514495a7a5aebad7d17b987b7b70c0f" }
 
 imxrt-rt = { version = "0.1.7", optional = true, features = ["device"] }
 
 [build-dependencies]
 cfg_aliases = "0.2.1"
-nxp-pac = { version = "0.1.0", git = "https://github.com/embassy-rs/nxp-pac", rev = "e93605d8e8686f1853726921d5349ef3ecdea693", default-features = false, features = ["metadata"] }
+nxp-pac = { version = "0.1.0", git = "https://github.com/embassy-rs/nxp-pac", rev = "c54814bbb514495a7a5aebad7d17b987b7b70c0f", default-features = false, features = ["metadata"] }
 proc-macro2 = "1.0.95"
 quote = "1.0.15"
 
@@ -56,7 +57,7 @@ default = ["rt"]
 rt = ["nxp-pac?/rt"]
 
 ## Enable [defmt support](https://docs.rs/defmt) and enables `defmt` debug-log messages and formatting in embassy drivers.
-defmt = ["dep:defmt", "embassy-hal-internal/defmt", "embassy-sync/defmt"]
+defmt = ["dep:defmt", "embassy-hal-internal/defmt", "embassy-sync/defmt", "embassy-usb-driver/defmt"]
 
 log = ["dep:log"]
 

--- a/embassy-nxp/src/dma/lpc55.rs
+++ b/embassy-nxp/src/dma/lpc55.rs
@@ -3,7 +3,7 @@
 use core::cell::RefCell;
 use core::future::Future;
 use core::pin::Pin;
-use core::sync::atomic::{Ordering, compiler_fence};
+use core::sync::atomic::{AtomicU32, Ordering, compiler_fence};
 use core::task::{Context, Poll};
 
 use critical_section::Mutex;
@@ -26,6 +26,7 @@ fn DMA0() {
         }
 
         if (inta & (1 << channel)) != 0 {
+            CHANNEL_IRQ_COUNTS[channel].fetch_add(1, Ordering::Relaxed);
             CHANNEL_WAKERS[channel].wake();
             DMA0.inta0().modify(|w| w.set_ia(1 << channel));
         }
@@ -248,6 +249,24 @@ impl<'a, C: Channel> Future for Transfer<'a, C> {
 pub(crate) const CHANNEL_COUNT: usize = 32;
 
 static CHANNEL_WAKERS: [AtomicWaker; CHANNEL_COUNT] = [const { AtomicWaker::new() }; CHANNEL_COUNT];
+static CHANNEL_IRQ_COUNTS: [AtomicU32; CHANNEL_COUNT] = [const { AtomicU32::new(0) }; CHANNEL_COUNT];
+
+/// Number of interrupt-A completions seen on `channel` since boot (wrapping).
+///
+/// For continuous linked/ping-pong descriptor chains programmed at the PAC
+/// level (with `SETINTA` on each descriptor), this counts completed
+/// descriptors and lets a consumer track the producer position without
+/// per-transfer interrupts.
+pub fn irq_count(channel: u8) -> u32 {
+    CHANNEL_IRQ_COUNTS[channel as usize].load(Ordering::Relaxed)
+}
+
+/// Waker woken on every interrupt-A completion of `channel`.
+///
+/// Companion to [`irq_count`]: register, then re-check the count.
+pub fn irq_waker(channel: u8) -> &'static AtomicWaker {
+    &CHANNEL_WAKERS[channel as usize]
+}
 
 // See section 22.5.2 (table 450)
 // UM11126, Rev. 2.8

--- a/embassy-nxp/src/dma/lpc55.rs
+++ b/embassy-nxp/src/dma/lpc55.rs
@@ -3,7 +3,7 @@
 use core::cell::RefCell;
 use core::future::Future;
 use core::pin::Pin;
-use core::sync::atomic::{AtomicU32, Ordering, compiler_fence};
+use core::sync::atomic::{Ordering, compiler_fence};
 use core::task::{Context, Poll};
 
 use critical_section::Mutex;
@@ -26,7 +26,6 @@ fn DMA0() {
         }
 
         if (inta & (1 << channel)) != 0 {
-            CHANNEL_IRQ_COUNTS[channel].fetch_add(1, Ordering::Relaxed);
             CHANNEL_WAKERS[channel].wake();
             DMA0.inta0().modify(|w| w.set_ia(1 << channel));
         }
@@ -249,24 +248,6 @@ impl<'a, C: Channel> Future for Transfer<'a, C> {
 pub(crate) const CHANNEL_COUNT: usize = 32;
 
 static CHANNEL_WAKERS: [AtomicWaker; CHANNEL_COUNT] = [const { AtomicWaker::new() }; CHANNEL_COUNT];
-static CHANNEL_IRQ_COUNTS: [AtomicU32; CHANNEL_COUNT] = [const { AtomicU32::new(0) }; CHANNEL_COUNT];
-
-/// Number of interrupt-A completions seen on `channel` since boot (wrapping).
-///
-/// For continuous linked/ping-pong descriptor chains programmed at the PAC
-/// level (with `SETINTA` on each descriptor), this counts completed
-/// descriptors and lets a consumer track the producer position without
-/// per-transfer interrupts.
-pub fn irq_count(channel: u8) -> u32 {
-    CHANNEL_IRQ_COUNTS[channel as usize].load(Ordering::Relaxed)
-}
-
-/// Waker woken on every interrupt-A completion of `channel`.
-///
-/// Companion to [`irq_count`]: register, then re-check the count.
-pub fn irq_waker(channel: u8) -> &'static AtomicWaker {
-    &CHANNEL_WAKERS[channel as usize]
-}
 
 // See section 22.5.2 (table 450)
 // UM11126, Rev. 2.8

--- a/embassy-nxp/src/lib.rs
+++ b/embassy-nxp/src/lib.rs
@@ -105,7 +105,9 @@ macro_rules! bind_interrupts {
 /// This returns the peripheral singletons that can be used for creating drivers.
 ///
 /// This should only be called once and at startup, otherwise it panics.
-pub fn init(_config: config::Config) -> Peripherals {
+pub fn init(config: config::Config) -> Peripherals {
+    #[cfg(not(lpc55))]
+    let _ = &config;
     // Do this first, so that it panics if user is calling `init` a second time
     // before doing anything important.
     let peripherals = Peripherals::take();
@@ -161,6 +163,25 @@ pub fn init(_config: config::Config) -> Peripherals {
 
     #[cfg(lpc55)]
     {
+        if config.main_clock == config::MainClock::FroHf96 {
+            // Flash wait states first, so timing is safe before the frequency rises.
+            // 9 system-clock access time covers rates up to 100 MHz.
+            pac::SYSCON
+                .fmccr()
+                .modify(|w| w.set_flashtim(pac::syscon::vals::Flashtim::Flashtim8));
+            // Ensure the FRO-HF 96 MHz output is enabled (ROM default leaves it on;
+            // set it anyway).
+            pac::ANACTRL.fro192m_ctrl().modify(|w| w.set_ena_96mhzclk(true));
+            // AHB divider = 1, then switch main clock to FRO-HF (glitch-free per UM).
+            pac::SYSCON.ahbclkdiv().modify(|w| w.set_div(0));
+            pac::SYSCON
+                .mainclksela()
+                .modify(|w| w.set_sel(pac::syscon::vals::MainclkselaSel::Enum0x3));
+            pac::SYSCON
+                .mainclkselb()
+                .modify(|w| w.set_sel(pac::syscon::vals::MainclkselbSel::Enum0x0));
+        }
+
         pint::init();
         pwm::Pwm::reset();
     }
@@ -176,8 +197,24 @@ pub fn init(_config: config::Config) -> Peripherals {
 
 /// HAL configuration for the NXP board.
 pub mod config {
+    /// Main (system) clock selection for LPC55.
+    #[cfg(lpc55)]
+    #[derive(Default, Clone, Copy, PartialEq, Eq)]
+    pub enum MainClock {
+        /// Leave the ROM boot default untouched.
+        #[default]
+        Untouched,
+        /// FRO HF 96 MHz as main clock (required for USB-HS).
+        FroHf96,
+    }
+
+    /// HAL configuration.
     #[derive(Default)]
-    pub struct Config {}
+    pub struct Config {
+        /// Main (system) clock selection.
+        #[cfg(lpc55)]
+        pub main_clock: MainClock,
+    }
 }
 
 #[allow(unused)]

--- a/embassy-nxp/src/lib.rs
+++ b/embassy-nxp/src/lib.rs
@@ -20,6 +20,9 @@ pub mod usart;
 #[cfg(lpc55)]
 pub mod usb;
 
+#[cfg(lpc55)]
+mod power;
+
 #[cfg(rt1xxx)]
 mod iomuxc;
 
@@ -166,15 +169,9 @@ pub fn init(config: config::Config) -> Peripherals {
     #[cfg(lpc55)]
     {
         if config.main_clock == config::MainClock::FroHf96 {
-            // Flash wait states first, so timing is safe before the frequency rises.
-            // 9 system-clock access time covers rates up to 100 MHz.
-            pac::SYSCON
-                .fmccr()
-                .modify(|w| w.set_flashtim(pac::syscon::vals::Flashtim::Flashtim8));
-            // Ensure the FRO-HF 96 MHz output is enabled (ROM default leaves it on;
-            // set it anyway).
+            power::set_voltage_for_freq(96_000_000);
+            clocks::set_flash_access_cycles(8);
             pac::ANACTRL.fro192m_ctrl().modify(|w| w.set_ena_96mhzclk(true));
-            // AHB divider = 1, then switch main clock to FRO-HF (glitch-free per UM).
             pac::SYSCON.ahbclkdiv().modify(|w| w.set_div(0));
             pac::SYSCON
                 .mainclksela()
@@ -201,73 +198,136 @@ pub fn init(config: config::Config) -> Peripherals {
     peripherals
 }
 
-/// LPC55 clock tree setup beyond the simple FRO paths handled inline in `init`.
+/// LPC55 clock tree setup.
 #[cfg(lpc55)]
 mod clocks {
-    use crate::pac;
+    use crate::{pac, power};
 
-    /// Switch the main (system) clock to PLL0 at 150 MHz, fed from the 16 MHz
-    /// external crystal (clk_in).
-    ///
-    /// PLL parameters (UM11126 §4.6.6): N = 8 (ref 2 MHz), M = 150
-    /// (CCO = 300 MHz, within the 275–550 MHz range), P = 1 (post-divide by
-    /// 2·P = 2) → 150 MHz. SELI/SELP follow the UM11126 bandwidth formulas
-    /// for M = 150 (SELI = 8000/M = 53, SELP = min(M/4 + 1, 31) = 31).
-    ///
-    /// NOTE: NXP's closed-source power library additionally raises the core
-    /// voltage for operation above 100 MHz (`POWER_SetVoltageForFreq`). The
-    /// registers involved are not documented in UM11126, so this runs on the
-    /// reset-default regulator settings; long-duration stress testing is the
-    /// acceptance gate for this configuration.
+    const CMD_SET_READ_MODE: u32 = 2;
+    const FLASH_COMMAND_TIMEOUT_POLLS: u32 = 1_000_000;
+    const XO_READY_TIMEOUT_POLLS: u32 = 1_000_000;
+    const PLL_LOCK_TIMEOUT_POLLS: u32 = 1_000_000;
+
+    const fn supports_pll0_150m(revision: u8) -> bool {
+        revision == 1
+    }
+
+    const fn pll0_output_frequency_hz(input_hz: u32, ndiv: u8, mdiv: u16, pdiv: u8) -> u32 {
+        input_hz / ndiv as u32 * mdiv as u32 / (2 * pdiv as u32)
+    }
+
+    /*
+     * Copyright 2017 - 2021 , NXP
+     * All rights reserved.
+     *
+     * SPDX-License-Identifier: BSD-3-Clause
+     */
+    pub(super) fn set_flash_access_cycles(wait_states: u8) {
+        assert!(
+            wait_states <= 0x0f,
+            "LPC55 flash wait-state value {} exceeds the FMCCR field",
+            wait_states
+        );
+
+        let prefetch_enabled = pac::SYSCON.fmccr().read().prefen();
+        pac::SYSCON.fmccr().modify(|w| w.set_prefen(false));
+
+        pac::FLASH
+            .int_clr_status()
+            .write_value(pac::flash::regs::IntClrStatus(0x1f));
+        pac::FLASH.dataw(0).modify(|w| {
+            w.set_dataw((w.dataw() & !0x0f) | u32::from(wait_states));
+        });
+        pac::FLASH.cmd().write_value(pac::flash::regs::Cmd(CMD_SET_READ_MODE));
+
+        let mut command_done = false;
+        for _ in 0..FLASH_COMMAND_TIMEOUT_POLLS {
+            let status = pac::FLASH.int_status().read();
+            if status.fail() || status.err() {
+                panic!(
+                    "LPC55 FLASH CMD_SET_READ_MODE failed: FAIL={}, ERR={}",
+                    status.fail(),
+                    status.err()
+                );
+            }
+            if status.done() {
+                command_done = true;
+                break;
+            }
+        }
+        if !command_done {
+            panic!(
+                "LPC55 FLASH CMD_SET_READ_MODE timed out after {} polls",
+                FLASH_COMMAND_TIMEOUT_POLLS
+            );
+        }
+
+        pac::SYSCON.fmccr().modify(|w| {
+            w.set_flashtim(pac::syscon::vals::Flashtim::from_bits(wait_states));
+            w.set_prefen(prefetch_enabled);
+        });
+    }
+
     pub(crate) fn setup_pll0_150m_main_clock() {
         const XTAL_HZ: u32 = 16_000_000;
         const NDIV: u8 = 8;
         const MDIV: u16 = 150;
         const PDIV: u8 = 1;
-        const SELI: u8 = 53; // 8000 / M, for 122 <= M < 8000
-        const SELP: u8 = 31; // min(M/4 + 1, 31)
-        const _: () = core::assert!(XTAL_HZ / NDIV as u32 * MDIV as u32 / (2 * PDIV as u32) == 150_000_000);
+        const SELI: u8 = 53;
+        const SELP: u8 = 31;
+        const _: () = core::assert!(pll0_output_frequency_hz(XTAL_HZ, NDIV, MDIV, PDIV) == 150_000_000);
 
-        // Flash wait states first: 12 system-clock access time covers 150 MHz
-        // (UM11126 FMCCR.FLASHTIM = 11).
+        let revision = pac::SYSCON.dieid().read().rev_id();
+        if !supports_pll0_150m(revision) {
+            panic!(
+                "LPC55 PLL0 150 MHz requires die revision 1B (REV_ID 1); observed REV_ID {}",
+                revision
+            );
+        }
+
         pac::SYSCON
-            .fmccr()
-            .modify(|w| w.set_flashtim(pac::syscon::vals::Flashtim::Flashtim11));
+            .mainclksela()
+            .write(|w| w.set_sel(pac::syscon::vals::MainclkselaSel::Enum0x0));
+        pac::SYSCON
+            .mainclkselb()
+            .write(|w| w.set_sel(pac::syscon::vals::MainclkselbSel::Enum0x0));
 
-        // Power up the 16 MHz crystal oscillator + its LDO, and route it to
-        // the system clock tree (clk_in). PDRUNCFG0: bit 8 = XTAL32M,
-        // bit 20 = LDOXO32M; writing 1 to the CLR register powers ON.
+        power::set_voltage_for_freq(150_000_000);
+        set_flash_access_cycles(11);
+
         pac::PMC
             .pdruncfgclr0()
             .write(|w| w.set_pdruncfgclr0((1 << 8) | (1 << 20)));
         pac::ANACTRL.xo32m_ctrl().modify(|w| w.set_enable_system_clk_out(true));
         pac::SYSCON.clock_ctrl().modify(|w| w.set_clkin_ena(true));
-        // Bounded wait for the crystal to be ready (typ. ~350 us).
-        for _ in 0..1_000_000 {
+
+        let mut crystal_ready = false;
+        for _ in 0..XO_READY_TIMEOUT_POLLS {
             if pac::ANACTRL.xo32m_status().read().xo_ready() {
+                crystal_ready = true;
                 break;
             }
         }
+        if !crystal_ready {
+            panic!(
+                "LPC55 16 MHz crystal did not report XO_READY within {} polls",
+                XO_READY_TIMEOUT_POLLS
+            );
+        }
 
-        // Power up PLL0 and its SSCG block (the M-divider lives in the SSCG
-        // wrapper even with spread spectrum disabled). Bits 9 / 23.
         pac::PMC
-            .pdruncfgclr0()
-            .write(|w| w.set_pdruncfgclr0((1 << 9) | (1 << 23)));
-
-        // PLL0 input = clk_in (16 MHz crystal).
+            .pdruncfgset0()
+            .write(|w| w.set_pdruncfgset0((1 << 9) | (1 << 23)));
         pac::SYSCON
             .pll0clksel()
             .write(|w| w.set_sel(pac::syscon::vals::Pll0clkselSel::Enum0x1));
 
-        // Bandwidth + enable the post-divider output clock.
         pac::SYSCON.pll0ctrl().write(|w| {
             w.set_selr(0);
             w.set_seli(SELI);
             w.set_selp(SELP);
             w.set_clken(true);
         });
-        // Dividers: write the ratio, then pulse the change request bit.
         pac::SYSCON.pll0ndec().write(|w| w.set_ndiv(NDIV));
         pac::SYSCON.pll0ndec().write(|w| {
             w.set_ndiv(NDIV);
@@ -278,38 +338,65 @@ mod clocks {
             w.set_pdiv(PDIV);
             w.set_preq(true);
         });
-        // Integer M via the external M-divider (SEL_EXT = 1), no spread
-        // spectrum (MF/MR/MC = 0).
+        pac::SYSCON.pll0sscg0().modify(|w| w.set_md_lbs(0));
         pac::SYSCON.pll0sscg1().write(|w| {
             w.set_mdiv_ext(MDIV);
             w.set_sel_ext(true);
         });
         pac::SYSCON.pll0sscg1().write(|w| {
             w.set_mdiv_ext(MDIV);
-            w.set_sel_ext(true);
+            w.set_md_req(true);
             w.set_mreq(true);
+            w.set_sel_ext(true);
         });
 
-        // Wait for lock (ref = 2 MHz > 100 kHz, so the lock detector is
-        // usable per UM11126), with a generous bound; the UM quotes a
-        // worst-case lock time of ~500 us.
-        let mut locked = false;
-        for _ in 0..1_000_000 {
+        pac::PMC
+            .pdruncfgclr0()
+            .write(|w| w.set_pdruncfgclr0((1 << 9) | (1 << 23)));
+
+        let mut pll_locked = false;
+        for _ in 0..PLL_LOCK_TIMEOUT_POLLS {
             if pac::SYSCON.pll0stat().read().lock() {
-                locked = true;
+                pll_locked = true;
                 break;
             }
         }
-        if !locked {
-            warn!("PLL0 failed to lock, main clock left unchanged");
-            return;
+        if !pll_locked {
+            panic!(
+                "LPC55 PLL0 did not lock at 150 MHz within {} polls",
+                PLL_LOCK_TIMEOUT_POLLS
+            );
         }
 
-        // AHB divider = 1, then glitch-free switch: main clock B = PLL0.
         pac::SYSCON.ahbclkdiv().modify(|w| w.set_div(0));
         pac::SYSCON
             .mainclkselb()
-            .modify(|w| w.set_sel(pac::syscon::vals::MainclkselbSel::Enum0x1));
+            .write(|w| w.set_sel(pac::syscon::vals::MainclkselbSel::Enum0x1));
+    }
+
+    #[cfg(test)]
+    mod tests {
+        use super::{pll0_output_frequency_hz, supports_pll0_150m};
+
+        #[test]
+        fn pll0_150m_rejects_revision_0a() {
+            assert!(!supports_pll0_150m(0));
+        }
+
+        #[test]
+        fn pll0_150m_accepts_revision_1b() {
+            assert!(supports_pll0_150m(1));
+        }
+
+        #[test]
+        fn pll0_150m_rejects_unknown_revision() {
+            assert!(!supports_pll0_150m(2));
+        }
+
+        #[test]
+        fn pll0_equation_yields_150mhz() {
+            assert_eq!(pll0_output_frequency_hz(16_000_000, 8, 150, 1), 150_000_000);
+        }
     }
 }
 
@@ -326,7 +413,9 @@ pub mod config {
         FroHf96,
         /// PLL0 at 150 MHz (from the 16 MHz crystal) as main clock.
         ///
-        /// Also satisfies the USB-HS >= 96 MHz system clock requirement.
+        /// This mode is available only on die revision 1B. It uses the NXP
+        /// power-profile algorithm before raising the system clock.
+        /// It also satisfies the USB-HS >= 96 MHz system clock requirement.
         Pll0_150M,
     }
 

--- a/embassy-nxp/src/lib.rs
+++ b/embassy-nxp/src/lib.rs
@@ -168,21 +168,21 @@ pub fn init(config: config::Config) -> Peripherals {
 
     #[cfg(lpc55)]
     {
-        if config.main_clock == config::MainClock::FroHf96 {
-            power::set_voltage_for_freq(96_000_000);
-            clocks::set_flash_access_cycles(8);
-            pac::ANACTRL.fro192m_ctrl().modify(|w| w.set_ena_96mhzclk(true));
-            pac::SYSCON.ahbclkdiv().modify(|w| w.set_div(0));
-            pac::SYSCON
-                .mainclksela()
-                .modify(|w| w.set_sel(pac::syscon::vals::MainclkselaSel::Enum0x3));
-            pac::SYSCON
-                .mainclkselb()
-                .modify(|w| w.set_sel(pac::syscon::vals::MainclkselbSel::Enum0x0));
-        }
-
-        if config.main_clock == config::MainClock::Pll0_150M {
-            clocks::setup_pll0_150m_main_clock();
+        match config.main_clock {
+            config::MainClock::Untouched => {}
+            config::MainClock::FroHf96 => {
+                power::set_voltage_for_freq(96_000_000);
+                clocks::set_flash_access_cycles(8);
+                pac::ANACTRL.fro192m_ctrl().modify(|w| w.set_ena_96mhzclk(true));
+                pac::SYSCON.ahbclkdiv().modify(|w| w.set_div(0));
+                pac::SYSCON
+                    .mainclksela()
+                    .modify(|w| w.set_sel(pac::syscon::vals::MainclkselaSel::Enum0x3));
+                pac::SYSCON
+                    .mainclkselb()
+                    .modify(|w| w.set_sel(pac::syscon::vals::MainclkselbSel::Enum0x0));
+            }
+            config::MainClock::Pll0_150M => clocks::setup_pll0_150m_main_clock(),
         }
 
         pint::init();
@@ -207,6 +207,10 @@ mod clocks {
     const FLASH_COMMAND_TIMEOUT_POLLS: u32 = 1_000_000;
     const XO_READY_TIMEOUT_POLLS: u32 = 1_000_000;
     const PLL_LOCK_TIMEOUT_POLLS: u32 = 1_000_000;
+
+    fn poll_bounded(polls: u32, mut ready: impl FnMut() -> bool) -> bool {
+        (0..polls).any(|_| ready())
+    }
 
     const fn supports_pll0_150m(revision: u8) -> bool {
         revision == 1
@@ -301,13 +305,7 @@ mod clocks {
         pac::ANACTRL.xo32m_ctrl().modify(|w| w.set_enable_system_clk_out(true));
         pac::SYSCON.clock_ctrl().modify(|w| w.set_clkin_ena(true));
 
-        let mut crystal_ready = false;
-        for _ in 0..XO_READY_TIMEOUT_POLLS {
-            if pac::ANACTRL.xo32m_status().read().xo_ready() {
-                crystal_ready = true;
-                break;
-            }
-        }
+        let crystal_ready = poll_bounded(XO_READY_TIMEOUT_POLLS, || pac::ANACTRL.xo32m_status().read().xo_ready());
         if !crystal_ready {
             panic!(
                 "LPC55 16 MHz crystal did not report XO_READY within {} polls",
@@ -354,13 +352,7 @@ mod clocks {
             .pdruncfgclr0()
             .write(|w| w.set_pdruncfgclr0((1 << 9) | (1 << 23)));
 
-        let mut pll_locked = false;
-        for _ in 0..PLL_LOCK_TIMEOUT_POLLS {
-            if pac::SYSCON.pll0stat().read().lock() {
-                pll_locked = true;
-                break;
-            }
-        }
+        let pll_locked = poll_bounded(PLL_LOCK_TIMEOUT_POLLS, || pac::SYSCON.pll0stat().read().lock());
         if !pll_locked {
             panic!(
                 "LPC55 PLL0 did not lock at 150 MHz within {} polls",
@@ -379,18 +371,10 @@ mod clocks {
         use super::{pll0_output_frequency_hz, supports_pll0_150m};
 
         #[test]
-        fn pll0_150m_rejects_revision_0a() {
-            assert!(!supports_pll0_150m(0));
-        }
-
-        #[test]
-        fn pll0_150m_accepts_revision_1b() {
-            assert!(supports_pll0_150m(1));
-        }
-
-        #[test]
-        fn pll0_150m_rejects_unknown_revision() {
-            assert!(!supports_pll0_150m(2));
+        fn pll0_150m_supports_only_revision_1b() {
+            for (revision, supported) in [(0, false), (1, true), (2, false)] {
+                assert_eq!(supports_pll0_150m(revision), supported);
+            }
         }
 
         #[test]

--- a/embassy-nxp/src/lib.rs
+++ b/embassy-nxp/src/lib.rs
@@ -184,6 +184,10 @@ pub fn init(config: config::Config) -> Peripherals {
                 .modify(|w| w.set_sel(pac::syscon::vals::MainclkselbSel::Enum0x0));
         }
 
+        if config.main_clock == config::MainClock::Pll0_150M {
+            clocks::setup_pll0_150m_main_clock();
+        }
+
         pint::init();
         pwm::Pwm::reset();
     }
@@ -197,6 +201,118 @@ pub fn init(config: config::Config) -> Peripherals {
     peripherals
 }
 
+/// LPC55 clock tree setup beyond the simple FRO paths handled inline in `init`.
+#[cfg(lpc55)]
+mod clocks {
+    use crate::pac;
+
+    /// Switch the main (system) clock to PLL0 at 150 MHz, fed from the 16 MHz
+    /// external crystal (clk_in).
+    ///
+    /// PLL parameters (UM11126 §4.6.6): N = 8 (ref 2 MHz), M = 150
+    /// (CCO = 300 MHz, within the 275–550 MHz range), P = 1 (post-divide by
+    /// 2·P = 2) → 150 MHz. SELI/SELP follow the UM11126 bandwidth formulas
+    /// for M = 150 (SELI = 8000/M = 53, SELP = min(M/4 + 1, 31) = 31).
+    ///
+    /// NOTE: NXP's closed-source power library additionally raises the core
+    /// voltage for operation above 100 MHz (`POWER_SetVoltageForFreq`). The
+    /// registers involved are not documented in UM11126, so this runs on the
+    /// reset-default regulator settings; long-duration stress testing is the
+    /// acceptance gate for this configuration.
+    pub(crate) fn setup_pll0_150m_main_clock() {
+        const XTAL_HZ: u32 = 16_000_000;
+        const NDIV: u8 = 8;
+        const MDIV: u16 = 150;
+        const PDIV: u8 = 1;
+        const SELI: u8 = 53; // 8000 / M, for 122 <= M < 8000
+        const SELP: u8 = 31; // min(M/4 + 1, 31)
+        const _: () = core::assert!(XTAL_HZ / NDIV as u32 * MDIV as u32 / (2 * PDIV as u32) == 150_000_000);
+
+        // Flash wait states first: 12 system-clock access time covers 150 MHz
+        // (UM11126 FMCCR.FLASHTIM = 11).
+        pac::SYSCON
+            .fmccr()
+            .modify(|w| w.set_flashtim(pac::syscon::vals::Flashtim::Flashtim11));
+
+        // Power up the 16 MHz crystal oscillator + its LDO, and route it to
+        // the system clock tree (clk_in). PDRUNCFG0: bit 8 = XTAL32M,
+        // bit 20 = LDOXO32M; writing 1 to the CLR register powers ON.
+        pac::PMC
+            .pdruncfgclr0()
+            .write(|w| w.set_pdruncfgclr0((1 << 8) | (1 << 20)));
+        pac::ANACTRL.xo32m_ctrl().modify(|w| w.set_enable_system_clk_out(true));
+        pac::SYSCON.clock_ctrl().modify(|w| w.set_clkin_ena(true));
+        // Bounded wait for the crystal to be ready (typ. ~350 us).
+        for _ in 0..1_000_000 {
+            if pac::ANACTRL.xo32m_status().read().xo_ready() {
+                break;
+            }
+        }
+
+        // Power up PLL0 and its SSCG block (the M-divider lives in the SSCG
+        // wrapper even with spread spectrum disabled). Bits 9 / 23.
+        pac::PMC
+            .pdruncfgclr0()
+            .write(|w| w.set_pdruncfgclr0((1 << 9) | (1 << 23)));
+
+        // PLL0 input = clk_in (16 MHz crystal).
+        pac::SYSCON
+            .pll0clksel()
+            .write(|w| w.set_sel(pac::syscon::vals::Pll0clkselSel::Enum0x1));
+
+        // Bandwidth + enable the post-divider output clock.
+        pac::SYSCON.pll0ctrl().write(|w| {
+            w.set_selr(0);
+            w.set_seli(SELI);
+            w.set_selp(SELP);
+            w.set_clken(true);
+        });
+        // Dividers: write the ratio, then pulse the change request bit.
+        pac::SYSCON.pll0ndec().write(|w| w.set_ndiv(NDIV));
+        pac::SYSCON.pll0ndec().write(|w| {
+            w.set_ndiv(NDIV);
+            w.set_nreq(true);
+        });
+        pac::SYSCON.pll0pdec().write(|w| w.set_pdiv(PDIV));
+        pac::SYSCON.pll0pdec().write(|w| {
+            w.set_pdiv(PDIV);
+            w.set_preq(true);
+        });
+        // Integer M via the external M-divider (SEL_EXT = 1), no spread
+        // spectrum (MF/MR/MC = 0).
+        pac::SYSCON.pll0sscg1().write(|w| {
+            w.set_mdiv_ext(MDIV);
+            w.set_sel_ext(true);
+        });
+        pac::SYSCON.pll0sscg1().write(|w| {
+            w.set_mdiv_ext(MDIV);
+            w.set_sel_ext(true);
+            w.set_mreq(true);
+        });
+
+        // Wait for lock (ref = 2 MHz > 100 kHz, so the lock detector is
+        // usable per UM11126), with a generous bound; the UM quotes a
+        // worst-case lock time of ~500 us.
+        let mut locked = false;
+        for _ in 0..1_000_000 {
+            if pac::SYSCON.pll0stat().read().lock() {
+                locked = true;
+                break;
+            }
+        }
+        if !locked {
+            warn!("PLL0 failed to lock, main clock left unchanged");
+            return;
+        }
+
+        // AHB divider = 1, then glitch-free switch: main clock B = PLL0.
+        pac::SYSCON.ahbclkdiv().modify(|w| w.set_div(0));
+        pac::SYSCON
+            .mainclkselb()
+            .modify(|w| w.set_sel(pac::syscon::vals::MainclkselbSel::Enum0x1));
+    }
+}
+
 /// HAL configuration for the NXP board.
 pub mod config {
     /// Main (system) clock selection for LPC55.
@@ -208,6 +324,10 @@ pub mod config {
         Untouched,
         /// FRO HF 96 MHz as main clock (required for USB-HS).
         FroHf96,
+        /// PLL0 at 150 MHz (from the 16 MHz crystal) as main clock.
+        ///
+        /// Also satisfies the USB-HS >= 96 MHz system clock requirement.
+        Pll0_150M,
     }
 
     /// HAL configuration.

--- a/embassy-nxp/src/lib.rs
+++ b/embassy-nxp/src/lib.rs
@@ -17,6 +17,8 @@ pub mod pwm;
 pub mod sct;
 #[cfg(lpc55)]
 pub mod usart;
+#[cfg(lpc55)]
+pub mod usb;
 
 #[cfg(rt1xxx)]
 mod iomuxc;

--- a/embassy-nxp/src/power.rs
+++ b/embassy-nxp/src/power.rs
@@ -14,24 +14,17 @@ use crate::pac;
 const NMPA_BASE: usize = 0x0009_fc00;
 #[cfg(feature = "lpc55s16")]
 const NMPA_BASE: usize = 0x0003_fc00;
-const DCDC_PROFILE_LOW_0: usize = NMPA_BASE + 0xe0;
-const DCDC_PROFILE_LOW_1: usize = NMPA_BASE + 0xe4;
-const DCDC_PROFILE_MEDIUM_0: usize = NMPA_BASE + 0xe8;
-const DCDC_PROFILE_MEDIUM_1: usize = NMPA_BASE + 0xec;
-const DCDC_PROFILE_HIGH_0: usize = NMPA_BASE + 0xd8;
-const DCDC_PROFILE_HIGH_1: usize = NMPA_BASE + 0xdc;
+const DCDC_TRIM_ADDRESSES: [(usize, usize); 3] = [
+    (NMPA_BASE + 0xe0, NMPA_BASE + 0xe4),
+    (NMPA_BASE + 0xe8, NMPA_BASE + 0xec),
+    (NMPA_BASE + 0xd8, NMPA_BASE + 0xdc),
+];
+#[cfg(feature = "lpc55-core0")]
+const DCDC_PROFILE_MAX_HZ: [u32; 3] = [100_000_000, 130_000_000, 150_000_000];
+#[cfg(feature = "lpc55s16")]
+const DCDC_PROFILE_MAX_HZ: [u32; 3] = [72_000_000, 100_000_000, 150_000_000];
 const PVT_MONITOR_0_RINGO: usize = NMPA_BASE + 0x130;
 const PVT_MONITOR_1_RINGO: usize = NMPA_BASE + 0x140;
-
-#[cfg(feature = "lpc55-core0")]
-const DCDC_PROFILE_LOW_MAX_HZ: u32 = 100_000_000;
-#[cfg(feature = "lpc55-core0")]
-const DCDC_PROFILE_MEDIUM_MAX_HZ: u32 = 130_000_000;
-#[cfg(feature = "lpc55s16")]
-const DCDC_PROFILE_LOW_MAX_HZ: u32 = 72_000_000;
-#[cfg(feature = "lpc55s16")]
-const DCDC_PROFILE_MEDIUM_MAX_HZ: u32 = 100_000_000;
-const DCDC_PROFILE_HIGH_MAX_HZ: u32 = 150_000_000;
 
 const PROCESS_NNN_AVG_HZ: u32 = 19_300_000;
 const PROCESS_NNN_STD_HZ: u32 = 400_000;
@@ -40,6 +33,7 @@ const PROCESS_NNN_MIN_HZ: u32 = PROCESS_NNN_AVG_HZ - PROCESS_NNN_LIMITS * PROCES
 const PROCESS_NNN_MAX_HZ: u32 = PROCESS_NNN_AVG_HZ + PROCESS_NNN_LIMITS * PROCESS_NNN_STD_HZ;
 
 #[derive(Clone, Copy)]
+#[repr(usize)]
 enum DcdcPowerProfile {
     Low,
     Medium,
@@ -47,25 +41,42 @@ enum DcdcPowerProfile {
 }
 
 #[derive(Clone, Copy)]
+#[repr(usize)]
 enum ProcessCorner {
     Slow,
     Nominal,
     Fast,
 }
 
+const DCDC_PROFILES: [DcdcPowerProfile; 3] = [DcdcPowerProfile::Low, DcdcPowerProfile::Medium, DcdcPowerProfile::High];
+
+#[cfg(feature = "lpc55-core0")]
+const PROCESS_VOLTAGES_MV: [[u32; 3]; 3] = [[1075, 1150, 1200], [1000, 1100, 1150], [1000, 1025, 1050]];
+#[cfg(feature = "lpc55s16")]
+const PROCESS_VOLTAGES_MV: [[u32; 3]; 3] = [[1100, 1150, 1200], [1050, 1075, 1150], [1000, 1025, 1050]];
+
+const SYSTEM_VOLTAGE_REGISTERS: [(u32, u8, u8, u8); 11] = [
+    (950, 0, 10, 15),
+    (975, 1, 12, 17),
+    (1000, 2, 14, 19),
+    (1025, 3, 17, 22),
+    (1050, 4, 20, 25),
+    (1075, 5, 22, 27),
+    (1100, 6, 24, 29),
+    (1125, 7, 27, 30),
+    (1150, 8, 30, 31),
+    (1175, 9, 30, 31),
+    (u32::MAX, 10, 30, 31),
+];
+
 pub(crate) fn set_voltage_for_freq(system_freq_hz: u32) {
     critical_section::with(|_| {
-        let profile = if system_freq_hz <= DCDC_PROFILE_LOW_MAX_HZ {
-            DcdcPowerProfile::Low
-        } else if system_freq_hz <= DCDC_PROFILE_MEDIUM_MAX_HZ {
-            DcdcPowerProfile::Medium
-        } else if system_freq_hz <= DCDC_PROFILE_HIGH_MAX_HZ {
-            DcdcPowerProfile::High
-        } else {
-            panic!(
+        let profile = match DCDC_PROFILE_MAX_HZ.iter().position(|&max_hz| system_freq_hz <= max_hz) {
+            Some(index) => DCDC_PROFILES[index],
+            None => panic!(
                 "LPC55 frequency {} Hz exceeds the 150 MHz voltage profile",
                 system_freq_hz
-            );
+            ),
         };
 
         set_dcdc_power_profile(profile);
@@ -74,11 +85,7 @@ pub(crate) fn set_voltage_for_freq(system_freq_hz: u32) {
 }
 
 fn set_dcdc_power_profile(profile: DcdcPowerProfile) {
-    let (trim_0_address, trim_1_address) = match profile {
-        DcdcPowerProfile::Low => (DCDC_PROFILE_LOW_0, DCDC_PROFILE_LOW_1),
-        DcdcPowerProfile::Medium => (DCDC_PROFILE_MEDIUM_0, DCDC_PROFILE_MEDIUM_1),
-        DcdcPowerProfile::High => (DCDC_PROFILE_HIGH_0, DCDC_PROFILE_HIGH_1),
-    };
+    let (trim_0_address, trim_1_address) = DCDC_TRIM_ADDRESSES[profile as usize];
     let trim_0 = read_nmpa_word(trim_0_address);
     let trim_1 = read_nmpa_word(trim_1_address);
 
@@ -110,60 +117,16 @@ fn set_voltage_for_process(profile: DcdcPowerProfile) {
     set_system_voltage(voltage_for_process(process_corner(), profile));
 }
 
-#[cfg(feature = "lpc55-core0")]
 fn voltage_for_process(corner: ProcessCorner, profile: DcdcPowerProfile) -> u32 {
-    match (corner, profile) {
-        (ProcessCorner::Slow, DcdcPowerProfile::Low) => 1075,
-        (ProcessCorner::Slow, DcdcPowerProfile::Medium) => 1150,
-        (ProcessCorner::Slow, DcdcPowerProfile::High) => 1200,
-        (ProcessCorner::Nominal, DcdcPowerProfile::Low) => 1000,
-        (ProcessCorner::Nominal, DcdcPowerProfile::Medium) => 1100,
-        (ProcessCorner::Nominal, DcdcPowerProfile::High) => 1150,
-        (ProcessCorner::Fast, DcdcPowerProfile::Low) => 1000,
-        (ProcessCorner::Fast, DcdcPowerProfile::Medium) => 1025,
-        (ProcessCorner::Fast, DcdcPowerProfile::High) => 1050,
-    }
-}
-
-#[cfg(feature = "lpc55s16")]
-fn voltage_for_process(corner: ProcessCorner, profile: DcdcPowerProfile) -> u32 {
-    match (corner, profile) {
-        (ProcessCorner::Slow, DcdcPowerProfile::Low) => 1100,
-        (ProcessCorner::Slow, DcdcPowerProfile::Medium) => 1150,
-        (ProcessCorner::Slow, DcdcPowerProfile::High) => 1200,
-        (ProcessCorner::Nominal, DcdcPowerProfile::Low) => 1050,
-        (ProcessCorner::Nominal, DcdcPowerProfile::Medium) => 1075,
-        (ProcessCorner::Nominal, DcdcPowerProfile::High) => 1150,
-        (ProcessCorner::Fast, DcdcPowerProfile::Low) => 1000,
-        (ProcessCorner::Fast, DcdcPowerProfile::Medium) => 1025,
-        (ProcessCorner::Fast, DcdcPowerProfile::High) => 1050,
-    }
+    PROCESS_VOLTAGES_MV[corner as usize][profile as usize]
 }
 
 fn set_system_voltage(system_voltage_mv: u32) {
-    let (dcdc, ldo_ao, ldo_ao_boost) = if system_voltage_mv <= 950 {
-        (0, 10, 15)
-    } else if system_voltage_mv <= 975 {
-        (1, 12, 17)
-    } else if system_voltage_mv <= 1000 {
-        (2, 14, 19)
-    } else if system_voltage_mv <= 1025 {
-        (3, 17, 22)
-    } else if system_voltage_mv <= 1050 {
-        (4, 20, 25)
-    } else if system_voltage_mv <= 1075 {
-        (5, 22, 27)
-    } else if system_voltage_mv <= 1100 {
-        (6, 24, 29)
-    } else if system_voltage_mv <= 1125 {
-        (7, 27, 30)
-    } else if system_voltage_mv <= 1150 {
-        (8, 30, 31)
-    } else if system_voltage_mv <= 1175 {
-        (9, 30, 31)
-    } else {
-        (10, 30, 31)
-    };
+    let (_, dcdc, ldo_ao, ldo_ao_boost) = SYSTEM_VOLTAGE_REGISTERS
+        .iter()
+        .copied()
+        .find(|(max_mv, _, _, _)| system_voltage_mv <= *max_mv)
+        .expect("system voltage table must cover every u32 value");
 
     pac::PMC.ldopmu().modify(|w| {
         w.set_vadj(pac::pmc::vals::Vadj::from_bits(ldo_ao));

--- a/embassy-nxp/src/power.rs
+++ b/embassy-nxp/src/power.rs
@@ -1,0 +1,180 @@
+/*
+ * Copyright (c) 2016, Freescale Semiconductor, Inc.
+ * Copyright 2016, NXP
+ * All rights reserved.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+use core::ptr::read_volatile;
+
+use crate::pac;
+
+#[cfg(feature = "lpc55-core0")]
+const NMPA_BASE: usize = 0x0009_fc00;
+#[cfg(feature = "lpc55s16")]
+const NMPA_BASE: usize = 0x0003_fc00;
+const DCDC_PROFILE_LOW_0: usize = NMPA_BASE + 0xe0;
+const DCDC_PROFILE_LOW_1: usize = NMPA_BASE + 0xe4;
+const DCDC_PROFILE_MEDIUM_0: usize = NMPA_BASE + 0xe8;
+const DCDC_PROFILE_MEDIUM_1: usize = NMPA_BASE + 0xec;
+const DCDC_PROFILE_HIGH_0: usize = NMPA_BASE + 0xd8;
+const DCDC_PROFILE_HIGH_1: usize = NMPA_BASE + 0xdc;
+const PVT_MONITOR_0_RINGO: usize = NMPA_BASE + 0x130;
+const PVT_MONITOR_1_RINGO: usize = NMPA_BASE + 0x140;
+
+#[cfg(feature = "lpc55-core0")]
+const DCDC_PROFILE_LOW_MAX_HZ: u32 = 100_000_000;
+#[cfg(feature = "lpc55-core0")]
+const DCDC_PROFILE_MEDIUM_MAX_HZ: u32 = 130_000_000;
+#[cfg(feature = "lpc55s16")]
+const DCDC_PROFILE_LOW_MAX_HZ: u32 = 72_000_000;
+#[cfg(feature = "lpc55s16")]
+const DCDC_PROFILE_MEDIUM_MAX_HZ: u32 = 100_000_000;
+const DCDC_PROFILE_HIGH_MAX_HZ: u32 = 150_000_000;
+
+const PROCESS_NNN_AVG_HZ: u32 = 19_300_000;
+const PROCESS_NNN_STD_HZ: u32 = 400_000;
+const PROCESS_NNN_LIMITS: u32 = 6;
+const PROCESS_NNN_MIN_HZ: u32 = PROCESS_NNN_AVG_HZ - PROCESS_NNN_LIMITS * PROCESS_NNN_STD_HZ;
+const PROCESS_NNN_MAX_HZ: u32 = PROCESS_NNN_AVG_HZ + PROCESS_NNN_LIMITS * PROCESS_NNN_STD_HZ;
+
+#[derive(Clone, Copy)]
+enum DcdcPowerProfile {
+    Low,
+    Medium,
+    High,
+}
+
+#[derive(Clone, Copy)]
+enum ProcessCorner {
+    Slow,
+    Nominal,
+    Fast,
+}
+
+pub(crate) fn set_voltage_for_freq(system_freq_hz: u32) {
+    critical_section::with(|_| {
+        let profile = if system_freq_hz <= DCDC_PROFILE_LOW_MAX_HZ {
+            DcdcPowerProfile::Low
+        } else if system_freq_hz <= DCDC_PROFILE_MEDIUM_MAX_HZ {
+            DcdcPowerProfile::Medium
+        } else if system_freq_hz <= DCDC_PROFILE_HIGH_MAX_HZ {
+            DcdcPowerProfile::High
+        } else {
+            panic!(
+                "LPC55 frequency {} Hz exceeds the 150 MHz voltage profile",
+                system_freq_hz
+            );
+        };
+
+        set_dcdc_power_profile(profile);
+        set_voltage_for_process(profile);
+    });
+}
+
+fn set_dcdc_power_profile(profile: DcdcPowerProfile) {
+    let (trim_0_address, trim_1_address) = match profile {
+        DcdcPowerProfile::Low => (DCDC_PROFILE_LOW_0, DCDC_PROFILE_LOW_1),
+        DcdcPowerProfile::Medium => (DCDC_PROFILE_MEDIUM_0, DCDC_PROFILE_MEDIUM_1),
+        DcdcPowerProfile::High => (DCDC_PROFILE_HIGH_0, DCDC_PROFILE_HIGH_1),
+    };
+    let trim_0 = read_nmpa_word(trim_0_address);
+    let trim_1 = read_nmpa_word(trim_1_address);
+
+    if trim_0 & 1 != 0 {
+        pac::PMC.dcdc0().write_value(pac::pmc::regs::Dcdc0(trim_0 >> 1));
+        pac::PMC.dcdc1().write_value(pac::pmc::regs::Dcdc1(trim_1));
+    }
+}
+
+fn process_corner() -> ProcessCorner {
+    let ringo_0 = valid_ringo_or_nominal(read_nmpa_word(PVT_MONITOR_0_RINGO));
+    let ringo_1 = valid_ringo_or_nominal(read_nmpa_word(PVT_MONITOR_1_RINGO));
+    let ringo_hz = ringo_0.min(ringo_1);
+
+    if ringo_hz <= PROCESS_NNN_MIN_HZ {
+        ProcessCorner::Slow
+    } else if ringo_hz <= PROCESS_NNN_MAX_HZ {
+        ProcessCorner::Nominal
+    } else {
+        ProcessCorner::Fast
+    }
+}
+
+fn valid_ringo_or_nominal(trim: u32) -> u32 {
+    if trim & 1 != 0 { trim >> 1 } else { PROCESS_NNN_AVG_HZ }
+}
+
+fn set_voltage_for_process(profile: DcdcPowerProfile) {
+    set_system_voltage(voltage_for_process(process_corner(), profile));
+}
+
+#[cfg(feature = "lpc55-core0")]
+fn voltage_for_process(corner: ProcessCorner, profile: DcdcPowerProfile) -> u32 {
+    match (corner, profile) {
+        (ProcessCorner::Slow, DcdcPowerProfile::Low) => 1075,
+        (ProcessCorner::Slow, DcdcPowerProfile::Medium) => 1150,
+        (ProcessCorner::Slow, DcdcPowerProfile::High) => 1200,
+        (ProcessCorner::Nominal, DcdcPowerProfile::Low) => 1000,
+        (ProcessCorner::Nominal, DcdcPowerProfile::Medium) => 1100,
+        (ProcessCorner::Nominal, DcdcPowerProfile::High) => 1150,
+        (ProcessCorner::Fast, DcdcPowerProfile::Low) => 1000,
+        (ProcessCorner::Fast, DcdcPowerProfile::Medium) => 1025,
+        (ProcessCorner::Fast, DcdcPowerProfile::High) => 1050,
+    }
+}
+
+#[cfg(feature = "lpc55s16")]
+fn voltage_for_process(corner: ProcessCorner, profile: DcdcPowerProfile) -> u32 {
+    match (corner, profile) {
+        (ProcessCorner::Slow, DcdcPowerProfile::Low) => 1100,
+        (ProcessCorner::Slow, DcdcPowerProfile::Medium) => 1150,
+        (ProcessCorner::Slow, DcdcPowerProfile::High) => 1200,
+        (ProcessCorner::Nominal, DcdcPowerProfile::Low) => 1050,
+        (ProcessCorner::Nominal, DcdcPowerProfile::Medium) => 1075,
+        (ProcessCorner::Nominal, DcdcPowerProfile::High) => 1150,
+        (ProcessCorner::Fast, DcdcPowerProfile::Low) => 1000,
+        (ProcessCorner::Fast, DcdcPowerProfile::Medium) => 1025,
+        (ProcessCorner::Fast, DcdcPowerProfile::High) => 1050,
+    }
+}
+
+fn set_system_voltage(system_voltage_mv: u32) {
+    let (dcdc, ldo_ao, ldo_ao_boost) = if system_voltage_mv <= 950 {
+        (0, 10, 15)
+    } else if system_voltage_mv <= 975 {
+        (1, 12, 17)
+    } else if system_voltage_mv <= 1000 {
+        (2, 14, 19)
+    } else if system_voltage_mv <= 1025 {
+        (3, 17, 22)
+    } else if system_voltage_mv <= 1050 {
+        (4, 20, 25)
+    } else if system_voltage_mv <= 1075 {
+        (5, 22, 27)
+    } else if system_voltage_mv <= 1100 {
+        (6, 24, 29)
+    } else if system_voltage_mv <= 1125 {
+        (7, 27, 30)
+    } else if system_voltage_mv <= 1150 {
+        (8, 30, 31)
+    } else if system_voltage_mv <= 1175 {
+        (9, 30, 31)
+    } else {
+        (10, 30, 31)
+    };
+
+    pac::PMC.ldopmu().modify(|w| {
+        w.set_vadj(pac::pmc::vals::Vadj::from_bits(ldo_ao));
+        w.set_vadj_boost(ldo_ao_boost);
+    });
+    pac::PMC
+        .dcdc0()
+        .modify(|w| w.set_vout(pac::pmc::vals::Vout::from_bits(dcdc)));
+}
+
+fn read_nmpa_word(address: usize) -> u32 {
+    // SAFETY: These fixed, word-aligned addresses are documented NMPA words for the selected LPC55 device.
+    unsafe { read_volatile(address as *const u32) }
+}

--- a/embassy-nxp/src/usb.rs
+++ b/embassy-nxp/src/usb.rs
@@ -1,0 +1,5 @@
+//! Universal Serial Bus (USB) device driver.
+
+#[cfg_attr(lpc55, path = "./usb/lpc55.rs")]
+mod inner;
+pub use inner::*;

--- a/embassy-nxp/src/usb/lpc55.rs
+++ b/embassy-nxp/src/usb/lpc55.rs
@@ -41,6 +41,7 @@ const CMD_A: u32 = 1 << 31; // Active (HW clears on completion)
 const CMD_D: u32 = 1 << 30; // Disabled
 const CMD_S: u32 = 1 << 29; // Stall
 const CMD_TR: u32 = 1 << 28; // Toggle Reset (write-1)
+#[allow(dead_code)] // documented for completeness of the CS-word encoding
 const CMD_TV: u32 = 1 << 27; // RF/TV: data toggle value for bulk/interrupt
 const NBYTES_SHIFT: u32 = 11;
 const NBYTES_MASK: u32 = 0x7FFF;

--- a/embassy-nxp/src/usb/lpc55.rs
+++ b/embassy-nxp/src/usb/lpc55.rs
@@ -129,6 +129,10 @@ const EP0_IN_OFFSET: u32 = EP0_OUT_OFFSET + 64;
 const DATA_BUFFER_OFFSET: u32 = EP0_IN_OFFSET + 64;
 const SLOT_RECLAIM_SPINS: usize = 1_000_000;
 
+fn poll_bounded(iterations: usize, mut ready: impl FnMut() -> bool) -> bool {
+    (0..iterations).any(|_| ready())
+}
+
 // Endpoint command/status word encoding. The bit flags below are common to
 // both controllers; the NBytes and AddressOffset field positions differ and
 // live on `Instance`.
@@ -163,65 +167,106 @@ const PRIMED0: u8 = 1 << 1; // OUT slot armed or holding an unread packet (`PRIM
 const TR_PENDING: u8 = 1 << 3; // reset the data toggle on the next arm
 const ISO: u8 = 1 << 4; // isochronous endpoint; survives enable/stall/reset
 
+struct EndpointState {
+    wakers: [AtomicWaker; MAX_EP_COUNT],
+    state: [AtomicU8; MAX_EP_COUNT],
+    generation: [AtomicU32; MAX_EP_COUNT],
+}
+
+impl EndpointState {
+    const fn new() -> Self {
+        Self {
+            wakers: [const { AtomicWaker::new() }; MAX_EP_COUNT],
+            state: [const { AtomicU8::new(0) }; MAX_EP_COUNT],
+            generation: [const { AtomicU32::new(0) }; MAX_EP_COUNT],
+        }
+    }
+
+    fn wake_all(&self) {
+        for waker in &self.wakers {
+            waker.wake();
+        }
+    }
+}
+
+#[derive(Clone, Copy)]
+struct TransferGeneration {
+    lifecycle: u32,
+    endpoint: u32,
+}
+
+#[derive(Clone, Copy, PartialEq, Eq)]
+struct ControlGeneration {
+    lifecycle: u32,
+    out: u32,
+    in_: u32,
+}
+
 /// Shared driver state for one controller instance.
 pub(crate) struct State {
     bus_waker: AtomicWaker,
-    ep_in_wakers: [AtomicWaker; MAX_EP_COUNT],
-    ep_out_wakers: [AtomicWaker; MAX_EP_COUNT],
-    ep_in_state: [AtomicU8; MAX_EP_COUNT],
-    ep_out_state: [AtomicU8; MAX_EP_COUNT],
+    ep_in: EndpointState,
+    ep_out: EndpointState,
     alive: AtomicBool,
     setup_pending: AtomicBool,
     lifecycle_generation: AtomicU32,
-    ep_in_generation: [AtomicU32; MAX_EP_COUNT],
-    ep_out_generation: [AtomicU32; MAX_EP_COUNT],
 }
 
 impl State {
     const fn new() -> Self {
         Self {
             bus_waker: AtomicWaker::new(),
-            ep_in_wakers: [const { AtomicWaker::new() }; MAX_EP_COUNT],
-            ep_out_wakers: [const { AtomicWaker::new() }; MAX_EP_COUNT],
-            ep_in_state: [const { AtomicU8::new(0) }; MAX_EP_COUNT],
-            ep_out_state: [const { AtomicU8::new(0) }; MAX_EP_COUNT],
+            ep_in: EndpointState::new(),
+            ep_out: EndpointState::new(),
             alive: AtomicBool::new(false),
             setup_pending: AtomicBool::new(false),
             lifecycle_generation: AtomicU32::new(0),
-            ep_in_generation: [const { AtomicU32::new(0) }; MAX_EP_COUNT],
-            ep_out_generation: [const { AtomicU32::new(0) }; MAX_EP_COUNT],
+        }
+    }
+
+    fn endpoint(&self, dir: Direction) -> &EndpointState {
+        match dir {
+            Direction::Out => &self.ep_out,
+            Direction::In => &self.ep_in,
         }
     }
 
     fn ep_state(&self, index: usize, dir: Direction) -> &AtomicU8 {
-        match dir {
-            Direction::Out => &self.ep_out_state[index],
-            Direction::In => &self.ep_in_state[index],
-        }
+        &self.endpoint(dir).state[index]
     }
 
     fn ep_waker(&self, index: usize, dir: Direction) -> &AtomicWaker {
-        match dir {
-            Direction::Out => &self.ep_out_wakers[index],
-            Direction::In => &self.ep_in_wakers[index],
-        }
+        &self.endpoint(dir).wakers[index]
     }
 
     fn ep_generation(&self, index: usize, dir: Direction) -> &AtomicU32 {
-        match dir {
-            Direction::Out => &self.ep_out_generation[index],
-            Direction::In => &self.ep_in_generation[index],
+        &self.endpoint(dir).generation[index]
+    }
+
+    fn transfer_generation(&self, index: usize, dir: Direction) -> TransferGeneration {
+        TransferGeneration {
+            lifecycle: self.lifecycle_generation.load(Ordering::Relaxed),
+            endpoint: self.ep_generation(index, dir).load(Ordering::Relaxed),
+        }
+    }
+
+    fn transfer_generation_valid(&self, index: usize, dir: Direction, generation: TransferGeneration) -> bool {
+        generation.lifecycle == self.lifecycle_generation.load(Ordering::Relaxed)
+            && generation.endpoint == self.ep_generation(index, dir).load(Ordering::Relaxed)
+    }
+
+    fn control_generation(&self) -> ControlGeneration {
+        ControlGeneration {
+            lifecycle: self.lifecycle_generation.load(Ordering::Relaxed),
+            out: self.ep_generation(0, Direction::Out).load(Ordering::Relaxed),
+            in_: self.ep_generation(0, Direction::In).load(Ordering::Relaxed),
         }
     }
 
     fn wake_all(&self) {
         self.bus_waker.wake();
-        for waker in &self.ep_in_wakers {
-            waker.wake();
-        }
-        for waker in &self.ep_out_wakers {
-            waker.wake();
-        }
+        self.ep_in.wake_all();
+        self.ep_out.wake_all();
     }
 
     fn invalidate_controller(&self) {
@@ -237,10 +282,10 @@ impl State {
 
     fn note_setup(&self) {
         if !self.setup_pending.swap(true, Ordering::AcqRel) {
-            self.ep_out_generation[0].fetch_add(1, Ordering::Relaxed);
-            self.ep_in_generation[0].fetch_add(1, Ordering::Relaxed);
-            self.ep_out_wakers[0].wake();
-            self.ep_in_wakers[0].wake();
+            self.ep_generation(0, Direction::Out).fetch_add(1, Ordering::Relaxed);
+            self.ep_generation(0, Direction::In).fetch_add(1, Ordering::Relaxed);
+            self.ep_waker(0, Direction::Out).wake();
+            self.ep_waker(0, Direction::In).wake();
         }
     }
 }
@@ -272,33 +317,118 @@ fn ep_int_mask<T: Instance>() -> u16 {
     ((1u32 << (2 * T::EP_COUNT)) - 1) as u16
 }
 
-/// Pointer to the command/status word of a physical endpoint buffer slot.
-fn ep_cmd_ptr(ep_list: u32, index: usize, dir: Direction, buf1: bool) -> *mut u32 {
-    let slot = match dir {
-        Direction::Out => 0,
-        Direction::In => 2,
-    } + buf1 as usize;
-    (ep_list as usize + index * 16 + slot * 4) as *mut u32
+/// Volatile command/status word for one physical endpoint buffer slot.
+#[derive(Clone, Copy)]
+struct EndpointCommand(*mut u32);
+
+impl EndpointCommand {
+    fn new(ep_list: u32, index: usize, dir: Direction, slot: usize) -> Self {
+        let direction = match dir {
+            Direction::Out => 0,
+            Direction::In => 2,
+        };
+        Self((ep_list as usize + index * 16 + (direction + slot) * 4) as *mut u32)
+    }
+
+    fn read(self) -> u32 {
+        unsafe { self.0.read_volatile() }
+    }
+
+    fn write(self, word: u32) {
+        unsafe { self.0.write_volatile(word) }
+    }
+
+    fn modify(self, f: impl FnOnce(u32) -> u32) {
+        critical_section::with(|_| self.write(f(self.read())));
+    }
+
+    /// Arms one buffer slot of a data endpoint.
+    ///
+    /// The command word is written whole: the controller tracks the
+    /// bulk/interrupt data toggle internally per endpoint (read-only EPTOGGLE
+    /// register), not in the entry's TV bit, which is only consumed together
+    /// with TR. `tr` requests that toggle reset; it is set exactly once for the
+    /// first transfer after enable/unstall (the NXP SDK's deferred toggle-reset
+    /// discipline).
+    ///
+    /// Isochronous endpoints are marked with `T` and never get `TR`: they have
+    /// no data toggle to reset.
+    fn arm<T: Instance>(self, len: u32, buf_addr: u32, tr: bool, iso: bool) {
+        let flags = if iso {
+            CMD_T
+        } else if tr {
+            CMD_TR
+        } else {
+            0
+        };
+        self.write(CMD_A | nbytes::<T>(len) | addroff::<T>(buf_addr) | flags);
+    }
 }
 
-fn ep_cmd_read(ep_list: u32, index: usize, dir: Direction, slot: usize) -> u32 {
-    unsafe { ep_cmd_ptr(ep_list, index, dir, slot != 0).read_volatile() }
+/// Fixed command-list and endpoint-zero buffer addresses.
+#[derive(Clone, Copy)]
+struct EndpointLayout {
+    list: u32,
+    setup: u32,
+    out: u32,
+    in_: u32,
 }
 
-fn ep_cmd_write(ep_list: u32, index: usize, dir: Direction, slot: usize, word: u32) {
-    unsafe { ep_cmd_ptr(ep_list, index, dir, slot != 0).write_volatile(word) }
+impl EndpointLayout {
+    fn new(base: u32) -> Self {
+        Self {
+            list: base,
+            setup: base + EP0_SETUP_OFFSET,
+            out: base + EP0_OUT_OFFSET,
+            in_: base + EP0_IN_OFFSET,
+        }
+    }
+
+    fn command(self, index: usize, dir: Direction, slot: usize) -> EndpointCommand {
+        EndpointCommand::new(self.list, index, dir, slot)
+    }
 }
 
-fn ep_cmd_modify(ep_list: u32, index: usize, dir: Direction, slot: usize, f: impl FnOnce(u32) -> u32) {
-    critical_section::with(|_| {
-        let p = ep_cmd_ptr(ep_list, index, dir, slot != 0);
-        unsafe { p.write_volatile(f(p.read_volatile())) }
-    });
+/// Waits for a slot to become inactive after registering its interrupt waker.
+///
+/// `validate` rechecks the transfer generation and software-selected slot
+/// inside the same critical section as the hardware command word.
+async fn wait_slot<T: Instance, R>(
+    command: EndpointCommand,
+    index: usize,
+    dir: Direction,
+    mut validate: impl FnMut() -> Result<R, EndpointError>,
+) -> Result<(u32, R), EndpointError> {
+    poll_fn(|cx| {
+        let shared = T::state();
+        shared.ep_waker(index, dir).register(cx.waker());
+
+        critical_section::with(|_| {
+            if !shared.alive.load(Ordering::Acquire) {
+                return Poll::Ready(Err(EndpointError::Disabled));
+            }
+            let value = match validate() {
+                Ok(value) => value,
+                Err(error) => return Poll::Ready(Err(error)),
+            };
+            let word = command.read();
+            if word & CMD_UNUSABLE != 0 {
+                Poll::Ready(Err(EndpointError::Disabled))
+            } else if word & CMD_A == 0 {
+                Poll::Ready(Ok((word, value)))
+            } else {
+                Poll::Pending
+            }
+        })
+    })
+    .await
 }
 fn valid_endpoint<T: Instance>(ep_addr: EndpointAddress) -> Option<(usize, Direction)> {
     let index = ep_addr.index();
     (index < T::EP_COUNT).then_some((index, ep_addr.direction()))
 }
+
+const DIRECTIONS: [Direction; 2] = [Direction::Out, Direction::In];
 
 fn select_slot<T: Instance>(index: usize, dir: Direction, slot: usize) {
     if index == 0 {
@@ -315,16 +445,16 @@ fn reclaim_slot<T: Instance>(ep_list: u32, index: usize, dir: Direction, slot: u
     let regs = T::regs();
     let phy_ep = 2 * index + (dir == Direction::In) as usize;
     select_slot::<T>(index, dir, slot);
-    if ep_cmd_read(ep_list, index, dir, slot) & CMD_A == 0 {
+    if EndpointCommand::new(ep_list, index, dir, slot).read() & CMD_A == 0 {
         return;
     }
 
     let mask = 1 << phy_ep;
     regs.epskip().write_value(pac::usbhsd::regs::Epskip(mask));
-    for _ in 0..SLOT_RECLAIM_SPINS {
-        if regs.epskip().read().0 & mask == 0 && ep_cmd_read(ep_list, index, dir, slot) & CMD_A == 0 {
-            return;
-        }
+    if poll_bounded(SLOT_RECLAIM_SPINS, || {
+        regs.epskip().read().0 & mask == 0 && EndpointCommand::new(ep_list, index, dir, slot).read() & CMD_A == 0
+    }) {
+        return;
     }
 
     let direction = if dir == Direction::In { "IN" } else { "OUT" };
@@ -333,7 +463,7 @@ fn reclaim_slot<T: Instance>(ep_list: u32, index: usize, dir: Direction, slot: u
         index,
         direction,
         slot,
-        ep_cmd_read(ep_list, index, dir, slot),
+        EndpointCommand::new(ep_list, index, dir, slot).read(),
         regs.epskip().read().0,
         regs.epinuse().read().0,
         regs.devcmdstat().read().0
@@ -355,40 +485,11 @@ fn reclaim_slots<T: Instance>(ep_list: u32, index: usize, dir: Direction) {
     select_slot::<T>(index, dir, 0);
 }
 
-/// Arm one buffer slot of a data endpoint.
-///
-/// The command word is written whole: the controller tracks the bulk/interrupt
-/// data toggle internally per endpoint (read-only EPTOGGLE register), not in
-/// the entry's TV bit, which is only consumed together with TR. `tr` requests
-/// that toggle reset; it is set exactly once for the first transfer after
-/// enable/unstall (the NXP SDK's deferred toggle-reset discipline).
-///
-/// Isochronous endpoints are marked with `T` and never get `TR`: they have no
-/// data toggle to reset.
-fn ep_arm_slot<T: Instance>(
-    ep_list: u32,
-    index: usize,
-    dir: Direction,
-    slot: usize,
-    len: u32,
-    buf_addr: u32,
-    tr: bool,
-    iso: bool,
-) {
-    let flags = if iso {
-        CMD_T
-    } else if tr {
-        CMD_TR
-    } else {
-        0
-    };
-    ep_cmd_write(
-        ep_list,
-        index,
-        dir,
-        slot,
-        CMD_A | nbytes::<T>(len) | addroff::<T>(buf_addr) | flags,
-    );
+fn reset_endpoint<T: Instance>(ep_list: u32, index: usize, dir: Direction) {
+    EndpointCommand::new(ep_list, index, dir, 0).write(CMD_D);
+    EndpointCommand::new(ep_list, index, dir, 1).write(CMD_D);
+    let state = T::state().ep_state(index, dir);
+    state.store(state.load(Ordering::Relaxed) & ISO, Ordering::Relaxed);
 }
 
 /// Copy into endpoint buffer memory using 32-bit accesses.
@@ -591,8 +692,7 @@ impl SealedInstance for crate::peripherals::USBHSD {
         // write sticks (it is silently dropped while the block is still
         // completing its reset). Use absolute writes: a read-modify-write on
         // the still-resetting block would write garbage read values back.
-        let mut handed_over = false;
-        for _ in 0..10_000 {
+        let handed_over = poll_bounded(10_000, || {
             let mut pm = pac::usbhsh::regs::Portmode(0);
             pm.set_dev_enable(true);
             // Keep the PHY power-down input (PDCOM) under software control
@@ -600,11 +700,8 @@ impl SealedInstance for crate::peripherals::USBHSD {
             // clock-gated host block, it powers the PHY down.
             pm.set_sw_ctrl_pdcom(true);
             pac::USBHSH.portmode().write_value(pm);
-            if pac::USBHSH.portmode().read().dev_enable() {
-                handed_over = true;
-                break;
-            }
-        }
+            pac::USBHSH.portmode().read().dev_enable()
+        });
         if !handed_over {
             warn!("USB1 port handover to device controller failed");
         }
@@ -652,13 +749,9 @@ impl SealedInstance for crate::peripherals::USBHSD {
         });
         // Bounded wait for PLL lock (~100 ms worth); carry on regardless, the
         // device simply won't enumerate if the PLL never locks.
-        let mut locked = false;
-        for _ in 0..1_000_000 {
-            if phy.pll_sic().read().pll_lock() == pac::usbphy::vals::PllSicPllLock::Value1 {
-                locked = true;
-                break;
-            }
-        }
+        let locked = poll_bounded(1_000_000, || {
+            phy.pll_sic().read().pll_lock() == pac::usbphy::vals::PllSicPllLock::Value1
+        });
         if !locked {
             warn!("USB1 PHY PLL failed to lock");
         }
@@ -759,13 +852,9 @@ impl SealedInstance for crate::peripherals::USB0 {
         pac::SYSCON.usb0clkdiv().modify(|w| w.set_div(1));
         pac::SYSCON.usb0clkdiv().modify(|w| w.set_halt(Usb0clkdivHalt::Run));
         pac::SYSCON.usb0clksel().write(|w| w.set_sel(Usb0clkselSel::Enum0x3));
-        let mut stable = false;
-        for _ in 0..1_000_000 {
-            if pac::SYSCON.usb0clkdiv().read().reqflag() == Usb0clkdivReqflag::Stable {
-                stable = true;
-                break;
-            }
-        }
+        let stable = poll_bounded(1_000_000, || {
+            pac::SYSCON.usb0clkdiv().read().reqflag() == Usb0clkdivReqflag::Stable
+        });
         if !stable {
             warn!("USB0 clock divider did not stabilize");
         }
@@ -801,13 +890,7 @@ impl SealedInstance for crate::peripherals::USB0 {
         // which is what makes crystal-less FS operation viable. Not functional
         // through more than one hub — erratum USB.3, see the module docs.
         pac::ANACTRL.fro192m_ctrl().modify(|w| w.set_usbclkadj(true));
-        let mut adjusted = false;
-        for _ in 0..1_000_000 {
-            if !pac::ANACTRL.fro192m_ctrl().read().usbmodchg() {
-                adjusted = true;
-                break;
-            }
-        }
+        let adjusted = poll_bounded(1_000_000, || !pac::ANACTRL.fro192m_ctrl().read().usbmodchg());
         if !adjusted {
             warn!("USB0 FRO clock adjustment did not settle");
         }
@@ -1032,10 +1115,10 @@ impl<T: Instance> crate::interrupt::typelevel::Handler<T::Interrupt> for Interru
 
         for i in 0..T::EP_COUNT {
             if stat.0 & (1 << (2 * i)) != 0 {
-                state.ep_out_wakers[i].wake();
+                state.ep_waker(i, Direction::Out).wake();
             }
             if stat.0 & (1 << (2 * i + 1)) != 0 {
-                state.ep_in_wakers[i].wake();
+                state.ep_waker(i, Direction::In).wake();
             }
         }
 
@@ -1063,10 +1146,9 @@ fn shutdown_controller<T: Instance>(ep_list: u32) {
             w.set_dev_en(false);
         });
         for index in 0..T::EP_COUNT {
-            for dir in [Direction::Out, Direction::In] {
+            for dir in DIRECTIONS {
                 reclaim_slots::<T>(ep_list, index, dir);
-                ep_cmd_write(ep_list, index, dir, 0, CMD_D);
-                ep_cmd_write(ep_list, index, dir, 1, CMD_D);
+                reset_endpoint::<T>(ep_list, index, dir);
             }
         }
         regs.inten().write_value(pac::usbhsd::regs::Inten(0));
@@ -1087,16 +1169,12 @@ pub struct Driver<'d, T: Instance> {
     memory: Option<MemoryLease<'d>>,
     ep_in_used: [bool; MAX_EP_COUNT],
     ep_out_used: [bool; MAX_EP_COUNT],
-    /// Base of the endpoint memory: the command/status list starts here.
-    ep_list: u32,
+    /// Command list and fixed endpoint-zero buffers.
+    layout: EndpointLayout,
     /// One past the end of the endpoint memory.
     mem_end: u32,
-    /// Bump allocator offset, relative to `ep_list`.
+    /// Bump allocator offset, relative to `layout.list`.
     alloc_offset: u32,
-    /// Address of the 8-byte (64-byte aligned) SETUP buffer.
-    setup_addr: u32,
-    ep0_out_addr: u32,
-    ep0_in_addr: u32,
 }
 
 impl<'d> Driver<'d, crate::peripherals::USBHSD> {
@@ -1177,21 +1255,19 @@ impl<'d, T: Instance> Driver<'d, T> {
         for i in 0..T::EP_COUNT * 4 {
             unsafe { ((base as usize + i * 4) as *mut u32).write_volatile(0) };
         }
-        let setup_addr = base + EP0_SETUP_OFFSET;
-        let ep0_out_addr = base + EP0_OUT_OFFSET;
-        let ep0_in_addr = base + EP0_IN_OFFSET;
+        let layout = EndpointLayout::new(base);
         unsafe {
-            (setup_addr as *mut u32).write_volatile(0);
-            (setup_addr as *mut u32).add(1).write_volatile(0);
-            ep_cmd_ptr(base, 0, Direction::Out, true).write_volatile(addroff::<T>(setup_addr));
+            (layout.setup as *mut u32).write_volatile(0);
+            (layout.setup as *mut u32).add(1).write_volatile(0);
+            layout.command(0, Direction::Out, 1).write(addroff::<T>(layout.setup));
         }
 
-        program_controller::<T>(base);
+        program_controller::<T>(layout.list);
         let state = T::state();
         state.invalidate_controller();
         for index in 0..T::EP_COUNT {
-            state.ep_in_state[index].store(0, Ordering::Relaxed);
-            state.ep_out_state[index].store(0, Ordering::Relaxed);
+            state.ep_state(index, Direction::In).store(0, Ordering::Relaxed);
+            state.ep_state(index, Direction::Out).store(0, Ordering::Relaxed);
         }
         state.alive.store(true, Ordering::Release);
 
@@ -1204,12 +1280,9 @@ impl<'d, T: Instance> Driver<'d, T> {
             memory: Some(lease),
             ep_in_used: [false; MAX_EP_COUNT],
             ep_out_used: [false; MAX_EP_COUNT],
-            ep_list: base,
+            layout,
             mem_end: base + len,
             alloc_offset: DATA_BUFFER_OFFSET,
-            setup_addr,
-            ep0_out_addr,
-            ep0_in_addr,
         }
     }
 
@@ -1221,13 +1294,26 @@ impl<'d, T: Instance> Driver<'d, T> {
     /// overrun inside the allocation. Do not tighten it.
     fn alloc_buffer(&mut self, len: u16) -> Result<u32, EndpointAllocError> {
         let len = (len as u32).div_ceil(64) * 64;
-        if self.ep_list + self.alloc_offset + len > self.mem_end {
+        if self.layout.list + self.alloc_offset + len > self.mem_end {
             warn!("USB endpoint memory full");
             return Err(EndpointAllocError);
         }
-        let addr = self.ep_list + self.alloc_offset;
+        let addr = self.layout.list + self.alloc_offset;
         self.alloc_offset += len;
         Ok(addr)
+    }
+
+    /// Allocates both slots atomically with respect to the bump pointer.
+    fn alloc_slots(&mut self, len: u16) -> Result<[u32; 2], EndpointAllocError> {
+        let mark = self.alloc_offset;
+        let result = match self.alloc_buffer(len) {
+            Ok(first) => self.alloc_buffer(len).map(|second| [first, second]),
+            Err(error) => Err(error),
+        };
+        if result.is_err() {
+            self.alloc_offset = mark;
+        }
+        result
     }
 
     fn alloc_endpoint<D: Dir>(
@@ -1289,25 +1375,13 @@ impl<'d, T: Instance> Driver<'d, T> {
             (EndpointType::Bulk, Direction::In) if T::MULTI_PACKET => T::BULK_IN_SLOT_LEN.max(max_packet_size),
             _ => max_packet_size,
         };
-        // Every failure path restores the bump allocator, so a rejected
-        // allocation consumes neither memory nor an endpoint index.
-        let mark = self.alloc_offset;
-        let (buf_addrs, slot_len) = match (self.alloc_buffer(want_len), self.alloc_buffer(want_len)) {
-            (Ok(a), Ok(b)) => ([a, b], want_len),
-            _ => {
-                self.alloc_offset = mark;
-                if want_len <= max_packet_size {
-                    return Err(EndpointAllocError);
-                }
+        let (buf_addrs, slot_len) = match self.alloc_slots(want_len) {
+            Ok(addrs) => (addrs, want_len),
+            Err(_) if want_len > max_packet_size => {
                 // The multi-packet slots did not fit; single-packet slots may.
-                match (self.alloc_buffer(max_packet_size), self.alloc_buffer(max_packet_size)) {
-                    (Ok(a), Ok(b)) => ([a, b], max_packet_size),
-                    _ => {
-                        self.alloc_offset = mark;
-                        return Err(EndpointAllocError);
-                    }
-                }
+                (self.alloc_slots(max_packet_size)?, max_packet_size)
             }
+            Err(error) => return Err(error),
         };
 
         // Only now that the allocation succeeded does the index get consumed:
@@ -1325,8 +1399,8 @@ impl<'d, T: Instance> Driver<'d, T> {
             .store(if iso { ISO } else { 0 }, Ordering::Relaxed);
 
         // Disabled until `endpoint_set_enabled`.
-        ep_cmd_write(self.ep_list, index, D::dir(), 0, CMD_D);
-        ep_cmd_write(self.ep_list, index, D::dir(), 1, CMD_D);
+        self.layout.command(index, D::dir(), 0).write(CMD_D);
+        self.layout.command(index, D::dir(), 1).write(CMD_D);
 
         trace!("  index={} addr={:08x}", index, buf_addrs[0]);
 
@@ -1338,7 +1412,7 @@ impl<'d, T: Instance> Driver<'d, T> {
                 max_packet_size,
                 interval_ms,
             },
-            ep_list: self.ep_list,
+            ep_list: self.layout.list,
             buf_addrs,
             slot_len,
             armed_len: [0; 2],
@@ -1349,7 +1423,7 @@ impl<'d, T: Instance> Driver<'d, T> {
 impl<'d, T: Instance> Drop for Driver<'d, T> {
     fn drop(&mut self) {
         if self._usb.is_some() {
-            shutdown_controller::<T>(self.ep_list);
+            shutdown_controller::<T>(self.layout.list);
         }
         drop(self.memory.take());
     }
@@ -1383,9 +1457,7 @@ impl<'d, T: Instance> driver::Driver<'d> for Driver<'d, T> {
 
     fn start(mut self, control_max_packet_size: u16) -> (Self::Bus, Self::ControlPipe) {
         assert!(control_max_packet_size <= 64);
-        let ep_list = self.ep_list;
-        let ep0_out_addr = self.ep0_out_addr;
-        let ep0_in_addr = self.ep0_in_addr;
+        let layout = self.layout;
         let Some(usb) = self._usb.take() else {
             unreachable!("USB peripheral token missing at start");
         };
@@ -1397,14 +1469,10 @@ impl<'d, T: Instance> driver::Driver<'d> for Driver<'d, T> {
         let control_memory = memory.clone_lease();
 
         critical_section::with(|_| {
-            ep_cmd_write(
-                ep_list,
-                0,
-                Direction::Out,
-                0,
-                CMD_A | nbytes::<T>(control_max_packet_size as u32) | addroff::<T>(ep0_out_addr),
-            );
-            ep_cmd_write(ep_list, 0, Direction::In, 0, addroff::<T>(ep0_in_addr));
+            layout
+                .command(0, Direction::Out, 0)
+                .arm::<T>(control_max_packet_size as u32, layout.out, false, false);
+            layout.command(0, Direction::In, 0).write(addroff::<T>(layout.in_));
             let vbus = T::regs().devcmdstat().read().vbus_debounced();
             devcmdstat_modify(T::regs(), |w| {
                 w.set_dev_en(true);
@@ -1421,23 +1489,15 @@ impl<'d, T: Instance> driver::Driver<'d> for Driver<'d, T> {
                 memory: Some(bus_memory),
                 vbus: false,
                 needs_reset: false,
-                ep_list,
-                setup_addr: self.setup_addr,
-                ep0_out_addr,
+                layout,
                 ep0_mps: control_max_packet_size,
             },
             ControlPipe {
                 _phantom: PhantomData,
                 _memory: control_memory,
                 max_packet_size: control_max_packet_size,
-                ep_list,
-                setup_addr: self.setup_addr,
-                ep0_out_addr,
-                ep0_in_addr,
-                accepted_lifecycle: 0,
-                accepted_out_generation: 0,
-                accepted_in_generation: 0,
-                setup_valid: false,
+                layout,
+                accepted_generation: None,
             },
         )
     }
@@ -1450,9 +1510,7 @@ pub struct Bus<'d, T: Instance> {
     memory: Option<MemoryLease<'d>>,
     vbus: bool,
     needs_reset: bool,
-    ep_list: u32,
-    setup_addr: u32,
-    ep0_out_addr: u32,
+    layout: EndpointLayout,
     ep0_mps: u16,
 }
 
@@ -1463,46 +1521,35 @@ impl<'d, T: Instance> Bus<'d, T> {
             let state = T::state();
             state.invalidate_controller();
 
-            state.ep_out_state[0].store(0, Ordering::Relaxed);
-            state.ep_in_state[0].store(0, Ordering::Relaxed);
+            state.ep_state(0, Direction::Out).store(0, Ordering::Relaxed);
+            state.ep_state(0, Direction::In).store(0, Ordering::Relaxed);
             for index in 0..T::EP_COUNT {
-                for dir in [Direction::Out, Direction::In] {
-                    reclaim_slots::<T>(self.ep_list, index, dir);
+                for dir in DIRECTIONS {
+                    reclaim_slots::<T>(self.layout.list, index, dir);
                 }
             }
             for index in 1..T::EP_COUNT {
-                for dir in [Direction::Out, Direction::In] {
-                    ep_cmd_write(self.ep_list, index, dir, 0, CMD_D);
-                    ep_cmd_write(self.ep_list, index, dir, 1, CMD_D);
-                    let ep_state = state.ep_state(index, dir);
-                    ep_state.store(ep_state.load(Ordering::Relaxed) & ISO, Ordering::Relaxed);
+                for dir in DIRECTIONS {
+                    reset_endpoint::<T>(self.layout.list, index, dir);
                 }
             }
             regs.epinuse().write(|w| w.set_buf(0));
             regs.epbufcfg().write(|w| w.set_buf_sb(ep_buf_mask::<T>()));
-            ep_cmd_write(
-                self.ep_list,
-                0,
-                Direction::Out,
-                0,
-                CMD_A | nbytes::<T>(self.ep0_mps as u32) | addroff::<T>(self.ep0_out_addr),
-            );
-            ep_cmd_write(self.ep_list, 0, Direction::In, 0, 0);
-            unsafe {
-                ep_cmd_ptr(self.ep_list, 0, Direction::Out, true).write_volatile(addroff::<T>(self.setup_addr));
-            }
+            self.layout
+                .command(0, Direction::Out, 0)
+                .arm::<T>(self.ep0_mps as u32, self.layout.out, false, false);
+            self.layout.command(0, Direction::In, 0).write(0);
+            self.layout
+                .command(0, Direction::Out, 1)
+                .write(addroff::<T>(self.layout.setup));
         });
     }
 
     fn disable_data_endpoints(&mut self) {
-        let state = T::state();
         for index in 1..T::EP_COUNT {
-            for dir in [Direction::Out, Direction::In] {
-                reclaim_slots::<T>(self.ep_list, index, dir);
-                ep_cmd_write(self.ep_list, index, dir, 0, CMD_D);
-                ep_cmd_write(self.ep_list, index, dir, 1, CMD_D);
-                let ep_state = state.ep_state(index, dir);
-                ep_state.store(ep_state.load(Ordering::Relaxed) & ISO, Ordering::Relaxed);
+            for dir in DIRECTIONS {
+                reclaim_slots::<T>(self.layout.list, index, dir);
+                reset_endpoint::<T>(self.layout.list, index, dir);
             }
         }
     }
@@ -1511,7 +1558,7 @@ impl<'d, T: Instance> Bus<'d, T> {
         if self._usb.is_none() {
             return;
         }
-        shutdown_controller::<T>(self.ep_list);
+        shutdown_controller::<T>(self.layout.list);
         drop(self.memory.take());
         self._usb.take();
         self._vbus.take();
@@ -1536,11 +1583,11 @@ impl<'d, T: Instance> driver::Bus for Bus<'d, T> {
             // the first enable would cancel the request that waits for reset.
             if self.needs_reset {
                 for index in 0..T::EP_COUNT {
-                    for dir in [Direction::Out, Direction::In] {
-                        reclaim_slots::<T>(self.ep_list, index, dir);
+                    for dir in DIRECTIONS {
+                        reclaim_slots::<T>(self.layout.list, index, dir);
                     }
                 }
-                program_controller::<T>(self.ep_list);
+                program_controller::<T>(self.layout.list);
                 self.reset_endpoints();
                 self.needs_reset = false;
             }
@@ -1643,18 +1690,18 @@ impl<'d, T: Instance> driver::Bus for Bus<'d, T> {
             let shared = T::state();
             let state = shared.ep_state(index, dir);
             let iso = state.load(Ordering::Relaxed) & ISO;
-            reclaim_slots::<T>(self.ep_list, index, dir);
+            reclaim_slots::<T>(self.layout.list, index, dir);
             shared.invalidate_endpoint(index, dir);
 
             if enabled {
-                ep_cmd_write(self.ep_list, index, dir, 0, if iso != 0 { 0 } else { CMD_TR });
-                ep_cmd_write(self.ep_list, index, dir, 1, 0);
+                self.layout
+                    .command(index, dir, 0)
+                    .write(if iso != 0 { 0 } else { CMD_TR });
+                self.layout.command(index, dir, 1).write(0);
                 select_slot::<T>(index, dir, 0);
                 state.store(iso | if iso == 0 { TR_PENDING } else { 0 }, Ordering::Relaxed);
             } else {
-                ep_cmd_write(self.ep_list, index, dir, 0, CMD_D);
-                ep_cmd_write(self.ep_list, index, dir, 1, CMD_D);
-                state.store(iso, Ordering::Relaxed);
+                reset_endpoint::<T>(self.layout.list, index, dir);
             }
         });
     }
@@ -1668,25 +1715,25 @@ impl<'d, T: Instance> driver::Bus for Bus<'d, T> {
         critical_section::with(|_| {
             let shared = T::state();
             let iso = index != 0 && shared.ep_state(index, dir).load(Ordering::Relaxed) & ISO != 0;
-            reclaim_slots::<T>(self.ep_list, index, dir);
+            reclaim_slots::<T>(self.layout.list, index, dir);
             shared.invalidate_endpoint(index, dir);
 
             if stalled {
                 if iso {
-                    ep_cmd_write(self.ep_list, index, dir, 0, 0);
-                    ep_cmd_write(self.ep_list, index, dir, 1, 0);
+                    self.layout.command(index, dir, 0).write(0);
+                    self.layout.command(index, dir, 1).write(0);
                     shared.ep_state(index, dir).store(ISO, Ordering::Relaxed);
                 } else {
-                    ep_cmd_write(self.ep_list, index, dir, 0, CMD_S);
+                    self.layout.command(index, dir, 0).write(CMD_S);
                     if index != 0 {
-                        ep_cmd_write(self.ep_list, index, dir, 1, CMD_S);
+                        self.layout.command(index, dir, 1).write(CMD_S);
                     }
                 }
             } else if index == 0 {
-                ep_cmd_write(self.ep_list, index, dir, 0, CMD_TR);
+                self.layout.command(index, dir, 0).write(CMD_TR);
             } else {
-                ep_cmd_write(self.ep_list, index, dir, 0, if iso { 0 } else { CMD_TR });
-                ep_cmd_write(self.ep_list, index, dir, 1, 0);
+                self.layout.command(index, dir, 0).write(if iso { 0 } else { CMD_TR });
+                self.layout.command(index, dir, 1).write(0);
                 let state = shared.ep_state(index, dir);
                 let keep = state.load(Ordering::Relaxed) & ISO;
                 state.store(keep | if keep == 0 { TR_PENDING } else { 0 }, Ordering::Relaxed);
@@ -1699,7 +1746,7 @@ impl<'d, T: Instance> driver::Bus for Bus<'d, T> {
             return false;
         };
         critical_section::with(|_| {
-            T::state().alive.load(Ordering::Acquire) && ep_cmd_read(self.ep_list, index, dir, 0) & CMD_S != 0
+            T::state().alive.load(Ordering::Acquire) && self.layout.command(index, dir, 0).read() & CMD_S != 0
         })
     }
 
@@ -1741,6 +1788,20 @@ impl<'d, T: Instance, D: Dir> Endpoint<'d, T, D> {
     fn is_iso(&self) -> bool {
         self.info.ep_type == EndpointType::Isochronous
     }
+
+    fn command(&self, slot: usize) -> EndpointCommand {
+        EndpointCommand::new(self.ep_list, self.info.addr.index(), D::dir(), slot)
+    }
+
+    fn read_slot(&self, slot: usize) -> u32 {
+        self.command(slot).read()
+    }
+
+    fn arm_slot(&mut self, slot: usize, len: u32, tr: bool) {
+        self.command(slot)
+            .arm::<T>(len, self.buf_addrs[slot], tr, self.is_iso());
+        self.armed_len[slot] = len as u16;
+    }
 }
 
 impl<'d, T: Instance, D: Dir> driver::Endpoint for Endpoint<'d, T, D> {
@@ -1757,7 +1818,7 @@ impl<'d, T: Instance, D: Dir> driver::Endpoint for Endpoint<'d, T, D> {
                 if !shared.alive.load(Ordering::Acquire) {
                     return Poll::Pending;
                 }
-                if ep_cmd_read(self.ep_list, index, D::dir(), 0) & CMD_D == 0 {
+                if self.read_slot(0) & CMD_D == 0 {
                     Poll::Ready(())
                 } else {
                     Poll::Pending
@@ -1785,68 +1846,40 @@ impl<'d, T: Instance> driver::EndpointOut for Endpoint<'d, T, Out> {
         let arm_len = self.info.max_packet_size as u32;
         let shared = T::state();
         let state = shared.ep_state(index, Direction::Out);
-        let iso = self.is_iso();
 
         let s = critical_section::with(|_| {
             if !shared.alive.load(Ordering::Acquire) {
                 return Err(EndpointError::Disabled);
             }
-            let lifecycle = shared.lifecycle_generation.load(Ordering::Relaxed);
-            let generation = shared.ep_out_generation[index].load(Ordering::Relaxed);
+            let generation = shared.transfer_generation(index, Direction::Out);
             let mut s = state.load(Ordering::Relaxed);
             for slot in 0..2 {
                 if s & (PRIMED0 << slot) == 0 {
-                    if ep_cmd_read(self.ep_list, index, Direction::Out, slot) & CMD_UNUSABLE != 0 {
+                    if self.read_slot(slot) & CMD_UNUSABLE != 0 {
                         return Err(EndpointError::Disabled);
                     }
-                    ep_arm_slot::<T>(
-                        self.ep_list,
-                        index,
-                        Direction::Out,
-                        slot,
-                        arm_len,
-                        self.buf_addrs[slot],
-                        s & TR_PENDING != 0,
-                        iso,
-                    );
-                    self.armed_len[slot] = arm_len as u16;
+                    self.arm_slot(slot, arm_len, s & TR_PENDING != 0);
                     s = (s | (PRIMED0 << slot)) & !TR_PENDING;
                     state.store(s, Ordering::Relaxed);
                 }
             }
-            if lifecycle != shared.lifecycle_generation.load(Ordering::Relaxed)
-                || generation != shared.ep_out_generation[index].load(Ordering::Relaxed)
-            {
+            if !shared.transfer_generation_valid(index, Direction::Out, generation) {
                 return Err(EndpointError::Disabled);
             }
-            Ok((s, lifecycle, generation))
+            Ok((s, generation))
         })?;
 
-        let (s, lifecycle, generation) = s;
+        let (s, generation) = s;
         let slot = (s & SLOT) as usize;
-        let (word, snapshot_state) = poll_fn(|cx| {
-            shared.ep_out_wakers[index].register(cx.waker());
-            critical_section::with(|_| {
-                if !shared.alive.load(Ordering::Acquire)
-                    || lifecycle != shared.lifecycle_generation.load(Ordering::Relaxed)
-                    || generation != shared.ep_out_generation[index].load(Ordering::Relaxed)
-                {
-                    return Poll::Ready(Err(EndpointError::Disabled));
-                }
-                let snapshot_state = state.load(Ordering::Relaxed);
-                if (snapshot_state & SLOT) as usize != slot || snapshot_state & (PRIMED0 << slot) == 0 {
-                    return Poll::Ready(Err(EndpointError::Disabled));
-                }
-                let word = ep_cmd_read(self.ep_list, index, Direction::Out, slot);
-                if word & CMD_UNUSABLE != 0 {
-                    return Poll::Ready(Err(EndpointError::Disabled));
-                }
-                if word & CMD_A == 0 {
-                    Poll::Ready(Ok((word, snapshot_state)))
-                } else {
-                    Poll::Pending
-                }
-            })
+        let (word, snapshot_state) = wait_slot::<T, _>(self.command(slot), index, Direction::Out, || {
+            if !shared.transfer_generation_valid(index, Direction::Out, generation) {
+                return Err(EndpointError::Disabled);
+            }
+            let snapshot_state = state.load(Ordering::Relaxed);
+            if (snapshot_state & SLOT) as usize != slot || snapshot_state & (PRIMED0 << slot) == 0 {
+                return Err(EndpointError::Disabled);
+            }
+            Ok(snapshot_state)
         })
         .await?;
 
@@ -1858,27 +1891,16 @@ impl<'d, T: Instance> driver::EndpointOut for Endpoint<'d, T, Out> {
 
         critical_section::with(|_| {
             if !shared.alive.load(Ordering::Acquire)
-                || lifecycle != shared.lifecycle_generation.load(Ordering::Relaxed)
-                || generation != shared.ep_out_generation[index].load(Ordering::Relaxed)
+                || !shared.transfer_generation_valid(index, Direction::Out, generation)
             {
                 return Err(EndpointError::Disabled);
             }
             let current = state.load(Ordering::Relaxed);
-            let command = ep_cmd_read(self.ep_list, index, Direction::Out, slot);
+            let command = self.read_slot(slot);
             if (current & SLOT) as usize != slot || current & (PRIMED0 << slot) == 0 || command & CMD_UNUSABLE != 0 {
                 return Err(EndpointError::Disabled);
             }
-            ep_arm_slot::<T>(
-                self.ep_list,
-                index,
-                Direction::Out,
-                slot,
-                arm_len,
-                self.buf_addrs[slot],
-                false,
-                iso,
-            );
-            self.armed_len[slot] = arm_len as u16;
+            self.arm_slot(slot, arm_len, false);
             state.store((snapshot_state ^ SLOT) | (PRIMED0 << slot), Ordering::Relaxed);
             Ok(())
         })?;
@@ -1904,68 +1926,39 @@ impl<'d, T: Instance> driver::EndpointIn for Endpoint<'d, T, In> {
         let index = self.info.addr.index();
         let shared = T::state();
         let state = shared.ep_state(index, Direction::In);
-        let iso = self.is_iso();
-        let (slot, lifecycle, generation) = critical_section::with(|_| {
+        let (slot, generation) = critical_section::with(|_| {
             if !shared.alive.load(Ordering::Acquire) {
                 return Err(EndpointError::Disabled);
             }
             let slot = (state.load(Ordering::Relaxed) & SLOT) as usize;
-            Ok((
-                slot,
-                shared.lifecycle_generation.load(Ordering::Relaxed),
-                shared.ep_in_generation[index].load(Ordering::Relaxed),
-            ))
+            Ok((slot, shared.transfer_generation(index, Direction::In)))
         })?;
 
-        let snapshot_state = poll_fn(|cx| {
-            shared.ep_in_wakers[index].register(cx.waker());
-            critical_section::with(|_| {
-                if !shared.alive.load(Ordering::Acquire)
-                    || lifecycle != shared.lifecycle_generation.load(Ordering::Relaxed)
-                    || generation != shared.ep_in_generation[index].load(Ordering::Relaxed)
-                {
-                    return Poll::Ready(Err(EndpointError::Disabled));
-                }
-                let snapshot_state = state.load(Ordering::Relaxed);
-                if (snapshot_state & SLOT) as usize != slot {
-                    return Poll::Ready(Err(EndpointError::Disabled));
-                }
-                let word = ep_cmd_read(self.ep_list, index, Direction::In, slot);
-                if word & CMD_UNUSABLE != 0 {
-                    return Poll::Ready(Err(EndpointError::Disabled));
-                }
-                if word & CMD_A == 0 {
-                    Poll::Ready(Ok(snapshot_state))
-                } else {
-                    Poll::Pending
-                }
-            })
+        let (_, snapshot_state) = wait_slot::<T, _>(self.command(slot), index, Direction::In, || {
+            if !shared.transfer_generation_valid(index, Direction::In, generation) {
+                return Err(EndpointError::Disabled);
+            }
+            let snapshot_state = state.load(Ordering::Relaxed);
+            if (snapshot_state & SLOT) as usize != slot {
+                return Err(EndpointError::Disabled);
+            }
+            Ok(snapshot_state)
         })
         .await?;
 
         copy_to_ep_buffer(self.buf_addrs[slot], buf);
         critical_section::with(|_| {
             if !shared.alive.load(Ordering::Acquire)
-                || lifecycle != shared.lifecycle_generation.load(Ordering::Relaxed)
-                || generation != shared.ep_in_generation[index].load(Ordering::Relaxed)
+                || !shared.transfer_generation_valid(index, Direction::In, generation)
             {
                 return Err(EndpointError::Disabled);
             }
             let current = state.load(Ordering::Relaxed);
-            let command = ep_cmd_read(self.ep_list, index, Direction::In, slot);
+            let command = self.read_slot(slot);
             if (current & SLOT) as usize != slot || command & (CMD_UNUSABLE | CMD_A) != 0 {
                 return Err(EndpointError::Disabled);
             }
-            ep_arm_slot::<T>(
-                self.ep_list,
-                index,
-                Direction::In,
-                slot,
-                buf.len() as u32,
-                self.buf_addrs[slot],
-                snapshot_state & TR_PENDING != 0,
-                iso,
-            );
+            self.arm_slot(slot, buf.len() as u32, snapshot_state & TR_PENDING != 0);
             state.store((snapshot_state ^ SLOT) & !TR_PENDING, Ordering::Relaxed);
             Ok(())
         })?;
@@ -1998,25 +1991,17 @@ pub struct ControlPipe<'d, T: Instance> {
     _phantom: PhantomData<&'d mut T>,
     _memory: MemoryLease<'d>,
     max_packet_size: u16,
-    ep_list: u32,
-    setup_addr: u32,
-    ep0_out_addr: u32,
-    ep0_in_addr: u32,
-    accepted_lifecycle: u32,
-    accepted_out_generation: u32,
-    accepted_in_generation: u32,
-    setup_valid: bool,
+    layout: EndpointLayout,
+    accepted_generation: Option<ControlGeneration>,
 }
 
 impl<'d, T: Instance> ControlPipe<'d, T> {
     fn request_valid(&self) -> bool {
         let state = T::state();
-        if !self.setup_valid
-            || !state.alive.load(Ordering::Acquire)
-            || self.accepted_lifecycle != state.lifecycle_generation.load(Ordering::Relaxed)
-            || self.accepted_out_generation != state.ep_out_generation[0].load(Ordering::Relaxed)
-            || self.accepted_in_generation != state.ep_in_generation[0].load(Ordering::Relaxed)
-        {
+        let Some(generation) = self.accepted_generation else {
+            return false;
+        };
+        if !state.alive.load(Ordering::Acquire) || generation != state.control_generation() {
             return false;
         }
         if T::regs().devcmdstat().read().setup() {
@@ -2024,6 +2009,22 @@ impl<'d, T: Instance> ControlPipe<'d, T> {
             return false;
         }
         true
+    }
+
+    fn command(&self, dir: Direction) -> EndpointCommand {
+        self.layout.command(0, dir, 0)
+    }
+
+    fn arm(&self, dir: Direction, len: u32) {
+        let addr = match dir {
+            Direction::Out => self.layout.out,
+            Direction::In => self.layout.in_,
+        };
+        self.command(dir).arm::<T>(len, addr, false, false);
+    }
+
+    fn validate_request(&self) -> Result<(), EndpointError> {
+        self.request_valid().then_some(()).ok_or(EndpointError::Disabled)
     }
 }
 
@@ -2035,7 +2036,7 @@ impl<'d, T: Instance> driver::ControlPipe for ControlPipe<'d, T> {
     async fn setup(&mut self) -> [u8; 8] {
         let shared = T::state();
         poll_fn(|cx| {
-            shared.ep_out_wakers[0].register(cx.waker());
+            shared.ep_waker(0, Direction::Out).register(cx.waker());
             critical_section::with(|_| {
                 if !shared.alive.load(Ordering::Acquire) {
                     return Poll::Pending;
@@ -2051,27 +2052,18 @@ impl<'d, T: Instance> driver::ControlPipe for ControlPipe<'d, T> {
         .await;
 
         let buf = critical_section::with(|_| {
-            ep_cmd_modify(self.ep_list, 0, Direction::Out, 0, |w| w & !(CMD_A | CMD_S));
-            ep_cmd_modify(self.ep_list, 0, Direction::In, 0, |w| w & !(CMD_A | CMD_S));
+            self.command(Direction::Out).modify(|w| w & !(CMD_A | CMD_S));
+            self.command(Direction::In).modify(|w| w & !(CMD_A | CMD_S));
 
             let mut buf = [0; 8];
-            copy_from_ep_buffer(self.setup_addr, &mut buf);
+            copy_from_ep_buffer(self.layout.setup, &mut buf);
             devcmdstat_modify(T::regs(), |w| w.set_setup(true));
-            unsafe {
-                ep_cmd_ptr(self.ep_list, 0, Direction::Out, true).write_volatile(addroff::<T>(self.setup_addr));
-            }
-            ep_cmd_write(
-                self.ep_list,
-                0,
-                Direction::Out,
-                0,
-                CMD_A | nbytes::<T>(self.max_packet_size as u32) | addroff::<T>(self.ep0_out_addr),
-            );
+            self.layout
+                .command(0, Direction::Out, 1)
+                .write(addroff::<T>(self.layout.setup));
+            self.arm(Direction::Out, self.max_packet_size as u32);
 
-            self.accepted_lifecycle = shared.lifecycle_generation.load(Ordering::Relaxed);
-            self.accepted_out_generation = shared.ep_out_generation[0].load(Ordering::Relaxed);
-            self.accepted_in_generation = shared.ep_in_generation[0].load(Ordering::Relaxed);
-            self.setup_valid = true;
+            self.accepted_generation = Some(shared.control_generation());
             shared.setup_pending.store(false, Ordering::Release);
             buf
         });
@@ -2082,22 +2074,8 @@ impl<'d, T: Instance> driver::ControlPipe for ControlPipe<'d, T> {
 
     async fn data_out(&mut self, buf: &mut [u8], _first: bool, _last: bool) -> Result<usize, EndpointError> {
         let mps = self.max_packet_size as u32;
-        let word = poll_fn(|cx| {
-            T::state().ep_out_wakers[0].register(cx.waker());
-            critical_section::with(|_| {
-                if !self.request_valid() {
-                    return Poll::Ready(Err(EndpointError::Disabled));
-                }
-                let word = ep_cmd_read(self.ep_list, 0, Direction::Out, 0);
-                if word & CMD_UNUSABLE != 0 {
-                    return Poll::Ready(Err(EndpointError::Disabled));
-                }
-                if word & CMD_A == 0 {
-                    Poll::Ready(Ok(word))
-                } else {
-                    Poll::Pending
-                }
-            })
+        let (word, ()) = wait_slot::<T, _>(self.command(Direction::Out), 0, Direction::Out, || {
+            self.validate_request()
         })
         .await?;
 
@@ -2105,19 +2083,14 @@ impl<'d, T: Instance> driver::ControlPipe for ControlPipe<'d, T> {
         if rx_len > buf.len() {
             return Err(EndpointError::BufferOverflow);
         }
-        copy_from_ep_buffer(self.ep0_out_addr, &mut buf[..rx_len]);
+        copy_from_ep_buffer(self.layout.out, &mut buf[..rx_len]);
 
         critical_section::with(|_| {
-            if !self.request_valid() || ep_cmd_read(self.ep_list, 0, Direction::Out, 0) & CMD_UNUSABLE != 0 {
+            self.validate_request()?;
+            if self.command(Direction::Out).read() & CMD_UNUSABLE != 0 {
                 return Err(EndpointError::Disabled);
             }
-            ep_cmd_write(
-                self.ep_list,
-                0,
-                Direction::Out,
-                0,
-                CMD_A | nbytes::<T>(mps) | addroff::<T>(self.ep0_out_addr),
-            );
+            self.arm(Direction::Out, mps);
             Ok(())
         })?;
 
@@ -2134,37 +2107,18 @@ impl<'d, T: Instance> driver::ControlPipe for ControlPipe<'d, T> {
         if !critical_section::with(|_| self.request_valid()) {
             return Err(EndpointError::Disabled);
         }
-        copy_to_ep_buffer(self.ep0_in_addr, data);
+        copy_to_ep_buffer(self.layout.in_, data);
         critical_section::with(|_| {
-            if !self.request_valid() || ep_cmd_read(self.ep_list, 0, Direction::In, 0) & CMD_UNUSABLE != 0 {
+            self.validate_request()?;
+            if self.command(Direction::In).read() & CMD_UNUSABLE != 0 {
                 return Err(EndpointError::Disabled);
             }
-            ep_cmd_write(
-                self.ep_list,
-                0,
-                Direction::In,
-                0,
-                CMD_A | nbytes::<T>(data.len() as u32) | addroff::<T>(self.ep0_in_addr),
-            );
+            self.arm(Direction::In, data.len() as u32);
             Ok(())
         })?;
 
-        poll_fn(|cx| {
-            T::state().ep_in_wakers[0].register(cx.waker());
-            critical_section::with(|_| {
-                if !self.request_valid() {
-                    return Poll::Ready(Err(EndpointError::Disabled));
-                }
-                let command = ep_cmd_read(self.ep_list, 0, Direction::In, 0);
-                if command & CMD_UNUSABLE != 0 {
-                    return Poll::Ready(Err(EndpointError::Disabled));
-                }
-                if command & CMD_A == 0 {
-                    Poll::Ready(Ok(()))
-                } else {
-                    Poll::Pending
-                }
-            })
+        wait_slot::<T, _>(self.command(Direction::In), 0, Direction::In, || {
+            self.validate_request()
         })
         .await?;
 
@@ -2178,31 +2132,15 @@ impl<'d, T: Instance> driver::ControlPipe for ControlPipe<'d, T> {
             if !self.request_valid() {
                 return false;
             }
-            ep_cmd_write(
-                self.ep_list,
-                0,
-                Direction::In,
-                0,
-                CMD_A | addroff::<T>(self.ep0_in_addr),
-            );
+            self.arm(Direction::In, 0);
             true
         });
         if !armed {
             return;
         }
 
-        poll_fn(|cx| {
-            T::state().ep_in_wakers[0].register(cx.waker());
-            critical_section::with(|_| {
-                if !self.request_valid() {
-                    return Poll::Ready(());
-                }
-                if ep_cmd_read(self.ep_list, 0, Direction::In, 0) & CMD_A == 0 {
-                    Poll::Ready(())
-                } else {
-                    Poll::Pending
-                }
-            })
+        let _ = wait_slot::<T, _>(self.command(Direction::In), 0, Direction::In, || {
+            self.validate_request()
         })
         .await;
     }
@@ -2213,8 +2151,8 @@ impl<'d, T: Instance> driver::ControlPipe for ControlPipe<'d, T> {
             if !self.request_valid() {
                 return;
             }
-            ep_cmd_modify(self.ep_list, 0, Direction::Out, 0, |w| w | CMD_S);
-            ep_cmd_modify(self.ep_list, 0, Direction::In, 0, |w| w | CMD_S);
+            self.command(Direction::Out).modify(|w| w | CMD_S);
+            self.command(Direction::In).modify(|w| w | CMD_S);
         });
     }
 

--- a/embassy-nxp/src/usb/lpc55.rs
+++ b/embassy-nxp/src/usb/lpc55.rs
@@ -45,6 +45,21 @@ const CMD_TV: u32 = 1 << 27; // RF/TV: data toggle value for bulk/interrupt
 const NBYTES_SHIFT: u32 = 11;
 const NBYTES_MASK: u32 = 0x7FFF;
 
+/// Per-slot buffer capacity for HS bulk endpoints, in bytes.
+///
+/// The ip3511-HS packetizes a single command/status entry: NBytes (15 bits)
+/// may span multiple max-packet-size packets and hardware streams them all
+/// without CPU involvement, so larger slots amortize the ISR + executor +
+/// re-arm turnaround over many packets.
+///
+/// OUT slots are a power of two (8 x 512) because an OUT window only
+/// completes when the buffer fills or a short packet arrives: host-side
+/// writes are power-of-two-sized, so windows tile them exactly. IN has no
+/// such constraint; 3584 (7 x 512) makes both directions plus EP0 and one
+/// interrupt endpoint fit the 16 KiB USB SRAM (2x4096 + 2x3584 + overhead).
+const BULK_OUT_SLOT_LEN: u16 = 4096;
+const BULK_IN_SLOT_LEN: u16 = 3584;
+
 static BUS_WAKER: AtomicWaker = AtomicWaker::new();
 static EP_IN_WAKERS: [AtomicWaker; EP_COUNT] = [const { AtomicWaker::new() }; EP_COUNT];
 static EP_OUT_WAKERS: [AtomicWaker; EP_COUNT] = [const { AtomicWaker::new() }; EP_COUNT];
@@ -521,8 +536,26 @@ impl<'d, T: Instance> Driver<'d, T> {
         used[index] = true;
 
         // Two buffer slots per endpoint (double buffering): software fills or
-        // drains one while the other is on the wire.
-        let buf_addrs = [self.alloc_buffer(max_packet_size)?, self.alloc_buffer(max_packet_size)?];
+        // drains one while the other is on the wire. HS bulk endpoints get
+        // multi-packet slots (see BULK_*_SLOT_LEN); fall back to single-packet
+        // slots if the USB SRAM cannot fit the large ones.
+        let want_len = match (ep_type, D::dir()) {
+            (EndpointType::Bulk, Direction::Out) => BULK_OUT_SLOT_LEN.max(max_packet_size),
+            (EndpointType::Bulk, Direction::In) => BULK_IN_SLOT_LEN.max(max_packet_size),
+            _ => max_packet_size,
+        };
+        let mark = self.alloc_offset;
+        let (buf_addrs, slot_len) = match (self.alloc_buffer(want_len), self.alloc_buffer(want_len)) {
+            (Ok(a), Ok(b)) => ([a, b], want_len),
+            _ if want_len > max_packet_size => {
+                self.alloc_offset = mark;
+                (
+                    [self.alloc_buffer(max_packet_size)?, self.alloc_buffer(max_packet_size)?],
+                    max_packet_size,
+                )
+            }
+            _ => return Err(EndpointAllocError),
+        };
 
         // Disabled until `endpoint_set_enabled`.
         ep_cmd_write(index, D::dir(), 0, CMD_D);
@@ -539,6 +572,8 @@ impl<'d, T: Instance> Driver<'d, T> {
                 interval_ms,
             },
             buf_addrs,
+            slot_len,
+            armed_len: [0; 2],
         })
     }
 }
@@ -792,6 +827,11 @@ pub struct Endpoint<'d, T: Instance, D> {
     _phantom: PhantomData<(&'d mut T, D)>,
     info: EndpointInfo,
     buf_addrs: [u32; 2],
+    /// Per-slot buffer capacity (multi-packet for HS bulk endpoints).
+    slot_len: u16,
+    /// Length each OUT slot was last armed with; needed to compute the
+    /// received count from the NBytes-remaining field on completion.
+    armed_len: [u16; 2],
 }
 
 impl<'d, T: Instance, D: Dir> driver::Endpoint for Endpoint<'d, T, D> {
@@ -824,6 +864,17 @@ impl<'d, T: Instance> driver::EndpointOut for Endpoint<'d, T, Out> {
         let mps = self.info.max_packet_size as u32;
         let state = &EP_OUT_STATE[index];
 
+        // Receive window per slot: a single packet by default, or a
+        // multi-packet window (hardware packetizes one command entry) when
+        // the caller's buffer spans several packets. A window completes when
+        // it fills or a short packet arrives, so callers using large buffers
+        // must expect coalescing without intermediate packet boundaries.
+        let arm_len = if buf.len() as u32 > mps {
+            (buf.len() as u32).min(self.slot_len as u32) / mps * mps
+        } else {
+            mps
+        };
+
         // Keep both slots armed so the endpoint does not NAK between packets
         // while the host streams. A slot with PRIMED set and Active clear
         // holds a received, not-yet-consumed packet.
@@ -837,10 +888,11 @@ impl<'d, T: Instance> driver::EndpointOut for Endpoint<'d, T, Out> {
                     index,
                     Direction::Out,
                     slot,
-                    mps,
+                    arm_len,
                     self.buf_addrs[slot],
                     s & TR_PENDING != 0,
                 );
+                self.armed_len[slot] = arm_len as u16;
                 s = (s | (PRIMED0 << slot)) & !TR_PENDING;
                 state.store(s, Ordering::Relaxed);
             }
@@ -867,7 +919,7 @@ impl<'d, T: Instance> driver::EndpointOut for Endpoint<'d, T, Out> {
         })
         .await?;
 
-        let rx_len = (mps - remaining_bytes(word)) as usize;
+        let rx_len = (self.armed_len[slot] as u32 - remaining_bytes(word)) as usize;
         if rx_len > buf.len() {
             return Err(EndpointError::BufferOverflow);
         }
@@ -875,7 +927,8 @@ impl<'d, T: Instance> driver::EndpointOut for Endpoint<'d, T, Out> {
 
         // Hand the drained slot straight back to hardware and advance the
         // consume cursor.
-        ep_arm_slot(index, Direction::Out, slot, mps, self.buf_addrs[slot], false);
+        ep_arm_slot(index, Direction::Out, slot, arm_len, self.buf_addrs[slot], false);
+        self.armed_len[slot] = arm_len as u16;
         state.store((s ^ SLOT) | (PRIMED0 << slot), Ordering::Relaxed);
 
         trace!("READ {:?} rx_len = {}", self.info.addr, rx_len);
@@ -885,7 +938,9 @@ impl<'d, T: Instance> driver::EndpointOut for Endpoint<'d, T, Out> {
 
 impl<'d, T: Instance> driver::EndpointIn for Endpoint<'d, T, In> {
     async fn write(&mut self, buf: &[u8]) -> Result<(), EndpointError> {
-        if buf.len() > self.info.max_packet_size as usize {
+        // Multi-packet: one command entry sends ceil(len / mps) packets
+        // without CPU involvement; the slot capacity is the only limit.
+        if buf.len() > self.slot_len as usize {
             return Err(EndpointError::BufferOverflow);
         }
 

--- a/embassy-nxp/src/usb/lpc55.rs
+++ b/embassy-nxp/src/usb/lpc55.rs
@@ -1,0 +1,968 @@
+//! USB1 high-speed device driver for LPC55 (ip3511-HS).
+//!
+//! Device mode only. Supports control, bulk and interrupt endpoints;
+//! isochronous endpoint allocation returns [`EndpointAllocError`].
+//!
+//! The system (main) clock must run at 96 MHz or higher, see
+//! [`crate::config::MainClock::FroHf96`].
+
+use core::future::poll_fn;
+use core::marker::PhantomData;
+use core::sync::atomic::{Ordering, compiler_fence};
+use core::task::Poll;
+
+use embassy_hal_internal::{Peri, PeripheralType};
+use embassy_sync::waitqueue::AtomicWaker;
+use embassy_usb_driver as driver;
+use embassy_usb_driver::{
+    Direction, EndpointAddress, EndpointAllocError, EndpointError, EndpointInfo, EndpointType, Event, Unsupported,
+};
+
+use crate::interrupt::typelevel::{Binding, Interrupt};
+use crate::pac;
+
+/// Number of logical endpoints (each has an IN and an OUT side).
+const EP_COUNT: usize = 6;
+/// Dedicated USB1 SRAM.
+const USB_SRAM_ADDR: u32 = 0x4010_0000;
+const USB_SRAM_SIZE: u32 = 0x4000;
+/// The endpoint command/status list occupies `EP_COUNT * 4` words at the
+/// start of the USB SRAM (256-byte aligned by construction). Word layout per
+/// logical EP i: `[out_buf0, out_buf1, in_buf0, in_buf1]`. EP0's `out_buf1`
+/// slot holds the SETUP buffer pointer.
+///
+/// Data buffers are bump-allocated 64-byte aligned from here on; the first
+/// allocation (in `Driver::new`) is the 8-byte SETUP buffer.
+const DATA_BUFFERS_START: u32 = USB_SRAM_ADDR + 0x80;
+
+// HS endpoint command/status word encoding. NOTE: differs from the USB0-FS
+// controller (NBytes is 15 bits at bit 11, AddressOffset is 11 bits).
+const CMD_A: u32 = 1 << 31; // Active (HW clears on completion)
+const CMD_D: u32 = 1 << 30; // Disabled
+const CMD_S: u32 = 1 << 29; // Stall
+const CMD_TR: u32 = 1 << 28; // Toggle Reset (write-1)
+const CMD_TV: u32 = 1 << 27; // RF/TV: data toggle value for bulk/interrupt
+const NBYTES_SHIFT: u32 = 11;
+const NBYTES_MASK: u32 = 0x7FFF;
+
+static BUS_WAKER: AtomicWaker = AtomicWaker::new();
+static EP_IN_WAKERS: [AtomicWaker; EP_COUNT] = [const { AtomicWaker::new() }; EP_COUNT];
+static EP_OUT_WAKERS: [AtomicWaker; EP_COUNT] = [const { AtomicWaker::new() }; EP_COUNT];
+
+fn nbytes(n: u32) -> u32 {
+    (n & NBYTES_MASK) << NBYTES_SHIFT
+}
+
+fn remaining_bytes(word: u32) -> u32 {
+    (word >> NBYTES_SHIFT) & NBYTES_MASK
+}
+
+/// AddressOffset field: bits [10:0] = buffer address >> 6. The upper address
+/// bits come from DATABUFSTART.
+fn addroff(buf_addr: u32) -> u32 {
+    debug_assert_eq!(buf_addr & 0x3F, 0);
+    (buf_addr >> 6) & 0x7FF
+}
+
+/// Pointer to the command/status word of a physical endpoint buffer slot.
+fn ep_cmd_ptr(index: usize, dir: Direction, buf1: bool) -> *mut u32 {
+    let slot = match dir {
+        Direction::Out => 0,
+        Direction::In => 2,
+    } + buf1 as usize;
+    (USB_SRAM_ADDR as usize + index * 16 + slot * 4) as *mut u32
+}
+
+fn ep_cmd_read(index: usize, dir: Direction) -> u32 {
+    unsafe { ep_cmd_ptr(index, dir, false).read_volatile() }
+}
+
+fn ep_cmd_write(index: usize, dir: Direction, word: u32) {
+    unsafe { ep_cmd_ptr(index, dir, false).write_volatile(word) }
+}
+
+fn ep_cmd_modify(index: usize, dir: Direction, f: impl FnOnce(u32) -> u32) {
+    critical_section::with(|_| {
+        let p = ep_cmd_ptr(index, dir, false);
+        unsafe { p.write_volatile(f(p.read_volatile())) }
+    });
+}
+
+/// Arm a data endpoint buffer for transfer, preserving the hardware-owned
+/// data-toggle value (TV, bit 27) and stall bit. A full-word write here would
+/// zero the toggle and the host would silently discard the mismatched packets
+/// (lpc55-hal uses the same read-modify-write discipline).
+fn ep_arm(index: usize, dir: Direction, len: u32, buf_addr: u32) {
+    let old = ep_cmd_read(index, dir);
+    ep_cmd_write(
+        index,
+        dir,
+        (old & (CMD_TV | CMD_S)) | CMD_A | nbytes(len) | addroff(buf_addr),
+    );
+}
+
+fn copy_to_usb_sram(buf_addr: u32, data: &[u8]) {
+    compiler_fence(Ordering::SeqCst);
+    let dst = buf_addr as *mut u8;
+    for (i, b) in data.iter().enumerate() {
+        unsafe { dst.add(i).write_volatile(*b) };
+    }
+    compiler_fence(Ordering::SeqCst);
+}
+
+fn copy_from_usb_sram(buf_addr: u32, data: &mut [u8]) {
+    compiler_fence(Ordering::SeqCst);
+    let src = buf_addr as *const u8;
+    for (i, b) in data.iter_mut().enumerate() {
+        *b = unsafe { src.add(i).read_volatile() };
+    }
+    compiler_fence(Ordering::SeqCst);
+}
+
+/// RMW DEVCMDSTAT without accidentally acknowledging pending events.
+///
+/// `SETUP`, `DCON_C`, `DSUS_C` and `DRES_C` are write-1-to-clear: a naive
+/// read-modify-write would clear whichever of them is currently pending.
+/// This helper zeroes them in the read value before applying `f`, so a set
+/// bit in the written value is always an intentional acknowledge by `f`.
+fn devcmdstat_modify(regs: pac::usbhsd::Usbhsd, f: impl FnOnce(&mut pac::usbhsd::regs::Devcmdstat)) {
+    critical_section::with(|_| {
+        let r = regs.devcmdstat();
+        let mut val = r.read();
+        val.set_setup(false);
+        val.set_dcon_c(false);
+        val.set_dsus_c(false);
+        val.set_dres_c(false);
+        f(&mut val);
+        r.write_value(val);
+    });
+}
+
+trait SealedInstance {
+    fn regs() -> pac::usbhsd::Usbhsd;
+}
+
+/// USB peripheral instance.
+#[allow(private_bounds)]
+pub trait Instance: SealedInstance + PeripheralType + 'static {
+    /// Interrupt for this instance.
+    type Interrupt: crate::interrupt::typelevel::Interrupt;
+}
+
+impl SealedInstance for crate::peripherals::USBHSD {
+    fn regs() -> pac::usbhsd::Usbhsd {
+        pac::USBHSD
+    }
+}
+
+impl Instance for crate::peripherals::USBHSD {
+    type Interrupt = crate::interrupt::typelevel::USB1;
+}
+
+/// Marker type for IN endpoints.
+pub enum In {}
+/// Marker type for OUT endpoints.
+pub enum Out {}
+
+trait SealedDir {
+    fn dir() -> Direction;
+}
+
+/// Endpoint direction marker.
+#[allow(private_bounds)]
+pub trait Dir: SealedDir {}
+
+impl SealedDir for In {
+    fn dir() -> Direction {
+        Direction::In
+    }
+}
+impl Dir for In {}
+
+impl SealedDir for Out {
+    fn dir() -> Direction {
+        Direction::Out
+    }
+}
+impl Dir for Out {}
+
+/// USB interrupt handler.
+pub struct InterruptHandler<T: Instance> {
+    _phantom: PhantomData<T>,
+}
+
+impl<T: Instance> crate::interrupt::typelevel::Handler<T::Interrupt> for InterruptHandler<T> {
+    unsafe fn on_interrupt() {
+        let regs = T::regs();
+        let stat = regs.intstat().read();
+        // W1C exactly the bits we saw. Later-arriving bits stay pending and
+        // re-fire the interrupt. Losing an edge is safe by design: the futures
+        // re-check level state (eplist Active bit / DEVCMDSTAT.SETUP).
+        regs.intstat().write_value(stat);
+
+        for i in 0..EP_COUNT {
+            if stat.0 & (1 << (2 * i)) != 0 {
+                EP_OUT_WAKERS[i].wake();
+            }
+            if stat.0 & (1 << (2 * i + 1)) != 0 {
+                EP_IN_WAKERS[i].wake();
+            }
+        }
+
+        // A pending SETUP must abort in-flight control transfers in either
+        // direction, so wake both EP0 futures.
+        if regs.devcmdstat().read().setup() {
+            EP_OUT_WAKERS[0].wake();
+            EP_IN_WAKERS[0].wake();
+        }
+
+        // dev_int: DEVCMDSTAT change bits are consumed by `Bus::poll`.
+        if stat.0 & (1 << 31) != 0 {
+            BUS_WAKER.wake();
+        }
+    }
+}
+
+/// LPC55 USB1 high-speed device driver.
+pub struct Driver<'d, T: Instance> {
+    _usb: Peri<'d, T>,
+    ep_in_used: [bool; EP_COUNT],
+    ep_out_used: [bool; EP_COUNT],
+    /// Bump allocator over the dedicated USB SRAM.
+    alloc_offset: u32,
+    /// Address of the 8-byte (64-byte aligned) SETUP buffer.
+    setup_addr: u32,
+}
+
+impl<'d, T: Instance> Driver<'d, T> {
+    /// Create a new USB driver.
+    ///
+    /// This powers up and configures the USB1 PHY (expects a 32 MHz crystal)
+    /// and the device controller, but does not connect to the bus yet; the
+    /// soft-connect happens in [`driver::Bus::enable`].
+    pub fn new(usb: Peri<'d, T>, _irq: impl Binding<T::Interrupt, InterruptHandler<T>> + 'd) -> Self {
+        use pac::syscon::vals::{Usb1DevRst, Usb1HostRst, Usb1PhyRst, Usb1RamRst};
+
+        let regs = T::regs();
+
+        // Reset the USB1 blocks sequentially, per block, with their clocks
+        // still off — the exact order lpc55-hal's `enabled_as_device` uses
+        // (host, then device + RAM, then PHY). Clocks are enabled per block
+        // further down, right before each block is first used.
+        critical_section::with(|_| {
+            pac::SYSCON
+                .presetctrl2()
+                .modify(|w| w.set_usb1_host_rst(Usb1HostRst::Asserted));
+            pac::SYSCON
+                .presetctrl2()
+                .modify(|w| w.set_usb1_host_rst(Usb1HostRst::Released));
+            pac::SYSCON.presetctrl2().modify(|w| {
+                w.set_usb1_dev_rst(Usb1DevRst::Asserted);
+                w.set_usb1_ram_rst(Usb1RamRst::Asserted);
+            });
+            pac::SYSCON.presetctrl2().modify(|w| {
+                w.set_usb1_dev_rst(Usb1DevRst::Released);
+                w.set_usb1_ram_rst(Usb1RamRst::Released);
+            });
+            pac::SYSCON
+                .presetctrl2()
+                .modify(|w| w.set_usb1_phy_rst(Usb1PhyRst::Asserted));
+            pac::SYSCON
+                .presetctrl2()
+                .modify(|w| w.set_usb1_phy_rst(Usb1PhyRst::Released));
+
+            // Host block clock on, only briefly, to hand the shared port over.
+            pac::SYSCON.ahbclkctrl2().modify(|w| w.set_usb1_host(true));
+        });
+
+        // Hand the shared USB1 port to the device controller; verify the
+        // write sticks (it is silently dropped while the block is still
+        // completing its reset). Use absolute writes: a read-modify-write on
+        // the still-resetting block would write garbage read values back.
+        let mut handed_over = false;
+        for _ in 0..10_000 {
+            let mut pm = pac::usbhsh::regs::Portmode(0);
+            pm.set_dev_enable(true);
+            // Keep the PHY power-down input (PDCOM) under software control
+            // (reset default), released. If hardware control is left to the
+            // clock-gated host block, it powers the PHY down.
+            pm.set_sw_ctrl_pdcom(true);
+            pac::USBHSH.portmode().write_value(pm);
+            if pac::USBHSH.portmode().read().dev_enable() {
+                handed_over = true;
+                break;
+            }
+        }
+        if !handed_over {
+            warn!("USB1 port handover to device controller failed");
+        }
+        critical_section::with(|_| {
+            pac::SYSCON.ahbclkctrl2().modify(|w| w.set_usb1_host(false));
+        });
+
+        // PDRUNCFG bit positions (1 = powered down; writing 1 to the CLR
+        // register clears the bit, i.e. powers the block ON).
+        const PDEN_XTAL32M: u32 = 1 << 8;
+        const PDEN_USBHSPHY: u32 = 1 << 12;
+        const PDEN_LDOUSBHS: u32 = 1 << 18;
+        const PDEN_LDOXO32M: u32 = 1 << 20;
+
+        // Power on the 32 MHz crystal + its LDO and route it to the USB PLL.
+        pac::PMC
+            .pdruncfgclr0()
+            .write(|w| w.set_pdruncfgclr0(PDEN_XTAL32M | PDEN_LDOXO32M));
+        pac::ANACTRL.xo32m_ctrl().modify(|w| w.set_enable_pll_usb_out(true));
+
+        // Power on the HS PHY + its LDO.
+        pac::PMC
+            .pdruncfgclr0()
+            .write(|w| w.set_pdruncfgclr0(PDEN_USBHSPHY | PDEN_LDOUSBHS));
+        // >= 5 ms for the PHY to be ready (1.5M cycles = 5 ms at a worst-case
+        // 300 MHz; proportionally longer at lower clocks, which is fine).
+        cortex_m::asm::delay(1_500_000);
+
+        // PHY register clock on, only now that the analog is powered.
+        critical_section::with(|_| {
+            pac::SYSCON.ahbclkctrl2().modify(|w| w.set_usb1_phy(true));
+        });
+
+        // PHY initialization (order mirrors lpc55-hal `enabled_as_device`).
+        let phy = pac::USBPHY;
+        // Leave soft reset and open the clock gate in one full write, before
+        // touching the PLL (lpc55-hal writes CTRL = 0 here).
+        phy.ctrl().write_value(pac::usbphy::regs::Ctrl(0));
+        phy.pll_sic().modify(|w| {
+            // Divide-by-30: 16 MHz crystal * 30 = 480 MHz (verified on this
+            // board; lpc55-hal uses the same divider).
+            w.set_pll_div_sel(pac::usbphy::vals::PllSicPllDivSel::Value6);
+            w.set_pll_reg_enable(true);
+        });
+        // Undocumented bit the NXP SDK clears after enabling the PLL regulator.
+        phy.pll_sic_clr().write_value(pac::usbphy::regs::PllSicClr(1 << 16));
+        // >= 15 us for the PLL regulator to stabilize.
+        cortex_m::asm::delay(5_000);
+        phy.pll_sic().modify(|w| {
+            w.set_pll_power(true);
+            w.set_pll_en_usb_clks(true);
+        });
+        // Bounded wait for PLL lock (~100 ms worth); carry on regardless, the
+        // device simply won't enumerate if the PLL never locks.
+        let mut locked = false;
+        for _ in 0..1_000_000 {
+            if phy.pll_sic().read().pll_lock() == pac::usbphy::vals::PllSicPllLock::Value1 {
+                locked = true;
+                break;
+            }
+        }
+        if !locked {
+            warn!("USB1 PHY PLL failed to lock");
+        }
+        phy.ctrl().modify(|w| {
+            w.set_clkgate(false);
+            w.set_enautoclr_clkgate(true);
+            // On suspend the controller powers the PHY down (hardware sets the PWD
+            // TX/RX bits); this makes wakeup auto-clear them again. Without it the
+            // PHY receiver stays powered off after the first bus-idle suspend and
+            // the controller never decodes another packet (SDK USB_EhciPhyInit
+            // sets this too).
+            w.set_enautoclr_phy_pwd(true);
+        });
+        // Power up everything in the PHY.
+        phy.pwd().write_value(pac::usbphy::regs::Pwd(0));
+
+        // Device controller + dedicated USB RAM clocks on, last (mirrors
+        // lpc55-hal's `enable_clock(USB1)` which gates both).
+        critical_section::with(|_| {
+            pac::SYSCON.ahbclkctrl2().modify(|w| {
+                w.set_usb1_dev(true);
+                w.set_usb1_ram(true);
+            });
+        });
+
+        // Zero the endpoint command/status list and reserve the SETUP buffer.
+        for i in 0..EP_COUNT * 4 {
+            unsafe { ((USB_SRAM_ADDR as usize + i * 4) as *mut u32).write_volatile(0) };
+        }
+        let setup_addr = DATA_BUFFERS_START;
+        unsafe {
+            (setup_addr as *mut u32).write_volatile(0);
+            (setup_addr as *mut u32).add(1).write_volatile(0);
+            // EP0 out_buf1 slot holds the SETUP buffer pointer.
+            ep_cmd_ptr(0, Direction::Out, true).write_volatile(addroff(setup_addr));
+        }
+
+        regs.databufstart().write(|w| w.set_da_buf(USB_SRAM_ADDR));
+        regs.epliststart()
+            .write_value(pac::usbhsd::regs::Epliststart(USB_SRAM_ADDR));
+        // Single-buffered operation everywhere.
+        regs.epinuse().write(|w| w.set_buf(0));
+        regs.epbufcfg().write(|w| w.set_buf_sb(0));
+        regs.epskip().write_value(pac::usbhsd::regs::Epskip(0));
+
+        // Enable the device controller, but do not connect yet. Preserve the
+        // reset defaults of the other fields (notably LPM_SUP).
+        devcmdstat_modify(regs, |w| w.set_dev_en(true));
+
+        regs.intstat().write_value(pac::usbhsd::regs::Intstat(!0));
+        regs.inten().write(|w| {
+            w.set_ep_int_en(0xFFF);
+            w.set_dev_int_en(true);
+        });
+
+        T::Interrupt::unpend();
+        unsafe { T::Interrupt::enable() };
+
+        Self {
+            _usb: usb,
+            ep_in_used: [false; EP_COUNT],
+            ep_out_used: [false; EP_COUNT],
+            alloc_offset: setup_addr + 64 - USB_SRAM_ADDR,
+            setup_addr,
+        }
+    }
+
+    /// Carve a 64-byte-aligned buffer out of the USB SRAM.
+    fn alloc_buffer(&mut self, len: u16) -> Result<u32, EndpointAllocError> {
+        let len = (len as u32 + 63) / 64 * 64;
+        if self.alloc_offset + len > USB_SRAM_SIZE {
+            warn!("USB SRAM full");
+            return Err(EndpointAllocError);
+        }
+        let addr = USB_SRAM_ADDR + self.alloc_offset;
+        self.alloc_offset += len;
+        Ok(addr)
+    }
+
+    fn alloc_endpoint<D: Dir>(
+        &mut self,
+        ep_type: EndpointType,
+        ep_addr: Option<EndpointAddress>,
+        max_packet_size: u16,
+        interval_ms: u8,
+    ) -> Result<Endpoint<'d, T, D>, EndpointAllocError> {
+        trace!(
+            "allocating type={:?} mps={:?} interval_ms={}, dir={:?}",
+            ep_type,
+            max_packet_size,
+            interval_ms,
+            D::dir()
+        );
+
+        let mps_limit = match ep_type {
+            // Isochronous unsupported (scope decision). Control is only used
+            // internally for EP0; embassy-usb never allocates extra control
+            // endpoints.
+            EndpointType::Isochronous | EndpointType::Control => return Err(EndpointAllocError),
+            EndpointType::Bulk => 512,
+            EndpointType::Interrupt => 1024,
+        };
+        if max_packet_size > mps_limit {
+            warn!("max_packet_size too high: {}", max_packet_size);
+            return Err(EndpointAllocError);
+        }
+
+        let used = match D::dir() {
+            Direction::Out => &mut self.ep_out_used,
+            Direction::In => &mut self.ep_in_used,
+        };
+        let index = match ep_addr {
+            Some(addr) => {
+                let i = addr.index();
+                if i == 0 || i >= EP_COUNT || used[i] {
+                    return Err(EndpointAllocError);
+                }
+                i
+            }
+            None => (1..EP_COUNT).find(|&i| !used[i]).ok_or(EndpointAllocError)?,
+        };
+        used[index] = true;
+
+        let buf_addr = self.alloc_buffer(max_packet_size)?;
+
+        // Disabled until `endpoint_set_enabled`.
+        ep_cmd_write(index, D::dir(), CMD_D);
+
+        trace!("  index={} addr={:08x}", index, buf_addr);
+
+        Ok(Endpoint {
+            _phantom: PhantomData,
+            info: EndpointInfo {
+                addr: EndpointAddress::from_parts(index, D::dir()),
+                ep_type,
+                max_packet_size,
+                interval_ms,
+            },
+            buf_addr,
+        })
+    }
+}
+
+impl<'d, T: Instance> driver::Driver<'d> for Driver<'d, T> {
+    type EndpointOut = Endpoint<'d, T, Out>;
+    type EndpointIn = Endpoint<'d, T, In>;
+    type ControlPipe = ControlPipe<'d, T>;
+    type Bus = Bus<'d, T>;
+
+    fn alloc_endpoint_in(
+        &mut self,
+        ep_type: EndpointType,
+        ep_addr: Option<EndpointAddress>,
+        max_packet_size: u16,
+        interval_ms: u8,
+    ) -> Result<Self::EndpointIn, EndpointAllocError> {
+        self.alloc_endpoint(ep_type, ep_addr, max_packet_size, interval_ms)
+    }
+
+    fn alloc_endpoint_out(
+        &mut self,
+        ep_type: EndpointType,
+        ep_addr: Option<EndpointAddress>,
+        max_packet_size: u16,
+        interval_ms: u8,
+    ) -> Result<Self::EndpointOut, EndpointAllocError> {
+        self.alloc_endpoint(ep_type, ep_addr, max_packet_size, interval_ms)
+    }
+
+    fn start(mut self, control_max_packet_size: u16) -> (Self::Bus, Self::ControlPipe) {
+        assert!(control_max_packet_size <= 64);
+        let ep0_out_addr = self.alloc_buffer(control_max_packet_size).unwrap();
+        let ep0_in_addr = self.alloc_buffer(control_max_packet_size).unwrap();
+
+        // EP0 OUT stays armed at all times (lpc55-hal discipline): the
+        // ip3511-HS needs an active EP0 OUT entry to accept SETUP and OUT
+        // packets on the control pipe. `setup()`/`data_out()` re-arm it after
+        // every consumed packet.
+        ep_cmd_write(
+            0,
+            Direction::Out,
+            CMD_A | nbytes(control_max_packet_size as u32) | addroff(ep0_out_addr),
+        );
+        ep_cmd_write(0, Direction::In, addroff(ep0_in_addr));
+
+        trace!("started");
+
+        (
+            Bus {
+                _phantom: PhantomData,
+                inited: false,
+                setup_addr: self.setup_addr,
+                ep0_out_addr,
+                ep0_mps: control_max_packet_size,
+            },
+            ControlPipe {
+                _phantom: PhantomData,
+                max_packet_size: control_max_packet_size,
+                setup_addr: self.setup_addr,
+                ep0_out_addr,
+                ep0_in_addr,
+            },
+        )
+    }
+}
+
+/// USB bus.
+pub struct Bus<'d, T: Instance> {
+    _phantom: PhantomData<&'d mut T>,
+    inited: bool,
+    setup_addr: u32,
+    ep0_out_addr: u32,
+    ep0_mps: u16,
+}
+
+impl<'d, T: Instance> driver::Bus for Bus<'d, T> {
+    async fn enable(&mut self) {
+        // Soft-connect.
+        devcmdstat_modify(T::regs(), |w| w.set_dcon(true));
+    }
+
+    async fn disable(&mut self) {
+        devcmdstat_modify(T::regs(), |w| w.set_dcon(false));
+    }
+
+    async fn poll(&mut self) -> Event {
+        poll_fn(move |cx| {
+            BUS_WAKER.register(cx.waker());
+
+            // No VBUS monitoring: report power immediately, once.
+            if !self.inited {
+                self.inited = true;
+                return Poll::Ready(Event::PowerDetected);
+            }
+
+            let regs = T::regs();
+            let dcs = regs.devcmdstat().read();
+
+            if dcs.dres_c() {
+                devcmdstat_modify(regs, |w| {
+                    w.set_dres_c(true);
+                    w.set_dev_addr(0);
+                });
+
+                // Disable all non-control endpoints; re-arm EP0 (EP0 OUT
+                // stays armed at all times) and keep the SETUP pointer.
+                for i in 1..EP_COUNT {
+                    ep_cmd_write(i, Direction::Out, CMD_D);
+                    ep_cmd_write(i, Direction::In, CMD_D);
+                }
+                ep_cmd_write(
+                    0,
+                    Direction::Out,
+                    CMD_A | nbytes(self.ep0_mps as u32) | addroff(self.ep0_out_addr),
+                );
+                ep_cmd_write(0, Direction::In, 0);
+                unsafe { ep_cmd_ptr(0, Direction::Out, true).write_volatile(addroff(self.setup_addr)) };
+
+                // Unstick any pending endpoint futures; they will observe the
+                // disabled/reset state.
+                for w in &EP_IN_WAKERS {
+                    w.wake();
+                }
+                for w in &EP_OUT_WAKERS {
+                    w.wake();
+                }
+
+                trace!("RESET");
+                return Poll::Ready(Event::Reset);
+            }
+
+            if dcs.dsus_c() {
+                devcmdstat_modify(regs, |w| w.set_dsus_c(true));
+                let event = if dcs.dsus() { Event::Suspend } else { Event::Resume };
+                trace!("{}", event);
+                return Poll::Ready(event);
+            }
+
+            if dcs.dcon_c() {
+                // No VBUS wired-status semantics needed; just acknowledge.
+                devcmdstat_modify(regs, |w| w.set_dcon_c(true));
+            }
+
+            Poll::Pending
+        })
+        .await
+    }
+
+    fn endpoint_set_enabled(&mut self, ep_addr: EndpointAddress, enabled: bool) {
+        trace!("set_enabled {:?} {}", ep_addr, enabled);
+        let index = ep_addr.index();
+        if index == 0 {
+            return;
+        }
+
+        if enabled {
+            // Clear Disabled, reset the data toggle to DATA0. Not Active:
+            // OUT endpoints NAK until a read arms them.
+            ep_cmd_write(index, ep_addr.direction(), CMD_TR);
+        } else {
+            ep_cmd_write(index, ep_addr.direction(), CMD_D);
+        }
+
+        match ep_addr.direction() {
+            Direction::Out => EP_OUT_WAKERS[index].wake(),
+            Direction::In => EP_IN_WAKERS[index].wake(),
+        }
+    }
+
+    fn endpoint_set_stalled(&mut self, ep_addr: EndpointAddress, stalled: bool) {
+        trace!("set_stalled {:?} {}", ep_addr, stalled);
+        let index = ep_addr.index();
+        let dir = ep_addr.direction();
+        let regs = T::regs();
+
+        if stalled {
+            if ep_cmd_read(index, dir) & CMD_A != 0 {
+                // Reclaim the active transfer first via EPSKIP.
+                let phy_ep = 2 * index + (dir == Direction::In) as usize;
+                regs.epskip().write_value(pac::usbhsd::regs::Epskip(1 << phy_ep));
+                while regs.epskip().read().0 & (1 << phy_ep) != 0 {}
+                regs.intstat().write_value(pac::usbhsd::regs::Intstat(1 << phy_ep));
+            }
+            ep_cmd_modify(index, dir, |w| (w & !CMD_A) | CMD_S);
+        } else {
+            // Clearing a stall resets the data toggle to DATA0.
+            ep_cmd_modify(index, dir, |w| (w & !CMD_S) | CMD_TR);
+        }
+
+        match dir {
+            Direction::Out => EP_OUT_WAKERS[index].wake(),
+            Direction::In => EP_IN_WAKERS[index].wake(),
+        }
+    }
+
+    fn endpoint_is_stalled(&mut self, ep_addr: EndpointAddress) -> bool {
+        ep_cmd_read(ep_addr.index(), ep_addr.direction()) & CMD_S != 0
+    }
+
+    async fn remote_wakeup(&mut self) -> Result<(), Unsupported> {
+        devcmdstat_modify(T::regs(), |w| w.set_dsus(false));
+        Ok(())
+    }
+}
+
+/// USB endpoint.
+pub struct Endpoint<'d, T: Instance, D> {
+    _phantom: PhantomData<(&'d mut T, D)>,
+    info: EndpointInfo,
+    buf_addr: u32,
+}
+
+impl<'d, T: Instance, D: Dir> driver::Endpoint for Endpoint<'d, T, D> {
+    fn info(&self) -> &EndpointInfo {
+        &self.info
+    }
+
+    async fn wait_enabled(&mut self) {
+        let index = self.info.addr.index();
+        let wakers = match D::dir() {
+            Direction::Out => &EP_OUT_WAKERS,
+            Direction::In => &EP_IN_WAKERS,
+        };
+        poll_fn(|cx| {
+            wakers[index].register(cx.waker());
+            if ep_cmd_read(index, D::dir()) & CMD_D == 0 {
+                Poll::Ready(())
+            } else {
+                Poll::Pending
+            }
+        })
+        .await;
+        trace!("wait_enabled {:?} OK", self.info.addr);
+    }
+}
+
+impl<'d, T: Instance> driver::EndpointOut for Endpoint<'d, T, Out> {
+    async fn read(&mut self, buf: &mut [u8]) -> Result<usize, EndpointError> {
+        let index = self.info.addr.index();
+        let mps = self.info.max_packet_size as u32;
+
+        if ep_cmd_read(index, Direction::Out) & CMD_D != 0 {
+            return Err(EndpointError::Disabled);
+        }
+
+        // Arm reception, preserving the data toggle. The endpoint NAKs while
+        // not armed, which is the correct default behavior.
+        ep_arm(index, Direction::Out, mps, self.buf_addr);
+
+        let word = poll_fn(|cx| {
+            EP_OUT_WAKERS[index].register(cx.waker());
+            let word = ep_cmd_read(index, Direction::Out);
+            if word & CMD_D != 0 {
+                // Disabled by a bus reset while waiting.
+                return Poll::Ready(Err(EndpointError::Disabled));
+            }
+            if word & CMD_A == 0 {
+                Poll::Ready(Ok(word))
+            } else {
+                Poll::Pending
+            }
+        })
+        .await?;
+
+        let rx_len = (mps - remaining_bytes(word)) as usize;
+        if rx_len > buf.len() {
+            return Err(EndpointError::BufferOverflow);
+        }
+        copy_from_usb_sram(self.buf_addr, &mut buf[..rx_len]);
+
+        trace!("READ {:?} rx_len = {}", self.info.addr, rx_len);
+        Ok(rx_len)
+    }
+}
+
+impl<'d, T: Instance> driver::EndpointIn for Endpoint<'d, T, In> {
+    async fn write(&mut self, buf: &[u8]) -> Result<(), EndpointError> {
+        if buf.len() > self.info.max_packet_size as usize {
+            return Err(EndpointError::BufferOverflow);
+        }
+
+        let index = self.info.addr.index();
+        if ep_cmd_read(index, Direction::In) & CMD_D != 0 {
+            return Err(EndpointError::Disabled);
+        }
+
+        copy_to_usb_sram(self.buf_addr, buf);
+        // Hardware advances the AddressOffset and NBytes as it transmits:
+        // always re-write those fields, preserving only the data toggle.
+        ep_arm(index, Direction::In, buf.len() as u32, self.buf_addr);
+
+        poll_fn(|cx| {
+            EP_IN_WAKERS[index].register(cx.waker());
+            let word = ep_cmd_read(index, Direction::In);
+            if word & CMD_D != 0 {
+                return Poll::Ready(Err(EndpointError::Disabled));
+            }
+            if word & CMD_A == 0 {
+                Poll::Ready(Ok(()))
+            } else {
+                Poll::Pending
+            }
+        })
+        .await?;
+
+        trace!("WRITE {:?} len = {}", self.info.addr, buf.len());
+        Ok(())
+    }
+}
+
+/// USB control pipe (endpoint 0, both directions).
+pub struct ControlPipe<'d, T: Instance> {
+    _phantom: PhantomData<&'d mut T>,
+    max_packet_size: u16,
+    setup_addr: u32,
+    ep0_out_addr: u32,
+    ep0_in_addr: u32,
+}
+
+impl<'d, T: Instance> driver::ControlPipe for ControlPipe<'d, T> {
+    fn max_packet_size(&self) -> usize {
+        self.max_packet_size as usize
+    }
+
+    async fn setup(&mut self) -> [u8; 8] {
+        let regs = T::regs();
+
+        poll_fn(|cx| {
+            EP_OUT_WAKERS[0].register(cx.waker());
+            if regs.devcmdstat().read().setup() {
+                Poll::Ready(())
+            } else {
+                Poll::Pending
+            }
+        })
+        .await;
+
+        // UM procedure: clear Active and Stall on both EP0 directions BEFORE
+        // acknowledging the SETUP bit.
+        ep_cmd_modify(0, Direction::Out, |w| w & !(CMD_A | CMD_S));
+        ep_cmd_modify(0, Direction::In, |w| w & !(CMD_A | CMD_S));
+
+        let mut buf = [0; 8];
+        copy_from_usb_sram(self.setup_addr, &mut buf);
+
+        devcmdstat_modify(regs, |w| w.set_setup(true));
+
+        // Hardware may overwrite the SETUP slot's address field: re-write it,
+        // and re-arm EP0 OUT for the next packet.
+        unsafe { ep_cmd_ptr(0, Direction::Out, true).write_volatile(addroff(self.setup_addr)) };
+        ep_cmd_write(
+            0,
+            Direction::Out,
+            CMD_A | nbytes(self.max_packet_size as u32) | addroff(self.ep0_out_addr),
+        );
+
+        trace!("SETUP {=[u8]:x}", buf);
+        buf
+    }
+
+    async fn data_out(&mut self, buf: &mut [u8], _first: bool, _last: bool) -> Result<usize, EndpointError> {
+        let regs = T::regs();
+        let mps = self.max_packet_size as u32;
+
+        // EP0 OUT is already armed (from `setup()` or the previous
+        // `data_out()`); just wait for the packet.
+
+        let word = poll_fn(|cx| {
+            EP_OUT_WAKERS[0].register(cx.waker());
+            // A new SETUP aborts the transfer (trait contract).
+            if regs.devcmdstat().read().setup() {
+                return Poll::Ready(Err(EndpointError::Disabled));
+            }
+            let word = ep_cmd_read(0, Direction::Out);
+            if word & CMD_A == 0 {
+                Poll::Ready(Ok(word))
+            } else {
+                Poll::Pending
+            }
+        })
+        .await?;
+
+        let rx_len = (mps - remaining_bytes(word)) as usize;
+        if rx_len > buf.len() {
+            return Err(EndpointError::BufferOverflow);
+        }
+        copy_from_usb_sram(self.ep0_out_addr, &mut buf[..rx_len]);
+
+        // Re-arm for the next OUT packet (or the status stage).
+        ep_cmd_write(0, Direction::Out, CMD_A | nbytes(mps) | addroff(self.ep0_out_addr));
+
+        trace!("control: data_out rx_len = {}", rx_len);
+        Ok(rx_len)
+    }
+
+    async fn data_in(&mut self, data: &[u8], _first: bool, last: bool) -> Result<(), EndpointError> {
+        trace!("control: data_in len = {} last = {}", data.len(), last);
+        if data.len() > self.max_packet_size as usize {
+            return Err(EndpointError::BufferOverflow);
+        }
+
+        let regs = T::regs();
+        if regs.devcmdstat().read().setup() {
+            return Err(EndpointError::Disabled);
+        }
+
+        copy_to_usb_sram(self.ep0_in_addr, data);
+        ep_cmd_write(
+            0,
+            Direction::In,
+            CMD_A | nbytes(data.len() as u32) | addroff(self.ep0_in_addr),
+        );
+
+        poll_fn(|cx| {
+            EP_IN_WAKERS[0].register(cx.waker());
+            if regs.devcmdstat().read().setup() {
+                return Poll::Ready(Err(EndpointError::Disabled));
+            }
+            if ep_cmd_read(0, Direction::In) & CMD_A == 0 {
+                Poll::Ready(Ok(()))
+            } else {
+                Poll::Pending
+            }
+        })
+        .await?;
+
+        // The status-stage OUT ZLP is accepted by the always-armed EP0 OUT
+        // buffer; nothing else to do for `last`.
+        let _ = last;
+
+        Ok(())
+    }
+
+    async fn accept(&mut self) {
+        trace!("control: accept");
+
+        // Zero-length status-stage IN packet.
+        ep_cmd_write(0, Direction::In, CMD_A | addroff(self.ep0_in_addr));
+
+        poll_fn(|cx| {
+            EP_IN_WAKERS[0].register(cx.waker());
+            // Bail out if the host abandoned the request with a new SETUP.
+            if T::regs().devcmdstat().read().setup() {
+                return Poll::Ready(());
+            }
+            if ep_cmd_read(0, Direction::In) & CMD_A == 0 {
+                Poll::Ready(())
+            } else {
+                Poll::Pending
+            }
+        })
+        .await;
+    }
+
+    async fn reject(&mut self) {
+        trace!("control: reject");
+        // Stall both EP0 directions; `setup()` clears the stalls on the next
+        // SETUP packet.
+        ep_cmd_modify(0, Direction::Out, |w| w | CMD_S);
+        ep_cmd_modify(0, Direction::In, |w| w | CMD_S);
+    }
+
+    async fn accept_set_address(&mut self, addr: u8) {
+        trace!("setting addr: {}", addr);
+        // ip3511 quirk (UM11126): the new device address must be programmed
+        // BEFORE the status stage completes, contrary to the USB spec's
+        // "after the status stage" wording. lpc55-hal encodes the same order
+        // via usb-device's `QUIRK_SET_ADDRESS_BEFORE_STATUS`.
+        devcmdstat_modify(T::regs(), |w| w.set_dev_addr(addr));
+        self.accept().await;
+    }
+}

--- a/embassy-nxp/src/usb/lpc55.rs
+++ b/embassy-nxp/src/usb/lpc55.rs
@@ -134,6 +134,17 @@ const CMD_TR: u32 = 1 << 28; // Toggle Reset (write-1)
 const CMD_TV: u32 = 1 << 27; // RF/TV: data toggle value for bulk/interrupt
 const CMD_T: u32 = 1 << 26; // Endpoint type: 0 = generic, 1 = isochronous
 
+/// A slot carrying either of these bits must not be armed or treated as
+/// complete.
+///
+/// `S` and `A` share one command word on ip3511, so a host-requested stall
+/// looks exactly like a completed transfer to a `poll_fn` that only tests `A`.
+/// Re-arming such a slot would overwrite `S` and silently un-halt the endpoint,
+/// so every read and write path reports [`EndpointError::Disabled`] instead -
+/// the trait's only "not usable right now" signal. Note that `wait_enabled`
+/// deliberately keeps testing `D` alone: a stalled endpoint is still enabled.
+const CMD_UNUSABLE: u32 = CMD_D | CMD_S;
+
 /// Per-endpoint state flags, kept in an `AtomicU8`.
 ///
 /// Double-buffer bookkeeping for data endpoints is shared between [`Bus`]
@@ -1320,10 +1331,21 @@ impl<'d, T: Instance> driver::Bus for Bus<'d, T> {
         let iso = state.load(Ordering::Relaxed) & ISO;
 
         if enabled {
-            // Both slots idle (NAK until armed). Hardware must restart on
-            // slot 0 to match the software cursor, and the data toggle is
-            // reset on the first armed transfer (TR_PENDING).
-            ep_cmd_write(self.ep_list, index, dir, 0, 0);
+            // Both slots idle (NAK until armed) with the data toggle reset,
+            // which USB requires whenever a SET_CONFIGURATION or SET_INTERFACE
+            // enables an endpoint. Hardware must also restart on slot 0 to match
+            // the software cursor.
+            //
+            // `TR` has to be in the word here and not only deferred to the first
+            // armed transfer via `TR_PENDING`: the full-speed block otherwise
+            // keeps the pre-disable toggle and silently drops the first packets
+            // after an alternate setting switches the endpoint back on.
+            //
+            // Only slot 0 carries it. `TR` is honoured on an inactive entry, so
+            // arming both slots with it lets hardware reset the toggle a second
+            // time after the first packet has already flipped it, which corrupts
+            // the very next transfer. Isochronous endpoints have no toggle at all.
+            ep_cmd_write(self.ep_list, index, dir, 0, if iso != 0 { 0 } else { CMD_TR });
             ep_cmd_write(self.ep_list, index, dir, 1, 0);
             let phy_ep = 2 * index + (dir == Direction::In) as usize;
             T::regs()
@@ -1371,9 +1393,19 @@ impl<'d, T: Instance> driver::Bus for Bus<'d, T> {
             ep_cmd_modify(self.ep_list, index, dir, 0, |w| (w & !CMD_S) | CMD_TR);
         } else {
             // Drop any buffered packets, resync the hardware slot cursor and
-            // defer the toggle reset to the next armed transfer.
+            // reset the data toggle, which USB requires when a halt is cleared.
+            //
+            // Both slot words are rewritten whole rather than having `S` and `A`
+            // masked out: keeping the aborted transfer's NBytes and
+            // AddressOffset leaves the full-speed block wedged - it acknowledges
+            // the next OUT packets on the wire and discards them without ever
+            // completing the entry.
+            //
+            // The toggle reset lands on slot 0 only, for the reason spelled out
+            // in `endpoint_set_enabled`.
             for slot in slots {
-                ep_cmd_modify(self.ep_list, index, dir, slot, |w| w & !(CMD_S | CMD_A));
+                let word = if slot == 0 && !iso { CMD_TR } else { 0 };
+                ep_cmd_write(self.ep_list, index, dir, slot, word);
             }
             regs.epinuse().modify(|w| w.set_buf(w.buf() & !(1 << (phy_ep - 2))));
             let state = T::state().ep_state(index, dir);
@@ -1468,7 +1500,7 @@ impl<'d, T: Instance> driver::EndpointOut for Endpoint<'d, T, Out> {
         let mut s = state.load(Ordering::Relaxed);
         for slot in 0..2 {
             if s & (PRIMED0 << slot) == 0 {
-                if ep_cmd_read(self.ep_list, index, Direction::Out, slot) & CMD_D != 0 {
+                if ep_cmd_read(self.ep_list, index, Direction::Out, slot) & CMD_UNUSABLE != 0 {
                     return Err(EndpointError::Disabled);
                 }
                 ep_arm_slot::<T>(
@@ -1492,8 +1524,8 @@ impl<'d, T: Instance> driver::EndpointOut for Endpoint<'d, T, Out> {
         let word = poll_fn(|cx| {
             T::state().ep_out_wakers[index].register(cx.waker());
             let word = ep_cmd_read(self.ep_list, index, Direction::Out, slot);
-            if word & CMD_D != 0 {
-                // Disabled by a bus reset while waiting.
+            if word & CMD_UNUSABLE != 0 {
+                // Disabled by a bus reset, or stalled by the host, while waiting.
                 return Poll::Ready(Err(EndpointError::Disabled));
             }
             if state.load(Ordering::Relaxed) & (PRIMED0 << slot) == 0 {
@@ -1517,6 +1549,13 @@ impl<'d, T: Instance> driver::EndpointOut for Endpoint<'d, T, Out> {
             return Err(EndpointError::BufferOverflow);
         }
         copy_from_ep_buffer(self.buf_addrs[slot], &mut buf[..rx_len]);
+
+        // A host halt landing between the completion poll and here would be
+        // erased by the re-arm below, so drop the packet instead: the host asked
+        // for the endpoint to stop.
+        if ep_cmd_read(self.ep_list, index, Direction::Out, slot) & CMD_S != 0 {
+            return Err(EndpointError::Disabled);
+        }
 
         // Hand the drained slot straight back to hardware and advance the
         // consume cursor.
@@ -1566,7 +1605,7 @@ impl<'d, T: Instance> driver::EndpointIn for Endpoint<'d, T, In> {
             poll_fn(|cx| {
                 T::state().ep_in_wakers[index].register(cx.waker());
                 let word = ep_cmd_read(self.ep_list, index, Direction::In, slot);
-                if word & CMD_D != 0 {
+                if word & CMD_UNUSABLE != 0 {
                     return Poll::Ready(Err(EndpointError::Disabled));
                 }
                 if word & CMD_A == 0 {
@@ -1582,6 +1621,12 @@ impl<'d, T: Instance> driver::EndpointIn for Endpoint<'d, T, In> {
             let s = state.load(Ordering::Relaxed);
             if (s & SLOT) as usize != slot {
                 continue;
+            }
+
+            // Same hazard as in `read`: a host halt landing here would be
+            // erased by the arm below.
+            if ep_cmd_read(self.ep_list, index, Direction::In, slot) & CMD_S != 0 {
+                return Err(EndpointError::Disabled);
             }
 
             copy_to_ep_buffer(self.buf_addrs[slot], buf);

--- a/embassy-nxp/src/usb/lpc55.rs
+++ b/embassy-nxp/src/usb/lpc55.rs
@@ -95,7 +95,7 @@
 
 use core::future::poll_fn;
 use core::marker::PhantomData;
-use core::sync::atomic::{AtomicBool, AtomicU8, Ordering, compiler_fence};
+use core::sync::atomic::{AtomicBool, AtomicU8, AtomicU32, Ordering, compiler_fence};
 use core::task::Poll;
 
 use embassy_hal_internal::{Peri, PeripheralType};
@@ -123,6 +123,11 @@ const USB1_SRAM_SIZE: u32 = 0x4000;
 /// buffer 64-byte aligned for every instance. EP0's `out_buf1` slot holds the
 /// SETUP buffer pointer rather than a command word.
 const EP_LIST_LEN: u32 = 0x80;
+const EP0_SETUP_OFFSET: u32 = EP_LIST_LEN;
+const EP0_OUT_OFFSET: u32 = EP0_SETUP_OFFSET + 64;
+const EP0_IN_OFFSET: u32 = EP0_OUT_OFFSET + 64;
+const DATA_BUFFER_OFFSET: u32 = EP0_IN_OFFSET + 64;
+const SLOT_RECLAIM_SPINS: usize = 1_000_000;
 
 // Endpoint command/status word encoding. The bit flags below are common to
 // both controllers; the NBytes and AddressOffset field positions differ and
@@ -165,6 +170,11 @@ pub(crate) struct State {
     ep_out_wakers: [AtomicWaker; MAX_EP_COUNT],
     ep_in_state: [AtomicU8; MAX_EP_COUNT],
     ep_out_state: [AtomicU8; MAX_EP_COUNT],
+    alive: AtomicBool,
+    setup_pending: AtomicBool,
+    lifecycle_generation: AtomicU32,
+    ep_in_generation: [AtomicU32; MAX_EP_COUNT],
+    ep_out_generation: [AtomicU32; MAX_EP_COUNT],
 }
 
 impl State {
@@ -175,6 +185,11 @@ impl State {
             ep_out_wakers: [const { AtomicWaker::new() }; MAX_EP_COUNT],
             ep_in_state: [const { AtomicU8::new(0) }; MAX_EP_COUNT],
             ep_out_state: [const { AtomicU8::new(0) }; MAX_EP_COUNT],
+            alive: AtomicBool::new(false),
+            setup_pending: AtomicBool::new(false),
+            lifecycle_generation: AtomicU32::new(0),
+            ep_in_generation: [const { AtomicU32::new(0) }; MAX_EP_COUNT],
+            ep_out_generation: [const { AtomicU32::new(0) }; MAX_EP_COUNT],
         }
     }
 
@@ -189,6 +204,43 @@ impl State {
         match dir {
             Direction::Out => &self.ep_out_wakers[index],
             Direction::In => &self.ep_in_wakers[index],
+        }
+    }
+
+    fn ep_generation(&self, index: usize, dir: Direction) -> &AtomicU32 {
+        match dir {
+            Direction::Out => &self.ep_out_generation[index],
+            Direction::In => &self.ep_in_generation[index],
+        }
+    }
+
+    fn wake_all(&self) {
+        self.bus_waker.wake();
+        for waker in &self.ep_in_wakers {
+            waker.wake();
+        }
+        for waker in &self.ep_out_wakers {
+            waker.wake();
+        }
+    }
+
+    fn invalidate_controller(&self) {
+        self.lifecycle_generation.fetch_add(1, Ordering::Relaxed);
+        self.setup_pending.store(false, Ordering::Release);
+        self.wake_all();
+    }
+
+    fn invalidate_endpoint(&self, index: usize, dir: Direction) {
+        self.ep_generation(index, dir).fetch_add(1, Ordering::Relaxed);
+        self.ep_waker(index, dir).wake();
+    }
+
+    fn note_setup(&self) {
+        if !self.setup_pending.swap(true, Ordering::AcqRel) {
+            self.ep_out_generation[0].fetch_add(1, Ordering::Relaxed);
+            self.ep_in_generation[0].fetch_add(1, Ordering::Relaxed);
+            self.ep_out_wakers[0].wake();
+            self.ep_in_wakers[0].wake();
         }
     }
 }
@@ -242,6 +294,65 @@ fn ep_cmd_modify(ep_list: u32, index: usize, dir: Direction, slot: usize, f: imp
         let p = ep_cmd_ptr(ep_list, index, dir, slot != 0);
         unsafe { p.write_volatile(f(p.read_volatile())) }
     });
+}
+fn valid_endpoint<T: Instance>(ep_addr: EndpointAddress) -> Option<(usize, Direction)> {
+    let index = ep_addr.index();
+    (index < T::EP_COUNT).then_some((index, ep_addr.direction()))
+}
+
+fn select_slot<T: Instance>(index: usize, dir: Direction, slot: usize) {
+    if index == 0 {
+        return;
+    }
+    let bit = 1 << (2 * index + (dir == Direction::In) as usize - 2);
+    T::regs().epinuse().modify(|w| {
+        let selected = if slot == 0 { w.buf() & !bit } else { w.buf() | bit };
+        w.set_buf(selected);
+    });
+}
+
+fn reclaim_slot<T: Instance>(ep_list: u32, index: usize, dir: Direction, slot: usize) {
+    let regs = T::regs();
+    let phy_ep = 2 * index + (dir == Direction::In) as usize;
+    select_slot::<T>(index, dir, slot);
+    if ep_cmd_read(ep_list, index, dir, slot) & CMD_A == 0 {
+        return;
+    }
+
+    let mask = 1 << phy_ep;
+    regs.epskip().write_value(pac::usbhsd::regs::Epskip(mask));
+    for _ in 0..SLOT_RECLAIM_SPINS {
+        if regs.epskip().read().0 & mask == 0 && ep_cmd_read(ep_list, index, dir, slot) & CMD_A == 0 {
+            return;
+        }
+    }
+
+    let direction = if dir == Direction::In { "IN" } else { "OUT" };
+    panic!(
+        "USB endpoint {} {} slot {} did not release: command={}, EPSKIP={}, EPINUSE={}, DEVCMDSTAT={}",
+        index,
+        direction,
+        slot,
+        ep_cmd_read(ep_list, index, dir, slot),
+        regs.epskip().read().0,
+        regs.epinuse().read().0,
+        regs.devcmdstat().read().0
+    );
+}
+
+fn reclaim_slots<T: Instance>(ep_list: u32, index: usize, dir: Direction) {
+    let regs = T::regs();
+    let phy_ep = 2 * index + (dir == Direction::In) as usize;
+    if index == 0 {
+        reclaim_slot::<T>(ep_list, index, dir, 0);
+    } else {
+        let bit = 1 << (phy_ep - 2);
+        let current = ((regs.epinuse().read().buf() & bit) != 0) as usize;
+        reclaim_slot::<T>(ep_list, index, dir, current);
+        reclaim_slot::<T>(ep_list, index, dir, current ^ 1);
+    }
+    regs.intstat().write_value(pac::usbhsd::regs::Intstat(1 << phy_ep));
+    select_slot::<T>(index, dir, 0);
 }
 
 /// Arm one buffer slot of a data endpoint.
@@ -380,8 +491,8 @@ fn program_controller<T: Instance>(ep_list: u32) {
 trait SealedInstance {
     fn regs() -> pac::usbhsd::Usbhsd;
     fn state() -> &'static State;
-    /// Power up clocks + PHY for this controller. Idempotent.
-    fn power_up();
+    /// Power up clocks and the PHY for this controller.
+    fn power_up(uses_usb1_sram: bool);
     /// Power the PHY down and gate this controller's clocks.
     fn power_down();
 }
@@ -394,6 +505,8 @@ pub trait Instance: SealedInstance + PeripheralType + 'static {
 
     /// Number of logical endpoints (EP0 plus data endpoints).
     const EP_COUNT: usize;
+    /// Whether this instance accepts only high-speed negotiation.
+    const HIGH_SPEED: bool;
     /// NBytes field of the command/status word.
     const NBYTES_SHIFT: u32;
     /// Mask of the NBytes field, before shifting.
@@ -438,14 +551,15 @@ impl SealedInstance for crate::peripherals::USBHSD {
         &STATE
     }
 
-    fn power_up() {
+    fn power_up(uses_usb1_sram: bool) {
         use pac::syscon::vals::{Usb1DevRst, Usb1HostRst, Usb1PhyRst, Usb1RamRst};
 
-        // Reset the USB1 blocks sequentially, per block, with their clocks
-        // still off — the exact order lpc55-hal's `enabled_as_device` uses
-        // (host, then device + RAM, then PHY). Clocks are enabled per block
-        // further down, right before each block is first used.
         critical_section::with(|_| {
+            let users = USB1_SRAM_USERS.load(Ordering::Relaxed);
+            let reset_ram = users == 0 || (uses_usb1_sram && users == 1);
+            USBHSD_ACTIVE.store(true, Ordering::Release);
+            pac::SYSCON.ahbclkctrl2().modify(|w| w.set_usb1_ram(true));
+
             pac::SYSCON
                 .presetctrl2()
                 .modify(|w| w.set_usb1_host_rst(Usb1HostRst::Asserted));
@@ -454,11 +568,15 @@ impl SealedInstance for crate::peripherals::USBHSD {
                 .modify(|w| w.set_usb1_host_rst(Usb1HostRst::Released));
             pac::SYSCON.presetctrl2().modify(|w| {
                 w.set_usb1_dev_rst(Usb1DevRst::Asserted);
-                w.set_usb1_ram_rst(Usb1RamRst::Asserted);
+                if reset_ram {
+                    w.set_usb1_ram_rst(Usb1RamRst::Asserted);
+                }
             });
             pac::SYSCON.presetctrl2().modify(|w| {
                 w.set_usb1_dev_rst(Usb1DevRst::Released);
-                w.set_usb1_ram_rst(Usb1RamRst::Released);
+                if reset_ram {
+                    w.set_usb1_ram_rst(Usb1RamRst::Released);
+                }
             });
             pac::SYSCON
                 .presetctrl2()
@@ -466,8 +584,6 @@ impl SealedInstance for crate::peripherals::USBHSD {
             pac::SYSCON
                 .presetctrl2()
                 .modify(|w| w.set_usb1_phy_rst(Usb1PhyRst::Released));
-
-            // Host block clock on, only briefly, to hand the shared port over.
             pac::SYSCON.ahbclkctrl2().modify(|w| w.set_usb1_host(true));
         });
 
@@ -559,13 +675,8 @@ impl SealedInstance for crate::peripherals::USBHSD {
         // Power up everything in the PHY.
         phy.pwd().write_value(pac::usbphy::regs::Pwd(0));
 
-        // Device controller + dedicated USB RAM clocks on, last (mirrors
-        // lpc55-hal's `enable_clock(USB1)` which gates both).
         critical_section::with(|_| {
-            pac::SYSCON.ahbclkctrl2().modify(|w| {
-                w.set_usb1_dev(true);
-                w.set_usb1_ram(true);
-            });
+            pac::SYSCON.ahbclkctrl2().modify(|w| w.set_usb1_dev(true));
         });
     }
 
@@ -578,9 +689,11 @@ impl SealedInstance for crate::peripherals::USBHSD {
             .pdruncfgset0()
             .write(|w| w.set_pdruncfgset0(PDEN_USBHSPHY | PDEN_LDOUSBHS));
         critical_section::with(|_| {
+            USBHSD_ACTIVE.store(false, Ordering::Release);
+            let keep_ram = USB1_SRAM_USERS.load(Ordering::Relaxed) != 0;
             pac::SYSCON.ahbclkctrl2().modify(|w| {
                 w.set_usb1_dev(false);
-                w.set_usb1_ram(false);
+                w.set_usb1_ram(keep_ram);
                 w.set_usb1_phy(false);
             });
         });
@@ -591,6 +704,7 @@ impl Instance for crate::peripherals::USBHSD {
     type Interrupt = crate::interrupt::typelevel::USB1;
 
     const EP_COUNT: usize = 6;
+    const HIGH_SPEED: bool = true;
     const NBYTES_SHIFT: u32 = 11;
     const NBYTES_MASK: u32 = 0x7FFF;
     const ADDROFF_MASK: u32 = 0x7FF;
@@ -632,7 +746,7 @@ impl SealedInstance for crate::peripherals::USB0 {
         &STATE
     }
 
-    fn power_up() {
+    fn power_up(_uses_usb1_sram: bool) {
         use pac::syscon::vals::{Usb0DevRst, Usb0clkdivHalt, Usb0clkdivReqflag, Usb0clkselSel};
 
         // The FS controller clocks off FRO-HF regardless of
@@ -720,6 +834,7 @@ impl Instance for crate::peripherals::USB0 {
     /// EP0's pair, `epskip.skip` / `inten.ep_int_en` are 10 bits), matching
     /// lpc55-hal's endpoint-list layout of `ep0out, setup, ep0in, _, eps[4]`.
     const EP_COUNT: usize = 5;
+    const HIGH_SPEED: bool = false;
     const NBYTES_SHIFT: u32 = 16;
     const NBYTES_MASK: u32 = 0x3FF;
     const ADDROFF_MASK: u32 = 0xFFFF;
@@ -759,30 +874,79 @@ impl VbusPin for crate::peripherals::PIO0_22 {}
 pub struct Memory<'d> {
     base: u32,
     len: u32,
-    _lifetime: PhantomData<&'d mut ()>,
+    lease: MemoryLease<'d>,
 }
 
-static USB1_SRAM_TAKEN: AtomicBool = AtomicBool::new(false);
+static USB1_SRAM_USERS: AtomicU8 = AtomicU8::new(0);
+static USBHSD_ACTIVE: AtomicBool = AtomicBool::new(false);
+
+struct Usb1SramLease;
+
+impl Usb1SramLease {
+    fn new() -> Self {
+        critical_section::with(|_| {
+            if USB1_SRAM_USERS.load(Ordering::Relaxed) != 0 {
+                panic!("USB1 SRAM already in use");
+            }
+            USB1_SRAM_USERS.store(1, Ordering::Relaxed);
+            pac::SYSCON.ahbclkctrl2().modify(|w| w.set_usb1_ram(true));
+        });
+        Self
+    }
+
+    fn clone_lease(&self) -> Self {
+        critical_section::with(|_| {
+            let users = USB1_SRAM_USERS.load(Ordering::Relaxed);
+            let next = users.checked_add(1).expect("USB1 SRAM lease count overflow");
+            USB1_SRAM_USERS.store(next, Ordering::Relaxed);
+        });
+        Self
+    }
+}
+
+impl Drop for Usb1SramLease {
+    fn drop(&mut self) {
+        critical_section::with(|_| {
+            let users = USB1_SRAM_USERS.load(Ordering::Relaxed);
+            debug_assert!(users != 0);
+            let remaining = users - 1;
+            USB1_SRAM_USERS.store(remaining, Ordering::Relaxed);
+            if remaining == 0 && !USBHSD_ACTIVE.load(Ordering::Acquire) {
+                pac::SYSCON.ahbclkctrl2().modify(|w| w.set_usb1_ram(false));
+            }
+        });
+    }
+}
+
+enum MemoryLease<'d> {
+    Usb1Sram(Usb1SramLease),
+    Buffer(PhantomData<&'d mut [u8]>),
+}
+
+impl<'d> MemoryLease<'d> {
+    fn clone_lease(&self) -> Self {
+        match self {
+            Self::Usb1Sram(lease) => Self::Usb1Sram(lease.clone_lease()),
+            Self::Buffer(_) => Self::Buffer(PhantomData),
+        }
+    }
+
+    fn uses_usb1_sram(&self) -> bool {
+        matches!(self, Self::Usb1Sram(_))
+    }
+}
 
 impl<'d> Memory<'d> {
     /// The dedicated 16 KiB USB1 SRAM at `0x4010_0000`.
     ///
-    /// Usable by either controller, but only by one at a time: constructing a
-    /// second one panics. There is no release path; the region is held for the
-    /// lifetime of the driver.
+    /// Usable by either controller, but only by one endpoint-memory owner at a
+    /// time. The claim is released after the last split driver object is
+    /// dropped.
     pub fn usb1_sram() -> Self {
-        if USB1_SRAM_TAKEN.swap(true, Ordering::Relaxed) {
-            panic!("USB1 SRAM already in use");
-        }
-        // The dedicated RAM has its own clock gate, independent of whichever
-        // controller ends up addressing it.
-        critical_section::with(|_| {
-            pac::SYSCON.ahbclkctrl2().modify(|w| w.set_usb1_ram(true));
-        });
         Self {
             base: USB1_SRAM_ADDR,
             len: USB1_SRAM_SIZE,
-            _lifetime: PhantomData,
+            lease: MemoryLease::Usb1Sram(Usb1SramLease::new()),
         }
     }
 
@@ -794,9 +958,9 @@ impl<'d> Memory<'d> {
     ///
     /// `buf` needs no particular alignment. `EPLISTSTART` reserves the low 8
     /// bits of the address, so up to 255 bytes at the front of `buf` are
-    /// skipped; at least 512 bytes must be left after that. Using this instead
-    /// of [`Memory::usb1_sram`] is what allows USB0 and USB1 to run at the same
-    /// time.
+    /// skipped; at least 512 bytes must be left after that. USB0 can use this
+    /// memory while USBHSD uses [`Memory::usb1_sram`]. USBHSD itself cannot
+    /// use this memory because its command/status list is fixed to USB1 SRAM.
     pub fn buffer(buf: &'d mut [u8]) -> Self {
         let raw_base = buf.as_mut_ptr() as u32;
         let base = raw_base.next_multiple_of(256);
@@ -808,7 +972,7 @@ impl<'d> Memory<'d> {
         Self {
             base,
             len,
-            _lifetime: PhantomData,
+            lease: MemoryLease::Buffer(PhantomData),
         }
     }
 
@@ -855,8 +1019,11 @@ pub struct InterruptHandler<T: Instance> {
 
 impl<T: Instance> crate::interrupt::typelevel::Handler<T::Interrupt> for InterruptHandler<T> {
     unsafe fn on_interrupt() {
-        let regs = T::regs();
         let state = T::state();
+        if !state.alive.load(Ordering::Acquire) {
+            return;
+        }
+        let regs = T::regs();
         let stat = regs.intstat().read();
         // W1C exactly the bits we saw. Later-arriving bits stay pending and
         // re-fire the interrupt. Losing an edge is safe by design: the futures
@@ -872,11 +1039,8 @@ impl<T: Instance> crate::interrupt::typelevel::Handler<T::Interrupt> for Interru
             }
         }
 
-        // A pending SETUP must abort in-flight control transfers in either
-        // direction, so wake both EP0 futures.
         if regs.devcmdstat().read().setup() {
-            state.ep_out_wakers[0].wake();
-            state.ep_in_wakers[0].wake();
+            state.note_setup();
         }
 
         // dev_int: DEVCMDSTAT change bits are consumed by `Bus::poll`.
@@ -885,11 +1049,42 @@ impl<T: Instance> crate::interrupt::typelevel::Handler<T::Interrupt> for Interru
         }
     }
 }
+fn shutdown_controller<T: Instance>(ep_list: u32) {
+    let state = T::state();
+    if !state.alive.swap(false, Ordering::AcqRel) {
+        return;
+    }
+    state.invalidate_controller();
+
+    critical_section::with(|_| {
+        let regs = T::regs();
+        devcmdstat_modify(regs, |w| {
+            w.set_dcon(false);
+            w.set_dev_en(false);
+        });
+        for index in 0..T::EP_COUNT {
+            for dir in [Direction::Out, Direction::In] {
+                reclaim_slots::<T>(ep_list, index, dir);
+                ep_cmd_write(ep_list, index, dir, 0, CMD_D);
+                ep_cmd_write(ep_list, index, dir, 1, CMD_D);
+            }
+        }
+        regs.inten().write_value(pac::usbhsd::regs::Inten(0));
+        regs.intstat()
+            .write_value(pac::usbhsd::regs::Intstat(ep_int_mask::<T>() as u32 | (1 << 31)));
+    });
+
+    T::Interrupt::disable();
+    T::Interrupt::unpend();
+    state.wake_all();
+    T::power_down();
+}
 
 /// LPC55 USB device driver.
 pub struct Driver<'d, T: Instance> {
-    _usb: Peri<'d, T>,
+    _usb: Option<Peri<'d, T>>,
     _vbus: Option<Peri<'d, crate::gpio::AnyPin>>,
+    memory: Option<MemoryLease<'d>>,
     ep_in_used: [bool; MAX_EP_COUNT],
     ep_out_used: [bool; MAX_EP_COUNT],
     /// Base of the endpoint memory: the command/status list starts here.
@@ -900,17 +1095,25 @@ pub struct Driver<'d, T: Instance> {
     alloc_offset: u32,
     /// Address of the 8-byte (64-byte aligned) SETUP buffer.
     setup_addr: u32,
+    ep0_out_addr: u32,
+    ep0_in_addr: u32,
 }
 
 impl<'d> Driver<'d, crate::peripherals::USBHSD> {
     /// Create a new USB1 high-speed driver.
     ///
     /// This powers up and configures the USB1 PHY (expects a 16 MHz crystal)
-    /// and the device controller, but does not connect to the bus yet; the
-    /// soft-connect happens in [`driver::Bus::enable`].
+    /// and the device controller. It does not connect to the bus yet;
+    /// [`driver::Bus::enable`] controls the soft-connect.
+    ///
+    /// USBHSD is high-speed-only in this release. The driver disconnects and
+    /// panics if the host negotiates a fallback speed.
     ///
     /// Requires a system clock of at least 96 MHz, see
     /// [`crate::config::MainClock::FroHf96`].
+    ///
+    /// `memory` must be [`Memory::usb1_sram`]. The USBHSD controller cannot
+    /// write its command/status list to main SRAM.
     pub fn new(
         usb: Peri<'d, crate::peripherals::USBHSD>,
         _irq: impl Binding<crate::interrupt::typelevel::USB1, InterruptHandler<crate::peripherals::USBHSD>> + 'd,
@@ -954,47 +1157,59 @@ impl<'d> Driver<'d, crate::peripherals::USB0> {
 
 impl<'d, T: Instance> Driver<'d, T> {
     fn new_inner(usb: Peri<'d, T>, vbus: Option<Peri<'d, crate::gpio::AnyPin>>, memory: Memory<'d>) -> Self {
-        let Memory { base, len, .. } = memory;
+        let Memory { base, len, lease } = memory;
+        let uses_usb1_sram = lease.uses_usb1_sram();
         assert!(
-            len >= EP_LIST_LEN + 64,
-            "USB endpoint memory is too small for the command list and SETUP buffer"
+            !T::HIGH_SPEED || uses_usb1_sram,
+            "USBHSD endpoint memory must use Memory::usb1_sram()"
         );
-        // AddressOffset only carries the low bits of a buffer address; the
-        // rest comes from DATABUFSTART, so the whole region must sit inside
-        // one DATABUFSTART window.
+        assert!(
+            len >= DATA_BUFFER_OFFSET,
+            "USB endpoint memory is too small for EP0 storage"
+        );
         assert!(
             base >> T::DATABUF_WINDOW_SHIFT == (base + len - 1) >> T::DATABUF_WINDOW_SHIFT,
             "endpoint memory crosses the DATABUFSTART window"
         );
 
-        T::power_up();
+        T::power_up(uses_usb1_sram);
 
-        // Zero the endpoint command/status list and reserve the SETUP buffer.
         for i in 0..T::EP_COUNT * 4 {
             unsafe { ((base as usize + i * 4) as *mut u32).write_volatile(0) };
         }
-        let setup_addr = base + EP_LIST_LEN;
+        let setup_addr = base + EP0_SETUP_OFFSET;
+        let ep0_out_addr = base + EP0_OUT_OFFSET;
+        let ep0_in_addr = base + EP0_IN_OFFSET;
         unsafe {
             (setup_addr as *mut u32).write_volatile(0);
             (setup_addr as *mut u32).add(1).write_volatile(0);
-            // EP0 out_buf1 slot holds the SETUP buffer pointer.
             ep_cmd_ptr(base, 0, Direction::Out, true).write_volatile(addroff::<T>(setup_addr));
         }
 
         program_controller::<T>(base);
+        let state = T::state();
+        state.invalidate_controller();
+        for index in 0..T::EP_COUNT {
+            state.ep_in_state[index].store(0, Ordering::Relaxed);
+            state.ep_out_state[index].store(0, Ordering::Relaxed);
+        }
+        state.alive.store(true, Ordering::Release);
 
         T::Interrupt::unpend();
         unsafe { T::Interrupt::enable() };
 
         Self {
-            _usb: usb,
+            _usb: Some(usb),
             _vbus: vbus,
+            memory: Some(lease),
             ep_in_used: [false; MAX_EP_COUNT],
             ep_out_used: [false; MAX_EP_COUNT],
             ep_list: base,
             mem_end: base + len,
-            alloc_offset: EP_LIST_LEN + 64,
+            alloc_offset: DATA_BUFFER_OFFSET,
             setup_addr,
+            ep0_out_addr,
+            ep0_in_addr,
         }
     }
 
@@ -1127,7 +1342,16 @@ impl<'d, T: Instance> Driver<'d, T> {
             buf_addrs,
             slot_len,
             armed_len: [0; 2],
+            _memory: self.memory.as_ref().ok_or(EndpointAllocError)?.clone_lease(),
         })
+    }
+}
+impl<'d, T: Instance> Drop for Driver<'d, T> {
+    fn drop(&mut self) {
+        if self._usb.is_some() {
+            shutdown_controller::<T>(self.ep_list);
+        }
+        drop(self.memory.take());
     }
 }
 
@@ -1160,33 +1384,43 @@ impl<'d, T: Instance> driver::Driver<'d> for Driver<'d, T> {
     fn start(mut self, control_max_packet_size: u16) -> (Self::Bus, Self::ControlPipe) {
         assert!(control_max_packet_size <= 64);
         let ep_list = self.ep_list;
-        let ep0_out_addr = self.alloc_buffer(control_max_packet_size).unwrap();
-        let ep0_in_addr = self.alloc_buffer(control_max_packet_size).unwrap();
+        let ep0_out_addr = self.ep0_out_addr;
+        let ep0_in_addr = self.ep0_in_addr;
+        let Some(usb) = self._usb.take() else {
+            unreachable!("USB peripheral token missing at start");
+        };
+        let vbus_pin = self._vbus.take();
+        let Some(memory) = self.memory.take() else {
+            unreachable!("USB endpoint memory lease missing at start");
+        };
+        let bus_memory = memory.clone_lease();
+        let control_memory = memory.clone_lease();
 
-        // EP0 OUT stays armed at all times (lpc55-hal discipline): the ip3511
-        // needs an active EP0 OUT entry to accept SETUP and OUT packets on the
-        // control pipe. `setup()`/`data_out()` re-arm it after every consumed
-        // packet.
-        ep_cmd_write(
-            ep_list,
-            0,
-            Direction::Out,
-            0,
-            CMD_A | nbytes::<T>(control_max_packet_size as u32) | addroff::<T>(ep0_out_addr),
-        );
-        ep_cmd_write(ep_list, 0, Direction::In, 0, addroff::<T>(ep0_in_addr));
+        critical_section::with(|_| {
+            ep_cmd_write(
+                ep_list,
+                0,
+                Direction::Out,
+                0,
+                CMD_A | nbytes::<T>(control_max_packet_size as u32) | addroff::<T>(ep0_out_addr),
+            );
+            ep_cmd_write(ep_list, 0, Direction::In, 0, addroff::<T>(ep0_in_addr));
+            let vbus = T::regs().devcmdstat().read().vbus_debounced();
+            devcmdstat_modify(T::regs(), |w| {
+                w.set_dev_en(true);
+                w.set_dcon(!vbus);
+            });
+        });
 
         trace!("started");
 
         (
             Bus {
-                _phantom: PhantomData,
-                _vbus: self._vbus,
-                // Deliberately `false` rather than sampled from the register:
-                // a `false` start is what makes the first `poll()` emit
-                // `PowerDetected` for an already-attached cable.
+                _usb: Some(usb),
+                _vbus: vbus_pin,
+                memory: Some(bus_memory),
                 vbus: false,
-                powered: true,
+                needs_reset: false,
                 ep_list,
                 setup_addr: self.setup_addr,
                 ep0_out_addr,
@@ -1194,11 +1428,16 @@ impl<'d, T: Instance> driver::Driver<'d> for Driver<'d, T> {
             },
             ControlPipe {
                 _phantom: PhantomData,
+                _memory: control_memory,
                 max_packet_size: control_max_packet_size,
                 ep_list,
                 setup_addr: self.setup_addr,
                 ep0_out_addr,
                 ep0_in_addr,
+                accepted_lifecycle: 0,
+                accepted_out_generation: 0,
+                accepted_in_generation: 0,
+                setup_valid: false,
             },
         )
     }
@@ -1206,10 +1445,11 @@ impl<'d, T: Instance> driver::Driver<'d> for Driver<'d, T> {
 
 /// USB bus.
 pub struct Bus<'d, T: Instance> {
-    _phantom: PhantomData<&'d mut T>,
+    _usb: Option<Peri<'d, T>>,
     _vbus: Option<Peri<'d, crate::gpio::AnyPin>>,
+    memory: Option<MemoryLease<'d>>,
     vbus: bool,
-    powered: bool,
+    needs_reset: bool,
     ep_list: u32,
     setup_addr: u32,
     ep0_out_addr: u32,
@@ -1217,90 +1457,135 @@ pub struct Bus<'d, T: Instance> {
 }
 
 impl<'d, T: Instance> Bus<'d, T> {
-    /// Re-apply the controller programming `Driver::new_inner` does, after a
-    /// `power_up` that reset the block.
-    fn reinit(&mut self) {
-        program_controller::<T>(self.ep_list);
-        self.reset_endpoints();
-    }
-
-    /// Disable all data endpoints, reset the double-buffer bookkeeping and
-    /// re-arm EP0. Shared by the bus-reset path and `reinit`.
     fn reset_endpoints(&mut self) {
-        let regs = T::regs();
+        critical_section::with(|_| {
+            let regs = T::regs();
+            let state = T::state();
+            state.invalidate_controller();
+
+            state.ep_out_state[0].store(0, Ordering::Relaxed);
+            state.ep_in_state[0].store(0, Ordering::Relaxed);
+            for index in 0..T::EP_COUNT {
+                for dir in [Direction::Out, Direction::In] {
+                    reclaim_slots::<T>(self.ep_list, index, dir);
+                }
+            }
+            for index in 1..T::EP_COUNT {
+                for dir in [Direction::Out, Direction::In] {
+                    ep_cmd_write(self.ep_list, index, dir, 0, CMD_D);
+                    ep_cmd_write(self.ep_list, index, dir, 1, CMD_D);
+                    let ep_state = state.ep_state(index, dir);
+                    ep_state.store(ep_state.load(Ordering::Relaxed) & ISO, Ordering::Relaxed);
+                }
+            }
+            regs.epinuse().write(|w| w.set_buf(0));
+            regs.epbufcfg().write(|w| w.set_buf_sb(ep_buf_mask::<T>()));
+            ep_cmd_write(
+                self.ep_list,
+                0,
+                Direction::Out,
+                0,
+                CMD_A | nbytes::<T>(self.ep0_mps as u32) | addroff::<T>(self.ep0_out_addr),
+            );
+            ep_cmd_write(self.ep_list, 0, Direction::In, 0, 0);
+            unsafe {
+                ep_cmd_ptr(self.ep_list, 0, Direction::Out, true).write_volatile(addroff::<T>(self.setup_addr));
+            }
+        });
+    }
+
+    fn disable_data_endpoints(&mut self) {
         let state = T::state();
-
-        for i in 1..T::EP_COUNT {
-            for slot in 0..2 {
-                ep_cmd_write(self.ep_list, i, Direction::Out, slot, CMD_D);
-                ep_cmd_write(self.ep_list, i, Direction::In, slot, CMD_D);
-            }
-            // Keep ISO: it describes the endpoint, not its transfer state.
+        for index in 1..T::EP_COUNT {
             for dir in [Direction::Out, Direction::In] {
-                let s = state.ep_state(i, dir);
-                s.store(s.load(Ordering::Relaxed) & ISO, Ordering::Relaxed);
+                reclaim_slots::<T>(self.ep_list, index, dir);
+                ep_cmd_write(self.ep_list, index, dir, 0, CMD_D);
+                ep_cmd_write(self.ep_list, index, dir, 1, CMD_D);
+                let ep_state = state.ep_state(index, dir);
+                ep_state.store(ep_state.load(Ordering::Relaxed) & ISO, Ordering::Relaxed);
             }
-        }
-        regs.epinuse().write(|w| w.set_buf(0));
-        regs.epbufcfg().write(|w| w.set_buf_sb(ep_buf_mask::<T>()));
-
-        // EP0 OUT stays armed at all times; keep the SETUP pointer.
-        ep_cmd_write(
-            self.ep_list,
-            0,
-            Direction::Out,
-            0,
-            CMD_A | nbytes::<T>(self.ep0_mps as u32) | addroff::<T>(self.ep0_out_addr),
-        );
-        ep_cmd_write(self.ep_list, 0, Direction::In, 0, 0);
-        unsafe {
-            ep_cmd_ptr(self.ep_list, 0, Direction::Out, true).write_volatile(addroff::<T>(self.setup_addr));
-        }
-
-        // Unstick any pending endpoint futures; they will observe the
-        // disabled/reset state.
-        for w in &state.ep_in_wakers {
-            w.wake();
-        }
-        for w in &state.ep_out_wakers {
-            w.wake();
         }
     }
+
+    fn shutdown(&mut self) {
+        if self._usb.is_none() {
+            return;
+        }
+        shutdown_controller::<T>(self.ep_list);
+        drop(self.memory.take());
+        self._usb.take();
+        self._vbus.take();
+    }
+}
+
+impl<'d, T: Instance> Drop for Bus<'d, T> {
+    fn drop(&mut self) {
+        self.shutdown();
+    }
+}
+
+const fn negotiated_speed_valid(high_speed: bool, speed: u8) -> bool {
+    // USB0 leaves the SPEED field reserved and reads it as zero.
+    speed == if high_speed { 0b10 } else { 0b00 }
 }
 
 impl<'d, T: Instance> driver::Bus for Bus<'d, T> {
     async fn enable(&mut self) {
-        if !self.powered {
-            T::power_up();
-            self.reinit();
-            self.powered = true;
-        }
-        // Soft-connect.
-        devcmdstat_modify(T::regs(), |w| w.set_dcon(true));
+        critical_section::with(|_| {
+            // `start` already programs and arms EP0. Reclaiming that slot on
+            // the first enable would cancel the request that waits for reset.
+            if self.needs_reset {
+                for index in 0..T::EP_COUNT {
+                    for dir in [Direction::Out, Direction::In] {
+                        reclaim_slots::<T>(self.ep_list, index, dir);
+                    }
+                }
+                program_controller::<T>(self.ep_list);
+                self.reset_endpoints();
+                self.needs_reset = false;
+            }
+            devcmdstat_modify(T::regs(), |w| {
+                w.set_dev_en(true);
+                w.set_dcon(true);
+            });
+        });
+        T::state().bus_waker.wake();
     }
 
     async fn disable(&mut self) {
-        devcmdstat_modify(T::regs(), |w| w.set_dcon(false));
-        devcmdstat_modify(T::regs(), |w| w.set_dev_en(false));
-        T::power_down();
-        self.powered = false;
+        critical_section::with(|_| {
+            let regs = T::regs();
+            let vbus = regs.devcmdstat().read().vbus_debounced();
+            T::state().invalidate_controller();
+            // EPSKIP only runs while the endpoint engine is connected.
+            self.disable_data_endpoints();
+            devcmdstat_modify(regs, |w| {
+                w.set_setup(true);
+                w.set_dev_en(true);
+                w.set_dcon(!vbus);
+            });
+            self.vbus = false;
+            self.needs_reset = true;
+        });
     }
 
     async fn poll(&mut self) -> Event {
         poll_fn(move |cx| {
-            T::state().bus_waker.register(cx.waker());
+            let state = T::state();
+            state.bus_waker.register(cx.waker());
+            if !state.alive.load(Ordering::Acquire) {
+                return Poll::Pending;
+            }
 
             let regs = T::regs();
             let dcs = regs.devcmdstat().read();
-
-            // VBUS level changes are reported before anything else: a lost
-            // cable invalidates every other event.
             let vbus = dcs.vbus_debounced();
             if vbus != self.vbus {
                 self.vbus = vbus;
                 let event = if vbus {
                     Event::PowerDetected
                 } else {
+                    critical_section::with(|_| state.invalidate_controller());
                     Event::PowerRemoved
                 };
                 trace!("{}", event);
@@ -1308,13 +1593,23 @@ impl<'d, T: Instance> driver::Bus for Bus<'d, T> {
             }
 
             if dcs.dres_c() {
+                let speed = dcs.speed();
+                if !negotiated_speed_valid(T::HIGH_SPEED, speed) {
+                    critical_section::with(|_| {
+                        state.invalidate_controller();
+                        devcmdstat_modify(regs, |w| w.set_dcon(false));
+                    });
+                    if T::HIGH_SPEED {
+                        panic!("USBHSD negotiated unsupported speed {}", speed);
+                    }
+                    panic!("USB0 negotiated unsupported speed {}", speed);
+                }
+
                 devcmdstat_modify(regs, |w| {
                     w.set_dres_c(true);
                     w.set_dev_addr(0);
                 });
-
                 self.reset_endpoints();
-
                 trace!("RESET");
                 return Poll::Ready(Event::Reset);
             }
@@ -1327,10 +1622,6 @@ impl<'d, T: Instance> driver::Bus for Bus<'d, T> {
             }
 
             if dcs.dcon_c() {
-                // Acknowledge only. Hardware gates the D+ pull-up on
-                // VBUS_DEBOUNCED, so a VBUS change forces a connect-state
-                // change: this is the wake that carries it, and the level was
-                // already picked up above.
                 devcmdstat_modify(regs, |w| w.set_dcon_c(true));
             }
 
@@ -1341,104 +1632,75 @@ impl<'d, T: Instance> driver::Bus for Bus<'d, T> {
 
     fn endpoint_set_enabled(&mut self, ep_addr: EndpointAddress, enabled: bool) {
         trace!("set_enabled {:?} {}", ep_addr, enabled);
-        let index = ep_addr.index();
+        let Some((index, dir)) = valid_endpoint::<T>(ep_addr) else {
+            return;
+        };
         if index == 0 {
             return;
         }
-        let dir = ep_addr.direction();
-        let state = T::state().ep_state(index, dir);
-        let iso = state.load(Ordering::Relaxed) & ISO;
 
-        if enabled {
-            // Both slots idle (NAK until armed) with the data toggle reset,
-            // which USB requires whenever a SET_CONFIGURATION or SET_INTERFACE
-            // enables an endpoint. Hardware must also restart on slot 0 to match
-            // the software cursor.
-            //
-            // `TR` has to be in the word here and not only deferred to the first
-            // armed transfer via `TR_PENDING`: the full-speed block otherwise
-            // keeps the pre-disable toggle and silently drops the first packets
-            // after an alternate setting switches the endpoint back on.
-            //
-            // Only slot 0 carries it. `TR` is honoured on an inactive entry, so
-            // arming both slots with it lets hardware reset the toggle a second
-            // time after the first packet has already flipped it, which corrupts
-            // the very next transfer. Isochronous endpoints have no toggle at all.
-            ep_cmd_write(self.ep_list, index, dir, 0, if iso != 0 { 0 } else { CMD_TR });
-            ep_cmd_write(self.ep_list, index, dir, 1, 0);
-            let phy_ep = 2 * index + (dir == Direction::In) as usize;
-            T::regs()
-                .epinuse()
-                .modify(|w| w.set_buf(w.buf() & !(1 << (phy_ep - 2))));
-            state.store(iso | TR_PENDING, Ordering::Relaxed);
-        } else {
-            ep_cmd_write(self.ep_list, index, dir, 0, CMD_D);
-            ep_cmd_write(self.ep_list, index, dir, 1, CMD_D);
-            state.store(iso, Ordering::Relaxed);
-        }
+        critical_section::with(|_| {
+            let shared = T::state();
+            let state = shared.ep_state(index, dir);
+            let iso = state.load(Ordering::Relaxed) & ISO;
+            reclaim_slots::<T>(self.ep_list, index, dir);
+            shared.invalidate_endpoint(index, dir);
 
-        T::state().ep_waker(index, dir).wake();
+            if enabled {
+                ep_cmd_write(self.ep_list, index, dir, 0, if iso != 0 { 0 } else { CMD_TR });
+                ep_cmd_write(self.ep_list, index, dir, 1, 0);
+                select_slot::<T>(index, dir, 0);
+                state.store(iso | if iso == 0 { TR_PENDING } else { 0 }, Ordering::Relaxed);
+            } else {
+                ep_cmd_write(self.ep_list, index, dir, 0, CMD_D);
+                ep_cmd_write(self.ep_list, index, dir, 1, CMD_D);
+                state.store(iso, Ordering::Relaxed);
+            }
+        });
     }
 
     fn endpoint_set_stalled(&mut self, ep_addr: EndpointAddress, stalled: bool) {
         trace!("set_stalled {:?} {}", ep_addr, stalled);
-        let index = ep_addr.index();
-        let dir = ep_addr.direction();
-        let regs = T::regs();
-        let phy_ep = 2 * index + (dir == Direction::In) as usize;
-        // EP0's second OUT slot is the SETUP pointer: never touch it.
-        let slots = if index == 0 { 0..1 } else { 0..2 };
-        // Isochronous endpoints have no handshake phase, so the S bit is
-        // meaningless for them: reclaim and resync, but never stall.
-        let iso = index != 0 && T::state().ep_state(index, dir).load(Ordering::Relaxed) & ISO != 0;
+        let Some((index, dir)) = valid_endpoint::<T>(ep_addr) else {
+            return;
+        };
 
-        if stalled {
-            for slot in slots.clone() {
-                if ep_cmd_read(self.ep_list, index, dir, slot) & CMD_A != 0 {
-                    // Reclaim the in-flight transfer via EPSKIP (skips the
-                    // slot EPINUSE points at).
-                    regs.epskip().write_value(pac::usbhsd::regs::Epskip(1 << phy_ep));
-                    while regs.epskip().read().0 & (1 << phy_ep) != 0 {}
-                    regs.intstat().write_value(pac::usbhsd::regs::Intstat(1 << phy_ep));
-                }
-            }
-            if !iso {
-                for slot in slots {
-                    ep_cmd_modify(self.ep_list, index, dir, slot, |w| (w & !CMD_A) | CMD_S);
-                }
-            }
-        } else if index == 0 {
-            // Clearing a stall resets the data toggle to DATA0.
-            ep_cmd_modify(self.ep_list, index, dir, 0, |w| (w & !CMD_S) | CMD_TR);
-        } else {
-            // Drop any buffered packets, resync the hardware slot cursor and
-            // reset the data toggle, which USB requires when a halt is cleared.
-            //
-            // Both slot words are rewritten whole rather than having `S` and `A`
-            // masked out: keeping the aborted transfer's NBytes and
-            // AddressOffset leaves the full-speed block wedged - it acknowledges
-            // the next OUT packets on the wire and discards them without ever
-            // completing the entry.
-            //
-            // The toggle reset lands on slot 0 only, for the reason spelled out
-            // in `endpoint_set_enabled`.
-            for slot in slots {
-                let word = if slot == 0 && !iso { CMD_TR } else { 0 };
-                ep_cmd_write(self.ep_list, index, dir, slot, word);
-            }
-            regs.epinuse().modify(|w| w.set_buf(w.buf() & !(1 << (phy_ep - 2))));
-            let state = T::state().ep_state(index, dir);
-            let keep = state.load(Ordering::Relaxed) & ISO;
-            state.store(keep | TR_PENDING, Ordering::Relaxed);
-        }
+        critical_section::with(|_| {
+            let shared = T::state();
+            let iso = index != 0 && shared.ep_state(index, dir).load(Ordering::Relaxed) & ISO != 0;
+            reclaim_slots::<T>(self.ep_list, index, dir);
+            shared.invalidate_endpoint(index, dir);
 
-        T::state().ep_waker(index, dir).wake();
+            if stalled {
+                if iso {
+                    ep_cmd_write(self.ep_list, index, dir, 0, 0);
+                    ep_cmd_write(self.ep_list, index, dir, 1, 0);
+                    shared.ep_state(index, dir).store(ISO, Ordering::Relaxed);
+                } else {
+                    ep_cmd_write(self.ep_list, index, dir, 0, CMD_S);
+                    if index != 0 {
+                        ep_cmd_write(self.ep_list, index, dir, 1, CMD_S);
+                    }
+                }
+            } else if index == 0 {
+                ep_cmd_write(self.ep_list, index, dir, 0, CMD_TR);
+            } else {
+                ep_cmd_write(self.ep_list, index, dir, 0, if iso { 0 } else { CMD_TR });
+                ep_cmd_write(self.ep_list, index, dir, 1, 0);
+                let state = shared.ep_state(index, dir);
+                let keep = state.load(Ordering::Relaxed) & ISO;
+                state.store(keep | if keep == 0 { TR_PENDING } else { 0 }, Ordering::Relaxed);
+            }
+        });
     }
 
     fn endpoint_is_stalled(&mut self, ep_addr: EndpointAddress) -> bool {
-        // Isochronous endpoints are never stalled, and `endpoint_set_stalled`
-        // never sets CMD_S on them, so this reports `false` for them.
-        ep_cmd_read(self.ep_list, ep_addr.index(), ep_addr.direction(), 0) & CMD_S != 0
+        let Some((index, dir)) = valid_endpoint::<T>(ep_addr) else {
+            return false;
+        };
+        critical_section::with(|_| {
+            T::state().alive.load(Ordering::Acquire) && ep_cmd_read(self.ep_list, index, dir, 0) & CMD_S != 0
+        })
     }
 
     async fn remote_wakeup(&mut self) -> Result<(), Unsupported> {
@@ -1447,13 +1709,16 @@ impl<'d, T: Instance> driver::Bus for Bus<'d, T> {
     }
 
     fn force_reset(&mut self) -> Result<(), Unsupported> {
-        devcmdstat_modify(T::regs(), |w| w.set_dcon(false));
-        // The host needs >= 10 us of SE0 to see a disconnect. This is a
-        // blocking trait method, so busy-wait: 10M cycles is 33-104 ms across
-        // the supported main clocks (300 MHz down to 96 MHz) - generous, but
-        // this path runs at most once per host-visible reconnect.
+        critical_section::with(|_| {
+            T::state().invalidate_controller();
+            devcmdstat_modify(T::regs(), |w| w.set_dcon(false));
+        });
         cortex_m::asm::delay(10_000_000);
-        devcmdstat_modify(T::regs(), |w| w.set_dcon(true));
+        critical_section::with(|_| {
+            if T::state().alive.load(Ordering::Acquire) {
+                devcmdstat_modify(T::regs(), |w| w.set_dcon(true));
+            }
+        });
         Ok(())
     }
 }
@@ -1469,6 +1734,7 @@ pub struct Endpoint<'d, T: Instance, D> {
     /// Length each OUT slot was last armed with; needed to compute the
     /// received count from the NBytes-remaining field on completion.
     armed_len: [u16; 2],
+    _memory: MemoryLease<'d>,
 }
 
 impl<'d, T: Instance, D: Dir> Endpoint<'d, T, D> {
@@ -1485,12 +1751,18 @@ impl<'d, T: Instance, D: Dir> driver::Endpoint for Endpoint<'d, T, D> {
     async fn wait_enabled(&mut self) {
         let index = self.info.addr.index();
         poll_fn(|cx| {
-            T::state().ep_waker(index, D::dir()).register(cx.waker());
-            if ep_cmd_read(self.ep_list, index, D::dir(), 0) & CMD_D == 0 {
-                Poll::Ready(())
-            } else {
-                Poll::Pending
-            }
+            let shared = T::state();
+            shared.ep_waker(index, D::dir()).register(cx.waker());
+            critical_section::with(|_| {
+                if !shared.alive.load(Ordering::Acquire) {
+                    return Poll::Pending;
+                }
+                if ep_cmd_read(self.ep_list, index, D::dir(), 0) & CMD_D == 0 {
+                    Poll::Ready(())
+                } else {
+                    Poll::Pending
+                }
+            })
         })
         .await;
         trace!("wait_enabled {:?} OK", self.info.addr);
@@ -1511,85 +1783,105 @@ impl<'d, T: Instance> driver::EndpointOut for Endpoint<'d, T, Out> {
     async fn read(&mut self, buf: &mut [u8]) -> Result<usize, EndpointError> {
         let index = self.info.addr.index();
         let arm_len = self.info.max_packet_size as u32;
-        let state = T::state().ep_state(index, Direction::Out);
+        let shared = T::state();
+        let state = shared.ep_state(index, Direction::Out);
         let iso = self.is_iso();
-        // Keep both slots armed so the endpoint does not NAK between packets
-        // while the host streams. A slot with PRIMED set and Active clear
-        // holds a received, not-yet-consumed packet.
-        let mut s = state.load(Ordering::Relaxed);
-        for slot in 0..2 {
-            if s & (PRIMED0 << slot) == 0 {
-                if ep_cmd_read(self.ep_list, index, Direction::Out, slot) & CMD_UNUSABLE != 0 {
-                    return Err(EndpointError::Disabled);
-                }
-                ep_arm_slot::<T>(
-                    self.ep_list,
-                    index,
-                    Direction::Out,
-                    slot,
-                    arm_len,
-                    self.buf_addrs[slot],
-                    s & TR_PENDING != 0,
-                    iso,
-                );
-                self.armed_len[slot] = arm_len as u16;
-                s = (s | (PRIMED0 << slot)) & !TR_PENDING;
-                state.store(s, Ordering::Relaxed);
-            }
-        }
 
-        // Consume in hardware ping-pong order.
+        let s = critical_section::with(|_| {
+            if !shared.alive.load(Ordering::Acquire) {
+                return Err(EndpointError::Disabled);
+            }
+            let lifecycle = shared.lifecycle_generation.load(Ordering::Relaxed);
+            let generation = shared.ep_out_generation[index].load(Ordering::Relaxed);
+            let mut s = state.load(Ordering::Relaxed);
+            for slot in 0..2 {
+                if s & (PRIMED0 << slot) == 0 {
+                    if ep_cmd_read(self.ep_list, index, Direction::Out, slot) & CMD_UNUSABLE != 0 {
+                        return Err(EndpointError::Disabled);
+                    }
+                    ep_arm_slot::<T>(
+                        self.ep_list,
+                        index,
+                        Direction::Out,
+                        slot,
+                        arm_len,
+                        self.buf_addrs[slot],
+                        s & TR_PENDING != 0,
+                        iso,
+                    );
+                    self.armed_len[slot] = arm_len as u16;
+                    s = (s | (PRIMED0 << slot)) & !TR_PENDING;
+                    state.store(s, Ordering::Relaxed);
+                }
+            }
+            if lifecycle != shared.lifecycle_generation.load(Ordering::Relaxed)
+                || generation != shared.ep_out_generation[index].load(Ordering::Relaxed)
+            {
+                return Err(EndpointError::Disabled);
+            }
+            Ok((s, lifecycle, generation))
+        })?;
+
+        let (s, lifecycle, generation) = s;
         let slot = (s & SLOT) as usize;
-        let word = poll_fn(|cx| {
-            T::state().ep_out_wakers[index].register(cx.waker());
-            let word = ep_cmd_read(self.ep_list, index, Direction::Out, slot);
-            if word & CMD_UNUSABLE != 0 {
-                // Disabled by a bus reset, or stalled by the host, while waiting.
-                return Poll::Ready(Err(EndpointError::Disabled));
-            }
-            if state.load(Ordering::Relaxed) & (PRIMED0 << slot) == 0 {
-                // A re-enable or unstall cancelled the armed transfer.
-                return Poll::Ready(Err(EndpointError::Disabled));
-            }
-            if word & CMD_A == 0 {
-                Poll::Ready(Ok(word))
-            } else {
-                Poll::Pending
-            }
+        let (word, snapshot_state) = poll_fn(|cx| {
+            shared.ep_out_wakers[index].register(cx.waker());
+            critical_section::with(|_| {
+                if !shared.alive.load(Ordering::Acquire)
+                    || lifecycle != shared.lifecycle_generation.load(Ordering::Relaxed)
+                    || generation != shared.ep_out_generation[index].load(Ordering::Relaxed)
+                {
+                    return Poll::Ready(Err(EndpointError::Disabled));
+                }
+                let snapshot_state = state.load(Ordering::Relaxed);
+                if (snapshot_state & SLOT) as usize != slot || snapshot_state & (PRIMED0 << slot) == 0 {
+                    return Poll::Ready(Err(EndpointError::Disabled));
+                }
+                let word = ep_cmd_read(self.ep_list, index, Direction::Out, slot);
+                if word & CMD_UNUSABLE != 0 {
+                    return Poll::Ready(Err(EndpointError::Disabled));
+                }
+                if word & CMD_A == 0 {
+                    Poll::Ready(Ok((word, snapshot_state)))
+                } else {
+                    Poll::Pending
+                }
+            })
         })
         .await?;
 
-        // A dropped or errored isochronous packet completes the entry with
-        // NBytes untouched, which this arithmetic turns into `Ok(0)`. That is
-        // the correct report for isochronous: there is no retry, and the
-        // caller sees a lost frame rather than an error. Do not "fix" it.
         let rx_len = (self.armed_len[slot] as u32 - remaining_bytes::<T>(word)) as usize;
         if rx_len > buf.len() {
             return Err(EndpointError::BufferOverflow);
         }
         copy_from_ep_buffer(self.buf_addrs[slot], &mut buf[..rx_len]);
 
-        // A host halt landing between the completion poll and here would be
-        // erased by the re-arm below, so drop the packet instead: the host asked
-        // for the endpoint to stop.
-        if ep_cmd_read(self.ep_list, index, Direction::Out, slot) & CMD_S != 0 {
-            return Err(EndpointError::Disabled);
-        }
-
-        // Hand the drained slot straight back to hardware and advance the
-        // consume cursor.
-        ep_arm_slot::<T>(
-            self.ep_list,
-            index,
-            Direction::Out,
-            slot,
-            arm_len,
-            self.buf_addrs[slot],
-            false,
-            iso,
-        );
-        self.armed_len[slot] = arm_len as u16;
-        state.store((s ^ SLOT) | (PRIMED0 << slot), Ordering::Relaxed);
+        critical_section::with(|_| {
+            if !shared.alive.load(Ordering::Acquire)
+                || lifecycle != shared.lifecycle_generation.load(Ordering::Relaxed)
+                || generation != shared.ep_out_generation[index].load(Ordering::Relaxed)
+            {
+                return Err(EndpointError::Disabled);
+            }
+            let current = state.load(Ordering::Relaxed);
+            let command = ep_cmd_read(self.ep_list, index, Direction::Out, slot);
+            if (current & SLOT) as usize != slot || current & (PRIMED0 << slot) == 0 || command & CMD_UNUSABLE != 0 {
+                return Err(EndpointError::Disabled);
+            }
+            ep_arm_slot::<T>(
+                self.ep_list,
+                index,
+                Direction::Out,
+                slot,
+                arm_len,
+                self.buf_addrs[slot],
+                false,
+                iso,
+            );
+            self.armed_len[slot] = arm_len as u16;
+            state.store((snapshot_state ^ SLOT) | (PRIMED0 << slot), Ordering::Relaxed);
+            Ok(())
+        })?;
 
         trace!("READ {:?} rx_len = {}", self.info.addr, rx_len);
         Ok(rx_len)
@@ -1610,45 +1902,60 @@ impl<'d, T: Instance> driver::EndpointIn for Endpoint<'d, T, In> {
         }
 
         let index = self.info.addr.index();
-        let state = T::state().ep_state(index, Direction::In);
+        let shared = T::state();
+        let state = shared.ep_state(index, Direction::In);
         let iso = self.is_iso();
+        let (slot, lifecycle, generation) = critical_section::with(|_| {
+            if !shared.alive.load(Ordering::Acquire) {
+                return Err(EndpointError::Disabled);
+            }
+            let slot = (state.load(Ordering::Relaxed) & SLOT) as usize;
+            Ok((
+                slot,
+                shared.lifecycle_generation.load(Ordering::Relaxed),
+                shared.ep_in_generation[index].load(Ordering::Relaxed),
+            ))
+        })?;
 
-        // Fill slots in hardware ping-pong order, returning as soon as the
-        // packet is armed: the wire transmits from one slot while software
-        // fills the other, so a saturating writer never lets the endpoint
-        // NAK an IN token.
-        loop {
-            let s = state.load(Ordering::Relaxed);
-            let slot = (s & SLOT) as usize;
-
-            poll_fn(|cx| {
-                T::state().ep_in_wakers[index].register(cx.waker());
+        let snapshot_state = poll_fn(|cx| {
+            shared.ep_in_wakers[index].register(cx.waker());
+            critical_section::with(|_| {
+                if !shared.alive.load(Ordering::Acquire)
+                    || lifecycle != shared.lifecycle_generation.load(Ordering::Relaxed)
+                    || generation != shared.ep_in_generation[index].load(Ordering::Relaxed)
+                {
+                    return Poll::Ready(Err(EndpointError::Disabled));
+                }
+                let snapshot_state = state.load(Ordering::Relaxed);
+                if (snapshot_state & SLOT) as usize != slot {
+                    return Poll::Ready(Err(EndpointError::Disabled));
+                }
                 let word = ep_cmd_read(self.ep_list, index, Direction::In, slot);
                 if word & CMD_UNUSABLE != 0 {
                     return Poll::Ready(Err(EndpointError::Disabled));
                 }
                 if word & CMD_A == 0 {
-                    Poll::Ready(Ok(()))
+                    Poll::Ready(Ok(snapshot_state))
                 } else {
                     Poll::Pending
                 }
             })
-            .await?;
+        })
+        .await?;
 
-            // A reset or re-enable while waiting may have moved the slot
-            // cursor; re-derive and retry if so.
-            let s = state.load(Ordering::Relaxed);
-            if (s & SLOT) as usize != slot {
-                continue;
-            }
-
-            // Same hazard as in `read`: a host halt landing here would be
-            // erased by the arm below.
-            if ep_cmd_read(self.ep_list, index, Direction::In, slot) & CMD_S != 0 {
+        copy_to_ep_buffer(self.buf_addrs[slot], buf);
+        critical_section::with(|_| {
+            if !shared.alive.load(Ordering::Acquire)
+                || lifecycle != shared.lifecycle_generation.load(Ordering::Relaxed)
+                || generation != shared.ep_in_generation[index].load(Ordering::Relaxed)
+            {
                 return Err(EndpointError::Disabled);
             }
-
-            copy_to_ep_buffer(self.buf_addrs[slot], buf);
+            let current = state.load(Ordering::Relaxed);
+            let command = ep_cmd_read(self.ep_list, index, Direction::In, slot);
+            if (current & SLOT) as usize != slot || command & (CMD_UNUSABLE | CMD_A) != 0 {
+                return Err(EndpointError::Disabled);
+            }
             ep_arm_slot::<T>(
                 self.ep_list,
                 index,
@@ -1656,14 +1963,15 @@ impl<'d, T: Instance> driver::EndpointIn for Endpoint<'d, T, In> {
                 slot,
                 buf.len() as u32,
                 self.buf_addrs[slot],
-                s & TR_PENDING != 0,
+                snapshot_state & TR_PENDING != 0,
                 iso,
             );
-            state.store((s ^ SLOT) & !TR_PENDING, Ordering::Relaxed);
+            state.store((snapshot_state ^ SLOT) & !TR_PENDING, Ordering::Relaxed);
+            Ok(())
+        })?;
 
-            trace!("WRITE {:?} len = {}", self.info.addr, buf.len());
-            return Ok(());
-        }
+        trace!("WRITE {:?} len = {}", self.info.addr, buf.len());
+        Ok(())
     }
 
     /// Sends all of `buf`, then a zero-length packet if the transfer needs one
@@ -1688,11 +1996,35 @@ impl<'d, T: Instance> driver::EndpointIn for Endpoint<'d, T, In> {
 /// USB control pipe (endpoint 0, both directions).
 pub struct ControlPipe<'d, T: Instance> {
     _phantom: PhantomData<&'d mut T>,
+    _memory: MemoryLease<'d>,
     max_packet_size: u16,
     ep_list: u32,
     setup_addr: u32,
     ep0_out_addr: u32,
     ep0_in_addr: u32,
+    accepted_lifecycle: u32,
+    accepted_out_generation: u32,
+    accepted_in_generation: u32,
+    setup_valid: bool,
+}
+
+impl<'d, T: Instance> ControlPipe<'d, T> {
+    fn request_valid(&self) -> bool {
+        let state = T::state();
+        if !self.setup_valid
+            || !state.alive.load(Ordering::Acquire)
+            || self.accepted_lifecycle != state.lifecycle_generation.load(Ordering::Relaxed)
+            || self.accepted_out_generation != state.ep_out_generation[0].load(Ordering::Relaxed)
+            || self.accepted_in_generation != state.ep_in_generation[0].load(Ordering::Relaxed)
+        {
+            return false;
+        }
+        if T::regs().devcmdstat().read().setup() {
+            state.note_setup();
+            return false;
+        }
+        true
+    }
 }
 
 impl<'d, T: Instance> driver::ControlPipe for ControlPipe<'d, T> {
@@ -1701,64 +2033,71 @@ impl<'d, T: Instance> driver::ControlPipe for ControlPipe<'d, T> {
     }
 
     async fn setup(&mut self) -> [u8; 8] {
-        let regs = T::regs();
-
+        let shared = T::state();
         poll_fn(|cx| {
-            T::state().ep_out_wakers[0].register(cx.waker());
-            if regs.devcmdstat().read().setup() {
-                Poll::Ready(())
-            } else {
-                Poll::Pending
-            }
+            shared.ep_out_wakers[0].register(cx.waker());
+            critical_section::with(|_| {
+                if !shared.alive.load(Ordering::Acquire) {
+                    return Poll::Pending;
+                }
+                if T::regs().devcmdstat().read().setup() {
+                    shared.note_setup();
+                    Poll::Ready(())
+                } else {
+                    Poll::Pending
+                }
+            })
         })
         .await;
 
-        // UM procedure: clear Active and Stall on both EP0 directions BEFORE
-        // acknowledging the SETUP bit.
-        ep_cmd_modify(self.ep_list, 0, Direction::Out, 0, |w| w & !(CMD_A | CMD_S));
-        ep_cmd_modify(self.ep_list, 0, Direction::In, 0, |w| w & !(CMD_A | CMD_S));
+        let buf = critical_section::with(|_| {
+            ep_cmd_modify(self.ep_list, 0, Direction::Out, 0, |w| w & !(CMD_A | CMD_S));
+            ep_cmd_modify(self.ep_list, 0, Direction::In, 0, |w| w & !(CMD_A | CMD_S));
 
-        let mut buf = [0; 8];
-        copy_from_ep_buffer(self.setup_addr, &mut buf);
+            let mut buf = [0; 8];
+            copy_from_ep_buffer(self.setup_addr, &mut buf);
+            devcmdstat_modify(T::regs(), |w| w.set_setup(true));
+            unsafe {
+                ep_cmd_ptr(self.ep_list, 0, Direction::Out, true).write_volatile(addroff::<T>(self.setup_addr));
+            }
+            ep_cmd_write(
+                self.ep_list,
+                0,
+                Direction::Out,
+                0,
+                CMD_A | nbytes::<T>(self.max_packet_size as u32) | addroff::<T>(self.ep0_out_addr),
+            );
 
-        devcmdstat_modify(regs, |w| w.set_setup(true));
-
-        // Hardware may overwrite the SETUP slot's address field: re-write it,
-        // and re-arm EP0 OUT for the next packet.
-        unsafe {
-            ep_cmd_ptr(self.ep_list, 0, Direction::Out, true).write_volatile(addroff::<T>(self.setup_addr));
-        }
-        ep_cmd_write(
-            self.ep_list,
-            0,
-            Direction::Out,
-            0,
-            CMD_A | nbytes::<T>(self.max_packet_size as u32) | addroff::<T>(self.ep0_out_addr),
-        );
+            self.accepted_lifecycle = shared.lifecycle_generation.load(Ordering::Relaxed);
+            self.accepted_out_generation = shared.ep_out_generation[0].load(Ordering::Relaxed);
+            self.accepted_in_generation = shared.ep_in_generation[0].load(Ordering::Relaxed);
+            self.setup_valid = true;
+            shared.setup_pending.store(false, Ordering::Release);
+            buf
+        });
 
         trace!("SETUP {=[u8]:x}", buf);
         buf
     }
 
     async fn data_out(&mut self, buf: &mut [u8], _first: bool, _last: bool) -> Result<usize, EndpointError> {
-        let regs = T::regs();
         let mps = self.max_packet_size as u32;
-
-        // EP0 OUT is already armed (from `setup()` or the previous
-        // `data_out()`); just wait for the packet.
-
         let word = poll_fn(|cx| {
             T::state().ep_out_wakers[0].register(cx.waker());
-            // A new SETUP aborts the transfer (trait contract).
-            if regs.devcmdstat().read().setup() {
-                return Poll::Ready(Err(EndpointError::Disabled));
-            }
-            let word = ep_cmd_read(self.ep_list, 0, Direction::Out, 0);
-            if word & CMD_A == 0 {
-                Poll::Ready(Ok(word))
-            } else {
-                Poll::Pending
-            }
+            critical_section::with(|_| {
+                if !self.request_valid() {
+                    return Poll::Ready(Err(EndpointError::Disabled));
+                }
+                let word = ep_cmd_read(self.ep_list, 0, Direction::Out, 0);
+                if word & CMD_UNUSABLE != 0 {
+                    return Poll::Ready(Err(EndpointError::Disabled));
+                }
+                if word & CMD_A == 0 {
+                    Poll::Ready(Ok(word))
+                } else {
+                    Poll::Pending
+                }
+            })
         })
         .await?;
 
@@ -1768,14 +2107,19 @@ impl<'d, T: Instance> driver::ControlPipe for ControlPipe<'d, T> {
         }
         copy_from_ep_buffer(self.ep0_out_addr, &mut buf[..rx_len]);
 
-        // Re-arm for the next OUT packet (or the status stage).
-        ep_cmd_write(
-            self.ep_list,
-            0,
-            Direction::Out,
-            0,
-            CMD_A | nbytes::<T>(mps) | addroff::<T>(self.ep0_out_addr),
-        );
+        critical_section::with(|_| {
+            if !self.request_valid() || ep_cmd_read(self.ep_list, 0, Direction::Out, 0) & CMD_UNUSABLE != 0 {
+                return Err(EndpointError::Disabled);
+            }
+            ep_cmd_write(
+                self.ep_list,
+                0,
+                Direction::Out,
+                0,
+                CMD_A | nbytes::<T>(mps) | addroff::<T>(self.ep0_out_addr),
+            );
+            Ok(())
+        })?;
 
         trace!("control: data_out rx_len = {}", rx_len);
         Ok(rx_len)
@@ -1787,82 +2131,123 @@ impl<'d, T: Instance> driver::ControlPipe for ControlPipe<'d, T> {
             return Err(EndpointError::BufferOverflow);
         }
 
-        let regs = T::regs();
-        if regs.devcmdstat().read().setup() {
+        if !critical_section::with(|_| self.request_valid()) {
             return Err(EndpointError::Disabled);
         }
-
         copy_to_ep_buffer(self.ep0_in_addr, data);
-        ep_cmd_write(
-            self.ep_list,
-            0,
-            Direction::In,
-            0,
-            CMD_A | nbytes::<T>(data.len() as u32) | addroff::<T>(self.ep0_in_addr),
-        );
+        critical_section::with(|_| {
+            if !self.request_valid() || ep_cmd_read(self.ep_list, 0, Direction::In, 0) & CMD_UNUSABLE != 0 {
+                return Err(EndpointError::Disabled);
+            }
+            ep_cmd_write(
+                self.ep_list,
+                0,
+                Direction::In,
+                0,
+                CMD_A | nbytes::<T>(data.len() as u32) | addroff::<T>(self.ep0_in_addr),
+            );
+            Ok(())
+        })?;
 
         poll_fn(|cx| {
             T::state().ep_in_wakers[0].register(cx.waker());
-            if regs.devcmdstat().read().setup() {
-                return Poll::Ready(Err(EndpointError::Disabled));
-            }
-            if ep_cmd_read(self.ep_list, 0, Direction::In, 0) & CMD_A == 0 {
-                Poll::Ready(Ok(()))
-            } else {
-                Poll::Pending
-            }
+            critical_section::with(|_| {
+                if !self.request_valid() {
+                    return Poll::Ready(Err(EndpointError::Disabled));
+                }
+                let command = ep_cmd_read(self.ep_list, 0, Direction::In, 0);
+                if command & CMD_UNUSABLE != 0 {
+                    return Poll::Ready(Err(EndpointError::Disabled));
+                }
+                if command & CMD_A == 0 {
+                    Poll::Ready(Ok(()))
+                } else {
+                    Poll::Pending
+                }
+            })
         })
         .await?;
 
-        // The status-stage OUT ZLP is accepted by the always-armed EP0 OUT
-        // buffer; nothing else to do for `last`.
         let _ = last;
-
         Ok(())
     }
 
     async fn accept(&mut self) {
         trace!("control: accept");
-
-        // Zero-length status-stage IN packet.
-        ep_cmd_write(
-            self.ep_list,
-            0,
-            Direction::In,
-            0,
-            CMD_A | addroff::<T>(self.ep0_in_addr),
-        );
+        let armed = critical_section::with(|_| {
+            if !self.request_valid() {
+                return false;
+            }
+            ep_cmd_write(
+                self.ep_list,
+                0,
+                Direction::In,
+                0,
+                CMD_A | addroff::<T>(self.ep0_in_addr),
+            );
+            true
+        });
+        if !armed {
+            return;
+        }
 
         poll_fn(|cx| {
             T::state().ep_in_wakers[0].register(cx.waker());
-            // Bail out if the host abandoned the request with a new SETUP.
-            if T::regs().devcmdstat().read().setup() {
-                return Poll::Ready(());
-            }
-            if ep_cmd_read(self.ep_list, 0, Direction::In, 0) & CMD_A == 0 {
-                Poll::Ready(())
-            } else {
-                Poll::Pending
-            }
+            critical_section::with(|_| {
+                if !self.request_valid() {
+                    return Poll::Ready(());
+                }
+                if ep_cmd_read(self.ep_list, 0, Direction::In, 0) & CMD_A == 0 {
+                    Poll::Ready(())
+                } else {
+                    Poll::Pending
+                }
+            })
         })
         .await;
     }
 
     async fn reject(&mut self) {
         trace!("control: reject");
-        // Stall both EP0 directions; `setup()` clears the stalls on the next
-        // SETUP packet.
-        ep_cmd_modify(self.ep_list, 0, Direction::Out, 0, |w| w | CMD_S);
-        ep_cmd_modify(self.ep_list, 0, Direction::In, 0, |w| w | CMD_S);
+        critical_section::with(|_| {
+            if !self.request_valid() {
+                return;
+            }
+            ep_cmd_modify(self.ep_list, 0, Direction::Out, 0, |w| w | CMD_S);
+            ep_cmd_modify(self.ep_list, 0, Direction::In, 0, |w| w | CMD_S);
+        });
     }
 
     async fn accept_set_address(&mut self, addr: u8) {
         trace!("setting addr: {}", addr);
-        // ip3511 quirk (UM11126): the new device address must be programmed
-        // BEFORE the status stage completes, contrary to the USB spec's
-        // "after the status stage" wording. lpc55-hal encodes the same order
-        // via usb-device's `QUIRK_SET_ADDRESS_BEFORE_STATUS`.
-        devcmdstat_modify(T::regs(), |w| w.set_dev_addr(addr));
-        self.accept().await;
+        let valid = critical_section::with(|_| {
+            if !self.request_valid() {
+                return false;
+            }
+            devcmdstat_modify(T::regs(), |w| w.set_dev_addr(addr));
+            true
+        });
+        if valid {
+            self.accept().await;
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::negotiated_speed_valid;
+
+    #[test]
+    fn usb0_accepts_its_full_speed_encoding() {
+        assert!(negotiated_speed_valid(false, 0b00));
+        assert!(!negotiated_speed_valid(false, 0b01));
+        assert!(!negotiated_speed_valid(false, 0b10));
+    }
+
+    #[test]
+    fn usbhsd_accepts_only_high_speed() {
+        assert!(negotiated_speed_valid(true, 0b10));
+        assert!(!negotiated_speed_valid(true, 0b00));
+        assert!(!negotiated_speed_valid(true, 0b01));
     }
 }

--- a/embassy-nxp/src/usb/lpc55.rs
+++ b/embassy-nxp/src/usb/lpc55.rs
@@ -65,7 +65,8 @@
 //! data buffers, chosen explicitly via [`Memory`]. [`Memory::usb1_sram`] hands
 //! over the dedicated 16 KiB USB1 SRAM; [`Memory::buffer`] takes a
 //! caller-owned buffer in main SRAM, which is what lets both controllers run
-//! at the same time.
+//! at the same time. `buffer` aligns the base itself, so a plain `[u8; N]`
+//! will do; no `#[repr(align(..))]` newtype is needed.
 //!
 //! # Silicon errata (ES_LPC55S6x, applies to revisions 0A and 1B)
 //!
@@ -785,20 +786,38 @@ impl<'d> Memory<'d> {
         }
     }
 
-    /// A caller-owned buffer, typically a `static mut` in main SRAM.
+    /// A caller-owned buffer, typically a local in `main`.
     ///
-    /// `buf` must be at least 512 bytes and 256-byte aligned. Using this
-    /// instead of [`Memory::usb1_sram`] is what allows USB0 and USB1 to run at
-    /// the same time.
+    /// A local is not a stack allocation: the body of `#[embassy_executor::main]`
+    /// is a task, so its locals live in the task's storage, which is a
+    /// `static`. A `static_cell::ConstStaticCell` works too.
+    ///
+    /// `buf` needs no particular alignment. `EPLISTSTART` reserves the low 8
+    /// bits of the address, so up to 255 bytes at the front of `buf` are
+    /// skipped; at least 512 bytes must be left after that. Using this instead
+    /// of [`Memory::usb1_sram`] is what allows USB0 and USB1 to run at the same
+    /// time.
     pub fn buffer(buf: &'d mut [u8]) -> Self {
-        let base = buf.as_ptr() as u32;
-        assert!(buf.len() >= 512, "USB endpoint memory must be at least 512 bytes");
-        assert!(base % 256 == 0, "USB endpoint memory must be 256-byte aligned");
+        let raw_base = buf.as_mut_ptr() as u32;
+        let base = raw_base.next_multiple_of(256);
+        let len = (buf.len() as u32).saturating_sub(base - raw_base);
+        assert!(
+            len >= 512,
+            "USB endpoint memory must leave at least 512 bytes after alignment"
+        );
         Self {
             base,
-            len: buf.len() as u32,
+            len,
             _lifetime: PhantomData,
         }
+    }
+
+    /// Base address of the region, after alignment.
+    ///
+    /// This is the address the driver programs into `EPLISTSTART` and
+    /// `DATABUFSTART`, and where the endpoint command/status list starts.
+    pub fn base(&self) -> u32 {
+        self.base
     }
 }
 

--- a/embassy-nxp/src/usb/lpc55.rs
+++ b/embassy-nxp/src/usb/lpc55.rs
@@ -1,14 +1,100 @@
-//! USB1 high-speed device driver for LPC55 (ip3511-HS).
+//! USB device driver for LPC55 (ip3511).
 //!
-//! Device mode only. Supports control, bulk and interrupt endpoints;
-//! isochronous endpoint allocation returns [`EndpointAllocError`].
+//! The LPC55 carries two independent device controllers, both instances of the
+//! same ip3511 design and both served by this driver through the [`Instance`]
+//! trait:
 //!
-//! The system (main) clock must run at 96 MHz or higher, see
-//! [`crate::config::MainClock::FroHf96`].
+//! | Peripheral | Speed                  | EVK connector | Logical endpoints |
+//! |------------|------------------------|---------------|-------------------|
+//! | [`USB0`]   | full-speed, 12 Mbps    | P10           | 5 (EP0 + 4)       |
+//! | [`USBHSD`] | high-speed, 480 Mbps   | P9            | 6 (EP0 + 5)       |
+//!
+//! [`USB0`]: crate::peripherals::USB0
+//! [`USBHSD`]: crate::peripherals::USBHSD
+//!
+//! # Clocking
+//!
+//! The high-speed controller needs a system (main) clock of at least 96 MHz —
+//! see [`crate::config::MainClock::FroHf96`] — and a 16 MHz crystal for its
+//! PHY PLL. The full-speed controller needs neither: it drives itself from the
+//! FRO-HF 96 MHz output divided to 48 MHz, which [`Driver::new`] enables
+//! itself, so it works under [`crate::config::Config::default()`].
+//!
+//! # Maximum packet sizes
+//!
+//! | Endpoint type   | USB0 (FS) | USBHSD (HS) |
+//! |-----------------|-----------|-------------|
+//! | Bulk            | 64        | 512         |
+//! | Interrupt       | 64        | 1024        |
+//! | Isochronous OUT | 1023      | 1024        |
+//! | Isochronous IN  | 1023      | 1023        |
+//!
+//! Control endpoints beyond EP0 are not allocatable; `embassy-usb` never asks
+//! for one.
+//!
+//! # Transfer granularity
+//!
+//! [`driver::EndpointOut::read`] returns exactly one packet, as its contract
+//! requires, and OUT slots are always armed for one packet.
+//!
+//! The high-speed controller can packetize a single endpoint command entry,
+//! streaming several kilobytes without CPU involvement, and IN endpoints use
+//! that: [`driver::EndpointIn::write`] accepts up to a slot's capacity
+//! ([`Instance::BULK_IN_SLOT_LEN`], 3584 B) rather than rejecting anything over
+//! the max packet size, and [`driver::EndpointIn::write_transfer`] chunks by
+//! that capacity instead of by packet. Measured on an LPC55S69 at 480 Mbps over
+//! CDC-ACM bulk, that is 44 MB/s against 23 MB/s for packet-at-a-time writes.
+//! Accepting an oversized `write` is an extension beyond the trait contract, so
+//! portable code should prefer `write_transfer`.
+//!
+//! OUT deliberately forgoes the same trick even though it would roughly double
+//! the 18 MB/s that packet-at-a-time reads reach. A slot's window length is
+//! committed when the slot is armed, which double buffering does one packet
+//! ahead of the caller, whereas the room left in the caller's buffer is only
+//! known when that slot is drained; the two cannot be reconciled without an
+//! internal holding buffer. [`driver::EndpointOut::read_transfer`] therefore
+//! keeps the trait's per-packet default.
+//!
+//! The full-speed controller has no packetizing capability at all: an entry
+//! whose NBytes exceeds the max packet size never completes, so both directions
+//! are one packet per call there.
+//!
+//! # Endpoint memory
+//!
+//! Each controller needs a region for its endpoint command/status list and
+//! data buffers, chosen explicitly via [`Memory`]. [`Memory::usb1_sram`] hands
+//! over the dedicated 16 KiB USB1 SRAM; [`Memory::buffer`] takes a
+//! caller-owned buffer in main SRAM, which is what lets both controllers run
+//! at the same time.
+//!
+//! # Silicon errata (ES_LPC55S6x, applies to revisions 0A and 1B)
+//!
+//! - **USB.3** (§3.11): locking the FRO to USB SOF packets, which the
+//!   full-speed bring-up enables via `FRO192M_CTRL.USBCLKADJ`, is not
+//!   functional when the device is reached through more than one hub. Direct
+//!   connections and single-hub paths are unaffected.
+//! - **USB.5** (§3.22): a high-speed OUT transfer whose length is not a
+//!   multiple of 8 has extra bytes written past its end, because the
+//!   controller always writes 8 bytes at a time. Every endpoint buffer
+//!   allocation is rounded up to 64 bytes, which absorbs the overrun.
+//! - **USB.6** (§3.23): a high-speed isochronous IN endpoint sending a
+//!   1024-byte packet raises no endpoint interrupt and leaves its
+//!   command/status entry untouched. `alloc_endpoint` therefore caps
+//!   high-speed isochronous IN at 1023 bytes, which is NXP's documented
+//!   workaround.
+//!
+//! # Known limitations
+//!
+//! [`driver::Bus::poll`] derives [`Event::PowerDetected`] and
+//! [`Event::PowerRemoved`] from `DEVCMDSTAT.VBUS_DEBOUNCED`, which is only
+//! sampled when the controller raises a device-status interrupt. Losing VBUS
+//! forces a connect-state change (hardware gates the D+ pull-up on
+//! `VBUS_DEBOUNCED`), so that interrupt does arrive, but the driver never
+//! polls VBUS on its own.
 
 use core::future::poll_fn;
 use core::marker::PhantomData;
-use core::sync::atomic::{AtomicU8, Ordering, compiler_fence};
+use core::sync::atomic::{AtomicBool, AtomicU8, Ordering, compiler_fence};
 use core::task::Poll;
 
 use embassy_hal_internal::{Peri, PeripheralType};
@@ -21,121 +107,175 @@ use embassy_usb_driver::{
 use crate::interrupt::typelevel::{Binding, Interrupt};
 use crate::pac;
 
-/// Number of logical endpoints (each has an IN and an OUT side).
-const EP_COUNT: usize = 6;
-/// Dedicated USB1 SRAM.
-const USB_SRAM_ADDR: u32 = 0x4010_0000;
-const USB_SRAM_SIZE: u32 = 0x4000;
-/// The endpoint command/status list occupies `EP_COUNT * 4` words at the
-/// start of the USB SRAM (256-byte aligned by construction). Word layout per
-/// logical EP i: `[out_buf0, out_buf1, in_buf0, in_buf1]`. EP0's `out_buf1`
-/// slot holds the SETUP buffer pointer.
-///
-/// Data buffers are bump-allocated 64-byte aligned from here on; the first
-/// allocation (in `Driver::new`) is the 8-byte SETUP buffer.
-const DATA_BUFFERS_START: u32 = USB_SRAM_ADDR + 0x80;
+/// Largest [`Instance::EP_COUNT`] across LPC55 controllers; sizes the static
+/// per-endpoint arrays in [`State`].
+const MAX_EP_COUNT: usize = 6;
 
-// HS endpoint command/status word encoding. NOTE: differs from the USB0-FS
-// controller (NBytes is 15 bits at bit 11, AddressOffset is 11 bits).
+/// Dedicated USB1 SRAM, usable as endpoint memory by either controller.
+const USB1_SRAM_ADDR: u32 = 0x4010_0000;
+const USB1_SRAM_SIZE: u32 = 0x4000;
+
+/// Bytes reserved at the start of the endpoint memory for the command/status
+/// list. Word layout per logical EP i: `[out_buf0, out_buf1, in_buf0,
+/// in_buf1]`, so the list itself needs `EP_COUNT * 16` bytes; rounding the
+/// reservation up to `MAX_EP_COUNT * 16` = 96 -> 128 keeps the first data
+/// buffer 64-byte aligned for every instance. EP0's `out_buf1` slot holds the
+/// SETUP buffer pointer rather than a command word.
+const EP_LIST_LEN: u32 = 0x80;
+
+// Endpoint command/status word encoding. The bit flags below are common to
+// both controllers; the NBytes and AddressOffset field positions differ and
+// live on `Instance`.
 const CMD_A: u32 = 1 << 31; // Active (HW clears on completion)
 const CMD_D: u32 = 1 << 30; // Disabled
 const CMD_S: u32 = 1 << 29; // Stall
 const CMD_TR: u32 = 1 << 28; // Toggle Reset (write-1)
 #[allow(dead_code)] // documented for completeness of the CS-word encoding
 const CMD_TV: u32 = 1 << 27; // RF/TV: data toggle value for bulk/interrupt
-const NBYTES_SHIFT: u32 = 11;
-const NBYTES_MASK: u32 = 0x7FFF;
+const CMD_T: u32 = 1 << 26; // Endpoint type: 0 = generic, 1 = isochronous
 
-/// Per-slot buffer capacity for HS bulk endpoints, in bytes.
+/// Per-endpoint state flags, kept in an `AtomicU8`.
 ///
-/// The ip3511-HS packetizes a single command/status entry: NBytes (15 bits)
-/// may span multiple max-packet-size packets and hardware streams them all
-/// without CPU involvement, so larger slots amortize the ISR + executor +
-/// re-arm turnaround over many packets.
-///
-/// OUT slots are a power of two (8 x 512) because an OUT window only
-/// completes when the buffer fills or a short packet arrives: host-side
-/// writes are power-of-two-sized, so windows tile them exactly. IN has no
-/// such constraint; 3584 (7 x 512) makes both directions plus EP0 and one
-/// interrupt endpoint fit the 16 KiB USB SRAM (2x4096 + 2x3584 + overhead).
-const BULK_OUT_SLOT_LEN: u16 = 4096;
-const BULK_IN_SLOT_LEN: u16 = 3584;
-
-static BUS_WAKER: AtomicWaker = AtomicWaker::new();
-static EP_IN_WAKERS: [AtomicWaker; EP_COUNT] = [const { AtomicWaker::new() }; EP_COUNT];
-static EP_OUT_WAKERS: [AtomicWaker; EP_COUNT] = [const { AtomicWaker::new() }; EP_COUNT];
-
-// Double-buffer bookkeeping for data endpoints, shared between `Bus`
-// (reset/enable/stall paths) and the endpoint futures. Hardware consumes the
-// two command/status entries of a double-buffered endpoint in strict EPINUSE
-// ping-pong order, so a 1-bit cursor kept in lockstep (resynced to slot 0
-// whenever EPINUSE is cleared) tracks the hardware exactly.
+/// Double-buffer bookkeeping for data endpoints is shared between [`Bus`]
+/// (reset/enable/stall paths) and the endpoint futures. Hardware consumes the
+/// two command/status entries of a double-buffered endpoint in strict EPINUSE
+/// ping-pong order, so a 1-bit cursor kept in lockstep (resynced to slot 0
+/// whenever EPINUSE is cleared) tracks the hardware exactly.
 const SLOT: u8 = 1 << 0; // next slot to arm (IN) / consume (OUT)
 const PRIMED0: u8 = 1 << 1; // OUT slot armed or holding an unread packet (`PRIMED0 << slot`)
 const TR_PENDING: u8 = 1 << 3; // reset the data toggle on the next arm
-static EP_IN_STATE: [AtomicU8; EP_COUNT] = [const { AtomicU8::new(0) }; EP_COUNT];
-static EP_OUT_STATE: [AtomicU8; EP_COUNT] = [const { AtomicU8::new(0) }; EP_COUNT];
+const ISO: u8 = 1 << 4; // isochronous endpoint; survives enable/stall/reset
 
-fn nbytes(n: u32) -> u32 {
-    (n & NBYTES_MASK) << NBYTES_SHIFT
+/// Shared driver state for one controller instance.
+pub(crate) struct State {
+    bus_waker: AtomicWaker,
+    ep_in_wakers: [AtomicWaker; MAX_EP_COUNT],
+    ep_out_wakers: [AtomicWaker; MAX_EP_COUNT],
+    ep_in_state: [AtomicU8; MAX_EP_COUNT],
+    ep_out_state: [AtomicU8; MAX_EP_COUNT],
 }
 
-fn remaining_bytes(word: u32) -> u32 {
-    (word >> NBYTES_SHIFT) & NBYTES_MASK
+impl State {
+    const fn new() -> Self {
+        Self {
+            bus_waker: AtomicWaker::new(),
+            ep_in_wakers: [const { AtomicWaker::new() }; MAX_EP_COUNT],
+            ep_out_wakers: [const { AtomicWaker::new() }; MAX_EP_COUNT],
+            ep_in_state: [const { AtomicU8::new(0) }; MAX_EP_COUNT],
+            ep_out_state: [const { AtomicU8::new(0) }; MAX_EP_COUNT],
+        }
+    }
+
+    fn ep_state(&self, index: usize, dir: Direction) -> &AtomicU8 {
+        match dir {
+            Direction::Out => &self.ep_out_state[index],
+            Direction::In => &self.ep_in_state[index],
+        }
+    }
+
+    fn ep_waker(&self, index: usize, dir: Direction) -> &AtomicWaker {
+        match dir {
+            Direction::Out => &self.ep_out_wakers[index],
+            Direction::In => &self.ep_in_wakers[index],
+        }
+    }
 }
 
-/// AddressOffset field: bits [10:0] = buffer address >> 6. The upper address
-/// bits come from DATABUFSTART.
-fn addroff(buf_addr: u32) -> u32 {
+fn nbytes<T: Instance>(n: u32) -> u32 {
+    (n & T::NBYTES_MASK) << T::NBYTES_SHIFT
+}
+
+fn remaining_bytes<T: Instance>(word: u32) -> u32 {
+    (word >> T::NBYTES_SHIFT) & T::NBYTES_MASK
+}
+
+/// AddressOffset field: buffer address >> 6, masked to the instance's field
+/// width. The upper address bits come from DATABUFSTART, which is why the
+/// whole endpoint memory region must sit inside one DATABUFSTART window.
+fn addroff<T: Instance>(buf_addr: u32) -> u32 {
     debug_assert_eq!(buf_addr & 0x3F, 0);
-    (buf_addr >> 6) & 0x7FF
+    (buf_addr >> 6) & T::ADDROFF_MASK
+}
+
+/// EPBUFCFG / EPINUSE cover the physical endpoints above EP0, two per logical
+/// endpoint.
+fn ep_buf_mask<T: Instance>() -> u16 {
+    ((1u32 << (2 * (T::EP_COUNT - 1))) - 1) as u16
+}
+
+/// INTEN.EP_INT_EN covers every physical endpoint including EP0's pair.
+fn ep_int_mask<T: Instance>() -> u16 {
+    ((1u32 << (2 * T::EP_COUNT)) - 1) as u16
 }
 
 /// Pointer to the command/status word of a physical endpoint buffer slot.
-fn ep_cmd_ptr(index: usize, dir: Direction, buf1: bool) -> *mut u32 {
+fn ep_cmd_ptr(ep_list: u32, index: usize, dir: Direction, buf1: bool) -> *mut u32 {
     let slot = match dir {
         Direction::Out => 0,
         Direction::In => 2,
     } + buf1 as usize;
-    (USB_SRAM_ADDR as usize + index * 16 + slot * 4) as *mut u32
+    (ep_list as usize + index * 16 + slot * 4) as *mut u32
 }
 
-fn ep_cmd_read(index: usize, dir: Direction, slot: usize) -> u32 {
-    unsafe { ep_cmd_ptr(index, dir, slot != 0).read_volatile() }
+fn ep_cmd_read(ep_list: u32, index: usize, dir: Direction, slot: usize) -> u32 {
+    unsafe { ep_cmd_ptr(ep_list, index, dir, slot != 0).read_volatile() }
 }
 
-fn ep_cmd_write(index: usize, dir: Direction, slot: usize, word: u32) {
-    unsafe { ep_cmd_ptr(index, dir, slot != 0).write_volatile(word) }
+fn ep_cmd_write(ep_list: u32, index: usize, dir: Direction, slot: usize, word: u32) {
+    unsafe { ep_cmd_ptr(ep_list, index, dir, slot != 0).write_volatile(word) }
 }
 
-fn ep_cmd_modify(index: usize, dir: Direction, slot: usize, f: impl FnOnce(u32) -> u32) {
+fn ep_cmd_modify(ep_list: u32, index: usize, dir: Direction, slot: usize, f: impl FnOnce(u32) -> u32) {
     critical_section::with(|_| {
-        let p = ep_cmd_ptr(index, dir, slot != 0);
+        let p = ep_cmd_ptr(ep_list, index, dir, slot != 0);
         unsafe { p.write_volatile(f(p.read_volatile())) }
     });
 }
 
 /// Arm one buffer slot of a data endpoint.
 ///
-/// The command word is written whole: the HS controller tracks the
-/// bulk/interrupt data toggle internally per endpoint (read-only EPTOGGLE
-/// register), not in the entry's TV bit, which is only consumed together
-/// with TR. `tr` requests that toggle reset; it is set exactly once for the
-/// first transfer after enable/unstall (the NXP SDK's deferred toggle-reset
-/// discipline).
-fn ep_arm_slot(index: usize, dir: Direction, slot: usize, len: u32, buf_addr: u32, tr: bool) {
-    let tr = if tr { CMD_TR } else { 0 };
-    ep_cmd_write(index, dir, slot, CMD_A | nbytes(len) | addroff(buf_addr) | tr);
+/// The command word is written whole: the controller tracks the bulk/interrupt
+/// data toggle internally per endpoint (read-only EPTOGGLE register), not in
+/// the entry's TV bit, which is only consumed together with TR. `tr` requests
+/// that toggle reset; it is set exactly once for the first transfer after
+/// enable/unstall (the NXP SDK's deferred toggle-reset discipline).
+///
+/// Isochronous endpoints are marked with `T` and never get `TR`: they have no
+/// data toggle to reset.
+fn ep_arm_slot<T: Instance>(
+    ep_list: u32,
+    index: usize,
+    dir: Direction,
+    slot: usize,
+    len: u32,
+    buf_addr: u32,
+    tr: bool,
+    iso: bool,
+) {
+    let flags = if iso {
+        CMD_T
+    } else if tr {
+        CMD_TR
+    } else {
+        0
+    };
+    ep_cmd_write(
+        ep_list,
+        index,
+        dir,
+        slot,
+        CMD_A | nbytes::<T>(len) | addroff::<T>(buf_addr) | flags,
+    );
 }
 
-/// Copy into the dedicated USB SRAM using 32-bit accesses.
+/// Copy into endpoint buffer memory using 32-bit accesses.
 ///
-/// The SRAM sits behind the AHB matrix, so each access is a full bus
+/// Endpoint memory sits behind the AHB matrix, so each access is a full bus
 /// transaction: byte-wise copies are 4x the transactions and dominate the
 /// per-packet cost at high speed. Endpoint buffers are 64-byte aligned and
 /// rounded up to 64-byte multiples (see `alloc_buffer`), so word-aligned
 /// stores plus a full-word tail never leave the allocation.
-fn copy_to_usb_sram(buf_addr: u32, data: &[u8]) {
+fn copy_to_ep_buffer(buf_addr: u32, data: &[u8]) {
     debug_assert!(buf_addr % 4 == 0);
     compiler_fence(Ordering::SeqCst);
     let mut dst = buf_addr as *mut u32;
@@ -155,9 +295,9 @@ fn copy_to_usb_sram(buf_addr: u32, data: &[u8]) {
     compiler_fence(Ordering::SeqCst);
 }
 
-/// Copy out of the dedicated USB SRAM using 32-bit accesses; see
-/// [`copy_to_usb_sram`] for the alignment/over-read reasoning.
-fn copy_from_usb_sram(buf_addr: u32, data: &mut [u8]) {
+/// Copy out of endpoint buffer memory using 32-bit accesses; see
+/// [`copy_to_ep_buffer`] for the alignment/over-read reasoning.
+fn copy_from_ep_buffer(buf_addr: u32, data: &mut [u8]) {
     debug_assert!(buf_addr % 4 == 0);
     compiler_fence(Ordering::SeqCst);
     let mut src = buf_addr as *const u32;
@@ -195,8 +335,43 @@ fn devcmdstat_modify(regs: pac::usbhsd::Usbhsd, f: impl FnOnce(&mut pac::usbhsd:
     });
 }
 
+/// Program the controller registers that describe the endpoint memory and
+/// enable the device block. Run after every [`SealedInstance::power_up`].
+fn program_controller<T: Instance>(ep_list: u32) {
+    let regs = T::regs();
+
+    // Both registers take the full region base; the hardware ignores the low
+    // bits it does not implement. `write_value` keeps one code path for the
+    // two instances, whose field decompositions differ.
+    regs.databufstart()
+        .write_value(pac::usbhsd::regs::Databufstart(ep_list));
+    regs.epliststart().write_value(pac::usbhsd::regs::Epliststart(ep_list));
+
+    // Non-control endpoints run double-buffered: EPBUFCFG has one bit per
+    // physical endpoint (EP0 excluded), and hardware ping-pongs the two
+    // command/status entries via EPINUSE.
+    regs.epinuse().write(|w| w.set_buf(0));
+    regs.epbufcfg().write(|w| w.set_buf_sb(ep_buf_mask::<T>()));
+    regs.epskip().write_value(pac::usbhsd::regs::Epskip(0));
+
+    // Enable the device controller, but do not connect yet. Preserve the
+    // reset defaults of the other fields (notably LPM_SUP).
+    devcmdstat_modify(regs, |w| w.set_dev_en(true));
+
+    regs.intstat().write_value(pac::usbhsd::regs::Intstat(!0));
+    regs.inten().write(|w| {
+        w.set_ep_int_en(ep_int_mask::<T>());
+        w.set_dev_int_en(true);
+    });
+}
+
 trait SealedInstance {
     fn regs() -> pac::usbhsd::Usbhsd;
+    fn state() -> &'static State;
+    /// Power up clocks + PHY for this controller. Idempotent.
+    fn power_up();
+    /// Power the PHY down and gate this controller's clocks.
+    fn power_down();
 }
 
 /// USB peripheral instance.
@@ -204,103 +379,55 @@ trait SealedInstance {
 pub trait Instance: SealedInstance + PeripheralType + 'static {
     /// Interrupt for this instance.
     type Interrupt: crate::interrupt::typelevel::Interrupt;
+
+    /// Number of logical endpoints (EP0 plus data endpoints).
+    const EP_COUNT: usize;
+    /// NBytes field of the command/status word.
+    const NBYTES_SHIFT: u32;
+    /// Mask of the NBytes field, before shifting.
+    const NBYTES_MASK: u32;
+    /// AddressOffset field of the command/status word, at bit 0.
+    const ADDROFF_MASK: u32;
+    /// `log2` of the address window DATABUFSTART spans; the whole endpoint
+    /// memory region must lie inside one such window.
+    const DATABUF_WINDOW_SHIFT: u32;
+    /// Largest max-packet-size accepted by `alloc_endpoint`, for bulk.
+    const MAX_BULK_MPS: u16;
+    /// Largest max-packet-size accepted by `alloc_endpoint`, for interrupt.
+    const MAX_INTERRUPT_MPS: u16;
+    /// Largest max-packet-size accepted by `alloc_endpoint`, for isochronous OUT.
+    const MAX_ISO_OUT_MPS: u16;
+    /// Largest max-packet-size accepted by `alloc_endpoint`, for isochronous IN.
+    const MAX_ISO_IN_MPS: u16;
+    /// Whether one command/status entry may span several max-packet-size
+    /// packets.
+    ///
+    /// The ip3511-**HS** packetizes a multi-packet entry in hardware, streaming
+    /// every packet without CPU involvement. The full-speed block has no such
+    /// capability: an entry whose NBytes exceeds the max packet size simply
+    /// never completes, so full-speed endpoints must be armed one packet at a
+    /// time.
+    ///
+    /// Only IN endpoints use it. OUT slots are always armed for one packet, so
+    /// that `read` can honour its single-packet contract.
+    const MULTI_PACKET: bool;
+    /// Multi-packet slot capacity for bulk IN endpoints. Inert when
+    /// [`Instance::MULTI_PACKET`] is `false`.
+    const BULK_IN_SLOT_LEN: u16;
 }
 
 impl SealedInstance for crate::peripherals::USBHSD {
     fn regs() -> pac::usbhsd::Usbhsd {
         pac::USBHSD
     }
-}
 
-impl Instance for crate::peripherals::USBHSD {
-    type Interrupt = crate::interrupt::typelevel::USB1;
-}
-
-/// Marker type for IN endpoints.
-pub enum In {}
-/// Marker type for OUT endpoints.
-pub enum Out {}
-
-trait SealedDir {
-    fn dir() -> Direction;
-}
-
-/// Endpoint direction marker.
-#[allow(private_bounds)]
-pub trait Dir: SealedDir {}
-
-impl SealedDir for In {
-    fn dir() -> Direction {
-        Direction::In
+    fn state() -> &'static State {
+        static STATE: State = State::new();
+        &STATE
     }
-}
-impl Dir for In {}
 
-impl SealedDir for Out {
-    fn dir() -> Direction {
-        Direction::Out
-    }
-}
-impl Dir for Out {}
-
-/// USB interrupt handler.
-pub struct InterruptHandler<T: Instance> {
-    _phantom: PhantomData<T>,
-}
-
-impl<T: Instance> crate::interrupt::typelevel::Handler<T::Interrupt> for InterruptHandler<T> {
-    unsafe fn on_interrupt() {
-        let regs = T::regs();
-        let stat = regs.intstat().read();
-        // W1C exactly the bits we saw. Later-arriving bits stay pending and
-        // re-fire the interrupt. Losing an edge is safe by design: the futures
-        // re-check level state (eplist Active bit / DEVCMDSTAT.SETUP).
-        regs.intstat().write_value(stat);
-
-        for i in 0..EP_COUNT {
-            if stat.0 & (1 << (2 * i)) != 0 {
-                EP_OUT_WAKERS[i].wake();
-            }
-            if stat.0 & (1 << (2 * i + 1)) != 0 {
-                EP_IN_WAKERS[i].wake();
-            }
-        }
-
-        // A pending SETUP must abort in-flight control transfers in either
-        // direction, so wake both EP0 futures.
-        if regs.devcmdstat().read().setup() {
-            EP_OUT_WAKERS[0].wake();
-            EP_IN_WAKERS[0].wake();
-        }
-
-        // dev_int: DEVCMDSTAT change bits are consumed by `Bus::poll`.
-        if stat.0 & (1 << 31) != 0 {
-            BUS_WAKER.wake();
-        }
-    }
-}
-
-/// LPC55 USB1 high-speed device driver.
-pub struct Driver<'d, T: Instance> {
-    _usb: Peri<'d, T>,
-    ep_in_used: [bool; EP_COUNT],
-    ep_out_used: [bool; EP_COUNT],
-    /// Bump allocator over the dedicated USB SRAM.
-    alloc_offset: u32,
-    /// Address of the 8-byte (64-byte aligned) SETUP buffer.
-    setup_addr: u32,
-}
-
-impl<'d, T: Instance> Driver<'d, T> {
-    /// Create a new USB driver.
-    ///
-    /// This powers up and configures the USB1 PHY (expects a 32 MHz crystal)
-    /// and the device controller, but does not connect to the bus yet; the
-    /// soft-connect happens in [`driver::Bus::enable`].
-    pub fn new(usb: Peri<'d, T>, _irq: impl Binding<T::Interrupt, InterruptHandler<T>> + 'd) -> Self {
+    fn power_up() {
         use pac::syscon::vals::{Usb1DevRst, Usb1HostRst, Usb1PhyRst, Usb1RamRst};
-
-        let regs = T::regs();
 
         // Reset the USB1 blocks sequentially, per block, with their clocks
         // still off — the exact order lpc55-hal's `enabled_as_device` uses
@@ -356,13 +483,6 @@ impl<'d, T: Instance> Driver<'d, T> {
         critical_section::with(|_| {
             pac::SYSCON.ahbclkctrl2().modify(|w| w.set_usb1_host(false));
         });
-
-        // PDRUNCFG bit positions (1 = powered down; writing 1 to the CLR
-        // register clears the bit, i.e. powers the block ON).
-        const PDEN_XTAL32M: u32 = 1 << 8;
-        const PDEN_USBHSPHY: u32 = 1 << 12;
-        const PDEN_LDOUSBHS: u32 = 1 << 18;
-        const PDEN_LDOXO32M: u32 = 1 << 20;
 
         // Power on the 32 MHz crystal + its LDO and route it to the USB PLL.
         pac::PMC
@@ -435,59 +555,432 @@ impl<'d, T: Instance> Driver<'d, T> {
                 w.set_usb1_ram(true);
             });
         });
+    }
+
+    fn power_down() {
+        // Reverse of `power_up`: PHY analog off, PHY register clock gated,
+        // analog supplies powered down, then the block clocks.
+        pac::USBPHY.pwd().write_value(pac::usbphy::regs::Pwd(!0));
+        pac::USBPHY.ctrl().modify(|w| w.set_clkgate(true));
+        pac::PMC
+            .pdruncfgset0()
+            .write(|w| w.set_pdruncfgset0(PDEN_USBHSPHY | PDEN_LDOUSBHS));
+        critical_section::with(|_| {
+            pac::SYSCON.ahbclkctrl2().modify(|w| {
+                w.set_usb1_dev(false);
+                w.set_usb1_ram(false);
+                w.set_usb1_phy(false);
+            });
+        });
+    }
+}
+
+impl Instance for crate::peripherals::USBHSD {
+    type Interrupt = crate::interrupt::typelevel::USB1;
+
+    const EP_COUNT: usize = 6;
+    const NBYTES_SHIFT: u32 = 11;
+    const NBYTES_MASK: u32 = 0x7FFF;
+    const ADDROFF_MASK: u32 = 0x7FF;
+    const DATABUF_WINDOW_SHIFT: u32 = 17;
+    const MAX_BULK_MPS: u16 = 512;
+    const MAX_INTERRUPT_MPS: u16 = 1024;
+    const MAX_ISO_OUT_MPS: u16 = 1024;
+    /// 1023, not 1024, per erratum **USB.6** (ES_LPC55S6x §3.23, revisions 0A
+    /// and 1B, no silicon fix): a high-speed isochronous IN endpoint sending a
+    /// 1024-byte packet raises no endpoint interrupt and does not update its
+    /// command/status entry, so [`driver::EndpointIn::write`] would never
+    /// complete. NXP's documented workaround is exactly this cap.
+    const MAX_ISO_IN_MPS: u16 = 1023;
+    const MULTI_PACKET: bool = true;
+    /// Per-slot buffer capacity for HS bulk IN endpoints, in bytes.
+    ///
+    /// The ip3511-HS packetizes a single command/status entry: NBytes (15
+    /// bits) may span multiple max-packet-size packets and hardware streams
+    /// them all without CPU involvement, so larger slots amortize the ISR +
+    /// executor + re-arm turnaround over many packets.
+    ///
+    /// 3584 (7 x 512) leaves both directions plus EP0 and one interrupt
+    /// endpoint inside the 16 KiB USB SRAM.
+    const BULK_IN_SLOT_LEN: u16 = 3584;
+}
+
+impl SealedInstance for crate::peripherals::USB0 {
+    fn regs() -> pac::usbhsd::Usbhsd {
+        // USB0 and USBHSD are the same ip3511 register map: every shared
+        // register sits at the same offset and every shared field at the same
+        // bit position. The HS block is the field-width superset, and this
+        // driver masks writes to the FS widths (`ep_buf_mask`, `ep_int_mask`),
+        // so nothing ever reaches an FS-reserved bit. See the module docs.
+        unsafe { pac::usbhsd::Usbhsd::from_ptr(pac::USB0.as_ptr()) }
+    }
+
+    fn state() -> &'static State {
+        static STATE: State = State::new();
+        &STATE
+    }
+
+    fn power_up() {
+        use pac::syscon::vals::{Usb0DevRst, Usb0clkdivHalt, Usb0clkdivReqflag, Usb0clkselSel};
+
+        // The FS controller clocks off FRO-HF regardless of
+        // `config::MainClock`, so it must enable the 96 MHz output itself
+        // rather than assume `init` did.
+        pac::ANACTRL.fro192m_ctrl().modify(|w| w.set_ena_96mhzclk(true));
+
+        // FRO 96 MHz / 2 = the 48 MHz the FS controller needs. Program the
+        // divider before selecting the source, then wait for it to settle.
+        pac::SYSCON.usb0clkdiv().modify(|w| w.set_div(1));
+        pac::SYSCON.usb0clkdiv().modify(|w| w.set_halt(Usb0clkdivHalt::Run));
+        pac::SYSCON.usb0clksel().write(|w| w.set_sel(Usb0clkselSel::Enum0x3));
+        let mut stable = false;
+        for _ in 0..1_000_000 {
+            if pac::SYSCON.usb0clkdiv().read().reqflag() == Usb0clkdivReqflag::Stable {
+                stable = true;
+                break;
+            }
+        }
+        if !stable {
+            warn!("USB0 clock divider did not stabilize");
+        }
+
+        // Power on the FS PHY. `pdruncfgclr0` is write-1-to-clear over a
+        // single wide field, so use the same raw-bit style as the HS path.
+        pac::PMC.pdruncfgclr0().write(|w| w.set_pdruncfgclr0(PDEN_USBFSPHY));
+
+        // Reset the device block, then clock it.
+        critical_section::with(|_| {
+            pac::SYSCON
+                .presetctrl1()
+                .modify(|w| w.set_usb0_dev_rst(Usb0DevRst::Asserted));
+            pac::SYSCON
+                .presetctrl1()
+                .modify(|w| w.set_usb0_dev_rst(Usb0DevRst::Released));
+            pac::SYSCON.ahbclkctrl1().modify(|w| w.set_usb0_dev(true));
+        });
+
+        // Hand the shared USB0 port to the device controller (reset default is
+        // host). The USB0 clock must already be running for this write, which
+        // is why it comes after the divider and the device clock: lpc55-hal
+        // flags it as a debugger-killer otherwise.
+        critical_section::with(|_| {
+            pac::SYSCON.ahbclkctrl2().modify(|w| w.set_usb0_hosts(true));
+        });
+        pac::USBFSH.portmode().modify(|w| w.set_dev_enable(true));
+        critical_section::with(|_| {
+            pac::SYSCON.ahbclkctrl2().modify(|w| w.set_usb0_hosts(false));
+        });
+
+        // Lock the FRO to USB SOF packets for full-speed timing accuracy,
+        // which is what makes crystal-less FS operation viable. Not functional
+        // through more than one hub — erratum USB.3, see the module docs.
+        pac::ANACTRL.fro192m_ctrl().modify(|w| w.set_usbclkadj(true));
+        let mut adjusted = false;
+        for _ in 0..1_000_000 {
+            if !pac::ANACTRL.fro192m_ctrl().read().usbmodchg() {
+                adjusted = true;
+                break;
+            }
+        }
+        if !adjusted {
+            warn!("USB0 FRO clock adjustment did not settle");
+        }
+    }
+
+    fn power_down() {
+        use pac::syscon::vals::Usb0clkdivHalt;
+
+        critical_section::with(|_| {
+            pac::SYSCON.ahbclkctrl1().modify(|w| w.set_usb0_dev(false));
+        });
+        pac::PMC.pdruncfgset0().write(|w| w.set_pdruncfgset0(PDEN_USBFSPHY));
+        // Leave USBCLKADJ set: the FRO trim it trained is still valid, and
+        // retraining costs another SOF lock on the next `power_up`.
+        pac::SYSCON.usb0clkdiv().modify(|w| w.set_halt(Usb0clkdivHalt::Halt));
+    }
+}
+
+impl Instance for crate::peripherals::USB0 {
+    type Interrupt = crate::interrupt::typelevel::USB0;
+
+    /// EP0 plus 4 data endpoints. The FS register field widths give 10
+    /// physical endpoints (`epbufcfg.buf_sb` / `epinuse.buf` are 8 bits above
+    /// EP0's pair, `epskip.skip` / `inten.ep_int_en` are 10 bits), matching
+    /// lpc55-hal's endpoint-list layout of `ep0out, setup, ep0in, _, eps[4]`.
+    const EP_COUNT: usize = 5;
+    const NBYTES_SHIFT: u32 = 16;
+    const NBYTES_MASK: u32 = 0x3FF;
+    const ADDROFF_MASK: u32 = 0xFFFF;
+    const DATABUF_WINDOW_SHIFT: u32 = 22;
+    const MAX_BULK_MPS: u16 = 64;
+    const MAX_INTERRUPT_MPS: u16 = 64;
+    const MAX_ISO_OUT_MPS: u16 = 1023;
+    const MAX_ISO_IN_MPS: u16 = 1023;
+    /// The full-speed block does not packetize a command entry: an entry whose
+    /// NBytes exceeds the max packet size never completes (verified on
+    /// hardware - a 512-byte IN entry on a 64-byte endpoint delivers nothing,
+    /// and `lpc55-hal`'s full-speed driver likewise never sets NBytes above
+    /// the max packet size). Endpoints are therefore armed one packet at a
+    /// time and [`Instance::BULK_IN_SLOT_LEN`] is inert.
+    const MULTI_PACKET: bool = false;
+    const BULK_IN_SLOT_LEN: u16 = 64;
+}
+
+// PDRUNCFG bit positions (1 = powered down; writing 1 to the CLR register
+// clears the bit, i.e. powers the block ON).
+const PDEN_XTAL32M: u32 = 1 << 8;
+const PDEN_USBFSPHY: u32 = 1 << 11;
+const PDEN_USBHSPHY: u32 = 1 << 12;
+const PDEN_LDOUSBHS: u32 = 1 << 18;
+const PDEN_LDOXO32M: u32 = 1 << 20;
+
+trait SealedVbusPin {}
+
+/// `USB0_VBUS` sense pin. Only `PIO0_22` carries this function on LPC55.
+#[allow(private_bounds)]
+pub trait VbusPin: SealedVbusPin + crate::gpio::Pin {}
+
+impl SealedVbusPin for crate::peripherals::PIO0_22 {}
+impl VbusPin for crate::peripherals::PIO0_22 {}
+
+/// Where a USB controller's endpoint command list and data buffers live.
+pub struct Memory<'d> {
+    base: u32,
+    len: u32,
+    _lifetime: PhantomData<&'d mut ()>,
+}
+
+static USB1_SRAM_TAKEN: AtomicBool = AtomicBool::new(false);
+
+impl<'d> Memory<'d> {
+    /// The dedicated 16 KiB USB1 SRAM at `0x4010_0000`.
+    ///
+    /// Usable by either controller, but only by one at a time: constructing a
+    /// second one panics. There is no release path; the region is held for the
+    /// lifetime of the driver.
+    pub fn usb1_sram() -> Self {
+        if USB1_SRAM_TAKEN.swap(true, Ordering::Relaxed) {
+            panic!("USB1 SRAM already in use");
+        }
+        // The dedicated RAM has its own clock gate, independent of whichever
+        // controller ends up addressing it.
+        critical_section::with(|_| {
+            pac::SYSCON.ahbclkctrl2().modify(|w| w.set_usb1_ram(true));
+        });
+        Self {
+            base: USB1_SRAM_ADDR,
+            len: USB1_SRAM_SIZE,
+            _lifetime: PhantomData,
+        }
+    }
+
+    /// A caller-owned buffer, typically a `static mut` in main SRAM.
+    ///
+    /// `buf` must be at least 512 bytes and 256-byte aligned. Using this
+    /// instead of [`Memory::usb1_sram`] is what allows USB0 and USB1 to run at
+    /// the same time.
+    pub fn buffer(buf: &'d mut [u8]) -> Self {
+        let base = buf.as_ptr() as u32;
+        assert!(buf.len() >= 512, "USB endpoint memory must be at least 512 bytes");
+        assert!(base % 256 == 0, "USB endpoint memory must be 256-byte aligned");
+        Self {
+            base,
+            len: buf.len() as u32,
+            _lifetime: PhantomData,
+        }
+    }
+}
+
+/// Marker type for IN endpoints.
+pub enum In {}
+/// Marker type for OUT endpoints.
+pub enum Out {}
+
+trait SealedDir {
+    fn dir() -> Direction;
+}
+
+/// Endpoint direction marker.
+#[allow(private_bounds)]
+pub trait Dir: SealedDir {}
+
+impl SealedDir for In {
+    fn dir() -> Direction {
+        Direction::In
+    }
+}
+impl Dir for In {}
+
+impl SealedDir for Out {
+    fn dir() -> Direction {
+        Direction::Out
+    }
+}
+impl Dir for Out {}
+
+/// USB interrupt handler.
+pub struct InterruptHandler<T: Instance> {
+    _phantom: PhantomData<T>,
+}
+
+impl<T: Instance> crate::interrupt::typelevel::Handler<T::Interrupt> for InterruptHandler<T> {
+    unsafe fn on_interrupt() {
+        let regs = T::regs();
+        let state = T::state();
+        let stat = regs.intstat().read();
+        // W1C exactly the bits we saw. Later-arriving bits stay pending and
+        // re-fire the interrupt. Losing an edge is safe by design: the futures
+        // re-check level state (eplist Active bit / DEVCMDSTAT.SETUP).
+        regs.intstat().write_value(stat);
+
+        for i in 0..T::EP_COUNT {
+            if stat.0 & (1 << (2 * i)) != 0 {
+                state.ep_out_wakers[i].wake();
+            }
+            if stat.0 & (1 << (2 * i + 1)) != 0 {
+                state.ep_in_wakers[i].wake();
+            }
+        }
+
+        // A pending SETUP must abort in-flight control transfers in either
+        // direction, so wake both EP0 futures.
+        if regs.devcmdstat().read().setup() {
+            state.ep_out_wakers[0].wake();
+            state.ep_in_wakers[0].wake();
+        }
+
+        // dev_int: DEVCMDSTAT change bits are consumed by `Bus::poll`.
+        if stat.0 & (1 << 31) != 0 {
+            state.bus_waker.wake();
+        }
+    }
+}
+
+/// LPC55 USB device driver.
+pub struct Driver<'d, T: Instance> {
+    _usb: Peri<'d, T>,
+    _vbus: Option<Peri<'d, crate::gpio::AnyPin>>,
+    ep_in_used: [bool; MAX_EP_COUNT],
+    ep_out_used: [bool; MAX_EP_COUNT],
+    /// Base of the endpoint memory: the command/status list starts here.
+    ep_list: u32,
+    /// One past the end of the endpoint memory.
+    mem_end: u32,
+    /// Bump allocator offset, relative to `ep_list`.
+    alloc_offset: u32,
+    /// Address of the 8-byte (64-byte aligned) SETUP buffer.
+    setup_addr: u32,
+}
+
+impl<'d> Driver<'d, crate::peripherals::USBHSD> {
+    /// Create a new USB1 high-speed driver.
+    ///
+    /// This powers up and configures the USB1 PHY (expects a 16 MHz crystal)
+    /// and the device controller, but does not connect to the bus yet; the
+    /// soft-connect happens in [`driver::Bus::enable`].
+    ///
+    /// Requires a system clock of at least 96 MHz, see
+    /// [`crate::config::MainClock::FroHf96`].
+    pub fn new(
+        usb: Peri<'d, crate::peripherals::USBHSD>,
+        _irq: impl Binding<crate::interrupt::typelevel::USB1, InterruptHandler<crate::peripherals::USBHSD>> + 'd,
+        memory: Memory<'d>,
+    ) -> Self {
+        Self::new_inner(usb, None, memory)
+    }
+}
+
+impl<'d> Driver<'d, crate::peripherals::USB0> {
+    /// Create a new USB0 full-speed driver.
+    ///
+    /// This brings up the controller's own 48 MHz clock and the full-speed
+    /// PHY, but does not connect to the bus yet; the soft-connect happens in
+    /// [`driver::Bus::enable`].
+    ///
+    /// `vbus` must be `PIO0_22`; it is routed to `USB0_VBUS` (IOCON FUNC7).
+    /// The pin is required because hardware gates the D+ pull-up on
+    /// `DEVCMDSTAT.VBUS_DEBOUNCED && DCON`, so the device cannot signal a
+    /// connect without it.
+    pub fn new(
+        usb: Peri<'d, crate::peripherals::USB0>,
+        _irq: impl Binding<crate::interrupt::typelevel::USB0, InterruptHandler<crate::peripherals::USB0>> + 'd,
+        vbus: Peri<'d, impl VbusPin>,
+        memory: Memory<'d>,
+    ) -> Self {
+        use pac::iocon::vals::{PioDigimode, PioFunc, PioMode, PioOd, PioSlew};
+
+        vbus.pio().modify(|w| {
+            w.set_func(PioFunc::Alt7);
+            w.set_mode(PioMode::Inactive);
+            w.set_slew(PioSlew::Standard);
+            w.set_invert(false);
+            w.set_digimode(PioDigimode::Digital);
+            w.set_od(PioOd::Normal);
+        });
+
+        Self::new_inner(usb, Some(vbus.into()), memory)
+    }
+}
+
+impl<'d, T: Instance> Driver<'d, T> {
+    fn new_inner(usb: Peri<'d, T>, vbus: Option<Peri<'d, crate::gpio::AnyPin>>, memory: Memory<'d>) -> Self {
+        let Memory { base, len, .. } = memory;
+        assert!(
+            len >= EP_LIST_LEN + 64,
+            "USB endpoint memory is too small for the command list and SETUP buffer"
+        );
+        // AddressOffset only carries the low bits of a buffer address; the
+        // rest comes from DATABUFSTART, so the whole region must sit inside
+        // one DATABUFSTART window.
+        assert!(
+            base >> T::DATABUF_WINDOW_SHIFT == (base + len - 1) >> T::DATABUF_WINDOW_SHIFT,
+            "endpoint memory crosses the DATABUFSTART window"
+        );
+
+        T::power_up();
 
         // Zero the endpoint command/status list and reserve the SETUP buffer.
-        for i in 0..EP_COUNT * 4 {
-            unsafe { ((USB_SRAM_ADDR as usize + i * 4) as *mut u32).write_volatile(0) };
+        for i in 0..T::EP_COUNT * 4 {
+            unsafe { ((base as usize + i * 4) as *mut u32).write_volatile(0) };
         }
-        let setup_addr = DATA_BUFFERS_START;
+        let setup_addr = base + EP_LIST_LEN;
         unsafe {
             (setup_addr as *mut u32).write_volatile(0);
             (setup_addr as *mut u32).add(1).write_volatile(0);
             // EP0 out_buf1 slot holds the SETUP buffer pointer.
-            ep_cmd_ptr(0, Direction::Out, true).write_volatile(addroff(setup_addr));
+            ep_cmd_ptr(base, 0, Direction::Out, true).write_volatile(addroff::<T>(setup_addr));
         }
 
-        regs.databufstart().write(|w| w.set_da_buf(USB_SRAM_ADDR));
-        regs.epliststart()
-            .write_value(pac::usbhsd::regs::Epliststart(USB_SRAM_ADDR));
-        // Non-control endpoints run double-buffered: EPBUFCFG has one bit
-        // per physical endpoint (EP0 excluded), and hardware ping-pongs the
-        // two command/status entries via EPINUSE.
-        regs.epinuse().write(|w| w.set_buf(0));
-        regs.epbufcfg().write(|w| w.set_buf_sb(0x3FF));
-        regs.epskip().write_value(pac::usbhsd::regs::Epskip(0));
-
-        // Enable the device controller, but do not connect yet. Preserve the
-        // reset defaults of the other fields (notably LPM_SUP).
-        devcmdstat_modify(regs, |w| w.set_dev_en(true));
-
-        regs.intstat().write_value(pac::usbhsd::regs::Intstat(!0));
-        regs.inten().write(|w| {
-            w.set_ep_int_en(0xFFF);
-            w.set_dev_int_en(true);
-        });
+        program_controller::<T>(base);
 
         T::Interrupt::unpend();
         unsafe { T::Interrupt::enable() };
 
         Self {
             _usb: usb,
-            ep_in_used: [false; EP_COUNT],
-            ep_out_used: [false; EP_COUNT],
-            alloc_offset: setup_addr + 64 - USB_SRAM_ADDR,
+            _vbus: vbus,
+            ep_in_used: [false; MAX_EP_COUNT],
+            ep_out_used: [false; MAX_EP_COUNT],
+            ep_list: base,
+            mem_end: base + len,
+            alloc_offset: EP_LIST_LEN + 64,
             setup_addr,
         }
     }
 
-    /// Carve a 64-byte-aligned buffer out of the USB SRAM.
+    /// Carve a 64-byte-aligned buffer out of the endpoint memory.
+    ///
+    /// The 64-byte rounding is load-bearing beyond alignment: erratum USB.5
+    /// has the high-speed controller write up to 7 bytes past an OUT transfer
+    /// whose length is not a multiple of 8, and a 64-byte granule keeps that
+    /// overrun inside the allocation. Do not tighten it.
     fn alloc_buffer(&mut self, len: u16) -> Result<u32, EndpointAllocError> {
-        let len = (len as u32 + 63) / 64 * 64;
-        if self.alloc_offset + len > USB_SRAM_SIZE {
-            warn!("USB SRAM full");
+        let len = (len as u32).div_ceil(64) * 64;
+        if self.ep_list + self.alloc_offset + len > self.mem_end {
+            warn!("USB endpoint memory full");
             return Err(EndpointAllocError);
         }
-        let addr = USB_SRAM_ADDR + self.alloc_offset;
+        let addr = self.ep_list + self.alloc_offset;
         self.alloc_offset += len;
         Ok(addr)
     }
@@ -508,12 +1001,15 @@ impl<'d, T: Instance> Driver<'d, T> {
         );
 
         let mps_limit = match ep_type {
-            // Isochronous unsupported (scope decision). Control is only used
-            // internally for EP0; embassy-usb never allocates extra control
-            // endpoints.
-            EndpointType::Isochronous | EndpointType::Control => return Err(EndpointAllocError),
-            EndpointType::Bulk => 512,
-            EndpointType::Interrupt => 1024,
+            // Control is only used internally for EP0; embassy-usb never
+            // allocates extra control endpoints.
+            EndpointType::Control => return Err(EndpointAllocError),
+            EndpointType::Isochronous => match D::dir() {
+                Direction::Out => T::MAX_ISO_OUT_MPS,
+                Direction::In => T::MAX_ISO_IN_MPS,
+            },
+            EndpointType::Bulk => T::MAX_BULK_MPS,
+            EndpointType::Interrupt => T::MAX_INTERRUPT_MPS,
         };
         if max_packet_size > mps_limit {
             warn!("max_packet_size too high: {}", max_packet_size);
@@ -527,40 +1023,65 @@ impl<'d, T: Instance> Driver<'d, T> {
         let index = match ep_addr {
             Some(addr) => {
                 let i = addr.index();
-                if i == 0 || i >= EP_COUNT || used[i] {
+                if i == 0 || i >= T::EP_COUNT || used[i] {
                     return Err(EndpointAllocError);
                 }
                 i
             }
-            None => (1..EP_COUNT).find(|&i| !used[i]).ok_or(EndpointAllocError)?,
+            None => (1..T::EP_COUNT).find(|&i| !used[i]).ok_or(EndpointAllocError)?,
         };
-        used[index] = true;
 
         // Two buffer slots per endpoint (double buffering): software fills or
-        // drains one while the other is on the wire. HS bulk endpoints get
-        // multi-packet slots (see BULK_*_SLOT_LEN); fall back to single-packet
-        // slots if the USB SRAM cannot fit the large ones.
+        // drains one while the other is on the wire. Bulk IN endpoints get a
+        // multi-packet slot where hardware packetizes a command entry (see
+        // BULK_IN_SLOT_LEN), and fall back to a single-packet slot if the
+        // endpoint memory cannot fit the large one.
+        //
+        // Everything else is one packet per slot: OUT because `read` owes the
+        // caller a single packet, isochronous because there is one packet per
+        // (micro)frame anyway.
         let want_len = match (ep_type, D::dir()) {
-            (EndpointType::Bulk, Direction::Out) => BULK_OUT_SLOT_LEN.max(max_packet_size),
-            (EndpointType::Bulk, Direction::In) => BULK_IN_SLOT_LEN.max(max_packet_size),
+            (EndpointType::Bulk, Direction::In) if T::MULTI_PACKET => T::BULK_IN_SLOT_LEN.max(max_packet_size),
             _ => max_packet_size,
         };
+        // Every failure path restores the bump allocator, so a rejected
+        // allocation consumes neither memory nor an endpoint index.
         let mark = self.alloc_offset;
         let (buf_addrs, slot_len) = match (self.alloc_buffer(want_len), self.alloc_buffer(want_len)) {
             (Ok(a), Ok(b)) => ([a, b], want_len),
-            _ if want_len > max_packet_size => {
+            _ => {
                 self.alloc_offset = mark;
-                (
-                    [self.alloc_buffer(max_packet_size)?, self.alloc_buffer(max_packet_size)?],
-                    max_packet_size,
-                )
+                if want_len <= max_packet_size {
+                    return Err(EndpointAllocError);
+                }
+                // The multi-packet slots did not fit; single-packet slots may.
+                match (self.alloc_buffer(max_packet_size), self.alloc_buffer(max_packet_size)) {
+                    (Ok(a), Ok(b)) => ([a, b], max_packet_size),
+                    _ => {
+                        self.alloc_offset = mark;
+                        return Err(EndpointAllocError);
+                    }
+                }
             }
-            _ => return Err(EndpointAllocError),
         };
 
+        // Only now that the allocation succeeded does the index get consumed:
+        // a rejected allocation must leave the driver untouched.
+        match D::dir() {
+            Direction::Out => self.ep_out_used[index] = true,
+            Direction::In => self.ep_in_used[index] = true,
+        }
+
+        // Isochronous endpoints keep a state flag: `Bus` only ever sees an
+        // `EndpointAddress`, and the stall path has to treat them differently.
+        let iso = ep_type == EndpointType::Isochronous;
+        T::state()
+            .ep_state(index, D::dir())
+            .store(if iso { ISO } else { 0 }, Ordering::Relaxed);
+
         // Disabled until `endpoint_set_enabled`.
-        ep_cmd_write(index, D::dir(), 0, CMD_D);
-        ep_cmd_write(index, D::dir(), 1, CMD_D);
+        ep_cmd_write(self.ep_list, index, D::dir(), 0, CMD_D);
+        ep_cmd_write(self.ep_list, index, D::dir(), 1, CMD_D);
 
         trace!("  index={} addr={:08x}", index, buf_addrs[0]);
 
@@ -572,6 +1093,7 @@ impl<'d, T: Instance> Driver<'d, T> {
                 max_packet_size,
                 interval_ms,
             },
+            ep_list: self.ep_list,
             buf_addrs,
             slot_len,
             armed_len: [0; 2],
@@ -607,27 +1129,35 @@ impl<'d, T: Instance> driver::Driver<'d> for Driver<'d, T> {
 
     fn start(mut self, control_max_packet_size: u16) -> (Self::Bus, Self::ControlPipe) {
         assert!(control_max_packet_size <= 64);
+        let ep_list = self.ep_list;
         let ep0_out_addr = self.alloc_buffer(control_max_packet_size).unwrap();
         let ep0_in_addr = self.alloc_buffer(control_max_packet_size).unwrap();
 
-        // EP0 OUT stays armed at all times (lpc55-hal discipline): the
-        // ip3511-HS needs an active EP0 OUT entry to accept SETUP and OUT
-        // packets on the control pipe. `setup()`/`data_out()` re-arm it after
-        // every consumed packet.
+        // EP0 OUT stays armed at all times (lpc55-hal discipline): the ip3511
+        // needs an active EP0 OUT entry to accept SETUP and OUT packets on the
+        // control pipe. `setup()`/`data_out()` re-arm it after every consumed
+        // packet.
         ep_cmd_write(
+            ep_list,
             0,
             Direction::Out,
             0,
-            CMD_A | nbytes(control_max_packet_size as u32) | addroff(ep0_out_addr),
+            CMD_A | nbytes::<T>(control_max_packet_size as u32) | addroff::<T>(ep0_out_addr),
         );
-        ep_cmd_write(0, Direction::In, 0, addroff(ep0_in_addr));
+        ep_cmd_write(ep_list, 0, Direction::In, 0, addroff::<T>(ep0_in_addr));
 
         trace!("started");
 
         (
             Bus {
                 _phantom: PhantomData,
-                inited: false,
+                _vbus: self._vbus,
+                // Deliberately `false` rather than sampled from the register:
+                // a `false` start is what makes the first `poll()` emit
+                // `PowerDetected` for an already-attached cable.
+                vbus: false,
+                powered: true,
+                ep_list,
                 setup_addr: self.setup_addr,
                 ep0_out_addr,
                 ep0_mps: control_max_packet_size,
@@ -635,6 +1165,7 @@ impl<'d, T: Instance> driver::Driver<'d> for Driver<'d, T> {
             ControlPipe {
                 _phantom: PhantomData,
                 max_packet_size: control_max_packet_size,
+                ep_list,
                 setup_addr: self.setup_addr,
                 ep0_out_addr,
                 ep0_in_addr,
@@ -646,34 +1177,105 @@ impl<'d, T: Instance> driver::Driver<'d> for Driver<'d, T> {
 /// USB bus.
 pub struct Bus<'d, T: Instance> {
     _phantom: PhantomData<&'d mut T>,
-    inited: bool,
+    _vbus: Option<Peri<'d, crate::gpio::AnyPin>>,
+    vbus: bool,
+    powered: bool,
+    ep_list: u32,
     setup_addr: u32,
     ep0_out_addr: u32,
     ep0_mps: u16,
 }
 
+impl<'d, T: Instance> Bus<'d, T> {
+    /// Re-apply the controller programming `Driver::new_inner` does, after a
+    /// `power_up` that reset the block.
+    fn reinit(&mut self) {
+        program_controller::<T>(self.ep_list);
+        self.reset_endpoints();
+    }
+
+    /// Disable all data endpoints, reset the double-buffer bookkeeping and
+    /// re-arm EP0. Shared by the bus-reset path and `reinit`.
+    fn reset_endpoints(&mut self) {
+        let regs = T::regs();
+        let state = T::state();
+
+        for i in 1..T::EP_COUNT {
+            for slot in 0..2 {
+                ep_cmd_write(self.ep_list, i, Direction::Out, slot, CMD_D);
+                ep_cmd_write(self.ep_list, i, Direction::In, slot, CMD_D);
+            }
+            // Keep ISO: it describes the endpoint, not its transfer state.
+            for dir in [Direction::Out, Direction::In] {
+                let s = state.ep_state(i, dir);
+                s.store(s.load(Ordering::Relaxed) & ISO, Ordering::Relaxed);
+            }
+        }
+        regs.epinuse().write(|w| w.set_buf(0));
+        regs.epbufcfg().write(|w| w.set_buf_sb(ep_buf_mask::<T>()));
+
+        // EP0 OUT stays armed at all times; keep the SETUP pointer.
+        ep_cmd_write(
+            self.ep_list,
+            0,
+            Direction::Out,
+            0,
+            CMD_A | nbytes::<T>(self.ep0_mps as u32) | addroff::<T>(self.ep0_out_addr),
+        );
+        ep_cmd_write(self.ep_list, 0, Direction::In, 0, 0);
+        unsafe {
+            ep_cmd_ptr(self.ep_list, 0, Direction::Out, true).write_volatile(addroff::<T>(self.setup_addr));
+        }
+
+        // Unstick any pending endpoint futures; they will observe the
+        // disabled/reset state.
+        for w in &state.ep_in_wakers {
+            w.wake();
+        }
+        for w in &state.ep_out_wakers {
+            w.wake();
+        }
+    }
+}
+
 impl<'d, T: Instance> driver::Bus for Bus<'d, T> {
     async fn enable(&mut self) {
+        if !self.powered {
+            T::power_up();
+            self.reinit();
+            self.powered = true;
+        }
         // Soft-connect.
         devcmdstat_modify(T::regs(), |w| w.set_dcon(true));
     }
 
     async fn disable(&mut self) {
         devcmdstat_modify(T::regs(), |w| w.set_dcon(false));
+        devcmdstat_modify(T::regs(), |w| w.set_dev_en(false));
+        T::power_down();
+        self.powered = false;
     }
 
     async fn poll(&mut self) -> Event {
         poll_fn(move |cx| {
-            BUS_WAKER.register(cx.waker());
-
-            // No VBUS monitoring: report power immediately, once.
-            if !self.inited {
-                self.inited = true;
-                return Poll::Ready(Event::PowerDetected);
-            }
+            T::state().bus_waker.register(cx.waker());
 
             let regs = T::regs();
             let dcs = regs.devcmdstat().read();
+
+            // VBUS level changes are reported before anything else: a lost
+            // cable invalidates every other event.
+            let vbus = dcs.vbus_debounced();
+            if vbus != self.vbus {
+                self.vbus = vbus;
+                let event = if vbus {
+                    Event::PowerDetected
+                } else {
+                    Event::PowerRemoved
+                };
+                trace!("{}", event);
+                return Poll::Ready(event);
+            }
 
             if dcs.dres_c() {
                 devcmdstat_modify(regs, |w| {
@@ -681,36 +1283,7 @@ impl<'d, T: Instance> driver::Bus for Bus<'d, T> {
                     w.set_dev_addr(0);
                 });
 
-                // Disable all non-control endpoints (both buffer slots) and
-                // reset the double-buffer bookkeeping; re-arm EP0 (EP0 OUT
-                // stays armed at all times) and keep the SETUP pointer.
-                for i in 1..EP_COUNT {
-                    for slot in 0..2 {
-                        ep_cmd_write(i, Direction::Out, slot, CMD_D);
-                        ep_cmd_write(i, Direction::In, slot, CMD_D);
-                    }
-                    EP_OUT_STATE[i].store(0, Ordering::Relaxed);
-                    EP_IN_STATE[i].store(0, Ordering::Relaxed);
-                }
-                regs.epinuse().write(|w| w.set_buf(0));
-                regs.epbufcfg().write(|w| w.set_buf_sb(0x3FF));
-                ep_cmd_write(
-                    0,
-                    Direction::Out,
-                    0,
-                    CMD_A | nbytes(self.ep0_mps as u32) | addroff(self.ep0_out_addr),
-                );
-                ep_cmd_write(0, Direction::In, 0, 0);
-                unsafe { ep_cmd_ptr(0, Direction::Out, true).write_volatile(addroff(self.setup_addr)) };
-
-                // Unstick any pending endpoint futures; they will observe the
-                // disabled/reset state.
-                for w in &EP_IN_WAKERS {
-                    w.wake();
-                }
-                for w in &EP_OUT_WAKERS {
-                    w.wake();
-                }
+                self.reset_endpoints();
 
                 trace!("RESET");
                 return Poll::Ready(Event::Reset);
@@ -724,7 +1297,10 @@ impl<'d, T: Instance> driver::Bus for Bus<'d, T> {
             }
 
             if dcs.dcon_c() {
-                // No VBUS wired-status semantics needed; just acknowledge.
+                // Acknowledge only. Hardware gates the D+ pull-up on
+                // VBUS_DEBOUNCED, so a VBUS change forces a connect-state
+                // change: this is the wake that carries it, and the level was
+                // already picked up above.
                 devcmdstat_modify(regs, |w| w.set_dcon_c(true));
             }
 
@@ -740,32 +1316,27 @@ impl<'d, T: Instance> driver::Bus for Bus<'d, T> {
             return;
         }
         let dir = ep_addr.direction();
-        let state = match dir {
-            Direction::Out => &EP_OUT_STATE[index],
-            Direction::In => &EP_IN_STATE[index],
-        };
+        let state = T::state().ep_state(index, dir);
+        let iso = state.load(Ordering::Relaxed) & ISO;
 
         if enabled {
             // Both slots idle (NAK until armed). Hardware must restart on
             // slot 0 to match the software cursor, and the data toggle is
             // reset on the first armed transfer (TR_PENDING).
-            ep_cmd_write(index, dir, 0, 0);
-            ep_cmd_write(index, dir, 1, 0);
+            ep_cmd_write(self.ep_list, index, dir, 0, 0);
+            ep_cmd_write(self.ep_list, index, dir, 1, 0);
             let phy_ep = 2 * index + (dir == Direction::In) as usize;
             T::regs()
                 .epinuse()
                 .modify(|w| w.set_buf(w.buf() & !(1 << (phy_ep - 2))));
-            state.store(TR_PENDING, Ordering::Relaxed);
+            state.store(iso | TR_PENDING, Ordering::Relaxed);
         } else {
-            ep_cmd_write(index, dir, 0, CMD_D);
-            ep_cmd_write(index, dir, 1, CMD_D);
-            state.store(0, Ordering::Relaxed);
+            ep_cmd_write(self.ep_list, index, dir, 0, CMD_D);
+            ep_cmd_write(self.ep_list, index, dir, 1, CMD_D);
+            state.store(iso, Ordering::Relaxed);
         }
 
-        match dir {
-            Direction::Out => EP_OUT_WAKERS[index].wake(),
-            Direction::In => EP_IN_WAKERS[index].wake(),
-        }
+        T::state().ep_waker(index, dir).wake();
     }
 
     fn endpoint_set_stalled(&mut self, ep_addr: EndpointAddress, stalled: bool) {
@@ -776,10 +1347,13 @@ impl<'d, T: Instance> driver::Bus for Bus<'d, T> {
         let phy_ep = 2 * index + (dir == Direction::In) as usize;
         // EP0's second OUT slot is the SETUP pointer: never touch it.
         let slots = if index == 0 { 0..1 } else { 0..2 };
+        // Isochronous endpoints have no handshake phase, so the S bit is
+        // meaningless for them: reclaim and resync, but never stall.
+        let iso = index != 0 && T::state().ep_state(index, dir).load(Ordering::Relaxed) & ISO != 0;
 
         if stalled {
             for slot in slots.clone() {
-                if ep_cmd_read(index, dir, slot) & CMD_A != 0 {
+                if ep_cmd_read(self.ep_list, index, dir, slot) & CMD_A != 0 {
                     // Reclaim the in-flight transfer via EPSKIP (skips the
                     // slot EPINUSE points at).
                     regs.epskip().write_value(pac::usbhsd::regs::Epskip(1 << phy_ep));
@@ -787,38 +1361,48 @@ impl<'d, T: Instance> driver::Bus for Bus<'d, T> {
                     regs.intstat().write_value(pac::usbhsd::regs::Intstat(1 << phy_ep));
                 }
             }
-            for slot in slots {
-                ep_cmd_modify(index, dir, slot, |w| (w & !CMD_A) | CMD_S);
+            if !iso {
+                for slot in slots {
+                    ep_cmd_modify(self.ep_list, index, dir, slot, |w| (w & !CMD_A) | CMD_S);
+                }
             }
         } else if index == 0 {
             // Clearing a stall resets the data toggle to DATA0.
-            ep_cmd_modify(index, dir, 0, |w| (w & !CMD_S) | CMD_TR);
+            ep_cmd_modify(self.ep_list, index, dir, 0, |w| (w & !CMD_S) | CMD_TR);
         } else {
             // Drop any buffered packets, resync the hardware slot cursor and
             // defer the toggle reset to the next armed transfer.
             for slot in slots {
-                ep_cmd_modify(index, dir, slot, |w| w & !(CMD_S | CMD_A));
+                ep_cmd_modify(self.ep_list, index, dir, slot, |w| w & !(CMD_S | CMD_A));
             }
             regs.epinuse().modify(|w| w.set_buf(w.buf() & !(1 << (phy_ep - 2))));
-            let state = match dir {
-                Direction::Out => &EP_OUT_STATE[index],
-                Direction::In => &EP_IN_STATE[index],
-            };
-            state.store(TR_PENDING, Ordering::Relaxed);
+            let state = T::state().ep_state(index, dir);
+            let keep = state.load(Ordering::Relaxed) & ISO;
+            state.store(keep | TR_PENDING, Ordering::Relaxed);
         }
 
-        match dir {
-            Direction::Out => EP_OUT_WAKERS[index].wake(),
-            Direction::In => EP_IN_WAKERS[index].wake(),
-        }
+        T::state().ep_waker(index, dir).wake();
     }
 
     fn endpoint_is_stalled(&mut self, ep_addr: EndpointAddress) -> bool {
-        ep_cmd_read(ep_addr.index(), ep_addr.direction(), 0) & CMD_S != 0
+        // Isochronous endpoints are never stalled, and `endpoint_set_stalled`
+        // never sets CMD_S on them, so this reports `false` for them.
+        ep_cmd_read(self.ep_list, ep_addr.index(), ep_addr.direction(), 0) & CMD_S != 0
     }
 
     async fn remote_wakeup(&mut self) -> Result<(), Unsupported> {
         devcmdstat_modify(T::regs(), |w| w.set_dsus(false));
+        Ok(())
+    }
+
+    fn force_reset(&mut self) -> Result<(), Unsupported> {
+        devcmdstat_modify(T::regs(), |w| w.set_dcon(false));
+        // The host needs >= 10 us of SE0 to see a disconnect. This is a
+        // blocking trait method, so busy-wait: 10M cycles is 33-104 ms across
+        // the supported main clocks (300 MHz down to 96 MHz) - generous, but
+        // this path runs at most once per host-visible reconnect.
+        cortex_m::asm::delay(10_000_000);
+        devcmdstat_modify(T::regs(), |w| w.set_dcon(true));
         Ok(())
     }
 }
@@ -827,12 +1411,19 @@ impl<'d, T: Instance> driver::Bus for Bus<'d, T> {
 pub struct Endpoint<'d, T: Instance, D> {
     _phantom: PhantomData<(&'d mut T, D)>,
     info: EndpointInfo,
+    ep_list: u32,
     buf_addrs: [u32; 2],
-    /// Per-slot buffer capacity (multi-packet for HS bulk endpoints).
+    /// Per-slot buffer capacity (multi-packet for bulk endpoints).
     slot_len: u16,
     /// Length each OUT slot was last armed with; needed to compute the
     /// received count from the NBytes-remaining field on completion.
     armed_len: [u16; 2],
+}
+
+impl<'d, T: Instance, D: Dir> Endpoint<'d, T, D> {
+    fn is_iso(&self) -> bool {
+        self.info.ep_type == EndpointType::Isochronous
+    }
 }
 
 impl<'d, T: Instance, D: Dir> driver::Endpoint for Endpoint<'d, T, D> {
@@ -842,13 +1433,9 @@ impl<'d, T: Instance, D: Dir> driver::Endpoint for Endpoint<'d, T, D> {
 
     async fn wait_enabled(&mut self) {
         let index = self.info.addr.index();
-        let wakers = match D::dir() {
-            Direction::Out => &EP_OUT_WAKERS,
-            Direction::In => &EP_IN_WAKERS,
-        };
         poll_fn(|cx| {
-            wakers[index].register(cx.waker());
-            if ep_cmd_read(index, D::dir(), 0) & CMD_D == 0 {
+            T::state().ep_waker(index, D::dir()).register(cx.waker());
+            if ep_cmd_read(self.ep_list, index, D::dir(), 0) & CMD_D == 0 {
                 Poll::Ready(())
             } else {
                 Poll::Pending
@@ -860,38 +1447,39 @@ impl<'d, T: Instance, D: Dir> driver::Endpoint for Endpoint<'d, T, D> {
 }
 
 impl<'d, T: Instance> driver::EndpointOut for Endpoint<'d, T, Out> {
+    /// Receives exactly one packet, per the trait contract.
+    ///
+    /// Slots are always armed for a single max-packet-size packet. Arming a
+    /// multi-packet window would let hardware coalesce packets into one command
+    /// entry - roughly twice the OUT rate - but the window length is committed
+    /// when a slot is armed, one packet ahead of the caller, while the room left
+    /// in the caller's buffer is only known when that slot is drained. Any
+    /// mismatch overflows, so the fast path is not expressible without an
+    /// internal holding buffer. `read_transfer` therefore keeps the trait's
+    /// per-packet default.
     async fn read(&mut self, buf: &mut [u8]) -> Result<usize, EndpointError> {
         let index = self.info.addr.index();
-        let mps = self.info.max_packet_size as u32;
-        let state = &EP_OUT_STATE[index];
-
-        // Receive window per slot: a single packet by default, or a
-        // multi-packet window (hardware packetizes one command entry) when
-        // the caller's buffer spans several packets. A window completes when
-        // it fills or a short packet arrives, so callers using large buffers
-        // must expect coalescing without intermediate packet boundaries.
-        let arm_len = if buf.len() as u32 > mps {
-            (buf.len() as u32).min(self.slot_len as u32) / mps * mps
-        } else {
-            mps
-        };
-
+        let arm_len = self.info.max_packet_size as u32;
+        let state = T::state().ep_state(index, Direction::Out);
+        let iso = self.is_iso();
         // Keep both slots armed so the endpoint does not NAK between packets
         // while the host streams. A slot with PRIMED set and Active clear
         // holds a received, not-yet-consumed packet.
         let mut s = state.load(Ordering::Relaxed);
         for slot in 0..2 {
             if s & (PRIMED0 << slot) == 0 {
-                if ep_cmd_read(index, Direction::Out, slot) & CMD_D != 0 {
+                if ep_cmd_read(self.ep_list, index, Direction::Out, slot) & CMD_D != 0 {
                     return Err(EndpointError::Disabled);
                 }
-                ep_arm_slot(
+                ep_arm_slot::<T>(
+                    self.ep_list,
                     index,
                     Direction::Out,
                     slot,
                     arm_len,
                     self.buf_addrs[slot],
                     s & TR_PENDING != 0,
+                    iso,
                 );
                 self.armed_len[slot] = arm_len as u16;
                 s = (s | (PRIMED0 << slot)) & !TR_PENDING;
@@ -902,8 +1490,8 @@ impl<'d, T: Instance> driver::EndpointOut for Endpoint<'d, T, Out> {
         // Consume in hardware ping-pong order.
         let slot = (s & SLOT) as usize;
         let word = poll_fn(|cx| {
-            EP_OUT_WAKERS[index].register(cx.waker());
-            let word = ep_cmd_read(index, Direction::Out, slot);
+            T::state().ep_out_wakers[index].register(cx.waker());
+            let word = ep_cmd_read(self.ep_list, index, Direction::Out, slot);
             if word & CMD_D != 0 {
                 // Disabled by a bus reset while waiting.
                 return Poll::Ready(Err(EndpointError::Disabled));
@@ -920,15 +1508,28 @@ impl<'d, T: Instance> driver::EndpointOut for Endpoint<'d, T, Out> {
         })
         .await?;
 
-        let rx_len = (self.armed_len[slot] as u32 - remaining_bytes(word)) as usize;
+        // A dropped or errored isochronous packet completes the entry with
+        // NBytes untouched, which this arithmetic turns into `Ok(0)`. That is
+        // the correct report for isochronous: there is no retry, and the
+        // caller sees a lost frame rather than an error. Do not "fix" it.
+        let rx_len = (self.armed_len[slot] as u32 - remaining_bytes::<T>(word)) as usize;
         if rx_len > buf.len() {
             return Err(EndpointError::BufferOverflow);
         }
-        copy_from_usb_sram(self.buf_addrs[slot], &mut buf[..rx_len]);
+        copy_from_ep_buffer(self.buf_addrs[slot], &mut buf[..rx_len]);
 
         // Hand the drained slot straight back to hardware and advance the
         // consume cursor.
-        ep_arm_slot(index, Direction::Out, slot, arm_len, self.buf_addrs[slot], false);
+        ep_arm_slot::<T>(
+            self.ep_list,
+            index,
+            Direction::Out,
+            slot,
+            arm_len,
+            self.buf_addrs[slot],
+            false,
+            iso,
+        );
         self.armed_len[slot] = arm_len as u16;
         state.store((s ^ SLOT) | (PRIMED0 << slot), Ordering::Relaxed);
 
@@ -938,15 +1539,21 @@ impl<'d, T: Instance> driver::EndpointOut for Endpoint<'d, T, Out> {
 }
 
 impl<'d, T: Instance> driver::EndpointIn for Endpoint<'d, T, In> {
+    /// Sends `buf` as one endpoint command entry.
+    ///
+    /// Beyond the trait's single-packet contract this accepts up to the
+    /// endpoint's slot capacity, which hardware then packetizes on its own
+    /// where [`Instance::MULTI_PACKET`] holds. Code relying on that is not
+    /// portable to drivers without it; [`driver::EndpointIn::write_transfer`]
+    /// is, and is just as fast here.
     async fn write(&mut self, buf: &[u8]) -> Result<(), EndpointError> {
-        // Multi-packet: one command entry sends ceil(len / mps) packets
-        // without CPU involvement; the slot capacity is the only limit.
         if buf.len() > self.slot_len as usize {
             return Err(EndpointError::BufferOverflow);
         }
 
         let index = self.info.addr.index();
-        let state = &EP_IN_STATE[index];
+        let state = T::state().ep_state(index, Direction::In);
+        let iso = self.is_iso();
 
         // Fill slots in hardware ping-pong order, returning as soon as the
         // packet is armed: the wire transmits from one slot while software
@@ -957,8 +1564,8 @@ impl<'d, T: Instance> driver::EndpointIn for Endpoint<'d, T, In> {
             let slot = (s & SLOT) as usize;
 
             poll_fn(|cx| {
-                EP_IN_WAKERS[index].register(cx.waker());
-                let word = ep_cmd_read(index, Direction::In, slot);
+                T::state().ep_in_wakers[index].register(cx.waker());
+                let word = ep_cmd_read(self.ep_list, index, Direction::In, slot);
                 if word & CMD_D != 0 {
                     return Poll::Ready(Err(EndpointError::Disabled));
                 }
@@ -977,14 +1584,16 @@ impl<'d, T: Instance> driver::EndpointIn for Endpoint<'d, T, In> {
                 continue;
             }
 
-            copy_to_usb_sram(self.buf_addrs[slot], buf);
-            ep_arm_slot(
+            copy_to_ep_buffer(self.buf_addrs[slot], buf);
+            ep_arm_slot::<T>(
+                self.ep_list,
                 index,
                 Direction::In,
                 slot,
                 buf.len() as u32,
                 self.buf_addrs[slot],
                 s & TR_PENDING != 0,
+                iso,
             );
             state.store((s ^ SLOT) & !TR_PENDING, Ordering::Relaxed);
 
@@ -992,12 +1601,31 @@ impl<'d, T: Instance> driver::EndpointIn for Endpoint<'d, T, In> {
             return Ok(());
         }
     }
+
+    /// Sends all of `buf`, then a zero-length packet if the transfer needs one
+    /// to terminate.
+    ///
+    /// Chunks by slot capacity rather than by max packet size, so hardware
+    /// packetizes each chunk instead of taking one interrupt per packet.
+    async fn write_transfer(&mut self, buf: &[u8], needs_zlp: bool) -> Result<(), EndpointError> {
+        let chunk_len = self.slot_len as usize;
+        for chunk in buf.chunks(chunk_len) {
+            self.write(chunk).await?;
+        }
+        // A transfer ending on a max-packet-size boundary is only complete once
+        // a short packet follows it; any other length already ended on one.
+        if needs_zlp && buf.len() % self.info.max_packet_size as usize == 0 {
+            self.write(&[]).await?;
+        }
+        Ok(())
+    }
 }
 
 /// USB control pipe (endpoint 0, both directions).
 pub struct ControlPipe<'d, T: Instance> {
     _phantom: PhantomData<&'d mut T>,
     max_packet_size: u16,
+    ep_list: u32,
     setup_addr: u32,
     ep0_out_addr: u32,
     ep0_in_addr: u32,
@@ -1012,7 +1640,7 @@ impl<'d, T: Instance> driver::ControlPipe for ControlPipe<'d, T> {
         let regs = T::regs();
 
         poll_fn(|cx| {
-            EP_OUT_WAKERS[0].register(cx.waker());
+            T::state().ep_out_wakers[0].register(cx.waker());
             if regs.devcmdstat().read().setup() {
                 Poll::Ready(())
             } else {
@@ -1023,22 +1651,25 @@ impl<'d, T: Instance> driver::ControlPipe for ControlPipe<'d, T> {
 
         // UM procedure: clear Active and Stall on both EP0 directions BEFORE
         // acknowledging the SETUP bit.
-        ep_cmd_modify(0, Direction::Out, 0, |w| w & !(CMD_A | CMD_S));
-        ep_cmd_modify(0, Direction::In, 0, |w| w & !(CMD_A | CMD_S));
+        ep_cmd_modify(self.ep_list, 0, Direction::Out, 0, |w| w & !(CMD_A | CMD_S));
+        ep_cmd_modify(self.ep_list, 0, Direction::In, 0, |w| w & !(CMD_A | CMD_S));
 
         let mut buf = [0; 8];
-        copy_from_usb_sram(self.setup_addr, &mut buf);
+        copy_from_ep_buffer(self.setup_addr, &mut buf);
 
         devcmdstat_modify(regs, |w| w.set_setup(true));
 
         // Hardware may overwrite the SETUP slot's address field: re-write it,
         // and re-arm EP0 OUT for the next packet.
-        unsafe { ep_cmd_ptr(0, Direction::Out, true).write_volatile(addroff(self.setup_addr)) };
+        unsafe {
+            ep_cmd_ptr(self.ep_list, 0, Direction::Out, true).write_volatile(addroff::<T>(self.setup_addr));
+        }
         ep_cmd_write(
+            self.ep_list,
             0,
             Direction::Out,
             0,
-            CMD_A | nbytes(self.max_packet_size as u32) | addroff(self.ep0_out_addr),
+            CMD_A | nbytes::<T>(self.max_packet_size as u32) | addroff::<T>(self.ep0_out_addr),
         );
 
         trace!("SETUP {=[u8]:x}", buf);
@@ -1053,12 +1684,12 @@ impl<'d, T: Instance> driver::ControlPipe for ControlPipe<'d, T> {
         // `data_out()`); just wait for the packet.
 
         let word = poll_fn(|cx| {
-            EP_OUT_WAKERS[0].register(cx.waker());
+            T::state().ep_out_wakers[0].register(cx.waker());
             // A new SETUP aborts the transfer (trait contract).
             if regs.devcmdstat().read().setup() {
                 return Poll::Ready(Err(EndpointError::Disabled));
             }
-            let word = ep_cmd_read(0, Direction::Out, 0);
+            let word = ep_cmd_read(self.ep_list, 0, Direction::Out, 0);
             if word & CMD_A == 0 {
                 Poll::Ready(Ok(word))
             } else {
@@ -1067,14 +1698,20 @@ impl<'d, T: Instance> driver::ControlPipe for ControlPipe<'d, T> {
         })
         .await?;
 
-        let rx_len = (mps - remaining_bytes(word)) as usize;
+        let rx_len = (mps - remaining_bytes::<T>(word)) as usize;
         if rx_len > buf.len() {
             return Err(EndpointError::BufferOverflow);
         }
-        copy_from_usb_sram(self.ep0_out_addr, &mut buf[..rx_len]);
+        copy_from_ep_buffer(self.ep0_out_addr, &mut buf[..rx_len]);
 
         // Re-arm for the next OUT packet (or the status stage).
-        ep_cmd_write(0, Direction::Out, 0, CMD_A | nbytes(mps) | addroff(self.ep0_out_addr));
+        ep_cmd_write(
+            self.ep_list,
+            0,
+            Direction::Out,
+            0,
+            CMD_A | nbytes::<T>(mps) | addroff::<T>(self.ep0_out_addr),
+        );
 
         trace!("control: data_out rx_len = {}", rx_len);
         Ok(rx_len)
@@ -1091,20 +1728,21 @@ impl<'d, T: Instance> driver::ControlPipe for ControlPipe<'d, T> {
             return Err(EndpointError::Disabled);
         }
 
-        copy_to_usb_sram(self.ep0_in_addr, data);
+        copy_to_ep_buffer(self.ep0_in_addr, data);
         ep_cmd_write(
+            self.ep_list,
             0,
             Direction::In,
             0,
-            CMD_A | nbytes(data.len() as u32) | addroff(self.ep0_in_addr),
+            CMD_A | nbytes::<T>(data.len() as u32) | addroff::<T>(self.ep0_in_addr),
         );
 
         poll_fn(|cx| {
-            EP_IN_WAKERS[0].register(cx.waker());
+            T::state().ep_in_wakers[0].register(cx.waker());
             if regs.devcmdstat().read().setup() {
                 return Poll::Ready(Err(EndpointError::Disabled));
             }
-            if ep_cmd_read(0, Direction::In, 0) & CMD_A == 0 {
+            if ep_cmd_read(self.ep_list, 0, Direction::In, 0) & CMD_A == 0 {
                 Poll::Ready(Ok(()))
             } else {
                 Poll::Pending
@@ -1123,15 +1761,21 @@ impl<'d, T: Instance> driver::ControlPipe for ControlPipe<'d, T> {
         trace!("control: accept");
 
         // Zero-length status-stage IN packet.
-        ep_cmd_write(0, Direction::In, 0, CMD_A | addroff(self.ep0_in_addr));
+        ep_cmd_write(
+            self.ep_list,
+            0,
+            Direction::In,
+            0,
+            CMD_A | addroff::<T>(self.ep0_in_addr),
+        );
 
         poll_fn(|cx| {
-            EP_IN_WAKERS[0].register(cx.waker());
+            T::state().ep_in_wakers[0].register(cx.waker());
             // Bail out if the host abandoned the request with a new SETUP.
             if T::regs().devcmdstat().read().setup() {
                 return Poll::Ready(());
             }
-            if ep_cmd_read(0, Direction::In, 0) & CMD_A == 0 {
+            if ep_cmd_read(self.ep_list, 0, Direction::In, 0) & CMD_A == 0 {
                 Poll::Ready(())
             } else {
                 Poll::Pending
@@ -1144,8 +1788,8 @@ impl<'d, T: Instance> driver::ControlPipe for ControlPipe<'d, T> {
         trace!("control: reject");
         // Stall both EP0 directions; `setup()` clears the stalls on the next
         // SETUP packet.
-        ep_cmd_modify(0, Direction::Out, 0, |w| w | CMD_S);
-        ep_cmd_modify(0, Direction::In, 0, |w| w | CMD_S);
+        ep_cmd_modify(self.ep_list, 0, Direction::Out, 0, |w| w | CMD_S);
+        ep_cmd_modify(self.ep_list, 0, Direction::In, 0, |w| w | CMD_S);
     }
 
     async fn accept_set_address(&mut self, addr: u8) {

--- a/embassy-nxp/src/usb/lpc55.rs
+++ b/embassy-nxp/src/usb/lpc55.rs
@@ -8,7 +8,7 @@
 
 use core::future::poll_fn;
 use core::marker::PhantomData;
-use core::sync::atomic::{Ordering, compiler_fence};
+use core::sync::atomic::{AtomicU8, Ordering, compiler_fence};
 use core::task::Poll;
 
 use embassy_hal_internal::{Peri, PeripheralType};
@@ -49,6 +49,17 @@ static BUS_WAKER: AtomicWaker = AtomicWaker::new();
 static EP_IN_WAKERS: [AtomicWaker; EP_COUNT] = [const { AtomicWaker::new() }; EP_COUNT];
 static EP_OUT_WAKERS: [AtomicWaker; EP_COUNT] = [const { AtomicWaker::new() }; EP_COUNT];
 
+// Double-buffer bookkeeping for data endpoints, shared between `Bus`
+// (reset/enable/stall paths) and the endpoint futures. Hardware consumes the
+// two command/status entries of a double-buffered endpoint in strict EPINUSE
+// ping-pong order, so a 1-bit cursor kept in lockstep (resynced to slot 0
+// whenever EPINUSE is cleared) tracks the hardware exactly.
+const SLOT: u8 = 1 << 0; // next slot to arm (IN) / consume (OUT)
+const PRIMED0: u8 = 1 << 1; // OUT slot armed or holding an unread packet (`PRIMED0 << slot`)
+const TR_PENDING: u8 = 1 << 3; // reset the data toggle on the next arm
+static EP_IN_STATE: [AtomicU8; EP_COUNT] = [const { AtomicU8::new(0) }; EP_COUNT];
+static EP_OUT_STATE: [AtomicU8; EP_COUNT] = [const { AtomicU8::new(0) }; EP_COUNT];
+
 fn nbytes(n: u32) -> u32 {
     (n & NBYTES_MASK) << NBYTES_SHIFT
 }
@@ -73,48 +84,78 @@ fn ep_cmd_ptr(index: usize, dir: Direction, buf1: bool) -> *mut u32 {
     (USB_SRAM_ADDR as usize + index * 16 + slot * 4) as *mut u32
 }
 
-fn ep_cmd_read(index: usize, dir: Direction) -> u32 {
-    unsafe { ep_cmd_ptr(index, dir, false).read_volatile() }
+fn ep_cmd_read(index: usize, dir: Direction, slot: usize) -> u32 {
+    unsafe { ep_cmd_ptr(index, dir, slot != 0).read_volatile() }
 }
 
-fn ep_cmd_write(index: usize, dir: Direction, word: u32) {
-    unsafe { ep_cmd_ptr(index, dir, false).write_volatile(word) }
+fn ep_cmd_write(index: usize, dir: Direction, slot: usize, word: u32) {
+    unsafe { ep_cmd_ptr(index, dir, slot != 0).write_volatile(word) }
 }
 
-fn ep_cmd_modify(index: usize, dir: Direction, f: impl FnOnce(u32) -> u32) {
+fn ep_cmd_modify(index: usize, dir: Direction, slot: usize, f: impl FnOnce(u32) -> u32) {
     critical_section::with(|_| {
-        let p = ep_cmd_ptr(index, dir, false);
+        let p = ep_cmd_ptr(index, dir, slot != 0);
         unsafe { p.write_volatile(f(p.read_volatile())) }
     });
 }
 
-/// Arm a data endpoint buffer for transfer, preserving the hardware-owned
-/// data-toggle value (TV, bit 27) and stall bit. A full-word write here would
-/// zero the toggle and the host would silently discard the mismatched packets
-/// (lpc55-hal uses the same read-modify-write discipline).
-fn ep_arm(index: usize, dir: Direction, len: u32, buf_addr: u32) {
-    let old = ep_cmd_read(index, dir);
-    ep_cmd_write(
-        index,
-        dir,
-        (old & (CMD_TV | CMD_S)) | CMD_A | nbytes(len) | addroff(buf_addr),
-    );
+/// Arm one buffer slot of a data endpoint.
+///
+/// The command word is written whole: the HS controller tracks the
+/// bulk/interrupt data toggle internally per endpoint (read-only EPTOGGLE
+/// register), not in the entry's TV bit, which is only consumed together
+/// with TR. `tr` requests that toggle reset; it is set exactly once for the
+/// first transfer after enable/unstall (the NXP SDK's deferred toggle-reset
+/// discipline).
+fn ep_arm_slot(index: usize, dir: Direction, slot: usize, len: u32, buf_addr: u32, tr: bool) {
+    let tr = if tr { CMD_TR } else { 0 };
+    ep_cmd_write(index, dir, slot, CMD_A | nbytes(len) | addroff(buf_addr) | tr);
 }
 
+/// Copy into the dedicated USB SRAM using 32-bit accesses.
+///
+/// The SRAM sits behind the AHB matrix, so each access is a full bus
+/// transaction: byte-wise copies are 4x the transactions and dominate the
+/// per-packet cost at high speed. Endpoint buffers are 64-byte aligned and
+/// rounded up to 64-byte multiples (see `alloc_buffer`), so word-aligned
+/// stores plus a full-word tail never leave the allocation.
 fn copy_to_usb_sram(buf_addr: u32, data: &[u8]) {
+    debug_assert!(buf_addr % 4 == 0);
     compiler_fence(Ordering::SeqCst);
-    let dst = buf_addr as *mut u8;
-    for (i, b) in data.iter().enumerate() {
-        unsafe { dst.add(i).write_volatile(*b) };
+    let mut dst = buf_addr as *mut u32;
+    let mut chunks = data.chunks_exact(4);
+    for c in &mut chunks {
+        unsafe {
+            dst.write_volatile(u32::from_le_bytes(c.try_into().unwrap()));
+            dst = dst.add(1);
+        }
+    }
+    let rem = chunks.remainder();
+    if !rem.is_empty() {
+        let mut tail = [0u8; 4];
+        tail[..rem.len()].copy_from_slice(rem);
+        unsafe { dst.write_volatile(u32::from_le_bytes(tail)) };
     }
     compiler_fence(Ordering::SeqCst);
 }
 
+/// Copy out of the dedicated USB SRAM using 32-bit accesses; see
+/// [`copy_to_usb_sram`] for the alignment/over-read reasoning.
 fn copy_from_usb_sram(buf_addr: u32, data: &mut [u8]) {
+    debug_assert!(buf_addr % 4 == 0);
     compiler_fence(Ordering::SeqCst);
-    let src = buf_addr as *const u8;
-    for (i, b) in data.iter_mut().enumerate() {
-        *b = unsafe { src.add(i).read_volatile() };
+    let mut src = buf_addr as *const u32;
+    let mut chunks = data.chunks_exact_mut(4);
+    for c in &mut chunks {
+        unsafe {
+            c.copy_from_slice(&src.read_volatile().to_le_bytes());
+            src = src.add(1);
+        }
+    }
+    let rem = chunks.into_remainder();
+    if !rem.is_empty() {
+        let tail = unsafe { src.read_volatile() }.to_le_bytes();
+        rem.copy_from_slice(&tail[..rem.len()]);
     }
     compiler_fence(Ordering::SeqCst);
 }
@@ -394,9 +435,11 @@ impl<'d, T: Instance> Driver<'d, T> {
         regs.databufstart().write(|w| w.set_da_buf(USB_SRAM_ADDR));
         regs.epliststart()
             .write_value(pac::usbhsd::regs::Epliststart(USB_SRAM_ADDR));
-        // Single-buffered operation everywhere.
+        // Non-control endpoints run double-buffered: EPBUFCFG has one bit
+        // per physical endpoint (EP0 excluded), and hardware ping-pongs the
+        // two command/status entries via EPINUSE.
         regs.epinuse().write(|w| w.set_buf(0));
-        regs.epbufcfg().write(|w| w.set_buf_sb(0));
+        regs.epbufcfg().write(|w| w.set_buf_sb(0x3FF));
         regs.epskip().write_value(pac::usbhsd::regs::Epskip(0));
 
         // Enable the device controller, but do not connect yet. Preserve the
@@ -477,12 +520,15 @@ impl<'d, T: Instance> Driver<'d, T> {
         };
         used[index] = true;
 
-        let buf_addr = self.alloc_buffer(max_packet_size)?;
+        // Two buffer slots per endpoint (double buffering): software fills or
+        // drains one while the other is on the wire.
+        let buf_addrs = [self.alloc_buffer(max_packet_size)?, self.alloc_buffer(max_packet_size)?];
 
         // Disabled until `endpoint_set_enabled`.
-        ep_cmd_write(index, D::dir(), CMD_D);
+        ep_cmd_write(index, D::dir(), 0, CMD_D);
+        ep_cmd_write(index, D::dir(), 1, CMD_D);
 
-        trace!("  index={} addr={:08x}", index, buf_addr);
+        trace!("  index={} addr={:08x}", index, buf_addrs[0]);
 
         Ok(Endpoint {
             _phantom: PhantomData,
@@ -492,7 +538,7 @@ impl<'d, T: Instance> Driver<'d, T> {
                 max_packet_size,
                 interval_ms,
             },
-            buf_addr,
+            buf_addrs,
         })
     }
 }
@@ -535,9 +581,10 @@ impl<'d, T: Instance> driver::Driver<'d> for Driver<'d, T> {
         ep_cmd_write(
             0,
             Direction::Out,
+            0,
             CMD_A | nbytes(control_max_packet_size as u32) | addroff(ep0_out_addr),
         );
-        ep_cmd_write(0, Direction::In, addroff(ep0_in_addr));
+        ep_cmd_write(0, Direction::In, 0, addroff(ep0_in_addr));
 
         trace!("started");
 
@@ -598,18 +645,26 @@ impl<'d, T: Instance> driver::Bus for Bus<'d, T> {
                     w.set_dev_addr(0);
                 });
 
-                // Disable all non-control endpoints; re-arm EP0 (EP0 OUT
+                // Disable all non-control endpoints (both buffer slots) and
+                // reset the double-buffer bookkeeping; re-arm EP0 (EP0 OUT
                 // stays armed at all times) and keep the SETUP pointer.
                 for i in 1..EP_COUNT {
-                    ep_cmd_write(i, Direction::Out, CMD_D);
-                    ep_cmd_write(i, Direction::In, CMD_D);
+                    for slot in 0..2 {
+                        ep_cmd_write(i, Direction::Out, slot, CMD_D);
+                        ep_cmd_write(i, Direction::In, slot, CMD_D);
+                    }
+                    EP_OUT_STATE[i].store(0, Ordering::Relaxed);
+                    EP_IN_STATE[i].store(0, Ordering::Relaxed);
                 }
+                regs.epinuse().write(|w| w.set_buf(0));
+                regs.epbufcfg().write(|w| w.set_buf_sb(0x3FF));
                 ep_cmd_write(
                     0,
                     Direction::Out,
+                    0,
                     CMD_A | nbytes(self.ep0_mps as u32) | addroff(self.ep0_out_addr),
                 );
-                ep_cmd_write(0, Direction::In, 0);
+                ep_cmd_write(0, Direction::In, 0, 0);
                 unsafe { ep_cmd_ptr(0, Direction::Out, true).write_volatile(addroff(self.setup_addr)) };
 
                 // Unstick any pending endpoint futures; they will observe the
@@ -648,16 +703,30 @@ impl<'d, T: Instance> driver::Bus for Bus<'d, T> {
         if index == 0 {
             return;
         }
+        let dir = ep_addr.direction();
+        let state = match dir {
+            Direction::Out => &EP_OUT_STATE[index],
+            Direction::In => &EP_IN_STATE[index],
+        };
 
         if enabled {
-            // Clear Disabled, reset the data toggle to DATA0. Not Active:
-            // OUT endpoints NAK until a read arms them.
-            ep_cmd_write(index, ep_addr.direction(), CMD_TR);
+            // Both slots idle (NAK until armed). Hardware must restart on
+            // slot 0 to match the software cursor, and the data toggle is
+            // reset on the first armed transfer (TR_PENDING).
+            ep_cmd_write(index, dir, 0, 0);
+            ep_cmd_write(index, dir, 1, 0);
+            let phy_ep = 2 * index + (dir == Direction::In) as usize;
+            T::regs()
+                .epinuse()
+                .modify(|w| w.set_buf(w.buf() & !(1 << (phy_ep - 2))));
+            state.store(TR_PENDING, Ordering::Relaxed);
         } else {
-            ep_cmd_write(index, ep_addr.direction(), CMD_D);
+            ep_cmd_write(index, dir, 0, CMD_D);
+            ep_cmd_write(index, dir, 1, CMD_D);
+            state.store(0, Ordering::Relaxed);
         }
 
-        match ep_addr.direction() {
+        match dir {
             Direction::Out => EP_OUT_WAKERS[index].wake(),
             Direction::In => EP_IN_WAKERS[index].wake(),
         }
@@ -668,19 +737,38 @@ impl<'d, T: Instance> driver::Bus for Bus<'d, T> {
         let index = ep_addr.index();
         let dir = ep_addr.direction();
         let regs = T::regs();
+        let phy_ep = 2 * index + (dir == Direction::In) as usize;
+        // EP0's second OUT slot is the SETUP pointer: never touch it.
+        let slots = if index == 0 { 0..1 } else { 0..2 };
 
         if stalled {
-            if ep_cmd_read(index, dir) & CMD_A != 0 {
-                // Reclaim the active transfer first via EPSKIP.
-                let phy_ep = 2 * index + (dir == Direction::In) as usize;
-                regs.epskip().write_value(pac::usbhsd::regs::Epskip(1 << phy_ep));
-                while regs.epskip().read().0 & (1 << phy_ep) != 0 {}
-                regs.intstat().write_value(pac::usbhsd::regs::Intstat(1 << phy_ep));
+            for slot in slots.clone() {
+                if ep_cmd_read(index, dir, slot) & CMD_A != 0 {
+                    // Reclaim the in-flight transfer via EPSKIP (skips the
+                    // slot EPINUSE points at).
+                    regs.epskip().write_value(pac::usbhsd::regs::Epskip(1 << phy_ep));
+                    while regs.epskip().read().0 & (1 << phy_ep) != 0 {}
+                    regs.intstat().write_value(pac::usbhsd::regs::Intstat(1 << phy_ep));
+                }
             }
-            ep_cmd_modify(index, dir, |w| (w & !CMD_A) | CMD_S);
-        } else {
+            for slot in slots {
+                ep_cmd_modify(index, dir, slot, |w| (w & !CMD_A) | CMD_S);
+            }
+        } else if index == 0 {
             // Clearing a stall resets the data toggle to DATA0.
-            ep_cmd_modify(index, dir, |w| (w & !CMD_S) | CMD_TR);
+            ep_cmd_modify(index, dir, 0, |w| (w & !CMD_S) | CMD_TR);
+        } else {
+            // Drop any buffered packets, resync the hardware slot cursor and
+            // defer the toggle reset to the next armed transfer.
+            for slot in slots {
+                ep_cmd_modify(index, dir, slot, |w| w & !(CMD_S | CMD_A));
+            }
+            regs.epinuse().modify(|w| w.set_buf(w.buf() & !(1 << (phy_ep - 2))));
+            let state = match dir {
+                Direction::Out => &EP_OUT_STATE[index],
+                Direction::In => &EP_IN_STATE[index],
+            };
+            state.store(TR_PENDING, Ordering::Relaxed);
         }
 
         match dir {
@@ -690,7 +778,7 @@ impl<'d, T: Instance> driver::Bus for Bus<'d, T> {
     }
 
     fn endpoint_is_stalled(&mut self, ep_addr: EndpointAddress) -> bool {
-        ep_cmd_read(ep_addr.index(), ep_addr.direction()) & CMD_S != 0
+        ep_cmd_read(ep_addr.index(), ep_addr.direction(), 0) & CMD_S != 0
     }
 
     async fn remote_wakeup(&mut self) -> Result<(), Unsupported> {
@@ -703,7 +791,7 @@ impl<'d, T: Instance> driver::Bus for Bus<'d, T> {
 pub struct Endpoint<'d, T: Instance, D> {
     _phantom: PhantomData<(&'d mut T, D)>,
     info: EndpointInfo,
-    buf_addr: u32,
+    buf_addrs: [u32; 2],
 }
 
 impl<'d, T: Instance, D: Dir> driver::Endpoint for Endpoint<'d, T, D> {
@@ -719,7 +807,7 @@ impl<'d, T: Instance, D: Dir> driver::Endpoint for Endpoint<'d, T, D> {
         };
         poll_fn(|cx| {
             wakers[index].register(cx.waker());
-            if ep_cmd_read(index, D::dir()) & CMD_D == 0 {
+            if ep_cmd_read(index, D::dir(), 0) & CMD_D == 0 {
                 Poll::Ready(())
             } else {
                 Poll::Pending
@@ -734,20 +822,41 @@ impl<'d, T: Instance> driver::EndpointOut for Endpoint<'d, T, Out> {
     async fn read(&mut self, buf: &mut [u8]) -> Result<usize, EndpointError> {
         let index = self.info.addr.index();
         let mps = self.info.max_packet_size as u32;
+        let state = &EP_OUT_STATE[index];
 
-        if ep_cmd_read(index, Direction::Out) & CMD_D != 0 {
-            return Err(EndpointError::Disabled);
+        // Keep both slots armed so the endpoint does not NAK between packets
+        // while the host streams. A slot with PRIMED set and Active clear
+        // holds a received, not-yet-consumed packet.
+        let mut s = state.load(Ordering::Relaxed);
+        for slot in 0..2 {
+            if s & (PRIMED0 << slot) == 0 {
+                if ep_cmd_read(index, Direction::Out, slot) & CMD_D != 0 {
+                    return Err(EndpointError::Disabled);
+                }
+                ep_arm_slot(
+                    index,
+                    Direction::Out,
+                    slot,
+                    mps,
+                    self.buf_addrs[slot],
+                    s & TR_PENDING != 0,
+                );
+                s = (s | (PRIMED0 << slot)) & !TR_PENDING;
+                state.store(s, Ordering::Relaxed);
+            }
         }
 
-        // Arm reception, preserving the data toggle. The endpoint NAKs while
-        // not armed, which is the correct default behavior.
-        ep_arm(index, Direction::Out, mps, self.buf_addr);
-
+        // Consume in hardware ping-pong order.
+        let slot = (s & SLOT) as usize;
         let word = poll_fn(|cx| {
             EP_OUT_WAKERS[index].register(cx.waker());
-            let word = ep_cmd_read(index, Direction::Out);
+            let word = ep_cmd_read(index, Direction::Out, slot);
             if word & CMD_D != 0 {
                 // Disabled by a bus reset while waiting.
+                return Poll::Ready(Err(EndpointError::Disabled));
+            }
+            if state.load(Ordering::Relaxed) & (PRIMED0 << slot) == 0 {
+                // A re-enable or unstall cancelled the armed transfer.
                 return Poll::Ready(Err(EndpointError::Disabled));
             }
             if word & CMD_A == 0 {
@@ -762,7 +871,12 @@ impl<'d, T: Instance> driver::EndpointOut for Endpoint<'d, T, Out> {
         if rx_len > buf.len() {
             return Err(EndpointError::BufferOverflow);
         }
-        copy_from_usb_sram(self.buf_addr, &mut buf[..rx_len]);
+        copy_from_usb_sram(self.buf_addrs[slot], &mut buf[..rx_len]);
+
+        // Hand the drained slot straight back to hardware and advance the
+        // consume cursor.
+        ep_arm_slot(index, Direction::Out, slot, mps, self.buf_addrs[slot], false);
+        state.store((s ^ SLOT) | (PRIMED0 << slot), Ordering::Relaxed);
 
         trace!("READ {:?} rx_len = {}", self.info.addr, rx_len);
         Ok(rx_len)
@@ -776,31 +890,51 @@ impl<'d, T: Instance> driver::EndpointIn for Endpoint<'d, T, In> {
         }
 
         let index = self.info.addr.index();
-        if ep_cmd_read(index, Direction::In) & CMD_D != 0 {
-            return Err(EndpointError::Disabled);
+        let state = &EP_IN_STATE[index];
+
+        // Fill slots in hardware ping-pong order, returning as soon as the
+        // packet is armed: the wire transmits from one slot while software
+        // fills the other, so a saturating writer never lets the endpoint
+        // NAK an IN token.
+        loop {
+            let s = state.load(Ordering::Relaxed);
+            let slot = (s & SLOT) as usize;
+
+            poll_fn(|cx| {
+                EP_IN_WAKERS[index].register(cx.waker());
+                let word = ep_cmd_read(index, Direction::In, slot);
+                if word & CMD_D != 0 {
+                    return Poll::Ready(Err(EndpointError::Disabled));
+                }
+                if word & CMD_A == 0 {
+                    Poll::Ready(Ok(()))
+                } else {
+                    Poll::Pending
+                }
+            })
+            .await?;
+
+            // A reset or re-enable while waiting may have moved the slot
+            // cursor; re-derive and retry if so.
+            let s = state.load(Ordering::Relaxed);
+            if (s & SLOT) as usize != slot {
+                continue;
+            }
+
+            copy_to_usb_sram(self.buf_addrs[slot], buf);
+            ep_arm_slot(
+                index,
+                Direction::In,
+                slot,
+                buf.len() as u32,
+                self.buf_addrs[slot],
+                s & TR_PENDING != 0,
+            );
+            state.store((s ^ SLOT) & !TR_PENDING, Ordering::Relaxed);
+
+            trace!("WRITE {:?} len = {}", self.info.addr, buf.len());
+            return Ok(());
         }
-
-        copy_to_usb_sram(self.buf_addr, buf);
-        // Hardware advances the AddressOffset and NBytes as it transmits:
-        // always re-write those fields, preserving only the data toggle.
-        ep_arm(index, Direction::In, buf.len() as u32, self.buf_addr);
-
-        poll_fn(|cx| {
-            EP_IN_WAKERS[index].register(cx.waker());
-            let word = ep_cmd_read(index, Direction::In);
-            if word & CMD_D != 0 {
-                return Poll::Ready(Err(EndpointError::Disabled));
-            }
-            if word & CMD_A == 0 {
-                Poll::Ready(Ok(()))
-            } else {
-                Poll::Pending
-            }
-        })
-        .await?;
-
-        trace!("WRITE {:?} len = {}", self.info.addr, buf.len());
-        Ok(())
     }
 }
 
@@ -833,8 +967,8 @@ impl<'d, T: Instance> driver::ControlPipe for ControlPipe<'d, T> {
 
         // UM procedure: clear Active and Stall on both EP0 directions BEFORE
         // acknowledging the SETUP bit.
-        ep_cmd_modify(0, Direction::Out, |w| w & !(CMD_A | CMD_S));
-        ep_cmd_modify(0, Direction::In, |w| w & !(CMD_A | CMD_S));
+        ep_cmd_modify(0, Direction::Out, 0, |w| w & !(CMD_A | CMD_S));
+        ep_cmd_modify(0, Direction::In, 0, |w| w & !(CMD_A | CMD_S));
 
         let mut buf = [0; 8];
         copy_from_usb_sram(self.setup_addr, &mut buf);
@@ -847,6 +981,7 @@ impl<'d, T: Instance> driver::ControlPipe for ControlPipe<'d, T> {
         ep_cmd_write(
             0,
             Direction::Out,
+            0,
             CMD_A | nbytes(self.max_packet_size as u32) | addroff(self.ep0_out_addr),
         );
 
@@ -867,7 +1002,7 @@ impl<'d, T: Instance> driver::ControlPipe for ControlPipe<'d, T> {
             if regs.devcmdstat().read().setup() {
                 return Poll::Ready(Err(EndpointError::Disabled));
             }
-            let word = ep_cmd_read(0, Direction::Out);
+            let word = ep_cmd_read(0, Direction::Out, 0);
             if word & CMD_A == 0 {
                 Poll::Ready(Ok(word))
             } else {
@@ -883,7 +1018,7 @@ impl<'d, T: Instance> driver::ControlPipe for ControlPipe<'d, T> {
         copy_from_usb_sram(self.ep0_out_addr, &mut buf[..rx_len]);
 
         // Re-arm for the next OUT packet (or the status stage).
-        ep_cmd_write(0, Direction::Out, CMD_A | nbytes(mps) | addroff(self.ep0_out_addr));
+        ep_cmd_write(0, Direction::Out, 0, CMD_A | nbytes(mps) | addroff(self.ep0_out_addr));
 
         trace!("control: data_out rx_len = {}", rx_len);
         Ok(rx_len)
@@ -904,6 +1039,7 @@ impl<'d, T: Instance> driver::ControlPipe for ControlPipe<'d, T> {
         ep_cmd_write(
             0,
             Direction::In,
+            0,
             CMD_A | nbytes(data.len() as u32) | addroff(self.ep0_in_addr),
         );
 
@@ -912,7 +1048,7 @@ impl<'d, T: Instance> driver::ControlPipe for ControlPipe<'d, T> {
             if regs.devcmdstat().read().setup() {
                 return Poll::Ready(Err(EndpointError::Disabled));
             }
-            if ep_cmd_read(0, Direction::In) & CMD_A == 0 {
+            if ep_cmd_read(0, Direction::In, 0) & CMD_A == 0 {
                 Poll::Ready(Ok(()))
             } else {
                 Poll::Pending
@@ -931,7 +1067,7 @@ impl<'d, T: Instance> driver::ControlPipe for ControlPipe<'d, T> {
         trace!("control: accept");
 
         // Zero-length status-stage IN packet.
-        ep_cmd_write(0, Direction::In, CMD_A | addroff(self.ep0_in_addr));
+        ep_cmd_write(0, Direction::In, 0, CMD_A | addroff(self.ep0_in_addr));
 
         poll_fn(|cx| {
             EP_IN_WAKERS[0].register(cx.waker());
@@ -939,7 +1075,7 @@ impl<'d, T: Instance> driver::ControlPipe for ControlPipe<'d, T> {
             if T::regs().devcmdstat().read().setup() {
                 return Poll::Ready(());
             }
-            if ep_cmd_read(0, Direction::In) & CMD_A == 0 {
+            if ep_cmd_read(0, Direction::In, 0) & CMD_A == 0 {
                 Poll::Ready(())
             } else {
                 Poll::Pending
@@ -952,8 +1088,8 @@ impl<'d, T: Instance> driver::ControlPipe for ControlPipe<'d, T> {
         trace!("control: reject");
         // Stall both EP0 directions; `setup()` clears the stalls on the next
         // SETUP packet.
-        ep_cmd_modify(0, Direction::Out, |w| w | CMD_S);
-        ep_cmd_modify(0, Direction::In, |w| w | CMD_S);
+        ep_cmd_modify(0, Direction::Out, 0, |w| w | CMD_S);
+        ep_cmd_modify(0, Direction::In, 0, |w| w | CMD_S);
     }
 
     async fn accept_set_address(&mut self, addr: u8) {

--- a/examples/lpc55s69/Cargo.toml
+++ b/examples/lpc55s69/Cargo.toml
@@ -11,6 +11,8 @@ embassy-nxp = { version = "0.1.0", path = "../../embassy-nxp", features = ["lpc5
 embassy-executor = { version = "0.10.0", path = "../../embassy-executor", features = ["platform-cortex-m", "executor-thread", "executor-interrupt"] }
 embassy-sync = { version = "0.8.0", path = "../../embassy-sync", features = ["defmt"] }
 embassy-time = { version = "0.5.1", path = "../../embassy-time", features = ["defmt", "tick-hz-32_768"] }
+embassy-usb = { version = "0.6.0", path = "../../embassy-usb", features = ["defmt"] }
+embassy-futures = { version = "0.1.2", path = "../../embassy-futures" }
 panic-halt = "1.0.0"
 cortex-m = { version = "0.7.6", features = ["inline-asm", "critical-section-single-core"] }
 cortex-m-rt = { version = "0.7.0"}

--- a/examples/lpc55s69/README.md
+++ b/examples/lpc55s69/README.md
@@ -4,6 +4,13 @@
 - blinky_nop: Blink the integrated RED LED using nops as delay. Useful for flashing simple and known-good software on board.
 - button_executor: Turn on/off an LED by pressing the USER button. Demonstrates how to use the PINT and GPIO drivers.
 - blinky_embassy_time: Blink the integrated RED LED using `embassy-time`. Demonstrates how to use the time-driver that uses RTC. 
+- usb_fs_serial / usb_hs_serial / usb_dual: CDC-ACM serial over USB0 (P10), USB1 (P9), or both.
+- usb_fs_throughput / usb_hs_throughput: bulk throughput peers for
+  [`scripts/usb_throughput.py`](scripts/usb_throughput.py). Unlike the serial examples these two
+  advertise WinUSB, so on Windows they appear as a libusb device rather than a COM port and the
+  script drives their endpoints directly; Windows' CDC driver drops packets at the high-speed
+  rate. Linux ignores the descriptors and binds `cdc_acm` as usual. See
+  [`tests/lpc55/README.md`](../../tests/lpc55/README.md) for the measurements.
 
 ## Important Notes
 

--- a/examples/lpc55s69/scripts/usb_throughput.py
+++ b/examples/lpc55s69/scripts/usb_throughput.py
@@ -124,14 +124,32 @@ def main() -> None:
     parser.add_argument(
         "--timeout", type=float, default=5.0, help="serial read timeout in seconds (default 5)"
     )
+    parser.add_argument(
+        "--wait-port",
+        type=float,
+        default=0.0,
+        help="seconds to wait for the port to appear (default 0, one attempt)",
+    )
+    parser.add_argument(
+        "--min-rate",
+        type=float,
+        default=None,
+        help="fail if measured throughput is below this many MB/s (default: no minimum)",
+    )
     args = parser.parse_args()
 
     count = args.bytes
-    try:
-        port = serial.Serial(args.port, timeout=args.timeout, write_timeout=args.timeout)
-    except serial.SerialException as exc:
-        fail(f"cannot open {args.port}: {exc}")
-
+    deadline = time.monotonic() + args.wait_port
+    while True:
+        try:
+            port = serial.Serial(args.port, timeout=args.timeout, write_timeout=args.timeout)
+            break
+        except serial.SerialException as exc:
+            # With the default --wait-port of 0 the deadline has already passed, so this is
+            # a single attempt followed by the original hard failure.
+            if time.monotonic() >= deadline:
+                fail(f"cannot open {args.port}: {exc}")
+            time.sleep(0.25)
     try:
         port.reset_input_buffer()
         port.reset_output_buffer()
@@ -151,6 +169,12 @@ def main() -> None:
     print(f"direction: {args.dir}  bytes: {count}  elapsed: {elapsed:.3f} s")
     print(f"throughput: {mbps_bytes:.3f} MB/s (MB = 1e6 bytes) = {mbits:.3f} Mbps")
 
+    if args.min_rate is not None and mbps_bytes < args.min_rate:
+        print(
+            f"error: throughput {mbps_bytes:.3f} MB/s below minimum {args.min_rate} MB/s",
+            file=sys.stderr,
+        )
+        sys.exit(1)
     if mismatches:
         sys.exit(1)
 

--- a/examples/lpc55s69/scripts/usb_throughput.py
+++ b/examples/lpc55s69/scripts/usb_throughput.py
@@ -1,0 +1,159 @@
+#!/usr/bin/env -S uv run --script
+# /// script
+# requires-python = ">=3.10"
+# dependencies = ["pyserial>=3.5"]
+# ///
+"""Host-side throughput bench for the LPC55 USB CDC-ACM throughput firmware.
+
+Wire protocol (identical on the full-speed and high-speed firmware):
+
+  host -> device: one command byte, then the byte count as little-endian u32.
+
+    b'I' + u32 N   device streams N bytes to the host. Byte k of the stream is
+                   (k % 512), i.e. a repeating 0..511 ramp.
+    b'O' + u32 N   host sends N payload bytes (same ramp); the device consumes
+                   them and replies with exactly 4 bytes, the received count as
+                   little-endian u32.
+
+Build the firmware with `--release`. An unoptimized `dev` build of the driver
+and the `embassy-usb` class layer is CPU-bound at well under 1 MB/s, roughly
+two orders of magnitude below the bus, so a `dev`-profile measurement says
+nothing about the hardware:
+
+    cargo run --release --bin usb_hs_throughput   # then --dir in/out here
+"""
+
+import argparse
+import struct
+import sys
+import time
+from typing import NoReturn
+
+import serial
+
+RAMP_PERIOD = 512
+# Byte k of the stream is `(k % 512) as u8`, so the 512-long ramp is 0..255 twice.
+RAMP = bytes((k % RAMP_PERIOD) & 0xFF for k in range(RAMP_PERIOD))
+CHUNK = 1 << 20
+# Pre-tiled so `ramp_slice` is a slice of a constant rather than a fresh
+# `RAMP * reps` allocation per chunk: at tens of MB/s that allocation shows up
+# in the measurement.
+RAMP_TILED = RAMP * (CHUNK // RAMP_PERIOD + 1)
+
+
+def parse_count(text: str) -> int:
+    value = int(text.replace("_", ""), 0)
+    if value <= 0:
+        raise argparse.ArgumentTypeError("byte count must be positive")
+    return value
+
+
+def ramp_slice(offset: int, length: int) -> bytes:
+    """The `length` payload bytes starting at stream offset `offset`."""
+    start = offset % RAMP_PERIOD
+    return RAMP_TILED[start : start + length]
+
+
+def fail(message: str) -> NoReturn:
+    print(f"error: {message}", file=sys.stderr)
+    sys.exit(1)
+
+
+def run_in(port: serial.Serial, count: int) -> tuple[float, int]:
+    """Device -> host. Returns (elapsed seconds, mismatching byte count)."""
+    port.write(b"I" + struct.pack("<I", count))
+    port.flush()
+
+    start = time.perf_counter()
+    received = 0
+    mismatches = 0
+    while received < count:
+        chunk = port.read(min(CHUNK, count - received))
+        if not chunk:
+            fail(f"timed out after {received} of {count} bytes")
+        expected = ramp_slice(received, len(chunk))
+        # The whole-buffer compare is a C memcmp; only a failing chunk pays for
+        # the per-byte count. Counting unconditionally caps this script at
+        # roughly 30 MB/s and silently understates the device.
+        if chunk != expected:
+            mismatches += sum(1 for a, b in zip(chunk, expected) if a != b)
+        received += len(chunk)
+    elapsed = time.perf_counter() - start
+    return elapsed, mismatches
+
+
+def run_out(port: serial.Serial, count: int) -> float:
+    """Host -> device. Returns elapsed seconds."""
+    port.write(b"O" + struct.pack("<I", count))
+    port.flush()
+
+    start = time.perf_counter()
+    sent = 0
+    while sent < count:
+        chunk = ramp_slice(sent, min(CHUNK, count - sent))
+        written = port.write(chunk)
+        if written is None:
+            written = len(chunk)
+        if written == 0:
+            fail(f"write stalled after {sent} of {count} bytes")
+        sent += written
+    port.flush()
+
+    ack = port.read(4)
+    elapsed = time.perf_counter() - start
+    if len(ack) != 4:
+        fail(f"short acknowledgement: got {len(ack)} of 4 bytes")
+    acked = struct.unpack("<I", ack)[0]
+    if acked != count:
+        fail(f"device acknowledged {acked} bytes, expected {count}")
+    return elapsed
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Measure USB CDC-ACM throughput against the LPC55 throughput firmware."
+    )
+    parser.add_argument("--port", required=True, help="serial device, e.g. /dev/ttyACM0")
+    parser.add_argument(
+        "--bytes",
+        type=parse_count,
+        default=4_000_000,
+        help="payload size in bytes (underscores allowed, default 4_000_000)",
+    )
+    parser.add_argument("--dir", required=True, choices=("in", "out"), help="transfer direction")
+    parser.add_argument(
+        "--timeout", type=float, default=5.0, help="serial read timeout in seconds (default 5)"
+    )
+    args = parser.parse_args()
+
+    count = args.bytes
+    try:
+        port = serial.Serial(args.port, timeout=args.timeout, write_timeout=args.timeout)
+    except serial.SerialException as exc:
+        fail(f"cannot open {args.port}: {exc}")
+
+    try:
+        port.reset_input_buffer()
+        port.reset_output_buffer()
+        if args.dir == "in":
+            elapsed, mismatches = run_in(port, count)
+            print(f"payload mismatches: {mismatches} (0 expected)")
+        else:
+            elapsed = run_out(port, count)
+            mismatches = 0
+    except serial.SerialTimeoutException as exc:
+        fail(f"serial timeout: {exc}")
+    finally:
+        port.close()
+
+    mbps_bytes = count / 1e6 / elapsed
+    mbits = count * 8 / 1e6 / elapsed
+    print(f"direction: {args.dir}  bytes: {count}  elapsed: {elapsed:.3f} s")
+    print(f"throughput: {mbps_bytes:.3f} MB/s (MB = 1e6 bytes) = {mbits:.3f} Mbps")
+
+    if mismatches:
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/lpc55s69/scripts/usb_throughput.py
+++ b/examples/lpc55s69/scripts/usb_throughput.py
@@ -45,6 +45,8 @@ def parse_count(text: str) -> int:
     value = int(text.replace("_", ""), 0)
     if value <= 0:
         raise argparse.ArgumentTypeError("byte count must be positive")
+    if value > 0xFFFF_FFFF:
+        raise argparse.ArgumentTypeError("byte count must fit in u32")
     return value
 
 
@@ -59,12 +61,71 @@ def fail(message: str) -> NoReturn:
     sys.exit(1)
 
 
-def run_in(port: serial.Serial, count: int) -> tuple[float, int]:
-    """Device -> host. Returns (elapsed seconds, mismatching byte count)."""
-    port.write(b"I" + struct.pack("<I", count))
+def read_exact(port: serial.Serial, count: int) -> bytes:
+    data = bytearray()
+    while len(data) < count:
+        chunk = port.read(count - len(data))
+        if not chunk:
+            fail(f"timed out after {len(data)} of {count} bytes")
+        data.extend(chunk)
+    return bytes(data)
+
+
+def write_split(port: serial.Serial, frame: bytes, split_at: int) -> None:
+    port.write(frame[:split_at])
+    port.flush()
+    time.sleep(0.02)
+    port.write(frame[split_at:])
     port.flush()
 
+
+def run_protocol_check(port: serial.Serial) -> None:
+    def expect_ack(expected: int, case: str) -> None:
+        acknowledged = struct.unpack("<I", read_exact(port, 4))[0]
+        if acknowledged != expected:
+            fail(f"{case}: device acknowledged {acknowledged} bytes, expected {expected}")
+
+    for split_at in range(1, 5):
+        in_frame = b"I" + struct.pack("<I", 257)
+        write_split(port, in_frame, split_at)
+        received = read_exact(port, 257)
+        if received != ramp_slice(0, 257):
+            fail(f"IN header split at {split_at}: payload mismatch")
+
+        out_frame = b"O" + struct.pack("<I", 257)
+        write_split(port, out_frame, split_at)
+        port.write(ramp_slice(0, 257))
+        port.flush()
+        expect_ack(257, f"OUT header split at {split_at}")
+
+    port.write(b"O" + struct.pack("<I", 0))
+    port.flush()
+    expect_ack(0, "zero-length OUT")
+
+    port.write(b"X" + struct.pack("<I", 0) + b"I" + struct.pack("<I", 17))
+    port.flush()
+    if read_exact(port, 17) != ramp_slice(0, 17):
+        fail("unknown-command recovery: payload mismatch")
+
+    combined = (
+        b"O" + struct.pack("<I", 3) + ramp_slice(0, 3) + b"I" + struct.pack("<I", 17)
+    )
+    port.write(combined)
+    port.flush()
+    expect_ack(3, "coalesced OUT")
+    if read_exact(port, 17) != ramp_slice(0, 17):
+        fail("coalesced IN: payload mismatch")
+
+    print("protocol stream check passed")
+
+
+def run_in(port: serial.Serial, count: int) -> tuple[float, int]:
+    """Device -> host. Returns (elapsed seconds, mismatching byte count)."""
+    frame = b"I" + struct.pack("<I", count)
     start = time.perf_counter()
+    port.write(frame)
+    port.flush()
+
     received = 0
     mismatches = 0
     while received < count:
@@ -72,11 +133,13 @@ def run_in(port: serial.Serial, count: int) -> tuple[float, int]:
         if not chunk:
             fail(f"timed out after {received} of {count} bytes")
         expected = ramp_slice(received, len(chunk))
-        # The whole-buffer compare is a C memcmp; only a failing chunk pays for
-        # the per-byte count. Counting unconditionally caps this script at
-        # roughly 30 MB/s and silently understates the device.
+        # The whole-buffer compare uses C memcmp. Count bytes only after a mismatch.
         if chunk != expected:
-            mismatches += sum(1 for a, b in zip(chunk, expected) if a != b)
+            mismatches += sum(
+                1
+                for actual, expected_byte in zip(chunk, expected)
+                if actual != expected_byte
+            )
         received += len(chunk)
     elapsed = time.perf_counter() - start
     return elapsed, mismatches
@@ -84,10 +147,11 @@ def run_in(port: serial.Serial, count: int) -> tuple[float, int]:
 
 def run_out(port: serial.Serial, count: int) -> float:
     """Host -> device. Returns elapsed seconds."""
-    port.write(b"O" + struct.pack("<I", count))
+    frame = b"O" + struct.pack("<I", count)
+    start = time.perf_counter()
+    port.write(frame)
     port.flush()
 
-    start = time.perf_counter()
     sent = 0
     while sent < count:
         chunk = ramp_slice(sent, min(CHUNK, count - sent))
@@ -99,13 +163,10 @@ def run_out(port: serial.Serial, count: int) -> float:
         sent += written
     port.flush()
 
-    ack = port.read(4)
+    acknowledged = struct.unpack("<I", read_exact(port, 4))[0]
+    if acknowledged != count:
+        fail(f"device acknowledged {acknowledged} bytes, expected {count}")
     elapsed = time.perf_counter() - start
-    if len(ack) != 4:
-        fail(f"short acknowledgement: got {len(ack)} of 4 bytes")
-    acked = struct.unpack("<I", ack)[0]
-    if acked != count:
-        fail(f"device acknowledged {acked} bytes, expected {count}")
     return elapsed
 
 
@@ -120,7 +181,13 @@ def main() -> None:
         default=4_000_000,
         help="payload size in bytes (underscores allowed, default 4_000_000)",
     )
-    parser.add_argument("--dir", required=True, choices=("in", "out"), help="transfer direction")
+    mode = parser.add_mutually_exclusive_group(required=True)
+    mode.add_argument("--dir", choices=("in", "out"), help="transfer direction")
+    mode.add_argument(
+        "--protocol-check",
+        action="store_true",
+        help="check fragmented and coalesced protocol frames",
+    )
     parser.add_argument(
         "--timeout", type=float, default=5.0, help="serial read timeout in seconds (default 5)"
     )
@@ -153,7 +220,9 @@ def main() -> None:
     try:
         port.reset_input_buffer()
         port.reset_output_buffer()
-        if args.dir == "in":
+        if args.protocol_check:
+            run_protocol_check(port)
+        elif args.dir == "in":
             elapsed, mismatches = run_in(port, count)
             print(f"payload mismatches: {mismatches} (0 expected)")
         else:
@@ -163,6 +232,9 @@ def main() -> None:
         fail(f"serial timeout: {exc}")
     finally:
         port.close()
+
+    if args.protocol_check:
+        return
 
     mbps_bytes = count / 1e6 / elapsed
     mbits = count * 8 / 1e6 / elapsed

--- a/examples/lpc55s69/scripts/usb_throughput.py
+++ b/examples/lpc55s69/scripts/usb_throughput.py
@@ -3,24 +3,22 @@
 # requires-python = ">=3.10"
 # dependencies = ["pyserial>=3.5"]
 # ///
-"""Host-side throughput bench for the LPC55 USB CDC-ACM throughput firmware.
+"""Measure LPC55 USB CDC-ACM throughput.
 
-Wire protocol (identical on the full-speed and high-speed firmware):
+The full-speed and high-speed firmware use the same wire protocol:
 
-  host -> device: one command byte, then the byte count as little-endian u32.
+    host -> device: one command byte, then a little-endian u32 byte count
 
-    b'I' + u32 N   device streams N bytes to the host. Byte k of the stream is
-                   (k % 512), i.e. a repeating 0..511 ramp.
-    b'O' + u32 N   host sends N payload bytes (same ramp); the device consumes
-                   them and replies with exactly 4 bytes, the received count as
-                   little-endian u32.
+    b'I' + u32 N   The device sends N bytes. Byte k is `(k % 512) & 0xff`.
+    b'O' + u32 N   The host sends the same ramp. The device returns the received
+                   byte count as exactly four little-endian bytes.
 
-Build the firmware with `--release`. An unoptimized `dev` build of the driver
-and the `embassy-usb` class layer is CPU-bound at well under 1 MB/s, roughly
-two orders of magnitude below the bus, so a `dev`-profile measurement says
-nothing about the hardware:
+Use a release build:
 
-    cargo run --release --bin usb_hs_throughput   # then --dir in/out here
+    cargo run --release --bin usb_hs_throughput   # then use --dir in/out here
+
+An unoptimized `dev` build makes the driver and `embassy-usb` class layer CPU-bound below
+1 MB/s. This is about two orders of magnitude below the bus rate.
 """
 
 import argparse

--- a/examples/lpc55s69/scripts/usb_throughput.py
+++ b/examples/lpc55s69/scripts/usb_throughput.py
@@ -1,7 +1,11 @@
 #!/usr/bin/env -S uv run --script
 # /// script
 # requires-python = ">=3.10"
-# dependencies = ["pyserial>=3.5"]
+# dependencies = [
+#     "pyserial>=3.5",
+#     "pyusb>=1.3; sys_platform == 'win32'",
+#     "libusb-package>=1.0.26; sys_platform == 'win32'",
+# ]
 # ///
 """Measure LPC55 USB CDC-ACM throughput.
 
@@ -19,15 +23,24 @@ Use a release build:
 
 An unoptimized `dev` build makes the driver and `embassy-usb` class layer CPU-bound below
 1 MB/s. This is about two orders of magnitude below the bus rate.
+
+On Windows the endpoints are driven through libusb rather than the CDC driver; see
+`LibusbPort` for the measurements behind that.
 """
 
 import argparse
+import re
 import struct
 import sys
 import time
 from typing import NoReturn
 
 import serial
+import serial.tools.list_ports
+
+# A `--port` value of this shape selects the CDC node by USB id instead of naming a device: the
+# device names differ per host (`/dev/ttyACM0`, `COM7`) but the ids never do.
+USB_ID = re.compile(r"^([0-9a-fA-F]{4}):([0-9a-fA-F]{4})$")
 
 RAMP_PERIOD = 512
 # Byte k of the stream is `(k % 512) as u8`, so the 512-long ramp is 0..255 twice.
@@ -59,7 +72,136 @@ def fail(message: str) -> NoReturn:
     sys.exit(1)
 
 
-def read_exact(port: serial.Serial, count: int) -> bytes:
+def resolve_port(spec: str) -> str | None:
+    """The device name for `spec`, or None while a `vid:pid` selector has no match."""
+    ids = USB_ID.match(spec)
+    if ids is None:
+        return spec
+    vid, pid = int(ids.group(1), 16), int(ids.group(2), 16)
+    for info in serial.tools.list_ports.comports():
+        if info.vid == vid and info.pid == pid:
+            return info.device
+    return None
+
+
+if sys.platform == "win32":
+    import libusb_package
+    import usb.core
+    import usb.util
+
+    # pyusb maps LIBUSB_ERROR_TIMEOUT onto this, whatever the platform.
+    _ERRNO_TIMEOUT = 110
+    # One bulk request per call; the callers all loop, so a short return is fine.
+    _MAX_REQUEST = 1 << 16
+
+    class LibusbPort:
+        """The peer's CDC data interface, driven through libusb instead of `usbser.sys`.
+
+        Windows' CDC driver cannot carry this benchmark. It discards stream data that
+        arrives while no read request is outstanding, which at the high-speed rate costs
+        whole 512-byte packets - 512 to 4096 bytes per 4 MB, in roughly half of all
+        transfers - through pyserial, through blocking reads on a dedicated thread, and at
+        every read and receive-buffer size tried. Keeping several overlapped requests queued
+        does stop the loss, but then the same transfer runs at 0.78 MB/s instead of 38.
+
+        Reading the endpoints directly avoids all of it: 25 consecutive 4 MB transfers with
+        no loss, at 45 MB/s rather than 38, which also matches the rate Linux measures. It
+        is the device driver under test here, not the host's CDC driver.
+
+        The firmware's MS OS 2.0 descriptors are what let Windows bind WinUSB to the
+        function. Linux ignores them and still binds `cdc_acm`, so pyserial drives this test
+        there and the port stays an ordinary CDC node.
+        """
+
+        def __init__(self, spec: str, timeout: float) -> None:
+            ids = USB_ID.match(spec)
+            if ids is None:
+                raise serial.SerialException(
+                    f"--port must be a vid:pid selector on Windows, not {spec!r}: the throughput "
+                    "firmware binds WinUSB and so has no COM port"
+                )
+            vid, pid = int(ids.group(1), 16), int(ids.group(2), 16)
+            self.name = f"{vid:04x}:{pid:04x}"
+            self._timeout_ms = max(1, int(timeout * 1000))
+            device = usb.core.find(
+                idVendor=vid, idProduct=pid, backend=libusb_package.get_libusb1_backend()
+            )
+            if device is None:
+                raise serial.SerialException(f"no USB device {self.name}")
+            try:
+                device.set_configuration()
+                # The data interface is the one carrying the two bulk endpoints; the
+                # notification interface has a single interrupt IN.
+                interface = next(i for i in device.get_active_configuration() if i.bNumEndpoints == 2)
+                usb.util.claim_interface(device, interface.bInterfaceNumber)
+            except (usb.core.USBError, NotImplementedError, StopIteration) as exc:
+                usb.util.dispose_resources(device)
+                raise serial.SerialException(f"cannot claim {self.name}: {exc}") from exc
+            self._device = device
+            self._interface = interface.bInterfaceNumber
+            self._in = next(e.bEndpointAddress for e in interface if e.bEndpointAddress & 0x80)
+            self._out = next(e.bEndpointAddress for e in interface if not e.bEndpointAddress & 0x80)
+
+        def read(self, size: int) -> bytes:
+            if size <= 0:
+                return b""
+            try:
+                return bytes(self._device.read(self._in, min(size, _MAX_REQUEST), self._timeout_ms))
+            except usb.core.USBError as exc:
+                if exc.errno == _ERRNO_TIMEOUT:
+                    return b""  # the same signal a pyserial read timeout gives
+                raise serial.SerialException(f"read from {self.name} failed: {exc}") from exc
+
+        def write(self, data: bytes) -> int:
+            if not data:
+                return 0
+            try:
+                return int(self._device.write(self._out, data, self._timeout_ms))
+            except usb.core.USBError as exc:
+                if exc.errno == _ERRNO_TIMEOUT:
+                    raise serial.SerialTimeoutException(f"write to {self.name} timed out") from exc
+                raise serial.SerialException(f"write to {self.name} failed: {exc}") from exc
+
+        def flush(self) -> None:
+            """Nothing to wait for: `write` returns once libusb has handed the data over."""
+
+        def reset_input_buffer(self) -> None:
+            """Drops whatever an interrupted earlier run left in flight."""
+            while True:
+                try:
+                    if not len(self._device.read(self._in, _MAX_REQUEST, 50)):
+                        return
+                except usb.core.USBError:
+                    return
+
+        def reset_output_buffer(self) -> None:
+            """Nothing to drop: `write` does not return until the data is submitted."""
+
+        def close(self) -> None:
+            if self._device is not None:
+                try:
+                    usb.util.release_interface(self._device, self._interface)
+                except usb.core.USBError:
+                    pass
+                usb.util.dispose_resources(self._device)
+                self._device = None
+
+    Port = LibusbPort
+else:
+    Port = serial.Serial
+
+
+def open_port(spec: str, timeout: float) -> Port:
+    """Opens the benchmark peer. Raises `serial.SerialException` while it is not there."""
+    if sys.platform == "win32":
+        return LibusbPort(spec, timeout)
+    device = resolve_port(spec)
+    if device is None:
+        raise serial.SerialException(f"no serial port with USB id {spec}")
+    return serial.Serial(device, timeout=timeout, write_timeout=timeout)
+
+
+def read_exact(port: Port, count: int) -> bytes:
     data = bytearray()
     while len(data) < count:
         chunk = port.read(count - len(data))
@@ -69,7 +211,7 @@ def read_exact(port: serial.Serial, count: int) -> bytes:
     return bytes(data)
 
 
-def write_split(port: serial.Serial, frame: bytes, split_at: int) -> None:
+def write_split(port: Port, frame: bytes, split_at: int) -> None:
     port.write(frame[:split_at])
     port.flush()
     time.sleep(0.02)
@@ -77,7 +219,7 @@ def write_split(port: serial.Serial, frame: bytes, split_at: int) -> None:
     port.flush()
 
 
-def run_protocol_check(port: serial.Serial) -> None:
+def run_protocol_check(port: Port) -> None:
     def expect_ack(expected: int, case: str) -> None:
         acknowledged = struct.unpack("<I", read_exact(port, 4))[0]
         if acknowledged != expected:
@@ -117,7 +259,7 @@ def run_protocol_check(port: serial.Serial) -> None:
     print("protocol stream check passed")
 
 
-def run_in(port: serial.Serial, count: int) -> tuple[float, int]:
+def run_in(port: Port, count: int) -> tuple[float, int]:
     """Device -> host. Returns (elapsed seconds, mismatching byte count)."""
     frame = b"I" + struct.pack("<I", count)
     start = time.perf_counter()
@@ -143,7 +285,7 @@ def run_in(port: serial.Serial, count: int) -> tuple[float, int]:
     return elapsed, mismatches
 
 
-def run_out(port: serial.Serial, count: int) -> float:
+def run_out(port: Port, count: int) -> float:
     """Host -> device. Returns elapsed seconds."""
     frame = b"O" + struct.pack("<I", count)
     start = time.perf_counter()
@@ -172,7 +314,11 @@ def main() -> None:
     parser = argparse.ArgumentParser(
         description="Measure USB CDC-ACM throughput against the LPC55 throughput firmware."
     )
-    parser.add_argument("--port", required=True, help="serial device, e.g. /dev/ttyACM0")
+    parser.add_argument(
+        "--port",
+        required=True,
+        help="serial device (/dev/ttyACM0, COM7) or a USB id selector such as c0de:cafe",
+    )
     parser.add_argument(
         "--bytes",
         type=parse_count,
@@ -207,7 +353,7 @@ def main() -> None:
     deadline = time.monotonic() + args.wait_port
     while True:
         try:
-            port = serial.Serial(args.port, timeout=args.timeout, write_timeout=args.timeout)
+            port = open_port(args.port, args.timeout)
             break
         except serial.SerialException as exc:
             # With the default --wait-port of 0 the deadline has already passed, so this is

--- a/examples/lpc55s69/src/bin/usb_dual.rs
+++ b/examples/lpc55s69/src/bin/usb_dual.rs
@@ -32,16 +32,6 @@ bind_interrupts!(struct Irqs {
     USB1 => InterruptHandler<peripherals::USBHSD>;
 });
 
-/// Endpoint memory for the full-speed controller, in main SRAM.
-///
-/// 4 KiB comfortably fits an FS CDC-ACM device (command list, SETUP buffer,
-/// EP0, one interrupt endpoint and two double-buffered 512-byte bulk slots ~
-/// 2.5 KiB). `Memory::buffer` requires at least 512 bytes and 256-byte
-/// alignment.
-#[repr(C, align(256))]
-struct EpMem([u8; 4096]);
-static mut EP_MEM: EpMem = EpMem([0; 4096]);
-
 #[embassy_executor::main]
 async fn main(_spawner: Spawner) {
     let mut config = embassy_nxp::config::Config::default();
@@ -54,9 +44,12 @@ async fn main(_spawner: Spawner) {
     // High speed takes the dedicated USB1 SRAM.
     let hs_driver = Driver::<peripherals::USBHSD>::new(p.USBHSD, Irqs, Memory::usb1_sram());
 
-    // Full speed takes a region in main SRAM. Edition 2024 forbids references
-    // to `static mut`, so go through a raw pointer.
-    let fs_mem = Memory::buffer(unsafe { &mut (*(&raw mut EP_MEM)).0 });
+    // Full speed takes a region in main SRAM. 4 KiB comfortably fits an FS
+    // CDC-ACM device (command list, SETUP buffer, EP0, one interrupt endpoint
+    // and two double-buffered 512-byte bulk slots ~ 2.5 KiB). The local lives
+    // in the main task's storage, which is a `static`, not on the stack.
+    let mut ep_mem = [0u8; 4096];
+    let fs_mem = Memory::buffer(&mut ep_mem);
     let fs_driver = Driver::<peripherals::USB0>::new(p.USB0, Irqs, p.PIO0_22, fs_mem);
 
     // --- High-speed device ---

--- a/examples/lpc55s69/src/bin/usb_dual.rs
+++ b/examples/lpc55s69/src/bin/usb_dual.rs
@@ -7,24 +7,19 @@
 //!
 //! - `c0de:cafe` "USB-HS dual echo" at 480 Mbps
 //! - `c0de:caff` "USB-FS dual echo" at 12 Mbps
-//!
-//! This is what the two-region [`Memory`] design buys: only one controller can
-//! own the dedicated USB1 SRAM, so simultaneous operation requires the other to
-//! take a caller-provided region.
 
 #![no_std]
 #![no_main]
 
-use defmt::{info, panic};
+use defmt::info;
 use defmt_rtt as _;
 use embassy_executor::Spawner;
-use embassy_futures::join::{join, join3};
+use embassy_futures::join::join;
 use embassy_nxp::config::MainClock;
 use embassy_nxp::usb::{Driver, InterruptHandler, Memory};
 use embassy_nxp::{bind_interrupts, peripherals};
+use embassy_nxp_lpc55s69_examples::serial::{self, Params};
 use embassy_usb::UsbDeviceSpeed;
-use embassy_usb::class::cdc_acm::{CdcAcmClass, State};
-use embassy_usb::driver::EndpointError;
 use panic_probe as _;
 
 bind_interrupts!(struct Irqs {
@@ -35,129 +30,40 @@ bind_interrupts!(struct Irqs {
 #[embassy_executor::main]
 async fn main(_spawner: Spawner) {
     let mut config = embassy_nxp::config::Config::default();
-    // Required by the high-speed controller; the full-speed one clocks itself.
     config.main_clock = MainClock::FroHf96;
     let p = embassy_nxp::init(config);
-
     info!("Initialization complete");
 
-    // High speed takes the dedicated USB1 SRAM.
+    // Only one controller can own the dedicated USB1 SRAM.
     let hs_driver = Driver::<peripherals::USBHSD>::new(p.USBHSD, Irqs, Memory::usb1_sram());
-
-    // Full speed takes a region in main SRAM. 4 KiB comfortably fits an FS
-    // CDC-ACM device (command list, SETUP buffer, EP0, one interrupt endpoint
-    // and two double-buffered 512-byte bulk slots ~ 2.5 KiB). The local lives
-    // in the main task's storage, which is a `static`, not on the stack.
     let mut ep_mem = [0u8; 4096];
-    let fs_mem = Memory::buffer(&mut ep_mem);
-    let fs_driver = Driver::<peripherals::USB0>::new(p.USB0, Irqs, p.PIO0_22, fs_mem);
+    let fs_driver = Driver::<peripherals::USB0>::new(p.USB0, Irqs, p.PIO0_22, Memory::buffer(&mut ep_mem));
 
-    // --- High-speed device ---
-    let mut hs_config = embassy_usb::Config::new(0xc0de, 0xcafe);
-    hs_config.manufacturer = Some("Embassy");
-    hs_config.product = Some("USB-HS dual echo");
-    hs_config.serial_number = Some("12345678");
-    hs_config.max_power = 100;
-    hs_config.max_packet_size_0 = 64;
-    hs_config.max_speed = UsbDeviceSpeed::High;
-
-    let mut hs_config_descriptor = [0; 256];
-    let mut hs_bos_descriptor = [0; 256];
-    let mut hs_control_buf = [0; 64];
-    let mut hs_state = State::new();
-
-    let mut hs_builder = embassy_usb::Builder::new(
+    let mut hs_resources = serial::Resources::new();
+    let mut fs_resources = serial::Resources::new();
+    let hs = serial::run::<_, 512>(
         hs_driver,
-        hs_config,
-        &mut hs_config_descriptor,
-        &mut hs_bos_descriptor,
-        &mut [], // no msos descriptors
-        &mut hs_control_buf,
+        &mut hs_resources,
+        Params {
+            pid: 0xcafe,
+            product: "USB-HS dual echo",
+            serial: "12345678",
+            max_speed: UsbDeviceSpeed::High,
+        },
+        "HS connected",
+        "HS disconnected",
     );
-    let mut hs_class = CdcAcmClass::new(&mut hs_builder, &mut hs_state, 512);
-    let mut hs_usb = hs_builder.build();
-
-    // --- Full-speed device ---
-    let mut fs_config = embassy_usb::Config::new(0xc0de, 0xcaff);
-    fs_config.manufacturer = Some("Embassy");
-    fs_config.product = Some("USB-FS dual echo");
-    fs_config.serial_number = Some("87654321");
-    fs_config.max_power = 100;
-    fs_config.max_packet_size_0 = 64;
-
-    let mut fs_config_descriptor = [0; 256];
-    let mut fs_bos_descriptor = [0; 256];
-    let mut fs_control_buf = [0; 64];
-    let mut fs_state = State::new();
-
-    let mut fs_builder = embassy_usb::Builder::new(
+    let fs = serial::run::<_, 64>(
         fs_driver,
-        fs_config,
-        &mut fs_config_descriptor,
-        &mut fs_bos_descriptor,
-        &mut [], // no msos descriptors
-        &mut fs_control_buf,
+        &mut fs_resources,
+        Params {
+            pid: 0xcaff,
+            product: "USB-FS dual echo",
+            serial: "87654321",
+            max_speed: UsbDeviceSpeed::Full,
+        },
+        "FS connected",
+        "FS disconnected",
     );
-    let mut fs_class = CdcAcmClass::new(&mut fs_builder, &mut fs_state, 64);
-    let mut fs_usb = fs_builder.build();
-
-    let hs_echo = async {
-        loop {
-            hs_class.wait_connection().await;
-            info!("HS connected");
-            let _ = echo_hs(&mut hs_class).await;
-            info!("HS disconnected");
-        }
-    };
-
-    let fs_echo = async {
-        loop {
-            fs_class.wait_connection().await;
-            info!("FS connected");
-            let _ = echo_fs(&mut fs_class).await;
-            info!("FS disconnected");
-        }
-    };
-
-    // Both device stacks and both echo loops run concurrently on one executor.
-    join(join3(hs_usb.run(), fs_usb.run(), hs_echo), fs_echo).await;
-}
-
-struct Disconnected {}
-
-impl From<EndpointError> for Disconnected {
-    fn from(val: EndpointError) -> Self {
-        match val {
-            EndpointError::BufferOverflow => panic!("Buffer overflow"),
-            EndpointError::Disabled => Disconnected {},
-        }
-    }
-}
-
-/// An echo of exactly one max-packet-size packet needs a trailing zero-length
-/// packet to end the transfer: without it the host keeps waiting for more and
-/// never delivers the reply.
-async fn echo_hs<'d>(class: &mut CdcAcmClass<'d, Driver<'d, peripherals::USBHSD>>) -> Result<(), Disconnected> {
-    const MPS: usize = 512;
-    let mut buf = [0; MPS];
-    loop {
-        let n = class.read_packet(&mut buf).await?;
-        class.write_packet(&buf[..n]).await?;
-        if n == MPS {
-            class.write_packet(&[]).await?;
-        }
-    }
-}
-
-/// See [`echo_hs`] for the trailing zero-length packet.
-async fn echo_fs<'d>(class: &mut CdcAcmClass<'d, Driver<'d, peripherals::USB0>>) -> Result<(), Disconnected> {
-    const MPS: usize = 64;
-    let mut buf = [0; MPS];
-    loop {
-        let n = class.read_packet(&mut buf).await?;
-        class.write_packet(&buf[..n]).await?;
-        if n == MPS {
-            class.write_packet(&[]).await?;
-        }
-    }
+    join(hs, fs).await;
 }

--- a/examples/lpc55s69/src/bin/usb_dual.rs
+++ b/examples/lpc55s69/src/bin/usb_dual.rs
@@ -1,0 +1,170 @@
+//! Both LPC55 USB controllers running at the same time.
+//!
+//! Brings up USB1 (high-speed, connector **P9**) on the dedicated USB1 SRAM and
+//! USB0 (full-speed, connector **P10**) on a buffer in main SRAM, then runs two
+//! independent `UsbDevice`s concurrently. Each is a CDC-ACM echo port with its
+//! own product string and PID, so the host sees two distinct devices:
+//!
+//! - `c0de:cafe` "USB-HS dual echo" at 480 Mbps
+//! - `c0de:caff` "USB-FS dual echo" at 12 Mbps
+//!
+//! This is what the two-region [`Memory`] design buys: only one controller can
+//! own the dedicated USB1 SRAM, so simultaneous operation requires the other to
+//! take a caller-provided region.
+
+#![no_std]
+#![no_main]
+
+use defmt::{info, panic};
+use defmt_rtt as _;
+use embassy_executor::Spawner;
+use embassy_futures::join::{join, join3};
+use embassy_nxp::config::MainClock;
+use embassy_nxp::usb::{Driver, InterruptHandler, Memory};
+use embassy_nxp::{bind_interrupts, peripherals};
+use embassy_usb::UsbDeviceSpeed;
+use embassy_usb::class::cdc_acm::{CdcAcmClass, State};
+use embassy_usb::driver::EndpointError;
+use panic_probe as _;
+
+bind_interrupts!(struct Irqs {
+    USB0 => InterruptHandler<peripherals::USB0>;
+    USB1 => InterruptHandler<peripherals::USBHSD>;
+});
+
+/// Endpoint memory for the full-speed controller, in main SRAM.
+///
+/// 4 KiB comfortably fits an FS CDC-ACM device (command list, SETUP buffer,
+/// EP0, one interrupt endpoint and two double-buffered 512-byte bulk slots ~
+/// 2.5 KiB). `Memory::buffer` requires at least 512 bytes and 256-byte
+/// alignment.
+#[repr(C, align(256))]
+struct EpMem([u8; 4096]);
+static mut EP_MEM: EpMem = EpMem([0; 4096]);
+
+#[embassy_executor::main]
+async fn main(_spawner: Spawner) {
+    let mut config = embassy_nxp::config::Config::default();
+    // Required by the high-speed controller; the full-speed one clocks itself.
+    config.main_clock = MainClock::FroHf96;
+    let p = embassy_nxp::init(config);
+
+    info!("Initialization complete");
+
+    // High speed takes the dedicated USB1 SRAM.
+    let hs_driver = Driver::<peripherals::USBHSD>::new(p.USBHSD, Irqs, Memory::usb1_sram());
+
+    // Full speed takes a region in main SRAM. Edition 2024 forbids references
+    // to `static mut`, so go through a raw pointer.
+    let fs_mem = Memory::buffer(unsafe { &mut (*(&raw mut EP_MEM)).0 });
+    let fs_driver = Driver::<peripherals::USB0>::new(p.USB0, Irqs, p.PIO0_22, fs_mem);
+
+    // --- High-speed device ---
+    let mut hs_config = embassy_usb::Config::new(0xc0de, 0xcafe);
+    hs_config.manufacturer = Some("Embassy");
+    hs_config.product = Some("USB-HS dual echo");
+    hs_config.serial_number = Some("12345678");
+    hs_config.max_power = 100;
+    hs_config.max_packet_size_0 = 64;
+    hs_config.max_speed = UsbDeviceSpeed::High;
+
+    let mut hs_config_descriptor = [0; 256];
+    let mut hs_bos_descriptor = [0; 256];
+    let mut hs_control_buf = [0; 64];
+    let mut hs_state = State::new();
+
+    let mut hs_builder = embassy_usb::Builder::new(
+        hs_driver,
+        hs_config,
+        &mut hs_config_descriptor,
+        &mut hs_bos_descriptor,
+        &mut [], // no msos descriptors
+        &mut hs_control_buf,
+    );
+    let mut hs_class = CdcAcmClass::new(&mut hs_builder, &mut hs_state, 512);
+    let mut hs_usb = hs_builder.build();
+
+    // --- Full-speed device ---
+    let mut fs_config = embassy_usb::Config::new(0xc0de, 0xcaff);
+    fs_config.manufacturer = Some("Embassy");
+    fs_config.product = Some("USB-FS dual echo");
+    fs_config.serial_number = Some("87654321");
+    fs_config.max_power = 100;
+    fs_config.max_packet_size_0 = 64;
+
+    let mut fs_config_descriptor = [0; 256];
+    let mut fs_bos_descriptor = [0; 256];
+    let mut fs_control_buf = [0; 64];
+    let mut fs_state = State::new();
+
+    let mut fs_builder = embassy_usb::Builder::new(
+        fs_driver,
+        fs_config,
+        &mut fs_config_descriptor,
+        &mut fs_bos_descriptor,
+        &mut [], // no msos descriptors
+        &mut fs_control_buf,
+    );
+    let mut fs_class = CdcAcmClass::new(&mut fs_builder, &mut fs_state, 64);
+    let mut fs_usb = fs_builder.build();
+
+    let hs_echo = async {
+        loop {
+            hs_class.wait_connection().await;
+            info!("HS connected");
+            let _ = echo_hs(&mut hs_class).await;
+            info!("HS disconnected");
+        }
+    };
+
+    let fs_echo = async {
+        loop {
+            fs_class.wait_connection().await;
+            info!("FS connected");
+            let _ = echo_fs(&mut fs_class).await;
+            info!("FS disconnected");
+        }
+    };
+
+    // Both device stacks and both echo loops run concurrently on one executor.
+    join(join3(hs_usb.run(), fs_usb.run(), hs_echo), fs_echo).await;
+}
+
+struct Disconnected {}
+
+impl From<EndpointError> for Disconnected {
+    fn from(val: EndpointError) -> Self {
+        match val {
+            EndpointError::BufferOverflow => panic!("Buffer overflow"),
+            EndpointError::Disabled => Disconnected {},
+        }
+    }
+}
+
+/// An echo of exactly one max-packet-size packet needs a trailing zero-length
+/// packet to end the transfer: without it the host keeps waiting for more and
+/// never delivers the reply.
+async fn echo_hs<'d>(class: &mut CdcAcmClass<'d, Driver<'d, peripherals::USBHSD>>) -> Result<(), Disconnected> {
+    const MPS: usize = 512;
+    let mut buf = [0; MPS];
+    loop {
+        let n = class.read_packet(&mut buf).await?;
+        class.write_packet(&buf[..n]).await?;
+        if n == MPS {
+            class.write_packet(&[]).await?;
+        }
+    }
+}
+
+/// See [`echo_hs`] for the trailing zero-length packet.
+async fn echo_fs<'d>(class: &mut CdcAcmClass<'d, Driver<'d, peripherals::USB0>>) -> Result<(), Disconnected> {
+    const MPS: usize = 64;
+    let mut buf = [0; MPS];
+    loop {
+        let n = class.read_packet(&mut buf).await?;
+        class.write_packet(&buf[..n]).await?;
+        if n == MPS {
+            class.write_packet(&[]).await?;
+        }
+    }
+}

--- a/examples/lpc55s69/src/bin/usb_fs_serial.rs
+++ b/examples/lpc55s69/src/bin/usb_fs_serial.rs
@@ -1,0 +1,112 @@
+//! USB0 full-speed CDC-ACM serial port example for the LPC55S6x.
+//!
+//! Creates a USB serial port on the USB0 (full-speed) port that echoes
+//! received data. The device enumerates at 12 Mbps.
+//!
+//! Uses the default HAL config on purpose: the full-speed controller brings up
+//! its own 48 MHz clock from FRO-HF, so unlike the high-speed examples it needs
+//! no `MainClock::FroHf96` and no crystal.
+//!
+//! Cable on connector **P10**.
+
+#![no_std]
+#![no_main]
+
+use defmt::{info, panic};
+use defmt_rtt as _;
+use embassy_executor::Spawner;
+use embassy_futures::join::join;
+use embassy_nxp::usb::{Driver, InterruptHandler, Memory};
+use embassy_nxp::{bind_interrupts, peripherals};
+use embassy_usb::class::cdc_acm::{CdcAcmClass, State};
+use embassy_usb::driver::EndpointError;
+use panic_probe as _;
+
+bind_interrupts!(struct Irqs {
+    USB0 => InterruptHandler<peripherals::USB0>;
+});
+
+#[embassy_executor::main]
+async fn main(_spawner: Spawner) {
+    let p = embassy_nxp::init(embassy_nxp::config::Config::default());
+
+    info!("Initialization complete");
+
+    // Create the driver, from the HAL. PIO0_22 is the USB0_VBUS sense pin.
+    let driver = Driver::<peripherals::USB0>::new(p.USB0, Irqs, p.PIO0_22, Memory::usb1_sram());
+
+    // Create embassy-usb Config
+    let mut config = embassy_usb::Config::new(0xc0de, 0xcafe);
+    config.manufacturer = Some("Embassy");
+    config.product = Some("USB-FS serial example");
+    config.serial_number = Some("12345678");
+    config.max_power = 100;
+    config.max_packet_size_0 = 64;
+
+    // Create embassy-usb DeviceBuilder using the driver and config.
+    // It needs some buffers for building the descriptors.
+    let mut config_descriptor = [0; 256];
+    let mut bos_descriptor = [0; 256];
+    let mut control_buf = [0; 64];
+
+    let mut state = State::new();
+
+    let mut builder = embassy_usb::Builder::new(
+        driver,
+        config,
+        &mut config_descriptor,
+        &mut bos_descriptor,
+        &mut [], // no msos descriptors
+        &mut control_buf,
+    );
+
+    // Create classes on the builder. 64-byte bulk max packet size for FS.
+    let mut class = CdcAcmClass::new(&mut builder, &mut state, 64);
+
+    // Build the builder.
+    let mut usb = builder.build();
+
+    // Run the USB device.
+    let usb_fut = usb.run();
+
+    // Do stuff with the class!
+    let echo_fut = async {
+        loop {
+            class.wait_connection().await;
+            info!("Connected");
+            let _ = echo(&mut class).await;
+            info!("Disconnected");
+        }
+    };
+
+    // Run everything concurrently.
+    join(usb_fut, echo_fut).await;
+}
+
+struct Disconnected {}
+
+impl From<EndpointError> for Disconnected {
+    fn from(val: EndpointError) -> Self {
+        match val {
+            EndpointError::BufferOverflow => panic!("Buffer overflow"),
+            EndpointError::Disabled => Disconnected {},
+        }
+    }
+}
+
+async fn echo<'d>(class: &mut CdcAcmClass<'d, Driver<'d, peripherals::USB0>>) -> Result<(), Disconnected> {
+    const MPS: usize = 64;
+    let mut buf = [0; MPS];
+    loop {
+        let n = class.read_packet(&mut buf).await?;
+        let data = &buf[..n];
+        info!("data: {:x}", data);
+        class.write_packet(data).await?;
+        // An echo of exactly one max-packet-size packet needs a zero-length
+        // packet to end the transfer: without it the host keeps waiting for
+        // more and never delivers the reply.
+        if n == MPS {
+            class.write_packet(&[]).await?;
+        }
+    }
+}

--- a/examples/lpc55s69/src/bin/usb_fs_serial.rs
+++ b/examples/lpc55s69/src/bin/usb_fs_serial.rs
@@ -12,14 +12,13 @@
 #![no_std]
 #![no_main]
 
-use defmt::{info, panic};
+use defmt::info;
 use defmt_rtt as _;
 use embassy_executor::Spawner;
-use embassy_futures::join::join;
 use embassy_nxp::usb::{Driver, InterruptHandler, Memory};
 use embassy_nxp::{bind_interrupts, peripherals};
-use embassy_usb::class::cdc_acm::{CdcAcmClass, State};
-use embassy_usb::driver::EndpointError;
+use embassy_nxp_lpc55s69_examples::serial::{self, Params};
+use embassy_usb::UsbDeviceSpeed;
 use panic_probe as _;
 
 bind_interrupts!(struct Irqs {
@@ -29,84 +28,21 @@ bind_interrupts!(struct Irqs {
 #[embassy_executor::main]
 async fn main(_spawner: Spawner) {
     let p = embassy_nxp::init(embassy_nxp::config::Config::default());
-
     info!("Initialization complete");
 
-    // Create the driver, from the HAL. PIO0_22 is the USB0_VBUS sense pin.
+    let mut resources = serial::Resources::new();
     let driver = Driver::<peripherals::USB0>::new(p.USB0, Irqs, p.PIO0_22, Memory::usb1_sram());
-
-    // Create embassy-usb Config
-    let mut config = embassy_usb::Config::new(0xc0de, 0xcafe);
-    config.manufacturer = Some("Embassy");
-    config.product = Some("USB-FS serial example");
-    config.serial_number = Some("12345678");
-    config.max_power = 100;
-    config.max_packet_size_0 = 64;
-
-    // Create embassy-usb DeviceBuilder using the driver and config.
-    // It needs some buffers for building the descriptors.
-    let mut config_descriptor = [0; 256];
-    let mut bos_descriptor = [0; 256];
-    let mut control_buf = [0; 64];
-
-    let mut state = State::new();
-
-    let mut builder = embassy_usb::Builder::new(
+    serial::run::<_, 64>(
         driver,
-        config,
-        &mut config_descriptor,
-        &mut bos_descriptor,
-        &mut [], // no msos descriptors
-        &mut control_buf,
-    );
-
-    // Create classes on the builder. 64-byte bulk max packet size for FS.
-    let mut class = CdcAcmClass::new(&mut builder, &mut state, 64);
-
-    // Build the builder.
-    let mut usb = builder.build();
-
-    // Run the USB device.
-    let usb_fut = usb.run();
-
-    // Do stuff with the class!
-    let echo_fut = async {
-        loop {
-            class.wait_connection().await;
-            info!("Connected");
-            let _ = echo(&mut class).await;
-            info!("Disconnected");
-        }
-    };
-
-    // Run everything concurrently.
-    join(usb_fut, echo_fut).await;
-}
-
-struct Disconnected {}
-
-impl From<EndpointError> for Disconnected {
-    fn from(val: EndpointError) -> Self {
-        match val {
-            EndpointError::BufferOverflow => panic!("Buffer overflow"),
-            EndpointError::Disabled => Disconnected {},
-        }
-    }
-}
-
-async fn echo<'d>(class: &mut CdcAcmClass<'d, Driver<'d, peripherals::USB0>>) -> Result<(), Disconnected> {
-    const MPS: usize = 64;
-    let mut buf = [0; MPS];
-    loop {
-        let n = class.read_packet(&mut buf).await?;
-        let data = &buf[..n];
-        info!("data: {:x}", data);
-        class.write_packet(data).await?;
-        // An echo of exactly one max-packet-size packet needs a zero-length
-        // packet to end the transfer: without it the host keeps waiting for
-        // more and never delivers the reply.
-        if n == MPS {
-            class.write_packet(&[]).await?;
-        }
-    }
+        &mut resources,
+        Params {
+            pid: 0xcafe,
+            product: "USB-FS serial example",
+            serial: "12345678",
+            max_speed: UsbDeviceSpeed::Full,
+        },
+        "Connected",
+        "Disconnected",
+    )
+    .await;
 }

--- a/examples/lpc55s69/src/bin/usb_fs_throughput.rs
+++ b/examples/lpc55s69/src/bin/usb_fs_throughput.rs
@@ -41,7 +41,7 @@ async fn main(_spawner: Spawner) {
         driver,
         &mut resources,
         Params {
-            pid: 0xcafe,
+            pid: 0xcb07,
             product: "USB-FS throughput test",
             serial: "12345678",
             max_speed: UsbDeviceSpeed::Full,

--- a/examples/lpc55s69/src/bin/usb_fs_throughput.rs
+++ b/examples/lpc55s69/src/bin/usb_fs_throughput.rs
@@ -17,6 +17,9 @@
 #![no_std]
 #![no_main]
 
+#[path = "../throughput.rs"]
+mod throughput;
+
 use defmt::{info, panic};
 use defmt_rtt as _;
 use embassy_executor::Spawner;
@@ -26,6 +29,8 @@ use embassy_nxp::{bind_interrupts, peripherals};
 use embassy_usb::class::cdc_acm::{CdcAcmClass, State};
 use embassy_usb::driver::EndpointError;
 use panic_probe as _;
+
+use throughput::{Event, Parser};
 
 bind_interrupts!(struct Irqs {
     USB0 => InterruptHandler<peripherals::USB0>;
@@ -91,60 +96,45 @@ impl From<EndpointError> for Disconnected {
 }
 
 async fn bench<'d>(class: &mut CdcAcmClass<'d, Driver<'d, peripherals::USB0>>) -> Result<(), Disconnected> {
-    // One packet per transfer: unlike the high-speed controller, the
-    // full-speed block does not packetize a command entry, so an endpoint is
-    // armed one max-packet-size packet at a time and `write_packet` rejects
-    // anything larger.
     const CHUNK: usize = 64;
 
-    // Recognizable pattern so the host can spot-check payload integrity:
-    // a 0..512 ramp repeating per 512-byte packet, identical to the HS bench.
-    // The ramp period spans 8 full-speed packets, so index by stream offset.
     let mut tx = [0u8; 512];
-    for (i, b) in tx.iter_mut().enumerate() {
-        *b = (i % 512) as u8;
+    for (i, byte) in tx.iter_mut().enumerate() {
+        *byte = (i % 512) as u8;
     }
     let mut buf = [0u8; CHUNK];
+    let mut parser = Parser::new();
 
     loop {
-        let n = class.read_packet(&mut buf).await?;
-        if n < 5 {
-            continue;
-        }
-        let cmd = buf[0];
-        let total = u32::from_le_bytes([buf[1], buf[2], buf[3], buf[4]]) as usize;
+        let len = class.read_packet(&mut buf).await?;
+        let mut offset = 0;
 
-        match cmd {
-            b'I' => {
-                info!("IN test: {} bytes", total);
-                let mut remaining = total;
-                let mut off = 0usize;
-                while remaining > 0 {
-                    let chunk = remaining.min(CHUNK);
-                    // Walk the 512-byte ramp so the host sees one continuous
-                    // stream rather than the first packet repeated.
-                    class.write_packet(&tx[off..off + chunk]).await?;
-                    off = (off + chunk) % tx.len();
-                    remaining -= chunk;
+        while offset < len {
+            let feed = parser.feed(&buf[offset..len]);
+            offset += feed.consumed;
+
+            match feed.event {
+                Some(Event::In(total)) => {
+                    info!("IN test: {} bytes", total);
+                    let mut remaining = total;
+                    let mut ramp_offset = 0;
+                    while remaining > 0 {
+                        let chunk = remaining.min(CHUNK as u32) as usize;
+                        class.write_packet(&tx[ramp_offset..ramp_offset + chunk]).await?;
+                        ramp_offset = (ramp_offset + chunk) % tx.len();
+                        remaining -= chunk as u32;
+                    }
+                    if total % CHUNK as u32 == 0 {
+                        class.write_packet(&[]).await?;
+                    }
                 }
-                // A stream ending exactly on a max-packet-size boundary needs
-                // a zero-length packet to tell the host the transfer is over;
-                // without it the host waits for more and the last packet is
-                // never delivered.
-                if total % CHUNK == 0 {
-                    class.write_packet(&[]).await?;
+                Some(Event::OutStarted(total)) => info!("OUT test: {} bytes", total),
+                Some(Event::OutComplete(total)) => {
+                    class.write_packet(&total.to_le_bytes()).await?;
                 }
+                Some(Event::Unknown(command)) => info!("unknown command {}", command),
+                None => {}
             }
-            b'O' => {
-                info!("OUT test: {} bytes", total);
-                // Payload may share the header packet.
-                let mut received = n - 5;
-                while received < total {
-                    received += class.read_packet(&mut buf).await?;
-                }
-                class.write_packet(&(received as u32).to_le_bytes()).await?;
-            }
-            _ => info!("unknown command {}", cmd),
         }
     }
 }

--- a/examples/lpc55s69/src/bin/usb_fs_throughput.rs
+++ b/examples/lpc55s69/src/bin/usb_fs_throughput.rs
@@ -1,0 +1,150 @@
+//! USB0 full-speed bulk throughput benchmark for the LPC55S6x.
+//!
+//! Speaks the same wire protocol as `usb_hs_throughput`, so one host script
+//! drives both: the host sends a 5-byte header on the CDC tty, a command byte
+//! followed by a little-endian u32 byte count.
+//!
+//! - `b'I'` + N: the device streams N bytes to the host.
+//! - `b'O'` + N: the host sends N bytes, then the device replies with the
+//!   received count as a little-endian u32.
+//!
+//! Drive it with `examples/lpc55s69/scripts/usb_throughput.py`. Expect roughly
+//! 1.0-1.2 MB/s, against a full-speed bulk ceiling of 1.216 MB/s.
+//!
+//! Uses the default HAL config: the full-speed controller brings up its own
+//! 48 MHz clock. Cable on connector **P10**.
+
+#![no_std]
+#![no_main]
+
+use defmt::{info, panic};
+use defmt_rtt as _;
+use embassy_executor::Spawner;
+use embassy_futures::join::join;
+use embassy_nxp::usb::{Driver, InterruptHandler, Memory};
+use embassy_nxp::{bind_interrupts, peripherals};
+use embassy_usb::class::cdc_acm::{CdcAcmClass, State};
+use embassy_usb::driver::EndpointError;
+use panic_probe as _;
+
+bind_interrupts!(struct Irqs {
+    USB0 => InterruptHandler<peripherals::USB0>;
+});
+
+#[embassy_executor::main]
+async fn main(_spawner: Spawner) {
+    let p = embassy_nxp::init(embassy_nxp::config::Config::default());
+
+    info!("Initialization complete");
+
+    let driver = Driver::<peripherals::USB0>::new(p.USB0, Irqs, p.PIO0_22, Memory::usb1_sram());
+
+    let mut config = embassy_usb::Config::new(0xc0de, 0xcafe);
+    config.manufacturer = Some("Embassy");
+    config.product = Some("USB-FS throughput test");
+    config.serial_number = Some("12345678");
+    config.max_power = 100;
+    config.max_packet_size_0 = 64;
+
+    let mut config_descriptor = [0; 256];
+    let mut bos_descriptor = [0; 256];
+    let mut control_buf = [0; 64];
+
+    let mut state = State::new();
+
+    let mut builder = embassy_usb::Builder::new(
+        driver,
+        config,
+        &mut config_descriptor,
+        &mut bos_descriptor,
+        &mut [], // no msos descriptors
+        &mut control_buf,
+    );
+
+    // 64-byte bulk max packet size for FS.
+    let mut class = CdcAcmClass::new(&mut builder, &mut state, 64);
+
+    let mut usb = builder.build();
+    let usb_fut = usb.run();
+
+    let bench_fut = async {
+        loop {
+            class.wait_connection().await;
+            info!("Connected");
+            let _ = bench(&mut class).await;
+            info!("Disconnected");
+        }
+    };
+
+    join(usb_fut, bench_fut).await;
+}
+
+struct Disconnected {}
+
+impl From<EndpointError> for Disconnected {
+    fn from(val: EndpointError) -> Self {
+        match val {
+            EndpointError::BufferOverflow => panic!("Buffer overflow"),
+            EndpointError::Disabled => Disconnected {},
+        }
+    }
+}
+
+async fn bench<'d>(class: &mut CdcAcmClass<'d, Driver<'d, peripherals::USB0>>) -> Result<(), Disconnected> {
+    // One packet per transfer: unlike the high-speed controller, the
+    // full-speed block does not packetize a command entry, so an endpoint is
+    // armed one max-packet-size packet at a time and `write_packet` rejects
+    // anything larger.
+    const CHUNK: usize = 64;
+
+    // Recognizable pattern so the host can spot-check payload integrity:
+    // a 0..512 ramp repeating per 512-byte packet, identical to the HS bench.
+    // The ramp period spans 8 full-speed packets, so index by stream offset.
+    let mut tx = [0u8; 512];
+    for (i, b) in tx.iter_mut().enumerate() {
+        *b = (i % 512) as u8;
+    }
+    let mut buf = [0u8; CHUNK];
+
+    loop {
+        let n = class.read_packet(&mut buf).await?;
+        if n < 5 {
+            continue;
+        }
+        let cmd = buf[0];
+        let total = u32::from_le_bytes([buf[1], buf[2], buf[3], buf[4]]) as usize;
+
+        match cmd {
+            b'I' => {
+                info!("IN test: {} bytes", total);
+                let mut remaining = total;
+                let mut off = 0usize;
+                while remaining > 0 {
+                    let chunk = remaining.min(CHUNK);
+                    // Walk the 512-byte ramp so the host sees one continuous
+                    // stream rather than the first packet repeated.
+                    class.write_packet(&tx[off..off + chunk]).await?;
+                    off = (off + chunk) % tx.len();
+                    remaining -= chunk;
+                }
+                // A stream ending exactly on a max-packet-size boundary needs
+                // a zero-length packet to tell the host the transfer is over;
+                // without it the host waits for more and the last packet is
+                // never delivered.
+                if total % CHUNK == 0 {
+                    class.write_packet(&[]).await?;
+                }
+            }
+            b'O' => {
+                info!("OUT test: {} bytes", total);
+                // Payload may share the header packet.
+                let mut received = n - 5;
+                while received < total {
+                    received += class.read_packet(&mut buf).await?;
+                }
+                class.write_packet(&(received as u32).to_le_bytes()).await?;
+            }
+            _ => info!("unknown command {}", cmd),
+        }
+    }
+}

--- a/examples/lpc55s69/src/bin/usb_fs_throughput.rs
+++ b/examples/lpc55s69/src/bin/usb_fs_throughput.rs
@@ -29,7 +29,6 @@ use embassy_nxp::{bind_interrupts, peripherals};
 use embassy_usb::class::cdc_acm::{CdcAcmClass, State};
 use embassy_usb::driver::EndpointError;
 use panic_probe as _;
-
 use throughput::{Event, Parser};
 
 bind_interrupts!(struct Irqs {

--- a/examples/lpc55s69/src/bin/usb_fs_throughput.rs
+++ b/examples/lpc55s69/src/bin/usb_fs_throughput.rs
@@ -17,19 +17,14 @@
 #![no_std]
 #![no_main]
 
-#[path = "../throughput.rs"]
-mod throughput;
-
-use defmt::{info, panic};
+use defmt::info;
 use defmt_rtt as _;
 use embassy_executor::Spawner;
-use embassy_futures::join::join;
 use embassy_nxp::usb::{Driver, InterruptHandler, Memory};
 use embassy_nxp::{bind_interrupts, peripherals};
-use embassy_usb::class::cdc_acm::{CdcAcmClass, State};
-use embassy_usb::driver::EndpointError;
+use embassy_nxp_lpc55s69_examples::throughput_device::{self, Params};
+use embassy_usb::UsbDeviceSpeed;
 use panic_probe as _;
-use throughput::{Event, Parser};
 
 bind_interrupts!(struct Irqs {
     USB0 => InterruptHandler<peripherals::USB0>;
@@ -38,102 +33,19 @@ bind_interrupts!(struct Irqs {
 #[embassy_executor::main]
 async fn main(_spawner: Spawner) {
     let p = embassy_nxp::init(embassy_nxp::config::Config::default());
-
     info!("Initialization complete");
 
+    let mut resources = throughput_device::Resources::new();
     let driver = Driver::<peripherals::USB0>::new(p.USB0, Irqs, p.PIO0_22, Memory::usb1_sram());
-
-    let mut config = embassy_usb::Config::new(0xc0de, 0xcafe);
-    config.manufacturer = Some("Embassy");
-    config.product = Some("USB-FS throughput test");
-    config.serial_number = Some("12345678");
-    config.max_power = 100;
-    config.max_packet_size_0 = 64;
-
-    let mut config_descriptor = [0; 256];
-    let mut bos_descriptor = [0; 256];
-    let mut control_buf = [0; 64];
-
-    let mut state = State::new();
-
-    let mut builder = embassy_usb::Builder::new(
+    throughput_device::run::<_, 64, 512, 64, 64>(
         driver,
-        config,
-        &mut config_descriptor,
-        &mut bos_descriptor,
-        &mut [], // no msos descriptors
-        &mut control_buf,
-    );
-
-    // 64-byte bulk max packet size for FS.
-    let mut class = CdcAcmClass::new(&mut builder, &mut state, 64);
-
-    let mut usb = builder.build();
-    let usb_fut = usb.run();
-
-    let bench_fut = async {
-        loop {
-            class.wait_connection().await;
-            info!("Connected");
-            let _ = bench(&mut class).await;
-            info!("Disconnected");
-        }
-    };
-
-    join(usb_fut, bench_fut).await;
-}
-
-struct Disconnected {}
-
-impl From<EndpointError> for Disconnected {
-    fn from(val: EndpointError) -> Self {
-        match val {
-            EndpointError::BufferOverflow => panic!("Buffer overflow"),
-            EndpointError::Disabled => Disconnected {},
-        }
-    }
-}
-
-async fn bench<'d>(class: &mut CdcAcmClass<'d, Driver<'d, peripherals::USB0>>) -> Result<(), Disconnected> {
-    const CHUNK: usize = 64;
-
-    let mut tx = [0u8; 512];
-    for (i, byte) in tx.iter_mut().enumerate() {
-        *byte = (i % 512) as u8;
-    }
-    let mut buf = [0u8; CHUNK];
-    let mut parser = Parser::new();
-
-    loop {
-        let len = class.read_packet(&mut buf).await?;
-        let mut offset = 0;
-
-        while offset < len {
-            let feed = parser.feed(&buf[offset..len]);
-            offset += feed.consumed;
-
-            match feed.event {
-                Some(Event::In(total)) => {
-                    info!("IN test: {} bytes", total);
-                    let mut remaining = total;
-                    let mut ramp_offset = 0;
-                    while remaining > 0 {
-                        let chunk = remaining.min(CHUNK as u32) as usize;
-                        class.write_packet(&tx[ramp_offset..ramp_offset + chunk]).await?;
-                        ramp_offset = (ramp_offset + chunk) % tx.len();
-                        remaining -= chunk as u32;
-                    }
-                    if total % CHUNK as u32 == 0 {
-                        class.write_packet(&[]).await?;
-                    }
-                }
-                Some(Event::OutStarted(total)) => info!("OUT test: {} bytes", total),
-                Some(Event::OutComplete(total)) => {
-                    class.write_packet(&total.to_le_bytes()).await?;
-                }
-                Some(Event::Unknown(command)) => info!("unknown command {}", command),
-                None => {}
-            }
-        }
-    }
+        &mut resources,
+        Params {
+            pid: 0xcafe,
+            product: "USB-FS throughput test",
+            serial: "12345678",
+            max_speed: UsbDeviceSpeed::Full,
+        },
+    )
+    .await;
 }

--- a/examples/lpc55s69/src/bin/usb_hs_serial.rs
+++ b/examples/lpc55s69/src/bin/usb_hs_serial.rs
@@ -1,0 +1,105 @@
+//! USB1 high-speed CDC-ACM serial port example for the LPC55S6x.
+//!
+//! Creates a USB serial port on the USB1 (high-speed) port that echoes
+//! received data. The device enumerates at 480 Mbps.
+
+#![no_std]
+#![no_main]
+
+use defmt::{info, panic};
+use defmt_rtt as _;
+use embassy_executor::Spawner;
+use embassy_futures::join::join;
+use embassy_nxp::config::MainClock;
+use embassy_nxp::usb::{Driver, InterruptHandler};
+use embassy_nxp::{bind_interrupts, peripherals};
+use embassy_usb::UsbDeviceSpeed;
+use embassy_usb::class::cdc_acm::{CdcAcmClass, State};
+use embassy_usb::driver::EndpointError;
+use panic_probe as _;
+
+bind_interrupts!(struct Irqs {
+    USB1 => InterruptHandler<peripherals::USBHSD>;
+});
+
+#[embassy_executor::main]
+async fn main(_spawner: Spawner) {
+    let mut config = embassy_nxp::config::Config::default();
+    // USB-HS requires a system clock of at least 96 MHz.
+    config.main_clock = MainClock::FroHf96;
+    let p = embassy_nxp::init(config);
+
+    info!("Initialization complete");
+
+    // Create the driver, from the HAL.
+    let driver = Driver::new(p.USBHSD, Irqs);
+
+    // Create embassy-usb Config
+    let mut config = embassy_usb::Config::new(0xc0de, 0xcafe);
+    config.manufacturer = Some("Embassy");
+    config.product = Some("USB-HS serial example");
+    config.serial_number = Some("12345678");
+    config.max_power = 100;
+    config.max_packet_size_0 = 64;
+    config.max_speed = UsbDeviceSpeed::High;
+
+    // Create embassy-usb DeviceBuilder using the driver and config.
+    // It needs some buffers for building the descriptors.
+    let mut config_descriptor = [0; 256];
+    let mut bos_descriptor = [0; 256];
+    let mut control_buf = [0; 64];
+
+    let mut state = State::new();
+
+    let mut builder = embassy_usb::Builder::new(
+        driver,
+        config,
+        &mut config_descriptor,
+        &mut bos_descriptor,
+        &mut [], // no msos descriptors
+        &mut control_buf,
+    );
+
+    // Create classes on the builder. 512-byte bulk max packet size for HS.
+    let mut class = CdcAcmClass::new(&mut builder, &mut state, 512);
+
+    // Build the builder.
+    let mut usb = builder.build();
+
+    // Run the USB device.
+    let usb_fut = usb.run();
+
+    // Do stuff with the class!
+    let echo_fut = async {
+        loop {
+            class.wait_connection().await;
+            info!("Connected");
+            let _ = echo(&mut class).await;
+            info!("Disconnected");
+        }
+    };
+
+    // Run everything concurrently.
+    join(usb_fut, echo_fut).await;
+}
+
+struct Disconnected {}
+
+impl From<EndpointError> for Disconnected {
+    fn from(val: EndpointError) -> Self {
+        match val {
+            EndpointError::BufferOverflow => panic!("Buffer overflow"),
+            EndpointError::Disabled => Disconnected {},
+        }
+    }
+}
+
+async fn echo<'d>(class: &mut CdcAcmClass<'d, Driver<'d, peripherals::USBHSD>>) -> Result<(), Disconnected> {
+    let mut buf = [0; 512];
+    loop {
+        let n = class.read_packet(&mut buf).await?;
+        let data = &buf[..n];
+        info!("data: {:x}", data);
+        class.write_packet(data).await?;
+    }
+}

--- a/examples/lpc55s69/src/bin/usb_hs_serial.rs
+++ b/examples/lpc55s69/src/bin/usb_hs_serial.rs
@@ -6,16 +6,14 @@
 #![no_std]
 #![no_main]
 
-use defmt::{info, panic};
+use defmt::info;
 use defmt_rtt as _;
 use embassy_executor::Spawner;
-use embassy_futures::join::join;
 use embassy_nxp::config::MainClock;
 use embassy_nxp::usb::{Driver, InterruptHandler, Memory};
 use embassy_nxp::{bind_interrupts, peripherals};
+use embassy_nxp_lpc55s69_examples::serial::{self, Params};
 use embassy_usb::UsbDeviceSpeed;
-use embassy_usb::class::cdc_acm::{CdcAcmClass, State};
-use embassy_usb::driver::EndpointError;
 use panic_probe as _;
 
 bind_interrupts!(struct Irqs {
@@ -25,88 +23,23 @@ bind_interrupts!(struct Irqs {
 #[embassy_executor::main]
 async fn main(_spawner: Spawner) {
     let mut config = embassy_nxp::config::Config::default();
-    // USB-HS requires a system clock of at least 96 MHz.
     config.main_clock = MainClock::FroHf96;
     let p = embassy_nxp::init(config);
-
     info!("Initialization complete");
 
-    // Create the driver, from the HAL.
+    let mut resources = serial::Resources::new();
     let driver = Driver::<peripherals::USBHSD>::new(p.USBHSD, Irqs, Memory::usb1_sram());
-
-    // Create embassy-usb Config
-    let mut config = embassy_usb::Config::new(0xc0de, 0xcafe);
-    config.manufacturer = Some("Embassy");
-    config.product = Some("USB-HS serial example");
-    config.serial_number = Some("12345678");
-    config.max_power = 100;
-    config.max_packet_size_0 = 64;
-    config.max_speed = UsbDeviceSpeed::High;
-
-    // Create embassy-usb DeviceBuilder using the driver and config.
-    // It needs some buffers for building the descriptors.
-    let mut config_descriptor = [0; 256];
-    let mut bos_descriptor = [0; 256];
-    let mut control_buf = [0; 64];
-
-    let mut state = State::new();
-
-    let mut builder = embassy_usb::Builder::new(
+    serial::run::<_, 512>(
         driver,
-        config,
-        &mut config_descriptor,
-        &mut bos_descriptor,
-        &mut [], // no msos descriptors
-        &mut control_buf,
-    );
-
-    // Create classes on the builder. 512-byte bulk max packet size for HS.
-    let mut class = CdcAcmClass::new(&mut builder, &mut state, 512);
-
-    // Build the builder.
-    let mut usb = builder.build();
-
-    // Run the USB device.
-    let usb_fut = usb.run();
-
-    // Do stuff with the class!
-    let echo_fut = async {
-        loop {
-            class.wait_connection().await;
-            info!("Connected");
-            let _ = echo(&mut class).await;
-            info!("Disconnected");
-        }
-    };
-
-    // Run everything concurrently.
-    join(usb_fut, echo_fut).await;
-}
-
-struct Disconnected {}
-
-impl From<EndpointError> for Disconnected {
-    fn from(val: EndpointError) -> Self {
-        match val {
-            EndpointError::BufferOverflow => panic!("Buffer overflow"),
-            EndpointError::Disabled => Disconnected {},
-        }
-    }
-}
-
-async fn echo<'d>(class: &mut CdcAcmClass<'d, Driver<'d, peripherals::USBHSD>>) -> Result<(), Disconnected> {
-    const MPS: usize = 512;
-    let mut buf = [0; MPS];
-    loop {
-        let n = class.read_packet(&mut buf).await?;
-        let data = &buf[..n];
-        info!("data: {:x}", data);
-        class.write_packet(data).await?;
-        // An echo of exactly one max-packet-size packet needs a zero-length
-        // packet to end the transfer: without it the host keeps waiting for
-        // more and never delivers the reply.
-        if n == MPS {
-            class.write_packet(&[]).await?;
-        }
-    }
+        &mut resources,
+        Params {
+            pid: 0xcafe,
+            product: "USB-HS serial example",
+            serial: "12345678",
+            max_speed: UsbDeviceSpeed::High,
+        },
+        "Connected",
+        "Disconnected",
+    )
+    .await;
 }

--- a/examples/lpc55s69/src/bin/usb_hs_serial.rs
+++ b/examples/lpc55s69/src/bin/usb_hs_serial.rs
@@ -11,7 +11,7 @@ use defmt_rtt as _;
 use embassy_executor::Spawner;
 use embassy_futures::join::join;
 use embassy_nxp::config::MainClock;
-use embassy_nxp::usb::{Driver, InterruptHandler};
+use embassy_nxp::usb::{Driver, InterruptHandler, Memory};
 use embassy_nxp::{bind_interrupts, peripherals};
 use embassy_usb::UsbDeviceSpeed;
 use embassy_usb::class::cdc_acm::{CdcAcmClass, State};
@@ -32,7 +32,7 @@ async fn main(_spawner: Spawner) {
     info!("Initialization complete");
 
     // Create the driver, from the HAL.
-    let driver = Driver::new(p.USBHSD, Irqs);
+    let driver = Driver::<peripherals::USBHSD>::new(p.USBHSD, Irqs, Memory::usb1_sram());
 
     // Create embassy-usb Config
     let mut config = embassy_usb::Config::new(0xc0de, 0xcafe);
@@ -95,11 +95,18 @@ impl From<EndpointError> for Disconnected {
 }
 
 async fn echo<'d>(class: &mut CdcAcmClass<'d, Driver<'d, peripherals::USBHSD>>) -> Result<(), Disconnected> {
-    let mut buf = [0; 512];
+    const MPS: usize = 512;
+    let mut buf = [0; MPS];
     loop {
         let n = class.read_packet(&mut buf).await?;
         let data = &buf[..n];
         info!("data: {:x}", data);
         class.write_packet(data).await?;
+        // An echo of exactly one max-packet-size packet needs a zero-length
+        // packet to end the transfer: without it the host keeps waiting for
+        // more and never delivers the reply.
+        if n == MPS {
+            class.write_packet(&[]).await?;
+        }
     }
 }

--- a/examples/lpc55s69/src/bin/usb_hs_throughput.rs
+++ b/examples/lpc55s69/src/bin/usb_hs_throughput.rs
@@ -19,7 +19,7 @@ use defmt_rtt as _;
 use embassy_executor::Spawner;
 use embassy_futures::join::join;
 use embassy_nxp::config::MainClock;
-use embassy_nxp::usb::{Driver, InterruptHandler};
+use embassy_nxp::usb::{Driver, InterruptHandler, Memory};
 use embassy_nxp::{bind_interrupts, peripherals};
 use embassy_usb::UsbDeviceSpeed;
 use embassy_usb::class::cdc_acm::{CdcAcmClass, State};
@@ -39,7 +39,7 @@ async fn main(_spawner: Spawner) {
 
     info!("Initialization complete");
 
-    let driver = Driver::new(p.USBHSD, Irqs);
+    let driver = Driver::<peripherals::USBHSD>::new(p.USBHSD, Irqs, Memory::usb1_sram());
 
     let mut config = embassy_usb::Config::new(0xc0de, 0xcafe);
     config.manufacturer = Some("Embassy");
@@ -94,12 +94,12 @@ impl From<EndpointError> for Disconnected {
 }
 
 async fn bench<'d>(class: &mut CdcAcmClass<'d, Driver<'d, peripherals::USBHSD>>) -> Result<(), Disconnected> {
-    // Chunk sizes match the driver's multi-packet bulk slots: IN slots are
-    // 3584 B (7 packets per command entry), OUT slots 4096 B (8 packets).
-    // Both are multiples of 512 so wire packets stay max-packet-sized and
-    // the host-visible 512-byte pattern ramp stays aligned.
+    // IN writes a whole 3584 B bulk slot per call (7 packets per command
+    // entry, hardware-packetized) and is a multiple of 512, so wire packets
+    // stay max-packet-sized and the host-visible ramp stays aligned. Reads
+    // return one packet at a time, so OUT only ever needs one packet of room.
     const IN_CHUNK: usize = 3584;
-    const OUT_CHUNK: usize = 4096;
+    const OUT_CHUNK: usize = 512;
 
     // Recognizable pattern so the host can spot-check payload integrity:
     // a 0..512 ramp repeating per 512-byte packet.
@@ -125,6 +125,13 @@ async fn bench<'d>(class: &mut CdcAcmClass<'d, Driver<'d, peripherals::USBHSD>>)
                     let chunk = remaining.min(IN_CHUNK);
                     class.write_packet(&tx[..chunk]).await?;
                     remaining -= chunk;
+                }
+                // A stream ending exactly on a max-packet-size boundary needs
+                // a zero-length packet to tell the host the transfer is over;
+                // without it the host waits for more and the last packet is
+                // never delivered.
+                if total % 512 == 0 {
+                    class.write_packet(&[]).await?;
                 }
             }
             b'O' => {

--- a/examples/lpc55s69/src/bin/usb_hs_throughput.rs
+++ b/examples/lpc55s69/src/bin/usb_hs_throughput.rs
@@ -1,0 +1,142 @@
+//! USB1 high-speed CDC-ACM throughput test firmware for the LPC55S6x.
+//!
+//! Command-driven benchmark peer for a host-side throughput script.
+//! The host sends a 5-byte header: a command byte followed by a u32 LE
+//! byte count.
+//!
+//! - `b'I'`: device sources (writes) exactly `count` bytes to the host.
+//! - `b'O'`: device sinks (reads) exactly `count` bytes, then replies
+//!   with the received count as a u32 LE ack.
+//!
+//! Any payload bytes that arrive in the same packet as an `b'O'` header
+//! count toward the sink total. No per-packet logging on the hot path.
+
+#![no_std]
+#![no_main]
+
+use defmt::{info, panic};
+use defmt_rtt as _;
+use embassy_executor::Spawner;
+use embassy_futures::join::join;
+use embassy_nxp::config::MainClock;
+use embassy_nxp::usb::{Driver, InterruptHandler};
+use embassy_nxp::{bind_interrupts, peripherals};
+use embassy_usb::UsbDeviceSpeed;
+use embassy_usb::class::cdc_acm::{CdcAcmClass, State};
+use embassy_usb::driver::EndpointError;
+use panic_probe as _;
+
+bind_interrupts!(struct Irqs {
+    USB1 => InterruptHandler<peripherals::USBHSD>;
+});
+
+#[embassy_executor::main]
+async fn main(_spawner: Spawner) {
+    let mut config = embassy_nxp::config::Config::default();
+    // USB-HS requires a system clock of at least 96 MHz.
+    config.main_clock = MainClock::FroHf96;
+    let p = embassy_nxp::init(config);
+
+    info!("Initialization complete");
+
+    let driver = Driver::new(p.USBHSD, Irqs);
+
+    let mut config = embassy_usb::Config::new(0xc0de, 0xcafe);
+    config.manufacturer = Some("Embassy");
+    config.product = Some("USB-HS throughput test");
+    config.serial_number = Some("12345678");
+    config.max_power = 100;
+    config.max_packet_size_0 = 64;
+    config.max_speed = UsbDeviceSpeed::High;
+
+    let mut config_descriptor = [0; 256];
+    let mut bos_descriptor = [0; 256];
+    let mut control_buf = [0; 64];
+
+    let mut state = State::new();
+
+    let mut builder = embassy_usb::Builder::new(
+        driver,
+        config,
+        &mut config_descriptor,
+        &mut bos_descriptor,
+        &mut [], // no msos descriptors
+        &mut control_buf,
+    );
+
+    // 512-byte bulk max packet size for HS.
+    let mut class = CdcAcmClass::new(&mut builder, &mut state, 512);
+
+    let mut usb = builder.build();
+    let usb_fut = usb.run();
+
+    let bench_fut = async {
+        loop {
+            class.wait_connection().await;
+            info!("Connected");
+            let _ = bench(&mut class).await;
+            info!("Disconnected");
+        }
+    };
+
+    join(usb_fut, bench_fut).await;
+}
+
+struct Disconnected {}
+
+impl From<EndpointError> for Disconnected {
+    fn from(val: EndpointError) -> Self {
+        match val {
+            EndpointError::BufferOverflow => panic!("Buffer overflow"),
+            EndpointError::Disabled => Disconnected {},
+        }
+    }
+}
+
+async fn bench<'d>(class: &mut CdcAcmClass<'d, Driver<'d, peripherals::USBHSD>>) -> Result<(), Disconnected> {
+    // Chunk sizes match the driver's multi-packet bulk slots: IN slots are
+    // 3584 B (7 packets per command entry), OUT slots 4096 B (8 packets).
+    // Both are multiples of 512 so wire packets stay max-packet-sized and
+    // the host-visible 512-byte pattern ramp stays aligned.
+    const IN_CHUNK: usize = 3584;
+    const OUT_CHUNK: usize = 4096;
+
+    // Recognizable pattern so the host can spot-check payload integrity:
+    // a 0..512 ramp repeating per 512-byte packet.
+    let mut tx = [0u8; IN_CHUNK];
+    for (i, b) in tx.iter_mut().enumerate() {
+        *b = (i % 512) as u8;
+    }
+    let mut buf = [0u8; OUT_CHUNK];
+
+    loop {
+        let n = class.read_packet(&mut buf).await?;
+        if n < 5 {
+            continue;
+        }
+        let cmd = buf[0];
+        let total = u32::from_le_bytes([buf[1], buf[2], buf[3], buf[4]]) as usize;
+
+        match cmd {
+            b'I' => {
+                info!("IN test: {} bytes", total);
+                let mut remaining = total;
+                while remaining > 0 {
+                    let chunk = remaining.min(IN_CHUNK);
+                    class.write_packet(&tx[..chunk]).await?;
+                    remaining -= chunk;
+                }
+            }
+            b'O' => {
+                info!("OUT test: {} bytes", total);
+                // Payload may share the header packet.
+                let mut received = n - 5;
+                while received < total {
+                    received += class.read_packet(&mut buf).await?;
+                }
+                class.write_packet(&(received as u32).to_le_bytes()).await?;
+            }
+            _ => info!("unknown command {}", cmd),
+        }
+    }
+}

--- a/examples/lpc55s69/src/bin/usb_hs_throughput.rs
+++ b/examples/lpc55s69/src/bin/usb_hs_throughput.rs
@@ -28,7 +28,6 @@ use embassy_usb::UsbDeviceSpeed;
 use embassy_usb::class::cdc_acm::{CdcAcmClass, State};
 use embassy_usb::driver::EndpointError;
 use panic_probe as _;
-
 use throughput::{Event, Parser};
 
 bind_interrupts!(struct Irqs {

--- a/examples/lpc55s69/src/bin/usb_hs_throughput.rs
+++ b/examples/lpc55s69/src/bin/usb_hs_throughput.rs
@@ -1,34 +1,26 @@
 //! USB1 high-speed CDC-ACM throughput test firmware for the LPC55S6x.
 //!
-//! Command-driven benchmark peer for a host-side throughput script.
-//! The host sends a 5-byte header: a command byte followed by a u32 LE
-//! byte count.
+//! Command-driven benchmark peer for the host throughput script. The host
+//! sends a 5-byte header: a command byte followed by a u32 LE byte count.
 //!
-//! - `b'I'`: device sources (writes) exactly `count` bytes to the host.
-//! - `b'O'`: device sinks (reads) exactly `count` bytes, then replies
-//!   with the received count as a u32 LE ack.
+//! - `b'I'`: device sources exactly `count` bytes to the host.
+//! - `b'O'`: device sinks exactly `count` bytes, then replies with the received
+//!   count as a u32 LE acknowledgement.
 //!
-//! Any payload bytes that arrive in the same packet as an `b'O'` header
-//! count toward the sink total. No per-packet logging on the hot path.
+//! Payload bytes in the same packet as an `b'O'` header count toward the total.
 
 #![no_std]
 #![no_main]
 
-#[path = "../throughput.rs"]
-mod throughput;
-
-use defmt::{info, panic};
+use defmt::info;
 use defmt_rtt as _;
 use embassy_executor::Spawner;
-use embassy_futures::join::join;
 use embassy_nxp::config::MainClock;
 use embassy_nxp::usb::{Driver, InterruptHandler, Memory};
 use embassy_nxp::{bind_interrupts, peripherals};
+use embassy_nxp_lpc55s69_examples::throughput_device::{self, Params};
 use embassy_usb::UsbDeviceSpeed;
-use embassy_usb::class::cdc_acm::{CdcAcmClass, State};
-use embassy_usb::driver::EndpointError;
 use panic_probe as _;
-use throughput::{Event, Parser};
 
 bind_interrupts!(struct Irqs {
     USB1 => InterruptHandler<peripherals::USBHSD>;
@@ -37,105 +29,21 @@ bind_interrupts!(struct Irqs {
 #[embassy_executor::main]
 async fn main(_spawner: Spawner) {
     let mut config = embassy_nxp::config::Config::default();
-    // USB-HS requires a system clock of at least 96 MHz.
     config.main_clock = MainClock::FroHf96;
     let p = embassy_nxp::init(config);
-
     info!("Initialization complete");
 
+    let mut resources = throughput_device::Resources::new();
     let driver = Driver::<peripherals::USBHSD>::new(p.USBHSD, Irqs, Memory::usb1_sram());
-
-    let mut config = embassy_usb::Config::new(0xc0de, 0xcafe);
-    config.manufacturer = Some("Embassy");
-    config.product = Some("USB-HS throughput test");
-    config.serial_number = Some("12345678");
-    config.max_power = 100;
-    config.max_packet_size_0 = 64;
-    config.max_speed = UsbDeviceSpeed::High;
-
-    let mut config_descriptor = [0; 256];
-    let mut bos_descriptor = [0; 256];
-    let mut control_buf = [0; 64];
-
-    let mut state = State::new();
-
-    let mut builder = embassy_usb::Builder::new(
+    throughput_device::run::<_, 512, 3584, 3584, 512>(
         driver,
-        config,
-        &mut config_descriptor,
-        &mut bos_descriptor,
-        &mut [], // no msos descriptors
-        &mut control_buf,
-    );
-
-    // 512-byte bulk max packet size for HS.
-    let mut class = CdcAcmClass::new(&mut builder, &mut state, 512);
-
-    let mut usb = builder.build();
-    let usb_fut = usb.run();
-
-    let bench_fut = async {
-        loop {
-            class.wait_connection().await;
-            info!("Connected");
-            let _ = bench(&mut class).await;
-            info!("Disconnected");
-        }
-    };
-
-    join(usb_fut, bench_fut).await;
-}
-
-struct Disconnected {}
-
-impl From<EndpointError> for Disconnected {
-    fn from(val: EndpointError) -> Self {
-        match val {
-            EndpointError::BufferOverflow => panic!("Buffer overflow"),
-            EndpointError::Disabled => Disconnected {},
-        }
-    }
-}
-
-async fn bench<'d>(class: &mut CdcAcmClass<'d, Driver<'d, peripherals::USBHSD>>) -> Result<(), Disconnected> {
-    const IN_CHUNK: usize = 3584;
-    const OUT_CHUNK: usize = 512;
-
-    let mut tx = [0u8; IN_CHUNK];
-    for (i, byte) in tx.iter_mut().enumerate() {
-        *byte = (i % 512) as u8;
-    }
-    let mut buf = [0u8; OUT_CHUNK];
-    let mut parser = Parser::new();
-
-    loop {
-        let len = class.read_packet(&mut buf).await?;
-        let mut offset = 0;
-
-        while offset < len {
-            let feed = parser.feed(&buf[offset..len]);
-            offset += feed.consumed;
-
-            match feed.event {
-                Some(Event::In(total)) => {
-                    info!("IN test: {} bytes", total);
-                    let mut remaining = total;
-                    while remaining > 0 {
-                        let chunk = remaining.min(IN_CHUNK as u32) as usize;
-                        class.write_packet(&tx[..chunk]).await?;
-                        remaining -= chunk as u32;
-                    }
-                    if total % OUT_CHUNK as u32 == 0 {
-                        class.write_packet(&[]).await?;
-                    }
-                }
-                Some(Event::OutStarted(total)) => info!("OUT test: {} bytes", total),
-                Some(Event::OutComplete(total)) => {
-                    class.write_packet(&total.to_le_bytes()).await?;
-                }
-                Some(Event::Unknown(command)) => info!("unknown command {}", command),
-                None => {}
-            }
-        }
-    }
+        &mut resources,
+        Params {
+            pid: 0xcafe,
+            product: "USB-HS throughput test",
+            serial: "12345678",
+            max_speed: UsbDeviceSpeed::High,
+        },
+    )
+    .await;
 }

--- a/examples/lpc55s69/src/bin/usb_hs_throughput.rs
+++ b/examples/lpc55s69/src/bin/usb_hs_throughput.rs
@@ -39,7 +39,7 @@ async fn main(_spawner: Spawner) {
         driver,
         &mut resources,
         Params {
-            pid: 0xcafe,
+            pid: 0xcb08,
             product: "USB-HS throughput test",
             serial: "12345678",
             max_speed: UsbDeviceSpeed::High,

--- a/examples/lpc55s69/src/bin/usb_hs_throughput.rs
+++ b/examples/lpc55s69/src/bin/usb_hs_throughput.rs
@@ -14,6 +14,9 @@
 #![no_std]
 #![no_main]
 
+#[path = "../throughput.rs"]
+mod throughput;
+
 use defmt::{info, panic};
 use defmt_rtt as _;
 use embassy_executor::Spawner;
@@ -25,6 +28,8 @@ use embassy_usb::UsbDeviceSpeed;
 use embassy_usb::class::cdc_acm::{CdcAcmClass, State};
 use embassy_usb::driver::EndpointError;
 use panic_probe as _;
+
+use throughput::{Event, Parser};
 
 bind_interrupts!(struct Irqs {
     USB1 => InterruptHandler<peripherals::USBHSD>;
@@ -94,56 +99,44 @@ impl From<EndpointError> for Disconnected {
 }
 
 async fn bench<'d>(class: &mut CdcAcmClass<'d, Driver<'d, peripherals::USBHSD>>) -> Result<(), Disconnected> {
-    // IN writes a whole 3584 B bulk slot per call (7 packets per command
-    // entry, hardware-packetized) and is a multiple of 512, so wire packets
-    // stay max-packet-sized and the host-visible ramp stays aligned. Reads
-    // return one packet at a time, so OUT only ever needs one packet of room.
     const IN_CHUNK: usize = 3584;
     const OUT_CHUNK: usize = 512;
 
-    // Recognizable pattern so the host can spot-check payload integrity:
-    // a 0..512 ramp repeating per 512-byte packet.
     let mut tx = [0u8; IN_CHUNK];
-    for (i, b) in tx.iter_mut().enumerate() {
-        *b = (i % 512) as u8;
+    for (i, byte) in tx.iter_mut().enumerate() {
+        *byte = (i % 512) as u8;
     }
     let mut buf = [0u8; OUT_CHUNK];
+    let mut parser = Parser::new();
 
     loop {
-        let n = class.read_packet(&mut buf).await?;
-        if n < 5 {
-            continue;
-        }
-        let cmd = buf[0];
-        let total = u32::from_le_bytes([buf[1], buf[2], buf[3], buf[4]]) as usize;
+        let len = class.read_packet(&mut buf).await?;
+        let mut offset = 0;
 
-        match cmd {
-            b'I' => {
-                info!("IN test: {} bytes", total);
-                let mut remaining = total;
-                while remaining > 0 {
-                    let chunk = remaining.min(IN_CHUNK);
-                    class.write_packet(&tx[..chunk]).await?;
-                    remaining -= chunk;
+        while offset < len {
+            let feed = parser.feed(&buf[offset..len]);
+            offset += feed.consumed;
+
+            match feed.event {
+                Some(Event::In(total)) => {
+                    info!("IN test: {} bytes", total);
+                    let mut remaining = total;
+                    while remaining > 0 {
+                        let chunk = remaining.min(IN_CHUNK as u32) as usize;
+                        class.write_packet(&tx[..chunk]).await?;
+                        remaining -= chunk as u32;
+                    }
+                    if total % OUT_CHUNK as u32 == 0 {
+                        class.write_packet(&[]).await?;
+                    }
                 }
-                // A stream ending exactly on a max-packet-size boundary needs
-                // a zero-length packet to tell the host the transfer is over;
-                // without it the host waits for more and the last packet is
-                // never delivered.
-                if total % 512 == 0 {
-                    class.write_packet(&[]).await?;
+                Some(Event::OutStarted(total)) => info!("OUT test: {} bytes", total),
+                Some(Event::OutComplete(total)) => {
+                    class.write_packet(&total.to_le_bytes()).await?;
                 }
+                Some(Event::Unknown(command)) => info!("unknown command {}", command),
+                None => {}
             }
-            b'O' => {
-                info!("OUT test: {} bytes", total);
-                // Payload may share the header packet.
-                let mut received = n - 5;
-                while received < total {
-                    received += class.read_packet(&mut buf).await?;
-                }
-                class.write_packet(&(received as u32).to_le_bytes()).await?;
-            }
-            _ => info!("unknown command {}", cmd),
         }
     }
 }

--- a/examples/lpc55s69/src/lib.rs
+++ b/examples/lpc55s69/src/lib.rs
@@ -3,10 +3,13 @@ use defmt::panic;
 use embassy_usb::UsbDeviceSpeed;
 use embassy_usb::class::cdc_acm::{CdcAcmClass, State};
 use embassy_usb::driver::{Driver, EndpointError};
+use embassy_usb::msos::{self, windows_version};
+use embassy_usb::types::InterfaceNumber;
 
 pub struct UsbResources<'d> {
     pub(crate) config_descriptor: [u8; 256],
     pub(crate) bos_descriptor: [u8; 256],
+    pub(crate) msos_descriptor: [u8; 256],
     pub(crate) control_buf: [u8; 64],
     pub(crate) state: State<'d>,
 }
@@ -16,6 +19,7 @@ impl<'d> UsbResources<'d> {
         Self {
             config_descriptor: [0; 256],
             bos_descriptor: [0; 256],
+            msos_descriptor: [0; 256],
             control_buf: [0; 64],
             state: State::new(),
         }
@@ -29,11 +33,40 @@ pub struct UsbParams {
     pub max_speed: UsbDeviceSpeed,
 }
 
+/// Identifies the throughput peers' data interface to WinUSB.
+const DEVICE_INTERFACE_GUIDS: &[&str] = &["{2F1B9A44-6C0E-4E1C-9C55-3B7A1D0E5F62}"];
+
+/// A plain CDC-ACM device: `usbser.sys` on Windows, `cdc_acm` on Linux.
 pub(crate) fn cdc<'d, D: Driver<'d>>(
     driver: D,
     resources: &'d mut UsbResources<'d>,
     params: UsbParams,
     mps: u16,
+) -> (embassy_usb::UsbDevice<'d, D>, CdcAcmClass<'d, D>) {
+    build(driver, resources, params, mps, false)
+}
+
+/// The same device, additionally advertising WinUSB compatibility.
+///
+/// Windows' CDC driver drops packets on a sustained high-speed bulk IN stream, so
+/// `scripts/usb_throughput.py` reads the endpoints through libusb there and needs Windows
+/// to bind WinUSB instead of `usbser.sys`. Linux ignores these descriptors and still binds
+/// `cdc_acm`, so the port stays a normal CDC node there.
+pub(crate) fn cdc_winusb<'d, D: Driver<'d>>(
+    driver: D,
+    resources: &'d mut UsbResources<'d>,
+    params: UsbParams,
+    mps: u16,
+) -> (embassy_usb::UsbDevice<'d, D>, CdcAcmClass<'d, D>) {
+    build(driver, resources, params, mps, true)
+}
+
+fn build<'d, D: Driver<'d>>(
+    driver: D,
+    resources: &'d mut UsbResources<'d>,
+    params: UsbParams,
+    mps: u16,
+    winusb: bool,
 ) -> (embassy_usb::UsbDevice<'d, D>, CdcAcmClass<'d, D>) {
     let mut config = embassy_usb::Config::new(0xc0de, params.pid);
     config.manufacturer = Some("Embassy");
@@ -47,10 +80,26 @@ pub(crate) fn cdc<'d, D: Driver<'d>>(
         config,
         &mut resources.config_descriptor,
         &mut resources.bos_descriptor,
-        &mut [],
+        &mut resources.msos_descriptor,
         &mut resources.control_buf,
     );
+    if winusb {
+        builder.msos_descriptor(windows_version::WIN8_1, 0x20);
+    }
     let class = CdcAcmClass::new(&mut builder, &mut resources.state, mps);
+    if winusb {
+        // CDC-ACM is a composite function, so `usbccgp` binds the function rather than the
+        // device: the compatible ID has to sit in a function subset naming the function's
+        // first interface. The class is already built, so the subset is written by hand.
+        let msos_writer = builder.msos_writer();
+        msos_writer.configuration(0);
+        msos_writer.function(InterfaceNumber(0));
+        msos_writer.function_feature(msos::CompatibleIdFeatureDescriptor::new("WINUSB", ""));
+        msos_writer.function_feature(msos::RegistryPropertyFeatureDescriptor::new(
+            "DeviceInterfaceGUIDs",
+            msos::PropertyData::RegMultiSz(DEVICE_INTERFACE_GUIDS),
+        ));
+    }
     (builder.build(), class)
 }
 

--- a/examples/lpc55s69/src/lib.rs
+++ b/examples/lpc55s69/src/lib.rs
@@ -1,0 +1,70 @@
+#![no_std]
+use defmt::panic;
+use embassy_usb::UsbDeviceSpeed;
+use embassy_usb::class::cdc_acm::{CdcAcmClass, State};
+use embassy_usb::driver::{Driver, EndpointError};
+
+pub struct UsbResources<'d> {
+    pub(crate) config_descriptor: [u8; 256],
+    pub(crate) bos_descriptor: [u8; 256],
+    pub(crate) control_buf: [u8; 64],
+    pub(crate) state: State<'d>,
+}
+
+impl<'d> UsbResources<'d> {
+    pub const fn new() -> Self {
+        Self {
+            config_descriptor: [0; 256],
+            bos_descriptor: [0; 256],
+            control_buf: [0; 64],
+            state: State::new(),
+        }
+    }
+}
+
+pub struct UsbParams {
+    pub pid: u16,
+    pub product: &'static str,
+    pub serial: &'static str,
+    pub max_speed: UsbDeviceSpeed,
+}
+
+pub(crate) fn cdc<'d, D: Driver<'d>>(
+    driver: D,
+    resources: &'d mut UsbResources<'d>,
+    params: UsbParams,
+    mps: u16,
+) -> (embassy_usb::UsbDevice<'d, D>, CdcAcmClass<'d, D>) {
+    let mut config = embassy_usb::Config::new(0xc0de, params.pid);
+    config.manufacturer = Some("Embassy");
+    config.product = Some(params.product);
+    config.serial_number = Some(params.serial);
+    config.max_power = 100;
+    config.max_packet_size_0 = 64;
+    config.max_speed = params.max_speed;
+    let mut builder = embassy_usb::Builder::new(
+        driver,
+        config,
+        &mut resources.config_descriptor,
+        &mut resources.bos_descriptor,
+        &mut [],
+        &mut resources.control_buf,
+    );
+    let class = CdcAcmClass::new(&mut builder, &mut resources.state, mps);
+    (builder.build(), class)
+}
+
+pub(crate) struct Disconnected;
+
+impl From<EndpointError> for Disconnected {
+    fn from(error: EndpointError) -> Self {
+        match error {
+            EndpointError::BufferOverflow => panic!("Buffer overflow"),
+            EndpointError::Disabled => Disconnected,
+        }
+    }
+}
+
+pub mod serial;
+pub mod throughput;
+pub mod throughput_device;

--- a/examples/lpc55s69/src/serial.rs
+++ b/examples/lpc55s69/src/serial.rs
@@ -1,0 +1,45 @@
+use defmt::info;
+use embassy_futures::join::join;
+use embassy_usb::class::cdc_acm::CdcAcmClass;
+use embassy_usb::driver::Driver;
+
+use crate::Disconnected;
+
+pub type Params = crate::UsbParams;
+
+pub type Resources<'d> = crate::UsbResources<'d>;
+
+pub async fn run<'d, D: Driver<'d>, const MPS: usize>(
+    driver: D,
+    resources: &'d mut Resources<'d>,
+    params: Params,
+    connected: &'static str,
+    disconnected: &'static str,
+) {
+    let (mut usb, mut class) = crate::cdc(driver, resources, params, MPS as u16);
+
+    let echo = async {
+        loop {
+            class.wait_connection().await;
+            info!("{}", connected);
+            let _ = echo::<D, MPS>(&mut class).await;
+            info!("{}", disconnected);
+        }
+    };
+
+    join(usb.run(), echo).await;
+}
+
+async fn echo<'d, D: Driver<'d>, const MPS: usize>(class: &mut CdcAcmClass<'d, D>) -> Result<(), Disconnected> {
+    let mut buf = [0; MPS];
+    loop {
+        let n = class.read_packet(&mut buf).await?;
+        let data = &buf[..n];
+        info!("data: {:x}", data);
+        class.write_packet(data).await?;
+        // A full packet needs a zero-length packet to terminate the transfer.
+        if n == MPS {
+            class.write_packet(&[]).await?;
+        }
+    }
+}

--- a/examples/lpc55s69/src/throughput.rs
+++ b/examples/lpc55s69/src/throughput.rs
@@ -1,0 +1,253 @@
+pub const HEADER_LEN: usize = 5;
+pub const CMD_IN: u8 = b'I';
+pub const CMD_OUT: u8 = b'O';
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum Event {
+    In(u32),
+    OutStarted(u32),
+    OutComplete(u32),
+    Unknown(u8),
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct Feed {
+    pub consumed: usize,
+    pub event: Option<Event>,
+}
+
+pub struct Parser {
+    header: [u8; HEADER_LEN],
+    header_len: usize,
+    out_remaining: u32,
+    out_total: u32,
+}
+
+impl Parser {
+    pub const fn new() -> Self {
+        Self {
+            header: [0; HEADER_LEN],
+            header_len: 0,
+            out_remaining: 0,
+            out_total: 0,
+        }
+    }
+
+    pub fn feed(&mut self, input: &[u8]) -> Feed {
+        if self.out_remaining != 0 {
+            let consumed = input.len().min(self.out_remaining as usize);
+            self.out_remaining -= consumed as u32;
+            let event = if self.out_remaining == 0 {
+                let total = self.out_total;
+                self.out_total = 0;
+                Some(Event::OutComplete(total))
+            } else {
+                None
+            };
+            return Feed { consumed, event };
+        }
+
+        let consumed = input.len().min(HEADER_LEN - self.header_len);
+        let end = self.header_len + consumed;
+        self.header[self.header_len..end].copy_from_slice(&input[..consumed]);
+        self.header_len = end;
+
+        if self.header_len != HEADER_LEN {
+            return Feed { consumed, event: None };
+        }
+
+        let command = self.header[0];
+        let count = u32::from_le_bytes([self.header[1], self.header[2], self.header[3], self.header[4]]);
+        self.header_len = 0;
+
+        let event = match command {
+            CMD_IN => Some(Event::In(count)),
+            CMD_OUT if count == 0 => Some(Event::OutComplete(0)),
+            CMD_OUT => {
+                self.out_remaining = count;
+                self.out_total = count;
+                Some(Event::OutStarted(count))
+            }
+            _ => Some(Event::Unknown(command)),
+        };
+
+        Feed { consumed, event }
+    }
+}
+
+impl Default for Parser {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn frame(command: u8, count: u32) -> [u8; HEADER_LEN] {
+        let count = count.to_le_bytes();
+        [command, count[0], count[1], count[2], count[3]]
+    }
+
+    #[test]
+    fn header_accepts_every_split_boundary() {
+        let input = frame(CMD_IN, 257);
+
+        for split_at in 1..HEADER_LEN {
+            let mut parser = Parser::new();
+            assert_eq!(
+                parser.feed(&input[..split_at]),
+                Feed {
+                    consumed: split_at,
+                    event: None,
+                }
+            );
+            assert_eq!(
+                parser.feed(&input[split_at..]),
+                Feed {
+                    consumed: HEADER_LEN - split_at,
+                    event: Some(Event::In(257)),
+                }
+            );
+        }
+    }
+
+    #[test]
+    fn header_accepts_five_single_byte_slices() {
+        let input = frame(CMD_IN, 17);
+        let mut parser = Parser::new();
+
+        for byte in &input[..HEADER_LEN - 1] {
+            assert_eq!(
+                parser.feed(core::slice::from_ref(byte)),
+                Feed {
+                    consumed: 1,
+                    event: None,
+                }
+            );
+        }
+        assert_eq!(
+            parser.feed(&input[HEADER_LEN - 1..]),
+            Feed {
+                consumed: 1,
+                event: Some(Event::In(17)),
+            }
+        );
+    }
+
+    #[test]
+    fn header_and_out_payload_share_one_slice() {
+        let input = [CMD_OUT, 3, 0, 0, 0, 0, 1, 2];
+        let mut parser = Parser::new();
+
+        let started = parser.feed(&input);
+        assert_eq!(
+            started,
+            Feed {
+                consumed: HEADER_LEN,
+                event: Some(Event::OutStarted(3)),
+            }
+        );
+        assert_eq!(
+            parser.feed(&input[started.consumed..]),
+            Feed {
+                consumed: 3,
+                event: Some(Event::OutComplete(3)),
+            }
+        );
+    }
+
+    #[test]
+    fn payload_completion_leaves_next_header_in_slice() {
+        let mut parser = Parser::new();
+        let out = frame(CMD_OUT, 2);
+        assert_eq!(parser.feed(&out).event, Some(Event::OutStarted(2)));
+
+        let input = [9, 10, CMD_IN, 17, 0, 0, 0];
+        let complete = parser.feed(&input);
+        assert_eq!(
+            complete,
+            Feed {
+                consumed: 2,
+                event: Some(Event::OutComplete(2)),
+            }
+        );
+        assert_eq!(
+            parser.feed(&input[complete.consumed..]),
+            Feed {
+                consumed: HEADER_LEN,
+                event: Some(Event::In(17)),
+            }
+        );
+    }
+
+    #[test]
+    fn zero_length_out_completes_with_its_header() {
+        let mut parser = Parser::new();
+
+        assert_eq!(
+            parser.feed(&frame(CMD_OUT, 0)),
+            Feed {
+                consumed: HEADER_LEN,
+                event: Some(Event::OutComplete(0)),
+            }
+        );
+    }
+
+    #[test]
+    fn unknown_command_consumes_frame_and_recovers() {
+        let input = [b'X', 0, 0, 0, 0, CMD_IN, 17, 0, 0, 0];
+        let mut parser = Parser::new();
+
+        let unknown = parser.feed(&input);
+        assert_eq!(
+            unknown,
+            Feed {
+                consumed: HEADER_LEN,
+                event: Some(Event::Unknown(b'X')),
+            }
+        );
+        assert_eq!(
+            parser.feed(&input[unknown.consumed..]),
+            Feed {
+                consumed: HEADER_LEN,
+                event: Some(Event::In(17)),
+            }
+        );
+    }
+
+    #[test]
+    fn reset_discards_a_fragmented_header() {
+        let mut parser = Parser::new();
+        assert_eq!(parser.feed(&[CMD_OUT, 9]).event, None);
+
+        parser = Parser::new();
+
+        assert_eq!(parser.feed(&frame(CMD_IN, 17)).event, Some(Event::In(17)));
+    }
+
+    #[test]
+    fn maximum_in_count_does_not_wrap() {
+        let mut parser = Parser::new();
+
+        assert_eq!(parser.feed(&frame(CMD_IN, u32::MAX)).event, Some(Event::In(u32::MAX)));
+    }
+
+    #[test]
+    fn maximum_out_count_does_not_wrap() {
+        let mut parser = Parser::new();
+
+        assert_eq!(
+            parser.feed(&frame(CMD_OUT, u32::MAX)).event,
+            Some(Event::OutStarted(u32::MAX))
+        );
+        assert_eq!(
+            parser.feed(&[0; 7]),
+            Feed {
+                consumed: 7,
+                event: None,
+            }
+        );
+    }
+}

--- a/examples/lpc55s69/src/throughput_device.rs
+++ b/examples/lpc55s69/src/throughput_device.rs
@@ -22,7 +22,7 @@ pub async fn run<
     resources: &'d mut Resources<'d>,
     params: Params,
 ) {
-    let (mut usb, mut class) = crate::cdc(driver, resources, params, MPS as u16);
+    let (mut usb, mut class) = crate::cdc_winusb(driver, resources, params, MPS as u16);
 
     let benchmark = async {
         loop {

--- a/examples/lpc55s69/src/throughput_device.rs
+++ b/examples/lpc55s69/src/throughput_device.rs
@@ -1,0 +1,85 @@
+use defmt::info;
+use embassy_futures::join::join;
+use embassy_usb::class::cdc_acm::CdcAcmClass;
+use embassy_usb::driver::Driver;
+
+use crate::Disconnected;
+use crate::throughput::{Event, Parser};
+
+pub type Params = crate::UsbParams;
+
+pub type Resources<'d> = crate::UsbResources<'d>;
+
+pub async fn run<
+    'd,
+    D: Driver<'d>,
+    const MPS: usize,
+    const TX_LEN: usize,
+    const IN_CHUNK: usize,
+    const OUT_CHUNK: usize,
+>(
+    driver: D,
+    resources: &'d mut Resources<'d>,
+    params: Params,
+) {
+    let (mut usb, mut class) = crate::cdc(driver, resources, params, MPS as u16);
+
+    let benchmark = async {
+        loop {
+            class.wait_connection().await;
+            info!("Connected");
+            let _ = bench::<D, MPS, TX_LEN, IN_CHUNK, OUT_CHUNK>(&mut class).await;
+            info!("Disconnected");
+        }
+    };
+
+    join(usb.run(), benchmark).await;
+}
+
+async fn bench<
+    'd,
+    D: Driver<'d>,
+    const MPS: usize,
+    const TX_LEN: usize,
+    const IN_CHUNK: usize,
+    const OUT_CHUNK: usize,
+>(
+    class: &mut CdcAcmClass<'d, D>,
+) -> Result<(), Disconnected> {
+    let mut tx = [0u8; TX_LEN];
+    for (index, byte) in tx.iter_mut().enumerate() {
+        *byte = index as u8;
+    }
+    let mut buf = [0u8; OUT_CHUNK];
+    let mut parser = Parser::new();
+
+    loop {
+        let len = class.read_packet(&mut buf).await?;
+        let mut offset = 0;
+        while offset < len {
+            let feed = parser.feed(&buf[offset..len]);
+            offset += feed.consumed;
+
+            match feed.event {
+                Some(Event::In(total)) => {
+                    info!("IN test: {} bytes", total);
+                    let mut remaining = total;
+                    let mut ramp_offset = 0;
+                    while remaining != 0 {
+                        let chunk = remaining.min(IN_CHUNK as u32).min((TX_LEN - ramp_offset) as u32) as usize;
+                        class.write_packet(&tx[ramp_offset..ramp_offset + chunk]).await?;
+                        ramp_offset = (ramp_offset + chunk) % TX_LEN;
+                        remaining -= chunk as u32;
+                    }
+                    if total % MPS as u32 == 0 {
+                        class.write_packet(&[]).await?;
+                    }
+                }
+                Some(Event::OutStarted(total)) => info!("OUT test: {} bytes", total),
+                Some(Event::OutComplete(total)) => class.write_packet(&total.to_le_bytes()).await?,
+                Some(Event::Unknown(command)) => info!("unknown command {}", command),
+                None => {}
+            }
+        }
+    }
+}

--- a/tests/lpc55/.cargo/config.toml
+++ b/tests/lpc55/.cargo/config.toml
@@ -1,0 +1,8 @@
+[target.'cfg(all(target_arch = "arm", target_os = "none"))']
+runner = "probe-rs run --chip LPC55S69JBD100"
+
+[build]
+target = "thumbv8m.main-none-eabihf"
+
+[env]
+DEFMT_LOG = "debug"

--- a/tests/lpc55/Cargo.toml
+++ b/tests/lpc55/Cargo.toml
@@ -21,3 +21,8 @@ panic-probe = { version = "1.0.0", features = ["print-defmt"] }
 
 [profile.release]
 debug = 2
+
+[package.metadata.embassy]
+build = [
+  { target = "thumbv8m.main-none-eabihf" }
+]

--- a/tests/lpc55/Cargo.toml
+++ b/tests/lpc55/Cargo.toml
@@ -12,6 +12,7 @@ embassy-executor = { version = "0.10.0", path = "../../embassy-executor", featur
 embassy-time = { version = "0.5.1", path = "../../embassy-time", features = ["defmt", "tick-hz-32_768"] }
 embassy-usb = { version = "0.6.0", path = "../../embassy-usb", features = ["defmt"] }
 embassy-futures = { version = "0.1.2", path = "../../embassy-futures" }
+embassy-sync = { version = "0.8.0", path = "../../embassy-sync", features = ["defmt"] }
 cortex-m = { version = "0.7.6", features = ["inline-asm", "critical-section-single-core"] }
 cortex-m-rt = { version = "0.7.0" }
 defmt = "1.0.1"

--- a/tests/lpc55/Cargo.toml
+++ b/tests/lpc55/Cargo.toml
@@ -1,0 +1,22 @@
+[package]
+edition = "2024"
+name = "embassy-nxp-lpc55-tests"
+version = "0.1.0"
+license = "MIT OR Apache-2.0"
+
+publish = false
+
+[dependencies]
+embassy-nxp = { version = "0.1.0", path = "../../embassy-nxp", features = ["lpc55-core0", "rt", "defmt", "time-driver-rtc", "unstable-pac"] }
+embassy-executor = { version = "0.10.0", path = "../../embassy-executor", features = ["platform-cortex-m", "executor-thread", "executor-interrupt"] }
+embassy-time = { version = "0.5.1", path = "../../embassy-time", features = ["defmt", "tick-hz-32_768"] }
+embassy-usb = { version = "0.6.0", path = "../../embassy-usb", features = ["defmt"] }
+embassy-futures = { version = "0.1.2", path = "../../embassy-futures" }
+cortex-m = { version = "0.7.6", features = ["inline-asm", "critical-section-single-core"] }
+cortex-m-rt = { version = "0.7.0" }
+defmt = "1.0.1"
+defmt-rtt = "1.0.0"
+panic-probe = { version = "1.0.0", features = ["print-defmt"] }
+
+[profile.release]
+debug = 2

--- a/tests/lpc55/README.md
+++ b/tests/lpc55/README.md
@@ -1,24 +1,24 @@
 # LPC55 USB HIL tests
 
-Hardware-in-the-loop tests for the `embassy-nxp` LPC55 USB device driver, run on an
+These hardware-in-the-loop tests cover the `embassy-nxp` LPC55 USB device driver on an
 LPCXpresso55S69 EVK (LPC55S69JBD100).
 
-Each firmware prints `Test OK` and halts on a breakpoint on success, and panics via `defmt` on
-failure. Tests that need a host peer print a fixed ready banner first and are driven by a
-script in [`host/`](host).
+Each firmware prints `Test OK` and stops at a breakpoint on success. On failure, it panics through
+`defmt`. A host-driven firmware first prints a fixed ready banner, then a script from
+[`host/`](host) runs its USB peer.
 
 ## Cabling
 
-- A debug probe on the SWD header must be connected to the host — `probe-rs` flashes and runs
-  over it. The onboard LPC-LINK2 (CMSIS-DAP) and an external probe such as a SEGGER J-Link both work.
-- **P10** (USB0, full speed): host cable required by every test except `alloc` and `bus_raw`.
-- **P9** (USB1, high speed): same.
-- `usb_alloc` and `usb_bus_raw` need no host cable at all: neither ever brings the bus up.
+- Connect a debug probe from the host to the SWD header. `probe-rs` flashes and runs through it.
+  The onboard LPC-LINK2 (CMSIS-DAP) and external probes such as the SEGGER J-Link both work.
+- Connect **P10** for USB0 full-speed tests and **P9** for USB1 high-speed tests.
+- The `alloc`, `alloc_small`, and `bus_raw` tests need no host cable. Their firmware never starts
+  either USB bus.
 
-A charge-only cable fails silently and looks like a driver bug: the board is powered, the
-firmware arms the bus, and the host sees nothing at all. Read `DEVCMDSTAT` over the probe to
-tell the two apart — `VBUS_DEBOUNCED=1` with `DCON=1` and `DEV_ADDR=0` means the device is
-attached and waiting, so the fault is in the cable or the port, not the firmware.
+A charge-only cable can look like a driver fault. It powers the board, the firmware arms the bus,
+and the host sees no device. Read `DEVCMDSTAT` through the probe to identify this fault.
+`VBUS_DEBOUNCED=1`, `DCON=1`, and `DEV_ADDR=0` mean that the device is attached and waiting.
+In that state, the cable or host port caused the fault.
 
 ## Running
 
@@ -29,11 +29,11 @@ python3 tests/lpc55/run.py --only hs_conformance
 python3 tests/lpc55/run.py --keep-going # do not stop at the first failure
 ```
 
-Run it **unprivileged**, so `cargo` and `probe-rs` keep the user's `~/.cargo` and target
-directory. The orchestrator elevates only the two conformance host scripts, which need raw USB
-access to a vendor interface, as `sudo -n <this interpreter> host/conformance.py …`. Passwordless
-`sudo` is therefore required for the conformance tests; everything else runs as the user
-(the CDC-based tests only need `/dev/ttyACM*`, which is `root:dialout`).
+Run the suite as an unprivileged user. This keeps `cargo` and `probe-rs` on the user's `~/.cargo`
+and target directories. The orchestrator uses `sudo` only for the two conformance entries:
+`sudo -n <this interpreter> host/conformance.py …`. They need raw USB access to the vendor
+interface, so passwordless `sudo` is required. All other entries run as the current user.
+The CDC tests need access to `/dev/ttyACM*`, which is normally owned by `root:dialout`.
 
 Individual firmwares still run standalone:
 
@@ -43,10 +43,11 @@ cd tests/lpc55 && cargo run --release --bin usb_alloc
 
 | Test | Firmware | Host peer | What it proves |
 |---|---|---|---|
-| `alloc` | `usb_alloc` | — | Max-packet-size caps per type, direction and instance, including the 1023-byte high-speed iso-IN cap from erratum USB.6; the multi-packet to single-packet slot fallback; endpoint-index exhaustion; control-endpoint rejection. Both controllers, no cable. |
-| `bus_raw` | `usb_bus_raw` | — | The `Bus` methods `embassy-usb` never calls: stall/unstall round-trip, iso endpoints never stalling, `disable` gating the clocks and powering down the PHY, a second `enable` taking the `reinit` path, and `force_reset`. Both controllers, no cable. |
-| `fs_enumerate` | `usb_fs_enumerate` | — | USB0 reaches `Configured` with a non-zero device address within 10 s under `Config::default()`, which proves the full-speed driver brings up its own 48 MHz clock. |
-| `hs_enumerate` | `usb_hs_enumerate` | — | The same for USB1 under `MainClock::FroHf96`, plus `DEVCMDSTAT.SPEED == 10b`, so a silent fallback to full speed on P9 fails instead of passing. |
+| `alloc` | `usb_alloc` | None | Max-packet-size caps per type, direction, and instance, including the 1023-byte high-speed iso-IN cap from erratum USB.6. It also covers multi-packet to single-packet slot fallback, endpoint-index exhaustion, and control-endpoint rejection. Both controllers, no cable. |
+| `alloc_small` | `usb_alloc_small` | None | EP0 stays reserved when exactly 512 bytes can hold only one double-buffered 64-byte data endpoint. USB0, no cable. |
+| `bus_raw` | `usb_bus_raw` | None | Covers `Bus` methods that `embassy-usb` does not call: stall/unstall round-trip, iso endpoints never stalling, `disable` clock and PHY gating, the second-`enable` `reinit` path, and `force_reset`. Both controllers, no cable. |
+| `fs_enumerate` | `usb_fs_enumerate` | None | USB0 reaches `Configured` with a non-zero device address within 10 s under `Config::default()`, which proves the full-speed driver brings up its own 48 MHz clock. |
+| `hs_enumerate` | `usb_hs_enumerate` | None | The same for USB1 under `MainClock::FroHf96`, plus `DEVCMDSTAT.SPEED == 10b`, so a silent fallback to full speed on P9 fails instead of passing. |
 | `dual_pll0` | `usb_dual_pll0` | `host/dual_echo.py` | Both controllers live at once under `MainClock::Pll0_150M`, high speed asserted on USB1, and a concurrent CDC-ACM echo on both ports driven from two host threads. |
 | `fs_conformance` | `usb_fs_conformance` | `host/conformance.py` | See below. Full speed. |
 | `hs_conformance` | `usb_hs_conformance` | `host/conformance.py` | See below. High speed. |
@@ -55,51 +56,53 @@ cd tests/lpc55 && cargo run --release --bin usb_alloc
 
 ## Conformance test
 
-`usb_{hs,fs}_conformance` expose one vendor interface with two alternate settings — alt 0 has
-bulk OUT, bulk IN and interrupt IN, alt 1 has isochronous OUT and IN — plus a vendor control
-protocol the host uses to set a mode, trigger single transfers and read back device-side
-counters. The firmware is one generic implementation in [`src/conformance.rs`](src/conformance.rs)
-parameterised per controller, so the two runs are directly comparable.
+`usb_{hs,fs}_conformance` expose one vendor interface with two alternate settings. Alt 0 has bulk
+OUT, bulk IN, and interrupt IN. Alt 1 has isochronous OUT and IN. The host uses a vendor control
+protocol to set modes, trigger transfers, and read device counters.
+
+Both controller binaries use the generic implementation in
+[`src/conformance.rs`](src/conformance.rs), so their results are directly comparable.
 
 `host/conformance.py` owns every host-observable expectation and runs these phases in order:
 
-1. **descriptors** — negotiated link speed from sysfs (480 or 12 Mbps), endpoint packet sizes,
-   two alternate settings on interface 0.
-2. **control_data** — vendor control echo at 0, 1, 63, 64, 65 and 200 bytes, covering the
-   multi-packet `ControlPipe::data_out` loop, the exact-EP0-packet boundary and a request with
+1. **descriptors**: negotiated link speed from sysfs (480 or 12 Mbps), endpoint packet sizes,
+   and two alternate settings on interface 0.
+2. **control_data**: vendor control echo at 0, 1, 63, 64, 65 and 200 bytes, covering the
+   multi-packet `ControlPipe::data_out` loop, the exact-EP0-packet boundary, and a request with
    no data stage.
-3. **control_reject** — an unsupported vendor request must STALL, and the next request must
-   succeed, proving `ControlPipe::setup` cleared the EP0 stall.
-4. **bulk_echo** — round-trip at 0, 1, 7, 8, 63, 64, 65, mps−1, mps, mps+1 and 3·mps bytes.
-   The odd lengths cover erratum USB.5 on high speed, the multiples of mps cover zero-length
-   packet termination, and 0 must round-trip a ZLP.
-5. **bulk_sink** — a sustained multi-packet OUT stream checked against a stream-offset ramp.
-6. **multi_packet_in** — a device-driven IN stream, which on high speed is one 3584-byte
-   hardware-packetized slot write plus a 512-byte one.
-7. **halt** — `SET_FEATURE(ENDPOINT_HALT)` on bulk IN with a reply already armed (the EPSKIP
-   reclaim path) and on bulk OUT with a read pending; `GET_STATUS` in both states; a transfer
-   that must STALL on the wire; `clear_halt`; and an exact echo afterwards, which is the
-   data-toggle-reset proof.
-8. **configuration_cycle** — `SET_CONFIGURATION(0)` must surface as `Disabled` to the endpoint
+3. **control_reject**: an unsupported vendor request must STALL. The next request must succeed
+   to prove that `ControlPipe::setup` cleared the EP0 stall.
+4. **bulk_echo**: round-trip at 0, 1, 7, 8, 63, 64, 65, mps−1, mps, mps+1 and 3·mps bytes.
+   The odd lengths cover erratum USB.5 on high speed. The mps multiples cover zero-length packet
+   termination, and 0 must round-trip a ZLP.
+5. **bulk_sink**: a sustained multi-packet OUT stream checked against a stream-offset ramp.
+6. **multi_packet_in**: a device-driven IN stream. At high speed, this uses one 3584-byte
+   hardware-packetized slot write followed by a 512-byte write.
+7. **halt**: `SET_FEATURE(ENDPOINT_HALT)` on bulk IN with a reply already armed (the EPSKIP
+   reclaim path), and on bulk OUT with a read pending. The phase checks `GET_STATUS` in both
+   states and requires a transfer to STALL on the wire. It then clears the halt and requires
+   an exact echo to prove that the data toggle reset.
+8. **configuration_cycle**: `SET_CONFIGURATION(0)` must surface as `Disabled` to the endpoint
    tasks, and `SET_CONFIGURATION(1)` must bring the endpoints back.
-9. **alt_and_iso** — switching to alt setting 1 must disable the bulk endpoints, `GET_INTERFACE`
-   must report 1, then 128 isochronous OUT packets and 128 isochronous IN packets each way with
-   an 80 % delivery floor and a per-packet payload check, then a return to alt 0 and an exact
-   bulk echo.
-10. **interrupt_in** — four triggered interrupt IN packets of 1, 8, 15 and 16 bytes.
+9. **alt_and_iso**: switching to alt setting 1 must disable the bulk endpoints, and
+   `GET_INTERFACE` must report 1. The host then transfers 128 isochronous OUT packets and 128
+   isochronous IN packets, with an 80 % delivery floor and a per-packet payload check. The phase
+   ends by returning to alt 0 and checking an exact bulk echo.
+10. **interrupt_in**: four triggered interrupt IN packets of 1, 8, 15 and 16 bytes.
 
-The device then checks what only it can see — no payload mismatches, no buffer overflows, at
-least two `Disabled` reports, traffic in both bulk directions, exactly four interrupt packets —
-and prints `Test OK`.
+The device then checks its private state: no payload mismatches, no buffer overflows, at least
+two `Disabled` reports, traffic in both bulk directions, and exactly four interrupt packets.
+It prints `Test OK` if all checks pass.
 
 Both host scripts and the firmware use the same ramp as
 `examples/lpc55s69/scripts/usb_throughput.py`: byte `k` of a payload is `(k % 512) as u8`.
 
-Full speed runs its isochronous endpoints at **512** bytes rather than the 1023-byte full-speed
-maximum. Two 1023-byte isochronous endpoints do not fit the 1 ms frame's 90 % periodic budget,
-and a 1023-byte full-speed isochronous IN through a high-speed hub's transaction translator only
-survives one packet per URB on a typical host — multi-packet URBs come back truncated. The
-1023-byte allocation boundary itself is covered by `usb_alloc` on both controllers.
+Full speed uses **512-byte** isochronous endpoints instead of the 1023-byte maximum. Two
+1023-byte isochronous endpoints exceed the 1 ms frame's 90 % periodic budget.
+
+A high-speed hub's transaction translator limits 1023-byte full-speed isochronous IN transfers
+to one packet per URB on a typical host. Multi-packet URBs return truncated data. `usb_alloc`
+covers the 1023-byte allocation boundary on both controllers.
 
 ## Throughput reference and gate
 
@@ -115,19 +118,19 @@ The gate is roughly 75 % of the measured figure, low enough to absorb host jitte
 enough to catch a real regression. `run.py` enforces it with the script's `--min-rate` option.
 
 FS is ~74 % of the 1.216 MB/s full-speed bulk ceiling (19 packets x 64 B per 1 ms frame).
-HS IN writes a whole 3584-byte bulk slot per call, which hardware packetizes; HS OUT reads one
-packet per call because [`EndpointOut::read`] owes its caller a single packet, so it pays a
+HS IN writes a whole 3584-byte bulk slot per call, which hardware packetizes. HS OUT reads one
+packet per call because [`EndpointOut::read`] owes its caller a single packet. This adds a
 per-packet turnaround.
 
-A `dev`-profile build measures roughly 0.3 MB/s in both directions on either controller. That
-is the unoptimized driver and class layer being CPU-bound, not the bus, and it is two orders of
-magnitude below the hardware — always measure with `--release`.
+A `dev`-profile build reaches roughly 0.3 MB/s in both directions on either controller. The
+unoptimized driver and class layer limit this rate, not the bus. This result is two orders of
+magnitude below the hardware rate, so always measure with `--release`.
 
 ## VBUS attach and detach
 
-`Event::PowerDetected` / `PowerRemoved` and the attach-armed soft-connect are not in `run.py` —
-no firmware can drop its own VBUS — so they are checked by hand. A hub with per-port power
-switching makes that repeatable without touching a cable:
+Manual checks cover `Event::PowerDetected`, `PowerRemoved`, and the attach-armed soft-connect.
+No firmware can remove its own VBUS. A hub with per-port power switching makes these checks
+repeatable without touching a cable:
 
 ```sh
 lsusb -t                                                  # locate the board, e.g. bus 1, hub 10, port 3
@@ -140,30 +143,28 @@ sudo sh -c "echo 0 > $port"    # VBUS on
 A hub without per-port power switching only disables the port and leaves VBUS up, which does
 not exercise this path at all.
 
-Checked on both controllers with `usb_fs_serial` (P10), `usb_hs_serial` (P9) and literal cable
+We checked both controllers with `usb_fs_serial` (P10), `usb_hs_serial` (P9), and literal cable
 pulls on `usb_dual`:
 
-- echo, VBUS drop, VBUS return, echo again — no reflash in between;
-- firmware started with the cable absent attaches when the cable arrives after `usb.run()` is
-  already polling;
-- a partial protocol header sent to `usb_{fs,hs}_throughput` does not survive the drop:
-  `usb_throughput.py --protocol-check` passes afterwards, because the bench loop builds a fresh
+- echo, VBUS drop, VBUS return, and echo again (no reflash in between).
+- firmware starts with the cable absent and attaches when the cable arrives after `usb.run()`
+  starts polling.
+- a partial protocol header sent to `usb_{fs,hs}_throughput` does not survive the drop.
+  `usb_throughput.py --protocol-check` passes afterwards because the bench loop builds a fresh
   `Parser` every time `wait_connection` returns.
 
-Pull one cable at a time. The board is powered from VBUS, so removing both cuts its supply and
-the firmware restarts instead of riding the disconnect out.
+Pull one cable at a time. VBUS powers the board, so removing both cables cuts its supply.
+The firmware then restarts instead of riding the disconnect out.
 
 ## Not covered
 
-- **Suspend and resume**, including the `enautoclr_phy_pwd` resume workaround. Needs the host to
-  suspend the bus on demand, which no unprivileged sysfs knob exposes reliably.
-- **Remote wakeup** (`Bus::remote_wakeup`). Only observable out of a host-driven suspend, so it
-  inherits the same blocker.
+- **Suspend and resume**, including the `enautoclr_phy_pwd` resume workaround. This needs the host
+  to suspend the bus on demand, which no unprivileged sysfs control exposes reliably.
+- **Remote wakeup** (`Bus::remote_wakeup`). It requires the same host-driven suspend.
 - **USBHSD rejecting a full-speed link.** The `USBHSD negotiated unsupported speed` panic needs
-  a full-speed-only USB 1.1 hub between P9 and the host. The source-level branch and the normal
-  high-speed P9 path are both retained; the panic itself is untested on hardware.
-- **`Memory::usb1_sram` double-take and the `Memory::buffer` size assert.** These
-  are panicking paths with no non-destructive assertion available; a test for them would have to
-  assert that the firmware panicked.
+  a full-speed-only USB 1.1 hub between P9 and the host. The driver retains the source branch and
+  the normal high-speed P9 path, but this panic remains untested on hardware.
+- **`Memory::usb1_sram` double-take and the `Memory::buffer` size assert.** These paths panic,
+  and no non-destructive assertion is available. A test would have to assert the firmware panic.
 
 [`EndpointOut::read`]: https://docs.rs/embassy-usb-driver/latest/embassy_usb_driver/trait.EndpointOut.html#tymethod.read

--- a/tests/lpc55/README.md
+++ b/tests/lpc55/README.md
@@ -3,35 +3,111 @@
 Hardware-in-the-loop tests for the `embassy-nxp` LPC55 USB device driver, run on an
 LPCXpresso55S69 EVK (LPC55S69JBD100).
 
+Each firmware prints `Test OK` and halts on a breakpoint on success, and panics via `defmt` on
+failure. Tests that need a host peer print a fixed ready banner first and are driven by a
+script in [`host/`](host).
+
 ## Cabling
 
 - The onboard SEGGER J-Link (debug header) must be connected to the host — `probe-rs` flashes
   and runs over it.
-- **P10** (USB0, full-speed): host cable required for `usb_fs_enumerate`.
-- **P9** (USB1, high-speed): host cable required for `usb_hs_enumerate`.
-- `usb_alloc` needs no host cable at all; it only exercises endpoint allocation.
-
-Each test prints `Test OK` and halts on a breakpoint on success, and panics via `defmt` on
-failure.
+- **P10** (USB0, full speed): host cable required by every test except `alloc` and `bus_raw`.
+- **P9** (USB1, high speed): same.
+- `usb_alloc` and `usb_bus_raw` need no host cable at all: neither ever brings the bus up.
 
 ## Running
 
 ```sh
-cargo run --bin usb_alloc          # no host cable
-cargo run --bin usb_fs_enumerate   # host cable on P10
-cargo run --bin usb_hs_enumerate   # host cable on P9
+python3 tests/lpc55/run.py              # the whole suite, ~2 minutes
+python3 tests/lpc55/run.py --list       # what it will run
+python3 tests/lpc55/run.py --only hs_conformance
+python3 tests/lpc55/run.py --keep-going # do not stop at the first failure
 ```
 
-## Throughput reference
+Run it **unprivileged**, so `cargo` and `probe-rs` keep the user's `~/.cargo` and target
+directory. The orchestrator elevates only the two conformance host scripts, which need raw USB
+access to a vendor interface, as `sudo -n <this interpreter> host/conformance.py …`. Passwordless
+`sudo` is therefore required for the conformance tests; everything else runs as the user
+(the CDC-based tests only need `/dev/ttyACM*`, which is `root:dialout`).
 
-Not part of this crate — `examples/lpc55s69` carries the benches — but recorded here because
-the numbers are easy to misread. Measured on an LPC55S69JBD100 with
-`scripts/usb_throughput.py`, CDC-ACM bulk, **release builds**:
+Individual firmwares still run standalone:
 
-| Controller | IN (device to host) | OUT (host to device) |
-|------------|---------------------|----------------------|
-| USB0 (FS)  | 0.90 MB/s           | 0.82 MB/s            |
-| USBHSD (HS)| 44.5 MB/s           | 17.5 MB/s            |
+```sh
+cd tests/lpc55 && cargo run --release --bin usb_alloc
+```
+
+| Test | Firmware | Host peer | What it proves |
+|---|---|---|---|
+| `alloc` | `usb_alloc` | — | Max-packet-size caps per type, direction and instance, including the 1023-byte high-speed iso-IN cap from erratum USB.6; the multi-packet to single-packet slot fallback; endpoint-index exhaustion; control-endpoint rejection. Both controllers, no cable. |
+| `bus_raw` | `usb_bus_raw` | — | The `Bus` methods `embassy-usb` never calls: stall/unstall round-trip, iso endpoints never stalling, `disable` gating the clocks and powering down the PHY, a second `enable` taking the `reinit` path, and `force_reset`. Both controllers, no cable. |
+| `fs_enumerate` | `usb_fs_enumerate` | — | USB0 reaches `Configured` with a non-zero device address within 10 s under `Config::default()`, which proves the full-speed driver brings up its own 48 MHz clock. |
+| `hs_enumerate` | `usb_hs_enumerate` | — | The same for USB1 under `MainClock::FroHf96`, plus `DEVCMDSTAT.SPEED == 10b`, so a silent fallback to full speed on P9 fails instead of passing. |
+| `dual_pll0` | `usb_dual_pll0` | `host/dual_echo.py` | Both controllers live at once under `MainClock::Pll0_150M`, high speed asserted on USB1, and a concurrent CDC-ACM echo on both ports driven from two host threads. |
+| `fs_conformance` | `usb_fs_conformance` | `host/conformance.py` | See below. Full speed. |
+| `hs_conformance` | `usb_hs_conformance` | `host/conformance.py` | See below. High speed. |
+| `fs_throughput` | `examples/lpc55s69` `usb_fs_throughput` | `scripts/usb_throughput.py` | CDC-ACM bulk throughput with a pass/fail floor, both directions. |
+| `hs_throughput` | `examples/lpc55s69` `usb_hs_throughput` | `scripts/usb_throughput.py` | The same at high speed. |
+
+## Conformance test
+
+`usb_{hs,fs}_conformance` expose one vendor interface with two alternate settings — alt 0 has
+bulk OUT, bulk IN and interrupt IN, alt 1 has isochronous OUT and IN — plus a vendor control
+protocol the host uses to set a mode, trigger single transfers and read back device-side
+counters. The firmware is one generic implementation in [`src/conformance.rs`](src/conformance.rs)
+parameterised per controller, so the two runs are directly comparable.
+
+`host/conformance.py` owns every host-observable expectation and runs these phases in order:
+
+1. **descriptors** — negotiated link speed from sysfs (480 or 12 Mbps), endpoint packet sizes,
+   two alternate settings on interface 0.
+2. **control_data** — vendor control echo at 0, 1, 63, 64, 65 and 200 bytes, covering the
+   multi-packet `ControlPipe::data_out` loop, the exact-EP0-packet boundary and a request with
+   no data stage.
+3. **control_reject** — an unsupported vendor request must STALL, and the next request must
+   succeed, proving `ControlPipe::setup` cleared the EP0 stall.
+4. **bulk_echo** — round-trip at 0, 1, 7, 8, 63, 64, 65, mps−1, mps, mps+1 and 3·mps bytes.
+   The odd lengths cover erratum USB.5 on high speed, the multiples of mps cover zero-length
+   packet termination, and 0 must round-trip a ZLP.
+5. **bulk_sink** — a sustained multi-packet OUT stream checked against a stream-offset ramp.
+6. **multi_packet_in** — a device-driven IN stream, which on high speed is one 3584-byte
+   hardware-packetized slot write plus a 512-byte one.
+7. **halt** — `SET_FEATURE(ENDPOINT_HALT)` on bulk IN with a reply already armed (the EPSKIP
+   reclaim path) and on bulk OUT with a read pending; `GET_STATUS` in both states; a transfer
+   that must STALL on the wire; `clear_halt`; and an exact echo afterwards, which is the
+   data-toggle-reset proof.
+8. **configuration_cycle** — `SET_CONFIGURATION(0)` must surface as `Disabled` to the endpoint
+   tasks, and `SET_CONFIGURATION(1)` must bring the endpoints back.
+9. **alt_and_iso** — switching to alt setting 1 must disable the bulk endpoints, `GET_INTERFACE`
+   must report 1, then 128 isochronous OUT packets and 128 isochronous IN packets each way with
+   an 80 % delivery floor and a per-packet payload check, then a return to alt 0 and an exact
+   bulk echo.
+10. **interrupt_in** — four triggered interrupt IN packets of 1, 8, 15 and 16 bytes.
+
+The device then checks what only it can see — no payload mismatches, no buffer overflows, at
+least two `Disabled` reports, traffic in both bulk directions, exactly four interrupt packets —
+and prints `Test OK`.
+
+Both host scripts and the firmware use the same ramp as
+`examples/lpc55s69/scripts/usb_throughput.py`: byte `k` of a payload is `(k % 512) as u8`.
+
+Full speed runs its isochronous endpoints at **512** bytes rather than the 1023-byte full-speed
+maximum. Two 1023-byte isochronous endpoints do not fit the 1 ms frame's 90 % periodic budget,
+and a 1023-byte full-speed isochronous IN through a high-speed hub's transaction translator only
+survives one packet per URB on a typical host — multi-packet URBs come back truncated. The
+1023-byte allocation boundary itself is covered by `usb_alloc` on both controllers.
+
+## Throughput reference and gate
+
+Measured on an LPC55S69JBD100 with `examples/lpc55s69/scripts/usb_throughput.py`, CDC-ACM bulk,
+**release builds**:
+
+| Controller | IN (device to host) | OUT (host to device) | Gate (IN / OUT) |
+|------------|---------------------|----------------------|-----------------|
+| USB0 (FS)  | 0.90 MB/s           | 0.82 MB/s            | 0.67 / 0.61     |
+| USBHSD (HS)| 44.5 MB/s           | 17.5 MB/s            | 33.0 / 13.0     |
+
+The gate is roughly 75 % of the measured figure, low enough to absorb host jitter and high
+enough to catch a real regression. `run.py` enforces it with the script's `--min-rate` option.
 
 FS is ~74 % of the 1.216 MB/s full-speed bulk ceiling (19 packets x 64 B per 1 ms frame).
 HS IN writes a whole 3584-byte bulk slot per call, which hardware packetizes; HS OUT reads one
@@ -41,5 +117,17 @@ per-packet turnaround.
 A `dev`-profile build measures roughly 0.3 MB/s in both directions on either controller. That
 is the unoptimized driver and class layer being CPU-bound, not the bus, and it is two orders of
 magnitude below the hardware — always measure with `--release`.
+
+## Not covered
+
+- **Suspend and resume**, including the `enautoclr_phy_pwd` resume workaround. Needs the host to
+  suspend the bus on demand, which no unprivileged sysfs knob exposes reliably.
+- **Remote wakeup** (`Bus::remote_wakeup`). Only observable out of a host-driven suspend, so it
+  inherits the same blocker.
+- **`Event::PowerDetected` / `PowerRemoved`**. Needs VBUS to physically drop, i.e. someone
+  unplugging P9 or P10 mid-run.
+- **`Memory::usb1_sram` double-take and the `Memory::buffer` size and alignment asserts.** These
+  are panicking paths with no non-destructive assertion available; a test for them would have to
+  assert that the firmware panicked.
 
 [`EndpointOut::read`]: https://docs.rs/embassy-usb-driver/latest/embassy_usb_driver/trait.EndpointOut.html#tymethod.read

--- a/tests/lpc55/README.md
+++ b/tests/lpc55/README.md
@@ -11,6 +11,10 @@ Each firmware prints `Test OK` and stops at a breakpoint on success. On failure,
 
 - Connect a debug probe from the host to the SWD header. `probe-rs` flashes and runs through it.
   The onboard LPC-LINK2 (CMSIS-DAP) and external probes such as the SEGGER J-Link both work.
+  On Windows, `probe-rs` opens the probe through WinUSB. The onboard LPC-LINK2 brings its own,
+  while a J-Link normally arrives bound to SEGGER's driver, which probe-rs refuses with
+  `incompatible driver is installed`. [Zadig](https://zadig.akeo.ie/) rebinds it to WinUSB,
+  after which SEGGER's own tools no longer see that probe.
 - Connect **P10** for USB0 full-speed tests and **P9** for USB1 high-speed tests.
 - The `alloc`, `alloc_small`, and `bus_raw` tests need no host cable. Their firmware never starts
   either USB bus.
@@ -29,11 +33,19 @@ python3 tests/lpc55/run.py --only hs_conformance
 python3 tests/lpc55/run.py --keep-going # do not stop at the first failure
 ```
 
+The orchestrator itself needs only the standard library. Every host peer declares its
+dependencies inline (PEP 723) and runs through `uv run --script`, so `uv` has to be on `PATH`
+and nothing else has to be installed.
+
 Run the suite as an unprivileged user. This keeps `cargo` and `probe-rs` on the user's `~/.cargo`
-and target directories. The orchestrator uses `sudo` only for the two conformance entries:
-`sudo -n <this interpreter> host/conformance.py …`. They need raw USB access to the vendor
-interface, so passwordless `sudo` is required. All other entries run as the current user.
-The CDC tests need access to `/dev/ttyACM*`, which is normally owned by `root:dialout`.
+and target directories.
+
+- **Linux**: the two conformance entries need raw USB access to a vendor interface, so those two
+  and only those run as `sudo -n <uv> run --script host/conformance.py …`, which means
+  passwordless `sudo` is required. The CDC tests need access to `/dev/ttyACM*`, normally owned by
+  `root:dialout`.
+- **Windows**: nothing is elevated. The conformance firmware advertises WinUSB, which Windows
+  binds by itself and an ordinary user can open.
 
 Individual firmwares still run standalone:
 
@@ -63,10 +75,18 @@ protocol to set modes, trigger transfers, and read device counters.
 Both controller binaries use the generic implementation in
 [`src/conformance.rs`](src/conformance.rs), so their results are directly comparable.
 
+The firmware also carries MS OS 2.0 descriptors advertising WinUSB compatibility. Windows binds
+no driver at all to a vendor interface on its own, so without them `libusb` cannot even open the
+device; Linux ignores them. One phase still cannot run there: WinUSB rejects `SET_CONFIGURATION`
+from user mode, because the hub driver owns the device configuration. `configuration_cycle`
+therefore prints `skipped: …` on Windows and runs normally on Linux. The device-side invariant it
+contributes to (`disabled_errors >= 2`) is satisfied by the halt and alt-setting phases anyway.
+
 `host/conformance.py` owns every host-observable expectation and runs these phases in order:
 
-1. **descriptors**: negotiated link speed from sysfs (480 or 12 Mbps), endpoint packet sizes,
-   and two alternate settings on interface 0.
+1. **descriptors**: negotiated link speed from `libusb_get_device_speed` (480 or 12 Mbps, the
+   one speed source Linux and Windows share), endpoint packet sizes, and two alternate settings
+   on interface 0.
 2. **control_data**: vendor control echo at 0, 1, 63, 64, 65 and 200 bytes, covering the
    multi-packet `ControlPipe::data_out` loop, the exact-EP0-packet boundary, and a request with
    no data stage.
@@ -83,11 +103,16 @@ Both controller binaries use the generic implementation in
    states and requires a transfer to STALL on the wire. It then clears the halt and requires
    an exact echo to prove that the data toggle reset.
 8. **configuration_cycle**: `SET_CONFIGURATION(0)` must surface as `Disabled` to the endpoint
-   tasks, and `SET_CONFIGURATION(1)` must bring the endpoints back.
+   tasks, and `SET_CONFIGURATION(1)` must bring the endpoints back. Linux only; see above.
 9. **alt_and_iso**: switching to alt setting 1 must disable the bulk endpoints, and
-   `GET_INTERFACE` must report 1. The host then transfers 128 isochronous OUT packets and 128
-   isochronous IN packets, with an 80 % delivery floor and a per-packet payload check. The phase
-   ends by returning to alt 0 and checking an exact bulk echo.
+   `GET_INTERFACE` must report 1. The host then streams 128 isochronous OUT packets and reads 128
+   isochronous IN packets, one transfer per direction, with an 80 % delivery floor and a
+   per-packet payload check. Submitting a transfer per packet instead measures the host's
+   isochronous scheduler rather than the driver: WinUSB restarts the pipe at every transfer
+   boundary, which both drops frames and replays buffered ones, so the device sees anywhere from
+   54 % to 180 % of them. One transfer is byte-exact on both controllers for every size from 1 to
+   128 packets, and 128 is also the most isochronous packets Linux accepts in a single URB. The
+   phase ends by returning to alt 0 and checking an exact bulk echo.
 10. **interrupt_in**: four triggered interrupt IN packets of 1, 8, 15 and 16 bytes.
 
 The device then checks its private state: no payload mismatches, no buffer overflows, at least
@@ -109,13 +134,16 @@ covers the 1023-byte allocation boundary on both controllers.
 Measured on an LPC55S69JBD100 with `examples/lpc55s69/scripts/usb_throughput.py`, CDC-ACM bulk,
 **release builds**:
 
-| Controller | IN (device to host) | OUT (host to device) | Gate (IN / OUT) |
-|------------|---------------------|----------------------|-----------------|
-| USB0 (FS)  | 0.90 MB/s           | 0.82 MB/s            | 0.67 / 0.61     |
-| USBHSD (HS)| 44.5 MB/s           | 17.5 MB/s            | 33.0 / 13.0     |
+| Controller | Host transport | IN (device to host) | OUT (host to device) | Gate (IN / OUT) |
+|------------|----------------|---------------------|----------------------|-----------------|
+| USB0 (FS)  | Linux `cdc_acm` | 0.90 MB/s | 0.82 MB/s | 0.67 / 0.61 |
+| USB0 (FS)  | Windows libusb  | 0.89 MB/s | 0.83 MB/s | 0.67 / 0.61 |
+| USBHSD (HS)| Linux `cdc_acm` | 44.5 MB/s | 17.5 MB/s | 33.0 / 13.0 |
+| USBHSD (HS)| Windows libusb  | 44.9 MB/s | 19.0 MB/s | 33.0 / 13.0 |
 
 The gate is roughly 75 % of the measured figure, low enough to absorb host jitter and high
-enough to catch a real regression. `run.py` enforces it with the script's `--min-rate` option.
+enough to catch a real regression. `run.py` enforces it with the script's `--min-rate` option,
+and both hosts clear the same numbers.
 
 FS is ~74 % of the 1.216 MB/s full-speed bulk ceiling (19 packets x 64 B per 1 ms frame).
 HS IN writes a whole 3584-byte bulk slot per call, which hardware packetizes. HS OUT reads one
@@ -126,7 +154,28 @@ A `dev`-profile build reaches roughly 0.3 MB/s in both directions on either cont
 unoptimized driver and class layer limit this rate, not the bus. This result is two orders of
 magnitude below the hardware rate, so always measure with `--release`.
 
-## VBUS attach and detach
+### Why the throughput firmwares are WinUSB devices
+
+`usb_fs_throughput` and `usb_hs_throughput` carry MS OS 2.0 descriptors too, so Windows binds
+WinUSB and the script drives their endpoints through `libusb` rather than a COM port. Linux
+ignores the descriptors and still binds `cdc_acm`, so the port stays an ordinary CDC node there.
+
+Windows' CDC driver cannot carry the high-speed stream. `usbser.sys` discards data that arrives
+while no read request is outstanding, which costs whole 512-byte packets: 512 to 4096 bytes per
+4 MB transfer, in roughly half of all attempts, through pyserial, through blocking reads on a
+dedicated reader thread, and at every read and receive-buffer size tried. Keeping several
+overlapped requests queued does stop the loss, but the same transfer then runs at 0.78 MB/s
+instead of 38. Reading the endpoints directly is both loss-free and faster.
+
+The driver is not at fault, and the same firmware shows it twice: read through libusb it
+delivered 25 consecutive 4 MB transfers without losing a byte, and in every failing CDC run its
+write loop had already handed over all 4,000,000 bytes and was serving the next command.
+
+These two binaries therefore carry their own product ids, `c0de:cb07` (FS) and `c0de:cb08` (HS),
+instead of sharing `c0de:cafe` with the serial examples: Windows caches its driver choice per id,
+so an id that has ever enumerated as a CDC port keeps `usbser.sys`.
+
+## VBUS attach and detach (checked on Linux)
 
 Manual checks cover `Event::PowerDetected`, `PowerRemoved`, and the attach-armed soft-connect.
 No firmware can remove its own VBUS. A hub with per-port power switching makes these checks
@@ -166,5 +215,7 @@ The firmware then restarts instead of riding the disconnect out.
   the normal high-speed P9 path, but this panic remains untested on hardware.
 - **`Memory::usb1_sram` double-take and the `Memory::buffer` size assert.** These paths panic,
   and no non-destructive assertion is available. A test would have to assert the firmware panic.
+- **`SET_CONFIGURATION` from the host on Windows.** WinUSB refuses the request, so
+  `configuration_cycle` runs on Linux only.
 
 [`EndpointOut::read`]: https://docs.rs/embassy-usb-driver/latest/embassy_usb_driver/trait.EndpointOut.html#tymethod.read

--- a/tests/lpc55/README.md
+++ b/tests/lpc55/README.md
@@ -9,8 +9,8 @@ script in [`host/`](host).
 
 ## Cabling
 
-- The onboard SEGGER J-Link (debug header) must be connected to the host — `probe-rs` flashes
-  and runs over it.
+- A debug probe on the SWD header must be connected to the host — `probe-rs` flashes and runs
+  over it. The onboard LPC-LINK2 (CMSIS-DAP) and an external probe such as a SEGGER J-Link both work.
 - **P10** (USB0, full speed): host cable required by every test except `alloc` and `bus_raw`.
 - **P9** (USB1, high speed): same.
 - `usb_alloc` and `usb_bus_raw` need no host cable at all: neither ever brings the bus up.

--- a/tests/lpc55/README.md
+++ b/tests/lpc55/README.md
@@ -15,6 +15,11 @@ script in [`host/`](host).
 - **P9** (USB1, high speed): same.
 - `usb_alloc` and `usb_bus_raw` need no host cable at all: neither ever brings the bus up.
 
+A charge-only cable fails silently and looks like a driver bug: the board is powered, the
+firmware arms the bus, and the host sees nothing at all. Read `DEVCMDSTAT` over the probe to
+tell the two apart — `VBUS_DEBOUNCED=1` with `DCON=1` and `DEV_ADDR=0` means the device is
+attached and waiting, so the fault is in the cable or the port, not the firmware.
+
 ## Running
 
 ```sh
@@ -118,14 +123,45 @@ A `dev`-profile build measures roughly 0.3 MB/s in both directions on either con
 is the unoptimized driver and class layer being CPU-bound, not the bus, and it is two orders of
 magnitude below the hardware — always measure with `--release`.
 
+## VBUS attach and detach
+
+`Event::PowerDetected` / `PowerRemoved` and the attach-armed soft-connect are not in `run.py` —
+no firmware can drop its own VBUS — so they are checked by hand. A hub with per-port power
+switching makes that repeatable without touching a cable:
+
+```sh
+lsusb -t                                                  # locate the board, e.g. bus 1, hub 10, port 3
+lsusb -v -d <hub-vid:pid> | grep -A2 wHubCharacteristic   # must say "Per-port power switching"
+port=/sys/bus/usb/devices/1-10:1.0/1-10-port3/disable
+sudo sh -c "echo 1 > $port"    # VBUS off
+sudo sh -c "echo 0 > $port"    # VBUS on
+```
+
+A hub without per-port power switching only disables the port and leaves VBUS up, which does
+not exercise this path at all.
+
+Checked on both controllers with `usb_fs_serial` (P10), `usb_hs_serial` (P9) and literal cable
+pulls on `usb_dual`:
+
+- echo, VBUS drop, VBUS return, echo again — no reflash in between;
+- firmware started with the cable absent attaches when the cable arrives after `usb.run()` is
+  already polling;
+- a partial protocol header sent to `usb_{fs,hs}_throughput` does not survive the drop:
+  `usb_throughput.py --protocol-check` passes afterwards, because the bench loop builds a fresh
+  `Parser` every time `wait_connection` returns.
+
+Pull one cable at a time. The board is powered from VBUS, so removing both cuts its supply and
+the firmware restarts instead of riding the disconnect out.
+
 ## Not covered
 
 - **Suspend and resume**, including the `enautoclr_phy_pwd` resume workaround. Needs the host to
   suspend the bus on demand, which no unprivileged sysfs knob exposes reliably.
 - **Remote wakeup** (`Bus::remote_wakeup`). Only observable out of a host-driven suspend, so it
   inherits the same blocker.
-- **`Event::PowerDetected` / `PowerRemoved`**. Needs VBUS to physically drop, i.e. someone
-  unplugging P9 or P10 mid-run.
+- **USBHSD rejecting a full-speed link.** The `USBHSD negotiated unsupported speed` panic needs
+  a full-speed-only USB 1.1 hub between P9 and the host. The source-level branch and the normal
+  high-speed P9 path are both retained; the panic itself is untested on hardware.
 - **`Memory::usb1_sram` double-take and the `Memory::buffer` size assert.** These
   are panicking paths with no non-destructive assertion available; a test for them would have to
   assert that the firmware panicked.

--- a/tests/lpc55/README.md
+++ b/tests/lpc55/README.md
@@ -1,0 +1,45 @@
+# LPC55 USB HIL tests
+
+Hardware-in-the-loop tests for the `embassy-nxp` LPC55 USB device driver, run on an
+LPCXpresso55S69 EVK (LPC55S69JBD100).
+
+## Cabling
+
+- The onboard SEGGER J-Link (debug header) must be connected to the host — `probe-rs` flashes
+  and runs over it.
+- **P10** (USB0, full-speed): host cable required for `usb_fs_enumerate`.
+- **P9** (USB1, high-speed): host cable required for `usb_hs_enumerate`.
+- `usb_alloc` needs no host cable at all; it only exercises endpoint allocation.
+
+Each test prints `Test OK` and halts on a breakpoint on success, and panics via `defmt` on
+failure.
+
+## Running
+
+```sh
+cargo run --bin usb_alloc          # no host cable
+cargo run --bin usb_fs_enumerate   # host cable on P10
+cargo run --bin usb_hs_enumerate   # host cable on P9
+```
+
+## Throughput reference
+
+Not part of this crate — `examples/lpc55s69` carries the benches — but recorded here because
+the numbers are easy to misread. Measured on an LPC55S69JBD100 with
+`scripts/usb_throughput.py`, CDC-ACM bulk, **release builds**:
+
+| Controller | IN (device to host) | OUT (host to device) |
+|------------|---------------------|----------------------|
+| USB0 (FS)  | 0.90 MB/s           | 0.82 MB/s            |
+| USBHSD (HS)| 44.5 MB/s           | 17.5 MB/s            |
+
+FS is ~74 % of the 1.216 MB/s full-speed bulk ceiling (19 packets x 64 B per 1 ms frame).
+HS IN writes a whole 3584-byte bulk slot per call, which hardware packetizes; HS OUT reads one
+packet per call because [`EndpointOut::read`] owes its caller a single packet, so it pays a
+per-packet turnaround.
+
+A `dev`-profile build measures roughly 0.3 MB/s in both directions on either controller. That
+is the unoptimized driver and class layer being CPU-bound, not the bus, and it is two orders of
+magnitude below the hardware — always measure with `--release`.
+
+[`EndpointOut::read`]: https://docs.rs/embassy-usb-driver/latest/embassy_usb_driver/trait.EndpointOut.html#tymethod.read

--- a/tests/lpc55/README.md
+++ b/tests/lpc55/README.md
@@ -126,7 +126,7 @@ magnitude below the hardware — always measure with `--release`.
   inherits the same blocker.
 - **`Event::PowerDetected` / `PowerRemoved`**. Needs VBUS to physically drop, i.e. someone
   unplugging P9 or P10 mid-run.
-- **`Memory::usb1_sram` double-take and the `Memory::buffer` size and alignment asserts.** These
+- **`Memory::usb1_sram` double-take and the `Memory::buffer` size assert.** These
   are panicking paths with no non-destructive assertion available; a test for them would have to
   assert that the firmware panicked.
 

--- a/tests/lpc55/build.rs
+++ b/tests/lpc55/build.rs
@@ -1,0 +1,35 @@
+//! This build script copies the `memory.x` file from the crate root into
+//! a directory where the linker can always find it at build time.
+//! For many projects this is optional, as the linker always searches the
+//! project root directory -- wherever `Cargo.toml` is. However, if you
+//! are using a workspace or have a more complicated build setup, this
+//! build script becomes required. Additionally, by requesting that
+//! Cargo re-run the build script whenever `memory.x` is changed,
+//! updating `memory.x` ensures a rebuild of the application with the
+//! new memory settings.
+
+use std::env;
+use std::fs::File;
+use std::io::Write;
+use std::path::PathBuf;
+
+fn main() {
+    // Put `memory.x` in our output directory and ensure it's
+    // on the linker search path.
+    let out = &PathBuf::from(env::var_os("OUT_DIR").unwrap());
+    File::create(out.join("memory.x"))
+        .unwrap()
+        .write_all(include_bytes!("memory.x"))
+        .unwrap();
+    println!("cargo:rustc-link-search={}", out.display());
+
+    // By default, Cargo will re-run a build script whenever
+    // any file in the project changes. By specifying `memory.x`
+    // here, we ensure the build script is only re-run when
+    // `memory.x` is changed.
+    println!("cargo:rerun-if-changed=memory.x");
+
+    println!("cargo:rustc-link-arg-bins=--nmagic");
+    println!("cargo:rustc-link-arg-bins=-Tlink.x");
+    println!("cargo:rustc-link-arg-bins=-Tdefmt.x");
+}

--- a/tests/lpc55/build.rs
+++ b/tests/lpc55/build.rs
@@ -1,6 +1,7 @@
 //! Makes `memory.x` available to the linker.
 
-use std::{env, fs, path::PathBuf};
+use std::path::PathBuf;
+use std::{env, fs};
 
 fn main() {
     let out = PathBuf::from(env::var_os("OUT_DIR").unwrap());

--- a/tests/lpc55/build.rs
+++ b/tests/lpc55/build.rs
@@ -1,32 +1,13 @@
-//! This build script copies the `memory.x` file from the crate root into
-//! a directory where the linker can always find it at build time.
-//! For many projects this is optional, as the linker always searches the
-//! project root directory -- wherever `Cargo.toml` is. However, if you
-//! are using a workspace or have a more complicated build setup, this
-//! build script becomes required. Additionally, by requesting that
-//! Cargo re-run the build script whenever `memory.x` is changed,
-//! updating `memory.x` ensures a rebuild of the application with the
-//! new memory settings.
+//! Makes `memory.x` available to the linker.
 
-use std::env;
-use std::fs::File;
-use std::io::Write;
-use std::path::PathBuf;
+use std::{env, fs, path::PathBuf};
 
 fn main() {
-    // Put `memory.x` in our output directory and ensure it's
-    // on the linker search path.
-    let out = &PathBuf::from(env::var_os("OUT_DIR").unwrap());
-    File::create(out.join("memory.x"))
-        .unwrap()
-        .write_all(include_bytes!("memory.x"))
-        .unwrap();
+    let out = PathBuf::from(env::var_os("OUT_DIR").unwrap());
+    fs::write(out.join("memory.x"), include_bytes!("memory.x")).unwrap();
     println!("cargo:rustc-link-search={}", out.display());
 
-    // By default, Cargo will re-run a build script whenever
-    // any file in the project changes. By specifying `memory.x`
-    // here, we ensure the build script is only re-run when
-    // `memory.x` is changed.
+    // Restrict build-script reruns to linker-script changes.
     println!("cargo:rerun-if-changed=memory.x");
 
     println!("cargo:rustc-link-arg-bins=--nmagic");

--- a/tests/lpc55/host/conformance.py
+++ b/tests/lpc55/host/conformance.py
@@ -1,9 +1,20 @@
-#!/usr/bin/env python3
+#!/usr/bin/env -S uv run --script
+# /// script
+# requires-python = ">=3.10"
+# dependencies = ["pyusb>=1.3", "libusb-package>=1.0.26"]
+# ///
 """Host driver for the LPC55 USB conformance firmware.
 
 Pairs with `tests/lpc55/src/conformance.rs` (bins `usb_hs_conformance` and
-`usb_fs_conformance`). Needs raw USB access, so it runs as root; the orchestrator
-(`tests/lpc55/run.py`) elevates only this script.
+`usb_fs_conformance`). Needs raw USB access to a vendor interface:
+
+- Linux: runs as root, and the orchestrator (`tests/lpc55/run.py`) elevates only
+  this script.
+- Windows: the firmware's MS OS 2.0 descriptors make Windows bind WinUSB, which
+  an unprivileged process can open. No elevation, no driver install.
+
+`libusb-package` supplies the libusb binary, so the same command works on either
+host without a system libusb.
 
 Every host-observable expectation lives here. The device only asserts the
 invariants it alone can see, once this script sends FINISH.
@@ -15,13 +26,12 @@ from __future__ import annotations
 
 import argparse
 from array import array
-import glob
-import os
 import struct
 import sys
 import time
 from typing import NamedTuple, NoReturn
 
+import libusb_package
 import usb.core
 import usb.util
 
@@ -66,7 +76,9 @@ EP_INT_IN = 0x82
 
 ERR_PIPE = 32  # EPIPE: the endpoint answered with a STALL handshake
 ERR_TIMEOUT = 110  # ETIMEDOUT: the endpoint NAKed until the deadline
-ISO_PACKET_TIMEOUT_MS = 100
+# The whole isochronous stream, not one packet: 128 packets take 128 ms at full speed and
+# 16 ms at high speed, so this leaves ample room without hanging the suite.
+ISO_STREAM_TIMEOUT_MS = 2000
 
 RAMP_PERIOD = 512
 # Byte k of any payload is `(k % 512) as u8` - the same ramp as
@@ -178,16 +190,26 @@ class Device:
         return int.from_bytes(bytes(raw), "little")
 
 
+# The bundled libusb: on Windows it also has to be the backend that opens the
+# WinUSB device, and on Linux it replaces a system libusb that may be absent.
+BACKEND = libusb_package.get_libusb1_backend()
+
+# `libusb_speed_t` to the link rate in Mbps, matching what Linux sysfs reports.
+LINK_SPEED_MBPS = {1: "1.5", 2: "12", 3: "480", 4: "5000"}
+
+
 def find_device(pid: int, budget: float) -> Device:
     """Waits for a device that is present *and* answers GET_REPORT.
 
     A previous test's firmware halted at a breakpoint stays enumerated but
-    unresponsive, so presence alone is not enough.
+    unresponsive, so presence alone is not enough. On Windows, a device that
+    Windows has not yet bound WinUSB to enumerates but cannot be opened, which
+    lands here as an open failure until the binding completes.
     """
     deadline = time.monotonic() + budget
     last = f"no device {VID:04x}:{pid:04x}"
     while time.monotonic() < deadline:
-        dev = usb.core.find(idVendor=VID, idProduct=pid)
+        dev = usb.core.find(idVendor=VID, idProduct=pid, backend=BACKEND)
         if dev is None:
             last = f"no device {VID:04x}:{pid:04x}"
         else:
@@ -195,29 +217,35 @@ def find_device(pid: int, budget: float) -> Device:
             try:
                 d.report()
                 return d
-            except (usb.core.USBError, Failure) as exc:
+            except (usb.core.USBError, NotImplementedError, Failure) as exc:
                 last = f"device present but GET_REPORT failed: {exc}"
                 usb.util.dispose_resources(dev)
         time.sleep(0.25)
     raise Failure(f"{last} (waited {budget:.0f} s)")
 
 
-def sysfs_speed(pid: int) -> str:
-    """The negotiated link speed in Mbps, as the kernel reports it."""
-    for vid_path in glob.glob("/sys/bus/usb/devices/*/idVendor"):
-        base = os.path.dirname(vid_path)
-        try:
-            with open(vid_path) as f:
-                if int(f.read().strip(), 16) != VID:
-                    continue
-            with open(os.path.join(base, "idProduct")) as f:
-                if int(f.read().strip(), 16) != pid:
-                    continue
-            with open(os.path.join(base, "speed")) as f:
-                return f.read().strip()
-        except (OSError, ValueError):
-            continue
-    raise Failure(f"no sysfs entry for {VID:04x}:{pid:04x}")
+def link_speed(dev: usb.core.Device) -> str:
+    """The negotiated link speed in Mbps.
+
+    `libusb_get_device_speed` is the only speed source both hosts share: pyusb
+    does not wrap it, and Linux sysfs has no Windows counterpart.
+    """
+    code = BACKEND.lib.libusb_get_device_speed(dev._ctx.dev.devid)
+    speed = LINK_SPEED_MBPS.get(code)
+    if speed is None:
+        raise Failure(f"libusb reports link speed code {code}, which is not a USB speed")
+    return speed
+
+
+# Phases the host stack cannot run, whatever the device does. WinUSB rejects
+# SET_CONFIGURATION from user mode: the hub driver owns the device configuration,
+# so `WinUsb_ControlTransfer` refuses the request and libusb reports it as
+# unsupported. Linux runs the phase and covers the driver path.
+UNSUPPORTED_PHASES = (
+    {"configuration_cycle": "WinUSB forbids SET_CONFIGURATION from user mode"}
+    if sys.platform == "win32"
+    else {}
+)
 
 
 # ------------------------------------------------------------------ phases
@@ -226,7 +254,7 @@ def sysfs_speed(pid: int) -> str:
 def phase_descriptors(d: Device, cfg: Config) -> tuple[int, int]:
     """Returns the isochronous OUT and IN endpoint addresses of alt setting 1."""
     want = "480" if cfg.speed == "hs" else "12"
-    got = sysfs_speed(cfg.pid)
+    got = link_speed(d.dev)
     require(got == want, f"negotiated {got} Mbps, expected {want} Mbps")
 
     conf = d.dev[0]
@@ -455,13 +483,21 @@ def phase_alt_and_iso(d: Device, cfg: Config, iso_out_addr: int, iso_in_addr: in
     before = d.report()
     d.set_mode(MODE_ISO_SINK)
     time.sleep(0.05)
-    packet = ramp(cfg.iso_out_mps)
-    for i in range(packet_count):
-        try:
-            written = d.dev.write(iso_out_addr, packet, 5000)
-        except usb.core.USBError as exc:
-            raise Failure(f"isochronous OUT packet {i} failed: {exc}") from exc
-        require(written == len(packet), f"isochronous OUT packet {i} wrote {written} of {len(packet)} bytes")
+    # One transfer carrying every packet. pyusb packetizes it at wMaxPacketSize, so the
+    # device still sees `packet_count` separate packets and its per-packet ramp check is
+    # unchanged. Submitting them as `packet_count` separate transfers instead measures the
+    # host's isochronous scheduler rather than the driver: WinUSB restarts the pipe at
+    # every transfer boundary, which both drops frames and replays already-buffered
+    # packets, so the device sees 54 % to 180 % of them. One transfer is byte-exact on
+    # both controllers for every size from 1 to 128 packets. 128 is also the most
+    # isochronous packets Linux accepts in a single URB, so the stream stays in one piece
+    # on either host.
+    stream = ramp(cfg.iso_out_mps * packet_count)
+    try:
+        written = d.dev.write(iso_out_addr, stream, 5000)
+    except usb.core.USBError as exc:
+        raise Failure(f"isochronous OUT stream failed: {exc}") from exc
+    require(written == len(stream), f"isochronous OUT wrote {written} of {len(stream)} bytes")
     time.sleep(0.2)
     rep = d.report()
     received_packets = rep.iso_out_packets - before.iso_out_packets
@@ -484,19 +520,28 @@ def phase_alt_and_iso(d: Device, cfg: Config, iso_out_addr: int, iso_in_addr: in
     before = d.report()
     d.set_mode(MODE_ISO_SOURCE)
     time.sleep(0.05)
+    # One transfer, for the same reason as the isochronous OUT stream above: a read per
+    # packet costs half the frames on Windows, and WinUSB reports a frame it missed as a
+    # full-length run of zeros instead of a timeout, so a per-packet read cannot even tell
+    # a dropped frame from a corrupt one.
+    expected = ramp(mps)
+    missing = bytes(mps)
     received_packets = 0
-    received_bytes = 0
-    for i in range(packet_count):
-        try:
-            data = bytes(d.dev.read(iso_in_addr, mps, ISO_PACKET_TIMEOUT_MS))
-        except usb.core.USBError as exc:
-            if exc.errno != ERR_TIMEOUT:
-                raise Failure(f"isochronous IN packet {i} failed: {exc}") from exc
-            continue
-        require(len(data) == mps, f"isochronous IN packet {i} has {len(data)} bytes, expected {mps}")
-        require(data == ramp(mps), f"isochronous IN packet {i} does not match the ramp")
-        received_packets += 1
-        received_bytes += len(data)
+    try:
+        data = bytes(d.dev.read(iso_in_addr, mps * packet_count, ISO_STREAM_TIMEOUT_MS))
+    except usb.core.USBError as exc:
+        if exc.errno != ERR_TIMEOUT:
+            raise Failure(f"isochronous IN stream failed: {exc}") from exc
+        data = b""
+    # libusb leaves every packet at its own `mps` stride and only truncates the tail, so
+    # the slices stay aligned even when a frame went missing.
+    for i in range(0, len(data) - mps + 1, mps):
+        packet = data[i : i + mps]
+        if packet == expected:
+            received_packets += 1
+        elif packet != missing:
+            raise Failure(f"isochronous IN packet {i // mps} does not match the ramp")
+    received_bytes = received_packets * mps
     rep = d.report()
     intended_bytes = packet_count * mps
     min_bytes = (intended_bytes * 4 + 4) // 5
@@ -613,6 +658,9 @@ def main() -> None:
             ("alt_and_iso", lambda: phase_alt_and_iso(d, cfg, iso_out_addr, iso_in_addr)),
             ("interrupt_in", lambda: phase_interrupt_in(d)),
         ):
+            if phase in UNSUPPORTED_PHASES:
+                print(f"[{phase}] skipped: {UNSUPPORTED_PHASES[phase]}")
+                continue
             fn()
             print(f"[{phase}] ok")
 

--- a/tests/lpc55/host/conformance.py
+++ b/tests/lpc55/host/conformance.py
@@ -65,6 +65,7 @@ EP_INT_IN = 0x82
 
 ERR_PIPE = 32  # EPIPE: the endpoint answered with a STALL handshake
 ERR_TIMEOUT = 110  # ETIMEDOUT: the endpoint NAKed until the deadline
+ISO_PACKET_TIMEOUT_MS = 100
 
 RAMP_PERIOD = 512
 # Byte k of any payload is `(k % 512) as u8` - the same ramp as
@@ -464,56 +465,71 @@ def phase_alt_and_iso(d: Device, cfg: Config, iso_out_addr: int, iso_in_addr: in
     raw = d.dev.ctrl_transfer(STD_IN_INTERFACE, REQ_GET_INTERFACE, 0, 0, 1, 2000)
     require(raw[0] == 1, f"GET_INTERFACE returned {raw[0]}, expected 1")
 
-    batches, per_batch = 4, 32
+    packet_count = 128
+    min_packets = (packet_count * 4 + 4) // 5
 
     # --- isochronous OUT ---
     before = d.report()
     d.set_mode(MODE_ISO_SINK)
     time.sleep(0.05)
     packet = ramp(cfg.iso_out_mps)
-    for _ in range(batches):
+    for i in range(packet_count):
         try:
-            d.dev.write(iso_out_addr, packet * per_batch, 5000)
+            written = d.dev.write(iso_out_addr, packet, 5000)
         except usb.core.USBError as exc:
-            raise Failure(f"isochronous OUT write failed: {exc}") from exc
+            raise Failure(f"isochronous OUT packet {i} failed: {exc}") from exc
+        require(written == len(packet), f"isochronous OUT packet {i} wrote {written} of {len(packet)} bytes")
     time.sleep(0.2)
     rep = d.report()
-    sent = batches * per_batch
-    received = rep.iso_out_packets - before.iso_out_packets
+    received_packets = rep.iso_out_packets - before.iso_out_packets
+    intended_bytes = packet_count * cfg.iso_out_mps
+    received_bytes = rep.iso_out_bytes - before.iso_out_bytes
+    min_bytes = (intended_bytes * 4 + 4) // 5
     require(
-        received >= sent * 8 // 10,
-        f"device saw {received} of {sent} isochronous OUT packets (under 80 %)",
+        received_packets >= min_packets,
+        f"device saw {received_packets} of {packet_count} isochronous OUT packets (under 80 %)",
     )
-    require(rep.ramp_mismatches == 0, f"{rep.ramp_mismatches} isochronous OUT ramp mismatches")
+    require(
+        received_bytes >= min_bytes,
+        f"device saw {received_bytes} of {intended_bytes} isochronous OUT bytes (under 80 %)",
+    )
+    mismatches = rep.ramp_mismatches - before.ramp_mismatches
+    require(mismatches == 0, f"{mismatches} isochronous OUT ramp mismatches")
 
     # --- isochronous IN ---
     mps = cfg.iso_in_mps
+    before = d.report()
     d.set_mode(MODE_ISO_SOURCE)
     time.sleep(0.05)
-    total = 0
-    for _ in range(batches):
+    received_packets = 0
+    received_bytes = 0
+    for i in range(packet_count):
         try:
-            data = bytes(d.dev.read(iso_in_addr, per_batch * mps, 5000))
+            data = bytes(d.dev.read(iso_in_addr, mps, ISO_PACKET_TIMEOUT_MS))
         except usb.core.USBError as exc:
-            # A whole batch timing out is tolerated and counted as zero bytes;
-            # the aggregate threshold below is what decides the verdict.
             if exc.errno != ERR_TIMEOUT:
-                raise Failure(f"isochronous IN read failed: {exc}") from exc
+                raise Failure(f"isochronous IN packet {i} failed: {exc}") from exc
             continue
-        total += len(data)
-        # libusb lays isochronous packets out at their *nominal* stride but only
-        # reports the summed actual length, so one short packet desynchronises
-        # every later offset. Packet 0 always starts at 0; when the whole batch
-        # came back full, every stride is meaningful.
-        full = len(data) // mps if len(data) == per_batch * mps else min(1, len(data) // mps)
-        for i in range(full):
-            off = i * mps
-            require(
-                data[off : off + mps] == ramp(mps),
-                f"isochronous IN packet {i} does not match the ramp",
-            )
-    want = batches * per_batch * mps
-    require(total >= want * 8 // 10, f"read {total} of {want} isochronous IN bytes (under 80 %)")
+        require(len(data) == mps, f"isochronous IN packet {i} has {len(data)} bytes, expected {mps}")
+        require(data == ramp(mps), f"isochronous IN packet {i} does not match the ramp")
+        received_packets += 1
+        received_bytes += len(data)
+    rep = d.report()
+    intended_bytes = packet_count * mps
+    min_bytes = (intended_bytes * 4 + 4) // 5
+    device_packets = rep.iso_in_packets - before.iso_in_packets
+    require(
+        received_packets >= min_packets,
+        f"host saw {received_packets} of {packet_count} isochronous IN packets (under 80 %)",
+    )
+    require(
+        received_bytes >= min_bytes,
+        f"host saw {received_bytes} of {intended_bytes} isochronous IN bytes (under 80 %)",
+    )
+    require(
+        device_packets >= min_packets,
+        f"device sent {device_packets} of {packet_count} isochronous IN packets (under 80 %)",
+    )
 
     d.set_mode(MODE_IDLE)
     d.dev.set_interface_altsetting(interface=0, alternate_setting=0)

--- a/tests/lpc55/host/conformance.py
+++ b/tests/lpc55/host/conformance.py
@@ -17,6 +17,7 @@ import argparse
 from array import array
 import glob
 import os
+import struct
 import sys
 import time
 from typing import NamedTuple, NoReturn
@@ -73,7 +74,7 @@ RAMP_PERIOD = 512
 _RAMP = bytes((k % RAMP_PERIOD) & 0xFF for k in range(RAMP_PERIOD))
 
 
-REPORT_LEN = 30
+REPORT = struct.Struct("<IIIIIHHHHH")
 
 
 class Report(NamedTuple):
@@ -126,27 +127,9 @@ class Device:
         return bytes(self.dev.ctrl_transfer(VENDOR_IN, request, w_value, 0, length, 5000))
 
     def report(self) -> Report:
-        raw = self.ctrl_in(GET_REPORT, REPORT_LEN)
-        require(len(raw) == REPORT_LEN, f"GET_REPORT returned {len(raw)} bytes")
-
-        def u32(o: int) -> int:
-            return int.from_bytes(raw[o : o + 4], "little")
-
-        def u16(o: int) -> int:
-            return int.from_bytes(raw[o : o + 2], "little")
-
-        return Report(
-            bulk_out_bytes=u32(0),
-            bulk_in_bytes=u32(4),
-            iso_out_bytes=u32(8),
-            disabled_errors=u32(12),
-            overflow_errors=u32(16),
-            iso_out_packets=u16(20),
-            iso_in_packets=u16(22),
-            int_in_packets=u16(24),
-            ramp_mismatches=u16(26),
-            zlp_out_count=u16(28),
-        )
+        raw = self.ctrl_in(GET_REPORT, REPORT.size)
+        require(len(raw) == REPORT.size, f"GET_REPORT returned {len(raw)} bytes")
+        return Report(*REPORT.unpack(raw))
 
     def set_mode(self, mode: int, param: int = 0) -> None:
         self.ctrl_out(SET_MODE, 0, bytes([mode, 0, param & 0xFF, (param >> 8) & 0xFF]))

--- a/tests/lpc55/host/conformance.py
+++ b/tests/lpc55/host/conformance.py
@@ -1,0 +1,638 @@
+#!/usr/bin/env python3
+"""Host driver for the LPC55 USB conformance firmware.
+
+Pairs with `tests/lpc55/src/conformance.rs` (bins `usb_hs_conformance` and
+`usb_fs_conformance`). Needs raw USB access, so it runs as root; the orchestrator
+(`tests/lpc55/run.py`) elevates only this script.
+
+Every host-observable expectation lives here. The device only asserts the
+invariants it alone can see, once this script sends FINISH.
+
+Exit 0 on pass. On failure, print `FAIL: <phase>: <detail>` to stderr, exit 1.
+"""
+
+from __future__ import annotations
+
+import argparse
+from array import array
+import glob
+import os
+import sys
+import time
+from typing import NamedTuple, NoReturn
+
+import usb.core
+import usb.util
+
+VID = 0xC0DE
+
+# Vendor requests. Recipient is always interface, wIndex always 0.
+SET_MODE = 0x01
+GET_REPORT = 0x02
+ECHO_WRITE = 0x03
+ECHO_READ = 0x04
+TRIGGER_INT = 0x05
+FINISH = 0x06
+UNSUPPORTED = 0x07
+RESET = 0x08
+
+VENDOR_OUT = 0x41  # bmRequestType: host-to-device, vendor, interface
+VENDOR_IN = 0xC1  # bmRequestType: device-to-host, vendor, interface
+
+# Modes, matching `conformance::Mode`.
+MODE_IDLE = 0
+MODE_ECHO = 1
+MODE_SINK = 2
+MODE_SOURCE = 3
+MODE_ISO_SINK = 4
+MODE_ISO_SOURCE = 5
+
+# Standard requests, issued raw where the point is to bypass the kernel's own
+# endpoint bookkeeping.
+STD_OUT_ENDPOINT = 0x02
+STD_IN_ENDPOINT = 0x82
+STD_OUT_DEVICE = 0x00
+STD_IN_INTERFACE = 0x81
+REQ_GET_STATUS = 0x00
+REQ_SET_FEATURE = 0x03
+REQ_GET_INTERFACE = 0x0A
+REQ_SET_CONFIGURATION = 0x09
+FEATURE_ENDPOINT_HALT = 0x00
+
+EP_BULK_OUT = 0x01
+EP_BULK_IN = 0x81
+EP_INT_IN = 0x82
+
+ERR_PIPE = 32  # EPIPE: the endpoint answered with a STALL handshake
+ERR_TIMEOUT = 110  # ETIMEDOUT: the endpoint NAKed until the deadline
+
+RAMP_PERIOD = 512
+# Byte k of any payload is `(k % 512) as u8` - the same ramp as
+# `examples/lpc55s69/scripts/usb_throughput.py` and `conformance::ramp_byte`.
+_RAMP = bytes((k % RAMP_PERIOD) & 0xFF for k in range(RAMP_PERIOD))
+
+
+REPORT_LEN = 30
+
+
+class Report(NamedTuple):
+    """The GET_REPORT payload, in wire order (see `conformance::REPORT_LEN`)."""
+
+    bulk_out_bytes: int
+    bulk_in_bytes: int
+    iso_out_bytes: int
+    disabled_errors: int
+    overflow_errors: int
+    iso_out_packets: int
+    iso_in_packets: int
+    int_in_packets: int
+    ramp_mismatches: int
+    zlp_out_count: int
+
+
+class Failure(Exception):
+    """A phase failed. The message is already human-readable."""
+
+
+def ramp(n: int, offset: int = 0) -> bytes:
+    """`n` payload bytes starting at stream offset `offset`."""
+    if n == 0:
+        return b""
+    start = offset % RAMP_PERIOD
+    return (_RAMP * ((start + n) // RAMP_PERIOD + 1))[start : start + n]
+
+
+def fail(phase: str, detail: str) -> NoReturn:
+    print(f"FAIL: {phase}: {detail}", file=sys.stderr)
+    sys.exit(1)
+
+
+def require(cond: bool, detail: str) -> None:
+    if not cond:
+        raise Failure(detail)
+
+
+class Device:
+    """The conformance device plus its vendor-protocol helpers."""
+
+    def __init__(self, dev: usb.core.Device) -> None:
+        self.dev = dev
+
+    def ctrl_out(self, request: int, w_value: int = 0, data: bytes = b"") -> None:
+        self.dev.ctrl_transfer(VENDOR_OUT, request, w_value, 0, data, 5000)
+
+    def ctrl_in(self, request: int, length: int, w_value: int = 0) -> bytes:
+        return bytes(self.dev.ctrl_transfer(VENDOR_IN, request, w_value, 0, length, 5000))
+
+    def report(self) -> Report:
+        raw = self.ctrl_in(GET_REPORT, REPORT_LEN)
+        require(len(raw) == REPORT_LEN, f"GET_REPORT returned {len(raw)} bytes")
+
+        def u32(o: int) -> int:
+            return int.from_bytes(raw[o : o + 4], "little")
+
+        def u16(o: int) -> int:
+            return int.from_bytes(raw[o : o + 2], "little")
+
+        return Report(
+            bulk_out_bytes=u32(0),
+            bulk_in_bytes=u32(4),
+            iso_out_bytes=u32(8),
+            disabled_errors=u32(12),
+            overflow_errors=u32(16),
+            iso_out_packets=u16(20),
+            iso_in_packets=u16(22),
+            int_in_packets=u16(24),
+            ramp_mismatches=u16(26),
+            zlp_out_count=u16(28),
+        )
+
+    def set_mode(self, mode: int, param: int = 0) -> None:
+        self.ctrl_out(SET_MODE, 0, bytes([mode, 0, param & 0xFF, (param >> 8) & 0xFF]))
+
+    def write_bulk(self, data: bytes, timeout: int = 2000) -> int:
+        return self.dev.write(EP_BULK_OUT, data, timeout)
+
+    def raw_write_bulk(self, data: bytes, timeout: int) -> int:
+        """Submits a bulk OUT transfer without pyusb's endpoint lookup.
+
+        `Device.write` resolves the address against the *active* alt setting and
+        raises `ValueError` when it is not there, which would hide what the
+        device does with a transfer to a disabled endpoint. libusb neither knows
+        nor cares about alt settings here, and the backend ignores the interface
+        argument.
+        """
+        ctx = self.dev._ctx
+        return ctx.backend.bulk_write(ctx.handle, EP_BULK_OUT, 0, array("B", data), timeout)
+
+    def read_bulk(self, n: int, timeout: int = 2000) -> bytes:
+        """Reads exactly `n` bytes from bulk IN, or one packet when `n == 0`.
+
+        The device terminates every echoed packet with a short packet, so libusb
+        completes each read early and a multi-packet echo needs several reads.
+        """
+        if n == 0:
+            return bytes(self.dev.read(EP_BULK_IN, 64, timeout))
+        out = bytearray()
+        deadline = time.monotonic() + timeout / 1000 + 1.0
+        while len(out) < n:
+            out += bytes(self.dev.read(EP_BULK_IN, n - len(out) + 64, timeout))
+            if time.monotonic() > deadline:
+                break
+        return bytes(out)
+
+    def echo(self, n: int, timeout: int = 2000) -> None:
+        """One bulk round trip that must come back byte-for-byte."""
+        payload = ramp(n)
+        self.write_bulk(payload, timeout)
+        got = self.read_bulk(n, timeout)
+        require(len(got) == n, f"echoed {len(got)} bytes, expected {n}")
+        require(got == payload, f"echo of {n} bytes came back corrupt")
+
+    def ep_status(self, ep_addr: int) -> int:
+        raw = self.dev.ctrl_transfer(STD_IN_ENDPOINT, REQ_GET_STATUS, 0, ep_addr, 2, 2000)
+        return int.from_bytes(bytes(raw), "little")
+
+
+def find_device(pid: int, budget: float) -> Device:
+    """Waits for a device that is present *and* answers GET_REPORT.
+
+    A previous test's firmware halted at a breakpoint stays enumerated but
+    unresponsive, so presence alone is not enough.
+    """
+    deadline = time.monotonic() + budget
+    last = f"no device {VID:04x}:{pid:04x}"
+    while time.monotonic() < deadline:
+        dev = usb.core.find(idVendor=VID, idProduct=pid)
+        if dev is None:
+            last = f"no device {VID:04x}:{pid:04x}"
+        else:
+            d = Device(dev)
+            try:
+                d.report()
+                return d
+            except (usb.core.USBError, Failure) as exc:
+                last = f"device present but GET_REPORT failed: {exc}"
+                usb.util.dispose_resources(dev)
+        time.sleep(0.25)
+    raise Failure(f"{last} (waited {budget:.0f} s)")
+
+
+def sysfs_speed(pid: int) -> str:
+    """The negotiated link speed in Mbps, as the kernel reports it."""
+    for vid_path in glob.glob("/sys/bus/usb/devices/*/idVendor"):
+        base = os.path.dirname(vid_path)
+        try:
+            with open(vid_path) as f:
+                if int(f.read().strip(), 16) != VID:
+                    continue
+            with open(os.path.join(base, "idProduct")) as f:
+                if int(f.read().strip(), 16) != pid:
+                    continue
+            with open(os.path.join(base, "speed")) as f:
+                return f.read().strip()
+        except (OSError, ValueError):
+            continue
+    raise Failure(f"no sysfs entry for {VID:04x}:{pid:04x}")
+
+
+# ------------------------------------------------------------------ phases
+
+
+def phase_descriptors(d: Device, cfg: Config) -> tuple[int, int]:
+    """Returns the isochronous OUT and IN endpoint addresses of alt setting 1."""
+    want = "480" if cfg.speed == "hs" else "12"
+    got = sysfs_speed(cfg.pid)
+    require(got == want, f"negotiated {got} Mbps, expected {want} Mbps")
+
+    conf = d.dev[0]
+    alts = [i for i in conf if i.bInterfaceNumber == 0]
+    require(len(alts) == 2, f"interface 0 has {len(alts)} alt settings, expected 2")
+
+    alt0 = next(i for i in alts if i.bAlternateSetting == 0)
+    eps0 = {e.bEndpointAddress: e for e in alt0}
+    require(
+        set(eps0) == {EP_BULK_OUT, EP_BULK_IN, EP_INT_IN},
+        f"alt 0 endpoints are {sorted(hex(a) for a in eps0)}",
+    )
+    for addr in (EP_BULK_OUT, EP_BULK_IN):
+        mps = eps0[addr].wMaxPacketSize
+        require(mps == cfg.bulk_mps, f"endpoint {addr:#04x} mps is {mps}, expected {cfg.bulk_mps}")
+    int_mps = eps0[EP_INT_IN].wMaxPacketSize
+    require(int_mps == 16, f"interrupt IN mps is {int_mps}, expected 16")
+
+    alt1 = next(i for i in alts if i.bAlternateSetting == 1)
+    iso = list(alt1)
+    require(len(iso) == 2, f"alt 1 has {len(iso)} endpoints, expected 2")
+    iso_out = [e for e in iso if e.bEndpointAddress & 0x80 == 0]
+    iso_in = [e for e in iso if e.bEndpointAddress & 0x80 != 0]
+    require(len(iso_out) == 1 and len(iso_in) == 1, "alt 1 must expose one iso OUT and one iso IN")
+    # On an isochronous endpoint, bits 12:11 of wMaxPacketSize carry the
+    # transactions-per-microframe count; the size is the low 11 bits.
+    out_mps = iso_out[0].wMaxPacketSize & 0x7FF
+    in_mps = iso_in[0].wMaxPacketSize & 0x7FF
+    require(out_mps == cfg.iso_out_mps, f"iso OUT mps is {out_mps}, expected {cfg.iso_out_mps}")
+    require(in_mps == cfg.iso_in_mps, f"iso IN mps is {in_mps}, expected {cfg.iso_in_mps}")
+    return iso_out[0].bEndpointAddress, iso_in[0].bEndpointAddress
+
+
+def phase_control_data(d: Device) -> None:
+    # 65 and 200 force the multi-packet `ControlPipe::data_out` loop on a
+    # 64-byte EP0; 64 is the exact-mps boundary; 0 has no data stage at all.
+    for n in (0, 1, 63, 64, 65, 200):
+        payload = ramp(n)
+        d.ctrl_out(ECHO_WRITE, 0, payload)
+        # A zero-length control IN is not requested: ask for one byte and
+        # require a zero-length response, which is the short-response path.
+        got = d.ctrl_in(ECHO_READ, max(n, 1))
+        require(got == payload, f"n={n}: echo returned {len(got)} bytes {got[:8].hex()}...")
+
+
+def phase_control_reject(d: Device) -> None:
+    try:
+        d.ctrl_in(UNSUPPORTED, 8)
+    except usb.core.USBError as exc:
+        require(exc.errno == ERR_PIPE, f"UNSUPPORTED raised errno {exc.errno}, expected {ERR_PIPE}")
+    else:
+        raise Failure("UNSUPPORTED was accepted, expected a STALL")
+    # Succeeding here proves `ControlPipe::setup` cleared the EP0 stall.
+    d.report()
+
+
+def phase_bulk_echo(d: Device, cfg: Config) -> None:
+    mps = cfg.bulk_mps
+    d.set_mode(MODE_ECHO)
+    # The odd lengths cover erratum USB.5 on high speed; mps and 3 * mps cover
+    # zero-length-packet termination; 0 must round-trip a ZLP.
+    for n in sorted({0, 1, 7, 8, 63, 64, 65, mps - 1, mps, mps + 1, 3 * mps}):
+        try:
+            d.echo(n)
+        except usb.core.USBError as exc:
+            raise Failure(f"n={n}: {exc}") from exc
+        except Failure as exc:
+            raise Failure(f"n={n}: {exc}") from exc
+    # Exactly one zero-length OUT packet in this phase: only n == 0 sends one.
+    zlp = d.report().zlp_out_count
+    require(zlp == 1, f"device counted {zlp} zero-length OUT packets, expected 1")
+
+
+def phase_bulk_sink(d: Device, cfg: Config) -> None:
+    """Sustained OUT in one multi-packet write, ramp-checked against a stream offset."""
+    total = 8 * cfg.bulk_mps
+    before = d.report()
+    d.set_mode(MODE_SINK)
+    try:
+        written = d.write_bulk(ramp(total), 5000)
+    except usb.core.USBError as exc:
+        raise Failure(f"bulk OUT write failed: {exc}") from exc
+    require(written == total, f"wrote {written} of {total} bytes")
+
+    deadline = time.monotonic() + 5.0
+    got, rep = 0, before
+    while time.monotonic() < deadline:
+        rep = d.report()
+        got = rep.bulk_out_bytes - before.bulk_out_bytes
+        if got >= total:
+            break
+        time.sleep(0.05)
+    require(got == total, f"device received {got} of {total} bytes")
+    require(rep.ramp_mismatches == 0, f"{rep.ramp_mismatches} ramp mismatches")
+    d.set_mode(MODE_IDLE)
+
+
+def phase_multi_packet_in(d: Device, cfg: Config) -> None:
+    total = cfg.source_total
+    d.set_mode(MODE_SOURCE, total)
+    out = bytearray()
+    deadline = time.monotonic() + 5.0
+    while len(out) < total:
+        try:
+            out += bytes(d.dev.read(EP_BULK_IN, total - len(out), 2000))
+        except usb.core.USBError as exc:
+            raise Failure(f"bulk IN read failed after {len(out)} bytes: {exc}") from exc
+        if time.monotonic() > deadline:
+            break
+    require(len(out) == total, f"read {len(out)} of {total} bytes")
+    require(bytes(out) == ramp(total), "source payload does not match the ramp")
+
+
+def phase_halt(d: Device, cfg: Config) -> None:
+    mps = cfg.bulk_mps
+    d.set_mode(MODE_ECHO)
+    for ep_addr in (EP_BULK_IN, EP_BULK_OUT):
+        if ep_addr == EP_BULK_IN:
+            # Arm an IN reply *before* halting and never read it: that is what
+            # makes `endpoint_set_stalled` take the EPSKIP reclaim path with a
+            # slot still active.
+            try:
+                d.write_bulk(ramp(mps))
+            except usb.core.USBError as exc:
+                raise Failure(f"{ep_addr:#04x}: priming OUT write failed: {exc}") from exc
+            time.sleep(0.05)
+
+        d.dev.ctrl_transfer(
+            STD_OUT_ENDPOINT, REQ_SET_FEATURE, FEATURE_ENDPOINT_HALT, ep_addr, None, 2000
+        )
+        status = d.ep_status(ep_addr)
+        require(status & 1 == 1, f"{ep_addr:#04x}: GET_STATUS is {status:#06x} after SET_FEATURE")
+
+        # Prove the halt is live on the wire, not just in the device's bookkeeping.
+        if ep_addr == EP_BULK_IN:
+            try:
+                got = d.read_bulk(mps, 500)
+            except usb.core.USBError as exc:
+                require(
+                    exc.errno == ERR_PIPE,
+                    f"{ep_addr:#04x}: bulk IN raised errno {exc.errno}, expected {ERR_PIPE}",
+                )
+            else:
+                raise Failure(
+                    f"{ep_addr:#04x}: halted bulk IN returned {len(got)} bytes instead of stalling"
+                )
+        else:
+            try:
+                d.write_bulk(ramp(mps), 500)
+            except usb.core.USBError as exc:
+                require(
+                    exc.errno == ERR_PIPE,
+                    f"{ep_addr:#04x}: bulk OUT raised errno {exc.errno}, expected {ERR_PIPE}",
+                )
+            else:
+                raise Failure(f"{ep_addr:#04x}: halted bulk OUT was accepted instead of stalling")
+
+        # `clear_halt` and not a raw CLEAR_FEATURE: libusb_clear_halt goes
+        # through the kernel, which sends CLEAR_FEATURE(HALT) *and* resets the
+        # host-side data toggle. A raw control transfer would leave the host on
+        # DATA1 while the driver's deferred TR_PENDING puts the device on DATA0,
+        # and every later transfer would silently hang.
+        d.dev.clear_halt(ep_addr)
+        status = d.ep_status(ep_addr)
+        require(status & 1 == 0, f"{ep_addr:#04x}: GET_STATUS is {status:#06x} after CLEAR_FEATURE")
+
+        # The round trip is the toggle-reset proof.
+        try:
+            d.echo(mps)
+        except usb.core.USBError as exc:
+            raise Failure(f"{ep_addr:#04x}: echo after unhalt failed: {exc}") from exc
+        except Failure as exc:
+            raise Failure(f"{ep_addr:#04x}: after unhalt: {exc}") from exc
+
+
+def phase_configuration_cycle(d: Device, cfg: Config) -> None:
+    before = d.report()
+    d.dev.ctrl_transfer(STD_OUT_DEVICE, REQ_SET_CONFIGURATION, 0x0000, 0, None, 2000)
+    time.sleep(0.05)
+    # SET_CONFIGURATION(0) disables every endpoint, which the bulk task must see
+    # as `Disabled` on its pending read.
+    rep = d.report()
+    require(
+        rep.disabled_errors > before.disabled_errors,
+        f"SET_CONFIGURATION(0) did not disable the endpoints "
+        f"(disabled_errors stayed at {rep.disabled_errors})",
+    )
+    d.dev.ctrl_transfer(STD_OUT_DEVICE, REQ_SET_CONFIGURATION, 0x0001, 0, None, 2000)
+    # Both transfers bypassed the kernel, so resynchronise the host toggles with
+    # the device's post-enable TR_PENDING state.
+    d.dev.clear_halt(EP_BULK_OUT)
+    d.dev.clear_halt(EP_BULK_IN)
+    d.set_mode(MODE_ECHO)
+    try:
+        d.echo(cfg.bulk_mps)
+    except usb.core.USBError as exc:
+        raise Failure(f"echo after the configuration cycle failed: {exc}") from exc
+
+
+def phase_alt_and_iso(d: Device, cfg: Config, iso_out_addr: int, iso_in_addr: int) -> None:
+    before_alt = d.report()
+    # Goes through the kernel, which resets the host toggles of the affected
+    # endpoints, so no clear_halt is needed afterwards.
+    d.dev.set_interface_altsetting(interface=0, alternate_setting=1)
+    time.sleep(0.05)
+
+    # That the bulk endpoints are now disabled cannot be shown from the host:
+    # both pyusb and the kernel refuse to submit a transfer to an endpoint that
+    # is not in the active alt setting, so nothing reaches the wire. The proof is
+    # device-side instead - the bulk task's pending `read` must have come back
+    # as `Disabled`, which is exactly what `endpoint_set_enabled(false)` does.
+    rep = d.report()
+    require(
+        rep.disabled_errors > before_alt.disabled_errors,
+        "selecting alt setting 1 did not disable the bulk endpoints "
+        f"(disabled_errors stayed at {rep.disabled_errors})",
+    )
+
+    raw = d.dev.ctrl_transfer(STD_IN_INTERFACE, REQ_GET_INTERFACE, 0, 0, 1, 2000)
+    require(raw[0] == 1, f"GET_INTERFACE returned {raw[0]}, expected 1")
+
+    batches, per_batch = 4, 32
+
+    # --- isochronous OUT ---
+    before = d.report()
+    d.set_mode(MODE_ISO_SINK)
+    time.sleep(0.05)
+    packet = ramp(cfg.iso_out_mps)
+    for _ in range(batches):
+        try:
+            d.dev.write(iso_out_addr, packet * per_batch, 5000)
+        except usb.core.USBError as exc:
+            raise Failure(f"isochronous OUT write failed: {exc}") from exc
+    time.sleep(0.2)
+    rep = d.report()
+    sent = batches * per_batch
+    received = rep.iso_out_packets - before.iso_out_packets
+    require(
+        received >= sent * 8 // 10,
+        f"device saw {received} of {sent} isochronous OUT packets (under 80 %)",
+    )
+    require(rep.ramp_mismatches == 0, f"{rep.ramp_mismatches} isochronous OUT ramp mismatches")
+
+    # --- isochronous IN ---
+    mps = cfg.iso_in_mps
+    d.set_mode(MODE_ISO_SOURCE)
+    time.sleep(0.05)
+    total = 0
+    for _ in range(batches):
+        try:
+            data = bytes(d.dev.read(iso_in_addr, per_batch * mps, 5000))
+        except usb.core.USBError as exc:
+            # A whole batch timing out is tolerated and counted as zero bytes;
+            # the aggregate threshold below is what decides the verdict.
+            if exc.errno != ERR_TIMEOUT:
+                raise Failure(f"isochronous IN read failed: {exc}") from exc
+            continue
+        total += len(data)
+        # libusb lays isochronous packets out at their *nominal* stride but only
+        # reports the summed actual length, so one short packet desynchronises
+        # every later offset. Packet 0 always starts at 0; when the whole batch
+        # came back full, every stride is meaningful.
+        full = len(data) // mps if len(data) == per_batch * mps else min(1, len(data) // mps)
+        for i in range(full):
+            off = i * mps
+            require(
+                data[off : off + mps] == ramp(mps),
+                f"isochronous IN packet {i} does not match the ramp",
+            )
+    want = batches * per_batch * mps
+    require(total >= want * 8 // 10, f"read {total} of {want} isochronous IN bytes (under 80 %)")
+
+    d.set_mode(MODE_IDLE)
+    d.dev.set_interface_altsetting(interface=0, alternate_setting=0)
+    d.set_mode(MODE_ECHO)
+    try:
+        # Proves the bulk endpoints came back enabled with a reset toggle.
+        d.echo(cfg.bulk_mps)
+    except usb.core.USBError as exc:
+        raise Failure(f"echo after returning to alt 0 failed: {exc}") from exc
+
+
+def phase_interrupt_in(d: Device) -> None:
+    d.set_mode(MODE_IDLE)
+    for n in (1, 8, 15, 16):
+        d.ctrl_out(TRIGGER_INT, n)
+        try:
+            got = bytes(d.dev.read(EP_INT_IN, 16, 2000))
+        except usb.core.USBError as exc:
+            raise Failure(f"n={n}: interrupt IN read failed: {exc}") from exc
+        require(got == ramp(n), f"n={n}: interrupt IN returned {got.hex()}")
+    packets = d.report().int_in_packets
+    require(packets == 4, f"device counted {packets} interrupt IN packets, expected 4")
+
+
+# ------------------------------------------------------------------ driver
+
+
+class Config(NamedTuple):
+    pid: int
+    speed: str
+    bulk_mps: int
+    iso_out_mps: int
+    iso_in_mps: int
+    source_total: int
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    parser.add_argument("--pid", required=True, type=lambda s: int(s, 0), help="idProduct, e.g. 0xcb01")
+    parser.add_argument("--speed", required=True, choices=("hs", "fs"))
+    parser.add_argument("--wait", type=float, default=15.0, help="seconds to wait for the device")
+    parser.add_argument(
+        "--iso-out-mps",
+        type=int,
+        default=None,
+        help="expected isochronous OUT wMaxPacketSize (default 1024 on hs, 512 on fs)",
+    )
+    parser.add_argument(
+        "--iso-in-mps",
+        type=int,
+        default=None,
+        help="expected isochronous IN wMaxPacketSize (default 1023 on hs, 512 on fs)",
+    )
+    args = parser.parse_args()
+
+    hs = args.speed == "hs"
+
+    def pick(given: int | None, default: int) -> int:
+        return default if given is None else given
+
+    cfg = Config(
+        pid=args.pid,
+        speed=args.speed,
+        bulk_mps=512 if hs else 64,
+        # Full speed runs its isochronous endpoints at 512 and not the 1023-byte
+        # maximum: two 1023-byte endpoints overrun the 1 ms frame's periodic
+        # budget, and a 1023-byte full-speed isochronous IN through a high-speed
+        # hub's transaction translator only survives one packet per URB.
+        iso_out_mps=pick(args.iso_out_mps, 1024 if hs else 512),
+        iso_in_mps=pick(args.iso_in_mps, 1023 if hs else 512),
+        source_total=4096 if hs else 1024,
+    )
+
+    phase = "acquire"
+    d = None
+    try:
+        d = find_device(cfg.pid, args.wait)
+        # Re-issues SET_CONFIGURATION(1), exercising the enable path.
+        d.dev.set_configuration()
+        usb.util.claim_interface(d.dev, 0)
+        # Every absolute expectation below counts from here, so the script is
+        # re-runnable against a firmware that is already up.
+        d.ctrl_out(RESET)
+        print(f"[{phase}] {VID:04x}:{cfg.pid:04x} responding")
+
+        phase = "descriptors"
+        iso_out_addr, iso_in_addr = phase_descriptors(d, cfg)
+        print(f"[{phase}] ok")
+
+        for phase, fn in (
+            ("control_data", lambda: phase_control_data(d)),
+            ("control_reject", lambda: phase_control_reject(d)),
+            ("bulk_echo", lambda: phase_bulk_echo(d, cfg)),
+            ("bulk_sink", lambda: phase_bulk_sink(d, cfg)),
+            ("multi_packet_in", lambda: phase_multi_packet_in(d, cfg)),
+            ("halt", lambda: phase_halt(d, cfg)),
+            ("configuration_cycle", lambda: phase_configuration_cycle(d, cfg)),
+            ("alt_and_iso", lambda: phase_alt_and_iso(d, cfg, iso_out_addr, iso_in_addr)),
+            ("interrupt_in", lambda: phase_interrupt_in(d)),
+        ):
+            fn()
+            print(f"[{phase}] ok")
+
+        phase = "finish"
+        print(f"[report] {d.report()}")
+        d.ctrl_out(FINISH)
+        print(f"[{phase}] ok")
+    except Failure as exc:
+        fail(phase, str(exc))
+    except usb.core.USBError as exc:
+        fail(phase, f"unexpected USB error: {exc}")
+    finally:
+        if d is not None:
+            try:
+                usb.util.release_interface(d.dev, 0)
+            except usb.core.USBError:
+                pass
+            usb.util.dispose_resources(d.dev)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/lpc55/host/dual_echo.py
+++ b/tests/lpc55/host/dual_echo.py
@@ -36,13 +36,18 @@ RAMP_PERIOD = 512
 # `examples/lpc55s69/scripts/usb_throughput.py` and `host/conformance.py`.
 _RAMP = bytes((k % RAMP_PERIOD) & 0xFF for k in range(RAMP_PERIOD))
 
+PAYLOAD_SIZE = 512
 ITERATIONS = 8
 READ_TIMEOUT = 5.0
+BARRIER_TIMEOUT = 5.0
+THREAD_TIMEOUT = ITERATIONS * READ_TIMEOUT + 10.0
+PAYLOAD_SEED = {"HS": 0, "FS": 128}
 
 
-def ramp(n: int) -> bytes:
-    """`n` payload bytes starting at stream offset 0."""
-    return (_RAMP * (n // RAMP_PERIOD + 1))[:n]
+def ramp(n: int, offset: int = 0) -> bytes:
+    """`n` payload bytes starting at the specified stream offset."""
+    repeats = (offset + n) // RAMP_PERIOD + 1
+    return (_RAMP * repeats)[offset : offset + n]
 
 
 def find_ports(wait: float) -> dict[str, str]:
@@ -79,21 +84,35 @@ def read_exact(port: serial.Serial, count: int) -> bytes:
     return bytes(buf)
 
 
-def echo_port(label: str, path: str, size: int, results: dict[str, str | None]) -> None:
+def echo_port(
+    label: str,
+    path: str,
+    barrier: threading.Barrier,
+    results: dict[str, str | None],
+) -> None:
     """Run the echo loop on one port, recording its own failure message."""
-    payload = ramp(size)
+    synchronized = False
     try:
         with serial.Serial(path, timeout=0.2, write_timeout=READ_TIMEOUT) as port:
+            try:
+                barrier.wait(timeout=BARRIER_TIMEOUT)
+            except threading.BrokenBarrierError as exc:
+                raise TimeoutError(f"peer did not reach the barrier in {BARRIER_TIMEOUT:g} s") from exc
+            synchronized = True
             for i in range(ITERATIONS):
-                port.write(payload)
-                port.flush()
-                echoed = read_exact(port, size)
+                payload = ramp(PAYLOAD_SIZE, PAYLOAD_SEED[label] + i)
+                written = port.write(payload)
+                if written != len(payload):
+                    raise TimeoutError(f"iteration {i}: wrote {written} of {len(payload)} bytes")
+                echoed = read_exact(port, PAYLOAD_SIZE)
                 if echoed != payload:
-                    bad = next(k for k in range(size) if echoed[k] != payload[k])
+                    bad = next(k for k in range(PAYLOAD_SIZE) if echoed[k] != payload[k])
                     raise ValueError(
                         f"iteration {i}: byte {bad} is {echoed[bad]:#04x}, expected {payload[bad]:#04x}"
                     )
     except Exception as exc:  # noqa: BLE001 - reported verbatim as the verdict
+        if not synchronized:
+            barrier.abort()
         results[label] = f"{type(exc).__name__}: {exc}"
         return
     results[label] = None
@@ -104,34 +123,39 @@ def main() -> int:
     parser.add_argument(
         "--wait", type=float, default=15.0, help="seconds to wait for both CDC ports to appear (default 15)"
     )
-    parser.add_argument(
-        "--bytes", type=int, default=512, dest="size", help="payload bytes per iteration (default 512)"
-    )
     args = parser.parse_args()
-
-    if args.size <= 0:
-        print("FAIL: args: --bytes must be positive", file=sys.stderr)
-        return 1
-
     try:
         ports = find_ports(args.wait)
     except TimeoutError as exc:
         print(f"FAIL: ports: {exc}", file=sys.stderr)
         return 1
-
+    barrier = threading.Barrier(2)
     results: dict[str, str | None] = {}
     threads = [
-        threading.Thread(target=echo_port, args=(label, ports[label], args.size, results), name=label)
+        threading.Thread(
+            target=echo_port,
+            args=(label, ports[label], barrier, results),
+            name=label,
+            daemon=True,
+        )
         for label, _ in PORTS
     ]
     for thread in threads:
         thread.start()
+    deadline = time.monotonic() + THREAD_TIMEOUT
     for thread in threads:
-        thread.join()
+        thread.join(max(0.0, deadline - time.monotonic()))
+    hung = {thread.name for thread in threads if thread.is_alive()}
+    if hung:
+        barrier.abort()
 
     failed = False
     for label, _ in PORTS:
-        reason = results.get(label, "thread produced no result")
+        reason = (
+            f"thread did not finish in {THREAD_TIMEOUT:g} s"
+            if label in hung
+            else results.get(label, "thread produced no result")
+        )
         if reason is not None:
             print(f"FAIL: {label}: {reason}", file=sys.stderr)
             failed = True
@@ -139,7 +163,10 @@ def main() -> int:
         return 1
 
     for label, _ in PORTS:
-        print(f"{label}: echoed {ITERATIONS} x {args.size} bytes = {ITERATIONS * args.size} bytes, exact match")
+        print(
+            f"{label}: echoed {ITERATIONS} x {PAYLOAD_SIZE} bytes = "
+            f"{ITERATIONS * PAYLOAD_SIZE} bytes, exact match"
+        )
     return 0
 
 

--- a/tests/lpc55/host/dual_echo.py
+++ b/tests/lpc55/host/dual_echo.py
@@ -1,16 +1,13 @@
 #!/usr/bin/env python3
-"""Host peer for `tests/lpc55/src/bin/usb_dual_pll0.rs`.
+"""Drive both CDC-ACM ports from `usb_dual_pll0`.
 
-Both LPC55 USB controllers run concurrently off PLL0 at 150 MHz, each exposing a
-CDC-ACM echo port. This script drives the two ports from two threads, so the
-controllers really overlap rather than taking turns: a clock or endpoint-memory
-mistake that only shows under simultaneous traffic still fails the test.
+The firmware runs both LPC55 USB controllers from PLL0 at 150 MHz. Two host threads transfer data
+at the same time, so clock and endpoint-memory faults under concurrent traffic fail the test.
 
-Only CDC nodes are touched, so no root is needed (`/dev/ttyACM*` is
-`root:dialout` and the test user is in `dialout`).
+The script uses only CDC nodes and does not need root. The test user must have access to
+`/dev/ttyACM*`, normally through the `dialout` group.
 
-Exit 0 on pass. On failure, print `FAIL: <port label>: <reason>` to stderr and
-exit 1.
+Exit 0 on success. On failure, print `FAIL: <port label>: <reason>` to stderr and exit 1.
 """
 
 from __future__ import annotations

--- a/tests/lpc55/host/dual_echo.py
+++ b/tests/lpc55/host/dual_echo.py
@@ -1,11 +1,16 @@
-#!/usr/bin/env python3
+#!/usr/bin/env -S uv run --script
+# /// script
+# requires-python = ">=3.10"
+# dependencies = ["pyserial>=3.5"]
+# ///
 """Drive both CDC-ACM ports from `usb_dual_pll0`.
 
 The firmware runs both LPC55 USB controllers from PLL0 at 150 MHz. Two host threads transfer data
 at the same time, so clock and endpoint-memory faults under concurrent traffic fail the test.
 
-The script uses only CDC nodes and does not need root. The test user must have access to
-`/dev/ttyACM*`, normally through the `dialout` group.
+The script uses only CDC nodes and needs no elevation. On Linux the test user must have access to
+`/dev/ttyACM*`, normally through the `dialout` group. On Windows, `usbser.sys` binds the ports
+automatically.
 
 Exit 0 on success. On failure, print `FAIL: <port label>: <reason>` to stderr and exit 1.
 """
@@ -13,20 +18,19 @@ Exit 0 on success. On failure, print `FAIL: <port label>: <reason>` to stderr an
 from __future__ import annotations
 
 import argparse
-import glob
 import sys
 import threading
 import time
 
 import serial
+import serial.tools.list_ports
 
-BY_ID = "/dev/serial/by-id/*"
+VID = 0xC0DE
 
-# Substrings of the `by-id` symlink, which Linux derives from the manufacturer,
-# product and serial strings the firmware reports. Matching on a substring keeps
-# a `by-id` naming variation (interface suffix, separator changes) from breaking
-# the test.
-PORTS = (("HS", "USB-HS_dual_pll0"), ("FS", "USB-FS_dual_pll0"))
+# `idProduct` per controller, from `tests/lpc55/src/bin/usb_dual_pll0.rs`. The USB IDs are the
+# only port identity both hosts expose: Linux `by-id` symlinks and Windows COM names share
+# nothing else.
+PORTS = (("HS", 0xCB03), ("FS", 0xCB04))
 
 RAMP_PERIOD = 512
 # Byte k of the stream is `(k % 512) as u8` - the same ramp as
@@ -48,23 +52,25 @@ def ramp(n: int, offset: int = 0) -> bytes:
 
 
 def find_ports(wait: float) -> dict[str, str]:
-    """Poll `/dev/serial/by-id` until both nodes exist or `wait` elapses."""
+    """Poll the serial ports until both controllers are present or `wait` elapses."""
     deadline = time.monotonic() + wait
     found: dict[str, str] = {}
     while True:
-        links = glob.glob(BY_ID)
-        for label, needle in PORTS:
+        present = serial.tools.list_ports.comports()
+        for label, pid in PORTS:
             if label in found:
                 continue
-            for link in links:
-                if needle in link:
-                    found[label] = link
+            for info in present:
+                if info.vid == VID and info.pid == pid:
+                    found[label] = info.device
                     break
         if len(found) == len(PORTS):
             return found
         if time.monotonic() >= deadline:
-            missing = ", ".join(label for label, _ in PORTS if label not in found)
-            raise TimeoutError(f"no {missing} CDC port in {BY_ID} after {wait:g} s")
+            missing = ", ".join(
+                f"{label} ({VID:04x}:{pid:04x})" for label, pid in PORTS if label not in found
+            )
+            raise TimeoutError(f"no CDC port for {missing} after {wait:g} s")
         time.sleep(0.2)
 
 

--- a/tests/lpc55/host/dual_echo.py
+++ b/tests/lpc55/host/dual_echo.py
@@ -1,0 +1,147 @@
+#!/usr/bin/env python3
+"""Host peer for `tests/lpc55/src/bin/usb_dual_pll0.rs`.
+
+Both LPC55 USB controllers run concurrently off PLL0 at 150 MHz, each exposing a
+CDC-ACM echo port. This script drives the two ports from two threads, so the
+controllers really overlap rather than taking turns: a clock or endpoint-memory
+mistake that only shows under simultaneous traffic still fails the test.
+
+Only CDC nodes are touched, so no root is needed (`/dev/ttyACM*` is
+`root:dialout` and the test user is in `dialout`).
+
+Exit 0 on pass. On failure, print `FAIL: <port label>: <reason>` to stderr and
+exit 1.
+"""
+
+from __future__ import annotations
+
+import argparse
+import glob
+import sys
+import threading
+import time
+
+import serial
+
+BY_ID = "/dev/serial/by-id/*"
+
+# Substrings of the `by-id` symlink, which Linux derives from the manufacturer,
+# product and serial strings the firmware reports. Matching on a substring keeps
+# a `by-id` naming variation (interface suffix, separator changes) from breaking
+# the test.
+PORTS = (("HS", "USB-HS_dual_pll0"), ("FS", "USB-FS_dual_pll0"))
+
+RAMP_PERIOD = 512
+# Byte k of the stream is `(k % 512) as u8` - the same ramp as
+# `examples/lpc55s69/scripts/usb_throughput.py` and `host/conformance.py`.
+_RAMP = bytes((k % RAMP_PERIOD) & 0xFF for k in range(RAMP_PERIOD))
+
+ITERATIONS = 8
+READ_TIMEOUT = 5.0
+
+
+def ramp(n: int) -> bytes:
+    """`n` payload bytes starting at stream offset 0."""
+    return (_RAMP * (n // RAMP_PERIOD + 1))[:n]
+
+
+def find_ports(wait: float) -> dict[str, str]:
+    """Poll `/dev/serial/by-id` until both nodes exist or `wait` elapses."""
+    deadline = time.monotonic() + wait
+    found: dict[str, str] = {}
+    while True:
+        links = glob.glob(BY_ID)
+        for label, needle in PORTS:
+            if label in found:
+                continue
+            for link in links:
+                if needle in link:
+                    found[label] = link
+                    break
+        if len(found) == len(PORTS):
+            return found
+        if time.monotonic() >= deadline:
+            missing = ", ".join(label for label, _ in PORTS if label not in found)
+            raise TimeoutError(f"no {missing} CDC port in {BY_ID} after {wait:g} s")
+        time.sleep(0.2)
+
+
+def read_exact(port: serial.Serial, count: int) -> bytes:
+    """Read `count` bytes, tolerating a CDC echo split across packets."""
+    deadline = time.monotonic() + READ_TIMEOUT
+    buf = bytearray()
+    while len(buf) < count:
+        chunk = port.read(count - len(buf))
+        if chunk:
+            buf += chunk
+        elif time.monotonic() >= deadline:
+            raise TimeoutError(f"got {len(buf)} of {count} echoed bytes in {READ_TIMEOUT:g} s")
+    return bytes(buf)
+
+
+def echo_port(label: str, path: str, size: int, results: dict[str, str | None]) -> None:
+    """Run the echo loop on one port, recording its own failure message."""
+    payload = ramp(size)
+    try:
+        with serial.Serial(path, timeout=0.2, write_timeout=READ_TIMEOUT) as port:
+            for i in range(ITERATIONS):
+                port.write(payload)
+                port.flush()
+                echoed = read_exact(port, size)
+                if echoed != payload:
+                    bad = next(k for k in range(size) if echoed[k] != payload[k])
+                    raise ValueError(
+                        f"iteration {i}: byte {bad} is {echoed[bad]:#04x}, expected {payload[bad]:#04x}"
+                    )
+    except Exception as exc:  # noqa: BLE001 - reported verbatim as the verdict
+        results[label] = f"{type(exc).__name__}: {exc}"
+        return
+    results[label] = None
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    parser.add_argument(
+        "--wait", type=float, default=15.0, help="seconds to wait for both CDC ports to appear (default 15)"
+    )
+    parser.add_argument(
+        "--bytes", type=int, default=512, dest="size", help="payload bytes per iteration (default 512)"
+    )
+    args = parser.parse_args()
+
+    if args.size <= 0:
+        print("FAIL: args: --bytes must be positive", file=sys.stderr)
+        return 1
+
+    try:
+        ports = find_ports(args.wait)
+    except TimeoutError as exc:
+        print(f"FAIL: ports: {exc}", file=sys.stderr)
+        return 1
+
+    results: dict[str, str | None] = {}
+    threads = [
+        threading.Thread(target=echo_port, args=(label, ports[label], args.size, results), name=label)
+        for label, _ in PORTS
+    ]
+    for thread in threads:
+        thread.start()
+    for thread in threads:
+        thread.join()
+
+    failed = False
+    for label, _ in PORTS:
+        reason = results.get(label, "thread produced no result")
+        if reason is not None:
+            print(f"FAIL: {label}: {reason}", file=sys.stderr)
+            failed = True
+    if failed:
+        return 1
+
+    for label, _ in PORTS:
+        print(f"{label}: echoed {ITERATIONS} x {args.size} bytes = {ITERATIONS * args.size} bytes, exact match")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/lpc55/memory.x
+++ b/tests/lpc55/memory.x
@@ -1,0 +1,28 @@
+/* File originally from lpc55-hal repo: https://github.com/lpc55/lpc55-hal/blob/main/memory.x */ 
+MEMORY
+{
+  FLASH : ORIGIN = 0x00000000, LENGTH = 512K
+
+  /* for use with standard link.x */
+  RAM : ORIGIN = 0x20000000, LENGTH = 256K
+
+  /* would be used with proper link.x */
+  /* needs changes to r0 (initialization code) */
+  /* SRAM0 : ORIGIN = 0x20000000, LENGTH = 64K */
+  /* SRAM1 : ORIGIN = 0x20010000, LENGTH = 64K */
+  /* SRAM2 : ORIGIN = 0x20020000, LENGTH = 64K */
+  /* SRAM3 : ORIGIN = 0x20030000, LENGTH = 64K */
+
+  /* CASPER SRAM regions */
+  /* SRAMX0: ORIGIN = 0x1400_0000, LENGTH = 4K /1* to 0x1400_0FFF *1/ */
+  /* SRAMX1: ORIGIN = 0x1400_4000, LENGTH = 4K /1* to 0x1400_4FFF *1/ */
+
+  /* USB1 SRAM regin */
+  /* USB1_SRAM : ORIGIN = 0x40100000, LENGTH = 16K */
+
+  /* To define our own USB RAM section in one regular */
+  /* RAM, probably easiest to shorten length of RAM */
+  /* above, and use this freed RAM section */
+
+}
+

--- a/tests/lpc55/memory.x
+++ b/tests/lpc55/memory.x
@@ -1,4 +1,4 @@
-/* File originally from lpc55-hal repo: https://github.com/lpc55/lpc55-hal/blob/main/memory.x */ 
+/* File originally from lpc55-hal repo: https://github.com/lpc55/lpc55-hal/blob/main/memory.x */
 MEMORY
 {
   FLASH : ORIGIN = 0x00000000, LENGTH = 512K
@@ -25,4 +25,3 @@ MEMORY
   /* above, and use this freed RAM section */
 
 }
-

--- a/tests/lpc55/run.py
+++ b/tests/lpc55/run.py
@@ -20,6 +20,7 @@ from __future__ import annotations
 
 import argparse
 import os
+import re
 import signal
 import subprocess
 import sys
@@ -151,6 +152,11 @@ TESTS_LIST = [
 # output; only match what the firmware could have printed.
 PANIC_MARKERS = ("panicked", "PANIC", "[ERROR]")
 
+# A `probe-rs` failure is a top-level `Error:` followed by an indented, numbered `Caused by:`
+# chain. The top level says which stage failed, the deepest cause says why.
+PROBE_ERROR = re.compile(r"^\s*Error: (.*\S)")
+PROBE_CAUSE = re.compile(r"^\s*\d+: (.*\S)")
+
 
 class Firmware:
     """`cargo run --release --bin <bin>`, with its output captured line by line."""
@@ -201,6 +207,21 @@ class Firmware:
         with self._lock:
             return [ln for ln in self.lines if any(m in ln for m in PANIC_MARKERS)]
 
+    def probe_failure(self) -> str | None:
+        """Describes an abnormal `probe-rs` exit. It otherwise sits at the breakpoint forever."""
+        code = self.proc.poll()
+        if code is None:
+            return None
+        with self._lock:
+            lines = list(self.lines)
+        parts = [f"probe-rs exited {code}"]
+        for pattern in (PROBE_ERROR, PROBE_CAUSE):
+            hits = [m.group(1) for ln in lines if (m := pattern.match(ln))]
+            if hits:
+                # probe-rs punctuates some messages and not others; `: ` is the separator here.
+                parts.append(hits[-1].rstrip("."))
+        return ": ".join(parts)
+
     def stop(self) -> None:
         if self.proc.poll() is None:
             self.proc.send_signal(signal.SIGINT)
@@ -237,9 +258,12 @@ def run_test(test: Test) -> str | None:
     fw = Firmware(test)
 
     def verdict(timeout_reason: str) -> str:
-        # A device panic explains a missing banner far better than the timeout.
+        # A device panic or a dead probe-rs explains a missing banner far better than a timeout:
+        # a flash that failed means the firmware never ran, so nothing was ever going to appear.
         panics = fw.panics()
-        return f"device panicked: {panics[0].strip()}" if panics else timeout_reason
+        if panics:
+            return f"device panicked: {panics[0].strip()}"
+        return fw.probe_failure() or timeout_reason
 
     try:
         if test.ready is not None and not fw.wait_for(test.ready, READY_TIMEOUT):
@@ -256,7 +280,7 @@ def run_test(test: Test) -> str | None:
         panics = fw.panics()
         if panics:
             return f"device panicked: {panics[0].strip()}"
-        return None
+        return fw.probe_failure()
     finally:
         fw.stop()
         time.sleep(SETTLE)

--- a/tests/lpc55/run.py
+++ b/tests/lpc55/run.py
@@ -4,9 +4,14 @@
 For each entry, the runner flashes release firmware through `probe-rs`, waits for its RTT ready
 banner, starts the host peer, and requires `Test OK`.
 
+Runs on Linux and Windows. This file is stdlib-only; every host peer declares its own
+dependencies inline and runs through `uv run --script`.
+
 Run the suite as an unprivileged user so `cargo` and `probe-rs` retain the user's `~/.cargo` and
-target directories. Only the raw-USB conformance entries use `sudo -n` with this interpreter.
-A plain `sudo python3` might not resolve pyusb.
+target directories. On Linux the two conformance entries need root for raw USB access and are
+the only ones run with `sudo -n`. On Windows the conformance firmware's MS OS 2.0 descriptors
+make Windows bind WinUSB by itself, which an unprivileged process can open, so the suite
+elevates nothing.
 
     python3 tests/lpc55/run.py [--only NAME]... [--list] [--keep-going]
 
@@ -17,9 +22,11 @@ Use an LPCXpresso55S69 EVK with a debug probe on the SWD header. Connect the hos
 from __future__ import annotations
 
 import argparse
+from collections.abc import Sequence
 from dataclasses import dataclass
 import os
 import re
+import shutil
 import signal
 import subprocess
 import sys
@@ -38,7 +45,15 @@ KILL_GRACE = 5.0
 # Lets the previous probe-rs session detach and the host see the device go away.
 SETTLE = 1.5
 
-HANDLED_SIGNALS = (signal.SIGINT, signal.SIGTERM, signal.SIGHUP)
+WINDOWS = sys.platform == "win32"
+
+# `uv` runs the host peers. Absolute, so `sudo -n` finds it whatever `secure_path` says.
+UV = shutil.which("uv")
+
+# SIGHUP is POSIX-only. SIGBREAK is what a Windows console raises in its place.
+HANDLED_SIGNALS = tuple(
+    getattr(signal, name) for name in ("SIGINT", "SIGTERM", "SIGHUP", "SIGBREAK") if hasattr(signal, name)
+)
 _SIGNAL_NUMBER: int | None = None
 _SIGNAL_DEFERRED = False
 
@@ -110,27 +125,142 @@ def terminate_group(proc: subprocess.Popen[str], first_signal: int) -> None:
     else:
         proc.wait()
 
-FS_PORT = "/dev/serial/by-id/usb-Embassy_USB-FS_throughput_test_12345678-if00"
-HS_PORT = "/dev/serial/by-id/usb-Embassy_USB-HS_throughput_test_12345678-if00"
+
+if WINDOWS:
+    import ctypes
+    from ctypes import wintypes
+
+    _KERNEL32 = ctypes.WinDLL("kernel32", use_last_error=True)
+    _KERNEL32.CreateJobObjectW.argtypes = (wintypes.LPVOID, wintypes.LPCWSTR)
+    _KERNEL32.CreateJobObjectW.restype = wintypes.HANDLE
+    _KERNEL32.AssignProcessToJobObject.argtypes = (wintypes.HANDLE, wintypes.HANDLE)
+    _KERNEL32.AssignProcessToJobObject.restype = wintypes.BOOL
+    _KERNEL32.TerminateJobObject.argtypes = (wintypes.HANDLE, wintypes.UINT)
+    _KERNEL32.TerminateJobObject.restype = wintypes.BOOL
+    _KERNEL32.CloseHandle.argtypes = (wintypes.HANDLE,)
+    _KERNEL32.CloseHandle.restype = wintypes.BOOL
+
+
+class Child:
+    """A child process and everything it spawns, stoppable as one unit.
+
+    `cargo run` execs `probe-rs`, and a `probe-rs` that outlives its test keeps the debug
+    probe and fails every entry after it, so stopping a test has to reach the whole tree.
+    POSIX gets a process group. Windows gets a job object, because `taskkill /T` walks
+    parent links that are already gone once `cargo` itself has exited, while
+    `TerminateJobObject` does not care about parentage.
+    """
+
+    def __init__(self, cmd: Sequence[str], cwd: str, merge_stderr: bool) -> None:
+        self._job = None
+        if WINDOWS:
+            self._job = _KERNEL32.CreateJobObjectW(None, None)
+            if not self._job:
+                raise ctypes.WinError(ctypes.get_last_error())
+            group: dict[str, object] = {"creationflags": subprocess.CREATE_NEW_PROCESS_GROUP}
+        else:
+            group = {"start_new_session": True}
+        try:
+            self.proc = subprocess.Popen(
+                list(cmd),
+                cwd=cwd,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.STDOUT if merge_stderr else subprocess.PIPE,
+                text=True,
+                bufsize=1,
+                **group,
+            )
+        except BaseException:
+            self._close_job()
+            raise
+        if self._job is not None:
+            # `cargo` still has to reach the filesystem before it can fork `probe-rs`, so
+            # it is childless here and nothing escapes the job.
+            handle = wintypes.HANDLE(int(self.proc._handle))
+            if not _KERNEL32.AssignProcessToJobObject(self._job, handle):
+                error = ctypes.get_last_error()
+                self.stop()
+                raise ctypes.WinError(error)
+
+    def stop(self) -> None:
+        """Interrupts the tree, then makes sure nothing in it survived."""
+        if WINDOWS:
+            self._stop_windows()
+        else:
+            terminate_group(self.proc, signal.SIGINT)
+
+    def _stop_windows(self) -> None:
+        if self._job is None:
+            return
+        if self.proc.poll() is None:
+            try:
+                # SIGINT's counterpart here. `probe-rs` installs a console handler, so it
+                # gets to release the debug probe: a hard kill leaves the probe wedged and
+                # the next session fails to open it. `cargo` shares the group and forwards
+                # nothing, so the event has to go to the group rather than the child.
+                self.proc.send_signal(signal.CTRL_C_EVENT)
+            except OSError:
+                pass
+            try:
+                self.proc.wait(timeout=KILL_GRACE)
+            except subprocess.TimeoutExpired:
+                pass
+        _KERNEL32.TerminateJobObject(self._job, 1)
+        try:
+            self.proc.wait(timeout=KILL_GRACE)
+        except subprocess.TimeoutExpired:
+            pass
+        self._close_job()
+
+    def _close_job(self) -> None:
+        if self._job is not None:
+            _KERNEL32.CloseHandle(self._job)
+            self._job = None
+
+# A USB id is the only peer identity Linux and Windows share: device names
+# (`/dev/serial/by-id/...`, `COM7`) have nothing in common, and on Windows these two
+# firmwares are not serial ports at all. One id per firmware, distinct from the serial
+# examples' `c0de:cafe`, so a stale binding or a leftover node can never be mistaken for
+# the peer under test.
+FS_USB_ID = "c0de:cb07"
+HS_USB_ID = "c0de:cb08"
 
 # Roughly 75 % of the release-profile numbers recorded in README.md, so the gate catches a
 # real regression without tripping on host jitter.
 FS_IN_MIN, FS_OUT_MIN = "0.67", "0.61"
 HS_IN_MIN, HS_OUT_MIN = "33.0", "13.0"
-THROUGHPUT = (sys.executable, os.path.join("scripts", "usb_throughput.py"))
+THROUGHPUT = os.path.join("scripts", "usb_throughput.py")
 
+
+def uv_command(argv: Sequence[str]) -> list[str]:
+    """`uv run --script` resolves each peer's inline PEP 723 dependencies, so neither pyusb
+    nor pyserial has to be installed for the suite."""
+    assert UV is not None  # `main` refuses to run the suite without it
+    return [UV, "run", "--script", *argv]
 
 
 def conformance_command(pid: str, speed: str) -> tuple[str, ...]:
-    return (sys.executable, os.path.join("host", "conformance.py"), "--pid", pid, "--speed", speed)
+    return (os.path.join("host", "conformance.py"), "--pid", pid, "--speed", speed)
 
 
-def throughput_command(port: str, direction: str, count: str, min_rate: str) -> tuple[str, ...]:
-    return (*THROUGHPUT, "--port", port, "--dir", direction, "--bytes", count, "--wait-port", "15", "--min-rate", min_rate)
+def throughput_command(usb_id: str, direction: str, count: str, min_rate: str) -> tuple[str, ...]:
+    return (
+        THROUGHPUT,
+        "--port",
+        usb_id,
+        "--dir",
+        direction,
+        "--bytes",
+        count,
+        "--wait-port",
+        "15",
+        "--min-rate",
+        min_rate,
+    )
 
 
-def protocol_check(port: str) -> tuple[str, ...]:
-    return (*THROUGHPUT, "--port", port, "--protocol-check", "--wait-port", "15")
+def protocol_check(usb_id: str) -> tuple[str, ...]:
+    return (THROUGHPUT, "--port", usb_id, "--protocol-check", "--wait-port", "15")
 
 
 @dataclass(frozen=True)
@@ -140,25 +270,36 @@ class Test:
     binary: str
     ready: str | None = None
     host: tuple[tuple[str, ...], ...] = ()
-    sudo: bool = False
+    # Raw USB access to the vendor interface. Only Linux needs a privilege for it.
+    raw_usb: bool = False
     expect_ok: bool = True
     note: str = ""
 
 
 def conformance_test(name: str, pid: str, speed: str, note: str) -> Test:
     return Test(
-        name, TESTS, f"usb_{name}", ready="conformance ready", host=(conformance_command(pid, speed),), sudo=True, note=note
+        name,
+        TESTS,
+        f"usb_{name}",
+        ready="conformance ready",
+        host=(conformance_command(pid, speed),),
+        raw_usb=True,
+        note=note,
     )
 
 
-def throughput_test(speed: str, port: str, count: str, in_min: str, out_min: str) -> Test:
+def throughput_test(speed: str, usb_id: str, count: str, in_min: str, out_min: str) -> Test:
     name = f"{speed}_throughput"
     return Test(
         name,
         EXAMPLES,
         f"usb_{name}",
         ready="Initialization complete",
-        host=(protocol_check(port), throughput_command(port, "in", count, in_min), throughput_command(port, "out", count, out_min)),
+        host=(
+            protocol_check(usb_id),
+            throughput_command(usb_id, "in", count, in_min),
+            throughput_command(usb_id, "out", count, out_min),
+        ),
         expect_ok=False,
         note=f"CDC bulk throughput gate, >= {in_min}/{out_min} MB/s",
     )
@@ -176,13 +317,13 @@ TESTS_LIST = (
         TESTS,
         "usb_dual_pll0",
         ready="dual pll0 ready",
-        host=((sys.executable, os.path.join("host", "dual_echo.py")),),
+        host=((os.path.join("host", "dual_echo.py"),),),
         note="both controllers concurrently on PLL0 at 150 MHz",
     ),
     conformance_test("fs_conformance", "0xcb02", "fs", "full-speed control/bulk/iso/interrupt conformance"),
     conformance_test("hs_conformance", "0xcb01", "hs", "high-speed control/bulk/iso/interrupt conformance"),
-    throughput_test("fs", FS_PORT, "1_000_000", FS_IN_MIN, FS_OUT_MIN),
-    throughput_test("hs", HS_PORT, "4_000_000", HS_IN_MIN, HS_OUT_MIN),
+    throughput_test("fs", FS_USB_ID, "1_000_000", FS_IN_MIN, FS_OUT_MIN),
+    throughput_test("hs", HS_USB_ID, "4_000_000", HS_IN_MIN, HS_OUT_MIN),
 )
 
 # probe-rs itself is noisy about SWD retries during flashing, and those lines are not device
@@ -202,25 +343,21 @@ class Firmware:
         self.test = test
         self.lines: list[str] = []
         self._lock = threading.Lock()
-        self.proc = subprocess.Popen(
+        self.child = Child(
             ["cargo", "run", "--release", "--bin", test.binary],
             cwd=os.path.join(REPO, test.cwd),
-            stdout=subprocess.PIPE,
-            stderr=subprocess.STDOUT,
-            text=True,
-            bufsize=1,
-            start_new_session=True,
+            merge_stderr=True,
         )
         self._pump = threading.Thread(target=self._read, daemon=True)
         try:
             self._pump.start()
         except BaseException:
-            terminate_group(self.proc, signal.SIGINT)
+            self.child.stop()
             raise
 
     def _read(self) -> None:
-        assert self.proc.stdout is not None
-        for line in self.proc.stdout:
+        assert self.child.proc.stdout is not None
+        for line in self.child.proc.stdout:
             line = line.rstrip("\n")
             with self._lock:
                 self.lines.append(line)
@@ -236,7 +373,7 @@ class Firmware:
                 panicked = any(m in ln for ln in self.lines for m in PANIC_MARKERS)
             if panicked:
                 return False
-            if self.proc.poll() is not None:
+            if self.child.proc.poll() is not None:
                 # One last look: the child may have exited right after printing.
                 time.sleep(0.2)
                 with self._lock:
@@ -251,7 +388,7 @@ class Firmware:
 
     def probe_failure(self) -> str | None:
         """Describes an abnormal `probe-rs` exit. It otherwise sits at the breakpoint forever."""
-        code = self.proc.poll()
+        code = self.child.proc.poll()
         if code is None:
             return None
         with self._lock:
@@ -265,7 +402,7 @@ class Firmware:
         return ": ".join(parts)
 
     def stop(self) -> None:
-        terminate_group(self.proc, signal.SIGINT)
+        self.child.stop()
         self._pump.join(timeout=KILL_GRACE)
         if self._pump.is_alive():
             raise RuntimeError(f"firmware output thread for {self.test.name} did not stop")
@@ -273,19 +410,14 @@ class Firmware:
 
 def run_host(test: Test, argv: tuple[str, ...]) -> str | None:
     """Runs one host command. Returns None on success or a failure description."""
-    cmd = ["sudo", "-n", *argv] if test.sudo else list(argv)
-    printable = " ".join(os.path.basename(c) if c == sys.executable else c for c in cmd)
+    cmd = uv_command(argv)
+    if test.raw_usb and not WINDOWS:
+        cmd = ["sudo", "-n", *cmd]
+    printable = " ".join(os.path.basename(c) if c == UV else c for c in cmd)
     print(f"  [{test.name}] host: {printable}", flush=True)
     defer_handled_signals()
     try:
-        proc = subprocess.Popen(
-            cmd,
-            cwd=os.path.join(REPO, test.cwd),
-            stdout=subprocess.PIPE,
-            stderr=subprocess.PIPE,
-            text=True,
-            start_new_session=True,
-        )
+        child = Child(cmd, cwd=os.path.join(REPO, test.cwd), merge_stderr=False)
     except BaseException:
         resume_handled_signals()
         raise
@@ -294,15 +426,15 @@ def run_host(test: Test, argv: tuple[str, ...]) -> str | None:
     try:
         resume_handled_signals()
         try:
-            stdout, stderr = proc.communicate(timeout=HOST_TIMEOUT)
+            stdout, stderr = child.proc.communicate(timeout=HOST_TIMEOUT)
         except subprocess.TimeoutExpired:
             timed_out = True
-            terminate_group(proc, signal.SIGINT)
-            stdout, stderr = proc.communicate(timeout=KILL_GRACE)
+            child.stop()
+            stdout, stderr = child.proc.communicate(timeout=KILL_GRACE)
     finally:
         defer_handled_signals()
         try:
-            terminate_group(proc, signal.SIGINT)
+            child.stop()
         finally:
             resume_handled_signals()
 
@@ -311,13 +443,13 @@ def run_host(test: Test, argv: tuple[str, ...]) -> str | None:
             print(f"  [{test.name}] | {line}", flush=True)
     if timed_out:
         return f"host command timed out after {HOST_TIMEOUT:g} s: {printable}"
-    if proc.returncode != 0:
-        return f"host command exited {proc.returncode}: {printable}"
+    if child.proc.returncode != 0:
+        return f"host command exited {child.proc.returncode}: {printable}"
     return None
 
 
-def run_test(test: Test) -> str | None:
-    """Runs one entry. Returns None on pass or a one-line reason on failure."""
+def attempt_test(test: Test) -> str | None:
+    """Runs one entry once. Returns None on pass or a one-line reason on failure."""
     print(f"\n=== {test.name}: {test.note} ===", flush=True)
     defer_handled_signals()
     try:
@@ -361,6 +493,32 @@ def run_test(test: Test) -> str | None:
             resume_handled_signals()
 
 
+# The debug probe sometimes refuses the next session right after the previous one released
+# it. probe-rs reports that as a failure to open, before the firmware has run at all, and it
+# clears by itself, so it is worth another attempt rather than a verdict on the test.
+PROBE_NOT_READY = (
+    "Failed to open the debug probe",
+    "bulk write timed out",
+    "endpoint stalled",
+    "Access to the probe was denied",
+)
+PROBE_RETRIES = 2
+PROBE_RETRY_SETTLE = 4.0
+
+
+def run_test(test: Test) -> str | None:
+    """Runs one entry, retrying while only the probe is at fault."""
+    for attempt in range(PROBE_RETRIES + 1):
+        failure = attempt_test(test)
+        if failure is None or not any(marker in failure for marker in PROBE_NOT_READY):
+            return failure
+        if attempt < PROBE_RETRIES:
+            print(f"  [{test.name}] probe not ready: {failure}", flush=True)
+            print(f"  [{test.name}] retrying in {PROBE_RETRY_SETTLE:g} s", flush=True)
+            time.sleep(PROBE_RETRY_SETTLE)
+    return failure
+
+
 def main() -> None:
     parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
     parser.add_argument(
@@ -379,6 +537,9 @@ def main() -> None:
         for test in TESTS_LIST:
             print(f"{test.name:16} {test.cwd}/{test.binary:22} {test.note}")
         return
+
+    if UV is None:
+        sys.exit("error: `uv` is not on PATH; the host peers run through `uv run --script`")
 
     selected = TESTS_LIST
     if args.only:

--- a/tests/lpc55/run.py
+++ b/tests/lpc55/run.py
@@ -34,10 +34,83 @@ EXAMPLES = os.path.join("examples", "lpc55s69")
 
 READY_TIMEOUT = 90.0
 OK_TIMEOUT = 90.0
+HOST_TIMEOUT = 90.0
 # `probe-rs run` keeps the core halted at the breakpoint, so the child never exits on its own.
 KILL_GRACE = 5.0
 # Lets the previous probe-rs session detach and the host see the device go away.
 SETTLE = 1.5
+
+HANDLED_SIGNALS = (signal.SIGINT, signal.SIGTERM, signal.SIGHUP)
+_SIGNAL_NUMBER: int | None = None
+_SIGNAL_DEFERRED = False
+
+
+def handle_signal(signum: int, _frame: object) -> None:
+    global _SIGNAL_NUMBER
+    if _SIGNAL_NUMBER is None:
+        _SIGNAL_NUMBER = signum
+    if not _SIGNAL_DEFERRED:
+        raise KeyboardInterrupt
+
+
+def defer_handled_signals() -> None:
+    global _SIGNAL_DEFERRED
+    _SIGNAL_DEFERRED = True
+
+
+def resume_handled_signals() -> None:
+    global _SIGNAL_DEFERRED
+    _SIGNAL_DEFERRED = False
+    if _SIGNAL_NUMBER is not None:
+        raise KeyboardInterrupt
+
+
+def process_group_exists(pgid: int) -> bool:
+    try:
+        os.killpg(pgid, 0)
+    except ProcessLookupError:
+        return False
+    return True
+
+
+def wait_process_group(proc: subprocess.Popen[str], timeout: float) -> bool:
+    deadline = time.monotonic() + timeout
+    while process_group_exists(proc.pid):
+        remaining = deadline - time.monotonic()
+        if remaining <= 0:
+            return False
+        if proc.poll() is None:
+            try:
+                proc.wait(timeout=min(0.1, remaining))
+            except subprocess.TimeoutExpired:
+                pass
+        else:
+            time.sleep(min(0.05, remaining))
+    return True
+
+
+def terminate_group(proc: subprocess.Popen[str], first_signal: int) -> None:
+    for signum in (first_signal, signal.SIGTERM, signal.SIGKILL):
+        if not process_group_exists(proc.pid):
+            break
+        try:
+            os.killpg(proc.pid, signum)
+        except ProcessLookupError:
+            break
+        if wait_process_group(proc, KILL_GRACE):
+            break
+
+    if proc.poll() is None:
+        try:
+            proc.wait(timeout=KILL_GRACE)
+        except subprocess.TimeoutExpired:
+            try:
+                os.killpg(proc.pid, signal.SIGKILL)
+            except ProcessLookupError:
+                pass
+            proc.wait(timeout=KILL_GRACE)
+    else:
+        proc.wait()
 
 FS_PORT = "/dev/serial/by-id/usb-Embassy_USB-FS_throughput_test_12345678-if00"
 HS_PORT = "/dev/serial/by-id/usb-Embassy_USB-HS_throughput_test_12345678-if00"
@@ -68,6 +141,17 @@ def throughput(port: str, direction: str, count: str, min_rate: str) -> list[str
         min_rate,
     ]
 
+def protocol_check(port: str) -> list[str]:
+    return [
+        sys.executable,
+        os.path.join("scripts", "usb_throughput.py"),
+        "--port",
+        port,
+        "--protocol-check",
+        "--wait-port",
+        "15",
+    ]
+
 
 class Test:
     def __init__(
@@ -94,6 +178,7 @@ class Test:
 # Fastest and least cable-dependent first, so a broken setup fails early and cheaply.
 TESTS_LIST = [
     Test("alloc", TESTS, "usb_alloc", note="endpoint allocation limits, no host cable"),
+    Test("alloc_small", TESTS, "usb_alloc_small", note="exact 512-byte endpoint memory"),
     Test("bus_raw", TESTS, "usb_bus_raw", note="raw Bus disable/enable/reinit/force_reset"),
     Test("fs_enumerate", TESTS, "usb_fs_enumerate", note="USB0 reaches Configured (P10)"),
     Test("hs_enumerate", TESTS, "usb_hs_enumerate", note="USBHSD at 480 Mbps (P9)"),
@@ -129,6 +214,7 @@ TESTS_LIST = [
         "usb_fs_throughput",
         ready="Initialization complete",
         host=[
+            protocol_check(FS_PORT),
             throughput(FS_PORT, "in", "1_000_000", FS_IN_MIN),
             throughput(FS_PORT, "out", "1_000_000", FS_OUT_MIN),
         ],
@@ -141,6 +227,7 @@ TESTS_LIST = [
         "usb_hs_throughput",
         ready="Initialization complete",
         host=[
+            protocol_check(HS_PORT),
             throughput(HS_PORT, "in", "4_000_000", HS_IN_MIN),
             throughput(HS_PORT, "out", "4_000_000", HS_OUT_MIN),
         ],
@@ -173,9 +260,14 @@ class Firmware:
             stderr=subprocess.STDOUT,
             text=True,
             bufsize=1,
+            start_new_session=True,
         )
         self._pump = threading.Thread(target=self._read, daemon=True)
-        self._pump.start()
+        try:
+            self._pump.start()
+        except BaseException:
+            terminate_group(self.proc, signal.SIGINT)
+            raise
 
     def _read(self) -> None:
         assert self.proc.stdout is not None
@@ -224,14 +316,10 @@ class Firmware:
         return ": ".join(parts)
 
     def stop(self) -> None:
-        if self.proc.poll() is None:
-            self.proc.send_signal(signal.SIGINT)
-            try:
-                self.proc.wait(KILL_GRACE)
-            except subprocess.TimeoutExpired:
-                self.proc.kill()
-        self.proc.wait()
-        self._pump.join(timeout=2.0)
+        terminate_group(self.proc, signal.SIGINT)
+        self._pump.join(timeout=KILL_GRACE)
+        if self._pump.is_alive():
+            raise RuntimeError(f"firmware output thread for {self.test.name} did not stop")
 
 
 def run_host(test: Test, argv: list[str]) -> str | None:
@@ -239,15 +327,41 @@ def run_host(test: Test, argv: list[str]) -> str | None:
     cmd = ["sudo", "-n", *argv] if test.sudo else list(argv)
     printable = " ".join(os.path.basename(c) if c == sys.executable else c for c in cmd)
     print(f"  [{test.name}] host: {printable}", flush=True)
-    proc = subprocess.run(
-        cmd,
-        cwd=os.path.join(REPO, test.cwd),
-        capture_output=True,
-        text=True,
-    )
-    for stream in (proc.stdout, proc.stderr):
+    defer_handled_signals()
+    try:
+        proc = subprocess.Popen(
+            cmd,
+            cwd=os.path.join(REPO, test.cwd),
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+            start_new_session=True,
+        )
+    except BaseException:
+        resume_handled_signals()
+        raise
+
+    timed_out = False
+    try:
+        resume_handled_signals()
+        try:
+            stdout, stderr = proc.communicate(timeout=HOST_TIMEOUT)
+        except subprocess.TimeoutExpired:
+            timed_out = True
+            terminate_group(proc, signal.SIGINT)
+            stdout, stderr = proc.communicate(timeout=KILL_GRACE)
+    finally:
+        defer_handled_signals()
+        try:
+            terminate_group(proc, signal.SIGINT)
+        finally:
+            resume_handled_signals()
+
+    for stream in (stdout, stderr):
         for line in stream.splitlines():
             print(f"  [{test.name}] | {line}", flush=True)
+    if timed_out:
+        return f"host command timed out after {HOST_TIMEOUT:g} s: {printable}"
     if proc.returncode != 0:
         return f"host command exited {proc.returncode}: {printable}"
     return None
@@ -256,17 +370,24 @@ def run_host(test: Test, argv: list[str]) -> str | None:
 def run_test(test: Test) -> str | None:
     """Runs one entry. Returns None on pass or a one-line reason on failure."""
     print(f"\n=== {test.name}: {test.note} ===", flush=True)
-    fw = Firmware(test)
-
-    def verdict(timeout_reason: str) -> str:
-        # A device panic or a dead probe-rs explains a missing banner far better than a timeout:
-        # a flash that failed means the firmware never ran, so nothing was ever going to appear.
-        panics = fw.panics()
-        if panics:
-            return f"device panicked: {panics[0].strip()}"
-        return fw.probe_failure() or timeout_reason
+    defer_handled_signals()
+    try:
+        fw = Firmware(test)
+    except BaseException:
+        resume_handled_signals()
+        raise
 
     try:
+        resume_handled_signals()
+
+        def verdict(timeout_reason: str) -> str:
+            # A device panic or a dead probe-rs explains a missing banner far better than a timeout:
+            # a flash that failed means the firmware never ran, so nothing was ever going to appear.
+            panics = fw.panics()
+            if panics:
+                return f"device panicked: {panics[0].strip()}"
+            return fw.probe_failure() or timeout_reason
+
         if test.ready is not None and not fw.wait_for(test.ready, READY_TIMEOUT):
             return verdict(f"ready banner {test.ready!r} not seen within {READY_TIMEOUT:.0f} s")
 
@@ -283,8 +404,12 @@ def run_test(test: Test) -> str | None:
             return f"device panicked: {panics[0].strip()}"
         return fw.probe_failure()
     finally:
-        fw.stop()
-        time.sleep(SETTLE)
+        defer_handled_signals()
+        try:
+            fw.stop()
+            time.sleep(SETTLE)
+        finally:
+            resume_handled_signals()
 
 
 def main() -> None:
@@ -334,4 +459,9 @@ def main() -> None:
 
 
 if __name__ == "__main__":
-    main()
+    for caught_signal in HANDLED_SIGNALS:
+        signal.signal(caught_signal, handle_signal)
+    try:
+        main()
+    except KeyboardInterrupt:
+        sys.exit(128 + (_SIGNAL_NUMBER or signal.SIGINT))

--- a/tests/lpc55/run.py
+++ b/tests/lpc55/run.py
@@ -1,25 +1,23 @@
 #!/usr/bin/env python3
-"""Runs the whole LPC55 USB hardware-in-the-loop suite.
+"""Run the LPC55 USB hardware-in-the-loop suite.
 
-Each entry flashes one firmware over the debug probe with `cargo run --release`, waits for its
-ready banner on the RTT log, drives the host side of the test, and requires the device to
-print `Test OK`.
+For each entry, the runner flashes release firmware through `probe-rs`, waits for its RTT ready
+banner, starts the host peer, and requires `Test OK`.
 
-Run it unprivileged from anywhere in the repo: `cargo` and `probe-rs` must keep the user's
-`~/.cargo` and target directories. Only the pyusb-based conformance script is elevated, with
-this interpreter, because raw USB access to the vendor interface needs root and a plain
-`sudo python3` would not resolve pyusb.
+Run the suite as an unprivileged user so `cargo` and `probe-rs` retain the user's `~/.cargo` and
+target directories. Only the raw-USB conformance entries use `sudo -n` with this interpreter.
+A plain `sudo python3` might not resolve pyusb.
 
     python3 tests/lpc55/run.py [--only NAME]... [--list] [--keep-going]
 
-Hardware: an LPCXpresso55S69 EVK with a debug probe on the SWD header - the onboard LPC-LINK2
-or an external one such as a J-Link - plus host cables on both **P9** (USB1, high speed) and
-**P10** (USB0, full speed).
+Use an LPCXpresso55S69 EVK with a debug probe on the SWD header. Connect the host to P9
+(USB1, high speed) and P10 (USB0, full speed).
 """
 
 from __future__ import annotations
 
 import argparse
+from dataclasses import dataclass
 import os
 import re
 import signal
@@ -119,64 +117,55 @@ HS_PORT = "/dev/serial/by-id/usb-Embassy_USB-HS_throughput_test_12345678-if00"
 # real regression without tripping on host jitter.
 FS_IN_MIN, FS_OUT_MIN = "0.67", "0.61"
 HS_IN_MIN, HS_OUT_MIN = "33.0", "13.0"
+THROUGHPUT = (sys.executable, os.path.join("scripts", "usb_throughput.py"))
 
 
-def conformance(pid: str, speed: str) -> list[str]:
-    return [sys.executable, os.path.join("host", "conformance.py"), "--pid", pid, "--speed", speed]
+
+def conformance_command(pid: str, speed: str) -> tuple[str, ...]:
+    return (sys.executable, os.path.join("host", "conformance.py"), "--pid", pid, "--speed", speed)
 
 
-def throughput(port: str, direction: str, count: str, min_rate: str) -> list[str]:
-    return [
-        sys.executable,
-        os.path.join("scripts", "usb_throughput.py"),
-        "--port",
-        port,
-        "--dir",
-        direction,
-        "--bytes",
-        count,
-        "--wait-port",
-        "15",
-        "--min-rate",
-        min_rate,
-    ]
-
-def protocol_check(port: str) -> list[str]:
-    return [
-        sys.executable,
-        os.path.join("scripts", "usb_throughput.py"),
-        "--port",
-        port,
-        "--protocol-check",
-        "--wait-port",
-        "15",
-    ]
+def throughput_command(port: str, direction: str, count: str, min_rate: str) -> tuple[str, ...]:
+    return (*THROUGHPUT, "--port", port, "--dir", direction, "--bytes", count, "--wait-port", "15", "--min-rate", min_rate)
 
 
+def protocol_check(port: str) -> tuple[str, ...]:
+    return (*THROUGHPUT, "--port", port, "--protocol-check", "--wait-port", "15")
+
+
+@dataclass(frozen=True)
 class Test:
-    def __init__(
-        self,
-        name: str,
-        cwd: str,
-        binary: str,
-        ready: str | None = None,
-        host: list[list[str]] | None = None,
-        sudo: bool = False,
-        expect_ok: bool = True,
-        note: str = "",
-    ) -> None:
-        self.name = name
-        self.cwd = cwd
-        self.binary = binary
-        self.ready = ready
-        self.host = host or []
-        self.sudo = sudo
-        self.expect_ok = expect_ok
-        self.note = note
+    name: str
+    cwd: str
+    binary: str
+    ready: str | None = None
+    host: tuple[tuple[str, ...], ...] = ()
+    sudo: bool = False
+    expect_ok: bool = True
+    note: str = ""
+
+
+def conformance_test(name: str, pid: str, speed: str, note: str) -> Test:
+    return Test(
+        name, TESTS, f"usb_{name}", ready="conformance ready", host=(conformance_command(pid, speed),), sudo=True, note=note
+    )
+
+
+def throughput_test(speed: str, port: str, count: str, in_min: str, out_min: str) -> Test:
+    name = f"{speed}_throughput"
+    return Test(
+        name,
+        EXAMPLES,
+        f"usb_{name}",
+        ready="Initialization complete",
+        host=(protocol_check(port), throughput_command(port, "in", count, in_min), throughput_command(port, "out", count, out_min)),
+        expect_ok=False,
+        note=f"CDC bulk throughput gate, >= {in_min}/{out_min} MB/s",
+    )
 
 
 # Fastest and least cable-dependent first, so a broken setup fails early and cheaply.
-TESTS_LIST = [
+TESTS_LIST = (
     Test("alloc", TESTS, "usb_alloc", note="endpoint allocation limits, no host cable"),
     Test("alloc_small", TESTS, "usb_alloc_small", note="exact 512-byte endpoint memory"),
     Test("bus_raw", TESTS, "usb_bus_raw", note="raw Bus disable/enable/reinit/force_reset"),
@@ -187,54 +176,14 @@ TESTS_LIST = [
         TESTS,
         "usb_dual_pll0",
         ready="dual pll0 ready",
-        host=[[sys.executable, os.path.join("host", "dual_echo.py")]],
+        host=((sys.executable, os.path.join("host", "dual_echo.py")),),
         note="both controllers concurrently on PLL0 at 150 MHz",
     ),
-    Test(
-        "fs_conformance",
-        TESTS,
-        "usb_fs_conformance",
-        ready="conformance ready",
-        host=[conformance("0xcb02", "fs")],
-        sudo=True,
-        note="full-speed control/bulk/iso/interrupt conformance",
-    ),
-    Test(
-        "hs_conformance",
-        TESTS,
-        "usb_hs_conformance",
-        ready="conformance ready",
-        host=[conformance("0xcb01", "hs")],
-        sudo=True,
-        note="high-speed control/bulk/iso/interrupt conformance",
-    ),
-    Test(
-        "fs_throughput",
-        EXAMPLES,
-        "usb_fs_throughput",
-        ready="Initialization complete",
-        host=[
-            protocol_check(FS_PORT),
-            throughput(FS_PORT, "in", "1_000_000", FS_IN_MIN),
-            throughput(FS_PORT, "out", "1_000_000", FS_OUT_MIN),
-        ],
-        expect_ok=False,
-        note=f"CDC bulk throughput gate, >= {FS_IN_MIN}/{FS_OUT_MIN} MB/s",
-    ),
-    Test(
-        "hs_throughput",
-        EXAMPLES,
-        "usb_hs_throughput",
-        ready="Initialization complete",
-        host=[
-            protocol_check(HS_PORT),
-            throughput(HS_PORT, "in", "4_000_000", HS_IN_MIN),
-            throughput(HS_PORT, "out", "4_000_000", HS_OUT_MIN),
-        ],
-        expect_ok=False,
-        note=f"CDC bulk throughput gate, >= {HS_IN_MIN}/{HS_OUT_MIN} MB/s",
-    ),
-]
+    conformance_test("fs_conformance", "0xcb02", "fs", "full-speed control/bulk/iso/interrupt conformance"),
+    conformance_test("hs_conformance", "0xcb01", "hs", "high-speed control/bulk/iso/interrupt conformance"),
+    throughput_test("fs", FS_PORT, "1_000_000", FS_IN_MIN, FS_OUT_MIN),
+    throughput_test("hs", HS_PORT, "4_000_000", HS_IN_MIN, HS_OUT_MIN),
+)
 
 # probe-rs itself is noisy about SWD retries during flashing, and those lines are not device
 # output; only match what the firmware could have printed.
@@ -322,7 +271,7 @@ class Firmware:
             raise RuntimeError(f"firmware output thread for {self.test.name} did not stop")
 
 
-def run_host(test: Test, argv: list[str]) -> str | None:
+def run_host(test: Test, argv: tuple[str, ...]) -> str | None:
     """Runs one host command. Returns None on success or a failure description."""
     cmd = ["sudo", "-n", *argv] if test.sudo else list(argv)
     printable = " ".join(os.path.basename(c) if c == sys.executable else c for c in cmd)

--- a/tests/lpc55/run.py
+++ b/tests/lpc55/run.py
@@ -1,0 +1,312 @@
+#!/usr/bin/env python3
+"""Runs the whole LPC55 USB hardware-in-the-loop suite.
+
+Each entry flashes one firmware over the J-Link with `cargo run --release`, waits for its
+ready banner on the RTT log, drives the host side of the test, and requires the device to
+print `Test OK`.
+
+Run it unprivileged from anywhere in the repo: `cargo` and `probe-rs` must keep the user's
+`~/.cargo` and target directories. Only the pyusb-based conformance script is elevated, with
+this interpreter, because raw USB access to the vendor interface needs root and a plain
+`sudo python3` would not resolve pyusb.
+
+    python3 tests/lpc55/run.py [--only NAME]... [--list] [--keep-going]
+
+Hardware: an LPCXpresso55S69 EVK with the onboard J-Link connected, plus host cables on both
+**P9** (USB1, high speed) and **P10** (USB0, full speed).
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import signal
+import subprocess
+import sys
+import threading
+import time
+
+REPO = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+TESTS = os.path.join("tests", "lpc55")
+EXAMPLES = os.path.join("examples", "lpc55s69")
+
+READY_TIMEOUT = 90.0
+OK_TIMEOUT = 90.0
+# `probe-rs run` keeps the core halted at the breakpoint, so the child never exits on its own.
+KILL_GRACE = 5.0
+# Lets the previous probe-rs session detach and the host see the device go away.
+SETTLE = 1.5
+
+FS_PORT = "/dev/serial/by-id/usb-Embassy_USB-FS_throughput_test_12345678-if00"
+HS_PORT = "/dev/serial/by-id/usb-Embassy_USB-HS_throughput_test_12345678-if00"
+
+# Roughly 75 % of the release-profile numbers recorded in README.md, so the gate catches a
+# real regression without tripping on host jitter.
+FS_IN_MIN, FS_OUT_MIN = "0.67", "0.61"
+HS_IN_MIN, HS_OUT_MIN = "33.0", "13.0"
+
+
+def conformance(pid: str, speed: str) -> list[str]:
+    return [sys.executable, os.path.join("host", "conformance.py"), "--pid", pid, "--speed", speed]
+
+
+def throughput(port: str, direction: str, count: str, min_rate: str) -> list[str]:
+    return [
+        sys.executable,
+        os.path.join("scripts", "usb_throughput.py"),
+        "--port",
+        port,
+        "--dir",
+        direction,
+        "--bytes",
+        count,
+        "--wait-port",
+        "15",
+        "--min-rate",
+        min_rate,
+    ]
+
+
+class Test:
+    def __init__(
+        self,
+        name: str,
+        cwd: str,
+        binary: str,
+        ready: str | None = None,
+        host: list[list[str]] | None = None,
+        sudo: bool = False,
+        expect_ok: bool = True,
+        note: str = "",
+    ) -> None:
+        self.name = name
+        self.cwd = cwd
+        self.binary = binary
+        self.ready = ready
+        self.host = host or []
+        self.sudo = sudo
+        self.expect_ok = expect_ok
+        self.note = note
+
+
+# Fastest and least cable-dependent first, so a broken setup fails early and cheaply.
+TESTS_LIST = [
+    Test("alloc", TESTS, "usb_alloc", note="endpoint allocation limits, no host cable"),
+    Test("bus_raw", TESTS, "usb_bus_raw", note="raw Bus disable/enable/reinit/force_reset"),
+    Test("fs_enumerate", TESTS, "usb_fs_enumerate", note="USB0 reaches Configured (P10)"),
+    Test("hs_enumerate", TESTS, "usb_hs_enumerate", note="USBHSD at 480 Mbps (P9)"),
+    Test(
+        "dual_pll0",
+        TESTS,
+        "usb_dual_pll0",
+        ready="dual pll0 ready",
+        host=[[sys.executable, os.path.join("host", "dual_echo.py")]],
+        note="both controllers concurrently on PLL0 at 150 MHz",
+    ),
+    Test(
+        "fs_conformance",
+        TESTS,
+        "usb_fs_conformance",
+        ready="conformance ready",
+        host=[conformance("0xcb02", "fs")],
+        sudo=True,
+        note="full-speed control/bulk/iso/interrupt conformance",
+    ),
+    Test(
+        "hs_conformance",
+        TESTS,
+        "usb_hs_conformance",
+        ready="conformance ready",
+        host=[conformance("0xcb01", "hs")],
+        sudo=True,
+        note="high-speed control/bulk/iso/interrupt conformance",
+    ),
+    Test(
+        "fs_throughput",
+        EXAMPLES,
+        "usb_fs_throughput",
+        ready="Initialization complete",
+        host=[
+            throughput(FS_PORT, "in", "1_000_000", FS_IN_MIN),
+            throughput(FS_PORT, "out", "1_000_000", FS_OUT_MIN),
+        ],
+        expect_ok=False,
+        note=f"CDC bulk throughput gate, >= {FS_IN_MIN}/{FS_OUT_MIN} MB/s",
+    ),
+    Test(
+        "hs_throughput",
+        EXAMPLES,
+        "usb_hs_throughput",
+        ready="Initialization complete",
+        host=[
+            throughput(HS_PORT, "in", "4_000_000", HS_IN_MIN),
+            throughput(HS_PORT, "out", "4_000_000", HS_OUT_MIN),
+        ],
+        expect_ok=False,
+        note=f"CDC bulk throughput gate, >= {HS_IN_MIN}/{HS_OUT_MIN} MB/s",
+    ),
+]
+
+# probe-rs itself is noisy about SWD retries during flashing, and those lines are not device
+# output; only match what the firmware could have printed.
+PANIC_MARKERS = ("panicked", "PANIC", "[ERROR]")
+
+
+class Firmware:
+    """`cargo run --release --bin <bin>`, with its output captured line by line."""
+
+    def __init__(self, test: Test) -> None:
+        self.test = test
+        self.lines: list[str] = []
+        self._lock = threading.Lock()
+        self.proc = subprocess.Popen(
+            ["cargo", "run", "--release", "--bin", test.binary],
+            cwd=os.path.join(REPO, test.cwd),
+            stdout=subprocess.PIPE,
+            stderr=subprocess.STDOUT,
+            text=True,
+            bufsize=1,
+        )
+        self._pump = threading.Thread(target=self._read, daemon=True)
+        self._pump.start()
+
+    def _read(self) -> None:
+        assert self.proc.stdout is not None
+        for line in self.proc.stdout:
+            line = line.rstrip("\n")
+            with self._lock:
+                self.lines.append(line)
+            print(f"  [{self.test.name}] {line}", flush=True)
+
+    def wait_for(self, needle: str, timeout: float) -> bool:
+        """Waits for `needle`. Returns early on a device panic - it will not come."""
+        deadline = time.monotonic() + timeout
+        while True:
+            with self._lock:
+                if any(needle in line for line in self.lines):
+                    return True
+                panicked = any(m in ln for ln in self.lines for m in PANIC_MARKERS)
+            if panicked:
+                return False
+            if self.proc.poll() is not None:
+                # One last look: the child may have exited right after printing.
+                time.sleep(0.2)
+                with self._lock:
+                    return any(needle in line for line in self.lines)
+            if time.monotonic() >= deadline:
+                return False
+            time.sleep(0.1)
+
+    def panics(self) -> list[str]:
+        with self._lock:
+            return [ln for ln in self.lines if any(m in ln for m in PANIC_MARKERS)]
+
+    def stop(self) -> None:
+        if self.proc.poll() is None:
+            self.proc.send_signal(signal.SIGINT)
+            try:
+                self.proc.wait(KILL_GRACE)
+            except subprocess.TimeoutExpired:
+                self.proc.kill()
+        self.proc.wait()
+        self._pump.join(timeout=2.0)
+
+
+def run_host(test: Test, argv: list[str]) -> str | None:
+    """Runs one host command. Returns None on success or a failure description."""
+    cmd = ["sudo", "-n", *argv] if test.sudo else list(argv)
+    printable = " ".join(os.path.basename(c) if c == sys.executable else c for c in cmd)
+    print(f"  [{test.name}] host: {printable}", flush=True)
+    proc = subprocess.run(
+        cmd,
+        cwd=os.path.join(REPO, test.cwd),
+        capture_output=True,
+        text=True,
+    )
+    for stream in (proc.stdout, proc.stderr):
+        for line in stream.splitlines():
+            print(f"  [{test.name}] | {line}", flush=True)
+    if proc.returncode != 0:
+        return f"host command exited {proc.returncode}: {printable}"
+    return None
+
+
+def run_test(test: Test) -> str | None:
+    """Runs one entry. Returns None on pass or a one-line reason on failure."""
+    print(f"\n=== {test.name}: {test.note} ===", flush=True)
+    fw = Firmware(test)
+
+    def verdict(timeout_reason: str) -> str:
+        # A device panic explains a missing banner far better than the timeout.
+        panics = fw.panics()
+        return f"device panicked: {panics[0].strip()}" if panics else timeout_reason
+
+    try:
+        if test.ready is not None and not fw.wait_for(test.ready, READY_TIMEOUT):
+            return verdict(f"ready banner {test.ready!r} not seen within {READY_TIMEOUT:.0f} s")
+
+        for argv in test.host:
+            failure = run_host(test, argv)
+            if failure is not None:
+                return verdict(failure)
+
+        if test.expect_ok and not fw.wait_for("Test OK", OK_TIMEOUT):
+            return verdict(f"device did not print 'Test OK' within {OK_TIMEOUT:.0f} s")
+
+        panics = fw.panics()
+        if panics:
+            return f"device panicked: {panics[0].strip()}"
+        return None
+    finally:
+        fw.stop()
+        time.sleep(SETTLE)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    parser.add_argument(
+        "--only",
+        action="append",
+        metavar="NAME",
+        help="run only this test; repeatable",
+    )
+    parser.add_argument("--list", action="store_true", help="list the tests and exit")
+    parser.add_argument(
+        "--keep-going", action="store_true", help="run the remaining tests after a failure"
+    )
+    args = parser.parse_args()
+
+    if args.list:
+        for test in TESTS_LIST:
+            print(f"{test.name:16} {test.cwd}/{test.binary:22} {test.note}")
+        return
+
+    selected = TESTS_LIST
+    if args.only:
+        known = {t.name for t in TESTS_LIST}
+        unknown = [n for n in args.only if n not in known]
+        if unknown:
+            parser.error(f"unknown test(s): {', '.join(unknown)}; try --list")
+        selected = [t for t in TESTS_LIST if t.name in set(args.only)]
+
+    results: list[tuple[str, str | None]] = []
+    for test in selected:
+        failure = run_test(test)
+        results.append((test.name, failure))
+        if failure is not None:
+            print(f"  [{test.name}] FAIL: {failure}", flush=True)
+            if not args.keep_going:
+                break
+
+    print("\n=== summary ===")
+    width = max(len(name) for name, _ in results)
+    for name, failure in results:
+        print(f"{name:{width}}  {'PASS' if failure is None else 'FAIL  ' + failure}")
+    skipped = len(selected) - len(results)
+    if skipped:
+        print(f"({skipped} test(s) not run; pass --keep-going to continue past a failure)")
+    sys.exit(1 if any(f is not None for _, f in results) or skipped else 0)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/lpc55/run.py
+++ b/tests/lpc55/run.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 """Runs the whole LPC55 USB hardware-in-the-loop suite.
 
-Each entry flashes one firmware over the J-Link with `cargo run --release`, waits for its
+Each entry flashes one firmware over the debug probe with `cargo run --release`, waits for its
 ready banner on the RTT log, drives the host side of the test, and requires the device to
 print `Test OK`.
 
@@ -12,8 +12,9 @@ this interpreter, because raw USB access to the vendor interface needs root and 
 
     python3 tests/lpc55/run.py [--only NAME]... [--list] [--keep-going]
 
-Hardware: an LPCXpresso55S69 EVK with the onboard J-Link connected, plus host cables on both
-**P9** (USB1, high speed) and **P10** (USB0, full speed).
+Hardware: an LPCXpresso55S69 EVK with a debug probe on the SWD header - the onboard LPC-LINK2
+or an external one such as a J-Link - plus host cables on both **P9** (USB1, high speed) and
+**P10** (USB0, full speed).
 """
 
 from __future__ import annotations

--- a/tests/lpc55/src/bin/usb_alloc.rs
+++ b/tests/lpc55/src/bin/usb_alloc.rs
@@ -1,0 +1,150 @@
+//! Endpoint allocation limits for both LPC55 USB controllers.
+//!
+//! Needs no host cable: neither driver is ever started, so no bus traffic
+//! happens. This is the only test that catches a pure allocator regression.
+//!
+//! Endpoint indices, not bytes, are what the exhaustion assertions probe: they
+//! use small endpoints so the relevant limit is `Instance::EP_COUNT` rather
+//! than the size of the endpoint memory, which would make the test brittle.
+
+#![no_std]
+#![no_main]
+
+use defmt_rtt as _;
+use embassy_executor::Spawner;
+use embassy_nxp::config::MainClock;
+use embassy_nxp::usb::{Driver, InterruptHandler, Memory};
+use embassy_nxp::{bind_interrupts, peripherals};
+use embassy_usb::driver::{Direction, Driver as _, EndpointAddress, EndpointType};
+use panic_probe as _;
+
+bind_interrupts!(struct Irqs {
+    USB0 => InterruptHandler<peripherals::USB0>;
+    USB1 => InterruptHandler<peripherals::USBHSD>;
+});
+
+/// Endpoint memory for USB0, in main SRAM. 4 KiB is enough for the command
+/// list plus every full-speed endpoint this test allocates.
+#[repr(C, align(256))]
+struct EpMem([u8; 4096]);
+static mut EP_MEM: EpMem = EpMem([0; 4096]);
+
+#[embassy_executor::main]
+async fn main(_spawner: Spawner) {
+    let mut config = embassy_nxp::config::Config::default();
+    // The high-speed controller requires a system clock of at least 96 MHz.
+    config.main_clock = MainClock::FroHf96;
+    let p = embassy_nxp::init(config);
+
+    // ---------------------------------------------------------------- USB1 HS
+    // EP_COUNT = 6, so data endpoint indices 1..=5 are usable per direction.
+    let mut hs = Driver::<peripherals::USBHSD>::new(p.USBHSD, Irqs, Memory::usb1_sram());
+
+    defmt::assert!(
+        hs.alloc_endpoint_out(EndpointType::Bulk, None, 512, 0).is_ok(),
+        "hs 1: bulk OUT 512 must be accepted (index 1 OUT)"
+    );
+    defmt::assert!(
+        hs.alloc_endpoint_out(EndpointType::Bulk, None, 1024, 0).is_err(),
+        "hs 2: bulk OUT 1024 exceeds the 512-byte high-speed bulk cap"
+    );
+    defmt::assert!(
+        hs.alloc_endpoint_in(EndpointType::Interrupt, None, 1024, 0).is_ok(),
+        "hs 3: interrupt IN 1024 must be accepted (index 1 IN)"
+    );
+    defmt::assert!(
+        hs.alloc_endpoint_out(EndpointType::Isochronous, None, 1024, 0).is_ok(),
+        "hs 4: isochronous OUT 1024 must be accepted (index 2 OUT)"
+    );
+    defmt::assert!(
+        hs.alloc_endpoint_in(EndpointType::Isochronous, None, 1024, 0).is_err(),
+        "hs 5: isochronous IN 1024 must be rejected (erratum USB.6)"
+    );
+    defmt::assert!(
+        hs.alloc_endpoint_in(EndpointType::Isochronous, None, 1023, 0).is_ok(),
+        "hs 6: isochronous IN 1023 must be accepted (index 2 IN)"
+    );
+    defmt::assert!(
+        hs.alloc_endpoint_in(EndpointType::Control, None, 64, 0).is_err(),
+        "hs 7: control endpoints beyond EP0 must be rejected"
+    );
+    defmt::assert!(
+        hs.alloc_endpoint_in(
+            EndpointType::Bulk,
+            Some(EndpointAddress::from_parts(1, Direction::In)),
+            512,
+            0
+        )
+        .is_err(),
+        "hs 8: index 1 IN is already taken"
+    );
+
+    // The 4096-byte multi-packet slots no longer fit alongside the isochronous
+    // endpoints allocated above, so this exercises the driver's single-packet
+    // fallback: it must succeed anyway.
+    defmt::assert!(
+        hs.alloc_endpoint_out(EndpointType::Bulk, None, 512, 0).is_ok(),
+        "hs 9: bulk OUT 512 must fall back to single-packet slots (index 3 OUT)"
+    );
+
+    // Index exhaustion on the IN side, using 64-byte endpoints so the limit
+    // reached is EP_COUNT and not the remaining endpoint memory. Indices 1 and
+    // 2 IN are taken, so exactly three more must fit.
+    for i in 3..=5 {
+        defmt::assert!(
+            hs.alloc_endpoint_in(EndpointType::Interrupt, None, 64, 0).is_ok(),
+            "hs 10: interrupt IN 64 must be accepted at index {}",
+            i
+        );
+    }
+    defmt::assert!(
+        hs.alloc_endpoint_in(EndpointType::Interrupt, None, 64, 0).is_err(),
+        "hs 11: no IN endpoint index is left"
+    );
+
+    // ---------------------------------------------------------------- USB0 FS
+    // EP_COUNT = 5, so data endpoint indices 1..=4 are usable per direction.
+    let mem = Memory::buffer(unsafe { &mut (*(&raw mut EP_MEM)).0 });
+    let mut fs = Driver::<peripherals::USB0>::new(p.USB0, Irqs, p.PIO0_22, mem);
+
+    defmt::assert!(
+        fs.alloc_endpoint_out(EndpointType::Bulk, None, 64, 0).is_ok(),
+        "fs 1: bulk OUT 64 must be accepted (index 1 OUT)"
+    );
+    defmt::assert!(
+        fs.alloc_endpoint_out(EndpointType::Bulk, None, 128, 0).is_err(),
+        "fs 2: bulk OUT 128 exceeds the 64-byte full-speed bulk cap"
+    );
+    defmt::assert!(
+        fs.alloc_endpoint_in(EndpointType::Interrupt, None, 64, 0).is_ok(),
+        "fs 3: interrupt IN 64 must be accepted (index 1 IN)"
+    );
+    defmt::assert!(
+        fs.alloc_endpoint_in(EndpointType::Interrupt, None, 128, 0).is_err(),
+        "fs 4: interrupt IN 128 exceeds the 64-byte full-speed interrupt cap"
+    );
+    defmt::assert!(
+        fs.alloc_endpoint_out(EndpointType::Isochronous, None, 1023, 0).is_ok(),
+        "fs 5: isochronous OUT 1023 must be accepted (index 2 OUT)"
+    );
+    defmt::assert!(
+        fs.alloc_endpoint_out(EndpointType::Isochronous, None, 1024, 0).is_err(),
+        "fs 6: isochronous OUT 1024 exceeds the full-speed isochronous cap"
+    );
+
+    // Indices 3 and 4 OUT, then index exhaustion.
+    for i in 3..=4 {
+        defmt::assert!(
+            fs.alloc_endpoint_out(EndpointType::Bulk, None, 64, 0).is_ok(),
+            "fs 7: bulk OUT 64 must be accepted at index {}",
+            i
+        );
+    }
+    defmt::assert!(
+        fs.alloc_endpoint_out(EndpointType::Bulk, None, 64, 0).is_err(),
+        "fs 8: no OUT endpoint index is left"
+    );
+
+    defmt::info!("Test OK");
+    cortex_m::asm::bkpt();
+}

--- a/tests/lpc55/src/bin/usb_alloc.rs
+++ b/tests/lpc55/src/bin/usb_alloc.rs
@@ -23,12 +23,6 @@ bind_interrupts!(struct Irqs {
     USB1 => InterruptHandler<peripherals::USBHSD>;
 });
 
-/// Endpoint memory for USB0, in main SRAM. 4 KiB is enough for the command
-/// list plus every full-speed endpoint this test allocates.
-#[repr(C, align(256))]
-struct EpMem([u8; 4096]);
-static mut EP_MEM: EpMem = EpMem([0; 4096]);
-
 #[embassy_executor::main]
 async fn main(_spawner: Spawner) {
     let mut config = embassy_nxp::config::Config::default();
@@ -104,7 +98,10 @@ async fn main(_spawner: Spawner) {
 
     // ---------------------------------------------------------------- USB0 FS
     // EP_COUNT = 5, so data endpoint indices 1..=4 are usable per direction.
-    let mem = Memory::buffer(unsafe { &mut (*(&raw mut EP_MEM)).0 });
+    // 4 KiB is enough for the command list plus every full-speed endpoint this
+    // test allocates.
+    let mut ep_mem = [0u8; 4096];
+    let mem = Memory::buffer(&mut ep_mem);
     let mut fs = Driver::<peripherals::USB0>::new(p.USB0, Irqs, p.PIO0_22, mem);
 
     defmt::assert!(

--- a/tests/lpc55/src/bin/usb_alloc.rs
+++ b/tests/lpc55/src/bin/usb_alloc.rs
@@ -23,6 +23,15 @@ bind_interrupts!(struct Irqs {
     USB1 => InterruptHandler<peripherals::USBHSD>;
 });
 
+fn expect_ok<T, E>(result: Result<T, E>, message: &'static str) {
+    defmt::assert!(result.is_ok(), "{}", message);
+}
+
+fn expect_err<T, E>(result: Result<T, E>, message: &'static str) {
+    defmt::assert!(result.is_err(), "{}", message);
+}
+
+
 #[embassy_executor::main]
 async fn main(_spawner: Spawner) {
     let mut config = embassy_nxp::config::Config::default();
@@ -34,50 +43,38 @@ async fn main(_spawner: Spawner) {
     // EP_COUNT = 6, so data endpoint indices 1..=5 are usable per direction.
     let mut hs = Driver::<peripherals::USBHSD>::new(p.USBHSD, Irqs, Memory::usb1_sram());
 
-    defmt::assert!(
-        hs.alloc_endpoint_out(EndpointType::Bulk, None, 512, 0).is_ok(),
-        "hs 1: bulk OUT 512 must be accepted (index 1 OUT)"
+    expect_ok(hs.alloc_endpoint_out(EndpointType::Bulk, None, 512, 0), "hs 1: bulk OUT 512");
+    expect_err(hs.alloc_endpoint_out(EndpointType::Bulk, None, 1024, 0), "hs 2: bulk OUT 1024");
+    expect_ok(
+        hs.alloc_endpoint_in(EndpointType::Interrupt, None, 1024, 0),
+        "hs 3: interrupt IN 1024",
     );
-    defmt::assert!(
-        hs.alloc_endpoint_out(EndpointType::Bulk, None, 1024, 0).is_err(),
-        "hs 2: bulk OUT 1024 exceeds the 512-byte high-speed bulk cap"
+    expect_ok(
+        hs.alloc_endpoint_out(EndpointType::Isochronous, None, 1024, 0),
+        "hs 4: isochronous OUT 1024",
     );
-    defmt::assert!(
-        hs.alloc_endpoint_in(EndpointType::Interrupt, None, 1024, 0).is_ok(),
-        "hs 3: interrupt IN 1024 must be accepted (index 1 IN)"
+    expect_err(
+        hs.alloc_endpoint_in(EndpointType::Isochronous, None, 1024, 0),
+        "hs 5: isochronous IN 1024 (erratum USB.6)",
     );
-    defmt::assert!(
-        hs.alloc_endpoint_out(EndpointType::Isochronous, None, 1024, 0).is_ok(),
-        "hs 4: isochronous OUT 1024 must be accepted (index 2 OUT)"
+    expect_ok(
+        hs.alloc_endpoint_in(EndpointType::Isochronous, None, 1023, 0),
+        "hs 6: isochronous IN 1023",
     );
-    defmt::assert!(
-        hs.alloc_endpoint_in(EndpointType::Isochronous, None, 1024, 0).is_err(),
-        "hs 5: isochronous IN 1024 must be rejected (erratum USB.6)"
-    );
-    defmt::assert!(
-        hs.alloc_endpoint_in(EndpointType::Isochronous, None, 1023, 0).is_ok(),
-        "hs 6: isochronous IN 1023 must be accepted (index 2 IN)"
-    );
-    defmt::assert!(
-        hs.alloc_endpoint_in(EndpointType::Control, None, 64, 0).is_err(),
-        "hs 7: control endpoints beyond EP0 must be rejected"
-    );
-    defmt::assert!(
+    expect_err(hs.alloc_endpoint_in(EndpointType::Control, None, 64, 0), "hs 7: control beyond EP0");
+    expect_err(
         hs.alloc_endpoint_in(
             EndpointType::Bulk,
             Some(EndpointAddress::from_parts(1, Direction::In)),
             512,
-            0
-        )
-        .is_err(),
-        "hs 8: index 1 IN is already taken"
+            0,
+        ),
+        "hs 8: index 1 IN already taken",
     );
-
-    defmt::assert!(
-        hs.alloc_endpoint_out(EndpointType::Interrupt, None, 1024, 0).is_ok(),
-        "hs 9: interrupt OUT 1024 must be accepted (index 3 OUT)"
+    expect_ok(
+        hs.alloc_endpoint_out(EndpointType::Interrupt, None, 1024, 0),
+        "hs 9: interrupt OUT 1024",
     );
-
     // The extra interrupt-OUT slots leave too little memory for two 3,584-byte
     // bulk-IN slots. The allocator must fall back to two 512-byte slots.
     let fallback = match hs.alloc_endpoint_in(EndpointType::Bulk, None, 512, 0) {
@@ -91,17 +88,13 @@ async fn main(_spawner: Spawner) {
     );
 
     // Indices 1 through 3 IN are taken, so only indices 4 and 5 remain.
-    for i in 4..=5 {
-        defmt::assert!(
-            hs.alloc_endpoint_in(EndpointType::Interrupt, None, 64, 0).is_ok(),
-            "hs 11: interrupt IN 64 must be accepted at index {}",
-            i
+    for _ in 4..=5 {
+        expect_ok(
+            hs.alloc_endpoint_in(EndpointType::Interrupt, None, 64, 0),
+            "hs 11: interrupt IN 64",
         );
     }
-    defmt::assert!(
-        hs.alloc_endpoint_in(EndpointType::Interrupt, None, 64, 0).is_err(),
-        "hs 12: no IN endpoint index is left"
-    );
+    expect_err(hs.alloc_endpoint_in(EndpointType::Interrupt, None, 64, 0), "hs 12: IN index exhaustion");
 
     // ---------------------------------------------------------------- USB0 FS
     // EP_COUNT = 5, so data endpoint indices 1..=4 are usable per direction.
@@ -111,43 +104,30 @@ async fn main(_spawner: Spawner) {
     let mem = Memory::buffer(&mut ep_mem);
     let mut fs = Driver::<peripherals::USB0>::new(p.USB0, Irqs, p.PIO0_22, mem);
 
-    defmt::assert!(
-        fs.alloc_endpoint_out(EndpointType::Bulk, None, 64, 0).is_ok(),
-        "fs 1: bulk OUT 64 must be accepted (index 1 OUT)"
+    expect_ok(fs.alloc_endpoint_out(EndpointType::Bulk, None, 64, 0), "fs 1: bulk OUT 64");
+    expect_err(fs.alloc_endpoint_out(EndpointType::Bulk, None, 128, 0), "fs 2: bulk OUT 128");
+    expect_ok(
+        fs.alloc_endpoint_in(EndpointType::Interrupt, None, 64, 0),
+        "fs 3: interrupt IN 64",
     );
-    defmt::assert!(
-        fs.alloc_endpoint_out(EndpointType::Bulk, None, 128, 0).is_err(),
-        "fs 2: bulk OUT 128 exceeds the 64-byte full-speed bulk cap"
+    expect_err(
+        fs.alloc_endpoint_in(EndpointType::Interrupt, None, 128, 0),
+        "fs 4: interrupt IN 128",
     );
-    defmt::assert!(
-        fs.alloc_endpoint_in(EndpointType::Interrupt, None, 64, 0).is_ok(),
-        "fs 3: interrupt IN 64 must be accepted (index 1 IN)"
+    expect_ok(
+        fs.alloc_endpoint_out(EndpointType::Isochronous, None, 1023, 0),
+        "fs 5: isochronous OUT 1023",
     );
-    defmt::assert!(
-        fs.alloc_endpoint_in(EndpointType::Interrupt, None, 128, 0).is_err(),
-        "fs 4: interrupt IN 128 exceeds the 64-byte full-speed interrupt cap"
-    );
-    defmt::assert!(
-        fs.alloc_endpoint_out(EndpointType::Isochronous, None, 1023, 0).is_ok(),
-        "fs 5: isochronous OUT 1023 must be accepted (index 2 OUT)"
-    );
-    defmt::assert!(
-        fs.alloc_endpoint_out(EndpointType::Isochronous, None, 1024, 0).is_err(),
-        "fs 6: isochronous OUT 1024 exceeds the full-speed isochronous cap"
+    expect_err(
+        fs.alloc_endpoint_out(EndpointType::Isochronous, None, 1024, 0),
+        "fs 6: isochronous OUT 1024",
     );
 
     // Indices 3 and 4 OUT, then index exhaustion.
-    for i in 3..=4 {
-        defmt::assert!(
-            fs.alloc_endpoint_out(EndpointType::Bulk, None, 64, 0).is_ok(),
-            "fs 7: bulk OUT 64 must be accepted at index {}",
-            i
-        );
+    for _ in 3..=4 {
+        expect_ok(fs.alloc_endpoint_out(EndpointType::Bulk, None, 64, 0), "fs 7: bulk OUT 64");
     }
-    defmt::assert!(
-        fs.alloc_endpoint_out(EndpointType::Bulk, None, 64, 0).is_err(),
-        "fs 8: no OUT endpoint index is left"
-    );
+    expect_err(fs.alloc_endpoint_out(EndpointType::Bulk, None, 64, 0), "fs 8: OUT index exhaustion");
 
     defmt::info!("Test OK");
     cortex_m::asm::bkpt();

--- a/tests/lpc55/src/bin/usb_alloc.rs
+++ b/tests/lpc55/src/bin/usb_alloc.rs
@@ -31,7 +31,6 @@ fn expect_err<T, E>(result: Result<T, E>, message: &'static str) {
     defmt::assert!(result.is_err(), "{}", message);
 }
 
-
 #[embassy_executor::main]
 async fn main(_spawner: Spawner) {
     let mut config = embassy_nxp::config::Config::default();
@@ -43,8 +42,14 @@ async fn main(_spawner: Spawner) {
     // EP_COUNT = 6, so data endpoint indices 1..=5 are usable per direction.
     let mut hs = Driver::<peripherals::USBHSD>::new(p.USBHSD, Irqs, Memory::usb1_sram());
 
-    expect_ok(hs.alloc_endpoint_out(EndpointType::Bulk, None, 512, 0), "hs 1: bulk OUT 512");
-    expect_err(hs.alloc_endpoint_out(EndpointType::Bulk, None, 1024, 0), "hs 2: bulk OUT 1024");
+    expect_ok(
+        hs.alloc_endpoint_out(EndpointType::Bulk, None, 512, 0),
+        "hs 1: bulk OUT 512",
+    );
+    expect_err(
+        hs.alloc_endpoint_out(EndpointType::Bulk, None, 1024, 0),
+        "hs 2: bulk OUT 1024",
+    );
     expect_ok(
         hs.alloc_endpoint_in(EndpointType::Interrupt, None, 1024, 0),
         "hs 3: interrupt IN 1024",
@@ -61,7 +66,10 @@ async fn main(_spawner: Spawner) {
         hs.alloc_endpoint_in(EndpointType::Isochronous, None, 1023, 0),
         "hs 6: isochronous IN 1023",
     );
-    expect_err(hs.alloc_endpoint_in(EndpointType::Control, None, 64, 0), "hs 7: control beyond EP0");
+    expect_err(
+        hs.alloc_endpoint_in(EndpointType::Control, None, 64, 0),
+        "hs 7: control beyond EP0",
+    );
     expect_err(
         hs.alloc_endpoint_in(
             EndpointType::Bulk,
@@ -94,7 +102,10 @@ async fn main(_spawner: Spawner) {
             "hs 11: interrupt IN 64",
         );
     }
-    expect_err(hs.alloc_endpoint_in(EndpointType::Interrupt, None, 64, 0), "hs 12: IN index exhaustion");
+    expect_err(
+        hs.alloc_endpoint_in(EndpointType::Interrupt, None, 64, 0),
+        "hs 12: IN index exhaustion",
+    );
 
     // ---------------------------------------------------------------- USB0 FS
     // EP_COUNT = 5, so data endpoint indices 1..=4 are usable per direction.
@@ -104,8 +115,14 @@ async fn main(_spawner: Spawner) {
     let mem = Memory::buffer(&mut ep_mem);
     let mut fs = Driver::<peripherals::USB0>::new(p.USB0, Irqs, p.PIO0_22, mem);
 
-    expect_ok(fs.alloc_endpoint_out(EndpointType::Bulk, None, 64, 0), "fs 1: bulk OUT 64");
-    expect_err(fs.alloc_endpoint_out(EndpointType::Bulk, None, 128, 0), "fs 2: bulk OUT 128");
+    expect_ok(
+        fs.alloc_endpoint_out(EndpointType::Bulk, None, 64, 0),
+        "fs 1: bulk OUT 64",
+    );
+    expect_err(
+        fs.alloc_endpoint_out(EndpointType::Bulk, None, 128, 0),
+        "fs 2: bulk OUT 128",
+    );
     expect_ok(
         fs.alloc_endpoint_in(EndpointType::Interrupt, None, 64, 0),
         "fs 3: interrupt IN 64",
@@ -125,9 +142,15 @@ async fn main(_spawner: Spawner) {
 
     // Indices 3 and 4 OUT, then index exhaustion.
     for _ in 3..=4 {
-        expect_ok(fs.alloc_endpoint_out(EndpointType::Bulk, None, 64, 0), "fs 7: bulk OUT 64");
+        expect_ok(
+            fs.alloc_endpoint_out(EndpointType::Bulk, None, 64, 0),
+            "fs 7: bulk OUT 64",
+        );
     }
-    expect_err(fs.alloc_endpoint_out(EndpointType::Bulk, None, 64, 0), "fs 8: OUT index exhaustion");
+    expect_err(
+        fs.alloc_endpoint_out(EndpointType::Bulk, None, 64, 0),
+        "fs 8: OUT index exhaustion",
+    );
 
     defmt::info!("Test OK");
     cortex_m::asm::bkpt();

--- a/tests/lpc55/src/bin/usb_alloc.rs
+++ b/tests/lpc55/src/bin/usb_alloc.rs
@@ -15,7 +15,7 @@ use embassy_executor::Spawner;
 use embassy_nxp::config::MainClock;
 use embassy_nxp::usb::{Driver, InterruptHandler, Memory};
 use embassy_nxp::{bind_interrupts, peripherals};
-use embassy_usb::driver::{Direction, Driver as _, EndpointAddress, EndpointType};
+use embassy_usb::driver::{Direction, Driver as _, Endpoint as _, EndpointAddress, EndpointType};
 use panic_probe as _;
 
 bind_interrupts!(struct Irqs {
@@ -73,27 +73,34 @@ async fn main(_spawner: Spawner) {
         "hs 8: index 1 IN is already taken"
     );
 
-    // The 4096-byte multi-packet slots no longer fit alongside the isochronous
-    // endpoints allocated above, so this exercises the driver's single-packet
-    // fallback: it must succeed anyway.
     defmt::assert!(
-        hs.alloc_endpoint_out(EndpointType::Bulk, None, 512, 0).is_ok(),
-        "hs 9: bulk OUT 512 must fall back to single-packet slots (index 3 OUT)"
+        hs.alloc_endpoint_out(EndpointType::Interrupt, None, 1024, 0).is_ok(),
+        "hs 9: interrupt OUT 1024 must be accepted (index 3 OUT)"
     );
 
-    // Index exhaustion on the IN side, using 64-byte endpoints so the limit
-    // reached is EP_COUNT and not the remaining endpoint memory. Indices 1 and
-    // 2 IN are taken, so exactly three more must fit.
-    for i in 3..=5 {
+    // The extra interrupt-OUT slots leave too little memory for two 3,584-byte
+    // bulk-IN slots. The allocator must fall back to two 512-byte slots.
+    let fallback = match hs.alloc_endpoint_in(EndpointType::Bulk, None, 512, 0) {
+        Ok(endpoint) => endpoint,
+        Err(_) => defmt::panic!("hs 10: bulk IN 512 single-packet fallback failed"),
+    };
+    defmt::assert_eq!(
+        fallback.info().addr,
+        EndpointAddress::from_parts(3, Direction::In),
+        "hs 10: bulk IN fallback must use index 3 IN"
+    );
+
+    // Indices 1 through 3 IN are taken, so only indices 4 and 5 remain.
+    for i in 4..=5 {
         defmt::assert!(
             hs.alloc_endpoint_in(EndpointType::Interrupt, None, 64, 0).is_ok(),
-            "hs 10: interrupt IN 64 must be accepted at index {}",
+            "hs 11: interrupt IN 64 must be accepted at index {}",
             i
         );
     }
     defmt::assert!(
         hs.alloc_endpoint_in(EndpointType::Interrupt, None, 64, 0).is_err(),
-        "hs 11: no IN endpoint index is left"
+        "hs 12: no IN endpoint index is left"
     );
 
     // ---------------------------------------------------------------- USB0 FS

--- a/tests/lpc55/src/bin/usb_alloc_small.rs
+++ b/tests/lpc55/src/bin/usb_alloc_small.rs
@@ -1,0 +1,52 @@
+//! USB0 endpoint allocation at the 512-byte minimum.
+//!
+//! This test needs no host cable. It checks that EP0 remains reserved when the
+//! remaining memory can hold only one double-buffered 64-byte data endpoint.
+
+#![no_std]
+#![no_main]
+
+use defmt_rtt as _;
+use embassy_executor::Spawner;
+use embassy_nxp::usb::{Driver, InterruptHandler, Memory};
+use embassy_nxp::{bind_interrupts, peripherals};
+use embassy_usb::driver::{Driver as _, EndpointAllocError, EndpointType};
+use panic_probe as _;
+
+bind_interrupts!(struct Irqs {
+    USB0 => InterruptHandler<peripherals::USB0>;
+});
+
+#[embassy_executor::main]
+async fn main(_spawner: Spawner) {
+    let p = embassy_nxp::init(embassy_nxp::config::Config::default());
+
+    let mut storage = [0u8; 512 + 255];
+    let offset = storage.as_ptr().align_offset(256);
+    defmt::assert!(offset <= 255, "failed to find 256-byte alignment");
+    let endpoint_memory = &mut storage[offset..offset + 512];
+    defmt::assert_eq!(endpoint_memory.as_ptr() as usize & 0xff, 0);
+
+    let memory = Memory::buffer(endpoint_memory);
+    let mut driver = Driver::<peripherals::USB0>::new(p.USB0, Irqs, p.PIO0_22, memory);
+
+    let endpoint = match driver.alloc_endpoint_out(EndpointType::Bulk, None, 64, 0) {
+        Ok(endpoint) => endpoint,
+        Err(_) => defmt::panic!("first 64-byte endpoint did not fit in 512 bytes"),
+    };
+    defmt::assert!(
+        matches!(
+            driver.alloc_endpoint_out(EndpointType::Bulk, None, 64, 0),
+            Err(EndpointAllocError)
+        ),
+        "second 64-byte endpoint fit in 512 bytes"
+    );
+
+    let (bus, control) = driver.start(64);
+    drop(endpoint);
+    drop(control);
+    drop(bus);
+
+    defmt::info!("Test OK");
+    cortex_m::asm::bkpt();
+}

--- a/tests/lpc55/src/bin/usb_bus_raw.rs
+++ b/tests/lpc55/src/bin/usb_bus_raw.rs
@@ -33,12 +33,6 @@ bind_interrupts!(struct Irqs {
     USB1 => InterruptHandler<peripherals::USBHSD>;
 });
 
-/// Endpoint memory for USB0, in main SRAM: `Memory::usb1_sram` is already taken
-/// by the high-speed half of this test and is never released.
-#[repr(C, align(256))]
-struct EpMem([u8; 4096]);
-static mut EP_MEM: EpMem = EpMem([0; 4096]);
-
 /// PDRUNCFG0 power-down bits, mirroring `PDEN_USBFSPHY` / `PDEN_USBHSPHY` in
 /// `embassy-nxp/src/usb/lpc55.rs`. The bit is *set* when the block is off.
 const PDEN_USBFSPHY: u32 = 1 << 11;
@@ -162,8 +156,11 @@ async fn main(_spawner: Spawner) {
     .await;
 
     // ---------------------------------------------------------------- USB0 FS
-    let mem = Memory::buffer(unsafe { &mut (*(&raw mut EP_MEM)).0 });
-    let fs_base = (&raw const EP_MEM) as u32;
+    // `Memory::usb1_sram` is already taken by the high-speed half of this test
+    // and is never released, so USB0 gets a region in main SRAM.
+    let mut ep_mem = [0u8; 4096];
+    let mem = Memory::buffer(&mut ep_mem);
+    let fs_base = mem.base();
     let fs = Driver::<peripherals::USB0>::new(p.USB0, Irqs, p.PIO0_22, mem);
     // Same ip3511 register map at the USB0 base; this is exactly how the driver
     // reaches USB0's registers.

--- a/tests/lpc55/src/bin/usb_bus_raw.rs
+++ b/tests/lpc55/src/bin/usb_bus_raw.rs
@@ -1,0 +1,185 @@
+//! Raw [`embassy_usb_driver::Bus`] lifecycle for both LPC55 USB controllers.
+//!
+//! This covers the `Bus` methods `embassy-usb` never calls, so nothing else in
+//! the suite can reach them: `force_reset` has no caller anywhere in
+//! `embassy-usb`, and `disable` followed by a second `enable` (the `reinit`
+//! path, which re-programs the controller after `power_down` reset the block)
+//! is only reachable through `UsbDevice::disable`, which none of the examples
+//! or tests use.
+//!
+//! Needs no host cable: the assertions are all on device-side registers and
+//! command-list state, and the bus never comes up, so no host traffic is
+//! involved. Soft-connect is asserted as a register bit, not as enumeration.
+//!
+//! The per-controller body is one generic function. That works because the
+//! driver itself views USB0 through the `usbhsd` register map (see
+//! `SealedInstance for USB0` in `embassy-nxp/src/usb/lpc55.rs`), so the two
+//! controllers share a register type; only the clock-gate and PDRUNCFG
+//! assertions differ, and those come in as a closure.
+
+#![no_std]
+#![no_main]
+
+use defmt_rtt as _;
+use embassy_executor::Spawner;
+use embassy_nxp::config::MainClock;
+use embassy_nxp::usb::{Driver, Instance, InterruptHandler, Memory};
+use embassy_nxp::{bind_interrupts, pac, peripherals};
+use embassy_usb::driver::{Bus as _, Driver as _, Endpoint as _, EndpointType};
+use panic_probe as _;
+
+bind_interrupts!(struct Irqs {
+    USB0 => InterruptHandler<peripherals::USB0>;
+    USB1 => InterruptHandler<peripherals::USBHSD>;
+});
+
+/// Endpoint memory for USB0, in main SRAM: `Memory::usb1_sram` is already taken
+/// by the high-speed half of this test and is never released.
+#[repr(C, align(256))]
+struct EpMem([u8; 4096]);
+static mut EP_MEM: EpMem = EpMem([0; 4096]);
+
+/// PDRUNCFG0 power-down bits, mirroring `PDEN_USBFSPHY` / `PDEN_USBHSPHY` in
+/// `embassy-nxp/src/usb/lpc55.rs`. The bit is *set* when the block is off.
+const PDEN_USBFSPHY: u32 = 1 << 11;
+const PDEN_USBHSPHY: u32 = 1 << 12;
+
+const USB1_SRAM_ADDR: u32 = 0x4010_0000;
+
+/// Drive one controller through the full `Bus` lifecycle.
+///
+/// `regs` is the ip3511 register block for this instance, `ep_list_base` the
+/// endpoint-list address the driver was handed, and `assert_powered_down` the
+/// instance-specific clock-gate/PDRUNCFG check run after `disable`.
+async fn check<T: Instance>(
+    mut driver: Driver<'_, T>,
+    name: &'static str,
+    mps: u16,
+    ep_list_base: u32,
+    regs: pac::usbhsd::Usbhsd,
+    assert_powered_down: impl Fn(),
+) {
+    let bulk = driver.alloc_endpoint_out(EndpointType::Bulk, None, mps, 0).unwrap();
+    let iso = driver
+        .alloc_endpoint_out(EndpointType::Isochronous, None, 1023, 1)
+        .unwrap();
+    let bulk_addr = bulk.info().addr;
+    let iso_addr = iso.info().addr;
+
+    let (mut bus, _control) = driver.start(64);
+
+    // Soft-connect and device-enable, the two bits `enable` owns.
+    bus.enable().await;
+    let dcs = regs.devcmdstat().read();
+    defmt::assert!(dcs.dcon(), "{}: enable did not set DCON", name);
+    defmt::assert!(dcs.dev_en(), "{}: enable did not set DEV_EN", name);
+
+    // Stall round-trip on a bulk endpoint: CMD_S set, observed, then cleared.
+    bus.endpoint_set_enabled(bulk_addr, true);
+    bus.endpoint_set_stalled(bulk_addr, true);
+    defmt::assert!(
+        bus.endpoint_is_stalled(bulk_addr),
+        "{}: bulk endpoint not reported stalled after set_stalled(true)",
+        name
+    );
+    bus.endpoint_set_stalled(bulk_addr, false);
+    defmt::assert!(
+        !bus.endpoint_is_stalled(bulk_addr),
+        "{}: bulk endpoint still reported stalled after set_stalled(false)",
+        name
+    );
+
+    // Isochronous transfers have no handshake phase, so an iso endpoint can
+    // never STALL; the driver deliberately never sets CMD_S on one, and
+    // `endpoint_is_stalled` therefore always reports `false` for it.
+    bus.endpoint_set_enabled(iso_addr, true);
+    bus.endpoint_set_stalled(iso_addr, true);
+    defmt::assert!(
+        !bus.endpoint_is_stalled(iso_addr),
+        "{}: isochronous endpoint reported stalled, but iso has no handshake phase",
+        name
+    );
+
+    // Power the block down and check the gates the driver claims to close.
+    bus.disable().await;
+    assert_powered_down();
+
+    // Second `enable`: `powered` is false, so this takes the `power_up` +
+    // `reinit` path, which must re-program the controller from scratch.
+    bus.enable().await;
+    defmt::assert_eq!(
+        regs.epliststart().read().0,
+        ep_list_base,
+        "{}: reinit did not restore EPLISTSTART",
+        name
+    );
+    let dcs = regs.devcmdstat().read();
+    defmt::assert!(dcs.dev_en(), "{}: reinit did not set DEV_EN", name);
+    defmt::assert!(dcs.dcon(), "{}: enable after reinit did not set DCON", name);
+    defmt::assert!(
+        regs.inten().read().dev_int_en(),
+        "{}: reinit did not re-enable the device interrupt",
+        name
+    );
+
+    // `force_reset` drops DCON for a host-visible SE0 and busy-waits
+    // `cortex_m::asm::delay(10_000_000)` (~100 ms at 96 MHz) before raising it
+    // again, so the test visibly pauses here.
+    defmt::assert!(bus.force_reset().is_ok(), "{}: force_reset reported Unsupported", name);
+    defmt::assert!(
+        regs.devcmdstat().read().dcon(),
+        "{}: force_reset left the device disconnected",
+        name
+    );
+
+    // Leave the controller powered down and disconnected. This test asserts
+    // DCON but never runs a `UsbDevice`, so a controller left connected is a
+    // device that pulls D+ up and then answers nothing: the host resets and
+    // retries the port for as long as the core sits at the breakpoint, which
+    // is enough to stop the next test's debug session from attaching.
+    bus.disable().await;
+    assert_powered_down();
+}
+
+#[embassy_executor::main]
+async fn main(_spawner: Spawner) {
+    let mut config = embassy_nxp::config::Config::default();
+    // The high-speed controller requires a system clock of at least 96 MHz.
+    config.main_clock = MainClock::FroHf96;
+    let p = embassy_nxp::init(config);
+
+    // ---------------------------------------------------------------- USB1 HS
+    let hs = Driver::<peripherals::USBHSD>::new(p.USBHSD, Irqs, Memory::usb1_sram());
+    check(hs, "USB1", 512, USB1_SRAM_ADDR, pac::USBHSD, || {
+        let clk = pac::SYSCON.ahbclkctrl2().read();
+        defmt::assert!(!clk.usb1_dev(), "USB1: disable left the device clock on");
+        defmt::assert!(!clk.usb1_phy(), "USB1: disable left the PHY clock on");
+        defmt::assert!(
+            pac::PMC.pdruncfg0().read().0 & PDEN_USBHSPHY != 0,
+            "USB1: disable left the HS PHY powered"
+        );
+    })
+    .await;
+
+    // ---------------------------------------------------------------- USB0 FS
+    let mem = Memory::buffer(unsafe { &mut (*(&raw mut EP_MEM)).0 });
+    let fs_base = (&raw const EP_MEM) as u32;
+    let fs = Driver::<peripherals::USB0>::new(p.USB0, Irqs, p.PIO0_22, mem);
+    // Same ip3511 register map at the USB0 base; this is exactly how the driver
+    // reaches USB0's registers.
+    let fs_regs = unsafe { pac::usbhsd::Usbhsd::from_ptr(pac::USB0.as_ptr()) };
+    check(fs, "USB0", 64, fs_base, fs_regs, || {
+        defmt::assert!(
+            !pac::SYSCON.ahbclkctrl1().read().usb0_dev(),
+            "USB0: disable left the device clock on"
+        );
+        defmt::assert!(
+            pac::PMC.pdruncfg0().read().0 & PDEN_USBFSPHY != 0,
+            "USB0: disable left the FS PHY powered"
+        );
+    })
+    .await;
+
+    defmt::info!("Test OK");
+    cortex_m::asm::bkpt();
+}

--- a/tests/lpc55/src/bin/usb_bus_raw.rs
+++ b/tests/lpc55/src/bin/usb_bus_raw.rs
@@ -35,6 +35,10 @@ const USB1_SRAM_ADDR: u32 = 0x4010_0000;
 ///
 /// `regs` is the register block for this instance. `assert_powered_up` checks
 /// that ordinary disable does not perform final hardware teardown.
+fn ensure(condition: bool, name: &'static str, failure: &'static str) {
+    defmt::assert!(condition, "{}: {}", name, failure);
+}
+
 async fn check<T: Instance>(
     bus: &mut Bus<'_, T>,
     bulk: &mut Endpoint<'_, T, Out>,
@@ -49,55 +53,35 @@ async fn check<T: Instance>(
 
     bus.enable().await;
     let dcs = regs.devcmdstat().read();
-    defmt::assert!(dcs.dcon(), "{}: enable did not set DCON", name);
-    defmt::assert!(dcs.dev_en(), "{}: enable did not set DEV_EN", name);
+    ensure(dcs.dcon(), name, "enable did not set DCON");
+    ensure(dcs.dev_en(), name, "enable did not set DEV_EN");
     assert_powered_up();
 
     bus.endpoint_set_enabled(bulk_addr, true);
     bus.endpoint_set_stalled(bulk_addr, true);
-    defmt::assert!(
-        bus.endpoint_is_stalled(bulk_addr),
-        "{}: bulk endpoint not reported stalled",
-        name
-    );
+    ensure(bus.endpoint_is_stalled(bulk_addr), name, "bulk endpoint not reported stalled");
     bus.endpoint_set_stalled(bulk_addr, false);
-    defmt::assert!(
-        !bus.endpoint_is_stalled(bulk_addr),
-        "{}: bulk endpoint remained stalled",
-        name
-    );
+    ensure(!bus.endpoint_is_stalled(bulk_addr), name, "bulk endpoint remained stalled");
 
     bus.endpoint_set_enabled(iso_addr, true);
     bus.endpoint_set_stalled(iso_addr, true);
-    defmt::assert!(
-        !bus.endpoint_is_stalled(iso_addr),
-        "{}: isochronous endpoint reported stalled",
-        name
-    );
+    ensure(!bus.endpoint_is_stalled(iso_addr), name, "isochronous endpoint reported stalled");
 
     for direction in [Direction::Out, Direction::In] {
         let invalid = EndpointAddress::from_parts(127, direction);
         bus.endpoint_set_enabled(invalid, true);
         bus.endpoint_set_stalled(invalid, true);
-        defmt::assert!(
-            !bus.endpoint_is_stalled(invalid),
-            "{}: invalid endpoint reported stalled",
-            name
-        );
+        ensure(!bus.endpoint_is_stalled(invalid), name, "invalid endpoint reported stalled");
     }
 
     let mut packet = [0; 512];
     let (read_result, ()) = join(bulk.read(&mut packet), bus.disable()).await;
-    defmt::assert!(
+    ensure(
         matches!(read_result, Err(EndpointError::Disabled)),
-        "{}: disable did not cancel a pending endpoint read",
-        name
+        name,
+        "disable did not cancel a pending endpoint read",
     );
-    defmt::assert!(
-        regs.devcmdstat().read().dev_en(),
-        "{}: reversible disable cleared DEV_EN",
-        name
-    );
+    ensure(regs.devcmdstat().read().dev_en(), name, "reversible disable cleared DEV_EN");
     let disabled_dcs = regs.devcmdstat().read();
     defmt::assert_eq!(
         disabled_dcs.dcon(),
@@ -115,19 +99,19 @@ async fn check<T: Instance>(
         name
     );
     let dcs = regs.devcmdstat().read();
-    defmt::assert!(dcs.dev_en(), "{}: second enable did not set DEV_EN", name);
-    defmt::assert!(dcs.dcon(), "{}: second enable did not set DCON", name);
-    defmt::assert!(
+    ensure(dcs.dev_en(), name, "second enable did not set DEV_EN");
+    ensure(dcs.dcon(), name, "second enable did not set DCON");
+    ensure(
         regs.inten().read().dev_int_en(),
-        "{}: second enable did not restore device interrupts",
-        name
+        name,
+        "second enable did not restore device interrupts",
     );
 
-    defmt::assert!(bus.force_reset().is_ok(), "{}: force_reset reported Unsupported", name);
-    defmt::assert!(
+    ensure(bus.force_reset().is_ok(), name, "force_reset reported Unsupported");
+    ensure(
         regs.devcmdstat().read().dcon(),
-        "{}: force_reset left the device disconnected",
-        name
+        name,
+        "force_reset left the device disconnected",
     );
 }
 
@@ -185,20 +169,23 @@ async fn main(_spawner: Spawner) {
     let hs_clk = pac::SYSCON.ahbclkctrl2().read();
     defmt::assert!(!hs_clk.usb1_dev(), "USB1 device clock remained on after Bus drop");
     defmt::assert!(!hs_clk.usb1_phy(), "USB1 PHY clock remained on after Bus drop");
-    defmt::assert!(
+    ensure(
         pac::PMC.pdruncfg0().read().0 & PDEN_USBHSPHY != 0,
-        "USB1 PHY remained powered after Bus drop"
+        "USB1",
+        "PHY remained powered after Bus drop",
     );
-    defmt::assert!(
+    ensure(
         !embassy_nxp::interrupt::typelevel::USB1::is_enabled(),
-        "USB1 interrupt remained enabled after Bus drop"
+        "USB1",
+        "interrupt remained enabled after Bus drop",
     );
     let hs_dcs = pac::USBHSD.devcmdstat().read();
     defmt::assert!(!hs_dcs.dcon() && !hs_dcs.dev_en(), "USB1 remained live after Bus drop");
 
-    defmt::assert!(
+    ensure(
         !pac::SYSCON.ahbclkctrl2().read().usb1_ram(),
-        "last USB1 SRAM lease did not gate the RAM clock"
+        "USB1",
+        "last SRAM lease did not gate the RAM clock",
     );
     defmt::assert_eq!(
         fs_regs.epliststart().read().0,
@@ -215,15 +202,17 @@ async fn main(_spawner: Spawner) {
     drop(fs_bus);
     defmt::assert!(!pac::SYSCON.ahbclkctrl1().read().usb0_dev());
     defmt::assert!(pac::PMC.pdruncfg0().read().0 & PDEN_USBFSPHY != 0);
-    defmt::assert!(
+    ensure(
         !embassy_nxp::interrupt::typelevel::USB0::is_enabled(),
-        "USB0 interrupt remained enabled after Bus drop"
+        "USB0",
+        "interrupt remained enabled after Bus drop",
     );
     let fs_dcs = fs_regs.devcmdstat().read();
     defmt::assert!(!fs_dcs.dcon() && !fs_dcs.dev_en(), "USB0 remained live after Bus drop");
-    defmt::assert!(
+    ensure(
         !pac::SYSCON.ahbclkctrl2().read().usb1_ram(),
-        "last USB1 SRAM lease did not gate the RAM clock"
+        "USB0",
+        "last USB1 SRAM lease did not gate the RAM clock",
     );
 
     let reacquired = Memory::usb1_sram();

--- a/tests/lpc55/src/bin/usb_bus_raw.rs
+++ b/tests/lpc55/src/bin/usb_bus_raw.rs
@@ -1,31 +1,22 @@
 //! Raw [`embassy_usb_driver::Bus`] lifecycle for both LPC55 USB controllers.
 //!
-//! This covers the `Bus` methods `embassy-usb` never calls, so nothing else in
-//! the suite can reach them: `force_reset` has no caller anywhere in
-//! `embassy-usb`, and `disable` followed by a second `enable` (the `reinit`
-//! path, which re-programs the controller after `power_down` reset the block)
-//! is only reachable through `UsbDevice::disable`, which none of the examples
-//! or tests use.
-//!
-//! Needs no host cable: the assertions are all on device-side registers and
-//! command-list state, and the bus never comes up, so no host traffic is
-//! involved. Soft-connect is asserted as a register bit, not as enumeration.
-//!
-//! The per-controller body is one generic function. That works because the
-//! driver itself views USB0 through the `usbhsd` register map (see
-//! `SealedInstance for USB0` in `embassy-nxp/src/usb/lpc55.rs`), so the two
-//! controllers share a register type; only the clock-gate and PDRUNCFG
-//! assertions differ, and those come in as a closure.
+//! This test covers reversible disable, endpoint cancellation, invalid endpoint
+//! addresses, final controller teardown, main-SRAM lifetime, and USB1 SRAM
+//! ownership while both controllers run.
 
 #![no_std]
 #![no_main]
 
 use defmt_rtt as _;
 use embassy_executor::Spawner;
+use embassy_futures::join::join;
 use embassy_nxp::config::MainClock;
-use embassy_nxp::usb::{Driver, Instance, InterruptHandler, Memory};
+use embassy_nxp::interrupt::typelevel::Interrupt as _;
+use embassy_nxp::usb::{Bus, Driver, Endpoint, Instance, InterruptHandler, Memory, Out};
 use embassy_nxp::{bind_interrupts, pac, peripherals};
-use embassy_usb::driver::{Bus as _, Driver as _, Endpoint as _, EndpointType};
+use embassy_usb::driver::{
+    Bus as _, Direction, Driver as _, Endpoint as _, EndpointAddress, EndpointError, EndpointOut as _, EndpointType,
+};
 use panic_probe as _;
 
 bind_interrupts!(struct Irqs {
@@ -40,142 +31,208 @@ const PDEN_USBHSPHY: u32 = 1 << 12;
 
 const USB1_SRAM_ADDR: u32 = 0x4010_0000;
 
-/// Drive one controller through the full `Bus` lifecycle.
+/// Exercise the reversible lifecycle while the controller remains powered.
 ///
-/// `regs` is the ip3511 register block for this instance, `ep_list_base` the
-/// endpoint-list address the driver was handed, and `assert_powered_down` the
-/// instance-specific clock-gate/PDRUNCFG check run after `disable`.
+/// `regs` is the register block for this instance. `assert_powered_up` checks
+/// that ordinary disable does not perform final hardware teardown.
 async fn check<T: Instance>(
-    mut driver: Driver<'_, T>,
+    bus: &mut Bus<'_, T>,
+    bulk: &mut Endpoint<'_, T, Out>,
+    iso: &Endpoint<'_, T, Out>,
     name: &'static str,
-    mps: u16,
     ep_list_base: u32,
     regs: pac::usbhsd::Usbhsd,
-    assert_powered_down: impl Fn(),
+    assert_powered_up: impl Fn(),
 ) {
-    let bulk = driver.alloc_endpoint_out(EndpointType::Bulk, None, mps, 0).unwrap();
-    let iso = driver
-        .alloc_endpoint_out(EndpointType::Isochronous, None, 1023, 1)
-        .unwrap();
     let bulk_addr = bulk.info().addr;
     let iso_addr = iso.info().addr;
 
-    let (mut bus, _control) = driver.start(64);
-
-    // Soft-connect and device-enable, the two bits `enable` owns.
     bus.enable().await;
     let dcs = regs.devcmdstat().read();
     defmt::assert!(dcs.dcon(), "{}: enable did not set DCON", name);
     defmt::assert!(dcs.dev_en(), "{}: enable did not set DEV_EN", name);
+    assert_powered_up();
 
-    // Stall round-trip on a bulk endpoint: CMD_S set, observed, then cleared.
     bus.endpoint_set_enabled(bulk_addr, true);
     bus.endpoint_set_stalled(bulk_addr, true);
     defmt::assert!(
         bus.endpoint_is_stalled(bulk_addr),
-        "{}: bulk endpoint not reported stalled after set_stalled(true)",
+        "{}: bulk endpoint not reported stalled",
         name
     );
     bus.endpoint_set_stalled(bulk_addr, false);
     defmt::assert!(
         !bus.endpoint_is_stalled(bulk_addr),
-        "{}: bulk endpoint still reported stalled after set_stalled(false)",
+        "{}: bulk endpoint remained stalled",
         name
     );
 
-    // Isochronous transfers have no handshake phase, so an iso endpoint can
-    // never STALL; the driver deliberately never sets CMD_S on one, and
-    // `endpoint_is_stalled` therefore always reports `false` for it.
     bus.endpoint_set_enabled(iso_addr, true);
     bus.endpoint_set_stalled(iso_addr, true);
     defmt::assert!(
         !bus.endpoint_is_stalled(iso_addr),
-        "{}: isochronous endpoint reported stalled, but iso has no handshake phase",
+        "{}: isochronous endpoint reported stalled",
         name
     );
 
-    // Power the block down and check the gates the driver claims to close.
-    bus.disable().await;
-    assert_powered_down();
+    for direction in [Direction::Out, Direction::In] {
+        let invalid = EndpointAddress::from_parts(127, direction);
+        bus.endpoint_set_enabled(invalid, true);
+        bus.endpoint_set_stalled(invalid, true);
+        defmt::assert!(
+            !bus.endpoint_is_stalled(invalid),
+            "{}: invalid endpoint reported stalled",
+            name
+        );
+    }
 
-    // Second `enable`: `powered` is false, so this takes the `power_up` +
-    // `reinit` path, which must re-program the controller from scratch.
+    let mut packet = [0; 512];
+    let (read_result, ()) = join(bulk.read(&mut packet), bus.disable()).await;
+    defmt::assert!(
+        matches!(read_result, Err(EndpointError::Disabled)),
+        "{}: disable did not cancel a pending endpoint read",
+        name
+    );
+    defmt::assert!(
+        regs.devcmdstat().read().dev_en(),
+        "{}: reversible disable cleared DEV_EN",
+        name
+    );
+    let disabled_dcs = regs.devcmdstat().read();
+    defmt::assert_eq!(
+        disabled_dcs.dcon(),
+        !disabled_dcs.vbus_debounced(),
+        "{}: disable did not disconnect or enter attach-armed state",
+        name
+    );
+    assert_powered_up();
+
     bus.enable().await;
     defmt::assert_eq!(
         regs.epliststart().read().0,
         ep_list_base,
-        "{}: reinit did not restore EPLISTSTART",
+        "{}: enable did not restore EPLISTSTART",
         name
     );
     let dcs = regs.devcmdstat().read();
-    defmt::assert!(dcs.dev_en(), "{}: reinit did not set DEV_EN", name);
-    defmt::assert!(dcs.dcon(), "{}: enable after reinit did not set DCON", name);
+    defmt::assert!(dcs.dev_en(), "{}: second enable did not set DEV_EN", name);
+    defmt::assert!(dcs.dcon(), "{}: second enable did not set DCON", name);
     defmt::assert!(
         regs.inten().read().dev_int_en(),
-        "{}: reinit did not re-enable the device interrupt",
+        "{}: second enable did not restore device interrupts",
         name
     );
 
-    // `force_reset` drops DCON for a host-visible SE0 and busy-waits
-    // `cortex_m::asm::delay(10_000_000)` (~100 ms at 96 MHz) before raising it
-    // again, so the test visibly pauses here.
     defmt::assert!(bus.force_reset().is_ok(), "{}: force_reset reported Unsupported", name);
     defmt::assert!(
         regs.devcmdstat().read().dcon(),
         "{}: force_reset left the device disconnected",
         name
     );
-
-    // Leave the controller powered down and disconnected. This test asserts
-    // DCON but never runs a `UsbDevice`, so a controller left connected is a
-    // device that pulls D+ up and then answers nothing: the host resets and
-    // retries the port for as long as the core sits at the breakpoint, which
-    // is enough to stop the next test's debug session from attaching.
-    bus.disable().await;
-    assert_powered_down();
 }
 
 #[embassy_executor::main]
 async fn main(_spawner: Spawner) {
     let mut config = embassy_nxp::config::Config::default();
-    // The high-speed controller requires a system clock of at least 96 MHz.
     config.main_clock = MainClock::FroHf96;
     let p = embassy_nxp::init(config);
 
-    // ---------------------------------------------------------------- USB1 HS
-    let hs = Driver::<peripherals::USBHSD>::new(p.USBHSD, Irqs, Memory::usb1_sram());
-    check(hs, "USB1", 512, USB1_SRAM_ADDR, pac::USBHSD, || {
-        let clk = pac::SYSCON.ahbclkctrl2().read();
-        defmt::assert!(!clk.usb1_dev(), "USB1: disable left the device clock on");
-        defmt::assert!(!clk.usb1_phy(), "USB1: disable left the PHY clock on");
-        defmt::assert!(
-            pac::PMC.pdruncfg0().read().0 & PDEN_USBHSPHY != 0,
-            "USB1: disable left the HS PHY powered"
-        );
+    let fs_regs = unsafe { pac::usbhsd::Usbhsd::from_ptr(pac::USB0.as_ptr()) };
+    let mut fs_mem = [0u8; 4096];
+    let fs_memory = Memory::buffer(&mut fs_mem);
+    let fs_base = fs_memory.base();
+    let mut fs_driver = Driver::<peripherals::USB0>::new(p.USB0, Irqs, p.PIO0_22, fs_memory);
+    let mut fs_bulk = fs_driver.alloc_endpoint_out(EndpointType::Bulk, None, 64, 0).unwrap();
+    let fs_iso = fs_driver
+        .alloc_endpoint_out(EndpointType::Isochronous, None, 1023, 1)
+        .unwrap();
+    let (mut fs_bus, fs_control) = fs_driver.start(64);
+
+    let mut hs_driver = Driver::<peripherals::USBHSD>::new(p.USBHSD, Irqs, Memory::usb1_sram());
+    let mut hs_bulk = hs_driver.alloc_endpoint_out(EndpointType::Bulk, None, 512, 0).unwrap();
+    let hs_iso = hs_driver
+        .alloc_endpoint_out(EndpointType::Isochronous, None, 1023, 1)
+        .unwrap();
+    let (mut hs_bus, hs_control) = hs_driver.start(64);
+
+    check(&mut fs_bus, &mut fs_bulk, &fs_iso, "USB0", fs_base, fs_regs, || {
+        defmt::assert!(pac::SYSCON.ahbclkctrl1().read().usb0_dev());
+        defmt::assert_eq!(pac::PMC.pdruncfg0().read().0 & PDEN_USBFSPHY, 0);
+        defmt::assert!(embassy_nxp::interrupt::typelevel::USB0::is_enabled());
     })
+    .await;
+    check(
+        &mut hs_bus,
+        &mut hs_bulk,
+        &hs_iso,
+        "USB1",
+        USB1_SRAM_ADDR,
+        pac::USBHSD,
+        || {
+            let clk = pac::SYSCON.ahbclkctrl2().read();
+            defmt::assert!(clk.usb1_dev());
+            defmt::assert!(clk.usb1_phy());
+            defmt::assert_eq!(pac::PMC.pdruncfg0().read().0 & PDEN_USBHSPHY, 0);
+            defmt::assert!(embassy_nxp::interrupt::typelevel::USB1::is_enabled());
+        },
+    )
     .await;
 
-    // ---------------------------------------------------------------- USB0 FS
-    // `Memory::usb1_sram` is already taken by the high-speed half of this test
-    // and is never released, so USB0 gets a region in main SRAM.
-    let mut ep_mem = [0u8; 4096];
-    let mem = Memory::buffer(&mut ep_mem);
-    let fs_base = mem.base();
-    let fs = Driver::<peripherals::USB0>::new(p.USB0, Irqs, p.PIO0_22, mem);
-    // Same ip3511 register map at the USB0 base; this is exactly how the driver
-    // reaches USB0's registers.
-    let fs_regs = unsafe { pac::usbhsd::Usbhsd::from_ptr(pac::USB0.as_ptr()) };
-    check(fs, "USB0", 64, fs_base, fs_regs, || {
-        defmt::assert!(
-            !pac::SYSCON.ahbclkctrl1().read().usb0_dev(),
-            "USB0: disable left the device clock on"
-        );
-        defmt::assert!(
-            pac::PMC.pdruncfg0().read().0 & PDEN_USBFSPHY != 0,
-            "USB0: disable left the FS PHY powered"
-        );
-    })
-    .await;
+    drop(hs_bulk);
+    drop(hs_iso);
+    drop(hs_control);
+    drop(hs_bus);
+    let hs_clk = pac::SYSCON.ahbclkctrl2().read();
+    defmt::assert!(!hs_clk.usb1_dev(), "USB1 device clock remained on after Bus drop");
+    defmt::assert!(!hs_clk.usb1_phy(), "USB1 PHY clock remained on after Bus drop");
+    defmt::assert!(
+        pac::PMC.pdruncfg0().read().0 & PDEN_USBHSPHY != 0,
+        "USB1 PHY remained powered after Bus drop"
+    );
+    defmt::assert!(
+        !embassy_nxp::interrupt::typelevel::USB1::is_enabled(),
+        "USB1 interrupt remained enabled after Bus drop"
+    );
+    let hs_dcs = pac::USBHSD.devcmdstat().read();
+    defmt::assert!(!hs_dcs.dcon() && !hs_dcs.dev_en(), "USB1 remained live after Bus drop");
+
+    defmt::assert!(
+        !pac::SYSCON.ahbclkctrl2().read().usb1_ram(),
+        "last USB1 SRAM lease did not gate the RAM clock"
+    );
+    defmt::assert_eq!(
+        fs_regs.epliststart().read().0,
+        fs_base,
+        "USB1 teardown corrupted USB0 EPLISTSTART"
+    );
+    fs_bus.endpoint_set_stalled(fs_bulk.info().addr, true);
+    defmt::assert!(fs_bus.endpoint_is_stalled(fs_bulk.info().addr));
+    fs_bus.endpoint_set_stalled(fs_bulk.info().addr, false);
+
+    drop(fs_bulk);
+    drop(fs_iso);
+    drop(fs_control);
+    drop(fs_bus);
+    defmt::assert!(!pac::SYSCON.ahbclkctrl1().read().usb0_dev());
+    defmt::assert!(pac::PMC.pdruncfg0().read().0 & PDEN_USBFSPHY != 0);
+    defmt::assert!(
+        !embassy_nxp::interrupt::typelevel::USB0::is_enabled(),
+        "USB0 interrupt remained enabled after Bus drop"
+    );
+    let fs_dcs = fs_regs.devcmdstat().read();
+    defmt::assert!(!fs_dcs.dcon() && !fs_dcs.dev_en(), "USB0 remained live after Bus drop");
+    defmt::assert!(
+        !pac::SYSCON.ahbclkctrl2().read().usb1_ram(),
+        "last USB1 SRAM lease did not gate the RAM clock"
+    );
+
+    let reacquired = Memory::usb1_sram();
+    defmt::assert!(pac::SYSCON.ahbclkctrl2().read().usb1_ram());
+    drop(reacquired);
+    defmt::assert!(!pac::SYSCON.ahbclkctrl2().read().usb1_ram());
+
+    fs_mem.fill(0xa5);
+    defmt::assert!(fs_mem.iter().all(|byte| *byte == 0xa5));
 
     defmt::info!("Test OK");
     cortex_m::asm::bkpt();

--- a/tests/lpc55/src/bin/usb_bus_raw.rs
+++ b/tests/lpc55/src/bin/usb_bus_raw.rs
@@ -59,19 +59,35 @@ async fn check<T: Instance>(
 
     bus.endpoint_set_enabled(bulk_addr, true);
     bus.endpoint_set_stalled(bulk_addr, true);
-    ensure(bus.endpoint_is_stalled(bulk_addr), name, "bulk endpoint not reported stalled");
+    ensure(
+        bus.endpoint_is_stalled(bulk_addr),
+        name,
+        "bulk endpoint not reported stalled",
+    );
     bus.endpoint_set_stalled(bulk_addr, false);
-    ensure(!bus.endpoint_is_stalled(bulk_addr), name, "bulk endpoint remained stalled");
+    ensure(
+        !bus.endpoint_is_stalled(bulk_addr),
+        name,
+        "bulk endpoint remained stalled",
+    );
 
     bus.endpoint_set_enabled(iso_addr, true);
     bus.endpoint_set_stalled(iso_addr, true);
-    ensure(!bus.endpoint_is_stalled(iso_addr), name, "isochronous endpoint reported stalled");
+    ensure(
+        !bus.endpoint_is_stalled(iso_addr),
+        name,
+        "isochronous endpoint reported stalled",
+    );
 
     for direction in [Direction::Out, Direction::In] {
         let invalid = EndpointAddress::from_parts(127, direction);
         bus.endpoint_set_enabled(invalid, true);
         bus.endpoint_set_stalled(invalid, true);
-        ensure(!bus.endpoint_is_stalled(invalid), name, "invalid endpoint reported stalled");
+        ensure(
+            !bus.endpoint_is_stalled(invalid),
+            name,
+            "invalid endpoint reported stalled",
+        );
     }
 
     let mut packet = [0; 512];
@@ -81,7 +97,11 @@ async fn check<T: Instance>(
         name,
         "disable did not cancel a pending endpoint read",
     );
-    ensure(regs.devcmdstat().read().dev_en(), name, "reversible disable cleared DEV_EN");
+    ensure(
+        regs.devcmdstat().read().dev_en(),
+        name,
+        "reversible disable cleared DEV_EN",
+    );
     let disabled_dcs = regs.devcmdstat().read();
     defmt::assert_eq!(
         disabled_dcs.dcon(),

--- a/tests/lpc55/src/bin/usb_dual_pll0.rs
+++ b/tests/lpc55/src/bin/usb_dual_pll0.rs
@@ -20,7 +20,7 @@ use core::sync::atomic::{AtomicBool, AtomicU32, Ordering};
 use defmt::{info, panic};
 use defmt_rtt as _;
 use embassy_executor::Spawner;
-use embassy_futures::join::join5;
+use embassy_futures::join::{join, join3};
 use embassy_nxp::config::MainClock;
 use embassy_nxp::usb::{Driver, InterruptHandler, Memory};
 use embassy_nxp::{bind_interrupts, pac, peripherals};
@@ -47,7 +47,6 @@ static FS_CONFIGURED: AtomicBool = AtomicBool::new(false);
 static HS_ECHOED: AtomicU32 = AtomicU32::new(0);
 static FS_ECHOED: AtomicU32 = AtomicU32::new(0);
 
-/// Records the host's `SET_CONFIGURATION` into a per-device flag.
 struct ConfiguredHandler(&'static AtomicBool);
 
 impl Handler for ConfiguredHandler {
@@ -56,6 +55,35 @@ impl Handler for ConfiguredHandler {
             self.0.store(true, Ordering::Relaxed);
         }
     }
+}
+
+struct Resources<'d> {
+    config_descriptor: [u8; 256],
+    bos_descriptor: [u8; 256],
+    control_buf: [u8; 64],
+    state: State<'d>,
+    handler: ConfiguredHandler,
+    echoed: &'static AtomicU32,
+}
+
+impl<'d> Resources<'d> {
+    const fn new(configured: &'static AtomicBool, echoed: &'static AtomicU32) -> Self {
+        Self {
+            config_descriptor: [0; 256],
+            bos_descriptor: [0; 256],
+            control_buf: [0; 64],
+            state: State::new(),
+            handler: ConfiguredHandler(configured),
+            echoed,
+        }
+    }
+}
+
+struct Params {
+    pid: u16,
+    product: &'static str,
+    serial: &'static str,
+    max_speed: UsbDeviceSpeed,
 }
 
 #[embassy_executor::main]
@@ -80,84 +108,69 @@ async fn main(_spawner: Spawner) {
     // USB0 uses main SRAM so both controllers can run at the same time.
     let hs_driver = Driver::<peripherals::USBHSD>::new(p.USBHSD, Irqs, Memory::usb1_sram());
     let mut ep_mem = [0u8; 4096];
-    let fs_mem = Memory::buffer(&mut ep_mem);
-    let fs_driver = Driver::<peripherals::USB0>::new(p.USB0, Irqs, p.PIO0_22, fs_mem);
+    let fs_driver = Driver::<peripherals::USB0>::new(p.USB0, Irqs, p.PIO0_22, Memory::buffer(&mut ep_mem));
+    let mut hs_resources = Resources::new(&HS_CONFIGURED, &HS_ECHOED);
+    let mut fs_resources = Resources::new(&FS_CONFIGURED, &FS_ECHOED);
 
-    // --- High-speed device ---
-    //
-    // The manufacturer, product and serial strings below are load-bearing: the
-    // Linux `/dev/serial/by-id/` symlink name is derived from them, and
-    // `host/dual_echo.py` matches on `USB-HS_dual_pll0` / `USB-FS_dual_pll0` to
-    // find the two CDC nodes. Changing them breaks the host peer.
-    let mut hs_config = embassy_usb::Config::new(0xc0de, 0xcb03);
-    hs_config.manufacturer = Some("Embassy");
-    hs_config.product = Some("USB-HS dual pll0");
-    hs_config.serial_number = Some("hs-dual");
-    hs_config.max_power = 100;
-    hs_config.max_packet_size_0 = 64;
-    hs_config.max_speed = UsbDeviceSpeed::High;
-
-    let mut hs_config_descriptor = [0; 256];
-    let mut hs_bos_descriptor = [0; 256];
-    let mut hs_control_buf = [0; 64];
-    let mut hs_state = State::new();
-    let mut hs_handler = ConfiguredHandler(&HS_CONFIGURED);
-
-    let mut hs_builder = embassy_usb::Builder::new(
+    // These strings are load-bearing: Linux derives `/dev/serial/by-id/` names
+    // from them, and `host/dual_echo.py` uses the product names to find both ports.
+    let hs = device::<_, 512>(
         hs_driver,
-        hs_config,
-        &mut hs_config_descriptor,
-        &mut hs_bos_descriptor,
-        &mut [], // no msos descriptors
-        &mut hs_control_buf,
+        &mut hs_resources,
+        Params {
+            pid: 0xcb03,
+            product: "USB-HS dual pll0",
+            serial: "hs-dual",
+            max_speed: UsbDeviceSpeed::High,
+        },
     );
-    let mut hs_class = CdcAcmClass::new(&mut hs_builder, &mut hs_state, 512);
-    hs_builder.handler(&mut hs_handler);
-    let mut hs_usb = hs_builder.build();
-
-    // --- Full-speed device ---
-    let mut fs_config = embassy_usb::Config::new(0xc0de, 0xcb04);
-    fs_config.manufacturer = Some("Embassy");
-    fs_config.product = Some("USB-FS dual pll0");
-    fs_config.serial_number = Some("fs-dual");
-    fs_config.max_power = 100;
-    fs_config.max_packet_size_0 = 64;
-
-    let mut fs_config_descriptor = [0; 256];
-    let mut fs_bos_descriptor = [0; 256];
-    let mut fs_control_buf = [0; 64];
-    let mut fs_state = State::new();
-    let mut fs_handler = ConfiguredHandler(&FS_CONFIGURED);
-
-    let mut fs_builder = embassy_usb::Builder::new(
+    let fs = device::<_, 64>(
         fs_driver,
-        fs_config,
-        &mut fs_config_descriptor,
-        &mut fs_bos_descriptor,
-        &mut [], // no msos descriptors
-        &mut fs_control_buf,
+        &mut fs_resources,
+        Params {
+            pid: 0xcb04,
+            product: "USB-FS dual pll0",
+            serial: "fs-dual",
+            max_speed: UsbDeviceSpeed::Full,
+        },
     );
-    let mut fs_class = CdcAcmClass::new(&mut fs_builder, &mut fs_state, 64);
-    fs_builder.handler(&mut fs_handler);
-    let mut fs_usb = fs_builder.build();
 
-    let hs_echo = async {
+    join3(hs, fs, verdict()).await;
+}
+
+async fn device<'d, D: embassy_usb::driver::Driver<'d>, const MPS: usize>(
+    driver: D,
+    resources: &'d mut Resources<'d>,
+    params: Params,
+) {
+    let mut config = embassy_usb::Config::new(0xc0de, params.pid);
+    config.manufacturer = Some("Embassy");
+    config.product = Some(params.product);
+    config.serial_number = Some(params.serial);
+    config.max_power = 100;
+    config.max_packet_size_0 = 64;
+    config.max_speed = params.max_speed;
+
+    let echoed = resources.echoed;
+    let mut builder = embassy_usb::Builder::new(
+        driver,
+        config,
+        &mut resources.config_descriptor,
+        &mut resources.bos_descriptor,
+        &mut [],
+        &mut resources.control_buf,
+    );
+    let mut class = CdcAcmClass::new(&mut builder, &mut resources.state, MPS as u16);
+    builder.handler(&mut resources.handler);
+    let mut usb = builder.build();
+
+    let echo = async {
         loop {
-            hs_class.wait_connection().await;
-            let _ = echo_hs(&mut hs_class).await;
+            class.wait_connection().await;
+            let _ = echo::<D, MPS>(&mut class, echoed).await;
         }
     };
-
-    let fs_echo = async {
-        loop {
-            fs_class.wait_connection().await;
-            let _ = echo_fs(&mut fs_class).await;
-        }
-    };
-
-    // Both device stacks, both echo loops and the verdict task run concurrently
-    // on one executor.
-    join5(hs_usb.run(), fs_usb.run(), hs_echo, fs_echo, verdict()).await;
+    join(usb.run(), echo).await;
 }
 
 /// Waits for both devices to enumerate, checks what only the device can see,
@@ -200,28 +213,27 @@ async fn verdict() -> ! {
     info!("Test OK");
     cortex_m::asm::bkpt();
 
-    // `bkpt` halts under a debugger, but keep the future's type honest.
     loop {
         Timer::after_millis(1000).await;
     }
 }
 
-struct Disconnected {}
+struct Disconnected;
 
 impl From<EndpointError> for Disconnected {
-    fn from(val: EndpointError) -> Self {
-        match val {
+    fn from(error: EndpointError) -> Self {
+        match error {
             EndpointError::BufferOverflow => panic!("Buffer overflow"),
-            EndpointError::Disabled => Disconnected {},
+            EndpointError::Disabled => Disconnected,
         }
     }
 }
 
-/// An echo of exactly one max-packet-size packet needs a trailing zero-length
-/// packet to end the transfer: without it the host keeps waiting for more and
-/// never delivers the reply.
-async fn echo_hs<'d>(class: &mut CdcAcmClass<'d, Driver<'d, peripherals::USBHSD>>) -> Result<(), Disconnected> {
-    const MPS: usize = 512;
+/// A full packet needs a trailing zero-length packet to terminate the transfer.
+async fn echo<'d, D: embassy_usb::driver::Driver<'d>, const MPS: usize>(
+    class: &mut CdcAcmClass<'d, D>,
+    echoed: &AtomicU32,
+) -> Result<(), Disconnected> {
     let mut buf = [0; MPS];
     loop {
         let n = class.read_packet(&mut buf).await?;
@@ -229,20 +241,6 @@ async fn echo_hs<'d>(class: &mut CdcAcmClass<'d, Driver<'d, peripherals::USBHSD>
         if n == MPS {
             class.write_packet(&[]).await?;
         }
-        HS_ECHOED.fetch_add(n as u32, Ordering::Relaxed);
-    }
-}
-
-/// See [`echo_hs`] for the trailing zero-length packet.
-async fn echo_fs<'d>(class: &mut CdcAcmClass<'d, Driver<'d, peripherals::USB0>>) -> Result<(), Disconnected> {
-    const MPS: usize = 64;
-    let mut buf = [0; MPS];
-    loop {
-        let n = class.read_packet(&mut buf).await?;
-        class.write_packet(&buf[..n]).await?;
-        if n == MPS {
-            class.write_packet(&[]).await?;
-        }
-        FS_ECHOED.fetch_add(n as u32, Ordering::Relaxed);
+        echoed.fetch_add(n as u32, Ordering::Relaxed);
     }
 }

--- a/tests/lpc55/src/bin/usb_dual_pll0.rs
+++ b/tests/lpc55/src/bin/usb_dual_pll0.rs
@@ -1,0 +1,249 @@
+//! Both LPC55 USB controllers running concurrently off `MainClock::Pll0_150M`.
+//!
+//! Requires host cables on **both** P9 (high speed) and P10 (full speed).
+//!
+//! The other dual-controller code in this repo runs on `MainClock::FroHf96`, so
+//! the PLL0 main-clock path was never exercised with USB live. PLL0 at 150 MHz
+//! satisfies the USB-HS >= 96 MHz system-clock requirement while changing the
+//! divider arithmetic behind both controllers' 48/480 MHz clocks, which is what
+//! this test covers: full enumeration of both devices, an asserted high-speed
+//! negotiation on USB1, and a bulk echo round-trip on each port.
+//!
+//! Host peer: `tests/lpc55/host/dual_echo.py`, started once the ready banner
+//! `dual pll0 ready` appears.
+
+#![no_std]
+#![no_main]
+
+use core::sync::atomic::{AtomicBool, AtomicU32, Ordering};
+
+use defmt::{info, panic};
+use defmt_rtt as _;
+use embassy_executor::Spawner;
+use embassy_futures::join::join5;
+use embassy_nxp::config::MainClock;
+use embassy_nxp::usb::{Driver, InterruptHandler, Memory};
+use embassy_nxp::{bind_interrupts, pac, peripherals};
+use embassy_time::{Duration, Instant, Timer};
+use embassy_usb::class::cdc_acm::{CdcAcmClass, State};
+use embassy_usb::driver::EndpointError;
+use embassy_usb::{Handler, UsbDeviceSpeed};
+use panic_probe as _;
+
+bind_interrupts!(struct Irqs {
+    USB0 => InterruptHandler<peripherals::USB0>;
+    USB1 => InterruptHandler<peripherals::USBHSD>;
+});
+
+/// Bytes the host echoes per port before the test is considered passed. The
+/// host script sends 8 x 512 bytes, so this is reached exactly once per port.
+const ECHO_TARGET: u32 = 4096;
+
+/// Budget for both echo streams, measured from the ready banner.
+const ECHO_TIMEOUT: Duration = Duration::from_secs(30);
+
+static HS_CONFIGURED: AtomicBool = AtomicBool::new(false);
+static FS_CONFIGURED: AtomicBool = AtomicBool::new(false);
+static HS_ECHOED: AtomicU32 = AtomicU32::new(0);
+static FS_ECHOED: AtomicU32 = AtomicU32::new(0);
+
+/// Endpoint memory for the full-speed controller, in main SRAM.
+///
+/// Only one controller can own the dedicated USB1 SRAM, so running both at once
+/// forces the other onto a caller-provided region. 4 KiB comfortably fits an FS
+/// CDC-ACM device; `Memory::buffer` requires at least 512 bytes and 256-byte
+/// alignment.
+#[repr(C, align(256))]
+struct EpMem([u8; 4096]);
+static mut EP_MEM: EpMem = EpMem([0; 4096]);
+
+/// Records the host's `SET_CONFIGURATION` into a per-device flag.
+struct ConfiguredHandler(&'static AtomicBool);
+
+impl Handler for ConfiguredHandler {
+    fn configured(&mut self, configured: bool) {
+        if configured {
+            self.0.store(true, Ordering::Relaxed);
+        }
+    }
+}
+
+#[embassy_executor::main]
+async fn main(_spawner: Spawner) {
+    let mut hal_config = embassy_nxp::config::Config::default();
+    // The point of this test: drive both controllers from PLL0 at 150 MHz
+    // instead of the 96 MHz FRO every other dual-controller binary uses.
+    hal_config.main_clock = MainClock::Pll0_150M;
+    let p = embassy_nxp::init(hal_config);
+
+    // High speed takes the dedicated USB1 SRAM.
+    let hs_driver = Driver::<peripherals::USBHSD>::new(p.USBHSD, Irqs, Memory::usb1_sram());
+
+    // Full speed takes a region in main SRAM. Edition 2024 forbids references
+    // to `static mut`, so go through a raw pointer.
+    let fs_mem = Memory::buffer(unsafe { &mut (*(&raw mut EP_MEM)).0 });
+    let fs_driver = Driver::<peripherals::USB0>::new(p.USB0, Irqs, p.PIO0_22, fs_mem);
+
+    // --- High-speed device ---
+    //
+    // The manufacturer, product and serial strings below are load-bearing: the
+    // Linux `/dev/serial/by-id/` symlink name is derived from them, and
+    // `host/dual_echo.py` matches on `USB-HS_dual_pll0` / `USB-FS_dual_pll0` to
+    // find the two CDC nodes. Changing them breaks the host peer.
+    let mut hs_config = embassy_usb::Config::new(0xc0de, 0xcb03);
+    hs_config.manufacturer = Some("Embassy");
+    hs_config.product = Some("USB-HS dual pll0");
+    hs_config.serial_number = Some("hs-dual");
+    hs_config.max_power = 100;
+    hs_config.max_packet_size_0 = 64;
+    hs_config.max_speed = UsbDeviceSpeed::High;
+
+    let mut hs_config_descriptor = [0; 256];
+    let mut hs_bos_descriptor = [0; 256];
+    let mut hs_control_buf = [0; 64];
+    let mut hs_state = State::new();
+    let mut hs_handler = ConfiguredHandler(&HS_CONFIGURED);
+
+    let mut hs_builder = embassy_usb::Builder::new(
+        hs_driver,
+        hs_config,
+        &mut hs_config_descriptor,
+        &mut hs_bos_descriptor,
+        &mut [], // no msos descriptors
+        &mut hs_control_buf,
+    );
+    let mut hs_class = CdcAcmClass::new(&mut hs_builder, &mut hs_state, 512);
+    hs_builder.handler(&mut hs_handler);
+    let mut hs_usb = hs_builder.build();
+
+    // --- Full-speed device ---
+    let mut fs_config = embassy_usb::Config::new(0xc0de, 0xcb04);
+    fs_config.manufacturer = Some("Embassy");
+    fs_config.product = Some("USB-FS dual pll0");
+    fs_config.serial_number = Some("fs-dual");
+    fs_config.max_power = 100;
+    fs_config.max_packet_size_0 = 64;
+
+    let mut fs_config_descriptor = [0; 256];
+    let mut fs_bos_descriptor = [0; 256];
+    let mut fs_control_buf = [0; 64];
+    let mut fs_state = State::new();
+    let mut fs_handler = ConfiguredHandler(&FS_CONFIGURED);
+
+    let mut fs_builder = embassy_usb::Builder::new(
+        fs_driver,
+        fs_config,
+        &mut fs_config_descriptor,
+        &mut fs_bos_descriptor,
+        &mut [], // no msos descriptors
+        &mut fs_control_buf,
+    );
+    let mut fs_class = CdcAcmClass::new(&mut fs_builder, &mut fs_state, 64);
+    fs_builder.handler(&mut fs_handler);
+    let mut fs_usb = fs_builder.build();
+
+    let hs_echo = async {
+        loop {
+            hs_class.wait_connection().await;
+            let _ = echo_hs(&mut hs_class).await;
+        }
+    };
+
+    let fs_echo = async {
+        loop {
+            fs_class.wait_connection().await;
+            let _ = echo_fs(&mut fs_class).await;
+        }
+    };
+
+    // Both device stacks, both echo loops and the verdict task run concurrently
+    // on one executor.
+    join5(hs_usb.run(), fs_usb.run(), hs_echo, fs_echo, verdict()).await;
+}
+
+/// Waits for both devices to enumerate, checks what only the device can see,
+/// prints the host's ready banner and then waits for both echo streams.
+async fn verdict() -> ! {
+    while !(HS_CONFIGURED.load(Ordering::Relaxed) && FS_CONFIGURED.load(Ordering::Relaxed)) {
+        Timer::after_millis(50).await;
+    }
+
+    // 10b = high speed, per the DEVCMDSTAT.SPEED field docs. A silent fallback
+    // to full speed on P9 would otherwise pass unnoticed.
+    defmt::assert_eq!(
+        pac::USBHSD.devcmdstat().read().speed(),
+        0b10,
+        "USB1 did not negotiate high speed under PLL0"
+    );
+    defmt::assert!(
+        pac::USB0.devcmdstat().read().dev_addr() != 0,
+        "USB0 was configured but DEVCMDSTAT.DEV_ADDR is still 0"
+    );
+
+    info!("dual pll0 ready");
+
+    let deadline = Instant::now() + ECHO_TIMEOUT;
+    loop {
+        let hs = HS_ECHOED.load(Ordering::Relaxed);
+        let fs = FS_ECHOED.load(Ordering::Relaxed);
+        if hs >= ECHO_TARGET && fs >= ECHO_TARGET {
+            break;
+        }
+        if Instant::now() >= deadline {
+            panic!(
+                "echo did not complete within 30 s: hs={} bytes, fs={} bytes (target {} each)",
+                hs, fs, ECHO_TARGET
+            );
+        }
+        Timer::after_millis(50).await;
+    }
+
+    info!("Test OK");
+    cortex_m::asm::bkpt();
+
+    // `bkpt` halts under a debugger, but keep the future's type honest.
+    loop {
+        Timer::after_millis(1000).await;
+    }
+}
+
+struct Disconnected {}
+
+impl From<EndpointError> for Disconnected {
+    fn from(val: EndpointError) -> Self {
+        match val {
+            EndpointError::BufferOverflow => panic!("Buffer overflow"),
+            EndpointError::Disabled => Disconnected {},
+        }
+    }
+}
+
+/// An echo of exactly one max-packet-size packet needs a trailing zero-length
+/// packet to end the transfer: without it the host keeps waiting for more and
+/// never delivers the reply.
+async fn echo_hs<'d>(class: &mut CdcAcmClass<'d, Driver<'d, peripherals::USBHSD>>) -> Result<(), Disconnected> {
+    const MPS: usize = 512;
+    let mut buf = [0; MPS];
+    loop {
+        let n = class.read_packet(&mut buf).await?;
+        class.write_packet(&buf[..n]).await?;
+        if n == MPS {
+            class.write_packet(&[]).await?;
+        }
+        HS_ECHOED.fetch_add(n as u32, Ordering::Relaxed);
+    }
+}
+
+/// See [`echo_hs`] for the trailing zero-length packet.
+async fn echo_fs<'d>(class: &mut CdcAcmClass<'d, Driver<'d, peripherals::USB0>>) -> Result<(), Disconnected> {
+    const MPS: usize = 64;
+    let mut buf = [0; MPS];
+    loop {
+        let n = class.read_packet(&mut buf).await?;
+        class.write_packet(&buf[..n]).await?;
+        if n == MPS {
+            class.write_packet(&[]).await?;
+        }
+        FS_ECHOED.fetch_add(n as u32, Ordering::Relaxed);
+    }
+}

--- a/tests/lpc55/src/bin/usb_dual_pll0.rs
+++ b/tests/lpc55/src/bin/usb_dual_pll0.rs
@@ -65,15 +65,20 @@ async fn main(_spawner: Spawner) {
     // instead of the 96 MHz FRO every other dual-controller binary uses.
     hal_config.main_clock = MainClock::Pll0_150M;
     let p = embassy_nxp::init(hal_config);
+    let revision = pac::SYSCON.dieid().read().rev_id();
+    let pll_locked = pac::SYSCON.pll0stat().read().lock();
+    let main_clock_source = pac::SYSCON.mainclkselb().read().sel();
+    defmt::assert_eq!(revision, 1, "PLL0 test requires LPC55 revision 1B");
+    defmt::assert!(pll_locked, "PLL0 lost lock after clock initialization");
+    defmt::assert!(
+        main_clock_source == pac::syscon::vals::MainclkselbSel::Enum0x1,
+        "main clock did not select PLL0"
+    );
+    info!("REV_ID={} PLL0STAT.LOCK={} MAINCLKSELB=PLL0", revision, pll_locked);
 
-    // High speed takes the dedicated USB1 SRAM.
+    // USBHSD can write its command list only in the dedicated USB1 SRAM.
+    // USB0 uses main SRAM so both controllers can run at the same time.
     let hs_driver = Driver::<peripherals::USBHSD>::new(p.USBHSD, Irqs, Memory::usb1_sram());
-
-    // Full speed takes a region in main SRAM: only one controller can own the
-    // dedicated USB1 SRAM, so running both at once forces the other onto a
-    // caller-provided region. 4 KiB comfortably fits an FS CDC-ACM device. The
-    // local lives in the main task's storage, which is a `static`, not on the
-    // stack.
     let mut ep_mem = [0u8; 4096];
     let fs_mem = Memory::buffer(&mut ep_mem);
     let fs_driver = Driver::<peripherals::USB0>::new(p.USB0, Irqs, p.PIO0_22, fs_mem);

--- a/tests/lpc55/src/bin/usb_dual_pll0.rs
+++ b/tests/lpc55/src/bin/usb_dual_pll0.rs
@@ -47,16 +47,6 @@ static FS_CONFIGURED: AtomicBool = AtomicBool::new(false);
 static HS_ECHOED: AtomicU32 = AtomicU32::new(0);
 static FS_ECHOED: AtomicU32 = AtomicU32::new(0);
 
-/// Endpoint memory for the full-speed controller, in main SRAM.
-///
-/// Only one controller can own the dedicated USB1 SRAM, so running both at once
-/// forces the other onto a caller-provided region. 4 KiB comfortably fits an FS
-/// CDC-ACM device; `Memory::buffer` requires at least 512 bytes and 256-byte
-/// alignment.
-#[repr(C, align(256))]
-struct EpMem([u8; 4096]);
-static mut EP_MEM: EpMem = EpMem([0; 4096]);
-
 /// Records the host's `SET_CONFIGURATION` into a per-device flag.
 struct ConfiguredHandler(&'static AtomicBool);
 
@@ -79,9 +69,13 @@ async fn main(_spawner: Spawner) {
     // High speed takes the dedicated USB1 SRAM.
     let hs_driver = Driver::<peripherals::USBHSD>::new(p.USBHSD, Irqs, Memory::usb1_sram());
 
-    // Full speed takes a region in main SRAM. Edition 2024 forbids references
-    // to `static mut`, so go through a raw pointer.
-    let fs_mem = Memory::buffer(unsafe { &mut (*(&raw mut EP_MEM)).0 });
+    // Full speed takes a region in main SRAM: only one controller can own the
+    // dedicated USB1 SRAM, so running both at once forces the other onto a
+    // caller-provided region. 4 KiB comfortably fits an FS CDC-ACM device. The
+    // local lives in the main task's storage, which is a `static`, not on the
+    // stack.
+    let mut ep_mem = [0u8; 4096];
+    let fs_mem = Memory::buffer(&mut ep_mem);
     let fs_driver = Driver::<peripherals::USB0>::new(p.USB0, Irqs, p.PIO0_22, fs_mem);
 
     // --- High-speed device ---

--- a/tests/lpc55/src/bin/usb_fs_conformance.rs
+++ b/tests/lpc55/src/bin/usb_fs_conformance.rs
@@ -1,0 +1,49 @@
+//! USB0 full-speed conformance test. Requires a host cable on **P10** and the
+//! host driver `host/conformance.py --pid 0xcb02 --speed fs`.
+
+#![no_std]
+#![no_main]
+
+use defmt_rtt as _;
+use embassy_executor::Spawner;
+use embassy_nxp::usb::{Driver, InterruptHandler, Memory};
+use embassy_nxp::{bind_interrupts, peripherals};
+use embassy_nxp_lpc55_tests::conformance::{self, Params};
+use embassy_usb::UsbDeviceSpeed;
+use panic_probe as _;
+
+bind_interrupts!(struct Irqs {
+    USB0 => InterruptHandler<peripherals::USB0>;
+});
+
+#[embassy_executor::main]
+async fn main(_spawner: Spawner) -> ! {
+    // Default main clock: the full-speed driver brings up its own 48 MHz.
+    let p = embassy_nxp::init(embassy_nxp::config::Config::default());
+
+    // Only one controller runs in this binary, so it may take the dedicated
+    // USB1 SRAM even though it drives USB0.
+    let driver = Driver::<peripherals::USB0>::new(p.USB0, Irqs, p.PIO0_22, Memory::usb1_sram());
+
+    conformance::run(
+        driver,
+        Params {
+            pid: 0xcb02,
+            product: "USB-FS conformance",
+            serial: "fs-conf",
+            max_speed: UsbDeviceSpeed::Full,
+            bulk_mps: 64,
+            int_mps: 16,
+            // 512 and not the full-speed maximum of 1023. Two 1023-byte
+            // isochronous endpoints do not fit the 1 ms full-speed frame's 90 %
+            // periodic budget (1350 B), and a 1023-byte full-speed isochronous
+            // IN through a high-speed hub's transaction translator only survives
+            // one packet per URB on this host - multi-packet URBs come back
+            // truncated or with EPIPE. The 1023-byte allocation boundary itself
+            // is covered by `usb_alloc` on both controllers.
+            iso_out_mps: 512,
+            iso_in_mps: 512,
+        },
+    )
+    .await
+}

--- a/tests/lpc55/src/bin/usb_fs_enumerate.rs
+++ b/tests/lpc55/src/bin/usb_fs_enumerate.rs
@@ -6,16 +6,14 @@
 #![no_std]
 #![no_main]
 
-use core::sync::atomic::{AtomicBool, Ordering};
+use core::sync::atomic::AtomicBool;
 
 use defmt_rtt as _;
 use embassy_executor::Spawner;
-use embassy_futures::select::{Either, select};
 use embassy_nxp::usb::{Driver, InterruptHandler, Memory};
 use embassy_nxp::{bind_interrupts, pac, peripherals};
-use embassy_time::Timer;
-use embassy_usb::Handler;
-use embassy_usb::class::cdc_acm::{CdcAcmClass, State};
+use embassy_nxp_lpc55_tests::enumerate::{self, Params, Resources};
+use embassy_usb::UsbDeviceSpeed;
 use panic_probe as _;
 
 bind_interrupts!(struct Irqs {
@@ -24,71 +22,25 @@ bind_interrupts!(struct Irqs {
 
 static CONFIGURED: AtomicBool = AtomicBool::new(false);
 
-struct ConfiguredHandler;
-
-impl Handler for ConfiguredHandler {
-    fn configured(&mut self, configured: bool) {
-        if configured {
-            CONFIGURED.store(true, Ordering::Relaxed);
-        }
-    }
-}
-
-/// Polls [`CONFIGURED`] for up to 10 s. Returns whether the host configured us.
-async fn wait_configured() -> bool {
-    for _ in 0..100 {
-        if CONFIGURED.load(Ordering::Relaxed) {
-            return true;
-        }
-        Timer::after_millis(100).await;
-    }
-    false
-}
-
 #[embassy_executor::main]
 async fn main(_spawner: Spawner) {
     let p = embassy_nxp::init(embassy_nxp::config::Config::default());
-
+    let mut resources = Resources::new(&CONFIGURED);
     let driver = Driver::<peripherals::USB0>::new(p.USB0, Irqs, p.PIO0_22, Memory::usb1_sram());
 
-    let mut config = embassy_usb::Config::new(0xc0de, 0xcafe);
-    config.manufacturer = Some("Embassy");
-    config.product = Some("USB-FS enumeration test");
-    config.serial_number = Some("12345678");
-    config.max_power = 100;
-    config.max_packet_size_0 = 64;
-
-    let mut config_descriptor = [0; 256];
-    let mut bos_descriptor = [0; 256];
-    let mut control_buf = [0; 64];
-
-    let mut state = State::new();
-    let mut handler = ConfiguredHandler;
-
-    let mut builder = embassy_usb::Builder::new(
+    enumerate::run::<_, _, 64>(
         driver,
-        config,
-        &mut config_descriptor,
-        &mut bos_descriptor,
-        &mut [], // no msos descriptors
-        &mut control_buf,
-    );
-
-    let _class = CdcAcmClass::new(&mut builder, &mut state, 64);
-    builder.handler(&mut handler);
-
-    let mut usb = builder.build();
-
-    match select(usb.run(), wait_configured()).await {
-        Either::First(never) => never,
-        Either::Second(true) => {
+        &mut resources,
+        Params {
+            product: "USB-FS enumeration test",
+            max_speed: UsbDeviceSpeed::Full,
+        },
+        || {
             defmt::assert!(
                 pac::USB0.devcmdstat().read().dev_addr() != 0,
                 "host configured us but DEVCMDSTAT.DEV_ADDR is still 0"
             );
-            defmt::info!("Test OK");
-            cortex_m::asm::bkpt();
-        }
-        Either::Second(false) => defmt::panic!("not configured within 10 s"),
-    }
+        },
+    )
+    .await;
 }

--- a/tests/lpc55/src/bin/usb_fs_enumerate.rs
+++ b/tests/lpc55/src/bin/usb_fs_enumerate.rs
@@ -1,0 +1,94 @@
+//! USB0 full-speed enumeration test. Requires a host cable on **P10**.
+//!
+//! Uses the default HAL config on purpose: the full-speed driver brings up its
+//! own 48 MHz clock, and proving that is part of the test.
+
+#![no_std]
+#![no_main]
+
+use core::sync::atomic::{AtomicBool, Ordering};
+
+use defmt_rtt as _;
+use embassy_executor::Spawner;
+use embassy_futures::select::{Either, select};
+use embassy_nxp::usb::{Driver, InterruptHandler, Memory};
+use embassy_nxp::{bind_interrupts, pac, peripherals};
+use embassy_time::Timer;
+use embassy_usb::Handler;
+use embassy_usb::class::cdc_acm::{CdcAcmClass, State};
+use panic_probe as _;
+
+bind_interrupts!(struct Irqs {
+    USB0 => InterruptHandler<peripherals::USB0>;
+});
+
+static CONFIGURED: AtomicBool = AtomicBool::new(false);
+
+struct ConfiguredHandler;
+
+impl Handler for ConfiguredHandler {
+    fn configured(&mut self, configured: bool) {
+        if configured {
+            CONFIGURED.store(true, Ordering::Relaxed);
+        }
+    }
+}
+
+/// Polls [`CONFIGURED`] for up to 10 s. Returns whether the host configured us.
+async fn wait_configured() -> bool {
+    for _ in 0..100 {
+        if CONFIGURED.load(Ordering::Relaxed) {
+            return true;
+        }
+        Timer::after_millis(100).await;
+    }
+    false
+}
+
+#[embassy_executor::main]
+async fn main(_spawner: Spawner) {
+    let p = embassy_nxp::init(embassy_nxp::config::Config::default());
+
+    let driver = Driver::<peripherals::USB0>::new(p.USB0, Irqs, p.PIO0_22, Memory::usb1_sram());
+
+    let mut config = embassy_usb::Config::new(0xc0de, 0xcafe);
+    config.manufacturer = Some("Embassy");
+    config.product = Some("USB-FS enumeration test");
+    config.serial_number = Some("12345678");
+    config.max_power = 100;
+    config.max_packet_size_0 = 64;
+
+    let mut config_descriptor = [0; 256];
+    let mut bos_descriptor = [0; 256];
+    let mut control_buf = [0; 64];
+
+    let mut state = State::new();
+    let mut handler = ConfiguredHandler;
+
+    let mut builder = embassy_usb::Builder::new(
+        driver,
+        config,
+        &mut config_descriptor,
+        &mut bos_descriptor,
+        &mut [], // no msos descriptors
+        &mut control_buf,
+    );
+
+    let _class = CdcAcmClass::new(&mut builder, &mut state, 64);
+    builder.handler(&mut handler);
+
+    let mut usb = builder.build();
+
+    match select(usb.run(), wait_configured()).await {
+        Either::First(never) => never,
+        Either::Second(true) => {
+            defmt::assert!(
+                pac::USB0.devcmdstat().read().dev_addr() != 0,
+                "host configured us but DEVCMDSTAT.DEV_ADDR is still 0"
+            );
+            defmt::info!("Test OK");
+            cortex_m::asm::bkpt();
+        }
+        Either::Second(false) => defmt::panic!("not configured within 10 s"),
+    }
+}

--- a/tests/lpc55/src/bin/usb_hs_conformance.rs
+++ b/tests/lpc55/src/bin/usb_hs_conformance.rs
@@ -1,0 +1,48 @@
+//! USB1 high-speed conformance test. Requires a host cable on **P9** and the
+//! host driver `host/conformance.py --pid 0xcb01 --speed hs`.
+
+#![no_std]
+#![no_main]
+
+use defmt_rtt as _;
+use embassy_executor::Spawner;
+use embassy_nxp::config::MainClock;
+use embassy_nxp::usb::{Driver, InterruptHandler, Memory};
+use embassy_nxp::{bind_interrupts, peripherals};
+use embassy_nxp_lpc55_tests::conformance::{self, Params};
+use embassy_usb::UsbDeviceSpeed;
+use panic_probe as _;
+
+bind_interrupts!(struct Irqs {
+    USB1 => InterruptHandler<peripherals::USBHSD>;
+});
+
+#[embassy_executor::main]
+async fn main(_spawner: Spawner) -> ! {
+    let mut hal_config = embassy_nxp::config::Config::default();
+    // The high-speed controller requires a system clock of at least 96 MHz.
+    hal_config.main_clock = MainClock::FroHf96;
+    let p = embassy_nxp::init(hal_config);
+
+    // Only one controller runs in this binary, so it may take the dedicated
+    // USB1 SRAM. Worst case there: list 128 + setup 64 + EP0 128 + bulk IN
+    // 2x3584 + bulk OUT 2x512 + interrupt IN 2x64 + iso OUT 2x1024 + iso IN
+    // 2x1024 = 12736 B of 16384 B.
+    let driver = Driver::<peripherals::USBHSD>::new(p.USBHSD, Irqs, Memory::usb1_sram());
+
+    conformance::run(
+        driver,
+        Params {
+            pid: 0xcb01,
+            product: "USB-HS conformance",
+            serial: "hs-conf",
+            max_speed: UsbDeviceSpeed::High,
+            bulk_mps: 512,
+            int_mps: 16,
+            iso_out_mps: 1024,
+            // 1023 and not 1024: erratum USB.6 caps high-speed isochronous IN.
+            iso_in_mps: 1023,
+        },
+    )
+    .await
+}

--- a/tests/lpc55/src/bin/usb_hs_enumerate.rs
+++ b/tests/lpc55/src/bin/usb_hs_enumerate.rs
@@ -1,0 +1,102 @@
+//! USB1 high-speed enumeration test. Requires a host cable on **P9**.
+
+#![no_std]
+#![no_main]
+
+use core::sync::atomic::{AtomicBool, Ordering};
+
+use defmt_rtt as _;
+use embassy_executor::Spawner;
+use embassy_futures::select::{Either, select};
+use embassy_nxp::config::MainClock;
+use embassy_nxp::usb::{Driver, InterruptHandler, Memory};
+use embassy_nxp::{bind_interrupts, pac, peripherals};
+use embassy_time::Timer;
+use embassy_usb::class::cdc_acm::{CdcAcmClass, State};
+use embassy_usb::{Handler, UsbDeviceSpeed};
+use panic_probe as _;
+
+bind_interrupts!(struct Irqs {
+    USB1 => InterruptHandler<peripherals::USBHSD>;
+});
+
+static CONFIGURED: AtomicBool = AtomicBool::new(false);
+
+struct ConfiguredHandler;
+
+impl Handler for ConfiguredHandler {
+    fn configured(&mut self, configured: bool) {
+        if configured {
+            CONFIGURED.store(true, Ordering::Relaxed);
+        }
+    }
+}
+
+/// Polls [`CONFIGURED`] for up to 10 s. Returns whether the host configured us.
+async fn wait_configured() -> bool {
+    for _ in 0..100 {
+        if CONFIGURED.load(Ordering::Relaxed) {
+            return true;
+        }
+        Timer::after_millis(100).await;
+    }
+    false
+}
+
+#[embassy_executor::main]
+async fn main(_spawner: Spawner) {
+    let mut hal_config = embassy_nxp::config::Config::default();
+    // The high-speed controller requires a system clock of at least 96 MHz.
+    hal_config.main_clock = MainClock::FroHf96;
+    let p = embassy_nxp::init(hal_config);
+
+    let driver = Driver::<peripherals::USBHSD>::new(p.USBHSD, Irqs, Memory::usb1_sram());
+
+    let mut config = embassy_usb::Config::new(0xc0de, 0xcafe);
+    config.manufacturer = Some("Embassy");
+    config.product = Some("USB-HS enumeration test");
+    config.serial_number = Some("12345678");
+    config.max_power = 100;
+    config.max_packet_size_0 = 64;
+    config.max_speed = UsbDeviceSpeed::High;
+
+    let mut config_descriptor = [0; 256];
+    let mut bos_descriptor = [0; 256];
+    let mut control_buf = [0; 64];
+
+    let mut state = State::new();
+    let mut handler = ConfiguredHandler;
+
+    let mut builder = embassy_usb::Builder::new(
+        driver,
+        config,
+        &mut config_descriptor,
+        &mut bos_descriptor,
+        &mut [], // no msos descriptors
+        &mut control_buf,
+    );
+
+    let _class = CdcAcmClass::new(&mut builder, &mut state, 512);
+    builder.handler(&mut handler);
+
+    let mut usb = builder.build();
+
+    match select(usb.run(), wait_configured()).await {
+        Either::First(never) => never,
+        Either::Second(true) => {
+            // 10b = high speed, per the DEVCMDSTAT.SPEED field docs.
+            defmt::assert_eq!(
+                pac::USBHSD.devcmdstat().read().speed(),
+                0b10,
+                "device did not negotiate high speed"
+            );
+            defmt::assert!(
+                pac::USBHSD.devcmdstat().read().dev_addr() != 0,
+                "host configured us but DEVCMDSTAT.DEV_ADDR is still 0"
+            );
+            defmt::info!("Test OK");
+            cortex_m::asm::bkpt();
+        }
+        Either::Second(false) => defmt::panic!("not configured within 10 s"),
+    }
+}

--- a/tests/lpc55/src/bin/usb_hs_enumerate.rs
+++ b/tests/lpc55/src/bin/usb_hs_enumerate.rs
@@ -3,17 +3,15 @@
 #![no_std]
 #![no_main]
 
-use core::sync::atomic::{AtomicBool, Ordering};
+use core::sync::atomic::AtomicBool;
 
 use defmt_rtt as _;
 use embassy_executor::Spawner;
-use embassy_futures::select::{Either, select};
 use embassy_nxp::config::MainClock;
 use embassy_nxp::usb::{Driver, InterruptHandler, Memory};
 use embassy_nxp::{bind_interrupts, pac, peripherals};
-use embassy_time::Timer;
-use embassy_usb::class::cdc_acm::{CdcAcmClass, State};
-use embassy_usb::{Handler, UsbDeviceSpeed};
+use embassy_nxp_lpc55_tests::enumerate::{self, Params, Resources};
+use embassy_usb::UsbDeviceSpeed;
 use panic_probe as _;
 
 bind_interrupts!(struct Irqs {
@@ -22,68 +20,23 @@ bind_interrupts!(struct Irqs {
 
 static CONFIGURED: AtomicBool = AtomicBool::new(false);
 
-struct ConfiguredHandler;
-
-impl Handler for ConfiguredHandler {
-    fn configured(&mut self, configured: bool) {
-        if configured {
-            CONFIGURED.store(true, Ordering::Relaxed);
-        }
-    }
-}
-
-/// Polls [`CONFIGURED`] for up to 10 s. Returns whether the host configured us.
-async fn wait_configured() -> bool {
-    for _ in 0..100 {
-        if CONFIGURED.load(Ordering::Relaxed) {
-            return true;
-        }
-        Timer::after_millis(100).await;
-    }
-    false
-}
-
 #[embassy_executor::main]
 async fn main(_spawner: Spawner) {
-    let mut hal_config = embassy_nxp::config::Config::default();
+    let mut config = embassy_nxp::config::Config::default();
     // The high-speed controller requires a system clock of at least 96 MHz.
-    hal_config.main_clock = MainClock::FroHf96;
-    let p = embassy_nxp::init(hal_config);
-
+    config.main_clock = MainClock::FroHf96;
+    let p = embassy_nxp::init(config);
+    let mut resources = Resources::new(&CONFIGURED);
     let driver = Driver::<peripherals::USBHSD>::new(p.USBHSD, Irqs, Memory::usb1_sram());
 
-    let mut config = embassy_usb::Config::new(0xc0de, 0xcafe);
-    config.manufacturer = Some("Embassy");
-    config.product = Some("USB-HS enumeration test");
-    config.serial_number = Some("12345678");
-    config.max_power = 100;
-    config.max_packet_size_0 = 64;
-    config.max_speed = UsbDeviceSpeed::High;
-
-    let mut config_descriptor = [0; 256];
-    let mut bos_descriptor = [0; 256];
-    let mut control_buf = [0; 64];
-
-    let mut state = State::new();
-    let mut handler = ConfiguredHandler;
-
-    let mut builder = embassy_usb::Builder::new(
+    enumerate::run::<_, _, 512>(
         driver,
-        config,
-        &mut config_descriptor,
-        &mut bos_descriptor,
-        &mut [], // no msos descriptors
-        &mut control_buf,
-    );
-
-    let _class = CdcAcmClass::new(&mut builder, &mut state, 512);
-    builder.handler(&mut handler);
-
-    let mut usb = builder.build();
-
-    match select(usb.run(), wait_configured()).await {
-        Either::First(never) => never,
-        Either::Second(true) => {
+        &mut resources,
+        Params {
+            product: "USB-HS enumeration test",
+            max_speed: UsbDeviceSpeed::High,
+        },
+        || {
             // 10b = high speed, per the DEVCMDSTAT.SPEED field docs.
             defmt::assert_eq!(
                 pac::USBHSD.devcmdstat().read().speed(),
@@ -94,9 +47,7 @@ async fn main(_spawner: Spawner) {
                 pac::USBHSD.devcmdstat().read().dev_addr() != 0,
                 "host configured us but DEVCMDSTAT.DEV_ADDR is still 0"
             );
-            defmt::info!("Test OK");
-            cortex_m::asm::bkpt();
-        }
-        Either::Second(false) => defmt::panic!("not configured within 10 s"),
-    }
+        },
+    )
+    .await;
 }

--- a/tests/lpc55/src/conformance.rs
+++ b/tests/lpc55/src/conformance.rs
@@ -1,0 +1,623 @@
+//! Firmware side of the host-driven USB conformance test.
+//!
+//! One generic implementation, instantiated once per controller by
+//! `src/bin/usb_hs_conformance.rs` and `src/bin/usb_fs_conformance.rs`. The
+//! device exposes a single vendor interface with two alternate settings and a
+//! vendor control protocol the host script (`host/conformance.py`) uses to put
+//! the device into a mode, trigger single transfers and read back counters:
+//!
+//! - alt 0: bulk OUT, bulk IN, interrupt IN
+//! - alt 1: isochronous OUT, isochronous IN
+//!
+//! Nothing here decides pass or fail on its own except the invariants only the
+//! device can observe: those are asserted once the host sends `FINISH`. Every
+//! host-observable expectation lives in the host script.
+
+use core::sync::atomic::{AtomicU16, AtomicU32, Ordering};
+
+use defmt::info;
+use embassy_futures::join::join5;
+use embassy_futures::select::{Either, select};
+use embassy_nxp::usb::{Driver, Instance};
+use embassy_sync::blocking_mutex::raw::CriticalSectionRawMutex;
+use embassy_sync::signal::Signal;
+use embassy_sync::watch::{Receiver, Watch};
+use embassy_time::Timer;
+use embassy_usb::control::{InResponse, OutResponse, Recipient, Request, RequestType};
+use embassy_usb::descriptor::{SynchronizationType, UsageType};
+use embassy_usb::driver::{EndpointError, EndpointIn, EndpointOut};
+use embassy_usb::{Handler, UsbDeviceSpeed};
+
+/// Per-controller parameters. Everything else about the device is identical
+/// across instantiations, which is what makes the two runs comparable.
+pub struct Params {
+    pub pid: u16,
+    pub product: &'static str,
+    pub serial: &'static str,
+    pub max_speed: UsbDeviceSpeed,
+    pub bulk_mps: u16,
+    /// 16 on both controllers.
+    pub int_mps: u16,
+    pub iso_out_mps: u16,
+    pub iso_in_mps: u16,
+}
+
+/// Largest bulk IN slot on either controller. Also the bulk task's buffer size,
+/// so a single `write` can hand hardware a whole multi-packet slot.
+const BULK_BUF: usize = 3584;
+/// Largest isochronous packet on either controller.
+const ISO_BUF: usize = 1024;
+/// Largest control-OUT payload `ECHO_WRITE` accepts.
+const ECHO_MAX: usize = 200;
+/// Size of the `GET_REPORT` payload. Layout, little-endian:
+///
+/// ```text
+///  0..4   u32 bulk_out_bytes     12..16  u32 disabled_errors
+///  4..8   u32 bulk_in_bytes      16..20  u32 overflow_errors
+///  8..12  u32 iso_out_bytes      20..22  u16 iso_out_packets
+/// 22..24  u16 iso_in_packets     24..26  u16 int_in_packets
+/// 26..28  u16 ramp_mismatches    28..30  u16 zlp_out_count
+/// ```
+const REPORT_LEN: usize = 30;
+
+/// Byte `k` of every test payload. Matches `ramp` in
+/// `examples/lpc55s69/scripts/usb_throughput.py` and `host/conformance.py`.
+fn ramp_byte(k: u32) -> u8 {
+    (k % 512) as u8
+}
+
+/// What the data tasks should be doing. Broadcast over [`MODE`].
+#[derive(Clone, Copy, PartialEq, Eq)]
+pub enum Mode {
+    Idle = 0,
+    /// Bulk: echo every OUT packet back on IN.
+    Echo = 1,
+    /// Bulk: drain OUT, checking the payload against the ramp.
+    Sink = 2,
+    /// Bulk: send `mode_param` ramp bytes on IN, then return to [`Mode::Idle`].
+    Source = 3,
+    /// Isochronous: drain OUT, checking every packet against the ramp.
+    IsoSink = 4,
+    /// Isochronous: send ramp packets on IN forever.
+    IsoSource = 5,
+}
+
+impl Mode {
+    fn from_u8(v: u8) -> Option<Self> {
+        Some(match v {
+            0 => Mode::Idle,
+            1 => Mode::Echo,
+            2 => Mode::Sink,
+            3 => Mode::Source,
+            4 => Mode::IsoSink,
+            5 => Mode::IsoSource,
+            _ => return None,
+        })
+    }
+}
+
+/// Counters the host reads back with `GET_REPORT`.
+struct ConformanceState {
+    bulk_out_bytes: AtomicU32,
+    bulk_in_bytes: AtomicU32,
+    iso_out_bytes: AtomicU32,
+    iso_out_packets: AtomicU16,
+    iso_in_packets: AtomicU16,
+    int_in_packets: AtomicU16,
+    ramp_mismatches: AtomicU16,
+    zlp_out_count: AtomicU16,
+    /// Kept as `u32` and clamped into the report's single byte: a halted (but
+    /// still enabled) endpoint reports `Disabled` at roughly 1 kHz for as long
+    /// as the host leaves the halt feature set, which would wrap a `u8`.
+    disabled_errors: AtomicU32,
+    overflow_errors: AtomicU32,
+    /// `wValue`-independent parameter of the last `SET_MODE`.
+    mode_param: AtomicU16,
+}
+
+impl ConformanceState {
+    /// Zeroes every counter so a host run's absolute expectations hold even
+    /// when the script is re-run against a firmware that is already up.
+    fn reset(&self) {
+        self.bulk_out_bytes.store(0, Ordering::Relaxed);
+        self.bulk_in_bytes.store(0, Ordering::Relaxed);
+        self.iso_out_bytes.store(0, Ordering::Relaxed);
+        self.iso_out_packets.store(0, Ordering::Relaxed);
+        self.iso_in_packets.store(0, Ordering::Relaxed);
+        self.int_in_packets.store(0, Ordering::Relaxed);
+        self.ramp_mismatches.store(0, Ordering::Relaxed);
+        self.zlp_out_count.store(0, Ordering::Relaxed);
+        self.disabled_errors.store(0, Ordering::Relaxed);
+        self.overflow_errors.store(0, Ordering::Relaxed);
+    }
+}
+
+static STATE: ConformanceState = ConformanceState {
+    bulk_out_bytes: AtomicU32::new(0),
+    bulk_in_bytes: AtomicU32::new(0),
+    iso_out_bytes: AtomicU32::new(0),
+    iso_out_packets: AtomicU16::new(0),
+    iso_in_packets: AtomicU16::new(0),
+    int_in_packets: AtomicU16::new(0),
+    ramp_mismatches: AtomicU16::new(0),
+    zlp_out_count: AtomicU16::new(0),
+    disabled_errors: AtomicU32::new(0),
+    overflow_errors: AtomicU32::new(0),
+    mode_param: AtomicU16::new(0),
+};
+
+/// A [`Watch`] and not a [`Signal`]: `Signal::wait` consumes the value, so with
+/// two consumers only one of them would ever see a given mode change. `N = 2`
+/// is exactly the number of receivers taken below.
+static MODE: Watch<CriticalSectionRawMutex, Mode, 2> = Watch::new();
+/// Requested interrupt-IN payload length. Single consumer.
+static INT_TRIGGER: Signal<CriticalSectionRawMutex, u16> = Signal::new();
+/// The host is done; check the device-side invariants. Single consumer.
+static FINISH: Signal<CriticalSectionRawMutex, ()> = Signal::new();
+
+type ModeRx = Receiver<'static, CriticalSectionRawMutex, Mode, 2>;
+
+fn mode_of(rx: &mut ModeRx) -> Mode {
+    rx.try_get().unwrap_or(Mode::Idle)
+}
+
+// Vendor request numbers. Recipient is always `Interface`, index always 0.
+const SET_MODE: u8 = 0x01;
+const GET_REPORT: u8 = 0x02;
+const ECHO_WRITE: u8 = 0x03;
+const ECHO_READ: u8 = 0x04;
+const TRIGGER_INT: u8 = 0x05;
+const FINISH_REQ: u8 = 0x06;
+const UNSUPPORTED: u8 = 0x07;
+const RESET: u8 = 0x08;
+
+/// Serves the vendor control protocol.
+///
+/// The echo payload lives here rather than in a static: both callbacks take
+/// `&mut self`, so no locking is needed.
+struct ControlHandler {
+    int_mps: u16,
+    echo: [u8; ECHO_MAX],
+    echo_len: usize,
+}
+
+impl ControlHandler {
+    fn new(int_mps: u16) -> Self {
+        Self {
+            int_mps,
+            echo: [0; ECHO_MAX],
+            echo_len: 0,
+        }
+    }
+
+    /// True for the vendor requests this handler owns; everything else must
+    /// fall through to the rest of the stack.
+    fn ours(req: &Request) -> bool {
+        req.request_type == RequestType::Vendor && req.recipient == Recipient::Interface && req.index == 0
+    }
+}
+
+impl Handler for ControlHandler {
+    fn control_out(&mut self, req: Request, data: &[u8]) -> Option<OutResponse> {
+        if !Self::ours(&req) {
+            return None;
+        }
+        Some(match req.request {
+            SET_MODE => {
+                if data.len() != 4 {
+                    OutResponse::Rejected
+                } else if let Some(mode) = Mode::from_u8(data[0]) {
+                    STATE
+                        .mode_param
+                        .store(u16::from_le_bytes([data[2], data[3]]), Ordering::Relaxed);
+                    MODE.sender().send(mode);
+                    OutResponse::Accepted
+                } else {
+                    OutResponse::Rejected
+                }
+            }
+            ECHO_WRITE => {
+                if data.len() > ECHO_MAX {
+                    OutResponse::Rejected
+                } else {
+                    self.echo[..data.len()].copy_from_slice(data);
+                    self.echo_len = data.len();
+                    OutResponse::Accepted
+                }
+            }
+            TRIGGER_INT => {
+                if req.value == 0 || req.value > self.int_mps {
+                    OutResponse::Rejected
+                } else {
+                    INT_TRIGGER.signal(req.value);
+                    OutResponse::Accepted
+                }
+            }
+            RESET => {
+                STATE.reset();
+                OutResponse::Accepted
+            }
+            FINISH_REQ => {
+                FINISH.signal(());
+                OutResponse::Accepted
+            }
+            UNSUPPORTED => OutResponse::Rejected,
+            _ => OutResponse::Rejected,
+        })
+    }
+
+    fn control_in<'a>(&'a mut self, req: Request, buf: &'a mut [u8]) -> Option<InResponse<'a>> {
+        if !Self::ours(&req) {
+            return None;
+        }
+        Some(match req.request {
+            GET_REPORT => {
+                if buf.len() < REPORT_LEN {
+                    return Some(InResponse::Rejected);
+                }
+                buf[0..4].copy_from_slice(&STATE.bulk_out_bytes.load(Ordering::Relaxed).to_le_bytes());
+                buf[4..8].copy_from_slice(&STATE.bulk_in_bytes.load(Ordering::Relaxed).to_le_bytes());
+                buf[8..12].copy_from_slice(&STATE.iso_out_bytes.load(Ordering::Relaxed).to_le_bytes());
+                buf[12..16].copy_from_slice(&STATE.disabled_errors.load(Ordering::Relaxed).to_le_bytes());
+                buf[16..20].copy_from_slice(&STATE.overflow_errors.load(Ordering::Relaxed).to_le_bytes());
+                buf[20..22].copy_from_slice(&STATE.iso_out_packets.load(Ordering::Relaxed).to_le_bytes());
+                buf[22..24].copy_from_slice(&STATE.iso_in_packets.load(Ordering::Relaxed).to_le_bytes());
+                buf[24..26].copy_from_slice(&STATE.int_in_packets.load(Ordering::Relaxed).to_le_bytes());
+                buf[26..28].copy_from_slice(&STATE.ramp_mismatches.load(Ordering::Relaxed).to_le_bytes());
+                buf[28..30].copy_from_slice(&STATE.zlp_out_count.load(Ordering::Relaxed).to_le_bytes());
+                InResponse::Accepted(&buf[..REPORT_LEN])
+            }
+            ECHO_READ => {
+                let n = self.echo_len;
+                buf[..n].copy_from_slice(&self.echo[..n]);
+                InResponse::Accepted(&buf[..n])
+            }
+            UNSUPPORTED => InResponse::Rejected,
+            _ => InResponse::Rejected,
+        })
+    }
+}
+
+/// Runs the conformance device. Never returns: [`finish_task`] halts the core at
+/// a breakpoint once the host has finished and the device invariants hold.
+pub async fn run<'d, T: Instance>(driver: Driver<'d, T>, params: Params) -> ! {
+    let mut config = embassy_usb::Config::new(0xc0de, params.pid);
+    config.manufacturer = Some("Embassy");
+    config.product = Some(params.product);
+    config.serial_number = Some(params.serial);
+    config.max_power = 100;
+    config.max_packet_size_0 = 64;
+    config.max_speed = params.max_speed;
+
+    let mut config_descriptor = [0u8; 256];
+    let mut bos_descriptor = [0u8; 256];
+    // Must exceed the 200-byte `ECHO_WRITE` payload.
+    let mut control_buf = [0u8; 256];
+    let mut handler = ControlHandler::new(params.int_mps);
+
+    let mut builder = embassy_usb::Builder::new(
+        driver,
+        config,
+        &mut config_descriptor,
+        &mut bos_descriptor,
+        &mut [], // no msos descriptors
+        &mut control_buf,
+    );
+
+    // One vendor-specific function, one interface, two alternate settings. The
+    // vendor class keeps the kernel from binding a driver, so the host script
+    // owns the interface outright.
+    let (bulk_out, bulk_in, int_in, iso_out, iso_in) = {
+        let mut function = builder.function(0xff, 0x00, 0x00);
+        let mut iface = function.interface();
+        let (bulk_out, bulk_in, int_in) = {
+            let mut alt = iface.alt_setting(0xff, 0x00, 0x00, None);
+            let bulk_out = alt.endpoint_bulk_out(None, params.bulk_mps);
+            let bulk_in = alt.endpoint_bulk_in(None, params.bulk_mps);
+            let int_in = alt.endpoint_interrupt_in(None, params.int_mps, 1);
+            (bulk_out, bulk_in, int_in)
+        };
+        let (iso_out, iso_in) = {
+            let mut alt = iface.alt_setting(0xff, 0x00, 0x00, None);
+            let iso_out = alt.endpoint_isochronous_out(
+                None,
+                params.iso_out_mps,
+                1,
+                SynchronizationType::Asynchronous,
+                UsageType::DataEndpoint,
+                &[],
+            );
+            let iso_in = alt.endpoint_isochronous_in(
+                None,
+                params.iso_in_mps,
+                1,
+                SynchronizationType::Asynchronous,
+                UsageType::DataEndpoint,
+                &[],
+            );
+            (iso_out, iso_in)
+        };
+        (bulk_out, bulk_in, int_in, iso_out, iso_in)
+    };
+
+    builder.handler(&mut handler);
+    let mut usb = builder.build();
+
+    // The orchestrator's ready banner: printed before anything blocks.
+    info!("conformance ready");
+
+    let joined = join5(
+        usb.run(),
+        bulk_task(bulk_out, bulk_in),
+        iso_task(iso_out, iso_in, params.iso_in_mps),
+        int_task(int_in),
+        finish_task(),
+    )
+    .await;
+    let _ = joined;
+    // `UsbDevice::run` never returns and `finish_task` halts the core.
+    defmt::unreachable!()
+}
+
+/// Bulk OUT/IN worker.
+///
+/// Every await that can block on the host is wrapped in a `select` against the
+/// mode watch, so a `SET_MODE` always takes effect even when the current mode's
+/// transfer never completes.
+async fn bulk_task<O: EndpointOut, I: EndpointIn>(mut ep_out: O, mut ep_in: I) -> ! {
+    let mut rx = MODE.receiver().unwrap();
+    let mut buf = [0u8; BULK_BUF];
+    // Ramp position for `Sink` and `Source`, reset whenever either is entered.
+    let mut offset: u32 = 0;
+    let mut remaining: u32 = 0;
+    let mut current = Mode::Idle;
+
+    ep_out.wait_enabled().await;
+
+    loop {
+        // Detect the transition here rather than in the `Idle` arm: a mode
+        // change can also arrive while a transfer is pending, in which case the
+        // `select` below just restarts the loop.
+        let mode = mode_of(&mut rx);
+        if mode != current {
+            current = mode;
+            if mode == Mode::Sink || mode == Mode::Source {
+                offset = 0;
+                remaining = STATE.mode_param.load(Ordering::Relaxed) as u32;
+            }
+        }
+        match mode {
+            Mode::Idle | Mode::IsoSink | Mode::IsoSource => {
+                rx.changed().await;
+            }
+            Mode::Echo => {
+                let n = match select(ep_out.read(&mut buf), rx.changed()).await {
+                    Either::First(r) => match bulk_err(r, &mut ep_out).await {
+                        Some(n) => n,
+                        None => continue,
+                    },
+                    Either::Second(_) => continue,
+                };
+                STATE.bulk_out_bytes.fetch_add(n as u32, Ordering::Relaxed);
+                if n == 0 {
+                    STATE.zlp_out_count.fetch_add(1, Ordering::Relaxed);
+                }
+                // `needs_zlp` is what makes an exact-multiple-of-mps echo
+                // terminate; for `n == 0` it is what emits the echoed ZLP.
+                match select(ep_in.write_transfer(&buf[..n], true), rx.changed()).await {
+                    Either::First(Err(e)) => {
+                        count_err(e);
+                        continue;
+                    }
+                    Either::First(Ok(())) => {
+                        STATE.bulk_in_bytes.fetch_add(n as u32, Ordering::Relaxed);
+                    }
+                    Either::Second(_) => continue,
+                }
+            }
+            Mode::Sink => {
+                let n = match select(ep_out.read(&mut buf), rx.changed()).await {
+                    Either::First(r) => match bulk_err(r, &mut ep_out).await {
+                        Some(n) => n,
+                        None => continue,
+                    },
+                    Either::Second(_) => continue,
+                };
+                STATE.bulk_out_bytes.fetch_add(n as u32, Ordering::Relaxed);
+                check_ramp(&buf[..n], offset);
+                offset += n as u32;
+            }
+            Mode::Source => {
+                if remaining == 0 {
+                    // Done: hand the tasks back to `Idle` and let the host
+                    // observe the transition through the counters.
+                    MODE.sender().send(Mode::Idle);
+                    continue;
+                }
+                let chunk = remaining.min(BULK_BUF as u32) as usize;
+                fill_ramp(&mut buf[..chunk], offset);
+                match select(ep_in.write_transfer(&buf[..chunk], false), rx.changed()).await {
+                    Either::First(Err(e)) => {
+                        count_err(e);
+                        continue;
+                    }
+                    Either::First(Ok(())) => {
+                        STATE.bulk_in_bytes.fetch_add(chunk as u32, Ordering::Relaxed);
+                        offset += chunk as u32;
+                        remaining -= chunk as u32;
+                    }
+                    Either::Second(_) => continue,
+                }
+            }
+        }
+    }
+}
+
+/// Isochronous OUT/IN worker. Iso payloads carry no stream offset: every packet
+/// is `ramp_byte(0..len)`, because a dropped packet would otherwise desync every
+/// later content check and isochronous has no retry.
+async fn iso_task<O: EndpointOut, I: EndpointIn>(mut ep_out: O, mut ep_in: I, iso_in_mps: u16) -> ! {
+    let mut rx = MODE.receiver().unwrap();
+    let mut buf = [0u8; ISO_BUF];
+    let mut tx = [0u8; ISO_BUF];
+    fill_ramp(&mut tx, 0);
+    let in_len = iso_in_mps as usize;
+
+    loop {
+        match mode_of(&mut rx) {
+            Mode::IsoSink => {
+                if let Either::Second(_) = select(ep_out.wait_enabled(), rx.changed()).await {
+                    continue;
+                }
+                loop {
+                    match select(ep_out.read(&mut buf), rx.changed()).await {
+                        Either::First(Ok(n)) => {
+                            STATE.iso_out_packets.fetch_add(1, Ordering::Relaxed);
+                            STATE.iso_out_bytes.fetch_add(n as u32, Ordering::Relaxed);
+                            // `Ok(0)` is how the driver reports a dropped or
+                            // errored isochronous packet: a lost frame, not a
+                            // content error.
+                            if n != 0 {
+                                check_ramp(&buf[..n], 0);
+                            }
+                        }
+                        Either::First(Err(e)) => {
+                            count_err(e);
+                            Timer::after_millis(1).await;
+                            break;
+                        }
+                        Either::Second(_) => break,
+                    }
+                }
+            }
+            Mode::IsoSource => {
+                if let Either::Second(_) = select(ep_in.wait_enabled(), rx.changed()).await {
+                    continue;
+                }
+                loop {
+                    match select(ep_in.write(&tx[..in_len]), rx.changed()).await {
+                        Either::First(Ok(())) => {
+                            STATE.iso_in_packets.fetch_add(1, Ordering::Relaxed);
+                        }
+                        Either::First(Err(e)) => {
+                            count_err(e);
+                            Timer::after_millis(1).await;
+                            break;
+                        }
+                        Either::Second(_) => break,
+                    }
+                }
+            }
+            _ => {
+                rx.changed().await;
+            }
+        }
+    }
+}
+
+/// Sends one interrupt-IN packet per `TRIGGER_INT`.
+async fn int_task<I: EndpointIn>(mut ep_in: I) -> ! {
+    let mut tx = [0u8; 64];
+    fill_ramp(&mut tx, 0);
+    loop {
+        let len = INT_TRIGGER.wait().await as usize;
+        ep_in.wait_enabled().await;
+        match ep_in.write(&tx[..len]).await {
+            Ok(()) => {
+                STATE.int_in_packets.fetch_add(1, Ordering::Relaxed);
+            }
+            Err(e) => count_err(e),
+        }
+    }
+}
+
+/// Checks the invariants only the device can see, then halts.
+async fn finish_task() -> ! {
+    FINISH.wait().await;
+    // Let the control status stage finish before the core stops.
+    Timer::after_millis(100).await;
+
+    let ramp_mismatches = STATE.ramp_mismatches.load(Ordering::Relaxed);
+    let overflow_errors = STATE.overflow_errors.load(Ordering::Relaxed);
+    let disabled_errors = STATE.disabled_errors.load(Ordering::Relaxed);
+    let bulk_out_bytes = STATE.bulk_out_bytes.load(Ordering::Relaxed);
+    let bulk_in_bytes = STATE.bulk_in_bytes.load(Ordering::Relaxed);
+    let int_in_packets = STATE.int_in_packets.load(Ordering::Relaxed);
+
+    info!(
+        "report: bulk_out={} bulk_in={} iso_out_bytes={} iso_out_pkts={} iso_in_pkts={} int_in_pkts={} ramp_mismatches={} zlp_out={} disabled_errors={} overflow_errors={}",
+        bulk_out_bytes,
+        bulk_in_bytes,
+        STATE.iso_out_bytes.load(Ordering::Relaxed),
+        STATE.iso_out_packets.load(Ordering::Relaxed),
+        STATE.iso_in_packets.load(Ordering::Relaxed),
+        int_in_packets,
+        ramp_mismatches,
+        STATE.zlp_out_count.load(Ordering::Relaxed),
+        disabled_errors,
+        overflow_errors,
+    );
+
+    defmt::assert_eq!(ramp_mismatches, 0, "payload ramp mismatches");
+    defmt::assert_eq!(overflow_errors, 0, "endpoint buffer overflows");
+    // At least one per halted direction. The host asserts the halt semantics
+    // itself; this only cross-checks that the driver really reported the halt
+    // to the endpoint tasks.
+    defmt::assert!(
+        disabled_errors >= 2,
+        "expected >= 2 Disabled reports from the halt and alt-setting phases, got {}",
+        disabled_errors
+    );
+    defmt::assert!(bulk_out_bytes > 0, "no bulk OUT traffic");
+    defmt::assert!(bulk_in_bytes > 0, "no bulk IN traffic");
+    defmt::assert_eq!(int_in_packets, 4, "expected exactly 4 interrupt IN packets");
+
+    info!("Test OK");
+    cortex_m::asm::bkpt();
+    loop {
+        Timer::after_millis(1000).await;
+    }
+}
+
+/// Maps a bulk read result onto a length, recovering from a disabled or halted
+/// endpoint.
+///
+/// The 1 ms backoff is load-bearing: a *stalled* endpoint is still enabled, so
+/// `wait_enabled` returns immediately and this would otherwise spin hot for as
+/// long as the host leaves the halt feature set.
+async fn bulk_err<O: EndpointOut>(r: Result<usize, EndpointError>, ep_out: &mut O) -> Option<usize> {
+    match r {
+        Ok(n) => Some(n),
+        Err(e) => {
+            count_err(e);
+            Timer::after_millis(1).await;
+            ep_out.wait_enabled().await;
+            None
+        }
+    }
+}
+
+fn count_err(e: EndpointError) {
+    match e {
+        EndpointError::Disabled => STATE.disabled_errors.fetch_add(1, Ordering::Relaxed),
+        EndpointError::BufferOverflow => STATE.overflow_errors.fetch_add(1, Ordering::Relaxed),
+    };
+}
+
+fn fill_ramp(buf: &mut [u8], offset: u32) {
+    for (i, b) in buf.iter_mut().enumerate() {
+        *b = ramp_byte(offset + i as u32);
+    }
+}
+
+fn check_ramp(buf: &[u8], offset: u32) {
+    let mut bad = 0u16;
+    for (i, b) in buf.iter().enumerate() {
+        if *b != ramp_byte(offset + i as u32) {
+            bad += 1;
+        }
+    }
+    if bad != 0 {
+        STATE.ramp_mismatches.fetch_add(bad, Ordering::Relaxed);
+    }
+}

--- a/tests/lpc55/src/conformance.rs
+++ b/tests/lpc55/src/conformance.rs
@@ -106,9 +106,8 @@ struct ConformanceState {
     int_in_packets: AtomicU16,
     ramp_mismatches: AtomicU16,
     zlp_out_count: AtomicU16,
-    /// Kept as `u32` and clamped into the report's single byte: a halted (but
-    /// still enabled) endpoint reports `Disabled` at roughly 1 kHz for as long
-    /// as the host leaves the halt feature set, which would wrap a `u8`.
+    /// A halted endpoint can report `Disabled` at roughly 1 kHz. Saturation
+    /// prevents a long-running firmware session from wrapping this counter.
     disabled_errors: AtomicU32,
     overflow_errors: AtomicU32,
     /// `wValue`-independent parameter of the last `SET_MODE`.
@@ -145,6 +144,18 @@ static STATE: ConformanceState = ConformanceState {
     overflow_errors: AtomicU32::new(0),
     mode_param: AtomicU16::new(0),
 };
+
+fn saturating_add_u16(counter: &AtomicU16, value: u16) {
+    let _ = counter.fetch_update(Ordering::Relaxed, Ordering::Relaxed, |current| {
+        Some(current.saturating_add(value))
+    });
+}
+
+fn saturating_add_u32(counter: &AtomicU32, value: u32) {
+    let _ = counter.fetch_update(Ordering::Relaxed, Ordering::Relaxed, |current| {
+        Some(current.saturating_add(value))
+    });
+}
 
 /// A [`Watch`] and not a [`Signal`]: `Signal::wait` consumes the value, so with
 /// two consumers only one of them would ever see a given mode change. `N = 2`
@@ -235,6 +246,8 @@ impl Handler for ControlHandler {
             }
             RESET => {
                 STATE.reset();
+                STATE.mode_param.store(0, Ordering::Relaxed);
+                MODE.sender().send(Mode::Idle);
                 OutResponse::Accepted
             }
             FINISH_REQ => {
@@ -398,9 +411,9 @@ async fn bulk_task<O: EndpointOut, I: EndpointIn>(mut ep_out: O, mut ep_in: I) -
                     },
                     Either::Second(_) => continue,
                 };
-                STATE.bulk_out_bytes.fetch_add(n as u32, Ordering::Relaxed);
+                saturating_add_u32(&STATE.bulk_out_bytes, n as u32);
                 if n == 0 {
-                    STATE.zlp_out_count.fetch_add(1, Ordering::Relaxed);
+                    saturating_add_u16(&STATE.zlp_out_count, 1);
                 }
                 // `needs_zlp` is what makes an exact-multiple-of-mps echo
                 // terminate; for `n == 0` it is what emits the echoed ZLP.
@@ -410,7 +423,7 @@ async fn bulk_task<O: EndpointOut, I: EndpointIn>(mut ep_out: O, mut ep_in: I) -
                         continue;
                     }
                     Either::First(Ok(())) => {
-                        STATE.bulk_in_bytes.fetch_add(n as u32, Ordering::Relaxed);
+                        saturating_add_u32(&STATE.bulk_in_bytes, n as u32);
                     }
                     Either::Second(_) => continue,
                 }
@@ -423,7 +436,7 @@ async fn bulk_task<O: EndpointOut, I: EndpointIn>(mut ep_out: O, mut ep_in: I) -
                     },
                     Either::Second(_) => continue,
                 };
-                STATE.bulk_out_bytes.fetch_add(n as u32, Ordering::Relaxed);
+                saturating_add_u32(&STATE.bulk_out_bytes, n as u32);
                 check_ramp(&buf[..n], offset);
                 offset += n as u32;
             }
@@ -442,7 +455,7 @@ async fn bulk_task<O: EndpointOut, I: EndpointIn>(mut ep_out: O, mut ep_in: I) -
                         continue;
                     }
                     Either::First(Ok(())) => {
-                        STATE.bulk_in_bytes.fetch_add(chunk as u32, Ordering::Relaxed);
+                        saturating_add_u32(&STATE.bulk_in_bytes, chunk as u32);
                         offset += chunk as u32;
                         remaining -= chunk as u32;
                     }
@@ -472,8 +485,8 @@ async fn iso_task<O: EndpointOut, I: EndpointIn>(mut ep_out: O, mut ep_in: I, is
                 loop {
                     match select(ep_out.read(&mut buf), rx.changed()).await {
                         Either::First(Ok(n)) => {
-                            STATE.iso_out_packets.fetch_add(1, Ordering::Relaxed);
-                            STATE.iso_out_bytes.fetch_add(n as u32, Ordering::Relaxed);
+                            saturating_add_u16(&STATE.iso_out_packets, 1);
+                            saturating_add_u32(&STATE.iso_out_bytes, n as u32);
                             // `Ok(0)` is how the driver reports a dropped or
                             // errored isochronous packet: a lost frame, not a
                             // content error.
@@ -497,7 +510,7 @@ async fn iso_task<O: EndpointOut, I: EndpointIn>(mut ep_out: O, mut ep_in: I, is
                 loop {
                     match select(ep_in.write(&tx[..in_len]), rx.changed()).await {
                         Either::First(Ok(())) => {
-                            STATE.iso_in_packets.fetch_add(1, Ordering::Relaxed);
+                            saturating_add_u16(&STATE.iso_in_packets, 1);
                         }
                         Either::First(Err(e)) => {
                             count_err(e);
@@ -524,7 +537,7 @@ async fn int_task<I: EndpointIn>(mut ep_in: I) -> ! {
         ep_in.wait_enabled().await;
         match ep_in.write(&tx[..len]).await {
             Ok(()) => {
-                STATE.int_in_packets.fetch_add(1, Ordering::Relaxed);
+                saturating_add_u16(&STATE.int_in_packets, 1);
             }
             Err(e) => count_err(e),
         }
@@ -599,8 +612,8 @@ async fn bulk_err<O: EndpointOut>(r: Result<usize, EndpointError>, ep_out: &mut 
 
 fn count_err(e: EndpointError) {
     match e {
-        EndpointError::Disabled => STATE.disabled_errors.fetch_add(1, Ordering::Relaxed),
-        EndpointError::BufferOverflow => STATE.overflow_errors.fetch_add(1, Ordering::Relaxed),
+        EndpointError::Disabled => saturating_add_u32(&STATE.disabled_errors, 1),
+        EndpointError::BufferOverflow => saturating_add_u32(&STATE.overflow_errors, 1),
     };
 }
 
@@ -618,6 +631,6 @@ fn check_ramp(buf: &[u8], offset: u32) {
         }
     }
     if bad != 0 {
-        STATE.ramp_mismatches.fetch_add(bad, Ordering::Relaxed);
+        saturating_add_u16(&STATE.ramp_mismatches, bad);
     }
 }

--- a/tests/lpc55/src/conformance.rs
+++ b/tests/lpc55/src/conformance.rs
@@ -96,66 +96,81 @@ impl Mode {
     }
 }
 
-/// Counters the host reads back with `GET_REPORT`.
+/// 32-bit counters in `GET_REPORT` wire order.
+#[derive(Clone, Copy)]
+#[repr(usize)]
+enum Counter32 {
+    BulkOutBytes,
+    BulkInBytes,
+    IsoOutBytes,
+    DisabledErrors,
+    OverflowErrors,
+}
+
+/// 16-bit counters in `GET_REPORT` wire order.
+#[derive(Clone, Copy)]
+#[repr(usize)]
+enum Counter16 {
+    IsoOutPackets,
+    IsoInPackets,
+    IntInPackets,
+    RampMismatches,
+    ZlpOutCount,
+}
+
 struct ConformanceState {
-    bulk_out_bytes: AtomicU32,
-    bulk_in_bytes: AtomicU32,
-    iso_out_bytes: AtomicU32,
-    iso_out_packets: AtomicU16,
-    iso_in_packets: AtomicU16,
-    int_in_packets: AtomicU16,
-    ramp_mismatches: AtomicU16,
-    zlp_out_count: AtomicU16,
-    /// A halted endpoint can report `Disabled` at roughly 1 kHz. Saturation
-    /// prevents a long-running firmware session from wrapping this counter.
-    disabled_errors: AtomicU32,
-    overflow_errors: AtomicU32,
+    counters32: [AtomicU32; 5],
+    counters16: [AtomicU16; 5],
     /// `wValue`-independent parameter of the last `SET_MODE`.
     mode_param: AtomicU16,
 }
 
 impl ConformanceState {
-    /// Zeroes every counter so a host run's absolute expectations hold even
-    /// when the script is re-run against a firmware that is already up.
     fn reset(&self) {
-        self.bulk_out_bytes.store(0, Ordering::Relaxed);
-        self.bulk_in_bytes.store(0, Ordering::Relaxed);
-        self.iso_out_bytes.store(0, Ordering::Relaxed);
-        self.iso_out_packets.store(0, Ordering::Relaxed);
-        self.iso_in_packets.store(0, Ordering::Relaxed);
-        self.int_in_packets.store(0, Ordering::Relaxed);
-        self.ramp_mismatches.store(0, Ordering::Relaxed);
-        self.zlp_out_count.store(0, Ordering::Relaxed);
-        self.disabled_errors.store(0, Ordering::Relaxed);
-        self.overflow_errors.store(0, Ordering::Relaxed);
+        for counter in &self.counters32 {
+            counter.store(0, Ordering::Relaxed);
+        }
+        for counter in &self.counters16 {
+            counter.store(0, Ordering::Relaxed);
+        }
+    }
+
+    fn serialize(&self, buf: &mut [u8]) {
+        let (words, halfwords) = buf[..REPORT_LEN].split_at_mut(20);
+        for (dst, counter) in words.chunks_exact_mut(4).zip(&self.counters32) {
+            dst.copy_from_slice(&counter.load(Ordering::Relaxed).to_le_bytes());
+        }
+        for (dst, counter) in halfwords.chunks_exact_mut(2).zip(&self.counters16) {
+            dst.copy_from_slice(&counter.load(Ordering::Relaxed).to_le_bytes());
+        }
+    }
+
+    fn load32(&self, counter: Counter32) -> u32 {
+        self.counters32[counter as usize].load(Ordering::Relaxed)
+    }
+
+    fn load16(&self, counter: Counter16) -> u16 {
+        self.counters16[counter as usize].load(Ordering::Relaxed)
+    }
+
+    fn add32(&self, counter: Counter32, value: u32) {
+        let _ = self.counters32[counter as usize].fetch_update(Ordering::Relaxed, Ordering::Relaxed, |current| {
+            Some(current.saturating_add(value))
+        });
+    }
+
+    fn add16(&self, counter: Counter16, value: u16) {
+        let _ = self.counters16[counter as usize].fetch_update(Ordering::Relaxed, Ordering::Relaxed, |current| {
+            Some(current.saturating_add(value))
+        });
     }
 }
 
 static STATE: ConformanceState = ConformanceState {
-    bulk_out_bytes: AtomicU32::new(0),
-    bulk_in_bytes: AtomicU32::new(0),
-    iso_out_bytes: AtomicU32::new(0),
-    iso_out_packets: AtomicU16::new(0),
-    iso_in_packets: AtomicU16::new(0),
-    int_in_packets: AtomicU16::new(0),
-    ramp_mismatches: AtomicU16::new(0),
-    zlp_out_count: AtomicU16::new(0),
-    disabled_errors: AtomicU32::new(0),
-    overflow_errors: AtomicU32::new(0),
+    counters32: [const { AtomicU32::new(0) }; 5],
+    counters16: [const { AtomicU16::new(0) }; 5],
     mode_param: AtomicU16::new(0),
 };
-
-fn saturating_add_u16(counter: &AtomicU16, value: u16) {
-    let _ = counter.fetch_update(Ordering::Relaxed, Ordering::Relaxed, |current| {
-        Some(current.saturating_add(value))
-    });
-}
-
-fn saturating_add_u32(counter: &AtomicU32, value: u32) {
-    let _ = counter.fetch_update(Ordering::Relaxed, Ordering::Relaxed, |current| {
-        Some(current.saturating_add(value))
-    });
-}
 
 /// A [`Watch`] and not a [`Signal`]: `Signal::wait` consumes the value, so with
 /// two consumers only one of them would ever see a given mode change. `N = 2`
@@ -268,16 +283,7 @@ impl Handler for ControlHandler {
                 if buf.len() < REPORT_LEN {
                     return Some(InResponse::Rejected);
                 }
-                buf[0..4].copy_from_slice(&STATE.bulk_out_bytes.load(Ordering::Relaxed).to_le_bytes());
-                buf[4..8].copy_from_slice(&STATE.bulk_in_bytes.load(Ordering::Relaxed).to_le_bytes());
-                buf[8..12].copy_from_slice(&STATE.iso_out_bytes.load(Ordering::Relaxed).to_le_bytes());
-                buf[12..16].copy_from_slice(&STATE.disabled_errors.load(Ordering::Relaxed).to_le_bytes());
-                buf[16..20].copy_from_slice(&STATE.overflow_errors.load(Ordering::Relaxed).to_le_bytes());
-                buf[20..22].copy_from_slice(&STATE.iso_out_packets.load(Ordering::Relaxed).to_le_bytes());
-                buf[22..24].copy_from_slice(&STATE.iso_in_packets.load(Ordering::Relaxed).to_le_bytes());
-                buf[24..26].copy_from_slice(&STATE.int_in_packets.load(Ordering::Relaxed).to_le_bytes());
-                buf[26..28].copy_from_slice(&STATE.ramp_mismatches.load(Ordering::Relaxed).to_le_bytes());
-                buf[28..30].copy_from_slice(&STATE.zlp_out_count.load(Ordering::Relaxed).to_le_bytes());
+                STATE.serialize(buf);
                 InResponse::Accepted(&buf[..REPORT_LEN])
             }
             ECHO_READ => {
@@ -411,9 +417,9 @@ async fn bulk_task<O: EndpointOut, I: EndpointIn>(mut ep_out: O, mut ep_in: I) -
                     },
                     Either::Second(_) => continue,
                 };
-                saturating_add_u32(&STATE.bulk_out_bytes, n as u32);
+                STATE.add32(Counter32::BulkOutBytes, n as u32);
                 if n == 0 {
-                    saturating_add_u16(&STATE.zlp_out_count, 1);
+                    STATE.add16(Counter16::ZlpOutCount, 1);
                 }
                 // `needs_zlp` is what makes an exact-multiple-of-mps echo
                 // terminate; for `n == 0` it is what emits the echoed ZLP.
@@ -423,7 +429,7 @@ async fn bulk_task<O: EndpointOut, I: EndpointIn>(mut ep_out: O, mut ep_in: I) -
                         continue;
                     }
                     Either::First(Ok(())) => {
-                        saturating_add_u32(&STATE.bulk_in_bytes, n as u32);
+                        STATE.add32(Counter32::BulkInBytes, n as u32);
                     }
                     Either::Second(_) => continue,
                 }
@@ -436,7 +442,7 @@ async fn bulk_task<O: EndpointOut, I: EndpointIn>(mut ep_out: O, mut ep_in: I) -
                     },
                     Either::Second(_) => continue,
                 };
-                saturating_add_u32(&STATE.bulk_out_bytes, n as u32);
+                STATE.add32(Counter32::BulkOutBytes, n as u32);
                 check_ramp(&buf[..n], offset);
                 offset += n as u32;
             }
@@ -455,7 +461,7 @@ async fn bulk_task<O: EndpointOut, I: EndpointIn>(mut ep_out: O, mut ep_in: I) -
                         continue;
                     }
                     Either::First(Ok(())) => {
-                        saturating_add_u32(&STATE.bulk_in_bytes, chunk as u32);
+                        STATE.add32(Counter32::BulkInBytes, chunk as u32);
                         offset += chunk as u32;
                         remaining -= chunk as u32;
                     }
@@ -485,8 +491,8 @@ async fn iso_task<O: EndpointOut, I: EndpointIn>(mut ep_out: O, mut ep_in: I, is
                 loop {
                     match select(ep_out.read(&mut buf), rx.changed()).await {
                         Either::First(Ok(n)) => {
-                            saturating_add_u16(&STATE.iso_out_packets, 1);
-                            saturating_add_u32(&STATE.iso_out_bytes, n as u32);
+                            STATE.add16(Counter16::IsoOutPackets, 1);
+                            STATE.add32(Counter32::IsoOutBytes, n as u32);
                             // `Ok(0)` is how the driver reports a dropped or
                             // errored isochronous packet: a lost frame, not a
                             // content error.
@@ -510,7 +516,7 @@ async fn iso_task<O: EndpointOut, I: EndpointIn>(mut ep_out: O, mut ep_in: I, is
                 loop {
                     match select(ep_in.write(&tx[..in_len]), rx.changed()).await {
                         Either::First(Ok(())) => {
-                            saturating_add_u16(&STATE.iso_in_packets, 1);
+                            STATE.add16(Counter16::IsoInPackets, 1);
                         }
                         Either::First(Err(e)) => {
                             count_err(e);
@@ -537,7 +543,7 @@ async fn int_task<I: EndpointIn>(mut ep_in: I) -> ! {
         ep_in.wait_enabled().await;
         match ep_in.write(&tx[..len]).await {
             Ok(()) => {
-                saturating_add_u16(&STATE.int_in_packets, 1);
+                STATE.add16(Counter16::IntInPackets, 1);
             }
             Err(e) => count_err(e),
         }
@@ -550,23 +556,23 @@ async fn finish_task() -> ! {
     // Let the control status stage finish before the core stops.
     Timer::after_millis(100).await;
 
-    let ramp_mismatches = STATE.ramp_mismatches.load(Ordering::Relaxed);
-    let overflow_errors = STATE.overflow_errors.load(Ordering::Relaxed);
-    let disabled_errors = STATE.disabled_errors.load(Ordering::Relaxed);
-    let bulk_out_bytes = STATE.bulk_out_bytes.load(Ordering::Relaxed);
-    let bulk_in_bytes = STATE.bulk_in_bytes.load(Ordering::Relaxed);
-    let int_in_packets = STATE.int_in_packets.load(Ordering::Relaxed);
+    let ramp_mismatches = STATE.load16(Counter16::RampMismatches);
+    let overflow_errors = STATE.load32(Counter32::OverflowErrors);
+    let disabled_errors = STATE.load32(Counter32::DisabledErrors);
+    let bulk_out_bytes = STATE.load32(Counter32::BulkOutBytes);
+    let bulk_in_bytes = STATE.load32(Counter32::BulkInBytes);
+    let int_in_packets = STATE.load16(Counter16::IntInPackets);
 
     info!(
         "report: bulk_out={} bulk_in={} iso_out_bytes={} iso_out_pkts={} iso_in_pkts={} int_in_pkts={} ramp_mismatches={} zlp_out={} disabled_errors={} overflow_errors={}",
         bulk_out_bytes,
         bulk_in_bytes,
-        STATE.iso_out_bytes.load(Ordering::Relaxed),
-        STATE.iso_out_packets.load(Ordering::Relaxed),
-        STATE.iso_in_packets.load(Ordering::Relaxed),
+        STATE.load32(Counter32::IsoOutBytes),
+        STATE.load16(Counter16::IsoOutPackets),
+        STATE.load16(Counter16::IsoInPackets),
         int_in_packets,
         ramp_mismatches,
-        STATE.zlp_out_count.load(Ordering::Relaxed),
+        STATE.load16(Counter16::ZlpOutCount),
         disabled_errors,
         overflow_errors,
     );
@@ -612,8 +618,8 @@ async fn bulk_err<O: EndpointOut>(r: Result<usize, EndpointError>, ep_out: &mut 
 
 fn count_err(e: EndpointError) {
     match e {
-        EndpointError::Disabled => saturating_add_u32(&STATE.disabled_errors, 1),
-        EndpointError::BufferOverflow => saturating_add_u32(&STATE.overflow_errors, 1),
+        EndpointError::Disabled => STATE.add32(Counter32::DisabledErrors, 1),
+        EndpointError::BufferOverflow => STATE.add32(Counter32::OverflowErrors, 1),
     };
 }
 
@@ -631,6 +637,6 @@ fn check_ramp(buf: &[u8], offset: u32) {
         }
     }
     if bad != 0 {
-        saturating_add_u16(&STATE.ramp_mismatches, bad);
+        STATE.add16(Counter16::RampMismatches, bad);
     }
 }

--- a/tests/lpc55/src/conformance.rs
+++ b/tests/lpc55/src/conformance.rs
@@ -26,6 +26,7 @@ use embassy_time::Timer;
 use embassy_usb::control::{InResponse, OutResponse, Recipient, Request, RequestType};
 use embassy_usb::descriptor::{SynchronizationType, UsageType};
 use embassy_usb::driver::{EndpointError, EndpointIn, EndpointOut};
+use embassy_usb::msos::{self, windows_version};
 use embassy_usb::{Handler, UsbDeviceSpeed};
 
 /// Per-controller parameters. Everything else about the device is identical
@@ -49,6 +50,16 @@ const BULK_BUF: usize = 3584;
 const ISO_BUF: usize = 1024;
 /// Largest control-OUT payload `ECHO_WRITE` accepts.
 const ECHO_MAX: usize = 200;
+
+/// Windows binds no driver to a vendor-class interface on its own, so `libusb`
+/// cannot open the device and `host/conformance.py` has nothing to talk to.
+/// These MS OS 2.0 descriptors make Windows load WinUSB by itself, which needs
+/// no driver install and no elevation. Linux ignores them.
+const DEVICE_INTERFACE_GUIDS: &[&str] = &["{6E4D2F2A-9C31-4B7E-9A2C-1F0B5E7A3D41}"];
+/// `bMS_VendorCode`, the request Windows uses to fetch the descriptor set above.
+/// Its recipient is the device, so [`ControlHandler::ours`] never claims it.
+const MSOS_VENDOR_CODE: u8 = 0x20;
+
 /// Size of the `GET_REPORT` payload. Layout, little-endian:
 ///
 /// ```text
@@ -310,6 +321,7 @@ pub async fn run<'d, T: Instance>(driver: Driver<'d, T>, params: Params) -> ! {
 
     let mut config_descriptor = [0u8; 256];
     let mut bos_descriptor = [0u8; 256];
+    let mut msos_descriptor = [0u8; 256];
     // Must exceed the 200-byte `ECHO_WRITE` payload.
     let mut control_buf = [0u8; 256];
     let mut handler = ControlHandler::new(params.int_mps);
@@ -319,9 +331,18 @@ pub async fn run<'d, T: Instance>(driver: Driver<'d, T>, params: Params) -> ! {
         config,
         &mut config_descriptor,
         &mut bos_descriptor,
-        &mut [], // no msos descriptors
+        &mut msos_descriptor,
         &mut control_buf,
     );
+
+    // Device-level, so Windows binds WinUSB to the whole device: there is only
+    // one function. Must precede `builder.function`, which starts a subset.
+    builder.msos_descriptor(windows_version::WIN8_1, MSOS_VENDOR_CODE);
+    builder.msos_feature(msos::CompatibleIdFeatureDescriptor::new("WINUSB", ""));
+    builder.msos_feature(msos::RegistryPropertyFeatureDescriptor::new(
+        "DeviceInterfaceGUIDs",
+        msos::PropertyData::RegMultiSz(DEVICE_INTERFACE_GUIDS),
+    ));
 
     // One vendor-specific function, one interface, two alternate settings. The
     // vendor class keeps the kernel from binding a driver, so the host script

--- a/tests/lpc55/src/enumerate.rs
+++ b/tests/lpc55/src/enumerate.rs
@@ -1,0 +1,90 @@
+use core::sync::atomic::{AtomicBool, Ordering};
+
+use embassy_futures::select::{Either, select};
+use embassy_time::Timer;
+use embassy_usb::class::cdc_acm::{CdcAcmClass, State};
+use embassy_usb::driver::Driver;
+use embassy_usb::{Handler, UsbDeviceSpeed};
+
+pub struct Params {
+    pub product: &'static str,
+    pub max_speed: UsbDeviceSpeed,
+}
+
+pub struct Resources<'d> {
+    config_descriptor: [u8; 256],
+    bos_descriptor: [u8; 256],
+    control_buf: [u8; 64],
+    state: State<'d>,
+    handler: ConfiguredHandler,
+}
+
+impl<'d> Resources<'d> {
+    pub const fn new(configured: &'static AtomicBool) -> Self {
+        Self {
+            config_descriptor: [0; 256],
+            bos_descriptor: [0; 256],
+            control_buf: [0; 64],
+            state: State::new(),
+            handler: ConfiguredHandler(configured),
+        }
+    }
+}
+
+struct ConfiguredHandler(&'static AtomicBool);
+
+impl Handler for ConfiguredHandler {
+    fn configured(&mut self, configured: bool) {
+        if configured {
+            self.0.store(true, Ordering::Relaxed);
+        }
+    }
+}
+
+pub async fn run<'d, D: Driver<'d>, F: FnOnce(), const MPS: usize>(
+    driver: D,
+    resources: &'d mut Resources<'d>,
+    params: Params,
+    validate: F,
+) {
+    let mut config = embassy_usb::Config::new(0xc0de, 0xcafe);
+    config.manufacturer = Some("Embassy");
+    config.product = Some(params.product);
+    config.serial_number = Some("12345678");
+    config.max_power = 100;
+    config.max_packet_size_0 = 64;
+    config.max_speed = params.max_speed;
+
+    let configured = resources.handler.0;
+    let mut builder = embassy_usb::Builder::new(
+        driver,
+        config,
+        &mut resources.config_descriptor,
+        &mut resources.bos_descriptor,
+        &mut [],
+        &mut resources.control_buf,
+    );
+    let _class = CdcAcmClass::new(&mut builder, &mut resources.state, MPS as u16);
+    builder.handler(&mut resources.handler);
+    let mut usb = builder.build();
+
+    match select(usb.run(), wait_configured(configured)).await {
+        Either::First(never) => never,
+        Either::Second(true) => {
+            validate();
+            defmt::info!("Test OK");
+            cortex_m::asm::bkpt();
+        }
+        Either::Second(false) => defmt::panic!("not configured within 10 s"),
+    }
+}
+
+async fn wait_configured(configured: &AtomicBool) -> bool {
+    for _ in 0..100 {
+        if configured.load(Ordering::Relaxed) {
+            return true;
+        }
+        Timer::after_millis(100).await;
+    }
+    false
+}

--- a/tests/lpc55/src/lib.rs
+++ b/tests/lpc55/src/lib.rs
@@ -1,0 +1,9 @@
+//! Shared firmware support for the LPC55 USB HIL tests.
+//!
+//! The crate keeps its `src/bin/*.rs` targets; this library only holds code two
+//! or more of them share. It deliberately does not link `defmt-rtt` or
+//! `panic-probe` — every binary already does.
+
+#![no_std]
+
+pub mod conformance;

--- a/tests/lpc55/src/lib.rs
+++ b/tests/lpc55/src/lib.rs
@@ -7,3 +7,4 @@
 #![no_std]
 
 pub mod conformance;
+pub mod enumerate;


### PR DESCRIPTION
Adds a USB device driver for both LPC55 ip3511 controllers, USB0 (full speed) and USBHSD (high speed), as one implementation generic over an `Instance` trait. Both can run at once. Also adds the main clock configuration the HS block needs (`config::MainClock`).

The caller chooses endpoint memory: `Memory::usb1_sram()` for the dedicated 16 KiB USB1 SRAM, or `Memory::buffer()` for a caller-owned region in main SRAM.

Control, bulk, interrupt, and isochronous endpoints. Non-control endpoints use double buffering, and the driver copies USB SRAM word-at-a-time. Measured on an LPCXpresso55S69, CDC-ACM, release build:

| Controller  | Host transport  | IN (device to host) | OUT (host to device) |
|:------------|:----------------|--------------------:|---------------------:|
| USB0 (FS)   | Linux `cdc_acm` |           0.90 MB/s |            0.82 MB/s |
| USB0 (FS)   | Windows libusb  |           0.89 MB/s |            0.83 MB/s |
| USBHSD (HS) | Linux `cdc_acm` |           44.5 MB/s |            17.5 MB/s |
| USBHSD (HS) | Windows libusb  |           44.9 MB/s |            19.0 MB/s |

Examples: `usb_fs_serial`, `usb_hs_serial`, `usb_dual` (both ports at once), plus a throughput bench per controller.

HIL tests run with `python3 tests/lpc55/run.py`: nine tests, about 2 min on an LPCXpresso55S69 EVK. They cover allocation limits, enumeration and speed, the raw `Bus` methods, a ten-phase conformance run per controller, dual-controller operation, and throughput gates. Details in `tests/lpc55/README.md`. This suite found three driver bugs, fixed here.

I checked VBUS attach and detach by hand on Linux, because no firmware can remove its own VBUS. Suspend, resume, and remote wakeup stay untested: they need the host to suspend the bus on demand. `tests/lpc55/README.md` lists every gap.

`Cargo.toml` pins `embassy-rs/nxp-pac` at `c54814bb`, the tip of nxp-pac main, which carries the USB0 metadata added in embassy-rs/nxp-pac#113.

Closes #6558
