### PR TITLE
stm32/adc: clean up sequence configuration

### DIFF
--- a/embassy-stm32/src/adc/adc4.rs
+++ b/embassy-stm32/src/adc/adc4.rs
@@ -323,7 +323,7 @@ impl AdcRegs for crate::pac::adc::Adc4 {
         });
     }
 
-    fn configure_sequence(&self, sequence: impl ExactSizeIterator<Item = ((u8, bool), SampleTime)>) {
+    fn configure_sequence(&self, sequence: impl ExactSizeIterator<Item = ((u8, bool), SampleTime)>, _injected: bool) {
         let mut prev_channel: i16 = -1;
         let mut chselr = Chselr::default();
         let mut smpr = self.smpr().read();

--- a/embassy-stm32/src/adc/c0.rs
+++ b/embassy-stm32/src/adc/c0.rs
@@ -108,7 +108,11 @@ impl AdcRegs for crate::pac::adc::Adc {
         });
     }
 
-    fn configure_sequence(&self, sequence: impl ExactSizeIterator<Item = ((u8, bool), Self::SampleTime)>) {
+    fn configure_sequence(
+        &self,
+        sequence: impl ExactSizeIterator<Item = ((u8, bool), Self::SampleTime)>,
+        _injected: bool,
+    ) {
         let mut needs_hw = sequence.len() == 1 || sequence.len() > CHSELR_SQ_SIZE;
         let mut is_ordered_up = true;
         let mut is_ordered_down = true;

--- a/embassy-stm32/src/adc/f1.rs
+++ b/embassy-stm32/src/adc/f1.rs
@@ -103,7 +103,7 @@ impl AdcRegs for crate::pac::adc::Adc {
         });
     }
 
-    fn configure_sequence(&self, sequence: impl ExactSizeIterator<Item = ((u8, bool), SampleTime)>) {
+    fn configure_sequence(&self, sequence: impl ExactSizeIterator<Item = ((u8, bool), SampleTime)>, injected: bool) {
         let mut sqr1 = Sqr1::default();
         let mut sqr2 = Sqr2::default();
         let mut sqr3 = Sqr3::default();
@@ -111,15 +111,19 @@ impl AdcRegs for crate::pac::adc::Adc {
         let mut smpr1 = Smpr1::default();
         let mut smpr2 = Smpr2::default();
 
-        // Check the sequence is long enough
-        sqr1.set_l((sequence.len() - 1).try_into().unwrap());
+        if !injected {
+            // Check the sequence is long enough
+            sqr1.set_l((sequence.len() - 1).try_into().unwrap());
+        }
 
         for (i, ((ch, _), sample_time)) in sequence.enumerate() {
-            match i {
-                0..=5 => sqr3.set_sq(i, ch),
-                6..=11 => sqr2.set_sq(i - 6, ch),
-                12..=15 => sqr1.set_sq(i - 12, ch),
-                _ => unreachable!(),
+            if !injected {
+                match i {
+                    0..=5 => sqr3.set_sq(i, ch),
+                    6..=11 => sqr2.set_sq(i - 6, ch),
+                    12..=15 => sqr1.set_sq(i - 12, ch),
+                    _ => unreachable!(),
+                }
             }
 
             let sample_time = sample_time.into();
@@ -130,9 +134,11 @@ impl AdcRegs for crate::pac::adc::Adc {
             }
         }
 
-        self.sqr1().write_value(sqr1);
-        self.sqr2().write_value(sqr2);
-        self.sqr3().write_value(sqr3);
+        if !injected {
+            self.sqr1().write_value(sqr1);
+            self.sqr2().write_value(sqr2);
+            self.sqr3().write_value(sqr3);
+        }
         self.smpr1().write_value(smpr1);
         self.smpr2().write_value(smpr2);
     }

--- a/embassy-stm32/src/adc/f3.rs
+++ b/embassy-stm32/src/adc/f3.rs
@@ -105,7 +105,7 @@ impl AdcRegs for crate::pac::adc::Adc {
         });
     }
 
-    fn configure_sequence(&self, sequence: impl ExactSizeIterator<Item = ((u8, bool), SampleTime)>) {
+    fn configure_sequence(&self, sequence: impl ExactSizeIterator<Item = ((u8, bool), SampleTime)>, injected: bool) {
         let mut sqr1 = Sqr1::default();
         let mut sqr2 = Sqr2::default();
         let mut sqr3 = Sqr3::default();
@@ -113,15 +113,19 @@ impl AdcRegs for crate::pac::adc::Adc {
         let mut smpr1 = Smpr1::default();
         let mut smpr2 = Smpr2::default();
 
-        // Check the sequence is long enough
-        sqr1.set_l((sequence.len() - 1).try_into().unwrap());
+        if !injected {
+            // Check the sequence is long enough
+            sqr1.set_l((sequence.len() - 1).try_into().unwrap());
+        }
 
         for (i, ((ch, _), sample_time)) in sequence.enumerate() {
-            match i {
-                0..=5 => sqr1.set_sq(i, ch),
-                6..=11 => sqr2.set_sq(i - 6, ch),
-                12..=15 => sqr3.set_sq(i - 12, ch),
-                _ => unreachable!(),
+            if !injected {
+                match i {
+                    0..=5 => sqr1.set_sq(i, ch),
+                    6..=11 => sqr2.set_sq(i - 6, ch),
+                    12..=15 => sqr3.set_sq(i - 12, ch),
+                    _ => unreachable!(),
+                }
             }
 
             let sample_time = sample_time.into();
@@ -132,9 +136,11 @@ impl AdcRegs for crate::pac::adc::Adc {
             }
         }
 
-        self.sqr1().write_value(sqr1);
-        self.sqr2().write_value(sqr2);
-        self.sqr3().write_value(sqr3);
+        if !injected {
+            self.sqr1().write_value(sqr1);
+            self.sqr2().write_value(sqr2);
+            self.sqr3().write_value(sqr3);
+        }
         self.smpr1().write_value(smpr1);
         self.smpr2().write_value(smpr2);
     }

--- a/embassy-stm32/src/adc/g4.rs
+++ b/embassy-stm32/src/adc/g4.rs
@@ -136,7 +136,7 @@ impl super::AdcRegs for crate::pac::adc::Adc {
         });
     }
 
-    fn configure_sequence(&self, sequence: impl ExactSizeIterator<Item = ((u8, bool), SampleTime)>) {
+    fn configure_sequence(&self, sequence: impl ExactSizeIterator<Item = ((u8, bool), SampleTime)>, injected: bool) {
         #[cfg(stm32g4)]
         if self.cr().read().aden() {
             self.cr().modify(|reg| reg.set_addis(true));
@@ -152,11 +152,18 @@ impl super::AdcRegs for crate::pac::adc::Adc {
         #[cfg(stm32g4)]
         let mut difsel = self.difsel().read();
 
-        // Set sequence length
-        sqr1.set_l(sequence.len() as u8 - 1);
+        let mut jsqr = Jsqr::default();
+
+        let len: u8 = sequence.len().try_into().unwrap();
+        if injected {
+            jsqr.set_jl(len - 1);
+        } else {
+            // Set sequence length
+            sqr1.set_l(len - 1);
+        }
 
         // Configure channels and ranks
-        for (_i, ((ch, is_differential), sample_time)) in sequence.enumerate() {
+        for (i, ((ch, is_differential), sample_time)) in sequence.enumerate() {
             let sample_time = sample_time.into();
             if ch <= 9 {
                 smpr.set_smp(ch as _, sample_time);
@@ -164,20 +171,32 @@ impl super::AdcRegs for crate::pac::adc::Adc {
                 smpr2.set_smp((ch - 10) as _, sample_time);
             }
 
-            match _i {
-                0..=3 => {
-                    sqr1.set_sq(_i, ch);
+            if injected {
+                let idx = match i {
+                    0..=3 => i,
+                    4..=8 => i - 4,
+                    9..=13 => i - 9,
+                    14..=15 => i - 14,
+                    _ => unreachable!(),
+                };
+
+                jsqr.set_jsq(idx, ch);
+            } else {
+                match i {
+                    0..=3 => {
+                        sqr1.set_sq(i, ch);
+                    }
+                    4..=8 => {
+                        sqr2.set_sq(i - 4, ch);
+                    }
+                    9..=13 => {
+                        sqr3.set_sq(i - 9, ch);
+                    }
+                    14..=15 => {
+                        sqr4.set_sq(i - 14, ch);
+                    }
+                    _ => unreachable!(),
                 }
-                4..=8 => {
-                    sqr2.set_sq(_i - 4, ch);
-                }
-                9..=13 => {
-                    sqr3.set_sq(_i - 9, ch);
-                }
-                14..=15 => {
-                    sqr4.set_sq(_i - 14, ch);
-                }
-                _ => unreachable!(),
             }
 
             #[cfg(stm32g4)]
@@ -197,70 +216,18 @@ impl super::AdcRegs for crate::pac::adc::Adc {
         self.difsel().write_value(difsel);
         self.smpr().write_value(smpr);
         self.smpr2().write_value(smpr2);
-        self.sqr1().write_value(sqr1);
-        self.sqr2().write_value(sqr2);
-        self.sqr3().write_value(sqr3);
-        self.sqr4().write_value(sqr4);
+        if injected {
+            self.jsqr().write_value(jsqr);
+        } else {
+            self.sqr1().write_value(sqr1);
+            self.sqr2().write_value(sqr2);
+            self.sqr3().write_value(sqr3);
+            self.sqr4().write_value(sqr4);
+        }
     }
 }
 
 impl InjectedRegs for crate::pac::adc::Adc {
-    fn configure_injected_sequence(&self, sequence: impl ExactSizeIterator<Item = ((u8, bool), Self::SampleTime)>) {
-        #[cfg(stm32g4)]
-        if self.cr().read().aden() {
-            self.cr().modify(|reg| reg.set_addis(true));
-            while self.cr().read().aden() {}
-        }
-
-        let mut smpr1 = self.smpr().read();
-        let mut smpr2 = self.smpr2().read();
-        #[cfg(stm32g4)]
-        let mut difsel = self.difsel().read();
-
-        let mut jsqr = Jsqr::default();
-
-        let len: u8 = sequence.len().try_into().unwrap();
-        jsqr.set_jl(len - 1);
-
-        for (n, ((channel, is_differential), sample_time)) in sequence.enumerate() {
-            let sample_time = sample_time.clone().into();
-            if channel <= 9 {
-                smpr1.set_smp(channel as _, sample_time);
-            } else {
-                smpr2.set_smp((channel - 10) as _, sample_time);
-            }
-
-            let idx = match n {
-                0..=3 => n,
-                4..=8 => n - 4,
-                9..=13 => n - 9,
-                14..=15 => n - 14,
-                _ => unreachable!(),
-            };
-
-            jsqr.set_jsq(idx, channel);
-
-            #[cfg(stm32g4)]
-            if channel < 18 {
-                difsel.set_difsel(
-                    channel.into(),
-                    if is_differential {
-                        Difsel::Differential
-                    } else {
-                        Difsel::SingleEnded
-                    },
-                );
-            }
-        }
-
-        #[cfg(stm32g4)]
-        self.difsel().write_value(difsel);
-        self.smpr().write_value(smpr1);
-        self.smpr2().write_value(smpr2);
-
-        self.jsqr().write_value(jsqr);
-    }
-
     fn configure_injected_trigger(&self, trigger: (u8, Exten), interrupt: bool) {
         self.cfgr().modify(|reg| reg.set_jdiscen(false));
 

--- a/embassy-stm32/src/adc/l1.rs
+++ b/embassy-stm32/src/adc/l1.rs
@@ -150,7 +150,7 @@ impl AdcRegs for crate::pac::adc::Adc {
         });
     }
 
-    fn configure_sequence(&self, sequence: impl ExactSizeIterator<Item = ((u8, bool), SampleTime)>) {
+    fn configure_sequence(&self, sequence: impl ExactSizeIterator<Item = ((u8, bool), SampleTime)>, injected: bool) {
         let mut sqr1 = Sqr1::default();
         let mut sqr2 = Sqr2::default();
         let mut sqr3 = Sqr3::default();
@@ -162,17 +162,21 @@ impl AdcRegs for crate::pac::adc::Adc {
         let mut smpr2 = Smpr2::default();
         let mut smpr3 = Smpr3::default();
 
-        // Check the sequence is long enough
-        sqr1.set_l((sequence.len() - 1).try_into().unwrap());
+        if !injected {
+            // Check the sequence is long enough
+            sqr1.set_l((sequence.len() - 1).try_into().unwrap());
+        }
 
         for (i, ((ch, _), sample_time)) in sequence.enumerate() {
-            match i {
-                0..=5 => sqr5.set_sq(i, ch),
-                6..=11 => sqr4.set_sq(i - 6, ch),
-                12..=15 => sqr3.set_sq(i - 12, ch),
-                18..=23 => sqr2.set_sq(i - 18, ch),
-                24..=27 => sqr1.set_sq(i - 24, ch),
-                _ => unreachable!(),
+            if !injected {
+                match i {
+                    0..=5 => sqr5.set_sq(i, ch),
+                    6..=11 => sqr4.set_sq(i - 6, ch),
+                    12..=15 => sqr3.set_sq(i - 12, ch),
+                    18..=23 => sqr2.set_sq(i - 18, ch),
+                    24..=27 => sqr1.set_sq(i - 24, ch),
+                    _ => unreachable!(),
+                }
             }
 
             let sample_time = sample_time.into();
@@ -185,11 +189,13 @@ impl AdcRegs for crate::pac::adc::Adc {
             }
         }
 
-        self.sqr1().write_value(sqr1);
-        self.sqr2().write_value(sqr2);
-        self.sqr3().write_value(sqr3);
-        self.sqr4().write_value(sqr4);
-        self.sqr5().write_value(sqr5);
+        if !injected {
+            self.sqr1().write_value(sqr1);
+            self.sqr2().write_value(sqr2);
+            self.sqr3().write_value(sqr3);
+            self.sqr4().write_value(sqr4);
+            self.sqr5().write_value(sqr5);
+        }
 
         self.smpr0().write_value(smpr0);
         self.smpr1().write_value(smpr1);

--- a/embassy-stm32/src/adc/mod.rs
+++ b/embassy-stm32/src/adc/mod.rs
@@ -158,15 +158,16 @@ trait AdcRegs: BasicAdcRegs {
     fn configure_dma(&self, conversion_mode: ConversionMode);
     /// Configure the sequence. If the ADC is capable of differential channels,
     /// this method must disable the ADC before configuring the sequence if required by hardware.
-    fn configure_sequence(&self, sequence: impl ExactSizeIterator<Item = ((u8, bool), Self::SampleTime)>);
+    fn configure_sequence(
+        &self,
+        sequence: impl ExactSizeIterator<Item = ((u8, bool), Self::SampleTime)>,
+        injected: bool,
+    );
     fn data(&self) -> *mut u16;
 }
 
 #[cfg(any(adc_v2, adc_g4, adc_h5))]
 trait InjectedRegs: AdcRegs {
-    /// Configure the sequence. If the ADC is capable of differential channels,
-    /// this method must disable the ADC before configuring the sequence if required by hardware.
-    fn configure_injected_sequence(&self, sequence: impl ExactSizeIterator<Item = ((u8, bool), Self::SampleTime)>);
     fn configure_injected_trigger(&self, trigger: (u8, Exten), interrupt: bool);
     fn start_injected(&self);
     fn stop_injected(&self);
@@ -296,7 +297,10 @@ impl<'d, T: Instance> Adc<'d, T> {
         let channel = channel.reborrow_adc();
 
         T::regs().stop();
-        T::regs().configure_sequence([((channel.channel(), channel.is_differential()), sample_time)].into_iter());
+        T::regs().configure_sequence(
+            [((channel.channel(), channel.is_differential()), sample_time)].into_iter(),
+            false,
+        );
 
         T::regs().enable();
         T::regs().configure_dma(ConversionMode::NoDma);
@@ -326,7 +330,10 @@ impl<'d, T: Instance> Adc<'d, T> {
         let channel = channel.reborrow_adc();
 
         T::regs().stop();
-        T::regs().configure_sequence([((channel.channel(), channel.is_differential()), sample_time)].into_iter());
+        T::regs().configure_sequence(
+            [((channel.channel(), channel.is_differential()), sample_time)].into_iter(),
+            false,
+        );
 
         T::regs().enable();
         T::regs().configure_dma(ConversionMode::NoDma);
@@ -397,6 +404,7 @@ impl<'d, T: Instance> Adc<'d, T> {
         T::regs().stop();
         T::regs().configure_sequence(
             sequence.map(|(channel, sample_time)| ((channel.channel, channel.is_differential), sample_time)),
+            false,
         );
 
         T::regs().enable();
@@ -475,6 +483,7 @@ impl<'d, T: Instance> Adc<'d, T> {
         T::regs().stop();
         T::regs().configure_sequence(
             sequence.map(|(channel, sample_time)| ((channel.channel, channel.is_differential), sample_time)),
+            false,
         );
 
         T::regs().enable();
@@ -554,6 +563,7 @@ impl<'d, T: Instance> Adc<'d, T> {
         T::regs().stop();
         T::regs().configure_sequence(
             sequence.map(|(channel, sample_time)| ((channel.channel, channel.is_differential), sample_time)),
+            false,
         );
 
         T::regs().enable();
@@ -606,6 +616,7 @@ impl<'d, T: Instance> Adc<'d, T> {
         T::regs().stop();
         T::regs().configure_sequence(
             sequence.map(|(channel, sample_time)| ((channel.channel, channel.is_differential), sample_time)),
+            false,
         );
 
         T::regs().enable();
@@ -661,10 +672,11 @@ impl<'d, T: Instance<Regs: InjectedAdcRegs>> Adc<'d, T> {
         );
 
         T::regs().stop();
-        T::regs().configure_injected_sequence(
+        T::regs().configure_sequence(
             sequence
                 .iter()
                 .map(|(channel, sample_time)| ((channel.channel, channel.is_differential), *sample_time)),
+            true,
         );
 
         T::regs().enable();

--- a/embassy-stm32/src/adc/v1.rs
+++ b/embassy-stm32/src/adc/v1.rs
@@ -160,7 +160,7 @@ impl AdcRegs for crate::pac::adc::Adc {
         });
     }
 
-    fn configure_sequence(&self, sequence: impl ExactSizeIterator<Item = ((u8, bool), SampleTime)>) {
+    fn configure_sequence(&self, sequence: impl ExactSizeIterator<Item = ((u8, bool), SampleTime)>, _injected: bool) {
         let mut is_ordered_up = true;
         let mut is_ordered_down = true;
 

--- a/embassy-stm32/src/adc/v2.rs
+++ b/embassy-stm32/src/adc/v2.rs
@@ -167,7 +167,7 @@ impl AdcRegs for crate::pac::adc::Adc {
         });
     }
 
-    fn configure_sequence(&self, sequence: impl ExactSizeIterator<Item = ((u8, bool), SampleTime)>) {
+    fn configure_sequence(&self, sequence: impl ExactSizeIterator<Item = ((u8, bool), SampleTime)>, injected: bool) {
         let mut sqr1 = Sqr1::default();
         let mut sqr2 = Sqr2::default();
         let mut sqr3 = Sqr3::default();
@@ -176,14 +176,30 @@ impl AdcRegs for crate::pac::adc::Adc {
         let mut smpr2 = self.smpr2().read();
 
         // Check the sequence is long enough
-        sqr1.set_l((sequence.len() - 1).try_into().unwrap());
+        let len: u8 = sequence.len().try_into().unwrap();
+        if injected {
+            // Set injected sequence length
+            self.jsqr().modify(|w| w.set_jl(len - 1));
+        } else {
+            sqr1.set_l(len - 1);
+        }
 
         for (i, ((ch, _), sample_time)) in sequence.enumerate() {
-            match i {
-                0..=5 => sqr3.set_sq(i, ch),
-                6..=11 => sqr2.set_sq(i - 6, ch),
-                12..=15 => sqr1.set_sq(i - 12, ch),
-                _ => unreachable!(),
+            if injected {
+                // On adc_v2/F4, injected JSQ rank field placement depends on the
+                // programmed sequence length (JL). ST's HAL uses:
+                //   shift = 5 * ((rank + 3) - sequence_len)
+                // with rank starting at 1.
+                let idx = i + (4usize - len as usize);
+
+                self.jsqr().modify(|w| w.set_jsq(idx, ch));
+            } else {
+                match i {
+                    0..=5 => sqr3.set_sq(i, ch),
+                    6..=11 => sqr2.set_sq(i - 6, ch),
+                    12..=15 => sqr1.set_sq(i - 12, ch),
+                    _ => unreachable!(),
+                }
             }
 
             let sample_time = sample_time.into();
@@ -194,39 +210,17 @@ impl AdcRegs for crate::pac::adc::Adc {
             }
         }
 
-        self.sqr1().write_value(sqr1);
-        self.sqr2().write_value(sqr2);
-        self.sqr3().write_value(sqr3);
+        if !injected {
+            self.sqr1().write_value(sqr1);
+            self.sqr2().write_value(sqr2);
+            self.sqr3().write_value(sqr3);
+        }
         self.smpr1().write_value(smpr1);
         self.smpr2().write_value(smpr2);
     }
 }
 
 impl InjectedRegs for crate::pac::adc::Adc {
-    fn configure_injected_sequence(&self, sequence: impl ExactSizeIterator<Item = ((u8, bool), Self::SampleTime)>) {
-        let len: u8 = sequence.len().try_into().unwrap();
-        self.cr1().modify(|w| w.set_jauto(false));
-        // Set injected sequence length
-        self.jsqr().modify(|w| w.set_jl(len - 1));
-
-        for (n, ((channel, _), sample_time)) in sequence.enumerate() {
-            let sample_time = sample_time.clone().into();
-            if channel <= 9 {
-                self.smpr2().modify(|reg| reg.set_smp(channel as _, sample_time));
-            } else {
-                self.smpr1().modify(|reg| reg.set_smp((channel - 10) as _, sample_time));
-            }
-
-            // On adc_v2/F4, injected JSQ rank field placement depends on the
-            // programmed sequence length (JL). ST's HAL uses:
-            //   shift = 5 * ((rank + 3) - sequence_len)
-            // with rank starting at 1.
-            let idx = n + (4usize - len as usize);
-
-            self.jsqr().modify(|w| w.set_jsq(idx, channel));
-        }
-    }
-
     fn configure_injected_trigger(&self, trigger: (u8, vals::Exten), interrupt: bool) {
         self.cr1().modify(|w| {
             w.set_scan(true);

--- a/embassy-stm32/src/adc/v3.rs
+++ b/embassy-stm32/src/adc/v3.rs
@@ -263,7 +263,7 @@ impl super::AdcRegs for crate::pac::adc::Adc {
         });
     }
 
-    fn configure_sequence(&self, sequence: impl ExactSizeIterator<Item = ((u8, bool), SampleTime)>, injected: bool) {
+    fn configure_sequence(&self, sequence: impl ExactSizeIterator<Item = ((u8, bool), SampleTime)>, _injected: bool) {
         #[cfg(adc_g0)]
         {
             let mut sample_times = Vec::<SampleTime, SAMPLE_TIMES_CAPACITY>::new();
@@ -351,7 +351,7 @@ impl super::AdcRegs for crate::pac::adc::Adc {
             }
 
             // Set sequence length
-            if injected {
+            if _injected {
                 jsqr.set_jl(sequence.len() as u8 - 1);
             } else {
                 sqr1.set_l(sequence.len() as u8 - 1);
@@ -410,7 +410,7 @@ impl super::AdcRegs for crate::pac::adc::Adc {
                 }
 
                 // Each channel is sampled according to sequence
-                if injected {
+                if _injected {
                     jsqr.set_jsq(i, channel);
                 } else {
                     match i {
@@ -436,7 +436,7 @@ impl super::AdcRegs for crate::pac::adc::Adc {
                 }
             }
 
-            if injected {
+            if _injected {
                 self.jsqr().write_value(jsqr);
             } else {
                 self.sqr1().write_value(sqr1);

--- a/embassy-stm32/src/adc/v3.rs
+++ b/embassy-stm32/src/adc/v3.rs
@@ -263,7 +263,7 @@ impl super::AdcRegs for crate::pac::adc::Adc {
         });
     }
 
-    fn configure_sequence(&self, sequence: impl ExactSizeIterator<Item = ((u8, bool), SampleTime)>) {
+    fn configure_sequence(&self, sequence: impl ExactSizeIterator<Item = ((u8, bool), SampleTime)>, injected: bool) {
         #[cfg(adc_g0)]
         {
             let mut sample_times = Vec::<SampleTime, SAMPLE_TIMES_CAPACITY>::new();
@@ -316,7 +316,7 @@ impl super::AdcRegs for crate::pac::adc::Adc {
 
         #[cfg(not(any(adc_g0, adc_u0)))]
         {
-            use crate::pac::adc::regs::{Sqr1, Sqr2, Sqr3, Sqr4};
+            use crate::pac::adc::regs::{Jsqr, Sqr1, Sqr2, Sqr3, Sqr4};
 
             #[cfg(adc_h5)]
             {
@@ -332,6 +332,8 @@ impl super::AdcRegs for crate::pac::adc::Adc {
 
             #[cfg(adc_h5)]
             let mut difsel = 0u32;
+
+            let mut jsqr = Jsqr::default();
 
             let mut sqr1 = Sqr1::default();
             let mut sqr2 = Sqr2::default();
@@ -349,10 +351,14 @@ impl super::AdcRegs for crate::pac::adc::Adc {
             }
 
             // Set sequence length
-            sqr1.set_l(sequence.len() as u8 - 1);
+            if injected {
+                jsqr.set_jl(sequence.len() as u8 - 1);
+            } else {
+                sqr1.set_l(sequence.len() as u8 - 1);
+            }
 
             // Configure channels and ranks
-            for (_i, ((channel, _is_differential), sample_time)) in sequence.enumerate() {
+            for (i, ((channel, _is_differential), sample_time)) in sequence.enumerate() {
                 // RM0492, RM0481, etc.
                 // OP0: Option bit 0
                 // For ADC1:
@@ -404,20 +410,24 @@ impl super::AdcRegs for crate::pac::adc::Adc {
                 }
 
                 // Each channel is sampled according to sequence
-                match _i {
-                    0..=3 => {
-                        sqr1.set_sq(_i, channel);
+                if injected {
+                    jsqr.set_jsq(i, channel);
+                } else {
+                    match i {
+                        0..=3 => {
+                            sqr1.set_sq(i, channel);
+                        }
+                        4..=8 => {
+                            sqr2.set_sq(i - 4, channel);
+                        }
+                        9..=13 => {
+                            sqr3.set_sq(i - 9, channel);
+                        }
+                        14..=15 => {
+                            sqr4.set_sq(i - 14, channel);
+                        }
+                        _ => unreachable!(),
                     }
-                    4..=8 => {
-                        sqr2.set_sq(_i - 4, channel);
-                    }
-                    9..=13 => {
-                        sqr3.set_sq(_i - 9, channel);
-                    }
-                    14..=15 => {
-                        sqr4.set_sq(_i - 14, channel);
-                    }
-                    _ => unreachable!(),
                 }
 
                 #[cfg(adc_h5)]
@@ -426,10 +436,14 @@ impl super::AdcRegs for crate::pac::adc::Adc {
                 }
             }
 
-            self.sqr1().write_value(sqr1);
-            self.sqr2().write_value(sqr2);
-            self.sqr3().write_value(sqr3);
-            self.sqr4().write_value(sqr4);
+            if injected {
+                self.jsqr().write_value(jsqr);
+            } else {
+                self.sqr1().write_value(sqr1);
+                self.sqr2().write_value(sqr2);
+                self.sqr3().write_value(sqr3);
+                self.sqr4().write_value(sqr4);
+            }
 
             cfg_if! {
                 if #[cfg(any(adc_h5, adc_h7rs))] {
@@ -449,114 +463,6 @@ impl super::AdcRegs for crate::pac::adc::Adc {
 
 #[cfg(adc_h5)]
 impl crate::adc::InjectedRegs for crate::pac::adc::Adc {
-    fn configure_injected_sequence(&self, sequence: impl ExactSizeIterator<Item = ((u8, bool), Self::SampleTime)>) {
-        use crate::pac::adc::regs::Jsqr;
-
-        #[cfg(adc_h5)]
-        {
-            // RM0481
-            // DIFSEL:
-            //   The software is allowed to write these bits only when the ADC is disabled (ADCAL = 0,
-            //   JADSTART = 0, JADSTP = 0, ADSTART = 0, ADSTP = 0, ADDIS = 0 and ADEN = 0).
-            if self.cr().read().aden() {
-                self.cr().modify(|reg| reg.set_addis(true));
-                while self.cr().read().aden() {}
-            }
-        }
-
-        let mut difsel = 0u32;
-
-        let mut jsqr = Jsqr::default();
-
-        cfg_if! {
-            if #[cfg(any(adc_h5, adc_h7rs))] {
-                let mut smpr1 = self.smpr1().read();
-                let mut smpr2 = self.smpr2().read();
-            } else {
-                let mut smpr1 = self.smpr(0).read();
-                let mut smpr2 = self.smpr(1).read();
-            }
-        }
-
-        // Set sequence length
-        jsqr.set_jl(sequence.len() as u8 - 1);
-
-        // Configure channels and ranks
-        for (i, ((channel, _is_differential), sample_time)) in sequence.enumerate() {
-            // RM0492, RM0481, etc.
-            // OP0: Option bit 0
-            // For ADC1:
-            //   0: INP0/INN1 GPIO switch control disabled (for both ADC1 and ADC2)
-            //   1: INP0/INN1 GPIO switch control enabled (for both ADC1 and ADC2)
-            //   Note: This option bit must be set to 1 when ADCx_INP0 or ADCx_INN1 channel is selected.
-            // For ADC2:
-            //   0: VDDCORE channel disabled (for both ADC2 and ADC3)
-            //   1: VDDCORE channel enabled (for both ADC2 and ADC3)
-            // For ADC3: (only available on STM32H543/553 devices)
-            //   0: INP0 GPIO switch control disabled
-            //   1: INP0 GPIO switch control enabled
-
-            #[cfg(adc_h5)]
-            if channel == 0 {
-                #[cfg(peri_adc2)]
-                let is_adc2 = self.as_ptr() == crate::pac::ADC2.as_ptr();
-
-                #[cfg(not(peri_adc2))]
-                let is_adc2 = false;
-
-                if is_adc2 {
-                    // when ADC2_INP0 should be enabled, set OP0 to 1 for ADC1
-                    crate::pac::ADC1.or().modify(|reg| reg.set_op0(true));
-                } else {
-                    // when ADC1_INP0 should be enabled, set OP0 to 1 for ADC1
-                    // when ADC3_INP0 should be enabled, set OP0 to 1 for ADC3
-                    self.or().modify(|reg| reg.set_op0(true));
-                }
-            }
-            #[cfg(adc_h7rs)]
-            if channel == 0 {
-                self.or().modify(|reg| reg.set_op0(true));
-            }
-
-            // Configure channel
-            match channel {
-                0..=9 => smpr1.set_smp(channel as usize % 10, sample_time.into()),
-                _ => smpr2.set_smp(channel as usize % 10, sample_time.into()),
-            }
-
-            #[cfg(stm32h7)]
-            {
-                use crate::pac::adc::vals::Pcsel;
-
-                self.cfgr2().modify(|w| w.set_lshift(0));
-                self.pcsel()
-                    .write(|w| w.set_pcsel(channel.channel() as _, Pcsel::PRESELECTED));
-            }
-
-            jsqr.set_jsq(i, channel);
-
-            #[cfg(adc_h5)]
-            {
-                difsel |= (_is_differential as u32) << channel;
-            }
-        }
-
-        self.jsqr().write_value(jsqr);
-
-        cfg_if! {
-            if #[cfg(any(adc_h5, adc_h7rs))] {
-                self.smpr1().write_value(smpr1);
-                self.smpr2().write_value(smpr2);
-            } else {
-                self.smpr(0).write_value(smpr1);
-                self.smpr(1).write_value(smpr2);
-            }
-        }
-
-        #[cfg(adc_h5)]
-        self.difsel().write(|w| w.set_difsel(difsel));
-    }
-
     fn configure_injected_trigger(&self, trigger: (u8, crate::adc::Exten), interrupt: bool) {
         self.cfgr().modify(|reg| reg.set_jdiscen(false));
 

--- a/embassy-stm32/src/adc/v4.rs
+++ b/embassy-stm32/src/adc/v4.rs
@@ -182,7 +182,7 @@ impl AdcRegs for crate::pac::adc::Adc {
         });
     }
 
-    fn configure_sequence(&self, sequence: impl ExactSizeIterator<Item = ((u8, bool), SampleTime)>) {
+    fn configure_sequence(&self, sequence: impl ExactSizeIterator<Item = ((u8, bool), SampleTime)>, injected: bool) {
         let mut sqr1 = Sqr1::default();
         let mut sqr2 = Sqr2::default();
         let mut sqr3 = Sqr3::default();
@@ -193,8 +193,10 @@ impl AdcRegs for crate::pac::adc::Adc {
         #[cfg(not(stm32u3))]
         let mut difsel = self.difsel().read();
 
-        // Set sequence length
-        sqr1.set_l(sequence.len() as u8 - 1);
+        if !injected {
+            // Set sequence length
+            sqr1.set_l(sequence.len() as u8 - 1);
+        }
 
         // Configure channels and ranks
         for (i, ((channel, _is_differential), sample_time)) in sequence.enumerate() {
@@ -223,27 +225,31 @@ impl AdcRegs for crate::pac::adc::Adc {
                 self.pcsel().modify(|w| w.set_pcsel(channel as _, Pcsel::Preselected));
             }
 
-            match i {
-                0..=3 => {
-                    sqr1.set_sq(i, channel);
+            if !injected {
+                match i {
+                    0..=3 => {
+                        sqr1.set_sq(i, channel);
+                    }
+                    4..=8 => {
+                        sqr2.set_sq(i - 4, channel);
+                    }
+                    9..=13 => {
+                        sqr3.set_sq(i - 9, channel);
+                    }
+                    14..=15 => {
+                        sqr4.set_sq(i - 14, channel);
+                    }
+                    _ => unreachable!(),
                 }
-                4..=8 => {
-                    sqr2.set_sq(i - 4, channel);
-                }
-                9..=13 => {
-                    sqr3.set_sq(i - 9, channel);
-                }
-                14..=15 => {
-                    sqr4.set_sq(i - 14, channel);
-                }
-                _ => unreachable!(),
             }
         }
 
-        self.sqr1().write_value(sqr1);
-        self.sqr2().write_value(sqr2);
-        self.sqr3().write_value(sqr3);
-        self.sqr4().write_value(sqr4);
+        if !injected {
+            self.sqr1().write_value(sqr1);
+            self.sqr2().write_value(sqr2);
+            self.sqr3().write_value(sqr3);
+            self.sqr4().write_value(sqr4);
+        }
         self.smpr(0).write_value(smpr1);
         self.smpr(1).write_value(smpr2);
         #[cfg(not(stm32u3))]

--- a/embassy-stm32/src/adc/watchdog_adc4.rs
+++ b/embassy-stm32/src/adc/watchdog_adc4.rs
@@ -141,7 +141,10 @@ impl<T: Instance<Regs = crate::pac::adc::Adc4>> AnalogWatchdog<T> {
         channel.setup();
 
         T::regs().stop();
-        T::regs().configure_sequence([((channel.channel(), channel.is_differential()), sample_time)].into_iter());
+        T::regs().configure_sequence(
+            [((channel.channel(), channel.is_differential()), sample_time)].into_iter(),
+            false,
+        );
         T::regs().enable();
         T::regs().configure_dma(ConversionMode::NoDma);
 


### PR DESCRIPTION
Alternative solution for #6577 proposed by @xoviat.

I'm only not sure what should happen in case injected convention is not supported (either by hardware or just not implemented). Maybe call `unimplemented!()`?

Tested both regular and injected on STM32H523CE, and only regular on STM32F411CE.

Idk why I did commits for each one, realized half way that it is not a good idea. :sweat_smile: 

closes #6577