### PR TITLE
stm32: add MDIOS and PSSI drivers

### DIFF
--- a/embassy-stm32/build.rs
+++ b/embassy-stm32/build.rs
@@ -1184,6 +1184,27 @@ fn main() {
         (("dcmi", "HSYNC"), quote!(crate::dcmi::HSyncPin)),
         (("dcmi", "VSYNC"), quote!(crate::dcmi::VSyncPin)),
         (("dcmi", "PIXCLK"), quote!(crate::dcmi::PixClkPin)),
+        (("pssi", "D0"), quote!(crate::pssi::D0Pin)),
+        (("pssi", "D1"), quote!(crate::pssi::D1Pin)),
+        (("pssi", "D2"), quote!(crate::pssi::D2Pin)),
+        (("pssi", "D3"), quote!(crate::pssi::D3Pin)),
+        (("pssi", "D4"), quote!(crate::pssi::D4Pin)),
+        (("pssi", "D5"), quote!(crate::pssi::D5Pin)),
+        (("pssi", "D6"), quote!(crate::pssi::D6Pin)),
+        (("pssi", "D7"), quote!(crate::pssi::D7Pin)),
+        (("pssi", "D8"), quote!(crate::pssi::D8Pin)),
+        (("pssi", "D9"), quote!(crate::pssi::D9Pin)),
+        (("pssi", "D10"), quote!(crate::pssi::D10Pin)),
+        (("pssi", "D11"), quote!(crate::pssi::D11Pin)),
+        (("pssi", "D12"), quote!(crate::pssi::D12Pin)),
+        (("pssi", "D13"), quote!(crate::pssi::D13Pin)),
+        (("pssi", "D14"), quote!(crate::pssi::D14Pin)),
+        (("pssi", "D15"), quote!(crate::pssi::D15Pin)),
+        (("pssi", "PDCK"), quote!(crate::pssi::PdckPin)),
+        (("pssi", "DE"), quote!(crate::pssi::DePin)),
+        (("pssi", "RDY"), quote!(crate::pssi::RdyPin)),
+        (("mdios", "MDC"), quote!(crate::mdios::MdcPin)),
+        (("mdios", "MDIO"), quote!(crate::mdios::MdioPin)),
         (("dsihost", "TE"), quote!(crate::dsihost::TePin)),
         (("ltdc", "CLK"), quote!(crate::ltdc::ClkPin)),
         (("ltdc", "HSYNC"), quote!(crate::ltdc::HsyncPin)),
@@ -1865,8 +1886,8 @@ fn main() {
                     }
                 }
 
-                // MDIO and MDC are special
-                if pin.signal == "MDIO" || pin.signal == "MDC" {
+                // MDIO and MDC are special for ETH
+                if (pin.signal == "MDIO" || pin.signal == "MDC") && p.name.starts_with("ETH") {
                     peri = format_ident!("{}", "ETH_SMA");
                 }
 
@@ -2112,6 +2133,7 @@ fn main() {
         (("i2c", "TX"), quote!(crate::i2c::TxDma)),
         (("dcmi", "DCMI"), quote!(crate::dcmi::FrameDma)),
         (("dcmi", "PSSI"), quote!(crate::dcmi::FrameDma)),
+        (("pssi", "PSSI"), quote!(crate::pssi::Dma)),
         // SDMMCv1 uses the same channel for both directions, so just implement for RX
         (("sdmmc", "RX"), quote!(crate::sdmmc::SdmmcDma)),
         (("quadspi", "QUADSPI"), quote!(crate::qspi::QuadDma)),

--- a/embassy-stm32/src/lib.rs
+++ b/embassy-stm32/src/lib.rs
@@ -174,12 +174,16 @@ pub mod ltdc;
 pub mod mce;
 #[cfg(mdf)]
 pub mod mdf;
+#[cfg(mdios)]
+pub mod mdios;
 #[cfg(opamp)]
 pub mod opamp;
 #[cfg(octospi)]
 pub mod ospi;
 #[cfg(any(pka_v1a, pka_n6))]
 pub mod pka;
+#[cfg(pssi)]
+pub mod pssi;
 #[cfg(quadspi)]
 pub mod qspi;
 #[cfg(ramcfg_wba)]

--- a/embassy-stm32/src/mdios.rs
+++ b/embassy-stm32/src/mdios.rs
@@ -1,0 +1,132 @@
+//! Management Data Input/Output Slave (MDIOS)
+//!
+//! MDIOS implements an IEEE 802.3 MDIO Slave interface, allowing the microcontroller
+//! to act as a managed Ethernet PHY or multi-register slave device on a 2-wire MDIO serial bus.
+
+use core::marker::PhantomData;
+
+use embassy_hal_internal::PeripheralType;
+use embassy_sync::waitqueue::AtomicWaker;
+
+use crate::gpio::{AfType, OutputType, Pull, Speed};
+use crate::rcc::RccPeripheral;
+use crate::{Peri, interrupt, peripherals};
+
+/// MDIOS configuration.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+pub enum Config {
+    /// Port address on the MDIO bus (0..31).
+    PortAddress(u8),
+}
+
+impl Default for Config {
+    fn default() -> Self {
+        Self::PortAddress(0)
+    }
+}
+
+/// MDIOS interrupt handler.
+pub struct InterruptHandler<T: Instance> {
+    _marker: PhantomData<T>,
+}
+
+impl<T: Instance> interrupt::typelevel::Handler<T::Interrupt> for InterruptHandler<T> {
+    unsafe fn on_interrupt() {
+        let r = T::regs();
+        // Disable interrupts to prevent refiring, wake async task
+        r.cr().modify(|w| {
+            w.set_eie(false);
+        });
+        T::waker().wake();
+    }
+}
+
+pub(crate) trait SealedInstance {
+    fn regs() -> crate::pac::mdios::Mdios;
+    fn waker() -> &'static AtomicWaker;
+}
+
+/// MDIOS instance trait.
+#[allow(private_bounds)]
+pub trait Instance: SealedInstance + PeripheralType + RccPeripheral {
+    /// Interrupt for this MDIOS instance.
+    type Interrupt: interrupt::typelevel::Interrupt;
+}
+
+pin_trait!(MdcPin, Instance);
+pin_trait!(MdioPin, Instance);
+
+/// MDIOS driver.
+pub struct Mdios<'d, T: Instance> {
+    _peri: Peri<'d, T>,
+}
+
+impl<'d, T: Instance> Mdios<'d, T> {
+    /// Create a new MDIOS driver.
+    pub fn new(
+        peri: Peri<'d, T>,
+        mdc: Peri<'d, impl MdcPin<T>>,
+        mdio: Peri<'d, impl MdioPin<T>>,
+        _irq: impl interrupt::typelevel::Binding<T::Interrupt, InterruptHandler<T>> + 'd,
+        config: Config,
+    ) -> Self {
+        crate::rcc::enable_and_reset::<T>();
+
+        mdc.set_as_af(mdc.af_num(), AfType::input(Pull::None));
+        mdio.set_as_af(mdio.af_num(), AfType::output(OutputType::PushPull, Speed::VeryHigh));
+
+        let r = T::regs();
+
+        let port_addr = match config {
+            Config::PortAddress(addr) => addr & 0x1F,
+        };
+
+        r.cr().write(|w| {
+            w.set_port_address(port_addr);
+            w.set_en(true); // Enable MDIOS peripheral
+        });
+
+        Self { _peri: peri }
+    }
+
+    /// Read data written by external MDIO master into input register `reg_idx` (0..31).
+    pub fn read_input_register(&self, reg_idx: usize) -> u16 {
+        assert!(reg_idx < 32, "MDIOS register index out of range 0..31");
+        T::regs().dinr(reg_idx).read().din()
+    }
+
+    /// Write output register `reg_idx` (0..31) to be served to external MDIO master upon read.
+    pub fn write_output_register(&mut self, reg_idx: usize, val: u16) {
+        assert!(reg_idx < 32, "MDIOS register index out of range 0..31");
+        T::regs().doutr(reg_idx).write(|w| w.set_dout(val));
+    }
+
+    /// Read status register.
+    pub fn status(&self) -> u32 {
+        T::regs().sr().read().0
+    }
+
+    /// Clear register flags.
+    pub fn clear_flags(&mut self, mask: u32) {
+        T::regs().clrfr().write(|w| w.0 = mask);
+    }
+}
+
+foreach_interrupt!(
+    ($inst:ident, mdios, MDIOS, GLOBAL, $irq:ident) => {
+        impl Instance for peripherals::$inst {
+            type Interrupt = crate::interrupt::typelevel::$irq;
+        }
+
+        impl SealedInstance for peripherals::$inst {
+            fn regs() -> crate::pac::mdios::Mdios {
+                crate::pac::$inst
+            }
+            fn waker() -> &'static AtomicWaker {
+                static WAKER: AtomicWaker = AtomicWaker::new();
+                &WAKER
+            }
+        }
+    };
+);

--- a/embassy-stm32/src/pssi.rs
+++ b/embassy-stm32/src/pssi.rs
@@ -1,0 +1,206 @@
+//! Parallel Synchronous Slave Interface (PSSI)
+//!
+//! PSSI supports high-speed 8-bit or 16-bit parallel data transfers (transmit or receive)
+//! with clock (PDCK), data enable (DE), and ready (RDY) signals.
+
+use core::marker::PhantomData;
+
+use embassy_hal_internal::PeripheralType;
+use embassy_sync::waitqueue::AtomicWaker;
+
+use crate::gpio::{AfType, Pull};
+use crate::rcc::RccPeripheral;
+use crate::{Peri, interrupt, peripherals};
+
+/// Data bus width.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+pub enum BusWidth {
+    /// 8-bit parallel bus (D0..D7).
+    Bits8,
+    /// 16-bit parallel bus (D0..D15).
+    Bits16,
+}
+
+/// Transfer direction.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+pub enum Direction {
+    /// Receive mode (input).
+    Receive,
+    /// Transmit mode (output).
+    Transmit,
+}
+
+/// Clock polarity.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+pub enum ClockPolarity {
+    /// Data sampled on rising edge of PDCK.
+    RisingEdge,
+    /// Data sampled on falling edge of PDCK.
+    FallingEdge,
+}
+
+/// PSSI configuration.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+pub struct Config {
+    /// Parallel bus width.
+    pub bus_width: BusWidth,
+    /// Data transfer direction.
+    pub direction: Direction,
+    /// Pixel clock polarity.
+    pub clock_polarity: ClockPolarity,
+    /// Enable DE (Data Enable) / RDY (Ready) pin signals.
+    pub enable_de_rdy: bool,
+}
+
+impl Default for Config {
+    fn default() -> Self {
+        Self {
+            bus_width: BusWidth::Bits8,
+            direction: Direction::Receive,
+            clock_polarity: ClockPolarity::RisingEdge,
+            enable_de_rdy: false,
+        }
+    }
+}
+
+/// PSSI interrupt handler.
+pub struct InterruptHandler<T: Instance> {
+    _marker: PhantomData<T>,
+}
+
+impl<T: Instance> interrupt::typelevel::Handler<T::Interrupt> for InterruptHandler<T> {
+    unsafe fn on_interrupt() {
+        let r = T::regs();
+        // Clear interrupt enable flags
+        r.ier().modify(|w| {
+            w.set_ovr_ie(false);
+        });
+        T::waker().wake();
+    }
+}
+
+pub(crate) trait SealedInstance {
+    fn regs() -> crate::pac::pssi::Pssi;
+    fn waker() -> &'static AtomicWaker;
+}
+
+/// PSSI instance trait.
+#[allow(private_bounds)]
+pub trait Instance: SealedInstance + PeripheralType + RccPeripheral {
+    /// Interrupt for this PSSI instance.
+    type Interrupt: interrupt::typelevel::Interrupt;
+}
+
+pin_trait!(D0Pin, Instance);
+pin_trait!(D1Pin, Instance);
+pin_trait!(D2Pin, Instance);
+pin_trait!(D3Pin, Instance);
+pin_trait!(D4Pin, Instance);
+pin_trait!(D5Pin, Instance);
+pin_trait!(D6Pin, Instance);
+pin_trait!(D7Pin, Instance);
+pin_trait!(D8Pin, Instance);
+pin_trait!(D9Pin, Instance);
+pin_trait!(D10Pin, Instance);
+pin_trait!(D11Pin, Instance);
+pin_trait!(D12Pin, Instance);
+pin_trait!(D13Pin, Instance);
+pin_trait!(D14Pin, Instance);
+pin_trait!(D15Pin, Instance);
+
+pin_trait!(PdckPin, Instance);
+pin_trait!(DePin, Instance);
+pin_trait!(RdyPin, Instance);
+
+dma_trait!(Dma, Instance);
+
+/// PSSI driver.
+pub struct Pssi<'d, T: Instance> {
+    _peri: Peri<'d, T>,
+}
+
+impl<'d, T: Instance> Pssi<'d, T> {
+    /// Create a new PSSI driver for 8-bit mode.
+    pub fn new_8bit(
+        peri: Peri<'d, T>,
+        pdck: Peri<'d, impl PdckPin<T>>,
+        d0: Peri<'d, impl D0Pin<T>>,
+        d1: Peri<'d, impl D1Pin<T>>,
+        d2: Peri<'d, impl D2Pin<T>>,
+        d3: Peri<'d, impl D3Pin<T>>,
+        d4: Peri<'d, impl D4Pin<T>>,
+        d5: Peri<'d, impl D5Pin<T>>,
+        d6: Peri<'d, impl D6Pin<T>>,
+        d7: Peri<'d, impl D7Pin<T>>,
+        _irq: impl interrupt::typelevel::Binding<T::Interrupt, InterruptHandler<T>> + 'd,
+        config: Config,
+    ) -> Self {
+        crate::rcc::enable_and_reset::<T>();
+
+        pdck.set_as_af(pdck.af_num(), AfType::input(Pull::None));
+        d0.set_as_af(d0.af_num(), AfType::input(Pull::None));
+        d1.set_as_af(d1.af_num(), AfType::input(Pull::None));
+        d2.set_as_af(d2.af_num(), AfType::input(Pull::None));
+        d3.set_as_af(d3.af_num(), AfType::input(Pull::None));
+        d4.set_as_af(d4.af_num(), AfType::input(Pull::None));
+        d5.set_as_af(d5.af_num(), AfType::input(Pull::None));
+        d6.set_as_af(d6.af_num(), AfType::input(Pull::None));
+        d7.set_as_af(d7.af_num(), AfType::input(Pull::None));
+
+        let r = T::regs();
+        r.cr().modify(|w| {
+            w.set_edm(match config.bus_width {
+                BusWidth::Bits8 => crate::pac::pssi::vals::Edm::BitWidth8,
+                BusWidth::Bits16 => crate::pac::pssi::vals::Edm::BitWidth16,
+            });
+            w.set_ckpol(match config.clock_polarity {
+                ClockPolarity::RisingEdge => crate::pac::pssi::vals::Ckpol::RisingEdge,
+                ClockPolarity::FallingEdge => crate::pac::pssi::vals::Ckpol::FallingEdge,
+            });
+            w.set_derdycfg(if config.enable_de_rdy {
+                crate::pac::pssi::vals::Derdycfg::Disabled
+            } else {
+                crate::pac::pssi::vals::Derdycfg::Disabled
+            });
+            w.set_outen(match config.direction {
+                Direction::Receive => crate::pac::pssi::vals::Outen::ReceiveMode,
+                Direction::Transmit => crate::pac::pssi::vals::Outen::TransmitMode,
+            });
+            w.set_enable(true);
+        });
+
+        Self { _peri: peri }
+    }
+
+    /// Read data from PSSI data register.
+    pub fn read_data_register(&self) -> u32 {
+        T::regs().dr().read().0
+    }
+
+    /// Write data to PSSI data register.
+    pub fn write_data_register(&mut self, val: u32) {
+        T::regs().dr().write(|w| w.0 = val);
+    }
+}
+
+foreach_interrupt!(
+    ($inst:ident, pssi, PSSI, GLOBAL, $irq:ident) => {
+        impl Instance for peripherals::$inst {
+            type Interrupt = crate::interrupt::typelevel::$irq;
+        }
+
+        impl SealedInstance for peripherals::$inst {
+            fn regs() -> crate::pac::pssi::Pssi {
+                crate::pac::$inst
+            }
+            fn waker() -> &'static AtomicWaker {
+                static WAKER: AtomicWaker = AtomicWaker::new();
+                &WAKER
+            }
+        }
+    };
+);


### PR DESCRIPTION
- feat(stm32/mdios): add MDIOS (Management Data I/O Slave) driver supporting MDIO slave operations, register read/write, status flags, and interrupt handling.
- feat(stm32/pssi): add PSSI (Parallel Synchronous Slave Interface) driver supporting 8-bit/16-bit parallel bus transfers, direction, clock polarity, and DMA/interrupt integration.
- build(stm32): add pin and DMA mappings for PSSI and MDIOS, and fix MDIO/MDC signal routing for MDIOS peripherals.