### PR TITLE
stm32/i3c: add STM32H5, STM32U3, STM32C5, and STM32H7R/H7S support

### DIFF
--- a/embassy-stm32/Cargo.toml
+++ b/embassy-stm32/Cargo.toml
@@ -1978,3 +1978,8 @@ stm32wle5cc = [ "stm32-metapac/stm32wle5cc" ]
 stm32wle5j8 = [ "stm32-metapac/stm32wle5j8" ]
 stm32wle5jb = [ "stm32-metapac/stm32wle5jb" ]
 stm32wle5jc = [ "stm32-metapac/stm32wle5jc" ]
+
+# Local dev override: pin stm32-metapac to a local build of embassy-rs/stm32-data
+# (../stm32-data) until embassy-rs/stm32-data#878 merges and a new release is cut.
+[patch."https://github.com/embassy-rs/stm32-data-generated"]
+stm32-metapac = { path = "/Users/gmata/Axon/open_source_projects/embassy-project/stm32-data/build/stm32-metapac" }

--- a/embassy-stm32/Cargo.toml
+++ b/embassy-stm32/Cargo.toml
@@ -213,11 +213,11 @@ heapless = "0.9.1"
 once_cell = { version = "1.21.4", default-features = false, features=["critical-section"] }
 
 # stm32-metapac = { version = "21" }
-stm32-metapac = { git = "https://github.com/embassy-rs/stm32-data-generated", tag = "stm32-data-2791d2c04cb1dc8adc179d3813fe7ff5e6e599d8" }
+stm32-metapac = { git = "https://github.com/embassy-rs/stm32-data-generated", tag = "stm32-data-81a0691bb74668219b39408222a1c9a607033084" }
 
 [build-dependencies]
 # stm32-metapac = { version = "21", default-features = false, features = ["metadata"]}
-stm32-metapac = { git = "https://github.com/embassy-rs/stm32-data-generated", tag = "stm32-data-2791d2c04cb1dc8adc179d3813fe7ff5e6e599d8" , default-features = false, features = ["metadata"] }
+stm32-metapac = { git = "https://github.com/embassy-rs/stm32-data-generated", tag = "stm32-data-81a0691bb74668219b39408222a1c9a607033084" , default-features = false, features = ["metadata"] }
 
 proc-macro2 = "1.0.36"
 quote = "1.0.15"
@@ -1978,8 +1978,3 @@ stm32wle5cc = [ "stm32-metapac/stm32wle5cc" ]
 stm32wle5j8 = [ "stm32-metapac/stm32wle5j8" ]
 stm32wle5jb = [ "stm32-metapac/stm32wle5jb" ]
 stm32wle5jc = [ "stm32-metapac/stm32wle5jc" ]
-
-# Local dev override: pin stm32-metapac to a local build of embassy-rs/stm32-data
-# (../stm32-data) until embassy-rs/stm32-data#878 merges and a new release is cut.
-[patch."https://github.com/embassy-rs/stm32-data-generated"]
-stm32-metapac = { path = "/Users/gmata/Axon/open_source_projects/embassy-project/stm32-data/build/stm32-metapac" }

--- a/embassy-stm32/build.rs
+++ b/embassy-stm32/build.rs
@@ -1750,10 +1750,11 @@ fn main() {
         signals.entry(key).or_default().push(value);
     }
 
-    // The `i3c` module is only compiled in for STM32N6 today; on other families
-    // (e.g. STM32H5) that also expose an "i3c" peripheral kind, `crate::i3c` doesn't
-    // exist, so drop these signals there to avoid generating unresolvable pin_trait_impl!s.
-    if !chip_name.starts_with("stm32n6") {
+    // The `i3c` module is only compiled in for STM32N6, STM32H5, and STM32U3
+    // today; on other families that also expose an "i3c" peripheral kind,
+    // `crate::i3c` doesn't exist, so drop these signals there to avoid
+    // generating unresolvable pin_trait_impl!s.
+    if !(chip_name.starts_with("stm32n6") || chip_name.starts_with("stm32h5") || chip_name.starts_with("stm32u3")) {
         signals.remove(&("i3c", "SDA"));
         signals.remove(&("i3c", "SCL"));
     }

--- a/embassy-stm32/build.rs
+++ b/embassy-stm32/build.rs
@@ -1750,11 +1750,17 @@ fn main() {
         signals.entry(key).or_default().push(value);
     }
 
-    // The `i3c` module is only compiled in for STM32N6, STM32H5, and STM32U3
-    // today; on other families that also expose an "i3c" peripheral kind,
-    // `crate::i3c` doesn't exist, so drop these signals there to avoid
-    // generating unresolvable pin_trait_impl!s.
-    if !(chip_name.starts_with("stm32n6") || chip_name.starts_with("stm32h5") || chip_name.starts_with("stm32u3")) {
+    // The `i3c` module is only compiled in for STM32N6, STM32H5, STM32U3,
+    // STM32C5, and STM32H7R/H7S today; on other families that also expose an
+    // "i3c" peripheral kind, `crate::i3c` doesn't exist, so drop these
+    // signals there to avoid generating unresolvable pin_trait_impl!s.
+    if !(chip_name.starts_with("stm32n6")
+        || chip_name.starts_with("stm32h5")
+        || chip_name.starts_with("stm32u3")
+        || chip_name.starts_with("stm32c5")
+        || chip_name.starts_with("stm32h7r")
+        || chip_name.starts_with("stm32h7s"))
+    {
         signals.remove(&("i3c", "SDA"));
         signals.remove(&("i3c", "SCL"));
     }

--- a/embassy-stm32/src/adc/mod.rs
+++ b/embassy-stm32/src/adc/mod.rs
@@ -12,7 +12,7 @@
 #[cfg_attr(adc_l0, path = "v1.rs")]
 #[cfg_attr(adc_v2, path = "v2.rs")]
 #[cfg_attr(any(adc_v3, adc_g0, adc_h5, adc_h7rs, adc_u0), path = "v3.rs")]
-#[cfg_attr(any(adc_v4, adc_u5, adc_u3, adc_n6), path = "v4.rs")]
+#[cfg_attr(any(adc_v4, adc_u5, adc_u3, adc_n6, adc_c5), path = "v4.rs")]
 #[cfg_attr(adc_g4, path = "g4.rs")]
 #[cfg_attr(adc_c0, path = "c0.rs")]
 mod _version;
@@ -206,7 +206,9 @@ pub(crate) trait SealedAdcChannel<T> {
     }
 }
 
-#[cfg(any(adc_c0, adc_v3, adc_g0, adc_h5, adc_h7rs, adc_u0, adc_v4, adc_u5, adc_u3, adc_n6))]
+#[cfg(any(
+    adc_c0, adc_v3, adc_g0, adc_h5, adc_h7rs, adc_u0, adc_v4, adc_u5, adc_u3, adc_n6, adc_c5
+))]
 /// Number of samples used for averaging.
 #[derive(Copy, Clone, Debug)]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
@@ -220,9 +222,9 @@ pub enum Averaging {
     Samples64,
     Samples128,
     Samples256,
-    #[cfg(any(adc_c0, adc_v4, adc_u5, adc_u3, adc_n6))]
+    #[cfg(any(adc_c0, adc_v4, adc_u5, adc_u3, adc_n6, adc_c5))]
     Samples512,
-    #[cfg(any(adc_c0, adc_v4, adc_u5, adc_u3, adc_n6))]
+    #[cfg(any(adc_c0, adc_v4, adc_u5, adc_u3, adc_n6, adc_c5))]
     Samples1024,
 }
 
@@ -1017,7 +1019,7 @@ pub(crate) trait AnalogPin {
 impl<T: crate::gpio::SealedPin> AnalogPin for T {
     fn set_as_analog(&self) {
         #[cfg(any(
-            adc_v1, adc_c0, adc_l0, adc_v2, adc_g4, adc_v3, adc_v4, adc_u3, adc_u5, adc_wba, stm32n6
+            adc_v1, adc_c0, adc_l0, adc_v2, adc_g4, adc_v3, adc_v4, adc_u3, adc_u5, adc_wba, stm32n6, adc_c5
         ))]
         T::set_as_analog(self);
     }

--- a/embassy-stm32/src/adc/v4.rs
+++ b/embassy-stm32/src/adc/v4.rs
@@ -1,12 +1,12 @@
 #[cfg(stm32n6)]
 use pac::adc::vals::Adcaldif;
-#[cfg(not(stm32u3))]
+#[cfg(not(any(stm32u3, stm32c5)))]
 use pac::adc::vals::Difsel;
-#[cfg(not(any(stm32u5, stm32u3, stm32n6)))]
+#[cfg(not(any(stm32u5, stm32u3, stm32n6, stm32c5)))]
 use pac::adc::vals::{Adcaldif, Boost};
 #[allow(unused)]
 use pac::adc::vals::{Adstp, Dmngt, Exten, Pcsel};
-#[cfg(not(any(stm32u3, stm32n6)))]
+#[cfg(not(any(stm32u3, stm32n6, stm32c5)))]
 use pac::adccommon::vals::Presc;
 #[cfg(stm32n6)]
 pub use pac::adccommon::vals::{Damdf, Dual};
@@ -15,7 +15,9 @@ pub use pac::adccommon::vals::{Damdf, Dual};
 use crate::adc::DefaultInstance;
 #[cfg(not(stm32n6))]
 use crate::adc::Temperature;
-use crate::adc::{Adc, AdcRegs, Averaging, ConversionMode, Instance, Resolution, SampleTime, Vbat, VrefInt};
+#[cfg(not(stm32c5))]
+use crate::adc::Vbat;
+use crate::adc::{Adc, AdcRegs, Averaging, ConversionMode, Instance, Resolution, SampleTime, VrefInt};
 use crate::pac::adc::regs::{Sqr1, Sqr2, Sqr3, Sqr4};
 use crate::time::Hertz;
 use crate::wait::block_for_us;
@@ -37,6 +39,9 @@ const MAX_ADC_CLK_FREQ: Hertz = Hertz::mhz(55);
 const MAX_ADC_CLK_FREQ: Hertz = Hertz::mhz(48);
 #[cfg(stm32n6)]
 const MAX_ADC_CLK_FREQ: Hertz = Hertz::mhz(70);
+// No prescaler on C5, like U3; conservative placeholder pending datasheet confirmation.
+#[cfg(stm32c5)]
+const MAX_ADC_CLK_FREQ: Hertz = Hertz::mhz(48);
 
 #[cfg(stm32g4)]
 impl<T: Instance> super::ConverterFor<super::VrefInt> for T {
@@ -90,7 +95,7 @@ impl<T: DefaultInstance> super::ConverterFor<super::VrefInt> for T {
     const CHANNEL: u8 = 17;
 }
 
-#[cfg(not(any(stm32u3, stm32n6)))]
+#[cfg(not(any(stm32u3, stm32n6, stm32c5)))]
 fn from_ker_ck(frequency: Hertz) -> Presc {
     let raw_prescaler = rcc::raw_prescaler(frequency.0, MAX_ADC_CLK_FREQ.0);
     match raw_prescaler {
@@ -190,7 +195,7 @@ impl AdcRegs for crate::pac::adc::Adc {
 
         let mut smpr1 = self.smpr(0).read();
         let mut smpr2 = self.smpr(1).read();
-        #[cfg(not(stm32u3))]
+        #[cfg(not(any(stm32u3, stm32c5)))]
         let mut difsel = self.difsel().read();
 
         // Set sequence length
@@ -205,7 +210,7 @@ impl AdcRegs for crate::pac::adc::Adc {
                 smpr2.set_smp((channel - 10) as _, sample_time);
             }
 
-            #[cfg(not(stm32u3))]
+            #[cfg(not(any(stm32u3, stm32c5)))]
             {
                 difsel.set_difsel(
                     channel as _,
@@ -217,7 +222,7 @@ impl AdcRegs for crate::pac::adc::Adc {
                 );
             }
 
-            #[cfg(any(stm32h7, stm32u5, stm32u3, stm32n6))]
+            #[cfg(any(stm32h7, stm32u5, stm32u3, stm32n6, stm32c5))]
             {
                 self.cfgr2().modify(|w| w.set_lshift(0));
                 self.pcsel().modify(|w| w.set_pcsel(channel as _, Pcsel::Preselected));
@@ -246,7 +251,7 @@ impl AdcRegs for crate::pac::adc::Adc {
         self.sqr4().write_value(sqr4);
         self.smpr(0).write_value(smpr1);
         self.smpr(1).write_value(smpr2);
-        #[cfg(not(stm32u3))]
+        #[cfg(not(any(stm32u3, stm32c5)))]
         self.difsel().write_value(difsel);
     }
 }
@@ -303,14 +308,14 @@ impl<'d, T: Instance<Regs = crate::pac::adc::Adc>> Adc<'d, T> {
     pub fn new(adc: Peri<'d, T>) -> Self {
         rcc::enable_and_reset::<T>();
 
-        #[cfg(not(any(stm32u3, stm32n6)))]
+        #[cfg(not(any(stm32u3, stm32n6, stm32c5)))]
         let prescaler = from_ker_ck(T::frequency());
-        #[cfg(not(any(stm32u3, stm32n6)))]
+        #[cfg(not(any(stm32u3, stm32n6, stm32c5)))]
         T::common_regs().ccr().modify(|w| w.set_presc(prescaler));
-        #[cfg(not(any(stm32u3, stm32n6)))]
+        #[cfg(not(any(stm32u3, stm32n6, stm32c5)))]
         let frequency = T::frequency() / prescaler;
 
-        #[cfg(any(stm32u3, stm32n6))]
+        #[cfg(any(stm32u3, stm32n6, stm32c5))]
         let frequency = T::frequency();
 
         info!("ADC frequency set to {}", frequency);
@@ -344,7 +349,7 @@ impl<'d, T: Instance<Regs = crate::pac::adc::Adc>> Adc<'d, T> {
 
         block_for_us(10);
 
-        #[cfg(not(stm32u3))]
+        #[cfg(not(any(stm32u3, stm32c5)))]
         T::regs().difsel().modify(|w| {
             for n in 0..20 {
                 w.set_difsel(n, Difsel::SingleEnded);
@@ -353,7 +358,7 @@ impl<'d, T: Instance<Regs = crate::pac::adc::Adc>> Adc<'d, T> {
 
         #[cfg(not(stm32n6))]
         {
-            #[cfg(not(stm32u3))]
+            #[cfg(not(any(stm32u3, stm32c5)))]
             T::regs().cr().modify(|w| {
                 #[cfg(not(adc_u5))]
                 w.set_adcaldif(Adcaldif::SingleEnded);
@@ -466,6 +471,7 @@ impl<'d, T: Instance<Regs = crate::pac::adc::Adc>> Adc<'d, T> {
     }
 
     /// Enable reading the vbat internal channel.
+    #[cfg(not(stm32c5))]
     pub fn enable_vbat(&mut self) -> Vbat {
         T::common_regs().ccr().modify(|reg| {
             reg.set_vbaten(true);

--- a/embassy-stm32/src/i3c/controller.rs
+++ b/embassy-stm32/src/i3c/controller.rs
@@ -1,4 +1,4 @@
-//! Blocking I3C controller driver for STM32N6.
+//! Blocking I3C controller driver for STM32N6, STM32H5, and STM32U3.
 
 use core::marker::PhantomData;
 
@@ -15,6 +15,7 @@ use super::{
 use crate::gpio::Flex;
 use crate::mode::Blocking;
 use crate::pac::i3c::regs::Cr;
+use crate::pac::i3c::vals::{Crinit, Mend, Thres};
 use crate::rcc;
 
 /// I3C controller in blocking mode.
@@ -322,7 +323,7 @@ fn init_controller(info: &Info, config: Config) {
     let c = config.controller;
 
     regs.cfgr().modify(|w| w.set_en(false));
-    regs.cfgr().modify(|w| w.set_crinit(true));
+    regs.cfgr().modify(|w| w.set_crinit(Crinit::Controller));
 
     regs.timingr0().write(|w| {
         w.set_scll_pp(t.scl_pp_low);
@@ -349,10 +350,10 @@ fn init_controller(info: &Info, config: Config) {
     regs.cfgr().modify(|w| {
         w.set_hksdaen(c.high_keeper_sda);
         w.set_hjack(c.hot_join_allowed);
-        w.set_rxthres(false);
-        w.set_txthres(false);
+        w.set_rxthres(Thres::Byte);
+        w.set_txthres(Thres::Byte);
         w.set_tmode(false);
-        w.set_smode(false);
+        w.set_rmode(false);
     });
 
     if c.dynamic_addr != 0 {
@@ -404,7 +405,11 @@ fn write_ccc_cr(regs: crate::pac::i3c::I3c, ccc: u8, end: u32) {
         w.set_dcnt(0);
         w.set_ccc(ccc);
         w.set_mtype((MTYPE_CCC >> 27) as u8);
-        w.set_mend(end == GENERATE_STOP);
+        w.set_mend(if end == GENERATE_STOP {
+            Mend::Stop
+        } else {
+            Mend::RepeatedStart
+        });
     });
 }
 

--- a/embassy-stm32/src/i3c/mod.rs
+++ b/embassy-stm32/src/i3c/mod.rs
@@ -1,8 +1,9 @@
 //! Improved inter-integrated circuit (I3C)
 //!
-//! STM32N6 I3C1/I3C2 controller driver. Based on the STM32N6 HAL I3C driver
-//! (`stm32n6xx_hal_i3c`). Supports blocking controller operations: direct CCC,
-//! private transfers, broadcast CCC, and dynamic address assignment (ENTDAA).
+//! I3C controller driver for STM32N6, STM32H5, and STM32U3. Originally based on the
+//! STM32N6 HAL I3C driver (`stm32n6xx_hal_i3c`). Supports blocking controller
+//! operations: direct CCC, private transfers, broadcast CCC, and dynamic address
+//! assignment (ENTDAA).
 
 mod config;
 pub mod controller;

--- a/embassy-stm32/src/lib.rs
+++ b/embassy-stm32/src/lib.rs
@@ -151,11 +151,7 @@ pub mod hspi;
 pub mod i2c;
 #[cfg(any(spi_v1_i2s, spi_v2_i2s, spi_v3_i2s, spi_v4_i2s, spi_v5_i2s))]
 pub mod i2s;
-// Restricted to N6: the generic `i3c` cfg also covers other chips (e.g. H5)
-// whose I3C instances aren't all wired up with complete RCC metadata (some
-// lack an enable/reset bit entirely in the PAC data), which this
-// register-access-only driver hasn't been written or tested against.
-#[cfg(all(i3c, stm32n6))]
+#[cfg(all(i3c, any(stm32n6, stm32h5, stm32u3)))]
 pub mod i3c;
 #[cfg(icache)]
 pub mod icache;

--- a/embassy-stm32/src/lib.rs
+++ b/embassy-stm32/src/lib.rs
@@ -151,7 +151,7 @@ pub mod hspi;
 pub mod i2c;
 #[cfg(any(spi_v1_i2s, spi_v2_i2s, spi_v3_i2s, spi_v4_i2s, spi_v5_i2s))]
 pub mod i2s;
-#[cfg(all(i3c, any(stm32n6, stm32h5, stm32u3)))]
+#[cfg(all(i3c, any(stm32n6, stm32h5, stm32u3, stm32c5, stm32h7rs)))]
 pub mod i3c;
 #[cfg(icache)]
 pub mod icache;

--- a/embassy-stm32/src/rcc/c5.rs
+++ b/embassy-stm32/src/rcc/c5.rs
@@ -165,6 +165,7 @@ pub(crate) unsafe fn init(config: Config) {
     set_clocks!(
         sys: Some(sys),
         hclk1: Some(hclk),
+        hclk2: Some(hclk),
         pclk1: Some(apb1),
         pclk1_tim: Some(hclk),
         pclk2: Some(apb2),


### PR DESCRIPTION
## Summary
- Widens the I3C controller driver (added for STM32N6 in #6571) to also cover STM32H5, STM32U3, STM32C5, and STM32H7R/H7S.
- All five families share the same unified `i3c_v1` register block in stm32-data ([embassy-rs/stm32-data#878](https://github.com/embassy-rs/stm32-data/pull/878), merged) - N6 previously had its own separate `i3c_n6` block that turned out to be byte-for-bit identical, just with YAML-authoring drift (field naming/typing differences).
- Updates `controller.rs` for the unified PAC API: `CFGR.RMODE` (was `SMODE` on the old N6-only block), and enum-typed `CRINIT`/`THRES`/`MEND` fields instead of plain bools.
- Bumps `stm32-metapac` to the tag containing the merged stm32-data changes.