### PR TITLE
STM32 FIX: VREFBUF VRR check logic correction

### DIFF
--- a/embassy-stm32/src/vrefbuf/mod.rs
+++ b/embassy-stm32/src/vrefbuf/mod.rs
@@ -62,7 +62,7 @@ impl<'d, T: Instance> VoltageReferenceBuffer<'d, T> {
             w.set_envr(true);
             w.set_vrs(voltage_scale);
         });
-        while vrefbuf.csr().read().vrr() != false {
+        while vrefbuf.csr().read().vrr() == false {
             // wait...
         }
         trace!(


### PR DESCRIPTION
The logic to check whether the voltage reference buffer (VREFBUF) is ready is backwards. The current code spins while it's true. If the intended behaviour is to wait until the voltage reference buffer is ready, then it should spin while it's false. 

See section 2 of VREFBUF application note (AN5690)
> VRR bit (voltage reference ready) is set when the VREFBUF output voltage accuracy is within 1% of the
selected voltage range. When the HIZ bit is set, the VRR is stuck at 1 and therefore it is up to the
application to ensure that the VREFBUF_OUT voltage remains in the selected scale voltage limits.


See section 23.4.1 of RM0440:
>Bit 3 VRR: Voltage reference buffer ready
>0: the voltage reference buffer output is not ready.
>1: the voltage reference buffer output reached the requested level.