### PR TITLE
stm32/adc: add async read for injected adc

### DIFF
--- a/embassy-stm32/src/adc/g4.rs
+++ b/embassy-stm32/src/adc/g4.rs
@@ -6,7 +6,7 @@ pub use pac::adc::vals::{Adcaldif, Adstp, Difsel, Dmacfg, Dmaen, Exten, Rovsm, T
 use pac::adc::vals::{Adcaldif, Difsel, Exten};
 pub use pac::adccommon::vals::{Dual, Presc};
 
-use crate::adc::{Adc, AdcRegs, ConversionMode, DefaultInstance, InjectedRegs, Resolution, SampleTime};
+use crate::adc::{Adc, AdcRegs, ConversionMode, DefaultInstance, InjectedRegs, Instance, Resolution, SampleTime};
 use crate::pac::adc::regs::{Jsqr, Smpr, Smpr2, Sqr1, Sqr2, Sqr3, Sqr4};
 use crate::time::Hertz;
 use crate::wait::block_for_us;
@@ -27,6 +27,29 @@ pub const NR_INJECTED_RANKS: usize = 4;
 const MAX_ADC_CLK_FREQ: Hertz = Hertz::mhz(60);
 #[cfg(stm32h7)]
 const MAX_ADC_CLK_FREQ: Hertz = Hertz::mhz(50);
+
+/// Interrupt handler.
+pub struct InterruptHandler<T: Instance> {
+    _marker: core::marker::PhantomData<T>,
+}
+
+impl<T: DefaultInstance> crate::interrupt::typelevel::Handler<T::Interrupt> for InterruptHandler<T> {
+    unsafe fn on_interrupt() {
+        let isr = T::regs().isr().read();
+        if isr.eoc() || isr.eos() || isr.jeoc() || isr.jeos() {
+            if isr.jeos() {
+                T::state()
+                    .injected_done
+                    .store(true, core::sync::atomic::Ordering::Release);
+            }
+
+            // flags are cleared by writing 1 to them
+            T::regs().isr().write_value(isr);
+
+            T::state().waker.wake();
+        }
+    }
+}
 
 fn from_ker_ck(frequency: Hertz) -> Presc {
     let raw_prescaler = rcc::raw_prescaler(frequency.0, MAX_ADC_CLK_FREQ.0);

--- a/embassy-stm32/src/adc/injected.rs
+++ b/embassy-stm32/src/adc/injected.rs
@@ -1,11 +1,15 @@
 use core::marker::PhantomData;
 use core::sync::atomic::{Ordering, compiler_fence};
+use core::future::poll_fn;
+use core::task::Poll;
 
-use crate::adc::{BasicAdcRegs, BorrowedAdcChannel, InjectedAdcRegs, Instance};
+use crate::adc::{BasicAdcRegs, BorrowedAdcChannel, InjectedAdcRegs, Instance, State};
+use crate::atomic::AtomicClear;
 
 /// Injected ADC sequence with owned channels.
 pub struct InjectedAdc<'d, R: InjectedAdcRegs> {
     regs: R,
+    state: &'static State,
     len: usize,
     _marker: PhantomData<&'d mut ()>,
 }
@@ -16,6 +20,7 @@ impl<'d, R: InjectedAdcRegs> InjectedAdc<'d, R> {
     ) -> Self {
         Self {
             regs: T::regs(),
+            state: T::state(),
             len: N,
             _marker: PhantomData,
         }
@@ -29,7 +34,24 @@ impl<'d, R: InjectedAdcRegs> InjectedAdc<'d, R> {
         self.regs.start_injected();
     }
 
-    pub fn read_injected_samples(&mut self, buf: &mut [u16]) {
+    pub async fn read(&mut self, buf: &mut [u16]) {
+        let f = poll_fn(|cx| {
+            self.state.waker.register(cx.waker());
+
+            if self.state.injected_eos.clear() {
+                Poll::Ready(())
+            } else {
+                Poll::Pending
+            }
+        });
+
+        self.start_injected_conversions();
+        f.await;
+
+        self.read_latest(buf);
+    }
+
+    pub fn read_latest(&mut self, buf: &mut [u16]) {
         assert!(
             buf.len() == self.len,
             "Buffer must have as many entries as the sequence"

--- a/embassy-stm32/src/adc/injected.rs
+++ b/embassy-stm32/src/adc/injected.rs
@@ -1,6 +1,6 @@
+use core::future::poll_fn;
 use core::marker::PhantomData;
 use core::sync::atomic::{Ordering, compiler_fence};
-use core::future::poll_fn;
 use core::task::Poll;
 
 use crate::adc::{BasicAdcRegs, BorrowedAdcChannel, InjectedAdcRegs, Instance, State};

--- a/embassy-stm32/src/adc/injected.rs
+++ b/embassy-stm32/src/adc/injected.rs
@@ -45,7 +45,7 @@ impl<'d, R: InjectedAdcRegs> InjectedAdc<'d, R> {
         let f = poll_fn(|cx| {
             self.state.waker.register(cx.waker());
 
-            if self.state.injected_eos.clear() {
+            if self.state.injected_done.clear() {
                 Poll::Ready(())
             } else {
                 Poll::Pending

--- a/embassy-stm32/src/adc/injected.rs
+++ b/embassy-stm32/src/adc/injected.rs
@@ -26,14 +26,21 @@ impl<'d, R: InjectedAdcRegs> InjectedAdc<'d, R> {
         }
     }
 
+    /// Stops injected convention.
+    ///
+    /// Any ongoing injected conversion is aborted with partial result discarded.
     pub fn stop_injected_conversions(&mut self) {
         self.regs.stop_injected();
     }
 
+    /// Starts injected convention:
+    /// - Immediately if in software trigger mode (JEXTEN = 0)
+    /// - At the next active edge of the selected injected hardware trigger (JEXTEN != 0)
     pub fn start_injected_conversions(&mut self) {
         self.regs.start_injected();
     }
 
+    /// Reads injected convention result after the end of sequence is detected.
     pub async fn read(&mut self, buf: &mut [u16]) {
         let f = poll_fn(|cx| {
             self.state.waker.register(cx.waker());
@@ -51,6 +58,10 @@ impl<'d, R: InjectedAdcRegs> InjectedAdc<'d, R> {
         self.read_latest(buf);
     }
 
+    /// Reads latest result directly from the injected convention registers.
+    ///
+    /// This function is intended to be used in a custom interrupt handler.
+    /// For other use cases prefer [`read`](Self::read) function.
     pub fn read_latest(&mut self, buf: &mut [u16]) {
         assert!(
             buf.len() == self.len,

--- a/embassy-stm32/src/adc/mod.rs
+++ b/embassy-stm32/src/adc/mod.rs
@@ -105,7 +105,7 @@ impl State {
     pub const fn new() -> Self {
         Self {
             waker: AtomicWaker::new(),
-            injected_eos: core::sync::atomic::AtomicBool::new(false)
+            injected_eos: core::sync::atomic::AtomicBool::new(false),
         }
     }
 }
@@ -653,8 +653,10 @@ impl<'d, T: Instance<Regs: InjectedAdcRegs>> Adc<'d, T> {
         _irq: impl crate::interrupt::typelevel::Binding<T::Interrupt, crate::adc::InterruptHandler<T>> + 'a,
         sequence: [(BorrowedAdcChannel<'a, T>, <T::Regs as BasicAdcRegs>::SampleTime); N],
         trigger: InjectedAdcTrigger<T>,
-    ) -> InjectedAdc<'a, T::Regs> where T: DefaultInstance {
-
+    ) -> InjectedAdc<'a, T::Regs>
+    where
+        T: DefaultInstance,
+    {
         assert!(N != 0, "Read sequence cannot be empty");
         assert!(
             N <= NR_INJECTED_RANKS,
@@ -664,7 +666,9 @@ impl<'d, T: Instance<Regs: InjectedAdcRegs>> Adc<'d, T> {
 
         use crate::interrupt::typelevel::Interrupt;
         T::Interrupt::unpend();
-        unsafe { T::Interrupt::enable(); }
+        unsafe {
+            T::Interrupt::enable();
+        }
 
         T::regs().stop();
         T::regs().configure_injected_sequence(
@@ -709,13 +713,18 @@ impl<'d, T: Instance<Regs: InjectedAdcRegs>> Adc<'d, T> {
         self,
         dma: embassy_hal_internal::Peri<'a, D>,
         dma_buf: &'a mut [u16],
-        _irq: impl crate::interrupt::typelevel::Binding<D::Interrupt, crate::dma::InterruptHandler<D>> + 'a
-        + crate::interrupt::typelevel::Binding<T::Interrupt, crate::adc::InterruptHandler<T>> + 'b,
+        _irq: impl crate::interrupt::typelevel::Binding<D::Interrupt, crate::dma::InterruptHandler<D>>
+        + 'a
+        + crate::interrupt::typelevel::Binding<T::Interrupt, crate::adc::InterruptHandler<T>>
+        + 'b,
         regular_sequence: impl ExactSizeIterator<Item = (BorrowedAdcChannel<'a, T>, <T::Regs as BasicAdcRegs>::SampleTime)>,
         regular_trigger: Option<RegularAdcTrigger<T>>,
         injected_sequence: [(BorrowedAdcChannel<'b, T>, <T::Regs as BasicAdcRegs>::SampleTime); N],
-        injected_trigger: InjectedAdcTrigger<T>
-    ) -> (RingBufferedAdc<'a, T::Regs>, InjectedAdc<'b, T::Regs>) where T: DefaultInstance {
+        injected_trigger: InjectedAdcTrigger<T>,
+    ) -> (RingBufferedAdc<'a, T::Regs>, InjectedAdc<'b, T::Regs>)
+    where
+        T: DefaultInstance,
+    {
         let ret = unsafe {
             (
                 Self {

--- a/embassy-stm32/src/adc/mod.rs
+++ b/embassy-stm32/src/adc/mod.rs
@@ -633,7 +633,6 @@ impl<'d, T: Instance<Regs: InjectedAdcRegs>> Adc<'d, T> {
     /// - `sequence`: An array of tuples containing the ADC channels and their sample times. The length
     ///   `N` determines the number of injected ranks to configure (maximum 4 for STM32).
     /// - `trigger`: The trigger source that starts the injected conversion sequence.
-    /// - `interrupt`: If `true`, enables the end-of-sequence (JEOS) interrupt for injected conversions.
     ///
     /// # Returns
     /// An `InjectedAdc<T, N>` instance that represents the configured injected sequence. The returned
@@ -693,7 +692,6 @@ impl<'d, T: Instance<Regs: InjectedAdcRegs>> Adc<'d, T> {
     /// - `regular_conversion_mode`: The mode for regular conversions (e.g., continuous or triggered).
     /// - `injected_sequence`: An array of channels and sample times for injected conversions (length `N`).
     /// - `injected_trigger`: The trigger source for injected conversions.
-    /// - `injected_interrupt`: Whether to enable the end-of-sequence interrupt for injected conversions.
     ///
     /// Injected conversions are typically used with interrupts. If ADC1 and ADC2 are used in dual mode,
     /// it is recommended to enable interrupts only for the ADC whose sequence takes the longest to complete.

--- a/embassy-stm32/src/adc/mod.rs
+++ b/embassy-stm32/src/adc/mod.rs
@@ -26,7 +26,7 @@ use core::marker::PhantomData;
 #[cfg(not(any(adc_f3v3, adc_wba, adc_wb1)))]
 pub use _version::*;
 pub use configured_sequence::ConfiguredSequence;
-#[cfg(any(adc_f1, adc_f3v1, adc_v1, adc_l0, adc_f3v2, adc_u5, adc_wba, adc_h5))]
+#[cfg(any(adc_f1, adc_f3v1, adc_v1, adc_l0, adc_f3v2, adc_u5, adc_wba, adc_h5, adc_v2, adc_g4))]
 use embassy_sync::waitqueue::AtomicWaker;
 pub use ringbuffered::{OverrunError, RingBufferedAdc};
 
@@ -94,13 +94,13 @@ pub struct Adc<'d, T: Instance> {
     adc: crate::Peri<'d, T>,
 }
 
-#[cfg(any(adc_f1, adc_f3v1, adc_v1, adc_l0, adc_f3v2, adc_h5))]
+#[cfg(any(adc_f1, adc_f3v1, adc_v1, adc_l0, adc_f3v2, adc_h5, adc_v2, adc_g4))]
 pub struct State {
     pub waker: AtomicWaker,
     pub injected_eos: core::sync::atomic::AtomicBool,
 }
 
-#[cfg(any(adc_f1, adc_f3v1, adc_v1, adc_l0, adc_f3v2, adc_h5))]
+#[cfg(any(adc_f1, adc_f3v1, adc_v1, adc_l0, adc_f3v2, adc_h5, adc_v2, adc_g4))]
 impl State {
     pub const fn new() -> Self {
         Self {
@@ -192,7 +192,7 @@ trait SealedInstance: BasicInstance {
     #[cfg(not(any(adc_f1, adc_v1, adc_l0, adc_f3v3, adc_f3v2, adc_g0)))]
     #[allow(unused)]
     fn common_regs() -> crate::pac::adccommon::AdcCommon;
-    #[cfg(any(adc_f1, adc_f3v1, adc_v1, adc_l0, adc_f3v2, adc_u5, adc_wba, adc_h5))]
+    #[cfg(any(adc_f1, adc_f3v1, adc_v1, adc_l0, adc_f3v2, adc_u5, adc_wba, adc_h5, adc_v2, adc_g4))]
     fn state() -> &'static State;
 }
 
@@ -1121,7 +1121,7 @@ foreach_adc!(
                 return crate::pac::$common_inst
             }
 
-            #[cfg(any(adc_f1, adc_f3v1, adc_f3v2, adc_v1, adc_l0, adc_h5))]
+            #[cfg(any(adc_f1, adc_f3v1, adc_f3v2, adc_v1, adc_l0, adc_h5, adc_v2, adc_g4))]
             fn state() -> &'static State {
                 static STATE: State = State::new();
                 &STATE

--- a/embassy-stm32/src/adc/mod.rs
+++ b/embassy-stm32/src/adc/mod.rs
@@ -26,7 +26,7 @@ use core::marker::PhantomData;
 #[cfg(not(any(adc_f3v3, adc_wba, adc_wb1)))]
 pub use _version::*;
 pub use configured_sequence::ConfiguredSequence;
-#[cfg(any(adc_f1, adc_f3v1, adc_v1, adc_l0, adc_f3v2, adc_u5, adc_wba))]
+#[cfg(any(adc_f1, adc_f3v1, adc_v1, adc_l0, adc_f3v2, adc_u5, adc_wba, adc_h5))]
 use embassy_sync::waitqueue::AtomicWaker;
 pub use ringbuffered::{OverrunError, RingBufferedAdc};
 
@@ -94,16 +94,18 @@ pub struct Adc<'d, T: Instance> {
     adc: crate::Peri<'d, T>,
 }
 
-#[cfg(any(adc_f1, adc_f3v1, adc_v1, adc_l0, adc_f3v2))]
+#[cfg(any(adc_f1, adc_f3v1, adc_v1, adc_l0, adc_f3v2, adc_h5))]
 pub struct State {
     pub waker: AtomicWaker,
+    pub injected_eos: core::sync::atomic::AtomicBool,
 }
 
-#[cfg(any(adc_f1, adc_f3v1, adc_v1, adc_l0, adc_f3v2))]
+#[cfg(any(adc_f1, adc_f3v1, adc_v1, adc_l0, adc_f3v2, adc_h5))]
 impl State {
     pub const fn new() -> Self {
         Self {
             waker: AtomicWaker::new(),
+            injected_eos: core::sync::atomic::AtomicBool::new(false)
         }
     }
 }
@@ -190,7 +192,7 @@ trait SealedInstance: BasicInstance {
     #[cfg(not(any(adc_f1, adc_v1, adc_l0, adc_f3v3, adc_f3v2, adc_g0)))]
     #[allow(unused)]
     fn common_regs() -> crate::pac::adccommon::AdcCommon;
-    #[cfg(any(adc_f1, adc_f3v1, adc_v1, adc_l0, adc_f3v2, adc_u5, adc_wba))]
+    #[cfg(any(adc_f1, adc_f3v1, adc_v1, adc_l0, adc_f3v2, adc_u5, adc_wba, adc_h5))]
     fn state() -> &'static State;
 }
 
@@ -649,16 +651,21 @@ impl<'d, T: Instance<Regs: InjectedAdcRegs>> Adc<'d, T> {
     ///   `InjectedAdc<T, N>` to enforce bounds at compile time.
     pub fn setup_injected_conversions<'a, const N: usize>(
         self,
+        _irq: impl crate::interrupt::typelevel::Binding<T::Interrupt, crate::adc::InterruptHandler<T>> + 'a,
         sequence: [(BorrowedAdcChannel<'a, T>, <T::Regs as BasicAdcRegs>::SampleTime); N],
         trigger: InjectedAdcTrigger<T>,
-        interrupt: bool,
-    ) -> InjectedAdc<'a, T::Regs> {
+    ) -> InjectedAdc<'a, T::Regs> where T: DefaultInstance {
+
         assert!(N != 0, "Read sequence cannot be empty");
         assert!(
             N <= NR_INJECTED_RANKS,
             "Read sequence cannot be more than {} in length",
             NR_INJECTED_RANKS
         );
+
+        use crate::interrupt::typelevel::Interrupt;
+        T::Interrupt::unpend();
+        unsafe { T::Interrupt::enable(); }
 
         T::regs().stop();
         T::regs().configure_injected_sequence(
@@ -668,7 +675,7 @@ impl<'d, T: Instance<Regs: InjectedAdcRegs>> Adc<'d, T> {
         );
 
         T::regs().enable();
-        T::regs().configure_injected_trigger((trigger._trigger, trigger._edge), interrupt);
+        T::regs().configure_injected_trigger((trigger._trigger, trigger._edge), true);
         T::regs().start_injected();
 
         core::mem::forget(self);
@@ -676,7 +683,7 @@ impl<'d, T: Instance<Regs: InjectedAdcRegs>> Adc<'d, T> {
         InjectedAdc::new(sequence) // InjectedAdc<'a, T, N> now borrows the channels
     }
 
-    #[cfg(any(adc_v2, adc_g4))]
+    #[cfg(any(adc_v2, adc_g4, adc_h5))]
     /// Configures ADC for both regular conversions with a ring-buffered DMA and injected conversions.
     ///
     /// # Parameters
@@ -704,13 +711,13 @@ impl<'d, T: Instance<Regs: InjectedAdcRegs>> Adc<'d, T> {
         self,
         dma: embassy_hal_internal::Peri<'a, D>,
         dma_buf: &'a mut [u16],
-        _irq: impl crate::interrupt::typelevel::Binding<D::Interrupt, crate::dma::InterruptHandler<D>> + 'a,
+        _irq: impl crate::interrupt::typelevel::Binding<D::Interrupt, crate::dma::InterruptHandler<D>> + 'a
+        + crate::interrupt::typelevel::Binding<T::Interrupt, crate::adc::InterruptHandler<T>> + 'b,
         regular_sequence: impl ExactSizeIterator<Item = (BorrowedAdcChannel<'a, T>, <T::Regs as BasicAdcRegs>::SampleTime)>,
         regular_trigger: Option<RegularAdcTrigger<T>>,
         injected_sequence: [(BorrowedAdcChannel<'b, T>, <T::Regs as BasicAdcRegs>::SampleTime); N],
-        injected_trigger: InjectedAdcTrigger<T>,
-        injected_interrupt: bool,
-    ) -> (RingBufferedAdc<'a, T::Regs>, InjectedAdc<'b, T::Regs>) {
+        injected_trigger: InjectedAdcTrigger<T>
+    ) -> (RingBufferedAdc<'a, T::Regs>, InjectedAdc<'b, T::Regs>) where T: DefaultInstance {
         let ret = unsafe {
             (
                 Self {
@@ -720,7 +727,7 @@ impl<'d, T: Instance<Regs: InjectedAdcRegs>> Adc<'d, T> {
                 Self {
                     adc: self.adc.clone_unchecked(),
                 }
-                .setup_injected_conversions(injected_sequence, injected_trigger, injected_interrupt),
+                .setup_injected_conversions(_irq, injected_sequence, injected_trigger),
             )
         };
 
@@ -997,7 +1004,7 @@ foreach_adc!(
                 return crate::pac::$common_inst
             }
 
-            #[cfg(any(adc_f1, adc_f3v1, adc_f3v2, adc_v1, adc_l0))]
+            #[cfg(any(adc_f1, adc_f3v1, adc_f3v2, adc_v1, adc_l0, adc_h5))]
             fn state() -> &'static State {
                 static STATE: State = State::new();
                 &STATE

--- a/embassy-stm32/src/adc/mod.rs
+++ b/embassy-stm32/src/adc/mod.rs
@@ -97,7 +97,7 @@ pub struct Adc<'d, T: Instance> {
 #[cfg(any(adc_f1, adc_f3v1, adc_v1, adc_l0, adc_f3v2, adc_h5, adc_v2, adc_g4))]
 pub struct State {
     pub waker: AtomicWaker,
-    pub injected_eos: core::sync::atomic::AtomicBool,
+    pub injected_done: core::sync::atomic::AtomicBool,
 }
 
 #[cfg(any(adc_f1, adc_f3v1, adc_v1, adc_l0, adc_f3v2, adc_h5, adc_v2, adc_g4))]
@@ -105,7 +105,7 @@ impl State {
     pub const fn new() -> Self {
         Self {
             waker: AtomicWaker::new(),
-            injected_eos: core::sync::atomic::AtomicBool::new(false),
+            injected_done: core::sync::atomic::AtomicBool::new(false),
         }
     }
 }
@@ -621,7 +621,7 @@ impl<'d, T: Instance> Adc<'d, T> {
 
 #[cfg(any(adc_v2, adc_g4, adc_h5))]
 impl<'d, T: Instance<Regs: InjectedAdcRegs>> Adc<'d, T> {
-    #[cfg(any(adc_h5))]
+    #[cfg(any(adc_v2, adc_g4, adc_h5))]
     /// Configures the ADC for injected conversions.
     ///
     /// Injected conversions are separate from the regular conversion sequence and are typically
@@ -686,7 +686,7 @@ impl<'d, T: Instance<Regs: InjectedAdcRegs>> Adc<'d, T> {
         InjectedAdc::new(sequence) // InjectedAdc<'a, T, N> now borrows the channels
     }
 
-    #[cfg(any(adc_h5))]
+    #[cfg(any(adc_v2, adc_g4, adc_h5))]
     /// Configures ADC for both regular conversions with a ring-buffered DMA and injected conversions.
     ///
     /// # Parameters
@@ -735,116 +735,6 @@ impl<'d, T: Instance<Regs: InjectedAdcRegs>> Adc<'d, T> {
                     adc: self.adc.clone_unchecked(),
                 }
                 .setup_injected_conversions(_irq, injected_sequence, injected_trigger),
-            )
-        };
-
-        core::mem::forget(self);
-
-        ret
-    }
-
-    #[cfg(any(adc_v2, adc_g4))]
-    /// Configures the ADC for injected conversions.
-    ///
-    /// Injected conversions are separate from the regular conversion sequence and are typically
-    /// triggered by software or an external event. This method sets up a fixed-length sequence of
-    /// injected channels with specified sample times, the trigger source, and whether the end-of-sequence
-    /// interrupt should be enabled.
-    ///
-    /// # Parameters
-    /// - `sequence`: An array of tuples containing the ADC channels and their sample times. The length
-    ///   `N` determines the number of injected ranks to configure (maximum 4 for STM32).
-    /// - `trigger`: The trigger source that starts the injected conversion sequence.
-    /// - `interrupt`: If `true`, enables the end-of-sequence (JEOS) interrupt for injected conversions.
-    ///
-    /// # Returns
-    /// An `InjectedAdc<T, N>` instance that represents the configured injected sequence. The returned
-    /// type encodes the sequence length `N` in its type, ensuring that reads return exactly `N` samples.
-    ///
-    /// # Panics
-    /// This function will panic if:
-    /// - `sequence` is empty.
-    /// - `sequence` length exceeds the maximum number of injected ranks (`NR_INJECTED_RANKS`).
-    ///
-    /// # Notes
-    /// - Injected conversions can run independently of regular ADC conversions.
-    /// - The order of channels in `sequence` determines the rank order in the injected sequence.
-    /// - Accessing samples beyond `N` will result in a panic; use the returned type
-    ///   `InjectedAdc<T, N>` to enforce bounds at compile time.
-    pub fn setup_injected_conversions<'a, const N: usize>(
-        self,
-        sequence: [(BorrowedAdcChannel<'a, T>, <T::Regs as BasicAdcRegs>::SampleTime); N],
-        trigger: InjectedAdcTrigger<T>,
-        interrupt: bool,
-    ) -> InjectedAdc<'a, T::Regs> {
-        assert!(N != 0, "Read sequence cannot be empty");
-        assert!(
-            N <= NR_INJECTED_RANKS,
-            "Read sequence cannot be more than {} in length",
-            NR_INJECTED_RANKS
-        );
-
-        T::regs().stop();
-        T::regs().configure_injected_sequence(
-            sequence
-                .iter()
-                .map(|(channel, sample_time)| ((channel.channel, channel.is_differential), *sample_time)),
-        );
-
-        T::regs().enable();
-        T::regs().configure_injected_trigger((trigger._trigger, trigger._edge), interrupt);
-        T::regs().start_injected();
-
-        core::mem::forget(self);
-
-        InjectedAdc::new(sequence) // InjectedAdc<'a, T, N> now borrows the channels
-    }
-
-    #[cfg(any(adc_v2, adc_g4))]
-    /// Configures ADC for both regular conversions with a ring-buffered DMA and injected conversions.
-    ///
-    /// # Parameters
-    /// - `dma`: The DMA peripheral to use for the ring-buffered ADC transfers.
-    /// - `dma_buf`: The buffer to store DMA-transferred samples for regular conversions.
-    /// - `regular_sequence`: The sequence of channels and their sample times for regular conversions.
-    /// - `regular_conversion_mode`: The mode for regular conversions (e.g., continuous or triggered).
-    /// - `injected_sequence`: An array of channels and sample times for injected conversions (length `N`).
-    /// - `injected_trigger`: The trigger source for injected conversions.
-    /// - `injected_interrupt`: Whether to enable the end-of-sequence interrupt for injected conversions.
-    ///
-    /// Injected conversions are typically used with interrupts. If ADC1 and ADC2 are used in dual mode,
-    /// it is recommended to enable interrupts only for the ADC whose sequence takes the longest to complete.
-    ///
-    /// # Returns
-    /// A tuple containing:
-    /// 1. `RingBufferedAdc<'a, T>` — the configured ADC for regular conversions using DMA.
-    /// 2. `InjectedAdc<T, N>` — the configured ADC for injected conversions.
-    ///
-    /// # Safety
-    /// This function is `unsafe` because it clones the ADC peripheral handle unchecked. Both the
-    /// `RingBufferedAdc` and `InjectedAdc` take ownership of the handle and drop it independently.
-    /// Ensure no other code concurrently accesses the same ADC instance in a conflicting way.
-    pub fn into_ring_buffered_and_injected<'a, 'b, const N: usize, D: RxDma<T>>(
-        self,
-        dma: embassy_hal_internal::Peri<'a, D>,
-        dma_buf: &'a mut [u16],
-        _irq: impl crate::interrupt::typelevel::Binding<D::Interrupt, crate::dma::InterruptHandler<D>> + 'a,
-        regular_sequence: impl ExactSizeIterator<Item = (BorrowedAdcChannel<'a, T>, <T::Regs as BasicAdcRegs>::SampleTime)>,
-        regular_trigger: Option<RegularAdcTrigger<T>>,
-        injected_sequence: [(BorrowedAdcChannel<'b, T>, <T::Regs as BasicAdcRegs>::SampleTime); N],
-        injected_trigger: InjectedAdcTrigger<T>,
-        injected_interrupt: bool,
-    ) -> (RingBufferedAdc<'a, T::Regs>, InjectedAdc<'b, T::Regs>) {
-        let ret = unsafe {
-            (
-                Self {
-                    adc: self.adc.clone_unchecked(),
-                }
-                .into_ring_buffered(dma, dma_buf, _irq, regular_sequence, regular_trigger),
-                Self {
-                    adc: self.adc.clone_unchecked(),
-                }
-                .setup_injected_conversions(injected_sequence, injected_trigger, injected_interrupt),
             )
         };
 

--- a/embassy-stm32/src/adc/mod.rs
+++ b/embassy-stm32/src/adc/mod.rs
@@ -621,7 +621,7 @@ impl<'d, T: Instance> Adc<'d, T> {
 
 #[cfg(any(adc_v2, adc_g4, adc_h5))]
 impl<'d, T: Instance<Regs: InjectedAdcRegs>> Adc<'d, T> {
-    #[cfg(any(adc_v2, adc_g4, adc_h5))]
+    #[cfg(any(adc_h5))]
     /// Configures the ADC for injected conversions.
     ///
     /// Injected conversions are separate from the regular conversion sequence and are typically
@@ -686,7 +686,7 @@ impl<'d, T: Instance<Regs: InjectedAdcRegs>> Adc<'d, T> {
         InjectedAdc::new(sequence) // InjectedAdc<'a, T, N> now borrows the channels
     }
 
-    #[cfg(any(adc_v2, adc_g4, adc_h5))]
+    #[cfg(any(adc_h5))]
     /// Configures ADC for both regular conversions with a ring-buffered DMA and injected conversions.
     ///
     /// # Parameters
@@ -735,6 +735,116 @@ impl<'d, T: Instance<Regs: InjectedAdcRegs>> Adc<'d, T> {
                     adc: self.adc.clone_unchecked(),
                 }
                 .setup_injected_conversions(_irq, injected_sequence, injected_trigger),
+            )
+        };
+
+        core::mem::forget(self);
+
+        ret
+    }
+
+    #[cfg(any(adc_v2, adc_g4))]
+    /// Configures the ADC for injected conversions.
+    ///
+    /// Injected conversions are separate from the regular conversion sequence and are typically
+    /// triggered by software or an external event. This method sets up a fixed-length sequence of
+    /// injected channels with specified sample times, the trigger source, and whether the end-of-sequence
+    /// interrupt should be enabled.
+    ///
+    /// # Parameters
+    /// - `sequence`: An array of tuples containing the ADC channels and their sample times. The length
+    ///   `N` determines the number of injected ranks to configure (maximum 4 for STM32).
+    /// - `trigger`: The trigger source that starts the injected conversion sequence.
+    /// - `interrupt`: If `true`, enables the end-of-sequence (JEOS) interrupt for injected conversions.
+    ///
+    /// # Returns
+    /// An `InjectedAdc<T, N>` instance that represents the configured injected sequence. The returned
+    /// type encodes the sequence length `N` in its type, ensuring that reads return exactly `N` samples.
+    ///
+    /// # Panics
+    /// This function will panic if:
+    /// - `sequence` is empty.
+    /// - `sequence` length exceeds the maximum number of injected ranks (`NR_INJECTED_RANKS`).
+    ///
+    /// # Notes
+    /// - Injected conversions can run independently of regular ADC conversions.
+    /// - The order of channels in `sequence` determines the rank order in the injected sequence.
+    /// - Accessing samples beyond `N` will result in a panic; use the returned type
+    ///   `InjectedAdc<T, N>` to enforce bounds at compile time.
+    pub fn setup_injected_conversions<'a, const N: usize>(
+        self,
+        sequence: [(BorrowedAdcChannel<'a, T>, <T::Regs as BasicAdcRegs>::SampleTime); N],
+        trigger: InjectedAdcTrigger<T>,
+        interrupt: bool,
+    ) -> InjectedAdc<'a, T::Regs> {
+        assert!(N != 0, "Read sequence cannot be empty");
+        assert!(
+            N <= NR_INJECTED_RANKS,
+            "Read sequence cannot be more than {} in length",
+            NR_INJECTED_RANKS
+        );
+
+        T::regs().stop();
+        T::regs().configure_injected_sequence(
+            sequence
+                .iter()
+                .map(|(channel, sample_time)| ((channel.channel, channel.is_differential), *sample_time)),
+        );
+
+        T::regs().enable();
+        T::regs().configure_injected_trigger((trigger._trigger, trigger._edge), interrupt);
+        T::regs().start_injected();
+
+        core::mem::forget(self);
+
+        InjectedAdc::new(sequence) // InjectedAdc<'a, T, N> now borrows the channels
+    }
+
+    #[cfg(any(adc_v2, adc_g4))]
+    /// Configures ADC for both regular conversions with a ring-buffered DMA and injected conversions.
+    ///
+    /// # Parameters
+    /// - `dma`: The DMA peripheral to use for the ring-buffered ADC transfers.
+    /// - `dma_buf`: The buffer to store DMA-transferred samples for regular conversions.
+    /// - `regular_sequence`: The sequence of channels and their sample times for regular conversions.
+    /// - `regular_conversion_mode`: The mode for regular conversions (e.g., continuous or triggered).
+    /// - `injected_sequence`: An array of channels and sample times for injected conversions (length `N`).
+    /// - `injected_trigger`: The trigger source for injected conversions.
+    /// - `injected_interrupt`: Whether to enable the end-of-sequence interrupt for injected conversions.
+    ///
+    /// Injected conversions are typically used with interrupts. If ADC1 and ADC2 are used in dual mode,
+    /// it is recommended to enable interrupts only for the ADC whose sequence takes the longest to complete.
+    ///
+    /// # Returns
+    /// A tuple containing:
+    /// 1. `RingBufferedAdc<'a, T>` — the configured ADC for regular conversions using DMA.
+    /// 2. `InjectedAdc<T, N>` — the configured ADC for injected conversions.
+    ///
+    /// # Safety
+    /// This function is `unsafe` because it clones the ADC peripheral handle unchecked. Both the
+    /// `RingBufferedAdc` and `InjectedAdc` take ownership of the handle and drop it independently.
+    /// Ensure no other code concurrently accesses the same ADC instance in a conflicting way.
+    pub fn into_ring_buffered_and_injected<'a, 'b, const N: usize, D: RxDma<T>>(
+        self,
+        dma: embassy_hal_internal::Peri<'a, D>,
+        dma_buf: &'a mut [u16],
+        _irq: impl crate::interrupt::typelevel::Binding<D::Interrupt, crate::dma::InterruptHandler<D>> + 'a,
+        regular_sequence: impl ExactSizeIterator<Item = (BorrowedAdcChannel<'a, T>, <T::Regs as BasicAdcRegs>::SampleTime)>,
+        regular_trigger: Option<RegularAdcTrigger<T>>,
+        injected_sequence: [(BorrowedAdcChannel<'b, T>, <T::Regs as BasicAdcRegs>::SampleTime); N],
+        injected_trigger: InjectedAdcTrigger<T>,
+        injected_interrupt: bool,
+    ) -> (RingBufferedAdc<'a, T::Regs>, InjectedAdc<'b, T::Regs>) {
+        let ret = unsafe {
+            (
+                Self {
+                    adc: self.adc.clone_unchecked(),
+                }
+                .into_ring_buffered(dma, dma_buf, _irq, regular_sequence, regular_trigger),
+                Self {
+                    adc: self.adc.clone_unchecked(),
+                }
+                .setup_injected_conversions(injected_sequence, injected_trigger, injected_interrupt),
             )
         };
 

--- a/embassy-stm32/src/adc/v2.rs
+++ b/embassy-stm32/src/adc/v2.rs
@@ -1,7 +1,8 @@
 use core::sync::atomic::{Ordering, compiler_fence};
 
 use crate::adc::{
-    Adc, AdcRegs, ConversionMode, DefaultInstance, InjectedRegs, Resolution, SampleTime, Temperature, Vbat, VrefInt,
+    Adc, AdcRegs, ConversionMode, DefaultInstance, InjectedRegs, Instance, Resolution, SampleTime, Temperature, Vbat,
+    VrefInt,
 };
 use crate::pac::adc::vals;
 pub use crate::pac::adccommon::vals::Adcpre;
@@ -28,6 +29,30 @@ pub const VREF_DEFAULT_MV: u32 = 3300;
 pub const VREF_CALIB_MV: u32 = 3300;
 
 pub const NR_INJECTED_RANKS: usize = 4;
+
+/// Interrupt handler.
+pub struct InterruptHandler<T: Instance> {
+    _marker: core::marker::PhantomData<T>,
+}
+
+impl<T: DefaultInstance> crate::interrupt::typelevel::Handler<T::Interrupt> for InterruptHandler<T> {
+    unsafe fn on_interrupt() {
+        let mut sr = T::regs().sr().read();
+        if sr.eoc() || sr.jeoc() {
+            if sr.jeoc() {
+                T::state()
+                    .injected_done
+                    .store(true, core::sync::atomic::Ordering::Release);
+            }
+
+            sr.set_eoc(false);
+            sr.set_jeoc(false);
+            T::regs().sr().write_value(sr);
+
+            T::state().waker.wake();
+        }
+    }
+}
 
 impl super::ConverterFor<super::VrefInt> for crate::peripherals::ADC1 {
     const CHANNEL: u8 = 17;

--- a/embassy-stm32/src/adc/v3.rs
+++ b/embassy-stm32/src/adc/v3.rs
@@ -1,3 +1,5 @@
+use core::marker::PhantomData;
+
 use cfg_if::cfg_if;
 #[cfg(adc_g0)]
 use heapless::Vec;
@@ -13,9 +15,9 @@ use pac::adccommon::vals::Presc;
 
 #[allow(unused_imports)]
 use crate::adc::SealedAdcChannel;
-use crate::adc::{Adc, Averaging, ConversionMode, Instance, Resolution, SampleTime, Temperature, Vbat, VrefInt};
+use crate::adc::{Adc, Averaging, ConversionMode, DefaultInstance, Instance, Resolution, SampleTime, Temperature, Vbat, VrefInt};
 use crate::wait::block_for_us;
-use crate::{Peri, pac, rcc};
+use crate::{Peri, interrupt, pac, rcc};
 
 #[cfg(adc_h5)]
 mod injected;
@@ -37,6 +39,27 @@ pub const NR_INJECTED_RANKS: usize = 4;
 /// The number of variants in Smpsel
 // TODO: Use [#![feature(variant_count)]](https://github.com/rust-lang/rust/issues/73662) when stable
 const SAMPLE_TIMES_CAPACITY: usize = 2;
+
+/// Interrupt handler.
+pub struct InterruptHandler<T: Instance> {
+    _marker: PhantomData<T>,
+}
+
+impl<T: DefaultInstance> interrupt::typelevel::Handler<T::Interrupt> for InterruptHandler<T> {
+    unsafe fn on_interrupt() {
+        let isr = T::regs().isr().read();
+        if isr.eoc() || isr.eos() || isr.jeoc() || isr.jeos() {
+            if isr.jeos() {
+                T::state().injected_eos.store(true, core::sync::atomic::Ordering::Release);
+            }
+
+            // flags are cleared by writing 1 to them
+            T::regs().isr().write_value(isr);
+
+            T::state().waker.wake();
+        }
+    }
+}
 
 #[cfg(adc_g0)]
 impl<T: Instance> super::ConverterFor<super::VrefInt> for T {

--- a/embassy-stm32/src/adc/v3.rs
+++ b/embassy-stm32/src/adc/v3.rs
@@ -15,7 +15,9 @@ use pac::adccommon::vals::Presc;
 
 #[allow(unused_imports)]
 use crate::adc::SealedAdcChannel;
-use crate::adc::{Adc, Averaging, ConversionMode, DefaultInstance, Instance, Resolution, SampleTime, Temperature, Vbat, VrefInt};
+use crate::adc::{
+    Adc, Averaging, ConversionMode, DefaultInstance, Instance, Resolution, SampleTime, Temperature, Vbat, VrefInt,
+};
 use crate::wait::block_for_us;
 use crate::{Peri, interrupt, pac, rcc};
 
@@ -50,7 +52,9 @@ impl<T: DefaultInstance> interrupt::typelevel::Handler<T::Interrupt> for Interru
         let isr = T::regs().isr().read();
         if isr.eoc() || isr.eos() || isr.jeoc() || isr.jeos() {
             if isr.jeos() {
-                T::state().injected_eos.store(true, core::sync::atomic::Ordering::Release);
+                T::state()
+                    .injected_eos
+                    .store(true, core::sync::atomic::Ordering::Release);
             }
 
             // flags are cleared by writing 1 to them

--- a/embassy-stm32/src/adc/v3.rs
+++ b/embassy-stm32/src/adc/v3.rs
@@ -51,7 +51,7 @@ impl<T: crate::adc::DefaultInstance> crate::interrupt::typelevel::Handler<T::Int
         if isr.eoc() || isr.eos() || isr.jeoc() || isr.jeos() {
             if isr.jeos() {
                 T::state()
-                    .injected_eos
+                    .injected_done
                     .store(true, core::sync::atomic::Ordering::Release);
             }
 

--- a/embassy-stm32/src/adc/v3.rs
+++ b/embassy-stm32/src/adc/v3.rs
@@ -1,5 +1,3 @@
-use core::marker::PhantomData;
-
 use cfg_if::cfg_if;
 #[cfg(adc_g0)]
 use heapless::Vec;
@@ -15,11 +13,9 @@ use pac::adccommon::vals::Presc;
 
 #[allow(unused_imports)]
 use crate::adc::SealedAdcChannel;
-use crate::adc::{
-    Adc, Averaging, ConversionMode, DefaultInstance, Instance, Resolution, SampleTime, Temperature, Vbat, VrefInt,
-};
+use crate::adc::{Adc, Averaging, ConversionMode, Instance, Resolution, SampleTime, Temperature, Vbat, VrefInt};
 use crate::wait::block_for_us;
-use crate::{Peri, interrupt, pac, rcc};
+use crate::{Peri, pac, rcc};
 
 #[cfg(adc_h5)]
 mod injected;
@@ -43,11 +39,13 @@ pub const NR_INJECTED_RANKS: usize = 4;
 const SAMPLE_TIMES_CAPACITY: usize = 2;
 
 /// Interrupt handler.
+#[cfg(adc_h5)]
 pub struct InterruptHandler<T: Instance> {
-    _marker: PhantomData<T>,
+    _marker: core::marker::PhantomData<T>,
 }
 
-impl<T: DefaultInstance> interrupt::typelevel::Handler<T::Interrupt> for InterruptHandler<T> {
+#[cfg(adc_h5)]
+impl<T: crate::adc::DefaultInstance> crate::interrupt::typelevel::Handler<T::Interrupt> for InterruptHandler<T> {
     unsafe fn on_interrupt() {
         let isr = T::regs().isr().read();
         if isr.eoc() || isr.eos() || isr.jeoc() || isr.jeos() {

--- a/examples/stm32g4/src/bin/adc_injected_and_regular.rs
+++ b/examples/stm32g4/src/bin/adc_injected_and_regular.rs
@@ -10,9 +10,8 @@ use core::cell::RefCell;
 
 use defmt::info;
 use embassy_stm32::adc::{
-    Adc, AdcChannel as _, Exten, InjectedAdc, InjectedAdcTrigger, RegularAdcTrigger, SampleTime, VrefInt,
+    self, Adc, AdcChannel as _, Exten, InjectedAdc, InjectedAdcTrigger, RegularAdcTrigger, SampleTime, VrefInt,
 };
-use embassy_stm32::interrupt::typelevel::{ADC1_2, Interrupt};
 use embassy_stm32::pac::adc::Adc as AdcRegs;
 use embassy_stm32::time::Hertz;
 use embassy_stm32::timer::complementary_pwm::{ComplementaryPwm, Mms2};
@@ -29,6 +28,15 @@ static ADC1_HANDLE: CriticalSectionMutex<RefCell<Option<InjectedAdc<AdcRegs>>>> 
 bind_interrupts!(struct Irqs {
     DMA1_CHANNEL1 => dma::InterruptHandler<peripherals::DMA1_CH1>;
 });
+
+// The interrupt is implemented manually.
+unsafe impl
+    embassy_stm32::interrupt::typelevel::Binding<
+        embassy_stm32::interrupt::typelevel::ADC1_2,
+        adc::InterruptHandler<peripherals::ADC1>,
+    > for Irqs
+{
+}
 
 /// This example showcases how to use both regular ADC conversions with DMA and injected ADC
 /// conversions with ADC interrupt simultaneously. Both conversion types can be configured with
@@ -108,15 +116,12 @@ async fn main(_spawner: embassy_executor::Spawner) {
         RegularAdcTrigger::from(TIM1_TRGO2, Exten::RisingEdge),
         injected_sequence,
         InjectedAdcTrigger::from(TIM1_TRGO2, Exten::RisingEdge),
-        true,
     );
 
     // Store ADC globally to allow access from ADC interrupt
     critical_section::with(|cs| {
         ADC1_HANDLE.borrow(cs).replace(Some(injected_adc));
     });
-    // Enable interrupt for ADC1_2
-    unsafe { ADC1_2::enable() };
 
     // Main loop for reading regular ADC measurements periodically
     let mut data = [0u16; 2];

--- a/examples/stm32g4/src/bin/adc_injected_and_regular.rs
+++ b/examples/stm32g4/src/bin/adc_injected_and_regular.rs
@@ -144,7 +144,7 @@ unsafe fn ADC1_2() {
     critical_section::with(|cs| {
         if let Some(injected_adc) = ADC1_HANDLE.borrow(cs).borrow_mut().as_mut() {
             let mut injected_data = [0u16; 1];
-            injected_adc.read_injected_samples(&mut injected_data);
+            injected_adc.read_latest(&mut injected_data);
             info!("Injected reading of PA2: {}", injected_data[0]);
         }
     });


### PR DESCRIPTION
Implements interrupt driven read function for injected ADC convention which waits for end of sequence. This way reading injected convention no longer requires manually implementing interrupt handler, but is still possible if needed.

I had to duplicate some code because otherwise I would have to implement ADC interrupt handler for more STMs, but I don't want to do that until I get some feedback on the actual feature. In case this PR is ok, it can be merged, and I will implement interrupt handlers in a separate PR or I can add them in this PR.

Tested on STM32H523CE.