### PR TITLE
embassy-usb: Clippy fixes

### DIFF
--- a/embassy-usb/CHANGELOG.md
+++ b/embassy-usb/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## Unreleased - ReleaseDate
 
 - Bump usbd-hid from 0.9.0 to 0.10.0
+- `UAC1`: Add audio source
+- `UAC1`: `Speaker::new` now returns `Self` with the parts inside instead of a tuple
 
 ## 0.6.0 - 2026-03-10
 

--- a/embassy-usb/README.md
+++ b/embassy-usb/README.md
@@ -37,11 +37,11 @@ and counts of buffers.
 They can be set in two ways:
 
 - Via Cargo features: enable a feature like `<name>-<value>`. `name` must be in lowercase and
-use dashes instead of underscores. For example. `max-interface-count-3`. Only a selection of values
-is available, check `Cargo.toml` for the list.
+  use dashes instead of underscores. For example. `max-interface-count-3`. Only a selection of values
+  is available, check `Cargo.toml` for the list.
 - Via environment variables at build time: set the variable named `EMBASSY_USB_<value>`. For example
-`EMBASSY_USB_MAX_INTERFACE_COUNT=3 cargo build`. You can also set them in the `[env]` section of `.cargo/config.toml`.
-Any value can be set, unlike with Cargo features.
+  `EMBASSY_USB_MAX_INTERFACE_COUNT=3 cargo build`. You can also set them in the `[env]` section of `.cargo/config.toml`.
+  Any value can be set, unlike with Cargo features.
 
 Environment variables take precedence over Cargo features. If two Cargo features are enabled for the same setting
 with different values, compilation fails.

--- a/embassy-usb/build.rs
+++ b/embassy-usb/build.rs
@@ -60,27 +60,28 @@ fn main() {
         }
 
         if let Some(feature) = var.strip_prefix("CARGO_FEATURE_")
-            && let Some(i) = feature.rfind('_') {
-                let name = &feature[..i];
-                let value = &feature[i + 1..];
-                if let Some(cfg) = configs.get_mut(name) {
-                    let Ok(value) = value.parse::<usize>() else {
-                        panic!("Invalid value for feature {name}: {value}")
-                    };
+            && let Some(i) = feature.rfind('_')
+        {
+            let name = &feature[..i];
+            let value = &feature[i + 1..];
+            if let Some(cfg) = configs.get_mut(name) {
+                let Ok(value) = value.parse::<usize>() else {
+                    panic!("Invalid value for feature {name}: {value}")
+                };
 
-                    // envvars take priority.
-                    if !cfg.seen_env {
-                        assert!(
-                            !cfg.seen_feature,
-                            "multiple values set for feature {}: {} and {}",
-                            name, cfg.value, value
-                        );
+                // envvars take priority.
+                if !cfg.seen_env {
+                    assert!(
+                        !cfg.seen_feature,
+                        "multiple values set for feature {}: {} and {}",
+                        name, cfg.value, value
+                    );
 
-                        cfg.value = value;
-                        cfg.seen_feature = true;
-                    }
+                    cfg.value = value;
+                    cfg.seen_feature = true;
                 }
             }
+        }
     }
 
     let mut data = String::new();

--- a/embassy-usb/build.rs
+++ b/embassy-usb/build.rs
@@ -59,8 +59,8 @@ fn main() {
             cfg.seen_env = true;
         }
 
-        if let Some(feature) = var.strip_prefix("CARGO_FEATURE_") {
-            if let Some(i) = feature.rfind('_') {
+        if let Some(feature) = var.strip_prefix("CARGO_FEATURE_")
+            && let Some(i) = feature.rfind('_') {
                 let name = &feature[..i];
                 let value = &feature[i + 1..];
                 if let Some(cfg) = configs.get_mut(name) {
@@ -81,7 +81,6 @@ fn main() {
                     }
                 }
             }
-        }
     }
 
     let mut data = String::new();

--- a/embassy-usb/src/builder.rs
+++ b/embassy-usb/src/builder.rs
@@ -504,13 +504,13 @@ impl<'a, 'd, D: Driver<'d>> InterfaceAltBuilder<'a, 'd, D> {
         max_packet_size: u16,
         interval_ms: u8,
     ) -> D::EndpointIn {
-        let ep = self
+        
+
+        self
             .builder
             .driver
             .alloc_endpoint_in(ep_type, ep_addr, max_packet_size, interval_ms)
-            .expect("alloc_endpoint_in failed");
-
-        ep
+            .expect("alloc_endpoint_in failed")
     }
 
     fn endpoint_in(
@@ -539,13 +539,13 @@ impl<'a, 'd, D: Driver<'d>> InterfaceAltBuilder<'a, 'd, D> {
         max_packet_size: u16,
         interval_ms: u8,
     ) -> D::EndpointOut {
-        let ep = self
+        
+
+        self
             .builder
             .driver
             .alloc_endpoint_out(ep_type, ep_addr, max_packet_size, interval_ms)
-            .expect("alloc_endpoint_out failed");
-
-        ep
+            .expect("alloc_endpoint_out failed")
     }
 
     fn endpoint_out(

--- a/embassy-usb/src/builder.rs
+++ b/embassy-usb/src/builder.rs
@@ -510,7 +510,6 @@ impl<'a, 'd, D: Driver<'d>> InterfaceAltBuilder<'a, 'd, D> {
             .expect("alloc_endpoint_in failed")
     }
 
-    #[allow(clippy::too_many_arguments)]
     fn endpoint_in(
         &mut self,
         ep_type: EndpointType,
@@ -543,7 +542,6 @@ impl<'a, 'd, D: Driver<'d>> InterfaceAltBuilder<'a, 'd, D> {
             .expect("alloc_endpoint_out failed")
     }
 
-    #[allow(clippy::too_many_arguments)]
     fn endpoint_out(
         &mut self,
         ep_type: EndpointType,

--- a/embassy-usb/src/builder.rs
+++ b/embassy-usb/src/builder.rs
@@ -510,6 +510,7 @@ impl<'a, 'd, D: Driver<'d>> InterfaceAltBuilder<'a, 'd, D> {
             .expect("alloc_endpoint_in failed")
     }
 
+    #[allow(clippy::too_many_arguments)]
     fn endpoint_in(
         &mut self,
         ep_type: EndpointType,
@@ -542,6 +543,7 @@ impl<'a, 'd, D: Driver<'d>> InterfaceAltBuilder<'a, 'd, D> {
             .expect("alloc_endpoint_out failed")
     }
 
+    #[allow(clippy::too_many_arguments)]
     fn endpoint_out(
         &mut self,
         ep_type: EndpointType,

--- a/embassy-usb/src/builder.rs
+++ b/embassy-usb/src/builder.rs
@@ -504,10 +504,7 @@ impl<'a, 'd, D: Driver<'d>> InterfaceAltBuilder<'a, 'd, D> {
         max_packet_size: u16,
         interval_ms: u8,
     ) -> D::EndpointIn {
-        
-
-        self
-            .builder
+        self.builder
             .driver
             .alloc_endpoint_in(ep_type, ep_addr, max_packet_size, interval_ms)
             .expect("alloc_endpoint_in failed")
@@ -539,10 +536,7 @@ impl<'a, 'd, D: Driver<'d>> InterfaceAltBuilder<'a, 'd, D> {
         max_packet_size: u16,
         interval_ms: u8,
     ) -> D::EndpointOut {
-        
-
-        self
-            .builder
+        self.builder
             .driver
             .alloc_endpoint_out(ep_type, ep_addr, max_packet_size, interval_ms)
             .expect("alloc_endpoint_out failed")

--- a/embassy-usb/src/builder.rs
+++ b/embassy-usb/src/builder.rs
@@ -2,12 +2,12 @@ use heapless::Vec;
 
 use crate::config::MAX_HANDLER_COUNT;
 use crate::descriptor::{
-    BosWriter, DescriptorWriter, SynchronizationType, UsageType, rewrite_config_descriptor_for_high_speed,
+    self, BosWriter, DescriptorWriter, SynchronizationType, UsageType, rewrite_config_descriptor_for_high_speed,
 };
 use crate::driver::{Driver, Endpoint, EndpointAddress, EndpointInfo, EndpointType};
 use crate::msos::{DeviceLevelDescriptor, FunctionLevelDescriptor, MsOsDescriptorWriter};
 use crate::types::{InterfaceNumber, StringIndex};
-use crate::{Handler, Interface, MAX_INTERFACE_COUNT, STRING_INDEX_CUSTOM_START, UsbDevice};
+use crate::{Handler, Inner, Interface, MAX_INTERFACE_COUNT, STRING_INDEX_CUSTOM_START, UsbDevice, UsbDeviceState};
 
 #[derive(Debug, Copy, Clone)]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
@@ -254,16 +254,43 @@ impl<'d, D: Driver<'d>> Builder<'d, D> {
         trace!("USB: msos_descriptor used: {}", msos_descriptor.len());
         trace!("USB: control_buf size: {}", self.control_buf.len());
 
-        UsbDevice::build(
-            self.driver,
-            self.config,
-            self.handlers,
-            config_descriptor,
-            self.bos_descriptor.writer.into_buf(),
-            msos_descriptor,
-            self.interfaces,
-            self.control_buf,
-        )
+        {
+            let driver = self.driver;
+            let config = self.config;
+            let handlers = self.handlers;
+            let bos_descriptor: &'d [u8] = self.bos_descriptor.writer.into_buf();
+            let interfaces = self.interfaces;
+            let control_buf: &'d mut [u8] = self.control_buf;
+
+            // Start the USB bus.
+            // This prevent further allocation by consuming the driver.
+            let (bus, control) = driver.start(config.max_packet_size_0 as u16);
+            let device_descriptor = descriptor::device_descriptor(&config);
+            let device_qualifier_descriptor = descriptor::device_qualifier_descriptor(&config);
+
+            UsbDevice {
+                control_buf,
+                control,
+                inner: Inner {
+                    bus,
+                    config,
+                    device_descriptor,
+                    device_qualifier_descriptor,
+                    config_descriptor,
+                    bos_descriptor,
+                    msos_descriptor,
+
+                    device_state: UsbDeviceState::Unpowered,
+                    suspended: false,
+                    remote_wakeup_enabled: false,
+                    self_powered: false,
+                    address: 0,
+                    set_address_pending: false,
+                    interfaces,
+                    handlers,
+                },
+            }
+        }
     }
 
     /// Returns the size of the control request data buffer. Can be used by

--- a/embassy-usb/src/builder.rs
+++ b/embassy-usb/src/builder.rs
@@ -231,65 +231,68 @@ impl<'d, D: Driver<'d>> Builder<'d, D> {
     }
 
     /// Creates the [`UsbDevice`] instance with the configuration in this builder.
-    pub fn build(mut self) -> UsbDevice<'d, D> {
-        let msos_descriptor = self.msos_descriptor.build(&mut self.bos_descriptor);
+    pub fn build(self) -> UsbDevice<'d, D> {
+        let Self {
+            config,
+            handlers,
+            interfaces,
+            control_buf,
+            driver,
+            next_string_index: _,
+            mut config_descriptor,
+            mut bos_descriptor,
+            msos_descriptor,
+        } = self;
 
-        self.config_descriptor.end_configuration();
-        self.bos_descriptor.end_bos();
+        let msos_descriptor = msos_descriptor.build(&mut bos_descriptor);
 
-        if self.config.max_speed == UsbDeviceSpeed::High {
+        config_descriptor.end_configuration();
+        let config_descriptor = config_descriptor.into_buf();
+
+        bos_descriptor.end_bos();
+        let bos_descriptor = bos_descriptor.writer.into_buf();
+
+        if config.max_speed == UsbDeviceSpeed::High {
             assert!(
-                self.config.max_packet_size_0 == 64,
+                config.max_packet_size_0 == 64,
                 "high-speed USB requires max_packet_size_0 = 64"
             );
-            let used = self.config_descriptor.position();
-            rewrite_config_descriptor_for_high_speed(&mut self.config_descriptor.buf[..used]);
+            rewrite_config_descriptor_for_high_speed(config_descriptor);
         }
-
-        let config_descriptor = self.config_descriptor.into_buf();
 
         // Log the number of allocator bytes actually used in descriptor buffers
         trace!("USB: config_descriptor used: {}", config_descriptor.len());
-        trace!("USB: bos_descriptor used: {}", self.bos_descriptor.writer.position());
+        trace!("USB: bos_descriptor used: {}", bos_descriptor.len());
         trace!("USB: msos_descriptor used: {}", msos_descriptor.len());
-        trace!("USB: control_buf size: {}", self.control_buf.len());
+        trace!("USB: control_buf size: {}", control_buf.len());
 
-        {
-            let driver = self.driver;
-            let config = self.config;
-            let handlers = self.handlers;
-            let bos_descriptor: &'d [u8] = self.bos_descriptor.writer.into_buf();
-            let interfaces = self.interfaces;
-            let control_buf: &'d mut [u8] = self.control_buf;
+        // Start the USB bus.
+        // This prevent further allocation by consuming the driver.
+        let (bus, control) = driver.start(config.max_packet_size_0 as u16);
+        let device_descriptor = descriptor::device_descriptor(&config);
+        let device_qualifier_descriptor = descriptor::device_qualifier_descriptor(&config);
 
-            // Start the USB bus.
-            // This prevent further allocation by consuming the driver.
-            let (bus, control) = driver.start(config.max_packet_size_0 as u16);
-            let device_descriptor = descriptor::device_descriptor(&config);
-            let device_qualifier_descriptor = descriptor::device_qualifier_descriptor(&config);
+        UsbDevice {
+            control_buf,
+            control,
+            inner: Inner {
+                bus,
+                config,
+                device_descriptor,
+                device_qualifier_descriptor,
+                config_descriptor,
+                bos_descriptor,
+                msos_descriptor,
 
-            UsbDevice {
-                control_buf,
-                control,
-                inner: Inner {
-                    bus,
-                    config,
-                    device_descriptor,
-                    device_qualifier_descriptor,
-                    config_descriptor,
-                    bos_descriptor,
-                    msos_descriptor,
-
-                    device_state: UsbDeviceState::Unpowered,
-                    suspended: false,
-                    remote_wakeup_enabled: false,
-                    self_powered: false,
-                    address: 0,
-                    set_address_pending: false,
-                    interfaces,
-                    handlers,
-                },
-            }
+                device_state: UsbDeviceState::Unpowered,
+                suspended: false,
+                remote_wakeup_enabled: false,
+                self_powered: false,
+                address: 0,
+                set_address_pending: false,
+                interfaces,
+                handlers,
+            },
         }
     }
 

--- a/embassy-usb/src/class/cdc_acm.rs
+++ b/embassy-usb/src/class/cdc_acm.rs
@@ -599,13 +599,13 @@ impl<'d, D: Driver<'d>> embedded_io_async::Read for BufferedReceiver<'d, D> {
         //
         // It's important that `start` and `end` be updated in this order so they're left in a
         // consistent state if the `read` future is dropped mid-execution, e.g. from a timeout.
-        match self.receiver.read_packet(&mut self.buffer).await {
+        match self.receiver.read_packet(self.buffer).await {
             Ok(n) => self.end = n,
             Err(EndpointError::BufferOverflow) => unreachable!(),
             Err(EndpointError::Disabled) => return Err(CdcAcmError::NotConnected),
         }
         self.start = 0;
-        return Ok(self.read_from_buffer(buf));
+        Ok(self.read_from_buffer(buf))
     }
 }
 

--- a/embassy-usb/src/class/cdc_acm.rs
+++ b/embassy-usb/src/class/cdc_acm.rs
@@ -626,7 +626,7 @@ pub enum StopBits {
 impl From<u8> for StopBits {
     fn from(value: u8) -> Self {
         if value <= 2 {
-            unsafe { mem::transmute(value) }
+            unsafe { mem::transmute::<u8, StopBits>(value) }
         } else {
             StopBits::One
         }
@@ -652,7 +652,7 @@ pub enum ParityType {
 impl From<u8> for ParityType {
     fn from(value: u8) -> Self {
         if value <= 4 {
-            unsafe { mem::transmute(value) }
+            unsafe { mem::transmute::<u8, ParityType>(value) }
         } else {
             ParityType::None
         }

--- a/embassy-usb/src/class/cdc_ncm/embassy_net.rs
+++ b/embassy-usb/src/class/cdc_ncm/embassy_net.rs
@@ -21,6 +21,12 @@ impl<const MTU: usize, const N_RX: usize, const N_TX: usize> State<MTU, N_RX, N_
     }
 }
 
+impl<const MTU: usize, const N_RX: usize, const N_TX: usize> Default for State<MTU, N_RX, N_TX> {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 /// Background runner for the CDC-NCM class.
 ///
 /// You must call `.run()` in a background task for the class to operate.

--- a/embassy-usb/src/class/cdc_ncm/mod.rs
+++ b/embassy-usb/src/class/cdc_ncm/mod.rs
@@ -70,7 +70,7 @@ const ALTERNATE_SETTING_DISABLED: u8 = 0x00;
 const ALTERNATE_SETTING_ENABLED: u8 = 0x01;
 
 /// Simple NTB header (NTH+NDP all in one) for sending packets
-#[repr(packed)]
+#[repr(C, packed)]
 #[allow(unused)]
 struct NtbOutHeader {
     // NTH
@@ -90,7 +90,7 @@ struct NtbOutHeader {
     ndp_term2: u16,
 }
 
-#[repr(packed)]
+#[repr(C, packed)]
 #[allow(unused)]
 struct NtbParameters {
     length: u16,
@@ -99,7 +99,7 @@ struct NtbParameters {
     out_params: NtbParametersDir,
 }
 
-#[repr(packed)]
+#[repr(C, packed)]
 #[allow(unused)]
 struct NtbParametersDir {
     max_size: u32,

--- a/embassy-usb/src/class/cmsis_dap_v2.rs
+++ b/embassy-usb/src/class/cmsis_dap_v2.rs
@@ -35,6 +35,12 @@ impl State {
     }
 }
 
+impl Default for State {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 /// USB device class for CMSIS-DAP v2 probes.
 pub struct CmsisDapV2Class<'d, D: Driver<'d>> {
     read_ep: D::EndpointOut,

--- a/embassy-usb/src/class/dfu/dfu_mode.rs
+++ b/embassy-usb/src/class/dfu/dfu_mode.rs
@@ -48,7 +48,7 @@ pub struct DfuState<H: Handler> {
     next_block_num: usize,
 }
 
-impl<'d, H: Handler> DfuState<H> {
+impl<H: Handler> DfuState<H> {
     /// Create a new DFU instance to handle DFU transfers.
     pub fn new(handler: H, attrs: DfuAttributes) -> Self {
         Self {

--- a/embassy-usb/src/class/uac1/source.rs
+++ b/embassy-usb/src/class/uac1/source.rs
@@ -239,7 +239,7 @@ impl<'d, D: Driver<'d>> AudioSource<'d, D> {
 
         // ALLOCATE the Isochronous IN Endpoint for Audio Data (AudioStream -> Host)
         let max_packet_size: u16 =
-            calculate_max_packet_size(*max_rate as u32, MAX_AUDIO_CHANNEL_COUNT as u8, sample_width as u8);
+            calculate_max_packet_size(*max_rate , MAX_AUDIO_CHANNEL_COUNT as u8, sample_width as u8);
         let audio_in_endpoint: <D as Driver<'d>>::EndpointIn = b.alloc_endpoint_in(
             EndpointType::Isochronous, // Endpoint type
             None,                      // Specific address (None lets the driver assign it, e.g., 0x81)
@@ -326,7 +326,7 @@ impl<'d, D: Driver<'d>> AudioSource<'d, D> {
         let ba_iface_nr = u8::from(iface_ctrl_num) + 1;
         {
             let mut alt_ctrl = iface_ctrl.alt_setting(USB_AUDIO_CLASS, USB_AUDIOCONTROL_SUBCLASS, PROTOCOL_NONE, None);
-            Self::create_control_function(&mut alt_ctrl, ba_iface_nr.into(), terminal_type);
+            Self::create_control_function(&mut alt_ctrl, ba_iface_nr, terminal_type);
         }
         // Create Audio Source Interface (IF 1) - TWO Alternate Settings
         // Alternate Setting 1: ACTIVE with Isochronous IN Endpoint
@@ -388,7 +388,8 @@ impl AudioSourceControlHandler {
         iface_ctrl_num: InterfaceNumber,
         iface_stream_num: InterfaceNumber,
     ) -> Self {
-        let obj = AudioSourceControlHandler {
+        
+        AudioSourceControlHandler {
             current_volume: [0, 0, 0],
             current_mute: [0, 0, 0],
             current_sample_rate_index: 0, // Default to the first supported sample rate index
@@ -398,8 +399,7 @@ impl AudioSourceControlHandler {
             ep_feedback_addr,
             iface_ctrl_num,
             iface_stream_num,
-        };
-        obj
+        }
     }
 
     fn handle_control_in<'r>(&'r mut self, req: Request, data: &'r mut [u8]) -> Option<InResponse<'r>> {
@@ -496,29 +496,29 @@ impl AudioSourceControlHandler {
         );
 
         match req.request {
-            SET_CUR | SET_RES => match control_selector as u8 {
+            SET_CUR | SET_RES => match control_selector {
                 VOLUME_CONTROL if channel < 3 && data.len() >= 2 => {
                     self.current_volume[channel] = i16::from_le_bytes([data[0], data[1]]);
                     debug!(
                         "AudioSourceControlHandler: Volume set: ch{} = {} (raw)",
                         channel, self.current_volume[channel]
                     );
-                    return Some(OutResponse::Accepted);
+                    Some(OutResponse::Accepted)
                 }
-                MUTE_CONTROL if channel < 3 && data.len() >= 1 => {
+                MUTE_CONTROL if channel < 3 && !data.is_empty() => {
                     self.current_mute[channel] = data[0];
                     debug!(
                         "AudioSourceControlHandler: Mute set: ch{} = {}",
                         channel, self.current_mute[channel]
                     );
-                    return Some(OutResponse::Accepted);
+                    Some(OutResponse::Accepted)
                 }
                 _ => {
                     debug!(
                         "AudioSourceControlHandler: Unsupported control selector {:?}. Rejected!",
                         control_selector
                     );
-                    return Some(OutResponse::Rejected);
+                    Some(OutResponse::Rejected)
                 }
             },
             _ => {
@@ -526,7 +526,7 @@ impl AudioSourceControlHandler {
                     "AudioSourceControlHandler: Unsupported request {:#02X}. Rejected!",
                     req.request
                 );
-                return Some(OutResponse::Rejected);
+                Some(OutResponse::Rejected)
             }
         }
     }
@@ -568,7 +568,7 @@ impl AudioSourceControlHandler {
                 );
             }
         }
-        return Some(InResponse::Rejected);
+        Some(InResponse::Rejected)
     }
 
     fn handle_ep_out(&mut self, req: Request, buf: &[u8]) -> Option<OutResponse> {
@@ -590,7 +590,7 @@ impl AudioSourceControlHandler {
                         buf
                     );
 
-                    let rate = ((buf[0] as u32) | (buf[1] as u32) << 8 | (buf[2] as u32) << 16) as u32;
+                    let rate = (buf[0] as u32) | (buf[1] as u32) << 8 | (buf[2] as u32) << 16 ;
                     let current_rate = self.supported_sample_rates[self.current_sample_rate_index];
 
                     if rate == current_rate {

--- a/embassy-usb/src/class/uac1/source.rs
+++ b/embassy-usb/src/class/uac1/source.rs
@@ -1,5 +1,3 @@
-use core::marker::PhantomData;
-
 use embassy_sync::blocking_mutex::raw::CriticalSectionRawMutex;
 use embassy_sync::pubsub::{PubSubChannel, Publisher, Subscriber};
 use embassy_usb_driver::{EndpointAddress, EndpointIn, EndpointOut};
@@ -102,7 +100,12 @@ impl<'d, D: Driver<'d>> AudioSourceEpOut<'d, D> {
 
 /// Implementation of the Audio Source interface
 pub struct AudioSource<'d, D: Driver<'d>> {
-    phantom: PhantomData<&'d D>,
+    /// Audio In Enpoint
+    pub audio_ep_in: AudioSourceEpIn<'d, D>,
+    /// Feedback In Endpoint
+    pub feedback_ep_in: AudioSourceEpIn<'d, D>,
+    /// Control Handler
+    pub handler: AudioSourceControlHandler,
 }
 
 impl<'d, D: Driver<'d>> AudioSource<'d, D> {
@@ -308,11 +311,7 @@ impl<'d, D: Driver<'d>> AudioSource<'d, D> {
         sample_width: SampleWidth,
         fedback_refresh_period_ms: u8,
         terminal_type: Option<TerminalType>,
-    ) -> (
-        AudioSourceEpIn<'d, D>,
-        AudioSourceEpIn<'d, D>,
-        AudioSourceControlHandler,
-    ) {
+    ) -> Self {
         // Create the Audio Function (IAD groups IF0 & IF1)
         let mut func = b.function(USB_AUDIO_CLASS, USB_AUDIOCONTROL_SUBCLASS, PROTOCOL_NONE);
 
@@ -347,17 +346,17 @@ impl<'d, D: Driver<'d>> AudioSource<'d, D> {
         let ep_audio_addr = ep_audio_in.info().addr;
         let ep_feedback_addr = ep_feedback_in.info().addr;
 
-        (
-            AudioSourceEpIn { ep: ep_audio_in },
-            AudioSourceEpIn { ep: ep_feedback_in },
-            AudioSourceControlHandler::new(
+        Self {
+            audio_ep_in: AudioSourceEpIn { ep: ep_audio_in },
+            feedback_ep_in: AudioSourceEpIn { ep: ep_feedback_in },
+            handler: AudioSourceControlHandler::new(
                 sample_rates,
                 ep_audio_addr,
                 ep_feedback_addr,
                 iface_ctrl_num,
                 iface_stream_num,
             ),
-        )
+        }
     }
 }
 

--- a/embassy-usb/src/class/uac1/source.rs
+++ b/embassy-usb/src/class/uac1/source.rs
@@ -331,8 +331,7 @@ impl<'d, D: Driver<'d>> AudioSource<'d, D> {
         let iface_stream_num = iface_stream.interface_number();
 
         // Alternate Setting 0 (INACTIVE - Zero Bandwidth)
-        let alt_setting = iface_stream.alt_setting(USB_AUDIO_CLASS, USB_AUDIOSTREAMING_SUBCLASS, PROTOCOL_NONE, None);
-        drop(alt_setting);
+        let _alt_setting = iface_stream.alt_setting(USB_AUDIO_CLASS, USB_AUDIOSTREAMING_SUBCLASS, PROTOCOL_NONE, None);
 
         // Alternate Setting 1 (ACTIVE - With Endpoints)
         let mut alt_setting =

--- a/embassy-usb/src/class/uac1/source.rs
+++ b/embassy-usb/src/class/uac1/source.rs
@@ -665,7 +665,7 @@ impl AudioSourceControlHandler {
     }
 }
 
-impl<'d> Handler for AudioSourceControlHandler {
+impl Handler for AudioSourceControlHandler {
     /// Called when the host has set the address of the device to `addr`.
     fn addressed(&mut self, addr: u8) {
         debug!("AudioSourceControlHandler: Host set address to: {:#02X}", addr);

--- a/embassy-usb/src/class/uac1/source.rs
+++ b/embassy-usb/src/class/uac1/source.rs
@@ -239,7 +239,7 @@ impl<'d, D: Driver<'d>> AudioSource<'d, D> {
 
         // ALLOCATE the Isochronous IN Endpoint for Audio Data (AudioStream -> Host)
         let max_packet_size: u16 =
-            calculate_max_packet_size(*max_rate , MAX_AUDIO_CHANNEL_COUNT as u8, sample_width as u8);
+            calculate_max_packet_size(*max_rate, MAX_AUDIO_CHANNEL_COUNT as u8, sample_width as u8);
         let audio_in_endpoint: <D as Driver<'d>>::EndpointIn = b.alloc_endpoint_in(
             EndpointType::Isochronous, // Endpoint type
             None,                      // Specific address (None lets the driver assign it, e.g., 0x81)
@@ -388,7 +388,6 @@ impl AudioSourceControlHandler {
         iface_ctrl_num: InterfaceNumber,
         iface_stream_num: InterfaceNumber,
     ) -> Self {
-        
         AudioSourceControlHandler {
             current_volume: [0, 0, 0],
             current_mute: [0, 0, 0],
@@ -590,7 +589,7 @@ impl AudioSourceControlHandler {
                         buf
                     );
 
-                    let rate = (buf[0] as u32) | (buf[1] as u32) << 8 | (buf[2] as u32) << 16 ;
+                    let rate = (buf[0] as u32) | (buf[1] as u32) << 8 | (buf[2] as u32) << 16;
                     let current_rate = self.supported_sample_rates[self.current_sample_rate_index];
 
                     if rate == current_rate {

--- a/embassy-usb/src/class/uac1/source.rs
+++ b/embassy-usb/src/class/uac1/source.rs
@@ -1,5 +1,4 @@
 use core::marker::PhantomData;
-use core::usize;
 
 use embassy_sync::blocking_mutex::raw::CriticalSectionRawMutex;
 use embassy_sync::pubsub::{PubSubChannel, Publisher, Subscriber};
@@ -115,10 +114,7 @@ impl<'d, D: Driver<'d>> AudioSource<'d, D> {
     ) {
         // USB Device Class Definition for Audio Devices
         // 4.3.2.1 Input Terminal Descriptor
-        let mut w_terminal_type: u16 = TerminalType::InMicrophone.into();
-        if terminal_type.is_some() {
-            w_terminal_type = terminal_type.unwrap().into();
-        }
+        let w_terminal_type: u16 = terminal_type.unwrap_or(TerminalType::InMicrophone).into();
 
         let channels_cfg: u16 = ChannelConfig::LeftFront as u16 | ChannelConfig::RightFront as u16;
         let input_terminal_descriptor: [u8; 10] = [

--- a/embassy-usb/src/class/uac1/speaker.rs
+++ b/embassy-usb/src/class/uac1/speaker.rs
@@ -447,8 +447,6 @@ pub struct ControlMonitor<'d> {
 
 impl<'d> ControlMonitor<'d> {
     fn audio_settings(&self) -> AudioSettings {
-        
-
         self.shared.audio_settings.lock(|x| x.get())
     }
 
@@ -625,8 +623,6 @@ impl<'d> Control<'d> {
         match req.request {
             GET_CUR => match control_unit {
                 VOLUME_CONTROL => {
-                    
-
                     let volume: i16 = match channel_index as usize {
                         ..=MAX_AUDIO_CHANNEL_INDEX => audio_settings.volume_8q8_db[channel_index as usize],
                         _ => return Some(InResponse::Rejected),
@@ -639,8 +635,6 @@ impl<'d> Control<'d> {
                     Some(InResponse::Accepted(&buf[..2]))
                 }
                 MUTE_CONTROL => {
-                    
-
                     let mute_state: bool = match channel_index as usize {
                         ..=MAX_AUDIO_CHANNEL_INDEX => audio_settings.muted[channel_index as usize],
                         _ => return Some(InResponse::Rejected),

--- a/embassy-usb/src/class/uac1/speaker.rs
+++ b/embassy-usb/src/class/uac1/speaker.rs
@@ -12,7 +12,6 @@
 
 use core::cell::{Cell, RefCell};
 use core::future::{Future, poll_fn};
-use core::marker::PhantomData;
 use core::sync::atomic::{AtomicBool, AtomicU32, Ordering};
 use core::task::Poll;
 
@@ -84,7 +83,12 @@ impl<'d> State<'d> {
 
 /// Implementation of the USB audio class 1.0.
 pub struct Speaker<'d, D: Driver<'d>> {
-    phantom: PhantomData<&'d D>,
+    /// Stream
+    pub stream: Stream<'d, D>,
+    /// Feedback
+    pub feedback: Feedback<'d, D>,
+    /// Control Monitor
+    pub control_monitor: ControlMonitor<'d>,
 }
 
 impl<'d, D: Driver<'d>> Speaker<'d, D> {
@@ -112,7 +116,7 @@ impl<'d, D: Driver<'d>> Speaker<'d, D> {
         sample_rates_hz: &[u32],
         channels: &'d [Channel],
         feedback_refresh_period: FeedbackRefresh,
-    ) -> (Stream<'d, D>, Feedback<'d, D>, ControlMonitor<'d>) {
+    ) -> Self {
         // The class and subclass fields of the IAD aren't required to match the class and subclass fields of
         // the interfaces in the interface collection that the IAD describes. Microsoft recommends that
         // the first interface of the collection has class and subclass fields that match the class and
@@ -325,11 +329,11 @@ impl<'d, D: Driver<'d>> Speaker<'d, D> {
 
         let control = &state.shared;
 
-        (
-            Stream { streaming_endpoint },
-            Feedback { feedback_endpoint },
-            ControlMonitor { shared: control },
-        )
+        Self {
+            stream: Stream { streaming_endpoint },
+            feedback: Feedback { feedback_endpoint },
+            control_monitor: ControlMonitor { shared: control },
+        }
     }
 }
 

--- a/embassy-usb/src/class/uac1/speaker.rs
+++ b/embassy-usb/src/class/uac1/speaker.rs
@@ -248,8 +248,7 @@ impl<'d, D: Driver<'d>> Speaker<'d, D> {
         // =====================================================
         // Audio streaming interface, zero-bandwidth [UAC 4.5.1]
         let mut interface = func.interface();
-        let alt = interface.alt_setting(USB_AUDIO_CLASS, USB_AUDIOSTREAMING_SUBCLASS, PROTOCOL_NONE, None);
-        drop(alt);
+        let _alt = interface.alt_setting(USB_AUDIO_CLASS, USB_AUDIOSTREAMING_SUBCLASS, PROTOCOL_NONE, None);
 
         // ==================================================
         // Audio streaming interface, operational [UAC 4.5.1]

--- a/embassy-usb/src/class/uac1/speaker.rs
+++ b/embassy-usb/src/class/uac1/speaker.rs
@@ -121,7 +121,7 @@ impl<'d, D: Driver<'d>> Speaker<'d, D> {
 
         // Audio control interface (mandatory) [UAC 4.3.1]
         let mut interface = func.interface();
-        let control_interface = interface.interface_number().into();
+        let control_interface = interface.interface_number();
         let streaming_interface = u8::from(control_interface) + 1;
         let mut alt = interface.alt_setting(USB_AUDIO_CLASS, USB_AUDIOCONTROL_SUBCLASS, PROTOCOL_NONE, None);
 
@@ -293,7 +293,7 @@ impl<'d, D: Driver<'d>> Speaker<'d, D> {
                 AS_GENERAL,            // bDescriptorSubtype (General)
                 SAMPLING_FREQ_CONTROL, // bmAttributes (support sampling frequency control)
                 0x02,                  // bLockDelayUnits (PCM)
-                0x0000 as u8,
+                0x0000_u8,
                 (0x0000 >> 8) as u8, // wLockDelay (0)
             ],
         );
@@ -447,9 +447,9 @@ pub struct ControlMonitor<'d> {
 
 impl<'d> ControlMonitor<'d> {
     fn audio_settings(&self) -> AudioSettings {
-        let audio_settings = self.shared.audio_settings.lock(|x| x.get());
+        
 
-        audio_settings
+        self.shared.audio_settings.lock(|x| x.get())
     }
 
     fn get_logical_channel(&self, search_channel: Channel) -> Option<usize> {
@@ -625,60 +625,60 @@ impl<'d> Control<'d> {
         match req.request {
             GET_CUR => match control_unit {
                 VOLUME_CONTROL => {
-                    let volume: i16;
+                    
 
-                    match channel_index as usize {
-                        ..=MAX_AUDIO_CHANNEL_INDEX => volume = audio_settings.volume_8q8_db[channel_index as usize],
+                    let volume: i16 = match channel_index as usize {
+                        ..=MAX_AUDIO_CHANNEL_INDEX => audio_settings.volume_8q8_db[channel_index as usize],
                         _ => return Some(InResponse::Rejected),
-                    }
+                    };
 
                     buf[0] = volume as u8;
                     buf[1] = (volume >> 8) as u8;
 
                     debug!("Got channel {} volume: {}.", channel_index, volume);
-                    return Some(InResponse::Accepted(&buf[..2]));
+                    Some(InResponse::Accepted(&buf[..2]))
                 }
                 MUTE_CONTROL => {
-                    let mute_state: bool;
+                    
 
-                    match channel_index as usize {
-                        ..=MAX_AUDIO_CHANNEL_INDEX => mute_state = audio_settings.muted[channel_index as usize],
+                    let mute_state: bool = match channel_index as usize {
+                        ..=MAX_AUDIO_CHANNEL_INDEX => audio_settings.muted[channel_index as usize],
                         _ => return Some(InResponse::Rejected),
-                    }
+                    };
 
                     buf[0] = mute_state.into();
                     debug!("Got channel {} mute state: {}.", channel_index, mute_state);
-                    return Some(InResponse::Accepted(&buf[..1]));
+                    Some(InResponse::Accepted(&buf[..1]))
                 }
-                _ => return Some(InResponse::Rejected),
+                _ => Some(InResponse::Rejected),
             },
             GET_MIN => match control_unit {
                 VOLUME_CONTROL => {
                     let min_volume = MIN_VOLUME_DB * VOLUME_STEPS_PER_DB;
                     buf[0] = min_volume as u8;
                     buf[1] = (min_volume >> 8) as u8;
-                    return Some(InResponse::Accepted(&buf[..2]));
+                    Some(InResponse::Accepted(&buf[..2]))
                 }
-                _ => return Some(InResponse::Rejected),
+                _ => Some(InResponse::Rejected),
             },
             GET_MAX => match control_unit {
                 VOLUME_CONTROL => {
                     let max_volume = MAX_VOLUME_DB * VOLUME_STEPS_PER_DB;
                     buf[0] = max_volume as u8;
                     buf[1] = (max_volume >> 8) as u8;
-                    return Some(InResponse::Accepted(&buf[..2]));
+                    Some(InResponse::Accepted(&buf[..2]))
                 }
-                _ => return Some(InResponse::Rejected),
+                _ => Some(InResponse::Rejected),
             },
             GET_RES => match control_unit {
                 VOLUME_CONTROL => {
                     buf[0] = VOLUME_STEPS_PER_DB as u8;
                     buf[1] = (VOLUME_STEPS_PER_DB >> 8) as u8;
-                    return Some(InResponse::Accepted(&buf[..2]));
+                    Some(InResponse::Accepted(&buf[..2]))
                 }
-                _ => return Some(InResponse::Rejected),
+                _ => Some(InResponse::Rejected),
             },
-            _ => return Some(InResponse::Rejected),
+            _ => Some(InResponse::Rejected),
         }
     }
 
@@ -691,7 +691,7 @@ impl<'d> Control<'d> {
             return None;
         }
 
-        if control_selector != SAMPLING_FREQ_CONTROL as u8 {
+        if control_selector != SAMPLING_FREQ_CONTROL {
             debug!(
                 "Unsupported endpoint get request for control selector {}.",
                 control_selector

--- a/embassy-usb/src/class/web_usb.rs
+++ b/embassy-usb/src/class/web_usb.rs
@@ -91,17 +91,18 @@ impl<'d> Handler for Control<'d> {
             && req.request == self.vendor_code
             && req.value == landing_value
             && req.index == WEB_USB_REQUEST_GET_URL
-            && let Some(url) = self.landing_url {
-                let url_bytes = url.as_bytes();
-                let len = url_bytes.len();
+            && let Some(url) = self.landing_url
+        {
+            let url_bytes = url.as_bytes();
+            let len = url_bytes.len();
 
-                self.ep_buf[0] = len as u8 + 3;
-                self.ep_buf[1] = WEB_USB_DESCRIPTOR_TYPE_URL;
-                self.ep_buf[2] = url.scheme();
-                self.ep_buf[3..3 + len].copy_from_slice(url_bytes);
+            self.ep_buf[0] = len as u8 + 3;
+            self.ep_buf[1] = WEB_USB_DESCRIPTOR_TYPE_URL;
+            self.ep_buf[2] = url.scheme();
+            self.ep_buf[3..3 + len].copy_from_slice(url_bytes);
 
-                return Some(InResponse::Accepted(&self.ep_buf[..3 + len]));
-            }
+            return Some(InResponse::Accepted(&self.ep_buf[..3 + len]));
+        }
         None
     }
 }

--- a/embassy-usb/src/class/web_usb.rs
+++ b/embassy-usb/src/class/web_usb.rs
@@ -91,8 +91,7 @@ impl<'d> Handler for Control<'d> {
             && req.request == self.vendor_code
             && req.value == landing_value
             && req.index == WEB_USB_REQUEST_GET_URL
-        {
-            if let Some(url) = self.landing_url {
+            && let Some(url) = self.landing_url {
                 let url_bytes = url.as_bytes();
                 let len = url_bytes.len();
 
@@ -103,7 +102,6 @@ impl<'d> Handler for Control<'d> {
 
                 return Some(InResponse::Accepted(&self.ep_buf[..3 + len]));
             }
-        }
         None
     }
 }

--- a/embassy-usb/src/control.rs
+++ b/embassy-usb/src/control.rs
@@ -112,9 +112,9 @@ impl Request {
 
         Request {
             direction: if rt & 0x80 == 0 { Direction::Out } else { Direction::In },
-            request_type: unsafe { mem::transmute((rt >> 5) & 0b11) },
+            request_type: unsafe { mem::transmute::<u8, RequestType>((rt >> 5) & 0b11) },
             recipient: if recipient <= 3 {
-                unsafe { mem::transmute(recipient) }
+                unsafe { mem::transmute::<u8, Recipient>(recipient) }
             } else {
                 Recipient::Reserved
             },

--- a/embassy-usb/src/descriptor.rs
+++ b/embassy-usb/src/descriptor.rs
@@ -204,7 +204,6 @@ impl<'a> DescriptorWriter<'a> {
     /// * `interface_sub_class` - Sub-class code. Depends on class.
     /// * `interface_protocol` - Protocol code. Depends on class and sub-class.
     /// * `interface_string` - Index of string descriptor describing this interface
-
     pub fn interface_alt(
         &mut self,
         number: InterfaceNumber,

--- a/embassy-usb/src/lib.rs
+++ b/embassy-usb/src/lib.rs
@@ -239,7 +239,6 @@ struct Inner<'d, D: Driver<'d>> {
 }
 
 impl<'d, D: Driver<'d>> UsbDevice<'d, D> {
-    #[allow(clippy::too_many_arguments)]
     pub(crate) fn build(
         driver: D,
         config: Config<'d>,

--- a/embassy-usb/src/lib.rs
+++ b/embassy-usb/src/lib.rs
@@ -239,6 +239,7 @@ struct Inner<'d, D: Driver<'d>> {
 }
 
 impl<'d, D: Driver<'d>> UsbDevice<'d, D> {
+    #[allow(clippy::too_many_arguments)]
     pub(crate) fn build(
         driver: D,
         config: Config<'d>,

--- a/embassy-usb/src/lib.rs
+++ b/embassy-usb/src/lib.rs
@@ -239,46 +239,6 @@ struct Inner<'d, D: Driver<'d>> {
 }
 
 impl<'d, D: Driver<'d>> UsbDevice<'d, D> {
-    pub(crate) fn build(
-        driver: D,
-        config: Config<'d>,
-        handlers: Vec<&'d mut dyn Handler, MAX_HANDLER_COUNT>,
-        config_descriptor: &'d [u8],
-        bos_descriptor: &'d [u8],
-        msos_descriptor: crate::msos::MsOsDescriptorSet<'d>,
-        interfaces: Vec<Interface, MAX_INTERFACE_COUNT>,
-        control_buf: &'d mut [u8],
-    ) -> UsbDevice<'d, D> {
-        // Start the USB bus.
-        // This prevent further allocation by consuming the driver.
-        let (bus, control) = driver.start(config.max_packet_size_0 as u16);
-        let device_descriptor = descriptor::device_descriptor(&config);
-        let device_qualifier_descriptor = descriptor::device_qualifier_descriptor(&config);
-
-        Self {
-            control_buf,
-            control,
-            inner: Inner {
-                bus,
-                config,
-                device_descriptor,
-                device_qualifier_descriptor,
-                config_descriptor,
-                bos_descriptor,
-                msos_descriptor,
-
-                device_state: UsbDeviceState::Unpowered,
-                suspended: false,
-                remote_wakeup_enabled: false,
-                self_powered: false,
-                address: 0,
-                set_address_pending: false,
-                interfaces,
-                handlers,
-            },
-        }
-    }
-
     /// Returns a report of the consumed buffers
     ///
     /// Useful for tuning buffer sizes for actual usage

--- a/embassy-usb/src/msos.rs
+++ b/embassy-usb/src/msos.rs
@@ -93,7 +93,7 @@ impl<'d> MsOsDescriptorWriter<'d> {
     /// Write the MS OS descriptor set header.
     ///
     /// - `windows_version` is an NTDDI version constant that describes a windows version. See the [`windows_version`]
-    /// module.
+    ///   module.
     /// - `vendor_code` is the vendor request code used to read the MS OS descriptor set.
     pub fn header(&mut self, windows_version: u32, vendor_code: u8) {
         assert!(self.is_empty(), "You can only call MsOsDescriptorWriter::header once");

--- a/embassy-usb/src/msos.rs
+++ b/embassy-usb/src/msos.rs
@@ -690,6 +690,12 @@ impl CcgpDeviceDescriptor {
     }
 }
 
+impl Default for CcgpDeviceDescriptor {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 /// Table 19. Microsoft OS 2.0 vendor revision descriptor.
 #[allow(non_snake_case)]
 #[repr(C, packed(1))]

--- a/embassy-usb/src/msos.rs
+++ b/embassy-usb/src/msos.rs
@@ -622,7 +622,7 @@ impl MinimumRecoveryTimeDescriptor {
     /// `resume_signaling_time` must be >= 1 and <= 20.
     pub fn new(resume_recovery_time: u8, resume_signaling_time: u8) -> Self {
         assert!(resume_recovery_time <= 10);
-        assert!(resume_signaling_time >= 1 && resume_signaling_time <= 20);
+        assert!((1..=20).contains(&resume_signaling_time));
         Self {
             wLength: (size_of::<Self>() as u16).to_le(),
             wDescriptorType: (Self::TYPE as u16).to_le(),

--- a/examples/stm32f1/src/bin/uac_source.rs
+++ b/examples/stm32f1/src/bin/uac_source.rs
@@ -2,6 +2,7 @@
 #![no_main]
 
 use defmt::*;
+use defmt_rtt as _;
 use embassy_executor::Spawner;
 use embassy_stm32::gpio::{Level, Output, Speed};
 use embassy_stm32::time::Hertz;
@@ -11,8 +12,8 @@ use embassy_usb::class::uac1::source::{AudioSource, AudioSourceControlHandler, A
 use embassy_usb::class::uac1::terminal_type::TerminalType;
 use embassy_usb::class::uac1::{self};
 use embassy_usb::{Builder, UsbVersion};
+use panic_probe as _;
 use static_cell::StaticCell;
-use {defmt_rtt as _, panic_probe as _};
 
 bind_interrupts!(struct Irqs {
     USB_LP_CAN1_RX0 => embassy_stm32::usb::InterruptHandler<peripherals::USB>;
@@ -145,7 +146,11 @@ async fn main(spawner: Spawner) {
     let mut builder = Builder::new(driver, usb_cfg, cfg_descr, bos_descr, &mut [], ctrl_buf);
 
     debug!("Create audio stream, feedback endpoints and handler");
-    let (audio_ep_in, feedback_ep_in, handler) = AudioSource::new(
+    let AudioSource {
+        audio_ep_in,
+        feedback_ep_in,
+        handler,
+    } = AudioSource::new(
         &mut builder,
         &SUPPORTED_SAMPLE_RATES,
         SAMPLE_WIDTH,

--- a/examples/stm32f1/src/bin/uac_source.rs
+++ b/examples/stm32f1/src/bin/uac_source.rs
@@ -2,7 +2,6 @@
 #![no_main]
 
 use defmt::*;
-use defmt_rtt as _;
 use embassy_executor::Spawner;
 use embassy_stm32::gpio::{Level, Output, Speed};
 use embassy_stm32::time::Hertz;
@@ -12,8 +11,8 @@ use embassy_usb::class::uac1::source::{AudioSource, AudioSourceControlHandler, A
 use embassy_usb::class::uac1::terminal_type::TerminalType;
 use embassy_usb::class::uac1::{self};
 use embassy_usb::{Builder, UsbVersion};
-use panic_probe as _;
 use static_cell::StaticCell;
+use {defmt_rtt as _, panic_probe as _};
 
 bind_interrupts!(struct Irqs {
     USB_LP_CAN1_RX0 => embassy_stm32::usb::InterruptHandler<peripherals::USB>;

--- a/examples/stm32f4/src/bin/usb_uac_speaker.rs
+++ b/examples/stm32f4/src/bin/usb_uac_speaker.rs
@@ -322,7 +322,11 @@ async fn main(spawner: Spawner) {
     );
 
     // Create the UAC1 Speaker class components
-    let (stream, feedback, control_monitor) = Speaker::new(
+    let Speaker {
+        stream,
+        feedback,
+        control_monitor,
+    } = Speaker::new(
         &mut builder,
         state,
         USB_MAX_PACKET_SIZE as u16,

--- a/examples/stm32h5/src/bin/usb_uac_speaker.rs
+++ b/examples/stm32h5/src/bin/usb_uac_speaker.rs
@@ -4,7 +4,6 @@
 use core::cell::{Cell, RefCell};
 
 use defmt::{panic, *};
-use defmt_rtt as _;
 use embassy_executor::Spawner;
 use embassy_stm32::time::Hertz;
 use embassy_stm32::{Config, bind_interrupts, interrupt, peripherals, timer, usb};
@@ -17,8 +16,8 @@ use embassy_usb::class::uac1::speaker::{self, Speaker};
 use embassy_usb::driver::EndpointError;
 use heapless::Vec;
 use micromath::F32Ext;
-use panic_probe as _;
 use static_cell::StaticCell;
+use {defmt_rtt as _, panic_probe as _};
 
 bind_interrupts!(struct Irqs {
     USB_DRD_FS => usb::InterruptHandler<peripherals::USB>;

--- a/examples/stm32h5/src/bin/usb_uac_speaker.rs
+++ b/examples/stm32h5/src/bin/usb_uac_speaker.rs
@@ -4,6 +4,7 @@
 use core::cell::{Cell, RefCell};
 
 use defmt::{panic, *};
+use defmt_rtt as _;
 use embassy_executor::Spawner;
 use embassy_stm32::time::Hertz;
 use embassy_stm32::{Config, bind_interrupts, interrupt, peripherals, timer, usb};
@@ -16,8 +17,8 @@ use embassy_usb::class::uac1::speaker::{self, Speaker};
 use embassy_usb::driver::EndpointError;
 use heapless::Vec;
 use micromath::F32Ext;
+use panic_probe as _;
 use static_cell::StaticCell;
-use {defmt_rtt as _, panic_probe as _};
 
 bind_interrupts!(struct Irqs {
     USB_DRD_FS => usb::InterruptHandler<peripherals::USB>;
@@ -319,7 +320,11 @@ async fn main(spawner: Spawner) {
     );
 
     // Create the UAC1 Speaker class components
-    let (stream, feedback, control_monitor) = Speaker::new(
+    let Speaker {
+        stream,
+        feedback,
+        control_monitor,
+    } = Speaker::new(
         &mut builder,
         state,
         USB_MAX_PACKET_SIZE as u16,


### PR DESCRIPTION
This is mostly non-function changes, except

- Changing a few instances of `#[repr(packed)]` to `#[repr(C, packed)]`, which is necessary for correctness.
- Making `AudioSource::new` and `Speaker::new` return `Self` with the parts inside instead of a tuple, which is an ergonomic improvement IMO.

Note that there is still a clippy warning, but it is a [false positive](https://github.com/rust-lang/rust-clippy/issues/17373). Coincidentally, it looks like the fix was merged less than two days ago.

<details>

<summary>False positive</summary>

```
warning: this `if` has identical blocks
   --> src/class/uac1/source.rs:686:39
    |
686 |               if alternate_setting == 0 {
    |  _______________________________________^
687 | |                 info!(
688 | |                     "AudioSourceControlHandler: Audio streaming interface({}) deactivated!",
689 | |                     iface
690 | |                 );
691 | |             } else if alternate_setting == 1 {
    | |_____________^
    |
note: same as this
   --> src/class/uac1/source.rs:691:46
    |
691 |               } else if alternate_setting == 1 {
    |  ______________________________________________^
692 | |                 info!(
693 | |                     "AudioSourceControlHandler: Audio streaming interface({}) activated!",
694 | |                     iface
695 | |                 );
696 | |             }
    | |_____________^
    = help: for further information visit https://rust-lang.github.io/rust-clippy/rust-1.92.0/index.html#if_same_then_else
    = note: `#[warn(clippy::if_same_then_else)]` on by default
```

</details>