### PR TITLE
feat: embassy-net: DHCPv4 server

### DIFF
--- a/embassy-net/Cargo.toml
+++ b/embassy-net/Cargo.toml
@@ -52,7 +52,7 @@ features = ["defmt", "tcp", "udp", "raw", "dns", "icmp", "dhcpv4", "proto-ipv6",
 target = "thumbv7em-none-eabi"
 
 [package.metadata.docs.rs]
-features = ["defmt", "tcp", "udp", "raw", "dns", "icmp", "dhcpv4", "proto-ipv6", "medium-ethernet", "medium-ip", "medium-ieee802154", "multicast", "dhcpv4-hostname", "packetmeta-id"]
+features = ["defmt", "tcp", "udp", "raw", "dns", "icmp", "dhcpv4", "proto-ipv6", "medium-ethernet", "medium-ip", "medium-ieee802154", "multicast", "dhcpv4-hostname", "packetmeta-id", "dhcpd"]
 
 [features]
 default = ["auto-icmp-echo-reply"]
@@ -64,6 +64,9 @@ log = ["dep:log"]
 
 ## Trace all raw received and transmitted packets using defmt or log.
 packet-trace = []
+
+## Enable the integrated DHCP server
+dhcpd = ["smoltcp/proto-dhcpv4", "udp"]
 
 #! Many of the following feature flags are re-exports of smoltcp feature flags. See 
 #! the [smoltcp feature flag documentation](https://github.com/smoltcp-rs/smoltcp#feature-flags)
@@ -130,3 +133,5 @@ managed = { version = "0.8.0", default-features = false, features = [ "map" ] }
 heapless = { version = "0.9", default-features = false }
 embedded-nal-async = "0.9.0"
 document-features = "0.2.7"
+
+rand-core-10 = { package = "rand_core", version = "0.10" }

--- a/embassy-net/src/dhcpd.rs
+++ b/embassy-net/src/dhcpd.rs
@@ -1,16 +1,14 @@
 //! DHCPv4 server implementation.
 
-use crate::Stack;
-use crate::udp::{PacketMetadata, UdpSocket};
-use embassy_sync::mutex::Mutex;
 use embassy_sync::blocking_mutex::raw::NoopRawMutex;
+use embassy_sync::mutex::Mutex;
 use embassy_time::Instant;
 use heapless::Vec;
 use rand_core_10::Rng;
-use smoltcp::wire::{
-    DhcpMessageType, DhcpPacket, DhcpRepr, Ipv4Address,
-    DHCP_SERVER_PORT, DHCP_CLIENT_PORT,
-};
+use smoltcp::wire::{DHCP_CLIENT_PORT, DHCP_SERVER_PORT, DhcpMessageType, DhcpPacket, DhcpRepr, Ipv4Address};
+
+use crate::Stack;
+use crate::udp::{PacketMetadata, UdpSocket};
 
 #[cfg(feature = "dhcpd")]
 const DHCPD_DOMAIN_LEN: usize = 32;
@@ -86,15 +84,14 @@ impl Default for DhcpdLease {
     }
 }
 
-
 /// Iterate through all leases, removing the ones that expired
 fn expire_leases<const DHCPD_MAX_LEASES: usize>(
     config: &'static DhcpdConfig,
-    leases: &mut Vec<DhcpdLease, DHCPD_MAX_LEASES>
+    leases: &mut Vec<DhcpdLease, DHCPD_MAX_LEASES>,
 ) -> () {
     if embassy_time::Instant::now().as_secs() < config.lease_time.as_secs() {
         // We do not yet run long enough to have any expired leases
-        return
+        return;
     }
 
     let deadline = embassy_time::Instant::now() - config.lease_time;
@@ -112,29 +109,37 @@ fn pick_offer<const DHCPD_MAX_LEASES: usize, T: Rng>(
     rng: &mut T,
     req: &DhcpRepr,
     config: &'static DhcpdConfig,
-    leases: &Vec<DhcpdLease, DHCPD_MAX_LEASES>
+    leases: &Vec<DhcpdLease, DHCPD_MAX_LEASES>,
 ) -> Option<Ipv4Address> {
-    info!("DHCP DISOCVER from {:?}.\nCurrent leases ({}):", req.client_hardware_address, leases.len());
+    info!(
+        "DHCP DISOCVER from {:?}.\nCurrent leases ({}):",
+        req.client_hardware_address,
+        leases.len()
+    );
 
     // Check if we already issued a lease to that client
     for x in leases {
         debug!("{:?}", x);
         if x.mac == Some(req.client_hardware_address) {
             debug!("MATCH: {:?} -> {:?}", x.mac, x.ip);
-            return x.ip
+            return x.ip;
         }
     }
 
     // If there is no lease, check if we have leases available
     if leases.len() >= DHCPD_MAX_LEASES {
         debug!("Too many leases. Given: {}, Max: {}", leases.len(), DHCPD_MAX_LEASES);
-        return None
+        return None;
     }
 
     // Check if the current number of leases is larger than the IP range size
     if leases.len() >= ((config.range_end.to_bits() - config.range_start.to_bits()) as usize) {
-        debug!("IP range saturated. Leases given: {}, Range size: {}", leases.len(), (config.range_end.to_bits() - config.range_start.to_bits()));
-        return None
+        debug!(
+            "IP range saturated. Leases given: {}, Range size: {}",
+            leases.len(),
+            (config.range_end.to_bits() - config.range_start.to_bits())
+        );
+        return None;
     }
 
     // Find a free IP address in the range. We will eventually find one since
@@ -142,10 +147,14 @@ fn pick_offer<const DHCPD_MAX_LEASES: usize, T: Rng>(
     loop {
         // Get a random IPv4 between range_start and range_end
         let rand: u32 = rng.next_u32();
-        let ip_u32: u32 = config.range_start.to_bits() + (rand % (config.range_end.to_bits() - config.range_start.to_bits() + 1));
+        let ip_u32: u32 =
+            config.range_start.to_bits() + (rand % (config.range_end.to_bits() - config.range_start.to_bits() + 1));
         let ip = core::net::Ipv4Addr::from_bits(ip_u32);
 
-        debug!("Scanning the leases for our random IP in range: {:?} - {:?} - {:?}", config.range_start, ip, config.range_end);
+        debug!(
+            "Scanning the leases for our random IP in range: {:?} - {:?} - {:?}",
+            config.range_start, ip, config.range_end
+        );
 
         // Find out if it's free or leased
         let mut found: bool = false;
@@ -159,7 +168,7 @@ fn pick_offer<const DHCPD_MAX_LEASES: usize, T: Rng>(
             // Our random IP was not found in the current leases => return it
             debug!("IP {:?} is not leased, taking it!", ip);
 
-            return Some(ip)
+            return Some(ip);
         }
     }
 }
@@ -168,10 +177,10 @@ fn pick_offer<const DHCPD_MAX_LEASES: usize, T: Rng>(
 fn validate_request<const DHCPD_MAX_LEASES: usize>(
     req: &DhcpRepr,
     config: &'static DhcpdConfig,
-    leases: &mut Vec<DhcpdLease, DHCPD_MAX_LEASES>
+    leases: &mut Vec<DhcpdLease, DHCPD_MAX_LEASES>,
 ) -> Option<Ipv4Address> {
     if req.requested_ip.is_none() && (req.client_ip == core::net::Ipv4Addr::UNSPECIFIED) {
-        return None
+        return None;
     }
 
     // A REQUEST packet has two use cases:
@@ -184,11 +193,18 @@ fn validate_request<const DHCPD_MAX_LEASES: usize>(
         requested_ip = req.requested_ip;
     }
 
-    info!("DHCP REQUEST from {:?}: {:?}.\nCurrent leases ({}):", req.client_hardware_address, requested_ip, leases.len());
+    info!(
+        "DHCP REQUEST from {:?}: {:?}.\nCurrent leases ({}):",
+        req.client_hardware_address,
+        requested_ip,
+        leases.len()
+    );
 
     // Check if the requested IP is in our range
-    if (requested_ip.unwrap().to_bits() < config.range_start.to_bits()) || (requested_ip.unwrap().to_bits() > config.range_end.to_bits()) {
-        return None
+    if (requested_ip.unwrap().to_bits() < config.range_start.to_bits())
+        || (requested_ip.unwrap().to_bits() > config.range_end.to_bits())
+    {
+        return None;
     }
 
     // Check if that IP is free (= not leased by someone else)
@@ -201,7 +217,7 @@ fn validate_request<const DHCPD_MAX_LEASES: usize>(
 
     // Leased by someone else => Send NAK
     if found {
-        return None
+        return None;
     }
 
     // The IP is not leased OR leased by the same client
@@ -212,7 +228,7 @@ fn validate_request<const DHCPD_MAX_LEASES: usize>(
         if x.mac == Some(req.client_hardware_address) {
             debug!("MATCH: {:?} -> {:?}", x.mac, x.ip);
             x.last_refresh = Some(Instant::now());
-            return x.ip
+            return x.ip;
         }
     }
 
@@ -221,7 +237,7 @@ fn validate_request<const DHCPD_MAX_LEASES: usize>(
     // Check if we have leases available
     if leases.len() >= DHCPD_MAX_LEASES {
         debug!("Too many leases. Given: {}, Max: {}", leases.len(), DHCPD_MAX_LEASES);
-        return None
+        return None;
     }
 
     let mut lease: DhcpdLease = DhcpdLease::default();
@@ -233,17 +249,13 @@ fn validate_request<const DHCPD_MAX_LEASES: usize>(
     let push_result = leases.push(lease);
 
     if push_result.is_err() {
-        return None
+        return None;
     }
 
     requested_ip
 }
 
-fn build_offer<'a>(
-    req: &'a DhcpRepr<'a>,
-    config: &'static DhcpdConfig,
-    yiaddr: Ipv4Address
-) -> DhcpRepr<'a> {
+fn build_offer<'a>(req: &'a DhcpRepr<'a>, config: &'static DhcpdConfig, yiaddr: Ipv4Address) -> DhcpRepr<'a> {
     DhcpRepr {
         message_type: DhcpMessageType::Offer,
         transaction_id: req.transaction_id,
@@ -269,11 +281,7 @@ fn build_offer<'a>(
     }
 }
 
-fn build_ack<'a>(
-    req: &'a DhcpRepr<'a>,
-    config: &'static DhcpdConfig,
-    yiaddr: Ipv4Address
-) -> DhcpRepr<'a> {
+fn build_ack<'a>(req: &'a DhcpRepr<'a>, config: &'static DhcpdConfig, yiaddr: Ipv4Address) -> DhcpRepr<'a> {
     DhcpRepr {
         message_type: DhcpMessageType::Ack,
         transaction_id: req.transaction_id,
@@ -299,11 +307,7 @@ fn build_ack<'a>(
     }
 }
 
-fn build_nak<'a>(
-    req: &'a DhcpRepr<'a>,
-    config: &'static DhcpdConfig,
-    yiaddr: Ipv4Address
-) -> DhcpRepr<'a> {
+fn build_nak<'a>(req: &'a DhcpRepr<'a>, config: &'static DhcpdConfig, yiaddr: Ipv4Address) -> DhcpRepr<'a> {
     DhcpRepr {
         message_type: DhcpMessageType::Nak,
         transaction_id: req.transaction_id,
@@ -336,12 +340,10 @@ fn emit_dhcp(repr: &DhcpRepr, out: &mut [u8]) -> Option<usize> {
     let mut pkt = DhcpPacket::new_unchecked(pkt_buf);
     let repr_result = repr.emit(&mut pkt);
     if repr_result.is_err() {
-        return None
+        return None;
     }
     Some(len)
 }
-
-
 
 /// DHCPd runner.
 ///
@@ -368,7 +370,9 @@ impl<'d, const DHCPD_MAX_LEASES: usize, T: Rng> Runner<'d, DHCPD_MAX_LEASES, T> 
 
         loop {
             let mut buf = [0u8; 1500];
-            let Ok((n, meta)) = sock.recv_from(&mut buf).await else { continue; };
+            let Ok((n, meta)) = sock.recv_from(&mut buf).await else {
+                continue;
+            };
 
             info!("DHCPd received {} bytes from {:?}", n, meta);
 
@@ -397,7 +401,9 @@ impl<'d, const DHCPD_MAX_LEASES: usize, T: Rng> Runner<'d, DHCPD_MAX_LEASES, T> 
                         debug!("Sending back DHCP OFFER: {:?}", resp);
                         let mut out = [0u8; 512];
                         let len = emit_dhcp(&resp, &mut out);
-                        let _ = sock.send_to(&out[..len.unwrap()], (Ipv4Address::BROADCAST, DHCP_CLIENT_PORT)).await;
+                        let _ = sock
+                            .send_to(&out[..len.unwrap()], (Ipv4Address::BROADCAST, DHCP_CLIENT_PORT))
+                            .await;
                     }
                 }
                 DhcpMessageType::Request => {
@@ -406,13 +412,17 @@ impl<'d, const DHCPD_MAX_LEASES: usize, T: Rng> Runner<'d, DHCPD_MAX_LEASES, T> 
                         debug!("Sending back DHCP ACK: {:?}", resp);
                         let mut out = [0u8; 512];
                         let len = emit_dhcp(&resp, &mut out);
-                        let _ = sock.send_to(&out[..len.unwrap()], (Ipv4Address::BROADCAST, DHCP_CLIENT_PORT)).await;
+                        let _ = sock
+                            .send_to(&out[..len.unwrap()], (Ipv4Address::BROADCAST, DHCP_CLIENT_PORT))
+                            .await;
                     } else {
                         let resp = build_nak(&req, self.config, req.requested_ip.unwrap());
                         debug!("Sending back DHCP NAK: {:?}", resp);
                         let mut out = [0u8; 512];
                         let len = emit_dhcp(&resp, &mut out);
-                        let _ = sock.send_to(&out[..len.unwrap()], (Ipv4Address::BROADCAST, DHCP_CLIENT_PORT)).await;
+                        let _ = sock
+                            .send_to(&out[..len.unwrap()], (Ipv4Address::BROADCAST, DHCP_CLIENT_PORT))
+                            .await;
                     }
                 }
                 _ => {}
@@ -420,7 +430,6 @@ impl<'d, const DHCPD_MAX_LEASES: usize, T: Rng> Runner<'d, DHCPD_MAX_LEASES, T> 
         }
     }
 }
-
 
 /// Create a new runner
 

--- a/embassy-net/src/dhcpd.rs
+++ b/embassy-net/src/dhcpd.rs
@@ -1,0 +1,439 @@
+//! DHCPv4 server implementation.
+
+use crate::Stack;
+use crate::udp::{PacketMetadata, UdpSocket};
+use embassy_sync::mutex::Mutex;
+use embassy_sync::blocking_mutex::raw::NoopRawMutex;
+use embassy_time::Instant;
+use heapless::Vec;
+use rand_core_10::Rng;
+use smoltcp::wire::{
+    DhcpMessageType, DhcpPacket, DhcpRepr, Ipv4Address,
+    DHCP_SERVER_PORT, DHCP_CLIENT_PORT,
+};
+
+#[cfg(feature = "dhcpd")]
+const DHCPD_DOMAIN_LEN: usize = 32;
+
+/// DHCPd configuration.
+#[cfg(feature = "dhcpd")]
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+#[non_exhaustive]
+pub struct DhcpdConfig {
+    /// Our own IPv4 address communicated to the client
+    pub server_ip: core::net::Ipv4Addr,
+    /// Server port. This is almost always 67. Do not change unless you know what you're doing
+    pub server_port: u16,
+    /// Start of the range we serve IPv4 addresses from
+    pub range_start: core::net::Ipv4Addr,
+    /// End of the range we serve IPv4 addresses from
+    pub range_end: core::net::Ipv4Addr,
+    /// Subnet mask we provide to the clients
+    pub subnet_mask: core::net::Ipv4Addr,
+    /// Time a single lease will be valid for. Defaults to 1h
+    pub lease_time: embassy_time::Duration,
+    /// The IP of the default router / gateway is provided to the clients
+    pub router_ip: Option<core::net::Ipv4Addr>,
+    /// The IPs of the DNS servers provided to the clients
+    pub dns_ip: Vec<core::net::Ipv4Addr, 3>,
+    /// The domain name provided to the clients
+    pub domain_name: Option<heapless::String<DHCPD_DOMAIN_LEN>>,
+    /// The MTU provided to the clients. Defaults to 1514
+    pub mtu: Option<u16>,
+}
+
+#[cfg(feature = "dhcpd")]
+impl Default for DhcpdConfig {
+    fn default() -> Self {
+        Self {
+            server_ip: core::net::Ipv4Addr::UNSPECIFIED,
+            server_port: smoltcp::wire::DHCP_SERVER_PORT,
+            range_start: core::net::Ipv4Addr::UNSPECIFIED,
+            range_end: core::net::Ipv4Addr::UNSPECIFIED,
+            subnet_mask: core::net::Ipv4Addr::UNSPECIFIED,
+            lease_time: embassy_time::Duration::from_secs(3600),
+            router_ip: None,
+            dns_ip: Vec::new(),
+            domain_name: None,
+            mtu: Some(1514),
+        }
+    }
+}
+
+/// DHCPd lease
+#[cfg(feature = "dhcpd")]
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+#[non_exhaustive]
+pub struct DhcpdLease {
+    /// Hardware / MAC address of the client holding the lease
+    pub mac: Option<smoltcp::wire::EthernetAddress>,
+    /// IPv4 address we assigned to the client
+    pub ip: Option<core::net::Ipv4Addr>,
+    /// When the lease was last assigned or confirmed
+    pub last_refresh: Option<embassy_time::Instant>,
+}
+
+#[cfg(feature = "dhcpd")]
+impl Default for DhcpdLease {
+    fn default() -> Self {
+        Self {
+            mac: None,
+            ip: None,
+            last_refresh: None,
+        }
+    }
+}
+
+
+/// Iterate through all leases, removing the ones that expired
+fn expire_leases<const DHCPD_MAX_LEASES: usize>(
+    config: &'static DhcpdConfig,
+    leases: &mut Vec<DhcpdLease, DHCPD_MAX_LEASES>
+) -> () {
+    if embassy_time::Instant::now().as_secs() < config.lease_time.as_secs() {
+        // We do not yet run long enough to have any expired leases
+        return
+    }
+
+    let deadline = embassy_time::Instant::now() - config.lease_time;
+
+    debug!("Leases before retain: {}", leases.len());
+
+    // Keep all those where the last_refresh happened after the deadline
+    leases.retain(|x| (*x).last_refresh >= Some(deadline));
+
+    debug!("Leases after retain: {}", leases.len());
+}
+
+/// Offer an IPv4 to a client. This is not yet a lease and does not modify the list of leases!
+fn pick_offer<const DHCPD_MAX_LEASES: usize, T: Rng>(
+    rng: &mut T,
+    req: &DhcpRepr,
+    config: &'static DhcpdConfig,
+    leases: &Vec<DhcpdLease, DHCPD_MAX_LEASES>
+) -> Option<Ipv4Address> {
+    info!("DHCP DISOCVER from {:?}.\nCurrent leases ({}):", req.client_hardware_address, leases.len());
+
+    // Check if we already issued a lease to that client
+    for x in leases {
+        debug!("{:?}", x);
+        if x.mac == Some(req.client_hardware_address) {
+            debug!("MATCH: {:?} -> {:?}", x.mac, x.ip);
+            return x.ip
+        }
+    }
+
+    // If there is no lease, check if we have leases available
+    if leases.len() >= DHCPD_MAX_LEASES {
+        debug!("Too many leases. Given: {}, Max: {}", leases.len(), DHCPD_MAX_LEASES);
+        return None
+    }
+
+    // Check if the current number of leases is larger than the IP range size
+    if leases.len() >= ((config.range_end.to_bits() - config.range_start.to_bits()) as usize) {
+        debug!("IP range saturated. Leases given: {}, Range size: {}", leases.len(), (config.range_end.to_bits() - config.range_start.to_bits()));
+        return None
+    }
+
+    // Find a free IP address in the range. We will eventually find one since
+    // the corner cases are handled above. Thus, we can loop{} and return
+    loop {
+        // Get a random IPv4 between range_start and range_end
+        let rand: u32 = rng.next_u32();
+        let ip_u32: u32 = config.range_start.to_bits() + (rand % (config.range_end.to_bits() - config.range_start.to_bits() + 1));
+        let ip = core::net::Ipv4Addr::from_bits(ip_u32);
+
+        debug!("Scanning the leases for our random IP in range: {:?} - {:?} - {:?}", config.range_start, ip, config.range_end);
+
+        // Find out if it's free or leased
+        let mut found: bool = false;
+        for x in leases {
+            if x.ip == Some(ip) {
+                found = true;
+                break;
+            }
+        }
+        if !found {
+            // Our random IP was not found in the current leases => return it
+            debug!("IP {:?} is not leased, taking it!", ip);
+
+            return Some(ip)
+        }
+    }
+}
+
+/// If we ACK a REQUEST, we hand out the lease and need to record that
+fn validate_request<const DHCPD_MAX_LEASES: usize>(
+    req: &DhcpRepr,
+    config: &'static DhcpdConfig,
+    leases: &mut Vec<DhcpdLease, DHCPD_MAX_LEASES>
+) -> Option<Ipv4Address> {
+    if req.requested_ip.is_none() && (req.client_ip == core::net::Ipv4Addr::UNSPECIFIED) {
+        return None
+    }
+
+    // A REQUEST packet has two use cases:
+    //  - acquiring a new lease (req.client_ip == 0.0.0.0 && req.requested_ip.is_some() == true)
+    //  - refreshing an existing lease (req.client_ip != 0.0.0.0 && req.requested_ip.is_none() == true)
+    // Here we treat both cases "the same"
+    let mut requested_ip: Option<core::net::Ipv4Addr> = Some(req.client_ip);
+
+    if req.requested_ip.is_some() {
+        requested_ip = req.requested_ip;
+    }
+
+    info!("DHCP REQUEST from {:?}: {:?}.\nCurrent leases ({}):", req.client_hardware_address, requested_ip, leases.len());
+
+    // Check if the requested IP is in our range
+    if (requested_ip.unwrap().to_bits() < config.range_start.to_bits()) || (requested_ip.unwrap().to_bits() > config.range_end.to_bits()) {
+        return None
+    }
+
+    // Check if that IP is free (= not leased by someone else)
+    let mut found = false;
+    for x in leases.iter() {
+        if (x.ip == requested_ip) && (x.mac != Some(req.client_hardware_address)) {
+            found = true;
+        }
+    }
+
+    // Leased by someone else => Send NAK
+    if found {
+        return None
+    }
+
+    // The IP is not leased OR leased by the same client
+
+    // Check if we already issued a lease to that client
+    for x in leases.iter_mut() {
+        debug!("{:?}", x);
+        if x.mac == Some(req.client_hardware_address) {
+            debug!("MATCH: {:?} -> {:?}", x.mac, x.ip);
+            x.last_refresh = Some(Instant::now());
+            return x.ip
+        }
+    }
+
+    // We don't have a lease for that client and need to record a new one
+
+    // Check if we have leases available
+    if leases.len() >= DHCPD_MAX_LEASES {
+        debug!("Too many leases. Given: {}, Max: {}", leases.len(), DHCPD_MAX_LEASES);
+        return None
+    }
+
+    let mut lease: DhcpdLease = DhcpdLease::default();
+
+    lease.mac = Some(req.client_hardware_address);
+    lease.ip = requested_ip;
+    lease.last_refresh = Some(Instant::now());
+
+    let push_result = leases.push(lease);
+
+    if push_result.is_err() {
+        return None
+    }
+
+    requested_ip
+}
+
+fn build_offer<'a>(
+    req: &'a DhcpRepr<'a>,
+    config: &'static DhcpdConfig,
+    yiaddr: Ipv4Address
+) -> DhcpRepr<'a> {
+    DhcpRepr {
+        message_type: DhcpMessageType::Offer,
+        transaction_id: req.transaction_id,
+        secs: 0,
+        client_hardware_address: req.client_hardware_address,
+        client_ip: Ipv4Address::UNSPECIFIED,
+        your_ip: yiaddr,
+        server_ip: config.server_ip,
+        router: config.router_ip,
+        subnet_mask: Some(config.subnet_mask),
+        relay_agent_ip: Ipv4Address::UNSPECIFIED,
+        broadcast: true,
+        requested_ip: None,
+        client_identifier: None,
+        server_identifier: Some(config.server_ip),
+        parameter_request_list: None,
+        max_size: None,
+        lease_duration: Some(config.lease_time.as_secs() as u32),
+        renew_duration: None,
+        rebind_duration: None,
+        dns_servers: Some(config.dns_ip.clone()),
+        additional_options: &[],
+    }
+}
+
+fn build_ack<'a>(
+    req: &'a DhcpRepr<'a>,
+    config: &'static DhcpdConfig,
+    yiaddr: Ipv4Address
+) -> DhcpRepr<'a> {
+    DhcpRepr {
+        message_type: DhcpMessageType::Ack,
+        transaction_id: req.transaction_id,
+        secs: 0,
+        client_hardware_address: req.client_hardware_address,
+        client_ip: Ipv4Address::UNSPECIFIED,
+        your_ip: yiaddr,
+        server_ip: config.server_ip,
+        router: config.router_ip,
+        subnet_mask: Some(config.subnet_mask),
+        relay_agent_ip: Ipv4Address::UNSPECIFIED,
+        broadcast: true,
+        requested_ip: None,
+        client_identifier: None,
+        server_identifier: Some(config.server_ip),
+        parameter_request_list: None,
+        max_size: None,
+        lease_duration: Some(config.lease_time.as_secs() as u32),
+        renew_duration: None,
+        rebind_duration: None,
+        dns_servers: Some(config.dns_ip.clone()),
+        additional_options: &[],
+    }
+}
+
+fn build_nak<'a>(
+    req: &'a DhcpRepr<'a>,
+    config: &'static DhcpdConfig,
+    yiaddr: Ipv4Address
+) -> DhcpRepr<'a> {
+    DhcpRepr {
+        message_type: DhcpMessageType::Nak,
+        transaction_id: req.transaction_id,
+        secs: 0,
+        client_hardware_address: req.client_hardware_address,
+        client_ip: Ipv4Address::UNSPECIFIED,
+        your_ip: yiaddr,
+        server_ip: config.server_ip,
+        router: config.router_ip,
+        subnet_mask: Some(config.subnet_mask),
+        relay_agent_ip: Ipv4Address::UNSPECIFIED,
+        broadcast: true,
+        requested_ip: None,
+        client_identifier: None,
+        server_identifier: Some(config.server_ip),
+        parameter_request_list: None,
+        max_size: None,
+        lease_duration: Some(config.lease_time.as_secs() as u32),
+        renew_duration: None,
+        rebind_duration: None,
+        dns_servers: Some(config.dns_ip.clone()),
+        additional_options: &[],
+    }
+}
+
+/// Serialize the DHCP representation into a buffer
+fn emit_dhcp(repr: &DhcpRepr, out: &mut [u8]) -> Option<usize> {
+    let len = repr.buffer_len();
+    let pkt_buf = &mut out[..len];
+    let mut pkt = DhcpPacket::new_unchecked(pkt_buf);
+    let repr_result = repr.emit(&mut pkt);
+    if repr_result.is_err() {
+        return None
+    }
+    Some(len)
+}
+
+
+
+/// DHCPd runner.
+///
+/// You must call [`Runner::run()`] in a background task for the network stack to work.
+pub struct Runner<'d, const DHCPD_MAX_LEASES: usize, T: Rng> {
+    stack: Stack<'d>,
+    rng: T,
+    config: &'static DhcpdConfig,
+    leases: &'static Mutex<NoopRawMutex, Vec<DhcpdLease, DHCPD_MAX_LEASES>>,
+}
+
+impl<'d, const DHCPD_MAX_LEASES: usize, T: Rng> Runner<'d, DHCPD_MAX_LEASES, T> {
+    /// Run the network stack.
+    ///
+    /// You must call this in a background task, to process network events.
+    pub async fn run(&mut self) -> ! {
+        let mut rx_meta = [PacketMetadata::EMPTY; 4];
+        let mut tx_meta = [PacketMetadata::EMPTY; 4];
+        let mut rx_buf = [0u8; 1536];
+        let mut tx_buf = [0u8; 1536];
+
+        let mut sock = UdpSocket::new(self.stack, &mut rx_meta, &mut rx_buf, &mut tx_meta, &mut tx_buf);
+        sock.bind(DHCP_SERVER_PORT).unwrap();
+
+        loop {
+            let mut buf = [0u8; 1500];
+            let Ok((n, meta)) = sock.recv_from(&mut buf).await else { continue; };
+
+            info!("DHCPd received {} bytes from {:?}", n, meta);
+
+            let pkt = match DhcpPacket::new_checked(&buf[..n]) {
+                Ok(p) => p,
+                Err(_) => continue,
+            };
+
+            let req = match DhcpRepr::parse(&pkt) {
+                Ok(r) => r,
+                Err(_) => continue,
+            };
+
+            info!("Parsed {:?}", req);
+
+            let mut g_leases = self.leases.lock().await;
+
+            // Check all leases for validity and remove the expired ones
+            expire_leases(self.config, &mut *g_leases);
+
+            match req.message_type {
+                DhcpMessageType::Discover => {
+                    let yiaddr = pick_offer(&mut self.rng, &req, self.config, &mut *g_leases);
+                    if yiaddr.is_some() {
+                        let resp = build_offer(&req, self.config, yiaddr.unwrap());
+                        debug!("Sending back DHCP OFFER: {:?}", resp);
+                        let mut out = [0u8; 512];
+                        let len = emit_dhcp(&resp, &mut out);
+                        let _ = sock.send_to(&out[..len.unwrap()], (Ipv4Address::BROADCAST, DHCP_CLIENT_PORT)).await;
+                    }
+                }
+                DhcpMessageType::Request => {
+                    if let Some(yiaddr) = validate_request(&req, self.config, &mut *g_leases) {
+                        let resp = build_ack(&req, self.config, yiaddr);
+                        debug!("Sending back DHCP ACK: {:?}", resp);
+                        let mut out = [0u8; 512];
+                        let len = emit_dhcp(&resp, &mut out);
+                        let _ = sock.send_to(&out[..len.unwrap()], (Ipv4Address::BROADCAST, DHCP_CLIENT_PORT)).await;
+                    } else {
+                        let resp = build_nak(&req, self.config, req.requested_ip.unwrap());
+                        debug!("Sending back DHCP NAK: {:?}", resp);
+                        let mut out = [0u8; 512];
+                        let len = emit_dhcp(&resp, &mut out);
+                        let _ = sock.send_to(&out[..len.unwrap()], (Ipv4Address::BROADCAST, DHCP_CLIENT_PORT)).await;
+                    }
+                }
+                _ => {}
+            }
+        }
+    }
+}
+
+
+/// Create a new runner
+
+pub fn new<'d, const DHCPD_MAX_LEASES: usize, T: Rng>(
+    stack: Stack<'static>,
+    rng: T,
+    config: &'static DhcpdConfig,
+    leases: &'static Mutex<NoopRawMutex, Vec<DhcpdLease, DHCPD_MAX_LEASES>>,
+) -> Runner<'d, DHCPD_MAX_LEASES, T> {
+    Runner {
+        stack,
+        rng,
+        config,
+        leases,
+    }
+}

--- a/embassy-net/src/lib.rs
+++ b/embassy-net/src/lib.rs
@@ -26,6 +26,8 @@ mod time;
 #[cfg(feature = "udp")]
 pub mod udp;
 pub mod vlan;
+#[cfg(feature = "dhcpd")]
+pub mod dhcpd;
 
 use core::cell::RefCell;
 use core::future::{Future, poll_fn};

--- a/embassy-net/src/lib.rs
+++ b/embassy-net/src/lib.rs
@@ -13,6 +13,8 @@ compile_error!("You must enable at least one of the following features: proto-ip
 // This mod MUST go first, so that the others see its macros.
 pub(crate) mod fmt;
 
+#[cfg(feature = "dhcpd")]
+pub mod dhcpd;
 #[cfg(feature = "dns")]
 pub mod dns;
 mod driver_util;
@@ -26,8 +28,6 @@ mod time;
 #[cfg(feature = "udp")]
 pub mod udp;
 pub mod vlan;
-#[cfg(feature = "dhcpd")]
-pub mod dhcpd;
 
 use core::cell::RefCell;
 use core::future::{Future, poll_fn};

--- a/examples/rp/Cargo.toml
+++ b/examples/rp/Cargo.toml
@@ -15,7 +15,7 @@ embassy-rp = { version = "0.10.0", path = "../../embassy-rp", features = ["defmt
 embassy-usb = { version = "0.6.0", path = "../../embassy-usb", features = ["defmt"] }
 embassy-usb-host = { version = "0.1.0", path = "../../embassy-usb-host", features = ["defmt"] }
 embassy-usb-driver = { version = "0.2.2", path = "../../embassy-usb-driver" }
-embassy-net = { version = "0.9.1", path = "../../embassy-net", features = ["defmt", "icmp", "tcp", "udp", "raw", "dhcpv4", "medium-ethernet", "dns", "proto-ipv4", "proto-ipv6", "multicast"] }
+embassy-net = { version = "0.9.1", path = "../../embassy-net", features = ["defmt", "icmp", "tcp", "udp", "raw", "dhcpv4", "medium-ethernet", "dns", "proto-ipv4", "proto-ipv6", "multicast", "dhcpd"] }
 embassy-net-wiznet = { version = "0.3.0", path = "../../embassy-net-wiznet", features = ["defmt"] }
 embassy-futures = { version = "0.1.2", path = "../../embassy-futures" }
 embassy-usb-logger = { version = "0.6.0", path = "../../embassy-usb-logger" }

--- a/examples/rp/src/bin/wifi_ap_dhcpd_tcp_server.rs
+++ b/examples/rp/src/bin/wifi_ap_dhcpd_tcp_server.rs
@@ -11,16 +11,16 @@ use cyw43::{ApAuth, aligned_bytes};
 use cyw43_pio::{DEFAULT_CLOCK_DIVIDER, PioSpi};
 use defmt::*;
 use embassy_executor::Spawner;
+use embassy_net::dhcpd::{DhcpdConfig, DhcpdLease};
 use embassy_net::tcp::TcpSocket;
 use embassy_net::{Config, StackResources};
-use embassy_net::dhcpd::{DhcpdConfig, DhcpdLease};
 use embassy_rp::clocks::RoscRng;
 use embassy_rp::gpio::{Level, Output};
 use embassy_rp::peripherals::{DMA_CH0, DMA_CH1, PIO0};
 use embassy_rp::pio::{InterruptHandler, Pio};
 use embassy_rp::{bind_interrupts, dma};
-use embassy_sync::mutex::Mutex;
 use embassy_sync::blocking_mutex::raw::NoopRawMutex;
+use embassy_sync::mutex::Mutex;
 use embassy_time::Duration;
 use embedded_io_async::Write;
 use heapless::Vec;
@@ -114,14 +114,15 @@ async fn main(spawner: Spawner) {
     static DHCPD_CONFIG: StaticCell<DhcpdConfig> = StaticCell::new();
 
     let dhcpd_config: &'static mut DhcpdConfig = DHCPD_CONFIG.init(DhcpdConfig::default());
-    dhcpd_config.server_ip   = core::net::Ipv4Addr::new(169, 254, 1, 1);
+    dhcpd_config.server_ip = core::net::Ipv4Addr::new(169, 254, 1, 1);
     dhcpd_config.range_start = core::net::Ipv4Addr::new(169, 254, 2, 100);
-    dhcpd_config.range_end   = core::net::Ipv4Addr::new(169, 254, 2, 200);
+    dhcpd_config.range_end = core::net::Ipv4Addr::new(169, 254, 2, 200);
     dhcpd_config.subnet_mask = core::net::Ipv4Addr::new(255, 255, 0, 0);
-    dhcpd_config.lease_time  = Duration::from_secs(300);
+    dhcpd_config.lease_time = Duration::from_secs(300);
 
     static LEASES: StaticCell<Mutex<NoopRawMutex, Vec<DhcpdLease, DHCPD_MAX_LEASES>>> = StaticCell::new();
-    let leases: &'static mut Mutex<NoopRawMutex, Vec<DhcpdLease, DHCPD_MAX_LEASES>> = LEASES.init(Mutex::new(Vec::new()));
+    let leases: &'static mut Mutex<NoopRawMutex, Vec<DhcpdLease, DHCPD_MAX_LEASES>> =
+        LEASES.init(Mutex::new(Vec::new()));
 
     let dhcpd_runner = embassy_net::dhcpd::new(stack, rng, dhcpd_config, leases);
 

--- a/examples/rp/src/bin/wifi_ap_dhcpd_tcp_server.rs
+++ b/examples/rp/src/bin/wifi_ap_dhcpd_tcp_server.rs
@@ -1,0 +1,179 @@
+//! This example uses the RP Pico W board Wifi chip (cyw43).
+//! Creates an Access point Wifi network and creates a TCP endpoint on port 1234.
+
+#![no_std]
+#![no_main]
+#![allow(async_fn_in_trait)]
+
+use core::str::from_utf8;
+
+use cyw43::{ApAuth, aligned_bytes};
+use cyw43_pio::{DEFAULT_CLOCK_DIVIDER, PioSpi};
+use defmt::*;
+use embassy_executor::Spawner;
+use embassy_net::tcp::TcpSocket;
+use embassy_net::{Config, StackResources};
+use embassy_net::dhcpd::{DhcpdConfig, DhcpdLease};
+use embassy_rp::clocks::RoscRng;
+use embassy_rp::gpio::{Level, Output};
+use embassy_rp::peripherals::{DMA_CH0, DMA_CH1, PIO0};
+use embassy_rp::pio::{InterruptHandler, Pio};
+use embassy_rp::{bind_interrupts, dma};
+use embassy_sync::mutex::Mutex;
+use embassy_sync::blocking_mutex::raw::NoopRawMutex;
+use embassy_time::Duration;
+use embedded_io_async::Write;
+use heapless::Vec;
+use static_cell::StaticCell;
+use {defmt_rtt as _, panic_probe as _};
+
+const DHCPD_MAX_LEASES: usize = 16;
+
+bind_interrupts!(struct Irqs {
+    PIO0_IRQ_0 => InterruptHandler<PIO0>;
+    DMA_IRQ_0 => dma::InterruptHandler<DMA_CH0>, dma::InterruptHandler<DMA_CH1>;
+});
+
+#[embassy_executor::task]
+async fn cyw43_task(
+    runner: cyw43::Runner<'static, cyw43::SpiBus<Output<'static>, PioSpi<'static, PIO0, 0>>, cyw43::Cyw43439>,
+) -> ! {
+    runner.run().await
+}
+
+#[embassy_executor::task]
+async fn net_task(mut runner: embassy_net::Runner<'static, cyw43::NetDriver<'static>>) -> ! {
+    runner.run().await
+}
+
+#[embassy_executor::task]
+async fn dhcpcd_task(mut runner: embassy_net::dhcpd::Runner<'static, DHCPD_MAX_LEASES, RoscRng>) -> ! {
+    runner.run().await
+}
+
+#[embassy_executor::main]
+async fn main(spawner: Spawner) {
+    info!("Hello World!");
+
+    let p = embassy_rp::init(Default::default());
+    let mut rng = RoscRng;
+
+    let fw = aligned_bytes!("../../../../cyw43-firmware/43439A0.bin");
+    let clm = aligned_bytes!("../../../../cyw43-firmware/43439A0_clm.bin");
+    let nvram = aligned_bytes!("../../../../cyw43-firmware/nvram_rp2040.bin");
+
+    // To make flashing faster for development, you may want to flash the firmwares independently
+    // at hardcoded addresses, instead of baking them into the program with `include_bytes!`:
+    //     probe-rs download 43439A0.bin --binary-format bin --chip RP2040 --base-address 0x10100000
+    //     probe-rs download 43439A0_clm.bin --binary-format bin --chip RP2040 --base-address 0x10140000
+    //let fw = unsafe { core::slice::from_raw_parts(0x10100000 as *const u8, 230321) };
+    //let clm = unsafe { core::slice::from_raw_parts(0x10140000 as *const u8, 4752) };
+
+    let pwr = Output::new(p.PIN_23, Level::Low);
+    let cs = Output::new(p.PIN_25, Level::High);
+    let mut pio = Pio::new(p.PIO0, Irqs);
+    let spi = PioSpi::new(
+        &mut pio.common,
+        pio.sm0,
+        DEFAULT_CLOCK_DIVIDER,
+        pio.irq0,
+        cs,
+        p.PIN_24,
+        p.PIN_29,
+        dma::Channel::new(p.DMA_CH0, Irqs),
+        dma::Channel::new(p.DMA_CH1, Irqs),
+    );
+
+    static STATE: StaticCell<cyw43::State> = StaticCell::new();
+    let state = STATE.init(cyw43::State::new());
+    let (net_device, mut control, runner) = cyw43::new(state, pwr, spi, fw, nvram).await;
+    spawner.spawn(unwrap!(cyw43_task(runner)));
+
+    control.init(clm).await;
+    control
+        .set_power_management(cyw43::PowerManagementMode::PowerSave)
+        .await;
+
+    // Use a link-local address for communication without DHCP server
+    let config = Config::ipv4_static(embassy_net::StaticConfigV4 {
+        address: embassy_net::Ipv4Cidr::new(embassy_net::Ipv4Address::new(169, 254, 1, 1), 16),
+        dns_servers: heapless::Vec::new(),
+        gateway: None,
+    });
+
+    // Generate random seed
+    let seed = rng.next_u64();
+
+    // Init network stack
+    static RESOURCES: StaticCell<StackResources<3>> = StaticCell::new();
+    let (stack, runner) = embassy_net::new(net_device, config, RESOURCES.init(StackResources::new()), seed);
+
+    spawner.spawn(unwrap!(net_task(runner)));
+
+    // Confgire and start the DHCPv4 server
+    static DHCPD_CONFIG: StaticCell<DhcpdConfig> = StaticCell::new();
+
+    let dhcpd_config: &'static mut DhcpdConfig = DHCPD_CONFIG.init(DhcpdConfig::default());
+    dhcpd_config.server_ip   = core::net::Ipv4Addr::new(169, 254, 1, 1);
+    dhcpd_config.range_start = core::net::Ipv4Addr::new(169, 254, 2, 100);
+    dhcpd_config.range_end   = core::net::Ipv4Addr::new(169, 254, 2, 200);
+    dhcpd_config.subnet_mask = core::net::Ipv4Addr::new(255, 255, 0, 0);
+    dhcpd_config.lease_time  = Duration::from_secs(300);
+
+    static LEASES: StaticCell<Mutex<NoopRawMutex, Vec<DhcpdLease, DHCPD_MAX_LEASES>>> = StaticCell::new();
+    let leases: &'static mut Mutex<NoopRawMutex, Vec<DhcpdLease, DHCPD_MAX_LEASES>> = LEASES.init(Mutex::new(Vec::new()));
+
+    let dhcpd_runner = embassy_net::dhcpd::new(stack, rng, dhcpd_config, leases);
+
+    spawner.spawn(unwrap!(dhcpcd_task(dhcpd_runner)));
+
+    control.start_ap("cyw43", "password", ApAuth::Wpa2, 5).await;
+    // WPA3 requires compatible CYW43 firmware and client support.
+    // control.start_ap("cyw43", "password", ApAuth::Wpa3, 5).await;
+    // control.start_ap("cyw43", "password", ApAuth::Wpa2Wpa3, 5).await;
+
+    // And now we can use it!
+
+    let mut rx_buffer = [0; 4096];
+    let mut tx_buffer = [0; 4096];
+    let mut buf = [0; 4096];
+
+    loop {
+        let mut socket = TcpSocket::new(stack, &mut rx_buffer, &mut tx_buffer);
+        socket.set_timeout(Some(Duration::from_secs(10)));
+
+        control.gpio_set(0, false).await;
+        info!("Listening on TCP:1234...");
+        if let Err(e) = socket.accept(1234).await {
+            warn!("accept error: {:?}", e);
+            continue;
+        }
+
+        info!("Received connection from {:?}", socket.remote_endpoint());
+        control.gpio_set(0, true).await;
+
+        loop {
+            let n = match socket.read(&mut buf).await {
+                Ok(0) => {
+                    warn!("read EOF");
+                    break;
+                }
+                Ok(n) => n,
+                Err(e) => {
+                    warn!("read error: {:?}", e);
+                    break;
+                }
+            };
+
+            info!("rxd {}", from_utf8(&buf[..n]).unwrap());
+
+            match socket.write_all(&buf[..n]).await {
+                Ok(()) => {}
+                Err(e) => {
+                    warn!("write error: {:?}", e);
+                    break;
+                }
+            };
+        }
+    }
+}

--- a/examples/rp235x/Cargo.toml
+++ b/examples/rp235x/Cargo.toml
@@ -13,7 +13,7 @@ embassy-executor = { version = "0.10.0", path = "../../embassy-executor", featur
 embassy-time = { version = "0.5.1", path = "../../embassy-time", features = ["defmt", "defmt-timestamp-uptime"] }
 embassy-rp = { version = "0.10.0", path = "../../embassy-rp", features = ["defmt", "unstable-pac", "time-driver", "critical-section-impl", "rp235xa", "binary-info"] }
 embassy-usb = { version = "0.6.0", path = "../../embassy-usb", features = ["defmt"] }
-embassy-net = { version = "0.9.1", path = "../../embassy-net", features = ["defmt", "icmp", "tcp", "udp", "raw", "dhcpv4", "medium-ethernet", "dns"] }
+embassy-net = { version = "0.9.1", path = "../../embassy-net", features = ["defmt", "icmp", "tcp", "udp", "raw", "dhcpv4", "medium-ethernet", "dns", "dhcpd"] }
 embassy-net-wiznet = { version = "0.3.0", path = "../../embassy-net-wiznet", features = ["defmt"] }
 embassy-futures = { version = "0.1.2", path = "../../embassy-futures" }
 embassy-usb-logger = { version = "0.6.0", path = "../../embassy-usb-logger" }

--- a/examples/rp235x/src/bin/usb_ethernet_with_dhcpd.rs
+++ b/examples/rp235x/src/bin/usb_ethernet_with_dhcpd.rs
@@ -1,0 +1,139 @@
+//! This example shows how to use USB (Universal Serial Bus) in the RP2350 chip.
+//!
+//! This is a CDC-NCM class implementation, aka Ethernet over USB. It also
+//! runs a DHCP server to automatically configure IPv4 on the host machine.
+
+#![no_std]
+#![no_main]
+
+use defmt::*;
+use embassy_executor::Spawner;
+use embassy_net::Ipv4Cidr;
+use embassy_net::StackResources;
+use embassy_net::dhcpd::{DhcpdConfig, DhcpdLease};
+use embassy_rp::clocks::RoscRng;
+use embassy_rp::peripherals::USB;
+use embassy_rp::usb::{Driver, InterruptHandler};
+use embassy_rp::{bind_interrupts, peripherals};
+use embassy_sync::mutex::Mutex;
+use embassy_sync::blocking_mutex::raw::NoopRawMutex;
+use embassy_time::Duration;
+use embassy_usb::class::cdc_ncm::embassy_net::{Device, Runner, State as NetState};
+use embassy_usb::class::cdc_ncm::{CdcNcmClass, State};
+use embassy_usb::{Builder, Config, UsbDevice};
+use heapless::Vec;
+use static_cell::StaticCell;
+use {defmt_rtt as _, panic_probe as _};
+
+bind_interrupts!(struct Irqs {
+    USBCTRL_IRQ => InterruptHandler<USB>;
+});
+
+type MyDriver = Driver<'static, peripherals::USB>;
+
+const MTU: usize = 1514;
+
+const DHCPD_MAX_LEASES: usize = 32;
+
+#[embassy_executor::task]
+async fn usb_task(mut device: UsbDevice<'static, MyDriver>) -> ! {
+    device.run().await
+}
+
+#[embassy_executor::task]
+async fn usb_ncm_task(class: Runner<'static, MyDriver, MTU>) -> ! {
+    class.run().await
+}
+
+#[embassy_executor::task]
+async fn net_task(mut runner: embassy_net::Runner<'static, Device<'static, MTU>>) -> ! {
+    runner.run().await
+}
+
+#[embassy_executor::task]
+async fn dhcpcd_task(mut runner: embassy_net::dhcpd::Runner<'static, DHCPD_MAX_LEASES, RoscRng>) -> ! {
+    runner.run().await
+}
+
+#[embassy_executor::main]
+async fn main(spawner: Spawner) {
+    let p = embassy_rp::init(Default::default());
+    let mut rng = RoscRng;
+
+    // Create the driver, from the HAL.
+    let driver = Driver::new(p.USB, Irqs);
+
+    // Create embassy-usb Config
+    let mut config = Config::new(0xc0de, 0xcafe);
+    config.manufacturer = Some("Embassy");
+    config.product = Some("USB-Ethernet example");
+    config.serial_number = Some("12345678");
+    config.max_power = 100;
+    config.max_packet_size_0 = 64;
+
+    // Create embassy-usb DeviceBuilder using the driver and config.
+    static CONFIG_DESC: StaticCell<[u8; 256]> = StaticCell::new();
+    static BOS_DESC: StaticCell<[u8; 256]> = StaticCell::new();
+    static CONTROL_BUF: StaticCell<[u8; 128]> = StaticCell::new();
+    let mut builder = Builder::new(
+        driver,
+        config,
+        &mut CONFIG_DESC.init([0; 256])[..],
+        &mut BOS_DESC.init([0; 256])[..],
+        &mut [], // no msos descriptors
+        &mut CONTROL_BUF.init([0; 128])[..],
+    );
+
+    // Our MAC addr.
+    let our_mac_addr = [0xCC, 0xCC, 0xCC, 0xCC, 0xCC, 0xCC];
+    // Host's MAC addr. This is the MAC the host "thinks" its USB-to-ethernet adapter has.
+    let host_mac_addr = [0x88, 0x88, 0x88, 0x88, 0x88, 0x88];
+
+    // Create classes on the builder.
+    static STATE: StaticCell<State> = StaticCell::new();
+    let class = CdcNcmClass::new(&mut builder, STATE.init(State::new()), host_mac_addr, 64);
+
+    // Build the builder.
+    let usb = builder.build();
+
+    spawner.spawn(unwrap!(usb_task(usb)));
+
+    static NET_STATE: StaticCell<NetState<MTU, 4, 4>> = StaticCell::new();
+    let (runner, device) = class.into_embassy_net_device::<MTU, 4, 4>(NET_STATE.init(NetState::new()), our_mac_addr);
+    spawner.spawn(unwrap!(usb_ncm_task(runner)));
+
+    // We use a static IPv4 address ourselves
+    let config = embassy_net::Config::ipv4_static(embassy_net::StaticConfigV4 {
+        address: Ipv4Cidr::new(core::net::Ipv4Addr::new(10, 42, 0, 61), 24),
+        dns_servers: Default::default(),
+        gateway: None,
+    });
+
+    // Generate random seed
+    let seed = rng.next_u64();
+
+    // Init network stack
+    static RESOURCES: StaticCell<StackResources<3>> = StaticCell::new();
+    let (stack, runner) = embassy_net::new(device, config, RESOURCES.init(StackResources::new()), seed);
+
+    spawner.spawn(unwrap!(net_task(runner)));
+
+    // Confgire and start the DHCPv4 server
+    static DHCPD_CONFIG: StaticCell<DhcpdConfig> = StaticCell::new();
+
+    let dhcpd_config: &'static mut DhcpdConfig = DHCPD_CONFIG.init(DhcpdConfig::default());
+    dhcpd_config.server_ip   = core::net::Ipv4Addr::new(10, 42, 0, 61);
+    dhcpd_config.range_start = core::net::Ipv4Addr::new(10, 42, 0, 62);
+    dhcpd_config.range_end   = core::net::Ipv4Addr::new(10, 42, 0, 64);
+    dhcpd_config.subnet_mask = core::net::Ipv4Addr::new(255, 255, 255, 0);
+    dhcpd_config.lease_time  = Duration::from_secs(300);
+
+    static LEASES: StaticCell<Mutex<NoopRawMutex, Vec<DhcpdLease, DHCPD_MAX_LEASES>>> = StaticCell::new();
+    let leases: &'static mut Mutex<NoopRawMutex, Vec<DhcpdLease, DHCPD_MAX_LEASES>> = LEASES.init(Mutex::new(Vec::new()));
+
+    let dhcpd_runner = embassy_net::dhcpd::new(stack, rng, dhcpd_config, leases);
+
+    spawner.spawn(unwrap!(dhcpcd_task(dhcpd_runner)));
+
+    // End of init, all other stuff happens in already spawned tasks
+}

--- a/examples/rp235x/src/bin/usb_ethernet_with_dhcpd.rs
+++ b/examples/rp235x/src/bin/usb_ethernet_with_dhcpd.rs
@@ -8,15 +8,14 @@
 
 use defmt::*;
 use embassy_executor::Spawner;
-use embassy_net::Ipv4Cidr;
-use embassy_net::StackResources;
 use embassy_net::dhcpd::{DhcpdConfig, DhcpdLease};
+use embassy_net::{Ipv4Cidr, StackResources};
 use embassy_rp::clocks::RoscRng;
 use embassy_rp::peripherals::USB;
 use embassy_rp::usb::{Driver, InterruptHandler};
 use embassy_rp::{bind_interrupts, peripherals};
-use embassy_sync::mutex::Mutex;
 use embassy_sync::blocking_mutex::raw::NoopRawMutex;
+use embassy_sync::mutex::Mutex;
 use embassy_time::Duration;
 use embassy_usb::class::cdc_ncm::embassy_net::{Device, Runner, State as NetState};
 use embassy_usb::class::cdc_ncm::{CdcNcmClass, State};
@@ -122,14 +121,15 @@ async fn main(spawner: Spawner) {
     static DHCPD_CONFIG: StaticCell<DhcpdConfig> = StaticCell::new();
 
     let dhcpd_config: &'static mut DhcpdConfig = DHCPD_CONFIG.init(DhcpdConfig::default());
-    dhcpd_config.server_ip   = core::net::Ipv4Addr::new(10, 42, 0, 61);
+    dhcpd_config.server_ip = core::net::Ipv4Addr::new(10, 42, 0, 61);
     dhcpd_config.range_start = core::net::Ipv4Addr::new(10, 42, 0, 62);
-    dhcpd_config.range_end   = core::net::Ipv4Addr::new(10, 42, 0, 64);
+    dhcpd_config.range_end = core::net::Ipv4Addr::new(10, 42, 0, 64);
     dhcpd_config.subnet_mask = core::net::Ipv4Addr::new(255, 255, 255, 0);
-    dhcpd_config.lease_time  = Duration::from_secs(300);
+    dhcpd_config.lease_time = Duration::from_secs(300);
 
     static LEASES: StaticCell<Mutex<NoopRawMutex, Vec<DhcpdLease, DHCPD_MAX_LEASES>>> = StaticCell::new();
-    let leases: &'static mut Mutex<NoopRawMutex, Vec<DhcpdLease, DHCPD_MAX_LEASES>> = LEASES.init(Mutex::new(Vec::new()));
+    let leases: &'static mut Mutex<NoopRawMutex, Vec<DhcpdLease, DHCPD_MAX_LEASES>> =
+        LEASES.init(Mutex::new(Vec::new()));
 
     let dhcpd_runner = embassy_net::dhcpd::new(stack, rng, dhcpd_config, leases);
 


### PR DESCRIPTION
This PR adds a basic DHCPv4 server (dhcpd) to embassy-net.

An example is added for the RP235x to showcase using the DHCP server with USB CDC NCM (Tested on a Pico 2 board)
Another example is added for the RP2040 to showcase using the DHCP server in combination with the cyw43 WiFi AP (Tested on a Pico W board).

Fixes #2845

This is my first production code in Rust, so please DO comment and propose enhancements or request changes if something could or should be improved. But please be gentle :) Thanks!