### PR TITLE
embassy-stm32: clear CMPOK before updating LPTIM compare

### DIFF
--- a/embassy-stm32/src/time_driver/lptim.rs
+++ b/embassy-stm32/src/time_driver/lptim.rs
@@ -87,6 +87,11 @@ fn icr_write_raw(r: Lptim, val: u32) {
 fn write_compare(r: Lptim, val: u16) {
     #[cfg(not(any(stm32wba, stm32u5, stm32u3)))]
     {
+        // On STM32WL, CMPOK remains set after a compare update. Clear the stale
+        // acknowledgement so the loop waits for the current CMP write.
+        #[cfg(any(stm32wlex, stm32wl5x))]
+        r.icr().write(|w| w.set_cmpokcf(0, true));
+
         r.cmp().write(|w| w.set_cmp(val));
         while !r.isr().read().cmpok(0) {}
     }


### PR DESCRIPTION
## Description

On STM32WL, the LPTIM time driver may miss compare events because `CMPOK`
from the previous compare update remains set.

The existing wait loop may therefore observe a stale acknowledgement and
continue before the new CMP value has reached the LPTIM clock domain.

This change clears `CMPOK` before updating CMP on STM32WL.

Fixes #6575

## Testing

Tested on STM32WLE5CC with `time-driver-lptim1`.

Before this change, a task running every 250 ms reproducibly experienced timer
waits of approximately 21–63 seconds around the 16-bit LPTIM counter boundary.

After this change, more than 2000 consecutive cycles completed without missed
timer events.

The change is currently limited to STM32WL because it has only been
hardware-tested on STM32WLE5CC.