### PR TITLE
stm32/adc: clean up h5 adc

### DIFF
--- a/embassy-stm32/src/adc/v3.rs
+++ b/embassy-stm32/src/adc/v3.rs
@@ -318,131 +318,38 @@ impl super::AdcRegs for crate::pac::adc::Adc {
         {
             use crate::pac::adc::regs::{Sqr1, Sqr2, Sqr3, Sqr4};
 
-            #[cfg(adc_h5)]
-            {
-                // RM0481
-                // DIFSEL:
-                //   The software is allowed to write these bits only when the ADC is disabled (ADCAL = 0,
-                //   JADSTART = 0, JADSTP = 0, ADSTART = 0, ADSTP = 0, ADDIS = 0 and ADEN = 0).
-                if self.cr().read().aden() {
-                    self.cr().modify(|reg| reg.set_addis(true));
-                    while self.cr().read().aden() {}
-                }
-            }
-
-            #[cfg(adc_h5)]
-            let mut difsel = 0u32;
-
             let mut sqr1 = Sqr1::default();
             let mut sqr2 = Sqr2::default();
             let mut sqr3 = Sqr3::default();
             let mut sqr4 = Sqr4::default();
 
-            cfg_if! {
-                if #[cfg(any(adc_h5, adc_h7rs))] {
-                    let mut smpr1 = self.smpr1().read();
-                    let mut smpr2 = self.smpr2().read();
-                } else {
-                    let mut smpr1 = self.smpr(0).read();
-                    let mut smpr2 = self.smpr(1).read();
-                }
-            }
-
             // Set sequence length
             sqr1.set_l(sequence.len() as u8 - 1);
 
             // Configure channels and ranks
-            for (_i, ((channel, _is_differential), sample_time)) in sequence.enumerate() {
-                // RM0492, RM0481, etc.
-                // OP0: Option bit 0
-                // For ADC1:
-                //   0: INP0/INN1 GPIO switch control disabled (for both ADC1 and ADC2)
-                //   1: INP0/INN1 GPIO switch control enabled (for both ADC1 and ADC2)
-                //   Note: This option bit must be set to 1 when ADCx_INP0 or ADCx_INN1 channel is selected.
-                // For ADC2:
-                //   0: VDDCORE channel disabled (for both ADC2 and ADC3)
-                //   1: VDDCORE channel enabled (for both ADC2 and ADC3)
-                // For ADC3: (only available on STM32H543/553 devices)
-                //   0: INP0 GPIO switch control disabled
-                //   1: INP0 GPIO switch control enabled
-
-                #[cfg(adc_h5)]
-                if channel == 0 {
-                    #[cfg(peri_adc2)]
-                    let is_adc2 = self.as_ptr() == crate::pac::ADC2.as_ptr();
-
-                    #[cfg(not(peri_adc2))]
-                    let is_adc2 = false;
-
-                    if is_adc2 {
-                        // when ADC2_INP0 should be enabled, set OP0 to 1 for ADC1
-                        crate::pac::ADC1.or().modify(|reg| reg.set_op0(true));
-                    } else {
-                        // when ADC1_INP0 should be enabled, set OP0 to 1 for ADC1
-                        // when ADC3_INP0 should be enabled, set OP0 to 1 for ADC3
-                        self.or().modify(|reg| reg.set_op0(true));
-                    }
-                }
-                #[cfg(adc_h7rs)]
-                if channel == 0 {
-                    self.or().modify(|reg| reg.set_op0(true));
-                }
-
-                // Configure channel
-                match channel {
-                    0..=9 => smpr1.set_smp(channel as usize % 10, sample_time.into()),
-                    _ => smpr2.set_smp(channel as usize % 10, sample_time.into()),
-                }
-
-                #[cfg(stm32h7)]
-                {
-                    use crate::pac::adc::vals::Pcsel;
-
-                    self.cfgr2().modify(|w| w.set_lshift(0));
-                    self.pcsel()
-                        .write(|w| w.set_pcsel(channel.channel() as _, Pcsel::PRESELECTED));
-                }
-
+            configure_sequence_common(&self, sequence, |i, channel| {
                 // Each channel is sampled according to sequence
-                match _i {
+                match i {
                     0..=3 => {
-                        sqr1.set_sq(_i, channel);
+                        sqr1.set_sq(i, channel);
                     }
                     4..=8 => {
-                        sqr2.set_sq(_i - 4, channel);
+                        sqr2.set_sq(i - 4, channel);
                     }
                     9..=13 => {
-                        sqr3.set_sq(_i - 9, channel);
+                        sqr3.set_sq(i - 9, channel);
                     }
                     14..=15 => {
-                        sqr4.set_sq(_i - 14, channel);
+                        sqr4.set_sq(i - 14, channel);
                     }
                     _ => unreachable!(),
                 }
-
-                #[cfg(adc_h5)]
-                {
-                    difsel |= (_is_differential as u32) << channel;
-                }
-            }
+            });
 
             self.sqr1().write_value(sqr1);
             self.sqr2().write_value(sqr2);
             self.sqr3().write_value(sqr3);
             self.sqr4().write_value(sqr4);
-
-            cfg_if! {
-                if #[cfg(any(adc_h5, adc_h7rs))] {
-                    self.smpr1().write_value(smpr1);
-                    self.smpr2().write_value(smpr2);
-                } else {
-                    self.smpr(0).write_value(smpr1);
-                    self.smpr(1).write_value(smpr2);
-                }
-            }
-
-            #[cfg(adc_h5)]
-            self.difsel().write(|w| w.set_difsel(difsel));
         }
     }
 }
@@ -452,109 +359,17 @@ impl crate::adc::InjectedRegs for crate::pac::adc::Adc {
     fn configure_injected_sequence(&self, sequence: impl ExactSizeIterator<Item = ((u8, bool), Self::SampleTime)>) {
         use crate::pac::adc::regs::Jsqr;
 
-        #[cfg(adc_h5)]
-        {
-            // RM0481
-            // DIFSEL:
-            //   The software is allowed to write these bits only when the ADC is disabled (ADCAL = 0,
-            //   JADSTART = 0, JADSTP = 0, ADSTART = 0, ADSTP = 0, ADDIS = 0 and ADEN = 0).
-            if self.cr().read().aden() {
-                self.cr().modify(|reg| reg.set_addis(true));
-                while self.cr().read().aden() {}
-            }
-        }
-
-        let mut difsel = 0u32;
-
         let mut jsqr = Jsqr::default();
-
-        cfg_if! {
-            if #[cfg(any(adc_h5, adc_h7rs))] {
-                let mut smpr1 = self.smpr1().read();
-                let mut smpr2 = self.smpr2().read();
-            } else {
-                let mut smpr1 = self.smpr(0).read();
-                let mut smpr2 = self.smpr(1).read();
-            }
-        }
 
         // Set sequence length
         jsqr.set_jl(sequence.len() as u8 - 1);
 
         // Configure channels and ranks
-        for (i, ((channel, _is_differential), sample_time)) in sequence.enumerate() {
-            // RM0492, RM0481, etc.
-            // OP0: Option bit 0
-            // For ADC1:
-            //   0: INP0/INN1 GPIO switch control disabled (for both ADC1 and ADC2)
-            //   1: INP0/INN1 GPIO switch control enabled (for both ADC1 and ADC2)
-            //   Note: This option bit must be set to 1 when ADCx_INP0 or ADCx_INN1 channel is selected.
-            // For ADC2:
-            //   0: VDDCORE channel disabled (for both ADC2 and ADC3)
-            //   1: VDDCORE channel enabled (for both ADC2 and ADC3)
-            // For ADC3: (only available on STM32H543/553 devices)
-            //   0: INP0 GPIO switch control disabled
-            //   1: INP0 GPIO switch control enabled
-
-            #[cfg(adc_h5)]
-            if channel == 0 {
-                #[cfg(peri_adc2)]
-                let is_adc2 = self.as_ptr() == crate::pac::ADC2.as_ptr();
-
-                #[cfg(not(peri_adc2))]
-                let is_adc2 = false;
-
-                if is_adc2 {
-                    // when ADC2_INP0 should be enabled, set OP0 to 1 for ADC1
-                    crate::pac::ADC1.or().modify(|reg| reg.set_op0(true));
-                } else {
-                    // when ADC1_INP0 should be enabled, set OP0 to 1 for ADC1
-                    // when ADC3_INP0 should be enabled, set OP0 to 1 for ADC3
-                    self.or().modify(|reg| reg.set_op0(true));
-                }
-            }
-            #[cfg(adc_h7rs)]
-            if channel == 0 {
-                self.or().modify(|reg| reg.set_op0(true));
-            }
-
-            // Configure channel
-            match channel {
-                0..=9 => smpr1.set_smp(channel as usize % 10, sample_time.into()),
-                _ => smpr2.set_smp(channel as usize % 10, sample_time.into()),
-            }
-
-            #[cfg(stm32h7)]
-            {
-                use crate::pac::adc::vals::Pcsel;
-
-                self.cfgr2().modify(|w| w.set_lshift(0));
-                self.pcsel()
-                    .write(|w| w.set_pcsel(channel.channel() as _, Pcsel::PRESELECTED));
-            }
-
+        configure_sequence_common(&self, sequence, |i, channel| {
             jsqr.set_jsq(i, channel);
-
-            #[cfg(adc_h5)]
-            {
-                difsel |= (_is_differential as u32) << channel;
-            }
-        }
+        });
 
         self.jsqr().write_value(jsqr);
-
-        cfg_if! {
-            if #[cfg(any(adc_h5, adc_h7rs))] {
-                self.smpr1().write_value(smpr1);
-                self.smpr2().write_value(smpr2);
-            } else {
-                self.smpr(0).write_value(smpr1);
-                self.smpr(1).write_value(smpr2);
-            }
-        }
-
-        #[cfg(adc_h5)]
-        self.difsel().write(|w| w.set_difsel(difsel));
     }
 
     fn configure_injected_trigger(&self, trigger: (u8, crate::adc::Exten), interrupt: bool) {
@@ -592,6 +407,111 @@ impl crate::adc::InjectedRegs for crate::pac::adc::Adc {
             *d = self.jdr(i).read().jdata();
         }
     }
+}
+
+#[cfg(not(any(adc_g0, adc_u0)))]
+fn configure_sequence_common(
+    regs: &crate::pac::adc::Adc,
+    sequence: impl ExactSizeIterator<Item = ((u8, bool), SampleTime)>,
+    mut channel_callback: impl FnMut(usize, u8),
+) {
+    #[cfg(adc_h5)]
+    {
+        // RM0481
+        // DIFSEL:
+        //   The software is allowed to write these bits only when the ADC is disabled (ADCAL = 0,
+        //   JADSTART = 0, JADSTP = 0, ADSTART = 0, ADSTP = 0, ADDIS = 0 and ADEN = 0).
+        if regs.cr().read().aden() {
+            regs.cr().modify(|reg| reg.set_addis(true));
+            while regs.cr().read().aden() {}
+        }
+    }
+
+    #[cfg(adc_h5)]
+    let mut difsel = 0u32;
+
+    cfg_if! {
+        if #[cfg(any(adc_h5, adc_h7rs))] {
+            let mut smpr1 = regs.smpr1().read();
+            let mut smpr2 = regs.smpr2().read();
+        } else {
+            let mut smpr1 = regs.smpr(0).read();
+            let mut smpr2 = regs.smpr(1).read();
+        }
+    }
+
+    // Configure channels and ranks
+    for (i, ((channel, _is_differential), sample_time)) in sequence.enumerate() {
+        // RM0492, RM0481, etc.
+        // OP0: Option bit 0
+        // For ADC1:
+        //   0: INP0/INN1 GPIO switch control disabled (for both ADC1 and ADC2)
+        //   1: INP0/INN1 GPIO switch control enabled (for both ADC1 and ADC2)
+        //   Note: This option bit must be set to 1 when ADCx_INP0 or ADCx_INN1 channel is selected.
+        // For ADC2:
+        //   0: VDDCORE channel disabled (for both ADC2 and ADC3)
+        //   1: VDDCORE channel enabled (for both ADC2 and ADC3)
+        // For ADC3: (only available on STM32H543/553 devices)
+        //   0: INP0 GPIO switch control disabled
+        //   1: INP0 GPIO switch control enabled
+
+        #[cfg(adc_h5)]
+        if channel == 0 {
+            #[cfg(peri_adc2)]
+            let is_adc2 = regs.as_ptr() == crate::pac::ADC2.as_ptr();
+
+            #[cfg(not(peri_adc2))]
+            let is_adc2 = false;
+
+            if is_adc2 {
+                // when ADC2_INP0 should be enabled, set OP0 to 1 for ADC1
+                crate::pac::ADC1.or().modify(|reg| reg.set_op0(true));
+            } else {
+                // when ADC1_INP0 should be enabled, set OP0 to 1 for ADC1
+                // when ADC3_INP0 should be enabled, set OP0 to 1 for ADC3
+                regs.or().modify(|reg| reg.set_op0(true));
+            }
+        }
+        #[cfg(adc_h7rs)]
+        if channel == 0 {
+            regs.or().modify(|reg| reg.set_op0(true));
+        }
+
+        // Configure channel
+        match channel {
+            0..=9 => smpr1.set_smp(channel as usize % 10, sample_time.into()),
+            _ => smpr2.set_smp(channel as usize % 10, sample_time.into()),
+        }
+
+        #[cfg(stm32h7)]
+        {
+            use crate::pac::adc::vals::Pcsel;
+
+            regs.cfgr2().modify(|w| w.set_lshift(0));
+            regs.pcsel()
+                .write(|w| w.set_pcsel(channel.channel() as _, Pcsel::PRESELECTED));
+        }
+
+        channel_callback(i, channel);
+
+        #[cfg(adc_h5)]
+        {
+            difsel |= (_is_differential as u32) << channel;
+        }
+    }
+
+    cfg_if! {
+        if #[cfg(any(adc_h5, adc_h7rs))] {
+            regs.smpr1().write_value(smpr1);
+            regs.smpr2().write_value(smpr2);
+        } else {
+            regs.smpr(0).write_value(smpr1);
+            regs.smpr(1).write_value(smpr2);
+        }
+    }
+
+    #[cfg(adc_h5)]
+    regs.difsel().write(|w| w.set_difsel(difsel));
 }
 
 impl<'d, T: Instance<Regs = crate::pac::adc::Adc>> Adc<'d, T> {


### PR DESCRIPTION
Extracts common initialization code for regular and injected conventions into `configure_sequence_common`.

Tested on STM32H523CE.