### PR TITLE
embassy-nxp: add CRC driver for LPC55.

### DIFF
--- a/embassy-nxp/Cargo.toml
+++ b/embassy-nxp/Cargo.toml
@@ -40,7 +40,7 @@ embassy-time-queue-utils = { version = "0.3.2", path = "../embassy-time-queue-ut
 embedded-io = { version = "0.7.1" }
 embedded-hal-02 = { package = "embedded-hal", version = "0.2.6", features = ["unproven"] }
 ## Chip dependencies
-nxp-pac = { version = "0.1.0", optional = true, git = "https://github.com/embassy-rs/nxp-pac", rev = "47dada0976da4114c348ea16f5ead31f38f36eea" }
+nxp-pac = { version = "0.1.0", optional = true, git = "https://github.com/embassy-rs/nxp-pac", rev = "47dada0976da4114c348ea16f5ead31f38f36eea", features = ["metadata", "lpc55s69_cm33_core0"] }
 
 imxrt-rt = { version = "0.1.7", optional = true, features = ["device"] }
 
@@ -87,3 +87,4 @@ lpc55-core0 = ["nxp-pac/lpc55s69_cm33_core0"]
 lpc55s16 = ["nxp-pac/lpc55s16", "_lpc55"]
 mimxrt1011 = ["nxp-pac/mimxrt1011", "_rt1xxx", "dep:imxrt-rt"]
 mimxrt1062 = ["nxp-pac/mimxrt1062", "_rt1xxx", "dep:imxrt-rt"]
+crc = []

--- a/embassy-nxp/Cargo.toml
+++ b/embassy-nxp/Cargo.toml
@@ -40,7 +40,7 @@ embassy-time-queue-utils = { version = "0.3.2", path = "../embassy-time-queue-ut
 embedded-io = { version = "0.7.1" }
 embedded-hal-02 = { package = "embedded-hal", version = "0.2.6", features = ["unproven"] }
 ## Chip dependencies
-nxp-pac = { version = "0.1.0", optional = true, git = "https://github.com/embassy-rs/nxp-pac", rev = "47dada0976da4114c348ea16f5ead31f38f36eea" }
+nxp-pac = { version = "0.1.0", optional = true, git = "https://github.com/embassy-rs/nxp-pac", rev = "47dada0976da4114c348ea16f5ead31f38f36eea"}
 
 imxrt-rt = { version = "0.1.7", optional = true, features = ["device"] }
 

--- a/embassy-nxp/build.rs
+++ b/embassy-nxp/build.rs
@@ -61,11 +61,7 @@ fn singletons(cfgs: &mut common::CfgSet) -> Vec<Singleton> {
 
     for peripheral in METADATA.peripherals {
         // GPIO and DMA are generated in a 2nd pass.
-        let skip_singleton = if peripheral.name.starts_with("GPIO") || peripheral.name.starts_with("DMA") {
-            true
-        } else {
-            false
-        };
+        let skip_singleton = peripheral.name.starts_with("GPIO") || peripheral.name.starts_with("DMA");
 
         if !skip_singleton {
             singletons.push(Singleton {
@@ -74,6 +70,12 @@ fn singletons(cfgs: &mut common::CfgSet) -> Vec<Singleton> {
             });
         }
     }
+
+    #[cfg(feature = "lpc55-core0")]
+    singletons.push(Singleton {
+        name: "CRC_ENGINE".into(),
+        cfg: None,
+    });
 
     cfgs.declare_all(&[
         "gpio1",

--- a/embassy-nxp/src/crc/crc.rs
+++ b/embassy-nxp/src/crc/crc.rs
@@ -1,0 +1,176 @@
+#![macro_use]
+use crate::pac::syscon::vals::CrcgenRst;
+use embassy_hal_internal::{Peri, PeripheralType};
+
+use crate::{pac, peripherals};
+// regs.rs -> nxp-pac
+// 10 = CRC-32
+// 01 = CRC-16
+// 00 = CRC-CCITT
+#[derive(Clone, Copy, PartialEq, Eq)]
+pub enum Polynomial {
+    // x^16 + x^12 + x^5 + 1
+    Ccitt = 0b00,
+    // x^16 + x^15 + x^2 + 1
+    Crc16 = 0b01,
+    // standard CRC-32
+    Crc32 = 0b10,
+}
+
+#[derive(Clone, Copy)]
+pub struct Config {
+    pub polynomial: Polynomial,
+    //If active every byte written in WR_DATA is reversed before processed
+    pub reverse_in: bool,
+    //If active every byte written in WR_DATA is complemented ('~byte') before processed
+    pub complement_in: bool,
+    //If active the result is reversed bit by bit 
+    pub reverse_out: bool,
+    //If active the result is complemented ('~sum')
+    pub complement_out: bool,
+    //final value
+    pub seed: u32,
+}
+
+impl Default for Config {
+    fn default() -> Self {
+        Self {
+            polynomial: Polynomial::Ccitt,
+            reverse_in: false,
+            complement_in: false,
+            reverse_out: false,
+            complement_out: false,
+            seed: 0xFFFF,
+        }
+    }
+}
+
+impl Config {
+    //CRC-32 processes reversed bits and compements the final result
+    pub fn crc32() -> Self {
+        Self {
+            polynomial: Polynomial::Crc32,
+            reverse_in: true,
+            complement_in: false,
+            reverse_out: true,
+            complement_out: true,
+            seed: 0xFFFF_FFFF,
+        }
+    }
+}
+//exclusive acces to hardware peripherals through 'Peri<'d, T>'
+// guarantees only one active instance at a time for the same peripheral
+pub struct Crc<'d, T: Instance> {
+    _p: Peri<'d, T>,
+}
+
+impl<'d, T: Instance> Crc<'d, T> {
+    //Initialize CRC peripherals
+    pub fn new(peri: Peri<'d, T>, config: Config) -> Self {
+        //clock enable and reset hardware
+        T::enable_and_reset();
+
+        let r = T::regs();
+        //configure mode register
+        r.mode().write(|w| {
+            w.set_crc_poly(config.polynomial as u8);
+            w.set_bit_rvs_wr(config.reverse_in);
+            w.set_cmpl_wr(config.complement_in);
+            w.set_bit_rvs_sum(config.reverse_out);
+            w.set_cmpl_sum(config.complement_out);
+        });
+        //load the inital seed value
+        r.seed().write_value(pac::crc_engine::regs::Seed(config.seed));
+
+        Self { _p: peri }
+    }
+    //reloads only the seed register
+    pub fn reset(&mut self, seed: u32) {
+        T::regs().seed().write_value(pac::crc_engine::regs::Seed(seed));
+    }
+    //sends data buffer to CRC engine
+    pub fn feed(&mut self, data: &[u8]) {
+        //WR_DATA register address : offset 0x08 in CRC block
+        let base = T::regs().as_ptr() as *mut u8;
+        let wr_data_addr = unsafe { base.add(0x08) };
+        let mut data = data;
+        // write bytes until buffer alligned 4 bytes
+        while !data.is_empty() && (data.as_ptr() as usize) & 3 != 0 {
+            unsafe { core::ptr::write_volatile(wr_data_addr, data[0]) };
+            data = &data[1..];
+        }
+        //write in 32 bytes blocks
+        let wr_data_addr32 = wr_data_addr as *mut u32;
+        let chunks = data.chunks_exact(4);
+        let remainder = chunks.remainder();
+        for chunk in chunks {
+            let word = u32::from_ne_bytes(chunk.try_into().unwrap());
+            unsafe { core::ptr::write_volatile(wr_data_addr32, word) };
+        }
+        //write remainder bytes
+        for &byte in remainder {
+            unsafe { core::ptr::write_volatile(wr_data_addr, byte) };
+        }
+    }
+    //return 32 byte result
+    pub fn sum32(&self) -> u32 {
+        T::regs().sum().read().0
+    }
+    //returns 16 byte result
+    pub fn sum16(&self) -> u16 {
+        T::regs().sum().read().0 as u16
+    }
+    //reads internal state of CRC engine
+    // used by seed when data is recieved in more than one set
+    pub fn checkpoint(&mut self) -> u32 {
+        let r = T::regs();
+        let mode = r.mode().read();
+
+        r.mode().modify(|w| {
+            w.set_bit_rvs_sum(false);
+            w.set_cmpl_sum(false);
+        });
+
+        let raw = r.sum().read().0;
+        //reset to original config
+        r.mode().write_value(mode);
+
+        raw
+    }
+}
+
+impl<'d, T: Instance> Drop for Crc<'d, T> {
+    fn drop(&mut self) {
+        //disable clock when driver is destroyed
+        T::disable();
+    }
+}
+//gives acces to peripherals registers
+pub(crate) trait SealedInstance {
+    fn regs() -> pac::crc_engine::CrcEngine;
+}
+// trait implemented for each existing CRC hardware instance on chip
+#[allow(private_bounds)]
+pub trait Instance: SealedInstance + PeripheralType + 'static {
+    fn enable_and_reset();
+    fn disable();
+}
+
+impl SealedInstance for peripherals::CRC_ENGINE {
+    fn regs() -> pac::crc_engine::CrcEngine {
+        pac::CRC_ENGINE
+    }
+}
+
+impl Instance for peripherals::CRC_ENGINE {
+    fn enable_and_reset() {
+        //activate CRC clock
+        pac::SYSCON.ahbclkctrl0().modify(|w| w.set_crcgen(true));
+        //reset hardware
+        pac::SYSCON.presetctrl0().modify(|w| w.set_crcgen_rst(CrcgenRst::ASSERTED));
+        pac::SYSCON.presetctrl0().modify(|w| w.set_crcgen_rst(CrcgenRst::RELEASED)); 
+    }
+    fn disable() {
+        pac::SYSCON.ahbclkctrl0().modify(|w| w.set_crcgen(false)); 
+    }
+}

--- a/embassy-nxp/src/crc/crc.rs
+++ b/embassy-nxp/src/crc/crc.rs
@@ -1,0 +1,170 @@
+#![macro_use]
+use crate::pac::syscon::vals::CrcgenRst;
+use embassy_hal_internal::{Peri, PeripheralType};
+
+use crate::{pac, peripherals};
+
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+pub enum Polynomial {
+    /// x^16 + x^12 + x^5 + 1
+    Ccitt = 0b00,
+    /// x^16 + x^15 + x^2 + 1
+    Crc16 = 0b01,
+    /// standard CRC-32
+    Crc32 = 0b10,
+}
+
+#[derive(Debug, Clone)]
+pub struct Config {
+    pub polynomial: Polynomial,
+    ///If active every byte written in WR_DATA is reversed before processed
+    pub reverse_in: bool,
+    ///If active every byte written in WR_DATA is complemented ('~byte') before processed
+    pub complement_in: bool,
+    ///If active the result is reversed bit by bit 
+    pub reverse_out: bool,
+    ///If active the result is complemented ('~sum')
+    pub complement_out: bool,
+    pub seed: u32,
+}
+
+impl Default for Config {
+    fn default() -> Self {
+        Self {
+            polynomial: Polynomial::Ccitt,
+            reverse_in: false,
+            complement_in: false,
+            reverse_out: false,
+            complement_out: false,
+            seed: 0xFFFF,
+        }
+    }
+}
+
+impl Config {
+    //CRC-32 processes reversed bits and compements the final result
+    pub fn crc32() -> Self {
+        Self {
+            polynomial: Polynomial::Crc32,
+            reverse_in: true,
+            complement_in: false,
+            reverse_out: true,
+            complement_out: true,
+            seed: 0xFFFF_FFFF,
+        }
+    }
+}
+///Exclusive acces to hardware peripherals through 'Peri<'d, T>'
+/// Guarantees only one active instance at a time for the same peripheral
+pub struct Crc<'d, T: Instance> {
+    _p: Peri<'d, T>,
+}
+
+impl<'d, T: Instance> Crc<'d, T> {
+    ///Initialize CRC peripherals
+    pub fn new(peri: Peri<'d, T>, config: Config) -> Self {
+        //clock enable and reset hardware
+        T::enable_and_reset();
+
+        let r = T::regs();
+        //configure mode register
+        r.mode().write(|w| {
+            w.set_crc_poly(config.polynomial as u8);
+            w.set_bit_rvs_wr(config.reverse_in);
+            w.set_cmpl_wr(config.complement_in);
+            w.set_bit_rvs_sum(config.reverse_out);
+            w.set_cmpl_sum(config.complement_out);
+        });
+        //load the inital seed value
+        r.seed().write_value(pac::crc_engine::regs::Seed(config.seed));
+
+        Self { _p: peri }
+    }
+    ///Reloads only the seed register
+    pub fn reset(&mut self, seed: u32) {
+        T::regs().seed().write_value(pac::crc_engine::regs::Seed(seed));
+    }
+    //sends data buffer to CRC engine
+    pub fn feed(&mut self, data: &[u8]) {
+        let wr_data_addr = T::regs().wr_data().as_ptr() as *mut u8;
+        let mut data = data;
+
+        while !data.is_empty() && (data.as_ptr() as usize) & 3 != 0 {
+            unsafe { core::ptr::write_volatile(wr_data_addr, data[0]) };
+            data = &data[1..];
+        }
+
+        let wr_data_addr32 = wr_data_addr as *mut u32;
+        let chunks = data.chunks_exact(4);
+        let remainder = chunks.remainder();
+        for chunk in chunks {
+            let word = u32::from_ne_bytes(chunk.try_into().unwrap());
+            unsafe { core::ptr::write_volatile(wr_data_addr32, word) };
+        }
+
+        for &byte in remainder {
+            unsafe { core::ptr::write_volatile(wr_data_addr, byte) };
+        }
+    }
+    ///Return 32 byte result
+    pub fn sum32(&self) -> u32 {
+        T::regs().sum().read().0
+    }
+    ///Returns 16 byte result
+    pub fn sum16(&self) -> u16 {
+        T::regs().sum().read().0 as u16
+    }
+    ///Reads internal state of CRC engine
+    /// Used by seed when data is recieved in more than one set
+    pub fn checkpoint(&mut self) -> u32 {
+        let r = T::regs();
+        let mode = r.mode().read();
+
+        r.mode().modify(|w| {
+            w.set_bit_rvs_sum(false);
+            w.set_cmpl_sum(false);
+        });
+
+        let raw = r.sum().read().0;
+        //reset to original config
+        r.mode().write_value(mode);
+
+        raw
+    }
+}
+
+impl<'d, T: Instance> Drop for Crc<'d, T> {
+    fn drop(&mut self) {
+        //disable clock when driver is destroyed
+        T::disable();
+    }
+}
+///Gives acces to peripherals registers
+pub(crate) trait SealedInstance {
+    fn regs() -> pac::crc_engine::CrcEngine;
+}
+/// Trait implemented for each existing CRC hardware instance on chip
+#[allow(private_bounds)]
+pub trait Instance: SealedInstance + PeripheralType + 'static {
+    fn enable_and_reset();
+    fn disable();
+}
+
+impl SealedInstance for peripherals::CRC_ENGINE {
+    fn regs() -> pac::crc_engine::CrcEngine {
+        pac::CRC_ENGINE
+    }
+}
+
+impl Instance for peripherals::CRC_ENGINE {
+    fn enable_and_reset() {
+        //activate CRC clock
+        pac::SYSCON.ahbclkctrl0().modify(|w| w.set_crcgen(true));
+        //reset hardware
+        pac::SYSCON.presetctrl0().modify(|w| w.set_crcgen_rst(CrcgenRst::ASSERTED));
+        pac::SYSCON.presetctrl0().modify(|w| w.set_crcgen_rst(CrcgenRst::RELEASED)); 
+    }
+    fn disable() {
+        pac::SYSCON.ahbclkctrl0().modify(|w| w.set_crcgen(false)); 
+    }
+}

--- a/embassy-nxp/src/crc/crc_test.rs
+++ b/embassy-nxp/src/crc/crc_test.rs
@@ -1,0 +1,32 @@
+#![no_std]
+#![no_main]
+
+use defmt::info;
+use embassy_executor::Spawner;
+use embassy_nxp::crc::{Crc, Config};
+use {defmt_rtt as _, panic_probe as _};
+
+#[embassy_executor::main]
+async fn main(_spawner: Spawner) {
+    let p = embassy_nxp::init(Default::default());
+
+    // Test CRC-32 standard
+    let mut crc32 = Crc::new(p.CRC_ENGINE, Config::crc32());
+    crc32.feed(b"123456789");
+    let result32 = crc32.sum32();
+    info!("CRC-32 result: {:#010x} (expected 0xcbf43926)", result32);
+    defmt::assert_eq!(result32, 0xCBF43926);
+
+    // Test CRC-16/CCITT-FALSE (default config)
+    let mut crc16 = Crc::new(p.CRC_ENGINE, Config::default());
+    crc16.feed(b"123456789");
+    let result16 = crc16.sum16();
+    info!("CRC-16/CCITT result: {:#06x} (expected 0x29b1)", result16);
+    defmt::assert_eq!(result16, 0x29B1);
+
+    info!("CRC driver validated successfully!");
+
+    loop {
+        embassy_time::Timer::after_secs(1).await;
+    }
+}

--- a/embassy-nxp/src/lib.rs
+++ b/embassy-nxp/src/lib.rs
@@ -15,7 +15,9 @@ pub mod pwm;
 pub mod sct;
 #[cfg(lpc55)]
 pub mod usart;
-
+#[cfg(all(lpc55, feature = "crc"))]
+#[path = "crc/crc.rs"]
+pub mod crc;
 #[cfg(rt1xxx)]
 mod iomuxc;
 

--- a/embassy-nxp/src/lib.rs
+++ b/embassy-nxp/src/lib.rs
@@ -15,7 +15,9 @@ pub mod pwm;
 pub mod sct;
 #[cfg(lpc55)]
 pub mod usart;
-
+#[cfg(lpc55)]
+#[path = "crc/crc.rs"]
+pub mod crc;
 #[cfg(rt1xxx)]
 mod iomuxc;
 

--- a/examples/lpc55s69/Cargo.toml
+++ b/examples/lpc55s69/Cargo.toml
@@ -7,7 +7,7 @@ license = "MIT OR Apache-2.0"
 publish = false
 
 [dependencies]
-embassy-nxp = { version = "0.1.0", path = "../../embassy-nxp", features = ["lpc55-core0", "rt", "defmt", "time-driver-rtc"] }
+embassy-nxp = { version = "0.1.0", path = "../../embassy-nxp", features = ["lpc55-core0", "rt", "defmt", "time-driver-rtc", "crc"] }
 embassy-executor = { version = "0.10.0", path = "../../embassy-executor", features = ["platform-cortex-m", "executor-thread", "executor-interrupt"] }
 embassy-sync = { version = "0.8.0", path = "../../embassy-sync", features = ["defmt"] }
 embassy-time = { version = "0.5.1", path = "../../embassy-time", features = ["defmt", "tick-hz-32_768"] }

--- a/examples/lpc55s69/src/bin/crc_test.rs
+++ b/examples/lpc55s69/src/bin/crc_test.rs
@@ -1,0 +1,37 @@
+#![no_std]
+#![no_main]
+
+use defmt::info;
+use embassy_executor::Spawner;
+use embassy_nxp::crc::{Crc, Config};
+
+use {defmt_rtt as _, panic_probe as _};
+
+#[embassy_executor::main]
+async fn main(_spawner: Spawner) {
+    let mut p = embassy_nxp::init(Default::default());
+
+    // Test CRC-32 standard
+    {
+        let mut crc32 = Crc::new(p.CRC_ENGINE.reborrow(), Config::crc32());
+        crc32.feed(b"123456789");
+        let result32 = crc32.sum32();
+        info!("CRC-32 result: {:#010x} (expected 0xcbf43926)", result32);
+        defmt::assert_eq!(result32, 0xCBF43926);
+    } // crc32 e eliberat aici
+
+    // Test CRC-16/CCITT-FALSE (default config)
+    {
+        let mut crc16 = Crc::new(p.CRC_ENGINE.reborrow(), Config::default());
+        crc16.feed(b"123456789");
+        let result16 = crc16.sum16();
+        info!("CRC-16/CCITT result: {:#06x} (expected 0x29b1)", result16);
+        defmt::assert_eq!(result16, 0x29B1);
+    }
+
+    info!("CRC driver validated successfully!");
+
+    loop {
+        embassy_time::Timer::after_secs(1).await;
+    }
+}


### PR DESCRIPTION
 Implements CRC-32/CRC-16/CRC-CCITT support for the LPC55 CRC engine peripheral, modeled after NXP's fsl_crc.c/h reference driver.
Tested on  LPCXpresso55S69 board.
The 'nxp-pac' metadata gap missing 'CRC-ENGINE' peripheral entry for 'lpc55s69_cm3_core, the 'build.rs' workaround is meant as a temporary fix.
Flashing required NXP's "LinkServer" tool instead of probe-rs due to a  SWD timeout issue unrelated to this driver.
'probe-rs attach', without flashing,  worked fine for RTT logging afterward.
