### PR TITLE
stm32/i3c: add blocking controller driver for STM32N6

### DIFF
--- a/embassy-stm32/build.rs
+++ b/embassy-stm32/build.rs
@@ -1750,6 +1750,14 @@ fn main() {
         signals.entry(key).or_default().push(value);
     }
 
+    // The `i3c` module is only compiled in for STM32N6 today; on other families
+    // (e.g. STM32H5) that also expose an "i3c" peripheral kind, `crate::i3c` doesn't
+    // exist, so drop these signals there to avoid generating unresolvable pin_trait_impl!s.
+    if !chip_name.starts_with("stm32n6") {
+        signals.remove(&("i3c", "SDA"));
+        signals.remove(&("i3c", "SCL"));
+    }
+
     // STM32U5 maps the external memory controller as kind "fsmc" (v5x1) but uses
     // the same pin signals as FMC on other families.
     for ((_, signal), traits) in signals.clone().into_iter().filter(|((kind, _), _)| *kind == "fmc") {

--- a/embassy-stm32/build.rs
+++ b/embassy-stm32/build.rs
@@ -1161,6 +1161,8 @@ fn main() {
         (("spi", "I2S_ext_SD"), quote!(crate::spi::SdExtPin)),
         (("i2c", "SDA"), quote!(crate::i2c::SdaPin)),
         (("i2c", "SCL"), quote!(crate::i2c::SclPin)),
+        (("i3c", "SDA"), quote!(crate::i3c::SdaPin)),
+        (("i3c", "SCL"), quote!(crate::i3c::SclPin)),
         (("rcc", "MCO_1"), quote!(crate::rcc::McoPin)),
         (("rcc", "MCO_2"), quote!(crate::rcc::McoPin)),
         (("rcc", "MCO"), quote!(crate::rcc::McoPin)),

--- a/embassy-stm32/src/i3c/config.rs
+++ b/embassy-stm32/src/i3c/config.rs
@@ -1,0 +1,116 @@
+//! I3C configuration.
+
+use crate::gpio::{AfType, OutputType, Pull, Speed};
+use crate::time::Hertz;
+
+/// SCL waveform timing in kernel clock cycles.
+///
+/// These values correspond to the fields in `TIMINGR0` and `TIMINGR1`.
+/// The ST CubeMX / `I3C_CtrlTimingComputation` utility can compute them from
+/// desired bus frequencies; the defaults match the Nucleo-N657X0 I3C examples.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+pub struct BusTiming {
+    /// SCL low duration in I3C push-pull phases (`TIMINGR0.SCLL_PP`).
+    pub scl_pp_low: u8,
+    /// SCL high duration for I3C messages (`TIMINGR0.SCLH_I3C`).
+    pub scl_i3c_high: u8,
+    /// SCL low duration in open-drain phases (`TIMINGR0.SCLL_OD`).
+    pub scl_od_low: u8,
+    /// SCL high duration for legacy I2C messages (`TIMINGR0.SCLH_I2C`).
+    pub scl_i2c_high: u8,
+    /// Bus free duration (`TIMINGR1.FREE`).
+    pub bus_free: u8,
+    /// Bus idle / hot-join duration (`TIMINGR1.AVAL`).
+    pub bus_idle: u8,
+    /// SDA hold time: `true` = 1.5 cycles, `false` = 0.5 cycles (`TIMINGR1.SDA_HD`).
+    pub sda_hold_1_5: bool,
+    /// Activity state of new controller (`TIMINGR1.ASNCR`), typically 0.
+    pub wait_time: u8,
+}
+
+impl Default for BusTiming {
+    fn default() -> Self {
+        // Values from NUCLEO-N657X0 I3C_Controller_Direct_Command_DMA example.
+        Self {
+            scl_pp_low: 0x07,
+            scl_i3c_high: 0x07,
+            scl_od_low: 0x47,
+            scl_i2c_high: 0x00,
+            bus_free: 0x28,
+            bus_idle: 0xc6,
+            sda_hold_1_5: true,
+            wait_time: 0,
+        }
+    }
+}
+
+/// Controller-specific options written to `TIMINGR2` and `CFGR`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+pub struct ControllerOptions {
+    /// Dynamic address used when the controller acts as a target (0 = none).
+    pub dynamic_addr: u8,
+    /// Controller clock stall time in kernel cycles (`TIMINGR2.STALL`).
+    pub stall_time: u8,
+    /// Acknowledge hot-join requests from targets.
+    pub hot_join_allowed: bool,
+    /// Enable SDA high-keeper.
+    pub high_keeper_sda: bool,
+}
+
+impl Default for ControllerOptions {
+    fn default() -> Self {
+        Self {
+            dynamic_addr: 0,
+            stall_time: 0,
+            hot_join_allowed: false,
+            high_keeper_sda: false,
+        }
+    }
+}
+
+/// I3C controller configuration.
+#[non_exhaustive]
+#[derive(Debug, Clone, Copy)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+pub struct Config {
+    /// Target I3C push-pull bus frequency (informational; actual timing comes from [`BusTiming`]).
+    pub push_pull_freq: Hertz,
+    /// Target I3C open-drain bus frequency (informational).
+    pub open_drain_freq: Hertz,
+    /// Bus waveform timing registers.
+    pub timing: BusTiming,
+    /// Controller role options.
+    pub controller: ControllerOptions,
+    /// GPIO slew rate for SCL/SDA.
+    pub gpio_speed: Speed,
+}
+
+impl Default for Config {
+    fn default() -> Self {
+        Self {
+            push_pull_freq: Hertz::mhz(12),
+            open_drain_freq: Hertz::khz(400),
+            timing: BusTiming::default(),
+            controller: ControllerOptions::default(),
+            gpio_speed: Speed::VeryHigh,
+        }
+    }
+}
+
+impl Config {
+    pub(super) fn scl_af(&self) -> AfType {
+        #[cfg(gpio_v1)]
+        return AfType::output(OutputType::PushPull, self.gpio_speed);
+        #[cfg(gpio_v2)]
+        return AfType::output_pull(OutputType::PushPull, self.gpio_speed, Pull::None);
+    }
+
+    pub(super) fn sda_af(&self) -> AfType {
+        #[cfg(gpio_v1)]
+        return AfType::output(OutputType::PushPull, self.gpio_speed);
+        #[cfg(gpio_v2)]
+        return AfType::output_pull(OutputType::PushPull, self.gpio_speed, Pull::None);
+    }
+}

--- a/embassy-stm32/src/i3c/controller.rs
+++ b/embassy-stm32/src/i3c/controller.rs
@@ -1,0 +1,461 @@
+//! Blocking I3C controller driver for STM32N6.
+
+use core::marker::PhantomData;
+
+use embassy_hal_internal::Peri;
+#[cfg(feature = "time")]
+use embassy_time::{Duration, Instant};
+
+use super::config::Config;
+use super::{
+    DIR_READ, DIR_WRITE, DIRECT_WITHOUT_DEFBYTE_RESTART, DIRECT_WITHOUT_DEFBYTE_STOP, Error, GENERATE_RESTART,
+    GENERATE_STOP, Info, Instance, MTYPE_CCC, MTYPE_DIRECT, MTYPE_PRIVATE, PRIVATE_WITHOUT_ARB_RESTART,
+    PRIVATE_WITHOUT_ARB_STOP, SclPin, SdaPin,
+};
+use crate::gpio::Flex;
+use crate::mode::Blocking;
+use crate::pac::i3c::regs::Cr;
+use crate::rcc;
+
+/// I3C controller in blocking mode.
+pub struct Controller<'d, T: Instance> {
+    info: &'static Info,
+    _peri: Peri<'d, T>,
+    _scl: Option<Flex<'d>>,
+    _sda: Option<Flex<'d>>,
+    #[cfg(feature = "time")]
+    timeout: Duration,
+    _mode: PhantomData<Blocking>,
+}
+
+impl<'d, T: Instance> Controller<'d, T> {
+    /// Create a new blocking I3C controller.
+    pub fn new_blocking(
+        peri: Peri<'d, T>,
+        scl: Peri<'d, impl SclPin<T>>,
+        sda: Peri<'d, impl SdaPin<T>>,
+        config: Config,
+    ) -> Self {
+        Self::new_inner(
+            peri,
+            new_pin!(scl, config.scl_af()),
+            new_pin!(sda, config.sda_af()),
+            config,
+        )
+    }
+
+    fn new_inner(peri: Peri<'d, T>, scl: Option<Flex<'d>>, sda: Option<Flex<'d>>, config: Config) -> Self {
+        rcc::enable_and_reset::<T>();
+
+        let info = T::info();
+        init_controller(info, config);
+
+        Self {
+            info,
+            _peri: peri,
+            _scl: scl,
+            _sda: sda,
+            #[cfg(feature = "time")]
+            timeout: Duration::from_millis(1000),
+            _mode: PhantomData,
+        }
+    }
+
+    /// Set the timeout for blocking operations.
+    #[cfg(feature = "time")]
+    pub fn set_timeout(&mut self, timeout: Duration) {
+        self.timeout = timeout;
+    }
+
+    /// Read data from a target using a direct CCC command.
+    pub fn direct_ccc_read(&mut self, target_addr: u8, ccc: u8, buf: &mut [u8]) -> Result<(), Error> {
+        let mut ctrl = [0u32; 2];
+        prepare_direct_ccc_control(&mut ctrl, target_addr, ccc, 0, buf.len(), true, false);
+        let rx_len = buf.len();
+
+        let mut ctx = XferContext {
+            ctrl: &mut ctrl,
+            ctrl_idx: 0,
+            ctrl_remaining: 2,
+            tx: &[],
+            tx_idx: 0,
+            tx_remaining: 0,
+            rx: buf,
+            rx_idx: 0,
+            rx_remaining: rx_len,
+        };
+        self.blocking_transfer(&mut ctx)
+    }
+
+    /// Write data to a target using a direct CCC command.
+    pub fn direct_ccc_write(&mut self, target_addr: u8, ccc: u8, data: &[u8]) -> Result<(), Error> {
+        let mut ctrl = [0u32; 2];
+        prepare_direct_ccc_control(&mut ctrl, target_addr, ccc, 0, data.len(), false, false);
+
+        let mut ctx = XferContext {
+            ctrl: &mut ctrl,
+            ctrl_idx: 0,
+            ctrl_remaining: 2,
+            tx: data,
+            tx_idx: 0,
+            tx_remaining: data.len(),
+            rx: &mut [],
+            rx_idx: 0,
+            rx_remaining: 0,
+        };
+        self.blocking_transfer(&mut ctx)
+    }
+
+    /// Perform a private I3C write to `target_addr`.
+    pub fn private_write(&mut self, target_addr: u8, data: &[u8]) -> Result<(), Error> {
+        let mut ctrl = [0u32; 1];
+        prepare_private_control(&mut ctrl, target_addr, data.len(), false, false);
+
+        let mut ctx = XferContext {
+            ctrl: &mut ctrl,
+            ctrl_idx: 0,
+            ctrl_remaining: 1,
+            tx: data,
+            tx_idx: 0,
+            tx_remaining: data.len(),
+            rx: &mut [],
+            rx_idx: 0,
+            rx_remaining: 0,
+        };
+        self.blocking_transfer(&mut ctx)
+    }
+
+    /// Perform a private I3C read from `target_addr`.
+    pub fn private_read(&mut self, target_addr: u8, buf: &mut [u8]) -> Result<(), Error> {
+        let mut ctrl = [0u32; 1];
+        prepare_private_control(&mut ctrl, target_addr, buf.len(), true, false);
+        let rx_len = buf.len();
+
+        let mut ctx = XferContext {
+            ctrl: &mut ctrl,
+            ctrl_idx: 0,
+            ctrl_remaining: 1,
+            tx: &[],
+            tx_idx: 0,
+            tx_remaining: 0,
+            rx: buf,
+            rx_idx: 0,
+            rx_remaining: rx_len,
+        };
+        self.blocking_transfer(&mut ctx)
+    }
+
+    /// Broadcast a CCC command (no target address).
+    pub fn broadcast_ccc(&mut self, ccc: u8, data: &[u8]) -> Result<(), Error> {
+        let mut ctrl = [0u32; 1];
+        ctrl[0] = (data.len() as u32) | ((ccc as u32) << 16) | MTYPE_CCC | GENERATE_STOP;
+
+        let mut ctx = XferContext {
+            ctrl: &mut ctrl,
+            ctrl_idx: 0,
+            ctrl_remaining: 1,
+            tx: data,
+            tx_idx: 0,
+            tx_remaining: data.len(),
+            rx: &mut [],
+            rx_idx: 0,
+            rx_remaining: 0,
+        };
+        self.blocking_transfer(&mut ctx)
+    }
+
+    /// Assign dynamic addresses to all targets on the bus (ENTDAA).
+    ///
+    /// Returns `(dynamic_address, provisioned_id)` pairs. Addresses start at `0x08`.
+    pub fn dyn_addr_assign(&mut self) -> Result<heapless::Vec<(u8, u64), 8>, Error> {
+        self.dyn_addr_assign_with_reset(false)
+    }
+
+    /// Assign dynamic addresses, optionally sending RSTDAA before ENTDAA.
+    pub fn dyn_addr_assign_with_reset(&mut self, reset_first: bool) -> Result<heapless::Vec<(u8, u64), 8>, Error> {
+        let regs = self.info.regs;
+        let mut targets = heapless::Vec::new();
+        let mut next_addr = 0x08u8;
+
+        regs.cfgr().modify(|w| w.set_noarbh(false));
+
+        if reset_first {
+            self.broadcast_ccc(0x06, &[])?; // RSTDAA
+        }
+
+        write_ccc_cr(regs, 0x07, GENERATE_STOP); // ENTDAA
+
+        loop {
+            self.wait_daa_event()?;
+
+            let evr = regs.evr().read();
+            if evr.fcf() {
+                regs.cevr().write(|w| w.set_cfcf(true));
+                break;
+            }
+
+            if evr.txfnff() {
+                let payload = read_entdaa_payload(regs);
+                let addr = next_addr;
+                next_addr = next_addr.wrapping_add(1);
+                if next_addr > 0x7E {
+                    return Err(Error::AddressOutOfRange);
+                }
+
+                regs.tx_data_regs().dr().write(|w| w.set_db(addr));
+                targets.push((addr, payload)).map_err(|_| Error::Other)?;
+            }
+        }
+
+        Ok(targets)
+    }
+
+    fn blocking_transfer(&mut self, ctx: &mut XferContext<'_>) -> Result<(), Error> {
+        let regs = self.info.regs;
+
+        if ctx.ctrl_remaining > 0 {
+            ctx.ctrl_remaining -= 1;
+            let word = ctx.next_word()?;
+            regs.cr().write_value(Cr(word));
+        }
+
+        loop {
+            service_control_fifo(regs, ctx)?;
+            service_tx_fifo(regs, ctx);
+            service_rx_fifo(regs, ctx);
+
+            let evr = regs.evr().read();
+            let exit = evr.0 & (1 << 9 | 1 << 22); // FCF | ERRF
+
+            if evr.fcf() && ctx.ctrl_remaining > 0 {
+                regs.cevr().write(|w| w.set_cfcf(true));
+                regs.cfgr().modify(|w| w.set_tsfset(true));
+            }
+
+            if exit != 0 {
+                break;
+            }
+        }
+
+        let evr = regs.evr().read();
+        if evr.fcf() {
+            regs.cevr().write(|w| w.set_cfcf(true));
+        }
+
+        if evr.errf() {
+            regs.cevr().write(|w| w.set_cerrf(true));
+            return Err(read_error(regs));
+        }
+
+        if ctx.tx_remaining != 0 || ctx.rx_remaining != 0 {
+            return Err(Error::Size);
+        }
+
+        Ok(())
+    }
+
+    fn wait_daa_event(&self) -> Result<(), Error> {
+        #[cfg(feature = "time")]
+        {
+            let deadline = Instant::now() + self.timeout;
+            loop {
+                let evr = self.info.regs.evr().read();
+                if evr.fcf() || evr.txfnff() {
+                    return Ok(());
+                }
+                if evr.errf() {
+                    self.info.regs.cevr().write(|w| w.set_cerrf(true));
+                    return Err(read_error(self.info.regs));
+                }
+                if Instant::now() >= deadline {
+                    return Err(Error::Timeout);
+                }
+            }
+        }
+
+        #[cfg(not(feature = "time"))]
+        loop {
+            let evr = self.info.regs.evr().read();
+            if evr.fcf() || evr.txfnff() {
+                return Ok(());
+            }
+            if evr.errf() {
+                self.info.regs.cevr().write(|w| w.set_cerrf(true));
+                return Err(read_error(self.info.regs));
+            }
+        }
+    }
+}
+
+impl<'d, T: Instance> Drop for Controller<'d, T> {
+    fn drop(&mut self) {
+        self.info.rcc.disable();
+    }
+}
+
+struct XferContext<'a> {
+    ctrl: &'a mut [u32],
+    ctrl_idx: usize,
+    ctrl_remaining: usize,
+    tx: &'a [u8],
+    tx_idx: usize,
+    tx_remaining: usize,
+    rx: &'a mut [u8],
+    rx_idx: usize,
+    rx_remaining: usize,
+}
+
+impl XferContext<'_> {
+    fn next_word(&mut self) -> Result<u32, Error> {
+        if self.ctrl_idx >= self.ctrl.len() {
+            return Err(Error::InvalidParam);
+        }
+        let word = self.ctrl[self.ctrl_idx];
+        self.ctrl_idx += 1;
+        Ok(word)
+    }
+}
+
+fn init_controller(info: &Info, config: Config) {
+    let regs = info.regs;
+    let t = config.timing;
+    let c = config.controller;
+
+    regs.cfgr().modify(|w| w.set_en(false));
+    regs.cfgr().modify(|w| w.set_crinit(true));
+
+    regs.timingr0().write(|w| {
+        w.set_scll_pp(t.scl_pp_low);
+        w.set_sclh_i3c(t.scl_i3c_high);
+        w.set_scll_od(t.scl_od_low);
+        w.set_sclh_i2c(t.scl_i2c_high);
+    });
+
+    regs.timingr1().write(|w| {
+        w.set_aval(t.bus_idle);
+        w.set_asncr(t.wait_time);
+        w.set_free(t.bus_free);
+        w.set_sda_hd(t.sda_hold_1_5);
+    });
+
+    regs.timingr2().write(|w| {
+        w.set_stall(c.stall_time);
+        w.set_stalla(false);
+        w.set_stallc(false);
+        w.set_stalld(false);
+        w.set_stallt(false);
+    });
+
+    regs.cfgr().modify(|w| {
+        w.set_hksdaen(c.high_keeper_sda);
+        w.set_hjack(c.hot_join_allowed);
+        w.set_rxthres(false);
+        w.set_txthres(false);
+        w.set_tmode(false);
+        w.set_smode(false);
+    });
+
+    if c.dynamic_addr != 0 {
+        regs.devr0().modify(|w| w.set_da(c.dynamic_addr));
+    }
+
+    regs.cfgr().modify(|w| w.set_en(true));
+}
+
+fn prepare_direct_ccc_control(
+    ctrl: &mut [u32],
+    target_addr: u8,
+    ccc: u8,
+    defbyte: u32,
+    data_len: usize,
+    read: bool,
+    stop_between: bool,
+) {
+    let stop = if stop_between {
+        DIRECT_WITHOUT_DEFBYTE_STOP
+    } else {
+        DIRECT_WITHOUT_DEFBYTE_RESTART
+    };
+
+    ctrl[0] = defbyte | ((ccc as u32) << 16) | MTYPE_CCC | GENERATE_RESTART;
+    ctrl[1] = ((data_len as u32).saturating_sub(defbyte))
+        | if read { DIR_READ } else { DIR_WRITE }
+        | ((target_addr as u32) << 17)
+        | MTYPE_DIRECT
+        | stop;
+}
+
+fn prepare_private_control(ctrl: &mut [u32], target_addr: u8, data_len: usize, read: bool, stop_between: bool) {
+    let stop = if stop_between {
+        PRIVATE_WITHOUT_ARB_STOP
+    } else {
+        PRIVATE_WITHOUT_ARB_RESTART
+    };
+
+    ctrl[0] = (data_len as u32)
+        | if read { DIR_READ } else { DIR_WRITE }
+        | ((target_addr as u32) << 17)
+        | MTYPE_PRIVATE
+        | stop;
+}
+
+fn write_ccc_cr(regs: crate::pac::i3c::I3c, ccc: u8, end: u32) {
+    regs.cr_alternate().write(|w| {
+        w.set_dcnt(0);
+        w.set_ccc(ccc);
+        w.set_mtype((MTYPE_CCC >> 27) as u8);
+        w.set_mend(end == GENERATE_STOP);
+    });
+}
+
+fn read_entdaa_payload(regs: crate::pac::i3c::I3c) -> u64 {
+    let mut payload = 0u64;
+    for i in 0..8 {
+        payload |= (regs.rx_data_regs().dr().read().db() as u64) << (i * 8);
+    }
+    payload
+}
+
+fn service_control_fifo(regs: crate::pac::i3c::I3c, ctx: &mut XferContext<'_>) -> Result<(), Error> {
+    if regs.evr().read().cfnff() && ctx.ctrl_remaining > 0 {
+        ctx.ctrl_remaining -= 1;
+        let word = ctx.next_word()?;
+        regs.cr().write_value(Cr(word));
+    }
+    Ok(())
+}
+
+fn service_tx_fifo(regs: crate::pac::i3c::I3c, ctx: &mut XferContext<'_>) {
+    while regs.evr().read().txfnff() && ctx.tx_remaining > 0 {
+        let byte = ctx.tx[ctx.tx_idx];
+        ctx.tx_idx += 1;
+        ctx.tx_remaining -= 1;
+        regs.tx_data_regs().dr().write(|w| w.set_db(byte));
+    }
+}
+
+fn service_rx_fifo(regs: crate::pac::i3c::I3c, ctx: &mut XferContext<'_>) {
+    while regs.evr().read().rxfnef() && ctx.rx_remaining > 0 {
+        let byte = regs.rx_data_regs().dr().read().db();
+        ctx.rx[ctx.rx_idx] = byte;
+        ctx.rx_idx += 1;
+        ctx.rx_remaining -= 1;
+    }
+}
+
+fn read_error(regs: crate::pac::i3c::I3c) -> Error {
+    let ser = regs.ser().read();
+    if ser.anack() {
+        Error::AddressNack
+    } else if ser.dnack() {
+        Error::DataNack
+    } else if ser.dovr() || ser.covr() {
+        Error::FifoOverrun
+    } else if ser.perr() {
+        Error::Protocol
+    } else if ser.derr() {
+        Error::DataHandOff
+    } else {
+        Error::Other
+    }
+}

--- a/embassy-stm32/src/i3c/mod.rs
+++ b/embassy-stm32/src/i3c/mod.rs
@@ -1,52 +1,136 @@
 //! Improved inter-integrated circuit (I3C)
 //!
-//! N6 exposes I3C1/I3C2 with event and error interrupts. This module provides
-//! instance wiring, RCC enable/reset, and direct register access. A full
-//! controller/target protocol driver is not yet implemented — use [`I3c::regs`]
-//! for register-level access until higher-level APIs land.
+//! STM32N6 I3C1/I3C2 controller driver. Based on the STM32N6 HAL I3C driver
+//! (`stm32n6xx_hal_i3c`). Supports blocking controller operations: direct CCC,
+//! private transfers, broadcast CCC, and dynamic address assignment (ENTDAA).
 
-use embassy_hal_internal::{Peri, PeripheralType};
+mod config;
+pub mod controller;
+
+pub use config::{BusTiming, Config, ControllerOptions};
+pub use controller::Controller;
+use embassy_hal_internal::PeripheralType;
 
 use crate::pac::i3c::I3c as Regs;
 use crate::peripherals;
-use crate::rcc::{self, RccPeripheral};
+use crate::rcc::{RccInfo, RccPeripheral, SealedRccPeripheral};
 
-trait SealedInstance: RccPeripheral {
-    fn regs() -> Regs;
+// ---- Control register constants (from STM32 LL/HAL) ----
+
+pub(crate) const DIR_READ: u32 = 1 << 16;
+pub(crate) const DIR_WRITE: u32 = 0;
+pub(crate) const GENERATE_STOP: u32 = 1 << 31;
+pub(crate) const GENERATE_RESTART: u32 = 0;
+
+pub(crate) const MTYPE_PRIVATE: u32 = 1 << 28;
+pub(crate) const MTYPE_DIRECT: u32 = 3 << 27;
+pub(crate) const MTYPE_CCC: u32 = 6 << 27;
+
+pub(crate) const DIRECT_WITHOUT_DEFBYTE_RESTART: u32 = MTYPE_DIRECT;
+pub(crate) const DIRECT_WITHOUT_DEFBYTE_STOP: u32 = MTYPE_DIRECT | GENERATE_STOP;
+pub(crate) const PRIVATE_WITHOUT_ARB_RESTART: u32 = MTYPE_PRIVATE | 4;
+pub(crate) const PRIVATE_WITHOUT_ARB_STOP: u32 = MTYPE_PRIVATE | 4 | GENERATE_STOP;
+
+/// I3C error.
+#[derive(Debug, PartialEq, Eq, Copy, Clone)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+#[non_exhaustive]
+pub enum Error {
+    /// Address not acknowledged.
+    AddressNack,
+    /// Data not acknowledged.
+    DataNack,
+    /// FIFO overrun/underrun.
+    FifoOverrun,
+    /// Protocol error.
+    Protocol,
+    /// Data hand-off error during controller-role transfer.
+    DataHandOff,
+    /// Transfer size mismatch.
+    Size,
+    /// Invalid parameter.
+    InvalidParam,
+    /// Dynamic address out of range.
+    AddressOutOfRange,
+    /// Timeout.
+    Timeout,
+    /// Other/unclassified error.
+    Other,
+}
+
+impl core::fmt::Display for Error {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        match self {
+            Self::AddressNack => f.write_str("address NACK"),
+            Self::DataNack => f.write_str("data NACK"),
+            Self::FifoOverrun => f.write_str("FIFO overrun"),
+            Self::Protocol => f.write_str("protocol error"),
+            Self::DataHandOff => f.write_str("data hand-off error"),
+            Self::Size => f.write_str("transfer size mismatch"),
+            Self::InvalidParam => f.write_str("invalid parameter"),
+            Self::AddressOutOfRange => f.write_str("address out of range"),
+            Self::Timeout => f.write_str("timeout"),
+            Self::Other => f.write_str("other error"),
+        }
+    }
+}
+
+impl core::error::Error for Error {}
+
+/// Common I3C direct CCC command codes.
+pub mod ccc {
+    /// Broadcast ENTDAA (enter dynamic address assignment).
+    pub const ENTDAA: u8 = 0x07;
+    /// Broadcast RSTDAA (reset dynamic address assignment).
+    pub const RSTDAA: u8 = 0x06;
+    /// Direct GETPID.
+    pub const GETPID: u8 = 0x8D;
+    /// Direct GETBCR.
+    pub const GETBCR: u8 = 0x8E;
+    /// Direct GETDCR.
+    pub const GETDCR: u8 = 0x8F;
+    /// Direct GETSTATUS.
+    pub const GETSTATUS: u8 = 0x90;
+    /// Direct GETMWL.
+    pub const GETMWL: u8 = 0x91;
+    /// Direct GETMRL.
+    pub const GETMRL: u8 = 0x92;
+    /// Direct SETMWL.
+    pub const SETMWL: u8 = 0x89;
+    /// Direct SETMRL.
+    pub const SETMRL: u8 = 0x8A;
+}
+
+pub(crate) struct Info {
+    pub(crate) regs: Regs,
+    pub(crate) rcc: RccInfo,
+}
+
+trait SealedInstance: SealedRccPeripheral {
+    fn info() -> &'static Info;
 }
 
 /// I3C instance trait.
 #[allow(private_bounds)]
-pub trait Instance: PeripheralType + SealedInstance + 'static {
+pub trait Instance: PeripheralType + SealedInstance + RccPeripheral + 'static {
     /// Event interrupt for this instance.
     type EventInterrupt: crate::interrupt::typelevel::Interrupt;
     /// Error interrupt for this instance.
     type ErrorInterrupt: crate::interrupt::typelevel::Interrupt;
 }
 
-/// I3C peripheral handle.
-pub struct I3c<'d, T: Instance> {
-    _peri: Peri<'d, T>,
-}
-
-impl<'d, T: Instance> I3c<'d, T> {
-    /// Create a new I3C handle and enable/reset the peripheral.
-    pub fn new(peri: Peri<'d, T>) -> Self {
-        rcc::enable_and_reset::<T>();
-        Self { _peri: peri }
-    }
-
-    /// Direct access to the underlying PAC registers.
-    pub fn regs() -> Regs {
-        T::regs()
-    }
-}
+pin_trait!(SclPin, Instance, @A);
+pin_trait!(SdaPin, Instance, @A);
 
 foreach_peripheral!(
     (i3c, $inst:ident) => {
         impl SealedInstance for peripherals::$inst {
-            fn regs() -> Regs {
-                crate::pac::$inst
+            fn info() -> &'static Info {
+                static INFO: Info = Info {
+                    regs: crate::pac::$inst,
+                    rcc: crate::peripherals::$inst::RCC_INFO,
+                };
+                &INFO
             }
         }
 


### PR DESCRIPTION
## Summary
- Adds `i3c::Controller`, a blocking I3C controller driver for STM32N6, based on the STM32N6 HAL I3C driver (`stm32n6xx_hal_i3c`).
- Supports direct CCC read/write, private read/write transfers, broadcast CCC, and dynamic address assignment (ENTDAA).
- Adds `i3c::Config` / `BusTiming` / `ControllerOptions` for bus timing and controller-role configuration.
- Wires up `SCL`/`SDA` pin AF resolution for the `i3c` peripheral in `build.rs`.