### PR TITLE
stm32: add STM32N6 peripheral driver support

### DIFF
--- a/embassy-stm32/build.rs
+++ b/embassy-stm32/build.rs
@@ -377,9 +377,18 @@ fn main() {
     let time_driver_irq_decl = if !time_driver_singleton.is_empty() {
         cfgs.enable(format!("time_driver_{}", time_driver_singleton.to_lowercase()));
 
-        let Some((p, _)) = peripheral_map.get(time_driver_singleton) else {
+        let Some((p, regs)) = peripheral_map.get(time_driver_singleton) else {
             panic!("Tried to select {time_driver_singleton}, which is not available on this device");
         };
+
+        if regs.kind == "lptim" && regs.version == "n6" {
+            panic!(
+                "{time_driver_singleton} does not support use as a time driver on this chip yet: N6's LPTIM \
+                 register layout (split isr_output/dier_output/icr_output registers) and RCC clock-mux \
+                 selection are not yet implemented for the time driver. Select a TIM-based time driver \
+                 (e.g. time-driver-any) instead."
+            );
+        }
         let irqs: BTreeSet<_> = p
             .interrupts
             .iter()
@@ -1753,10 +1762,6 @@ fn main() {
         let mut adc_pairs: BTreeMap<u8, (Option<Ident>, Option<Ident>)> = BTreeMap::new();
         let mut seen_lcd_seg_pins = HashSet::new();
 
-        if regs.version == "n6" && (regs.kind == "lptim" || regs.kind == "sai") {
-            continue;
-        }
-
         if let Some(peri) = p.name.strip_prefix("SPI")
             && peripheral_map.contains_key(format!("I2S{}", peri).as_str())
         {
@@ -2035,7 +2040,7 @@ fn main() {
                 }
             }
 
-            if regs.kind == "spdifrx" && regs.version != "n6" {
+            if regs.kind == "spdifrx" {
                 let peri = format_ident!("{}", p.name);
                 let pin_name = format_ident!("{}", pin.pin);
                 let af = pin.af.unwrap_or(0);
@@ -2168,10 +2173,6 @@ fn main() {
 
     for (p, regs) in &peripheral_list {
         if regs.kind == "adc" && (regs.version == "f3v3" || regs.version == "wb1") {
-            continue;
-        }
-
-        if regs.version == "n6" && (regs.kind == "lptim" || regs.kind == "sai") {
             continue;
         }
 
@@ -2398,6 +2399,12 @@ fn main() {
             let sname = format_ident!("{}", irq.signal);
             pt.extend(quote!(pub type #sname = crate::interrupt::typelevel::#iname;));
         }
+        if let Some(regs) = &p.registers {
+            if regs.kind == "spdifrx" && p.interrupts.is_empty() {
+                let iname = format_ident!("{}", p.name);
+                pt.extend(quote!(pub type GLOBAL = crate::interrupt::typelevel::#iname;));
+            }
+        }
 
         let pname = format_ident!("{}", p.name);
         mt.extend(quote!(pub mod #pname { #pt }));
@@ -2509,6 +2516,15 @@ fn main() {
                 irq.interrupt.to_ascii_uppercase(),
             ];
             interrupts_table.push(row)
+        }
+        if regs.kind == "spdifrx" && p.interrupts.is_empty() {
+            interrupts_table.push(vec![
+                p.name.to_string(),
+                regs.kind.to_string(),
+                regs.block.to_string(),
+                "GLOBAL".to_string(),
+                p.name.to_string(),
+            ]);
         }
 
         let row = vec![regs.kind.to_string(), p.name.to_string()];

--- a/embassy-stm32/src/adc/mod.rs
+++ b/embassy-stm32/src/adc/mod.rs
@@ -1087,7 +1087,7 @@ pub const fn resolution_to_max_count(res: Resolution) -> u32 {
         Resolution::Bits12 => (1 << 12) - 1,
         Resolution::Bits10 => (1 << 10) - 1,
         Resolution::Bits8 => (1 << 8) - 1,
-        #[cfg(any(adc_v1, adc_v2, adc_v3, adc_l0, adc_c0, adc_g0, adc_f3v1, adc_f3v2, adc_h5))]
+        #[cfg(any(adc_v1, adc_v2, adc_v3, adc_l0, adc_c0, adc_g0, adc_f3v1, adc_f3v2, adc_h5, adc_n6))]
         Resolution::Bits6 => (1 << 6) - 1,
         #[allow(unreachable_patterns)]
         _ => core::unreachable!(),

--- a/embassy-stm32/src/adc/v4.rs
+++ b/embassy-stm32/src/adc/v4.rs
@@ -197,7 +197,7 @@ impl AdcRegs for crate::pac::adc::Adc {
         sqr1.set_l(sequence.len() as u8 - 1);
 
         // Configure channels and ranks
-        for (i, ((channel, is_differential), sample_time)) in sequence.enumerate() {
+        for (i, ((channel, _is_differential), sample_time)) in sequence.enumerate() {
             let sample_time = sample_time.into();
             if channel <= 9 {
                 smpr1.set_smp(channel as _, sample_time);
@@ -209,7 +209,7 @@ impl AdcRegs for crate::pac::adc::Adc {
             {
                 difsel.set_difsel(
                     channel as _,
-                    if is_differential {
+                    if _is_differential {
                         Difsel::Differential
                     } else {
                         Difsel::SingleEnded

--- a/embassy-stm32/src/adc/v4.rs
+++ b/embassy-stm32/src/adc/v4.rs
@@ -8,6 +8,8 @@ use pac::adc::vals::{Adcaldif, Boost};
 use pac::adc::vals::{Adstp, Dmngt, Exten, Pcsel};
 #[cfg(not(any(stm32u3, stm32n6)))]
 use pac::adccommon::vals::Presc;
+#[cfg(stm32n6)]
+pub use pac::adccommon::vals::{Damdf, Dual};
 
 #[cfg(any(stm32u5, stm32u3, stm32n6))]
 use crate::adc::DefaultInstance;
@@ -108,6 +110,15 @@ fn from_ker_ck(frequency: Hertz) -> Presc {
 pub struct AdcConfig {
     pub resolution: Option<Resolution>,
     pub averaging: Option<Averaging>,
+    /// Dual-ADC mode for ADC1/ADC2 via `ADC12_COMMON` (N6 only).
+    #[cfg(stm32n6)]
+    pub dual_mode: Option<Dual>,
+    /// Dual-mode data format in `ADC12_COMMON` (N6 only).
+    #[cfg(stm32n6)]
+    pub damdf: Option<Damdf>,
+    /// Delay between dual-ADC sampling phases (N6 only).
+    #[cfg(stm32n6)]
+    pub dual_delay: Option<u8>,
 }
 
 impl AdcRegs for crate::pac::adc::Adc {
@@ -179,17 +190,31 @@ impl AdcRegs for crate::pac::adc::Adc {
 
         let mut smpr1 = self.smpr(0).read();
         let mut smpr2 = self.smpr(1).read();
+        #[cfg(not(stm32u3))]
+        let mut difsel = self.difsel().read();
 
         // Set sequence length
         sqr1.set_l(sequence.len() as u8 - 1);
 
         // Configure channels and ranks
-        for (i, ((channel, _), sample_time)) in sequence.enumerate() {
+        for (i, ((channel, is_differential), sample_time)) in sequence.enumerate() {
             let sample_time = sample_time.into();
             if channel <= 9 {
                 smpr1.set_smp(channel as _, sample_time);
             } else {
                 smpr2.set_smp((channel - 10) as _, sample_time);
+            }
+
+            #[cfg(not(stm32u3))]
+            {
+                difsel.set_difsel(
+                    channel as _,
+                    if is_differential {
+                        Difsel::Differential
+                    } else {
+                        Difsel::SingleEnded
+                    },
+                );
             }
 
             #[cfg(any(stm32h7, stm32u5, stm32u3, stm32n6))]
@@ -221,6 +246,8 @@ impl AdcRegs for crate::pac::adc::Adc {
         self.sqr4().write_value(sqr4);
         self.smpr(0).write_value(smpr1);
         self.smpr(1).write_value(smpr2);
+        #[cfg(not(stm32u3))]
+        self.difsel().write_value(difsel);
     }
 }
 
@@ -232,6 +259,19 @@ impl<'d, T: Instance<Regs = crate::pac::adc::Adc>> Adc<'d, T> {
         if let Some(resolution) = config.resolution {
             T::regs().cfgr().modify(|reg| reg.set_res(resolution.into()));
         }
+
+        #[cfg(stm32n6)]
+        T::common_regs().ccr().modify(|reg| {
+            if let Some(dual) = config.dual_mode {
+                reg.set_dual(dual);
+            }
+            if let Some(damdf) = config.damdf {
+                reg.set_damdf(damdf);
+            }
+            if let Some(delay) = config.dual_delay {
+                reg.set_delay(delay);
+            }
+        });
 
         // Set hardware averaging.
         if let Some(averaging) = config.averaging {
@@ -413,8 +453,11 @@ impl<'d, T: Instance<Regs = crate::pac::adc::Adc>> Adc<'d, T> {
     }
 
     /// Enable reading the temperature internal channel.
+    ///
+    /// On STM32N6 there is no ADC-connected temperature sensor; use the
+    /// [`crate::dts`] driver instead.
+    #[cfg(not(stm32n6))]
     pub fn enable_temperature(&mut self) -> Temperature {
-        #[cfg(not(stm32n6))]
         T::common_regs().ccr().modify(|reg| {
             reg.set_vsenseen(true);
         });

--- a/embassy-stm32/src/adc/v4.rs
+++ b/embassy-stm32/src/adc/v4.rs
@@ -13,9 +13,9 @@ pub use pac::adccommon::vals::{Damdf, Dual};
 
 #[cfg(any(stm32u5, stm32u3, stm32n6))]
 use crate::adc::DefaultInstance;
-use crate::adc::{
-    Adc, AdcRegs, Averaging, ConversionMode, Instance, Resolution, SampleTime, Temperature, Vbat, VrefInt,
-};
+#[cfg(not(stm32n6))]
+use crate::adc::Temperature;
+use crate::adc::{Adc, AdcRegs, Averaging, ConversionMode, Instance, Resolution, SampleTime, Vbat, VrefInt};
 use crate::pac::adc::regs::{Sqr1, Sqr2, Sqr3, Sqr4};
 use crate::time::Hertz;
 use crate::wait::block_for_us;

--- a/embassy-stm32/src/aes/mod.rs
+++ b/embassy-stm32/src/aes/mod.rs
@@ -148,6 +148,7 @@ use core::task::Poll;
 use embassy_hal_internal::{Peri, PeripheralType};
 use embassy_sync::waitqueue::AtomicWaker;
 
+pub use crate::crypto::{CipherAuthenticated, CipherSized, Direction, Error, IVSized, KeySize};
 use crate::dma::ChannelAndRequest;
 use crate::interrupt::typelevel::Interrupt;
 use crate::mode::{Async, Blocking, Mode};
@@ -178,40 +179,6 @@ impl<T: Instance> interrupt::typelevel::Handler<T::Interrupt> for InterruptHandl
             T::regs().icr().write(|w| w.0 = 0xFFFF_FFFF);
         }
     }
-}
-
-/// AES error
-#[derive(Debug, PartialEq, Eq, Clone, Copy)]
-#[cfg_attr(feature = "defmt", derive(defmt::Format))]
-pub enum Error {
-    /// Invalid key size
-    KeyError,
-    /// Read error - unexpected output read during computation
-    ReadError,
-    /// Write error - unexpected input write during output phase
-    WriteError,
-    /// Invalid configuration
-    ConfigError,
-}
-
-/// AES cipher direction
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-#[cfg_attr(feature = "defmt", derive(defmt::Format))]
-pub enum Direction {
-    /// Encryption mode
-    Encrypt = 0,
-    /// Decryption mode (MODE = 2)
-    Decrypt = 2,
-}
-
-/// AES key size
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-#[cfg_attr(feature = "defmt", derive(defmt::Format))]
-pub enum KeySize {
-    /// 128-bit key
-    Bits128 = 0,
-    /// 256-bit key
-    Bits256 = 1,
 }
 
 /// This trait encapsulates all cipher-specific behavior.
@@ -342,18 +309,6 @@ pub trait Cipher<'c> {
         };
         (header, len)
     }
-}
-
-/// This trait enables restriction of ciphers to specific key sizes.
-pub trait CipherSized {}
-
-/// This trait enables restriction of initialization vectors to sizes compatible with a cipher mode.
-pub trait IVSized {}
-
-/// This trait enables restriction of a header phase to authenticated ciphers only.
-pub trait CipherAuthenticated<const TAG_SIZE: usize> {
-    /// Defines the authentication tag size.
-    const TAG_SIZE: usize = TAG_SIZE;
 }
 
 /// AES-ECB Cipher Mode

--- a/embassy-stm32/src/cacheaxi.rs
+++ b/embassy-stm32/src/cacheaxi.rs
@@ -17,8 +17,11 @@ fn regs() -> pac::cacheaxi::Cacheaxi {
 #[derive(Clone, Copy, PartialEq, Eq, Debug)]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub enum ReadMonitor {
+    /// Count read hits only.
     Hit,
+    /// Count read misses only.
     Miss,
+    /// Count both read hits and misses.
     Both,
 }
 
@@ -36,8 +39,11 @@ impl ReadMonitor {
 #[derive(Clone, Copy, PartialEq, Eq, Debug)]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub enum WriteMonitor {
+    /// Count write hits only.
     Hit,
+    /// Count write misses only.
     Miss,
+    /// Count both write hits and misses.
     Both,
 }
 

--- a/embassy-stm32/src/cacheaxi.rs
+++ b/embassy-stm32/src/cacheaxi.rs
@@ -1,0 +1,207 @@
+//! AXI cache (CACHEAXI)
+//!
+//! CACHEAXI speeds up AXI memory accesses by caching them in on-chip RAM. It has
+//! no independent clock gate on N6, so [`Cacheaxi::new()`] does not call
+//! `rcc::enable_and_reset`.
+
+use embassy_hal_internal::Peri;
+
+use crate::pac;
+use crate::peripherals::CACHEAXI;
+
+fn regs() -> pac::cacheaxi::Cacheaxi {
+    pac::CACHEAXI
+}
+
+/// Read-side performance counter selection.
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+pub enum ReadMonitor {
+    Hit,
+    Miss,
+    Both,
+}
+
+impl ReadMonitor {
+    fn hit(self) -> bool {
+        matches!(self, ReadMonitor::Hit | ReadMonitor::Both)
+    }
+
+    fn miss(self) -> bool {
+        matches!(self, ReadMonitor::Miss | ReadMonitor::Both)
+    }
+}
+
+/// Write-side performance counter selection.
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+pub enum WriteMonitor {
+    Hit,
+    Miss,
+    Both,
+}
+
+impl WriteMonitor {
+    fn hit(self) -> bool {
+        matches!(self, WriteMonitor::Hit | WriteMonitor::Both)
+    }
+
+    fn miss(self) -> bool {
+        matches!(self, WriteMonitor::Miss | WriteMonitor::Both)
+    }
+}
+
+/// AXI cache driver.
+pub struct Cacheaxi<'d> {
+    _peri: Peri<'d, CACHEAXI>,
+}
+
+impl<'d> Cacheaxi<'d> {
+    /// Create a new CACHEAXI driver. The cache is left disabled; call [`Self::enable()`] to turn it on.
+    pub fn new(_peri: Peri<'d, CACHEAXI>) -> Self {
+        Self { _peri }
+    }
+
+    /// Enable the cache.
+    pub fn enable(&mut self) {
+        regs().cr1().modify(|w| w.set_en(true));
+    }
+
+    /// Disable the cache and wait until `EN` reads back as cleared.
+    pub fn disable(&mut self) {
+        regs().fcr().write(|w| w.set_cbsyendf(true));
+        regs().cr1().modify(|w| w.set_en(false));
+        while regs().cr1().read().en() {}
+    }
+
+    /// Returns whether the cache is currently enabled.
+    pub fn is_enabled(&self) -> bool {
+        regs().cr1().read().en()
+    }
+
+    /// Invalidate the entire cache, blocking until the operation completes.
+    pub fn invalidate(&mut self) {
+        if !regs().sr().read().busyf() {
+            regs().cr1().modify(|w| w.set_cacheinv(true));
+        }
+        while regs().sr().read().busyf() {}
+        regs().fcr().write(|w| w.set_cbsyendf(true));
+    }
+
+    /// Start the given read-side performance counter(s).
+    pub fn start_read_monitors(&mut self, monitor: ReadMonitor) {
+        regs().cr1().modify(|w| {
+            if monitor.hit() {
+                w.set_rhitmen(true);
+            }
+            if monitor.miss() {
+                w.set_rmissmen(true);
+            }
+        });
+    }
+
+    /// Stop the given read-side performance counter(s).
+    pub fn stop_read_monitors(&mut self, monitor: ReadMonitor) {
+        regs().cr1().modify(|w| {
+            if monitor.hit() {
+                w.set_rhitmen(false);
+            }
+            if monitor.miss() {
+                w.set_rmissmen(false);
+            }
+        });
+    }
+
+    /// Reset the given read-side performance counter(s) to zero.
+    pub fn reset_read_monitors(&mut self, monitor: ReadMonitor) {
+        regs().cr1().modify(|w| {
+            if monitor.hit() {
+                w.set_rhitmrst(true);
+            }
+            if monitor.miss() {
+                w.set_rmissmrst(true);
+            }
+        });
+        regs().cr1().modify(|w| {
+            if monitor.hit() {
+                w.set_rhitmrst(false);
+            }
+            if monitor.miss() {
+                w.set_rmissmrst(false);
+            }
+        });
+    }
+
+    /// Start the given write-side performance counter(s).
+    pub fn start_write_monitors(&mut self, monitor: WriteMonitor) {
+        regs().cr1().modify(|w| {
+            if monitor.hit() {
+                w.set_whitmen(true);
+            }
+            if monitor.miss() {
+                w.set_wmissmen(true);
+            }
+        });
+    }
+
+    /// Stop the given write-side performance counter(s).
+    pub fn stop_write_monitors(&mut self, monitor: WriteMonitor) {
+        regs().cr1().modify(|w| {
+            if monitor.hit() {
+                w.set_whitmen(false);
+            }
+            if monitor.miss() {
+                w.set_wmissmen(false);
+            }
+        });
+    }
+
+    /// Reset the given write-side performance counter(s) to zero.
+    pub fn reset_write_monitors(&mut self, monitor: WriteMonitor) {
+        regs().cr1().modify(|w| {
+            if monitor.hit() {
+                w.set_whitmrst(true);
+            }
+            if monitor.miss() {
+                w.set_wmissmrst(true);
+            }
+        });
+        regs().cr1().modify(|w| {
+            if monitor.hit() {
+                w.set_whitmrst(false);
+            }
+            if monitor.miss() {
+                w.set_wmissmrst(false);
+            }
+        });
+    }
+
+    /// Current read-hit count.
+    pub fn read_hit_count(&self) -> u32 {
+        regs().rhmonr().read().rhitmon()
+    }
+
+    /// Current read-miss count.
+    pub fn read_miss_count(&self) -> u32 {
+        regs().rmmonr().read().rmissmon()
+    }
+
+    /// Current write-hit count.
+    pub fn write_hit_count(&self) -> u32 {
+        regs().whmonr().read().whitmon()
+    }
+
+    /// Current write-miss count.
+    pub fn write_miss_count(&self) -> u32 {
+        regs().wmmonr().read().wmissmon()
+    }
+
+    /// Returns `true` and clears the flag if a cache error has occurred since the last call.
+    pub fn take_error(&mut self) -> bool {
+        let err = regs().sr().read().errf();
+        if err {
+            regs().fcr().write(|w| w.set_cerrf(true));
+        }
+        err
+    }
+}

--- a/embassy-stm32/src/crypto.rs
+++ b/embassy-stm32/src/crypto.rs
@@ -34,61 +34,6 @@ pub enum KeySize {
     Bits256 = 1,
 }
 
-const AES_BLOCK_SIZE: usize = 16;
-
-pub trait Cipher<'c> {
-    const BLOCK_SIZE: usize = AES_BLOCK_SIZE;
-    const REQUIRES_PADDING: bool = false;
-    fn key(&self) -> &[u8];
-    fn iv(&self) -> &[u8];
-    fn key_size(&self) -> KeySize {
-        match self.key().len() {
-            16 => KeySize::Bits128,
-            32 => KeySize::Bits256,
-            _ => panic!("Invalid key size"),
-        }
-    }
-    fn datatype(&self) -> u8 {
-        0
-    }
-    fn chmod_bits(&self) -> u8 {
-        0
-    }
-    fn get_header_block(&self) -> &[u8] {
-        [0; 0].as_slice()
-    }
-    fn uses_gcm_phases(&self) -> bool {
-        false
-    }
-    fn is_ccm_mode(&self) -> bool {
-        false
-    }
-    fn ccm_b0(&self) -> Option<&[u8; 16]> {
-        None
-    }
-    fn ccm_format_aad_header(&self, aad_len: usize) -> ([u8; 10], usize) {
-        let mut header = [0u8; 10];
-        let len = if aad_len == 0 {
-            0
-        } else if aad_len < (1 << 16) - (1 << 8) {
-            header[0] = (aad_len >> 8) as u8;
-            header[1] = aad_len as u8;
-            2
-        } else if aad_len < (1u64 << 32) as usize {
-            header[0] = 0xFF;
-            header[1] = 0xFE;
-            header[2..6].copy_from_slice(&(aad_len as u32).to_be_bytes());
-            6
-        } else {
-            header[0] = 0xFF;
-            header[1] = 0xFF;
-            header[2..10].copy_from_slice(&(aad_len as u64).to_be_bytes());
-            10
-        };
-        (header, len)
-    }
-}
-
 /// This trait enables restriction of ciphers to specific key sizes.
 pub trait CipherSized {}
 
@@ -101,330 +46,420 @@ pub trait CipherAuthenticated<const TAG_SIZE: usize> {
     const TAG_SIZE: usize = TAG_SIZE;
 }
 
-/// AES-ECB Cipher Mode
-pub struct AesEcb<'c, const KEY_SIZE: usize> {
-    iv: &'c [u8; 0],
-    key: &'c [u8; KEY_SIZE],
-}
+// The cipher-mode types below are only reachable through `crate::saes`'s N6
+// re-export (this module is private, and `aes_v3b` chips use `crate::aes`'s
+// copy instead), so they only need to exist for that configuration.
+#[cfg(all(saes_n6, not(aes_v3b)))]
+mod ciphers {
+    use super::{CipherAuthenticated, CipherSized, Direction, IVSized, KeySize};
 
-impl<'c, const KEY_SIZE: usize> AesEcb<'c, KEY_SIZE> {
-    /// Constructs a new AES-ECB cipher for a cryptographic operation.
-    pub fn new(key: &'c [u8; KEY_SIZE]) -> Self {
-        Self { key, iv: &[0; 0] }
-    }
-}
+    const AES_BLOCK_SIZE: usize = 16;
 
-impl<'c, const KEY_SIZE: usize> Cipher<'c> for AesEcb<'c, KEY_SIZE> {
-    const REQUIRES_PADDING: bool = true;
+    /// This trait encapsulates all cipher-specific behavior.
+    pub trait Cipher<'c> {
+        /// Processing block size (always 16 bytes for AES).
+        const BLOCK_SIZE: usize = AES_BLOCK_SIZE;
 
-    fn key(&self) -> &[u8] {
-        self.key
-    }
+        /// Indicates whether the cipher requires the application to provide padding.
+        const REQUIRES_PADDING: bool = false;
 
-    fn iv(&self) -> &[u8] {
-        self.iv
-    }
+        /// Returns the symmetric key.
+        fn key(&self) -> &[u8];
 
-    fn chmod_bits(&self) -> u8 {
-        0
-    }
-}
+        /// Returns the initialization vector.
+        fn iv(&self) -> &[u8];
 
-impl<'c> CipherSized for AesEcb<'c, { 128 / 8 }> {}
-impl<'c> CipherSized for AesEcb<'c, { 256 / 8 }> {}
-impl<'c, const KEY_SIZE: usize> IVSized for AesEcb<'c, KEY_SIZE> {}
+        /// Returns the key size.
+        fn key_size(&self) -> KeySize {
+            match self.key().len() {
+                16 => KeySize::Bits128,
+                32 => KeySize::Bits256,
+                _ => panic!("Invalid key size"),
+            }
+        }
 
-/// AES-CBC Cipher Mode
-pub struct AesCbc<'c, const KEY_SIZE: usize> {
-    iv: &'c [u8; 16],
-    key: &'c [u8; KEY_SIZE],
-}
+        /// Returns the data type setting for this cipher mode.
+        fn datatype(&self) -> u8 {
+            0
+        }
 
-impl<'c, const KEY_SIZE: usize> AesCbc<'c, KEY_SIZE> {
-    /// Constructs a new AES-CBC cipher for a cryptographic operation.
-    pub fn new(key: &'c [u8; KEY_SIZE], iv: &'c [u8; 16]) -> Self {
-        Self { key, iv }
-    }
-}
+        /// Returns the raw CHMOD field value for this cipher mode.
+        fn chmod_bits(&self) -> u8 {
+            0
+        }
 
-impl<'c, const KEY_SIZE: usize> Cipher<'c> for AesCbc<'c, KEY_SIZE> {
-    const REQUIRES_PADDING: bool = true;
+        /// Returns the AAD header block as required by the cipher (for authenticated modes).
+        fn get_header_block(&self) -> &[u8] {
+            [0; 0].as_slice()
+        }
 
-    fn key(&self) -> &[u8] {
-        self.key
-    }
+        /// Indicates whether this cipher mode uses GCM/CCM phases (init, header, payload, final).
+        fn uses_gcm_phases(&self) -> bool {
+            false
+        }
 
-    fn iv(&self) -> &[u8] {
-        self.iv
-    }
+        /// Indicates whether this is CCM mode (which has different final phase handling).
+        fn is_ccm_mode(&self) -> bool {
+            false
+        }
 
-    fn chmod_bits(&self) -> u8 {
-        1
-    }
-}
+        /// Returns the pre-computed B0 block for CCM mode (None for other modes).
+        fn ccm_b0(&self) -> Option<&[u8; 16]> {
+            None
+        }
 
-impl<'c> CipherSized for AesCbc<'c, { 128 / 8 }> {}
-impl<'c> CipherSized for AesCbc<'c, { 256 / 8 }> {}
-impl<'c, const KEY_SIZE: usize> IVSized for AesCbc<'c, KEY_SIZE> {}
-
-/// AES-CTR Cipher Mode
-pub struct AesCtr<'c, const KEY_SIZE: usize> {
-    iv: &'c [u8; 16],
-    key: &'c [u8; KEY_SIZE],
-}
-
-impl<'c, const KEY_SIZE: usize> AesCtr<'c, KEY_SIZE> {
-    /// Constructs a new AES-CTR cipher for a cryptographic operation.
-    pub fn new(key: &'c [u8; KEY_SIZE], iv: &'c [u8; 16]) -> Self {
-        Self { key, iv }
-    }
-}
-
-impl<'c, const KEY_SIZE: usize> Cipher<'c> for AesCtr<'c, KEY_SIZE> {
-    const REQUIRES_PADDING: bool = false; // Stream cipher, no padding needed
-
-    fn key(&self) -> &[u8] {
-        self.key
-    }
-
-    fn iv(&self) -> &[u8] {
-        self.iv
+        /// Returns the formatted AAD length prefix for CCM mode.
+        fn ccm_format_aad_header(&self, aad_len: usize) -> ([u8; 10], usize) {
+            let mut header = [0u8; 10];
+            let len = if aad_len == 0 {
+                0
+            } else if aad_len < (1 << 16) - (1 << 8) {
+                header[0] = (aad_len >> 8) as u8;
+                header[1] = aad_len as u8;
+                2
+            } else if aad_len < (1u64 << 32) as usize {
+                header[0] = 0xFF;
+                header[1] = 0xFE;
+                header[2..6].copy_from_slice(&(aad_len as u32).to_be_bytes());
+                6
+            } else {
+                header[0] = 0xFF;
+                header[1] = 0xFF;
+                header[2..10].copy_from_slice(&(aad_len as u64).to_be_bytes());
+                10
+            };
+            (header, len)
+        }
     }
 
-    fn chmod_bits(&self) -> u8 {
-        2
-    }
-}
-
-impl<'c> CipherSized for AesCtr<'c, { 128 / 8 }> {}
-impl<'c> CipherSized for AesCtr<'c, { 256 / 8 }> {}
-impl<'c, const KEY_SIZE: usize> IVSized for AesCtr<'c, KEY_SIZE> {}
-
-/// AES-GCM Cipher Mode
-pub struct AesGcm<'c, const KEY_SIZE: usize> {
-    key: &'c [u8; KEY_SIZE],
-    iv: [u8; 16],
-}
-
-impl<'c, const KEY_SIZE: usize> AesGcm<'c, KEY_SIZE> {
-    /// Constructs a new AES-GCM cipher for a cryptographic operation.
-    /// The IV should be 12 bytes long (96 bits).
-    pub fn new(key: &'c [u8; KEY_SIZE], iv: &'c [u8; 12]) -> Self {
-        let mut iv_full = [0u8; 16];
-        iv_full[..12].copy_from_slice(iv);
-        iv_full[15] = 2; // Initial counter value
-        Self { key, iv: iv_full }
-    }
-}
-
-impl<'c, const KEY_SIZE: usize> Cipher<'c> for AesGcm<'c, KEY_SIZE> {
-    const REQUIRES_PADDING: bool = false;
-
-    fn key(&self) -> &[u8] {
-        self.key
+    /// AES-ECB Cipher Mode
+    pub struct AesEcb<'c, const KEY_SIZE: usize> {
+        iv: &'c [u8; 0],
+        key: &'c [u8; KEY_SIZE],
     }
 
-    fn iv(&self) -> &[u8] {
-        &self.iv
+    impl<'c, const KEY_SIZE: usize> AesEcb<'c, KEY_SIZE> {
+        /// Constructs a new AES-ECB cipher for a cryptographic operation.
+        pub fn new(key: &'c [u8; KEY_SIZE]) -> Self {
+            Self { key, iv: &[0; 0] }
+        }
     }
 
-    fn chmod_bits(&self) -> u8 {
-        3
+    impl<'c, const KEY_SIZE: usize> Cipher<'c> for AesEcb<'c, KEY_SIZE> {
+        const REQUIRES_PADDING: bool = true;
+
+        fn key(&self) -> &[u8] {
+            self.key
+        }
+
+        fn iv(&self) -> &[u8] {
+            self.iv
+        }
+
+        fn chmod_bits(&self) -> u8 {
+            0
+        }
     }
 
-    fn uses_gcm_phases(&self) -> bool {
-        true
-    }
-}
+    impl<'c> CipherSized for AesEcb<'c, { 128 / 8 }> {}
+    impl<'c> CipherSized for AesEcb<'c, { 256 / 8 }> {}
+    impl<'c, const KEY_SIZE: usize> IVSized for AesEcb<'c, KEY_SIZE> {}
 
-impl<'c> CipherSized for AesGcm<'c, { 128 / 8 }> {}
-impl<'c> CipherSized for AesGcm<'c, { 256 / 8 }> {}
-impl<'c, const KEY_SIZE: usize> IVSized for AesGcm<'c, KEY_SIZE> {}
-impl<'c, const KEY_SIZE: usize> CipherAuthenticated<16> for AesGcm<'c, KEY_SIZE> {}
-
-/// AES-GMAC Cipher Mode (Galois Message Authentication Code)
-///
-/// GMAC provides message authentication without encryption. Use this when you need
-/// to authenticate data integrity without confidentiality - the data remains in
-/// plaintext but any tampering will be detected.
-///
-/// # Use Cases
-/// - Authenticating packet headers in network protocols
-/// - Verifying integrity of publicly-readable metadata
-/// - Any scenario requiring authentication without encryption
-///
-/// # Example
-/// ```no_run
-/// let key = [0u8; 16];
-/// let iv = [0u8; 12];  // 96-bit nonce
-/// let cipher = AesGmac::new(&key, &iv);
-///
-/// let mut ctx = aes.start(&cipher, Direction::Encrypt);
-/// aes.aad_blocking(&mut ctx, &header_data, true);
-/// if let Ok(Some(tag)) = aes.finish_blocking(ctx) {
-///     // Use tag to verify integrity
-/// }
-/// ```
-pub struct AesGmac<'c, const KEY_SIZE: usize> {
-    key: &'c [u8; KEY_SIZE],
-    iv: [u8; 16],
-}
-
-impl<'c, const KEY_SIZE: usize> AesGmac<'c, KEY_SIZE> {
-    /// Constructs a new AES-GMAC cipher for message authentication.
-    /// The IV should be 12 bytes long (96 bits) and unique per message.
-    pub fn new(key: &'c [u8; KEY_SIZE], iv: &'c [u8; 12]) -> Self {
-        let mut iv_full = [0u8; 16];
-        iv_full[..12].copy_from_slice(iv);
-        iv_full[15] = 2; // Initial counter value (same as GCM)
-        Self { key, iv: iv_full }
-    }
-}
-
-impl<'c, const KEY_SIZE: usize> Cipher<'c> for AesGmac<'c, KEY_SIZE> {
-    const REQUIRES_PADDING: bool = false;
-
-    fn key(&self) -> &[u8] {
-        self.key
+    /// AES-CBC Cipher Mode
+    pub struct AesCbc<'c, const KEY_SIZE: usize> {
+        iv: &'c [u8; 16],
+        key: &'c [u8; KEY_SIZE],
     }
 
-    fn iv(&self) -> &[u8] {
-        &self.iv
+    impl<'c, const KEY_SIZE: usize> AesCbc<'c, KEY_SIZE> {
+        /// Constructs a new AES-CBC cipher for a cryptographic operation.
+        pub fn new(key: &'c [u8; KEY_SIZE], iv: &'c [u8; 16]) -> Self {
+            Self { key, iv }
+        }
     }
 
-    fn chmod_bits(&self) -> u8 {
-        3
+    impl<'c, const KEY_SIZE: usize> Cipher<'c> for AesCbc<'c, KEY_SIZE> {
+        const REQUIRES_PADDING: bool = true;
+
+        fn key(&self) -> &[u8] {
+            self.key
+        }
+
+        fn iv(&self) -> &[u8] {
+            self.iv
+        }
+
+        fn chmod_bits(&self) -> u8 {
+            1
+        }
     }
 
-    fn uses_gcm_phases(&self) -> bool {
-        true
+    impl<'c> CipherSized for AesCbc<'c, { 128 / 8 }> {}
+    impl<'c> CipherSized for AesCbc<'c, { 256 / 8 }> {}
+    impl<'c, const KEY_SIZE: usize> IVSized for AesCbc<'c, KEY_SIZE> {}
+
+    /// AES-CTR Cipher Mode
+    pub struct AesCtr<'c, const KEY_SIZE: usize> {
+        iv: &'c [u8; 16],
+        key: &'c [u8; KEY_SIZE],
     }
-}
 
-impl<'c> CipherSized for AesGmac<'c, { 128 / 8 }> {}
-impl<'c> CipherSized for AesGmac<'c, { 256 / 8 }> {}
-impl<'c, const KEY_SIZE: usize> IVSized for AesGmac<'c, KEY_SIZE> {}
-impl<'c, const KEY_SIZE: usize> CipherAuthenticated<16> for AesGmac<'c, KEY_SIZE> {}
+    impl<'c, const KEY_SIZE: usize> AesCtr<'c, KEY_SIZE> {
+        /// Constructs a new AES-CTR cipher for a cryptographic operation.
+        pub fn new(key: &'c [u8; KEY_SIZE], iv: &'c [u8; 16]) -> Self {
+            Self { key, iv }
+        }
+    }
 
-/// AES-CCM Cipher Mode (Counter with CBC-MAC)
-pub struct AesCcm<'c, const KEY_SIZE: usize, const IV_SIZE: usize, const TAG_SIZE: usize> {
-    key: &'c [u8; KEY_SIZE],
-    iv: [u8; 16],
-    #[allow(dead_code)] // Stored for potential future use in verification
-    aad_len: usize,
-    #[allow(dead_code)] // Stored for potential future use in verification
-    payload_len: usize,
-}
+    impl<'c, const KEY_SIZE: usize> Cipher<'c> for AesCtr<'c, KEY_SIZE> {
+        const REQUIRES_PADDING: bool = false; // Stream cipher, no padding needed
 
-impl<'c, const KEY_SIZE: usize, const IV_SIZE: usize, const TAG_SIZE: usize> AesCcm<'c, KEY_SIZE, IV_SIZE, TAG_SIZE> {
-    /// Constructs a new AES-CCM cipher for a cryptographic operation.
-    /// - `key`: The encryption key (16 or 32 bytes)
-    /// - `iv`: The nonce/IV (7-13 bytes recommended, typically 12 bytes)
-    /// - `aad_len`: Length of additional authenticated data (known in advance)
-    /// - `payload_len`: Length of payload data (known in advance)
+        fn key(&self) -> &[u8] {
+            self.key
+        }
+
+        fn iv(&self) -> &[u8] {
+            self.iv
+        }
+
+        fn chmod_bits(&self) -> u8 {
+            2
+        }
+    }
+
+    impl<'c> CipherSized for AesCtr<'c, { 128 / 8 }> {}
+    impl<'c> CipherSized for AesCtr<'c, { 256 / 8 }> {}
+    impl<'c, const KEY_SIZE: usize> IVSized for AesCtr<'c, KEY_SIZE> {}
+
+    /// AES-GCM Cipher Mode
+    pub struct AesGcm<'c, const KEY_SIZE: usize> {
+        key: &'c [u8; KEY_SIZE],
+        iv: [u8; 16],
+    }
+
+    impl<'c, const KEY_SIZE: usize> AesGcm<'c, KEY_SIZE> {
+        /// Constructs a new AES-GCM cipher for a cryptographic operation.
+        /// The IV should be 12 bytes long (96 bits).
+        pub fn new(key: &'c [u8; KEY_SIZE], iv: &'c [u8; 12]) -> Self {
+            let mut iv_full = [0u8; 16];
+            iv_full[..12].copy_from_slice(iv);
+            iv_full[15] = 2; // Initial counter value
+            Self { key, iv: iv_full }
+        }
+    }
+
+    impl<'c, const KEY_SIZE: usize> Cipher<'c> for AesGcm<'c, KEY_SIZE> {
+        const REQUIRES_PADDING: bool = false;
+
+        fn key(&self) -> &[u8] {
+            self.key
+        }
+
+        fn iv(&self) -> &[u8] {
+            &self.iv
+        }
+
+        fn chmod_bits(&self) -> u8 {
+            3
+        }
+
+        fn uses_gcm_phases(&self) -> bool {
+            true
+        }
+    }
+
+    impl<'c> CipherSized for AesGcm<'c, { 128 / 8 }> {}
+    impl<'c> CipherSized for AesGcm<'c, { 256 / 8 }> {}
+    impl<'c, const KEY_SIZE: usize> IVSized for AesGcm<'c, KEY_SIZE> {}
+    impl<'c, const KEY_SIZE: usize> CipherAuthenticated<16> for AesGcm<'c, KEY_SIZE> {}
+
+    /// AES-GMAC Cipher Mode (Galois Message Authentication Code)
     ///
-    /// Note: CCM requires knowing the data lengths in advance.
-    pub fn new(key: &'c [u8; KEY_SIZE], iv: &'c [u8; IV_SIZE], aad_len: usize, payload_len: usize) -> Self {
-        // Validate IV size (7-13 bytes per NIST SP 800-38C)
-        assert!(IV_SIZE >= 7 && IV_SIZE <= 13, "CCM IV must be 7-13 bytes");
-        // Validate tag size (4, 6, 8, 10, 12, 14, or 16 bytes)
-        assert!(
-            TAG_SIZE >= 4 && TAG_SIZE <= 16 && TAG_SIZE % 2 == 0,
-            "CCM tag must be 4-16 bytes and even"
-        );
+    /// GMAC provides message authentication without encryption. Use this when you need
+    /// to authenticate data integrity without confidentiality - the data remains in
+    /// plaintext but any tampering will be detected.
+    ///
+    /// # Use Cases
+    /// - Authenticating packet headers in network protocols
+    /// - Verifying integrity of publicly-readable metadata
+    /// - Any scenario requiring authentication without encryption
+    ///
+    /// # Example
+    /// ```no_run
+    /// let key = [0u8; 16];
+    /// let iv = [0u8; 12];  // 96-bit nonce
+    /// let cipher = AesGmac::new(&key, &iv);
+    ///
+    /// let mut ctx = aes.start(&cipher, Direction::Encrypt);
+    /// aes.aad_blocking(&mut ctx, &header_data, true);
+    /// if let Ok(Some(tag)) = aes.finish_blocking(ctx) {
+    ///     // Use tag to verify integrity
+    /// }
+    /// ```
+    pub struct AesGmac<'c, const KEY_SIZE: usize> {
+        key: &'c [u8; KEY_SIZE],
+        iv: [u8; 16],
+    }
 
-        let mut iv_full = [0u8; 16];
-        // Format B0 block for CCM
-        let l = 15 - IV_SIZE; // l = size of length field
-        iv_full[0] = ((l - 1) as u8) | ((((TAG_SIZE - 2) / 2) as u8) << 3);
-        if aad_len > 0 {
-            iv_full[0] |= 0x40; // Set Adata flag
+    impl<'c, const KEY_SIZE: usize> AesGmac<'c, KEY_SIZE> {
+        /// Constructs a new AES-GMAC cipher for message authentication.
+        /// The IV should be 12 bytes long (96 bits) and unique per message.
+        pub fn new(key: &'c [u8; KEY_SIZE], iv: &'c [u8; 12]) -> Self {
+            let mut iv_full = [0u8; 16];
+            iv_full[..12].copy_from_slice(iv);
+            iv_full[15] = 2; // Initial counter value (same as GCM)
+            Self { key, iv: iv_full }
         }
-        iv_full[1..1 + IV_SIZE].copy_from_slice(iv);
+    }
 
-        // Encode payload length in the last l bytes (as big-endian)
-        // Use u64 to ensure consistent handling on 32-bit and 64-bit platforms
-        let payload_bytes = (payload_len as u64).to_be_bytes();
-        let offset = 16 - l;
-        iv_full[offset..].copy_from_slice(&payload_bytes[8 - l..]);
+    impl<'c, const KEY_SIZE: usize> Cipher<'c> for AesGmac<'c, KEY_SIZE> {
+        const REQUIRES_PADDING: bool = false;
 
-        Self {
-            key,
-            iv: iv_full,
-            aad_len,
-            payload_len,
+        fn key(&self) -> &[u8] {
+            self.key
+        }
+
+        fn iv(&self) -> &[u8] {
+            &self.iv
+        }
+
+        fn chmod_bits(&self) -> u8 {
+            3
+        }
+
+        fn uses_gcm_phases(&self) -> bool {
+            true
         }
     }
+
+    impl<'c> CipherSized for AesGmac<'c, { 128 / 8 }> {}
+    impl<'c> CipherSized for AesGmac<'c, { 256 / 8 }> {}
+    impl<'c, const KEY_SIZE: usize> IVSized for AesGmac<'c, KEY_SIZE> {}
+    impl<'c, const KEY_SIZE: usize> CipherAuthenticated<16> for AesGmac<'c, KEY_SIZE> {}
+
+    /// AES-CCM Cipher Mode (Counter with CBC-MAC)
+    pub struct AesCcm<'c, const KEY_SIZE: usize, const IV_SIZE: usize, const TAG_SIZE: usize> {
+        key: &'c [u8; KEY_SIZE],
+        iv: [u8; 16],
+        #[allow(dead_code)] // Stored for potential future use in verification
+        aad_len: usize,
+        #[allow(dead_code)] // Stored for potential future use in verification
+        payload_len: usize,
+    }
+
+    impl<'c, const KEY_SIZE: usize, const IV_SIZE: usize, const TAG_SIZE: usize> AesCcm<'c, KEY_SIZE, IV_SIZE, TAG_SIZE> {
+        /// Constructs a new AES-CCM cipher for a cryptographic operation.
+        /// - `key`: The encryption key (16 or 32 bytes)
+        /// - `iv`: The nonce/IV (7-13 bytes recommended, typically 12 bytes)
+        /// - `aad_len`: Length of additional authenticated data (known in advance)
+        /// - `payload_len`: Length of payload data (known in advance)
+        ///
+        /// Note: CCM requires knowing the data lengths in advance.
+        pub fn new(key: &'c [u8; KEY_SIZE], iv: &'c [u8; IV_SIZE], aad_len: usize, payload_len: usize) -> Self {
+            // Validate IV size (7-13 bytes per NIST SP 800-38C)
+            assert!(IV_SIZE >= 7 && IV_SIZE <= 13, "CCM IV must be 7-13 bytes");
+            // Validate tag size (4, 6, 8, 10, 12, 14, or 16 bytes)
+            assert!(
+                TAG_SIZE >= 4 && TAG_SIZE <= 16 && TAG_SIZE % 2 == 0,
+                "CCM tag must be 4-16 bytes and even"
+            );
+
+            let mut iv_full = [0u8; 16];
+            // Format B0 block for CCM
+            let l = 15 - IV_SIZE; // l = size of length field
+            iv_full[0] = ((l - 1) as u8) | ((((TAG_SIZE - 2) / 2) as u8) << 3);
+            if aad_len > 0 {
+                iv_full[0] |= 0x40; // Set Adata flag
+            }
+            iv_full[1..1 + IV_SIZE].copy_from_slice(iv);
+
+            // Encode payload length in the last l bytes (as big-endian)
+            // Use u64 to ensure consistent handling on 32-bit and 64-bit platforms
+            let payload_bytes = (payload_len as u64).to_be_bytes();
+            let offset = 16 - l;
+            iv_full[offset..].copy_from_slice(&payload_bytes[8 - l..]);
+
+            Self {
+                key,
+                iv: iv_full,
+                aad_len,
+                payload_len,
+            }
+        }
+    }
+
+    impl<'c, const KEY_SIZE: usize, const IV_SIZE: usize, const TAG_SIZE: usize> Cipher<'c>
+        for AesCcm<'c, KEY_SIZE, IV_SIZE, TAG_SIZE>
+    {
+        const REQUIRES_PADDING: bool = false;
+
+        fn key(&self) -> &[u8] {
+            self.key
+        }
+
+        fn iv(&self) -> &[u8] {
+            &self.iv
+        }
+
+        fn chmod_bits(&self) -> u8 {
+            4
+        }
+
+        fn uses_gcm_phases(&self) -> bool {
+            true
+        }
+
+        fn is_ccm_mode(&self) -> bool {
+            true
+        }
+
+        fn ccm_b0(&self) -> Option<&[u8; 16]> {
+            Some(&self.iv)
+        }
+    }
+
+    impl<'c, const IV_SIZE: usize, const TAG_SIZE: usize> CipherSized for AesCcm<'c, { 128 / 8 }, IV_SIZE, TAG_SIZE> {}
+    impl<'c, const IV_SIZE: usize, const TAG_SIZE: usize> CipherSized for AesCcm<'c, { 256 / 8 }, IV_SIZE, TAG_SIZE> {}
+    impl<'c, const KEY_SIZE: usize, const IV_SIZE: usize, const TAG_SIZE: usize> IVSized
+        for AesCcm<'c, KEY_SIZE, IV_SIZE, TAG_SIZE>
+    {
+    }
+    impl<'c, const KEY_SIZE: usize, const IV_SIZE: usize, const TAG_SIZE: usize> CipherAuthenticated<TAG_SIZE>
+        for AesCcm<'c, KEY_SIZE, IV_SIZE, TAG_SIZE>
+    {
+    }
+
+    /// Stores the state of the AES peripheral for suspending/resuming operations.
+    #[derive(Clone)]
+    pub struct Context<'c, C: Cipher<'c>> {
+        /// The cipher configuration
+        pub cipher: &'c C,
+        /// Encryption or decryption direction
+        pub dir: Direction,
+        /// Whether the last block has been processed
+        pub last_block_processed: bool,
+        /// Whether this is a GCM/CCM authenticated mode
+        pub is_gcm_ccm: bool,
+        // For GCM/CCM authenticated modes
+        /// Whether the header (AAD) has been processed
+        pub header_processed: bool,
+        /// Total length of additional authenticated data
+        pub header_len: u64,
+        /// Total length of payload data
+        pub payload_len: u64,
+        /// Buffer for partial AAD blocks
+        pub aad_buffer: [u8; 16],
+        /// Number of bytes in AAD buffer
+        pub aad_buffer_len: usize,
+        // Hardware state
+        /// Control register state
+        pub cr: u32,
+        /// Initialization vector state
+        pub iv: [u32; 4],
+        /// Suspend registers for GCM/CCM
+        pub suspr: [u32; 8],
+    }
 }
 
-impl<'c, const KEY_SIZE: usize, const IV_SIZE: usize, const TAG_SIZE: usize> Cipher<'c>
-    for AesCcm<'c, KEY_SIZE, IV_SIZE, TAG_SIZE>
-{
-    const REQUIRES_PADDING: bool = false;
-
-    fn key(&self) -> &[u8] {
-        self.key
-    }
-
-    fn iv(&self) -> &[u8] {
-        &self.iv
-    }
-
-    fn chmod_bits(&self) -> u8 {
-        4
-    }
-
-    fn uses_gcm_phases(&self) -> bool {
-        true
-    }
-
-    fn is_ccm_mode(&self) -> bool {
-        true
-    }
-
-    fn ccm_b0(&self) -> Option<&[u8; 16]> {
-        Some(&self.iv)
-    }
-}
-
-impl<'c, const IV_SIZE: usize, const TAG_SIZE: usize> CipherSized for AesCcm<'c, { 128 / 8 }, IV_SIZE, TAG_SIZE> {}
-impl<'c, const IV_SIZE: usize, const TAG_SIZE: usize> CipherSized for AesCcm<'c, { 256 / 8 }, IV_SIZE, TAG_SIZE> {}
-impl<'c, const KEY_SIZE: usize, const IV_SIZE: usize, const TAG_SIZE: usize> IVSized
-    for AesCcm<'c, KEY_SIZE, IV_SIZE, TAG_SIZE>
-{
-}
-impl<'c, const KEY_SIZE: usize, const IV_SIZE: usize, const TAG_SIZE: usize> CipherAuthenticated<TAG_SIZE>
-    for AesCcm<'c, KEY_SIZE, IV_SIZE, TAG_SIZE>
-{
-}
-
-/// Stores the state of the AES peripheral for suspending/resuming operations.
-#[derive(Clone)]
-pub struct Context<'c, C: Cipher<'c>> {
-    /// The cipher configuration
-    pub cipher: &'c C,
-    /// Encryption or decryption direction
-    pub dir: Direction,
-    /// Whether the last block has been processed
-    pub last_block_processed: bool,
-    /// Whether this is a GCM/CCM authenticated mode
-    pub is_gcm_ccm: bool,
-    // For GCM/CCM authenticated modes
-    /// Whether the header (AAD) has been processed
-    pub header_processed: bool,
-    /// Total length of additional authenticated data
-    pub header_len: u64,
-    /// Total length of payload data
-    pub payload_len: u64,
-    /// Buffer for partial AAD blocks
-    pub aad_buffer: [u8; 16],
-    /// Number of bytes in AAD buffer
-    pub aad_buffer_len: usize,
-    // Hardware state
-    /// Control register state
-    pub cr: u32,
-    /// Initialization vector state
-    pub iv: [u32; 4],
-    /// Suspend registers for GCM/CCM
-    pub suspr: [u32; 8],
-}
+#[cfg(all(saes_n6, not(aes_v3b)))]
+pub use ciphers::{AesCbc, AesCcm, AesCtr, AesEcb, AesGcm, AesGmac, Cipher, Context};

--- a/embassy-stm32/src/crypto.rs
+++ b/embassy-stm32/src/crypto.rs
@@ -1,0 +1,430 @@
+//! Shared AES cipher mode types used by [`crate::aes`] and [`crate::saes`].
+
+/// AES error
+#[derive(Debug, PartialEq, Eq, Clone, Copy)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+pub enum Error {
+    /// Invalid key size
+    KeyError,
+    /// Read error - unexpected output read during computation
+    ReadError,
+    /// Write error - unexpected input write during output phase
+    WriteError,
+    /// Invalid configuration
+    ConfigError,
+}
+
+/// AES cipher direction
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+pub enum Direction {
+    /// Encryption mode
+    Encrypt = 0,
+    /// Decryption mode (MODE = 2)
+    Decrypt = 2,
+}
+
+/// AES key size
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+pub enum KeySize {
+    /// 128-bit key
+    Bits128 = 0,
+    /// 256-bit key
+    Bits256 = 1,
+}
+
+const AES_BLOCK_SIZE: usize = 16;
+
+pub trait Cipher<'c> {
+    const BLOCK_SIZE: usize = AES_BLOCK_SIZE;
+    const REQUIRES_PADDING: bool = false;
+    fn key(&self) -> &[u8];
+    fn iv(&self) -> &[u8];
+    fn key_size(&self) -> KeySize {
+        match self.key().len() {
+            16 => KeySize::Bits128,
+            32 => KeySize::Bits256,
+            _ => panic!("Invalid key size"),
+        }
+    }
+    fn datatype(&self) -> u8 {
+        0
+    }
+    fn chmod_bits(&self) -> u8 {
+        0
+    }
+    fn get_header_block(&self) -> &[u8] {
+        [0; 0].as_slice()
+    }
+    fn uses_gcm_phases(&self) -> bool {
+        false
+    }
+    fn is_ccm_mode(&self) -> bool {
+        false
+    }
+    fn ccm_b0(&self) -> Option<&[u8; 16]> {
+        None
+    }
+    fn ccm_format_aad_header(&self, aad_len: usize) -> ([u8; 10], usize) {
+        let mut header = [0u8; 10];
+        let len = if aad_len == 0 {
+            0
+        } else if aad_len < (1 << 16) - (1 << 8) {
+            header[0] = (aad_len >> 8) as u8;
+            header[1] = aad_len as u8;
+            2
+        } else if aad_len < (1u64 << 32) as usize {
+            header[0] = 0xFF;
+            header[1] = 0xFE;
+            header[2..6].copy_from_slice(&(aad_len as u32).to_be_bytes());
+            6
+        } else {
+            header[0] = 0xFF;
+            header[1] = 0xFF;
+            header[2..10].copy_from_slice(&(aad_len as u64).to_be_bytes());
+            10
+        };
+        (header, len)
+    }
+}
+
+/// This trait enables restriction of ciphers to specific key sizes.
+pub trait CipherSized {}
+
+/// This trait enables restriction of initialization vectors to sizes compatible with a cipher mode.
+pub trait IVSized {}
+
+/// This trait enables restriction of a header phase to authenticated ciphers only.
+pub trait CipherAuthenticated<const TAG_SIZE: usize> {
+    /// Defines the authentication tag size.
+    const TAG_SIZE: usize = TAG_SIZE;
+}
+
+/// AES-ECB Cipher Mode
+pub struct AesEcb<'c, const KEY_SIZE: usize> {
+    iv: &'c [u8; 0],
+    key: &'c [u8; KEY_SIZE],
+}
+
+impl<'c, const KEY_SIZE: usize> AesEcb<'c, KEY_SIZE> {
+    /// Constructs a new AES-ECB cipher for a cryptographic operation.
+    pub fn new(key: &'c [u8; KEY_SIZE]) -> Self {
+        Self { key, iv: &[0; 0] }
+    }
+}
+
+impl<'c, const KEY_SIZE: usize> Cipher<'c> for AesEcb<'c, KEY_SIZE> {
+    const REQUIRES_PADDING: bool = true;
+
+    fn key(&self) -> &[u8] {
+        self.key
+    }
+
+    fn iv(&self) -> &[u8] {
+        self.iv
+    }
+
+    fn chmod_bits(&self) -> u8 {
+        0
+    }
+}
+
+impl<'c> CipherSized for AesEcb<'c, { 128 / 8 }> {}
+impl<'c> CipherSized for AesEcb<'c, { 256 / 8 }> {}
+impl<'c, const KEY_SIZE: usize> IVSized for AesEcb<'c, KEY_SIZE> {}
+
+/// AES-CBC Cipher Mode
+pub struct AesCbc<'c, const KEY_SIZE: usize> {
+    iv: &'c [u8; 16],
+    key: &'c [u8; KEY_SIZE],
+}
+
+impl<'c, const KEY_SIZE: usize> AesCbc<'c, KEY_SIZE> {
+    /// Constructs a new AES-CBC cipher for a cryptographic operation.
+    pub fn new(key: &'c [u8; KEY_SIZE], iv: &'c [u8; 16]) -> Self {
+        Self { key, iv }
+    }
+}
+
+impl<'c, const KEY_SIZE: usize> Cipher<'c> for AesCbc<'c, KEY_SIZE> {
+    const REQUIRES_PADDING: bool = true;
+
+    fn key(&self) -> &[u8] {
+        self.key
+    }
+
+    fn iv(&self) -> &[u8] {
+        self.iv
+    }
+
+    fn chmod_bits(&self) -> u8 {
+        1
+    }
+}
+
+impl<'c> CipherSized for AesCbc<'c, { 128 / 8 }> {}
+impl<'c> CipherSized for AesCbc<'c, { 256 / 8 }> {}
+impl<'c, const KEY_SIZE: usize> IVSized for AesCbc<'c, KEY_SIZE> {}
+
+/// AES-CTR Cipher Mode
+pub struct AesCtr<'c, const KEY_SIZE: usize> {
+    iv: &'c [u8; 16],
+    key: &'c [u8; KEY_SIZE],
+}
+
+impl<'c, const KEY_SIZE: usize> AesCtr<'c, KEY_SIZE> {
+    /// Constructs a new AES-CTR cipher for a cryptographic operation.
+    pub fn new(key: &'c [u8; KEY_SIZE], iv: &'c [u8; 16]) -> Self {
+        Self { key, iv }
+    }
+}
+
+impl<'c, const KEY_SIZE: usize> Cipher<'c> for AesCtr<'c, KEY_SIZE> {
+    const REQUIRES_PADDING: bool = false; // Stream cipher, no padding needed
+
+    fn key(&self) -> &[u8] {
+        self.key
+    }
+
+    fn iv(&self) -> &[u8] {
+        self.iv
+    }
+
+    fn chmod_bits(&self) -> u8 {
+        2
+    }
+}
+
+impl<'c> CipherSized for AesCtr<'c, { 128 / 8 }> {}
+impl<'c> CipherSized for AesCtr<'c, { 256 / 8 }> {}
+impl<'c, const KEY_SIZE: usize> IVSized for AesCtr<'c, KEY_SIZE> {}
+
+/// AES-GCM Cipher Mode
+pub struct AesGcm<'c, const KEY_SIZE: usize> {
+    key: &'c [u8; KEY_SIZE],
+    iv: [u8; 16],
+}
+
+impl<'c, const KEY_SIZE: usize> AesGcm<'c, KEY_SIZE> {
+    /// Constructs a new AES-GCM cipher for a cryptographic operation.
+    /// The IV should be 12 bytes long (96 bits).
+    pub fn new(key: &'c [u8; KEY_SIZE], iv: &'c [u8; 12]) -> Self {
+        let mut iv_full = [0u8; 16];
+        iv_full[..12].copy_from_slice(iv);
+        iv_full[15] = 2; // Initial counter value
+        Self { key, iv: iv_full }
+    }
+}
+
+impl<'c, const KEY_SIZE: usize> Cipher<'c> for AesGcm<'c, KEY_SIZE> {
+    const REQUIRES_PADDING: bool = false;
+
+    fn key(&self) -> &[u8] {
+        self.key
+    }
+
+    fn iv(&self) -> &[u8] {
+        &self.iv
+    }
+
+    fn chmod_bits(&self) -> u8 {
+        3
+    }
+
+    fn uses_gcm_phases(&self) -> bool {
+        true
+    }
+}
+
+impl<'c> CipherSized for AesGcm<'c, { 128 / 8 }> {}
+impl<'c> CipherSized for AesGcm<'c, { 256 / 8 }> {}
+impl<'c, const KEY_SIZE: usize> IVSized for AesGcm<'c, KEY_SIZE> {}
+impl<'c, const KEY_SIZE: usize> CipherAuthenticated<16> for AesGcm<'c, KEY_SIZE> {}
+
+/// AES-GMAC Cipher Mode (Galois Message Authentication Code)
+///
+/// GMAC provides message authentication without encryption. Use this when you need
+/// to authenticate data integrity without confidentiality - the data remains in
+/// plaintext but any tampering will be detected.
+///
+/// # Use Cases
+/// - Authenticating packet headers in network protocols
+/// - Verifying integrity of publicly-readable metadata
+/// - Any scenario requiring authentication without encryption
+///
+/// # Example
+/// ```no_run
+/// let key = [0u8; 16];
+/// let iv = [0u8; 12];  // 96-bit nonce
+/// let cipher = AesGmac::new(&key, &iv);
+///
+/// let mut ctx = aes.start(&cipher, Direction::Encrypt);
+/// aes.aad_blocking(&mut ctx, &header_data, true);
+/// if let Ok(Some(tag)) = aes.finish_blocking(ctx) {
+///     // Use tag to verify integrity
+/// }
+/// ```
+pub struct AesGmac<'c, const KEY_SIZE: usize> {
+    key: &'c [u8; KEY_SIZE],
+    iv: [u8; 16],
+}
+
+impl<'c, const KEY_SIZE: usize> AesGmac<'c, KEY_SIZE> {
+    /// Constructs a new AES-GMAC cipher for message authentication.
+    /// The IV should be 12 bytes long (96 bits) and unique per message.
+    pub fn new(key: &'c [u8; KEY_SIZE], iv: &'c [u8; 12]) -> Self {
+        let mut iv_full = [0u8; 16];
+        iv_full[..12].copy_from_slice(iv);
+        iv_full[15] = 2; // Initial counter value (same as GCM)
+        Self { key, iv: iv_full }
+    }
+}
+
+impl<'c, const KEY_SIZE: usize> Cipher<'c> for AesGmac<'c, KEY_SIZE> {
+    const REQUIRES_PADDING: bool = false;
+
+    fn key(&self) -> &[u8] {
+        self.key
+    }
+
+    fn iv(&self) -> &[u8] {
+        &self.iv
+    }
+
+    fn chmod_bits(&self) -> u8 {
+        3
+    }
+
+    fn uses_gcm_phases(&self) -> bool {
+        true
+    }
+}
+
+impl<'c> CipherSized for AesGmac<'c, { 128 / 8 }> {}
+impl<'c> CipherSized for AesGmac<'c, { 256 / 8 }> {}
+impl<'c, const KEY_SIZE: usize> IVSized for AesGmac<'c, KEY_SIZE> {}
+impl<'c, const KEY_SIZE: usize> CipherAuthenticated<16> for AesGmac<'c, KEY_SIZE> {}
+
+/// AES-CCM Cipher Mode (Counter with CBC-MAC)
+pub struct AesCcm<'c, const KEY_SIZE: usize, const IV_SIZE: usize, const TAG_SIZE: usize> {
+    key: &'c [u8; KEY_SIZE],
+    iv: [u8; 16],
+    #[allow(dead_code)] // Stored for potential future use in verification
+    aad_len: usize,
+    #[allow(dead_code)] // Stored for potential future use in verification
+    payload_len: usize,
+}
+
+impl<'c, const KEY_SIZE: usize, const IV_SIZE: usize, const TAG_SIZE: usize> AesCcm<'c, KEY_SIZE, IV_SIZE, TAG_SIZE> {
+    /// Constructs a new AES-CCM cipher for a cryptographic operation.
+    /// - `key`: The encryption key (16 or 32 bytes)
+    /// - `iv`: The nonce/IV (7-13 bytes recommended, typically 12 bytes)
+    /// - `aad_len`: Length of additional authenticated data (known in advance)
+    /// - `payload_len`: Length of payload data (known in advance)
+    ///
+    /// Note: CCM requires knowing the data lengths in advance.
+    pub fn new(key: &'c [u8; KEY_SIZE], iv: &'c [u8; IV_SIZE], aad_len: usize, payload_len: usize) -> Self {
+        // Validate IV size (7-13 bytes per NIST SP 800-38C)
+        assert!(IV_SIZE >= 7 && IV_SIZE <= 13, "CCM IV must be 7-13 bytes");
+        // Validate tag size (4, 6, 8, 10, 12, 14, or 16 bytes)
+        assert!(
+            TAG_SIZE >= 4 && TAG_SIZE <= 16 && TAG_SIZE % 2 == 0,
+            "CCM tag must be 4-16 bytes and even"
+        );
+
+        let mut iv_full = [0u8; 16];
+        // Format B0 block for CCM
+        let l = 15 - IV_SIZE; // l = size of length field
+        iv_full[0] = ((l - 1) as u8) | ((((TAG_SIZE - 2) / 2) as u8) << 3);
+        if aad_len > 0 {
+            iv_full[0] |= 0x40; // Set Adata flag
+        }
+        iv_full[1..1 + IV_SIZE].copy_from_slice(iv);
+
+        // Encode payload length in the last l bytes (as big-endian)
+        // Use u64 to ensure consistent handling on 32-bit and 64-bit platforms
+        let payload_bytes = (payload_len as u64).to_be_bytes();
+        let offset = 16 - l;
+        iv_full[offset..].copy_from_slice(&payload_bytes[8 - l..]);
+
+        Self {
+            key,
+            iv: iv_full,
+            aad_len,
+            payload_len,
+        }
+    }
+}
+
+impl<'c, const KEY_SIZE: usize, const IV_SIZE: usize, const TAG_SIZE: usize> Cipher<'c>
+    for AesCcm<'c, KEY_SIZE, IV_SIZE, TAG_SIZE>
+{
+    const REQUIRES_PADDING: bool = false;
+
+    fn key(&self) -> &[u8] {
+        self.key
+    }
+
+    fn iv(&self) -> &[u8] {
+        &self.iv
+    }
+
+    fn chmod_bits(&self) -> u8 {
+        4
+    }
+
+    fn uses_gcm_phases(&self) -> bool {
+        true
+    }
+
+    fn is_ccm_mode(&self) -> bool {
+        true
+    }
+
+    fn ccm_b0(&self) -> Option<&[u8; 16]> {
+        Some(&self.iv)
+    }
+}
+
+impl<'c, const IV_SIZE: usize, const TAG_SIZE: usize> CipherSized for AesCcm<'c, { 128 / 8 }, IV_SIZE, TAG_SIZE> {}
+impl<'c, const IV_SIZE: usize, const TAG_SIZE: usize> CipherSized for AesCcm<'c, { 256 / 8 }, IV_SIZE, TAG_SIZE> {}
+impl<'c, const KEY_SIZE: usize, const IV_SIZE: usize, const TAG_SIZE: usize> IVSized
+    for AesCcm<'c, KEY_SIZE, IV_SIZE, TAG_SIZE>
+{
+}
+impl<'c, const KEY_SIZE: usize, const IV_SIZE: usize, const TAG_SIZE: usize> CipherAuthenticated<TAG_SIZE>
+    for AesCcm<'c, KEY_SIZE, IV_SIZE, TAG_SIZE>
+{
+}
+
+/// Stores the state of the AES peripheral for suspending/resuming operations.
+#[derive(Clone)]
+pub struct Context<'c, C: Cipher<'c>> {
+    /// The cipher configuration
+    pub cipher: &'c C,
+    /// Encryption or decryption direction
+    pub dir: Direction,
+    /// Whether the last block has been processed
+    pub last_block_processed: bool,
+    /// Whether this is a GCM/CCM authenticated mode
+    pub is_gcm_ccm: bool,
+    // For GCM/CCM authenticated modes
+    /// Whether the header (AAD) has been processed
+    pub header_processed: bool,
+    /// Total length of additional authenticated data
+    pub header_len: u64,
+    /// Total length of payload data
+    pub payload_len: u64,
+    /// Buffer for partial AAD blocks
+    pub aad_buffer: [u8; 16],
+    /// Number of bytes in AAD buffer
+    pub aad_buffer_len: usize,
+    // Hardware state
+    /// Control register state
+    pub cr: u32,
+    /// Initialization vector state
+    pub iv: [u32; 4],
+    /// Suspend registers for GCM/CCM
+    pub suspr: [u32; 8],
+}

--- a/embassy-stm32/src/gfxmmu.rs
+++ b/embassy-stm32/src/gfxmmu.rs
@@ -10,6 +10,7 @@ use embassy_hal_internal::PeripheralType;
 
 use crate::interrupt::typelevel::Interrupt;
 use crate::pac::gfxmmu::Gfxmmu as Regs;
+#[cfg(gfxmmu_v2)]
 use crate::pac::gfxmmu::vals::Bm192;
 use crate::{Peri, interrupt, rcc};
 
@@ -50,6 +51,10 @@ pub struct Config {
     /// Use 192 blocks per line instead of 256.
     pub block_mode_192: bool,
     /// Enable the cache unit.
+    ///
+    /// Not available on N6 (`gfxmmu_n6`): the block has no cache controller,
+    /// so this field doesn't exist for that variant.
+    #[cfg(gfxmmu_v2)]
     pub cache_enable: bool,
     /// Default 32-bit fill value for unmapped blocks.
     pub default_value: u32,
@@ -59,6 +64,7 @@ impl Default for Config {
     fn default() -> Self {
         Self {
             block_mode_192: true,
+            #[cfg(gfxmmu_v2)]
             cache_enable: true,
             default_value: 0,
         }
@@ -98,15 +104,23 @@ impl<'d, T: Instance> Gfxmmu<'d, T> {
         let regs = T::regs();
         regs.dvr().write(|w| w.set_dv(config.default_value));
         regs.cr().modify(|w| {
-            w.set_bm(
-                0,
-                if config.block_mode_192 {
-                    Bm192::_192blocksPerLine
-                } else {
-                    Bm192::_256blocksPerLine
-                },
-            );
-            w.set_ce(config.cache_enable);
+            #[cfg(gfxmmu_v2)]
+            {
+                w.set_bm(
+                    0,
+                    if config.block_mode_192 {
+                        Bm192::_192blocksPerLine
+                    } else {
+                        Bm192::_256blocksPerLine
+                    },
+                );
+                w.set_ce(config.cache_enable);
+            }
+            #[cfg(gfxmmu_n6)]
+            {
+                w.set_bs(config.block_mode_192);
+                w.set_ate(true);
+            }
         });
 
         Self { _peri: peri }
@@ -165,6 +179,9 @@ impl<'d, T: Instance> Gfxmmu<'d, T> {
     }
 
     /// Flush the cache (blocks until complete).
+    ///
+    /// Not available on N6 (`gfxmmu_n6`): the block has no cache controller.
+    #[cfg(gfxmmu_v2)]
     pub fn flush_cache(&mut self) {
         let regs = T::regs();
         regs.ccr().modify(|w| w.set_ff(true));
@@ -172,6 +189,9 @@ impl<'d, T: Instance> Gfxmmu<'d, T> {
     }
 
     /// Invalidate the cache (blocks until complete).
+    ///
+    /// Not available on N6 (`gfxmmu_n6`): the block has no cache controller.
+    #[cfg(gfxmmu_v2)]
     pub fn invalidate_cache(&mut self) {
         let regs = T::regs();
         regs.ccr().modify(|w| w.set_fi(true));

--- a/embassy-stm32/src/i3c/mod.rs
+++ b/embassy-stm32/src/i3c/mod.rs
@@ -18,7 +18,9 @@ trait SealedInstance: RccPeripheral {
 /// I3C instance trait.
 #[allow(private_bounds)]
 pub trait Instance: PeripheralType + SealedInstance + 'static {
+    /// Event interrupt for this instance.
     type EventInterrupt: crate::interrupt::typelevel::Interrupt;
+    /// Error interrupt for this instance.
     type ErrorInterrupt: crate::interrupt::typelevel::Interrupt;
 }
 

--- a/embassy-stm32/src/i3c/mod.rs
+++ b/embassy-stm32/src/i3c/mod.rs
@@ -1,0 +1,56 @@
+//! Improved inter-integrated circuit (I3C)
+//!
+//! N6 exposes I3C1/I3C2 with event and error interrupts. This module provides
+//! instance wiring, RCC enable/reset, and direct register access. A full
+//! controller/target protocol driver is not yet implemented — use [`I3c::regs`]
+//! for register-level access until higher-level APIs land.
+
+use embassy_hal_internal::{Peri, PeripheralType};
+
+use crate::pac::i3c::I3c as Regs;
+use crate::peripherals;
+use crate::rcc::{self, RccPeripheral};
+
+trait SealedInstance: RccPeripheral {
+    fn regs() -> Regs;
+}
+
+/// I3C instance trait.
+#[allow(private_bounds)]
+pub trait Instance: PeripheralType + SealedInstance + 'static {
+    type EventInterrupt: crate::interrupt::typelevel::Interrupt;
+    type ErrorInterrupt: crate::interrupt::typelevel::Interrupt;
+}
+
+/// I3C peripheral handle.
+pub struct I3c<'d, T: Instance> {
+    _peri: Peri<'d, T>,
+}
+
+impl<'d, T: Instance> I3c<'d, T> {
+    /// Create a new I3C handle and enable/reset the peripheral.
+    pub fn new(peri: Peri<'d, T>) -> Self {
+        rcc::enable_and_reset::<T>();
+        Self { _peri: peri }
+    }
+
+    /// Direct access to the underlying PAC registers.
+    pub fn regs() -> Regs {
+        T::regs()
+    }
+}
+
+foreach_peripheral!(
+    (i3c, $inst:ident) => {
+        impl SealedInstance for peripherals::$inst {
+            fn regs() -> Regs {
+                crate::pac::$inst
+            }
+        }
+
+        impl Instance for peripherals::$inst {
+            type EventInterrupt = crate::_generated::peripheral_interrupts::$inst::EV;
+            type ErrorInterrupt = crate::_generated::peripheral_interrupts::$inst::ER;
+        }
+    };
+);

--- a/embassy-stm32/src/lib.rs
+++ b/embassy-stm32/src/lib.rs
@@ -151,7 +151,11 @@ pub mod hspi;
 pub mod i2c;
 #[cfg(any(spi_v1_i2s, spi_v2_i2s, spi_v3_i2s, spi_v4_i2s, spi_v5_i2s))]
 pub mod i2s;
-#[cfg(i3c)]
+// Restricted to N6: the generic `i3c` cfg also covers other chips (e.g. H5)
+// whose I3C instances aren't all wired up with complete RCC metadata (some
+// lack an enable/reset bit entirely in the PAC data), which this
+// register-access-only driver hasn't been written or tested against.
+#[cfg(all(i3c, stm32n6))]
 pub mod i3c;
 #[cfg(icache)]
 pub mod icache;

--- a/embassy-stm32/src/lib.rs
+++ b/embassy-stm32/src/lib.rs
@@ -71,6 +71,8 @@ pub mod can;
 pub mod comp;
 #[cfg(all(cordic, not(stm32c5)))]
 pub mod cordic;
+#[cfg(any(aes_v3b, saes_n6))]
+mod crypto;
 
 #[cfg(not(any(comp_u5, comp_v1, comp_v2)))]
 pub mod comp {
@@ -97,6 +99,8 @@ macro_rules! impl_comp_inp_pin {
 macro_rules! impl_comp_inm_pin {
     ($inst:ident, $pin:ident, $ch:expr) => {};
 }
+#[cfg(cacheaxi)]
+pub mod cacheaxi;
 #[cfg(any(ipcc, hsem))]
 pub mod cpu;
 #[cfg(crc)]
@@ -129,7 +133,7 @@ pub mod flash;
 pub mod fmac;
 #[cfg(any(fmc, fsmc))]
 pub mod fmc;
-#[cfg(gfxmmu_v2)]
+#[cfg(any(gfxmmu_v2, gfxmmu_n6))]
 pub mod gfxmmu;
 #[cfg(gfxtim)]
 pub mod gfxtim;
@@ -147,6 +151,8 @@ pub mod hspi;
 pub mod i2c;
 #[cfg(any(spi_v1_i2s, spi_v2_i2s, spi_v3_i2s, spi_v4_i2s, spi_v5_i2s))]
 pub mod i2s;
+#[cfg(i3c)]
+pub mod i3c;
 #[cfg(icache)]
 pub mod icache;
 #[cfg(any(stm32wb, stm32wl5x))]
@@ -160,17 +166,19 @@ pub mod lcd;
 pub mod low_power;
 #[cfg(lpgpio)]
 pub mod lpgpio;
-#[cfg(all(lptim, not(lptim_n6)))]
+#[cfg(lptim)]
 pub mod lptim;
 #[cfg(ltdc)]
 pub mod ltdc;
+#[cfg(mce)]
+pub mod mce;
 #[cfg(mdf)]
 pub mod mdf;
 #[cfg(opamp)]
 pub mod opamp;
 #[cfg(octospi)]
 pub mod ospi;
-#[cfg(pka_v1a)]
+#[cfg(any(pka_v1a, pka_n6))]
 pub mod pka;
 #[cfg(quadspi)]
 pub mod qspi;
@@ -182,17 +190,17 @@ pub mod rif;
 pub mod rng;
 #[cfg(all(rtc, not(rtc_v1)))]
 pub mod rtc;
-#[cfg(saes_v1a)]
+#[cfg(any(saes_v1a, saes_n6))]
 pub mod saes;
-#[cfg(all(sai, not(sai_n6)))]
+#[cfg(sai)]
 pub mod sai;
 #[cfg(any(sdmmc_v1, sdmmc_v2, sdmmc_v3))]
 pub mod sdmmc;
-#[cfg(all(spdifrx, not(spdifrx_n6)))]
+#[cfg(spdifrx)]
 pub mod spdifrx;
 #[cfg(spi)]
 pub mod spi;
-#[cfg(any(tamp_g0, tamp_g4, tamp_h5, tamp_l5, tamp_u5, tamp_wba, tamp_wl))]
+#[cfg(any(tamp_g0, tamp_g4, tamp_h5, tamp_l5, tamp_u5, tamp_wba, tamp_wl, tamp_n6))]
 pub mod tamp;
 #[cfg(tsc)]
 pub mod tsc;

--- a/embassy-stm32/src/lptim/mod.rs
+++ b/embassy-stm32/src/lptim/mod.rs
@@ -2,13 +2,14 @@
 
 pub mod pwm;
 pub mod timer;
+pub(crate) mod vals;
 
 use crate::rcc::RccPeripheral;
 
 /// Timer channel.
-#[cfg(any(lptim_v2a, lptim_v2b))]
+#[cfg(any(lptim_v2a, lptim_v2b, lptim_n6))]
 mod channel;
-#[cfg(any(lptim_v2a, lptim_v2b))]
+#[cfg(any(lptim_v2a, lptim_v2b, lptim_n6))]
 pub use channel::Channel;
 use embassy_hal_internal::PeripheralType;
 

--- a/embassy-stm32/src/lptim/pwm.rs
+++ b/embassy-stm32/src/lptim/pwm.rs
@@ -4,11 +4,11 @@ use core::marker::PhantomData;
 
 use embassy_hal_internal::Peri;
 
-#[cfg(not(any(lptim_v2a, lptim_v2b)))]
+#[cfg(not(any(lptim_v2a, lptim_v2b, lptim_n6)))]
 use super::OutputPin;
 use super::timer::Timer;
 use super::{BasicInstance, Instance};
-#[cfg(any(lptim_v2a, lptim_v2b))]
+#[cfg(any(lptim_v2a, lptim_v2b, lptim_n6))]
 use super::{Channel1Pin, Channel2Pin, channel::Channel, timer::ChannelDirection};
 #[cfg(gpio_v2)]
 use crate::gpio::Pull;
@@ -78,11 +78,11 @@ macro_rules! channel_impl {
     };
 }
 
-#[cfg(not(any(lptim_v2a, lptim_v2b)))]
+#[cfg(not(any(lptim_v2a, lptim_v2b, lptim_n6)))]
 channel_impl!(new, new_with_config, Output, OutputPin);
-#[cfg(any(lptim_v2a, lptim_v2b))]
+#[cfg(any(lptim_v2a, lptim_v2b, lptim_n6))]
 channel_impl!(new_ch1, new_ch1_with_config, Ch1, Channel1Pin);
-#[cfg(any(lptim_v2a, lptim_v2b))]
+#[cfg(any(lptim_v2a, lptim_v2b, lptim_n6))]
 channel_impl!(new_ch2, new_ch2_with_config, Ch2, Channel2Pin);
 
 /// PWM driver.
@@ -90,7 +90,7 @@ pub struct Pwm<'d, T: Instance> {
     inner: Timer<'d, T>,
 }
 
-#[cfg(not(any(lptim_v2a, lptim_v2b)))]
+#[cfg(not(any(lptim_v2a, lptim_v2b, lptim_n6)))]
 impl<'d, T: Instance> Pwm<'d, T> {
     /// Create a new PWM driver.
     pub fn new(tim: Peri<'d, T>, _output_pin: PwmPin<'d, T, Output>, freq: Hertz) -> Self {
@@ -115,7 +115,7 @@ impl<'d, T: Instance> Pwm<'d, T> {
     fn post_init(&mut self) {}
 }
 
-#[cfg(any(lptim_v2a, lptim_v2b))]
+#[cfg(any(lptim_v2a, lptim_v2b, lptim_n6))]
 impl<'d, T: Instance> Pwm<'d, T> {
     /// Create a new PWM driver.
     pub fn new(

--- a/embassy-stm32/src/lptim/timer/channel_direction.rs
+++ b/embassy-stm32/src/lptim/timer/channel_direction.rs
@@ -1,4 +1,4 @@
-use crate::pac::lptim::vals;
+use crate::lptim::vals::Ccsel;
 
 /// Direction of a low-power timer channel
 pub enum ChannelDirection {
@@ -8,11 +8,19 @@ pub enum ChannelDirection {
     InputCapture,
 }
 
-impl From<ChannelDirection> for vals::Ccsel {
-    fn from(direction: ChannelDirection) -> Self {
-        match direction {
-            ChannelDirection::OutputPwm => vals::Ccsel::OutputCompare,
-            ChannelDirection::InputCapture => vals::Ccsel::InputCapture,
+impl ChannelDirection {
+    pub(crate) fn ccsel(&self) -> Ccsel {
+        match self {
+            ChannelDirection::OutputPwm => Ccsel::OutputCompare,
+            ChannelDirection::InputCapture => Ccsel::InputCapture,
+        }
+    }
+
+    #[cfg(lptim_n6)]
+    pub(crate) fn ccsel_bool(&self) -> bool {
+        match self {
+            ChannelDirection::OutputPwm => false,
+            ChannelDirection::InputCapture => true,
         }
     }
 }

--- a/embassy-stm32/src/lptim/timer/channel_direction.rs
+++ b/embassy-stm32/src/lptim/timer/channel_direction.rs
@@ -1,3 +1,4 @@
+#[cfg(not(lptim_n6))]
 use crate::lptim::vals::Ccsel;
 
 /// Direction of a low-power timer channel
@@ -9,6 +10,7 @@ pub enum ChannelDirection {
 }
 
 impl ChannelDirection {
+    #[cfg(not(lptim_n6))]
     pub(crate) fn ccsel(&self) -> Ccsel {
         match self {
             ChannelDirection::OutputPwm => Ccsel::OutputCompare,

--- a/embassy-stm32/src/lptim/timer/mod.rs
+++ b/embassy-stm32/src/lptim/timer/mod.rs
@@ -3,16 +3,16 @@ mod prescaler;
 
 use embassy_hal_internal::Peri;
 
-#[cfg(any(lptim_v2a, lptim_v2b))]
+#[cfg(any(lptim_v2a, lptim_v2b, lptim_n6))]
 use super::channel::Channel;
-#[cfg(any(lptim_v2a, lptim_v2b))]
+#[cfg(any(lptim_v2a, lptim_v2b, lptim_n6))]
 mod channel_direction;
-#[cfg(any(lptim_v2a, lptim_v2b))]
+#[cfg(any(lptim_v2a, lptim_v2b, lptim_n6))]
 pub use channel_direction::ChannelDirection;
 use prescaler::Prescaler;
 
 use super::Instance;
-use crate::pac::lptim::vals::{Filter, Trigen};
+use crate::lptim::vals::{self, Filter, Trigen};
 use crate::rcc;
 use crate::time::Hertz;
 
@@ -60,8 +60,14 @@ impl<'d, T: Instance> Timer<'d, T> {
 
         let psc = Prescaler::from_ticks(pclk_ticks_per_timer_period);
         let arr = psc.scale_down(pclk_ticks_per_timer_period);
+        let presc = vals::Presc::from(&psc);
 
-        T::regs().cfgr().modify(|r| r.set_presc((&psc).into()));
+        T::regs().cfgr().modify(|r| {
+            #[cfg(not(lptim_n6))]
+            r.set_presc(presc);
+            #[cfg(lptim_n6)]
+            r.set_presc(presc.to_bits());
+        });
         T::regs().arr().modify(|r| r.set_arr(arr.into()));
     }
 
@@ -69,7 +75,17 @@ impl<'d, T: Instance> Timer<'d, T> {
     pub fn get_frequency(&self) -> Hertz {
         let pclk_f = T::frequency();
         let arr = T::regs().arr().read().arr();
-        let psc = Prescaler::from(T::regs().cfgr().read().presc());
+        let presc = {
+            #[cfg(not(lptim_n6))]
+            {
+                T::regs().cfgr().read().presc()
+            }
+            #[cfg(lptim_n6)]
+            {
+                vals::Presc::from_bits(T::regs().cfgr().read().presc())
+            }
+        };
+        let psc = Prescaler::from(presc);
 
         pclk_f / psc.scale_up(arr)
     }
@@ -92,12 +108,22 @@ impl<'d, T: Instance> Timer<'d, T> {
     /// Use [`Trigen::Software`] for software start. Any edge mode enables
     /// external trigger start.
     pub fn set_trigger_mode(&self, mode: Trigen) {
-        T::regs().cfgr().modify(|r| r.set_trigen(mode));
+        T::regs().cfgr().modify(|r| {
+            #[cfg(not(lptim_n6))]
+            r.set_trigen(mode);
+            #[cfg(lptim_n6)]
+            r.set_trigen(mode.to_bits());
+        });
     }
 
     /// Configure the digital filter applied to trigger input transitions.
     pub fn set_trigger_filter(&self, filter: Filter) {
-        T::regs().cfgr().modify(|r| r.set_trgflt(filter));
+        T::regs().cfgr().modify(|r| {
+            #[cfg(not(lptim_n6))]
+            r.set_trgflt(filter);
+            #[cfg(lptim_n6)]
+            r.set_trgflt(filter.to_bits());
+        });
     }
 
     /// Convenience helper to enable external trigger start with source, edge and filter.
@@ -113,10 +139,15 @@ impl<'d, T: Instance> Timer<'d, T> {
     }
 }
 
-#[cfg(any(lptim_v2a, lptim_v2b))]
+#[cfg(any(lptim_v2a, lptim_v2b, lptim_n6))]
 impl<'d, T: Instance> Timer<'d, T> {
     /// Enable/disable a channel.
     pub fn enable_channel(&self, channel: Channel, enable: bool) {
+        #[cfg(lptim_n6)]
+        T::regs().ccmr1().modify(|w| {
+            w.set_cce(channel.index(), enable);
+        });
+        #[cfg(not(lptim_n6))]
         T::regs().ccmr(0).modify(|w| {
             w.set_cce(channel.index(), enable);
         });
@@ -124,7 +155,14 @@ impl<'d, T: Instance> Timer<'d, T> {
 
     /// Get enable/disable state of a channel
     pub fn get_channel_enable_state(&self, channel: Channel) -> bool {
-        T::regs().ccmr(0).read().cce(channel.index())
+        #[cfg(lptim_n6)]
+        {
+            T::regs().ccmr1().read().cce(channel.index())
+        }
+        #[cfg(not(lptim_n6))]
+        {
+            T::regs().ccmr(0).read().cce(channel.index())
+        }
     }
 
     /// Set compare value for a channel.
@@ -138,40 +176,67 @@ impl<'d, T: Instance> Timer<'d, T> {
     }
 
     /// Set channel direction.
-    #[cfg(any(lptim_v2a, lptim_v2b))]
     pub fn set_channel_direction(&self, channel: Channel, direction: ChannelDirection) {
-        T::regs()
-            .ccmr(0)
-            .modify(|w| w.set_ccsel(channel.index(), direction.into()));
+        #[cfg(lptim_n6)]
+        T::regs().ccmr1().modify(|w| {
+            w.set_ccsel(channel.index(), direction.ccsel_bool());
+        });
+        #[cfg(not(lptim_n6))]
+        T::regs().ccmr(0).modify(|w| {
+            w.set_ccsel(channel.index(), direction.ccsel());
+        });
     }
 
     /// Enable the timer interrupt.
     pub fn enable_interrupt(&self) {
+        #[cfg(lptim_n6)]
+        T::regs().dier_output().modify(|w| w.set_arrmie(true));
+        #[cfg(not(lptim_n6))]
         T::regs().dier().modify(|w| w.set_arrmie(true));
     }
 
     /// Disable the timer interrupt.
     pub fn disable_interrupt(&self) {
+        #[cfg(lptim_n6)]
+        T::regs().dier_output().modify(|w| w.set_arrmie(false));
+        #[cfg(not(lptim_n6))]
         T::regs().dier().modify(|w| w.set_arrmie(false));
     }
 
     /// Check if the timer interrupt is enabled.
     pub fn is_interrupt_enabled(&self) -> bool {
-        T::regs().dier().read().arrmie()
+        #[cfg(lptim_n6)]
+        {
+            T::regs().dier_output().read().arrmie()
+        }
+        #[cfg(not(lptim_n6))]
+        {
+            T::regs().dier().read().arrmie()
+        }
     }
 
     /// Check if the timer interrupt is pending.
     pub fn is_interrupt_pending(&self) -> bool {
-        T::regs().isr().read().arrm()
+        #[cfg(lptim_n6)]
+        {
+            T::regs().isr_output().read().arrm()
+        }
+        #[cfg(not(lptim_n6))]
+        {
+            T::regs().isr().read().arrm()
+        }
     }
 
     /// Clear the timer interrupt.
     pub fn clear_interrupt(&self) {
+        #[cfg(lptim_n6)]
+        T::regs().icr_output().write(|w| w.set_arrmcf(true));
+        #[cfg(not(lptim_n6))]
         T::regs().icr().write(|w| w.set_arrmcf(true));
     }
 }
 
-#[cfg(not(any(lptim_v2a, lptim_v2b)))]
+#[cfg(not(any(lptim_v2a, lptim_v2b, lptim_n6)))]
 impl<'d, T: Instance> Timer<'d, T> {
     /// Set compare value for a channel.
     pub fn set_compare_value(&self, value: u16) {

--- a/embassy-stm32/src/lptim/timer/prescaler.rs
+++ b/embassy-stm32/src/lptim/timer/prescaler.rs
@@ -1,6 +1,6 @@
 //! Low-level timer driver.
 
-use crate::pac::lptim::vals;
+use crate::lptim::vals;
 
 pub enum Prescaler {
     Div1,

--- a/embassy-stm32/src/lptim/vals.rs
+++ b/embassy-stm32/src/lptim/vals.rs
@@ -1,0 +1,42 @@
+//! LPTIM register value enums.
+//!
+//! N6 (`lptim_n6`) PAC blocks omit the `vals` module; provide compatible enums here.
+
+#[cfg(not(lptim_n6))]
+pub use crate::pac::lptim::vals::*;
+
+#[cfg(lptim_n6)]
+mod imp {
+    u8_enum!(Ccsel {
+        OutputCompare = 0x0,
+        InputCapture = 0x01,
+    });
+
+    u8_enum!(Filter {
+        Count1 = 0x0,
+        Count2 = 0x01,
+        Count4 = 0x02,
+        Count8 = 0x03,
+    });
+
+    u8_enum!(Presc {
+        Div1 = 0x0,
+        Div2 = 0x01,
+        Div4 = 0x02,
+        Div8 = 0x03,
+        Div16 = 0x04,
+        Div32 = 0x05,
+        Div64 = 0x06,
+        Div128 = 0x07,
+    });
+
+    u8_enum!(Trigen {
+        Software = 0x0,
+        RisingEdge = 0x01,
+        FallingEdge = 0x02,
+        BothEdges = 0x03,
+    });
+}
+
+#[cfg(lptim_n6)]
+pub use imp::*;

--- a/embassy-stm32/src/macros.rs
+++ b/embassy-stm32/src/macros.rs
@@ -292,3 +292,44 @@ macro_rules! if_afio {
         impl $trait<$a, $b, $c>
     };
 }
+
+/// Defines a `u8`-backed enum with `from_bits`/`to_bits`/`From` conversions.
+///
+/// Used to shim PAC `vals` enums on chips whose generated PAC blocks omit
+/// the `vals` module entirely (e.g. N6 lptim/sai).
+macro_rules! u8_enum {
+    ($name:ident { $($variant:ident = $val:expr),* $(,)? }) => {
+        #[repr(u8)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
+        pub enum $name {
+            $($variant = $val,)*
+        }
+
+        impl $name {
+            #[inline(always)]
+            pub const fn from_bits(val: u8) -> Self {
+                unsafe { core::mem::transmute(val) }
+            }
+
+            #[inline(always)]
+            pub const fn to_bits(self) -> u8 {
+                self as u8
+            }
+        }
+
+        impl From<u8> for $name {
+            #[inline(always)]
+            fn from(val: u8) -> Self {
+                Self::from_bits(val)
+            }
+        }
+
+        impl From<$name> for u8 {
+            #[inline(always)]
+            fn from(val: $name) -> u8 {
+                val.to_bits()
+            }
+        }
+    };
+}

--- a/embassy-stm32/src/macros.rs
+++ b/embassy-stm32/src/macros.rs
@@ -297,6 +297,7 @@ macro_rules! if_afio {
 ///
 /// Used to shim PAC `vals` enums on chips whose generated PAC blocks omit
 /// the `vals` module entirely (e.g. N6 lptim/sai).
+#[cfg(any(sai_n6, lptim_n6))]
 macro_rules! u8_enum {
     ($name:ident { $($variant:ident = $val:expr),* $(,)? }) => {
         #[repr(u8)]

--- a/embassy-stm32/src/mce.rs
+++ b/embassy-stm32/src/mce.rs
@@ -1,0 +1,134 @@
+//! Memory Cipher Engine (MCE)
+//!
+//! MCE transparently encrypts/decrypts memory regions on the AXI bus. This is a
+//! minimal driver covering region configuration and illegal-access interrupts;
+//! cipher-context/key programming is left to the application via [`Mce::regs`].
+
+use core::marker::PhantomData;
+
+use embassy_hal_internal::{Peri, PeripheralType};
+
+use crate::interrupt::typelevel::Interrupt;
+use crate::pac::mce::Mce as Regs;
+use crate::pac::mce::regs::Iacr;
+use crate::rcc::{self, RccPeripheral};
+use crate::{interrupt, peripherals};
+
+/// One of four address regions on an MCE instance (0..3).
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+pub struct Region(pub u8);
+
+impl Region {
+    fn index(self) -> usize {
+        assert!(self.0 < 4);
+        self.0 as usize
+    }
+}
+
+/// Region address and encryption settings.
+#[derive(Clone, Copy, Debug)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+pub struct RegionConfig {
+    /// Inclusive start address (physical). Must be 4KiB-aligned.
+    pub start: u32,
+    /// Exclusive end address (physical). Must be 4KiB-aligned.
+    pub end: u32,
+    /// Cipher context ID (0..3).
+    pub context_id: u8,
+    /// When true, traffic in this region is encrypted.
+    pub encrypted: bool,
+}
+
+trait SealedInstance: RccPeripheral {
+    fn regs() -> Regs;
+}
+
+/// MCE instance trait.
+#[allow(private_bounds)]
+pub trait Instance: PeripheralType + SealedInstance + 'static {
+    type GlobalInterrupt: interrupt::typelevel::Interrupt;
+}
+
+/// Memory Cipher Engine driver.
+pub struct Mce<'d, T: Instance> {
+    _peri: Peri<'d, T>,
+}
+
+impl<'d, T: Instance> Mce<'d, T> {
+    /// Create a new MCE driver and enable its bus clock.
+    pub fn new(
+        peri: Peri<'d, T>,
+        _irq: impl interrupt::typelevel::Binding<T::GlobalInterrupt, GlobalInterruptHandler<T>> + 'd,
+    ) -> Self {
+        rcc::enable_and_reset::<T>();
+
+        T::GlobalInterrupt::unpend();
+        unsafe { T::GlobalInterrupt::enable() };
+
+        Self { _peri: peri }
+    }
+
+    /// Direct access to the underlying PAC registers.
+    pub fn regs() -> Regs {
+        T::regs()
+    }
+
+    /// Configure (but do not enable) a memory region.
+    ///
+    /// `config.start` and `config.end` must be aligned to the 4KiB block size.
+    pub fn configure_region(region: Region, config: RegionConfig) {
+        assert!(config.context_id < 4);
+        assert!(config.start < config.end);
+        assert!(config.start % 4096 == 0, "MCE region start must be 4KiB-aligned");
+        assert!(config.end % 4096 == 0, "MCE region end must be 4KiB-aligned");
+
+        let idx = region.index();
+        let start = config.start >> 12;
+        let end = (config.end - 1) >> 12;
+
+        T::regs().saddr(idx).write(|w| w.set_baddstart(start));
+        T::regs().eaddr(idx).write(|w| w.set_baddend(end));
+        T::regs().regcr(idx).modify(|w| {
+            w.set_ctxid(config.context_id);
+            w.set_enc(if config.encrypted { 1 } else { 0 });
+            w.set_bren(false);
+        });
+    }
+
+    /// Enable or disable a configured region.
+    pub fn set_region_enabled(region: Region, enabled: bool) {
+        T::regs().regcr(region.index()).modify(|w| w.set_bren(enabled));
+    }
+
+    /// Clear illegal-access status flags.
+    pub fn clear_illegal_access_flags() {
+        let iasr = T::regs().iasr().read().0;
+        T::regs().iacr().write_value(Iacr(iasr));
+    }
+}
+
+/// Global interrupt handler for illegal access events.
+pub struct GlobalInterruptHandler<T: Instance> {
+    _marker: PhantomData<T>,
+}
+
+impl<T: Instance> interrupt::typelevel::Handler<T::GlobalInterrupt> for GlobalInterruptHandler<T> {
+    unsafe fn on_interrupt() {
+        Mce::<T>::clear_illegal_access_flags();
+    }
+}
+
+foreach_peripheral!(
+    (mce, $inst:ident) => {
+        impl SealedInstance for peripherals::$inst {
+            fn regs() -> Regs {
+                crate::pac::$inst
+            }
+        }
+
+        impl Instance for peripherals::$inst {
+            type GlobalInterrupt = crate::_generated::peripheral_interrupts::$inst::GLOBAL;
+        }
+    };
+);

--- a/embassy-stm32/src/mce.rs
+++ b/embassy-stm32/src/mce.rs
@@ -47,6 +47,7 @@ trait SealedInstance: RccPeripheral {
 /// MCE instance trait.
 #[allow(private_bounds)]
 pub trait Instance: PeripheralType + SealedInstance + 'static {
+    /// Global interrupt for this instance.
     type GlobalInterrupt: interrupt::typelevel::Interrupt;
 }
 

--- a/embassy-stm32/src/mdf.rs
+++ b/embassy-stm32/src/mdf.rs
@@ -246,6 +246,11 @@ impl<'d, T: Instance, F: Filter> Mdf<'d, T, F> {
             w.set_cicmod(v::Cicmod::from_bits(Cicmod::Sinc5.to_bits()));
             #[cfg(not(mdf_n6))]
             w.set_mcicd(config.filter.cic_decimation);
+            #[cfg(mdf_n6)]
+            {
+                w.set_mcicd(config.filter.cic_decimation as u8);
+                w.set_mcicd8(config.filter.cic_decimation > 0xFF);
+            }
             w.set_scale(config.filter.scale);
         });
         regs.dfltrsfr(index).modify(|w| {

--- a/embassy-stm32/src/pka/mod.rs
+++ b/embassy-stm32/src/pka/mod.rs
@@ -1478,6 +1478,8 @@ impl<'d, T: Instance, M: Mode> Pka<'d, T, M> {
         const PKA_RAM_WORDS: usize = 1334;
         #[cfg(pka_v1c)]
         const PKA_RAM_WORDS: usize = 894;
+        #[cfg(pka_n6)]
+        const PKA_RAM_WORDS: usize = 1334;
 
         let p = T::regs();
         for i in 0..PKA_RAM_WORDS {

--- a/embassy-stm32/src/saes/mod.rs
+++ b/embassy-stm32/src/saes/mod.rs
@@ -98,13 +98,19 @@
 //! - [`aes`](crate::aes) - Standard AES implementation (all WBA chips)
 //! - [`pka`](crate::pka) - Public Key Accelerator
 
-// Re-export most types from AES since they're identical
+// Re-export cipher types from AES (WBA) or the shared crypto module (N6).
 use core::marker::PhantomData;
 
 use embassy_hal_internal::{Peri, PeripheralType};
 use embassy_sync::waitqueue::AtomicWaker;
 
+#[cfg(aes_v3b)]
 pub use crate::aes::{
+    AesCbc, AesCcm, AesCtr, AesEcb, AesGcm, Cipher, CipherAuthenticated, CipherSized, Context, Direction, Error,
+    IVSized, KeySize,
+};
+#[cfg(all(saes_n6, not(aes_v3b)))]
+pub use crate::crypto::{
     AesCbc, AesCcm, AesCtr, AesEcb, AesGcm, Cipher, CipherAuthenticated, CipherSized, Context, Direction, Error,
     IVSized, KeySize,
 };
@@ -114,6 +120,95 @@ use crate::mode::{Async, Blocking, Mode};
 use crate::{interrupt, pac, peripherals, rcc};
 
 static SAES_WAKER: AtomicWaker = AtomicWaker::new();
+
+#[inline]
+fn set_chmod(p: pac::saes::Saes, bits: u8) {
+    p.cr().modify(|w| {
+        #[cfg(not(saes_n6))]
+        w.set_chmod(pac::saes::vals::Chmod::from_bits(bits));
+        #[cfg(saes_n6)]
+        {
+            w.set_chmod(bits & 0x3);
+            w.set_chmod_1((bits >> 2) & 1 != 0);
+        }
+    });
+}
+
+#[inline]
+fn set_mode(p: pac::saes::Saes, mode: u8) {
+    p.cr().modify(|w| {
+        #[cfg(not(saes_n6))]
+        w.set_mode(pac::saes::vals::Mode::from_bits(mode));
+        #[cfg(saes_n6)]
+        w.set_mode(mode);
+    });
+}
+
+#[inline]
+fn set_datatype(p: pac::saes::Saes, datatype: u8) {
+    p.cr().modify(|w| {
+        #[cfg(not(saes_n6))]
+        w.set_datatype(pac::saes::vals::Datatype::from_bits(datatype));
+        #[cfg(saes_n6)]
+        w.set_datatype(datatype);
+    });
+}
+
+#[inline]
+fn set_keysize(p: pac::saes::Saes, keysize: KeySize) {
+    p.cr().modify(|w| {
+        #[cfg(not(saes_n6))]
+        {
+            let val = match keysize {
+                KeySize::Bits128 => pac::saes::vals::Keysize::Bits128,
+                KeySize::Bits256 => pac::saes::vals::Keysize::Bits256,
+            };
+            w.set_keysize(val);
+        }
+        #[cfg(saes_n6)]
+        w.set_keysize(keysize == KeySize::Bits256);
+    });
+}
+
+#[inline]
+fn set_kmod(p: pac::saes::Saes, key_mode: KeyMode) {
+    p.cr().modify(|w| {
+        #[cfg(not(saes_n6))]
+        w.set_kmod(pac::saes::vals::Kmod::from_bits(key_mode as u8));
+        #[cfg(saes_n6)]
+        w.set_kmod(key_mode as u8);
+    });
+}
+
+#[inline]
+fn set_gcmph(p: pac::saes::Saes, phase: u8) {
+    p.cr().modify(|w| {
+        #[cfg(not(saes_n6))]
+        w.set_gcmph(pac::saes::vals::Gcmph::from_bits(phase));
+        #[cfg(saes_n6)]
+        w.set_gcmph(phase);
+    });
+}
+
+#[inline]
+fn set_keysel(p: pac::saes::Saes, hw_key_src: HardwareKeySource) {
+    p.cr().modify(|w| {
+        #[cfg(not(saes_n6))]
+        w.set_keysel(pac::saes::vals::Keysel::from_bits(hw_key_src as u8));
+        #[cfg(saes_n6)]
+        w.set_keysel(hw_key_src as u8);
+    });
+}
+
+#[inline]
+fn set_kshareid(p: pac::saes::Saes, target: KeyShareTarget) {
+    p.cr().modify(|w| {
+        #[cfg(not(saes_n6))]
+        w.set_kshareid(pac::saes::vals::Kshareid::from_bits(target as u8));
+        #[cfg(saes_n6)]
+        w.set_kshareid(target as u8);
+    });
+}
 
 /// SAES interrupt handler.
 pub struct InterruptHandler<T: Instance> {
@@ -359,16 +454,11 @@ impl<'d, T: Instance, M: Mode> Saes<'d, T, M> {
         p.icr().write(|w| w.0 = 0xFFFF_FFFF);
 
         // Configure data type based on cipher mode (NO_SWAP, BYTE_SWAP, or BIT_SWAP)
-        p.cr()
-            .modify(|w| w.set_datatype(pac::saes::vals::Datatype::from_bits(cipher.datatype())));
+        set_datatype(p, cipher.datatype());
 
         // Configure key size
         let keysize = cipher.key_size();
-        let keysize_val = match keysize {
-            KeySize::Bits128 => pac::saes::vals::Keysize::Bits128,
-            KeySize::Bits256 => pac::saes::vals::Keysize::Bits256,
-        };
-        p.cr().modify(|w| w.set_keysize(keysize_val));
+        set_keysize(p, keysize);
         // Changing KEYSIZE may trigger a new RNG mask fetch (BUSY=1) inside SAES,
         // particularly when switching from 128-bit to 256-bit, which needs a larger mask.
         while p.sr().read().busy() {}
@@ -378,25 +468,19 @@ impl<'d, T: Instance, M: Mode> Saes<'d, T, M> {
         let is_gcm_ccm = cipher.uses_gcm_phases();
 
         // Set direction
-        let mode_val = match dir {
-            Direction::Encrypt => pac::saes::vals::Mode::Encryption,
-            Direction::Decrypt => pac::saes::vals::Mode::Decryption,
-        };
-        p.cr().modify(|w| w.set_mode(mode_val));
+        set_mode(p, dir as u8);
 
         // Set key mode
-        let kmod_val = pac::saes::vals::Kmod::from_bits(key_mode as u8);
-        p.cr().modify(|w| w.set_kmod(kmod_val));
+        set_kmod(p, key_mode);
 
         // For GCM/CCM (authenticated) modes, set GCMPH=0 (init phase) BEFORE loading the key.
         if is_gcm_ccm {
-            p.cr().modify(|w| w.set_gcmph(pac::saes::vals::Gcmph::from_bits(0)));
+            set_gcmph(p, 0);
         }
 
         // Configure and load the key (after GCMPH is set).
         if let Some(hw_key_src) = hw_key {
-            let keysel_val = pac::saes::vals::Keysel::from_bits(hw_key_src as u8);
-            p.cr().modify(|w| w.set_keysel(keysel_val));
+            set_keysel(p, hw_key_src);
             p.cr().modify(|w| w.set_keyprot(true));
             // For hardware keys (non-SW), SAES fetches the key autonomously: wait for KEYVALID.
             while !p.sr().read().keyvalid() {}
@@ -412,14 +496,14 @@ impl<'d, T: Instance, M: Mode> Saes<'d, T, M> {
         // CTR, GCM, and CCM use the encryption key schedule in both directions - no derivation.
         let needs_key_derivation = dir == Direction::Decrypt && matches!(cipher.chmod_bits(), 0 | 1);
         if needs_key_derivation {
-            p.cr().modify(|w| w.set_mode(pac::saes::vals::Mode::KeyDerivation));
+            set_mode(p, 1);
             p.cr().modify(|w| w.set_en(true));
             // Wait for CCF (computation complete), not BUSY
             while !p.isr().read().ccf() {}
             // Clear CCF via ICR
             p.icr().write(|w| w.0 = 0xFFFF_FFFF);
             // Restore decrypt mode for the actual operation
-            p.cr().modify(|w| w.set_mode(mode_val));
+            set_mode(p, dir as u8);
         }
 
         // Load IV
@@ -461,11 +545,7 @@ impl<'d, T: Instance, M: Mode> Saes<'d, T, M> {
     /// Share the current unwrapped key with another peripheral.
     /// This must be called after a decryption operation that unwrapped a key.
     pub fn share_key_with(&mut self, target: KeyShareTarget) {
-        let p = T::regs();
-        let kshareid_val = match target {
-            KeyShareTarget::AES => pac::saes::vals::Kshareid::Aes,
-        };
-        p.cr().modify(|w| w.set_kshareid(kshareid_val));
+        set_kshareid(T::regs(), target);
     }
 
     /// Set cipher mode for SAES peripheral using the cipher's CHMOD bits.
@@ -473,11 +553,7 @@ impl<'d, T: Instance, M: Mode> Saes<'d, T, M> {
     where
         C: Cipher<'c>,
     {
-        // Use the cipher's canonical CHMOD value (0=ECB, 1=CBC, 2=CTR, 3=GCM/GMAC, 4=CCM).
-        // Inferring mode from IV length is unreliable: GCM, CBC, and CTR all use 16-byte IVs
-        // after AesGcm::new() pads the 12-byte nonce to 16 bytes.
-        p.cr()
-            .modify(|w| w.set_chmod(pac::saes::vals::Chmod::from_bits(cipher.chmod_bits())));
+        set_chmod(p, cipher.chmod_bits());
     }
 
     /// Process authenticated additional data (AAD) for GCM/CCM modes.
@@ -494,7 +570,7 @@ impl<'d, T: Instance, M: Mode> Saes<'d, T, M> {
 
         // Set GCM phase to header (phase 1), then re-enable.
         // After the init phase SAES auto-clears EN, so we must set EN=1 here.
-        p.cr().modify(|w| w.set_gcmph(pac::saes::vals::Gcmph::from_bits(1)));
+        set_gcmph(p, 1);
         p.cr().modify(|w| w.set_en(true));
 
         let mut aad_remaining = aad.len();
@@ -582,7 +658,7 @@ impl<'d, T: Instance, M: Mode> Saes<'d, T, M> {
             if !ctx.header_processed {
                 ctx.header_processed = true;
             }
-            p.cr().modify(|w| w.set_gcmph(pac::saes::vals::Gcmph::from_bits(2)));
+            set_gcmph(p, 2);
             p.cr().modify(|w| w.set_npblb(0));
             p.cr().modify(|w| w.set_en(true));
         }
@@ -656,7 +732,7 @@ impl<'d, T: Instance, M: Mode> Saes<'d, T, M> {
             while p.sr().read().busy() {}
 
             // Set GCM phase to final (phase 3)
-            p.cr().modify(|w| w.set_gcmph(pac::saes::vals::Gcmph::from_bits(3)));
+            set_gcmph(p, 3);
 
             // Write lengths (in bits) as final block
             let header_bits = (ctx.header_len * 8) as u64;
@@ -728,7 +804,12 @@ impl<'d, T: Instance, M: Mode> Saes<'d, T, M> {
         let p = T::regs();
 
         // Check for write error before starting
+        #[cfg(not(saes_n6))]
         if p.sr().read().wrerr() {
+            return Err(Error::WriteError);
+        }
+        #[cfg(saes_n6)]
+        if p.sr().read().wrerrf() {
             return Err(Error::WriteError);
         }
 

--- a/embassy-stm32/src/saes/mod.rs
+++ b/embassy-stm32/src/saes/mod.rs
@@ -111,8 +111,8 @@ pub use crate::aes::{
 };
 #[cfg(all(saes_n6, not(aes_v3b)))]
 pub use crate::crypto::{
-    AesCbc, AesCcm, AesCtr, AesEcb, AesGcm, Cipher, CipherAuthenticated, CipherSized, Context, Direction, Error,
-    IVSized, KeySize,
+    AesCbc, AesCcm, AesCtr, AesEcb, AesGcm, AesGmac, Cipher, CipherAuthenticated, CipherSized, Context, Direction,
+    Error, IVSized, KeySize,
 };
 use crate::dma::ChannelAndRequest;
 use crate::interrupt::typelevel::Interrupt;

--- a/embassy-stm32/src/sai/mod.rs
+++ b/embassy-stm32/src/sai/mod.rs
@@ -1,6 +1,9 @@
 //! Serial Audio Interface (SAI)
 #![macro_use]
 
+mod regs;
+pub(crate) mod vals;
+
 use core::marker::PhantomData;
 
 use embassy_hal_internal::PeripheralType;
@@ -8,9 +11,9 @@ use embassy_hal_internal::PeripheralType;
 pub use crate::dma::word;
 use crate::dma::{self, Channel, ReadableRingBuffer, Request, TransferOptions, WritableRingBuffer, ringbuffer};
 use crate::gpio::{AfType, Flex, OutputType, Pull, Speed};
-pub use crate::pac::sai::vals::Mckdiv as MasterClockDivider;
-use crate::pac::sai::{Sai as Regs, vals};
+use crate::pac::sai::Sai as Regs;
 use crate::rcc::{self, RccPeripheral};
+pub use crate::sai::vals::Mckdiv as MasterClockDivider;
 use crate::{Peri, interrupt, peripherals};
 
 /// SAI error
@@ -182,7 +185,7 @@ pub enum SyncInput {
     /// Syncs with the other A/B sub-block within the SAI unit
     Internal,
     /// Syncs with a sub-block in the other SAI unit
-    #[cfg(any(sai_v3, sai_v4))]
+    #[cfg(any(sai_v3, sai_v4, sai_n6))]
     External(SyncInputInstance),
 }
 
@@ -191,14 +194,14 @@ impl SyncInput {
         match self {
             SyncInput::None => vals::Syncen::Asynchronous,
             SyncInput::Internal => vals::Syncen::Internal,
-            #[cfg(any(sai_v3, sai_v4))]
+            #[cfg(any(sai_v3, sai_v4, sai_n6))]
             SyncInput::External(_) => vals::Syncen::External,
         }
     }
 }
 
 /// SAI instance to sync from.
-#[cfg(any(sai_v3, sai_v4))]
+#[cfg(any(sai_v3, sai_v4, sai_n6))]
 #[derive(Copy, Clone, PartialEq)]
 #[allow(missing_docs)]
 pub enum SyncInputInstance {
@@ -502,7 +505,7 @@ fn update_synchronous_config(config: &mut Config) {
         config.sync_input = SyncInput::Internal;
     }
 
-    #[cfg(any(sai_v3, sai_v4))]
+    #[cfg(any(sai_v3, sai_v4, sai_n6))]
     {
         //this must either be Internal or External
         //The asynchronous sub-block on the same SAI needs to enable sync_output
@@ -646,7 +649,7 @@ impl<'d, T: Instance, W: word::Word> Sai<'d, T, W> {
 
         ch.cr2().modify(|w| w.set_fflush(true));
 
-        #[cfg(any(sai_v3, sai_v4))]
+        #[cfg(any(sai_v3, sai_v4, sai_n6))]
         {
             if let SyncInput::External(i) = config.sync_input {
                 T::REGS.gcr().modify(|w| {
@@ -665,47 +668,15 @@ impl<'d, T: Instance, W: word::Word> Sai<'d, T, W> {
             }
         }
 
-        ch.cr1().modify(|w| {
-            w.set_mode(config.mode.mode(if Self::is_transmitter(&ring_buffer) {
-                TxRx::Transmitter
-            } else {
-                TxRx::Receiver
-            }));
-            w.set_prtcfg(config.protocol.prtcfg());
-            w.set_ds(config.data_size.ds());
-            w.set_lsbfirst(config.bit_order.lsbfirst());
-            w.set_ckstr(config.clock_strobe.ckstr());
-            w.set_syncen(config.sync_input.syncen());
-            w.set_mono(config.stereo_mono.mono());
-            w.set_outdriv(config.output_drive.outdriv());
-            w.set_mckdiv(config.master_clock_divider);
-            w.set_nodiv(config.nodiv);
-            w.set_dmaen(true);
-        });
-
-        ch.cr2().modify(|w| {
-            w.set_fth(config.fifo_threshold.fth());
-            w.set_comp(config.companding.comp());
-            w.set_cpl(config.complement_format.cpl());
-            w.set_muteval(config.mute_value.muteval());
-            w.set_mutecnt(config.mute_detection_counter.0 as u8);
-            w.set_tris(config.is_high_impedance_on_inactive_slot);
-        });
-
-        ch.frcr().modify(|w| {
-            w.set_fsoff(config.frame_sync_offset.fsoff());
-            w.set_fspol(config.frame_sync_polarity.fspol());
-            w.set_fsdef(config.frame_sync_definition.fsdef());
-            w.set_fsall(config.frame_sync_active_level_length.0 as u8 - 1);
-            w.set_frl((config.frame_length - 1).try_into().unwrap());
-        });
-
-        ch.slotr().modify(|w| {
-            w.set_nbslot(config.slot_count.0 as u8 - 1);
-            w.set_slotsz(config.slot_size.slotsz());
-            w.set_fboff(config.first_bit_offset.0 as u8);
-            w.set_sloten(vals::Sloten::from_bits(config.slot_enable as u16));
-        });
+        let tx_rx = if Self::is_transmitter(&ring_buffer) {
+            TxRx::Transmitter
+        } else {
+            TxRx::Receiver
+        };
+        regs::configure_cr1(ch, &config, tx_rx);
+        regs::configure_cr2(ch, &config);
+        regs::configure_frcr(ch, &config);
+        regs::configure_slotr(ch, &config);
 
         ch.cr1().modify(|w| w.set_saien(true));
 

--- a/embassy-stm32/src/sai/regs.rs
+++ b/embassy-stm32/src/sai/regs.rs
@@ -1,0 +1,108 @@
+//! SAI register write helpers for PAC variants without typed field setters.
+
+use super::{Config, TxRx};
+use crate::pac::sai::Ch;
+
+#[cfg(not(sai_n6))]
+pub(crate) fn configure_cr1(ch: Ch, config: &Config, tx_rx: TxRx) {
+    let mode = config.mode.mode(tx_rx);
+
+    ch.cr1().modify(|w| {
+        w.set_mode(mode);
+        w.set_prtcfg(config.protocol.prtcfg());
+        w.set_ds(config.data_size.ds());
+        w.set_lsbfirst(config.bit_order.lsbfirst());
+        w.set_ckstr(config.clock_strobe.ckstr());
+        w.set_syncen(config.sync_input.syncen());
+        w.set_mono(config.stereo_mono.mono());
+        w.set_outdriv(config.output_drive.outdriv());
+        w.set_mckdiv(config.master_clock_divider);
+        w.set_nodiv(config.nodiv);
+        w.set_dmaen(true);
+    });
+}
+
+#[cfg(sai_n6)]
+pub(crate) fn configure_cr1(ch: Ch, config: &Config, tx_rx: TxRx) {
+    let mode = config.mode.mode(tx_rx);
+
+    ch.cr1().modify(|w| {
+        w.set_mode(mode.to_bits());
+        w.set_prtcfg(config.protocol.prtcfg().to_bits());
+        w.set_ds(config.data_size.ds().to_bits());
+        w.set_lsbfirst(config.bit_order.lsbfirst().to_bits() != 0);
+        w.set_ckstr(config.clock_strobe.ckstr().to_bits() != 0);
+        w.set_syncen(config.sync_input.syncen().to_bits());
+        w.set_mono(config.stereo_mono.mono().to_bits() != 0);
+        w.set_outdriv(config.output_drive.outdriv().to_bits() != 0);
+        w.set_mckdiv(config.master_clock_divider.to_bits());
+        w.set_nodiv(config.nodiv);
+        w.set_dmaen(true);
+    });
+}
+
+#[cfg(not(sai_n6))]
+pub(crate) fn configure_cr2(ch: Ch, config: &Config) {
+    ch.cr2().modify(|w| {
+        w.set_fth(config.fifo_threshold.fth());
+        w.set_comp(config.companding.comp());
+        w.set_cpl(config.complement_format.cpl());
+        w.set_muteval(config.mute_value.muteval());
+        w.set_mutecnt(config.mute_detection_counter.0 as u8);
+        w.set_tris(config.is_high_impedance_on_inactive_slot);
+    });
+}
+
+#[cfg(sai_n6)]
+pub(crate) fn configure_cr2(ch: Ch, config: &Config) {
+    ch.cr2().modify(|w| {
+        w.set_fth(config.fifo_threshold.fth().to_bits());
+        w.set_comp(config.companding.comp().to_bits());
+        w.set_cpl(config.complement_format.cpl().to_bits() != 0);
+        w.set_muteval(config.mute_value.muteval().to_bits() != 0);
+        w.set_mutecnt(config.mute_detection_counter.0 as u8);
+        w.set_tris(config.is_high_impedance_on_inactive_slot);
+    });
+}
+
+#[cfg(not(sai_n6))]
+pub(crate) fn configure_frcr(ch: Ch, config: &Config) {
+    ch.frcr().modify(|w| {
+        w.set_fsoff(config.frame_sync_offset.fsoff());
+        w.set_fspol(config.frame_sync_polarity.fspol());
+        w.set_fsdef(config.frame_sync_definition.fsdef());
+        w.set_fsall(config.frame_sync_active_level_length.0 as u8 - 1);
+        w.set_frl((config.frame_length - 1).try_into().unwrap());
+    });
+}
+
+#[cfg(sai_n6)]
+pub(crate) fn configure_frcr(ch: Ch, config: &Config) {
+    ch.frcr().modify(|w| {
+        w.set_fsoff(config.frame_sync_offset.fsoff().to_bits() != 0);
+        w.set_fspol(config.frame_sync_polarity.fspol().to_bits() != 0);
+        w.set_fsdef(config.frame_sync_definition.fsdef());
+        w.set_fsall(config.frame_sync_active_level_length.0 as u8 - 1);
+        w.set_frl((config.frame_length - 1).try_into().unwrap());
+    });
+}
+
+#[cfg(not(sai_n6))]
+pub(crate) fn configure_slotr(ch: Ch, config: &Config) {
+    ch.slotr().modify(|w| {
+        w.set_nbslot(config.slot_count.0 as u8 - 1);
+        w.set_fboff(config.first_bit_offset.0 as u8);
+        w.set_slotsz(config.slot_size.slotsz());
+        w.set_sloten(super::vals::Sloten::from_bits(config.slot_enable as u16));
+    });
+}
+
+#[cfg(sai_n6)]
+pub(crate) fn configure_slotr(ch: Ch, config: &Config) {
+    ch.slotr().modify(|w| {
+        w.set_nbslot(config.slot_count.0 as u8 - 1);
+        w.set_fboff(config.first_bit_offset.0 as u8);
+        w.set_slotsz(config.slot_size.slotsz().to_bits());
+        w.set_sloten(config.slot_enable);
+    });
+}

--- a/embassy-stm32/src/sai/vals.rs
+++ b/embassy-stm32/src/sai/vals.rs
@@ -1,0 +1,196 @@
+//! SAI register value enums.
+//!
+//! N6 (`sai_n6`) PAC blocks omit the `vals` module; provide compatible enums here.
+
+#[cfg(not(sai_n6))]
+pub use crate::pac::sai::vals::*;
+
+#[cfg(sai_n6)]
+mod imp {
+    u8_enum!(Ckstr {
+        FallingEdge = 0x0,
+        RisingEdge = 0x01,
+    });
+
+    u8_enum!(Comp {
+        NoCompanding = 0x0,
+        MuLaw = 0x02,
+        ALaw = 0x03,
+    });
+
+    u8_enum!(Cpl {
+        OnesComplement = 0x0,
+        TwosComplement = 0x01,
+    });
+
+    u8_enum!(Ds {
+        Bit8 = 0x02,
+        Bit10 = 0x03,
+        Bit16 = 0x04,
+        Bit20 = 0x05,
+        Bit24 = 0x06,
+        Bit32 = 0x07,
+    });
+
+    u8_enum!(Fsoff {
+        OnFirst = 0x0,
+        BeforeFirst = 0x01,
+    });
+
+    u8_enum!(Fspol {
+        FallingEdge = 0x0,
+        RisingEdge = 0x01,
+    });
+
+    u8_enum!(Fth {
+        Empty = 0x0,
+        Quarter1 = 0x01,
+        Quarter2 = 0x02,
+        Quarter3 = 0x03,
+        Full = 0x05,
+    });
+
+    u8_enum!(Lsbfirst {
+        LsbFirst = 0x0,
+        MsbFirst = 0x01,
+    });
+
+    // Full divider range uses the same bit layout as SAI v3.
+    #[repr(u8)]
+    #[derive(Copy, Clone, Debug, Eq, PartialEq)]
+    #[cfg_attr(feature = "defmt", derive(defmt::Format))]
+    pub enum Mckdiv {
+        Div1 = 0x01,
+        Div2 = 0x02,
+        Div3 = 0x03,
+        Div4 = 0x04,
+        Div5 = 0x05,
+        Div6 = 0x06,
+        Div7 = 0x07,
+        Div8 = 0x08,
+        Div9 = 0x09,
+        Div10 = 0x0a,
+        Div11 = 0x0b,
+        Div12 = 0x0c,
+        Div13 = 0x0d,
+        Div14 = 0x0e,
+        Div15 = 0x0f,
+        Div16 = 0x10,
+        Div17 = 0x11,
+        Div18 = 0x12,
+        Div19 = 0x13,
+        Div20 = 0x14,
+        Div21 = 0x15,
+        Div22 = 0x16,
+        Div23 = 0x17,
+        Div24 = 0x18,
+        Div25 = 0x19,
+        Div26 = 0x1a,
+        Div27 = 0x1b,
+        Div28 = 0x1c,
+        Div29 = 0x1d,
+        Div30 = 0x1e,
+        Div31 = 0x1f,
+        Div32 = 0x20,
+        Div33 = 0x21,
+        Div34 = 0x22,
+        Div35 = 0x23,
+        Div36 = 0x24,
+        Div37 = 0x25,
+        Div38 = 0x26,
+        Div39 = 0x27,
+        Div40 = 0x28,
+        Div41 = 0x29,
+        Div42 = 0x2a,
+        Div43 = 0x2b,
+        Div44 = 0x2c,
+        Div45 = 0x2d,
+        Div46 = 0x2e,
+        Div47 = 0x2f,
+        Div48 = 0x30,
+        Div49 = 0x31,
+        Div50 = 0x32,
+        Div51 = 0x33,
+        Div52 = 0x34,
+        Div53 = 0x35,
+        Div54 = 0x36,
+        Div55 = 0x37,
+        Div56 = 0x38,
+        Div57 = 0x39,
+        Div58 = 0x3a,
+        Div59 = 0x3b,
+        Div60 = 0x3c,
+        Div61 = 0x3d,
+        Div62 = 0x3e,
+        Div63 = 0x3f,
+    }
+
+    impl Mckdiv {
+        #[inline(always)]
+        pub const fn from_bits(val: u8) -> Self {
+            unsafe { core::mem::transmute(val & 0x3f) }
+        }
+
+        #[inline(always)]
+        pub const fn to_bits(self) -> u8 {
+            unsafe { core::mem::transmute(self) }
+        }
+    }
+
+    impl From<u8> for Mckdiv {
+        #[inline(always)]
+        fn from(val: u8) -> Self {
+            Mckdiv::from_bits(val)
+        }
+    }
+
+    impl From<Mckdiv> for u8 {
+        #[inline(always)]
+        fn from(val: Mckdiv) -> u8 {
+            Mckdiv::to_bits(val)
+        }
+    }
+
+    u8_enum!(Mode {
+        MasterTx = 0x0,
+        MasterRx = 0x01,
+        SlaveTx = 0x02,
+        SlaveRx = 0x03,
+    });
+
+    u8_enum!(Mono {
+        Stereo = 0x0,
+        Mono = 0x01,
+    });
+
+    u8_enum!(Muteval {
+        SendZero = 0x0,
+        SendLast = 0x01,
+    });
+
+    u8_enum!(Outdriv {
+        OnStart = 0x0,
+        Immediately = 0x01,
+    });
+
+    u8_enum!(Prtcfg {
+        Free = 0x0,
+        Spdif = 0x01,
+        Ac97 = 0x02,
+    });
+
+    u8_enum!(Slotsz {
+        DataSize = 0x0,
+        Bit16 = 0x01,
+        Bit32 = 0x02,
+    });
+
+    u8_enum!(Syncen {
+        Asynchronous = 0x0,
+        Internal = 0x01,
+        External = 0x02,
+    });
+}
+
+#[cfg(sai_n6)]
+pub use imp::*;

--- a/embassy-stm32/src/sai/vals.rs
+++ b/embassy-stm32/src/sai/vals.rs
@@ -59,78 +59,144 @@ mod imp {
     #[repr(u8)]
     #[derive(Copy, Clone, Debug, Eq, PartialEq)]
     #[cfg_attr(feature = "defmt", derive(defmt::Format))]
+    /// SAI master clock divider (`MCKDIV` field), full range (1..63).
     pub enum Mckdiv {
+        /// Master clock divider = 1.
         Div1 = 0x01,
+        /// Master clock divider = 2.
         Div2 = 0x02,
+        /// Master clock divider = 3.
         Div3 = 0x03,
+        /// Master clock divider = 4.
         Div4 = 0x04,
+        /// Master clock divider = 5.
         Div5 = 0x05,
+        /// Master clock divider = 6.
         Div6 = 0x06,
+        /// Master clock divider = 7.
         Div7 = 0x07,
+        /// Master clock divider = 8.
         Div8 = 0x08,
+        /// Master clock divider = 9.
         Div9 = 0x09,
+        /// Master clock divider = 10.
         Div10 = 0x0a,
+        /// Master clock divider = 11.
         Div11 = 0x0b,
+        /// Master clock divider = 12.
         Div12 = 0x0c,
+        /// Master clock divider = 13.
         Div13 = 0x0d,
+        /// Master clock divider = 14.
         Div14 = 0x0e,
+        /// Master clock divider = 15.
         Div15 = 0x0f,
+        /// Master clock divider = 16.
         Div16 = 0x10,
+        /// Master clock divider = 17.
         Div17 = 0x11,
+        /// Master clock divider = 18.
         Div18 = 0x12,
+        /// Master clock divider = 19.
         Div19 = 0x13,
+        /// Master clock divider = 20.
         Div20 = 0x14,
+        /// Master clock divider = 21.
         Div21 = 0x15,
+        /// Master clock divider = 22.
         Div22 = 0x16,
+        /// Master clock divider = 23.
         Div23 = 0x17,
+        /// Master clock divider = 24.
         Div24 = 0x18,
+        /// Master clock divider = 25.
         Div25 = 0x19,
+        /// Master clock divider = 26.
         Div26 = 0x1a,
+        /// Master clock divider = 27.
         Div27 = 0x1b,
+        /// Master clock divider = 28.
         Div28 = 0x1c,
+        /// Master clock divider = 29.
         Div29 = 0x1d,
+        /// Master clock divider = 30.
         Div30 = 0x1e,
+        /// Master clock divider = 31.
         Div31 = 0x1f,
+        /// Master clock divider = 32.
         Div32 = 0x20,
+        /// Master clock divider = 33.
         Div33 = 0x21,
+        /// Master clock divider = 34.
         Div34 = 0x22,
+        /// Master clock divider = 35.
         Div35 = 0x23,
+        /// Master clock divider = 36.
         Div36 = 0x24,
+        /// Master clock divider = 37.
         Div37 = 0x25,
+        /// Master clock divider = 38.
         Div38 = 0x26,
+        /// Master clock divider = 39.
         Div39 = 0x27,
+        /// Master clock divider = 40.
         Div40 = 0x28,
+        /// Master clock divider = 41.
         Div41 = 0x29,
+        /// Master clock divider = 42.
         Div42 = 0x2a,
+        /// Master clock divider = 43.
         Div43 = 0x2b,
+        /// Master clock divider = 44.
         Div44 = 0x2c,
+        /// Master clock divider = 45.
         Div45 = 0x2d,
+        /// Master clock divider = 46.
         Div46 = 0x2e,
+        /// Master clock divider = 47.
         Div47 = 0x2f,
+        /// Master clock divider = 48.
         Div48 = 0x30,
+        /// Master clock divider = 49.
         Div49 = 0x31,
+        /// Master clock divider = 50.
         Div50 = 0x32,
+        /// Master clock divider = 51.
         Div51 = 0x33,
+        /// Master clock divider = 52.
         Div52 = 0x34,
+        /// Master clock divider = 53.
         Div53 = 0x35,
+        /// Master clock divider = 54.
         Div54 = 0x36,
+        /// Master clock divider = 55.
         Div55 = 0x37,
+        /// Master clock divider = 56.
         Div56 = 0x38,
+        /// Master clock divider = 57.
         Div57 = 0x39,
+        /// Master clock divider = 58.
         Div58 = 0x3a,
+        /// Master clock divider = 59.
         Div59 = 0x3b,
+        /// Master clock divider = 60.
         Div60 = 0x3c,
+        /// Master clock divider = 61.
         Div61 = 0x3d,
+        /// Master clock divider = 62.
         Div62 = 0x3e,
+        /// Master clock divider = 63.
         Div63 = 0x3f,
     }
 
     impl Mckdiv {
+        /// Construct from the raw `MCKDIV` field value (masked to 6 bits).
         #[inline(always)]
         pub const fn from_bits(val: u8) -> Self {
             unsafe { core::mem::transmute(val & 0x3f) }
         }
 
+        /// Returns the raw `MCKDIV` field value.
         #[inline(always)]
         pub const fn to_bits(self) -> u8 {
             unsafe { core::mem::transmute(self) }

--- a/embassy-stm32/src/spdifrx/mod.rs
+++ b/embassy-stm32/src/spdifrx/mod.rs
@@ -64,12 +64,20 @@ pub struct Spdifrx<'d, T: Instance> {
 
 /// Gives the address of the data register.
 fn dr_address(r: Regs) -> *mut u32 {
-    #[cfg(spdifrx_v1)]
+    #[cfg(any(spdifrx_v1, spdifrx_n6))]
     let address = r.dr().as_ptr() as _;
     #[cfg(spdifrx_h7)]
     let address = r.fmt0_dr().as_ptr() as _; // All fmtx_dr() implementations have the same address.
 
     return address;
+}
+
+#[inline]
+fn set_spdifen(cr: &mut crate::pac::spdifrx::regs::Cr, val: u8) {
+    #[cfg(spdifrx_n6)]
+    cr.set_spdifrxen(val);
+    #[cfg(not(spdifrx_n6))]
+    cr.set_spdifen(val);
 }
 
 /// Gives the address of the channel status register.
@@ -173,7 +181,7 @@ impl<'d, T: Instance> Spdifrx<'d, T> {
         });
 
         regs.cr().write(|cr| {
-            cr.set_spdifen(0x00); // Disable SPDIF receiver synchronization.
+            set_spdifen(cr, 0x00); // Disable SPDIF receiver synchronization.
             cr.set_rxdmaen(true); // Use RX DMA for data. Enabled on `read`.
             cr.set_cbdmaen(false); // Do not capture channel info.
             cr.set_rxsteo(true); // Operate in stereo mode.
@@ -208,7 +216,7 @@ impl<'d, T: Instance> Spdifrx<'d, T> {
         self.data_ring_buffer.start();
 
         T::info().regs.cr().modify(|cr| {
-            cr.set_spdifen(0x03); // Enable S/PDIF receiver.
+            set_spdifen(cr, 0x03); // Enable S/PDIF receiver.
         });
     }
 
@@ -246,7 +254,7 @@ impl<'d, T: Instance> Spdifrx<'d, T> {
 
 impl<'d, T: Instance> Drop for Spdifrx<'d, T> {
     fn drop(&mut self) {
-        T::info().regs.cr().modify(|cr| cr.set_spdifen(0x00));
+        T::info().regs.cr().modify(|cr| set_spdifen(cr, 0x00));
     }
 }
 
@@ -298,8 +306,8 @@ impl<T: Instance> interrupt::typelevel::Handler<T::GlobalInterrupt> for GlobalIn
             trace!("SPDIFRX error, resync");
 
             // Clear errors by disabling SPDIFRX, then reenable.
-            regs.cr().modify(|cr| cr.set_spdifen(0x00));
-            regs.cr().modify(|cr| cr.set_spdifen(0x03));
+            regs.cr().modify(|cr| set_spdifen(cr, 0x00));
+            regs.cr().modify(|cr| set_spdifen(cr, 0x03));
         } else if sr.syncd() {
             // Synchronization was successful.
             trace!("SPDIFRX sync success");

--- a/embassy-stm32/src/tamp/mod.rs
+++ b/embassy-stm32/src/tamp/mod.rs
@@ -41,6 +41,7 @@ mod n6;
 /// Indices not listed in the table fall through to the `_` arm: reads return
 /// `false`/no-op and writes are a no-op, per the `InternalTamper` contract
 /// ("indices that aren't physically present are simply inert").
+#[cfg(any(tamp_h5, tamp_n6))]
 macro_rules! itamp_fields {
     ($( $idx:literal => ($e:ident, $set_e:ident, $ie:ident, $set_ie:ident, $f:ident, $mf:ident, $set_cf:ident) ),* $(,)?) => {
         pub fn cr1_itampe(r: crate::pac::tamp::regs::Cr1, n: usize) -> bool {
@@ -93,6 +94,7 @@ macro_rules! itamp_fields {
         }
     };
 }
+#[cfg(any(tamp_h5, tamp_n6))]
 pub(crate) use itamp_fields;
 
 // On several chips TAMP doesn't have its own NVIC line — its interrupt is

--- a/embassy-stm32/src/tamp/mod.rs
+++ b/embassy-stm32/src/tamp/mod.rs
@@ -10,7 +10,7 @@
 //! unlocked unconditionally during [`crate::init()`]. So, unlike most other
 //! peripherals, [`Tamp::new()`] does not call `rcc::enable_and_reset`.
 //!
-//! Supported on STM32G0, G4, H5, L5, U5, WBA and WL. The underlying register
+//! Supported on STM32G0, G4, H5, L5, U5, WBA, WL and N6. The underlying register
 //! layout differs meaningfully across these (channel/tamper counts, whether
 //! there's a monotonic counter, and — on H5 — internal tampers are exposed as
 //! individually named bit fields rather than an indexed array); those
@@ -31,6 +31,69 @@ use crate::{interrupt, pac};
 
 #[cfg(tamp_h5)]
 mod h5;
+#[cfg(tamp_n6)]
+mod n6;
+
+/// Generates the seven index-mapping functions used by chips that expose
+/// internal tampers as individually named bit fields (`itamp1e()`, `itamp2e()`,
+/// ...) instead of an indexed array accessor.
+///
+/// Indices not listed in the table fall through to the `_` arm: reads return
+/// `false`/no-op and writes are a no-op, per the `InternalTamper` contract
+/// ("indices that aren't physically present are simply inert").
+macro_rules! itamp_fields {
+    ($( $idx:literal => ($e:ident, $set_e:ident, $ie:ident, $set_ie:ident, $f:ident, $mf:ident, $set_cf:ident) ),* $(,)?) => {
+        pub fn cr1_itampe(r: crate::pac::tamp::regs::Cr1, n: usize) -> bool {
+            match n {
+                $( $idx => r.$e(), )*
+                _ => false,
+            }
+        }
+
+        pub fn cr1_set_itampe(w: &mut crate::pac::tamp::regs::Cr1, n: usize, val: bool) {
+            match n {
+                $( $idx => w.$set_e(val), )*
+                _ => {}
+            }
+        }
+
+        pub fn ier_itampie(r: crate::pac::tamp::regs::Ier, n: usize) -> bool {
+            match n {
+                $( $idx => r.$ie(), )*
+                _ => false,
+            }
+        }
+
+        pub fn ier_set_itampie(w: &mut crate::pac::tamp::regs::Ier, n: usize, val: bool) {
+            match n {
+                $( $idx => w.$set_ie(val), )*
+                _ => {}
+            }
+        }
+
+        pub fn sr_itampf(r: crate::pac::tamp::regs::Sr, n: usize) -> bool {
+            match n {
+                $( $idx => r.$f(), )*
+                _ => false,
+            }
+        }
+
+        pub fn misr_itampmf(r: crate::pac::tamp::regs::Misr, n: usize) -> bool {
+            match n {
+                $( $idx => r.$mf(), )*
+                _ => false,
+            }
+        }
+
+        pub fn scr_set_citampf(w: &mut crate::pac::tamp::regs::Scr, n: usize, val: bool) {
+            match n {
+                $( $idx => w.$set_cf(val), )*
+                _ => {}
+            }
+        }
+    };
+}
+pub(crate) use itamp_fields;
 
 // On several chips TAMP doesn't have its own NVIC line — its interrupt is
 // combined with RTC's (alarm/wakeup/LSE-CSS) on a shared vector. `bind_interrupts!`
@@ -45,7 +108,7 @@ type TampInterrupt = interrupt::typelevel::RTC_TAMP_LSECSS;
 type TampInterrupt = interrupt::typelevel::TAMP_STAMP_LSECSS_SSRU;
 #[cfg(all(tamp_wl, feature = "_core-cm0p"))]
 type TampInterrupt = interrupt::typelevel::RTC_LSECSS;
-#[cfg(any(tamp_h5, tamp_l5, tamp_u5, tamp_wba))]
+#[cfg(any(tamp_h5, tamp_l5, tamp_u5, tamp_wba, tamp_n6))]
 type TampInterrupt = interrupt::typelevel::TAMP;
 
 #[cfg(tamp_wba)]
@@ -58,6 +121,8 @@ const EXTERNAL_CHANNELS: u8 = 2;
 const EXTERNAL_CHANNELS: u8 = 3;
 #[cfg(tamp_h5)]
 const EXTERNAL_CHANNELS: u8 = 8;
+#[cfg(tamp_n6)]
+const EXTERNAL_CHANNELS: u8 = 7;
 #[cfg(tamp_l5)]
 const EXTERNAL_CHANNELS: u8 = 8;
 #[cfg(tamp_wl)]
@@ -71,12 +136,14 @@ const INTERNAL_TAMPERS: u8 = 6;
 const INTERNAL_TAMPERS: u8 = 8;
 #[cfg(tamp_h5)]
 const INTERNAL_TAMPERS: u8 = h5::INTERNAL_TAMPERS;
+#[cfg(tamp_n6)]
+const INTERNAL_TAMPERS: u8 = n6::INTERNAL_TAMPERS;
 
 #[cfg(tamp_g0)]
 const BACKUP_REGISTER_COUNT: usize = 5;
 #[cfg(tamp_wl)]
 const BACKUP_REGISTER_COUNT: usize = 20;
-#[cfg(any(tamp_u5, tamp_wba, tamp_g4, tamp_h5, tamp_l5))]
+#[cfg(any(tamp_u5, tamp_wba, tamp_g4, tamp_h5, tamp_l5, tamp_n6))]
 const BACKUP_REGISTER_COUNT: usize = 32;
 
 static WAKER: AtomicWaker = AtomicWaker::new();
@@ -90,7 +157,11 @@ fn cr1_itampe(r: Cr1, n: usize) -> bool {
     {
         h5::cr1_itampe(r, n)
     }
-    #[cfg(not(tamp_h5))]
+    #[cfg(tamp_n6)]
+    {
+        n6::cr1_itampe(r, n)
+    }
+    #[cfg(not(any(tamp_h5, tamp_n6)))]
     {
         r.itampe(n)
     }
@@ -101,7 +172,11 @@ fn cr1_set_itampe(w: &mut Cr1, n: usize, val: bool) {
     {
         h5::cr1_set_itampe(w, n, val);
     }
-    #[cfg(not(tamp_h5))]
+    #[cfg(tamp_n6)]
+    {
+        n6::cr1_set_itampe(w, n, val);
+    }
+    #[cfg(not(any(tamp_h5, tamp_n6)))]
     {
         w.set_itampe(n, val);
     }
@@ -112,7 +187,11 @@ fn ier_itampie(r: Ier, n: usize) -> bool {
     {
         h5::ier_itampie(r, n)
     }
-    #[cfg(not(tamp_h5))]
+    #[cfg(tamp_n6)]
+    {
+        n6::ier_itampie(r, n)
+    }
+    #[cfg(not(any(tamp_h5, tamp_n6)))]
     {
         r.itampie(n)
     }
@@ -123,7 +202,11 @@ fn ier_set_itampie(w: &mut Ier, n: usize, val: bool) {
     {
         h5::ier_set_itampie(w, n, val);
     }
-    #[cfg(not(tamp_h5))]
+    #[cfg(tamp_n6)]
+    {
+        n6::ier_set_itampie(w, n, val);
+    }
+    #[cfg(not(any(tamp_h5, tamp_n6)))]
     {
         w.set_itampie(n, val);
     }
@@ -134,7 +217,11 @@ fn sr_itampf(r: Sr, n: usize) -> bool {
     {
         h5::sr_itampf(r, n)
     }
-    #[cfg(not(tamp_h5))]
+    #[cfg(tamp_n6)]
+    {
+        n6::sr_itampf(r, n)
+    }
+    #[cfg(not(any(tamp_h5, tamp_n6)))]
     {
         r.itampf(n)
     }
@@ -145,7 +232,11 @@ fn misr_itampmf(r: Misr, n: usize) -> bool {
     {
         h5::misr_itampmf(r, n)
     }
-    #[cfg(not(tamp_h5))]
+    #[cfg(tamp_n6)]
+    {
+        n6::misr_itampmf(r, n)
+    }
+    #[cfg(not(any(tamp_h5, tamp_n6)))]
     {
         r.itampmf(n)
     }
@@ -156,7 +247,11 @@ fn scr_set_citampf(w: &mut Scr, n: usize, val: bool) {
     {
         h5::scr_set_citampf(w, n, val);
     }
-    #[cfg(not(tamp_h5))]
+    #[cfg(tamp_n6)]
+    {
+        n6::scr_set_citampf(w, n, val);
+    }
+    #[cfg(not(any(tamp_h5, tamp_n6)))]
     {
         w.set_citampf(n, val);
     }
@@ -167,7 +262,7 @@ fn set_tampflt(w: &mut Fltcr, filter: Filter) {
     {
         w.set_tampflt(pac::tamp::vals::Tampflt::from_bits(filter as u8));
     }
-    #[cfg(any(tamp_g0, tamp_g4, tamp_h5, tamp_l5))]
+    #[cfg(any(tamp_g0, tamp_g4, tamp_h5, tamp_l5, tamp_n6))]
     {
         w.set_tampflt(filter as u8);
     }
@@ -178,29 +273,29 @@ fn set_tamptrg(w: &mut pac::tamp::regs::Cr2, n: usize, trigger: Trigger) {
     {
         w.set_tamptrg(n, pac::tamp::vals::Tamptrg::from_bits(trigger as u8));
     }
-    #[cfg(any(tamp_g0, tamp_g4, tamp_h5, tamp_l5))]
+    #[cfg(any(tamp_g0, tamp_g4, tamp_h5, tamp_l5, tamp_n6))]
     {
         w.set_tamptrg(n, trigger as u8 != 0);
     }
 }
 
 fn read_bkpr(register: usize) -> u32 {
-    #[cfg(tamp_h5)]
+    #[cfg(any(tamp_h5, tamp_n6))]
     {
         regs().bkpr(register).read()
     }
-    #[cfg(not(tamp_h5))]
+    #[cfg(not(any(tamp_h5, tamp_n6)))]
     {
         regs().bkpr(register).read().bkp()
     }
 }
 
 fn write_bkpr(register: usize, value: u32) {
-    #[cfg(tamp_h5)]
+    #[cfg(any(tamp_h5, tamp_n6))]
     {
         regs().bkpr(register).write_value(value);
     }
-    #[cfg(not(tamp_h5))]
+    #[cfg(not(any(tamp_h5, tamp_n6)))]
     {
         regs().bkpr(register).write(|w| w.set_bkp(value));
     }
@@ -465,13 +560,13 @@ impl<'d> Tamp<'d> {
     ///
     /// Not available on G0/G4, which don't have this register — this method
     /// doesn't exist on those chips.
-    #[cfg(any(tamp_u5, tamp_wba, tamp_h5, tamp_l5, tamp_wl))]
+    #[cfg(any(tamp_u5, tamp_wba, tamp_h5, tamp_l5, tamp_wl, tamp_n6))]
     pub fn monotonic_counter(&self) -> u32 {
-        #[cfg(tamp_h5)]
+        #[cfg(any(tamp_h5, tamp_n6))]
         {
             regs().count1r().read()
         }
-        #[cfg(not(tamp_h5))]
+        #[cfg(not(any(tamp_h5, tamp_n6)))]
         {
             regs().countr().read().count()
         }

--- a/embassy-stm32/src/tamp/n6.rs
+++ b/embassy-stm32/src/tamp/n6.rs
@@ -1,15 +1,12 @@
-//! H5-specific internal tamper field access.
+//! N6-specific internal tamper field access.
 //!
-//! Every other supported TAMP version exposes internal tampers through an
-//! indexed array accessor (`itampe(n)`, `itampf(n)`, ...). H5 instead exposes
-//! them as individually named bit fields (`itamp1e()`, `itamp2e()`, ...), with
-//! gaps at ITAMP10 and ITAMP14 (reserved, not physically present). This shims
-//! them behind the same 0-based index used everywhere else in this driver,
-//! where index `n` means ITAMP`(n + 1)`.
+//! Like H5, N6 exposes internal tampers as individually named bit fields
+//! (`itamp1e()`, `itamp2e()`, …) rather than an indexed array. Index `n`
+//! maps to ITAMP`(n + 1)` with a gap at index 9 (ITAMP10 is not present).
 
 use super::itamp_fields;
 
-pub const INTERNAL_TAMPERS: u8 = 15;
+pub const INTERNAL_TAMPERS: u8 = 11;
 
 itamp_fields! {
     0 => (itamp1e, set_itamp1e, itamp1ie, set_itamp1ie, itamp1f, itamp1mf, set_citamp1f),
@@ -22,7 +19,4 @@ itamp_fields! {
     7 => (itamp8e, set_itamp8e, itamp8ie, set_itamp8ie, itamp8f, itamp8mf, set_citamp8f),
     8 => (itamp9e, set_itamp9e, itamp9ie, set_itamp9ie, itamp9f, itamp9mf, set_citamp9f),
     10 => (itamp11e, set_itamp11e, itamp11ie, set_itamp11ie, itamp11f, itamp11mf, set_citamp11f),
-    11 => (itamp12e, set_itamp12e, itamp12ie, set_itamp12ie, itamp12f, itamp12mf, set_citamp12f),
-    12 => (itamp13e, set_itamp13e, itamp13ie, set_itamp13ie, itamp13f, itamp13mf, set_citamp13f),
-    14 => (itamp15e, set_itamp15e, itamp15ie, set_itamp15ie, itamp15f, itamp15mf, set_citamp15f),
 }

--- a/embassy-stm32/src/time_driver/lptim.rs
+++ b/embassy-stm32/src/time_driver/lptim.rs
@@ -17,7 +17,7 @@ use stm32_metapac::lptim::Lptim;
 use super::AlarmState;
 use crate::interrupt::typelevel::Interrupt;
 use crate::lptim::SealedInstance;
-use crate::pac::lptim::vals;
+use crate::lptim::vals;
 use crate::rcc::SealedRccPeripheral;
 use crate::{peripherals, rcc};
 

--- a/embassy-stm32/src/time_driver/lptim.rs
+++ b/embassy-stm32/src/time_driver/lptim.rs
@@ -16,8 +16,7 @@ use stm32_metapac::lptim::Lptim;
 
 use super::AlarmState;
 use crate::interrupt::typelevel::Interrupt;
-use crate::lptim::SealedInstance;
-use crate::lptim::vals;
+use crate::lptim::{SealedInstance, vals};
 use crate::rcc::SealedRccPeripheral;
 use crate::{peripherals, rcc};
 


### PR DESCRIPTION
## Summary

Adds STM32N6 support across several peripheral drivers:

- **ADC**: dual-ADC mode config (`ADC12_COMMON`) for N6
- **CACHEAXI**: new driver for N6's AXI cache controller
- **crypto.rs**: shared AES cipher-mode types used by both `aes` and `saes`
- **GFXMMU**: N6 register layout support
- **I3C**: instance wiring, RCC enable/reset, and direct register access (a full controller/target protocol driver is not yet implemented — this exposes register-level access only)
- **LPTIM**: timer/PWM support for N6's split register layout, with a `vals.rs` shim for PAC blocks that omit the `vals` module
- **MCE**: new minimal Memory Cipher Engine driver (region configuration + illegal-access interrupts; key/cipher-context programming is left to the application)
- **PKA**: N6 RAM size for the scrub helper
- **SAES**: N6 cipher-mode support
- **SAI**: N6 support via `regs.rs`/`vals.rs` shims
- **SPDIFRX**: N6 register naming
- **TAMP**: N6 internal-tamper support

Also includes a few correctness fixes found during review:
- Fixed internal-tamper gap indices panicking instead of the documented inert no-op (affected both the new N6 shim and the pre-existing H5 one), and deduplicated the two chip-specific shims behind a shared `itamp_fields!` macro.
- Fixed a leftover `crate::pac::lptim::vals` import in the time driver that doesn't exist for N6's PAC block, and added a `build.rs` guard that rejects N6 + `time-driver-lptim1/2/3` with a clear error — that combination needs further RCC clock-mux and register-layout work not included in this PR.
- MCE: assert 4KiB alignment on region start/end instead of silently truncating.
- GFXMMU: gated `Config::cache_enable` behind `gfxmmu_v2` instead of silently ignoring it on N6, which has no cache controller.
- Deduplicated the `u8_enum!` shim macro (`sai/vals.rs`, `lptim/vals.rs`) into the crate's shared `macros.rs`, and shared `Error`/`Direction`/`KeySize`/`CipherSized`/`IVSized`/`CipherAuthenticated` between `aes/mod.rs` and `crypto.rs`.
- Removed an unused `From<ChannelDirection> for Ccsel` impl.