### PR TITLE
rp: fix core voltage adjustment on rp235x

### DIFF
--- a/embassy-rp/src/clocks.rs
+++ b/embassy-rp/src/clocks.rs
@@ -1043,12 +1043,20 @@ pub(crate) unsafe fn init(config: ClockConfig) {
             #[cfg(feature = "rp2040")]
             vreg.vreg().modify(|w| w.set_vsel(target_vsel));
             #[cfg(feature = "_rp235x")]
-            // For rp235x changes to the voltage regulator are protected by a password, see datasheet section 6.4 Power Management (POWMAN) Registers
-            // The password is "5AFE" (0x5AFE), it must be set in the top 16 bits of the register
-            vreg.vreg().modify(|w| {
-                w.0 = (w.0 & 0x0000FFFF) | (0x5AFE << 16); // Set the password
-                w.set_vsel(target_vsel);
-            });
+            {
+                // For rp235x changes to the voltage regulator are protected by a password, see datasheet section 6.4 Power Management (POWMAN) Registers
+                // The password is "5AFE" (0x5AFE), it must be set in the top 16 bits of the registers
+                // Unlock the VREG control interface, this cannot be locked after being unlocked
+                vreg.vreg_ctrl().modify(|w| {
+                    w.0 = (w.0 & 0x0000FFFF) | (0x5AFE << 16); // Password
+                    w.set_unlock(true);
+                });
+                // Set the regulator to the target voltage
+                vreg.vreg().modify(|w| {
+                    w.0 = (w.0 & 0x0000FFFF) | (0x5AFE << 16); // Password
+                    w.set_vsel(target_vsel);
+                });
+            }
 
             // Wait for the voltage to stabilize. Use the provided delay or default based on voltage
             let settling_time_us = config.voltage_stabilization_delay_us.unwrap_or_else(|| {


### PR DESCRIPTION
Hi, I was experimenting with overclocking the rp2350 but noticed that the core voltage setting didn't change the max stable clock speed. Measuring the regulator output showed that it stayed at 1.1V. Turns out the VREG interface has to be unlocked first using VREG_CTRL before the regulator voltage can be adjusted (See "POWMAN: VREG_CTRL Register" in the datasheet), which is added in this patch.

This was the workaround I initially used:
```rust
let powman = embassy_rp::pac::POWMAN;
let vreg_ctrl = powman.vreg_ctrl();
vreg_ctrl.modify(|w| {
    w.0 = (w.0 & 0x0000FFFF) | (0x5AFE << 16); // Password
    w.set_unlock(true);
});

let mut config = embassy_rp::config::Config::default();
config.clocks = ClockConfig::system_freq(300_000_000).unwrap();
config.clocks.core_voltage = embassy_rp::clocks::CoreVoltage::V1_20;

let p = embassy_rp::init(config);
```

If anyone's curious, these were the max clock speeds I got for various core voltages until it started consistently crashing (without cooling), your results may vary etc.:
| Set  | Measured  | Max Freq  |
|---|---|---|
| 1.05V  | 1.042V  |  260 MHz |
| 1.10V (Default) | 1.093V  |  290 MHz |
| 1.15V  | 1.143V  | 310 MHz  |
| 1.20V  | 1.193V  |  340 MHz |
| 1.25V  | 1.213V  | 370 MHz  |
| 1.30V  | 1.260V  | 390 MHz  |

<sub><sub>I can kinda see why people like overclocking stuff, this is pretty fun :D</sup></sup>