### PR TITLE
stm32/usb: fix compiling without time enabled

### DIFF
--- a/embassy-stm32/src/usb/usb_host.rs
+++ b/embassy-stm32/src/usb/usb_host.rs
@@ -6,7 +6,6 @@ use core::sync::atomic::{AtomicBool, AtomicU32, Ordering};
 use core::task::Poll;
 
 use embassy_sync::waitqueue::AtomicWaker;
-use embassy_time::{Duration, Instant, Timer};
 use embassy_usb_driver::host::{
     DeviceEvent, HostError, PipeError, TimeoutConfig, UsbHostAllocator, UsbHostController, UsbPipe, pipe,
 };
@@ -19,6 +18,7 @@ use crate::pac::USBRAM;
 use crate::pac::usb::regs;
 use crate::pac::usb::vals::{EpType, Stat};
 use crate::peripherals::USB;
+use crate::wait::{block_for_us, wait_for_us};
 use crate::{Peri, interrupt};
 
 /// The number of registers is 8, allowing up to 16 mono-
@@ -304,10 +304,7 @@ impl<'d, I: SealedHostInstance> UsbHost<'d, I> {
         });
 
         // Wait for voltage reference
-        #[cfg(feature = "time")]
-        embassy_time::block_for(embassy_time::Duration::from_millis(100));
-        #[cfg(not(feature = "time"))]
-        cortex_m::asm::delay(unsafe { crate::rcc::get_freqs() }.sys.unwrap().0 / 10);
+        block_for_us(100_0000); // 100 ms
 
         #[cfg(not(usb_v4))]
         regs.btable().write(|w| w.set_btable(0));
@@ -525,13 +522,16 @@ impl<'d, I: SealedHostInstance, D: pipe::Direction, T: pipe::Type> Channel<'d, I
         self.write_data(buf);
 
         let index = self.index;
+
+        #[allow(unused)]
         let timeout_ms = 1000;
 
         self.activate_tx();
 
         let regs = I::regs();
 
-        let t0 = Instant::now();
+        #[cfg(feature = "time")]
+        let t0 = embassy_time::Instant::now();
 
         poll_fn(|cx| {
             EP_OUT_WAKERS[index].register(cx.waker());
@@ -543,7 +543,8 @@ impl<'d, I: SealedHostInstance, D: pipe::Direction, T: pipe::Type> Channel<'d, I
                 return Poll::Ready(Err(PipeError::Disconnected));
             }
 
-            if t0.elapsed() > Duration::from_millis(timeout_ms as u64) {
+            #[cfg(feature = "time")]
+            if t0.elapsed() > embassy_time::Duration::from_millis(timeout_ms as u64) {
                 // Timeout, we need to stop the current transaction.
                 self.disable_tx();
                 return Poll::Ready(Err(PipeError::Timeout));
@@ -562,6 +563,7 @@ impl<'d, I: SealedHostInstance, D: pipe::Direction, T: pipe::Type> Channel<'d, I
     async fn read(&mut self, buf: &mut [u8]) -> Result<usize, PipeError> {
         let index = self.index;
 
+        #[allow(unused)]
         let timeout_ms = 1000;
 
         // A cancelled read leaves the channel armed and the packet may land
@@ -579,7 +581,8 @@ impl<'d, I: SealedHostInstance, D: pipe::Direction, T: pipe::Type> Channel<'d, I
 
         let mut count: usize = 0;
 
-        let t0 = Instant::now();
+        #[cfg(feature = "time")]
+        let t0 = embassy_time::Instant::now();
 
         poll_fn(|cx| {
             EP_IN_WAKERS[index].register(cx.waker());
@@ -591,7 +594,8 @@ impl<'d, I: SealedHostInstance, D: pipe::Direction, T: pipe::Type> Channel<'d, I
                 return Poll::Ready(Err(PipeError::Disconnected));
             }
 
-            if t0.elapsed() > Duration::from_millis(timeout_ms as u64) {
+            #[cfg(feature = "time")]
+            if t0.elapsed() > embassy_time::Duration::from_millis(timeout_ms as u64) {
                 self.disable_rx();
                 return Poll::Ready(Err(PipeError::Timeout));
             }
@@ -920,7 +924,7 @@ impl<'d, I: SealedHostInstance> UsbHostController<'d> for UsbHost<'d, I> {
         });
 
         // USB Spec says wait 50ms
-        Timer::after_millis(50).await;
+        wait_for_us(50_0000).await;
 
         // Clear reset state; device will be in default state
         regs.cntr().modify(|w| {
@@ -935,7 +939,7 @@ impl<'d, I: SealedHostInstance> UsbHostController<'d> for UsbHost<'d, I> {
             // completion on attach before returning.
             self.bus_reset().await;
             // USB 2.0 §7.1.7.5: reset recovery time before the device must respond.
-            Timer::after_millis(10).await;
+            wait_for_us(10_0000).await; // 10 ms
         }
         event
     }


### PR DESCRIPTION
Removes usb host dependency on `embassy_time`, and instead uses `wait` utility where applicable.

Quite important:
- These changes disable timeout in `read` and `write` when time feature is not enabled. I'm not sure if this is acceptable, but I also don't know how it can be implemented without time feature.
- I haven't tested it because I do not have a board that supports usb host (without hardware modification). While the changes are small, I would be glad if someone could test it.

So if these changes are not right, please treat this PR as an issue instead.