### PR TITLE
fix(stm32/qei): support full counting range on 32-bit timers

### DIFF
--- a/embassy-stm32/CHANGELOG.md
+++ b/embassy-stm32/CHANGELOG.md
@@ -38,6 +38,10 @@ Timer:
 - feat: stm32/timer/input_capture: add per-channel split API for concurrent multi-channel capture
 - feat: stm32/timer: add timer_v2 dithering APIs (`DitheringConfig`, ARR/CCR fractional nibble setters) in low-level, simple PWM, and complementary PWM drivers
 - feat: stm32/timer: add low-level timer status helpers for UIF remap control and counting direction (`is_counting_up`/`is_counting_down`)
+- feat: stm32/timer: add `low_level::Timer::get_counter()` to read the counter register as `T::Word`
+
+QEI:
+- fix: stm32/qei: `count()`, `reset()`, and `auto_reload` always used the 16-bit register view, so on 32-bit timers `reset()` only cleared the lower 16 bits of the counter (leaving the upper bits stale) and `auto_reload`/`count()` were truncated to `u16`; `Config`/`AdvancedConfig` are now generic over the timer instance and use `T::Word` so 32-bit timers work correctly across their full range (breaking change)
 
 PKA:
 - feat: stm32/pka: extend ECC point buffer support to 640-bit operands (80-byte coordinates) in public point types and Jacobian conversion paths

--- a/embassy-stm32/CHANGELOG.md
+++ b/embassy-stm32/CHANGELOG.md
@@ -41,7 +41,7 @@ Timer:
 - feat: stm32/timer: add `low_level::Timer::get_counter()` to read the counter register as `T::Word`
 
 QEI:
-- fix: stm32/qei: `count()`, `reset()`, and `auto_reload` always used the 16-bit register view, so on 32-bit timers `reset()` only cleared the lower 16 bits of the counter (leaving the upper bits stale) and `auto_reload`/`count()` were truncated to `u16`; `Config`/`AdvancedConfig` are now generic over the timer instance and use `T::Word` so 32-bit timers work correctly across their full range (breaking change)
+- fix: stm32/qei: `count()`, `reset()`, and `auto_reload` always used the 16-bit register view, so on 32-bit timers `reset()` only cleared the lower 16 bits of the counter (leaving the upper bits stale) and `auto_reload`/`count()` were truncated to `u16`; `Config`/`AdvancedConfig` are now generic over the timer instance and `auto_reload` uses `T::Word`, while `count()` returns `u32` so 32-bit timers work correctly across their full range (breaking change)
 
 PKA:
 - feat: stm32/pka: extend ECC point buffer support to 640-bit operands (80-byte coordinates) in public point types and Jacobian conversion paths

--- a/embassy-stm32/src/timer/low_level.rs
+++ b/embassy-stm32/src/timer/low_level.rs
@@ -472,6 +472,14 @@ impl<'d, T: CoreInstance> Timer<'d, T> {
         self.regs_core().cnt().write(|r| r.set_cnt(0));
     }
 
+    /// Get the current counter value.
+    pub fn get_counter(&self) -> T::Word {
+        #[cfg(not(stm32l0))]
+        return unwrap!(self.regs_gp32_unchecked().cnt().read().try_into());
+        #[cfg(stm32l0)]
+        return unwrap!(self.regs_gp32_unchecked().cnt().read().cnt().try_into());
+    }
+
     /// get the capability of the timer
     pub fn bits(&self) -> TimerBits {
         match T::Word::bits() {

--- a/embassy-stm32/src/timer/qei.rs
+++ b/embassy-stm32/src/timer/qei.rs
@@ -6,13 +6,17 @@ use super::low_level::Timer;
 pub use super::{Ch1, Ch2};
 use super::{GeneralInstance4Channel, TimerPin};
 use crate::Peri;
+use crate::dma::word::Word;
 use crate::gpio::{AfType, Flex, Pull};
+use crate::timer::CoreInstance;
 use crate::timer::TimerChannel;
 
 /// Qei driver config.
+///
+/// `T` is the timer instance.
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
 #[derive(Clone, Copy)]
-pub struct Config {
+pub struct Config<T: CoreInstance> {
     /// Configures the internal pull up/down resistor for Qei's channel 1 pin.
     pub ch1_pull: Pull,
     /// Configures the internal pull up/down resistor for Qei's channel 2 pin.
@@ -20,17 +24,16 @@ pub struct Config {
     /// Specifies the encoder mode to use for the Qei peripheral.
     pub mode: QeiMode,
     /// Sets the auto-reload value for the counter.
-    pub auto_reload: u16,
+    pub auto_reload: T::Word,
 }
 
-impl Default for Config {
-    /// Arbitrary defaults to preserve backwards compatibility
+impl<T: CoreInstance> Default for Config<T> {
     fn default() -> Self {
         Self {
             ch1_pull: Pull::None,
             ch2_pull: Pull::None,
             mode: QeiMode::Mode3,
-            auto_reload: u16::MAX,
+            auto_reload: unwrap!(T::Word::try_from(T::Word::max() as u64)),
         }
     }
 }
@@ -40,10 +43,10 @@ impl Default for Config {
 /// This extends [`Config`] with optional encoder-index controls on timer variants
 /// that expose TIMx_ECR/TIMx_SR index fields.
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
-#[derive(Clone, Copy, Default)]
-pub struct AdvancedConfig {
+#[derive(Clone, Copy)]
+pub struct AdvancedConfig<T: CoreInstance> {
     /// Base QEI configuration.
-    pub base: Config,
+    pub base: Config<T>,
     /// Optional index behavior configuration.
     #[cfg(timer_v2)]
     pub index: Option<IndexConfig>,
@@ -55,8 +58,17 @@ pub struct AdvancedConfig {
     pub enable_direction_change_interrupt: bool,
 }
 
-impl From<Config> for AdvancedConfig {
-    fn from(base: Config) -> Self {
+impl<T: CoreInstance> Default for AdvancedConfig<T>
+where
+    Config<T>: Default,
+{
+    fn default() -> Self {
+        Config::default().into()
+    }
+}
+
+impl<T: CoreInstance> From<Config<T>> for AdvancedConfig<T> {
+    fn from(base: Config<T>) -> Self {
         Self {
             base,
             #[cfg(timer_v2)]
@@ -136,7 +148,7 @@ impl<'d, T: GeneralInstance4Channel> Qei<'d, T> {
         tim: Peri<'d, T>,
         ch1: Peri<'d, if_afio!(impl TimerPin<T, CH1, A>)>,
         ch2: Peri<'d, if_afio!(impl TimerPin<T, CH2, A>)>,
-        config: Config,
+        config: Config<T>,
     ) -> Self {
         Self::new_advanced(tim, ch1, ch2, config.into())
     }
@@ -147,7 +159,7 @@ impl<'d, T: GeneralInstance4Channel> Qei<'d, T> {
         tim: Peri<'d, T>,
         ch1: Peri<'d, if_afio!(impl TimerPin<T, CH1, A>)>,
         ch2: Peri<'d, if_afio!(impl TimerPin<T, CH2, A>)>,
-        config: AdvancedConfig,
+        config: AdvancedConfig<T>,
     ) -> Self {
         // Configure the pins to be used for the QEI peripheral.
         critical_section::with(|_| {
@@ -177,7 +189,7 @@ impl<'d, T: GeneralInstance4Channel> Qei<'d, T> {
             w.set_sms(config.base.mode.into());
         });
 
-        r.arr().modify(|w| w.set_arr(config.base.auto_reload));
+        inner.set_max_compare_value(config.base.auto_reload);
         r.cr1().modify(|w| w.set_cen(true));
 
         #[cfg(timer_v2)]
@@ -208,13 +220,13 @@ impl<'d, T: GeneralInstance4Channel> Qei<'d, T> {
     }
 
     /// Get count.
-    pub fn count(&self) -> u16 {
-        self.inner.regs_gp16().cnt().read().cnt()
+    pub fn count(&self) -> T::Word {
+        self.inner.get_counter()
     }
 
     /// Reset count.
     pub fn reset(&mut self) {
-        self.inner.regs_gp16().cnt().modify(|w| w.set_cnt(0));
+        self.inner.reset();
     }
 
     #[cfg(timer_v2)]

--- a/embassy-stm32/src/timer/qei.rs
+++ b/embassy-stm32/src/timer/qei.rs
@@ -8,8 +8,7 @@ use super::{GeneralInstance4Channel, TimerPin};
 use crate::Peri;
 use crate::dma::word::Word;
 use crate::gpio::{AfType, Flex, Pull};
-use crate::timer::CoreInstance;
-use crate::timer::TimerChannel;
+use crate::timer::{CoreInstance, TimerChannel};
 
 /// Qei driver config.
 ///
@@ -220,8 +219,8 @@ impl<'d, T: GeneralInstance4Channel> Qei<'d, T> {
     }
 
     /// Get count.
-    pub fn count(&self) -> T::Word {
-        self.inner.get_counter()
+    pub fn count(&self) -> u32 {
+        self.inner.get_counter().into()
     }
 
     /// Reset count.


### PR DESCRIPTION
Config::auto_reload and Qei::count()/reset() previously used the 16-bit register view unconditionally, so on 32-bit timers the ARR and counter were truncated to u16 and reset() only cleared the lower 16 bits, leaving the upper bits stale.

Make Config and AdvancedConfig generic over the timer instance and use T::Word for auto_reload/count(), and add
low_level::Timer::get_counter() to read the counter as T::Word.